### PR TITLE
ARROW-15929: [R] io_thread_count is actually the CPU thread count

### DIFF
--- a/r/R/config.R
+++ b/r/R/config.R
@@ -26,7 +26,9 @@ cpu_count <- function() {
 #' @param num_threads integer: New number of threads for thread pool
 #' @export
 set_cpu_count <- function(num_threads) {
+  current_cpu_count <- cpu_count()
   SetCpuThreadPoolCapacity(as.integer(num_threads))
+  invisible(current_cpu_count)
 }
 
 #' Manage the global I/O thread pool in libarrow
@@ -40,5 +42,7 @@ io_thread_count <- function() {
 #' @param num_threads integer: New number of threads for thread pool
 #' @export
 set_io_thread_count <- function(num_threads) {
+  current_io_thread_count <- io_thread_count()
   SetIOThreadPoolCapacity(as.integer(num_threads))
+  invisible(current_io_thread_count)
 }

--- a/r/src/threadpool.cpp
+++ b/r/src/threadpool.cpp
@@ -19,7 +19,7 @@
 
 #if defined(ARROW_R_WITH_ARROW)
 
-#include <arrow/io/concurrency.h>
+#include <arrow/io/type_fwd.h>
 #include <arrow/util/parallel.h>
 
 //' View and manage the capacity of the global thread pool
@@ -49,25 +49,12 @@ void SetCpuThreadPoolCapacity(int threads) {
   StopIfNotOk(arrow::SetCpuThreadPoolCapacity(threads));
 }
 
-// This is clearly not how this should be done...maybe we need to
-// expose something like Get/SetIOThreadPoolCapacity from C++?
-// Or maybe there's a reason it's not exposed?
-namespace arrow {
-namespace io {
-namespace internal {
-arrow::internal::ThreadPool* GetIOThreadPool();
-}
-}  // namespace io
-}  // namespace arrow
-
 // [[arrow::export]]
-int GetIOThreadPoolCapacity() {
-  return arrow::io::internal::GetIOThreadPool()->GetCapacity();
-}
+int GetIOThreadPoolCapacity() { return arrow::io::GetIOThreadPoolCapacity(); }
 
 // [[arrow::export]]
 void SetIOThreadPoolCapacity(int threads) {
-  StopIfNotOk(arrow::io::internal::GetIOThreadPool()->SetCapacity(threads));
+  StopIfNotOk(arrow::io::SetIOThreadPoolCapacity(threads));
 }
 
 #endif

--- a/r/src/threadpool.cpp
+++ b/r/src/threadpool.cpp
@@ -19,6 +19,7 @@
 
 #if defined(ARROW_R_WITH_ARROW)
 
+#include <arrow/io/concurrency.h>
 #include <arrow/util/parallel.h>
 
 //' View and manage the capacity of the global thread pool
@@ -48,12 +49,25 @@ void SetCpuThreadPoolCapacity(int threads) {
   StopIfNotOk(arrow::SetCpuThreadPoolCapacity(threads));
 }
 
+// This is clearly not how this should be done...maybe we need to
+// expose something like Get/SetIOThreadPoolCapacity from C++?
+// Or maybe there's a reason it's not exposed?
+namespace arrow {
+namespace io {
+namespace internal {
+arrow::internal::ThreadPool* GetIOThreadPool();
+}
+}  // namespace io
+}  // namespace arrow
+
 // [[arrow::export]]
-int GetIOThreadPoolCapacity() { return arrow::GetCpuThreadPoolCapacity(); }
+int GetIOThreadPoolCapacity() {
+  return arrow::io::internal::GetIOThreadPool()->GetCapacity();
+}
 
 // [[arrow::export]]
 void SetIOThreadPoolCapacity(int threads) {
-  StopIfNotOk(arrow::SetCpuThreadPoolCapacity(threads));
+  StopIfNotOk(arrow::io::internal::GetIOThreadPool()->SetCapacity(threads));
 }
 
 #endif

--- a/r/tests/testthat/test-config.R
+++ b/r/tests/testthat/test-config.R
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+test_that("set_io_thread_count() sets the number of io threads", {
+  current_io_thread_count <- io_thread_count()
+  on.exit(set_io_thread_count(current_io_thread_count))
+
+  expect_identical(set_io_thread_count(1), current_io_thread_count)
+  expect_identical(io_thread_count(), 1L)
+  expect_identical(set_io_thread_count(current_io_thread_count), 1L)
+})
+
+test_that("set_cpu_count() sets the number of CPU threads", {
+  current_cpu_count <- cpu_count()
+  on.exit(set_cpu_count(current_cpu_count))
+
+  expect_identical(set_cpu_count(1), current_cpu_count)
+  expect_identical(cpu_count(), 1L)
+  expect_identical(set_cpu_count(current_cpu_count), 1L)
+})

--- a/r/tests/testthat/test-config.R
+++ b/r/tests/testthat/test-config.R
@@ -19,8 +19,10 @@ test_that("set_io_thread_count() sets the number of io threads", {
   current_io_thread_count <- io_thread_count()
   on.exit(set_io_thread_count(current_io_thread_count))
 
-  expect_identical(set_io_thread_count(1), current_io_thread_count)
+  previous_io_thread_count <- set_io_thread_count(1)
+  expect_identical(previous_io_thread_count, current_io_thread_count)
   expect_identical(io_thread_count(), 1L)
+
   expect_identical(set_io_thread_count(current_io_thread_count), 1L)
 })
 
@@ -28,7 +30,9 @@ test_that("set_cpu_count() sets the number of CPU threads", {
   current_cpu_count <- cpu_count()
   on.exit(set_cpu_count(current_cpu_count))
 
-  expect_identical(set_cpu_count(1), current_cpu_count)
+  previous_cpu_count <- set_cpu_count(1)
+  expect_identical(previous_cpu_count, current_cpu_count)
   expect_identical(cpu_count(), 1L)
+
   expect_identical(set_cpu_count(current_cpu_count), 1L)
 })


### PR DESCRIPTION
As noted in ARROW-15929, we have code referring to the wrong thread pool (i.e., `arrow::io_thread_count()` and `arrow::set_io_thread_count()` are actually setting the number of cores used instead of the actual thread count). This appears to have been an inadvertent addition changed in ARROW-12760 (#10316).

``` r
# remotes::install_github("apache/arrow/r")
library(arrow, warn.conflicts = FALSE)

cpu_count()
#> [1] 8
set_io_thread_count(4)
cpu_count()
#> [1] 4
```

This PR switches that so that we're referring to the correct thread pool:

``` r
# remotes::install_github("paleolimbot/arrow/r@r-thread-io-pool-count")
library(arrow, warn.conflicts = FALSE)

cpu_count()
#> [1] 8
set_io_thread_count(4)
cpu_count()
#> [1] 8
io_thread_count()
#> [1] 4
```