### PR TITLE
ARROW-15998: [Docs][CI] Use sphinx-design tabs instead of sphinx-tabs

### DIFF
--- a/ci/conda_env_sphinx.txt
+++ b/ci/conda_env_sphinx.txt
@@ -24,4 +24,3 @@ pydata-sphinx-theme
 sphinx-design
 sphinx>=4.2
 sphinx-copybutton
-sphinx-tabs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,7 +6,6 @@ breathe
 ipython
 numpydoc
 pydata-sphinx-theme
-sphinx-tabs
 sphinx-design
 sphinx-copybutton
 sphinx>=4.2

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -66,7 +66,6 @@ extensions = [
     'IPython.sphinxext.ipython_directive',
     'numpydoc',
     'sphinx_design',
-    'sphinx_tabs.tabs',
     'sphinx_copybutton',
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',

--- a/docs/source/cpp/memory.rst
+++ b/docs/source/cpp/memory.rst
@@ -231,9 +231,9 @@ Collecting ``$params`` allows us to record the size of the allocations
 requested, while collecting ``$retval`` allows us to record the address of
 recorded allocations, so we can correlate them with the call to free/de-allocate.
 
-.. tabs::
+.. tab-set::
 
-   .. tab:: jemalloc
+   .. tab-item:: jemalloc
       
       .. code-block:: shell
 
@@ -248,7 +248,7 @@ recorded allocations, so we can correlate them with the call to free/de-allocate
             -e probe_libarrow:je_arrow_rallocx__return \
             -e probe_libarrow:je_arrow_dallocx"
 
-   .. tab:: mimalloc
+   .. tab-item:: mimalloc
       
       .. code-block:: shell
 

--- a/docs/source/developers/bug_reports.rst
+++ b/docs/source/developers/bug_reports.rst
@@ -111,9 +111,9 @@ understand the issue and provide those supporting details up front.
 
 Good reproducible examples or minimal bug reports can be found in next tabs:
 
-.. tabs::
+.. tab-set::
 
-   .. tab:: Python
+   .. tab-item:: Python
 
       The ``print`` method of a timestamp with timezone errors:
 
@@ -137,7 +137,7 @@ Good reproducible examples or minimal bug reports can be found in next tabs:
          #  File "pyarrow/scalar.pxi", line 393, in pyarrow.lib._datetime_from_int
          #ValueError: fromutc: dt.tzinfo is not self
 
-   .. tab:: R
+   .. tab-item:: R
 
       Error when reading a CSV file with ``col_types`` option ``"T"`` or ``"t"`` when source data is in millisecond precision:
 

--- a/docs/source/developers/contributing.rst
+++ b/docs/source/developers/contributing.rst
@@ -164,23 +164,23 @@ Language specific
 
 Connection to the specific language development pages:
 
-.. tabs::
+.. tab-set::
 
-   .. tab:: C++
+   .. tab-item:: C++
 
       * :ref:`cpp-development`
       * :ref:`C++ Development Guidelines <development-cpp>`
       * :ref:`building-arrow-cpp`
 
-   .. tab:: Python
+   .. tab-item:: Python
 
       * :ref:`python-development`
 
-   .. tab:: R
+   .. tab-item:: R
 
       * `Arrow R Package: Developer environment setup <https://arrow.apache.org/docs/dev/r/articles/developers/setup.html>`_
       * `Arrow R Package: Common developer workflow tasks <https://arrow.apache.org/docs/dev/r/articles/developers/workflow.html>`_
 
-   .. tab:: Ruby
+   .. tab-item:: Ruby
 
       * `Red Arrow - Apache Arrow Ruby <https://github.com/apache/arrow/tree/master/ruby/red-arrow#development>`_

--- a/docs/source/developers/guide/step_by_step/arrow_codebase.rst
+++ b/docs/source/developers/guide/step_by_step/arrow_codebase.rst
@@ -102,9 +102,9 @@ C++ we must create the binding manually to use it in that implementation.
 	There is much you can learn by checking **Pull Requests**
 	and **unit tests** for similar issues.  
 
-.. tabs::
+.. tab-set::
 
-   .. tab:: Python
+   .. tab-item:: Python
 
       **Adding a fix in Python**
 
@@ -143,7 +143,7 @@ C++ we must create the binding manually to use it in that implementation.
       If you are adding a new future in Python you can look at
       the :ref:`tutorial <python_tutorial>` for ideas.
 
-   .. tab:: R
+   .. tab-item:: R
 
       **Philosophy behind R bindings**
 

--- a/docs/source/developers/guide/step_by_step/building.rst
+++ b/docs/source/developers/guide/step_by_step/building.rst
@@ -118,9 +118,9 @@ for all things connected to the build, also for setting CMake flags.
 Building other Arrow libraries
 ==============================
 
-.. tabs::
+.. tab-set::
 
-   .. tab:: Building PyArrow
+   .. tab-item:: Building PyArrow
 
       After building the Arrow C++ library, you need to build PyArrow on top
       of it also. The reason is the same; so you can edit the code and run
@@ -167,7 +167,7 @@ Building other Arrow libraries
       made changes to any C++ files. In this case,
       re-run the build commands again.
 
-   .. tab:: Building the R package
+   .. tab-item:: Building the R package
 
      When working on code in the R package, depending on your OS and planned
      changes, you may or may not need to build the Arrow C++ library (often

--- a/docs/source/developers/guide/step_by_step/styling.rst
+++ b/docs/source/developers/guide/step_by_step/styling.rst
@@ -27,9 +27,9 @@ In this section we will provide links to the existing documentation
 to make it easier for you to find the relevant information about
 linters and styling of the code.
 
-.. tabs::
+.. tab-set::
 
-   .. tab:: PyArrow
+   .. tab-item:: PyArrow
 
       We use flake8 linting for styling issues in Python. To help
       developers check styling of the code, among other common
@@ -40,7 +40,7 @@ linters and styling of the code.
       can be found in the Coding Style section of the
       :ref:`python-development`.
 
-   .. tab:: R package
+   .. tab-item:: R package
 
       For the R package you can use ``{lintr}`` or ``{styler}``
       to check if the code follows the

--- a/docs/source/developers/guide/step_by_step/testing.rst
+++ b/docs/source/developers/guide/step_by_step/testing.rst
@@ -32,9 +32,9 @@ Testing 🧪
 
 In this section we outline steps needed for unit testing in Arrow.
 
-.. tabs::
+.. tab-set::
 
-   .. tab:: PyArrow
+   .. tab-item:: PyArrow
 
       We use `pytest <https://docs.pytest.org/en/latest/>`_ for
       unit tests in Python. For more info about the required
@@ -119,7 +119,7 @@ In this section we outline steps needed for unit testing in Arrow.
       `Full pytest documentation <https://docs.pytest.org/en/stable/contents.html>`_
 
 
-   .. tab:: R package
+   .. tab-item:: R package
 
       We use `testthat <https://testthat.r-lib.org/index.html>`_ for
       unit testing in R. More specifically, we use the `3rd edition


### PR DESCRIPTION
This PR replaces the use of `sphinx-tabs` directives with `tab-set` and `tab-item` directive from `sphinx-design`.