### PR TITLE
ARROW-16563: [Go][Parquet] Fix broken parquet plain boolean decoder

### DIFF
--- a/go/parquet/internal/encoding/boolean_decoder.go
+++ b/go/parquet/internal/encoding/boolean_decoder.go
@@ -37,6 +37,12 @@ func (PlainBooleanDecoder) Type() parquet.Type {
 	return parquet.Types.Boolean
 }
 
+func (dec *PlainBooleanDecoder) SetData(nvals int, data []byte) error {
+	dec.decoder.SetData(nvals, data)
+	dec.bitOffset = 0
+	return nil
+}
+
 // Decode fills out with bools decoded from the data at the current point
 // or until we reach the end of the data.
 //
@@ -44,41 +50,44 @@ func (PlainBooleanDecoder) Type() parquet.Type {
 func (dec *PlainBooleanDecoder) Decode(out []bool) (int, error) {
 	max := shared_utils.MinInt(len(out), dec.nvals)
 
-	unalignedExtract := func(start, end, curBitOffset int) int {
+	// attempts to read all remaining bool values from the current data byte, starting at curBitOffset
+	unalignedExtract := func(start, curBitOffset int) int {
 		i := start
-		for ; curBitOffset < end && i < max; i, curBitOffset = i+1, curBitOffset+1 {
+		for ; curBitOffset < 8 && i < max; i, curBitOffset = i+1, curBitOffset+1 {
 			out[i] = (dec.data[0] & byte(1<<curBitOffset)) != 0
 		}
-		return i // return the number of bits we extracted
+		if curBitOffset == 8 {
+			// we read every bit from this byte, move data forward
+			curBitOffset = 0
+			dec.data = dec.data[1:]
+		}
+		dec.bitOffset = curBitOffset
+		return i - start // return the number of bits we extracted
 	}
 
 	// if we aren't at a byte boundary, then get bools until we hit
 	// a byte boundary with the bit offset.
 	i := 0
 	if dec.bitOffset != 0 {
-		i = unalignedExtract(0, 8, dec.bitOffset)
-		dec.bitOffset = (dec.bitOffset + i) % 8
+		i += unalignedExtract(0, dec.bitOffset)
 	}
 
 	// determine the number of full bytes worth of bits we can decode
 	// given the number of values we want to decode.
 	bitsRemain := max - i
-	batch := bitsRemain / 8 * 8
+	batch := (bitsRemain / 8) * 8
 	if batch > 0 { // only go in here if there's at least one full byte to decode
-		if i > 0 { // skip our data forward if we decoded anything above
-			dec.data = dec.data[1:]
-			out = out[i:]
-		}
 		// determine the number of aligned bytes we can grab using SIMD optimized
 		// functions to improve performance.
 		alignedBytes := bitutil.BytesForBits(int64(batch))
-		utils.BytesToBools(dec.data[:alignedBytes], out)
-		dec.data = dec.data[alignedBytes:]
-		out = out[alignedBytes*8:]
+		utils.BytesToBools(dec.data[:alignedBytes], out[i:])
+
+		dec.data = dec.data[alignedBytes:] // move data forward
+		i += int(alignedBytes) * 8
 	}
 
 	// grab any trailing bits now that we've got our aligned bytes.
-	dec.bitOffset += unalignedExtract(dec.bitOffset, bitsRemain-batch, dec.bitOffset)
+	i += unalignedExtract(i, dec.bitOffset)
 
 	dec.nvals -= max
 	return max, nil

--- a/go/parquet/internal/encoding/boolean_decoder.go
+++ b/go/parquet/internal/encoding/boolean_decoder.go
@@ -87,7 +87,7 @@ func (dec *PlainBooleanDecoder) Decode(out []bool) (int, error) {
 	}
 
 	// grab any trailing bits now that we've got our aligned bytes.
-	i = unalignedExtract(i)
+	_ = unalignedExtract(i)
 
 	dec.nvals -= max
 	return max, nil

--- a/go/parquet/internal/testutils/pagebuilder.go
+++ b/go/parquet/internal/testutils/pagebuilder.go
@@ -114,7 +114,7 @@ func (d *DataPageBuilder) AppendValues(desc *schema.Column, values interface{}, 
 		enc.(encoding.ByteArrayEncoder).Put(v)
 		sz = len(v)
 	default:
-		panic(fmt.Sprintf("no testutil dictionary page builder for type %T", values))
+		panic(fmt.Sprintf("no testutil data page builder for type %T", values))
 	}
 	buf, _ := enc.FlushValues()
 	_, err := d.sink.Write(buf.Bytes())

--- a/go/parquet/internal/testutils/pagebuilder.go
+++ b/go/parquet/internal/testutils/pagebuilder.go
@@ -18,6 +18,7 @@ package testutils
 
 import (
 	"encoding/binary"
+	"fmt"
 	"io"
 	"reflect"
 
@@ -91,6 +92,9 @@ func (d *DataPageBuilder) AppendValues(desc *schema.Column, values interface{}, 
 	enc := encoding.NewEncoder(desc.PhysicalType(), e, false, desc, mem)
 	var sz int
 	switch v := values.(type) {
+	case []bool:
+		enc.(encoding.BooleanEncoder).Put(v)
+		sz = len(v)
 	case []int32:
 		enc.(encoding.Int32Encoder).Put(v)
 		sz = len(v)
@@ -109,6 +113,8 @@ func (d *DataPageBuilder) AppendValues(desc *schema.Column, values interface{}, 
 	case []parquet.ByteArray:
 		enc.(encoding.ByteArrayEncoder).Put(v)
 		sz = len(v)
+	default:
+		panic(fmt.Sprintf("no testutil dictionary page builder for type %T", values))
 	}
 	buf, _ := enc.FlushValues()
 	_, err := d.sink.Write(buf.Bytes())
@@ -147,6 +153,8 @@ func (d *DictionaryPageBuilder) AppendValues(values interface{}) encoding.Buffer
 		d.traits.(encoding.Float64Encoder).Put(v)
 	case []parquet.ByteArray:
 		d.traits.(encoding.ByteArrayEncoder).Put(v)
+	default:
+		panic(fmt.Sprintf("no testutil dictionary page builder for type %T", values))
 	}
 
 	d.numDictValues = int32(d.traits.NumEntries())


### PR DESCRIPTION
While reading parquet files using this library, we discovered that boolean fields with `PLAIN` encoding were not being read properly. It was discovered that this was due to how `bitOffset` was managed in the boolean decoder; this PR patches the decoder and also adds test coverage for reading plain boolean pages.