### PR TITLE
ARROW-16613: [C++][Parquet] Fix performance of repeated calls to AppendRowGroups()

### DIFF
--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -662,7 +662,7 @@ class FileMetaData::FileMetaDataImpl {
     //  about inappropriate uses of reserve()).
     const auto start = metadata_->row_groups.size();
     metadata_->row_groups.resize(start + n);
-    for (int64_t i = 0; i < n; i++) {
+    for (int i = 0; i < n; i++) {
       metadata_->row_groups[start + i] = other->row_group(i);
       metadata_->num_rows += metadata_->row_groups[start + i].num_rows;
     }

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -656,11 +656,15 @@ class FileMetaData::FileMetaDataImpl {
 
     // ARROW-13654: `other` may point to self, be careful not to enter an infinite loop
     const int n = other->num_row_groups();
-    metadata_->row_groups.reserve(metadata_->row_groups.size() + n);
-    for (int i = 0; i < n; i++) {
-      format::RowGroup other_rg = other->row_group(i);
-      metadata_->num_rows += other_rg.num_rows;
-      metadata_->row_groups.push_back(std::move(other_rg));
+    // ARROW-16613: do not use reserve() as that may suppress overallocation
+    // and incur O(n²) behavior on repeated calls to AppendRowGroups().
+    // (see https://en.cppreference.com/w/cpp/container/vector/reserve
+    //  about inappropriate uses of reserve()).
+    const auto start = metadata_->row_groups.size();
+    metadata_->row_groups.resize(start + n);
+    for (int64_t i = 0; i < n; i++) {
+      metadata_->row_groups[start + i] = other->row_group(i);
+      metadata_->num_rows += metadata_->row_groups[start + i].num_rows;
     }
   }
 


### PR DESCRIPTION
Repeated calls to `FileMetaData::AppendRowGroups()` would be O(n²) due to incorrect use of `std::vector::reserve`.