### PR TITLE
MINOR: [C++][CI] Unpin CMake

### DIFF
--- a/ci/conda_env_cpp.txt
+++ b/ci/conda_env_cpp.txt
@@ -21,8 +21,7 @@ boost-cpp>=1.68.0
 brotli
 bzip2
 c-ares
-# Required due to the AWS SDK C++ pin
-cmake<3.22
+cmake
 gflags
 glog
 gmock>=1.10.0


### PR DESCRIPTION
CMake >=3.22.3 fixes the error causing us to pin the CMake version
(see https://gitlab.kitware.com/cmake/cmake/-/issues/22524).