### PR TITLE
ARROW-14114: [C++][Parquet] Fix multi-threaded read of PME files

### DIFF
--- a/cpp/src/parquet/encryption/encryption_internal.cc
+++ b/cpp/src/parquet/encryption/encryption_internal.cc
@@ -427,9 +427,9 @@ AesDecryptor::AesDecryptor(ParquetCipher::type alg_id, int key_len, bool metadat
     : impl_{std::make_shared<AesDecryptorImpl>(alg_id, key_len, metadata,
                                                contains_length)} {}
 
-std::shared_ptr<AesDecryptor> AesDecryptor::Make(ParquetCipher::type alg_id, int key_len,
-                                                 bool metadata,
-                              std::vector<std::weak_ptr<AesDecryptor>>* all_decryptors) {
+std::shared_ptr<AesDecryptor> AesDecryptor::Make(
+    ParquetCipher::type alg_id, int key_len, bool metadata,
+    std::vector<std::weak_ptr<AesDecryptor>>* all_decryptors) {
   if (ParquetCipher::AES_GCM_V1 != alg_id && ParquetCipher::AES_GCM_CTR_V1 != alg_id) {
     std::stringstream ss;
     ss << "Crypto algorithm " << alg_id << " is not supported";

--- a/cpp/src/parquet/encryption/encryption_internal.cc
+++ b/cpp/src/parquet/encryption/encryption_internal.cc
@@ -424,8 +424,8 @@ AesEncryptor* AesEncryptor::Make(ParquetCipher::type alg_id, int key_len, bool m
 
 AesDecryptor::AesDecryptor(ParquetCipher::type alg_id, int key_len, bool metadata,
                            bool contains_length)
-    : impl_{std::make_shared<AesDecryptorImpl>(alg_id, key_len, metadata,
-                                               contains_length)} {}
+    : impl_{std::unique_ptr<AesDecryptorImpl>(
+          new AesDecryptorImpl(alg_id, key_len, metadata, contains_length))} {}
 
 std::shared_ptr<AesDecryptor> AesDecryptor::Make(
     ParquetCipher::type alg_id, int key_len, bool metadata,

--- a/cpp/src/parquet/encryption/encryption_internal.cc
+++ b/cpp/src/parquet/encryption/encryption_internal.cc
@@ -424,18 +424,19 @@ AesEncryptor* AesEncryptor::Make(ParquetCipher::type alg_id, int key_len, bool m
 
 AesDecryptor::AesDecryptor(ParquetCipher::type alg_id, int key_len, bool metadata,
                            bool contains_length)
-    : impl_{std::unique_ptr<AesDecryptorImpl>(
-          new AesDecryptorImpl(alg_id, key_len, metadata, contains_length))} {}
+    : impl_{std::make_shared<AesDecryptorImpl>(alg_id, key_len, metadata,
+                                               contains_length)} {}
 
-AesDecryptor* AesDecryptor::Make(ParquetCipher::type alg_id, int key_len, bool metadata,
-                                 std::vector<AesDecryptor*>* all_decryptors) {
+std::shared_ptr<AesDecryptor> AesDecryptor::Make(ParquetCipher::type alg_id, int key_len,
+                                                 bool metadata,
+                              std::vector<std::weak_ptr<AesDecryptor>>* all_decryptors) {
   if (ParquetCipher::AES_GCM_V1 != alg_id && ParquetCipher::AES_GCM_CTR_V1 != alg_id) {
     std::stringstream ss;
     ss << "Crypto algorithm " << alg_id << " is not supported";
     throw ParquetException(ss.str());
   }
 
-  AesDecryptor* decryptor = new AesDecryptor(alg_id, key_len, metadata);
+  auto decryptor = std::make_shared<AesDecryptor>(alg_id, key_len, metadata);
   if (all_decryptors != nullptr) {
     all_decryptors->push_back(decryptor);
   }

--- a/cpp/src/parquet/encryption/encryption_internal.h
+++ b/cpp/src/parquet/encryption/encryption_internal.h
@@ -106,7 +106,7 @@ class AesDecryptor {
  private:
   // PIMPL Idiom
   class AesDecryptorImpl;
-  std::shared_ptr<AesDecryptorImpl> impl_;
+  std::unique_ptr<AesDecryptorImpl> impl_;
 };
 
 std::string CreateModuleAad(const std::string& file_aad, int8_t module_type,

--- a/cpp/src/parquet/encryption/encryption_internal.h
+++ b/cpp/src/parquet/encryption/encryption_internal.h
@@ -88,6 +88,14 @@ class AesDecryptor {
   explicit AesDecryptor(ParquetCipher::type alg_id, int key_len, bool metadata,
                         bool contains_length = true);
 
+  /// \brief Factory function to create an AesDecryptor
+  ///
+  /// \param alg_id the encryption algorithm to use
+  /// \param key_len key length. Possible values: 16, 24, 32 bytes.
+  /// \param metadata if true then this is a metadata decryptor
+  /// \param all_decryptors A weak reference to all decryptors that need to be wiped
+  /// out when decryption is finished
+  /// \return shared pointer to a new AesDecryptor
   static std::shared_ptr<AesDecryptor> Make(
       ParquetCipher::type alg_id, int key_len, bool metadata,
       std::vector<std::weak_ptr<AesDecryptor>>* all_decryptors);

--- a/cpp/src/parquet/encryption/encryption_internal.h
+++ b/cpp/src/parquet/encryption/encryption_internal.h
@@ -88,9 +88,9 @@ class AesDecryptor {
   explicit AesDecryptor(ParquetCipher::type alg_id, int key_len, bool metadata,
                         bool contains_length = true);
 
-  static std::shared_ptr<AesDecryptor> Make(ParquetCipher::type alg_id, int key_len,
-                            bool metadata,
-                            std::vector<std::weak_ptr<AesDecryptor>>* all_decryptors);
+  static std::shared_ptr<AesDecryptor> Make(
+      ParquetCipher::type alg_id, int key_len, bool metadata,
+      std::vector<std::weak_ptr<AesDecryptor>>* all_decryptors);
 
   ~AesDecryptor();
   void WipeOut();

--- a/cpp/src/parquet/encryption/encryption_internal.h
+++ b/cpp/src/parquet/encryption/encryption_internal.h
@@ -88,8 +88,9 @@ class AesDecryptor {
   explicit AesDecryptor(ParquetCipher::type alg_id, int key_len, bool metadata,
                         bool contains_length = true);
 
-  static AesDecryptor* Make(ParquetCipher::type alg_id, int key_len, bool metadata,
-                            std::vector<AesDecryptor*>* all_decryptors);
+  static std::shared_ptr<AesDecryptor> Make(ParquetCipher::type alg_id, int key_len,
+                            bool metadata,
+                            std::vector<std::weak_ptr<AesDecryptor>>* all_decryptors);
 
   ~AesDecryptor();
   void WipeOut();
@@ -105,7 +106,7 @@ class AesDecryptor {
  private:
   // PIMPL Idiom
   class AesDecryptorImpl;
-  std::unique_ptr<AesDecryptorImpl> impl_;
+  std::shared_ptr<AesDecryptorImpl> impl_;
 };
 
 std::string CreateModuleAad(const std::string& file_aad, int8_t module_type,

--- a/cpp/src/parquet/encryption/encryption_internal_nossl.cc
+++ b/cpp/src/parquet/encryption/encryption_internal_nossl.cc
@@ -86,8 +86,9 @@ AesDecryptor::AesDecryptor(ParquetCipher::type alg_id, int key_len, bool metadat
   ThrowOpenSSLRequiredException();
 }
 
-AesDecryptor* AesDecryptor::Make(ParquetCipher::type alg_id, int key_len, bool metadata,
-                                 std::vector<AesDecryptor*>* all_decryptors) {
+std::shared_ptr<AesDecryptor> AesDecryptor::Make(ParquetCipher::type alg_id, int key_len,
+                                                 bool metadata,
+                              std::vector<std::weak_ptr<AesDecryptor>>* all_decryptors) {
   return NULLPTR;
 }
 

--- a/cpp/src/parquet/encryption/encryption_internal_nossl.cc
+++ b/cpp/src/parquet/encryption/encryption_internal_nossl.cc
@@ -86,9 +86,9 @@ AesDecryptor::AesDecryptor(ParquetCipher::type alg_id, int key_len, bool metadat
   ThrowOpenSSLRequiredException();
 }
 
-std::shared_ptr<AesDecryptor> AesDecryptor::Make(ParquetCipher::type alg_id, int key_len,
-                                                 bool metadata,
-                              std::vector<std::weak_ptr<AesDecryptor>>* all_decryptors) {
+std::shared_ptr<AesDecryptor> AesDecryptor::Make(
+    ParquetCipher::type alg_id, int key_len, bool metadata,
+    std::vector<std::weak_ptr<AesDecryptor>>* all_decryptors) {
   return NULLPTR;
 }
 

--- a/cpp/src/parquet/encryption/internal_file_decryptor.cc
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.cc
@@ -137,10 +137,10 @@ std::shared_ptr<Decryptor> InternalFileDecryptor::GetFooterDecryptor(
   // Create both data and metadata decryptors to avoid redundant retrieval of key
   // from the key_retriever.
   int key_len = static_cast<int>(footer_key.size());
-  auto aes_metadata_decryptor =
-      encryption::AesDecryptor::Make(algorithm_, key_len, true, &all_decryptors_);
-  auto aes_data_decryptor =
-      encryption::AesDecryptor::Make(algorithm_, key_len, false, &all_decryptors_);
+  auto aes_metadata_decryptor = encryption::AesDecryptor::Make(
+      algorithm_, key_len, /*metadata=*/true, &all_decryptors_);
+  auto aes_data_decryptor = encryption::AesDecryptor::Make(
+      algorithm_, key_len, /*metadata=*/false, &all_decryptors_);
 
   footer_metadata_decryptor_ = std::make_shared<Decryptor>(
       aes_metadata_decryptor, footer_key, file_aad_, aad, pool_);
@@ -201,10 +201,10 @@ std::shared_ptr<Decryptor> InternalFileDecryptor::GetColumnDecryptor(
   // Create both data and metadata decryptors to avoid redundant retrieval of key
   // using the key_retriever.
   int key_len = static_cast<int>(column_key.size());
-  auto aes_metadata_decryptor =
-      encryption::AesDecryptor::Make(algorithm_, key_len, true, &all_decryptors_);
-  auto aes_data_decryptor =
-      encryption::AesDecryptor::Make(algorithm_, key_len, false, &all_decryptors_);
+  auto aes_metadata_decryptor = encryption::AesDecryptor::Make(
+      algorithm_, key_len, /*metadata=*/true, &all_decryptors_);
+  auto aes_data_decryptor = encryption::AesDecryptor::Make(
+      algorithm_, key_len, /*metadata=*/false, &all_decryptors_);
 
   column_metadata_map_[column_path] = std::make_shared<Decryptor>(
       aes_metadata_decryptor, column_key, file_aad_, aad, pool_);

--- a/cpp/src/parquet/encryption/internal_file_decryptor.cc
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.cc
@@ -202,9 +202,9 @@ std::shared_ptr<Decryptor> InternalFileDecryptor::GetColumnDecryptor(
   // using the key_retriever.
   int key_len = static_cast<int>(column_key.size());
   auto aes_metadata_decryptor =
-       encryption::AesDecryptor::Make(algorithm_, key_len, true, &all_decryptors_);
+      encryption::AesDecryptor::Make(algorithm_, key_len, true, &all_decryptors_);
   auto aes_data_decryptor =
-       encryption::AesDecryptor::Make(algorithm_, key_len, false, &all_decryptors_);
+      encryption::AesDecryptor::Make(algorithm_, key_len, false, &all_decryptors_);
 
   column_metadata_map_[column_path] = std::make_shared<Decryptor>(
       aes_metadata_decryptor, column_key, file_aad_, aad, pool_);

--- a/cpp/src/parquet/encryption/internal_file_decryptor.cc
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.cc
@@ -22,9 +22,9 @@
 namespace parquet {
 
 // Decryptor
-Decryptor::Decryptor(encryption::AesDecryptor* aes_decryptor, const std::string& key,
-                     const std::string& file_aad, const std::string& aad,
-                     ::arrow::MemoryPool* pool)
+Decryptor::Decryptor(std::shared_ptr<encryption::AesDecryptor> aes_decryptor,
+                     const std::string& key, const std::string& file_aad,
+                     const std::string& aad, ::arrow::MemoryPool* pool)
     : aes_decryptor_(aes_decryptor),
       key_(key),
       file_aad_(file_aad),
@@ -61,7 +61,9 @@ InternalFileDecryptor::InternalFileDecryptor(FileDecryptionProperties* propertie
 void InternalFileDecryptor::WipeOutDecryptionKeys() {
   properties_->WipeOutDecryptionKeys();
   for (auto const& i : all_decryptors_) {
-    i->WipeOut();
+    if (auto aes_decryptor = i.lock()) {
+      aes_decryptor->WipeOut();
+    }
   }
 }
 
@@ -134,8 +136,11 @@ std::shared_ptr<Decryptor> InternalFileDecryptor::GetFooterDecryptor(
 
   // Create both data and metadata decryptors to avoid redundant retrieval of key
   // from the key_retriever.
-  auto aes_metadata_decryptor = GetMetaAesDecryptor(footer_key.size());
-  auto aes_data_decryptor = GetDataAesDecryptor(footer_key.size());
+  int key_len = static_cast<int>(footer_key.size());
+  auto aes_metadata_decryptor =
+      encryption::AesDecryptor::Make(algorithm_, key_len, true, &all_decryptors_);
+  auto aes_data_decryptor =
+      encryption::AesDecryptor::Make(algorithm_, key_len, false, &all_decryptors_);
 
   footer_metadata_decryptor_ = std::make_shared<Decryptor>(
       aes_metadata_decryptor, footer_key, file_aad_, aad, pool_);
@@ -195,8 +200,11 @@ std::shared_ptr<Decryptor> InternalFileDecryptor::GetColumnDecryptor(
 
   // Create both data and metadata decryptors to avoid redundant retrieval of key
   // using the key_retriever.
-  auto aes_metadata_decryptor = GetMetaAesDecryptor(column_key.size());
-  auto aes_data_decryptor = GetDataAesDecryptor(column_key.size());
+  int key_len = static_cast<int>(column_key.size());
+  auto aes_metadata_decryptor =
+       encryption::AesDecryptor::Make(algorithm_, key_len, true, &all_decryptors_);
+  auto aes_data_decryptor =
+       encryption::AesDecryptor::Make(algorithm_, key_len, false, &all_decryptors_);
 
   column_metadata_map_[column_path] = std::make_shared<Decryptor>(
       aes_metadata_decryptor, column_key, file_aad_, aad, pool_);
@@ -205,36 +213,6 @@ std::shared_ptr<Decryptor> InternalFileDecryptor::GetColumnDecryptor(
 
   if (metadata) return column_metadata_map_[column_path];
   return column_data_map_[column_path];
-}
-
-int InternalFileDecryptor::MapKeyLenToDecryptorArrayIndex(int key_len) {
-  if (key_len == 16)
-    return 0;
-  else if (key_len == 24)
-    return 1;
-  else if (key_len == 32)
-    return 2;
-  throw ParquetException("decryption key must be 16, 24 or 32 bytes in length");
-}
-
-encryption::AesDecryptor* InternalFileDecryptor::GetMetaAesDecryptor(size_t key_size) {
-  int key_len = static_cast<int>(key_size);
-  int index = MapKeyLenToDecryptorArrayIndex(key_len);
-  if (meta_decryptor_[index] == nullptr) {
-    meta_decryptor_[index].reset(
-        encryption::AesDecryptor::Make(algorithm_, key_len, true, &all_decryptors_));
-  }
-  return meta_decryptor_[index].get();
-}
-
-encryption::AesDecryptor* InternalFileDecryptor::GetDataAesDecryptor(size_t key_size) {
-  int key_len = static_cast<int>(key_size);
-  int index = MapKeyLenToDecryptorArrayIndex(key_len);
-  if (data_decryptor_[index] == nullptr) {
-    data_decryptor_[index].reset(
-        encryption::AesDecryptor::Make(algorithm_, key_len, false, &all_decryptors_));
-  }
-  return data_decryptor_[index].get();
 }
 
 }  // namespace parquet

--- a/cpp/src/parquet/encryption/internal_file_decryptor.h
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.h
@@ -35,7 +35,7 @@ class FileDecryptionProperties;
 
 class PARQUET_EXPORT Decryptor {
  public:
-  Decryptor(encryption::AesDecryptor* decryptor, const std::string& key,
+  Decryptor(std::shared_ptr<encryption::AesDecryptor> decryptor, const std::string& key,
             const std::string& file_aad, const std::string& aad,
             ::arrow::MemoryPool* pool);
 
@@ -47,7 +47,7 @@ class PARQUET_EXPORT Decryptor {
   int Decrypt(const uint8_t* ciphertext, int ciphertext_len, uint8_t* plaintext);
 
  private:
-  encryption::AesDecryptor* aes_decryptor_;
+  std::shared_ptr<encryption::AesDecryptor> aes_decryptor_;
   std::string key_;
   std::string file_aad_;
   std::string aad_;
@@ -97,12 +97,7 @@ class InternalFileDecryptor {
   std::shared_ptr<Decryptor> footer_data_decryptor_;
   ParquetCipher::type algorithm_;
   std::string footer_key_metadata_;
-  std::vector<encryption::AesDecryptor*> all_decryptors_;
-
-  /// Key must be 16, 24 or 32 bytes in length. Thus there could be up to three
-  // types of meta_decryptors and data_decryptors.
-  std::unique_ptr<encryption::AesDecryptor> meta_decryptor_[3];
-  std::unique_ptr<encryption::AesDecryptor> data_decryptor_[3];
+  std::vector<std::weak_ptr<encryption::AesDecryptor>> all_decryptors_;
 
   ::arrow::MemoryPool* pool_;
 
@@ -111,11 +106,6 @@ class InternalFileDecryptor {
                                                 const std::string& column_key_metadata,
                                                 const std::string& aad,
                                                 bool metadata = false);
-
-  encryption::AesDecryptor* GetMetaAesDecryptor(size_t key_size);
-  encryption::AesDecryptor* GetDataAesDecryptor(size_t key_size);
-
-  int MapKeyLenToDecryptorArrayIndex(int key_len);
 };
 
 }  // namespace parquet

--- a/cpp/src/parquet/encryption/internal_file_decryptor.h
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.h
@@ -97,6 +97,8 @@ class InternalFileDecryptor {
   std::shared_ptr<Decryptor> footer_data_decryptor_;
   ParquetCipher::type algorithm_;
   std::string footer_key_metadata_;
+  // A weak reference to all decryptors that need to be wiped out when decryption is
+  // finished
   std::vector<std::weak_ptr<encryption::AesDecryptor>> all_decryptors_;
 
   ::arrow::MemoryPool* pool_;

--- a/python/pyarrow/tests/parquet/test_encryption.py
+++ b/python/pyarrow/tests/parquet/test_encryption.py
@@ -126,7 +126,7 @@ def read_encrypted_parquet(path, decryption_config,
 
     result = pq.ParquetFile(
         path, decryption_properties=file_decryption_properties)
-    return result.read(use_threads=False)
+    return result.read(use_threads=True)
 
 
 def test_encrypted_parquet_write_read_wrong_key(tempdir, data_table):
@@ -486,8 +486,6 @@ def test_encrypted_parquet_write_external(tempdir, data_table):
                             kms_connection_config, crypto_factory)
 
 
-@pytest.mark.skip(reason="ARROW-14114: Multithreaded read sometimes fails"
-                  "decryption finalization or with Segmentation fault")
 def test_encrypted_parquet_loop(tempdir, data_table, basic_encryption_config):
     """Write an encrypted parquet, verify it's encrypted,
     and then read it multithreaded in a loop."""


### PR DESCRIPTION
Change AesDecryptor to be per Decryptor, instead of shared.
This solves the problem of reading with PME using multiple threads.


Details:
It was discovered when exposing high-level PME in PyArrow that reading an encrypted parquet file in PyArrow intermittently fails decryption finalization and sometime fails with Segmentation fault. The same in C++ reading an encrypted parquet with FileReader.ReadTable() multithreaded (with set_use_threads(true) ).
The current implementation uses two caches: meta_decryptor_ and data_decryptor_ , for AesDecryptors, and every Decryptor gets the same AesDecryptor with AesDecryptorImpl from this cache. 
However, AesDecryptor::AesDecryptorImpl::GcmDecrypt() and AesDecryptor::AesDecryptorImpl::CtrDecrypt() use ctx_ member of type EVP_CIPHER_CTX from OpenSSL, which shouldn't be used from multiple threads concurrently.
So, instead of sharing the same AesDecryptor between all Decryptors, an AesDecryptor will be created per Decryptor, which is per column.



Co-authored-by: Gidon Gershinsky <ggershinsky@apple.com>

CC @thamht4190 @pitrou @revit13 