### PR TITLE
ARROW-14942: [R] Bindings for lubridate's dpicoseconds, dnanoseconds, desconds, dmilliseconds, dmicroseconds

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -25,6 +25,8 @@
   * Added `make_date()` & `make_datetime()` + `ISOdatetime()` & `ISOdate()` to create date-times from numeric representations. 
   * Added `decimal_date()` and `date_decimal()`
   * Added `make_difftime()` (duration constructor)
+  * `make_date()` & `make_datetime()` + `ISOdatetime()` & `ISOdate()` to create date-times from numeric representations.
+  * duration helper functions: `dyears()`, `dmonths()`, `dweeks()`, `ddays()`, `dhours()`, `dminutes()`, `dseconds()`, `dmilliseconds()`, `dmicroseconds()`, `dnanoseconds()`.
 * date-time functionality:
   * Added `difftime` and `as.difftime()` 
   * Added `as.Date()` to convert to date

--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -25,8 +25,7 @@
   * Added `make_date()` & `make_datetime()` + `ISOdatetime()` & `ISOdate()` to create date-times from numeric representations. 
   * Added `decimal_date()` and `date_decimal()`
   * Added `make_difftime()` (duration constructor)
-  * `make_date()` & `make_datetime()` + `ISOdatetime()` & `ISOdate()` to create date-times from numeric representations.
-  * duration helper functions: `dyears()`, `dmonths()`, `dweeks()`, `ddays()`, `dhours()`, `dminutes()`, `dseconds()`, `dmilliseconds()`, `dmicroseconds()`, `dnanoseconds()`.
+  * Added duration helper functions: `dyears()`, `dmonths()`, `dweeks()`, `ddays()`, `dhours()`, `dminutes()`, `dseconds()`, `dmilliseconds()`, `dmicroseconds()`, `dnanoseconds()`.
 * date-time functionality:
   * Added `difftime` and `as.difftime()` 
   * Added `as.Date()` to convert to date

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -350,6 +350,8 @@ register_bindings_duration <- function() {
     delta <- build_expr("floor", seconds * fraction)
     delta <- delta$cast(int64())
     start + delta$cast(duration("s"))
+    })
+  }
   register_binding("dseconds", function(x = 1) {
     dseconds_int64 <- Expression$create("cast", x, options = cast_options(to_type = int64()))
     build_expr("cast", dseconds_int64, options = list(to_type = duration(unit = "s")))

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -353,11 +353,11 @@ register_bindings_duration <- function() {
   })
 }
 
+make_duration <- function(x, unit) {
+  x <- build_expr("cast", x, options = cast_options(to_type = int64()))
+  x$cast(duration(unit))
+}
 register_bindings_duration_helpers <- function() {
-  make_duration <- function(x, unit) {
-    x <- build_expr("cast", x, options = cast_options(to_type = int64()))
-    x$cast(duration(unit))
-  }
   register_binding("dseconds", function(x = 1) {
     make_duration(x, "s")
   })

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -354,16 +354,16 @@ register_bindings_duration <- function() {
 }
 
 .helpers_function_map <- list(
-  "dminutes" = c(60, "s"),
-  "dhours" = c(3600, "s"),
-  "ddays" = c(86400, "s"),
-  "dweeks" = c(604800, "s"),
-  "dmonths" = c(2629800, "s"),
-  "ydyears" = c(31557600, "s"),
-  "dseconds" = c(1, "s"),
-  "dmilliseconds" = c(1, "ms"),
-  "dmicroseconds" = c(1, "us"),
-  "dnanoseconds" = c(1, "ns")
+  "dminutes" = list(60, "s"),
+  "dhours" = list(3600, "s"),
+  "ddays" = list(86400, "s"),
+  "dweeks" = list(604800, "s"),
+  "dmonths" = list(2629800, "s"),
+  "dyears" = list(31557600, "s"),
+  "dseconds" = list(1, "s"),
+  "dmilliseconds" = list(1, "ms"),
+  "dmicroseconds" = list(1, "us"),
+  "dnanoseconds" = list(1, "ns")
 )
 make_duration <- function(x, unit) {
   x <- build_expr("cast", x, options = cast_options(to_type = int64()))
@@ -380,8 +380,8 @@ register_bindings_duration_helpers <- function() {
     register_binding(
       name,
       duration_helpers_map_factory(
-        .helpers_function_map[[name]][1],
-        .helpers_function_map[[name]][2]
+        .helpers_function_map[[name]][[1]],
+        .helpers_function_map[[name]][[2]]
       )
     )
   }

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -353,28 +353,6 @@ register_bindings_duration <- function() {
   })
 }
 
-make_duration <- function(x, unit) {
-  x <- build_expr("cast", x, options = cast_options(to_type = int64()))
-  x$cast(duration(unit))
-}
-register_bindings_duration_helpers <- function() {
-  register_binding("dseconds", function(x = 1) {
-    make_duration(x, "s")
-  })
-  register_binding("dmilliseconds", function(x = 1) {
-    make_duration(x, "ms")
-  })
-  register_binding("dmicroseconds", function(x = 1) {
-    make_duration(x, "us")
-  })
-  register_binding("dnanoseconds", function(x = 1) {
-    make_duration(x, "ns")
-  })
-  register_binding("dpicoseconds", function(x = 1) {
-    abort("Duration in picoseconds not supported in Arrow.")
-  })
-}
-
 register_bindings_difftime_constructors <- function() {
   register_binding("make_difftime", function(num = NULL,
                                              units = "secs",
@@ -427,8 +405,6 @@ register_bindings_duration_helpers <- function() {
   })
   register_binding("dyears", function(x = 1) {
     make_duration(x * 31557600, "s")
-<<<<<<< HEAD
-=======
   })
   register_binding("dseconds", function(x = 1) {
     make_duration(x, "s")
@@ -444,7 +420,6 @@ register_bindings_duration_helpers <- function() {
   })
   register_binding("dpicoseconds", function(x = 1) {
     abort("Duration in picoseconds not supported in Arrow.")
->>>>>>> 3651fb81a (Correct two typos left from the conflict merge)
   })
 }
 

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -354,21 +354,21 @@ register_bindings_duration <- function() {
 }
 
 register_bindings_duration_helpers <- function() {
-  register_binding("dseconds", function(x = 1) {
+  make_duration <- function(x, unit) {
     x <- build_expr("cast", x, options = cast_options(to_type = int64()))
-    x$cast(duration("s"))
+    x$cast(duration(unit))
+  }
+  register_binding("dseconds", function(x = 1) {
+    make_duration(x, "s")
   })
   register_binding("dmilliseconds", function(x = 1) {
-    x <- build_expr("cast", x, options = cast_options(to_type = int64()))
-    x$cast(duration("ms"))
+    make_duration(x, "ms")
   })
   register_binding("dmicroseconds", function(x = 1) {
-    x <- build_expr("cast", x, options = cast_options(to_type = int64()))
-    x$cast(duration("us"))
+    make_duration(x, "us")
   })
   register_binding("dnanoseconds", function(x = 1) {
-    x <- build_expr("cast", x, options = cast_options(to_type = int64()))
-    x$cast(duration("ns"))
+    make_duration(x, "ns")
   })
   register_binding("dpicoseconds", function(x = 1) {
     abort("Duration in picoseconds not supported in Arrow.")

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -350,6 +350,24 @@ register_bindings_duration <- function() {
     delta <- build_expr("floor", seconds * fraction)
     delta <- delta$cast(int64())
     start + delta$cast(duration("s"))
+  register_binding("dseconds", function(x = 1) {
+    dseconds_int64 <- Expression$create("cast", x, options = cast_options(to_type = int64()))
+    build_expr("cast", dseconds_int64, options = list(to_type = duration(unit = "s")))
+  })
+  register_binding("dmilliseconds", function(x = 1) {
+    dmilliseconds_int64 <- Expression$create("cast", x, options = cast_options(to_type = int64()))
+    build_expr("cast", dmilliseconds_int64, options = list(to_type = duration(unit = "ms")))
+  })
+  register_binding("dmicroseconds", function(x = 1) {
+    dmicroseconds_int64 <- Expression$create("cast", x, options = cast_options(to_type = int64()))
+    build_expr("cast", dmicroseconds_int64, options = list(to_type = duration(unit = "us")))
+  })
+  register_binding("dnanoseconds", function(x = 1) {
+    dnanoseconds_int64 <- Expression$create("cast", x, options = cast_options(to_type = int64()))
+    build_expr("cast", dnanoseconds_int64, options = list(to_type = duration(unit = "ns")))
+  })
+  register_binding("dpicoseconds", function(x = 1) {
+    arrow_not_supported("Duration in picoseconds.")
   })
 }
 

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -427,6 +427,24 @@ register_bindings_duration_helpers <- function() {
   })
   register_binding("dyears", function(x = 1) {
     make_duration(x * 31557600, "s")
+<<<<<<< HEAD
+=======
+  })
+  register_binding("dseconds", function(x = 1) {
+    make_duration(x, "s")
+  })
+  register_binding("dmilliseconds", function(x = 1) {
+    make_duration(x, "ms")
+  })
+  register_binding("dmicroseconds", function(x = 1) {
+    make_duration(x, "us")
+  })
+  register_binding("dnanoseconds", function(x = 1) {
+    make_duration(x, "ns")
+  })
+  register_binding("dpicoseconds", function(x = 1) {
+    abort("Duration in picoseconds not supported in Arrow.")
+>>>>>>> 3651fb81a (Correct two typos left from the conflict merge)
   })
 }
 

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -376,7 +376,7 @@ register_bindings_duration_helpers <- function() {
     function(x = 1) make_duration(x * value, unit)
   }
 
-  for (name in names(.helpers_function_map)){
+  for (name in names(.helpers_function_map)) {
     register_binding(
       name,
       duration_helpers_map_factory(

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -323,6 +323,37 @@ register_bindings_duration <- function() {
 
     build_expr("cast", x, options = cast_options(to_type = duration(unit = "s")))
   })
+  register_binding("dseconds", function(x = 1) {
+    if (!inherits(x, "Expression")) {
+      x <- Expression$scalar(x)
+    }
+    dseconds_int64 <- Expression$create("cast", x, options = cast_options(to_type = int64()))
+    build_expr("cast", dseconds_int64, options = list(to_type = duration(unit = "s")))
+  })
+  register_binding("dmilliseconds", function(x = 1) {
+    if (!inherits(x, "Expression")) {
+      x <- Expression$scalar(x)
+    }
+    dmilliseconds_int64 <- Expression$create("cast", x, options = cast_options(to_type = int64()))
+    build_expr("cast", dmilliseconds_int64, options = list(to_type = duration(unit = "ms")))
+  })
+  register_binding("dmicroseconds", function(x = 1) {
+    if (!inherits(x, "Expression")) {
+      x <- Expression$scalar(x)
+    }
+    dmicroseconds_int64 <- Expression$create("cast", x, options = cast_options(to_type = int64()))
+    build_expr("cast", dmicroseconds_int64, options = list(to_type = duration(unit = "us")))
+  })
+  register_binding("dnanoseconds", function(x = 1) {
+    if (!inherits(x, "Expression")) {
+      x <- Expression$scalar(x)
+    }
+    dnanoseconds_int64 <- Expression$create("cast", x, options = cast_options(to_type = int64()))
+    build_expr("cast", dnanoseconds_int64, options = list(to_type = duration(unit = "ns")))
+  })
+  register_binding("dpicoseconds", function(x = 1) {
+    abort("Duration in picoseconds not supported in Arrow.")
+  })
   register_binding("decimal_date", function(date) {
     y <- build_expr("year", date)
     start <- call_binding("make_datetime", year = y, tz = "UTC")
@@ -350,26 +381,6 @@ register_bindings_duration <- function() {
     delta <- build_expr("floor", seconds * fraction)
     delta <- delta$cast(int64())
     start + delta$cast(duration("s"))
-    })
-  }
-  register_binding("dseconds", function(x = 1) {
-    dseconds_int64 <- Expression$create("cast", x, options = cast_options(to_type = int64()))
-    build_expr("cast", dseconds_int64, options = list(to_type = duration(unit = "s")))
-  })
-  register_binding("dmilliseconds", function(x = 1) {
-    dmilliseconds_int64 <- Expression$create("cast", x, options = cast_options(to_type = int64()))
-    build_expr("cast", dmilliseconds_int64, options = list(to_type = duration(unit = "ms")))
-  })
-  register_binding("dmicroseconds", function(x = 1) {
-    dmicroseconds_int64 <- Expression$create("cast", x, options = cast_options(to_type = int64()))
-    build_expr("cast", dmicroseconds_int64, options = list(to_type = duration(unit = "us")))
-  })
-  register_binding("dnanoseconds", function(x = 1) {
-    dnanoseconds_int64 <- Expression$create("cast", x, options = cast_options(to_type = int64()))
-    build_expr("cast", dnanoseconds_int64, options = list(to_type = duration(unit = "ns")))
-  })
-  register_binding("dpicoseconds", function(x = 1) {
-    arrow_not_supported("Duration in picoseconds.")
   })
 }
 

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -353,23 +353,39 @@ register_bindings_duration <- function() {
   })
 }
 
+.helpers_function_map <- list(
+  "dminutes" = c(60, "s"),
+  "dhours" = c(3600, "s"),
+  "ddays" = c(86400, "s"),
+  "dweeks" = c(604800, "s"),
+  "dmonths" = c(2629800, "s"),
+  "ydyears" = c(31557600, "s"),
+  "dseconds" = c(1, "s"),
+  "dmilliseconds" = c(1, "ms"),
+  "dmicroseconds" = c(1, "us"),
+  "dnanoseconds" = c(1, "ns")
+)
 make_duration <- function(x, unit) {
   x <- build_expr("cast", x, options = cast_options(to_type = int64()))
   x$cast(duration(unit))
 }
 register_bindings_duration_helpers <- function() {
-  register_binding("dseconds", function(x = 1) {
-    make_duration(x, "s")
-  })
-  register_binding("dmilliseconds", function(x = 1) {
-    make_duration(x, "ms")
-  })
-  register_binding("dmicroseconds", function(x = 1) {
-    make_duration(x, "us")
-  })
-  register_binding("dnanoseconds", function(x = 1) {
-    make_duration(x, "ns")
-  })
+  duration_helpers_map_factory <- function(value, unit) {
+    force(value)
+    force(unit)
+    function(x = 1) make_duration(x * value, unit)
+  }
+
+  for (name in names(.helpers_function_map)){
+    register_binding(
+      name,
+      duration_helpers_map_factory(
+        .helpers_function_map[[name]][1],
+        .helpers_function_map[[name]][2]
+      )
+    )
+  }
+
   register_binding("dpicoseconds", function(x = 1) {
     abort("Duration in picoseconds not supported in Arrow.")
   })
@@ -402,46 +418,6 @@ register_bindings_difftime_constructors <- function() {
 
     duration <- build_expr("cast", duration, options = cast_options(to_type = int64()))
     duration$cast(duration("s"))
-  })
-}
-
-make_duration <- function(x, unit) {
-  x <- build_expr("cast", x, options = cast_options(to_type = int64()))
-  x$cast(duration(unit))
-}
-register_bindings_duration_helpers <- function() {
-  register_binding("dminutes", function(x = 1) {
-    make_duration(x * 60, "s")
-  })
-  register_binding("dhours", function(x = 1) {
-    make_duration(x * 3600, "s")
-  })
-  register_binding("ddays", function(x = 1) {
-    make_duration(x * 86400, "s")
-  })
-  register_binding("dweeks", function(x = 1) {
-    make_duration(x * 604800, "s")
-  })
-  register_binding("dmonths", function(x = 1) {
-    make_duration(x * 2629800, "s")
-  })
-  register_binding("dyears", function(x = 1) {
-    make_duration(x * 31557600, "s")
-  })
-  register_binding("dseconds", function(x = 1) {
-    make_duration(x, "s")
-  })
-  register_binding("dmilliseconds", function(x = 1) {
-    make_duration(x, "ms")
-  })
-  register_binding("dmicroseconds", function(x = 1) {
-    make_duration(x, "us")
-  })
-  register_binding("dnanoseconds", function(x = 1) {
-    make_duration(x, "ns")
-  })
-  register_binding("dpicoseconds", function(x = 1) {
-    abort("Duration in picoseconds not supported in Arrow.")
   })
 }
 

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -355,32 +355,20 @@ register_bindings_duration <- function() {
 
 register_bindings_duration_helpers <- function() {
   register_binding("dseconds", function(x = 1) {
-    if (!inherits(x, "Expression")) {
-      x <- Expression$scalar(x)
-    }
-    dseconds_int64 <- Expression$create("cast", x, options = cast_options(to_type = int64()))
-    build_expr("cast", dseconds_int64, options = list(to_type = duration(unit = "s")))
+    x <- build_expr("cast", x, options = cast_options(to_type = int64()))
+    x$cast(duration("s"))
   })
   register_binding("dmilliseconds", function(x = 1) {
-    if (!inherits(x, "Expression")) {
-      x <- Expression$scalar(x)
-    }
-    dmilliseconds_int64 <- Expression$create("cast", x, options = cast_options(to_type = int64()))
-    build_expr("cast", dmilliseconds_int64, options = list(to_type = duration(unit = "ms")))
+    x <- build_expr("cast", x, options = cast_options(to_type = int64()))
+    x$cast(duration("ms"))
   })
   register_binding("dmicroseconds", function(x = 1) {
-    if (!inherits(x, "Expression")) {
-      x <- Expression$scalar(x)
-    }
-    dmicroseconds_int64 <- Expression$create("cast", x, options = cast_options(to_type = int64()))
-    build_expr("cast", dmicroseconds_int64, options = list(to_type = duration(unit = "us")))
+    x <- build_expr("cast", x, options = cast_options(to_type = int64()))
+    x$cast(duration("us"))
   })
   register_binding("dnanoseconds", function(x = 1) {
-    if (!inherits(x, "Expression")) {
-      x <- Expression$scalar(x)
-    }
-    dnanoseconds_int64 <- Expression$create("cast", x, options = cast_options(to_type = int64()))
-    build_expr("cast", dnanoseconds_int64, options = list(to_type = duration(unit = "ns")))
+    x <- build_expr("cast", x, options = cast_options(to_type = int64()))
+    x$cast(duration("ns"))
   })
   register_binding("dpicoseconds", function(x = 1) {
     abort("Duration in picoseconds not supported in Arrow.")

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1303,6 +1303,15 @@ test_that("dminutes, dhours, ddays, dweeks, dmonths, dyears", {
     tibble(),
     ignore_attr = TRUE
   )
+
+  # double -> duration not supported in Arrow.
+  # Error is generated in the C++ code
+  expect_error(
+    test_df %>%
+      arrow_table() %>%
+      mutate(r_obj_dminutes = dminutes(1.12345)) %>%
+      collect()
+  )
 })
 
 test_that("dseconds, dmilliseconds, dmicroseconds, dnanoseconds, dpicoseconds", {
@@ -1352,6 +1361,15 @@ test_that("dseconds, dmilliseconds, dmicroseconds, dnanoseconds, dpicoseconds", 
   expect_error(
     call_binding("dpicoseconds"),
     "Duration in picoseconds not supported in Arrow"
+  )
+
+  # double -> duration not supported in Arrow.
+  # Error is generated in the C++ code
+  expect_error(
+    test_df %>%
+      arrow_table() %>%
+      mutate(r_obj_dseconds = dseconds(1.12345)) %>%
+      collect()
   )
 })
 

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1305,6 +1305,56 @@ test_that("dminutes, dhours, ddays, dweeks, dmonths, dyears", {
   )
 })
 
+test_that("dseconds, dmilliseconds, dmicroseconds, dnanoseconds, dpicoseconds", {
+  example_d <- tibble(x = c(1:10, NA))
+  date_to_add <- ymd("2009-08-03", tz = "America/Chicago")
+
+  compare_dplyr_binding(
+    .input %>%
+      mutate(
+        dseconds = dseconds(x),
+        dmilliseconds = dmilliseconds(x),
+        dmicroseconds = dmicroseconds(x),
+        dnanoseconds = dnanoseconds(x),
+      ) %>%
+      collect(),
+    example_d,
+    ignore_attr = TRUE
+  )
+
+  compare_dplyr_binding(
+    .input %>%
+      mutate(
+        dseconds = dseconds(x),
+        dmicroseconds = dmicroseconds(x),
+        new_date_1 = date_to_add + dseconds,
+        new_date_2 = date_to_add + dseconds - dmicroseconds,
+        new_duration = dseconds - dmicroseconds
+      ) %>%
+      collect(),
+    example_d,
+    ignore_attr = TRUE
+  )
+
+  compare_dplyr_binding(
+    .input %>%
+      mutate(
+        r_obj_dseconds = dseconds(1),
+        r_obj_dmilliseconds = dmilliseconds(2),
+        r_obj_dmicroseconds = dmicroseconds(3),
+        r_obj_dnanoseconds = dnanoseconds(4)
+      ) %>%
+      collect(),
+    tibble(),
+    ignore_attr = TRUE
+  )
+
+  expect_error(
+    call_binding("dpicoseconds"),
+    "Duration in picoseconds not supported in Arrow"
+  )
+})
+
 test_that("make_difftime()", {
   test_df <- tibble(
     seconds = c(3, 4, 5, 6),

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1260,6 +1260,11 @@ test_that("dminutes, dhours, ddays, dweeks, dmonths, dyears", {
   example_d <- tibble(x = c(1:10, NA))
   date_to_add <- ymd("2009-08-03", tz = "Pacific/Marquesas")
 
+  # When comparing results we use ignore_attr = TRUE because of the diff in:
+  # attribute 'package' (absent vs. 'lubridate')
+  # class (difftime vs Duration)
+  # attribute 'units' (character vector ('secs') vs. absent)
+
   compare_dplyr_binding(
     .input %>%
       mutate(
@@ -1317,6 +1322,11 @@ test_that("dminutes, dhours, ddays, dweeks, dmonths, dyears", {
 test_that("dseconds, dmilliseconds, dmicroseconds, dnanoseconds, dpicoseconds", {
   example_d <- tibble(x = c(1:10, NA))
   date_to_add <- ymd("2009-08-03", tz = "Pacific/Marquesas")
+
+  # When comparing results we use ignore_attr = TRUE because of the diff in:
+  # attribute 'package' (absent vs. 'lubridate')
+  # class (difftime vs Duration)
+  # attribute 'units' (character vector ('secs') vs. absent)
 
   compare_dplyr_binding(
     .input %>%

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1258,7 +1258,7 @@ test_that("`decimal_date()` and `date_decimal()`", {
 
 test_that("dminutes, dhours, ddays, dweeks, dmonths, dyears", {
   example_d <- tibble(x = c(1:10, NA))
-  date_to_add <- ymd("2009-08-03", tz = "America/Chicago")
+  date_to_add <- ymd("2009-08-03", tz = "Pacific/Marquesas")
 
   compare_dplyr_binding(
     .input %>%
@@ -1307,7 +1307,7 @@ test_that("dminutes, dhours, ddays, dweeks, dmonths, dyears", {
 
 test_that("dseconds, dmilliseconds, dmicroseconds, dnanoseconds, dpicoseconds", {
   example_d <- tibble(x = c(1:10, NA))
-  date_to_add <- ymd("2009-08-03", tz = "America/Chicago")
+  date_to_add <- ymd("2009-08-03", tz = "Pacific/Marquesas")
 
   compare_dplyr_binding(
     .input %>%


### PR DESCRIPTION
This PR adds bindings for lubridate's `dseconds`, `dmilliseconds`, `dmicroseconds` and `dnanoseconds`.

As `picoseconds` are not supported by [duration in Arrow](https://arrow.apache.org/docs/cpp/api/datatype.html#_CPPv4N5arrow4Type4type8DURATIONE) and duration is of integer type, the call to `picoseconds()` raises a warning.