### PR TITLE
ARROW-16738: [C++][Gandiva] Fix TO_TIMESTAMP(INTEGER) function for big integer values

### DIFF
--- a/cpp/src/gandiva/precompiled/time.cc
+++ b/cpp/src/gandiva/precompiled/time.cc
@@ -40,18 +40,24 @@ extern "C" {
   INNER(date64)           \
   INNER(timestamp)
 
-// Expand inner macro for all base numeric types.
-#define NUMERIC_TYPES(INNER) \
-  INNER(int8)                \
-  INNER(int16)               \
-  INNER(int32)               \
-  INNER(int64)               \
-  INNER(uint8)               \
-  INNER(uint16)              \
-  INNER(uint32)              \
-  INNER(uint64)              \
-  INNER(float32)             \
+#define INTEGER_NUMERIC_TYPES(INNER) \
+  INNER(int8)                        \
+  INNER(int16)                       \
+  INNER(int32)                       \
+  INNER(int64)                       \
+  INNER(uint8)                       \
+  INNER(uint16)                      \
+  INNER(uint32)                      \
+  INNER(uint64)
+
+#define REAL_NUMERIC_TYPES(INNER) \
+  INNER(float32)                  \
   INNER(float64)
+
+// Expand inner macro for all base numeric types.
+#define NUMERIC_TYPES(INNER)   \
+  INTEGER_NUMERIC_TYPES(INNER) \
+  REAL_NUMERIC_TYPES(INNER)
 
 // Extract millennium
 #define EXTRACT_MILLENNIUM(TYPE)                            \
@@ -983,13 +989,23 @@ gdv_int64 castBIGINT_daytimeinterval(gdv_day_time_interval in) {
 }
 
 // Convert the seconds since epoch argument to timestamp
-#define TO_TIMESTAMP(TYPE)                                      \
+#define TO_TIMESTAMP_INTEGER(TYPE)                              \
+  FORCE_INLINE                                                  \
+  gdv_timestamp to_timestamp##_##TYPE(gdv_##TYPE seconds) {     \
+    return static_cast<gdv_timestamp>(seconds) * MILLIS_IN_SEC; \
+  }
+
+#define TO_TIMESTAMP_REAL(TYPE)                                 \
   FORCE_INLINE                                                  \
   gdv_timestamp to_timestamp##_##TYPE(gdv_##TYPE seconds) {     \
     return static_cast<gdv_timestamp>(seconds * MILLIS_IN_SEC); \
   }
 
-NUMERIC_TYPES(TO_TIMESTAMP)
+INTEGER_NUMERIC_TYPES(TO_TIMESTAMP_INTEGER)
+REAL_NUMERIC_TYPES(TO_TIMESTAMP_REAL)
+
+#undef TO_TIMESTAMP_INTEGER
+#undef TO_TIMESTAMP_REAL
 
 // Convert the seconds since epoch argument to time
 #define TO_TIME(TYPE)                                                     \

--- a/cpp/src/gandiva/precompiled/time_test.cc
+++ b/cpp/src/gandiva/precompiled/time_test.cc
@@ -962,6 +962,10 @@ TEST(TestTime, TestToTimestamp) {
   EXPECT_EQ(ts, to_timestamp_float32(1));
   EXPECT_EQ(ts, to_timestamp_float64(1));
 
+  ts = StringToTimestamp("2021-07-14 09:31:39");
+  EXPECT_EQ(ts, to_timestamp_int32(1626255099));
+  EXPECT_EQ(ts, to_timestamp_int64(1626255099));
+
   ts = StringToTimestamp("1970-01-01 00:01:00");
   EXPECT_EQ(ts, to_timestamp_int32(60));
   EXPECT_EQ(ts, to_timestamp_int64(60));


### PR DESCRIPTION
When to_timestamp function gets a big value, the function returns an incorrect date due integer overflow:
- TO_TIMESTAMP(1626255099[INT32]) -> '1969-12-14 04:54:53.816'
 
The correct response would be:
- TO_TIMESTAMP(1626255099[INT32]) -> '2021-07-14 09:31:39'

The error is because we cast the integers to timestamp(int64) after multiplying the result for the total of millis.
It is necessary to change the order and convert it to int64 before multiplying by the number of seconds