### PR TITLE
ARROW-16415: [R] Update `strptime` binding signature with the `tz` argument

### DIFF
--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -57,7 +57,11 @@ register_bindings_datetime_utility <- function() {
       tz <- Sys.timezone()
     }
 
-    # convert a "timezone-naive" into a "timezone-aware" timestamp
+    # if a timestamp does not contain timezone information (i.e. it is
+    # "timezone-naive") we can attach timezone information (i.e. convert it into
+    # a "timezone-aware" timestamp) with `assume_timezone`
+    # if we want to cast to a different timezone, we can only do it for
+    # timezone-aware timestamps, not for timezone-naive ones
     if (!is.null(tz)) {
       output <- build_expr(
         "assume_timezone",

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -57,6 +57,7 @@ register_bindings_datetime_utility <- function() {
       tz <- Sys.timezone()
     }
 
+    # convert a "timezone-naive" into a "timezone-aware" timestamp
     if (!is.null(tz)) {
       output <- build_expr(
         "assume_timezone",

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -30,7 +30,7 @@ register_bindings_datetime <- function() {
 register_bindings_datetime_utility <- function() {
   register_binding("strptime", function(x,
                                         format = "%Y-%m-%d %H:%M:%S",
-                                        tz = NULL,
+                                        tz = "",
                                         unit = "ms") {
     # Arrow uses unit for time parsing, strptime() does not.
     # Arrow has no default option for strptime (format, unit),
@@ -52,6 +52,10 @@ register_bindings_datetime_utility <- function() {
           error_is_null = TRUE
         )
     )
+
+    if (tz == "") {
+      tz <- Sys.timezone()
+    }
 
     if (!is.null(tz)) {
       output <- build_expr(

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -28,25 +28,48 @@ register_bindings_datetime <- function() {
 }
 
 register_bindings_datetime_utility <- function() {
-  register_binding("strptime", function(x, format = "%Y-%m-%d %H:%M:%S", tz = NULL,
+  register_binding("strptime", function(x,
+                                        format = "%Y-%m-%d %H:%M:%S",
+                                        tz = NULL,
                                         unit = "ms") {
     # Arrow uses unit for time parsing, strptime() does not.
     # Arrow has no default option for strptime (format, unit),
     # we suggest following format = "%Y-%m-%d %H:%M:%S", unit = MILLI/1L/"ms",
     # (ARROW-12809)
 
-    # ParseTimestampStrptime currently ignores the timezone information (ARROW-12820).
-    # Stop if tz is provided.
-    if (is.character(tz)) {
-      arrow_not_supported("Time zone argument")
+    unit <- make_valid_time_unit(
+      unit,
+      c(valid_time64_units, valid_time32_units)
+    )
+
+    output <- build_expr(
+      "strptime",
+      x,
+      options =
+        list(
+          format = format,
+          unit = unit,
+          error_is_null = TRUE
+        )
+    )
+
+    if (!is.null(tz)) {
+      output <- build_expr(
+        "assume_timezone",
+        output,
+        options =
+          list(
+            timezone = tz
+          )
+      )
     }
-
-    unit <- make_valid_time_unit(unit, c(valid_time64_units, valid_time32_units))
-
-    build_expr("strptime", x, options = list(format = format, unit = unit, error_is_null = TRUE))
+    output
   })
 
-  register_binding("strftime", function(x, format = "", tz = "", usetz = FALSE) {
+  register_binding("strftime", function(x,
+                                        format = "",
+                                        tz = "",
+                                        usetz = FALSE) {
     if (usetz) {
       format <- paste(format, "%Z")
     }

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -74,6 +74,9 @@ test_that("strptime", {
   })
 
   # adding a timezone to a timezone-naive timestamp works
+  # and since our TZ when running the test is (typically) Pacific/Marquesas
+  # this also tests that assigning a TZ different from the current session one
+  # works as expected
   expect_equal(
     t_string %>%
       arrow_table() %>%

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -111,7 +111,7 @@ test_that("strptime", {
         x = strptime(x, format = "%Y-%m-%d %H:%M:%S", unit = "ns", tz = "UTC")
       ) %>%
       collect(),
-    t_stamp
+    t_stamp_with_utc_tz
   )
 
   expect_equal(

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -54,10 +54,12 @@ test_that("strptime", {
     x = c(lubridate::ymd_hms("2018-10-07 19:04:05", tz = "Pacific/Marquesas"), NA)
   )
 
+  # base::strptime returns a POSIXlt (a list) => we cannot use compare_dplyr_binding
+  # => we use expect_equal
   withr::with_timezone("Pacific/Marquesas", {
     expect_equal(
       t_string %>%
-        arrow_table() %>%
+        record_batch() %>%
         mutate(
           x = strptime(x, format = "%Y-%m-%d %H:%M:%S")
         ) %>%

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -50,9 +50,21 @@ test_df <- tibble::tibble(
 test_that("strptime", {
   t_string <- tibble(x = c("2018-10-07 19:04:05", NA))
   t_stamp <- tibble(x = c(lubridate::ymd_hms("2018-10-07 19:04:05"), NA))
-  t_stamp_with_tz <- tibble(
+  t_stamp_with_pm_tz <- tibble(
     x = c(lubridate::ymd_hms("2018-10-07 19:04:05", tz = "Pacific/Marquesas"), NA)
   )
+
+  withr::with_timezone("Pacific/Marquesas", {
+    expect_equal(
+      t_string %>%
+        arrow_table() %>%
+        mutate(
+          x = strptime(x, format = "%Y-%m-%d %H:%M:%S")
+        ) %>%
+        collect(),
+      t_stamp_with_pm_tz
+    )
+  })
 
   expect_equal(
     t_string %>%
@@ -61,51 +73,47 @@ test_that("strptime", {
         x = strptime(x, format = "%Y-%m-%d %H:%M:%S", tz = "Pacific/Marquesas")
       ) %>%
       collect(),
-    t_stamp_with_tz
+    t_stamp_with_pm_tz
   )
 
   expect_equal(
     t_string %>%
       Table$create() %>%
       mutate(
-        x = strptime(x)
+        x = strptime(x, tz = "UTC")
       ) %>%
       collect(),
-    t_stamp,
-    ignore_attr = "tzone"
+    t_stamp
   )
 
   expect_equal(
     t_string %>%
       Table$create() %>%
       mutate(
-        x = strptime(x, format = "%Y-%m-%d %H:%M:%S")
+        x = strptime(x, format = "%Y-%m-%d %H:%M:%S", tz = "UTC")
       ) %>%
       collect(),
-    t_stamp,
-    ignore_attr = "tzone"
+    t_stamp
   )
 
   expect_equal(
     t_string %>%
       Table$create() %>%
       mutate(
-        x = strptime(x, format = "%Y-%m-%d %H:%M:%S", unit = "ns")
+        x = strptime(x, format = "%Y-%m-%d %H:%M:%S", unit = "ns", tz = "UTC")
       ) %>%
       collect(),
-    t_stamp,
-    ignore_attr = "tzone"
+    t_stamp
   )
 
   expect_equal(
     t_string %>%
       Table$create() %>%
       mutate(
-        x = strptime(x, format = "%Y-%m-%d %H:%M:%S", unit = "s")
+        x = strptime(x, format = "%Y-%m-%d %H:%M:%S", unit = "s", tz = "UTC")
       ) %>%
       collect(),
-    t_stamp,
-    ignore_attr = "tzone"
+    t_stamp
   )
 
   tstring <- tibble(x = c("08-05-2008", NA))

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -50,6 +50,19 @@ test_df <- tibble::tibble(
 test_that("strptime", {
   t_string <- tibble(x = c("2018-10-07 19:04:05", NA))
   t_stamp <- tibble(x = c(lubridate::ymd_hms("2018-10-07 19:04:05"), NA))
+  t_stamp_with_tz <- tibble(
+    x = c(lubridate::ymd_hms("2018-10-07 19:04:05", tz = "Pacific/Marquesas"), NA)
+  )
+
+  expect_equal(
+    t_string %>%
+      arrow_table() %>%
+      mutate(
+        x = strptime(x, format = "%Y-%m-%d %H:%M:%S", tz = "Pacific/Marquesas")
+      ) %>%
+      collect(),
+    t_stamp_with_tz
+  )
 
   expect_equal(
     t_string %>%
@@ -108,15 +121,6 @@ test_that("strptime", {
     # R's strptime returns POSIXlt (list type)
     as.POSIXct(tstamp),
     ignore_attr = "tzone"
-  )
-})
-
-test_that("errors in strptime", {
-  # Error when tz is passed
-  x <- Expression$field_ref("x")
-  expect_error(
-    call_binding("strptime", x, tz = "PDT"),
-    "Time zone argument not supported in Arrow"
   )
 })
 


### PR DESCRIPTION
This PR enables the `tz` argument for the `strptime` binding by using the `assume_timezone` compute function. 

Current behaviour:
``` r
library(arrow, warn.conflicts = FALSE)
library(dplyr, warn.conflicts = FALSE)

test_df <- tibble::tibble(
    timestamp_naive_string = c("2018-10-07 19:04:05", NA)
)

test_df %>% 
    arrow_table() %>% 
    mutate(
        timestamp = 
            strptime(
                timestamp_naive_string, 
                format = "%Y-%m-%d %H:%M:%S", 
                tz = "Pacific/Marquesas"
            )
    ) %>%
    collect()
#> Warning: In strptime(timestamp_naive_string, format = "%Y-%m-%d %H:%M:%S", ...,
#> Time zone argument not supported in Arrow; pulling data into R
#> # A tibble: 2 × 2
#>   timestamp_naive_string timestamp          
#>   <chr>                  <dttm>             
#> 1 2018-10-07 19:04:05    2018-10-07 19:04:05
#> 2 <NA>                   NA
```

<sup>Created on 2022-05-18 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Future/desired behaviour:
``` r
library(arrow, warn.conflicts = FALSE)
library(dplyr, warn.conflicts = FALSE)

test_df <- tibble::tibble(
  timestamp_naive_string = c("2018-10-07 19:04:05", NA)
)

a <- test_df %>% 
  arrow_table() %>% 
  mutate(
    timestamp = 
      strptime(
        timestamp_naive_string, 
        format = "%Y-%m-%d %H:%M:%S", 
        tz = "Pacific/Marquesas"
      )
  ) %>%
  collect()

a
#> # A tibble: 2 × 2
#>   timestamp_naive_string timestamp          
#>   <chr>                  <dttm>             
#> 1 2018-10-07 19:04:05    2018-10-07 19:04:05
#> 2 <NA>                   NA
attributes(a$timestamp)
#> $class
#> [1] "POSIXlt" "POSIXt" 
#> 
#> $tzone
#> [1] "Pacific/Marquesas"
```

<sup>Created on 2022-05-19 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>