### PR TITLE
MINOR: [C++] Aggregate doc fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "cpp/submodules/parquet-testing"]
 	path = cpp/submodules/parquet-testing
 	url = https://github.com/apache/parquet-testing.git
+[submodule "testing"]
+	path = testing
+	url = https://github.com/apache/arrow-testing

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "cpp/submodules/parquet-testing"]
 	path = cpp/submodules/parquet-testing
 	url = https://github.com/apache/parquet-testing.git
-[submodule "testing"]
-	path = testing
-	url = https://github.com/apache/arrow-testing

--- a/cpp/src/arrow/compute/api_aggregate.h
+++ b/cpp/src/arrow/compute/api_aggregate.h
@@ -184,6 +184,21 @@ class ARROW_EXPORT IndexOptions : public FunctionOptions {
   std::shared_ptr<Scalar> value;
 };
 
+/// \brief Configure a grouped aggregation
+struct ARROW_EXPORT Aggregate {
+  /// the name of the aggregation function
+  std::string function;
+
+  /// options for the aggregation function
+  std::shared_ptr<FunctionOptions> options;
+
+  // fields to which aggregations will be applied
+  FieldRef target;
+
+  // output field name for aggregations
+  std::string name;
+};
+
 /// @}
 
 /// \brief Count values in an array.
@@ -392,21 +407,6 @@ Result<Datum> TDigest(const Datum& value,
 ARROW_EXPORT
 Result<Datum> Index(const Datum& value, const IndexOptions& options,
                     ExecContext* ctx = NULLPTR);
-
-/// \brief Configure a grouped aggregation
-struct ARROW_EXPORT Aggregate {
-  /// the name of the aggregation function
-  std::string function;
-
-  /// options for the aggregation function
-  std::shared_ptr<FunctionOptions> options;
-
-  // fields to which aggregations will be applied
-  FieldRef target;
-
-  // output field name for aggregations
-  std::string name;
-};
 
 }  // namespace compute
 }  // namespace arrow


### PR DESCRIPTION
The `Aggregate` was exposed to the user, but the docs weren't properly fixed to reflect that. Adding that minor change in this PR.