### PR TITLE
MINOR: [R] Drop opensuse42 build and update opensuse15

### DIFF
--- a/ci/etc/rprofile
+++ b/ci/etc/rprofile
@@ -2,7 +2,7 @@ local({
   .pick_cran <- function() {
     # Return a CRAN repo URL, preferring RSPM binaries if available for this OS
     rspm_template <- "https://packagemanager.rstudio.com/cran/__linux__/%s/latest"
-    supported_os <- c("focal", "xenial", "bionic", "centos7", "centos8", "opensuse42", "opensuse15", "opensuse152")
+    supported_os <- c("focal", "xenial", "bionic", "centos7", "centos8" "opensuse153")
 
     if (nzchar(Sys.which("lsb_release"))) {
       os <- tolower(system("lsb_release -cs", intern = TRUE))

--- a/ci/etc/rprofile
+++ b/ci/etc/rprofile
@@ -21,7 +21,7 @@ local({
         return(sprintf(rspm_template, os))
       } else {
         names(vals) <- sub("^(.*)=.*$", "\\1", os_release)
-        if (vals["ID"] == "opensuse") {
+        if (grepl("opensuse", vals["ID"])) {
           version <- sub('^"?([0-9]+)\\.?([0-9]+).*"?.*$', "\\1\\2", vals["VERSION_ID"])
           os <- paste0("opensuse", version)
           if (os %in% supported_os) {

--- a/ci/etc/rprofile
+++ b/ci/etc/rprofile
@@ -2,7 +2,9 @@ local({
   .pick_cran <- function() {
     # Return a CRAN repo URL, preferring RSPM binaries if available for this OS
     rspm_template <- "https://packagemanager.rstudio.com/cran/__linux__/%s/latest"
-    supported_os <- c("focal", "xenial", "bionic", "centos7", "centos8" "opensuse153")
+    # See https://github.com/rstudio/r-docker#releases-and-tags,
+    # but note that RSPM still uses "centos8"
+    supported_os <- c("bionic", "focal", "jammy", "centos7", "centos8", "opensuse153")
 
     if (nzchar(Sys.which("lsb_release"))) {
       os <- tolower(system("lsb_release -cs", intern = TRUE))
@@ -20,7 +22,7 @@ local({
       } else {
         names(vals) <- sub("^(.*)=.*$", "\\1", os_release)
         if (vals["ID"] == "opensuse") {
-          version <- sub('^"?([0-9]+).*"?.*$', "\\1", vals["VERSION_ID"])
+          version <- sub('^"?([0-9]+)\\.?([0-9]+).*"?.*$', "\\1\\2", vals["VERSION_ID"])
           os <- paste0("opensuse", version)
           if (os %in% supported_os) {
             return(sprintf(rspm_template, os))

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1331,8 +1331,7 @@ tasks:
 {% for r_org, r_image, r_tag in [("rhub", "ubuntu-gcc-release", "latest"),
                                  ("rocker", "r-base", "latest"),
                                  ("rstudio", "r-base", "4.2-focal"),
-                                 ("rstudio", "r-base", "4.1-opensuse15"),
-                                 ("rstudio", "r-base", "4.2-opensuse42")] %}
+                                 ("rstudio", "r-base", "4.1-opensuse153")] %}
   test-r-{{ r_org }}-{{ r_image }}-{{ r_tag }}:
     ci: azure
     template: r/azure.linux.yml


### PR DESCRIPTION
The opensuse42 job has been failing for a while on nightlies, and it is EOL and RSPM is no longer doing anything for it, so we should drop it. 