### PR TITLE
MINOR: [Docs] Fix typo in python.rst

### DIFF
--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -309,7 +309,7 @@ created above (stored in ``$ARROW_HOME``):
    $ make install
    $ popd
 
-There are a number of optional components that can can be switched ON by
+There are a number of optional components that can be switched ON by
 adding flags with ``ON``:
 
 * ``ARROW_CUDA``: Support for CUDA-enabled GPUs


### PR DESCRIPTION
Fix description in "Build and Test" section of python.rst.