### PR TITLE
ARROW-16831: [Go] panic in ipc.Reader when string array offsets are invalid

### DIFF
--- a/go/arrow/array/binary.go
+++ b/go/arrow/array/binary.go
@@ -116,6 +116,19 @@ func (a *Binary) setData(data *Data) {
 	if valueOffsets := data.buffers[1]; valueOffsets != nil {
 		a.valueOffsets = arrow.Int32Traits.CastFromBytes(valueOffsets.Bytes())
 	}
+
+	if a.array.data.length < 1 {
+		return
+	}
+
+	expNumOffsets := a.array.data.offset + a.array.data.length + 1
+	if len(a.valueOffsets) < expNumOffsets {
+		panic(fmt.Errorf("arrow/array: binary offset buffer must have at least %d values", expNumOffsets))
+	}
+
+	if int(a.valueOffsets[expNumOffsets-1]) > len(a.valueBytes) {
+		panic("arrow/array: binary offsets out of bounds of data buffer")
+	}
 }
 
 func (a *Binary) getOneForMarshal(i int) interface{} {

--- a/go/arrow/array/concat_test.go
+++ b/go/arrow/array/concat_test.go
@@ -18,7 +18,6 @@ package array_test
 
 import (
 	"fmt"
-	"math"
 	"sort"
 	"testing"
 
@@ -288,14 +287,4 @@ func (cts *ConcatTestSuite) TestCheckConcat() {
 			}
 		})
 	}
-}
-
-func TestOffsetOverflow(t *testing.T) {
-	fakeOffsets := memory.NewBufferBytes(arrow.Int32Traits.CastToBytes([]int32{0, math.MaxInt32}))
-	fakeArr := array.NewStringData(array.NewData(arrow.BinaryTypes.String, 1, []*memory.Buffer{nil, fakeOffsets, memory.NewBufferBytes([]byte{})}, nil, 0, 0))
-	var err error
-	assert.NotPanics(t, func() {
-		_, err = array.Concatenate([]arrow.Array{fakeArr, fakeArr}, memory.DefaultAllocator)
-	})
-	assert.EqualError(t, err, "offset overflow while concatenating arrays")
 }

--- a/go/arrow/array/string.go
+++ b/go/arrow/array/string.go
@@ -113,6 +113,12 @@ func (a *String) setData(data *Data) {
 	if offsets := data.buffers[1]; offsets != nil {
 		a.offsets = arrow.Int32Traits.CastFromBytes(offsets.Bytes())
 	}
+
+	expNumOffsets := a.array.data.offset + a.array.data.length + 1
+	if a.array.data.length > 0 &&
+		(len(a.offsets) < expNumOffsets || int(a.offsets[expNumOffsets-2]) > len(a.values)) {
+		panic("arrow/array: string offsets out of bounds of data buffer")
+	}
 }
 
 func (a *String) getOneForMarshal(i int) interface{} {

--- a/go/arrow/array/string.go
+++ b/go/arrow/array/string.go
@@ -125,7 +125,7 @@ func (a *String) setData(data *Data) {
 	}
 
 	lastValValid := a.IsValid(a.Len() - 1)
-	if lastValValid && int(a.offsets[expNumOffsets-2]) > len(a.values) {
+	if lastValValid && int(a.offsets[expNumOffsets-1]) > len(a.values) {
 		panic("arrow/array: string offsets out of bounds of data buffer")
 	}
 }

--- a/go/arrow/array/string.go
+++ b/go/arrow/array/string.go
@@ -120,7 +120,7 @@ func (a *String) setData(data *Data) {
 
 	expNumOffsets := a.array.data.offset + a.array.data.length + 1
 	if len(a.offsets) < expNumOffsets {
-		panic("arrow/array: string offsets missing")
+		panic(fmt.Errorf("arrow/array: string offset buffer must have at least %d values", expNumOffsets))
 	}
 
 	if int(a.offsets[expNumOffsets-1]) > len(a.values) {

--- a/go/arrow/array/string.go
+++ b/go/arrow/array/string.go
@@ -123,8 +123,7 @@ func (a *String) setData(data *Data) {
 		panic("arrow/array: string offsets missing")
 	}
 
-	lastValValid := a.IsValid(a.Len() - 1)
-	if lastValValid && int(a.offsets[expNumOffsets-1]) > len(a.values) {
+	if int(a.offsets[expNumOffsets-1]) > len(a.values) {
 		panic("arrow/array: string offsets out of bounds of data buffer")
 	}
 }

--- a/go/arrow/array/string.go
+++ b/go/arrow/array/string.go
@@ -120,8 +120,7 @@ func (a *String) setData(data *Data) {
 
 	expNumOffsets := a.array.data.offset + a.array.data.length + 1
 	if len(a.offsets) < expNumOffsets {
-		// panic("arrow/array: string offsets missing")
-		panic("arrow/array: string offsets out of bounds of data buffer")
+		panic("arrow/array: string offsets missing")
 	}
 
 	lastValValid := a.IsValid(a.Len() - 1)

--- a/go/arrow/array/string.go
+++ b/go/arrow/array/string.go
@@ -114,9 +114,18 @@ func (a *String) setData(data *Data) {
 		a.offsets = arrow.Int32Traits.CastFromBytes(offsets.Bytes())
 	}
 
+	if a.array.data.length < 1 {
+		return
+	}
+
 	expNumOffsets := a.array.data.offset + a.array.data.length + 1
-	if a.array.data.length > 0 &&
-		(len(a.offsets) < expNumOffsets || int(a.offsets[expNumOffsets-2]) > len(a.values)) {
+	if len(a.offsets) < expNumOffsets {
+		// panic("arrow/array: string offsets missing")
+		panic("arrow/array: string offsets out of bounds of data buffer")
+	}
+
+	lastValValid := a.IsValid(a.Len() - 1)
+	if lastValValid && int(a.offsets[expNumOffsets-2]) > len(a.values) {
 		panic("arrow/array: string offsets out of bounds of data buffer")
 	}
 }

--- a/go/arrow/array/string_test.go
+++ b/go/arrow/array/string_test.go
@@ -236,11 +236,6 @@ func TestStringInvalidOffsets(t *testing.T) {
 	}, "empty array, offsets ignored")
 
 	assert.NotPanics(t, func() {
-		buffers := makeBuffers(nil, []int32{0, 5}, "")
-		array.NewStringData(array.NewData(arrow.BinaryTypes.String, 0, buffers, nil, 0, 0))
-	}, "empty array, offsets ignored")
-
-	assert.NotPanics(t, func() {
 		buffers := makeBuffers(nil, []int32{0, 3, 4, 9}, "oooabcdef")
 		array.NewStringData(array.NewData(arrow.BinaryTypes.String, 1, buffers, nil, 0, 2))
 	}, "data has offset and value offsets are valid")
@@ -271,6 +266,11 @@ func TestStringInvalidOffsets(t *testing.T) {
 		buffers := makeBuffers(nil, []int32{0, 5}, "abc")
 		array.NewStringData(array.NewData(arrow.BinaryTypes.String, 1, buffers, nil, 0, 0))
 	}, "last offset is overflowing")
+
+	assert.PanicsWithValue(t, "arrow/array: string offsets missing", func() {
+		buffers := makeBuffers(nil, []int32{0}, "abc")
+		array.NewStringData(array.NewData(arrow.BinaryTypes.String, 1, buffers, nil, 0, 0))
+	}, "last offset is missing")
 
 	assert.PanicsWithValue(t, expectedPanic, func() {
 		buffers := makeBuffers(nil, []int32{0, 3, 10, 15}, "oooabcdef")

--- a/go/arrow/array/string_test.go
+++ b/go/arrow/array/string_test.go
@@ -267,7 +267,7 @@ func TestStringInvalidOffsets(t *testing.T) {
 		array.NewStringData(array.NewData(arrow.BinaryTypes.String, 1, buffers, nil, 0, 0))
 	}, "last offset is overflowing")
 
-	assert.PanicsWithValue(t, "arrow/array: string offsets missing", func() {
+	assert.PanicsWithError(t, "arrow/array: string offset buffer must have at least 2 values", func() {
 		buffers := makeBuffers(nil, []int32{0}, "abc")
 		array.NewStringData(array.NewData(arrow.BinaryTypes.String, 1, buffers, nil, 0, 0))
 	}, "last offset is missing")

--- a/go/arrow/array/string_test.go
+++ b/go/arrow/array/string_test.go
@@ -241,11 +241,6 @@ func TestStringInvalidOffsets(t *testing.T) {
 	}, "empty array, offsets ignored")
 
 	assert.NotPanics(t, func() {
-		buffers := makeBuffers(nil, []int32{0, 5}, "a")
-		array.NewStringData(array.NewData(arrow.BinaryTypes.String, 1, buffers, nil, 0, 0))
-	}, "last offset is allowed to overflow length")
-
-	assert.NotPanics(t, func() {
 		buffers := makeBuffers(nil, []int32{0, 3, 4, 9}, "oooabcdef")
 		array.NewStringData(array.NewData(arrow.BinaryTypes.String, 1, buffers, nil, 0, 2))
 	}, "data has offset and value offsets are valid")
@@ -273,9 +268,9 @@ func TestStringInvalidOffsets(t *testing.T) {
 	}, "simple valid case with nulls")
 
 	assert.PanicsWithValue(t, expectedPanic, func() {
-		buffers := makeBuffers(nil, []int32{1, 5}, "")
+		buffers := makeBuffers(nil, []int32{0, 5}, "abc")
 		array.NewStringData(array.NewData(arrow.BinaryTypes.String, 1, buffers, nil, 0, 0))
-	}, "second-last offset is overflowing")
+	}, "last offset is overflowing")
 
 	assert.PanicsWithValue(t, expectedPanic, func() {
 		buffers := makeBuffers(nil, []int32{0, 3, 10, 15}, "oooabcdef")

--- a/go/arrow/array/string_test.go
+++ b/go/arrow/array/string_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/apache/arrow/go/v9/arrow"
 	"github.com/apache/arrow/go/v9/arrow/array"
+	"github.com/apache/arrow/go/v9/arrow/bitutil"
 	"github.com/apache/arrow/go/v9/arrow/memory"
 	"github.com/stretchr/testify/assert"
 )
@@ -210,33 +211,72 @@ func TestStringReset(t *testing.T) {
 func TestStringInvalidOffsets(t *testing.T) {
 	const expectedPanic = "arrow/array: string offsets out of bounds of data buffer"
 
-	makeBuffers := func(offsets []int32, data string) []*memory.Buffer {
+	makeBuffers := func(valids []bool, offsets []int32, data string) []*memory.Buffer {
 		offsetBuf := memory.NewBufferBytes(arrow.Int32Traits.CastToBytes(offsets))
-		return []*memory.Buffer{nil, offsetBuf, memory.NewBufferBytes([]byte(data))}
+		var nullBufBytes []byte
+		var nullBuf *memory.Buffer
+		if valids != nil {
+			nullBufBytes = make([]byte, bitutil.BytesForBits(int64(len(valids))))
+			for i, v := range valids {
+				bitutil.SetBitTo(nullBufBytes, i, v)
+			}
+			nullBuf = memory.NewBufferBytes(nullBufBytes)
+		}
+		return []*memory.Buffer{nullBuf, offsetBuf, memory.NewBufferBytes([]byte(data))}
 	}
 
 	assert.NotPanics(t, func() {
-		buffers := makeBuffers([]int32{}, "")
+		buffers := makeBuffers(nil, []int32{}, "")
 		array.NewStringData(array.NewData(arrow.BinaryTypes.String, 0, buffers, nil, 0, 0))
-	}, "empty array has no offsets")
+	}, "empty array with no offsets")
 
 	assert.NotPanics(t, func() {
-		buffers := makeBuffers([]int32{0, 5}, "")
+		buffers := makeBuffers(nil, []int32{0, 5}, "")
+		array.NewStringData(array.NewData(arrow.BinaryTypes.String, 0, buffers, nil, 0, 0))
+	}, "empty array, offsets ignored")
+
+	assert.NotPanics(t, func() {
+		buffers := makeBuffers(nil, []int32{0, 5}, "")
+		array.NewStringData(array.NewData(arrow.BinaryTypes.String, 0, buffers, nil, 0, 0))
+	}, "empty array, offsets ignored")
+
+	assert.NotPanics(t, func() {
+		buffers := makeBuffers(nil, []int32{0, 5}, "")
 		array.NewStringData(array.NewData(arrow.BinaryTypes.String, 1, buffers, nil, 0, 0))
 	}, "last offset is allowed to overflow length")
 
+	assert.NotPanics(t, func() {
+		buffers := makeBuffers(nil, []int32{0, 3, 4, 9}, "oooabcdef")
+		array.NewStringData(array.NewData(arrow.BinaryTypes.String, 1, buffers, nil, 0, 2))
+	}, "data has offset and value offsets are valid")
+
+	assert.NotPanics(t, func() {
+		buffers := makeBuffers(nil, []int32{0, 3, 4, 9}, "oooabcdef")
+		arr := array.NewStringData(array.NewData(arrow.BinaryTypes.String, 3, buffers, nil, 0, 0))
+		if assert.Equal(t, 3, arr.Len()) && assert.Zero(t, arr.NullN()) {
+			assert.Equal(t, "ooo", arr.Value(0))
+			assert.Equal(t, "a", arr.Value(1))
+			assert.Equal(t, "bcdef", arr.Value(2))
+		}
+	}, "simple valid case")
+
+	assert.NotPanics(t, func() {
+		buffers := makeBuffers([]bool{true, false, true}, []int32{0, 3, 4, 9}, "oooabcdef")
+		arr := array.NewStringData(array.NewData(arrow.BinaryTypes.String, 3, buffers, nil, 1, 0))
+		if assert.Equal(t, 3, arr.Len()) && assert.Equal(t, 1, arr.NullN()) {
+			assert.Equal(t, "ooo", arr.Value(0))
+			assert.True(t, arr.IsNull(1))
+			assert.Equal(t, "bcdef", arr.Value(2))
+		}
+	}, "simple valid case with nulls")
+
 	assert.PanicsWithValue(t, expectedPanic, func() {
-		buffers := makeBuffers([]int32{1, 5}, "")
+		buffers := makeBuffers(nil, []int32{1, 5}, "")
 		array.NewStringData(array.NewData(arrow.BinaryTypes.String, 1, buffers, nil, 0, 0))
 	}, "second-last offset is overflowing")
 
 	assert.PanicsWithValue(t, expectedPanic, func() {
-		buffers := makeBuffers([]int32{0, 3, 10, 15}, "oooabcdef")
+		buffers := makeBuffers(nil, []int32{0, 3, 10, 15}, "oooabcdef")
 		array.NewStringData(array.NewData(arrow.BinaryTypes.String, 1, buffers, nil, 0, 2))
 	}, "data has offset and value offset is overflowing")
-
-	assert.NotPanics(t, func() {
-		buffers := makeBuffers([]int32{0, 3, 4, 8}, "oooabcdef")
-		array.NewStringData(array.NewData(arrow.BinaryTypes.String, 1, buffers, nil, 0, 2))
-	}, "data has offset and value offsets are valid")
 }

--- a/go/arrow/ipc/reader.go
+++ b/go/arrow/ipc/reader.go
@@ -54,7 +54,12 @@ type Reader struct {
 // NewReaderFromMessageReader allows constructing a new reader object with the
 // provided MessageReader allowing injection of reading messages other than
 // by simple streaming bytes such as Arrow Flight which receives a protobuf message
-func NewReaderFromMessageReader(r MessageReader, opts ...Option) (*Reader, error) {
+func NewReaderFromMessageReader(r MessageReader, opts ...Option) (reader *Reader, err error) {
+	defer func() {
+		if pErr := recover(); pErr != nil {
+			err = fmt.Errorf("arrow/ipc: unknown error while reading: %v", pErr)
+		}
+	}()
 	cfg := newConfig()
 	for _, opt := range opts {
 		opt(cfg)
@@ -68,7 +73,7 @@ func NewReaderFromMessageReader(r MessageReader, opts ...Option) (*Reader, error
 		mem:  cfg.alloc,
 	}
 
-	err := rr.readSchema(cfg.schema)
+	err = rr.readSchema(cfg.schema)
 	if err != nil {
 		return nil, fmt.Errorf("arrow/ipc: could not read schema from stream: %w", err)
 	}

--- a/go/arrow/ipc/reader.go
+++ b/go/arrow/ipc/reader.go
@@ -191,6 +191,12 @@ func (r *Reader) getInitialDicts() bool {
 }
 
 func (r *Reader) next() bool {
+	defer func() {
+		if pErr := recover(); pErr != nil {
+			r.err = fmt.Errorf("arrow/ipc: unknown error while reading: %v", pErr)
+		}
+	}()
+
 	if !r.readInitialDicts && !r.getInitialDicts() {
 		return false
 	}

--- a/go/arrow/ipc/reader_test.go
+++ b/go/arrow/ipc/reader_test.go
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipc
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/apache/arrow/go/v9/arrow"
+	"github.com/apache/arrow/go/v9/arrow/array"
+	"github.com/apache/arrow/go/v9/arrow/memory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReaderCatchPanic(t *testing.T) {
+	alloc := memory.NewGoAllocator()
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "s", Type: arrow.BinaryTypes.String},
+	}, nil)
+
+	b := array.NewRecordBuilder(alloc, schema)
+	defer b.Release()
+
+	b.Field(0).(*array.StringBuilder).AppendValues([]string{"foo", "bar", "baz"}, nil)
+	rec := b.NewRecord()
+	defer rec.Release()
+
+	buf := new(bytes.Buffer)
+	writer := NewWriter(buf, WithSchema(schema))
+	require.NoError(t, writer.Write(rec))
+
+	for i := buf.Len() - 100; i < buf.Len(); i++ {
+		buf.Bytes()[i] = 0
+	}
+
+	reader, err := NewReader(buf)
+	require.NoError(t, err)
+
+	_, err = reader.Read()
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "arrow/ipc: unknown error while reading")
+	}
+}


### PR DESCRIPTION
Add a check for invalid offsets in a string array and panic. This
prevents panic'ing later when accessing the column data or
attempting to write it with ipc.Writer.