### PR TITLE
ARROW-16334: [Archery][CI] Use build links on nightly report emails instead of branch link

### DIFF
--- a/dev/archery/archery/crossbow/reports.py
+++ b/dev/archery/archery/crossbow/reports.py
@@ -180,14 +180,21 @@ class EmailReport(Report):
     def branch_url(self, branch):
         return '{}/tree/{}'.format(self.repo_url, branch)
 
+    def task_url(self, task):
+        if task.status().build_links:
+            # show link to the actual build, some CI providers implement
+            # the statuses API others implement the checks API, retrieve any.
+            return task.status().build_links[0]
+        else:
+            # show link to the branch if no status build link was found.
+            return self.branch_url(task.branch)
+
     def listing(self, tasks):
         return '\n'.join(
-            # Use the actual build link if present, otherwise the branch url
             sorted(
                 self.TASK.format(
                     name=task_name,
-                    url=(task.status().build_links or
-                         self.branch_url(task.branch))
+                    url=self.task_url(task)
                 )
                 for task_name, task in tasks.items()
             )

--- a/dev/archery/archery/crossbow/reports.py
+++ b/dev/archery/archery/crossbow/reports.py
@@ -182,9 +182,13 @@ class EmailReport(Report):
 
     def listing(self, tasks):
         return '\n'.join(
+            # Use the actual build link if present, otherwise the branch url
             sorted(
                 self.TASK.format(
-                    name=task_name, url=self.branch_url(task.branch))
+                    name=task_name,
+                    url=(task.status().build_links or
+                         self.branch_url(task.branch))
+                )
                 for task_name, task in tasks.items()
             )
         )


### PR DESCRIPTION
This PR aims to improve the nightly build reporting by changing the link that appears on the report to point to the build instead of the branch. If the task contains a build link it will be shown on the email report. Example of local test:
```bash
$ archery crossbow report --no-fetch nightly-packaging-2022-04-25-0
From: None <None>
To: None
Subject: [NIGHTLY] Arrow Build Report for Job nightly-packaging-2022-04-25-0: 0 failed, 0 pending


Arrow Build Report for Job nightly-packaging-2022-04-25-0

All tasks: https://github.com/ursacomputing/crossbow/branches/all?query=nightly-packaging-2022-04-25-0

Succeeded Tasks:
- conda-osx-clang-py310:
  URL: https://github.com/ursacomputing/crossbow/runs/6156745194
- conda-osx-clang-py38:
  URL: https://github.com/ursacomputing/crossbow/runs/6157874092
- wheel-macos-high-sierra-cp310-amd64:
  URL: https://github.com/ursacomputing/crossbow/runs/6155840346?check_suite_focus=true
```