### PR TITLE
ARROW-16393: [Java] Update option spec to accept value for query, catalog, schema and table

### DIFF
--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/example/FlightSqlClientDemoApp.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/example/FlightSqlClientDemoApp.java
@@ -56,10 +56,10 @@ public class FlightSqlClientDemoApp implements AutoCloseable {
     options.addRequiredOption("port", "port", true, "Port to connect to");
     options.addRequiredOption("command", "command", true, "Method to run");
 
-    options.addOption("query", "query", false, "Query");
-    options.addOption("catalog", "catalog", false, "Catalog");
-    options.addOption("schema", "schema", false, "Schema");
-    options.addOption("table", "table", false, "Table");
+    options.addOption("query", "query", true, "Query");
+    options.addOption("catalog", "catalog", true, "Catalog");
+    options.addOption("schema", "schema", true, "Schema");
+    options.addOption("table", "table", true, "Table");
 
     CommandLineParser parser = new DefaultParser();
     HelpFormatter formatter = new HelpFormatter();


### PR DESCRIPTION
Fixes the issue reported in https://issues.apache.org/jira/browse/ARROW-16393

mvn compile exec:java -Dcheckstyle.skip -Drat.skip=true  -Dexec.mainClass="org.apache.arrow.flight.sql.example.FlightSqlClientDemoApp" -Dexec.args='-host localhost -port 52358 -command Execute -query "select * from APP.INTTABLE"'

ID      KEYNAME VALUE   FOREIGNID
1       one     1       1
2       zero    0       1
3       negative one    -1      1

ID      KEYNAME VALUE   FOREIGNID