### PR TITLE
ARROW-16201: [R] SafeCallIntoR on 3.4

### DIFF
--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -16,6 +16,8 @@
 # under the License.
 
 skip_if(on_old_windows())
+# In 3.4 the lack of tzone attribute causes spurious failures
+skip_if_r_version("3.4.4")
 
 library(lubridate, warn.conflicts = FALSE)
 library(dplyr, warn.conflicts = FALSE)

--- a/r/tests/testthat/test-dplyr-funcs-type.R
+++ b/r/tests/testthat/test-dplyr-funcs-type.R
@@ -877,6 +877,8 @@ test_that("as.Date() converts successfully from date, timestamp, integer, char a
 
 test_that("format date/time", {
   skip_on_os("windows") # https://issues.apache.org/jira/browse/ARROW-13168
+  # In 3.4 the lack of tzone attribute causes spurious failures
+  skip_if_r_version("3.4.4")
 
   times <- tibble(
     datetime = c(lubridate::ymd_hms("2018-10-07 19:04:05", tz = "Pacific/Marquesas"), NA),

--- a/r/tests/testthat/test-safe-call-into-r.R
+++ b/r/tests/testthat/test-safe-call-into-r.R
@@ -17,8 +17,6 @@
 
 # Note that TestSafeCallIntoR is defined in safe-call-into-r-impl.cpp
 
-skip_if_r_version("3.4")
-
 test_that("SafeCallIntoR works from the main R thread", {
   skip_on_cran()
 
@@ -48,6 +46,7 @@ test_that("SafeCallIntoR works within RunWithCapturedR", {
 })
 
 test_that("SafeCallIntoR errors from the non-R thread", {
+  skip_if_r_version("3.4")
   skip_on_cran()
 
   expect_error(

--- a/r/tests/testthat/test-safe-call-into-r.R
+++ b/r/tests/testthat/test-safe-call-into-r.R
@@ -46,7 +46,7 @@ test_that("SafeCallIntoR works within RunWithCapturedR", {
 })
 
 test_that("SafeCallIntoR errors from the non-R thread", {
-  skip_if_r_version("3.4")
+  skip_if_r_version("3.4.4")
   skip_on_cran()
 
   expect_error(

--- a/r/tests/testthat/test-safe-call-into-r.R
+++ b/r/tests/testthat/test-safe-call-into-r.R
@@ -17,6 +17,8 @@
 
 # Note that TestSafeCallIntoR is defined in safe-call-into-r-impl.cpp
 
+skip_if_r_version("3.6")
+
 test_that("SafeCallIntoR works from the main R thread", {
   skip_on_cran()
 

--- a/r/tests/testthat/test-safe-call-into-r.R
+++ b/r/tests/testthat/test-safe-call-into-r.R
@@ -17,7 +17,7 @@
 
 # Note that TestSafeCallIntoR is defined in safe-call-into-r-impl.cpp
 
-skip_if_r_version("3.6")
+skip_if_r_version("3.4")
 
 test_that("SafeCallIntoR works from the main R thread", {
   skip_on_cran()


### PR DESCRIPTION
Disabling the tests for now, 3.4 will no longer be in our support window shortly with the release of 4.2 also skip a number of tests that failed because of `tzone` being non-present on 3.4.