### PR TITLE
ARROW-16408: [C++] Add support for DATE type in SQLite FlightSQL example

### DIFF
--- a/cpp/src/arrow/flight/sql/example/sqlite_server.cc
+++ b/cpp/src/arrow/flight/sql/example/sqlite_server.cc
@@ -207,6 +207,7 @@ std::shared_ptr<DataType> GetArrowType(const char* sqlite_type) {
   } else if (boost::iequals(sqlite_type, "BLOB")) {
     return binary();
   } else if (boost::iequals(sqlite_type, "TEXT") ||
+             boost::iequals(sqlite_type, "DATE") ||
              boost::istarts_with(sqlite_type, "char") ||
              boost::istarts_with(sqlite_type, "varchar")) {
     return utf8();
@@ -228,6 +229,7 @@ int32_t GetSqlTypeFromTypeName(const char* sqlite_type) {
   } else if (boost::iequals(sqlite_type, "BLOB")) {
     return SQLITE_BLOB;
   } else if (boost::iequals(sqlite_type, "TEXT") ||
+             boost::iequals(sqlite_type, "DATE") ||
              boost::istarts_with(sqlite_type, "char") ||
              boost::istarts_with(sqlite_type, "varchar")) {
     return SQLITE_TEXT;

--- a/cpp/src/arrow/flight/sql/example/sqlite_server.cc
+++ b/cpp/src/arrow/flight/sql/example/sqlite_server.cc
@@ -206,8 +206,7 @@ std::shared_ptr<DataType> GetArrowType(const char* sqlite_type) {
     return float64();
   } else if (boost::iequals(sqlite_type, "BLOB")) {
     return binary();
-  } else if (boost::iequals(sqlite_type, "TEXT") ||
-             boost::iequals(sqlite_type, "DATE") ||
+  } else if (boost::iequals(sqlite_type, "TEXT") || boost::iequals(sqlite_type, "DATE") ||
              boost::istarts_with(sqlite_type, "char") ||
              boost::istarts_with(sqlite_type, "varchar")) {
     return utf8();
@@ -228,8 +227,7 @@ int32_t GetSqlTypeFromTypeName(const char* sqlite_type) {
     return SQLITE_FLOAT;
   } else if (boost::iequals(sqlite_type, "BLOB")) {
     return SQLITE_BLOB;
-  } else if (boost::iequals(sqlite_type, "TEXT") ||
-             boost::iequals(sqlite_type, "DATE") ||
+  } else if (boost::iequals(sqlite_type, "TEXT") || boost::iequals(sqlite_type, "DATE") ||
              boost::istarts_with(sqlite_type, "char") ||
              boost::istarts_with(sqlite_type, "varchar")) {
     return SQLITE_TEXT;


### PR DESCRIPTION
While it works in the integration tests, some SQLite databases have been created (erroneously) with `DATE` data type (instead of `TEXT`). This minor fix handle this edge case.