### PR TITLE
MINOR: [C++] Properly skip nested fork test on MacOS

### DIFF
--- a/cpp/src/arrow/util/thread_pool_test.cc
+++ b/cpp/src/arrow/util/thread_pool_test.cc
@@ -858,7 +858,7 @@ TEST_F(TestThreadPoolForkSafety, MultipleChildThreads) {
 
 TEST_F(TestThreadPoolForkSafety, NestedChild) {
   {
-#ifndef __APPLE__
+#ifdef __APPLE__
     GTEST_SKIP() << "Nested fork is not supported on macos";
 #endif
     auto pool = this->MakeThreadPool(3);


### PR DESCRIPTION
I had inverted the `ifdef` logic when I first added the skip