### PR TITLE
ARROW-16806: [CI][Python] Bump required setuptools version

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -515,8 +515,8 @@ maybe_setup_virtualenv() {
       $python -m venv ${virtualenv}
       # Activate the environment
       source "${virtualenv}/bin/activate"
-      # Upgrade pip
-      pip install -U pip
+      # Upgrade pip and setuptools
+      pip install -U pip setuptools
     else
       show_info "Using already created virtualenv at ${virtualenv}"
       # Activate the environment

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -20,6 +20,6 @@ requires = [
     "cython >= 0.29.22",
     "oldest-supported-numpy>=0.14",
     "setuptools_scm",
-    "setuptools >= 38.6.0",
+    "setuptools >= 40.1.0",
     "wheel"
 ]


### PR DESCRIPTION
Our `setup.py` script now uses the `find_namespace_packages` function which is not provided by old setuptools versions.

Fixes source release verification script on Ubuntu 18.04.