### PR TITLE
MINOR: [Java][Flight] Add context of descriptor on integration tests when not found

### DIFF
--- a/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/IntegrationProducer.java
+++ b/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/IntegrationProducer.java
@@ -97,7 +97,7 @@ public class IntegrationProducer extends NoOpFlightProducer implements AutoClose
   public FlightInfo getFlightInfo(CallContext context, FlightDescriptor descriptor) {
     Dataset h = datasets.get(descriptor);
     if (h == null) {
-      throw CallStatus.NOT_FOUND.withDescription("Unknown descriptor.").toRuntimeException();
+      throw CallStatus.NOT_FOUND.withDescription("Unknown descriptor: " + descriptor).toRuntimeException();
     }
     return h.getFlightInfo(location);
   }


### PR DESCRIPTION
This PR adds minor logging info about the descriptor looked up when it can't be found.

For example on this ticket failure [ARROW-16441](https://issues.apache.org/jira/browse/ARROW-16441) we should be able to get more info around the descriptor:

```
panic: rpc error: code = NotFound desc = Unknown descriptor.
```