### PR TITLE
ARROW-16516: [R] Implement ym() my() and yq() parsers

### DIFF
--- a/r/R/dplyr-datetime-helpers.R
+++ b/r/R/dplyr-datetime-helpers.R
@@ -159,6 +159,10 @@ build_formats <- function(orders) {
   orders <- gsub("[^A-Za-z_]", "", orders)
   orders <- gsub("Y", "y", orders)
 
+  if (orders %in% c("ym", "my")) {
+    orders <- paste0(orders, "d")
+  }
+
   supported_orders <- c("ymd", "ydm", "mdy", "myd", "dmy", "dym")
   unsupported_passed_orders <- setdiff(orders, supported_orders)
   supported_passed_orders <- intersect(orders, supported_orders)

--- a/r/R/dplyr-datetime-helpers.R
+++ b/r/R/dplyr-datetime-helpers.R
@@ -159,12 +159,11 @@ build_formats <- function(orders) {
   orders <- gsub("[^A-Za-z_]", "", orders)
   orders <- gsub("Y", "y", orders)
 
-  # we need a different logic in order to deal with "ym', "my", and "yq" orders
-  # we separate them from the rest of the `orders` vector and transform them.
-  # `ym` and `yq` become `ymd` & `my` becomes `myd`
-  # this is needed because strptime does not parse "2022-05", so we add "-01",
-  # thus changing the format, and for equivalence with lubridate, which parses
-  # `ym` to the first day of the month
+  # we separate "ym', "my", and "yq" from the rest of the `orders` vector and
+  # transform them. `ym` and `yq` -> `ymd` & `my` -> `myd`
+  # this is needed for 2 reasons:
+  # 1. strptime does not parse "2022-05" -> we add "-01", thus changing the format,
+  # 2. for equivalence to lubridate, which parses `ym` to the first day of the month
   short_orders <- c("ym", "my")
 
   if (any(orders %in% short_orders)) {

--- a/r/R/dplyr-datetime-helpers.R
+++ b/r/R/dplyr-datetime-helpers.R
@@ -159,6 +159,12 @@ build_formats <- function(orders) {
   orders <- gsub("[^A-Za-z_]", "", orders)
   orders <- gsub("Y", "y", orders)
 
+  # we need a different logic in order to deal with "ym', "my", and "yq" orders
+  # we separate them from the rest of the `orders` vector and transform them.
+  # `ym` and `yq` become `ymd` & `my` becomes `myd`
+  # this is needed because strptime does not parse "2022-05", so we add "-01",
+  # thus changing the format, and for equivalence with lubridate, which parses
+  # `ym` to the first day of the month
   short_orders <- c("ym", "my")
 
   if (any(orders %in% short_orders)) {

--- a/r/R/dplyr-datetime-helpers.R
+++ b/r/R/dplyr-datetime-helpers.R
@@ -159,8 +159,19 @@ build_formats <- function(orders) {
   orders <- gsub("[^A-Za-z_]", "", orders)
   orders <- gsub("Y", "y", orders)
 
-  if (orders %in% c("ym", "my")) {
-    orders <- paste0(orders, "d")
+  short_orders <- c("ym", "my")
+
+  if (any(orders %in% short_orders)) {
+    orders1 <- setdiff(orders, short_orders)
+    orders2 <- intersect(orders, short_orders)
+    orders2 <- paste0(orders2, "d")
+    orders <- unique(c(orders1, orders2))
+  }
+
+  if (any(orders == "yq")) {
+    orders1 <- setdiff(orders, "yq")
+    orders2 <- "ymd"
+    orders <- unique(c(orders1, orders2))
   }
 
   supported_orders <- c("ymd", "ydm", "mdy", "myd", "dmy", "dym")

--- a/r/R/dplyr-datetime-helpers.R
+++ b/r/R/dplyr-datetime-helpers.R
@@ -191,7 +191,8 @@ build_formats <- function(orders) {
   }
 
   formats_list <- map(orders, build_format_from_order)
-  purrr::flatten_chr(formats_list)
+  formats <- purrr::flatten_chr(formats_list)
+  unique(formats)
 }
 
 build_format_from_order <- function(order) {

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -529,15 +529,18 @@ register_bindings_datetime_parsers <- function() {
     # tricky given the possible combinations between dmy formats + locale
 
     # build a list of expressions for each format
-    parse_attempt_expressions <- list()
-
-    for (i in seq_along(formats)) {
-      parse_attempt_expressions[[i]] <- build_expr(
+    parse_attempt_expressions <- map(
+      formats,
+      ~ build_expr(
         "strptime",
         x,
-        options = list(format = formats[[i]], unit = 0L, error_is_null = TRUE)
+        options = list(
+          format = .x,
+          unit = 0L,
+          error_is_null = TRUE
+        )
       )
-    }
+    )
 
     # build separate expression lists of parsing attempts for the orders that
     # need an augmented `x`
@@ -545,26 +548,35 @@ register_bindings_datetime_parsers <- function() {
     parse_attempt_exp_augmented_x <- list()
 
     if (!is.null(augmented_x)) {
-      for (i in seq_along(formats)) {
-        parse_attempt_expressions[[i]] <- build_expr(
+      parse_attempt_exp_augmented_x <- map(
+        formats,
+        ~ build_expr(
           "strptime",
           augmented_x,
-          options = list(format = formats[[i]], unit = 0L, error_is_null = TRUE)
+          options = list(
+            format = .x,
+            unit = 0L,
+            error_is_null = TRUE
+          )
         )
-      }
+      )
     }
 
     # list for attempts when orders %in% c("yq")
     parse_attempt_exp_augmented_x2 <- list()
-
     if (!is.null(augmented_x2)) {
-      for (i in seq_along(formats)) {
-        parse_attempt_expressions[[i]] <- build_expr(
+      parse_attempt_exp_augmented_x2 <- map(
+        formats,
+        ~ build_expr(
           "strptime",
           augmented_x2,
-          options = list(format = formats[[i]], unit = 0L, error_is_null = TRUE)
+          options = list(
+            format = .x,
+            unit = 0L,
+            error_is_null = TRUE
+          )
         )
-      }
+      )
     }
 
     # combine all attempts expressions in prep for coalesce

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -498,6 +498,11 @@ register_bindings_datetime_parsers <- function() {
     # collapse multiple separators into a single one
     x <- call_binding("gsub", "-{2,}", "-", x)
 
+    # add a day (01) for "ym" and "my" orders
+    if (orders %in% c("ym", "my")) {
+      x <- call_binding("paste0", x, "-01")
+    }
+
     # TODO figure out how to parse strings that have no separators
     # https://issues.apache.org/jira/browse/ARROW-16446
     # we could insert separators at the "likely" positions, but it might be
@@ -527,7 +532,7 @@ register_bindings_datetime_parsers <- function() {
 
   })
 
-  ymd_parser_vec <- c("ymd", "ydm", "mdy", "myd", "dmy", "dym")
+  ymd_parser_vec <- c("ymd", "ydm", "mdy", "myd", "dmy", "dym", "ym", "my")
 
   ymd_parser_map_factory <- function(order) {
     force(order)

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1779,8 +1779,10 @@ test_that("year, month, day date/time parsers", {
 
 test_that("ym, my & yq parsers", {
   test_df <- tibble::tibble(
-    ym_string = c("2022-05", "2022/02", "22.03", NA),
-    my_string = c("05-2022", "02/2022", "03.22", NA)
+    ym_string = c("2022-05", "2022/02", "22.03", "1979//12", "88.09", NA),
+    my_string = c("05-2022", "02/2022", "03.22", "12//1979", "09.88", NA),
+    yq_string = c("2007.3", "1970.2", "2020.1", "2009.4", "1975.1", NA),
+    yq_numeric = c(2007.3, 1970.2, 2020.1, 2009.4, 1975.1, NA),
   )
 
   compare_dplyr_binding(
@@ -1789,7 +1791,15 @@ test_that("ym, my & yq parsers", {
         ym_date = ym(ym_string),
         ym_datetime = ym(ym_string, tz = "Pacific/Marquesas"),
         my_date = my(my_string),
-        my_datetime = my(my_string, tz = "Pacific/Marquesas")
+        my_datetime = my(my_string, tz = "Pacific/Marquesas"),
+        yq_date_from_string = yq(yq_string),
+        yq_datetime_from_string = yq(yq_string, tz = "Pacific/Marquesas"),
+        yq_date_from_numeric = yq(yq_numeric),
+        yq_datetime_from_numeric = yq(yq_numeric, tz = "Pacific/Marquesas"),
+        ym_date2 = parse_date_time(ym_string, orders = c("ym", "ymd")),
+        my_date2 = parse_date_time(my_string, orders = c("my", "myd")),
+        yq_date_from_string2 = parse_date_time(yq_string, orders = "yq"),
+        yq_date_from_numeric2 = parse_date_time(yq_numeric, orders = "yq")
       ) %>%
       collect(),
     test_df

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1735,7 +1735,7 @@ test_that("parse_date_time() doesn't work with hour, minutes, and second compone
   )
 })
 
-test_that("year, month, day date/time parsers work", {
+test_that("year, month, day date/time parsers", {
   test_df <- tibble::tibble(
     ymd_string = c("2022-05-11", "2022/05/12", "22.05-13"),
     ydm_string = c("2022-11-05", "2022/12/05", "22.13-05"),
@@ -1771,6 +1771,25 @@ test_that("year, month, day date/time parsers work", {
         myd_date = myd(myd_string, tz = "Pacific/Marquesas"),
         dmy_date = dmy(dmy_string, tz = "Pacific/Marquesas"),
         dym_date = dym(dym_string, tz = "Pacific/Marquesas")
+      ) %>%
+      collect(),
+    test_df
+  )
+})
+
+test_that("ym, my & yq parsers", {
+  test_df <- tibble::tibble(
+    ym_string = c("2022-05", "2022/02", "22.03", NA),
+    my_string = c("05-2022", "02/2022", "03.22", NA)
+  )
+
+  compare_dplyr_binding(
+    .input %>%
+      mutate(
+        ym_date = ym(ym_string),
+        ym_datetime = ym(ym_string, tz = "Pacific/Marquesas"),
+        my_date = my(my_string),
+        my_datetime = my(my_string, tz = "Pacific/Marquesas")
       ) %>%
       collect(),
     test_df

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1783,6 +1783,7 @@ test_that("ym, my & yq parsers", {
     my_string = c("05-2022", "02/2022", "03.22", "12//1979", "09.88", NA),
     yq_string = c("2007.3", "1970.2", "2020.1", "2009.4", "1975.1", NA),
     yq_numeric = c(2007.3, 1970.2, 2020.1, 2009.4, 1975.1, NA),
+    yq_space = c("2007 3", "1970 2", "2020 1", "2009 4", "1975 1", NA)
   )
 
   # these functions' internals use some string processing which requires the
@@ -1799,10 +1800,13 @@ test_that("ym, my & yq parsers", {
         yq_datetime_from_string = yq(yq_string, tz = "Pacific/Marquesas"),
         yq_date_from_numeric = yq(yq_numeric),
         yq_datetime_from_numeric = yq(yq_numeric, tz = "Pacific/Marquesas"),
+        yq_date_from_string_with_space = yq(yq_space),
+        yq_datetime_from_string_with_space = yq(yq_space, tz = "Pacific/Marquesas"),
         ym_date2 = parse_date_time(ym_string, orders = c("ym", "ymd")),
         my_date2 = parse_date_time(my_string, orders = c("my", "myd")),
         yq_date_from_string2 = parse_date_time(yq_string, orders = "yq"),
-        yq_date_from_numeric2 = parse_date_time(yq_numeric, orders = "yq")
+        yq_date_from_numeric2 = parse_date_time(yq_numeric, orders = "yq"),
+        yq_date_from_string_with_space2 = parse_date_time(yq_space, orders = "yq")
       ) %>%
       collect(),
     test_df

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1785,6 +1785,9 @@ test_that("ym, my & yq parsers", {
     yq_numeric = c(2007.3, 1970.2, 2020.1, 2009.4, 1975.1, NA),
   )
 
+  # these functions' internals use some string processing which requires the
+  # RE2 library (not available on Windows with R 3.6)
+  skip_if_not_available("re2")
   compare_dplyr_binding(
     .input %>%
       mutate(


### PR DESCRIPTION
The `ym()`, `my()` and `yq()` bindings will make the following possible (and identical):

``` r
library(arrow, warn.conflicts = FALSE)
library(dplyr, warn.conflicts = FALSE)
library(lubridate, warn.conflicts = FALSE)

test_df <- tibble::tibble(
  ym_string = c("2022-05", "2022/02", "22.03", NA)
)

test_df %>% 
  mutate(ym_date = ym(ym_string))
#> # A tibble: 4 × 2
#>   ym_string ym_date   
#>   <chr>     <date>    
#> 1 2022-05   2022-05-01
#> 2 2022/02   2022-02-01
#> 3 22.03     2022-03-01
#> 4 <NA>      NA

test_df %>% 
  arrow_table() %>% 
  mutate(ym_date = ym(ym_string)) %>% 
  collect()
#> # A tibble: 4 × 2
#>   ym_string ym_date   
#>   <chr>     <date>    
#> 1 2022-05   2022-05-01
#> 2 2022/02   2022-02-01
#> 3 22.03     2022-03-01
#> 4 <NA>      NA
```

<sup>Created on 2022-05-16 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup> 

I've implementing this with the following steps:
* add `"-01"` to the end of the strings we're trying to parse, and then
* use one the supported `orders` (`"ymd"` or `"myd"`)  