### PR TITLE
ARROW-15873: [CI] Migrate from Ubuntu 21.04 to 22.04

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,6 +28,7 @@
 !ci/**
 !c_glib/Gemfile
 !dev/archery/setup.py
+!dev/release/setup-*.sh
 !docs/requirements*.txt
 !python/requirements*.txt
 !python/manylinux1/**

--- a/.env
+++ b/.env
@@ -61,7 +61,8 @@ GO=1.16
 HDFS=3.2.1
 JDK=8
 KARTOTHEK=latest
-LLVM=12
+# LLVM 12 and GCC 11 reports -Wmismatched-new-delete.
+LLVM=13
 MAVEN=3.5.4
 NODE=16
 NUMPY=latest

--- a/ci/docker/ubuntu-18.04-verify-rc.dockerfile
+++ b/ci/docker/ubuntu-18.04-verify-rc.dockerfile
@@ -19,42 +19,8 @@ ARG arch=amd64
 FROM ${arch}/ubuntu:18.04
 
 ENV DEBIAN_FRONTEND=noninteractive
-
-ARG llvm=12
-RUN apt-get update -y -q && \
-    apt-get install -y -q --no-install-recommends \
-       apt-transport-https \
-       ca-certificates \
-       gnupg \
-       wget && \
-    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-    echo "deb https://apt.llvm.org/bionic/ llvm-toolchain-bionic-${llvm} main" > \
-       /etc/apt/sources.list.d/llvm.list && \
-    apt-get update -y -q && \
-    apt-get install -y -q --no-install-recommends \
-        build-essential \
-        clang \
-        cmake \
-        curl \
-        git \
-        libcurl4-openssl-dev \
-        libgirepository1.0-dev \
-        libglib2.0-dev \
-        libsqlite3-dev \
-        libssl-dev \
-        llvm-${llvm}-dev \
-        maven \
-        ninja-build \
-        openjdk-11-jdk \
-        pkg-config \
-        python3-pip \
-        python3.8-dev \
-        python3.8-venv \
-        ruby-dev \
-        wget \
-        tzdata && \
+COPY dev/release/setup-ubuntu.sh /
+RUN /setup-ubuntu.sh && \
+    rm /setup-ubuntu.sh && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists*
-
-RUN python3.8 -m pip install -U pip && \
-    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1

--- a/ci/docker/ubuntu-22.04-cpp-minimal.dockerfile
+++ b/ci/docker/ubuntu-22.04-cpp-minimal.dockerfile
@@ -1,0 +1,98 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ARG base=amd64/ubuntu:22.04
+FROM ${base}
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN echo "debconf debconf/frontend select Noninteractive" | \
+        debconf-set-selections
+
+RUN apt-get update -y -q && \
+    apt-get install -y -q \
+        build-essential \
+        ccache \
+        cmake \
+        git \
+        libssl-dev \
+        libcurl4-openssl-dev \
+        python3-pip \
+        wget && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists*
+
+# Installs LLVM toolchain, for Gandiva and testing other compilers
+#
+# Note that this is installed before the base packages to improve iteration
+# while debugging package list with docker build.
+ARG llvm
+RUN latest_system_llvm=14 && \
+    if [ ${llvm} -gt ${latest_system_llvm} ]; then \
+      apt-get update -y -q && \
+      apt-get install -y -q --no-install-recommends \
+          apt-transport-https \
+          ca-certificates \
+          gnupg \
+          lsb-release \
+          wget && \
+      wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
+      code_name=$(lsb_release --codename --short) && \
+      if [ ${llvm} -gt 10 ]; then \
+        echo "deb https://apt.llvm.org/${code_name}/ llvm-toolchain-${code_name}-${llvm} main" > \
+           /etc/apt/sources.list.d/llvm.list; \
+      fi; \
+    fi && \
+    apt-get update -y -q && \
+    apt-get install -y -q --no-install-recommends \
+        clang-${llvm} \
+        llvm-${llvm}-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists*
+
+COPY ci/scripts/install_minio.sh /arrow/ci/scripts/
+RUN /arrow/ci/scripts/install_minio.sh latest /usr/local
+
+COPY ci/scripts/install_gcs_testbench.sh /arrow/ci/scripts/
+RUN /arrow/ci/scripts/install_gcs_testbench.sh default
+
+ENV ARROW_BUILD_TESTS=ON \
+    ARROW_DATASET=ON \
+    ARROW_FLIGHT=ON \
+    ARROW_GANDIVA=ON \
+    ARROW_GCS=ON \
+    ARROW_HDFS=ON \
+    ARROW_HOME=/usr/local \
+    ARROW_INSTALL_NAME_RPATH=OFF \
+    ARROW_NO_DEPRECATED_API=ON \
+    ARROW_ORC=ON \
+    ARROW_PARQUET=ON \
+    ARROW_PLASMA=ON \
+    ARROW_S3=ON \
+    ARROW_USE_CCACHE=ON \
+    ARROW_WITH_BROTLI=ON \
+    ARROW_WITH_BZ2=ON \
+    ARROW_WITH_LZ4=ON \
+    ARROW_WITH_OPENTELEMETRY=OFF \
+    ARROW_WITH_SNAPPY=ON \
+    ARROW_WITH_ZLIB=ON \
+    ARROW_WITH_ZSTD=ON \
+    CMAKE_GENERATOR="Unix Makefiles" \
+    PARQUET_BUILD_EXAMPLES=ON \
+    PARQUET_BUILD_EXECUTABLES=ON \
+    PATH=/usr/lib/ccache/:$PATH \
+    PYTHON=python3

--- a/ci/docker/ubuntu-22.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-22.04-cpp.dockerfile
@@ -123,6 +123,14 @@ RUN if [ "${gcc_version}" = "" ]; then \
           gcc-${gcc_version} && \
       update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${gcc_version} 100 && \
       update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${gcc_version} 100 && \
+      update-alternatives --install \
+        /usr/bin/$(uname --machine)-linux-gnu-gcc \
+        $(uname --machine)-linux-gnu-gcc \
+        /usr/bin/$(uname --machine)-linux-gnu-gcc-${gcc_version} 100 && \
+      update-alternatives --install \
+        /usr/bin/$(uname --machine)-linux-gnu-g++ \
+        $(uname --machine)-linux-gnu-g++ \
+        /usr/bin/$(uname --machine)-linux-gnu-g++-${gcc_version} 100 && \
       update-alternatives --install /usr/bin/cc cc /usr/bin/gcc 100 && \
       update-alternatives --set cc /usr/bin/gcc && \
       update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 100 && \

--- a/ci/docker/ubuntu-22.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-22.04-cpp.dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-ARG base=amd64/ubuntu:21.04
+ARG base=amd64/ubuntu:22.04
 FROM ${base}
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -29,7 +29,7 @@ RUN echo "debconf debconf/frontend select Noninteractive" | \
 # while debugging package list with docker build.
 ARG clang_tools
 ARG llvm
-RUN latest_system_llvm=12 && \
+RUN latest_system_llvm=14 && \
     if [ ${llvm} -gt ${latest_system_llvm} -o \
          ${clang_tools} -gt ${latest_system_llvm} ]; then \
       apt-get update -y -q && \
@@ -157,7 +157,7 @@ RUN if [ "${gcc_version}" = "" ]; then \
           g++ \
           gcc; \
     else \
-      if [ "${gcc_version}" -gt "10" ]; then \
+      if [ "${gcc_version}" -gt "11" ]; then \
           apt-get update -y -q && \
           apt-get install -y -q --no-install-recommends software-properties-common && \
           add-apt-repository ppa:ubuntu-toolchain-r/volatile; \

--- a/ci/docker/ubuntu-22.04-verify-rc.dockerfile
+++ b/ci/docker/ubuntu-22.04-verify-rc.dockerfile
@@ -16,7 +16,7 @@
 # under the License.
 
 ARG arch=amd64
-FROM ${arch}/ubuntu:20.04
+FROM ${arch}/ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 COPY dev/release/setup-ubuntu.sh /

--- a/dev/release/setup-ubuntu.sh
+++ b/dev/release/setup-ubuntu.sh
@@ -24,7 +24,7 @@ set -exu
 
 codename=$(. /etc/os-release && echo ${UBUNTU_CODENAME})
 
-case ${code_name} in
+case ${codename} in
   bionic)
     llvm=12
     python=3.8
@@ -72,7 +72,7 @@ apt-get install -y -q --no-install-recommends \
   wget \
   tzdata
 
-case ${code_name} in
+case ${codename} in
   bionic)
     python${python} -m pip install -U pip
     update-alternatives \

--- a/dev/release/setup-ubuntu.sh
+++ b/dev/release/setup-ubuntu.sh
@@ -27,6 +27,7 @@ codename=$(. /etc/os-release && echo ${UBUNTU_CODENAME})
 case ${codename} in
   bionic)
     llvm=12
+    nlohmann_json=
     python=3.8
     apt-get update -y -q
     apt-get install -y -q --no-install-recommends \
@@ -42,6 +43,7 @@ case ${codename} in
       llvm-${llvm}-dev
     ;;
   *)
+    nlohmann_json=3
     python=3
     apt-get update -y -q
     apt-get install -y -q --no-install-recommends \
@@ -62,7 +64,7 @@ apt-get install -y -q --no-install-recommends \
   libssl-dev \
   maven \
   ninja-build \
-  nlohmann-json3-dev \
+  nlohmann-json${nlohmann_json}-dev \
   openjdk-11-jdk \
   pkg-config \
   python3-pip \

--- a/dev/release/setup-ubuntu.sh
+++ b/dev/release/setup-ubuntu.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,10 +18,38 @@
 # under the License.
 
 # A script to install dependencies required for release
-# verification on Ubuntu 20.04
+# verification on Ubuntu.
 
-apt-get update
-apt-get -y install \
+set -exu
+
+codename=$(. /etc/os-release && echo ${UBUNTU_CODENAME})
+
+case ${code_name} in
+  bionic)
+    llvm=12
+    python=3.8
+    apt-get update -y -q
+    apt-get install -y -q --no-install-recommends \
+      apt-transport-https \
+      ca-certificates \
+      gnupg \
+      wget
+    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
+    echo "deb https://apt.llvm.org/${codename}/ llvm-toolchain-${codename}-${llvm} main" > \
+      /etc/apt/sources.list.d/llvm.list
+    apt-get update -y -q
+    apt-get install -y -q --no-install-recommends \
+      llvm-${llvm}-dev
+    ;;
+  *)
+    python=3
+    apt-get update -y -q
+    apt-get install -y -q --no-install-recommends \
+      llvm-dev
+    ;;
+esac
+
+apt-get install -y -q --no-install-recommends \
   build-essential \
   clang \
   cmake \
@@ -30,12 +60,22 @@ apt-get -y install \
   libglib2.0-dev \
   libsqlite3-dev \
   libssl-dev \
-  llvm-dev \
   maven \
   ninja-build \
+  nlohmann-json3-dev \
   openjdk-11-jdk \
   pkg-config \
   python3-pip \
-  python3-venv \
+  python${python}-dev \
+  python${python}-venv \
   ruby-dev \
-  wget
+  wget \
+  tzdata
+
+case ${code_name} in
+  bionic)
+    python${python} -m pip install -U pip
+    update-alternatives \
+      --install /usr/bin/python3 python3 /usr/bin/python${python} 1
+    ;;
+esac

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -900,7 +900,8 @@ tasks:
 {% for distribution, version in [("conda", "latest"),
                                  ("almalinux", "8"),
                                  ("ubuntu", "18.04"),
-                                 ("ubuntu", "20.04")] %}
+                                 ("ubuntu", "20.04"),
+                                 ("ubuntu", "22.04")] %}
   {% for target in ["cpp",
                     "csharp",
                     "go",
@@ -1060,7 +1061,7 @@ tasks:
     params:
       image: conda-cpp-valgrind
 
-{% for ubuntu_version in ["18.04", "20.04", "21.04"] %}
+{% for ubuntu_version in ["18.04", "20.04", "22.04"] %}
   test-ubuntu-{{ ubuntu_version }}-cpp:
     ci: github
     template: docker-tests/github.linux.yml
@@ -1305,12 +1306,12 @@ tasks:
       flags: '-e NOT_CRAN=false -e INSTALL_ARGS=--use-LTO'
 
   # This one has -flto=auto
-  test-r-ubuntu-21.04:
+  test-r-ubuntu-22.04:
     ci: github
     template: docker-tests/github.linux.yml
     params:
       env:
-        UBUNTU: 21.04
+        UBUNTU: 22.04
         R_PRUNE_DEPS: TRUE
       image: ubuntu-r-only-r
 
@@ -1320,7 +1321,7 @@ tasks:
     template: docker-tests/github.linux.yml
     params:
       env:
-        UBUNTU: 21.04
+        UBUNTU: 22.04
         GCC_VERSION: 11
       # S3 support is not buildable with gcc11 right now
       flags: '-e ARROW_S3=OFF'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1767,7 +1767,7 @@ services:
     #   docker-compose build ubuntu-verify-rc-source
     #   docker-compose run -e VERIFY_VERSION=6.0.1 -e VERIFY_RC=1 ubuntu-verify-rc-source
     # Parameters:
-    #   UBUNTU: 18.04, 20.04
+    #   UBUNTU: 18.04, 20.04, 22.04
     image: ${REPO}:${ARCH}-ubuntu-${UBUNTU}-verify-rc
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1736,8 +1736,8 @@ services:
 
   almalinux-verify-rc:
     # Usage:
-    #   docker-compose build almalinux-verify-rc-source
-    #   docker-compose run -e VERIFY_VERSION=6.0.1 -e VERIFY_RC=1 almalinux-verify-rc-source
+    #   docker-compose build almalinux-verify-rc
+    #   docker-compose run -e VERIFY_VERSION=6.0.1 -e VERIFY_RC=1 almalinux-verify-rc
     # Parameters:
     #   ALMALINUX: 8
     image: ${REPO}:${ARCH}-almalinux-${ALMALINUX}-verify-rc
@@ -1764,8 +1764,8 @@ services:
 
   ubuntu-verify-rc:
     # Usage:
-    #   docker-compose build ubuntu-verify-rc-source
-    #   docker-compose run -e VERIFY_VERSION=6.0.1 -e VERIFY_RC=1 ubuntu-verify-rc-source
+    #   docker-compose build ubuntu-verify-rc
+    #   docker-compose run -e VERIFY_VERSION=6.0.1 -e VERIFY_RC=1 ubuntu-verify-rc
     # Parameters:
     #   UBUNTU: 18.04, 20.04, 22.04
     image: ${REPO}:${ARCH}-ubuntu-${UBUNTU}-verify-rc


### PR DESCRIPTION
Ubuntu 21.04 reached EOL at 2022-01.

Ubuntu 22.04 will be released in 2022-04.