### PR TITLE
ARROW-16600: [Java] Configurable RoundingMode to handle inconsistent scale in BigDecimals

### DIFF
--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigBuilder.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigBuilder.java
@@ -19,6 +19,7 @@ package org.apache.arrow.adapter.jdbc;
 
 import static org.apache.arrow.adapter.jdbc.JdbcToArrowConfig.DEFAULT_TARGET_BATCH_SIZE;
 
+import java.math.RoundingMode;
 import java.util.Calendar;
 import java.util.Map;
 import java.util.function.Function;
@@ -41,6 +42,7 @@ public class JdbcToArrowConfigBuilder {
   private Map<String, JdbcFieldInfo> explicitTypesByColumnName;
   private int targetBatchSize;
   private Function<JdbcFieldInfo, ArrowType> jdbcToArrowTypeConverter;
+  private RoundingMode bigDecimalRoundingMode;
 
   /**
    * Default constructor for the <code>JdbcToArrowConfigBuilder}</code>.
@@ -56,6 +58,7 @@ public class JdbcToArrowConfigBuilder {
     this.arraySubTypesByColumnName = null;
     this.explicitTypesByColumnIndex = null;
     this.explicitTypesByColumnName = null;
+    this.bigDecimalRoundingMode = null;
   }
 
   /**
@@ -193,6 +196,11 @@ public class JdbcToArrowConfigBuilder {
     return this;
   }
 
+  public JdbcToArrowConfigBuilder setBigDecimalRoundingMode(RoundingMode bigDecimalRoundingMode) {
+    this.bigDecimalRoundingMode = bigDecimalRoundingMode;
+    return this;
+  }
+
   /**
    * This builds the {@link JdbcToArrowConfig} from the provided
    * {@link BufferAllocator} and {@link Calendar}.
@@ -211,6 +219,7 @@ public class JdbcToArrowConfigBuilder {
         targetBatchSize,
         jdbcToArrowTypeConverter,
         explicitTypesByColumnIndex,
-        explicitTypesByColumnName);
+        explicitTypesByColumnName,
+        bigDecimalRoundingMode);
   }
 }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
@@ -21,6 +21,7 @@ import static org.apache.arrow.vector.types.FloatingPointPrecision.DOUBLE;
 import static org.apache.arrow.vector.types.FloatingPointPrecision.SINGLE;
 
 import java.io.IOException;
+import java.math.RoundingMode;
 import java.sql.Date;
 import java.sql.ParameterMetaData;
 import java.sql.ResultSet;
@@ -427,7 +428,8 @@ public class JdbcToArrowUtils {
             return null;
         }
       case Decimal:
-        return DecimalConsumer.createConsumer((DecimalVector) vector, columnIndex, nullable);
+        final RoundingMode bigDecimalRoundingMode = config.getBigDecimalRoundingMode();
+        return DecimalConsumer.createConsumer((DecimalVector) vector, columnIndex, nullable, bigDecimalRoundingMode);
       case FloatingPoint:
         switch (((ArrowType.FloatingPoint) arrowType).getPrecision()) {
           case SINGLE:

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DecimalConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DecimalConsumer.java
@@ -18,6 +18,7 @@
 package org.apache.arrow.adapter.jdbc.consumer;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
@@ -27,29 +28,68 @@ import org.apache.arrow.vector.DecimalVector;
  * Consumer which consume decimal type values from {@link ResultSet}.
  * Write the data to {@link org.apache.arrow.vector.DecimalVector}.
  */
-public class DecimalConsumer {
+public abstract class DecimalConsumer extends BaseConsumer<DecimalVector> {
+  private final RoundingMode bigDecimalRoundingMode;
+  private final int scale;
+
+  /**
+   * Constructs a new consumer.
+   *
+   * @param vector the underlying vector for the consumer.
+   * @param index  the column id for the consumer.
+   */
+  public DecimalConsumer(DecimalVector vector, int index) {
+    this(vector, index, null);
+  }
+
+  /**
+   * Constructs a new consumer, with optional coercibility.
+   * @param vector the underlying vector for the consumer.
+   * @param index the column index for the consumer.
+   * @param bigDecimalRoundingMode java.math.RoundingMode to be applied if the BigDecimal scale does not match that
+   *                               of the target vector.  Set to null to retain strict matching behavior (scale of
+   *                               source and target vector must match exactly).
+   */
+  public DecimalConsumer(DecimalVector vector, int index, RoundingMode bigDecimalRoundingMode) {
+    super(vector, index);
+    this.bigDecimalRoundingMode = bigDecimalRoundingMode;
+    this.scale = vector.getScale();
+  }
 
   /**
    * Creates a consumer for {@link DecimalVector}.
    */
-  public static JdbcConsumer<DecimalVector> createConsumer(DecimalVector vector, int index, boolean nullable) {
+  public static JdbcConsumer<DecimalVector> createConsumer(
+          DecimalVector vector,
+          int index,
+          boolean nullable,
+          RoundingMode bigDecimalRoundingMode
+  ) {
     if (nullable) {
-      return new NullableDecimalConsumer(vector, index);
+      return new NullableDecimalConsumer(vector, index, bigDecimalRoundingMode);
     } else {
-      return new NonNullableDecimalConsumer(vector, index);
+      return new NonNullableDecimalConsumer(vector, index, bigDecimalRoundingMode);
     }
   }
+
+  protected void set(BigDecimal value) {
+    if (bigDecimalRoundingMode != null && value.scale() != scale) {
+      value = value.setScale(scale, bigDecimalRoundingMode);
+    }
+    vector.set(currentIndex, value);
+  }
+
 
   /**
    * Consumer for nullable decimal.
    */
-  static class NullableDecimalConsumer extends BaseConsumer<DecimalVector> {
+  static class NullableDecimalConsumer extends DecimalConsumer {
 
     /**
      * Instantiate a DecimalConsumer.
      */
-    public NullableDecimalConsumer(DecimalVector vector, int index) {
-      super(vector, index);
+    public NullableDecimalConsumer(DecimalVector vector, int index, RoundingMode bigDecimalRoundingMode) {
+      super(vector, index, bigDecimalRoundingMode);
     }
 
     @Override
@@ -58,7 +98,7 @@ public class DecimalConsumer {
       if (!resultSet.wasNull()) {
         // for fixed width vectors, we have allocated enough memory proactively,
         // so there is no need to call the setSafe method here.
-        vector.set(currentIndex, value);
+        set(value);
       }
       currentIndex++;
     }
@@ -67,13 +107,13 @@ public class DecimalConsumer {
   /**
    * Consumer for non-nullable decimal.
    */
-  static class NonNullableDecimalConsumer extends BaseConsumer<DecimalVector> {
+  static class NonNullableDecimalConsumer extends DecimalConsumer {
 
     /**
      * Instantiate a DecimalConsumer.
      */
-    public NonNullableDecimalConsumer(DecimalVector vector, int index) {
-      super(vector, index);
+    public NonNullableDecimalConsumer(DecimalVector vector, int index, RoundingMode bigDecimalRoundingMode) {
+      super(vector, index, bigDecimalRoundingMode);
     }
 
     @Override
@@ -81,7 +121,7 @@ public class DecimalConsumer {
       BigDecimal value = resultSet.getBigDecimal(columnIndexInResultSet);
       // for fixed width vectors, we have allocated enough memory proactively,
       // so there is no need to call the setSafe method here.
-      vector.set(currentIndex, value);
+      set(value);
       currentIndex++;
     }
   }


### PR DESCRIPTION
Under certain conditions, JDBC vendors may return ResultSets where the scale of BigDecimal values differ by row. Existing logic required exact matching of every row to the established scale for the column (target vector), and throws UnsupportedOperationException when there is a mismatch, aborting ResultSet processing.  This change enables configuration of a java.math.RoundingMode to be applied in any required scale conversion, and should enable both full-fidelity truncation (trimming trailing zeros right of decimal) as well as lossy conversion (see [RoundingModes javadoc](https://docs.oracle.com/javase/8/docs/api/java/math/RoundingMode.html)).

Note that this is implemented as a global configuration options - it will apply to all BigDecimal columns in a ResultSet being processed using the supplied config. It's possible to provide per-column control over this behavior, but I assessed that to complicate configuration for little benefit. Please indicate if this decision should be reevaluated.
