### PR TITLE
ARROW-16744: [JavaScript] Fix yarn perf failure

### DIFF
--- a/js/tsconfig.json
+++ b/js/tsconfig.json
@@ -6,7 +6,7 @@
   },
   "compilerOptions": {
     "target": "ESNext",
-    "module": "NodeNext",
+    "module": "ESNext",
     "isolatedModules": true,
     "noEmit": true,
     "esModuleInterop": true,


### PR DESCRIPTION
This PR fixes this yarn perf failure:
```
yarn run v1.22.17
$ node --loader ts-node/esm/transpile-only ./perf/index.ts
(node:27902) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
ReferenceError: exports is not defined in ES module scope
    at file:///Users/elena/tmp/arrow/js/perf/index.ts:18:23
    at ModuleJob.run (internal/modules/esm/module_job.js:183:25)
    at async Loader.import (internal/modules/esm/loader.js:178:24)
    at async Object.loadESM (internal/process/esm_loader.js:68:5)
    at async handleMainPromise (internal/modules/run_main.js:59:12)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```