### PR TITLE
ARROW-13612: [Python] Allow specifying a custom type for converting ExtensionScalar to python object

### DIFF
--- a/docs/source/python/api/arrays.rst
+++ b/docs/source/python/api/arrays.rst
@@ -127,3 +127,4 @@ classes may expose data type-specific methods or properties.
    MapScalar
    StructScalar
    UnionScalar
+   ExtensionScalar

--- a/docs/source/python/extending_types.rst
+++ b/docs/source/python/extending_types.rst
@@ -304,10 +304,7 @@ method. For example, if we wanted the above example 3D point type to return a cu
             return Point3DType, ()
 
         def scalar_as_py(self, scalar):
-            if scalar is None:
-                return None
-            else:
-                return Point3D(*scalar.as_py())
+            return Point3D(*scalar.as_py())
 
 Arrays built using this extension type now provide scalars that convert to our ``Point3D`` class::
 

--- a/docs/source/python/extending_types.rst
+++ b/docs/source/python/extending_types.rst
@@ -286,6 +286,36 @@ are available).
 The same ``__arrow_ext_class__`` specialization can be used with custom types defined
 by subclassing :class:`ExtensionType`.
 
+Custom scalar conversion
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you want scalars of your custom extension type to convert to a custom type when
+:meth:`ExtensionScalar.as_py()` is called, you can override the :meth:`ExtensionType.scalar_as_py()`
+method. For example, if we wanted the above example 3D point type to return a tuple instead
+of a list, we would implement::
+
+    Point3D = namedtuple("Point3D", ["x", "y", "z"])
+
+    class Point3DType(pa.PyExtensionType):
+        def __init__(self):
+            pa.PyExtensionType.__init__(self, pa.list_(pa.float32(), 3))
+
+        def __reduce__(self):
+            return Point3DType, ()
+
+        def scalar_as_py(self, scalar):
+            if scalar is None:
+                return None
+            else:
+                return Point3D(*scalar.as_py())
+
+Arrays built using this extension scalar type now have the expected scalar behaviour::
+
+    >>> storage = pa.array([[1, 2, 3], [4, 5, 6]], pa.list_(pa.float32(), 3))
+    >>> arr = pa.ExtensionArray.from_storage(Point3DType(), storage)
+    >>> arr[0].as_py()
+    Point3D(x=1.0, y=2.0, z=3.0)
+
 
 Conversion to pandas
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/python/extending_types.rst
+++ b/docs/source/python/extending_types.rst
@@ -303,7 +303,7 @@ method. For example, if we wanted the above example 3D point type to return a cu
         def __reduce__(self):
             return Point3DType, ()
 
-        def scalar_as_py(self, scalar):
+        def scalar_as_py(self, scalar: ListScalar) -> Point3D:
             return Point3D(*scalar.as_py())
 
 Arrays built using this extension type now provide scalars that convert to our ``Point3D`` class::

--- a/docs/source/python/extending_types.rst
+++ b/docs/source/python/extending_types.rst
@@ -303,7 +303,7 @@ method. For example, if we wanted the above example 3D point type to return a cu
         def __reduce__(self):
             return Point3DType, ()
 
-        def scalar_as_py(self, scalar: ListScalar) -> Point3D:
+        def scalar_as_py(self, scalar: pa.ListScalar) -> Point3D:
             return Point3D(*scalar.as_py())
 
 Arrays built using this extension type now provide scalars that convert to our ``Point3D`` class::
@@ -312,6 +312,9 @@ Arrays built using this extension type now provide scalars that convert to our `
     >>> arr = pa.ExtensionArray.from_storage(Point3DType(), storage)
     >>> arr[0].as_py()
     Point3D(x=1.0, y=2.0, z=3.0)
+
+    >>> arr.to_pylist()
+    [Point3D(x=1.0, y=2.0, z=3.0), Point3D(x=4.0, y=5.0, z=6.0)]
 
 
 Conversion to pandas

--- a/docs/source/python/extending_types.rst
+++ b/docs/source/python/extending_types.rst
@@ -291,8 +291,8 @@ Custom scalar conversion
 
 If you want scalars of your custom extension type to convert to a custom type when
 :meth:`ExtensionScalar.as_py()` is called, you can override the :meth:`ExtensionType.scalar_as_py()`
-method. For example, if we wanted the above example 3D point type to return a tuple instead
-of a list, we would implement::
+method. For example, if we wanted the above example 3D point type to return a custom
+3D point class instead of a list, we would implement::
 
     Point3D = namedtuple("Point3D", ["x", "y", "z"])
 
@@ -309,7 +309,7 @@ of a list, we would implement::
             else:
                 return Point3D(*scalar.as_py())
 
-Arrays built using this extension scalar type now have the expected scalar behaviour::
+Arrays built using this extension type now provide scalars that convert to our ``Point3D`` class::
 
     >>> storage = pa.array([[1, 2, 3], [4, 5, 6]], pa.list_(pa.float32(), 3))
     >>> arr = pa.ExtensionArray.from_storage(Point3DType(), storage)

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -896,7 +896,10 @@ cdef class ExtensionScalar(Scalar):
         """
         Return this scalar as a Python object.
         """
-        return self.type.scalar_as_py(self.value)
+        if self.value is None:
+            return None
+        else:
+            return self.type.scalar_as_py(self.value)
 
     @staticmethod
     def from_storage(BaseExtensionType typ, value):

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -896,9 +896,7 @@ cdef class ExtensionScalar(Scalar):
         """
         Return this scalar as a Python object.
         """
-        # XXX should there be a hook to wrap the result in a custom class?
-        value = self.value
-        return None if value is None else value.as_py()
+        return self.type.scalar_as_py(self.value)
 
     @staticmethod
     def from_storage(BaseExtensionType typ, value):

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -17,6 +17,7 @@
 
 import pickle
 import weakref
+from uuid import uuid4, UUID
 
 import numpy as np
 import pyarrow as pa
@@ -40,6 +41,12 @@ class UuidType(pa.PyExtensionType):
 
     def __reduce__(self):
         return UuidType, ()
+
+    def scalar_as_py(self, scalar):
+        if scalar is not None:
+            return UUID(bytes=scalar.as_py())
+        else:
+            return None
 
 
 class ParamExtType(pa.PyExtensionType):
@@ -133,6 +140,38 @@ def test_ext_type__storage_type():
     ty = ParamExtType(5)
     assert ty.storage_type == pa.binary(5)
     assert ty.__class__ is ParamExtType
+
+
+def test_ext_type_as_py():
+    ty = UuidType()
+    expected = uuid4()
+    scalar = pa.ExtensionScalar.from_storage(ty, expected.bytes)
+    assert scalar.as_py() == expected
+
+    # test array
+    uuids = [uuid4() for _ in range(3)]
+    storage = pa.array([uuid.bytes for uuid in uuids], type=pa.binary(16))
+    arr = pa.ExtensionArray.from_storage(ty, storage)
+
+    # Works for __get_item__
+    for i, expected in enumerate(uuids):
+        assert arr[i].as_py() == expected
+
+    # Works for __iter__
+    for result, expected in zip(arr, uuids):
+        assert result.as_py() == expected
+
+    # test chunked array
+    data = [
+        pa.ExtensionArray.from_storage(ty, storage),
+        pa.ExtensionArray.from_storage(ty, storage)
+    ]
+    carr = pa.chunked_array(data)
+    for i, expected in enumerate(uuids + uuids):
+        assert carr[i].as_py() == expected
+
+    for result, expected in zip(carr, uuids + uuids):
+        assert result.as_py() == expected
 
 
 def test_uuid_type_pickle():
@@ -261,16 +300,19 @@ def test_ext_scalar_from_array():
         assert s.type == ty1
         if val is not None:
             assert s.value == pa.scalar(val, storage.type)
+            assert s.as_py() == UUID(bytes=val)
         else:
             assert s.value is None
-        assert s.as_py() == val
 
     scalars_b = list(b)
     assert len(scalars_b) == 4
 
     for sa, sb in zip(scalars_a, scalars_b):
         assert sa.is_valid == sb.is_valid
-        assert sa.as_py() == sb.as_py()
+        if sa.as_py() is None:
+            assert sa.as_py() == sb.as_py()
+        else:
+            assert sa.as_py().bytes == sb.as_py()
         assert sa != sb
 
 

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -43,10 +43,7 @@ class UuidType(pa.PyExtensionType):
         return UuidType, ()
 
     def scalar_as_py(self, scalar):
-        if scalar is not None:
-            return UUID(bytes=scalar.as_py())
-        else:
-            return None
+        return UUID(bytes=scalar.as_py())
 
 
 class ParamExtType(pa.PyExtensionType):

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -45,6 +45,7 @@ class UuidType(pa.PyExtensionType):
     def scalar_as_py(self, scalar):
         return UUID(bytes=scalar.as_py())
 
+
 class UuidType2(pa.PyExtensionType):
 
     def __init__(self):

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -907,7 +907,7 @@ cdef class ExtensionType(BaseExtensionType):
 
         This method can be overridden in subclasses to customize what type
         scalars are converted to. Implementations should handle the case
-        where the scalar argument is None."""
+        where the scalar argument is ``None``."""
         return scalar.as_py() if scalar is not None else None
 
 cdef class PyExtensionType(ExtensionType):

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -910,8 +910,8 @@ cdef class ExtensionType(BaseExtensionType):
 
         Parameters
         ----------
-        scalar : pyarrow.ExtensionScalar
-          The scalar to be converted to a Python object.
+        scalar : pyarrow.Scalar
+          Not-None Scalar of storage type to be converted to a Python object.
 
         Returns
         -------

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -908,7 +908,7 @@ cdef class ExtensionType(BaseExtensionType):
         This method can be overridden in subclasses to customize what type
         scalars are converted to. Implementations should handle the case
         where the scalar argument is ``None``.
-        
+
         Parameters
         ----------
         scalar : pyarrow.ExtensionScalar or None

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -912,8 +912,12 @@ cdef class ExtensionType(BaseExtensionType):
         ----------
         scalar : pyarrow.ExtensionScalar
           The scalar to be converted to a Python object.
+
+        Returns
+        -------
+        Scalar value as a native Python object.
         """
-        return scalar.as_py() if scalar is not None else None
+        return scalar.as_py()
 
 cdef class PyExtensionType(ExtensionType):
     """

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -907,7 +907,13 @@ cdef class ExtensionType(BaseExtensionType):
 
         This method can be overridden in subclasses to customize what type
         scalars are converted to. Implementations should handle the case
-        where the scalar argument is ``None``."""
+        where the scalar argument is ``None``.
+        
+        Parameters
+        ----------
+        scalar : pyarrow.ExtensionScalar or None
+          The scalar to be converted to a Python object.
+        """
         return scalar.as_py() if scalar is not None else None
 
 cdef class PyExtensionType(ExtensionType):

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -906,12 +906,11 @@ cdef class ExtensionType(BaseExtensionType):
         """Convert scalar to a Python type.
 
         This method can be overridden in subclasses to customize what type
-        scalars are converted to. Implementations should handle the case
-        where the scalar argument is ``None``.
+        scalars are converted to.
 
         Parameters
         ----------
-        scalar : pyarrow.ExtensionScalar or None
+        scalar : pyarrow.ExtensionScalar
           The scalar to be converted to a Python object.
         """
         return scalar.as_py() if scalar is not None else None

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -902,6 +902,13 @@ cdef class ExtensionType(BaseExtensionType):
         """
         return ExtensionArray
 
+    def scalar_as_py(self, scalar):
+        """Convert scalar to a Python type.
+
+        This method can be overridden in subclasses to customize what type
+        scalars are converted to. Implementations should handle the case
+        where the scalar argument is None."""
+        return scalar.as_py() if scalar is not None else None
 
 cdef class PyExtensionType(ExtensionType):
     """


### PR DESCRIPTION
This is to resolve [ARROW-13612](https://issues.apache.org/jira/browse/ARROW-13612).