### PR TITLE
ARROW-14168: [R] Warn only once about arrow function differences

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -26,6 +26,7 @@
 * date-time functionality:
   * `difftime` and `as.difftime()` 
   * `as.Date()` to convert to date
+* `median()` and `quantile()` will warn once about approximate calculations regardless of interactivity.
 
 # arrow 7.0.0
 

--- a/r/R/dplyr-summarize.R
+++ b/r/R/dplyr-summarize.R
@@ -107,7 +107,8 @@ register_bindings_aggregate <- function() {
     warn(
       "quantile() currently returns an approximate quantile in Arrow",
       .frequency = "once",
-      .frequency_id = "arrow.quantile.approximate"
+      .frequency_id = "arrow.quantile.approximate",
+      class = "arrow.quantile.approximate"
     )
     list(
       fun = "tdigest",
@@ -121,7 +122,8 @@ register_bindings_aggregate <- function() {
     warn(
       "median() currently returns an approximate median in Arrow",
       .frequency = "once",
-      .frequency_id = "arrow.median.approximate"
+      .frequency_id = "arrow.median.approximate",
+      class = "arrow.median.approximate"
     )
     list(
       fun = "approximate_median",

--- a/r/R/dplyr-summarize.R
+++ b/r/R/dplyr-summarize.R
@@ -106,7 +106,7 @@ register_bindings_aggregate <- function() {
     # this warning (ARROW-14021)
     warn(
       "quantile() currently returns an approximate quantile in Arrow",
-      .frequency = ifelse(is_interactive(), "once", "always"),
+      .frequency = "once",
       .frequency_id = "arrow.quantile.approximate"
     )
     list(
@@ -120,7 +120,7 @@ register_bindings_aggregate <- function() {
     # this warning (ARROW-14021)
     warn(
       "median() currently returns an approximate median in Arrow",
-      .frequency = ifelse(is_interactive(), "once", "always"),
+      .frequency = "once",
       .frequency_id = "arrow.median.approximate"
     )
     list(

--- a/r/tests/testthat/helper-arrow.R
+++ b/r/tests/testthat/helper-arrow.R
@@ -58,14 +58,18 @@ test_that <- function(what, code) {
 
 # backport of 4.0.0 implementation
 suppressWarnings <- function (expr, classes = "warning") {
-  withCallingHandlers(
-    expr,
-    warning = function(w) {
-      if (inherits(w, classes)) {
-        invokeRestart("muffleWarning")
+  if (getRversion() < "4.0.0") {
+    withCallingHandlers(
+      expr,
+      warning = function(w) {
+        if (inherits(w, classes)) {
+          invokeRestart("muffleWarning")
+        }
       }
-    }
-  )
+    )
+  } else {
+    base::suppressWarnings(expr = expr, classes = classes)
+  }
 }
 
 # Wrapper to run tests that only touch R code even when the C++ library isn't

--- a/r/tests/testthat/helper-arrow.R
+++ b/r/tests/testthat/helper-arrow.R
@@ -69,7 +69,6 @@ if (getRversion() < "4.0.0") {
     )
   }
 }
-}
 
 # Wrapper to run tests that only touch R code even when the C++ library isn't
 # available (so that at least some tests are run on those platforms)

--- a/r/tests/testthat/helper-arrow.R
+++ b/r/tests/testthat/helper-arrow.R
@@ -60,7 +60,11 @@ test_that <- function(what, code) {
 suppressWarnings <- function (expr, classes = "warning") {
   withCallingHandlers(
     expr,
-    warning = function(w) if (inherits(w, classes)) invokeRestart("muffleWarning")
+    warning = function(w) {
+      if (inherits(w, classes)) {
+        invokeRestart("muffleWarning")
+      }
+    }
   )
 }
 

--- a/r/tests/testthat/helper-arrow.R
+++ b/r/tests/testthat/helper-arrow.R
@@ -60,7 +60,7 @@ test_that <- function(what, code) {
 suppressWarnings <- function (expr, classes = "warning") {
   withCallingHandlers(
     expr,
-    warning = function(w) if (inherits(w, classes)) tryInvokeRestart("muffleWarning")
+    warning = function(w) if (inherits(w, classes)) invokeRestart("muffleWarning")
   )
 }
 

--- a/r/tests/testthat/helper-arrow.R
+++ b/r/tests/testthat/helper-arrow.R
@@ -57,8 +57,8 @@ test_that <- function(what, code) {
 }
 
 # backport of 4.0.0 implementation
-suppressWarnings <- function(expr, classes = "warning") {
-  if (getRversion() < "4.0.0") {
+if (getRversion() < "4.0.0") {
+  suppressWarnings <- function(expr, classes = "warning") {
     withCallingHandlers(
       expr,
       warning = function(w) {
@@ -67,9 +67,8 @@ suppressWarnings <- function(expr, classes = "warning") {
         }
       }
     )
-  } else {
-    base::suppressWarnings(expr = expr, classes = classes)
   }
+}
 }
 
 # Wrapper to run tests that only touch R code even when the C++ library isn't

--- a/r/tests/testthat/helper-arrow.R
+++ b/r/tests/testthat/helper-arrow.R
@@ -57,7 +57,7 @@ test_that <- function(what, code) {
 }
 
 # backport of 4.0.0 implementation
-suppressWarnings <- function (expr, classes = "warning") {
+suppressWarnings <- function(expr, classes = "warning") {
   if (getRversion() < "4.0.0") {
     withCallingHandlers(
       expr,

--- a/r/tests/testthat/helper-arrow.R
+++ b/r/tests/testthat/helper-arrow.R
@@ -56,6 +56,14 @@ test_that <- function(what, code) {
   })
 }
 
+# backport of 4.0.0 implementation
+suppressWarnings <- function (expr, classes = "warning") {
+  withCallingHandlers(
+    expr,
+    warning = function(w) if (inherits(w, classes)) tryInvokeRestart("muffleWarning")
+  )
+}
+
 # Wrapper to run tests that only touch R code even when the C++ library isn't
 # available (so that at least some tests are run on those platforms)
 r_only <- function(code) {

--- a/r/tests/testthat/test-dplyr-summarize.R
+++ b/r/tests/testthat/test-dplyr-summarize.R
@@ -299,6 +299,8 @@ test_that("median()", {
   # Use old testthat behavior here so we don't have to assert the same warning
   # over and over
   local_edition(2)
+  # warn always, not just once
+  rlang::local_options(rlib_warning_verbosity = "verbose")
 
   # with groups
   compare_dplyr_binding(
@@ -317,6 +319,9 @@ test_that("median()", {
     tbl,
     warning = "median\\(\\) currently returns an approximate median in Arrow"
   )
+  # silence warnings
+  rlang::local_options(rlib_warning_verbosity = "quiet")
+
   # without groups, with na.rm = TRUE
   compare_dplyr_binding(
     .input %>%
@@ -325,8 +330,7 @@ test_that("median()", {
         med_int_narmt = as.double(median(int, TRUE))
       ) %>%
       collect(),
-    tbl,
-    warning = "median\\(\\) currently returns an approximate median in Arrow"
+    tbl
   )
   # without groups, with na.rm = FALSE (the default)
   compare_dplyr_binding(
@@ -338,8 +342,7 @@ test_that("median()", {
         med_int_narmf = as.double(median(int, na.rm = FALSE))
       ) %>%
       collect(),
-    tbl,
-    warning = "median\\(\\) currently returns an approximate median in Arrow"
+    tbl
   )
   local_edition(3)
 })
@@ -368,6 +371,9 @@ test_that("quantile()", {
   # below are enclosed in as.double() to work around this known difference.
 
   local_edition(2)
+  # warn always, not just once
+  rlang::local_options(rlib_warning_verbosity = "verbose")
+
   # with groups
   expect_warning(
     expect_equal(
@@ -392,44 +398,38 @@ test_that("quantile()", {
     "quantile() currently returns an approximate quantile in Arrow",
     fixed = TRUE
   )
+  # silence warnings
+  rlang::local_options(rlib_warning_verbosity = "quiet")
 
   # without groups
-  expect_warning(
-    expect_equal(
-      tbl %>%
-        summarize(
-          q_dbl = quantile(dbl, probs = 0.5, na.rm = TRUE, names = FALSE),
-          q_int = as.double(
-            quantile(int, probs = 0.5, na.rm = TRUE, names = FALSE)
-          )
-        ),
-      Table$create(tbl) %>%
-        summarize(
-          q_dbl = quantile(dbl, probs = 0.5, na.rm = TRUE),
-          q_int = as.double(quantile(int, probs = 0.5, na.rm = TRUE))
-        ) %>%
-        collect()
-    ),
-    "quantile() currently returns an approximate quantile in Arrow",
-    fixed = TRUE
+  expect_equal(
+    tbl %>%
+      summarize(
+        q_dbl = quantile(dbl, probs = 0.5, na.rm = TRUE, names = FALSE),
+        q_int = as.double(
+          quantile(int, probs = 0.5, na.rm = TRUE, names = FALSE)
+        )
+      ),
+    Table$create(tbl) %>%
+      summarize(
+        q_dbl = quantile(dbl, probs = 0.5, na.rm = TRUE),
+        q_int = as.double(quantile(int, probs = 0.5, na.rm = TRUE))
+      ) %>%
+      collect()
   )
 
   # with missing values and na.rm = FALSE
-  expect_warning(
-    expect_equal(
-      tibble(
-        q_dbl = NA_real_,
-        q_int = NA_real_
-      ),
-      Table$create(tbl) %>%
-        summarize(
-          q_dbl = quantile(dbl, probs = 0.5, na.rm = FALSE),
-          q_int = as.double(quantile(int, probs = 0.5, na.rm = FALSE))
-        ) %>%
-        collect()
+  expect_equal(
+    tibble(
+      q_dbl = NA_real_,
+      q_int = NA_real_
     ),
-    "quantile() currently returns an approximate quantile in Arrow",
-    fixed = TRUE
+    Table$create(tbl) %>%
+      summarize(
+        q_dbl = quantile(dbl, probs = 0.5, na.rm = FALSE),
+        q_int = as.double(quantile(int, probs = 0.5, na.rm = FALSE))
+      ) %>%
+      collect()
   )
   local_edition(3)
 

--- a/r/tests/testthat/test-dplyr-summarize.R
+++ b/r/tests/testthat/test-dplyr-summarize.R
@@ -20,6 +20,8 @@ skip_if(on_old_windows())
 withr::local_options(list(
   arrow.summarise.sort = TRUE,
   rlib_warning_verbosity = "verbose",
+  # This prevents the warning in `summarize()` about having grouped output without 
+  # also specifying what to do with `.groups`
   dplyr.summarise.inform = FALSE
 ))
 

--- a/r/tests/testthat/test-dplyr-summarize.R
+++ b/r/tests/testthat/test-dplyr-summarize.R
@@ -20,7 +20,7 @@ skip_if(on_old_windows())
 withr::local_options(list(
   arrow.summarise.sort = TRUE,
   rlib_warning_verbosity = "verbose",
-  # This prevents the warning in `summarize()` about having grouped output without 
+  # This prevents the warning in `summarize()` about having grouped output without
   # also specifying what to do with `.groups`
   dplyr.summarise.inform = FALSE
 ))


### PR DESCRIPTION
Addresses [ARROW-14168](https://issues.apache.org/jira/browse/ARROW-14168) by changing `median()` and `quantile()` to warn once, and adjusts the tests accordingly.