### PR TITLE
ARROW-16237: [Docs] Apache Impala is no longer incubating

### DIFF
--- a/docs/source/cpp/orc.rst
+++ b/docs/source/cpp/orc.rst
@@ -29,7 +29,7 @@ standardized open-source columnar storage format for use in data analysis
 systems. It was created originally for use in `Apache Hadoop
 <http://hadoop.apache.org/>`_ with systems like `Apache Drill
 <http://drill.apache.org>`_, `Apache Hive <http://hive.apache.org>`_, `Apache
-Impala (incubating) <http://impala.apache.org>`_, and `Apache Spark
+Impala <http://impala.apache.org>`_, and `Apache Spark
 <http://spark.apache.org>`_ adopting it as a shared standard for high
 performance data IO.
 

--- a/docs/source/python/orc.rst
+++ b/docs/source/python/orc.rst
@@ -26,7 +26,7 @@ standardized open-source columnar storage format for use in data analysis
 systems. It was created originally for use in `Apache Hadoop
 <http://hadoop.apache.org/>`_ with systems like `Apache Drill
 <http://drill.apache.org>`_, `Apache Hive <http://hive.apache.org>`_, `Apache
-Impala (incubating) <http://impala.apache.org>`_, and `Apache Spark
+Impala <http://impala.apache.org>`_, and `Apache Spark
 <http://spark.apache.org>`_ adopting it as a shared standard for high
 performance data IO.
 

--- a/docs/source/python/parquet.rst
+++ b/docs/source/python/parquet.rst
@@ -26,7 +26,7 @@ standardized open-source columnar storage format for use in data analysis
 systems. It was created originally for use in `Apache Hadoop
 <http://hadoop.apache.org/>`_ with systems like `Apache Drill
 <http://drill.apache.org>`_, `Apache Hive <http://hive.apache.org>`_, `Apache
-Impala (incubating) <http://impala.apache.org>`_, and `Apache Spark
+Impala <http://impala.apache.org>`_, and `Apache Spark
 <http://spark.apache.org>`_ adopting it as a shared standard for high
 performance data IO.
 


### PR DESCRIPTION
According to https://incubator.apache.org/projects/ Apache Impala graduated in 2017. Hence all instances of "incubating" in our user guides related to Impala need to be removed.