### PR TITLE
ARROW-16178: [C++] Add a ThreadLocalState concept built on thread local

### DIFF
--- a/cpp/src/arrow/util/async_generator.h
+++ b/cpp/src/arrow/util/async_generator.h
@@ -1622,8 +1622,6 @@ class BackgroundGenerator {
   }
 
  protected:
-  static constexpr uint64_t kUnlikelyThreadId{std::numeric_limits<uint64_t>::max()};
-
   struct State {
     State(internal::Executor* io_executor, Iterator<T> it, int max_q, int q_restart)
         : io_executor(io_executor),
@@ -1695,7 +1693,7 @@ class BackgroundGenerator {
     const int max_q;
     const int q_restart;
     Iterator<T> it;
-    std::atomic<uint64_t> worker_thread_id{kUnlikelyThreadId};
+    std::atomic<uint64_t> worker_thread_id{internal::kUnlikelyThreadId};
 
     // If true, the task is actively pumping items from the queue and does not need a
     // restart
@@ -1795,7 +1793,7 @@ class BackgroundGenerator {
       // reference it.  We can safely transition to idle now.
       task_finished = state->task_finished;
       state->task_finished = Future<>();
-      state->worker_thread_id.store(kUnlikelyThreadId);
+      state->worker_thread_id.store(internal::kUnlikelyThreadId);
     }
     task_finished.MarkFinished();
   }

--- a/cpp/src/arrow/util/io_util.cc
+++ b/cpp/src/arrow/util/io_util.cc
@@ -1862,10 +1862,5 @@ uint64_t GetThreadId() {
   return equiv;
 }
 
-uint64_t GetOptionalThreadId() {
-  auto tid = GetThreadId();
-  return (tid == 0) ? tid - 1 : tid;
-}
-
 }  // namespace internal
 }  // namespace arrow

--- a/cpp/src/arrow/util/io_util.h
+++ b/cpp/src/arrow/util/io_util.h
@@ -339,6 +339,9 @@ Status SendSignalToThread(int signum, uint64_t thread_id);
 ARROW_EXPORT
 int64_t GetRandomSeed();
 
+/// \brief A value that should never be returned by GetThreadId
+static constexpr uint64_t kUnlikelyThreadId{std::numeric_limits<uint64_t>::max()};
+
 /// \brief Get the current thread id
 ///
 /// In addition to having the same properties as std::thread, the returned value


### PR DESCRIPTION
Add the ability to get the thread index from an executor.  Use this to create a "thread local state" object which can be used by runners in the executor.