### PR TITLE
MINOR: [R] Don't use warning() in .onLoad()

### DIFF
--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -76,7 +76,7 @@
       tzdb::tzdb_initialize()
       set_timezone_database(tzdb::tzdb_path("text"))
     } else {
-      warning("The tzdb package is not installed. Timezones will not be available.")
+      packageStartupMessage("The tzdb package is not installed. Timezones will not be available.")
     }
   }
 


### PR DESCRIPTION
According to the [docs](https://stat.ethz.ch/R-manual/R-devel/library/base/html/ns-hooks.html), `packageStartupMessage()` is preferred. With `warning()`, it can show up in the `R CMD INSTALL` output like this:

```
installing to D:/a/_temp/Library/00LOCK-arrow/00new/arrow/libs/x64
** R
** inst
** byte-compile and prepare package for lazy loading
** help
*** installing help indices
** building package indices
** installing vignettes
** testing if installed package can be loaded from temporary location
Warning in fun(libname, pkgname) :
  The tzdb package is not installed. Timezones will not be available.
** testing if installed package can be loaded from final location
Warning in fun(libname, pkgname) :
** testing if installed package keeps a record of temporary installation path
  The tzdb package is not installed. Timezones will not be available.
* MD5 sums
packaged installation of 'arrow' as arrow_7.0.0.20220505.zip
* DONE (arrow)
```

I will cherry-pick when preparing the 8.0.0 CRAN submission