### PR TITLE
MINOR: [R] Move tzdb loading out of .onLoad() to avoid a check NOTE

### DIFF
--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -72,12 +72,7 @@
     options(arrow.use_threads = FALSE)
 
     # Try to set timezone database
-    if (requireNamespace("tzdb", quietly = TRUE)) {
-      tzdb::tzdb_initialize()
-      set_timezone_database(tzdb::tzdb_path("text"))
-    } else {
-      packageStartupMessage("The tzdb package is not installed. Timezones will not be available.")
-    }
+    configure_tzdb()
   }
 
   if (arrow_available()) {
@@ -86,6 +81,16 @@
   }
 
   invisible()
+}
+
+configure_tzdb <- function() {
+  # This is needed on Windows to support timezone-aware calculations
+  if (requireNamespace("tzdb", quietly = TRUE)) {
+    tzdb::tzdb_initialize()
+    set_timezone_database(tzdb::tzdb_path("text"))
+  } else {
+    packageStartupMessage("The tzdb package is not installed. Timezones will not be available to Arrow compute functions.")
+  }
 }
 
 .onAttach <- function(libname, pkgname) {

--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -89,7 +89,11 @@ configure_tzdb <- function() {
     tzdb::tzdb_initialize()
     set_timezone_database(tzdb::tzdb_path("text"))
   } else {
-    packageStartupMessage("The tzdb package is not installed. Timezones will not be available to Arrow compute functions.")
+    msg <- paste(
+      "The tzdb package is not installed.",
+      "Timezones will not be available to Arrow compute functions."
+    )
+    packageStartupMessage(msg)
   }
 }
 


### PR DESCRIPTION
`R CMD check` now raises a NOTE after my previous fix (f49fbda3dffeaead7d192ec64bfd2a7cfc4172a3):

```
* checking R code for possible problems ... NOTE
File ‘arrow/R/arrow-package.R’:
  .onLoad calls:
    packageStartupMessage("The tzdb package is not installed. Timezones will not be available.")
See section ‘Good practice’ in '?.onAttach'.
```

Interestingly, the docs they point to say to use `packageStartupMessage()` like we are doing here. In any case, if we move it to a function that `.onLoad()` calls rather than having it directly in .onLoad, `check` doesn't find it 🤷 