### PR TITLE
ARROW-16695: [R][Python][C++] Extension types are not supported in joins

### DIFF
--- a/cpp/src/arrow/compute/exec/hash_join_node.cc
+++ b/cpp/src/arrow/compute/exec/hash_join_node.cc
@@ -45,6 +45,9 @@ bool HashJoinSchema::IsTypeSupported(const DataType& type) {
   if (id == Type::DICTIONARY) {
     return IsTypeSupported(*checked_cast<const DictionaryType&>(type).value_type());
   }
+  if (id == Type::EXTENSION) {
+    return IsTypeSupported(*checked_cast<const ExtensionType&>(type).storage_type());
+  }
   return is_fixed_width(id) || is_binary_like(id) || is_large_binary_like(id);
 }
 

--- a/cpp/src/arrow/compute/exec/hash_join_node_test.cc
+++ b/cpp/src/arrow/compute/exec/hash_join_node_test.cc
@@ -1831,10 +1831,10 @@ TEST(HashJoin, ExtensionTypes) {
                            {l_int_arr, bin_arr}, {r_int_arr, ext_arr}, 4, 4));
   ASSERT_OK_AND_ASSIGN(auto output_rows_test,
                        TableFromExecBatches(output_schema, batches));
-  auto table =
+  auto expected_table =
       arrow::Table::Make(output_schema, {l_int_arr, bin_arr, r_int_arr, ext_arr}, 4);
 
-  AssertTablesEqual(*table, *output_rows_test, /*same_chunk_layout=*/false,
+  AssertTablesEqual(*expected_table, *output_rows_test, /*same_chunk_layout=*/false,
                     /*flatten=*/true);
 }
 

--- a/cpp/src/arrow/compute/kernels/row_encoder.cc
+++ b/cpp/src/arrow/compute/kernels/row_encoder.cc
@@ -259,7 +259,13 @@ void RowEncoder::Init(const std::vector<TypeHolder>& column_types, ExecContext* 
   encoders_.resize(column_types.size());
 
   for (size_t i = 0; i < column_types.size(); ++i) {
-    const TypeHolder& type = column_types[i];
+    const bool is_extension = column_types[i].id() == Type::EXTENSION;
+    const TypeHolder& type = is_extension
+                                 ? arrow::internal::checked_pointer_cast<ExtensionType>(
+                                       column_types[i].GetSharedPtr())
+                                       ->storage_type()
+                                 : column_types[i];
+
     if (type.id() == Type::BOOL) {
       encoders_[i] = std::make_shared<BooleanKeyEncoder>();
       continue;

--- a/cpp/src/arrow/compute/kernels/row_encoder.cc
+++ b/cpp/src/arrow/compute/kernels/row_encoder.cc
@@ -257,6 +257,7 @@ Result<std::shared_ptr<ArrayData>> DictionaryKeyEncoder::Decode(uint8_t** encode
 void RowEncoder::Init(const std::vector<TypeHolder>& column_types, ExecContext* ctx) {
   ctx_ = ctx;
   encoders_.resize(column_types.size());
+  extension_types_.resize(column_types.size());
 
   for (size_t i = 0; i < column_types.size(); ++i) {
     const bool is_extension = column_types[i].id() == Type::EXTENSION;
@@ -266,6 +267,10 @@ void RowEncoder::Init(const std::vector<TypeHolder>& column_types, ExecContext* 
                                        ->storage_type()
                                  : column_types[i];
 
+    if (is_extension) {
+      extension_types_[i] = arrow::internal::checked_pointer_cast<ExtensionType>(
+          column_types[i].GetSharedPtr());
+    }
     if (type.id() == Type::BOOL) {
       encoders_[i] = std::make_shared<BooleanKeyEncoder>();
       continue;
@@ -360,9 +365,16 @@ Result<ExecBatch> RowEncoder::Decode(int64_t num_rows, const int32_t* row_ids) {
   out.values.resize(encoders_.size());
   for (size_t i = 0; i < encoders_.size(); ++i) {
     ARROW_ASSIGN_OR_RAISE(
-        out.values[i],
+        auto column_array_data,
         encoders_[i]->Decode(buf_ptrs.data(), static_cast<int32_t>(num_rows),
                              ctx_->memory_pool()));
+
+    if (extension_types_[i] != nullptr) {
+      ARROW_ASSIGN_OR_RAISE(out.values[i], ::arrow::internal::GetArrayView(
+                                               column_array_data, extension_types_[i]))
+    } else {
+      out.values[i] = column_array_data;
+    }
   }
 
   return out;

--- a/cpp/src/arrow/compute/kernels/row_encoder.h
+++ b/cpp/src/arrow/compute/kernels/row_encoder.h
@@ -280,6 +280,7 @@ class ARROW_EXPORT RowEncoder {
   std::vector<int32_t> offsets_;
   std::vector<uint8_t> bytes_;
   std::vector<uint8_t> encoded_nulls_;
+  std::vector<std::shared_ptr<ExtensionType>> extension_types_;
 };
 
 }  // namespace internal

--- a/python/pyarrow/tests/test_exec_plan.py
+++ b/python/pyarrow/tests/test_exec_plan.py
@@ -18,6 +18,7 @@
 import pytest
 import pyarrow as pa
 import pyarrow.compute as pc
+from .test_extension_type import IntegerType
 
 try:
     import pyarrow.dataset as ds
@@ -26,24 +27,6 @@ except ImportError:
     pass
 
 pytestmark = pytest.mark.dataset
-
-
-class UuidType(pa.PyExtensionType):
-
-    def __init__(self):
-        pa.PyExtensionType.__init__(self, pa.binary(16))
-
-    def __reduce__(self):
-        return UuidType, ()
-
-
-class TestType(pa.PyExtensionType):
-
-    def __init__(self):
-        pa.PyExtensionType.__init__(self, pa.int64())
-
-    def __reduce__(self):
-        return pa.int64, ()
 
 
 def test_joins_corner_cases():
@@ -302,7 +285,7 @@ def test_complex_filter_table():
 
 def test_join_extension_array_column():
     storage = pa.array([1, 2, 3], type=pa.int64())
-    ty = TestType()
+    ty = IntegerType()
     ext_array = pa.ExtensionArray.from_storage(ty, storage)
     t1 = pa.table({
         "colA": [1, 2, 6],

--- a/python/pyarrow/tests/test_exec_plan.py
+++ b/python/pyarrow/tests/test_exec_plan.py
@@ -287,6 +287,8 @@ def test_join_extension_array_column():
     storage = pa.array([1, 2, 3], type=pa.int64())
     ty = IntegerType()
     ext_array = pa.ExtensionArray.from_storage(ty, storage)
+    dict_array = pa.DictionaryArray.from_arrays(
+        pa.array([0, 2, 1]), pa.array(['a', 'b', 'c']))
     t1 = pa.table({
         "colA": [1, 2, 6],
         "colB": ext_array,
@@ -298,10 +300,24 @@ def test_join_extension_array_column():
         "colC": ext_array,
     })
 
+    t3 = pa.table({
+        "colA": [99, 2, 1],
+        "colC": ext_array,
+        "colD": dict_array,
+    })
+
     result = ep._perform_join(
         "left outer", t1, ["colA"], t2, ["colA"])
     assert result["colVals"] == pa.chunked_array(ext_array)
 
     result = ep._perform_join(
         "left outer", t1, ["colB"], t2, ["colC"])
+    assert result["colB"] == pa.chunked_array(ext_array)
+
+    result = ep._perform_join(
+        "left outer", t1, ["colA"], t3, ["colA"])
+    assert result["colVals"] == pa.chunked_array(ext_array)
+
+    result = ep._perform_join(
+        "left outer", t1, ["colB"], t3, ["colC"])
     assert result["colB"] == pa.chunked_array(ext_array)


### PR DESCRIPTION
This is to resolve [ARROW-16695](https://issues.apache.org/jira/browse/ARROW-16695).