### PR TITLE
ARROW-15906: [C++][Python][R] By default, don't create or delete S3 buckets

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -770,9 +770,6 @@ class ClientBuilder {
 
   const S3Options& options() const { return options_; }
 
-  void allow_bucket_creation(bool allow) { options_.allow_bucket_creation = allow; }
-  void allow_bucket_deletion(bool allow) { options_.allow_bucket_deletion = allow; }
-
  protected:
   S3Options options_;
   Aws::Client::ClientConfiguration client_config_;
@@ -1661,9 +1658,6 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
     return std::string(FromAwsString(builder_.config().region));
   }
 
-  void allow_bucket_creation(bool allow) { builder_.allow_bucket_creation(allow); }
-  void allow_bucket_deletion(bool allow) { builder_.allow_bucket_deletion(allow); }
-
   template <typename Error>
   void SaveBackend(const Aws::Client::AWSError<Error>& error) {
     if (!backend_ || *backend_ == S3Backend::Other) {
@@ -2222,14 +2216,6 @@ bool S3FileSystem::Equals(const FileSystem& other) const {
 S3Options S3FileSystem::options() const { return impl_->options(); }
 
 std::string S3FileSystem::region() const { return impl_->region(); }
-
-void S3FileSystem::allow_bucket_creation(bool allow) {
-  impl_->allow_bucket_creation(allow);
-}
-
-void S3FileSystem::allow_bucket_deletion(bool allow) {
-  impl_->allow_bucket_deletion(allow);
-}
 
 Result<FileInfo> S3FileSystem::GetFileInfo(const std::string& s) {
   ARROW_ASSIGN_OR_RAISE(auto path, S3Path::FromString(s));

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -383,6 +383,8 @@ Result<S3Options> S3Options::FromUri(const std::string& uri_string,
 bool S3Options::Equals(const S3Options& other) const {
   return (region == other.region && endpoint_override == other.endpoint_override &&
           scheme == other.scheme && background_writes == other.background_writes &&
+          allow_bucket_creation == other.allow_bucket_creation &&
+          allow_bucket_deletion == other.allow_bucket_deletion &&
           credentials_kind == other.credentials_kind &&
           proxy_options.Equals(other.proxy_options) &&
           GetAccessKey() == other.GetAccessKey() &&

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -355,11 +355,11 @@ Result<S3Options> S3Options::FromUri(const Uri& uri, std::string* out_path) {
     } else if (kv.first == "endpoint_override") {
       options.endpoint_override = kv.second;
     } else if (kv.first == "allow_bucket_creation") {
-      options.allow_bucket_creation =
-          ::arrow::internal::AsciiEqualsCaseInsensitive(kv.second, "true");
+      ARROW_ASSIGN_OR_RAISE(options.allow_bucket_creation,
+                            ::arrow::internal::ParseBoolean(kv.second));
     } else if (kv.first == "allow_bucket_deletion") {
-      options.allow_bucket_deletion =
-          ::arrow::internal::AsciiEqualsCaseInsensitive(kv.second, "true");
+      ARROW_ASSIGN_OR_RAISE(options.allow_bucket_deletion,
+                            ::arrow::internal::ParseBoolean(kv.second));
     } else {
       return Status::Invalid("Unexpected query parameter in S3 URI: '", kv.first, "'");
     }

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -1702,7 +1702,7 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
 
       if (!options().allow_bucket_creation) {
         return Status::IOError(
-            "Bucket does not exist: '", bucket, "'. ",
+            "Bucket '", bucket, "' not found. ",
             "To create buckets, enable the allow_bucket_creation option.");
       }
     }
@@ -2411,7 +2411,7 @@ Status S3FileSystem::DeleteDir(const std::string& s) {
         std::forward_as_tuple("When deleting bucket '", path.bucket, "': "),
         impl_->client_->DeleteBucket(req));
   } else if (path.key.empty()) {
-    return Status::IOError("Would delete bucket: '", path.bucket, "'. ",
+    return Status::IOError("Would delete bucket '", path.bucket, "'. ",
                            "To delete buckets, enable the allow_bucket_deletion option.");
   } else {
     // Delete "directory"

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -91,6 +91,7 @@
 #include "arrow/util/key_value_metadata.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/optional.h"
+#include "arrow/util/string.h"
 #include "arrow/util/task_group.h"
 #include "arrow/util/thread_pool.h"
 
@@ -353,6 +354,9 @@ Result<S3Options> S3Options::FromUri(const Uri& uri, std::string* out_path) {
       options.scheme = kv.second;
     } else if (kv.first == "endpoint_override") {
       options.endpoint_override = kv.second;
+    } else if (kv.first == "allow_create_buckets") {
+      options.allow_create_buckets =
+          ::arrow::internal::AsciiEqualsCaseInsensitive(kv.second, "true");
     } else {
       return Status::Invalid("Unexpected query parameter in S3 URI: '", kv.first, "'");
     }

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -763,9 +763,7 @@ class ClientBuilder {
 
   const S3Options& options() const { return options_; }
 
-  void allow_create_buckets(bool allow) {
-    options_.allow_create_buckets = allow;
-  }
+  void allow_create_buckets(bool allow) { options_.allow_create_buckets = allow; }
 
  protected:
   S3Options options_;
@@ -1655,9 +1653,7 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
     return std::string(FromAwsString(builder_.config().region));
   }
 
-  void allow_create_buckets(bool allow) {
-    builder_.allow_create_buckets(allow);
-  }
+  void allow_create_buckets(bool allow) { builder_.allow_create_buckets(allow); }
 
   template <typename Error>
   void SaveBackend(const Aws::Client::AWSError<Error>& error) {
@@ -2414,9 +2410,8 @@ Status S3FileSystem::DeleteDir(const std::string& s) {
         std::forward_as_tuple("When deleting bucket '", path.bucket, "': "),
         impl_->client_->DeleteBucket(req));
   } else if (path.key.empty()) {
-    return Status::IOError(
-        "Would delete bucket: '", path.bucket, "'. ",
-        "To delete buckets, enable the allow_create_buckets option.");
+    return Status::IOError("Would delete bucket: '", path.bucket, "'. ",
+                           "To delete buckets, enable the allow_create_buckets option.");
   } else {
     // Delete "directory"
     RETURN_NOT_OK(impl_->DeleteObject(path.bucket, path.key + kSep));

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -221,6 +221,8 @@ class ARROW_EXPORT S3FileSystem : public FileSystem {
   /// Return the actual region this filesystem connects to
   std::string region() const;
 
+  void allow_create_buckets(bool allow);
+
   bool Equals(const FileSystem& other) const override;
 
   /// \cond FALSE

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -229,12 +229,6 @@ class ARROW_EXPORT S3FileSystem : public FileSystem {
   /// Return the actual region this filesystem connects to
   std::string region() const;
 
-  /// Set create_buckets property of options
-  void allow_bucket_creation(bool allow);
-
-  /// Set delete_buckets property of options
-  void allow_bucket_deletion(bool allow);
-
   bool Equals(const FileSystem& other) const override;
 
   /// \cond FALSE

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -130,6 +130,9 @@ struct ARROW_EXPORT S3Options {
   /// Whether OutputStream writes will be issued in the background, without blocking.
   bool background_writes = true;
 
+  /// Whether to allow creation of new buckets
+  bool allow_create_buckets = false;
+
   /// \brief Default metadata for OpenOutputStream.
   ///
   /// This will be ignored if non-empty metadata is passed to OpenOutputStream.

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -130,7 +130,7 @@ struct ARROW_EXPORT S3Options {
   /// Whether OutputStream writes will be issued in the background, without blocking.
   bool background_writes = true;
 
-  /// Whether to allow creation or deletion of buckets
+  /// Whether to allow creation of buckets
   ///
   /// When S3FileSystem creates new buckets, it does not pass any non-default settings.
   /// In AWS S3, the bucket and all objects will be not publicly visible, and there

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -130,7 +130,12 @@ struct ARROW_EXPORT S3Options {
   /// Whether OutputStream writes will be issued in the background, without blocking.
   bool background_writes = true;
 
-  /// Whether to allow creation of new buckets
+  /// Whether to allow creation or deletion of buckets
+  ///
+  /// When S3FileSystem creates new buckets, it does not pass any non-default settings.
+  /// In AWS S3, the bucket and all objects will be not publicly visible, and there
+  /// will be no bucket policies and no resource tags. To have more control over how
+  /// buckets are created, use a different API to create them.
   bool allow_create_buckets = false;
 
   /// \brief Default metadata for OpenOutputStream.

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -136,7 +136,10 @@ struct ARROW_EXPORT S3Options {
   /// In AWS S3, the bucket and all objects will be not publicly visible, and there
   /// will be no bucket policies and no resource tags. To have more control over how
   /// buckets are created, use a different API to create them.
-  bool allow_create_buckets = false;
+  bool allow_bucket_creation = false;
+
+  /// Whether to allow deletion of buckets
+  bool allow_bucket_deletion = false;
 
   /// \brief Default metadata for OpenOutputStream.
   ///
@@ -226,7 +229,11 @@ class ARROW_EXPORT S3FileSystem : public FileSystem {
   /// Return the actual region this filesystem connects to
   std::string region() const;
 
-  void allow_create_buckets(bool allow);
+  /// Set create_buckets property of options
+  void allow_bucket_creation(bool allow);
+
+  /// Set delete_buckets property of options
+  void allow_bucket_deletion(bool allow);
 
   bool Equals(const FileSystem& other) const override;
 

--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -406,7 +406,8 @@ class TestS3FS : public S3TestMixin {
   void SetUp() override {
     S3TestMixin::SetUp();
     // Most tests will create buckets
-    options_.allow_create_buckets = true;
+    options_.allow_bucket_creation = true;
+    options_.allow_bucket_deletion = true;
     MakeFileSystem();
     // Set up test bucket
     {
@@ -1130,7 +1131,8 @@ TEST_F(TestS3FS, NoCreateDeleteBucket) {
   // Create a bucket to try deleting
   ASSERT_OK(fs_->CreateDir("test-no-delete"));
 
-  options_.allow_create_buckets = false;
+  options_.allow_bucket_creation = false;
+  options_.allow_bucket_deletion = false;
   MakeFileSystem();
   ASSERT_RAISES(IOError, fs_->CreateDir("test-no-create"));
   ASSERT_RAISES(IOError, fs_->DeleteDir("test-no-delete"));

--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -442,6 +442,7 @@ class TestS3FS : public S3TestMixin {
     if (!options_.retry_strategy) {
       options_.retry_strategy = std::make_shared<ShortRetryStrategy>();
     }
+    options_.allow_create_buckets = true;
     ASSERT_OK_AND_ASSIGN(fs_, S3FileSystem::Make(options_));
   }
 

--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -1134,8 +1134,16 @@ TEST_F(TestS3FS, NoCreateDeleteBucket) {
   options_.allow_bucket_creation = false;
   options_.allow_bucket_deletion = false;
   MakeFileSystem();
-  ASSERT_RAISES(IOError, fs_->CreateDir("test-no-create"));
-  ASSERT_RAISES(IOError, fs_->DeleteDir("test-no-delete"));
+
+  auto maybe_create_dir = fs_->CreateDir("test-no-create");
+  ASSERT_RAISES(IOError, maybe_create_dir);
+  ASSERT_THAT(maybe_create_dir.message(),
+              ::testing::HasSubstr("Bucket 'test-no-create' not found"));
+
+  auto maybe_delete_dir = fs_->DeleteDir("test-no-delete");
+  ASSERT_RAISES(IOError, maybe_delete_dir);
+  ASSERT_THAT(maybe_delete_dir.message(),
+              ::testing::HasSubstr("Would delete bucket 'test-no-delete'"));
 }
 
 // Simple retry strategy that records errors encountered and its emitted retry delays

--- a/cpp/src/arrow/util/string.cc
+++ b/cpp/src/arrow/util/string.cc
@@ -187,5 +187,15 @@ util::optional<std::string> Replace(util::string_view s, util::string_view token
          s.substr(token_start + token.size()).to_string();
 }
 
+Result<bool> ParseBoolean(util::string_view value) {
+  if (AsciiEqualsCaseInsensitive(value, "true") || value == "1") {
+    return true;
+  } else if (AsciiEqualsCaseInsensitive(value, "false") || value == "0") {
+    return false;
+  } else {
+    return Status::Invalid("String is not a valid boolean value: '", value, "'.");
+  }
+}
+
 }  // namespace internal
 }  // namespace arrow

--- a/cpp/src/arrow/util/string.h
+++ b/cpp/src/arrow/util/string.h
@@ -20,6 +20,7 @@
 #include <string>
 #include <vector>
 
+#include "arrow/result.h"
 #include "arrow/util/optional.h"
 #include "arrow/util/string_view.h"
 #include "arrow/util/visibility.h"
@@ -75,5 +76,12 @@ ARROW_EXPORT
 util::optional<std::string> Replace(util::string_view s, util::string_view token,
                                     util::string_view replacement);
 
+/// \brief Get boolean value from string
+///
+/// If "1", "true" (case-insensitive), returns true
+/// If "0", "false" (case-insensitive), returns false
+/// Otherwise, returns Status::Invalid
+ARROW_EXPORT
+arrow::Result<bool> ParseBoolean(util::string_view value);
 }  // namespace internal
 }  // namespace arrow

--- a/python/pyarrow/_s3fs.pyx
+++ b/python/pyarrow/_s3fs.pyx
@@ -157,11 +157,11 @@ cdef class S3FileSystem(FileSystem):
                                         'port': 8020, 'username': 'username',
                                         'password': 'password'})
     allow_bucket_creation : bool, default False
-        If True, allows creating buckets. This option may also be passed in a 
-        URI query parameter.
+        Whether to allow CreateDir at the bucket-level. This option may also be 
+        passed in a URI query parameter.
     allow_bucket_deletion : bool, default False
-        If True, allows deleting buckets. This option may also be passed in a 
-        URI query parameter.
+        Whether to allow DeleteDir at the bucket-level. This option may also be 
+        passed in a URI query parameter.
     """
 
     cdef:
@@ -328,25 +328,3 @@ cdef class S3FileSystem(FileSystem):
         The AWS region this filesystem connects to.
         """
         return frombytes(self.s3fs.region())
-
-    @property
-    def allow_bucket_creation(self):
-        """
-        Whether to allow CreateDir at the bucket-level.
-        """
-        return self.s3fs.options().allow_bucket_creation
-
-    @allow_bucket_creation.setter
-    def allow_bucket_creation(self, value):
-        self.s3fs.allow_bucket_creation(value)
-
-    @property
-    def allow_bucket_deletion(self):
-        """
-        Whether to allow DeleteDir at the bucket-level.
-        """
-        return self.s3fs.options().allow_bucket_deletion
-
-    @allow_bucket_deletion.setter
-    def allow_bucket_deletion(self, value):
-        self.s3fs.allow_bucket_deletion(value)

--- a/python/pyarrow/_s3fs.pyx
+++ b/python/pyarrow/_s3fs.pyx
@@ -311,6 +311,8 @@ cdef class S3FileSystem(FileSystem):
                 external_id=frombytes(opts.external_id),
                 load_frequency=opts.load_frequency,
                 background_writes=opts.background_writes,
+                allow_bucket_creation=opts.allow_bucket_creation,
+                allow_bucket_deletion=opts.allow_bucket_deletion,
                 default_metadata=pyarrow_wrap_metadata(opts.default_metadata),
                 proxy_options={'scheme': frombytes(opts.proxy_options.scheme),
                                'host': frombytes(opts.proxy_options.host),
@@ -318,7 +320,7 @@ cdef class S3FileSystem(FileSystem):
                                'username': frombytes(
                                    opts.proxy_options.username),
                                'password': frombytes(
-                                   opts.proxy_options.password)}
+                                   opts.proxy_options.password)},
             ),)
         )
 

--- a/python/pyarrow/_s3fs.pyx
+++ b/python/pyarrow/_s3fs.pyx
@@ -150,6 +150,8 @@ cdef class S3FileSystem(FileSystem):
             S3FileSystem(proxy_options={'scheme': 'http', 'host': 'localhost',
                                         'port': 8020, 'username': 'username',
                                         'password': 'password'})
+    allow_create_buckets : bool, default False
+        If True, allows creating and deleting buckets.
     """
 
     cdef:
@@ -159,7 +161,8 @@ cdef class S3FileSystem(FileSystem):
                  bint anonymous=False, region=None, scheme=None,
                  endpoint_override=None, bint background_writes=True,
                  default_metadata=None, role_arn=None, session_name=None,
-                 external_id=None, load_frequency=900, proxy_options=None):
+                 external_id=None, load_frequency=900, proxy_options=None,
+                 allow_create_buckets=False):
         cdef:
             CS3Options options
             shared_ptr[CS3FileSystem] wrapped
@@ -252,6 +255,8 @@ cdef class S3FileSystem(FileSystem):
                 raise TypeError(
                     "'proxy_options': expected 'dict' or 'str', "
                     f"got {type(proxy_options)} instead.")
+
+        options.allow_create_buckets = allow_create_buckets
 
         with nogil:
             wrapped = GetResultValue(CS3FileSystem.Make(options))

--- a/python/pyarrow/_s3fs.pyx
+++ b/python/pyarrow/_s3fs.pyx
@@ -320,6 +320,9 @@ cdef class S3FileSystem(FileSystem):
 
     @property
     def allow_create_buckets(self):
+        """
+        Whether to allow CreateDir and DeleteDir at the bucket-level.
+        """
         return self.s3fs.options().allow_create_buckets
 
     @allow_create_buckets.setter

--- a/python/pyarrow/_s3fs.pyx
+++ b/python/pyarrow/_s3fs.pyx
@@ -99,6 +99,12 @@ cdef class S3FileSystem(FileSystem):
     Note: S3 buckets are special and the operations available on them may be
     limited or more expensive than desired.
 
+    When S3FileSystem creates new buckets (assuming allow_create_buckets is True),
+    it does not pass any non-default settings. In AWS S3, the bucket and all 
+    objects will be not publicly visible, and will have no bucket policies 
+    and no resource tags. To have more control over how buckets are created,
+    use a different API to create them.
+
     Parameters
     ----------
     access_key : str, default None
@@ -151,7 +157,8 @@ cdef class S3FileSystem(FileSystem):
                                         'port': 8020, 'username': 'username',
                                         'password': 'password'})
     allow_create_buckets : bool, default False
-        If True, allows creating and deleting buckets.
+        If True, allows creating and deleting buckets. This option may also be
+        passed in a URI query parameter.
     """
 
     cdef:

--- a/python/pyarrow/_s3fs.pyx
+++ b/python/pyarrow/_s3fs.pyx
@@ -317,3 +317,11 @@ cdef class S3FileSystem(FileSystem):
         The AWS region this filesystem connects to.
         """
         return frombytes(self.s3fs.region())
+
+    @property
+    def allow_create_buckets(self):
+        return self.s3fs.options().allow_create_buckets
+
+    @allow_create_buckets.setter
+    def allow_create_buckets(self, value):
+        self.s3fs.allow_create_buckets(value)

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -194,6 +194,7 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         CResult[shared_ptr[CS3FileSystem]] Make(const CS3Options& options)
         CS3Options options()
         c_string region()
+        void allow_create_buckets(c_bool allow)
 
     cdef CStatus CInitializeS3 "arrow::fs::InitializeS3"(
         const CS3GlobalOptions& options)

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -195,8 +195,6 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         CResult[shared_ptr[CS3FileSystem]] Make(const CS3Options& options)
         CS3Options options()
         c_string region()
-        void allow_bucket_creation(c_bool allow)
-        void allow_bucket_deletion(c_bool allow)
 
     cdef CStatus CInitializeS3 "arrow::fs::InitializeS3"(
         const CS3GlobalOptions& options)

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -155,7 +155,8 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         c_string endpoint_override
         c_string scheme
         c_bool background_writes
-        c_bool allow_create_buckets
+        c_bool allow_bucket_creation
+        c_bool allow_bucket_deletion
         shared_ptr[const CKeyValueMetadata] default_metadata
         c_string role_arn
         c_string session_name
@@ -194,7 +195,8 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         CResult[shared_ptr[CS3FileSystem]] Make(const CS3Options& options)
         CS3Options options()
         c_string region()
-        void allow_create_buckets(c_bool allow)
+        void allow_bucket_creation(c_bool allow)
+        void allow_bucket_deletion(c_bool allow)
 
     cdef CStatus CInitializeS3 "arrow::fs::InitializeS3"(
         const CS3GlobalOptions& options)

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -155,6 +155,7 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         c_string endpoint_override
         c_string scheme
         c_bool background_writes
+        c_bool allow_create_buckets
         shared_ptr[const CKeyValueMetadata] default_metadata
         c_string role_arn
         c_string session_name

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -2495,11 +2495,11 @@ def s3_example_simple(s3_server):
     host, port, access_key, secret_key = s3_server['connection']
     uri = (
         "s3://{}:{}@mybucket/data.parquet?scheme=http&endpoint_override={}:{}"
+        "&allow_create_buckets=True"
         .format(access_key, secret_key, host, port)
     )
 
     fs, path = FileSystem.from_uri(uri)
-    fs.allow_create_buckets = True
 
     fs.create_dir("mybucket")
     table = pa.table({'a': [1, 2, 3]})

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -2490,7 +2490,7 @@ def test_dataset_partitioned_dictionary_type_reconstruct(tempdir):
 @pytest.fixture
 @pytest.mark.parquet
 def s3_example_simple(s3_server):
-    from pyarrow.fs import S3FileSystem
+    from pyarrow.fs import FileSystem
 
     host, port, access_key, secret_key = s3_server['connection']
     uri = (
@@ -2498,14 +2498,8 @@ def s3_example_simple(s3_server):
         .format(access_key, secret_key, host, port)
     )
 
-    fs = S3FileSystem(
-        access_key=access_key,
-        secret_key=secret_key,
-        scheme="http",
-        endpoint_override="{}:{}".format(host, port),
-        allow_create_buckets=True,
-    )
-    path = "mybucket/data.parquet"
+    fs, path = FileSystem.from_uri(uri)
+    fs.allow_create_buckets = True
 
     fs.create_dir("mybucket")
     table = pa.table({'a': [1, 2, 3]})
@@ -2559,7 +2553,7 @@ def test_open_dataset_from_uri_s3_fsspec(s3_example_simple):
 @pytest.mark.parquet
 @pytest.mark.s3
 def test_open_dataset_from_s3_with_filesystem_uri(s3_server):
-    from pyarrow.fs import S3FileSystem
+    from pyarrow.fs import FileSystem
 
     host, port, access_key, secret_key = s3_server['connection']
     bucket = 'theirbucket'
@@ -2568,17 +2562,12 @@ def test_open_dataset_from_s3_with_filesystem_uri(s3_server):
         access_key, secret_key, bucket, path, host, port
     )
 
-    # At first need a fs that can create buckets
-    fs = S3FileSystem(
-        access_key=access_key,
-        secret_key=secret_key,
-        scheme="http",
-        endpoint_override="{}:{}".format(host, port),
-        allow_create_buckets=True,
-    )
+    fs, path = FileSystem.from_uri(uri)
+    assert path == 'theirbucket/nested/folder/data.parquet'
+
+    fs.allow_create_buckets = True
     fs.create_dir(bucket)
 
-    path = bucket + '/' + path
     table = pa.table({'a': [1, 2, 3]})
     with fs.open_output_stream(path) as out:
         pq.write_table(table, out)

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -2558,14 +2558,14 @@ def test_open_dataset_from_s3_with_filesystem_uri(s3_server):
     host, port, access_key, secret_key = s3_server['connection']
     bucket = 'theirbucket'
     path = 'nested/folder/data.parquet'
-    uri = "s3://{}:{}@{}/{}?scheme=http&endpoint_override={}:{}".format(
-        access_key, secret_key, bucket, path, host, port
-    )
+    uri = "s3://{}:{}@{}/{}?scheme=http&endpoint_override={}:{}"\
+        "&allow_bucket_creation=true".format(
+            access_key, secret_key, bucket, path, host, port
+        )
 
     fs, path = FileSystem.from_uri(uri)
     assert path == 'theirbucket/nested/folder/data.parquet'
 
-    fs.allow_bucket_creation = True
     fs.create_dir(bucket)
 
     table = pa.table({'a': [1, 2, 3]})
@@ -4552,7 +4552,13 @@ def test_write_dataset_s3_put_only(s3_server):
         )
 
     # Error enforced by minio / S3 service
-    fs.allow_bucket_creation = True
+    fs = S3FileSystem(
+        access_key='limited',
+        secret_key='limited123',
+        endpoint_override='{}:{}'.format(host, port),
+        scheme='http',
+        allow_bucket_creation=True,
+    )
     with pytest.raises(OSError, match="Access Denied"):
         ds.write_dataset(
             table, "non-existing-bucket", filesystem=fs,

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -4531,9 +4531,21 @@ def test_write_dataset_s3_put_only(s3_server):
     ).to_table()
     assert result.equals(table)
 
-    with pytest.raises(OSError, match="Access Denied"):
+    # Passing create_dir is fine if the bucket already exists
+    ds.write_dataset(
+        table, "existing-bucket", filesystem=fs,
+        format="feather", create_dir=True, partitioning=part,
+        existing_data_behavior='overwrite_or_ignore'
+    )
+    # check roundtrip
+    result = ds.dataset(
+        "existing-bucket", filesystem=fs, format="ipc", partitioning="hive"
+    ).to_table()
+    assert result.equals(table)
+
+    with pytest.raises(OSError, match="Bucket does not exist"):
         ds.write_dataset(
-            table, "existing-bucket", filesystem=fs,
+            table, "non-existing-bucket", filesystem=fs,
             format="feather", create_dir=True,
             existing_data_behavior='overwrite_or_ignore'
         )

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -4543,7 +4543,17 @@ def test_write_dataset_s3_put_only(s3_server):
     ).to_table()
     assert result.equals(table)
 
+    # Error enforced by filesystem
     with pytest.raises(OSError, match="Bucket does not exist"):
+        ds.write_dataset(
+            table, "non-existing-bucket", filesystem=fs,
+            format="feather", create_dir=True,
+            existing_data_behavior='overwrite_or_ignore'
+        )
+
+    # Error enforced by minio / S3 service
+    fs.allow_create_buckets = True
+    with pytest.raises(OSError, match="Access Denied"):
         ds.write_dataset(
             table, "non-existing-bucket", filesystem=fs,
             format="feather", create_dir=True,

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -4544,7 +4544,8 @@ def test_write_dataset_s3_put_only(s3_server):
     assert result.equals(table)
 
     # Error enforced by filesystem
-    with pytest.raises(OSError, match="Bucket does not exist"):
+    with pytest.raises(OSError,
+                       match="Bucket 'non-existing-bucket' not found"):
         ds.write_dataset(
             table, "non-existing-bucket", filesystem=fs,
             format="feather", create_dir=True,

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -2495,7 +2495,7 @@ def s3_example_simple(s3_server):
     host, port, access_key, secret_key = s3_server['connection']
     uri = (
         "s3://{}:{}@mybucket/data.parquet?scheme=http&endpoint_override={}:{}"
-        "&allow_create_buckets=True"
+        "&allow_bucket_creation=True"
         .format(access_key, secret_key, host, port)
     )
 
@@ -2565,7 +2565,7 @@ def test_open_dataset_from_s3_with_filesystem_uri(s3_server):
     fs, path = FileSystem.from_uri(uri)
     assert path == 'theirbucket/nested/folder/data.parquet'
 
-    fs.allow_create_buckets = True
+    fs.allow_bucket_creation = True
     fs.create_dir(bucket)
 
     table = pa.table({'a': [1, 2, 3]})
@@ -4552,7 +4552,7 @@ def test_write_dataset_s3_put_only(s3_server):
         )
 
     # Error enforced by minio / S3 service
-    fs.allow_create_buckets = True
+    fs.allow_bucket_creation = True
     with pytest.raises(OSError, match="Access Denied"):
         ds.write_dataset(
             table, "non-existing-bucket", filesystem=fs,

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -1319,6 +1319,12 @@ def test_filesystem_from_uri_s3(s3_server):
     assert isinstance(fs, S3FileSystem)
     assert path == "mybucket/foo/bar"
 
+    fs.allow_create_buckets = True
+    fs.create_dir(path)
+    [info] = fs.get_file_info([path])
+    assert info.path == path
+    assert info.type == FileType.Directory
+
 
 def test_py_filesystem():
     handler = DummyHandler()

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -213,7 +213,8 @@ def s3fs(request, s3_server):
         secret_key=secret_key,
         endpoint_override='{}:{}'.format(host, port),
         scheme='http',
-        allow_create_buckets=True
+        allow_bucket_creation=True,
+        allow_bucket_deletion=True
     )
     fs.create_dir(bucket)
 
@@ -446,6 +447,9 @@ def test_s3fs_limited_permissions_create_bucket(s3_server):
 
     with pytest.raises(pa.ArrowIOError):
         fs.create_dir('new-bucket')
+    
+    with pytest.raises(pa.ArrowIOError):
+        fs.delete_dir('existing-bucket')
 
 
 def test_file_info_constructor():
@@ -1319,7 +1323,7 @@ def test_filesystem_from_uri_s3(s3_server):
     assert isinstance(fs, S3FileSystem)
     assert path == "mybucket/foo/bar"
 
-    fs.allow_create_buckets = True
+    fs.allow_bucket_creation = True
     fs.create_dir(path)
     [info] = fs.get_file_info([path])
     assert info.path == path

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -445,10 +445,10 @@ def test_s3fs_limited_permissions_create_bucket(s3_server):
     )
     fs.create_dir('existing-bucket/test')
 
-    with pytest.raises(pa.ArrowIOError):
+    with pytest.raises(pa.ArrowIOError, match="Bucket does not exist"):
         fs.create_dir('new-bucket')
 
-    with pytest.raises(pa.ArrowIOError):
+    with pytest.raises(pa.ArrowIOError, match="Would delete bucket"):
         fs.delete_dir('existing-bucket')
 
 
@@ -1041,6 +1041,10 @@ def test_s3_options():
     fs = S3FileSystem(background_writes=True,
                       default_metadata={"ACL": "authenticated-read",
                                         "Content-Type": "text/plain"})
+    assert isinstance(fs, S3FileSystem)
+    assert pickle.loads(pickle.dumps(fs)) == fs
+
+    fs = S3FileSystem(allow_bucket_creation=True, allow_bucket_deletion=True)
     assert isinstance(fs, S3FileSystem)
     assert pickle.loads(pickle.dumps(fs)) == fs
 

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -447,7 +447,7 @@ def test_s3fs_limited_permissions_create_bucket(s3_server):
 
     with pytest.raises(pa.ArrowIOError):
         fs.create_dir('new-bucket')
-    
+
     with pytest.raises(pa.ArrowIOError):
         fs.delete_dir('existing-bucket')
 

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -445,7 +445,7 @@ def test_s3fs_limited_permissions_create_bucket(s3_server):
     )
     fs.create_dir('existing-bucket/test')
 
-    with pytest.raises(pa.ArrowIOError, match="Bucket does not exist"):
+    with pytest.raises(pa.ArrowIOError, match="Bucket 'new-bucket' not found"):
         fs.create_dir('new-bucket')
 
     with pytest.raises(pa.ArrowIOError, match="Would delete bucket"):

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -1316,14 +1316,14 @@ def test_filesystem_from_uri_s3(s3_server):
 
     host, port, access_key, secret_key = s3_server['connection']
 
-    uri = "s3://{}:{}@mybucket/foo/bar?scheme=http&endpoint_override={}:{}" \
-        .format(access_key, secret_key, host, port)
+    uri = "s3://{}:{}@mybucket/foo/bar?scheme=http&endpoint_override={}:{}"\
+          "&allow_bucket_creation=True" \
+          .format(access_key, secret_key, host, port)
 
     fs, path = FileSystem.from_uri(uri)
     assert isinstance(fs, S3FileSystem)
     assert path == "mybucket/foo/bar"
 
-    fs.allow_bucket_creation = True
     fs.create_dir(path)
     [info] = fs.get_file_info([path])
     assert info.path == path

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -212,7 +212,8 @@ def s3fs(request, s3_server):
         access_key=access_key,
         secret_key=secret_key,
         endpoint_override='{}:{}'.format(host, port),
-        scheme='http'
+        scheme='http',
+        allow_create_buckets=True
     )
     fs.create_dir(bucket)
 
@@ -442,6 +443,9 @@ def test_s3fs_limited_permissions_create_bucket(s3_server):
         scheme='http'
     )
     fs.create_dir('existing-bucket/test')
+
+    with pytest.raises(pa.ArrowIOError):
+        fs.create_dir('new-bucket')
 
 
 def test_file_info_constructor():
@@ -1314,11 +1318,6 @@ def test_filesystem_from_uri_s3(s3_server):
     fs, path = FileSystem.from_uri(uri)
     assert isinstance(fs, S3FileSystem)
     assert path == "mybucket/foo/bar"
-
-    fs.create_dir(path)
-    [info] = fs.get_file_info([path])
-    assert info.path == path
-    assert info.type == FileType.Directory
 
 
 def test_py_filesystem():

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -1288,14 +1288,6 @@ fs___S3FileSystem__region <- function(fs) {
   .Call(`_arrow_fs___S3FileSystem__region`, fs)
 }
 
-fs__S3FileSystem__allow_bucket_creation <- function(fs, allow) {
-  invisible(.Call(`_arrow_fs__S3FileSystem__allow_bucket_creation`, fs, allow))
-}
-
-fs__S3FileSystem__allow_bucket_deletion <- function(fs, allow) {
-  invisible(.Call(`_arrow_fs__S3FileSystem__allow_bucket_deletion`, fs, allow))
-}
-
 io___Readable__Read <- function(x, nbytes) {
   .Call(`_arrow_io___Readable__Read`, x, nbytes)
 }

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -1288,6 +1288,10 @@ fs___S3FileSystem__region <- function(fs) {
   .Call(`_arrow_fs___S3FileSystem__region`, fs)
 }
 
+fs__S3FileSystem__allow_create_buckets <- function(fs, allow) {
+  invisible(.Call(`_arrow_fs__S3FileSystem__allow_create_buckets`, fs, allow))
+}
+
 io___Readable__Read <- function(x, nbytes) {
   .Call(`_arrow_io___Readable__Read`, x, nbytes)
 }

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -1280,16 +1280,20 @@ fs___CopyFiles <- function(source_fs, source_sel, destination_fs, destination_ba
   invisible(.Call(`_arrow_fs___CopyFiles`, source_fs, source_sel, destination_fs, destination_base_dir, chunk_size, use_threads))
 }
 
-fs___S3FileSystem__create <- function(anonymous, access_key, secret_key, session_token, role_arn, session_name, external_id, load_frequency, region, endpoint_override, scheme, proxy_options, background_writes, allow_create_buckets) {
-  .Call(`_arrow_fs___S3FileSystem__create`, anonymous, access_key, secret_key, session_token, role_arn, session_name, external_id, load_frequency, region, endpoint_override, scheme, proxy_options, background_writes, allow_create_buckets)
+fs___S3FileSystem__create <- function(anonymous, access_key, secret_key, session_token, role_arn, session_name, external_id, load_frequency, region, endpoint_override, scheme, proxy_options, background_writes, allow_bucket_creation, allow_bucket_deletion) {
+  .Call(`_arrow_fs___S3FileSystem__create`, anonymous, access_key, secret_key, session_token, role_arn, session_name, external_id, load_frequency, region, endpoint_override, scheme, proxy_options, background_writes, allow_bucket_creation, allow_bucket_deletion)
 }
 
 fs___S3FileSystem__region <- function(fs) {
   .Call(`_arrow_fs___S3FileSystem__region`, fs)
 }
 
-fs__S3FileSystem__allow_create_buckets <- function(fs, allow) {
-  invisible(.Call(`_arrow_fs__S3FileSystem__allow_create_buckets`, fs, allow))
+fs__S3FileSystem__allow_bucket_creation <- function(fs, allow) {
+  invisible(.Call(`_arrow_fs__S3FileSystem__allow_bucket_creation`, fs, allow))
+}
+
+fs__S3FileSystem__allow_bucket_deletion <- function(fs, allow) {
+  invisible(.Call(`_arrow_fs__S3FileSystem__allow_bucket_deletion`, fs, allow))
 }
 
 io___Readable__Read <- function(x, nbytes) {

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -1280,8 +1280,8 @@ fs___CopyFiles <- function(source_fs, source_sel, destination_fs, destination_ba
   invisible(.Call(`_arrow_fs___CopyFiles`, source_fs, source_sel, destination_fs, destination_base_dir, chunk_size, use_threads))
 }
 
-fs___S3FileSystem__create <- function(anonymous, access_key, secret_key, session_token, role_arn, session_name, external_id, load_frequency, region, endpoint_override, scheme, proxy_options, background_writes) {
-  .Call(`_arrow_fs___S3FileSystem__create`, anonymous, access_key, secret_key, session_token, role_arn, session_name, external_id, load_frequency, region, endpoint_override, scheme, proxy_options, background_writes)
+fs___S3FileSystem__create <- function(anonymous, access_key, secret_key, session_token, role_arn, session_name, external_id, load_frequency, region, endpoint_override, scheme, proxy_options, background_writes, allow_create_buckets) {
+  .Call(`_arrow_fs___S3FileSystem__create`, anonymous, access_key, secret_key, session_token, role_arn, session_name, external_id, load_frequency, region, endpoint_override, scheme, proxy_options, background_writes, allow_create_buckets)
 }
 
 fs___S3FileSystem__region <- function(fs) {

--- a/r/R/filesystem.R
+++ b/r/R/filesystem.R
@@ -182,6 +182,10 @@ FileSelector$create <- function(base_dir, allow_not_found = FALSE, recursive = F
 #'    sequential writing.
 #' - `$OpenAppendStream(path)`: Open an [output stream][OutputStream] for
 #'    appending.
+#' 
+#' `S3FileSystem` also has a method:
+#' 
+#' - `$allow_create_buckets()` which can set the corresponding option above. 
 #'
 #' @section Active bindings:
 #'

--- a/r/R/filesystem.R
+++ b/r/R/filesystem.R
@@ -150,6 +150,9 @@ FileSelector$create <- function(base_dir, allow_not_found = FALSE, recursive = F
 #' - `scheme`: S3 connection transport (default "https")
 #' - `background_writes`: logical, whether `OutputStream` writes will be issued
 #'    in the background, without blocking (default `TRUE`)
+#' - `allow_create_buckets`: logical, if TRUE, the filesystem will create or
+#'    delete buckets if `$CreateDir()` or `$DeleteDir()` is called on the bucket
+#'    level (default `FALSE`).
 #'
 #' @section Methods:
 #'
@@ -338,7 +341,7 @@ S3FileSystem$create <- function(anonymous = FALSE, ...) {
     invalid_args <- intersect(
       c(
         "access_key", "secret_key", "session_token", "role_arn", "session_name",
-        "external_id", "load_frequency"
+        "external_id", "load_frequency", "allow_create_buckets"
       ),
       names(args)
     )
@@ -383,7 +386,8 @@ default_s3_options <- list(
   endpoint_override = "",
   scheme = "",
   proxy_options = "",
-  background_writes = TRUE
+  background_writes = TRUE,
+  allow_create_buckets = FALSE
 )
 
 #' Connect to an AWS S3 bucket

--- a/r/R/filesystem.R
+++ b/r/R/filesystem.R
@@ -196,6 +196,15 @@ FileSelector$create <- function(base_dir, allow_not_found = FALSE, recursive = F
 #' - `$base_path`: for `SubTreeFileSystem`, the path in `$base_fs` which is considered
 #'    root in this `SubTreeFileSystem`.
 #'
+#' @section Notes:
+#'
+#' On S3FileSystem, `$CreateDir()` on a top-level directory creates a new bucket.
+#' When S3FileSystem creates new buckets (assuming allow_create_buckets is TRUE),
+#' it does not pass any non-default settings. In AWS S3, the bucket and all
+#' objects will be not publicly visible, and will have no bucket policies
+#' and no resource tags. To have more control over how buckets are created,
+#' use a different API to create them.
+#'
 #' @usage NULL
 #' @format NULL
 #' @docType class

--- a/r/R/filesystem.R
+++ b/r/R/filesystem.R
@@ -182,10 +182,10 @@ FileSelector$create <- function(base_dir, allow_not_found = FALSE, recursive = F
 #'    sequential writing.
 #' - `$OpenAppendStream(path)`: Open an [output stream][OutputStream] for
 #'    appending.
-#' 
+#'
 #' `S3FileSystem` also has a method:
-#' 
-#' - `$allow_create_buckets()` which can set the corresponding option above. 
+#'
+#' - `$allow_create_buckets()` which can set the corresponding option above.
 #'
 #' @section Active bindings:
 #'

--- a/r/R/filesystem.R
+++ b/r/R/filesystem.R
@@ -184,11 +184,6 @@ FileSelector$create <- function(base_dir, allow_not_found = FALSE, recursive = F
 #' - `$OpenAppendStream(path)`: Open an [output stream][OutputStream] for
 #'    appending.
 #'
-#' `S3FileSystem` also has methods:
-#'
-#' - `$allow_bucket_creation()` which can set the corresponding option above.
-#' - `$allow_bucket_deletion()` which can set the corresponding option above.
-#'
 #' @section Active bindings:
 #'
 #' - `$type_name`: string filesystem type name, such as "local", "s3", etc.
@@ -348,10 +343,6 @@ S3FileSystem <- R6Class("S3FileSystem",
   inherit = FileSystem,
   active = list(
     region = function() fs___S3FileSystem__region(self)
-  ),
-  public = list(
-    allow_bucket_creation = function(allow) fs__S3FileSystem__allow_bucket_creation(self, allow),
-    allow_bucket_deletion = function(allow) fs__S3FileSystem__allow_bucket_deletion(self, allow)
   )
 )
 S3FileSystem$create <- function(anonymous = FALSE, ...) {

--- a/r/R/filesystem.R
+++ b/r/R/filesystem.R
@@ -150,9 +150,10 @@ FileSelector$create <- function(base_dir, allow_not_found = FALSE, recursive = F
 #' - `scheme`: S3 connection transport (default "https")
 #' - `background_writes`: logical, whether `OutputStream` writes will be issued
 #'    in the background, without blocking (default `TRUE`)
-#' - `allow_create_buckets`: logical, if TRUE, the filesystem will create or
-#'    delete buckets if `$CreateDir()` or `$DeleteDir()` is called on the bucket
-#'    level (default `FALSE`).
+#' - `allow_bucket_creation`: logical, if TRUE, the filesystem will create
+#'    buckets if `$CreateDir()` is called on the bucket level (default `FALSE`).
+#' - `allow_bucket_deletion`: logical, if TRUE, the filesystem will delete
+#'    buckets if`$DeleteDir()` is called on the bucket level (default `FALSE`).
 #'
 #' @section Methods:
 #'
@@ -183,9 +184,10 @@ FileSelector$create <- function(base_dir, allow_not_found = FALSE, recursive = F
 #' - `$OpenAppendStream(path)`: Open an [output stream][OutputStream] for
 #'    appending.
 #'
-#' `S3FileSystem` also has a method:
+#' `S3FileSystem` also has methods:
 #'
-#' - `$allow_create_buckets()` which can set the corresponding option above.
+#' - `$allow_bucket_creation()` which can set the corresponding option above.
+#' - `$allow_bucket_deletion()` which can set the corresponding option above.
 #'
 #' @section Active bindings:
 #'
@@ -199,7 +201,7 @@ FileSelector$create <- function(base_dir, allow_not_found = FALSE, recursive = F
 #' @section Notes:
 #'
 #' On S3FileSystem, `$CreateDir()` on a top-level directory creates a new bucket.
-#' When S3FileSystem creates new buckets (assuming allow_create_buckets is TRUE),
+#' When S3FileSystem creates new buckets (assuming allow_bucket_creation is TRUE),
 #' it does not pass any non-default settings. In AWS S3, the bucket and all
 #' objects will be not publicly visible, and will have no bucket policies
 #' and no resource tags. To have more control over how buckets are created,
@@ -348,7 +350,8 @@ S3FileSystem <- R6Class("S3FileSystem",
     region = function() fs___S3FileSystem__region(self)
   ),
   public = list(
-    allow_create_buckets = function(allow) fs__S3FileSystem__allow_create_buckets(self, allow)
+    allow_bucket_creation = function(allow) fs__S3FileSystem__allow_bucket_creation(self, allow),
+    allow_bucket_deletion = function(allow) fs__S3FileSystem__allow_bucket_deletion(self, allow)
   )
 )
 S3FileSystem$create <- function(anonymous = FALSE, ...) {
@@ -357,7 +360,7 @@ S3FileSystem$create <- function(anonymous = FALSE, ...) {
     invalid_args <- intersect(
       c(
         "access_key", "secret_key", "session_token", "role_arn", "session_name",
-        "external_id", "load_frequency", "allow_create_buckets"
+        "external_id", "load_frequency", "allow_bucket_creation", "allow_bucket_deletion"
       ),
       names(args)
     )
@@ -403,7 +406,8 @@ default_s3_options <- list(
   scheme = "",
   proxy_options = "",
   background_writes = TRUE,
-  allow_create_buckets = FALSE
+  allow_bucket_creation = FALSE,
+  allow_bucket_deletion = FALSE
 )
 
 #' Connect to an AWS S3 bucket

--- a/r/R/filesystem.R
+++ b/r/R/filesystem.R
@@ -333,6 +333,9 @@ S3FileSystem <- R6Class("S3FileSystem",
   inherit = FileSystem,
   active = list(
     region = function() fs___S3FileSystem__region(self)
+  ),
+  public = list(
+    allow_create_buckets = function(allow) fs__S3FileSystem__allow_create_buckets(self, allow)
   )
 )
 S3FileSystem$create <- function(anonymous = FALSE, ...) {

--- a/r/man/FileSystem.Rd
+++ b/r/man/FileSystem.Rd
@@ -86,6 +86,11 @@ sequential writing.
 \item \verb{$OpenAppendStream(path)}: Open an \link[=OutputStream]{output stream} for
 appending.
 }
+
+\code{S3FileSystem} also has a method:
+\itemize{
+\item \verb{$allow_create_buckets()} which can set the corresponding option above.
+}
 }
 
 \section{Active bindings}{
@@ -98,5 +103,16 @@ containing a \code{S3FileSystem}
 \item \verb{$base_path}: for \code{SubTreeFileSystem}, the path in \verb{$base_fs} which is considered
 root in this \code{SubTreeFileSystem}.
 }
+}
+
+\section{Notes}{
+
+
+On S3FileSystem, \verb{$CreateDir()} on a top-level directory creates a new bucket.
+When S3FileSystem creates new buckets (assuming allow_create_buckets is TRUE),
+it does not pass any non-default settings. In AWS S3, the bucket and all
+objects will be not publicly visible, and will have no bucket policies
+and no resource tags. To have more control over how buckets are created,
+use a different API to create them.
 }
 

--- a/r/man/FileSystem.Rd
+++ b/r/man/FileSystem.Rd
@@ -50,6 +50,9 @@ that emulate S3.
 \item \code{scheme}: S3 connection transport (default "https")
 \item \code{background_writes}: logical, whether \code{OutputStream} writes will be issued
 in the background, without blocking (default \code{TRUE})
+\item \code{allow_create_buckets}: logical, if TRUE, the filesystem will create or
+delete buckets if \verb{$CreateDir()} or \verb{$DeleteDir()} is called on the bucket
+level (default \code{FALSE}).
 }
 }
 

--- a/r/man/FileSystem.Rd
+++ b/r/man/FileSystem.Rd
@@ -50,9 +50,10 @@ that emulate S3.
 \item \code{scheme}: S3 connection transport (default "https")
 \item \code{background_writes}: logical, whether \code{OutputStream} writes will be issued
 in the background, without blocking (default \code{TRUE})
-\item \code{allow_create_buckets}: logical, if TRUE, the filesystem will create or
-delete buckets if \verb{$CreateDir()} or \verb{$DeleteDir()} is called on the bucket
-level (default \code{FALSE}).
+\item \code{allow_bucket_creation}: logical, if TRUE, the filesystem will create
+buckets if \verb{$CreateDir()} is called on the bucket level (default \code{FALSE}).
+\item \code{allow_bucket_deletion}: logical, if TRUE, the filesystem will delete
+buckets if\verb{$DeleteDir()} is called on the bucket level (default \code{FALSE}).
 }
 }
 
@@ -87,9 +88,10 @@ sequential writing.
 appending.
 }
 
-\code{S3FileSystem} also has a method:
+\code{S3FileSystem} also has methods:
 \itemize{
-\item \verb{$allow_create_buckets()} which can set the corresponding option above.
+\item \verb{$allow_bucket_creation()} which can set the corresponding option above.
+\item \verb{$allow_bucket_deletion()} which can set the corresponding option above.
 }
 }
 
@@ -109,7 +111,7 @@ root in this \code{SubTreeFileSystem}.
 
 
 On S3FileSystem, \verb{$CreateDir()} on a top-level directory creates a new bucket.
-When S3FileSystem creates new buckets (assuming allow_create_buckets is TRUE),
+When S3FileSystem creates new buckets (assuming allow_bucket_creation is TRUE),
 it does not pass any non-default settings. In AWS S3, the bucket and all
 objects will be not publicly visible, and will have no bucket policies
 and no resource tags. To have more control over how buckets are created,

--- a/r/man/FileSystem.Rd
+++ b/r/man/FileSystem.Rd
@@ -87,12 +87,6 @@ sequential writing.
 \item \verb{$OpenAppendStream(path)}: Open an \link[=OutputStream]{output stream} for
 appending.
 }
-
-\code{S3FileSystem} also has methods:
-\itemize{
-\item \verb{$allow_bucket_creation()} which can set the corresponding option above.
-\item \verb{$allow_bucket_deletion()} which can set the corresponding option above.
-}
 }
 
 \section{Active bindings}{

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -3180,8 +3180,8 @@ END_CPP11
 }
 // filesystem.cpp
 #if defined(ARROW_R_WITH_S3)
-std::shared_ptr<fs::S3FileSystem> fs___S3FileSystem__create(bool anonymous, std::string access_key, std::string secret_key, std::string session_token, std::string role_arn, std::string session_name, std::string external_id, int load_frequency, std::string region, std::string endpoint_override, std::string scheme, std::string proxy_options, bool background_writes, bool allow_create_buckets);
-extern "C" SEXP _arrow_fs___S3FileSystem__create(SEXP anonymous_sexp, SEXP access_key_sexp, SEXP secret_key_sexp, SEXP session_token_sexp, SEXP role_arn_sexp, SEXP session_name_sexp, SEXP external_id_sexp, SEXP load_frequency_sexp, SEXP region_sexp, SEXP endpoint_override_sexp, SEXP scheme_sexp, SEXP proxy_options_sexp, SEXP background_writes_sexp, SEXP allow_create_buckets_sexp){
+std::shared_ptr<fs::S3FileSystem> fs___S3FileSystem__create(bool anonymous, std::string access_key, std::string secret_key, std::string session_token, std::string role_arn, std::string session_name, std::string external_id, int load_frequency, std::string region, std::string endpoint_override, std::string scheme, std::string proxy_options, bool background_writes, bool allow_bucket_creation, bool allow_bucket_deletion);
+extern "C" SEXP _arrow_fs___S3FileSystem__create(SEXP anonymous_sexp, SEXP access_key_sexp, SEXP secret_key_sexp, SEXP session_token_sexp, SEXP role_arn_sexp, SEXP session_name_sexp, SEXP external_id_sexp, SEXP load_frequency_sexp, SEXP region_sexp, SEXP endpoint_override_sexp, SEXP scheme_sexp, SEXP proxy_options_sexp, SEXP background_writes_sexp, SEXP allow_bucket_creation_sexp, SEXP allow_bucket_deletion_sexp){
 BEGIN_CPP11
 	arrow::r::Input<bool>::type anonymous(anonymous_sexp);
 	arrow::r::Input<std::string>::type access_key(access_key_sexp);
@@ -3196,12 +3196,13 @@ BEGIN_CPP11
 	arrow::r::Input<std::string>::type scheme(scheme_sexp);
 	arrow::r::Input<std::string>::type proxy_options(proxy_options_sexp);
 	arrow::r::Input<bool>::type background_writes(background_writes_sexp);
-	arrow::r::Input<bool>::type allow_create_buckets(allow_create_buckets_sexp);
-	return cpp11::as_sexp(fs___S3FileSystem__create(anonymous, access_key, secret_key, session_token, role_arn, session_name, external_id, load_frequency, region, endpoint_override, scheme, proxy_options, background_writes, allow_create_buckets));
+	arrow::r::Input<bool>::type allow_bucket_creation(allow_bucket_creation_sexp);
+	arrow::r::Input<bool>::type allow_bucket_deletion(allow_bucket_deletion_sexp);
+	return cpp11::as_sexp(fs___S3FileSystem__create(anonymous, access_key, secret_key, session_token, role_arn, session_name, external_id, load_frequency, region, endpoint_override, scheme, proxy_options, background_writes, allow_bucket_creation, allow_bucket_deletion));
 END_CPP11
 }
 #else
-extern "C" SEXP _arrow_fs___S3FileSystem__create(SEXP anonymous_sexp, SEXP access_key_sexp, SEXP secret_key_sexp, SEXP session_token_sexp, SEXP role_arn_sexp, SEXP session_name_sexp, SEXP external_id_sexp, SEXP load_frequency_sexp, SEXP region_sexp, SEXP endpoint_override_sexp, SEXP scheme_sexp, SEXP proxy_options_sexp, SEXP background_writes_sexp, SEXP allow_create_buckets_sexp){
+extern "C" SEXP _arrow_fs___S3FileSystem__create(SEXP anonymous_sexp, SEXP access_key_sexp, SEXP secret_key_sexp, SEXP session_token_sexp, SEXP role_arn_sexp, SEXP session_name_sexp, SEXP external_id_sexp, SEXP load_frequency_sexp, SEXP region_sexp, SEXP endpoint_override_sexp, SEXP scheme_sexp, SEXP proxy_options_sexp, SEXP background_writes_sexp, SEXP allow_bucket_creation_sexp, SEXP allow_bucket_deletion_sexp){
 	Rf_error("Cannot call fs___S3FileSystem__create(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
 }
 #endif
@@ -3223,18 +3224,35 @@ extern "C" SEXP _arrow_fs___S3FileSystem__region(SEXP fs_sexp){
 
 // filesystem.cpp
 #if defined(ARROW_R_WITH_S3)
-void fs__S3FileSystem__allow_create_buckets(const std::shared_ptr<fs::S3FileSystem>& fs, bool allow);
-extern "C" SEXP _arrow_fs__S3FileSystem__allow_create_buckets(SEXP fs_sexp, SEXP allow_sexp){
+void fs__S3FileSystem__allow_bucket_creation(const std::shared_ptr<fs::S3FileSystem>& fs, bool allow);
+extern "C" SEXP _arrow_fs__S3FileSystem__allow_bucket_creation(SEXP fs_sexp, SEXP allow_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<fs::S3FileSystem>&>::type fs(fs_sexp);
 	arrow::r::Input<bool>::type allow(allow_sexp);
-	fs__S3FileSystem__allow_create_buckets(fs, allow);
+	fs__S3FileSystem__allow_bucket_creation(fs, allow);
 	return R_NilValue;
 END_CPP11
 }
 #else
-extern "C" SEXP _arrow_fs__S3FileSystem__allow_create_buckets(SEXP fs_sexp, SEXP allow_sexp){
-	Rf_error("Cannot call fs__S3FileSystem__allow_create_buckets(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
+extern "C" SEXP _arrow_fs__S3FileSystem__allow_bucket_creation(SEXP fs_sexp, SEXP allow_sexp){
+	Rf_error("Cannot call fs__S3FileSystem__allow_bucket_creation(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
+}
+#endif
+
+// filesystem.cpp
+#if defined(ARROW_R_WITH_S3)
+void fs__S3FileSystem__allow_bucket_deletion(const std::shared_ptr<fs::S3FileSystem>& fs, bool allow);
+extern "C" SEXP _arrow_fs__S3FileSystem__allow_bucket_deletion(SEXP fs_sexp, SEXP allow_sexp){
+BEGIN_CPP11
+	arrow::r::Input<const std::shared_ptr<fs::S3FileSystem>&>::type fs(fs_sexp);
+	arrow::r::Input<bool>::type allow(allow_sexp);
+	fs__S3FileSystem__allow_bucket_deletion(fs, allow);
+	return R_NilValue;
+END_CPP11
+}
+#else
+extern "C" SEXP _arrow_fs__S3FileSystem__allow_bucket_deletion(SEXP fs_sexp, SEXP allow_sexp){
+	Rf_error("Cannot call fs__S3FileSystem__allow_bucket_deletion(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
 }
 #endif
 
@@ -5450,9 +5468,10 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_fs___SubTreeFileSystem__base_path", (DL_FUNC) &_arrow_fs___SubTreeFileSystem__base_path, 1}, 
 		{ "_arrow_fs___FileSystemFromUri", (DL_FUNC) &_arrow_fs___FileSystemFromUri, 1}, 
 		{ "_arrow_fs___CopyFiles", (DL_FUNC) &_arrow_fs___CopyFiles, 6}, 
-		{ "_arrow_fs___S3FileSystem__create", (DL_FUNC) &_arrow_fs___S3FileSystem__create, 14}, 
+		{ "_arrow_fs___S3FileSystem__create", (DL_FUNC) &_arrow_fs___S3FileSystem__create, 15}, 
 		{ "_arrow_fs___S3FileSystem__region", (DL_FUNC) &_arrow_fs___S3FileSystem__region, 1}, 
-		{ "_arrow_fs__S3FileSystem__allow_create_buckets", (DL_FUNC) &_arrow_fs__S3FileSystem__allow_create_buckets, 2}, 
+		{ "_arrow_fs__S3FileSystem__allow_bucket_creation", (DL_FUNC) &_arrow_fs__S3FileSystem__allow_bucket_creation, 2}, 
+		{ "_arrow_fs__S3FileSystem__allow_bucket_deletion", (DL_FUNC) &_arrow_fs__S3FileSystem__allow_bucket_deletion, 2}, 
 		{ "_arrow_io___Readable__Read", (DL_FUNC) &_arrow_io___Readable__Read, 2}, 
 		{ "_arrow_io___InputStream__Close", (DL_FUNC) &_arrow_io___InputStream__Close, 1}, 
 		{ "_arrow_io___OutputStream__Close", (DL_FUNC) &_arrow_io___OutputStream__Close, 1}, 

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -3221,6 +3221,23 @@ extern "C" SEXP _arrow_fs___S3FileSystem__region(SEXP fs_sexp){
 }
 #endif
 
+// filesystem.cpp
+#if defined(ARROW_R_WITH_S3)
+void fs__S3FileSystem__allow_create_buckets(const std::shared_ptr<fs::S3FileSystem>& fs, bool allow);
+extern "C" SEXP _arrow_fs__S3FileSystem__allow_create_buckets(SEXP fs_sexp, SEXP allow_sexp){
+BEGIN_CPP11
+	arrow::r::Input<const std::shared_ptr<fs::S3FileSystem>&>::type fs(fs_sexp);
+	arrow::r::Input<bool>::type allow(allow_sexp);
+	fs__S3FileSystem__allow_create_buckets(fs, allow);
+	return R_NilValue;
+END_CPP11
+}
+#else
+extern "C" SEXP _arrow_fs__S3FileSystem__allow_create_buckets(SEXP fs_sexp, SEXP allow_sexp){
+	Rf_error("Cannot call fs__S3FileSystem__allow_create_buckets(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
+}
+#endif
+
 // io.cpp
 std::shared_ptr<arrow::Buffer> io___Readable__Read(const std::shared_ptr<arrow::io::Readable>& x, int64_t nbytes);
 extern "C" SEXP _arrow_io___Readable__Read(SEXP x_sexp, SEXP nbytes_sexp){
@@ -5435,6 +5452,7 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_fs___CopyFiles", (DL_FUNC) &_arrow_fs___CopyFiles, 6}, 
 		{ "_arrow_fs___S3FileSystem__create", (DL_FUNC) &_arrow_fs___S3FileSystem__create, 14}, 
 		{ "_arrow_fs___S3FileSystem__region", (DL_FUNC) &_arrow_fs___S3FileSystem__region, 1}, 
+		{ "_arrow_fs__S3FileSystem__allow_create_buckets", (DL_FUNC) &_arrow_fs__S3FileSystem__allow_create_buckets, 2}, 
 		{ "_arrow_io___Readable__Read", (DL_FUNC) &_arrow_io___Readable__Read, 2}, 
 		{ "_arrow_io___InputStream__Close", (DL_FUNC) &_arrow_io___InputStream__Close, 1}, 
 		{ "_arrow_io___OutputStream__Close", (DL_FUNC) &_arrow_io___OutputStream__Close, 1}, 

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -3222,40 +3222,6 @@ extern "C" SEXP _arrow_fs___S3FileSystem__region(SEXP fs_sexp){
 }
 #endif
 
-// filesystem.cpp
-#if defined(ARROW_R_WITH_S3)
-void fs__S3FileSystem__allow_bucket_creation(const std::shared_ptr<fs::S3FileSystem>& fs, bool allow);
-extern "C" SEXP _arrow_fs__S3FileSystem__allow_bucket_creation(SEXP fs_sexp, SEXP allow_sexp){
-BEGIN_CPP11
-	arrow::r::Input<const std::shared_ptr<fs::S3FileSystem>&>::type fs(fs_sexp);
-	arrow::r::Input<bool>::type allow(allow_sexp);
-	fs__S3FileSystem__allow_bucket_creation(fs, allow);
-	return R_NilValue;
-END_CPP11
-}
-#else
-extern "C" SEXP _arrow_fs__S3FileSystem__allow_bucket_creation(SEXP fs_sexp, SEXP allow_sexp){
-	Rf_error("Cannot call fs__S3FileSystem__allow_bucket_creation(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
-}
-#endif
-
-// filesystem.cpp
-#if defined(ARROW_R_WITH_S3)
-void fs__S3FileSystem__allow_bucket_deletion(const std::shared_ptr<fs::S3FileSystem>& fs, bool allow);
-extern "C" SEXP _arrow_fs__S3FileSystem__allow_bucket_deletion(SEXP fs_sexp, SEXP allow_sexp){
-BEGIN_CPP11
-	arrow::r::Input<const std::shared_ptr<fs::S3FileSystem>&>::type fs(fs_sexp);
-	arrow::r::Input<bool>::type allow(allow_sexp);
-	fs__S3FileSystem__allow_bucket_deletion(fs, allow);
-	return R_NilValue;
-END_CPP11
-}
-#else
-extern "C" SEXP _arrow_fs__S3FileSystem__allow_bucket_deletion(SEXP fs_sexp, SEXP allow_sexp){
-	Rf_error("Cannot call fs__S3FileSystem__allow_bucket_deletion(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
-}
-#endif
-
 // io.cpp
 std::shared_ptr<arrow::Buffer> io___Readable__Read(const std::shared_ptr<arrow::io::Readable>& x, int64_t nbytes);
 extern "C" SEXP _arrow_io___Readable__Read(SEXP x_sexp, SEXP nbytes_sexp){
@@ -5470,8 +5436,6 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_fs___CopyFiles", (DL_FUNC) &_arrow_fs___CopyFiles, 6}, 
 		{ "_arrow_fs___S3FileSystem__create", (DL_FUNC) &_arrow_fs___S3FileSystem__create, 15}, 
 		{ "_arrow_fs___S3FileSystem__region", (DL_FUNC) &_arrow_fs___S3FileSystem__region, 1}, 
-		{ "_arrow_fs__S3FileSystem__allow_bucket_creation", (DL_FUNC) &_arrow_fs__S3FileSystem__allow_bucket_creation, 2}, 
-		{ "_arrow_fs__S3FileSystem__allow_bucket_deletion", (DL_FUNC) &_arrow_fs__S3FileSystem__allow_bucket_deletion, 2}, 
 		{ "_arrow_io___Readable__Read", (DL_FUNC) &_arrow_io___Readable__Read, 2}, 
 		{ "_arrow_io___InputStream__Close", (DL_FUNC) &_arrow_io___InputStream__Close, 1}, 
 		{ "_arrow_io___OutputStream__Close", (DL_FUNC) &_arrow_io___OutputStream__Close, 1}, 

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -3180,8 +3180,8 @@ END_CPP11
 }
 // filesystem.cpp
 #if defined(ARROW_R_WITH_S3)
-std::shared_ptr<fs::S3FileSystem> fs___S3FileSystem__create(bool anonymous, std::string access_key, std::string secret_key, std::string session_token, std::string role_arn, std::string session_name, std::string external_id, int load_frequency, std::string region, std::string endpoint_override, std::string scheme, std::string proxy_options, bool background_writes);
-extern "C" SEXP _arrow_fs___S3FileSystem__create(SEXP anonymous_sexp, SEXP access_key_sexp, SEXP secret_key_sexp, SEXP session_token_sexp, SEXP role_arn_sexp, SEXP session_name_sexp, SEXP external_id_sexp, SEXP load_frequency_sexp, SEXP region_sexp, SEXP endpoint_override_sexp, SEXP scheme_sexp, SEXP proxy_options_sexp, SEXP background_writes_sexp){
+std::shared_ptr<fs::S3FileSystem> fs___S3FileSystem__create(bool anonymous, std::string access_key, std::string secret_key, std::string session_token, std::string role_arn, std::string session_name, std::string external_id, int load_frequency, std::string region, std::string endpoint_override, std::string scheme, std::string proxy_options, bool background_writes, bool allow_create_buckets);
+extern "C" SEXP _arrow_fs___S3FileSystem__create(SEXP anonymous_sexp, SEXP access_key_sexp, SEXP secret_key_sexp, SEXP session_token_sexp, SEXP role_arn_sexp, SEXP session_name_sexp, SEXP external_id_sexp, SEXP load_frequency_sexp, SEXP region_sexp, SEXP endpoint_override_sexp, SEXP scheme_sexp, SEXP proxy_options_sexp, SEXP background_writes_sexp, SEXP allow_create_buckets_sexp){
 BEGIN_CPP11
 	arrow::r::Input<bool>::type anonymous(anonymous_sexp);
 	arrow::r::Input<std::string>::type access_key(access_key_sexp);
@@ -3196,11 +3196,12 @@ BEGIN_CPP11
 	arrow::r::Input<std::string>::type scheme(scheme_sexp);
 	arrow::r::Input<std::string>::type proxy_options(proxy_options_sexp);
 	arrow::r::Input<bool>::type background_writes(background_writes_sexp);
-	return cpp11::as_sexp(fs___S3FileSystem__create(anonymous, access_key, secret_key, session_token, role_arn, session_name, external_id, load_frequency, region, endpoint_override, scheme, proxy_options, background_writes));
+	arrow::r::Input<bool>::type allow_create_buckets(allow_create_buckets_sexp);
+	return cpp11::as_sexp(fs___S3FileSystem__create(anonymous, access_key, secret_key, session_token, role_arn, session_name, external_id, load_frequency, region, endpoint_override, scheme, proxy_options, background_writes, allow_create_buckets));
 END_CPP11
 }
 #else
-extern "C" SEXP _arrow_fs___S3FileSystem__create(SEXP anonymous_sexp, SEXP access_key_sexp, SEXP secret_key_sexp, SEXP session_token_sexp, SEXP role_arn_sexp, SEXP session_name_sexp, SEXP external_id_sexp, SEXP load_frequency_sexp, SEXP region_sexp, SEXP endpoint_override_sexp, SEXP scheme_sexp, SEXP proxy_options_sexp, SEXP background_writes_sexp){
+extern "C" SEXP _arrow_fs___S3FileSystem__create(SEXP anonymous_sexp, SEXP access_key_sexp, SEXP secret_key_sexp, SEXP session_token_sexp, SEXP role_arn_sexp, SEXP session_name_sexp, SEXP external_id_sexp, SEXP load_frequency_sexp, SEXP region_sexp, SEXP endpoint_override_sexp, SEXP scheme_sexp, SEXP proxy_options_sexp, SEXP background_writes_sexp, SEXP allow_create_buckets_sexp){
 	Rf_error("Cannot call fs___S3FileSystem__create(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
 }
 #endif
@@ -5432,7 +5433,7 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_fs___SubTreeFileSystem__base_path", (DL_FUNC) &_arrow_fs___SubTreeFileSystem__base_path, 1}, 
 		{ "_arrow_fs___FileSystemFromUri", (DL_FUNC) &_arrow_fs___FileSystemFromUri, 1}, 
 		{ "_arrow_fs___CopyFiles", (DL_FUNC) &_arrow_fs___CopyFiles, 6}, 
-		{ "_arrow_fs___S3FileSystem__create", (DL_FUNC) &_arrow_fs___S3FileSystem__create, 13}, 
+		{ "_arrow_fs___S3FileSystem__create", (DL_FUNC) &_arrow_fs___S3FileSystem__create, 14}, 
 		{ "_arrow_fs___S3FileSystem__region", (DL_FUNC) &_arrow_fs___S3FileSystem__region, 1}, 
 		{ "_arrow_io___Readable__Read", (DL_FUNC) &_arrow_io___Readable__Read, 2}, 
 		{ "_arrow_io___InputStream__Close", (DL_FUNC) &_arrow_io___InputStream__Close, 1}, 

--- a/r/src/filesystem.cpp
+++ b/r/src/filesystem.cpp
@@ -282,7 +282,8 @@ std::shared_ptr<fs::S3FileSystem> fs___S3FileSystem__create(
     std::string session_token = "", std::string role_arn = "",
     std::string session_name = "", std::string external_id = "", int load_frequency = 900,
     std::string region = "", std::string endpoint_override = "", std::string scheme = "",
-    std::string proxy_options = "", bool background_writes = true) {
+    std::string proxy_options = "", bool background_writes = true,
+    bool allow_create_buckets = false) {
   // We need to ensure that S3 is initialized before we start messing with the
   // options
   StopIfNotOk(fs::EnsureS3Initialized());
@@ -320,6 +321,8 @@ std::shared_ptr<fs::S3FileSystem> fs___S3FileSystem__create(
   /// Whether OutputStream writes will be issued in the background, without blocking
   /// default true
   s3_opts.background_writes = background_writes;
+
+  s3_opts.allow_create_buckets = allow_create_buckets;
 
   auto io_context = arrow::io::IOContext(gc_memory_pool());
   return ValueOrStop(fs::S3FileSystem::Make(s3_opts, io_context));

--- a/r/src/filesystem.cpp
+++ b/r/src/filesystem.cpp
@@ -333,4 +333,9 @@ std::string fs___S3FileSystem__region(const std::shared_ptr<fs::S3FileSystem>& f
   return fs->region();
 }
 
+// [[s3::export]]
+void fs__S3FileSystem__allow_create_buckets(const std::shared_ptr<fs::S3FileSystem>& fs, bool allow) {
+  fs->allow_create_buckets(allow);
+}
+
 #endif

--- a/r/src/filesystem.cpp
+++ b/r/src/filesystem.cpp
@@ -283,7 +283,7 @@ std::shared_ptr<fs::S3FileSystem> fs___S3FileSystem__create(
     std::string session_name = "", std::string external_id = "", int load_frequency = 900,
     std::string region = "", std::string endpoint_override = "", std::string scheme = "",
     std::string proxy_options = "", bool background_writes = true,
-    bool allow_create_buckets = false) {
+    bool allow_bucket_creation = false, bool allow_bucket_deletion = false) {
   // We need to ensure that S3 is initialized before we start messing with the
   // options
   StopIfNotOk(fs::EnsureS3Initialized());
@@ -322,7 +322,8 @@ std::shared_ptr<fs::S3FileSystem> fs___S3FileSystem__create(
   /// default true
   s3_opts.background_writes = background_writes;
 
-  s3_opts.allow_create_buckets = allow_create_buckets;
+  s3_opts.allow_bucket_creation = allow_bucket_creation;
+  s3_opts.allow_bucket_deletion = allow_bucket_deletion;
 
   auto io_context = arrow::io::IOContext(gc_memory_pool());
   return ValueOrStop(fs::S3FileSystem::Make(s3_opts, io_context));
@@ -334,9 +335,15 @@ std::string fs___S3FileSystem__region(const std::shared_ptr<fs::S3FileSystem>& f
 }
 
 // [[s3::export]]
-void fs__S3FileSystem__allow_create_buckets(const std::shared_ptr<fs::S3FileSystem>& fs,
-                                            bool allow) {
-  fs->allow_create_buckets(allow);
+void fs__S3FileSystem__allow_bucket_creation(const std::shared_ptr<fs::S3FileSystem>& fs,
+                                             bool allow) {
+  fs->allow_bucket_creation(allow);
+}
+
+// [[s3::export]]
+void fs__S3FileSystem__allow_bucket_deletion(const std::shared_ptr<fs::S3FileSystem>& fs,
+                                             bool allow) {
+  fs->allow_bucket_deletion(allow);
 }
 
 #endif

--- a/r/src/filesystem.cpp
+++ b/r/src/filesystem.cpp
@@ -334,7 +334,8 @@ std::string fs___S3FileSystem__region(const std::shared_ptr<fs::S3FileSystem>& f
 }
 
 // [[s3::export]]
-void fs__S3FileSystem__allow_create_buckets(const std::shared_ptr<fs::S3FileSystem>& fs, bool allow) {
+void fs__S3FileSystem__allow_create_buckets(const std::shared_ptr<fs::S3FileSystem>& fs,
+                                            bool allow) {
   fs->allow_create_buckets(allow);
 }
 

--- a/r/src/filesystem.cpp
+++ b/r/src/filesystem.cpp
@@ -334,16 +334,4 @@ std::string fs___S3FileSystem__region(const std::shared_ptr<fs::S3FileSystem>& f
   return fs->region();
 }
 
-// [[s3::export]]
-void fs__S3FileSystem__allow_bucket_creation(const std::shared_ptr<fs::S3FileSystem>& fs,
-                                             bool allow) {
-  fs->allow_bucket_creation(allow);
-}
-
-// [[s3::export]]
-void fs__S3FileSystem__allow_bucket_deletion(const std::shared_ptr<fs::S3FileSystem>& fs,
-                                             bool allow) {
-  fs->allow_bucket_deletion(allow);
-}
-
 #endif

--- a/r/tests/testthat/test-s3-minio.R
+++ b/r/tests/testthat/test-s3-minio.R
@@ -38,6 +38,14 @@ if (arrow_with_s3() && process_is_running("minio server")) {
     allow_bucket_creation = TRUE,
     allow_bucket_deletion = TRUE
   )
+  limited_fs <- S3FileSystem$create(
+    access_key = minio_key,
+    secret_key = minio_secret,
+    scheme = "http",
+    endpoint_override = paste0("localhost:", minio_port),
+    allow_bucket_creation = FALSE,
+    allow_bucket_deletion = FALSE
+  )
   now <- as.character(as.numeric(Sys.time()))
   fs$CreateDir(now)
   # Clean up when we're all done
@@ -186,18 +194,14 @@ if (arrow_with_s3() && process_is_running("minio server")) {
       now_tmp <- paste0(now, "-test-fail-delete")
       fs$CreateDir(now_tmp)
 
-      fs$allow_bucket_creation(FALSE)
-      fs$allow_bucket_deletion(FALSE)
       expect_error(
-        fs$CreateDir("should-fail"),
+        limited_fs$CreateDir("should-fail"),
         regexp = "Bucket does not exist"
       )
       expect_error(
-        fs$DeleteDir(now_tmp),
+        limited_fs$DeleteDir(now_tmp),
         regexp = "Would delete bucket"
       )
-      fs$allow_bucket_creation(TRUE)
-      fs$allow_bucket_deletion(TRUE)
     })
 
     test_that("Let's test copy_files too", {

--- a/r/tests/testthat/test-s3-minio.R
+++ b/r/tests/testthat/test-s3-minio.R
@@ -181,6 +181,22 @@ if (arrow_with_s3() && process_is_running("minio server")) {
       expect_length(fs$ls(minio_path("new_dataset_dir")), 1)
     })
 
+    test_that("CreateDir fails on bucket if allow_create_buckets=False", {
+      now_tmp <- paste0(now, "-test-fail-delete")
+      fs$CreateDir(now_tmp)
+
+      fs$allow_create_buckets(FALSE)
+      expect_error(
+        fs$CreateDir("should-fail"),
+        regexp = "Bucket does not exist"
+      )
+      expect_error(
+        fs$DeleteDir(now_tmp),
+        regexp = "Would delete bucket"
+      )
+      fs$allow_create_buckets(TRUE)
+    })
+
     test_that("Let's test copy_files too", {
       td <- make_temp_dir()
       copy_files(minio_uri("hive_dir"), td)

--- a/r/tests/testthat/test-s3-minio.R
+++ b/r/tests/testthat/test-s3-minio.R
@@ -34,7 +34,8 @@ if (arrow_with_s3() && process_is_running("minio server")) {
     access_key = minio_key,
     secret_key = minio_secret,
     scheme = "http",
-    endpoint_override = paste0("localhost:", minio_port)
+    endpoint_override = paste0("localhost:", minio_port),
+    allow_create_buckets = TRUE
   )
   now <- as.character(as.numeric(Sys.time()))
   fs$CreateDir(now)

--- a/r/tests/testthat/test-s3-minio.R
+++ b/r/tests/testthat/test-s3-minio.R
@@ -194,14 +194,8 @@ if (arrow_with_s3() && process_is_running("minio server")) {
       now_tmp <- paste0(now, "-test-fail-delete")
       fs$CreateDir(now_tmp)
 
-      expect_error(
-        limited_fs$CreateDir("should-fail"),
-        regexp = "Bucket does not exist"
-      )
-      expect_error(
-        limited_fs$DeleteDir(now_tmp),
-        regexp = "Would delete bucket"
-      )
+      expect_error(limited_fs$CreateDir("should-fail"))
+      expect_error(limited_fs$DeleteDir(now_tmp))
     })
 
     test_that("Let's test copy_files too", {

--- a/r/tests/testthat/test-s3-minio.R
+++ b/r/tests/testthat/test-s3-minio.R
@@ -35,7 +35,8 @@ if (arrow_with_s3() && process_is_running("minio server")) {
     secret_key = minio_secret,
     scheme = "http",
     endpoint_override = paste0("localhost:", minio_port),
-    allow_create_buckets = TRUE
+    allow_bucket_creation = TRUE,
+    allow_bucket_deletion = TRUE
   )
   now <- as.character(as.numeric(Sys.time()))
   fs$CreateDir(now)
@@ -181,11 +182,12 @@ if (arrow_with_s3() && process_is_running("minio server")) {
       expect_length(fs$ls(minio_path("new_dataset_dir")), 1)
     })
 
-    test_that("CreateDir fails on bucket if allow_create_buckets=False", {
+    test_that("CreateDir fails on bucket if allow_bucket_creation=False", {
       now_tmp <- paste0(now, "-test-fail-delete")
       fs$CreateDir(now_tmp)
 
-      fs$allow_create_buckets(FALSE)
+      fs$allow_bucket_creation(FALSE)
+      fs$allow_bucket_deletion(FALSE)
       expect_error(
         fs$CreateDir("should-fail"),
         regexp = "Bucket does not exist"
@@ -194,7 +196,8 @@ if (arrow_with_s3() && process_is_running("minio server")) {
         fs$DeleteDir(now_tmp),
         regexp = "Would delete bucket"
       )
-      fs$allow_create_buckets(TRUE)
+      fs$allow_bucket_creation(TRUE)
+      fs$allow_bucket_deletion(TRUE)
     })
 
     test_that("Let's test copy_files too", {


### PR DESCRIPTION
BREAKING CHANGE: modifies `S3FileSystem` to not allow creating or deleting buckets by default. Two new options are added: `allow_bucket_creation`, which enables creating buckets, and `allow_bucket_deletion`, which enables deleting buckets.

Outside of tests, most use cases will not want to create or delete buckets, and doing so accidentally is not desirable either. Buckets have governance controls like permissions and cost-tracking tags.

To make it easy for users to transition, the `FromUri` method also supports these arguments:

```python
from pyarrow.fs import FileSystem

uri = "s3://minioadmin:minioadmin@?scheme=http&endpoint_override=localhost%3A9000"
fs, path = FileSystem.from_uri(uri)

fs.create_dir("test")
# Traceback (most recent call last):
#   File "<stdin>", line 1, in <module>
#   File "pyarrow/_fs.pyx", line 463, in pyarrow._fs.FileSystem.create_dir
#     check_status(self.fs.CreateDir(directory, recursive=recursive))
#   File "pyarrow/error.pxi", line 115, in pyarrow.lib.check_status
#     raise IOError(message)
# OSError: Bucket 'test' not found. To create buckets, enable the allow_bucket_creation option.
uri = uri + "&allow_bucket_creation=True&allow_bucket_deletion=True"
fs, path = FileSystem.from_uri(uri)

fs.create_dir("test")
fs.delete_dir("test")
```

```r
fs <- FileSystem$from_uri("s3://minioadmin:minioadmin@?scheme=http&endpoint_override=localhost%3A9000")$fs
fs$CreateDir("test")
#> Error: IOError: Bucket 'test' not found. To create buckets, enable the allow_bucket_creation option.

fs <- FileSystem$from_uri(
    paste0("s3://minioadmin:minioadmin@?scheme=http&endpoint_override=localhost%3A9000",
           "&allow_bucket_creation=TRUE&allow_bucket_deletion=TRUE")
    )$fs
fs$CreateDir("test")
fs$DeleteDir("test")
```