### PR TITLE
ARROW-15921: [Format][FlightRPC][C++][Java] Clarify interpretation of FlightEndpoint.locations

### DIFF
--- a/format/Flight.proto
+++ b/format/Flight.proto
@@ -265,6 +265,9 @@ message FlightInfo {
    *
    * In other words, an application can use multiple endpoints to
    * represent partitioned data.
+   *
+   * There is no ordering defined on endpoints. Hence, if the returned
+   * data has an ordering, it should be returned in a single endpoint.
    */
   repeated FlightEndpoint endpoint = 3;
 

--- a/format/Flight.proto
+++ b/format/Flight.proto
@@ -259,8 +259,9 @@ message FlightInfo {
   FlightDescriptor flight_descriptor = 2;
 
   /*
-   * A list of endpoints associated with the flight. To consume the whole
-   * flight, all endpoints must be consumed.
+   * A list of endpoints associated with the flight. To consume the
+   * whole flight, all endpoints must be consumed. In other words,
+   * multiple endpoints provide partitioning.
    */
   repeated FlightEndpoint endpoint = 3;
 
@@ -280,9 +281,16 @@ message FlightEndpoint {
   Ticket ticket = 1;
 
   /*
-   * A list of URIs where this ticket can be redeemed. If the list is
-   * empty, the expectation is that the ticket can only be redeemed on the
-   * current service where the ticket was generated.
+   * A list of URIs where this ticket can be redeemed.
+   *
+   * If the list is empty, the expectation is that the ticket can only
+   * be redeemed on the current service where the ticket was
+   * generated.
+   *
+   * If the list is not empty, the expectation is that the ticket can
+   * be redeemed at any of the locations, and that the data returned
+   * will be equivalent. In other words, multiple locations provide
+   * redundancy/load balancing.
    */
   repeated Location location = 2;
 }

--- a/format/Flight.proto
+++ b/format/Flight.proto
@@ -260,9 +260,11 @@ message FlightInfo {
 
   /*
    * A list of endpoints associated with the flight. To consume the
-   * whole flight, all endpoints (and hence all Tickets) must be consumed.
+   * whole flight, all endpoints (and hence all Tickets) must be
+   * consumed. Endpoints can be consumed in any order.
    *
-   * In other words, multiple endpoints provide partitioning.
+   * In other words, an application can use multiple endpoints to
+   * represent partitioned data.
    */
   repeated FlightEndpoint endpoint = 3;
 
@@ -294,7 +296,8 @@ message FlightEndpoint {
    * at one of the given locations, and not (necessarily) on the
    * current service.
    *
-   * In other words, multiple locations provide redundancy/load balancing.
+   * In other words, an application can use multiple locations to
+   * represent redundant and/or load balanced services.
    */
   repeated Location location = 2;
 }

--- a/format/Flight.proto
+++ b/format/Flight.proto
@@ -287,7 +287,7 @@ message FlightEndpoint {
   Ticket ticket = 1;
 
   /*
-   * A list of URIs where this ticket can be redeemed.
+   * A list of URIs where this ticket can be redeemed via DoGet().
    *
    * If the list is empty, the expectation is that the ticket can only
    * be redeemed on the current service where the ticket was
@@ -317,8 +317,8 @@ message Location {
  * An opaque identifier that the service can use to retrieve a particular
  * portion of a stream.
  *
- * Tickets are meant to be single use. It is an error/undefined behavior
- * to reuse a ticket.
+ * Tickets are meant to be single use. It is an error/application-defined
+ * behavior to reuse a ticket.
  */
 message Ticket {
   bytes ticket = 1;

--- a/format/Flight.proto
+++ b/format/Flight.proto
@@ -260,8 +260,9 @@ message FlightInfo {
 
   /*
    * A list of endpoints associated with the flight. To consume the
-   * whole flight, all endpoints must be consumed. In other words,
-   * multiple endpoints provide partitioning.
+   * whole flight, all endpoints (and hence all Tickets) must be consumed.
+   *
+   * In other words, multiple endpoints provide partitioning.
    */
   repeated FlightEndpoint endpoint = 3;
 
@@ -289,8 +290,11 @@ message FlightEndpoint {
    *
    * If the list is not empty, the expectation is that the ticket can
    * be redeemed at any of the locations, and that the data returned
-   * will be equivalent. In other words, multiple locations provide
-   * redundancy/load balancing.
+   * will be equivalent. In this case, the ticket may only be redeemed
+   * at one of the given locations, and not (necessarily) on the
+   * current service.
+   *
+   * In other words, multiple locations provide redundancy/load balancing.
    */
   repeated Location location = 2;
 }
@@ -306,6 +310,9 @@ message Location {
 /*
  * An opaque identifier that the service can use to retrieve a particular
  * portion of a stream.
+ *
+ * Tickets are meant to be single use. It is an error/undefined behavior
+ * to reuse a ticket.
  */
 message Ticket {
   bytes ticket = 1;

--- a/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/IntegrationTestClient.java
+++ b/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/IntegrationTestClient.java
@@ -154,12 +154,10 @@ class IntegrationTestClient {
       List<Location> locations = endpoint.getLocations();
       if (locations.isEmpty()) {
         // No locations provided, validate the server itself.
-        System.out.println("Verifying location " + server.getUri());
         testTicket(allocator, client, endpoint.getTicket(), inputPath);
       } else {
         // All locations should be equivalent, validate each one.
         for (Location location : locations) {
-          System.out.println("Verifying location " + location.getUri());
           try (FlightClient readClient = FlightClient.builder(allocator, location).build()) {
             testTicket(allocator, readClient, endpoint.getTicket(), inputPath);
           } catch (Exception e) {

--- a/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/IntegrationTestClient.java
+++ b/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/IntegrationTestClient.java
@@ -32,6 +32,7 @@ import org.apache.arrow.flight.FlightInfo;
 import org.apache.arrow.flight.FlightStream;
 import org.apache.arrow.flight.Location;
 import org.apache.arrow.flight.PutResult;
+import org.apache.arrow.flight.Ticket;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
@@ -152,46 +153,57 @@ class IntegrationTestClient {
       // 3. Download the data from the server.
       List<Location> locations = endpoint.getLocations();
       if (locations.isEmpty()) {
-        throw new RuntimeException("No locations returned from Flight server.");
-      }
-      for (Location location : locations) {
-        System.out.println("Verifying location " + location.getUri());
-        try (FlightClient readClient = FlightClient.builder(allocator, location).build();
-             FlightStream stream = readClient.getStream(endpoint.getTicket());
-             VectorSchemaRoot root = stream.getRoot();
-             VectorSchemaRoot downloadedRoot = VectorSchemaRoot.create(root.getSchema(), allocator);
-             JsonFileReader reader = new JsonFileReader(new File(inputPath), allocator)) {
-          VectorLoader loader = new VectorLoader(downloadedRoot);
-          VectorUnloader unloader = new VectorUnloader(root);
-
-          Schema jsonSchema = reader.start();
-          Validator.compareSchemas(root.getSchema(), jsonSchema);
-          try (VectorSchemaRoot jsonRoot = VectorSchemaRoot.create(jsonSchema, allocator)) {
-
-            while (stream.next()) {
-              try (final ArrowRecordBatch arb = unloader.getRecordBatch()) {
-                loader.load(arb);
-                if (reader.read(jsonRoot)) {
-
-                  // 4. Validate the data.
-                  Validator.compareVectorSchemaRoot(jsonRoot, downloadedRoot);
-                  jsonRoot.clear();
-                } else {
-                  throw new RuntimeException("Flight stream has more batches than JSON");
-                }
-              }
-            }
-
-            // Verify no more batches with data in JSON
-            // NOTE: Currently the C++ Flight server skips empty batches at end of the stream
-            if (reader.read(jsonRoot) && jsonRoot.getRowCount() > 0) {
-              throw new RuntimeException("JSON has more batches with than Flight stream");
-            }
+        // No locations provided, validate the server itself.
+        System.out.println("Verifying location " + server.getUri());
+        testTicket(allocator, client, endpoint.getTicket(), inputPath);
+      } else {
+        // All locations should be equivalent, validate each one.
+        for (Location location : locations) {
+          System.out.println("Verifying location " + location.getUri());
+          try (FlightClient readClient = FlightClient.builder(allocator, location).build()) {
+            testTicket(allocator, readClient, endpoint.getTicket(), inputPath);
+          } catch (Exception e) {
+            throw new RuntimeException(e);
           }
-        } catch (Exception e) {
-          throw new RuntimeException(e);
         }
       }
+    }
+  }
+
+  private static void testTicket(BufferAllocator allocator, FlightClient readClient, Ticket ticket, String inputPath) {
+    try (FlightStream stream = readClient.getStream(ticket);
+         VectorSchemaRoot root = stream.getRoot();
+         VectorSchemaRoot downloadedRoot = VectorSchemaRoot.create(root.getSchema(), allocator);
+         JsonFileReader reader = new JsonFileReader(new File(inputPath), allocator)) {
+      VectorLoader loader = new VectorLoader(downloadedRoot);
+      VectorUnloader unloader = new VectorUnloader(root);
+
+      Schema jsonSchema = reader.start();
+      Validator.compareSchemas(root.getSchema(), jsonSchema);
+      try (VectorSchemaRoot jsonRoot = VectorSchemaRoot.create(jsonSchema, allocator)) {
+
+        while (stream.next()) {
+          try (final ArrowRecordBatch arb = unloader.getRecordBatch()) {
+            loader.load(arb);
+            if (reader.read(jsonRoot)) {
+
+              // 4. Validate the data.
+              Validator.compareVectorSchemaRoot(jsonRoot, downloadedRoot);
+              jsonRoot.clear();
+            } else {
+              throw new RuntimeException("Flight stream has more batches than JSON");
+            }
+          }
+        }
+
+        // Verify no more batches with data in JSON
+        // NOTE: Currently the C++ Flight server skips empty batches at end of the stream
+        if (reader.read(jsonRoot) && jsonRoot.getRowCount() > 0) {
+          throw new RuntimeException("JSON has more batches with than Flight stream");
+        }
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
   }
 }


### PR DESCRIPTION
Clarify that an empty list of locations means we should fetch data from the same server, and that multiple locations mean that all locations are equivalent.

See ["[Java] [Flight] Usage of Locations on FlightEndpoint"](https://lists.apache.org/thread/1668fk1myqf8168xh296qck5fn8ztcmn) on user@ for the original discussion.