### PR TITLE
ARROW-16948: [C++] Benchmark Aggregates Fails To Compile After Aggregate Updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "cpp/submodules/parquet-testing"]
 	path = cpp/submodules/parquet-testing
 	url = https://github.com/apache/parquet-testing.git
+[submodule "testing"]
+	path = testing
+	url = https://github.com/apache/arrow-testing

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "cpp/submodules/parquet-testing"]
 	path = cpp/submodules/parquet-testing
 	url = https://github.com/apache/parquet-testing.git
-[submodule "testing"]
-	path = testing
-	url = https://github.com/apache/arrow-testing

--- a/cpp/src/arrow/compute/kernels/aggregate_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_benchmark.cc
@@ -308,6 +308,9 @@ BENCHMARK_TEMPLATE(ReferenceSum, SumBitmapVectorizeUnroll<int64_t>)
 
 using arrow::compute::internal::GroupBy;
 
+// The internal function GroupBy simulates an aggregate node and
+// doesn't need a target or name.  This helper class allows us to
+// just specify the fields we need and make up a dummy target / name.
 struct BenchmarkAggregate {
   std::string function;
   std::shared_ptr<FunctionOptions> options;

--- a/cpp/src/arrow/compute/kernels/aggregate_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_benchmark.cc
@@ -314,17 +314,17 @@ struct BenchmarkAggregate {
 };
 
 static void BenchmarkGroupBy(benchmark::State& state,
-                             std::vector<BenchmarkAggregate> aggregates,
+                             std::vector<BenchmarkAggregate> bench_aggregates,
                              std::vector<Datum> arguments, std::vector<Datum> keys) {
-  std::vector<Aggregate> c_aggregates;
-  c_aggregates.reserve(aggregates.size());
+  std::vector<Aggregate> aggregates;
+  aggregates.reserve(bench_aggregates.size());
   int idx = 0;
-  for (const auto& b_agg : aggregates) {
-    c_aggregates[idx] = {b_agg.function, std::move(b_agg.options),
-                         "agg_" + std::to_string(idx), b_agg.function};
+  for (const auto& b_agg : bench_aggregates) {
+    aggregates.push_back({b_agg.function, std::move(b_agg.options),
+                          "agg_" + std::to_string(idx++), b_agg.function});
   }
   for (auto _ : state) {
-    ABORT_NOT_OK(GroupBy(arguments, keys, c_aggregates).status());
+    ABORT_NOT_OK(GroupBy(arguments, keys, aggregates).status());
   }
 }
 

--- a/cpp/src/arrow/compute/kernels/aggregate_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_benchmark.cc
@@ -320,8 +320,8 @@ static void BenchmarkGroupBy(benchmark::State& state,
   c_aggregates.reserve(aggregates.size());
   int idx = 0;
   for (const auto& b_agg : aggregates) {
-    c_aggregates[idx] = {b_agg.function, b_agg.options, "agg_" + std::to_string(idx),
-                         b_agg.function};
+    c_aggregates[idx] = {b_agg.function, std::move(b_agg.options),
+                         "agg_" + std::to_string(idx), b_agg.function};
   }
   for (auto _ : state) {
     ABORT_NOT_OK(GroupBy(arguments, keys, c_aggregates).status());


### PR DESCRIPTION
This PR is a FIX for compilation issue in `aggregate_benchmark.cc` and possibly didn't covered by my previous PR on Aggregate simplification (https://issues.apache.org/jira/browse/ARROW-16549). 

PS: This wasn't compiled on Mac M1. In addition also think there could be a CI improvement that can be later on added to cover this. Open for discussion.