### PR TITLE
ARROW-16113: [Python] Partitioning.dictionaries in case of a subset of fields are dictionary encoded

### DIFF
--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1354,8 +1354,9 @@ cdef class KeyValuePartitioning(Partitioning):
             if arr.get() == nullptr:
                 # Partitioning object has not been created through
                 # inspected Factory
-                continue
-            res.append(pyarrow_wrap_array(arr))
+                res.append(None)
+            else:
+                res.append(pyarrow_wrap_array(arr))
         return res
 
 

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -549,7 +549,8 @@ def test_partitioning():
             pa.field('key', pa.float64())
         ])
     )
-    assert len(partitioning.dictionaries) == 0
+    assert len(partitioning.dictionaries) == 2
+    assert all(x is None for x in partitioning.dictionaries) is True
     expr = partitioning.parse('/3/3.14')
     assert isinstance(expr, ds.Expression)
 
@@ -570,7 +571,8 @@ def test_partitioning():
         ]),
         null_fallback='xyz'
     )
-    assert len(partitioning.dictionaries) == 0
+    assert len(partitioning.dictionaries) == 2
+    assert all(x is None for x in partitioning.dictionaries) is True
     expr = partitioning.parse('/alpha=0/beta=3')
     expected = (
         (ds.field('alpha') == ds.scalar(0)) &
@@ -594,7 +596,8 @@ def test_partitioning():
             pa.field('key', pa.float64())
         ])
     )
-    assert len(partitioning.dictionaries) == 0
+    assert len(partitioning.dictionaries) == 2
+    assert all(x is None for x in partitioning.dictionaries) is True
     expr = partitioning.parse('3_3.14_')
     assert isinstance(expr, ds.Expression)
 
@@ -612,7 +615,7 @@ def test_partitioning():
         dictionaries={
             "key": pa.array(["first", "second", "third"]),
         })
-    assert partitioning.dictionaries[0].to_pylist() == [
+    assert partitioning.dictionaries[1].to_pylist() == [
         "first", "second", "third"]
 
     partitioning = ds.FilenamePartitioning(
@@ -623,7 +626,7 @@ def test_partitioning():
         dictionaries={
             "key": pa.array(["first", "second", "third"]),
         })
-    assert partitioning.dictionaries[0].to_pylist() == [
+    assert partitioning.dictionaries[1].to_pylist() == [
         "first", "second", "third"]
 
 
@@ -3322,13 +3325,15 @@ def test_dataset_preserved_partitioning(tempdir):
     # through discovery, with hive partitioning (from a partitioning object)
     part = ds.partitioning(pa.schema([("part", pa.int32())]), flavor="hive")
     assert isinstance(part, ds.HivePartitioning)  # not a factory
-    assert len(part.dictionaries) == 0
+    assert len(part.dictionaries) == 1
+    assert all(x is None for x in part.dictionaries) is True
     dataset = ds.dataset(path, partitioning=part)
     part = dataset.partitioning
     assert isinstance(part, ds.HivePartitioning)
     assert part.schema == pa.schema([("part", pa.int32())])
     # TODO is this expected?
-    assert len(part.dictionaries) == 0
+    assert len(part.dictionaries) == 1
+    assert all(x is None for x in part.dictionaries) is True
 
     # through manual creation -> not available
     dataset = ds.dataset(path, partitioning="hive")

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -550,7 +550,7 @@ def test_partitioning():
         ])
     )
     assert len(partitioning.dictionaries) == 2
-    assert all(x is None for x in partitioning.dictionaries) is True
+    assert all(x is None for x in partitioning.dictionaries)
     expr = partitioning.parse('/3/3.14')
     assert isinstance(expr, ds.Expression)
 
@@ -572,7 +572,7 @@ def test_partitioning():
         null_fallback='xyz'
     )
     assert len(partitioning.dictionaries) == 2
-    assert all(x is None for x in partitioning.dictionaries) is True
+    assert all(x is None for x in partitioning.dictionaries)
     expr = partitioning.parse('/alpha=0/beta=3')
     expected = (
         (ds.field('alpha') == ds.scalar(0)) &
@@ -597,7 +597,7 @@ def test_partitioning():
         ])
     )
     assert len(partitioning.dictionaries) == 2
-    assert all(x is None for x in partitioning.dictionaries) is True
+    assert all(x is None for x in partitioning.dictionaries)
     expr = partitioning.parse('3_3.14_')
     assert isinstance(expr, ds.Expression)
 
@@ -3326,14 +3326,14 @@ def test_dataset_preserved_partitioning(tempdir):
     part = ds.partitioning(pa.schema([("part", pa.int32())]), flavor="hive")
     assert isinstance(part, ds.HivePartitioning)  # not a factory
     assert len(part.dictionaries) == 1
-    assert all(x is None for x in part.dictionaries) is True
+    assert all(x is None for x in part.dictionaries) 
     dataset = ds.dataset(path, partitioning=part)
     part = dataset.partitioning
     assert isinstance(part, ds.HivePartitioning)
     assert part.schema == pa.schema([("part", pa.int32())])
     # TODO is this expected?
     assert len(part.dictionaries) == 1
-    assert all(x is None for x in part.dictionaries) is True
+    assert all(x is None for x in part.dictionaries) 
 
     # through manual creation -> not available
     dataset = ds.dataset(path, partitioning="hive")

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -615,6 +615,7 @@ def test_partitioning():
         dictionaries={
             "key": pa.array(["first", "second", "third"]),
         })
+    assert partitioning.dictionaries[0] is None
     assert partitioning.dictionaries[1].to_pylist() == [
         "first", "second", "third"]
 
@@ -626,6 +627,7 @@ def test_partitioning():
         dictionaries={
             "key": pa.array(["first", "second", "third"]),
         })
+    assert partitioning.dictionaries[0] is None
     assert partitioning.dictionaries[1].to_pylist() == [
         "first", "second", "third"]
 
@@ -3326,14 +3328,14 @@ def test_dataset_preserved_partitioning(tempdir):
     part = ds.partitioning(pa.schema([("part", pa.int32())]), flavor="hive")
     assert isinstance(part, ds.HivePartitioning)  # not a factory
     assert len(part.dictionaries) == 1
-    assert all(x is None for x in part.dictionaries) 
+    assert all(x is None for x in part.dictionaries)
     dataset = ds.dataset(path, partitioning=part)
     part = dataset.partitioning
     assert isinstance(part, ds.HivePartitioning)
     assert part.schema == pa.schema([("part", pa.int32())])
     # TODO is this expected?
     assert len(part.dictionaries) == 1
-    assert all(x is None for x in part.dictionaries) 
+    assert all(x is None for x in part.dictionaries)
 
     # through manual creation -> not available
     dataset = ds.dataset(path, partitioning="hive")


### PR DESCRIPTION
This PR modifies the `dictionaries` method to have entries for all the fields. With this change, the method will return a list with the values if present, otherwise it shall contain `None`, thus returning a list of same length.


Ref: https://github.com/apache/arrow/pull/12530#discussion_r841886153