### PR TITLE
ARROW-16561 [Go][Parquet] test for parquet root node configuration

### DIFF
--- a/go/parquet/pqarrow/schema_test.go
+++ b/go/parquet/pqarrow/schema_test.go
@@ -61,6 +61,37 @@ func TestGetOriginSchemaBase64(t *testing.T) {
 	}
 }
 
+func TestToParquetWriterConfig(t *testing.T) {
+	origSc := arrow.NewSchema([]arrow.Field{
+		{Name: "f1", Type: arrow.BinaryTypes.String},
+		{Name: "f2", Type: arrow.PrimitiveTypes.Int64},
+	}, nil)
+
+	tests := []struct {
+		name           string
+		rootRepetition parquet.Repetition
+	}{
+		{"test1", parquet.Repetitions.Required},
+		{"test2", parquet.Repetitions.Repeated},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			pqschema, err := pqarrow.ToParquet(origSc,
+				parquet.NewWriterProperties(
+					parquet.WithRootName(tt.name),
+					parquet.WithRootRepetition(tt.rootRepetition),
+				),
+				pqarrow.DefaultWriterProps())
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.name, pqschema.Root().Name())
+			assert.Equal(t, tt.rootRepetition, pqschema.Root().RepetitionType())
+		})
+	}
+}
+
 func TestConvertArrowFlatPrimitives(t *testing.T) {
 	parquetFields := make(schema.FieldList, 0)
 	arrowFields := make([]arrow.Field, 0)

--- a/go/parquet/reader_writer_properties_test.go
+++ b/go/parquet/reader_writer_properties_test.go
@@ -48,7 +48,9 @@ func TestWriterPropAdvanced(t *testing.T) {
 		parquet.WithCompression(compress.Codecs.Snappy),
 		parquet.WithEncoding(parquet.Encodings.DeltaBinaryPacked),
 		parquet.WithEncodingFor("delta-length", parquet.Encodings.DeltaLengthByteArray),
-		parquet.WithDataPageVersion(parquet.DataPageV2))
+		parquet.WithDataPageVersion(parquet.DataPageV2),
+		parquet.WithRootName("test2"),
+		parquet.WithRootRepetition(parquet.Repetitions.Required))
 
 	assert.Equal(t, compress.Codecs.Gzip, props.CompressionPath(parquet.ColumnPathFromString("gzip")))
 	assert.Equal(t, compress.Codecs.Zstd, props.CompressionFor("zstd"))
@@ -56,6 +58,8 @@ func TestWriterPropAdvanced(t *testing.T) {
 	assert.Equal(t, parquet.Encodings.DeltaBinaryPacked, props.EncodingFor("gzip"))
 	assert.Equal(t, parquet.Encodings.DeltaLengthByteArray, props.EncodingPath(parquet.ColumnPathFromString("delta-length")))
 	assert.Equal(t, parquet.DataPageV2, props.DataPageVersion())
+	assert.Equal(t, "test2", props.RootName())
+	assert.Equal(t, parquet.Repetitions.Required, props.RootRepetition())
 }
 
 func TestReaderPropsGetStreamInsufficient(t *testing.T) {


### PR DESCRIPTION
As requested in #13139 I have added a test with some example configuration to verify it works as intended.

I added it to the schema test as well as that is where I am using it, hopefully that is fine @zeroshade .