### PR TITLE
ARROW-16872: [C++] Fix CSV parser edge case

### DIFF
--- a/cpp/src/arrow/csv/parser.cc
+++ b/cpp/src/arrow/csv/parser.cc
@@ -240,6 +240,7 @@ class BlockParserImpl {
     int32_t num_cols = 0;
     char c;
     const auto start = data;
+    int32_t final_offset = 0;
 
     DCHECK_GT(data_end, data);
 
@@ -296,6 +297,9 @@ class BlockParserImpl {
     if (UseBulkFilter) {
       const char* bulk_end = RunBulkFilter(parsed_writer, data, data_end, bulk_filter);
       if (ARROW_PREDICT_FALSE(bulk_end == nullptr)) {
+        if (is_final) {
+          final_offset = static_cast<int32_t>(data_end - data);
+        }
         goto AbortLine;
       }
       data = bulk_end;
@@ -389,7 +393,7 @@ class BlockParserImpl {
       }
     }
     ++batch_.num_rows_;
-    *out_data = data;
+    *out_data = data + final_offset;
     return Status::OK();
 
   AbortLine:

--- a/cpp/src/arrow/csv/parser.cc
+++ b/cpp/src/arrow/csv/parser.cc
@@ -240,7 +240,6 @@ class BlockParserImpl {
     int32_t num_cols = 0;
     char c;
     const auto start = data;
-    int32_t final_offset = 0;
 
     DCHECK_GT(data_end, data);
 
@@ -298,7 +297,7 @@ class BlockParserImpl {
       const char* bulk_end = RunBulkFilter(parsed_writer, data, data_end, bulk_filter);
       if (ARROW_PREDICT_FALSE(bulk_end == nullptr)) {
         if (is_final) {
-          final_offset = static_cast<int32_t>(data_end - data);
+          data = data_end;
         }
         goto AbortLine;
       }
@@ -341,6 +340,9 @@ class BlockParserImpl {
     if (UseBulkFilter) {
       const char* bulk_end = RunBulkFilter(parsed_writer, data, data_end, bulk_filter);
       if (ARROW_PREDICT_FALSE(bulk_end == nullptr)) {
+        if (is_final) {
+          data = data_end;
+        }
         goto AbortLine;
       }
       data = bulk_end;
@@ -393,7 +395,7 @@ class BlockParserImpl {
       }
     }
     ++batch_.num_rows_;
-    *out_data = data + final_offset;
+    *out_data = data;
     return Status::OK();
 
   AbortLine:

--- a/cpp/src/arrow/csv/parser_test.cc
+++ b/cpp/src/arrow/csv/parser_test.cc
@@ -421,9 +421,8 @@ TEST(BlockParser, FinalTruncatedBulkFilterNoEol) {
 
   uint32_t out_size;
   BlockParser parser(ParseOptions::Defaults());
-  Status st = ParseFinal(parser, csv, &out_size);
-  ASSERT_RAISES(Invalid, st);
-  ASSERT_NE(st.ToString().find(err_msg), std::string::npos);
+  EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, ::testing::HasSubstr(err_msg),
+                                  ParseFinal(parser, csv, &out_size));
 }
 
 TEST(BlockParser, QuotingSimple) {

--- a/cpp/src/arrow/csv/parser_test.cc
+++ b/cpp/src/arrow/csv/parser_test.cc
@@ -417,12 +417,13 @@ TEST(BlockParser, FinalBulkFilterNoEol) {
 TEST(BlockParser, FinalTruncatedBulkFilterNoEol) {
   // Not enough fields at last line. Processed by bulk filter. No EOL at last line.
   auto csv = MakeCSVData({"12345678901,12345678\n", "87654321"});
+  const char* err_msg = "Expected 2 columns, got 1: 87654321";
 
   uint32_t out_size;
   BlockParser parser(ParseOptions::Defaults());
-  ASSERT_RAISES_WITH_MESSAGE(
-      Invalid, "Invalid: CSV parse error: Expected 2 columns, got 1: 87654321",
-      ParseFinal(parser, csv, &out_size));
+  Status st = ParseFinal(parser, csv, &out_size);
+  ASSERT_RAISES(Invalid, st);
+  ASSERT_NE(st.ToString().find(err_msg), std::string::npos);
 }
 
 TEST(BlockParser, QuotingSimple) {

--- a/cpp/src/arrow/csv/parser_test.cc
+++ b/cpp/src/arrow/csv/parser_test.cc
@@ -405,6 +405,15 @@ TEST(BlockParser, FinalTruncatedData) {
   ASSERT_RAISES(Invalid, st);
 }
 
+TEST(BlockParser, FinalBulkFilterNoEol) {
+  // Last field processed by bulk filter. No EOL at last line.
+  auto csv = MakeCSVData({"12345678901,12345678\n", "12345678901,12345678"});
+
+  BlockParser parser(ParseOptions::Defaults());
+  AssertParseFinal(parser, csv);
+  AssertColumnsEq(parser, {{"12345678901", "12345678901"}, {"12345678", "12345678"}});
+}
+
 TEST(BlockParser, QuotingSimple) {
   auto csv = MakeCSVData({"1,\",3,\",5\n"});
 

--- a/cpp/src/arrow/csv/parser_test.cc
+++ b/cpp/src/arrow/csv/parser_test.cc
@@ -407,11 +407,22 @@ TEST(BlockParser, FinalTruncatedData) {
 
 TEST(BlockParser, FinalBulkFilterNoEol) {
   // Last field processed by bulk filter. No EOL at last line.
-  auto csv = MakeCSVData({"12345678901,12345678\n", "12345678901,12345678"});
+  auto csv = MakeCSVData({"12345678901,12345678\n", "10987654321,87654321"});
 
   BlockParser parser(ParseOptions::Defaults());
   AssertParseFinal(parser, csv);
-  AssertColumnsEq(parser, {{"12345678901", "12345678901"}, {"12345678", "12345678"}});
+  AssertColumnsEq(parser, {{"12345678901", "10987654321"}, {"12345678", "87654321"}});
+}
+
+TEST(BlockParser, FinalTruncatedBulkFilterNoEol) {
+  // Not enough fields at last line. Processed by bulk filter. No EOL at last line.
+  auto csv = MakeCSVData({"12345678901,12345678\n", "87654321"});
+
+  uint32_t out_size;
+  BlockParser parser(ParseOptions::Defaults());
+  ASSERT_RAISES_WITH_MESSAGE(
+      Invalid, "Invalid: CSV parse error: Expected 2 columns, got 1: 87654321",
+      ParseFinal(parser, csv, &out_size));
 }
 
 TEST(BlockParser, QuotingSimple) {


### PR DESCRIPTION
Fixes an error when there's no EOL at last line, and last field is consumed by bulk filter.