### PR TITLE
MINOR: [Docs] Fix typo in parquet.rst

### DIFF
--- a/docs/source/python/parquet.rst
+++ b/docs/source/python/parquet.rst
@@ -411,8 +411,8 @@ Compatibility Note: if using ``pq.write_to_dataset`` to create a table that
 will then be used by HIVE then partition column values must be compatible with
 the allowed character set of the HIVE version you are running.
 
-Writing ``_metadata`` and ``_common_medata`` files
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Writing ``_metadata`` and ``_common_metadata`` files
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Some processing frameworks such as Spark or Dask (optionally) use ``_metadata``
 and ``_common_metadata`` files with partitioned datasets.


### PR DESCRIPTION
Not sure if it's important, but this will break the link to this section, which is currently
```
https://arrow.apache.org/docs/python/parquet.html#writing-metadata-and-common-medata-files
```