### PR TITLE
ARROW-16494: [C++] Add missing include that is making some packaging jobs fail

### DIFF
--- a/cpp/src/arrow/dataset/file_csv.cc
+++ b/cpp/src/arrow/dataset/file_csv.cc
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <unordered_set>
 #include <utility>


### PR DESCRIPTION
This PR tries to fix the issue that has been raised on some packaging builds like:
- [conda-linux-gcc-py310-cuda](https://github.com/ursacomputing/crossbow/runs/6321523101)
- [conda-linux-gcc-py310-ppc64le](https://github.com/ursacomputing/crossbow/runs/6321445819)
- [conda-linux-gcc-py37-arm64](https://github.com/ursacomputing/crossbow/runs/6322824420)
- [conda-linux-gcc-py37-cpu-r40](https://github.com/ursacomputing/crossbow/runs/6321760095)