### PR TITLE
ARROW-15982: [Python] parquet.read_table fails to parse home directory path

### DIFF
--- a/python/pyarrow/filesystem.py
+++ b/python/pyarrow/filesystem.py
@@ -473,7 +473,7 @@ def resolve_filesystem_and_path(where, filesystem=None):
     if filesystem is not None:
         filesystem = _ensure_filesystem(filesystem)
         if isinstance(filesystem, LocalFileSystem):
-            path = os.path.expanduser(_stringify_path(where))
+            path = _stringify_path(where)
         elif not isinstance(where, str):
             raise TypeError(
                 "Expected string path; path-like objects are only allowed "
@@ -502,10 +502,10 @@ def resolve_filesystem_and_path(where, filesystem=None):
     elif parsed_uri.scheme == 'file':
         # Input is local URI such as file:///home/user/myfile.parquet
         fs = LocalFileSystem._get_instance()
-        fs_path = os.path.expanduser(parsed_uri.path)
+        fs_path = parsed_uri.path
     else:
         # Input is local path such as /home/user/myfile.parquet
         fs = LocalFileSystem._get_instance()
-        fs_path = os.path.expanduser(path)
+        fs_path = path
 
     return fs, fs_path

--- a/python/pyarrow/filesystem.py
+++ b/python/pyarrow/filesystem.py
@@ -473,7 +473,7 @@ def resolve_filesystem_and_path(where, filesystem=None):
     if filesystem is not None:
         filesystem = _ensure_filesystem(filesystem)
         if isinstance(filesystem, LocalFileSystem):
-            path = _stringify_path(where)
+            path = os.path.expanduser(_stringify_path(where))
         elif not isinstance(where, str):
             raise TypeError(
                 "Expected string path; path-like objects are only allowed "
@@ -502,10 +502,10 @@ def resolve_filesystem_and_path(where, filesystem=None):
     elif parsed_uri.scheme == 'file':
         # Input is local URI such as file:///home/user/myfile.parquet
         fs = LocalFileSystem._get_instance()
-        fs_path = parsed_uri.path
+        fs_path = os.path.expanduser(parsed_uri.path)
     else:
         # Input is local path such as /home/user/myfile.parquet
         fs = LocalFileSystem._get_instance()
-        fs_path = path
+        fs_path = os.path.expanduser(path)
 
     return fs, fs_path

--- a/python/pyarrow/tests/test_filesystem.py
+++ b/python/pyarrow/tests/test_filesystem.py
@@ -18,6 +18,7 @@
 import pyarrow as pa
 from pyarrow import filesystem
 
+import os
 import pytest
 
 
@@ -60,3 +61,14 @@ def test_resolve_local_path():
         fs, path = filesystem.resolve_filesystem_and_path(uri)
         assert isinstance(fs, filesystem.LocalFileSystem)
         assert path == uri
+
+
+def test_resolve_home_directory():
+    uri = '~/myfile.parquet'
+    fs, path = filesystem.resolve_filesystem_and_path(uri)
+    assert isinstance(fs, filesystem.LocalFileSystem)
+    assert path == os.path.expanduser(uri)
+
+    local_fs = filesystem.LocalFileSystem()
+    fs, path = filesystem.resolve_filesystem_and_path(uri, local_fs)
+    assert path == os.path.expanduser(uri)

--- a/python/pyarrow/util.py
+++ b/python/pyarrow/util.py
@@ -17,6 +17,7 @@
 
 # Miscellaneous utility code
 
+import os
 import contextlib
 import functools
 import gc
@@ -81,11 +82,11 @@ def _stringify_path(path):
     Convert *path* to a string or unicode path if possible.
     """
     if isinstance(path, str):
-        return path
+        return os.path.expanduser(path)
 
     # checking whether path implements the filesystem protocol
     try:
-        return path.__fspath__()
+        return os.path.expanduser(path.__fspath__())
     except AttributeError:
         pass
 


### PR DESCRIPTION
This PR adds support for the home directory in paths. This fixes a problem where `pyarrow.parquet.read_table` fails to find files relative to the home directory. 

I added `os.path.expanduser` to the `_stringify_path` function to have the widest effect with minimal changes. Happy to adjust that if there is a better place.

