### PR TITLE
ARROW-15590: [C++] Add support for joins to the Substrait consumer

### DIFF
--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -296,20 +296,19 @@ class ARROW_EXPORT HashJoinNodeOptions : public ExecNodeOptions {
       this->key_cmp[i] = JoinKeyCmp::EQ;
     }
   }
-  HashJoinNodeOptions(
-      JoinType in_join_type, std::vector<FieldRef> in_left_keys,
-      std::vector<FieldRef> in_right_keys, std::vector<JoinKeyCmp> key_cmp,
-      Expression filter = literal(true),
-      std::string output_suffix_for_left = default_output_suffix_for_left,
-      std::string output_suffix_for_right = default_output_suffix_for_right)
-      : join_type(in_join_type),
-        left_keys(std::move(in_left_keys)),
-        right_keys(std::move(in_right_keys)),
-        output_all(true),
-        key_cmp(std::move(key_cmp)),
-        output_suffix_for_left(std::move(output_suffix_for_left)),
-        output_suffix_for_right(std::move(output_suffix_for_right)),
-        filter(std::move(filter)) {}
+  HashJoinNodeOptions(std::vector<FieldRef> in_left_keys,
+                      std::vector<FieldRef> in_right_keys)
+      : left_keys(std::move(in_left_keys)), right_keys(std::move(in_right_keys)) {
+    this->join_type = JoinType::INNER;
+    this->output_all = true;
+    this->output_suffix_for_left = default_output_suffix_for_left;
+    this->output_suffix_for_right = default_output_suffix_for_right;
+    this->key_cmp.resize(this->left_keys.size());
+    for (size_t i = 0; i < this->left_keys.size(); ++i) {
+      this->key_cmp[i] = JoinKeyCmp::EQ;
+    }
+    this->filter = literal(true);
+  }
   HashJoinNodeOptions(
       JoinType join_type, std::vector<FieldRef> left_keys,
       std::vector<FieldRef> right_keys, std::vector<FieldRef> left_output,

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -297,6 +297,20 @@ class ARROW_EXPORT HashJoinNodeOptions : public ExecNodeOptions {
     }
   }
   HashJoinNodeOptions(
+      JoinType in_join_type, std::vector<FieldRef> in_left_keys,
+      std::vector<FieldRef> in_right_keys, std::vector<JoinKeyCmp> key_cmp,
+      Expression filter = literal(true),
+      std::string output_suffix_for_left = default_output_suffix_for_left,
+      std::string output_suffix_for_right = default_output_suffix_for_right)
+      : join_type(in_join_type),
+        left_keys(std::move(in_left_keys)),
+        right_keys(std::move(in_right_keys)),
+        output_all(true),
+        key_cmp(std::move(key_cmp)),
+        output_suffix_for_left(std::move(output_suffix_for_left)),
+        output_suffix_for_right(std::move(output_suffix_for_right)),
+        filter(std::move(filter)) {}
+  HashJoinNodeOptions(
       JoinType join_type, std::vector<FieldRef> left_keys,
       std::vector<FieldRef> right_keys, std::vector<FieldRef> left_output,
       std::vector<FieldRef> right_output, Expression filter = literal(true),

--- a/cpp/src/arrow/engine/substrait/extension_set.cc
+++ b/cpp/src/arrow/engine/substrait/extension_set.cc
@@ -249,6 +249,7 @@ ExtensionIdRegistry* default_extension_id_registry() {
       for (util::string_view name : {
                "add",
                "equal",
+               "is_not_distinct_from",
            }) {
         DCHECK_OK(RegisterFunction({kArrowExtTypesUri, name}, name.to_string()));
       }

--- a/cpp/src/arrow/engine/substrait/extension_set.cc
+++ b/cpp/src/arrow/engine/substrait/extension_set.cc
@@ -247,7 +247,8 @@ ExtensionIdRegistry* default_extension_id_registry() {
       // for Substrait, and include mappings for all of them here. See
       // ARROW-15535.
       for (util::string_view name : {
-               "add", "equal",
+               "add",
+               "equal",
            }) {
         DCHECK_OK(RegisterFunction({kArrowExtTypesUri, name}, name.to_string()));
       }

--- a/cpp/src/arrow/engine/substrait/extension_set.cc
+++ b/cpp/src/arrow/engine/substrait/extension_set.cc
@@ -247,7 +247,7 @@ ExtensionIdRegistry* default_extension_id_registry() {
       // for Substrait, and include mappings for all of them here. See
       // ARROW-15535.
       for (util::string_view name : {
-               "add",
+               "add", "equal",
            }) {
         DCHECK_OK(RegisterFunction({kArrowExtTypesUri, name}, name.to_string()));
       }

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -250,7 +250,7 @@ Result<compute::Declaration> FromProto(const substrait::Rel& rel,
         case substrait::JoinRel::JOIN_TYPE_LEFT:
           join_type = compute::JoinType::LEFT_OUTER;
           break;
-        case 4:
+        case substrait::JoinRel::JOIN_TYPE_RIGHT:
           join_type = compute::JoinType::RIGHT_OUTER;
           break;
         case 5:

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -291,7 +291,7 @@ Result<compute::Declaration> FromProto(const substrait::Rel& rel,
             callptr->function_name);
       }
 
-      // TODO: Add Suffix support for Substrait
+      // TODO: ARROW-166241 Add Suffix support for Substrait
       const auto* left_keys = callptr->arguments[0].field_ref();
       const auto* right_keys = callptr->arguments[1].field_ref();
       if (!left_keys || !right_keys) {

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -256,7 +256,7 @@ Result<compute::Declaration> FromProto(const substrait::Rel& rel,
         case substrait::JoinRel::JOIN_TYPE_SEMI:
           join_type = compute::JoinType::LEFT_SEMI;
           break;
-        case 6:
+        case substrait::JoinRel::JOIN_TYPE_ANTI:
           join_type = compute::JoinType::LEFT_ANTI;
           break;
         default:

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -253,7 +253,7 @@ Result<compute::Declaration> FromProto(const substrait::Rel& rel,
         case substrait::JoinRel::JOIN_TYPE_RIGHT:
           join_type = compute::JoinType::RIGHT_OUTER;
           break;
-        case 5:
+        case substrait::JoinRel::JOIN_TYPE_SEMI:
           join_type = compute::JoinType::LEFT_SEMI;
           break;
         case 6:

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -244,7 +244,7 @@ Result<compute::Declaration> FromProto(const substrait::Rel& rel,
         case substrait::JoinRel::JOIN_TYPE_INNER:
           join_type = compute::JoinType::INNER;
           break;
-        case 2:
+        case substrait::JoinRel::JOIN_TYPE_OUTER:
           join_type = compute::JoinType::FULL_OUTER;
           break;
         case 3:

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -247,7 +247,7 @@ Result<compute::Declaration> FromProto(const substrait::Rel& rel,
         case substrait::JoinRel::JOIN_TYPE_OUTER:
           join_type = compute::JoinType::FULL_OUTER;
           break;
-        case 3:
+        case substrait::JoinRel::JOIN_TYPE_LEFT:
           join_type = compute::JoinType::LEFT_OUTER;
           break;
         case 4:

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -241,7 +241,7 @@ Result<compute::Declaration> FromProto(const substrait::Rel& rel,
       switch (join.type()) {
         case 0:
           return Status::NotImplemented("Unspecified join type is not supported");
-        case 1:
+        case substrait::JoinRel::JOIN_TYPE_INNER:
           join_type = compute::JoinType::INNER;
           break;
         case 2:

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -239,7 +239,7 @@ Result<compute::Declaration> FromProto(const substrait::Rel& rel,
 
       compute::JoinType join_type;
       switch (join.type()) {
-        case 0:
+        case substrait::JoinRel::JOIN_TYPE_UNSPECIFIED:
           return Status::NotImplemented("Unspecified join type is not supported");
         case substrait::JoinRel::JOIN_TYPE_INNER:
           join_type = compute::JoinType::INNER;

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -245,15 +245,20 @@ Result<compute::Declaration> FromProto(const substrait::Rel& rel,
           join_type = compute::JoinType::INNER;
           break;
         case 2:
-          return Status::NotImplemented("Outer join type is not supported");
+          join_type = compute::JoinType::FULL_OUTER;
+          break;
         case 3:
-          return Status::NotImplemented("Left join type is not supported");
+          join_type = compute::JoinType::LEFT_OUTER;
+          break;
         case 4:
-          return Status::NotImplemented("Right join type is not supported");
+          join_type = compute::JoinType::RIGHT_OUTER;
+          break;
         case 5:
-          return Status::NotImplemented("Semi join type is not supported");
+          join_type = compute::JoinType::LEFT_SEMI;
+          break;
         case 6:
-          return Status::NotImplemented("Anti join type is not supported");
+          join_type = compute::JoinType::LEFT_ANTI;
+          break;
         default:
           return Status::Invalid("Unsupported join type");
       }

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -292,10 +292,10 @@ Result<compute::Declaration> FromProto(const substrait::Rel& rel,
           arrow::compute::literal(true),
           "_l",
           "_r"};
-      compute::Declaration join_dec{"hashjoin", join_options};
-      join_dec.inputs.emplace_back(left);
-      join_dec.inputs.emplace_back(right);
-      return compute::Declaration::Sequence({join_dec});
+      compute::Declaration join_dec{"hashjoin", std::move(join_options)};
+      join_dec.inputs.emplace_back(std::move(left));
+      join_dec.inputs.emplace_back(std::move(right));
+      return compute::Declaration::Sequence({std::move(join_dec)});
     }
 
     default:

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -225,6 +225,24 @@ Result<compute::Declaration> FromProto(const substrait::Rel& rel,
       });
     }
 
+    case substrait::Rel::RelTypeCase::kJoin: {
+      const auto& join = rel.join();
+      RETURN_NOT_OK(CheckRelCommon(join));
+
+      if (!join.has_left()) {
+        return Status::Invalid("substrait::JoinRel with no left relation");
+      }
+
+      if (!join.has_right()) {
+        return Status::Invalid("substrait::JoinRel with no right relation");
+      }
+
+      ARROW_ASSIGN_OR_RAISE(auto left, FromProto(join.left(), ext_set));
+      ARROW_ASSIGN_OR_RAISE(auto right, FromProto(join.right(), ext_set));
+    
+      break;
+    }
+
     default:
       break;
   }

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -285,13 +285,10 @@ Result<compute::Declaration> FromProto(const substrait::Rel& rel,
 
       // TODO: Add Suffix support for Substrait
       compute::HashJoinNodeOptions join_options{
-          join_type,
           {std::move(*callptr->arguments[0].field_ref())},
-          {std::move(*callptr->arguments[1].field_ref())},
-          {join_key_cmp},
-          arrow::compute::literal(true),
-          "_l",
-          "_r"};
+          {std::move(*callptr->arguments[1].field_ref())}};
+      join_options.join_type = join_type;
+      join_options.key_cmp = {join_key_cmp};
       compute::Declaration join_dec{"hashjoin", std::move(join_options)};
       join_dec.inputs.emplace_back(std::move(left));
       join_dec.inputs.emplace_back(std::move(right));

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -255,7 +255,7 @@ Result<compute::Declaration> FromProto(const substrait::Rel& rel,
         case 6:
           return Status::NotImplemented("Anti join type is not supported");
         default:
-          break;
+          return Status::Invalid("Unsupported join type");
       }
 
       ARROW_ASSIGN_OR_RAISE(auto left, FromProto(join.left(), ext_set));

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -1051,8 +1051,6 @@ TEST(Substrait, JoinPlanInvalidKeyCmp) {
           &ext_set));
 }
 
-//  {"literal": {"list": {"values": []}}}
-
 TEST(Substrait, JoinPlanInvalidExpression) {
   ASSERT_OK_AND_ASSIGN(auto buf, internal::SubstraitFromJSON("Plan", R"({
   "relations": [{

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -914,7 +914,7 @@ TEST(Substrait, JoinPlanBasic) {
   ExtensionSet ext_set;
   ASSERT_OK_AND_ASSIGN(
       auto sink_decls,
-      DeserializePlan(
+      DeserializePlans(
           *buf, [] { return std::shared_ptr<compute::SinkNodeConsumer>{nullptr}; },
           &ext_set));
 
@@ -1046,7 +1046,7 @@ TEST(Substrait, JoinPlanInvalidKeyCmp) {
   ExtensionSet ext_set;
   ASSERT_RAISES(
       Invalid,
-      DeserializePlan(
+      DeserializePlans(
           *buf, [] { return std::shared_ptr<compute::SinkNodeConsumer>{nullptr}; },
           &ext_set));
 }
@@ -1113,7 +1113,7 @@ TEST(Substrait, JoinPlanInvalidExpression) {
   ExtensionSet ext_set;
   ASSERT_RAISES(
       Invalid,
-      DeserializePlan(
+      DeserializePlans(
           *buf, [] { return std::shared_ptr<compute::SinkNodeConsumer>{nullptr}; },
           &ext_set));
 }
@@ -1181,7 +1181,7 @@ TEST(Substrait, JoinPlanInvalidKeys) {
   ExtensionSet ext_set;
   ASSERT_RAISES(
       Invalid,
-      DeserializePlan(
+      DeserializePlans(
           *buf, [] { return std::shared_ptr<compute::SinkNodeConsumer>{nullptr}; },
           &ext_set));
 }

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -926,7 +926,7 @@ TEST(Substrait, JoinPlanBasic) {
       checked_cast<const compute::HashJoinNodeOptions&>(*join_rel->options);
 
   EXPECT_EQ(join_rel->factory_name, "hashjoin");
-  EXPECT_EQ(compute::ToString(join_options.join_type), "INNER");
+  EXPECT_EQ(join_options.join_type, compute::JoinType::INNER);
 
   const auto& left_rel = join_rel->inputs[0].get<compute::Declaration>();
   const auto& right_rel = join_rel->inputs[1].get<compute::Declaration>();
@@ -943,7 +943,7 @@ TEST(Substrait, JoinPlanBasic) {
       r_options.dataset->schema(),
       schema({field("X", int32()), field("Y", int32()), field("A", int32())}));
 
-  EXPECT_EQ((int)join_options.key_cmp[0], (int)compute::JoinKeyCmp::EQ);
+  EXPECT_EQ(join_options.key_cmp[0], compute::JoinKeyCmp::EQ);
 }
 
 TEST(Substrait, JoinPlanInvalidKeyCmp) {

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -931,7 +931,6 @@ TEST(Substrait, JoinRel) {
       DeserializePlan(
           *buf, [] { return std::shared_ptr<compute::SinkNodeConsumer>{nullptr}; },
           &ext_set));
-
 }
 
 }  // namespace engine

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -1118,5 +1118,73 @@ TEST(Substrait, JoinPlanInvalidExpression) {
           &ext_set));
 }
 
+TEST(Substrait, JoinPlanInvalidKeys) {
+  ASSERT_OK_AND_ASSIGN(auto buf, internal::SubstraitFromJSON("Plan", R"({
+  "relations": [{
+    "rel": {
+      "join": {
+        "left": {
+          "read": {
+            "base_schema": {
+              "names": ["A", "B", "C"],
+              "struct": {
+                "types": [{
+                  "i32": {}
+                }, {
+                  "i32": {}
+                }, {
+                  "i32": {}
+                }]
+              }
+            },
+            "local_files": { 
+              "items": [
+                {
+                  "uri_file": "file:///tmp/dat1.parquet",
+                  "format": "FILE_FORMAT_PARQUET"
+                }
+              ] 
+            }
+          }
+        },
+        "expression": {
+          "scalarFunction": {
+            "functionReference": 0,
+            "args": [{
+              "selection": {
+                "directReference": {
+                  "structField": {
+                    "field": 0
+                  }
+                },
+                "rootReference": {
+                }
+              }
+            }, {
+              "selection": {
+                "directReference": {
+                  "structField": {
+                    "field": 5
+                  }
+                },
+                "rootReference": {
+                }
+              }
+            }]
+          }
+        },
+        "type": "JOIN_TYPE_INNER"
+      }
+    }
+  }]
+  })"));
+  ExtensionSet ext_set;
+  ASSERT_RAISES(
+      Invalid,
+      DeserializePlan(
+          *buf, [] { return std::shared_ptr<compute::SinkNodeConsumer>{nullptr}; },
+          &ext_set));
+}
+
 }  // namespace engine
 }  // namespace arrow

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -814,100 +814,86 @@ TEST(Substrait, InvalidPlan) {
   ASSERT_RAISES(Invalid, substrait::ExecuteSerializedPlan(*buf));
 }
 
-TEST(Substrait, JoinRel) {
+TEST(Substrait, JoinPlanBasic) {
   ASSERT_OK_AND_ASSIGN(auto buf, internal::SubstraitFromJSON("Plan", R"({
   "relations": [{
     "rel": {
-      "project": {
-        "input": {
-          "join": {
-            "left": {
-              "read": {
-                "base_schema": {
-                  "names": ["A", "B", "C"],
-                  "struct": {
-                    "types": [{
-                      "i32": {}
-                    }, {
-                      "i32": {}
-                    }, {
-                      "i32": {}
-                    }]
-                  }
-                },
-                "local_files": { "items": [] }
-              }
-            },
-            "right": {
-              "read": {
-                "base_schema": {
-                  "names": ["X", "Y", "A"],
-                  "struct": {
-                    "types": [{
-                      "i32": {}
-                    }, {
-                      "i32": {}
-                    }, {
-                      "i32": {}
-                    }]
-                  }
-                },
-                "local_files": { "items": [] }
-              }
-            },
-            "expression": {
-              "scalarFunction": {
-                "functionReference": 0,
-                "args": [{
-                  "selection": {
-                    "directReference": {
-                      "structField": {
-                        "field": 5
-                      }
-                    },
-                    "rootReference": {
-                    }
-                  }
+      "join": {
+        "left": {
+          "read": {
+            "base_schema": {
+              "names": ["A", "B", "C"],
+              "struct": {
+                "types": [{
+                  "i32": {}
                 }, {
-                  "selection": {
-                    "directReference": {
-                      "structField": {
-                        "field": 0
-                      }
-                    },
-                    "rootReference": {
-                    }
-                  }
-                }],
-                "outputType": {
-                  "bool": {}
-                }
+                  "i32": {}
+                }, {
+                  "i32": {}
+                }]
               }
             },
-            "type": "JOIN_TYPE_INNER"
+            "local_files": { 
+              "items": [
+                {
+                  "uri_file": "file:///tmp/dat1.parquet",
+                  "format": "FILE_FORMAT_PARQUET"
+                }
+              ] 
+            }
           }
         },
-        "expressions": [{
-          "selection": {
-            "directReference": {
-              "structField": {
-                "field": 1
+        "right": {
+          "read": {
+            "base_schema": {
+              "names": ["X", "Y", "A"],
+              "struct": {
+                "types": [{
+                  "i32": {}
+                }, {
+                  "i32": {}
+                }, {
+                  "i32": {}
+                }]
               }
             },
-            "rootReference": {
+            "local_files": { 
+              "items": [
+                {
+                  "uri_file": "file:///tmp/dat2.parquet",
+                  "format": "FILE_FORMAT_PARQUET"
+                }
+              ]
             }
           }
-        }, {
-          "selection": {
-            "directReference": {
-              "structField": {
-                "field": 4
+        },
+        "expression": {
+          "scalarFunction": {
+            "functionReference": 0,
+            "args": [{
+              "selection": {
+                "directReference": {
+                  "structField": {
+                    "field": 0
+                  }
+                },
+                "rootReference": {
+                }
               }
-            },
-            "rootReference": {
-            }
+            }, {
+              "selection": {
+                "directReference": {
+                  "structField": {
+                    "field": 5
+                  }
+                },
+                "rootReference": {
+                }
+              }
+            }]
           }
-        }]
+        },
+        "type": "JOIN_TYPE_INNER"
       }
     }
   }],
@@ -928,6 +914,207 @@ TEST(Substrait, JoinRel) {
   ExtensionSet ext_set;
   ASSERT_OK_AND_ASSIGN(
       auto sink_decls,
+      DeserializePlan(
+          *buf, [] { return std::shared_ptr<compute::SinkNodeConsumer>{nullptr}; },
+          &ext_set));
+
+  auto join_decl = sink_decls[0].inputs[0];
+
+  const auto& join_rel = join_decl.get<compute::Declaration>();
+
+  const auto& join_options =
+      checked_cast<const compute::HashJoinNodeOptions&>(*join_rel->options);
+
+  EXPECT_EQ(join_rel->factory_name, "hashjoin");
+  EXPECT_EQ(compute::ToString(join_options.join_type), "INNER");
+
+  const auto& left_rel = join_rel->inputs[0].get<compute::Declaration>();
+  const auto& right_rel = join_rel->inputs[1].get<compute::Declaration>();
+
+  const auto& l_options =
+      checked_cast<const dataset::ScanNodeOptions&>(*left_rel->options);
+  const auto& r_options =
+      checked_cast<const dataset::ScanNodeOptions&>(*right_rel->options);
+
+  AssertSchemaEqual(
+      l_options.dataset->schema(),
+      schema({field("A", int32()), field("B", int32()), field("C", int32())}));
+  AssertSchemaEqual(
+      r_options.dataset->schema(),
+      schema({field("X", int32()), field("Y", int32()), field("A", int32())}));
+
+  EXPECT_EQ((int)join_options.key_cmp[0], (int)compute::JoinKeyCmp::EQ);
+}
+
+TEST(Substrait, JoinPlanInvalidKeyCmp) {
+  ASSERT_OK_AND_ASSIGN(auto buf, internal::SubstraitFromJSON("Plan", R"({
+  "relations": [{
+    "rel": {
+      "join": {
+        "left": {
+          "read": {
+            "base_schema": {
+              "names": ["A", "B", "C"],
+              "struct": {
+                "types": [{
+                  "i32": {}
+                }, {
+                  "i32": {}
+                }, {
+                  "i32": {}
+                }]
+              }
+            },
+            "local_files": { 
+              "items": [
+                {
+                  "uri_file": "file:///tmp/dat1.parquet",
+                  "format": "FILE_FORMAT_PARQUET"
+                }
+              ] 
+            }
+          }
+        },
+        "right": {
+          "read": {
+            "base_schema": {
+              "names": ["X", "Y", "A"],
+              "struct": {
+                "types": [{
+                  "i32": {}
+                }, {
+                  "i32": {}
+                }, {
+                  "i32": {}
+                }]
+              }
+            },
+            "local_files": { 
+              "items": [
+                {
+                  "uri_file": "file:///tmp/dat2.parquet",
+                  "format": "FILE_FORMAT_PARQUET"
+                }
+              ]
+            }
+          }
+        },
+        "expression": {
+          "scalarFunction": {
+            "functionReference": 0,
+            "args": [{
+              "selection": {
+                "directReference": {
+                  "structField": {
+                    "field": 0
+                  }
+                },
+                "rootReference": {
+                }
+              }
+            }, {
+              "selection": {
+                "directReference": {
+                  "structField": {
+                    "field": 5
+                  }
+                },
+                "rootReference": {
+                }
+              }
+            }]
+          }
+        },
+        "type": "JOIN_TYPE_INNER"
+      }
+    }
+  }],
+  "extension_uris": [
+      {
+        "extension_uri_anchor": 0,
+        "uri": "https://github.com/apache/arrow/blob/master/format/substrait/extension_types.yaml"
+      }
+    ],
+    "extensions": [
+      {"extension_function": {
+        "extension_uri_reference": 0,
+        "function_anchor": 0,
+        "name": "add"
+      }}
+    ]
+  })"));
+  ExtensionSet ext_set;
+  ASSERT_RAISES(
+      Invalid,
+      DeserializePlan(
+          *buf, [] { return std::shared_ptr<compute::SinkNodeConsumer>{nullptr}; },
+          &ext_set));
+}
+
+//  {"literal": {"list": {"values": []}}}
+
+TEST(Substrait, JoinPlanInvalidExpression) {
+  ASSERT_OK_AND_ASSIGN(auto buf, internal::SubstraitFromJSON("Plan", R"({
+  "relations": [{
+    "rel": {
+      "join": {
+        "left": {
+          "read": {
+            "base_schema": {
+              "names": ["A", "B", "C"],
+              "struct": {
+                "types": [{
+                  "i32": {}
+                }, {
+                  "i32": {}
+                }, {
+                  "i32": {}
+                }]
+              }
+            },
+            "local_files": { 
+              "items": [
+                {
+                  "uri_file": "file:///tmp/dat1.parquet",
+                  "format": "FILE_FORMAT_PARQUET"
+                }
+              ] 
+            }
+          }
+        },
+        "right": {
+          "read": {
+            "base_schema": {
+              "names": ["X", "Y", "A"],
+              "struct": {
+                "types": [{
+                  "i32": {}
+                }, {
+                  "i32": {}
+                }, {
+                  "i32": {}
+                }]
+              }
+            },
+            "local_files": { 
+              "items": [
+                {
+                  "uri_file": "file:///tmp/dat2.parquet",
+                  "format": "FILE_FORMAT_PARQUET"
+                }
+              ]
+            }
+          }
+        },
+        "expression": {"literal": {"list": {"values": []}}},
+        "type": "JOIN_TYPE_INNER"
+      }
+    }
+  }]
+  })"));
+  ExtensionSet ext_set;
+  ASSERT_RAISES(
+      Invalid,
       DeserializePlan(
           *buf, [] { return std::shared_ptr<compute::SinkNodeConsumer>{nullptr}; },
           &ext_set));


### PR DESCRIPTION
Initial Version of Substrait Join Support

This PR doesn't support the complete join functionality, but it include the following features. 
This will be a followed by a set of PRs to solve the remaining features [1].

Features included

- [X] Only Support Inner Join (A follow up PR would include the support for other join types)
- [X] Support Join operations with a single call-expression of types "equal" and "is_not_distinct_from"
- [X] Test cases to check the basic functionality and limitations

Todo:
- [x] Fix the Windows CI Issue

[1]. https://issues.apache.org/jira/browse/ARROW-16485 