### PR TITLE
ARROW-16358: [CI][Dev] Allow archery crossbow to generate a CSV report for nightly builds

### DIFF
--- a/dev/archery/archery/crossbow/cli.py
+++ b/dev/archery/archery/crossbow/cli.py
@@ -341,6 +341,31 @@ def report_chat(obj, job_name, send, webhook, extra_message_success,
 
 @crossbow.command()
 @click.argument('job-name', required=True)
+@click.option('--save/--dry-run', default=False,
+              help='Just display the report, don\'t save it')
+@click.option('--fetch/--no-fetch', default=True,
+              help='Fetch references (branches and tags) from the remote')
+@click.pass_obj
+def report_csv(obj, job_name, save, fetch):
+    """
+    Generates a CSV report with the different tasks information
+    from a Crossbow run.
+    """
+    output = obj['output']
+    queue = obj['queue']
+    if fetch:
+        queue.fetch()
+
+    job = queue.get(job_name)
+    report = Report(job)
+    if save:
+        ReportUtils.write_csv(report)
+    else:
+        output.write("\n".join([str(row) for row in report.rows]))
+
+
+@crossbow.command()
+@click.argument('job-name', required=True)
 @click.option('-t', '--target-dir',
               default=_default_arrow_path / 'packages',
               type=click.Path(file_okay=False, dir_okay=True),

--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -947,8 +947,6 @@ class Job(Serializable):
             raise ValueError('each `tasks` mus be an instance of Task')
         if not isinstance(target, Target):
             raise ValueError('`target` must be an instance of Target')
-        if not isinstance(target, Target):
-            raise ValueError('`target` must be an instance of Target')
         if not isinstance(params, dict):
             raise ValueError('`params` must be an instance of dict')
 

--- a/dev/archery/archery/crossbow/reports.py
+++ b/dev/archery/archery/crossbow/reports.py
@@ -31,14 +31,14 @@ from archery.utils.report import JinjaReport
 class Report:
 
     ROW_HEADERS = [
-        "Task name",
-        "Task status",
-        "Build links",
-        "Crossbow branch URL",
-        "CI system",
-        "Task extra params",
-        "Template used",
-        "Arrow commit",
+        "task_name",
+        "task_status",
+        "build_links",
+        "crossbow_branch_url",
+        "ci_system",
+        "extra_params",
+        "template",
+        "arrow_commit",
     ]
 
     def __init__(self, job, task_filters=None):

--- a/dev/archery/archery/crossbow/reports.py
+++ b/dev/archery/archery/crossbow/reports.py
@@ -30,6 +30,17 @@ from archery.utils.report import JinjaReport
 # TODO(kszucs): use archery.report.JinjaReport instead
 class Report:
 
+    ROW_HEADERS = [
+        "Task name",
+        "Task status",
+        "Build links",
+        "Crossbow branch URL",
+        "CI system",
+        "Task extra params",
+        "Template used",
+        "Arrow commit",
+    ]
+
     def __init__(self, job, task_filters=None):
         self.job = job
 
@@ -89,6 +100,7 @@ class Report:
         """
         Produces a generator that allow us to iterate over
         the job tasks as a list of rows.
+        Row headers are defined at Report.ROW_HEADERS.
         """
         for task_name, task in sorted(self.job.tasks.items()):
             task_status = task.status()
@@ -235,9 +247,11 @@ class ReportUtils:
         server.close()
 
     @classmethod
-    def write_csv(cls, report):
+    def write_csv(cls, report, add_headers=True):
         with open(f'{report.job.branch}.csv', 'w') as csvfile:
             task_writer = csv.writer(csvfile)
+            if add_headers:
+                task_writer.writerow(report.ROW_HEADERS)
             task_writer.writerows(report.rows)
 
 

--- a/dev/archery/archery/crossbow/tests/test_reports.py
+++ b/dev/archery/archery/crossbow/tests/test_reports.py
@@ -76,8 +76,27 @@ def test_crossbow_email_report(load_fixture):
     job = load_fixture('crossbow-job.yaml', decoder=yaml.load)
     report = Report(job)
     assert report.tasks_by_state is not None
-    empail_report = EmailReport(report=report, sender_name="Sender Reporter",
-                                sender_email="sender@arrow.com",
-                                recipient_email="recipient@arrow.com")
+    email_report = EmailReport(report=report, sender_name="Sender Reporter",
+                               sender_email="sender@arrow.com",
+                               recipient_email="recipient@arrow.com")
 
-    assert empail_report.render("text") == textwrap.dedent(expected_msg)
+    assert email_report.render("text") == textwrap.dedent(expected_msg)
+
+
+def test_crossbow_export_report(load_fixture):
+    job = load_fixture('crossbow-job.yaml', decoder=yaml.load)
+    report = Report(job)
+    assert len(list(report.rows)) == 4
+    expected_first_row = [
+        'docker-cpp-cmake32',
+        'success',
+        ['https://github.com/apache/crossbow/runs/1'],
+        'https://github.com/apache/crossbow/tree/'
+        'ursabot-1-circle-docker-cpp-cmake32',
+        'circle',
+        {'commands': ['docker-compose build cpp-cmake32',
+                      'docker-compose run cpp-cmake32']},
+        'docker-tests/circle.linux.yml',
+        'f766a1d615dd1b7ee706d05102e579195951a61c'
+    ]
+    assert next(report.rows) == expected_first_row


### PR DESCRIPTION
This PR will allow us to generate a CSV with the nightly builds status. This will be used in order to generate a static page with the different builds information and will allow us to analyze historical information from the different builds like since when they have been failing, last successful build commit, some tags, etcetera.

An example of a CSV generated can be seen on the following gist:
https://gist.github.com/raulcd/1799c8499ef228dfdf1ab0d986367d2a