### PR TITLE
ARROW-16467: [Python] Add helper function _exec_plan._filter_table to filter tables based on Expression

### DIFF
--- a/python/pyarrow/_exec_plan.pyx
+++ b/python/pyarrow/_exec_plan.pyx
@@ -383,7 +383,7 @@ def _filter_table(table, expression, output_type=Table):
     )
 
     r = execplan([table], plan=c_decl_plan,
-                 output_type=Table)
+                 output_type=Table, use_threads=False)
 
     if output_type == Table:
         return r

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2458,6 +2458,9 @@ cdef extern from "arrow/compute/exec/options.h" namespace "arrow::compute" nogil
     cdef cppclass CSinkNodeOptions "arrow::compute::SinkNodeOptions"(CExecNodeOptions):
         pass
 
+    cdef cppclass CFilterNodeOptions "arrow::compute::FilterNodeOptions"(CExecNodeOptions):
+        CFilterNodeOptions(CExpression, c_bool async_mode)
+
     cdef cppclass CProjectNodeOptions "arrow::compute::ProjectNodeOptions"(CExecNodeOptions):
         CProjectNodeOptions(vector[CExpression] expressions)
         CProjectNodeOptions(vector[CExpression] expressions,

--- a/python/pyarrow/tests/test_exec_plan.py
+++ b/python/pyarrow/tests/test_exec_plan.py
@@ -251,7 +251,7 @@ def test_filter_table_ordering():
 
     for _ in range(20):
         # 20 seems to consistently cause errors when order is not preserved.
-        # Worst case if the order problem is reintroduced this test will become flaky
+        # If the order problem is reintroduced this test will become flaky
         # which is still a signal that the order is not preserved.
         r = ep._filter_table(table, pc.field('a') == 1)
         assert r["b"] == pa.chunked_array([["a"], ["b"]])

--- a/python/pyarrow/tests/test_exec_plan.py
+++ b/python/pyarrow/tests/test_exec_plan.py
@@ -242,3 +242,16 @@ def test_filter_table(use_datasets):
         "a": [4, 5],
         "b": [40, 50]
     })
+
+
+def test_filter_table_ordering():
+    table1 = pa.table({'a': [1, 2, 3, 4], 'b': ['a'] * 4})
+    table2 = pa.table({'a': [1, 2, 3, 4], 'b': ['b'] * 4})
+    table = pa.concat_tables([table1, table2])
+
+    for _ in range(20):
+        # 20 seems to consistently cause errors when order is not preserved.
+        # Worst case if the order problem is reintroduced this test will become flaky
+        # which is still a signal that the order is not preserved.
+        r = ep._filter_table(table, pc.field('a') == 1)
+        assert r["b"] == pa.chunked_array([["a"], ["b"]])

--- a/python/pyarrow/tests/test_exec_plan.py
+++ b/python/pyarrow/tests/test_exec_plan.py
@@ -203,18 +203,22 @@ def test_filter_table(use_datasets):
         t = ds.dataset([t])
 
     result = ep._filter_table(
-        t, (pc.field("a") <= pc.scalar(3)) & (pc.field("b") == pc.scalar(20))
+        t, (pc.field("a") <= pc.scalar(3)) & (pc.field("b") == pc.scalar(20)),
+        output_type=pa.Table if not use_datasets else ds.InMemoryDataset
     )
-    result = result.select(["a", "b"]).combine_chunks()
+    if use_datasets:
+        result = result.to_table()
     assert result == pa.table({
         "a": [2],
         "b": [20]
     })
 
     result = ep._filter_table(
-        t, pc.field("b") > pc.scalar(30)
+        t, pc.field("b") > pc.scalar(30),
+        output_type=pa.Table if not use_datasets else ds.InMemoryDataset
     )
-    result = result.select(["a", "b"]).combine_chunks()
+    if use_datasets:
+        result = result.to_table()
     assert result == pa.table({
         "a": [4, 5],
         "b": [40, 50]

--- a/python/pyarrow/tests/test_exec_plan.py
+++ b/python/pyarrow/tests/test_exec_plan.py
@@ -193,6 +193,25 @@ def test_table_join_keys_order():
     })
 
 
+def test_filter_table_errors():
+    t = pa.table({
+        "a": [1, 2, 3, 4, 5],
+        "b": [10, 20, 30, 40, 50]
+    })
+
+    with pytest.raises(pa.ArrowTypeError):
+        ep._filter_table(
+            t, pc.divide(pc.field("a"), pc.scalar(2)),
+            output_type=pa.Table
+        )
+
+    with pytest.raises(pa.ArrowInvalid):
+        ep._filter_table(
+            t, (pc.field("Z") <= pc.scalar(2)),
+            output_type=pa.Table
+        )
+
+
 @pytest.mark.parametrize("use_datasets", [False, True])
 def test_filter_table(use_datasets):
     t = pa.table({


### PR DESCRIPTION
The function is focused on Tables, as it will be the foundation for `Table.filter`, but as the extra work was minimal I added support for Dataset too.