### PR TITLE
ARROW-16780: [CI] Add automatic PR label for docs PRs

### DIFF
--- a/.github/workflows/dev_pr/labeler.yml
+++ b/.github/workflows/dev_pr/labeler.yml
@@ -61,3 +61,7 @@ parquet:
   - cpp/src/parquet/**/*
   - r/R/parquet.*
   - ruby/red-parquet/**/*
+
+docs:
+  - docs/**/*
+  - **/*.{md, rst, Rmd, Rd}


### PR DESCRIPTION
AFAIK the `docs` label needs to be created manually for this to work.
I added the files extensions that I know are used for documentation, to add the docs label in addition to a language label and not only for changes in `docs/`. 

@pitrou could you have a look?