### PR TITLE
ARROW-16602: [Dev] Use GitHub API to merge pull request

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -55,7 +55,7 @@ directly)
 
 The merge script uses the GitHub REST API. You must set a
 `ARROW_GITHUB_API_TOKEN` environment variable to use a Personal Access
-Token. You need only `public_repo` scope for the Personal Access Token.
+Token. You need to add `workflow` scope to the Personal Access Token.
 
 You can specify the username and the password of your JIRA account in
 `APACHE_JIRA_USERNAME` and `APACHE_JIRA_PASSWORD` environment variables.

--- a/dev/README.md
+++ b/dev/README.md
@@ -53,9 +53,9 @@ After installed, it runs the merge script.
 have to install Python dependencies yourself and then run `dev/merge_arrow_pr.py`
 directly)
 
-The merge script uses the GitHub REST API; if you encounter rate limit issues,
-you may set a `ARROW_GITHUB_API_TOKEN` environment variable to use a Personal
-Access Token.
+The merge script uses the GitHub REST API. You must set a
+`ARROW_GITHUB_API_TOKEN` environment variable to use a Personal Access
+Token. You need only `public_repo` scope for the Personal Access Token.
 
 You can specify the username and the password of your JIRA account in
 `APACHE_JIRA_USERNAME` and `APACHE_JIRA_PASSWORD` environment variables.

--- a/dev/merge.conf.sample
+++ b/dev/merge.conf.sample
@@ -25,5 +25,5 @@ username=johnsmith
 password=123456
 
 [github]
-# GitHub's personal access token. "public_repo" scope is only needed.
+# GitHub's personal access token. "workflow" scope is needed.
 api_token=ghp_ABC

--- a/dev/merge.conf.sample
+++ b/dev/merge.conf.sample
@@ -23,3 +23,7 @@
 # token credentials. Ensure that the file is properly protected.
 username=johnsmith
 password=123456
+
+[github]
+# GitHub's personal access token. "public_repo" scope is only needed.
+api_token=ghp_ABC

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -266,17 +266,17 @@ class GitHubAPI(object):
                         headers=self.headers)
 
     def merge_pr(self, number, commit_title, commit_message):
+        url = f'{self.github_api}/pulls/{number}/merge'
         payload = {
             'commit_title': commit_title,
             'commit_message': commit_message,
             'merge_method': 'squash',
         }
-        response = requests.put(f'{self.github_api}/pulls/{number}/merge',
-                                headers=self.headers,
-                                json=payload)
+        response = requests.put(url, headers=self.headers, json=payload)
         result = response.json()
         if response.status_code != 200 and 'merged' not in result:
             result['merged'] = False
+            result['message'] += f': {url}'
         return result
 
 

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -33,8 +33,7 @@
 # Configuration environment variables:
 #   - APACHE_JIRA_USERNAME: your Apache JIRA ID
 #   - APACHE_JIRA_PASSWORD: your Apache JIRA password
-#   - ARROW_GITHUB_API_TOKEN: a GitHub API token to use for API requests (to
-#                             avoid rate limiting)
+#   - ARROW_GITHUB_API_TOKEN: a GitHub API token to use for API requests
 #   - PR_REMOTE_NAME: the name of the remote to the Apache git repo (set to
 #                     'apache' by default)
 #   - DEBUG: use for testing to avoid pushing to apache (0 by default)
@@ -242,12 +241,20 @@ class GitHubAPI(object):
         self.github_api = ("https://api.github.com/repos/apache/{0}"
                            .format(project_name))
 
-        token = os.environ.get('ARROW_GITHUB_API_TOKEN', None)
+        token = None
+        config = load_configuration()
+        if "github" in config.sections():
+            token = config["github"]["api_token"]
+        if not token:
+            token = os.environ.get('ARROW_GITHUB_API_TOKEN')
+        if not token:
+            token = cmd.prompt('Env ARROW_GITHUB_API_TOKEN not set, '
+                               'please enter your GitHub API token '
+                               '(GitHub personal access token):')
         headers = {
             'Accept': 'application/vnd.github.v3+json',
+            'Authorization': 'token {0}'.format(token),
         }
-        if token:
-            headers['Authorization'] = 'token {0}'.format(token)
         self.headers = headers
 
     def get_pr_data(self, number):

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -237,7 +237,7 @@ URL\t\t{}/{}""".format(jira_id, summary, assignee, components, status,
 
 class GitHubAPI(object):
 
-    def __init__(self, project_name):
+    def __init__(self, project_name, cmd):
         self.github_api = ("https://api.github.com/repos/apache/{0}"
                            .format(project_name))
 
@@ -555,7 +555,7 @@ def cli():
 
     os.chdir(ARROW_HOME)
 
-    github_api = GitHubAPI(PROJECT_NAME)
+    github_api = GitHubAPI(PROJECT_NAME, cmd)
 
     jira_con = connect_jira(cmd)
     pr = PullRequest(cmd, github_api, PR_REMOTE_NAME, jira_con, pr_num)

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -443,7 +443,7 @@ def get_primary_author(cmd, distinct_authors):
             "\"name <email>\" [%s]: " % distinct_authors[0])
 
         if primary_author == "":
-            return distinct_authors[0], distinct_authors
+            return distinct_authors[0], distinct_authors[1:]
 
         if author_pat.match(primary_author):
             break

--- a/dev/release/post-04-website.sh
+++ b/dev/release/post-04-website.sh
@@ -67,7 +67,7 @@ rough_n_development_months=$((
 git_tag=apache-arrow-${version}
 git_range=apache-arrow-${previous_version}..${git_tag}
 
-committers_command_line="git shortlog -csn ${git_range}"
+committers_command_line="git shortlog -sn --group=trailer:signed-off-by ${git_range}"
 contributors_command_line="git shortlog -sn ${git_range}"
 
 committers=$(${committers_command_line})

--- a/dev/test_merge_arrow_pr.py
+++ b/dev/test_merge_arrow_pr.py
@@ -208,25 +208,25 @@ def test_multiple_authors_bad_input():
     a0 = 'Jimbob Crawfish <jimbob.crawfish@gmail.com>'
     a1 = 'Jarvis McCratchett <jarvis.mccratchett@hotmail.com>'
     a2 = 'Hank Miller <hank.miller@protonmail.com>'
-    distinct_other_authors = [a1]
+    distinct_authors = [a0, a1]
 
     cmd = FakeCLI(responses=[''])
-    primary_author, new_distinct_other_authors = \
+    primary_author, distinct_other_authors = \
         merge_arrow_pr.get_primary_author(cmd, distinct_authors)
     assert primary_author == a0
-    assert new_distinct_other_authors == [a1]
+    assert distinct_other_authors == [a1]
 
     cmd = FakeCLI(responses=['oops', a1])
-    primary_author, new_distinct_other_authors = \
+    primary_author, distinct_other_authors = \
         merge_arrow_pr.get_primary_author(cmd, distinct_authors)
     assert primary_author == a1
-    assert new_distinct_other_authors == [a0]
+    assert distinct_other_authors == [a0]
 
     cmd = FakeCLI(responses=[a2])
-    primary_author, new_other_distinct_authors = \
+    primary_author, other_distinct_authors = \
         merge_arrow_pr.get_primary_author(cmd, distinct_authors)
     assert primary_author == a2
-    assert new_distinct_other_authors == [a0, a1]
+    assert distinct_other_authors == [a0, a1]
 
 
 def test_jira_already_resolved():

--- a/dev/test_merge_arrow_pr.py
+++ b/dev/test_merge_arrow_pr.py
@@ -208,25 +208,25 @@ def test_multiple_authors_bad_input():
     a0 = 'Jimbob Crawfish <jimbob.crawfish@gmail.com>'
     a1 = 'Jarvis McCratchett <jarvis.mccratchett@hotmail.com>'
     a2 = 'Hank Miller <hank.miller@protonmail.com>'
-    distinct_authors = [a0, a1]
+    distinct_other_authors = [a1]
 
     cmd = FakeCLI(responses=[''])
-    primary_author, new_distinct_authors = merge_arrow_pr.get_primary_author(
-        cmd, distinct_authors)
+    primary_author, new_distinct_other_authors = \
+        merge_arrow_pr.get_primary_author(cmd, distinct_authors)
     assert primary_author == a0
-    assert new_distinct_authors == [a0, a1]
+    assert new_distinct_other_authors == [a1]
 
     cmd = FakeCLI(responses=['oops', a1])
-    primary_author, new_distinct_authors = merge_arrow_pr.get_primary_author(
-        cmd, distinct_authors)
+    primary_author, new_distinct_other_authors = \
+        merge_arrow_pr.get_primary_author(cmd, distinct_authors)
     assert primary_author == a1
-    assert new_distinct_authors == [a1, a0]
+    assert new_distinct_other_authors == [a0]
 
     cmd = FakeCLI(responses=[a2])
-    primary_author, new_distinct_authors = merge_arrow_pr.get_primary_author(
-        cmd, distinct_authors)
+    primary_author, new_other_distinct_authors = \
+        merge_arrow_pr.get_primary_author(cmd, distinct_authors)
     assert primary_author == a2
-    assert new_distinct_authors == [a2, a0, a1]
+    assert new_distinct_other_authors == [a0, a1]
 
 
 def test_jira_already_resolved():

--- a/dev/test_merge_arrow_pr.py
+++ b/dev/test_merge_arrow_pr.py
@@ -223,7 +223,7 @@ def test_multiple_authors_bad_input():
     assert distinct_other_authors == [a0]
 
     cmd = FakeCLI(responses=[a2])
-    primary_author, other_distinct_authors = \
+    primary_author, distinct_other_authors = \
         merge_arrow_pr.get_primary_author(cmd, distinct_authors)
     assert primary_author == a2
     assert distinct_other_authors == [a0, a1]


### PR DESCRIPTION
We use local "git merge" to merge a pull request in
dev/merge_arrow_pr.py.

If we use "git merge" to merge a pull request, GitHub's Web UI shows
"Closed" mark not "Merged" mark in a pull request page. This sometimes
confuses new contributors. "Why was my pull request closed without
merging?" See
https://github.com/apache/arrow/pull/12004#issuecomment-1031619771 for
example.

If we use GitHub API
https://docs.github.com/en/rest/pulls/pulls#merge-a-pull-request to
merge a pull request, GitHub's Web UI shows "Merged" mark not "Closed"
mark. See https://github.com/apache/arrow/pull/13180 for example. I
used GitHub API to merge the pull request.

And we don't need to create a local branch on local repository to
merge a pull request. But we must specify ARROW_GITHUB_API_TOKEN to
run dev/merge_arrow_pr.py.