### PR TITLE
ARROW-15534: [C++] Add convenience function to substrait consumer to create plan instead of declaration

### DIFF
--- a/cpp/examples/arrow/engine_substrait_consumption.cc
+++ b/cpp/examples/arrow/engine_substrait_consumption.cc
@@ -159,7 +159,7 @@ int main(int argc, char** argv) {
 
   // Deserialize each relation tree in the substrait plan to an Arrow compute Declaration
   arrow::Result<std::vector<cp::Declaration>> maybe_decls =
-      eng::DeserializePlan(*serialized_plan, consumer_factory);
+      eng::DeserializePlans(*serialized_plan, consumer_factory);
   ABORT_ON_FAILURE(maybe_decls.status());
   std::vector<cp::Declaration> decls = std::move(maybe_decls).ValueOrDie();
 

--- a/cpp/src/arrow/engine/substrait/serde.cc
+++ b/cpp/src/arrow/engine/substrait/serde.cc
@@ -92,7 +92,7 @@ Result<compute::ExecPlan> DeserializePlan(const Buffer& buf,
   ARROW_ASSIGN_OR_RAISE(auto declarations,
                         DeserializePlans(buf, consumer_factory, ext_set_out));
   if (declarations.size() > 1) {
-    return Status::Invalid("DeserializePlan does not support root relations");
+    return Status::Invalid("DeserializePlan does not support multiple root relations");
   } else {
     ARROW_ASSIGN_OR_RAISE(auto plan, compute::ExecPlan::Make());
     std::ignore = declarations[0].AddToPlan(plan.get());

--- a/cpp/src/arrow/engine/substrait/serde.cc
+++ b/cpp/src/arrow/engine/substrait/serde.cc
@@ -60,7 +60,7 @@ Result<compute::Declaration> DeserializeRelation(const Buffer& buf,
 
 Result<std::vector<compute::Declaration>> DeserializePlans(
     const Buffer& buf, const ConsumerFactory& consumer_factory,
-    ExtensionSet* ext_set) {
+    ExtensionSet* ext_set_out) {
   ARROW_ASSIGN_OR_RAISE(auto plan, ParseFromBuffer<substrait::Plan>(buf));
 
   ARROW_ASSIGN_OR_RAISE(auto ext_set, GetExtensionSetFromPlan(plan));
@@ -86,19 +86,19 @@ Result<std::vector<compute::Declaration>> DeserializePlans(
   return sink_decls;
 }
 
-Result<compute::ExecPlan> DeserializePlan(
-    const Buffer& buf, const ConsumerFactory& consumer_factory,
-    ExtensionSet* ext_set) {
-  ARROW_ASSIGN_OR_RAISE(auto declarations, DeserializePlans(buf, consumer_factory, ext_set_out));
-  if(declarations.size()>1){
+Result<compute::ExecPlan> DeserializePlan(const Buffer& buf,
+                                          const ConsumerFactory& consumer_factory,
+                                          ExtensionSet* ext_set_out) {
+  ARROW_ASSIGN_OR_RAISE(auto declarations,
+                        DeserializePlans(buf, consumer_factory, ext_set_out));
+  if (declarations.size() > 1) {
     return Status::Invalid("Substrait plan cannot have multiple root relations");
-  } else{
+  } else {
     ARROW_ASSIGN_OR_RAISE(auto plan, compute::ExecPlan::Make());
     std::ignore = declarations[0].AddToPlan(plan.get());
     return *std::move(plan);
   }
 }
-
 
 Result<std::shared_ptr<Schema>> DeserializeSchema(const Buffer& buf,
                                                   const ExtensionSet& ext_set) {

--- a/cpp/src/arrow/engine/substrait/serde.cc
+++ b/cpp/src/arrow/engine/substrait/serde.cc
@@ -92,7 +92,7 @@ Result<compute::ExecPlan> DeserializePlan(const Buffer& buf,
   ARROW_ASSIGN_OR_RAISE(auto declarations,
                         DeserializePlans(buf, consumer_factory, ext_set_out));
   if (declarations.size() > 1) {
-    return Status::Invalid("Substrait plan cannot have multiple root relations");
+    return Status::Invalid("DeserializePlan does not support root relations");
   } else {
     ARROW_ASSIGN_OR_RAISE(auto plan, compute::ExecPlan::Make());
     std::ignore = declarations[0].AddToPlan(plan.get());

--- a/cpp/src/arrow/engine/substrait/serde.cc
+++ b/cpp/src/arrow/engine/substrait/serde.cc
@@ -58,9 +58,9 @@ Result<compute::Declaration> DeserializeRelation(const Buffer& buf,
   return FromProto(rel, ext_set);
 }
 
-Result<std::vector<compute::Declaration>> DeserializePlan(
+Result<std::vector<compute::Declaration>> DeserializePlans(
     const Buffer& buf, const ConsumerFactory& consumer_factory,
-    ExtensionSet* ext_set_out) {
+    ExtensionSet* ext_set) {
   ARROW_ASSIGN_OR_RAISE(auto plan, ParseFromBuffer<substrait::Plan>(buf));
 
   ARROW_ASSIGN_OR_RAISE(auto ext_set, GetExtensionSetFromPlan(plan));
@@ -85,6 +85,20 @@ Result<std::vector<compute::Declaration>> DeserializePlan(
   }
   return sink_decls;
 }
+
+Result<compute::ExecPlan> DeserializePlan(
+    const Buffer& buf, const ConsumerFactory& consumer_factory,
+    ExtensionSet* ext_set) {
+  ARROW_ASSIGN_OR_RAISE(auto declarations, DeserializePlans(buf, consumer_factory, ext_set_out));
+  if(declarations.size()>1){
+    return Status::Invalid("Substrait plan cannot have multiple root relations");
+  } else{
+    ARROW_ASSIGN_OR_RAISE(auto plan, compute::ExecPlan::Make());
+    std::ignore = declarations[0].AddToPlan(plan.get());
+    return *std::move(plan);
+  }
+}
+
 
 Result<std::shared_ptr<Schema>> DeserializeSchema(const Buffer& buf,
                                                   const ExtensionSet& ext_set) {

--- a/cpp/src/arrow/engine/substrait/serde.h
+++ b/cpp/src/arrow/engine/substrait/serde.h
@@ -49,7 +49,7 @@ using ConsumerFactory = std::function<std::shared_ptr<compute::SinkNodeConsumer>
 /// \return a vector of ExecNode declarations, one for each toplevel relation in the
 /// Substrait Plan
 ARROW_ENGINE_EXPORT Result<std::vector<compute::Declaration>> DeserializePlans(
-    const Buffer& buf, const ConsumerFactory& consumer_factory, ExtensionSet* ext_set);
+    const Buffer& buf, const ConsumerFactory& consumer_factory, ExtensionSet* ext_set = NULLPTR);
 
 Result<compute::ExecPlan> DeserializePlan(const Buffer& buf,
                                           const ConsumerFactory& consumer_factory,

--- a/cpp/src/arrow/engine/substrait/serde.h
+++ b/cpp/src/arrow/engine/substrait/serde.h
@@ -44,16 +44,16 @@ using ConsumerFactory = std::function<std::shared_ptr<compute::SinkNodeConsumer>
 /// message
 /// \param[in] consumer_factory factory function for generating the node that consumes
 /// the batches produced by each toplevel Substrait relation
-/// \param[out] ext_set if non-null, the extension mapping used by the Substrait Plan is
+/// \param[out] ext_set_out if non-null, the extension mapping used by the Substrait Plan is
 /// returned here.
 /// \return a vector of ExecNode declarations, one for each toplevel relation in the
 /// Substrait Plan
 ARROW_ENGINE_EXPORT Result<std::vector<compute::Declaration>> DeserializePlans(
-    const Buffer& buf, const ConsumerFactory& consumer_factory, ExtensionSet* ext_set = NULLPTR);
+    const Buffer& buf, const ConsumerFactory& consumer_factory, ExtensionSet* ext_set_out = NULLPTR);
 
 Result<compute::ExecPlan> DeserializePlan(const Buffer& buf,
                                           const ConsumerFactory& consumer_factory,
-                                          ExtensionSet* ext_set = NULLPTR);
+                                          ExtensionSet* ext_set_out = NULLPTR);
 
 /// \brief Deserializes a Substrait Type message to the corresponding Arrow type
 ///

--- a/cpp/src/arrow/engine/substrait/serde.h
+++ b/cpp/src/arrow/engine/substrait/serde.h
@@ -48,7 +48,11 @@ using ConsumerFactory = std::function<std::shared_ptr<compute::SinkNodeConsumer>
 /// returned here.
 /// \return a vector of ExecNode declarations, one for each toplevel relation in the
 /// Substrait Plan
-ARROW_ENGINE_EXPORT Result<std::vector<compute::Declaration>> DeserializePlan(
+ARROW_ENGINE_EXPORT Result<std::vector<compute::Declaration>> DeserializePlans(
+    const Buffer& buf , const ConsumerFactory& consumer_factory,
+    ExtensionSet* ext_set);
+
+Result<compute::ExecPlan> DeserializePlan(
     const Buffer& buf, const ConsumerFactory& consumer_factory,
     ExtensionSet* ext_set = NULLPTR);
 

--- a/cpp/src/arrow/engine/substrait/serde.h
+++ b/cpp/src/arrow/engine/substrait/serde.h
@@ -49,12 +49,11 @@ using ConsumerFactory = std::function<std::shared_ptr<compute::SinkNodeConsumer>
 /// \return a vector of ExecNode declarations, one for each toplevel relation in the
 /// Substrait Plan
 ARROW_ENGINE_EXPORT Result<std::vector<compute::Declaration>> DeserializePlans(
-    const Buffer& buf , const ConsumerFactory& consumer_factory,
-    ExtensionSet* ext_set);
+    const Buffer& buf, const ConsumerFactory& consumer_factory, ExtensionSet* ext_set);
 
-Result<compute::ExecPlan> DeserializePlan(
-    const Buffer& buf, const ConsumerFactory& consumer_factory,
-    ExtensionSet* ext_set = NULLPTR);
+Result<compute::ExecPlan> DeserializePlan(const Buffer& buf,
+                                          const ConsumerFactory& consumer_factory,
+                                          ExtensionSet* ext_set = NULLPTR);
 
 /// \brief Deserializes a Substrait Type message to the corresponding Arrow type
 ///

--- a/cpp/src/arrow/engine/substrait/serde.h
+++ b/cpp/src/arrow/engine/substrait/serde.h
@@ -44,12 +44,13 @@ using ConsumerFactory = std::function<std::shared_ptr<compute::SinkNodeConsumer>
 /// message
 /// \param[in] consumer_factory factory function for generating the node that consumes
 /// the batches produced by each toplevel Substrait relation
-/// \param[out] ext_set_out if non-null, the extension mapping used by the Substrait Plan is
-/// returned here.
+/// \param[out] ext_set_out if non-null, the extension mapping used by the Substrait
+/// Plan is returned here.
 /// \return a vector of ExecNode declarations, one for each toplevel relation in the
 /// Substrait Plan
 ARROW_ENGINE_EXPORT Result<std::vector<compute::Declaration>> DeserializePlans(
-    const Buffer& buf, const ConsumerFactory& consumer_factory, ExtensionSet* ext_set_out = NULLPTR);
+    const Buffer& buf, const ConsumerFactory& consumer_factory,
+    ExtensionSet* ext_set_out = NULLPTR);
 
 Result<compute::ExecPlan> DeserializePlan(const Buffer& buf,
                                           const ConsumerFactory& consumer_factory,

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -702,7 +702,7 @@ TEST(Substrait, ExtensionSetFromPlan) {
   ExtensionSet ext_set;
   ASSERT_OK_AND_ASSIGN(
       auto sink_decls,
-      DeserializePlan(
+      DeserializePlans(
           *buf, [] { return std::shared_ptr<compute::SinkNodeConsumer>{nullptr}; },
           &ext_set));
 
@@ -745,7 +745,7 @@ TEST(Substrait, ExtensionSetFromPlanMissingFunc) {
   ExtensionSet ext_set;
   ASSERT_RAISES(
       Invalid,
-      DeserializePlan(
+      DeserializePlans(
           *buf, [] { return std::shared_ptr<compute::SinkNodeConsumer>{nullptr}; },
           &ext_set));
 }

--- a/r/src/compute-exec.cpp
+++ b/r/src/compute-exec.cpp
@@ -391,7 +391,7 @@ std::shared_ptr<arrow::Table> ExecPlan_run_substrait(
   };
 
   arrow::Result<std::vector<compute::Declaration>> maybe_decls =
-      ValueOrStop(arrow::engine::DeserializePlan(*serialized_plan, consumer_factory));
+      ValueOrStop(arrow::engine::DeserializePlans(*serialized_plan, consumer_factory));
   std::vector<compute::Declaration> decls = std::move(ValueOrStop(maybe_decls));
 
   // For now, the Substrait plan must include a 'read' that points to


### PR DESCRIPTION
This PR adds a convenience function to Substrait consumer for the `DeserializePlan` method, which creates ExecPlan for single root relations.