### PR TITLE
ARROW-16892: [Dev][Release] Fix version sorting on merge_arrow script

### DIFF
--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -142,11 +142,9 @@ class JiraIssue(object):
     @classmethod
     def sort_versions(cls, versions):
         def version_tuple(x):
-            version = x.name
             # Parquet versions are something like cpp-1.2.0
-            if "-" in version:
-                version = version.split("-")[1]
-            return tuple(int(_) for _ in version.split("."))
+            numeric_version = x.name.split("-", 1)[-1]
+            return tuple(int(_) for _ in numeric_version.split("."))
         return sorted(versions, key=version_tuple, reverse=True)
 
     def get_candidate_fix_versions(self, merge_branches=('master',)):

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -122,6 +122,31 @@ PR_TITLE_REGEXEN = [(project, re.compile(r'^(' + project + r'-[0-9]+)\b.*$'))
                     for project in SUPPORTED_PROJECTS]
 
 
+class ComparableVersion(object):
+
+    def __init__(self, jira_version):
+        self.jira_version = jira_version
+        version_name = jira_version.name
+        if "-" in version_name:
+            # Support pre-semver versioning like: JS-0.4.0
+            self.prefix, version_name = version_name.split("-", 1)
+        (major, minor, patch) = version_name.split(".")
+        self.major = int(major)
+        self.minor = int(minor)
+        self.patch = int(patch)
+
+    def __gt__(self, other):
+        if self.major != other.major:
+            return self.major > other.major
+        if self.minor != other.minor:
+            return self.minor > other.minor
+        if self.patch != other.patch:
+            return self.patch > other.patch
+
+    def __repr__(self):
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+
 class JiraIssue(object):
 
     def __init__(self, jira_con, jira_id, project, cmd):
@@ -139,14 +164,24 @@ class JiraIssue(object):
     def current_fix_versions(self):
         return self.issue.fields.fixVersions
 
+    @classmethod
+    def sort_versions(cls, versions):
+        # Use utility ComparableVersion class to sort JIRA text versions
+        comparable_versions = [
+            ComparableVersion(version) for version in versions
+        ]
+        comparable_versions = sorted(comparable_versions, reverse=True)
+        return [
+            comp_version.jira_version for comp_version in comparable_versions
+        ]
+
     def get_candidate_fix_versions(self, merge_branches=('master',)):
         # Only suggest versions starting with a number, like 0.x but not JS-0.x
         all_versions = self.jira_con.project_versions(self.project)
         unreleased_versions = [x for x in all_versions
                                if not x.raw['released']]
 
-        unreleased_versions = sorted(unreleased_versions,
-                                     key=lambda x: x.name, reverse=True)
+        unreleased_versions = self.sort_versions(unreleased_versions)
 
         mainline_versions = self._filter_mainline_versions(unreleased_versions)
 

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -121,6 +121,7 @@ SUPPORTED_PROJECTS = ['ARROW', 'PARQUET']
 PR_TITLE_REGEXEN = [(project, re.compile(r'^(' + project + r'-[0-9]+)\b.*$'))
                     for project in SUPPORTED_PROJECTS]
 
+
 class JiraIssue(object):
 
     def __init__(self, jira_con, jira_id, project, cmd):
@@ -146,9 +147,7 @@ class JiraIssue(object):
             if "-" in version:
                 version = version.split("-")[1]
             return tuple(int(_) for _ in version.split("."))
-        return sorted(versions,
-            key=version_tuple,
-            reverse=True)
+        return sorted(versions, key=version_tuple, reverse=True)
 
     def get_candidate_fix_versions(self, merge_branches=('master',)):
         # Only suggest versions starting with a number, like 0.x but not JS-0.x

--- a/dev/test_merge_arrow_pr.py
+++ b/dev/test_merge_arrow_pr.py
@@ -34,10 +34,10 @@ FakeVersion = namedtuple('version', ['name', 'raw'])
 
 RAW_VERSION_JSON = [
     {'name': 'JS-0.4.0', 'released': False},
-    {'name': '0.11.0', 'released': False},
-    {'name': '0.12.0', 'released': False},
-    {'name': '0.10.0', 'released': True},
-    {'name': '0.9.0', 'released': True}
+    {'name': '0.9.0', 'released': False},
+    {'name': '0.10.0', 'released': False},
+    {'name': '0.8.0', 'released': True},
+    {'name': '0.7.0', 'released': True}
 ]
 
 
@@ -78,7 +78,7 @@ class FakeJIRA:
         }
 
     def get_candidate_fix_versions(self):
-        return SOURCE_VERSIONS, ['0.12.0']
+        return SOURCE_VERSIONS, ['0.11.0']
 
     def project_versions(self, project):
         return self._project_versions
@@ -106,13 +106,13 @@ def test_jira_fix_versions():
     issue = merge_arrow_pr.JiraIssue(jira, 'ARROW-1234', 'ARROW', FakeCLI())
     all_versions, default_versions = issue.get_candidate_fix_versions()
     assert all_versions == SOURCE_VERSIONS
-    assert default_versions == ['0.11.0']
+    assert default_versions == ['0.9.0']
 
 
 def test_jira_no_suggest_patch_release():
     versions_json = [
-        {'name': '0.11.1', 'released': False},
-        {'name': '0.12.0', 'released': False},
+        {'name': '0.9.1', 'released': False},
+        {'name': '0.10.0', 'released': False},
     ]
 
     versions = [FakeVersion(raw['name'], raw) for raw in versions_json]
@@ -121,7 +121,7 @@ def test_jira_no_suggest_patch_release():
     issue = merge_arrow_pr.JiraIssue(jira, 'ARROW-1234', 'ARROW', FakeCLI())
     all_versions, default_versions = issue.get_candidate_fix_versions()
     assert all_versions == versions
-    assert default_versions == ['0.12.0']
+    assert default_versions == ['0.10.0']
 
 
 def test_jira_parquet_no_suggest_non_cpp():
@@ -199,7 +199,7 @@ def test_jira_resolve_released_fix_version():
                     project_versions=SOURCE_VERSIONS,
                     transitions=TRANSITIONS)
 
-    cmd = FakeCLI(responses=['0.9.0'])
+    cmd = FakeCLI(responses=['0.7.0'])
     fix_versions_json = merge_arrow_pr.prompt_for_fix_version(cmd, jira)
     assert fix_versions_json == [RAW_VERSION_JSON[-1]]
 
@@ -315,3 +315,13 @@ Assignee\tFoo Bar
 Components\tC++, Python
 Status\t\tResolved
 URL\t\thttps://issues.apache.org/jira/browse/ARROW-1234"""
+
+
+def test_sorting_versions():
+    versions_json = [
+        {'name': '9.0.0', 'released': False},
+        {'name': '10.0.0', 'released': False},
+    ]
+    versions = [FakeVersion(raw['name'], raw) for raw in versions_json]
+    ordered_versions = merge_arrow_pr.JiraIssue.sort_versions(versions)
+    assert ordered_versions[0].name == "10.0.0"


### PR DESCRIPTION
I have tested injecting FakeVersions and seeing how it prompts the correct one.
If there would be an 8.0.0 today it will prompt for it:
```
(Pdb) versions[0].name = "8.0.0"
(Pdb) c
Enter comma-separated fix version(s) [8.0.0]:
```
If there would be a 10.0.0 it would prompt the 9.0.0 as expected:
```
(Pdb) versions[0].name = "10.0.0"
(Pdb) c
Enter comma-separated fix version(s) [9.0.0]: 
```