### PR TITLE
ARROW-15946: [Go] Fix memory leak in pqarrow.NewColumnWriter when writing nested data

### DIFF
--- a/go/parquet/pqarrow/encode_arrow.go
+++ b/go/parquet/pqarrow/encode_arrow.go
@@ -134,6 +134,7 @@ func NewArrowColumnWriter(data *arrow.Chunked, offset, size int64, manifest *Sch
 		// the chunk offset will be 0 here except for possibly the first chunk
 		// because of the above advancing logic
 		arrToWrite := array.NewSlice(chunk, chunkOffset, chunkOffset+chunkWriteSize)
+		defer arrToWrite.Release()
 
 		if arrToWrite.Len() > 0 {
 			bldr, err := newMultipathLevelBuilder(arrToWrite, isNullable)

--- a/go/parquet/pqarrow/encode_arrow_test.go
+++ b/go/parquet/pqarrow/encode_arrow_test.go
@@ -1361,6 +1361,7 @@ func TestWriteTableMemoryAllocation(t *testing.T) {
 		{Name: "struct_i64_f64", Type: arrow.StructOf(
 			arrow.Field{Name: "i64", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 			arrow.Field{Name: "f64", Type: arrow.PrimitiveTypes.Float64, Nullable: true})},
+		{Name: "arr_i64", Type: arrow.ListOf(arrow.PrimitiveTypes.Int64)},
 	}, nil)
 
 	bld := array.NewRecordBuilder(allocator, sc)
@@ -1370,6 +1371,9 @@ func TestWriteTableMemoryAllocation(t *testing.T) {
 	sbld.Append(true)
 	sbld.FieldBuilder(0).(*array.Int64Builder).Append(1)
 	sbld.FieldBuilder(1).(*array.Float64Builder).Append(1.0)
+	abld := bld.Field(3).(*array.ListBuilder)
+	abld.Append(true)
+	abld.ValueBuilder().(*array.Int64Builder).Append(2)
 
 	rec := bld.NewRecord()
 	bld.Release()

--- a/go/parquet/pqarrow/encode_arrow_test.go
+++ b/go/parquet/pqarrow/encode_arrow_test.go
@@ -1352,3 +1352,37 @@ func (ps *ParquetIOTestSuite) TestArrowMapTypeRoundTrip() {
 
 	ps.roundTripTable(tbl, true)
 }
+
+func TestWriteTableMemoryAllocation(t *testing.T) {
+	allocator := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	sc := arrow.NewSchema([]arrow.Field{
+		{Name: "f32", Type: arrow.PrimitiveTypes.Float32, Nullable: true},
+		{Name: "i32", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+		{Name: "struct_i64_f64", Type: arrow.StructOf(
+			arrow.Field{Name: "i64", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+			arrow.Field{Name: "f64", Type: arrow.PrimitiveTypes.Float64, Nullable: true})},
+	}, nil)
+
+	bld := array.NewRecordBuilder(allocator, sc)
+	bld.Field(0).(*array.Float32Builder).Append(1.0)
+	bld.Field(1).(*array.Int32Builder).Append(1)
+	sbld := bld.Field(2).(*array.StructBuilder)
+	sbld.Append(true)
+	sbld.FieldBuilder(0).(*array.Int64Builder).Append(1)
+	sbld.FieldBuilder(1).(*array.Float64Builder).Append(1.0)
+
+	rec := bld.NewRecord()
+	bld.Release()
+
+	var buf bytes.Buffer
+	wr, err := pqarrow.NewFileWriter(sc, &buf,
+		parquet.NewWriterProperties(parquet.WithCompression(compress.Codecs.Snappy)),
+		pqarrow.NewArrowWriterProperties(pqarrow.WithAllocator(allocator)))
+	require.NoError(t, err)
+
+	require.NoError(t, wr.Write(rec))
+	rec.Release()
+	wr.Close()
+
+	require.Zero(t, allocator.CurrentAlloc())
+}

--- a/go/parquet/pqarrow/path_builder.go
+++ b/go/parquet/pqarrow/path_builder.go
@@ -555,7 +555,6 @@ type multipathLevelResult struct {
 }
 
 func (m *multipathLevelResult) Release() {
-	m.leafArr.Release()
 	m.defLevels = nil
 	if m.defLevelsBuffer != nil {
 		m.defLevelsBuffer.Release()


### PR DESCRIPTION
`arrToWrite` is given to `newMultipathLevelBuilder`, which does call `Retain` on the provided array, so `NewColumnWriter` can `arrToWrite.Release`