### PR TITLE
ARROW-16606: [FlightRPC][Python] Handle non-lowercase header names

### DIFF
--- a/cpp/src/arrow/flight/middleware.h
+++ b/cpp/src/arrow/flight/middleware.h
@@ -44,6 +44,11 @@ class ARROW_FLIGHT_EXPORT AddCallHeaders {
   virtual ~AddCallHeaders() = default;
 
   /// \brief Add a header to be sent to the client.
+  ///
+  /// \param[in] key The header name. Must be lowercase ASCII; some
+  ///   transports may reject invalid header names.
+  /// \param[in] value The header value. Some transports may only
+  ///   accept binary header values if the header name ends in "-bin".
   virtual void AddHeader(const std::string& key, const std::string& value) = 0;
 };
 

--- a/python/pyarrow/tests/test_flight.py
+++ b/python/pyarrow/tests/test_flight.py
@@ -819,6 +819,9 @@ class MultiHeaderClientMiddleware(ClientMiddleware):
     EXPECTED = {
         "x-text": ["foo", "bar"],
         "x-binary-bin": [b"\x00", b"\x01"],
+        # ARROW-16606: ensure mixed-case headers are accepted
+        "x-MIXED-case": ["baz"],
+        b"x-other-MIXED-case": ["baz"],
     }
 
     def __init__(self, factory):
@@ -1909,6 +1912,9 @@ def test_middleware_multi_header():
             client_headers = ast.literal_eval(raw_headers)
             # Don't directly compare; gRPC may add headers like User-Agent.
             for header, values in MultiHeaderClientMiddleware.EXPECTED.items():
+                header = header.lower()
+                if isinstance(header, bytes):
+                    header = header.decode("ascii")
                 assert client_headers.get(header) == values
                 assert headers.last_headers.get(header) == values
 


### PR DESCRIPTION
gRPC may abort if it gets a non-lowercase header. In Python, just
pay the tax of normalizing case. In C++, add a note to the docs
instead.