### PR TITLE
ARROW-16726: [Python] Fix Setuptools warnings about installing packages as data

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -34,7 +34,7 @@ else:
     from distutils import sysconfig
 
 import pkg_resources
-from setuptools import setup, Extension, Distribution
+from setuptools import setup, Extension, Distribution, find_namespace_packages
 
 from Cython.Distutils import build_ext as _build_ext
 import Cython
@@ -613,9 +613,10 @@ else:
 
 
 if strtobool(os.environ.get('PYARROW_INSTALL_TESTS', '1')):
-    packages = ['pyarrow', 'pyarrow.tests']
+    packages = find_namespace_packages()
 else:
-    packages = ['pyarrow']
+    packages = find_namespace_packages()
+    packages.remove('pyarrow.tests')
 
 
 setup(

--- a/python/setup.py
+++ b/python/setup.py
@@ -613,10 +613,10 @@ else:
 
 
 if strtobool(os.environ.get('PYARROW_INSTALL_TESTS', '1')):
-    packages = find_namespace_packages()
+    packages = find_namespace_packages(include=['pyarrow*'])
 else:
-    packages = find_namespace_packages()
-    packages.remove('pyarrow.tests')
+    packages = find_namespace_packages(include=['pyarrow*'],
+                                       exclude=["pyarrow.tests*"])
 
 
 setup(


### PR DESCRIPTION
I have tested locally this change and the warning disappears on `archery docker run conda-python-docs` when using `find_namespace_packages` instead.
I have validated that the wheel generated is the same size locally before:
```
(pyarrow-dev) raulcd@drogon ~/code/arrow/python/dist (master)  $ ls -laht
total 142M
-rw-rw-r--  1 raulcd raulcd 142M jun  3 13:28 pyarrow-9.0.0.dev169+g5273c90.d20220603-cp310-cp310-linux_x86_64.whl
```
and after the change:
```
(pyarrow-dev) raulcd@drogon ~/code/arrow/python/dist (master)  $ ls -laht
total 142M
-rw-rw-r--  1 raulcd raulcd 142M jun  3 13:36 pyarrow-9.0.0.dev169+g5273c90.d20220603-cp310-cp310-linux_x86_64.whl
```