### PR TITLE
ARROW-16007: [R] grepl bindings return FALSE for NA inputs

### DIFF
--- a/r/R/dplyr-funcs-string.R
+++ b/r/R/dplyr-funcs-string.R
@@ -192,16 +192,12 @@ register_bindings_string_join <- function() {
 
 register_bindings_string_regex <- function() {
 
-  create_string_match_expr <- function(arrow_fun, string, pattern, ignore_case, negate) {
+  create_string_match_expr <- function(arrow_fun, string, pattern, ignore_case) {
     out <- Expression$create(
       arrow_fun,
       string,
       options = list(pattern = pattern, ignore_case = ignore_case)
     )
-    if (negate) {
-      out <- !out
-    }
-    out
   }
 
   register_binding("grepl", function(pattern, x, ignore.case = FALSE, fixed = FALSE) {
@@ -210,8 +206,7 @@ register_bindings_string_regex <- function() {
       arrow_fun,
       string = x,
       pattern = pattern,
-      ignore_case = ignore.case,
-      negate = FALSE
+      ignore_case = ignore.case
     )
     call_binding("if_else", call_binding("is.na", out), FALSE, out)
   })
@@ -220,11 +215,14 @@ register_bindings_string_regex <- function() {
   register_binding("str_detect", function(string, pattern, negate = FALSE) {
     opts <- get_stringr_pattern_options(enexpr(pattern))
     arrow_fun <- ifelse(opts$fixed, "match_substring", "match_substring_regex")
-    create_string_match_expr(arrow_fun,
-                             string = string,
-                             pattern = opts$pattern,
-                             ignore_case = opts$ignore_case,
-                             negate = negate)
+    out <- create_string_match_expr(arrow_fun,
+                                    string = string,
+                                    pattern = opts$pattern,
+                                    ignore_case = opts$ignore_case)
+    if (negate) {
+      out <- !out
+    }
+    out
   })
 
   register_binding("str_like", function(string, pattern, ignore_case = TRUE) {
@@ -273,9 +271,11 @@ register_bindings_string_regex <- function() {
         arrow_fun = "match_substring_regex",
         string = string,
         pattern = paste0("^", opts$pattern),
-        ignore_case = opts$ignore_case,
-        negate = negate
+        ignore_case = opts$ignore_case
       )
+    }
+    if (negate) {
+      out <- !out
     }
     out
   })
@@ -289,9 +289,11 @@ register_bindings_string_regex <- function() {
         arrow_fun = "match_substring_regex",
         string = string,
         pattern = paste0(opts$pattern, "$"),
-        ignore_case = opts$ignore_case,
-        negate = negate
+        ignore_case = opts$ignore_case
       )
+    }
+    if (negate) {
+      out <- !out
     }
     out
   })

--- a/r/R/dplyr-funcs-string.R
+++ b/r/R/dplyr-funcs-string.R
@@ -192,27 +192,39 @@ register_bindings_string_join <- function() {
 
 register_bindings_string_regex <- function() {
 
-  register_binding("grepl", function(pattern, x, ignore.case = FALSE, fixed = FALSE) {
-    arrow_fun <- ifelse(fixed, "match_substring", "match_substring_regex")
-    Expression$create(
+  create_string_match_expr <- function(arrow_fun, string, pattern, ignore_case, negate) {
+    out <- Expression$create(
       arrow_fun,
-      x,
-      options = list(pattern = pattern, ignore_case = ignore.case)
-    )
-  })
-
-  register_binding("str_detect", function(string, pattern, negate = FALSE) {
-    opts <- get_stringr_pattern_options(enexpr(pattern))
-    out <- call_binding("grepl",
-                            pattern = opts$pattern,
-                            x = string,
-                            ignore.case = opts$ignore_case,
-                            fixed = opts$fixed
+      string,
+      options = list(pattern = pattern, ignore_case = ignore_case)
     )
     if (negate) {
       out <- !out
     }
     out
+  }
+
+  register_binding("grepl", function(pattern, x, ignore.case = FALSE, fixed = FALSE) {
+    arrow_fun <- ifelse(fixed, "match_substring", "match_substring_regex")
+    out <- create_string_match_expr(
+      arrow_fun,
+      string = x,
+      pattern = pattern,
+      ignore_case = ignore.case,
+      negate = FALSE
+    )
+    call_binding("if_else", call_binding("is.na", out), FALSE, out)
+  })
+
+
+  register_binding("str_detect", function(string, pattern, negate = FALSE) {
+    opts <- get_stringr_pattern_options(enexpr(pattern))
+    arrow_fun <- ifelse(opts$fixed, "match_substring", "match_substring_regex")
+    create_string_match_expr(arrow_fun,
+                             string = string,
+                             pattern = opts$pattern,
+                             ignore_case = opts$ignore_case,
+                             negate = negate)
   })
 
   register_binding("str_like", function(string, pattern, ignore_case = TRUE) {
@@ -257,11 +269,13 @@ register_bindings_string_regex <- function() {
     if (opts$fixed) {
       out <- call_binding("startsWith", x = string, prefix = opts$pattern)
     } else {
-      out <- call_binding("grepl", pattern = paste0("^", opts$pattern), x = string, fixed = FALSE)
-    }
-
-    if (negate) {
-      out <- !out
+      out <- create_string_match_expr(
+        arrow_fun = "match_substring_regex",
+        string = string,
+        pattern = paste0("^", opts$pattern),
+        ignore_case = opts$ignore_case,
+        negate = negate
+      )
     }
     out
   })
@@ -271,11 +285,13 @@ register_bindings_string_regex <- function() {
     if (opts$fixed) {
       out <- call_binding("endsWith", x = string, suffix = opts$pattern)
     } else {
-      out <- call_binding("grepl", pattern = paste0(opts$pattern, "$"), x = string, fixed = FALSE)
-    }
-
-    if (negate) {
-      out <- !out
+      out <- create_string_match_expr(
+        arrow_fun = "match_substring_regex",
+        string = string,
+        pattern = paste0(opts$pattern, "$"),
+        ignore_case = opts$ignore_case,
+        negate = negate
+      )
     }
     out
   })

--- a/r/tests/testthat/test-dplyr-funcs-string.R
+++ b/r/tests/testthat/test-dplyr-funcs-string.R
@@ -1134,7 +1134,8 @@ test_that("str_starts, str_ends, startsWith, endsWith", {
     .input %>%
       transmute(a = str_ends(x, "r"),
                 b = str_ends(x, "r", negate = TRUE),
-                d = str_ends(x, fixed("r"))) %>%
+                c = str_ends(x, fixed("r")),
+                d = str_ends(x, fixed("r"), negate = TRUE)) %>%
       collect(),
     df
   )

--- a/r/tests/testthat/test-dplyr-funcs-string.R
+++ b/r/tests/testthat/test-dplyr-funcs-string.R
@@ -180,10 +180,16 @@ test_that("paste, paste0, and str_c", {
 })
 
 test_that("grepl with ignore.case = FALSE and fixed = TRUE", {
-  df <- tibble(x = c("Foo", "bar"))
+  df <- tibble(x = c("Foo", "bar", NA_character_))
   compare_dplyr_binding(
     .input %>%
       filter(grepl("o", x, fixed = TRUE)) %>%
+      collect(),
+    df
+  )
+  compare_dplyr_binding(
+    .input %>%
+      mutate(x = grepl("o", x, fixed = TRUE)) %>%
       collect(),
     df
   )
@@ -209,7 +215,7 @@ test_that("sub and gsub with ignore.case = FALSE and fixed = TRUE", {
 skip_if_not_available("re2")
 
 test_that("grepl", {
-  df <- tibble(x = c("Foo", "bar"))
+  df <- tibble(x = c("Foo", "bar", NA_character_))
 
   for (fixed in c(TRUE, FALSE)) {
     compare_dplyr_binding(
@@ -234,7 +240,7 @@ test_that("grepl", {
 })
 
 test_that("grepl with ignore.case = TRUE and fixed = TRUE", {
-  df <- tibble(x = c("Foo", "bar"))
+  df <- tibble(x = c("Foo", "bar", NA_character_))
 
   # base::grepl() ignores ignore.case = TRUE with a warning when fixed = TRUE,
   # so we can't use compare_dplyr_binding() for these tests
@@ -248,14 +254,26 @@ test_that("grepl with ignore.case = TRUE and fixed = TRUE", {
   expect_equal(
     df %>%
       Table$create() %>%
-      filter(x = grepl("^B.+", x, ignore.case = TRUE, fixed = TRUE)) %>%
+      filter(grepl("^B.+", x, ignore.case = TRUE, fixed = TRUE)) %>%
       collect(),
     tibble(x = character(0))
+  )
+  expect_equal(
+    df %>%
+      Table$create() %>%
+      transmute(
+        a = grepl("O", x, ignore.case = TRUE, fixed = TRUE)
+      ) %>%
+      collect(),
+    tibble(
+      x = c("Foo", "bar", NA_character_),
+      a = c(TRUE, FALSE, FALSE)
+    )
   )
 })
 
 test_that("str_detect", {
-  df <- tibble(x = c("Foo", "bar"))
+  df <- tibble(x = c("Foo", "bar", NA_character_))
 
   compare_dplyr_binding(
     .input %>%
@@ -1045,7 +1063,7 @@ test_that("str_sub", {
 })
 
 test_that("str_starts, str_ends, startsWith, endsWith", {
-  df <- tibble(x = c("Foo", "bar", "baz", "qux"))
+  df <- tibble(x = c("Foo", "bar", "baz", "qux", NA_character_))
 
   compare_dplyr_binding(
     .input %>%
@@ -1071,6 +1089,15 @@ test_that("str_starts, str_ends, startsWith, endsWith", {
   compare_dplyr_binding(
     .input %>%
       filter(str_starts(x, fixed("b"))) %>%
+      collect(),
+    df
+  )
+
+  compare_dplyr_binding(
+    .input %>%
+      transmute(a = str_starts(x, "b.*"),
+                b = str_starts(x, "b.*", negate = TRUE),
+                d = str_starts(x, fixed("b"))) %>%
       collect(),
     df
   )
@@ -1105,6 +1132,14 @@ test_that("str_starts, str_ends, startsWith, endsWith", {
 
   compare_dplyr_binding(
     .input %>%
+      transmute(a = str_ends(x, "r"),
+                b = str_ends(x, "r", negate = TRUE),
+                d = str_ends(x, fixed("r"))) %>%
+      collect(),
+    df
+  )
+  compare_dplyr_binding(
+    .input %>%
       filter(startsWith(x, "b")) %>%
       collect(),
     df
@@ -1127,6 +1162,14 @@ test_that("str_starts, str_ends, startsWith, endsWith", {
   compare_dplyr_binding(
     .input %>%
       filter(endsWith(x, "r$")) %>%
+      collect(),
+    df
+  )
+
+  compare_dplyr_binding(
+    .input %>%
+      transmute(a = startsWith(x, "b"),
+                b = endsWith(x, "r")) %>%
       collect(),
     df
   )

--- a/r/tests/testthat/test-dplyr-funcs-string.R
+++ b/r/tests/testthat/test-dplyr-funcs-string.R
@@ -261,7 +261,7 @@ test_that("grepl with ignore.case = TRUE and fixed = TRUE", {
   expect_equal(
     df %>%
       Table$create() %>%
-      transmute(
+      mutate(
         a = grepl("O", x, ignore.case = TRUE, fixed = TRUE)
       ) %>%
       collect(),

--- a/r/tests/testthat/test-dplyr-funcs-string.R
+++ b/r/tests/testthat/test-dplyr-funcs-string.R
@@ -1097,7 +1097,9 @@ test_that("str_starts, str_ends, startsWith, endsWith", {
     .input %>%
       transmute(a = str_starts(x, "b.*"),
                 b = str_starts(x, "b.*", negate = TRUE),
-                d = str_starts(x, fixed("b"))) %>%
+                c = str_starts(x, fixed("b")),
+                d = str_starts(x, fixed("b"), negate = TRUE)
+                ) %>%
       collect(),
     df
   )


### PR DESCRIPTION
This ensures that the `grepl` binding mimics R's base `grepl` by returning `FALSE` for `NA` inputs (previously it returned `NA`). As several other bindings called the `grepl` binding and we don't want the `grepl` behaviour with `NA` to propagate to those bindings (they all return `NA` with `NA` inputs), I had to change how they were constructed as well. I abstracted out the main parts of the `register_binding` for the string matching functions (those that return a `logical`) into a helper function `create_string_match_expr()`, which is used by the bindings for `grepl`, `str_detect`, `str_starts`, and `str_ends`.

I added several tests for `NA` behaviour - which [failed before the changes](https://github.com/ateucher/arrow/actions/runs/2037010015) and now pass (at least locally, will wait for CI to finish here)