### PR TITLE
MINOR: [Docs] rename developers/advanced to in developers/overview dev toctree

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -89,7 +89,7 @@ target environment.**
    developers/contributing
    developers/bug_reports
    developers/guide/index
-   developers/advanced
+   developers/overview
    developers/reviewing
    developers/cpp/index
    developers/java/index


### PR DESCRIPTION
This PR corrects a page name change missing in toctree (leftover from https://github.com/apache/arrow/pull/12483)