### PR TITLE
ARROW-16156: [R] Clarify warning message for features not turned on in .onAttach()

### DIFF
--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -109,7 +109,7 @@
       if (some_features_are_off(features)) {
         packageStartupMessage(
           paste(
-            "Some features of Arrow C++ are turned off.",
+            "Some features are not enabled in this build of Arrow.",
             "Run `arrow_info()` for more information."
           )
         )

--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -107,7 +107,12 @@
       #
       # Let's print a message if some are off
       if (some_features_are_off(features)) {
-        packageStartupMessage("See arrow_info() for available features")
+        packageStartupMessage(
+          paste(
+            "Some features of Arrow C++ are turned off.",
+            "Run `arrow_info()` for more information."
+          )
+        )
       }
     })
   }
@@ -264,7 +269,7 @@ arrow_info <- function() {
 some_features_are_off <- function(features) {
   # `features` is a named logical vector (as in arrow_info()$capabilities)
   # Let's exclude some less relevant ones
-  blocklist <- c("lzo", "bz2", "brotli")
+  blocklist <- c("lzo", "bz2", "brotli", "engine")
   # Return TRUE if any of the other features are FALSE
   !all(features[setdiff(names(features), blocklist)])
 }


### PR DESCRIPTION
After ARROW-15818 (#12564) we get an extra message on package load because "engine" was added to `arrow_info()$capabilities` and few if any users will have this turned on for at least the next release:

```r
library(arrow)
#> See arrow_info() for available features
```

This PR adds "engine" to the list of features we don't message users about and clarifies the message so that it's more clear why it's being shown:

```r
library(arrow)
#> Some features of Arrow C++ are turned off. Run `arrow_info()` for more information.
```