### PR TITLE
ARROW-16219: [CI] Fix git config to prevent SCM tools failure

### DIFF
--- a/ci/scripts/cpp_build.sh
+++ b/ci/scripts/cpp_build.sh
@@ -26,7 +26,7 @@ build_dir=${2}/cpp
 : ${BUILD_DOCS_CPP:=OFF}
 
 if [ -x "$(command -v git)" ]; then
-  git config --global --add safe.directory ${arrow_dir}
+  git config --global --add safe.directory ${1}
 fi
 
 # TODO(kszucs): consider to move these to CMake

--- a/ci/scripts/cpp_build.sh
+++ b/ci/scripts/cpp_build.sh
@@ -25,7 +25,9 @@ build_dir=${2}/cpp
 : ${ARROW_USE_CCACHE:=OFF}
 : ${BUILD_DOCS_CPP:=OFF}
 
-git config --global --add safe.directory ${1}
+if [ -x "$(command -v git)" ]; then
+  git config --global --add safe.directory ${arrow_dir}
+fi
 
 # TODO(kszucs): consider to move these to CMake
 if [ ! -z "${CONDA_PREFIX}" ]; then

--- a/ci/scripts/cpp_build.sh
+++ b/ci/scripts/cpp_build.sh
@@ -25,6 +25,8 @@ build_dir=${2}/cpp
 : ${ARROW_USE_CCACHE:=OFF}
 : ${BUILD_DOCS_CPP:=OFF}
 
+git config --global --add safe.directory ${1}
+
 # TODO(kszucs): consider to move these to CMake
 if [ ! -z "${CONDA_PREFIX}" ]; then
   echo -e "===\n=== Conda environment for build\n==="

--- a/ci/scripts/python_build.sh
+++ b/ci/scripts/python_build.sh
@@ -27,6 +27,8 @@ python_build_dir=${build_dir}/python
 
 : ${BUILD_DOCS_PYTHON:=OFF}
 
+git config --global --add safe.directory ${arrow_dir}
+
 case "$(uname)" in
   Linux)
     n_jobs=$(nproc)

--- a/ci/scripts/python_build.sh
+++ b/ci/scripts/python_build.sh
@@ -27,7 +27,9 @@ python_build_dir=${build_dir}/python
 
 : ${BUILD_DOCS_PYTHON:=OFF}
 
-git config --global --add safe.directory ${arrow_dir}
+if [ -x "$(command -v git)" ]; then
+  git config --global --add safe.directory ${arrow_dir}
+fi
 
 case "$(uname)" in
   Linux)

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -895,6 +895,8 @@ ensure_source_directory() {
     fi
   fi
 
+  # Ensure ARROW_SOURCE_DIR is a safe.directory for git
+  git config --global --add safe.directory $ARROW_SOURCE_DIR
   # Ensure that the testing repositories are cloned
   if [ ! -d "${ARROW_SOURCE_DIR}/testing/data" ]; then
     git clone https://github.com/apache/arrow-testing.git ${ARROW_SOURCE_DIR}/testing

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -895,8 +895,6 @@ ensure_source_directory() {
     fi
   fi
 
-  # Ensure ARROW_SOURCE_DIR is a safe.directory for git
-  git config --global --add safe.directory $ARROW_SOURCE_DIR
   # Ensure that the testing repositories are cloned
   if [ ! -d "${ARROW_SOURCE_DIR}/testing/data" ]; then
     git clone https://github.com/apache/arrow-testing.git ${ARROW_SOURCE_DIR}/testing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1733,6 +1733,7 @@ services:
     command: >
       /bin/bash -c "
         apt update -y && apt install -y curl git gnupg tzdata wget &&
+        git config --global --add safe.directory /arrow &&
         /arrow/dev/release/verify-release-candidate.sh $${VERIFY_VERSION} $${VERIFY_RC}"
 
   almalinux-verify-rc:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1581,7 +1581,10 @@ services:
     environment:
       <<: *ccache
     volumes: *ubuntu-volumes
-    command: archery lint --all --no-clang-tidy --no-iwyu --no-numpydoc
+    command: >
+      /bin/bash -c "
+        git config --global --add safe.directory /arrow &&
+        archery lint --all --no-clang-tidy --no-iwyu --no-numpydoc"
 
   ######################### Integration Tests #################################
 


### PR DESCRIPTION
This PR fixes the CI failures due to the latest git release fixing CVE-2022-24765.
I have been able to see the build passing the scm step with the change here:
https://app.travis-ci.com/github/raulcd/arrow/builds/249688925
The above build fails due to some tests failing but not related with installation anymore.

And this was the failure before the change:
https://app.travis-ci.com/github/raulcd/arrow/builds/249683847

I also have been able to reproduce the issue on the `verify-conda-rc` locally.

The failure:
  ```
  $ docker-compose run  conda-verify-rc

....
  Preparing transaction: done
Verifying transaction: done
Executing transaction: done
/arrow/python /arrow /
Traceback (most recent call last):
  File "/arrow/python/setup.py", line 607, in <module>
    setup(
  File "/tmp/arrow-HEAD.YUVPq/mambaforge/envs/conda-source/lib/python3.10/site-packages/setuptools/__init__.py", line 87, in setup
    return distutils.core.setup(**attrs)
  File "/tmp/arrow-HEAD.YUVPq/mambaforge/envs/conda-source/lib/python3.10/site-packages/setuptools/_distutils/core.py", line 109, in setup
    _setup_distribution = dist = klass(attrs)
  File "/tmp/arrow-HEAD.YUVPq/mambaforge/envs/conda-source/lib/python3.10/site-packages/setuptools/dist.py", line 462, in __init__
    _Distribution.__init__(
  File "/tmp/arrow-HEAD.YUVPq/mambaforge/envs/conda-source/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 293, in __init__
    self.finalize_options()
  File "/tmp/arrow-HEAD.YUVPq/mambaforge/envs/conda-source/lib/python3.10/site-packages/setuptools/dist.py", line 886, in finalize_options
    ep(self)
  File "/tmp/arrow-HEAD.YUVPq/mambaforge/envs/conda-source/lib/python3.10/site-packages/setuptools/dist.py", line 907, in _finalize_setup_keywords
    ep.load()(self, ep.name, value)
  File "/tmp/arrow-HEAD.YUVPq/mambaforge/envs/conda-source/lib/python3.10/site-packages/setuptools_scm/integration.py", line 75, in version_keyword
    _assign_version(dist, config)
  File "/tmp/arrow-HEAD.YUVPq/mambaforge/envs/conda-source/lib/python3.10/site-packages/setuptools_scm/integration.py", line 51, in _assign_version
    _version_missing(config)
  File "/tmp/arrow-HEAD.YUVPq/mambaforge/envs/conda-source/lib/python3.10/site-packages/setuptools_scm/__init__.py", line 106, in _version_missing
    raise LookupError(
LookupError: setuptools-scm was unable to detect version for /arrow.

Make sure you're either building from a fully intact git repository or PyPI tarballs. Most other sources (such as GitHub's tarballs, a git checkout without the .git folder) don't contain the necessary metadata and will not work.

For example, if you're using pip, instead of https://github.com/user/proj/archive/master.zip use git+https://github.com/user/proj.git#egg=proj
Failed to verify release candidate. See /tmp/arrow-HEAD.YUVPq for details.
  ```

Waiting to validate the verify-rc fix at the moment, will update once the local build finishes