### PR TITLE
ARROW-15994: [C++] Back out taskify changes

### DIFF
--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -437,18 +437,15 @@ void MapNode::SubmitTask(std::function<Result<ExecBatch>(ExecBatch)> map_fn,
   };
 
   status = task();
-  if (input_counter_.Increment()) {
-    this->Finish(status);
-  }
-
-  // If we get a cancelled status from AddTask it means this node was stopped
-  // or errored out already so we can just drop the task.
-  if (!status.ok() && !status.IsCancelled()) {
+  if (!status.ok()) {
     if (input_counter_.Cancel()) {
       this->Finish(status);
     }
     inputs_[0]->StopProducing(this);
     return;
+  }
+  if (input_counter_.Increment()) {
+    this->Finish();
   }
 }
 

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -453,7 +453,7 @@ void MapNode::SubmitTask(std::function<Result<ExecBatch>(ExecBatch)> map_fn,
 }
 
 void MapNode::Finish(Status finish_st /*= Status::OK()*/) {
-    this->finished_.MarkFinished(finish_st);
+  this->finished_.MarkFinished(finish_st);
 }
 
 std::shared_ptr<RecordBatchReader> MakeGeneratorReader(

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -436,22 +436,11 @@ void MapNode::SubmitTask(std::function<Result<ExecBatch>(ExecBatch)> map_fn,
     return Status::OK();
   };
 
-  if (executor_) {
-    status = task_group_.AddTask([this, task]() -> Result<Future<>> {
-      return this->executor_->Submit(this->stop_source_.token(), [this, task]() {
-        auto status = task();
-        if (this->input_counter_.Increment()) {
-          this->Finish(status);
-        }
-        return status;
-      });
-    });
-  } else {
-    status = task();
-    if (input_counter_.Increment()) {
-      this->Finish(status);
-    }
+  status = task();
+  if (input_counter_.Increment()) {
+    this->Finish(status);
   }
+
   // If we get a cancelled status from AddTask it means this node was stopped
   // or errored out already so we can just drop the task.
   if (!status.ok() && !status.IsCancelled()) {
@@ -464,14 +453,7 @@ void MapNode::SubmitTask(std::function<Result<ExecBatch>(ExecBatch)> map_fn,
 }
 
 void MapNode::Finish(Status finish_st /*= Status::OK()*/) {
-  if (executor_) {
-    task_group_.End().AddCallback([this, finish_st](const Status& st) {
-      Status final_status = finish_st & st;
-      this->finished_.MarkFinished(final_status);
-    });
-  } else {
     this->finished_.MarkFinished(finish_st);
-  }
 }
 
 std::shared_ptr<RecordBatchReader> MakeGeneratorReader(

--- a/cpp/src/arrow/compute/exec/exec_plan.h
+++ b/cpp/src/arrow/compute/exec/exec_plan.h
@@ -300,9 +300,6 @@ class MapNode : public ExecNode {
   // Counter for the number of batches received
   AtomicCounter input_counter_;
 
-  // The task group for the corresponding batches
-  util::AsyncTaskGroup task_group_;
-
   ::arrow::internal::Executor* executor_;
 
   // Variable used to cancel remaining tasks in the executor


### PR DESCRIPTION
This PR modifies the `SubmitTask` and `Finish` methods of MapNode in `ExecPlan` to avoid scheduling extra thread tasks.

Performed the TPC-H Benchmark developed in PR #12537 with and without the changes.
```
TPC-H Benchmark (With Extra Thread Tasks)
-------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations
-------------------------------------------------------------------
BM_Tpch_Q1/ScaleFactor:1   95035633 ns       178700 ns          100


TPC-H Benchmark (Without Extra Thread Tasks)
-------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations
-------------------------------------------------------------------
BM_Tpch_Q1/ScaleFactor:1   91511754 ns       182060 ns          100

```

Also, tested with the Query Tester as proposed in PR #12586 
```
With Thread Tasks (batch size = 4096)
./query_tester tpch-1
Average       Duration: 0.106694s (+/- 0s)
Average Output  Rows/S: 37.4902rps
Average Output Bytes/S: 4573.81bps

Without Thread Tasks (batch size = 4096)
./query_tester tpch-1
Average       Duration: 0.104658s (+/- 0s)
Average Output  Rows/S: 38.2198rps
Average Output Bytes/S: 4662.82bps
```