### PR TITLE
ARROW-16109: [Python] Add dataset mark to test in order to avoid failure

### DIFF
--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -1551,6 +1551,7 @@ def test_dataset_read_dictionary(tempdir, use_legacy_dataset):
         assert c1.equals(ex_chunks[0])
 
 
+@pytest.mark.dataset
 @pytest.mark.pandas
 def test_read_table_schema(tempdir):
     # test that schema keyword is passed through in read_table


### PR DESCRIPTION
This PR is to avoid a test failure when building and testing pyarrow without `-DARROW_DATASET=On`.

**Context:**

When following the [contributing guidelines ](https://arrow.apache.org/docs/dev/developers/python.html#building-on-linux-and-macos) I built arrow as described:
```
cmake -DCMAKE_INSTALL_PREFIX=$ARROW_HOME \
      -DCMAKE_INSTALL_LIBDIR=lib \
      -DCMAKE_BUILD_TYPE=Debug \
      -DARROW_WITH_BZ2=ON \
      -DARROW_WITH_ZLIB=ON \
      -DARROW_WITH_ZSTD=ON \
      -DARROW_WITH_LZ4=ON \
      -DARROW_WITH_SNAPPY=ON \
      -DARROW_WITH_BROTLI=ON \
      -DARROW_PARQUET=ON \
      -DPARQUET_REQUIRE_ENCRYPTION=ON \
      -DARROW_PYTHON=ON \
      -DARROW_BUILD_TESTS=ON \
      ..
```
When running tests I found that DATASET was required for `python/pyarrow/tests/parquet/test_dataset.py::test_read_table_schema` or an import error was raised `ModuleNotFoundError: No module named 'pyarrow._dataset'`.

The PR adds the requires pytest mark to skip the test under that scenario.