### PR TITLE
MINOR: [R][CI] Add default for R_CUSTOM_CCACHE to .env

### DIFF
--- a/.env
+++ b/.env
@@ -78,6 +78,7 @@ R_ORG=rhub
 R_TAG=latest
 
 # Env vars for R builds
+R_CUSTOM_CCACHE=false
 ARROW_R_DEV=TRUE
 R_PRUNE_DEPS=FALSE
 TZ=UTC


### PR DESCRIPTION
Using archery locally to run docker builds causes a warning if `R_CUSTOM_CCACHE` is not set, even if unrelated to the build:
```
$ archery docker run conda-cpp-valgrind bash
WARNING: The R_CUSTOM_CCACHE variable is not set. Defaulting to a blank string.
```
Setting the defaul in `.env` fixes this.