### PR TITLE
ARROW-15905: [Python][C++] Fix CMake warning when building PyArrow

### DIFF
--- a/cpp/cmake_modules/FindArrow.cmake
+++ b/cpp/cmake_modules/FindArrow.cmake
@@ -36,7 +36,7 @@ if(DEFINED ARROW_FOUND)
   return()
 endif()
 
-include(FindPkgConfig)
+find_package(PkgConfig)
 include(FindPackageHandleStandardArgs)
 
 if(WIN32 AND NOT MINGW)


### PR DESCRIPTION
Use `find_package` to add `FindPkgConfig.cmake` instead of `include(FindPkgConfig)` to avoid warning being raised.

Before the change when building pyarrow I could see the following warning:
```shell
CMake Warning (dev) at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:438 (message):
  The package name passed to `find_package_handle_standard_args` (PkgConfig)
  does not match the name of the calling package (Arrow).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPkgConfig.cmake:99 (find_package_handle_standard_args)
  cmake_modules/FindArrow.cmake:39 (include)
  cmake_modules/FindArrowPython.cmake:47 (find_package)
  CMakeLists.txt:231 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```
With the change the Warning disappears.

The rationale for the change comes from some investigation over the [find_package](https://cmake.org/cmake/help/latest/command/find_package.html?highlight=find_package) and [include](https://cmake.org/cmake/help/latest/command/include.html?highlight=include) documentation and this [stackoverflow thread](https://stackoverflow.com/a/29316084)
