### PR TITLE
ARROW-15428: [Python] Address docstrings in Parquet classes and functions

### DIFF
--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -2767,6 +2767,44 @@ def write_table(table, where, row_group_size=None, version='1.0',
                 pass
         raise
 
+_write_table_example = """\
+Generate an example PyArrow Table:
+
+>>> import pyarrow as pa
+>>> import pandas as pd
+>>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+...                    'month': [3, 5, 7, 9, 11, 12],
+...                    'day': [1, 5, 9, 13, 17, 23],
+...                    'n_legs': [2, 2, 4, 4, 5, 100],
+...                    'animals': ["Flamingo", "Parot", "Dog", "Horse",
+...                    "Brittle stars", "Centipede"]})
+>>> table = pa.Table.from_pandas(df)
+
+and write the Table into Parquet file:
+
+>>> import pyarrow.parquet as pq
+>>> pq.write_table(table, 'example.parquet')
+
+Defining row group size for the Parquet file:
+
+>>> pq.write_table(table, 'example.parquet', row_group_size=3)
+
+Defining row group compression (default is Snappy):
+
+>>> pq.write_table(table, 'example.parquet', compression='none')
+
+Defining row group compression and encoding per-column:
+
+>>> pq.write_table(table, 'example.parquet',
+...                compression={'foo': 'snappy', 'bar': 'gzip'},
+...                use_dictionary=['foo', 'bar'])
+
+
+Defining column encoding per-column:
+
+>>> pq.write_table(table, 'example.parquet', column_encoding={'animals':'PLAIN'},
+...                use_dictionary=False)
+"""
 
 write_table.__doc__ = """
 Write a Table to Parquet format.
@@ -2782,7 +2820,11 @@ row_group_size : int
 {}
 **kwargs : optional
     Additional options for ParquetWriter
-""".format(_parquet_writer_arg_docs)
+
+Examples
+--------
+{}
+""".format(_parquet_writer_arg_docs, _write_table_example)
 
 
 def _mkdir_if_not_exists(fs, path):

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -804,7 +804,7 @@ and write the Table into the Parquet file:
 >>> pq.read_table('example.parquet').to_pandas()
    year  month  day  n_legs        animals
 0  2020      3    1       2       Flamingo
-1  2022      5    5       2          Parrot
+1  2022      5    5       2         Parrot
 2  2021      7    9       4            Dog
 3  2022      9   13       4          Horse
 4  2019     11   17       5  Brittle stars
@@ -822,7 +822,7 @@ and write the RecordBatch into the Parquet file:
 >>> pq.read_table('example2.parquet').to_pandas()
    year  month  day  n_legs        animals
 0  2020      3    1       2       Flamingo
-1  2022      5    5       2          Parrot
+1  2022      5    5       2         Parrot
 2  2021      7    9       4            Dog
 3  2022      9   13       4          Horse
 4  2019     11   17       5  Brittle stars
@@ -1590,7 +1590,7 @@ and read the data:
 1       2       Flamingo  2020     3   1
 2     100      Centipede  2021    12  23
 3       4            Dog  2021     7   9
-4       2          Parrot  2022     5   5
+4       2         Parrot  2022     5   5
 5       4          Horse  2022     9  13
 
 create a ParquetDataset object with filter:
@@ -2537,18 +2537,18 @@ Generate an example PyArrow Table and write it to a partitioned dataset:
 >>> table = pa.Table.from_pandas(df)
 
 >>> import pyarrow.parquet as pq
->>> pq.write_to_dataset(table, root_path='dataset_name',
+>>> pq.write_to_dataset(table, root_path='dataset_name_2',
 ...                     partition_cols=['year', 'month', 'day'])
 
 Read the data:
 
->>> pq.read_table('dataset_name').to_pandas()
+>>> pq.read_table('dataset_name_2').to_pandas()
    n_legs        animals  year month day
 0       5  Brittle stars  2019    11  17
 1       2       Flamingo  2020     3   1
 2     100      Centipede  2021    12  23
 3       4            Dog  2021     7   9
-4       2         ßParrot  2022     5   5
+4       2         Parrot  2022     5   5
 5       4          Horse  2022     9  13
 
 
@@ -2564,7 +2564,7 @@ animals: [["Brittle stars"],["Flamingo"],...,["Parrot"],["Horse"]]
 
 Read a subset of columns and read one column as DictionaryArray:
 
->>> pq.read_table('dataset_name', columns=["n_legs", "animals"], read_dictionary=["animals"])
+>>> pq.read_table('dataset_name_2', columns=["n_legs", "animals"], read_dictionary=["animals"])
 pyarrow.Table
 n_legs: int64
 animals: dictionary<values=string, indices=int32, ordered=0>
@@ -2582,10 +2582,10 @@ animals: [  -- dictionary:
 
 Read the table with filter:
 
->>> pq.read_table('dataset_name', columns=["n_legs", "animals"], filters=[('n_legs','<',4)]).to_pandas()
+>>> pq.read_table('dataset_name_2', columns=["n_legs", "animals"], filters=[('n_legs','<',4)]).to_pandas()
    n_legs   animals
 0       2  Flamingo
-1       2     Parrot
+1       2    Parrot
 
 You can also read data from a single Parquet file:
 
@@ -2596,7 +2596,7 @@ You can also read data from a single Parquet file:
 1       2       Flamingo  2020     3   1
 2     100      Centipede  2021    12  23
 3       4            Dog  2021     7   9
-4       2         ßParrot  2022     5   5
+4       2         Parrot  2022     5   5
 5       4          Horse  2022     9  13
 """
 
@@ -2712,7 +2712,7 @@ switched to False.""",
     index columns are also loaded.""")),
     """pyarrow.Table
     Content of the file as a table (of columns)""",
-    _DNF_filter_doc, _parquet_dataset_example)
+    _DNF_filter_doc, _read_table_example)
 
 
 def read_pandas(source, columns=None, **kwargs):

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -2880,7 +2880,6 @@ Defining row group compression and encoding per-column:
 ...                compression={'n_legs': 'snappy', 'animal': 'gzip'},
 ...                use_dictionary=['n_legs', 'animal'])
 
-
 Defining column encoding per-column:
 
 >>> pq.write_table(table, 'example.parquet',
@@ -2985,16 +2984,6 @@ def write_to_dataset(table, root_path, partition_cols=None,
     ...                    )
     >>> pq.ParquetDataset('dataset_name_3', use_legacy_dataset=False).files
     ['dataset_name_3/year=2019/part-0.parquet', ...
-
-    Use old Arrow Dataset API and override the partition filename:
-
-    >>> pq.write_to_dataset(table, root_path='dataset_name_5',
-    ...                     partition_cols=['year'],
-    ...                     partition_filename_cb=lambda x:
-    ...                     str(x[0]) + '.parquet'
-    ...                    )
-    >>> pq.ParquetDataset('dataset_name_5/', use_legacy_dataset=False).files
-    ['dataset_name_5/year=2019/2019.parquet', ...
 
     Write to a single Parquet file:
 

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -322,17 +322,6 @@ class ParquetFile:
     def metadata(self):
         """
         Return the Parquet metadata.
-
-        Examples
-        --------
-        >>> parquet_file.metadata
-        <pyarrow._parquet.FileMetaData object at 0x1160d04f0>
-          created_by: parquet-cpp-arrow version 8.0.0-SNAPSHOT
-          num_columns: 5
-          num_rows: 6
-          num_row_groups: 1
-          format_version: 1.0
-          serialized_size: 3225
         """
         return self.reader.metadata
 
@@ -340,18 +329,6 @@ class ParquetFile:
     def schema(self):
         """
         Return the Parquet schema, unconverted to Arrow types
-
-        Examples
-        --------
-        >>> parquet_file.schema
-        <pyarrow._parquet.ParquetSchema object at 0x11668cb00>
-        required group field_id=-1 schema {
-          optional int64 field_id=-1 year;
-          optional int64 field_id=-1 month;
-          optional int64 field_id=-1 day;
-          optional int64 field_id=-1 n_legs;
-          optional binary field_id=-1 animals (String);
-        }
         """
         return self.metadata.schema
 
@@ -363,6 +340,23 @@ class ParquetFile:
 
         Examples
         --------
+        Generate an example Parquet file:
+
+        >>> import pandas as pd
+        >>> import pyarrow as pa
+        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+        ...                    'month': [3, 5, 7, 9, 11, 12],
+        ...                    'day': [1, 5, 9, 13, 17, 23],
+        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> import pyarrow.parquet as pq
+        >>> pq.write_table(table, 'example.parquet')
+        >>> parquet_file = pq.ParquetFile('example.parquet')
+
+        Read the Arrow schema:
+
         >>> parquet_file.schema_arrow
         year: int64
         month: int64
@@ -370,7 +364,7 @@ class ParquetFile:
         n_legs: int64
         animals: string
         -- schema metadata --
-        pandas: '{"index_columns": [{"kind": "range", "name": null, "start": 0, "' + 814
+        pandas: '{"index_columns": [{"kind": "range", "name": null, "start": 0, "' + 824
         """
         return self.reader.schema_arrow
 
@@ -381,6 +375,19 @@ class ParquetFile:
 
         Examples
         --------
+        >>> import pandas as pd
+        >>> import pyarrow as pa
+        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+        ...                    'month': [3, 5, 7, 9, 11, 12],
+        ...                    'day': [1, 5, 9, 13, 17, 23],
+        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> import pyarrow.parquet as pq
+        >>> pq.write_table(table, 'example.parquet')
+        >>> parquet_file = pq.ParquetFile('example.parquet')
+
         >>> parquet_file.num_row_groups
         1
         """
@@ -412,6 +419,19 @@ class ParquetFile:
 
         Examples
         --------
+        >>> import pandas as pd
+        >>> import pyarrow as pa
+        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+        ...                    'month': [3, 5, 7, 9, 11, 12],
+        ...                    'day': [1, 5, 9, 13, 17, 23],
+        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> import pyarrow.parquet as pq
+        >>> pq.write_table(table, 'example.parquet')
+        >>> parquet_file = pq.ParquetFile('example.parquet')
+
         >>> parquet_file.read_row_group(0)
         pyarrow.Table
         year: int64
@@ -457,6 +477,19 @@ class ParquetFile:
 
         Examples
         --------
+        >>> import pandas as pd
+        >>> import pyarrow as pa
+        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+        ...                    'month': [3, 5, 7, 9, 11, 12],
+        ...                    'day': [1, 5, 9, 13, 17, 23],
+        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> import pyarrow.parquet as pq
+        >>> pq.write_table(table, 'example.parquet')
+        >>> parquet_file = pq.ParquetFile('example.parquet')
+
         >>> parquet_file.read_row_groups([0,0])
         pyarrow.Table
         year: int64
@@ -469,8 +502,7 @@ class ParquetFile:
         month: [[3,5,7,9,11,...,5,7,9,11,12]]
         day: [[1,5,9,13,17,...,5,9,13,17,23]]
         n_legs: [[2,2,4,4,5,...,2,4,4,5,100]]
-        animals: [["Flamingo","Parrot","Dog","Horse","Brittle stars",...,
-        "Parrot","Dog","Horse","Brittle stars","Centipede"]]
+        animals: [["Flamingo","Parrot","Dog","Horse","Brittle stars",...,"Parrot","Dog","Horse","Brittle stars","Centipede"]]
         """
         column_indices = self._get_column_indices(
             columns, use_pandas_metadata=use_pandas_metadata)
@@ -507,6 +539,23 @@ class ParquetFile:
 
         Examples
         --------
+        Generate an example Parquet file:
+
+        >>> import pandas as pd
+        >>> import pyarrow as pa
+        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+        ...                    'month': [3, 5, 7, 9, 11, 12],
+        ...                    'day': [1, 5, 9, 13, 17, 23],
+        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> import pyarrow.parquet as pq
+        >>> pq.write_table(table, 'example.parquet')
+        >>> parquet_file = pq.ParquetFile('example.parquet')
+
+        Read streaming batches:
+
         >>> for i in parquet_file.iter_batches(batch_size=3):
         ...     print("RecordBatch")
         ...     print(i.to_pandas())
@@ -514,7 +563,7 @@ class ParquetFile:
         RecordBatch
            year  month  day  n_legs   animals
         0  2020      3    1       2  Flamingo
-        1  2022      5    5       2     Parrot
+        1  2022      5    5       2    Parrot
         2  2021      7    9       4       Dog
         RecordBatch
            year  month  day  n_legs        animals
@@ -556,6 +605,23 @@ class ParquetFile:
 
         Examples
         --------
+        Generate an example Parquet file:
+
+        >>> import pandas as pd
+        >>> import pyarrow as pa
+        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+        ...                    'month': [3, 5, 7, 9, 11, 12],
+        ...                    'day': [1, 5, 9, 13, 17, 23],
+        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> import pyarrow.parquet as pq
+        >>> pq.write_table(table, 'example.parquet')
+        >>> parquet_file = pq.ParquetFile('example.parquet')
+
+        Read a Table:
+
         >>> parquet_file.read(columns=["animals"])
         pyarrow.Table
         animals: string
@@ -589,6 +655,19 @@ class ParquetFile:
 
         Examples
         --------
+        >>> import pandas as pd
+        >>> import pyarrow as pa
+        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+        ...                    'month': [3, 5, 7, 9, 11, 12],
+        ...                    'day': [1, 5, 9, 13, 17, 23],
+        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> import pyarrow.parquet as pq
+        >>> pq.write_table(table, 'example.parquet')
+        >>> parquet_file = pq.ParquetFile('example.parquet')
+
         >>> parquet_file.scan_contents()
         6
         """
@@ -947,13 +1026,6 @@ Examples
             Maximum size of each written row group. If None, the
             row group size will be the minimum of the input
             table or batch length and 64 * 1024 * 1024.
-
-        Examples
-        --------
-        >>> import pyarrow.parquet as pq
-        >>> writer = pq.ParquetWriter('example.parquet', table.schema)
-        >>> writer.write(table)
-        >>> writer.close()
         """
         if isinstance(table_or_batch, pa.RecordBatch):
             self.write_batch(table_or_batch, row_group_size)
@@ -973,13 +1045,6 @@ Examples
             Maximum size of each written row group. If None, the
             row group size will be the minimum of the RecordBatch
             size and 64 * 1024 * 1024.
-
-        Examples
-        --------
-        >>> import pyarrow.parquet as pq
-        >>> writer = pq.ParquetWriter('example.parquet', batch.schema)
-        >>> writer.write_batch(table)
-        >>> writer.close()
         """
         table = pa.Table.from_batches([batch], batch.schema)
         self.write_table(table, row_group_size)
@@ -996,12 +1061,6 @@ Examples
             row group size will be the minimum of the Table size
             and 64 * 1024 * 1024.
 
-        Examples
-        --------
-        >>> import pyarrow.parquet as pq
-        >>> writer = pq.ParquetWriter('example.parquet', table.schema)
-        >>> writer.write_table(table)
-        >>> writer.close()
         """
         if self.schema_changed:
             table = _sanitize_table(table, self.schema, self.flavor)
@@ -1018,12 +1077,6 @@ Examples
     def close(self):
         """
         Close the connection to the Parquet file.
-
-        Examples
-        --------
-        >>> import pyarrow.parquet as pq
-        >>> writer = pq.ParquetWriter('example.parquet', table.schema)
-        >>> writer.close()
         """
         if self.is_open:
             self.writer.close()
@@ -1576,7 +1629,8 @@ Generate an example PyArrow Table and write it to a partitioned dataset:
 
 >>> import pyarrow.parquet as pq
 >>> pq.write_to_dataset(table, root_path='dataset_name',
-...                     partition_cols=['year', 'month', 'day'])
+...                     partition_cols=['year', 'month', 'day'],
+...                     use_legacy_dataset=False)
 
 create a ParquetDataset object from the dataset source:
 
@@ -1848,6 +1902,25 @@ Examples
 
         Examples
         --------
+        Generate an example dataset:
+
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+        ...                    'month': [3, 5, 7, 9, 11, 12],
+        ...                    'day': [1, 5, 9, 13, 17, 23],
+        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> import pyarrow.parquet as pq
+        >>> pq.write_to_dataset(table, root_path='dataset_name_read',
+        ...                     partition_cols=['year', 'month', 'day'],
+        ...                     use_legacy_dataset=False)
+        >>> dataset = pq.ParquetDataset('dataset_name_read/', use_legacy_dataset=False)
+
+        Read multiple Parquet files as a single pyarrow.Table:
+
         >>> dataset.read(columns=["n_legs"])
         pyarrow.Table
         n_legs: int64
@@ -1893,22 +1966,35 @@ Examples
 
         Examples
         --------
+        Generate an example PyArrow Table and write it to a partitioned dataset:
+
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+        ...                    'month': [3, 5, 7, 9, 11, 12],
+        ...                    'day': [1, 5, 9, 13, 17, 23],
+        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> import pyarrow.parquet as pq
+        >>> pq.write_to_dataset(table, root_path='dataset_name_read_pandas',
+        ...                     partition_cols=['year', 'month', 'day'],
+        ...                     use_legacy_dataset=False)
+        >>> dataset = pq.ParquetDataset('dataset_name_read_pandas/', use_legacy_dataset=False)
+
+        Read dataset including pandas metadata:
+
         >>> dataset.read_pandas(columns=["n_legs"])
         pyarrow.Table
         n_legs: int64
         ----
-        n_legs: [[5],[5],...,[4],[4]]
+        n_legs: [[5],[2],...,[2],[4]]
 
         Select pandas metadata:
 
         >>> dataset.read_pandas(columns=["n_legs"]).schema.pandas_metadata
-        {'index_columns': [], 'column_indexes': [{'name': None, 'field_name': None,
-        'pandas_type': 'unicode', 'numpy_type': 'object', 'metadata': {'encoding': 'UTF-8'}}],
-        'columns': [{'name': 'n_legs', 'field_name': 'n_legs', 'pandas_type': 'int64',
-        'numpy_type': 'int64', 'metadata': None}, {'name': 'animals', 'field_name': 'animals',
-        'pandas_type': 'unicode', 'numpy_type': 'object', 'metadata': None}],
-        'creator': {'library': 'pyarrow', 'version': '8.0.0.dev221+g884d2b873'},
-        'pandas_version': '1.3.4'}
+        {'index_columns': [{'kind': 'range', 'name': None, 'start': 0, 'stop': 6, 'step': 1}], 'column_indexes': [{'name': None, 'field_name': None, 'pandas_type': 'unicode', 'numpy_type': 'object', 'metadata': {'encoding': 'UTF-8'}}], 'columns': [{'name': 'year', 'field_name': 'year', 'pandas_type': 'int64', 'numpy_type': 'int64', 'metadata': None}, {'name': 'month', 'field_name': 'month', 'pandas_type': 'int64', 'numpy_type': 'int64', 'metadata': None}, {'name': 'day', 'field_name': 'day', 'pandas_type': 'int64', 'numpy_type': 'int64', 'metadata': None}, {'name': 'n_legs', 'field_name': 'n_legs', 'pandas_type': 'int64', 'numpy_type': 'int64', 'metadata': None}, {'name': 'animals', 'field_name': 'animals', 'pandas_type': 'unicode', 'numpy_type': 'object', 'metadata': None}], 'creator': {'library': 'pyarrow', 'version': '8.0.0.dev248+g45ae537d2.d20220328'}, 'pandas_version': '1.4.1'}
         """
         return self.read(use_pandas_metadata=True, **kwargs)
 
@@ -2043,14 +2129,27 @@ Examples
 
         Examples
         --------
+        Generate an example dataset:
+
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+        ...                    'month': [3, 5, 7, 9, 11, 12],
+        ...                    'day': [1, 5, 9, 13, 17, 23],
+        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> import pyarrow.parquet as pq
+        >>> pq.write_to_dataset(table, root_path='dataset_name_fragments',
+        ...                     partition_cols=['year', 'month', 'day'],
+        ...                     use_legacy_dataset=False)
+        >>> dataset = pq._ParquetDatasetV2('dataset_name_fragments/')
+        
+        List the fragments:
 
         >>> dataset.fragments
-        [<pyarrow.dataset.ParquetFileFragment path=dataset_name/year=2019/month=11/day=17/60c4a2430c6944f2a19bcdc3487bb0ba.parquet partition=[day=17, month=11, year=2019]>
-        <pyarrow.dataset.ParquetFileFragment path=dataset_name/year=2020/month=3/day=1/06319dcabb64451f9e23f5d47965b7f2.parquet partition=[day=1, month=3, year=2020]>,
-        <pyarrow.dataset.ParquetFileFragment path=dataset_name/year=2021/month=12/day=23/43aa6c683ef743e389a238d235461018.parquet partition=[day=23, month=12, year=2021]>,
-        <pyarrow.dataset.ParquetFileFragment path=dataset_name/year=2021/month=7/day=9/60579fe1daea4036a30f2b159b9d906b.parquet partition=[day=9, month=7, year=2021]>,
-        <pyarrow.dataset.ParquetFileFragment path=dataset_name/year=2022/month=5/day=5/b9fcc1de4474415e9ce1e998f66e8f8c.parquet partition=[day=5, month=5, year=2022]>,
-        <pyarrow.dataset.ParquetFileFragment path=dataset_name/year=2022/month=9/day=13/bd6aab52214a438db244428ee4a1896b.parquet partition=[day=13, month=9, year=2022]>]
+        [<pyarrow.dataset.ParquetFileFragment path=dataset_name_fragments/year=2019/month=11/day=17/part-0.parquet partition=[day=17, month=11, year=2019]>, <pyarrow.dataset.ParquetFileFragment path=dataset_name_fragments/year=2020/month=3/day=1/part-0.parquet partition=[day=1, month=3, year=2020]>, <pyarrow.dataset.ParquetFileFragment path=dataset_name_fragments/year=2021/month=12/day=23/part-0.parquet partition=[day=23, month=12, year=2021]>, <pyarrow.dataset.ParquetFileFragment path=dataset_name_fragments/year=2021/month=7/day=9/part-0.parquet partition=[day=9, month=7, year=2021]>, <pyarrow.dataset.ParquetFileFragment path=dataset_name_fragments/year=2022/month=5/day=5/part-0.parquet partition=[day=5, month=5, year=2022]>, <pyarrow.dataset.ParquetFileFragment path=dataset_name_fragments/year=2022/month=9/day=13/part-0.parquet partition=[day=13, month=9, year=2022]>]
         """
         raise NotImplementedError(
             "To use this property set 'use_legacy_dataset=False' while "
@@ -2065,13 +2164,27 @@ Examples
 
         Examples
         --------
+        Generate an example dataset:
+
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+        ...                    'month': [3, 5, 7, 9, 11, 12],
+        ...                    'day': [1, 5, 9, 13, 17, 23],
+        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> import pyarrow.parquet as pq
+        >>> pq.write_to_dataset(table, root_path='dataset_name_files',
+        ...                     partition_cols=['year', 'month', 'day'],
+        ...                     use_legacy_dataset=False)
+        >>> dataset = pq._ParquetDatasetV2('dataset_name_files/')
+        
+        List the files:
+
         >>> dataset.files
-        ['dataset_name/year=2019/month=11/day=17/60c4a2430c6944f2a19bcdc3487bb0ba.parquet',
-        'dataset_name/year=2020/month=3/day=1/06319dcabb64451f9e23f5d47965b7f2.parquet',
-        'dataset_name/year=2021/month=12/day=23/43aa6c683ef743e389a238d235461018.parquet',
-        'dataset_name/year=2021/month=7/day=9/60579fe1daea4036a30f2b159b9d906b.parquet',
-        'dataset_name/year=2022/month=5/day=5/b9fcc1de4474415e9ce1e998f66e8f8c.parquet',
-        'dataset_name/year=2022/month=9/day=13/bd6aab52214a438db244428ee4a1896b.parquet']
+        ['dataset_name_files/year=2019/month=11/day=17/part-0.parquet', 'dataset_name_files/year=2020/month=3/day=1/part-0.parquet', 'dataset_name_files/year=2021/month=12/day=23/part-0.parquet', 'dataset_name_files/year=2021/month=7/day=9/part-0.parquet', 'dataset_name_files/year=2022/month=5/day=5/part-0.parquet', 'dataset_name_files/year=2022/month=9/day=13/part-0.parquet']
         """
         raise NotImplementedError(
             "To use this property set 'use_legacy_dataset=False' while "
@@ -2083,11 +2196,6 @@ Examples
         The filesystem type of the Dataset source.
         To use this property set 'use_legacy_dataset=False'
         while constructing ParquetDataset object.
-
-        Examples
-        --------
-        >>> dataset.filesystem
-        <pyarrow._fs.LocalFileSystem object at 0x1179443f0>
         """
         raise NotImplementedError(
             "To use this property set 'use_legacy_dataset=False' while "
@@ -2099,11 +2207,6 @@ Examples
         The partitioning of the Dataset source, if discovered.
         To use this property set 'use_legacy_dataset=False'
         while constructing ParquetDataset object.
-
-        Examples
-        --------
-        >>> dataset.partitioning
-        <pyarrow._dataset.HivePartitioning object at 0x117926230>
         """
         raise NotImplementedError(
             "To use this property set 'use_legacy_dataset=False' while "
@@ -2174,12 +2277,13 @@ class _ParquetDatasetV2:
     >>> table = pa.Table.from_pandas(df)
 
     >>> import pyarrow.parquet as pq
-    >>> pq.write_to_dataset(table, root_path='dataset_name',
-    ...                     partition_cols=['year', 'month', 'day'])
+    >>> pq.write_to_dataset(table, root_path='dataset_v2',
+    ...                     partition_cols=['year', 'month', 'day'],
+    ...                     use_legacy_dataset=False)
 
     create a _ParquetDatasetV2 object from the dataset source:
 
-    >>> dataset = pq._ParquetDatasetV2('dataset_name/')
+    >>> dataset = pq._ParquetDatasetV2('dataset_v2/')
 
     and read the data:
 
@@ -2194,7 +2298,7 @@ class _ParquetDatasetV2:
 
     create a _ParquetDatasetV2 object with filter:
 
-    >>> dataset = pq._ParquetDatasetV2('dataset_name/', filters=[('n_legs','=',4)])
+    >>> dataset = pq._ParquetDatasetV2('dataset_v2/', filters=[('n_legs','=',4)])
     >>> dataset.read().to_pandas()
        n_legs animals  year month day
     0       4     Dog  2021     7   9
@@ -2305,6 +2409,25 @@ class _ParquetDatasetV2:
 
         Examples
         --------
+        Generate an example dataset:
+
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+        ...                    'month': [3, 5, 7, 9, 11, 12],
+        ...                    'day': [1, 5, 9, 13, 17, 23],
+        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> import pyarrow.parquet as pq
+        >>> pq.write_to_dataset(table, root_path='dataset_v2_schema',
+        ...                     partition_cols=['year', 'month', 'day'],
+        ...                     use_legacy_dataset=False)
+        >>> dataset = pq._ParquetDatasetV2('dataset_v2_schema/')
+
+        Read the schema:
+
         >>> dataset.schema
         n_legs: int64
         animals: string
@@ -2312,7 +2435,7 @@ class _ParquetDatasetV2:
         month: dictionary<values=int32, indices=int32, ordered=0>
         day: dictionary<values=int32, indices=int32, ordered=0>
         -- schema metadata --
-        pandas: '{"index_columns": [], "column_indexes": [{"name": null, "field_n' + 434
+        pandas: '{"index_columns": [{"kind": "range", "name": null, "start": 0, "' + 824
         """
         return self._dataset.schema
 
@@ -2339,10 +2462,10 @@ class _ParquetDatasetV2:
 
         Examples
         --------
-
-        Generate data and save them as a dataset:
+        Generate an example dataset:
 
         >>> import pyarrow as pa
+        >>> import pandas as pd
         >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
         ...                    'month': [3, 5, 7, 9, 11, 12],
         ...                    'day': [1, 5, 9, 13, 17, 23],
@@ -2350,16 +2473,14 @@ class _ParquetDatasetV2:
         ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
         ...                    "Brittle stars", "Centipede"]})
         >>> table = pa.Table.from_pandas(df)
-
-        Write it to a Parquet dataset:
-
         >>> import pyarrow.parquet as pq
-        >>> pq.write_to_dataset(table, root_path='dataset_name',
-        ...                     partition_cols=['year', 'month', 'day'])
+        >>> pq.write_to_dataset(table, root_path='dataset_v2_read',
+        ...                     partition_cols=['year', 'month', 'day'],
+        ...                     use_legacy_dataset=False)
+        >>> dataset = pq._ParquetDatasetV2('dataset_v2_read/')
 
         Read the dataset:
 
-        >>> dataset = pq._ParquetDatasetV2('dataset_name/')
         >>> dataset.read(columns=["n_legs"])
         pyarrow.Table
         n_legs: int64
@@ -2402,6 +2523,25 @@ class _ParquetDatasetV2:
 
         Examples
         --------
+        Generate an example dataset:
+
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+        ...                    'month': [3, 5, 7, 9, 11, 12],
+        ...                    'day': [1, 5, 9, 13, 17, 23],
+        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> import pyarrow.parquet as pq
+        >>> pq.write_to_dataset(table, root_path='dataset_v2_read_pandas',
+        ...                     partition_cols=['year', 'month', 'day'],
+        ...                     use_legacy_dataset=False)
+        >>> dataset = pq._ParquetDatasetV2('dataset_v2_read_pandas/')
+
+        Read the dataset with pandas metadata:
+
         >>> dataset.read_pandas(columns=["n_legs"])
         pyarrow.Table
         n_legs: int64
@@ -2409,13 +2549,7 @@ class _ParquetDatasetV2:
         n_legs: [[5],[2],...,[2],[4]]
 
         >>> dataset.read_pandas(columns=["n_legs"]).schema.pandas_metadata
-        {'index_columns': [], 'column_indexes': [{'name': None, 'field_name':
-        None, 'pandas_type': 'unicode', 'numpy_type': 'object', 'metadata':
-        {'encoding': 'UTF-8'}}], 'columns': [{'name': 'n_legs', 'field_name':
-        'n_legs', 'pandas_type': 'int64', 'numpy_type': 'int64', 'metadata': None},
-        {'name': 'animals', 'field_name': 'animals', 'pandas_type': 'unicode',
-        'numpy_type': 'object', 'metadata': None}], 'creator': {'library': 'pyarrow',
-        'version': '8.0.0.dev221+g884d2b873'}, 'pandas_version': '1.3.4'}
+        {'index_columns': [{'kind': 'range', 'name': None, 'start': 0, 'stop': 6, 'step': 1}], 'column_indexes': [{'name': None, 'field_name': None, 'pandas_type': 'unicode', 'numpy_type': 'object', 'metadata': {'encoding': 'UTF-8'}}], 'columns': [{'name': 'year', 'field_name': 'year', 'pandas_type': 'int64', 'numpy_type': 'int64', 'metadata': None}, {'name': 'month', 'field_name': 'month', 'pandas_type': 'int64', 'numpy_type': 'int64', 'metadata': None}, {'name': 'day', 'field_name': 'day', 'pandas_type': 'int64', 'numpy_type': 'int64', 'metadata': None}, {'name': 'n_legs', 'field_name': 'n_legs', 'pandas_type': 'int64', 'numpy_type': 'int64', 'metadata': None}, {'name': 'animals', 'field_name': 'animals', 'pandas_type': 'unicode', 'numpy_type': 'object', 'metadata': None}], 'creator': {'library': 'pyarrow', 'version': '8.0.0.dev248+g45ae537d2.d20220328'}, 'pandas_version': '1.4.1'}
         """
         return self.read(use_pandas_metadata=True, **kwargs)
 
@@ -2435,14 +2569,27 @@ class _ParquetDatasetV2:
 
         Examples
         --------
+        Generate an example dataset:
+
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+        ...                    'month': [3, 5, 7, 9, 11, 12],
+        ...                    'day': [1, 5, 9, 13, 17, 23],
+        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> import pyarrow.parquet as pq
+        >>> pq.write_to_dataset(table, root_path='dataset_v2_fragments',
+        ...                     partition_cols=['year', 'month', 'day'],
+        ...                     use_legacy_dataset=False)
+        >>> dataset = pq._ParquetDatasetV2('dataset_v2_fragments/')
+        
+        List the fragments:
 
         >>> dataset.fragments
-        [<pyarrow.dataset.ParquetFileFragment path=dataset_name/year=2019/month=11/day=17/60c4a2430c6944f2a19bcdc3487bb0ba.parquet partition=[day=17, month=11, year=2019]>
-        <pyarrow.dataset.ParquetFileFragment path=dataset_name/year=2020/month=3/day=1/06319dcabb64451f9e23f5d47965b7f2.parquet partition=[day=1, month=3, year=2020]>,
-        <pyarrow.dataset.ParquetFileFragment path=dataset_name/year=2021/month=12/day=23/43aa6c683ef743e389a238d235461018.parquet partition=[day=23, month=12, year=2021]>,
-        <pyarrow.dataset.ParquetFileFragment path=dataset_name/year=2021/month=7/day=9/60579fe1daea4036a30f2b159b9d906b.parquet partition=[day=9, month=7, year=2021]>,
-        <pyarrow.dataset.ParquetFileFragment path=dataset_name/year=2022/month=5/day=5/b9fcc1de4474415e9ce1e998f66e8f8c.parquet partition=[day=5, month=5, year=2022]>,
-        <pyarrow.dataset.ParquetFileFragment path=dataset_name/year=2022/month=9/day=13/bd6aab52214a438db244428ee4a1896b.parquet partition=[day=13, month=9, year=2022]>]
+        [<pyarrow.dataset.ParquetFileFragment path=dataset_v2_fragments/year=2019/month=11/day=17/part-0.parquet partition=[day=17, month=11, year=2019]>, <pyarrow.dataset.ParquetFileFragment path=dataset_v2_fragments/year=2020/month=3/day=1/part-0.parquet partition=[day=1, month=3, year=2020]>, <pyarrow.dataset.ParquetFileFragment path=dataset_v2_fragments/year=2021/month=12/day=23/part-0.parquet partition=[day=23, month=12, year=2021]>, <pyarrow.dataset.ParquetFileFragment path=dataset_v2_fragments/year=2021/month=7/day=9/part-0.parquet partition=[day=9, month=7, year=2021]>, <pyarrow.dataset.ParquetFileFragment path=dataset_v2_fragments/year=2022/month=5/day=5/part-0.parquet partition=[day=5, month=5, year=2022]>, <pyarrow.dataset.ParquetFileFragment path=dataset_v2_fragments/year=2022/month=9/day=13/part-0.parquet partition=[day=13, month=9, year=2022]>]
         """
         return list(self._dataset.get_fragments())
 
@@ -2453,13 +2600,27 @@ class _ParquetDatasetV2:
 
         Examples
         --------
+        Generate an example dataset:
+
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+        ...                    'month': [3, 5, 7, 9, 11, 12],
+        ...                    'day': [1, 5, 9, 13, 17, 23],
+        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> import pyarrow.parquet as pq
+        >>> pq.write_to_dataset(table, root_path='dataset_v2_files',
+        ...                     partition_cols=['year', 'month', 'day'],
+        ...                     use_legacy_dataset=False)
+        >>> dataset = pq._ParquetDatasetV2('dataset_v2_files/')
+        
+        List the files:
+
         >>> dataset.files
-        ['dataset_name/year=2019/month=11/day=17/60c4a2430c6944f2a19bcdc3487bb0ba.parquet',
-        'dataset_name/year=2020/month=3/day=1/06319dcabb64451f9e23f5d47965b7f2.parquet',
-        'dataset_name/year=2021/month=12/day=23/43aa6c683ef743e389a238d235461018.parquet',
-        'dataset_name/year=2021/month=7/day=9/60579fe1daea4036a30f2b159b9d906b.parquet',
-        'dataset_name/year=2022/month=5/day=5/b9fcc1de4474415e9ce1e998f66e8f8c.parquet',
-        'dataset_name/year=2022/month=9/day=13/bd6aab52214a438db244428ee4a1896b.parquet']
+        ['dataset_v2_files/year=2019/month=11/day=17/part-0.parquet', 'dataset_v2_files/year=2020/month=3/day=1/part-0.parquet', 'dataset_v2_files/year=2021/month=12/day=23/part-0.parquet', 'dataset_v2_files/year=2021/month=7/day=9/part-0.parquet', 'dataset_v2_files/year=2022/month=5/day=5/part-0.parquet', 'dataset_v2_files/year=2022/month=9/day=13/part-0.parquet']
         """
         return self._dataset.files
 
@@ -2467,11 +2628,6 @@ class _ParquetDatasetV2:
     def filesystem(self):
         """
         The filesystem type of the Dataset source.
-
-        Examples
-        --------
-        >>> dataset.filesystem
-        <pyarrow._fs.LocalFileSystem object at 0x1179443f0>
         """
         return self._dataset.filesystem
 
@@ -2479,11 +2635,6 @@ class _ParquetDatasetV2:
     def partitioning(self):
         """
         The partitioning of the Dataset source, if discovered.
-
-        Examples
-        --------
-        >>> dataset.partitioning
-        <pyarrow._dataset.HivePartitioning object at 0x117926230>
         """
         return self._dataset.partitioning
 
@@ -2628,7 +2779,7 @@ Read the table with filter:
 0       2  Flamingo
 1       2    Parrot
 
-You can also read data from a single Parquet file:
+Read data from a single Parquet file:
 
 >>> pq.write_table(table, 'example.parquet')
 >>> pq.read_table('dataset_name').to_pandas()
@@ -2964,13 +3115,6 @@ def write_to_dataset(table, root_path, partition_cols=None,
     >>> pq.ParquetDataset('dataset_name_3', use_legacy_dataset=False).files
     ['dataset_name_3/year=2019/month=11/day=17/part-0.parquet', 'dataset_name_3/year=2020/month=3/day=1/part-0.parquet', 'dataset_name_3/year=2021/month=12/day=23/part-0.parquet', 'dataset_name_3/year=2021/month=7/day=9/part-0.parquet', 'dataset_name_3/year=2022/month=5/day=5/part-0.parquet', 'dataset_name_3/year=2022/month=9/day=13/part-0.parquet']
 
-    Use old Arrow Dataset API:
-
-    >>> pq.write_to_dataset(table, root_path='dataset_name_4',
-    ...                     partition_cols=['year', 'month', 'day'])
-    >>> pq.ParquetDataset('dataset_name_4/', use_legacy_dataset=False).files
-    ['dataset_name_4/year=2019/month=11/day=17/59cfd909d9a54fe49540edb359a19331.parquet', 'dataset_name_4/year=2020/month=3/day=1/1e2cf97bb5db400f832900628081e9a0.parquet', 'dataset_name_4/year=2021/month=12/day=23/93f54630e5a3483a8f6aa808a7e9b469.parquet', 'dataset_name_4/year=2021/month=7/day=9/9a34bf7a2f37482b99f77d6895f09b88.parquet', 'dataset_name_4/year=2022/month=5/day=5/de2e52d6142940dca04558335a9af892.parquet', 'dataset_name_4/year=2022/month=9/day=13/9307aabc3d8149b3acb8f3a31a07dbd7.parquet']
-
     Use old Arrow Dataset API and override the partition filename:
 
     >>> pq.write_to_dataset(table, root_path='dataset_name_5',
@@ -2982,14 +3126,9 @@ def write_to_dataset(table, root_path, partition_cols=None,
 
     Write to a single Parquet file:
 
-    >>> import pyarrow.parquet as pq
-    >>> pq.write_to_dataset(table, root_path='dataset_name_3')
-    >>> pq.ParquetDataset('dataset_name_3/', use_legacy_dataset=False).files
-    ['dataset_name_3/0c7a313fcfee4b31b3380ee480739153.parquet']
-
-    >>> pq.write_to_dataset(table, root_path='dataset_name', use_legacy_dataset=False)
-    >>> pq.ParquetDataset('dataset_name_3/', use_legacy_dataset=False).files
-    ['dataset_name_3/part-0.parquet']
+    >>> pq.write_to_dataset(table, root_path='dataset_name_4', use_legacy_dataset=False)
+    >>> pq.ParquetDataset('dataset_name_4/', use_legacy_dataset=False).files
+    ['dataset_name_4/part-0.parquet']
     """
     if use_legacy_dataset is None:
         # if a new filesystem is passed -> default to new implementation
@@ -3112,24 +3251,36 @@ def write_metadata(schema, where, metadata_collector=None, **kwargs):
 
     Examples
     --------
+    Generate example data:
+
+    >>> import pyarrow as pa
+    >>> import pandas as pd
+    >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+    ...                    'month': [3, 5, 7, 9, 11, 12],
+    ...                    'day': [1, 5, 9, 13, 17, 23],
+    ...                    'n_legs': [2, 2, 4, 4, 5, 100],
+    ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+    ...                    "Brittle stars", "Centipede"]})
+    >>> table = pa.Table.from_pandas(df)
 
     Write a dataset and collect metadata information.
 
     >>> metadata_collector = []
-    >>> write_to_dataset(
-    ...     table, root_path,
-    ...     metadata_collector=metadata_collector, **writer_kwargs)
+    >>> import pyarrow.parquet as pq
+    >>> pq.write_to_dataset(
+    ...     table, 'dataset_metadata',
+    ...      metadata_collector=metadata_collector)
 
     Write the `_common_metadata` parquet file without row groups statistics.
 
-    >>> write_metadata(
-    ...     table.schema, root_path / '_common_metadata', **writer_kwargs)
+    >>> pq.write_metadata(
+    ...     table.schema, 'dataset_metadata/_common_metadata')
 
     Write the `_metadata` parquet file with row groups statistics.
 
-    >>> write_metadata(
-    ...     table.schema, root_path / '_metadata',
-    ...     metadata_collector=metadata_collector, **writer_kwargs)
+    >>> pq.write_metadata(
+    ...     table.schema, 'dataset_metadata/_metadata',
+    ...     metadata_collector=metadata_collector)
     """
     writer = ParquetWriter(where, schema, **kwargs)
     writer.close()

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -1826,7 +1826,7 @@ Examples
         Generate an example dataset:
 
         >>> import pyarrow as pa
-        >>> table = pa.table({'year': [2020, 2022, 2021, 2022, 2019, 2021],         
+        >>> table = pa.table({'year': [2020, 2022, 2021, 2022, 2019, 2021],
         ...                   'n_legs': [2, 2, 4, 4, 5, 100],
         ...                   'animal': ["Flamingo", "Parrot", "Dog", "Horse",
         ...                              "Brittle stars", "Centipede"]})

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -2145,7 +2145,7 @@ Examples
         ...                     partition_cols=['year', 'month', 'day'],
         ...                     use_legacy_dataset=False)
         >>> dataset = pq._ParquetDatasetV2('dataset_name_fragments/')
-        
+
         List the fragments:
 
         >>> dataset.fragments
@@ -2180,7 +2180,7 @@ Examples
         ...                     partition_cols=['year', 'month', 'day'],
         ...                     use_legacy_dataset=False)
         >>> dataset = pq._ParquetDatasetV2('dataset_name_files/')
-        
+
         List the files:
 
         >>> dataset.files
@@ -2585,7 +2585,7 @@ class _ParquetDatasetV2:
         ...                     partition_cols=['year', 'month', 'day'],
         ...                     use_legacy_dataset=False)
         >>> dataset = pq._ParquetDatasetV2('dataset_v2_fragments/')
-        
+
         List the fragments:
 
         >>> dataset.fragments
@@ -2616,7 +2616,7 @@ class _ParquetDatasetV2:
         ...                     partition_cols=['year', 'month', 'day'],
         ...                     use_legacy_dataset=False)
         >>> dataset = pq._ParquetDatasetV2('dataset_v2_files/')
-        
+
         List the files:
 
         >>> dataset.files

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -253,7 +253,7 @@ class ParquetFile:
     n_legs: [[2,2,4,4,5,100]]
     animal: [["Flamingo","Parrot","Dog","Horse","Brittle stars","Centipede"]]
 
-    create a ParquetFile object with "animal" column as DictionaryArray:
+    Create a ParquetFile object with "animal" column as DictionaryArray:
 
     >>> parquet_file = pq.ParquetFile('example.parquet',
     ...                               read_dictionary=["animal"])

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -237,7 +237,7 @@ class ParquetFile:
     ...                    'month': [3, 5, 7, 9, 11, 12],
     ...                    'day': [1, 5, 9, 13, 17, 23],
     ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-    ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+    ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
     ...                    "Brittle stars", "Centipede"]})
     >>> table = pa.Table.from_pandas(df)
 
@@ -256,31 +256,32 @@ class ParquetFile:
     month: int64
     day: int64
     n_legs: int64
-    animals: string
+    animal: string
     ----
     year: [[2020,2022,2021,2022,2019,2021]]
     month: [[3,5,7,9,11,12]]
     day: [[1,5,9,13,17,23]]
     n_legs: [[2,2,4,4,5,100]]
-    animals: [["Flamingo","Parrot","Dog","Horse","Brittle stars","Centipede"]]
+    animal: [["Flamingo","Parrot","Dog","Horse","Brittle stars","Centipede"]]
 
     create a ParquetFile object with "animals" column as DictionaryArray:
 
-    >>> parquet_file = pq.ParquetFile('example.parquet', read_dictionary=["animals"])
+    >>> parquet_file = pq.ParquetFile('example.parquet',
+    ...                               read_dictionary=["animal"])
     >>> parquet_file.read()
     pyarrow.Table
     year: int64
     month: int64
     day: int64
     n_legs: int64
-    animals: dictionary<values=string, indices=int32, ordered=0>
+    animal: dictionary<values=string, indices=int32, ordered=0>
     ----
     year: [[2020,2022,2021,2022,2019,2021]]
     month: [[3,5,7,9,11,12]]
     day: [[1,5,9,13,17,23]]
     n_legs: [[2,2,4,4,5,100]]
-    animals: [  -- dictionary:
-    ["Flamingo","Parrot","Dog","Horse","Brittle stars","Centipede"]  -- indices:
+    animal: [  -- dictionary:
+    ["Flamingo","Parrot",...,"Brittle stars","Centipede"]  -- indices:
     [0,1,2,3,4,5]]
     """
 
@@ -348,7 +349,7 @@ class ParquetFile:
         ...                    'month': [3, 5, 7, 9, 11, 12],
         ...                    'day': [1, 5, 9, 13, 17, 23],
         ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
         ...                    "Brittle stars", "Centipede"]})
         >>> table = pa.Table.from_pandas(df)
         >>> import pyarrow.parquet as pq
@@ -362,9 +363,9 @@ class ParquetFile:
         month: int64
         day: int64
         n_legs: int64
-        animals: string
+        animal: string
         -- schema metadata --
-        pandas: '{"index_columns": [{"kind": "range", "name": null, "start": 0, "' + 824
+        pandas: '{"index_columns": [{"kind": "range", "name": null,...
         """
         return self.reader.schema_arrow
 
@@ -381,7 +382,7 @@ class ParquetFile:
         ...                    'month': [3, 5, 7, 9, 11, 12],
         ...                    'day': [1, 5, 9, 13, 17, 23],
         ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
         ...                    "Brittle stars", "Centipede"]})
         >>> table = pa.Table.from_pandas(df)
         >>> import pyarrow.parquet as pq
@@ -425,7 +426,7 @@ class ParquetFile:
         ...                    'month': [3, 5, 7, 9, 11, 12],
         ...                    'day': [1, 5, 9, 13, 17, 23],
         ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
         ...                    "Brittle stars", "Centipede"]})
         >>> table = pa.Table.from_pandas(df)
         >>> import pyarrow.parquet as pq
@@ -438,13 +439,13 @@ class ParquetFile:
         month: int64
         day: int64
         n_legs: int64
-        animals: string
+        animal: string
         ----
         year: [[2020,2022,2021,2022,2019,2021]]
         month: [[3,5,7,9,11,12]]
         day: [[1,5,9,13,17,23]]
         n_legs: [[2,2,4,4,5,100]]
-        animals: [["Flamingo","Parrot","Dog","Horse","Brittle stars","Centipede"]]
+        animal: [["Flamingo","Parrot",...,"Brittle stars","Centipede"]]
         """
         column_indices = self._get_column_indices(
             columns, use_pandas_metadata=use_pandas_metadata)
@@ -483,7 +484,7 @@ class ParquetFile:
         ...                    'month': [3, 5, 7, 9, 11, 12],
         ...                    'day': [1, 5, 9, 13, 17, 23],
         ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
         ...                    "Brittle stars", "Centipede"]})
         >>> table = pa.Table.from_pandas(df)
         >>> import pyarrow.parquet as pq
@@ -496,13 +497,13 @@ class ParquetFile:
         month: int64
         day: int64
         n_legs: int64
-        animals: string
+        animal: string
         ----
         year: [[2020,2022,2021,2022,2019,...,2022,2021,2022,2019,2021]]
         month: [[3,5,7,9,11,...,5,7,9,11,12]]
         day: [[1,5,9,13,17,...,5,9,13,17,23]]
         n_legs: [[2,2,4,4,5,...,2,4,4,5,100]]
-        animals: [["Flamingo","Parrot","Dog","Horse","Brittle stars",...,"Parrot","Dog","Horse","Brittle stars","Centipede"]]
+        animal: [["Flamingo","Parrot","Dog",...,"Brittle stars","Centipede"]]
         """
         column_indices = self._get_column_indices(
             columns, use_pandas_metadata=use_pandas_metadata)
@@ -547,7 +548,7 @@ class ParquetFile:
         ...                    'month': [3, 5, 7, 9, 11, 12],
         ...                    'day': [1, 5, 9, 13, 17, 23],
         ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
         ...                    "Brittle stars", "Centipede"]})
         >>> table = pa.Table.from_pandas(df)
         >>> import pyarrow.parquet as pq
@@ -561,12 +562,12 @@ class ParquetFile:
         ...     print(i.to_pandas())
         ...
         RecordBatch
-           year  month  day  n_legs   animals
+           year  month  day  n_legs    animal
         0  2020      3    1       2  Flamingo
         1  2022      5    5       2    Parrot
         2  2021      7    9       4       Dog
         RecordBatch
-           year  month  day  n_legs        animals
+           year  month  day  n_legs         animal
         0  2022      9   13       4          Horse
         1  2019     11   17       5  Brittle stars
         2  2021     12   23     100      Centipede
@@ -613,7 +614,7 @@ class ParquetFile:
         ...                    'month': [3, 5, 7, 9, 11, 12],
         ...                    'day': [1, 5, 9, 13, 17, 23],
         ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
         ...                    "Brittle stars", "Centipede"]})
         >>> table = pa.Table.from_pandas(df)
         >>> import pyarrow.parquet as pq
@@ -622,11 +623,11 @@ class ParquetFile:
 
         Read a Table:
 
-        >>> parquet_file.read(columns=["animals"])
+        >>> parquet_file.read(columns=["animal"])
         pyarrow.Table
-        animals: string
+        animal: string
         ----
-        animals: [["Flamingo","Parrot","Dog","Horse","Brittle stars","Centipede"]]
+        animal: [["Flamingo","Parrot",...,"Brittle stars","Centipede"]]
         """
         column_indices = self._get_column_indices(
             columns, use_pandas_metadata=use_pandas_metadata)
@@ -661,7 +662,7 @@ class ParquetFile:
         ...                    'month': [3, 5, 7, 9, 11, 12],
         ...                    'day': [1, 5, 9, 13, 17, 23],
         ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
         ...                    "Brittle stars", "Centipede"]})
         >>> table = pa.Table.from_pandas(df)
         >>> import pyarrow.parquet as pq
@@ -1623,7 +1624,7 @@ Generate an example PyArrow Table and write it to a partitioned dataset:
 ...                    'month': [3, 5, 7, 9, 11, 12],
 ...                    'day': [1, 5, 9, 13, 17, 23],
 ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
 ...                    "Brittle stars", "Centipede"]})
 >>> table = pa.Table.from_pandas(df)
 
@@ -1639,7 +1640,7 @@ create a ParquetDataset object from the dataset source:
 and read the data:
 
 >>> dataset.read().to_pandas()
-   n_legs        animals  year month day
+   n_legs         animal  year month day
 0       5  Brittle stars  2019    11  17
 1       2       Flamingo  2020     3   1
 2     100      Centipede  2021    12  23
@@ -1652,9 +1653,9 @@ create a ParquetDataset object with filter:
 >>> dataset = pq.ParquetDataset('dataset_name/', use_legacy_dataset=False,
 ...                             filters=[('n_legs','=',4)])
 >>> dataset.read().to_pandas()
-   n_legs animals  year month day
-0       4     Dog  2021     7   9
-1       4   Horse  2022     9  13
+   n_legs animal  year month day
+0       4    Dog  2021     7   9
+1       4  Horse  2022     9  13
 """
 
 
@@ -1910,14 +1911,15 @@ Examples
         ...                    'month': [3, 5, 7, 9, 11, 12],
         ...                    'day': [1, 5, 9, 13, 17, 23],
         ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
         ...                    "Brittle stars", "Centipede"]})
         >>> table = pa.Table.from_pandas(df)
         >>> import pyarrow.parquet as pq
         >>> pq.write_to_dataset(table, root_path='dataset_name_read',
         ...                     partition_cols=['year', 'month', 'day'],
         ...                     use_legacy_dataset=False)
-        >>> dataset = pq.ParquetDataset('dataset_name_read/', use_legacy_dataset=False)
+        >>> dataset = pq.ParquetDataset('dataset_name_read/',
+        ...                             use_legacy_dataset=False)
 
         Read multiple Parquet files as a single pyarrow.Table:
 
@@ -1966,7 +1968,8 @@ Examples
 
         Examples
         --------
-        Generate an example PyArrow Table and write it to a partitioned dataset:
+        Generate an example PyArrow Table and write it to a partitioned
+        dataset:
 
         >>> import pyarrow as pa
         >>> import pandas as pd
@@ -1974,14 +1977,15 @@ Examples
         ...                    'month': [3, 5, 7, 9, 11, 12],
         ...                    'day': [1, 5, 9, 13, 17, 23],
         ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
         ...                    "Brittle stars", "Centipede"]})
         >>> table = pa.Table.from_pandas(df)
         >>> import pyarrow.parquet as pq
         >>> pq.write_to_dataset(table, root_path='dataset_name_read_pandas',
         ...                     partition_cols=['year', 'month', 'day'],
         ...                     use_legacy_dataset=False)
-        >>> dataset = pq.ParquetDataset('dataset_name_read_pandas/', use_legacy_dataset=False)
+        >>> dataset = pq.ParquetDataset('dataset_name_read_pandas/',
+        ...                             use_legacy_dataset=False)
 
         Read dataset including pandas metadata:
 
@@ -1994,7 +1998,7 @@ Examples
         Select pandas metadata:
 
         >>> dataset.read_pandas(columns=["n_legs"]).schema.pandas_metadata
-        {'index_columns': [{'kind': 'range', 'name': None, 'start': 0, 'stop': 6, 'step': 1}], 'column_indexes': [{'name': None, 'field_name': None, 'pandas_type': 'unicode', 'numpy_type': 'object', 'metadata': {'encoding': 'UTF-8'}}], 'columns': [{'name': 'year', 'field_name': 'year', 'pandas_type': 'int64', 'numpy_type': 'int64', 'metadata': None}, {'name': 'month', 'field_name': 'month', 'pandas_type': 'int64', 'numpy_type': 'int64', 'metadata': None}, {'name': 'day', 'field_name': 'day', 'pandas_type': 'int64', 'numpy_type': 'int64', 'metadata': None}, {'name': 'n_legs', 'field_name': 'n_legs', 'pandas_type': 'int64', 'numpy_type': 'int64', 'metadata': None}, {'name': 'animals', 'field_name': 'animals', 'pandas_type': 'unicode', 'numpy_type': 'object', 'metadata': None}], 'creator': {'library': 'pyarrow', 'version': '8.0.0.dev248+g45ae537d2.d20220328'}, 'pandas_version': '1.4.1'}
+        {'index_columns': [{'kind': 'range', ... 'pandas_version': '1.4.1'}
         """
         return self.read(use_pandas_metadata=True, **kwargs)
 
@@ -2137,7 +2141,7 @@ Examples
         ...                    'month': [3, 5, 7, 9, 11, 12],
         ...                    'day': [1, 5, 9, 13, 17, 23],
         ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
         ...                    "Brittle stars", "Centipede"]})
         >>> table = pa.Table.from_pandas(df)
         >>> import pyarrow.parquet as pq
@@ -2149,7 +2153,7 @@ Examples
         List the fragments:
 
         >>> dataset.fragments
-        [<pyarrow.dataset.ParquetFileFragment path=dataset_name_fragments/year=2019/month=11/day=17/part-0.parquet partition=[day=17, month=11, year=2019]>, <pyarrow.dataset.ParquetFileFragment path=dataset_name_fragments/year=2020/month=3/day=1/part-0.parquet partition=[day=1, month=3, year=2020]>, <pyarrow.dataset.ParquetFileFragment path=dataset_name_fragments/year=2021/month=12/day=23/part-0.parquet partition=[day=23, month=12, year=2021]>, <pyarrow.dataset.ParquetFileFragment path=dataset_name_fragments/year=2021/month=7/day=9/part-0.parquet partition=[day=9, month=7, year=2021]>, <pyarrow.dataset.ParquetFileFragment path=dataset_name_fragments/year=2022/month=5/day=5/part-0.parquet partition=[day=5, month=5, year=2022]>, <pyarrow.dataset.ParquetFileFragment path=dataset_name_fragments/year=2022/month=9/day=13/part-0.parquet partition=[day=13, month=9, year=2022]>]
+        [<pyarrow.dataset.ParquetFileFragment path=dataset_name_fragments/...
         """
         raise NotImplementedError(
             "To use this property set 'use_legacy_dataset=False' while "
@@ -2172,7 +2176,7 @@ Examples
         ...                    'month': [3, 5, 7, 9, 11, 12],
         ...                    'day': [1, 5, 9, 13, 17, 23],
         ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
         ...                    "Brittle stars", "Centipede"]})
         >>> table = pa.Table.from_pandas(df)
         >>> import pyarrow.parquet as pq
@@ -2184,7 +2188,7 @@ Examples
         List the files:
 
         >>> dataset.files
-        ['dataset_name_files/year=2019/month=11/day=17/part-0.parquet', 'dataset_name_files/year=2020/month=3/day=1/part-0.parquet', 'dataset_name_files/year=2021/month=12/day=23/part-0.parquet', 'dataset_name_files/year=2021/month=7/day=9/part-0.parquet', 'dataset_name_files/year=2022/month=5/day=5/part-0.parquet', 'dataset_name_files/year=2022/month=9/day=13/part-0.parquet']
+        ['dataset_name_files/year=2019/month=11/day=17/part-0.parquet', ...
         """
         raise NotImplementedError(
             "To use this property set 'use_legacy_dataset=False' while "
@@ -2272,7 +2276,7 @@ class _ParquetDatasetV2:
     ...                    'month': [3, 5, 7, 9, 11, 12],
     ...                    'day': [1, 5, 9, 13, 17, 23],
     ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-    ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+    ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
     ...                    "Brittle stars", "Centipede"]})
     >>> table = pa.Table.from_pandas(df)
 
@@ -2288,7 +2292,7 @@ class _ParquetDatasetV2:
     and read the data:
 
     >>> dataset.read().to_pandas()
-       n_legs        animals  year month day
+       n_legs         animal  year month day
     0       5  Brittle stars  2019    11  17
     1       2       Flamingo  2020     3   1
     2     100      Centipede  2021    12  23
@@ -2298,11 +2302,12 @@ class _ParquetDatasetV2:
 
     create a _ParquetDatasetV2 object with filter:
 
-    >>> dataset = pq._ParquetDatasetV2('dataset_v2/', filters=[('n_legs','=',4)])
+    >>> dataset = pq._ParquetDatasetV2('dataset_v2/',
+    ...                                filters=[('n_legs','=',4)])
     >>> dataset.read().to_pandas()
-       n_legs animals  year month day
-    0       4     Dog  2021     7   9
-    1       4   Horse  2022     9  13
+       n_legs animal  year month day
+    0       4    Dog  2021     7   9
+    1       4  Horse  2022     9  13
     """
 
     def __init__(self, path_or_paths, filesystem=None, filters=None,
@@ -2417,7 +2422,7 @@ class _ParquetDatasetV2:
         ...                    'month': [3, 5, 7, 9, 11, 12],
         ...                    'day': [1, 5, 9, 13, 17, 23],
         ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
         ...                    "Brittle stars", "Centipede"]})
         >>> table = pa.Table.from_pandas(df)
         >>> import pyarrow.parquet as pq
@@ -2430,12 +2435,12 @@ class _ParquetDatasetV2:
 
         >>> dataset.schema
         n_legs: int64
-        animals: string
+        animal: string
         year: dictionary<values=int32, indices=int32, ordered=0>
         month: dictionary<values=int32, indices=int32, ordered=0>
         day: dictionary<values=int32, indices=int32, ordered=0>
         -- schema metadata --
-        pandas: '{"index_columns": [{"kind": "range", "name": null, "start": 0, "' + 824
+        pandas: '{"index_columns": [{"kind": "range", "name": null, ...
         """
         return self._dataset.schema
 
@@ -2470,7 +2475,7 @@ class _ParquetDatasetV2:
         ...                    'month': [3, 5, 7, 9, 11, 12],
         ...                    'day': [1, 5, 9, 13, 17, 23],
         ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
         ...                    "Brittle stars", "Centipede"]})
         >>> table = pa.Table.from_pandas(df)
         >>> import pyarrow.parquet as pq
@@ -2531,7 +2536,7 @@ class _ParquetDatasetV2:
         ...                    'month': [3, 5, 7, 9, 11, 12],
         ...                    'day': [1, 5, 9, 13, 17, 23],
         ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
         ...                    "Brittle stars", "Centipede"]})
         >>> table = pa.Table.from_pandas(df)
         >>> import pyarrow.parquet as pq
@@ -2549,7 +2554,7 @@ class _ParquetDatasetV2:
         n_legs: [[5],[2],...,[2],[4]]
 
         >>> dataset.read_pandas(columns=["n_legs"]).schema.pandas_metadata
-        {'index_columns': [{'kind': 'range', 'name': None, 'start': 0, 'stop': 6, 'step': 1}], 'column_indexes': [{'name': None, 'field_name': None, 'pandas_type': 'unicode', 'numpy_type': 'object', 'metadata': {'encoding': 'UTF-8'}}], 'columns': [{'name': 'year', 'field_name': 'year', 'pandas_type': 'int64', 'numpy_type': 'int64', 'metadata': None}, {'name': 'month', 'field_name': 'month', 'pandas_type': 'int64', 'numpy_type': 'int64', 'metadata': None}, {'name': 'day', 'field_name': 'day', 'pandas_type': 'int64', 'numpy_type': 'int64', 'metadata': None}, {'name': 'n_legs', 'field_name': 'n_legs', 'pandas_type': 'int64', 'numpy_type': 'int64', 'metadata': None}, {'name': 'animals', 'field_name': 'animals', 'pandas_type': 'unicode', 'numpy_type': 'object', 'metadata': None}], 'creator': {'library': 'pyarrow', 'version': '8.0.0.dev248+g45ae537d2.d20220328'}, 'pandas_version': '1.4.1'}
+        {'index_columns': [{'kind': 'range', ... 'pandas_version': '1.4.1'}
         """
         return self.read(use_pandas_metadata=True, **kwargs)
 
@@ -2577,7 +2582,7 @@ class _ParquetDatasetV2:
         ...                    'month': [3, 5, 7, 9, 11, 12],
         ...                    'day': [1, 5, 9, 13, 17, 23],
         ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
         ...                    "Brittle stars", "Centipede"]})
         >>> table = pa.Table.from_pandas(df)
         >>> import pyarrow.parquet as pq
@@ -2589,7 +2594,7 @@ class _ParquetDatasetV2:
         List the fragments:
 
         >>> dataset.fragments
-        [<pyarrow.dataset.ParquetFileFragment path=dataset_v2_fragments/year=2019/month=11/day=17/part-0.parquet partition=[day=17, month=11, year=2019]>, <pyarrow.dataset.ParquetFileFragment path=dataset_v2_fragments/year=2020/month=3/day=1/part-0.parquet partition=[day=1, month=3, year=2020]>, <pyarrow.dataset.ParquetFileFragment path=dataset_v2_fragments/year=2021/month=12/day=23/part-0.parquet partition=[day=23, month=12, year=2021]>, <pyarrow.dataset.ParquetFileFragment path=dataset_v2_fragments/year=2021/month=7/day=9/part-0.parquet partition=[day=9, month=7, year=2021]>, <pyarrow.dataset.ParquetFileFragment path=dataset_v2_fragments/year=2022/month=5/day=5/part-0.parquet partition=[day=5, month=5, year=2022]>, <pyarrow.dataset.ParquetFileFragment path=dataset_v2_fragments/year=2022/month=9/day=13/part-0.parquet partition=[day=13, month=9, year=2022]>]
+        [<pyarrow.dataset.ParquetFileFragment path=dataset_v2_fragments/...
         """
         return list(self._dataset.get_fragments())
 
@@ -2608,7 +2613,7 @@ class _ParquetDatasetV2:
         ...                    'month': [3, 5, 7, 9, 11, 12],
         ...                    'day': [1, 5, 9, 13, 17, 23],
         ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
         ...                    "Brittle stars", "Centipede"]})
         >>> table = pa.Table.from_pandas(df)
         >>> import pyarrow.parquet as pq
@@ -2620,7 +2625,7 @@ class _ParquetDatasetV2:
         List the files:
 
         >>> dataset.files
-        ['dataset_v2_files/year=2019/month=11/day=17/part-0.parquet', 'dataset_v2_files/year=2020/month=3/day=1/part-0.parquet', 'dataset_v2_files/year=2021/month=12/day=23/part-0.parquet', 'dataset_v2_files/year=2021/month=7/day=9/part-0.parquet', 'dataset_v2_files/year=2022/month=5/day=5/part-0.parquet', 'dataset_v2_files/year=2022/month=9/day=13/part-0.parquet']
+        ['dataset_v2_files/year=2019/month=11/day=17/part-0.parquet', ...
         """
         return self._dataset.files
 
@@ -2746,7 +2751,7 @@ Read the data:
 
 Read only a subset of columns:
 
->>> pq.read_table('dataset_name', columns=["n_legs", "animals"])
+>>> pq.read_table('dataset_name_2', columns=["n_legs", "animals"])
 pyarrow.Table
 n_legs: int64
 animals: string
@@ -2756,7 +2761,8 @@ animals: [["Brittle stars"],["Flamingo"],...,["Parrot"],["Horse"]]
 
 Read a subset of columns and read one column as DictionaryArray:
 
->>> pq.read_table('dataset_name_2', columns=["n_legs", "animals"], read_dictionary=["animals"])
+>>> pq.read_table('dataset_name_2', columns=["n_legs", "animals"],
+...               read_dictionary=["animals"])
 pyarrow.Table
 n_legs: int64
 animals: dictionary<values=string, indices=int32, ordered=0>
@@ -2774,7 +2780,8 @@ animals: [  -- dictionary:
 
 Read the table with filter:
 
->>> pq.read_table('dataset_name_2', columns=["n_legs", "animals"], filters=[('n_legs','<',4)]).to_pandas()
+>>> pq.read_table('dataset_name_2', columns=["n_legs", "animals"],
+...               filters=[('n_legs','<',4)]).to_pandas()
    n_legs   animals
 0       2  Flamingo
 1       2    Parrot
@@ -2782,7 +2789,7 @@ Read the table with filter:
 Read data from a single Parquet file:
 
 >>> pq.write_table(table, 'example.parquet')
->>> pq.read_table('dataset_name').to_pandas()
+>>> pq.read_table('dataset_name_2').to_pandas()
    n_legs        animals  year month day
 0       5  Brittle stars  2019    11  17
 1       2       Flamingo  2020     3   1
@@ -3009,7 +3016,8 @@ Defining row group compression and encoding per-column:
 
 Defining column encoding per-column:
 
->>> pq.write_table(table, 'example.parquet', column_encoding={'animals':'PLAIN'},
+>>> pq.write_table(table, 'example.parquet',
+...                column_encoding={'animals':'PLAIN'},
 ...                use_dictionary=False)
 """
 
@@ -3113,20 +3121,22 @@ def write_to_dataset(table, root_path, partition_cols=None,
     ...                     use_legacy_dataset=False
     ...                    )
     >>> pq.ParquetDataset('dataset_name_3', use_legacy_dataset=False).files
-    ['dataset_name_3/year=2019/month=11/day=17/part-0.parquet', 'dataset_name_3/year=2020/month=3/day=1/part-0.parquet', 'dataset_name_3/year=2021/month=12/day=23/part-0.parquet', 'dataset_name_3/year=2021/month=7/day=9/part-0.parquet', 'dataset_name_3/year=2022/month=5/day=5/part-0.parquet', 'dataset_name_3/year=2022/month=9/day=13/part-0.parquet']
+    ['dataset_name_3/year=2019/month=11/day=17/part-0.parquet', ...
 
     Use old Arrow Dataset API and override the partition filename:
 
     >>> pq.write_to_dataset(table, root_path='dataset_name_5',
     ...                     partition_cols=['year', 'month', 'day'],
-    ...                     partition_filename_cb=lambda x: str(x[0]) + str(x[1]) + str(x[2])  + '.parquet'
+    ...                     partition_filename_cb=lambda x:
+    ...                     str(x[0]) + str(x[1]) + str(x[2])  + '.parquet'
     ...                    )
     >>> pq.ParquetDataset('dataset_name_5/', use_legacy_dataset=False).files
-    ['dataset_name_5/year=2019/month=11/day=17/20191117.parquet', 'dataset_name_5/year=2020/month=3/day=1/202031.parquet', 'dataset_name_5/year=2021/month=12/day=23/20211223.parquet', 'dataset_name_5/year=2021/month=7/day=9/202179.parquet', 'dataset_name_5/year=2022/month=5/day=5/202255.parquet', 'dataset_name_5/year=2022/month=9/day=13/2022913.parquet']
+    ['dataset_name_5/year=2019/month=11/day=17/20191117.parquet', ...
 
     Write to a single Parquet file:
 
-    >>> pq.write_to_dataset(table, root_path='dataset_name_4', use_legacy_dataset=False)
+    >>> pq.write_to_dataset(table, root_path='dataset_name_4',
+    ...                     use_legacy_dataset=False)
     >>> pq.ParquetDataset('dataset_name_4/', use_legacy_dataset=False).files
     ['dataset_name_4/part-0.parquet']
     """

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -495,23 +495,18 @@ class ParquetFile:
         >>> import pyarrow.parquet as pq
         >>> pq.write_table(table, 'example.parquet')
         >>> parquet_file = pq.ParquetFile('example.parquet')
-
-        Read streaming batches:
-
-        >>> for i in parquet_file.iter_batches(batch_size=3):
+        >>> for i in parquet_file.iter_batches():
         ...     print("RecordBatch")
         ...     print(i.to_pandas())
         ...
         RecordBatch
-           n_legs    animal
-        0       2  Flamingo
-        1       2    Parrot
-        2       4       Dog
-        RecordBatch
            n_legs         animal
-        0       4          Horse
-        1       5  Brittle stars
-        2     100      Centipede
+        0       2       Flamingo
+        1       2         Parrot
+        2       4            Dog
+        3       4          Horse
+        4       5  Brittle stars
+        5     100      Centipede
         """
         if row_groups is None:
             row_groups = range(0, self.metadata.num_row_groups)

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -829,6 +829,7 @@ and write the RecordBatch into the Parquet file:
 5  2021     12   23     100      Centipede
 """
 
+
 class ParquetWriter:
 
     __doc__ = """
@@ -1601,6 +1602,7 @@ create a ParquetDataset object with filter:
 0       4     Dog  2021     7   9
 1       4   Horse  2022     9  13
 """
+
 
 class ParquetDataset:
 
@@ -2598,6 +2600,7 @@ You can also read data from a single Parquet file:
 5       4          Horse  2022     9  13
 """
 
+
 def read_table(source, columns=None, use_threads=True, metadata=None,
                schema=None, use_pandas_metadata=False, memory_map=False,
                read_dictionary=None, filesystem=None, filters=None,
@@ -2711,6 +2714,7 @@ switched to False.""",
     Content of the file as a table (of columns)""",
     _DNF_filter_doc, _parquet_dataset_example)
 
+
 def read_pandas(source, columns=None, **kwargs):
     return read_table(
         source, columns=columns, use_pandas_metadata=True, **kwargs
@@ -2776,6 +2780,7 @@ def write_table(table, where, row_group_size=None, version='1.0',
             except os.error:
                 pass
         raise
+
 
 _write_table_example = """\
 Generate an example PyArrow Table:

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -2985,7 +2985,7 @@ def write_to_dataset(table, root_path, partition_cols=None,
     >>> pq.ParquetDataset('dataset_name_3', use_legacy_dataset=False).files
     ['dataset_name_3/year=2019/part-0.parquet', ...
 
-    Write to a single Parquet file:
+    Write a single Parquet file into the root folder:
 
     >>> pq.write_to_dataset(table, root_path='dataset_name_4',
     ...                     use_legacy_dataset=False)

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -2018,9 +2018,19 @@ Examples
             DeprecationWarning, stacklevel=2)
         return self._metadata.fs
 
-    common_metadata = property(
+    _common_metadata = property(
         operator.attrgetter('_metadata.common_metadata')
     )
+
+    @property
+    def common_metadata(self):
+        """
+        DEPRECATED
+        """
+        warnings.warn(
+            _DEPR_MSG.format("ParquetDataset.common_metadata", ""),
+            DeprecationWarning, stacklevel=2)
+        return self._metadata.common_metadata
 
     @property
     def fragments(self):
@@ -2938,17 +2948,12 @@ def write_to_dataset(table, root_path, partition_cols=None,
     'dataset_name/year=2022/month=5/day=5/202255.parquet',
     'dataset_name/year=2022/month=9/day=13/2022913.parquet']
 
-    Write to single Parquet file:
+    Write to a single Parquet file:
 
     >>> import pyarrow.parquet as pq
     >>> pq.write_to_dataset(table, root_path='dataset_name')
-
-
-
     >>> pq.ParquetDataset('dataset_name/', use_legacy_dataset=False).files
     ['dataset_name/0c7a313fcfee4b31b3380ee480739153.parquet']
-
-
 
     >>> pq.write_to_dataset(table, root_path='dataset_name', use_legacy_dataset=False)
     >>> pq.ParquetDataset('dataset_name/', use_legacy_dataset=False).files

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -237,7 +237,7 @@ class ParquetFile:
     ...                    'month': [3, 5, 7, 9, 11, 12],
     ...                    'day': [1, 5, 9, 13, 17, 23],
     ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-    ...                    'animals': ["Flamingo", "Parot", "Dog", "Horse",
+    ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
     ...                    "Brittle stars", "Centipede"]})
     >>> table = pa.Table.from_pandas(df)
 
@@ -262,7 +262,7 @@ class ParquetFile:
     month: [[3,5,7,9,11,12]]
     day: [[1,5,9,13,17,23]]
     n_legs: [[2,2,4,4,5,100]]
-    animals: [["Flamingo","Parot","Dog","Horse","Brittle stars","Centipede"]]
+    animals: [["Flamingo","Parrot","Dog","Horse","Brittle stars","Centipede"]]
 
     create a ParquetFile object with "animals" column as DictionaryArray:
 
@@ -280,7 +280,7 @@ class ParquetFile:
     day: [[1,5,9,13,17,23]]
     n_legs: [[2,2,4,4,5,100]]
     animals: [  -- dictionary:
-    ["Flamingo","Parot","Dog","Horse","Brittle stars","Centipede"]  -- indices:
+    ["Flamingo","Parrot","Dog","Horse","Brittle stars","Centipede"]  -- indices:
     [0,1,2,3,4,5]]
     """
 
@@ -424,7 +424,7 @@ class ParquetFile:
         month: [[3,5,7,9,11,12]]
         day: [[1,5,9,13,17,23]]
         n_legs: [[2,2,4,4,5,100]]
-        animals: [["Flamingo","Parot","Dog","Horse","Brittle stars","Centipede"]]
+        animals: [["Flamingo","Parrot","Dog","Horse","Brittle stars","Centipede"]]
         """
         column_indices = self._get_column_indices(
             columns, use_pandas_metadata=use_pandas_metadata)
@@ -469,8 +469,8 @@ class ParquetFile:
         month: [[3,5,7,9,11,...,5,7,9,11,12]]
         day: [[1,5,9,13,17,...,5,9,13,17,23]]
         n_legs: [[2,2,4,4,5,...,2,4,4,5,100]]
-        animals: [["Flamingo","Parot","Dog","Horse","Brittle stars",...,
-        "Parot","Dog","Horse","Brittle stars","Centipede"]]
+        animals: [["Flamingo","Parrot","Dog","Horse","Brittle stars",...,
+        "Parrot","Dog","Horse","Brittle stars","Centipede"]]
         """
         column_indices = self._get_column_indices(
             columns, use_pandas_metadata=use_pandas_metadata)
@@ -514,7 +514,7 @@ class ParquetFile:
         RecordBatch
            year  month  day  n_legs   animals
         0  2020      3    1       2  Flamingo
-        1  2022      5    5       2     Parot
+        1  2022      5    5       2     Parrot
         2  2021      7    9       4       Dog
         RecordBatch
            year  month  day  n_legs        animals
@@ -560,7 +560,7 @@ class ParquetFile:
         pyarrow.Table
         animals: string
         ----
-        animals: [["Flamingo","Parot","Dog","Horse","Brittle stars","Centipede"]]
+        animals: [["Flamingo","Parrot","Dog","Horse","Brittle stars","Centipede"]]
         """
         column_indices = self._get_column_indices(
             columns, use_pandas_metadata=use_pandas_metadata)
@@ -786,7 +786,7 @@ Generate an example PyArrow Table and RecordBatch:
 ...                    'month': [3, 5, 7, 9, 11, 12],
 ...                    'day': [1, 5, 9, 13, 17, 23],
 ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-...                    'animals': ["Flamingo", "Parot", "Dog", "Horse",
+...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
 ...                    "Brittle stars", "Centipede"]})
 >>> table = pa.Table.from_pandas(df)
 >>> batch = pa.RecordBatch.from_pandas(df)
@@ -804,7 +804,7 @@ and write the Table into the Parquet file:
 >>> pq.read_table('example.parquet').to_pandas()
    year  month  day  n_legs        animals
 0  2020      3    1       2       Flamingo
-1  2022      5    5       2          Parot
+1  2022      5    5       2          Parrot
 2  2021      7    9       4            Dog
 3  2022      9   13       4          Horse
 4  2019     11   17       5  Brittle stars
@@ -822,7 +822,7 @@ and write the RecordBatch into the Parquet file:
 >>> pq.read_table('example2.parquet').to_pandas()
    year  month  day  n_legs        animals
 0  2020      3    1       2       Flamingo
-1  2022      5    5       2          Parot
+1  2022      5    5       2          Parrot
 2  2021      7    9       4            Dog
 3  2022      9   13       4          Horse
 4  2019     11   17       5  Brittle stars
@@ -1569,7 +1569,7 @@ Generate an example PyArrow Table and write it to a partitioned dataset:
 ...                    'month': [3, 5, 7, 9, 11, 12],
 ...                    'day': [1, 5, 9, 13, 17, 23],
 ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-...                    'animals': ["Flamingo", "Parot", "Dog", "Horse",
+...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
 ...                    "Brittle stars", "Centipede"]})
 >>> table = pa.Table.from_pandas(df)
 
@@ -1589,7 +1589,7 @@ and read the data:
 1       2       Flamingo  2020     3   1
 2     100      Centipede  2021    12  23
 3       4            Dog  2021     7   9
-4       2          Parot  2022     5   5
+4       2          Parrot  2022     5   5
 5       4          Horse  2022     9  13
 
 create a ParquetDataset object with filter:
@@ -2294,7 +2294,7 @@ class _ParquetDatasetV2:
         ...                    'month': [3, 5, 7, 9, 11, 12],
         ...                    'day': [1, 5, 9, 13, 17, 23],
         ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animals': ["Flamingo", "Parot", "Dog", "Horse",
+        ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
         ...                    "Brittle stars", "Centipede"]})
         >>> table = pa.Table.from_pandas(df)
 
@@ -2520,7 +2520,7 @@ Generate an example PyArrow Table and write it to a partitioned dataset:
 ...                    'month': [3, 5, 7, 9, 11, 12],
 ...                    'day': [1, 5, 9, 13, 17, 23],
 ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-...                    'animals': ["Flamingo", "Parot", "Dog", "Horse",
+...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
 ...                    "Brittle stars", "Centipede"]})
 >>> table = pa.Table.from_pandas(df)
 
@@ -2536,7 +2536,7 @@ Read the data:
 1       2       Flamingo  2020     3   1
 2     100      Centipede  2021    12  23
 3       4            Dog  2021     7   9
-4       2          Parot  2022     5   5
+4       2         ßParrot  2022     5   5
 5       4          Horse  2022     9  13
 
 
@@ -2548,7 +2548,7 @@ n_legs: int64
 animals: string
 ----
 n_legs: [[5],[2],...,[2],[4]]
-animals: [["Brittle stars"],["Flamingo"],...,["Parot"],["Horse"]]
+animals: [["Brittle stars"],["Flamingo"],...,["Parrot"],["Horse"]]
 
 Read a subset of columns and read one column as DictionaryArray:
 
@@ -2563,7 +2563,7 @@ animals: [  -- dictionary:
 [0],  -- dictionary:
 ["Flamingo"]  -- indices:
 [0],...,  -- dictionary:
-["Parot"]  -- indices:
+["Parrot"]  -- indices:
 [0],  -- dictionary:
 ["Horse"]  -- indices:
 [0]]
@@ -2573,7 +2573,7 @@ Read the table with filter:
 >>> pq.read_table('dataset_name', columns=["n_legs", "animals"], filters=[('n_legs','<',4)]).to_pandas()
    n_legs   animals
 0       2  Flamingo
-1       2     Parot
+1       2     Parrot
 
 You can also read data from a single Parquet file:
 
@@ -2584,7 +2584,7 @@ You can also read data from a single Parquet file:
 1       2       Flamingo  2020     3   1
 2     100      Centipede  2021    12  23
 3       4            Dog  2021     7   9
-4       2          Parot  2022     5   5
+4       2         ßParrot  2022     5   5
 5       4          Horse  2022     9  13
 """
 
@@ -2776,7 +2776,7 @@ Generate an example PyArrow Table:
 ...                    'month': [3, 5, 7, 9, 11, 12],
 ...                    'day': [1, 5, 9, 13, 17, 23],
 ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-...                    'animals': ["Flamingo", "Parot", "Dog", "Horse",
+...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
 ...                    "Brittle stars", "Centipede"]})
 >>> table = pa.Table.from_pandas(df)
 
@@ -2859,13 +2859,13 @@ def write_to_dataset(table, root_path, partition_cols=None,
     Parameters
     ----------
     table : pyarrow.Table
-    root_path : str, pathlib.Path
+    root_path : str, pathlib.Pathß
         The root directory of the dataset
     filesystem : FileSystem, default None
         If nothing passed, paths assumed to be found in the local on-disk
         filesystem
     partition_cols : list,
-        Column names by which to partition the dataset
+        Column names by which to partition the dataset.
         Columns are partitioned in the order they are given
     partition_filename_cb : callable,
         A callback function that takes the partition key(s) as an argument
@@ -2883,6 +2883,76 @@ def write_to_dataset(table, root_path, partition_cols=None,
         Using `metadata_collector` in kwargs allows one to collect the
         file metadata instances of dataset pieces. The file paths in the
         ColumnChunkMetaData will be set relative to `root_path`.
+
+    Examples
+    --------
+    Generate an example PyArrow Table:
+
+    >>> import pyarrow as pa
+    >>> import pandas as pd
+    >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+    ...                    'month': [3, 5, 7, 9, 11, 12],
+    ...                    'day': [1, 5, 9, 13, 17, 23],
+    ...                    'n_legs': [2, 2, 4, 4, 5, 100],
+    ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
+    ...                    "Brittle stars", "Centipede"]})
+    >>> table = pa.Table.from_pandas(df)
+
+    and write it to a partitioned dataset:
+
+    >>> pq.write_to_dataset(table, root_path='dataset_name',
+    ...                     partition_cols=['year', 'month', 'day'],
+    ...                     use_legacy_dataset=False
+    ...                    )
+    >>> pq.ParquetDataset('dataset_name/', use_legacy_dataset=False).files
+    ['dataset_name/year=2019/month=11/day=17/part-0.parquet',
+    'dataset_name/year=2020/month=3/day=1/part-0.parquet',
+    'dataset_name/year=2021/month=12/day=23/part-0.parquet',
+    'dataset_name/year=2021/month=7/day=9/part-0.parquet',
+    'dataset_name/year=2022/month=5/day=5/part-0.parquet',
+    'dataset_name/year=2022/month=9/day=13/part-0.parquet']
+
+    Use old Arrow Dataset API:
+
+    >>> pq.write_to_dataset(table, root_path='dataset_name',
+    ...                     partition_cols=['year', 'month', 'day'])
+    >>> pq.ParquetDataset('dataset_name/', use_legacy_dataset=False).files
+    ['dataset_name/year=2019/month=11/day=17/59cfd909d9a54fe49540edb359a19331.parquet',
+    'dataset_name/year=2020/month=3/day=1/1e2cf97bb5db400f832900628081e9a0.parquet',
+    'dataset_name/year=2021/month=12/day=23/93f54630e5a3483a8f6aa808a7e9b469.parquet',
+    'dataset_name/year=2021/month=7/day=9/9a34bf7a2f37482b99f77d6895f09b88.parquet',
+    'dataset_name/year=2022/month=5/day=5/de2e52d6142940dca04558335a9af892.parquet',
+    'dataset_name/year=2022/month=9/day=13/9307aabc3d8149b3acb8f3a31a07dbd7.parquet']
+
+    Use old Arrow Dataset API and override the partition filename:
+
+    >>> pq.write_to_dataset(table, root_path='dataset_name',
+    ...                     partition_cols=['year', 'month', 'day'],
+    ...                     partition_filename_cb=lambda x: str(x[0]) + str(x[1]) + str(x[2])  + '.parquet'
+    ...                    )
+    >>> pq.ParquetDataset('dataset_name/', use_legacy_dataset=False).files
+    ['dataset_name/year=2019/month=11/day=17/20191117.parquet',
+    'dataset_name/year=2020/month=3/day=1/202031.parquet',
+    'dataset_name/year=2021/month=12/day=23/20211223.parquet',
+    'dataset_name/year=2021/month=7/day=9/202179.parquet',
+    'dataset_name/year=2022/month=5/day=5/202255.parquet',
+    'dataset_name/year=2022/month=9/day=13/2022913.parquet']
+
+    Write to single Parquet file:
+
+    >>> import pyarrow.parquet as pq
+    >>> pq.write_to_dataset(table, root_path='dataset_name')
+
+
+
+    >>> pq.ParquetDataset('dataset_name/', use_legacy_dataset=False).files
+    ['dataset_name/0c7a313fcfee4b31b3380ee480739153.parquet']
+
+
+
+    >>> pq.write_to_dataset(table, root_path='dataset_name', use_legacy_dataset=False)
+    >>> pq.ParquetDataset('dataset_name/', use_legacy_dataset=False).files
+    ['dataset_name/part-0.parquet']
     """
     if use_legacy_dataset is None:
         # if a new filesystem is passed -> default to new implementation

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -239,11 +239,11 @@ class ParquetFile:
     >>> import pyarrow.parquet as pq
     >>> pq.write_table(table, 'example.parquet')
 
-    create a ParquetFile object from the Parqet file:
+    Create a ``ParquetFile`` object from the Parquet file:
 
     >>> parquet_file = pq.ParquetFile('example.parquet')
 
-    read the data:
+    Read the data:
 
     >>> parquet_file.read()
     pyarrow.Table
@@ -2940,7 +2940,7 @@ def write_to_dataset(table, root_path, partition_cols=None,
     Parameters
     ----------
     table : pyarrow.Table
-    root_path : str, pathlib.Pathß
+    root_path : str, pathlib.Path
         The root directory of the dataset
     filesystem : FileSystem, default None
         If nothing passed, paths assumed to be found in the local on-disk

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -2058,7 +2058,8 @@ Examples
         >>> pq.write_to_dataset(table, root_path='dataset_name_fragments',
         ...                     partition_cols=['year'],
         ...                     use_legacy_dataset=False)
-        >>> dataset = pq._ParquetDatasetV2('dataset_name_fragments/')
+        >>> dataset = pq.ParquetDataset('dataset_name_files/',
+        ...                             use_legacy_dataset=False)
 
         List the fragments:
 
@@ -2089,7 +2090,8 @@ Examples
         >>> pq.write_to_dataset(table, root_path='dataset_name_files',
         ...                     partition_cols=['year'],
         ...                     use_legacy_dataset=False)
-        >>> dataset = pq._ParquetDatasetV2('dataset_name_files/')
+        >>> dataset = pq.ParquetDataset('dataset_name_files/',
+        ...                             use_legacy_dataset=False)
 
         List the files:
 

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -231,15 +231,10 @@ class ParquetFile:
 
     Generate an example PyArrow Table and write it to Parquet file:
 
-    >>> import pandas as pd
     >>> import pyarrow as pa
-    >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
-    ...                    'month': [3, 5, 7, 9, 11, 12],
-    ...                    'day': [1, 5, 9, 13, 17, 23],
-    ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-    ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
-    ...                    "Brittle stars", "Centipede"]})
-    >>> table = pa.Table.from_pandas(df)
+    >>> table = pa.table({'n_legs': [2, 2, 4, 4, 5, 100],
+    ...                   'animal': ["Flamingo", "Parrot", "Dog", "Horse",
+    ...                              "Brittle stars", "Centipede"]})
 
     >>> import pyarrow.parquet as pq
     >>> pq.write_table(table, 'example.parquet')
@@ -252,33 +247,21 @@ class ParquetFile:
 
     >>> parquet_file.read()
     pyarrow.Table
-    year: int64
-    month: int64
-    day: int64
     n_legs: int64
     animal: string
     ----
-    year: [[2020,2022,2021,2022,2019,2021]]
-    month: [[3,5,7,9,11,12]]
-    day: [[1,5,9,13,17,23]]
     n_legs: [[2,2,4,4,5,100]]
     animal: [["Flamingo","Parrot","Dog","Horse","Brittle stars","Centipede"]]
 
-    create a ParquetFile object with "animals" column as DictionaryArray:
+    create a ParquetFile object with "animal" column as DictionaryArray:
 
     >>> parquet_file = pq.ParquetFile('example.parquet',
     ...                               read_dictionary=["animal"])
     >>> parquet_file.read()
     pyarrow.Table
-    year: int64
-    month: int64
-    day: int64
     n_legs: int64
     animal: dictionary<values=string, indices=int32, ordered=0>
     ----
-    year: [[2020,2022,2021,2022,2019,2021]]
-    month: [[3,5,7,9,11,12]]
-    day: [[1,5,9,13,17,23]]
     n_legs: [[2,2,4,4,5,100]]
     animal: [  -- dictionary:
     ["Flamingo","Parrot",...,"Brittle stars","Centipede"]  -- indices:
@@ -343,15 +326,10 @@ class ParquetFile:
         --------
         Generate an example Parquet file:
 
-        >>> import pandas as pd
         >>> import pyarrow as pa
-        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
-        ...                    'month': [3, 5, 7, 9, 11, 12],
-        ...                    'day': [1, 5, 9, 13, 17, 23],
-        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
-        ...                    "Brittle stars", "Centipede"]})
-        >>> table = pa.Table.from_pandas(df)
+        >>> table = pa.table({'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                   'animal': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                              "Brittle stars", "Centipede"]})
         >>> import pyarrow.parquet as pq
         >>> pq.write_table(table, 'example.parquet')
         >>> parquet_file = pq.ParquetFile('example.parquet')
@@ -359,13 +337,8 @@ class ParquetFile:
         Read the Arrow schema:
 
         >>> parquet_file.schema_arrow
-        year: int64
-        month: int64
-        day: int64
         n_legs: int64
         animal: string
-        -- schema metadata --
-        pandas: '{"index_columns": [{"kind": "range", "name": null,...
         """
         return self.reader.schema_arrow
 
@@ -376,15 +349,10 @@ class ParquetFile:
 
         Examples
         --------
-        >>> import pandas as pd
         >>> import pyarrow as pa
-        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
-        ...                    'month': [3, 5, 7, 9, 11, 12],
-        ...                    'day': [1, 5, 9, 13, 17, 23],
-        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
-        ...                    "Brittle stars", "Centipede"]})
-        >>> table = pa.Table.from_pandas(df)
+        >>> table = pa.table({'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                   'animal': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                              "Brittle stars", "Centipede"]})
         >>> import pyarrow.parquet as pq
         >>> pq.write_table(table, 'example.parquet')
         >>> parquet_file = pq.ParquetFile('example.parquet')
@@ -420,30 +388,19 @@ class ParquetFile:
 
         Examples
         --------
-        >>> import pandas as pd
         >>> import pyarrow as pa
-        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
-        ...                    'month': [3, 5, 7, 9, 11, 12],
-        ...                    'day': [1, 5, 9, 13, 17, 23],
-        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
-        ...                    "Brittle stars", "Centipede"]})
-        >>> table = pa.Table.from_pandas(df)
+        >>> table = pa.table({'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                   'animal': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                              "Brittle stars", "Centipede"]})
         >>> import pyarrow.parquet as pq
         >>> pq.write_table(table, 'example.parquet')
         >>> parquet_file = pq.ParquetFile('example.parquet')
 
         >>> parquet_file.read_row_group(0)
         pyarrow.Table
-        year: int64
-        month: int64
-        day: int64
         n_legs: int64
         animal: string
         ----
-        year: [[2020,2022,2021,2022,2019,2021]]
-        month: [[3,5,7,9,11,12]]
-        day: [[1,5,9,13,17,23]]
         n_legs: [[2,2,4,4,5,100]]
         animal: [["Flamingo","Parrot",...,"Brittle stars","Centipede"]]
         """
@@ -478,30 +435,19 @@ class ParquetFile:
 
         Examples
         --------
-        >>> import pandas as pd
         >>> import pyarrow as pa
-        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
-        ...                    'month': [3, 5, 7, 9, 11, 12],
-        ...                    'day': [1, 5, 9, 13, 17, 23],
-        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
-        ...                    "Brittle stars", "Centipede"]})
-        >>> table = pa.Table.from_pandas(df)
+        >>> table = pa.table({'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                   'animal': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                              "Brittle stars", "Centipede"]})
         >>> import pyarrow.parquet as pq
         >>> pq.write_table(table, 'example.parquet')
         >>> parquet_file = pq.ParquetFile('example.parquet')
 
         >>> parquet_file.read_row_groups([0,0])
         pyarrow.Table
-        year: int64
-        month: int64
-        day: int64
         n_legs: int64
         animal: string
         ----
-        year: [[2020,2022,2021,2022,2019,...,2022,2021,2022,2019,2021]]
-        month: [[3,5,7,9,11,...,5,7,9,11,12]]
-        day: [[1,5,9,13,17,...,5,9,13,17,23]]
         n_legs: [[2,2,4,4,5,...,2,4,4,5,100]]
         animal: [["Flamingo","Parrot","Dog",...,"Brittle stars","Centipede"]]
         """
@@ -542,15 +488,10 @@ class ParquetFile:
         --------
         Generate an example Parquet file:
 
-        >>> import pandas as pd
         >>> import pyarrow as pa
-        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
-        ...                    'month': [3, 5, 7, 9, 11, 12],
-        ...                    'day': [1, 5, 9, 13, 17, 23],
-        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
-        ...                    "Brittle stars", "Centipede"]})
-        >>> table = pa.Table.from_pandas(df)
+        >>> table = pa.table({'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                   'animal': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                              "Brittle stars", "Centipede"]})
         >>> import pyarrow.parquet as pq
         >>> pq.write_table(table, 'example.parquet')
         >>> parquet_file = pq.ParquetFile('example.parquet')
@@ -562,15 +503,15 @@ class ParquetFile:
         ...     print(i.to_pandas())
         ...
         RecordBatch
-           year  month  day  n_legs    animal
-        0  2020      3    1       2  Flamingo
-        1  2022      5    5       2    Parrot
-        2  2021      7    9       4       Dog
+           n_legs    animal
+        0       2  Flamingo
+        1       2    Parrot
+        2       4       Dog
         RecordBatch
-           year  month  day  n_legs         animal
-        0  2022      9   13       4          Horse
-        1  2019     11   17       5  Brittle stars
-        2  2021     12   23     100      Centipede
+           n_legs         animal
+        0       4          Horse
+        1       5  Brittle stars
+        2     100      Centipede
         """
         if row_groups is None:
             row_groups = range(0, self.metadata.num_row_groups)
@@ -608,15 +549,10 @@ class ParquetFile:
         --------
         Generate an example Parquet file:
 
-        >>> import pandas as pd
         >>> import pyarrow as pa
-        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
-        ...                    'month': [3, 5, 7, 9, 11, 12],
-        ...                    'day': [1, 5, 9, 13, 17, 23],
-        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
-        ...                    "Brittle stars", "Centipede"]})
-        >>> table = pa.Table.from_pandas(df)
+        >>> table = pa.table({'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                   'animal': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                              "Brittle stars", "Centipede"]})
         >>> import pyarrow.parquet as pq
         >>> pq.write_table(table, 'example.parquet')
         >>> parquet_file = pq.ParquetFile('example.parquet')
@@ -656,15 +592,10 @@ class ParquetFile:
 
         Examples
         --------
-        >>> import pandas as pd
         >>> import pyarrow as pa
-        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
-        ...                    'month': [3, 5, 7, 9, 11, 12],
-        ...                    'day': [1, 5, 9, 13, 17, 23],
-        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
-        ...                    "Brittle stars", "Centipede"]})
-        >>> table = pa.Table.from_pandas(df)
+        >>> table = pa.table({'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                   'animal': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                              "Brittle stars", "Centipede"]})
         >>> import pyarrow.parquet as pq
         >>> pq.write_table(table, 'example.parquet')
         >>> parquet_file = pq.ParquetFile('example.parquet')
@@ -860,16 +791,14 @@ write_batch_size : int, default None
 _parquet_writer_example_doc = """\
 Generate an example PyArrow Table and RecordBatch:
 
->>> import pandas as pd
 >>> import pyarrow as pa
->>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
-...                    'month': [3, 5, 7, 9, 11, 12],
-...                    'day': [1, 5, 9, 13, 17, 23],
-...                    'n_legs': [2, 2, 4, 4, 5, 100],
-...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
-...                    "Brittle stars", "Centipede"]})
->>> table = pa.Table.from_pandas(df)
->>> batch = pa.RecordBatch.from_pandas(df)
+>>> table = pa.table({'n_legs': [2, 2, 4, 4, 5, 100],
+...                   'animal': ["Flamingo", "Parrot", "Dog", "Horse",
+...                              "Brittle stars", "Centipede"]})
+>>> batch = pa.record_batch([[2, 2, 4, 4, 5, 100],
+...                         ["Flamingo", "Parrot", "Dog", "Horse",
+...                          "Brittle stars", "Centipede"]],
+...                         names=['n_legs', 'animal'])
 
 create a ParquetWriter object:
 
@@ -882,13 +811,13 @@ and write the Table into the Parquet file:
 >>> writer.close()
 
 >>> pq.read_table('example.parquet').to_pandas()
-   year  month  day  n_legs        animals
-0  2020      3    1       2       Flamingo
-1  2022      5    5       2         Parrot
-2  2021      7    9       4            Dog
-3  2022      9   13       4          Horse
-4  2019     11   17       5  Brittle stars
-5  2021     12   23     100      Centipede
+   n_legs         animal
+0       2       Flamingo
+1       2         Parrot
+2       4            Dog
+3       4          Horse
+4       5  Brittle stars
+5     100      Centipede
 
 create a ParquetWriter object for the RecordBatch:
 
@@ -900,13 +829,13 @@ and write the RecordBatch into the Parquet file:
 >>> writer2.close()
 
 >>> pq.read_table('example2.parquet').to_pandas()
-   year  month  day  n_legs        animals
-0  2020      3    1       2       Flamingo
-1  2022      5    5       2         Parrot
-2  2021      7    9       4            Dog
-3  2022      9   13       4          Horse
-4  2019     11   17       5  Brittle stars
-5  2021     12   23     100      Centipede
+   n_legs         animal
+0       2       Flamingo
+1       2         Parrot
+2       4            Dog
+3       4          Horse
+4       5  Brittle stars
+5     100      Centipede
 """
 
 
@@ -1619,18 +1548,14 @@ _parquet_dataset_example = """\
 Generate an example PyArrow Table and write it to a partitioned dataset:
 
 >>> import pyarrow as pa
->>> import pandas as pd
->>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
-...                    'month': [3, 5, 7, 9, 11, 12],
-...                    'day': [1, 5, 9, 13, 17, 23],
-...                    'n_legs': [2, 2, 4, 4, 5, 100],
-...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
-...                    "Brittle stars", "Centipede"]})
->>> table = pa.Table.from_pandas(df)
+>>> table = pa.table({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+...                   'n_legs': [2, 2, 4, 4, 5, 100],
+...                   'animal': ["Flamingo", "Parrot", "Dog", "Horse",
+...                              "Brittle stars", "Centipede"]})
 
 >>> import pyarrow.parquet as pq
 >>> pq.write_to_dataset(table, root_path='dataset_name',
-...                     partition_cols=['year', 'month', 'day'],
+...                     partition_cols=['year'],
 ...                     use_legacy_dataset=False)
 
 create a ParquetDataset object from the dataset source:
@@ -1640,22 +1565,22 @@ create a ParquetDataset object from the dataset source:
 and read the data:
 
 >>> dataset.read().to_pandas()
-   n_legs         animal  year month day
-0       5  Brittle stars  2019    11  17
-1       2       Flamingo  2020     3   1
-2     100      Centipede  2021    12  23
-3       4            Dog  2021     7   9
-4       2         Parrot  2022     5   5
-5       4          Horse  2022     9  13
+   n_legs         animal  year
+0       5  Brittle stars  2019
+1       2       Flamingo  2020
+2       4            Dog  2021
+3     100      Centipede  2021
+4       2         Parrot  2022
+5       4          Horse  2022
 
 create a ParquetDataset object with filter:
 
 >>> dataset = pq.ParquetDataset('dataset_name/', use_legacy_dataset=False,
 ...                             filters=[('n_legs','=',4)])
 >>> dataset.read().to_pandas()
-   n_legs animal  year month day
-0       4    Dog  2021     7   9
-1       4  Horse  2022     9  13
+   n_legs animal  year
+0       4    Dog  2021
+1       4  Horse  2022
 """
 
 
@@ -1906,17 +1831,13 @@ Examples
         Generate an example dataset:
 
         >>> import pyarrow as pa
-        >>> import pandas as pd
-        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
-        ...                    'month': [3, 5, 7, 9, 11, 12],
-        ...                    'day': [1, 5, 9, 13, 17, 23],
-        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
-        ...                    "Brittle stars", "Centipede"]})
-        >>> table = pa.Table.from_pandas(df)
+        >>> table = pa.table({'year': [2020, 2022, 2021, 2022, 2019, 2021],         
+        ...                   'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                   'animal': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                              "Brittle stars", "Centipede"]})
         >>> import pyarrow.parquet as pq
         >>> pq.write_to_dataset(table, root_path='dataset_name_read',
-        ...                     partition_cols=['year', 'month', 'day'],
+        ...                     partition_cols=['year'],
         ...                     use_legacy_dataset=False)
         >>> dataset = pq.ParquetDataset('dataset_name_read/',
         ...                             use_legacy_dataset=False)
@@ -1974,15 +1895,13 @@ Examples
         >>> import pyarrow as pa
         >>> import pandas as pd
         >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
-        ...                    'month': [3, 5, 7, 9, 11, 12],
-        ...                    'day': [1, 5, 9, 13, 17, 23],
         ...                    'n_legs': [2, 2, 4, 4, 5, 100],
         ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
         ...                    "Brittle stars", "Centipede"]})
         >>> table = pa.Table.from_pandas(df)
         >>> import pyarrow.parquet as pq
         >>> pq.write_to_dataset(table, root_path='dataset_name_read_pandas',
-        ...                     partition_cols=['year', 'month', 'day'],
+        ...                     partition_cols=['year'],
         ...                     use_legacy_dataset=False)
         >>> dataset = pq.ParquetDataset('dataset_name_read_pandas/',
         ...                             use_legacy_dataset=False)
@@ -2136,17 +2055,13 @@ Examples
         Generate an example dataset:
 
         >>> import pyarrow as pa
-        >>> import pandas as pd
-        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
-        ...                    'month': [3, 5, 7, 9, 11, 12],
-        ...                    'day': [1, 5, 9, 13, 17, 23],
-        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
-        ...                    "Brittle stars", "Centipede"]})
-        >>> table = pa.Table.from_pandas(df)
+        >>> table = pa.table({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+        ...                   'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                   'animal': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                              "Brittle stars", "Centipede"]})
         >>> import pyarrow.parquet as pq
         >>> pq.write_to_dataset(table, root_path='dataset_name_fragments',
-        ...                     partition_cols=['year', 'month', 'day'],
+        ...                     partition_cols=['year'],
         ...                     use_legacy_dataset=False)
         >>> dataset = pq._ParquetDatasetV2('dataset_name_fragments/')
 
@@ -2171,24 +2086,20 @@ Examples
         Generate an example dataset:
 
         >>> import pyarrow as pa
-        >>> import pandas as pd
-        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
-        ...                    'month': [3, 5, 7, 9, 11, 12],
-        ...                    'day': [1, 5, 9, 13, 17, 23],
-        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
-        ...                    "Brittle stars", "Centipede"]})
-        >>> table = pa.Table.from_pandas(df)
+        >>> table = pa.table({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+        ...                   'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                   'animal': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                              "Brittle stars", "Centipede"]})
         >>> import pyarrow.parquet as pq
         >>> pq.write_to_dataset(table, root_path='dataset_name_files',
-        ...                     partition_cols=['year', 'month', 'day'],
+        ...                     partition_cols=['year'],
         ...                     use_legacy_dataset=False)
         >>> dataset = pq._ParquetDatasetV2('dataset_name_files/')
 
         List the files:
 
         >>> dataset.files
-        ['dataset_name_files/year=2019/month=11/day=17/part-0.parquet', ...
+        ['dataset_name_files/year=2019/part-0.parquet', ...
         """
         raise NotImplementedError(
             "To use this property set 'use_legacy_dataset=False' while "
@@ -2271,18 +2182,13 @@ class _ParquetDatasetV2:
     Generate an example PyArrow Table and write it to a partitioned dataset:
 
     >>> import pyarrow as pa
-    >>> import pandas as pd
-    >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
-    ...                    'month': [3, 5, 7, 9, 11, 12],
-    ...                    'day': [1, 5, 9, 13, 17, 23],
-    ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-    ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
-    ...                    "Brittle stars", "Centipede"]})
-    >>> table = pa.Table.from_pandas(df)
-
+    >>> table = pa.table({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+    ...                   'n_legs': [2, 2, 4, 4, 5, 100],
+    ...                   'animal': ["Flamingo", "Parrot", "Dog", "Horse",
+    ...                              "Brittle stars", "Centipede"]})
     >>> import pyarrow.parquet as pq
     >>> pq.write_to_dataset(table, root_path='dataset_v2',
-    ...                     partition_cols=['year', 'month', 'day'],
+    ...                     partition_cols=['year'],
     ...                     use_legacy_dataset=False)
 
     create a _ParquetDatasetV2 object from the dataset source:
@@ -2292,22 +2198,22 @@ class _ParquetDatasetV2:
     and read the data:
 
     >>> dataset.read().to_pandas()
-       n_legs         animal  year month day
-    0       5  Brittle stars  2019    11  17
-    1       2       Flamingo  2020     3   1
-    2     100      Centipede  2021    12  23
-    3       4            Dog  2021     7   9
-    4       2         Parrot  2022     5   5
-    5       4          Horse  2022     9  13
+       n_legs         animal  year
+    0       5  Brittle stars  2019
+    1       2       Flamingo  2020
+    2       4            Dog  2021
+    3     100      Centipede  2021
+    4       2         Parrot  2022
+    5       4          Horse  2022
 
     create a _ParquetDatasetV2 object with filter:
 
     >>> dataset = pq._ParquetDatasetV2('dataset_v2/',
     ...                                filters=[('n_legs','=',4)])
     >>> dataset.read().to_pandas()
-       n_legs animal  year month day
-    0       4    Dog  2021     7   9
-    1       4  Horse  2022     9  13
+       n_legs animal  year
+    0       4    Dog  2021
+    1       4  Horse  2022
     """
 
     def __init__(self, path_or_paths, filesystem=None, filters=None,
@@ -2417,17 +2323,13 @@ class _ParquetDatasetV2:
         Generate an example dataset:
 
         >>> import pyarrow as pa
-        >>> import pandas as pd
-        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
-        ...                    'month': [3, 5, 7, 9, 11, 12],
-        ...                    'day': [1, 5, 9, 13, 17, 23],
-        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
-        ...                    "Brittle stars", "Centipede"]})
-        >>> table = pa.Table.from_pandas(df)
+        >>> table = pa.table({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+        ...                   'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                   'animal': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                              "Brittle stars", "Centipede"]})
         >>> import pyarrow.parquet as pq
         >>> pq.write_to_dataset(table, root_path='dataset_v2_schema',
-        ...                     partition_cols=['year', 'month', 'day'],
+        ...                     partition_cols=['year'],
         ...                     use_legacy_dataset=False)
         >>> dataset = pq._ParquetDatasetV2('dataset_v2_schema/')
 
@@ -2437,10 +2339,6 @@ class _ParquetDatasetV2:
         n_legs: int64
         animal: string
         year: dictionary<values=int32, indices=int32, ordered=0>
-        month: dictionary<values=int32, indices=int32, ordered=0>
-        day: dictionary<values=int32, indices=int32, ordered=0>
-        -- schema metadata --
-        pandas: '{"index_columns": [{"kind": "range", "name": null, ...
         """
         return self._dataset.schema
 
@@ -2470,17 +2368,13 @@ class _ParquetDatasetV2:
         Generate an example dataset:
 
         >>> import pyarrow as pa
-        >>> import pandas as pd
-        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
-        ...                    'month': [3, 5, 7, 9, 11, 12],
-        ...                    'day': [1, 5, 9, 13, 17, 23],
-        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
-        ...                    "Brittle stars", "Centipede"]})
-        >>> table = pa.Table.from_pandas(df)
+        >>> table = pa.table({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+        ...                   'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                   'animal': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                              "Brittle stars", "Centipede"]})
         >>> import pyarrow.parquet as pq
         >>> pq.write_to_dataset(table, root_path='dataset_v2_read',
-        ...                     partition_cols=['year', 'month', 'day'],
+        ...                     partition_cols=['year'],
         ...                     use_legacy_dataset=False)
         >>> dataset = pq._ParquetDatasetV2('dataset_v2_read/')
 
@@ -2531,17 +2425,13 @@ class _ParquetDatasetV2:
         Generate an example dataset:
 
         >>> import pyarrow as pa
-        >>> import pandas as pd
-        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
-        ...                    'month': [3, 5, 7, 9, 11, 12],
-        ...                    'day': [1, 5, 9, 13, 17, 23],
-        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
-        ...                    "Brittle stars", "Centipede"]})
-        >>> table = pa.Table.from_pandas(df)
+        >>> table = pa.table({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+        ...                   'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                   'animal': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                              "Brittle stars", "Centipede"]})
         >>> import pyarrow.parquet as pq
         >>> pq.write_to_dataset(table, root_path='dataset_v2_read_pandas',
-        ...                     partition_cols=['year', 'month', 'day'],
+        ...                     partition_cols=['year'],
         ...                     use_legacy_dataset=False)
         >>> dataset = pq._ParquetDatasetV2('dataset_v2_read_pandas/')
 
@@ -2577,17 +2467,13 @@ class _ParquetDatasetV2:
         Generate an example dataset:
 
         >>> import pyarrow as pa
-        >>> import pandas as pd
-        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
-        ...                    'month': [3, 5, 7, 9, 11, 12],
-        ...                    'day': [1, 5, 9, 13, 17, 23],
-        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
-        ...                    "Brittle stars", "Centipede"]})
-        >>> table = pa.Table.from_pandas(df)
+        >>> table = pa.table({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+        ...                   'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                   'animal': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                              "Brittle stars", "Centipede"]})
         >>> import pyarrow.parquet as pq
         >>> pq.write_to_dataset(table, root_path='dataset_v2_fragments',
-        ...                     partition_cols=['year', 'month', 'day'],
+        ...                     partition_cols=['year'],
         ...                     use_legacy_dataset=False)
         >>> dataset = pq._ParquetDatasetV2('dataset_v2_fragments/')
 
@@ -2608,24 +2494,20 @@ class _ParquetDatasetV2:
         Generate an example dataset:
 
         >>> import pyarrow as pa
-        >>> import pandas as pd
-        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
-        ...                    'month': [3, 5, 7, 9, 11, 12],
-        ...                    'day': [1, 5, 9, 13, 17, 23],
-        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
-        ...                    "Brittle stars", "Centipede"]})
-        >>> table = pa.Table.from_pandas(df)
+        >>> table = pa.table({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+        ...                   'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                   'animal': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                              "Brittle stars", "Centipede"]})
         >>> import pyarrow.parquet as pq
         >>> pq.write_to_dataset(table, root_path='dataset_v2_files',
-        ...                     partition_cols=['year', 'month', 'day'],
+        ...                     partition_cols=['year'],
         ...                     use_legacy_dataset=False)
         >>> dataset = pq._ParquetDatasetV2('dataset_v2_files/')
 
         List the files:
 
         >>> dataset.files
-        ['dataset_v2_files/year=2019/month=11/day=17/part-0.parquet', ...
+        ['dataset_v2_files/year=2019/part-0.parquet', ...
         """
         return self._dataset.files
 
@@ -2724,51 +2606,46 @@ Examples
 Generate an example PyArrow Table and write it to a partitioned dataset:
 
 >>> import pyarrow as pa
->>> import pandas as pd
->>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
-...                    'month': [3, 5, 7, 9, 11, 12],
-...                    'day': [1, 5, 9, 13, 17, 23],
-...                    'n_legs': [2, 2, 4, 4, 5, 100],
-...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
-...                    "Brittle stars", "Centipede"]})
->>> table = pa.Table.from_pandas(df)
-
+>>> table = pa.table({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+...                   'n_legs': [2, 2, 4, 4, 5, 100],
+...                   'animal': ["Flamingo", "Parrot", "Dog", "Horse",
+...                              "Brittle stars", "Centipede"]})
 >>> import pyarrow.parquet as pq
 >>> pq.write_to_dataset(table, root_path='dataset_name_2',
-...                     partition_cols=['year', 'month', 'day'])
+...                     partition_cols=['year'])
 
 Read the data:
 
 >>> pq.read_table('dataset_name_2').to_pandas()
-   n_legs        animals  year month day
-0       5  Brittle stars  2019    11  17
-1       2       Flamingo  2020     3   1
-2     100      Centipede  2021    12  23
-3       4            Dog  2021     7   9
-4       2         Parrot  2022     5   5
-5       4          Horse  2022     9  13
+   n_legs         animal  year
+0       5  Brittle stars  2019
+1       2       Flamingo  2020
+2       4            Dog  2021
+3     100      Centipede  2021
+4       2         Parrot  2022
+5       4          Horse  2022
 
 
 Read only a subset of columns:
 
->>> pq.read_table('dataset_name_2', columns=["n_legs", "animals"])
+>>> pq.read_table('dataset_name_2', columns=["n_legs", "animal"])
 pyarrow.Table
 n_legs: int64
-animals: string
+animal: string
 ----
 n_legs: [[5],[2],...,[2],[4]]
-animals: [["Brittle stars"],["Flamingo"],...,["Parrot"],["Horse"]]
+animal: [["Brittle stars"],["Flamingo"],...,["Parrot"],["Horse"]]
 
 Read a subset of columns and read one column as DictionaryArray:
 
->>> pq.read_table('dataset_name_2', columns=["n_legs", "animals"],
-...               read_dictionary=["animals"])
+>>> pq.read_table('dataset_name_2', columns=["n_legs", "animal"],
+...               read_dictionary=["animal"])
 pyarrow.Table
 n_legs: int64
-animals: dictionary<values=string, indices=int32, ordered=0>
+animal: dictionary<values=string, indices=int32, ordered=0>
 ----
 n_legs: [[5],[2],...,[2],[4]]
-animals: [  -- dictionary:
+animal: [  -- dictionary:
 ["Brittle stars"]  -- indices:
 [0],  -- dictionary:
 ["Flamingo"]  -- indices:
@@ -2780,9 +2657,9 @@ animals: [  -- dictionary:
 
 Read the table with filter:
 
->>> pq.read_table('dataset_name_2', columns=["n_legs", "animals"],
+>>> pq.read_table('dataset_name_2', columns=["n_legs", "animal"],
 ...               filters=[('n_legs','<',4)]).to_pandas()
-   n_legs   animals
+   n_legs    animal
 0       2  Flamingo
 1       2    Parrot
 
@@ -2790,13 +2667,13 @@ Read data from a single Parquet file:
 
 >>> pq.write_table(table, 'example.parquet')
 >>> pq.read_table('dataset_name_2').to_pandas()
-   n_legs        animals  year month day
-0       5  Brittle stars  2019    11  17
-1       2       Flamingo  2020     3   1
-2     100      Centipede  2021    12  23
-3       4            Dog  2021     7   9
-4       2         Parrot  2022     5   5
-5       4          Horse  2022     9  13
+   n_legs         animal  year
+0       5  Brittle stars  2019
+1       2       Flamingo  2020
+2     100      Centipede  2021
+3       4            Dog  2021
+4       2         Parrot  2022
+5       4          Horse  2022
 """
 
 
@@ -2985,14 +2862,9 @@ _write_table_example = """\
 Generate an example PyArrow Table:
 
 >>> import pyarrow as pa
->>> import pandas as pd
->>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
-...                    'month': [3, 5, 7, 9, 11, 12],
-...                    'day': [1, 5, 9, 13, 17, 23],
-...                    'n_legs': [2, 2, 4, 4, 5, 100],
-...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
-...                    "Brittle stars", "Centipede"]})
->>> table = pa.Table.from_pandas(df)
+>>> table = pa.table({'n_legs': [2, 2, 4, 4, 5, 100],
+...                   'animal': ["Flamingo", "Parrot", "Dog", "Horse",
+...                              "Brittle stars", "Centipede"]})
 
 and write the Table into Parquet file:
 
@@ -3010,14 +2882,14 @@ Defining row group compression (default is Snappy):
 Defining row group compression and encoding per-column:
 
 >>> pq.write_table(table, 'example.parquet',
-...                compression={'foo': 'snappy', 'bar': 'gzip'},
-...                use_dictionary=['foo', 'bar'])
+...                compression={'n_legs': 'snappy', 'animal': 'gzip'},
+...                use_dictionary=['n_legs', 'animal'])
 
 
 Defining column encoding per-column:
 
 >>> pq.write_table(table, 'example.parquet',
-...                column_encoding={'animals':'PLAIN'},
+...                column_encoding={'animal':'PLAIN'},
 ...                use_dictionary=False)
 """
 
@@ -3104,34 +2976,30 @@ def write_to_dataset(table, root_path, partition_cols=None,
     Generate an example PyArrow Table:
 
     >>> import pyarrow as pa
-    >>> import pandas as pd
-    >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
-    ...                    'month': [3, 5, 7, 9, 11, 12],
-    ...                    'day': [1, 5, 9, 13, 17, 23],
-    ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-    ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
-    ...                    "Brittle stars", "Centipede"]})
-    >>> table = pa.Table.from_pandas(df)
+    >>> table = pa.table({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+    ...                   'n_legs': [2, 2, 4, 4, 5, 100],
+    ...                   'animal': ["Flamingo", "Parrot", "Dog", "Horse",
+    ...                              "Brittle stars", "Centipede"]})
 
     and write it to a partitioned dataset:
 
     >>> import pyarrow.parquet as pq
     >>> pq.write_to_dataset(table, root_path='dataset_name_3',
-    ...                     partition_cols=['year', 'month', 'day'],
+    ...                     partition_cols=['year'],
     ...                     use_legacy_dataset=False
     ...                    )
     >>> pq.ParquetDataset('dataset_name_3', use_legacy_dataset=False).files
-    ['dataset_name_3/year=2019/month=11/day=17/part-0.parquet', ...
+    ['dataset_name_3/year=2019/part-0.parquet', ...
 
     Use old Arrow Dataset API and override the partition filename:
 
     >>> pq.write_to_dataset(table, root_path='dataset_name_5',
-    ...                     partition_cols=['year', 'month', 'day'],
+    ...                     partition_cols=['year'],
     ...                     partition_filename_cb=lambda x:
-    ...                     str(x[0]) + str(x[1]) + str(x[2])  + '.parquet'
+    ...                     str(x[0]) + '.parquet'
     ...                    )
     >>> pq.ParquetDataset('dataset_name_5/', use_legacy_dataset=False).files
-    ['dataset_name_5/year=2019/month=11/day=17/20191117.parquet', ...
+    ['dataset_name_5/year=2019/2019.parquet', ...
 
     Write to a single Parquet file:
 
@@ -3264,14 +3132,9 @@ def write_metadata(schema, where, metadata_collector=None, **kwargs):
     Generate example data:
 
     >>> import pyarrow as pa
-    >>> import pandas as pd
-    >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
-    ...                    'month': [3, 5, 7, 9, 11, 12],
-    ...                    'day': [1, 5, 9, 13, 17, 23],
-    ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-    ...                    'animals': ["Flamingo", "Parrot", "Dog", "Horse",
-    ...                    "Brittle stars", "Centipede"]})
-    >>> table = pa.Table.from_pandas(df)
+    >>> table = pa.table({'n_legs': [2, 2, 4, 4, 5, 100],
+    ...                   'animal': ["Flamingo", "Parrot", "Dog", "Horse",
+    ...                              "Brittle stars", "Centipede"]})
 
     Write a dataset and collect metadata information.
 

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -603,7 +603,9 @@ def test_read_table_doesnt_warn(datadir, use_legacy_dataset):
                       use_legacy_dataset=use_legacy_dataset)
 
     if use_legacy_dataset:
-        assert len(record) == 1
+        # DeprecationWarning: 'use_legacy_dataset=True'
+        # DeprecationWarning: 'ParquetDataset.common_metadata' attribute
+        assert len(record) == 2
     else:
         assert len(record) == 0
 


### PR DESCRIPTION
This PR is adding docstring examples to:

- /docs/python/generated/pyarrow.parquet.ParquetDataset.html
- /docs/python/generated/pyarrow.parquet.ParquetFile.html
- /docs/python/generated/pyarrow.parquet.ParquetWriter.html
- /docs/python/generated/pyarrow.parquet.read_table.html
- /docs/python/generated/pyarrow.parquet.write_table.html
- /docs/python/generated/pyarrow.parquet.write_to_dataset.html