### PR TITLE
ARROW-16098: [JS] Don't return null in table and recordbatch iterators

### DIFF
--- a/js/src/recordbatch.ts
+++ b/js/src/recordbatch.ts
@@ -162,7 +162,7 @@ export class RecordBatch<T extends TypeMap = any> {
      * Iterator for rows in this RecordBatch.
      */
     public [Symbol.iterator]() {
-        return iteratorVisitor.visit(new Vector([this.data]));
+        return iteratorVisitor.visit(new Vector([this.data])) as IterableIterator<Struct<T>['TValue']>;
     }
 
     /**

--- a/js/src/table.ts
+++ b/js/src/table.ts
@@ -224,7 +224,7 @@ export class Table<T extends TypeMap = any> {
      * Iterator for rows in this Table.
      */
     public [Symbol.iterator]() {
-        return iteratorVisitor.visit(new Vector(this.data));
+        return iteratorVisitor.visit(new Vector(this.data)) as IterableIterator<Struct<T>['TValue']>;
     }
 
     /**


### PR DESCRIPTION
Before Arrow 7, Table supported `Iterable<Record<string, any>>` and with this change it does support it again. 

I wanted this to work:

```ts
function foo(): Iterable<Record<string, any>> {
    return new Table();
}
```