### PR TITLE
ARROW-16338: [CI] Update azure windows image as vs2017-win2016 is retired

### DIFF
--- a/dev/tasks/conda-recipes/azure.win.yml
+++ b/dev/tasks/conda-recipes/azure.win.yml
@@ -3,7 +3,7 @@
 jobs:
 - job: win
   pool:
-    vmImage: vs2017-win2016
+    vmImage: windows-2019
   timeoutInMinutes: 360
   variables:
     CONFIG: {{ config }}


### PR DESCRIPTION
This should fix the `conda-win-vs2017-*` packaging fails.