### PR TITLE
ARROW-16566: [Java] Initialize JNI components on use instead of statically

### DIFF
--- a/java/c/src/main/java/org/apache/arrow/c/jni/JniWrapper.java
+++ b/java/c/src/main/java/org/apache/arrow/c/jni/JniWrapper.java
@@ -24,6 +24,7 @@ public class JniWrapper {
   private static final JniWrapper INSTANCE = new JniWrapper();
 
   public static JniWrapper get() {
+    JniLoader.get().ensureLoaded();
     return INSTANCE;
   }
 
@@ -34,7 +35,6 @@ public class JniWrapper {
       throw new UnsupportedOperationException(
           "The Java C Data Interface implementation is currently only supported on 64-bit systems");
     }
-    JniLoader.get().ensureLoaded();
   }
 
   public native void releaseSchema(long memoryAddress);

--- a/java/dataset/src/main/java/org/apache/arrow/dataset/file/JniWrapper.java
+++ b/java/dataset/src/main/java/org/apache/arrow/dataset/file/JniWrapper.java
@@ -27,11 +27,11 @@ public class JniWrapper {
   private static final JniWrapper INSTANCE = new JniWrapper();
   
   public static JniWrapper get() {
+    JniLoader.get().ensureLoaded();
     return INSTANCE;
   }
 
   private JniWrapper() {
-    JniLoader.get().ensureLoaded();
   }
 
   /**

--- a/java/dataset/src/main/java/org/apache/arrow/dataset/jni/JniWrapper.java
+++ b/java/dataset/src/main/java/org/apache/arrow/dataset/jni/JniWrapper.java
@@ -25,11 +25,11 @@ public class JniWrapper {
   private static final JniWrapper INSTANCE = new JniWrapper();
 
   public static JniWrapper get() {
+    JniLoader.get().ensureLoaded();
     return INSTANCE;
   }
 
   private JniWrapper() {
-    JniLoader.get().ensureLoaded();
   }
 
   /**

--- a/java/dataset/src/main/java/org/apache/arrow/dataset/jni/NativeMemoryPool.java
+++ b/java/dataset/src/main/java/org/apache/arrow/dataset/jni/NativeMemoryPool.java
@@ -23,10 +23,6 @@ package org.apache.arrow.dataset.jni;
 public class NativeMemoryPool implements AutoCloseable {
   private final long nativeInstanceId;
 
-  private static void ensureLoaded() {
-    JniLoader.get().ensureLoaded();
-  }
-
   private NativeMemoryPool(long nativeInstanceId) {
     this.nativeInstanceId = nativeInstanceId;
   }
@@ -35,7 +31,7 @@ public class NativeMemoryPool implements AutoCloseable {
    * Get the default memory pool. This will return arrow::default_memory_pool() directly.
    */
   public static NativeMemoryPool getDefault() {
-    ensureLoaded();
+    JniLoader.get().ensureLoaded();
     return new NativeMemoryPool(getDefaultMemoryPool());
   }
 
@@ -45,7 +41,7 @@ public class NativeMemoryPool implements AutoCloseable {
    * from the listener in advance.
    */
   public static NativeMemoryPool createListenable(ReservationListener listener) {
-    ensureLoaded();
+    JniLoader.get().ensureLoaded();
     return new NativeMemoryPool(createListenableMemoryPool(listener));
   }
 

--- a/java/dataset/src/main/java/org/apache/arrow/dataset/jni/NativeMemoryPool.java
+++ b/java/dataset/src/main/java/org/apache/arrow/dataset/jni/NativeMemoryPool.java
@@ -23,7 +23,7 @@ package org.apache.arrow.dataset.jni;
 public class NativeMemoryPool implements AutoCloseable {
   private final long nativeInstanceId;
 
-  static {
+  private static void ensureLoaded() {
     JniLoader.get().ensureLoaded();
   }
 
@@ -35,6 +35,7 @@ public class NativeMemoryPool implements AutoCloseable {
    * Get the default memory pool. This will return arrow::default_memory_pool() directly.
    */
   public static NativeMemoryPool getDefault() {
+    ensureLoaded();
     return new NativeMemoryPool(getDefaultMemoryPool());
   }
 
@@ -44,6 +45,7 @@ public class NativeMemoryPool implements AutoCloseable {
    * from the listener in advance.
    */
   public static NativeMemoryPool createListenable(ReservationListener listener) {
+    ensureLoaded();
     return new NativeMemoryPool(createListenableMemoryPool(listener));
   }
 


### PR DESCRIPTION
We are using Arrow in Spark. When speculation is turned on, it is possible for the task to be forcibly killed during the running process. It means, `JniLoader.get().ensureLoaded()` maybe failed with `ClosedByInterruptException` when the task was killed, and it should be accepted with this.
However, `NativeMemoryPool` use it as a static code, this leads to an init failure every time the NativeMemroyPool is trying to initialized and can never succeed. It would always fail to init `NativeMemoryPool` with `java.lang.NoClassDefFoundError: Could not initialize class org.apache.arrow.dataset.jni.NativeMemoryPool`.