### PR TITLE
ARROW-16051: [Gandiva][C++] Fix datediff regression build

### DIFF
--- a/cpp/src/gandiva/function_registry_datetime.cc
+++ b/cpp/src/gandiva/function_registry_datetime.cc
@@ -155,6 +155,9 @@ std::vector<NativeFunction> GetDateTimeFunctionRegistry() {
           NativeFunction::kNeedsContext | NativeFunction::kNeedsFunctionHolder |
               NativeFunction::kCanReturnErrors),
 
+      NativeFunction("datediff", {}, DataTypeVector{timestamp(), timestamp()}, int32(),
+                     kResultNullIfNull, "datediff_timestamp_timestamp"),
+
       DATE_TYPES(LAST_DAY_SAFE_NULL_IF_NULL, last_day, {}),
       BASE_NUMERIC_TYPES(TO_TIME_SAFE_NULL_IF_NULL, to_time, {}),
       BASE_NUMERIC_TYPES(TO_TIMESTAMP_SAFE_NULL_IF_NULL, to_timestamp, {})};

--- a/cpp/src/gandiva/function_registry_timestamp_arithmetic.cc
+++ b/cpp/src/gandiva/function_registry_timestamp_arithmetic.cc
@@ -58,7 +58,7 @@ std::vector<NativeFunction> GetDateTimeArithmeticFunctionRegistry() {
       TIMESTAMP_DIFF_FN(timestampdiffSecond, {}),
       TIMESTAMP_DIFF_FN(timestampdiffMinute, {}),
       TIMESTAMP_DIFF_FN(timestampdiffHour, {}),
-      TIMESTAMP_DIFF_FN(timestampdiffDay, {"datediff"}),
+      TIMESTAMP_DIFF_FN(timestampdiffDay, {}),
       TIMESTAMP_DIFF_FN(timestampdiffWeek, {}),
       TIMESTAMP_DIFF_FN(timestampdiffMonth, {}),
       TIMESTAMP_DIFF_FN(timestampdiffQuarter, {}),

--- a/cpp/src/gandiva/precompiled/time.cc
+++ b/cpp/src/gandiva/precompiled/time.cc
@@ -991,6 +991,13 @@ CAST_NULLABLE_INTERVAL_DAY(int64)
     return value;                                                                      \
   }
 
+FORCE_INLINE
+gdv_int32 datediff_timestamp_timestamp(gdv_timestamp start_millis,
+                                       gdv_timestamp end_millis) {
+  return static_cast<int32_t>(
+      ((start_millis - end_millis) / (24 * (60 * (60 * (1000))))));
+}
+
 CAST_NULLABLE_INTERVAL_YEAR(int32)
 CAST_NULLABLE_INTERVAL_YEAR(int64)
 

--- a/cpp/src/gandiva/precompiled/time_test.cc
+++ b/cpp/src/gandiva/precompiled/time_test.cc
@@ -223,6 +223,36 @@ TEST(TestTime, TestExtractTime) {
   EXPECT_EQ(extractSecond_time32(time_as_millis_in_day), 33);
 }
 
+TEST(TestTime, TestDateDiff) {
+  gdv_timestamp ts1 = StringToTimestamp("2019-06-30 00:00:00");
+  gdv_timestamp ts2 = StringToTimestamp("2019-05-31 00:00:00");
+  EXPECT_EQ(datediff_timestamp_timestamp(ts1, ts2), 30);
+
+  ts1 = StringToTimestamp("2019-06-30 00:00:00");
+  ts2 = StringToTimestamp("2019-02-28 00:00:00");
+  EXPECT_EQ(datediff_timestamp_timestamp(ts1, ts2), 122);
+
+  ts1 = StringToTimestamp("2019-06-30 00:00:00");
+  ts2 = StringToTimestamp("2019-03-31 00:00:00");
+  EXPECT_EQ(datediff_timestamp_timestamp(ts1, ts2), 91);
+
+  ts1 = StringToTimestamp("2019-06-30 00:00:00");
+  ts2 = StringToTimestamp("2019-06-30 00:00:00");
+  EXPECT_EQ(datediff_timestamp_timestamp(ts1, ts2), 0);
+
+  ts1 = StringToTimestamp("2019-06-30 00:00:00");
+  ts2 = StringToTimestamp("2019-07-31 00:00:00");
+  EXPECT_EQ(datediff_timestamp_timestamp(ts1, ts2), -31);
+
+  ts1 = StringToTimestamp("2019-06-30 00:00:00");
+  ts2 = StringToTimestamp("2019-07-30 00:00:00");
+  EXPECT_EQ(datediff_timestamp_timestamp(ts1, ts2), -30);
+
+  ts1 = StringToTimestamp("2019-06-30 00:00:00");
+  ts2 = StringToTimestamp("2019-07-29 00:00:00");
+  EXPECT_EQ(datediff_timestamp_timestamp(ts1, ts2), -29);
+}
+
 TEST(TestTime, TestTimestampDiffMonth) {
   gdv_timestamp ts1 = StringToTimestamp("2019-06-30 00:00:00");
   gdv_timestamp ts2 = StringToTimestamp("2019-05-31 00:00:00");

--- a/cpp/src/gandiva/precompiled/time_test.cc
+++ b/cpp/src/gandiva/precompiled/time_test.cc
@@ -241,6 +241,10 @@ TEST(TestTime, TestDateDiff) {
   EXPECT_EQ(datediff_timestamp_timestamp(ts1, ts2), 0);
 
   ts1 = StringToTimestamp("2019-06-30 00:00:00");
+  ts2 = StringToTimestamp("2019-07-01 00:00:00");
+  EXPECT_EQ(datediff_timestamp_timestamp(ts1, ts2), -1);
+
+  ts1 = StringToTimestamp("2019-06-30 00:00:00");
   ts2 = StringToTimestamp("2019-07-31 00:00:00");
   EXPECT_EQ(datediff_timestamp_timestamp(ts1, ts2), -31);
 

--- a/cpp/src/gandiva/precompiled/timestamp_arithmetic.cc
+++ b/cpp/src/gandiva/precompiled/timestamp_arithmetic.cc
@@ -67,7 +67,7 @@ extern "C" {
 #define TIMESTAMP_DIFF_FIXED_UNITS(TYPE, NAME, FROM_MILLIS)                          \
   FORCE_INLINE                                                                       \
   gdv_int32 NAME##_##TYPE##_##TYPE(gdv_##TYPE start_millis, gdv_##TYPE end_millis) { \
-    return static_cast<int32_t>(FROM_MILLIS(start_millis - end_millis));             \
+    return static_cast<int32_t>(FROM_MILLIS(end_millis - start_millis));             \
   }
 
 #define SIGN_ADJUST_DIFF(is_positive, diff) ((is_positive) ? (diff) : -(diff))

--- a/cpp/src/gandiva/precompiled/timestamp_arithmetic.cc
+++ b/cpp/src/gandiva/precompiled/timestamp_arithmetic.cc
@@ -67,7 +67,7 @@ extern "C" {
 #define TIMESTAMP_DIFF_FIXED_UNITS(TYPE, NAME, FROM_MILLIS)                          \
   FORCE_INLINE                                                                       \
   gdv_int32 NAME##_##TYPE##_##TYPE(gdv_##TYPE start_millis, gdv_##TYPE end_millis) { \
-    return static_cast<int32_t>(FROM_MILLIS(end_millis - start_millis));             \
+    return static_cast<int32_t>(FROM_MILLIS(start_millis - end_millis));             \
   }
 
 #define SIGN_ADJUST_DIFF(is_positive, diff) ((is_positive) ? (diff) : -(diff))

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -173,6 +173,8 @@ gdv_int64 date_trunc_Year_date64(gdv_date64);
 gdv_int64 date_trunc_Decade_date64(gdv_date64);
 gdv_int64 date_trunc_Century_date64(gdv_date64);
 gdv_int64 date_trunc_Millennium_date64(gdv_date64);
+gdv_int32 datediff_timestamp_timestamp(gdv_timestamp start_millis,
+                                       gdv_timestamp end_millis);
 
 gdv_int64 date_trunc_Week_timestamp(gdv_timestamp);
 double months_between_timestamp_timestamp(gdv_uint64, gdv_uint64);

--- a/cpp/src/gandiva/tests/date_time_test.cc
+++ b/cpp/src/gandiva/tests/date_time_test.cc
@@ -415,12 +415,12 @@ TEST_F(TestProjector, TestTimestampDiff) {
   // expected output
   std::vector<ArrayPtr> exp_output;
   exp_output.push_back(
-      MakeArrowArrayInt32({-48996077, 48996077, 0, 23 * 3600}, validity));
-  exp_output.push_back(MakeArrowArrayInt32({-816601, 816601, 0, 23 * 60}, validity));
-  exp_output.push_back(MakeArrowArrayInt32({-13610, 13610, 0, 23}, validity));
+      MakeArrowArrayInt32({48996077, -48996077, 0, -23 * 3600}, validity));
+  exp_output.push_back(MakeArrowArrayInt32({816601, -816601, 0, -23 * 60}, validity));
+  exp_output.push_back(MakeArrowArrayInt32({13610, -13610, 0, -23}, validity));
+  exp_output.push_back(MakeArrowArrayInt32({567, -567, 0, 0}, validity));
   exp_output.push_back(MakeArrowArrayInt32({-567, 567, 0, 0}, validity));
-  exp_output.push_back(MakeArrowArrayInt32({-567, 567, 0, 0}, validity));
-  exp_output.push_back(MakeArrowArrayInt32({-81, 81, 0, 0}, validity));
+  exp_output.push_back(MakeArrowArrayInt32({81, -81, 0, 0}, validity));
   exp_output.push_back(MakeArrowArrayInt32({18, -18, 0, 0}, validity));
   exp_output.push_back(MakeArrowArrayInt32({6, -6, 0, 0}, validity));
   exp_output.push_back(MakeArrowArrayInt32({1, -1, 0, 0}, validity));

--- a/cpp/src/gandiva/tests/date_time_test.cc
+++ b/cpp/src/gandiva/tests/date_time_test.cc
@@ -415,12 +415,12 @@ TEST_F(TestProjector, TestTimestampDiff) {
   // expected output
   std::vector<ArrayPtr> exp_output;
   exp_output.push_back(
-      MakeArrowArrayInt32({48996077, -48996077, 0, -23 * 3600}, validity));
-  exp_output.push_back(MakeArrowArrayInt32({816601, -816601, 0, -23 * 60}, validity));
-  exp_output.push_back(MakeArrowArrayInt32({13610, -13610, 0, -23}, validity));
-  exp_output.push_back(MakeArrowArrayInt32({567, -567, 0, 0}, validity));
-  exp_output.push_back(MakeArrowArrayInt32({567, -567, 0, 0}, validity));
-  exp_output.push_back(MakeArrowArrayInt32({81, -81, 0, 0}, validity));
+      MakeArrowArrayInt32({-48996077, 48996077, 0, 23 * 3600}, validity));
+  exp_output.push_back(MakeArrowArrayInt32({-816601, 816601, 0, 23 * 60}, validity));
+  exp_output.push_back(MakeArrowArrayInt32({-13610, 13610, 0, 23}, validity));
+  exp_output.push_back(MakeArrowArrayInt32({-567, 567, 0, 0}, validity));
+  exp_output.push_back(MakeArrowArrayInt32({-567, 567, 0, 0}, validity));
+  exp_output.push_back(MakeArrowArrayInt32({-81, 81, 0, 0}, validity));
   exp_output.push_back(MakeArrowArrayInt32({18, -18, 0, 0}, validity));
   exp_output.push_back(MakeArrowArrayInt32({6, -6, 0, 0}, validity));
   exp_output.push_back(MakeArrowArrayInt32({1, -1, 0, 0}, validity));


### PR DESCRIPTION
Modifying the order to subtract in Arrow implementation for DateDiff function.

As is:
Hive implementation: 1st parameter - 2st parameter
Arrow implementation:  2st parameter - 1st parameter.

To be:
Hive implementation: 1st parameter - 2st parameter
Arrow implementation:  1st parameter - 2st parameter.