### PR TITLE
ARROW-16594: [R] Consistently use "getOption" to set nightly repo

### DIFF
--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -19,7 +19,7 @@ args <- commandArgs(TRUE)
 VERSION <- args[1]
 dst_dir <- paste0("libarrow/arrow-", VERSION)
 
-arrow_repo <- "https://arrow-r-nightly.s3.amazonaws.com/libarrow/"
+arrow_repo <- paste0(getOption("arrow.dev_repo", "https://arrow-r-nightly.s3.amazonaws.com"), "/libarrow/")
 
 options(.arrow.cleanup = character()) # To collect dirs to rm on exit
 on.exit(unlink(getOption(".arrow.cleanup")))

--- a/r/tools/winlibs.R
+++ b/r/tools/winlibs.R
@@ -38,7 +38,10 @@ if (!file.exists(sprintf("windows/arrow-%s/include/arrow/api.h", VERSION))) {
       )
     }
     # URL templates
-    nightly <- "https://arrow-r-nightly.s3.amazonaws.com/libarrow/bin/windows/arrow-%s.zip"
+    nightly <- paste0(
+      getOption("arrow.dev_repo", "https://arrow-r-nightly.s3.amazonaws.com"),
+      "/libarrow/bin/windows/arrow-%s.zip"
+    )
     rwinlib <- "https://github.com/rwinlib/arrow/archive/v%s.zip"
     # First look for a nightly
     get_file(nightly, VERSION)


### PR DESCRIPTION
The behavior can be seen in action [here](https://github.com/assignUser/test-repo-a/actions/runs/2340358110) where I build this branch with the daily version number `20220517` which does not yet exists in the s3 bucket.
~~It actually looks like it is not working for linux binary builds https://github.com/assignUser/test-repo-a/runs/6472478941?check_suite_focus=true#step:4:153~~ This issue was due to .Rprofile configuration.