### PR TITLE
MINOR: [Docs] Use endpoint_override in code example for minIO

### DIFF
--- a/docs/source/python/dataset.rst
+++ b/docs/source/python/dataset.rst
@@ -386,7 +386,7 @@ useful for testing or benchmarking.
     from pyarrow import fs
 
     # By default, MinIO will listen for unencrypted HTTP traffic.
-    minio = fs.S3FileSystem(scheme="http", endpoint="localhost:9000")
+    minio = fs.S3FileSystem(scheme="http", endpoint_override="localhost:9000")
     dataset = ds.dataset("ursa-labs-taxi-data/", filesystem=minio,
                          partitioning=["year", "month"])
 


### PR DESCRIPTION
Current code snippet show how to configure connection to minIO appears to use wrong named argument for endpoint. Instead of `endpoint` it should be `endpoint_override`

see https://arrow.apache.org/docs/python/generated/pyarrow.fs.S3FileSystem.html

<img width="560" alt="image" src="https://user-images.githubusercontent.com/179870/175815553-18042907-1c9d-4cd1-8a3b-ef9a1284b4c8.png">
