### PR TITLE
ARROW-16676: [C++] ReservationListenableMemoryPool::Impl::bytes_allocated() should return its own number of bytes rather than the underlying pool's

### DIFF
--- a/cpp/src/jni/dataset/jni_util.cc
+++ b/cpp/src/jni/dataset/jni_util.cc
@@ -108,12 +108,15 @@ class ReservationListenableMemoryPool::Impl {
     }
     int64_t bytes_granted = (new_block_count - blocks_reserved_) * block_size_;
     blocks_reserved_ = new_block_count;
+    if (bytes_reserved_ > max_bytes_reserved_) {
+      max_bytes_reserved_ = bytes_reserved_;
+    }
     return bytes_granted;
   }
 
-  int64_t bytes_allocated() { return pool_->bytes_allocated(); }
+  int64_t bytes_allocated() { return bytes_reserved_; }
 
-  int64_t max_memory() { return pool_->max_memory(); }
+  int64_t max_memory() { return max_bytes_reserved_; }
 
   std::string backend_name() { return pool_->backend_name(); }
 
@@ -125,6 +128,7 @@ class ReservationListenableMemoryPool::Impl {
   int64_t block_size_;
   int64_t blocks_reserved_;
   int64_t bytes_reserved_;
+  int64_t max_bytes_reserved_ = 0L;
   std::mutex mutex_;
 };
 

--- a/cpp/src/jni/dataset/jni_util.cc
+++ b/cpp/src/jni/dataset/jni_util.cc
@@ -35,8 +35,7 @@ class ReservationListenableMemoryPool::Impl {
       : pool_(pool),
         listener_(listener),
         block_size_(block_size),
-        blocks_reserved_(0),
-        bytes_reserved_(0) {}
+        blocks_reserved_(0) {}
 
   arrow::Status Allocate(int64_t size, uint8_t** out) {
     RETURN_NOT_OK(UpdateReservation(size));

--- a/cpp/src/jni/dataset/jni_util.cc
+++ b/cpp/src/jni/dataset/jni_util.cc
@@ -98,25 +98,23 @@ class ReservationListenableMemoryPool::Impl {
 
   int64_t Reserve(int64_t diff) {
     std::lock_guard<std::mutex> lock(mutex_);
-    bytes_reserved_ += diff;
+    stats_.UpdateAllocatedBytes(diff);
     int64_t new_block_count;
-    if (bytes_reserved_ == 0) {
+    int64_t bytes_reserved = stats_.bytes_allocated();
+    if (bytes_reserved == 0) {
       new_block_count = 0;
     } else {
       // ceil to get the required block number
-      new_block_count = (bytes_reserved_ - 1) / block_size_ + 1;
+      new_block_count = (bytes_reserved - 1) / block_size_ + 1;
     }
     int64_t bytes_granted = (new_block_count - blocks_reserved_) * block_size_;
     blocks_reserved_ = new_block_count;
-    if (bytes_reserved_ > max_bytes_reserved_) {
-      max_bytes_reserved_ = bytes_reserved_;
-    }
     return bytes_granted;
   }
 
-  int64_t bytes_allocated() { return bytes_reserved_; }
+  int64_t bytes_allocated() { return stats_.bytes_allocated(); }
 
-  int64_t max_memory() { return max_bytes_reserved_; }
+  int64_t max_memory() { return stats_.max_memory(); }
 
   std::string backend_name() { return pool_->backend_name(); }
 
@@ -127,8 +125,7 @@ class ReservationListenableMemoryPool::Impl {
   std::shared_ptr<ReservationListener> listener_;
   int64_t block_size_;
   int64_t blocks_reserved_;
-  int64_t bytes_reserved_;
-  int64_t max_bytes_reserved_ = 0L;
+  arrow::internal::MemoryPoolStats stats_;
   std::mutex mutex_;
 };
 

--- a/cpp/src/jni/dataset/jni_util.cc
+++ b/cpp/src/jni/dataset/jni_util.cc
@@ -32,10 +32,7 @@ class ReservationListenableMemoryPool::Impl {
  public:
   explicit Impl(arrow::MemoryPool* pool, std::shared_ptr<ReservationListener> listener,
                 int64_t block_size)
-      : pool_(pool),
-        listener_(listener),
-        block_size_(block_size),
-        blocks_reserved_(0) {}
+      : pool_(pool), listener_(listener), block_size_(block_size), blocks_reserved_(0) {}
 
   arrow::Status Allocate(int64_t size, uint8_t** out) {
     RETURN_NOT_OK(UpdateReservation(size));


### PR DESCRIPTION
ReservationListenableMemoryPool is a decorator of the underlying memory pool with its own mem counter. It should represent for the bytes reserved from itself rather than the underlying pool.

E.g. a ReservationListenableMemoryPool `pool-a`  instance wraps the default pool, and default pool's allocation is now 1GB, `pool-a`'s allocation is 10MB, we should let `pool-a.bytes_allocated()` return 10MB rather than 1GB.

It's not really a bug but can limit the information user can get when calling these APIs.