### PR TITLE
ARROW-15857: [R] rhub/fedora-clang-devel fails to install 'sass' (rmarkdown dependency)

### DIFF
--- a/ci/scripts/r_docker_configure.sh
+++ b/ci/scripts/r_docker_configure.sh
@@ -52,6 +52,9 @@ if [ "$RHUB_PLATFORM" = "linux-x86_64-fedora-clang" ]; then
 
   sed -i.bak -E -e 's/(CXXFLAGS = )(.*)/\1 -g -O3 -Wall -pedantic -frtti -fPIC/' $(${R_BIN} RHOME)/etc/Makeconf
   rm -rf $(${R_BIN} RHOME)/etc/Makeconf.bak
+
+  sed -i.bak -E -e 's/(LDFLAGS =.*)/\1 -stdlib=libc++/g' $(${R_BIN} RHOME)/etc/Makeconf
+  rm -rf $(${R_BIN} RHOME)/etc/Makeconf.bak
 fi
 
 # Special hacking to try to reproduce quirks on centos using non-default build


### PR DESCRIPTION
Fixes the nightly build failures for rhub/fedora-clang-devel (github-test-r-linux-as-cran). (For example, https://github.com/ursacomputing/crossbow/runs/5713825093?check_suite_focus=true#step:5:3011). The gist of the problem is that `-stdlib=libc++` is in CXXFLAGS but not LDFLAGS.

@jonkeane I have no idea how to test to make sure this works!