### PR TITLE
ARROW-16350: [Dev][Archery] Add missing newline in error message comment

### DIFF
--- a/dev/archery/archery/bot.py
+++ b/dev/archery/archery/bot.py
@@ -160,7 +160,7 @@ class CommentBot:
                 run_id=os.environ["GITHUB_RUN_ID"],
             )
             pull.create_issue_comment(
-                f"```\n{e}\nThe Archery job run can be found at: {url}```")
+                f"```\n{e}\nThe Archery job run can be found at: {url}\n```")
             comment.create_reaction('-1')
         else:
             comment.create_reaction('+1')

--- a/dev/archery/archery/tests/test_bot.py
+++ b/dev/archery/archery/tests/test_bot.py
@@ -223,7 +223,8 @@ def test_respond_with_usage(load_fixture, responses):
         {'body':
          ("```\ntest-usage\n"
           "The Archery job run can be found at: "
-          "https://github.com/apache/arrow/actions/runs/1463784188```")
+          "https://github.com/apache/arrow/actions/runs/1463784188\n"
+          "```")
          }
 
 

--- a/dev/archery/archery/tests/test_bot.py
+++ b/dev/archery/archery/tests/test_bot.py
@@ -143,7 +143,8 @@ def test_unathorized_user_comment(load_fixture, responses):
                "Please ask someone from the community for help with getting "
                "the first commit in.\n"
                "The Archery job run can be found at: "
-               "https://github.com/apache/arrow/actions/runs/1463784188```")
+               "https://github.com/apache/arrow/actions/runs/1463784188\n"
+               "```")
     assert json.loads(post.request.body) == {
         "body": f'{comment}'}
     assert json.loads(reaction.request.body) == {'content': '-1'}


### PR DESCRIPTION
e.g.:
https://github.com/apache/arrow/pull/13003#issuecomment-1110271419

    ```
    Failed to push updated references, potentially because of credential issues: ['refs/heads/actions-1969-github-verify-rc-binaries-jars-linux-almalinux-8-amd64', 'refs/tags/actions-1969-github-verify-rc-binaries-jars-linux-almalinux-8-amd64', 'refs/heads/actions-1969']
    The Archery job run can be found at: https://github.com/apache/arrow/actions/runs/2229490743```

The last ``` should be in a new line.