### PR TITLE
ARROW-16025: [Python][C++] Fix segmentation fault when closing ORCFileWritter

### DIFF
--- a/cpp/src/arrow/adapters/orc/adapter.cc
+++ b/cpp/src/arrow/adapters/orc/adapter.cc
@@ -837,7 +837,9 @@ class ORCFileWriter::Impl {
   }
 
   Status Close() {
-    writer_->close();
+    if (writer_) {
+      writer_->close();
+    }
     return Status::OK();
   }
 

--- a/cpp/src/arrow/adapters/orc/adapter_test.cc
+++ b/cpp/src/arrow/adapters/orc/adapter_test.cc
@@ -253,23 +253,6 @@ void AssertTableWriteReadEqual(const std::shared_ptr<Table>& input_table,
   AssertTablesEqual(*expected_output_table, *actual_output_table, false, false);
 }
 
-void TestORCWriterNoWrite(const int64_t max_size = kDefaultSmallMemStreamSize) {
-  EXPECT_OK_AND_ASSIGN(auto buffer_output_stream,
-                       io::BufferOutputStream::Create(max_size));
-  auto write_options = adapters::orc::WriteOptions();
-#ifdef ARROW_WITH_SNAPPY
-  write_options.compression = Compression::SNAPPY;
-#else
-  write_options.compression = Compression::UNCOMPRESSED;
-#endif
-  write_options.file_version = adapters::orc::FileVersion(0, 11);
-  write_options.compression_block_size = 32768;
-  write_options.row_index_stride = 5000;
-  EXPECT_OK_AND_ASSIGN(auto writer, adapters::orc::ORCFileWriter::Open(
-                                        buffer_output_stream.get(), write_options));
-  ARROW_EXPECT_OK(writer->Close());
-}
-
 void AssertArrayWriteReadEqual(const std::shared_ptr<Array>& input_array,
                                const std::shared_ptr<Array>& expected_output_array,
                                const int64_t max_size = kDefaultSmallMemStreamSize) {
@@ -425,7 +408,20 @@ TEST(TestAdapterRead, ReadIntAndStringFileMultipleStripes) {
 
 class TestORCWriterTrivialNoWrite : public ::testing::Test {};
 TEST_F(TestORCWriterTrivialNoWrite, noWrite) {
-  TestORCWriterNoWrite(kDefaultSmallMemStreamSize / 16);
+  EXPECT_OK_AND_ASSIGN(auto buffer_output_stream,
+                       io::BufferOutputStream::Create(kDefaultSmallMemStreamSize / 16));
+  auto write_options = adapters::orc::WriteOptions();
+#ifdef ARROW_WITH_SNAPPY
+  write_options.compression = Compression::SNAPPY;
+#else
+  write_options.compression = Compression::UNCOMPRESSED;
+#endif
+  write_options.file_version = adapters::orc::FileVersion(0, 11);
+  write_options.compression_block_size = 32768;
+  write_options.row_index_stride = 5000;
+  EXPECT_OK_AND_ASSIGN(auto writer, adapters::orc::ORCFileWriter::Open(
+                                        buffer_output_stream.get(), write_options));
+  ARROW_EXPECT_OK(writer->Close());
 }
 class TestORCWriterTrivialNoConversion : public ::testing::Test {
  public:

--- a/python/pyarrow/tests/test_orc.py
+++ b/python/pyarrow/tests/test_orc.py
@@ -614,6 +614,7 @@ def test_column_selection(tempdir):
     with pytest.raises(ValueError):
         orc_file.read(columns=[5])
 
+
 def test_wrong_usage_orc_writer(tempdir):
     from pyarrow import orc
 

--- a/python/pyarrow/tests/test_orc.py
+++ b/python/pyarrow/tests/test_orc.py
@@ -622,3 +622,14 @@ def test_wrong_usage_orc_writer(tempdir):
     with orc.ORCWriter(path) as writer:
         with pytest.raises(AttributeError):
             writer.test()
+
+def test_orc_writer_with_null_arrays(tempdir):
+    from pyarrow import orc
+    import pyarrow as pa
+
+    path = str(tempdir / 'test.orc')
+    a = pa.array([1, None, 3, None])
+    b = pa.array([None, None, None, None])
+    table = pa.table({"int64": a, "utf8": b})
+    with pytest.raises(pa.ArrowNotImplementedError):
+        orc.write_table(table, path)

--- a/python/pyarrow/tests/test_orc.py
+++ b/python/pyarrow/tests/test_orc.py
@@ -613,3 +613,11 @@ def test_column_selection(tempdir):
 
     with pytest.raises(ValueError):
         orc_file.read(columns=[5])
+
+def test_wrong_usage_orc_writer(tempdir):
+    from pyarrow import orc
+
+    path = str(tempdir / 'test.orc')
+    with orc.ORCWriter(path) as writer:
+        with pytest.raises(AttributeError):
+            writer.test()

--- a/python/pyarrow/tests/test_orc.py
+++ b/python/pyarrow/tests/test_orc.py
@@ -623,6 +623,7 @@ def test_wrong_usage_orc_writer(tempdir):
         with pytest.raises(AttributeError):
             writer.test()
 
+
 def test_orc_writer_with_null_arrays(tempdir):
     from pyarrow import orc
     import pyarrow as pa


### PR DESCRIPTION
This PR fixes ARROW-16025 (Calling nonexistent method of pyarrow.orc.ORCWriter causes segfault).

The segmentation fault can be reproduced with the test:
```python
def test_wrong_usage_orc_writer(tempdir):
    from pyarrow import orc

    path = str(tempdir / 'test.orc')
    with orc.ORCWriter(path) as writer:
        with pytest.raises(AttributeError):
            writer.test()
```

The issue was that closing `ORCFileWriter` without actually writing was trying to close a null writer (`writer_->close();`) causing the segmentation fault.