### PR TITLE
[C++] Fix LZ4 support build for VS 2019 & 2022

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2271,11 +2271,20 @@ macro(build_lz4)
         set(LZ4_RUNTIME_LIBRARY_LINKAGE "/p:RuntimeLibrary=MultiThreaded")
       endif()
     endif()
+
+    # The LZ4 Visual Studio solution doesn't have RelWithDebInfo,
+    # use Release instead.
+    if(${UPPERCASE_BUILD_TYPE} STREQUAL "RELWITHDEBINFO")
+      set(LZ4_BUILD_TYPE "Release")
+    else()
+      set(LZ4_BUILD_TYPE ${CMAKE_BUILD_TYPE})
+    endif()
+
     set(LZ4_STATIC_LIB
-        "${LZ4_BUILD_DIR}/build/VS2010/bin/x64_${CMAKE_BUILD_TYPE}/liblz4_static.lib")
+        "${LZ4_BUILD_DIR}/build/VS2010/bin/x64_${LZ4_BUILD_TYPE}/liblz4_static.lib")
     set(LZ4_BUILD_COMMAND
-        BUILD_COMMAND msbuild.exe /m /p:Configuration=${CMAKE_BUILD_TYPE} /p:Platform=x64
-        /p:PlatformToolset=v140 ${LZ4_RUNTIME_LIBRARY_LINKAGE} /t:Build
+        BUILD_COMMAND msbuild.exe /m /p:Configuration=${LZ4_BUILD_TYPE} /p:Platform=x64
+        /p:PlatformToolset=v${MSVC_TOOLSET_VERSION} ${LZ4_RUNTIME_LIBRARY_LINKAGE} /t:Build
         ${LZ4_BUILD_DIR}/build/VS2010/lz4.sln)
   else()
     set(LZ4_STATIC_LIB "${LZ4_BUILD_DIR}/lib/liblz4.a")


### PR DESCRIPTION
This fixes building arrow/parquet with LZ4 support on Windows for Visual Studio 2019 & 2022.

Changes:
1. PlatformToolset=v140 requires Windows SDK 8, which is not normally installed with VS 2019 or 2022. I changed it to use the toolset available for the current build system, which will be v142 or v143 in recent VS versions.
2. The LZ4 library project doesn't have "Relwithdebinfo" configuration, so when trying to build arrow/parquet with relwithdebinfo, it fails. I added a condition to use Release for LZ4 when the parent arrow/parquet is being built using with relwithdebinfo.

With above changes, I could create arrow/parquet dlls with LZ4 support to be used internally at Microsoft.
