### PR TITLE
ARROW-16148: [C++] TPC-H generator cleanup

### DIFF
--- a/cpp/src/arrow/compute/exec/tpch_node.cc
+++ b/cpp/src/arrow/compute/exec/tpch_node.cc
@@ -1232,7 +1232,8 @@ class PartAndPartSupplierGenerator {
 
   Status PS_COMMENT(size_t thread_index) {
     ThreadLocalData& tld = thread_local_data_[thread_index];
-    if (tld.part[PARTSUPP::PS_COMMENT].kind() == Datum::NONE) {
+    if (!tld.generated_partsupp[PARTSUPP::PS_COMMENT]) {
+      tld.generated_partsupp[PARTSUPP::PS_COMMENT] = true;
       int64_t irow = 0;
       int64_t ps_to_generate = kPartSuppRowsPerPart * tld.part_to_generate;
       for (size_t ibatch = 0; ibatch < tld.partsupp.size(); ibatch++) {
@@ -1327,13 +1328,14 @@ class OrdersAndLineItemGenerator {
             std::min(batch_size_, orders_rows_to_generate_ - orders_rows_generated_);
         orders_rows_generated_ += tld.orders_to_generate;
         orders_batches_generated_.fetch_add(1);
+        tld.first_batch_offset = 0;
+        RETURN_NOT_OK(GenerateRowCounts(thread_index));
+        lineitem_batches_generated_.fetch_add(static_cast<int64_t>(tld.lineitem.size()));
         ARROW_DCHECK(orders_rows_generated_ <= orders_rows_to_generate_);
       }
     }
     tld.orders.resize(ORDERS::kNumCols);
     std::fill(tld.orders.begin(), tld.orders.end(), Datum());
-    RETURN_NOT_OK(GenerateRowCounts(thread_index));
-    tld.first_batch_offset = 0;
     tld.generated_lineitem.reset();
 
     for (int col : orders_cols_) RETURN_NOT_OK(kOrdersGenerators[col](thread_index));
@@ -1395,15 +1397,16 @@ class OrdersAndLineItemGenerator {
       tld.orders_to_generate =
           std::min(batch_size_, orders_rows_to_generate_ - orders_rows_generated_);
       orders_rows_generated_ += tld.orders_to_generate;
-      orders_batches_generated_.fetch_add(1ll);
+      orders_batches_generated_.fetch_add(1);
+      RETURN_NOT_OK(GenerateRowCounts(thread_index));
+      lineitem_batches_generated_.fetch_add(
+          static_cast<int64_t>(tld.lineitem.size() - from_queue));
       ARROW_DCHECK(orders_rows_generated_ <= orders_rows_to_generate_);
     }
     tld.orders.resize(ORDERS::kNumCols);
     std::fill(tld.orders.begin(), tld.orders.end(), Datum());
-    RETURN_NOT_OK(GenerateRowCounts(thread_index));
     tld.generated_lineitem.reset();
     if (from_queue) {
-      lineitem_batches_generated_.fetch_sub(1);
       for (size_t i = 0; i < lineitem_cols_.size(); i++)
         if (tld.lineitem[0][lineitem_cols_[i]].kind() == Datum::NONE)
           tld.lineitem[0][lineitem_cols_[i]] = std::move(queued[i]);
@@ -1435,7 +1438,6 @@ class OrdersAndLineItemGenerator {
       ARROW_ASSIGN_OR_RAISE(ExecBatch eb, ExecBatch::Make(std::move(lineitem_result)));
       lineitem_results.emplace_back(std::move(eb));
     }
-    lineitem_batches_generated_.fetch_add(static_cast<int64_t>(lineitem_results.size()));
     // Return the first batch, enqueue the rest.
     {
       std::lock_guard<std::mutex> lock(lineitem_output_queue_mutex_);
@@ -1774,6 +1776,7 @@ class OrdersAndLineItemGenerator {
                                         size_t& out_batch_offset) {
     ThreadLocalData& tld = thread_local_data_[thread_index];
     if (tld.lineitem[ibatch][column].kind() == Datum::NONE) {
+      ARROW_DCHECK(ibatch != 0 || tld.first_batch_offset == 0);
       int32_t byte_width = arrow::internal::GetByteWidth(*kLineitemTypes[column]);
       ARROW_ASSIGN_OR_RAISE(std::unique_ptr<Buffer> buff,
                             AllocateBuffer(batch_size_ * byte_width));
@@ -2323,16 +2326,17 @@ class OrdersAndLineItemGenerator {
     if (!tld.generated_lineitem[LINEITEM::L_COMMENT]) {
       tld.generated_lineitem[LINEITEM::L_COMMENT] = true;
 
-      size_t batch_offset = tld.first_batch_offset;
       size_t ibatch = 0;
       for (int64_t irow = 0; irow < tld.lineitem_to_generate; ibatch++) {
         // Comments are kind of sneaky: we always generate the full batch and then just
         // bump the length
+        size_t batch_offset = 0;
         if (tld.lineitem[ibatch][LINEITEM::L_COMMENT].kind() == Datum::NONE) {
           ARROW_ASSIGN_OR_RAISE(tld.lineitem[ibatch][LINEITEM::L_COMMENT],
                                 g_text.GenerateComments(batch_size_, 10, 43, tld.rng));
           batch_offset = 0;
         }
+        if (irow == 0) batch_offset = tld.first_batch_offset;
 
         int64_t remaining_in_batch = static_cast<int64_t>(batch_size_ - batch_offset);
         int64_t next_run = std::min(tld.lineitem_to_generate - irow, remaining_in_batch);
@@ -2694,8 +2698,10 @@ class PartGenerator : public TpchTableGenerator {
         bool expected = false;
         if (done_.compare_exchange_strong(expected, true))
           finished_callback_(batches_outputted_.load());
+        return Status::OK();
       }
-      return Status::OK();
+      return schedule_callback_(
+          [this](size_t thread_index) { return this->ProduceCallback(thread_index); });
     }
     ExecBatch batch = std::move(*maybe_batch);
     output_callback_(std::move(batch));
@@ -2754,8 +2760,10 @@ class PartSuppGenerator : public TpchTableGenerator {
         bool expected = false;
         if (done_.compare_exchange_strong(expected, true))
           finished_callback_(batches_outputted_.load());
+        return Status::OK();
       }
-      return Status::OK();
+      return schedule_callback_(
+          [this](size_t thread_index) { return this->ProduceCallback(thread_index); });
     }
     ExecBatch batch = std::move(*maybe_batch);
     output_callback_(std::move(batch));
@@ -3070,8 +3078,10 @@ class OrdersGenerator : public TpchTableGenerator {
         bool expected = false;
         if (done_.compare_exchange_strong(expected, true))
           finished_callback_(batches_outputted_.load());
+        return Status::OK();
       }
-      return Status::OK();
+      return schedule_callback_(
+          [this](size_t thread_index) { return this->ProduceCallback(thread_index); });
     }
     ExecBatch batch = std::move(*maybe_batch);
     output_callback_(std::move(batch));
@@ -3130,8 +3140,11 @@ class LineitemGenerator : public TpchTableGenerator {
         bool expected = false;
         if (done_.compare_exchange_strong(expected, true))
           finished_callback_(batches_outputted_.load());
+        return Status::OK();
       }
-      return Status::OK();
+      // We may have generated but not outputted all of the batches.
+      return schedule_callback_(
+          [this](size_t thread_index) { return this->ProduceCallback(thread_index); });
     }
     ExecBatch batch = std::move(*maybe_batch);
     output_callback_(std::move(batch));

--- a/cpp/src/arrow/compute/exec/tpch_node.cc
+++ b/cpp/src/arrow/compute/exec/tpch_node.cc
@@ -1098,16 +1098,16 @@ class PartAndPartSupplierGenerator {
     return Status::OK();
   }
 
-    Status SetPartSuppColumnSize(size_t thread_index, size_t ibatch, int column, size_t new_size)
-    {
-        ThreadLocalData &tld = thread_local_data_[thread_index];
-        int32_t byte_width = arrow::internal::GetByteWidth(*kPartsuppTypes[column]);
-        tld.partsupp[ibatch][column].array()->length =
-            static_cast<int64_t>(new_size);
-        ResizableBuffer *buff = checked_cast<ResizableBuffer *>(tld.partsupp[ibatch][column].array()->buffers[1].get());
-        return buff->Resize(static_cast<int64_t>(new_size * byte_width), /*shrink_to_fit=*/false);
-    }
-
+  Status SetPartSuppColumnSize(size_t thread_index, size_t ibatch, int column,
+                               size_t new_size) {
+    ThreadLocalData& tld = thread_local_data_[thread_index];
+    int32_t byte_width = arrow::internal::GetByteWidth(*kPartsuppTypes[column]);
+    tld.partsupp[ibatch][column].array()->length = static_cast<int64_t>(new_size);
+    ResizableBuffer* buff = checked_cast<ResizableBuffer*>(
+        tld.partsupp[ibatch][column].array()->buffers[1].get());
+    return buff->Resize(static_cast<int64_t>(new_size * byte_width),
+                        /*shrink_to_fit=*/false);
+  }
 
   Status PS_PARTKEY(size_t thread_index) {
     ThreadLocalData& tld = thread_local_data_[thread_index];
@@ -1140,7 +1140,8 @@ class PartAndPartSupplierGenerator {
             ipart++;
           }
         }
-        RETURN_NOT_OK(SetPartSuppColumnSize(thread_index, ibatch, PARTSUPP::PS_PARTKEY, next_run));
+        RETURN_NOT_OK(
+            SetPartSuppColumnSize(thread_index, ibatch, PARTSUPP::PS_PARTKEY, next_run));
         irow += next_run;
       }
     }
@@ -1184,7 +1185,8 @@ class PartAndPartSupplierGenerator {
             ipart++;
           }
         }
-        RETURN_NOT_OK(SetPartSuppColumnSize(thread_index, ibatch, PARTSUPP::PS_SUPPKEY, next_run));
+        RETURN_NOT_OK(
+            SetPartSuppColumnSize(thread_index, ibatch, PARTSUPP::PS_SUPPKEY, next_run));
         irow += next_run;
       }
     }
@@ -1208,7 +1210,8 @@ class PartAndPartSupplierGenerator {
         int64_t next_run = std::min(batch_size_, ps_to_generate - irow);
         for (int64_t irun = 0; irun < next_run; irun++) ps_availqty[irun] = dist(tld.rng);
 
-        RETURN_NOT_OK(SetPartSuppColumnSize(thread_index, ibatch, PARTSUPP::PS_AVAILQTY, next_run));
+        RETURN_NOT_OK(
+            SetPartSuppColumnSize(thread_index, ibatch, PARTSUPP::PS_AVAILQTY, next_run));
         irow += next_run;
       }
     }
@@ -1234,7 +1237,8 @@ class PartAndPartSupplierGenerator {
         for (int64_t irun = 0; irun < next_run; irun++)
           ps_supplycost[irun] = {dist(tld.rng)};
 
-        RETURN_NOT_OK(SetPartSuppColumnSize(thread_index, ibatch, PARTSUPP::PS_SUPPLYCOST, next_run));
+        RETURN_NOT_OK(SetPartSuppColumnSize(thread_index, ibatch, PARTSUPP::PS_SUPPLYCOST,
+                                            next_run));
         irow += next_run;
       }
     }
@@ -1800,15 +1804,16 @@ class OrdersAndLineItemGenerator {
     return Status::OK();
   }
 
-    Status SetLineItemColumnSize(size_t thread_index, size_t ibatch, int column, size_t new_size)
-    {
-        ThreadLocalData &tld = thread_local_data_[thread_index];
-        int32_t byte_width = arrow::internal::GetByteWidth(*kLineitemTypes[column]);
-        tld.lineitem[ibatch][column].array()->length =
-            static_cast<int64_t>(new_size);
-        ResizableBuffer *buff = checked_cast<ResizableBuffer *>(tld.lineitem[ibatch][column].array()->buffers[1].get());
-        return buff->Resize(static_cast<int64_t>(new_size * byte_width), /*shrink_to_fit=*/false);
-    }
+  Status SetLineItemColumnSize(size_t thread_index, size_t ibatch, int column,
+                               size_t new_size) {
+    ThreadLocalData& tld = thread_local_data_[thread_index];
+    int32_t byte_width = arrow::internal::GetByteWidth(*kLineitemTypes[column]);
+    tld.lineitem[ibatch][column].array()->length = static_cast<int64_t>(new_size);
+    ResizableBuffer* buff = checked_cast<ResizableBuffer*>(
+        tld.lineitem[ibatch][column].array()->buffers[1].get());
+    return buff->Resize(static_cast<int64_t>(new_size * byte_width),
+                        /*shrink_to_fit=*/false);
+  }
 
   Status L_ORDERKEY(size_t thread_index) {
     ThreadLocalData& tld = thread_local_data_[thread_index];
@@ -1841,7 +1846,8 @@ class OrdersAndLineItemGenerator {
           }
         }
         irow += next_run;
-        RETURN_NOT_OK(SetLineItemColumnSize(thread_index, ibatch, LINEITEM::L_ORDERKEY, batch_offset));
+        RETURN_NOT_OK(SetLineItemColumnSize(thread_index, ibatch, LINEITEM::L_ORDERKEY,
+                                            batch_offset));
       }
     }
     return Status::OK();
@@ -1870,7 +1876,8 @@ class OrdersAndLineItemGenerator {
           l_partkey[batch_offset] = dist(tld.rng);
 
         irow += next_run;
-        RETURN_NOT_OK(SetLineItemColumnSize(thread_index, ibatch, LINEITEM::L_PARTKEY, batch_offset));
+        RETURN_NOT_OK(SetLineItemColumnSize(thread_index, ibatch, LINEITEM::L_PARTKEY,
+                                            batch_offset));
       }
     }
     return Status::OK();
@@ -1907,7 +1914,8 @@ class OrdersAndLineItemGenerator {
               (partkey + (supplier * ((S / 4) + (partkey - 1) / S))) % S + 1;
         }
         irow += next_run;
-        RETURN_NOT_OK(SetLineItemColumnSize(thread_index, ibatch, LINEITEM::L_SUPPKEY, batch_offset));
+        RETURN_NOT_OK(SetLineItemColumnSize(thread_index, ibatch, LINEITEM::L_SUPPKEY,
+                                            batch_offset));
       }
     }
     return Status::OK();
@@ -1943,7 +1951,8 @@ class OrdersAndLineItemGenerator {
           }
         }
         irow += next_run;
-        RETURN_NOT_OK(SetLineItemColumnSize(thread_index, ibatch, LINEITEM::L_LINENUMBER, batch_offset));
+        RETURN_NOT_OK(SetLineItemColumnSize(thread_index, ibatch, LINEITEM::L_LINENUMBER,
+                                            batch_offset));
       }
     }
     return Status::OK();
@@ -1974,7 +1983,8 @@ class OrdersAndLineItemGenerator {
           l_quantity[batch_offset++] = {quantity};
         }
         irow += next_run;
-        RETURN_NOT_OK(SetLineItemColumnSize(thread_index, ibatch, LINEITEM::L_QUANTITY, batch_offset));
+        RETURN_NOT_OK(SetLineItemColumnSize(thread_index, ibatch, LINEITEM::L_QUANTITY,
+                                            batch_offset));
       }
     }
     return Status::OK();
@@ -2017,7 +2027,8 @@ class OrdersAndLineItemGenerator {
           l_extendedprice[batch_offset] = {extended_price};
         }
         irow += next_run;
-        RETURN_NOT_OK(SetLineItemColumnSize(thread_index, ibatch, LINEITEM::L_EXTENDEDPRICE, batch_offset));
+        RETURN_NOT_OK(SetLineItemColumnSize(thread_index, ibatch,
+                                            LINEITEM::L_EXTENDEDPRICE, batch_offset));
       }
     }
     return Status::OK();
@@ -2045,7 +2056,8 @@ class OrdersAndLineItemGenerator {
         for (int64_t i = 0; i < next_run; i++, batch_offset++)
           l_discount[batch_offset] = {dist(tld.rng)};
         irow += next_run;
-        RETURN_NOT_OK(SetLineItemColumnSize(thread_index, ibatch, LINEITEM::L_DISCOUNT, batch_offset));
+        RETURN_NOT_OK(SetLineItemColumnSize(thread_index, ibatch, LINEITEM::L_DISCOUNT,
+                                            batch_offset));
       }
     }
     return Status::OK();
@@ -2069,7 +2081,8 @@ class OrdersAndLineItemGenerator {
         for (int64_t i = 0; i < next_run; i++, batch_offset++)
           l_tax[batch_offset] = {dist(tld.rng)};
         irow += next_run;
-        RETURN_NOT_OK(SetLineItemColumnSize(thread_index, ibatch, LINEITEM::L_TAX, batch_offset));
+        RETURN_NOT_OK(
+            SetLineItemColumnSize(thread_index, ibatch, LINEITEM::L_TAX, batch_offset));
       }
     }
     return Status::OK();
@@ -2109,7 +2122,8 @@ class OrdersAndLineItemGenerator {
           }
         }
         irow += next_run;
-        RETURN_NOT_OK(SetLineItemColumnSize(thread_index, ibatch, LINEITEM::L_RETURNFLAG, batch_offset));
+        RETURN_NOT_OK(SetLineItemColumnSize(thread_index, ibatch, LINEITEM::L_RETURNFLAG,
+                                            batch_offset));
       }
     }
     return Status::OK();
@@ -2146,7 +2160,8 @@ class OrdersAndLineItemGenerator {
             l_linestatus[batch_offset] = 'F';
         }
         irow += next_run;
-        RETURN_NOT_OK(SetLineItemColumnSize(thread_index, ibatch, LINEITEM::L_LINESTATUS, batch_offset));
+        RETURN_NOT_OK(SetLineItemColumnSize(thread_index, ibatch, LINEITEM::L_LINESTATUS,
+                                            batch_offset));
       }
     }
     return Status::OK();
@@ -2183,7 +2198,8 @@ class OrdersAndLineItemGenerator {
           }
         }
         irow += next_run;
-        RETURN_NOT_OK(SetLineItemColumnSize(thread_index, ibatch, LINEITEM::L_SHIPDATE, batch_offset));
+        RETURN_NOT_OK(SetLineItemColumnSize(thread_index, ibatch, LINEITEM::L_SHIPDATE,
+                                            batch_offset));
       }
     }
     return Status::OK();
@@ -2220,7 +2236,8 @@ class OrdersAndLineItemGenerator {
           }
         }
         irow += next_run;
-        RETURN_NOT_OK(SetLineItemColumnSize(thread_index, ibatch, LINEITEM::L_COMMITDATE, batch_offset));
+        RETURN_NOT_OK(SetLineItemColumnSize(thread_index, ibatch, LINEITEM::L_COMMITDATE,
+                                            batch_offset));
       }
     }
     return Status::OK();
@@ -2255,7 +2272,8 @@ class OrdersAndLineItemGenerator {
           l_receiptdate[batch_offset] = l_shipdate[batch_offset] + dist(tld.rng);
 
         irow += next_run;
-        RETURN_NOT_OK(SetLineItemColumnSize(thread_index, ibatch, LINEITEM::L_RECEIPTDATE, batch_offset));
+        RETURN_NOT_OK(SetLineItemColumnSize(thread_index, ibatch, LINEITEM::L_RECEIPTDATE,
+                                            batch_offset));
       }
     }
     return Status::OK();
@@ -2289,7 +2307,8 @@ class OrdersAndLineItemGenerator {
           std::strncpy(l_shipinstruct + batch_offset * byte_width, str, byte_width);
         }
         irow += next_run;
-        RETURN_NOT_OK(SetLineItemColumnSize(thread_index, ibatch, LINEITEM::L_SHIPINSTRUCT, batch_offset));
+        RETURN_NOT_OK(SetLineItemColumnSize(thread_index, ibatch,
+                                            LINEITEM::L_SHIPINSTRUCT, batch_offset));
       }
     }
     return Status::OK();
@@ -2321,7 +2340,8 @@ class OrdersAndLineItemGenerator {
           std::strncpy(l_shipmode + batch_offset * byte_width, str, byte_width);
         }
         irow += next_run;
-        RETURN_NOT_OK(SetLineItemColumnSize(thread_index, ibatch, LINEITEM::L_SHIPMODE, batch_offset));
+        RETURN_NOT_OK(SetLineItemColumnSize(thread_index, ibatch, LINEITEM::L_SHIPMODE,
+                                            batch_offset));
       }
     }
     return Status::OK();

--- a/cpp/src/arrow/compute/exec/tpch_node_test.cc
+++ b/cpp/src/arrow/compute/exec/tpch_node_test.cc
@@ -370,12 +370,6 @@ void VerifySupplier(const std::vector<ExecBatch>& batches,
   ASSERT_EQ(bad_count, static_cast<int64_t>(5 * scale_factor));
 }
 
-TEST(TpchNode, ScaleFactor) {
-  constexpr double kScaleFactor = 0.01;
-  ASSERT_OK_AND_ASSIGN(auto res, GenerateTable(&TpchGen::Supplier, kScaleFactor));
-  VerifySupplier(res, kScaleFactor);
-}
-
 TEST(TpchNode, Supplier) {
   ASSERT_OK_AND_ASSIGN(auto res, GenerateTable(&TpchGen::Supplier));
   VerifySupplier(res);
@@ -636,7 +630,7 @@ TEST(TpchNode, AllTables) {
 
   ASSERT_OK(plan->Validate());
   ASSERT_OK(plan->StartProducing());
-  plan->finished().Wait();
+  ASSERT_OK(plan->finished().status());
   for (int i = 0; i < kNumTables; i++) {
     auto fut = CollectAsyncGenerator(gens[i]);
     ASSERT_OK_AND_ASSIGN(auto maybe_batches, fut.MoveResult());

--- a/cpp/src/arrow/compute/exec/tpch_node_test.cc
+++ b/cpp/src/arrow/compute/exec/tpch_node_test.cc
@@ -619,7 +619,6 @@ TEST(TpchNode, AllTables) {
   };
 
   std::array<AsyncGenerator<util::optional<ExecBatch>>, kNumTables> gens;
-  std::array<std::vector<ExecBatch>, kNumTables> batches;
   ExecContext ctx(default_memory_pool(), arrow::internal::GetCpuThreadPool());
   ASSERT_OK_AND_ASSIGN(std::shared_ptr<ExecPlan> plan, ExecPlan::Make(&ctx));
   ASSERT_OK_AND_ASSIGN(std::unique_ptr<TpchGen> gen,
@@ -634,9 +633,9 @@ TEST(TpchNode, AllTables) {
   for (int i = 0; i < kNumTables; i++) {
     auto fut = CollectAsyncGenerator(gens[i]);
     ASSERT_OK_AND_ASSIGN(auto maybe_batches, fut.MoveResult());
-    for (auto& maybe_batch : maybe_batches)
-      batches[i].emplace_back(std::move(*maybe_batch));
-    verify_fns[i](batches[i], kScaleFactor);
+    std::vector<ExecBatch> batches;
+    for (auto& maybe_batch : maybe_batches) batches.emplace_back(std::move(*maybe_batch));
+    verify_fns[i](batches, kScaleFactor);
   }
 }
 

--- a/cpp/src/arrow/compute/exec/tpch_node_test.cc
+++ b/cpp/src/arrow/compute/exec/tpch_node_test.cc
@@ -511,7 +511,7 @@ void VerifyLineitem(const std::vector<ExecBatch>& batches, double scale_factor =
     ValidateBatch(batch);
     CountInstances(&counts, batch[0]);
     VerifyAllBetween(batch[1], /*min=*/1,
-                     /*max=*/static_cast<int64_t>(200000 * scale_factor));
+                     /*max=*/static_cast<int32_t>(200000 * scale_factor));
     VerifyAllBetween(batch[3], /*min=*/1, /*max=*/7);
     VerifyDecimalsBetween(batch[4], /*min=*/100, /*max=*/5000);
     VerifyDecimalsBetween(batch[6], /*min=*/0, /*max=*/10);

--- a/cpp/src/arrow/compute/exec/tpch_node_test.cc
+++ b/cpp/src/arrow/compute/exec/tpch_node_test.cc
@@ -47,11 +47,7 @@ static constexpr uint32_t kEndDate =
 
 using TableNodeFn = Result<ExecNode*> (TpchGen::*)(std::vector<std::string>);
 
-#ifdef THREAD_SANITIZER
-constexpr double kDefaultScaleFactor = 0.25;
-#else
-constexpr double kDefaultScaleFactor = 1.0;
-#endif
+constexpr double kDefaultScaleFactor = 0.1;
 
 Status AddTableAndSinkToPlan(ExecPlan& plan, TpchGen& gen,
                              AsyncGenerator<util::optional<ExecBatch>>& sink_gen,
@@ -375,7 +371,7 @@ void VerifySupplier(const std::vector<ExecBatch>& batches,
 }
 
 TEST(TpchNode, ScaleFactor) {
-  constexpr double kScaleFactor = 0.25;
+  constexpr double kScaleFactor = 0.01;
   ASSERT_OK_AND_ASSIGN(auto res, GenerateTable(&TpchGen::Supplier, kScaleFactor));
   VerifySupplier(res, kScaleFactor);
 }
@@ -616,11 +612,7 @@ TEST(TpchNode, Region) {
 }
 
 TEST(TpchNode, AllTables) {
-#ifdef THREAD_SANITIZER
-  constexpr double kScaleFactor = 0.1;
-#else
-  constexpr double kScaleFactor = 0.25;
-#endif
+  constexpr double kScaleFactor = 0.05;
   constexpr int kNumTables = 8;
   std::array<TableNodeFn, kNumTables> tables = {
       &TpchGen::Supplier, &TpchGen::Part,     &TpchGen::PartSupp, &TpchGen::Customer,

--- a/cpp/src/arrow/compute/exec/tpch_node_test.cc
+++ b/cpp/src/arrow/compute/exec/tpch_node_test.cc
@@ -342,7 +342,7 @@ void CountModifiedComments(const Datum& d, int* good_count, int* bad_count) {
 }
 
 void VerifySupplier(const std::vector<ExecBatch>& batches, double scale_factor = 1.0) {
-    int64_t kExpectedRows = static_cast<int64_t>(10000 * scale_factor);
+  int64_t kExpectedRows = static_cast<int64_t>(10000 * scale_factor);
   int64_t num_rows = 0;
 
   std::unordered_set<int32_t> seen_suppkey;
@@ -379,7 +379,7 @@ TEST(TpchNode, Supplier) {
 }
 
 void VerifyPart(const std::vector<ExecBatch>& batches, double scale_factor = 1.0) {
-    int64_t kExpectedRows = static_cast<int64_t>(200000 * scale_factor);
+  int64_t kExpectedRows = static_cast<int64_t>(200000 * scale_factor);
   int64_t num_rows = 0;
 
   std::unordered_set<int32_t> seen_partkey;
@@ -414,7 +414,7 @@ TEST(TpchNode, Part) {
 }
 
 void VerifyPartSupp(const std::vector<ExecBatch>& batches, double scale_factor = 1.0) {
-    const int64_t kExpectedRows = static_cast<int64_t>(800000 * scale_factor);
+  const int64_t kExpectedRows = static_cast<int64_t>(800000 * scale_factor);
   int64_t num_rows = 0;
 
   std::unordered_map<int32_t, int32_t> counts;
@@ -510,7 +510,8 @@ void VerifyLineitem(const std::vector<ExecBatch>& batches, double scale_factor =
   for (auto& batch : batches) {
     ValidateBatch(batch);
     CountInstances(&counts, batch[0]);
-    VerifyAllBetween(batch[1], /*min=*/1, /*max=*/static_cast<int64_t>(200000 * scale_factor));
+    VerifyAllBetween(batch[1], /*min=*/1,
+                     /*max=*/static_cast<int64_t>(200000 * scale_factor));
     VerifyAllBetween(batch[3], /*min=*/1, /*max=*/7);
     VerifyDecimalsBetween(batch[4], /*min=*/100, /*max=*/5000);
     VerifyDecimalsBetween(batch[6], /*min=*/0, /*max=*/10);
@@ -617,7 +618,8 @@ TEST(TpchNode, AllTables) {
   std::array<std::vector<ExecBatch>, kNumTables> batches;
   ExecContext ctx(default_memory_pool(), arrow::internal::GetCpuThreadPool());
   ASSERT_OK_AND_ASSIGN(std::shared_ptr<ExecPlan> plan, ExecPlan::Make(&ctx));
-  ASSERT_OK_AND_ASSIGN(std::unique_ptr<TpchGen> gen, TpchGen::Make(plan.get(), kScaleFactor));
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<TpchGen> gen,
+                       TpchGen::Make(plan.get(), kScaleFactor));
   for (int i = 0; i < kNumTables; i++) {
     ASSERT_OK(AddTableAndSinkToPlan(*plan, *gen, gens[i], tables[i]));
   }


### PR DESCRIPTION
We'd occasionally get a hang in the multi-column generators. This was due to us creating an insufficient number of tasks, so we'd never actually finish outputting. This fixes it. 
This PR also adds a test to exercise it: it generates TPC-H SF 1 all in one plan and verifies the result. 