### PR TITLE
ARROW-16783: [R] Explicit check for supported classes in arrow_dplyr_query

### DIFF
--- a/r/R/dataset-write.R
+++ b/r/R/dataset-write.R
@@ -143,21 +143,7 @@ write_dataset <- function(dataset,
       # now to construct `partitioning` and don't want it in the metadata$r
       dataset <- dplyr::ungroup(dataset)
     }
-    dataset <- tryCatch(
-      as_adq(dataset),
-      error = function(e) {
-        supported <- c(
-          "Dataset", "RecordBatch", "Table", "arrow_dplyr_query", "data.frame"
-        )
-        stop(
-          "'dataset' must be a ",
-          oxford_paste(supported, "or", quote = FALSE),
-          ", not ",
-          deparse(class(dataset)),
-          call. = FALSE
-        )
-      }
-    )
+    dataset <- as_adq(dataset)
   }
 
   plan <- ExecPlan$create()

--- a/r/R/dplyr.R
+++ b/r/R/dplyr.R
@@ -31,9 +31,9 @@ arrow_dplyr_query <- function(.data) {
   )
   if (!inherits(.data, supported)) {
     stop(
-      "'dataset' must be a ",
+      "You must supply a ",
       oxford_paste(supported, "or", quote = FALSE),
-      ", not ",
+      ", not an object of type ",
       deparse(class(.data)),
       call. = FALSE
     )

--- a/r/R/dplyr.R
+++ b/r/R/dplyr.R
@@ -53,7 +53,7 @@ arrow_dplyr_query <- function(.data) {
   dupes <- duplicated(names(.data))
   if (any(dupes)) {
     abort(c(
-      "Duplicated field names",
+      "Field names must be unique.",
       x = paste0(
         "The following field names were found more than once in the data: ",
         oxford_paste(names(.data)[dupes])

--- a/r/R/dplyr.R
+++ b/r/R/dplyr.R
@@ -24,6 +24,21 @@ arrow_dplyr_query <- function(.data) {
   # RecordBatch, or Dataset) and the state of the user's dplyr query--things
   # like selected columns, filters, and group vars.
   # An arrow_dplyr_query can contain another arrow_dplyr_query in .data
+
+  supported <- c(
+    "Dataset", "RecordBatch", "RecordBatchReader",
+    "Table", "arrow_dplyr_query", "data.frame"
+  )
+  if (!inherits(.data, supported)) {
+    stop(
+      "'dataset' must be a ",
+      oxford_paste(supported, "or", quote = FALSE),
+      ", not ",
+      deparse(class(.data)),
+      call. = FALSE
+    )
+  }
+
   gv <- tryCatch(
     # If dplyr is not available, or if the input doesn't have a group_vars
     # method, assume no group vars

--- a/r/tests/testthat/test-dataset-write.R
+++ b/r/tests/testthat/test-dataset-write.R
@@ -459,7 +459,7 @@ test_that("Dataset writing: unsupported features/input validation", {
   skip_if_not_available("parquet")
   expect_error(write_dataset(4), "'dataset' must be a Dataset, ")
   expect_error(write_dataset(data.frame(x = 1, x = 2, check.names = FALSE)),
-               "Duplicated field names")
+               "Field names must be unique")
 
   ds <- open_dataset(hive_dir)
   expect_error(

--- a/r/tests/testthat/test-dataset-write.R
+++ b/r/tests/testthat/test-dataset-write.R
@@ -458,6 +458,8 @@ test_that("Writing a dataset: CSV format options", {
 test_that("Dataset writing: unsupported features/input validation", {
   skip_if_not_available("parquet")
   expect_error(write_dataset(4), "'dataset' must be a Dataset, ")
+  expect_error(write_dataset(data.frame(x = 1, x = 2, check.names = FALSE)),
+               "Duplicated field names")
 
   ds <- open_dataset(hive_dir)
   expect_error(

--- a/r/tests/testthat/test-dataset-write.R
+++ b/r/tests/testthat/test-dataset-write.R
@@ -457,7 +457,7 @@ test_that("Writing a dataset: CSV format options", {
 
 test_that("Dataset writing: unsupported features/input validation", {
   skip_if_not_available("parquet")
-  expect_error(write_dataset(4), "'dataset' must be a Dataset, ")
+  expect_error(write_dataset(4), "You must supply a")
   expect_error(write_dataset(data.frame(x = 1, x = 2, check.names = FALSE)),
                "Field names must be unique")
 


### PR DESCRIPTION
Check for supported classes in `arrow_dplyr_query` rather than via `tryCatch()` in `write_dataset()`

I also added `RecordBatchReader` to the list of supported classes, since `as_adq()` can be called on `RecordBatchReaders` (e.g., https://github.com/apache/arrow/blob/0d5cf1882228624271062e6c19583c8b0c361a20/r/tests/testthat/test-dataset.R#L1000), and `write_dataset()` also works on `RecordBatchReader`s.

Addresses https://issues.apache.org/jira/browse/ARROW-16783