### PR TITLE
ARROW-16305: [C++] Missed reference to ARROW_ENGINE during the rename

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ jobs:
           -e ARROW_GCS=OFF
           -e ARROW_MIMALLOC=OFF
           -e ARROW_ORC=OFF
-          -e ARROW_ENGINE=OFF
+          -e ARROW_SUBSTRAIT=OFF
           -e ARROW_PARQUET=OFF
           -e ARROW_S3=OFF
           -e CMAKE_UNITY_BUILD=ON


### PR DESCRIPTION
I had not thought to check .travis.yml.  The errors appeared to be completely unrelated and I'm still not entirely sure why we receive them.  However, in the past, we were not building parquet on the s390x build.  With ARROW-16158 we accidentally enabled parquet on this build.  This change should disable `ARROW_SUBSTRAIT` (and transitively, `ARROW_PARQUET`) so that the behavior is the same as it was before.