### PR TITLE
ARROW-16295: [CI][Release] Use windows-2019 for verify-rc-source-windows

### DIFF
--- a/dev/release/verify-release-candidate.bat
+++ b/dev/release/verify-release-candidate.bat
@@ -94,7 +94,7 @@ call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tool
 @rem generator used
 
 cmake -G "%GENERATOR%" ^
-      -A "%ARCHITECTURE" ^
+      -A "%ARCHITECTURE%" ^
       -DARROW_BOOST_USE_SHARED=ON ^
       -DARROW_BUILD_STATIC=OFF ^
       -DARROW_BUILD_TESTS=ON ^

--- a/dev/release/verify-release-candidate.bat
+++ b/dev/release/verify-release-candidate.bat
@@ -73,7 +73,8 @@ call activate %_VERIFICATION_CONDA_ENV% || exit /B 1
 @rem for more context, see https://issues.apache.org/jira/browse/ARROW-15378
 call conda remove -y gtest gmock || exit /B 1
 
-set GENERATOR=Visual Studio 15 2017 Win64
+set GENERATOR=Visual Studio 16 2019
+set ARCHITECTURE=x64
 set CONFIGURATION=release
 
 pushd !ARROW_SOURCE!
@@ -93,6 +94,7 @@ call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tool
 @rem generator used
 
 cmake -G "%GENERATOR%" ^
+      -A "%ARCHITECTURE" ^
       -DARROW_BOOST_USE_SHARED=ON ^
       -DARROW_BUILD_STATIC=OFF ^
       -DARROW_BUILD_TESTS=ON ^

--- a/dev/tasks/verify-rc/github.win.yml
+++ b/dev/tasks/verify-rc/github.win.yml
@@ -22,7 +22,7 @@
 jobs:
   verify:
     name: "Verify release candidate Windows source"
-    runs-on: windows-2016
+    runs-on: windows-2019
     {% if env is defined %}
     env:
     {% for key, value in env.items() %}


### PR DESCRIPTION
Because windows-2016 is deprecated:
https://github.com/actions/virtual-environments/issues/4312