### PR TITLE
ARROW-15962: [C++][GANDIVA] Fix unhex errors return

### DIFF
--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -474,8 +474,7 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      kResultNullIfNull, "to_hex_int32", NativeFunction::kNeedsContext),
 
       NativeFunction("from_hex", {"unhex"}, DataTypeVector{utf8()}, binary(),
-                     kResultNullIfNull, "from_hex_utf8",
-                     NativeFunction::kNeedsContext | NativeFunction::kCanReturnErrors),
+                     kResultNullInternal, "from_hex_utf8", NativeFunction::kNeedsContext),
 
       NativeFunction("split_part", {}, DataTypeVector{utf8(), utf8(), int32()}, utf8(),
                      kResultNullIfNull, "split_part",

--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -474,7 +474,8 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      kResultNullIfNull, "to_hex_int32", NativeFunction::kNeedsContext),
 
       NativeFunction("from_hex", {"unhex"}, DataTypeVector{utf8()}, binary(),
-                     kResultNullIfNull, "from_hex_utf8", NativeFunction::kNeedsContext),
+                     kResultNullIfNull, "from_hex_utf8",
+                     NativeFunction::kNeedsContext | NativeFunction::kCanReturnErrors),
 
       NativeFunction("split_part", {}, DataTypeVector{utf8(), utf8(), int32()}, utf8(),
                      kResultNullIfNull, "split_part",

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -2737,7 +2737,7 @@ const char* to_hex_int32(int64_t context, int32_t data, int32_t* out_len) {
 FORCE_INLINE
 const char* from_hex_utf8(int64_t context, const char* text, int32_t text_len,
                           bool text_validity, bool* out_valid, int32_t* out_len) {
-  if (text_len == 0) {
+  if (text_len == 0 || !text_validity) {
     *out_valid = true;
     *out_len = 0;
     return "";

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -2736,16 +2736,16 @@ const char* to_hex_int32(int64_t context, int32_t data, int32_t* out_len) {
 
 FORCE_INLINE
 const char* from_hex_utf8(int64_t context, const char* text, int32_t text_len,
-                          int32_t* out_len) {
+                          bool text_validity, bool* out_valid, int32_t* out_len) {
   if (text_len == 0) {
+    *out_valid = true;
     *out_len = 0;
     return "";
   }
 
   // the input string should have a length multiple of two
   if (text_len % 2 != 0) {
-    gdv_fn_context_set_error_msg(
-        context, "Error parsing hex string, length was not a multiple of two.");
+    *out_valid = false;
     *out_len = 0;
     return "";
   }
@@ -2753,7 +2753,7 @@ const char* from_hex_utf8(int64_t context, const char* text, int32_t text_len,
   char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, text_len / 2));
 
   if (ret == nullptr) {
-    gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
+    *out_valid = false;
     *out_len = 0;
     return "";
   }
@@ -2767,12 +2767,12 @@ const char* from_hex_utf8(int64_t context, const char* text, int32_t text_len,
       // [a-fA-F0-9]
       ret[j++] = to_binary_from_hex(b1) * 16 + to_binary_from_hex(b2);
     } else {
-      gdv_fn_context_set_error_msg(
-          context, "Error parsing hex string, one or more bytes are not valid.");
+      *out_valid = false;
       *out_len = 0;
       return "";
     }
   }
+  *out_valid = true;
   *out_len = j;
   return ret;
 }

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -2737,14 +2737,14 @@ const char* to_hex_int32(int64_t context, int32_t data, int32_t* out_len) {
 FORCE_INLINE
 const char* from_hex_utf8(int64_t context, const char* text, int32_t text_len,
                           bool text_validity, bool* out_valid, int32_t* out_len) {
-  if (text_len == 0 || !text_validity) {
+  if (text_len == 0) {
     *out_valid = true;
     *out_len = 0;
     return "";
   }
 
-  // the input string should have a length multiple of two
-  if (text_len % 2 != 0) {
+  // the input string should have a length multiple of two and a true validity
+  if (text_len % 2 != 0 || !text_validity) {
     *out_valid = false;
     *out_len = 0;
     return "";

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -2294,6 +2294,22 @@ TEST(TestStringOps, TestFromHex) {
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "OM");
 
+  out_str = from_hex_utf8(ctx_ptr, "egular courts above th", 22, &out_len);
+  output = std::string(out_str, out_len);
+  EXPECT_EQ(output, "");
+  EXPECT_THAT(
+      ctx.get_error(),
+      ::testing::HasSubstr("Error parsing hex string, one or more bytes are not valid."));
+  ctx.Reset();
+
+  out_str = from_hex_utf8(ctx_ptr, "lites. fluffily even de", 23, &out_len);
+  output = std::string(out_str, out_len);
+  EXPECT_EQ(output, "");
+  EXPECT_THAT(
+      ctx.get_error(),
+      ::testing::HasSubstr("Error parsing hex string, length was not a multiple of"));
+  ctx.Reset();
+
   out_str = from_hex_utf8(ctx_ptr, "T", 1, &out_len);
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "");

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -2268,63 +2268,60 @@ TEST(TestStringOps, TestFromHex) {
   gandiva::ExecutionContext ctx;
   uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
   gdv_int32 out_len = 0;
+  bool out_valid = false;
   const char* out_str;
 
-  out_str = from_hex_utf8(ctx_ptr, "414243", 6, &out_len);
+  out_str = from_hex_utf8(ctx_ptr, "414243", 6, true, &out_valid, &out_len);
   std::string output = std::string(out_str, out_len);
   EXPECT_EQ(output, "ABC");
+  EXPECT_EQ(out_valid, true);
 
-  out_str = from_hex_utf8(ctx_ptr, "", 0, &out_len);
+  out_str = from_hex_utf8(ctx_ptr, "", 0, true, &out_valid, &out_len);
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "");
+  EXPECT_EQ(out_valid, true);
 
-  out_str = from_hex_utf8(ctx_ptr, "41", 2, &out_len);
+  out_str = from_hex_utf8(ctx_ptr, "41", 2, true, &out_valid, &out_len);
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "A");
+  EXPECT_EQ(out_valid, true);
 
-  out_str = from_hex_utf8(ctx_ptr, "6d6D", 4, &out_len);
+  out_str = from_hex_utf8(ctx_ptr, "6d6D", 4, true, &out_valid, &out_len);
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "mm");
+  EXPECT_EQ(out_valid, true);
 
-  out_str = from_hex_utf8(ctx_ptr, "6f6d", 4, &out_len);
+  out_str = from_hex_utf8(ctx_ptr, "6f6d", 4, true, &out_valid, &out_len);
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "om");
+  EXPECT_EQ(out_valid, true);
 
-  out_str = from_hex_utf8(ctx_ptr, "4f4D", 4, &out_len);
+  out_str = from_hex_utf8(ctx_ptr, "4f4D", 4, true, &out_valid, &out_len);
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "OM");
+  EXPECT_EQ(out_valid, true);
 
-  out_str = from_hex_utf8(ctx_ptr, "egular courts above th", 22, &out_len);
+  out_str =
+      from_hex_utf8(ctx_ptr, "egular courts above th", 22, true, &out_valid, &out_len);
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "");
-  EXPECT_THAT(
-      ctx.get_error(),
-      ::testing::HasSubstr("Error parsing hex string, one or more bytes are not valid."));
-  ctx.Reset();
+  EXPECT_EQ(out_valid, false);
 
-  out_str = from_hex_utf8(ctx_ptr, "lites. fluffily even de", 23, &out_len);
+  out_str =
+      from_hex_utf8(ctx_ptr, "lites. fluffily even de", 23, true, &out_valid, &out_len);
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "");
-  EXPECT_THAT(
-      ctx.get_error(),
-      ::testing::HasSubstr("Error parsing hex string, length was not a multiple of"));
-  ctx.Reset();
+  EXPECT_EQ(out_valid, false);
 
-  out_str = from_hex_utf8(ctx_ptr, "T", 1, &out_len);
+  out_str = from_hex_utf8(ctx_ptr, "T", 1, true, &out_valid, &out_len);
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "");
-  EXPECT_THAT(
-      ctx.get_error(),
-      ::testing::HasSubstr("Error parsing hex string, length was not a multiple of"));
-  ctx.Reset();
+  EXPECT_EQ(out_valid, false);
 
-  out_str = from_hex_utf8(ctx_ptr, "\\x41\\x42\\x43", 12, &out_len);
+  out_str = from_hex_utf8(ctx_ptr, "\\x41\\x42\\x43", 12, true, &out_valid, &out_len);
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "");
-  EXPECT_THAT(
-      ctx.get_error(),
-      ::testing::HasSubstr("Error parsing hex string, one or more bytes are not valid."));
-  ctx.Reset();
+  EXPECT_EQ(out_valid, false);
 }
 TEST(TestStringOps, TestSoundex) {
   gandiva::ExecutionContext ctx;

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -2301,6 +2301,11 @@ TEST(TestStringOps, TestFromHex) {
   EXPECT_EQ(output, "OM");
   EXPECT_EQ(out_valid, true);
 
+  out_str = from_hex_utf8(ctx_ptr, "4f4D", 4, false, &out_valid, &out_len);
+  output = std::string(out_str, out_len);
+  EXPECT_EQ(output, "");
+  EXPECT_EQ(out_valid, true);
+
   out_str =
       from_hex_utf8(ctx_ptr, "egular courts above th", 22, true, &out_valid, &out_len);
   output = std::string(out_str, out_len);

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -2304,7 +2304,7 @@ TEST(TestStringOps, TestFromHex) {
   out_str = from_hex_utf8(ctx_ptr, "4f4D", 4, false, &out_valid, &out_len);
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "");
-  EXPECT_EQ(out_valid, true);
+  EXPECT_EQ(out_valid, false);
 
   out_str =
       from_hex_utf8(ctx_ptr, "egular courts above th", 22, true, &out_valid, &out_len);

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -700,7 +700,7 @@ const char* to_hex_int64(int64_t context, int64_t data, int32_t* out_len);
 const char* to_hex_int32(int64_t context, int32_t data, int32_t* out_len);
 
 const char* from_hex_utf8(int64_t context, const char* text, int32_t text_len,
-                          int32_t* out_len);
+                          bool text_validity, bool* out_valid, int32_t* out_len);
 
 int32_t castINT_utf8(int64_t context, const char* data, int32_t len);
 

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -2187,12 +2187,14 @@ TEST_F(TestProjector, TestConcatFromHex) {
   EXPECT_TRUE(status.ok()) << status.message();
 
   // Create a row-batch with some sample data
-  int num_records = 6;
-  auto array0 = MakeArrowArrayUtf8({"414243", "", "41", "4f4D", "6f6d", "4f"},
-                                   {true, true, true, true, true, true});
+  int num_records = 8;
+  auto array0 = MakeArrowArrayUtf8({"414243", "", "41", "4f4D", "6f6d", "4f",
+                                    "egular courts above th", "lites. fluffily even de"},
+                                   {true, true, true, true, true, true, true, true});
   // expected output
-  auto exp_from_hex = MakeArrowArrayBinary({"ABC", "", "A", "OM", "om", "O"},
-                                           {true, true, true, true, true, true});
+  auto exp_from_hex =
+      MakeArrowArrayBinary({"ABC", "", "A", "OM", "om", "O", "", ""},
+                           {true, true, true, true, true, true, false, false});
 
   // prepare input record batch
   auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array0});


### PR DESCRIPTION
Modifying function behavior to not pop errors on non-hex inputs