### PR TITLE
ARROW-16191  [C++][Gandiva] Fix size 0 case in arena malloc 

### DIFF
--- a/cpp/src/gandiva/simple_arena.h
+++ b/cpp/src/gandiva/simple_arena.h
@@ -100,6 +100,9 @@ inline SimpleArena::SimpleArena(arrow::MemoryPool* pool, int64_t min_chunk_size)
 inline SimpleArena::~SimpleArena() { ReleaseChunks(false /*retain_first*/); }
 
 inline uint8_t* SimpleArena::Allocate(int64_t size) {
+  if (size == 0) {
+    return (uint8_t*)"";
+  }
   if (avail_bytes_ < size) {
     auto status = AllocateChunk(std::max(size, min_chunk_size_));
     if (!status.ok()) {


### PR DESCRIPTION
Fix size 0 case in arena malloc's Allocate function to return an empty string rather than NULL which will solve the errors seen in functions like convert_fromUTF8.