### PR TITLE
ARROW-16487: [C++][Parquet] Fix parquet::Statistics::Equals() with minmax

### DIFF
--- a/c_glib/test/parquet/test-statistics.rb
+++ b/c_glib/test/parquet/test-statistics.rb
@@ -31,7 +31,6 @@ class TestParquetStatistics < Test::Unit::TestCase
   end
 
   test("#==") do
-    omit("parquet::Statistics::Equals() is broken.")
     reader = Parquet::ArrowFileReader.new(@file.path)
     other_statistics =
       reader.metadata.get_row_group(0).get_column_chunk(0).statistics

--- a/cpp/src/parquet/statistics.cc
+++ b/cpp/src/parquet/statistics.cc
@@ -527,8 +527,11 @@ class TypedStatisticsImpl : public TypedStatistics<DType> {
     const auto& other = checked_cast<const TypedStatisticsImpl&>(raw_other);
 
     if (has_min_max_ != other.has_min_max_) return false;
+    if (has_min_max_) {
+      if (!MinMaxEqual(other)) return false;
+    }
 
-    return (has_min_max_ && MinMaxEqual(other)) && null_count() == other.null_count() &&
+    return null_count() == other.null_count() &&
            distinct_count() == other.distinct_count() &&
            num_values() == other.num_values();
   }
@@ -672,7 +675,7 @@ inline bool TypedStatisticsImpl<FLBAType>::MinMaxEqual(
 template <typename DType>
 bool TypedStatisticsImpl<DType>::MinMaxEqual(
     const TypedStatisticsImpl<DType>& other) const {
-  return min_ != other.min_ && max_ != other.max_;
+  return min_ == other.min_ && max_ == other.max_;
 }
 
 template <>

--- a/cpp/src/parquet/statistics_test.cc
+++ b/cpp/src/parquet/statistics_test.cc
@@ -377,6 +377,24 @@ class TestStatistics : public PrimitiveTypedTest<TestType> {
     ASSERT_EQ(total->max(), std::max(statistics1->max(), statistics2->max()));
   }
 
+  void TestEquals() {
+    const auto n_values = 1;
+    auto statistics_have_minmax1 = MakeStatistics<TestType>(this->schema_.Column(0));
+    const auto seed1 = 1;
+    this->GenerateData(n_values, seed1);
+    statistics_have_minmax1->Update(this->values_ptr_, this->values_.size(), 0);
+    auto statistics_have_minmax2 = MakeStatistics<TestType>(this->schema_.Column(0));
+    const auto seed2 = 9999;
+    this->GenerateData(n_values, seed2);
+    statistics_have_minmax2->Update(this->values_ptr_, this->values_.size(), 0);
+    auto statistics_no_minmax = MakeStatistics<TestType>(this->schema_.Column(0));
+
+    ASSERT_EQ(true, statistics_have_minmax1->Equals(*statistics_have_minmax1));
+    ASSERT_EQ(true, statistics_no_minmax->Equals(*statistics_no_minmax));
+    ASSERT_EQ(false, statistics_have_minmax1->Equals(*statistics_have_minmax2));
+    ASSERT_EQ(false, statistics_have_minmax1->Equals(*statistics_no_minmax));
+  }
+
   void TestFullRoundtrip(int64_t num_values, int64_t null_count) {
     this->GenerateData(num_values);
 
@@ -543,6 +561,11 @@ TYPED_TEST(TestStatistics, Reset) {
   ASSERT_NO_FATAL_FAILURE(this->TestReset());
 }
 
+TYPED_TEST(TestStatistics, Equals) {
+  this->SetUpSchema(Repetition::OPTIONAL);
+  ASSERT_NO_FATAL_FAILURE(this->TestEquals());
+}
+
 TYPED_TEST(TestStatistics, FullRoundtrip) {
   this->SetUpSchema(Repetition::OPTIONAL);
   ASSERT_NO_FATAL_FAILURE(this->TestFullRoundtrip(100, 31));
@@ -560,6 +583,11 @@ TYPED_TEST_SUITE(TestNumericStatistics, NumericTypes);
 TYPED_TEST(TestNumericStatistics, Merge) {
   this->SetUpSchema(Repetition::OPTIONAL);
   ASSERT_NO_FATAL_FAILURE(this->TestMerge());
+}
+
+TYPED_TEST(TestNumericStatistics, Equals) {
+  this->SetUpSchema(Repetition::OPTIONAL);
+  ASSERT_NO_FATAL_FAILURE(this->TestEquals());
 }
 
 // Helper for basic statistics tests below


### PR DESCRIPTION
The following cases return wrong result:

* statistics_no_minmax.Equals(statistics_no_minmax):
  This must returns true but false is returned.
* statistics_minmax.Equals(statistics_minmax):
  This must returns true but false is returned.
* statistics_minmax1.Equals(statistics_minmax2) where
  statistics_minmax1 and statistics_minmax2 have different minmax:
  This must returns false but true is returned.
  
Note that parquet::Statistics::Equals() was introduced by
https://github.com/apache/arrow/pull/8507 .