### PR TITLE
ARROW-15365: [Python] Expose full cast options in the pyarrow.compute.cast function

### DIFF
--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2180,7 +2180,7 @@ cdef class Expression(_Weakrefable):
         options = NullOptions(nan_is_null=nan_is_null)
         return Expression._call("is_null", [self], options)
 
-    def cast(self, type, bint safe=True):
+    def cast(self, type, safe=None, options=None):
         """
         Explicitly set or change the expression's data type.
 
@@ -2198,7 +2198,14 @@ cdef class Expression(_Weakrefable):
         -------
         cast : Expression
         """
-        options = CastOptions.safe(ensure_type(type))
+        if (safe is not None) and (options is not None):
+            raise ValueError(
+                "Must past only a value for 'safe' or only a value for 'options'")
+        if options is None:
+            if safe is False:
+                options = CastOptions.unsafe(type)
+            else:
+                options = CastOptions.safe(type)
         return Expression._call("cast", [self], options)
 
     def isin(self, values):

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2180,7 +2180,7 @@ cdef class Expression(_Weakrefable):
         options = NullOptions(nan_is_null=nan_is_null)
         return Expression._call("is_null", [self], options)
 
-    def cast(self, type, safe=None, options=None):
+    def cast(self, type=None, safe=None, options=None):
         """
         Explicitly set or change the expression's data type.
 
@@ -2189,7 +2189,7 @@ cdef class Expression(_Weakrefable):
 
         Parameters
         ----------
-        type : DataType
+        type : DataType, default None
             Type to cast array to.
         safe : boolean, default True
             Whether to check for conversion errors such as overflow.
@@ -2198,10 +2198,16 @@ cdef class Expression(_Weakrefable):
         -------
         cast : Expression
         """
-        if (safe is not None) and (options is not None):
-            raise ValueError(
-                "Must past only a value for 'safe' or only a value for 'options'")
+        safe_vars_passed = (safe is not None) or (type is not None)
+
+        if safe_vars_passed and (options is not None):
+            raise ValueError("Must either pass values for 'type' and 'safe' or pass a "
+                             "value for 'options'")
+
         if options is None:
+            if type is None:
+                raise ValueError(
+                    "If no 'options' are passed, a 'type' must be passed")
             if safe is False:
                 options = CastOptions.unsafe(type)
             else:

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2205,9 +2205,7 @@ cdef class Expression(_Weakrefable):
                              "value for 'options'")
 
         if options is None:
-            if type is None:
-                raise ValueError(
-                    "If no 'options' are passed, a 'type' must be passed")
+            ensure_type(type, allow_none=False)
             if safe is False:
                 options = CastOptions.unsafe(type)
             else:

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2193,6 +2193,8 @@ cdef class Expression(_Weakrefable):
             Type to cast array to.
         safe : boolean, default True
             Whether to check for conversion errors such as overflow.
+        options : CastOptions, default None
+            Additional checks pass by CastOptions
 
         Returns
         -------
@@ -2205,7 +2207,7 @@ cdef class Expression(_Weakrefable):
                              "value for 'options'")
 
         if options is None:
-            ensure_type(type, allow_none=False)
+            type = ensure_type(type, allow_none=False)
             if safe is False:
                 options = CastOptions.unsafe(type)
             else:

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -895,7 +895,7 @@ cdef class Array(_PandasConvertible):
             result = self.ap.Diff(deref(other.ap))
         return frombytes(result, safe=True)
 
-    def cast(self, object target_type, safe=None, options=None):
+    def cast(self, object target_type=None, safe=None, options=None):
         """
         Cast array values to another data type
 
@@ -903,7 +903,7 @@ cdef class Array(_PandasConvertible):
 
         Parameters
         ----------
-        target_type : DataType
+        target_type : DataType, default None
             Type to cast array to.
         safe : boolean, default True
             Whether to check for conversion errors such as overflow.

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -895,7 +895,7 @@ cdef class Array(_PandasConvertible):
             result = self.ap.Diff(deref(other.ap))
         return frombytes(result, safe=True)
 
-    def cast(self, object target_type, safe=True):
+    def cast(self, object target_type, safe=True, options=None):
         """
         Cast array values to another data type
 
@@ -912,7 +912,7 @@ cdef class Array(_PandasConvertible):
         -------
         cast : Array
         """
-        return _pc().cast(self, target_type, safe=safe)
+        return _pc().cast(self, target_type, safe=safe, options=options)
 
     def view(self, object target_type):
         """

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -905,7 +905,7 @@ cdef class Array(_PandasConvertible):
         ----------
         target_type : DataType
             Type to cast array to.
-        safe : boolean, default None
+        safe : boolean, default True
             Whether to check for conversion errors such as overflow.
         options : CastOptions, default None
             Additional checks pass by CastOptions

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -907,6 +907,8 @@ cdef class Array(_PandasConvertible):
             Type to cast array to.
         safe : boolean, default True
             Whether to check for conversion errors such as overflow.
+        options : CastOptions, default None
+            Additional checks pass by CastOptions
 
         Returns
         -------

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -895,7 +895,7 @@ cdef class Array(_PandasConvertible):
             result = self.ap.Diff(deref(other.ap))
         return frombytes(result, safe=True)
 
-    def cast(self, object target_type, safe=True, options=None):
+    def cast(self, object target_type, safe=None, options=None):
         """
         Cast array values to another data type
 
@@ -905,7 +905,7 @@ cdef class Array(_PandasConvertible):
         ----------
         target_type : DataType
             Type to cast array to.
-        safe : boolean, default True
+        safe : boolean, default None
             Whether to check for conversion errors such as overflow.
         options : CastOptions, default None
             Additional checks pass by CastOptions

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -318,7 +318,7 @@ def _make_global_functions():
 _make_global_functions()
 
 
-def cast(arr, target_type, safe=None, options=None):
+def cast(arr, target_type=None, safe=None, options=None):
     """
     Cast array values to another data type. Can also be invoked as an array
     instance method.
@@ -369,12 +369,16 @@ def cast(arr, target_type, safe=None, options=None):
     -------
     casted : Array
     """
-    if target_type is None:
-        raise ValueError("Cast target type must not be None")
-    if (safe is not None) and (options is not None):
-        raise ValueError(
-            "Must past only a value for 'safe' or only a value for 'options'")
+    safe_vars_passed = (safe is not None) or (target_type is not None)
+
+    if safe_vars_passed and (options is not None):
+        raise ValueError("Must either pass values for 'target_type' and 'safe' or pass a "
+                         "value for 'options'")
+
     if options is None:
+        if target_type is None:
+            raise ValueError(
+                "If no 'options' are passed, a 'target_type' must be passed")
         if safe is False:
             options = CastOptions.unsafe(target_type)
         else:

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -376,9 +376,7 @@ def cast(arr, target_type=None, safe=None, options=None):
                          " or pass a value for 'options'")
 
     if options is None:
-        if target_type is None:
-            raise ValueError(
-                "If no 'options' are passed, a 'target_type' must be passed")
+        pa.types.lib.ensure_type(target_type)
         if safe is False:
             options = CastOptions.unsafe(target_type)
         else:

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -376,7 +376,7 @@ def cast(arr, target_type=None, safe=None, options=None):
                          " or pass a value for 'options'")
 
     if options is None:
-        pa.types.lib.ensure_type(target_type)
+        target_type = pa.types.lib.ensure_type(target_type)
         if safe is False:
             options = CastOptions.unsafe(target_type)
         else:

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -372,8 +372,8 @@ def cast(arr, target_type=None, safe=None, options=None):
     safe_vars_passed = (safe is not None) or (target_type is not None)
 
     if safe_vars_passed and (options is not None):
-        raise ValueError("Must either pass values for 'target_type' and 'safe' or pass a "
-                         "value for 'options'")
+        raise ValueError("Must either pass values for 'target_type' and 'safe'"
+                         " or pass a value for 'options'")
 
     if options is None:
         if target_type is None:

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -330,6 +330,8 @@ def cast(arr, target_type, safe=True, options=None):
         Type to cast to
     safe : bool, default True
         Check for overflows or other unsafe conversions
+    options : CastOptions, default None
+        Additional checks pass by CastOptions
 
     Examples
     --------

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -318,7 +318,7 @@ def _make_global_functions():
 _make_global_functions()
 
 
-def cast(arr, target_type, safe=True, options=None):
+def cast(arr, target_type, safe=None, options=None):
     """
     Cast array values to another data type. Can also be invoked as an array
     instance method.
@@ -328,7 +328,7 @@ def cast(arr, target_type, safe=True, options=None):
     arr : Array-like
     target_type : DataType or str
         Type to cast to
-    safe : bool, default True
+    safe : bool, default None
         Check for overflows or other unsafe conversions
     options : CastOptions, default None
         Additional checks pass by CastOptions
@@ -371,6 +371,8 @@ def cast(arr, target_type, safe=True, options=None):
     """
     if target_type is None:
         raise ValueError("Cast target type must not be None")
+    if (safe is not None) and (options is not None):
+        raise ValueError("Must past only a value for 'safe' or only a value for 'options'")
     if options is None:
         if safe:
             options = CastOptions.safe(target_type)

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -372,7 +372,8 @@ def cast(arr, target_type, safe=None, options=None):
     if target_type is None:
         raise ValueError("Cast target type must not be None")
     if (safe is not None) and (options is not None):
-        raise ValueError("Must past only a value for 'safe' or only a value for 'options'")
+        raise ValueError(
+            "Must past only a value for 'safe' or only a value for 'options'")
     if options is None:
         if safe:
             options = CastOptions.safe(target_type)

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -328,7 +328,7 @@ def cast(arr, target_type, safe=None, options=None):
     arr : Array-like
     target_type : DataType or str
         Type to cast to
-    safe : bool, default None
+    safe : bool, default True
         Check for overflows or other unsafe conversions
     options : CastOptions, default None
         Additional checks pass by CastOptions
@@ -375,10 +375,10 @@ def cast(arr, target_type, safe=None, options=None):
         raise ValueError(
             "Must past only a value for 'safe' or only a value for 'options'")
     if options is None:
-        if safe:
-            options = CastOptions.safe(target_type)
-        else:
+        if safe is False:
             options = CastOptions.unsafe(target_type)
+        else:
+            options = CastOptions.safe(target_type)
     return call_function("cast", [arr], options)
 
 

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -318,7 +318,7 @@ def _make_global_functions():
 _make_global_functions()
 
 
-def cast(arr, target_type, safe=True):
+def cast(arr, target_type, safe=True, options=None):
     """
     Cast array values to another data type. Can also be invoked as an array
     instance method.
@@ -369,10 +369,11 @@ def cast(arr, target_type, safe=True):
     """
     if target_type is None:
         raise ValueError("Cast target type must not be None")
-    if safe:
-        options = CastOptions.safe(target_type)
-    else:
-        options = CastOptions.unsafe(target_type)
+    if options is None:
+        if safe:
+            options = CastOptions.safe(target_type)
+        else:
+            options = CastOptions.unsafe(target_type)
     return call_function("cast", [arr], options)
 
 

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -490,7 +490,7 @@ cdef class ChunkedArray(_PandasConvertible):
             return values
         return values.astype(dtype)
 
-    def cast(self, object target_type, safe=None, options=None):
+    def cast(self, object target_type=None, safe=None, options=None):
         """
         Cast array values to another data type
 
@@ -498,7 +498,7 @@ cdef class ChunkedArray(_PandasConvertible):
 
         Parameters
         ----------
-        target_type : DataType
+        target_type : DataType, None
             Type to cast array to.
         safe : boolean, default True
             Whether to check for conversion errors such as overflow.

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -3335,7 +3335,7 @@ cdef class Table(_PandasConvertible):
 
         return result
 
-    def cast(self, Schema target_schema, bint safe=True):
+    def cast(self, Schema target_schema, safe=None, options=None):
         """
         Cast table values to another schema.
 
@@ -3345,6 +3345,8 @@ cdef class Table(_PandasConvertible):
             Schema to cast to, the names and order of fields must match.
         safe : bool, default True
             Check for overflows or other unsafe conversions.
+        options : CastOptions, default None
+            Additional checks pass by CastOptions
 
         Returns
         -------
@@ -3388,7 +3390,7 @@ cdef class Table(_PandasConvertible):
                              .format(self.schema.names, target_schema.names))
 
         for column, field in zip(self.itercolumns(), target_schema):
-            casted = column.cast(field.type, safe=safe)
+            casted = column.cast(field.type, safe=safe, options=options)
             newcols.append(casted)
 
         return Table.from_arrays(newcols, schema=target_schema)

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -500,7 +500,7 @@ cdef class ChunkedArray(_PandasConvertible):
         ----------
         target_type : DataType
             Type to cast array to.
-        safe : boolean, default None
+        safe : boolean, default True
             Whether to check for conversion errors such as overflow.
         options : CastOptions, default None
             Additional checks pass by CastOptions

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -490,7 +490,7 @@ cdef class ChunkedArray(_PandasConvertible):
             return values
         return values.astype(dtype)
 
-    def cast(self, object target_type, safe=True):
+    def cast(self, object target_type, safe=True, options=None):
         """
         Cast array values to another data type
 
@@ -520,7 +520,7 @@ cdef class ChunkedArray(_PandasConvertible):
         >>> n_legs_seconds.type
         DurationType(duration[s])
         """
-        return _pc().cast(self, target_type, safe=safe)
+        return _pc().cast(self, target_type, safe=safe, options=options)
 
     def dictionary_encode(self, null_encoding='mask'):
         """

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -490,7 +490,7 @@ cdef class ChunkedArray(_PandasConvertible):
             return values
         return values.astype(dtype)
 
-    def cast(self, object target_type, safe=True, options=None):
+    def cast(self, object target_type, safe=None, options=None):
         """
         Cast array values to another data type
 
@@ -500,7 +500,7 @@ cdef class ChunkedArray(_PandasConvertible):
         ----------
         target_type : DataType
             Type to cast array to.
-        safe : boolean, default True
+        safe : boolean, default None
             Whether to check for conversion errors such as overflow.
         options : CastOptions, default None
             Additional checks pass by CastOptions

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -502,6 +502,8 @@ cdef class ChunkedArray(_PandasConvertible):
             Type to cast array to.
         safe : boolean, default True
             Whether to check for conversion errors such as overflow.
+        options : CastOptions, default None
+            Additional checks pass by CastOptions
 
         Returns
         -------

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1281,7 +1281,7 @@ def test_cast_none():
     # ARROW-3735: Ensure that calling cast(None) doesn't segfault.
     arr = pa.array([1, 2, 3])
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         arr.cast(None)
 
 

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1703,7 +1703,7 @@ def test_logical():
 
 def test_cast():
     arr = pa.array([1, 2, 3, 4], type='int64')
-    options = pc.CastOptions()
+    options = pc.CastOptions('int8')
 
     with pytest.raises(ValueError):
         pc.cast(arr, target_type=None)
@@ -1718,11 +1718,12 @@ def test_cast():
         [1, 2, 3, 4], type='int8')
 
     arr = pa.array([2 ** 63 - 1], type='int64')
-    allow_overflow_options = pc.CastOptions(pa.int32(), allow_int_overflow=True)
+    options = pc.CastOptions('int32')
+    allow_overflow_options = pc.CastOptions('int32', allow_int_overflow=True)
 
     with pytest.raises(pa.ArrowInvalid):
         pc.cast(arr, 'int32')
-    
+
     with pytest.raises(pa.ArrowInvalid):
         pc.cast(arr, 'int32', options)
 

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1718,11 +1718,18 @@ def test_cast():
         [1, 2, 3, 4], type='int8')
 
     arr = pa.array([2 ** 63 - 1], type='int64')
+    allow_overflow_options = pc.CastOptions(pa.int32(), allow_int_overflow=True)
 
     with pytest.raises(pa.ArrowInvalid):
         pc.cast(arr, 'int32')
+    
+    with pytest.raises(pa.ArrowInvalid):
+        pc.cast(arr, 'int32', options)
 
     assert pc.cast(arr, 'int32', safe=False) == pa.array([-1], type='int32')
+
+    assert pc.cast(arr, 'int32', options=allow_overflow_options) == pa.array(
+        [-1], type='int32')
 
     arr = pa.array([datetime(2010, 1, 1), datetime(2015, 1, 1)])
     expected = pa.array([1262304000000, 1420070400000], type='timestamp[ms]')

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1718,15 +1718,11 @@ def test_cast():
         [1, 2, 3, 4], type='int8')
 
     arr = pa.array([2 ** 63 - 1], type='int64')
-    options = pc.CastOptions(pa.int32())
     allow_overflow_options = pc.CastOptions(
         pa.int32(), allow_int_overflow=True)
 
     with pytest.raises(pa.ArrowInvalid):
         pc.cast(arr, 'int32')
-
-    with pytest.raises(pa.ArrowInvalid):
-        pc.cast(arr, 'int32', options)
 
     assert pc.cast(arr, 'int32', safe=False) == pa.array([-1], type='int32')
 

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1702,11 +1702,6 @@ def test_logical():
 
 
 def test_cast():
-    arr = pa.array([2 ** 63 - 1], type='int64')
-
-    with pytest.raises(pa.ArrowInvalid):
-        pc.cast(arr, 'int32')
-
     arr = pa.array([1, 2, 3, 4], type='int64')
     options = pc.CastOptions()
 
@@ -1718,6 +1713,11 @@ def test_cast():
 
     with pytest.raises(ValueError):
         pc.cast(arr, 'int32', safe=False, options=options)
+
+    arr = pa.array([2 ** 63 - 1], type='int64')
+
+    with pytest.raises(pa.ArrowInvalid):
+        pc.cast(arr, 'int32')
 
     assert pc.cast(arr, 'int32', safe=False) == pa.array([-1], type='int32')
 

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1707,6 +1707,18 @@ def test_cast():
     with pytest.raises(pa.ArrowInvalid):
         pc.cast(arr, 'int32')
 
+    arr = pa.array([1, 2, 3, 4], type='int64')
+    options = pc.CastOptions()
+
+    with pytest.raises(ValueError):
+        pc.cast(arr, target_type=None)
+
+    with pytest.raises(ValueError):
+        pc.cast(arr, 'int32', safe=True, options=options)
+
+    with pytest.raises(ValueError):
+        pc.cast(arr, 'int32', safe=False, options=options)
+
     assert pc.cast(arr, 'int32', safe=False) == pa.array([-1], type='int32')
 
     arr = pa.array([datetime(2010, 1, 1), datetime(2015, 1, 1)])

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1705,7 +1705,7 @@ def test_cast():
     arr = pa.array([1, 2, 3, 4], type='int64')
     options = pc.CastOptions(pa.int8())
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         pc.cast(arr, target_type=None)
 
     with pytest.raises(ValueError):

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1709,12 +1709,12 @@ def test_cast():
         pc.cast(arr, target_type=None)
 
     with pytest.raises(ValueError):
-        pc.cast(arr, 'int32', safe=True, options=options)
+        pc.cast(arr, 'int32', options=options)
 
     with pytest.raises(ValueError):
-        pc.cast(arr, 'int32', safe=False, options=options)
+        pc.cast(arr, safe=True, options=options)
 
-    assert pc.cast(arr, 'int8', options=options) == pa.array(
+    assert pc.cast(arr, options=options) == pa.array(
         [1, 2, 3, 4], type='int8')
 
     arr = pa.array([2 ** 63 - 1], type='int64')
@@ -1726,7 +1726,7 @@ def test_cast():
 
     assert pc.cast(arr, 'int32', safe=False) == pa.array([-1], type='int32')
 
-    assert pc.cast(arr, 'int32', options=allow_overflow_options) == pa.array(
+    assert pc.cast(arr, options=allow_overflow_options) == pa.array(
         [-1], type='int32')
 
     arr = pa.array([datetime(2010, 1, 1), datetime(2015, 1, 1)])

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1714,6 +1714,9 @@ def test_cast():
     with pytest.raises(ValueError):
         pc.cast(arr, 'int32', safe=False, options=options)
 
+    assert pc.cast(arr, 'int8', options=options) == pa.array(
+        [1, 2, 3, 4], type='int8')
+
     arr = pa.array([2 ** 63 - 1], type='int64')
 
     with pytest.raises(pa.ArrowInvalid):

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1719,7 +1719,8 @@ def test_cast():
 
     arr = pa.array([2 ** 63 - 1], type='int64')
     options = pc.CastOptions(pa.int32())
-    allow_overflow_options = pc.CastOptions(pa.int32(), allow_int_overflow=True)
+    allow_overflow_options = pc.CastOptions(
+        pa.int32(), allow_int_overflow=True)
 
     with pytest.raises(pa.ArrowInvalid):
         pc.cast(arr, 'int32')

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1703,7 +1703,7 @@ def test_logical():
 
 def test_cast():
     arr = pa.array([1, 2, 3, 4], type='int64')
-    options = pc.CastOptions('int8')
+    options = pc.CastOptions(pa.int8())
 
     with pytest.raises(ValueError):
         pc.cast(arr, target_type=None)
@@ -1718,8 +1718,8 @@ def test_cast():
         [1, 2, 3, 4], type='int8')
 
     arr = pa.array([2 ** 63 - 1], type='int64')
-    options = pc.CastOptions('int32')
-    allow_overflow_options = pc.CastOptions('int32', allow_int_overflow=True)
+    options = pc.CastOptions(pa.int32())
+    allow_overflow_options = pc.CastOptions(pa.int32(), allow_int_overflow=True)
 
     with pytest.raises(pa.ArrowInvalid):
         pc.cast(arr, 'int32')


### PR DESCRIPTION
Added CastOptions to pc.cast and related relate cast functions