### PR TITLE
ARROW-16048: [Python] Avoid exposing null buffer address to the Python buffer protocol

### DIFF
--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1116,7 +1116,9 @@ cdef class Buffer(_Weakrefable):
             return self.equals(py_buffer(other))
 
     def __reduce_ex__(self, protocol):
-        if protocol >= 5:
+        # null buffers with zero size have ambiguous meaning
+	# to pickle5 with asserts on.
+        if protocol >= 5 and self.size > 0:
             return py_buffer, (builtin_pickle.PickleBuffer(self),)
         else:
             return py_buffer, (self.to_pybytes(),)

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -36,10 +36,13 @@ from pyarrow.util import _is_path_like, _stringify_path
 DEFAULT_BUFFER_SIZE = 2 ** 16
 
 
-# To let us get a PyObject* and avoid Cython auto-ref-counting
 cdef extern from "Python.h":
+    # To let us get a PyObject* and avoid Cython auto-ref-counting
     PyObject* PyBytes_FromStringAndSizeNative" PyBytes_FromStringAndSize"(
         char *v, Py_ssize_t len) except NULL
+
+    # Workaround https://github.com/cython/cython/issues/4707
+    bytearray PyByteArray_FromStringAndSize(char *string, Py_ssize_t len)
 
 
 def io_thread_count():
@@ -1116,12 +1119,17 @@ cdef class Buffer(_Weakrefable):
             return self.equals(py_buffer(other))
 
     def __reduce_ex__(self, protocol):
-        # null buffers with zero size have ambiguous meaning
-	# to pickle5 with asserts on.
-        if protocol >= 5 and self.size > 0:
-            return py_buffer, (builtin_pickle.PickleBuffer(self),)
+        if protocol >= 5:
+            bufobj = builtin_pickle.PickleBuffer(self)
+        elif self.buffer.get().is_mutable():
+            # Need to pass a bytearray to recreate a mutable buffer when
+            # unpickling.
+            bufobj = PyByteArray_FromStringAndSize(
+                <const char*>self.buffer.get().data(),
+                self.buffer.get().size())
         else:
-            return py_buffer, (self.to_pybytes(),)
+            bufobj = self.to_pybytes()
+        return py_buffer, (bufobj,)
 
     def to_pybytes(self):
         """
@@ -1140,10 +1148,14 @@ cdef class Buffer(_Weakrefable):
                                   "buffer was not mutable")
             buffer.readonly = 1
         buffer.buf = <char *>self.buffer.get().data()
+        buffer.len = self.size
+        if buffer.buf == NULL:
+            # ARROW-16048: Ensure we don't export a NULL address.
+            assert buffer.len == 0
+            buffer.buf = cp.PyBytes_AS_STRING(b"")
         buffer.format = 'b'
         buffer.internal = NULL
         buffer.itemsize = 1
-        buffer.len = self.size
         buffer.ndim = 1
         buffer.obj = self
         buffer.shape = self.shape

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -344,6 +344,18 @@ def test_buffer_bytes():
     result = result_buf.to_pybytes()
     assert result == val
 
+    # Check that buffers survive a pickle roundtrip
+    # under highest protocol
+    highest = pickle.HIGHEST_PROTOCOL
+    result_buf = pickle.loads(pickle.dumps(buf, protocol=highest))
+    result = result_buf.to_pybytes()
+    assert result == val
+
+    null_buff = pa.foreign_buffer(address=0, size=0)
+    pickle.loads(pickle.dumps(null_buff, protocol=highest))
+
+
+
 
 def test_buffer_memoryview():
     val = b'some data'

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -327,6 +327,16 @@ def test_python_file_closing():
 # Buffers
 
 
+def check_buffer_pickling(buf, check_func=None):
+    # Check that buffer survives a pickle roundtrip
+    for protocol in range(0, pickle.HIGHEST_PROTOCOL + 1):
+        result = pickle.loads(pickle.dumps(buf, protocol=protocol))
+        assert len(result) == len(buf)
+        assert memoryview(result) == memoryview(buf)
+        assert result.to_pybytes() == buf.to_pybytes()
+        assert result.is_mutable == buf.is_mutable
+
+
 def test_buffer_bytes():
     val = b'some data'
 
@@ -336,25 +346,22 @@ def test_buffer_bytes():
     assert buf.is_cpu
 
     result = buf.to_pybytes()
-
     assert result == val
 
-    # Check that buffers survive a pickle roundtrip
-    result_buf = pickle.loads(pickle.dumps(buf))
-    result = result_buf.to_pybytes()
-    assert result == val
+    check_buffer_pickling(buf)
 
-    # Check that buffers survive a pickle roundtrip
-    # under highest protocol
-    highest = pickle.HIGHEST_PROTOCOL
-    result_buf = pickle.loads(pickle.dumps(buf, protocol=highest))
-    result = result_buf.to_pybytes()
-    assert result == val
 
+def test_buffer_null_data():
     null_buff = pa.foreign_buffer(address=0, size=0)
-    pickle.loads(pickle.dumps(null_buff, protocol=highest))
+    assert null_buff.to_pybytes() == b""
+    assert null_buff.address == 0
+    # ARROW-16048: we shouldn't expose a NULL address through the Python
+    # buffer protocol.
+    m = memoryview(null_buff)
+    assert m.tobytes() == b""
+    assert pa.py_buffer(m).address != 0
 
-
+    check_buffer_pickling(null_buff)
 
 
 def test_buffer_memoryview():
@@ -366,8 +373,9 @@ def test_buffer_memoryview():
     assert buf.is_cpu
 
     result = memoryview(buf)
-
     assert result == val
+
+    check_buffer_pickling(buf)
 
 
 def test_buffer_bytearray():
@@ -379,8 +387,9 @@ def test_buffer_bytearray():
     assert buf.is_cpu
 
     result = bytearray(buf)
-
     assert result == val
+
+    check_buffer_pickling(buf)
 
 
 def test_buffer_invalid():

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -327,7 +327,7 @@ def test_python_file_closing():
 # Buffers
 
 
-def check_buffer_pickling(buf, check_func=None):
+def check_buffer_pickling(buf):
     # Check that buffer survives a pickle roundtrip
     for protocol in range(0, pickle.HIGHEST_PROTOCOL + 1):
         result = pickle.loads(pickle.dumps(buf, protocol=protocol))


### PR DESCRIPTION
A 0-size buffer created in C++ can very well have a null address. However, when exporting that buffer through the Python buffer API, we should ensure we pass a valid pointer.

Also, ensure mutability of a buffer is preserved when pickling and unpickling.