### PR TITLE
ARROW-15523: [Python] Support for Datasets as inputs of Joins

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -627,6 +627,7 @@ endif()
 
 if(PYARROW_BUILD_DATASET)
   target_link_libraries(_dataset PRIVATE ${DATASET_LINK_LIBS})
+  target_link_libraries(_exec_plan PRIVATE ${DATASET_LINK_LIBS})
   if(PYARROW_BUILD_ORC)
     target_link_libraries(_dataset_orc PRIVATE ${DATASET_LINK_LIBS})
   endif()

--- a/python/pyarrow/_dataset.pxd
+++ b/python/pyarrow/_dataset.pxd
@@ -42,6 +42,20 @@ cdef class DatasetFactory(_Weakrefable):
     cdef inline shared_ptr[CDatasetFactory] unwrap(self) nogil
 
 
+cdef class Dataset(_Weakrefable):
+
+    cdef:
+        shared_ptr[CDataset] wrapped
+        CDataset* dataset
+
+    cdef void init(self, const shared_ptr[CDataset]& sp)
+
+    @staticmethod
+    cdef wrap(const shared_ptr[CDataset]& sp)
+
+    cdef shared_ptr[CDataset] unwrap(self) nogil
+
+
 cdef class FragmentScanOptions(_Weakrefable):
 
     cdef:

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -148,10 +148,6 @@ cdef class Dataset(_Weakrefable):
     can accelerate queries that only touch some partitions (files).
     """
 
-    cdef:
-        shared_ptr[CDataset] wrapped
-        CDataset* dataset
-
     def __init__(self):
         _forbid_instantiation(self.__class__)
 

--- a/python/pyarrow/_exec_plan.pyx
+++ b/python/pyarrow/_exec_plan.pyx
@@ -159,94 +159,43 @@ cdef execplan(inputs, output_type, vector[CDeclaration] plan, c_bool use_threads
     return output
 
 
-def tables_join(join_type, left_table not None, left_keys,
-                right_table not None, right_keys,
-                left_suffix=None, right_suffix=None,
-                use_threads=True, coalesce_keys=False):
-    """
-    Perform join of two tables.
-
-    The result will be an output table with the result of the join operation
-
-    Parameters
-    ----------
-    join_type : str
-        One of supported join types.
-    left_table : Table
-        The left table for the join operation.
-    left_keys : str or list[str]
-        The left table key (or keys) on which the join operation should be performed.
-    right_table : Table
-        The right table for the join operation.
-    right_keys : str or list[str]
-        The right table key (or keys) on which the join operation should be performed.
-    left_suffix : str, default None
-        Which suffix to add to right column names. This prevents confusion
-        when the columns in left and right tables have colliding names.
-    right_suffix : str, default None
-        Which suffic to add to the left column names. This prevents confusion
-        when the columns in left and right tables have colliding names.
-    use_threads : bool, default True
-        Whenever to use multithreading or not.
-    coalesce_keys : bool, default False
-        If the duplicated keys should be omitted from one of the sides
-        in the join result.
-
-    Returns
-    -------
-    result_table : Table
-    """
-    return _perform_join(join_type, left_table, left_keys,
-                         right_table, right_keys, left_suffix,
-                         right_suffix, use_threads, coalesce_keys)
-
-
-def datasets_join(join_type, left_dataset not None, left_keys,
-                  right_dataset not None, right_keys,
-                  left_suffix=None, right_suffix=None,
-                  use_threads=True, coalesce_keys=False):
-    """
-    Perform join of two datasets.
-
-    The result will be an output table with the result of the join operation
-
-    Parameters
-    ----------
-    join_type : str
-        One of supported join types.
-    left_datasets : Dataset
-        The left dataset for the join operation.
-    left_keys : str or list[str]
-        The left dataset key (or keys) on which the join operation should be performed.
-    right_dataset : Dataset
-        The right dataset for the join operation.
-    right_keys : str or list[str]
-        The right dataset key (or keys) on which the join operation should be performed.
-    left_suffix : str, default None
-        Which suffix to add to right column names. This prevents confusion
-        when the columns in left and right datasets have colliding names.
-    right_suffix : str, default None
-        Which suffic to add to the left column names. This prevents confusion
-        when the columns in left and right datasets have colliding names.
-    use_threads : bool, default True
-        Whenever to use multithreading or not.
-    coalesce_keys : bool, default False
-        If the duplicated keys should be omitted from one of the sides
-        in the join result.
-
-    Returns
-    -------
-    result_table : Table
-    """
-    return _perform_join(join_type, left_dataset, left_keys,
-                         right_dataset, right_keys, left_suffix,
-                         right_suffix, use_threads, coalesce_keys)
-
-
 def _perform_join(join_type, left_operand not None, left_keys,
                   right_operand not None, right_keys,
                   left_suffix=None, right_suffix=None,
                   use_threads=True, coalesce_keys=False):
+    """
+    Perform join of two tables or datasets.
+
+    The result will be an output table with the result of the join operation
+
+    Parameters
+    ----------
+    join_type : str
+        One of supported join types.
+    left_operand : Table or Dataset
+        The left operand for the join operation.
+    left_keys : str or list[str]
+        The left key (or keys) on which the join operation should be performed.
+    right_operand : Table or Dataset
+        The right operand for the join operation.
+    right_keys : str or list[str]
+        The right key (or keys) on which the join operation should be performed.
+    left_suffix : str, default None
+        Which suffix to add to right column names. This prevents confusion
+        when the columns in left and right operands have colliding names.
+    right_suffix : str, default None
+        Which suffic to add to the left column names. This prevents confusion
+        when the columns in left and right operands have colliding names.
+    use_threads : bool, default True
+        Whenever to use multithreading or not.
+    coalesce_keys : bool, default False
+        If the duplicated keys should be omitted from one of the sides
+        in the join result.
+
+    Returns
+    -------
+    result_table : Table
+    """
     cdef:
         vector[CFieldRef] c_left_keys
         vector[CFieldRef] c_right_keys

--- a/python/pyarrow/_exec_plan.pyx
+++ b/python/pyarrow/_exec_plan.pyx
@@ -103,6 +103,7 @@ cdef execplan(inputs, output_type, vector[CDeclaration] plan, c_bool use_threads
             c_in_dataset = (<Dataset>ipt).unwrap()
             c_scanopts = make_shared[CScanNodeOptions](
                 c_in_dataset, make_shared[CScanOptions]())
+            deref(deref(c_scanopts).scan_options).use_threads = use_threads
             c_input_node_opts.swap(deref(<shared_ptr[CExecNodeOptions]*>&c_scanopts))
         else:
             raise TypeError("Unsupported type")

--- a/python/pyarrow/_exec_plan.pyx
+++ b/python/pyarrow/_exec_plan.pyx
@@ -97,14 +97,16 @@ cdef execplan(inputs, output_type, vector[CDeclaration] plan, c_bool use_threads
             c_in_table = pyarrow_unwrap_table(ipt).get()
             c_sourceopts = GetResultValue(
                 CSourceNodeOptions.FromTable(deref(c_in_table), deref(c_exec_context).executor()))
-            c_input_node_opts = static_pointer_cast[CExecNodeOptions, CSourceNodeOptions](c_sourceopts)
+            c_input_node_opts = static_pointer_cast[CExecNodeOptions, CSourceNodeOptions](
+                c_sourceopts)
         elif isinstance(ipt, Dataset):
             node_factory = "scan"
             c_in_dataset = (<Dataset>ipt).unwrap()
             c_scanopts = make_shared[CScanNodeOptions](
                 c_in_dataset, make_shared[CScanOptions]())
             deref(deref(c_scanopts).scan_options).use_threads = use_threads
-            c_input_node_opts = static_pointer_cast[CExecNodeOptions, CScanNodeOptions](c_scanopts)
+            c_input_node_opts = static_pointer_cast[CExecNodeOptions, CScanNodeOptions](
+                c_scanopts)
         else:
             raise TypeError("Unsupported type")
 

--- a/python/pyarrow/_exec_plan.pyx
+++ b/python/pyarrow/_exec_plan.pyx
@@ -97,14 +97,14 @@ cdef execplan(inputs, output_type, vector[CDeclaration] plan, c_bool use_threads
             c_in_table = pyarrow_unwrap_table(ipt).get()
             c_sourceopts = GetResultValue(
                 CSourceNodeOptions.FromTable(deref(c_in_table), deref(c_exec_context).executor()))
-            c_input_node_opts.swap(deref(<shared_ptr[CExecNodeOptions]*>&c_sourceopts))
+            c_input_node_opts = static_pointer_cast[CExecNodeOptions, CSourceNodeOptions](c_sourceopts)
         elif isinstance(ipt, Dataset):
             node_factory = "scan"
             c_in_dataset = (<Dataset>ipt).unwrap()
             c_scanopts = make_shared[CScanNodeOptions](
                 c_in_dataset, make_shared[CScanOptions]())
             deref(deref(c_scanopts).scan_options).use_threads = use_threads
-            c_input_node_opts.swap(deref(<shared_ptr[CExecNodeOptions]*>&c_scanopts))
+            c_input_node_opts = static_pointer_cast[CExecNodeOptions, CScanNodeOptions](c_scanopts)
         else:
             raise TypeError("Unsupported type")
 

--- a/python/pyarrow/_exec_plan.pyx
+++ b/python/pyarrow/_exec_plan.pyx
@@ -75,7 +75,7 @@ cdef execplan(inputs, output_type, vector[CDeclaration] plan, c_bool use_threads
     if not _dataset_support_initialised:
         Initialize()  # Initialise support for Datasets in ExecPlan
         _dataset_support_initialised = True
-    
+
     if use_threads:
         c_executor = GetCpuThreadPool()
     else:
@@ -106,7 +106,8 @@ cdef execplan(inputs, output_type, vector[CDeclaration] plan, c_bool use_threads
                 )
         elif isinstance(ipt, Dataset):
             c_in_dataset = (<Dataset>ipt).unwrap()
-            c_scanopts = make_shared[CScanNodeOptions](c_in_dataset, make_shared[CScanOptions]())
+            c_scanopts = make_shared[CScanNodeOptions](
+                c_in_dataset, make_shared[CScanOptions]())
             if plan_iter != plan.end():
                 # Flag the source as the input of the first plan node.
                 deref(plan_iter).inputs.push_back(CDeclaration.Input(
@@ -119,7 +120,6 @@ cdef execplan(inputs, output_type, vector[CDeclaration] plan, c_bool use_threads
                 )
         else:
             raise TypeError("Unsupported type")
-
 
     # Add Here additional nodes
     while plan_iter != plan.end():
@@ -205,9 +205,9 @@ def tables_join(join_type, left_table not None, left_keys,
 
 
 def datasets_join(join_type, left_dataset not None, left_keys,
-                right_dataset not None, right_keys,
-                left_suffix=None, right_suffix=None,
-                use_threads=True, coalesce_keys=False):
+                  right_dataset not None, right_keys,
+                  left_suffix=None, right_suffix=None,
+                  use_threads=True, coalesce_keys=False):
     """
     Perform join of two datasets.
 
@@ -244,7 +244,6 @@ def datasets_join(join_type, left_dataset not None, left_keys,
     return _perform_join(join_type, left_dataset, left_keys,
                          right_dataset, right_keys, left_suffix,
                          right_suffix, use_threads, coalesce_keys)
-
 
 
 def _perform_join(join_type, left_table not None, left_keys,

--- a/python/pyarrow/_exec_plan.pyx
+++ b/python/pyarrow/_exec_plan.pyx
@@ -32,7 +32,7 @@ from pyarrow.lib import tobytes, _pc
 from pyarrow._compute cimport Expression, _true
 from pyarrow._dataset cimport Dataset
 
-_dataset_support_initialised = False
+Initialize()  # Initialise support for Datasets in ExecPlan
 
 
 cdef execplan(inputs, output_type, vector[CDeclaration] plan, c_bool use_threads=True):
@@ -72,11 +72,6 @@ cdef execplan(inputs, output_type, vector[CDeclaration] plan, c_bool use_threads
         shared_ptr[CRecordBatchReader] c_recordbatchreader
         vector[CDeclaration].iterator plan_iter
         vector[CDeclaration.Input] no_c_inputs
-
-    global _dataset_support_initialised
-    if not _dataset_support_initialised:
-        Initialize()  # Initialise support for Datasets in ExecPlan
-        _dataset_support_initialised = True
 
     if use_threads:
         c_executor = GetCpuThreadPool()

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -79,7 +79,6 @@ from pyarrow._compute import (  # noqa
     # Expressions
     Expression,
 )
-from pyarrow import _exec_plan  # noqa
 
 from collections import namedtuple
 import inspect

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2503,6 +2503,7 @@ cdef extern from "arrow/compute/exec/exec_plan.h" namespace "arrow::compute" nog
         vector[Input] inputs
 
         CDeclaration(c_string factory_name, CExecNodeOptions options)
+        CDeclaration(c_string factory_name, vector[Input] inputs, shared_ptr[CExecNodeOptions] options)
 
         @staticmethod
         CDeclaration Sequence(vector[CDeclaration] decls)

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -52,9 +52,12 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
     cdef cppclass CScanOptions "arrow::dataset::ScanOptions":
         shared_ptr[CSchema] dataset_schema
         shared_ptr[CSchema] projected_schema
+        c_bool use_threads
 
     cdef cppclass CScanNodeOptions "arrow::dataset::ScanNodeOptions"(CExecNodeOptions):
         CScanNodeOptions(shared_ptr[CDataset] dataset, shared_ptr[CScanOptions] scan_options)
+
+        shared_ptr[CScanOptions] scan_options
 
     cdef cppclass CFragmentScanOptions "arrow::dataset::FragmentScanOptions":
         c_string type_name() const

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -31,6 +31,11 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         pass
 
 
+cdef extern from "arrow/dataset/plan.h" namespace "arrow::dataset::internal" nogil:
+
+    cdef void Initialize()
+
+
 ctypedef CStatus cb_writer_finish_internal(CFileWriter*)
 ctypedef void cb_writer_finish(dict, CFileWriter*)
 
@@ -45,11 +50,11 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
             arrow::dataset::ExistingDataBehavior::kError"
 
     cdef cppclass CScanOptions "arrow::dataset::ScanOptions":
-        @staticmethod
-        shared_ptr[CScanOptions] Make(shared_ptr[CSchema] schema)
-
         shared_ptr[CSchema] dataset_schema
         shared_ptr[CSchema] projected_schema
+
+    cdef cppclass CScanNodeOptions "arrow::dataset::ScanNodeOptions"(CExecNodeOptions):
+        CScanNodeOptions(shared_ptr[CDataset] dataset, shared_ptr[CScanOptions] scan_options)
 
     cdef cppclass CFragmentScanOptions "arrow::dataset::FragmentScanOptions":
         c_string type_name() const

--- a/python/pyarrow/lib.pyx
+++ b/python/pyarrow/lib.pyx
@@ -118,6 +118,8 @@ UnionMode_SPARSE = _UnionMode_SPARSE
 UnionMode_DENSE = _UnionMode_DENSE
 
 __pc = None
+
+
 def _pc():
     global __pc
     if __pc is None:

--- a/python/pyarrow/lib.pyx
+++ b/python/pyarrow/lib.pyx
@@ -120,6 +120,8 @@ UnionMode_DENSE = _UnionMode_DENSE
 
 def _pc():
     import pyarrow.compute as pc
+    from pyarrow import _exec_plan
+    pc._exec_plan = _exec_plan
     return pc
 
 

--- a/python/pyarrow/lib.pyx
+++ b/python/pyarrow/lib.pyx
@@ -117,12 +117,18 @@ Type_DICTIONARY = _Type_DICTIONARY
 UnionMode_SPARSE = _UnionMode_SPARSE
 UnionMode_DENSE = _UnionMode_DENSE
 
-
+__pc = None
 def _pc():
-    import pyarrow.compute as pc
-    from pyarrow import _exec_plan
-    pc._exec_plan = _exec_plan
-    return pc
+    global __pc
+    if __pc is None:
+        import pyarrow.compute as pc
+        try:
+            from pyarrow import _exec_plan
+            pc._exec_plan = _exec_plan
+        except ImportError:
+            pass
+        __pc = pc
+    return __pc
 
 
 def _gdb_test_session():

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -2643,9 +2643,9 @@ cdef class Table(_PandasConvertible):
         """
         if right_keys is None:
             right_keys = keys
-        return _pc()._exec_plan.tables_join(join_type, self, keys, right_table, right_keys,
-                                            left_suffix=left_suffix, right_suffix=right_suffix,
-                                            use_threads=use_threads, coalesce_keys=coalesce_keys)
+        return _pc()._exec_plan._perform_join(join_type, self, keys, right_table, right_keys,
+                                              left_suffix=left_suffix, right_suffix=right_suffix,
+                                              use_threads=use_threads, coalesce_keys=coalesce_keys)
 
     def group_by(self, keys):
         """Declare a grouping over the columns of the table.

--- a/python/pyarrow/tests/test_exec_plan.py
+++ b/python/pyarrow/tests/test_exec_plan.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from ast import Import
 import pytest
 
 pytestmark = pytest.mark.dataset

--- a/python/pyarrow/tests/test_exec_plan.py
+++ b/python/pyarrow/tests/test_exec_plan.py
@@ -16,9 +16,6 @@
 # under the License.
 
 import pytest
-
-pytestmark = pytest.mark.dataset
-
 import pyarrow as pa
 
 try:
@@ -26,6 +23,8 @@ try:
     import pyarrow._exec_plan as ep
 except ImportError:
     pass
+
+pytestmark = pytest.mark.dataset
 
 
 def test_joins_corner_cases():

--- a/python/pyarrow/tests/test_exec_plan.py
+++ b/python/pyarrow/tests/test_exec_plan.py
@@ -15,11 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from ast import Import
 import pytest
 
+pytestmark = pytest.mark.dataset
+
 import pyarrow as pa
-import pyarrow.dataset as ds
-import pyarrow._exec_plan as ep
+
+try:
+    import pyarrow.dataset as ds
+    import pyarrow._exec_plan as ep
+except ImportError:
+    pass
 
 
 def test_joins_corner_cases():

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -2045,6 +2045,7 @@ def test_table_to_recordbatchreader():
     assert reader.read_next_batch().num_rows == 1
 
 
+@pytest.mark.dataset
 def test_table_join():
     t1 = pa.table({
         "colA": [1, 2, 6],
@@ -2071,6 +2072,7 @@ def test_table_join():
     })
 
 
+@pytest.mark.dataset
 def test_table_join_unique_key():
     t1 = pa.table({
         "colA": [1, 2, 6],
@@ -2097,6 +2099,7 @@ def test_table_join_unique_key():
     })
 
 
+@pytest.mark.dataset
 def test_table_join_collisions():
     t1 = pa.table({
         "colA": [1, 2, 6],


### PR DESCRIPTION
This supports providing Datasets as inputs of the join operation. 
Until https://issues.apache.org/jira/browse/ARROW-15526 is completed, the join will temporary return a Table in case of Datasets too.