### PR TITLE
ARROW-16108: [Gandiva][C++] Fix castINTERVALDAY and castINTERVALYEAR

### DIFF
--- a/cpp/src/gandiva/function_holder_registry.h
+++ b/cpp/src/gandiva/function_holder_registry.h
@@ -67,8 +67,6 @@ class FunctionHolderRegistry {
                                  {"rand", LAMBDA_MAKER(RandomGeneratorHolder)},
                                  {"regexp_replace", LAMBDA_MAKER(ReplaceHolder)},
                                  {"regexp_extract", LAMBDA_MAKER(ExtractHolder)},
-                                 {"castintervalday", LAMBDA_MAKER(IntervalDaysHolder)},
-                                 {"castintervalyear", LAMBDA_MAKER(IntervalYearsHolder)}};
                                  {"castINTERVALDAY", LAMBDA_MAKER(IntervalDaysHolder)},
                                  {"castINTERVALYEAR", LAMBDA_MAKER(IntervalYearsHolder)}};
     return maker_map;

--- a/cpp/src/gandiva/function_holder_registry.h
+++ b/cpp/src/gandiva/function_holder_registry.h
@@ -69,6 +69,8 @@ class FunctionHolderRegistry {
                                  {"regexp_extract", LAMBDA_MAKER(ExtractHolder)},
                                  {"castintervalday", LAMBDA_MAKER(IntervalDaysHolder)},
                                  {"castintervalyear", LAMBDA_MAKER(IntervalYearsHolder)}};
+                                 {"castINTERVALDAY", LAMBDA_MAKER(IntervalDaysHolder)},
+                                 {"castINTERVALYEAR", LAMBDA_MAKER(IntervalYearsHolder)}};
     return maker_map;
   }
 };

--- a/cpp/src/gandiva/function_registry_datetime.cc
+++ b/cpp/src/gandiva/function_registry_datetime.cc
@@ -143,19 +143,19 @@ std::vector<NativeFunction> GetDateTimeFunctionRegistry() {
                          NativeFunction::kCanReturnErrors),
 
       NativeFunction(
-          "castintervalday", {}, DataTypeVector{utf8(), int32()}, day_time_interval(),
+          "castINTERVALDAY", {}, DataTypeVector{utf8(), int32()}, day_time_interval(),
           kResultNullInternal, "gdv_fn_cast_intervalday_utf8_int32",
           NativeFunction::kNeedsContext | NativeFunction::kNeedsFunctionHolder |
               NativeFunction::kCanReturnErrors),
 
-      NativeFunction("castintervalyear", {}, DataTypeVector{utf8()}, month_interval(),
+      NativeFunction("castINTERVALYEAR", {}, DataTypeVector{utf8()}, month_interval(),
                      kResultNullInternal, "gdv_fn_cast_intervalyear_utf8",
                      NativeFunction::kNeedsContext |
                          NativeFunction::kNeedsFunctionHolder |
                          NativeFunction::kCanReturnErrors),
 
       NativeFunction(
-          "castintervalyear", {}, DataTypeVector{utf8(), int32()}, month_interval(),
+          "castINTERVALYEAR", {}, DataTypeVector{utf8(), int32()}, month_interval(),
           kResultNullInternal, "gdv_fn_cast_intervalyear_utf8_int32",
           NativeFunction::kNeedsContext | NativeFunction::kNeedsFunctionHolder |
               NativeFunction::kCanReturnErrors),

--- a/cpp/src/gandiva/interval_holder.cc
+++ b/cpp/src/gandiva/interval_holder.cc
@@ -29,19 +29,19 @@ static const RE2 period_only_contains_numbers(R"(\d+)");
 
 // pre-compiled pattern for matching periods in 8601 formats that not contains weeks.
 static const RE2 iso8601_complete_period(
-    R"(P([[:digit:]]+Y|[[:digit:]]+[,.][[:digit:]]+Y)?)"
-    R"(([[:digit:]]+M|[[:digit:]]+[,.][[:digit:]]+M)?)"
-    R"(([[:digit:]]+D|[[:digit:]]+[,.][[:digit:]]+D)?)"
-    R"(T([[:digit:]]+H|[[:digit:]]+[,.][[:digit:]]+H)?)"
-    R"(([[:digit:]]+M|[[:digit:]]+[,.][[:digit:]]+M)?)"
-    R"(([[:digit:]]+S|[[:digit:]]+[,.][[:digit:]]+S)?)");
+    R"(P(-?[[:digit:]]+Y|-?[[:digit:]]+[,.][[:digit:]]+Y)?)"
+    R"((-?[[:digit:]]+M|-?[[:digit:]]+[,.][[:digit:]]+M)?)"
+    R"((-?[[:digit:]]+D|-?[[:digit:]]+[,.][[:digit:]]+D)?)"
+    R"(T(-?[[:digit:]]+H|-?[[:digit:]]+[,.][[:digit:]]+H)?)"
+    R"((-?[[:digit:]]+M|-?[[:digit:]]+[,.][[:digit:]]+M)?)"
+    R"((-?[[:digit:]]+S|-?[[:digit:]]+[,.][[:digit:]]+S)?)");
 
 // pre-compiled pattern for matching periods in 8601 formats that not contain time
 // (hours, minutes and seconds) information.
 static const RE2 iso8601_period_without_time(
-    R"(P([[:digit:]]+Y|[[:digit:]]+[,.][[:digit:]]+Y)?)"
-    R"(([[:digit:]]+M|[[:digit:]]+[,.][[:digit:]]+M)?)"
-    R"(([[:digit:]]+D|[[:digit:]]+[,.][[:digit:]]+D)?)");
+    R"(P(-?[[:digit:]]+Y|-?[[:digit:]]+[,.][[:digit:]]+Y)?)"
+    R"((-?[[:digit:]]+M|-?[[:digit:]]+[,.][[:digit:]]+M)?)"
+    R"((-?[[:digit:]]+D|-?[[:digit:]]+[,.][[:digit:]]+D)?)");
 
 // pre-compiled pattern for matching periods in 8601 formats that not contain time
 // (hours, minutes and seconds) information.
@@ -51,7 +51,7 @@ static const std::regex period_not_contains_time(R"(^((?!T).)*$)");
 // them. The ISO8601 specification defines that if the string contains a week, it can not
 // have other time granularities information, like day, years and months.
 static const RE2 iso8601_period_with_weeks(
-    R"(P([[:digit:]]+W|[[:digit:]]+[,.][[:digit:]]+W){1})");
+    R"(P(-?[[:digit:]]+W|-?[[:digit:]]+[,.][[:digit:]]+W){1})");
 
 // It considers that a day has exactly 24 hours of duration
 static const int64_t kMillisInDay = 86400000;

--- a/cpp/src/gandiva/interval_holder_test.cc
+++ b/cpp/src/gandiva/interval_holder_test.cc
@@ -197,6 +197,60 @@ TEST_F(TestIntervalHolder, TestMatchAllPeriods) {
   EXPECT_TRUE(out_valid);
   EXPECT_FALSE(execution_context_.has_error());
   EXPECT_EQ(response_interval_yrs, 35);
+
+  // Pass negative value
+  data = "P-1D";
+  response = cast_interval_day(&execution_context_, data.data(), 4, true, &out_valid);
+  qty_days_in_response = -1;
+  qty_millis_in_response = 0;
+  EXPECT_TRUE(out_valid);
+  EXPECT_FALSE(execution_context_.has_error());
+  EXPECT_EQ(response, (qty_millis_in_response << 32) | (qty_days_in_response & 0x00000000FFFFFFFF));
+
+  data = "P-2D";
+  response = cast_interval_day(&execution_context_, data.data(), 4, true, &out_valid);
+  qty_days_in_response = -2;
+  qty_millis_in_response = 0;
+  EXPECT_TRUE(out_valid);
+  EXPECT_FALSE(execution_context_.has_error());
+  EXPECT_EQ(response, (qty_millis_in_response << 32) | (qty_days_in_response & 0x00000000FFFFFFFF));
+
+  data = "P-1W";
+  response = cast_interval_day(&execution_context_, data.data(), 4, true, &out_valid);
+  qty_days_in_response = -7;
+  qty_millis_in_response = 0;
+  EXPECT_TRUE(out_valid);
+  EXPECT_FALSE(execution_context_.has_error());
+  EXPECT_EQ(response, (qty_millis_in_response << 32) | (qty_days_in_response & 0x00000000FFFFFFFF));
+
+  data = "P-1M";
+  response = cast_interval_day(&execution_context_, data.data(), 4, true, &out_valid);
+  qty_days_in_response = 0;
+  qty_millis_in_response = 0;
+  EXPECT_TRUE(out_valid);
+  EXPECT_FALSE(execution_context_.has_error());
+  EXPECT_EQ(response, (qty_millis_in_response << 32) | (qty_days_in_response & 0x00000000FFFFFFFF));
+
+  response_interval_yrs =
+      cast_interval_year(&execution_context_, data.data(), 4, true, &out_valid);
+  EXPECT_TRUE(out_valid);
+  EXPECT_FALSE(execution_context_.has_error());
+  EXPECT_EQ(response_interval_yrs, -1);
+
+  data = "P-1Y";
+  response = cast_interval_day(&execution_context_, data.data(), 4, true, &out_valid);
+  qty_days_in_response = 0;
+  qty_millis_in_response = 0;
+  EXPECT_TRUE(out_valid);
+  EXPECT_FALSE(execution_context_.has_error());
+  EXPECT_EQ(response, (qty_millis_in_response << 32) | (qty_days_in_response & 0x00000000FFFFFFFF));
+
+  response_interval_yrs =
+      cast_interval_year(&execution_context_, data.data(), 4, true, &out_valid);
+  EXPECT_TRUE(out_valid);
+  EXPECT_FALSE(execution_context_.has_error());
+  EXPECT_EQ(response_interval_yrs, -12);
+
 }
 
 TEST_F(TestIntervalHolder, TestMatchErrorsForCastIntervalDay) {

--- a/cpp/src/gandiva/interval_holder_test.cc
+++ b/cpp/src/gandiva/interval_holder_test.cc
@@ -69,6 +69,14 @@ TEST_F(TestIntervalHolder, TestMatchAllPeriods) {
   EXPECT_FALSE(execution_context_.has_error());
   EXPECT_EQ(response, (qty_millis_in_response << 32) | qty_days_in_response);
 
+  data = "PT0.001S";
+  response = cast_interval_day(&execution_context_, data.data(), 8, true, &out_valid);
+  qty_days_in_response = 0;
+  qty_millis_in_response = 1;
+  EXPECT_TRUE(out_valid);
+  EXPECT_FALSE(execution_context_.has_error());
+  EXPECT_EQ(response, (qty_millis_in_response << 32) | qty_days_in_response);
+
   // Pass only years and days to cast
   data = "P12Y15D";
   response = cast_interval_day(&execution_context_, data.data(), 7, true, &out_valid);

--- a/cpp/src/gandiva/interval_holder_test.cc
+++ b/cpp/src/gandiva/interval_holder_test.cc
@@ -205,7 +205,8 @@ TEST_F(TestIntervalHolder, TestMatchAllPeriods) {
   qty_millis_in_response = 0;
   EXPECT_TRUE(out_valid);
   EXPECT_FALSE(execution_context_.has_error());
-  EXPECT_EQ(response, (qty_millis_in_response << 32) | (qty_days_in_response & 0x00000000FFFFFFFF));
+  EXPECT_EQ(response,
+            (qty_millis_in_response << 32) | (qty_days_in_response & 0x00000000FFFFFFFF));
 
   data = "P-2D";
   response = cast_interval_day(&execution_context_, data.data(), 4, true, &out_valid);
@@ -213,7 +214,8 @@ TEST_F(TestIntervalHolder, TestMatchAllPeriods) {
   qty_millis_in_response = 0;
   EXPECT_TRUE(out_valid);
   EXPECT_FALSE(execution_context_.has_error());
-  EXPECT_EQ(response, (qty_millis_in_response << 32) | (qty_days_in_response & 0x00000000FFFFFFFF));
+  EXPECT_EQ(response,
+            (qty_millis_in_response << 32) | (qty_days_in_response & 0x00000000FFFFFFFF));
 
   data = "P-1W";
   response = cast_interval_day(&execution_context_, data.data(), 4, true, &out_valid);
@@ -221,7 +223,8 @@ TEST_F(TestIntervalHolder, TestMatchAllPeriods) {
   qty_millis_in_response = 0;
   EXPECT_TRUE(out_valid);
   EXPECT_FALSE(execution_context_.has_error());
-  EXPECT_EQ(response, (qty_millis_in_response << 32) | (qty_days_in_response & 0x00000000FFFFFFFF));
+  EXPECT_EQ(response,
+            (qty_millis_in_response << 32) | (qty_days_in_response & 0x00000000FFFFFFFF));
 
   data = "P-1M";
   response = cast_interval_day(&execution_context_, data.data(), 4, true, &out_valid);
@@ -229,7 +232,8 @@ TEST_F(TestIntervalHolder, TestMatchAllPeriods) {
   qty_millis_in_response = 0;
   EXPECT_TRUE(out_valid);
   EXPECT_FALSE(execution_context_.has_error());
-  EXPECT_EQ(response, (qty_millis_in_response << 32) | (qty_days_in_response & 0x00000000FFFFFFFF));
+  EXPECT_EQ(response,
+            (qty_millis_in_response << 32) | (qty_days_in_response & 0x00000000FFFFFFFF));
 
   response_interval_yrs =
       cast_interval_year(&execution_context_, data.data(), 4, true, &out_valid);
@@ -243,14 +247,14 @@ TEST_F(TestIntervalHolder, TestMatchAllPeriods) {
   qty_millis_in_response = 0;
   EXPECT_TRUE(out_valid);
   EXPECT_FALSE(execution_context_.has_error());
-  EXPECT_EQ(response, (qty_millis_in_response << 32) | (qty_days_in_response & 0x00000000FFFFFFFF));
+  EXPECT_EQ(response,
+            (qty_millis_in_response << 32) | (qty_days_in_response & 0x00000000FFFFFFFF));
 
   response_interval_yrs =
       cast_interval_year(&execution_context_, data.data(), 4, true, &out_valid);
   EXPECT_TRUE(out_valid);
   EXPECT_FALSE(execution_context_.has_error());
   EXPECT_EQ(response_interval_yrs, -12);
-
 }
 
 TEST_F(TestIntervalHolder, TestMatchErrorsForCastIntervalDay) {

--- a/cpp/src/gandiva/interval_holder_test.cc
+++ b/cpp/src/gandiva/interval_holder_test.cc
@@ -61,6 +61,14 @@ TEST_F(TestIntervalHolder, TestMatchAllPeriods) {
   EXPECT_TRUE(out_valid);
   EXPECT_FALSE(execution_context_.has_error());
 
+  data = "1";
+  response = cast_interval_day(&execution_context_, data.data(), 1, true, &out_valid);
+  qty_days_in_response = 0;
+  qty_millis_in_response = 1;
+  EXPECT_TRUE(out_valid);
+  EXPECT_FALSE(execution_context_.has_error());
+  EXPECT_EQ(response, (qty_millis_in_response << 32) | qty_days_in_response);
+
   // Pass only years and days to cast
   data = "P12Y15D";
   response = cast_interval_day(&execution_context_, data.data(), 7, true, &out_valid);

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -1975,7 +1975,7 @@ TEST_F(TestProjector, TestCastIntervalDayFunction) {
 
   // Last validity is false and the cast functions throw error when input is empty. Should
   // not be evaluated due to addition of NativeFunction::kCanReturnErrors
-  auto array0 = MakeArrowArrayUtf8({"PT0.001S", "1742461111", "P1Y1M1DT1H1M1S", "PT48H1M1S"}, {true, true, true, true});
+  auto array0 = MakeArrowArrayUtf8({"PT1.111S", "1742461111", "P1Y1M1DT1H1M1S", "PT48H1M1S"}, {true, true, true, true});
 
   auto in_batch =
       arrow::RecordBatch::Make(schema, num_records, {array0});
@@ -1985,7 +1985,7 @@ TEST_F(TestProjector, TestCastIntervalDayFunction) {
   arrow::ArrayFromVector<arrow::DayTimeIntervalType,
                          arrow::DayTimeIntervalType::DayMilliseconds>(
       arrow::day_time_interval(), {true, true, true, true, true, true, true},
-      {{0, 1},
+      {{0, 1111},
        {20, 14461111},
        {1, 3661000},
        {2, 61000}},

--- a/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorTest.java
+++ b/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorTest.java
@@ -87,6 +87,11 @@ public class ProjectorTest extends BaseEvaluatorTest {
 
     int startOffset = 0;
     for (int i = 0; i < strings.length; i++) {
+      //      if (strings[i].contains(".")) {
+      //        offsetsBuffer.writeFloat(startOffset);
+      //      } else {
+      //        offsetsBuffer.writeInt(startOffset);
+      //      }
       offsetsBuffer.writeInt(startOffset);
 
       final byte[] bytes = strings[i].getBytes(charset);
@@ -94,6 +99,7 @@ public class ProjectorTest extends BaseEvaluatorTest {
       dataBuffer.setBytes(startOffset, bytes, 0, bytes.length);
       startOffset += bytes.length;
     }
+    //offsetsBuffer.writeFloat(startOffset); // offset for the last element
     offsetsBuffer.writeInt(startOffset); // offset for the last element
 
     return Arrays.asList(offsetsBuffer, dataBuffer);
@@ -734,15 +740,16 @@ public class ProjectorTest extends BaseEvaluatorTest {
     Schema schema = new Schema(Lists.newArrayList(x));
     Projector eval = Projector.make(schema, Lists.newArrayList(expr));
 
-    int numRows = 4;
-    byte[] validity = new byte[]{(byte) 7, 0};
-    String[] valuesX = new String[]{"1742461111", "P1Y1M1DT1H1M1S", "PT48H1M1S", "test"};
+    int numRows = 5;
+    byte[] validity = new byte[]{(byte) 15, 0};
+    String[] valuesX = new String[]{"PT0.001S", "1742461111", "P1Y1M1DT1H1M1S", "PT48H1M1S", "test"};
     int[][] expected =
-            new int[][]{ // day and millis
-                {20, 14461111},
-                {1, 3661000},
-                {2, 61000},
-                null};
+          new int[][]{ // day and millis
+              {0, 1},
+              {20, 14461111},
+              {1, 3661000},
+              {2, 61000},
+              null};
 
     ArrowBuf validityX = buf(validity);
     List<ArrowBuf> dataBufsX = stringBufs(valuesX);

--- a/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorTest.java
+++ b/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorTest.java
@@ -727,7 +727,7 @@ public class ProjectorTest extends BaseEvaluatorTest {
 
     TreeNode cond =
             TreeBuilder.makeFunction(
-                    "castintervalday",
+                    "castINTERVALDAY",
                     Lists.newArrayList(TreeBuilder.makeField(x)),
                     new ArrowType.Interval(IntervalUnit.DAY_TIME));
     ExpressionTree expr = TreeBuilder.makeExpression(cond, retType);
@@ -790,7 +790,7 @@ public class ProjectorTest extends BaseEvaluatorTest {
 
     TreeNode cond =
             TreeBuilder.makeFunction(
-                    "castintervalyear",
+                    "castINTERVALYEAR",
                     Lists.newArrayList(TreeBuilder.makeField(x)),
                     new ArrowType.Interval(IntervalUnit.YEAR_MONTH));
     ExpressionTree expr = TreeBuilder.makeExpression(cond, retType);

--- a/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorTest.java
+++ b/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorTest.java
@@ -742,10 +742,10 @@ public class ProjectorTest extends BaseEvaluatorTest {
 
     int numRows = 5;
     byte[] validity = new byte[]{(byte) 15, 0};
-    String[] valuesX = new String[]{"PT0.001S", "1742461111", "P1Y1M1DT1H1M1S", "PT48H1M1S", "test"};
+    String[] valuesX = new String[]{"PT1.111S", "1742461111", "P1Y1M1DT1H1M1S", "PT48H1M1S", "test"};
     int[][] expected =
           new int[][]{ // day and millis
-              {0, 1},
+              {0, 1111},
               {20, 14461111},
               {1, 3661000},
               {2, 61000},


### PR DESCRIPTION
Fix error in LLVM where didn't find these two functions.

Fix regex to allow negative digits for Interval Day and Interval Year.