### PR TITLE
ARROW-16604: [C++] Remove needless Boost dependency from benchmarks

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -854,13 +854,8 @@ if(NOT MSVC_TOOLCHAIN)
   list(APPEND ARROW_SHARED_INSTALL_INTERFACE_LIBS ${CMAKE_DL_LIBS})
 endif()
 
-set(ARROW_TEST_LINK_TOOLCHAIN
-    arrow::flatbuffers
-    GTest::gtest_main
-    GTest::gtest
-    GTest::gmock
-    Boost::filesystem
-    Boost::system)
+set(ARROW_TEST_LINK_TOOLCHAIN arrow::flatbuffers GTest::gtest_main GTest::gtest
+                              GTest::gmock)
 
 if(ARROW_BUILD_TESTS)
   add_dependencies(arrow_test_dependencies ${ARROW_TEST_LINK_TOOLCHAIN})

--- a/cpp/cmake_modules/DefineOptions.cmake
+++ b/cpp/cmake_modules/DefineOptions.cmake
@@ -238,7 +238,6 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
 
   define_option(ARROW_GCS
                 "Build Arrow with GCS support (requires the GCloud SDK for C++)" OFF)
-  mark_as_advanced(ARROW_GCS) # TODO(ARROW-1231) - remove once completed
 
   define_option(ARROW_HDFS "Build the Arrow HDFS bridge" OFF)
 

--- a/cpp/src/arrow/filesystem/CMakeLists.txt
+++ b/cpp/src/arrow/filesystem/CMakeLists.txt
@@ -29,7 +29,12 @@ add_arrow_test(filesystem-test
                filesystem)
 
 if(ARROW_GCS)
-  add_arrow_test(gcsfs_test EXTRA_LABELS filesystem)
+  add_arrow_test(gcsfs_test
+                 EXTRA_LABELS
+                 filesystem
+                 EXTRA_LINK_LIBS
+                 Boost::filesystem
+                 Boost::system)
 endif()
 
 if(ARROW_S3)
@@ -38,7 +43,10 @@ if(ARROW_S3)
                  s3fs_test.cc
                  s3_test_util.cc
                  EXTRA_LABELS
-                 filesystem)
+                 filesystem
+                 EXTRA_LINK_LIBS
+                 Boost::filesystem
+                 Boost::system)
   if(TARGET arrow-s3fs-test)
     set(ARROW_S3FS_TEST_COMPILE_DEFINITIONS)
     get_target_property(AWS_CPP_SDK_S3_TYPE aws-cpp-sdk-s3 TYPE)
@@ -73,7 +81,11 @@ if(ARROW_S3)
                         "arrow-filesystem"
                         SOURCES
                         s3fs_benchmark.cc
-                        s3_test_util.cc)
+                        s3_test_util.cc
+                        STATIC_LINK_LIBS
+                        ${ARROW_BENCHMARK_LINK_LIBS}
+                        Boost::filesystem
+                        Boost::system)
     if(ARROW_TEST_LINKAGE STREQUAL "static")
       target_link_libraries(arrow-filesystem-s3fs-benchmark PRIVATE parquet_static)
     else()

--- a/cpp/src/arrow/io/CMakeLists.txt
+++ b/cpp/src/arrow/io/CMakeLists.txt
@@ -23,7 +23,13 @@ add_arrow_test(compressed_test PREFIX "arrow-io")
 add_arrow_test(file_test PREFIX "arrow-io")
 
 if(ARROW_HDFS)
-  add_arrow_test(hdfs_test NO_VALGRIND PREFIX "arrow-io")
+  add_arrow_test(hdfs_test
+                 NO_VALGRIND
+                 PREFIX
+                 "arrow-io"
+                 EXTRA_LINK_LIBS
+                 Boost::filesystem
+                 Boost::system)
 endif()
 
 add_arrow_test(memory_test PREFIX "arrow-io")


### PR DESCRIPTION
We need Boost only for benchmarks of S3 and Flight.
Append an extra line for testing only.