### PR TITLE
ARROW-16058: [Python] Address docstrings for Table class, methods, attributes and constructor

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -756,10 +756,10 @@ cdef class _PandasConvertible(_Weakrefable):
         Convert a Table to pandas DataFrame:
 
         >>> import pyarrow as pa
-        >>> n_legs = pa.array([2, 4, 5, 100])
-        >>> animals = pa.array(["Flamingo", "Horse", "Brittle stars", "Centipede"])
-        >>> names = ["n_legs", "animals"]
-        >>> table = pa.Table.from_arrays([n_legs, animals], names=names)
+        >>> table = pa.table([
+        ...    pa.array([2, 4, 5, 100]),
+        ...    pa.array(["Flamingo", "Horse", "Brittle stars", "Centipede"])
+        ...    ], names=['n_legs', 'animals'])
         >>> table.to_pandas()
            n_legs        animals
         0       2       Flamingo

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -768,7 +768,6 @@ cdef class _PandasConvertible(_Weakrefable):
         3     100      Centipede
         >>> isinstance(table.to_pandas(), pd.DataFrame)
         True
-
         """
         options = dict(
             pool=memory_pool,

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -2798,6 +2798,23 @@ def concat_arrays(arrays, MemoryPool memory_pool=None):
         Arrays to concatenate, must be identically typed.
     memory_pool : MemoryPool, default None
         For memory allocations. If None, the default pool is used.
+
+    Examples
+    --------
+    >>> import pyarrow as pa
+    >>> arr1 = pa.array([2, 4, 5, 100])
+    >>> arr2 = pa.array([2, 4])
+    >>> pa.concat_arrays([arr1, arr2])
+    <pyarrow.lib.Int64Array object at 0x1166eb1c0>
+    [
+      2,
+      4,
+      5,
+      100,
+      2,
+      4
+    ]
+
     """
     cdef:
         vector[shared_ptr[CArray]] c_arrays

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -750,6 +750,25 @@ cdef class _PandasConvertible(_Weakrefable):
         Returns
         -------
         pandas.Series or pandas.DataFrame depending on type of object
+
+        Examples
+        --------
+        Convert a Table to pandas DataFrame:
+
+        >>> import pyarrow as pa
+        >>> n_legs = pa.array([2, 4, 5, 100])
+        >>> animals = pa.array(["Flamingo", "Horse", "Brittle stars", "Centipede"])
+        >>> names = ["n_legs", "animals"]
+        >>> table = pa.Table.from_arrays([n_legs, animals], names=names)
+        >>> table.to_pandas()
+           n_legs        animals
+        0       2       Flamingo
+        1       4          Horse
+        2       5  Brittle stars
+        3     100      Centipede
+        >>> isinstance(table.to_pandas(), pd.DataFrame)
+        True
+
         """
         options = dict(
             pool=memory_pool,

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1497,13 +1497,13 @@ cdef class Table(_PandasConvertible):
     Construct a Table from a RecordBatch:
 
     >>> batch = pa.record_batch([n_legs, animals], names=names)
-    >>> pa.Table.from_batches([batch, batch])
+    >>> pa.Table.from_batches([batch])
     pyarrow.Table
     n_legs: int64
     animals: string
     ----
-    n_legs: [[2,4,5,100],[2,4,5,100]]
-    animals: [["Flamingo","Horse","Brittle stars","Centipede"],["Flamingo","Horse","Brittle stars","Centipede"]]
+    n_legs: [[2,4,5,100]]
+    animals: [["Flamingo","Horse","Brittle stars","Centipede"]]
 
     Construct a Table from pandas DataFrame:
 
@@ -1602,6 +1602,18 @@ cdef class Table(_PandasConvertible):
         Returns
         -------
         str
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'year': [2020, 2022, 2019, 2021],
+        ...                    'n_legs': [2, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> table.to_string()
+        'pyarrow.Table\nyear: int64\nn_legs: int64\nanimals: string'
+
         """
         # Use less verbose schema output.
         schema_as_string = self.schema.to_string(
@@ -1694,6 +1706,43 @@ cdef class Table(_PandasConvertible):
         Returns
         -------
         Table
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'year': [2020, 2022, 2019, 2021],
+        ...                    'n_legs': [2, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> table.slice(length=3)
+        pyarrow.Table
+        year: int64
+        n_legs: int64
+        animals: string
+        ----
+        year: [[2020,2022,2019]]
+        n_legs: [[2,4,5]]
+        animals: [["Flamingo","Horse","Brittle stars"]]
+        >>> table.slice(offset=2)
+        pyarrow.Table
+        year: int64
+        n_legs: int64
+        animals: string
+        ----
+        year: [[2019,2021]]
+        n_legs: [[5,100]]
+        animals: [["Brittle stars","Centipede"]]
+        >>> table.slice(offset=2, length=1)
+        pyarrow.Table
+        year: int64
+        n_legs: int64
+        animals: string
+        ----
+        year: [[2019]]
+        n_legs: [[5]]
+        animals: [["Brittle stars"]]
+
         """
         cdef shared_ptr[CTable] result
 
@@ -1726,6 +1775,38 @@ cdef class Table(_PandasConvertible):
         filtered : Table
             A table of the same schema, with only the rows selected
             by the boolean mask.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'year': [2020, 2022, 2019, 2021],
+        ...                    'n_legs': [2, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+
+        Define a mask and select rows:
+
+        >>> mask=[True, True, False, None]
+        >>> table.filter(mask)
+        pyarrow.Table
+        year: int64
+        n_legs: int64
+        animals: string
+        ----
+        year: [[2020,2022]]
+        n_legs: [[2,4]]
+        animals: [["Flamingo","Horse"]]
+        >>> table.filter(mask, null_selection_behavior='emit_null')
+        pyarrow.Table
+        year: int64
+        n_legs: int64
+        animals: string
+        ----
+        year: [[2020,2022,null]]
+        n_legs: [[2,4,null]]
+        animals: [["Flamingo","Horse",null]]
+
         """
         return _pc().filter(self, mask, null_selection_behavior)
 
@@ -1744,6 +1825,25 @@ cdef class Table(_PandasConvertible):
         -------
         taken : Table
             A table with the same schema, containing the taken rows.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'year': [2020, 2022, 2019, 2021],
+        ...                    'n_legs': [2, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> table.take([1,3])
+        pyarrow.Table
+        year: int64
+        n_legs: int64
+        animals: string
+        ----
+        year: [[2022,2021]]
+        n_legs: [[4,100]]
+        animals: [["Horse","Centipede"]]
+
         """
         return _pc().take(self, indices)
 
@@ -1751,6 +1851,25 @@ cdef class Table(_PandasConvertible):
         """
         Remove missing values from a Table.
         See :func:`pyarrow.compute.drop_null` for full usage.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'year': [None, 2022, 2019, 2021],
+        ...                   'n_legs': [2, 4, 5, 100],
+        ...                   'animals': ["Flamingo", "Horse", None, "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> table.drop_null()
+        pyarrow.Table
+        year: double
+        n_legs: int64
+        animals: string
+        ----
+        year: [[2022,2021]]
+        n_legs: [[4,100]]
+        animals: [["Horse","Centipede"]]
+
         """
         return _pc().drop_null(self)
 
@@ -1769,6 +1888,28 @@ cdef class Table(_PandasConvertible):
         Returns
         -------
         Table
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'year': [2020, 2022, 2019, 2021],
+        ...                    'n_legs': [2, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> table.select([0,1])
+        pyarrow.Table
+        year: int64
+        n_legs: int64
+        ----
+        year: [[2020,2022,2019,2021]]
+        n_legs: [[2,4,5,100]]
+        >>> table.select(["year"])
+        pyarrow.Table
+        year: int64
+        ----
+        year: [[2020,2022,2019,2021]]
+
         """
         cdef:
             shared_ptr[CTable] c_table
@@ -1797,6 +1938,45 @@ cdef class Table(_PandasConvertible):
         Returns
         -------
         Table
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'year': [2020, 2022, 2019, 2021],
+        ...                    'n_legs': [2, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+
+        Constructing a Table with pyarrow schema and metadata:
+
+        >>> my_schema = pa.schema([
+        ...     pa.field('n_legs', pa.int64()),
+        ...     pa.field('animals', pa.string())],
+        ...     metadata={"n_legs": "Number of legs per animal"})
+        >>> table= pa.table(df, my_schema)
+        >>> table.schema
+        n_legs: int64
+        animals: string
+        -- schema metadata --
+        n_legs: 'Number of legs per animal'
+        pandas: ...
+
+        Create a shallow copy of a Table with deleted schema metadata:
+
+        >>> table.replace_schema_metadata().schema
+        n_legs: int64
+        animals: string
+
+        Create a shallow copy of a Table with new schema metadata:
+
+        >>> metadata={"animals": "Which animal"}
+        >>> table.replace_schema_metadata(metadata = metadata).schema
+        n_legs: int64
+        animals: string
+        -- schema metadata --
+        animals: 'Which animal'
+
         """
         cdef:
             shared_ptr[const CKeyValueMetadata] c_meta
@@ -1824,6 +2004,47 @@ cdef class Table(_PandasConvertible):
         Returns
         -------
         Table
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> struct = pa.array([{'n_legs': 2, 'animals': 'Parrot'},
+        ...                    {'year': 2022, 'n_legs': 4}])
+        >>> month = pa.array([4, 6])
+        >>> table = pa.Table.from_arrays([struct,month],
+        ...                              names = ["a", "month"])
+        >>> table
+        pyarrow.Table
+        a: struct<animals: string, n_legs: int64, year: int64>
+          child 0, animals: string
+          child 1, n_legs: int64
+          child 2, year: int64
+        month: int64
+        ----
+        a: [
+          -- is_valid: all not null
+          -- child 0 type: string
+        ["Parrot",null]
+          -- child 1 type: int64
+        [2,4]
+          -- child 2 type: int64
+        [null,2022]]
+        month: [[4,6]]
+
+        Flatten the columns with struct field:
+
+        >>> table.flatten()
+        pyarrow.Table
+        a.animals: string
+        a.n_legs: int64
+        a.year: int64
+        month: int64
+        ----
+        a.animals: [["Parrot",null]]
+        a.n_legs: [[2,4]]
+        a.year: [[null,2022]]
+        month: [[4,6]]
+
         """
         cdef:
             shared_ptr[CTable] flattened
@@ -1849,6 +2070,29 @@ cdef class Table(_PandasConvertible):
         Returns
         -------
         Table
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> n_legs = pa.chunked_array([[2, 2, 4], [4, 5, 100]])
+        >>> animals = pa.chunked_array([["Flamingo", "Parrot", "Dog"], ["Horse", "Brittle stars", "Centipede"]])
+        >>> names = ["n_legs", "animals"]
+        >>> table = pa.table([n_legs, animals], names=names)
+        >>> table
+        pyarrow.Table
+        n_legs: int64
+        animals: string
+        ----
+        n_legs: [[2,2,4],[4,5,100]]
+        animals: [["Flamingo","Parrot","Dog"],["Horse","Brittle stars","Centipede"]]
+        >>> table.combine_chunks()
+        pyarrow.Table
+        n_legs: int64
+        animals: string
+        ----
+        n_legs: [[2,2,4,4,5,100]]
+        animals: [["Flamingo","Parrot","Dog","Horse","Brittle stars","Centipede"]]
+
         """
         cdef:
             shared_ptr[CTable] combined
@@ -1877,6 +2121,36 @@ cdef class Table(_PandasConvertible):
         Returns
         -------
         Table
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> arr_1 = pa.array(["Flamingo", "Parot", "Dog"]).dictionary_encode()
+        >>> arr_2 = pa.array(["Horse", "Brittle stars", "Centipede"]).dictionary_encode()
+        >>> c_arr = pa.chunked_array([arr_1, arr_2])
+        >>> table = pa.table([c_arr], names=["animals"])
+        >>> table
+        pyarrow.Table
+        animals: dictionary<values=string, indices=int32, ordered=0>
+        ----
+        animals: [  -- dictionary:
+        ["Flamingo","Parot","Dog"]  -- indices:
+        [0,1,2],  -- dictionary:
+        ["Horse","Brittle stars","Centipede"]  -- indices:
+        [0,1,2]]
+
+        Unify dictionaries across both chunks:
+        
+        >>> table.unify_dictionaries()
+        pyarrow.Table
+        animals: dictionary<values=string, indices=int32, ordered=0>
+        ----
+        animals: [  -- dictionary:
+        ["Flamingo","Parot","Dog","Horse","Brittle stars","Centipede"]  -- indices:
+        [0,1,2],  -- dictionary:
+        ["Flamingo","Parot","Dog","Horse","Brittle stars","Centipede"]  -- indices:
+        [3,4,5]]
+
         """
         cdef:
             CMemoryPool* pool = maybe_unbox_memory_pool(memory_pool)
@@ -1908,6 +2182,27 @@ cdef class Table(_PandasConvertible):
         Returns
         -------
         bool
+
+        Examples
+        --------
+        >>> import pyarrow as pa  
+        >>> n_legs = pa.array([2, 2, 4, 4, 5, 100])
+        >>> animals = pa.array(["Flamingo", "Parrot", "Dog", "Horse", "Brittle stars", "Centipede"])
+        >>> names=["n_legs", "animals"]
+        >>> table = pa.Table.from_arrays([n_legs, animals], names=names)
+        >>> table_0 = pa.Table.from_arrays([])
+        >>> table_1 = pa.Table.from_arrays([n_legs, animals],
+        ...                                 names=names,
+        ...                                 metadata={"n_legs": "Number of legs per animal"})
+        >>> table.equals(table)
+        True
+        >>> table.equals(table_0)
+        False
+        >>> table.equals(table_1)
+        True
+        >>> table.equals(table_1, check_metadata=True)
+        False
+
         """
         if other is None:
             return False
@@ -1936,6 +2231,34 @@ cdef class Table(_PandasConvertible):
         Returns
         -------
         Table
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'n_legs': [2, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> table.schema
+        n_legs: int64
+        animals: string
+        -- schema metadata --
+        pandas: '{"index_columns": [{"kind": "range", "name": null, "start": 0, "' + 509
+
+        Define new schema and cast table values:
+
+        >>> my_schema = pa.schema([
+        ...     pa.field('n_legs', pa.duration('s')),
+        ...     pa.field('animals', pa.string())]
+        ...     )
+        >>> table.cast(target_schema=my_schema)
+        pyarrow.Table
+        n_legs: duration[s]
+        animals: string
+        ----
+        n_legs: [[2,4,5,100]]
+        animals: [["Flamingo","Horse","Brittle stars","Centipede"]]
+
         """
         cdef:
             ChunkedArray column, casted
@@ -2003,15 +2326,18 @@ cdef class Table(_PandasConvertible):
 
         Examples
         --------
-
-        >>> import pandas as pd
         >>> import pyarrow as pa
-        >>> df = pd.DataFrame({
-        ...     'int': [1, 2],
-        ...     'str': ['a', 'b']
-        ... })
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'n_legs': [2, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
         >>> pa.Table.from_pandas(df)
-        <pyarrow.lib.Table object at 0x7f05d1fb1b40>
+        pyarrow.Table
+        n_legs: int64
+        animals: string
+        ----
+        n_legs: [[2,4,5,100]]
+        animals: [["Flamingo","Horse","Brittle stars","Centipede"]]
+
         """
         from pyarrow.pandas_compat import dataframe_to_arrays
         arrays, schema, n_rows = dataframe_to_arrays(
@@ -2050,6 +2376,65 @@ cdef class Table(_PandasConvertible):
         Returns
         -------
         Table
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> n_legs = pa.array([2, 4, 5, 100])
+        >>> animals = pa.array(["Flamingo", "Horse", "Brittle stars", "Centipede"])
+        >>> names = ["n_legs", "animals"]
+
+        Construct a Table from arrays:
+
+        >>> pa.Table.from_arrays([n_legs, animals], names=names)
+        pyarrow.Table
+        n_legs: int64
+        animals: string
+        ----
+        n_legs: [[2,4,5,100]]
+        animals: [["Flamingo","Horse","Brittle stars","Centipede"]]
+
+        Construct a Table from arrays with metadata:
+
+        >>> my_metadata={"n_legs": "Number of legs per animal"}
+        >>> pa.Table.from_arrays([n_legs, animals],
+        ...                       names=names,
+        ...                       metadata=my_metadata)
+        pyarrow.Table
+        n_legs: int64
+        animals: string
+        ----
+        n_legs: [[2,4,5,100]]
+        animals: [["Flamingo","Horse","Brittle stars","Centipede"]]
+        >>> pa.Table.from_arrays([n_legs, animals],
+        ...                       names=names,
+        ...                       metadata=my_metadata).schema
+        n_legs: int64
+        animals: string
+        -- schema metadata --
+        n_legs: 'Number of legs per animal'
+
+        Construct a Table from arrays with pyarrow schema:
+
+        >>> my_schema = pa.schema([
+        ...     pa.field('n_legs', pa.int64()),
+        ...     pa.field('animals', pa.string())],
+        ...     metadata={"animals": "Name of the animal species"})
+        >>> pa.Table.from_arrays([n_legs, animals],
+        ...                       schema=my_schema)
+        pyarrow.Table
+        n_legs: int64
+        animals: string
+        ----
+        n_legs: [[2,4,5,100]]
+        animals: [["Flamingo","Horse","Brittle stars","Centipede"]]
+        >>> pa.Table.from_arrays([n_legs, animals],
+        ...                       schema=my_schema).schema
+        n_legs: int64
+        animals: string
+        -- schema metadata --
+        animals: 'Name of the animal species'
+
         """
         cdef:
             vector[shared_ptr[CChunkedArray]] columns
@@ -2097,14 +2482,32 @@ cdef class Table(_PandasConvertible):
         Examples
         --------
         >>> import pyarrow as pa
-        >>> pydict = {'int': [1, 2], 'str': ['a', 'b']}
+        >>> n_legs = pa.array([2, 4, 5, 100])
+        >>> animals = pa.array(["Flamingo", "Horse", "Brittle stars", "Centipede"])
+        >>> pydict = {'n_legs': n_legs, 'animals': animals}
+
+        Construct a Table from a dictionary of arrays:
+
         >>> pa.Table.from_pydict(pydict)
         pyarrow.Table
-        int: int64
-        str: string
+        n_legs: int64
+        animals: string
         ----
-        int: [[1,2]]
-        str: [["a","b"]]
+        n_legs: [[2,4,5,100]]
+        animals: [["Flamingo","Horse","Brittle stars","Centipede"]]
+        >>> pa.Table.from_pydict(pydict).schema
+        n_legs: int64
+        animals: string
+
+        Construct a Table from a dictionary of arrays with metadata:
+
+        >>> my_metadata={"n_legs": "Number of legs per animal"}
+        >>> pa.Table.from_pydict(pydict, metadata=my_metadata).schema
+        n_legs: int64
+        animals: string
+        -- schema metadata --
+        n_legs: 'Number of legs per animal'
+
         """
 
         return _from_pydict(cls=Table,
@@ -2134,14 +2537,35 @@ cdef class Table(_PandasConvertible):
         Examples
         --------
         >>> import pyarrow as pa
-        >>> pylist = [{'int': 1, 'str': 'a'}, {'int': 2, 'str': 'b'}]
+        >>> n_legs = pa.array([2, 4, 5, 100])
+        >>> animals = pa.array(["Flamingo", "Horse", "Brittle stars", "Centipede"])
+        >>> pylist = [{'n_legs': 2, 'animals': 'Flamingo'},
+        ...           {'year': 2021, 'animals': 'Centipede'}]
+
+        Construct a Table from a list of rows:
+
         >>> pa.Table.from_pylist(pylist)
         pyarrow.Table
-        int: int64
-        str: string
+        n_legs: int64
+        animals: string
         ----
-        int: [[1,2]]
-        str: [["a","b"]]
+        n_legs: [[2,null]]
+        animals: [["Flamingo","Centipede"]]
+
+        Construct a Table from a list of rows with pyarrow schema:
+
+        >>> my_schema = pa.schema([
+        ...     pa.field('year', pa.int64()),
+        ...     pa.field('n_legs', pa.int64()),
+        ...     pa.field('animals', pa.string())],
+        ...     metadata={"year": "Year of entry"})
+        >>> pa.Table.from_pylist(pylist, schema=my_schema).schema
+        year: int64
+        n_legs: int64
+        animals: string
+        -- schema metadata --
+        year: 'Year of entry'
+
         """
 
         return _from_pylist(cls=Table,
@@ -2164,6 +2588,41 @@ cdef class Table(_PandasConvertible):
         Returns
         -------
         Table
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> n_legs = pa.array([2, 4, 5, 100])
+        >>> animals = pa.array(["Flamingo", "Horse", "Brittle stars", "Centipede"])
+        >>> batch = pa.record_batch([n_legs, animals], names=names)
+        >>> batch.to_pandas()
+           n_legs        animals
+        0       2       Flamingo
+        1       4          Horse
+        2       5  Brittle stars
+        3     100      Centipede
+
+        Construct a Table from a RecordBatch:
+
+        >>> pa.Table.from_batches([batch])
+        pyarrow.Table
+        n_legs: int64
+        animals: string
+        ----
+        n_legs: [[2,4,5,100]]
+        animals: [["Flamingo","Horse","Brittle stars","Centipede"]]
+
+        Construct a Table from a sequence of RecordBatches:
+
+        >>> pa.Table.from_batches([batch, batch])
+        pyarrow.Table
+        n_legs: int64
+        animals: string
+        ----
+        n_legs: [[2,4,5,100],[2,4,5,100]]
+        animals: [["Flamingo","Horse","Brittle stars","Centipede"],["Flamingo","Horse","Brittle stars","Centipede"]]
+
+
         """
         cdef:
             vector[shared_ptr[CRecordBatch]] c_batches
@@ -2204,6 +2663,35 @@ cdef class Table(_PandasConvertible):
         Returns
         -------
         list[RecordBatch]
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'n_legs': [2, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+
+        Convert a Table to a RecordBatch:
+
+        >>> table.to_batches()[0].to_pandas()
+           n_legs        animals
+        0       2       Flamingo
+        1       4          Horse
+        2       5  Brittle stars
+        3     100      Centipede
+
+        Convert a Table to a list of RecordBatches:
+
+        >>> table.to_batches(max_chunksize=2)[0].to_pandas()
+           n_legs   animals
+        0       2  Flamingo
+        1       4     Horse
+        >>> table.to_batches(max_chunksize=2)[1].to_pandas()
+           n_legs        animals
+        0       5  Brittle stars
+        1     100      Centipede
+
         """
         cdef:
             unique_ptr[TableBatchReader] reader
@@ -2243,7 +2731,35 @@ cdef class Table(_PandasConvertible):
 
         Returns
         -------
-        RecordBatchReader        
+        RecordBatchReader
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'n_legs': [2, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+
+        Convert a Table to a RecordBatchReader:
+
+        >>> table.to_reader()
+        <pyarrow.lib.RecordBatchReader object at ...>
+
+        >>> reader = table.to_reader()
+        >>> reader.schema
+        n_legs: int64
+        animals: string
+        -- schema metadata --
+        pandas: '{"index_columns": [{"kind": "range", "name": null, "start": 0, "' + 509
+        >>> reader.read_all()
+        pyarrow.Table
+        n_legs: int64
+        animals: string
+        ----
+        n_legs: [[2,4,5,100]]
+        animals: [["Flamingo","Horse","Brittle stars","Centipede"]]
+
         """
         cdef:
             shared_ptr[CRecordBatchReader] c_reader
@@ -2280,12 +2796,13 @@ cdef class Table(_PandasConvertible):
         Examples
         --------
         >>> import pyarrow as pa
-        >>> table = pa.table([
-        ...     pa.array([1, 2]),
-        ...     pa.array(["a", "b"])
-        ... ], names=["int", "str"])
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'n_legs': [2, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
         >>> table.to_pydict()
-        {'int': [1, 2], 'str': ['a', 'b']}
+        {'n_legs': [2, 4, 5, 100], 'animals': ['Flamingo', 'Horse', 'Brittle stars', 'Centipede']}
+
         """
         cdef:
             size_t i
@@ -2310,12 +2827,13 @@ cdef class Table(_PandasConvertible):
         Examples
         --------
         >>> import pyarrow as pa
-        >>> table = pa.table([
-        ...     pa.array([1, 2]),
-        ...     pa.array(["a", "b"])
-        ... ], names=["int", "str"])
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'n_legs': [2, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
         >>> table.to_pylist()
-        [{'int': 1, 'str': 'a'}, {'int': 2, 'str': 'b'}]
+        [{'n_legs': 2, 'animals': 'Flamingo'}, {'n_legs': 4, 'animals': 'Horse'}, ...
+
         """
         pydict = self.to_pydict()
         names = self.schema.names
@@ -2331,6 +2849,20 @@ cdef class Table(_PandasConvertible):
         Returns
         -------
         Schema
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'n_legs': [2, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> table.schema
+        n_legs: int64
+        animals: string
+        -- schema metadata --
+        pandas: '{"index_columns": [{"kind": "range", "name": null, "start": 0, "' ...
+
         """
         return pyarrow_wrap_schema(self.table.schema())
 
@@ -2346,6 +2878,19 @@ cdef class Table(_PandasConvertible):
         Returns
         -------
         Field
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'n_legs': [2, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> table.field(0)
+        pyarrow.Field<n_legs: int64>
+        >>> table.field(1)
+        pyarrow.Field<animals: string>
+
         """
         return self.schema.field(i)
 
@@ -2381,6 +2926,41 @@ cdef class Table(_PandasConvertible):
         Returns
         -------
         ChunkedArray
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'n_legs': [2, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+
+        Select a column by numeric index:
+
+        >>> table.column(0)
+        <pyarrow.lib.ChunkedArray object at ...>
+        [
+          [
+            2,
+            4,
+            5,
+            100
+          ]
+        ]
+
+        Select a column by its name:
+
+        >>> table.column("animals")
+        <pyarrow.lib.ChunkedArray object at ...>
+        [
+          [
+            "Flamingo",
+            "Horse",
+            "Brittle stars",
+            "Centipede"
+          ]
+        ]
+
         """
         return self._column(self._ensure_integer_index(i))
 
@@ -2410,6 +2990,21 @@ cdef class Table(_PandasConvertible):
         Yields
         ------
         ChunkedArray
+        ChunkedArray
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'n_legs': [None, 4, 5, None],
+        ...                    'animals': ["Flamingo", "Horse", None, "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> for i in table.itercolumns():
+        ...     print(i.null_count)
+        ... 
+        2
+        1
+
         """
         for i in range(self.num_columns):
             yield self._column(i)
@@ -2422,6 +3017,33 @@ cdef class Table(_PandasConvertible):
         Returns
         -------
         list of ChunkedArray
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'n_legs': [None, 4, 5, None],
+        ...                    'animals': ["Flamingo", "Horse", None, "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> table.columns
+        [<pyarrow.lib.ChunkedArray object at ...>
+        [
+          [
+            null,
+            4,
+            5,
+            null
+          ]
+        ], <pyarrow.lib.ChunkedArray object at ...>
+        [
+          [
+            "Flamingo",
+            "Horse",
+            null,
+            "Centipede"
+          ]
+        ]]
+
         """
         return [self._column(i) for i in range(self.num_columns)]
 
@@ -2433,6 +3055,17 @@ cdef class Table(_PandasConvertible):
         Returns
         -------
         int
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'n_legs': [None, 4, 5, None],
+        ...                    'animals': ["Flamingo", "Horse", None, "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> table.num_columns
+        2
+
         """
         return self.table.num_columns()
 
@@ -2447,6 +3080,17 @@ cdef class Table(_PandasConvertible):
         Returns
         -------
         int
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'n_legs': [None, 4, 5, None],
+        ...                    'animals': ["Flamingo", "Horse", None, "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> table.num_rows
+        4
+
         """
         return self.table.num_rows()
 
@@ -2462,6 +3106,17 @@ cdef class Table(_PandasConvertible):
         -------
         (int, int)
             Number of rows and number of columns.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'n_legs': [None, 4, 5, None],
+        ...                    'animals': ["Flamingo", "Horse", None, "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> table.shape
+        (4, 2)
+
         """
         return (self.num_rows, self.num_columns)
 
@@ -2480,6 +3135,17 @@ cdef class Table(_PandasConvertible):
 
         The dictionary of dictionary arrays will always be counted in their
         entirety even if the array only references a portion of the dictionary.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'n_legs': [None, 4, 5, None],
+        ...                    'animals': ["Flamingo", "Horse", None, "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> table.nbytes
+        72
+
         """
         cdef:
             CResult[int64_t] c_res_buffer
@@ -2498,6 +3164,17 @@ cdef class Table(_PandasConvertible):
 
         If a buffer is referenced multiple times then it will
         only be counted once.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'n_legs': [None, 4, 5, None],
+        ...                    'animals': ["Flamingo", "Horse", None, "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> table.get_total_buffer_size()
+        76
+
         """
         cdef:
             int64_t total_buffer_size
@@ -2529,6 +3206,38 @@ cdef class Table(_PandasConvertible):
         -------
         Table
             New table with the passed column added.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'n_legs': [2, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+
+        Add column:
+
+        >>> year = [2021, 2022, 2019, 2021]
+        >>> table.add_column(0,"year", [year])
+        pyarrow.Table
+        year: int64
+        n_legs: int64
+        animals: string
+        ----
+        year: [[2021,2022,2019,2021]]
+        n_legs: [[2,4,5,100]]
+        animals: [["Flamingo","Horse","Brittle stars","Centipede"]]
+
+        Original table is left unchanged:
+
+        >>> table
+        pyarrow.Table
+        n_legs: int64
+        animals: string
+        ----
+        n_legs: [[2,4,5,100]]
+        animals: [["Flamingo","Horse","Brittle stars","Centipede"]]
+
         """
         cdef:
             shared_ptr[CTable] c_table
@@ -2567,6 +3276,28 @@ cdef class Table(_PandasConvertible):
         -------
         Table
             New table with the passed column added.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'n_legs': [2, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+
+        Append column at the end:
+
+        >>> year = [2021, 2022, 2019, 2021]
+        >>> table.append_column('year', [year])
+        pyarrow.Table
+        n_legs: int64
+        animals: string
+        year: int64
+        ----
+        n_legs: [[2,4,5,100]]
+        animals: [["Flamingo","Horse","Brittle stars","Centipede"]]
+        year: [[2021,2022,2019,2021]]
+
         """
         return self.add_column(self.num_columns, field_, column)
 
@@ -2583,6 +3314,20 @@ cdef class Table(_PandasConvertible):
         -------
         Table
             New table without the column.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'n_legs': [2, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> table.remove_column(1)
+        pyarrow.Table
+        n_legs: int64
+        ----
+        n_legs: [[2,4,5,100]]
+
         """
         cdef shared_ptr[CTable] c_table
 
@@ -2609,6 +3354,26 @@ cdef class Table(_PandasConvertible):
         -------
         Table
             New table with the passed column set.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'n_legs': [2, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+
+        Replace a column:
+
+        >>> year = [2021, 2022, 2019, 2021]
+        >>> table.set_column(1,'year', [year])
+        pyarrow.Table
+        n_legs: int64
+        year: int64
+        ----
+        n_legs: [[2,4,5,100]]
+        year: [[2021,2022,2019,2021]]
+
         """
         cdef:
             shared_ptr[CTable] c_table
@@ -2639,6 +3404,17 @@ cdef class Table(_PandasConvertible):
         Returns
         -------
         list of str
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'n_legs': [2, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> table.column_names
+        ['n_legs', 'animals']
+
         """
         names = self.table.ColumnNames()
         return [frombytes(name) for name in names]
@@ -2655,6 +3431,23 @@ cdef class Table(_PandasConvertible):
         Returns
         -------
         Table
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'n_legs': [2, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> new_names = ["n", "name"]
+        >>> table.rename_columns(new_names)
+        pyarrow.Table
+        n: int64
+        name: string
+        ----
+        n: [[2,4,5,100]]
+        name: [["Flamingo","Horse","Brittle stars","Centipede"]]
+
         """
         cdef:
             shared_ptr[CTable] c_table
@@ -2686,6 +3479,30 @@ cdef class Table(_PandasConvertible):
         -------
         Table
             New table without the columns.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'n_legs': [2, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+
+        Drop one column:
+
+        >>> table.drop(["animals"])
+        pyarrow.Table
+        n_legs: int64
+        ----
+        n_legs: [[2,4,5,100]]
+
+        Drop more columns:
+
+        >>> table.drop(["n_legs", "animals"])
+        pyarrow.Table
+        ...
+        ----
+
         """
         indices = []
         for col in columns:
@@ -2743,6 +3560,73 @@ cdef class Table(_PandasConvertible):
         Returns
         -------
         Table
+
+        Examples
+        --------
+        >>> import pandas as pd
+        >>> import pyarrow as pa
+        >>> df1 = pd.DataFrame({'id': [1, 2, 3],
+        ...                     'year': [2020, 2022, 2019]})
+        >>> df2 = pd.DataFrame({'id': [3, 4],
+        ...                     'n_legs': [5, 100],
+        ...                     'animal': ["Brittle stars", "Centipede"]})
+        >>> t1 = pa.Table.from_pandas(df1)
+        >>> t2 = pa.Table.from_pandas(df2)
+
+        Left outer join:
+
+        >>> t1.join(t2, 'id')
+        pyarrow.Table
+        id: int64
+        year: int64
+        n_legs: int64
+        animal: string
+        ----
+        id: [[3,1,2]]
+        year: [[2019,2020,2022]]
+        n_legs: [[5,null,null]]
+        animal: [["Brittle stars",null,null]]
+
+        Full outer join:
+
+        >>> t1.join(t2, 'id', join_type="full outer")
+        pyarrow.Table
+        id: int64
+        year: int64
+        n_legs: int64
+        animal: string
+        ----
+        id: [[3,1,2],[4]]
+        year: [[2019,2020,2022],[null]]
+        n_legs: [[5,null,null],[100]]
+        animal: [["Brittle stars",null,null],["Centipede"]]
+
+        Right outer join:
+
+        >>> t1.join(t2, 'id', join_type="right outer")
+        pyarrow.Table
+        year: int64
+        id: int64
+        n_legs: int64
+        animal: string
+        ----
+        year: [[2019],[null]]
+        id: [[3],[4]]
+        n_legs: [[5],[100]]
+        animal: [["Brittle stars"],["Centipede"]]
+
+        Right anti join
+
+        >>> t1.join(t2, 'id', join_type="right anti")
+        pyarrow.Table
+        id: int64
+        n_legs: int64
+        animal: string
+        ----
+        id: [[4]]
+        n_legs: [[100]]
+        animal: [["Centipede"]]
+
         """
         if right_keys is None:
             right_keys = keys
@@ -2768,6 +3652,24 @@ cdef class Table(_PandasConvertible):
         See Also
         --------
         TableGroupBy.aggregate
+
+        Examples
+        --------
+        >>> import pandas as pd
+        >>> import pyarrow as pa
+        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> table.group_by('year').aggregate([('n_legs', 'sum')])
+        pyarrow.Table
+        n_legs_sum: int64
+        year: int64
+        ----
+        n_legs_sum: [[2,6,104,5]]
+        year: [[2020,2022,2021,2019]]
+
         """
         return TableGroupBy(self, keys)
 
@@ -2787,6 +3689,26 @@ cdef class Table(_PandasConvertible):
         -------
         Table
             A new table sorted according to the sort keys.
+
+        Examples
+        --------
+        >>> import pandas as pd
+        >>> import pyarrow as pa
+        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> table.sort_by('animal')
+        pyarrow.Table
+        year: int64
+        n_legs: int64
+        animal: string
+        ----
+        year: [[2019,2021,2021,2020,2022,2022]]
+        n_legs: [[5,100,4,2,4,2]]
+        animal: [["Brittle stars","Centipede","Dog","Flamingo","Horse","Parrot"]]
+
         """
         if isinstance(sorting, str):
             sorting = [(sorting, "ascending")]
@@ -2936,17 +3858,16 @@ def table(data, names=None, schema=None, metadata=None, nthreads=None):
 
     Construct a Table from chunked arrays:
 
-    >>> n_legs = [[2, 2, 4], [4, 5, 100]]
-    >>> animals = [["Flamingo", "Parrot", "Dog"], ["Horse", "Brittle stars", "Centipede"]]
-    >>> pa.table([n_legs, animals], names=names)
+    >>> n_legs = pa.chunked_array([[2, 2, 4], [4, 5, 100]])
+    >>> animals = pa.chunked_array([["Flamingo", "Parrot", "Dog"], ["Horse", "Brittle stars", "Centipede"]])
+    >>> table = pa.table([n_legs, animals], names=names)
+    >>> table
     pyarrow.Table
-    n_legs: list<item: int64>
-      child 0, item: int64
-    animals: list<item: string>
-      child 0, item: string
+    n_legs: int64
+    animals: string
     ----
-    n_legs: [[[2,2,4],[4,5,100]]]
-    animals: [[["Flamingo","Parrot","Dog"],["Horse","Brittle stars","Centipede"]]]
+    n_legs: [[2,2,4],[4,5,100]]
+    animals: [["Flamingo","Parrot","Dog"],["Horse","Brittle stars","Centipede"]]
 
     """
     # accept schema as first argument for backwards compatibility / usability

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -3993,6 +3993,29 @@ class TableGroupBy:
         Input table to execute the aggregation on.
     keys : str or list[str]
         Name of the grouped columns.
+
+    Examples
+    --------
+    >>> import pyarrow as pa
+    >>> t = pa.table([
+    ...       pa.array(["a", "a", "b", "b", "c"]),
+    ...       pa.array([1, 2, 3, 4, 5]),
+    ... ], names=["keys", "values"])
+
+    Grouping of columns:
+
+    >>> pa.TableGroupBy(t,'keys')
+    <pyarrow.lib.TableGroupBy object at ...>
+
+    Perform aggregations:
+
+    >>> pa.TableGroupBy(t,'keys').aggregate([("values", "sum")])
+    pyarrow.Table
+    values_sum: int64
+    keys: string
+    ----
+    values_sum: [[3,7,5]]
+    keys: [["a","b","c"]]
     """
 
     def __init__(self, table, keys):

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1476,6 +1476,109 @@ cdef class Table(_PandasConvertible):
     --------
     Do not call this class's constructor directly, use one of the ``from_*``
     methods instead.
+
+    Examples
+    --------
+    >>> import pyarrow as pa
+    >>> n_legs = pa.array([2, 4, 5, 100])
+    >>> animals = pa.array(["Flamingo", "Horse", "Brittle stars", "Centipede"])
+    >>> names = ["n_legs", "animals"]
+
+    Construct a Table from arrays:
+
+    >>> pa.Table.from_arrays([n_legs, animals], names=names)
+    pyarrow.Table
+    n_legs: int64
+    animals: string
+    ----
+    n_legs: [[2,4,5,100]]
+    animals: [["Flamingo","Horse","Brittle stars","Centipede"]]
+
+    Construct a Table from a RecordBatch:
+
+    >>> batch = pa.record_batch([n_legs, animals], names=names)
+    >>> pa.Table.from_batches([batch, batch])
+    pyarrow.Table
+    n_legs: int64
+    animals: string
+    ----
+    n_legs: [[2,4,5,100],[2,4,5,100]]
+    animals: [["Flamingo","Horse","Brittle stars","Centipede"],["Flamingo","Horse","Brittle stars","Centipede"]]
+
+    Construct a Table from pandas DataFrame:
+
+    >>> import pandas as pd
+    >>> df = pd.DataFrame({'year': [2020, 2022, 2019, 2021],
+    ...                    'n_legs': [2, 4, 5, 100],
+    ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
+    >>> pa.Table.from_pandas(df)
+    pyarrow.Table
+    year: int64
+    n_legs: int64
+    animals: string
+    ----
+    year: [[2020,2022,2019,2021]]
+    n_legs: [[2,4,5,100]]
+    animals: [["Flamingo","Horse","Brittle stars","Centipede"]]
+
+    Construct a Table from a dictionary of arrays:
+
+    >>> pydict = {'n_legs': n_legs, 'animals': animals}
+    >>> pa.Table.from_pydict(pydict)
+    pyarrow.Table
+    n_legs: int64
+    animals: string
+    ----
+    n_legs: [[2,4,5,100]]
+    animals: [["Flamingo","Horse","Brittle stars","Centipede"]]
+    >>> pa.Table.from_pydict(pydict).schema
+    n_legs: int64
+    animals: string
+
+    Construct a Table from a dictionary of arrays with metadata:
+
+    >>> my_metadata={"n_legs": "Number of legs per animal"}
+    >>> pa.Table.from_pydict(pydict, metadata=my_metadata).schema
+    n_legs: int64
+    animals: string
+    -- schema metadata --
+    n_legs: 'Number of legs per animal'
+
+    Construct a Table from a list of rows:
+
+    >>> pylist = [{'n_legs': 2, 'animals': 'Flamingo'}, {'year': 2021, 'animals': 'Centipede'}]
+    >>> pa.Table.from_pylist(pylist)
+    pyarrow.Table
+    n_legs: int64
+    animals: string
+    ----
+    n_legs: [[2,null]]
+    animals: [["Flamingo","Centipede"]]
+
+    Construct a Table from a list of rows with pyarrow schema:
+
+    >>> my_schema = pa.schema([
+    ...     pa.field('year', pa.int64()),
+    ...     pa.field('n_legs', pa.int64()),
+    ...     pa.field('animals', pa.string())],
+    ...     metadata={"year": "Year of entry"})
+    >>> pa.Table.from_pylist(pylist, schema=my_schema).schema
+    year: int64
+    n_legs: int64
+    animals: string
+    -- schema metadata --
+    year: 'Year of entry'
+
+    Construct a Table with :func:`pyarrow.table`:
+
+    >>> pa.table([n_legs, animals], names=names)
+    pyarrow.Table
+    n_legs: int64
+    animals: string
+    ----
+    n_legs: [[2,4,5,100]]
+    animals: [["Flamingo","Horse","Brittle stars","Centipede"]]
+
     """
 
     def __cinit__(self):
@@ -1904,9 +2007,9 @@ cdef class Table(_PandasConvertible):
         >>> import pandas as pd
         >>> import pyarrow as pa
         >>> df = pd.DataFrame({
-            ...     'int': [1, 2],
-            ...     'str': ['a', 'b']
-            ... })
+        ...     'int': [1, 2],
+        ...     'str': ['a', 'b']
+        ... })
         >>> pa.Table.from_pandas(df)
         <pyarrow.lib.Table object at 0x7f05d1fb1b40>
         """
@@ -2775,6 +2878,76 @@ def table(data, names=None, schema=None, metadata=None, nthreads=None):
     See Also
     --------
     Table.from_arrays, Table.from_pandas, Table.from_pydict
+
+    Example
+    -------
+    >>> import pyarrow as pa
+    >>> n_legs = pa.array([2, 4, 5, 100])
+    >>> animals = pa.array(["Flamingo", "Horse", "Brittle stars", "Centipede"])
+    >>> names = ["n_legs", "animals"]
+
+    Construct a Table from arrays:
+
+    >>> pa.table([n_legs, animals], names=names)
+    pyarrow.Table
+    n_legs: int64
+    animals: string
+    ----
+    n_legs: [[2,4,5,100]]
+    animals: [["Flamingo","Horse","Brittle stars","Centipede"]]
+
+    Construct a Table from arrays with metadata:
+
+    >>> my_metadata={"n_legs": "Number of legs per animal"}
+    >>> pa.table([n_legs, animals], names=names, metadata = my_metadata).schema
+    n_legs: int64
+    animals: string
+    -- schema metadata --
+    n_legs: 'Number of legs per animal'
+
+    Construct a Table from pandas DataFrame:
+
+    >>> import pandas as pd
+    >>> df = pd.DataFrame({'year': [2020, 2022, 2019, 2021],
+    ...                    'n_legs': [2, 4, 5, 100],
+    ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
+    >>> pa.table(df)
+    pyarrow.Table
+    year: int64
+    n_legs: int64
+    animals: string
+    ----
+    year: [[2020,2022,2019,2021]]
+    n_legs: [[2,4,5,100]]
+    animals: [["Flamingo","Horse","Brittle stars","Centipede"]]
+
+    Construct a Table from pandas DataFrame with pyarrow schema:
+
+    >>> my_schema = pa.schema([
+    ...     pa.field('n_legs', pa.int64()),
+    ...     pa.field('animals', pa.string())],
+    ...     metadata={"n_legs": "Number of legs per animal"})
+    >>> pa.table(df, my_schema).schema
+    n_legs: int64
+    animals: string
+    -- schema metadata --
+    n_legs: 'Number of legs per animal'
+    pandas: '{"index_columns": [], "column_indexes": [{"name": null, ...
+
+    Construct a Table from chunked arrays:
+
+    >>> n_legs = [[2, 2, 4], [4, 5, 100]]
+    >>> animals = [["Flamingo", "Parrot", "Dog"], ["Horse", "Brittle stars", "Centipede"]]
+    >>> pa.table([n_legs, animals], names=names)
+    pyarrow.Table
+    n_legs: list<item: int64>
+      child 0, item: int64
+    animals: list<item: string>
+      child 0, item: string
+    ----
+    n_legs: [[[2,2,4],[4,5,100]]]
+    animals: [[["Flamingo","Parrot","Dog"],["Horse","Brittle stars","Centipede"]]]
+
     """
     # accept schema as first argument for backwards compatibility / usability
     if isinstance(names, Schema) and schema is None:

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -3875,6 +3875,26 @@ def concat_tables(tables, c_bool promote=False, MemoryPool memory_pool=None):
         If True, concatenate tables with null-filling and null type promotion.
     memory_pool : MemoryPool, default None
         For memory allocations, if required, otherwise use default pool.
+
+    Examples
+    --------
+    >>> import pyarrow as pa
+    >>> t1 = pa.table([
+    ...     pa.array([2, 4, 5, 100]),
+    ...     pa.array(["Flamingo", "Horse", "Brittle stars", "Centipede"])
+    ...     ], names=['n_legs', 'animals'])
+    >>> t2 = pa.table([
+    ...     pa.array([2, 4]),
+    ...     pa.array(["Parrot", "Dog"])
+    ...     ], names=['n_legs', 'animals'])
+    >>> pa.concat_tables([t1,t2])
+    pyarrow.Table
+    n_legs: int64
+    animals: string
+    ----
+    n_legs: [[2,4,5,100],[2,4]]
+    animals: [["Flamingo","Horse","Brittle stars","Centipede"],["Parrot","Dog"]]
+
     """
     cdef:
         vector[shared_ptr[CTable]] c_tables
@@ -4004,12 +4024,12 @@ class TableGroupBy:
 
     Grouping of columns:
 
-    >>> pa.TableGroupBy(t,'keys')
+    >>> pa.TableGroupBy(t,"keys")
     <pyarrow.lib.TableGroupBy object at ...>
 
     Perform aggregations:
 
-    >>> pa.TableGroupBy(t,'keys').aggregate([("values", "sum")])
+    >>> pa.TableGroupBy(t,"keys").aggregate([("values", "sum")])
     pyarrow.Table
     values_sum: int64
     keys: string

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1578,7 +1578,6 @@ cdef class Table(_PandasConvertible):
     ----
     n_legs: [[2,4,5,100]]
     animals: [["Flamingo","Horse","Brittle stars","Centipede"]]
-
     """
 
     def __cinit__(self):
@@ -1613,7 +1612,6 @@ cdef class Table(_PandasConvertible):
         >>> table = pa.Table.from_pandas(df)
         >>> table.to_string()
         'pyarrow.Table\nyear: int64\nn_legs: int64\nanimals: string'
-
         """
         # Use less verbose schema output.
         schema_as_string = self.schema.to_string(
@@ -1742,7 +1740,6 @@ cdef class Table(_PandasConvertible):
         year: [[2019]]
         n_legs: [[5]]
         animals: [["Brittle stars"]]
-
         """
         cdef shared_ptr[CTable] result
 
@@ -1806,7 +1803,6 @@ cdef class Table(_PandasConvertible):
         year: [[2020,2022,null]]
         n_legs: [[2,4,null]]
         animals: [["Flamingo","Horse",null]]
-
         """
         return _pc().filter(self, mask, null_selection_behavior)
 
@@ -1843,7 +1839,6 @@ cdef class Table(_PandasConvertible):
         year: [[2022,2021]]
         n_legs: [[4,100]]
         animals: [["Horse","Centipede"]]
-
         """
         return _pc().take(self, indices)
 
@@ -1869,7 +1864,6 @@ cdef class Table(_PandasConvertible):
         year: [[2022,2021]]
         n_legs: [[4,100]]
         animals: [["Horse","Centipede"]]
-
         """
         return _pc().drop_null(self)
 
@@ -1909,7 +1903,6 @@ cdef class Table(_PandasConvertible):
         year: int64
         ----
         year: [[2020,2022,2019,2021]]
-
         """
         cdef:
             shared_ptr[CTable] c_table
@@ -1976,7 +1969,6 @@ cdef class Table(_PandasConvertible):
         animals: string
         -- schema metadata --
         animals: 'Which animal'
-
         """
         cdef:
             shared_ptr[const CKeyValueMetadata] c_meta
@@ -2044,7 +2036,6 @@ cdef class Table(_PandasConvertible):
         a.n_legs: [[2,4]]
         a.year: [[null,2022]]
         month: [[4,6]]
-
         """
         cdef:
             shared_ptr[CTable] flattened
@@ -2092,7 +2083,6 @@ cdef class Table(_PandasConvertible):
         ----
         n_legs: [[2,2,4,4,5,100]]
         animals: [["Flamingo","Parrot","Dog","Horse","Brittle stars","Centipede"]]
-
         """
         cdef:
             shared_ptr[CTable] combined
@@ -2140,7 +2130,7 @@ cdef class Table(_PandasConvertible):
         [0,1,2]]
 
         Unify dictionaries across both chunks:
-        
+
         >>> table.unify_dictionaries()
         pyarrow.Table
         animals: dictionary<values=string, indices=int32, ordered=0>
@@ -2150,7 +2140,6 @@ cdef class Table(_PandasConvertible):
         [0,1,2],  -- dictionary:
         ["Flamingo","Parot","Dog","Horse","Brittle stars","Centipede"]  -- indices:
         [3,4,5]]
-
         """
         cdef:
             CMemoryPool* pool = maybe_unbox_memory_pool(memory_pool)
@@ -2202,7 +2191,6 @@ cdef class Table(_PandasConvertible):
         True
         >>> table.equals(table_1, check_metadata=True)
         False
-
         """
         if other is None:
             return False
@@ -2258,7 +2246,6 @@ cdef class Table(_PandasConvertible):
         ----
         n_legs: [[2,4,5,100]]
         animals: [["Flamingo","Horse","Brittle stars","Centipede"]]
-
         """
         cdef:
             ChunkedArray column, casted
@@ -2337,7 +2324,6 @@ cdef class Table(_PandasConvertible):
         ----
         n_legs: [[2,4,5,100]]
         animals: [["Flamingo","Horse","Brittle stars","Centipede"]]
-
         """
         from pyarrow.pandas_compat import dataframe_to_arrays
         arrays, schema, n_rows = dataframe_to_arrays(
@@ -2434,7 +2420,6 @@ cdef class Table(_PandasConvertible):
         animals: string
         -- schema metadata --
         animals: 'Name of the animal species'
-
         """
         cdef:
             vector[shared_ptr[CChunkedArray]] columns
@@ -2507,7 +2492,6 @@ cdef class Table(_PandasConvertible):
         animals: string
         -- schema metadata --
         n_legs: 'Number of legs per animal'
-
         """
 
         return _from_pydict(cls=Table,
@@ -2565,7 +2549,6 @@ cdef class Table(_PandasConvertible):
         animals: string
         -- schema metadata --
         year: 'Year of entry'
-
         """
 
         return _from_pylist(cls=Table,
@@ -2621,8 +2604,6 @@ cdef class Table(_PandasConvertible):
         ----
         n_legs: [[2,4,5,100],[2,4,5,100]]
         animals: [["Flamingo","Horse","Brittle stars","Centipede"],["Flamingo","Horse","Brittle stars","Centipede"]]
-
-
         """
         cdef:
             vector[shared_ptr[CRecordBatch]] c_batches
@@ -2691,7 +2672,6 @@ cdef class Table(_PandasConvertible):
            n_legs        animals
         0       5  Brittle stars
         1     100      Centipede
-
         """
         cdef:
             unique_ptr[TableBatchReader] reader
@@ -2759,7 +2739,6 @@ cdef class Table(_PandasConvertible):
         ----
         n_legs: [[2,4,5,100]]
         animals: [["Flamingo","Horse","Brittle stars","Centipede"]]
-
         """
         cdef:
             shared_ptr[CRecordBatchReader] c_reader
@@ -2802,7 +2781,6 @@ cdef class Table(_PandasConvertible):
         >>> table = pa.Table.from_pandas(df)
         >>> table.to_pydict()
         {'n_legs': [2, 4, 5, 100], 'animals': ['Flamingo', 'Horse', 'Brittle stars', 'Centipede']}
-
         """
         cdef:
             size_t i
@@ -2833,7 +2811,6 @@ cdef class Table(_PandasConvertible):
         >>> table = pa.Table.from_pandas(df)
         >>> table.to_pylist()
         [{'n_legs': 2, 'animals': 'Flamingo'}, {'n_legs': 4, 'animals': 'Horse'}, ...
-
         """
         pydict = self.to_pydict()
         names = self.schema.names
@@ -2862,7 +2839,6 @@ cdef class Table(_PandasConvertible):
         animals: string
         -- schema metadata --
         pandas: '{"index_columns": [{"kind": "range", "name": null, "start": 0, "' ...
-
         """
         return pyarrow_wrap_schema(self.table.schema())
 
@@ -2890,7 +2866,6 @@ cdef class Table(_PandasConvertible):
         pyarrow.Field<n_legs: int64>
         >>> table.field(1)
         pyarrow.Field<animals: string>
-
         """
         return self.schema.field(i)
 
@@ -2960,7 +2935,6 @@ cdef class Table(_PandasConvertible):
             "Centipede"
           ]
         ]
-
         """
         return self._column(self._ensure_integer_index(i))
 
@@ -3004,7 +2978,6 @@ cdef class Table(_PandasConvertible):
         ... 
         2
         1
-
         """
         for i in range(self.num_columns):
             yield self._column(i)
@@ -3043,7 +3016,6 @@ cdef class Table(_PandasConvertible):
             "Centipede"
           ]
         ]]
-
         """
         return [self._column(i) for i in range(self.num_columns)]
 
@@ -3065,7 +3037,6 @@ cdef class Table(_PandasConvertible):
         >>> table = pa.Table.from_pandas(df)
         >>> table.num_columns
         2
-
         """
         return self.table.num_columns()
 
@@ -3090,7 +3061,6 @@ cdef class Table(_PandasConvertible):
         >>> table = pa.Table.from_pandas(df)
         >>> table.num_rows
         4
-
         """
         return self.table.num_rows()
 
@@ -3116,7 +3086,6 @@ cdef class Table(_PandasConvertible):
         >>> table = pa.Table.from_pandas(df)
         >>> table.shape
         (4, 2)
-
         """
         return (self.num_rows, self.num_columns)
 
@@ -3145,7 +3114,6 @@ cdef class Table(_PandasConvertible):
         >>> table = pa.Table.from_pandas(df)
         >>> table.nbytes
         72
-
         """
         cdef:
             CResult[int64_t] c_res_buffer
@@ -3174,7 +3142,6 @@ cdef class Table(_PandasConvertible):
         >>> table = pa.Table.from_pandas(df)
         >>> table.get_total_buffer_size()
         76
-
         """
         cdef:
             int64_t total_buffer_size
@@ -3237,7 +3204,6 @@ cdef class Table(_PandasConvertible):
         ----
         n_legs: [[2,4,5,100]]
         animals: [["Flamingo","Horse","Brittle stars","Centipede"]]
-
         """
         cdef:
             shared_ptr[CTable] c_table
@@ -3297,7 +3263,6 @@ cdef class Table(_PandasConvertible):
         n_legs: [[2,4,5,100]]
         animals: [["Flamingo","Horse","Brittle stars","Centipede"]]
         year: [[2021,2022,2019,2021]]
-
         """
         return self.add_column(self.num_columns, field_, column)
 
@@ -3327,7 +3292,6 @@ cdef class Table(_PandasConvertible):
         n_legs: int64
         ----
         n_legs: [[2,4,5,100]]
-
         """
         cdef shared_ptr[CTable] c_table
 
@@ -3373,7 +3337,6 @@ cdef class Table(_PandasConvertible):
         ----
         n_legs: [[2,4,5,100]]
         year: [[2021,2022,2019,2021]]
-
         """
         cdef:
             shared_ptr[CTable] c_table
@@ -3414,7 +3377,6 @@ cdef class Table(_PandasConvertible):
         >>> table = pa.Table.from_pandas(df)
         >>> table.column_names
         ['n_legs', 'animals']
-
         """
         names = self.table.ColumnNames()
         return [frombytes(name) for name in names]
@@ -3447,7 +3409,6 @@ cdef class Table(_PandasConvertible):
         ----
         n: [[2,4,5,100]]
         name: [["Flamingo","Horse","Brittle stars","Centipede"]]
-
         """
         cdef:
             shared_ptr[CTable] c_table
@@ -3502,7 +3463,6 @@ cdef class Table(_PandasConvertible):
         pyarrow.Table
         ...
         ----
-
         """
         indices = []
         for col in columns:
@@ -3626,7 +3586,6 @@ cdef class Table(_PandasConvertible):
         id: [[4]]
         n_legs: [[100]]
         animal: [["Centipede"]]
-
         """
         if right_keys is None:
             right_keys = keys
@@ -3669,7 +3628,6 @@ cdef class Table(_PandasConvertible):
         ----
         n_legs_sum: [[2,6,104,5]]
         year: [[2020,2022,2021,2019]]
-
         """
         return TableGroupBy(self, keys)
 
@@ -3708,7 +3666,6 @@ cdef class Table(_PandasConvertible):
         year: [[2019,2021,2021,2020,2022,2022]]
         n_legs: [[5,100,4,2,4,2]]
         animal: [["Brittle stars","Centipede","Dog","Flamingo","Horse","Parrot"]]
-
         """
         if isinstance(sorting, str):
             sorting = [(sorting, "ascending")]
@@ -3868,7 +3825,6 @@ def table(data, names=None, schema=None, metadata=None, nthreads=None):
     ----
     n_legs: [[2,2,4],[4,5,100]]
     animals: [["Flamingo","Parrot","Dog"],["Horse","Brittle stars","Centipede"]]
-
     """
     # accept schema as first argument for backwards compatibility / usability
     if isinstance(names, Schema) and schema is None:

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1601,17 +1601,6 @@ cdef class Table(_PandasConvertible):
         Returns
         -------
         str
-
-        Examples
-        --------
-        >>> import pyarrow as pa
-        >>> import pandas as pd
-        >>> df = pd.DataFrame({'year': [2020, 2022, 2019, 2021],
-        ...                    'n_legs': [2, 4, 5, 100],
-        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
-        >>> table = pa.Table.from_pandas(df)
-        >>> table.to_string()
-        'pyarrow.Table\nyear: int64\nn_legs: int64\nanimals: string'
         """
         # Use less verbose schema output.
         schema_as_string = self.schema.to_string(


### PR DESCRIPTION
This PR adds docstring examples to:

- `pyarrow.Table` class methods and attributes
- `pyarrow.table`
- `to_pandas` for `_PandasConvertible`
- `pyarrow.TableGroupBy` class
- `pyarrow.concat_tables`
- `pyarrow.concat_arrays`