### PR TITLE
ARROW-16568: [Java] Enable skipping BOUNDS_CHECKING with setBytes and getBytes of ArrowBuf

### DIFF
--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/ArrowBuf.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/ArrowBuf.java
@@ -692,12 +692,14 @@ public final class ArrowBuf implements AutoCloseable {
   }
 
   private void checkIndex(long index, long fieldLength) {
-    // check reference count
-    this.ensureAccessible();
-    // check bounds
-    if (isOutOfBounds(index, fieldLength, this.capacity())) {
-      throw new IndexOutOfBoundsException(String.format("index: %d, length: %d (expected: range(0, %d))",
-        index, fieldLength, this.capacity()));
+    if (BoundsChecking.BOUNDS_CHECKING_ENABLED) {
+      // check reference count
+      this.ensureAccessible();
+      // check bounds
+      if (isOutOfBounds(index, fieldLength, this.capacity())) {
+        throw new IndexOutOfBoundsException(String.format("index: %d, length: %d (expected: range(0, %d))",
+                index, fieldLength, this.capacity()));
+      }
     }
   }
 


### PR DESCRIPTION
We have BOUNDS_CHECKING_SKIP in ArrowBuf.setByte or ArrowBuf.getByte, it helps to remove unexpected bounds checks. However, it doesn't exists in ArrowBuf.setBytes or ArrowBuf.getBytes, which makes 10% cpu time cost for checking bounds in our environment.