### PR TITLE
ARROW-16374: [R] [C++] skip another snappy test during sanitizer runs

### DIFF
--- a/r/tests/testthat/test-parquet.R
+++ b/r/tests/testthat/test-parquet.R
@@ -197,6 +197,8 @@ test_that("Maps are preserved when writing/reading from Parquet", {
 })
 
 test_that("read_parquet() and write_parquet() accept connection objects", {
+  skip_if_not_available("snappy")
+
   tf <- tempfile()
   on.exit(unlink(tf))
 


### PR DESCRIPTION
Another example of https://github.com/google/snappy/pull/148 