### PR TITLE
ARROW-15879: [R] passing a schema calls open_dataset to fail on hive-partitioned csv files

### DIFF
--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -495,6 +495,7 @@ test_that("Including partition columns in schema and partitioning, hive style CS
     partitioning = "cyl"
   )
   expect_equal(mtcars_ds$schema, tab$schema)
+  expect_equal(collect(mtcars_ds), mtcars)
 })
 
 test_that("partitioning = NULL to ignore partition information (but why?)", {


### PR DESCRIPTION
This is a WIP that introduces a failing test for csv schema reading. I _think_ this is a duplicate of this ticket: https://issues.apache.org/jira/browse/ARROW-14743