### PR TITLE
ARROW-16694: [Packaging][Python] Use Mamba instead of conda to build conda environment for windows packaging jobs

### DIFF
--- a/dev/tasks/conda-recipes/azure.win.yml
+++ b/dev/tasks/conda-recipes/azure.win.yml
@@ -62,8 +62,7 @@ jobs:
       workingDirectory: arrow\dev\tasks\conda-recipes
 
     - script: |
-        call activate base
-        conda.exe mambabuild arrow-cpp parquet-cpp -m .ci_support\%CONFIG%.yaml
+        conda.exe build arrow-cpp parquet-cpp -m .ci_support\%CONFIG%.yaml
       displayName: Build recipe
       workingDirectory: arrow\dev\tasks\conda-recipes
       env:
@@ -71,8 +70,7 @@ jobs:
       condition: not(contains(variables['CONFIG'], 'vs2008'))
 
     - script: |
-        call activate base
-        conda.exe mambabuild r-arrow -m .ci_support\r\%R_CONFIG%.yaml
+        conda.exe build r-arrow -m .ci_support\r\%R_CONFIG%.yaml
       displayName: Build recipe
       workingDirectory: arrow\dev\tasks\conda-recipes
       env:

--- a/dev/tasks/conda-recipes/azure.win.yml
+++ b/dev/tasks/conda-recipes/azure.win.yml
@@ -35,12 +35,26 @@ jobs:
       condition: contains(variables['CONFIG'], 'vs2008')
       displayName: Patch vs2008 (if needed)
 
-    - task: CondaEnvironment@1
+    - task: PythonScript@0
+      displayName: 'Download Miniforge'
       inputs:
-        packageSpecs: 'python=3.9 conda-build conda "conda-forge-ci-setup=3" pip' # Optional
-        installOptions: "-c conda-forge"
-        updateConda: true
-      displayName: Install conda-build and activate environment
+        scriptSource: inline
+        script: |
+          import urllib.request
+          url = 'https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Windows-x86_64.exe'
+          path = r"$(Build.ArtifactStagingDirectory)/Miniforge.exe"
+          urllib.request.urlretrieve(url, path)
+
+    - script: |
+        start /wait "" %BUILD_ARTIFACTSTAGINGDIRECTORY%\Miniforge.exe /InstallationType=JustMe /RegisterPython=0 /S /D=C:\Miniforge
+      displayName: Install Miniforge
+    - powershell: Write-Host "##vso[task.prependpath]C:\Miniforge\Scripts"
+      displayName: Add conda to PATH
+
+    - script: |
+        call activate base
+        mamba.exe install 'python=3.9' conda-build conda pip boa 'conda-forge-ci-setup=3' -c conda-forge --strict-channel-priority --yes
+      displayName: Install conda-build
 
     - script: set PYTHONUNBUFFERED=1
       displayName: Set PYTHONUNBUFFERED
@@ -52,6 +66,7 @@ jobs:
         call activate base
         setup_conda_rc .\ .\ .\.ci_support\%CONFIG%.yaml
       workingDirectory: arrow\dev\tasks\conda-recipes
+      displayName: conda-forge CI setup
 
     # Configure the VM.
     - script: |
@@ -62,16 +77,18 @@ jobs:
       workingDirectory: arrow\dev\tasks\conda-recipes
 
     - script: |
-        conda.exe build arrow-cpp parquet-cpp -m .ci_support\%CONFIG%.yaml
-      displayName: Build recipe
+        call activate base
+        conda.exe mambabuild arrow-cpp parquet-cpp -m .ci_support\%CONFIG%.yaml
+      displayName: Build Arrow recipe
       workingDirectory: arrow\dev\tasks\conda-recipes
       env:
         PYTHONUNBUFFERED: 1
       condition: not(contains(variables['CONFIG'], 'vs2008'))
 
     - script: |
-        conda.exe build r-arrow -m .ci_support\r\%R_CONFIG%.yaml
-      displayName: Build recipe
+        call activate base
+        conda.exe mambabuild r-arrow -m .ci_support\r\%R_CONFIG%.yaml
+      displayName: Build R-Arrow recipe
       workingDirectory: arrow\dev\tasks\conda-recipes
       env:
         PYTHONUNBUFFERED: 1

--- a/dev/tasks/conda-recipes/azure.win.yml
+++ b/dev/tasks/conda-recipes/azure.win.yml
@@ -37,7 +37,7 @@ jobs:
 
     - task: CondaEnvironment@1
       inputs:
-        packageSpecs: 'python=3.9 conda-build conda "conda-forge-ci-setup=3" pip boa' # Optional
+        packageSpecs: 'python=3.9 conda-build conda "conda-forge-ci-setup=3" pip' # Optional
         installOptions: "-c conda-forge"
         updateConda: true
       displayName: Install conda-build and activate environment


### PR DESCRIPTION
Conda windows packaging jobs have been failing since the 26th of May.
There was a problem when creating the conda environment using conda with the boa requirement having conflicts.
This PR updates the Azure pipeline to use Mamba instead of conda to create the environment as the upstream feedstock does:
https://github.com/conda-forge/arrow-cpp-feedstock/blob/main/.azure-pipelines/azure-pipelines-win.yml