### PR TITLE
ARROW-15973: [CI] Split nightly reports into three: Tests, Packaging, Release

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -151,6 +151,31 @@ groups:
     # ARROW-15970 and duckdb/duckdb#3258
     - ~test-r-dev-duckdb
 
+  nightly-tests:
+    - test-*
+    # ARROW-15970 and duckdb/duckdb#3258
+    - ~test-r-dev-duckdb
+    - example-*
+
+  nightly-packaging:
+    - almalinux-*
+    - amazon-linux-*
+    - debian-*
+    - ubuntu-*
+    - centos-*
+    - conda-*
+    - java-jars
+    # List the homebrews explicitly because we don't care about running homebrew-cpp-autobrew
+    - homebrew-cpp
+    - homebrew-r-autobrew
+    - homebrew-r-brew
+    - nuget
+    - wheel-*
+    - python-sdist  
+
+  nightly-release:
+    - verify-rc-source-*
+
 tasks:
   # arbitrary_task_name:
   #   template: path of jinja2 templated yml


### PR DESCRIPTION
This will need changes in https://github.com/ursacomputing/crossbow/pull/9 to actually send separate reports, but the arrow changes are necessary to be merged first (so the task groups exist). 