### PR TITLE
MINOR: [FlightRPC] Document assumption about catalogs support on SQL_CATALOG_TERM

### DIFF
--- a/format/FlightSql.proto
+++ b/format/FlightSql.proto
@@ -345,7 +345,10 @@ enum SqlInfo {
   // Retrieves a UTF-8 string with the preferred term for "procedure".
   SQL_PROCEDURE_TERM = 530;
 
-  // Retrieves a UTF-8 string with the preferred term for "catalog".
+  /*
+   * Retrieves a UTF-8 string with the preferred term for "catalog".
+   * If a empty string is returned its assumed that the server does NOT supports catalogs.
+   */
   SQL_CATALOG_TERM = 531;
 
   /*


### PR DESCRIPTION
To indicate that a Flight SQL server does not support catalogs we assume that sources will return empty string for `SQL_CATALOG_TERM` on Flight SQL's CommandGetSqlInfo response.