### PR TITLE
ARROW-15993: [CI] Add sphinx-tabs to ci/conda_env_sphinx.txt

### DIFF
--- a/ci/conda_env_sphinx.txt
+++ b/ci/conda_env_sphinx.txt
@@ -22,7 +22,4 @@ ipython
 numpydoc
 pydata-sphinx-theme
 sphinx>=4.2
-
-# Unable to install sphinx-tabs from conda-forge due to:
-# - package sphinx-tabs-1.2.1-py_0 requires sphinx >=2,<4, but none of the providers can be installed
-# sphinx-tabs
+sphinx-tabs

--- a/ci/docker/conda-python.dockerfile
+++ b/ci/docker/conda-python.dockerfile
@@ -32,10 +32,6 @@ RUN mamba install -q \
         nomkl && \
     mamba clean --all
 
-# unable to install from conda-forge due to sphinx version pin, see comment in
-# arrow/ci/conda_env_sphinx.txt
-RUN pip install sphinx-tabs
-
 ENV ARROW_PYTHON=ON \
     ARROW_BUILD_STATIC=OFF \
     ARROW_BUILD_TESTS=OFF \


### PR DESCRIPTION
sphinx-tabs 3.2.0 is compatible with our other dependencies now. Hence we should add it back to ci/conda_env_sphinx.txt so that the developer guide on building docs match reality.