### PR TITLE
ARROW-16456: [Go] Fix RecordBuilder UnmarshalJSON when extra fields are present

### DIFF
--- a/go/arrow/array/json_reader_test.go
+++ b/go/arrow/array/json_reader_test.go
@@ -115,3 +115,27 @@ func TestJSONReaderChunked(t *testing.T) {
 	assert.Equal(t, 4, n)
 	assert.NoError(t, rdr.Err())
 }
+
+func TestUnmarshalJSON(t *testing.T) {
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "region", Type: arrow.BinaryTypes.String, Nullable: true},
+		{Name: "model", Type: arrow.BinaryTypes.String},
+		{Name: "sales", Type: arrow.PrimitiveTypes.Float64, Nullable: true},
+	}, nil)
+
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	recordBuilder := array.NewRecordBuilder(mem, schema)
+	defer recordBuilder.Release()
+
+	jsondata := `{"region": "NY", "model": "3", "sales": 742.0, "extra": 1234}`
+
+	err := recordBuilder.UnmarshalJSON([]byte(jsondata))
+	assert.NoError(t, err)
+
+	record := recordBuilder.NewRecord()
+	defer record.Release()
+
+	assert.NotNil(t, record)
+}

--- a/go/arrow/array/record.go
+++ b/go/arrow/array/record.go
@@ -353,6 +353,10 @@ func (b *RecordBuilder) UnmarshalJSON(data []byte) error {
 
 		indices := b.schema.FieldIndices(key)
 		if len(indices) == 0 {
+			_, err = dec.Token()
+			if err != nil {
+				return err
+			}
 			continue
 		}
 


### PR DESCRIPTION
If RecordBuilder.UnmarshalJSON encountered an unknown field in the JSON document; it wouldn't consume the next JSON token representing the value.

Fix this by manually calling `dec.Token()` and allowing the next call to `dec.Token()` to return the following key.

Note that this only handles the case where the ignored value is a simple type, and not a nested array or object. I'm not sure what the correct fix for that would be.