### PR TITLE
ARROW-16815: [Packaging][RPM] Disable Apache Arrow Flight for aarch64

### DIFF
--- a/dev/release/verify-yum.sh
+++ b/dev/release/verify-yum.sh
@@ -93,6 +93,7 @@ case "${distribution}-${distribution_version}" in
     ;;
 esac
 if [ "$(arch)" = "aarch64" ]; then
+  have_flight=no
   have_gandiva=no
 fi
 

--- a/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
+++ b/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
@@ -45,12 +45,12 @@
 %if %{rhel} >= 9
 %define arrow_cmake_builddir %{__cmake_builddir}
 %define arrow_cmake %cmake
-%define arrow_cmake_build ninja -C %{arrow_cmake_builddir} %{?_smp_mflags} -v
+%define arrow_cmake_build ninja -C %{arrow_cmake_builddir} %{?_smp_mflags}
 %define arrow_cmake_install %cmake_install
 %else
 %define arrow_cmake_builddir build
 %define arrow_cmake %cmake3 -S . -B %{arrow_cmake_builddir}
-%define arrow_cmake_build ninja -C %{arrow_cmake_builddir} %{?_smp_mflags} -v
+%define arrow_cmake_build ninja -C %{arrow_cmake_builddir} %{?_smp_mflags}
 %define arrow_cmake_install DESTDIR="%{buildroot}" ninja -C %{arrow_cmake_builddir} install
 %endif
 

--- a/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
+++ b/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
@@ -45,12 +45,12 @@
 %if %{rhel} >= 9
 %define arrow_cmake_builddir %{__cmake_builddir}
 %define arrow_cmake %cmake
-%define arrow_cmake_build %cmake_build
+%define arrow_cmake_build ninja -C %{arrow_cmake_builddir} %{?_smp_mflags} -v
 %define arrow_cmake_install %cmake_install
 %else
 %define arrow_cmake_builddir build
 %define arrow_cmake %cmake3 -S . -B %{arrow_cmake_builddir}
-%define arrow_cmake_build ninja -C %{arrow_cmake_builddir} -v
+%define arrow_cmake_build ninja -C %{arrow_cmake_builddir} %{?_smp_mflags} -v
 %define arrow_cmake_install DESTDIR="%{buildroot}" ninja -C %{arrow_cmake_builddir} install
 %endif
 

--- a/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
+++ b/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
@@ -55,7 +55,8 @@
 %endif
 
 %define use_boost (!%{is_amazon_linux})
-%define use_flight (%{rhel} >= 8)
+# TODO: Enable this on aarch64 too. This causes timeout on Travis CI.
+%define use_flight (%{rhel} >= 8 && "%{_arch}" != "aarch64")
 %define use_gandiva (%{rhel} >= 8 && "%{_arch}" != "aarch64")
 %define use_gcs (%{rhel} >= 8 || %{is_amazon_linux})
 %define use_gflags (!%{is_amazon_linux})

--- a/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
+++ b/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
@@ -45,13 +45,13 @@
 %if %{rhel} >= 9
 %define arrow_cmake_builddir %{__cmake_builddir}
 %define arrow_cmake %cmake
-%define arrow_cmake_build ninja -C %{arrow_cmake_builddir} %{?_smp_mflags}
+%define arrow_cmake_build make -C %{arrow_cmake_builddir} %{?_smp_mflags}
 %define arrow_cmake_install %cmake_install
 %else
 %define arrow_cmake_builddir build
 %define arrow_cmake %cmake3 -S . -B %{arrow_cmake_builddir}
-%define arrow_cmake_build ninja -C %{arrow_cmake_builddir} %{?_smp_mflags}
-%define arrow_cmake_install DESTDIR="%{buildroot}" ninja -C %{arrow_cmake_builddir} install
+%define arrow_cmake_build make -C %{arrow_cmake_builddir} %{?_smp_mflags}
+%define arrow_cmake_install DESTDIR="%{buildroot}" make -C %{arrow_cmake_builddir} install
 %endif
 
 %define use_boost (!%{is_amazon_linux})
@@ -189,7 +189,7 @@ cd cpp
   -DPythonInterp_FIND_VERSION=ON \
   -DPythonInterp_FIND_VERSION_MAJOR=3 \
 %endif
-  -GNinja
+  -G"Unix Makefiles"
 %arrow_cmake_build
 cd -
 

--- a/dev/tasks/linux-packages/travis.linux.arm64.yml
+++ b/dev/tasks/linux-packages/travis.linux.arm64.yml
@@ -114,13 +114,12 @@ script:
       done
   - popd
   - |
-      travis_wait 55 \
-        rake \
-          --trace \
-          {{ task_namespace }}:build \
-          BUILD_DIR=build \
-          DEB_BUILD_OPTIONS=parallel=2 \
-          RPM_BUILD_NCPUS=2
+      rake \
+        --trace \
+        {{ task_namespace }}:build \
+        BUILD_DIR=build \
+        DEB_BUILD_OPTIONS=parallel=2 \
+        RPM_BUILD_NCPUS=1
   - sudo rm -rf */*/build
   - popd
   # Push Docker image

--- a/dev/tasks/linux-packages/travis.linux.arm64.yml
+++ b/dev/tasks/linux-packages/travis.linux.arm64.yml
@@ -119,7 +119,7 @@ script:
         {{ task_namespace }}:build \
         BUILD_DIR=build \
         DEB_BUILD_OPTIONS=parallel=2 \
-        RPM_BUILD_NCPUS=1
+        RPM_BUILD_NCPUS=2
   - sudo rm -rf */*/build
   - popd
   # Push Docker image

--- a/dev/tasks/linux-packages/travis.linux.arm64.yml
+++ b/dev/tasks/linux-packages/travis.linux.arm64.yml
@@ -114,12 +114,13 @@ script:
       done
   - popd
   - |
-      rake \
-        --trace \
-        {{ task_namespace }}:build \
-        BUILD_DIR=build \
-        DEB_BUILD_OPTIONS=parallel=2 \
-        RPM_BUILD_NCPUS=2
+      travis_wait 30 \
+        rake \
+          --trace \
+          {{ task_namespace }}:build \
+          BUILD_DIR=build \
+          DEB_BUILD_OPTIONS=parallel=2 \
+          RPM_BUILD_NCPUS=2
   - sudo rm -rf */*/build
   - popd
   # Push Docker image

--- a/dev/tasks/linux-packages/travis.linux.arm64.yml
+++ b/dev/tasks/linux-packages/travis.linux.arm64.yml
@@ -114,7 +114,7 @@ script:
       done
   - popd
   - |
-      travis_wait 30 \
+      travis_wait 55 \
         rake \
           --trace \
           {{ task_namespace }}:build \


### PR DESCRIPTION
This is a follow-up of ARROW-16745/#13307.

If we enable Apache Arrow Flight, we can't build packages in 60min on Travis CI.
If we can't finish a job in 60min, Travis CI terminates the job as time-out.