### PR TITLE
ARROW-15963: [Go][Parquet] simplify ReaderAtSeeker interface

### DIFF
--- a/go/parquet/file/row_group_reader.go
+++ b/go/parquet/file/row_group_reader.go
@@ -17,7 +17,6 @@
 package file
 
 import (
-	"github.com/apache/arrow/go/v8/arrow/ipc"
 	"github.com/apache/arrow/go/v8/parquet"
 	"github.com/apache/arrow/go/v8/parquet/internal/encryption"
 	"github.com/apache/arrow/go/v8/parquet/internal/utils"
@@ -31,7 +30,7 @@ const (
 
 // RowGroupReader is the primary interface for reading a single row group
 type RowGroupReader struct {
-	r             ipc.ReadAtSeeker
+	r             parquet.ReaderAtSeeker
 	sourceSz      int64
 	fileMetadata  *metadata.FileMetaData
 	rgMetadata    *metadata.RowGroupMetaData

--- a/go/parquet/internal/testutils/pagebuilder.go
+++ b/go/parquet/internal/testutils/pagebuilder.go
@@ -220,7 +220,7 @@ func (m *MockPageReader) Err() error {
 	return m.Called().Error(0)
 }
 
-func (m *MockPageReader) Reset(parquet.ReaderAtSeeker, int64, compress.Compression, *file.CryptoContext) {
+func (m *MockPageReader) Reset(io.ReadSeeker, int64, compress.Compression, *file.CryptoContext) {
 }
 
 func (m *MockPageReader) SetMaxPageHeaderSize(int) {}

--- a/go/parquet/reader_properties.go
+++ b/go/parquet/reader_properties.go
@@ -60,7 +60,7 @@ func (r *ReaderProperties) Allocator() memory.Allocator { return r.alloc }
 //
 // If BufferedStreamEnabled is true, it creates an io.SectionReader, otherwise it will read the entire section
 // into a buffer in memory and return a bytes.NewReader for that buffer.
-func (r *ReaderProperties) GetStream(source io.ReaderAt, start, nbytes int64) (ReaderAtSeeker, error) {
+func (r *ReaderProperties) GetStream(source io.ReaderAt, start, nbytes int64) (io.ReadSeeker, error) {
 	if r.BufferedStreamEnabled {
 		return io.NewSectionReader(source, start, nbytes), nil
 	}

--- a/go/parquet/types.go
+++ b/go/parquet/types.go
@@ -54,7 +54,7 @@ var (
 // to be able to call ReadAt, Read, and Seek
 type ReaderAtSeeker interface {
 	io.ReaderAt
-	io.ReadSeeker
+	io.Seeker
 }
 
 // NewInt96 creates a new Int96 from the given 3 uint32 values.


### PR DESCRIPTION
Proposed by and closes #12428 I've simplified the ReaderAtSeeker interface to only require `io.ReaderAt` and `io.Seeker` rather than `io.ReadSeeker`. This means there are only two methods required for the `parquet.ReaderAtSeeker` interface: `ReadAt` and `Seek`. 

Simplifying the interface makes it easier for anyone to use the Parquet library by reducing the burden on implementing new sources.