### PR TITLE
MINOR: [R] Fix compiler warning/CMD check NOTE when compiling with ARROW_R_WITH_ENGINE

### DIFF
--- a/r/src/compute-exec.cpp
+++ b/r/src/compute-exec.cpp
@@ -301,7 +301,7 @@ class AccumulatingConsumer : public compute::SinkNodeConsumer {
  public:
   const std::vector<std::shared_ptr<arrow::RecordBatch>>& batches() { return batches_; }
 
-  arrow::Status Init(const std::shared_ptr<arrow::Schema>& schema) {
+  arrow::Status Init(const std::shared_ptr<arrow::Schema>& schema) override {
     schema_ = schema;
     return arrow::Status::OK();
   }


### PR DESCRIPTION
After ARROW-16033 (#12721) we get this compiler warning when compiling with `ARROW_R_WITH_ENGINE`:

```
   compute-exec.cpp:304:17: warning: 'Init' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
     arrow::Status Init(const std::shared_ptr<arrow::Schema>& schema) {
                   ^
   /Users/deweydunnington/.r-arrow-dev-build/dist/include/arrow/compute/exec/options.h:153:18: note: overridden virtual function is here
     virtual Status Init(const std::shared_ptr<Schema>& schema) = 0;
                    ^
   1 warning generated.
```

This PR just adds the requisite `override`.