### PR TITLE
MINOR: [DOC] CDataInterface.rst: fix ReleaseExportedArray() example

### DIFF
--- a/docs/source/format/CDataInterface.rst
+++ b/docs/source/format/CDataInterface.rst
@@ -589,7 +589,7 @@ TODO area must be filled with producer-specific deallocation code:
 
    static void ReleaseExportedArray(struct ArrowArray* array) {
      // This should not be called on already released array
-     assert(array->format != NULL);
+     assert(array->release != NULL);
 
      // Release children
      for (int64_t i = 0; i < array->n_children; ++i) {


### PR DESCRIPTION
The initial assertion ``array->format != NULL`` refers to a non-existing field. I assume that this was intended to be the release callback