### PR TITLE
ARROW-16935: [Packaging][RPM] Disable GCS for Amazon Linux 2

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
+++ b/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
@@ -58,7 +58,7 @@
 # TODO: Enable this on aarch64 too. This causes timeout on Travis CI.
 %define use_flight (%{rhel} >= 8 && "%{_arch}" != "aarch64")
 %define use_gandiva (%{rhel} >= 8 && "%{_arch}" != "aarch64")
-%define use_gcs (%{rhel} >= 8 || %{is_amazon_linux})
+%define use_gcs (%{rhel} >= 8)
 %define use_gflags (!%{is_amazon_linux})
 %define use_glog (%{rhel} <= 8)
 %define use_mimalloc (%{rhel} >= 8)


### PR DESCRIPTION
Because it hits an RPM bug:
https://bugzilla.redhat.com/show_bug.cgi?id=304121

It was fixed in RPM 4.14.0 by
https://github.com/rpm-software-management/rpm/commit/88989572fff1f31e0c4f972a6895585e4742ef4b
but Amazon Linux 2 ships 4.11.3.

This is caused by the latest Google Cloud C++ SDK updated by
ARROW-16510.