### PR TITLE
ARROW-16280: [C++] Avoid copying shared_ptr in Expression::type()

### DIFF
--- a/cpp/src/arrow/compute/exec/expression.cc
+++ b/cpp/src/arrow/compute/exec/expression.cc
@@ -107,6 +107,21 @@ ValueDescr Expression::descr() const {
   return CallNotNull(*this)->descr;
 }
 
+const std::shared_ptr<DataType> &Expression::type() const {
+  static const std::shared_ptr<DataType> no_type;
+  if (impl_ == nullptr) return no_type;
+
+  if (auto lit = literal()) {
+    return lit->type();
+  }
+
+  if (auto parameter = this->parameter()) {
+    return parameter->descr.type;
+  }
+
+  return CallNotNull(*this)->descr.type;
+}
+
 namespace {
 
 std::string PrintDatum(const Datum& datum) {

--- a/cpp/src/arrow/compute/exec/expression.cc
+++ b/cpp/src/arrow/compute/exec/expression.cc
@@ -107,7 +107,7 @@ ValueDescr Expression::descr() const {
   return CallNotNull(*this)->descr;
 }
 
-const std::shared_ptr<DataType> &Expression::type() const {
+const std::shared_ptr<DataType>& Expression::type() const {
   static const std::shared_ptr<DataType> no_type;
   if (impl_ == nullptr) return no_type;
 

--- a/cpp/src/arrow/compute/exec/expression.h
+++ b/cpp/src/arrow/compute/exec/expression.h
@@ -109,7 +109,7 @@ class ARROW_EXPORT Expression {
 
   /// The type and shape to which this expression will evaluate
   ValueDescr descr() const;
-  std::shared_ptr<DataType> type() const { return descr().type; }
+  const std::shared_ptr<DataType> &type() const;
   // XXX someday
   // NullGeneralization::type nullable() const;
 

--- a/cpp/src/arrow/compute/exec/expression.h
+++ b/cpp/src/arrow/compute/exec/expression.h
@@ -109,7 +109,7 @@ class ARROW_EXPORT Expression {
 
   /// The type and shape to which this expression will evaluate
   ValueDescr descr() const;
-  const std::shared_ptr<DataType> &type() const;
+  const std::shared_ptr<DataType>& type() const;
   // XXX someday
   // NullGeneralization::type nullable() const;
 


### PR DESCRIPTION
I see big improvements in the `ExecuteScalarExpressionOverhead` benchmarks, especially `ref_only_expression` with this, for example:
```
before:
ExecuteScalarExpressionOverhead/ref_only_expression/rows_per_batch:1000000/real_time/threads:1         35.4 ns         35.4 ns     19577007 batches_per_second=28.2395M/s rows_per_second=28.2395T/s
ExecuteScalarExpressionOverhead/ref_only_expression/rows_per_batch:1000000/real_time/threads:16        49.8 ns          788 ns     14280992 batches_per_second=20.0734M/s rows_per_second=20.0734T/s

after:
ExecuteScalarExpressionOverhead/ref_only_expression/rows_per_batch:1000000/real_time/threads:1         27.6 ns         27.5 ns     25090317 batches_per_second=36.2832M/s rows_per_second=36.2832T/s
ExecuteScalarExpressionOverhead/ref_only_expression/rows_per_batch:1000000/real_time/threads:16        4.26 ns         67.2 ns    184745728 batches_per_second=235.006M/s rows_per_second=235.006T/s

```

Also the overhead of small batch size/multithreaded benchmarks is reduced, for example in `complex_expression`:
```
before:
ExecuteScalarExpressionOverhead/complex_expression/rows_per_batch:1000/real_time/threads:1          3723682 ns      3721326 ns          191 batches_per_second=268.551k/s rows_per_second=268.551M/s
ExecuteScalarExpressionOverhead/complex_expression/rows_per_batch:1000/real_time/threads:16         1153070 ns     18365265 ns          624 batches_per_second=867.25k/s rows_per_second=867.25M/s

after:
ExecuteScalarExpressionOverhead/complex_expression/rows_per_batch:1000/real_time/threads:1          3543745 ns      3541909 ns          197 batches_per_second=282.187k/s rows_per_second=282.187M/s
ExecuteScalarExpressionOverhead/complex_expression/rows_per_batch:1000/real_time/threads:16          841776 ns     13395266 ns          944 batches_per_second=1.18796M/s rows_per_second=1.18796G/s
```