### PR TITLE
MINOR: [R] Clarify read_json_arrow() docs

### DIFF
--- a/r/R/json.R
+++ b/r/R/json.R
@@ -17,7 +17,7 @@
 
 #' Read a JSON file
 #'
-#' Use [JsonTableReader] to read a newline-delimited JSON (ndjson) file into a
+#' Wrapper around [JsonTableReader] to read a newline-delimited JSON (ndjson) file into a
 #' data frame or Arrow Table.
 #'
 #' If passed a path, will detect and handle compression from the file extension

--- a/r/R/json.R
+++ b/r/R/json.R
@@ -17,7 +17,11 @@
 
 #' Read a JSON file
 #'
-#' Using [JsonTableReader]
+#' Use [JsonTableReader] to read a newline-delimited JSON (ndjson) file into a
+#' data frame or Arrow Table.
+#'
+#' If passed a path, will detect and handle compression from the file extension
+#' (e.g. `.json.gz`). Accepts explicit or implicit nulls.
 #'
 #' @inheritParams read_delim_arrow
 #' @param schema [Schema] that describes the table.

--- a/r/man/read_json_arrow.Rd
+++ b/r/man/read_json_arrow.Rd
@@ -36,7 +36,7 @@ an Arrow \link{Table}?}
 A \code{data.frame}, or a Table if \code{as_data_frame = FALSE}.
 }
 \description{
-Use \link{JsonTableReader} to read a newline-delimited JSON (ndjson) file into a
+Wrapper around \link{JsonTableReader} to read a newline-delimited JSON (ndjson) file into a
 data frame or Arrow Table.
 }
 \details{

--- a/r/man/read_json_arrow.Rd
+++ b/r/man/read_json_arrow.Rd
@@ -36,7 +36,12 @@ an Arrow \link{Table}?}
 A \code{data.frame}, or a Table if \code{as_data_frame = FALSE}.
 }
 \description{
-Using \link{JsonTableReader}
+Use \link{JsonTableReader} to read a newline-delimited JSON (ndjson) file into a
+data frame or Arrow Table.
+}
+\details{
+If passed a path, will detect and handle compression from the file extension
+(e.g. \code{.json.gz}). Accepts explicit or implicit nulls.
 }
 \examples{
 \dontshow{if (arrow_with_json()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}


### PR DESCRIPTION
A quick PR to clarify `read_json_arrow()` docs I found confusing while benchmarking. Specifically, specifies the function

- is for ndjson (as opposed to say the many json formats to which pandas can write a dataframe)
- handles compression
- handles implicit and explicit nulls (was in the example, but not previously stated)

Open to changes, but do feel these docs need to at least explicitly say "ndjson" somewhere.