### PR TITLE
ARROW-16187: [Go][Parquet] Properly utilize BufferedStream and buffer size when reading

### DIFF
--- a/go/internal/utils/buf_reader.go
+++ b/go/internal/utils/buf_reader.go
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package utils
 
 import (

--- a/go/internal/utils/buf_reader.go
+++ b/go/internal/utils/buf_reader.go
@@ -1,0 +1,179 @@
+package utils
+
+import (
+	"errors"
+	"io"
+)
+
+// bufferedReader is similar to bufio.Reader except
+// it will expand the buffer if necessary when asked to Peek
+// more bytes than are in the buffer
+type bufferedReader struct {
+	bufferSz int
+	buf      []byte
+	r, w     int
+	rd       io.Reader
+	err      error
+}
+
+func NewBufferedReader(rd io.Reader, sz int) *bufferedReader {
+	b, ok := rd.(*bufferedReader)
+	if ok && len(b.buf) >= sz {
+		return b
+	}
+
+	r := &bufferedReader{
+		rd: rd,
+	}
+	r.resizeBuffer(sz)
+	return r
+}
+
+func (b *bufferedReader) resetBuffer() {
+	if b.buf == nil {
+		b.buf = make([]byte, b.bufferSz)
+	} else if b.bufferSz > cap(b.buf) {
+		buf := b.buf
+		b.buf = make([]byte, b.bufferSz)
+		copy(b.buf, buf)
+	} else {
+		b.buf = b.buf[:b.bufferSz]
+	}
+}
+
+func (b *bufferedReader) resizeBuffer(newSize int) {
+	b.bufferSz = newSize
+	b.resetBuffer()
+}
+
+func (b *bufferedReader) fill() {
+	// slide existing data to the beginning
+	if b.r > 0 {
+		copy(b.buf, b.buf[b.r:b.w])
+		b.w -= b.r
+		b.r = 0
+	}
+
+	if b.w >= len(b.buf) {
+		panic("parquet/bufio: tried to fill full buffer")
+	}
+
+	n, err := io.ReadAtLeast(b.rd, b.buf[b.w:], 1)
+	if n < 0 {
+		panic("negative read")
+	}
+
+	b.w += n
+	b.err = err
+}
+
+func (b *bufferedReader) readErr() error {
+	err := b.err
+	b.err = nil
+	return err
+}
+
+func (b *bufferedReader) Buffered() int { return b.w - b.r }
+
+func (b *bufferedReader) SetBufferSize(newSize int) error {
+	if newSize <= 0 {
+		return errors.New("buffer size should be positive")
+	}
+
+	if b.w >= newSize {
+		return errors.New("cannot shrink read buffer if buffered data remains")
+	}
+
+	b.resizeBuffer(newSize)
+	return nil
+}
+
+func (b *bufferedReader) Peek(n int) ([]byte, error) {
+	if n < 0 {
+		return nil, errors.New("parquet/bufio: negative count")
+	}
+
+	if n > len(b.buf) {
+		if err := b.SetBufferSize(n); err != nil {
+			return nil, err
+		}
+	}
+
+	for b.w-b.r < n && b.w-b.r < len(b.buf) && b.err == nil {
+		b.fill() // b.w-b.r < len(b.buf) => buffer is not full
+	}
+
+	return b.buf[b.r : b.r+n], b.readErr()
+}
+
+func (b *bufferedReader) Discard(n int) (discarded int, err error) {
+	if n < 0 {
+		return 0, errors.New("negative count")
+	}
+
+	if n == 0 {
+		return
+	}
+
+	remain := n
+	for {
+		skip := b.Buffered()
+		if skip == 0 {
+			b.fill()
+			skip = b.Buffered()
+		}
+		if skip > remain {
+			skip = remain
+		}
+		b.r += skip
+		remain -= skip
+		if remain == 0 {
+			return n, nil
+		}
+		if b.err != nil {
+			return n - remain, b.readErr()
+		}
+	}
+}
+
+func (b *bufferedReader) Read(p []byte) (n int, err error) {
+	n = len(p)
+	if n == 0 {
+		if b.Buffered() > 0 {
+			return 0, nil
+		}
+		return 0, b.readErr()
+	}
+
+	if b.r == b.w {
+		if b.err != nil {
+			return 0, b.readErr()
+		}
+		if len(p) >= len(b.buf) {
+			// large read, empty buffer
+			// read directly into p to avoid extra copy
+			n, b.err = b.rd.Read(p)
+			if n < 0 {
+				panic("negative read")
+			}
+			return n, b.readErr()
+		}
+
+		// one read
+		// don't use b.fill
+		b.r, b.w = 0, 0
+		n, b.err = b.rd.Read(b.buf)
+		if n < 0 {
+			panic("negative read")
+		}
+		if n == 0 {
+			return 0, b.readErr()
+		}
+		b.w += n
+	}
+
+	// copy as much as we can
+	n = copy(p, b.buf[b.r:b.w])
+	b.r += n
+	return n, nil
+}

--- a/go/parquet/file/column_reader.go
+++ b/go/parquet/file/column_reader.go
@@ -30,6 +30,8 @@ import (
 )
 
 const (
+	// 4 MB is the default maximum page header size
+	defaultMaxPageHeaderSize = 4 * 1024 * 1024
 	// 16 KB is the default expected page header size
 	defaultPageHeaderSize = 16 * 1024
 )

--- a/go/parquet/file/column_reader.go
+++ b/go/parquet/file/column_reader.go
@@ -30,8 +30,6 @@ import (
 )
 
 const (
-	// 4 MB is the default maximum page header size
-	defaultMaxPageHeaderSize = 4 * 1024 * 1024
 	// 16 KB is the default expected page header size
 	defaultPageHeaderSize = 16 * 1024
 )

--- a/go/parquet/file/column_writer_test.go
+++ b/go/parquet/file/column_writer_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/apache/arrow/go/v8/arrow/bitutil"
 	"github.com/apache/arrow/go/v8/arrow/memory"
+	arrutils "github.com/apache/arrow/go/v8/internal/utils"
 	"github.com/apache/arrow/go/v8/parquet"
 	"github.com/apache/arrow/go/v8/parquet/compress"
 	"github.com/apache/arrow/go/v8/parquet/file"
@@ -233,7 +234,7 @@ func (p *PrimitiveWriterTestSuite) SetupTest() {
 
 func (p *PrimitiveWriterTestSuite) buildReader(nrows int64, compression compress.Compression) file.ColumnChunkReader {
 	p.readbuffer = p.sink.Finish()
-	pagereader, _ := file.NewPageReader(bytes.NewReader(p.readbuffer.Bytes()), nrows, compression, mem, nil)
+	pagereader, _ := file.NewPageReader(arrutils.NewBufferedReader(bytes.NewReader(p.readbuffer.Bytes()), p.readbuffer.Len()), nrows, compression, mem, nil)
 	return file.NewColumnReader(p.descr, pagereader, mem)
 }
 

--- a/go/parquet/file/column_writer_test.go
+++ b/go/parquet/file/column_writer_test.go
@@ -17,7 +17,6 @@
 package file_test
 
 import (
-	"bufio"
 	"bytes"
 	"math"
 	"reflect"
@@ -234,7 +233,7 @@ func (p *PrimitiveWriterTestSuite) SetupTest() {
 
 func (p *PrimitiveWriterTestSuite) buildReader(nrows int64, compression compress.Compression) file.ColumnChunkReader {
 	p.readbuffer = p.sink.Finish()
-	pagereader, _ := file.NewPageReader(bufio.NewReader(bytes.NewReader(p.readbuffer.Bytes())), nrows, compression, mem, nil)
+	pagereader, _ := file.NewPageReader(bytes.NewReader(p.readbuffer.Bytes()), nrows, compression, mem, nil)
 	return file.NewColumnReader(p.descr, pagereader, mem)
 }
 

--- a/go/parquet/file/column_writer_test.go
+++ b/go/parquet/file/column_writer_test.go
@@ -17,6 +17,7 @@
 package file_test
 
 import (
+	"bufio"
 	"bytes"
 	"math"
 	"reflect"
@@ -233,7 +234,7 @@ func (p *PrimitiveWriterTestSuite) SetupTest() {
 
 func (p *PrimitiveWriterTestSuite) buildReader(nrows int64, compression compress.Compression) file.ColumnChunkReader {
 	p.readbuffer = p.sink.Finish()
-	pagereader, _ := file.NewPageReader(bytes.NewReader(p.readbuffer.Bytes()), nrows, compression, mem, nil)
+	pagereader, _ := file.NewPageReader(bufio.NewReader(bytes.NewReader(p.readbuffer.Bytes())), nrows, compression, mem, nil)
 	return file.NewColumnReader(p.descr, pagereader, mem)
 }
 

--- a/go/parquet/file/file_reader_test.go
+++ b/go/parquet/file/file_reader_test.go
@@ -205,26 +205,6 @@ func (p *PageSerdeSuite) TestLargePageHeaders() {
 	p.CheckDataPageHeader(p.dataPageHdr, p.pageReader.Page())
 }
 
-func (p *PageSerdeSuite) TestFailLargePageHeaders() {
-	const (
-		statsSize      = 256 * 1024 // 256KB
-		nrows          = 1337       // dummy value
-		maxHeaderSize  = 512 * 1024 // 512 KB
-		smallerMaxSize = 128 * 1024 // 128KB
-	)
-	p.dataPageHdr.Statistics = getDummyStats(statsSize, false)
-	p.WriteDataPageHeader(maxHeaderSize, 0, 0)
-	pos, err := p.sink.Seek(0, io.SeekCurrent)
-	p.NoError(err)
-	p.GreaterOrEqual(maxHeaderSize, int(pos))
-
-	p.LessOrEqual(smallerMaxSize, int(pos))
-	p.InitSerializedPageReader(nrows, compress.Codecs.Uncompressed)
-	p.pageReader.SetMaxPageHeaderSize(smallerMaxSize)
-	p.NotPanics(func() { p.False(p.pageReader.Next()) })
-	p.Error(p.pageReader.Err())
-}
-
 func (p *PageSerdeSuite) TestCompression() {
 	codecs := []compress.Compression{
 		compress.Codecs.Snappy,

--- a/go/parquet/file/file_reader_test.go
+++ b/go/parquet/file/file_reader_test.go
@@ -17,6 +17,7 @@
 package file_test
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/binary"
 	"io"
@@ -101,7 +102,7 @@ func (p *PageSerdeSuite) SetupTest() {
 func (p *PageSerdeSuite) InitSerializedPageReader(nrows int64, codec compress.Compression) {
 	p.EndStream()
 
-	p.pageReader, _ = file.NewPageReader(bytes.NewReader(p.buffer.Bytes()), nrows, codec, memory.DefaultAllocator, nil)
+	p.pageReader, _ = file.NewPageReader(bufio.NewReader(bytes.NewReader(p.buffer.Bytes())), nrows, codec, memory.DefaultAllocator, nil)
 }
 
 func (p *PageSerdeSuite) WriteDataPageHeader(maxSerialized int, uncompressed, compressed int32) {

--- a/go/parquet/file/page_reader.go
+++ b/go/parquet/file/page_reader.go
@@ -17,7 +17,6 @@
 package file
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
 	"io"
@@ -27,6 +26,7 @@ import (
 	"github.com/apache/arrow/go/v8/arrow/memory"
 	"github.com/apache/arrow/go/v8/parquet"
 	"github.com/apache/arrow/go/v8/parquet/compress"
+	"github.com/apache/arrow/go/v8/parquet/internal/debug"
 	"github.com/apache/arrow/go/v8/parquet/internal/encryption"
 	format "github.com/apache/arrow/go/v8/parquet/internal/gen-go/parquet"
 	"github.com/apache/arrow/go/v8/parquet/internal/thrift"
@@ -37,8 +37,6 @@ import (
 // PageReader is the interface used by the columnreader in order to read
 // and handle DataPages and loop through them.
 type PageReader interface {
-	// Set the maximum Page header size allowed to be read
-	SetMaxPageHeaderSize(int)
 	// Return the current page, or nil if there are no more
 	Page() Page
 	// Fetch the next page, returns false if there are no more pages
@@ -290,16 +288,15 @@ func (d *DictionaryPage) Release() {
 func (d *DictionaryPage) IsSorted() bool { return d.sorted }
 
 type serializedPageReader struct {
-	r        *bufio.Reader
+	r        io.Reader
 	nrows    int64
 	rowsSeen int64
 	mem      memory.Allocator
 	codec    compress.Codec
 
-	curPageHdr        *format.PageHeader
-	buf               *memory.Buffer
-	pageOrd           int16
-	maxPageHeaderSize int
+	curPageHdr *format.PageHeader
+	buf        *memory.Buffer
+	pageOrd    int16
 
 	curPage           Page
 	cryptoCtx         CryptoContext
@@ -311,7 +308,7 @@ type serializedPageReader struct {
 }
 
 // NewPageReader returns a page reader for the data which can be read from the provided reader and compression.
-func NewPageReader(r *bufio.Reader, nrows int64, compressType compress.Compression, mem memory.Allocator, ctx *CryptoContext) (PageReader, error) {
+func NewPageReader(r io.Reader, nrows int64, compressType compress.Compression, mem memory.Allocator, ctx *CryptoContext) (PageReader, error) {
 	if mem == nil {
 		mem = memory.NewGoAllocator()
 	}
@@ -322,12 +319,11 @@ func NewPageReader(r *bufio.Reader, nrows int64, compressType compress.Compressi
 	}
 
 	rdr := &serializedPageReader{
-		r:                 r,
-		maxPageHeaderSize: defaultMaxPageHeaderSize,
-		nrows:             nrows,
-		mem:               mem,
-		codec:             codec,
-		buf:               memory.NewResizableBuffer(mem),
+		r:     r,
+		nrows: nrows,
+		mem:   mem,
+		codec: codec,
+		buf:   memory.NewResizableBuffer(mem),
 	}
 	rdr.decompressBuffer.Grow(defaultPageHeaderSize)
 	if ctx != nil {
@@ -340,7 +336,7 @@ func NewPageReader(r *bufio.Reader, nrows int64, compressType compress.Compressi
 func (p *serializedPageReader) Reset(r io.Reader, nrows int64, compressType compress.Compression, ctx *CryptoContext) {
 	p.rowsSeen, p.pageOrd, p.nrows = 0, 0, nrows
 	p.curPageHdr, p.curPage, p.err = nil, nil, nil
-	p.r.Reset(r)
+	p.r = r
 
 	p.codec, p.err = compress.GetCodec(compressType)
 	if p.err != nil {
@@ -359,10 +355,6 @@ func (p *serializedPageReader) Reset(r io.Reader, nrows int64, compressType comp
 }
 
 func (p *serializedPageReader) Err() error { return p.err }
-
-func (p *serializedPageReader) SetMaxPageHeaderSize(sz int) {
-	p.maxPageHeaderSize = sz
-}
 
 func (p *serializedPageReader) initDecryption() {
 	if p.cryptoCtx.DataDecryptor != nil {
@@ -391,7 +383,6 @@ func (p *serializedPageReader) Page() Page {
 }
 
 func (p *serializedPageReader) decompress(lenCompressed int, buf []byte) ([]byte, error) {
-	p.decompressBuffer.Reset()
 	p.decompressBuffer.Grow(lenCompressed)
 	if _, err := io.CopyN(&p.decompressBuffer, p.r, int64(lenCompressed)); err != nil {
 		return nil, err
@@ -445,43 +436,22 @@ func (p *serializedPageReader) Next() bool {
 	p.err = nil
 
 	for p.rowsSeen < p.nrows {
-		// headerSize := 0
-		allowedPgSz := defaultPageHeaderSize
-
 		p.decompressBuffer.Reset()
-		// Page headers can be very large because of page statistics
-		// We try to deserialize a larger buffer progressively
-		// until a maximum allowed header limit
-		for {
-			view, err := p.r.Peek(allowedPgSz)
-			if err != nil && err != io.EOF {
+		if p.cryptoCtx.MetaDecryptor != nil {
+			p.updateDecryption(p.cryptoCtx.MetaDecryptor, encryption.DictPageHeaderModule, p.dataPageHeaderAad)
+			decrypted := p.cryptoCtx.MetaDecryptor.DecryptFrom(p.r)
+			remain, err := thrift.DeserializeThrift(p.curPageHdr, decrypted)
+			if err != nil {
 				p.err = err
 				return false
 			}
-
-			if len(view) == 0 {
+			debug.Assert(remain == 0, "extra remaining from deserializing thrift?")
+		} else {
+			err := thrift.DeserializeThriftStream(p.curPageHdr, p.r)
+			if err != nil {
+				p.err = err
 				return false
 			}
-
-			extra := 0
-			if p.cryptoCtx.MetaDecryptor != nil {
-				p.updateDecryption(p.cryptoCtx.MetaDecryptor, encryption.DictPageHeaderModule, p.dataPageHeaderAad)
-				view = p.cryptoCtx.MetaDecryptor.Decrypt(view)
-				extra = p.cryptoCtx.MetaDecryptor.CiphertextSizeDelta()
-			}
-
-			remaining, err := thrift.DeserializeThrift(p.curPageHdr, view)
-			if err != nil {
-				allowedPgSz *= 2
-				if allowedPgSz > p.maxPageHeaderSize {
-					p.err = xerrors.New("parquet: deserializing page header failed")
-					return false
-				}
-				continue
-			}
-
-			p.r.Discard(len(view) - int(remaining) + extra)
-			break
 		}
 
 		lenCompressed := int(p.curPageHdr.GetCompressedPageSize())
@@ -591,8 +561,12 @@ func (p *serializedPageReader) Next() bool {
 					return false
 				}
 			} else {
-				io.ReadFull(p.r, p.buf.Bytes())
+				var n int
 				data = p.buf.Bytes()
+				if p.decompressBuffer.Len() > 0 {
+					n, _ = p.decompressBuffer.Read(data)
+				}
+				io.ReadFull(p.r, data[n:])
 			}
 			if len(data) != lenUncompressed {
 				p.err = fmt.Errorf("parquet: metadata said %d bytes uncompressed data page, got %d bytes", lenUncompressed, len(data))

--- a/go/parquet/internal/encryption/decryptor.go
+++ b/go/parquet/internal/encryption/decryptor.go
@@ -17,6 +17,8 @@
 package encryption
 
 import (
+	"io"
+
 	"github.com/apache/arrow/go/v8/arrow/memory"
 	"github.com/apache/arrow/go/v8/parquet"
 )
@@ -240,6 +242,8 @@ type Decryptor interface {
 	CiphertextSizeDelta() int
 	// Decrypt just returns the decrypted plaintext from the src ciphertext
 	Decrypt(src []byte) []byte
+	// Decrypt just returns the decrypted plaintext from the src ciphertext
+	DecryptFrom(r io.Reader) []byte
 	// set the AAD bytes of the decryptor to the provided string
 	UpdateAad(string)
 }
@@ -258,4 +262,7 @@ func (d *decryptor) UpdateAad(aad string)        { d.aad = []byte(aad) }
 func (d *decryptor) CiphertextSizeDelta() int    { return d.decryptor.CiphertextSizeDelta() }
 func (d *decryptor) Decrypt(src []byte) []byte {
 	return d.decryptor.Decrypt(src, d.key, d.aad)
+}
+func (d *decryptor) DecryptFrom(r io.Reader) []byte {
+	return d.decryptor.DecryptFrom(r, d.key, d.aad)
 }

--- a/go/parquet/internal/testutils/pagebuilder.go
+++ b/go/parquet/internal/testutils/pagebuilder.go
@@ -220,8 +220,10 @@ func (m *MockPageReader) Err() error {
 	return m.Called().Error(0)
 }
 
-func (m *MockPageReader) Reset(io.Reader, int64, compress.Compression, *file.CryptoContext) {
+func (m *MockPageReader) Reset(parquet.BufferedReader, int64, compress.Compression, *file.CryptoContext) {
 }
+
+func (m *MockPageReader) SetMaxPageHeaderSize(int) {}
 
 func (m *MockPageReader) Page() file.Page {
 	return m.TestData().Get("pages").Data().([]file.Page)[m.curpage-1]

--- a/go/parquet/internal/testutils/pagebuilder.go
+++ b/go/parquet/internal/testutils/pagebuilder.go
@@ -220,7 +220,7 @@ func (m *MockPageReader) Err() error {
 	return m.Called().Error(0)
 }
 
-func (m *MockPageReader) Reset(io.ReadSeeker, int64, compress.Compression, *file.CryptoContext) {
+func (m *MockPageReader) Reset(io.Reader, int64, compress.Compression, *file.CryptoContext) {
 }
 
 func (m *MockPageReader) SetMaxPageHeaderSize(int) {}

--- a/go/parquet/internal/testutils/pagebuilder.go
+++ b/go/parquet/internal/testutils/pagebuilder.go
@@ -223,8 +223,6 @@ func (m *MockPageReader) Err() error {
 func (m *MockPageReader) Reset(io.Reader, int64, compress.Compression, *file.CryptoContext) {
 }
 
-func (m *MockPageReader) SetMaxPageHeaderSize(int) {}
-
 func (m *MockPageReader) Page() file.Page {
 	return m.TestData().Get("pages").Data().([]file.Page)[m.curpage-1]
 }

--- a/go/parquet/reader_properties.go
+++ b/go/parquet/reader_properties.go
@@ -17,18 +17,21 @@
 package parquet
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
 	"io"
 
 	"github.com/apache/arrow/go/v8/arrow/memory"
+	"github.com/apache/arrow/go/v8/internal/utils"
 )
 
 // ReaderProperties are used to define how the file reader will handle buffering and allocating buffers
 type ReaderProperties struct {
 	alloc memory.Allocator
-	// Default buffer size to utilize when reading chunks
+	// Default buffer size to utilize when reading chunks, when reading page
+	// headers or other metadata, this buffer may be increased if necessary
+	// to read in the necessary metadata. The value here is simply the default
+	// initial BufferSize when reading a new chunk.
 	BufferSize int64
 	// create with NewFileDecryptionProperties if dealing with an encrypted file
 	FileDecryptProps *FileDecryptionProperties
@@ -42,6 +45,12 @@ type ReaderProperties struct {
 	// reading small portions / subsets  of the parquet file, this can be set to false
 	// to reduce the amount of IO performed in order to avoid reading excess amounts of data.
 	BufferedStreamEnabled bool
+}
+
+type BufferedReader interface {
+	Peek(int) ([]byte, error)
+	Discard(int) (int, error)
+	io.Reader
 }
 
 // NewReaderProperties returns the default Reader Properties using the provided allocator.
@@ -61,9 +70,9 @@ func (r *ReaderProperties) Allocator() memory.Allocator { return r.alloc }
 //
 // If BufferedStreamEnabled is true, it creates an io.SectionReader, otherwise it will read the entire section
 // into a buffer in memory and return a bytes.NewReader for that buffer.
-func (r *ReaderProperties) GetStream(source io.ReaderAt, start, nbytes int64) (io.Reader, error) {
+func (r *ReaderProperties) GetStream(source io.ReaderAt, start, nbytes int64) (BufferedReader, error) {
 	if r.BufferedStreamEnabled {
-		return bufio.NewReaderSize(io.NewSectionReader(source, start, nbytes), int(r.BufferSize)), nil
+		return utils.NewBufferedReader(io.NewSectionReader(source, start, nbytes), int(r.BufferSize)), nil
 	}
 
 	data := make([]byte, nbytes)
@@ -75,5 +84,5 @@ func (r *ReaderProperties) GetStream(source io.ReaderAt, start, nbytes int64) (i
 		return nil, fmt.Errorf("parquet: tried reading %d bytes starting at position %d from file but only got %d", nbytes, start, n)
 	}
 
-	return bytes.NewReader(data), nil
+	return utils.NewBufferedReader(bytes.NewReader(data), int(nbytes)), nil
 }

--- a/go/parquet/reader_properties.go
+++ b/go/parquet/reader_properties.go
@@ -61,7 +61,7 @@ func (r *ReaderProperties) Allocator() memory.Allocator { return r.alloc }
 //
 // If BufferedStreamEnabled is true, it creates an io.SectionReader, otherwise it will read the entire section
 // into a buffer in memory and return a bytes.NewReader for that buffer.
-func (r *ReaderProperties) GetStream(source io.ReaderAt, start, nbytes int64) (*bufio.Reader, error) {
+func (r *ReaderProperties) GetStream(source io.ReaderAt, start, nbytes int64) (io.Reader, error) {
 	if r.BufferedStreamEnabled {
 		return bufio.NewReaderSize(io.NewSectionReader(source, start, nbytes), int(r.BufferSize)), nil
 	}
@@ -75,5 +75,5 @@ func (r *ReaderProperties) GetStream(source io.ReaderAt, start, nbytes int64) (*
 		return nil, fmt.Errorf("parquet: tried reading %d bytes starting at position %d from file but only got %d", nbytes, start, n)
 	}
 
-	return bufio.NewReader(bytes.NewReader(data)), nil
+	return bytes.NewReader(data), nil
 }


### PR DESCRIPTION
Currently the BufferSize in the `ReaderProperties` isn't utilized properly when enabling BufferedStreams. This fixes that issue so that enabling `BufferedStream` reading via the properties will correctly utilize the given buffer size when reading. The default buffersize is currently 16K, so reads that are larger than that will ignore the buffering and just pull directly from the underlying reader when BufferedStream is enabled, pulling the entire page or otherwise from the reader if BufferedStream is not enabled.

The buffer size can be set larger so that controlled reads can improve performance on high-latency readers without having to use the memory to read the entire column/page/row group into memory.