### PR TITLE
ARROW-16131 [C++] support saving and retrieving custom metadata in batches for IPC file

### DIFF
--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -654,7 +654,7 @@ Result<std::shared_ptr<RecordBatch>> ReadRecordBatch(
                          reader.get());
 }
 
-Result<std::shared_ptr<RecordBatch>> ReadRecordBatchInternal(
+Result<RecordBatchWithMetadata> ReadRecordBatchInternal(
     const Buffer& metadata, const std::shared_ptr<Schema>& schema,
     const std::vector<bool>& inclusion_mask, IpcReadContext& context,
     io::RandomAccessFile* file) {
@@ -676,7 +676,15 @@ Result<std::shared_ptr<RecordBatch>> ReadRecordBatchInternal(
   }
   context.compression = compression;
   context.metadata_version = internal::GetMetadataVersion(message->version());
-  return LoadRecordBatch(batch, schema, inclusion_mask, context, file);
+
+  std::shared_ptr<KeyValueMetadata> custom_metadata;
+  if (message->custom_metadata() != nullptr) {
+    RETURN_NOT_OK(
+        internal::GetKeyValueMetadata(message->custom_metadata(), &custom_metadata));
+  }
+  ARROW_ASSIGN_OR_RAISE(auto record_batch,
+                        LoadRecordBatch(batch, schema, inclusion_mask, context, file));
+  return RecordBatchWithMetadata{record_batch, custom_metadata};
 }
 
 // If we are selecting only certain fields, populate an inclusion mask for fast lookups.
@@ -756,7 +764,10 @@ Result<std::shared_ptr<RecordBatch>> ReadRecordBatch(
   IpcReadContext context(const_cast<DictionaryMemo*>(dictionary_memo), options, false);
   RETURN_NOT_OK(GetInclusionMaskAndOutSchema(schema, context.options.included_fields,
                                              &inclusion_mask, &out_schema));
-  return ReadRecordBatchInternal(metadata, schema, inclusion_mask, context, file);
+  ARROW_ASSIGN_OR_RAISE(
+      auto batch_and_custom_metadata,
+      ReadRecordBatchInternal(metadata, schema, inclusion_mask, context, file));
+  return batch_and_custom_metadata.batch;
 }
 
 Status ReadDictionary(const Buffer& metadata, const IpcReadContext& context,
@@ -852,15 +863,21 @@ class RecordBatchStreamReaderImpl : public RecordBatchStreamReader {
   }
 
   Status ReadNext(std::shared_ptr<RecordBatch>* batch) override {
+    ARROW_ASSIGN_OR_RAISE(auto batch_with_metadata, ReadNext());
+    *batch = std::move(batch_with_metadata.batch);
+    return Status::OK();
+  }
+
+  Result<RecordBatchWithMetadata> ReadNext() override {
     if (!have_read_initial_dictionaries_) {
       RETURN_NOT_OK(ReadInitialDictionaries());
     }
 
+    RecordBatchWithMetadata batch_with_metadata;
     if (empty_stream_) {
       // ARROW-6006: Degenerate case where stream contains no data, we do not
       // bother trying to read a RecordBatch message from the stream
-      *batch = nullptr;
-      return Status::OK();
+      return batch_with_metadata;
     }
 
     // Continue to read other dictionaries, if any
@@ -874,16 +891,17 @@ class RecordBatchStreamReaderImpl : public RecordBatchStreamReader {
 
     if (message == nullptr) {
       // End of stream
-      *batch = nullptr;
-      return Status::OK();
+      return batch_with_metadata;
     }
 
     CHECK_HAS_BODY(*message);
     ARROW_ASSIGN_OR_RAISE(auto reader, Buffer::GetReader(message->body()));
     IpcReadContext context(&dictionary_memo_, options_, swap_endian_);
-    return ReadRecordBatchInternal(*message->metadata(), schema_, field_inclusion_mask_,
-                                   context, reader.get())
-        .Value(batch);
+    ARROW_ASSIGN_OR_RAISE(
+        batch_with_metadata,
+        ReadRecordBatchInternal(*message->metadata(), schema_, field_inclusion_mask_,
+                                context, reader.get()));
+    return batch_with_metadata;
   }
 
   std::shared_ptr<Schema> schema() const override { return out_schema_; }
@@ -1158,12 +1176,30 @@ class RecordBatchFileReaderImpl : public RecordBatchFileReader {
   }
 
   Result<std::shared_ptr<RecordBatch>> ReadRecordBatch(int i) override {
+    ARROW_ASSIGN_OR_RAISE(auto batch_with_metadata, ReadRecordBatchWithCustomMetadata(i));
+    return batch_with_metadata.batch;
+  }
+
+  Result<RecordBatchWithMetadata> ReadRecordBatchWithCustomMetadata(int i) override {
     DCHECK_GE(i, 0);
     DCHECK_LT(i, num_record_batches());
 
     auto cached_metadata = cached_metadata_.find(i);
     if (cached_metadata != cached_metadata_.end()) {
-      return ReadCachedRecordBatch(i, cached_metadata->second).result();
+      auto result = ReadCachedRecordBatch(i, cached_metadata->second).result();
+      if (result.ok()) {
+        auto batch = result.ValueOrDie();
+        ARROW_ASSIGN_OR_RAISE(auto message_obj, cached_metadata->second.result());
+        ARROW_ASSIGN_OR_RAISE(auto message, GetFlatbufMessage(message_obj));
+        std::shared_ptr<KeyValueMetadata> custom_metadata;
+        if (message->custom_metadata() != nullptr) {
+          RETURN_NOT_OK(internal::GetKeyValueMetadata(message->custom_metadata(),
+                                                      &custom_metadata));
+        }
+        return RecordBatchWithMetadata{std::move(batch), std::move(custom_metadata)};
+      } else {
+        return result.status();
+      }
     }
 
     RETURN_NOT_OK(WaitForDictionaryReadFinished());
@@ -1185,11 +1221,12 @@ class RecordBatchFileReaderImpl : public RecordBatchFileReader {
     CHECK_HAS_BODY(*message);
     ARROW_ASSIGN_OR_RAISE(auto reader, Buffer::GetReader(message->body()));
     IpcReadContext context(&dictionary_memo_, options_, swap_endian_);
-    ARROW_ASSIGN_OR_RAISE(auto batch, ReadRecordBatchInternal(
-                                          *message->metadata(), schema_,
-                                          field_inclusion_mask_, context, reader.get()));
+    ARROW_ASSIGN_OR_RAISE(
+        auto batch_with_metadata,
+        ReadRecordBatchInternal(*message->metadata(), schema_, field_inclusion_mask_,
+                                context, reader.get()));
     ++stats_.num_record_batches;
-    return batch;
+    return batch_with_metadata;
   }
 
   Result<int64_t> CountRows() override {
@@ -1832,8 +1869,11 @@ Result<std::shared_ptr<RecordBatch>> WholeIpcFileRecordBatchGenerator::ReadRecor
   CHECK_HAS_BODY(*message);
   ARROW_ASSIGN_OR_RAISE(auto reader, Buffer::GetReader(message->body()));
   IpcReadContext context(&state->dictionary_memo_, state->options_, state->swap_endian_);
-  return ReadRecordBatchInternal(*message->metadata(), state->schema_,
-                                 state->field_inclusion_mask_, context, reader.get());
+  ARROW_ASSIGN_OR_RAISE(
+      auto batch_with_metadata,
+      ReadRecordBatchInternal(*message->metadata(), state->schema_,
+                              state->field_inclusion_mask_, context, reader.get()));
+  return batch_with_metadata.batch;
 }
 
 Status Listener::OnEOS() { return Status::OK(); }
@@ -1938,11 +1978,11 @@ class StreamDecoder::StreamDecoderImpl : public MessageDecoderListener {
       ARROW_ASSIGN_OR_RAISE(auto reader, Buffer::GetReader(message->body()));
       IpcReadContext context(&dictionary_memo_, options_, swap_endian_);
       ARROW_ASSIGN_OR_RAISE(
-          auto batch,
+          auto batch_with_metadata,
           ReadRecordBatchInternal(*message->metadata(), schema_, field_inclusion_mask_,
                                   context, reader.get()));
       ++stats_.num_record_batches;
-      return listener_->OnRecordBatchDecoded(std::move(batch));
+      return listener_->OnRecordBatchDecoded(std::move(batch_with_metadata.batch));
     }
   }
 

--- a/cpp/src/arrow/ipc/reader.h
+++ b/cpp/src/arrow/ipc/reader.h
@@ -190,6 +190,13 @@ class ARROW_EXPORT RecordBatchFileReader
   /// \return the read batch
   virtual Result<std::shared_ptr<RecordBatch>> ReadRecordBatch(int i) = 0;
 
+  /// \brief Read a particular record batch along with its custom metadada from the file.
+  /// Does not copy memory if the input source supports zero-copy.
+  ///
+  /// \param[in] i the index of the record batch to return
+  /// \return a struct containing the read batch and its custom metadata
+  virtual Result<RecordBatchWithMetadata> ReadRecordBatchWithCustomMetadata(int i) = 0;
+
   /// \brief Return current read statistics
   virtual ReadStats stats() const = 0;
 

--- a/cpp/src/arrow/ipc/writer.h
+++ b/cpp/src/arrow/ipc/writer.h
@@ -96,6 +96,18 @@ class ARROW_EXPORT RecordBatchWriter {
   /// \return Status
   virtual Status WriteRecordBatch(const RecordBatch& batch) = 0;
 
+  /// \brief Write a record batch with custom metadata to the stream
+  ///
+  /// \param[in] batch the record batch to write to the stream
+  /// \param[in] custom_metadata the record batch's custom metadata to write to the stream
+  /// \return Status
+  virtual Status WriteRecordBatch(
+      const RecordBatch& batch,
+      const std::shared_ptr<const KeyValueMetadata>& custom_metadata) {
+    return Status::NotImplemented(
+        "Write record batch with custom metadata not implemented");
+  }
+
   /// \brief Write possibly-chunked table by creating sequence of record batches
   /// \param[in] table table to write
   /// \return Status
@@ -388,6 +400,18 @@ Status GetDictionaryPayload(int64_t id, bool is_delta,
 ARROW_EXPORT
 Status GetRecordBatchPayload(const RecordBatch& batch, const IpcWriteOptions& options,
                              IpcPayload* out);
+
+/// \brief Compute IpcPayload for the given record batch and custom metadata
+/// \param[in] batch the RecordBatch that is being serialized
+/// \param[in] custom_metadata the custom metadata to be serialized with the record batch
+/// \param[in] options options for serialization
+/// \param[out] out the returned IpcPayload
+/// \return Status
+ARROW_EXPORT
+Status GetRecordBatchPayload(
+    const RecordBatch& batch,
+    const std::shared_ptr<const KeyValueMetadata>& custom_metadata,
+    const IpcWriteOptions& options, IpcPayload* out);
 
 /// \brief Write an IPC payload to the given stream.
 /// \param[in] payload the payload to write

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -210,6 +210,11 @@ class ARROW_EXPORT RecordBatch {
   ARROW_DISALLOW_COPY_AND_ASSIGN(RecordBatch);
 };
 
+struct ARROW_EXPORT RecordBatchWithMetadata {
+  std::shared_ptr<RecordBatch> batch;
+  std::shared_ptr<KeyValueMetadata> custom_metadata;
+};
+
 /// \brief Abstract interface for reading stream of record batches
 class ARROW_EXPORT RecordBatchReader {
  public:
@@ -226,6 +231,10 @@ class ARROW_EXPORT RecordBatchReader {
   /// \param[out] batch the next loaded batch, null at end of stream
   /// \return Status
   virtual Status ReadNext(std::shared_ptr<RecordBatch>* batch) = 0;
+
+  virtual Result<RecordBatchWithMetadata> ReadNext() {
+    return Status::NotImplemented("ReadNext with custom metadata");
+  }
 
   /// \brief Iterator interface
   Result<std::shared_ptr<RecordBatch>> Next() {


### PR DESCRIPTION
This PR aims to address https://issues.apache.org/jira/projects/ARROW/issues/ARROW-16131

Currently, when writing an IPC file with multiple record batches using the `arrow::ipc::RecordBatchWriter`, the `custom_metadata` for each record batch is not saved and will be discarded silently. 

The current writer does provide the `AppendCustomMetadata` API internally, but it is never called. I use this API to add the custom metadata during writing and retrieve the custom metadata when reading the record batch. I am not completely sure if this is intentionally ignored or accidentally missing, but from a user's perspective, the metadata can be set via public API (see the example case in ARROW-16131) and I think it is not very friendly that this piece of data is silently discarded.

Several test cases are added in the `read_write_test.cc` for verifying this change. 

