### PR TITLE
ARROW-16656: [CI][Release] Allow archery to support MINOR tickets and update release comments to contain MINOR

### DIFF
--- a/dev/archery/archery/release.py
+++ b/dev/archery/archery/release.py
@@ -137,6 +137,7 @@ class CachedJira:
 
 _TITLE_REGEX = re.compile(
     r"(?P<issue>(?P<project>(ARROW|PARQUET))\-\d+)?\s*:?\s*"
+    r"(?P<minor>(MINOR))?\s*:?\s*"
     r"(?P<components>\[.*\])?\s*(?P<summary>.*)"
 )
 _COMPONENT_REGEX = re.compile(r"\[([^\[\]]+)\]")
@@ -144,11 +145,13 @@ _COMPONENT_REGEX = re.compile(r"\[([^\[\]]+)\]")
 
 class CommitTitle:
 
-    def __init__(self, summary, project=None, issue=None, components=None):
+    def __init__(self, summary, project=None, issue=None, minor=None,
+                 components=None):
         self.project = project
         self.issue = issue
         self.components = components or []
         self.summary = summary
+        self.minor = bool(minor)
 
     def __str__(self):
         return self.to_string()
@@ -158,6 +161,7 @@ class CommitTitle:
             self.summary == other.summary and
             self.project == other.project and
             self.issue == other.issue and
+            self.minor == other.minor and
             self.components == other.components
         )
 
@@ -183,6 +187,7 @@ class CommitTitle:
             values['summary'],
             project=values.get('project'),
             issue=values.get('issue'),
+            minor=values.get('minor'),
             components=components
         )
 

--- a/dev/archery/archery/tests/test_release.py
+++ b/dev/archery/archery/tests/test_release.py
@@ -149,6 +149,7 @@ def test_commit_title():
     assert t.issue == "ARROW-9598"
     assert t.components == ["C++", "Parquet"]
     assert t.summary == "Fix writing nullable structs"
+    assert t.minor is False
 
     t = CommitTitle.parse(
         "ARROW-8002: [C++][Dataset][R] Support partitioned dataset writing"
@@ -157,6 +158,7 @@ def test_commit_title():
     assert t.issue == "ARROW-8002"
     assert t.components == ["C++", "Dataset", "R"]
     assert t.summary == "Support partitioned dataset writing"
+    assert t.minor is False
 
     t = CommitTitle.parse(
         "ARROW-9600: [Rust][Arrow] pin older version of proc-macro2 during "
@@ -166,18 +168,28 @@ def test_commit_title():
     assert t.issue == "ARROW-9600"
     assert t.components == ["Rust", "Arrow"]
     assert t.summary == "pin older version of proc-macro2 during build"
+    assert t.minor is False
+
+    t = CommitTitle.parse("[Release] Update versions for 1.0.0")
+    assert t.project is None
+    assert t.issue is None
+    assert t.components == ["Release"]
+    assert t.summary == "Update versions for 1.0.0"
+    assert t.minor is False
 
     t = CommitTitle.parse("MINOR: [Release] Update versions for 1.0.0")
     assert t.project is None
     assert t.issue is None
     assert t.components == ["Release"]
     assert t.summary == "Update versions for 1.0.0"
+    assert t.minor is True
 
     t = CommitTitle.parse("[Python][Doc] Fix rst role dataset.rst (#7725)")
     assert t.project is None
     assert t.issue is None
     assert t.components == ["Python", "Doc"]
     assert t.summary == "Fix rst role dataset.rst (#7725)"
+    assert t.minor is False
 
     t = CommitTitle.parse(
         "PARQUET-1882: [C++] Buffered Reads should allow for 0 length"
@@ -186,6 +198,7 @@ def test_commit_title():
     assert t.issue == 'PARQUET-1882'
     assert t.components == ["C++"]
     assert t.summary == "Buffered Reads should allow for 0 length"
+    assert t.minor is False
 
     t = CommitTitle.parse(
         "ARROW-9340 [R] Use CRAN version of decor package "
@@ -196,6 +209,7 @@ def test_commit_title():
     assert t.issue == 'ARROW-9340'
     assert t.components == ["R"]
     assert t.summary == "Use CRAN version of decor package "
+    assert t.minor is False
 
 
 def test_release_basics(fake_jira):

--- a/dev/archery/archery/tests/test_release.py
+++ b/dev/archery/archery/tests/test_release.py
@@ -167,7 +167,7 @@ def test_commit_title():
     assert t.components == ["Rust", "Arrow"]
     assert t.summary == "pin older version of proc-macro2 during build"
 
-    t = CommitTitle.parse("[Release] Update versions for 1.0.0")
+    t = CommitTitle.parse("MINOR: [Release] Update versions for 1.0.0")
     assert t.project is None
     assert t.issue is None
     assert t.components == ["Release"]

--- a/dev/release/01-prepare.sh
+++ b/dev/release/01-prepare.sh
@@ -75,7 +75,7 @@ if [ ${PREPARE_CHANGELOG} -gt 0 ]; then
   # Update changelog
   archery release changelog add $version
   git add ${SOURCE_DIR}/../../CHANGELOG.md
-  git commit -m "[Release] Update CHANGELOG.md for $version"
+  git commit -m "MINOR: [Release] Update CHANGELOG.md for $version"
 fi
 
 if [ ${PREPARE_LINUX_PACKAGES} -gt 0 ]; then
@@ -86,7 +86,7 @@ if [ ${PREPARE_LINUX_PACKAGES} -gt 0 ]; then
     ARROW_RELEASE_TIME="$(date +%Y-%m-%dT%H:%M:%S%z)" \
     ARROW_VERSION=${version}
   git add */debian*/changelog */yum/*.spec.in
-  git commit -m "[Release] Update .deb/.rpm changelogs for $version"
+  git commit -m "MINOR: [Release] Update .deb/.rpm changelogs for $version"
   cd -
 fi
 
@@ -94,7 +94,7 @@ if [ ${PREPARE_VERSION_PRE_TAG} -gt 0 ]; then
   echo "Prepare release ${version} on tag ${release_tag} then reset to version ${next_version_snapshot}"
 
   update_versions "${version}" "${next_version}" "release"
-  git commit -m "[Release] Update versions for ${version}"
+  git commit -m "MINOR: [Release] Update versions for ${version}"
 fi
 
 ############################## Tag the Release ##############################

--- a/dev/release/post-12-bump-versions.sh
+++ b/dev/release/post-12-bump-versions.sh
@@ -51,7 +51,7 @@ fi
 if [ ${BUMP_VERSION_POST_TAG} -gt 0 ]; then
   echo "Updating versions for ${next_version_snapshot}"
   update_versions "${version}" "${next_version}" "snapshot"
-  git commit -m "[Release] Update versions for ${next_version_snapshot}"
+  git commit -m "MINOR: [Release] Update versions for ${next_version_snapshot}"
 fi
 
 if [ ${BUMP_DEB_PACKAGE_NAMES} -gt 0 ]; then
@@ -85,7 +85,7 @@ if [ ${BUMP_DEB_PACKAGE_NAMES} -gt 0 ]; then
     sed -i.bak -E -e "${deb_lib_suffix_substitute_pattern}" rat_exclude_files.txt
     rm -f rat_exclude_files.txt.bak
     git add rat_exclude_files.txt
-    git commit -m "[Release] Update .deb package names for $next_version"
+    git commit -m "MINOR: [Release] Update .deb package names for $next_version"
     cd -
   fi
 fi
@@ -98,7 +98,7 @@ if [ ${BUMP_LINUX_PACKAGES} -gt 0 ]; then
     ARROW_RELEASE_TIME="$(git log -n1 --format=%aI apache-arrow-${version})" \
     ARROW_VERSION=${version}
   git add */debian*/changelog */yum/*.spec.in
-  git commit -m "[Release] Update .deb/.rpm changelogs for $version"
+  git commit -m "MINOR: [Release] Update .deb/.rpm changelogs for $version"
   cd -
 fi
 


### PR DESCRIPTION
This is a minor fix to be consistent with our commit messages on the automated release comments and a minor fix to archery release to be able to process tickets that are `MINOR`.