### PR TITLE
ARROW-16500: [Release][R] Don't use GNU sed extension for r/NEWS.md update

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -58,9 +58,16 @@ jobs:
         run: archery docker push ubuntu-lint
 
   release:
-    name: Source Release and Merge Script
-    runs-on: ubuntu-20.04
+    name: Source Release and Merge Script on ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.runs-on }}
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on:
+          - macos-latest
+          - ubuntu-latest
     env:
       GIT_AUTHOR_NAME: Github Actions
       GIT_AUTHOR_EMAIL: github@actions
@@ -68,7 +75,7 @@ jobs:
       GIT_COMMITTER_EMAIL: github@actions
     steps:
       - name: Checkout Arrow
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Install Python
@@ -78,7 +85,11 @@ jobs:
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.6'
+          ruby-version: '2.7'
+      - name: Install .NET
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: '6.0.x'
       - name: Install Dependencies
         shell: bash
         run: |

--- a/dev/release/utils-prepare.sh
+++ b/dev/release/utils-prepare.sh
@@ -129,12 +129,12 @@ update_versions() {
   git add DESCRIPTION
   # Replace dev version with release version
   sed -i.bak -E -e \
-    "0,/^# arrow /s/^# arrow .+/# arrow ${base_version}/" \
+    "/^<!--/,/^# arrow /s/^# arrow .+/# arrow ${base_version}/" \
     NEWS.md
   if [ ${type} = "snapshot" ]; then
     # Add a news entry for the new dev version
     sed -i.bak -E -e \
-      "0,/^# arrow /s/^(# arrow .+)/# arrow ${r_version}\n\n\1/" \
+      "/^<!--/,/^# arrow /s/^(# arrow .+)/# arrow ${r_version}\n\n\1/" \
       NEWS.md
   fi
   rm -f NEWS.md.bak


### PR DESCRIPTION
We should not '0,/.../' syntax for updating r/NEWS.md because it's a
GNU sed extension. If we use it, our release script doesn't work on
macOS that uses BSD sed.