### PR TITLE
MINOR: [C++] Fix typo that causes segfault when unknown functions are passed to Substrait

### DIFF
--- a/cpp/src/arrow/engine/substrait/extension_set.cc
+++ b/cpp/src/arrow/engine/substrait/extension_set.cc
@@ -164,7 +164,7 @@ Result<ExtensionSet> ExtensionSet::Make(std::vector<util::string_view> uris,
       set.functions_[i] = {rec->id, rec->function_name};
       continue;
     }
-    return Status::Invalid("Function ", function_ids[i].uri, "#", type_ids[i].name,
+    return Status::Invalid("Function ", function_ids[i].uri, "#", function_ids[i].name,
                            " not found");
   }
 


### PR DESCRIPTION
I'm not sure if this is outside the scope of MINOR (I'm also happy to create a JIRA), but there's a typo in `ExtensionSet::Make()` that causes a crash whenever somebody provides an unsupported function into the Substrait consumer.

Reprex (after the change in this PR...before this change it segfaults):

``` r
arrow:::do_exec_plan_substrait('
{
  "extensionUris": [
    {
      "extensionUriAnchor": 1
    }
  ],
  "extensions": [
    {
      "extensionFunction": {
        "extensionUriReference": 1,
        "functionAnchor": 2,
        "name": "abs_checked"
      }
    }
  ],
  "relations": [
    {
      "rel": {
        "project": {
          "input": {
            "read": {
              "baseSchema": {
                "names": [
                  "letter",
                  "number"
                ],
                "struct": {
                  "types": [
                    {
                      "string": {

                      }
                    },
                    {
                      "i32": {

                      }
                    }
                  ]
                }
              },
              "namedTable": {
                "names": [
                  "named_table_1"
                ]
              }
            }
          },
          "expressions": [
            {
              "scalarFunction": {
                "functionReference": 2,
                "args": [
                  {
                    "selection": {
                      "directReference": {
                        "structField": {
                          "field": 1
                        }
                      }
                    }
                  }
                ],
                "outputType": {

                }
              }
            }
          ]
        }
      }
    }
  ]
}
')
#> Error: Invalid: Uri  was referenced by an extension but was not declared in the ExtensionSet.
#> /Users/deweydunnington/Desktop/rscratch/arrow/cpp/src/arrow/engine/substrait/extension_set.cc:161  set.impl_->CheckHasUri(function_ids[i].uri)
#> /Users/deweydunnington/Desktop/rscratch/arrow/cpp/src/arrow/engine/substrait/serde.cc:66  GetExtensionSetFromPlan(plan)
```

<sup>Created on 2022-04-07 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>