### PR TITLE
ARROW-16824: [C++] Migrate VectorKernels to use ExecSpan, split out ChunkedArray execution

### DIFF
--- a/cpp/src/arrow/array/array_primitive.cc
+++ b/cpp/src/arrow/array/array_primitive.cc
@@ -58,18 +58,9 @@ int64_t BooleanArray::false_count() const {
 int64_t BooleanArray::true_count() const {
   if (data_->null_count.load() != 0) {
     DCHECK(data_->buffers[0]);
-    internal::BinaryBitBlockCounter bit_counter(data_->buffers[0]->data(), data_->offset,
-                                                data_->buffers[1]->data(), data_->offset,
-                                                data_->length);
-    int64_t count = 0;
-    while (true) {
-      internal::BitBlockCount block = bit_counter.NextAndWord();
-      if (block.length == 0) {
-        break;
-      }
-      count += block.popcount;
-    }
-    return count;
+    return internal::CountAndSetBits(data_->buffers[0]->data(), data_->offset,
+                                     data_->buffers[1]->data(), data_->offset,
+                                     data_->length);
   } else {
     return internal::CountSetBits(data_->buffers[1]->data(), data_->offset,
                                   data_->length);

--- a/cpp/src/arrow/array/data.cc
+++ b/cpp/src/arrow/array/data.cc
@@ -152,8 +152,8 @@ void ArraySpan::SetMembers(const ArrayData& data) {
   }
 
   Type::type type_id = this->type->id();
-  if (data.buffers[0] = nullptr && type_id != Type::NA && type_id != Type::SPARSE_UNION &&
-                        type_id != Type::DENSE_UNION) {
+  if (data.buffers[0] == nullptr && type_id != Type::NA &&
+      type_id != Type::SPARSE_UNION && type_id != Type::DENSE_UNION) {
     // This should already be zero but we make for sure
     this->null_count = 0;
   }

--- a/cpp/src/arrow/array/data.cc
+++ b/cpp/src/arrow/array/data.cc
@@ -215,7 +215,6 @@ int64_t ArraySpan::GetNullCount() const {
 int GetNumBuffers(const DataType& type) {
   switch (type.id()) {
     case Type::NA:
-      return 0;
     case Type::STRUCT:
     case Type::FIXED_SIZE_LIST:
       return 1;

--- a/cpp/src/arrow/array/data.cc
+++ b/cpp/src/arrow/array/data.cc
@@ -232,7 +232,7 @@ int ArraySpan::num_buffers() const { return GetNumBuffers(*this->type); }
 
 std::shared_ptr<ArrayData> ArraySpan::ToArrayData() const {
   auto result = std::make_shared<ArrayData>(this->type->Copy(), this->length,
-                                            kUnknownNullCount, this->offset);
+                                            this->null_count, this->offset);
 
   for (int i = 0; i < this->num_buffers(); ++i) {
     if (this->buffers[i].owner) {

--- a/cpp/src/arrow/array/data.cc
+++ b/cpp/src/arrow/array/data.cc
@@ -151,6 +151,13 @@ void ArraySpan::SetMembers(const ArrayData& data) {
     }
   }
 
+  Type::type type_id = this->type->id();
+  if (data.buffers[0] = nullptr && type_id != Type::NA && type_id != Type::SPARSE_UNION &&
+                        type_id != Type::DENSE_UNION) {
+    // This should already be zero but we make for sure
+    this->null_count = 0;
+  }
+
   // Makes sure any other buffers are seen as null / non-existent
   for (int i = static_cast<int>(data.buffers.size()); i < 3; ++i) {
     ClearBuffer(i);

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -170,7 +170,7 @@ struct DictionaryBuilderCase {
       out->reset(new internal::DictionaryBuilderBase<TypeErasedIntBuilder, ValueType>(
           index_type, value_type, pool));
     } else {
-      auto start_int_size = internal::GetByteWidth(*index_type);
+      auto start_int_size = index_type->byte_width();
       out->reset(new AdaptiveBuilderType(start_int_size, value_type, pool));
     }
     return Status::OK();

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -1022,10 +1022,10 @@ bool IntegerTensorEquals(const Tensor& left, const Tensor& right) {
     if (!(left_row_major_p && right_row_major_p) &&
         !(left_column_major_p && right_column_major_p)) {
       const auto& type = checked_cast<const FixedWidthType&>(*left.type());
-      are_equal = StridedIntegerTensorContentEquals(0, 0, 0, internal::GetByteWidth(type),
-                                                    left, right);
+      are_equal =
+          StridedIntegerTensorContentEquals(0, 0, 0, type.byte_width(), left, right);
     } else {
-      const int byte_width = internal::GetByteWidth(*left.type());
+      const int byte_width = left.type()->byte_width();
       DCHECK_GT(byte_width, 0);
 
       const uint8_t* left_data = left.data()->data();
@@ -1195,7 +1195,7 @@ struct SparseTensorEqualsImpl<SparseIndexType, SparseIndexType> {
       return false;
     }
 
-    const int byte_width = internal::GetByteWidth(*left.type());
+    const int byte_width = left.type()->byte_width();
     DCHECK_GT(byte_width, 0);
 
     const uint8_t* left_data = left.data()->data();

--- a/cpp/src/arrow/compute/api_vector.cc
+++ b/cpp/src/arrow/compute/api_vector.cc
@@ -313,10 +313,7 @@ Result<std::shared_ptr<Array>> SortIndices(const ChunkedArray& chunked_array,
 
 Result<std::shared_ptr<Array>> SortIndices(const ChunkedArray& chunked_array,
                                            SortOrder order, ExecContext* ctx) {
-  SortOptions options({SortKey("not-used", order)});
-  ARROW_ASSIGN_OR_RAISE(
-      Datum result, CallFunction("sort_indices", {Datum(chunked_array)}, &options, ctx));
-  return result.make_array();
+  return SortIndices(chunked_array, ArraySortOptions(order.order), ctx);
 }
 
 Result<std::shared_ptr<Array>> SortIndices(const Datum& datum, const SortOptions& options,

--- a/cpp/src/arrow/compute/api_vector.cc
+++ b/cpp/src/arrow/compute/api_vector.cc
@@ -301,8 +301,7 @@ Result<std::shared_ptr<Array>> SortIndices(const ChunkedArray& chunked_array,
                                            ExecContext* ctx) {
   KernelContext kernel_ctx(ctx);
   ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Buffer> out,
-                        kernel_ctx.Allocate(chunked_array.length() *
-                                            sizeof(uint64_t)));
+                        kernel_ctx.Allocate(chunked_array.length() * sizeof(uint64_t)));
   uint64_t* out_begin = reinterpret_cast<uint64_t*>(out->mutable_data());
   uint64_t* out_end = out_begin + out_arr->length;
   std::iota(out_begin, out_end, 0);

--- a/cpp/src/arrow/compute/api_vector.cc
+++ b/cpp/src/arrow/compute/api_vector.cc
@@ -298,6 +298,15 @@ Result<std::shared_ptr<Array>> SortIndices(const ChunkedArray& chunked_array,
                                            const ArraySortOptions& array_options,
                                            ExecContext* ctx) {
   SortOptions options({SortKey("", array_options.order)}, array_options.null_placement);
+
+  uint64_t* out_begin = out_arr->GetValues<uint64_t>(1);
+  uint64_t* out_end = out_begin + out_arr->length;
+  std::iota(out_begin, out_end, 0);
+
+      return SortChunkedArray(ctx->exec_context(), out_begin, out_end,
+                              *batch[0].chunked_array(), options.order,
+                              options.null_placement);
+
   ARROW_ASSIGN_OR_RAISE(
       Datum result, CallFunction("sort_indices", {Datum(chunked_array)}, &options, ctx));
   return result.make_array();

--- a/cpp/src/arrow/compute/api_vector.cc
+++ b/cpp/src/arrow/compute/api_vector.cc
@@ -318,9 +318,13 @@ Result<std::shared_ptr<Array>> SortIndices(const ChunkedArray& chunked_array,
 
 Result<std::shared_ptr<Array>> SortIndices(const Datum& datum, const SortOptions& options,
                                            ExecContext* ctx) {
-  ARROW_ASSIGN_OR_RAISE(Datum result,
-                        CallFunction("sort_indices", {datum}, &options, ctx));
-  return result.make_array();
+  if (datum.is_chunked_array()) {
+    return SortIndices(*datum.chunked_array(), options, ctx);
+  } else if (datum.is_array()) {
+    return SortIndices(*datum.array(), options, ctx);
+  } else {
+    return Status::Invalid("Can only sort array-like data");
+  }
 }
 
 Result<std::shared_ptr<Array>> Unique(const Datum& value, ExecContext* ctx) {

--- a/cpp/src/arrow/compute/api_vector.h
+++ b/cpp/src/arrow/compute/api_vector.h
@@ -275,14 +275,14 @@ namespace internal {
 
 /// \brief Return the number of selected indices in the boolean filter
 ARROW_EXPORT
-int64_t GetFilterOutputSize(const ArrayData& filter,
+int64_t GetFilterOutputSize(const ArraySpan& filter,
                             FilterOptions::NullSelectionBehavior null_selection);
 
 /// \brief Compute uint64 selection indices for use with Take given a boolean
 /// filter
 ARROW_EXPORT
 Result<std::shared_ptr<ArrayData>> GetTakeIndices(
-    const ArrayData& filter, FilterOptions::NullSelectionBehavior null_selection,
+    const ArraySpan& filter, FilterOptions::NullSelectionBehavior null_selection,
     MemoryPool* memory_pool = default_memory_pool());
 
 }  // namespace internal

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -338,9 +338,7 @@ Status ExecSpanIterator::Init(const ExecBatch& batch, ValueDescr::Shape output_s
       return Status::Invalid("Value lengths differed from ExecBatch length");
     }
     if (!all_args_same_length) {
-      return Status::Invalid(
-          "ExecSpanIterator cannot be used with arguments of "
-          "different lengths");
+      return Status::Invalid("Array arguments must all be the same length");
     }
   }
   args_ = &batch.values;

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -338,8 +338,9 @@ Status ExecSpanIterator::Init(const ExecBatch& batch, ValueDescr::Shape output_s
       return Status::Invalid("Value lengths differed from ExecBatch length");
     }
     if (!all_args_same_length) {
-      return Status::Invalid("ExecSpanIterator cannot be used with arguments of "
-                             "different lengths");
+      return Status::Invalid(
+          "ExecSpanIterator cannot be used with arguments of "
+          "different lengths");
     }
   }
   args_ = &batch.values;

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -991,43 +991,62 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
   ExecSpanIterator span_iterator_;
 };
 
-Status PackBatchNoChunks(const std::vector<Datum>& args, ExecBatch* out) {
-  int64_t length = 0;
-  for (const auto& arg : args) {
-    switch (arg.kind()) {
-      case Datum::SCALAR:
-      case Datum::ARRAY:
-      case Datum::CHUNKED_ARRAY:
-        length = std::max(arg.length(), length);
-        break;
-      default:
-        DCHECK(false);
-        break;
-    }
-  }
-  out->length = length;
-  out->values = args;
-  return Status::OK();
-}
-
 class VectorExecutor : public KernelExecutorImpl<VectorKernel> {
  public:
-  Status ExecuteImpl(const std::vector<Datum>& args, ExecListener* listener) {
-    RETURN_NOT_OK(PrepareExecute(args));
-    ExecBatch batch;
+  Status Execute(const ExecBatch& batch, ExecListener* listener) override {
+    // TODO(wesm): remove in ARROW-16577
+    if (output_descr_.shape == ValueDescr::SCALAR) {
+      return Status::Invalid("VectorExecutor only supports array output types");
+    }
+
+    // Some vector kernels have a separate code path for handling
+    // chunked arrays (VectorKernel::exec_chunked) so we check if we
+    // have any chunked arrays. If we do and an exec_chunked function
+    // is defined then we call that.
+    bool have_chunked_arrays = false;
+    for (const Datum& arg : batch.values) {
+      if (arg.is_chunked_array()) have_chunked_arrays = true;
+    }
+
+    output_num_buffers_ = static_cast<int>(output_descr_.type->layout().buffers.size());
+
+    // Decide if we need to preallocate memory for this kernel
+    validity_preallocated_ =
+        (kernel_->null_handling != NullHandling::COMPUTED_NO_PREALLOCATE &&
+         kernel_->null_handling != NullHandling::OUTPUT_NOT_NULL);
+    if (kernel_->mem_allocation == MemAllocation::PREALLOCATE) {
+      ComputeDataPreallocate(*output_descr_.type, &data_preallocated_);
+    }
+
     if (kernel_->can_execute_chunkwise) {
-      while (batch_iterator_->Next(&batch)) {
-        RETURN_NOT_OK(ExecuteBatch(batch, listener));
+      RETURN_NOT_OK(span_iterator_.Init(batch, output_descr_.shape,
+                                        exec_context()->exec_chunksize()));
+      ExecSpan span;
+      while (span_iterator_.Next(&span)) {
+        RETURN_NOT_OK(Exec(span, listener));
       }
     } else {
-      RETURN_NOT_OK(PackBatchNoChunks(args, &batch));
-      RETURN_NOT_OK(ExecuteBatch(batch, listener));
+      // Kernel cannot execute chunkwise. If we have any chunked
+      // arrays, then VectorKernel::exec_chunked must be defined
+      // otherwise we raise an error
+      if (have_chunked_arrays) {
+        RETURN_NOT_OK(ExecChunked(batch, listener));
+      } else {
+        // No chunked arrays. We pack the args into an ExecSpan and
+        // call the regular exec code path
+        RETURN_NOT_OK(Exec(ExecSpan(batch), listener));
+      }
     }
-    return Finalize(listener);
-  }
 
-  Status Execute(const ExecBatch& batch, ExecListener* listener) override {
-    return ExecuteImpl(batch.values, listener);
+    if (kernel_->finalize) {
+      // Intermediate results require post-processing after the execution is
+      // completed (possibly involving some accumulated state)
+      RETURN_NOT_OK(kernel_->finalize(kernel_ctx_, &results_));
+      for (const auto& result : results_) {
+        RETURN_NOT_OK(listener->OnResult(result));
+      }
+    }
+    return Status::OK();
   }
 
   Datum WrapResults(const std::vector<Datum>& inputs,
@@ -1047,19 +1066,43 @@ class VectorExecutor : public KernelExecutorImpl<VectorKernel> {
   }
 
  protected:
-  Status ExecuteBatch(const ExecBatch& batch, ExecListener* listener) {
-    Datum out;
-    if (output_descr_.shape == ValueDescr::ARRAY) {
-      // We preallocate (maybe) only for the output of processing the current
-      // batch
-      ARROW_ASSIGN_OR_RAISE(out.value, PrepareOutput(batch.length));
+  Status Exec(const ExecSpan& span, ExecListener* listener) {
+    ExecResult out;
+
+    // We preallocate (maybe) only for the output of processing the current
+    // batch, but create an output ArrayData instance regardless
+    ARROW_ASSIGN_OR_RAISE(out.value, PrepareOutput(span.length));
+
+    if (kernel_->null_handling == NullHandling::INTERSECTION) {
+      RETURN_NOT_OK(PropagateNulls(kernel_ctx_, span, out.array_data().get()));
+    }
+    RETURN_NOT_OK(kernel_->exec(kernel_ctx_, span, &out));
+    if (!kernel_->finalize) {
+      // If there is no result finalizer (e.g. for hash-based functions, we can
+      // emit the processed batch right away rather than waiting
+      RETURN_NOT_OK(listener->OnResult(out.array_data()));
+    } else {
+      results_.emplace_back(out.array_data());
+    }
+    return Status::OK();
+  }
+
+  Status ExecChunked(const ExecBatch& batch, ExecListener* listener) {
+    if (kernel_->exec_chunked == nullptr) {
+      return Status::Invalid(
+          "Vector kernel cannot execute chunkwise and no "
+          "chunked exec function was defined");
     }
 
-    if (kernel_->null_handling == NullHandling::INTERSECTION &&
-        output_descr_.shape == ValueDescr::ARRAY) {
-      RETURN_NOT_OK(PropagateNulls(kernel_ctx_, ExecSpan(batch), out.mutable_array()));
+    if (kernel_->null_handling == NullHandling::INTERSECTION) {
+      return Status::Invalid(
+          "Null pre-propagation is unsupported for ChunkedArray "
+          "execution in vector kernels");
     }
-    RETURN_NOT_OK(kernel_->exec(kernel_ctx_, batch, &out));
+
+    Datum out;
+    ARROW_ASSIGN_OR_RAISE(out.value, PrepareOutput(batch.length));
+    RETURN_NOT_OK(kernel_->exec_chunked(kernel_ctx_, batch, &out));
     if (!kernel_->finalize) {
       // If there is no result finalizer (e.g. for hash-based functions, we can
       // emit the processed batch right away rather than waiting
@@ -1070,36 +1113,7 @@ class VectorExecutor : public KernelExecutorImpl<VectorKernel> {
     return Status::OK();
   }
 
-  Status Finalize(ExecListener* listener) {
-    if (kernel_->finalize) {
-      // Intermediate results require post-processing after the execution is
-      // completed (possibly involving some accumulated state)
-      RETURN_NOT_OK(kernel_->finalize(kernel_ctx_, &results_));
-      for (const auto& result : results_) {
-        RETURN_NOT_OK(listener->OnResult(result));
-      }
-    }
-    return Status::OK();
-  }
-
-  Status PrepareExecute(const std::vector<Datum>& args) {
-    if (kernel_->can_execute_chunkwise) {
-      ARROW_ASSIGN_OR_RAISE(batch_iterator_, ExecBatchIterator::Make(
-                                                 args, exec_context()->exec_chunksize()));
-    }
-    output_num_buffers_ = static_cast<int>(output_descr_.type->layout().buffers.size());
-
-    // Decide if we need to preallocate memory for this kernel
-    validity_preallocated_ =
-        (kernel_->null_handling != NullHandling::COMPUTED_NO_PREALLOCATE &&
-         kernel_->null_handling != NullHandling::OUTPUT_NOT_NULL);
-    if (kernel_->mem_allocation == MemAllocation::PREALLOCATE) {
-      ComputeDataPreallocate(*output_descr_.type, &data_preallocated_);
-    }
-    return Status::OK();
-  }
-
-  std::unique_ptr<ExecBatchIterator> batch_iterator_;
+  ExecSpanIterator span_iterator_;
   std::vector<Datum> results_;
 };
 

--- a/cpp/src/arrow/compute/exec.h
+++ b/cpp/src/arrow/compute/exec.h
@@ -20,7 +20,6 @@
 
 #pragma once
 
-#include <algorithm>
 #include <atomic>
 #include <cstdint>
 #include <limits>
@@ -397,8 +396,12 @@ struct ARROW_EXPORT ExecSpan {
   }
 
   bool is_all_scalar() const {
-    return std::all_of(this->values.begin(), this->values.end(),
-                       [](const ExecValue& v) { return v.is_scalar(); });
+    for (const ExecValue& value : this->values) {
+      if (value.is_array()) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /// \brief Return the value at the i-th index

--- a/cpp/src/arrow/compute/exec/expression.cc
+++ b/cpp/src/arrow/compute/exec/expression.cc
@@ -419,7 +419,7 @@ Result<Expression> BindNonRecursive(Expression::Call call, bool insert_implicit_
     }
   }
 
-  compute::KernelContext kernel_context(exec_context);
+  compute::KernelContext kernel_context(exec_context, call.kernel);
   if (call.kernel->init) {
     const FunctionOptions* options =
         call.options ? call.options.get() : call.function->default_options();
@@ -593,7 +593,7 @@ Result<Datum> ExecuteScalarExpression(const Expression& expr, const ExecBatch& i
 
   auto executor = compute::detail::KernelExecutor::MakeScalar();
 
-  compute::KernelContext kernel_context(exec_context);
+  compute::KernelContext kernel_context(exec_context, call->kernel);
   kernel_context.SetState(call->kernel_state.get());
 
   auto kernel = call->kernel;

--- a/cpp/src/arrow/compute/exec/hash_join.cc
+++ b/cpp/src/arrow/compute/exec/hash_join.cc
@@ -127,7 +127,7 @@ class HashJoinBasicImpl : public HashJoinImpl {
       *opt_projected_batch = projected;
     }
 
-    return encoder->EncodeAndAppend(projected);
+    return encoder->EncodeAndAppend(ExecSpan(projected));
   }
 
   void ProbeBatch_Lookup(ThreadLocalState* local_state, const RowEncoder& exec_batch_keys,

--- a/cpp/src/arrow/compute/exec/hash_join_node_test.cc
+++ b/cpp/src/arrow/compute/exec/hash_join_node_test.cc
@@ -496,7 +496,7 @@ std::vector<std::shared_ptr<Array>> GenRandomUniqueRecords(
   for (size_t i = 0; i < result.size(); ++i) {
     batch.values[i] = result[i];
   }
-  Status status = encoder.EncodeAndAppend(batch);
+  Status status = encoder.EncodeAndAppend(ExecSpan(batch));
   ARROW_DCHECK(status.ok());
 
   std::unordered_map<std::string, int> uniques;

--- a/cpp/src/arrow/compute/exec/tpch_node.cc
+++ b/cpp/src/arrow/compute/exec/tpch_node.cc
@@ -844,7 +844,7 @@ class PartAndPartSupplierGenerator {
   Status AllocatePartBatch(size_t thread_index, int column) {
     ThreadLocalData& tld = thread_local_data_[thread_index];
     ARROW_DCHECK(tld.part[column].kind() == Datum::NONE);
-    int32_t byte_width = arrow::internal::GetByteWidth(*kPartTypes[column]);
+    int32_t byte_width = kPartTypes[column]->byte_width();
     ARROW_ASSIGN_OR_RAISE(std::unique_ptr<Buffer> buff,
                           AllocateBuffer(tld.part_to_generate * byte_width));
     ArrayData ad(kPartTypes[column], tld.part_to_generate, {nullptr, std::move(buff)});
@@ -917,7 +917,7 @@ class PartAndPartSupplierGenerator {
       RETURN_NOT_OK(AllocatePartBatch(thread_index, PART::P_MFGR));
       char* p_mfgr = reinterpret_cast<char*>(
           tld.part[PART::P_MFGR].array()->buffers[1]->mutable_data());
-      int32_t byte_width = arrow::internal::GetByteWidth(*kPartTypes[PART::P_MFGR]);
+      int32_t byte_width = kPartTypes[PART::P_MFGR]->byte_width();
       for (int64_t irow = 0; irow < tld.part_to_generate; irow++) {
         std::strncpy(p_mfgr + byte_width * irow, manufacturer, byte_width);
         char mfgr_id = '0' + dist(tld.rng);
@@ -939,8 +939,8 @@ class PartAndPartSupplierGenerator {
           tld.part[PART::P_MFGR].array()->buffers[1]->data());
       char* p_brand = reinterpret_cast<char*>(
           tld.part[PART::P_BRAND].array()->buffers[1]->mutable_data());
-      int32_t byte_width = arrow::internal::GetByteWidth(*kPartTypes[PART::P_BRAND]);
-      int32_t mfgr_byte_width = arrow::internal::GetByteWidth(*kPartTypes[PART::P_MFGR]);
+      int32_t byte_width = kPartTypes[PART::P_BRAND]->byte_width();
+      int32_t mfgr_byte_width = kPartTypes[PART::P_MFGR]->byte_width();
       const size_t mfgr_id_offset = std::strlen("Manufacturer#");
       for (int64_t irow = 0; irow < tld.part_to_generate; irow++) {
         char* row = p_brand + byte_width * irow;
@@ -1023,7 +1023,7 @@ class PartAndPartSupplierGenerator {
       RETURN_NOT_OK(AllocatePartBatch(thread_index, PART::P_CONTAINER));
       char* p_container = reinterpret_cast<char*>(
           tld.part[PART::P_CONTAINER].array()->buffers[1]->mutable_data());
-      int32_t byte_width = arrow::internal::GetByteWidth(*kPartTypes[PART::P_CONTAINER]);
+      int32_t byte_width = kPartTypes[PART::P_CONTAINER]->byte_width();
       for (int64_t irow = 0; irow < tld.part_to_generate; irow++) {
         int container1_idx = dist1(tld.rng);
         int container2_idx = dist2(tld.rng);
@@ -1090,7 +1090,7 @@ class PartAndPartSupplierGenerator {
 
   Status AllocatePartSuppBatch(size_t thread_index, size_t ibatch, int column) {
     ThreadLocalData& tld = thread_local_data_[thread_index];
-    int32_t byte_width = arrow::internal::GetByteWidth(*kPartsuppTypes[column]);
+    int32_t byte_width = kPartsuppTypes[column]->byte_width();
     ARROW_ASSIGN_OR_RAISE(std::unique_ptr<Buffer> buff,
                           AllocateResizableBuffer(batch_size_ * byte_width));
     ArrayData ad(kPartsuppTypes[column], batch_size_, {nullptr, std::move(buff)});
@@ -1101,7 +1101,7 @@ class PartAndPartSupplierGenerator {
   Status SetPartSuppColumnSize(size_t thread_index, size_t ibatch, int column,
                                size_t new_size) {
     ThreadLocalData& tld = thread_local_data_[thread_index];
-    int32_t byte_width = arrow::internal::GetByteWidth(*kPartsuppTypes[column]);
+    int32_t byte_width = kPartsuppTypes[column]->byte_width();
     tld.partsupp[ibatch][column].array()->length = static_cast<int64_t>(new_size);
     ResizableBuffer* buff = checked_cast<ResizableBuffer*>(
         tld.partsupp[ibatch][column].array()->buffers[1].get());
@@ -1554,7 +1554,7 @@ class OrdersAndLineItemGenerator {
   Status AllocateOrdersBatch(size_t thread_index, int column) {
     ThreadLocalData& tld = thread_local_data_[thread_index];
     ARROW_DCHECK(tld.orders[column].kind() == Datum::NONE);
-    int32_t byte_width = arrow::internal::GetByteWidth(*kOrdersTypes[column]);
+    int32_t byte_width = kOrdersTypes[column]->byte_width();
     ARROW_ASSIGN_OR_RAISE(std::unique_ptr<Buffer> buff,
                           AllocateBuffer(tld.orders_to_generate * byte_width));
     ArrayData ad(kOrdersTypes[column], tld.orders_to_generate,
@@ -1711,8 +1711,7 @@ class OrdersAndLineItemGenerator {
     ThreadLocalData& tld = thread_local_data_[thread_index];
     if (tld.orders[ORDERS::O_ORDERPRIORITY].kind() == Datum::NONE) {
       RETURN_NOT_OK(AllocateOrdersBatch(thread_index, ORDERS::O_ORDERPRIORITY));
-      int32_t byte_width =
-          arrow::internal::GetByteWidth(*kOrdersTypes[ORDERS::O_ORDERPRIORITY]);
+      int32_t byte_width = kOrdersTypes[ORDERS::O_ORDERPRIORITY]->byte_width();
       std::uniform_int_distribution<int32_t> dist(0, kNumPriorities - 1);
       char* o_orderpriority = reinterpret_cast<char*>(
           tld.orders[ORDERS::O_ORDERPRIORITY].array()->buffers[1]->mutable_data());
@@ -1728,7 +1727,7 @@ class OrdersAndLineItemGenerator {
     ThreadLocalData& tld = thread_local_data_[thread_index];
     if (tld.orders[ORDERS::O_CLERK].kind() == Datum::NONE) {
       RETURN_NOT_OK(AllocateOrdersBatch(thread_index, ORDERS::O_CLERK));
-      int32_t byte_width = arrow::internal::GetByteWidth(*kOrdersTypes[ORDERS::O_CLERK]);
+      int32_t byte_width = kOrdersTypes[ORDERS::O_CLERK]->byte_width();
       int64_t max_clerk_id = static_cast<int64_t>(scale_factor_ * 1000);
       std::uniform_int_distribution<int64_t> dist(1, max_clerk_id);
       char* o_clerk = reinterpret_cast<char*>(
@@ -1792,7 +1791,7 @@ class OrdersAndLineItemGenerator {
     ThreadLocalData& tld = thread_local_data_[thread_index];
     if (tld.lineitem[ibatch][column].kind() == Datum::NONE) {
       ARROW_DCHECK(ibatch != 0 || tld.first_batch_offset == 0);
-      int32_t byte_width = arrow::internal::GetByteWidth(*kLineitemTypes[column]);
+      int32_t byte_width = kLineitemTypes[column]->byte_width();
       ARROW_ASSIGN_OR_RAISE(std::unique_ptr<Buffer> buff,
                             AllocateResizableBuffer(batch_size_ * byte_width));
       ArrayData ad(kLineitemTypes[column], batch_size_, {nullptr, std::move(buff)});
@@ -1807,7 +1806,7 @@ class OrdersAndLineItemGenerator {
   Status SetLineItemColumnSize(size_t thread_index, size_t ibatch, int column,
                                size_t new_size) {
     ThreadLocalData& tld = thread_local_data_[thread_index];
-    int32_t byte_width = arrow::internal::GetByteWidth(*kLineitemTypes[column]);
+    int32_t byte_width = kLineitemTypes[column]->byte_width();
     tld.lineitem[ibatch][column].array()->length = static_cast<int64_t>(new_size);
     ResizableBuffer* buff = checked_cast<ResizableBuffer*>(
         tld.lineitem[ibatch][column].array()->buffers[1].get());
@@ -2283,8 +2282,7 @@ class OrdersAndLineItemGenerator {
     ThreadLocalData& tld = thread_local_data_[thread_index];
     if (!tld.generated_lineitem[LINEITEM::L_SHIPINSTRUCT]) {
       tld.generated_lineitem[LINEITEM::L_SHIPINSTRUCT] = true;
-      int32_t byte_width =
-          arrow::internal::GetByteWidth(*kLineitemTypes[LINEITEM::L_SHIPINSTRUCT]);
+      int32_t byte_width = kLineitemTypes[LINEITEM::L_SHIPINSTRUCT]->byte_width();
       size_t ibatch = 0;
       std::uniform_int_distribution<size_t> dist(0, kNumInstructions - 1);
       for (int64_t irow = 0; irow < tld.lineitem_to_generate; ibatch++) {
@@ -2318,8 +2316,7 @@ class OrdersAndLineItemGenerator {
     ThreadLocalData& tld = thread_local_data_[thread_index];
     if (!tld.generated_lineitem[LINEITEM::L_SHIPMODE]) {
       tld.generated_lineitem[LINEITEM::L_SHIPMODE] = true;
-      int32_t byte_width =
-          arrow::internal::GetByteWidth(*kLineitemTypes[LINEITEM::L_SHIPMODE]);
+      int32_t byte_width = kLineitemTypes[LINEITEM::L_SHIPMODE]->byte_width();
       size_t ibatch = 0;
       std::uniform_int_distribution<size_t> dist(0, kNumModes - 1);
       for (int64_t irow = 0; irow < tld.lineitem_to_generate; ibatch++) {
@@ -2530,7 +2527,7 @@ class SupplierGenerator : public TpchTableGenerator {
   Status AllocateColumn(size_t thread_index, int column) {
     ThreadLocalData& tld = thread_local_data_[thread_index];
     ARROW_DCHECK(tld.batch[column].kind() == Datum::NONE);
-    int32_t byte_width = arrow::internal::GetByteWidth(*kTypes[column]);
+    int32_t byte_width = kTypes[column]->byte_width();
     ARROW_ASSIGN_OR_RAISE(std::unique_ptr<Buffer> buff,
                           AllocateBuffer(tld.to_generate * byte_width));
     ArrayData ad(kTypes[column], tld.to_generate, {nullptr, std::move(buff)});
@@ -2558,7 +2555,7 @@ class SupplierGenerator : public TpchTableGenerator {
       const int32_t* s_suppkey = reinterpret_cast<const int32_t*>(
           tld.batch[SUPPLIER::S_SUPPKEY].array()->buffers[1]->data());
       RETURN_NOT_OK(AllocateColumn(thread_index, SUPPLIER::S_NAME));
-      int32_t byte_width = arrow::internal::GetByteWidth(*kTypes[SUPPLIER::S_NAME]);
+      int32_t byte_width = kTypes[SUPPLIER::S_NAME]->byte_width();
       char* s_name = reinterpret_cast<char*>(
           tld.batch[SUPPLIER::S_NAME].array()->buffers[1]->mutable_data());
       // Look man, I'm just following the spec ok? Section 4.2.3 as of March 1 2022
@@ -2600,7 +2597,7 @@ class SupplierGenerator : public TpchTableGenerator {
     if (tld.batch[SUPPLIER::S_PHONE].kind() == Datum::NONE) {
       RETURN_NOT_OK(S_NATIONKEY(thread_index));
       RETURN_NOT_OK(AllocateColumn(thread_index, SUPPLIER::S_PHONE));
-      int32_t byte_width = arrow::internal::GetByteWidth(*kTypes[SUPPLIER::S_PHONE]);
+      int32_t byte_width = kTypes[SUPPLIER::S_PHONE]->byte_width();
       const int32_t* s_nationkey = reinterpret_cast<const int32_t*>(
           tld.batch[SUPPLIER::S_NATIONKEY].array()->buffers[1]->data());
       char* s_phone = reinterpret_cast<char*>(
@@ -2913,7 +2910,7 @@ class CustomerGenerator : public TpchTableGenerator {
   Status AllocateColumn(size_t thread_index, int column) {
     ThreadLocalData& tld = thread_local_data_[thread_index];
     ARROW_DCHECK(tld.batch[column].kind() == Datum::NONE);
-    int32_t byte_width = arrow::internal::GetByteWidth(*kTypes[column]);
+    int32_t byte_width = kTypes[column]->byte_width();
     ARROW_ASSIGN_OR_RAISE(std::unique_ptr<Buffer> buff,
                           AllocateBuffer(tld.to_generate * byte_width));
     ArrayData ad(kTypes[column], tld.to_generate, {nullptr, std::move(buff)});
@@ -2994,7 +2991,7 @@ class CustomerGenerator : public TpchTableGenerator {
     if (tld.batch[CUSTOMER::C_PHONE].kind() == Datum::NONE) {
       RETURN_NOT_OK(C_NATIONKEY(thread_index));
       RETURN_NOT_OK(AllocateColumn(thread_index, CUSTOMER::C_PHONE));
-      int32_t byte_width = arrow::internal::GetByteWidth(*kTypes[CUSTOMER::C_PHONE]);
+      int32_t byte_width = kTypes[CUSTOMER::C_PHONE]->byte_width();
       const int32_t* c_nationkey = reinterpret_cast<const int32_t*>(
           tld.batch[CUSTOMER::C_NATIONKEY].array()->buffers[1]->data());
       char* c_phone = reinterpret_cast<char*>(
@@ -3023,7 +3020,7 @@ class CustomerGenerator : public TpchTableGenerator {
     ThreadLocalData& tld = thread_local_data_[thread_index];
     if (tld.batch[CUSTOMER::C_MKTSEGMENT].kind() == Datum::NONE) {
       RETURN_NOT_OK(AllocateColumn(thread_index, CUSTOMER::C_MKTSEGMENT));
-      int32_t byte_width = arrow::internal::GetByteWidth(*kTypes[CUSTOMER::C_MKTSEGMENT]);
+      int32_t byte_width = kTypes[CUSTOMER::C_MKTSEGMENT]->byte_width();
       char* c_mktsegment = reinterpret_cast<char*>(
           tld.batch[CUSTOMER::C_MKTSEGMENT].array()->buffers[1]->mutable_data());
       std::uniform_int_distribution<int32_t> dist(0, kNumSegments - 1);

--- a/cpp/src/arrow/compute/exec_internal.h
+++ b/cpp/src/arrow/compute/exec_internal.h
@@ -179,7 +179,7 @@ class ARROW_EXPORT KernelExecutor {
   static std::unique_ptr<KernelExecutor> MakeScalarAggregate();
 };
 
-Result<int64_t> InferBatchLength(const std::vector<Datum>& values);
+int64_t InferBatchLength(const std::vector<Datum>& values, bool* all_same);
 
 /// \brief Populate validity bitmap with the intersection of the nullity of the
 /// arguments. If a preallocated bitmap is not provided, then one will be

--- a/cpp/src/arrow/compute/function.cc
+++ b/cpp/src/arrow/compute/function.cc
@@ -280,9 +280,7 @@ Result<Datum> Function::ExecuteInternal(const std::vector<Datum>& args,
     } else if (kind() == Function::VECTOR) {
       auto vkernel = static_cast<const VectorKernel*>(kernel);
       if (!(all_same_length || !vkernel->can_execute_chunkwise)) {
-        return Status::Invalid(
-            "Vector kernels can only execute chunkwise if all "
-            "arguments are the same length");
+        return Status::Invalid("Vector kernel arguments must all be the same length");
       }
     }
   }

--- a/cpp/src/arrow/compute/function.cc
+++ b/cpp/src/arrow/compute/function.cc
@@ -279,13 +279,10 @@ Result<Datum> Function::ExecuteInternal(const std::vector<Datum>& args,
       DCHECK(passed_length == -1 || passed_length == inferred_length);
     } else if (kind() == Function::VECTOR) {
       auto vkernel = static_cast<const VectorKernel*>(kernel);
-      DCHECK(all_same_length || !vkernel->can_execute_chunkwise) <<
-        "Vector kernels can only execute chunkwise if all arguments are the same length";
-      if (!all_same_length) {
-        // Do not make an assertion about batch length that is
-        // possibly untrue; ExecBatch only serves as a container to
-        // pass the arguments to the kernel now
-        input.length = 0;
+      if (!(all_same_length || !vkernel->can_execute_chunkwise)) {
+        return Status::Invalid(
+            "Vector kernels can only execute chunkwise if all "
+            "arguments are the same length");
       }
     }
   }

--- a/cpp/src/arrow/compute/function.cc
+++ b/cpp/src/arrow/compute/function.cc
@@ -252,11 +252,11 @@ Result<Datum> Function::ExecuteInternal(const std::vector<Datum>& args,
     return Status::NotImplemented("Direct execution of HASH_AGGREGATE functions");
   }
 
-  ARROW_ASSIGN_OR_RAISE(auto kernel, DispatchBest(&inputs));
+  ARROW_ASSIGN_OR_RAISE(const Kernel* kernel, DispatchBest(&inputs));
   ARROW_ASSIGN_OR_RAISE(std::vector<Datum> args_with_casts, Cast(args, inputs, ctx));
 
   std::unique_ptr<KernelState> state;
-  KernelContext kernel_ctx{ctx};
+  KernelContext kernel_ctx{ctx, kernel};
   if (kernel->init) {
     ARROW_ASSIGN_OR_RAISE(state, kernel->init(&kernel_ctx, {kernel, inputs, options}));
     kernel_ctx.SetState(state.get());

--- a/cpp/src/arrow/compute/function.cc
+++ b/cpp/src/arrow/compute/function.cc
@@ -366,7 +366,7 @@ Status ScalarFunction::AddKernel(ScalarKernel kernel) {
 }
 
 Status VectorFunction::AddKernel(std::vector<InputType> in_types, OutputType out_type,
-                                 ArrayKernelExecOld exec, KernelInit init) {
+                                 ArrayKernelExec exec, KernelInit init) {
   RETURN_NOT_OK(CheckArity(in_types));
 
   if (arity_.is_varargs && in_types.size() != 1) {

--- a/cpp/src/arrow/compute/function.h
+++ b/cpp/src/arrow/compute/function.h
@@ -344,7 +344,7 @@ class ARROW_EXPORT VectorFunction : public detail::FunctionImpl<VectorKernel> {
   /// state initialization, no data preallocation, and no preallocation of the
   /// validity bitmap.
   Status AddKernel(std::vector<InputType> in_types, OutputType out_type,
-                   ArrayKernelExecOld exec, KernelInit init = NULLPTR);
+                   ArrayKernelExec exec, KernelInit init = NULLPTR);
 
   /// \brief Add a kernel (function implementation). Returns error if the
   /// kernel's signature does not match the function's arity.

--- a/cpp/src/arrow/compute/function_test.cc
+++ b/cpp/src/arrow/compute/function_test.cc
@@ -214,10 +214,6 @@ auto ExecNYI = [](KernelContext* ctx, const ExecSpan& args, ExecResult* out) {
   return Status::NotImplemented("NYI");
 };
 
-auto ExecNYIOld = [](KernelContext* ctx, const ExecBatch& args, Datum* out) {
-  return Status::NotImplemented("NYI");
-};
-
 template <typename FunctionType, typename ExecType>
 void CheckAddDispatch(FunctionType* func, ExecType exec) {
   using KernelType = typename FunctionType::KernelType;
@@ -272,7 +268,7 @@ TEST(ScalarVectorFunction, DispatchExact) {
   CheckAddDispatch(&func1, ExecNYI);
 
   // ARROW-16576: will migrate later to new span-based kernel exec API
-  CheckAddDispatch(&func2, ExecNYIOld);
+  CheckAddDispatch(&func2, ExecNYI);
 }
 
 TEST(ArrayFunction, VarArgs) {

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -595,7 +595,7 @@ struct VectorKernel : public Kernel {
 
   /// \brief Function for executing a stateful VectorKernel against a
   /// ChunkedArray input. Does not need to be defined for all VectorKernels
-  typedef Status (*ChunkedExecFunc)(KernelContext*, const ExecBatch&, Datum* out)>;
+  typedef Status (*ChunkedExec)(KernelContext*, const ExecBatch&, Datum* out)>;
 
   VectorKernel() = default;
 
@@ -617,7 +617,7 @@ struct VectorKernel : public Kernel {
   ArrayKernelExec exec;
 
   /// \brief Execute the kernel on a ChunkedArray. Does not need to be defined
-  ChunkedExecFunc exec_chunked = NULLPTR;
+  ChunkedExec exec_chunked = NULLPTR;
 
   /// \brief For VectorKernel, convert intermediate results into finalized
   /// results. Mutates input argument. Some kernels may accumulate state

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -548,10 +548,6 @@ struct Kernel {
 using ArrayKernelExec =
     std::function<Status(KernelContext*, const ExecSpan&, ExecResult*)>;
 
-/// \brief Kernel execution API being phased out per ARROW-16756
-using ArrayKernelExecOld =
-    std::function<Status(KernelContext*, const ExecBatch&, Datum*)>;
-
 /// \brief Kernel data structure for implementations of ScalarFunction. In
 /// addition to the members found in Kernel, contains the null handling
 /// and memory pre-allocation preferences.
@@ -600,13 +596,13 @@ struct VectorKernel : public Kernel {
   VectorKernel() = default;
 
   VectorKernel(std::vector<InputType> in_types, OutputType out_type,
-               ArrayKernelExecOld exec, KernelInit init = NULLPTR,
+               ArrayKernelExec exec, KernelInit init = NULLPTR,
                FinalizeFunc finalize = NULLPTR)
       : Kernel(std::move(in_types), std::move(out_type), std::move(init)),
         exec(std::move(exec)),
         finalize(std::move(finalize)) {}
 
-  VectorKernel(std::shared_ptr<KernelSignature> sig, ArrayKernelExecOld exec,
+  VectorKernel(std::shared_ptr<KernelSignature> sig, ArrayKernelExec exec,
                KernelInit init = NULLPTR, FinalizeFunc finalize = NULLPTR)
       : Kernel(std::move(sig), std::move(init)),
         exec(std::move(exec)),
@@ -614,7 +610,7 @@ struct VectorKernel : public Kernel {
 
   /// \brief Perform a single invocation of this kernel. Any required state is
   /// managed through the KernelContext.
-  ArrayKernelExecOld exec;
+  ArrayKernelExec exec;
 
   /// \brief For VectorKernel, convert intermediate results into finalized
   /// results. Mutates input argument. Some kernels may accumulate state

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -52,7 +52,8 @@ struct ARROW_EXPORT KernelState {
 /// \brief Context/state for the execution of a particular kernel.
 class ARROW_EXPORT KernelContext {
  public:
-  explicit KernelContext(ExecContext* exec_ctx) : exec_ctx_(exec_ctx) {}
+  explicit KernelContext(ExecContext* exec_ctx, const Kernel* kernel)
+      : exec_ctx_(exec_ctx), kernel_(kernel) {}
 
   /// \brief Allocate buffer from the context's memory pool. The contents are
   /// not initialized.
@@ -78,9 +79,12 @@ class ARROW_EXPORT KernelContext {
   /// MemoryPool contained in the ExecContext used to create the KernelContext.
   MemoryPool* memory_pool() { return exec_ctx_->memory_pool(); }
 
+  const Kernel* kernel() const { return kernel_; }
+
  private:
   ExecContext* exec_ctx_;
   KernelState* state_ = NULLPTR;
+  const Kernel* kernel_ = NULLPTR;
 };
 
 /// \brief An type-checking interface to permit customizable validation rules
@@ -582,7 +586,7 @@ struct ScalarKernel : public Kernel {
   MemAllocation::type mem_allocation = MemAllocation::PREALLOCATE;
 
   // Additional kernel-specific data
-  std::unique_ptr<KernelState> data;
+  std::shared_ptr<KernelState> data;
 };
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -52,7 +52,9 @@ struct ARROW_EXPORT KernelState {
 /// \brief Context/state for the execution of a particular kernel.
 class ARROW_EXPORT KernelContext {
  public:
-  explicit KernelContext(ExecContext* exec_ctx, const Kernel* kernel)
+  // Can pass optional backreference; not used consistently for the
+  // moment but will be made so in the future
+  explicit KernelContext(ExecContext* exec_ctx, const Kernel* kernel = NULLPTR)
       : exec_ctx_(exec_ctx), kernel_(kernel) {}
 
   /// \brief Allocate buffer from the context's memory pool. The contents are
@@ -68,6 +70,10 @@ class ARROW_EXPORT KernelContext {
   /// kernel execution. Ownership and memory lifetime of the KernelState must
   /// be minded separately.
   void SetState(KernelState* state) { state_ = state; }
+
+  // Set kernel that is being invoked since some kernel
+  // implementations will examine the kernel state.
+  void SetKernel(const Kernel* kernel) { kernel_ = kernel; }
 
   KernelState* state() { return state_; }
 
@@ -646,7 +652,7 @@ struct VectorKernel : public Kernel {
   /// functionality.
   bool can_write_into_slices = true;
 
-  /// Some vector kernels can do chunkwise execution using ExecBatchIterator,
+  /// Some vector kernels can do chunkwise execution using ExecSpanIterator,
   /// in some cases accumulating some state. Other kernels (like Take) need to
   /// be passed whole arrays and don't work on ChunkedArray inputs
   bool can_execute_chunkwise = true;

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -595,13 +595,12 @@ struct VectorKernel : public Kernel {
 
   /// \brief Function for executing a stateful VectorKernel against a
   /// ChunkedArray input. Does not need to be defined for all VectorKernels
-  typedef Status (*ChunkedExec)(KernelContext*, const ExecBatch&, Datum* out)>;
+  typedef Status (*ChunkedExec)(KernelContext*, const ExecBatch&, Datum* out);
 
   VectorKernel() = default;
 
-  VectorKernel(std::vector<InputType> in_types, OutputType out_type,
-               ArrayKernelExec exec, KernelInit init = NULLPTR,
-               FinalizeFunc finalize = NULLPTR)
+  VectorKernel(std::vector<InputType> in_types, OutputType out_type, ArrayKernelExec exec,
+               KernelInit init = NULLPTR, FinalizeFunc finalize = NULLPTR)
       : Kernel(std::move(in_types), std::move(out_type), std::move(init)),
         exec(std::move(exec)),
         finalize(std::move(finalize)) {}

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -593,6 +593,10 @@ struct VectorKernel : public Kernel {
   /// \brief See VectorKernel::finalize member for usage
   using FinalizeFunc = std::function<Status(KernelContext*, std::vector<Datum>*)>;
 
+  /// \brief Function for executing a stateful VectorKernel against a
+  /// ChunkedArray input. Does not need to be defined for all VectorKernels
+  typedef Status (*ChunkedExecFunc)(KernelContext*, const ExecBatch&, Datum* out)>;
+
   VectorKernel() = default;
 
   VectorKernel(std::vector<InputType> in_types, OutputType out_type,
@@ -611,6 +615,9 @@ struct VectorKernel : public Kernel {
   /// \brief Perform a single invocation of this kernel. Any required state is
   /// managed through the KernelContext.
   ArrayKernelExec exec;
+
+  /// \brief Execute the kernel on a ChunkedArray. Does not need to be defined
+  ChunkedExecFunc exec_chunked = NULLPTR;
 
   /// \brief For VectorKernel, convert intermediate results into finalized
   /// results. Mutates input argument. Some kernels may accumulate state

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -580,6 +580,9 @@ struct ScalarKernel : public Kernel {
   // bitmaps is a reasonable default
   NullHandling::type null_handling = NullHandling::INTERSECTION;
   MemAllocation::type mem_allocation = MemAllocation::PREALLOCATE;
+
+  // Additional kernel-specific data
+  std::unique_ptr<KernelState> data;
 };
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/compute/kernels/aggregate_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_internal.h
@@ -91,7 +91,7 @@ struct MultiplyTraits<Type, enable_if_decimal<Type>> {
 };
 
 struct ScalarAggregator : public KernelState {
-  virtual Status Consume(KernelContext* ctx, const ExecSpan& batch) = 0;
+  virtual Status Consume(KernelContext* ctx, const ExecBatch& batch) = 0;
   virtual Status MergeFrom(KernelContext* ctx, KernelState&& src) = 0;
   virtual Status Finalize(KernelContext* ctx, Datum* out) = 0;
 };

--- a/cpp/src/arrow/compute/kernels/aggregate_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_internal.h
@@ -91,7 +91,7 @@ struct MultiplyTraits<Type, enable_if_decimal<Type>> {
 };
 
 struct ScalarAggregator : public KernelState {
-  virtual Status Consume(KernelContext* ctx, const ExecBatch& batch) = 0;
+  virtual Status Consume(KernelContext* ctx, const ExecSpan& batch) = 0;
   virtual Status MergeFrom(KernelContext* ctx, KernelState&& src) = 0;
   virtual Status Finalize(KernelContext* ctx, Datum* out) = 0;
 };

--- a/cpp/src/arrow/compute/kernels/aggregate_mode.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_mode.cc
@@ -64,7 +64,8 @@ Result<std::pair<CType*, int64_t*>> PrepareOutput(int64_t n, KernelContext* ctx,
     count_buffer = count_data->template GetMutableValues<int64_t>(1);
   }
 
-  out->value = ArrayData::Make(out->type(), n, {nullptr}, {mode_data, count_data}, 0);
+  out->value =
+      ArrayData::Make(out->type()->Copy(), n, {nullptr}, {mode_data, count_data}, 0);
   return std::make_pair(mode_buffer, count_buffer);
 }
 

--- a/cpp/src/arrow/compute/kernels/aggregate_mode.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_mode.cc
@@ -389,7 +389,7 @@ Result<ValueDescr> ModeType(KernelContext*, const std::vector<ValueDescr>& descr
 }
 
 VectorKernel NewModeKernel(const std::shared_ptr<DataType>& in_type,
-                           ArrayKernelExecOld exec) {
+                           ArrayKernelExec exec) {
   VectorKernel kernel;
   kernel.init = ModeState::Init;
   kernel.can_execute_chunkwise = false;
@@ -435,7 +435,7 @@ void RegisterScalarAggregateMode(FunctionRegistry* registry) {
   for (const auto& type : NumericTypes()) {
     // TODO(wesm):
     DCHECK_OK(func->AddKernel(
-        NewModeKernel(type, GenerateNumericOld<ModeExecutor, StructType>(*type))));
+        NewModeKernel(type, GenerateNumeric<ModeExecutor, StructType>(*type))));
   }
   // Type parameters are ignored
   DCHECK_OK(func->AddKernel(

--- a/cpp/src/arrow/compute/kernels/aggregate_quantile.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_quantile.cc
@@ -423,9 +423,8 @@ Status ScalarQuantile(KernelContext* ctx, const QuantileOptions& options,
   ArrayData* output = out->mutable_array();
   output->length = options.q.size();
   auto out_type = IsDataPoint(options) ? scalar.type : float64();
-  ARROW_ASSIGN_OR_RAISE(
-      output->buffers[1],
-      ctx->Allocate(output->length * out_type->byte_width()));
+  ARROW_ASSIGN_OR_RAISE(output->buffers[1],
+                        ctx->Allocate(output->length * out_type->byte_width()));
 
   if (!scalar.is_valid || options.min_count > 1) {
     output->null_count = output->length;

--- a/cpp/src/arrow/compute/kernels/aggregate_quantile.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_quantile.cc
@@ -89,39 +89,19 @@ struct SortQuantiler {
   using CType = typename TypeTraits<InType>::CType;
   using Allocator = arrow::stl::allocator<CType>;
 
-  Status Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-    const QuantileOptions& options = QuantileState::Get(ctx);
-    const Datum& datum = batch[0];
-
-    // copy all chunks to a buffer, ignore nulls and nans
-    std::vector<CType, Allocator> in_buffer(Allocator(ctx->memory_pool()));
-    int64_t in_length = 0;
-    if ((!options.skip_nulls && datum.null_count() > 0) ||
-        (datum.length() - datum.null_count() < options.min_count)) {
-      in_length = 0;
-    } else {
-      in_length = datum.length() - datum.null_count();
-    }
-
-    if (in_length > 0) {
-      in_buffer.resize(in_length);
-      CopyNonNullValues(datum, in_buffer.data());
-
-      // drop nan
-      if (is_floating_type<InType>::value) {
-        const auto& it = std::remove_if(in_buffer.begin(), in_buffer.end(),
-                                        [](CType v) { return v != v; });
-        in_buffer.resize(it - in_buffer.begin());
-      }
-    }
-
+  Status ComputeQuantile(KernelContext* ctx, const QuantileOptions& options,
+                         const std::shared_ptr<DataType>& type,
+                         std::vector<CType, Allocator>& in_buffer, ExecResult* out) {
     // prepare out array
     // out type depends on options
     const bool is_datapoint = IsDataPoint(options);
-    const std::shared_ptr<DataType> out_type = is_datapoint ? datum.type() : float64();
+    const std::shared_ptr<DataType> out_type = is_datapoint ? type : float64();
     int64_t out_length = options.q.size();
     if (in_buffer.empty()) {
-      return MakeArrayOfNull(out_type, out_length, ctx->memory_pool()).Value(out);
+      ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Array> result,
+                            MakeArrayOfNull(out_type, out_length, ctx->memory_pool()));
+      out->value = result->data();
+      return Status::OK();
     }
     auto out_data = ArrayData::Make(out_type, out_length, 0);
     out_data->buffers.resize(2, nullptr);
@@ -153,14 +133,59 @@ struct SortQuantiler {
         double* out_buffer = out_data->template GetMutableValues<double>(1);
         for (int64_t i = 0; i < out_length; ++i) {
           const int64_t q_index = q_indices[i];
-          out_buffer[q_index] =
-              GetQuantileByInterp(in_buffer, &last_index, options.q[q_index],
-                                  options.interpolation, *datum.type());
+          out_buffer[q_index] = GetQuantileByInterp(
+              in_buffer, &last_index, options.q[q_index], options.interpolation, *type);
         }
       }
     }
 
-    *out = Datum(std::move(out_data));
+    out->value = std::move(out_data);
+    return Status::OK();
+  }
+
+  template <typename Container>
+  void FillBuffer(const QuantileOptions& options, const Container& container,
+                  int64_t length, int64_t null_count,
+                  std::vector<CType, Allocator>* in_buffer) {
+    int64_t in_length = 0;
+    if ((!options.skip_nulls && null_count > 0) ||
+        (length - null_count < options.min_count)) {
+      in_length = 0;
+    } else {
+      in_length = length - null_count;
+    }
+
+    if (in_length > 0) {
+      in_buffer->resize(in_length);
+      CopyNonNullValues(container, in_buffer->data());
+
+      // drop nan
+      if (is_floating_type<InType>::value) {
+        const auto& it = std::remove_if(in_buffer->begin(), in_buffer->end(),
+                                        [](CType v) { return v != v; });
+        in_buffer->resize(it - in_buffer->begin());
+      }
+    }
+  }
+
+  Status Exec(KernelContext* ctx, const ArraySpan& values, ExecResult* out) {
+    const QuantileOptions& options = QuantileState::Get(ctx);
+
+    // copy all chunks to a buffer, ignore nulls and nans
+    std::vector<CType, Allocator> in_buffer(Allocator(ctx->memory_pool()));
+    FillBuffer(options, values, values.length, values.GetNullCount(), &in_buffer);
+    return ComputeQuantile(ctx, options, values.type->Copy(), in_buffer, out);
+  }
+
+  Status Exec(KernelContext* ctx, const ChunkedArray& values, Datum* out) {
+    const QuantileOptions& options = QuantileState::Get(ctx);
+
+    // copy all chunks to a buffer, ignore nulls and nans
+    std::vector<CType, Allocator> in_buffer(Allocator(ctx->memory_pool()));
+    FillBuffer(options, values, values.length(), values.null_count(), &in_buffer);
+    ExecResult result;
+    RETURN_NOT_OK(ComputeQuantile(ctx, options, values.type(), in_buffer, &result));
+    *out = result.array_data();
     return Status::OK();
   }
 
@@ -245,17 +270,8 @@ struct CountQuantiler {
     this->counts.resize(value_range, 0);
   }
 
-  Status Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-    const QuantileOptions& options = QuantileState::Get(ctx);
-
-    // count values in all chunks, ignore nulls
-    const Datum& datum = batch[0];
-    int64_t in_length = 0;
-    if ((options.skip_nulls || (!options.skip_nulls && datum.null_count() == 0)) &&
-        (datum.length() - datum.null_count() >= options.min_count)) {
-      in_length = CountValues<CType>(this->counts.data(), datum, this->min);
-    }
-
+  Status ComputeQuantile(KernelContext* ctx, const QuantileOptions& options,
+                         int64_t in_length, ExecResult* out) {
     // prepare out array
     // out type depends on options
     const bool is_datapoint = IsDataPoint(options);
@@ -263,7 +279,10 @@ struct CountQuantiler {
         is_datapoint ? TypeTraits<InType>::type_singleton() : float64();
     int64_t out_length = options.q.size();
     if (in_length == 0) {
-      return MakeArrayOfNull(out_type, out_length, ctx->memory_pool()).Value(out);
+      ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Array> result,
+                            MakeArrayOfNull(out_type, out_length, ctx->memory_pool()));
+      out->value = std::move(result->data());
+      return Status::OK();
     }
     auto out_data = ArrayData::Make(out_type, out_length, 0);
     out_data->buffers.resize(2, nullptr);
@@ -298,8 +317,36 @@ struct CountQuantiler {
         }
       }
     }
+    out->value = std::move(out_data);
+    return Status::OK();
+  }
 
-    *out = Datum(std::move(out_data));
+  Status Exec(KernelContext* ctx, const ArraySpan& values, ExecResult* out) {
+    const QuantileOptions& options = QuantileState::Get(ctx);
+
+    // count values in all chunks, ignore nulls
+    int64_t in_length = 0;
+    if ((options.skip_nulls || (!options.skip_nulls && values.GetNullCount() == 0)) &&
+        (values.length - values.GetNullCount() >= options.min_count)) {
+      in_length = CountValues<CType>(values, this->min, this->counts.data());
+    }
+
+    return ComputeQuantile(ctx, options, in_length, out);
+  }
+
+  Status Exec(KernelContext* ctx, const ChunkedArray& values, Datum* out) {
+    const QuantileOptions& options = QuantileState::Get(ctx);
+
+    // count values in all chunks, ignore nulls
+    int64_t in_length = 0;
+    if ((options.skip_nulls || (!options.skip_nulls && values.null_count() == 0)) &&
+        (values.length() - values.null_count() >= options.min_count)) {
+      in_length = CountValues<CType>(values, this->min, this->counts.data());
+    }
+
+    ExecResult result;
+    RETURN_NOT_OK(ComputeQuantile(ctx, options, in_length, &result));
+    *out = result.array_data();
     return Status::OK();
   }
 
@@ -365,23 +412,31 @@ template <typename InType>
 struct CountOrSortQuantiler {
   using CType = typename InType::c_type;
 
-  Status Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-    // cross point to benefit from histogram approach
-    // parameters estimated from ad-hoc benchmarks manually
-    static constexpr int kMinArraySize = 65536;
-    static constexpr int kMaxValueRange = 65536;
+  // cross point to benefit from histogram approach
+  // parameters estimated from ad-hoc benchmarks manually
+  static constexpr int kMinArraySize = 65536;
+  static constexpr int kMaxValueRange = 65536;
 
-    const Datum& datum = batch[0];
-    if (datum.length() - datum.null_count() >= kMinArraySize) {
+  Status Exec(KernelContext* ctx, const ArraySpan& values, ExecResult* out) {
+    if (values.length - values.GetNullCount() >= kMinArraySize) {
       CType min, max;
-      std::tie(min, max) = GetMinMax<CType>(datum);
-
+      std::tie(min, max) = GetMinMax<CType>(values);
       if (static_cast<uint64_t>(max) - static_cast<uint64_t>(min) <= kMaxValueRange) {
-        return CountQuantiler<InType>(min, max).Exec(ctx, batch, out);
+        return CountQuantiler<InType>(min, max).Exec(ctx, values, out);
       }
     }
+    return SortQuantiler<InType>().Exec(ctx, values, out);
+  }
 
-    return SortQuantiler<InType>().Exec(ctx, batch, out);
+  Status Exec(KernelContext* ctx, const ChunkedArray& values, Datum* out) {
+    if (values.length() - values.null_count() >= kMinArraySize) {
+      CType min, max;
+      std::tie(min, max) = GetMinMax<CType>(values);
+      if (static_cast<uint64_t>(max) - static_cast<uint64_t>(min) <= kMaxValueRange) {
+        return CountQuantiler<InType>(min, max).Exec(ctx, values, out);
+      }
+    }
+    return SortQuantiler<InType>().Exec(ctx, values, out);
   }
 };
 
@@ -417,10 +472,10 @@ struct ExactQuantiler<InType, enable_if_t<is_decimal_type<InType>::value>> {
 };
 
 template <typename T>
-Status ScalarQuantile(KernelContext* ctx, const QuantileOptions& options,
-                      const Scalar& scalar, Datum* out) {
+Status ScalarQuantile(KernelContext* ctx, const Scalar& scalar, ExecResult* out) {
+  const QuantileOptions& options = QuantileState::Get(ctx);
   using CType = typename TypeTraits<T>::CType;
-  ArrayData* output = out->mutable_array();
+  ArrayData* output = out->array_data().get();
   output->length = options.q.size();
   auto out_type = IsDataPoint(options) ? scalar.type : float64();
   ARROW_ASSIGN_OR_RAISE(output->buffers[1],
@@ -455,28 +510,39 @@ Status ScalarQuantile(KernelContext* ctx, const QuantileOptions& options,
   return Status::OK();
 }
 
-template <typename _, typename InType>
+Status CheckQuantileOptions(KernelContext* ctx) {
+  if (ctx->state() == nullptr) {
+    return Status::Invalid("Quantile requires QuantileOptions");
+  }
+
+  const QuantileOptions& options = QuantileState::Get(ctx);
+  if (options.q.empty()) {
+    return Status::Invalid("Requires quantile argument");
+  }
+  for (double q : options.q) {
+    if (q < 0 || q > 1) {
+      return Status::Invalid("Quantile must be between 0 and 1");
+    }
+  }
+  return Status::OK();
+}
+
+template <typename OutputTypeUnused, typename InType>
 struct QuantileExecutor {
-  static Status Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-    if (ctx->state() == nullptr) {
-      return Status::Invalid("Quantile requires QuantileOptions");
-    }
-
-    const QuantileOptions& options = QuantileState::Get(ctx);
-    if (options.q.empty()) {
-      return Status::Invalid("Requires quantile argument");
-    }
-    for (double q : options.q) {
-      if (q < 0 || q > 1) {
-        return Status::Invalid("Quantile must be between 0 and 1");
-      }
-    }
-
+  static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
+    RETURN_NOT_OK(CheckQuantileOptions(ctx));
     if (batch[0].is_scalar()) {
-      return ScalarQuantile<InType>(ctx, options, *batch[0].scalar(), out);
+      return ScalarQuantile<InType>(ctx, *batch[0].scalar, out);
     }
+    return ExactQuantiler<InType>().impl.Exec(ctx, batch[0].array, out);
+  }
+};
 
-    return ExactQuantiler<InType>().impl.Exec(ctx, batch, out);
+template <typename OutputTypeUnused, typename InType>
+struct QuantileExecutorChunked {
+  static Status Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+    RETURN_NOT_OK(CheckQuantileOptions(ctx));
+    return ExactQuantiler<InType>().impl.Exec(ctx, *batch[0].chunked_array(), out);
   }
 };
 
@@ -500,18 +566,23 @@ void AddQuantileKernels(VectorFunction* func) {
     base.signature = KernelSignature::Make({InputType(ty)}, OutputType(ResolveOutput));
     // output type is determined at runtime, set template argument to nulltype
     base.exec = GenerateNumeric<QuantileExecutor, NullType>(*ty);
+    base.exec_chunked =
+        GenerateNumeric<QuantileExecutorChunked, NullType, VectorKernel::ChunkedExec>(
+            *ty);
     DCHECK_OK(func->AddKernel(base));
   }
   {
     base.signature =
         KernelSignature::Make({InputType(Type::DECIMAL128)}, OutputType(ResolveOutput));
     base.exec = QuantileExecutor<NullType, Decimal128Type>::Exec;
+    base.exec_chunked = QuantileExecutorChunked<NullType, Decimal128Type>::Exec;
     DCHECK_OK(func->AddKernel(base));
   }
   {
     base.signature =
         KernelSignature::Make({InputType(Type::DECIMAL256)}, OutputType(ResolveOutput));
     base.exec = QuantileExecutor<NullType, Decimal256Type>::Exec;
+    base.exec_chunked = QuantileExecutorChunked<NullType, Decimal256Type>::Exec;
     DCHECK_OK(func->AddKernel(base));
   }
 }

--- a/cpp/src/arrow/compute/kernels/aggregate_quantile.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_quantile.cc
@@ -129,7 +129,7 @@ struct SortQuantiler {
     // calculate quantiles
     if (out_length > 0) {
       ARROW_ASSIGN_OR_RAISE(out_data->buffers[1],
-                            ctx->Allocate(out_length * GetBitWidth(*out_type) / 8));
+                            ctx->Allocate(out_length * out_type->byte_width()));
 
       // find quantiles in descending order
       std::vector<int64_t> q_indices(out_length);
@@ -271,7 +271,7 @@ struct CountQuantiler {
     // calculate quantiles
     if (out_length > 0) {
       ARROW_ASSIGN_OR_RAISE(out_data->buffers[1],
-                            ctx->Allocate(out_length * GetBitWidth(*out_type) / 8));
+                            ctx->Allocate(out_length * out_type->byte_width()));
 
       // find quantiles in ascending order
       std::vector<int64_t> q_indices(out_length);
@@ -425,7 +425,7 @@ Status ScalarQuantile(KernelContext* ctx, const QuantileOptions& options,
   auto out_type = IsDataPoint(options) ? scalar.type : float64();
   ARROW_ASSIGN_OR_RAISE(
       output->buffers[1],
-      ctx->Allocate(output->length * bit_util::BytesForBits(GetBitWidth(*out_type))));
+      ctx->Allocate(output->length * out_type->byte_width()));
 
   if (!scalar.is_valid || options.min_count > 1) {
     output->null_count = output->length;

--- a/cpp/src/arrow/compute/kernels/aggregate_quantile.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_quantile.cc
@@ -500,7 +500,7 @@ void AddQuantileKernels(VectorFunction* func) {
   for (const auto& ty : NumericTypes()) {
     base.signature = KernelSignature::Make({InputType(ty)}, OutputType(ResolveOutput));
     // output type is determined at runtime, set template argument to nulltype
-    base.exec = GenerateNumericOld<QuantileExecutor, NullType>(*ty);
+    base.exec = GenerateNumeric<QuantileExecutor, NullType>(*ty);
     DCHECK_OK(func->AddKernel(base));
   }
   {

--- a/cpp/src/arrow/compute/kernels/codegen_internal.cc
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.cc
@@ -33,13 +33,7 @@ Status ExecFail(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
   return Status::NotImplemented("This kernel is malformed");
 }
 
-ArrayKernelExec MakeFlippedBinaryExec(ArrayKernelExec exec) {
-  return [exec](KernelContext* ctx, const ExecSpan& span, ExecResult* out) {
-    ExecSpan flipped_span = span;
-    std::swap(flipped_span.values[0], flipped_span.values[1]);
-    return exec(ctx, flipped_span, out);
-  };
-}
+using ExecFail = ;
 
 const std::vector<std::shared_ptr<DataType>>& ExampleParametricTypes() {
   static DataTypeVector example_parametric_types = {

--- a/cpp/src/arrow/compute/kernels/codegen_internal.cc
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.cc
@@ -33,8 +33,6 @@ Status ExecFail(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
   return Status::NotImplemented("This kernel is malformed");
 }
 
-using ExecFail = ;
-
 const std::vector<std::shared_ptr<DataType>>& ExampleParametricTypes() {
   static DataTypeVector example_parametric_types = {
       decimal128(12, 2),

--- a/cpp/src/arrow/compute/kernels/codegen_internal.cc
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.cc
@@ -33,10 +33,6 @@ Status ExecFail(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
   return Status::NotImplemented("This kernel is malformed");
 }
 
-Status ExecFailOld(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-  return Status::NotImplemented("This kernel is malformed");
-}
-
 ArrayKernelExec MakeFlippedBinaryExec(ArrayKernelExec exec) {
   return [exec](KernelContext* ctx, const ExecSpan& span, ExecResult* out) {
     ExecSpan flipped_span = span;

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -460,7 +460,6 @@ Result<ValueDescr> ListValuesType(KernelContext*, const std::vector<ValueDescr>&
 // Generate an array kernel given template classes
 
 Status ExecFail(KernelContext* ctx, const ExecSpan& batch, ExecResult* out);
-Status ExecFailOld(KernelContext* ctx, const ExecBatch& batch, Datum* out);
 
 ArrayKernelExec MakeFlippedBinaryExec(ArrayKernelExec exec);
 
@@ -1062,38 +1061,6 @@ ArrayKernelExec GenerateNumeric(detail::GetTypeId get_id) {
   }
 }
 
-// TODO(wesm): for ARROW-16756, while in transition to a new kernel
-// API I duplicated this generator dispatcher to be able to create old
-// kernel types
-template <template <typename...> class Generator, typename Type0, typename... Args>
-ArrayKernelExecOld GenerateNumericOld(detail::GetTypeId get_id) {
-  switch (get_id.id) {
-    case Type::INT8:
-      return Generator<Type0, Int8Type, Args...>::Exec;
-    case Type::UINT8:
-      return Generator<Type0, UInt8Type, Args...>::Exec;
-    case Type::INT16:
-      return Generator<Type0, Int16Type, Args...>::Exec;
-    case Type::UINT16:
-      return Generator<Type0, UInt16Type, Args...>::Exec;
-    case Type::INT32:
-      return Generator<Type0, Int32Type, Args...>::Exec;
-    case Type::UINT32:
-      return Generator<Type0, UInt32Type, Args...>::Exec;
-    case Type::INT64:
-      return Generator<Type0, Int64Type, Args...>::Exec;
-    case Type::UINT64:
-      return Generator<Type0, UInt64Type, Args...>::Exec;
-    case Type::FLOAT:
-      return Generator<Type0, FloatType, Args...>::Exec;
-    case Type::DOUBLE:
-      return Generator<Type0, DoubleType, Args...>::Exec;
-    default:
-      DCHECK(false);
-      return ExecFailOld;
-  }
-}
-
 // Generate a kernel given a templated functor for floating point types
 //
 // See "Numeric" above for description of the generator functor
@@ -1197,39 +1164,6 @@ ArrayKernelExec ArithmeticExecFromOp(detail::GetTypeId get_id) {
     default:
       DCHECK(false);
       return ExecFail;
-  }
-}
-
-// ARROW-16756: temporarily duplicated until we get all the kernels
-// migrated to the new API
-template <template <typename...> class KernelGenerator, typename Op, typename... Args>
-ArrayKernelExecOld ArithmeticExecFromOpOld(detail::GetTypeId get_id) {
-  switch (get_id.id) {
-    case Type::INT8:
-      return KernelGenerator<Int8Type, Int8Type, Op, Args...>::Exec;
-    case Type::UINT8:
-      return KernelGenerator<UInt8Type, UInt8Type, Op, Args...>::Exec;
-    case Type::INT16:
-      return KernelGenerator<Int16Type, Int16Type, Op, Args...>::Exec;
-    case Type::UINT16:
-      return KernelGenerator<UInt16Type, UInt16Type, Op, Args...>::Exec;
-    case Type::INT32:
-      return KernelGenerator<Int32Type, Int32Type, Op, Args...>::Exec;
-    case Type::UINT32:
-      return KernelGenerator<UInt32Type, UInt32Type, Op, Args...>::Exec;
-    case Type::DURATION:
-    case Type::INT64:
-    case Type::TIMESTAMP:
-      return KernelGenerator<Int64Type, Int64Type, Op, Args...>::Exec;
-    case Type::UINT64:
-      return KernelGenerator<UInt64Type, UInt64Type, Op, Args...>::Exec;
-    case Type::FLOAT:
-      return KernelGenerator<FloatType, FloatType, Op, Args...>::Exec;
-    case Type::DOUBLE:
-      return KernelGenerator<DoubleType, DoubleType, Op, Args...>::Exec;
-    default:
-      DCHECK(false);
-      return ExecFailOld;
   }
 }
 
@@ -1346,44 +1280,6 @@ ArrayKernelExec GenerateTypeAgnosticPrimitive(detail::GetTypeId get_id) {
   }
 }
 
-// XXX: Duplicated temporarily
-template <template <typename...> class Generator, typename... Args>
-ArrayKernelExecOld GenerateTypeAgnosticPrimitiveOld(detail::GetTypeId get_id) {
-  switch (get_id.id) {
-    case Type::NA:
-      return Generator<NullType, Args...>::Exec;
-    case Type::BOOL:
-      return Generator<BooleanType, Args...>::Exec;
-    case Type::UINT8:
-    case Type::INT8:
-      return Generator<UInt8Type, Args...>::Exec;
-    case Type::UINT16:
-    case Type::INT16:
-      return Generator<UInt16Type, Args...>::Exec;
-    case Type::UINT32:
-    case Type::INT32:
-    case Type::FLOAT:
-    case Type::DATE32:
-    case Type::TIME32:
-    case Type::INTERVAL_MONTHS:
-      return Generator<UInt32Type, Args...>::Exec;
-    case Type::UINT64:
-    case Type::INT64:
-    case Type::DOUBLE:
-    case Type::DATE64:
-    case Type::TIMESTAMP:
-    case Type::TIME64:
-    case Type::DURATION:
-    case Type::INTERVAL_DAY_TIME:
-      return Generator<UInt64Type, Args...>::Exec;
-    case Type::INTERVAL_MONTH_DAY_NANO:
-      return Generator<MonthDayNanoIntervalType, Args...>::Exec;
-    default:
-      DCHECK(false);
-      return ExecFailOld;
-  }
-}
-
 // similar to GenerateTypeAgnosticPrimitive, but for base variable binary types
 template <template <typename...> class Generator, typename... Args>
 ArrayKernelExec GenerateTypeAgnosticVarBinaryBase(detail::GetTypeId get_id) {
@@ -1397,22 +1293,6 @@ ArrayKernelExec GenerateTypeAgnosticVarBinaryBase(detail::GetTypeId get_id) {
     default:
       DCHECK(false);
       return ExecFail;
-  }
-}
-
-// XXX: Duplicated temporarily
-template <template <typename...> class Generator, typename... Args>
-ArrayKernelExecOld GenerateTypeAgnosticVarBinaryBaseOld(detail::GetTypeId get_id) {
-  switch (get_id.id) {
-    case Type::BINARY:
-    case Type::STRING:
-      return Generator<BinaryType, Args...>::Exec;
-    case Type::LARGE_BINARY:
-    case Type::LARGE_STRING:
-      return Generator<LargeBinaryType, Args...>::Exec;
-    default:
-      DCHECK(false);
-      return ExecFailOld;
   }
 }
 
@@ -1452,22 +1332,6 @@ ArrayKernelExec GenerateVarBinaryBase(detail::GetTypeId get_id) {
     default:
       DCHECK(false);
       return ExecFail;
-  }
-}
-
-// TODO: Duplicated in ARROW-16756
-template <template <typename...> class Generator, typename Type0, typename... Args>
-ArrayKernelExecOld GenerateVarBinaryBaseOld(detail::GetTypeId get_id) {
-  switch (get_id.id) {
-    case Type::BINARY:
-    case Type::STRING:
-      return Generator<Type0, BinaryType, Args...>::Exec;
-    case Type::LARGE_BINARY:
-    case Type::LARGE_STRING:
-      return Generator<Type0, LargeBinaryType, Args...>::Exec;
-    default:
-      DCHECK(false);
-      return ExecFailOld;
   }
 }
 
@@ -1526,20 +1390,6 @@ ArrayKernelExec GenerateDecimal(detail::GetTypeId get_id) {
     default:
       DCHECK(false);
       return ExecFail;
-  }
-}
-
-// Temporarily duplicated for ARROW-16756
-template <template <typename...> class Generator, typename Type0, typename... Args>
-ArrayKernelExecOld GenerateDecimalOld(detail::GetTypeId get_id) {
-  switch (get_id.id) {
-    case Type::DECIMAL128:
-      return Generator<Type0, Decimal128Type, Args...>::Exec;
-    case Type::DECIMAL256:
-      return Generator<Type0, Decimal256Type, Args...>::Exec;
-    default:
-      DCHECK(false);
-      return ExecFailOld;
   }
 }
 

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -1044,8 +1044,9 @@ struct FailFunctor<VectorKernel::ChunkedExec> {
 Status ExecFail(KernelContext* ctx, const ExecSpan& batch, ExecResult* out);
 
 // GD for numeric types (integer and floating point)
-template <template <typename...> class Generator, typename Type0, typename... Args>
-ArrayKernelExec GenerateNumeric(detail::GetTypeId get_id) {
+template <template <typename...> class Generator, typename Type0,
+          typename KernelType = ArrayKernelExec, typename... Args>
+KernelType GenerateNumeric(detail::GetTypeId get_id) {
   switch (get_id.id) {
     case Type::INT8:
       return Generator<Type0, Int8Type, Args...>::Exec;
@@ -1069,7 +1070,7 @@ ArrayKernelExec GenerateNumeric(detail::GetTypeId get_id) {
       return Generator<Type0, DoubleType, Args...>::Exec;
     default:
       DCHECK(false);
-      return ExecFail;
+      return FailFunctor<KernelType>::Exec;
   }
 }
 
@@ -1148,8 +1149,8 @@ ArrayKernelExec GeneratePhysicalInteger(detail::GetTypeId get_id) {
   }
 }
 
-template <template <typename...> class KernelGenerator, typename Op, typename KernelType,
-          typename... Args>
+template <template <typename...> class KernelGenerator, typename Op,
+          typename KernelType = ArrayKernelExec, typename... Args>
 KernelType ArithmeticExecFromOp(detail::GetTypeId get_id) {
   switch (get_id.id) {
     case Type::INT8:

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -1136,8 +1136,9 @@ ArrayKernelExec GeneratePhysicalInteger(detail::GetTypeId get_id) {
   }
 }
 
-template <template <typename...> class KernelGenerator, typename Op, typename... Args>
-ArrayKernelExec ArithmeticExecFromOp(detail::GetTypeId get_id) {
+template <template <typename...> class KernelGenerator, typename Op, typename KernelType,
+          typename... Args>
+KernelType ArithmeticExecFromOp(detail::GetTypeId get_id) {
   switch (get_id.id) {
     case Type::INT8:
       return KernelGenerator<Int8Type, Int8Type, Op, Args...>::Exec;
@@ -1243,8 +1244,7 @@ ArrayKernelExec GenerateSignedInteger(detail::GetTypeId get_id) {
 // bits).
 //
 // See "Numeric" above for description of the generator functor
-template <template <typename...> class Generator,
-          typename KernelType = ArrayKernelExec,
+template <template <typename...> class Generator, typename KernelType = ArrayKernelExec,
           typename... Args>
 KernelType GenerateTypeAgnosticPrimitive(detail::GetTypeId get_id) {
   switch (get_id.id) {

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -1243,8 +1243,10 @@ ArrayKernelExec GenerateSignedInteger(detail::GetTypeId get_id) {
 // bits).
 //
 // See "Numeric" above for description of the generator functor
-template <template <typename...> class Generator, typename... Args>
-ArrayKernelExec GenerateTypeAgnosticPrimitive(detail::GetTypeId get_id) {
+template <template <typename...> class Generator,
+          typename KernelType = ArrayKernelExec,
+          typename... Args>
+KernelType GenerateTypeAgnosticPrimitive(detail::GetTypeId get_id) {
   switch (get_id.id) {
     case Type::NA:
       return Generator<NullType, Args...>::Exec;

--- a/cpp/src/arrow/compute/kernels/copy_data_internal.h
+++ b/cpp/src/arrow/compute/kernels/copy_data_internal.h
@@ -40,7 +40,7 @@ struct CopyDataUtils<BooleanType> {
     arrow::internal::CopyBitmap(in, in_offset, length, out, out_offset);
   }
 
-  static void CopyData(const DataType&, const ArrayData& in, const int64_t in_offset,
+  static void CopyData(const DataType&, const ArraySpan& in, const int64_t in_offset,
                        uint8_t* out, const int64_t out_offset, const int64_t length) {
     const auto in_arr = in.GetValues<uint8_t>(1, /*absolute_offset=*/0);
     CopyData(*in.type, in_arr, in_offset, out, out_offset, length);
@@ -51,7 +51,7 @@ template <>
 struct CopyDataUtils<FixedSizeBinaryType> {
   static void CopyData(const DataType& ty, const Scalar& in, const int64_t in_offset,
                        uint8_t* out, const int64_t out_offset, const int64_t length) {
-    const int32_t width = checked_cast<const FixedSizeBinaryType&>(ty).byte_width();
+    const int32_t width = ty.byte_width();
     uint8_t* begin = out + (width * out_offset);
     const auto& scalar = checked_cast<const arrow::internal::PrimitiveScalarBase&>(in);
     // Null scalar may have null value buffer
@@ -69,14 +69,14 @@ struct CopyDataUtils<FixedSizeBinaryType> {
 
   static void CopyData(const DataType& ty, const uint8_t* in, const int64_t in_offset,
                        uint8_t* out, const int64_t out_offset, const int64_t length) {
-    const int32_t width = checked_cast<const FixedSizeBinaryType&>(ty).byte_width();
+    const int32_t width = ty.byte_width();
     uint8_t* begin = out + (width * out_offset);
     std::memcpy(begin, in + in_offset * width, length * width);
   }
 
-  static void CopyData(const DataType& ty, const ArrayData& in, const int64_t in_offset,
+  static void CopyData(const DataType& ty, const ArraySpan& in, const int64_t in_offset,
                        uint8_t* out, const int64_t out_offset, const int64_t length) {
-    const int32_t width = checked_cast<const FixedSizeBinaryType&>(ty).byte_width();
+    const int32_t width = ty.byte_width();
     const auto in_arr = in.GetValues<uint8_t>(1, in.offset * width);
     CopyData(ty, in_arr, in_offset, out, out_offset, length);
   }
@@ -100,7 +100,7 @@ struct CopyDataUtils<
                 length * sizeof(CType));
   }
 
-  static void CopyData(const DataType&, const ArrayData& in, const int64_t in_offset,
+  static void CopyData(const DataType&, const ArraySpan& in, const int64_t in_offset,
                        uint8_t* out, const int64_t out_offset, const int64_t length) {
     const auto in_arr = in.GetValues<uint8_t>(1, in.offset * sizeof(CType));
     CopyData(*in.type, in_arr, in_offset, out, out_offset, length);

--- a/cpp/src/arrow/compute/kernels/row_encoder.cc
+++ b/cpp/src/arrow/compute/kernels/row_encoder.cc
@@ -305,7 +305,7 @@ void RowEncoder::Clear() {
   bytes_.clear();
 }
 
-Status RowEncoder::EncodeAndAppend(const ExecBatch& batch) {
+Status RowEncoder::EncodeAndAppend(const ExecSpan& batch) {
   if (offsets_.empty()) {
     offsets_.resize(1);
     offsets_[0] = 0;

--- a/cpp/src/arrow/compute/kernels/row_encoder.cc
+++ b/cpp/src/arrow/compute/kernels/row_encoder.cc
@@ -61,7 +61,7 @@ Status KeyEncoder::DecodeNulls(MemoryPool* pool, int32_t length, uint8_t** encod
   return Status ::OK();
 }
 
-void BooleanKeyEncoder::AddLength(const Datum& data, int64_t batch_length,
+void BooleanKeyEncoder::AddLength(const ExecValue&, int64_t batch_length,
                                   int32_t* lengths) {
   for (int64_t i = 0; i < batch_length; ++i) {
     lengths[i] += kByteWidth + kExtraByteForNull;
@@ -72,11 +72,11 @@ void BooleanKeyEncoder::AddLengthNull(int32_t* length) {
   *length += kByteWidth + kExtraByteForNull;
 }
 
-Status BooleanKeyEncoder::Encode(const Datum& data, int64_t batch_length,
+Status BooleanKeyEncoder::Encode(const ExecValue& data, int64_t batch_length,
                                  uint8_t** encoded_bytes) {
   if (data.is_array()) {
     VisitArraySpanInline<BooleanType>(
-        *data.array(),
+        data.array,
         [&](bool value) {
           auto& encoded_ptr = *encoded_bytes++;
           *encoded_ptr++ = kValidByte;
@@ -126,7 +126,7 @@ Result<std::shared_ptr<ArrayData>> BooleanKeyEncoder::Decode(uint8_t** encoded_b
                          null_count);
 }
 
-void FixedWidthKeyEncoder::AddLength(const Datum& data, int64_t batch_length,
+void FixedWidthKeyEncoder::AddLength(const ExecValue&, int64_t batch_length,
                                      int32_t* lengths) {
   for (int64_t i = 0; i < batch_length; ++i) {
     lengths[i] += byte_width_ + kExtraByteForNull;
@@ -137,13 +137,12 @@ void FixedWidthKeyEncoder::AddLengthNull(int32_t* length) {
   *length += byte_width_ + kExtraByteForNull;
 }
 
-Status FixedWidthKeyEncoder::Encode(const Datum& data, int64_t batch_length,
+Status FixedWidthKeyEncoder::Encode(const ExecValue& data, int64_t batch_length,
                                     uint8_t** encoded_bytes) {
   if (data.is_array()) {
-    const auto& arr = *data.array();
-    ArrayData viewed(fixed_size_binary(byte_width_), arr.length, arr.buffers,
-                     arr.null_count, arr.offset);
-
+    ArraySpan viewed = data.array;
+    auto view_ty = fixed_size_binary(byte_width_);
+    viewed.type = view_ty.get();
     VisitArraySpanInline<FixedSizeBinaryType>(
         viewed,
         [&](util::string_view bytes) {
@@ -209,10 +208,15 @@ Result<std::shared_ptr<ArrayData>> FixedWidthKeyEncoder::Decode(uint8_t** encode
                          null_count);
 }
 
-Status DictionaryKeyEncoder::Encode(const Datum& data, int64_t batch_length,
+Status DictionaryKeyEncoder::Encode(const ExecValue& data, int64_t batch_length,
                                     uint8_t** encoded_bytes) {
-  auto dict = data.is_array() ? MakeArray(data.array()->dictionary)
-                              : data.scalar_as<DictionaryScalar>().value.dictionary;
+  std::shared_ptr<Array> dict;
+  if (data.is_array()) {
+    dict = data.dictionary().ToArray();
+  } else {
+    dict = data.scalar_as<DictionaryScalar>().value.dictionary;
+  }
+
   if (dictionary_) {
     if (!dictionary_->Equals(dict)) {
       // TODO(bkietz) unify if necessary. For now, just error if any batch's dictionary

--- a/cpp/src/arrow/compute/kernels/row_encoder.cc
+++ b/cpp/src/arrow/compute/kernels/row_encoder.cc
@@ -212,7 +212,7 @@ Status DictionaryKeyEncoder::Encode(const ExecValue& data, int64_t batch_length,
                                     uint8_t** encoded_bytes) {
   std::shared_ptr<Array> dict;
   if (data.is_array()) {
-    dict = data.dictionary().ToArray();
+    dict = data.array.dictionary().ToArray();
   } else {
     dict = data.scalar_as<DictionaryScalar>().value.dictionary;
   }
@@ -228,9 +228,11 @@ Status DictionaryKeyEncoder::Encode(const ExecValue& data, int64_t batch_length,
   }
   if (data.is_array()) {
     return FixedWidthKeyEncoder::Encode(data, batch_length, encoded_bytes);
+  } else {
+    const std::shared_ptr<Scalar>& index = data.scalar_as<DictionaryScalar>().value.index;
+    return FixedWidthKeyEncoder::Encode(ExecValue(index.get()), batch_length,
+                                        encoded_bytes);
   }
-  return FixedWidthKeyEncoder::Encode(data.scalar_as<DictionaryScalar>().value.index,
-                                      batch_length, encoded_bytes);
 }
 
 Result<std::shared_ptr<ArrayData>> DictionaryKeyEncoder::Decode(uint8_t** encoded_bytes,

--- a/cpp/src/arrow/compute/kernels/row_encoder.h
+++ b/cpp/src/arrow/compute/kernels/row_encoder.h
@@ -39,7 +39,8 @@ struct KeyEncoder {
 
   virtual ~KeyEncoder() = default;
 
-  virtual void AddLength(const ExecValue&, int64_t batch_length, int32_t* lengths) = 0;
+  virtual void AddLength(const ExecValue& value, int64_t batch_length,
+                         int32_t* lengths) = 0;
 
   virtual void AddLengthNull(int32_t* length) = 0;
 

--- a/cpp/src/arrow/compute/kernels/row_encoder.h
+++ b/cpp/src/arrow/compute/kernels/row_encoder.h
@@ -39,11 +39,11 @@ struct KeyEncoder {
 
   virtual ~KeyEncoder() = default;
 
-  virtual void AddLength(const Datum&, int64_t batch_length, int32_t* lengths) = 0;
+  virtual void AddLength(const ExecValue&, int64_t batch_length, int32_t* lengths) = 0;
 
   virtual void AddLengthNull(int32_t* length) = 0;
 
-  virtual Status Encode(const Datum&, int64_t batch_length, uint8_t** encoded_bytes) = 0;
+  virtual Status Encode(const ExecValue&, int64_t batch_length, uint8_t** encoded_bytes) = 0;
 
   virtual void EncodeNull(uint8_t** encoded_bytes) = 0;
 
@@ -62,11 +62,11 @@ struct KeyEncoder {
 struct BooleanKeyEncoder : KeyEncoder {
   static constexpr int kByteWidth = 1;
 
-  void AddLength(const Datum& data, int64_t batch_length, int32_t* lengths) override;
+  void AddLength(const ExecValue& data, int64_t batch_length, int32_t* lengths) override;
 
   void AddLengthNull(int32_t* length) override;
 
-  Status Encode(const Datum& data, int64_t batch_length,
+  Status Encode(const ExecValue& data, int64_t batch_length,
                 uint8_t** encoded_bytes) override;
 
   void EncodeNull(uint8_t** encoded_bytes) override;
@@ -80,11 +80,11 @@ struct FixedWidthKeyEncoder : KeyEncoder {
       : type_(std::move(type)),
         byte_width_(checked_cast<const FixedWidthType&>(*type_).bit_width() / 8) {}
 
-  void AddLength(const Datum& data, int64_t batch_length, int32_t* lengths) override;
+  void AddLength(const ExecValue& data, int64_t batch_length, int32_t* lengths) override;
 
   void AddLengthNull(int32_t* length) override;
 
-  Status Encode(const Datum& data, int64_t batch_length,
+  Status Encode(const ExecValue& data, int64_t batch_length,
                 uint8_t** encoded_bytes) override;
 
   void EncodeNull(uint8_t** encoded_bytes) override;
@@ -100,7 +100,7 @@ struct DictionaryKeyEncoder : FixedWidthKeyEncoder {
   DictionaryKeyEncoder(std::shared_ptr<DataType> type, MemoryPool* pool)
       : FixedWidthKeyEncoder(std::move(type)), pool_(pool) {}
 
-  Status Encode(const Datum& data, int64_t batch_length,
+  Status Encode(const ExecValue& data, int64_t batch_length,
                 uint8_t** encoded_bytes) override;
 
   Result<std::shared_ptr<ArrayData>> Decode(uint8_t** encoded_bytes, int32_t length,
@@ -114,18 +114,18 @@ template <typename T>
 struct VarLengthKeyEncoder : KeyEncoder {
   using Offset = typename T::offset_type;
 
-  void AddLength(const Datum& data, int64_t batch_length, int32_t* lengths) override {
+  void AddLength(const ExecValue& data, int64_t batch_length, int32_t* lengths) override {
     if (data.is_array()) {
       int64_t i = 0;
       VisitArraySpanInline<T>(
-          *data.array(),
+          data.array,
           [&](util::string_view bytes) {
             lengths[i++] +=
                 kExtraByteForNull + sizeof(Offset) + static_cast<int32_t>(bytes.size());
           },
           [&] { lengths[i++] += kExtraByteForNull + sizeof(Offset); });
     } else {
-      const Scalar& scalar = *data.scalar();
+      const Scalar& scalar = *data.scalar;
       const int32_t buffer_size =
           scalar.is_valid ? static_cast<int32_t>(UnboxScalar<T>::Unbox(scalar).size())
                           : 0;
@@ -139,11 +139,11 @@ struct VarLengthKeyEncoder : KeyEncoder {
     *length += kExtraByteForNull + sizeof(Offset);
   }
 
-  Status Encode(const Datum& data, int64_t batch_length,
+  Status Encode(const ExecValue& data, int64_t batch_length,
                 uint8_t** encoded_bytes) override {
     if (data.is_array()) {
       VisitArraySpanInline<T>(
-          *data.array(),
+          data.array,
           [&](util::string_view bytes) {
             auto& encoded_ptr = *encoded_bytes++;
             *encoded_ptr++ = kValidByte;
@@ -236,7 +236,7 @@ struct NullKeyEncoder : KeyEncoder {
 
   void AddLengthNull(int32_t* length) override {}
 
-  Status Encode(const Datum& data, int64_t batch_length,
+  Status Encode(const ExecValue& data, int64_t batch_length,
                 uint8_t** encoded_bytes) override {
     return Status::OK();
   }
@@ -255,7 +255,7 @@ class ARROW_EXPORT RowEncoder {
 
   void Init(const std::vector<ValueDescr>& column_types, ExecContext* ctx);
   void Clear();
-  Status EncodeAndAppend(const ExecBatch& batch);
+  Status EncodeAndAppend(const ExecSpan& batch);
   Result<ExecBatch> Decode(int64_t num_rows, const int32_t* row_ids);
 
   inline std::string encoded_row(int32_t i) const {

--- a/cpp/src/arrow/compute/kernels/row_encoder.h
+++ b/cpp/src/arrow/compute/kernels/row_encoder.h
@@ -233,7 +233,7 @@ struct VarLengthKeyEncoder : KeyEncoder {
 };
 
 struct NullKeyEncoder : KeyEncoder {
-  void AddLength(const Datum&, int64_t batch_length, int32_t* lengths) override {}
+  void AddLength(const ExecValue&, int64_t batch_length, int32_t* lengths) override {}
 
   void AddLengthNull(int32_t* length) override {}
 

--- a/cpp/src/arrow/compute/kernels/row_encoder.h
+++ b/cpp/src/arrow/compute/kernels/row_encoder.h
@@ -43,7 +43,8 @@ struct KeyEncoder {
 
   virtual void AddLengthNull(int32_t* length) = 0;
 
-  virtual Status Encode(const ExecValue&, int64_t batch_length, uint8_t** encoded_bytes) = 0;
+  virtual Status Encode(const ExecValue&, int64_t batch_length,
+                        uint8_t** encoded_bytes) = 0;
 
   virtual void EncodeNull(uint8_t** encoded_bytes) = 0;
 

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -1447,6 +1447,8 @@ Status ExecRound(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
       state.options.ToString());
 }
 
+#undef ROUND_CASE
+
 // Like MakeUnaryArithmeticFunction, but for unary rounding functions that control
 // kernel dispatch based on RoundMode, only on non-null output.
 template <template <typename, RoundMode, typename...> class Op, typename OptionsType>

--- a/cpp/src/arrow/compute/kernels/scalar_cast_boolean.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_boolean.cc
@@ -54,7 +54,8 @@ std::vector<std::shared_ptr<CastFunction>> GetBooleanCasts() {
 
   for (const auto& ty : NumericTypes()) {
     ArrayKernelExec exec =
-        GenerateNumeric<applicator::ScalarUnary, BooleanType, IsNonZero>(*ty);
+        GenerateNumeric<applicator::ScalarUnary, BooleanType, ArrayKernelExec, IsNonZero>(
+            *ty);
     DCHECK_OK(func->AddKernel(ty->id(), {ty}, boolean(), exec));
   }
   for (const auto& ty : BaseBinaryTypes()) {

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -312,11 +312,13 @@ std::shared_ptr<ScalarFunction> MakeCompareFunction(std::string name, FunctionDo
 
 struct FlippedData : public KernelState {
   ArrayKernelExec unflipped_exec;
+  FlippedData(ArrayKernelExec unflipped_exec) : unflipped_exec(unflipped_exec) {}
 };
 
 Status FlippedBinaryExec(KernelContext* ctx, const ExecSpan& span, ExecResult* out) {
   const auto kernel = static_cast<const ScalarKernel*>(ctx->kernel());
-  const auto kernel_data = static_cast<const FlippedData*>(kernel.data.get());
+  DCHECK(kernel);
+  const auto kernel_data = static_cast<const FlippedData*>(kernel->data.get());
 
   ExecSpan flipped_span = span;
   std::swap(flipped_span.values[0], flipped_span.values[1]);

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -312,7 +312,7 @@ std::shared_ptr<ScalarFunction> MakeCompareFunction(std::string name, FunctionDo
 
 struct FlippedData : public KernelState {
   ArrayKernelExec unflipped_exec;
-  FlippedData(ArrayKernelExec unflipped_exec) : unflipped_exec(unflipped_exec) {}
+  explicit FlippedData(ArrayKernelExec unflipped_exec) : unflipped_exec(unflipped_exec) {}
 };
 
 Status FlippedBinaryExec(KernelContext* ctx, const ExecSpan& span, ExecResult* out) {

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -330,7 +330,7 @@ std::shared_ptr<ScalarFunction> MakeFlippedFunction(std::string name,
       std::make_shared<CompareFunction>(name, Arity::Binary(), std::move(doc));
   for (const ScalarKernel* kernel : func.kernels()) {
     ScalarKernel flipped_kernel = *kernel;
-    flipped_kernel.data = std::unique_ptr<KernelState>(new FlippedData{kernel->exec});
+    flipped_kernel.data = std::make_shared<FlippedData>(kernel->exec);
     flipped_kernel.exec = FlippedBinaryExec;
     DCHECK_OK(flipped_func->AddKernel(std::move(flipped_kernel)));
   }
@@ -722,7 +722,8 @@ std::shared_ptr<ScalarFunction> MakeScalarMinMax(std::string name, FunctionDoc d
     DCHECK_OK(func->AddKernel(std::move(kernel)));
   }
   for (const auto& ty : BaseBinaryTypes()) {
-    auto exec = GenerateTypeAgnosticVarBinaryBase<BinaryScalarMinMax, Op>(ty);
+    auto exec =
+        GenerateTypeAgnosticVarBinaryBase<BinaryScalarMinMax, ArrayKernelExec, Op>(ty);
     ScalarKernel kernel{KernelSignature::Make({ty}, ty, /*is_varargs=*/true), exec,
                         MinMaxState::Init};
     kernel.null_handling = NullHandling::COMPUTED_NO_PREALLOCATE;

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -1244,7 +1244,7 @@ void AddPrimitiveIfElseKernels(const std::shared_ptr<ScalarFunction>& scalar_fun
                                const std::vector<std::shared_ptr<DataType>>& types) {
   for (auto&& type : types) {
     auto exec =
-        internal::GenerateTypeAgnosticPrimitive<ResolveIfElseExec,
+        internal::GenerateTypeAgnosticPrimitive<ResolveIfElseExec, ArrayKernelExec,
                                                 /*AllocateMem=*/std::false_type>(*type);
     // cond array needs to be boolean always
     std::shared_ptr<KernelSignature> sig;
@@ -1269,7 +1269,7 @@ void AddBinaryIfElseKernels(const std::shared_ptr<IfElseFunction>& scalar_functi
                             const std::vector<std::shared_ptr<DataType>>& types) {
   for (auto&& type : types) {
     auto exec =
-        internal::GenerateTypeAgnosticVarBinaryBase<ResolveIfElseExec,
+        internal::GenerateTypeAgnosticVarBinaryBase<ResolveIfElseExec, ArrayKernelExec,
                                                     /*AllocateMem=*/std::true_type>(
             *type);
     // cond array needs to be boolean always

--- a/cpp/src/arrow/compute/kernels/scalar_string_ascii.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_ascii.cc
@@ -3262,7 +3262,8 @@ const JoinOptions* GetDefaultJoinOptions() {
 template <typename ListType>
 void AddBinaryJoinForListType(ScalarFunction* func) {
   for (const auto& ty : BaseBinaryTypes()) {
-    auto exec = GenerateTypeAgnosticVarBinaryBase<BinaryJoin, ListType>(*ty);
+    auto exec =
+        GenerateTypeAgnosticVarBinaryBase<BinaryJoin, ArrayKernelExec, ListType>(*ty);
     auto list_ty = std::make_shared<ListType>(ty);
     DCHECK_OK(func->AddKernel({InputType(list_ty), InputType(ty)}, ty, std::move(exec)));
   }

--- a/cpp/src/arrow/compute/kernels/util_internal.cc
+++ b/cpp/src/arrow/compute/kernels/util_internal.cc
@@ -94,6 +94,25 @@ ArrayKernelExec TrivialScalarUnaryAsArraysExec(ArrayKernelExec exec, bool use_ar
   };
 }
 
+ExecValue GetExecValue(const Datum& value) {
+  ExecValue result;
+  if (value.is_array()) {
+    result.SetArray(*value.array());
+  } else {
+    result.SetScalar(value.scalar().get());
+  }
+  return result;
+}
+
+int64_t GetTrueCount(const ArraySpan& mask) {
+  if (mask.buffers[0].data != nullptr) {
+    return CountAndSetBits(mask.buffers[0].data, mask.offset,
+                           mask.buffers[1].data, mask.offset, mask.length);
+  } else {
+    return CountSetBits(mask.buffers[1].data, mask.offset, mask.length);
+  }
+}
+
 }  // namespace internal
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/util_internal.cc
+++ b/cpp/src/arrow/compute/kernels/util_internal.cc
@@ -30,33 +30,6 @@ using internal::checked_cast;
 namespace compute {
 namespace internal {
 
-const uint8_t* GetValidityBitmap(const ArrayData& data) {
-  const uint8_t* bitmap = nullptr;
-  if (data.buffers[0]) {
-    bitmap = data.buffers[0]->data();
-  }
-  return bitmap;
-}
-
-int GetBitWidth(const DataType& type) {
-  return checked_cast<const FixedWidthType&>(type).bit_width();
-}
-
-PrimitiveArg GetPrimitiveArg(const ArrayData& arr) {
-  PrimitiveArg arg;
-  arg.is_valid = GetValidityBitmap(arr);
-  arg.data = arr.buffers[1]->data();
-  arg.bit_width = GetBitWidth(*arr.type);
-  arg.offset = arr.offset;
-  arg.length = arr.length;
-  if (arg.bit_width > 1) {
-    arg.data += arr.offset * arg.bit_width / 8;
-  }
-  // This may be kUnknownNullCount
-  arg.null_count = (arg.is_valid != nullptr) ? arr.null_count.load() : 0;
-  return arg;
-}
-
 // TODO(wesm): ARROW-16577: this will be unneeded later
 ArrayKernelExec TrivialScalarUnaryAsArraysExec(ArrayKernelExec exec, bool use_array_span,
                                                NullHandling::type null_handling) {

--- a/cpp/src/arrow/compute/kernels/util_internal.cc
+++ b/cpp/src/arrow/compute/kernels/util_internal.cc
@@ -106,8 +106,8 @@ ExecValue GetExecValue(const Datum& value) {
 
 int64_t GetTrueCount(const ArraySpan& mask) {
   if (mask.buffers[0].data != nullptr) {
-    return CountAndSetBits(mask.buffers[0].data, mask.offset,
-                           mask.buffers[1].data, mask.offset, mask.length);
+    return CountAndSetBits(mask.buffers[0].data, mask.offset, mask.buffers[1].data,
+                           mask.offset, mask.length);
   } else {
     return CountSetBits(mask.buffers[1].data, mask.offset, mask.length);
   }

--- a/cpp/src/arrow/compute/kernels/util_internal.h
+++ b/cpp/src/arrow/compute/kernels/util_internal.h
@@ -90,11 +90,11 @@ std::pair<T, T> GetMinMax(const Datum& datum) {
 // Count value occurrences of an array, ignore nulls.
 // 'counts' must be zeroed and with enough size.
 template <typename T>
-ARROW_NOINLINE int64_t CountValues(uint64_t* counts, const ArrayData& data, T min) {
+ARROW_NOINLINE int64_t CountValues(uint64_t* counts, const ArraySpan& data, T min) {
   const int64_t n = data.length - data.GetNullCount();
   if (n > 0) {
     const T* values = data.GetValues<T>(1);
-    arrow::internal::VisitSetBitRunsVoid(data.buffers[0], data.offset, data.length,
+    arrow::internal::VisitSetBitRunsVoid(data.buffers[0].data, data.offset, data.length,
                                          [&](int64_t pos, int64_t len) {
                                            for (int64_t i = 0; i < len; ++i) {
                                              ++counts[values[pos + i] - min];
@@ -141,7 +141,7 @@ int64_t CopyNonNullValues(const Datum& datum, T* out) {
 ExecValue GetExecValue(const Datum& value) {
   ExecValue result;
   if (value.is_array()) {
-    result.SetArray(value.array());
+    result.SetArray(*value.array());
   } else {
     result.SetScalar(value.scalar().get());
   }

--- a/cpp/src/arrow/compute/kernels/util_internal.h
+++ b/cpp/src/arrow/compute/kernels/util_internal.h
@@ -143,24 +143,9 @@ int64_t CopyNonNullValues(const ChunkedArray& arr, T* out) {
   return n;
 }
 
-ExecValue GetExecValue(const Datum& value) {
-  ExecValue result;
-  if (value.is_array()) {
-    result.SetArray(*value.array());
-  } else {
-    result.SetScalar(value.scalar().get());
-  }
-  return result;
-}
+ExecValue GetExecValue(const Datum& value);
 
-int64_t GetTrueCount(const ArraySpan& mask) {
-  if (mask.buffers[0].data != nullptr) {
-    return CountAndSetBits(mask.buffers[0].data, mask.offset, mask.buffers[1].data,
-                           mask.offset, mask.length);
-  } else {
-    return CountSetBits(mask.buffers[1].data, mask.offset, mask.length);
-  }
-}
+int64_t GetTrueCount(const ArraySpan& mask);
 
 }  // namespace internal
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/vector_array_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_array_sort.cc
@@ -114,8 +114,8 @@ inline void VisitRawValuesInline(const ArraySpan& values,
   const c_type* data = values.GetValues<c_type>(1);
   const uint8_t* bitmap = values.buffers[0].data;
   VisitBitBlocksVoid(
-      bitmap, values.offset, values.length,
-      [&](int64_t i) { visitor_not_null(data[i]); }, [&]() { visitor_null(); });
+      bitmap, values.offset, values.length, [&](int64_t i) { visitor_not_null(data[i]); },
+      [&]() { visitor_null(); });
 }
 
 template <typename VisitorNotNull, typename VisitorNull>

--- a/cpp/src/arrow/compute/kernels/vector_cumulative_ops.cc
+++ b/cpp/src/arrow/compute/kernels/vector_cumulative_ops.cc
@@ -196,8 +196,8 @@ void MakeVectorCumulativeFunction(FunctionRegistry* registry, const std::string 
     kernel.can_execute_chunkwise = false;
     kernel.null_handling = NullHandling::type::COMPUTED_NO_PREALLOCATE;
     kernel.mem_allocation = MemAllocation::type::NO_PREALLOCATE;
-    kernel.signature = KernelSignature::Make({InputType(ty)},
-                                             OutputType(ValueDescr(ty, ValueDescr::ARRAY)));
+    kernel.signature =
+        KernelSignature::Make({InputType::Array(ty)}, OutputType(ValueDescr(ty)));
     kernel.exec =
         ArithmeticExecFromOp<CumulativeKernel, Op, ArrayKernelExec, OptionsType>(ty);
     kernel.exec_chunked =

--- a/cpp/src/arrow/compute/kernels/vector_cumulative_ops.cc
+++ b/cpp/src/arrow/compute/kernels/vector_cumulative_ops.cc
@@ -159,7 +159,7 @@ struct CumulativeGeneric {
     return st;
   }
 
-  static Status Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+  static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
     const auto& options = CumulativeOptionsWrapper<OptionsType>::Get(ctx);
 
     auto start = UnboxScalar<OutType>::Unbox(*(options.start));

--- a/cpp/src/arrow/compute/kernels/vector_nested.cc
+++ b/cpp/src/arrow/compute/kernels/vector_nested.cc
@@ -29,7 +29,7 @@ namespace {
 
 template <typename Type>
 Status ListFlatten(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
-  typename TypeTraits<Type>::ArrayType list_array(batch[0].array());
+  typename TypeTraits<Type>::ArrayType list_array(batch[0].array.ToArrayData());
   ARROW_ASSIGN_OR_RAISE(auto result, list_array.Flatten(ctx->memory_pool()));
   out->value = std::move(result->data());
   return Status::OK();

--- a/cpp/src/arrow/compute/kernels/vector_nested.cc
+++ b/cpp/src/arrow/compute/kernels/vector_nested.cc
@@ -31,7 +31,7 @@ template <typename Type>
 Status ListFlatten(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
   typename TypeTraits<Type>::ArrayType list_array(batch[0].array());
   ARROW_ASSIGN_OR_RAISE(auto result, list_array.Flatten(ctx->memory_pool()));
-  out->value = result->data();
+  out->value = std::move(result->data());
   return Status::OK();
 }
 

--- a/cpp/src/arrow/compute/kernels/vector_nested.cc
+++ b/cpp/src/arrow/compute/kernels/vector_nested.cc
@@ -28,7 +28,7 @@ namespace internal {
 namespace {
 
 template <typename Type>
-Status ListFlatten(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+Status ListFlatten(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
   typename TypeTraits<Type>::ArrayType list_array(batch[0].array());
   ARROW_ASSIGN_OR_RAISE(auto result, list_array.Flatten(ctx->memory_pool()));
   out->value = result->data();

--- a/cpp/src/arrow/compute/kernels/vector_replace.cc
+++ b/cpp/src/arrow/compute/kernels/vector_replace.cc
@@ -22,10 +22,6 @@
 #include "arrow/util/bitmap_ops.h"
 
 namespace arrow {
-
-using internal::CountAndSetBits;
-using internal::CountSetBits;
-
 namespace compute {
 namespace internal {
 
@@ -332,12 +328,7 @@ Status CheckReplaceMaskInputs(const DataType& value_type, int64_t arr_length,
     mask_count = (mask.is_valid && mask.value) ? arr_length : 0;
   } else {
     const ArraySpan& mask = mask_box.array;
-    if (mask.buffers[0].data != nullptr) {
-      mask_count = CountAndSetBits(mask.buffers[0].data, mask.offset,
-                                   mask.buffers[1].data, mask.offset, mask.length);
-    } else {
-      mask_count = CountSetBits(mask.buffers[1].data, mask.offset, mask.length);
-    }
+    mask_count = GetTrueCount(mask);
     if (mask.length != arr_length) {
       return Status::Invalid("Mask must be of same length as array (expected ",
                              arr_length, " items but got ", mask.length, " items)");

--- a/cpp/src/arrow/compute/kernels/vector_replace_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_replace_test.cc
@@ -383,7 +383,8 @@ TYPED_TEST(TestReplaceNumeric, ReplaceWithMask) {
            {"[null]", "[null, null]", "[null, null]", "[null, null, null]", "[null]"})},
   };
 
-  for (auto test_case : cases) {
+  for (size_t i = 0; i < cases.size(); ++i) {
+    auto test_case = cases[i];
     if (std::is_same<TypeParam, Date64Type>::value) {
       // ARROW-10924: account for Date64 value restrictions
       ASSERT_OK_AND_ASSIGN(test_case.input, Cast(test_case.input, int64()));

--- a/cpp/src/arrow/compute/kernels/vector_selection.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection.cc
@@ -54,7 +54,6 @@ using internal::CheckIndexBounds;
 using internal::CopyBitmap;
 using internal::CountSetBits;
 using internal::GetArrayView;
-using internal::GetByteWidth;
 using internal::OptionalBitBlockCounter;
 using internal::OptionalBitIndexer;
 
@@ -85,7 +84,7 @@ int64_t GetFilterOutputSize(const ArraySpan& filter,
     }
   } else {
     // The filter has no nulls, so we can use CountSetBits
-    output_size = CountSetBits(filter.buffers[1].data(), filter.offset, filter.length);
+    output_size = CountSetBits(filter.buffers[1].data, filter.offset, filter.length);
   }
   return output_size;
 }
@@ -94,16 +93,16 @@ namespace {
 
 template <typename IndexType>
 Result<std::shared_ptr<ArrayData>> GetTakeIndicesImpl(
-    const ArrayData& filter, FilterOptions::NullSelectionBehavior null_selection,
+    const ArraySpan& filter, FilterOptions::NullSelectionBehavior null_selection,
     MemoryPool* memory_pool) {
   using T = typename IndexType::c_type;
 
-  const uint8_t* filter_data = filter.buffers[1]->data();
+  const uint8_t* filter_data = filter.buffers[1].data;
   const bool have_filter_nulls = filter.MayHaveNulls();
   const uint8_t* filter_is_valid =
-      have_filter_nulls ? filter.buffers[0]->data() : nullptr;
+      filter.buffers[0].data
 
-  if (have_filter_nulls && null_selection == FilterOptions::EMIT_NULL) {
+      if (have_filter_nulls && null_selection == FilterOptions::EMIT_NULL) {
     // Most complex case: the filter may have nulls and we don't drop them.
     // The logic is ternary:
     // - filter is null: emit null
@@ -224,7 +223,7 @@ Result<std::shared_ptr<ArrayData>> GetTakeIndicesImpl(
 }  // namespace
 
 Result<std::shared_ptr<ArrayData>> GetTakeIndices(
-    const ArrayData& filter, FilterOptions::NullSelectionBehavior null_selection,
+    const ArraySpan& filter, FilterOptions::NullSelectionBehavior null_selection,
     MemoryPool* memory_pool) {
   DCHECK_EQ(filter.type->id(), Type::BOOL);
   if (filter.length <= std::numeric_limits<uint16_t>::max()) {
@@ -275,14 +274,14 @@ Status PreallocateData(KernelContext* ctx, int64_t length, int bit_width,
 /// This function assumes that the indices have been boundschecked.
 template <typename IndexCType, typename ValueCType>
 struct PrimitiveTakeImpl {
-  static void Exec(const PrimitiveArg& values, const PrimitiveArg& indices,
+  static void Exec(const ArraySpan& values, const ArraySpan& indices,
                    ArrayData* out_arr) {
-    auto values_data = reinterpret_cast<const ValueCType*>(values.data);
-    auto values_is_valid = values.is_valid;
+    const ValueCType* values_data = values.GetValues<ValueCType>(1);
+    const uint8_t* values_is_valid = values.buffers[0].data;
     auto values_offset = values.offset;
 
-    auto indices_data = reinterpret_cast<const IndexCType*>(indices.data);
-    auto indices_is_valid = indices.is_valid;
+    const IndexCType* indices_data = indices.GetValues<IndexCType>(1);
+    const uint8_t* indices_is_valid = indices.buffers[0].data;
     auto indices_offset = indices.offset;
 
     auto out = out_arr->GetMutableValues<ValueCType>(1);
@@ -373,14 +372,14 @@ struct PrimitiveTakeImpl {
 
 template <typename IndexCType>
 struct BooleanTakeImpl {
-  static void Exec(const PrimitiveArg& values, const PrimitiveArg& indices,
+  static void Exec(const ArraySpan& values, const ArraySpan& indices,
                    ArrayData* out_arr) {
-    const uint8_t* values_data = values.data;
-    auto values_is_valid = values.is_valid;
+    const uint8_t* values_data = values.buffers[1].data;
+    const uint8_t* values_is_valid = values.buffers[0].data;
     auto values_offset = values.offset;
 
-    auto indices_data = reinterpret_cast<const IndexCType*>(indices.data);
-    auto indices_is_valid = indices.is_valid;
+    const IndexCType* indices_data = indices.GetValues<IndexCType>(1);
+    const uint8_t* indices_is_valid = indices.buffers[0].data;
     auto indices_offset = indices.offset;
 
     auto out = out_arr->buffers[1]->mutable_data();
@@ -471,21 +470,21 @@ struct BooleanTakeImpl {
 };
 
 template <template <typename...> class TakeImpl, typename... Args>
-void TakeIndexDispatch(const PrimitiveArg& values, const PrimitiveArg& indices,
+void TakeIndexDispatch(const ArraySpan& values, const ArraySpan& indices,
                        ArrayData* out) {
   // With the simplifying assumption that boundschecking has taken place
   // already at a higher level, we can now assume that the index values are all
   // non-negative. Thus, we can interpret signed integers as unsigned and avoid
   // having to generate double the amount of binary code to handle each integer
   // width.
-  switch (indices.bit_width) {
-    case 8:
+  switch (indices.type->byte_width()) {
+    case 1:
       return TakeImpl<uint8_t, Args...>::Exec(values, indices, out);
-    case 16:
+    case 2:
       return TakeImpl<uint16_t, Args...>::Exec(values, indices, out);
-    case 32:
+    case 4:
       return TakeImpl<uint32_t, Args...>::Exec(values, indices, out);
-    case 64:
+    case 8:
       return TakeImpl<uint64_t, Args...>::Exec(values, indices, out);
     default:
       DCHECK(false) << "Invalid indices byte width";
@@ -493,23 +492,25 @@ void TakeIndexDispatch(const PrimitiveArg& values, const PrimitiveArg& indices,
   }
 }
 
-Status PrimitiveTake(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+Status PrimitiveTake(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
+  const ArraySpan& values = batch[0].array;
+  const ArraySpan& indices = batch[1].array;
+
   if (TakeState::Get(ctx).boundscheck) {
-    RETURN_NOT_OK(CheckIndexBounds(*batch[1].array(), batch[0].length()));
+    RETURN_NOT_OK(CheckIndexBounds(indices, values.length));
   }
 
-  PrimitiveArg values = GetPrimitiveArg(*batch[0].array());
-  PrimitiveArg indices = GetPrimitiveArg(*batch[1].array());
+  ArrayData* out_arr = out->array_data().get();
 
-  ArrayData* out_arr = out->mutable_array();
+  const int bit_width = values.type->bit_width();
 
   // TODO: When neither values nor indices contain nulls, we can skip
   // allocating the validity bitmap altogether and save time and space. A
   // streamlined PrimitiveTakeImpl would need to be written that skips all
   // interactions with the output validity bitmap, though.
-  RETURN_NOT_OK(PreallocateData(ctx, indices.length, values.bit_width,
+  RETURN_NOT_OK(PreallocateData(ctx, indices.length, bit_width,
                                 /*allocate_validity=*/true, out_arr));
-  switch (values.bit_width) {
+  switch (bit_width) {
     case 1:
       TakeIndexDispatch<BooleanTakeImpl>(values, indices, out_arr);
       break;
@@ -575,16 +576,16 @@ class PrimitiveFilterImpl {
   using T = typename std::conditional<std::is_same<ArrowType, BooleanType>::value,
                                       uint8_t, typename ArrowType::c_type>::type;
 
-  PrimitiveFilterImpl(const PrimitiveArg& values, const PrimitiveArg& filter,
+  PrimitiveFilterImpl(const ArraySpan& values, const ArraySpan& filter,
                       FilterOptions::NullSelectionBehavior null_selection,
                       ArrayData* out_arr)
-      : values_is_valid_(values.is_valid),
-        values_data_(reinterpret_cast<const T*>(values.data)),
+      : values_is_valid_(values.buffers[0].data),
+        values_data_(values.GetValues<T>(1)),
         values_null_count_(values.null_count),
         values_offset_(values.offset),
         values_length_(values.length),
-        filter_is_valid_(filter.is_valid),
-        filter_data_(filter.data),
+        filter_is_valid_(filter.buffers[0].data),
+        filter_data_(filter.buffers[1].data),
         filter_null_count_(filter.null_count),
         filter_offset_(filter.offset),
         null_selection_(null_selection) {
@@ -786,15 +787,15 @@ inline void PrimitiveFilterImpl<BooleanType>::WriteNull() {
   bit_util::ClearBit(out_data_, out_offset_ + out_position_++);
 }
 
-Status PrimitiveFilter(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-  PrimitiveArg values = GetPrimitiveArg(*batch[0].array());
-  PrimitiveArg filter = GetPrimitiveArg(*batch[1].array());
+Status PrimitiveFilter(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
+  const ArraySpan& values = batch[0].array;
+  const ArraySpan& filter = batch[1].array;
   FilterOptions::NullSelectionBehavior null_selection =
       FilterState::Get(ctx).null_selection_behavior;
 
-  int64_t output_length = GetFilterOutputSize(*batch[1].array(), null_selection);
+  int64_t output_length = GetFilterOutputSize(filter, null_selection);
 
-  ArrayData* out_arr = out->mutable_array();
+  ArrayData* out_arr = out->array_data().get();
 
   // The output precomputed null count is unknown except in the narrow
   // condition that all the values are non-null and the filter will not cause
@@ -811,10 +812,11 @@ Status PrimitiveFilter(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
   // validity bitmap.
   bool allocate_validity = values.null_count != 0 || filter.null_count != 0;
 
+  const int bit_width = values.type->bit_width();
   RETURN_NOT_OK(
-      PreallocateData(ctx, output_length, values.bit_width, allocate_validity, out_arr));
+      PreallocateData(ctx, output_length, bit_width, allocate_validity, out_arr));
 
-  switch (values.bit_width) {
+  switch (bit_width) {
     case 1:
       PrimitiveFilterImpl<BooleanType>(values, filter, null_selection, out_arr).Exec();
       break;
@@ -841,9 +843,8 @@ Status PrimitiveFilter(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
 // Optimized filter for base binary types (32-bit and 64-bit)
 
 #define BINARY_FILTER_SETUP_COMMON()                                                    \
-  auto raw_offsets =                                                                    \
-      reinterpret_cast<const offset_type*>(values.buffers[1]->data()) + values.offset;  \
-  const uint8_t* raw_data = values.buffers[2]->data();                                  \
+  const auto raw_offsets = values.GetValues<offset_type>(1);                            \
+  const uint8_t* raw_data = values.buffers[2].data;                                     \
                                                                                         \
   TypedBufferBuilder<offset_type> offset_builder(ctx->memory_pool());                   \
   TypedBufferBuilder<uint8_t> data_builder(ctx->memory_pool());                         \
@@ -877,12 +878,12 @@ Status PrimitiveFilter(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
 // Optimized binary filter for the case where neither values nor filter have
 // nulls
 template <typename Type>
-Status BinaryFilterNonNullImpl(KernelContext* ctx, const ArrayData& values,
-                               const ArrayData& filter, int64_t output_length,
+Status BinaryFilterNonNullImpl(KernelContext* ctx, const ArraySpan& values,
+                               const ArraySpan& filter, int64_t output_length,
                                FilterOptions::NullSelectionBehavior null_selection,
                                ArrayData* out) {
   using offset_type = typename Type::offset_type;
-  const auto filter_data = filter.buffers[1]->data();
+  const auto filter_data = filter.buffers[1].data;
 
   BINARY_FILTER_SETUP_COMMON();
 
@@ -909,17 +910,17 @@ Status BinaryFilterNonNullImpl(KernelContext* ctx, const ArrayData& values,
 }
 
 template <typename Type>
-Status BinaryFilterImpl(KernelContext* ctx, const ArrayData& values,
-                        const ArrayData& filter, int64_t output_length,
+Status BinaryFilterImpl(KernelContext* ctx, const ArraySpan& values,
+                        const ArraySpan& filter, int64_t output_length,
                         FilterOptions::NullSelectionBehavior null_selection,
                         ArrayData* out) {
   using offset_type = typename Type::offset_type;
 
-  const auto filter_data = filter.buffers[1]->data();
-  const uint8_t* filter_is_valid = GetValidityBitmap(filter);
+  const auto filter_data = filter.buffers[1].data;
+  const uint8_t* filter_is_valid = filter.buffers[0].data;
   const int64_t filter_offset = filter.offset;
 
-  const uint8_t* values_is_valid = GetValidityBitmap(values);
+  const uint8_t* values_is_valid = values.buffers[0].data;
   const int64_t values_offset = values.offset;
 
   uint8_t* out_is_valid = out->buffers[0]->mutable_data();
@@ -1082,14 +1083,15 @@ Status BinaryFilterImpl(KernelContext* ctx, const ArrayData& values,
 #undef APPEND_RAW_DATA
 #undef APPEND_SINGLE_VALUE
 
-Status BinaryFilter(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+Status BinaryFilter(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
   FilterOptions::NullSelectionBehavior null_selection =
       FilterState::Get(ctx).null_selection_behavior;
 
-  const ArrayData& values = *batch[0].array();
-  const ArrayData& filter = *batch[1].array();
+  const ArraySpan& values = batch[0].array;
+  const ArraySpan& filter = batch[1].array;
   int64_t output_length = GetFilterOutputSize(filter, null_selection);
-  ArrayData* out_arr = out->mutable_array();
+
+  ArrayData* out_arr = out->array_data().get();
 
   // The output precomputed null count is unknown except in the narrow
   // condition that all the values are non-null and the filter will not cause
@@ -1132,19 +1134,19 @@ Status BinaryFilter(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
 // ----------------------------------------------------------------------
 // Null take and filter
 
-Status NullTake(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+Status NullTake(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
   if (TakeState::Get(ctx).boundscheck) {
-    RETURN_NOT_OK(CheckIndexBounds(*batch[1].array(), batch[0].length()));
+    RETURN_NOT_OK(CheckIndexBounds(batch[1].array, batch[0].length()));
   }
   // batch.length doesn't take into account the take indices
-  auto new_length = batch[1].array()->length;
+  auto new_length = batch[1].array.length;
   out->value = std::make_shared<NullArray>(new_length)->data();
   return Status::OK();
 }
 
-Status NullFilter(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-  int64_t output_length = GetFilterOutputSize(
-      *batch[1].array(), FilterState::Get(ctx).null_selection_behavior);
+Status NullFilter(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
+  int64_t output_length =
+      GetFilterOutputSize(batch[1].array, FilterState::Get(ctx).null_selection_behavior);
   out->value = std::make_shared<NullArray>(output_length)->data();
   return Status::OK();
 }
@@ -1152,21 +1154,21 @@ Status NullFilter(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
 // ----------------------------------------------------------------------
 // Dictionary take and filter
 
-Status DictionaryTake(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-  DictionaryArray values(batch[0].array());
+Status DictionaryTake(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
+  DictionaryArray values(batch[0].array.ToArrayData());
   Datum result;
-  RETURN_NOT_OK(
-      Take(Datum(values.indices()), batch[1], TakeState::Get(ctx), ctx->exec_context())
-          .Value(&result));
+  RETURN_NOT_OK(Take(Datum(values.indices()), batch[1].array.ToArrayData(),
+                     TakeState::Get(ctx), ctx->exec_context())
+                    .Value(&result));
   DictionaryArray taken_values(values.type(), result.make_array(), values.dictionary());
   out->value = taken_values.data();
   return Status::OK();
 }
 
-Status DictionaryFilter(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-  DictionaryArray dict_values(batch[0].array());
+Status DictionaryFilter(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
+  DictionaryArray dict_values(batch[0].array.ToArrayData());
   Datum result;
-  RETURN_NOT_OK(Filter(Datum(dict_values.indices()), batch[1].array(),
+  RETURN_NOT_OK(Filter(Datum(dict_values.indices()), batch[1].array.ToArrayData(),
                        FilterState::Get(ctx), ctx->exec_context())
                     .Value(&result));
   DictionaryArray filtered_values(dict_values.type(), result.make_array(),
@@ -1178,21 +1180,21 @@ Status DictionaryFilter(KernelContext* ctx, const ExecBatch& batch, Datum* out) 
 // ----------------------------------------------------------------------
 // Extension take and filter
 
-Status ExtensionTake(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-  ExtensionArray values(batch[0].array());
+Status ExtensionTake(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
+  ExtensionArray values(batch[0].array.ToArrayData());
   Datum result;
-  RETURN_NOT_OK(
-      Take(Datum(values.storage()), batch[1], TakeState::Get(ctx), ctx->exec_context())
-          .Value(&result));
+  RETURN_NOT_OK(Take(Datum(values.storage()), batch[1].array.ToArrayData(),
+                     TakeState::Get(ctx), ctx->exec_context())
+                    .Value(&result));
   ExtensionArray taken_values(values.type(), result.make_array());
   out->value = taken_values.data();
   return Status::OK();
 }
 
-Status ExtensionFilter(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-  ExtensionArray ext_values(batch[0].array());
+Status ExtensionFilter(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
+  ExtensionArray ext_values(batch[0].array.ToArrayData());
   Datum result;
-  RETURN_NOT_OK(Filter(Datum(ext_values.storage()), batch[1].array(),
+  RETURN_NOT_OK(Filter(Datum(ext_values.storage()), batch[1].array.ToArrayData(),
                        FilterState::Get(ctx), ctx->exec_context())
                     .Value(&result));
   ExtensionArray filtered_values(ext_values.type(), result.make_array());
@@ -1238,24 +1240,25 @@ struct Selection {
   };
 
   KernelContext* ctx;
-  std::shared_ptr<ArrayData> values;
-  std::shared_ptr<ArrayData> selection;
+  const ArraySpan& values;
+  const ArraySpan& selection;
   int64_t output_length;
   ArrayData* out;
   TypedBufferBuilder<bool> validity_builder;
 
-  Selection(KernelContext* ctx, const ExecBatch& batch, int64_t output_length, Datum* out)
+  Selection(KernelContext* ctx, const ExecBatch& batch, int64_t output_length,
+            ExecResult* out)
       : ctx(ctx),
-        values(batch[0].array()),
-        selection(batch[1].array()),
+        values(batch[0].array),
+        selection(batch[1].array),
         output_length(output_length),
-        out(out->mutable_array()),
+        out(out->array_data().get()),
         validity_builder(ctx->memory_pool()) {}
 
   virtual ~Selection() = default;
 
   Status FinishCommon() {
-    out->buffers.resize(values->buffers.size());
+    out->buffers.resize(values.num_buffers());
     out->length = validity_builder.length();
     out->null_count = validity_builder.false_count();
     return validity_builder.Finish(&out->buffers[0]);
@@ -1263,15 +1266,15 @@ struct Selection {
 
   template <typename IndexCType, typename ValidVisitor, typename NullVisitor>
   Status VisitTake(ValidVisitor&& visit_valid, NullVisitor&& visit_null) {
-    const auto indices_values = selection->GetValues<IndexCType>(1);
-    const uint8_t* is_valid = GetValidityBitmap(*selection);
-    OptionalBitIndexer indices_is_valid(selection->buffers[0], selection->offset);
-    OptionalBitIndexer values_is_valid(values->buffers[0], values->offset);
+    const auto indices_values = selection.GetValues<IndexCType>(1);
+    const uint8_t* is_valid = selection.buffers[0].data;
+    OptionalBitIndexer indices_is_valid(is_valid, selection.offset);
+    OptionalBitIndexer values_is_valid(values.buffers[0].data, values.offset);
 
-    const bool values_have_nulls = values->MayHaveNulls();
-    OptionalBitBlockCounter bit_counter(is_valid, selection->offset, selection->length);
+    const bool values_have_nulls = values.MayHaveNulls();
+    OptionalBitBlockCounter bit_counter(is_valid, selection.offset, selection.length);
     int64_t position = 0;
-    while (position < selection->length) {
+    while (position < selection.length) {
       BitBlockCount block = bit_counter.NextBlock();
       const bool indices_have_nulls = block.popcount < block.length;
       if (!indices_have_nulls && !values_have_nulls) {
@@ -1313,22 +1316,22 @@ struct Selection {
   Status VisitFilter(ValidVisitor&& visit_valid, NullVisitor&& visit_null) {
     auto null_selection = FilterState::Get(ctx).null_selection_behavior;
 
-    const auto filter_data = selection->buffers[1]->data();
+    const uint8_t* filter_data = selection.buffers[1].data;
 
-    const uint8_t* filter_is_valid = GetValidityBitmap(*selection);
-    const int64_t filter_offset = selection->offset;
-    OptionalBitIndexer values_is_valid(values->buffers[0], values->offset);
+    const uint8_t* filter_is_valid = selection.buffers[0].data;
+    const int64_t filter_offset = selection.offset;
+    OptionalBitIndexer values_is_valid(values.buffers[0].data, values.offset);
 
     // We use 3 block counters for fast scanning of the filter
     //
     // * values_valid_counter: for values null/not-null
     // * filter_valid_counter: for filter null/not-null
     // * filter_counter: for filter true/false
-    OptionalBitBlockCounter values_valid_counter(GetValidityBitmap(*values),
-                                                 values->offset, values->length);
+    OptionalBitBlockCounter values_valid_counter(values.buffers[0].data, values.offset,
+                                                 values.length);
     OptionalBitBlockCounter filter_valid_counter(filter_is_valid, filter_offset,
-                                                 selection->length);
-    BitBlockCounter filter_counter(filter_data, filter_offset, selection->length);
+                                                 selection.length);
+    BitBlockCounter filter_counter(filter_data, filter_offset, selection.length);
     int64_t in_position = 0;
 
     auto AppendNotNull = [&](int64_t index) -> Status {
@@ -1349,7 +1352,7 @@ struct Selection {
       }
     };
 
-    while (in_position < selection->length) {
+    while (in_position < selection.length) {
       BitBlockCount filter_valid_block = filter_valid_counter.NextWord();
       BitBlockCount values_valid_block = values_valid_counter.NextWord();
       BitBlockCount filter_block = filter_counter.NextWord();
@@ -1436,7 +1439,7 @@ struct Selection {
   Status ExecTake() {
     RETURN_NOT_OK(this->validity_builder.Reserve(output_length));
     RETURN_NOT_OK(Init());
-    int index_width = GetByteWidth(*this->selection->type);
+    int index_width = this->selection->type->byte_width();
 
     // CTRP dispatch here
     switch (index_width) {
@@ -1517,9 +1520,9 @@ struct VarBinaryImpl : public Selection<VarBinaryImpl<Type>, Type> {
     ValuesArrayType typed_values(this->values_as_binary);
 
     // Presize the data builder with a rough estimate of the required data size
-    if (values->length > 0) {
+    if (values.length > 0) {
       const double mean_value_length =
-          (typed_values.total_values_length() / static_cast<double>(values->length));
+          (typed_values.total_values_length() / static_cast<double>(values.length));
 
       // TODO: See if possible to reduce output_length for take/filter cases
       // where there are nulls in the selection array
@@ -1685,7 +1688,7 @@ struct DenseUnionImpl : public Selection<DenseUnionImpl, DenseUnionType> {
       : Base(ctx, batch, output_length, out),
         value_offset_buffer_builder_(ctx->memory_pool()),
         child_id_buffer_builder_(ctx->memory_pool()),
-        type_codes_(checked_cast<const UnionType&>(*this->values->type).type_codes()),
+        type_codes_(checked_cast<const UnionType&>(*this->values.type).type_codes()),
         child_indices_builders_(type_codes_.size()) {
     for (auto& child_indices_builder : child_indices_builders_) {
       child_indices_builder = Int32Builder(ctx->memory_pool());
@@ -1820,8 +1823,8 @@ struct StructImpl : public Selection<StructImpl, StructType> {
     StructArray typed_values(values);
 
     // Select from children without boundschecking
-    out->child_data.resize(values->type->num_fields());
-    for (int field_index = 0; field_index < values->type->num_fields(); ++field_index) {
+    out->child_data.resize(values.type->num_fields());
+    for (int field_index = 0; field_index < values.type->num_fields(); ++field_index) {
       ARROW_ASSIGN_OR_RAISE(Datum taken_field,
                             Take(Datum(typed_values.field(field_index)), Datum(selection),
                                  TakeOptions::NoBoundsCheck(), ctx->exec_context()));
@@ -2308,18 +2311,18 @@ class DropNullMetaFunction : public MetaFunction {
 // ----------------------------------------------------------------------
 
 template <typename Impl>
-Status FilterExec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+Status FilterExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
   // TODO: where are the values and filter length equality checked?
-  int64_t output_length = GetFilterOutputSize(
-      *batch[1].array(), FilterState::Get(ctx).null_selection_behavior);
+  int64_t output_length =
+      GetFilterOutputSize(batch[1].array, FilterState::Get(ctx).null_selection_behavior);
   Impl kernel(ctx, batch, output_length, out);
   return kernel.ExecFilter();
 }
 
 template <typename Impl>
-Status TakeExec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+Status TakeExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
   if (TakeState::Get(ctx).boundscheck) {
-    RETURN_NOT_OK(CheckIndexBounds(*batch[1].array(), batch[0].length()));
+    RETURN_NOT_OK(CheckIndexBounds(batch[1].array, batch[0].length()));
   }
   Impl kernel(ctx, batch, /*output_length=*/batch[1].length(), out);
   return kernel.ExecTake();

--- a/cpp/src/arrow/compute/kernels/vector_selection.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection.cc
@@ -61,13 +61,13 @@ using internal::OptionalBitIndexer;
 namespace compute {
 namespace internal {
 
-int64_t GetFilterOutputSize(const ArrayData& filter,
+int64_t GetFilterOutputSize(const ArraySpan& filter,
                             FilterOptions::NullSelectionBehavior null_selection) {
   int64_t output_size = 0;
 
   if (filter.MayHaveNulls()) {
-    const uint8_t* filter_is_valid = filter.buffers[0]->data();
-    BinaryBitBlockCounter bit_counter(filter.buffers[1]->data(), filter.offset,
+    const uint8_t* filter_is_valid = filter.buffers[0].data;
+    BinaryBitBlockCounter bit_counter(filter.buffers[1].data, filter.offset,
                                       filter_is_valid, filter.offset, filter.length);
     int64_t position = 0;
     if (null_selection == FilterOptions::EMIT_NULL) {
@@ -85,7 +85,7 @@ int64_t GetFilterOutputSize(const ArrayData& filter,
     }
   } else {
     // The filter has no nulls, so we can use CountSetBits
-    output_size = CountSetBits(filter.buffers[1]->data(), filter.offset, filter.length);
+    output_size = CountSetBits(filter.buffers[1].data(), filter.offset, filter.length);
   }
   return output_size;
 }

--- a/cpp/src/arrow/compute/kernels/vector_selection.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection.cc
@@ -578,7 +578,7 @@ class PrimitiveFilterImpl {
                       FilterOptions::NullSelectionBehavior null_selection,
                       ArrayData* out_arr)
       : values_is_valid_(values.buffers[0].data),
-        values_data_(values.GetValues<T>(1)),
+        values_data_(reinterpret_cast<const T*>(values.buffers[1].data)),
         values_null_count_(values.null_count),
         values_offset_(values.offset),
         values_length_(values.length),
@@ -587,6 +587,11 @@ class PrimitiveFilterImpl {
         filter_null_count_(filter.null_count),
         filter_offset_(filter.offset),
         null_selection_(null_selection) {
+    if (values.type->id() != Type::BOOL) {
+      // No offset applied for boolean because it's a bitmap
+      values_data_ += values.offset;
+    }
+
     if (out_arr->buffers[0] != nullptr) {
       // May not be allocated if neither filter nor values contains nulls
       out_is_valid_ = out_arr->buffers[0]->mutable_data();

--- a/cpp/src/arrow/compute/kernels/vector_selection.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection.cc
@@ -2423,7 +2423,7 @@ Status IndicesNonZeroExec(KernelContext* ctx, const ExecSpan& batch, ExecResult*
 
 Status IndicesNonZeroExecChunked(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
   const ChunkedArray& arr = *batch[0].chunked_array();
-  std::vector<ArraySpan> arrays(arr.num_chunks());
+  std::vector<ArraySpan> arrays;
   for (int i = 0; i < arr.num_chunks(); ++i) {
     arrays.push_back(ArraySpan(*arr.chunk(i)->data()));
   }

--- a/cpp/src/arrow/compute/kernels/vector_selection.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection.cc
@@ -2327,7 +2327,7 @@ Status TakeExec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
 
 struct SelectionKernelDescr {
   InputType input;
-  ArrayKernelExecOld exec;
+  ArrayKernelExec exec;
 };
 
 void RegisterSelectionFunction(const std::string& name, FunctionDoc doc,

--- a/cpp/src/arrow/compute/row/grouper.cc
+++ b/cpp/src/arrow/compute/row/grouper.cc
@@ -101,7 +101,13 @@ struct GrouperImpl : Grouper {
   Result<Datum> Consume(const ExecBatch& batch) override {
     std::vector<int32_t> offsets_batch(batch.length + 1);
     for (int i = 0; i < batch.num_values(); ++i) {
-      encoders_[i]->AddLength(*batch[i].array(), batch.length, offsets_batch.data());
+      ExecValue value;
+      if (batch[i].is_array()) {
+        value.SetArray(*batch[i].array());
+      } else {
+        value.SetScalar(batch[i].scalar().get());
+      }
+      encoders_[i]->AddLength(value, batch.length, offsets_batch.data());
     }
 
     int32_t total_length = 0;
@@ -119,8 +125,13 @@ struct GrouperImpl : Grouper {
     }
 
     for (int i = 0; i < batch.num_values(); ++i) {
-      RETURN_NOT_OK(
-          encoders_[i]->Encode(*batch[i].array(), batch.length, key_buf_ptrs.data()));
+      ExecValue value;
+      if (batch[i].is_array()) {
+        value.SetArray(*batch[i].array());
+      } else {
+        value.SetScalar(batch[i].scalar().get());
+      }
+      RETURN_NOT_OK(encoders_[i]->Encode(value, batch.length, key_buf_ptrs.data()));
     }
 
     TypedBufferBuilder<uint32_t> group_ids_batch(ctx_->memory_pool());

--- a/cpp/src/arrow/compute/row/grouper.cc
+++ b/cpp/src/arrow/compute/row/grouper.cc
@@ -101,7 +101,7 @@ struct GrouperImpl : Grouper {
   Result<Datum> Consume(const ExecBatch& batch) override {
     std::vector<int32_t> offsets_batch(batch.length + 1);
     for (int i = 0; i < batch.num_values(); ++i) {
-      encoders_[i]->AddLength(batch[i], batch.length, offsets_batch.data());
+      encoders_[i]->AddLength(*batch[i].array(), batch.length, offsets_batch.data());
     }
 
     int32_t total_length = 0;
@@ -119,7 +119,8 @@ struct GrouperImpl : Grouper {
     }
 
     for (int i = 0; i < batch.num_values(); ++i) {
-      RETURN_NOT_OK(encoders_[i]->Encode(batch[i], batch.length, key_buf_ptrs.data()));
+      RETURN_NOT_OK(
+          encoders_[i]->Encode(*batch[i].array(), batch.length, key_buf_ptrs.data()));
     }
 
     TypedBufferBuilder<uint32_t> group_ids_batch(ctx_->memory_pool());

--- a/cpp/src/arrow/ipc/metadata_internal.cc
+++ b/cpp/src/arrow/ipc/metadata_internal.cc
@@ -51,7 +51,6 @@ namespace arrow {
 
 namespace flatbuf = org::apache::arrow::flatbuf;
 using internal::checked_cast;
-using internal::GetByteWidth;
 
 namespace ipc {
 namespace internal {
@@ -1055,8 +1054,8 @@ Status MakeSparseTensorIndexCSF(FBB& fbb, const SparseCSFIndex& sparse_index,
   auto indices_type_offset = flatbuf::CreateInt(fbb, indices_value_type.bit_width(),
                                                 indices_value_type.is_signed());
 
-  const int64_t indptr_elem_size = GetByteWidth(indptr_value_type);
-  const int64_t indices_elem_size = GetByteWidth(indices_value_type);
+  const int64_t indptr_elem_size = indptr_value_type.byte_width();
+  const int64_t indices_elem_size = indices_value_type.byte_width();
 
   int64_t offset = 0;
   std::vector<flatbuf::Buffer> indptr, indices;
@@ -1224,7 +1223,7 @@ Result<std::shared_ptr<Buffer>> WriteTensorMessage(const Tensor& tensor,
   using TensorOffset = flatbuffers::Offset<flatbuf::Tensor>;
 
   FBB fbb;
-  const int elem_size = GetByteWidth(*tensor.type());
+  const int elem_size = tensor.type()->byte_width();
 
   flatbuf::Type fb_type_type;
   Offset fb_type;

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -59,7 +59,6 @@ namespace arrow {
 
 using internal::checked_cast;
 using internal::checked_pointer_cast;
-using internal::GetByteWidth;
 using internal::TemporaryDir;
 
 namespace ipc {

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -71,7 +71,6 @@ namespace flatbuf = org::apache::arrow::flatbuf;
 
 using internal::checked_cast;
 using internal::checked_pointer_cast;
-using internal::GetByteWidth;
 
 namespace ipc {
 
@@ -2095,7 +2094,7 @@ Result<std::shared_ptr<SparseIndex>> ReadSparseCOOIndex(
 
   std::shared_ptr<DataType> indices_type;
   RETURN_NOT_OK(internal::GetSparseCOOIndexMetadata(sparse_index, &indices_type));
-  const int64_t indices_elsize = GetByteWidth(*indices_type);
+  const int64_t indices_elsize = indices_type->byte_width();
 
   auto* indices_buffer = sparse_index->indicesBuffer();
   ARROW_ASSIGN_OR_RAISE(auto indices_data,
@@ -2131,7 +2130,7 @@ Result<std::shared_ptr<SparseIndex>> ReadSparseCSXIndex(
   std::shared_ptr<DataType> indptr_type, indices_type;
   RETURN_NOT_OK(
       internal::GetSparseCSXIndexMetadata(sparse_index, &indptr_type, &indices_type));
-  const int indptr_byte_width = GetByteWidth(*indptr_type);
+  const int indptr_byte_width = indptr_type->byte_width();
 
   auto* indptr_buffer = sparse_index->indptrBuffer();
   ARROW_ASSIGN_OR_RAISE(auto indptr_data,
@@ -2142,7 +2141,7 @@ Result<std::shared_ptr<SparseIndex>> ReadSparseCSXIndex(
                         file->ReadAt(indices_buffer->offset(), indices_buffer->length()));
 
   std::vector<int64_t> indices_shape({non_zero_length});
-  const auto indices_minimum_bytes = indices_shape[0] * GetByteWidth(*indices_type);
+  const auto indices_minimum_bytes = indices_shape[0] * indices_type->byte_width();
   if (indices_minimum_bytes > indices_buffer->length()) {
     return Status::Invalid("shape is inconsistent to the size of indices buffer");
   }

--- a/cpp/src/arrow/ipc/tensor_test.cc
+++ b/cpp/src/arrow/ipc/tensor_test.cc
@@ -42,7 +42,6 @@
 namespace arrow {
 
 using internal::checked_cast;
-using internal::GetByteWidth;
 using internal::TemporaryDir;
 
 namespace ipc {
@@ -64,7 +63,7 @@ class TestTensorRoundTrip : public BaseTensorTest {
   void CheckTensorRoundTrip(const Tensor& tensor) {
     int32_t metadata_length;
     int64_t body_length;
-    const int elem_size = GetByteWidth(*tensor.type());
+    const int elem_size = tensor.type()->byte_width();
 
     ASSERT_OK(mmap_->Seek(0));
 
@@ -139,7 +138,7 @@ template <typename IndexValueType>
 class TestSparseTensorRoundTrip : public BaseTensorTest {
  public:
   void CheckSparseCOOTensorRoundTrip(const SparseCOOTensor& sparse_tensor) {
-    const int elem_size = GetByteWidth(*sparse_tensor.type());
+    const int elem_size = sparse_tensor.type()->byte_width();
     const int index_elem_size = sizeof(typename IndexValueType::c_type);
 
     int32_t metadata_length;
@@ -180,7 +179,7 @@ class TestSparseTensorRoundTrip : public BaseTensorTest {
                       std::is_same<SparseIndexType, SparseCSCIndex>::value,
                   "SparseIndexType must be either SparseCSRIndex or SparseCSCIndex");
 
-    const int elem_size = GetByteWidth(*sparse_tensor.type());
+    const int elem_size = sparse_tensor.type()->byte_width();
     const int index_elem_size = sizeof(typename IndexValueType::c_type);
 
     int32_t metadata_length;
@@ -221,7 +220,7 @@ class TestSparseTensorRoundTrip : public BaseTensorTest {
   }
 
   void CheckSparseCSFTensorRoundTrip(const SparseCSFTensor& sparse_tensor) {
-    const int elem_size = GetByteWidth(*sparse_tensor.type());
+    const int elem_size = sparse_tensor.type()->byte_width();
     const int index_elem_size = sizeof(typename IndexValueType::c_type);
 
     int32_t metadata_length;

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -62,7 +62,6 @@ namespace arrow {
 using internal::checked_cast;
 using internal::checked_pointer_cast;
 using internal::CopyBitmap;
-using internal::GetByteWidth;
 
 namespace ipc {
 
@@ -322,7 +321,7 @@ class RecordBatchSerializer {
   Visit(const T& array) {
     std::shared_ptr<Buffer> data = array.values();
 
-    const int64_t type_width = GetByteWidth(*array.type());
+    const int64_t type_width = array.type()->byte_width();
     int64_t min_length = PaddedLength(array.length() * type_width);
 
     if (NeedTruncate(array.offset(), data.get(), min_length)) {
@@ -705,7 +704,7 @@ Status WriteStridedTensorData(int dim_index, int64_t offset, int elem_size,
 
 Status GetContiguousTensor(const Tensor& tensor, MemoryPool* pool,
                            std::unique_ptr<Tensor>* out) {
-  const int elem_size = GetByteWidth(*tensor.type());
+  const int elem_size = tensor.type()->byte_width();
 
   ARROW_ASSIGN_OR_RAISE(
       auto scratch_space,
@@ -727,7 +726,7 @@ Status GetContiguousTensor(const Tensor& tensor, MemoryPool* pool,
 
 Status WriteTensor(const Tensor& tensor, io::OutputStream* dst, int32_t* metadata_length,
                    int64_t* body_length) {
-  const int elem_size = GetByteWidth(*tensor.type());
+  const int elem_size = tensor.type()->byte_width();
 
   *body_length = tensor.size() * elem_size;
 

--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -65,7 +65,6 @@ class MemoryPool;
 
 using internal::checked_cast;
 using internal::CheckIndexBounds;
-using internal::GetByteWidth;
 using internal::OptionalParallelFor;
 
 namespace py {
@@ -280,7 +279,7 @@ inline const T* GetPrimitiveValues(const Array& arr) {
   if (arr.length() == 0) {
     return nullptr;
   }
-  const int elsize = GetByteWidth(*arr.type());
+  const int elsize = arr.type()->byte_width();
   const auto& prim_arr = checked_cast<const PrimitiveArray&>(arr);
   return reinterpret_cast<const T*>(prim_arr.values()->data() + arr.offset() * elsize);
 }

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -277,7 +277,7 @@ Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::Make(
   if (!is_integer(indices_type->id())) {
     return Status::TypeError("Type of SparseCOOIndex indices must be integer");
   }
-  const int64_t elsize = internal::GetByteWidth(*indices_type);
+  const int64_t elsize = indices_type->byte_width();
   std::vector<int64_t> indices_shape({non_zero_length, ndim});
   std::vector<int64_t> indices_strides({elsize * ndim, elsize});
   return Make(indices_type, indices_shape, indices_strides, indices_data);

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -44,7 +44,7 @@ namespace internal {
 Status ComputeRowMajorStrides(const FixedWidthType& type,
                               const std::vector<int64_t>& shape,
                               std::vector<int64_t>* strides) {
-  const int byte_width = GetByteWidth(type);
+  const int byte_width = type.byte_width();
   const size_t ndim = shape.size();
 
   int64_t remaining = 0;
@@ -75,7 +75,7 @@ Status ComputeRowMajorStrides(const FixedWidthType& type,
 Status ComputeColumnMajorStrides(const FixedWidthType& type,
                                  const std::vector<int64_t>& shape,
                                  std::vector<int64_t>* strides) {
-  const int byte_width = internal::GetByteWidth(type);
+  const int byte_width = type.byte_width();
   const size_t ndim = shape.size();
 
   int64_t total = 0;
@@ -183,7 +183,7 @@ Status CheckTensorStridesValidity(const std::shared_ptr<Buffer>& data,
         "offsets computed from shape and strides would not fit in 64-bit integer");
   }
 
-  const int byte_width = internal::GetByteWidth(*type);
+  const int byte_width = type->byte_width();
   if (largest_offset > data->size() - byte_width) {
     return Status::Invalid("strides must not involve buffer over run");
   }

--- a/cpp/src/arrow/tensor/coo_converter.cc
+++ b/cpp/src/arrow/tensor/coo_converter.cc
@@ -172,8 +172,8 @@ class SparseCOOTensorConverter : private SparseTensorConverterMixin {
     RETURN_NOT_OK(::arrow::internal::CheckSparseIndexMaximumValue(index_value_type_,
                                                                   tensor_.shape()));
 
-    const int index_elsize = GetByteWidth(*index_value_type_);
-    const int value_elsize = GetByteWidth(*tensor_.type());
+    const int index_elsize = index_value_type_->byte_width();
+    const int value_elsize = tensor_.type()->byte_width();
 
     const int64_t ndim = tensor_.ndim();
     ARROW_ASSIGN_OR_RAISE(int64_t nonzero_count, tensor_.CountNonZero());
@@ -295,10 +295,10 @@ Result<std::shared_ptr<Tensor>> MakeTensorFromSparseCOOTensor(
   const auto& coords = sparse_index.indices();
   const auto* coords_data = coords->raw_data();
 
-  const int index_elsize = GetByteWidth(*coords->type());
+  const int index_elsize = coords->type()->byte_width();
 
   const auto& value_type = checked_cast<const FixedWidthType&>(*sparse_tensor->type());
-  const int value_elsize = GetByteWidth(value_type);
+  const int value_elsize = value_type.byte_width();
   ARROW_ASSIGN_OR_RAISE(auto values_buffer,
                         AllocateBuffer(value_elsize * sparse_tensor->size(), pool));
   auto values = values_buffer->mutable_data();

--- a/cpp/src/arrow/tensor/csf_converter.cc
+++ b/cpp/src/arrow/tensor/csf_converter.cc
@@ -71,8 +71,8 @@ class SparseCSFTensorConverter : private SparseTensorConverterMixin {
     RETURN_NOT_OK(::arrow::internal::CheckSparseIndexMaximumValue(index_value_type_,
                                                                   tensor_.shape()));
 
-    const int index_elsize = GetByteWidth(*index_value_type_);
-    const int value_elsize = GetByteWidth(*tensor_.type());
+    const int index_elsize = index_value_type_->byte_width();
+    const int value_elsize = tensor_.type()->byte_width();
 
     const int64_t ndim = tensor_.ndim();
     // Axis order as ascending order of dimension size is a good heuristic but is not
@@ -203,11 +203,11 @@ class TensorBuilderFromSparseCSFTensor : private SparseTensorConverterMixin {
         ndim_(sparse_tensor->ndim()),
         tensor_size_(sparse_tensor->size()),
         value_type_(checked_cast<const FixedWidthType&>(*sparse_tensor->type())),
-        value_elsize_(GetByteWidth(value_type_)),
+        value_elsize_(value_type_.byte_width()),
         raw_data_(sparse_tensor->raw_data()) {}
 
   int ElementSize(const std::shared_ptr<Tensor>& tensor) const {
-    return GetByteWidth(*tensor->type());
+    return tensor->type()->byte_width();
   }
 
   Result<std::shared_ptr<Tensor>> Build() {

--- a/cpp/src/arrow/tensor/csx_converter.cc
+++ b/cpp/src/arrow/tensor/csx_converter.cc
@@ -52,8 +52,8 @@ class SparseCSXMatrixConverter : private SparseTensorConverterMixin {
     RETURN_NOT_OK(::arrow::internal::CheckSparseIndexMaximumValue(index_value_type_,
                                                                   tensor_.shape()));
 
-    const int index_elsize = GetByteWidth(*index_value_type_);
-    const int value_elsize = GetByteWidth(*tensor_.type());
+    const int index_elsize = index_value_type_->byte_width();
+    const int value_elsize = tensor_.type()->byte_width();
 
     const int64_t ndim = tensor_.ndim();
     if (ndim > 2) {
@@ -166,11 +166,11 @@ Result<std::shared_ptr<Tensor>> MakeTensorFromSparseCSXMatrix(
   const auto* indptr_data = indptr->raw_data();
   const auto* indices_data = indices->raw_data();
 
-  const int indptr_elsize = GetByteWidth(*indptr->type());
-  const int indices_elsize = GetByteWidth(*indices->type());
+  const int indptr_elsize = indptr->type()->byte_width();
+  const int indices_elsize = indices->type()->byte_width();
 
   const auto& fw_value_type = checked_cast<const FixedWidthType&>(*value_type);
-  const int value_elsize = GetByteWidth(fw_value_type);
+  const int value_elsize = fw_value_type.byte_width();
   ARROW_ASSIGN_OR_RAISE(auto values_buffer,
                         AllocateBuffer(value_elsize * tensor_size, pool));
   auto values = values_buffer->mutable_data();

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -183,11 +183,6 @@ std::string ToString(TimeUnit::type unit) {
   }
 }
 
-int GetByteWidth(const DataType& type) {
-  const auto& fw_type = checked_cast<const FixedWidthType&>(type);
-  return fw_type.bit_width() / CHAR_BIT;
-}
-
 }  // namespace internal
 
 namespace {

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -178,7 +178,7 @@ class ARROW_EXPORT DataType : public std::enable_shared_from_this<DataType>,
   /// \brief Returns the type's fixed byte width, if any. Returns -1
   /// for non-fixed-width types, and should only be used for
   /// subclasses of FixedWidthType
-  virtual int32_t byte_width() const {
+  int32_t byte_width() const {
     int32_t num_bits = this->bit_width();
     return num_bits > 0 ? num_bits / 8 : -1;
   }
@@ -718,7 +718,6 @@ class ARROW_EXPORT FixedSizeBinaryType : public FixedWidthType, public Parametri
         {DataTypeLayout::Bitmap(), DataTypeLayout::FixedWidth(byte_width())});
   }
 
-  int32_t byte_width() const override { return byte_width_; }
   int bit_width() const override;
 
   // Validating constructor
@@ -2059,9 +2058,6 @@ std::string ToTypeName(Type::type id);
 
 ARROW_EXPORT
 std::string ToString(TimeUnit::type unit);
-
-ARROW_EXPORT
-int GetByteWidth(const DataType& type);
 
 }  // namespace internal
 

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -178,7 +178,7 @@ class ARROW_EXPORT DataType : public std::enable_shared_from_this<DataType>,
   /// \brief Returns the type's fixed byte width, if any. Returns -1
   /// for non-fixed-width types, and should only be used for
   /// subclasses of FixedWidthType
-  int32_t byte_width() const {
+  virtual int32_t byte_width() const {
     int32_t num_bits = this->bit_width();
     return num_bits > 0 ? num_bits / 8 : -1;
   }
@@ -717,6 +717,8 @@ class ARROW_EXPORT FixedSizeBinaryType : public FixedWidthType, public Parametri
     return DataTypeLayout(
         {DataTypeLayout::Bitmap(), DataTypeLayout::FixedWidth(byte_width())});
   }
+
+  int byte_width() const override { return byte_width_; }
 
   int bit_width() const override;
 

--- a/cpp/src/arrow/util/bitmap_ops.cc
+++ b/cpp/src/arrow/util/bitmap_ops.cc
@@ -25,6 +25,7 @@
 #include "arrow/buffer.h"
 #include "arrow/result.h"
 #include "arrow/util/align_util.h"
+#include "arrow/util/bit_block_counter.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_reader.h"
 #include "arrow/util/bitmap_writer.h"

--- a/cpp/src/arrow/util/bitmap_ops.cc
+++ b/cpp/src/arrow/util/bitmap_ops.cc
@@ -87,8 +87,8 @@ int64_t CountSetBits(const uint8_t* data, int64_t bit_offset, int64_t length) {
 int64_t CountAndSetBits(const uint8_t* left_bitmap, int64_t left_offset,
                         const uint8_t* right_bitmap, int64_t right_offset,
                         int64_t length) {
-  BinaryBitBlockCounter bit_counter(left_bitmap, left_offset, right_bitmap,
-                                    right_offset, length);
+  BinaryBitBlockCounter bit_counter(left_bitmap, left_offset, right_bitmap, right_offset,
+                                    length);
   int64_t count = 0;
   while (true) {
     BitBlockCount block = bit_counter.NextAndWord();

--- a/cpp/src/arrow/util/bitmap_ops.cc
+++ b/cpp/src/arrow/util/bitmap_ops.cc
@@ -84,6 +84,22 @@ int64_t CountSetBits(const uint8_t* data, int64_t bit_offset, int64_t length) {
   return count;
 }
 
+int64_t CountAndSetBits(const uint8_t* left_bitmap, int64_t left_offset,
+                        const uint8_t* right_bitmap, int64_t right_offset,
+                        int64_t length) {
+  BinaryBitBlockCounter bit_counter(left_bitmap, left_offset, right_bitmap,
+                                    right_offset, length);
+  int64_t count = 0;
+  while (true) {
+    BitBlockCount block = bit_counter.NextAndWord();
+    if (block.length == 0) {
+      break;
+    }
+    count += block.popcount;
+  }
+  return count;
+}
+
 enum class TransferMode : bool { Copy, Invert };
 
 // Reverse all bits from entire byte(uint8)

--- a/cpp/src/arrow/util/bitmap_ops.h
+++ b/cpp/src/arrow/util/bitmap_ops.h
@@ -121,12 +121,14 @@ int64_t CountSetBits(const uint8_t* data, int64_t bit_offset, int64_t length);
 /// \param[in] left_bitmap a packed LSB-ordered bitmap as a byte array
 /// \param[in] left_offset a bitwise offset into the left bitmap
 /// \param[in] right_bitmap a packed LSB-ordered bitmap as a byte array
-/// \param[in] ight_offset a bitwise offset into the right bitmap
+/// \param[in] right_offset a bitwise offset into the right bitmap
 /// \param[in] length the length of the bitmaps (must be the same)
 ///
 /// \return The number of set (1) bits in the "and" of the two bitmaps
 ARROW_EXPORT
-int64_t CountAndSetBits(const uint8_t* data, int64_t bit_offset, int64_t length);
+int64_t CountAndSetBits(const uint8_t* left_bitmap, int64_t left_offset,
+                        const uint8_t* right_bitmap, int64_t right_offset,
+                        int64_t length);
 
 ARROW_EXPORT
 bool BitmapEquals(const uint8_t* left, int64_t left_offset, const uint8_t* right,

--- a/cpp/src/arrow/util/bitmap_ops.h
+++ b/cpp/src/arrow/util/bitmap_ops.h
@@ -116,6 +116,18 @@ Result<std::shared_ptr<Buffer>> ReverseBitmap(MemoryPool* pool, const uint8_t* b
 ARROW_EXPORT
 int64_t CountSetBits(const uint8_t* data, int64_t bit_offset, int64_t length);
 
+/// Compute the number of 1's in the result of an "and" (&) of two bitmaps
+///
+/// \param[in] left_bitmap a packed LSB-ordered bitmap as a byte array
+/// \param[in] left_offset a bitwise offset into the left bitmap
+/// \param[in] right_bitmap a packed LSB-ordered bitmap as a byte array
+/// \param[in] ight_offset a bitwise offset into the right bitmap
+/// \param[in] length the length of the bitmaps (must be the same)
+///
+/// \return The number of set (1) bits in the "and" of the two bitmaps
+ARROW_EXPORT
+int64_t CountAndSetBits(const uint8_t* data, int64_t bit_offset, int64_t length);
+
 ARROW_EXPORT
 bool BitmapEquals(const uint8_t* left, int64_t left_offset, const uint8_t* right,
                   int64_t right_offset, int64_t length);

--- a/cpp/src/arrow/util/bitmap_reader.h
+++ b/cpp/src/arrow/util/bitmap_reader.h
@@ -260,8 +260,8 @@ struct OptionalBitIndexer {
   const uint8_t* bitmap;
   const int64_t offset;
 
-  explicit OptionalBitIndexer(const std::shared_ptr<Buffer>& buffer, int64_t offset = 0)
-      : bitmap(buffer == NULLPTR ? NULLPTR : buffer->data()), offset(offset) {}
+  explicit OptionalBitIndexer(const uint8_t* buffer = NULLPTR, int64_t offset = 0)
+      : bitmap(buffer), offset(offset) {}
 
   bool operator[](int64_t i) const {
     return bitmap == NULLPTR || bit_util::GetBit(bitmap, offset + i);

--- a/r/tests/testthat/test-compute-vector.R
+++ b/r/tests/testthat/test-compute-vector.R
@@ -116,7 +116,7 @@ test_that("call_function validation", {
       Array$create(c(TRUE, FALSE, TRUE)),
       options = list(keep_na = TRUE)
     ),
-    "Array arguments must all be the same length"
+    "arguments must all be the same length"
   )
   expect_error(
     call_function("filter",


### PR DESCRIPTION
This is mostly mechanical refactoring. Since many VectorKernels support being passed in a ChunkedArray, I separated the `ExecSpan` code path (which does not support chunked arrays) from a separate `VectorKernel::exec_chunked` function which continues to use the `const ExecBatch&` input format. 

Aggregate (scalar and hash) kernels will have to get refactored in a follow up PR. I was going to try to pack that into this branch but it got to be a little bit too much. I would like to work on ARROW-16757 next anyway which will help a lot with cleaning up a lot of accumulated cruft

I also removed the "scalar" input mode of "cumulative_sum" because the result was ill-defined per a separate discussion.