### PR TITLE
ARROW-13922: [Python] Fix ParquetDataset throw error when len(path_or_paths) == 1

### DIFF
--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -1791,10 +1791,7 @@ class _ParquetDatasetV2:
 
         # check for single fragment dataset
         single_file = None
-        if isinstance(path_or_paths, list):
-            if len(path_or_paths) == 1:
-                single_file = path_or_paths[0]
-        else:
+        if not isinstance(path_or_paths, list):
             if _is_path_like(path_or_paths):
                 path_or_paths = _stringify_path(path_or_paths)
                 if filesystem is None:

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -642,8 +642,7 @@ def test_read_directory_s3fs(s3_example_s3fs, use_legacy_dataset):
 @pytest.mark.pandas
 @parametrize_legacy_dataset
 def test_read_single_file_list(tempdir, use_legacy_dataset):
-    base_path = str(tempdir)
-    data_path = os.path.join(base_path, 'data.parquet')
+    data_path = str(tempdir / 'data.parquet')
 
     table = pa.table({"a": [1, 2, 3]})
     _write_table(table, data_path)

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -640,6 +640,21 @@ def test_read_directory_s3fs(s3_example_s3fs, use_legacy_dataset):
 
 
 @pytest.mark.pandas
+@parametrize_legacy_dataset
+def test_read_single_file_list(tempdir, use_legacy_dataset):
+    base_path = str(tempdir)
+    data_path = os.path.join(base_path, 'data.parquet')
+
+    table = pa.table({"a": [1, 2, 3]})
+    _write_table(table, data_path)
+
+    result = pq.ParquetDataset(
+        [data_path], use_legacy_dataset=use_legacy_dataset
+    ).read()
+    assert result.equals(table)
+
+
+@pytest.mark.pandas
 @pytest.mark.s3
 @parametrize_legacy_dataset
 def test_read_partitioned_directory_s3fs_wrapper(


### PR DESCRIPTION
This PR fixes a bug when a list with a single element was used on `ParquestDataset.read()`.

The following snippet was reported to reproduce the bug:

**Before solution**
```python
In [1]: import pyarrow.parquet as pq
   ...: import pandas as pd
   ...: df = pd.DataFrame({'A': [1, 2, 3], 'B': ['a', 'b', 'c']})
   ...: df.to_parquet('/tmp/test.parquet', index=False)
   ...: pq.ParquetDataset(['/tmp/test.parquet'], use_legacy_dataset=False).read(use_threads=False).to_pandas()
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
ValueError: cannot construct a FileSource from a path without a FileSystem
Exception ignored in: 'pyarrow._dataset._make_file_source'
Traceback (most recent call last):
  File "/home/raulcd/open_source/arrow/python/pyarrow/parquet.py", line 1815, in __init__
    fragment = parquet_format.make_fragment(single_file, filesystem)
ValueError: cannot construct a FileSource from a path without a FileSystem
---------------------------------------------------------------------------
```

**After solution**
```python
In [1]: import pyarrow.parquet as pq
   ...: import pandas as pd
   ...: df = pd.DataFrame({'A': [1, 2, 3], 'B': ['a', 'b', 'c']})
   ...: df.to_parquet('/tmp/test.parquet', index=False)
   ...: pq.ParquetDataset(['/tmp/test.parquet'], use_legacy_dataset=False).read(use_threads=False).to_pandas()
Out[1]: 
   A  B
0  1  a
1  2  b
2  3  c

```