### PR TITLE
MINOR: [CI] update to nightly reports individual job URLs

### DIFF
--- a/dev/archery/archery/crossbow/reports.py
+++ b/dev/archery/archery/crossbow/reports.py
@@ -173,10 +173,15 @@ class EmailReport(Report):
         repo_url = self.job.queue.remote_url.strip('.git')
         return '{}/branches/all?query={}'.format(repo_url, query)
 
+    def branch_url(self, branch):
+        repo_url = self.job.queue.remote_url.strip('.git')
+        return '{}/tree/{}'.format(repo_url, branch)
+
     def listing(self, tasks):
         return '\n'.join(
             sorted(
-                self.TASK.format(name=task_name, url=self.url(task.branch))
+                self.TASK.format(
+                    name=task_name, url=self.branch_url(task.branch))
                 for task_name, task in tasks.items()
             )
         )

--- a/dev/archery/archery/crossbow/reports.py
+++ b/dev/archery/archery/crossbow/reports.py
@@ -169,13 +169,16 @@ class EmailReport(Report):
         self.recipient_email = recipient_email
         super().__init__(job)
 
+    @property
+    def repo_url(self):
+        url = self.job.queue.remote_url
+        return url[:-4] if url.endswith('.git') else url
+
     def url(self, query):
-        repo_url = self.job.queue.remote_url.strip('.git')
-        return '{}/branches/all?query={}'.format(repo_url, query)
+        return '{}/branches/all?query={}'.format(self.repo_url, query)
 
     def branch_url(self, branch):
-        repo_url = self.job.queue.remote_url.strip('.git')
-        return '{}/tree/{}'.format(repo_url, branch)
+        return '{}/tree/{}'.format(self.repo_url, branch)
 
     def listing(self, tasks):
         return '\n'.join(


### PR DESCRIPTION
We currently have around 86K branches on the crossbow repository. This causes some direct problems on browsing and the email reports queries sometimes failing to open.

There are some initiatives to reduce the number of branches (https://github.com/ursacomputing/crossbow/pull/12) both to improve the browsing experience and to avoid possible issues with Github.


One small improvement I propose is to update the URLs on our nightly report emails for individual tasks to avoid a search on github that might timeout.
Instead of using:


https://github.com/ursacomputing/crossbow/branches/all?query=nightly-tests-2022-04-14-0-github-test-build-vcpkg-win

Using the direct branch URL to avoid the search:


https://github.com/ursacomputing/crossbow/tree/nightly-tests-2022-04-14-0-github-test-build-vcpkg-win