### PR TITLE
ARROW-15951: [CI][Python] "Test wheel" step successful despite test error

### DIFF
--- a/ci/scripts/python_wheel_windows_test.bat
+++ b/ci/scripts/python_wheel_windows_test.bat
@@ -35,21 +35,21 @@ set ARROW_TEST_DATA=C:\arrow\testing\data
 set PARQUET_TEST_DATA=C:\arrow\submodules\parquet-testing\data
 
 @REM Install testing dependencies
-pip install -r C:\arrow\python\requirements-wheel-test.txt || exit /B
+pip install -r C:\arrow\python\requirements-wheel-test.txt || exit /B 1
 
 @REM Install the built wheels
-python -m pip install --no-index --find-links=C:\arrow\python\dist\ pyarrow || exit /B
+python -m pip install --no-index --find-links=C:\arrow\python\dist\ pyarrow || exit /B 1 
 
 @REM Test that the modules are importable
-python -c "import pyarrow" || exit /B
-python -c "import pyarrow._hdfs" || exit /B
-python -c "import pyarrow._s3fs" || exit /B
-python -c "import pyarrow.csv" || exit /B
-python -c "import pyarrow.dataset" || exit /B
-python -c "import pyarrow.flight" || exit /B
-python -c "import pyarrow.fs" || exit /B
-python -c "import pyarrow.json" || exit /B
-python -c "import pyarrow.parquet" || exit /B
+python -c "import pyarrow" || exit /B 1
+python -c "import pyarrow._hdfs" || exit /B 1 
+python -c "import pyarrow._s3fs" || exit /B 1
+python -c "import pyarrow.csv" || exit /B 1
+python -c "import pyarrow.dataset" || exit /B 1
+python -c "import pyarrow.flight" || exit /B 1
+python -c "import pyarrow.fs" || exit /B 1
+python -c "import pyarrow.json" || exit /B 1
+python -c "import pyarrow.parquet" || exit /B 1
 
 @REM Execute unittest
-pytest -r s --pyargs pyarrow || exit /B
+pytest -r s --pyargs pyarrow || exit /B 1

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -36,7 +36,10 @@ except ImportError:
 import pyarrow as pa
 import pyarrow.tests.strategies as past
 
+def fail_always():
+    assert False
 
+    
 def test_total_bytes_allocated():
     assert pa.total_allocated_bytes() == 0
 

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -36,10 +36,7 @@ except ImportError:
 import pyarrow as pa
 import pyarrow.tests.strategies as past
 
-def fail_always():
-    assert False
 
-    
 def test_total_bytes_allocated():
     assert pa.total_allocated_bytes() == 0
 


### PR DESCRIPTION
With no explicit exit code `exit /b` returns 0. This made the the step never fail.
The failing test is only for demonstration and will of course be removed prior to merging this PR.    
I also checked that the same issue isn't happening anywhere else.