### PR TITLE
ARROW-16548: [Python] Add pytest.mark.parquet to all tests under tests/parquet package

### DIFF
--- a/python/pyarrow/tests/parquet/common.py
+++ b/python/pyarrow/tests/parquet/common.py
@@ -43,10 +43,6 @@ parametrize_legacy_dataset_fixed = pytest.mark.parametrize(
      pytest.param(False, marks=pytest.mark.dataset)]
 )
 
-# Marks all of the tests in this module
-# Ignore these with pytest ... -m 'not parquet'
-pytestmark = pytest.mark.parquet
-
 
 def _write_table(table, path, **kwargs):
     # So we see the ImportError somewhere

--- a/python/pyarrow/tests/parquet/conftest.py
+++ b/python/pyarrow/tests/parquet/conftest.py
@@ -25,14 +25,6 @@ def datadir(base_datadir):
     return base_datadir / 'parquet'
 
 
-def pytest_collection_modifyitems(items):
-    for item in items:
-        # Marks all tests in the parquet package
-        # Ignore these with pytest ... -m 'not parquet'c
-        if item.parent.parent.name == "parquet":
-            item.add_marker(pytest.mark.parquet)
-
-
 @pytest.fixture
 def s3_bucket(s3_server):
     boto3 = pytest.importorskip('boto3')

--- a/python/pyarrow/tests/parquet/conftest.py
+++ b/python/pyarrow/tests/parquet/conftest.py
@@ -25,6 +25,14 @@ def datadir(base_datadir):
     return base_datadir / 'parquet'
 
 
+def pytest_collection_modifyitems(items):
+    for item in items:
+        # Marks all tests in the parquet package
+        # Ignore these with pytest ... -m 'not parquet'c
+        if item.parent.parent.name == "parquet":
+            item.add_marker(pytest.mark.parquet)
+
+
 @pytest.fixture
 def s3_bucket(s3_server):
     boto3 = pytest.importorskip('boto3')

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -46,6 +46,11 @@ except ImportError:
     pd = tm = None
 
 
+# Marks all of the tests in this module
+# Ignore these with pytest ... -m 'not parquet'
+pytestmark = pytest.mark.parquet
+
+
 def test_parquet_invalid_version(tempdir):
     table = pa.table({'a': [1, 2, 3]})
     with pytest.raises(ValueError, match="Unsupported Parquet format version"):

--- a/python/pyarrow/tests/parquet/test_compliant_nested_type.py
+++ b/python/pyarrow/tests/parquet/test_compliant_nested_type.py
@@ -36,6 +36,11 @@ except ImportError:
     pd = tm = None
 
 
+# Marks all of the tests in this module
+# Ignore these with pytest ... -m 'not parquet'
+pytestmark = pytest.mark.parquet
+
+
 # Tests for ARROW-11497
 _test_data_simple = [
     {'items': [1, 2]},

--- a/python/pyarrow/tests/parquet/test_data_types.py
+++ b/python/pyarrow/tests/parquet/test_data_types.py
@@ -44,6 +44,11 @@ except ImportError:
     pd = tm = None
 
 
+# Marks all of the tests in this module
+# Ignore these with pytest ... -m 'not parquet'
+pytestmark = pytest.mark.parquet
+
+
 # General roundtrip of data types
 # -----------------------------------------------------------------------------
 

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -47,6 +47,11 @@ except ImportError:
     pd = tm = None
 
 
+# Marks all of the tests in this module
+# Ignore these with pytest ... -m 'not parquet'
+pytestmark = pytest.mark.parquet
+
+
 @pytest.mark.pandas
 def test_parquet_piece_read(tempdir):
     df = _test_dataframe(1000)

--- a/python/pyarrow/tests/parquet/test_datetime.py
+++ b/python/pyarrow/tests/parquet/test_datetime.py
@@ -41,6 +41,11 @@ except ImportError:
     pd = tm = None
 
 
+# Marks all of the tests in this module
+# Ignore these with pytest ... -m 'not parquet'
+pytestmark = pytest.mark.parquet
+
+
 @pytest.mark.pandas
 @parametrize_legacy_dataset
 def test_pandas_parquet_datetime_tz(use_legacy_dataset):

--- a/python/pyarrow/tests/parquet/test_encryption.py
+++ b/python/pyarrow/tests/parquet/test_encryption.py
@@ -38,7 +38,9 @@ COL_KEY_NAME = "col_key"
 
 # Marks all of the tests in this module
 # Ignore these with pytest ... -m 'not parquet_encryption'
+# Ignore these with pytest ... -m 'not parquet'
 pytestmark = pytest.mark.parquet_encryption
+pytestmark = pytest.mark.parquet
 
 
 @pytest.fixture(scope='module')

--- a/python/pyarrow/tests/parquet/test_metadata.py
+++ b/python/pyarrow/tests/parquet/test_metadata.py
@@ -41,6 +41,11 @@ except ImportError:
     pd = tm = None
 
 
+# Marks all of the tests in this module
+# Ignore these with pytest ... -m 'not parquet'
+pytestmark = pytest.mark.parquet
+
+
 @pytest.mark.pandas
 def test_parquet_metadata_api():
     df = alltypes_sample(size=10000)

--- a/python/pyarrow/tests/parquet/test_pandas.py
+++ b/python/pyarrow/tests/parquet/test_pandas.py
@@ -46,6 +46,11 @@ except ImportError:
     pd = tm = None
 
 
+# Marks all of the tests in this module
+# Ignore these with pytest ... -m 'not parquet'
+pytestmark = pytest.mark.parquet
+
+
 @pytest.mark.pandas
 def test_pandas_parquet_custom_metadata(tempdir):
     df = alltypes_sample(size=10000)

--- a/python/pyarrow/tests/parquet/test_parquet_file.py
+++ b/python/pyarrow/tests/parquet/test_parquet_file.py
@@ -37,6 +37,11 @@ except ImportError:
     pd = tm = None
 
 
+# Marks all of the tests in this module
+# Ignore these with pytest ... -m 'not parquet'
+pytestmark = pytest.mark.parquet
+
+
 @pytest.mark.pandas
 def test_pass_separate_metadata():
     # ARROW-471

--- a/python/pyarrow/tests/parquet/test_parquet_writer.py
+++ b/python/pyarrow/tests/parquet/test_parquet_writer.py
@@ -37,6 +37,11 @@ except ImportError:
     pd = tm = None
 
 
+# Marks all of the tests in this module
+# Ignore these with pytest ... -m 'not parquet'
+pytestmark = pytest.mark.parquet
+
+
 @pytest.mark.pandas
 @parametrize_legacy_dataset
 def test_parquet_incremental_file_build(tempdir, use_legacy_dataset):


### PR DESCRIPTION
If we built arrow and pyarrow without PARQUET and tried to run the PARQUET tests. The first test being executed was not correctly marked.
```
> /home/raulcd/open_source/arrow/python/pyarrow/tests/conftest.py(244)pytest_runtest_setup()
-> for mark in item.iter_markers():
(Pdb) item
<Function test_parquet_invalid_version>
(Pdb) [x for x in item.iter_markers()]
[]
(Pdb)
```
Meaning the test was not correctly skipped. This was found on the minimal builds PR: https://github.com/apache/arrow/pull/13113 on this job failures: https://github.com/ursacomputing/crossbow/runs/6407176338?check_suite_focus=true

All tests under the parquet package are on the structure:
- parquet
├── test_basic.py
├── test_compliant_nested_type.py
├── test_dataset.py
├── test_data_types.py
├── test_datetime.py
├── test_encryption.py
├── test_metadata.py
├── test_pandas.py
├── test_parquet_file.py
└── test_parquet_writer.py

The implementation marks all the individual tests that are on this structure with the parquet dataset mark correctly.