### PR TITLE
ARROW-16526: [Python] test_partitioned_dataset fails when building with PARQUET but without DATASET

### DIFF
--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -1542,7 +1542,8 @@ def test_partitioned_dataset(tempdir, use_legacy_dataset):
     })
     table = pa.Table.from_pandas(df)
     pq.write_to_dataset(table, root_path=str(path),
-                        partition_cols=['one', 'two'])
+                        partition_cols=['one', 'two'],
+                        use_legacy_dataset=use_legacy_dataset)
     table = pq.ParquetDataset(
         path, use_legacy_dataset=use_legacy_dataset).read()
     pq.write_table(table, path / "output.parquet")


### PR DESCRIPTION
One of the legacy parquet dataset tests was not properly passing use_legacy_dataset and this caused the test to attempt to use the new datasets module even if it wasn't enabled