### PR TITLE
MINOR: [Python][CI] Fix Numpydoc check failure

### DIFF
--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -1650,7 +1650,6 @@ coerce_int96_timestamp_unit : str, default None.
     Cast timestamps that are stored in INT96 format to a particular resolution
     (e.g. 'ms'). Setting to None is equivalent to 'ns' and therefore INT96
     timestamps will be inferred as timestamps in nanoseconds.
-
 thrift_string_size_limit : int, default None
     If not None, override the maximum total string size allocated
     when decoding Thrift structures. The default limit should be

--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -1651,6 +1651,15 @@ coerce_int96_timestamp_unit : str, default None.
     (e.g. 'ms'). Setting to None is equivalent to 'ns' and therefore INT96
     timestamps will be inferred as timestamps in nanoseconds.
 
+thrift_string_size_limit : int, default None
+    If not None, override the maximum total string size allocated
+    when decoding Thrift structures. The default limit should be
+    sufficient for most Parquet files.
+thrift_container_size_limit : int, default None
+    If not None, override the maximum total size of containers allocated
+    when decoding Thrift structures. The default limit should be
+    sufficient for most Parquet files.
+
 Examples
 --------
 {2}


### PR DESCRIPTION
Fix CI failure introduced by ARROW-16546 (missing docstring for new parameters).