### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/archery.yml
+++ b/.github/workflows/archery.yml
@@ -35,6 +35,9 @@ concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
 
   test:

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -51,6 +51,9 @@ env:
   ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
   ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
   docker:
     name: ${{ matrix.title }}

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -33,6 +33,9 @@ concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
 
   ubuntu:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -30,6 +30,9 @@ env:
   ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
   ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
 
   lint:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,9 @@ env:
   ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
   ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
 
   complete:

--- a/.github/workflows/docs_light.yml
+++ b/.github/workflows/docs_light.yml
@@ -34,6 +34,9 @@ env:
   ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
   ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
 
   light:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -40,6 +40,9 @@ env:
   ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
   ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
 
   docker:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -50,6 +50,9 @@ env:
   ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
   ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
 
   docker:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -44,6 +44,9 @@ env:
   ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
   ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
 
   debian:

--- a/.github/workflows/java_jni.yml
+++ b/.github/workflows/java_jni.yml
@@ -44,6 +44,9 @@ env:
   ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
   ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
 
   docker:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -39,6 +39,9 @@ env:
   ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
   ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
 
   docker:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -40,6 +40,9 @@ env:
   ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
   ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
 
   docker:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -52,6 +52,9 @@ env:
   ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
   ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
 
   ubuntu:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
