### PR TITLE
ARROW-16448: [CI][Archery] Refactor EmailReport to be a JinjaReport

### DIFF
--- a/dev/archery/archery/crossbow/cli.py
+++ b/dev/archery/archery/crossbow/cli.py
@@ -279,8 +279,8 @@ def report(obj, job_name, sender_name, sender_email, recipient_email,
         queue.fetch()
 
     job = queue.get(job_name)
-    report = EmailReport(
-        job=job,
+    email_report = EmailReport(
+        report=Report(job),
         sender_name=sender_name,
         sender_email=sender_email,
         recipient_email=recipient_email
@@ -293,14 +293,16 @@ def report(obj, job_name, sender_name, sender_email, recipient_email,
         )
 
     if send:
-        report.send(
+        ReportUtils.send_email(
             smtp_user=smtp_user,
             smtp_password=smtp_password,
             smtp_server=smtp_server,
-            smtp_port=smtp_port
+            smtp_port=smtp_port,
+            recipient_email=recipient_email,
+            message=email_report.render("text")
         )
     else:
-        report.show(output)
+        output.write(email_report.render("text"))
 
 
 @crossbow.command()

--- a/dev/archery/archery/crossbow/tests/fixtures/email-report.txt
+++ b/dev/archery/archery/crossbow/tests/fixtures/email-report.txt
@@ -1,0 +1,27 @@
+From: Sender Reporter <sender@arrow.com>
+To: recipient@arrow.com
+Subject: [NIGHTLY] Arrow Build Report for Job ursabot-1: 2 failed, 1 pending
+
+Arrow Build Report for Job ursabot-1
+
+All tasks: https://github.com/apache/crossbow/branches/all?query=ursabot-1
+
+Failed Tasks:
+
+- wheel-osx-cp37m
+  https://github.com/apache/crossbow/runs/2
+
+Errored Tasks:
+
+- wheel-osx-cp36m
+  https://github.com/apache/crossbow/runs/3
+
+Pending Tasks:
+
+- wheel-win-cp36m
+  https://github.com/apache/crossbow/runs/4
+
+Succeeded Tasks:
+
+- docker-cpp-cmake32
+  https://github.com/apache/crossbow/runs/1

--- a/dev/archery/archery/crossbow/tests/test_reports.py
+++ b/dev/archery/archery/crossbow/tests/test_reports.py
@@ -18,7 +18,8 @@
 import textwrap
 
 from archery.crossbow.core import yaml
-from archery.crossbow.reports import ChatReport, CommentReport, Report
+from archery.crossbow.reports import (ChatReport, CommentReport, EmailReport,
+                                      Report)
 
 
 def test_crossbow_comment_formatter(load_fixture):
@@ -35,7 +36,7 @@ def test_crossbow_comment_formatter(load_fixture):
     assert report.show() == textwrap.dedent(expected).strip()
 
 
-def test_crossbow_report(load_fixture):
+def test_crossbow_chat_report(load_fixture):
     expected_msg = load_fixture('chat-report.txt')
     job = load_fixture('crossbow-job.yaml', decoder=yaml.load)
     report = Report(job)
@@ -43,3 +44,15 @@ def test_crossbow_report(load_fixture):
     report_chat = ChatReport(report=report)
 
     assert report_chat.render("text") == textwrap.dedent(expected_msg)
+
+
+def test_crossbow_email_report(load_fixture):
+    expected_msg = load_fixture('email-report.txt')
+    job = load_fixture('crossbow-job.yaml', decoder=yaml.load)
+    report = Report(job)
+    assert report.tasks_by_state is not None
+    empail_report = EmailReport(report=report, sender_name="Sender Reporter",
+                                sender_email="sender@arrow.com",
+                                recipient_email="recipient@arrow.com")
+
+    assert empail_report.render("text") == textwrap.dedent(expected_msg)

--- a/dev/archery/archery/templates/email_nightly_report.txt.j2
+++ b/dev/archery/archery/templates/email_nightly_report.txt.j2
@@ -1,0 +1,59 @@
+{#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#}
+{%- if True -%}
+{%- endif -%}
+From: {{ sender_name }} <{{ sender_email }}>
+To: {{ recipient_email }}
+Subject: [NIGHTLY] Arrow Build Report for Job {{report.job.branch}}: {{ (report.tasks_by_state["error"] | length) +  (report.tasks_by_state["failure"] | length) }} failed, {{ report.tasks_by_state["pending"] | length }} pending
+
+Arrow Build Report for Job {{ report.job.branch }}
+
+All tasks: {{ report.url(report.job.branch) }}
+{% if report.tasks_by_state["failure"] %}
+Failed Tasks:
+
+{% for task_name, task in report.tasks_by_state["failure"] | dictsort -%}
+- {{ task_name }}
+  {{ report.task_url(task) }}
+{% endfor %}
+{% endif %}
+{%- if report.tasks_by_state["error"] -%}
+Errored Tasks:
+
+{% for task_name, task in report.tasks_by_state["error"] | dictsort -%}
+- {{ task_name }}
+  {{ report.task_url(task) }}
+{% endfor %}
+{% endif %}
+{%- if report.tasks_by_state["pending"] -%}
+Pending Tasks:
+
+{% for task_name, task in report.tasks_by_state["pending"] | dictsort -%}
+- {{ task_name }}
+  {{ report.task_url(task) }}
+{% endfor %}
+{% endif %}
+{%- if report.tasks_by_state["success"] -%}
+Succeeded Tasks:
+
+{% for task_name, task in report.tasks_by_state["success"] | dictsort -%}
+- {{ task_name }}
+  {{ report.task_url(task) }}
+{% endfor %}
+{%- endif -%}


### PR DESCRIPTION
This PR tries to move the current `EmailReport` used for the Nightly report emails to a `JinjaReport` and adds a test for the report generation.
I also have tested locally sending an email successfully.