### PR TITLE
ARROW-15932: [C++][FlightRPC] Add more tests to the common Flight suite

### DIFF
--- a/cpp/src/arrow/flight/flight_test.cc
+++ b/cpp/src/arrow/flight/flight_test.cc
@@ -81,6 +81,7 @@ TEST_F(GrpcConnectivityTest, GetPort) { TestGetPort(); }
 TEST_F(GrpcConnectivityTest, BuilderHook) { TestBuilderHook(); }
 TEST_F(GrpcConnectivityTest, Shutdown) { TestShutdown(); }
 TEST_F(GrpcConnectivityTest, ShutdownWithDeadline) { TestShutdownWithDeadline(); }
+TEST_F(GrpcConnectivityTest, BrokenConnection) { TestBrokenConnection(); }
 
 class GrpcDataTest : public DataTest {
  protected:
@@ -100,6 +101,8 @@ TEST_F(GrpcDataTest, TestDoExchangePut) { TestDoExchangePut(); }
 TEST_F(GrpcDataTest, TestDoExchangeEcho) { TestDoExchangeEcho(); }
 TEST_F(GrpcDataTest, TestDoExchangeTotal) { TestDoExchangeTotal(); }
 TEST_F(GrpcDataTest, TestDoExchangeError) { TestDoExchangeError(); }
+TEST_F(GrpcDataTest, TestDoExchangeConcurrency) { TestDoExchangeConcurrency(); }
+TEST_F(GrpcDataTest, TestDoExchangeUndrained) { TestDoExchangeUndrained(); }
 TEST_F(GrpcDataTest, TestIssue5095) { TestIssue5095(); }
 
 class GrpcDoPutTest : public DoPutTest {
@@ -112,6 +115,7 @@ TEST_F(GrpcDoPutTest, TestEmptyBatch) { TestEmptyBatch(); }
 TEST_F(GrpcDoPutTest, TestDicts) { TestDicts(); }
 TEST_F(GrpcDoPutTest, TestLargeBatch) { TestLargeBatch(); }
 TEST_F(GrpcDoPutTest, TestSizeLimit) { TestSizeLimit(); }
+TEST_F(GrpcDoPutTest, TestUndrained) { TestUndrained(); }
 
 class GrpcAppMetadataTest : public AppMetadataTest {
  protected:

--- a/cpp/src/arrow/flight/flight_test.cc
+++ b/cpp/src/arrow/flight/flight_test.cc
@@ -1224,8 +1224,10 @@ TEST_F(TestBasicAuthHandler, FailUnauthenticatedCalls) {
   std::shared_ptr<Schema> schema(
       (new arrow::Schema(std::vector<std::shared_ptr<Field>>())));
   status = client_->DoPut(FlightDescriptor{}, schema, &writer, &reader);
-  ASSERT_OK(status);
+  // May or may not succeed depending on if the transport buffers the write
+  ARROW_UNUSED(status);
   status = writer->Close();
+  // But this should definitely fail
   ASSERT_RAISES(IOError, status);
   ASSERT_THAT(status.message(), ::testing::HasSubstr("Invalid token"));
 }

--- a/cpp/src/arrow/flight/flight_test.cc
+++ b/cpp/src/arrow/flight/flight_test.cc
@@ -77,79 +77,37 @@ class GrpcConnectivityTest : public ConnectivityTest {
  protected:
   std::string transport() const override { return "grpc"; }
 };
-TEST_F(GrpcConnectivityTest, GetPort) { TestGetPort(); }
-TEST_F(GrpcConnectivityTest, BuilderHook) { TestBuilderHook(); }
-TEST_F(GrpcConnectivityTest, Shutdown) { TestShutdown(); }
-TEST_F(GrpcConnectivityTest, ShutdownWithDeadline) { TestShutdownWithDeadline(); }
-TEST_F(GrpcConnectivityTest, BrokenConnection) { TestBrokenConnection(); }
+ARROW_FLIGHT_TEST_CONNECTIVITY(GrpcConnectivityTest);
 
 class GrpcDataTest : public DataTest {
  protected:
   std::string transport() const override { return "grpc"; }
 };
-TEST_F(GrpcDataTest, TestDoGetInts) { TestDoGetInts(); }
-TEST_F(GrpcDataTest, TestDoGetFloats) { TestDoGetFloats(); }
-TEST_F(GrpcDataTest, TestDoGetDicts) { TestDoGetDicts(); }
-TEST_F(GrpcDataTest, TestDoGetLargeBatch) { TestDoGetLargeBatch(); }
-TEST_F(GrpcDataTest, TestOverflowServerBatch) { TestOverflowServerBatch(); }
-TEST_F(GrpcDataTest, TestOverflowClientBatch) { TestOverflowClientBatch(); }
-TEST_F(GrpcDataTest, TestDoExchange) { TestDoExchange(); }
-TEST_F(GrpcDataTest, TestDoExchangeNoData) { TestDoExchangeNoData(); }
-TEST_F(GrpcDataTest, TestDoExchangeWriteOnlySchema) { TestDoExchangeWriteOnlySchema(); }
-TEST_F(GrpcDataTest, TestDoExchangeGet) { TestDoExchangeGet(); }
-TEST_F(GrpcDataTest, TestDoExchangePut) { TestDoExchangePut(); }
-TEST_F(GrpcDataTest, TestDoExchangeEcho) { TestDoExchangeEcho(); }
-TEST_F(GrpcDataTest, TestDoExchangeTotal) { TestDoExchangeTotal(); }
-TEST_F(GrpcDataTest, TestDoExchangeError) { TestDoExchangeError(); }
-TEST_F(GrpcDataTest, TestDoExchangeConcurrency) { TestDoExchangeConcurrency(); }
-TEST_F(GrpcDataTest, TestDoExchangeUndrained) { TestDoExchangeUndrained(); }
-TEST_F(GrpcDataTest, TestIssue5095) { TestIssue5095(); }
+ARROW_FLIGHT_TEST_DATA(GrpcDataTest);
 
 class GrpcDoPutTest : public DoPutTest {
  protected:
   std::string transport() const override { return "grpc"; }
 };
-TEST_F(GrpcDoPutTest, TestInts) { TestInts(); }
-TEST_F(GrpcDoPutTest, TestFloats) { TestFloats(); }
-TEST_F(GrpcDoPutTest, TestEmptyBatch) { TestEmptyBatch(); }
-TEST_F(GrpcDoPutTest, TestDicts) { TestDicts(); }
-TEST_F(GrpcDoPutTest, TestLargeBatch) { TestLargeBatch(); }
-TEST_F(GrpcDoPutTest, TestSizeLimit) { TestSizeLimit(); }
-TEST_F(GrpcDoPutTest, TestUndrained) { TestUndrained(); }
+ARROW_FLIGHT_TEST_DO_PUT(GrpcDoPutTest);
 
 class GrpcAppMetadataTest : public AppMetadataTest {
  protected:
   std::string transport() const override { return "grpc"; }
 };
-TEST_F(GrpcAppMetadataTest, TestDoGet) { TestDoGet(); }
-TEST_F(GrpcAppMetadataTest, TestDoGetDictionaries) { TestDoGetDictionaries(); }
-TEST_F(GrpcAppMetadataTest, TestDoPut) { TestDoPut(); }
-TEST_F(GrpcAppMetadataTest, TestDoPutDictionaries) { TestDoPutDictionaries(); }
-TEST_F(GrpcAppMetadataTest, TestDoPutReadMetadata) { TestDoPutReadMetadata(); }
+ARROW_FLIGHT_TEST_APP_METADATA(GrpcAppMetadataTest);
 
 class GrpcIpcOptionsTest : public IpcOptionsTest {
  protected:
   std::string transport() const override { return "grpc"; }
 };
-TEST_F(GrpcIpcOptionsTest, TestDoGetReadOptions) { TestDoGetReadOptions(); }
-TEST_F(GrpcIpcOptionsTest, TestDoPutWriteOptions) { TestDoPutWriteOptions(); }
-TEST_F(GrpcIpcOptionsTest, TestDoExchangeClientWriteOptions) {
-  TestDoExchangeClientWriteOptions();
-}
-TEST_F(GrpcIpcOptionsTest, TestDoExchangeClientWriteOptionsBegin) {
-  TestDoExchangeClientWriteOptionsBegin();
-}
-TEST_F(GrpcIpcOptionsTest, TestDoExchangeServerWriteOptions) {
-  TestDoExchangeServerWriteOptions();
-}
+ARROW_FLIGHT_TEST_IPC_OPTIONS(GrpcIpcOptionsTest);
 
 class GrpcCudaDataTest : public CudaDataTest {
  protected:
   std::string transport() const override { return "grpc"; }
 };
-TEST_F(GrpcCudaDataTest, TestDoGet) { TestDoGet(); }
-TEST_F(GrpcCudaDataTest, TestDoPut) { TestDoPut(); }
-TEST_F(GrpcCudaDataTest, TestDoExchange) { TestDoExchange(); }
+ARROW_FLIGHT_TEST_CUDA_DATA(GrpcCudaDataTest);
 
 //------------------------------------------------------------
 // Ad-hoc gRPC-specific tests

--- a/cpp/src/arrow/flight/test_definitions.cc
+++ b/cpp/src/arrow/flight/test_definitions.cc
@@ -91,6 +91,23 @@ void ConnectivityTest::TestShutdownWithDeadline() {
   ASSERT_OK(server->Shutdown(&deadline));
   ASSERT_OK(server->Wait());
 }
+void ConnectivityTest::TestBrokenConnection() {
+  std::unique_ptr<FlightServerBase> server = ExampleTestServer();
+  ASSERT_OK_AND_ASSIGN(auto location, Location::ForScheme(transport(), "localhost", 0));
+  FlightServerOptions options(location);
+  ASSERT_OK(server->Init(options));
+
+  std::unique_ptr<FlightClient> client;
+  ASSERT_OK_AND_ASSIGN(location,
+                       Location::ForScheme(transport(), "localhost", server->port()));
+  ASSERT_OK(FlightClient::Connect(location, &client));
+
+  ASSERT_OK(server->Shutdown());
+  ASSERT_OK(server->Wait());
+
+  std::unique_ptr<FlightInfo> info;
+  ASSERT_FALSE(client->GetFlightInfo(FlightDescriptor::Command(""), &info).ok());
+}
 
 //------------------------------------------------------------
 // Tests of data plane methods
@@ -500,6 +517,60 @@ void DataTest::TestDoExchangeError() {
   // buffer writes - a write won't immediately fail even if the server
   // would immediately return an error.
 }
+void DataTest::TestDoExchangeConcurrency() {
+  // Ensure that we can do reads/writes on separate threads
+  auto descr = FlightDescriptor::Command("echo");
+  std::unique_ptr<FlightStreamReader> reader;
+  std::unique_ptr<FlightStreamWriter> writer;
+  ASSERT_OK(client_->DoExchange(descr, &writer, &reader));
+
+  RecordBatchVector batches;
+  ASSERT_OK(ExampleIntBatches(&batches));
+  ASSERT_OK(writer->Begin(ExampleIntSchema()));
+
+  std::thread reader_thread([&reader, &batches]() {
+    FlightStreamChunk chunk;
+    for (size_t i = 0; i < batches.size(); i++) {
+      ASSERT_OK(reader->Next(&chunk));
+      ASSERT_NE(nullptr, chunk.data);
+      ASSERT_EQ(nullptr, chunk.app_metadata);
+      AssertBatchesEqual(*batches[i], *chunk.data);
+    }
+    ASSERT_OK(reader->Next(&chunk));
+    ASSERT_EQ(nullptr, chunk.data);
+    ASSERT_EQ(nullptr, chunk.app_metadata);
+  });
+
+  for (const auto& batch : batches) {
+    ASSERT_OK(writer->WriteRecordBatch(*batch));
+  }
+  ASSERT_OK(writer->DoneWriting());
+  reader_thread.join();
+  ASSERT_OK(writer->Close());
+}
+void DataTest::TestDoExchangeUndrained() {
+  // Ensure if the application doesn't drain all messages, that the
+  // server/transport does
+
+  auto descr = FlightDescriptor::Command("TestUndrained");
+  auto schema = arrow::schema({arrow::field("ints", int64())});
+  std::unique_ptr<FlightStreamReader> reader;
+  std::unique_ptr<FlightStreamWriter> writer;
+  ASSERT_OK(client_->DoExchange(descr, &writer, &reader));
+
+  auto batch = RecordBatchFromJSON(schema, "[[1], [2], [3], [4]]");
+  ASSERT_OK(writer->Begin(schema));
+  // These calls may or may not fail depending on how quickly the
+  // transport reacts, whether it batches, writes, etc.
+  ARROW_UNUSED(writer->WriteRecordBatch(*batch));
+  ARROW_UNUSED(writer->WriteRecordBatch(*batch));
+  ARROW_UNUSED(writer->WriteRecordBatch(*batch));
+  ARROW_UNUSED(writer->WriteRecordBatch(*batch));
+  ASSERT_OK(writer->Close());
+
+  // We should be able to make another call
+  TestDoExchangeGet();
+}
 void DataTest::TestIssue5095() {
   // Make sure the server-side error message is reflected to the
   // client
@@ -518,22 +589,49 @@ void DataTest::TestIssue5095() {
 //------------------------------------------------------------
 // Specific tests for DoPut
 
+static constexpr char kExpectedMetadata[] = "foo bar";
+
 class DoPutTestServer : public FlightServerBase {
  public:
   Status DoPut(const ServerCallContext& context,
                std::unique_ptr<FlightMessageReader> reader,
                std::unique_ptr<FlightMetadataWriter> writer) override {
     descriptor_ = reader->descriptor();
+
+    if (descriptor_.type == FlightDescriptor::DescriptorType::CMD) {
+      if (descriptor_.cmd == "TestUndrained") {
+        // Don't read all the messages
+        return Status::OK();
+      }
+    }
+
     int counter = 0;
+    FlightStreamChunk chunk;
     while (true) {
-      FlightStreamChunk chunk;
       RETURN_NOT_OK(reader->Next(&chunk));
       if (!chunk.data) break;
+      if (counter % 2 == 1) {
+        if (!chunk.app_metadata) {
+          return Status::Invalid("Expected app_metadata");
+        } else if (chunk.app_metadata->ToString() != std::to_string(counter)) {
+          return Status::Invalid("Expected app_metadata to be ", counter, " but got ",
+                                 chunk.app_metadata->ToString());
+        }
+      }
       batches_.push_back(std::move(chunk.data));
       auto buffer = Buffer::FromString(std::to_string(counter));
       RETURN_NOT_OK(writer->WriteMetadata(*buffer));
       counter++;
     }
+
+    // Expect a metadata-only message
+    if (!chunk.app_metadata) {
+      return Status::Invalid("Expected app_metadata at end of stream (#1)");
+    } else if (chunk.app_metadata->ToString() != kExpectedMetadata) {
+      return Status::Invalid("Expected app_metadata to be ", kExpectedMetadata,
+                             " but got ", chunk.app_metadata->ToString());
+    }
+
     return Status::OK();
   }
 
@@ -573,17 +671,25 @@ void DoPutTest::CheckDoPut(const FlightDescriptor& descr,
   ASSERT_OK(client_->DoPut(descr, schema, &stream, &reader));
 
   // Ensure that the reader can be used independently of the writer
-  auto* reader_ref = reader.get();
-  std::thread reader_thread([reader_ref, &batches]() {
+  std::thread reader_thread([&reader, &batches]() {
     for (size_t i = 0; i < batches.size(); i++) {
       std::shared_ptr<Buffer> out;
-      ASSERT_OK(reader_ref->ReadMetadata(&out));
+      ASSERT_OK(reader->ReadMetadata(&out));
     }
   });
 
+  int64_t counter = 0;
   for (const auto& batch : batches) {
-    ASSERT_OK(stream->WriteRecordBatch(*batch));
+    if (counter % 2 == 0) {
+      ASSERT_OK(stream->WriteRecordBatch(*batch));
+    } else {
+      auto buffer = Buffer::FromString(std::to_string(counter));
+      ASSERT_OK(stream->WriteWithMetadata(*batch, std::move(buffer)));
+    }
+    counter++;
   }
+  // Write a metadata-only message
+  ASSERT_OK(stream->WriteMetadata(Buffer::FromString(kExpectedMetadata)));
   ASSERT_OK(stream->DoneWriting());
   reader_thread.join();
   ASSERT_OK(stream->Close());
@@ -671,13 +777,12 @@ void DoPutTest::TestSizeLimit() {
   std::unique_ptr<FlightClient> client;
   ASSERT_OK(FlightClient::Connect(location, client_options, &client));
 
-  auto descr = FlightDescriptor::Path({"ints"});
+  auto descr = FlightDescriptor::Command("simple");
   // Batch is too large to fit in one message
   auto schema = arrow::schema({field("f1", arrow::int64())});
   auto batch = arrow::ConstantArrayGenerator::Zeroes(768, schema);
-  RecordBatchVector batches;
-  batches.push_back(batch->Slice(0, 384));
-  batches.push_back(batch->Slice(384));
+  auto batch1 = batch->Slice(0, 384);
+  auto batch2 = batch->Slice(384);
 
   std::unique_ptr<FlightStreamWriter> stream;
   std::unique_ptr<FlightMetadataReader> reader;
@@ -692,14 +797,37 @@ void DoPutTest::TestSizeLimit() {
   ASSERT_EQ(size_limit, detail->limit());
   ASSERT_GT(detail->actual(), size_limit);
 
-  // But we can retry with a smaller batch
-  for (const auto& batch : batches) {
-    ASSERT_OK(stream->WriteRecordBatch(*batch));
-  }
+  // But we can retry with smaller batches
+  ASSERT_OK(stream->WriteRecordBatch(*batch1));
+  ASSERT_OK(stream->WriteWithMetadata(*batch2, Buffer::FromString("1")));
+
+  // Write a metadata-only message
+  ASSERT_OK(stream->WriteMetadata(Buffer::FromString(kExpectedMetadata)));
 
   ASSERT_OK(stream->DoneWriting());
   ASSERT_OK(stream->Close());
-  CheckBatches(descr, batches);
+  CheckBatches(descr, {batch1, batch2});
+}
+void DoPutTest::TestUndrained() {
+  // Ensure if the application doesn't drain all messages, that the
+  // server/transport does
+
+  auto descr = FlightDescriptor::Command("TestUndrained");
+  auto schema = arrow::schema({arrow::field("ints", int64())});
+  std::unique_ptr<FlightStreamWriter> stream;
+  std::unique_ptr<FlightMetadataReader> reader;
+  ASSERT_OK(client_->DoPut(descr, schema, &stream, &reader));
+  auto batch = RecordBatchFromJSON(schema, "[[1], [2], [3], [4]]");
+  // These calls may or may not fail depending on how quickly the
+  // transport reacts, whether it batches, writes, etc.
+  ARROW_UNUSED(stream->WriteRecordBatch(*batch));
+  ARROW_UNUSED(stream->WriteRecordBatch(*batch));
+  ARROW_UNUSED(stream->WriteRecordBatch(*batch));
+  ARROW_UNUSED(stream->WriteRecordBatch(*batch));
+  ASSERT_OK(stream->Close());
+
+  // We should be able to make another call
+  CheckDoPut(FlightDescriptor::Command("foo"), schema, {batch, batch});
 }
 
 //------------------------------------------------------------
@@ -1057,26 +1185,21 @@ arrow::Result<std::shared_ptr<RecordBatch>> CopyBatchToHost(const RecordBatch& b
 
 class CudaTestServer : public FlightServerBase {
  public:
-  explicit CudaTestServer(std::shared_ptr<Device> device) : device_(std::move(device)) {}
+  explicit CudaTestServer(std::shared_ptr<Device> device,
+                          std::shared_ptr<cuda::CudaContext> context)
+      : device_(std::move(device)), context_(std::move(context)) {}
 
   Status DoGet(const ServerCallContext&, const Ticket&,
                std::unique_ptr<FlightDataStream>* data_stream) override {
-    RecordBatchVector batches;
-    RETURN_NOT_OK(ExampleIntBatches(&batches));
-    ARROW_ASSIGN_OR_RAISE(auto batch_reader, RecordBatchReader::Make(batches));
+    RETURN_NOT_OK(ExampleIntBatches(&batches_));
+    ARROW_ASSIGN_OR_RAISE(auto batch_reader, RecordBatchReader::Make(batches_));
     *data_stream = std::unique_ptr<FlightDataStream>(new RecordBatchStream(batch_reader));
     return Status::OK();
   }
 
   Status DoPut(const ServerCallContext&, std::unique_ptr<FlightMessageReader> reader,
                std::unique_ptr<FlightMetadataWriter> writer) override {
-    RecordBatchVector batches;
-    RETURN_NOT_OK(reader->ReadAll(&batches));
-    for (const auto& batch : batches) {
-      for (const auto& column : batch->columns()) {
-        RETURN_NOT_OK(CheckBuffersOnDevice(*column, *device_));
-      }
-    }
+    RETURN_NOT_OK(reader->ReadAll(&batches_));
     return Status::OK();
   }
 
@@ -1095,13 +1218,20 @@ class CudaTestServer : public FlightServerBase {
       for (const auto& column : chunk.data->columns()) {
         RETURN_NOT_OK(CheckBuffersOnDevice(*column, *device_));
       }
+      // XXX: do not assume transport will synchronize, we must
+      // synchronize or else data will be "missing"
+      RETURN_NOT_OK(context_->Synchronize());
       RETURN_NOT_OK(writer->WriteRecordBatch(*chunk.data));
     }
     return Status::OK();
   }
 
+  const RecordBatchVector& batches() const { return batches_; }
+
  private:
+  RecordBatchVector batches_;
   std::shared_ptr<Device> device_;
+  std::shared_ptr<cuda::CudaContext> context_;
 };
 
 // Store CUDA objects without exposing them in the public header
@@ -1128,7 +1258,8 @@ void CudaDataTest::SetUp() {
         options->memory_manager = impl_->device->default_memory_manager();
         return Status::OK();
       },
-      [](FlightClientOptions* options) { return Status::OK(); }, impl_->device));
+      [](FlightClientOptions* options) { return Status::OK(); }, impl_->device,
+      impl_->context));
 }
 void CudaDataTest::TearDown() {
   ASSERT_OK(client_->Close());
@@ -1140,17 +1271,34 @@ void CudaDataTest::TestDoGet() {
   FlightCallOptions options;
   options.memory_manager = impl_->device->default_memory_manager();
 
+  const RecordBatchVector& batches =
+      reinterpret_cast<CudaTestServer*>(server_.get())->batches();
+
   Ticket ticket{""};
   std::unique_ptr<FlightStreamReader> stream;
   ASSERT_OK(client_->DoGet(options, ticket, &stream));
-  std::shared_ptr<Table> table;
-  ASSERT_OK(stream->ReadAll(&table));
 
-  for (const auto& column : table->columns()) {
-    for (const auto& chunk : column->chunks()) {
-      ASSERT_OK(CheckBuffersOnDevice(*chunk, *impl_->device));
+  size_t idx = 0;
+  while (true) {
+    FlightStreamChunk chunk;
+    ASSERT_OK(stream->Next(&chunk));
+    if (!chunk.data) break;
+
+    for (const auto& column : chunk.data->columns()) {
+      ASSERT_OK(CheckBuffersOnDevice(*column, *impl_->device));
     }
+
+    if (idx >= batches.size()) {
+      FAIL() << "Server returned more than " << batches.size() << " batches";
+      return;
+    }
+
+    // Bounce record batch back to host memory
+    ASSERT_OK_AND_ASSIGN(auto host_batch, CopyBatchToHost(*chunk.data));
+    AssertBatchesEqual(*batches[idx], *host_batch);
+    idx++;
   }
+  ASSERT_EQ(idx, batches.size()) << "Server returned too few batches";
 }
 void CudaDataTest::TestDoPut() {
   RecordBatchVector batches;
@@ -1175,6 +1323,23 @@ void CudaDataTest::TestDoPut() {
     ASSERT_OK(writer->WriteRecordBatch(*cuda_batch));
   }
   ASSERT_OK(writer->Close());
+  ASSERT_OK(impl_->context->Synchronize());
+
+  const RecordBatchVector& written =
+      reinterpret_cast<CudaTestServer*>(server_.get())->batches();
+  ASSERT_EQ(written.size(), batches.size());
+
+  size_t idx = 0;
+  for (const auto& batch : written) {
+    for (const auto& column : batch->columns()) {
+      ASSERT_OK(CheckBuffersOnDevice(*column, *impl_->device));
+    }
+
+    // Bounce record batch back to host memory
+    ASSERT_OK_AND_ASSIGN(auto host_batch, CopyBatchToHost(*batch));
+    AssertBatchesEqual(*batches[idx], *host_batch);
+    idx++;
+  }
 }
 void CudaDataTest::TestDoExchange() {
   FlightCallOptions options;

--- a/cpp/src/arrow/flight/test_definitions.cc
+++ b/cpp/src/arrow/flight/test_definitions.cc
@@ -106,7 +106,7 @@ void ConnectivityTest::TestBrokenConnection() {
   ASSERT_OK(server->Wait());
 
   std::unique_ptr<FlightInfo> info;
-  ASSERT_FALSE(client->GetFlightInfo(FlightDescriptor::Command(""), &info).ok());
+  ASSERT_RAISES(IOError, client->GetFlightInfo(FlightDescriptor::Command(""), &info));
 }
 
 //------------------------------------------------------------

--- a/cpp/src/arrow/flight/test_definitions.h
+++ b/cpp/src/arrow/flight/test_definitions.h
@@ -50,6 +50,7 @@ class ARROW_FLIGHT_EXPORT ConnectivityTest : public FlightTest {
   void TestBuilderHook();
   void TestShutdown();
   void TestShutdownWithDeadline();
+  void TestBrokenConnection();
 };
 
 /// Common tests of data plane methods
@@ -74,6 +75,8 @@ class ARROW_FLIGHT_EXPORT DataTest : public FlightTest {
   void TestDoExchangeEcho();
   void TestDoExchangeTotal();
   void TestDoExchangeError();
+  void TestDoExchangeConcurrency();
+  void TestDoExchangeUndrained();
   void TestIssue5095();
 
  private:
@@ -103,6 +106,7 @@ class ARROW_FLIGHT_EXPORT DoPutTest : public FlightTest {
   void TestDicts();
   void TestLargeBatch();
   void TestSizeLimit();
+  void TestUndrained();
 
  private:
   std::unique_ptr<FlightClient> client_;

--- a/cpp/src/arrow/flight/test_definitions.h
+++ b/cpp/src/arrow/flight/test_definitions.h
@@ -29,10 +29,12 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include "arrow/flight/server.h"
 #include "arrow/flight/types.h"
+#include "arrow/util/macros.h"
 
 namespace arrow {
 namespace flight {
@@ -52,6 +54,15 @@ class ARROW_FLIGHT_EXPORT ConnectivityTest : public FlightTest {
   void TestShutdownWithDeadline();
   void TestBrokenConnection();
 };
+
+#define ARROW_FLIGHT_TEST_CONNECTIVITY(FIXTURE)                                  \
+  static_assert(std::is_base_of<ConnectivityTest, FIXTURE>::value,               \
+                ARROW_STRINGIFY(FIXTURE) " must inherit from ConnectivityTest"); \
+  TEST_F(FIXTURE, GetPort) { TestGetPort(); }                                    \
+  TEST_F(FIXTURE, BuilderHook) { TestBuilderHook(); }                            \
+  TEST_F(FIXTURE, Shutdown) { TestShutdown(); }                                  \
+  TEST_F(FIXTURE, ShutdownWithDeadline) { TestShutdownWithDeadline(); }          \
+  TEST_F(FIXTURE, BrokenConnection) { TestBrokenConnection(); }
 
 /// Common tests of data plane methods
 class ARROW_FLIGHT_EXPORT DataTest : public FlightTest {
@@ -89,6 +100,27 @@ class ARROW_FLIGHT_EXPORT DataTest : public FlightTest {
   std::unique_ptr<FlightServerBase> server_;
 };
 
+#define ARROW_FLIGHT_TEST_DATA(FIXTURE)                                               \
+  static_assert(std::is_base_of<DataTest, FIXTURE>::value,                            \
+                ARROW_STRINGIFY(FIXTURE) " must inherit from DataTest");              \
+  TEST_F(FIXTURE, TestDoGetInts) { TestDoGetInts(); }                                 \
+  TEST_F(FIXTURE, TestDoGetFloats) { TestDoGetFloats(); }                             \
+  TEST_F(FIXTURE, TestDoGetDicts) { TestDoGetDicts(); }                               \
+  TEST_F(FIXTURE, TestDoGetLargeBatch) { TestDoGetLargeBatch(); }                     \
+  TEST_F(FIXTURE, TestOverflowServerBatch) { TestOverflowServerBatch(); }             \
+  TEST_F(FIXTURE, TestOverflowClientBatch) { TestOverflowClientBatch(); }             \
+  TEST_F(FIXTURE, TestDoExchange) { TestDoExchange(); }                               \
+  TEST_F(FIXTURE, TestDoExchangeNoData) { TestDoExchangeNoData(); }                   \
+  TEST_F(FIXTURE, TestDoExchangeWriteOnlySchema) { TestDoExchangeWriteOnlySchema(); } \
+  TEST_F(FIXTURE, TestDoExchangeGet) { TestDoExchangeGet(); }                         \
+  TEST_F(FIXTURE, TestDoExchangePut) { TestDoExchangePut(); }                         \
+  TEST_F(FIXTURE, TestDoExchangeEcho) { TestDoExchangeEcho(); }                       \
+  TEST_F(FIXTURE, TestDoExchangeTotal) { TestDoExchangeTotal(); }                     \
+  TEST_F(FIXTURE, TestDoExchangeError) { TestDoExchangeError(); }                     \
+  TEST_F(FIXTURE, TestDoExchangeConcurrency) { TestDoExchangeConcurrency(); }         \
+  TEST_F(FIXTURE, TestDoExchangeUndrained) { TestDoExchangeUndrained(); }             \
+  TEST_F(FIXTURE, TestIssue5095) { TestIssue5095(); }
+
 /// \brief Specific tests of DoPut.
 class ARROW_FLIGHT_EXPORT DoPutTest : public FlightTest {
  public:
@@ -112,6 +144,17 @@ class ARROW_FLIGHT_EXPORT DoPutTest : public FlightTest {
   std::unique_ptr<FlightClient> client_;
   std::unique_ptr<FlightServerBase> server_;
 };
+
+#define ARROW_FLIGHT_TEST_DO_PUT(FIXTURE)                                 \
+  static_assert(std::is_base_of<DoPutTest, FIXTURE>::value,               \
+                ARROW_STRINGIFY(FIXTURE) " must inherit from DoPutTest"); \
+  TEST_F(FIXTURE, TestInts) { TestInts(); }                               \
+  TEST_F(FIXTURE, TestFloats) { TestFloats(); }                           \
+  TEST_F(FIXTURE, TestEmptyBatch) { TestEmptyBatch(); }                   \
+  TEST_F(FIXTURE, TestDicts) { TestDicts(); }                             \
+  TEST_F(FIXTURE, TestLargeBatch) { TestLargeBatch(); }                   \
+  TEST_F(FIXTURE, TestSizeLimit) { TestSizeLimit(); }                     \
+  TEST_F(FIXTURE, TestUndrained) { TestUndrained(); }
 
 class ARROW_FLIGHT_EXPORT AppMetadataTestServer : public FlightServerBase {
  public:
@@ -143,6 +186,15 @@ class ARROW_FLIGHT_EXPORT AppMetadataTest : public FlightTest {
   std::unique_ptr<FlightServerBase> server_;
 };
 
+#define ARROW_FLIGHT_TEST_APP_METADATA(FIXTURE)                                 \
+  static_assert(std::is_base_of<AppMetadataTest, FIXTURE>::value,               \
+                ARROW_STRINGIFY(FIXTURE) " must inherit from AppMetadataTest"); \
+  TEST_F(FIXTURE, TestDoGet) { TestDoGet(); }                                   \
+  TEST_F(FIXTURE, TestDoGetDictionaries) { TestDoGetDictionaries(); }           \
+  TEST_F(FIXTURE, TestDoPut) { TestDoPut(); }                                   \
+  TEST_F(FIXTURE, TestDoPutDictionaries) { TestDoPutDictionaries(); }           \
+  TEST_F(FIXTURE, TestDoPutReadMetadata) { TestDoPutReadMetadata(); }
+
 /// \brief Tests of IPC options in data plane methods.
 class ARROW_FLIGHT_EXPORT IpcOptionsTest : public FlightTest {
  public:
@@ -160,6 +212,21 @@ class ARROW_FLIGHT_EXPORT IpcOptionsTest : public FlightTest {
   std::unique_ptr<FlightClient> client_;
   std::unique_ptr<FlightServerBase> server_;
 };
+
+#define ARROW_FLIGHT_TEST_IPC_OPTIONS(FIXTURE)                                 \
+  static_assert(std::is_base_of<IpcOptionsTest, FIXTURE>::value,               \
+                ARROW_STRINGIFY(FIXTURE) " must inherit from IpcOptionsTest"); \
+  TEST_F(FIXTURE, TestDoGetReadOptions) { TestDoGetReadOptions(); }            \
+  TEST_F(FIXTURE, TestDoPutWriteOptions) { TestDoPutWriteOptions(); }          \
+  TEST_F(FIXTURE, TestDoExchangeClientWriteOptions) {                          \
+    TestDoExchangeClientWriteOptions();                                        \
+  }                                                                            \
+  TEST_F(FIXTURE, TestDoExchangeClientWriteOptionsBegin) {                     \
+    TestDoExchangeClientWriteOptionsBegin();                                   \
+  }                                                                            \
+  TEST_F(FIXTURE, TestDoExchangeServerWriteOptions) {                          \
+    TestDoExchangeServerWriteOptions();                                        \
+  }
 
 /// \brief Tests of data plane methods with CUDA memory.
 ///
@@ -180,6 +247,13 @@ class ARROW_FLIGHT_EXPORT CudaDataTest : public FlightTest {
   std::unique_ptr<FlightServerBase> server_;
   std::shared_ptr<Impl> impl_;
 };
+
+#define ARROW_FLIGHT_TEST_CUDA_DATA(FIXTURE)                                 \
+  static_assert(std::is_base_of<CudaDataTest, FIXTURE>::value,               \
+                ARROW_STRINGIFY(FIXTURE) " must inherit from CudaDataTest"); \
+  TEST_F(FIXTURE, TestDoGet) { TestDoGet(); }                                \
+  TEST_F(FIXTURE, TestDoPut) { TestDoPut(); }                                \
+  TEST_F(FIXTURE, TestDoExchange) { TestDoExchange(); }
 
 }  // namespace flight
 }  // namespace arrow

--- a/cpp/src/arrow/flight/test_util.cc
+++ b/cpp/src/arrow/flight/test_util.cc
@@ -262,6 +262,9 @@ class FlightTestServer : public FlightServerBase {
       return RunExchangeEcho(std::move(reader), std::move(writer));
     } else if (cmd == "large_batch") {
       return RunExchangeLargeBatch(std::move(reader), std::move(writer));
+    } else if (cmd == "TestUndrained") {
+      ARROW_ASSIGN_OR_RAISE(auto schema, reader->GetSchema());
+      return Status::OK();
     } else {
       return Status::NotImplemented("Scenario not implemented: ", cmd);
     }


### PR DESCRIPTION
Expand the common Flight suite with some edge cases discovered while testing UCX (ARROW-15706). Also, factor the Flight client's handling of non-host memory types out of the gRPC transport and into the common code.