### PR TITLE
MINOR: [C++] Always call cmake message() with explicit mode

### DIFF
--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -548,8 +548,8 @@ if(NOT WIN32 AND NOT APPLE)
                     OUTPUT_VARIABLE GOLD_LOCATION
                     OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
     if("${GOLD_LOCATION}" MATCHES "^/opt/rh/devtoolset")
-      message("Skipping optional gold linker (version ${GOLD_VERSION}) because "
-              "it's in devtoolset")
+      message(STATUS "Skipping optional gold linker (version ${GOLD_VERSION}) because "
+                     "it's in devtoolset")
       set(GOLD_VERSION)
     endif()
   endif()
@@ -571,7 +571,7 @@ if(NOT WIN32 AND NOT APPLE)
       set(ARROW_BUGGY_GOLD 1)
     endif()
     if(MUST_USE_GOLD)
-      message("Using hard-wired gold linker (version ${GOLD_VERSION})")
+      message(STATUS "Using hard-wired gold linker (version ${GOLD_VERSION})")
       if(ARROW_BUGGY_GOLD)
         if("${ARROW_LINK}" STREQUAL "d" AND "${CMAKE_BUILD_TYPE}" STREQUAL "RELEASE")
           message(SEND_ERROR "Configured to use buggy gold with dynamic linking "
@@ -582,12 +582,12 @@ if(NOT WIN32 AND NOT APPLE)
       # The Gold linker must be manually enabled.
       set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fuse-ld=gold")
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fuse-ld=gold")
-      message("Using optional gold linker (version ${GOLD_VERSION})")
+      message(STATUS "Using optional gold linker (version ${GOLD_VERSION})")
     else()
-      message("Optional gold linker is buggy, using ld linker instead")
+      message(STATUS "Optional gold linker is buggy, using ld linker instead")
     endif()
   else()
-    message("Using ld linker")
+    message(STATUS "Using ld linker")
   endif()
 endif()
 
@@ -625,7 +625,7 @@ set(CXX_FLAGS_PROFILE_GEN "${CXX_FLAGS_RELEASE} -fprofile-generate")
 set(CXX_FLAGS_PROFILE_BUILD "${CXX_FLAGS_RELEASE} -fprofile-use")
 
 # Set compile flags based on the build type.
-message("Configured for ${CMAKE_BUILD_TYPE} build (set with cmake -DCMAKE_BUILD_TYPE={release,debug,...})"
+message(STATUS "Configured for ${CMAKE_BUILD_TYPE} build (set with cmake -DCMAKE_BUILD_TYPE={release,debug,...})"
 )
 if("${CMAKE_BUILD_TYPE}" STREQUAL "DEBUG")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${C_FLAGS_DEBUG}")

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -1423,7 +1423,7 @@ macro(build_thrift)
     message(FATAL_ERROR "Building thrift using ExternalProject requires at least CMake 3.10"
     )
   endif()
-  message("Building Apache Thrift from source")
+  message(STATUS "Building Apache Thrift from source")
   set(THRIFT_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/thrift_ep-install")
   set(THRIFT_INCLUDE_DIR "${THRIFT_PREFIX}/include")
   set(THRIFT_CMAKE_ARGS
@@ -1526,7 +1526,7 @@ endif()
 # Protocol Buffers (required for ORC, Flight, Gandiva and Substrait libraries)
 
 macro(build_protobuf)
-  message("Building Protocol Buffers from source")
+  message(STATUS "Building Protocol Buffers from source")
   set(PROTOBUF_VENDORED TRUE)
   set(PROTOBUF_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/protobuf_ep-install")
   set(PROTOBUF_INCLUDE_DIR "${PROTOBUF_PREFIX}/include")
@@ -1710,7 +1710,7 @@ endif()
 # Substrait (required by compute engine)
 
 macro(build_substrait)
-  message("Building Substrait from source")
+  message(STATUS "Building Substrait from source")
 
   set(SUBSTRAIT_PROTOS
       capabilities
@@ -4019,7 +4019,7 @@ endif()
 # Apache ORC
 
 macro(build_orc)
-  message("Building Apache ORC from source")
+  message(STATUS "Building Apache ORC from source")
 
   set(ORC_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/orc_ep-install")
   set(ORC_HOME "${ORC_PREFIX}")
@@ -4321,7 +4321,7 @@ endif()
 # AWS SDK for C++
 
 macro(build_awssdk)
-  message("Building AWS C++ SDK from source")
+  message(STATUS "Building AWS C++ SDK from source")
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS
                                               "4.9")
     message(FATAL_ERROR "AWS C++ SDK requires gcc >= 4.9")

--- a/cpp/cmake_modules/san-config.cmake
+++ b/cpp/cmake_modules/san-config.cmake
@@ -84,7 +84,7 @@ if(${ARROW_USE_TSAN})
   # guarantee that is via dynamic linking (not all 3rd party archives are
   # compiled with -fPIC e.g. boost).
   if("${ARROW_LINK}" STREQUAL "a")
-    message("Using dynamic linking for TSAN")
+    message(STATUS "Using dynamic linking for TSAN")
     set(ARROW_LINK "d")
   elseif("${ARROW_LINK}" STREQUAL "s")
     message(SEND_ERROR "Cannot use TSAN with static linking")


### PR DESCRIPTION
`message()` without mode is not preceded with `--`, and may be printed
out of order.

E.g., `Using ld linker` is not aligned with other messages.
```
-- Performing Test CXX_SUPPORTS_AVX512 - Success
-- Arrow build warning level: CHECKIN
Using ld linker
-- Configured for RELWITHDEBINFO build ...
```