### PR TITLE
ARROW-15658: [C++] Parquet pushdown filtering fails if the filter expression uses numeric field references

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "cpp/submodules/parquet-testing"]
 	path = cpp/submodules/parquet-testing
 	url = https://github.com/apache/parquet-testing.git
+[submodule "testing"]
+	path = testing
+	url = https://github.com/apache/arrow-testing

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "cpp/submodules/parquet-testing"]
 	path = cpp/submodules/parquet-testing
 	url = https://github.com/apache/parquet-testing.git
-[submodule "testing"]
-	path = testing
-	url = https://github.com/apache/arrow-testing

--- a/cpp/examples/arrow/dataset_parquet_scan_example.cc
+++ b/cpp/examples/arrow/dataset_parquet_scan_example.cc
@@ -42,11 +42,11 @@ namespace cp = arrow::compute;
 // \brief Run Example
 // ./dataset-parquet-scan-example file:///sell_data.parquet
 // sample data set
-//           pickup_at dropoff_at  total_amount
-//         0         A          B            10
-//         1         B          A          1200
-//         2         C          A          2400
-//         3         A          C           500
+//   pickup_at dropoff_at  total_amount
+// 0         A          B            10
+// 1         B          A          1200
+// 2         C          A          2400
+// 3         A          C           500
 
 #define ABORT_ON_FAILURE(expr)                     \
   do {                                             \

--- a/cpp/examples/arrow/dataset_parquet_scan_example.cc
+++ b/cpp/examples/arrow/dataset_parquet_scan_example.cc
@@ -39,6 +39,17 @@ namespace ds = arrow::dataset;
 
 namespace cp = arrow::compute;
 
+/**
+ * @brief Run Example
+ * .dataset-parquet-scan-example file:///sell_data.parquet
+ * sample data in csv format
+ *           pickup_at dropoff_at  total_amount
+ *         0         A          B            10
+ *         1         B          A          1200
+ *         2         C          A          2400
+ *         3         A          C           500
+ */
+
 #define ABORT_ON_FAILURE(expr)                     \
   do {                                             \
     arrow::Status status_ = (expr);                \
@@ -62,8 +73,7 @@ struct Configuration {
 
   // Indicates the filter by which rows will be filtered. This optimization can
   // make use of partition information and/or file metadata if possible.
-  cp::Expression filter =
-      cp::greater(cp::field_ref("total_amount"), cp::literal(1000.0f));
+  cp::Expression filter = cp::greater(cp::field_ref(2), cp::literal(1000.0f));
 
   ds::InspectOptions inspect_options{};
   ds::FinishOptions finish_options{};
@@ -185,6 +195,10 @@ int main(int argc, char** argv) {
 
   auto table = GetTableFromScanner(scanner);
   std::cout << "Table size: " << table->num_rows() << "\n";
+
+  std::cout << "Data : " << std::endl;
+
+  std::cout << table->ToString() << std::endl;
 
   return EXIT_SUCCESS;
 }

--- a/cpp/examples/arrow/dataset_parquet_scan_example.cc
+++ b/cpp/examples/arrow/dataset_parquet_scan_example.cc
@@ -41,8 +41,8 @@ namespace cp = arrow::compute;
 
 /**
  * @brief Run Example
- * .dataset-parquet-scan-example file:///sell_data.parquet
- * sample data in csv format
+ * ./dataset-parquet-scan-example file:///sell_data.parquet
+ * sample data set
  *           pickup_at dropoff_at  total_amount
  *         0         A          B            10
  *         1         B          A          1200
@@ -73,6 +73,10 @@ struct Configuration {
 
   // Indicates the filter by which rows will be filtered. This optimization can
   // make use of partition information and/or file metadata if possible.
+  // Equivalent filter with field_name instead of field_index
+  // cp::Expression filter = cp::greater(cp::field_ref("total_amount"),
+  // cp::literal(1000.0f));
+  // 0: pickup_at, 1: dropoff_at, 2: total_amount
   cp::Expression filter = cp::greater(cp::field_ref(2), cp::literal(1000.0f));
 
   ds::InspectOptions inspect_options{};

--- a/cpp/examples/arrow/dataset_parquet_scan_example.cc
+++ b/cpp/examples/arrow/dataset_parquet_scan_example.cc
@@ -39,16 +39,14 @@ namespace ds = arrow::dataset;
 
 namespace cp = arrow::compute;
 
-/**
- * @brief Run Example
- * ./dataset-parquet-scan-example file:///sell_data.parquet
- * sample data set
- *           pickup_at dropoff_at  total_amount
- *         0         A          B            10
- *         1         B          A          1200
- *         2         C          A          2400
- *         3         A          C           500
- */
+// @brief Run Example
+// ./dataset-parquet-scan-example file:///sell_data.parquet
+// sample data set
+//           pickup_at dropoff_at  total_amount
+//         0         A          B            10
+//         1         B          A          1200
+//         2         C          A          2400
+//         3         A          C           500
 
 #define ABORT_ON_FAILURE(expr)                     \
   do {                                             \
@@ -74,11 +72,10 @@ struct Configuration {
   // Indicates the filter by which rows will be filtered. This optimization can
   // make use of partition information and/or file metadata if possible.
   // Equivalent filter with field_name instead of field_index
-  // cp::Expression filter = cp::greater(cp::field_ref("total_amount"),
-  // cp::literal(1000.0f));
   // 0: pickup_at, 1: dropoff_at, 2: total_amount
-  cp::Expression filter = cp::greater(cp::field_ref(2), cp::literal(1000.0f));
-
+  cp::Expression filter1 = cp::greater(cp::field_ref(2), cp::literal(1000));
+  cp::Expression filter2 = cp::less(cp::field_ref("total_amount"), cp::literal(2000));
+  cp::Expression filter = cp::and_(filter1, filter2);
   ds::InspectOptions inspect_options{};
   ds::FinishOptions finish_options{};
 } conf;

--- a/cpp/examples/arrow/dataset_parquet_scan_example.cc
+++ b/cpp/examples/arrow/dataset_parquet_scan_example.cc
@@ -39,7 +39,7 @@ namespace ds = arrow::dataset;
 
 namespace cp = arrow::compute;
 
-// @brief Run Example
+// \brief Run Example
 // ./dataset-parquet-scan-example file:///sell_data.parquet
 // sample data set
 //           pickup_at dropoff_at  total_amount
@@ -69,9 +69,9 @@ struct Configuration {
   std::vector<std::string> projected_columns = {"pickup_at", "dropoff_at",
                                                 "total_amount"};
 
-  // Indicates the filter by which rows will be filtered. This optimization can
+  // Indicates the expression by which rows will be filtered. This optimization can
   // make use of partition information and/or file metadata if possible.
-  // Equivalent filter with field_name instead of field_index
+  // fields can be referenced by name or by index.  This example assumes the schema:
   // 0: pickup_at, 1: dropoff_at, 2: total_amount
   cp::Expression filter1 = cp::greater(cp::field_ref(2), cp::literal(1000));
   cp::Expression filter2 = cp::less(cp::field_ref("total_amount"), cp::literal(2000));
@@ -197,7 +197,7 @@ int main(int argc, char** argv) {
   auto table = GetTableFromScanner(scanner);
   std::cout << "Table size: " << table->num_rows() << "\n";
 
-  std::cout << "Data : " << std::endl;
+  std::cout << "Data: " << std::endl;
 
   std::cout << table->ToString() << std::endl;
 

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -156,7 +156,7 @@ void AddColumnIndices(const SchemaField& schema_field,
 }
 
 Status ResolveOneFieldRef(
-    const SchemaManifest& manifest, const std::shared_ptr<Schema> dataset_schema,
+    const SchemaManifest& manifest, const std::shared_ptr<Schema>& dataset_schema,
     const FieldRef& field_ref,
     const std::unordered_map<std::string, const SchemaField*>& field_lookup,
     const std::unordered_set<std::string>& duplicate_fields,
@@ -255,8 +255,6 @@ Result<std::vector<int>> InferColumnProjection(const parquet::arrow::FileReader&
   // Checks if the field is needed in either the projection or the filter.
   auto field_refs = options.MaterializedFields();
 
-  auto dataset_schema = options.dataset_schema;
-
   // Build a lookup table from top level field name to field metadata.
   // This is to avoid quadratic-time mapping of projected fields to
   // column indices, in the common case of selecting top level
@@ -275,7 +273,7 @@ Result<std::vector<int>> InferColumnProjection(const parquet::arrow::FileReader&
 
   std::vector<int> columns_selection;
   for (const auto& ref : field_refs) {
-    RETURN_NOT_OK(ResolveOneFieldRef(manifest, dataset_schema, ref, field_lookup,
+    RETURN_NOT_OK(ResolveOneFieldRef(manifest, options.dataset_schema, ref, field_lookup,
                                      duplicate_fields, &columns_selection));
   }
   return columns_selection;

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -176,8 +176,7 @@ Status ResolveOneFieldRef(
   };
 
   if (const std::string* name = field_ref.name()) {
-    RETURN_NOT_OK(resolve_field_ref(name));
-    return Status::OK();
+    return resolve_field_ref(name);
   } else if (const FieldPath* path = field_ref.field_path()) {
     auto indices = path->indices();
     if (indices.size() > 1) {
@@ -185,7 +184,7 @@ Status ResolveOneFieldRef(
                                     ", Nested FieldPaths are not supported!");
     }
     int index = indices[0];
-    auto schema_field = manifest.schema_fields.at(index);
+    auto schema_field = manifest.schema_fields[index];
     auto col_name = schema_field.field->name();
     RETURN_NOT_OK(resolve_field_ref(&col_name));
     return Status::OK();

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -179,7 +179,12 @@ Status ResolveOneFieldRef(
     RETURN_NOT_OK(resolve_field_ref(name));
     return Status::OK();
   } else if (const FieldPath* path = field_ref.field_path()) {
-    int index = path->indices()[0];
+    auto indices = path->indices();
+    if (indices.size() > 1) {
+      return Status::NotImplemented("Provided FieldRef ", field_ref.ToString(),
+                                    ", Nested FieldPaths are not supported!");
+    }
+    int index = indices[0];
     auto schema_field = manifest.schema_fields.at(index);
     auto col_name = schema_field.field->name();
     RETURN_NOT_OK(resolve_field_ref(&col_name));

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -170,13 +170,13 @@ Status ResolveOneFieldRef(
       return Status::Invalid("Ambiguous reference to column '", *name,
                              "' which occurs more than once");
     }
+    // "Virtual" column: field is not in file but is in the ScanOptions.
+    // Ignore it here, as projection will pad the batch with a null column.
     return Status::OK();
   };
 
   if (const std::string* name = field_ref.name()) {
     RETURN_NOT_OK(resolve_field_ref(name));
-    // "Virtual" column: field is not in file but is in the ScanOptions.
-    // Ignore it here, as projection will pad the batch with a null column.
     return Status::OK();
   } else if (const FieldPath* path = field_ref.field_path()) {
     int index = path->indices()[0];

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -394,7 +394,7 @@ TEST_P(TestParquetFileFormatScan, ScanRecordBatchReaderWithFieldPathFilter) {
   TestScanWithFieldPathFilter();
 }
 TEST_P(TestParquetFileFormatScan, ScanRecordBatchReaderWithFieldPathMultiFileFilter) {
-  compute::Expression filter = greater(field_ref(0), literal(20));
+  compute::Expression filter = greater(field_ref("x"), literal(20));
   auto fields = {field("x", int32()), field("y", int32()), field("z", int32())};
   auto dataset_schema = schema(fields);
   SetSchema(fields);
@@ -402,8 +402,8 @@ TEST_P(TestParquetFileFormatScan, ScanRecordBatchReaderWithFieldPathMultiFileFil
   auto table = TableFromJSON(dataset_schema,
                              {
                                  R"([[10, 20, 30]])",
+                                 R"([[30, 40, 50]])",
                              });
-
   auto options =
       checked_pointer_cast<ParquetFileWriteOptions>(format_->DefaultWriteOptions());
   options->writer_properties = parquet::WriterProperties::Builder()
@@ -411,10 +411,10 @@ TEST_P(TestParquetFileFormatScan, ScanRecordBatchReaderWithFieldPathMultiFileFil
   options->arrow_writer_properties = parquet::ArrowWriterProperties::Builder()
                                          .build();
 
-  auto written = WriteToBufferFromTable(dataset_schema, table, options);
+  auto written = WriteTableToBuffer(table, options);
 
   EXPECT_OK_AND_ASSIGN(auto fragment, format_->MakeFragment(FileSource{written}));
-
+  
   for (auto maybe_batch : PhysicalBatches(fragment)) {
     ASSERT_OK_AND_ASSIGN(auto batch, maybe_batch);
     std::cout << "Batch ::" << std::endl;

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -390,6 +390,9 @@ TEST_P(TestParquetFileFormatScan, ScanRecordBatchReaderWithVirtualColumn) {
 TEST_P(TestParquetFileFormatScan, ScanRecordBatchReaderWithDuplicateColumn) {
   TestScanWithDuplicateColumn();
 }
+TEST_P(TestParquetFileFormatScan, ScanRecordBatchReaderWithFieldPathFilter) {
+  TestScanWithFieldPathFilter();
+}
 TEST_P(TestParquetFileFormatScan, ScanRecordBatchReaderWithDuplicateColumnError) {
   TestScanWithDuplicateColumnError();
 }

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -393,6 +393,7 @@ TEST_P(TestParquetFileFormatScan, ScanRecordBatchReaderWithDuplicateColumn) {
 TEST_P(TestParquetFileFormatScan, ScanRecordBatchReaderWithFieldPathFilter) {
   TestScanWithFieldPathFilter();
 }
+
 TEST_P(TestParquetFileFormatScan, ScanRecordBatchReaderWithDuplicateColumnError) {
   TestScanWithDuplicateColumnError();
 }

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -393,7 +393,6 @@ TEST_P(TestParquetFileFormatScan, ScanRecordBatchReaderWithDuplicateColumn) {
 TEST_P(TestParquetFileFormatScan, ScanRecordBatchReaderWithFieldPathFilter) {
   TestScanWithFieldPathFilter();
 }
-
 TEST_P(TestParquetFileFormatScan, ScanRecordBatchReaderWithDuplicateColumnError) {
   TestScanWithDuplicateColumnError();
 }

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -513,11 +513,11 @@ class FileFormatFixtureMixin : public ::testing::Test {
     EXPECT_OK_AND_ASSIGN(auto written, sink->Finish());
     return written;
   }
-  std::shared_ptr<Buffer> WriteToBufferFromTable(
-      std::shared_ptr<Schema> schema,
+  std::shared_ptr<Buffer> WriteTableToBuffer(
       std::shared_ptr<Table> table,
       std::shared_ptr<FileWriteOptions> options = nullptr) {
     auto format = format_;
+    auto schema = table->schema();
     SetSchema(schema->fields());
     EXPECT_OK_AND_ASSIGN(auto sink, GetFileSink());
     if (!options) options = format->DefaultWriteOptions();
@@ -874,7 +874,6 @@ class FileFormatScanMixin : public FileFormatFixtureMixin<FormatHelper>,
       ASSERT_EQ(row_count, expected_rows());
       row_counts.push_back(row_count);
     }
-
     ASSERT_EQ(row_counts.at(0), row_counts.at(1));
   }
 

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -834,7 +834,6 @@ class FileFormatScanMixin : public FileFormatFixtureMixin<FormatHelper>,
       this->opts_->dataset_schema = schema({i32, i64});
       this->Project({});
       this->SetFilter(filter);
-      auto expected_schema = schema({i32, i64});
       auto reader = this->GetRecordBatchReader(opts_->dataset_schema);
       auto source = this->GetFileSource(reader.get());
       auto fragment = this->MakeFragment(*source);


### PR DESCRIPTION
This PR contains an initial step towards a fix for ARROW-15658

- [x] Added a fix to enable numeric field references
- [x] Adopted a test case from the [JIRA description](https://issues.apache.org/jira/browse/ARROW-15658) by @westonpace