### PR TITLE
MINOR: [Docs] Replace old filesystem docs with reference to new location

### DIFF
--- a/docs/source/python/api/files.rst
+++ b/docs/source/python/api/files.rst
@@ -55,11 +55,4 @@ Stream Classes
 File Systems
 ------------
 
-.. autosummary::
-   :toctree: ../generated/
-
-   hdfs.connect
-   LocalFileSystem
-
-.. class:: HadoopFileSystem
-   :noindex:
+See :ref:`api.fs`.

--- a/docs/source/python/api/filesystems.rst
+++ b/docs/source/python/api/filesystems.rst
@@ -17,10 +17,10 @@
 
 .. currentmodule:: pyarrow.fs
 
+.. _api.fs:
+
 Filesystems
 ===========
-
-.. _api.fs:
 
 Interface
 ---------


### PR DESCRIPTION
The old docs were oddly formatted: https://arrow.apache.org/docs/python/api/files.html#file-systems
![Screen Shot 2022-04-04 at 10 50 05 AM](https://user-images.githubusercontent.com/5488879/161602133-9c967bc3-480b-4b4d-8a23-6cf084577b13.png)

The legacy filesystem stuff already has API docs on [this other page](https://arrow.apache.org/docs/python/filesystems_deprecated.html), so we aren't losing anything by deleting the stuff on `files.rst`. 