### PR TITLE
ARROW-15954: [Java] Remove mac native netty kqueue dependency after upgrade

### DIFF
--- a/java/flight/flight-core/pom.xml
+++ b/java/flight/flight-core/pom.xml
@@ -367,12 +367,6 @@
           <version>${dep.netty.version}</version>
           <classifier>${os.detected.name}-${os.detected.arch}</classifier>
         </dependency>
-        <dependency>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-transport-native-kqueue</artifactId>
-          <version>${dep.netty.version}</version>
-          <classifier>${os.detected.name}-${os.detected.arch}</classifier>
-        </dependency>
       </dependencies>
     </profile>
   </profiles>


### PR DESCRIPTION
In https://github.com/apache/arrow/pull/12550, the grpc/netty upgrade no longer used native dependencies epoll for linux and kqueue for mac. This caused an unused dependency error when building the Java Flight JARs. The epoll dependency was previously removed, this removes the kqueue.