### PR TITLE
ARROW-15939: [Python] Add pickle support for JSON options classes

### DIFF
--- a/python/pyarrow/_json.pyx
+++ b/python/pyarrow/_json.pyx
@@ -79,6 +79,12 @@ cdef class ReadOptions(_Weakrefable):
     def block_size(self, value):
         self.options.block_size = value
 
+    def __reduce__(self):
+        return ReadOptions, (
+            self.use_threads,
+            self.block_size
+        )
+
 
 cdef class ParseOptions(_Weakrefable):
     """
@@ -116,6 +122,13 @@ cdef class ParseOptions(_Weakrefable):
             self.newlines_in_values = newlines_in_values
         if unexpected_field_behavior is not None:
             self.unexpected_field_behavior = unexpected_field_behavior
+
+    def __reduce__(self):
+        return ParseOptions, (
+            self.explicit_schema,
+            self.newlines_in_values,
+            self.unexpected_field_behavior
+        )
 
     @property
     def explicit_schema(self):

--- a/python/pyarrow/tests/test_json.py
+++ b/python/pyarrow/tests/test_json.py
@@ -19,6 +19,7 @@ from collections import OrderedDict
 import io
 import itertools
 import json
+import pickle
 import string
 import unittest
 
@@ -51,6 +52,14 @@ def make_random_json(num_cols=2, num_rows=10, linesep='\r\n'):
     return data, expected
 
 
+def check_options_class_pickling(cls, **attr_values):
+    opts = cls(**attr_values)
+    new_opts = pickle.loads(pickle.dumps(opts,
+                                         protocol=pickle.HIGHEST_PROTOCOL))
+    for name, value in attr_values.items():
+        assert getattr(new_opts, name) == value
+
+
 def test_read_options():
     cls = ReadOptions
     opts = cls()
@@ -67,6 +76,8 @@ def test_read_options():
     assert opts.block_size == 1234
     assert opts.use_threads is False
 
+    check_options_class_pickling(cls, block_size=1234,
+                                 use_threads=False)
 
 def test_parse_options():
     cls = ParseOptions
@@ -88,6 +99,10 @@ def test_parse_options():
 
     with pytest.raises(ValueError):
         opts.unexpected_field_behavior = "invalid-value"
+
+    check_options_class_pickling(cls, explicit_schema=schema,
+                                 newlines_in_values=False,
+                                 unexpected_field_behavior="ignore")
 
 
 class BaseTestJSONRead:

--- a/python/pyarrow/tests/test_json.py
+++ b/python/pyarrow/tests/test_json.py
@@ -79,6 +79,7 @@ def test_read_options():
     check_options_class_pickling(cls, block_size=1234,
                                  use_threads=False)
 
+
 def test_parse_options():
     cls = ParseOptions
     opts = cls()


### PR DESCRIPTION
Use Scenario:

I was using ray.data.read_json to read json data source, in while i got error says that pyarrow.json.ReadOptions & pyarrow.json.ParseOptions does not support pickling so the task could not be passed between workers.

Goal:

Support pickling options class for json.