### PR TITLE
ARROW-15852: [JS] Fix error thrown by `Table.getByteLength()`

### DIFF
--- a/js/src/visitor/bytelength.ts
+++ b/js/src/visitor/bytelength.ts
@@ -48,19 +48,46 @@ export interface GetByteLengthVisitor extends Visitor {
 
 /** @ignore */
 export class GetByteLengthVisitor extends Visitor {
-    public visitNull(____: Data<Null>, _: number) { return 0; }
-    public visitInt(data: Data<Int>, _: number) { return data.type.bitWidth / 8; }
-    public visitFloat(data: Data<Float>, _: number) { return data.type.ArrayType.BYTES_PER_ELEMENT; }
-    public visitBool(____: Data<Bool>, _: number) { return 1 / 8; }
-    public visitDecimal(____: Data<Decimal>, _: number) { return 16; }
-    public visitDate(data: Data<Date_>, _: number) { return (data.type.unit + 1) * 4; }
-    public visitTime(data: Data<Time>, _: number) { return data.type.bitWidth / 8; }
-    public visitTimestamp(data: Data<Timestamp>, _: number) { return data.type.unit === TimeUnit.SECOND ? 4 : 8; }
-    public visitInterval(data: Data<Interval>, _: number) { return (data.type.unit + 1) * 4; }
-    public visitStruct(data: Data<Struct>, _: number) { return this.visitMany(data.children, data.children.map(() => _)).reduce(sum, 0); }
-    public visitFixedSizeBinary(data: Data<FixedSizeBinary>, _: number) { return data.type.byteWidth; }
-    public visitMap(data: Data<Map_>, _: number) { return this.visitMany(data.children, data.children.map(() => _)).reduce(sum, 0); }
-    public visitDictionary(data: Data<Dictionary>, _: number) { return (data.type.indices.bitWidth / 8) + (data.dictionary?.getByteLength(data.values[_]) || 0); }
+    public visitNull(____: Data<Null>, _: number) {
+        return 0;
+    }
+    public visitInt(data: Data<Int>, _: number) {
+        return data.type.bitWidth / 8;
+    }
+    public visitFloat(data: Data<Float>, _: number) {
+        return data.type.ArrayType.BYTES_PER_ELEMENT;
+    }
+    public visitBool(____: Data<Bool>, _: number) {
+        return 1 / 8;
+    }
+    public visitDecimal(data: Data<Decimal>, _: number) {
+        return data.type.bitWidth / 8;
+    }
+    public visitDate(data: Data<Date_>, _: number) {
+        return (data.type.unit + 1) * 4;
+    }
+    public visitTime(data: Data<Time>, _: number) {
+        return data.type.bitWidth / 8;
+    }
+    public visitTimestamp(data: Data<Timestamp>, _: number) {
+        return data.type.unit === TimeUnit.SECOND ? 4 : 8;
+    }
+    public visitInterval(data: Data<Interval>, _: number) {
+        return (data.type.unit + 1) * 4;
+    }
+    public visitStruct(data: Data<Struct>, i: number) {
+        return data.children.reduce((total, child) => total + instance.visit(child, i), 0);
+    }
+    public visitFixedSizeBinary(data: Data<FixedSizeBinary>, _: number) {
+        return data.type.byteWidth;
+    }
+    public visitMap(data: Data<Map_>, i: number) {
+        // 4 + 4 for the indices
+        return 8 + data.children.reduce((total, child) => total + instance.visit(child, i), 0);
+    }
+    public visitDictionary(data: Data<Dictionary>, i: number) {
+        return (data.type.indices.bitWidth / 8) + (data.dictionary?.getByteLength(data.values[i]) || 0);
+    }
 }
 
 /** @ignore */

--- a/js/test/unit/table-tests.ts
+++ b/js/test/unit/table-tests.ts
@@ -313,10 +313,9 @@ describe(`Table`, () => {
                 expect(table.numRows).toEqual(values.length);
             });
 
-            const table = datum.table();
-            const values = datum.values();
-
             test(`table.select() basic tests`, () => {
+                const table = datum.table();
+                const values = datum.values();
                 const selected = table.select(['f32', 'dictionary']);
                 expect(selected.schema.fields).toHaveLength(2);
                 expect(selected.schema.fields[0]).toEqual(table.schema.fields[0]);
@@ -332,6 +331,13 @@ describe(`Table`, () => {
                         expect(row.f32).toEqual(expected_row[F32]);
                         expect(row.dictionary).toEqual(expected_row[DICT]);
                     }
+                }
+            });
+
+            test(`table.getByteLength() returns the byteLength of each row`, () => {
+                const table = datum.table();
+                for (let i = -1, n = table.numRows; ++i < n;) {
+                    expect(table.getByteLength(i)).toBeGreaterThan(0);
                 }
             });
         });


### PR DESCRIPTION
Fixes an oversight in the v7.0.0 big refactor -- now methods added to the Table's prototype aren't called within the context of the visitor, so `getByteLength()` was throwing a null reference error.

Related JIRA: https://issues.apache.org/jira/browse/ARROW-15852