### PR TITLE
ARROW-16122: [Python] Change use_legacy_dataset default and deprecate no-longer supported keywords in parquet.write_to_dataset

### DIFF
--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -2926,8 +2926,8 @@ def _mkdir_if_not_exists(fs, path):
 
 def write_to_dataset(table, root_path, partition_cols=None,
                      partition_filename_cb=None, filesystem=None,
-                     use_legacy_dataset=None, file_options=None,
-                     schema=None, partitioning=None, basename_template=None,
+                     use_legacy_dataset=None, schema=None,
+                     partitioning=None, basename_template=None,
                      use_threads=None, file_visitor=None, **kwargs):
     """Wrapper around parquet.write_dataset for writing a Table to
     Parquet format by partitions.
@@ -2969,9 +2969,6 @@ def write_to_dataset(table, root_path, partition_cols=None,
         removed in a future version). The legacy implementation still
         supports `partition_filename_cb` and `metadata_collector` keywords
         but is less efficient when using partition columns.
-    file_options : pyarrow.dataset.FileWriteOptions, optional
-        FileFormat specific write options, created using the
-        ``FileFormat.make_write_options()`` function.
     use_threads : bool, default True
         Write files in parallel. If enabled, then maximum parallelism will be
         used determined by the number of available CPU cores.
@@ -3103,8 +3100,6 @@ def write_to_dataset(table, root_path, partition_cols=None,
         "'use_legacy_dataset=False' while constructing the "
         "ParquetDataset."
     )
-    if file_options is not None:
-        raise ValueError(msg2.format("file_options"))
     if schema is not None:
         raise ValueError(msg2.format("schema"))
     if partitioning is not None:

--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -3003,16 +3003,16 @@ def write_to_dataset(table, root_path, partition_cols=None,
     """
     if use_legacy_dataset:
         warnings.warn(
-        "Passing 'use_legacy_dataset=True' to get the legacy behaviour is "
-        "deprecated as of pyarrow 8.0.0, and the legacy implementation will "
-        "be removed in a future version.",
-        FutureWarning, stacklevel=2)
+            "Passing 'use_legacy_dataset=True' to get the legacy behaviour is "
+            "deprecated as of pyarrow 8.0.0, and the legacy implementation "
+            "will be removed in a future version.",
+            FutureWarning, stacklevel=2)
 
         # raise for unsupported keywords
         if partition_filename_cb is not None:
             warnings.warn(
-            _DEPR_MSG.format("partition_filename_cb", ""),
-            FutureWarning, stacklevel=2)
+                _DEPR_MSG.format("partition_filename_cb", ""),
+                FutureWarning, stacklevel=2)
 
     if not use_legacy_dataset:
         import pyarrow.dataset as ds

--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -2939,14 +2939,14 @@ def write_to_dataset(table, root_path, partition_cols=None,
     root_dir/
       group1=value1
         group2=value1
-          part-0.parquet
+          <uuid>.parquet
         group2=value2
-          part-0.parquet
+          <uuid>.parquet
       group1=valueN
         group2=value1
-          part-0.parquet
+          <uuid>.parquet
         group2=valueN
-          part-0.parquet
+          <uuid>.parquet
 
     Parameters
     ----------
@@ -3027,16 +3027,13 @@ def write_to_dataset(table, root_path, partition_cols=None,
 
     >>> import pyarrow.parquet as pq
     >>> pq.write_to_dataset(table, root_path='dataset_name_3',
-    ...                     partition_cols=['year'],
-    ...                     use_legacy_dataset=False
-    ...                    )
+    ...                     partition_cols=['year'])
     >>> pq.ParquetDataset('dataset_name_3', use_legacy_dataset=False).files
     ['dataset_name_3/year=2019/part-0.parquet', ...
 
     Write a single Parquet file into the root folder:
 
-    >>> pq.write_to_dataset(table, root_path='dataset_name_4',
-    ...                     use_legacy_dataset=False)
+    >>> pq.write_to_dataset(table, root_path='dataset_name_4')
     >>> pq.ParquetDataset('dataset_name_4/', use_legacy_dataset=False).files
     ['dataset_name_4/part-0.parquet']
     """

--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -2970,6 +2970,43 @@ def write_to_dataset(table, root_path, partition_cols=None,
         removed in a future version). The legacy implementation still
         supports `partition_filename_cb` and `metadata_collector` keywords
         but is less efficient when using partition columns.
+    format : FileFormat or str
+        The format in which to write the dataset. Currently supported:
+        "parquet", "ipc"/"arrow"/"feather", and "csv". If a FileSystemDataset
+        is being written and `format` is not specified, it defaults to the
+        same format as the specified FileSystemDataset. When writing a
+        Table or RecordBatch, this keyword is required.
+    file_options : pyarrow.dataset.FileWriteOptions, optional
+        FileFormat specific write options, created using the
+        ``FileFormat.make_write_options()`` function.
+    use_threads : bool, default True
+        Write files in parallel. If enabled, then maximum parallelism will be
+        used determined by the number of available CPU cores.
+    schema : Schema, optional
+    partitioning : Partitioning or list[str], optional
+        The partitioning scheme specified with the ``partitioning()``
+        function or a list of field names. When providing a list of
+        field names, you can use ``partitioning_flavor`` to drive which
+        partitioning type should be used.
+    file_visitor : function
+        If set, this function will be called with a WrittenFile instance
+        for each file created during the call.  This object will have both
+        a path attribute and a metadata attribute.
+
+        The path attribute will be a string containing the path to
+        the created file.
+
+        The metadata attribute will be the parquet metadata of the file.
+        This metadata will have the file path attribute set and can be used
+        to build a _metadata file.  The metadata attribute will be None if
+        the format is not parquet.
+
+        Example visitor which simple collects the filenames created::
+
+            visited_paths = []
+
+            def file_visitor(written_file):
+                visited_paths.append(written_file.path)
     **kwargs : dict,
         Additional kwargs for write_table function. See docstring for
         `write_table` or `ParquetWriter` for more information.

--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -3107,12 +3107,14 @@ def write_to_dataset(table, root_path, partition_cols=None,
         raise ValueError(msg2.format("use_threads"))
     if file_visitor is not None:
         raise ValueError(msg2.format("file_visitor"))
-    msg3 = (
-        " Specify 'use_legacy_dataset=False' while "
-        " constructing the ParquetDataset, and then use the "
-        "'basename_template' parameter instead. For usage see "
-        "`pyarrow.dataset.write_dataset`"
-    )
+    if partition_filename_cb is not None:
+        warnings.warn(
+            _DEPR_MSG.format("partition_filename_cb", " Specify "
+                "'use_legacy_dataset=False' while constructing "
+                "the ParquetDataset, and then use the "
+                "'basename_template' parameter instead. For usage "
+                "see `pyarrow.dataset.write_dataset`"),
+            FutureWarning, stacklevel=2)
 
     fs, root_path = legacyfs.resolve_filesystem_and_path(root_path, filesystem)
 
@@ -3147,11 +3149,6 @@ def write_to_dataset(table, root_path, partition_cols=None,
             _mkdir_if_not_exists(fs, '/'.join([root_path, subdir]))
             if partition_filename_cb:
                 outfile = partition_filename_cb(keys)
-
-                # raise for unsupported keywords
-                warnings.warn(
-                    _DEPR_MSG.format("partition_filename_cb", msg3),
-                    FutureWarning, stacklevel=2)
             else:
                 outfile = guid() + '.parquet'
             relative_path = '/'.join([subdir, outfile])
@@ -3164,11 +3161,6 @@ def write_to_dataset(table, root_path, partition_cols=None,
     else:
         if partition_filename_cb:
             outfile = partition_filename_cb(None)
-
-            # raise for unsupported keywords
-            warnings.warn(
-                _DEPR_MSG.format("partition_filename_cb", msg3),
-                FutureWarning, stacklevel=2)
         else:
             outfile = guid() + '.parquet'
         full_path = '/'.join([root_path, outfile])

--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -2974,10 +2974,11 @@ def write_to_dataset(table, root_path, partition_cols=None,
         used determined by the number of available CPU cores.
     schema : Schema, optional
     partitioning : Partitioning or list[str], optional
-        The partitioning scheme specified with the ``pyarrow.dataset.partitioning()``
-        function or a list of field names. When providing a list of
-        field names, you can use ``partitioning_flavor`` to drive which
-        partitioning type should be used.
+        The partitioning scheme specified with the
+        ``pyarrow.dataset.partitioning()`` function or a list of field names.
+        When providing a list of field names, you can use
+        ``partitioning_flavor`` to drive which partitioning type should be
+        used.
     basename_template : str, optional
         A template string used to generate basenames of written data files.
         The token '{i}' will be replaced with an automatically incremented

--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -3110,10 +3110,10 @@ def write_to_dataset(table, root_path, partition_cols=None,
     if partition_filename_cb is not None:
         warnings.warn(
             _DEPR_MSG.format("partition_filename_cb", " Specify "
-                "'use_legacy_dataset=False' while constructing "
-                "the ParquetDataset, and then use the "
-                "'basename_template' parameter instead. For usage "
-                "see `pyarrow.dataset.write_dataset`"),
+                             "'use_legacy_dataset=False' while constructing "
+                             "the ParquetDataset, and then use the "
+                             "'basename_template' parameter instead. For "
+                             "usage see `pyarrow.dataset.write_dataset`"),
             FutureWarning, stacklevel=2)
 
     fs, root_path = legacyfs.resolve_filesystem_and_path(root_path, filesystem)

--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -2926,7 +2926,7 @@ def _mkdir_if_not_exists(fs, path):
 
 def write_to_dataset(table, root_path, partition_cols=None,
                      partition_filename_cb=None, filesystem=None,
-                     use_legacy_dataset=False, **kwargs):
+                     use_legacy_dataset=None, **kwargs):
     """Wrapper around parquet.write_table for writing a Table to
     Parquet format by partitions.
     For each combination of partition columns and values,
@@ -3001,6 +3001,15 @@ def write_to_dataset(table, root_path, partition_cols=None,
     >>> pq.ParquetDataset('dataset_name_4/', use_legacy_dataset=False).files
     ['dataset_name_4/part-0.parquet']
     """
+    if use_legacy_dataset is None:
+        # if partition_filename_cb is specified ->
+        # default to the old implementation
+        if partition_filename_cb:
+            use_legacy_dataset = True
+        # otherwise the default is False
+        else:
+            use_legacy_dataset = False
+
     if not use_legacy_dataset:
         import pyarrow.dataset as ds
 

--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -2981,8 +2981,7 @@ def write_to_dataset(table, root_path, partition_cols=None,
     basename_template : str, optional
         A template string used to generate basenames of written data files.
         The token '{i}' will be replaced with an automatically incremented
-        integer. If not specified, it defaults to
-        "part-{i}." + format.default_extname
+        integer. If not specified, it defaults to "guid-{i}.parquet"
     file_visitor : function
         If set, this function will be called with a WrittenFile instance
         for each file created during the call.  This object will have both
@@ -3076,7 +3075,7 @@ def write_to_dataset(table, root_path, partition_cols=None,
             partitioning = ds.partitioning(part_schema, flavor="hive")
 
         if basename_template is None:
-            basename_template = guid() + '{i}.parquet'
+            basename_template = guid() + '-{i}.parquet'
 
         ds.write_dataset(
             table, root_path, filesystem=filesystem,

--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -2970,12 +2970,6 @@ def write_to_dataset(table, root_path, partition_cols=None,
         removed in a future version). The legacy implementation still
         supports `partition_filename_cb` and `metadata_collector` keywords
         but is less efficient when using partition columns.
-    format : FileFormat or str
-        The format in which to write the dataset. Currently supported:
-        "parquet", "ipc"/"arrow"/"feather", and "csv". If a FileSystemDataset
-        is being written and `format` is not specified, it defaults to the
-        same format as the specified FileSystemDataset. When writing a
-        Table or RecordBatch, this keyword is required.
     file_options : pyarrow.dataset.FileWriteOptions, optional
         FileFormat specific write options, created using the
         ``FileFormat.make_write_options()`` function.
@@ -3103,8 +3097,6 @@ def write_to_dataset(table, root_path, partition_cols=None,
         "'use_legacy_dataset=False' while constructing the "
         "ParquetDataset."
     )
-    if format is not None:
-        raise ValueError(msg2.format("format"))
     if file_options is not None:
         raise ValueError(msg2.format("file_options"))
     if schema is not None:

--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -2974,7 +2974,7 @@ def write_to_dataset(table, root_path, partition_cols=None,
         used determined by the number of available CPU cores.
     schema : Schema, optional
     partitioning : Partitioning or list[str], optional
-        The partitioning scheme specified with the ``partitioning()``
+        The partitioning scheme specified with the ``pyarrow.dataset.partitioning()``
         function or a list of field names. When providing a list of
         field names, you can use ``partitioning_flavor`` to drive which
         partitioning type should be used.

--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -3090,6 +3090,15 @@ def write_to_dataset(table, root_path, partition_cols=None,
             _mkdir_if_not_exists(fs, '/'.join([root_path, subdir]))
             if partition_filename_cb:
                 outfile = partition_filename_cb(keys)
+
+                # raise for unsupported keywords
+                warnings.warn(
+                    _DEPR_MSG.format("partition_filename_cb",
+                    " Specify 'use_legacy_dataset=False' while constructing the "
+                    "ParquetDataset, and then use the 'basename_template' "
+                    "parameter instead. For usage see "
+                    "`pyarrow.dataset.write_dataset`"),
+                    FutureWarning, stacklevel=2)
             else:
                 outfile = guid() + '.parquet'
             relative_path = '/'.join([subdir, outfile])
@@ -3105,7 +3114,11 @@ def write_to_dataset(table, root_path, partition_cols=None,
 
             # raise for unsupported keywords
             warnings.warn(
-                _DEPR_MSG.format("partition_filename_cb", ""),
+                _DEPR_MSG.format("partition_filename_cb",
+                " Specify 'use_legacy_dataset=False' while constructing the "
+                "ParquetDataset, and then use the 'basename_template' "
+                "parameter instead. For usage see "
+                "`pyarrow.dataset.write_dataset`"),
                 FutureWarning, stacklevel=2)
         else:
             outfile = guid() + '.parquet'

--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -2926,9 +2926,8 @@ def _mkdir_if_not_exists(fs, path):
 
 def write_to_dataset(table, root_path, partition_cols=None,
                      partition_filename_cb=None, filesystem=None,
-                     use_legacy_dataset=None, format=None,
-                     file_options=None, schema=None,
-                     partitioning=None, basename_template=None,
+                     use_legacy_dataset=None, file_options=None,
+                     schema=None, partitioning=None, basename_template=None,
                      use_threads=None, file_visitor=None, **kwargs):
     """Wrapper around parquet.write_dataset for writing a Table to
     Parquet format by partitions.

--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -3001,19 +3001,6 @@ def write_to_dataset(table, root_path, partition_cols=None,
     >>> pq.ParquetDataset('dataset_name_4/', use_legacy_dataset=False).files
     ['dataset_name_4/part-0.parquet']
     """
-    if use_legacy_dataset:
-        warnings.warn(
-            "Passing 'use_legacy_dataset=True' to get the legacy behaviour is "
-            "deprecated as of pyarrow 8.0.0, and the legacy implementation "
-            "will be removed in a future version.",
-            FutureWarning, stacklevel=2)
-
-        # raise for unsupported keywords
-        if partition_filename_cb is not None:
-            warnings.warn(
-                _DEPR_MSG.format("partition_filename_cb", ""),
-                FutureWarning, stacklevel=2)
-
     if not use_legacy_dataset:
         import pyarrow.dataset as ds
 
@@ -3053,6 +3040,13 @@ def write_to_dataset(table, root_path, partition_cols=None,
             partitioning=partitioning, use_threads=use_threads,
             file_visitor=file_visitor)
         return
+
+    if use_legacy_dataset:
+        warnings.warn(
+            "Passing 'use_legacy_dataset=True' to get the legacy behaviour is "
+            "deprecated as of pyarrow 8.0.0, and the legacy implementation "
+            "will be removed in a future version.",
+            FutureWarning, stacklevel=2)
 
     fs, root_path = legacyfs.resolve_filesystem_and_path(root_path, filesystem)
 
@@ -3099,6 +3093,11 @@ def write_to_dataset(table, root_path, partition_cols=None,
     else:
         if partition_filename_cb:
             outfile = partition_filename_cb(None)
+
+            # raise for unsupported keywords
+            warnings.warn(
+                _DEPR_MSG.format("partition_filename_cb", ""),
+                FutureWarning, stacklevel=2)
         else:
             outfile = guid() + '.parquet'
         full_path = '/'.join([root_path, outfile])

--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -2927,7 +2927,7 @@ def _mkdir_if_not_exists(fs, path):
 def write_to_dataset(table, root_path, partition_cols=None,
                      partition_filename_cb=None, filesystem=None,
                      use_legacy_dataset=None, **kwargs):
-    """Wrapper around parquet.write_table for writing a Table to
+    """Wrapper around parquet.write_dataset for writing a Table to
     Parquet format by partitions.
     For each combination of partition columns and values,
     a subdirectories are created in the following
@@ -2936,14 +2936,14 @@ def write_to_dataset(table, root_path, partition_cols=None,
     root_dir/
       group1=value1
         group2=value1
-          <uuid>.parquet
+          part-0.parquet
         group2=value2
-          <uuid>.parquet
+          part-0.parquet
       group1=valueN
         group2=value1
-          <uuid>.parquet
+          part-0.parquet
         group2=valueN
-          <uuid>.parquet
+          part-0.parquet
 
     Parameters
     ----------

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -1304,7 +1304,8 @@ def _test_write_to_dataset_no_partitions(base_path,
     # Without partitions, append files to root_path
     n = 5
     for i in range(n):
-        pq.write_to_dataset(output_table, base_path, use_legacy_dataset=True,
+        pq.write_to_dataset(output_table, base_path,
+                            use_legacy_dataset=use_legacy_dataset,
                             filesystem=filesystem)
     output_files = [file for file in filesystem.ls(str(base_path))
                     if file.endswith(".parquet")]
@@ -1544,9 +1545,10 @@ def test_dataset_read_dictionary(tempdir, use_legacy_dataset):
     path = tempdir / "ARROW-3325-dataset"
     t1 = pa.table([[util.rands(10) for i in range(5)] * 10], names=['f0'])
     t2 = pa.table([[util.rands(10) for i in range(5)] * 10], names=['f0'])
-    # TODO pass use_legacy_dataset (need to fix unique names)
-    pq.write_to_dataset(t1, root_path=str(path), use_legacy_dataset=True)
-    pq.write_to_dataset(t2, root_path=str(path), use_legacy_dataset=True)
+    pq.write_to_dataset(t1, root_path=str(path),
+                        use_legacy_dataset=use_legacy_dataset)
+    pq.write_to_dataset(t2, root_path=str(path),
+                        use_legacy_dataset=use_legacy_dataset)
 
     result = pq.ParquetDataset(
         path, read_dictionary=['f0'],
@@ -1739,10 +1741,6 @@ def test_parquet_write_to_dataset_deprecated_properties(tempdir):
 def test_parquet_write_to_dataset_unsupported_keywards_in_legacy(tempdir):
     table = pa.table({'a': [1, 2, 3]})
     path = tempdir / 'data.parquet'
-
-    with pytest.raises(ValueError, match="file_options"):
-        pq.write_to_dataset(table, path, use_legacy_dataset=True,
-                            file_options=True)
 
     with pytest.raises(ValueError, match="schema"):
         pq.write_to_dataset(table, path, use_legacy_dataset=True,

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -1717,14 +1717,17 @@ def test_parquet_dataset_deprecated_properties(tempdir):
     with pytest.warns(DeprecationWarning, match="'ParquetDataset.pieces"):
         dataset2.pieces
 
+
 @pytest.mark.dataset
 def test_parquet_write_to_dataset_deprecated_properties(tempdir):
     table = pa.table({'a': [1, 2, 3]})
     path = tempdir / 'data.parquet'
 
-    with pytest.warns(FutureWarning, match="Passing 'use_legacy_dataset=True'"):
+    with pytest.warns(FutureWarning,
+                      match="Passing 'use_legacy_dataset=True'"):
         pq.write_to_dataset(table, path, use_legacy_dataset=True)
 
-    with pytest.warns(FutureWarning, match="Passing 'use_legacy_dataset=True'"):
+    with pytest.warns(FutureWarning,
+                      match="Passing 'use_legacy_dataset=True'"):
         pq.write_to_dataset(table, path, use_legacy_dataset=True,
-                            partition_filename_cb=lambda x: 'file_name.parquet')
+                            partition_filename_cb=lambda x: 'filename.parquet')

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -1727,7 +1727,41 @@ def test_parquet_write_to_dataset_deprecated_properties(tempdir):
                       match="Passing 'use_legacy_dataset=True'"):
         pq.write_to_dataset(table, path, use_legacy_dataset=True)
 
+    # check also that legacy implementation is set when
+    # partition_filename_cb is specified
     with pytest.warns(FutureWarning,
                       match="Passing 'use_legacy_dataset=True'"):
-        pq.write_to_dataset(table, path, use_legacy_dataset=True,
+        pq.write_to_dataset(table, path,
                             partition_filename_cb=lambda x: 'filename.parquet')
+
+
+@pytest.mark.dataset
+def test_parquet_write_to_dataset_unsupported_keywards_in_legacy(tempdir):
+    table = pa.table({'a': [1, 2, 3]})
+    path = tempdir / 'data.parquet'
+
+    with pytest.raises(ValueError, match="format"):
+        pq.write_to_dataset(table, path, use_legacy_dataset=True,
+                            format="ipc")
+
+    with pytest.raises(ValueError, match="file_options"):
+        pq.write_to_dataset(table, path, use_legacy_dataset=True,
+                            file_options=True)
+
+    with pytest.raises(ValueError, match="schema"):
+        pq.write_to_dataset(table, path, use_legacy_dataset=True,
+                            schema=pa.schema([
+                                ('a', pa.int32())
+                            ]))
+
+    with pytest.raises(ValueError, match="partitioning"):
+        pq.write_to_dataset(table, path, use_legacy_dataset=True,
+                            partitioning=["a"])
+
+    with pytest.raises(ValueError, match="use_threads"):
+        pq.write_to_dataset(table, path, use_legacy_dataset=True,
+                            use_threads=False)
+
+    with pytest.raises(ValueError, match="file_visitor"):
+        pq.write_to_dataset(table, path, use_legacy_dataset=True,
+                            file_visitor=lambda x: x)

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -1740,10 +1740,6 @@ def test_parquet_write_to_dataset_unsupported_keywards_in_legacy(tempdir):
     table = pa.table({'a': [1, 2, 3]})
     path = tempdir / 'data.parquet'
 
-    with pytest.raises(ValueError, match="format"):
-        pq.write_to_dataset(table, path, use_legacy_dataset=True,
-                            format="ipc")
-
     with pytest.raises(ValueError, match="file_options"):
         pq.write_to_dataset(table, path, use_legacy_dataset=True,
                             file_options=True)

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -1304,7 +1304,7 @@ def _test_write_to_dataset_no_partitions(base_path,
     # Without partitions, append files to root_path
     n = 5
     for i in range(n):
-        pq.write_to_dataset(output_table, base_path,
+        pq.write_to_dataset(output_table, base_path, use_legacy_dataset=True,
                             filesystem=filesystem)
     output_files = [file for file in filesystem.ls(str(base_path))
                     if file.endswith(".parquet")]
@@ -1545,8 +1545,8 @@ def test_dataset_read_dictionary(tempdir, use_legacy_dataset):
     t1 = pa.table([[util.rands(10) for i in range(5)] * 10], names=['f0'])
     t2 = pa.table([[util.rands(10) for i in range(5)] * 10], names=['f0'])
     # TODO pass use_legacy_dataset (need to fix unique names)
-    pq.write_to_dataset(t1, root_path=str(path))
-    pq.write_to_dataset(t2, root_path=str(path))
+    pq.write_to_dataset(t1, root_path=str(path), use_legacy_dataset=True)
+    pq.write_to_dataset(t2, root_path=str(path), use_legacy_dataset=True)
 
     result = pq.ParquetDataset(
         path, read_dictionary=['f0'],
@@ -1716,3 +1716,15 @@ def test_parquet_dataset_deprecated_properties(tempdir):
 
     with pytest.warns(DeprecationWarning, match="'ParquetDataset.pieces"):
         dataset2.pieces
+
+@pytest.mark.dataset
+def test_parquet_write_to_dataset_deprecated_properties(tempdir):
+    table = pa.table({'a': [1, 2, 3]})
+    path = tempdir / 'data.parquet'
+
+    with pytest.warns(FutureWarning, match="Passing 'use_legacy_dataset=True'"):
+        pq.write_to_dataset(table, path, use_legacy_dataset=True)
+
+    with pytest.warns(FutureWarning, match="Passing 'use_legacy_dataset=True'"):
+        pq.write_to_dataset(table, path, use_legacy_dataset=True,
+                            partition_filename_cb=lambda x: 'file_name.parquet')

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -3047,8 +3047,7 @@ def _create_parquet_dataset_simple(root_path):
     for i in range(4):
         table = pa.table({'f1': [i] * 10, 'f2': np.random.randn(10)})
         pq.write_to_dataset(
-            table, str(root_path), use_legacy_dataset=True,
-            metadata_collector=metadata_collector
+            table, str(root_path), metadata_collector=metadata_collector
         )
 
     metadata_path = str(root_path / '_metadata')

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -971,7 +971,7 @@ def _create_dataset_for_fragments(tempdir, chunk_size=None, filesystem=None):
     path = str(tempdir / "test_parquet_dataset")
 
     # write_to_dataset currently requires pandas
-    pq.write_to_dataset(table, path,
+    pq.write_to_dataset(table, path, use_legacy_dataset=True,
                         partition_cols=["part"], chunk_size=chunk_size)
     dataset = ds.dataset(
         path, format="parquet", partitioning="hive", filesystem=filesystem
@@ -1247,7 +1247,8 @@ def _create_dataset_all_types(tempdir, chunk_size=None):
     path = str(tempdir / "test_parquet_dataset_all_types")
 
     # write_to_dataset currently requires pandas
-    pq.write_to_dataset(table, path, chunk_size=chunk_size)
+    pq.write_to_dataset(table, path, use_legacy_dataset=True,
+                        chunk_size=chunk_size)
 
     return table, ds.dataset(path, format="parquet", partitioning="hive")
 
@@ -3046,7 +3047,8 @@ def _create_parquet_dataset_simple(root_path):
     for i in range(4):
         table = pa.table({'f1': [i] * 10, 'f2': np.random.randn(10)})
         pq.write_to_dataset(
-            table, str(root_path), metadata_collector=metadata_collector
+            table, str(root_path), use_legacy_dataset=True,
+            metadata_collector=metadata_collector
         )
 
     metadata_path = str(root_path / '_metadata')


### PR DESCRIPTION
This PR tries to amend `pq.write_to_dataset` to:

1. raise a deprecation warning for `use_legacy_dataset=True` and already switch the default to `False`.
2. raise deprecation warnings for all keywords (when `use_legacy_dataset=True`) that won't be supported in the new implementation.