### PR TITLE
ARROW-16225: [C++][Parquet] Fix length of encryption AAD random byte generation

### DIFF
--- a/cpp/src/parquet/encryption/encryption.cc
+++ b/cpp/src/parquet/encryption/encryption.cc
@@ -389,8 +389,7 @@ FileEncryptionProperties::FileEncryptionProperties(
          footer_key.length() == 32);
 
   uint8_t aad_file_unique[kAadFileUniqueLength];
-  memset(aad_file_unique, 0, kAadFileUniqueLength);
-  encryption::RandBytes(aad_file_unique, sizeof(kAadFileUniqueLength));
+  encryption::RandBytes(aad_file_unique, kAadFileUniqueLength);
   std::string aad_file_unique_str(reinterpret_cast<char const*>(aad_file_unique),
                                   kAadFileUniqueLength);
 


### PR DESCRIPTION
sizeof is indeed unnecessary here. 
And no need to initialize the buffer to 0 either before using rand_bytes(), if the AAD is the full length of the buffer.