### PR TITLE
ARROW-13564: [Dev] Check individual commit messages for "Co-authored-by:" tags when integrating a pull request

### DIFF
--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -377,7 +377,10 @@ class PullRequest(object):
 
         commit_authors = run_cmd(['git', 'log', 'HEAD..%s' % pr_branch_name,
                                  '--pretty=format:%an <%ae>']).split("\n")
-        distinct_authors = sorted(set(commit_authors),
+        commit_co_authors = run_cmd(['git', 'log', 'HEAD..%s' % pr_branch_name,
+                                 '%(trailers:key=Co-authored-by,valueonly)']).split("\n")
+        all_commit_authors = commit_authors + commit_co_authors
+        distinct_authors = sorted(set(all_commit_authors),
                                   key=lambda x: commit_authors.count(x),
                                   reverse=True)
 

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -19,19 +19,25 @@
 
 # Utility for creating well-formed pull request merges and pushing them to
 # Apache.
-#   usage: ./merge_arrow_pr.py    (see config env vars below)
+#   usage: ./merge_arrow_pr.py  <pr-number>  (see config env vars below)
 #
-# This utility assumes you already have a local Arrow git clone and that you
-# have added remotes corresponding to both (i) the GitHub Apache Arrow mirror
-# and (ii) the apache git repo.
+# This utility assumes:
+#   - you already have a local Arrow git clone
+#   - you have added remotes corresponding to both:
+#       (i) the GitHub Apache Arrow mirror
+#       (ii) the Apache git repo
 #
 # There are several pieces of authorization possibly needed via environment
-# variables
+# variables.
 #
-# APACHE_JIRA_USERNAME: your Apache JIRA id
-# APACHE_JIRA_PASSWORD: your Apache JIRA password
-# ARROW_GITHUB_API_TOKEN: a GitHub API token to use for API requests (to avoid
-# rate limiting)
+# Configuration environment variables:
+#   - APACHE_JIRA_USERNAME: your Apache JIRA ID
+#   - APACHE_JIRA_PASSWORD: your Apache JIRA password
+#   - ARROW_GITHUB_API_TOKEN: a GitHub API token to use for API requests (to
+#                             avoid rate limiting)
+#   - PR_REMOTE_NAME: the name of the remote to the Apache git repo (set to
+#                     'apache' by default)
+#   - DEBUG: use for testing to avoid pushing to apache (0 by default)
 
 import configparser
 import os

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -378,7 +378,8 @@ class PullRequest(object):
         commit_authors = run_cmd(['git', 'log', 'HEAD..%s' % pr_branch_name,
                                  '--pretty=format:%an <%ae>']).split("\n")
         commit_co_authors = run_cmd(['git', 'log', 'HEAD..%s' % pr_branch_name,
-                                 '%(trailers:key=Co-authored-by,valueonly)']).split("\n")
+                                    '%(trailers:key=Co-authored-by,valueonly)']
+                                    ).split("\n")
         all_commit_authors = commit_authors + commit_co_authors
         distinct_authors = sorted(set(all_commit_authors),
                                   key=lambda x: commit_authors.count(x),

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -380,6 +380,7 @@ class PullRequest(object):
         commit_co_authors = run_cmd(['git', 'log', 'HEAD..%s' % pr_branch_name,
                                     '--pretty=%(trailers:key=Co-authored-by,'
                                      'valueonly)']).split("\n")
+        commit_co_authors = list(filter(None, commit_co_authors))
         all_commit_authors = commit_authors + commit_co_authors
         distinct_authors = sorted(set(all_commit_authors),
                                   key=lambda x: commit_authors.count(x),

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -378,8 +378,8 @@ class PullRequest(object):
         commit_authors = run_cmd(['git', 'log', 'HEAD..%s' % pr_branch_name,
                                  '--pretty=format:%an <%ae>']).split("\n")
         commit_co_authors = run_cmd(['git', 'log', 'HEAD..%s' % pr_branch_name,
-                                    '%(trailers:key=Co-authored-by,valueonly)']
-                                    ).split("\n")
+                                    '--pretty=%(trailers:key=Co-authored-by,'
+                                     'valueonly)']).split("\n")
         all_commit_authors = commit_authors + commit_co_authors
         distinct_authors = sorted(set(all_commit_authors),
                                   key=lambda x: commit_authors.count(x),


### PR DESCRIPTION
## Overview
The goal of this pull request is to add functionality to `dev/merge_arrow_pr.py`, that checks individual commit messages for `Co-authored-by:` tags, when creating the squashed commit message when merging a pull request.

This will ensure that all authors are included in the final commit message, to make sure they are acknowledged for their contributions.

## Implementation
1. Use the [`trailers`](https://git-scm.com/docs/git-log#Documentation/git-log.txt-emtrailersoptionsem) options of `git log` to check for the [`Co-authored-by` trailer](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors). The equivalent `git` command is:
`git log HEAD..<pull-request-branch> --pretty="%(trailers:key=Co-authored-by,valueonly)"`
2. For each commit in `<pull-request-branch>`, this command prints the value of any `Co-authored-by` trailers, which should be in the form of `<name> <<email-address>>`.
3. The values returned by this command are appended to the list of all commit authors.
4. Added a comment to set `PR_REMOTE_NAME` if the user has not set a remote named `apache` to `git@github.com:apache/arrow.git`.

## Testing
I qualified the changes to `merge_arrow_pr.py` by taking the the following steps:
1. Created a branch for this change, [ARROW-13564](https://github.com/mathworks/arrow/tree/ARROW-13564) and corresponding [pull request](https://github.com/apache/arrow/pull/12693).
2. Add a [commit](https://github.com/apache/arrow/pull/12693/commits/defab97167af14295465e052cabf65bc39deec59) that has multiple Co-authors.
3. Set the following environment variables:
    - `DEBUG 1`
    - `PR_REMOTE_NAME upstream` (my remote to `git@github.com:apache/arrow.git` is named `upstream`) 
5. Run the merge script, `merge_arrow_pr.py`, following the usage text.
6. The output from the merge script:

```
-m
Closes #12693 from lafiona/ARROW-13564
-m
Lead-authored-by: Fiona La <fionala@mathworks.com>
Co-authored-by: Fiona La <fionala7@gmail.com>
Co-authored-by: Kevin Gurney <kgurney@mathworks.com>
Signed-off-by: Fiona La <fionala@mathworks.com>

Merge complete (local ref PR_TOOL_MERGE_PR_12693_MASTER). Push to upstream? (y/n): n
```
## Notes
Thank you @kevingurney and @lidavidm for your help with this pull request!