### PR TITLE
ARROW-14771: [C++] Export Protobuf symbol table

### DIFF
--- a/cpp/src/arrow/symbols.map
+++ b/cpp/src/arrow/symbols.map
@@ -33,6 +33,8 @@
     # Also export C-level helpers
     arrow_*;
     pyarrow_*;
+    # ARROW-14771: export Protobuf symbol table
+    descriptor_table_Flight_2eproto;
 
   # Symbols marked as 'local' are not exported by the DSO and thus may not
   # be used by client applications.  Everything except the above falls here.


### PR DESCRIPTION
This makes it possible to build applications that have Protobuf dependencies on Flight.proto and link to Arrow.