### PR TITLE
ARROW-16278: [CI] Fix git installation failure on brew

### DIFF
--- a/dev/tasks/verify-rc/github.macos.amd64.yml
+++ b/dev/tasks/verify-rc/github.macos.amd64.yml
@@ -40,6 +40,7 @@ jobs:
         shell: bash
         run: |
           brew update
+          brew install --overwrite git
           brew bundle --file=arrow/cpp/Brewfile
           brew bundle --file=arrow/c_glib/Brewfile
       {% endif %}


### PR DESCRIPTION
This is a follow-up of #12958.