### PR TITLE
ARROW-5598: [Go] Rename array.Array{,Approx}Equal to array.{,Approx}Equal

### DIFF
--- a/go/arrow/array/compare.go
+++ b/go/arrow/array/compare.go
@@ -119,7 +119,7 @@ func ChunkedEqual(left, right *Chunked) bool {
 
 	var isequal bool
 	chunkedBinaryApply(left, right, func(left arrow.Array, lbeg, lend int64, right arrow.Array, rbeg, rend int64) bool {
-		isequal = ArraySliceEqual(left, lbeg, lend, right, rbeg, rend)
+		isequal = SliceEqual(left, lbeg, lend, right, rbeg, rend)
 		return isequal
 	})
 
@@ -142,7 +142,7 @@ func ChunkedApproxEqual(left, right *Chunked, opts ...EqualOption) bool {
 
 	var isequal bool
 	chunkedBinaryApply(left, right, func(left arrow.Array, lbeg, lend int64, right arrow.Array, rbeg, rend int64) bool {
-		isequal = ArraySliceApproxEqual(left, lbeg, lend, right, rbeg, rend, opts...)
+		isequal = SliceApproxEqual(left, lbeg, lend, right, rbeg, rend, opts...)
 		return isequal
 	})
 
@@ -196,7 +196,16 @@ func TableApproxEqual(left, right Table, opts ...EqualOption) bool {
 }
 
 // ArrayEqual reports whether the two provided arrays are equal.
+//
+// Deprecated: This currently just delegates to calling Equal. This will be
+// removed in v9 so please update any calling code to just call array.Equal
+// directly instead.
 func ArrayEqual(left, right arrow.Array) bool {
+	return Equal(left, right)
+}
+
+// Equal reports whether the two provided arrays are equal.
+func Equal(left, right arrow.Array) bool {
 	switch {
 	case !baseArrayEqual(left, right):
 		return false
@@ -309,23 +318,39 @@ func ArrayEqual(left, right arrow.Array) bool {
 }
 
 // ArraySliceEqual reports whether slices left[lbeg:lend] and right[rbeg:rend] are equal.
+//
+// Deprecated: Renamed to just array.SliceEqual, this currently will just delegate to the renamed
+// function and will be removed in v9. Please update any calling code.
 func ArraySliceEqual(left arrow.Array, lbeg, lend int64, right arrow.Array, rbeg, rend int64) bool {
+	return SliceEqual(left, lbeg, lend, right, rbeg, rend)
+}
+
+// SliceEqual reports whether slices left[lbeg:lend] and right[rbeg:rend] are equal.
+func SliceEqual(left arrow.Array, lbeg, lend int64, right arrow.Array, rbeg, rend int64) bool {
 	l := NewSlice(left, lbeg, lend)
 	defer l.Release()
 	r := NewSlice(right, rbeg, rend)
 	defer r.Release()
 
-	return ArrayEqual(l, r)
+	return Equal(l, r)
 }
 
 // ArraySliceApproxEqual reports whether slices left[lbeg:lend] and right[rbeg:rend] are approximately equal.
+//
+// Deprecated: renamed to just SliceApproxEqual and will be removed in v9. Please update
+// calling code to just call array.SliceApproxEqual.
 func ArraySliceApproxEqual(left arrow.Array, lbeg, lend int64, right arrow.Array, rbeg, rend int64, opts ...EqualOption) bool {
+	return SliceApproxEqual(left, lbeg, lend, right, rbeg, rend, opts...)
+}
+
+// SliceApproxEqual reports whether slices left[lbeg:lend] and right[rbeg:rend] are approximately equal.
+func SliceApproxEqual(left arrow.Array, lbeg, lend int64, right arrow.Array, rbeg, rend int64, opts ...EqualOption) bool {
 	l := NewSlice(left, lbeg, lend)
 	defer l.Release()
 	r := NewSlice(right, rbeg, rend)
 	defer r.Release()
 
-	return ArrayApproxEqual(l, r, opts...)
+	return ApproxEqual(l, r, opts...)
 }
 
 const defaultAbsoluteTolerance = 1e-5
@@ -398,7 +423,16 @@ func WithAbsTolerance(atol float64) EqualOption {
 
 // ArrayApproxEqual reports whether the two provided arrays are approximately equal.
 // For non-floating point arrays, it is equivalent to ArrayEqual.
+//
+// Deprecated: renamed to just ApproxEqual, this alias will be removed in v9. Please update
+// calling code to just call array.ApproxEqual
 func ArrayApproxEqual(left, right arrow.Array, opts ...EqualOption) bool {
+	return ApproxEqual(left, right, opts...)
+}
+
+// ApproxEqual reports whether the two provided arrays are approximately equal.
+// For non-floating point arrays, it is equivalent to ArrayEqual.
+func ApproxEqual(left, right arrow.Array, opts ...EqualOption) bool {
 	opt := newEqualOption(opts...)
 	return arrayApproxEqual(left, right, opt)
 }

--- a/go/arrow/array/compare_test.go
+++ b/go/arrow/array/compare_test.go
@@ -63,7 +63,7 @@ func TestArraySliceEqual(t *testing.T) {
 			for i, col := range rec.Columns() {
 				t.Run(schema.Field(i).Name, func(t *testing.T) {
 					arr := col
-					if !array.ArraySliceEqual(
+					if !array.SliceEqual(
 						arr, 0, int64(arr.Len()),
 						arr, 0, int64(arr.Len()),
 					) {
@@ -75,7 +75,7 @@ func TestArraySliceEqual(t *testing.T) {
 					sub2 := array.NewSlice(arr, 0, int64(arr.Len()-1))
 					defer sub2.Release()
 
-					if array.ArraySliceEqual(sub1, 0, int64(sub1.Len()), sub2, 0, int64(sub2.Len())) && name != "nulls" {
+					if array.SliceEqual(sub1, 0, int64(sub1.Len()), sub2, 0, int64(sub2.Len())) && name != "nulls" {
 						t.Fatalf("non-identical slices should not compare equal:\nsub1=%v\nsub2=%v\narrf=%v\n", sub1, sub2, arr)
 					}
 				})
@@ -92,7 +92,7 @@ func TestArrayApproxEqual(t *testing.T) {
 			for i, col := range rec.Columns() {
 				t.Run(schema.Field(i).Name, func(t *testing.T) {
 					arr := col
-					if !array.ArrayApproxEqual(arr, arr) {
+					if !array.ApproxEqual(arr, arr) {
 						t.Fatalf("identical arrays should compare equal:\narray=%v", arr)
 					}
 					sub1 := array.NewSlice(arr, 1, int64(arr.Len()))
@@ -101,7 +101,7 @@ func TestArrayApproxEqual(t *testing.T) {
 					sub2 := array.NewSlice(arr, 0, int64(arr.Len()-1))
 					defer sub2.Release()
 
-					if array.ArrayApproxEqual(sub1, sub2) && name != "nulls" {
+					if array.ApproxEqual(sub1, sub2) && name != "nulls" {
 						t.Fatalf("non-identical arrays should not compare equal:\nsub1=%v\nsub2=%v\narrf=%v\n", sub1, sub2, arr)
 					}
 				})
@@ -295,7 +295,7 @@ func TestArrayApproxEqualFloats(t *testing.T) {
 			a2 := arrayOf(mem, tc.a2, nil)
 			defer a2.Release()
 
-			if got, want := array.ArrayApproxEqual(a1, a2, tc.opts...), tc.want; got != want {
+			if got, want := array.ApproxEqual(a1, a2, tc.opts...), tc.want; got != want {
 				t.Fatalf("invalid comparison: got=%v, want=%v\na1: %v\na2: %v\n", got, want, a1, a2)
 			}
 		})

--- a/go/arrow/array/extension.go
+++ b/go/arrow/array/extension.go
@@ -52,7 +52,7 @@ func arrayEqualExtension(l, r ExtensionArray) bool {
 		return false
 	}
 
-	return ArrayEqual(l.Storage(), r.Storage())
+	return Equal(l.Storage(), r.Storage())
 }
 
 // two extension arrays are approximately equal if their data types are

--- a/go/arrow/array/fixed_size_list.go
+++ b/go/arrow/array/fixed_size_list.go
@@ -90,7 +90,7 @@ func arrayEqualFixedSizeList(left, right *FixedSizeList) bool {
 			defer l.Release()
 			r := right.newListValue(i)
 			defer r.Release()
-			return ArrayEqual(l, r)
+			return Equal(l, r)
 		}()
 		if !o {
 			return false

--- a/go/arrow/array/list.go
+++ b/go/arrow/array/list.go
@@ -122,7 +122,7 @@ func arrayEqualList(left, right *List) bool {
 			defer l.Release()
 			r := right.newListValue(i)
 			defer r.Release()
-			return ArrayEqual(l, r)
+			return Equal(l, r)
 		}()
 		if !o {
 			return false

--- a/go/arrow/array/map_test.go
+++ b/go/arrow/array/map_test.go
@@ -84,10 +84,10 @@ func TestMapArray(t *testing.T) {
 	assert.False(t, array.ArrayEqual(equalArr, unequalArr))
 	assert.False(t, array.ArrayEqual(unequalArr, equalArr))
 
-	assert.True(t, array.ArraySliceEqual(arr, 0, 1, unequalArr, 0, 1))
-	assert.False(t, array.ArraySliceEqual(arr, 0, 2, unequalArr, 0, 2))
-	assert.False(t, array.ArraySliceEqual(arr, 1, 2, unequalArr, 1, 2))
-	assert.True(t, array.ArraySliceEqual(arr, 2, 3, unequalArr, 2, 3))
+	assert.True(t, array.SliceEqual(arr, 0, 1, unequalArr, 0, 1))
+	assert.False(t, array.SliceEqual(arr, 0, 2, unequalArr, 0, 2))
+	assert.False(t, array.SliceEqual(arr, 1, 2, unequalArr, 1, 2))
+	assert.True(t, array.SliceEqual(arr, 2, 3, unequalArr, 2, 3))
 }
 
 func TestMapArrayBuildIntToInt(t *testing.T) {

--- a/go/arrow/array/struct.go
+++ b/go/arrow/array/struct.go
@@ -140,7 +140,7 @@ func (a *Struct) MarshalJSON() ([]byte, error) {
 func arrayEqualStruct(left, right *Struct) bool {
 	for i, lf := range left.fields {
 		rf := right.fields[i]
-		if !ArrayEqual(lf, rf) {
+		if !Equal(lf, rf) {
 			return false
 		}
 	}

--- a/go/arrow/cdata/cdata_test.go
+++ b/go/arrow/cdata/cdata_test.go
@@ -458,7 +458,7 @@ func TestPrimitiveSliced(t *testing.T) {
 	imported, err := ImportCArrayWithType(carr, arr.DataType())
 	assert.NoError(t, err)
 	assert.True(t, array.ArrayEqual(sl, imported))
-	assert.True(t, array.ArraySliceEqual(arr, 1, 2, imported, 0, int64(imported.Len())))
+	assert.True(t, array.SliceEqual(arr, 1, 2, imported, 0, int64(imported.Len())))
 	assert.True(t, isReleased(carr))
 
 	imported.Release()

--- a/go/arrow/compute/datum.go
+++ b/go/arrow/compute/datum.go
@@ -182,7 +182,7 @@ func (d *ArrayDatum) Equals(other Datum) bool {
 	right := rhs.MakeArray()
 	defer right.Release()
 
-	return array.ArrayEqual(left, right)
+	return array.Equal(left, right)
 }
 
 // ChunkedDatum contains a chunked array for use with expressions and compute.

--- a/go/arrow/scalar/nested.go
+++ b/go/arrow/scalar/nested.go
@@ -44,7 +44,7 @@ func (l *List) Retain()              { l.Value.Retain() }
 func (l *List) value() interface{}   { return l.Value }
 func (l *List) GetList() arrow.Array { return l.Value }
 func (l *List) equals(rhs Scalar) bool {
-	return array.ArrayEqual(l.Value, rhs.(ListScalar).GetList())
+	return array.Equal(l.Value, rhs.(ListScalar).GetList())
 }
 func (l *List) Validate() (err error) {
 	if err = l.scalar.Validate(); err != nil {

--- a/go/arrow/scalar/scalar_test.go
+++ b/go/arrow/scalar/scalar_test.go
@@ -733,7 +733,7 @@ func TestMapScalarBasics(t *testing.T) {
 
 	expectedScalarType := arrow.MapOf(arrow.BinaryTypes.String, arrow.PrimitiveTypes.Int8)
 	assert.True(t, arrow.TypeEqual(s.DataType(), expectedScalarType))
-	assert.True(t, array.ArrayEqual(value, s.GetList()))
+	assert.True(t, array.Equal(value, s.GetList()))
 
 	checkMakeNullScalar(t, expectedScalarType)
 }

--- a/go/parquet/pqarrow/encode_arrow_test.go
+++ b/go/parquet/pqarrow/encode_arrow_test.go
@@ -908,7 +908,7 @@ func (ps *ParquetIOTestSuite) roundTripTable(expected arrow.Table, storeSchema b
 		ps.Equal(ex.Len(), tb.Len())
 		// only compare the non-null values
 		ps.NoErrorf(utils.VisitSetBitRuns(ex.NullBitmapBytes(), int64(ex.Data().Offset()), int64(ex.Len()), func(pos, length int64) error {
-			if !ps.True(array.ArraySliceEqual(ex, pos, pos+length, tb, pos, pos+length)) {
+			if !ps.True(array.SliceEqual(ex, pos, pos+length, tb, pos, pos+length)) {
 				return errors.New("failed")
 			}
 			return nil

--- a/go/parquet/pqarrow/encode_arrow_test.go
+++ b/go/parquet/pqarrow/encode_arrow_test.go
@@ -335,7 +335,7 @@ func simpleRoundTrip(t *testing.T, tbl arrow.Table, rowGroupSize int64) {
 			assert.EqualValues(t, chnk.Len(), slc.Len())
 			if len(slc.Chunks()) == 1 {
 				offset += int64(chnk.Len())
-				assert.True(t, array.ArrayEqual(chnk, slc.Chunk(0)))
+				assert.True(t, array.Equal(chnk, slc.Chunk(0)))
 			}
 		}
 	}
@@ -629,7 +629,7 @@ func (ps *ParquetIOTestSuite) checkSingleColumnRequiredTableRead(typ arrow.DataT
 
 	chunked := tbl.Column(0).Data()
 	ps.Len(chunked.Chunks(), 1)
-	ps.True(array.ArrayEqual(values, chunked.Chunk(0)))
+	ps.True(array.Equal(values, chunked.Chunk(0)))
 }
 
 func (ps *ParquetIOTestSuite) checkSingleColumnRead(typ arrow.DataType, numChunks int) {
@@ -647,7 +647,7 @@ func (ps *ParquetIOTestSuite) checkSingleColumnRead(typ arrow.DataType, numChunk
 	defer chunked.Release()
 
 	ps.Len(chunked.Chunks(), 1)
-	ps.True(array.ArrayEqual(values, chunked.Chunk(0)))
+	ps.True(array.Equal(values, chunked.Chunk(0)))
 }
 
 func (ps *ParquetIOTestSuite) TestDateTimeTypesReadWriteTable() {
@@ -675,7 +675,7 @@ func (ps *ParquetIOTestSuite) TestDateTimeTypesReadWriteTable() {
 		tblChunk := tbl.Column(i).Data()
 
 		ps.Equal(len(exChunk.Chunks()), len(tblChunk.Chunks()))
-		ps.Truef(array.ArrayEqual(exChunk.Chunk(0), tblChunk.Chunk(0)), "expected %s\ngot %s", exChunk.Chunk(0), tblChunk.Chunk(0))
+		ps.Truef(array.Equal(exChunk.Chunk(0), tblChunk.Chunk(0)), "expected %s\ngot %s", exChunk.Chunk(0), tblChunk.Chunk(0))
 	}
 }
 
@@ -701,7 +701,7 @@ func (ps *ParquetIOTestSuite) TestDateTimeTypesWithInt96ReadWriteTable() {
 		tblChunk := tbl.Column(i).Data()
 
 		ps.Equal(len(exChunk.Chunks()), len(tblChunk.Chunks()))
-		ps.Truef(array.ArrayEqual(exChunk.Chunk(0), tblChunk.Chunk(0)), "expected %s\ngot %s", exChunk.Chunk(0), tblChunk.Chunk(0))
+		ps.Truef(array.Equal(exChunk.Chunk(0), tblChunk.Chunk(0)), "expected %s\ngot %s", exChunk.Chunk(0), tblChunk.Chunk(0))
 	}
 }
 
@@ -800,7 +800,7 @@ func (ps *ParquetIOTestSuite) TestReadDecimals() {
 	defer chunked.Release()
 
 	ps.Len(chunked.Chunks(), 1)
-	ps.True(array.ArrayEqual(expected, chunked.Chunk(0)))
+	ps.True(array.Equal(expected, chunked.Chunk(0)))
 }
 
 func (ps *ParquetIOTestSuite) writeColumn(sc *schema.GroupNode, values arrow.Array) []byte {
@@ -832,7 +832,7 @@ func (ps *ParquetIOTestSuite) readAndCheckSingleColumnFile(data []byte, values a
 	ps.Len(chunked.Chunks(), 1)
 	ps.NotNil(chunked.Chunk(0))
 
-	ps.True(array.ArrayEqual(values, chunked.Chunk(0)))
+	ps.True(array.Equal(values, chunked.Chunk(0)))
 }
 
 var fullTypeList = []arrow.DataType{
@@ -894,7 +894,7 @@ func (ps *ParquetIOTestSuite) roundTripTable(expected arrow.Table, storeSchema b
 
 	ps.Equal(len(exChunk.Chunks()), len(tblChunk.Chunks()))
 	if exChunk.DataType().ID() != arrow.STRUCT {
-		ps.Truef(array.ArrayEqual(exChunk.Chunk(0), tblChunk.Chunk(0)), "expected: %s\ngot: %s", exChunk.Chunk(0), tblChunk.Chunk(0))
+		ps.Truef(array.Equal(exChunk.Chunk(0), tblChunk.Chunk(0)), "expected: %s\ngot: %s", exChunk.Chunk(0), tblChunk.Chunk(0))
 	} else {
 		// current impl of ArrayEquals for structs doesn't correctly handle nulls in the parent
 		// with a non-nullable child when comparing. Since after the round trip, the data in the
@@ -1037,7 +1037,7 @@ func (ps *ParquetIOTestSuite) TestSingleEmptyListsColumnReadWrite() {
 	tblChunk := tbl.Column(0).Data()
 
 	ps.Equal(len(exChunk.Chunks()), len(tblChunk.Chunks()))
-	ps.True(array.ArrayEqual(exChunk.Chunk(0), tblChunk.Chunk(0)))
+	ps.True(array.Equal(exChunk.Chunk(0), tblChunk.Chunk(0)))
 }
 
 func (ps *ParquetIOTestSuite) TestSingleColumnOptionalReadWrite() {

--- a/go/parquet/pqarrow/file_reader_test.go
+++ b/go/parquet/pqarrow/file_reader_test.go
@@ -92,7 +92,7 @@ func TestArrowReaderAdHocReadDecimals(t *testing.T) {
 			expectedArr := bldr.NewDecimal128Array()
 			defer expectedArr.Release()
 
-			assert.Truef(t, array.ArrayEqual(expectedArr, chunk), "expected: %s\ngot: %s", expectedArr, chunk)
+			assert.Truef(t, array.Equal(expectedArr, chunk), "expected: %s\ngot: %s", expectedArr, chunk)
 		})
 	}
 }


### PR DESCRIPTION
Also renames `ArraySliceEqual` and `ArraySliceApproxEqual` to `SliceEqual` and `SliceApproxEqual` accordingly.

Leaves the original names existing with deprecation messages that will show up in the documentation so that consumers aren't negatively effected. The deprecated versions can be removed for v9.