### PR TITLE
ARROW-16869: [CI][C++][Homebrew] Build Apache Arrow with C++17

### DIFF
--- a/dev/tasks/homebrew-formulae/apache-arrow.rb
+++ b/dev/tasks/homebrew-formulae/apache-arrow.rb
@@ -89,6 +89,7 @@ class ApacheArrow < Formula
       -DARROW_WITH_UTF8PROC=ON
       -DARROW_WITH_ZLIB=ON
       -DARROW_WITH_ZSTD=ON
+      -DCMAKE_CXX_STANDARD=17
       -DCMAKE_FIND_PACKAGE_PREFER_CONFIG=TRUE
       -DPython3_EXECUTABLE=#{Formula["python@3.9"].bin/"python3"}
     ]


### PR DESCRIPTION
The `homebrew-r-brew` nightly job has been failing since the ARROW_GCS flag was turned on in [ARROW-14892](https://issues.apache.org/jira/browse/ARROW-14892). The failure is an undefined absl symbol

```
** testing if installed package can be loaded from temporary location
Error: Error: package or namespace load failed for ‘arrow’ in dyn.load(file, DLLpath = DLLpath, ...):
 unable to load shared object '/Users/runner/work/crossbow/crossbow/arrow/r/check/arrow.Rcheck/00LOCK-arrow/00new/arrow/libs/arrow.so':
  dlopen(/Users/runner/work/crossbow/crossbow/arrow/r/check/arrow.Rcheck/00LOCK-arrow/00new/arrow/libs/arrow.so, 6): Symbol not found: __ZN4absl12lts_2021110210FormatTimeENS0_11string_viewENS0_4TimeENS0_8TimeZoneE
  Referenced from: /usr/local/opt/apache-arrow/lib/libarrow.900.dylib
  Expected in: flat namespace
 in /usr/local/opt/apache-arrow/lib/libarrow.900.dylib
```

We need to build Apache Arrow with C++17 because system Abseil installed by Homebrew uses C++17 and we use
Abseil features such as `absl::FormatTime()` in `gcsfs_internal.cc`.
