### PR TITLE
ARROW-15544: [Go][Parquet] Fix origin schema base64 decoding

### DIFF
--- a/go/parquet/pqarrow/file_writer.go
+++ b/go/parquet/pqarrow/file_writer.go
@@ -78,7 +78,7 @@ func NewFileWriter(arrschema *arrow.Schema, w io.Writer, props *parquet.WriterPr
 		}
 
 		serializedSchema := flight.SerializeSchema(arrschema, props.Allocator())
-		meta.Append("ARROW:schema", base64.RawStdEncoding.EncodeToString(serializedSchema))
+		meta.Append("ARROW:schema", base64.StdEncoding.EncodeToString(serializedSchema))
 	}
 
 	schemaNode := pqschema.Root()

--- a/go/parquet/pqarrow/schema.go
+++ b/go/parquet/pqarrow/schema.go
@@ -871,7 +871,22 @@ func getOriginSchema(meta metadata.KeyValueMetadata, mem memory.Allocator) (*arr
 		return nil, nil
 	}
 
-	decoded, err := base64.RawStdEncoding.DecodeString(*serialized)
+	var (
+		decoded []byte
+		err     error
+	)
+
+	// if the length of serialized is not a multiple of 4, it cannot be
+	// padded with std encoding.
+	if len(*serialized)%4 == 0 {
+		decoded, err = base64.StdEncoding.DecodeString(*serialized)
+	}
+	// if we failed to decode it with stdencoding or the length wasn't
+	// a multiple of 4, try using the Raw unpadded encoding
+	if len(decoded) == 0 || err != nil {
+		decoded, err = base64.RawStdEncoding.DecodeString(*serialized)
+	}
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The C++ implementation appears to use the Padded base64 encoding, so let's default the writer to using `StdEncoding` and make sure we can decode both `RawStdEncoding` and `StdEncoding`.