### PR TITLE
ARROW-16349: [Release][Packaging][RPM] Remove ed25519 keys from KEYS

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow-release/Rakefile
+++ b/dev/tasks/linux-packages/apache-arrow-release/Rakefile
@@ -40,8 +40,28 @@ class ApacheArrowReleasePackageTask < PackageTask
     file @archive_name => [repo_path] do
       rm_rf(@archive_base_name)
       mkdir(@archive_base_name)
+      keys_path = "#{@archive_base_name}/KEYS"
       download("https://downloads.apache.org/arrow/KEYS",
-               "#{@archive_base_name}/KEYS")
+               keys_path)
+      keys = File.read(keys_path)
+      File.open(keys_path, "w") do |keys_file|
+        is_ed25519_key = false
+        keys.each_line do |line|
+          case line.chomp
+          when /\Apub\s+ed25519\s/
+            is_ed25519_key = true
+            next
+          when "-----END PGP PUBLIC KEY BLOCK-----"
+            if is_ed25519_key
+              is_ed25519_key = false
+              next
+            end
+          else
+            next if is_ed25519_key
+          end
+          keys_file.print(line)
+        end
+      end
       cp(repo_path, @archive_base_name)
       sh("tar", "czf", @archive_name, @archive_base_name)
       rm_rf(@archive_base_name)
@@ -53,6 +73,7 @@ class ApacheArrowReleasePackageTask < PackageTask
         rpm_archive_base_name = File.basename(rpm_archive_name, ".tar.gz")
         mv(@archive_base_name, rpm_archive_base_name)
         sh("tar", "czf", rpm_archive_name, rpm_archive_base_name)
+        rm_rf(rpm_archive_base_name)
       end
     end
   end

--- a/dev/tasks/linux-packages/github.linux.amd64.yml
+++ b/dev/tasks/linux-packages/github.linux.amd64.yml
@@ -82,7 +82,7 @@ jobs:
             gpg --full-generate-key --batch
           GPG_KEY_ID=$(gpg --list-keys --with-colon test@example.com | grep fpr | cut -d: -f10)
           echo "GPG_KEY_ID=${GPG_KEY_ID}" >> ${GITHUB_ENV}
-          gpg --export --armor test@example.com > arrow/dev/tasks/linux-packages/KEYS
+          gpg --export --armor test@example.com >> arrow/dev/tasks/linux-packages/KEYS
       # We can install createrepo_c by package with Ubuntu 22.04.
       # This is workaround:
       - name: Install createrepo_c

--- a/dev/tasks/linux-packages/github.linux.amd64.yml
+++ b/dev/tasks/linux-packages/github.linux.amd64.yml
@@ -82,6 +82,15 @@ jobs:
             gpg --full-generate-key --batch
           GPG_KEY_ID=$(gpg --list-keys --with-colon test@example.com | grep fpr | cut -d: -f10)
           echo "GPG_KEY_ID=${GPG_KEY_ID}" >> ${GITHUB_ENV}
+          case "{{ target }}" in
+            almalinux-*|amazon-linux-*|centos-*)
+              repositories_dir=arrow/dev/tasks/linux-packages/apache-arrow-release/yum/repositories
+              rpm2cpio ${repositories_dir}/*/*/*/Packages/apache-arrow-release-*.rpm | \
+                cpio -id
+              mv etc/pki/rpm-gpg/RPM-GPG-KEY-Apache-Arrow \
+                arrow/dev/tasks/linux-packages/KEYS
+              ;;
+          esac
           gpg --export --armor test@example.com >> arrow/dev/tasks/linux-packages/KEYS
       # We can install createrepo_c by package with Ubuntu 22.04.
       # This is workaround:

--- a/dev/tasks/linux-packages/travis.linux.arm64.yml
+++ b/dev/tasks/linux-packages/travis.linux.arm64.yml
@@ -141,7 +141,17 @@ script:
         gpg --full-generate-key --batch
   - |
       GPG_KEY_ID=$(gpg --list-keys --with-colon test@example.com | grep fpr | cut -d: -f10)
-  - gpg --export --armor test@example.com > arrow/dev/tasks/linux-packages/KEYS
+  - |
+      case "{{ target }}" in
+        almalinux-*|amazon-linux-*|centos-*)
+          repositories_dir=arrow/dev/tasks/linux-packages/apache-arrow-release/yum/repositories
+          rpm2cpio ${repositories_dir}/*/*/*/Packages/apache-arrow-release-*.rpm | \
+            cpio -id
+          mv etc/pki/rpm-gpg/RPM-GPG-KEY-Apache-Arrow \
+            arrow/dev/tasks/linux-packages/KEYS
+          ;;
+      esac
+  - gpg --export --armor test@example.com >> arrow/dev/tasks/linux-packages/KEYS
   - pushd arrow/dev/tasks/linux-packages
   - |
       rake --trace {{ task_namespace }}:test \


### PR DESCRIPTION
It seems that ed25519 isn't supported on Red Hat Enterprise Linux 8
or earlier.