### PR TITLE
ARROW-16647: [C++] Add support for unique(), value_counts(), dictionary_encode() with interval types

### DIFF
--- a/cpp/src/arrow/compute/kernels/vector_hash.cc
+++ b/cpp/src/arrow/compute/kernels/vector_hash.cc
@@ -555,6 +555,7 @@ KernelInit GetHashInit(Type::type type_id) {
     case Type::FLOAT:
     case Type::DATE32:
     case Type::TIME32:
+    case Type::INTERVAL_MONTHS:
       return HashInit<UInt32Type, Action>;
     case Type::INT64:
     case Type::UINT64:
@@ -563,6 +564,7 @@ KernelInit GetHashInit(Type::type type_id) {
     case Type::TIME64:
     case Type::TIMESTAMP:
     case Type::DURATION:
+    case Type::INTERVAL_DAY_TIME:
       return HashInit<UInt64Type, Action>;
     case Type::BINARY:
     case Type::STRING:
@@ -574,6 +576,8 @@ KernelInit GetHashInit(Type::type type_id) {
     case Type::DECIMAL128:
     case Type::DECIMAL256:
       return HashInit<FixedSizeBinaryType, Action>;
+    case Type::INTERVAL_MONTH_DAY_NANO:
+      return HashInit<MonthDayNanoIntervalType, Action>;
     default:
       DCHECK(false);
       return nullptr;
@@ -721,6 +725,12 @@ void AddHashKernels(VectorFunction* func, VectorKernel base, OutputType out_ty) 
   for (auto t : {Type::DECIMAL128, Type::DECIMAL256}) {
     base.init = GetHashInit<Action>(t);
     base.signature = KernelSignature::Make({InputType::Array(t)}, out_ty);
+    DCHECK_OK(func->AddKernel(base));
+  }
+
+  for (const auto& ty : IntervalTypes()) {
+    base.init = GetHashInit<Action>(ty->id());
+    base.signature = KernelSignature::Make({InputType::Array(ty)}, out_ty);
     DCHECK_OK(func->AddKernel(base));
   }
 }

--- a/cpp/src/arrow/compute/kernels/vector_hash_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_hash_test.cc
@@ -638,6 +638,50 @@ TEST_F(TestHashKernel, DictEncodeDecimal) {
                                               {}, {0, 0, 1, 0, 2});
 }
 
+TEST_F(TestHashKernel, UniqueIntervalMonth) {
+  CheckUnique<MonthIntervalType, int32_t>(month_interval(), {2, 1, 2, 1},
+                                          {true, false, true, true}, {2, 0, 1},
+                                          {true, false, true});
+
+  CheckUnique<DayTimeIntervalType, DayTimeIntervalType::DayMilliseconds>(
+      day_time_interval(), {{2, 1}, {3, 2}, {2, 1}, {1, 2}}, {true, false, true, true},
+      {{2, 1}, {1, 1}, {1, 2}}, {true, false, true});
+
+  CheckUnique<MonthDayNanoIntervalType, MonthDayNanoIntervalType::MonthDayNanos>(
+      month_day_nano_interval(), {{2, 1, 1}, {3, 2, 1}, {2, 1, 1}, {1, 2, 1}},
+      {true, false, true, true}, {{2, 1, 1}, {1, 1, 1}, {1, 2, 1}}, {true, false, true});
+}
+
+TEST_F(TestHashKernel, ValueCountsIntervalMonth) {
+  CheckValueCounts<MonthIntervalType, int32_t>(month_interval(), {2, 1, 2, 1},
+                                               {true, false, true, true}, {2, 0, 1},
+                                               {true, false, true}, {2, 1, 1});
+
+  CheckValueCounts<DayTimeIntervalType, DayTimeIntervalType::DayMilliseconds>(
+      day_time_interval(), {{2, 1}, {3, 2}, {2, 1}, {1, 2}}, {true, false, true, true},
+      {{2, 1}, {1, 1}, {1, 2}}, {true, false, true}, {2, 1, 1});
+
+  CheckValueCounts<MonthDayNanoIntervalType, MonthDayNanoIntervalType::MonthDayNanos>(
+      month_day_nano_interval(), {{2, 1, 1}, {3, 2, 1}, {2, 1, 1}, {1, 2, 1}},
+      {true, false, true, true}, {{2, 1, 1}, {1, 1, 1}, {1, 2, 1}}, {true, false, true},
+      {2, 1, 1});
+}
+
+TEST_F(TestHashKernel, DictEncodeIntervalMonth) {
+  CheckDictEncode<MonthIntervalType, int32_t>(month_interval(), {2, 2, 1, 2, 3},
+                                              {true, false, true, true, true}, {2, 1, 3},
+                                              {}, {0, 0, 1, 0, 2});
+
+  CheckDictEncode<DayTimeIntervalType, DayTimeIntervalType::DayMilliseconds>(
+      day_time_interval(), {{2, 1}, {2, 1}, {3, 2}, {2, 1}, {1, 2}},
+      {true, false, true, true, true}, {{2, 1}, {3, 2}, {1, 2}}, {}, {0, 0, 1, 0, 2});
+
+  CheckDictEncode<MonthDayNanoIntervalType, MonthDayNanoIntervalType::MonthDayNanos>(
+      month_day_nano_interval(), {{2, 1, 1}, {2, 1, 1}, {3, 2, 1}, {2, 1, 1}, {1, 2, 1}},
+      {true, false, true, true, true}, {{2, 1, 1}, {3, 2, 1}, {1, 2, 1}}, {},
+      {0, 0, 1, 0, 2});
+}
+
 TEST_F(TestHashKernel, DictionaryUniqueAndValueCounts) {
   auto dict_json = "[10, 20, 30, 40]";
   auto dict = ArrayFromJSON(int64(), dict_json);


### PR DESCRIPTION
Add support for unique(), value_counts(), dictionary_encode() with interval types.