### PR TITLE
ARROW-9612: [C++] increase default block_size from 1MB to 16MB

### DIFF
--- a/cpp/src/arrow/json/options.h
+++ b/cpp/src/arrow/json/options.h
@@ -64,7 +64,7 @@ struct ARROW_EXPORT ReadOptions {
   bool use_threads = true;
   /// Block size we request from the IO layer; also determines the size of
   /// chunks when use_threads is true
-  int32_t block_size = 1 << 20;  // 1 MB
+  int32_t block_size = 1 << 24;  // 16 MB
 
   /// Create read options with default values
   static ReadOptions Defaults();


### PR DESCRIPTION
Parsing JSONL with large objects fails with previous 1MB block_size.
Experimentation is required to find a workable block_size.
These days JSON blobs are more frequently bigger than 1MB.
16MB is a more reasonable balance between amount of memory allocated for the
buffer, and number of JSON files in the wild that can be parsed
immediately and without friction.