### PR TITLE
ARROW-15643: [C++] Allow selecting subset of fields of a StructArray via cast

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
@@ -164,8 +164,8 @@ struct CastStruct {
     for (int in_field_index = 0;
          in_field_index < in_field_count && out_field_index < out_field_count;
          ++in_field_index) {
-      const auto in_field = in_type.field(in_field_index);
-      const auto out_field = out_type.field(out_field_index);
+      const auto& in_field = in_type.field(in_field_index);
+      const auto& out_field = out_type.field(out_field_index);
       if (in_field->name() == out_field->name()) {
         if (in_field->nullable() && !out_field->nullable()) {
           return Status::TypeError("cannot cast nullable field to non-nullable field: ",
@@ -189,8 +189,8 @@ struct CastStruct {
       if (in_scalar.is_valid) {
         out_field_index = 0;
         for (int field_index : fields_to_select) {
-          auto values = in_scalar.value[field_index];
-          auto target_type = out->type()->field(out_field_index++)->type();
+          const auto& values = in_scalar.value[field_index];
+          const auto& target_type = out->type()->field(out_field_index++)->type();
           ARROW_ASSIGN_OR_RAISE(Datum cast_values,
                                 Cast(values, target_type, options, ctx->exec_context()));
           DCHECK_EQ(Datum::SCALAR, cast_values.kind());
@@ -212,9 +212,9 @@ struct CastStruct {
 
     out_field_index = 0;
     for (int field_index : fields_to_select) {
-      auto values =
+      const auto& values =
           in_array.child_data[field_index]->Slice(in_array.offset, in_array.length);
-      auto target_type = out->type()->field(out_field_index++)->type();
+      const auto& target_type = out->type()->field(out_field_index++)->type();
 
       ARROW_ASSIGN_OR_RAISE(Datum cast_values,
                             Cast(values, target_type, options, ctx->exec_context()));

--- a/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
@@ -153,84 +153,6 @@ void AddListCast(CastFunction* func) {
 struct CastStruct {
   static Status Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
     const CastOptions& options = CastState::Get(ctx);
-    const StructType& in_type = checked_cast<const StructType&>(*batch[0].type());
-    const StructType& out_type = checked_cast<const StructType&>(*out->type());
-    const auto in_field_count = in_type.num_fields();
-
-    if (in_field_count != out_type.num_fields()) {
-      return Status::TypeError("struct field sizes do not match: ", in_type.ToString(),
-                               " ", out_type.ToString());
-    }
-
-    for (int i = 0; i < in_field_count; ++i) {
-      const auto in_field = in_type.field(i);
-      const auto out_field = out_type.field(i);
-      if (in_field->name() != out_field->name()) {
-        return Status::TypeError("struct field names do not match: ", in_type.ToString(),
-                                 " ", out_type.ToString());
-      }
-
-      if (in_field->nullable() && !out_field->nullable()) {
-        return Status::TypeError("cannot cast nullable struct to non-nullable struct: ",
-                                 in_type.ToString(), " ", out_type.ToString());
-      }
-    }
-
-    if (out->kind() == Datum::SCALAR) {
-      const auto& in_scalar = checked_cast<const StructScalar&>(*batch[0].scalar());
-      auto out_scalar = checked_cast<StructScalar*>(out->scalar().get());
-
-      DCHECK(!out_scalar->is_valid);
-      if (in_scalar.is_valid) {
-        for (int i = 0; i < in_field_count; i++) {
-          auto values = in_scalar.value[i];
-          auto target_type = out->type()->field(i)->type();
-          ARROW_ASSIGN_OR_RAISE(Datum cast_values,
-                                Cast(values, target_type, options, ctx->exec_context()));
-          DCHECK_EQ(Datum::SCALAR, cast_values.kind());
-          out_scalar->value.push_back(cast_values.scalar());
-        }
-        out_scalar->is_valid = true;
-      }
-      return Status::OK();
-    }
-
-    const ArrayData& in_array = *batch[0].array();
-    ArrayData* out_array = out->mutable_array();
-
-    if (in_array.buffers[0]) {
-      ARROW_ASSIGN_OR_RAISE(out_array->buffers[0],
-                            CopyBitmap(ctx->memory_pool(), in_array.buffers[0]->data(),
-                                       in_array.offset, in_array.length));
-    }
-
-    for (int i = 0; i < in_field_count; ++i) {
-      auto values = in_array.child_data[i]->Slice(in_array.offset, in_array.length);
-      auto target_type = out->type()->field(i)->type();
-
-      ARROW_ASSIGN_OR_RAISE(Datum cast_values,
-                            Cast(values, target_type, options, ctx->exec_context()));
-
-      DCHECK_EQ(Datum::ARRAY, cast_values.kind());
-      out_array->child_data.push_back(cast_values.array());
-    }
-
-    return Status::OK();
-  }
-};
-
-void AddStructToStructCast(CastFunction* func) {
-  ScalarKernel kernel;
-  kernel.exec = CastStruct::Exec;
-  kernel.signature =
-      KernelSignature::Make({InputType(StructType::type_id)}, kOutputTargetType);
-  kernel.null_handling = NullHandling::COMPUTED_NO_PREALLOCATE;
-  DCHECK_OK(func->AddKernel(StructType::type_id, std::move(kernel)));
-}
-
-struct CastStructSubset {
-  static Status Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-    const CastOptions& options = CastState::Get(ctx);
     const auto& in_type = checked_cast<const StructType&>(*batch[0].type());
     const auto& out_type = checked_cast<const StructType&>(*out->type());
     const int in_field_count = in_type.num_fields();
@@ -305,9 +227,9 @@ struct CastStructSubset {
   }
 };
 
-void AddStructToStructSubsetCast(CastFunction* func) {
+void AddStructToStructCast(CastFunction* func) {
   ScalarKernel kernel;
-  kernel.exec = CastStructSubset::Exec;
+  kernel.exec = CastStruct::Exec;
   kernel.signature =
       KernelSignature::Make({InputType(StructType::type_id)}, kOutputTargetType);
   kernel.null_handling = NullHandling::COMPUTED_NO_PREALLOCATE;
@@ -338,7 +260,6 @@ std::vector<std::shared_ptr<CastFunction>> GetNestedCasts() {
   // So is struct
   auto cast_struct = std::make_shared<CastFunction>("cast_struct", Type::STRUCT);
   AddCommonCasts(Type::STRUCT, kOutputTargetType, cast_struct.get());
-  AddStructToStructSubsetCast(cast_struct.get());
   AddStructToStructCast(cast_struct.get());
 
   // So is dictionary

--- a/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
@@ -168,7 +168,7 @@ struct CastStruct {
       const auto out_field = out_type.field(out_field_index);
       if (in_field->name() == out_field->name()) {
         if (in_field->nullable() && !out_field->nullable()) {
-          return Status::TypeError("cannot cast nullable struct to non-nullable struct: ",
+          return Status::TypeError("cannot cast nullable field to non-nullable field: ",
                                    in_type.ToString(), " ", out_type.ToString());
         }
         fields_to_select[out_field_index++] = in_field_index;
@@ -177,7 +177,7 @@ struct CastStruct {
 
     if (out_field_index < out_field_count) {
       return Status::TypeError(
-          "struct (sub)fields don't match or are in the wrong order: Input fields: ",
+          "struct fields don't match or are in the wrong order: Input fields: ",
           in_type.ToString(), " output fields: ", out_type.ToString());
     }
 

--- a/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
@@ -254,7 +254,7 @@ struct CastStructSubset {
       }
     }
 
-    if (out_field_index < out_field_count - 1) {
+    if (out_field_index < out_field_count) {
       return Status::TypeError(
           "struct subfields names don't match or are in the wrong order: ",
           in_type.ToString(), " ", out_type.ToString());

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -2355,17 +2355,17 @@ static void CheckStructToStructSubsetWithNulls(
 
       std::shared_ptr<Array> a1, b1, c1, d1, e1;
       a1 = ArrayFromJSON(src_value_type, "[1, 2, 5]");
-      b1 = ArrayFromJSON(src_value_type, "[3, 4, 7]");
+      b1 = ArrayFromJSON(src_value_type, "[3, null, 7]");
       c1 = ArrayFromJSON(src_value_type, "[9, 11, 44]");
-      d1 = ArrayFromJSON(src_value_type, "[6, 51, 49]");
-      e1 = ArrayFromJSON(src_value_type, "[19, 17, 74]");
+      d1 = ArrayFromJSON(src_value_type, "[6, 51, null]");
+      e1 = ArrayFromJSON(src_value_type, "[null, 17, 74]");
 
       std::shared_ptr<Array> a2, b2, c2, d2, e2;
       a2 = ArrayFromJSON(dest_value_type, "[1, 2, 5]");
-      b2 = ArrayFromJSON(dest_value_type, "[3, 4, 7]");
+      b2 = ArrayFromJSON(dest_value_type, "[3, null, 7]");
       c2 = ArrayFromJSON(dest_value_type, "[9, 11, 44]");
-      d2 = ArrayFromJSON(dest_value_type, "[6, 51, 49]");
-      e2 = ArrayFromJSON(dest_value_type, "[19, 17, 74]");
+      d2 = ArrayFromJSON(dest_value_type, "[6, 51, null]");
+      e2 = ArrayFromJSON(dest_value_type, "[null, 17, 74]");
 
       std::shared_ptr<Buffer> null_bitmap;
       BitmapFromVector<int>({0, 1, 0}, &null_bitmap);

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -2248,7 +2248,10 @@ static void CheckStructToStruct(
 static void CheckStructToStructSubset(
     const std::vector<std::shared_ptr<DataType>>& value_types) {
   for (const auto& src_value_type : value_types) {
+    ARROW_SCOPED_TRACE("From type: ", src_value_type->ToString());
     for (const auto& dest_value_type : value_types) {
+      ARROW_SCOPED_TRACE("To type: ", dest_value_type->ToString());
+
       std::vector<std::string> field_names = {"a", "b", "c", "d", "e"};
 
       std::shared_ptr<Array> a1, b1, c1, d1, e1;
@@ -2267,48 +2270,84 @@ static void CheckStructToStructSubset(
 
       ASSERT_OK_AND_ASSIGN(auto src,
                            StructArray::Make({a1, b1, c1, d1, e1}, field_names));
-      ASSERT_OK_AND_ASSIGN(
-          auto dest1, StructArray::Make({a2, c2}, std::vector<std::string>{"a", "c"}));
+      ASSERT_OK_AND_ASSIGN(auto dest1,
+                           StructArray::Make({a2}, std::vector<std::string>{"a"}));
       CheckCast(src, dest1);
 
       ASSERT_OK_AND_ASSIGN(
-          auto dest2, StructArray::Make({b2, d2}, std::vector<std::string>{"b", "d"}));
+          auto dest2, StructArray::Make({b2, c2}, std::vector<std::string>{"b", "c"}));
       CheckCast(src, dest2);
 
       ASSERT_OK_AND_ASSIGN(
-          auto dest3, StructArray::Make({c2, e2}, std::vector<std::string>{"c", "e"}));
+          auto dest3,
+          StructArray::Make({c2, d2, e2}, std::vector<std::string>{"c", "d", "e"}));
       CheckCast(src, dest3);
 
       ASSERT_OK_AND_ASSIGN(
-          auto dest4,
-          StructArray::Make({a2, d2, e2}, std::vector<std::string>{"a", "d", "e"}));
+          auto dest4, StructArray::Make({a2, b2, c2, e2},
+                                        std::vector<std::string>{"a", "b", "c", "e"}));
       CheckCast(src, dest4);
 
       ASSERT_OK_AND_ASSIGN(
-          auto dest5,
-          StructArray::Make({b2, c2, e2}, std::vector<std::string>{"b", "c", "e"}));
+          auto dest5, StructArray::Make({a2, b2, c2, d2, e2}, {"a", "b", "c", "d", "e"}));
       CheckCast(src, dest5);
 
-      ASSERT_OK_AND_ASSIGN(
-          auto dest6, StructArray::Make({a2, b2, c2, e2},
-                                        std::vector<std::string>{"a", "b", "c", "e"}));
-      CheckCast(src, dest6);
-
-      ASSERT_OK_AND_ASSIGN(
-          auto dest7, StructArray::Make({a2, b2, c2, d2, e2}, {"a", "b", "c", "d", "e"}));
-      CheckCast(src, dest7);
-
-      const auto dest8 = arrow::struct_({std::make_shared<Field>("a", int8()),
+      // field does not exist
+      const auto dest6 = arrow::struct_({std::make_shared<Field>("a", int8()),
                                          std::make_shared<Field>("d", int16()),
                                          std::make_shared<Field>("f", int64())});
-      const auto options = CastOptions::Safe(dest8);
+      const auto options6 = CastOptions::Safe(dest6);
       EXPECT_RAISES_WITH_MESSAGE_THAT(
           TypeError,
-          ::testing::HasSubstr(
-              "struct (sub)fields don't match or are in the wrong order"),
-          Cast(src, options));
+          ::testing::HasSubstr("struct fields don't match or are in the wrong order"),
+          Cast(src, options6));
 
-      // With nulls
+      // fields in wrong order
+      const auto dest7 = arrow::struct_({std::make_shared<Field>("a", int8()),
+                                         std::make_shared<Field>("c", int16()),
+                                         std::make_shared<Field>("b", int64())});
+      const auto options7 = CastOptions::Safe(dest7);
+      EXPECT_RAISES_WITH_MESSAGE_THAT(
+          TypeError,
+          ::testing::HasSubstr("struct fields don't match or are in the wrong order"),
+          Cast(src, options7));
+
+      // duplicate field names
+      const auto dest8 = arrow::struct_(
+          {std::make_shared<Field>("a", int8()), std::make_shared<Field>("c", int16()),
+           std::make_shared<Field>("d", int32()), std::make_shared<Field>("a", int64())});
+      const auto options8 = CastOptions::Safe(dest8);
+      EXPECT_RAISES_WITH_MESSAGE_THAT(
+          TypeError,
+          ::testing::HasSubstr("struct fields don't match or are in the wrong order"),
+          Cast(src, options8));
+    }
+  }
+}
+
+static void CheckStructToStructSubsetWithNulls(
+    const std::vector<std::shared_ptr<DataType>>& value_types) {
+  for (const auto& src_value_type : value_types) {
+    ARROW_SCOPED_TRACE("From type: ", src_value_type->ToString());
+    for (const auto& dest_value_type : value_types) {
+      ARROW_SCOPED_TRACE("To type: ", dest_value_type->ToString());
+
+      std::vector<std::string> field_names = {"a", "b", "c", "d", "e"};
+
+      std::shared_ptr<Array> a1, b1, c1, d1, e1;
+      a1 = ArrayFromJSON(src_value_type, "[1, 2, 5]");
+      b1 = ArrayFromJSON(src_value_type, "[3, 4, 7]");
+      c1 = ArrayFromJSON(src_value_type, "[9, 11, 44]");
+      d1 = ArrayFromJSON(src_value_type, "[6, 51, 49]");
+      e1 = ArrayFromJSON(src_value_type, "[19, 17, 74]");
+
+      std::shared_ptr<Array> a2, b2, c2, d2, e2;
+      a2 = ArrayFromJSON(dest_value_type, "[1, 2, 5]");
+      b2 = ArrayFromJSON(dest_value_type, "[3, 4, 7]");
+      c2 = ArrayFromJSON(dest_value_type, "[9, 11, 44]");
+      d2 = ArrayFromJSON(dest_value_type, "[6, 51, 49]");
+      e2 = ArrayFromJSON(dest_value_type, "[19, 17, 74]");
+
       std::shared_ptr<Buffer> null_bitmap;
       BitmapFromVector<int>({0, 1, 0}, &null_bitmap);
 
@@ -2316,53 +2355,62 @@ static void CheckStructToStructSubset(
                                                             field_names, null_bitmap));
       ASSERT_OK_AND_ASSIGN(
           auto dest1_null,
-          StructArray::Make({a2, c2}, std::vector<std::string>{"a", "c"}, null_bitmap));
+          StructArray::Make({a2}, std::vector<std::string>{"a"}, null_bitmap));
       CheckCast(src_null, dest1_null);
 
       ASSERT_OK_AND_ASSIGN(
           auto dest2_null,
-          StructArray::Make({b2, d2}, std::vector<std::string>{"b", "d"}, null_bitmap));
+          StructArray::Make({b2, c2}, std::vector<std::string>{"b", "c"}, null_bitmap));
       CheckCast(src_null, dest2_null);
 
       ASSERT_OK_AND_ASSIGN(
           auto dest3_null,
-          StructArray::Make({c2, e2}, std::vector<std::string>{"c", "e"}, null_bitmap));
+          StructArray::Make({a2, d2, e2}, std::vector<std::string>{"a", "d", "e"},
+                            null_bitmap));
       CheckCast(src_null, dest3_null);
 
       ASSERT_OK_AND_ASSIGN(
           auto dest4_null,
-          StructArray::Make({a2, d2, e2}, std::vector<std::string>{"a", "d", "e"},
-                            null_bitmap));
+          StructArray::Make({a2, b2, c2, e2},
+                            std::vector<std::string>{"a", "b", "c", "e"}, null_bitmap));
       CheckCast(src_null, dest4_null);
 
       ASSERT_OK_AND_ASSIGN(
           auto dest5_null,
-          StructArray::Make({b2, c2, e2}, std::vector<std::string>{"b", "c", "e"},
-                            null_bitmap));
-      CheckCast(src_null, dest5_null);
-
-      ASSERT_OK_AND_ASSIGN(
-          auto dest6_null,
-          StructArray::Make({a2, b2, c2, e2},
-                            std::vector<std::string>{"a", "b", "c", "e"}, null_bitmap));
-      CheckCast(src_null, dest6_null);
-
-      ASSERT_OK_AND_ASSIGN(
-          auto dest7_null,
           StructArray::Make({a2, b2, c2, d2, e2},
                             std::vector<std::string>{"a", "b", "c", "d", "e"},
                             null_bitmap));
-      CheckCast(src_null, dest7_null);
+      CheckCast(src_null, dest5_null);
 
-      const auto dest8_null = arrow::struct_({std::make_shared<Field>("a", int8()),
+      // field does not exist
+      const auto dest6_null = arrow::struct_({std::make_shared<Field>("a", int8()),
                                               std::make_shared<Field>("d", int16()),
                                               std::make_shared<Field>("f", int64())});
-      const auto options_null = CastOptions::Safe(dest8_null);
+      const auto options6_null = CastOptions::Safe(dest6_null);
       EXPECT_RAISES_WITH_MESSAGE_THAT(
           TypeError,
-          ::testing::HasSubstr(
-              "struct (sub)fields don't match or are in the wrong order"),
-          Cast(src_null, options_null));
+          ::testing::HasSubstr("struct fields don't match or are in the wrong order"),
+          Cast(src_null, options6_null));
+
+      // fields in wrong order
+      const auto dest7_null = arrow::struct_({std::make_shared<Field>("a", int8()),
+                                              std::make_shared<Field>("c", int16()),
+                                              std::make_shared<Field>("b", int64())});
+      const auto options7_null = CastOptions::Safe(dest7_null);
+      EXPECT_RAISES_WITH_MESSAGE_THAT(
+          TypeError,
+          ::testing::HasSubstr("struct fields don't match or are in the wrong order"),
+          Cast(src_null, options7_null));
+
+      // duplicate field names
+      const auto dest8_null = arrow::struct_(
+          {std::make_shared<Field>("a", int8()), std::make_shared<Field>("c", int16()),
+           std::make_shared<Field>("d", int32()), std::make_shared<Field>("a", int64())});
+      const auto options8_null = CastOptions::Safe(dest8_null);
+      EXPECT_RAISES_WITH_MESSAGE_THAT(
+          TypeError,
+          ::testing::HasSubstr("struct fields don't match or are in the wrong order"),
+          Cast(src_null, options8_null));
     }
   }
 }
@@ -2370,6 +2418,10 @@ static void CheckStructToStructSubset(
 TEST(Cast, StructToSameSizedAndNamedStruct) { CheckStructToStruct(NumericTypes()); }
 
 TEST(Cast, StructToStructSubset) { CheckStructToStructSubset(NumericTypes()); }
+
+TEST(Cast, StructToStructSubsetWithNulls) {
+  CheckStructToStructSubsetWithNulls(NumericTypes());
+}
 
 TEST(Cast, StructToSameSizedButDifferentNamedStruct) {
   std::vector<std::string> field_names = {"a", "b"};
@@ -2384,11 +2436,11 @@ TEST(Cast, StructToSameSizedButDifferentNamedStruct) {
 
   EXPECT_RAISES_WITH_MESSAGE_THAT(
       TypeError,
-      ::testing::HasSubstr("struct (sub)fields don't match or are in the wrong order"),
+      ::testing::HasSubstr("struct fields don't match or are in the wrong order"),
       Cast(src, options));
 }
 
-TEST(Cast, StructToLargerSizeStruct) {
+TEST(Cast, StructToBiggerStruct) {
   std::vector<std::string> field_names = {"a", "b"};
   std::shared_ptr<Array> a, b;
   a = ArrayFromJSON(int8(), "[1, 2]");
@@ -2402,51 +2454,102 @@ TEST(Cast, StructToLargerSizeStruct) {
 
   EXPECT_RAISES_WITH_MESSAGE_THAT(
       TypeError,
-      ::testing::HasSubstr("struct (sub)fields don't match or are in the wrong order"),
+      ::testing::HasSubstr("struct fields don't match or are in the wrong order"),
       Cast(src, options));
 }
 
-TEST(Cast, StructToSameSizedButDifferentNullabilityStruct) {
-  // OK to go from not-nullable to nullable...
-  std::vector<std::shared_ptr<Field>> fields1 = {
-      std::make_shared<Field>("a", int8(), false),
-      std::make_shared<Field>("b", int8(), false)};
-  std::shared_ptr<Array> a1, b1;
-  a1 = ArrayFromJSON(int8(), "[1, 2]");
-  b1 = ArrayFromJSON(int8(), "[3, 4]");
-  ASSERT_OK_AND_ASSIGN(auto src1, StructArray::Make({a1, b1}, fields1));
+TEST(Cast, StructToDifferentNullabilityStruct) {
+  {
+    // OK to go from non-nullable to nullable...
+    ARROW_SCOPED_TRACE("From non-nullable to nullable");
+    std::vector<std::shared_ptr<Field>> fields_src_non_nullable = {
+        std::make_shared<Field>("a", int8(), false),
+        std::make_shared<Field>("b", int8(), false),
+        std::make_shared<Field>("c", int8(), false)};
+    std::shared_ptr<Array> a_src_non_nullable, b_src_non_nullable, c_src_non_nullable;
+    a_src_non_nullable = ArrayFromJSON(int8(), "[11, 23, 56]");
+    b_src_non_nullable = ArrayFromJSON(int8(), "[32, 46, 37]");
+    c_src_non_nullable = ArrayFromJSON(int8(), "[95, 11, 44]");
+    ASSERT_OK_AND_ASSIGN(
+        auto src_non_nullable,
+        StructArray::Make({a_src_non_nullable, b_src_non_nullable, c_src_non_nullable},
+                          fields_src_non_nullable));
 
-  std::vector<std::shared_ptr<Field>> fields2 = {
-      std::make_shared<Field>("a", int8(), true),
-      std::make_shared<Field>("b", int8(), true)};
-  std::shared_ptr<Array> a2, b2;
-  a2 = ArrayFromJSON(int8(), "[1, 2]");
-  b2 = ArrayFromJSON(int8(), "[3, 4]");
-  ASSERT_OK_AND_ASSIGN(auto dest1, StructArray::Make({a2, b2}, fields2));
+    std::shared_ptr<Array> a_dest_nullable, b_dest_nullable, c_dest_nullable;
+    a_dest_nullable = ArrayFromJSON(int64(), "[11, 23, 56]");
+    b_dest_nullable = ArrayFromJSON(int64(), "[32, 46, 37]");
+    c_dest_nullable = ArrayFromJSON(int64(), "[95, 11, 44]");
 
-  CheckCast(src1, dest1);
+    std::vector<std::shared_ptr<Field>> fields_dest1_nullable = {
+        std::make_shared<Field>("a", int64(), true),
+        std::make_shared<Field>("b", int64(), true),
+        std::make_shared<Field>("c", int64(), true)};
+    ASSERT_OK_AND_ASSIGN(
+        auto dest1_nullable,
+        StructArray::Make({a_dest_nullable, b_dest_nullable, c_dest_nullable},
+                          fields_dest1_nullable));
+    CheckCast(src_non_nullable, dest1_nullable);
 
-  // But not the other way around
-  std::vector<std::shared_ptr<Field>> fields3 = {
-      std::make_shared<Field>("a", int8(), true),
-      std::make_shared<Field>("b", int8(), true)};
-  std::shared_ptr<Array> a3, b3;
-  a3 = ArrayFromJSON(int8(), "[1, null]");
-  b3 = ArrayFromJSON(int8(), "[3, 4]");
-  ASSERT_OK_AND_ASSIGN(auto src2, StructArray::Make({a3, b3}, fields3));
+    std::vector<std::shared_ptr<Field>> fields_dest2_nullable = {
+        std::make_shared<Field>("a", int64(), true),
+        std::make_shared<Field>("c", int64(), true)};
+    ASSERT_OK_AND_ASSIGN(
+        auto dest2_nullable,
+        StructArray::Make({a_dest_nullable, c_dest_nullable}, fields_dest2_nullable));
+    CheckCast(src_non_nullable, dest2_nullable);
 
-  std::vector<std::shared_ptr<Field>> fields4 = {
-      std::make_shared<Field>("a", int8(), false),
-      std::make_shared<Field>("b", int8(), false)};
-  const auto dest2 = arrow::struct_(fields4);
-  const auto options = CastOptions::Safe(dest2);
+    std::vector<std::shared_ptr<Field>> fields_dest3_nullable = {
+        std::make_shared<Field>("b", int64(), true)};
+    ASSERT_OK_AND_ASSIGN(auto dest3_nullable,
+                         StructArray::Make({b_dest_nullable}, fields_dest3_nullable));
+    CheckCast(src_non_nullable, dest3_nullable);
+  }
+  {
+    // But NOT OK to go from nullable to non-nullable...
+    ARROW_SCOPED_TRACE("From nullable to non-nullable");
+    std::vector<std::shared_ptr<Field>> fields_src_nullable = {
+        std::make_shared<Field>("a", int8(), true),
+        std::make_shared<Field>("b", int8(), true),
+        std::make_shared<Field>("c", int8(), true)};
+    std::shared_ptr<Array> a_src_nullable, b_src_nullable, c_src_nullable;
+    a_src_nullable = ArrayFromJSON(int8(), "[1, null, 5]");
+    b_src_nullable = ArrayFromJSON(int8(), "[3, 4, null]");
+    c_src_nullable = ArrayFromJSON(int8(), "[9, 11, 44]");
+    ASSERT_OK_AND_ASSIGN(
+        auto src_nullable,
+        StructArray::Make({a_src_nullable, b_src_nullable, c_src_nullable},
+                          fields_src_nullable));
 
-  EXPECT_RAISES_WITH_MESSAGE_THAT(
-      TypeError,
-      ::testing::HasSubstr(
-          "Type error: cannot cast nullable struct to non-nullable "
-          "struct: struct<a: int8, b: int8> struct<a: int8 not null, b: int8 not null>"),
-      Cast(src2, options));
+    std::vector<std::shared_ptr<Field>> fields_dest1_non_nullable = {
+        std::make_shared<Field>("a", int64(), false),
+        std::make_shared<Field>("b", int64(), false),
+        std::make_shared<Field>("c", int64(), false)};
+    const auto dest1_non_nullable = arrow::struct_(fields_dest1_non_nullable);
+    const auto options1_non_nullable = CastOptions::Safe(dest1_non_nullable);
+    EXPECT_RAISES_WITH_MESSAGE_THAT(
+        TypeError,
+        ::testing::HasSubstr("cannot cast nullable field to non-nullable field"),
+        Cast(src_nullable, options1_non_nullable));
+
+    std::vector<std::shared_ptr<Field>> fields_dest2_non_nullble = {
+        std::make_shared<Field>("a", int64(), false),
+        std::make_shared<Field>("c", int64(), false)};
+    const auto dest2_non_nullable = arrow::struct_(fields_dest2_non_nullble);
+    const auto options2_non_nullable = CastOptions::Safe(dest2_non_nullable);
+    EXPECT_RAISES_WITH_MESSAGE_THAT(
+        TypeError,
+        ::testing::HasSubstr("cannot cast nullable field to non-nullable field"),
+        Cast(src_nullable, options2_non_nullable));
+
+    std::vector<std::shared_ptr<Field>> fields_dest3_non_nullble = {
+        std::make_shared<Field>("c", int64(), false)};
+    const auto dest3_non_nullable = arrow::struct_(fields_dest3_non_nullble);
+    const auto options3_non_nullable = CastOptions::Safe(dest3_non_nullable);
+    EXPECT_RAISES_WITH_MESSAGE_THAT(
+        TypeError,
+        ::testing::HasSubstr("cannot cast nullable field to non-nullable field"),
+        Cast(src_nullable, options3_non_nullable));
+  }
 }
 
 TEST(Cast, IdentityCasts) {

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -2329,6 +2329,26 @@ TEST(Cast, StructToSameSizedButDifferentNullabilityStruct) {
       Cast(src2, options));
 }
 
+TEST(Cats, StructSubset) {
+  std::vector<std::string> field_names = {"a", "b", "c"};
+  std::shared_ptr<Array> a, b, c;
+  a = ArrayFromJSON(int8(), "[1, 2, 5]");
+  b = ArrayFromJSON(int8(), "[3, 4, 7]");
+  c = ArrayFromJSON(int8(), "[9, 11, 44]");
+  ASSERT_OK_AND_ASSIGN(auto src, StructArray::Make({a, b, c}, field_names));
+  ASSERT_OK_AND_ASSIGN(auto dest, StructArray::Make({a, c}, {"a", "c"}));
+
+  //  const auto dest = arrow::struct_(
+  //      {std::make_shared<Field>("a", int8()), std::make_shared<Field>("c", int8())});
+
+  //  const auto options = CastOptions::Safe(dest);
+  //
+  //  auto res = Cast(src, options).ValueOrDie();
+  //  ARROW_LOG(WARNING) << res.make_array()->ToString();
+
+  CheckCast(src, dest);
+}
+
 TEST(Cast, IdentityCasts) {
   // ARROW-4102
   auto CheckIdentityCast = [](std::shared_ptr<DataType> type, const std::string& json) {

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -1657,7 +1657,7 @@ TEST(ScanNode, MaterializationOfNestedVirtualColumn) {
   // TODO(ARROW-1888): allow scanner to "patch up" structs with casts
   EXPECT_FINISHES_AND_RAISES_WITH_MESSAGE_THAT(
       TypeError,
-      ::testing::HasSubstr("struct (sub)fields don't match or are in the wrong order"),
+      ::testing::HasSubstr("struct fields don't match or are in the wrong order"),
       plan.Run());
 }
 

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -1656,7 +1656,10 @@ TEST(ScanNode, MaterializationOfNestedVirtualColumn) {
 
   // TODO(ARROW-1888): allow scanner to "patch up" structs with casts
   EXPECT_FINISHES_AND_RAISES_WITH_MESSAGE_THAT(
-      TypeError, ::testing::HasSubstr("struct field sizes do not match"), plan.Run());
+      TypeError,
+      ::testing::HasSubstr(
+          "struct subfields names don't match or are in the wrong order"),
+      plan.Run());
 }
 
 TEST(ScanNode, MinimalEndToEnd) {

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -1657,8 +1657,7 @@ TEST(ScanNode, MaterializationOfNestedVirtualColumn) {
   // TODO(ARROW-1888): allow scanner to "patch up" structs with casts
   EXPECT_FINISHES_AND_RAISES_WITH_MESSAGE_THAT(
       TypeError,
-      ::testing::HasSubstr(
-          "struct subfields names don't match or are in the wrong order"),
+      ::testing::HasSubstr("struct (sub)fields don't match or are in the wrong order"),
       plan.Run());
 }
 


### PR DESCRIPTION
Provide the ability to select a subset of the fields of a StructArray array by casting it to the required fields, provided the fields exist in the StructArray.