### PR TITLE
ARROW-16152: [C++] Fix segfault with unknown functions in Substrait

### DIFF
--- a/cpp/src/arrow/engine/substrait/extension_set.cc
+++ b/cpp/src/arrow/engine/substrait/extension_set.cc
@@ -164,7 +164,7 @@ Result<ExtensionSet> ExtensionSet::Make(std::vector<util::string_view> uris,
       set.functions_[i] = {rec->id, rec->function_name};
       continue;
     }
-    return Status::Invalid("Function ", function_ids[i].uri, "#", type_ids[i].name,
+    return Status::Invalid("Function ", function_ids[i].uri, "#", function_ids[i].name,
                            " not found");
   }
 

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -724,5 +724,31 @@ TEST(Substrait, ExtensionSetFromPlan) {
   EXPECT_EQ(decoded_add_func.name, "add");
 }
 
+TEST(Substrait, ExtensionSetFromPlanMissinFunc) {
+  ASSERT_OK_AND_ASSIGN(auto buf, internal::SubstraitFromJSON("Plan", R"({
+    "relations": [],
+    "extension_uris": [
+      {
+        "extension_uri_anchor": 7,
+        "uri": "https://github.com/apache/arrow/blob/master/format/substrait/extension_types.yaml"
+      }
+    ],
+    "extensions": [
+      {"extension_function": {
+        "extension_uri_reference": 7,
+        "function_anchor": 42,
+        "name": "does_not_exist"
+      }}
+    ]
+  })"));
+
+  ExtensionSet ext_set;
+  ASSERT_RAISES(
+      Invalid,
+      DeserializePlan(
+          *buf, [] { return std::shared_ptr<compute::SinkNodeConsumer>{nullptr}; },
+          &ext_set));
+}
+
 }  // namespace engine
 }  // namespace arrow

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -724,7 +724,7 @@ TEST(Substrait, ExtensionSetFromPlan) {
   EXPECT_EQ(decoded_add_func.name, "add");
 }
 
-TEST(Substrait, ExtensionSetFromPlanMissinFunc) {
+TEST(Substrait, ExtensionSetFromPlanMissingFunc) {
   ASSERT_OK_AND_ASSIGN(auto buf, internal::SubstraitFromJSON("Plan", R"({
     "relations": [],
     "extension_uris": [


### PR DESCRIPTION
Revised from #12828 with proper JIRA and unit test!

Reprex (after the change in this PR...before this change it segfaults):

``` r
arrow:::do_exec_plan_substrait('
{
  "extensionUris": [
    {
      "extensionUriAnchor": 1
    }
  ],
  "extensions": [
    {
      "extensionFunction": {
        "extensionUriReference": 1,
        "functionAnchor": 2,
        "name": "abs_checked"
      }
    }
  ],
  "relations": [
    {
      "rel": {
        "project": {
          "input": {
            "read": {
              "baseSchema": {
                "names": [
                  "letter",
                  "number"
                ],
                "struct": {
                  "types": [
                    {
                      "string": {

                      }
                    },
                    {
                      "i32": {

                      }
                    }
                  ]
                }
              },
              "namedTable": {
                "names": [
                  "named_table_1"
                ]
              }
            }
          },
          "expressions": [
            {
              "scalarFunction": {
                "functionReference": 2,
                "args": [
                  {
                    "selection": {
                      "directReference": {
                        "structField": {
                          "field": 1
                        }
                      }
                    }
                  }
                ],
                "outputType": {

                }
              }
            }
          ]
        }
      }
    }
  ]
}
')
#> Error: Invalid: Uri  was referenced by an extension but was not declared in the ExtensionSet.
#> /Users/deweydunnington/Desktop/rscratch/arrow/cpp/src/arrow/engine/substrait/extension_set.cc:161  set.impl_->CheckHasUri(function_ids[i].uri)
#> /Users/deweydunnington/Desktop/rscratch/arrow/cpp/src/arrow/engine/substrait/serde.cc:66  GetExtensionSetFromPlan(plan)
```
