### PR TITLE
ARROW-15804: [R] Improve as.Date() error message when supplying several tryFormats

### DIFF
--- a/r/R/dplyr-datetime-helpers.R
+++ b/r/R/dplyr-datetime-helpers.R
@@ -108,7 +108,7 @@ binding_as_date <- function(x,
     abort(
       paste(
         "`as.Date()` with multiple `tryFormats` is not supported in Arrow,",
-        "consider using the specialised parsing functions in lubridate, such as, `ymd()`"
+        "consider using the lubridate specialised parsing functions such as, `ymd()`, `ymd()`, etc."
       )
     )
   }

--- a/r/R/dplyr-datetime-helpers.R
+++ b/r/R/dplyr-datetime-helpers.R
@@ -122,6 +122,14 @@ binding_as_date_character <- function(x,
                                       format = NULL,
                                       tryFormats = c("%Y-%m-%d", "%Y/%m/%d"),
                                       ...) {
+browser()
+  force(x)
+  for (i in 1:x$length()) {
+    if (x$IsValid(i -1)) {
+      xx <- x$Slice(i -1 , 1)
+      break()
+    }
+  }
 
   # `tryFormats` is an argument only for `as.Date()`, but `as_date()` behaves in
   # a similar fashion, with its `.parse_iso_dt()`

--- a/r/R/dplyr-datetime-helpers.R
+++ b/r/R/dplyr-datetime-helpers.R
@@ -127,8 +127,7 @@ binding_as_date_character <- function(x,
 }
 
 binding_as_date_numeric <- function(x,
-                                    origin = "1970-01-01",
-                                    ...) {
+                                    origin = "1970-01-01") {
 
   # Arrow does not support direct casting from double to date32(), but for
   # integer-like values we can go via int32()

--- a/r/R/dplyr-datetime-helpers.R
+++ b/r/R/dplyr-datetime-helpers.R
@@ -123,14 +123,6 @@ binding_as_date_character <- function(x,
                                       tryFormats = c("%Y-%m-%d", "%Y/%m/%d"),
                                       ...) {
 
-  force(x)
-  for (i in 1:x$length()) {
-    if (x$IsValid(i -1)) {
-      xx <- x$Slice(i -1 , 1)
-      break()
-    }
-  }
-
   # `tryFormats` is an argument only for `as.Date()`, but `as_date()` behaves in
   # a similar fashion, with its `.parse_iso_dt()`
   if (is.null(format)) {

--- a/r/R/dplyr-datetime-helpers.R
+++ b/r/R/dplyr-datetime-helpers.R
@@ -108,7 +108,7 @@ binding_as_date <- function(x,
     abort(
       paste(
         "`as.Date()` with multiple `tryFormats` is not supported in Arrow,",
-        "consider using the specialised parsing functions"
+        "consider using the specialised parsing functions in lubridate, such as, `ymd()`"
       )
     )
   }

--- a/r/R/dplyr-datetime-helpers.R
+++ b/r/R/dplyr-datetime-helpers.R
@@ -131,7 +131,10 @@ binding_as_date_character <- function(x,
   # format <- format %||% tryFormats[[1]]
   # # unit = 0L is the identifier for seconds in valid_time32_units
   # build_expr("strptime", x, options = list(format = format, unit = 0L))
-  if (missing(format)) {
+
+  # we need to split the logic between as_date() and as.Date() since `tryFormats`
+  # is an argument only for `as.Date()`
+  if (is.null(format)) {
     parse_attempts <- list()
     for (i in seq_along(tryFormats)) {
       parse_attempts[[i]] <-

--- a/r/R/dplyr-datetime-helpers.R
+++ b/r/R/dplyr-datetime-helpers.R
@@ -105,7 +105,12 @@ binding_as_date <- function(x,
                             tryFormats = "%Y-%m-%d",
                             origin = "1970-01-01") {
   if (is.null(format) && length(tryFormats) > 1) {
-    abort("`as.Date()` with multiple `tryFormats` is not supported in Arrow")
+    abort(
+      paste(
+        "`as.Date()` with multiple `tryFormats` is not supported in Arrow,",
+        "consider using the specialised parsing functions"
+      )
+    )
   }
 
   if (call_binding("is.Date", x)) {

--- a/r/R/dplyr-datetime-helpers.R
+++ b/r/R/dplyr-datetime-helpers.R
@@ -101,24 +101,18 @@ duration_from_chunks <- function(chunks) {
 
 
 binding_as_date <- function(x,
-                            format = NULL,
-                            tryFormats = "%Y-%m-%d",
-                            origin = "1970-01-01") {
-
-  # if (is.null(format) && length(tryFormats) > 1) {
-  #   abort("`as.Date()` with multiple `tryFormats` is not supported in Arrow")
-  # }
+                            ...) {
 
   if (call_binding("is.Date", x)) {
     return(x)
 
     # cast from character
   } else if (call_binding("is.character", x)) {
-    x <- binding_as_date_character(x, format, tryFormats)
+    x <- binding_as_date_character(x, ...)
 
     # cast from numeric
   } else if (call_binding("is.numeric", x)) {
-    x <- binding_as_date_numeric(x, origin)
+    x <- binding_as_date_numeric(x, ...)
   }
 
   build_expr("cast", x, options = cast_options(to_type = date32()))
@@ -126,7 +120,8 @@ binding_as_date <- function(x,
 
 binding_as_date_character <- function(x,
                                       format = NULL,
-                                      tryFormats = c("%Y-%m-%d", "%Y/%m/%d")) {
+                                      tryFormats = c("%Y-%m-%d", "%Y/%m/%d"),
+                                      ...) {
 
   # `tryFormats` is an argument only for `as.Date()`, but `as_date()` behaves in
   # a similar fashion, with its `.parse_iso_dt()`
@@ -138,7 +133,9 @@ binding_as_date_character <- function(x,
   parsed_date
 }
 
-binding_as_date_numeric <- function(x, origin = "1970-01-01") {
+binding_as_date_numeric <- function(x,
+                                    origin = "1970-01-01",
+                                    ...) {
 
   # Arrow does not support direct casting from double to date32(), but for
   # integer-like values we can go via int32()

--- a/r/R/dplyr-datetime-helpers.R
+++ b/r/R/dplyr-datetime-helpers.R
@@ -120,36 +120,10 @@ binding_as_date <- function(x,
 
 binding_as_date_character <- function(x,
                                       format = NULL,
-                                      tryFormats = c("%Y-%m-%d", "%Y/%m/%d"),
-                                      coalesce = TRUE,
-                                      ...) {
-
-  if (is.null(format) && coalesce) {
-    parsed_date <- call_binding("parse_date_time", x, orders = tryFormats)
-  }
-
-  if (is.null(format) && !coalesce) {
-      attempts <- map(
-        tryFormats,
-        ~ build_expr(
-          "strptime",
-          x,
-          options = list(format = .x, unit = 0L, error_is_null = TRUE)
-        )
-      )
-      n <- length(tryFormats)
-      results <- vector("list", n)
-      mask <- caller_env(n = 3)
-      for (i in seq_len(n)) {
-        results[[i]] <- arrow_eval(attempts[[i]], mask)
-      }
-      parsed_date <- results[[1]]
-    }
-
-  if (!is.null(format)) {
-    parsed_date <- build_expr("strptime", x, options = list(format = format, unit = 0L))
-  }
-  parsed_date
+                                      tryFormats = "%Y-%m-%d") {
+  format <- format %||% tryFormats[[1]]
+  # unit = 0L is the identifier for seconds in valid_time32_units
+  build_expr("strptime", x, options = list(format = format, unit = 0L))
 }
 
 binding_as_date_numeric <- function(x,

--- a/r/R/dplyr-datetime-helpers.R
+++ b/r/R/dplyr-datetime-helpers.R
@@ -101,7 +101,9 @@ duration_from_chunks <- function(chunks) {
 
 
 binding_as_date <- function(x,
-                            ...) {
+                            format = NULL,
+                            tryFormats = "%Y-%m-%d",
+                            origin = "1970-01-01") {
   if (is.null(format) && length(tryFormats) > 1) {
     abort("`as.Date()` with multiple `tryFormats` is not supported in Arrow")
   }
@@ -111,11 +113,11 @@ binding_as_date <- function(x,
 
     # cast from character
   } else if (call_binding("is.character", x)) {
-    x <- binding_as_date_character(x, ...)
+    x <- binding_as_date_character(x, format, tryFormats)
 
     # cast from numeric
   } else if (call_binding("is.numeric", x)) {
-    x <- binding_as_date_numeric(x, ...)
+    x <- binding_as_date_numeric(x, origin)
   }
 
   build_expr("cast", x, options = cast_options(to_type = date32()))

--- a/r/R/dplyr-datetime-helpers.R
+++ b/r/R/dplyr-datetime-helpers.R
@@ -128,26 +128,14 @@ binding_as_date_character <- function(x,
                                       format = NULL,
                                       tryFormats = c("%Y-%m-%d", "%Y/%m/%d")) {
 
-  # format <- format %||% tryFormats[[1]]
-  # # unit = 0L is the identifier for seconds in valid_time32_units
-  # build_expr("strptime", x, options = list(format = format, unit = 0L))
-
-  # we need to split the logic between as_date() and as.Date() since `tryFormats`
-  # is an argument only for `as.Date()`
+  # `tryFormats` is an argument only for `as.Date()`, but `as_date()` behaves in
+  # a similar fashion, with its `.parse_iso_dt()`
   if (is.null(format)) {
-    parse_attempt_expressions <- list()
-    for (i in seq_along(tryFormats)) {
-      parse_attempt_expressions[[i]] <-
-        build_expr(
-          "strptime", x,
-          options = list(format = tryFormats[[i]], unit = 0L, error_is_null = TRUE)
-        )
-    }
-    coalesce_output <- build_expr("coalesce", args = parse_attempt_expressions)
-    return(coalesce_output)
+    parsed_date <- call_binding("parse_date_time", x, orders = tryFormats)
   } else {
-    build_expr("strptime", x, options = list(format = format, unit = 0L))
+    parsed_date <- build_expr("strptime", x, options = list(format = format, unit = 0L))
   }
+  parsed_date
 }
 
 binding_as_date_numeric <- function(x, origin = "1970-01-01") {

--- a/r/R/dplyr-datetime-helpers.R
+++ b/r/R/dplyr-datetime-helpers.R
@@ -102,6 +102,9 @@ duration_from_chunks <- function(chunks) {
 
 binding_as_date <- function(x,
                             ...) {
+  if (is.null(format) && length(tryFormats) > 1) {
+    abort("`as.Date()` with multiple `tryFormats` is not supported in Arrow")
+  }
 
   if (call_binding("is.Date", x)) {
     return(x)
@@ -126,8 +129,7 @@ binding_as_date_character <- function(x,
   build_expr("strptime", x, options = list(format = format, unit = 0L))
 }
 
-binding_as_date_numeric <- function(x,
-                                    origin = "1970-01-01") {
+binding_as_date_numeric <- function(x, origin = "1970-01-01") {
 
   # Arrow does not support direct casting from double to date32(), but for
   # integer-like values we can go via int32()

--- a/r/R/dplyr-datetime-helpers.R
+++ b/r/R/dplyr-datetime-helpers.R
@@ -135,18 +135,16 @@ binding_as_date_character <- function(x,
   # we need to split the logic between as_date() and as.Date() since `tryFormats`
   # is an argument only for `as.Date()`
   if (is.null(format)) {
-    parse_attempts <- list()
+    parse_attempt_expressions <- list()
     for (i in seq_along(tryFormats)) {
-      parse_attempts[[i]] <-
+      parse_attempt_expressions[[i]] <-
         build_expr(
           "strptime", x,
           options = list(format = tryFormats[[i]], unit = 0L, error_is_null = TRUE)
         )
     }
-    # coalesce_output <- build_expr("coalesce", parse_attempts[[1]], parse_attempts[[2]])
-    coalesce_output <- build_expr("coalesce", args = parse_attempts)
+    coalesce_output <- build_expr("coalesce", args = parse_attempt_expressions)
     return(coalesce_output)
-    # purrr::lift_dl(build_expr("coalesce"))(parse_attempts)
   } else {
     build_expr("strptime", x, options = list(format = format, unit = 0L))
   }

--- a/r/R/dplyr-datetime-helpers.R
+++ b/r/R/dplyr-datetime-helpers.R
@@ -104,14 +104,6 @@ binding_as_date <- function(x,
                             format = NULL,
                             tryFormats = "%Y-%m-%d",
                             origin = "1970-01-01") {
-  if (is.null(format) && length(tryFormats) > 1) {
-    abort(
-      paste(
-        "`as.Date()` with multiple `tryFormats` is not supported in Arrow,",
-        "consider using the lubridate specialised parsing functions such as, `ymd()`, `ymd()`, etc."
-      )
-    )
-  }
 
   if (call_binding("is.Date", x)) {
     return(x)

--- a/r/R/dplyr-datetime-helpers.R
+++ b/r/R/dplyr-datetime-helpers.R
@@ -122,7 +122,7 @@ binding_as_date_character <- function(x,
                                       format = NULL,
                                       tryFormats = c("%Y-%m-%d", "%Y/%m/%d"),
                                       ...) {
-browser()
+
   force(x)
   for (i in 1:x$length()) {
     if (x$IsValid(i -1)) {

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -297,6 +297,16 @@ register_bindings_datetime_conversion <- function() {
                                        tryFormats = "%Y-%m-%d",
                                        origin = "1970-01-01",
                                        tz = "UTC") {
+
+    if (is.null(format) && length(tryFormats) > 1) {
+      abort(
+        paste(
+          "`as.Date()` with multiple `tryFormats` is not supported in Arrow,",
+          "consider using the lubridate specialised parsing functions such as, `ymd()`, `ymd()`, etc."
+        )
+      )
+    }
+
     # base::as.Date() and lubridate::as_date() differ in the way they use the
     # `tz` argument. Both cast to the desired timezone, if present. The
     # difference appears when the `tz` argument is not set: `as.Date()` uses the

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -311,7 +311,8 @@ register_bindings_datetime_conversion <- function() {
       x = x,
       format = format,
       tryFormats = tryFormats,
-      origin = origin
+      origin = origin,
+      coalesce = FALSE
     )
   })
 
@@ -331,7 +332,8 @@ register_bindings_datetime_conversion <- function() {
     binding_as_date(
       x = x,
       format = format,
-      origin = origin
+      origin = origin,
+      coalesce = TRUE
     )
   })
 

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -311,8 +311,7 @@ register_bindings_datetime_conversion <- function() {
       x = x,
       format = format,
       tryFormats = tryFormats,
-      origin = origin,
-      coalesce = FALSE
+      origin = origin
     )
   })
 
@@ -332,8 +331,7 @@ register_bindings_datetime_conversion <- function() {
     binding_as_date(
       x = x,
       format = format,
-      origin = origin,
-      coalesce = TRUE
+      origin = origin
     )
   })
 

--- a/r/tests/testthat/test-dataset-dplyr.R
+++ b/r/tests/testthat/test-dataset-dplyr.R
@@ -108,20 +108,18 @@ test_that("filter() on date32 columns", {
   df <- data.frame(date = as.Date(c("2020-02-02", "2020-02-03")))
   write_parquet(df, file.path(tmp, "file.parquet"))
 
-  # Also with timestamp scalar
   expect_equal(
     open_dataset(tmp) %>%
-      filter(date > lubridate::ymd_hms("2020-02-02 00:00:00")) %>%
+      filter(date > as.Date("2020-02-02")) %>%
       collect() %>%
       nrow(),
     1L
   )
 
-  # string processing requires RE2 library (not available on Windows with R 3.6)
-  skip_if_not_available("re2")
+  # Also with timestamp scalar
   expect_equal(
     open_dataset(tmp) %>%
-      filter(date > as.Date("2020-02-02")) %>%
+      filter(date > lubridate::ymd_hms("2020-02-02 00:00:00")) %>%
       collect() %>%
       nrow(),
     1L

--- a/r/tests/testthat/test-dataset-dplyr.R
+++ b/r/tests/testthat/test-dataset-dplyr.R
@@ -80,21 +80,21 @@ test_that("filter() on timestamp columns", {
     df1[5:10, c("ts")],
   )
 
-  # Now with bare string date
-  skip("Implement more aggressive implicit casting for scalars (ARROW-11402)")
+  # Now with Date
   expect_equal(
     ds %>%
-      filter(ts >= "2015-05-04") %>%
+      filter(ts >= as.Date("2015-05-04")) %>%
       filter(part == 1) %>%
       select(ts) %>%
       collect(),
     df1[5:10, c("ts")],
   )
 
-  # Now with Date
+  # Now with bare string date
+  skip("Implement more aggressive implicit casting for scalars (ARROW-11402)")
   expect_equal(
     ds %>%
-      filter(ts >= as.Date("2015-05-04")) %>%
+      filter(ts >= "2015-05-04") %>%
       filter(part == 1) %>%
       select(ts) %>%
       collect(),

--- a/r/tests/testthat/test-dataset-dplyr.R
+++ b/r/tests/testthat/test-dataset-dplyr.R
@@ -91,8 +91,6 @@ test_that("filter() on timestamp columns", {
     df1[5:10, c("ts")],
   )
 
-  # string processing requires RE2 library (not available on Windows with R 3.6)
-  skip_if_not_available("re2")
   # Now with Date
   expect_equal(
     ds %>%
@@ -102,7 +100,6 @@ test_that("filter() on timestamp columns", {
       collect(),
     df1[5:10, c("ts")],
   )
-
 })
 
 test_that("filter() on date32 columns", {

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1589,10 +1589,10 @@ test_that("`as.Date()` and `as_date()`", {
     expect_equal(
       test_df %>%
         arrow_table() %>%
-        mutate(date_char_ymd_hms = as_date(character_ymd_hms_var), .keep = "used") %>%
+        mutate(date_char_ymd_hms = as_date(character_ymd_hms_var)) %>%
         collect(),
       test_df %>%
-        mutate(date_char_ymd_hms = as_date(character_ymd_hms_var), .keep = "used") %>%
+        mutate(date_char_ymd_hms = as_date(character_ymd_hms_var)) %>%
         collect()
     )
   )
@@ -1602,10 +1602,10 @@ test_that("`as.Date()` and `as_date()`", {
     expect_equal(
       test_df %>%
         arrow_table() %>%
-        mutate(date_char_ymd_hms = as.Date(character_ymd_hms_var), .keep = "used") %>%
+        mutate(date_char_ymd_hms = as.Date(character_ymd_hms_var)) %>%
         collect(),
       test_df %>%
-        mutate(date_char_ymd_hms = as.Date(character_ymd_hms_var), .keep = "used") %>%
+        mutate(date_char_ymd_hms = as.Date(character_ymd_hms_var)) %>%
         collect()
     )
   )

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1725,18 +1725,6 @@ test_that("parse_date_time() works with year, month, and date components", {
     )
   )
 
-  # parse_date_time() works with R objects
-  compare_dplyr_binding(
-    .input %>%
-      mutate(
-        parsed_date_ymd = parse_date_time("2021/09///2", orders = "ymd")
-      ) %>%
-      collect(),
-    tibble::tibble(
-      a = 1
-    )
-  )
-
   # locale (affecting "%b% and "%B" formats) does not work properly on Windows
   # TODO revisit once https://issues.apache.org/jira/browse/ARROW-16443 is done
   skip_on_os("windows")
@@ -1783,6 +1771,18 @@ test_that("parse_date_time() works with a mix of formats and orders", {
       ) %>%
       collect(),
     test_df
+  )
+
+  # parse_date_time() works with R objects
+  compare_dplyr_binding(
+    .input %>%
+      mutate(
+        parsed_date_ymd = parse_date_time("2021/09///2", orders = "ymd")
+      ) %>%
+      collect(),
+    tibble::tibble(
+      a = 1
+    )
   )
 })
 

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1575,7 +1575,7 @@ test_that("`as.Date()` and `as_date()`", {
   expect_error(
     test_df %>%
       arrow_table() %>%
-      mutate(date_char_ymd = as.Date(character_ymd_hms_var)) %>%
+      mutate(date_char_ymd_hms = as.Date(character_ymd_hms_var), .keep = "used") %>%
       collect(),
     regexp = "Failed to parse string: '2022-02-25 00:00:01' as a scalar of type timestamp[s]",
     fixed = TRUE

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1513,6 +1513,7 @@ test_that("`as.Date()` and `as_date()`", {
     dt_utc = ymd_hms("2010-08-03 00:50:50"),
     date_var = as.Date("2022-02-25"),
     difference_date = ymd_hms("2010-08-03 00:50:50", tz = "Pacific/Marquesas"),
+    try_formats_string = c(NA, "2022-01-01", "2022/01/01"),
     character_ymd_hms_var = "2022-02-25 00:00:01",
     character_ydm_hms_var = "2022/25/02 00:00:01",
     character_ymd_var = "2022-02-25",
@@ -1596,6 +1597,17 @@ test_that("`as.Date()` and `as_date()`", {
       collect()
   )
 
+  test_df %>%
+    arrow_table() %>%
+    mutate(
+      date_try_formats_base = as.Date(
+        try_formats_string,
+        tryFormats = c("%Y-%m-%d", "%Y/%m/%d")
+      ),
+      .keep = "used"
+    ) %>%
+    collect()
+
   # difference between as.Date() and as_date():
   # `as.Date()` ignores the `tzone` attribute and uses the value of the `tz` arg
   # to `as.Date()`
@@ -1605,7 +1617,12 @@ test_that("`as.Date()` and `as_date()`", {
     .input %>%
       transmute(
         date_diff_lubridate = as_date(difference_date),
-        date_diff_base = as.Date(difference_date)
+        date_diff_base = as.Date(difference_date),
+        date_try_formats_base = as.Date(
+          try_formats_string,
+          tryFormats = c("%Y-%m-%d", "%Y/%m/%d")
+        ),
+        date_try_formats_lubridate = as_date(try_formats_string)
       ) %>%
       collect(),
     test_df

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1721,6 +1721,18 @@ test_that("parse_date_time() works with year, month, and date components", {
     )
   )
 
+  # parse_date_time() works with R objects
+  compare_dplyr_binding(
+    .input %>%
+      mutate(
+        parsed_date_ymd = parse_date_time("2021/09///2", orders = "ymd")
+      ) %>%
+      collect(),
+    tibble::tibble(
+      a = 1
+    )
+  )
+
   # locale (affecting "%b% and "%B" formats) does not work properly on Windows
   # TODO revisit once https://issues.apache.org/jira/browse/ARROW-16443 is done
   skip_on_os("windows")

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1624,22 +1624,6 @@ test_that("`as.Date()` and `as_date()`", {
       collect(),
     test_df
   )
-
-  # some string processing (which depends on the RE2 library) is involved when
-  # parsing as date with multiple formats. RE2 is not available in R 3.6 on Windows
-  skip_if_not_available("re2")
-  # as.Date() supports multiple tryFormats
-  compare_dplyr_binding(
-    .input %>%
-      mutate(date_char_ymd = as.Date(
-        character_ymd_var,
-        tryFormats = c("%Y-%m-%d", "%Y/%m/%d")
-      )
-      ) %>%
-      collect(),
-    test_df
-  )
-
 })
 
 test_that("`as_date()` and `as.Date()` work with R objects", {

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1513,8 +1513,10 @@ test_that("`as.Date()` and `as_date()`", {
     dt_utc = ymd_hms("2010-08-03 00:50:50"),
     date_var = as.Date("2022-02-25"),
     difference_date = ymd_hms("2010-08-03 00:50:50", tz = "Pacific/Marquesas"),
-    character_ymd_var = "2022-02-25 00:00:01",
-    character_ydm_var = "2022/25/02 00:00:01",
+    character_ymd_hms_var = "2022-02-25 00:00:01",
+    character_ydm_hms_var = "2022/25/02 00:00:01",
+    character_ymd_var = "2022-02-25",
+    character_ydm_var = "2022/25/02",
     integer_var = 32L,
     integerish_var = 32,
     double_var = 34.56
@@ -1528,8 +1530,8 @@ test_that("`as.Date()` and `as_date()`", {
         date_pv_tz1 = as.Date(posixct_var, tz = "Pacific/Marquesas"),
         date_utc1 = as.Date(dt_utc),
         date_europe1 = as.Date(dt_europe),
-        date_char_ymd1 = as.Date(character_ymd_var, format = "%Y-%m-%d %H:%M:%S"),
-        date_char_ydm1 = as.Date(character_ydm_var, format = "%Y/%d/%m %H:%M:%S"),
+        date_char_ymd_hms1 = as.Date(character_ymd_hms_var, format = "%Y-%m-%d %H:%M:%S"),
+        date_char_ydm_hms1 = as.Date(character_ydm_hms_var, format = "%Y/%d/%m %H:%M:%S"),
         date_int1 = as.Date(integer_var, origin = "1970-01-01"),
         date_int_origin1 = as.Date(integer_var, origin = "1970-01-03"),
         date_integerish1 = as.Date(integerish_var, origin = "1970-01-01"),
@@ -1538,8 +1540,8 @@ test_that("`as.Date()` and `as_date()`", {
         date_pv_tz2 = as_date(posixct_var, tz = "Pacific/Marquesas"),
         date_utc2 = as_date(dt_utc),
         date_europe2 = as_date(dt_europe),
-        date_char_ymd2 = as_date(character_ymd_var, format = "%Y-%m-%d %H:%M:%S"),
-        date_char_ydm2 = as_date(character_ydm_var, format = "%Y/%d/%m %H:%M:%S"),
+        date_char_ymd2 = as_date(character_ymd_hms_var, format = "%Y-%m-%d %H:%M:%S"),
+        date_char_ydm2 = as_date(character_ydm_hms_var, format = "%Y/%d/%m %H:%M:%S"),
         date_int2 = as_date(integer_var, origin = "1970-01-01"),
         date_int_origin2 = as_date(integer_var, origin = "1970-01-03"),
         date_integerish2 = as_date(integerish_var, origin = "1970-01-01")
@@ -1547,6 +1549,17 @@ test_that("`as.Date()` and `as_date()`", {
       collect(),
     test_df
   )
+
+  # test_df %>%
+  #   arrow_table() %>%
+  #   mutate(
+  #     date_char_ymd = as.Date(
+  #       character_ymd_var,
+  #       tryFormats = c("%Y-%m-%d", "%Y/%m/%d")
+  #     ),
+  #     .keep = "used"
+  #   ) %>%
+  #   collect()
 
   # we do not support multiple tryFormats
   compare_dplyr_binding(
@@ -1565,14 +1578,14 @@ test_that("`as.Date()` and `as_date()`", {
   expect_error(
     test_df %>%
       arrow_table() %>%
-      mutate(date_char_ymd = as_date(character_ymd_var)) %>%
+      mutate(date_char_ymd = as_date(character_ymd_hms_var), .keep = "used") %>%
       collect()
   )
 
   expect_error(
     test_df %>%
       arrow_table() %>%
-      mutate(date_char_ymd = as.Date(character_ymd_var)) %>%
+      mutate(date_char_ymd = as.Date(character_ymd_hms_var)) %>%
       collect(),
     regexp = "Failed to parse string: '2022-02-25 00:00:01' as a scalar of type timestamp[s]",
     fixed = TRUE

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1566,7 +1566,7 @@ test_that("`as.Date()` and `as_date()`", {
         .keep = "used"
       ) %>%
       collect(),
-    regexp = "consider using the specialised parsing functions"
+    regexp = "consider using the lubridate specialised parsing functions"
   )
 
   # record batch test
@@ -1581,7 +1581,7 @@ test_that("`as.Date()` and `as_date()`", {
         .keep = "used"
       ) %>%
       collect(),
-    regexp = "consider using the specialised parsing functions"
+    regexp = "consider using the lubridate specialised parsing functions"
   )
 
   # strptime does not support a partial format - Arrow returns NA, while

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1562,23 +1562,6 @@ test_that("`as.Date()` and `as_date()`", {
     test_df
   )
 
-  # as_date() and as.Date() work with R objects
-  compare_dplyr_binding(
-    .input %>%
-      mutate(
-        date1 = as.Date("2022-05-10"),
-        date2 = as.Date(12, origin = "2022-05-01"),
-        date3 = as.Date("2022-10-03", tryFormats = "%Y-%m-%d"),
-        date4 = as_date("2022-05-10"),
-        date5 = as_date(12, origin = "2022-05-01"),
-        date6 = as_date("2022-10-03")
-      ) %>%
-      collect(),
-    tibble(
-      a = 1
-    )
-  )
-
   # strptime does not support a partial format - Arrow returns NA, while
   # lubridate parses correctly
   # TODO revisit once - https://issues.apache.org/jira/browse/ARROW-15813
@@ -1638,6 +1621,27 @@ test_that("`as.Date()` and `as_date()`", {
       ) %>%
       collect(),
     test_df
+  )
+})
+
+test_that("`as_date()` and `as.Date()` work with R objects", {
+  # some string processing (which depends on the RE2 library) is involved when
+  # parsing as date with multiple formats. RE2 is not available in R 3.6 on Windows
+  skip_if_not_available("re2")
+  compare_dplyr_binding(
+    .input %>%
+      mutate(
+        date1 = as.Date("2022-05-10"),
+        date2 = as.Date(12, origin = "2022-05-01"),
+        date3 = as.Date("2022-10-03", tryFormats = "%Y-%m-%d"),
+        date4 = as_date("2022-05-10"),
+        date5 = as_date(12, origin = "2022-05-01"),
+        date6 = as_date("2022-10-03")
+      ) %>%
+      collect(),
+    tibble(
+      a = 1
+    )
   )
 })
 

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1550,16 +1550,16 @@ test_that("`as.Date()` and `as_date()`", {
     test_df
   )
 
-  # test_df %>%
-  #   arrow_table() %>%
-  #   mutate(
-  #     date_char_ymd = as.Date(
-  #       character_ymd_var,
-  #       tryFormats = c("%Y-%m-%d", "%Y/%m/%d")
-  #     ),
-  #     .keep = "used"
-  #   ) %>%
-  #   collect()
+  test_df %>%
+    arrow_table() %>%
+    mutate(
+      date_char_ymd = as.Date(
+        character_ymd_var,
+        tryFormats = c("%Y-%m-%d", "%Y/%m/%d")
+      ),
+      .keep = "used"
+    ) %>%
+    collect()
 
   # we do not support multiple tryFormats
   compare_dplyr_binding(
@@ -1568,8 +1568,8 @@ test_that("`as.Date()` and `as_date()`", {
         tryFormats = c("%Y-%m-%d", "%Y/%m/%d")
       )) %>%
       collect(),
-    test_df,
-    warning = TRUE
+    test_df#,
+    # warning = TRUE
   )
 
   # strptime does not support a partial format - testing an error surfaced from
@@ -1577,7 +1577,7 @@ test_that("`as.Date()` and `as_date()`", {
   # TODO revisit once - https://issues.apache.org/jira/browse/ARROW-15813
   expect_error(
     test_df %>%
-      arrow_table() %>%
+      # arrow_table() %>%
       mutate(date_char_ymd = as_date(character_ymd_hms_var), .keep = "used") %>%
       collect()
   )

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1550,7 +1550,7 @@ test_that("`as.Date()` and `as_date()`", {
     test_df
   )
 
-  # we now support multiple tryFormats
+  # as.Date() supports multiple tryFormats
   compare_dplyr_binding(
     .input %>%
       mutate(date_char_ymd = as.Date(
@@ -1560,6 +1560,23 @@ test_that("`as.Date()` and `as_date()`", {
       ) %>%
       collect(),
     test_df
+  )
+
+  # as_date() and as.Date() work with R objects
+  compare_dplyr_binding(
+    .input %>%
+      mutate(
+        date1 = as.Date("2022-05-10"),
+        date2 = as.Date(12, origin = "2022-05-01"),
+        date3 = as.Date("2022-10-03", tryFormats = "%Y-%m-%d"),
+        date4 = as_date("2022-05-10"),
+        date5 = as_date(12, origin = "2022-05-01"),
+        date6 = as_date("2022-10-03")
+      ) %>%
+      collect(),
+    tibble(
+      a = 1
+    )
   )
 
   # strptime does not support a partial format - Arrow returns NA, while

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1627,9 +1627,6 @@ test_that("`as.Date()` and `as_date()`", {
 })
 
 test_that("`as_date()` and `as.Date()` work with R objects", {
-  # some string processing (which depends on the RE2 library) is involved when
-  # parsing as date with multiple formats. RE2 is not available in R 3.6 on Windows
-  skip_if_not_available("re2")
   compare_dplyr_binding(
     .input %>%
       mutate(
@@ -1773,18 +1770,6 @@ test_that("parse_date_time() works with a mix of formats and orders", {
       ) %>%
       collect(),
     test_df
-  )
-
-  # parse_date_time() works with R objects
-  compare_dplyr_binding(
-    .input %>%
-      mutate(
-        parsed_date_ymd = parse_date_time("2021/09///2", orders = "ymd")
-      ) %>%
-      collect(),
-    tibble::tibble(
-      a = 1
-    )
   )
 })
 

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1562,25 +1562,33 @@ test_that("`as.Date()` and `as_date()`", {
     test_df
   )
 
-  # strptime does not support a partial format - testing an error surfaced from
-  # C++ (hence not testing the content of the error message)
+  # strptime does not support a partial format - Arrow returns NA, while
+  # lubridate parses correctly
   # TODO revisit once - https://issues.apache.org/jira/browse/ARROW-15813
   expect_error(
-    test_df %>%
-      arrow_table() %>%
-      mutate(date_char_ymd_hms = as_date(character_ymd_hms_var), .keep = "used") %>%
-      collect()
+    expect_equal(
+      test_df %>%
+        arrow_table() %>%
+        mutate(date_char_ymd_hms = as_date(character_ymd_hms_var), .keep = "used") %>%
+        collect(),
+      test_df %>%
+        mutate(date_char_ymd_hms = as_date(character_ymd_hms_var), .keep = "used") %>%
+        collect()
+    )
   )
 
+  # same as above
   expect_error(
-    test_df %>%
-      arrow_table() %>%
-      mutate(date_char_ymd_hms = as.Date(character_ymd_hms_var), .keep = "used") %>%
-      collect(),
-    regexp = "Failed to parse string: '2022-02-25 00:00:01' as a scalar of type timestamp[s]",
-    fixed = TRUE
+    expect_equal(
+      test_df %>%
+        arrow_table() %>%
+        mutate(date_char_ymd_hms = as.Date(character_ymd_hms_var), .keep = "used") %>%
+        collect(),
+      test_df %>%
+        mutate(date_char_ymd_hms = as.Date(character_ymd_hms_var), .keep = "used") %>%
+        collect()
+    )
   )
-
 
   # we do not support as.Date() with double/ float (error surfaced from C++)
   # TODO revisit after https://issues.apache.org/jira/browse/ARROW-15798

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1554,9 +1554,11 @@ test_that("`as.Date()` and `as_date()`", {
   # we do not support multiple tryFormats
   compare_dplyr_binding(
     .input %>%
-      mutate(date_char_ymd = as.Date(character_ymd_var,
-                                     tryFormats = c("%Y-%m-%d", "%Y/%m/%d")
-      )) %>%
+      mutate(date_char_ymd = as.Date(
+        character_ymd_var,
+        tryFormats = c("%Y-%m-%d", "%Y/%m/%d")
+      )
+      ) %>%
       collect(),
     test_df,
     warning = TRUE
@@ -1608,17 +1610,6 @@ test_that("`as.Date()` and `as_date()`", {
       collect()
   )
 
-  test_df %>%
-    arrow_table() %>%
-    mutate(
-      date_try_formats_base = as.Date(
-        try_formats_string,
-        tryFormats = c("%Y-%m-%d", "%Y/%m/%d")
-      ),
-      .keep = "used"
-    ) %>%
-    collect()
-
   # difference between as.Date() and as_date():
   # `as.Date()` ignores the `tzone` attribute and uses the value of the `tz` arg
   # to `as.Date()`
@@ -1628,12 +1619,7 @@ test_that("`as.Date()` and `as_date()`", {
     .input %>%
       transmute(
         date_diff_lubridate = as_date(difference_date),
-        date_diff_base = as.Date(difference_date),
-        date_try_formats_base = as.Date(
-          try_formats_string,
-          tryFormats = c("%Y-%m-%d", "%Y/%m/%d")
-        ),
-        date_try_formats_lubridate = as_date(try_formats_string)
+        date_diff_base = as.Date(difference_date)
       ) %>%
       collect(),
     test_df

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1550,26 +1550,16 @@ test_that("`as.Date()` and `as_date()`", {
     test_df
   )
 
-  test_df %>%
-    arrow_table() %>%
-    mutate(
-      date_char_ymd = as.Date(
-        character_ymd_var,
-        tryFormats = c("%Y-%m-%d", "%Y/%m/%d")
-      ),
-      .keep = "used"
-    ) %>%
-    collect()
-
-  # we do not support multiple tryFormats
+  # we now support multiple tryFormats
   compare_dplyr_binding(
     .input %>%
-      mutate(date_char_ymd = as.Date(character_ymd_var,
+      mutate(date_char_ymd = as.Date(
+        character_ymd_var,
         tryFormats = c("%Y-%m-%d", "%Y/%m/%d")
-      )) %>%
+      )
+      ) %>%
       collect(),
-    test_df#,
-    # warning = TRUE
+    test_df
   )
 
   # strptime does not support a partial format - testing an error surfaced from
@@ -1577,8 +1567,8 @@ test_that("`as.Date()` and `as_date()`", {
   # TODO revisit once - https://issues.apache.org/jira/browse/ARROW-15813
   expect_error(
     test_df %>%
-      # arrow_table() %>%
-      mutate(date_char_ymd = as_date(character_ymd_hms_var), .keep = "used") %>%
+      arrow_table() %>%
+      mutate(date_char_ymd_hms = as_date(character_ymd_hms_var), .keep = "used") %>%
       collect()
   )
 

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1550,18 +1550,6 @@ test_that("`as.Date()` and `as_date()`", {
     test_df
   )
 
-  # as.Date() supports multiple tryFormats
-  compare_dplyr_binding(
-    .input %>%
-      mutate(date_char_ymd = as.Date(
-        character_ymd_var,
-        tryFormats = c("%Y-%m-%d", "%Y/%m/%d")
-      )
-      ) %>%
-      collect(),
-    test_df
-  )
-
   # strptime does not support a partial format - Arrow returns NA, while
   # lubridate parses correctly
   # TODO revisit once - https://issues.apache.org/jira/browse/ARROW-15813
@@ -1622,6 +1610,22 @@ test_that("`as.Date()` and `as_date()`", {
       collect(),
     test_df
   )
+
+  # some string processing (which depends on the RE2 library) is involved when
+  # parsing as date with multiple formats. RE2 is not available in R 3.6 on Windows
+  skip_if_not_available("re2")
+  # as.Date() supports multiple tryFormats
+  compare_dplyr_binding(
+    .input %>%
+      mutate(date_char_ymd = as.Date(
+        character_ymd_var,
+        tryFormats = c("%Y-%m-%d", "%Y/%m/%d")
+      )
+      ) %>%
+      collect(),
+    test_df
+  )
+
 })
 
 test_that("`as_date()` and `as.Date()` work with R objects", {

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1562,8 +1562,7 @@ test_that("`as.Date()` and `as_date()`", {
         date_char_ymd = as.Date(
           character_ymd_var,
           tryFormats = c("%Y-%m-%d", "%Y/%m/%d")
-        ),
-        .keep = "used"
+        )
       ) %>%
       collect(),
     regexp = "consider using the lubridate specialised parsing functions"
@@ -1577,8 +1576,7 @@ test_that("`as.Date()` and `as_date()`", {
         date_char_ymd = as.Date(
           character_ymd_var,
           tryFormats = c("%Y-%m-%d", "%Y/%m/%d")
-        ),
-        .keep = "used"
+        )
       ) %>%
       collect(),
     regexp = "consider using the lubridate specialised parsing functions"

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1551,6 +1551,17 @@ test_that("`as.Date()` and `as_date()`", {
     test_df
   )
 
+  # we do not support multiple tryFormats
+  compare_dplyr_binding(
+    .input %>%
+      mutate(date_char_ymd = as.Date(character_ymd_var,
+                                     tryFormats = c("%Y-%m-%d", "%Y/%m/%d")
+      )) %>%
+      collect(),
+    test_df,
+    warning = TRUE
+  )
+
   # strptime does not support a partial format - Arrow returns NA, while
   # lubridate parses correctly
   # TODO revisit once - https://issues.apache.org/jira/browse/ARROW-15813

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1552,16 +1552,36 @@ test_that("`as.Date()` and `as_date()`", {
   )
 
   # we do not support multiple tryFormats
-  compare_dplyr_binding(
-    .input %>%
-      mutate(date_char_ymd = as.Date(
-        character_ymd_var,
-        tryFormats = c("%Y-%m-%d", "%Y/%m/%d")
-      )
+  # this is not a simple warning, therefore we cannot use compare_dplyr_binding()
+  # with `warning = TRUE`
+  # arrow_table test
+  expect_warning(
+    test_df %>%
+      arrow_table() %>%
+      mutate(
+        date_char_ymd = as.Date(
+          character_ymd_var,
+          tryFormats = c("%Y-%m-%d", "%Y/%m/%d")
+        ),
+        .keep = "used"
       ) %>%
       collect(),
-    test_df,
-    warning = TRUE
+    regexp = "consider using the specialised parsing functions"
+  )
+
+  # record batch test
+  expect_warning(
+    test_df %>%
+      record_batch() %>%
+      mutate(
+        date_char_ymd = as.Date(
+          character_ymd_var,
+          tryFormats = c("%Y-%m-%d", "%Y/%m/%d")
+        ),
+        .keep = "used"
+      ) %>%
+      collect(),
+    regexp = "consider using the specialised parsing functions"
   )
 
   # strptime does not support a partial format - Arrow returns NA, while

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1508,19 +1508,19 @@ test_that("make_difftime()", {
 
 test_that("`as.Date()` and `as_date()`", {
   test_df <- tibble::tibble(
-    posixct_var = as.POSIXct("2022-02-25 00:00:01", tz = "Pacific/Marquesas"),
-    dt_europe = ymd_hms("2010-08-03 00:50:50", tz = "Europe/London"),
-    dt_utc = ymd_hms("2010-08-03 00:50:50"),
-    date_var = as.Date("2022-02-25"),
-    difference_date = ymd_hms("2010-08-03 00:50:50", tz = "Pacific/Marquesas"),
+    posixct_var = as.POSIXct(c("2022-02-25 00:00:01", "1987-11-24 12:34:56", NA), tz = "Pacific/Marquesas"),
+    dt_europe = ymd_hms("2010-08-03 00:50:50", "1987-11-24 12:34:56", NA, tz = "Europe/London"),
+    dt_utc = ymd_hms("2010-08-03 00:50:50", "1987-11-24 12:34:56", NA),
+    date_var = as.Date(c("2022-02-25", "1987-11-24", NA)),
+    difference_date = ymd_hms("2010-08-03 00:50:50", "1987-11-24 12:34:56", NA, tz = "Pacific/Marquesas"),
     try_formats_string = c(NA, "2022-01-01", "2022/01/01"),
-    character_ymd_hms_var = "2022-02-25 00:00:01",
-    character_ydm_hms_var = "2022/25/02 00:00:01",
-    character_ymd_var = "2022-02-25",
-    character_ydm_var = "2022/25/02",
-    integer_var = 32L,
-    integerish_var = 32,
-    double_var = 34.56
+    character_ymd_hms_var = c("2022-02-25 00:00:01", "1987-11-24 12:34:56", NA),
+    character_ydm_hms_var = c("2022/25/02 00:00:01", "1987/24/11 12:34:56", NA),
+    character_ymd_var = c("2022-02-25", "1987-11-24", NA),
+    character_ydm_var = c("2022/25/02", "1987/24/11", NA),
+    integer_var = c(21L, 32L, NA),
+    integerish_var = c(21, 32, NA),
+    double_var = c(12.34, 56.78, NA)
   )
 
   compare_dplyr_binding(


### PR DESCRIPTION
**Update**: this PR will only improve the message users get when trying to pass multiple formats to `tryFormats`. The new message will include an advice to use the dedicated parsing functions. This conclusion / recommendation can be found here (first comment): https://issues.apache.org/jira/browse/ARROW-15805

=================

**Old description**: This PR will allow users to try parsing with several formats via the `tryFormats` argument to `as.Date()` and `as_date()`

> _tryFormats_ - character vector of format strings to try if format is not specified.

`as_date()` does not have the `tryFormats` argument, but will assume an ISO 8601 format if nothing is passed via the `format` argument.

https://github.com/tidyverse/lubridate/blob/c4714046ec412e669906ab8d1cd9a8e4fb125e13/R/coercion.r#L725

I implemented `tryFormats` with the `parse_date_time()` binding to coalesce through the format strings. One implication is that `as.Date()` is no longer erroring when not being able to parse, but rather return an `NA`. 

**A thought**: should we only support `tryFormats` only when `RE2` is available? As it currently is, this PR will remove the `as.Date` functionality if `format` is `NULL` for Windows R 3.6 users. 
