### PR TITLE
ARROW-16049: [C++][FlightRPC] Fix Flight SQL's ColumnMetadata constructor visibility

### DIFF
--- a/cpp/src/arrow/flight/sql/column_metadata.cc
+++ b/cpp/src/arrow/flight/sql/column_metadata.cc
@@ -49,7 +49,8 @@ const char* ColumnMetadata::kIsCaseSensitive = "ARROW:FLIGHT:SQL:IS_CASE_SENSITI
 const char* ColumnMetadata::kIsReadOnly = "ARROW:FLIGHT:SQL:IS_READ_ONLY";
 const char* ColumnMetadata::kIsSearchable = "ARROW:FLIGHT:SQL:IS_SEARCHABLE";
 
-ColumnMetadata::ColumnMetadata(std::shared_ptr<arrow::KeyValueMetadata> metadata_map)
+ColumnMetadata::ColumnMetadata(
+    std::shared_ptr<const arrow::KeyValueMetadata> metadata_map)
     : metadata_map_(std::move(metadata_map)) {}
 
 arrow::Result<std::string> ColumnMetadata::GetCatalogName() const {
@@ -106,7 +107,8 @@ ColumnMetadata::ColumnMetadataBuilder ColumnMetadata::Builder() {
   return ColumnMetadataBuilder{};
 }
 
-const std::shared_ptr<arrow::KeyValueMetadata>& ColumnMetadata::metadata_map() const {
+const std::shared_ptr<const arrow::KeyValueMetadata>& ColumnMetadata::metadata_map()
+    const {
   return metadata_map_;
 }
 

--- a/cpp/src/arrow/flight/sql/column_metadata.h
+++ b/cpp/src/arrow/flight/sql/column_metadata.h
@@ -28,11 +28,12 @@ namespace sql {
 /// \brief Helper class to set column metadata.
 class ColumnMetadata {
  private:
-  std::shared_ptr<arrow::KeyValueMetadata> metadata_map_;
-  explicit ColumnMetadata(std::shared_ptr<arrow::KeyValueMetadata> metadata_map);
+  std::shared_ptr<const arrow::KeyValueMetadata> metadata_map_;
 
  public:
   class ColumnMetadataBuilder;
+
+  explicit ColumnMetadata(std::shared_ptr<const arrow::KeyValueMetadata> metadata_map);
 
   /// \brief Constant variable to hold the value of the key that
   ///        will be used in the KeyValueMetadata class.
@@ -103,7 +104,7 @@ class ColumnMetadata {
 
   /// \brief  Return the KeyValueMetadata.
   /// \return The KeyValueMetadata.
-  const std::shared_ptr<arrow::KeyValueMetadata>& metadata_map() const;
+  const std::shared_ptr<const arrow::KeyValueMetadata>& metadata_map() const;
 
   /// \brief A builder class to construct the ColumnMetadata object.
   class ColumnMetadataBuilder {


### PR DESCRIPTION
User should be able to get a ColumnMetadata object from a `std::shared_ptr<const arrow::KeyValueMetadata>` object, but the
constructor was not public to do so.