### PR TITLE
ARROW-15965: [C++][Python] Add Scalar constructor of RoundToMultipleOptions to Python

### DIFF
--- a/cpp/src/arrow/compute/api_scalar.h
+++ b/cpp/src/arrow/compute/api_scalar.h
@@ -129,10 +129,9 @@ class ARROW_EXPORT RoundToMultipleOptions : public FunctionOptions {
   static RoundToMultipleOptions Defaults() { return RoundToMultipleOptions(); }
   /// Rounding scale (multiple to round to).
   ///
-  /// Should be a scalar of a type compatible with the argument to be rounded.
-  /// For example, rounding a decimal value means a decimal multiple is
-  /// required. Rounding a floating point or integer value means a floating
-  /// point scalar is required.
+  /// Should be a positive numeric scalar of a type compatible with the
+  /// argument to be rounded. The cast kernel is used to convert the rounding
+  /// multiple to match the result type.
   std::shared_ptr<Scalar> multiple;
   /// Rounding and tie-breaking mode
   RoundMode round_mode;

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -1437,7 +1437,7 @@ struct RoundToMultiple<ArrowType, kRoundMode, enable_if_decimal<ArrowType>> {
 
   template <typename T = ArrowType, typename CType = typename TypeTraits<T>::CType>
   enable_if_decimal_value<CType> Call(KernelContext* ctx, CType arg, Status* st) const {
-    if (multiple == T(0)) {
+    if (multiple == T{0}) {
       return 0;
     }
     std::pair<CType, CType> pair;

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -1381,20 +1381,8 @@ struct RoundToMultiple {
   CType multiple;
 
   explicit RoundToMultiple(const State& state, const DataType& out_ty) {
-    // const auto& options = state.options;
-    // DCHECK(options.multiple);
-    // DCHECK(options.multiple->is_valid);
-    // DCHECK(is_floating(options.multiple->type->id()));
-    // switch (options.multiple->type->id()) {
-    //   case Type::FLOAT:
-    //     multiple = static_cast<CType>(UnboxScalar<FloatType>::Unbox(*options.multiple));
-    //     break;
-    //   case Type::DOUBLE:
-    //     multiple = static_cast<CType>(UnboxScalar<DoubleType>::Unbox(*options.multiple));
-    //     break;
-    //   default:
-    //     DCHECK(false);
-    // }
+    const auto& options = state.options;
+    multiple = static_cast<CType>(UnboxScalar<ArrowType>::Unbox(*options.multiple));
   }
 
   template <typename T = ArrowType, typename CType = typename TypeTraits<T>::CType>
@@ -1438,12 +1426,8 @@ struct RoundToMultiple<ArrowType, kRoundMode, enable_if_decimal<ArrowType>> {
   explicit RoundToMultiple(const State& state, const DataType& out_ty)
       : ty(checked_cast<const ArrowType&>(out_ty)) {
     const auto& options = state.options;
-    // DCHECK(options.multiple);
-    // DCHECK(options.multiple->is_valid);
-    // DCHECK(options.multiple->type->Equals(out_ty));
     multiple = UnboxScalar<ArrowType>::Unbox(*options.multiple);
-    half_multiple = multiple;
-    half_multiple /= 2;
+    half_multiple = multiple / 2;
     neg_half_multiple = -half_multiple;
     has_halfway_point = multiple.low_bits() % 2 == 0;
   }

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -1397,7 +1397,12 @@ struct RoundToMultiple {
   CType multiple;
 
   explicit RoundToMultiple(const State& state, const DataType& out_ty)
-      : multiple(UnboxScalar<ArrowType>::Unbox(*state.options.multiple)) {}
+      : multiple(UnboxScalar<ArrowType>::Unbox(*state.options.multiple)) {
+    const auto& options = state.options;
+    DCHECK(options.multiple);
+    DCHECK(options.multiple->is_valid);
+    DCHECK(is_floating(options.multiple->type->id()));
+  }
 
   template <typename T = ArrowType, typename CType = typename TypeTraits<T>::CType>
   enable_if_floating_value<CType> Call(KernelContext* ctx, CType arg, Status* st) const {
@@ -1442,7 +1447,12 @@ struct RoundToMultiple<ArrowType, kRoundMode, enable_if_decimal<ArrowType>> {
         multiple(UnboxScalar<ArrowType>::Unbox(*state.options.multiple)),
         half_multiple(multiple / 2),
         neg_half_multiple(-half_multiple),
-        has_halfway_point(multiple.low_bits() % 2 == 0) {}
+        has_halfway_point(multiple.low_bits() % 2 == 0) {
+    const auto& options = state.options;
+    DCHECK(options.multiple);
+    DCHECK(options.multiple->is_valid);
+    DCHECK(options.multiple->type->Equals(out_ty));
+  }
 
   template <typename T = ArrowType, typename CType = typename TypeTraits<T>::CType>
   enable_if_decimal_value<CType> Call(KernelContext* ctx, CType arg, Status* st) const {

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -2013,12 +2013,12 @@ TEST_F(TestUnaryArithmeticDecimal, RoundToMultipleTowardsInfinity) {
     CheckRaises(func, {ArrayFromJSON(ty, R"(["99.99"])")},
                 "Rounded value 100.00 does not fit in precision", &options);
     options.multiple = std::make_shared<DoubleScalar>(1.0);
-    CheckRaises(func, {ArrayFromJSON(ty, R"(["99.99"])")}, "scalar, not double",
-                &options);
+    CheckRaises(func, {ArrayFromJSON(ty, R"(["99.99"])")},
+                "Rounded value 100.00 does not fit in precision", &options);
     options.multiple =
         std::make_shared<Decimal128Scalar>(Decimal128(0), decimal128(3, 0));
-    CheckRaises(func, {ArrayFromJSON(ty, R"(["99.99"])")}, "scalar, not decimal128(3, 0)",
-                &options);
+    CheckRaises(func, {ArrayFromJSON(ty, R"(["99.99"])")},
+                "Rounding multiple must be positive", &options);
     options.multiple = std::make_shared<Decimal128Scalar>(decimal128(3, 0));
     CheckRaises(func, {ArrayFromJSON(ty, R"(["99.99"])")},
                 "Rounding multiple must be non-null and valid", &options);

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -2004,21 +2004,25 @@ TEST_F(TestUnaryArithmeticDecimal, RoundToMultipleTowardsInfinity) {
     set_multiple(ty, 1);
     CheckScalar(func, {values}, values, &options);
     set_multiple(ty, 0);
-    CheckRaises(func, {ArrayFromJSON(ty, R"(["99.99"])")},
-                "Rounding multiple must be positive", &options);
+    CheckScalar(
+        func, {values},
+        ArrayFromJSON(ty, R"(["0.00", "0.00", "0.00", "0.00", "0.00", "0.00", null])"),
+        &options);
+    options.multiple =
+        std::make_shared<Decimal128Scalar>(Decimal128(0), decimal128(4, 2));
+    CheckScalar(
+        func, {values},
+        ArrayFromJSON(ty, R"(["0.00", "0.00", "0.00", "0.00", "0.00", "0.00", null])"),
+        &options);
     set_multiple(ty, -10);
     CheckRaises(func, {ArrayFromJSON(ty, R"(["99.99"])")},
-                "Rounding multiple must be positive", &options);
+                "Rounding multiple must be nonnegative", &options);
     set_multiple(ty, 100);
     CheckRaises(func, {ArrayFromJSON(ty, R"(["99.99"])")},
                 "Rounded value 100.00 does not fit in precision", &options);
     options.multiple = std::make_shared<DoubleScalar>(1.0);
     CheckRaises(func, {ArrayFromJSON(ty, R"(["99.99"])")},
                 "Rounded value 100.00 does not fit in precision", &options);
-    options.multiple =
-        std::make_shared<Decimal128Scalar>(Decimal128(0), decimal128(3, 0));
-    CheckRaises(func, {ArrayFromJSON(ty, R"(["99.99"])")},
-                "Rounding multiple must be positive", &options);
     options.multiple = std::make_shared<Decimal128Scalar>(decimal128(3, 0));
     CheckRaises(func, {ArrayFromJSON(ty, R"(["99.99"])")},
                 "Rounding multiple must be non-null and valid", &options);
@@ -2321,6 +2325,7 @@ TYPED_TEST(TestUnaryRoundToMultipleSigned, RoundToMultiple) {
 
   // Test different round multiples for nearest rounding mode
   std::vector<std::pair<double, std::string>> multiple_and_expected{{
+      {0, "[0, 0, 0, 0, 0]"},
       {2, "[0.0, 2, -14, -50, 116]"},
       {0.05, "[0.0, 1, -13, -50, 115]"},
       {0.1, values},
@@ -2345,9 +2350,10 @@ TYPED_TEST(TestUnaryRoundToMultipleUnsigned, RoundToMultiple) {
 
   // Test different round multiples for nearest rounding mode
   std::vector<std::pair<double, std::string>> multiple_and_expected{{
-      {2, "[0, 2, 14, 50, 116]"},
+      {0, "[0, 0, 0, 0, 0]"},
       {0.05, "[0, 1, 13, 50, 115]"},
       {0.1, values},
+      {2, "[0, 2, 14, 50, 116]"},
       {10, "[0, 0, 10, 50, 120]"},
       {100, "[0, 0, 0, 100, 100]"},
   }};
@@ -2387,9 +2393,10 @@ TYPED_TEST(TestUnaryRoundToMultipleFloating, RoundToMultiple) {
   // Test different round multiples for nearest rounding mode
   values = "[320, 3.5, 3.075, 4.5, -3.212, -35.1234, -3.045]";
   std::vector<std::pair<double, std::string>> multiple_and_expected{{
-      {2, "[320, 4, 4, 4, -4, -36, -4]"},
+      {0, "[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]"},
       {0.05, "[320, 3.5, 3.1, 4.5, -3.2, -35.1, -3.05]"},
       {0.1, "[320, 3.5, 3.1, 4.5, -3.2, -35.1, -3]"},
+      {2, "[320, 4, 4, 4, -4, -36, -4]"},
       {10, "[320, 0.0, 0.0, 0.0, -0.0, -40, -0.0]"},
       {100, "[300, 0.0, 0.0, 0.0, -0.0, -0.0, -0.0]"},
   }};
@@ -2400,7 +2407,7 @@ TYPED_TEST(TestUnaryRoundToMultipleFloating, RoundToMultiple) {
   }
 
   this->SetRoundMultiple(-2);
-  this->AssertUnaryOpRaises(RoundToMultiple, values, "multiple must be positive");
+  this->AssertUnaryOpRaises(RoundToMultiple, values, "multiple must be nonnegative");
 }
 
 class TestBinaryArithmeticDecimal : public TestArithmeticDecimal {};

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -2004,19 +2004,13 @@ TEST_F(TestUnaryArithmeticDecimal, RoundToMultipleTowardsInfinity) {
     set_multiple(ty, 1);
     CheckScalar(func, {values}, values, &options);
     set_multiple(ty, 0);
-    CheckScalar(
-        func, {values},
-        ArrayFromJSON(ty, R"(["0.00", "0.00", "0.00", "0.00", "0.00", "0.00", null])"),
-        &options);
+    CheckRaises(func, {values}, "Rounding multiple must be positive", &options);
     options.multiple =
         std::make_shared<Decimal128Scalar>(Decimal128(0), decimal128(4, 2));
-    CheckScalar(
-        func, {values},
-        ArrayFromJSON(ty, R"(["0.00", "0.00", "0.00", "0.00", "0.00", "0.00", null])"),
-        &options);
+    CheckRaises(func, {values}, "Rounding multiple must be positive", &options);
     set_multiple(ty, -10);
     CheckRaises(func, {ArrayFromJSON(ty, R"(["99.99"])")},
-                "Rounding multiple must be nonnegative", &options);
+                "Rounding multiple must be positive", &options);
     set_multiple(ty, 100);
     CheckRaises(func, {ArrayFromJSON(ty, R"(["99.99"])")},
                 "Rounded value 100.00 does not fit in precision", &options);
@@ -2325,7 +2319,6 @@ TYPED_TEST(TestUnaryRoundToMultipleSigned, RoundToMultiple) {
 
   // Test different round multiples for nearest rounding mode
   std::vector<std::pair<double, std::string>> multiple_and_expected{{
-      {0, "[0, 0, 0, 0, 0]"},
       {2, "[0.0, 2, -14, -50, 116]"},
       {0.05, "[0.0, 1, -13, -50, 115]"},
       {0.1, values},
@@ -2350,7 +2343,6 @@ TYPED_TEST(TestUnaryRoundToMultipleUnsigned, RoundToMultiple) {
 
   // Test different round multiples for nearest rounding mode
   std::vector<std::pair<double, std::string>> multiple_and_expected{{
-      {0, "[0, 0, 0, 0, 0]"},
       {0.05, "[0, 1, 13, 50, 115]"},
       {0.1, values},
       {2, "[0, 2, 14, 50, 116]"},
@@ -2393,7 +2385,6 @@ TYPED_TEST(TestUnaryRoundToMultipleFloating, RoundToMultiple) {
   // Test different round multiples for nearest rounding mode
   values = "[320, 3.5, 3.075, 4.5, -3.212, -35.1234, -3.045]";
   std::vector<std::pair<double, std::string>> multiple_and_expected{{
-      {0, "[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]"},
       {0.05, "[320, 3.5, 3.1, 4.5, -3.2, -35.1, -3.05]"},
       {0.1, "[320, 3.5, 3.1, 4.5, -3.2, -35.1, -3]"},
       {2, "[320, 4, 4, 4, -4, -36, -4]"},
@@ -2407,7 +2398,8 @@ TYPED_TEST(TestUnaryRoundToMultipleFloating, RoundToMultiple) {
   }
 
   this->SetRoundMultiple(-2);
-  this->AssertUnaryOpRaises(RoundToMultiple, values, "multiple must be nonnegative");
+  this->AssertUnaryOpRaises(RoundToMultiple, values,
+                            "Rounding multiple must be positive");
 }
 
 class TestBinaryArithmeticDecimal : public TestArithmeticDecimal {};

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -2003,6 +2003,12 @@ TEST_F(TestUnaryArithmeticDecimal, RoundToMultipleTowardsInfinity) {
         &options);
     set_multiple(ty, 1);
     CheckScalar(func, {values}, values, &options);
+    set_multiple(decimal128(2, 0), 2);
+    CheckScalar(
+        func, {values},
+        ArrayFromJSON(ty,
+                      R"(["2.00", "2.00", "2.00", "-42.00", "-44.00", "-44.00", null])"),
+        &options);
     set_multiple(ty, 0);
     CheckRaises(func, {values}, "Rounding multiple must be positive", &options);
     options.multiple =
@@ -2066,6 +2072,14 @@ TEST_F(TestUnaryArithmeticDecimal, RoundToMultipleHalfToOdd) {
                 ArrayFromJSON(ty, R"(["-0.48", "-0.48", "-0.24", "-0.24", "-0.24", "0.00",
                               "0.24", "0.24", "0.24", "0.48", "0.48", null])"),
                 &options);
+    set_multiple(decimal128(3, 1), 1);
+    CheckScalar(
+        func, {values},
+        ArrayFromJSON(
+            ty,
+            R"(["-0.40", "-0.40", "-0.30", "-0.10", "-0.10", "0.00", "0.10", "0.10",
+                      "0.30", "0.40", "0.40", null])"),
+        &options);
   }
   for (const auto& ty : {decimal128(2, -2), decimal256(2, -2)}) {
     auto values = DecimalArrayFromJSON(

--- a/cpp/src/arrow/util/int_util.h
+++ b/cpp/src/arrow/util/int_util.h
@@ -95,7 +95,7 @@ Status TransposeInts(const DataType& src_type, const DataType& dest_type,
                      int64_t dest_offset, int64_t length, const int32_t* transpose_map);
 
 /// \brief Do vectorized boundschecking of integer-type array indices. The
-/// indices must be non-nonnegative and strictly less than the passed upper
+/// indices must be nonnegative and strictly less than the passed upper
 /// limit (which is usually the length of an array that is being indexed-into).
 ARROW_EXPORT
 Status CheckIndexBounds(const ArrayData& indices, uint64_t upper_limit);

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -914,17 +914,11 @@ cdef class _RoundToMultipleOptions(FunctionOptions):
                 new CRoundToMultipleOptions(pyarrow_unwrap_scalar(multiple),
                                             unwrap_round_mode(round_mode))
             )
-        elif isinstance(multiple, (int, float)):
-            # Explicit numeric type checks are used because Cython allows
-            # bool-to-double conversions but Arrow C++ rounding functions
-            # and corresponding options do not support boolean values.
+        else:
             self.wrapped.reset(
                 new CRoundToMultipleOptions(<double> multiple,
                                             unwrap_round_mode(round_mode))
             )
-        else:
-            _raise_invalid_function_option(
-                multiple, "multiple", exception_class=TypeError)
 
 
 class RoundToMultipleOptions(_RoundToMultipleOptions):

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -910,7 +910,7 @@ class RoundTemporalOptions(_RoundTemporalOptions):
 cdef class _RoundToMultipleOptions(FunctionOptions):
     def _set_options(self, multiple, round_mode):
         self.wrapped.reset(
-            new CRoundToMultipleOptions(multiple,
+            new CRoundToMultipleOptions(pyarrow_unwrap_scalar(multiple),
                                         unwrap_round_mode(round_mode))
         )
 

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -914,8 +914,8 @@ cdef class _RoundToMultipleOptions(FunctionOptions):
                 multiple = lib.scalar(multiple)
             except Exception:
                 _raise_invalid_function_option(
-                    multiple, "`multiple` type for RoundToMultipleOptions",
-                    TypeError)
+                    multiple, "multiple type for RoundToMultipleOptions",
+                    exception_class=TypeError)
 
         self.wrapped.reset(
             new CRoundToMultipleOptions(

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -913,9 +913,14 @@ cdef class _RoundToMultipleOptions(FunctionOptions):
             try:
                 multiple = lib.scalar(multiple)
             except Exception:
-                _raise_invalid_function_option(multiple, "`multiple` type for RoundToMultipleOptions", TypeError)
+                _raise_invalid_function_option(
+                    multiple, "`multiple` type for RoundToMultipleOptions",
+                    TypeError)
 
-        self.wrapped.reset(new CRoundToMultipleOptions(pyarrow_unwrap_scalar(multiple), unwrap_round_mode(round_mode)))
+        self.wrapped.reset(
+            new CRoundToMultipleOptions(
+                pyarrow_unwrap_scalar(multiple), unwrap_round_mode(round_mode))
+        )
 
 
 class RoundToMultipleOptions(_RoundToMultipleOptions):

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -909,29 +909,13 @@ class RoundTemporalOptions(_RoundTemporalOptions):
 
 cdef class _RoundToMultipleOptions(FunctionOptions):
     def _set_options(self, multiple, round_mode):
-        # if isinstance(multiple, Scalar):
-        #     self.wrapped.reset(
-        #         new CRoundToMultipleOptions(pyarrow_unwrap_scalar(multiple),
-        #                                     unwrap_round_mode(round_mode))
-        #     )
-        # else:
-        #     self.wrapped.reset(
-        #         new CRoundToMultipleOptions(<double> multiple,
-        #                                     unwrap_round_mode(round_mode))
-        #     )
-
         if not isinstance(multiple, Scalar):
-            # Is it a Python scalar?
             try:
                 multiple = lib.scalar(multiple)
             except Exception:
-                raise TypeError(f"Got unexpected argument type {type(multiple)} "
-                                "for RoundToMultipleOptions")
+                _raise_invalid_function_option(multiple, "`multiple` type for RoundToMultipleOptions", TypeError)
 
-            self.wrapped.reset(
-                new CRoundToMultipleOptions(pyarrow_unwrap_scalar(multiple),
-                                            unwrap_round_mode(round_mode))
-            )
+        self.wrapped.reset(new CRoundToMultipleOptions(pyarrow_unwrap_scalar(multiple), unwrap_round_mode(round_mode)))
 
 
 class RoundToMultipleOptions(_RoundToMultipleOptions):

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -914,11 +914,13 @@ cdef class _RoundToMultipleOptions(FunctionOptions):
                 new CRoundToMultipleOptions(pyarrow_unwrap_scalar(multiple),
                                             unwrap_round_mode(round_mode))
             )
-        else:
+        elif isinstance(multiple, (int, float)) and not isinstance(multiple, bool):
             self.wrapped.reset(
-                new CRoundToMultipleOptions((<double> multiple),
+                new CRoundToMultipleOptions(<double> multiple,
                                             unwrap_round_mode(round_mode))
             )
+        else:
+            _raise_invalid_function_option(multiple, "multiple")
 
 
 class RoundToMultipleOptions(_RoundToMultipleOptions):

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -914,13 +914,17 @@ cdef class _RoundToMultipleOptions(FunctionOptions):
                 new CRoundToMultipleOptions(pyarrow_unwrap_scalar(multiple),
                                             unwrap_round_mode(round_mode))
             )
-        elif isinstance(multiple, (int, float)) and not isinstance(multiple, bool):
+        elif isinstance(multiple, (int, float)):
+            # Explicit numeric type checks are used because Cython allows
+            # bool-to-double conversions but Arrow C++ rounding functions
+            # and corresponding options do not support boolean values.
             self.wrapped.reset(
                 new CRoundToMultipleOptions(<double> multiple,
                                             unwrap_round_mode(round_mode))
             )
         else:
-            _raise_invalid_function_option(multiple, "multiple")
+            _raise_invalid_function_option(
+                multiple, "multiple", exception_class=TypeError)
 
 
 class RoundToMultipleOptions(_RoundToMultipleOptions):

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -909,14 +909,27 @@ class RoundTemporalOptions(_RoundTemporalOptions):
 
 cdef class _RoundToMultipleOptions(FunctionOptions):
     def _set_options(self, multiple, round_mode):
-        if isinstance(multiple, Scalar):
+        # if isinstance(multiple, Scalar):
+        #     self.wrapped.reset(
+        #         new CRoundToMultipleOptions(pyarrow_unwrap_scalar(multiple),
+        #                                     unwrap_round_mode(round_mode))
+        #     )
+        # else:
+        #     self.wrapped.reset(
+        #         new CRoundToMultipleOptions(<double> multiple,
+        #                                     unwrap_round_mode(round_mode))
+        #     )
+
+        if not isinstance(multiple, Scalar):
+            # Is it a Python scalar?
+            try:
+                multiple = lib.scalar(multiple)
+            except Exception:
+                raise TypeError(f"Got unexpected argument type {type(multiple)} "
+                                "for RoundToMultipleOptions")
+
             self.wrapped.reset(
                 new CRoundToMultipleOptions(pyarrow_unwrap_scalar(multiple),
-                                            unwrap_round_mode(round_mode))
-            )
-        else:
-            self.wrapped.reset(
-                new CRoundToMultipleOptions(<double> multiple,
                                             unwrap_round_mode(round_mode))
             )
 

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -909,10 +909,16 @@ class RoundTemporalOptions(_RoundTemporalOptions):
 
 cdef class _RoundToMultipleOptions(FunctionOptions):
     def _set_options(self, multiple, round_mode):
-        self.wrapped.reset(
-            new CRoundToMultipleOptions(pyarrow_unwrap_scalar(multiple),
-                                        unwrap_round_mode(round_mode))
-        )
+        if isinstance(multiple, Scalar):
+            self.wrapped.reset(
+                new CRoundToMultipleOptions(pyarrow_unwrap_scalar(multiple),
+                                            unwrap_round_mode(round_mode))
+            )
+        else:
+            self.wrapped.reset(
+                new CRoundToMultipleOptions((<double> multiple),
+                                            unwrap_round_mode(round_mode))
+            )
 
 
 class RoundToMultipleOptions(_RoundToMultipleOptions):
@@ -1409,13 +1415,13 @@ cdef class _SetLookupOptions(FunctionOptions):
     def _set_options(self, value_set, c_bool skip_nulls):
         cdef unique_ptr[CDatum] valset
         if isinstance(value_set, Array):
-            valset.reset(new CDatum((< Array > value_set).sp_array))
+            valset.reset(new CDatum((<Array> value_set).sp_array))
         elif isinstance(value_set, ChunkedArray):
             valset.reset(
-                new CDatum((< ChunkedArray > value_set).sp_chunked_array)
+                new CDatum((<ChunkedArray> value_set).sp_chunked_array)
             )
         elif isinstance(value_set, Scalar):
-            valset.reset(new CDatum((< Scalar > value_set).unwrap()))
+            valset.reset(new CDatum((<Scalar> value_set).unwrap()))
         else:
             _raise_invalid_function_option(value_set, "value set",
                                            exception_class=TypeError)

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1968,7 +1968,6 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
 
     cdef cppclass CRoundToMultipleOptions \
             "arrow::compute::RoundToMultipleOptions"(CFunctionOptions):
-        CRoundToMultipleOptions(double multiple, CRoundMode round_mode)
         CRoundToMultipleOptions(shared_ptr[CScalar] multiple, CRoundMode round_mode)
         shared_ptr[CScalar] multiple
         CRoundMode round_mode

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1969,7 +1969,8 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
     cdef cppclass CRoundToMultipleOptions \
             "arrow::compute::RoundToMultipleOptions"(CFunctionOptions):
         CRoundToMultipleOptions(double multiple, CRoundMode round_mode)
-        double multiple
+        CRoundToMultipleOptions(shared_ptr[CScalar] multiple, CRoundMode round_mode)
+        shared_ptr[CScalar] multiple
         CRoundMode round_mode
 
     cdef enum CJoinNullHandlingBehavior \

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1568,9 +1568,9 @@ def test_round_to_multiple():
         assert pc.round_to_multiple(values, multiple,
                                     "half_towards_infinity") == result
 
-    for multiple in [-2, pa.scalar(-10.4)]:
+    for multiple in [0, -2, pa.scalar(-10.4)]:
         with pytest.raises(pa.ArrowInvalid,
-                           match="multiple must be nonnegative"):
+                           match="Rounding multiple must be positive"):
             pc.round_to_multiple(values, multiple=multiple)
 
 

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1556,9 +1556,9 @@ def test_round_to_multiple():
     multiple_and_expected = {
         2: [320, 4, 4, 4, -4, -36, -4, None],
         0.05: [320, 3.5, 3.1, 4.5, -3.2, -35.1, -3.05, None],
-        0.1: [320, 3.5, 3.1, 4.5, -3.2, -35.1, -3, None],
+        pa.scalar(0.1): [320, 3.5, 3.1, 4.5, -3.2, -35.1, -3, None],
         10: [320, 0, 0, 0, -0, -40, -0, None],
-        100: [300, 0, 0, 0, -0, -0, -0, None],
+        pa.scalar(100, type=pa.decimal256(10,4)): [300, 0, 0, 0, -0, -0, -0, None],
     }
     for multiple, expected in multiple_and_expected.items():
         options = pc.RoundToMultipleOptions(multiple, "half_towards_infinity")
@@ -1567,8 +1567,9 @@ def test_round_to_multiple():
         assert pc.round_to_multiple(values, multiple,
                                     "half_towards_infinity") == result
 
-    with pytest.raises(pa.ArrowInvalid, match="multiple must be positive"):
-        pc.round_to_multiple(values, multiple=-2)
+    for multiple in [-2, pa.scalar(-10.4)]:
+        with pytest.raises(pa.ArrowInvalid, match="multiple must be positive"):
+            pc.round_to_multiple(values, multiple=multiple)
 
 
 def test_is_null():

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1573,6 +1573,10 @@ def test_round_to_multiple():
                            match="Rounding multiple must be positive"):
             pc.round_to_multiple(values, multiple=multiple)
 
+    for multiple in [object, 99999999999999999999999]:
+        with pytest.raises(TypeError, match="is not a valid multiple type"):
+            pc.round_to_multiple(values, multiple=multiple)
+
 
 def test_is_null():
     arr = pa.array([1, 2, 3, None])

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1554,11 +1554,12 @@ def test_round():
 def test_round_to_multiple():
     values = [320, 3.5, 3.075, 4.5, -3.212, -35.1234, -3.045, None]
     multiple_and_expected = {
-        2: [320, 4, 4, 4, -4, -36, -4, None],
         0.05: [320, 3.5, 3.1, 4.5, -3.2, -35.1, -3.05, None],
         pa.scalar(0.1): [320, 3.5, 3.1, 4.5, -3.2, -35.1, -3, None],
+        2: [320, 4, 4, 4, -4, -36, -4, None],
         10: [320, 0, 0, 0, -0, -40, -0, None],
-        pa.scalar(100, type=pa.decimal256(10,4)): [300, 0, 0, 0, -0, -0, -0, None],
+        pa.scalar(100, type=pa.decimal256(10, 4)):
+            [300, 0, 0, 0, -0, -0, -0, None],
     }
     for multiple, expected in multiple_and_expected.items():
         options = pc.RoundToMultipleOptions(multiple, "half_towards_infinity")
@@ -1568,7 +1569,8 @@ def test_round_to_multiple():
                                     "half_towards_infinity") == result
 
     for multiple in [-2, pa.scalar(-10.4)]:
-        with pytest.raises(pa.ArrowInvalid, match="multiple must be positive"):
+        with pytest.raises(pa.ArrowInvalid,
+                           match="multiple must be nonnegative"):
             pc.round_to_multiple(values, multiple=multiple)
 
 


### PR DESCRIPTION
* Improves support for Scalar multiple member in RoundToMultipleOptions (C++ and Python)
* Automatic cast for Scalar multiple member
* Validates multiple is a positive value