### PR TITLE
ARROW-16272: [Python] Fix NativeFile.read1()

### DIFF
--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -330,8 +330,7 @@ cdef class NativeFile(_Weakrefable):
 
     def write(self, data):
         """
-        Write byte from any object implementing buffer protocol (bytes,
-        bytearray, ndarray, pyarrow.Buffer)
+        Write data to the file.
 
         Parameters
         ----------
@@ -353,8 +352,9 @@ cdef class NativeFile(_Weakrefable):
 
     def read(self, nbytes=None):
         """
-        Read indicated number of bytes from file, or read all remaining bytes
-        if no argument passed
+        Read and return up to n bytes.
+
+        If *nbytes* is None, then the entire remaining file contents are read.
 
         Parameters
         ----------
@@ -440,12 +440,17 @@ cdef class NativeFile(_Weakrefable):
     def read1(self, nbytes=None):
         """Read and return up to n bytes.
 
-        A short result does not imply that EOF is imminent.
+        Unlike read(), if *nbytes* is None then a chunk is read, not the
+        entire file.
 
         Parameters
         ----------
-        nbytes : int
+        nbytes : int, default None
             The maximum number of bytes to read.
+
+        Returns
+        -------
+        data : bytes
         """
         if nbytes is None:
             # The expectation when passing `nbytes=None` is not to read the
@@ -453,8 +458,6 @@ cdef class NativeFile(_Weakrefable):
             # a reasonable size (the use case being to read a bufferable
             # amount of bytes, such as with io.TextIOWrapper).
             nbytes = self._default_chunk_size
-        else:
-            nbytes = min(nbytes, self._default_chunk_size)
         return self.read(nbytes)
 
     def readall(self):

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -1649,20 +1649,3 @@ def test_copy_files_directory(tempdir):
     destination_dir5.mkdir()
     copy_files(source_dir, destination_dir5, chunk_size=1, use_threads=False)
     check_copied_files(destination_dir5)
-
-
-@pytest.mark.pandas
-@pytest.mark.s3
-def test_pandas_text_reader_s3(tmpdir):
-    # ARROW-16272: Pandas' read_csv() should not exhaust a S3 input stream
-    # when a small nrows is passed.
-    import pandas as pd
-    from pyarrow.fs import S3FileSystem
-
-    fs = S3FileSystem(anonymous=True, region="us-east-2")
-    f = fs.open_input_file("ursa-qa/nyctaxi/yellow_tripdata_2010-01.csv")
-
-    df = pd.read_csv(f, nrows=2)
-    assert list(df["vendor_id"]) == ["VTS", "DDS"]
-    # Some readahead occurred, but not up to the end of file (which is ~2 GB)
-    assert f.tell() <= 256 * 1024

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -1649,3 +1649,20 @@ def test_copy_files_directory(tempdir):
     destination_dir5.mkdir()
     copy_files(source_dir, destination_dir5, chunk_size=1, use_threads=False)
     check_copied_files(destination_dir5)
+
+
+@pytest.mark.pandas
+@pytest.mark.s3
+def test_pandas_text_reader_s3(tmpdir):
+    # ARROW-16272: Pandas' read_csv() should not exhaust a S3 input stream
+    # when a small nrows is passed.
+    import pandas as pd
+    from pyarrow.fs import S3FileSystem
+
+    fs = S3FileSystem(anonymous=True, region="us-east-2")
+    f = fs.open_input_file("ursa-qa/nyctaxi/yellow_tripdata_2010-01.csv")
+
+    df = pd.read_csv(f, nrows=2)
+    assert list(df["vendor_id"]) == ["VTS", "DDS"]
+    # Some readahead occurred, but not up to the end of file (which is ~2 GB)
+    assert f.tell() <= 256 * 1024

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -1220,8 +1220,8 @@ def test_native_file_TextIOWrapper_perf(tmpdir):
 
 
 def test_native_file_read1(tmpdir):
-    # read1() should not exhaust the input stream if there is a large amount
-    # of data remaining.
+    # ARROW-16272: read1() should not exhaust the input stream if there
+    # is a large amount of data remaining.
     data = b'123\n' * 1_000_000
     path = str(tmpdir / 'largefile.txt')
     with open(path, 'wb') as f:


### PR DESCRIPTION
`read1()` should not read the entire input stream but instead return a reasonable amount of bytes, suitable for building up an internal buffer.

Should fix the performance issue when using `TextIOWrapper` or `pandas.read_csv` on a S3 input file.