### PR TITLE
MINOR: [C++] Mark ChunkResolver move constructor noexcept

### DIFF
--- a/cpp/src/arrow/chunk_resolver.h
+++ b/cpp/src/arrow/chunk_resolver.h
@@ -39,7 +39,7 @@ struct ChunkResolver {
 
   explicit ChunkResolver(const RecordBatchVector& batches);
 
-  ChunkResolver(ChunkResolver&& other)
+  ChunkResolver(ChunkResolver&& other) noexcept
       : offsets_(std::move(other.offsets_)), cached_chunk_(other.cached_chunk_.load()) {}
 
   ChunkResolver& operator=(ChunkResolver&& other) {


### PR DESCRIPTION
It also makes ChunkedArray nothrow move constructible as it contains a
ChunkResolver data member.