### PR TITLE
ARROW-16864: [Python] Allow omitting S3 external_id and session_name with role_arn

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -381,13 +381,21 @@ Result<S3Options> S3Options::FromUri(const std::string& uri_string,
 }
 
 bool S3Options::Equals(const S3Options& other) const {
+  const int64_t default_metadata_size = default_metadata ? default_metadata->size() : 0;
+  const bool default_metadata_equals =
+      default_metadata_size
+          ? (other.default_metadata && other.default_metadata->Equals(*default_metadata))
+          : (!other.default_metadata || other.default_metadata->size() == 0);
   return (region == other.region && endpoint_override == other.endpoint_override &&
-          scheme == other.scheme && background_writes == other.background_writes &&
+          scheme == other.scheme && role_arn == other.role_arn &&
+          session_name == other.session_name && external_id == other.external_id &&
+          load_frequency == other.load_frequency &&
+          proxy_options.Equals(other.proxy_options) &&
+          credentials_kind == other.credentials_kind &&
+          background_writes == other.background_writes &&
           allow_bucket_creation == other.allow_bucket_creation &&
           allow_bucket_deletion == other.allow_bucket_deletion &&
-          credentials_kind == other.credentials_kind &&
-          proxy_options.Equals(other.proxy_options) &&
-          GetAccessKey() == other.GetAccessKey() &&
+          default_metadata_equals && GetAccessKey() == other.GetAccessKey() &&
           GetSecretKey() == other.GetSecretKey() &&
           GetSessionToken() == other.GetSessionToken());
 }

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -116,7 +116,7 @@ struct ARROW_EXPORT S3Options {
   /// Optional external idenitifer to pass to STS when assuming a role
   std::string external_id;
   /// Frequency (in seconds) to refresh temporary credentials from assumed role
-  int load_frequency;
+  int load_frequency = 900;
 
   /// If connection is through a proxy, set options here
   S3ProxyOptions proxy_options;

--- a/python/pyarrow/_s3fs.pyx
+++ b/python/pyarrow/_s3fs.pyx
@@ -234,6 +234,10 @@ cdef class S3FileSystem(FileSystem):
 
             options = CS3Options.Anonymous()
         elif role_arn:
+            if session_name is None:
+                session_name = ''
+            if external_id is None:
+                external_id = ''
 
             options = CS3Options.FromAssumeRole(
                 tobytes(role_arn),

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -1107,15 +1107,25 @@ def test_s3_options():
     assert isinstance(fs, S3FileSystem)
     assert pickle.loads(pickle.dumps(fs)) == fs
 
+    fs2 = S3FileSystem(role_arn='role')
+    assert isinstance(fs2, S3FileSystem)
+    assert pickle.loads(pickle.dumps(fs2)) == fs2
+    assert fs2 != fs
+
     fs = S3FileSystem(anonymous=True)
     assert isinstance(fs, S3FileSystem)
     assert pickle.loads(pickle.dumps(fs)) == fs
 
-    fs = S3FileSystem(background_writes=True,
-                      default_metadata={"ACL": "authenticated-read",
-                                        "Content-Type": "text/plain"})
+    fs = S3FileSystem(background_writes=True)
     assert isinstance(fs, S3FileSystem)
     assert pickle.loads(pickle.dumps(fs)) == fs
+
+    fs2 = S3FileSystem(background_writes=True,
+                       default_metadata={"ACL": "authenticated-read",
+                                         "Content-Type": "text/plain"})
+    assert isinstance(fs2, S3FileSystem)
+    assert pickle.loads(pickle.dumps(fs2)) == fs2
+    assert fs2 != fs
 
     fs = S3FileSystem(allow_bucket_creation=True, allow_bucket_deletion=True)
     assert isinstance(fs, S3FileSystem)


### PR DESCRIPTION
Both external_id and session_name are optional parameters when an Assume Role authentication is requested, but omitting them would raise an error.