### PR TITLE
ARROW-16085: [C++][R] InMemoryDataset::ReplaceSchema does not alter scan output

### DIFF
--- a/cpp/src/arrow/dataset/dataset.cc
+++ b/cpp/src/arrow/dataset/dataset.cc
@@ -202,11 +202,6 @@ Result<FragmentIterator> InMemoryDataset::GetFragmentsImpl(compute::Expression) 
 
   auto create_fragment =
       [schema](std::shared_ptr<RecordBatch> batch) -> Result<std::shared_ptr<Fragment>> {
-    if (!batch->schema()->Equals(schema)) {
-      return Status::TypeError("yielded batch had schema ", *batch->schema(),
-                               " which did not match InMemorySource's: ", *schema);
-    }
-
     return std::make_shared<InMemoryFragment>(RecordBatchVector{std::move(batch)});
   };
 

--- a/cpp/src/arrow/dataset/dataset.cc
+++ b/cpp/src/arrow/dataset/dataset.cc
@@ -202,6 +202,7 @@ Result<FragmentIterator> InMemoryDataset::GetFragmentsImpl(compute::Expression) 
 
   auto create_fragment =
       [schema](std::shared_ptr<RecordBatch> batch) -> Result<std::shared_ptr<Fragment>> {
+    RETURN_NOT_OK(CheckProjectable(*schema, *batch->schema()));
     return std::make_shared<InMemoryFragment>(RecordBatchVector{std::move(batch)});
   };
 

--- a/cpp/src/arrow/dataset/dataset_test.cc
+++ b/cpp/src/arrow/dataset/dataset_test.cc
@@ -117,7 +117,7 @@ TEST_F(TestInMemoryDataset, HandlesDifferingSchemas) {
   // These schemas can be merged
   SetSchema({field("i32", int32()), field("f64", float64())});
   auto batch1 = ConstantArrayGenerator::Zeroes(kBatchSize, schema_);
-  SetSchema({field("i32", int64())});
+  SetSchema({field("i32", int32())});
   auto batch2 = ConstantArrayGenerator::Zeroes(kBatchSize, schema_);
   RecordBatchVector batches{batch1, batch2};
 
@@ -140,7 +140,9 @@ TEST_F(TestInMemoryDataset, HandlesDifferingSchemas) {
 
   ASSERT_OK_AND_ASSIGN(scanner_builder, dataset->NewScan());
   ASSERT_OK_AND_ASSIGN(scanner, scanner_builder->Finish());
-  ASSERT_NOT_OK(scanner->ToTable());
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      TypeError, testing::HasSubstr("fields had matching names but differing types"),
+      scanner->ToTable());
 }
 
 class TestUnionDataset : public DatasetFixtureMixin {};

--- a/cpp/src/arrow/dataset/dataset_test.cc
+++ b/cpp/src/arrow/dataset/dataset_test.cc
@@ -62,9 +62,13 @@ TEST_F(TestInMemoryDataset, ReplaceSchema) {
       schema_, RecordBatchVector{static_cast<size_t>(kNumberBatches), batch});
 
   // drop field
-  ASSERT_OK(dataset->ReplaceSchema(schema({field("i32", int32())})).status());
+  auto new_schema = schema({field("i32", int32())});
+  ASSERT_OK_AND_ASSIGN(auto new_dataset, dataset->ReplaceSchema(new_schema));
+  AssertDatasetHasSchema(new_dataset, new_schema);
   // add field (will be materialized as null during projection)
-  ASSERT_OK(dataset->ReplaceSchema(schema({field("str", utf8())})).status());
+  new_schema = schema({field("str", utf8())});
+  ASSERT_OK_AND_ASSIGN(new_dataset, dataset->ReplaceSchema(new_schema));
+  AssertDatasetHasSchema(new_dataset, new_schema);
   // incompatible type
   ASSERT_RAISES(TypeError,
                 dataset->ReplaceSchema(schema({field("i32", utf8())})).status());
@@ -131,9 +135,13 @@ TEST_F(TestUnionDataset, ReplaceSchema) {
   AssertDatasetEquals(reader.get(), dataset.get());
 
   // drop field
-  ASSERT_OK(dataset->ReplaceSchema(schema({field("i32", int32())})).status());
+  auto new_schema = schema({field("i32", int32())});
+  ASSERT_OK_AND_ASSIGN(auto new_dataset, dataset->ReplaceSchema(new_schema));
+  AssertDatasetHasSchema(new_dataset, new_schema);
   // add nullable field (will be materialized as null during projection)
-  ASSERT_OK(dataset->ReplaceSchema(schema({field("str", utf8())})).status());
+  new_schema = schema({field("str", utf8())});
+  ASSERT_OK_AND_ASSIGN(new_dataset, dataset->ReplaceSchema(new_schema));
+  AssertDatasetHasSchema(new_dataset, new_schema);
   // incompatible type
   ASSERT_RAISES(TypeError,
                 dataset->ReplaceSchema(schema({field("i32", utf8())})).status());

--- a/cpp/src/arrow/dataset/file_test.cc
+++ b/cpp/src/arrow/dataset/file_test.cc
@@ -148,9 +148,13 @@ TEST_F(TestFileSystemDataset, ReplaceSchema) {
                        FileSystemDataset::Make(schm, literal(true), format, nullptr, {}));
 
   // drop field
-  ASSERT_OK(dataset->ReplaceSchema(schema({field("i32", int32())})).status());
+  auto new_schema = schema({field("i32", int32())});
+  ASSERT_OK_AND_ASSIGN(auto new_dataset, dataset->ReplaceSchema(new_schema));
+  AssertDatasetHasSchema(new_dataset, new_schema);
   // add nullable field (will be materialized as null during projection)
-  ASSERT_OK(dataset->ReplaceSchema(schema({field("str", utf8())})).status());
+  new_schema = schema({field("str", utf8())});
+  ASSERT_OK_AND_ASSIGN(new_dataset, dataset->ReplaceSchema(new_schema));
+  AssertDatasetHasSchema(new_dataset, new_schema);
   // incompatible type
   ASSERT_RAISES(TypeError,
                 dataset->ReplaceSchema(schema({field("i32", utf8())})).status());

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -282,6 +282,15 @@ class DatasetFixtureMixin : public ::testing::Test {
     }
   }
 
+  /// \brief Assert a dataset produces data with the schema
+  void AssertDatasetHasSchema(std::shared_ptr<Dataset> ds,
+                              std::shared_ptr<Schema> schema) {
+    ASSERT_OK_AND_ASSIGN(auto scanner_builder, ds->NewScan());
+    ASSERT_OK_AND_ASSIGN(auto scanner, scanner_builder->Finish());
+    ASSERT_OK_AND_ASSIGN(auto table, scanner->ToTable());
+    ASSERT_EQ(table->schema(), schema);
+  }
+
  protected:
   void SetSchema(std::vector<std::shared_ptr<Field>> fields) {
     schema_ = schema(std::move(fields));

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -81,6 +81,16 @@ using compute::project;
 
 using fs::internal::GetAbstractPathExtension;
 
+/// \brief Assert a dataset produces data with the schema
+void AssertDatasetHasSchema(std::shared_ptr<Dataset> ds, std::shared_ptr<Schema> schema) {
+  ASSERT_OK_AND_ASSIGN(auto scanner_builder, ds->NewScan());
+  // ASSERT_EQ(scanner_builder->projected_schema(), schema);
+  ASSERT_OK_AND_ASSIGN(auto scanner, scanner_builder->Finish());
+  // ASSERT_EQ(scanner->options()->projected_schema, schema);
+  ASSERT_OK_AND_ASSIGN(auto table, scanner->ToTable());
+  ASSERT_EQ(*table->schema(), *schema);
+}
+
 class FileSourceFixtureMixin : public ::testing::Test {
  public:
   std::unique_ptr<FileSource> GetSource(std::shared_ptr<Buffer> buffer) {
@@ -280,15 +290,6 @@ class DatasetFixtureMixin : public ::testing::Test {
     if (ensure_drained) {
       EnsureRecordBatchReaderDrained(expected);
     }
-  }
-
-  /// \brief Assert a dataset produces data with the schema
-  void AssertDatasetHasSchema(std::shared_ptr<Dataset> ds,
-                              std::shared_ptr<Schema> schema) {
-    ASSERT_OK_AND_ASSIGN(auto scanner_builder, ds->NewScan());
-    ASSERT_OK_AND_ASSIGN(auto scanner, scanner_builder->Finish());
-    ASSERT_OK_AND_ASSIGN(auto table, scanner->ToTable());
-    ASSERT_EQ(table->schema(), schema);
   }
 
  protected:

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -84,9 +84,7 @@ using fs::internal::GetAbstractPathExtension;
 /// \brief Assert a dataset produces data with the schema
 void AssertDatasetHasSchema(std::shared_ptr<Dataset> ds, std::shared_ptr<Schema> schema) {
   ASSERT_OK_AND_ASSIGN(auto scanner_builder, ds->NewScan());
-  // ASSERT_EQ(scanner_builder->projected_schema(), schema);
   ASSERT_OK_AND_ASSIGN(auto scanner, scanner_builder->Finish());
-  // ASSERT_EQ(scanner->options()->projected_schema, schema);
   ASSERT_OK_AND_ASSIGN(auto table, scanner->ToTable());
   ASSERT_EQ(*table->schema(), *schema);
 }

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -608,7 +608,7 @@ test_that("UnionDataset handles InMemoryDatasets", {
   ds1 <- InMemoryDataset$create(sub_df1)
   ds2 <- InMemoryDataset$create(sub_df2)
   ds <- c(ds1, ds2)
-  actual <- ds %>% collect()
+  actual <- ds %>% collect(as_data_frame = FALSE)
   expected <- concat_tables(sub_df1, sub_df2)
   expect_equal(actual, expected)
 })

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -595,6 +595,24 @@ test_that("UnionDataset can merge schemas", {
   expect_equal(actual, expected)
 })
 
+test_that("UnionDataset handles InMemoryDatasets", {
+  sub_df1 <- Table$create(
+    x = Array$create(c(1, 2, 3)),
+    y = Array$create(c("a", "b", "c"))
+  )
+  sub_df2 <- Table$create(
+    x = Array$create(c(4, 5)),
+    z = Array$create(c("d", "e"))
+  )
+
+  ds1 <- InMemoryDataset$create(sub_df1)
+  ds2 <- InMemoryDataset$create(sub_df2)
+  ds <- c(ds1, ds2)
+  actual <- ds %>% collect()
+  expected <- concat_tables(sub_df1, sub_df2)
+  expect_equal(actual, expected)
+})
+
 test_that("map_batches", {
   ds <- open_dataset(dataset_dir, partitioning = "part")
 


### PR DESCRIPTION
Feels a little funny that deleting this code just makes it work, so I added a decent number of tests to make sure differing schemas are handled. LMK if you think I missed something.