### PR TITLE
ARROW-16912: [R][CI] Fix nightly centos package without GCS

### DIFF
--- a/.github/workflows/r_nightly.yml
+++ b/.github/workflows/r_nightly.yml
@@ -17,7 +17,7 @@
 
 name: Upload R Nightly builds
 # This workflow downloads the (nightly) binaries created in crossbow and uploads them
-# to nightlies.apache.org. Due to authorization requirements, this upload can't be done 
+# to nightlies.apache.org. Due to authorization requirements, this upload can't be done
 
 # from the crossbow repository.
 
@@ -50,7 +50,7 @@ jobs:
           fetch-depth: 0
           path: crossbow
           repository: ursacomputing/crossbow
-          ref: master 
+          ref: master
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
@@ -69,7 +69,7 @@ jobs:
           fi
           echo $PREFIX
 
-          archery crossbow download-artifacts -f r-nightly-packages -t binaries $PREFIX
+          archery crossbow download-artifacts -f r-binary-packages -t binaries $PREFIX
 
           if [ -n "$(ls -A binaries/*/*/)" ]; then
             echo "Found files!"
@@ -82,12 +82,12 @@ jobs:
         run: |
           # folder that we rsync to nightlies.apache.org
           repo_root <- "repo"
-          # The binaries are in a nested dir 
+          # The binaries are in a nested dir
           # so we need to find the correct path.
           art_path <- list.files("binaries",
             recursive = TRUE,
             include.dirs = TRUE,
-            pattern = "r-nightly-packages$",
+            pattern = "r-binary-packages$",
             full.names = TRUE
           )
 

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -18,7 +18,7 @@
 {% import 'macros.jinja' as macros with context %}
 
 # This allows us to set a custom version via param:
-# crossbow submit --param custom_version=8.5.3 r-nightly-packages
+# crossbow submit --param custom_version=8.5.3 r-binary-packages
 # if the param is unset defaults to the usual Ymd naming scheme
 {% set package_version = custom_version|default("\\2.\'\"$(date +%Y%m%d)\"\'") %}
 # We need this as boolean and string
@@ -44,7 +44,7 @@ jobs:
       - name: Save Version
         id: save-version
         shell: bash
-        run: | 
+        run: |
           echo "::set-output name=pkg_version::$(grep ^Version arrow/r/DESCRIPTION | sed s/Version:\ //)"
 
       - uses: r-lib/actions/setup-r@v2
@@ -99,7 +99,7 @@ jobs:
           cd arrow/r/libarrow/dist
           # These files were created by the docker user so we have to sudo to get them
           sudo -E zip -r $PKG_FILE lib/ include/
-          
+
       - name: Upload binary artifact
         uses: actions/upload-artifact@v3
         with:
@@ -131,7 +131,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: r-lib__libarrow__bin__windows
-          path: build/arrow-*.zip 
+          path: build/arrow-*.zip
 
   r-packages:
     needs: [source, windows-cpp]
@@ -158,7 +158,7 @@ jobs:
       - name: Build Binary
         id: build
         shell: Rscript {0}
-        env:  
+        env:
           ARROW_R_DEV: TRUE
         run: |
           on_windows <- tolower(Sys.info()[["sysname"]]) == "windows"
@@ -171,7 +171,7 @@ jobs:
 
           cat("Remove old arrow version.\n")
           remove.packages("arrow")
-          
+
           # Build
           Sys.setenv(MAKEFLAGS = paste0("-j", parallel::detectCores()))
           INSTALL_opts <- "--build"
@@ -195,7 +195,7 @@ jobs:
 
           # encode contrib.url for artifact name
           cmd <- paste0(
-            "::set-output name=path::", 
+            "::set-output name=path::",
             gsub(
               "/", "__",
               contrib.url("", type = "binary")
@@ -287,9 +287,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       {{ macros.github_checkout_arrow()|indent }}
-      - name: Download Artifacts 
+      - name: Download Artifacts
         uses: actions/download-artifact@v3
-        with: 
+        with:
           path: artifacts
       - name: Install R
         uses: r-lib/actions/setup-r@v2
@@ -304,4 +304,3 @@ jobs:
           file.copy(file.path("artifacts", file_paths), new_names)
 
       {{ macros.github_upload_releases("binaries/r-*")|indent }}
-          

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -87,6 +87,7 @@ groups:
     - conda-linux-gcc-py*-cpu-r*
     - conda-osx-clang-py*-r*
     - conda-win-vs2017-py*-r*
+    - r-binary-packages
 
   ruby:
     - test-*ruby*
@@ -177,7 +178,7 @@ groups:
     - nuget
     - wheel-*
     - python-sdist
-    - r-nightly-packages
+    - r-binary-packages
 
   nightly-release:
     - verify-rc-source-*
@@ -931,7 +932,7 @@ tasks:
       - Apache.Arrow.{no_rc_version}.snupkg
 
   ######################## R packages & binaries ##############################
-  r-nightly-packages:
+  r-binary-packages:
     ci: github
     template: r/github.packages.yml
     artifacts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -354,7 +354,7 @@ services:
       - .:/arrow:delegated
       - ${DOCKER_VOLUME_PREFIX}ubuntu-ccache:/ccache:delegated
     command: *cpp-command
-  
+
   ubuntu-cpp-static:
     # Usage:
     #   docker-compose build ubuntu-cpp-static
@@ -400,7 +400,7 @@ services:
       cache_from:
         - ${REPO}:centos-7-cpp-static
     shm_size: *shm-size
-    volumes: 
+    volumes:
       - .:/arrow:delegated
     environment:
       <<: *ccache
@@ -410,9 +410,9 @@ services:
       ARROW_MIMALLOC: "ON"
     command: >
       /bin/bash -c "
-        if grep -q -i -e 'centos.* 7' /etc/os-release; then export ARROW_S3=OFF ARROW_MIMALLOC=OFF; fi &&
+        if grep -q -i -e 'centos.* 7' /etc/os-release; then export ARROW_S3=OFF ARROW_GCS=OFF ARROW_MIMALLOC=OFF; fi &&
         cd /arrow && r/inst/build_arrow_static.sh"
-        
+
   ubuntu-cpp-bundled:
     # Arrow build with BUNDLED dependencies
     image: ${REPO}:${ARCH}-ubuntu-${UBUNTU}-cpp-minimal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -404,13 +404,15 @@ services:
       - .:/arrow:delegated
     environment:
       <<: *ccache
-      ARROW_HOME: /arrow
       ARROW_DEPENDENCY_SOURCE: BUNDLED
+      ARROW_HOME: /arrow
       LIBARROW_MINIMAL: "false"
-      ARROW_MIMALLOC: "ON"
+      # Turn off features that aren't supported on CentOS 7 gcc 4.8
+      ARROW_GCS: "OFF"
+      ARROW_MIMALLOC: "OFF"
+      ARROW_S3: "OFF"
     command: >
       /bin/bash -c "
-        if grep -q -i -e 'centos.* 7' /etc/os-release; then export ARROW_S3=OFF ARROW_GCS=OFF ARROW_MIMALLOC=OFF; fi &&
         cd /arrow && r/inst/build_arrow_static.sh"
 
   ubuntu-cpp-bundled:


### PR DESCRIPTION
cc @assignUser 

Most of the diff seems to be my editor trimming whitespace. The actual changes:

* Rename `r-nightly-packages` to `r-binary-packages` since they can be run on demand (not only nightly)
* Add it to the `r` crossbow group
* Turn ARROW_GCS=OFF in the centos-7 package. Where this setting happens is not obvious.