### PR TITLE
ARROW-16709: [Docs][Python] Add how to run doctests to the developer guide

### DIFF
--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -105,15 +105,8 @@ The test groups currently include:
 * ``s3``: Tests for Amazon S3
 * ``tensorflow``: Tests that involve TensorFlow
 
-Benchmarking
-------------
-
-For running the benchmarks, see :ref:`python-benchmarks`.
-
-.. _build_pyarrow:
-
 Doctest
-=======
+-------
 
 We are using `doctest <https://docs.python.org/3/library/doctest.html>`_
 to check that docstrings examples are up-to-date and correct. You can
@@ -137,6 +130,13 @@ for ``.py`` files or
 
 for ``.pyx`` and ``.pxi`` files. In this case you will also need to
 install `pytest-cython <https://github.com/lgpage/pytest-cython>`_ plugin.
+
+Benchmarking
+------------
+
+For running the benchmarks, see :ref:`python-benchmarks`.
+
+.. _build_pyarrow:
 
 Building on Linux and MacOS
 =============================

--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -109,7 +109,7 @@ Doctest
 -------
 
 We are using `doctest <https://docs.python.org/3/library/doctest.html>`_
-to check that docstrings examples are up-to-date and correct. You can
+to check that docstring examples are up-to-date and correct. You can
 also do that locally by running:
 
 .. code-block::
@@ -129,7 +129,7 @@ for ``.py`` files or
    $ popd
 
 for ``.pyx`` and ``.pxi`` files. In this case you will also need to
-install `pytest-cython <https://github.com/lgpage/pytest-cython>`_ plugin.
+install the `pytest-cython <https://github.com/lgpage/pytest-cython>`_ plugin.
 
 Benchmarking
 ------------

--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -115,8 +115,8 @@ also do that locally by running:
 .. code-block::
 
    $ pushd arrow/python
-   $ pytest --doctest-modules
-   $ pytest --doctest-modules path/to/module.py # checking single file
+   $ python -m pytest --doctest-modules
+   $ python -m pytest --doctest-modules path/to/module.py # checking single file
    $ popd
 
 for ``.py`` files or
@@ -124,8 +124,8 @@ for ``.py`` files or
 .. code-block::
 
    $ pushd arrow/python
-   $ pytest --doctest-cython
-   $ pytest --doctest-cython path/to/module.pyx # checking single file
+   $ python -m pytest --doctest-cython
+   $ python -m pytest --doctest-cython path/to/module.pyx # checking single file
    $ popd
 
 for ``.pyx`` and ``.pxi`` files. In this case you will also need to

--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -112,6 +112,32 @@ For running the benchmarks, see :ref:`python-benchmarks`.
 
 .. _build_pyarrow:
 
+Doctest
+=======
+
+We are using `doctest <https://docs.python.org/3/library/doctest.html>`_
+to check that docstrings examples are up-to-date and correct. You can
+also do that locally by running:
+
+.. code-block::
+
+   $ pushd arrow/python
+   $ pytest --doctest-modules
+   $ pytest --doctest-modules path/to/module.py # checking single file
+   $ popd
+
+for ``.py`` files or
+
+.. code-block::
+
+   $ pushd arrow/python
+   $ pytest --doctest-cython
+   $ pytest --doctest-cython path/to/module.pyx # checking single file
+   $ popd
+
+for ``.pyx`` and ``.pxi`` files. In this case you will also need to
+install `pytest-cython <https://github.com/lgpage/pytest-cython>`_ plugin.
+
 Building on Linux and MacOS
 =============================
 


### PR DESCRIPTION
This PR adds content to the documentation about running `doctest` on PyArrow docstring examples.