### PR TITLE
ARROW-16420: [Python] pq.write_to_dataset always ignores partitioning

### DIFF
--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -3145,8 +3145,9 @@ def write_to_dataset(table, root_path, partition_cols=None,
 
         if basename_template is None:
             basename_template = guid() + '-{i}.parquet'
-            if existing_data_behavior is None:
-                existing_data_behavior = 'overwrite_or_ignore'
+
+        if existing_data_behavior is None:
+            existing_data_behavior = 'overwrite_or_ignore'
 
         ds.write_dataset(
             table, root_path, filesystem=filesystem,

--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -3125,7 +3125,6 @@ def write_to_dataset(table, root_path, partition_cols=None,
             "implementation."
         )
         metadata_collector = kwargs.pop('metadata_collector', None)
-        file_visitor = None
         if metadata_collector is not None:
             def file_visitor(written_file):
                 metadata_collector.append(written_file.metadata)
@@ -3140,7 +3139,6 @@ def write_to_dataset(table, root_path, partition_cols=None,
         if filesystem is not None:
             filesystem = _ensure_filesystem(filesystem)
 
-        partitioning = None
         if partition_cols:
             part_schema = table.select(partition_cols).schema
             partitioning = ds.partitioning(part_schema, flavor="hive")

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -1782,3 +1782,21 @@ def test_parquet_write_to_dataset_unsupported_keywards_in_legacy(tempdir):
     with pytest.raises(ValueError, match="existing_data_behavior"):
         pq.write_to_dataset(table, path, use_legacy_dataset=True,
                             existing_data_behavior='error')
+
+
+@pytest.mark.dataset
+def test_parquet_write_to_dataset_exposed_keywords(tempdir):
+    table = pa.table({'a': [1, 2, 3]})
+    path = tempdir / 'data.parquet'
+
+    # Check if the partitioning keyward is not ignored
+    pq.write_to_dataset(table, path, partitioning=["a"],
+                        use_legacy_dataset=False)
+    dataset = pq.ParquetDataset(path, use_legacy_dataset=False)
+    assert len(dataset.files) == 3
+
+    path2 = tempdir / 'data2.parquet'
+    # This should be single parquet file if partitioning keyword not set
+    pq.write_to_dataset(table, path2, use_legacy_dataset=False)
+    dataset2 = pq.ParquetDataset(path2, use_legacy_dataset=False)
+    assert len(dataset2.files) == 1


### PR DESCRIPTION
Remove the lines that unconditionally set `partitioning` and `file_visitor` in `pq.write_to_dataset` to None. This is a leftover from https://github.com/apache/arrow/pull/12811 where additional `pq.write_dataset` keywords were exposed.