### PR TITLE
ARROW-16311: [Java] Do not return table_schema column when it's not requested

### DIFF
--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/TestFlightSql.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/TestFlightSql.java
@@ -181,6 +181,14 @@ public class TestFlightSql {
   }
 
   @Test
+  public void testGetTablesSchemaExcludeSchema() {
+    final FlightInfo info = sqlClient.getTables(null, null, null, null, false);
+    collector.checkThat(info.getSchema(), is(FlightSqlProducer.Schemas.GET_TABLES_SCHEMA_NO_SCHEMA));
+  }
+
+
+
+  @Test
   public void testGetTablesResultNoSchema() throws Exception {
     try (final FlightStream stream =
              sqlClient.getStream(

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/TestFlightSql.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/TestFlightSql.java
@@ -186,8 +186,6 @@ public class TestFlightSql {
     collector.checkThat(info.getSchema(), is(FlightSqlProducer.Schemas.GET_TABLES_SCHEMA_NO_SCHEMA));
   }
 
-
-
   @Test
   public void testGetTablesResultNoSchema() throws Exception {
     try (final FlightStream stream =

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/example/FlightSqlExample.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/example/FlightSqlExample.java
@@ -1492,7 +1492,7 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
 
     Schema schemaToUse = Schemas.GET_TABLES_SCHEMA;
 
-    if(!request.getIncludeSchema()) {
+    if (!request.getIncludeSchema()) {
       List<Field> fieldsToUse = Schemas.GET_TABLES_SCHEMA
               .getFields()
               .stream()

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/example/FlightSqlExample.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/example/FlightSqlExample.java
@@ -78,7 +78,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.arrow.adapter.jdbc.ArrowVectorIterator;
@@ -1493,12 +1492,7 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
     Schema schemaToUse = Schemas.GET_TABLES_SCHEMA;
 
     if (!request.getIncludeSchema()) {
-      List<Field> fieldsToUse = Schemas.GET_TABLES_SCHEMA
-              .getFields()
-              .stream()
-              .filter(f -> !f.getName().equals("table_schema"))
-              .collect(Collectors.toList());
-      schemaToUse = new Schema(fieldsToUse);
+      schemaToUse = Schemas.GET_TABLES_SCHEMA_NO_SCHEMA;
     }
 
     return getFlightInfoForSchema(request, descriptor, schemaToUse);

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/example/FlightSqlExample.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/example/FlightSqlExample.java
@@ -1488,13 +1488,10 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
   @Override
   public FlightInfo getFlightInfoTables(final CommandGetTables request, final CallContext context,
                                         final FlightDescriptor descriptor) {
-
     Schema schemaToUse = Schemas.GET_TABLES_SCHEMA;
-
     if (!request.getIncludeSchema()) {
       schemaToUse = Schemas.GET_TABLES_SCHEMA_NO_SCHEMA;
     }
-
     return getFlightInfoForSchema(request, descriptor, schemaToUse);
   }
 

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/example/FlightSqlExample.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/example/FlightSqlExample.java
@@ -78,6 +78,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.arrow.adapter.jdbc.ArrowVectorIterator;
@@ -1488,7 +1489,19 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
   @Override
   public FlightInfo getFlightInfoTables(final CommandGetTables request, final CallContext context,
                                         final FlightDescriptor descriptor) {
-    return getFlightInfoForSchema(request, descriptor, Schemas.GET_TABLES_SCHEMA);
+
+    Schema schemaToUse = Schemas.GET_TABLES_SCHEMA;
+
+    if(!request.getIncludeSchema()) {
+      List<Field> fieldsToUse = Schemas.GET_TABLES_SCHEMA
+              .getFields()
+              .stream()
+              .filter(f -> !f.getName().equals("table_schema"))
+              .collect(Collectors.toList());
+      schemaToUse = new Schema(fieldsToUse);
+    }
+
+    return getFlightInfoForSchema(request, descriptor, schemaToUse);
   }
 
   @Override


### PR DESCRIPTION
Currently, when the FlightInfo for CommandGetTables is requested, it always (hardcoded) returns a schema which includes the table_schema column (Schema.GET_TABLES_SCHEMA)  even when the table_schema is not requested (include_schema on CommandGetTables = false).

