### PR TITLE
ARROW-15783: [Python] Initialize static pandas data on write

### DIFF
--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -348,7 +348,10 @@ class PandasWriter {
   };
 
   PandasWriter(const PandasOptions& options, int64_t num_rows, int num_columns)
-      : options_(options), num_rows_(num_rows), num_columns_(num_columns) {}
+      : options_(options), num_rows_(num_rows), num_columns_(num_columns) {
+    PyAcquireGIL lock;
+    internal::InitPandasStaticData();
+  }
   virtual ~PandasWriter() {}
 
   void SetBlockData(PyObject* arr) {
@@ -371,7 +374,6 @@ class PandasWriter {
       return Status::OK();
     }
     PyAcquireGIL lock;
-    internal::InitPandasStaticData();
     npy_intp placement_dims[1] = {num_columns_};
     PyObject* placement_arr = PyArray_SimpleNew(1, placement_dims, NPY_INT64);
     RETURN_IF_PYERROR();

--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -348,8 +348,7 @@ class PandasWriter {
   };
 
   PandasWriter(const PandasOptions& options, int64_t num_rows, int num_columns)
-      : options_(options), num_rows_(num_rows), num_columns_(num_columns) {
-  }
+      : options_(options), num_rows_(num_rows), num_columns_(num_columns) {}
   virtual ~PandasWriter() {}
 
   void SetBlockData(PyObject* arr) {

--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -348,7 +348,8 @@ class PandasWriter {
   };
 
   PandasWriter(const PandasOptions& options, int64_t num_rows, int num_columns)
-      : options_(options), num_rows_(num_rows), num_columns_(num_columns) {}
+      : options_(options), num_rows_(num_rows), num_columns_(num_columns) {
+  }
   virtual ~PandasWriter() {}
 
   void SetBlockData(PyObject* arr) {
@@ -371,7 +372,7 @@ class PandasWriter {
       return Status::OK();
     }
     PyAcquireGIL lock;
-
+    internal::InitPandasStaticData();
     npy_intp placement_dims[1] = {num_columns_};
     PyObject* placement_arr = PyArray_SimpleNew(1, placement_dims, NPY_INT64);
     RETURN_IF_PYERROR();

--- a/python/pyarrow/tests/read_record_batch.py
+++ b/python/pyarrow/tests/read_record_batch.py
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This file is called from a test in test_ipc.py.
+
+import sys
+
+import pyarrow as pa
+
+with open(sys.argv[1], 'rb') as f:
+    pa.ipc.open_file(f).read_all().to_pandas()

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -26,7 +26,7 @@ import weakref
 import numpy as np
 
 import pyarrow as pa
-from pyarrow.tests.util import changed_environ
+from pyarrow.tests.util import changed_environ, invoke_script
 
 
 try:
@@ -238,6 +238,19 @@ def test_empty_stream():
     buf = io.BytesIO(b'')
     with pytest.raises(pa.ArrowInvalid):
         pa.ipc.open_stream(buf)
+
+
+def test_read_year_month_nano_interval(tmpdir):
+    mdn_interval_type = pa.month_day_nano_interval()
+    schema = pa.schema([pa.field('nums', mdn_interval_type)])
+
+    path = tmpdir.join('file.arrow').strpath
+    with pa.OSFile(path, 'wb') as sink:
+        with pa.ipc.new_file(sink, schema) as writer:
+            interval_array = pa.array([(1, 2, 3)], type=mdn_interval_type)
+            batch = pa.record_batch([interval_array], schema)
+            writer.write(batch)
+    invoke_script('read_record_batch.py', path)
 
 
 @pytest.mark.pandas

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -240,6 +240,7 @@ def test_empty_stream():
         pa.ipc.open_stream(buf)
 
 
+@pytest.mark.pandas
 def test_read_year_month_nano_interval(tmpdir):
     """ARROW-15783: Verify to_pandas works for interval types.
 

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -241,6 +241,11 @@ def test_empty_stream():
 
 
 def test_read_year_month_nano_interval(tmpdir):
+    """ARROW-15783: Verify to_pandas works for interval types.
+
+    Interval types require static structures to be enabled. This test verifies
+    that they are when no other library functions are invoked.
+    """
     mdn_interval_type = pa.month_day_nano_interval()
     schema = pa.schema([pa.field('nums', mdn_interval_type)])
 


### PR DESCRIPTION
I'm not sure if this is the best place to ensure we always set this, but it seemed reasonable, happy to change it.

The underlying issue is this was the first type were we required C++ code for writing pandas data.