### PR TITLE
ARROW-16163: [Go] IPC FileReader leaks memory when used with ZSTD compression

### DIFF
--- a/go/arrow/ipc/file_reader.go
+++ b/go/arrow/ipc/file_reader.go
@@ -326,6 +326,7 @@ func newRecord(schema *arrow.Schema, meta *memory.Buffer, body ReadAtSeeker, mem
 	bodyCompress := md.Compression(nil)
 	if bodyCompress != nil {
 		codec = getDecompressor(bodyCompress.Codec())
+		defer codec.Close()
 	}
 
 	ctx := &arrayLoaderContext{


### PR DESCRIPTION
When used in its stream version (calling .Read()), the ZSTD decoder makes use of a Goroutine with a channel to receive input. This channel is closed by the decoder's .Close() function, which ends the Goroutine and therefore the collection of its memory by the GC.

Here, we add Close() to the exposed decompressor interface and call its close at the end of the function that uses it.