### PR TITLE
ARROW-16560: [Website][Release] Fix versions.json update phase

### DIFF
--- a/dev/release/01-prepare-test.rb
+++ b/dev/release/01-prepare-test.rb
@@ -155,6 +155,21 @@ class PrepareTest < Test::Unit::TestCase
         ],
       },
       {
+        path: "docs/source/_static/versions.json",
+        hunks: [
+          [
+            "-        \"name\": \"#{@release_compatible_version} (dev)\",",
+            "+        \"name\": \"#{@next_compatible_version} (dev)\",",
+            "-        \"name\": \"#{@previous_compatible_version} (stable)\",",
+            "+        \"name\": \"#{@release_compatible_version} (stable)\",",
+            "+    {",
+            "+        \"name\": \"#{@previous_compatible_version}\",",
+            "+        \"version\": \"#{@previous_compatible_version}/\"",
+            "+    },",
+          ],
+        ],
+      },
+      {
         path: "go/parquet/writer_properties.go",
         hunks: [
           ["-\tDefaultCreatedBy          = \"parquet-go version #{@snapshot_version}\"",
@@ -194,6 +209,21 @@ class PrepareTest < Test::Unit::TestCase
         hunks: [
           ["-\# arrow #{@previous_version}.9000",
            "+\# arrow #{@release_version}"],
+        ],
+      },
+      {
+        path: "r/pkgdown/assets/versions.json",
+        hunks: [
+          [
+            "-        \"name\": \"#{@previous_version}.9000 (dev)\",",
+            "+        \"name\": \"#{@release_version}.9000 (dev)\",",
+            "-        \"name\": \"#{@previous_version} (release)\",",
+            "+        \"name\": \"#{@release_version} (release)\",",
+            "+    {",
+            "+        \"name\": \"#{@previous_version}\",",
+            "+        \"version\": \"#{@previous_compatible_version}/\"",
+            "+    },",
+          ]
         ],
       },
     ]

--- a/dev/release/post-12-bump-versions-test.rb
+++ b/dev/release/post-12-bump-versions-test.rb
@@ -116,21 +116,6 @@ class PostBumpVersionsTest < Test::Unit::TestCase
         ],
       },
       {
-        path: "docs/source/_static/versions.json",
-        hunks: [
-          [
-            "-        \"name\": \"#{@release_compatible_version} (dev)\",",
-            "+        \"name\": \"#{@next_compatible_version} (dev)\",",
-            "-        \"name\": \"#{@previous_compatible_version} (stable)\",",
-            "+        \"name\": \"#{@release_compatible_version} (stable)\",",
-            "+    {",
-            "+        \"name\": \"#{@previous_compatible_version}\",",
-            "+        \"version\": \"#{@previous_compatible_version}/\"",
-            "+    },",
-          ]
-        ]
-      },
-      {
         path: "js/package.json",
         hunks: [
           ["-  \"version\": \"#{@snapshot_version}\"",
@@ -166,20 +151,6 @@ class PostBumpVersionsTest < Test::Unit::TestCase
            "+",
            "+# arrow #{@release_version}",],
         ],
-      },
-      {
-        path: "r/pkgdown/assets/versions.json",
-        hunks: [
-          [ "-        \"name\": \"#{@previous_version}.9000 (dev)\",",
-            "+        \"name\": \"#{@release_version}.9000 (dev)\",",
-            "-        \"name\": \"#{@previous_version} (release)\",",
-            "+        \"name\": \"#{@release_version} (release)\",",
-            "+    {",
-            "+        \"name\": \"#{@previous_version}\",",
-            "+        \"version\": \"#{@previous_compatible_version}/\"",
-            "+    },"
-          ]
-        ]
       },
     ]
 

--- a/dev/release/utils-prepare.sh
+++ b/dev/release/utils-prepare.sh
@@ -161,11 +161,14 @@ update_versions() {
   popd
 
   case ${type} in
-    snapshot)
+    release)
       pushd "${ARROW_DIR}"
-      ${PYTHON:-python3} "dev/release/utils-update-docs-versions.py" . "${version}" "${r_version}"
-      git add r/pkgdown/assets/versions.json
+      ${PYTHON:-python3} "dev/release/utils-update-docs-versions.py" \
+                         . \
+                         "${version}" \
+                         "${next_version}"
       git add docs/source/_static/versions.json
+      git add r/pkgdown/assets/versions.json
       popd
       ;;
   esac

--- a/dev/release/utils-update-docs-versions.py
+++ b/dev/release/utils-update-docs-versions.py
@@ -19,10 +19,10 @@ import json
 import sys
 
 dir_path = sys.argv[1]
-# X.Y.Z-SNAPSHOT
+# X.Y.Z
 version = sys.argv[2]
-# {X-1}.Y.Z.9000
-r_version = sys.argv[3]
+# {X+1}.Y.Z
+next_version = sys.argv[3]
 
 main_versions_path = dir_path + "/docs/source/_static/versions.json"
 r_versions_path = dir_path + "/r/pkgdown/assets/versions.json"
@@ -33,8 +33,9 @@ with open(main_versions_path) as json_file:
     old_versions = json.load(json_file)
 
 split_version = version.split(".")
-dev_compatible_version = ".".join(split_version[:2])
-stable_compatible_version = f"{str(int(split_version[0]) - 1)}.0"
+split_next_version = next_version.split(".")
+dev_compatible_version = ".".join(split_next_version[:2])
+stable_compatible_version = ".".join(split_version[:2])
 previous_compatible_version = old_versions[1]["name"].split(" ")[0]
 
 # Create new versions
@@ -56,8 +57,8 @@ with open(main_versions_path, 'w') as json_file:
 with open(r_versions_path) as json_file:
     old_r_versions = json.load(json_file)
 
-dev_r_version = r_version
-release_r_version = ".".join(r_version.split(".")[:3])
+dev_r_version = f"{version}.9000"
+release_r_version = version
 previous_r_name = old_r_versions[1]["name"].split(" ")[0]
 previous_r_version = ".".join(previous_r_name.split(".")[:2])
 


### PR DESCRIPTION
Update versions.json before (not after) we tag a new version. Because
we need to use updated versions.json on release. If we update
versions.json after tagging, documentations of new release use
non-updated versions.json.