### PR TITLE
ARROW-16551: [Go] Improve Temporal Types

### DIFF
--- a/go/arrow/array/numericbuilder.gen.go
+++ b/go/arrow/array/numericbuilder.gen.go
@@ -2211,7 +2211,9 @@ func (b *TimestampBuilder) unmarshalOne(dec *json.Decoder) error {
 	case nil:
 		b.AppendNull()
 	case string:
-		tm, err := arrow.TimestampFromString(v, b.dtype.Unit)
+		loc, _ := b.dtype.GetZone()
+		tm, err := arrow.TimestampFromStringInLocation(v, b.dtype.Unit, loc)
+
 		if err != nil {
 			return &json.UnmarshalTypeError{
 				Value:  v,
@@ -2221,6 +2223,18 @@ func (b *TimestampBuilder) unmarshalOne(dec *json.Decoder) error {
 		}
 
 		b.Append(tm)
+	case json.Number:
+		n, err := v.Int64()
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value:  v.String(),
+				Type:   reflect.TypeOf(arrow.Timestamp(0)),
+				Offset: dec.InputOffset(),
+			}
+		}
+		b.Append(arrow.Timestamp(n))
+	case float64:
+		b.Append(arrow.Timestamp(v))
 
 	default:
 		return &json.UnmarshalTypeError{
@@ -2404,6 +2418,7 @@ func (b *Time32Builder) unmarshalOne(dec *json.Decoder) error {
 		b.AppendNull()
 	case string:
 		tm, err := arrow.Time32FromString(v, b.dtype.Unit)
+
 		if err != nil {
 			return &json.UnmarshalTypeError{
 				Value:  v,
@@ -2413,6 +2428,18 @@ func (b *Time32Builder) unmarshalOne(dec *json.Decoder) error {
 		}
 
 		b.Append(tm)
+	case json.Number:
+		n, err := v.Int64()
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value:  v.String(),
+				Type:   reflect.TypeOf(arrow.Time32(0)),
+				Offset: dec.InputOffset(),
+			}
+		}
+		b.Append(arrow.Time32(n))
+	case float64:
+		b.Append(arrow.Time32(v))
 
 	default:
 		return &json.UnmarshalTypeError{
@@ -2596,6 +2623,7 @@ func (b *Time64Builder) unmarshalOne(dec *json.Decoder) error {
 		b.AppendNull()
 	case string:
 		tm, err := arrow.Time64FromString(v, b.dtype.Unit)
+
 		if err != nil {
 			return &json.UnmarshalTypeError{
 				Value:  v,
@@ -2605,6 +2633,18 @@ func (b *Time64Builder) unmarshalOne(dec *json.Decoder) error {
 		}
 
 		b.Append(tm)
+	case json.Number:
+		n, err := v.Int64()
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value:  v.String(),
+				Type:   reflect.TypeOf(arrow.Time64(0)),
+				Offset: dec.InputOffset(),
+			}
+		}
+		b.Append(arrow.Time64(n))
+	case float64:
+		b.Append(arrow.Time64(v))
 
 	default:
 		return &json.UnmarshalTypeError{
@@ -2796,6 +2836,18 @@ func (b *Date32Builder) unmarshalOne(dec *json.Decoder) error {
 		}
 
 		b.Append(arrow.Date32FromTime(tm))
+	case json.Number:
+		n, err := v.Int64()
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value:  v.String(),
+				Type:   reflect.TypeOf(arrow.Date32(0)),
+				Offset: dec.InputOffset(),
+			}
+		}
+		b.Append(arrow.Date32(n))
+	case float64:
+		b.Append(arrow.Date32(v))
 
 	default:
 		return &json.UnmarshalTypeError{
@@ -2987,6 +3039,18 @@ func (b *Date64Builder) unmarshalOne(dec *json.Decoder) error {
 		}
 
 		b.Append(arrow.Date64FromTime(tm))
+	case json.Number:
+		n, err := v.Int64()
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value:  v.String(),
+				Type:   reflect.TypeOf(arrow.Date64(0)),
+				Offset: dec.InputOffset(),
+			}
+		}
+		b.Append(arrow.Date64(n))
+	case float64:
+		b.Append(arrow.Date64(v))
 
 	default:
 		return &json.UnmarshalTypeError{
@@ -3168,6 +3232,18 @@ func (b *DurationBuilder) unmarshalOne(dec *json.Decoder) error {
 	switch v := t.(type) {
 	case nil:
 		b.AppendNull()
+	case json.Number:
+		n, err := v.Int64()
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value:  v.String(),
+				Type:   reflect.TypeOf(arrow.Duration(0)),
+				Offset: dec.InputOffset(),
+			}
+		}
+		b.Append(arrow.Duration(n))
+	case float64:
+		b.Append(arrow.Duration(v))
 	case string:
 		// be flexible for specifying durations by accepting forms like
 		// 3h2m0.5s regardless of the unit and converting it to the proper

--- a/go/arrow/array/numericbuilder.gen.go.tmpl
+++ b/go/arrow/array/numericbuilder.gen.go.tmpl
@@ -196,9 +196,26 @@ func (b *{{.Name}}Builder) unmarshalOne(dec *json.Decoder) error {
 		}
 
 		b.Append({{.QualifiedType}}FromTime(tm))
+	case json.Number:
+		n, err := v.Int64()
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: v.String(),
+				Type: reflect.TypeOf({{.QualifiedType}}(0)),
+				Offset: dec.InputOffset(),
+			}
+		}
+		b.Append({{.QualifiedType}}(n))
+	case float64:
+		b.Append({{.QualifiedType}}(v))
 {{else if or (eq .Name "Time32") (eq .Name "Time64") (eq .Name "Timestamp") -}}
 	case string:
+{{if (eq .Name "Timestamp") -}}
+		loc, _ := b.dtype.GetZone()
+		tm, err := arrow.TimestampFromStringInLocation(v, b.dtype.Unit, loc)
+{{else -}}
 		tm, err := {{.QualifiedType}}FromString(v, b.dtype.Unit)
+{{end}}
 		if err != nil {
 			return &json.UnmarshalTypeError{
 				Value: v,
@@ -208,7 +225,31 @@ func (b *{{.Name}}Builder) unmarshalOne(dec *json.Decoder) error {
 		}
 
 		b.Append(tm)
+	case json.Number:
+		n, err := v.Int64()
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: v.String(),
+				Type: reflect.TypeOf({{.QualifiedType}}(0)),
+				Offset: dec.InputOffset(),
+			}
+		}
+		b.Append({{.QualifiedType}}(n))
+	case float64:
+		b.Append({{.QualifiedType}}(v))
 {{else if eq .Name "Duration" -}}
+	case json.Number:
+		n, err := v.Int64()
+		if err != nil {
+			return &json.UnmarshalTypeError{
+				Value: v.String(),
+				Type: reflect.TypeOf({{.QualifiedType}}(0)),
+				Offset: dec.InputOffset(),
+			}
+		}
+		b.Append({{.QualifiedType}}(n))
+	case float64:
+		b.Append({{.QualifiedType}}(v))
 	case string:
 		// be flexible for specifying durations by accepting forms like
 		// 3h2m0.5s regardless of the unit and converting it to the proper

--- a/go/arrow/array/util_test.go
+++ b/go/arrow/array/util_test.go
@@ -288,9 +288,10 @@ func TestDateJSON(t *testing.T) {
 		bldr := array.NewDate32Builder(memory.DefaultAllocator)
 		defer bldr.Release()
 
-		jsonstr := `["1970-01-06", null, "1970-02-12"]`
+		jsonstr := `["1970-01-06", null, "1970-02-12", 0]`
+		jsonExp := `["1970-01-06", null, "1970-02-12", "1970-01-01"]`
 
-		bldr.AppendValues([]arrow.Date32{5, 0, 42}, []bool{true, false, true})
+		bldr.AppendValues([]arrow.Date32{5, 0, 42, 0}, []bool{true, false, true, true})
 		expected := bldr.NewArray()
 		defer expected.Release()
 
@@ -302,15 +303,16 @@ func TestDateJSON(t *testing.T) {
 
 		data, err := json.Marshal(arr)
 		assert.NoError(t, err)
-		assert.JSONEq(t, jsonstr, string(data))
+		assert.JSONEq(t, jsonExp, string(data))
 	})
 	t.Run("date64", func(t *testing.T) {
 		bldr := array.NewDate64Builder(memory.DefaultAllocator)
 		defer bldr.Release()
 
-		jsonstr := `["1970-01-02", null, "2286-11-20"]`
+		jsonstr := `["1970-01-02", null, "2286-11-20", 86400000]`
+		jsonExp := `["1970-01-02", null, "2286-11-20", "1970-01-02"]`
 
-		bldr.AppendValues([]arrow.Date64{86400000, 0, 9999936000000}, []bool{true, false, true})
+		bldr.AppendValues([]arrow.Date64{86400000, 0, 9999936000000, 86400000}, []bool{true, false, true, true})
 		expected := bldr.NewArray()
 		defer expected.Release()
 
@@ -322,7 +324,7 @@ func TestDateJSON(t *testing.T) {
 
 		data, err := json.Marshal(arr)
 		assert.NoError(t, err)
-		assert.JSONEq(t, jsonstr, string(data))
+		assert.JSONEq(t, jsonExp, string(data))
 	})
 }
 
@@ -331,12 +333,13 @@ func TestTimeJSON(t *testing.T) {
 	tests := []struct {
 		dt       arrow.DataType
 		jsonstr  string
+		jsonexp  string
 		valueadd int
 	}{
-		{arrow.FixedWidthTypes.Time32s, `[null, "10:10:10"]`, 123},
-		{arrow.FixedWidthTypes.Time32ms, `[null, "10:10:10.123"]`, 456},
-		{arrow.FixedWidthTypes.Time64us, `[null, "10:10:10.123456"]`, 789},
-		{arrow.FixedWidthTypes.Time64ns, `[null, "10:10:10.123456789"]`, 0},
+		{arrow.FixedWidthTypes.Time32s, `[null, "10:10:10", 36610]`, `[null, "10:10:10", "10:10:10"]`, 123},
+		{arrow.FixedWidthTypes.Time32ms, `[null, "10:10:10.123", 36610123]`, `[null, "10:10:10.123", "10:10:10.123"]`, 456},
+		{arrow.FixedWidthTypes.Time64us, `[null, "10:10:10.123456", 36610123456]`, `[null, "10:10:10.123456", "10:10:10.123456"]`, 789},
+		{arrow.FixedWidthTypes.Time64ns, `[null, "10:10:10.123456789", 36610123456789]`, `[null, "10:10:10.123456789", "10:10:10.123456789"]`, 0},
 	}
 
 	for _, tt := range tests {
@@ -350,9 +353,9 @@ func TestTimeJSON(t *testing.T) {
 
 			switch tt.dt.ID() {
 			case arrow.TIME32:
-				bldr.(*array.Time32Builder).AppendValues([]arrow.Time32{0, arrow.Time32(tententen)}, []bool{false, true})
+				bldr.(*array.Time32Builder).AppendValues([]arrow.Time32{0, arrow.Time32(tententen), arrow.Time32(tententen)}, []bool{false, true, true})
 			case arrow.TIME64:
-				bldr.(*array.Time64Builder).AppendValues([]arrow.Time64{0, arrow.Time64(tententen)}, []bool{false, true})
+				bldr.(*array.Time64Builder).AppendValues([]arrow.Time64{0, arrow.Time64(tententen), arrow.Time64(tententen)}, []bool{false, true, true})
 			}
 
 			expected := bldr.NewArray()
@@ -366,7 +369,7 @@ func TestTimeJSON(t *testing.T) {
 
 			data, err := json.Marshal(arr)
 			assert.NoError(t, err)
-			assert.JSONEq(t, tt.jsonstr, string(data))
+			assert.JSONEq(t, tt.jsonexp, string(data))
 		})
 	}
 }

--- a/go/arrow/datatype_fixedwidth_test.go
+++ b/go/arrow/datatype_fixedwidth_test.go
@@ -112,7 +112,7 @@ func TestTimestampType(t *testing.T) {
 		{arrow.Second, "", "timestamp[s]"},
 	} {
 		t.Run(tc.want, func(t *testing.T) {
-			dt := arrow.TimestampType{tc.unit, tc.timeZone}
+			dt := arrow.TimestampType{Unit: tc.unit, TimeZone: tc.timeZone}
 			if got, want := dt.BitWidth(), 64; got != want {
 				t.Fatalf("invalid bitwidth: got=%d, want=%d", got, want)
 			}


### PR DESCRIPTION
Fix JSON reading of Temporal types to allow passing numbers in addition to strings that will be parsed. Enhance timestamps to allow specifying the time zone when parsing the string. Provide function to retrieve a time.Location from a TimestampType