### PR TITLE
ARROW-16218: [Java] Don't depend on netty-transport-native-unix-common on s390s

### DIFF
--- a/java/flight/flight-core/pom.xml
+++ b/java/flight/flight-core/pom.xml
@@ -317,7 +317,7 @@
       <activation>
         <os>
           <family>linux</family>
-          <arch>!s390_64</arch>
+          <arch>!s390x</arch>
         </os>
       </activation>
       <dependencies>

--- a/java/flight/flight-core/pom.xml
+++ b/java/flight/flight-core/pom.xml
@@ -317,6 +317,7 @@
       <activation>
         <os>
           <family>linux</family>
+          <arch>!s390_64</arch>
         </os>
       </activation>
       <dependencies>


### PR DESCRIPTION
This should hopefully fix Java test failures. It isn't perfect - it means we'll skip testing domain sockets on this platform. Alternatively, we need to build and upload the right libraries for s390 and then pull them down in java_build.sh