### PR TITLE
ARROW-15364: [Python] Update filesystem entry in read docstrings to reflect current behaviour

### DIFF
--- a/python/pyarrow/orc.py
+++ b/python/pyarrow/orc.py
@@ -325,8 +325,9 @@ columns : list
     that the table will still have the correct num_rows set despite having
     no columns.
 filesystem : FileSystem, default None
-    If nothing passed, paths assumed to be found in the local on-disk
-    filesystem.
+    If nothing passed, will be inferred based on path.
+    Path will try to be found in the local on-disk filesystem otherwise
+    it will be parsed as an URI to determine the filesystem.
 """
 
 

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -1322,8 +1322,9 @@ Parameters
 path_or_paths : str or List[str]
     A directory name, single file name, or list of file names.
 filesystem : FileSystem, default None
-    If nothing passed, paths assumed to be found in the local on-disk
-    filesystem.
+    If nothing passed, will be inferred based on path.
+    Path will try to be found in the local on-disk filesystem otherwise
+    it will be parsed as an URI to determine the filesystem.
 metadata : pyarrow.parquet.FileMetaData
     Use metadata obtained elsewhere to validate file schemas.
 schema : pyarrow.parquet.Schema
@@ -1956,8 +1957,9 @@ ignore_prefixes : list, optional
     By default this is ['.', '_'].
     Note that discovery happens only if a directory is passed as source.
 filesystem : FileSystem, default None
-    If nothing passed, paths assumed to be found in the local on-disk
-    filesystem.
+    If nothing passed, will be inferred based on path.
+    Path will try to be found in the local on-disk filesystem otherwise
+    it will be parsed as an URI to determine the filesystem.
 filters : List[Tuple] or List[List[Tuple]] or None (default)
     Rows which do not match the filter predicate will be removed from scanned
     data. Partition keys embedded in a nested directory structure will be
@@ -2223,8 +2225,9 @@ def write_to_dataset(table, root_path, partition_cols=None,
     root_path : str, pathlib.Path
         The root directory of the dataset
     filesystem : FileSystem, default None
-        If nothing passed, paths assumed to be found in the local on-disk
-        filesystem
+        If nothing passed, will be inferred based on path.
+        Path will try to be found in the local on-disk filesystem otherwise
+        it will be parsed as an URI to determine the filesystem.
     partition_cols : list,
         Column names by which to partition the dataset
         Columns are partitioned in the order they are given


### PR DESCRIPTION
Update docstring to reflect current behaviour.

When filesystem is `None` we will use `LocalFileSystem` if path is found and exists locally. Otherwise we try to find the FileSystem based on the URI as seen here: https://github.com/apache/arrow/blob/master/python/pyarrow/fs.py#L166-L187