### PR TITLE
ARROW-16294: [C++] Improve performance of parquet readahead

### DIFF
--- a/cpp/src/arrow/compute/exec/source_node.cc
+++ b/cpp/src/arrow/compute/exec/source_node.cc
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <iostream>
 #include <mutex>
 
 #include "arrow/compute/exec.h"

--- a/cpp/src/arrow/compute/exec/source_node.cc
+++ b/cpp/src/arrow/compute/exec/source_node.cc
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <iostream>
 #include <mutex>
 
 #include "arrow/compute/exec.h"

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -461,10 +461,11 @@ Result<RecordBatchGenerator> ParquetFileFormat::ScanBatchesAsync(
         GetFragmentScanOptions<ParquetFragmentScanOptions>(
             kParquetTypeName, options.get(), default_fragment_scan_options));
     int batch_readahead = options->batch_readahead;
-    ARROW_ASSIGN_OR_RAISE(auto generator, reader->GetRecordBatchGenerator(
-                                              reader, row_groups, column_projection,
-                                              ::arrow::internal::GetCpuThreadPool(),
-                                              batch_readahead * batch_size));
+    int64_t rows_to_readahead = batch_readahead * batch_size;
+    ARROW_ASSIGN_OR_RAISE(auto generator,
+                          reader->GetRecordBatchGenerator(
+                              reader, row_groups, column_projection,
+                              ::arrow::internal::GetCpuThreadPool(), rows_to_readahead));
     RecordBatchGenerator sliced = SlicingGenerator(std::move(generator), batch_size);
     RecordBatchGenerator sliced_readahead =
         MakeSerialReadaheadGenerator(std::move(sliced), batch_readahead);

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -384,6 +384,48 @@ Future<std::shared_ptr<parquet::arrow::FileReader>> ParquetFileFormat::GetReader
       });
 }
 
+struct SlicingGenerator {
+  SlicingGenerator(RecordBatchGenerator source, int64_t batch_size)
+      : state(std::make_shared<State>(source, batch_size)) {}
+
+  Future<std::shared_ptr<RecordBatch>> operator()() {
+    if (state->current) {
+      return state->SliceOffABatch();
+    } else {
+      auto state_capture = state;
+      return state->source().Then(
+          [state_capture](const std::shared_ptr<RecordBatch>& next) {
+            if (IsIterationEnd(next)) {
+              return next;
+            }
+            state_capture->current = next;
+            return state_capture->SliceOffABatch();
+          });
+    }
+  }
+
+  struct State {
+    State(RecordBatchGenerator source, int64_t batch_size)
+        : source(std::move(source)), current(), batch_size(batch_size) {}
+
+    std::shared_ptr<RecordBatch> SliceOffABatch() {
+      if (current->num_rows() <= batch_size) {
+        auto sliced = current;
+        current = nullptr;
+        return sliced;
+      }
+      auto slice = current->Slice(0, batch_size);
+      current = current->Slice(batch_size);
+      return slice;
+    }
+
+    RecordBatchGenerator source;
+    std::shared_ptr<RecordBatch> current;
+    int64_t batch_size;
+  };
+  std::shared_ptr<State> state;
+};
+
 Result<RecordBatchGenerator> ParquetFileFormat::ScanBatchesAsync(
     const std::shared_ptr<ScanOptions>& options,
     const std::shared_ptr<FileFragment>& file) const {
@@ -399,6 +441,7 @@ Result<RecordBatchGenerator> ParquetFileFormat::ScanBatchesAsync(
     pre_filtered = true;
     if (row_groups.empty()) return MakeEmptyGenerator<std::shared_ptr<RecordBatch>>();
   }
+  int64_t batch_size = options->batch_size;
   // Open the reader and pay the real IO cost.
   auto make_generator =
       [=](const std::shared_ptr<parquet::arrow::FileReader>& reader) mutable
@@ -418,11 +461,14 @@ Result<RecordBatchGenerator> ParquetFileFormat::ScanBatchesAsync(
         GetFragmentScanOptions<ParquetFragmentScanOptions>(
             kParquetTypeName, options.get(), default_fragment_scan_options));
     int batch_readahead = options->batch_readahead;
-    ARROW_ASSIGN_OR_RAISE(auto generator,
-                          reader->GetRecordBatchGenerator(
-                              reader, row_groups, column_projection,
-                              ::arrow::internal::GetCpuThreadPool(), batch_readahead));
-    return generator;
+    ARROW_ASSIGN_OR_RAISE(auto generator, reader->GetRecordBatchGenerator(
+                                              reader, row_groups, column_projection,
+                                              ::arrow::internal::GetCpuThreadPool(),
+                                              batch_readahead * batch_size));
+    RecordBatchGenerator sliced = SlicingGenerator(std::move(generator), batch_size);
+    RecordBatchGenerator sliced_readahead =
+        MakeSerialReadaheadGenerator(std::move(sliced), batch_readahead);
+    return sliced_readahead;
   };
   auto generator = MakeFromFuture(GetReaderAsync(parquet_fragment->source(), options)
                                       .Then(std::move(make_generator)));

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -341,7 +341,7 @@ class FileReaderImpl : public FileReader {
                           const std::vector<int> row_group_indices,
                           const std::vector<int> column_indices,
                           ::arrow::internal::Executor* cpu_executor,
-                          int row_group_readahead) override;
+                          int64_t rows_to_readahead) override;
 
   int num_columns() const { return reader_->metadata()->num_columns(); }
 
@@ -1163,7 +1163,7 @@ FileReaderImpl::GetRecordBatchGenerator(std::shared_ptr<FileReader> reader,
                                         const std::vector<int> row_group_indices,
                                         const std::vector<int> column_indices,
                                         ::arrow::internal::Executor* cpu_executor,
-                                        int rows_to_readahead) {
+                                        int64_t rows_to_readahead) {
   RETURN_NOT_OK(BoundsCheck(row_group_indices, column_indices));
   if (rows_to_readahead < 0) {
     return Status::Invalid("rows_to_readahead must be > 0");

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -1096,7 +1096,7 @@ class RowGroupGenerator {
   }
 
   void FetchNext() {
-    int row_group_index = readahead_index_++;
+    size_t row_group_index = readahead_index_++;
     int row_group = row_groups_[row_group_index];
     std::vector<int> column_indices = column_indices_;
     auto reader = arrow_reader_;

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -193,7 +193,7 @@ class PARQUET_EXPORT FileReader {
                           const std::vector<int> row_group_indices,
                           const std::vector<int> column_indices,
                           ::arrow::internal::Executor* cpu_executor = NULLPTR,
-                          int rows_to_readahead = 0) = 0;
+                          int64_t rows_to_readahead = 0) = 0;
 
   ::arrow::Status GetRecordBatchReader(const std::vector<int>& row_group_indices,
                                        const std::vector<int>& column_indices,

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -193,7 +193,7 @@ class PARQUET_EXPORT FileReader {
                           const std::vector<int> row_group_indices,
                           const std::vector<int> column_indices,
                           ::arrow::internal::Executor* cpu_executor = NULLPTR,
-                          int row_group_readahead = 0) = 0;
+                          int rows_to_readahead = 0) = 0;
 
   ::arrow::Status GetRecordBatchReader(const std::vector<int>& row_group_indices,
                                        const std::vector<int>& column_indices,

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -2133,7 +2133,7 @@ cdef class TaggedRecordBatchIterator(_Weakrefable):
             fragment=Fragment.wrap(batch.fragment))
 
 
-_DEFAULT_BATCH_SIZE = 2**20
+_DEFAULT_BATCH_SIZE = 2**17
 
 
 cdef void _populate_builder(const shared_ptr[CScannerBuilder]& ptr,
@@ -2216,7 +2216,7 @@ cdef class Scanner(_Weakrefable):
         partition information or internal metadata found in the data
         source, e.g. Parquet statistics. Otherwise filters the loaded
         RecordBatches before yielding them.
-    batch_size : int, default 1M
+    batch_size : int, default 128Ki
         The maximum row count for scanned record batches. If scanned
         record batches are overflowing memory then this method can be
         called to reduce their size.
@@ -2290,7 +2290,7 @@ cdef class Scanner(_Weakrefable):
             partition information or internal metadata found in the data
             source, e.g. Parquet statistics. Otherwise filters the loaded
             RecordBatches before yielding them.
-        batch_size : int, default 1M
+        batch_size : int, default 128Ki
             The maximum row count for scanned record batches. If scanned
             record batches are overflowing memory then this method can be
             called to reduce their size.
@@ -2368,7 +2368,7 @@ cdef class Scanner(_Weakrefable):
             partition information or internal metadata found in the data
             source, e.g. Parquet statistics. Otherwise filters the loaded
             RecordBatches before yielding them.
-        batch_size : int, default 1M
+        batch_size : int, default 128Ki
             The maximum row count for scanned record batches. If scanned
             record batches are overflowing memory then this method can be
             called to reduce their size.
@@ -2432,7 +2432,7 @@ cdef class Scanner(_Weakrefable):
                 The columns to project.
         filter : Expression, default None
             Scan will return only the rows matching the filter.
-        batch_size : int, default 1M
+        batch_size : int, default 128Ki
             The maximum row count for scanned record batches.
         use_threads : bool, default True
             If enabled, then maximum parallelism will be used determined by

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -1740,17 +1740,18 @@ def test_dictionary_partitioning_outer_nulls_raises(tempdir):
 @pytest.mark.parquet
 @pytest.mark.pandas
 def test_read_partition_keys_only(tempdir):
+    BATCH_SIZE = 2 ** 17
     # This is a regression test for ARROW-15318 which saw issues
     # reading only the partition keys from files with batches larger
     # than the default batch size (e.g. so we need to return two chunks)
     table = pa.table({
-        'key': pa.repeat(0, 2 ** 20 + 1),
-        'value': np.arange(2 ** 20 + 1)})
+        'key': pa.repeat(0, BATCH_SIZE + 1),
+        'value': np.arange(BATCH_SIZE + 1)})
     pq.write_to_dataset(
-        table[:2 ** 20],
+        table[:BATCH_SIZE],
         tempdir / 'one', partition_cols=['key'])
     pq.write_to_dataset(
-        table[:2 ** 20 + 1],
+        table[:BATCH_SIZE + 1],
         tempdir / 'two', partition_cols=['key'])
 
     table = pq.read_table(tempdir / 'one', columns=['key'])


### PR DESCRIPTION
 * Turns out the batch size we were slicing internally for parquet (in the TableBatchReader) was not the batch size from the scanner.  I added batch slicing in file_parquet to leave the parquet reader itself more or less unchanged here (and it's not clear it would make more sense to use the smaller batch size slicing inside the reader anyways).
 * Changed parquet readahead so it reads ahead more than one row group.  It now tries to keep `batch_size * batch_readahead` reads in flight.  Users that want more parallel reads can increase batch readahead.