### PR TITLE
ARROW-16306: [CI] Fix Nightly verify rc on ubuntu

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1795,4 +1795,5 @@ services:
       TEST_YUM: 0
     command: >
       /bin/bash -c "
+        git config --global --add safe.directory /arrow &&
         /arrow/dev/release/verify-release-candidate.sh $${VERIFY_VERSION} $${VERIFY_RC}"


### PR DESCRIPTION
Currently the following jobs are failing:
- verify-rc-source-python-linux-ubuntu-18.04-amd64:
- verify-rc-source-python-linux-ubuntu-20.04-amd64:
due to the following error (https://github.com/ursacomputing/crossbow/runs/6147121617?check_suite_focus=true):
```
Traceback (most recent call last):
  File "setup.py", line 607, in <module>
    setup(
  File "/tmp/arrow-HEAD.7Wo1N/venv-source/lib/python3.8/site-packages/setuptools/__init__.py", line 129, in setup
    return distutils.core.setup(**attrs)
  File "/usr/lib/python3.8/distutils/core.py", line 108, in setup
    _setup_distribution = dist = klass(attrs)
  File "/tmp/arrow-HEAD.7Wo1N/venv-source/lib/python3.8/site-packages/setuptools/dist.py", line 372, in __init__
    _Distribution.__init__(self, attrs)
  File "/usr/lib/python3.8/distutils/dist.py", line 292, in __init__
    self.finalize_options()
  File "/tmp/arrow-HEAD.7Wo1N/venv-source/lib/python3.8/site-packages/setuptools/dist.py", line 528, in finalize_options
    ep.load()(self, ep.name, value)
  File "/tmp/arrow-HEAD.7Wo1N/venv-source/lib/python3.8/site-packages/setuptools_scm/integration.py", line 75, in version_keyword
    _assign_version(dist, config)
  File "/tmp/arrow-HEAD.7Wo1N/venv-source/lib/python3.8/site-packages/setuptools_scm/integration.py", line 51, in _assign_version
    _version_missing(config)
  File "/tmp/arrow-HEAD.7Wo1N/venv-source/lib/python3.8/site-packages/setuptools_scm/__init__.py", line 106, in _version_missing
    raise LookupError(
LookupError: setuptools-scm was unable to detect version for /arrow.Make sure you're either building from a fully intact git repository or PyPI tarballs. Most other sources (such as GitHub's tarballs, a git checkout without the .git folder) don't contain the necessary metadata and will not work.For example, if you're using pip, instead of https://github.com/user/proj/archive/master.zip use git+https://github.com/user/proj.git#egg=proj
Failed to verify release candidate. See /tmp/arrow-HEAD.7Wo1N for details.
1
Error: `docker-compose --file /home/runner/work/crossbow/crossbow/arrow/docker-compose.yml run --rm -e VERIFY_VERSION= -e VERIFY_RC= -e TEST_DEFAULT=0 -e TEST_PYTHON=1 ubuntu-verify-rc` exited with a non-zero exit code 1, see the process log above.The docker-compose command was invoked with the following parameters:
```
