### PR TITLE
MINOR: [CI] Fix centos cmake path

### DIFF
--- a/ci/docker/centos-7-cpp.dockerfile
+++ b/ci/docker/centos-7-cpp.dockerfile
@@ -30,7 +30,7 @@ RUN yum install -y \
 
 ARG cmake=3.23.1
 RUN wget -nv -O - https://github.com/Kitware/CMake/releases/download/v${cmake}/cmake-${cmake}-Linux-x86_64.tar.gz | tar -xzf - -C /opt
-ENV PATH=/opt/cmake-${cmake}-Linux-x86_64/bin:$PATH
+ENV PATH=/opt/cmake-${cmake}-linux-x86_64/bin:$PATH
 ENV CC=/usr/bin/gcc
 ENV CXX=/usr/bin/g++
 ENV EXTRA_CMAKE_FLAGS="-DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX"

--- a/ci/docker/centos-7-cpp.dockerfile
+++ b/ci/docker/centos-7-cpp.dockerfile
@@ -27,10 +27,11 @@ RUN yum install -y \
         which
 
 # yum install cmake version is too old
-
 ARG cmake=3.23.1
-RUN wget -nv -O - https://github.com/Kitware/CMake/releases/download/v${cmake}/cmake-${cmake}-Linux-x86_64.tar.gz | tar -xzf - -C /opt
-ENV PATH=/opt/cmake-${cmake}-linux-x86_64/bin:$PATH
+RUN mkdir /opt/cmake-${cmake}
+RUN wget -nv -O - https://github.com/Kitware/CMake/releases/download/v${cmake}/cmake-${cmake}-Linux-x86_64.tar.gz | \
+    tar -xzf -  --strip-components=1 -C /opt/cmake-${cmake}
+ENV PATH=/opt/cmake-${cmake}/bin:$PATH
 ENV CC=/usr/bin/gcc
 ENV CXX=/usr/bin/g++
 ENV EXTRA_CMAKE_FLAGS="-DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX"


### PR DESCRIPTION
cmake file naming convention changed sometime between 3.18 and 3.23