### PR TITLE
ARROW-16607: [R] Improve KeyValueMetadata handling

### DIFF
--- a/r/R/arrow-tabular.R
+++ b/r/R/arrow-tabular.R
@@ -70,7 +70,6 @@ ArrowTabular <- R6Class("ArrowTabular",
         self$schema$metadata
       } else {
         # Set the metadata
-        new <- prepare_key_value_metadata(new)
         out <- self$ReplaceSchemaMetadata(new)
         # ReplaceSchemaMetadata returns a new object but we're modifying in place,
         # so swap in that new C++ object pointer into our R6 object
@@ -82,16 +81,10 @@ ArrowTabular <- R6Class("ArrowTabular",
       # Helper for the R metadata that handles the serialization
       # See also method on Schema
       if (missing(new)) {
-        out <- self$metadata$r
-        if (!is.null(out)) {
-          # Can't unserialize NULL
-          out <- .unserialize_arrow_r_metadata(out)
-        }
-        # Returns either NULL or a named list
-        out
+        self$metadata$r
       } else {
         # Set the R metadata
-        self$metadata$r <- .serialize_arrow_r_metadata(new)
+        self$metadata$r <- new
         self
       }
     }
@@ -101,11 +94,7 @@ ArrowTabular <- R6Class("ArrowTabular",
 #' @export
 as.data.frame.ArrowTabular <- function(x, row.names = NULL, optional = FALSE, ...) {
   df <- x$to_data_frame()
-
-  if (!is.null(r_metadata <- x$metadata$r)) {
-    df <- apply_arrow_r_metadata(df, .unserialize_arrow_r_metadata(r_metadata))
-  }
-  df
+  apply_arrow_r_metadata(df, x$metadata$r)
 }
 
 #' @export

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -404,8 +404,8 @@ ExecPlan_create <- function(use_threads) {
   .Call(`_arrow_ExecPlan_create`, use_threads)
 }
 
-ExecPlan_run <- function(plan, final_node, sort_options, head) {
-  .Call(`_arrow_ExecPlan_run`, plan, final_node, sort_options, head)
+ExecPlan_run <- function(plan, final_node, sort_options, metadata, head) {
+  .Call(`_arrow_ExecPlan_run`, plan, final_node, sort_options, metadata, head)
 }
 
 ExecPlan_StopProducing <- function(plan) {

--- a/r/R/dataset-scan.R
+++ b/r/R/dataset-scan.R
@@ -206,10 +206,8 @@ map_batches <- function(X, FUN, ..., .data.frame = NULL) {
       call. = FALSE
     )
   }
-  plan <- ExecPlan$create()
-  final_node <- plan$Build(as_adq(X))
-  reader <- plan$Run(final_node)
   FUN <- as_mapper(FUN)
+  reader <- as_record_batch_reader(X)
 
   # TODO: for future consideration
   # * Move eval to C++ and make it a generator so it can stream, not block

--- a/r/R/dataset-write.R
+++ b/r/R/dataset-write.R
@@ -162,7 +162,7 @@ write_dataset <- function(dataset,
 
   plan <- ExecPlan$create()
   final_node <- plan$Build(dataset)
-  if (!is.null(final_node$sort %||% final_node$head %||% final_node$tail)) {
+  if (!is.null(final_node$extras$sort %||% final_node$extras$head %||% final_node$extras$tail)) {
     # Because sorting and topK are only handled in the SinkNode (or in R!),
     # they wouldn't get picked up in the WriteNode. So let's Run this ExecPlan
     # to capture those, and then create a new plan for writing
@@ -206,14 +206,16 @@ write_dataset <- function(dataset,
   validate_positive_int_value(min_rows_per_group)
   validate_positive_int_value(max_rows_per_group)
 
-  source_schema <- source_data(dataset)$schema
+  # Collect metadata and trim R metadata based on columns in result
+  # (Move this into plan$Write?)
+  source_schema <- final_node$extras$source_schema
   # For backwards compatibility with Scanner-based writer (arrow <= 7.0.0):
   # retain metadata from source dataset
   output_schema$metadata <- source_schema$metadata
   new_r_meta <- get_r_metadata_from_old_schema(
     output_schema,
     source_schema,
-    drop_attributes = has_aggregation(dataset)
+    drop_attributes = isTRUE(final_node$extras$has_aggregation)
   )
   if (!is.null(new_r_meta)) {
     output_schema$r_metadata <- new_r_meta

--- a/r/R/dataset-write.R
+++ b/r/R/dataset-write.R
@@ -211,17 +211,11 @@ write_dataset <- function(dataset,
   source_schema <- final_node$extras$source_schema
   # For backwards compatibility with Scanner-based writer (arrow <= 7.0.0):
   # retain metadata from source dataset
-  output_schema$metadata <- source_schema$metadata
-  new_r_meta <- get_r_metadata_from_old_schema(
-    output_schema,
-    source_schema,
-    drop_attributes = isTRUE(final_node$extras$has_aggregation)
-  )
-  if (!is.null(new_r_meta)) {
-    output_schema$r_metadata <- new_r_meta
-  }
+  out_metadata <- source_schema$metadata
+  out_metadata$r <- get_r_metadata_from_old_schema(output_schema, source_schema)
+
   plan$Write(
-    final_node, prepare_key_value_metadata(output_schema$metadata),
+    final_node, prepare_key_value_metadata(out_metadata),
     options, path_and_fs$fs, path_and_fs$path,
     partitioning, basename_template,
     existing_data_behavior, max_partitions,

--- a/r/R/dataset-write.R
+++ b/r/R/dataset-write.R
@@ -206,16 +206,8 @@ write_dataset <- function(dataset,
   validate_positive_int_value(min_rows_per_group)
   validate_positive_int_value(max_rows_per_group)
 
-  # Collect metadata and trim R metadata based on columns in result
-  # (Move this into plan$Write?)
-  source_schema <- final_node$extras$source_schema
-  # For backwards compatibility with Scanner-based writer (arrow <= 7.0.0):
-  # retain metadata from source dataset
-  out_metadata <- source_schema$metadata
-  out_metadata$r <- get_r_metadata_from_old_schema(output_schema, source_schema)
-
   plan$Write(
-    final_node, prepare_key_value_metadata(out_metadata),
+    final_node,
     options, path_and_fs$fs, path_and_fs$path,
     partitioning, basename_template,
     existing_data_behavior, max_partitions,

--- a/r/R/dplyr-collect.R
+++ b/r/R/dplyr-collect.R
@@ -30,7 +30,7 @@ collect.arrow_dplyr_query <- function(x, as_data_frame = TRUE, ...) {
   plan <- ExecPlan$create()
   final_node <- plan$Build(x)
   tryCatch(
-    tab <- plan$Run(final_node)$read_table(),
+    out <- plan$Run(final_node)$read_table(),
     # n = 4 because we want the error to show up as being from collect()
     # and not handle_csv_read_error()
     error = function(e, call = caller_env(n = 4)) {
@@ -38,25 +38,10 @@ collect.arrow_dplyr_query <- function(x, as_data_frame = TRUE, ...) {
     }
   )
 
-  # TODO(ARROW-16607): move KVM handling into ExecPlan
-  if (ncol(tab)) {
-    # Apply any column metadata from the original schema, where appropriate
-    new_r_metadata <- get_r_metadata_from_old_schema(
-      tab$schema,
-      source_data(x)$schema,
-      drop_attributes = has_aggregation(x)
-    )
-    if (!is.null(new_r_metadata)) {
-      tab$r_metadata <- new_r_metadata
-    }
-  }
-
   if (as_data_frame) {
-    df <- as.data.frame(tab)
-    restore_dplyr_features(df, x)
-  } else {
-    restore_dplyr_features(tab, x)
+    out <- as.data.frame(out)
   }
+  restore_dplyr_features(out, x)
 }
 collect.ArrowTabular <- function(x, as_data_frame = TRUE, ...) {
   if (as_data_frame) {

--- a/r/R/dplyr-group-by.R
+++ b/r/R/dplyr-group-by.R
@@ -64,7 +64,7 @@ group_vars.arrow_dplyr_query <- function(x) x$group_by_vars
 group_vars.Dataset <- function(x) NULL
 group_vars.RecordBatchReader <- function(x) NULL
 group_vars.ArrowTabular <- function(x) {
-  x$r_metadata$attributes$.group_vars
+  x$metadata$r$attributes$.group_vars
 }
 
 # the logical literal in the two functions below controls the default value of
@@ -81,6 +81,6 @@ ungroup.arrow_dplyr_query <- function(x, ...) {
 }
 ungroup.Dataset <- ungroup.RecordBatchReader <- force
 ungroup.ArrowTabular <- function(x) {
-  x$r_metadata$attributes$.group_vars <- NULL
+  x$metadata$r$attributes$.group_vars <- NULL
   x
 }

--- a/r/R/dplyr.R
+++ b/r/R/dplyr.R
@@ -176,13 +176,13 @@ as.data.frame.arrow_dplyr_query <- function(x, row.names = NULL, optional = FALS
 
 #' @export
 head.arrow_dplyr_query <- function(x, n = 6L, ...) {
-  x$head <- n
+  x$extras$head <- n
   collapse.arrow_dplyr_query(x)
 }
 
 #' @export
 tail.arrow_dplyr_query <- function(x, n = 6L, ...) {
-  x$tail <- n
+  x$extras$tail <- n
   collapse.arrow_dplyr_query(x)
 }
 
@@ -269,5 +269,5 @@ has_aggregation <- function(x) {
 }
 
 has_head_tail <- function(x) {
-  !is.null(x$head) || !is.null(x$tail) || (is_collapsed(x) && has_head_tail(x$.data))
+  !is.null(x$extras$head) || !is.null(x$extras$tail) || (is_collapsed(x) && has_head_tail(x$.data))
 }

--- a/r/R/dplyr.R
+++ b/r/R/dplyr.R
@@ -176,13 +176,13 @@ as.data.frame.arrow_dplyr_query <- function(x, row.names = NULL, optional = FALS
 
 #' @export
 head.arrow_dplyr_query <- function(x, n = 6L, ...) {
-  x$extras$head <- n
+  x$head <- n
   collapse.arrow_dplyr_query(x)
 }
 
 #' @export
 tail.arrow_dplyr_query <- function(x, n = 6L, ...) {
-  x$extras$tail <- n
+  x$tail <- n
   collapse.arrow_dplyr_query(x)
 }
 
@@ -269,5 +269,5 @@ has_aggregation <- function(x) {
 }
 
 has_head_tail <- function(x) {
-  !is.null(x$extras$head) || !is.null(x$extras$tail) || (is_collapsed(x) && has_head_tail(x$.data))
+  !is.null(x$head) || !is.null(x$tail) || (is_collapsed(x) && has_head_tail(x$.data))
 }

--- a/r/R/metadata.R
+++ b/r/R/metadata.R
@@ -35,7 +35,7 @@
   rawToChar(out)
 }
 
-.unserialize_arrow_r_metadata <- function(x) {
+.deserialize_arrow_r_metadata <- function(x) {
   tryCatch(
     expr = {
       out <- unserialize(charToRaw(x))
@@ -55,6 +55,9 @@
 
 #' @importFrom rlang trace_back
 apply_arrow_r_metadata <- function(x, r_metadata) {
+  if (is.null(r_metadata)) {
+    return(x)
+  }
   tryCatch(
     expr = {
       columns_metadata <- r_metadata$columns
@@ -196,12 +199,10 @@ arrow_attributes <- function(x, only_top_level = FALSE) {
   }
 }
 
-get_r_metadata_from_old_schema <- function(new_schema,
-                                           old_schema,
-                                           drop_attributes = FALSE) {
+get_r_metadata_from_old_schema <- function(new_schema, old_schema) {
   # TODO: do we care about other (non-R) metadata preservation?
   # How would we know if it were meaningful?
-  r_meta <- old_schema$r_metadata
+  r_meta <- old_schema$metadata$r
   if (!is.null(r_meta)) {
     # Filter r_metadata$columns on columns with name _and_ type match
     common_names <- intersect(names(r_meta$columns), names(new_schema))
@@ -209,10 +210,6 @@ get_r_metadata_from_old_schema <- function(new_schema,
       map_lgl(common_names, ~ old_schema[[.]] == new_schema[[.]])
     ]
     r_meta$columns <- r_meta$columns[keep]
-    if (drop_attributes) {
-      # dplyr drops top-level attributes if you do summarize
-      r_meta$attributes <- NULL
-    }
   }
   r_meta
 }

--- a/r/R/query-engine.R
+++ b/r/R/query-engine.R
@@ -185,7 +185,8 @@ ExecPlan <- R6Class("ExecPlan",
         sorting$orders <- as.integer(sorting$orders)
       }
 
-      out <- ExecPlan_run(self, node, sorting, select_k)
+      # TODO(this PR): send output metadata in here
+      out <- ExecPlan_run(self, node, sorting, "", select_k)
 
       if (!has_sorting) {
         # Since ExecPlans don't scan in deterministic order, head/tail are both

--- a/r/R/query-engine.R
+++ b/r/R/query-engine.R
@@ -163,7 +163,7 @@ ExecPlan <- R6Class("ExecPlan",
         }
 
         if (!is.null(.data$union_all)) {
-          node <- node$UnionAll(self$Build(.data$union_all$right_data))
+          node <- node$Union(self$Build(.data$union_all$right_data))
         }
       }
 
@@ -327,8 +327,8 @@ ExecNode <- R6Class("ExecNode",
         )
       )
     },
-    UnionAll = function(right_node) {
-      self$preserve_sort(ExecNode_Union(self, right_node))
+    Union = function(right_node) {
+      self$preserve_extras(ExecNode_Union(self, right_node))
     }
   ),
   active = list(

--- a/r/R/record-batch-reader.R
+++ b/r/R/record-batch-reader.R
@@ -237,8 +237,10 @@ as_record_batch_reader.Dataset <- function(x, ...) {
 #' @rdname as_record_batch_reader
 #' @export
 as_record_batch_reader.arrow_dplyr_query <- function(x, ...) {
-  # TODO(ARROW-16607): use ExecPlan directly when it handles metadata
-  as_record_batch_reader(compute.arrow_dplyr_query(x))
+  # See query-engine.R for ExecPlan/Nodes
+  plan <- ExecPlan$create()
+  final_node <- plan$Build(x)
+  plan$Run(final_node)
 }
 
 #' @rdname as_record_batch_reader

--- a/r/R/record-batch.R
+++ b/r/R/record-batch.R
@@ -102,7 +102,7 @@ RecordBatch <- R6Class("RecordBatch",
     },
     RemoveColumn = function(i) RecordBatch__RemoveColumn(self, i),
     ReplaceSchemaMetadata = function(new) {
-      RecordBatch__ReplaceSchemaMetadata(self, new)
+      RecordBatch__ReplaceSchemaMetadata(self, prepare_key_value_metadata(new))
     },
     Slice = function(offset, length = NULL) {
       if (is.null(length)) {

--- a/r/R/schema.R
+++ b/r/R/schema.R
@@ -139,9 +139,18 @@ Schema <- R6Class("Schema",
     num_fields = function() Schema__num_fields(self),
     fields = function() Schema__fields(self),
     HasMetadata = function() Schema__HasMetadata(self),
+    raw_metadata = function() {
+      # This is the named list of strings
+      Schema__metadata(self)
+    },
     metadata = function(new_metadata) {
       if (missing(new_metadata)) {
-        Schema__metadata(self)
+        out <- self$raw_metadata
+        if (!is.null(out[["r"]])) {
+          # Can't unserialize NULL
+          out[["r"]] <- .deserialize_arrow_r_metadata(out[["r"]])
+        }
+        out
       } else {
         # Set the metadata
         out <- self$WithMetadata(new_metadata)
@@ -155,16 +164,10 @@ Schema <- R6Class("Schema",
       # Helper for the R metadata that handles the serialization
       # See also method on ArrowTabular
       if (missing(new)) {
-        out <- self$metadata$r
-        if (!is.null(out)) {
-          # Can't unserialize NULL
-          out <- .unserialize_arrow_r_metadata(out)
-        }
-        # Returns either NULL or a named list
-        out
+        self$metadata$r
       } else {
         # Set the R metadata
-        self$metadata$r <- .serialize_arrow_r_metadata(new)
+        self$metadata$r <- new
         self
       }
     }
@@ -199,6 +202,9 @@ prepare_key_value_metadata <- function(metadata) {
       "Key-value metadata must be a named list or character vector",
       call. = FALSE
     )
+  }
+  if (is.list(metadata[["r"]])) {
+    metadata[["r"]] <- .serialize_arrow_r_metadata(metadata[["r"]])
   }
   map_chr(metadata, as.character)
 }
@@ -347,7 +353,7 @@ unify_schemas <- function(..., schemas = list(...)) {
 #' @export
 print.arrow_r_metadata <- function(x, ...) {
   utils::str(x)
-  utils::str(.unserialize_arrow_r_metadata(x))
+  utils::str(.deserialize_arrow_r_metadata(x))
   invisible(x)
 }
 

--- a/r/R/table.R
+++ b/r/R/table.R
@@ -93,7 +93,7 @@ Table <- R6Class("Table",
     AddColumn = function(i, new_field, value) Table__AddColumn(self, i, new_field, value),
     SetColumn = function(i, new_field, value) Table__SetColumn(self, i, new_field, value),
     ReplaceSchemaMetadata = function(new) {
-      Table__ReplaceSchemaMetadata(self, new)
+      Table__ReplaceSchemaMetadata(self, prepare_key_value_metadata(new))
     },
     field = function(i) Table__field(self, i),
     serialize = function(output_stream, ...) write_table(self, output_stream, ...),

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -869,14 +869,15 @@ BEGIN_CPP11
 END_CPP11
 }
 // compute-exec.cpp
-std::shared_ptr<arrow::RecordBatchReader> ExecPlan_run(const std::shared_ptr<compute::ExecPlan>& plan, const std::shared_ptr<compute::ExecNode>& final_node, cpp11::list sort_options, int64_t head);
-extern "C" SEXP _arrow_ExecPlan_run(SEXP plan_sexp, SEXP final_node_sexp, SEXP sort_options_sexp, SEXP head_sexp){
+std::shared_ptr<arrow::RecordBatchReader> ExecPlan_run(const std::shared_ptr<compute::ExecPlan>& plan, const std::shared_ptr<compute::ExecNode>& final_node, cpp11::list sort_options, cpp11::strings metadata, int64_t head);
+extern "C" SEXP _arrow_ExecPlan_run(SEXP plan_sexp, SEXP final_node_sexp, SEXP sort_options_sexp, SEXP metadata_sexp, SEXP head_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<compute::ExecPlan>&>::type plan(plan_sexp);
 	arrow::r::Input<const std::shared_ptr<compute::ExecNode>&>::type final_node(final_node_sexp);
 	arrow::r::Input<cpp11::list>::type sort_options(sort_options_sexp);
+	arrow::r::Input<cpp11::strings>::type metadata(metadata_sexp);
 	arrow::r::Input<int64_t>::type head(head_sexp);
-	return cpp11::as_sexp(ExecPlan_run(plan, final_node, sort_options, head));
+	return cpp11::as_sexp(ExecPlan_run(plan, final_node, sort_options, metadata, head));
 END_CPP11
 }
 // compute-exec.cpp
@@ -5212,7 +5213,7 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_io___CompressedOutputStream__Make", (DL_FUNC) &_arrow_io___CompressedOutputStream__Make, 2}, 
 		{ "_arrow_io___CompressedInputStream__Make", (DL_FUNC) &_arrow_io___CompressedInputStream__Make, 2}, 
 		{ "_arrow_ExecPlan_create", (DL_FUNC) &_arrow_ExecPlan_create, 1}, 
-		{ "_arrow_ExecPlan_run", (DL_FUNC) &_arrow_ExecPlan_run, 4}, 
+		{ "_arrow_ExecPlan_run", (DL_FUNC) &_arrow_ExecPlan_run, 5}, 
 		{ "_arrow_ExecPlan_StopProducing", (DL_FUNC) &_arrow_ExecPlan_StopProducing, 1}, 
 		{ "_arrow_ExecNode_output_schema", (DL_FUNC) &_arrow_ExecNode_output_schema, 1}, 
 		{ "_arrow_ExecNode_Scan", (DL_FUNC) &_arrow_ExecNode_Scan, 4}, 

--- a/r/src/compute-exec.cpp
+++ b/r/src/compute-exec.cpp
@@ -34,6 +34,8 @@ namespace compute = ::arrow::compute;
 std::shared_ptr<compute::FunctionOptions> make_compute_options(std::string func_name,
                                                                cpp11::list options);
 
+std::shared_ptr<arrow::KeyValueMetadata> strings_to_kvm(cpp11::strings metadata);
+
 // [[arrow::export]]
 std::shared_ptr<compute::ExecPlan> ExecPlan_create(bool use_threads) {
   static compute::ExecContext threaded_context{gc_memory_pool(),
@@ -57,7 +59,7 @@ std::shared_ptr<compute::ExecNode> MakeExecNodeOrStop(
 std::shared_ptr<arrow::RecordBatchReader> ExecPlan_run(
     const std::shared_ptr<compute::ExecPlan>& plan,
     const std::shared_ptr<compute::ExecNode>& final_node, cpp11::list sort_options,
-    int64_t head = -1, cpp11::strings metadata) {
+    cpp11::strings metadata, int64_t head = -1) {
   // For now, don't require R to construct SinkNodes.
   // Instead, just pass the node we should collect as an argument.
   arrow::AsyncGenerator<arrow::util::optional<compute::ExecBatch>> sink_gen;
@@ -102,15 +104,14 @@ std::shared_ptr<arrow::RecordBatchReader> ExecPlan_run(
                                        }};
 
   // Attach metadata to the schema
-  // TODO: factor this out to a strings_to_KVM() helper
-  auto values = cpp11::as_cpp<std::vector<std::string>>(metadata);
-  auto names = cpp11::as_cpp<std::vector<std::string>>(metadata.attr("names"));
-
-  auto kv =
-      std::make_shared<arrow::KeyValueMetadata>(std::move(names), std::move(values));
+  auto out_schema = final_node->output_schema();
+  if (metadata.size() > 0) {
+    auto kv = strings_to_kvm(metadata);
+    out_schema = out_schema->WithMetadata(kv);
+  }
   return compute::MakeGeneratorReader(
-      final_node->output_schema()->WithMetadata(std::move(kv)),
-      [stop_producing, plan, sink_gen] { return sink_gen(); }, gc_memory_pool());
+      out_schema, [stop_producing, plan, sink_gen] { return sink_gen(); },
+      gc_memory_pool());
 }
 
 // [[arrow::export]]
@@ -190,13 +191,7 @@ void ExecPlan_Write(
   opts.min_rows_per_group = min_rows_per_group;
   opts.max_rows_per_group = max_rows_per_group;
 
-  // TODO: factor this out to a strings_to_KVM() helper
-  auto values = cpp11::as_cpp<std::vector<std::string>>(metadata);
-  auto names = cpp11::as_cpp<std::vector<std::string>>(metadata.attr("names"));
-
-  auto kv =
-      std::make_shared<arrow::KeyValueMetadata>(std::move(names), std::move(values));
-
+  auto kv = strings_to_kvm(metadata);
   MakeExecNodeOrStop("write", final_node->plan(), {final_node.get()},
                      ds::WriteNodeOptions{std::move(opts), std::move(kv)});
 

--- a/r/src/schema.cpp
+++ b/r/src/schema.cpp
@@ -112,14 +112,17 @@ cpp11::writable::list Schema__metadata(const std::shared_ptr<arrow::Schema>& sch
   return out;
 }
 
-// [[arrow::export]]
-std::shared_ptr<arrow::Schema> Schema__WithMetadata(
-    const std::shared_ptr<arrow::Schema>& schema, cpp11::strings metadata) {
+std::shared_ptr<arrow::KeyValueMetadata> strings_to_kvm(cpp11::strings metadata) {
   auto values = cpp11::as_cpp<std::vector<std::string>>(metadata);
   auto names = cpp11::as_cpp<std::vector<std::string>>(metadata.attr("names"));
 
-  auto kv =
-      std::make_shared<arrow::KeyValueMetadata>(std::move(names), std::move(values));
+  return std::make_shared<arrow::KeyValueMetadata>(std::move(names), std::move(values));
+}
+
+// [[arrow::export]]
+std::shared_ptr<arrow::Schema> Schema__WithMetadata(
+    const std::shared_ptr<arrow::Schema>& schema, cpp11::strings metadata) {
+  auto kv = strings_to_kvm(metadata);
   return schema->WithMetadata(std::move(kv));
 }
 

--- a/r/tests/testthat/test-metadata.R
+++ b/r/tests/testthat/test-metadata.R
@@ -52,7 +52,11 @@ test_that("Table metadata", {
 
 test_that("Table R metadata", {
   tab <- Table$create(example_with_metadata)
-  expect_output(print(tab$metadata), "arrow_r_metadata")
+  expect_output(
+    print(tab$metadata),
+    "$r$columns$c$columns$c1$attributes$extra_attr",
+    fixed = TRUE
+  )
   expect_identical(as.data.frame(tab), example_with_metadata)
 })
 
@@ -96,6 +100,7 @@ test_that("Garbage R metadata doesn't break things", {
   )
   # serialize data like .serialize_arrow_r_metadata does, but don't call that
   # directly since it checks to ensure that the data is a list
+  tab <- Table$create(example_data[1:6])
   tab$metadata$r <- rawToChar(serialize("garbage", NULL, ascii = TRUE))
   expect_warning(
     expect_identical(as.data.frame(tab), example_data[1:6]),


### PR DESCRIPTION
* Pushes KVM handling into ExecPlan so that Run() preserves the R metadata we want.
* Also pushes special handling for a kind of collapsed query from collect() into Build(). 
* Better encapsulate KVM for the the $metadata and $r_metadata so that as a user/developer, you never have to touch the serialize/deserialize functions, you just have a list to work with. This is a slight API change, most noticeable if you were to `print(tab$metadata)`; better is to `print(str(tab$metdata))`.
* Factor out a common utility in r/src for taking cpp11::strings (named character vector) and producing arrow::KeyValueMetadata

The upshot of all of this is that we can push the ExecPlan evaluation into `as_record_batch_reader()`, and all that `collect()` does on top is read the RBR into a Table/data.frame. This means that we can plug dplyr queries into anything else that expects a RecordBatchReader, and it will be (to the maximum extent possible, given the limitations of ExecPlan) streaming, not requiring you to `compute()` and materialize things first.