### PR TITLE
ARROW-16439: [R] Implement binding for `lubridate::fast_strptime`

### DIFF
--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -546,4 +546,36 @@ register_bindings_datetime_parsers <- function() {
   for (ymd_order in ymd_parser_vec) {
     register_binding(ymd_order, ymd_parser_map_factory(ymd_order))
   }
+
+  register_binding("fast_strptime", function( x,
+                                              format,
+                                              tz = "UTC",
+                                              lt = FALSE,
+                                              cutoff_2000 = 68L) {
+    browser()
+    # `lt` controls the output `lt = TRUE` returns a POSIXlt (which doesn't play
+    # well with mutate, for example)
+    if (lt) {
+      arrow_not_supported("`lt = TRUE` argument")
+    }
+
+    # TODO revisit once https://issues.apache.org/jira/browse/ARROW-16596 is done
+    if (cutoff_2000 != 68L) {
+      arrow_not_supported("`cutoff_2000` != 68L argument")
+    }
+
+    parse_attempt_expressions <- list()
+
+    for (i in seq_along(format)) {
+      parse_attempt_expressions[[i]] <- build_expr(
+        "strptime",
+        x,
+        options = list(format = format[[i]], unit = 0L, error_is_null = TRUE)
+      )
+    }
+
+    coalesce_output <- call_binding("strptime", args = parse_attempt_expressions)
+
+    build_expr("assume_timezone", coalesce_output, options = list(timezone = tz))
+  })
 }

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -552,7 +552,6 @@ register_bindings_datetime_parsers <- function() {
                                               tz = "UTC",
                                               lt = FALSE,
                                               cutoff_2000 = 68L) {
-    browser()
     # `lt` controls the output `lt = TRUE` returns a POSIXlt (which doesn't play
     # well with mutate, for example)
     if (lt) {
@@ -566,15 +565,20 @@ register_bindings_datetime_parsers <- function() {
 
     parse_attempt_expressions <- list()
 
-    for (i in seq_along(format)) {
-      parse_attempt_expressions[[i]] <- build_expr(
+    parse_attempt_expressions <- map(
+      format,
+      ~ build_expr(
         "strptime",
         x,
-        options = list(format = format[[i]], unit = 0L, error_is_null = TRUE)
+        options = list(
+          format = .x,
+          unit = 0L,
+          error_is_null = TRUE
+        )
       )
-    }
+    )
 
-    coalesce_output <- call_binding("strptime", args = parse_attempt_expressions)
+    coalesce_output <- build_expr("coalesce", args = parse_attempt_expressions)
 
     build_expr("assume_timezone", coalesce_output, options = list(timezone = tz))
   })

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -547,11 +547,11 @@ register_bindings_datetime_parsers <- function() {
     register_binding(ymd_order, ymd_parser_map_factory(ymd_order))
   }
 
-  register_binding("fast_strptime", function( x,
-                                              format,
-                                              tz = "UTC",
-                                              lt = FALSE,
-                                              cutoff_2000 = 68L) {
+  register_binding("fast_strptime", function(x,
+                                             format,
+                                             tz = "UTC",
+                                             lt = FALSE,
+                                             cutoff_2000 = 68L) {
     # `lt` controls the output `lt = TRUE` returns a POSIXlt (which doesn't play
     # well with mutate, for example)
     if (lt) {

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1828,9 +1828,9 @@ test_that("lubridate's fast_strptime", {
       collect(),
     tibble(
       x = c("2018-10-07 19:04:05", "2022-05-17 21:23:45", NA)
-    ),
+    )#,
     # arrow does not preserve the `tzone` attribute
-    ignore_attr = TRUE
+    # test ignore_attr = TRUE
   )
 
   # R object
@@ -1847,8 +1847,8 @@ test_that("lubridate's fast_strptime", {
       collect(),
     tibble(
       x = c("2018-10-07 19:04:05", NA)
-    ),
-    ignore_attr = TRUE
+    )#,
+    # test ignore_attr = TRUE
   )
 
   compare_dplyr_binding(
@@ -1883,9 +1883,9 @@ test_that("lubridate's fast_strptime", {
     tibble(
       x =
         c("68-10-07 19:04:05", "69-10-07 19:04:05", NA)
-    ),
+    )#,
     # arrow does not preserve the `tzone` attribute
-    ignore_attr = TRUE
+    # test ignore_attr = TRUE
   )
 
   # the arrow binding errors for a value different from 68L for `cutoff_2000`

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1776,3 +1776,62 @@ test_that("year, month, day date/time parsers work", {
     test_df
   )
 })
+
+
+test_that("lubridate's fast_strptime", {
+  t_string <- tibble(x = c("2018-10-07 19:04:05", NA))
+  t_string_y <- tibble(x = c("68-10-07 19:04:05", "69-10-07 19:04:05", NA))
+  t_string_2formats <- tibble(x = c("2018-10-07 19:04:05", "68-10-07 19:04:05"))
+  t_stamp <- tibble(x = c(lubridate::ymd_hms("2018-10-07 19:04:05"), NA))
+
+  compare_dplyr_binding(
+    .input %>%
+      mutate(y = fast_strptime(x, format = "%Y-%m-%d %H:%M:%S", lt = FALSE)) %>%
+      collect(),
+    t_string,
+    # arrow does not preserve the `tzone` attribute
+    ignore_attr = TRUE
+  )
+
+  compare_dplyr_binding(
+    .input %>%
+      mutate(y =
+               fast_strptime("68-10-07 19:04:05", format = "%y-%m-%d %H:%M:%S", lt = FALSE)
+      ) %>%
+      collect(),
+    t_string,
+    ignore_attr = TRUE
+  )
+
+  # fast_strptime()'s `cutoff_2000` argument is not supported, but its value is
+  # implicitly set to 68L both in base R and in Arrow
+  compare_dplyr_binding(
+    .input %>%
+      mutate(date_short_year = fast_strptime(x, format = "%y-%m-%d %H:%M:%S", lt = FALSE)) %>%
+      collect(),
+    t_string_y,
+    # arrow does not preserve the `tzone` attribute
+    ignore_attr = TRUE
+  )
+
+  compare_dplyr_binding(
+    .input %>%
+      mutate(
+        date_short_year =
+          fast_strptime(x, format = "%y-%m-%d %H:%M:%S", lt = FALSE, cutoff_2000 = 69L)
+      ) %>%
+      collect(),
+    t_string_y,
+    warning = TRUE
+  )
+
+  formats <- c("%Y-%m-%d %H:%M:%S", "%y-%m-%d %H:%M:%S")
+  compare_dplyr_binding(
+    .input %>%
+      mutate(date_multi_formats =
+               fast_strptime(x, format = formats, lt = FALSE)) %>%
+      collect(),
+    t_string_2formats,
+    warning = TRUE
+  )
+})

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1906,4 +1906,22 @@ test_that("lubridate's fast_strptime", {
     ),
     warning = TRUE
   )
+
+  # compare_dplyr_binding would not work here since lt = TRUE returns a list
+  # and it also errors in regular dplyr pipelines
+  expect_warning(
+    tibble(
+      x = c("68-10-07 19:04:05", "69-10-07 19:04:05", NA)
+    ) %>%
+      arrow_table() %>%
+      mutate(
+        date_short_year =
+          fast_strptime(
+            x,
+            format = "%y-%m-%d %H:%M:%S",
+            lt = TRUE
+          )
+      ) %>%
+      collect()
+  )
 })

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1867,6 +1867,24 @@ test_that("lubridate's fast_strptime", {
     )
   )
 
+  compare_dplyr_binding(
+    .input %>%
+      mutate(
+        dttm_with_tz = fast_strptime(
+          dttm_as_string,
+          format = "%Y-%m-%d %H:%M:%S",
+          tz = "Pacific/Marquesas",
+          lt = FALSE
+        )
+      ) %>%
+      collect(),
+    tibble(
+      dttm_as_string =
+        c("2018-10-07 19:04:05", "1969-10-07 19:04:05", NA)
+    )
+  )
+
+
   # fast_strptime()'s `cutoff_2000` argument is not supported, but its value is
   # implicitly set to 68L both in lubridate and in Arrow
   compare_dplyr_binding(

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1884,7 +1884,6 @@ test_that("lubridate's fast_strptime", {
     )
   )
 
-
   # fast_strptime()'s `cutoff_2000` argument is not supported, but its value is
   # implicitly set to 68L both in lubridate and in Arrow
   compare_dplyr_binding(


### PR DESCRIPTION
This PR adds:
* a binding emulating lubridate's `fast_strptime` functionality  

This PR does not support the following arguments:
* `lt = TRUE` - this returns a POSIXlt object (a list) which cannot be easily used in a dplyr pipeline (currently it actually errors) => we have a different default `lt = FALSE` for the Arrow binding, and
* `cutoff_2000 = 68L` - for the `y%` format two-digit numbers smaller or equal to `cutoff_2000` are parsed as though starting with 20, otherwise parsed as though starting with 19. It would be nice to have this, so I raised [ARROW-16596](https://issues.apache.org/jira/browse/ARROW-16596). We can always suggest users they manipulate the strings before parsing, so I don't think this is crucial functionality. 

The following code will be possible once the PR is merged:
``` r
library(lubridate, warn.conflicts = FALSE)
library(dplyr, warn.conflicts = FALSE)
library(arrow, warn.conflicts = FALSE)

dates_table <- tibble(
  string_with_short_year = c("68-05-17", "69-05-17", "55-05-17")
)

dates_table %>% 
  mutate(
    date = fast_strptime(
      string_with_short_year, 
      format = "%y-%m-%d",
      lt = FALSE
    )
  )
#> # A tibble: 3 × 2
#>   string_with_short_year date               
#>   <chr>                  <dttm>             
#> 1 68-05-17               2068-05-17 00:00:00
#> 2 69-05-17               1969-05-17 00:00:00
#> 3 55-05-17               2055-05-17 00:00:00

dates_table %>% 
  arrow_table() %>% 
  mutate(
    date = fast_strptime(
      string_with_short_year, 
      format = "%y-%m-%d",
      lt = FALSE
    )
  ) %>%
  collect()
#> # A tibble: 3 × 2
#>   string_with_short_year date               
#>   <chr>                  <dttm>             
#> 1 68-05-17               2068-05-17 00:00:00
#> 2 69-05-17               1969-05-17 00:00:00
#> 3 55-05-17               2055-05-17 00:00:00
```

<sup>Created on 2022-05-18 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
