### PR TITLE
ARROW-16064: [Java] [C++] [FlightRPC] Add missing column metadata for type name on FlightSQL

### DIFF
--- a/cpp/src/arrow/flight/integration_tests/test_integration.cc
+++ b/cpp/src/arrow/flight/integration_tests/test_integration.cc
@@ -267,11 +267,13 @@ std::shared_ptr<Schema> GetQuerySchema() {
   std::string table_name = "test";
   std::string schema_name = "schema_test";
   std::string catalog_name = "catalog_test";
+  std::string type_name = "type_test";
   return arrow::schema({arrow::field("id", int64(), true,
                                      arrow::flight::sql::ColumnMetadata::Builder()
                                          .TableName(table_name)
                                          .IsAutoIncrement(true)
                                          .IsCaseSensitive(false)
+                                         .TypeName(type_name)
                                          .SchemaName(schema_name)
                                          .IsSearchable(true)
                                          .CatalogName(catalog_name)

--- a/cpp/src/arrow/flight/sql/column_metadata.cc
+++ b/cpp/src/arrow/flight/sql/column_metadata.cc
@@ -42,6 +42,7 @@ bool StringToBoolean(const std::string& string_value) {
 const char* ColumnMetadata::kCatalogName = "ARROW:FLIGHT:SQL:CATALOG_NAME";
 const char* ColumnMetadata::kSchemaName = "ARROW:FLIGHT:SQL:SCHEMA_NAME";
 const char* ColumnMetadata::kTableName = "ARROW:FLIGHT:SQL:TABLE_NAME";
+const char* ColumnMetadata::kTypeName = "ARROW:FLIGHT:SQL:TYPE_NAME";
 const char* ColumnMetadata::kPrecision = "ARROW:FLIGHT:SQL:PRECISION";
 const char* ColumnMetadata::kScale = "ARROW:FLIGHT:SQL:SCALE";
 const char* ColumnMetadata::kIsAutoIncrement = "ARROW:FLIGHT:SQL:IS_AUTO_INCREMENT";
@@ -63,6 +64,10 @@ arrow::Result<std::string> ColumnMetadata::GetSchemaName() const {
 
 arrow::Result<std::string> ColumnMetadata::GetTableName() const {
   return metadata_map_->Get(kTableName);
+}
+
+arrow::Result<std::string> ColumnMetadata::GetTypeName() const {
+  return metadata_map_->Get(kTypeName);
 }
 
 arrow::Result<int32_t> ColumnMetadata::GetPrecision() const {
@@ -127,6 +132,12 @@ ColumnMetadata::ColumnMetadataBuilder& ColumnMetadata::ColumnMetadataBuilder::Sc
 ColumnMetadata::ColumnMetadataBuilder& ColumnMetadata::ColumnMetadataBuilder::TableName(
     std::string& table_name) {
   metadata_map_->Append(ColumnMetadata::kTableName, table_name);
+  return *this;
+}
+
+ColumnMetadata::ColumnMetadataBuilder& ColumnMetadata::ColumnMetadataBuilder::TypeName(
+    std::string& type_name) {
+  metadata_map_->Append(ColumnMetadata::kTypeName, type_name);
   return *this;
 }
 

--- a/cpp/src/arrow/flight/sql/column_metadata.h
+++ b/cpp/src/arrow/flight/sql/column_metadata.h
@@ -46,6 +46,9 @@ class ColumnMetadata {
   static const char* kTableName;
   /// \brief Constant variable to hold the value of the key that
   ///        will be used in the KeyValueMetadata class.
+  static const char* kTypeName;
+  /// \brief Constant variable to hold the value of the key that
+  ///        will be used in the KeyValueMetadata class.
   static const char* kPrecision;
   /// \brief Constant variable to hold the value of the key that
   ///        will be used in the KeyValueMetadata class.
@@ -77,6 +80,10 @@ class ColumnMetadata {
   /// \brief  Return the table name set in the KeyValueMetadata.
   /// \return The table name.
   arrow::Result<std::string> GetTableName() const;
+
+  /// \brief  Return the type name set in the KeyValueMetadata.
+  /// \return The type name.
+  arrow::Result<std::string> GetTypeName() const;
 
   /// \brief  Return the precision set in the KeyValueMetadata.
   /// \return The precision.
@@ -117,14 +124,19 @@ class ColumnMetadata {
     ColumnMetadataBuilder& CatalogName(std::string& catalog_name);
 
     /// \brief Set the schema_name in the KeyValueMetadata object.
-    /// \param[in] schema_name The schema_name.
+    /// \param[in] schema_name  The schema_name.
     /// \return                 A ColumnMetadataBuilder.
     ColumnMetadataBuilder& SchemaName(std::string& schema_name);
 
     /// \brief Set the table name in the KeyValueMetadata object.
-    /// \param[in] table_name The table name.
+    /// \param[in] table_name   The table name.
     /// \return                 A ColumnMetadataBuilder.
     ColumnMetadataBuilder& TableName(std::string& table_name);
+
+    /// \brief Set the type name in the KeyValueMetadata object.
+    /// \param[in] type_name    The type name.
+    /// \return                 A ColumnMetadataBuilder.
+    ColumnMetadataBuilder& TypeName(std::string& type_name);
 
     /// \brief Set the precision in the KeyValueMetadata object.
     /// \param[in] precision    The precision.
@@ -138,22 +150,22 @@ class ColumnMetadata {
 
     /// \brief Set the IsAutoIncrement in the KeyValueMetadata object.
     /// \param[in] is_auto_increment  The IsAutoIncrement.
-    /// \return                     A ColumnMetadataBuilder.
+    /// \return                       A ColumnMetadataBuilder.
     ColumnMetadataBuilder& IsAutoIncrement(bool is_auto_increment);
 
     /// \brief Set the IsCaseSensitive in the KeyValueMetadata object.
     /// \param[in] is_case_sensitive The IsCaseSensitive.
-    /// \return                    A ColumnMetadataBuilder.
+    /// \return                      A ColumnMetadataBuilder.
     ColumnMetadataBuilder& IsCaseSensitive(bool is_case_sensitive);
 
     /// \brief Set the IsReadOnly in the KeyValueMetadata object.
     /// \param[in] is_read_only   The IsReadOnly.
-    /// \return                 A ColumnMetadataBuilder.
+    /// \return                   A ColumnMetadataBuilder.
     ColumnMetadataBuilder& IsReadOnly(bool is_read_only);
 
     /// \brief Set the IsSearchable in the KeyValueMetadata object.
     /// \param[in] is_searchable The IsSearchable.
-    /// \return                 A ColumnMetadataBuilder.
+    /// \return                  A ColumnMetadataBuilder.
     ColumnMetadataBuilder& IsSearchable(bool is_searchable);
 
     ColumnMetadata Build() const;

--- a/cpp/src/arrow/flight/sql/column_metadata.h
+++ b/cpp/src/arrow/flight/sql/column_metadata.h
@@ -81,7 +81,7 @@ class ColumnMetadata {
   /// \return The table name.
   arrow::Result<std::string> GetTableName() const;
 
-  /// \brief  Return the type name set in the KeyValueMetadata.
+  /// \brief  Return the data source-specific name for the data type of the column.
   /// \return The type name.
   arrow::Result<std::string> GetTypeName() const;
 

--- a/format/FlightSql.proto
+++ b/format/FlightSql.proto
@@ -1118,7 +1118,7 @@ message CommandGetDbSchemas {
  *  - ARROW:FLIGHT:SQL:CATALOG_NAME      - Table's catalog name
  *  - ARROW:FLIGHT:SQL:DB_SCHEMA_NAME    - Database schema name
  *  - ARROW:FLIGHT:SQL:TABLE_NAME        - Table name
- *  - ARROW:FLIGHT:SQL:TYPE_NAME         - Type name
+ *  - ARROW:FLIGHT:SQL:TYPE_NAME         - The data source-specific name for the data type of the column.
  *  - ARROW:FLIGHT:SQL:PRECISION         - Column precision/size
  *  - ARROW:FLIGHT:SQL:SCALE             - Column scale/decimal digits if applicable
  *  - ARROW:FLIGHT:SQL:IS_AUTO_INCREMENT - "1" indicates if the column is auto incremented, "0" otherwise.
@@ -1458,7 +1458,7 @@ message ActionClosePreparedStatementRequest {
  *    - ARROW:FLIGHT:SQL:CATALOG_NAME      - Table's catalog name
  *    - ARROW:FLIGHT:SQL:DB_SCHEMA_NAME    - Database schema name
  *    - ARROW:FLIGHT:SQL:TABLE_NAME        - Table name
- *    - ARROW:FLIGHT:SQL:TYPE_NAME         - Type name
+ *    - ARROW:FLIGHT:SQL:TYPE_NAME         - The data source-specific name for the data type of the column.
  *    - ARROW:FLIGHT:SQL:PRECISION         - Column precision/size
  *    - ARROW:FLIGHT:SQL:SCALE             - Column scale/decimal digits if applicable
  *    - ARROW:FLIGHT:SQL:IS_AUTO_INCREMENT - "1" indicates if the column is auto incremented, "0" otherwise.
@@ -1493,7 +1493,7 @@ message TicketStatementQuery {
  *    - ARROW:FLIGHT:SQL:CATALOG_NAME      - Table's catalog name
  *    - ARROW:FLIGHT:SQL:DB_SCHEMA_NAME    - Database schema name
  *    - ARROW:FLIGHT:SQL:TABLE_NAME        - Table name
- *    - ARROW:FLIGHT:SQL:TYPE_NAME         - Type name
+ *    - ARROW:FLIGHT:SQL:TYPE_NAME         - The data source-specific name for the data type of the column.
  *    - ARROW:FLIGHT:SQL:PRECISION         - Column precision/size
  *    - ARROW:FLIGHT:SQL:SCALE             - Column scale/decimal digits if applicable
  *    - ARROW:FLIGHT:SQL:IS_AUTO_INCREMENT - "1" indicates if the column is auto incremented, "0" otherwise.

--- a/format/FlightSql.proto
+++ b/format/FlightSql.proto
@@ -1118,6 +1118,7 @@ message CommandGetDbSchemas {
  *  - ARROW:FLIGHT:SQL:CATALOG_NAME      - Table's catalog name
  *  - ARROW:FLIGHT:SQL:DB_SCHEMA_NAME    - Database schema name
  *  - ARROW:FLIGHT:SQL:TABLE_NAME        - Table name
+ *  - ARROW:FLIGHT:SQL:TYPE_NAME         - Type name
  *  - ARROW:FLIGHT:SQL:PRECISION         - Column precision/size
  *  - ARROW:FLIGHT:SQL:SCALE             - Column scale/decimal digits if applicable
  *  - ARROW:FLIGHT:SQL:IS_AUTO_INCREMENT - "1" indicates if the column is auto incremented, "0" otherwise.
@@ -1457,6 +1458,7 @@ message ActionClosePreparedStatementRequest {
  *    - ARROW:FLIGHT:SQL:CATALOG_NAME      - Table's catalog name
  *    - ARROW:FLIGHT:SQL:DB_SCHEMA_NAME    - Database schema name
  *    - ARROW:FLIGHT:SQL:TABLE_NAME        - Table name
+ *    - ARROW:FLIGHT:SQL:TYPE_NAME         - Type name
  *    - ARROW:FLIGHT:SQL:PRECISION         - Column precision/size
  *    - ARROW:FLIGHT:SQL:SCALE             - Column scale/decimal digits if applicable
  *    - ARROW:FLIGHT:SQL:IS_AUTO_INCREMENT - "1" indicates if the column is auto incremented, "0" otherwise.
@@ -1491,6 +1493,7 @@ message TicketStatementQuery {
  *    - ARROW:FLIGHT:SQL:CATALOG_NAME      - Table's catalog name
  *    - ARROW:FLIGHT:SQL:DB_SCHEMA_NAME    - Database schema name
  *    - ARROW:FLIGHT:SQL:TABLE_NAME        - Table name
+ *    - ARROW:FLIGHT:SQL:TYPE_NAME         - Type name
  *    - ARROW:FLIGHT:SQL:PRECISION         - Column precision/size
  *    - ARROW:FLIGHT:SQL:SCALE             - Column scale/decimal digits if applicable
  *    - ARROW:FLIGHT:SQL:IS_AUTO_INCREMENT - "1" indicates if the column is auto incremented, "0" otherwise.

--- a/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/FlightSqlScenarioProducer.java
+++ b/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/FlightSqlScenarioProducer.java
@@ -67,6 +67,7 @@ public class FlightSqlScenarioProducer implements FlightSqlProducer {
                 .tableName("test")
                 .isAutoIncrement(true)
                 .isCaseSensitive(false)
+                .typeName("type_test")
                 .schemaName("schema_test")
                 .isSearchable(true)
                 .catalogName("catalog_test")

--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightSqlColumnMetadata.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightSqlColumnMetadata.java
@@ -45,6 +45,7 @@ public class FlightSqlColumnMetadata {
   private static final String CATALOG_NAME = "ARROW:FLIGHT:SQL:CATALOG_NAME";
   private static final String SCHEMA_NAME = "ARROW:FLIGHT:SQL:SCHEMA_NAME";
   private static final String TABLE_NAME = "ARROW:FLIGHT:SQL:TABLE_NAME";
+  private static final String TYPE_NAME = "ARROW:FLIGHT:SQL:TYPE_NAME";
   private static final String PRECISION = "ARROW:FLIGHT:SQL:PRECISION";
   private static final String SCALE = "ARROW:FLIGHT:SQL:SCALE";
   private static final String IS_AUTO_INCREMENT = "ARROW:FLIGHT:SQL:IS_AUTO_INCREMENT";
@@ -94,6 +95,14 @@ public class FlightSqlColumnMetadata {
    */
   public String getTableName() {
     return metadataMap.get(TABLE_NAME);
+  }
+
+  /**
+   * Returns the type name.
+   * @return The type name.
+   */
+  public String getTypeName() {
+    return metadataMap.get(TYPE_NAME);
   }
 
   /**
@@ -214,6 +223,16 @@ public class FlightSqlColumnMetadata {
      */
     public Builder tableName(String tableName) {
       metadataMap.put(TABLE_NAME, tableName);
+      return this;
+    }
+
+    /**
+     * Sets the type name.
+     * @param typeName The type name.
+     * @return This builder.
+     */
+    public Builder typeName(String typeName) {
+      metadataMap.put(TYPE_NAME, typeName);
       return this;
     }
 


### PR DESCRIPTION
This adds a new column metadata field ARROW:FLIGHT:SQL:TYPE_NAME to FlightSQL resultset schemas.

This improvement allows datasources to specify custom data type names on JDBC driver.