### PR TITLE
ARROW-14185: [C++] HashJoinNode should validate HashJoinNodeOptions

### DIFF
--- a/cpp/src/arrow/compute/exec/hash_join_node.cc
+++ b/cpp/src/arrow/compute/exec/hash_join_node.cc
@@ -456,12 +456,12 @@ Status HashJoinSchema::CollectFilterColumns(std::vector<FieldRef>& left_filter,
 
 Status ValidateHashJoinNodeOptions(const HashJoinNodeOptions& join_options) {
   if (join_options.key_cmp.size() < 1 || join_options.left_keys.size() < 1 ||
-      join_options.left_keys.size() < 1) {
+      join_options.right_keys.size() < 1) {
     return Status::Invalid("key_cmp and keys cannot be empty");
   }
 
-  if ((join_options.key_cmp.size() != join_options.left_keys.size()) < 1 ||
-      (join_options.key_cmp.size() != join_options.left_keys.size()) < 1) {
+  if ((join_options.key_cmp.size() != join_options.left_keys.size()) ||
+      (join_options.key_cmp.size() != join_options.right_keys.size()) {
     return Status::Invalid("key_cmp and keys must have the same size");
   }
 

--- a/cpp/src/arrow/compute/exec/hash_join_node.cc
+++ b/cpp/src/arrow/compute/exec/hash_join_node.cc
@@ -455,13 +455,13 @@ Status HashJoinSchema::CollectFilterColumns(std::vector<FieldRef>& left_filter,
 }
 
 Status ValidateHashJoinNodeOptions(const HashJoinNodeOptions& join_options) {
-  if (join_options.key_cmp.size() < 1 || join_options.left_keys.size() < 1 ||
-      join_options.right_keys.size() < 1) {
+  if (join_options.key_cmp.empty() || join_options.left_keys.empty() ||
+      join_options.right_keys.empty()) {
     return Status::Invalid("key_cmp and keys cannot be empty");
   }
 
   if ((join_options.key_cmp.size() != join_options.left_keys.size()) ||
-      (join_options.key_cmp.size() != join_options.right_keys.size()) {
+      (join_options.key_cmp.size() != join_options.right_keys.size())) {
     return Status::Invalid("key_cmp and keys must have the same size");
   }
 

--- a/cpp/src/arrow/compute/exec/hash_join_node.cc
+++ b/cpp/src/arrow/compute/exec/hash_join_node.cc
@@ -454,6 +454,20 @@ Status HashJoinSchema::CollectFilterColumns(std::vector<FieldRef>& left_filter,
   return Status::OK();
 }
 
+Status ValidateHashJoinNodeOptions(const HashJoinNodeOptions& join_options) {
+  if (join_options.key_cmp.size() < 1 || join_options.left_keys.size() < 1 ||
+      join_options.left_keys.size() < 1) {
+    return Status::Invalid("key_cmp and keys cannot be empty");
+  }
+
+  if ((join_options.key_cmp.size() != join_options.left_keys.size()) < 1 ||
+      (join_options.key_cmp.size() != join_options.left_keys.size()) < 1) {
+    return Status::Invalid("key_cmp and keys must have the same size");
+  }
+
+  return Status::OK();
+}
+
 class HashJoinNode : public ExecNode {
  public:
   HashJoinNode(ExecPlan* plan, NodeVector inputs, const HashJoinNodeOptions& join_options,
@@ -481,6 +495,7 @@ class HashJoinNode : public ExecNode {
         ::arrow::internal::make_unique<HashJoinSchema>();
 
     const auto& join_options = checked_cast<const HashJoinNodeOptions&>(options);
+    RETURN_NOT_OK(ValidateHashJoinNodeOptions(join_options));
 
     const auto& left_schema = *(inputs[0]->output_schema());
     const auto& right_schema = *(inputs[1]->output_schema());

--- a/cpp/src/arrow/compute/exec/hash_join_node_test.cc
+++ b/cpp/src/arrow/compute/exec/hash_join_node_test.cc
@@ -977,7 +977,7 @@ TEST(HashJoin, Suffix) {
                        MakeExecNode("source", plan.get(), {},
                                     SourceNodeOptions{input_right.schema,
                                                       input_right.gen(/*parallel=*/false,
-                                                                      /*slow=*/false)}))
+                                                                      /*slow=*/false)}));
 
   HashJoinNodeOptions join_opts{JoinType::INNER,
                                 /*left_keys=*/{"lkey"},
@@ -1780,6 +1780,71 @@ TEST(HashJoin, UnsupportedTypes) {
         "source", SourceNodeOptions{r_batches.schema, r_batches.gen(parallel, slow)}});
 
     ASSERT_RAISES(Invalid, join.AddToPlan(plan.get()));
+  }
+}
+
+TEST(HashJoin, CheckHashJoinNodeOptionsValidation) {
+  auto exec_ctx =
+      arrow::internal::make_unique<ExecContext>(default_memory_pool(), nullptr);
+  ASSERT_OK_AND_ASSIGN(auto plan, ExecPlan::Make(exec_ctx.get()));
+
+  BatchesWithSchema input_left;
+  input_left.batches = {ExecBatchFromJSON({int32(), int32(), int32()}, R"([
+                   [1, 4, 7],
+                   [2, 5, 8],
+                   [3, 6, 9]
+                 ])")};
+  input_left.schema = schema(
+      {field("lkey", int32()), field("shared", int32()), field("ldistinct", int32())});
+
+  BatchesWithSchema input_right;
+  input_right.batches = {ExecBatchFromJSON({int32(), int32(), int32()}, R"([
+                   [1, 10, 13],
+                   [2, 11, 14],
+                   [3, 12, 15]
+                 ])")};
+  input_right.schema = schema(
+      {field("rkey", int32()), field("shared", int32()), field("rdistinct", int32())});
+
+  ExecNode* l_source;
+  ExecNode* r_source;
+  ASSERT_OK_AND_ASSIGN(
+      l_source,
+      MakeExecNode("source", plan.get(), {},
+                   SourceNodeOptions{input_left.schema, input_left.gen(/*parallel=*/false,
+                                                                       /*slow=*/false)}));
+
+  ASSERT_OK_AND_ASSIGN(r_source,
+                       MakeExecNode("source", plan.get(), {},
+                                    SourceNodeOptions{input_right.schema,
+                                                      input_right.gen(/*parallel=*/false,
+                                                                      /*slow=*/false)}))
+
+  std::vector<std::vector<FieldRef>> l_keys = {
+      {},
+      {FieldRef("lkey")},
+      {FieldRef("lkey"), FieldRef("shared"), FieldRef("ldistinct")}};
+  std::vector<std::vector<FieldRef>> r_keys = {
+      {},
+      {FieldRef("rkey")},
+      {FieldRef("rkey"), FieldRef("shared"), FieldRef("rdistinct")}};
+  std::vector<std::vector<JoinKeyCmp>> key_cmps = {
+      {}, {JoinKeyCmp::EQ}, {JoinKeyCmp::EQ, JoinKeyCmp::EQ, JoinKeyCmp::EQ}};
+
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      for (int k = 0; k < 3; ++k) {
+        if (i == j && j == k && i != 0) {
+          continue;
+        }
+
+        HashJoinNodeOptions options{JoinType::INNER, l_keys[j], r_keys[k], {}, {},
+                                    key_cmps[i]};
+        EXPECT_RAISES_WITH_MESSAGE_THAT(
+            Invalid, ::testing::HasSubstr("key_cmp and keys"),
+            MakeExecNode("hashjoin", plan.get(), {l_source, r_source}, options));
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Adding validation for HashJoinNodeOptions