### PR TITLE
ARROW-16012: [C++] Retry S3 request in tests when Minio not fully initialized

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -100,7 +100,8 @@ class ShortRetryStrategy : public S3RetryStrategy {
       // which would trigger spurious retries.
       return false;
     }
-    return error.should_retry && (attempted_retries * kRetryInterval < kMaxRetryDuration);
+    return (error.should_retry || error.exception_name == "XMinioServerNotInitialized") &&
+           (attempted_retries * kRetryInterval < kMaxRetryDuration);
   }
 
   int64_t CalculateDelayBeforeNextRetry(const AWSErrorDetail& error,


### PR DESCRIPTION
Avoid sporadic test failures with this kind of error message:
```
'fs_->CopyFile("bucket/somefile", "bucket/newfile")' failed with IOError: When copying key 'somefile' in bucket 'bucket' to key 'newfile' in bucket 'bucket': AWS Error [code 100]: Unable to parse ExceptionName: XMinioServerNotInitialized Message: Server not initialized, please try again.
```