### PR TITLE
ARROW-16143: [Java] Upgrade jackson dependencies CVE-2020-36518

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -34,7 +34,7 @@
     <dep.slf4j.version>1.7.25</dep.slf4j.version>
     <dep.guava.version>30.1.1-jre</dep.guava.version>
     <dep.netty.version>4.1.72.Final</dep.netty.version>
-    <dep.jackson.version>2.11.4</dep.jackson.version>
+    <dep.jackson.version>2.13.2</dep.jackson.version>
     <dep.jackson-bom.version>2.13.2.20220328</dep.jackson-bom.version>
     <dep.hadoop.version>2.7.1</dep.hadoop.version>
     <dep.fbs.version>1.12.0</dep.fbs.version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -35,6 +35,7 @@
     <dep.guava.version>30.1.1-jre</dep.guava.version>
     <dep.netty.version>4.1.72.Final</dep.netty.version>
     <dep.jackson.version>2.11.4</dep.jackson.version>
+    <dep.jackson-bom.version>2.13.2.20220328</dep.jackson-bom.version>
     <dep.hadoop.version>2.7.1</dep.hadoop.version>
     <dep.fbs.version>1.12.0</dep.fbs.version>
     <dep.avro.version>1.10.0</dep.avro.version>
@@ -540,7 +541,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>${dep.jackson.version}</version>
+        <version>${dep.jackson-bom.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
[CVE-2020-36518](https://github.com/advisories/GHSA-57j2-w4cx-62h2): Deeply nested json in jackson-databind.

Solved based on [Jackson release 2.13](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.13):
````
jackson-databind 2.13.2.2 (28-Mar-2022) -- with jackson-bom version 2.13.2.20220328
````

Before the change: ` mvn compile dependency:tree -Drat.skip=true | grep databind` :
````
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.11.4:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.11.4:compile
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.11.4:compile
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.11.4:test
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.11.4:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.11.4:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.11.4:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.11.4:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.11.4:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.11.4:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.11.4:compile
````

After the change:
````
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.13.2.2:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.13.2.2:compile
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.13.2.2:compile
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.11.4:test
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.13.2.2:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.13.2.2:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.13.2.2:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.13.2.2:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.13.2.2:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.13.2.2:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.13.2.2:compile
````