### PR TITLE
ARROW-15892: [C++] Dataset APIs require s3:ListBucket Permissions

### DIFF
--- a/cpp/src/arrow/dataset/dataset_writer.cc
+++ b/cpp/src/arrow/dataset/dataset_writer.cc
@@ -459,9 +459,11 @@ class DatasetWriter::DatasetWriterImpl : public util::AsyncDestroyable {
     if (!directory.empty()) {
       auto full_path =
           fs::internal::ConcatAbstractPath(write_options_.base_dir, directory);
-      return DoWriteRecordBatch(std::move(batch), full_path, prefix, write_options_.create_dir);
+      return DoWriteRecordBatch(std::move(batch), full_path, prefix,
+                                write_options_.create_dir);
     } else {
-      return DoWriteRecordBatch(std::move(batch), write_options_.base_dir, prefix,  write_options_.create_dir);
+      return DoWriteRecordBatch(std::move(batch), write_options_.base_dir, prefix,
+                                write_options_.create_dir);
     }
   }
 
@@ -480,7 +482,8 @@ class DatasetWriter::DatasetWriterImpl : public util::AsyncDestroyable {
   }
 
   Future<> DoWriteRecordBatch(std::shared_ptr<RecordBatch> batch,
-                              const std::string& directory, const std::string& prefix, const bool& create_dir) {
+                              const std::string& directory, const std::string& prefix,
+                              const bool& create_dir) {
     ARROW_ASSIGN_OR_RAISE(
         auto dir_queue_itr,
         ::arrow::internal::GetOrInsertGenerated(
@@ -519,7 +522,7 @@ class DatasetWriter::DatasetWriterImpl : public util::AsyncDestroyable {
     }
 
     if (batch) {
-      return backpressure.Then([this, batch, directory, prefix] {
+      return backpressure.Then([this, batch, directory, prefix, create_dir] {
         return DoWriteRecordBatch(batch, directory, prefix, create_dir);
       });
     }

--- a/cpp/src/arrow/dataset/dataset_writer.cc
+++ b/cpp/src/arrow/dataset/dataset_writer.cc
@@ -328,7 +328,7 @@ class DatasetWriterDirectoryQueue : public util::AsyncDestroyable {
   uint64_t rows_written() const { return rows_written_; }
 
   void PrepareDirectory() {
-    if (directory_.empty()) {
+    if (directory_.empty() || !write_options_.create_dir) {
       init_future_ = Future<>::MakeFinished();
     } else {
       if (write_options_.existing_data_behavior ==
@@ -355,9 +355,7 @@ class DatasetWriterDirectoryQueue : public util::AsyncDestroyable {
         std::move(directory), std::move(prefix), std::move(schema), write_options,
         writer_state);
     RETURN_NOT_OK(task_group->AddTask(dir_queue->on_closed()));
-    if (write_options.create_dir) {
-      dir_queue->PrepareDirectory();
-    }
+    dir_queue->PrepareDirectory();
     ARROW_ASSIGN_OR_RAISE(dir_queue->current_filename_, dir_queue->GetNextFilename());
     // std::move required to make RTools 3.5 mingw compiler happy
     return std::move(dir_queue);

--- a/cpp/src/arrow/dataset/dataset_writer.cc
+++ b/cpp/src/arrow/dataset/dataset_writer.cc
@@ -457,11 +457,9 @@ class DatasetWriter::DatasetWriterImpl : public util::AsyncDestroyable {
     if (!directory.empty()) {
       auto full_path =
           fs::internal::ConcatAbstractPath(write_options_.base_dir, directory);
-      return DoWriteRecordBatch(std::move(batch), full_path, prefix,
-                                write_options_.create_dir);
+      return DoWriteRecordBatch(std::move(batch), full_path, prefix);
     } else {
-      return DoWriteRecordBatch(std::move(batch), write_options_.base_dir, prefix,
-                                write_options_.create_dir);
+      return DoWriteRecordBatch(std::move(batch), write_options_.base_dir, prefix);
     }
   }
 
@@ -480,8 +478,7 @@ class DatasetWriter::DatasetWriterImpl : public util::AsyncDestroyable {
   }
 
   Future<> DoWriteRecordBatch(std::shared_ptr<RecordBatch> batch,
-                              const std::string& directory, const std::string& prefix,
-                              const bool& create_dir) {
+                              const std::string& directory, const std::string& prefix) {
     ARROW_ASSIGN_OR_RAISE(
         auto dir_queue_itr,
         ::arrow::internal::GetOrInsertGenerated(
@@ -520,8 +517,8 @@ class DatasetWriter::DatasetWriterImpl : public util::AsyncDestroyable {
     }
 
     if (batch) {
-      return backpressure.Then([this, batch, directory, prefix, create_dir] {
-        return DoWriteRecordBatch(batch, directory, prefix, create_dir);
+      return backpressure.Then([this, batch, directory, prefix] {
+        return DoWriteRecordBatch(batch, directory, prefix);
       });
     }
     return Future<>::MakeFinished();

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -387,8 +387,8 @@ struct ARROW_DS_EXPORT FileSystemDatasetWriteOptions {
   /// Controls what happens if an output directory already exists.
   ExistingDataBehavior existing_data_behavior = ExistingDataBehavior::kError;
 
-  /// Whether to attempt creating the dataset directory.
-  /// This can be set to false to work around limited permissions on some filesystems.
+  /// \brief If false the dataset writer will not create directories
+  /// This is mainly intended for filesystems that do not require directories such as S3.
   bool create_dir = true;
 
   /// Callback to be invoked against all FileWriters before

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -387,6 +387,7 @@ struct ARROW_DS_EXPORT FileSystemDatasetWriteOptions {
   /// Controls what happens if an output directory already exists.
   ExistingDataBehavior existing_data_behavior = ExistingDataBehavior::kError;
 
+  /// Flag to restrict or allow creating directory for writing the dataset.
   bool create_dir = true;
 
   /// Callback to be invoked against all FileWriters before

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -387,6 +387,8 @@ struct ARROW_DS_EXPORT FileSystemDatasetWriteOptions {
   /// Controls what happens if an output directory already exists.
   ExistingDataBehavior existing_data_behavior = ExistingDataBehavior::kError;
 
+  bool create_dir = true;
+
   /// Callback to be invoked against all FileWriters before
   /// they are finalized with FileWriter::Finish().
   std::function<Status(FileWriter*)> writer_pre_finish = [](FileWriter*) {

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -387,7 +387,8 @@ struct ARROW_DS_EXPORT FileSystemDatasetWriteOptions {
   /// Controls what happens if an output directory already exists.
   ExistingDataBehavior existing_data_behavior = ExistingDataBehavior::kError;
 
-  /// Flag to restrict or allow creating directory for writing the dataset.
+  /// Whether to attempt creating the dataset directory.
+  /// This can be set to false to work around limited permissions on some filesystems.
   bool create_dir = true;
 
   /// Callback to be invoked against all FileWriters before

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -24,6 +24,7 @@ from cython.operator cimport dereference as deref
 import collections
 import os
 import warnings
+from libcpp cimport bool
 
 import pyarrow as pa
 from pyarrow.lib cimport *
@@ -2683,6 +2684,7 @@ def _filesystemdataset_write(
     int max_rows_per_file,
     int min_rows_per_group,
     int max_rows_per_group,
+    bool create_dir
 ):
     """
     CFileSystemDataset.Write wrapper
@@ -2715,6 +2717,7 @@ def _filesystemdataset_write(
             ("existing_data_behavior must be one of 'error', ",
              "'overwrite_or_ignore' or 'delete_matching'")
         )
+    c_options.create_dir = create_dir
 
     if file_visitor is not None:
         visit_args = {'base_dir': c_options.base_dir,

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -753,7 +753,7 @@ def write_dataset(data, base_dir, basename_template=None, format=None,
                   max_partitions=None, max_open_files=None,
                   max_rows_per_file=None, min_rows_per_group=None,
                   max_rows_per_group=None, file_visitor=None,
-                  existing_data_behavior='error'):
+                  existing_data_behavior='error', create_dir=True):
     """
     Write a dataset to a given format and partitioning.
 
@@ -928,5 +928,5 @@ Table/RecordBatch, or iterable of RecordBatch
         scanner, base_dir, basename_template, filesystem, partitioning,
         file_options, max_partitions, file_visitor, existing_data_behavior,
         max_open_files, max_rows_per_file,
-        min_rows_per_group, max_rows_per_group
+        min_rows_per_group, max_rows_per_group, create_dir
     )

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -852,6 +852,8 @@ Table/RecordBatch, or iterable of RecordBatch
         dataset.  The first time each partition directory is encountered
         the entire directory will be deleted.  This allows you to overwrite
         old partitions completely.
+    create_dir : bool, default True
+        Flag to restrict or allow creating directory while writing a dataset.
     """
     from pyarrow.fs import _resolve_filesystem_and_path
 

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -853,7 +853,8 @@ Table/RecordBatch, or iterable of RecordBatch
         the entire directory will be deleted.  This allows you to overwrite
         old partitions completely.
     create_dir : bool, default True
-        Flag to restrict or allow creating directory while writing a dataset.
+        If False, directories will not be created.  This can be useful for
+        filesystems that do not require directories.
     """
     from pyarrow.fs import _resolve_filesystem_and_path
 

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -18,7 +18,7 @@
 # distutils: language = c++
 
 from libcpp.unordered_map cimport unordered_map
-from libcpp cimport bool
+from libcpp cimport bool as c_bool
 
 from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport *
@@ -224,7 +224,7 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         function[cb_writer_finish_internal] writer_pre_finish
         function[cb_writer_finish_internal] writer_post_finish
         ExistingDataBehavior existing_data_behavior
-        bool create_dir
+        c_bool create_dir
         uint32_t max_open_files
         uint64_t max_rows_per_file
         uint64_t min_rows_per_group

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -18,6 +18,7 @@
 # distutils: language = c++
 
 from libcpp.unordered_map cimport unordered_map
+from libcpp cimport bool
 
 from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport *
@@ -223,6 +224,7 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         function[cb_writer_finish_internal] writer_pre_finish
         function[cb_writer_finish_internal] writer_post_finish
         ExistingDataBehavior existing_data_behavior
+        bool create_dir
         uint32_t max_open_files
         uint64_t max_rows_per_file
         uint64_t min_rows_per_group

--- a/python/pyarrow/tests/conftest.py
+++ b/python/pyarrow/tests/conftest.py
@@ -314,22 +314,3 @@ def s3_server(s3_connection):
             if proc is not None:
                 proc.kill()
 
-
-@pytest.fixture(scope='session')
-def limited_s3_user(request, s3_server):
-    def _limited_s3_user(policy):
-        if sys.platform == 'win32':
-            # Can't rely on FileNotFound check because
-            # there is sometimes an mc command on Windows
-            # which is unrelated to the minio mc
-            pytest.skip('The mc command is not installed on Windows')
-        request.config.pyarrow.requires('s3')
-        tempdir = s3_server['tempdir']
-        host, port, access_key, secret_key = s3_server['connection']
-        address = '{}:{}'.format(host, port)
-        if not _configure_limited_user(tempdir, address,
-                                       access_key, secret_key, policy):
-            pytest.skip(
-                'Could not locate mc command to configure limited user')
-
-    return _limited_s3_user

--- a/python/pyarrow/tests/conftest.py
+++ b/python/pyarrow/tests/conftest.py
@@ -314,3 +314,22 @@ def s3_server(s3_connection):
             if proc is not None:
                 proc.kill()
 
+
+@pytest.fixture(scope='session')
+def limited_s3_user(request, s3_server):
+    def _limited_s3_user(policy):
+        if sys.platform == 'win32':
+            # Can't rely on FileNotFound check because
+            # there is sometimes an mc command on Windows
+            # which is unrelated to the minio mc
+            pytest.skip('The mc command is not installed on Windows')
+        request.config.pyarrow.requires('s3')
+        tempdir = s3_server['tempdir']
+        host, port, access_key, secret_key = s3_server['connection']
+        address = '{}:{}'.format(host, port)
+        if not _configure_limited_user(tempdir, address,
+                                       access_key, secret_key, policy):
+            pytest.skip(
+                'Could not locate mc command to configure limited user')
+
+    return _limited_s3_user

--- a/python/pyarrow/tests/conftest.py
+++ b/python/pyarrow/tests/conftest.py
@@ -16,7 +16,6 @@
 # under the License.
 
 import os
-import sys
 import pathlib
 import subprocess
 from tempfile import TemporaryDirectory
@@ -26,7 +25,6 @@ import hypothesis as h
 
 from pyarrow.util import find_free_port
 from pyarrow import Codec
-from pyarrow.tests.util import _configure_limited_user
 
 
 # setup hypothesis profiles
@@ -313,23 +311,3 @@ def s3_server(s3_connection):
         finally:
             if proc is not None:
                 proc.kill()
-
-
-@pytest.fixture(scope='session')
-def limited_s3_user(request, s3_server):
-    def _limited_s3_user(policy):
-        if sys.platform == 'win32':
-            # Can't rely on FileNotFound check because
-            # there is sometimes an mc command on Windows
-            # which is unrelated to the minio mc
-            pytest.skip('The mc command is not installed on Windows')
-        request.config.pyarrow.requires('s3')
-        tempdir = s3_server['tempdir']
-        host, port, access_key, secret_key = s3_server['connection']
-        address = '{}:{}'.format(host, port)
-        if not _configure_limited_user(tempdir, address,
-                                       access_key, secret_key, policy):
-            pytest.skip(
-                'Could not locate mc command to configure limited user')
-
-    return _limited_s3_user

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -35,7 +35,7 @@ import pyarrow.csv
 import pyarrow.feather
 import pyarrow.fs as fs
 from pyarrow.tests.util import (change_cwd, _filesystem_uri,
-                                FSProtocolClass, ProxyHandler)
+                                FSProtocolClass, ProxyHandler, limited_s3_user)
 
 try:
     import pandas as pd
@@ -4354,7 +4354,7 @@ _minio_put_only_policy = """{
 
 @pytest.mark.parquet
 @pytest.mark.s3
-def test_write_dataset_s3_put_only(s3_server, limited_s3_user):
+def test_write_dataset_s3_put_only(s3_server):
     # [ARROW-15892] Testing the create_dir flag which will restrict
     # creating a new directory for writing a dataset. This is
     # required while writing a dataset in s3 where we have very
@@ -4370,7 +4370,7 @@ def test_write_dataset_s3_put_only(s3_server, limited_s3_user):
         endpoint_override='{}:{}'.format(host, port),
         scheme='http'
     )
-    limited_s3_user(_minio_put_only_policy)
+    limited_s3_user(s3_server, _minio_put_only_policy)
     table = pa.table([
         pa.array(range(20)), pa.array(np.random.randn(20)),
         pa.array(np.repeat(['a', 'b'], 10))],

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -35,7 +35,8 @@ import pyarrow.csv
 import pyarrow.feather
 import pyarrow.fs as fs
 from pyarrow.tests.util import (change_cwd, _filesystem_uri,
-                                FSProtocolClass, ProxyHandler)
+                                FSProtocolClass, ProxyHandler,
+                                limited_s3_user)
 
 try:
     import pandas as pd
@@ -4354,7 +4355,7 @@ _minio_put_only_policy = """{
 
 @pytest.mark.parquet
 @pytest.mark.s3
-def test_write_dataset_s3_put_only(s3_server, limited_s3_user):
+def test_write_dataset_s3_put_only(s3_server):
     from pyarrow.fs import S3FileSystem
 
     # write dataset with s3 filesystem

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -4356,6 +4356,11 @@ _minio_put_only_policy = """{
 @pytest.mark.parquet
 @pytest.mark.s3
 def test_write_dataset_s3_put_only(s3_server, limited_s3_user):
+    # [ARROW-15892] Testing the create_dir flag which will restrict 
+    # creating a new directory for writing a dataset. This is
+    # required while writing a dataset in s3 where we have very 
+    # limited permissions and thus we can directly write the dataset
+    # without creating a directory. 
     from pyarrow.fs import S3FileSystem
 
     # write dataset with s3 filesystem

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -35,7 +35,7 @@ import pyarrow.csv
 import pyarrow.feather
 import pyarrow.fs as fs
 from pyarrow.tests.util import (change_cwd, _filesystem_uri,
-                                FSProtocolClass, ProxyHandler, limited_s3_user)
+                                FSProtocolClass, ProxyHandler, _configure_s3_limited_user)
 
 try:
     import pandas as pd
@@ -4370,7 +4370,7 @@ def test_write_dataset_s3_put_only(s3_server):
         endpoint_override='{}:{}'.format(host, port),
         scheme='http'
     )
-    limited_s3_user(s3_server, _minio_put_only_policy)
+    _configure_s3_limited_user(s3_server, _minio_put_only_policy)
     table = pa.table([
         pa.array(range(20)), pa.array(np.random.randn(20)),
         pa.array(np.repeat(['a', 'b'], 10))],

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -25,6 +25,7 @@ import textwrap
 import tempfile
 import threading
 import time
+from venv import create
 
 import numpy as np
 import pytest
@@ -35,8 +36,7 @@ import pyarrow.csv
 import pyarrow.feather
 import pyarrow.fs as fs
 from pyarrow.tests.util import (change_cwd, _filesystem_uri,
-                                FSProtocolClass, ProxyHandler,
-                                limited_s3_user)
+                                FSProtocolClass, ProxyHandler)
 
 try:
     import pandas as pd
@@ -4355,7 +4355,7 @@ _minio_put_only_policy = """{
 
 @pytest.mark.parquet
 @pytest.mark.s3
-def test_write_dataset_s3_put_only(s3_server):
+def test_write_dataset_s3_put_only(s3_server, limited_s3_user):
     from pyarrow.fs import S3FileSystem
 
     # write dataset with s3 filesystem
@@ -4382,6 +4382,12 @@ def test_write_dataset_s3_put_only(s3_server):
         "existing-bucket", filesystem=fs, format="ipc",
     ).to_table()
     assert result.equals(table)
+    
+    with pytest.raises(OSError, match="Access Denied"):
+        ds.write_dataset(
+            table, "existing-bucket", filesystem=fs,
+            format="feather", create_dir=True
+        )
 
 
 @pytest.mark.parquet

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -4371,7 +4371,9 @@ def test_write_dataset_s3_put_only(s3_server):
         endpoint_override='{}:{}'.format(host, port),
         scheme='http'
     )
-    _configure_s3_limited_user(s3_server, _minio_put_only_policy)
+    if not _configure_s3_limited_user(s3_server, _minio_put_only_policy):
+        pytest.skip("Configuring limited s3 user failed")
+
     table = pa.table([
         pa.array(range(20)), pa.array(np.random.randn(20)),
         pa.array(np.repeat(['a', 'b'], 10))],

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -25,7 +25,6 @@ import textwrap
 import tempfile
 import threading
 import time
-from venv import create
 
 import numpy as np
 import pytest

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -35,7 +35,8 @@ import pyarrow.csv
 import pyarrow.feather
 import pyarrow.fs as fs
 from pyarrow.tests.util import (change_cwd, _filesystem_uri,
-                                FSProtocolClass, ProxyHandler, _configure_s3_limited_user)
+                                FSProtocolClass, ProxyHandler,
+                                _configure_s3_limited_user)
 
 try:
     import pandas as pd

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -4377,21 +4377,25 @@ def test_write_dataset_s3_put_only(s3_server):
         pa.array(np.repeat(['a', 'b'], 10))],
         names=["f1", "f2", "part"]
     )
+    part = ds.partitioning(pa.schema([("part", pa.string())]), flavor="hive")
+
     # writing with filesystem object with create_dir flag set to false
     ds.write_dataset(
         table, "existing-bucket", filesystem=fs,
-        format="feather", create_dir=False
+        format="feather", create_dir=False, partitioning=part,
+        existing_data_behavior='overwrite_or_ignore'
     )
     # check roundtrip
     result = ds.dataset(
-        "existing-bucket", filesystem=fs, format="ipc",
+        "existing-bucket", filesystem=fs, format="ipc", partitioning="hive"
     ).to_table()
     assert result.equals(table)
 
     with pytest.raises(OSError, match="Access Denied"):
         ds.write_dataset(
             table, "existing-bucket", filesystem=fs,
-            format="feather", create_dir=True
+            format="feather", create_dir=True,
+            existing_data_behavior='overwrite_or_ignore'
         )
 
 

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -25,7 +25,6 @@ import textwrap
 import tempfile
 import threading
 import time
-from venv import create
 
 import numpy as np
 import pytest
@@ -4356,11 +4355,11 @@ _minio_put_only_policy = """{
 @pytest.mark.parquet
 @pytest.mark.s3
 def test_write_dataset_s3_put_only(s3_server, limited_s3_user):
-    # [ARROW-15892] Testing the create_dir flag which will restrict 
+    # [ARROW-15892] Testing the create_dir flag which will restrict
     # creating a new directory for writing a dataset. This is
-    # required while writing a dataset in s3 where we have very 
+    # required while writing a dataset in s3 where we have very
     # limited permissions and thus we can directly write the dataset
-    # without creating a directory. 
+    # without creating a directory.
     from pyarrow.fs import S3FileSystem
 
     # write dataset with s3 filesystem
@@ -4387,7 +4386,7 @@ def test_write_dataset_s3_put_only(s3_server, limited_s3_user):
         "existing-bucket", filesystem=fs, format="ipc",
     ).to_table()
     assert result.equals(table)
-    
+
     with pytest.raises(OSError, match="Access Denied"):
         ds.write_dataset(
             table, "existing-bucket", filesystem=fs,

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -4371,8 +4371,7 @@ def test_write_dataset_s3_put_only(s3_server):
         endpoint_override='{}:{}'.format(host, port),
         scheme='http'
     )
-    if not _configure_s3_limited_user(s3_server, _minio_put_only_policy):
-        pytest.skip("Configuring limited s3 user failed")
+    _configure_s3_limited_user(s3_server, _minio_put_only_policy)
 
     table = pa.table([
         pa.array(range(20)), pa.array(np.random.randn(20)),

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -26,7 +26,7 @@ import weakref
 
 import pyarrow as pa
 from pyarrow.tests.test_io import assert_file_not_found
-from pyarrow.tests.util import _filesystem_uri, ProxyHandler
+from pyarrow.tests.util import _filesystem_uri, ProxyHandler, limited_s3_user
 
 from pyarrow.fs import (FileType, FileInfo, FileSelector, FileSystem,
                         LocalFileSystem, SubTreeFileSystem, _MockFileSystem,
@@ -429,7 +429,7 @@ def skip_fsspec_s3fs(fs):
 
 
 @pytest.mark.s3
-def test_s3fs_limited_permissions_create_bucket(s3_server, limited_s3_user):
+def test_s3fs_limited_permissions_create_bucket(s3_server):
     from pyarrow.fs import S3FileSystem
     limited_s3_user(_minio_limited_policy)
     host, port, _, _ = s3_server['connection']

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -26,7 +26,7 @@ import weakref
 
 import pyarrow as pa
 from pyarrow.tests.test_io import assert_file_not_found
-from pyarrow.tests.util import _filesystem_uri, ProxyHandler, limited_s3_user
+from pyarrow.tests.util import _filesystem_uri, ProxyHandler
 
 from pyarrow.fs import (FileType, FileInfo, FileSelector, FileSystem,
                         LocalFileSystem, SubTreeFileSystem, _MockFileSystem,
@@ -429,7 +429,7 @@ def skip_fsspec_s3fs(fs):
 
 
 @pytest.mark.s3
-def test_s3fs_limited_permissions_create_bucket(s3_server):
+def test_s3fs_limited_permissions_create_bucket(s3_server, limited_s3_user):
     from pyarrow.fs import S3FileSystem
     limited_s3_user(_minio_limited_policy)
     host, port, _, _ = s3_server['connection']

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -26,7 +26,7 @@ import weakref
 
 import pyarrow as pa
 from pyarrow.tests.test_io import assert_file_not_found
-from pyarrow.tests.util import _filesystem_uri, ProxyHandler, limited_s3_user
+from pyarrow.tests.util import _filesystem_uri, ProxyHandler, _configure_s3_limited_user
 
 from pyarrow.fs import (FileType, FileInfo, FileSelector, FileSystem,
                         LocalFileSystem, SubTreeFileSystem, _MockFileSystem,
@@ -431,7 +431,7 @@ def skip_fsspec_s3fs(fs):
 @pytest.mark.s3
 def test_s3fs_limited_permissions_create_bucket(s3_server):
     from pyarrow.fs import S3FileSystem
-    limited_s3_user(s3_server, _minio_limited_policy)
+    _configure_s3_limited_user(s3_server, _minio_limited_policy)
     host, port, _, _ = s3_server['connection']
 
     fs = S3FileSystem(

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -26,7 +26,7 @@ import weakref
 
 import pyarrow as pa
 from pyarrow.tests.test_io import assert_file_not_found
-from pyarrow.tests.util import _filesystem_uri, ProxyHandler
+from pyarrow.tests.util import _filesystem_uri, ProxyHandler, limited_s3_user
 
 from pyarrow.fs import (FileType, FileInfo, FileSelector, FileSystem,
                         LocalFileSystem, SubTreeFileSystem, _MockFileSystem,
@@ -429,9 +429,9 @@ def skip_fsspec_s3fs(fs):
 
 
 @pytest.mark.s3
-def test_s3fs_limited_permissions_create_bucket(s3_server, limited_s3_user):
+def test_s3fs_limited_permissions_create_bucket(s3_server):
     from pyarrow.fs import S3FileSystem
-    limited_s3_user(_minio_limited_policy)
+    limited_s3_user(s3_server, _minio_limited_policy)
     host, port, _, _ = s3_server['connection']
 
     fs = S3FileSystem(

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -20,10 +20,6 @@ import gzip
 import os
 import pathlib
 import pickle
-import re
-import subprocess
-import sys
-import time
 
 import pytest
 import weakref

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -432,8 +432,7 @@ def skip_fsspec_s3fs(fs):
 @pytest.mark.s3
 def test_s3fs_limited_permissions_create_bucket(s3_server):
     from pyarrow.fs import S3FileSystem
-    if not _configure_s3_limited_user(s3_server, _minio_limited_policy):
-        pytest.skip("Configuring limited s3 user failed")
+    _configure_s3_limited_user(s3_server, _minio_limited_policy)
     host, port, _, _ = s3_server['connection']
 
     fs = S3FileSystem(

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -261,104 +261,6 @@ _minio_limited_policy = """{
 }"""
 
 
-def _run_mc_command(mcdir, *args):
-    full_args = ['mc', '-C', mcdir] + list(args)
-    proc = subprocess.Popen(full_args, stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE, encoding='utf-8')
-    retval = proc.wait(10)
-    cmd_str = ' '.join(full_args)
-    print(f'Cmd: {cmd_str}')
-    print(f'  Return: {retval}')
-    print(f'  Stdout: {proc.stdout.read()}')
-    print(f'  Stderr: {proc.stderr.read()}')
-    if retval != 0:
-        raise ChildProcessError("Could not run mc")
-
-
-def _wait_for_minio_startup(mcdir, address, access_key, secret_key):
-    start = time.time()
-    while time.time() - start < 10:
-        try:
-            _run_mc_command(mcdir, 'alias', 'set', 'myminio',
-                            f'http://{address}', access_key, secret_key)
-            return
-        except ChildProcessError:
-            time.sleep(1)
-    raise Exception("mc command could not connect to local minio")
-
-
-def _ensure_minio_component_version(component, minimum_year):
-    full_args = [component, '--version']
-    proc = subprocess.Popen(full_args, stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE, encoding='utf-8')
-    if proc.wait(10) != 0:
-        return False
-    stdout = proc.stdout.read()
-    pattern = component + r' version RELEASE\.(\d+)-.*'
-    version_match = re.search(pattern, stdout)
-    if version_match:
-        version_year = version_match.group(1)
-        return int(version_year) >= minimum_year
-    else:
-        return False
-
-
-def _configure_limited_user(tmpdir, address, access_key, secret_key):
-    """
-    Attempts to use the mc command to configure the minio server
-    with a special user limited:limited123 which does not have
-    permission to create buckets.  This mirrors some real life S3
-    configurations where users are given strict permissions.
-
-    Arrow S3 operations should still work in such a configuration
-    (e.g. see ARROW-13685)
-    """
-    try:
-        if not _ensure_minio_component_version('mc', 2021):
-            # mc version is too old for the capabilities we need
-            return False
-        if not _ensure_minio_component_version('minio', 2021):
-            # minio version is too old for the capabilities we need
-            return False
-        mcdir = os.path.join(tmpdir, 'mc')
-        os.mkdir(mcdir)
-        policy_path = os.path.join(tmpdir, 'limited-buckets-policy.json')
-        with open(policy_path, mode='w') as policy_file:
-            policy_file.write(_minio_limited_policy)
-        # The s3_server fixture starts the minio process but
-        # it takes a few moments for the process to become available
-        _wait_for_minio_startup(mcdir, address, access_key, secret_key)
-        # These commands create a limited user with a specific
-        # policy and creates a sample bucket for that user to
-        # write to
-        _run_mc_command(mcdir, 'admin', 'policy', 'add',
-                        'myminio/', 'no-create-buckets', policy_path)
-        _run_mc_command(mcdir, 'admin', 'user', 'add',
-                        'myminio/', 'limited', 'limited123')
-        _run_mc_command(mcdir, 'admin', 'policy', 'set',
-                        'myminio', 'no-create-buckets', 'user=limited')
-        _run_mc_command(mcdir, 'mb', 'myminio/existing-bucket')
-        return True
-    except FileNotFoundError:
-        # If mc is not found, skip these tests
-        return False
-
-
-@pytest.fixture(scope='session')
-def limited_s3_user(request, s3_server):
-    if sys.platform == 'win32':
-        # Can't rely on FileNotFound check because
-        # there is sometimes an mc command on Windows
-        # which is unrelated to the minio mc
-        pytest.skip('The mc command is not installed on Windows')
-    request.config.pyarrow.requires('s3')
-    tempdir = s3_server['tempdir']
-    host, port, access_key, secret_key = s3_server['connection']
-    address = '{}:{}'.format(host, port)
-    if not _configure_limited_user(tempdir, address, access_key, secret_key):
-        pytest.skip('Could not locate mc command to configure limited user')
-
-
 @pytest.fixture
 def hdfs(request, hdfs_connection):
     request.config.pyarrow.requires('hdfs')
@@ -533,7 +435,7 @@ def skip_fsspec_s3fs(fs):
 @pytest.mark.s3
 def test_s3fs_limited_permissions_create_bucket(s3_server, limited_s3_user):
     from pyarrow.fs import S3FileSystem
-
+    limited_s3_user(_minio_limited_policy)
     host, port, _, _ = s3_server['connection']
 
     fs = S3FileSystem(

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -26,7 +26,8 @@ import weakref
 
 import pyarrow as pa
 from pyarrow.tests.test_io import assert_file_not_found
-from pyarrow.tests.util import _filesystem_uri, ProxyHandler, _configure_s3_limited_user
+from pyarrow.tests.util import (_filesystem_uri, ProxyHandler,
+                                _configure_s3_limited_user)
 
 from pyarrow.fs import (FileType, FileInfo, FileSelector, FileSystem,
                         LocalFileSystem, SubTreeFileSystem, _MockFileSystem,

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -432,7 +432,8 @@ def skip_fsspec_s3fs(fs):
 @pytest.mark.s3
 def test_s3fs_limited_permissions_create_bucket(s3_server):
     from pyarrow.fs import S3FileSystem
-    _configure_s3_limited_user(s3_server, _minio_limited_policy)
+    if not _configure_s3_limited_user(s3_server, _minio_limited_policy):
+        pytest.skip("Configuring limited s3 user failed")
     host, port, _, _ = s3_server['connection']
 
     fs = S3FileSystem(

--- a/python/pyarrow/tests/util.py
+++ b/python/pyarrow/tests/util.py
@@ -414,7 +414,8 @@ def _configure_limited_user(tmpdir, address, access_key, secret_key, policy):
             # minio version is too old for the capabilities we need
             return False
         mcdir = os.path.join(tmpdir, 'mc')
-        os.mkdir(mcdir)
+        if not os.path.exists(mcdir):
+            os.mkdir(mcdir)
         policy_path = os.path.join(tmpdir, 'limited-buckets-policy.json')
         with open(policy_path, mode='w') as policy_file:
             policy_file.write(policy)

--- a/python/pyarrow/tests/util.py
+++ b/python/pyarrow/tests/util.py
@@ -25,12 +25,12 @@ import gc
 import numpy as np
 import os
 import random
+import re
 import signal
 import socket
 import string
 import subprocess
 import sys
-import re
 import time
 
 import pytest

--- a/python/pyarrow/tests/util.py
+++ b/python/pyarrow/tests/util.py
@@ -435,3 +435,18 @@ def _configure_limited_user(tmpdir, address, access_key, secret_key, policy):
     except FileNotFoundError:
         # If mc is not found, skip these tests
         return False
+
+
+def limited_s3_user(s3_server, policy):
+    if sys.platform == 'win32':
+        # Can't rely on FileNotFound check because
+        # there is sometimes an mc command on Windows
+        # which is unrelated to the minio mc
+        pytest.skip('The mc command is not installed on Windows')
+    tempdir = s3_server['tempdir']
+    host, port, access_key, secret_key = s3_server['connection']
+    address = '{}:{}'.format(host, port)
+    if not _configure_limited_user(tempdir, address,
+                                   access_key, secret_key, policy):
+        pytest.skip(
+            'Could not locate mc command to configure limited user')

--- a/python/pyarrow/tests/util.py
+++ b/python/pyarrow/tests/util.py
@@ -25,6 +25,7 @@ import gc
 import numpy as np
 import os
 import random
+import re
 import shutil
 import signal
 import socket
@@ -354,6 +355,22 @@ def signal_wakeup_fd(*, warn_on_full_buffer=False):
         w.close()
 
 
+def _ensure_minio_component_version(component, minimum_year):
+    full_args = [component, '--version']
+    proc = subprocess.Popen(full_args, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE, encoding='utf-8')
+    if proc.wait(10) != 0:
+        return False
+    stdout = proc.stdout.read()
+    pattern = component + r' version RELEASE\.(\d+)-.*'
+    version_match = re.search(pattern, stdout)
+    if version_match:
+        version_year = version_match.group(1)
+        return int(version_year) >= minimum_year
+    else:
+        return False
+
+
 def _wait_for_minio_startup(mcdir, address, access_key, secret_key):
     start = time.time()
     while time.time() - start < 10:
@@ -400,15 +417,16 @@ def _configure_s3_limited_user(s3_server, policy):
     host, port, access_key, secret_key = s3_server['connection']
     address = '{}:{}'.format(host, port)
 
-    mcdir = os.path.join(tempdir, 'mc')
-    if os.path.exists(mcdir):
-        shutil.rmtree(mcdir)
-    os.mkdir(mcdir)
-    policy_path = os.path.join(tempdir, 'limited-buckets-policy.json')
-
-    with open(policy_path, mode='w') as policy_file:
-        policy_file.write(policy)
-    try:
+    # ensuring version of mc and minio for the capabilities we need
+    if (_ensure_minio_component_version('mc', 2021) and
+            _ensure_minio_component_version('minio', 2021)):
+        mcdir = os.path.join(tempdir, 'mc')
+        if os.path.exists(mcdir):
+            shutil.rmtree(mcdir)
+        os.mkdir(mcdir)
+        policy_path = os.path.join(tempdir, 'limited-buckets-policy.json')
+        with open(policy_path, mode='w') as policy_file:
+            policy_file.write(policy)
         # The s3_server fixture starts the minio process but
         # it takes a few moments for the process to become available
         _wait_for_minio_startup(mcdir, address, access_key, secret_key)
@@ -423,7 +441,3 @@ def _configure_s3_limited_user(s3_server, policy):
                         'myminio', 'no-create-buckets', 'user=limited')
         _run_mc_command(mcdir, 'mb', 'myminio/existing-bucket',
                         '--ignore-existing')
-
-    except FileNotFoundError:
-        pytest.skip(
-            'Could not locate mc command to configure limited user')

--- a/python/pyarrow/tests/util.py
+++ b/python/pyarrow/tests/util.py
@@ -436,14 +436,13 @@ def _configure_limited_user(tmpdir, address, access_key, secret_key, policy):
         # If mc is not found, skip these tests
         return False
 
-def limited_s3_user(request, s3_server):
+def limited_s3_user(s3_server):
     def _limited_s3_user(policy):
         if sys.platform == 'win32':
             # Can't rely on FileNotFound check because
             # there is sometimes an mc command on Windows
             # which is unrelated to the minio mc
             pytest.skip('The mc command is not installed on Windows')
-        request.config.pyarrow.requires('s3')
         tempdir = s3_server['tempdir']
         host, port, access_key, secret_key = s3_server['connection']
         address = '{}:{}'.format(host, port)

--- a/python/pyarrow/tests/util.py
+++ b/python/pyarrow/tests/util.py
@@ -443,7 +443,8 @@ def _configure_s3_limited_user(s3_server, policy):
                         'myminio/', 'limited', 'limited123')
         _run_mc_command(mcdir, 'admin', 'policy', 'set',
                         'myminio', 'no-create-buckets', 'user=limited')
-        _run_mc_command(mcdir, 'mb', 'myminio/existing-bucket')
+        _run_mc_command(mcdir, 'mb', 'myminio/existing-bucket',
+                        '--ignore-existing')
 
     except FileNotFoundError:
         pytest.skip(

--- a/python/pyarrow/tests/util.py
+++ b/python/pyarrow/tests/util.py
@@ -435,20 +435,3 @@ def _configure_limited_user(tmpdir, address, access_key, secret_key, policy):
     except FileNotFoundError:
         # If mc is not found, skip these tests
         return False
-
-def limited_s3_user(s3_server):
-    def _limited_s3_user(policy):
-        if sys.platform == 'win32':
-            # Can't rely on FileNotFound check because
-            # there is sometimes an mc command on Windows
-            # which is unrelated to the minio mc
-            pytest.skip('The mc command is not installed on Windows')
-        tempdir = s3_server['tempdir']
-        host, port, access_key, secret_key = s3_server['connection']
-        address = '{}:{}'.format(host, port)
-        if not _configure_limited_user(tempdir, address,
-                                       access_key, secret_key, policy):
-            pytest.skip(
-                'Could not locate mc command to configure limited user')
-
-    return _limited_s3_user

--- a/python/pyarrow/tests/util.py
+++ b/python/pyarrow/tests/util.py
@@ -435,3 +435,21 @@ def _configure_limited_user(tmpdir, address, access_key, secret_key, policy):
     except FileNotFoundError:
         # If mc is not found, skip these tests
         return False
+
+def limited_s3_user(request, s3_server):
+    def _limited_s3_user(policy):
+        if sys.platform == 'win32':
+            # Can't rely on FileNotFound check because
+            # there is sometimes an mc command on Windows
+            # which is unrelated to the minio mc
+            pytest.skip('The mc command is not installed on Windows')
+        request.config.pyarrow.requires('s3')
+        tempdir = s3_server['tempdir']
+        host, port, access_key, secret_key = s3_server['connection']
+        address = '{}:{}'.format(host, port)
+        if not _configure_limited_user(tempdir, address,
+                                       access_key, secret_key, policy):
+            pytest.skip(
+                'Could not locate mc command to configure limited user')
+
+    return _limited_s3_user

--- a/python/pyarrow/tests/util.py
+++ b/python/pyarrow/tests/util.py
@@ -406,7 +406,7 @@ def _configure_s3_limited_user(s3_server, policy):
     Arrow S3 operations should still work in such a configuration
     (e.g. see ARROW-13685)
     """
-    
+
     if sys.platform == 'win32':
         # Can't rely on FileNotFound check because
         # there is sometimes an mc command on Windows
@@ -446,4 +446,3 @@ def _configure_s3_limited_user(s3_server, policy):
     except FileNotFoundError:
         pytest.skip(
             'Could not locate mc command to configure limited user')
-

--- a/python/pyarrow/tests/util.py
+++ b/python/pyarrow/tests/util.py
@@ -26,6 +26,7 @@ import numpy as np
 import os
 import random
 import re
+import shutil
 import signal
 import socket
 import string
@@ -424,8 +425,9 @@ def _configure_s3_limited_user(s3_server, policy):
             # minio version is too old for the capabilities we need
             return False
         mcdir = os.path.join(tempdir, 'mc')
-        if not os.path.exists(mcdir):
-            os.mkdir(mcdir)
+        if os.path.exists(mcdir):
+            shutil.rmtree(mcdir)
+        os.mkdir(mcdir)
         policy_path = os.path.join(tempdir, 'limited-buckets-policy.json')
         with open(policy_path, mode='w') as policy_file:
             policy_file.write(policy)

--- a/python/pyarrow/tests/util.py
+++ b/python/pyarrow/tests/util.py
@@ -30,6 +30,8 @@ import socket
 import string
 import subprocess
 import sys
+import re
+import time
 
 import pytest
 
@@ -350,3 +352,86 @@ def signal_wakeup_fd(*, warn_on_full_buffer=False):
             signal.set_wakeup_fd(old_fd)
         r.close()
         w.close()
+
+
+def _ensure_minio_component_version(component, minimum_year):
+    full_args = [component, '--version']
+    proc = subprocess.Popen(full_args, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE, encoding='utf-8')
+    if proc.wait(10) != 0:
+        return False
+    stdout = proc.stdout.read()
+    pattern = component + r' version RELEASE\.(\d+)-.*'
+    version_match = re.search(pattern, stdout)
+    if version_match:
+        version_year = version_match.group(1)
+        return int(version_year) >= minimum_year
+    else:
+        return False
+
+
+def _wait_for_minio_startup(mcdir, address, access_key, secret_key):
+    start = time.time()
+    while time.time() - start < 10:
+        try:
+            _run_mc_command(mcdir, 'alias', 'set', 'myminio',
+                            f'http://{address}', access_key, secret_key)
+            return
+        except ChildProcessError:
+            time.sleep(1)
+    raise Exception("mc command could not connect to local minio")
+
+
+def _run_mc_command(mcdir, *args):
+    full_args = ['mc', '-C', mcdir] + list(args)
+    proc = subprocess.Popen(full_args, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE, encoding='utf-8')
+    retval = proc.wait(10)
+    cmd_str = ' '.join(full_args)
+    print(f'Cmd: {cmd_str}')
+    print(f'  Return: {retval}')
+    print(f'  Stdout: {proc.stdout.read()}')
+    print(f'  Stderr: {proc.stderr.read()}')
+    if retval != 0:
+        raise ChildProcessError("Could not run mc")
+
+
+def _configure_limited_user(tmpdir, address, access_key, secret_key, policy):
+    """
+    Attempts to use the mc command to configure the minio server
+    with a special user limited:limited123 which does not have
+    permission to create buckets.  This mirrors some real life S3
+    configurations where users are given strict permissions.
+
+    Arrow S3 operations should still work in such a configuration
+    (e.g. see ARROW-13685)
+    """
+    try:
+        if not _ensure_minio_component_version('mc', 2021):
+            # mc version is too old for the capabilities we need
+            return False
+        if not _ensure_minio_component_version('minio', 2021):
+            # minio version is too old for the capabilities we need
+            return False
+        mcdir = os.path.join(tmpdir, 'mc')
+        os.mkdir(mcdir)
+        policy_path = os.path.join(tmpdir, 'limited-buckets-policy.json')
+        with open(policy_path, mode='w') as policy_file:
+            policy_file.write(policy)
+        # The s3_server fixture starts the minio process but
+        # it takes a few moments for the process to become available
+        _wait_for_minio_startup(mcdir, address, access_key, secret_key)
+        # These commands create a limited user with a specific
+        # policy and creates a sample bucket for that user to
+        # write to
+        _run_mc_command(mcdir, 'admin', 'policy', 'add',
+                        'myminio/', 'no-create-buckets', policy_path)
+        _run_mc_command(mcdir, 'admin', 'user', 'add',
+                        'myminio/', 'limited', 'limited123')
+        _run_mc_command(mcdir, 'admin', 'policy', 'set',
+                        'myminio', 'no-create-buckets', 'user=limited')
+        _run_mc_command(mcdir, 'mb', 'myminio/existing-bucket')
+        return True
+    except FileNotFoundError:
+        # If mc is not found, skip these tests
+        return False


### PR DESCRIPTION
This PR adds a boolean flag which can be used to avoid creating directories with the Dataset API for filesystems like s3.

**Checklist**
- [x]  Implementation to avoid creating directories
- [x] s3 filesystem tests with limited permissions (only put object permissions) 