### PR TITLE
ARROW-16383: [C++] Disable memory mapping by default in Arrow-C++

### DIFF
--- a/cpp/src/parquet/file_reader.h
+++ b/cpp/src/parquet/file_reader.h
@@ -113,7 +113,7 @@ class PARQUET_EXPORT ParquetFileReader {
   // API Convenience to open a serialized Parquet file on disk, using Arrow IO
   // interfaces.
   static std::unique_ptr<ParquetFileReader> OpenFile(
-      const std::string& path, bool memory_map = true,
+      const std::string& path, bool memory_map = false,
       const ReaderProperties& props = default_reader_properties(),
       std::shared_ptr<FileMetaData> metadata = NULLPTR);
 


### PR DESCRIPTION
Disable memory mapping by default in Arrow-C++