### PR TITLE
MINOR: [R] Specify minimum tidyselect version required

### DIFF
--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -36,7 +36,7 @@ Imports:
     R6,
     rlang,
     stats,
-    tidyselect,
+    tidyselect (>= 1.0.0),
     utils,
     vctrs
 Roxygen: list(markdown = TRUE, r6 = FALSE, load = "source")


### PR DESCRIPTION
Fix #12965