### PR TITLE
ARROW-16031: [C++][Gandiva] Fix Soundex errors generate

### DIFF
--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -84,7 +84,7 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      kResultNullIfNull, "repeat_utf8_int32",
                      NativeFunction::kNeedsContext),
 
-      NativeFunction("soundex", {}, DataTypeVector{utf8()}, utf8(), kResultNullIfNull,
+      NativeFunction("soundex", {}, DataTypeVector{utf8()}, utf8(), kResultNullInternal,
                      "soundex_utf8", NativeFunction::kNeedsContext),
 
       NativeFunction("upper", {}, DataTypeVector{utf8()}, utf8(), kResultNullIfNull,

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -2921,6 +2921,11 @@ const char* soundex_utf8(gdv_int64 ctx, const char* in, gdv_int32 in_len,
   }
 
   for (int i = 1; i < si; i++) {
+    // If the saved letter's digit is the same as the resulting first digit, remove the
+    // digit.
+    if (i == 1 && soundex[i] == mappings[ret[0] - 65]) {
+      i++;
+    }
     if (soundex[i] != '0') {
       ret[ret_len] = soundex[i];
       ret_len++;

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -2910,6 +2910,13 @@ const char* soundex_utf8(gdv_int64 ctx, const char* in, gdv_int32 in_len,
     }
   }
 
+  // If ret[0] is not initialised, return one exception
+  if (start_idx == 0) {
+    gdv_fn_context_set_error_msg(ctx, "There are no valid values in this entry.");
+    *out_len = 0;
+    return "";
+  }
+
   soundex[0] = '\0';
   // Replace consonants with digits and special letters with 0
   for (int i = start_idx; i < in_len; i++) {
@@ -2923,10 +2930,9 @@ const char* soundex_utf8(gdv_int64 ctx, const char* in, gdv_int32 in_len,
   }
 
   int i = 1;
-  // If the saved letter's digit is the same as the resulting first digit, remove the
-  // digit.
-  if (soundex[i] == mappings[ret[0] - 65]) {
-    i++;
+  // If the saved letter's digit is the same as the resulting first digit, skip it
+  if (soundex[1] == mappings[ret[0] - 65]) {
+    i = 2;
   }
 
   for (; i < si; i++) {
@@ -2945,6 +2951,7 @@ const char* soundex_utf8(gdv_int64 ctx, const char* in, gdv_int32 in_len,
       ret_len++;
     }
   }
+
   *out_len = 4;
   return ret;
 }

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -2879,19 +2879,21 @@ static char mappings[] = {'0', '1', '2', '3', '0', '1', '2', '0', '0',
 //    numbers, append with zeros until there are three numbers. If you have four or more
 //    numbers, retain only the first three.
 FORCE_INLINE
-const char* soundex_utf8(gdv_int64 ctx, const char* in, gdv_int32 in_len,
-                         int32_t* out_len) {
+const char* soundex_utf8(gdv_int64 context, const char* in, gdv_int32 in_len,
+                         bool in_validity, bool* out_valid, int32_t* out_len) {
   if (in_len <= 0) {
+    *out_valid = true;
     *out_len = 0;
     return "";
   }
 
   // The soundex code is composed by one letter and three numbers
-  char* soundex = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(ctx, in_len));
-  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(ctx, 4));
+  char* soundex = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, in_len));
+  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, 4));
 
   if (soundex == nullptr || ret == nullptr) {
-    gdv_fn_context_set_error_msg(ctx, "Could not allocate memory for output string");
+    gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
+    *out_valid = false;
     *out_len = 0;
     return "";
   }
@@ -2910,9 +2912,9 @@ const char* soundex_utf8(gdv_int64 ctx, const char* in, gdv_int32 in_len,
     }
   }
 
-  // If ret[0] is not initialised, return one exception
+  // If ret[0] is not initialised, return validity false
   if (start_idx == 0) {
-    gdv_fn_context_set_error_msg(ctx, "There are no valid values in this entry.");
+    *out_valid = false;
     *out_len = 0;
     return "";
   }
@@ -2951,7 +2953,7 @@ const char* soundex_utf8(gdv_int64 ctx, const char* in, gdv_int32 in_len,
       ret_len++;
     }
   }
-
+  *out_valid = true;
   *out_len = 4;
   return ret;
 }

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -2933,17 +2933,19 @@ const char* soundex_utf8(gdv_int64 context, const char* in, gdv_int32 in_len,
 
   int i = 1;
   // If the saved letter's digit is the same as the resulting first digit, skip it
-  if (soundex[1] == mappings[ret[0] - 65]) {
-    i = 2;
-  }
-
-  for (; i < si; i++) {
-    // If it is a special letter, we ignore, because it has been dropped in first step
-    if (soundex[i] != '0') {
-      ret[ret_len] = soundex[i];
-      ret_len++;
+  if (si > 1) {
+    if (soundex[1] == mappings[ret[0] - 65]) {
+      i = 2;
     }
-    if (ret_len > 3) break;
+
+    for (; i < si; i++) {
+      // If it is a special letter, we ignore, because it has been dropped in first step
+      if (soundex[i] != '0') {
+        ret[ret_len] = soundex[i];
+        ret_len++;
+      }
+      if (ret_len > 3) break;
+    }
   }
 
   // If the return have too few numbers, append with zeros until there are three

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -2872,10 +2872,9 @@ static char mappings[] = {'0', '1', '2', '3', '0', '1', '2', '0', '0',
 //        l → 4
 //        m, n → 5
 //        r → 6
-//    3. If two or more letters with the same number are adjacent in the original name
-//    (before step 1), only retain the first letter; also two letters with the same number
-//    separated by 'h' or 'w' are coded as a single number, whereas such letters separated
-//    by a vowel are coded twice. This rule also applies to the first letter.
+//    3. If two or more letters with the same number were adjacent in the original name
+//    (before step 1), or adjacent except for any intervening h and w, then omit all but
+//    the first.
 //    4. If the string have too few letters in the word that you can't assign three
 //    numbers, append with zeros until there are three numbers. If you have four or more
 //    numbers, retain only the first three.
@@ -2910,7 +2909,8 @@ const char* soundex_utf8(gdv_int64 ctx, const char* in, gdv_int32 in_len,
     }
   }
 
-  for (int i = start_idx, l = in_len; i < l; i++) {
+  soundex[0] = '\0';
+  for (int i = start_idx; i < in_len; i++) {
     if (isalpha(in[i]) > 0) {
       c = toupper(in[i]) - 65;
       if (mappings[c] != soundex[si - 1]) {
@@ -2920,12 +2920,14 @@ const char* soundex_utf8(gdv_int64 ctx, const char* in, gdv_int32 in_len,
     }
   }
 
-  for (int i = 1; i < si; i++) {
-    // If the saved letter's digit is the same as the resulting first digit, remove the
-    // digit.
-    if (i == 1 && soundex[i] == mappings[ret[0] - 65]) {
-      i++;
-    }
+  int i = 1;
+  // If the saved letter's digit is the same as the resulting first digit, remove the
+  // digit.
+  if (soundex[i] == mappings[ret[0] - 65]) {
+    i++;
+  }
+
+  for (; i < si; i++) {
     if (soundex[i] != '0') {
       ret[ret_len] = soundex[i];
       ret_len++;

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -2873,8 +2873,8 @@ static char mappings[] = {'0', '1', '2', '3', '0', '1', '2', '0', '0',
 //        m, n → 5
 //        r → 6
 //    3. If two or more letters with the same number were adjacent in the original name
-//    (before step 1), or adjacent for any intervening from any special letters, then omit
-//    all but the first. This rule also applies to the first letter.
+//    (before step 1), then omit all but the first. This rule also applies to the first
+//    letter.
 //    4. If the string have too few letters in the word that you can't assign three
 //    numbers, append with zeros until there are three numbers. If you have four or more
 //    numbers, retain only the first three.

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -2383,11 +2383,21 @@ TEST(TestStringOps, TestFromHex) {
   EXPECT_EQ(output, "");
   EXPECT_EQ(out_valid, false);
 }
+
 TEST(TestStringOps, TestSoundex) {
   gandiva::ExecutionContext ctx;
   auto ctx_ptr = reinterpret_cast<int64_t>(&ctx);
   int32_t out_len = 0;
   const char* out;
+
+  out = soundex_utf8(ctx_ptr, "Luke Garcia", 11, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "L226");
+
+  out = soundex_utf8(ctx_ptr, "123 321 Luke 987 Gar4cia", 24, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "L226");
+
+  out = soundex_utf8(ctx_ptr, "Alice Ichabod", 13, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "A422");
 
   out = soundex_utf8(ctx_ptr, "Miller", 6, &out_len);
   EXPECT_EQ(std::string(out, out_len), "M460");

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -2388,92 +2388,117 @@ TEST(TestStringOps, TestSoundex) {
   gandiva::ExecutionContext ctx;
   auto ctx_ptr = reinterpret_cast<int64_t>(&ctx);
   int32_t out_len = 0;
+  bool validity = false;
   const char* out;
 
-  out = soundex_utf8(ctx_ptr, "123456789", 9, &out_len);
+  out = soundex_utf8(ctx_ptr, "123456789", 9, true, &validity, &out_len);
   EXPECT_EQ(std::string(out, out_len), "");
-  EXPECT_THAT(ctx.get_error(),
-              ::testing::HasSubstr("There are no valid values in this entry."));
-  ctx.Reset();
+  EXPECT_EQ(validity, false);
 
-  out = soundex_utf8(ctx_ptr, "a", 1, &out_len);
+  out = soundex_utf8(ctx_ptr, "a", 1, true, &validity, &out_len);
   EXPECT_EQ(std::string(out, out_len), "A000");
+  EXPECT_EQ(validity, true);
 
-  out = soundex_utf8(ctx_ptr, "123456789a", 10, &out_len);
+  out = soundex_utf8(ctx_ptr, "123456789a", 10, true, &validity, &out_len);
   EXPECT_EQ(std::string(out, out_len), "A000");
+  EXPECT_EQ(validity, true);
 
-  out = soundex_utf8(ctx_ptr, "a123456789", 10, &out_len);
+  out = soundex_utf8(ctx_ptr, "a123456789", 10, true, &validity, &out_len);
   EXPECT_EQ(std::string(out, out_len), "A000");
+  EXPECT_EQ(validity, true);
 
-  out = soundex_utf8(ctx_ptr, "robert", 6, &out_len);
+  out = soundex_utf8(ctx_ptr, "robert", 6, true, &validity, &out_len);
   EXPECT_EQ(std::string(out, out_len), "R163");
+  EXPECT_EQ(validity, true);
 
-  out = soundex_utf8(ctx_ptr, "r-O-b-E-r-T", 11, &out_len);
+  out = soundex_utf8(ctx_ptr, "r-O-b-E-r-T", 11, true, &validity, &out_len);
   EXPECT_EQ(std::string(out, out_len), "R163");
+  EXPECT_EQ(validity, true);
 
-  out = soundex_utf8(ctx_ptr, "Robert", 6, &out_len);
+  out = soundex_utf8(ctx_ptr, "Robert", 6, true, &validity, &out_len);
   EXPECT_EQ(std::string(out, out_len), "R163");
+  EXPECT_EQ(validity, true);
 
-  out = soundex_utf8(ctx_ptr, "Rupert", 6, &out_len);
+  out = soundex_utf8(ctx_ptr, "Rupert", 6, true, &validity, &out_len);
   EXPECT_EQ(std::string(out, out_len), "R163");
+  EXPECT_EQ(validity, true);
 
-  out = soundex_utf8(ctx_ptr, "Honeyman", 8, &out_len);
+  out = soundex_utf8(ctx_ptr, "Honeyman", 8, true, &validity, &out_len);
   EXPECT_EQ(std::string(out, out_len), "H555");
+  EXPECT_EQ(validity, true);
 
-  out = soundex_utf8(ctx_ptr, "Tymczak", 7, &out_len);
+  out = soundex_utf8(ctx_ptr, "Tymczak", 7, true, &validity, &out_len);
   EXPECT_EQ(std::string(out, out_len), "T522");
+  EXPECT_EQ(validity, true);
 
-  out = soundex_utf8(ctx_ptr, "Ashcraft", 8, &out_len);
+  out = soundex_utf8(ctx_ptr, "Ashcraft", 8, true, &validity, &out_len);
   EXPECT_EQ(std::string(out, out_len), "A226");
+  EXPECT_EQ(validity, true);
 
-  out = soundex_utf8(ctx_ptr, "Ashcroft", 8, &out_len);
+  out = soundex_utf8(ctx_ptr, "Ashcroft", 8, true, &validity, &out_len);
   EXPECT_EQ(std::string(out, out_len), "A226");
+  EXPECT_EQ(validity, true);
 
-  out = soundex_utf8(ctx_ptr, "Jjjice", 6, &out_len);
+  out = soundex_utf8(ctx_ptr, "Jjjice", 6, true, &validity, &out_len);
   EXPECT_EQ(std::string(out, out_len), "J200");
+  EXPECT_EQ(validity, true);
 
-  out = soundex_utf8(ctx_ptr, "Luke Garcia", 11, &out_len);
+  out = soundex_utf8(ctx_ptr, "Luke Garcia", 11, true, &validity, &out_len);
   EXPECT_EQ(std::string(out, out_len), "L226");
+  EXPECT_EQ(validity, true);
 
-  out = soundex_utf8(ctx_ptr, "123 321 Luke 987 Gar4cia", 24, &out_len);
+  out = soundex_utf8(ctx_ptr, "123 321 Luke 987 Gar4cia", 24, true, &validity, &out_len);
   EXPECT_EQ(std::string(out, out_len), "L226");
+  EXPECT_EQ(validity, true);
 
-  out = soundex_utf8(ctx_ptr, "Alice Ichabod", 13, &out_len);
+  out = soundex_utf8(ctx_ptr, "Alice Ichabod", 13, true, &validity, &out_len);
   EXPECT_EQ(std::string(out, out_len), "A422");
+  EXPECT_EQ(validity, true);
 
-  out = soundex_utf8(ctx_ptr, "Miller", 6, &out_len);
+  out = soundex_utf8(ctx_ptr, "Miller", 6, true, &validity, &out_len);
   EXPECT_EQ(std::string(out, out_len), "M460");
+  EXPECT_EQ(validity, true);
 
-  out = soundex_utf8(ctx_ptr, "3Miller", 7, &out_len);
+  out = soundex_utf8(ctx_ptr, "3Miller", 7, true, &validity, &out_len);
   EXPECT_EQ(std::string(out, out_len), "M460");
+  EXPECT_EQ(validity, true);
 
-  out = soundex_utf8(ctx_ptr, "Mill3r", 6, &out_len);
+  out = soundex_utf8(ctx_ptr, "Mill3r", 6, true, &validity, &out_len);
   EXPECT_EQ(std::string(out, out_len), "M460");
+  EXPECT_EQ(validity, true);
 
-  out = soundex_utf8(ctx_ptr, "abc", 3, &out_len);
+  out = soundex_utf8(ctx_ptr, "abc", 3, true, &validity, &out_len);
   EXPECT_EQ(std::string(out, out_len), "A120");
+  EXPECT_EQ(validity, true);
 
-  out = soundex_utf8(ctx_ptr, "123abc", 6, &out_len);
+  out = soundex_utf8(ctx_ptr, "123abc", 6, true, &validity, &out_len);
   EXPECT_EQ(std::string(out, out_len), "A120");
+  EXPECT_EQ(validity, true);
 
-  out = soundex_utf8(ctx_ptr, "test", 4, &out_len);
+  out = soundex_utf8(ctx_ptr, "test", 4, true, &validity, &out_len);
   EXPECT_EQ(std::string(out, out_len), "T230");
+  EXPECT_EQ(validity, true);
 
-  out = soundex_utf8(ctx_ptr, "", 0, &out_len);
+  out = soundex_utf8(ctx_ptr, "", 0, true, &validity, &out_len);
   EXPECT_EQ(std::string(out, out_len), "");
+  EXPECT_EQ(validity, true);
 
-  out = soundex_utf8(ctx_ptr, "Elvis", 5, &out_len);
+  out = soundex_utf8(ctx_ptr, "Elvis", 5, true, &validity, &out_len);
   EXPECT_EQ(std::string(out, out_len), "E412");
+  EXPECT_EQ(validity, true);
 
-  out = soundex_utf8(ctx_ptr, "waterloo", 8, &out_len);
+  out = soundex_utf8(ctx_ptr, "waterloo", 8, true, &validity, &out_len);
   EXPECT_EQ(std::string(out, out_len), "W364");
+  EXPECT_EQ(validity, true);
 
-  out = soundex_utf8(ctx_ptr, "eowolf", 6, &out_len);
+  out = soundex_utf8(ctx_ptr, "eowolf", 6, true, &validity, &out_len);
   EXPECT_EQ(std::string(out, out_len), "E410");
+  EXPECT_EQ(validity, true);
 
-  out = soundex_utf8(ctx_ptr, "Smith", 5, &out_len);
-  auto out2 = soundex_utf8(ctx_ptr, "Smythe", 6, &out_len);
+  out = soundex_utf8(ctx_ptr, "Smith", 5, true, &validity, &out_len);
+  auto out2 = soundex_utf8(ctx_ptr, "Smythe", 6, true, &validity, &out_len);
   EXPECT_EQ(std::string(out, out_len), std::string(out2, out_len));
+  EXPECT_EQ(validity, true);
 }
 
 TEST(TestStringOps, TestInstr) {

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -2390,6 +2390,12 @@ TEST(TestStringOps, TestSoundex) {
   int32_t out_len = 0;
   const char* out;
 
+  out = soundex_utf8(ctx_ptr, "robert", 6, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "R163");
+
+  out = soundex_utf8(ctx_ptr, "r-O-b-E-r-T", 11, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "R163");
+
   out = soundex_utf8(ctx_ptr, "Robert", 6, &out_len);
   EXPECT_EQ(std::string(out, out_len), "R163");
 

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -2390,6 +2390,27 @@ TEST(TestStringOps, TestSoundex) {
   int32_t out_len = 0;
   const char* out;
 
+  out = soundex_utf8(ctx_ptr, "Robert", 6, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "R163");
+
+  out = soundex_utf8(ctx_ptr, "Rupert", 6, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "R163");
+
+  out = soundex_utf8(ctx_ptr, "Honeyman", 8, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "H555");
+
+  out = soundex_utf8(ctx_ptr, "Tymczak", 7, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "T522");
+
+  out = soundex_utf8(ctx_ptr, "Ashcraft", 8, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "A226");
+
+  out = soundex_utf8(ctx_ptr, "Ashcroft", 8, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "A226");
+
+  out = soundex_utf8(ctx_ptr, "Jjjice", 6, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "J200");
+
   out = soundex_utf8(ctx_ptr, "Luke Garcia", 11, &out_len);
   EXPECT_EQ(std::string(out, out_len), "L226");
 

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -2390,6 +2390,21 @@ TEST(TestStringOps, TestSoundex) {
   int32_t out_len = 0;
   const char* out;
 
+  out = soundex_utf8(ctx_ptr, "123456789", 9, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "");
+  EXPECT_THAT(ctx.get_error(),
+              ::testing::HasSubstr("There are no valid values in this entry."));
+  ctx.Reset();
+
+  out = soundex_utf8(ctx_ptr, "a", 1, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "A000");
+
+  out = soundex_utf8(ctx_ptr, "123456789a", 10, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "A000");
+
+  out = soundex_utf8(ctx_ptr, "a123456789", 10, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "A000");
+
   out = soundex_utf8(ctx_ptr, "robert", 6, &out_len);
   EXPECT_EQ(std::string(out, out_len), "R163");
 

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -682,8 +682,8 @@ const char* byte_substr_binary_int32_int32(gdv_int64 context, const char* text,
                                            gdv_int32 text_len, gdv_int32 offset,
                                            gdv_int32 length, gdv_int32* out_len);
 
-const char* soundex_utf8(gdv_int64 ctx, const char* in, gdv_int32 in_len,
-                         int32_t* out_len);
+const char* soundex_utf8(gdv_int64 context, const char* in, gdv_int32 in_len,
+                         bool in_validity, bool* out_valid, int32_t* out_len);
 
 const char* castVARCHAR_bool_int64(gdv_int64 context, gdv_boolean value,
                                    gdv_int64 out_len, gdv_int32* out_length);

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -835,14 +835,14 @@ TEST_F(TestProjector, TestSoundex) {
   EXPECT_TRUE(status.ok()) << status.message();
 
   // Create a row-batch with some sample data
-  int num_records = 7;
+  int num_records = 8;
   auto array0 = MakeArrowArrayUtf8(
-      {"test", "", "Miller", "abc", "democrat", "luke garcia", "alice ichabod"},
-      {true, true, true, true, true, true, true});
+      {"test", "", "Miller", "abc", "democrat", "luke garcia", "alice ichabod", "Jjjice"},
+      {true, true, true, true, true, true, true, true});
   // expected output
   auto exp_soundex =
-      MakeArrowArrayUtf8({"T230", "", "M460", "A120", "D526", "L226", "A422"},
-                         {true, true, true, true, true, true, true});
+      MakeArrowArrayUtf8({"T230", "", "M460", "A120", "D526", "L226", "A422", "J200"},
+                         {true, true, true, true, true, true, true, true});
 
   // prepare input record batch
   auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array0});

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -835,15 +835,16 @@ TEST_F(TestProjector, TestSoundex) {
   EXPECT_TRUE(status.ok()) << status.message();
 
   // Create a row-batch with some sample data
-  int num_records = 10;
-  auto array0 =
-      MakeArrowArrayUtf8({"test", "", "Miller", "abc", "democrat", "luke garcia",
-                          "alice ichabod", "Jjjice", "SACHS", "路-大学b路%$大"},
-                         {true, true, true, true, true, true, true, true, true, true});
+  int num_records = 11;
+  auto array0 = MakeArrowArrayUtf8(
+      {"test", "", "Miller", "abc", "democrat", "luke garcia", "alice ichabod", "Jjjice",
+       "SACHS", "路-大学b路%$大", "a"},
+      {true, true, true, true, true, true, true, true, true, true, true});
   // expected output
   auto exp_soundex = MakeArrowArrayUtf8(
-      {"T230", "", "M460", "A120", "D526", "L226", "A422", "J200", "S220", "B000"},
-      {true, true, true, true, true, true, true, true, true, true});
+      {"T230", "", "M460", "A120", "D526", "L226", "A422", "J200", "S220", "B000",
+       "A000"},
+      {true, true, true, true, true, true, true, true, true, true, true});
 
   // prepare input record batch
   auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array0});

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -835,15 +835,15 @@ TEST_F(TestProjector, TestSoundex) {
   EXPECT_TRUE(status.ok()) << status.message();
 
   // Create a row-batch with some sample data
-  int num_records = 9;
+  int num_records = 10;
   auto array0 =
       MakeArrowArrayUtf8({"test", "", "Miller", "abc", "democrat", "luke garcia",
-                          "alice ichabod", "Jjjice", "SACHS"},
-                         {true, true, true, true, true, true, true, true, true});
+                          "alice ichabod", "Jjjice", "SACHS", "路-大学b路%$大"},
+                         {true, true, true, true, true, true, true, true, true, true});
   // expected output
   auto exp_soundex = MakeArrowArrayUtf8(
-      {"T230", "", "M460", "A120", "D526", "L226", "A422", "J200", "S220"},
-      {true, true, true, true, true, true, true, true, true});
+      {"T230", "", "M460", "A120", "D526", "L226", "A422", "J200", "S220", "B000"},
+      {true, true, true, true, true, true, true, true, true, true});
 
   // prepare input record batch
   auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array0});

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -835,14 +835,15 @@ TEST_F(TestProjector, TestSoundex) {
   EXPECT_TRUE(status.ok()) << status.message();
 
   // Create a row-batch with some sample data
-  int num_records = 8;
-  auto array0 = MakeArrowArrayUtf8(
-      {"test", "", "Miller", "abc", "democrat", "luke garcia", "alice ichabod", "Jjjice"},
-      {true, true, true, true, true, true, true, true});
+  int num_records = 9;
+  auto array0 =
+      MakeArrowArrayUtf8({"test", "", "Miller", "abc", "democrat", "luke garcia",
+                          "alice ichabod", "Jjjice", "SACHS"},
+                         {true, true, true, true, true, true, true, true, true});
   // expected output
-  auto exp_soundex =
-      MakeArrowArrayUtf8({"T230", "", "M460", "A120", "D526", "L226", "A422", "J200"},
-                         {true, true, true, true, true, true, true, true});
+  auto exp_soundex = MakeArrowArrayUtf8(
+      {"T230", "", "M460", "A120", "D526", "L226", "A422", "J200", "S220"},
+      {true, true, true, true, true, true, true, true, true});
 
   // prepare input record batch
   auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array0});

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -835,12 +835,14 @@ TEST_F(TestProjector, TestSoundex) {
   EXPECT_TRUE(status.ok()) << status.message();
 
   // Create a row-batch with some sample data
-  int num_records = 4;
-  auto array0 =
-      MakeArrowArrayUtf8({"test", "", "Miller", "abc"}, {true, true, true, true});
+  int num_records = 7;
+  auto array0 = MakeArrowArrayUtf8(
+      {"test", "", "Miller", "abc", "democrat", "luke garcia", "alice ichabod"},
+      {true, true, true, true, true, true, true});
   // expected output
   auto exp_soundex =
-      MakeArrowArrayUtf8({"T230", "", "M460", "A120"}, {true, true, true, true});
+      MakeArrowArrayUtf8({"T230", "", "M460", "A120", "D526", "L226", "A422"},
+                         {true, true, true, true, true, true, true});
 
   // prepare input record batch
   auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array0});


### PR DESCRIPTION
Current Soundex Function presents errors in generating results for some specific cases, when we have a sequence of 2 equal numbers separated by 0 it ends up ignoring it, as it deletes the 0 before generating the entire Soundex

**Example with errors:**

Alice Ichabod   -> Correct return is **A422** but the Soundex returned **A421**

Luke Garcia       -> Correct return is **L226** but the Soundex returned  **L262**