### PR TITLE
MINOR: Fix wrongly redefining pytestmark for parquet encryption tests

### DIFF
--- a/python/pyarrow/tests/parquet/test_encryption.py
+++ b/python/pyarrow/tests/parquet/test_encryption.py
@@ -39,8 +39,10 @@ COL_KEY_NAME = "col_key"
 # Marks all of the tests in this module
 # Ignore these with pytest ... -m 'not parquet_encryption'
 # Ignore these with pytest ... -m 'not parquet'
-pytestmark = pytest.mark.parquet_encryption
-pytestmark = pytest.mark.parquet
+pytestmark = [
+    pytest.mark.parquet_encryption,
+    pytest.mark.parquet
+]
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
This PR should correctly skip the tests and fix the failures introduced by https://github.com/apache/arrow/pull/13147#discussion_r875953997 on the following builds:
- [test-conda-python-3.7-pandas-latest](https://github.com/ursacomputing/crossbow/runs/6482062339?check_suite_focus=true)
- [test-conda-python-3.8-pandas-latest](https://github.com/ursacomputing/crossbow/runs/6482065559?check_suite_focus=true)