### PR TITLE
ARROW-16488: [Archery][Dev] Allow extra message to be sent on chat report

### DIFF
--- a/dev/archery/archery/crossbow/cli.py
+++ b/dev/archery/archery/crossbow/cli.py
@@ -309,10 +309,12 @@ def report(obj, job_name, sender_name, sender_email, recipient_email,
               help='Just display the report, don\'t send it')
 @click.option('--webhook', '-w',
               help='Zulip/Slack Webhook address to send the report to')
+@click.option('--extra-message', '-s', default=None,
+              help='Extra message information, will be appended.')
 @click.option('--fetch/--no-fetch', default=True,
               help='Fetch references (branches and tags) from the remote')
 @click.pass_obj
-def report_chat(obj, job_name, send, webhook, fetch):
+def report_chat(obj, job_name, send, webhook, extra_message, fetch):
     """
     Send a chat report to a webhook showing success/failure
     of tasks in a Crossbow run.
@@ -323,7 +325,7 @@ def report_chat(obj, job_name, send, webhook, fetch):
         queue.fetch()
 
     job = queue.get(job_name)
-    report_chat = ChatReport(report=Report(job))
+    report_chat = ChatReport(report=Report(job), extra_message=extra_message)
     if send:
         ReportUtils.send_message(webhook, report_chat.render("text"))
     else:

--- a/dev/archery/archery/crossbow/reports.py
+++ b/dev/archery/archery/crossbow/reports.py
@@ -173,6 +173,7 @@ class ChatReport(JinjaReport):
     }
     fields = [
         'report',
+        'extra_message',
     ]
 
 

--- a/dev/archery/archery/crossbow/tests/fixtures/chat-report-extra-message.txt
+++ b/dev/archery/archery/crossbow/tests/fixtures/chat-report-extra-message.txt
@@ -10,3 +10,5 @@
 :warning: *1 pending jobs*
 
 :tada: *1 successful jobs*
+
+This message is extended

--- a/dev/archery/archery/crossbow/tests/test_reports.py
+++ b/dev/archery/archery/crossbow/tests/test_reports.py
@@ -40,6 +40,17 @@ def test_crossbow_report(load_fixture):
     job = load_fixture('crossbow-job.yaml', decoder=yaml.load)
     report = Report(job)
     assert report.tasks_by_state is not None
-    report_chat = ChatReport(report=report)
+    report_chat = ChatReport(report=report, extra_message=None)
+
+    assert report_chat.render("text") == textwrap.dedent(expected_msg)
+
+
+def test_crossbow_chat_report_extra_message(load_fixture):
+    expected_msg = load_fixture('chat-report-extra-message.txt')
+    job = load_fixture('crossbow-job.yaml', decoder=yaml.load)
+    report = Report(job)
+    assert report.tasks_by_state is not None
+    report_chat = ChatReport(report=report,
+                             extra_message="This message is extended")
 
     assert report_chat.render("text") == textwrap.dedent(expected_msg)

--- a/dev/archery/archery/templates/chat_nightly_report.txt.j2
+++ b/dev/archery/archery/templates/chat_nightly_report.txt.j2
@@ -29,3 +29,6 @@
 :warning: *{{ report.tasks_by_state["pending"] | length }} pending jobs*
 
 :tada: *{{ report.tasks_by_state["success"] | length }} successful jobs*
+{% if extra_message %}
+{{ extra_message }}
+{% endif %}


### PR DESCRIPTION
This PR allows an extra CLI argument `--extra-message` to be used when sending a chat report in order to append content to the message being sent.