### PR TITLE
ARROW-16121: [Python] Deprecate the (common_)metadata(_path) attributes of ParquetDataset

### DIFF
--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -1715,14 +1715,14 @@ Examples
 
         (self._pieces,
          self._partitions,
-         self.common_metadata_path,
-         self.metadata_path) = _make_manifest(
+         self._common_metadata_path,
+         self._metadata_path) = _make_manifest(
              path_or_paths, self._fs, metadata_nthreads=metadata_nthreads,
              open_file_func=partial(_open_dataset_file, self._metadata)
         )
 
-        if self.common_metadata_path is not None:
-            with self._fs.open(self.common_metadata_path) as f:
+        if self._common_metadata_path is not None:
+            with self._fs.open(self._common_metadata_path) as f:
                 self._metadata.common_metadata = read_metadata(
                     f,
                     memory_map=memory_map
@@ -2030,6 +2030,36 @@ Examples
                 "instead."),
             FutureWarning, stacklevel=2)
         return self._metadata.fs
+
+    @property
+    def metadata_(self):
+        """
+        DEPRECATED
+        """
+        warnings.warn(
+            _DEPR_MSG.format("ParquetDataset.metadata_", ""),
+            FutureWarning, stacklevel=2)
+        return self._metadata
+
+    @property
+    def metadata_path(self):
+        """
+        DEPRECATED
+        """
+        warnings.warn(
+            _DEPR_MSG.format("ParquetDataset.metadata_path", ""),
+            FutureWarning, stacklevel=2)
+        return self._metadata_path
+
+    @property
+    def common_metadata_path(self):
+        """
+        DEPRECATED
+        """
+        warnings.warn(
+            _DEPR_MSG.format("ParquetDataset.common_metadata_path", ""),
+            FutureWarning, stacklevel=2)
+        return self._common_metadata_path
 
     _common_metadata = property(
         operator.attrgetter('_metadata.common_metadata')

--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -2043,7 +2043,7 @@ Examples
         DEPRECATED
         """
         warnings.warn(
-            _DEPR_MSG.format("ParquetDataset.metadata_", ""),
+            _DEPR_MSG.format("ParquetDataset.metadata", ""),
             FutureWarning, stacklevel=2)
         return self.__metadata
 

--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -1730,6 +1730,12 @@ Examples
         else:
             self._metadata.common_metadata = None
 
+        if metadata is not None:
+            warnings.warn(
+                "Specifying the 'metadata' argument with 'use_legacy_dataset="
+                "True' is deprecated as of pyarrow 8.0.0.",
+                FutureWarning, stacklevel=2)
+
         if metadata is None and self.metadata_path is not None:
             with self._fs.open(self.metadata_path) as f:
                 self.metadata = read_metadata(f, memory_map=memory_map)

--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -1736,11 +1736,11 @@ Examples
                 "True' is deprecated as of pyarrow 8.0.0.",
                 FutureWarning, stacklevel=2)
 
-        if metadata is None and self.metadata_path is not None:
-            with self._fs.open(self.metadata_path) as f:
-                self.metadata = read_metadata(f, memory_map=memory_map)
+        if metadata is None and self._metadata_path is not None:
+            with self._fs.open(self._metadata_path) as f:
+                self.__metadata = read_metadata(f, memory_map=memory_map)
         else:
-            self.metadata = metadata
+            self.__metadata = metadata
 
         if schema is not None:
             warnings.warn(
@@ -1789,13 +1789,13 @@ Examples
             return NotImplemented
 
     def validate_schemas(self):
-        if self.metadata is None and self._schema is None:
-            if self.common_metadata is not None:
-                self._schema = self.common_metadata.schema
+        if self.__metadata is None and self._schema is None:
+            if self._common_metadata is not None:
+                self._schema = self._common_metadata.schema
             else:
                 self._schema = self._pieces[0].get_metadata().schema
         elif self._schema is None:
-            self._schema = self.metadata.schema
+            self._schema = self.__metadata.schema
 
         # Verify schemas are all compatible
         dataset_schema = self._schema.to_arrow_schema()
@@ -2038,14 +2038,14 @@ Examples
         return self._metadata.fs
 
     @property
-    def metadata_(self):
+    def metadata(self):
         """
         DEPRECATED
         """
         warnings.warn(
             _DEPR_MSG.format("ParquetDataset.metadata_", ""),
             FutureWarning, stacklevel=2)
-        return self._metadata
+        return self.__metadata
 
     @property
     def metadata_path(self):

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -618,9 +618,7 @@ def test_read_table_doesnt_warn(datadir, use_legacy_dataset):
 
     if use_legacy_dataset:
         # FutureWarning: 'use_legacy_dataset=True'
-        # FutureWarning: 'ParquetDataset.metadata_path' attribute
-        # FutureWarning: 'ParquetDataset.common_metadata' attribute
-        assert len(record) == 3
+        assert len(record) == 1
     else:
         assert len(record) == 0
 

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -617,9 +617,10 @@ def test_read_table_doesnt_warn(datadir, use_legacy_dataset):
                       use_legacy_dataset=use_legacy_dataset)
 
     if use_legacy_dataset:
-        # DeprecationWarning: 'use_legacy_dataset=True'
-        # DeprecationWarning: 'ParquetDataset.common_metadata' attribute
-        assert len(record) == 2
+        # FutureWarning: 'use_legacy_dataset=True'
+        # FutureWarning: 'ParquetDataset.metadata_path' attribute
+        # FutureWarning: 'ParquetDataset.common_metadata' attribute
+        assert len(record) == 3
     else:
         assert len(record) == 0
 

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -1719,6 +1719,16 @@ def test_parquet_dataset_deprecated_properties(tempdir):
     with pytest.warns(FutureWarning, match="'ParquetDataset.common_metadata'"):
         dataset.common_metadata
 
+    with pytest.warns(FutureWarning, match="'ParquetDataset.metadata"):
+        dataset.metadata
+
+    with pytest.warns(FutureWarning, match="'ParquetDataset.metadata_path"):
+        dataset.metadata_path
+
+    with pytest.warns(FutureWarning,
+                      match="'ParquetDataset.common_metadata_path"):
+        dataset.common_metadata_path
+
     dataset2 = pq.ParquetDataset(path, use_legacy_dataset=False)
 
     with pytest.warns(FutureWarning, match="'ParquetDataset.pieces"):


### PR DESCRIPTION
This PR tries to:

- deprecate the `metadata,` `metadata_path` and `common_metadata_path` attributes in the legacy ParquetDataset.
- deprecate passing the `metadata` keyword in the ParquetDataset constructor.

`common_metadata` attribute has already been deprecated.