### PR TITLE
ARROW-16278: [CI] Fix git installation failure on brew

### DIFF
--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -52,7 +52,9 @@ jobs:
       {{ macros.github_checkout_arrow()|indent }}
       {{ macros.github_install_archery()|indent }}
       - name: Install Dependencies
-        run: brew bundle --file=arrow/cpp/Brewfile
+        run: |
+          brew install --overwrite git
+          brew bundle --file=arrow/cpp/Brewfile
       - name: Build C Data Interface lib
         run: |
           set -e


### PR DESCRIPTION
This is a follow-up of #12958.