### PR TITLE
MINOR: [Docs][Python] Remove outdated reference to libhdfs3 backend

### DIFF
--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -94,7 +94,7 @@ The test groups currently include:
 * ``dataset``: Apache Arrow Dataset tests
 * ``flight``: Flight RPC tests
 * ``gandiva``: tests for Gandiva expression compiler (uses LLVM)
-* ``hdfs``: tests that use libhdfs or libhdfs3 to access the Hadoop filesystem
+* ``hdfs``: tests that use libhdfs to access the Hadoop filesystem
 * ``hypothesis``: tests that use the ``hypothesis`` module for generating
   random test cases. Note that ``--hypothesis`` doesn't work due to a quirk
   with pytest, so you have to pass ``--enable-hypothesis``

--- a/docs/source/python/filesystems_deprecated.rst
+++ b/docs/source/python/filesystems_deprecated.rst
@@ -59,13 +59,6 @@ LD_LIBRARY_PATH), and relies on some environment variables.
 If ``CLASSPATH`` is not set, then it will be set automatically if the
 ``hadoop`` executable is in your system path, or if ``HADOOP_HOME`` is set.
 
-You can also use libhdfs3, a thirdparty C++ library for HDFS from Pivotal Labs:
-
-.. code-block:: python
-
-   fs = pa.hdfs.connect(host, port, user=user, kerb_ticket=ticket_cache_path,
-                       driver='libhdfs3')
-
 HDFS API
 ~~~~~~~~
 


### PR DESCRIPTION
While the (deprecated) docs give an example of using libhdfs3 instead of the JNI interface, this actually hasn't existed in a long time.