### PR TITLE
ARROW-16572: [C++] Fix LZ4 build for external projects

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2314,7 +2314,7 @@ macro(build_lz4)
     set(LZ4_STATIC_LIB "${LZ4_BUILD_DIR}/lib/liblz4.a")
     # Must explicitly invoke sh on MinGW
     set(LZ4_BUILD_COMMAND
-        BUILD_COMMAND sh "${CMAKE_SOURCE_DIR}/build-support/build-lz4-lib.sh"
+        BUILD_COMMAND sh "${CMAKE_CURRENT_SOURCE_DIR}/build-support/build-lz4-lib.sh"
         "AR=${CMAKE_AR}" "OS=${CMAKE_SYSTEM_NAME}")
   endif()
 


### PR DESCRIPTION
The use of CMAKE_SOURCE_DIR is not compatible with projects that build arrow from source as a CMake project dependency.