### PR TITLE
ARROW-16638: [Go][Parquet] Fix boolean column skip

### DIFF
--- a/go/parquet/file/column_reader_types.gen.go
+++ b/go/parquet/file/column_reader_types.gen.go
@@ -207,10 +207,11 @@ type BooleanColumnChunkReader struct {
 func (cr *BooleanColumnChunkReader) Skip(nvalues int64) (int64, error) {
 	return cr.columnChunkReader.skipValues(nvalues,
 		func(batch int64, buf []byte) (int64, error) {
+			// buf is large enough to hold values, but not to hold def and rep lvls; use nil for them
 			vals, _, err := cr.ReadBatch(batch,
 				*(*[]bool)(unsafe.Pointer(&buf)),
-				arrow.Int16Traits.CastFromBytes(buf),
-				arrow.Int16Traits.CastFromBytes(buf))
+				nil,
+				nil)
 			return vals, err
 		})
 }

--- a/go/parquet/file/column_reader_types.gen.go
+++ b/go/parquet/file/column_reader_types.gen.go
@@ -207,7 +207,6 @@ type BooleanColumnChunkReader struct {
 func (cr *BooleanColumnChunkReader) Skip(nvalues int64) (int64, error) {
 	return cr.columnChunkReader.skipValues(nvalues,
 		func(batch int64, buf []byte) (int64, error) {
-			// buf is large enough to hold values, but not to hold def and rep lvls; use nil for them
 			vals, _, err := cr.ReadBatch(batch,
 				*(*[]bool)(unsafe.Pointer(&buf)),
 				nil,

--- a/go/parquet/file/column_reader_types.gen.go.tmpl
+++ b/go/parquet/file/column_reader_types.gen.go.tmpl
@@ -36,11 +36,13 @@ func (cr *{{.Name}}ColumnChunkReader) Skip(nvalues int64) (int64, error) {
       vals, _, err := cr.ReadBatch(batch,
         {{- if ne .Name "Boolean"}}
         {{.prefix}}.{{.Name}}Traits.CastFromBytes(buf),
-        {{- else}}
-        *(*[]bool)(unsafe.Pointer(&buf)),
-        {{- end}}
         arrow.Int16Traits.CastFromBytes(buf),
         arrow.Int16Traits.CastFromBytes(buf))
+        {{- else}}
+        *(*[]bool)(unsafe.Pointer(&buf)),
+        nil,
+        nil)
+        {{- end}}
       return vals, err
     })
 }


### PR DESCRIPTION
Uses `nil` for `defLvls` and `repLvls` when skipping boolean values, since the scratch buffer allocated for n boolean values when skipping is not large enough to hold n def and rep levels, resulting in an [out of bounds panic](https://github.com/apache/arrow/blob/4c21fd12f93e4853c03c05919ffb22c6bb8f09b0/go/parquet/file/column_reader.go#L407) when skipping too many rows.