### PR TITLE
ARROW-16434: [R][CI] Revert devdocs to setup-r@v1 for now

### DIFF
--- a/dev/tasks/r/github.devdocs.yml
+++ b/dev/tasks/r/github.devdocs.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       {{ macros.github_checkout_arrow()|indent }}
-
+      # TODO (ARROW-16376): Switch to v2 once we use UCRT
       - uses: r-lib/actions/setup-r@v1
         with:
           # temp workaround the fact that R 4.2 requires UCRT which isn't

--- a/dev/tasks/r/github.devdocs.yml
+++ b/dev/tasks/r/github.devdocs.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       {{ macros.github_checkout_arrow()|indent }}
 
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r@v1
         with:
           # temp workaround the fact that R 4.2 requires UCRT which isn't
           # currently part of this build.


### PR DESCRIPTION
I'm not 100% sure of the specific cause, but also don't think it's worth getting to the exact root since we will be replacing with UCRT version soon. It seems switching to `setup-r@v2` broke our setup. My best guess is we unexpectedly were dependent on this line:

https://github.com/r-lib/actions/blob/2acb5b24ed4d2f8a065b600c903d5ee62bbbe893/setup-r/src/installer.ts#L382

But that we removed in v2 in:

https://github.com/r-lib/actions/commit/18ab426b87dc230e2eb2d3efda516f30399f70b2

