### PR TITLE
ARROW-16681: [Python] Fix doc for PyArrow unit tests dependant on module path

### DIFF
--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -58,7 +58,9 @@ like so:
 
 .. code-block::
 
-   $ python -m pytest arrow/python/pyarrow
+   $ pushd arrow/python
+   $ python -m pytest pyarrow
+   $ popd
 
 Package requirements to run the unit tests are found in
 ``requirements-test.txt`` and can be installed if needed with ``pip install -r


### PR DESCRIPTION
See [ARROW-16681](https://issues.apache.org/jira/browse/ARROW-16681) for details.