### PR TITLE
MINOR: [R] [CI] Disable the DuckDB dev tests that are failing

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -148,6 +148,8 @@ groups:
     - example-*
     - wheel-*
     - python-sdist
+    # ARROW-15970 and duckdb/duckdb#3258
+    - ~test-r-dev-duckdb
 
 tasks:
   # arbitrary_task_name:


### PR DESCRIPTION
This is being tracked at https://github.com/duckdb/duckdb/issues/3258 and we have a follow up to re-enable: https://issues.apache.org/jira/browse/ARROW-15970 