### PR TITLE
ARROW-16262: [CI][Integration] Skip failing tests from kartothek integration

### DIFF
--- a/ci/scripts/integration_kartothek.sh
+++ b/ci/scripts/integration_kartothek.sh
@@ -29,4 +29,6 @@ python -c "import kartothek"
 pushd /kartothek
 # See ARROW-12314, test_load_dataframes_columns_raises_missing skipped because of changed error message
 # See ARROW-16262 and https://github.com/JDASoftwareGroup/kartothek/issues/515
-pytest -n0 --ignore tests/cli/test_query.py -k "not test_load_dataframes_columns_raises_missing and not dates_as_object and not test_predicate_pushdown and not test_predicate_evaluation_date"
+pytest -n0 --ignore tests/cli/test_query.py -k "not test_load_dataframes_columns_raises_missing \
+              and not dates_as_object and not test_date_as_object \
+              and not test_predicate_pushdown and not test_predicate_evaluation_date"

--- a/ci/scripts/integration_kartothek.sh
+++ b/ci/scripts/integration_kartothek.sh
@@ -28,4 +28,5 @@ python -c "import kartothek"
 
 pushd /kartothek
 # See ARROW-12314, test_load_dataframes_columns_raises_missing skipped because of changed error message
-pytest -n0 --ignore tests/cli/test_query.py -k "not test_load_dataframes_columns_raises_missing"
+# See ARROW-16262 and https://github.com/JDASoftwareGroup/kartothek/issues/515
+pytest -n0 --ignore tests/cli/test_query.py -k "not test_load_dataframes_columns_raises_missing and not dates_as_object and not test_predicate_pushdown and not test_predicate_evaluation_date"


### PR DESCRIPTION
As discussed on https://github.com/apache/arrow/pull/12902#issuecomment-1102750381 there is an issue on the Kartothek integration https://github.com/JDASoftwareGroup/kartothek/issues/515
This PR aims to skip the failing tests.