### PR TITLE
ARROW-16534: [Java] update Gandiva protobuf library to enable builds on M1

### DIFF
--- a/java/gandiva/pom.xml
+++ b/java/gandiva/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <protobuf.version>2.5.0</protobuf.version>
+        <protobuf.version>3.20.1</protobuf.version>
         <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
         <arrow.cpp.build.dir>../../../cpp/release-build</arrow.cpp.build.dir>
     </properties>


### PR DESCRIPTION
Currently used protobuf library 2.5.0 does not include support for M1, causing tests to fail after compiling from source on Apple Silicon. Version 3.20.1 does provide M1 support. This PR updates the library version. 