### PR TITLE
ARROW-14314: [C++] Sorting dictionary array not implemented

### DIFF
--- a/cpp/src/arrow/array/array_dict.h
+++ b/cpp/src/arrow/array/array_dict.h
@@ -111,6 +111,10 @@ class ARROW_EXPORT DictionaryArray : public Array {
 
   const DictionaryType* dict_type() const { return dict_type_; }
 
+  bool IsNull(int64_t i) const {
+    return indices_->IsNull(i) || dictionary_->IsNull(GetValueIndex(i));
+  }
+
  private:
   void SetData(const std::shared_ptr<ArrayData>& data);
   const DictionaryType* dict_type_;

--- a/cpp/src/arrow/array/array_dict.h
+++ b/cpp/src/arrow/array/array_dict.h
@@ -112,7 +112,7 @@ class ARROW_EXPORT DictionaryArray : public Array {
   const DictionaryType* dict_type() const { return dict_type_; }
 
   bool IsNull(int64_t i) const {
-    return indices_->IsNull(i) || dictionary_->IsNull(GetValueIndex(i));
+    return indices_->IsNull(i) || dictionary()->IsNull(GetValueIndex(i));
   }
 
  private:

--- a/cpp/src/arrow/compute/kernels/vector_array_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_array_sort.cc
@@ -215,6 +215,37 @@ class ArrayCompareSorter<DictionaryType> {
     }
   };
 
+  Result<std::shared_ptr<Array>> RanksWithNulls(const std::shared_ptr<Array>& array) {
+    // Notes:
+    // * The order is always ascending here, since the goal is to produce
+    //   an exactly-equivalent-order of the dictionary values.
+    // * We're going to re-emit nulls in the output, so we can just always consider
+    //   them "at the end".  Note that choosing AtStart would merely shift other
+    //   ranks by 1 if there are any nulls...
+    RankOptions rank_options(SortOrder::Ascending, NullPlacement::AtEnd,
+                             RankOptions::Dense);
+
+    // XXX Should this support Type::NA?
+    auto data = array->data();
+    std::shared_ptr<Buffer> null_bitmap;
+    if (array->null_count() > 0) {
+      null_bitmap = array->null_bitmap();
+      data = array->data()->Copy();
+      data->buffers[0] = nullptr;
+      data->null_count = 0;
+      DCHECK_EQ(data->offset, 0);  // FIXME
+    }
+    ARROW_ASSIGN_OR_RAISE(auto rank_datum, CallFunction("rank", {array}, &rank_options));
+    auto rank_data = rank_datum.array();
+    DCHECK_EQ(rank_data->GetNullCount(), 0);
+    // If there were nulls in the input, paste them in the output
+    if (null_bitmap) {
+      rank_data->buffers[0] = std::move(null_bitmap);
+      rank_data->null_count = array->null_count();
+    }
+    return MakeArray(rank_data);
+  }
+
  public:
   NullPartitionResult operator()(uint64_t* indices_begin, uint64_t* indices_end,
                                  const Array& array, int64_t offset,
@@ -222,32 +253,32 @@ class ArrayCompareSorter<DictionaryType> {
     const auto& dict_array = checked_cast<const DictionaryArray&>(array);
     const auto& dict_values = dict_array.dictionary();
     const auto& dict_indices = dict_array.indices();
-    const auto& index_type = dict_array.dict_type()->index_type();
 
-    NullPartitionResult p = PartitionNulls<DictionaryArray, StablePartitioner>(
-        indices_begin, indices_end, dict_array, offset, options.null_placement);
-
-    // TODO should be able to execute rank() with the caller's KernelContext
-    RankOptions rank_options(options.order, options.null_placement, RankOptions::Dense);
-    // FIXME propagate instead of aborting on error
-    auto rank =
-        CallFunction("rank", {dict_values}, &rank_options).ValueOrDie().make_array();
-    DCHECK_EQ(rank->null_count(), 0);
-
-    // TODO Instead, try to take the ranks with the dict indices,
-    // then run a sort on the results.  Since the ranks are dense,
-    // a much faster counting sort may be used.
+    // Algorithm:
+    // 1) Use the Rank function to get an exactly-equivalent-order array
+    //    of the dictionary values, but with a datatype that's friendlier to
+    //    sorting (uint64).
+    // 2) Act as if we were sorting a dictionary array with the same indices,
+    //    but with the ranks as dictionary values.
+    // 2a) Dictionary-decode the ranks by calling Take.
+    // 2b) Sort the decoded ranks. Not only those are uint64, they are dense
+    //     in a [0, k) range where k is the number of unique dictionary values.
+    //     Therefore, unless the dictionary is very large, a fast counting sort
+    //     will be used.
     //
-    // However, this will first require a rank() variant that emits null
-    // for null inputs (instead of assigning them a non-null rank number).
+    // The bottom line is that performance will usually be much better
+    // (potentially an order of magnitude faster) than by naively decoding
+    // the original dictionary and sorting the decoded version.
 
-    const auto& rank_array = checked_cast<const UInt64Array&>(*rank);
-    DictionaryInternal visitor = {&p, dict_indices, rank_array, options, offset};
-    visitor.Sort(index_type);
+    // FIXME Should be able to use the caller's KernelContext for rank() and take()
 
-    // FIXME this is not correct, as it doesn't account for nulls in the
-    // dictionary values.
-    return p;
+    // FIXME Propagate errors instead of aborting
+    auto ranks = *RanksWithNulls(dict_values);
+
+    auto decoded_ranks = *Take(*ranks, *dict_indices);
+
+    auto rank_sorter = *GetArraySorter(*decoded_ranks->type() /* should be uint64 */);
+    return rank_sorter(indices_begin, indices_end, *decoded_ranks, offset, options);
   }
 };
 

--- a/cpp/src/arrow/compute/kernels/vector_array_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_array_sort.cc
@@ -199,6 +199,8 @@ class ArrayCompareSorter<DictionaryType> {
     // (potentially an order of magnitude faster) than by naively decoding
     // the original dictionary and sorting the decoded version.
 
+    // TODO special-case all-nulls arrays to avoid ranking and decoding them?
+
     // FIXME Should be able to use the caller's KernelContext for rank() and take()
 
     // FIXME Propagate errors instead of aborting

--- a/cpp/src/arrow/compute/kernels/vector_array_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_array_sort.cc
@@ -181,7 +181,7 @@ class ArrayCompareSorter<DictionaryType> {
                                  const ArraySortOptions& options) {
     const auto& dict_array = checked_cast<const DictionaryArray&>(array);
 
-    const auto& indices = checked_cast<const UInt64Array&>(*(dict_array.indices()));
+    const auto& indices = dict_array.indices();
     const auto& values = dict_array.dictionary();
 
     const auto p = PartitionNulls<DictionaryArray, StablePartitioner>(
@@ -209,9 +209,9 @@ class ArrayCompareSorter<DictionaryType> {
         p.non_nulls_begin, p.non_nulls_end,
         [&indices, &sort_order, &offset](uint64_t left, uint64_t right) {
           const auto lhs =
-              GetViewType<UInt64Type>::LogicalValue(indices.GetView(left - offset));
+              std::stoull(indices->GetScalar(left - offset).ValueOrDie()->ToString());
           const auto rhs =
-              GetViewType<UInt64Type>::LogicalValue(indices.GetView(right - offset));
+              std::stoull(indices->GetScalar(right - offset).ValueOrDie()->ToString());
           return sort_order[lhs] < sort_order[rhs];
         });
 

--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -374,8 +374,8 @@ class ConcreteRecordBatchColumnSorter : public RecordBatchColumnSorter {
     } else {
       // NOTE that null_count_ is merely an upper bound on the number of nulls
       // in this particular range.
-      p = PartitionNullsOnly<StablePartitioner>(indices_begin, indices_end, array_,
-                                                offset, null_placement_);
+      p = PartitionNullsOnly<ArrayType, StablePartitioner>(
+          indices_begin, indices_end, array_, offset, null_placement_);
       DCHECK_LE(p.nulls_end - p.nulls_begin, null_count_);
     }
     const NullPartitionResult q = PartitionNullLikes<ArrayType, StablePartitioner>(
@@ -797,8 +797,8 @@ class MultipleKeyRecordBatchSorter : public TypeVisitor {
     using ArrayType = typename TypeTraits<Type>::ArrayType;
     const ArrayType& array = checked_cast<const ArrayType&>(first_sort_key.array);
 
-    const auto p = PartitionNullsOnly<StablePartitioner>(indices_begin_, indices_end_,
-                                                         array, 0, null_placement_);
+    const auto p = PartitionNullsOnly<ArrayType, StablePartitioner>(
+        indices_begin_, indices_end_, array, 0, null_placement_);
     const auto q = PartitionNullLikes<ArrayType, StablePartitioner>(
         p.non_nulls_begin, p.non_nulls_end, array, 0, null_placement_);
 

--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -201,7 +201,7 @@ class ChunkedArraySorter : public TypeVisitor {
 
     // Sort each chunk independently and merge to sorted indices.
     // This is a serial implementation.
-    std::vector<NullPartitionResult> sorted(num_chunks);
+    std::vector<Result<NullPartitionResult>> sorted(num_chunks);
 
     // First sort all individual chunks
     int64_t begin_offset = 0;
@@ -244,8 +244,8 @@ class ChunkedArraySorter : public TypeVisitor {
         auto out_it = sorted.begin();
         auto it = sorted.begin();
         while (it < sorted.end() - 1) {
-          const auto& left = *it++;
-          const auto& right = *it++;
+          ARROW_ASSIGN_OR_RAISE(const auto& left, *it++);
+          ARROW_ASSIGN_OR_RAISE(const auto& right, *it++);
           DCHECK_EQ(left.overall_end(), right.overall_begin());
           const auto merged = merge_impl.Merge(left, right, null_count);
           *out_it++ = merged;
@@ -258,10 +258,11 @@ class ChunkedArraySorter : public TypeVisitor {
     }
 
     DCHECK_EQ(sorted.size(), 1);
-    DCHECK_EQ(sorted[0].overall_begin(), indices_begin_);
-    DCHECK_EQ(sorted[0].overall_end(), indices_end_);
+    ARROW_ASSIGN_OR_RAISE(auto sorted_arr, sorted[0]);
+    DCHECK_EQ(sorted_arr.overall_begin(), indices_begin_);
+    DCHECK_EQ(sorted_arr.overall_end(), indices_end_);
     // Note that "nulls" can also include NaNs, hence the >= check
-    DCHECK_GE(sorted[0].null_count(), null_count);
+    DCHECK_GE(sorted_arr.null_count(), null_count);
 
     return Status::OK();
   }
@@ -1957,9 +1958,8 @@ class ArrayRanker : public TypeVisitor {
     std::iota(sort_begin, sort_end, 0);
 
     ARROW_ASSIGN_OR_RAISE(auto array_sorter, GetArraySorter(*physical_type_));
-
-    NullPartitionResult sorted =
-        array_sorter(sort_begin, sort_end, arr, 0, array_options);
+    ARROW_ASSIGN_OR_RAISE(auto sorted,
+                          array_sorter(sort_begin, sort_end, arr, 0, array_options));
     uint64_t rank;
 
     ARROW_ASSIGN_OR_RAISE(auto rankings,

--- a/cpp/src/arrow/compute/kernels/vector_sort_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_benchmark.cc
@@ -27,7 +27,9 @@
 
 namespace arrow {
 namespace compute {
+
 constexpr auto kSeed = 0x0ff1ce;
+constexpr int32_t kDictionarySize = 20;  // a typical dictionary size
 
 static void ArraySortIndicesBenchmark(benchmark::State& state,
                                       const std::shared_ptr<Array>& values) {
@@ -61,20 +63,20 @@ static void ArraySortIndicesInt64DictBenchmark(benchmark::State& state, int64_t 
   RegressionArgs args(state);
 
   const int64_t array_size = args.size / sizeof(int64_t);
-  const int32_t dict_values_size = 20;  // a typical dictionary size
 
   auto rand = random::RandomArrayGenerator(kSeed);
-  auto dict_values = rand.Int64(dict_values_size, min, max, args.null_proportion / 2);
+  auto dict_values = rand.Int64(kDictionarySize, min, max, args.null_proportion / 2);
   auto dict_indices =
-      rand.Int64(array_size, 0, dict_values_size - 1, args.null_proportion / 2);
+      rand.Int64(array_size, 0, kDictionarySize - 1, args.null_proportion / 2);
   auto dict_array = *DictionaryArray::FromArrays(dict_indices, dict_values);
 
   ArraySortIndicesBenchmark(state, dict_array);
 }
 
 static void ArraySortIndicesStringsBenchmark(benchmark::State& state) {
-  RegressionArgs args(state);
+  RegressionArgs args(state, /*size_is_bytes=*/false);
 
+  // XXX This division to make numbers comparable with ArraySortIndicesInt64Benchmark
   const int64_t array_size = args.size / sizeof(int64_t);
   auto rand = random::RandomArrayGenerator(kSeed);
   auto values =
@@ -84,16 +86,16 @@ static void ArraySortIndicesStringsBenchmark(benchmark::State& state) {
 }
 
 static void ArraySortIndicesStringsDictBenchmark(benchmark::State& state) {
-  RegressionArgs args(state);
+  RegressionArgs args(state, /*size_is_bytes=*/false);
 
+  // XXX Same as in ArraySortIndicesStringsBenchmark above
   const int64_t array_size = args.size / sizeof(int64_t);
-  const int32_t dict_values_size = 20;  // a typical dictionary size
 
   auto rand = random::RandomArrayGenerator(kSeed);
-  auto dict_values = rand.String(dict_values_size, /*min_length=*/3, /*max_length=*/25,
+  auto dict_values = rand.String(kDictionarySize, /*min_length=*/3, /*max_length=*/25,
                                  args.null_proportion / 2);
   auto dict_indices =
-      rand.Int64(array_size, 0, dict_values_size - 1, args.null_proportion / 2);
+      rand.Int64(array_size, 0, kDictionarySize - 1, args.null_proportion / 2);
   auto dict_array = *DictionaryArray::FromArrays(dict_indices, dict_values);
 
   ArraySortIndicesBenchmark(state, dict_array);

--- a/cpp/src/arrow/compute/kernels/vector_sort_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_benchmark.cc
@@ -36,6 +36,8 @@ static void ArraySortIndicesBenchmark(benchmark::State& state,
   for (auto _ : state) {
     ABORT_NOT_OK(SortIndices(*values).status());
   }
+  // This may be redundant with the SetItemsProcessed() call in RegressionArgs,
+  // if size_is_bytes was false.
   state.SetItemsProcessed(state.iterations() * values->length());
 }
 
@@ -75,9 +77,11 @@ static void ArraySortIndicesInt64DictBenchmark(benchmark::State& state, int64_t 
 
 static void ArraySortIndicesStringsBenchmark(benchmark::State& state) {
   RegressionArgs args(state, /*size_is_bytes=*/false);
-
   // XXX This division to make numbers comparable with ArraySortIndicesInt64Benchmark
-  const int64_t array_size = args.size / sizeof(int64_t);
+  // (including the SetItemsProcessed() call in the RegressionArgs destructor)
+  args.size /= sizeof(int64_t);
+
+  const int64_t array_size = args.size;
   auto rand = random::RandomArrayGenerator(kSeed);
   auto values =
       rand.String(array_size, /*min_length=*/3, /*max_length=*/25, args.null_proportion);
@@ -87,10 +91,10 @@ static void ArraySortIndicesStringsBenchmark(benchmark::State& state) {
 
 static void ArraySortIndicesStringsDictBenchmark(benchmark::State& state) {
   RegressionArgs args(state, /*size_is_bytes=*/false);
-
   // XXX Same as in ArraySortIndicesStringsBenchmark above
-  const int64_t array_size = args.size / sizeof(int64_t);
+  args.size /= sizeof(int64_t);
 
+  const int64_t array_size = args.size;
   auto rand = random::RandomArrayGenerator(kSeed);
   auto dict_values = rand.String(kDictionarySize, /*min_length=*/3, /*max_length=*/25,
                                  args.null_proportion / 2);

--- a/cpp/src/arrow/compute/kernels/vector_sort_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_benchmark.cc
@@ -56,6 +56,49 @@ static void ArraySortIndicesInt64Benchmark(benchmark::State& state, int64_t min,
   ArraySortIndicesBenchmark(state, values);
 }
 
+static void ArraySortIndicesInt64DictBenchmark(benchmark::State& state, int64_t min,
+                                               int64_t max) {
+  RegressionArgs args(state);
+
+  const int64_t array_size = args.size / sizeof(int64_t);
+  const int32_t dict_values_size = 20;  // a typical dictionary size
+
+  auto rand = random::RandomArrayGenerator(kSeed);
+  auto dict_values = rand.Int64(dict_values_size, min, max, args.null_proportion / 2);
+  auto dict_indices =
+      rand.Int64(array_size, 0, dict_values_size - 1, args.null_proportion / 2);
+  auto dict_array = *DictionaryArray::FromArrays(dict_indices, dict_values);
+
+  ArraySortIndicesBenchmark(state, dict_array);
+}
+
+static void ArraySortIndicesStringsBenchmark(benchmark::State& state) {
+  RegressionArgs args(state);
+
+  const int64_t array_size = args.size / sizeof(int64_t);
+  auto rand = random::RandomArrayGenerator(kSeed);
+  auto values =
+      rand.String(array_size, /*min_length=*/3, /*max_length=*/25, args.null_proportion);
+
+  ArraySortIndicesBenchmark(state, values);
+}
+
+static void ArraySortIndicesStringsDictBenchmark(benchmark::State& state) {
+  RegressionArgs args(state);
+
+  const int64_t array_size = args.size / sizeof(int64_t);
+  const int32_t dict_values_size = 20;  // a typical dictionary size
+
+  auto rand = random::RandomArrayGenerator(kSeed);
+  auto dict_values = rand.String(dict_values_size, /*min_length=*/3, /*max_length=*/25,
+                                 args.null_proportion / 2);
+  auto dict_indices =
+      rand.Int64(array_size, 0, dict_values_size - 1, args.null_proportion / 2);
+  auto dict_array = *DictionaryArray::FromArrays(dict_indices, dict_values);
+
+  ArraySortIndicesBenchmark(state, dict_array);
+}
+
 static void ChunkedArraySortIndicesInt64Benchmark(benchmark::State& state, int64_t min,
                                                   int64_t max) {
   RegressionArgs args(state);
@@ -79,6 +122,20 @@ static void ArraySortIndicesInt64Wide(benchmark::State& state) {
   const auto min = std::numeric_limits<int64_t>::min();
   const auto max = std::numeric_limits<int64_t>::max();
   ArraySortIndicesInt64Benchmark(state, min, max);
+}
+
+static void ArraySortIndicesInt64Dict(benchmark::State& state) {
+  const auto min = std::numeric_limits<int64_t>::min();
+  const auto max = std::numeric_limits<int64_t>::max();
+  ArraySortIndicesInt64DictBenchmark(state, min, max);
+}
+
+static void ArraySortIndicesStrings(benchmark::State& state) {
+  ArraySortIndicesStringsBenchmark(state);
+}
+
+static void ArraySortIndicesStringsDict(benchmark::State& state) {
+  ArraySortIndicesStringsDictBenchmark(state);
 }
 
 static void ArraySortIndicesBool(benchmark::State& state) {
@@ -244,6 +301,24 @@ BENCHMARK(ArraySortIndicesInt64Narrow)
     ->Unit(benchmark::TimeUnit::kNanosecond);
 
 BENCHMARK(ArraySortIndicesInt64Wide)
+    ->Apply(RegressionSetArgs)
+    ->Args({1 << 20, 100})
+    ->Args({1 << 23, 100})
+    ->Unit(benchmark::TimeUnit::kNanosecond);
+
+BENCHMARK(ArraySortIndicesInt64Dict)
+    ->Apply(RegressionSetArgs)
+    ->Args({1 << 20, 100})
+    ->Args({1 << 23, 100})
+    ->Unit(benchmark::TimeUnit::kNanosecond);
+
+BENCHMARK(ArraySortIndicesStrings)
+    ->Apply(RegressionSetArgs)
+    ->Args({1 << 20, 100})
+    ->Args({1 << 23, 100})
+    ->Unit(benchmark::TimeUnit::kNanosecond);
+
+BENCHMARK(ArraySortIndicesStringsDict)
     ->Apply(RegressionSetArgs)
     ->Args({1 << 20, 100})
     ->Args({1 << 23, 100})

--- a/cpp/src/arrow/compute/kernels/vector_sort_internal.h
+++ b/cpp/src/arrow/compute/kernels/vector_sort_internal.h
@@ -191,9 +191,9 @@ struct NullPartitionResult {
 // Move nulls (not null-like values) to end of array.
 //
 // `offset` is used when this is called on a chunk of a chunked array
-template <typename Partitioner>
+template <typename ArrayType, typename Partitioner>
 NullPartitionResult PartitionNullsOnly(uint64_t* indices_begin, uint64_t* indices_end,
-                                       const Array& values, int64_t offset,
+                                       const ArrayType& values, int64_t offset,
                                        NullPlacement null_placement) {
   if (values.null_count() == 0) {
     return NullPartitionResult::NoNulls(indices_begin, indices_end, null_placement);
@@ -254,8 +254,8 @@ NullPartitionResult PartitionNulls(uint64_t* indices_begin, uint64_t* indices_en
                                    const ArrayType& values, int64_t offset,
                                    NullPlacement null_placement) {
   // Partition nulls at start (resp. end), and null-like values just before (resp. after)
-  NullPartitionResult p = PartitionNullsOnly<Partitioner>(indices_begin, indices_end,
-                                                          values, offset, null_placement);
+  NullPartitionResult p = PartitionNullsOnly<ArrayType, Partitioner>(
+      indices_begin, indices_end, values, offset, null_placement);
   NullPartitionResult q = PartitionNullLikes<ArrayType, Partitioner>(
       p.non_nulls_begin, p.non_nulls_end, values, offset, null_placement);
   return NullPartitionResult{q.non_nulls_begin, q.non_nulls_end,

--- a/cpp/src/arrow/compute/kernels/vector_sort_internal.h
+++ b/cpp/src/arrow/compute/kernels/vector_sort_internal.h
@@ -446,7 +446,7 @@ struct MergeImpl {
 // TODO make this usable if indices are non trivial on input
 // (see ConcreteRecordBatchColumnSorter)
 // `offset` is used when this is called on a chunk of a chunked array
-using ArraySortFunc = std::function<Result<NullPartitionResult>(
+using ArraySortFunc = std::function<NullPartitionResult(
     uint64_t* indices_begin, uint64_t* indices_end, const Array& values, int64_t offset,
     const ArraySortOptions& options)>;
 

--- a/cpp/src/arrow/compute/kernels/vector_sort_internal.h
+++ b/cpp/src/arrow/compute/kernels/vector_sort_internal.h
@@ -446,7 +446,7 @@ struct MergeImpl {
 // TODO make this usable if indices are non trivial on input
 // (see ConcreteRecordBatchColumnSorter)
 // `offset` is used when this is called on a chunk of a chunked array
-using ArraySortFunc = std::function<NullPartitionResult(
+using ArraySortFunc = std::function<Result<NullPartitionResult>(
     uint64_t* indices_begin, uint64_t* indices_end, const Array& values, int64_t offset,
     const ArraySortOptions& options)>;
 

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -352,6 +352,17 @@ TEST(ArraySortIndicesFunction, Array) {
   expected = ArrayFromJSON(uint64(), "[2, 4, 6, 1, 0, 3, 5]");
   ASSERT_OK_AND_ASSIGN(actual, CallFunction("array_sort_indices", {arr}, &options));
   AssertDatumsEqual(expected, actual, /*verbose=*/true);
+
+  // Dictionary Array
+  auto dict_arr = DictArrayFromJSON(dictionary(uint64(), utf8()), "[0, null, 1, 0, 2, 3]",
+                                    "[ \"b\", null, \"c\", \"a\"]");
+  expected = ArrayFromJSON(uint64(), "[5, 0, 3, 4, 1, 2]");
+  ASSERT_OK_AND_ASSIGN(actual, CallFunction("array_sort_indices", {dict_arr}));
+  AssertDatumsEqual(expected, actual, /*verbose=*/true);
+
+  expected = ArrayFromJSON(uint64(), "[1, 2, 4, 0, 3, 5]");
+  ASSERT_OK_AND_ASSIGN(actual, CallFunction("array_sort_indices", {dict_arr}, &options));
+  AssertDatumsEqual(expected, actual, /*verbose=*/true);
 }
 
 TEST(ArraySortIndicesFunction, ChunkedArray) {

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -355,7 +355,9 @@ TEST(ArraySortIndicesFunction, Array) {
 }
 
 TEST(ArraySortIndicesFunction, DictionaryArray) {
-  // Dictionary Array (["b", null, null, null, "b", "c", "a"])
+  // Decoded dictionary array:
+  // (["b", "c", null, null, null, "b", "c", "c", "a"])
+
   std::vector<std::string> expected_str = {
       "[8, 0, 5, 1, 6, 7, 2, 3, 4]",  // SortOrder::Ascending NullPlacement::AtEnd
       "[2, 3, 4, 8, 0, 5, 1, 6, 7]",  // SortOrder::Ascending NullPlacement::AtStart
@@ -363,7 +365,8 @@ TEST(ArraySortIndicesFunction, DictionaryArray) {
       "[2, 3, 4, 1, 6, 7, 0, 5, 8]"   // SortOrder::Descending NullPlacement::AtStart
   };
 
-  for (auto index_type : {uint8(), uint16(), uint32(), uint64()}) {
+  for (auto index_type : all_dictionary_index_types()) {
+    ARROW_SCOPED_TRACE("index_type = ", index_type->ToString());
     int i = 0;
     auto dict_arr = DictArrayFromJSON(dictionary(index_type, utf8()),
                                       "[0, 4, null, 1, null, 0, 4, 2, 3]",
@@ -374,8 +377,47 @@ TEST(ArraySortIndicesFunction, DictionaryArray) {
         auto expected = ArrayFromJSON(uint64(), expected_str[i++]);
         ASSERT_OK_AND_ASSIGN(auto actual,
                              CallFunction("array_sort_indices", {dict_arr}, &options));
+        ValidateOutput(actual);
         AssertDatumsEqual(expected, actual, /*verbose=*/true);
       }
+    }
+  }
+}
+
+Result<std::shared_ptr<Array>> DecodeDictionary(const Array& array) {
+  const auto& dict_array = checked_cast<const DictionaryArray&>(array);
+  ARROW_ASSIGN_OR_RAISE(auto decoded_datum,
+                        Take(dict_array.dictionary(), dict_array.indices()));
+  return decoded_datum.make_array();
+}
+
+TEST(ArraySortIndicesFunction, RandomDictionaryArray) {
+  ::arrow::random::RandomArrayGenerator rng(/*seed=*/1234);
+  constexpr int64_t kLength = 200;
+  constexpr int64_t kDictLength = 20;
+
+  // Ensure there are duplicates in the dictionary and the indices,
+  // and nulls in both as well.
+  auto dict_values = rng.StringWithRepeats(kDictLength, /*unique=*/kDictLength / 2,
+                                           /*min_length=*/1, /*max_length=*/10,
+                                           /*null_probability=*/0.2);
+  auto dict_indices = rng.Int64(kLength, 0, kDictLength - 1, /*null_probability = */ 0.2);
+  ASSERT_OK_AND_ASSIGN(auto dict_array,
+                       DictionaryArray::FromArrays(dict_indices, dict_values));
+  ASSERT_OK_AND_ASSIGN(auto decoded, DecodeDictionary(*dict_array));
+
+  for (auto order : AllOrders()) {
+    for (auto null_placement : AllNullPlacements()) {
+      ArraySortOptions options{order, null_placement};
+      // Sorting the dictionary array...
+      ASSERT_OK_AND_ASSIGN(auto actual,
+                           CallFunction("array_sort_indices", {dict_array}, &options));
+      ValidateOutput(actual);
+
+      // should give identical results to sorting the decoded array
+      ASSERT_OK_AND_ASSIGN(auto expected,
+                           CallFunction("array_sort_indices", {decoded}, &options));
+      AssertDatumsEqual(expected, actual, /*verbose=*/true);
     }
   }
 }

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -373,6 +373,7 @@ TEST(ArraySortIndicesFunction, DictionaryArray) {
                                       "[ \"b\", null, \"c\", \"a\", \"c\"]");
     for (auto order : AllOrders()) {
       for (auto null_placement : AllNullPlacements()) {
+        ARROW_SCOPED_TRACE("i = ", i);
         ArraySortOptions options{order, null_placement};
         auto expected = ArrayFromJSON(uint64(), expected_str[i++]);
         ASSERT_OK_AND_ASSIGN(auto actual,

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -421,6 +421,8 @@ TEST(ArraySortIndicesFunction, RandomDictionaryArray) {
       AssertDatumsEqual(expected, actual, /*verbose=*/true);
     }
   }
+
+  // TODO test with sliced dict indices and values...
 }
 
 TEST(ArraySortIndicesFunction, ChunkedArray) {

--- a/cpp/src/arrow/util/benchmark_util.h
+++ b/cpp/src/arrow/util/benchmark_util.h
@@ -104,7 +104,7 @@ void RegressionSetArgs(benchmark::internal::Benchmark* bench) {
 // RAII struct to handle some of the boilerplate in regression benchmarks
 struct RegressionArgs {
   // size of memory tested (per iteration) in bytes
-  const int64_t size;
+  int64_t size;
 
   // proportion of nulls in generated arrays
   double null_proportion;


### PR DESCRIPTION
Sort dictionary array

Implementation:

- Split nulls and non nulls values
- Get sorted indices array of dictionary values
- Assign new indices to each different dictionary value 
- Sort non nulls values based on previously obtained indices