### PR TITLE
ARROW-16424: [C++] Update uri_path parsing in FromProto

### DIFF
--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -27,6 +27,7 @@
 #include "arrow/engine/substrait/type_internal.h"
 #include "arrow/filesystem/localfs.h"
 #include "arrow/filesystem/util_internal.h"
+#include "arrow/util/uri.h"
 
 namespace arrow {
 namespace engine {

--- a/cpp/src/arrow/engine/substrait/relation_internal.h
+++ b/cpp/src/arrow/engine/substrait/relation_internal.h
@@ -24,6 +24,7 @@
 #include "arrow/engine/substrait/serde.h"
 #include "arrow/engine/substrait/visibility.h"
 #include "arrow/type_fwd.h"
+#include "arrow/util/uri.h"
 
 #include "substrait/relations.pb.h"  // IWYU pragma: export
 

--- a/cpp/src/arrow/engine/substrait/relation_internal.h
+++ b/cpp/src/arrow/engine/substrait/relation_internal.h
@@ -24,7 +24,6 @@
 #include "arrow/engine/substrait/serde.h"
 #include "arrow/engine/substrait/visibility.h"
 #include "arrow/type_fwd.h"
-#include "arrow/util/uri.h"
 
 #include "substrait/relations.pb.h"  // IWYU pragma: export
 

--- a/cpp/src/arrow/util/uri.cc
+++ b/cpp/src/arrow/util/uri.cc
@@ -208,6 +208,8 @@ std::string Uri::path() const {
   return std::move(ss).str();
 }
 
+std::string Uri::extension() const { return impl_->path_segments_.back().to_string(); }
+
 std::string Uri::query_string() const { return TextRangeToString(impl_->uri_.query); }
 
 Result<std::vector<std::pair<std::string, std::string>>> Uri::query_items() const {

--- a/cpp/src/arrow/util/uri.cc
+++ b/cpp/src/arrow/util/uri.cc
@@ -208,7 +208,11 @@ std::string Uri::path() const {
   return std::move(ss).str();
 }
 
-std::string Uri::extension() const { return impl_->path_segments_.back().to_string(); }
+std::string Uri::extension() const { 
+  std::string filename = impl_->path_segments_.back().to_string();
+  size_t extension_index = filename.find(".");
+  return filename.substr(extension_index); 
+}
 
 std::string Uri::query_string() const { return TextRangeToString(impl_->uri_.query); }
 

--- a/cpp/src/arrow/util/uri.h
+++ b/cpp/src/arrow/util/uri.h
@@ -68,6 +68,8 @@ class ARROW_EXPORT Uri {
   /// The URI path component.
   std::string path() const;
 
+  std::string extension() const;
+
   /// The URI query string
   std::string query_string() const;
 

--- a/cpp/src/arrow/util/uri.h
+++ b/cpp/src/arrow/util/uri.h
@@ -68,6 +68,7 @@ class ARROW_EXPORT Uri {
   /// The URI path component.
   std::string path() const;
 
+  /// The Extension component for file
   std::string extension() const;
 
   /// The URI query string


### PR DESCRIPTION
This PR updates the parsing of paths using the `UriParser` in `relation_internal.cc`, where a method is also introduced for extracting the extension component from a file path.