### PR TITLE
ARROW-15987: [C++][FlightRPC] Work around arrow-flight-test crash on AppVeyor

### DIFF
--- a/ci/conda_env_cpp.txt
+++ b/ci/conda_env_cpp.txt
@@ -27,7 +27,8 @@ gflags
 glog
 gmock>=1.10.0
 google-cloud-cpp>=1.34.0
-grpc-cpp>=1.27.3
+# 1.45.0 appears to segfault on Windows/AppVeyor
+grpc-cpp>=1.27.3,<1.45.0
 gtest>=1.10.0
 libprotobuf
 libutf8proc


### PR DESCRIPTION
Unable to root cause. Poking around with a debugger, MSVC appears to generate wild code that calls into seemingly random functions, causing a crash. Holding back grpc-cpp does avoid the crash, so it seems to be something about the new gRPC version.