### PR TITLE
ARROW-16382: [Python] Disable memory mapping by default in pyarrow

### DIFF
--- a/python/pyarrow/_orc.pyx
+++ b/python/pyarrow/_orc.pyx
@@ -246,7 +246,7 @@ cdef class ORCReader(_Weakrefable):
     def __cinit__(self, MemoryPool memory_pool=None):
         self.allocator = maybe_unbox_memory_pool(memory_pool)
 
-    def open(self, object source, c_bool use_memory_map=True):
+    def open(self, object source, c_bool use_memory_map=False):
         cdef:
             shared_ptr[CRandomAccessFile] rd_handle
 

--- a/python/pyarrow/_orc.pyx
+++ b/python/pyarrow/_orc.pyx
@@ -246,7 +246,7 @@ cdef class ORCReader(_Weakrefable):
     def __cinit__(self, MemoryPool memory_pool=None):
         self.allocator = maybe_unbox_memory_pool(memory_pool)
 
-    def open(self, object source, c_bool use_memory_map=False):
+    def open(self, object source, c_bool use_memory_map=True):
         cdef:
             shared_ptr[CRandomAccessFile] rd_handle
 

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -1167,7 +1167,7 @@ cdef class ParquetReader(_Weakrefable):
         self.pool = maybe_unbox_memory_pool(memory_pool)
         self._metadata = None
 
-    def open(self, object source not None, *, bint use_memory_map=True,
+    def open(self, object source not None, *, bint use_memory_map=False,
              read_dictionary=None, FileMetaData metadata=None,
              int buffer_size=0, bint pre_buffer=False,
              coerce_int96_timestamp_unit=None,

--- a/python/pyarrow/feather.py
+++ b/python/pyarrow/feather.py
@@ -204,7 +204,7 @@ def write_feather(df, dest, compression=None, compression_level=None,
         raise
 
 
-def read_feather(source, columns=None, use_threads=True, memory_map=True):
+def read_feather(source, columns=None, use_threads=True, memory_map=False):
     """
     Read a pandas.DataFrame from Feather format. To read as pyarrow.Table use
     feather.read_table.
@@ -219,7 +219,7 @@ def read_feather(source, columns=None, use_threads=True, memory_map=True):
         Whether to parallelize reading using multiple threads. If false the
         restriction is used in the conversion to Pandas as well as in the
         reading from Feather format.
-    memory_map : boolean, default True
+    memory_map : boolean, default False
         Use memory mapping when opening file on disk
 
     Returns
@@ -232,7 +232,7 @@ def read_feather(source, columns=None, use_threads=True, memory_map=True):
         use_threads=use_threads).to_pandas(use_threads=use_threads))
 
 
-def read_table(source, columns=None, memory_map=True, use_threads=True):
+def read_table(source, columns=None, memory_map=False, use_threads=True):
     """
     Read a pyarrow.Table from Feather format
 
@@ -242,7 +242,7 @@ def read_table(source, columns=None, memory_map=True, use_threads=True):
     columns : sequence, optional
         Only read a specific set of columns. If not provided, all columns are
         read.
-    memory_map : boolean, default True
+    memory_map : boolean, default False
         Use memory mapping when opening file on disk
     use_threads : bool, default True
         Whether to parallelize reading using multiple threads.

--- a/python/pyarrow/feather.py
+++ b/python/pyarrow/feather.py
@@ -212,6 +212,7 @@ def read_feather(source, columns=None, use_threads=True, memory_map=False):
     Parameters
     ----------
     source : str file path, or file-like object
+        You can use MemoryMappedFile as source, for explicitly use memory map.
     columns : sequence, optional
         Only read a specific set of columns. If not provided, all columns are
         read.
@@ -220,7 +221,7 @@ def read_feather(source, columns=None, use_threads=True, memory_map=False):
         restriction is used in the conversion to Pandas as well as in the
         reading from Feather format.
     memory_map : boolean, default False
-        Use memory mapping when opening file on disk
+        Use memory mapping when opening file on disk, when source is a str.
 
     Returns
     -------
@@ -239,11 +240,12 @@ def read_table(source, columns=None, memory_map=False, use_threads=True):
     Parameters
     ----------
     source : str file path, or file-like object
+        You can use MemoryMappedFile as source, for explicitly use memory map.
     columns : sequence, optional
         Only read a specific set of columns. If not provided, all columns are
         read.
     memory_map : boolean, default False
-        Use memory mapping when opening file on disk
+        Use memory mapping when opening file on disk, when source is a str
     use_threads : bool, default True
         Whether to parallelize reading using multiple threads.
 

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -399,23 +399,22 @@ cdef class MessageReader(_Weakrefable):
                         "instead.".format(self.__class__.__name__))
 
     @staticmethod
-    def open_stream(source, use_memory_map=False):
+    def open_stream(source):
         """
-        Open stream from source.
+        Open stream from source, if you want to use memory map use
+        MemoryMappedFile as source.
 
         Parameters
         ----------
         source
             A readable source, like an InputStream
-        use_memory_map : boolean, default False
-            Use memory mapping when opening file on disk
         """
         cdef:
             MessageReader result = MessageReader.__new__(MessageReader)
             shared_ptr[CInputStream] in_stream
             unique_ptr[CMessageReader] reader
 
-        _get_input_stream(source, &in_stream, use_memory_map)
+        _get_input_stream(source, &in_stream)
         with nogil:
             reader = CMessageReader.Open(in_stream)
             result.reader.reset(reader.release())
@@ -564,14 +563,14 @@ cdef class _RecordBatchStreamWriter(_CRecordBatchWriter):
                                  self.options))
 
 
-cdef _get_input_stream(object source, shared_ptr[CInputStream]* out, use_memory_map=False):
+cdef _get_input_stream(object source, shared_ptr[CInputStream]* out):
     try:
         source = as_buffer(source)
     except TypeError:
         # Non-buffer-like
         pass
 
-    get_input_stream(source, use_memory_map, out)
+    get_input_stream(source, True, out)
 
 
 class _ReadPandasMixin:

--- a/python/pyarrow/ipc.py
+++ b/python/pyarrow/ipc.py
@@ -39,21 +39,17 @@ class RecordBatchStreamReader(lib._RecordBatchStreamReader):
     ----------
     source : bytes/buffer-like, pyarrow.NativeFile, or file-like Python object
         Either an in-memory buffer, or a readable file object.
+        If you want to use memory map use MemoryMappedFile as source.
     options : pyarrow.ipc.IpcReadOptions
         Options for IPC deserialization.
         If None, default values will be used.
     memory_pool : MemoryPool, default None
         If None, default memory pool is used.
-    use_memory_map : bool, default False
-        If the source is a file path, use a memory map to read file, which can
-        improve performance in some environments.
     """
 
-    def __init__(self, source, *, options=None, memory_pool=None,
-                 use_memory_map=False):
+    def __init__(self, source, *, options=None, memory_pool=None):
         options = _ensure_default_ipc_read_options(options)
-        self._open(source, options=options, memory_pool=memory_pool,
-                   use_memory_map=use_memory_map)
+        self._open(source, options=options, memory_pool=memory_pool)
 
 
 _ipc_writer_class_doc = """\
@@ -96,7 +92,8 @@ class RecordBatchFileReader(lib._RecordBatchFileReader):
     Parameters
     ----------
     source : bytes/buffer-like, pyarrow.NativeFile, or file-like Python object
-        Either an in-memory buffer, or a readable file object
+        Either an in-memory buffer, or a readable file object.
+        If you want to use memory map use MemoryMappedFile as source.
     footer_offset : int, default None
         If the file is embedded in some larger file, this is the byte offset to
         the very end of the file data
@@ -105,16 +102,13 @@ class RecordBatchFileReader(lib._RecordBatchFileReader):
         If None, default values will be used.
     memory_pool : MemoryPool, default None
         If None, default memory pool is used.
-    use_memory_map : boolean, default False
-        Use memory mapping when opening file on disk
     """
 
     def __init__(self, source, footer_offset=None, *, options=None,
-                 memory_pool=None, use_memory_map=False):
+                 memory_pool=None):
         options = _ensure_default_ipc_read_options(options)
         self._open(source, footer_offset=footer_offset,
-                   options=options, memory_pool=memory_pool,
-                   use_memory_map=use_memory_map)
+                   options=options, memory_pool=memory_pool)
 
 
 class RecordBatchFileWriter(lib._RecordBatchFileWriter):

--- a/python/pyarrow/ipc.py
+++ b/python/pyarrow/ipc.py
@@ -44,11 +44,16 @@ class RecordBatchStreamReader(lib._RecordBatchStreamReader):
         If None, default values will be used.
     memory_pool : MemoryPool, default None
         If None, default memory pool is used.
+    use_memory_map : bool, default False
+        If the source is a file path, use a memory map to read file, which can
+        improve performance in some environments.
     """
 
-    def __init__(self, source, *, options=None, memory_pool=None):
+    def __init__(self, source, *, options=None, memory_pool=None,
+                 use_memory_map=False):
         options = _ensure_default_ipc_read_options(options)
-        self._open(source, options=options, memory_pool=memory_pool)
+        self._open(source, options=options, memory_pool=memory_pool,
+                   use_memory_map=use_memory_map)
 
 
 _ipc_writer_class_doc = """\
@@ -100,13 +105,16 @@ class RecordBatchFileReader(lib._RecordBatchFileReader):
         If None, default values will be used.
     memory_pool : MemoryPool, default None
         If None, default memory pool is used.
+    use_memory_map : boolean, default False
+        Use memory mapping when opening file on disk
     """
 
     def __init__(self, source, footer_offset=None, *, options=None,
-                 memory_pool=None):
+                 memory_pool=None, use_memory_map=False):
         options = _ensure_default_ipc_read_options(options)
         self._open(source, footer_offset=footer_offset,
-                   options=options, memory_pool=memory_pool)
+                   options=options, memory_pool=memory_pool,
+                   use_memory_map=use_memory_map)
 
 
 class RecordBatchFileWriter(lib._RecordBatchFileWriter):

--- a/python/pyarrow/serialization.pxi
+++ b/python/pyarrow/serialization.pxi
@@ -425,7 +425,7 @@ def serialize_to(object value, sink, SerializationContext context=None):
     serialized.write_to(sink)
 
 
-def read_serialized(source, base=None):
+def read_serialized(source, base=None, use_memory_map=False):
     """
     DEPRECATED: Read serialized Python sequence from file-like object.
 
@@ -442,18 +442,20 @@ def read_serialized(source, base=None):
     base : object
         This object will be the base object of all the numpy arrays
         contained in the sequence.
+    use_memory_map : boolean, default False
+        Use memory mapping when opening file on disk
 
     Returns
     -------
     serialized : the serialized data
     """
     _deprecate_serialization("read_serialized")
-    return _read_serialized(source, base=base)
+    return _read_serialized(source, base=base, use_memory_map=use_memory_map)
 
 
-def _read_serialized(source, base=None):
+def _read_serialized(source, base=None, use_memory_map=False):
     cdef shared_ptr[CRandomAccessFile] stream
-    get_reader(source, True, &stream)
+    get_reader(source, use_memory_map, &stream)
 
     cdef SerializedPyObject serialized = SerializedPyObject()
     serialized.base = base
@@ -463,7 +465,7 @@ def _read_serialized(source, base=None):
     return serialized
 
 
-def deserialize_from(source, object base, SerializationContext context=None):
+def deserialize_from(source, object base, SerializationContext context=None, use_memory_map=False):
     """
     DEPRECATED: Deserialize a Python sequence from a file.
 
@@ -485,6 +487,8 @@ def deserialize_from(source, object base, SerializationContext context=None):
         contained in the sequence.
     context : SerializationContext
         Custom serialization and deserialization context.
+    use_memory_map : boolean, default False
+        Use memory mapping when opening file on disk
 
     Returns
     -------
@@ -492,7 +496,8 @@ def deserialize_from(source, object base, SerializationContext context=None):
         Python object for the deserialized sequence.
     """
     _deprecate_serialization("deserialize_from")
-    serialized = _read_serialized(source, base=base)
+    serialized = _read_serialized(
+        source, base=base, use_memory_map=use_memory_map)
     return serialized.deserialize(context)
 
 
@@ -550,7 +555,8 @@ def deserialize(obj, SerializationContext context=None):
     return _deserialize(obj, context=context)
 
 
-def _deserialize(obj, SerializationContext context=None):
+def _deserialize(obj, SerializationContext context=None, use_memory_map=False):
     source = BufferReader(obj)
-    serialized = _read_serialized(source, base=obj)
+    serialized = _read_serialized(
+        source, base=obj, use_memory_map=use_memory_map)
     return serialized.deserialize(context)

--- a/python/pyarrow/serialization.pxi
+++ b/python/pyarrow/serialization.pxi
@@ -425,7 +425,7 @@ def serialize_to(object value, sink, SerializationContext context=None):
     serialized.write_to(sink)
 
 
-def read_serialized(source, base=None, use_memory_map=False):
+def read_serialized(source, base=None):
     """
     DEPRECATED: Read serialized Python sequence from file-like object.
 
@@ -442,20 +442,18 @@ def read_serialized(source, base=None, use_memory_map=False):
     base : object
         This object will be the base object of all the numpy arrays
         contained in the sequence.
-    use_memory_map : boolean, default False
-        Use memory mapping when opening file on disk
 
     Returns
     -------
     serialized : the serialized data
     """
     _deprecate_serialization("read_serialized")
-    return _read_serialized(source, base=base, use_memory_map=use_memory_map)
+    return _read_serialized(source, base=base)
 
 
-def _read_serialized(source, base=None, use_memory_map=False):
+def _read_serialized(source, base=None):
     cdef shared_ptr[CRandomAccessFile] stream
-    get_reader(source, use_memory_map, &stream)
+    get_reader(source, False, &stream)
 
     cdef SerializedPyObject serialized = SerializedPyObject()
     serialized.base = base
@@ -465,7 +463,7 @@ def _read_serialized(source, base=None, use_memory_map=False):
     return serialized
 
 
-def deserialize_from(source, object base, SerializationContext context=None, use_memory_map=False):
+def deserialize_from(source, object base, SerializationContext context=None):
     """
     DEPRECATED: Deserialize a Python sequence from a file.
 
@@ -487,8 +485,6 @@ def deserialize_from(source, object base, SerializationContext context=None, use
         contained in the sequence.
     context : SerializationContext
         Custom serialization and deserialization context.
-    use_memory_map : boolean, default False
-        Use memory mapping when opening file on disk
 
     Returns
     -------
@@ -496,8 +492,7 @@ def deserialize_from(source, object base, SerializationContext context=None, use
         Python object for the deserialized sequence.
     """
     _deprecate_serialization("deserialize_from")
-    serialized = _read_serialized(
-        source, base=base, use_memory_map=use_memory_map)
+    serialized = _read_serialized(source, base=base)
     return serialized.deserialize(context)
 
 
@@ -555,8 +550,7 @@ def deserialize(obj, SerializationContext context=None):
     return _deserialize(obj, context=context)
 
 
-def _deserialize(obj, SerializationContext context=None, use_memory_map=False):
+def _deserialize(obj, SerializationContext context=None):
     source = BufferReader(obj)
-    serialized = _read_serialized(
-        source, base=obj, use_memory_map=use_memory_map)
+    serialized = _read_serialized(source, base=obj)
     return serialized.deserialize(context)


### PR DESCRIPTION
[Python] Disable memory mapping by default in pyarrow