### PR TITLE
ARROW-15622: [R] Implement union_all and union for arrow_dplyr_query

### DIFF
--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -109,6 +109,7 @@ Collate:
     'dplyr-mutate.R'
     'dplyr-select.R'
     'dplyr-summarize.R'
+    'dplyr-union.R'
     'record-batch.R'
     'table.R'
     'dplyr.R'

--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -41,7 +41,7 @@
       "group_vars", "group_by_drop_default", "ungroup", "mutate", "transmute",
       "arrange", "rename", "pull", "relocate", "compute", "collapse",
       "distinct", "left_join", "right_join", "inner_join", "full_join",
-      "semi_join", "anti_join", "count", "tally", "rename_with"
+      "semi_join", "anti_join", "count", "tally", "rename_with", "union", "union_all"
     )
   )
   for (cl in c("Dataset", "ArrowTabular", "RecordBatchReader", "arrow_dplyr_query")) {

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -440,6 +440,10 @@ ExecNode_Join <- function(input, type, right_data, left_keys, right_keys, left_o
   .Call(`_arrow_ExecNode_Join`, input, type, right_data, left_keys, right_keys, left_output, right_output, output_suffix_for_left, output_suffix_for_right)
 }
 
+ExecNode_Union <- function(input, right_data) {
+  .Call(`_arrow_ExecNode_Union`, input, right_data)
+}
+
 ExecNode_SourceNode <- function(plan, reader) {
   .Call(`_arrow_ExecNode_SourceNode`, plan, reader)
 }
@@ -2003,4 +2007,3 @@ SetIOThreadPoolCapacity <- function(threads) {
 Array__infer_type <- function(x) {
   .Call(`_arrow_Array__infer_type`, x)
 }
-

--- a/r/R/dplyr-union.R
+++ b/r/R/dplyr-union.R
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# The following S3 methods are registered on load if dplyr is present
+
 union.arrow_dplyr_query <- function(x, y, ...) {
   x <- as_adq(x)
   y <- as_adq(y)

--- a/r/R/dplyr-union.R
+++ b/r/R/dplyr-union.R
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+union.arrow_dplyr_query <- function(x, y, ...) {
+  x <- as_adq(x)
+  y <- as_adq(y)
+
+  distinct(union_all(x, y))
+}
+
+union.Dataset <- union.ArrowTabular <- union.RecordBatchReader <- union.arrow_dplyr_query
+
+union_all.arrow_dplyr_query <- function(x, y, ...) {
+  x <- as_adq(x)
+  y <- as_adq(y)
+
+  x$union_all <- list(right_data = y)
+  collapse.arrow_dplyr_query(x)
+}
+
+union_all.Dataset <- union_all.ArrowTabular <- union_all.RecordBatchReader <- union_all.arrow_dplyr_query

--- a/r/R/query-engine.R
+++ b/r/R/query-engine.R
@@ -138,6 +138,10 @@ ExecPlan <- R6Class("ExecPlan",
             right_suffix = .data$join$suffix[[2]]
           )
         }
+
+        if (!is.null(.data$union_all)) {
+          node <- node$UnionAll(self$Build(.data$union_all$right_data))
+        }
       }
 
       # Apply sorting: this is currently not an ExecNode itself, it is a
@@ -271,6 +275,9 @@ ExecNode <- R6Class("ExecNode",
           output_suffix_for_right = right_suffix
         )
       )
+    },
+    UnionAll = function(right_node) {
+      self$preserve_sort(ExecNode_Union(self, right_node))
     }
   ),
   active = list(

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -991,6 +991,15 @@ BEGIN_CPP11
 END_CPP11
 }
 // compute-exec.cpp
+std::shared_ptr<compute::ExecNode> ExecNode_Union(const std::shared_ptr<compute::ExecNode>& input, const std::shared_ptr<compute::ExecNode>& right_data);
+extern "C" SEXP _arrow_ExecNode_Union(SEXP input_sexp, SEXP right_data_sexp){
+BEGIN_CPP11
+	arrow::r::Input<const std::shared_ptr<compute::ExecNode>&>::type input(input_sexp);
+	arrow::r::Input<const std::shared_ptr<compute::ExecNode>&>::type right_data(right_data_sexp);
+	return cpp11::as_sexp(ExecNode_Union(input, right_data));
+END_CPP11
+}
+// compute-exec.cpp
 std::shared_ptr<compute::ExecNode> ExecNode_SourceNode(const std::shared_ptr<compute::ExecPlan>& plan, const std::shared_ptr<arrow::RecordBatchReader>& reader);
 extern "C" SEXP _arrow_ExecNode_SourceNode(SEXP plan_sexp, SEXP reader_sexp){
 BEGIN_CPP11
@@ -5212,6 +5221,7 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_ExecNode_Project", (DL_FUNC) &_arrow_ExecNode_Project, 3}, 
 		{ "_arrow_ExecNode_Aggregate", (DL_FUNC) &_arrow_ExecNode_Aggregate, 5}, 
 		{ "_arrow_ExecNode_Join", (DL_FUNC) &_arrow_ExecNode_Join, 9}, 
+		{ "_arrow_ExecNode_Union", (DL_FUNC) &_arrow_ExecNode_Union, 2}, 
 		{ "_arrow_ExecNode_SourceNode", (DL_FUNC) &_arrow_ExecNode_SourceNode, 2}, 
 		{ "_arrow_ExecNode_TableSourceNode", (DL_FUNC) &_arrow_ExecNode_TableSourceNode, 2}, 
 		{ "_arrow_substrait__internal__SubstraitToJSON", (DL_FUNC) &_arrow_substrait__internal__SubstraitToJSON, 1}, 

--- a/r/src/compute-exec.cpp
+++ b/r/src/compute-exec.cpp
@@ -311,8 +311,8 @@ std::shared_ptr<compute::ExecNode> ExecNode_Join(
 
 // [[arrow::export]]
 std::shared_ptr<compute::ExecNode> ExecNode_Union(
-  const std::shared_ptr<compute::ExecNode>& input,
-  const std::shared_ptr<compute::ExecNode>& right_data) {
+    const std::shared_ptr<compute::ExecNode>& input,
+    const std::shared_ptr<compute::ExecNode>& right_data) {
   return MakeExecNodeOrStop("union", input->plan(), {input.get(), right_data.get()}, {});
 }
 

--- a/r/src/compute-exec.cpp
+++ b/r/src/compute-exec.cpp
@@ -310,6 +310,13 @@ std::shared_ptr<compute::ExecNode> ExecNode_Join(
 }
 
 // [[arrow::export]]
+std::shared_ptr<compute::ExecNode> ExecNode_Union(
+  const std::shared_ptr<compute::ExecNode>& input,
+  const std::shared_ptr<compute::ExecNode>& right_data) {
+  return MakeExecNodeOrStop("union", input->plan(), {input.get(), right_data.get()}, {});
+}
+
+// [[arrow::export]]
 std::shared_ptr<compute::ExecNode> ExecNode_SourceNode(
     const std::shared_ptr<compute::ExecPlan>& plan,
     const std::shared_ptr<arrow::RecordBatchReader>& reader) {

--- a/r/tests/testthat/test-dplyr-union.R
+++ b/r/tests/testthat/test-dplyr-union.R
@@ -19,6 +19,8 @@ skip_if(on_old_windows())
 
 library(dplyr, warn.conflicts = FALSE)
 
+withr::local_options(list(arrow.summarise.sort = FALSE))
+
 test_that("union_all", {
   compare_dplyr_binding(
     .input %>%

--- a/r/tests/testthat/test-dplyr-union.R
+++ b/r/tests/testthat/test-dplyr-union.R
@@ -26,6 +26,23 @@ test_that("union_all", {
       collect(),
     example_data
   )
+
+  test_table <- arrow_table(x = 1:10)
+
+  # Union with empty table produces same dataset
+  expect_equal(
+    test_table |>
+      union_all(test_table$Slice(0, 0)) |>
+      collect(test_table, as_data_frame = FALSE),
+    test_table
+  )
+
+  expect_error(
+    test_table |>
+      union_all(arrow_table(y = 1:10)) |>
+      collect(),
+    regex = "input schemas must all match"
+  )
 })
 
 test_that("union", {
@@ -34,5 +51,22 @@ test_that("union", {
       dplyr::union(example_data) %>%
       collect(),
     example_data
+  )
+
+  test_table <- arrow_table(x = 1:10)
+
+  # Union with empty table produces same dataset
+  expect_equal(
+    test_table |>
+      dplyr::union(test_table$Slice(0, 0)) |>
+      collect(test_table, as_data_frame = FALSE),
+    test_table
+  )
+
+  expect_error(
+    test_table |>
+      dplyr::union(arrow_table(y = 1:10)) |>
+      collect(),
+    regex = "input schemas must all match"
   )
 })

--- a/r/tests/testthat/test-dplyr-union.R
+++ b/r/tests/testthat/test-dplyr-union.R
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+skip_if(on_old_windows())
+
+library(dplyr, warn.conflicts = FALSE)
+
+test_that("union_all", {
+  compare_dplyr_binding(
+    .input %>%
+      union_all(example_data) %>%
+      collect(),
+    example_data
+  )
+})
+
+test_that("union", {
+  compare_dplyr_binding(
+    .input %>%
+      dplyr::union(example_data) %>%
+      collect(),
+    example_data
+  )
+})

--- a/r/tests/testthat/test-dplyr-union.R
+++ b/r/tests/testthat/test-dplyr-union.R
@@ -35,7 +35,7 @@ test_that("union_all", {
   expect_equal(
     test_table %>%
       union_all(test_table$Slice(0, 0)) %>%
-      collect(test_table, as_data_frame = FALSE),
+      compute(),
     test_table
   )
 
@@ -61,7 +61,7 @@ test_that("union", {
   expect_equal(
     test_table %>%
       dplyr::union(test_table$Slice(0, 0)) %>%
-      collect(test_table, as_data_frame = FALSE),
+      compute(),
     test_table
   )
 

--- a/r/tests/testthat/test-dplyr-union.R
+++ b/r/tests/testthat/test-dplyr-union.R
@@ -31,15 +31,15 @@ test_that("union_all", {
 
   # Union with empty table produces same dataset
   expect_equal(
-    test_table |>
-      union_all(test_table$Slice(0, 0)) |>
+    test_table %>%
+      union_all(test_table$Slice(0, 0)) %>%
       collect(test_table, as_data_frame = FALSE),
     test_table
   )
 
   expect_error(
-    test_table |>
-      union_all(arrow_table(y = 1:10)) |>
+    test_table %>%
+      union_all(arrow_table(y = 1:10)) %>%
       collect(),
     regex = "input schemas must all match"
   )
@@ -57,15 +57,15 @@ test_that("union", {
 
   # Union with empty table produces same dataset
   expect_equal(
-    test_table |>
-      dplyr::union(test_table$Slice(0, 0)) |>
+    test_table %>%
+      dplyr::union(test_table$Slice(0, 0)) %>%
       collect(test_table, as_data_frame = FALSE),
     test_table
   )
 
   expect_error(
-    test_table |>
-      dplyr::union(arrow_table(y = 1:10)) |>
+    test_table %>%
+      dplyr::union(arrow_table(y = 1:10)) %>%
       collect(),
     regex = "input schemas must all match"
   )


### PR DESCRIPTION
This PR adds support for `dplyr::union` and `dplyr::union_all`. Not sure why, but I find I must use the fully qualified name `dplyr::union` or else will get an error.