### PR TITLE
ARROW-16573: [C++][Format] Add canonical include guard for C Data Interface

### DIFF
--- a/cpp/src/arrow/c/abi.h
+++ b/cpp/src/arrow/c/abi.h
@@ -65,14 +65,6 @@ struct ArrowArray {
 
 #endif  // ARROW_C_DATA_INTERFACE
 
-#ifdef __cplusplus
-}
-#endif
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 // EXPERIMENTAL: C stream interface
 
 #ifndef ARROW_C_STREAM_INTERFACE

--- a/cpp/src/arrow/c/abi.h
+++ b/cpp/src/arrow/c/abi.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #ifndef ARROW_C_DATA_H
+#define ARROW_C_DATA_H
 
 #include <stdint.h>
 
@@ -65,6 +66,7 @@ struct ArrowArray {
 #endif  // ARROW_C_DATA_H
 
 #ifndef ARROW_C_STREAM_H
+#define ARROW_C_STREAM_H
 
 // EXPERIMENTAL: C stream interface
 

--- a/cpp/src/arrow/c/abi.h
+++ b/cpp/src/arrow/c/abi.h
@@ -17,14 +17,14 @@
 
 #pragma once
 
-#ifndef ARROW_C_DATA_H
-#define ARROW_C_DATA_H
-
 #include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#ifndef ARROW_C_DATA_INTERFACE
+#define ARROW_C_DATA_INTERFACE
 
 #define ARROW_FLAG_DICTIONARY_ORDERED 1
 #define ARROW_FLAG_NULLABLE 2
@@ -63,20 +63,20 @@ struct ArrowArray {
   void* private_data;
 };
 
+#endif  // ARROW_C_DATA_INTERFACE
+
 #ifdef __cplusplus
 }
 #endif
 
-#endif  // ARROW_C_DATA_H
-
-#ifndef ARROW_C_STREAM_H
-#define ARROW_C_STREAM_H
-
-// EXPERIMENTAL: C stream interface
-
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// EXPERIMENTAL: C stream interface
+
+#ifndef ARROW_C_STREAM_INTERFACE
+#define ARROW_C_STREAM_INTERFACE
 
 struct ArrowArrayStream {
   // Callback to get the stream type
@@ -114,8 +114,8 @@ struct ArrowArrayStream {
   void* private_data;
 };
 
+#endif  // ARROW_C_STREAM_INTERFACE
+
 #ifdef __cplusplus
 }
 #endif
-
-#endif  // ARROW_C_STREAM_H

--- a/cpp/src/arrow/c/abi.h
+++ b/cpp/src/arrow/c/abi.h
@@ -63,12 +63,20 @@ struct ArrowArray {
   void* private_data;
 };
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  // ARROW_C_DATA_H
 
 #ifndef ARROW_C_STREAM_H
 #define ARROW_C_STREAM_H
 
 // EXPERIMENTAL: C stream interface
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct ArrowArrayStream {
   // Callback to get the stream type

--- a/cpp/src/arrow/c/abi.h
+++ b/cpp/src/arrow/c/abi.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#ifndef ARROW_C_DATA_H
+
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -60,6 +62,10 @@ struct ArrowArray {
   void* private_data;
 };
 
+#endif  // ARROW_C_DATA_H
+
+#ifndef ARROW_C_STREAM_H
+
 // EXPERIMENTAL: C stream interface
 
 struct ArrowArrayStream {
@@ -101,3 +107,5 @@ struct ArrowArrayStream {
 #ifdef __cplusplus
 }
 #endif
+
+#endif  // ARROW_C_STREAM_H

--- a/docs/source/format/CDataInterface.rst
+++ b/docs/source/format/CDataInterface.rst
@@ -255,8 +255,8 @@ are available under the Apache License 2.0.
 
 .. code-block:: c
 
-   #ifndef ARROW_C_DATA_H
-   #define ARROW_C_DATA_H
+   #ifndef ARROW_C_DATA_INTERFACE
+   #define ARROW_C_DATA_INTERFACE
 
    #define ARROW_FLAG_DICTIONARY_ORDERED 1
    #define ARROW_FLAG_NULLABLE 2
@@ -295,13 +295,15 @@ are available under the Apache License 2.0.
      void* private_data;
    };
 
-   #endif  // ARROW_C_DATA_H
+   #endif  // ARROW_C_DATA_INTERFACE
+
 .. note::
-   The canonical guard ``ARROW_C_DATA_INTERFACE`` is meant to avoid duplicate
-   definitions if two projects copy the C data interface definitions in their own headers,
-   and a third-party project includes from these two projects.
-   It is therefore important that this guard is kept exactly as-is when these definitions
-   are copied.
+   The canonical guard ``ARROW_C_DATA_INTERFACE`` is meant to avoid
+   duplicate definitions if two projects copy the C data interface
+   definitions in their own headers, and a third-party project
+   includes from these two projects.  It is therefore important that
+   this guard is kept exactly as-is when these definitions are copied.
+
 The ArrowSchema structure
 -------------------------
 

--- a/docs/source/format/CDataInterface.rst
+++ b/docs/source/format/CDataInterface.rst
@@ -296,7 +296,12 @@ are available under the Apache License 2.0.
    };
 
    #endif  // ARROW_C_DATA_H
-
+.. note::
+   The canonical guard ``ARROW_C_DATA_INTERFACE`` is meant to avoid duplicate
+   definitions if two projects copy the C data interface definitions in their own headers,
+   and a third-party project includes from these two projects.
+   It is therefore important that this guard is kept exactly as-is when these definitions
+   are copied.
 The ArrowSchema structure
 -------------------------
 

--- a/docs/source/format/CDataInterface.rst
+++ b/docs/source/format/CDataInterface.rst
@@ -256,6 +256,7 @@ are available under the Apache License 2.0.
 .. code-block:: c
 
    #ifndef ARROW_C_DATA_H
+   #define ARROW_C_DATA_H
 
    #define ARROW_FLAG_DICTIONARY_ORDERED 1
    #define ARROW_FLAG_NULLABLE 2

--- a/docs/source/format/CDataInterface.rst
+++ b/docs/source/format/CDataInterface.rst
@@ -255,6 +255,8 @@ are available under the Apache License 2.0.
 
 .. code-block:: c
 
+   #ifndef ARROW_C_DATA_H
+
    #define ARROW_FLAG_DICTIONARY_ORDERED 1
    #define ARROW_FLAG_NULLABLE 2
    #define ARROW_FLAG_MAP_KEYS_SORTED 4
@@ -291,6 +293,8 @@ are available under the Apache License 2.0.
      // Opaque producer-specific data
      void* private_data;
    };
+
+   #endif  // ARROW_C_DATA_H
 
 The ArrowSchema structure
 -------------------------

--- a/docs/source/format/CStreamInterface.rst
+++ b/docs/source/format/CStreamInterface.rst
@@ -45,8 +45,8 @@ Structure definition
 
 The C stream interface is defined by a single ``struct`` definition::
 
-   #ifndef ARROW_C_STREAM_H
-   #define ARROW_C_STREAM_H
+   #ifndef ARROW_C_STREAM_INTERFACE
+   #define ARROW_C_STREAM_INTERFACE
 
    struct ArrowArrayStream {
      // Callbacks providing stream functionality
@@ -61,7 +61,14 @@ The C stream interface is defined by a single ``struct`` definition::
      void* private_data;
    };
 
-   #endif  // ARROW_C_STREAM_H
+   #endif  // ARROW_C_STREAM_INTERFACE
+
+.. note::
+   The canonical guard ``ARROW_C_STREAM_INTERFACE`` is meant to avoid
+   duplicate definitions if two projects copy the C data interface
+   definitions in their own headers, and a third-party project
+   includes from these two projects.  It is therefore important that
+   this guard is kept exactly as-is when these definitions are copied.
 
 The ArrowArrayStream structure
 ------------------------------

--- a/docs/source/format/CStreamInterface.rst
+++ b/docs/source/format/CStreamInterface.rst
@@ -46,6 +46,7 @@ Structure definition
 The C stream interface is defined by a single ``struct`` definition::
 
    #ifndef ARROW_C_STREAM_H
+   #define ARROW_C_STREAM_H
 
    struct ArrowArrayStream {
      // Callbacks providing stream functionality

--- a/docs/source/format/CStreamInterface.rst
+++ b/docs/source/format/CStreamInterface.rst
@@ -45,6 +45,8 @@ Structure definition
 
 The C stream interface is defined by a single ``struct`` definition::
 
+   #ifndef ARROW_C_STREAM_H
+
    struct ArrowArrayStream {
      // Callbacks providing stream functionality
      int (*get_schema)(struct ArrowArrayStream*, struct ArrowSchema* out);
@@ -57,6 +59,8 @@ The C stream interface is defined by a single ``struct`` definition::
      // Opaque producer-specific data
      void* private_data;
    };
+
+   #endif  // ARROW_C_STREAM_H
 
 The ArrowArrayStream structure
 ------------------------------

--- a/go/arrow/cdata/arrow/c/abi.h
+++ b/go/arrow/cdata/arrow/c/abi.h
@@ -65,14 +65,6 @@ struct ArrowArray {
 
 #endif  // ARROW_C_DATA_INTERFACE
 
-#ifdef __cplusplus
-}
-#endif
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 // EXPERIMENTAL: C stream interface
 
 #ifndef ARROW_C_STREAM_INTERFACE

--- a/go/arrow/cdata/arrow/c/abi.h
+++ b/go/arrow/cdata/arrow/c/abi.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #ifndef ARROW_C_DATA_H
+#define ARROW_C_DATA_H
 
 #include <stdint.h>
 
@@ -65,6 +66,7 @@ struct ArrowArray {
 #endif  // ARROW_C_DATA_H
 
 #ifndef ARROW_C_STREAM_H
+#define ARROW_C_STREAM_H
 
 // EXPERIMENTAL: C stream interface
 

--- a/go/arrow/cdata/arrow/c/abi.h
+++ b/go/arrow/cdata/arrow/c/abi.h
@@ -17,14 +17,14 @@
 
 #pragma once
 
-#ifndef ARROW_C_DATA_H
-#define ARROW_C_DATA_H
-
 #include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#ifndef ARROW_C_DATA_INTERFACE
+#define ARROW_C_DATA_INTERFACE
 
 #define ARROW_FLAG_DICTIONARY_ORDERED 1
 #define ARROW_FLAG_NULLABLE 2
@@ -63,20 +63,20 @@ struct ArrowArray {
   void* private_data;
 };
 
+#endif  // ARROW_C_DATA_INTERFACE
+
 #ifdef __cplusplus
 }
 #endif
 
-#endif  // ARROW_C_DATA_H
-
-#ifndef ARROW_C_STREAM_H
-#define ARROW_C_STREAM_H
-
-// EXPERIMENTAL: C stream interface
-
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// EXPERIMENTAL: C stream interface
+
+#ifndef ARROW_C_STREAM_INTERFACE
+#define ARROW_C_STREAM_INTERFACE
 
 struct ArrowArrayStream {
   // Callback to get the stream type
@@ -114,8 +114,8 @@ struct ArrowArrayStream {
   void* private_data;
 };
 
+#endif  // ARROW_C_STREAM_INTERFACE
+
 #ifdef __cplusplus
 }
 #endif
-
-#endif  // ARROW_C_STREAM_H

--- a/go/arrow/cdata/arrow/c/abi.h
+++ b/go/arrow/cdata/arrow/c/abi.h
@@ -63,12 +63,20 @@ struct ArrowArray {
   void* private_data;
 };
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  // ARROW_C_DATA_H
 
 #ifndef ARROW_C_STREAM_H
 #define ARROW_C_STREAM_H
 
 // EXPERIMENTAL: C stream interface
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct ArrowArrayStream {
   // Callback to get the stream type

--- a/go/arrow/cdata/arrow/c/abi.h
+++ b/go/arrow/cdata/arrow/c/abi.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#ifndef ARROW_C_DATA_H
+
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -60,6 +62,10 @@ struct ArrowArray {
   void* private_data;
 };
 
+#endif  // ARROW_C_DATA_H
+
+#ifndef ARROW_C_STREAM_H
+
 // EXPERIMENTAL: C stream interface
 
 struct ArrowArrayStream {
@@ -101,3 +107,5 @@ struct ArrowArrayStream {
 #ifdef __cplusplus
 }
 #endif
+
+#endif  // ARROW_C_STREAM_H

--- a/java/c/src/main/cpp/abi.h
+++ b/java/c/src/main/cpp/abi.h
@@ -65,14 +65,6 @@ struct ArrowArray {
 
 #endif  // ARROW_C_DATA_INTERFACE
 
-#ifdef __cplusplus
-}
-#endif
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 // EXPERIMENTAL: C stream interface
 
 #ifndef ARROW_C_STREAM_INTERFACE

--- a/java/c/src/main/cpp/abi.h
+++ b/java/c/src/main/cpp/abi.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #ifndef ARROW_C_DATA_H
+#define ARROW_C_DATA_H
 
 #include <stdint.h>
 
@@ -65,6 +66,7 @@ struct ArrowArray {
 #endif  // ARROW_C_DATA_H
 
 #ifndef ARROW_C_STREAM_H
+#define ARROW_C_STREAM_H
 
 // EXPERIMENTAL: C stream interface
 

--- a/java/c/src/main/cpp/abi.h
+++ b/java/c/src/main/cpp/abi.h
@@ -17,14 +17,14 @@
 
 #pragma once
 
-#ifndef ARROW_C_DATA_H
-#define ARROW_C_DATA_H
-
 #include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#ifndef ARROW_C_DATA_INTERFACE
+#define ARROW_C_DATA_INTERFACE
 
 #define ARROW_FLAG_DICTIONARY_ORDERED 1
 #define ARROW_FLAG_NULLABLE 2
@@ -63,20 +63,20 @@ struct ArrowArray {
   void* private_data;
 };
 
+#endif  // ARROW_C_DATA_INTERFACE
+
 #ifdef __cplusplus
 }
 #endif
 
-#endif  // ARROW_C_DATA_H
-
-#ifndef ARROW_C_STREAM_H
-#define ARROW_C_STREAM_H
-
-// EXPERIMENTAL: C stream interface
-
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// EXPERIMENTAL: C stream interface
+
+#ifndef ARROW_C_STREAM_INTERFACE
+#define ARROW_C_STREAM_INTERFACE
 
 struct ArrowArrayStream {
   // Callback to get the stream type
@@ -114,8 +114,8 @@ struct ArrowArrayStream {
   void* private_data;
 };
 
+#endif  // ARROW_C_STREAM_INTERFACE
+
 #ifdef __cplusplus
 }
 #endif
-
-#endif  // ARROW_C_STREAM_H

--- a/java/c/src/main/cpp/abi.h
+++ b/java/c/src/main/cpp/abi.h
@@ -63,12 +63,20 @@ struct ArrowArray {
   void* private_data;
 };
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif  // ARROW_C_DATA_H
 
 #ifndef ARROW_C_STREAM_H
 #define ARROW_C_STREAM_H
 
 // EXPERIMENTAL: C stream interface
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct ArrowArrayStream {
   // Callback to get the stream type

--- a/java/c/src/main/cpp/abi.h
+++ b/java/c/src/main/cpp/abi.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#ifndef ARROW_C_DATA_H
+
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -60,6 +62,10 @@ struct ArrowArray {
   void* private_data;
 };
 
+#endif  // ARROW_C_DATA_H
+
+#ifndef ARROW_C_STREAM_H
+
 // EXPERIMENTAL: C stream interface
 
 struct ArrowArrayStream {
@@ -101,3 +107,5 @@ struct ArrowArrayStream {
 #ifdef __cplusplus
 }
 #endif
+
+#endif  // ARROW_C_STREAM_H


### PR DESCRIPTION
Follow up from this mailing list discussion: "Arrow C-Data and DuckDB" [1]

Introduce canonical include guards so that the header can be embedded in other headers safely (some projects/APIs do this for convenience).

[1] https://lists.apache.org/thread/fxrbpo9ywm0yjol9b5zgb04w6tns59qj