### PR TITLE
ARROW-16484: [Go][Parquet] Update parquet writer version

### DIFF
--- a/dev/release/01-prepare-test.rb
+++ b/dev/release/01-prepare-test.rb
@@ -155,6 +155,13 @@ class PrepareTest < Test::Unit::TestCase
         ],
       },
       {
+        path: "go/parquet/writer_properties.go",
+        hunks: [
+          ["-\tDefaultCreatedBy          = \"parquet-go version #{@snapshot_version}\"",
+           "+\tDefaultCreatedBy          = \"parquet-go version #{@release_version}\""],
+        ],
+      },
+      {
         path: "js/package.json",
         hunks: [
           ["-  \"version\": \"#{@snapshot_version}\"",

--- a/dev/release/post-12-bump-versions-test.rb
+++ b/dev/release/post-12-bump-versions-test.rb
@@ -114,14 +114,7 @@ class PostBumpVersionsTest < Test::Unit::TestCase
           ["-  url \"https://www.apache.org/dyn/closer.lua?path=arrow/arrow-#{@previous_version}.9000/apache-arrow-#{@previous_version}.9000.tar.gz\"",
            "+  url \"https://www.apache.org/dyn/closer.lua?path=arrow/arrow-#{@release_version}.9000/apache-arrow-#{@release_version}.9000.tar.gz\""],
         ],
-      },
-      {
-        path: "go/parquet/writer_properties.go",
-        hunks: [
-          ["-\tDefaultCreatedBy          = \"parquet-go version #{@snapshot_version}\"",
-           "+\tDefaultCreatedBy          = \"parquet-go version #{@next_snapshot_version}\""]
-        ],
-      },
+      },      
       {
         path: "docs/source/_static/versions.json",
         hunks: [
@@ -204,6 +197,10 @@ class PostBumpVersionsTest < Test::Unit::TestCase
           "v#{@next_major_version}"
         end
         hunk << "+#{new_line}"
+      end
+      if path == "go/parquet/writer_properties.go"
+        hunk << "-\tDefaultCreatedBy          = \"parquet-go version #{@snapshot_version}\""
+        hunk << "+\tDefaultCreatedBy          = \"parquet-go version #{@next_snapshot_version}\""        
       end
       expected_changes << {hunks: [hunk], path: path}
     end

--- a/dev/release/post-12-bump-versions-test.rb
+++ b/dev/release/post-12-bump-versions-test.rb
@@ -121,7 +121,7 @@ class PostBumpVersionsTest < Test::Unit::TestCase
           ["-\tDefaultCreatedBy          = \"parquet-go version #{@previous_version}\"",
            "+\tDefaultCreatedBy          = \"parquet-go version #{@next_snapshot_version}\""]
         ],
-      }.
+      },
       {
         path: "docs/source/_static/versions.json",
         hunks: [

--- a/dev/release/post-12-bump-versions-test.rb
+++ b/dev/release/post-12-bump-versions-test.rb
@@ -116,6 +116,13 @@ class PostBumpVersionsTest < Test::Unit::TestCase
         ],
       },
       {
+        path: "go/parquet/writer_properties.go",
+        hunks: [
+          ["-\tDefaultCreatedBy          = \"parquet-go version #{@previous_version}\"",
+           "+\tDefaultCreatedBy          = \"parquet-go version #{@next_snapshot_version}\""]
+        ],
+      }.
+      {
         path: "docs/source/_static/versions.json",
         hunks: [
           [

--- a/dev/release/post-12-bump-versions-test.rb
+++ b/dev/release/post-12-bump-versions-test.rb
@@ -118,7 +118,7 @@ class PostBumpVersionsTest < Test::Unit::TestCase
       {
         path: "go/parquet/writer_properties.go",
         hunks: [
-          ["-\tDefaultCreatedBy          = \"parquet-go version #{@previous_version}\"",
+          ["-\tDefaultCreatedBy          = \"parquet-go version #{@snapshot_version}\"",
            "+\tDefaultCreatedBy          = \"parquet-go version #{@next_snapshot_version}\""]
         ],
       },

--- a/dev/release/post-12-bump-versions-test.rb
+++ b/dev/release/post-12-bump-versions-test.rb
@@ -114,7 +114,7 @@ class PostBumpVersionsTest < Test::Unit::TestCase
           ["-  url \"https://www.apache.org/dyn/closer.lua?path=arrow/arrow-#{@previous_version}.9000/apache-arrow-#{@previous_version}.9000.tar.gz\"",
            "+  url \"https://www.apache.org/dyn/closer.lua?path=arrow/arrow-#{@release_version}.9000/apache-arrow-#{@release_version}.9000.tar.gz\""],
         ],
-      },      
+      },
       {
         path: "docs/source/_static/versions.json",
         hunks: [
@@ -188,6 +188,7 @@ class PostBumpVersionsTest < Test::Unit::TestCase
       lines = File.readlines(path, chomp: true)
       target_lines = lines.grep(/#{Regexp.escape(import_path)}/)
       next if target_lines.empty?
+      hunks = []
       hunk = []
       target_lines.each do |line|
         hunk << "-#{line}"
@@ -198,11 +199,14 @@ class PostBumpVersionsTest < Test::Unit::TestCase
         end
         hunk << "+#{new_line}"
       end
+      hunks << hunk
       if path == "go/parquet/writer_properties.go"
-        hunk.append("-\tDefaultCreatedBy          = \"parquet-go version #{@snapshot_version}\"")
-        hunk.append("+\tDefaultCreatedBy          = \"parquet-go version #{@next_snapshot_version}\"")
+        hunks << [
+          "-\tDefaultCreatedBy          = \"parquet-go version #{@snapshot_version}\"",
+          "+\tDefaultCreatedBy          = \"parquet-go version #{@next_snapshot_version}\"",
+        ]
       end
-      expected_changes << {hunks: [hunk], path: path}
+      expected_changes << {hunks: hunks, path: path}
     end
 
     Dir.glob("java/**/pom.xml") do |path|

--- a/dev/release/post-12-bump-versions-test.rb
+++ b/dev/release/post-12-bump-versions-test.rb
@@ -199,8 +199,8 @@ class PostBumpVersionsTest < Test::Unit::TestCase
         hunk << "+#{new_line}"
       end
       if path == "go/parquet/writer_properties.go"
-        hunk << "-\tDefaultCreatedBy          = \"parquet-go version #{@snapshot_version}\""
-        hunk << "+\tDefaultCreatedBy          = \"parquet-go version #{@next_snapshot_version}\""        
+        hunk.append("-\tDefaultCreatedBy          = \"parquet-go version #{@snapshot_version}\"")
+        hunk.append("+\tDefaultCreatedBy          = \"parquet-go version #{@next_snapshot_version}\"")
       end
       expected_changes << {hunks: [hunk], path: path}
     end

--- a/dev/release/utils-prepare.sh
+++ b/dev/release/utils-prepare.sh
@@ -153,6 +153,9 @@ update_versions() {
   find . "(" -name "*.go*" -o -name "go.mod" ")" -exec sed -i.bak -E -e \
     "s|(github\\.com/apache/arrow/go)/v[0-9]+|\1/v${major_version}|" {} \;
   find . -name "*.bak" -exec rm {} \;
+  # update parquet writer version
+  sed -i -E -e "s/\"parquet-go version .+\"/\"parquet-go version ${version}\"/"
+
   git add .
   popd
 

--- a/dev/release/utils-prepare.sh
+++ b/dev/release/utils-prepare.sh
@@ -152,9 +152,11 @@ update_versions() {
   pushd "${ARROW_DIR}/go"
   find . "(" -name "*.go*" -o -name "go.mod" ")" -exec sed -i.bak -E -e \
     "s|(github\\.com/apache/arrow/go)/v[0-9]+|\1/v${major_version}|" {} \;
-  find . -name "*.bak" -exec rm {} \;
   # update parquet writer version
-  sed -i -E -e "s/\"parquet-go version .+\"/\"parquet-go version ${version}\"/" parquet/writer_properties.go
+  sed -i.bak -E -e \
+    "s/\"parquet-go version .+\"/\"parquet-go version ${version}\"/" \
+    parquet/writer_properties.go
+  find . -name "*.bak" -exec rm {} \;
 
   git add .
   popd

--- a/dev/release/utils-prepare.sh
+++ b/dev/release/utils-prepare.sh
@@ -157,7 +157,6 @@ update_versions() {
     "s/\"parquet-go version .+\"/\"parquet-go version ${version}\"/" \
     parquet/writer_properties.go
   find . -name "*.bak" -exec rm {} \;
-
   git add .
   popd
 

--- a/dev/release/utils-prepare.sh
+++ b/dev/release/utils-prepare.sh
@@ -154,7 +154,7 @@ update_versions() {
     "s|(github\\.com/apache/arrow/go)/v[0-9]+|\1/v${major_version}|" {} \;
   find . -name "*.bak" -exec rm {} \;
   # update parquet writer version
-  sed -i -E -e "s/\"parquet-go version .+\"/\"parquet-go version ${version}\"/"
+  sed -i -E -e "s/\"parquet-go version .+\"/\"parquet-go version ${version}\"/" parquet/writer_properties.go
 
   git add .
   popd

--- a/go/parquet/writer_properties.go
+++ b/go/parquet/writer_properties.go
@@ -46,7 +46,7 @@ const (
 	DefaultStatsEnabled = true
 	// If the stats are larger than 4K the writer will skip writing them out anyways.
 	DefaultMaxStatsSize int64 = 4096
-	DefaultCreatedBy          = "parquet-go version 1.0.0"
+	DefaultCreatedBy          = "parquet-go version 9.0.0-SNAPSHOT"
 )
 
 // ColumnProperties defines the encoding, codec, and so on for a given column.


### PR DESCRIPTION
This updates the default `Created By` string of the Go Parquet Writer, and updates the release script to correctly update that string with releases in the future.