### PR TITLE
MINOR: [Docs] Update phrasing of intro sentence in the new contributors guide

### DIFF
--- a/docs/source/developers/guide/index.rst
+++ b/docs/source/developers/guide/index.rst
@@ -30,7 +30,7 @@
 New Contributor's Guide
 ***********************
 
-This guide is meant to be a resource for contributing to
+This guide is a resource for contributing to
 Apache Arrow for new contributors.
 
 No matter what your current skills are, you can try and make


### PR DESCRIPTION
A tiny phrasing suggestion - I think this sounds stronger this way; it's not just **intended** to be a resource for new contributors, is **is** a resource for new contributors.

CC @AlenkaF - let me know what you think, happy to close this PR unmerged if the old phrasing is preferred!