### PR TITLE
MINOR: [Format] Remove extraneous comment from extension_types.yaml

### DIFF
--- a/format/substrait/extension_types.yaml
+++ b/format/substrait/extension_types.yaml
@@ -41,11 +41,6 @@
 # we'd have to declare a different dictionary type for all encoded types
 # (but that is an infinite space). Similarly, we would have to declare a
 # timestamp variation for all possible timezone strings.
-#
-# Ultimately these declarations are a promise which needs to be backed by
-# equivalent serde in c++. This is handled by default_extension_id_registry(),
-# defined in cpp/src/arrow/engine/substrait/extension_set.cc. These files
-# currently need to be kept in sync manually; see ARROW-15535.
 
 type_variations:
   - parent: i8


### PR DESCRIPTION
The point is described sufficiently in ARROW-15535 and I'd like to avoid mention of C++ in a implementation-agnostic file.