### PR TITLE
ARROW-16312: [C++][CI] Install tzdata in the windows verification builds

### DIFF
--- a/dev/tasks/verify-rc/github.win.yml
+++ b/dev/tasks/verify-rc/github.win.yml
@@ -38,6 +38,11 @@ jobs:
         run: |
           choco install boost-msvc-14.1
           choco install wget
+
+      - name: Download Timezone Database
+        shell: bash
+        run: arrow/ci/scripts/download_tz_database.sh
+
       - name: Run verification
         shell: cmd
         run: |


### PR DESCRIPTION
The build now fails with a different error: https://github.com/ursacomputing/crossbow/runs/6154173225?check_suite_focus=true