### PR TITLE
MINOR: [JS] Update dev dependency gulp-vinyl-size

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -94,7 +94,7 @@
     "gulp-sourcemaps": "3.0.0",
     "gulp-terser": "2.1.0",
     "gulp-typescript": "5.0.1",
-    "gulp-vinyl-size": "1.0.1",
+    "gulp-vinyl-size": "1.1.3",
     "ix": "4.5.2",
     "jest": "27.5.1",
     "jest-silent-reporter": "0.5.0",

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -4216,10 +4216,10 @@ file-uri-to-path@1.0.0:
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
   integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
-filesize@^6.1.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/filesize/-/filesize-6.4.0.tgz#914f50471dd66fdca3cefe628bd0cde4ef769bcd"
-  integrity sha512-mjFIpOHC4jbfcTfoh4rkWpI31mF7viw9ikj/JyLoKzqlwG/YsefKfvYlYhdYdg/9mtK2z1AzgN/0LvVQ3zdlSQ==
+filesize@^8.0.7:
+  version "8.0.7"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-8.0.7.tgz#695e70d80f4e47012c132d57a059e80c6b580bd8"
+  integrity sha512-pjmC+bkIF8XI7fWaH8KxHcZL3DPybs1roSKP4rKDvy20tAWwIObE4+JIseG2byfGKhud5ZnM4YSGKBz7Sh0ndQ==
 
 fill-range@^4.0.0:
   version "4.0.0"
@@ -4850,14 +4850,14 @@ gulp-typescript@5.0.1:
     vinyl "^2.1.0"
     vinyl-fs "^3.0.3"
 
-gulp-vinyl-size@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/gulp-vinyl-size/-/gulp-vinyl-size-1.0.1.tgz#c8e841885ed0d1265d93a36e609f1b38bbd5b5cb"
-  integrity sha512-HLCioBB8624qiUbD2sa1A0VpdqV5emv0VkCLwpK4P+BObzg6kKaJvKKbMYc42L39wb2QjTIJ0OczDThMfRC3Zw==
+gulp-vinyl-size@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/gulp-vinyl-size/-/gulp-vinyl-size-1.1.3.tgz#9916e15a7b504289a1d443ed6f55cbdea47d0be3"
+  integrity sha512-ZIBCHldmuhAFK6ioH7ZRPw00oRwVjFDBIKfpAMwjK6f2MfH+nyQWmBnGpQ06rmUZH0fATKCR8Kop7+VgBjWsBg==
   dependencies:
     fancy-log "^1.3.3"
-    filesize "^6.1.0"
-    gzip-size "^5.1.1"
+    filesize "^8.0.7"
+    gzip-size "^6.0.0"
 
 gulp@4.0.2:
   version "4.0.2"
@@ -4875,14 +4875,6 @@ gulplog@^1.0.0:
   integrity sha1-4oxNRdBey77YGDY86PnFkmIp/+U=
   dependencies:
     glogg "^1.0.0"
-
-gzip-size@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-5.1.1.tgz#cb9bee692f87c0612b232840a873904e4c135274"
-  integrity sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==
-  dependencies:
-    duplexer "^0.1.1"
-    pify "^4.0.1"
 
 gzip-size@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
A minor version bump for [gulp-vinyl-size](https://www.npmjs.com/package/gulp-vinyl-size). As the first big user of that thing I thought I'd let ya'll know of the update.

The only difference for Apache Arrow will be that when `yarn run test:bundle` is run, the size values will be in SI units `kB` (1000B) instead of JEDEC `KB` (1024B).

It'll also remove the need for both gzip-size `5.1.1` _and_ `6.0.0` (the latter is already being pulled in by webpack-bundle-analyzer).