### PR TITLE
ARROW-16099: [JS] RecordBatches that are compressed should throw an error

### DIFF
--- a/js/src/ipc/metadata/message.ts
+++ b/js/src/ipc/metadata/message.ts
@@ -298,7 +298,7 @@ function decodeSchema(_schema: _Schema, dictionaries: Map<number, DataType> = ne
 /** @ignore */
 function decodeRecordBatch(batch: _RecordBatch, version = MetadataVersion.V4) {
     if (batch.compression() !== null) {
-        throw new Error("Record batch compression not implemented");
+        throw new Error('Record batch compression not implemented');
     }
     return new RecordBatch(batch.length(), decodeFieldNodes(batch), decodeBuffers(batch, version));
 }

--- a/js/src/ipc/metadata/message.ts
+++ b/js/src/ipc/metadata/message.ts
@@ -297,6 +297,9 @@ function decodeSchema(_schema: _Schema, dictionaries: Map<number, DataType> = ne
 
 /** @ignore */
 function decodeRecordBatch(batch: _RecordBatch, version = MetadataVersion.V4) {
+    if (batch.compression() !== null) {
+        throw new Error("Record batch compression not implemented");
+    }
     return new RecordBatch(batch.length(), decodeFieldNodes(batch), decodeBuffers(batch, version));
 }
 


### PR DESCRIPTION
While https://issues.apache.org/jira/browse/ARROW-8674 is not implemented, ArrowJS will silently provide corrupt (not uncompressed) data to applications when compressed files are passed in. This happens to be the default from Python, e.g. with `df.to_feather('my_file')`.

Opening as a draft as I didn't find how to add a sample file for testing that this behaves as expected. I'd appreciate any pointers on which part of the test suite we can assert this behavior in.