### PR TITLE
ARROW-15955: [Packaging][RPM] Add missing json-devel to CentOS Stream 8 build image

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow/yum/centos-8-stream/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/yum/centos-8-stream/Dockerfile
@@ -40,6 +40,7 @@ RUN \
     glog-devel \
     gobject-introspection-devel \
     gtk-doc \
+    json-devel \
     libarchive \
     libzstd-devel \
     llvm-devel \


### PR DESCRIPTION
https://github.com/ursacomputing/crossbow/runs/5565150630?check_suite_focus=true#step:6:152

    json-devel is needed by arrow-8.0.0.dev229-1.el8.x86_64