### PR TITLE
MINOR: [C++] Avoid using deprecated RecordBatchReader::ReadAll

### DIFF
--- a/cpp/src/arrow/dataset/file_orc_test.cc
+++ b/cpp/src/arrow/dataset/file_orc_test.cc
@@ -41,8 +41,7 @@ class OrcFormatHelper {
   static Result<std::shared_ptr<Buffer>> Write(RecordBatchReader* reader) {
     ARROW_ASSIGN_OR_RAISE(auto sink, io::BufferOutputStream::Create());
     ARROW_ASSIGN_OR_RAISE(auto writer, adapters::orc::ORCFileWriter::Open(sink.get()));
-    std::shared_ptr<Table> table;
-    RETURN_NOT_OK(reader->ReadAll(&table));
+    ARROW_ASSIGN_OR_RAISE(auto table, reader->ToTable());
     RETURN_NOT_OK(writer->Write(*table));
     RETURN_NOT_OK(writer->Close());
     return sink->Finish();


### PR DESCRIPTION
Fix this compilation error:
```
/home/antoine/arrow/dev/cpp/src/arrow/dataset/file_orc_test.cc:45:27: error: 'ReadAll' is deprecated: Deprecated in 8.0.0. Use ToTable instead. [-Werror,-Wdeprecated-declarations]
    RETURN_NOT_OK(reader->ReadAll(&table));
                          ^
```