### PR TITLE
ARROW-15934: [Python] Expose write_batch_size in python

### DIFF
--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -552,7 +552,8 @@ cdef shared_ptr[WriterProperties] _create_writer_properties(
     use_byte_stream_split=*,
     column_encoding=*,
     data_page_version=*,
-    FileEncryptionProperties encryption_properties=*) except *
+    FileEncryptionProperties encryption_properties=*,
+    write_batch_size=*) except *
 
 
 cdef shared_ptr[ArrowWriterProperties] _create_arrow_writer_properties(

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -1224,7 +1224,8 @@ cdef shared_ptr[WriterProperties] _create_writer_properties(
         use_byte_stream_split=False,
         column_encoding=None,
         data_page_version=None,
-        FileEncryptionProperties encryption_properties=None) except *:
+        FileEncryptionProperties encryption_properties=None,
+        write_batch_size=None) except *:
     """General writer properties"""
     cdef:
         shared_ptr[WriterProperties] properties
@@ -1347,6 +1348,9 @@ cdef shared_ptr[WriterProperties] _create_writer_properties(
     if data_page_size is not None:
         props.data_pagesize(data_page_size)
 
+    if write_batch_size is not None:
+        props.write_batch_size(write_batch_size)
+
     # encryption
 
     if encryption_properties is not None:
@@ -1441,6 +1445,7 @@ cdef class ParquetWriter(_Weakrefable):
         int row_group_size
         int64_t data_page_size
         FileEncryptionProperties encryption_properties
+        int64_t write_batch_size
 
     def __cinit__(self, where, Schema schema, use_dictionary=None,
                   compression=None, version=None,
@@ -1456,7 +1461,8 @@ cdef class ParquetWriter(_Weakrefable):
                   writer_engine_version=None,
                   data_page_version=None,
                   use_compliant_nested_type=False,
-                  encryption_properties=None):
+                  encryption_properties=None,
+                  write_batch_size=None):
         cdef:
             shared_ptr[WriterProperties] properties
             shared_ptr[ArrowWriterProperties] arrow_properties
@@ -1484,7 +1490,8 @@ cdef class ParquetWriter(_Weakrefable):
             use_byte_stream_split=use_byte_stream_split,
             column_encoding=column_encoding,
             data_page_version=data_page_version,
-            encryption_properties=encryption_properties
+            encryption_properties=encryption_properties,
+            write_batch_size=write_batch_size
         )
         arrow_properties = _create_arrow_writer_properties(
             use_deprecated_int96_timestamps=use_deprecated_int96_timestamps,

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -605,6 +605,11 @@ encryption_properties : FileEncryptionProperties, default None
     If None, no encryption will be done.
     The encryption properties can be created using:
     ``CryptoFactory.file_encryption_properties()``.
+write_batch_size : int, default None
+    Number of values to write to a page at a time. If None, use the default of
+    1024. ``write_batch_size`` is complementary to ``data_page_size``. If pages
+    are exceeding the ``data_page_size`` due to large column values, lowering
+    the batch size can help keep page sizes closer to the intended size.
 """
 
 
@@ -640,6 +645,7 @@ writer_engine_version : unused
                  data_page_version='1.0',
                  use_compliant_nested_type=False,
                  encryption_properties=None,
+                 write_batch_size=None,
                  **options):
         if use_deprecated_int96_timestamps is None:
             # Use int96 timestamps for Spark
@@ -693,6 +699,7 @@ writer_engine_version : unused
             data_page_version=data_page_version,
             use_compliant_nested_type=use_compliant_nested_type,
             encryption_properties=encryption_properties,
+            write_batch_size=write_batch_size,
             **options)
         self.is_open = True
 
@@ -2086,6 +2093,7 @@ def write_table(table, where, row_group_size=None, version='1.0',
                 data_page_version='1.0',
                 use_compliant_nested_type=False,
                 encryption_properties=None,
+                write_batch_size=None,
                 **kwargs):
     row_group_size = kwargs.pop('chunk_size', row_group_size)
     use_int96 = use_deprecated_int96_timestamps
@@ -2108,6 +2116,7 @@ def write_table(table, where, row_group_size=None, version='1.0',
                 data_page_version=data_page_version,
                 use_compliant_nested_type=use_compliant_nested_type,
                 encryption_properties=encryption_properties,
+                write_batch_size=write_batch_size,
                 **kwargs) as writer:
             writer.write_table(table, row_group_size=row_group_size)
     except Exception:

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -26,7 +26,8 @@ from pyarrow import fs
 from pyarrow.filesystem import LocalFileSystem, FileSystem
 from pyarrow.tests import util
 from pyarrow.tests.parquet.common import (_check_roundtrip, _roundtrip_table,
-                                          parametrize_legacy_dataset)
+                                          parametrize_legacy_dataset,
+                                          _test_dataframe)
 
 try:
     import pyarrow.parquet as pq
@@ -65,6 +66,17 @@ def test_set_data_page_size(use_legacy_dataset):
     for target_page_size in page_sizes:
         _check_roundtrip(t, data_page_size=target_page_size,
                          use_legacy_dataset=use_legacy_dataset)
+
+
+@pytest.mark.pandas
+@parametrize_legacy_dataset
+def test_set_write_batch_size(use_legacy_dataset):
+    df = _test_dataframe(100)
+    table = pa.Table.from_pandas(df, preserve_index=False)
+
+    _check_roundtrip(
+        table, data_page_size=10, write_batch_size=1, version='2.4'
+    )
 
 
 @pytest.mark.pandas

--- a/python/pyarrow/tests/parquet/test_parquet_writer.py
+++ b/python/pyarrow/tests/parquet/test_parquet_writer.py
@@ -268,22 +268,6 @@ def test_parquet_writer_filesystem_s3fs(s3_example_s3fs):
 
 
 @pytest.mark.pandas
-def test_parquet_writer_page_size_batch():
-    df = _test_dataframe(100)
-    table = pa.Table.from_pandas(df, preserve_index=False)
-
-    out = pa.BufferOutputStream()
-
-    with pq.ParquetWriter(out, table.schema, data_page_size=10,
-                          write_batch_size=1, version='2.4') as writer:
-        writer.write_table(table)
-
-    buf = out.getvalue()
-    result = _read_table(pa.BufferReader(buf)).to_pandas()
-    tm.assert_frame_equal(result, df)
-
-
-@pytest.mark.pandas
 def test_parquet_writer_filesystem_buffer_raises():
     df = _test_dataframe(100)
     table = pa.Table.from_pandas(df, preserve_index=False)

--- a/python/pyarrow/tests/parquet/test_parquet_writer.py
+++ b/python/pyarrow/tests/parquet/test_parquet_writer.py
@@ -268,6 +268,22 @@ def test_parquet_writer_filesystem_s3fs(s3_example_s3fs):
 
 
 @pytest.mark.pandas
+def test_parquet_writer_page_size_batch():
+    df = _test_dataframe(100)
+    table = pa.Table.from_pandas(df, preserve_index=False)
+
+    out = pa.BufferOutputStream()
+
+    with pq.ParquetWriter(out, table.schema, data_page_size=10,
+                          write_batch_size=1, version='2.4') as writer:
+        writer.write_table(table)
+
+    buf = out.getvalue()
+    result = _read_table(pa.BufferReader(buf)).to_pandas()
+    tm.assert_frame_equal(result, df)
+
+
+@pytest.mark.pandas
 def test_parquet_writer_filesystem_buffer_raises():
     df = _test_dataframe(100)
     table = pa.Table.from_pandas(df, preserve_index=False)


### PR DESCRIPTION
Already exposed in C++. Useful when dealing columns of large strings.