### PR TITLE
ARROW-16490: [C++][Windows] Don't force to use bundled GoogleTest

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -77,14 +77,6 @@ set(ARROW_THIRDPARTY_DEPENDENCIES
     ZLIB
     zstd)
 
-# TODO(wesm): External GTest shared libraries are not currently
-# supported when building with MSVC because of the way that
-# conda-forge packages have 4 variants of the libraries packaged
-# together
-if(MSVC AND "${GTest_SOURCE}" STREQUAL "")
-  set(GTest_SOURCE "BUNDLED")
-endif()
-
 # For backward compatibility. We use "BOOST_SOURCE" if "Boost_SOURCE"
 # isn't specified and "BOOST_SOURCE" is specified.
 # We renamed "BOOST" dependency name to "Boost" in 3.0.0 because

--- a/dev/tasks/vcpkg-tests/github.windows.yml
+++ b/dev/tasks/vcpkg-tests/github.windows.yml
@@ -35,6 +35,9 @@ jobs:
           git -C arrow fetch -t {{ arrow.remote }} {{ arrow.branch }}
           git -C arrow checkout FETCH_HEAD
           git -C arrow submodule update --init --recursive
+      - name: Download Timezone Database
+        shell: bash
+        run: arrow/ci/scripts/download_tz_database.sh
       - name: Remove and Reinstall vcpkg
         # When running vcpkg in Github Actions on Windows, remove the
         # preinstalled vcpkg and install the newest version from source.


### PR DESCRIPTION
It seems that conda-forge's GoogleTest package for Windows solved the problem we encountered.

We can use GoogleTest installed by vcpkg by removing the workaround.