### PR TITLE
ARROW-16616: [Python] Add lazy Dataset.filter() method

### DIFF
--- a/cpp/src/arrow/compute/exec/options.cc
+++ b/cpp/src/arrow/compute/exec/options.cc
@@ -62,5 +62,17 @@ Result<std::shared_ptr<SourceNodeOptions>> SourceNodeOptions::FromTable(
   return std::make_shared<SourceNodeOptions>(table.schema(), batch_gen);
 }
 
+Result<std::shared_ptr<SourceNodeOptions>> SourceNodeOptions::FromRecordBatchReader(
+    std::shared_ptr<RecordBatchReader> reader, std::shared_ptr<Schema> schema,
+    arrow::internal::Executor* exc) {
+  if (exc == nullptr) return Status::TypeError("No executor provided.");
+
+  // Map the RecordBatchReader to a SourceNode
+  ARROW_ASSIGN_OR_RAISE(auto batch_gen, MakeReaderGenerator(std::move(reader), exc));
+
+  return std::shared_ptr<SourceNodeOptions>(
+      new SourceNodeOptions(schema, batch_gen));
+}
+
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/exec/options.cc
+++ b/cpp/src/arrow/compute/exec/options.cc
@@ -51,24 +51,24 @@ std::string ToString(JoinType t) {
 }
 
 Result<std::shared_ptr<SourceNodeOptions>> SourceNodeOptions::FromTable(
-    const Table& table, arrow::internal::Executor* exc) {
+    const Table& table, arrow::internal::Executor* executor) {
   std::shared_ptr<RecordBatchReader> reader = std::make_shared<TableBatchReader>(table);
 
-  if (exc == nullptr) return Status::TypeError("No executor provided.");
+  if (executor == nullptr) return Status::TypeError("No executor provided.");
 
   // Map the RecordBatchReader to a SourceNode
-  ARROW_ASSIGN_OR_RAISE(auto batch_gen, MakeReaderGenerator(std::move(reader), exc));
+  ARROW_ASSIGN_OR_RAISE(auto batch_gen, MakeReaderGenerator(std::move(reader), executor));
 
   return std::make_shared<SourceNodeOptions>(table.schema(), batch_gen);
 }
 
 Result<std::shared_ptr<SourceNodeOptions>> SourceNodeOptions::FromRecordBatchReader(
     std::shared_ptr<RecordBatchReader> reader, std::shared_ptr<Schema> schema,
-    arrow::internal::Executor* exc) {
-  if (exc == nullptr) return Status::TypeError("No executor provided.");
+    arrow::internal::Executor* executor) {
+  if (executor == nullptr) return Status::TypeError("No executor provided.");
 
   // Map the RecordBatchReader to a SourceNode
-  ARROW_ASSIGN_OR_RAISE(auto batch_gen, MakeReaderGenerator(std::move(reader), exc));
+  ARROW_ASSIGN_OR_RAISE(auto batch_gen, MakeReaderGenerator(std::move(reader), executor));
 
   return std::shared_ptr<SourceNodeOptions>(new SourceNodeOptions(schema, batch_gen));
 }

--- a/cpp/src/arrow/compute/exec/options.cc
+++ b/cpp/src/arrow/compute/exec/options.cc
@@ -70,8 +70,7 @@ Result<std::shared_ptr<SourceNodeOptions>> SourceNodeOptions::FromRecordBatchRea
   // Map the RecordBatchReader to a SourceNode
   ARROW_ASSIGN_OR_RAISE(auto batch_gen, MakeReaderGenerator(std::move(reader), executor));
 
-  return std::shared_ptr<SourceNodeOptions>(
-      new SourceNodeOptions(std::move(schema), batch_gen));
+  return std::make_shared<SourceNodeOptions>(std::move(schema), std::move(batch_gen));
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/exec/options.cc
+++ b/cpp/src/arrow/compute/exec/options.cc
@@ -70,7 +70,8 @@ Result<std::shared_ptr<SourceNodeOptions>> SourceNodeOptions::FromRecordBatchRea
   // Map the RecordBatchReader to a SourceNode
   ARROW_ASSIGN_OR_RAISE(auto batch_gen, MakeReaderGenerator(std::move(reader), executor));
 
-  return std::shared_ptr<SourceNodeOptions>(new SourceNodeOptions(schema, batch_gen));
+  return std::shared_ptr<SourceNodeOptions>(
+      new SourceNodeOptions(std::move(schema), batch_gen));
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/exec/options.cc
+++ b/cpp/src/arrow/compute/exec/options.cc
@@ -70,8 +70,7 @@ Result<std::shared_ptr<SourceNodeOptions>> SourceNodeOptions::FromRecordBatchRea
   // Map the RecordBatchReader to a SourceNode
   ARROW_ASSIGN_OR_RAISE(auto batch_gen, MakeReaderGenerator(std::move(reader), exc));
 
-  return std::shared_ptr<SourceNodeOptions>(
-      new SourceNodeOptions(schema, batch_gen));
+  return std::shared_ptr<SourceNodeOptions>(new SourceNodeOptions(schema, batch_gen));
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -67,7 +67,7 @@ class ARROW_EXPORT SourceNodeOptions : public ExecNodeOptions {
 
   static Result<std::shared_ptr<SourceNodeOptions>> FromRecordBatchReader(
       std::shared_ptr<RecordBatchReader> reader, std::shared_ptr<Schema> schema,
-      arrow::internal::Executor* exc);
+      arrow::internal::Executor*);
 
   std::shared_ptr<Schema> output_schema;
   std::function<Future<std::optional<ExecBatch>>()> generator;

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -65,6 +65,10 @@ class ARROW_EXPORT SourceNodeOptions : public ExecNodeOptions {
   static Result<std::shared_ptr<SourceNodeOptions>> FromTable(const Table& table,
                                                               arrow::internal::Executor*);
 
+  static Result<std::shared_ptr<SourceNodeOptions>> FromRecordBatchReader(
+    std::shared_ptr<RecordBatchReader> reader, std::shared_ptr<Schema> schema,
+    arrow::internal::Executor* exc);
+
   std::shared_ptr<Schema> output_schema;
   std::function<Future<std::optional<ExecBatch>>()> generator;
 };

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -66,8 +66,8 @@ class ARROW_EXPORT SourceNodeOptions : public ExecNodeOptions {
                                                               arrow::internal::Executor*);
 
   static Result<std::shared_ptr<SourceNodeOptions>> FromRecordBatchReader(
-    std::shared_ptr<RecordBatchReader> reader, std::shared_ptr<Schema> schema,
-    arrow::internal::Executor* exc);
+      std::shared_ptr<RecordBatchReader> reader, std::shared_ptr<Schema> schema,
+      arrow::internal::Executor* exc);
 
   std::shared_ptr<Schema> output_schema;
   std::function<Future<std::optional<ExecBatch>>()> generator;

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -927,12 +927,17 @@ Status ScannerBuilder::Backpressure(compute::BackpressureOptions backpressure) {
   return Status::OK();
 }
 
-Result<std::shared_ptr<Scanner>> ScannerBuilder::Finish() {
+Result<std::shared_ptr<ScanOptions>> ScannerBuilder::GetScanOptions() {
   if (!scan_options_->projection.IsBound()) {
     RETURN_NOT_OK(Project(scan_options_->dataset_schema->field_names()));
   }
 
-  return std::make_shared<AsyncScanner>(dataset_, scan_options_);
+  return scan_options_;
+}
+
+Result<std::shared_ptr<Scanner>> ScannerBuilder::Finish() {
+  ARROW_ASSIGN_OR_RAISE(auto scan_options, GetScanOptions());
+  return std::make_shared<AsyncScanner>(dataset_, scan_options);
 }
 
 namespace {

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -520,6 +520,9 @@ class ARROW_DS_EXPORT ScannerBuilder {
   /// \brief Override default backpressure configuration
   Status Backpressure(compute::BackpressureOptions backpressure);
 
+  /// \brief Return the current scan options for the builder.
+  Result<std::shared_ptr<ScanOptions>> GetScanOptions();
+
   /// \brief Return the constructed now-immutable Scanner object
   Result<std::shared_ptr<Scanner>> Finish();
 

--- a/docs/source/python/api/dataset.rst
+++ b/docs/source/python/api/dataset.rst
@@ -60,6 +60,7 @@ Classes
    HivePartitioning
    FilenamePartitioning
    Dataset
+   FilteredDataset
    FileSystemDataset
    FileSystemFactoryOptions
    FileSystemDatasetFactory

--- a/docs/source/python/api/dataset.rst
+++ b/docs/source/python/api/dataset.rst
@@ -60,7 +60,6 @@ Classes
    HivePartitioning
    FilenamePartitioning
    Dataset
-   FilteredDataset
    FileSystemDataset
    FileSystemFactoryOptions
    FileSystemDatasetFactory

--- a/docs/source/python/compute.rst
+++ b/docs/source/python/compute.rst
@@ -368,8 +368,19 @@ our ``even_filter`` with a ``pc.field("nums") > 5`` filter:
    nums: [[6,8,10]]
    chars: [["f","h","l"]]
 
-:class:`.Dataset` currently can be filtered using :meth:`.Dataset.to_table` method
-passing a ``filter`` argument. See :ref:`py-filter-dataset` in Dataset documentation.
+:class:`.Dataset` can be filtered with :meth:`.Dataset.filter` method too.
+The method will return an instance of `.FilteredDataset` which will lazily
+apply the filter as soon as actual data of the dataset is accessed:
+
+   >>> dataset = ds.dataset(table)
+   >>> filtered = dataset.filter(pc.field("nums") < 5).filter(pc.field("nums") > 2)
+   >>> filtered.to_table()
+   pyarrow.Table
+   nums: int64
+   chars: string
+   ----
+   nums: [[3,4]]
+   chars: [["c","d"]]
 
 
 User-Defined Functions

--- a/docs/source/python/compute.rst
+++ b/docs/source/python/compute.rst
@@ -368,7 +368,7 @@ our ``even_filter`` with a ``pc.field("nums") > 5`` filter:
    nums: [[6,8,10]]
    chars: [["f","h","l"]]
 
-:class:`.Dataset` can be filtered with :meth:`.Dataset.filter` method too.
+:class:`.Dataset` can similarly be filtered with the :meth:`.Dataset.filter` method.
 The method will return an instance of :class:`.FilteredDataset` which will lazily
 apply the filter as soon as actual data of the dataset is accessed:
 

--- a/docs/source/python/compute.rst
+++ b/docs/source/python/compute.rst
@@ -369,7 +369,7 @@ our ``even_filter`` with a ``pc.field("nums") > 5`` filter:
    chars: [["f","h","l"]]
 
 :class:`.Dataset` can be filtered with :meth:`.Dataset.filter` method too.
-The method will return an instance of `.FilteredDataset` which will lazily
+The method will return an instance of :class:`.FilteredDataset` which will lazily
 apply the filter as soon as actual data of the dataset is accessed:
 
    >>> dataset = ds.dataset(table)

--- a/docs/source/python/compute.rst
+++ b/docs/source/python/compute.rst
@@ -369,7 +369,7 @@ our ``even_filter`` with a ``pc.field("nums") > 5`` filter:
    chars: [["f","h","l"]]
 
 :class:`.Dataset` can similarly be filtered with the :meth:`.Dataset.filter` method.
-The method will return an instance of :class:`.FilteredDataset` which will lazily
+The method will return an instance of :class:`.Dataset` which will lazily
 apply the filter as soon as actual data of the dataset is accessed:
 
    >>> dataset = ds.dataset(table)

--- a/python/pyarrow/_dataset.pxd
+++ b/python/pyarrow/_dataset.pxd
@@ -47,6 +47,7 @@ cdef class Dataset(_Weakrefable):
     cdef:
         shared_ptr[CDataset] wrapped
         CDataset* dataset
+        public dict _scanner_options
 
     cdef void init(self, const shared_ptr[CDataset]& sp)
 

--- a/python/pyarrow/_dataset.pxd
+++ b/python/pyarrow/_dataset.pxd
@@ -47,6 +47,7 @@ cdef class Dataset(_Weakrefable):
     cdef:
         shared_ptr[CDataset] wrapped
         CDataset* dataset
+        public dict _scan_options
 
     cdef void init(self, const shared_ptr[CDataset]& sp)
 
@@ -54,12 +55,6 @@ cdef class Dataset(_Weakrefable):
     cdef wrap(const shared_ptr[CDataset]& sp)
 
     cdef shared_ptr[CDataset] unwrap(self) nogil
-
-
-cdef class FilteredDataset(Dataset):
-
-    cdef:
-        public dict _scan_options
 
 
 cdef class Scanner(_Weakrefable):

--- a/python/pyarrow/_dataset.pxd
+++ b/python/pyarrow/_dataset.pxd
@@ -47,7 +47,6 @@ cdef class Dataset(_Weakrefable):
     cdef:
         shared_ptr[CDataset] wrapped
         CDataset* dataset
-        public dict _scanner_options
 
     cdef void init(self, const shared_ptr[CDataset]& sp)
 
@@ -55,6 +54,27 @@ cdef class Dataset(_Weakrefable):
     cdef wrap(const shared_ptr[CDataset]& sp)
 
     cdef shared_ptr[CDataset] unwrap(self) nogil
+
+
+cdef class FilteredDataset(Dataset):
+
+    cdef:
+        public object _filter
+
+    cdef Scanner _make_scanner(self, options)
+
+
+cdef class Scanner(_Weakrefable):
+    cdef:
+        shared_ptr[CScanner] wrapped
+        CScanner* scanner
+
+    cdef void init(self, const shared_ptr[CScanner]& sp)
+
+    @staticmethod
+    cdef wrap(const shared_ptr[CScanner]& sp)
+
+    cdef shared_ptr[CScanner] unwrap(self)
 
 
 cdef class FragmentScanOptions(_Weakrefable):

--- a/python/pyarrow/_dataset.pxd
+++ b/python/pyarrow/_dataset.pxd
@@ -59,9 +59,7 @@ cdef class Dataset(_Weakrefable):
 cdef class FilteredDataset(Dataset):
 
     cdef:
-        public object _filter
-
-    cdef Scanner _make_scanner(self, options)
+        public dict _scan_options
 
 
 cdef class Scanner(_Weakrefable):
@@ -75,6 +73,9 @@ cdef class Scanner(_Weakrefable):
     cdef wrap(const shared_ptr[CScanner]& sp)
 
     cdef shared_ptr[CScanner] unwrap(self)
+
+    @staticmethod
+    cdef shared_ptr[CScanOptions] _make_scan_options(Dataset dataset, dict py_scanoptions) except *
 
 
 cdef class FragmentScanOptions(_Weakrefable):

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -504,8 +504,8 @@ cdef class FilteredDataset(Dataset):
         if requested_filter is not None and current_filter is not None:
             new_options["filter"] = current_filter & requested_filter
         elif current_filter is not None:
-            new_options["filter"] = current_filter 
-        
+            new_options["filter"] = current_filter
+
         return new_options
 
 cdef class InMemoryDataset(Dataset):
@@ -2456,12 +2456,15 @@ cdef class Scanner(_Weakrefable):
 
         # Need to explicitly expand the arguments as Cython doesn't support
         # keyword expansion in cdef functions.
-        _populate_builder(builder, 
-                          columns=py_scanoptions.get("columns"), 
+        _populate_builder(builder,
+                          columns=py_scanoptions.get("columns"),
                           filter=py_scanoptions.get("filter"),
-                          batch_size=py_scanoptions.get("batch_size", _DEFAULT_BATCH_SIZE),
-                          batch_readahead=py_scanoptions.get("batch_readahead", _DEFAULT_BATCH_READAHEAD),
-                          fragment_readahead=py_scanoptions.get("fragment_readahead", _DEFAULT_FRAGMENT_READAHEAD),
+                          batch_size=py_scanoptions.get(
+                              "batch_size", _DEFAULT_BATCH_SIZE),
+                          batch_readahead=py_scanoptions.get(
+                              "batch_readahead", _DEFAULT_BATCH_READAHEAD),
+                          fragment_readahead=py_scanoptions.get(
+                              "fragment_readahead", _DEFAULT_FRAGMENT_READAHEAD),
                           use_threads=py_scanoptions.get("use_threads", True),
                           memory_pool=py_scanoptions.get("memory_pool"),
                           fragment_scan_options=py_scanoptions.get("fragment_scan_options"))
@@ -2538,10 +2541,10 @@ cdef class Scanner(_Weakrefable):
         """
         cdef:
             shared_ptr[CScanOptions] options = Scanner._make_scan_options(dataset, dict(columns=columns, filter=filter,
-                          batch_size=batch_size, batch_readahead=batch_readahead,
-                          fragment_readahead=fragment_readahead, use_threads=use_threads,
-                          memory_pool=memory_pool,
-                          fragment_scan_options=fragment_scan_options))
+                                                                                        batch_size=batch_size, batch_readahead=batch_readahead,
+                                                                                        fragment_readahead=fragment_readahead, use_threads=use_threads,
+                                                                                        memory_pool=memory_pool,
+                                                                                        fragment_scan_options=fragment_scan_options))
             shared_ptr[CScannerBuilder] builder = make_shared[CScannerBuilder](dataset.unwrap(), options)
             shared_ptr[CScanner] scanner
 

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -2472,10 +2472,9 @@ cdef class Scanner(_Weakrefable):
         return GetResultValue(deref(builder).GetScanOptions())
 
     @staticmethod
-    def from_dataset(Dataset dataset not None,
-                     bint use_threads=True, object use_async=None,
-                     MemoryPool memory_pool=None,
-                     object columns=None, Expression filter=None,
+    def from_dataset(Dataset dataset not None, *,
+                     object columns=None,
+                     Expression filter=None,
                      int batch_size=_DEFAULT_BATCH_SIZE,
                      int batch_readahead=_DEFAULT_BATCH_READAHEAD,
                      int fragment_readahead=_DEFAULT_FRAGMENT_READAHEAD,

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -386,6 +386,14 @@ cdef class Dataset(_Weakrefable):
         return pyarrow_wrap_schema(self.dataset.schema())
 
     def filter(self, expression):
+        """
+        Apply a row filter to the dataset.
+
+        Parameters
+        ----------
+        expression : Expression
+            The filter that should be applied to the dataset.
+        """
         return FilteredDataset(self, expression)
 
     def join(self, right_dataset, keys, right_keys=None, join_type="left outer",

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -490,6 +490,7 @@ cdef class Dataset(_Weakrefable):
                                               use_threads=use_threads, coalesce_keys=coalesce_keys,
                                               output_type=InMemoryDataset)
 
+
 cdef class InMemoryDataset(Dataset):
     """
     A Dataset wrapping in-memory data.

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -447,6 +447,7 @@ cdef class FilteredDataset(Dataset):
     expression : Expression
         The filter that should be applied to the dataset.
     """
+
     def __init__(self, dataset, expression):
         self.init(<shared_ptr[CDataset]>(<Dataset>dataset).wrapped)
         self._filter = expression
@@ -467,7 +468,7 @@ cdef class FilteredDataset(Dataset):
         filtered_dataset.init(self.wrapped)
         filtered_dataset._filter = new_filter
         return filtered_dataset
-        
+
     cdef Scanner _make_scanner(self, options):
         scanner_options = dict(options, filter=self._filter)
         return Scanner.from_dataset(self, **scanner_options)

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -2450,8 +2450,10 @@ cdef class Scanner(_Weakrefable):
             columns=py_scanoptions.get("columns"),
             filter=py_scanoptions.get("filter"),
             batch_size=py_scanoptions.get("batch_size", _DEFAULT_BATCH_SIZE),
-            batch_readahead=py_scanoptions.get("batch_readahead", _DEFAULT_BATCH_READAHEAD),
-            fragment_readahead=py_scanoptions.get("fragment_readahead", _DEFAULT_FRAGMENT_READAHEAD),
+            batch_readahead=py_scanoptions.get(
+                "batch_readahead", _DEFAULT_BATCH_READAHEAD),
+            fragment_readahead=py_scanoptions.get(
+                "fragment_readahead", _DEFAULT_FRAGMENT_READAHEAD),
             use_threads=py_scanoptions.get("use_threads", True),
             memory_pool=py_scanoptions.get("memory_pool"),
             fragment_scan_options=py_scanoptions.get("fragment_scan_options"))

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -239,7 +239,7 @@ cdef class Dataset(_Weakrefable):
         which exposes further operations (e.g. loading all data as a
         table, counting rows).
 
-        See the `Scanner.from_dataset` method for further information.
+        See the :meth:`Scanner.from_dataset` method for further information.
 
         Parameters
         ----------
@@ -471,7 +471,14 @@ cdef class FilteredDataset(Dataset):
     def filter(self, expression):
         """Apply an additional row filter to the filtered dataset.
 
-        See :meth:`.Dataset.filter` for documentation.
+        Parameters
+        ----------
+        expression : Expression
+            The filter that should be applied to the dataset.
+
+        Returns
+        -------
+        FilteredDataset
         """
         cdef:
             FilteredDataset filtered_dataset
@@ -495,8 +502,16 @@ cdef class FilteredDataset(Dataset):
     def scanner(self, **kwargs):
         """Build a scan operation against the dataset.
 
-        See :meth:`.Dataset.scanner` for list of supported
-        arguments.
+        See :meth:`.Dataset.scanner` for additional information
+
+        Parameters
+        ----------
+        **kwargs : dict, optional
+            Arguments for :meth:`Scanner.from_dataset`.
+
+        Returns
+        -------
+        scanner : Scanner
         """
         return self._make_scanner(kwargs)
 

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -489,7 +489,7 @@ cdef class FilteredDataset(Dataset):
             new_filter = expression
         filtered_dataset = self.__class__.__new__(self.__class__)
         filtered_dataset.init(self.wrapped)
-        filtered_dataset._filter = new_filter
+        filtered_dataset._scan_options = dict(filter=new_filter)
         return filtered_dataset
 
     cdef Scanner _make_scanner(self, options):

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -220,7 +220,7 @@ cdef class Dataset(_Weakrefable):
         """
         if self._scan_options.get("filter") is not None:
             # Accessing fragments of a filtered dataset is not supported.
-            # It would be unclear if you wanted to filter the fragments 
+            # It would be unclear if you wanted to filter the fragments
             # or the rows in those fragments.
             raise ValueError(
                 "Retrieving fragments of a filtered or projected "
@@ -416,7 +416,7 @@ cdef class Dataset(_Weakrefable):
         """The common schema of the full Dataset"""
         return pyarrow_wrap_schema(self.dataset.schema())
 
-    def filter(self, expression):
+    def filter(self, expression not None):
         """
         Apply a row filter to the dataset.
 

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -393,6 +393,10 @@ cdef class Dataset(_Weakrefable):
         ----------
         expression : Expression
             The filter that should be applied to the dataset.
+
+        Returns
+        -------
+        FilteredDataset
         """
         return FilteredDataset(self, expression)
 
@@ -465,6 +469,10 @@ cdef class FilteredDataset(Dataset):
         self._filter = None
 
     def filter(self, expression):
+        """Apply an additional row filter to the filtered dataset.
+
+        See :meth:`.Dataset.filter` for documentation.
+        """
         cdef:
             FilteredDataset filtered_dataset
 
@@ -478,9 +486,18 @@ cdef class FilteredDataset(Dataset):
         return filtered_dataset
 
     cdef Scanner _make_scanner(self, options):
+        if "filter" in options:
+            raise ValueError(
+                "Passing filter in scanner option is not valid for FilteredDataset."
+            )
         return Scanner.from_dataset(self, filter=self._filter, **options)
 
     def scanner(self, **kwargs):
+        """Build a scan operation against the dataset.
+
+        See :meth:`.Dataset.scanner` for list of supported
+        arguments.
+        """
         return self._make_scanner(kwargs)
 
 

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -478,8 +478,7 @@ cdef class FilteredDataset(Dataset):
         return filtered_dataset
 
     cdef Scanner _make_scanner(self, options):
-        scanner_options = dict(options, filter=self._filter)
-        return Scanner.from_dataset(self, **scanner_options)
+        return Scanner.from_dataset(self, filter=self._filter, **options)
 
     def scanner(self, **kwargs):
         return self._make_scanner(kwargs)

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -201,8 +201,14 @@ cdef class Dataset(_Weakrefable):
             The new dataset schema.
         """
         cdef shared_ptr[CDataset] copy = GetResultValue(
-            self.dataset.ReplaceSchema(pyarrow_unwrap_schema(schema)))
-        return Dataset.wrap(move(copy))
+            self.dataset.ReplaceSchema(pyarrow_unwrap_schema(schema))
+        )
+
+        d = Dataset.wrap(move(copy))
+        if self._scan_options:
+            # Preserve scan options if set.
+            d._scan_options = self._scan_options.copy()
+        return d
 
     def get_fragments(self, Expression filter=None):
         """Returns an iterator over the fragments in this dataset.

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -2445,18 +2445,16 @@ cdef class Scanner(_Weakrefable):
 
         # Need to explicitly expand the arguments as Cython doesn't support
         # keyword expansion in cdef functions.
-        _populate_builder(builder,
-                          columns=py_scanoptions.get("columns"),
-                          filter=py_scanoptions.get("filter"),
-                          batch_size=py_scanoptions.get(
-                              "batch_size", _DEFAULT_BATCH_SIZE),
-                          batch_readahead=py_scanoptions.get(
-                              "batch_readahead", _DEFAULT_BATCH_READAHEAD),
-                          fragment_readahead=py_scanoptions.get(
-                              "fragment_readahead", _DEFAULT_FRAGMENT_READAHEAD),
-                          use_threads=py_scanoptions.get("use_threads", True),
-                          memory_pool=py_scanoptions.get("memory_pool"),
-                          fragment_scan_options=py_scanoptions.get("fragment_scan_options"))
+        _populate_builder(
+            builder,
+            columns=py_scanoptions.get("columns"),
+            filter=py_scanoptions.get("filter"),
+            batch_size=py_scanoptions.get("batch_size", _DEFAULT_BATCH_SIZE),
+            batch_readahead=py_scanoptions.get("batch_readahead", _DEFAULT_BATCH_READAHEAD),
+            fragment_readahead=py_scanoptions.get("fragment_readahead", _DEFAULT_FRAGMENT_READAHEAD),
+            use_threads=py_scanoptions.get("use_threads", True),
+            memory_pool=py_scanoptions.get("memory_pool"),
+            fragment_scan_options=py_scanoptions.get("fragment_scan_options"))
 
         return GetResultValue(deref(builder).GetScanOptions())
 
@@ -2528,12 +2526,8 @@ cdef class Scanner(_Weakrefable):
             default pool.
         """
         cdef:
-            shared_ptr[CScanOptions] options = Scanner._make_scan_options(dataset, dict(columns=columns, filter=filter,
-                                                                                        batch_size=batch_size, batch_readahead=batch_readahead,
-                                                                                        fragment_readahead=fragment_readahead, use_threads=use_threads,
-                                                                                        memory_pool=memory_pool,
-                                                                                        fragment_scan_options=fragment_scan_options))
-            shared_ptr[CScannerBuilder] builder = make_shared[CScannerBuilder](dataset.unwrap(), options)
+            shared_ptr[CScanOptions] options
+            shared_ptr[CScannerBuilder] builder
             shared_ptr[CScanner] scanner
 
         if use_async is not None:
@@ -2541,6 +2535,14 @@ cdef class Scanner(_Weakrefable):
                           'effect.  It will be removed in the next release.',
                           FutureWarning)
 
+        options = Scanner._make_scan_options(
+            dataset,
+            dict(columns=columns, filter=filter, batch_size=batch_size,
+                 batch_readahead=batch_readahead,
+                 fragment_readahead=fragment_readahead, use_threads=use_threads,
+                 memory_pool=memory_pool, fragment_scan_options=fragment_scan_options)
+        )
+        builder = make_shared[CScannerBuilder](dataset.unwrap(), options)
         scanner = GetResultValue(builder.get().Finish())
         return Scanner.wrap(scanner)
 

--- a/python/pyarrow/_exec_plan.pyx
+++ b/python/pyarrow/_exec_plan.pyx
@@ -113,7 +113,7 @@ cdef execplan(inputs, output_type, vector[CDeclaration] plan, c_bool use_threads
             current_decl = CDeclaration(tobytes("filter"), no_c_inputs,
                                         static_pointer_cast[CExecNodeOptions, CFilterNodeOptions](
                 make_shared[CFilterNodeOptions](
-                    deref(deref(c_scanopts).scan_options).filter, True)
+                    deref(deref(c_scanopts).scan_options).filter)
             )
             )
             current_decl.inputs.push_back(

--- a/python/pyarrow/_exec_plan.pyx
+++ b/python/pyarrow/_exec_plan.pyx
@@ -27,7 +27,7 @@ from cython.operator cimport dereference as deref, preincrement as inc
 from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport *
 from pyarrow.includes.libarrow_dataset cimport *
-from pyarrow.lib cimport (Table, check_status, pyarrow_unwrap_table, pyarrow_wrap_table, 
+from pyarrow.lib cimport (Table, check_status, pyarrow_unwrap_table, pyarrow_wrap_table,
                           RecordBatchReader)
 from pyarrow.lib import tobytes
 from pyarrow._compute cimport Expression, _true
@@ -108,8 +108,9 @@ cdef execplan(inputs, output_type, vector[CDeclaration] plan, c_bool use_threads
                 GetResultValue(deref(c_dataset_scanner).ToRecordBatchReader())
             )
             c_sourceopts = GetResultValue(
-                CSourceNodeOptions.FromRecordBatchReader(c_recordbatchreader_in, 
-                                                         deref(c_in_dataset).schema(), 
+                CSourceNodeOptions.FromRecordBatchReader(c_recordbatchreader_in,
+                                                         deref(
+                                                             c_in_dataset).schema(),
                                                          c_executor)
             )
             c_input_node_opts = static_pointer_cast[CExecNodeOptions, CSourceNodeOptions](

--- a/python/pyarrow/_exec_plan.pyx
+++ b/python/pyarrow/_exec_plan.pyx
@@ -101,11 +101,9 @@ cdef execplan(inputs, output_type, vector[CDeclaration] plan, c_bool use_threads
         elif isinstance(ipt, FilteredDataset):
             node_factory = "source"
             c_in_dataset = (<Dataset>ipt).unwrap()
-            c_dataset_scanner = <shared_ptr[CScanner]>(
-                (<Scanner>(<FilteredDataset>ipt)._make_scanner({})).unwrap()
-            )
-            c_recordbatchreader_in = <shared_ptr[CRecordBatchReader]>(
-                GetResultValue(deref(c_dataset_scanner).ToRecordBatchReader())
+            c_dataset_scanner = (<FilteredDataset>ipt)._make_scanner({}).unwrap()
+            c_recordbatchreader_in = GetResultValue(
+                deref(c_dataset_scanner).ToRecordBatchReader()
             )
             c_sourceopts = GetResultValue(
                 CSourceNodeOptions.FromRecordBatchReader(c_recordbatchreader_in,

--- a/python/pyarrow/_exec_plan.pyx
+++ b/python/pyarrow/_exec_plan.pyx
@@ -31,7 +31,7 @@ from pyarrow.lib cimport (Table, check_status, pyarrow_unwrap_table, pyarrow_wra
                           RecordBatchReader)
 from pyarrow.lib import tobytes
 from pyarrow._compute cimport Expression, _true
-from pyarrow._dataset cimport Dataset, FilteredDataset, Scanner
+from pyarrow._dataset cimport Dataset, Scanner
 from pyarrow._dataset import InMemoryDataset
 
 Initialize()  # Initialise support for Datasets in ExecPlan

--- a/python/pyarrow/_exec_plan.pyx
+++ b/python/pyarrow/_exec_plan.pyx
@@ -98,8 +98,9 @@ cdef execplan(inputs, output_type, vector[CDeclaration] plan, c_bool use_threads
                 c_in_table)
             c_input_node_opts = static_pointer_cast[CExecNodeOptions, CTableSourceNodeOptions](
                 c_tablesourceopts)
-            
-            current_decl = CDeclaration(tobytes("table_source"), no_c_inputs, c_input_node_opts)
+
+            current_decl = CDeclaration(
+                tobytes("table_source"), no_c_inputs, c_input_node_opts)
         elif isinstance(ipt, Dataset):
             c_in_dataset = (<Dataset>ipt).unwrap()
             c_scanopts = make_shared[CScanNodeOptions](
@@ -109,13 +110,15 @@ cdef execplan(inputs, output_type, vector[CDeclaration] plan, c_bool use_threads
 
             # Filters applied in CScanNodeOptions are "best effort" for the scan node itself,
             # so we always need to inject an additional Filter node to apply them for real.
-            current_decl = CDeclaration(tobytes("filter"), no_c_inputs, 
-                static_pointer_cast[CExecNodeOptions, CFilterNodeOptions](
-                    make_shared[CFilterNodeOptions](deref(deref(c_scanopts).scan_options).filter, True)
-                )
+            current_decl = CDeclaration(tobytes("filter"), no_c_inputs,
+                                        static_pointer_cast[CExecNodeOptions, CFilterNodeOptions](
+                make_shared[CFilterNodeOptions](
+                    deref(deref(c_scanopts).scan_options).filter, True)
+            )
             )
             current_decl.inputs.push_back(
-                CDeclaration.Input(CDeclaration(tobytes("scan"), no_c_inputs, c_input_node_opts))
+                CDeclaration.Input(CDeclaration(
+                    tobytes("scan"), no_c_inputs, c_input_node_opts))
             )
         else:
             raise TypeError("Unsupported type")

--- a/python/pyarrow/_exec_plan.pyx
+++ b/python/pyarrow/_exec_plan.pyx
@@ -110,15 +110,18 @@ cdef execplan(inputs, output_type, vector[CDeclaration] plan, c_bool use_threads
 
             # Filters applied in CScanNodeOptions are "best effort" for the scan node itself,
             # so we always need to inject an additional Filter node to apply them for real.
-            current_decl = CDeclaration(tobytes("filter"), no_c_inputs,
-                                        static_pointer_cast[CExecNodeOptions, CFilterNodeOptions](
-                make_shared[CFilterNodeOptions](
-                    deref(deref(c_scanopts).scan_options).filter)
-            )
+            current_decl = CDeclaration(
+                tobytes("filter"),
+                no_c_inputs,
+                static_pointer_cast[CExecNodeOptions, CFilterNodeOptions](
+                    make_shared[CFilterNodeOptions](
+                        deref(deref(c_scanopts).scan_options).filter
+                    )
+                )
             )
             current_decl.inputs.push_back(
-                CDeclaration.Input(CDeclaration(
-                    tobytes("scan"), no_c_inputs, c_input_node_opts))
+                CDeclaration.Input(
+                    CDeclaration(tobytes("scan"), no_c_inputs, c_input_node_opts))
             )
         else:
             raise TypeError("Unsupported type")

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -472,6 +472,14 @@ def _union_dataset(children, schema=None, **kwargs):
         # unify the children datasets' schemas
         schema = pa.unify_schemas([child.schema for child in children])
 
+    for child in children:
+        if getattr(child, "_scan_options", None):
+            raise ValueError(
+                "Creating an UnionDataset from filtered or projected Datasets "
+                "is currently not supported. Union the unfiltered datasets "
+                "and apply the filtered to the resulting union."
+            )
+
     # create datasets with the requested schema
     children = [child.replace_schema(schema) for child in children]
 

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -477,7 +477,7 @@ def _union_dataset(children, schema=None, **kwargs):
             raise ValueError(
                 "Creating an UnionDataset from filtered or projected Datasets "
                 "is currently not supported. Union the unfiltered datasets "
-                "and apply the filtered to the resulting union."
+                "and apply the filter to the resulting union."
             )
 
     # create datasets with the requested schema

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -24,6 +24,7 @@ from pyarrow._dataset import (  # noqa
     CsvFileFormat,
     CsvFragmentScanOptions,
     Dataset,
+    FilteredDataset,
     DatasetFactory,
     DirectoryPartitioning,
     FeatherFileFormat,

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -24,7 +24,6 @@ from pyarrow._dataset import (  # noqa
     CsvFileFormat,
     CsvFragmentScanOptions,
     Dataset,
-    FilteredDataset,
     DatasetFactory,
     DirectoryPartitioning,
     FeatherFileFormat,

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2545,6 +2545,12 @@ cdef extern from "arrow/compute/exec/options.h" namespace "arrow::compute" nogil
     cdef cppclass CExecNodeOptions "arrow::compute::ExecNodeOptions":
         pass
 
+    cdef cppclass CSourceNodeOptions "arrow::compute::SourceNodeOptions"(CExecNodeOptions):
+        @staticmethod
+        CResult[shared_ptr[CSourceNodeOptions]] FromRecordBatchReader(
+            shared_ptr[CRecordBatchReader] reader, shared_ptr[CSchema] schema,
+            CExecutor* exc)
+
     cdef cppclass CTableSourceNodeOptions "arrow::compute::TableSourceNodeOptions"(CExecNodeOptions):
         CTableSourceNodeOptions(shared_ptr[CTable] table, int64_t max_batch_size)
 

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2546,10 +2546,7 @@ cdef extern from "arrow/compute/exec/options.h" namespace "arrow::compute" nogil
         pass
 
     cdef cppclass CSourceNodeOptions "arrow::compute::SourceNodeOptions"(CExecNodeOptions):
-        @staticmethod
-        CResult[shared_ptr[CSourceNodeOptions]] FromRecordBatchReader(
-            shared_ptr[CRecordBatchReader] reader, shared_ptr[CSchema] schema,
-            CExecutor* exc)
+        pass
 
     cdef cppclass CTableSourceNodeOptions "arrow::compute::TableSourceNodeOptions"(CExecNodeOptions):
         CTableSourceNodeOptions(shared_ptr[CTable] table, int64_t max_batch_size)

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -54,6 +54,7 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         shared_ptr[CSchema] dataset_schema
         shared_ptr[CSchema] projected_schema
         c_bool use_threads
+        CExpression filter
 
     cdef cppclass CScanNodeOptions "arrow::dataset::ScanNodeOptions"(CExecNodeOptions):
         CScanNodeOptions(shared_ptr[CDataset] dataset, shared_ptr[CScanOptions] scan_options)
@@ -126,6 +127,7 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         CStatus FragmentReadahead(int32_t fragment_readahead)
         CStatus FragmentScanOptions(
             shared_ptr[CFragmentScanOptions] fragment_scan_options)
+        CResult[shared_ptr[CScanOptions]] GetScanOptions()
         CResult[shared_ptr[CScanner]] Finish()
         shared_ptr[CSchema] schema() const
 

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -4907,8 +4907,6 @@ def test_dataset_filter(tempdir, dstype):
     # Can't get fragments of a filtered dataset
     with pytest.raises(ValueError):
         result.get_fragments()
-    fragments = list(result.filter(None).get_fragments())
-    assert len(fragments) == 1
 
 
 def test_write_dataset_with_scanner_use_projected_schema(tempdir):

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -4923,6 +4923,56 @@ def test_dataset_filter(tempdir, dstype):
         result.replace_schema(schema_without_colB).to_table()
 
 
+@pytest.mark.dataset
+@pytest.mark.parametrize('dstype', [
+    "fs", "mem"
+])
+def test_union_dataset_filter(tempdir, dstype):
+    t1 = pa.table({
+        "colA": [1, 2, 6, 8],
+        "col2": ["a", "b", "f", "g"]
+    })
+    t2 = pa.table({
+        "colA": [9, 10, 11],
+        "col2": ["h", "i", "l"]
+    })
+    if dstype == "fs":
+        ds.write_dataset(t1, tempdir / "t1", format="ipc")
+        ds1 = ds.dataset(tempdir / "t1", format="ipc")
+        ds.write_dataset(t2, tempdir / "t2", format="ipc")
+        ds2 = ds.dataset(tempdir / "t2", format="ipc")
+    elif dstype == "mem":
+        ds1 = ds.dataset(t1)
+        ds2 = ds.dataset(t2)
+    else:
+        raise NotImplementedError
+
+    filtered_union_ds = ds.dataset((ds1, ds2)).filter(
+        (pc.field("colA") < 3) | (pc.field("colA") == 9)
+    )
+    assert filtered_union_ds.to_table() == pa.table({
+        "colA": [1, 2, 9],
+        "col2": ["a", "b", "h"]
+    })
+
+    joined = filtered_union_ds.join(ds.dataset(pa.table({
+        "colB": [10, 20],
+        "col2": ["a", "b"]
+    })), keys="col2", join_type="left outer")
+    assert joined.to_table().sort_by("colA") == pa.table({
+        "colA": [1, 2, 9],
+        "col2": ["a", "b", "h"],
+        "colB": [10, 20, None]
+    })
+
+    filtered_ds1 = ds1.filter(pc.field("colA") < 3)
+    filtered_ds2 = ds2.filter(pc.field("colA") < 10)
+
+    with pytest.raises(ValueError) as err:
+        ds.dataset((filtered_ds1, filtered_ds2))
+    assert "currently not supported" in str(err.value)
+
+
 def test_write_dataset_with_scanner_use_projected_schema(tempdir):
     """
     Ensure the projected schema is used to validate partitions for scanner

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -4851,8 +4851,8 @@ def test_dataset_join_collisions(tempdir):
 ])
 def test_dataset_filter(tempdir, dstype):
     t1 = pa.table({
-        "colA": [1, 2, 6],
-        "col2": ["a", "b", "f"]
+        "colA": [1, 2, 6, 8],
+        "col2": ["a", "b", "f", "g"]
     })
     if dstype == "fs":
         ds.write_dataset(t1, tempdir / "t1", format="ipc")
@@ -4862,6 +4862,7 @@ def test_dataset_filter(tempdir, dstype):
     else:
         raise NotImplementedError
 
+    # Ensure chained filtering works.
     result = ds1.filter(pc.field("colA") < 3).filter(pc.field("col2") == "a")
     assert result.to_table() == pa.table({
         "colA": [1],
@@ -4875,6 +4876,14 @@ def test_dataset_filter(tempdir, dstype):
         "col2": ["a"]
     })
 
+    # Ensure that further filtering with scanners works too
+    r2 = ds1.filter(pc.field("colA") < 8).filter(pc.field("colA") > 1).scanner(filter=pc.field("colA") != 6)
+    assert r2.to_table() == pa.table({
+        "colA": [2],
+        "col2": ["b"]
+    })
+
+    # Ensure that writing back to disk works.
     ds.write_dataset(result, tempdir / "filtered", format="ipc")
     filtered = ds.dataset(tempdir / "filtered", format="ipc")
     assert filtered.to_table() == pa.table({

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -4870,6 +4870,11 @@ def test_dataset_filter(tempdir, dstype):
 
     assert type(result) == ds.FilteredDataset
 
+    assert result.head(5) == pa.table({
+        "colA": [1],
+        "col2": ["a"]
+    })
+
     ds.write_dataset(result, tempdir / "filtered", format="ipc")
     filtered = ds.dataset(tempdir / "filtered", format="ipc")
     assert filtered.to_table() == pa.table({

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -4854,10 +4854,19 @@ def test_dataset_filter(tempdir):
     ds.write_dataset(t1, tempdir / "t1", format="ipc")
     ds1 = ds.dataset(tempdir / "t1", format="ipc")
 
-    result = ds1.scanner(filter=pc.field("colA") < 3)
+    result = ds1.filter(pc.field("colA") < 3).filter(pc.field("col2") == "a")
     assert result.to_table() == pa.table({
-        "colA": [1, 2],
-        "col2": ["a", "b"]
+        "colA": [1],
+        "col2": ["a"]
+    })
+
+    assert type(result) == ds.FileSystemDataset
+
+    ds.write_dataset(result, tempdir / "filtered", format="ipc")
+    filtered = ds.dataset(tempdir / "filtered", format="ipc")
+    assert filtered.to_table() == pa.table({
+        "colA": [1],
+        "col2": ["a"]
     })
 
 

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -4864,12 +4864,13 @@ def test_dataset_filter(tempdir, dstype):
 
     # Ensure chained filtering works.
     result = ds1.filter(pc.field("colA") < 3).filter(pc.field("col2") == "a")
+    assert type(result) == (ds.FileSystemDataset if dstype ==
+                            "fs" else ds.InMemoryDataset)
+
     assert result.to_table() == pa.table({
         "colA": [1],
         "col2": ["a"]
     })
-
-    assert type(result) == ds.FilteredDataset
 
     assert result.head(5) == pa.table({
         "colA": [1],
@@ -4877,7 +4878,8 @@ def test_dataset_filter(tempdir, dstype):
     })
 
     # Ensure that further filtering with scanners works too
-    r2 = ds1.filter(pc.field("colA") < 8).filter(pc.field("colA") > 1).scanner(filter=pc.field("colA") != 6)
+    r2 = ds1.filter(pc.field("colA") < 8).filter(
+        pc.field("colA") > 1).scanner(filter=pc.field("colA") != 6)
     assert r2.to_table() == pa.table({
         "colA": [2],
         "col2": ["b"]
@@ -4891,6 +4893,7 @@ def test_dataset_filter(tempdir, dstype):
         "col2": ["a"]
     })
 
+    # Ensure that joining to a filtered Dataset works.
     joined = result.join(ds.dataset(pa.table({
         "colB": [10, 20],
         "col2": ["a", "b"]

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -4886,7 +4886,7 @@ def test_dataset_filter(tempdir, dstype):
         "colB": [10, 20],
         "col2": ["a", "b"]
     })), keys="col2", join_type="right outer")
-    assert joined.to_table().combine_chunks() == pa.table({
+    assert joined.to_table().sort_by("colB") == pa.table({
         "colA": [1, None],
         "colB": [10, 20],
         "col2": ["a", "b"]

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -4974,6 +4974,21 @@ def test_union_dataset_filter(tempdir, dstype):
         ds.dataset((filtered_ds1, filtered_ds2))
 
 
+def test_parquet_dataset_filter(tempdir):
+    root_path = tempdir / "test_parquet_dataset_filter"
+    metadata_path, _ = _create_parquet_dataset_simple(root_path)
+    dataset = ds.parquet_dataset(metadata_path)
+
+    result = dataset.to_table()
+    assert result.num_rows == 40
+
+    filtered_ds = dataset.filter(pc.field("f1") < 2)
+    assert filtered_ds.to_table().num_rows == 20
+
+    with pytest.raises(ValueError):
+        filtered_ds.get_fragments()
+
+
 def test_write_dataset_with_scanner_use_projected_schema(tempdir):
     """
     Ensure the projected schema is used to validate partitions for scanner

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -4908,6 +4908,20 @@ def test_dataset_filter(tempdir, dstype):
     with pytest.raises(ValueError):
         result.get_fragments()
 
+    # Ensure replacing schema preserves the filter.
+    schema_without_colB = ds1.schema.remove(1)
+    newschema = ds1.filter(
+        pc.field("colA") < 3
+    ).replace_schema(schema_without_colB)
+    assert newschema.to_table() == pa.table({
+        "colA": [1, 2],
+    })
+    with pytest.raises(pa.ArrowInvalid):
+        # The schema might end up being replaced with
+        # something that makes the filter invalid.
+        # Let's make sure we error nicely.
+        result.replace_schema(schema_without_colB).to_table()
+
 
 def test_write_dataset_with_scanner_use_projected_schema(tempdir):
     """

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -4904,6 +4904,12 @@ def test_dataset_filter(tempdir, dstype):
         "col2": ["a", "b"]
     })
 
+    # Can't get fragments of a filtered dataset
+    with pytest.raises(ValueError):
+        result.get_fragments()
+    fragments = list(result.filter(None).get_fragments())
+    assert len(fragments) == 1
+
 
 def test_write_dataset_with_scanner_use_projected_schema(tempdir):
     """


### PR DESCRIPTION
Expose a `Dataset.filter` method that applies a filter to the dataset without actually loading it in memory.

Addresses what was discussed in https://github.com/apache/arrow/pull/13155#discussion_r875076518

- [x] Update documentation
- [x] Ensure the filtered dataset preserves the filter when writing it back
- [x] Ensure the filtered dataset preserves the filter when joining
- [x] Ensure the filtered dataset preserves the filter when applying standard `Dataset.something` methods.
- [x] Allow to extend the filter by adding more conditions subsequently `dataset(filter=X).filter(filter=Y).scanner(filter=Z)` (related to https://github.com/apache/arrow/pull/13409#discussion_r914281876)
- [x]  Refactor to use only `Dataset` class instead of `FilteredDataset` as discussed with @jorisvandenbossche 
- [x] Add support in replace_schema
- [x] Error in get_fragments in case a filter is set.
- [x] Verify support in UnionDataset
