### PR TITLE
ARROW-16071: [R] More undefined global functions

### DIFF
--- a/r/R/dplyr-select.R
+++ b/r/R/dplyr-select.R
@@ -34,8 +34,8 @@ rename.Dataset <- rename.ArrowTabular <- rename.RecordBatchReader <- rename.arro
 
 rename_with.arrow_dplyr_query <- function(.data, .fn, .cols = everything(), ...) {
   .fn <- as_function(.fn)
-  old_names <- names(select(.data, {{ .cols }}))
-  rename(.data, !!set_names(old_names, .fn(old_names)))
+  old_names <- names(dplyr::select(.data, {{ .cols }}))
+  dplyr::rename(.data, !!set_names(old_names, .fn(old_names)))
 }
 rename_with.Dataset <- rename_with.ArrowTabular <- rename_with.RecordBatchReader <- rename_with.arrow_dplyr_query
 


### PR DESCRIPTION
This PR qualifies calls to `select()` and `rename()` with `dplyr::` that were introduced in ARROW-15947. This gives us a CMD check NOTE (and would fail if a user hadn't `library(dplyr)` before calling `dplyr::rename_with(some_arrow_thing)`).