### PR TITLE
ARROW-16917: [C++][Gandiva] Add a Secondary Cache to cache gandiva object code

### DIFF
--- a/cpp/src/gandiva/cache.h
+++ b/cpp/src/gandiva/cache.h
@@ -50,6 +50,11 @@ class Cache {
     cache_.insert(cache_key, module);
   }
 
+  void Clear() {
+    std::lock_guard<std::mutex> lock(mtx_);
+    cache_.clear();
+  }
+
  private:
   LruCache<KeyType, ValueType> cache_;
   std::mutex mtx_;

--- a/cpp/src/gandiva/engine.cc
+++ b/cpp/src/gandiva/engine.cc
@@ -89,6 +89,7 @@ std::once_flag llvm_init_once_flag;
 static bool llvm_init = false;
 static llvm::StringRef cpu_name;
 static llvm::SmallVector<std::string, 10> cpu_attrs;
+static char* cpu_details_;
 
 void Engine::InitOnce() {
   DCHECK_EQ(llvm_init, false);
@@ -112,7 +113,18 @@ void Engine::InitOnce() {
   }
   ARROW_LOG(INFO) << "Detected CPU Name : " << cpu_name.str();
   ARROW_LOG(INFO) << "Detected CPU Features:" << cpu_attrs_str;
+
+  std::string cpu_details = cpu_name.str();
+  cpu_details += cpu_attrs_str;
+  cpu_details_ = strdup(cpu_details.c_str());
+
   llvm_init = true;
+}
+
+char* Engine::GetCpuIdentifier() {
+  DCHECK_EQ(llvm_init, true);
+
+  return cpu_details_;
 }
 
 Engine::Engine(const std::shared_ptr<Configuration>& conf,

--- a/cpp/src/gandiva/engine.h
+++ b/cpp/src/gandiva/engine.h
@@ -76,6 +76,8 @@ class GANDIVA_EXPORT Engine {
   /// Load the function IRs that can be accessed in the module.
   Status LoadFunctionIRs();
 
+  static char* GetCpuIdentifier();
+
  private:
   Engine(const std::shared_ptr<Configuration>& conf,
          std::unique_ptr<llvm::LLVMContext> ctx,

--- a/cpp/src/gandiva/expression_cache_key.h
+++ b/cpp/src/gandiva/expression_cache_key.h
@@ -19,6 +19,7 @@
 
 #include <stddef.h>
 
+#include <sstream>
 #include <thread>
 
 #include "arrow/util/hash_util.h"
@@ -108,6 +109,18 @@ class ExpressionCacheKey {
   }
 
   bool operator!=(const ExpressionCacheKey& other) const { return !(*this == other); }
+
+  std::string ToString() {
+    std::stringstream s;
+
+    s << schema_->ToString() << "\n";
+    s << mode_ << configuration_->Hash() << uniqifier_ << "\n";
+    for (std::string expr : expressions_as_strings_) {
+      s << expr << "\n";
+    }
+
+    return s.str();
+  }
 
  private:
   size_t hash_code_;

--- a/cpp/src/gandiva/filter.h
+++ b/cpp/src/gandiva/filter.h
@@ -27,6 +27,7 @@
 #include "gandiva/arrow.h"
 #include "gandiva/condition.h"
 #include "gandiva/configuration.h"
+#include "gandiva/secondary_cache.h"
 #include "gandiva/selection_vector.h"
 #include "gandiva/visibility.h"
 
@@ -68,6 +69,19 @@ class GANDIVA_EXPORT Filter {
                      std::shared_ptr<Configuration> config,
                      std::shared_ptr<Filter>* filter);
 
+  /// \brief Build a filter for the given schema and condition.
+  /// Customize the filter with runtime configuration.
+  ///
+  /// \param[in] schema schema for the record batches, and the condition.
+  /// \param[in] condition filter conditions.
+  /// \param[in] config run time configuration.
+  /// \param[in] sec_cache object to enable jni upcalls.
+  /// \param[out] filter the returned filter object
+  static Status Make(SchemaPtr schema, ConditionPtr condition,
+                     std::shared_ptr<Configuration> config,
+                     std::shared_ptr<SecondaryCacheInterface> sec_cache,
+                     std::shared_ptr<Filter>* filter);
+
   /// Evaluate the specified record batch, and populate output selection vector.
   ///
   /// \param[in] batch the record batch. schema should be the same as the one in 'Make'
@@ -82,7 +96,12 @@ class GANDIVA_EXPORT Filter {
 
   bool GetBuiltFromCache();
 
+  void Clear();
+
  private:
+  // Create an arrow buffer with the key for the secondary cache.
+  static std::shared_ptr<arrow::Buffer> GetSecondaryCacheKey(std::string primaryKey);
+
   std::unique_ptr<LLVMGenerator> llvm_generator_;
   SchemaPtr schema_;
   std::shared_ptr<Configuration> configuration_;

--- a/cpp/src/gandiva/jni/jni_common.cc
+++ b/cpp/src/gandiva/jni/jni_common.cc
@@ -38,6 +38,7 @@
 #include "gandiva/jni/id_to_module_map.h"
 #include "gandiva/jni/module_holder.h"
 #include "gandiva/projector.h"
+#include "gandiva/secondary_cache.h"
 #include "gandiva/selection_vector.h"
 #include "gandiva/tree_expr_builder.h"
 #include "jni/org_apache_arrow_gandiva_evaluator_JniWrapper.h"
@@ -79,6 +80,13 @@ static jmethodID vector_expander_method_;
 static jfieldID vector_expander_ret_address_;
 static jfieldID vector_expander_ret_capacity_;
 
+static jclass secondary_cache_class_;
+static jmethodID cache_get_method_;
+static jmethodID cache_set_method_;
+static jclass cache_buf_ret_class_;
+static jfieldID cache_buf_ret_address_;
+static jfieldID cache_buf_ret_size_;
+
 // module maps
 gandiva::IdToModuleMap<std::shared_ptr<ProjectorHolder>> projector_modules_;
 gandiva::IdToModuleMap<std::shared_ptr<FilterHolder>> filter_modules_;
@@ -118,6 +126,26 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
       env->GetFieldID(vector_expander_ret_class_, "address", "J");
   vector_expander_ret_capacity_ =
       env->GetFieldID(vector_expander_ret_class_, "capacity", "J");
+
+  jclass local_cache_class =
+      env->FindClass("org/apache/arrow/gandiva/evaluator/JavaSecondaryCacheInterface");
+  secondary_cache_class_ = (jclass)env->NewGlobalRef(local_cache_class);
+  env->DeleteLocalRef(local_expander_ret_class);
+
+  cache_get_method_ = env->GetMethodID(secondary_cache_class_, "getSecondaryCache",
+                                       "(JJ)Lorg/apache/arrow/gandiva/evaluator/"
+                                       "JavaSecondaryCacheInterface$BufferResult;");
+  cache_set_method_ =
+      env->GetMethodID(secondary_cache_class_, "setSecondaryCache", "(JJJJ)V");
+
+  jclass local_cache_ret_class = env->FindClass(
+      "org/apache/arrow/gandiva/evaluator/JavaSecondaryCacheInterface$BufferResult");
+  cache_buf_ret_class_ = (jclass)env->NewGlobalRef(local_cache_ret_class);
+  env->DeleteLocalRef(local_cache_ret_class);
+
+  cache_buf_ret_address_ = env->GetFieldID(cache_buf_ret_class_, "address", "J");
+  cache_buf_ret_size_ = env->GetFieldID(cache_buf_ret_class_, "size", "J");
+
   return JNI_VERSION;
 }
 
@@ -128,6 +156,8 @@ void JNI_OnUnload(JavaVM* vm, void* reserved) {
   env->DeleteGlobalRef(gandiva_exception_);
   env->DeleteGlobalRef(vector_expander_class_);
   env->DeleteGlobalRef(vector_expander_ret_class_);
+  env->DeleteGlobalRef(secondary_cache_class_);
+  env->DeleteGlobalRef(cache_buf_ret_class_);
 }
 
 DataTypePtr ProtoTypeToTime32(const types::ExtGandivaType& ext_type) {
@@ -600,8 +630,50 @@ void releaseProjectorInput(jbyteArray schema_arr, jbyte* schema_bytes,
   env->ReleaseByteArrayElements(exprs_arr, exprs_bytes, JNI_ABORT);
 }
 
+///
+/// \brief Secondary cache class for performing the upcall to java
+///
+class JavaSecondaryCache : public gandiva::SecondaryCacheInterface {
+ public:
+  JavaSecondaryCache(JNIEnv* env, jobject jcache) : env_(env), jcache_(jcache) {}
+
+  // get from the secondary cache using the serialized expression as the key
+  std::shared_ptr<arrow::Buffer> Get(std::shared_ptr<arrow::Buffer> key);
+
+  // create a new entry in the secondary cache using the serialized expression as the key
+  // and object code as the value
+  void Set(std::shared_ptr<arrow::Buffer> key, std::shared_ptr<arrow::Buffer> value);
+
+ private:
+  JNIEnv* env_;
+  jobject jcache_;
+};
+
+std::shared_ptr<arrow::Buffer> JavaSecondaryCache::Get(
+    std::shared_ptr<arrow::Buffer> key) {
+  jobject ret =
+      env_->CallObjectMethod(jcache_, cache_get_method_, key->address(), key->size());
+  if (ret == nullptr) {
+    return nullptr;
+  }
+
+  jlong ret_address = env_->GetLongField(ret, cache_buf_ret_address_);
+  jlong ret_size = env_->GetLongField(ret, cache_buf_ret_size_);
+
+  auto data = std::shared_ptr<arrow::Buffer>(
+      new arrow::Buffer(reinterpret_cast<uint8_t*>(ret_address), ret_size));
+
+  return data;
+}
+
+void JavaSecondaryCache::Set(std::shared_ptr<arrow::Buffer> key,
+                             std::shared_ptr<arrow::Buffer> value) {
+  env_->CallObjectMethod(jcache_, cache_set_method_, key->address(), key->size(),
+                         value->address(), value->size());
+}
+
 JNIEXPORT jlong JNICALL Java_org_apache_arrow_gandiva_evaluator_JniWrapper_buildProjector(
-    JNIEnv* env, jobject obj, jbyteArray schema_arr, jbyteArray exprs_arr,
+    JNIEnv* env, jobject obj, jobject jcache, jbyteArray schema_arr, jbyteArray exprs_arr,
     jint selection_vector_type, jlong configuration_id) {
   jlong module_id = 0LL;
   std::shared_ptr<Projector> projector;
@@ -620,6 +692,12 @@ JNIEXPORT jlong JNICALL Java_org_apache_arrow_gandiva_evaluator_JniWrapper_build
   FieldVector ret_types;
   gandiva::Status status;
   auto mode = gandiva::SelectionVector::MODE_NONE;
+
+  std::shared_ptr<JavaSecondaryCache> sec_cache = nullptr;
+  if (jcache != nullptr) {
+    // enable the secondary cache
+    sec_cache = std::make_shared<JavaSecondaryCache>(env, jcache);
+  }
 
   std::shared_ptr<Configuration> config = ConfigHolder::MapLookup(configuration_id);
   std::stringstream ss;
@@ -675,8 +753,9 @@ JNIEXPORT jlong JNICALL Java_org_apache_arrow_gandiva_evaluator_JniWrapper_build
       mode = gandiva::SelectionVector::MODE_UINT32;
       break;
   }
+
   // good to invoke the evaluator now
-  status = Projector::Make(schema_ptr, expr_vector, mode, config, &projector);
+  status = Projector::Make(schema_ptr, expr_vector, mode, config, sec_cache, &projector);
 
   if (!status.ok()) {
     ss << "Failed to make LLVM module due to " << status.message() << "\n";
@@ -899,8 +978,8 @@ void releaseFilterInput(jbyteArray schema_arr, jbyte* schema_bytes,
 }
 
 JNIEXPORT jlong JNICALL Java_org_apache_arrow_gandiva_evaluator_JniWrapper_buildFilter(
-    JNIEnv* env, jobject obj, jbyteArray schema_arr, jbyteArray condition_arr,
-    jlong configuration_id) {
+    JNIEnv* env, jobject obj, jobject jcache, jbyteArray schema_arr,
+    jbyteArray condition_arr, jlong configuration_id) {
   jlong module_id = 0LL;
   std::shared_ptr<Filter> filter;
   std::shared_ptr<FilterHolder> holder;
@@ -916,6 +995,11 @@ JNIEXPORT jlong JNICALL Java_org_apache_arrow_gandiva_evaluator_JniWrapper_build
   ConditionPtr condition_ptr;
   SchemaPtr schema_ptr;
   gandiva::Status status;
+
+  std::shared_ptr<JavaSecondaryCache> sec_cache = nullptr;
+  if (jcache != nullptr) {
+    sec_cache = std::make_shared<JavaSecondaryCache>(env, jcache);
+  }
 
   std::shared_ptr<Configuration> config = ConfigHolder::MapLookup(configuration_id);
   std::stringstream ss;
@@ -955,7 +1039,7 @@ JNIEXPORT jlong JNICALL Java_org_apache_arrow_gandiva_evaluator_JniWrapper_build
   }
 
   // good to invoke the filter builder now
-  status = Filter::Make(schema_ptr, condition_ptr, config, &filter);
+  status = Filter::Make(schema_ptr, condition_ptr, config, sec_cache, &filter);
   if (!status.ok()) {
     ss << "Failed to make LLVM module due to " << status.message() << "\n";
     releaseFilterInput(schema_arr, schema_bytes, condition_arr, condition_bytes, env);

--- a/cpp/src/gandiva/projector.h
+++ b/cpp/src/gandiva/projector.h
@@ -27,6 +27,7 @@
 #include "gandiva/arrow.h"
 #include "gandiva/configuration.h"
 #include "gandiva/expression.h"
+#include "gandiva/secondary_cache.h"
 #include "gandiva/selection_vector.h"
 #include "gandiva/visibility.h"
 
@@ -77,6 +78,34 @@ class GANDIVA_EXPORT Projector {
                      std::shared_ptr<Configuration> configuration,
                      std::shared_ptr<Projector>* projector);
 
+  /// Build a projector for the given schema to evaluate the vector of expressions.
+  /// Customize the projector with a secondary cache
+  ///
+  /// \param[in] schema schema for the record batches, and the expressions.
+  /// \param[in] exprs vector of expressions.
+  /// \param[in] configuration run time configuration.
+  /// \param[in] sec_cache object to enable jni upcalls.
+  /// \param[out] projector the returned projector object
+  static Status Make(SchemaPtr schema, const ExpressionVector& exprs,
+                     std::shared_ptr<Configuration> configuration,
+                     std::shared_ptr<SecondaryCacheInterface> sec_cache,
+                     std::shared_ptr<Projector>* projector);
+
+  /// Build a projector for the given schema to evaluate the vector of expressions.
+  /// Customize the projector with a secondary cache
+  ///
+  /// \param[in] schema schema for the record batches, and the expressions.
+  /// \param[in] exprs vector of expressions.
+  /// \param[in] selection_vector_mode mode of selection vector
+  /// \param[in] configuration run time configuration.
+  /// \param[in] sec_cache object to enable jni upcalls.
+  /// \param[out] projector the returned projector object
+  static Status Make(SchemaPtr schema, const ExpressionVector& exprs,
+                     SelectionVector::Mode selection_vector_mode,
+                     std::shared_ptr<Configuration> configuration,
+                     std::shared_ptr<SecondaryCacheInterface> sec_cache,
+                     std::shared_ptr<Projector>* projector);
+
   /// Evaluate the specified record batch, and return the allocated and populated output
   /// arrays. The output arrays will be allocated from the memory pool 'pool', and added
   /// to the vector 'output'.
@@ -123,6 +152,8 @@ class GANDIVA_EXPORT Projector {
 
   bool GetBuiltFromCache();
 
+  void Clear();
+
  private:
   Projector(std::unique_ptr<LLVMGenerator> llvm_generator, SchemaPtr schema,
             const FieldVector& output_fields, std::shared_ptr<Configuration>);
@@ -137,6 +168,9 @@ class GANDIVA_EXPORT Projector {
 
   /// Validate the common args for Evaluate() APIs.
   Status ValidateEvaluateArgsCommon(const arrow::RecordBatch& batch);
+
+  // Create an arrow buffer with the key for the secondary cache.
+  static std::shared_ptr<arrow::Buffer> GetSecondaryCacheKey(std::string primaryKey);
 
   std::unique_ptr<LLVMGenerator> llvm_generator_;
   SchemaPtr schema_;

--- a/cpp/src/gandiva/secondary_cache.h
+++ b/cpp/src/gandiva/secondary_cache.h
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "arrow/buffer.h"
+
+namespace gandiva {
+
+// secondary cache c++ interface
+class GANDIVA_EXPORT SecondaryCacheInterface {
+ public:
+  virtual std::shared_ptr<arrow::Buffer> Get(
+      std::shared_ptr<arrow::Buffer> serialized_expr) = 0;
+
+  virtual void Set(std::shared_ptr<arrow::Buffer> serialized_expr,
+                   std::shared_ptr<arrow::Buffer> value) = 0;
+
+  virtual ~SecondaryCacheInterface() {}
+};
+
+}  // namespace gandiva

--- a/cpp/src/gandiva/tests/CMakeLists.txt
+++ b/cpp/src/gandiva/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ add_gandiva_test(null_validity_test)
 add_gandiva_test(decimal_test)
 add_gandiva_test(decimal_single_test)
 add_gandiva_test(filter_project_test)
+add_gandiva_test(secondary_cache_test)
 
 if(ARROW_BUILD_STATIC)
   add_gandiva_test(projector_test_static SOURCES projector_test.cc USE_STATIC_LINKING)

--- a/cpp/src/gandiva/tests/secondary_cache_test.cc
+++ b/cpp/src/gandiva/tests/secondary_cache_test.cc
@@ -1,0 +1,222 @@
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#include "gandiva/filter.h"
+#include "gandiva/projector.h"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include "arrow/memory_pool.h"
+#include "gandiva/literal_holder.h"
+#include "gandiva/node.h"
+#include "gandiva/tests/test_util.h"
+#include "gandiva/tree_expr_builder.h"
+
+namespace gandiva {
+
+using arrow::boolean;
+using arrow::float32;
+using arrow::int32;
+using arrow::int64;
+using arrow::utf8;
+
+// compare the string representation of the arrow buffers
+struct compare {
+  bool operator()(const std::shared_ptr<arrow::Buffer>& lhs,
+                  const std::shared_ptr<arrow::Buffer>& rhs) const {
+    return lhs->ToString().compare(rhs->ToString()) < 0;
+  }
+};
+
+class SecondaryCache : public SecondaryCacheInterface {
+ public:
+  std::shared_ptr<arrow::Buffer> Get(std::shared_ptr<arrow::Buffer> key) {
+    auto it = cache.find(key);
+    if (it != cache.end()) {
+      return it->second;
+    }
+    return nullptr;
+  }
+
+  void Set(std::shared_ptr<arrow::Buffer> key, std::shared_ptr<arrow::Buffer> value) {
+    cache[key] = value;
+  }
+
+ private:
+  std::map<std::shared_ptr<arrow::Buffer>, std::shared_ptr<arrow::Buffer>, compare> cache;
+};
+
+class TestSecondaryCache : public ::testing::Test {
+ public:
+  void SetUp() {
+    pool_ = arrow::default_memory_pool();
+    sec_cache_ = std::make_shared<SecondaryCache>();
+    // Setup arrow log severity threshold to debug level.
+    arrow::util::ArrowLog::StartArrowLog("", arrow::util::ArrowLogLevel::ARROW_DEBUG);
+  }
+
+ protected:
+  arrow::MemoryPool* pool_;
+  std::shared_ptr<SecondaryCache> sec_cache_;
+};
+
+TEST_F(TestSecondaryCache, TestProjectSecCache) {
+  // schema for input fields
+  auto field0 = field("f0", int32());
+  auto field1 = field("f2", int32());
+  auto schema = arrow::schema({field0, field1});
+
+  // output fields
+  auto field_sum = field("add", int32());
+  auto field_sub = field("subtract", int32());
+
+  // Build expression
+  auto sum_expr = TreeExprBuilder::MakeExpression("add", {field0, field1}, field_sum);
+  auto sub_expr =
+      TreeExprBuilder::MakeExpression("subtract", {field0, field1}, field_sub);
+
+  auto configuration = TestConfiguration();
+
+  std::shared_ptr<Projector> projector;
+  auto status = Projector::Make(schema, {sum_expr, sub_expr}, configuration, sec_cache_,
+                                &projector);
+  ASSERT_OK(status);
+  EXPECT_FALSE(projector->GetBuiltFromCache());
+  projector->Clear();
+
+  // everything is same, should return the same projector.
+  auto schema_same = arrow::schema({field0, field1});
+  std::shared_ptr<Projector> cached_projector;
+  status = Projector::Make(schema_same, {sum_expr, sub_expr}, configuration, sec_cache_,
+                           &cached_projector);
+  ASSERT_OK(status);
+  EXPECT_TRUE(cached_projector->GetBuiltFromCache());
+  cached_projector->Clear();
+
+  // schema is different should return a new projector.
+  auto field2 = field("f2", int32());
+  auto different_schema = arrow::schema({field0, field1, field2});
+  std::shared_ptr<Projector> should_be_new_projector;
+  status = Projector::Make(different_schema, {sum_expr, sub_expr}, configuration,
+                           sec_cache_, &should_be_new_projector);
+  ASSERT_OK(status);
+  EXPECT_FALSE(should_be_new_projector->GetBuiltFromCache());
+  should_be_new_projector->Clear();
+
+  // expression list is different should return a new projector.
+  std::shared_ptr<Projector> should_be_new_projector1;
+  status = Projector::Make(schema, {sum_expr}, configuration, sec_cache_,
+                           &should_be_new_projector1);
+  ASSERT_OK(status);
+  EXPECT_FALSE(should_be_new_projector1->GetBuiltFromCache());
+  should_be_new_projector1->Clear();
+
+  // another instance of the same configuration, should return the same projector.
+  status = Projector::Make(schema, {sum_expr, sub_expr}, TestConfiguration(), sec_cache_,
+                           &cached_projector);
+  ASSERT_OK(status);
+  EXPECT_TRUE(cached_projector->GetBuiltFromCache());
+}
+
+TEST_F(TestSecondaryCache, TestProjectCacheDecimalCast) {
+  auto field_float64 = field("float64", arrow::float64());
+  auto schema = arrow::schema({field_float64});
+
+  auto res_31_13 = field("result", arrow::decimal(31, 13));
+  auto expr0 = TreeExprBuilder::MakeExpression("castDECIMAL", {field_float64}, res_31_13);
+  std::shared_ptr<Projector> projector0;
+  ASSERT_OK(
+      Projector::Make(schema, {expr0}, TestConfiguration(), sec_cache_, &projector0));
+  EXPECT_FALSE(projector0->GetBuiltFromCache());
+  projector0->Clear();
+
+  // if the output scale is different, the cache can't be used.
+  auto res_31_14 = field("result", arrow::decimal(31, 14));
+  auto expr1 = TreeExprBuilder::MakeExpression("castDECIMAL", {field_float64}, res_31_14);
+  std::shared_ptr<Projector> projector1;
+  ASSERT_OK(
+      Projector::Make(schema, {expr1}, TestConfiguration(), sec_cache_, &projector1));
+  EXPECT_FALSE(projector1->GetBuiltFromCache());
+  projector1->Clear();
+
+  // if the output scale/precision are same, should get a cache hit.
+  auto res_31_13_alt = field("result", arrow::decimal(31, 13));
+  auto expr2 =
+      TreeExprBuilder::MakeExpression("castDECIMAL", {field_float64}, res_31_13_alt);
+  std::shared_ptr<Projector> projector2;
+  ASSERT_OK(
+      Projector::Make(schema, {expr2}, TestConfiguration(), sec_cache_, &projector2));
+  EXPECT_TRUE(projector2->GetBuiltFromCache());
+}
+
+TEST_F(TestSecondaryCache, TestFilterCache) {
+  // schema for input fields
+  auto field0 = field("f0", int32());
+  auto field1 = field("f1", int32());
+  auto schema = arrow::schema({field0, field1});
+
+  // Build condition f0 + f1 < 10
+  auto node_f0 = TreeExprBuilder::MakeField(field0);
+  auto node_f1 = TreeExprBuilder::MakeField(field1);
+  auto sum_func =
+      TreeExprBuilder::MakeFunction("add", {node_f0, node_f1}, arrow::int32());
+  auto literal_10 = TreeExprBuilder::MakeLiteral((int32_t)10);
+  auto less_than_10 = TreeExprBuilder::MakeFunction("less_than", {sum_func, literal_10},
+                                                    arrow::boolean());
+  auto condition = TreeExprBuilder::MakeCondition(less_than_10);
+  auto configuration = TestConfiguration();
+
+  std::shared_ptr<Filter> filter;
+  auto status = Filter::Make(schema, condition, configuration, sec_cache_, &filter);
+  EXPECT_TRUE(status.ok());
+  EXPECT_FALSE(filter->GetBuiltFromCache());
+  filter->Clear();
+
+  // same schema and condition, should return the same filter as above.
+  std::shared_ptr<Filter> cached_filter;
+  status = Filter::Make(schema, condition, configuration, sec_cache_, &cached_filter);
+  EXPECT_TRUE(status.ok());
+  EXPECT_TRUE(cached_filter->GetBuiltFromCache());
+  cached_filter->Clear();
+
+  // schema is different should return a new filter.
+  auto field2 = field("f2", int32());
+  auto different_schema = arrow::schema({field0, field1, field2});
+  std::shared_ptr<Filter> should_be_new_filter;
+  status = Filter::Make(different_schema, condition, configuration, sec_cache_,
+                        &should_be_new_filter);
+  EXPECT_TRUE(status.ok());
+  EXPECT_FALSE(should_be_new_filter->GetBuiltFromCache());
+
+  // condition is different, should return a new filter.
+  auto greater_than_10 = TreeExprBuilder::MakeFunction(
+      "greater_than", {sum_func, literal_10}, arrow::boolean());
+  auto new_condition = TreeExprBuilder::MakeCondition(greater_than_10);
+  std::shared_ptr<Filter> should_be_new_filter1;
+  status = Filter::Make(schema, new_condition, configuration, sec_cache_,
+                        &should_be_new_filter1);
+  EXPECT_TRUE(status.ok());
+  EXPECT_FALSE(should_be_new_filter->GetBuiltFromCache());
+}
+}  // namespace gandiva

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/JavaSecondaryCacheInterface.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/JavaSecondaryCacheInterface.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.gandiva.evaluator;
+
+/**
+ * Acts as an interface to the secondary cache class that uses a callback
+ * mechanism from gandiva.
+ */
+public interface JavaSecondaryCacheInterface {
+  /**
+   * Resultant buffer of the get call to the secondary cache.
+   */
+  class BufferResult {
+    public long address;
+    public long size;
+
+    public BufferResult(long address, long size) {
+      this.address = address;
+      this.size = size;
+    }
+
+  }
+
+  BufferResult getSecondaryCache(long addr, long size);
+
+  void setSecondaryCache(long addrExpr, long sizeExpr, long addr, long size);
+
+}
+

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/JavaSecondaryCacheInterface.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/JavaSecondaryCacheInterface.java
@@ -36,9 +36,27 @@ public interface JavaSecondaryCacheInterface {
 
   }
 
-  BufferResult getSecondaryCache(long addr, long size);
+  /**
+   * Get from the secondary cache using the key buffer.
+   * @param keyBufAddr address of the key buffer
+   * @param keyBufSize size of the key buffer
+   * @return
+   */
+  BufferResult get(long keyBufAddr, long keyBufSize);
 
-  void setSecondaryCache(long addrExpr, long sizeExpr, long addr, long size);
+  /**
+   * Set the secondary cache with the value in the buffer.
+   * @param keyBufAddr address of the key buffer
+   * @param keyBufSize size of the key buffer
+   * @param valueBufAddr address of the value buffer
+   * @param valueBufSize size of the value buffer
+   */
+  void set(long keyBufAddr, long keyBufSize, long valueBufAddr, long valueBufSize);
+
+  /**
+   * release the buffer associated with the given address.
+   */
+  void releaseBufferResult(long address);
 
 }
 

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/JniWrapper.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/JniWrapper.java
@@ -31,6 +31,7 @@ public class JniWrapper {
    * Generates the projector module to evaluate the expressions with
    * custom configuration.
    *
+   * @param cache       SecondaryCacheInterface object. Used for callbacks from cpp.
    * @param schemaBuf   The schema serialized as a protobuf. See Types.proto
    *                    to see the protobuf specification
    * @param exprListBuf The serialized protobuf of the expression vector. Each
@@ -40,7 +41,7 @@ public class JniWrapper {
    * @return A moduleId that is passed to the evaluateProjector() and closeProjector() methods
    *
    */
-  native long buildProjector(byte[] schemaBuf, byte[] exprListBuf,
+  native long buildProjector(Object cache, byte[] schemaBuf, byte[] exprListBuf,
                              int selectionVectorType,
                              long configId) throws GandivaException;
 
@@ -79,6 +80,7 @@ public class JniWrapper {
    * Generates the filter module to evaluate the condition expression with
    * custom configuration.
    *
+   * @param cache        SecondaryCacheInterface object. Used for callbacks from cpp.
    * @param schemaBuf    The schema serialized as a protobuf. See Types.proto
    *                     to see the protobuf specification
    * @param conditionBuf The serialized protobuf of the condition expression. Each
@@ -87,7 +89,7 @@ public class JniWrapper {
    * @return A moduleId that is passed to the evaluateFilter() and closeFilter() methods
    *
    */
-  native long buildFilter(byte[] schemaBuf, byte[] conditionBuf,
+  native long buildFilter(Object cache, byte[] schemaBuf, byte[] conditionBuf,
                           long configId) throws GandivaException;
 
   /**
@@ -118,3 +120,4 @@ public class JniWrapper {
    */
   native void closeFilter(long moduleId);
 }
+

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/Projector.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/Projector.java
@@ -187,6 +187,45 @@ public class Projector {
   public static Projector make(Schema schema, List<ExpressionTree> exprs,
       SelectionVectorType selectionVectorType,
       long configurationId) throws GandivaException {
+    return make(schema, exprs, selectionVectorType, configurationId, null);
+  }
+    
+  /**
+   * Invoke this function to generate LLVM code to evaluate the list of project expressions.
+   * Invoke Projector::Evaluate() against a RecordBatch to evaluate the record batch
+   * against these projections.
+   *
+   * @param schema         Table schema. The field names in the schema should match the fields used
+   *                       to create the TreeNodes
+   * @param exprs          List of expressions to be evaluated against data
+   * @param configOptions  ConfigOptions parameter
+   * @param secondaryCache SecondaryCache cache for gandiva object code.
+   *
+   * @return A native evaluator object that can be used to invoke these projections on a RecordBatch
+   */
+  public static Projector make(Schema schema, List<ExpressionTree> exprs,
+      ConfigurationBuilder.ConfigOptions configOptions,
+      JavaSecondaryCacheInterface secondaryCache) throws GandivaException {
+    return make(schema, exprs, SelectionVectorType.SV_NONE, JniLoader.getConfiguration(configOptions), secondaryCache);
+  }
+    
+  /**
+   * Invoke this function to generate LLVM code to evaluate the list of project expressions.
+   * Invoke Projector::Evaluate() against a RecordBatch to evaluate the record batch
+   * against these projections.
+   *
+   * @param schema              Table schema. The field names in the schema should match the fields used
+   *                            to create the TreeNodes
+   * @param exprs               List of expressions to be evaluated against data
+   * @param selectionVectorType type of selection vector
+   * @param configurationId     Custom configuration created through config builder.
+   * @param secondaryCache      SecondaryCache cache for gandiva object code.
+   *
+   * @return A native evaluator object that can be used to invoke these projections on a RecordBatch
+   */
+  public static Projector make(Schema schema, List<ExpressionTree> exprs,
+      SelectionVectorType selectionVectorType,
+      long configurationId, JavaSecondaryCacheInterface secondaryCache) throws GandivaException {
     // serialize the schema and the list of expressions as a protobuf
     GandivaTypes.ExpressionList.Builder builder = GandivaTypes.ExpressionList.newBuilder();
     for (ExpressionTree expr : exprs) {
@@ -196,7 +235,7 @@ public class Projector {
     // Invoke the JNI layer to create the LLVM module representing the expressions
     GandivaTypes.Schema schemaBuf = ArrowTypeHelper.arrowSchemaToProtobuf(schema);
     JniWrapper wrapper = JniLoader.getInstance().getWrapper();
-    long moduleId = wrapper.buildProjector(schemaBuf.toByteArray(),
+    long moduleId = wrapper.buildProjector(secondaryCache, schemaBuf.toByteArray(),
         builder.build().toByteArray(), selectionVectorType.getNumber(), configurationId);
     logger.debug("Created module for the projector with id {}", moduleId);
     return new Projector(wrapper, moduleId, schema, exprs.size());

--- a/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorTest.java
+++ b/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorTest.java
@@ -2606,14 +2606,16 @@ public class ProjectorTest extends BaseEvaluatorTest {
       setToCache = false;
     }
 
-    public BufferResult getSecondaryCache(long addrKey, long sizeKey) {
+    public BufferResult get(long addrKey, long sizeKey) {
       gotFromCache = true;
       return null;
     }
 
-    public void setSecondaryCache(long addrKey, long sizeKey, long addrValue, long sizeValue) {
+    public void set(long addrKey, long sizeKey, long addrValue, long sizeValue) {
       setToCache = true;
     }
+
+    public void releaseBufferResult(long address) {}
 
     public boolean gotFromCache;
     public boolean setToCache;


### PR DESCRIPTION
Arrow gandiva has a primary cache but this cache doesn't persist across
restarts. Integrate a new API in project and filter make calls that
allow the user to specify the implementation of the secondary cache by
providing a c++ and java interface to this persistent cache.