### PR TITLE
ARROW-15665: [C++] Fix error_is_null in strptime with invalid inputs

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -1841,14 +1841,14 @@ TYPED_TEST(TestBaseBinaryKernels, ExtractRegexInvalid) {
 
 TYPED_TEST(TestStringKernels, Strptime) {
   std::string input1 = R"(["5/1/2020", null, null, "12/13/1900", null])";
-  std::string input2 = R"(["5/1/2020", "12/13/1900"])";
+  std::string input2 = R"(["5-1-2020", "12/13/1900"])";
   std::string input3 = R"(["5/1/2020", "AA/BB/CCCC"])";
   std::string input4 = R"(["5/1/2020", "AA/BB/CCCC", "AA/BB/CCCC", "AA/BB/CCCC", null])";
   std::string input5 = R"(["5/1/2020 %z", null, null, "12/13/1900 %z", null])";
   std::string output1 = R"(["2020-05-01", null, null, "1900-12-13", null])";
-  std::string output4 = R"(["2020-01-05", null, null, null, null])";
-  std::string output2 = R"(["2020-05-01", "1900-12-13"])";
+  std::string output2 = R"([null, "1900-12-13"])";
   std::string output3 = R"(["2020-05-01", null])";
+  std::string output4 = R"(["2020-01-05", null, null, null, null])";
 
   StrptimeOptions options("%m/%d/%Y", TimeUnit::MICRO, /*error_is_null=*/true);
   auto unit = timestamp(TimeUnit::MICRO);

--- a/cpp/src/arrow/compute/kernels/scalar_temporal_unary.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_unary.cc
@@ -1230,6 +1230,7 @@ struct Strptime {
         if ((*self.parser)(s.data(), s.size(), self.unit, &result)) {
           *out_data++ = result;
         } else {
+          out_data++;
           out_writer.Clear();
           null_count++;
         }


### PR DESCRIPTION
As reported by @dragosmg the following:
```
StrptimeOptions options("%m/%d/%Y", TimeUnit::MICRO, /*error_is_null=*/true);
std::string input2 = R"(["5-1-2020", "12/13/1900"])";
std::string output2 = R"([null, "1900-12-13"])";
Strptime(input2, options)
```
Would cause:
```
Expected:
  [
    null,
    1900-12-13 00:00:00.000000
  ]
Actual:
  [
    null,
    1970-01-01 00:00:00.000000
  ]
```
This was due to out_data pointer not updating on failed parsing.

This change fixes the issue and adds a test.