### PR TITLE
ARROW-15312: [R][C++] filtering a Parquet dataset with is.na() misses some rows

### DIFF
--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -966,3 +966,29 @@ test_that("dataset to C-interface to arrow_dplyr_query with proj/filter", {
   # must clean up the pointer or we leak
   delete_arrow_array_stream(stream_ptr)
 })
+
+
+test_that("Filter parquet dataset with is.na ARROW-15312", {
+  ds_path <- make_temp_dir()
+
+  df <- tibble(x=1:3, y=c(0L, 0L, NA_integer_), z=c(0L, 1L, NA_integer_))
+  write_dataset(df, ds_path)
+
+  # OK: Collect then filter: returns row 3, as expected
+  expect_identical(
+    open_dataset(ds_path) %>% collect() %>% filter(is.na(y)),
+    df %>% collect() %>% filter(is.na(y))
+  )
+
+  # ERROR: Filter then collect (on y) returns a tibble with no row
+  expect_identical(
+    open_dataset(ds_path) %>% filter(is.na(y)) %>% collect(),
+    df %>% filter(is.na(y)) %>% collect()
+  )
+
+  # OK: Filter then collect (on z) returns row 3, as expected
+  expect_identical(
+    open_dataset(ds_path) %>% filter(is.na(z)) %>% collect(),
+    df %>% filter(is.na(z)) %>% collect()
+  )
+})

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -980,7 +980,7 @@ test_that("Filter parquet dataset with is.na ARROW-15312", {
     df %>% collect() %>% filter(is.na(y))
   )
 
-  # ERROR: Filter then collect (on y) returns a tibble with no row
+  # Before the fix: Filter then collect on y returned a 0-row tibble
   expect_identical(
     open_dataset(ds_path) %>% filter(is.na(y)) %>% collect(),
     df %>% filter(is.na(y)) %>% collect()

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -971,7 +971,7 @@ test_that("dataset to C-interface to arrow_dplyr_query with proj/filter", {
 test_that("Filter parquet dataset with is.na ARROW-15312", {
   ds_path <- make_temp_dir()
 
-  df <- tibble(x=1:3, y=c(0L, 0L, NA_integer_), z=c(0L, 1L, NA_integer_))
+  df <- tibble(x = 1:3, y = c(0L, 0L, NA_integer_), z = c(0L, 1L, NA_integer_))
   write_dataset(df, ds_path)
 
   # OK: Collect then filter: returns row 3, as expected


### PR DESCRIPTION
The real fix was in https://github.com/apache/arrow/pull/12891 ([ARROW-12659](https://issues.apache.org/jira/browse/ARROW-12659)) but this adds integration tests from the ticket to confirm this works in R + we don't run into this in the future