### PR TITLE
MINOR: [C++] [Docs] Fix TableSinkNodeOptions click-able visibility in docs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "cpp/submodules/parquet-testing"]
 	path = cpp/submodules/parquet-testing
 	url = https://github.com/apache/parquet-testing.git
+[submodule "testing"]
+	path = testing
+	url = https://github.com/apache/arrow-testing

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "cpp/submodules/parquet-testing"]
 	path = cpp/submodules/parquet-testing
 	url = https://github.com/apache/parquet-testing.git
-[submodule "testing"]
-	path = testing
-	url = https://github.com/apache/arrow-testing

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -398,7 +398,6 @@ class ARROW_EXPORT SelectKSinkNodeOptions : public SinkNodeOptions {
   /// SelectK options
   SelectKOptions select_k_options;
 };
-/// @}
 
 /// \brief Adapt a Table as a sink node
 ///
@@ -411,6 +410,8 @@ class ARROW_EXPORT TableSinkNodeOptions : public ExecNodeOptions {
 
   std::shared_ptr<Table>* output_table;
 };
+
+/// @}
 
 }  // namespace compute
 }  // namespace arrow


### PR DESCRIPTION
Adding minor doc change to include a click-able link to `TableSinkNodeOptions` in ACERO docs. 