### PR TITLE
ARROW-16055: [C++][Gandiva] Skip unnecessary work during cache hit when using object code cache

### DIFF
--- a/cpp/src/gandiva/compiled_expr.h
+++ b/cpp/src/gandiva/compiled_expr.h
@@ -38,11 +38,11 @@ class CompiledExpr {
 
   FieldDescriptorPtr output() const { return output_; }
 
-  void SetIRFunction(SelectionVector::Mode mode, llvm::Function* ir_function) {
-    ir_functions_[static_cast<int>(mode)] = ir_function;
+  void SetFunctionName(SelectionVector::Mode mode, std::string& name) {
+    ir_functions_[static_cast<int>(mode)] = name;
   }
 
-  llvm::Function* GetIRFunction(SelectionVector::Mode mode) const {
+  std::string GetFunctionName(SelectionVector::Mode mode) const {
     return ir_functions_[static_cast<int>(mode)];
   }
 
@@ -61,8 +61,8 @@ class CompiledExpr {
   // output field
   FieldDescriptorPtr output_;
 
-  // IR functions for various modes in the generated code
-  std::array<llvm::Function*, SelectionVector::kNumModes> ir_functions_;
+  // Function names for various modes in the generated code
+  std::array<std::string, SelectionVector::kNumModes> ir_functions_;
 
   // JIT functions in the generated code (set after the module is optimised and finalized)
   std::array<EvalFunc, SelectionVector::kNumModes> jit_functions_;

--- a/cpp/src/gandiva/engine_llvm_test.cc
+++ b/cpp/src/gandiva/engine_llvm_test.cc
@@ -28,7 +28,7 @@ typedef int64_t (*add_vector_func_t)(int64_t* data, int n);
 
 class TestEngine : public ::testing::Test {
  protected:
-  llvm::Function* BuildVecAdd(Engine* engine) {
+  std::string BuildVecAdd(Engine* engine) {
     auto types = engine->types();
     llvm::IRBuilder<>* builder = engine->ir_builder();
     llvm::LLVMContext* context = engine->context();
@@ -95,10 +95,10 @@ class TestEngine : public ::testing::Test {
     // Loop exit
     builder->SetInsertPoint(loop_exit);
     builder->CreateRet(sum_update);
-    return fn;
+    return func_name;
   }
 
-  void BuildEngine() { ASSERT_OK(Engine::Make(TestConfiguration(), &engine)); }
+  void BuildEngine() { ASSERT_OK(Engine::Make(TestConfiguration(), false, &engine)); }
 
   std::unique_ptr<Engine> engine;
   std::shared_ptr<Configuration> configuration = TestConfiguration();
@@ -108,9 +108,9 @@ TEST_F(TestEngine, TestAddUnoptimised) {
   configuration->set_optimize(false);
   BuildEngine();
 
-  llvm::Function* ir_func = BuildVecAdd(engine.get());
+  std::string fn_name = BuildVecAdd(engine.get());
   ASSERT_OK(engine->FinalizeModule());
-  auto add_func = reinterpret_cast<add_vector_func_t>(engine->CompiledFunction(ir_func));
+  auto add_func = reinterpret_cast<add_vector_func_t>(engine->CompiledFunction(fn_name));
 
   int64_t my_array[] = {1, 3, -5, 8, 10};
   EXPECT_EQ(add_func(my_array, 5), 17);
@@ -120,9 +120,9 @@ TEST_F(TestEngine, TestAddOptimised) {
   configuration->set_optimize(true);
   BuildEngine();
 
-  llvm::Function* ir_func = BuildVecAdd(engine.get());
+  std::string fn_name = BuildVecAdd(engine.get());
   ASSERT_OK(engine->FinalizeModule());
-  auto add_func = reinterpret_cast<add_vector_func_t>(engine->CompiledFunction(ir_func));
+  auto add_func = reinterpret_cast<add_vector_func_t>(engine->CompiledFunction(fn_name));
 
   int64_t my_array[] = {1, 3, -5, 8, 10};
   EXPECT_EQ(add_func(my_array, 5), 17);

--- a/cpp/src/gandiva/filter.cc
+++ b/cpp/src/gandiva/filter.cc
@@ -45,12 +45,8 @@ Status Filter::Make(SchemaPtr schema, ConditionPtr condition,
   ARROW_RETURN_IF(configuration == nullptr,
                   Status::Invalid("Configuration cannot be null"));
 
-#ifdef GANDIVA_ENABLE_OBJECT_CODE_CACHE
   std::shared_ptr<Cache<ExpressionCacheKey, std::shared_ptr<llvm::MemoryBuffer>>> cache =
       LLVMGenerator::GetCache();
-#else
-  static Cache<ExpressionCacheKey, std::shared_ptr<Filter>> cache;
-#endif
 
   Condition conditionToKey = *(condition.get());
 
@@ -58,9 +54,8 @@ Status Filter::Make(SchemaPtr schema, ConditionPtr condition,
 
   bool is_cached = false;
 
-#ifdef GANDIVA_ENABLE_OBJECT_CODE_CACHE
-
-  auto prev_cached_obj = cache->GetObjectCode(cache_key);
+  std::shared_ptr<llvm::MemoryBuffer> prev_cached_obj;
+  prev_cached_obj = cache->GetObjectCode(cache_key);
 
   // Verify if previous filter obj code was cached
   if (prev_cached_obj != nullptr) {
@@ -68,39 +63,26 @@ Status Filter::Make(SchemaPtr schema, ConditionPtr condition,
   }
 
   GandivaObjectCache obj_cache(cache, cache_key);
-#else
-  auto prev_cached_obj = cache.GetObjectCode(cache_key);
-  // Verify if previous filter obj code was cached
-  if (prev_cached_obj != nullptr) {
-    *filter = prev_cached_obj;
-    filter->get()->SetBuiltFromCache(true);
-    return Status::OK();
-  }
-#endif
 
   // Build LLVM generator, and generate code for the specified expression
   std::unique_ptr<LLVMGenerator> llvm_gen;
-  ARROW_RETURN_NOT_OK(LLVMGenerator::Make(configuration, &llvm_gen));
+  ARROW_RETURN_NOT_OK(LLVMGenerator::Make(configuration, is_cached, &llvm_gen));
 
-  // Run the validation on the expression.
-  // Return if the expression is invalid since we will not be able to process further.
-  ExprValidator expr_validator(llvm_gen->types(), schema);
-  ARROW_RETURN_NOT_OK(expr_validator.Validate(condition));
+  if (!is_cached) {
+    // Run the validation on the expression.
+    // Return if the expression is invalid since we will not be able to process further.
+    ExprValidator expr_validator(llvm_gen->types(), schema);
+    ARROW_RETURN_NOT_OK(expr_validator.Validate(condition));
+  }
 
-#ifdef GANDIVA_ENABLE_OBJECT_CODE_CACHE
   // Set the object cache for LLVM
   llvm_gen->SetLLVMObjectCache(obj_cache);
-#endif
 
   ARROW_RETURN_NOT_OK(llvm_gen->Build({condition}, SelectionVector::Mode::MODE_NONE));
 
   // Instantiate the filter with the completely built llvm generator
   *filter = std::make_shared<Filter>(std::move(llvm_gen), schema, configuration);
   filter->get()->SetBuiltFromCache(is_cached);
-
-#ifndef GANDIVA_ENABLE_OBJECT_CODE_CACHE
-  cache.PutObjectCode(cache_key, *filter);
-#endif
 
   return Status::OK();
 }
@@ -141,4 +123,5 @@ std::string Filter::DumpIR() { return llvm_generator_->DumpIR(); }
 void Filter::SetBuiltFromCache(bool flag) { built_from_cache_ = flag; }
 
 bool Filter::GetBuiltFromCache() { return built_from_cache_; }
+
 }  // namespace gandiva

--- a/cpp/src/gandiva/gandiva_object_cache.cc
+++ b/cpp/src/gandiva/gandiva_object_cache.cc
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifdef GANDIVA_ENABLE_OBJECT_CODE_CACHE
 #include "gandiva/gandiva_object_cache.h"
 
 #include <utility>
@@ -44,12 +43,9 @@ std::unique_ptr<llvm::MemoryBuffer> GandivaObjectCache::getObject(const llvm::Mo
   if (cached_obj != nullptr) {
     std::unique_ptr<llvm::MemoryBuffer> cached_buffer = cached_obj->getMemBufferCopy(
         cached_obj->getBuffer(), cached_obj->getBufferIdentifier());
-    ARROW_LOG(INFO) << "[INFO][CACHE-LOG]: An object code was found on cache.";
     return cached_buffer;
   }
-  ARROW_LOG(INFO) << "[INFO][CACHE-LOG]: No object code was found on cache.";
   return nullptr;
 }
 
 }  // namespace gandiva
-#endif  // GANDIVA_ENABLE_OBJECT_CODE_CACHE

--- a/cpp/src/gandiva/gandiva_object_cache.h
+++ b/cpp/src/gandiva/gandiva_object_cache.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#ifdef GANDIVA_ENABLE_OBJECT_CODE_CACHE
 #if defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable : 4244)
@@ -53,4 +52,3 @@ class GandivaObjectCache : public llvm::ObjectCache {
   std::shared_ptr<Cache<ExpressionCacheKey, std::shared_ptr<llvm::MemoryBuffer>>> cache_;
 };
 }  // namespace gandiva
-#endif  // GANDIVA_ENABLE_OBJECT_CODE_CACHE

--- a/cpp/src/gandiva/llvm_generator.h
+++ b/cpp/src/gandiva/llvm_generator.h
@@ -47,17 +47,15 @@ class FunctionHolder;
 class GANDIVA_EXPORT LLVMGenerator {
  public:
   /// \brief Factory method to initialize the generator.
-  static Status Make(std::shared_ptr<Configuration> config,
+  static Status Make(std::shared_ptr<Configuration> config, bool cached,
                      std::unique_ptr<LLVMGenerator>* llvm_generator);
 
-#ifdef GANDIVA_ENABLE_OBJECT_CODE_CACHE
   /// \brief Get the cache to be used for LLVM ObjectCache.
   static std::shared_ptr<Cache<ExpressionCacheKey, std::shared_ptr<llvm::MemoryBuffer>>>
   GetCache();
 
   /// \brief Set LLVM ObjectCache.
   void SetLLVMObjectCache(GandivaObjectCache& object_cache);
-#endif
 
   /// \brief Build the code for the expression trees for default mode with a LLVM
   /// ObjectCache. Each element in the vector represents an expression tree
@@ -84,7 +82,7 @@ class GANDIVA_EXPORT LLVMGenerator {
   std::string DumpIR() { return engine_->DumpIR(); }
 
  private:
-  LLVMGenerator();
+  explicit LLVMGenerator(bool cached);
 
   FRIEND_TEST(TestLLVMGenerator, VerifyPCFunctions);
   FRIEND_TEST(TestLLVMGenerator, TestAdd);
@@ -202,7 +200,7 @@ class GANDIVA_EXPORT LLVMGenerator {
 
   /// Generate code for the value array of one expression.
   Status CodeGenExprValue(DexPtr value_expr, int num_buffers, FieldDescriptorPtr output,
-                          int suffix_idx, llvm::Function** fn,
+                          int suffix_idx, std::string& fn_name,
                           SelectionVector::Mode selection_vector_mode);
 
   /// Generate code to load the local bitmap specified index and cast it as bitmap.
@@ -251,6 +249,7 @@ class GANDIVA_EXPORT LLVMGenerator {
 
   std::unique_ptr<Engine> engine_;
   std::vector<std::unique_ptr<CompiledExpr>> compiled_exprs_;
+  bool cached_;
   FunctionRegistry function_registry_;
   Annotator annotator_;
   SelectionVector::Mode selection_vector_mode_;


### PR DESCRIPTION
This change enables object code cache and skips the unnecessary work that was done before loading the compiled object code in memory. The following still needs to be done:
* expression decomposition in order to create the function and in holders in memory 
* Add mappings for global functions to the llvm module
