### PR TITLE
ARROW-16504 [Go][CSV] Add arrow.TimestampType support to the reader

### DIFF
--- a/go/arrow/csv/common.go
+++ b/go/arrow/csv/common.go
@@ -118,6 +118,18 @@ func WithHeader(useHeader bool) Option {
 	}
 }
 
+// WithTimestampUnit specifies the timestamp unit used while parsing CSV files.
+func WithTimestampUnit(unit arrow.TimeUnit) Option {
+	return func(cfg config) {
+		switch cfg := cfg.(type) {
+		case *Reader:
+			cfg.timestampUnit = unit
+		default:
+			panic(fmt.Errorf("arrow/csv: unknown config type %T", cfg))
+		}
+	}
+}
+
 // DefaultNullValues is the set of values considered as NULL values by default
 // when Reader is configured to handle NULL values.
 var DefaultNullValues = []string{"", "NULL", "null"}
@@ -167,6 +179,7 @@ func validate(schema *arrow.Schema) {
 		case *arrow.Uint8Type, *arrow.Uint16Type, *arrow.Uint32Type, *arrow.Uint64Type:
 		case *arrow.Float32Type, *arrow.Float64Type:
 		case *arrow.StringType:
+		case *arrow.TimestampType:
 		default:
 			panic(fmt.Errorf("arrow/csv: field %d (%s) has invalid data type %T", i, f.Name, ft))
 		}

--- a/go/arrow/csv/common.go
+++ b/go/arrow/csv/common.go
@@ -118,18 +118,6 @@ func WithHeader(useHeader bool) Option {
 	}
 }
 
-// WithTimestampUnit specifies the timestamp unit used while parsing CSV files.
-func WithTimestampUnit(unit arrow.TimeUnit) Option {
-	return func(cfg config) {
-		switch cfg := cfg.(type) {
-		case *Reader:
-			cfg.timestampUnit = unit
-		default:
-			panic(fmt.Errorf("arrow/csv: unknown config type %T", cfg))
-		}
-	}
-}
-
 // DefaultNullValues is the set of values considered as NULL values by default
 // when Reader is configured to handle NULL values.
 var DefaultNullValues = []string{"", "NULL", "null"}

--- a/go/arrow/csv/reader_test.go
+++ b/go/arrow/csv/reader_test.go
@@ -201,6 +201,7 @@ func testCSVReader(t *testing.T, filepath string, withHeader bool) {
 			arrow.Field{Name: "f32", Type: arrow.PrimitiveTypes.Float32},
 			arrow.Field{Name: "f64", Type: arrow.PrimitiveTypes.Float64},
 			arrow.Field{Name: "str", Type: arrow.BinaryTypes.String},
+			arrow.Field{Name: "ts", Type: arrow.FixedWidthTypes.Timestamp_ms},
 		},
 		nil,
 	)
@@ -246,6 +247,7 @@ rec[0]["u64"]: [1]
 rec[0]["f32"]: [1.1]
 rec[0]["f64"]: [1.1]
 rec[0]["str"]: ["str-1"]
+rec[0]["ts"]: [1652054461000]
 rec[1]["bool"]: [false]
 rec[1]["i8"]: [-2]
 rec[1]["i16"]: [-2]
@@ -258,6 +260,7 @@ rec[1]["u64"]: [2]
 rec[1]["f32"]: [2.2]
 rec[1]["f64"]: [2.2]
 rec[1]["str"]: ["str-2"]
+rec[1]["ts"]: [1652140799000]
 rec[2]["bool"]: [(null)]
 rec[2]["i8"]: [(null)]
 rec[2]["i16"]: [(null)]
@@ -270,6 +273,7 @@ rec[2]["u64"]: [(null)]
 rec[2]["f32"]: [(null)]
 rec[2]["f64"]: [(null)]
 rec[2]["str"]: [(null)]
+rec[2]["ts"]: [(null)]
 `
 
 	if got, want := out.String(), want; got != want {

--- a/go/arrow/csv/testdata/header.csv
+++ b/go/arrow/csv/testdata/header.csv
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-bool;i8;i16;i32;i64;u8;u16;u32;u64;f32;f64;str
-true;-1;-1;-1;-1;1;1;1;1;1.1;1.1;str-1
-false;-2;-2;-2;-2;2;2;2;2;2.2;2.2;str-2
-null;null;null;null;null;null;null;null;null;null;null;null
+bool;i8;i16;i32;i64;u8;u16;u32;u64;f32;f64;str;ts
+true;-1;-1;-1;-1;1;1;1;1;1.1;1.1;str-1;2022-05-09T00:01:01
+false;-2;-2;-2;-2;2;2;2;2;2.2;2.2;str-2;2022-05-09T23:59:59
+null;NULL;null;N/A;;null;null;null;null;null;null;null;null

--- a/go/arrow/csv/testdata/types.csv
+++ b/go/arrow/csv/testdata/types.csv
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-## supported types: bool;int8;int16;int32;int64;uint8;uint16;uint32;uint64;float32;float64;string
-true;-1;-1;-1;-1;1;1;1;1;1.1;1.1;str-1
-false;-2;-2;-2;-2;2;2;2;2;2.2;2.2;str-2
-null;NULL;null;N/A;;null;null;null;null;null;null;null
+## supported types: bool;int8;int16;int32;int64;uint8;uint16;uint32;uint64;float32;float64;string;timestamp
+true;-1;-1;-1;-1;1;1;1;1;1.1;1.1;str-1;2022-05-09T00:01:01
+false;-2;-2;-2;-2;2;2;2;2;2.2;2.2;str-2;2022-05-09T23:59:59
+null;NULL;null;N/A;;null;null;null;null;null;null;null;null


### PR DESCRIPTION
There is already a helper to convert strings to arrow.Timestamp so incorporate this into the CSV reader.

The CSV files I am currently working with have RFC3339 timestamps so I followed some of the code JSON and stuck with millisecond default. 

Was really easy to add this using the existing functions and structure.