### PR TITLE
[MINOR] [Python Docs] Fix docs and comment for pyarrow.fs.S3FileSystem

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -103,8 +103,7 @@ struct ARROW_EXPORT S3Options {
   /// server).
   std::string region;
 
-  /// If non-empty, override region with a connect string such as "localhost:9000"
-  // XXX perhaps instead take a URL like "http://localhost:9000"?
+  /// If non-empty, override region with a connect string such as "http://localhost:9000"
   std::string endpoint_override;
   /// S3 connection transport, default "https"
   std::string scheme = "https";

--- a/python/pyarrow/_s3fs.pyx
+++ b/python/pyarrow/_s3fs.pyx
@@ -130,7 +130,7 @@ cdef class S3FileSystem(FileSystem):
     scheme : str, default 'https'
         S3 connection transport scheme.
     endpoint_override : str, default None
-        Override region with a connect string such as "localhost:9000"
+        Override region with a connect string such as "http://localhost:9000"
     background_writes : boolean, default True
         Whether file writes will be issued in the background, without
         blocking.

--- a/r/src/filesystem.cpp
+++ b/r/src/filesystem.cpp
@@ -305,7 +305,7 @@ std::shared_ptr<fs::S3FileSystem> fs___S3FileSystem__create(
   if (region != "") {
     s3_opts.region = region;
   }
-  /// If non-empty, override region with a connect string such as "localhost:9000"
+  /// If non-empty, override region with a connect string such as "http://localhost:9000"
   s3_opts.endpoint_override = endpoint_override;
   /// S3 connection transport, default "https"
   if (scheme != "") {


### PR DESCRIPTION
Hi, I am Dario, a developer at [BuildNN](https://github.com/buildnn). First of all, thank you for your work!

Today I was trying to connect to [minio](https://min.io/) using [`S3FileSystem`](https://arrow.apache.org/docs/python/generated/pyarrow.fs.S3FileSystem.html).
So I tried `endpoint_override="localhost:9000"` as suggested in your documentation, but I got the following error:

```py
File "pyarrow/error.pxi", line 114, in pyarrow.lib.check_status
OSError: When creating bucket 'test-bucket': AWS Error [code 99]: curlCode: 35, SSL connect error
```

After some tries, I discovered that the protocol prefix is required (e.g. `http:\\`), so when I use `endpoint_override="http://localhost:9000"` everything works just fine.

I guess then that the documentation is not updated