### PR TITLE
ARROW-16943: [Java][Packaging] Fix nigthly build problem that generates excessive jars

### DIFF
--- a/ci/scripts/java_full_build.sh
+++ b/ci/scripts/java_full_build.sh
@@ -26,6 +26,13 @@ export ARROW_TEST_DATA=${arrow_dir}/testing/data
 
 pushd ${arrow_dir}/java
 
+# Ensure that there is no old jar
+# inside the maven repository
+find ~/.m2/repository/org/apache/arrow \
+     "(" -name "*.jar" -o -name "*.zip" -o -name "*.pom" ")" \
+     -exec echo {} ";" \
+     -exec rm -rf {} ";"
+
 # generate dummy GPG key for -Papache-release.
 # -Papache-release generates signs (*.asc) of artifacts.
 # We don't use these signs in our release process.


### PR DESCRIPTION
Since June 24 the nightly build is generating multiple jars for the same module.

In that example: https://github.com/ursacomputing/crossbow/releases/tag/nightly-packaging-2022-06-24-0-github-java-jars you can find three different jars for the arrow-gandiva.

The commit purpose is clean the .m2 folder before executing the clean install command and copy the artifacts to the folder where they will be uploaded.