### PR TITLE
ARROW-15970: [R] [CI] Re-enable DuckDB dev tests

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -148,13 +148,9 @@ groups:
     - example-*
     - wheel-*
     - python-sdist
-    # ARROW-15970 and duckdb/duckdb#3258
-    - ~test-r-dev-duckdb
 
   nightly-tests:
     - test-*
-    # ARROW-15970 and duckdb/duckdb#3258
-    - ~test-r-dev-duckdb
     - example-*
 
   nightly-packaging:


### PR DESCRIPTION
Now that [duckdb has resolved the issue](https://github.com/duckdb/duckdb/issues/3258) we should restart running these tests in our nightly tests.