### PR TITLE
ARROW-16416: [C++] Support cast-function in Substrait

### DIFF
--- a/cpp/src/arrow/engine/substrait/expression_internal.cc
+++ b/cpp/src/arrow/engine/substrait/expression_internal.cc
@@ -171,8 +171,8 @@ Result<compute::Expression> FromProto(const substrait::Expression& expr,
       } else {
         ARROW_ASSIGN_OR_RAISE(auto output_type_desc,
                               FromProto(scalar_fn.output_type(), ext_set));
-        auto cast_options = compute::CastOptions::Safe(output_type_desc.first);
-        return compute::call(func_name, std::move(arguments), cast_options);
+        auto cast_options = compute::CastOptions::Safe(std::move(output_type_desc.first));
+        return compute::call(func_name, std::move(arguments), std::move(cast_options));
       }
     }
 

--- a/cpp/src/arrow/engine/substrait/expression_internal.cc
+++ b/cpp/src/arrow/engine/substrait/expression_internal.cc
@@ -165,7 +165,15 @@ Result<compute::Expression> FromProto(const substrait::Expression& expr,
         ARROW_ASSIGN_OR_RAISE(arguments[i], FromProto(scalar_fn.args(i), ext_set));
       }
 
-      return compute::call(decoded_function.name.to_string(), std::move(arguments));
+      auto func_name = decoded_function.name.to_string();
+      if (func_name != "cast") {
+        return compute::call(func_name, std::move(arguments));
+      } else {
+        ARROW_ASSIGN_OR_RAISE(auto output_type_desc,
+                              FromProto(scalar_fn.output_type(), ext_set));
+        auto cast_options = compute::CastOptions::Safe(output_type_desc.first);
+        return compute::call(func_name, std::move(arguments), cast_options);
+      }
     }
 
     default:


### PR DESCRIPTION
The cast-function is special in Arrow, because its operation is determined by its output type rather than just by its parameter, and so it requires special handling in Substrait to support it.