### PR TITLE
ARROW-16314: [Python][CI] Skip running cython tests in windows verification builds

### DIFF
--- a/dev/release/verify-release-candidate-wheels.bat
+++ b/dev/release/verify-release-candidate-wheels.bat
@@ -101,6 +101,8 @@ python -c "import pyarrow.flight" || EXIT /B 1
 python -c "import pyarrow.dataset" || EXIT /B 1
 
 pip install -r arrow\python\requirements-test.txt || EXIT /B 1
+
+set PYARROW_TEST_CYTHON=OFF
 pytest %CONDA_ENV_PATH%\Lib\site-packages\pyarrow --pdb -v || EXIT /B 1
 
 :done

--- a/dev/release/verify-release-candidate.bat
+++ b/dev/release/verify-release-candidate.bat
@@ -135,6 +135,7 @@ set PYARROW_WITH_FLIGHT=1
 set PYARROW_WITH_PARQUET=1
 set PYARROW_WITH_PARQUET_ENCRYPTION=1
 set PYARROW_WITH_DATASET=1
+set PYARROW_TEST_CYTHON=OFF
 python setup.py build_ext --inplace --bundle-arrow-cpp bdist_wheel || exit /B 1
 pytest pyarrow -v -s --enable-parquet || exit /B 1
 


### PR DESCRIPTION
Created a follow-up to investigate it further: https://issues.apache.org/jira/browse/ARROW-16315