### PR TITLE
ARROW-16455: [CI][Packaging] Add linux-ppc64le to the list of platforms to clean on conda

### DIFF
--- a/dev/tasks/conda-recipes/clean.py
+++ b/dev/tasks/conda-recipes/clean.py
@@ -14,6 +14,7 @@ DELETE_BEFORE = pd.Timestamp.now() - pd.Timedelta(days=30)
 PLATFORMS = [
     "linux-64",
     "linux-aarch64",
+    "linux-ppc64le",
     "osx-64",
     "osx-arm64",
     "win-64",


### PR DESCRIPTION
This PR aims to fix the issue:
```
"[ERROR] ('Storage requirements exceeded (3221225472 bytes). Payment is required to add a file. Please go to https://anaconda.org/binstar.settings/billing to update your plan', 402)" 
```