### PR TITLE
ARROW-16128: [C++][FlightRPC] Fix Flight SQL static build on Windows

### DIFF
--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -445,6 +445,7 @@ function(ADD_ARROW_LIB LIB_NAME)
 
     if(ARROW_BUILD_STATIC AND WIN32)
       target_compile_definitions(${LIB_NAME}_static PUBLIC ARROW_STATIC)
+      target_compile_definitions(${LIB_NAME}_static PUBLIC ARROW_FLIGHT_STATIC)
     endif()
 
     set_target_properties(${LIB_NAME}_static

--- a/cpp/src/arrow/flight/sql/client.cc
+++ b/cpp/src/arrow/flight/sql/client.cc
@@ -369,8 +369,9 @@ arrow::Result<int64_t> PreparedStatement::ExecuteUpdate() {
   } else {
     const std::shared_ptr<Schema> schema = arrow::schema({});
     ARROW_RETURN_NOT_OK(client_->DoPut(options_, descriptor, schema, &writer, &reader));
+    const auto& columns = std::vector<std::shared_ptr<Array>>{};
     const auto& record_batch =
-        arrow::RecordBatch::Make(schema, 0, (std::vector<std::shared_ptr<Array>>){});
+        arrow::RecordBatch::Make(schema, 0, columns);
     ARROW_RETURN_NOT_OK(writer->WriteRecordBatch(*record_batch));
   }
 

--- a/cpp/src/arrow/flight/sql/client.cc
+++ b/cpp/src/arrow/flight/sql/client.cc
@@ -369,9 +369,8 @@ arrow::Result<int64_t> PreparedStatement::ExecuteUpdate() {
   } else {
     const std::shared_ptr<Schema> schema = arrow::schema({});
     ARROW_RETURN_NOT_OK(client_->DoPut(options_, descriptor, schema, &writer, &reader));
-    const auto& columns = std::vector<std::shared_ptr<Array>>{};
-    const auto& record_batch =
-        arrow::RecordBatch::Make(schema, 0, columns);
+    const ArrayVector columns = std::vector<std::shared_ptr<Array>>{};
+    const auto& record_batch = arrow::RecordBatch::Make(schema, 0, columns);
     ARROW_RETURN_NOT_OK(writer->WriteRecordBatch(*record_batch));
   }
 

--- a/cpp/src/arrow/flight/sql/client.cc
+++ b/cpp/src/arrow/flight/sql/client.cc
@@ -369,7 +369,7 @@ arrow::Result<int64_t> PreparedStatement::ExecuteUpdate() {
   } else {
     const std::shared_ptr<Schema> schema = arrow::schema({});
     ARROW_RETURN_NOT_OK(client_->DoPut(options_, descriptor, schema, &writer, &reader));
-    const ArrayVector columns = std::vector<std::shared_ptr<Array>>{};
+    const ArrayVector columns;
     const auto& record_batch = arrow::RecordBatch::Make(schema, 0, columns);
     ARROW_RETURN_NOT_OK(writer->WriteRecordBatch(*record_batch));
   }

--- a/docs/source/developers/cpp/windows.rst
+++ b/docs/source/developers/cpp/windows.rst
@@ -362,6 +362,20 @@ suppress dllimport/dllexport marking of symbols. Projects that statically link
 against Arrow on Windows additionally need this definition. The Unix builds do
 not use the macro.
 
+In addition if using ``-DARROW_FLIGHT=ON``, ``ARROW_FLIGHT_STATIC`` needs to
+be defined.
+
+.. code-block:: cmake
+
+   project(MyExample)
+
+   find_package(Arrow REQUIRED)
+
+   add_executable(my_example my_example.cc)
+   target_link_libraries(my_example PRIVATE arrow_static arrow_flight_static)
+
+   add_compile_definitions(ARROW_STATIC ARROW_FLIGHT_STATIC)
+
 Downloading the Timezone Database
 =================================
 

--- a/docs/source/developers/cpp/windows.rst
+++ b/docs/source/developers/cpp/windows.rst
@@ -374,7 +374,7 @@ be defined.
    add_executable(my_example my_example.cc)
    target_link_libraries(my_example PRIVATE arrow_static arrow_flight_static)
 
-   add_compile_definitions(ARROW_STATIC ARROW_FLIGHT_STATIC)
+   target_compile_definitions(my_example PUBLIC ARROW_STATIC ARROW_FLIGHT_STATIC)
 
 Downloading the Timezone Database
 =================================


### PR DESCRIPTION
* Removes non-std initializer list
* Sets ARROW_FLIGHT_STATIC to match ARROW_STATIC when ARROW_BUILD_STATIC
  and WIN32
* Updates the documentation arrow staticly linking on windows to include
  the ARROW_FLIGHT_STATIC definition, including an example

The goal of this is to allow flightsql to build easily on Windows.