### PR TITLE
ARROW-16144: [R] Write compressed data streams (particularly over S3)

### DIFF
--- a/r/R/io.R
+++ b/r/R/io.R
@@ -301,7 +301,6 @@ make_output_stream <- function(x, filesystem = NULL, compression = NULL) {
     return(MakeRConnectionOutputStream(x))
   }
 
-
   if (inherits(x, "SubTreeFileSystem")) {
     filesystem <- x$base_fs
     x <- x$base_path

--- a/r/R/io.R
+++ b/r/R/io.R
@@ -270,7 +270,7 @@ make_readable_file <- function(file, mmap = TRUE, compression = NULL, filesystem
       file <- ReadableFile$create(file)
     }
 
-    if (!identical(compression, "uncompressed")) {
+    if (is_compressed(compression)) {
       file <- CompressedInputStream$create(file, compression)
     }
   } else if (inherits(file, c("raw", "Buffer"))) {

--- a/r/R/io.R
+++ b/r/R/io.R
@@ -335,7 +335,6 @@ detect_compression <- function(path) {
   # Remove any trailing slashes, which FileSystem$from_uri may add
   path <- gsub("/$", "", path)
 
-
   switch(tools::file_ext(path),
     bz2 = "bz2",
     gz = "gzip",

--- a/r/R/io.R
+++ b/r/R/io.R
@@ -321,9 +321,9 @@ make_output_stream <- function(x, filesystem = NULL, compression = NULL) {
   } else if (is.null(filesystem) && !is_compressed(compression)) {
     FileOutputStream$create(x) ## uncompressed local
   } else if (!is.null(filesystem) && is_compressed(compression)) {
-    CompressedOutputStream$create(filesystem$OpenOutputStream(x)) ## compressed s3
+    CompressedOutputStream$create(filesystem$OpenOutputStream(x)) ## compressed remote
   } else {
-    filesystem$OpenOutputStream(x) ## uncompressed s3
+    filesystem$OpenOutputStream(x) ## uncompressed remote
   }
 }
 

--- a/r/R/io.R
+++ b/r/R/io.R
@@ -333,7 +333,7 @@ detect_compression <- function(path) {
     return("uncompressed")
   }
 
-  ## Remove any trailing slashes
+  # Remove any trailing slashes, which FileSystem$from_uri may add
   path <- gsub("/$", "", path)
 
 

--- a/r/R/util.R
+++ b/r/R/util.R
@@ -211,3 +211,7 @@ handle_csv_read_error <- function(e, schema, call) {
   }
   abort(msg, call = call)
 }
+
+is_compressed <- function(compression) {
+  !identical(compression, "uncompressed")
+}

--- a/r/tests/testthat/test-csv.R
+++ b/r/tests/testthat/test-csv.R
@@ -576,6 +576,17 @@ test_that("write_csv_arrow() compresses by file extension", {
   expect_lt(file.size(tfgz), file.size(tf))
 })
 
+test_that("read/write compressed file", {
+  skip_if_not_available("gzip")
+  tfgz <- tempfile(fileext = ".csv.gz")
+  on.exit(unlink(tfgz))
+  write_csv_arrow(tbl, tfgz)
+  expect_identical(
+    read_csv_arrow(tfgz),
+    tbl
+  )
+})
+
 test_that("read_csv_arrow() can read sub-second timestamps with col_types T setting (ARROW-15599)", {
   tbl <- tibble::tibble(time = c("2018-10-07 19:04:05.000", "2018-10-07 19:04:05.001"))
   tf <- tempfile()

--- a/r/tests/testthat/test-csv.R
+++ b/r/tests/testthat/test-csv.R
@@ -564,6 +564,18 @@ test_that("write_csv_arrow can write from RecordBatchReader objects", {
   expect_equal(nrow(tbl_in), 3)
 })
 
+test_that("write_csv_arrow() compresses by file extension", {
+  skip_if_not_available("gzip")
+  tfgz <- tempfile(fileext = ".csv.gz")
+  tf <- tempfile(fileext = ".csv")
+  on.exit(unlink(tf))
+  on.exit(unlink(tfgz))
+
+  write_csv_arrow(tbl, tf)
+  write_csv_arrow(tbl, tfgz)
+  expect_lt(file.size(tfgz), file.size(tf))
+})
+
 test_that("read_csv_arrow() can read sub-second timestamps with col_types T setting (ARROW-15599)", {
   tbl <- tibble::tibble(time = c("2018-10-07 19:04:05.000", "2018-10-07 19:04:05.001"))
   tf <- tempfile()

--- a/r/tests/testthat/test-csv.R
+++ b/r/tests/testthat/test-csv.R
@@ -564,7 +564,7 @@ test_that("write_csv_arrow can write from RecordBatchReader objects", {
   expect_equal(nrow(tbl_in), 3)
 })
 
-test_that("write_csv_arrow() compresses by file extension", {
+test_that("read/write compressed file successfully", {
   skip_if_not_available("gzip")
   tfgz <- tempfile(fileext = ".csv.gz")
   tf <- tempfile(fileext = ".csv")
@@ -574,13 +574,7 @@ test_that("write_csv_arrow() compresses by file extension", {
   write_csv_arrow(tbl, tf)
   write_csv_arrow(tbl, tfgz)
   expect_lt(file.size(tfgz), file.size(tf))
-})
 
-test_that("read/write compressed file", {
-  skip_if_not_available("gzip")
-  tfgz <- tempfile(fileext = ".csv.gz")
-  on.exit(unlink(tfgz))
-  write_csv_arrow(tbl, tfgz)
   expect_identical(
     read_csv_arrow(tfgz),
     tbl

--- a/r/tests/testthat/test-s3-minio.R
+++ b/r/tests/testthat/test-s3-minio.R
@@ -55,15 +55,16 @@ if (arrow_with_s3() && process_is_running("minio server")) {
   })
 
   test_that("read/write compressed csv by filesystem", {
-    write_csv_arrow(example_data, fs$path(minio_path("test.csv.gz")))
+    dat <- tibble(x = seq(1,10, by = 0.2))
+    write_csv_arrow(dat, fs$path(minio_path("test.csv.gz")))
     expect_identical(
       read_csv_arrow(fs$path(minio_path("test.csv.gz"))),
-      example_data
+      dat
     )
   })
 
   test_that("read/write csv by filesystem", {
-    dat <- data.frame(x = seq(1,10, by = 0.2))
+    dat <- tibble(x = seq(1,10, by = 0.2))
     write_csv_arrow(dat, fs$path(minio_path("test.csv")))
     expect_identical(
       read_csv_arrow(fs$path(minio_path("test.csv"))),

--- a/r/tests/testthat/test-s3-minio.R
+++ b/r/tests/testthat/test-s3-minio.R
@@ -55,6 +55,7 @@ if (arrow_with_s3() && process_is_running("minio server")) {
   })
 
   test_that("read/write compressed csv by filesystem", {
+    skip_if_not_available("gzip")
     dat <- tibble(x = seq(1, 10, by = 0.2))
     write_csv_arrow(dat, fs$path(minio_path("test.csv.gz")))
     expect_identical(
@@ -64,6 +65,7 @@ if (arrow_with_s3() && process_is_running("minio server")) {
   })
 
   test_that("read/write csv by filesystem", {
+    skip_if_not_available("gzip")
     dat <- tibble(x = seq(1, 10, by = 0.2))
     write_csv_arrow(dat, fs$path(minio_path("test.csv")))
     expect_identical(

--- a/r/tests/testthat/test-s3-minio.R
+++ b/r/tests/testthat/test-s3-minio.R
@@ -54,6 +54,22 @@ if (arrow_with_s3() && process_is_running("minio server")) {
     )
   })
 
+  test_that("read/write compressed csv by filesystem", {
+    write_csv_arrow(example_data, fs$path(minio_path("test.csv.gz")))
+    expect_identical(
+      read_csv_arrow(fs$path(minio_path("test.csv.gz"))),
+      example_data
+    )
+  })
+
+  test_that("read/write csv by filesystem", {
+    write_csv_arrow(example_data, fs$path(minio_path("test.csv")))
+    expect_identical(
+      read_csv_arrow(fs$path(minio_path("test.csv"))),
+      example_data
+    )
+  })
+
   test_that("read/write stream", {
     write_ipc_stream(example_data, fs$path(minio_path("test3.ipc")))
     expect_identical(

--- a/r/tests/testthat/test-s3-minio.R
+++ b/r/tests/testthat/test-s3-minio.R
@@ -55,7 +55,7 @@ if (arrow_with_s3() && process_is_running("minio server")) {
   })
 
   test_that("read/write compressed csv by filesystem", {
-    dat <- tibble(x = seq(1,10, by = 0.2))
+    dat <- tibble(x = seq(1, 10, by = 0.2))
     write_csv_arrow(dat, fs$path(minio_path("test.csv.gz")))
     expect_identical(
       read_csv_arrow(fs$path(minio_path("test.csv.gz"))),
@@ -64,7 +64,7 @@ if (arrow_with_s3() && process_is_running("minio server")) {
   })
 
   test_that("read/write csv by filesystem", {
-    dat <- tibble(x = seq(1,10, by = 0.2))
+    dat <- tibble(x = seq(1, 10, by = 0.2))
     write_csv_arrow(dat, fs$path(minio_path("test.csv")))
     expect_identical(
       read_csv_arrow(fs$path(minio_path("test.csv"))),

--- a/r/tests/testthat/test-s3-minio.R
+++ b/r/tests/testthat/test-s3-minio.R
@@ -63,10 +63,11 @@ if (arrow_with_s3() && process_is_running("minio server")) {
   })
 
   test_that("read/write csv by filesystem", {
-    write_csv_arrow(example_data, fs$path(minio_path("test.csv")))
+    dat <- data.frame(x = seq(1,10, by = 0.2))
+    write_csv_arrow(dat, fs$path(minio_path("test.csv")))
     expect_identical(
       read_csv_arrow(fs$path(minio_path("test.csv"))),
-      example_data
+      dat
     )
   })
 


### PR DESCRIPTION
This PR enables reading/writing compressed data streams over s3 and locally and adds some tests to test some of those round trips. For the filesystem path I had to do a little regex on the string for compression detection but any feedback on alternative approaches is very welcome. Previously supplying a file with a compression extension wrote out an uncompressed file. Here is a reprex of the updated writing behaviour:

```r
library(arrow, warn.conflicts = FALSE)
## local
write_csv_arrow(mtcars, file = file)
write_csv_arrow(mtcars, file = comp_file)
file.size(file)
[1] 1303
file.size(comp_file)
[1] 567

## or with s3
dir <- tempfile()
dir.create(dir)
subdir <- file.path(dir, "bucket")
dir.create(subdir)

minio_server <- processx::process$new("minio", args = c("server", dir), supervise = TRUE)
Sys.sleep(2)
stopifnot(minio_server$is_alive())

s3_uri <- "s3://minioadmin:minioadmin@?scheme=http&endpoint_override=localhost%3A9000"
bucket <- s3_bucket(s3_uri)

write_csv_arrow(mtcars, bucket$path("bucket/data.csv.gz"))
write_csv_arrow(mtcars, bucket$path("bucket/data.csv"))

file.size(file.path(subdir, "data.csv.gz"))
[1] 567
file.size(file.path(subdir, "data.csv"))
[1] 1303
```