### PR TITLE
MINOR: [C++] Move static declaration to non-static declaration to improve performance

### DIFF
--- a/cpp/src/arrow/compute/exec/expression.cc
+++ b/cpp/src/arrow/compute/exec/expression.cc
@@ -107,9 +107,10 @@ ValueDescr Expression::descr() const {
   return CallNotNull(*this)->descr;
 }
 
+const std::shared_ptr<DataType> kNoType;
+
 const std::shared_ptr<DataType>& Expression::type() const {
-  const std::shared_ptr<DataType> no_type;
-  if (impl_ == nullptr) return no_type;
+  if (impl_ == nullptr) return kNoType;
 
   if (auto lit = literal()) {
     return lit->type();

--- a/cpp/src/arrow/compute/exec/expression.cc
+++ b/cpp/src/arrow/compute/exec/expression.cc
@@ -107,7 +107,9 @@ ValueDescr Expression::descr() const {
   return CallNotNull(*this)->descr;
 }
 
-const std::shared_ptr<DataType> kNoType;
+// This is a module-global singleton to avoid synchronization costs of a
+// function-static singleton.
+static const std::shared_ptr<DataType> kNoType;
 
 const std::shared_ptr<DataType>& Expression::type() const {
   if (impl_ == nullptr) return kNoType;

--- a/cpp/src/arrow/compute/exec/expression.cc
+++ b/cpp/src/arrow/compute/exec/expression.cc
@@ -108,7 +108,7 @@ ValueDescr Expression::descr() const {
 }
 
 const std::shared_ptr<DataType>& Expression::type() const {
-  static const std::shared_ptr<DataType> no_type;
+  const std::shared_ptr<DataType> no_type;
   if (impl_ == nullptr) return no_type;
 
   if (auto lit = literal()) {


### PR DESCRIPTION
According to conbench there was a slight regression on #12957 .  Poking around a bit it seems that a static local variable is implemented using some kind of global lock (__cxa_guard_acquire / __cxa_guard_release).  On the other hand, constructing an empty shared_ptr is cheap (two pointers are set to 0).  So if we care about performance here we probably don't want `static`.  This may be what is causing the conbench issue.