### PR TITLE
ARROW-16477: [Packaging][deb] Use -Dvapi instead of -Dvala

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow/debian/rules
+++ b/dev/tasks/linux-packages/apache-arrow/debian/rules
@@ -76,7 +76,7 @@ override_dh_auto_build:
 	  -Darrow_cpp_build_type=$(BUILD_TYPE)		\
 	  -Darrow_cpp_build_dir=../cpp_build		\
 	  -Dgtk_doc=true				\
-	  -Dvala=true
+	  -Dvapi=true
 	env							\
 	  LD_LIBRARY_PATH=$(CURDIR)/cpp_build/$(BUILD_TYPE)	\
 	    dh_auto_build					\


### PR DESCRIPTION
This is a follow-up of ARROW-16477/#13473.

We should have updated option name of Apache Arrow GLib for .deb too.