### PR TITLE
ARROW-15851: [C++] Enable RE2 when building with gRPC

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -303,6 +303,7 @@ if(ARROW_FLIGHT)
 endif()
 
 if(ARROW_WITH_GRPC)
+  set(ARROW_WITH_RE2 ON)
   set(ARROW_WITH_ZLIB ON)
 endif()
 


### PR DESCRIPTION
This fixes a build issue with some CMake presets.