### PR TITLE
ARROW-13564: [Dev] Check individual commit messages for "Co-authored-by:" tags when integrating a pull request

### DIFF
--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -377,7 +377,10 @@ class PullRequest(object):
 
         commit_authors = run_cmd(['git', 'log', 'HEAD..%s' % pr_branch_name,
                                  '--pretty=format:%an <%ae>']).split("\n")
-        distinct_authors = sorted(set(commit_authors),
+        commit_co_authors = run_cmd(['git', 'log', 'HEAD..%s' % pr_branch_name,
+                                 '%(trailers:key=Co-authored-by,valueonly)']).split("\n")
+        all_commit_authors = commit_authors + commit_co_authors
+        distinct_authors = sorted(set(all_commit_authors),
                                   key=lambda x: commit_authors.count(x),
                                   reverse=True)
 

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -378,7 +378,8 @@ class PullRequest(object):
         commit_authors = run_cmd(['git', 'log', 'HEAD..%s' % pr_branch_name,
                                  '--pretty=format:%an <%ae>']).split("\n")
         commit_co_authors = run_cmd(['git', 'log', 'HEAD..%s' % pr_branch_name,
-                                 '%(trailers:key=Co-authored-by,valueonly)']).split("\n")
+                                    '%(trailers:key=Co-authored-by,valueonly)']
+                                    ).split("\n")
         all_commit_authors = commit_authors + commit_co_authors
         distinct_authors = sorted(set(all_commit_authors),
                                   key=lambda x: commit_authors.count(x),


### PR DESCRIPTION
## Overview
The goal of this pull request is to add functionality to dev/merge_arrow_pr.py, that checks individual commit messages for "Co-authored-by:" tags when creating the squashed commit message when merging a pull request.

This will ensure that all authors are included in the final commit message to make sure they are acknowledged for their contributions.

## Implementation
Use the [`trailers`](https://git-scm.com/docs/git-log#Documentation/git-log.txt-emtrailersoptionsem) options of `git log` to check for the "Co-authored-by" trailer. The equivalent `git` command is:
`git log HEAD..<pull-request-branch> --pretty="%(trailers:key=Co-authored-by,valueonly)"`

For each commit in <pull-request-branch>, this command prints the value of any `Co-authored-by` trailers, which should be in the form of `<name> <<email-address>>`.

## Testing
I attempted to qualify the changes to `merge_arrow_pr.py` by taking the the following steps:
1. Created a branch for this change, [ARROW-13564](https://github.com/mathworks/arrow/tree/ARROW-13564) and corresponding [pull request](https://github.com/apache/arrow/pull/12682).
3. Set the DEBUGGING environment variable to `1`.
4. Following the steps within `merge_arrow_pr.py`, I run the merge script and receive an error that (I believe) is indicating I do not have necessary repository permissions to continue with the merge request:


```
Proceed with merging pull request #12682? (y/n): y
fatal: 'apache' does not appear to be a git repository
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
Command failed: ['git', 'fetch', 'apache', 'pull/12682/head:PR_TOOL_MERGE_PR_12682']
```
I am not able to reach the step where the new commit message is created. Do you have any advice for qualifying this change?

## Notes
Thank you @kevingurney for your help with this pull request!