### PR TITLE
ARROW-16529: [Java] Fix ArrowVectorIterator.hasNext()

### DIFF
--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/ArrowVectorIterator.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/ArrowVectorIterator.java
@@ -163,14 +163,7 @@ public class ArrowVectorIterator implements Iterator<VectorSchemaRoot>, AutoClos
 
   @Override
   public boolean hasNext() {
-    if (readComplete) {
-      return false;
-    }
-    try {
-      return !resultSet.isLast();
-    } catch (SQLException e) {
-      throw new RuntimeException(e);
-    }
+    return !readComplete;
   }
 
   /**

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTest.java
@@ -265,7 +265,11 @@ public class JdbcToArrowTest extends AbstractJdbcToArrowTest {
             .setReuseVectorSchemaRoot(reuseVectorSchemaRoot).build();
 
     ArrowVectorIterator iter = JdbcToArrow.sqlToArrowVectorIterator(rs, config);
-    assertFalse("Iterator on zero row ResultSet should not haveNext()", iter.hasNext());
+    assertTrue("Iterator on zero row ResultSet should haveNext() before use", iter.hasNext());
+    VectorSchemaRoot root = iter.next();
+    assertNotNull("VectorSchemaRoot from first next() result should never be null", root);
+    assertEquals("VectorSchemaRoot from empty ResultSet should have zero rows", 0, root.getRowCount());
+    assertFalse("hasNext() should return false on empty ResultSets after initial next() call", iter.hasNext());
   }
 
   private class FakeResultSet implements ResultSet {


### PR DESCRIPTION
Calls to ArrowVectorIterator.hasNext() should return true until ArrowVectorIterator.next() has been called, and the underlying ResultSet has been fully consumed.