### PR TITLE
ARROW-16317: [CI][Dev] Do not use incremental ids on crossbow submit action branches

### DIFF
--- a/dev/archery/archery/bot.py
+++ b/dev/archery/archery/bot.py
@@ -265,7 +265,7 @@ def submit(obj, tasks, groups, params, arrow_version):
                               groups=groups, params=params)
 
         # add the job to the crossbow queue and push to the remote repository
-        queue.put(job, prefix="actions")
+        queue.put(job, prefix="actions", increment_job_id=False)
         queue.push()
 
         # render the response comment's content


### PR DESCRIPTION
The aim of this PR is to avoid a possible race condition when submitting crossbow builds. Currently when there is a race condition when submitting crossbow builds we can see the following type of error:
```
Failed to push updated references, potentially because of credential issues: ['refs/heads/actions-1883-github-wheel-windows-cp310-amd64', 'refs/tags/actions-1883-github-wheel-windows-cp310-amd64', 'refs/heads/actions-1883-github-wheel-windows-cp39-amd64', 'refs/tags/actions-1883-github-wheel-windows-cp39-amd64', 'refs/heads/actions-1883-github-wheel-windows-cp37-amd64', 'refs/tags/actions-1883-github-wheel-windows-cp37-amd64', 'refs/heads/actions-1883-github-wheel-windows-cp38-amd64', 'refs/tags/actions-1883-github-wheel-windows-cp38-amd64', 'refs/heads/actions-1883']
The Archery job run can be found at: https://github.com/apache/arrow/actions/runs/2195038965
```

The idea is to use a 10 characters hex from an uuid instead of an incremental id.