### PR TITLE
MINOR: [R] Avoid {glue}'s whitespace trimming

### DIFF
--- a/r/data-raw/codegen.R
+++ b/r/data-raw/codegen.R
@@ -184,9 +184,9 @@ glue::glue_collapse(glue::glue('
 '
 static const R_CallMethodDef CallEntries[] = {
 ',
-glue::glue_collapse(glue::glue('
-\t\t{{ "_{features}_available", (DL_FUNC)& _{features}_available, 0 }},
-'), sep = '\n'),
+glue::glue_collapse(glue::glue(
+  '\t\t{{ "_{features}_available", (DL_FUNC)& _{features}_available, 0 }},',
+), sep = '\n'),
 glue::glue('\n
 {cpp_functions_registration}
 \t\t{{NULL, NULL, 0}}


### PR DESCRIPTION
For a while now glue has been removing the tabs before: (this might be from https://github.com/tidyverse/glue/commit/8369f9afe09cc52847624d2e55f0f72ce64ef25a which was to change [a different thing we noticed with whitespace stripping](https://github.com/tidyverse/glue/issues/247)).

Regardless, the fix is easy enough (don't include new lines around the line we are glueing)

Before the change, the format of the relevant lines of arrowExports.cpp are:
```
static const R_CallMethodDef CallEntries[] = {
{ "_arrow_available", (DL_FUNC)& _arrow_available, 0 },
{ "_dataset_available", (DL_FUNC)& _dataset_available, 0 },
{ "_engine_available", (DL_FUNC)& _engine_available, 0 },
{ "_parquet_available", (DL_FUNC)& _parquet_available, 0 },
{ "_s3_available", (DL_FUNC)& _s3_available, 0 },
{ "_json_available", (DL_FUNC)& _json_available, 0 },
{ "_arrow_test_SET_STRING_ELT", (DL_FUNC) &_arrow_test_SET_STRING_ELT, 1}, 
```
  
When they should be:
```
static const R_CallMethodDef CallEntries[] = {
	{ "_arrow_available", (DL_FUNC)& _arrow_available, 0 },
	{ "_dataset_available", (DL_FUNC)& _dataset_available, 0 },
	{ "_engine_available", (DL_FUNC)& _engine_available, 0 },
	{ "_parquet_available", (DL_FUNC)& _parquet_available, 0 },
	{ "_s3_available", (DL_FUNC)& _s3_available, 0 },
	{ "_json_available", (DL_FUNC)& _json_available, 0 },
	{ "_arrow_test_SET_STRING_ELT", (DL_FUNC) &_arrow_test_SET_STRING_ELT, 1}, 
```

This change restores the indentation we expect there (so the file won't change on rebuilds)