### PR TITLE
ARROW-16579: [Go][CI] Fix Flakey Struct Test

### DIFF
--- a/go/arrow/array/struct_test.go
+++ b/go/arrow/array/struct_test.go
@@ -425,31 +425,34 @@ func TestStructArrayUnmarshalJSONMissingFields(t *testing.T) {
 		dtype = arrow.StructOf(fields...)
 	)
 
-	sb := array.NewStructBuilder(pool, dtype)
-	defer sb.Release()
-
-	tests := map[string]struct {
+	tests := []struct {
+		name      string
 		jsonInput string
 		want      string
 		panic     bool
 	}{
-		"missing optional fields": {
-			jsonInput: `[{"f2": 3, "f3": {"f3_3": "test"}}]`,
-			panic:     false,
-			want:      `{[(null)] [3] {[(null)] [(null)] ["test"]}}`,
-		},
-		"missing required field": {
+		{
+			name:      "missing required field",
 			jsonInput: `[{"f2": 3, "f3": {"f3_1": "test"}}]`,
 			panic:     true,
 			want:      "",
 		},
+		{
+			name:      "missing optional fields",
+			jsonInput: `[{"f2": 3, "f3": {"f3_3": "test"}}]`,
+			panic:     false,
+			want:      `{[(null)] [3] {[(null)] [(null)] ["test"]}}`,
+		},
 	}
 
-	for name, tc := range tests {
+	for _, tc := range tests {
 		t.Run(
-			name, func(t *testing.T) {
+			tc.name, func(t *testing.T) {
 
 				var val bool
+
+				sb := array.NewStructBuilder(pool, dtype)
+				defer sb.Release()
 
 				if tc.panic {
 					defer func() {


### PR DESCRIPTION
The tests for [ARROW-16502](https://issues.apache.org/jira/browse/ARROW-16502) reused the same `StructBuilder` between cases. But since it was testing for a panic, it left the StructBuilder in a bad state. This is understandable as it's a panic. Because the order of Go map's is non-deterministic, the test would only intermittently fail if the panic test went first and succeed if it went second.

By shifting the StructBuilder creating inside the test function, the two test cases no longer share it and the test is no longer flakey.