### PR TITLE
MINOR: [R][Docs] Fix install command for nightly builds

### DIFF
--- a/r/README.md
+++ b/r/README.md
@@ -79,7 +79,7 @@ nightly and hosted at <https://arrow-r-nightly.s3.amazonaws.com>. To
 install from there:
 
 ``` r
-install.packages("arrow", repos = "https://arrow-r-nightly.s3.amazonaws.com")
+install.packages("arrow", repos = c(arrow = "https://arrow-r-nightly.s3.amazonaws.com", getOption("repos")))
 ```
 
 Conda users can install `arrow` nightly builds with

--- a/r/vignettes/install.Rmd
+++ b/r/vignettes/install.Rmd
@@ -259,7 +259,7 @@ from the Ursa Labs repository:
 
 ```r
 Sys.setenv(NOT_CRAN = TRUE)
-install.packages("arrow", repos = "https://arrow-r-nightly.s3.amazonaws.com")
+install.packages("arrow", repos = c(arrow = "https://arrow-r-nightly.s3.amazonaws.com", getOption("repos")))
 ```
 
 or for conda users via:


### PR DESCRIPTION
`getOption("repos")` must be specified to install dependent packages.