### PR TITLE
ARROW-15583: [C++] The Substrait consumer could potentially use a massive amount of RAM if the producer uses large anchors

### DIFF
--- a/cpp/examples/arrow/engine_substrait_consumption.cc
+++ b/cpp/examples/arrow/engine_substrait_consumption.cc
@@ -106,11 +106,6 @@ arrow::Future<std::shared_ptr<arrow::Buffer>> GetSubstraitFromServer(
         "type_anchor": 42,
         "name": "null"
       }},
-      {"extension_type_variation": {
-        "extension_uri_reference": 7,
-        "type_variation_anchor": 23,
-        "name": "u8"
-      }},
       {"extension_function": {
         "extension_uri_reference": 7,
         "function_anchor": 42,

--- a/cpp/src/arrow/engine/substrait/extension_set.cc
+++ b/cpp/src/arrow/engine/substrait/extension_set.cc
@@ -42,6 +42,18 @@ struct TypePtrHashEq {
 
 }  // namespace
 
+size_t ExtensionIdRegistry::IdHashEq::operator()(ExtensionIdRegistry::Id id) const {
+  constexpr ::arrow::internal::StringViewHash hash = {};
+  auto out = static_cast<size_t>(hash(id.uri));
+  ::arrow::internal::hash_combine(out, hash(id.name));
+  return out;
+}
+
+bool ExtensionIdRegistry::IdHashEq::operator()(ExtensionIdRegistry::Id l,
+                                               ExtensionIdRegistry::Id r) const {
+  return l.uri == r.uri && l.name == r.name;
+}
+
 // A builder used when creating a Substrait plan from an Arrow execution plan.  In
 // that situation we do not have a set of anchor values already defined so we keep
 // a map of what Ids we have seen.

--- a/cpp/src/arrow/engine/substrait/extension_set.cc
+++ b/cpp/src/arrow/engine/substrait/extension_set.cc
@@ -70,7 +70,7 @@ void ExtensionSet::AddUri(std::pair<uint32_t, util::string_view> uri) {
 }
 
 Status ExtensionSet::AddUri(Id id) {
-  if(uris_.find(uris_.size()) != uris_.end()){
+  if (uris_.find(uris_.size()) != uris_.end()) {
     return Status::Invalid("Key already exist in the uris map");
   }
   uris_[uris_.size()] = id.uri;
@@ -78,9 +78,9 @@ Status ExtensionSet::AddUri(Id id) {
 }
 
 Result<ExtensionSet> ExtensionSet::Make(
-    std::unordered_map<uint32_t, util::string_view> uris, std::unordered_map<uint32_t, Id> type_ids,
-    std::unordered_map<uint32_t, Id> function_ids,
-    ExtensionIdRegistry* registry) {
+    std::unordered_map<uint32_t, util::string_view> uris,
+    std::unordered_map<uint32_t, Id> type_ids,
+    std::unordered_map<uint32_t, Id> function_ids, ExtensionIdRegistry* registry) {
   ExtensionSet set;
   set.registry_ = registry;
 
@@ -110,7 +110,7 @@ Result<ExtensionSet> ExtensionSet::Make(
       set.types_[i] = {rec->id, rec->type};
       continue;
     }
-    return Status::Invalid("Type ",type_ids[i].uri, "#", type_ids[i].name, " not found");
+    return Status::Invalid("Type ", type_ids[i].uri, "#", type_ids[i].name, " not found");
   }
 
   set.functions_.reserve(function_ids.size());
@@ -146,9 +146,9 @@ Result<uint32_t> ExtensionSet::EncodeType(const DataType& type) {
     auto it_success =
         types_map_.emplace(rec->id, static_cast<uint32_t>(types_map_.size()));
     if (it_success.second) {
-        if(types_.find(types_.size()) != types_.end()){
-          return Status::Invalid("Key already exist in the uris map");
-        }
+      if (types_.find(types_.size()) != types_.end()) {
+        return Status::Invalid("Key already exist in the uris map");
+      }
       types_[types_.size()] = {rec->id, rec->type};
     }
     return it_success.first->second;
@@ -170,7 +170,7 @@ Result<uint32_t> ExtensionSet::EncodeFunction(util::string_view function_name) {
     auto it_success =
         functions_map_.emplace(rec->id, static_cast<uint32_t>(functions_map_.size()));
     if (it_success.second) {
-      if(functions_.find(functions_.size()) != functions_.end()){
+      if (functions_.find(functions_.size()) != functions_.end()) {
         return Status::Invalid("Key already exist in the uris map");
       }
       functions_[functions_.size()] = {rec->id, rec->function_name};
@@ -240,8 +240,7 @@ ExtensionIdRegistry* default_extension_id_registry() {
     }
 
     util::optional<TypeRecord> GetType(Id id) const override {
-      if (auto index =
-              GetIndex(id_to_index_, id)) {
+      if (auto index = GetIndex(id_to_index_, id)) {
         return TypeRecord{type_ids_[*index], types_[*index]};
       }
       return {};

--- a/cpp/src/arrow/engine/substrait/extension_set.cc
+++ b/cpp/src/arrow/engine/substrait/extension_set.cc
@@ -71,14 +71,11 @@ void ExtensionSet::AddUri(std::pair<uint32_t, util::string_view> uri,
   self->uris_[uri.first] = uri.second;
 }
 
-void ExtensionSet::AddUri(util::string_view uri, ExtensionSet* self) {
-  auto it =
-      std::find_if(self->uris_.begin(), self->uris_.end(),
-                   [&uri](const std::pair<uint32_t, util::string_view>& anchor_uri_pair) {
-                     return anchor_uri_pair.second == uri;
-                   });
-  if (it != self->uris_.end()) return;
-  self->uris_[self->uris_.size()] = uri;
+void ExtensionSet::AddUri(Id id, ExtensionSet* self) {
+  if (self->functions_map_.find(id) != self->functions_map_.end() &&
+      self->types_map_.find(id) != self->types_map_.end())
+    return;
+  self->uris_[self->uris_.size()] = id.uri;
 }
 
 Result<ExtensionSet> ExtensionSet::Make(
@@ -152,7 +149,7 @@ Result<ExtensionSet::TypeRecord> ExtensionSet::DecodeType(uint32_t anchor) const
 
 Result<uint32_t> ExtensionSet::EncodeType(const DataType& type) {
   if (auto rec = registry_->GetType(type)) {
-    AddUri(rec->id.uri, this);
+    AddUri(rec->id, this);
     auto it_success =
         types_map_.emplace(rec->id, static_cast<uint32_t>(types_map_.size()));
     if (it_success.second) {
@@ -173,7 +170,7 @@ Result<ExtensionSet::FunctionRecord> ExtensionSet::DecodeFunction(uint32_t ancho
 
 Result<uint32_t> ExtensionSet::EncodeFunction(util::string_view function_name) {
   if (auto rec = registry_->GetFunction(function_name)) {
-    AddUri(rec->id.uri, this);
+    AddUri(rec->id, this);
     auto it_success =
         functions_map_.emplace(rec->id, static_cast<uint32_t>(functions_map_.size()));
     if (it_success.second) {

--- a/cpp/src/arrow/engine/substrait/extension_set.cc
+++ b/cpp/src/arrow/engine/substrait/extension_set.cc
@@ -110,7 +110,7 @@ struct ExtensionSet::Impl {
 ExtensionSet::ExtensionSet(ExtensionIdRegistry* registry)
     : registry_(registry), impl_(new Impl(), [](Impl* impl) { delete impl; }) {}
 
-Result<ExtensionSet> ExtensionSet::Make(std::vector<util::string_view> uris,
+Result<ExtensionSet> ExtensionSet::Make(std::unordered_map<uint32_t, util::string_view> uris,
                                         std::vector<Id> type_ids,
                                         std::vector<bool> type_is_variation,
                                         std::vector<Id> function_ids,
@@ -126,12 +126,11 @@ Result<ExtensionSet> ExtensionSet::Make(std::vector<util::string_view> uris,
   }
 
   for (auto& uri : uris) {
-    if (uri.empty()) continue;
-    auto it = uris_owned_by_registry.find(uri);
+    auto it = uris_owned_by_registry.find(uri.second);
     if (it == uris_owned_by_registry.end()) {
       return Status::KeyError("Uri '", uri, "' not found in registry");
     }
-    uri = *it;  // Ensure uris point into the registry's memory
+    // uri = *it;  // Ensure uris point into the registry's memory
     set.impl_->AddUri(*it, &set);
   }
 

--- a/cpp/src/arrow/engine/substrait/extension_set.cc
+++ b/cpp/src/arrow/engine/substrait/extension_set.cc
@@ -150,10 +150,8 @@ Result<uint32_t> ExtensionSet::EncodeType(const DataType& type) {
     auto it_success =
         types_map_.emplace(rec->id, static_cast<uint32_t>(types_map_.size()));
     if (it_success.second) {
-      if (types_.find(static_cast<unsigned int>(types_.size())) != types_.end()) {
-        DCHECK_EQ(types_.find(static_cast<unsigned int>(types_.size())), types_.end())
-            << "Type existed in types_ but not types_map_.  ExtensionSet is inconsistent";
-      }
+      DCHECK_EQ(types_.find(static_cast<unsigned int>(types_.size())), types_.end())
+          << "Type existed in types_ but not types_map_.  ExtensionSet is inconsistent";
       types_[static_cast<unsigned int>(types_.size())] = {rec->id, rec->type};
     }
     return it_success.first->second;
@@ -175,13 +173,10 @@ Result<uint32_t> ExtensionSet::EncodeFunction(util::string_view function_name) {
     auto it_success =
         functions_map_.emplace(rec->id, static_cast<uint32_t>(functions_map_.size()));
     if (it_success.second) {
-      if (functions_.find(static_cast<unsigned int>(functions_.size())) !=
-          functions_.end()) {
-        DCHECK_EQ(functions_.find(static_cast<unsigned int>(functions_.size())),
-                  functions_.end())
-            << "Function existed in functions_ but not functions_map_.  ExtensionSet is "
-               "inconsistent";
-      }
+      DCHECK_EQ(functions_.find(static_cast<unsigned int>(functions_.size())),
+                functions_.end())
+          << "Function existed in functions_ but not functions_map_.  ExtensionSet is "
+             "inconsistent";
       functions_[static_cast<unsigned int>(functions_.size())] = {rec->id,
                                                                   rec->function_name};
     }

--- a/cpp/src/arrow/engine/substrait/extension_set.cc
+++ b/cpp/src/arrow/engine/substrait/extension_set.cc
@@ -70,10 +70,11 @@ void ExtensionSet::AddUri(std::pair<uint32_t, util::string_view> uri) {
 }
 
 Status ExtensionSet::AddUri(Id id) {
-  if (uris_.find(uris_.size()) != uris_.end()) {
+  auto uris_size = static_cast<unsigned int>(uris_.size());
+  if (uris_.find(uris_size) != uris_.end()) {
     return Status::Invalid("Key already exist in the uris map");
   }
-  uris_[uris_.size()] = id.uri;
+  uris_[uris_size] = id.uri;
   return Status::OK();
 }
 
@@ -102,7 +103,7 @@ Result<ExtensionSet> ExtensionSet::Make(
 
   set.types_.reserve(type_ids.size());
 
-  for (size_t i = 0; i < type_ids.size(); ++i) {
+  for (unsigned int i = 0; i < static_cast<unsigned int>(type_ids.size()); ++i) {
     if (type_ids[i].empty()) continue;
     RETURN_NOT_OK(set.CheckHasUri(type_ids[i].uri));
 
@@ -115,7 +116,7 @@ Result<ExtensionSet> ExtensionSet::Make(
 
   set.functions_.reserve(function_ids.size());
 
-  for (size_t i = 0; i < function_ids.size(); ++i) {
+  for (unsigned int i = 0; i < static_cast<unsigned int>(function_ids.size()); ++i) {
     if (function_ids[i].empty()) continue;
     RETURN_NOT_OK(set.CheckHasUri(function_ids[i].uri));
 
@@ -146,10 +147,10 @@ Result<uint32_t> ExtensionSet::EncodeType(const DataType& type) {
     auto it_success =
         types_map_.emplace(rec->id, static_cast<uint32_t>(types_map_.size()));
     if (it_success.second) {
-      if (types_.find(types_.size()) != types_.end()) {
+      if (types_.find(static_cast<unsigned int>(types_.size())) != types_.end()) {
         return Status::Invalid("Key already exist in the uris map");
       }
-      types_[types_.size()] = {rec->id, rec->type};
+      types_[static_cast<unsigned int>(types_.size())] = {rec->id, rec->type};
     }
     return it_success.first->second;
   }
@@ -170,10 +171,12 @@ Result<uint32_t> ExtensionSet::EncodeFunction(util::string_view function_name) {
     auto it_success =
         functions_map_.emplace(rec->id, static_cast<uint32_t>(functions_map_.size()));
     if (it_success.second) {
-      if (functions_.find(functions_.size()) != functions_.end()) {
+      if (functions_.find(static_cast<unsigned int>(functions_.size())) !=
+          functions_.end()) {
         return Status::Invalid("Key already exist in the uris map");
       }
-      functions_[functions_.size()] = {rec->id, rec->function_name};
+      functions_[static_cast<unsigned int>(functions_.size())] = {rec->id,
+                                                                  rec->function_name};
     }
     return it_success.first->second;
   }

--- a/cpp/src/arrow/engine/substrait/extension_set.h
+++ b/cpp/src/arrow/engine/substrait/extension_set.h
@@ -28,7 +28,6 @@
 #include "arrow/util/string_view.h"
 
 #include "arrow/util/hash_util.h"
-#include "arrow/util/hashing.h"
 
 namespace arrow {
 namespace engine {

--- a/cpp/src/arrow/engine/substrait/extension_set.h
+++ b/cpp/src/arrow/engine/substrait/extension_set.h
@@ -159,10 +159,6 @@ class ARROW_ENGINE_EXPORT ExtensionSet {
   explicit ExtensionSet(ExtensionIdRegistry* = default_extension_id_registry());
   ARROW_DEFAULT_MOVE_AND_ASSIGN(ExtensionSet);
 
-  static Status CheckHasUri(util::string_view uri, ExtensionSet* self);
-  static void AddUri(std::pair<uint32_t, util::string_view> uri, ExtensionSet* self);
-  static void AddUri(Id id, ExtensionSet* self);
-
   /// Construct an ExtensionSet with explicit extension ids for efficient referencing
   /// during deserialization. Note that input vectors need not be densely packed; an empty
   /// (default constructed) Id may be used as a placeholder to indicate an unused
@@ -182,9 +178,7 @@ class ARROW_ENGINE_EXPORT ExtensionSet {
       std::vector<bool> type_is_variation, std::vector<Id> function_ids,
       ExtensionIdRegistry* = default_extension_id_registry());
 
-  // index in these vectors == value of _anchor/_reference fields
-  /// TODO(ARROW-15583) this assumes that _anchor/_references won't be huge, which is not
-  /// guaranteed. Could it be?
+
   const std::unordered_map<uint32_t, util::string_view>& uris() const { return uris_; }
 
   /// \brief Returns a data type given an anchor
@@ -250,6 +244,10 @@ class ARROW_ENGINE_EXPORT ExtensionSet {
   std::vector<TypeRecord> types_;
   std::vector<FunctionRecord> functions_;
   std::unordered_map<Id, uint32_t, IdHashEq, IdHashEq> types_map_, functions_map_;
+
+  Status CheckHasUri(util::string_view uri);
+  void AddUri(std::pair<uint32_t, util::string_view> uri);
+  void AddUri(Id id);
 };
 
 }  // namespace engine

--- a/cpp/src/arrow/engine/substrait/extension_set.h
+++ b/cpp/src/arrow/engine/substrait/extension_set.h
@@ -60,14 +60,8 @@ class ARROW_ENGINE_EXPORT ExtensionIdRegistry {
   };
 
   struct IdHashEq {
-    size_t operator()(Id id) const {
-      constexpr ::arrow::internal::StringViewHash hash = {};
-      auto out = static_cast<size_t>(hash(id.uri));
-      ::arrow::internal::hash_combine(out, hash(id.name));
-      return out;
-    }
-
-    bool operator()(Id l, Id r) const { return l.uri == r.uri && l.name == r.name; }
+    size_t operator()(Id id) const;
+    bool operator()(Id l, Id r) const;
   };
 
   /// \brief A mapping between a Substrait ID and an arrow::DataType

--- a/cpp/src/arrow/engine/substrait/extension_set.h
+++ b/cpp/src/arrow/engine/substrait/extension_set.h
@@ -161,7 +161,7 @@ class ARROW_ENGINE_EXPORT ExtensionSet {
 
   static Status CheckHasUri(util::string_view uri, ExtensionSet* self);
   static void AddUri(std::pair<uint32_t, util::string_view> uri, ExtensionSet* self);
-  static void AddUri(util::string_view uri, ExtensionSet* self);
+  static void AddUri(Id id, ExtensionSet* self);
 
   /// Construct an ExtensionSet with explicit extension ids for efficient referencing
   /// during deserialization. Note that input vectors need not be densely packed; an empty

--- a/cpp/src/arrow/engine/substrait/extension_set.h
+++ b/cpp/src/arrow/engine/substrait/extension_set.h
@@ -172,9 +172,10 @@ class ARROW_ENGINE_EXPORT ExtensionSet {
   /// An extension set should instead be created using
   /// arrow::engine::GetExtensionSetFromPlan
   static Result<ExtensionSet> Make(
-      std::unordered_map<uint32_t, util::string_view> uris, std::unordered_map<uint32_t, Id> type_ids,
-      std::unordered_map<uint32_t, Id> function_ids, ExtensionIdRegistry* = default_extension_id_registry());
-
+      std::unordered_map<uint32_t, util::string_view> uris,
+      std::unordered_map<uint32_t, Id> type_ids,
+      std::unordered_map<uint32_t, Id> function_ids,
+      ExtensionIdRegistry* = default_extension_id_registry());
 
   const std::unordered_map<uint32_t, util::string_view>& uris() const { return uris_; }
 

--- a/cpp/src/arrow/engine/substrait/extension_set.h
+++ b/cpp/src/arrow/engine/substrait/extension_set.h
@@ -158,7 +158,7 @@ class ARROW_ENGINE_EXPORT ExtensionSet {
   /// An extension set should instead be created using
   /// arrow::engine::GetExtensionSetFromPlan
   static Result<ExtensionSet> Make(
-      std::vector<util::string_view> uris, std::vector<Id> type_ids,
+      std::unordered_map<uint32_t, util::string_view> uris, std::vector<Id> type_ids,
       std::vector<bool> type_is_variation, std::vector<Id> function_ids,
       ExtensionIdRegistry* = default_extension_id_registry());
 
@@ -226,7 +226,7 @@ class ARROW_ENGINE_EXPORT ExtensionSet {
  private:
   ExtensionIdRegistry* registry_;
   /// The subset of extension registry URIs referenced by this extension set
-  std::vector<util::string_view> uris_;
+  std::unordered_map<uint32_t, util::string_view> uris_;
   std::vector<TypeRecord> types_;
 
   std::vector<FunctionRecord> functions_;

--- a/cpp/src/arrow/engine/substrait/extension_set.h
+++ b/cpp/src/arrow/engine/substrait/extension_set.h
@@ -74,11 +74,10 @@ class ARROW_ENGINE_EXPORT ExtensionIdRegistry {
   struct TypeRecord {
     Id id;
     const std::shared_ptr<DataType>& type;
-    bool is_variation;
   };
   virtual util::optional<TypeRecord> GetType(const DataType&) const = 0;
-  virtual util::optional<TypeRecord> GetType(Id, bool is_variation) const = 0;
-  virtual Status RegisterType(Id, std::shared_ptr<DataType>, bool is_variation) = 0;
+  virtual util::optional<TypeRecord> GetType(Id) const = 0;
+  virtual Status RegisterType(Id, std::shared_ptr<DataType>) = 0;
 
   /// \brief A mapping between a Substrait ID and an Arrow function
   ///
@@ -152,7 +151,6 @@ class ARROW_ENGINE_EXPORT ExtensionSet {
   struct TypeRecord {
     Id id;
     std::shared_ptr<DataType> type;
-    bool is_variation;
   };
 
   /// Construct an empty ExtensionSet to be populated during serialization.
@@ -174,9 +172,8 @@ class ARROW_ENGINE_EXPORT ExtensionSet {
   /// An extension set should instead be created using
   /// arrow::engine::GetExtensionSetFromPlan
   static Result<ExtensionSet> Make(
-      std::unordered_map<uint32_t, util::string_view> uris, std::vector<Id> type_ids,
-      std::vector<bool> type_is_variation, std::vector<Id> function_ids,
-      ExtensionIdRegistry* = default_extension_id_registry());
+      std::unordered_map<uint32_t, util::string_view> uris, std::unordered_map<uint32_t, Id> type_ids,
+      std::unordered_map<uint32_t, Id> function_ids, ExtensionIdRegistry* = default_extension_id_registry());
 
 
   const std::unordered_map<uint32_t, util::string_view>& uris() const { return uris_; }
@@ -241,13 +238,13 @@ class ARROW_ENGINE_EXPORT ExtensionSet {
   ExtensionIdRegistry* registry_;
   /// The subset of extension registry URIs referenced by this extension set
   std::unordered_map<uint32_t, util::string_view> uris_;
-  std::vector<TypeRecord> types_;
-  std::vector<FunctionRecord> functions_;
+  std::unordered_map<uint32_t, TypeRecord> types_;
+  std::unordered_map<uint32_t, FunctionRecord> functions_;
   std::unordered_map<Id, uint32_t, IdHashEq, IdHashEq> types_map_, functions_map_;
 
   Status CheckHasUri(util::string_view uri);
   void AddUri(std::pair<uint32_t, util::string_view> uri);
-  void AddUri(Id id);
+  Status AddUri(Id id);
 };
 
 }  // namespace engine

--- a/cpp/src/arrow/engine/substrait/extension_set.h
+++ b/cpp/src/arrow/engine/substrait/extension_set.h
@@ -237,11 +237,21 @@ class ARROW_ENGINE_EXPORT ExtensionSet {
 
  private:
   ExtensionIdRegistry* registry_;
-  /// The subset of extension registry URIs referenced by this extension set
+
+  // Map from anchor values to URI values referenced by this extension set
   std::unordered_map<uint32_t, util::string_view> uris_;
+  // Map from anchor values to type definitions, used during Substrait->Arrow
+  // and populated from the Substrait extension set
   std::unordered_map<uint32_t, TypeRecord> types_;
+  // Map from anchor values to function definitions, used during Substrait->Arrow
+  // and populated from the Substrait extension set
   std::unordered_map<uint32_t, FunctionRecord> functions_;
-  std::unordered_map<Id, uint32_t, IdHashEq, IdHashEq> types_map_, functions_map_;
+  // Map from type names to anchor values.  Used during Arrow->Substrait
+  // and built as the plan is created.
+  std::unordered_map<Id, uint32_t, IdHashEq, IdHashEq> types_map_;
+  // Map from function names to anchor values.  Used during Arrow->Substrait
+  // and built as the plan is created.
+  std::unordered_map<Id, uint32_t, IdHashEq, IdHashEq> functions_map_;
 
   Status CheckHasUri(util::string_view uri);
   void AddUri(std::pair<uint32_t, util::string_view> uri);

--- a/cpp/src/arrow/engine/substrait/extension_set.h
+++ b/cpp/src/arrow/engine/substrait/extension_set.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <unordered_map>
 #include <vector>
 
 #include "arrow/engine/substrait/visibility.h"
@@ -143,6 +144,9 @@ class ARROW_ENGINE_EXPORT ExtensionSet {
   explicit ExtensionSet(ExtensionIdRegistry* = default_extension_id_registry());
   ARROW_DEFAULT_MOVE_AND_ASSIGN(ExtensionSet);
 
+  static Status CheckHasUri(util::string_view uri, ExtensionSet* self);
+  static void AddUri(std::pair<uint32_t, util::string_view> uri, ExtensionSet* self);
+
   /// Construct an ExtensionSet with explicit extension ids for efficient referencing
   /// during deserialization. Note that input vectors need not be densely packed; an empty
   /// (default constructed) Id may be used as a placeholder to indicate an unused
@@ -165,7 +169,7 @@ class ARROW_ENGINE_EXPORT ExtensionSet {
   // index in these vectors == value of _anchor/_reference fields
   /// TODO(ARROW-15583) this assumes that _anchor/_references won't be huge, which is not
   /// guaranteed. Could it be?
-  const std::vector<util::string_view>& uris() const { return uris_; }
+  const std::unordered_map<uint32_t, util::string_view>& uris() const { return uris_; }
 
   /// \brief Returns a data type given an anchor
   ///
@@ -230,10 +234,6 @@ class ARROW_ENGINE_EXPORT ExtensionSet {
   std::vector<TypeRecord> types_;
 
   std::vector<FunctionRecord> functions_;
-
-  // pimpl pattern to hide lookup details
-  struct Impl;
-  std::unique_ptr<Impl, void (*)(Impl*)> impl_;
 };
 
 }  // namespace engine

--- a/cpp/src/arrow/engine/substrait/plan_internal.cc
+++ b/cpp/src/arrow/engine/substrait/plan_internal.cc
@@ -43,7 +43,7 @@ Status AddExtensionSetToPlan(const ExtensionSet& ext_set, substrait::Plan* plan)
   auto uris = plan->mutable_extension_uris();
   uris->Reserve(static_cast<int>(ext_set.uris().size()));
   for (uint32_t anchor = 0; anchor < ext_set.uris().size(); ++anchor) {
-    auto uri = ext_set.uris()[anchor];
+    auto uri = ext_set.uris().at(anchor);
     if (uri.empty()) continue;
 
     auto ext_uri = internal::make_unique<substrait::extensions::SimpleExtensionURI>();
@@ -113,9 +113,9 @@ template <typename Element, typename key, typename value>
 void SetMapElement(key i, const Element& element, std::unordered_map<key, value>* map) {
   DCHECK_LE(i, 1 << 20);
   if (i >= map->size()) {
-    vector->reserve(i + 1);
+    map->reserve(i + 1);
   }
-  (*map)[i] = static_cast<T>(element);
+  (*map)[i] = static_cast<value>(element);
 }
 
 }  // namespace

--- a/cpp/src/arrow/engine/substrait/plan_internal.cc
+++ b/cpp/src/arrow/engine/substrait/plan_internal.cc
@@ -91,18 +91,6 @@ Status AddExtensionSetToPlan(const ExtensionSet& ext_set, substrait::Plan* plan)
   return Status::OK();
 }
 
-namespace {
-template <typename Element, typename T>
-void SetElement(size_t i, const Element& element, std::vector<T>* vector) {
-  DCHECK_LE(i, 1 << 20);
-  if (i >= vector->size()) {
-    vector->resize(i + 1);
-  }
-  (*vector)[i] = static_cast<T>(element);
-}
-
-}  // namespace
-
 Result<ExtensionSet> GetExtensionSetFromPlan(const substrait::Plan& plan,
                                              ExtensionIdRegistry* registry) {
   std::unordered_map<uint32_t, util::string_view> uris;

--- a/cpp/src/arrow/engine/substrait/plan_internal.cc
+++ b/cpp/src/arrow/engine/substrait/plan_internal.cc
@@ -70,7 +70,6 @@ Status AddExtensionSetToPlan(const ExtensionSet& ext_set, substrait::Plan* plan)
     type->set_type_anchor(anchor);
     type->set_name(type_record.id.name.to_string());
     ext_decl->set_allocated_extension_type(type.release());
-    
     extensions->AddAllocated(ext_decl.release());
   }
 
@@ -107,7 +106,6 @@ Result<ExtensionSet> GetExtensionSetFromPlan(const substrait::Plan& plan,
   std::unordered_map<uint32_t, Id> type_ids, function_ids;
   for (const auto& ext : plan.extensions()) {
     switch (ext.mapping_type_case()) {
-
       case substrait::extensions::SimpleExtensionDeclaration::kExtensionTypeVariation: {
         return Status::NotImplemented("Type Variations are not yet implemented");
       }
@@ -131,8 +129,7 @@ Result<ExtensionSet> GetExtensionSetFromPlan(const substrait::Plan& plan,
     }
   }
 
-  return ExtensionSet::Make(std::move(uris), std::move(type_ids),
-                            std::move(function_ids),
+  return ExtensionSet::Make(std::move(uris), std::move(type_ids), std::move(function_ids),
                             registry);
 }
 

--- a/cpp/src/arrow/engine/substrait/plan_internal.cc
+++ b/cpp/src/arrow/engine/substrait/plan_internal.cc
@@ -43,7 +43,7 @@ Status AddExtensionSetToPlan(const ExtensionSet& ext_set, substrait::Plan* plan)
   auto uris = plan->mutable_extension_uris();
   uris->Reserve(static_cast<int>(ext_set.uris().size()));
   for (uint32_t anchor = 0; anchor < ext_set.uris().size(); ++anchor) {
-    auto uri = ext_set.uris()[anchor];
+    auto uri = ext_set.uris().at(anchor);
     if (uri.empty()) continue;
 
     auto ext_uri = internal::make_unique<substrait::extensions::SimpleExtensionURI>();
@@ -65,20 +65,12 @@ Status AddExtensionSetToPlan(const ExtensionSet& ext_set, substrait::Plan* plan)
 
     auto ext_decl = internal::make_unique<ExtDecl>();
 
-    if (type_record.is_variation) {
-      auto type_var = internal::make_unique<ExtDecl::ExtensionTypeVariation>();
-      type_var->set_extension_uri_reference(map[type_record.id.uri]);
-      type_var->set_type_variation_anchor(anchor);
-      type_var->set_name(type_record.id.name.to_string());
-      ext_decl->set_allocated_extension_type_variation(type_var.release());
-    } else {
-      auto type = internal::make_unique<ExtDecl::ExtensionType>();
-      type->set_extension_uri_reference(map[type_record.id.uri]);
-      type->set_type_anchor(anchor);
-      type->set_name(type_record.id.name.to_string());
-      ext_decl->set_allocated_extension_type(type.release());
-    }
-
+    auto type = internal::make_unique<ExtDecl::ExtensionType>();
+    type->set_extension_uri_reference(map[type_record.id.uri]);
+    type->set_type_anchor(anchor);
+    type->set_name(type_record.id.name.to_string());
+    ext_decl->set_allocated_extension_type(type.release());
+    
     extensions->AddAllocated(ext_decl.release());
   }
 
@@ -124,30 +116,25 @@ Result<ExtensionSet> GetExtensionSetFromPlan(const substrait::Plan& plan,
 
   using Id = ExtensionSet::Id;
 
-  std::vector<Id> type_ids, function_ids;
-  std::vector<bool> type_is_variation;
+  std::unordered_map<uint32_t, Id> type_ids, function_ids;
   for (const auto& ext : plan.extensions()) {
     switch (ext.mapping_type_case()) {
+
       case substrait::extensions::SimpleExtensionDeclaration::kExtensionTypeVariation: {
-        const auto& type_var = ext.extension_type_variation();
-        util::string_view uri = uris[type_var.extension_uri_reference()];
-        SetElement(type_var.type_variation_anchor(), Id{uri, type_var.name()}, &type_ids);
-        SetElement(type_var.type_variation_anchor(), true, &type_is_variation);
-        break;
+        return Status::NotImplemented("Type Variations are not yet implemented");
       }
 
       case substrait::extensions::SimpleExtensionDeclaration::kExtensionType: {
         const auto& type = ext.extension_type();
         util::string_view uri = uris[type.extension_uri_reference()];
-        SetElement(type.type_anchor(), Id{uri, type.name()}, &type_ids);
-        SetElement(type.type_anchor(), false, &type_is_variation);
+        type_ids[type.type_anchor()] = Id{uri, type.name()};
         break;
       }
 
       case substrait::extensions::SimpleExtensionDeclaration::kExtensionFunction: {
         const auto& fn = ext.extension_function();
         util::string_view uri = uris[fn.extension_uri_reference()];
-        SetElement(fn.function_anchor(), Id{uri, fn.name()}, &function_ids);
+        function_ids[fn.function_anchor()] = Id{uri, fn.name()};
         break;
       }
 
@@ -157,7 +144,7 @@ Result<ExtensionSet> GetExtensionSetFromPlan(const substrait::Plan& plan,
   }
 
   return ExtensionSet::Make(std::move(uris), std::move(type_ids),
-                            std::move(type_is_variation), std::move(function_ids),
+                            std::move(function_ids),
                             registry);
 }
 

--- a/cpp/src/arrow/engine/substrait/plan_internal.cc
+++ b/cpp/src/arrow/engine/substrait/plan_internal.cc
@@ -108,13 +108,23 @@ void SetElement(size_t i, const Element& element, std::vector<T>* vector) {
   }
   (*vector)[i] = static_cast<T>(element);
 }
+
+template <typename Element, typename key, typename value>
+void SetMapElement(key i, const Element& element, std::unordered_map<key, value>* map) {
+  DCHECK_LE(i, 1 << 20);
+  if (i >= map->size()) {
+    vector->reserve(i + 1);
+  }
+  (*map)[i] = static_cast<T>(element);
+}
+
 }  // namespace
 
 Result<ExtensionSet> GetExtensionSetFromPlan(const substrait::Plan& plan,
                                              ExtensionIdRegistry* registry) {
-  std::vector<util::string_view> uris;
+  std::unordered_map<uint32_t, util::string_view> uris;
   for (const auto& uri : plan.extension_uris()) {
-    SetElement(uri.extension_uri_anchor(), uri.uri(), &uris);
+    SetMapElement(uri.extension_uri_anchor(), uri.uri(), &uris);
   }
 
   // NOTE: it's acceptable to use views to memory owned by plan; ExtensionSet::Make

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -689,11 +689,6 @@ TEST(Substrait, ExtensionSetFromPlan) {
         "type_anchor": 42,
         "name": "null"
       }},
-      {"extension_type_variation": {
-        "extension_uri_reference": 7,
-        "type_variation_anchor": 23,
-        "name": "u8"
-      }},
       {"extension_function": {
         "extension_uri_reference": 7,
         "function_anchor": 42,
@@ -701,7 +696,6 @@ TEST(Substrait, ExtensionSetFromPlan) {
       }}
     ]
   })"));
-
   ExtensionSet ext_set;
   ASSERT_OK_AND_ASSIGN(
       auto sink_decls,
@@ -713,13 +707,6 @@ TEST(Substrait, ExtensionSetFromPlan) {
   EXPECT_EQ(decoded_null_type.id.uri, kArrowExtTypesUri);
   EXPECT_EQ(decoded_null_type.id.name, "null");
   EXPECT_EQ(*decoded_null_type.type, NullType());
-  EXPECT_FALSE(decoded_null_type.is_variation);
-
-  EXPECT_OK_AND_ASSIGN(auto decoded_uint8_type, ext_set.DecodeType(23));
-  EXPECT_EQ(decoded_uint8_type.id.uri, kArrowExtTypesUri);
-  EXPECT_EQ(decoded_uint8_type.id.name, "u8");
-  EXPECT_EQ(*decoded_uint8_type.type, UInt8Type());
-  EXPECT_TRUE(decoded_uint8_type.is_variation);
 
   EXPECT_OK_AND_ASSIGN(auto decoded_add_func, ext_set.DecodeFunction(42));
   EXPECT_EQ(decoded_add_func.id.uri, kArrowExtTypesUri);


### PR DESCRIPTION
This PR modifies the ExtensionSet in C++ Consumer to use an `unordered_map` instead of a `vector` to store the `uri` anchors as the lookup table. This also modifies the usage of the `impl` struct as now the included functions are defined directly with the ExtensionSet implementation.