### PR TITLE
ARROW-16653: [R] All formats are supported with the lubridate `parse_date_time` binding

### DIFF
--- a/r/R/dplyr-datetime-helpers.R
+++ b/r/R/dplyr-datetime-helpers.R
@@ -186,7 +186,7 @@ build_formats <- function(orders) {
   orders <- unique(orders)
 
   formats_list <- map(orders, build_format_from_order)
-  formats_length <- map(map(formats_list, nchar), max)
+  formats_length <- map_int(map_int(formats_list, nchar), max)
   invalid_orders <- formats_length < 6
 
   if (any(invalid_orders)) {
@@ -215,9 +215,9 @@ build_formats <- function(orders) {
 build_format_from_order <- function(order) {
   char_list <- list(
     "%T" = "%H-%M-%S",
-    "%y" = c("%y", "%Y"),
-    "%m" = c("%m", "%B", "%b"),
-    "%b" = c("%m", "%B", "%b")
+    "%y" = "%y", "%Y",
+    "%m" = "%m", "%B", "%b",
+    "%b" = "%m", "%B", "%b"
   )
 
   formats <- regmatches(order, gregexpr("(O{0,1}[a-zA-Z])", order))[[1]]

--- a/r/R/dplyr-datetime-helpers.R
+++ b/r/R/dplyr-datetime-helpers.R
@@ -164,8 +164,11 @@ build_formats <- function(orders) {
   # Processing is needed (instead of passing
   # formats as-is) due to the processing of the character vector in parse_date_time()
 
+  orders <- gsub("[^A-Za-z]", "", orders)
+  orders <- gsub("Y", "y", orders)
+
   valid_formats <- "[a|A|b|B|d|H|I|j|m|Om|M|Op|p|q|OS|S|U|w|W|y|Y|r|R|T|z]"
-  invalid_orders <- !grepl(valid_formats, orders)
+  invalid_orders <- nchar(gsub(valid_formats, "", orders)) > 0
 
   if (any(invalid_orders)) {
     arrow_not_supported(
@@ -177,9 +180,6 @@ build_formats <- function(orders) {
       )
     )
   }
-
-  orders <- gsub("[^A-Za-z]", "", orders)
-  orders <- gsub("Y", "y", orders)
 
   # we separate "ym', "my", and "yq" from the rest of the `orders` vector and
   # transform them. `ym` and `yq` -> `ymd` & `my` -> `myd`
@@ -238,6 +238,7 @@ build_format_from_order <- function(order) {
     "%w" = "%w",
     "%W" = "%W",
     "%p" = "%p",
+    "%Op" = "%Op",
     "%z" = "%z",
     "%r" = c("%H", "%I-%p"),
     "%R" = c("%H-%M", "%I-%M-%p"),

--- a/r/R/dplyr-datetime-helpers.R
+++ b/r/R/dplyr-datetime-helpers.R
@@ -220,7 +220,7 @@ build_format_from_order <- function(order) {
     "%b" = c("%m", "%B", "%b")
   )
 
-  formats <- stringr::str_extract_all(order, "%{0,1}(O*[a-zA-Z])")[[1]]
+  formats <- regmatches(order, gregexpr("(O{0,1}[a-zA-Z])", order))[[1]]
   formats <- paste0("%", formats)
   formats <- ifelse(formats %in% names(char_list), char_list[formats], formats)
 

--- a/r/R/dplyr-datetime-helpers.R
+++ b/r/R/dplyr-datetime-helpers.R
@@ -166,6 +166,18 @@ build_formats <- function(orders) {
   orders <- gsub("[^A-Za-z]", "", orders)
   orders <- gsub("Y", "y", orders)
 
+  invalid_orders <- nchar(gsub("[ymdqIHMS]", "", orders)) > 0
+  if (any(invalid_orders)) {
+      arrow_not_supported(
+        paste0(
+          oxford_paste(
+            orders[invalid_orders]
+          ),
+          " `orders`"
+        )
+      )
+  }
+
   # we separate "ym', "my", and "yq" from the rest of the `orders` vector and
   # transform them. `ym` and `yq` -> `ymd` & `my` -> `myd`
   # this is needed for 2 reasons:
@@ -190,39 +202,6 @@ build_formats <- function(orders) {
     orders1 <- setdiff(orders, "qy")
     orders2 <- "ymd"
     orders <- unique(c(orders1, orders2))
-  }
-
-  ymd_orders <- c("ymd", "ydm", "mdy", "myd", "dmy", "dym")
-  ymd_hms_orders <- c(
-    "ymd_HMS", "ymd_HM", "ymd_H", "dmy_HMS", "dmy_HM", "dmy_H", "mdy_HMS",
-    "mdy_HM", "mdy_H", "ydm_HMS", "ydm_HM", "ydm_H"
-  )
-  # support "%I" hour formats
-  ymd_ims_orders <- gsub("H", "I", ymd_hms_orders)
-
-  supported_orders <- c(
-    ymd_orders,
-    ymd_hms_orders,
-    gsub("_", " ", ymd_hms_orders), # allow "_", " " and "" as order separators
-    gsub("_", "", ymd_hms_orders),
-    ymd_ims_orders,
-    gsub("_", " ", ymd_ims_orders), # allow "_", " " and "" as order separators
-    gsub("_", "", ymd_ims_orders)
-  )
-
-  unsupported_passed_orders <- setdiff(orders, supported_orders)
-  supported_passed_orders <- intersect(orders, supported_orders)
-
-  # error only if there isn't at least one valid order we can try
-  if (length(supported_passed_orders) == 0) {
-    arrow_not_supported(
-      paste0(
-        oxford_paste(
-          unsupported_passed_orders
-        ),
-        " `orders`"
-      )
-    )
   }
 
   formats_list <- map(orders, build_format_from_order)

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -2671,7 +2671,7 @@ test_that("build_formats() and build_format_from_order()", {
   )
 
   expect_error(
-    build_formats("vup"),
+    build_formats(c("vup", "ymd")),
     '"vup" `orders` not supported in Arrow'
   )
 

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -151,31 +151,31 @@ test_that("strptime", {
     ignore_attr = "tzone"
   )
 
+  # these functions' internals use some string processing which requires the
+  # RE2 library (not available on Windows with R 3.6)
+  skip_if_not_available("re2")
+
   tz <- "Pacific/Marquesas"
   set.seed(42)
   times <- seq(as.POSIXct("1999-02-07", tz = tz), as.POSIXct("2000-01-01", tz = tz), by = "sec")
   times <- sample(times, 100)
 
-  # %Op format is currently not supported by strptime
-  # We support a subset of flags on Windows
-  if (tolower(Sys.info()[["sysname"]]) == "windows") {
-    formats <- c(
-      "%d", "%H", "%j", "%m", "%T", "%S", "%q", "%M", "%U", "%w", "%W", "%y", "%Y", "%R"
-    )
-    formats2 <- c("d", "H", "j", "m", "T", "S", "q", "M", "U", "w", "W", "y", "Y", "R")
-  } else {
-    formats <- c(
-      "%a", "%A", "%b", "%B", "%d", "%H", "%j", "%m", "%Om", "%T", "%OS", "%I%p",
-      "%S", "%q", "%M", "%U", "%w", "%W", "%y", "%Y", "%r", "%R", "%T%z"
-    )
-    formats2 <- c(
-      "a", "A", "b", "B", "d", "H", "j", "m", "Om", "T", "OS", "Ip",
-      "S", "q", "M", "U", "w", "W", "y", "Y", "r", "R", "Tz"
-    )
-  }
-
+  # Op format is currently not supported by strptime
+  formats <- c(
+    "%d", "%H", "%j", "%m", "%T",
+    "%S", "%q", "%M", "%U", "%w", "%W", "%y", "%Y", "%R", "%T"
+  )
+  formats2 <- c(
+    "a", "A", "b", "B", "d", "H", "j", "m", "Om", "T", "OS", "Ip",
+    "S", "q", "M", "U", "w", "W", "y", "Y", "r", "R", "Tz"
+  )
   base_format <- "%Y-%m-%d"
   base_format2 <- "ymd"
+
+  # Some formats are not supported on Windows
+  if (!tolower(Sys.info()[["sysname"]]) == "windows") {
+    formats <- c(formats, "%a", "%A", "%b", "%B", "%Om", "%OS", "%I%p", "%r", "%T%z")
+  }
 
   for (fmt in formats) {
     fmt <- paste(base_format, fmt)
@@ -2110,6 +2110,118 @@ test_that("ym, my & yq parsers", {
   )
 })
 
+test_that("parse_date_time's other formats", {
+  # these functions' internals use some string processing which requires the
+  # RE2 library (not available on Windows with R 3.6)
+  skip_if_not_available("re2")
+
+  # q, OS, Op, z formats are currently not supported by strptime
+  test_df <- tibble(
+    string_a = c("2023-12-30-Sat", NA),
+    string_A = c("2023-12-30-Saturday", NA),
+    string_b = c("2023-12-30-Dec", NA),
+    string_B = c("2023-12-30-December", NA),
+    string_H = c("2023-12-30-01", NA),
+    string_I = c("2023-12-30-01", NA),
+    string_j = c("2023-12-30-364", NA),
+    string_M = c("2023-12-30-00", NA),
+    string_p = c("2023-12-30-AM", NA),
+    string_S = c("2023-12-30-00", NA),
+    string_U = c("2023-12-30-52", NA),
+    string_w = c("2023-12-30-6", NA),
+    string_W = c("2023-12-30-52", NA),
+    string_y = c("23-12-30", NA),
+    string_Y = c("2023-12-30", NA),
+    string_Om = c("2023-01-30", NA),
+    string_r = c("2023-12-30-01", NA),
+    string_R = c("2023-12-30-01:00", NA),
+    string_T = c("2023-12-30-01:00:00", NA)
+  )
+
+  compare_dplyr_binding(
+    .input %>%
+      mutate(
+        parsed_H = parse_date_time(string_H, orders = "%Y-%m-%d-%H"),
+        parsed_I = parse_date_time(string_I, orders = "%Y-%m-%d-%I"),
+        parsed_j = parse_date_time(string_j, orders = "%Y-%m-%d-%j"),
+        parsed_M = parse_date_time(string_M, orders = "%Y-%m-%d-%M"),
+        parsed_S = parse_date_time(string_S, orders = "%Y-%m-%d-%S"),
+        parsed_U = parse_date_time(string_U, orders = "%Y-%m-%d-%U"),
+        parsed_w = parse_date_time(string_w, orders = "%Y-%m-%d-%w"),
+        parsed_W = parse_date_time(string_W, orders = "%Y-%m-%d-%W"),
+        parsed_y = parse_date_time(string_y, orders = "%y-%m-%d"),
+        parsed_Y = parse_date_time(string_Y, orders = "%Y-%m-%d"),
+        parsed_R = parse_date_time(string_R, orders = "%Y-%m-%d-%R"),
+        parsed_T = parse_date_time(string_T, orders = "%Y-%m-%d-%T")
+      ) %>%
+      collect(),
+    test_df
+  )
+
+  compare_dplyr_binding(
+    .input %>%
+      mutate(
+        parsed_H = parse_date_time(string_H, orders = "ymdH"),
+        parsed_I = parse_date_time(string_I, orders = "ymdI"),
+        parsed_j = parse_date_time(string_j, orders = "ymdj"),
+        parsed_M = parse_date_time(string_M, orders = "ymdM"),
+        parsed_S = parse_date_time(string_S, orders = "ymdS"),
+        parsed_U = parse_date_time(string_U, orders = "ymdU"),
+        parsed_w = parse_date_time(string_w, orders = "ymdw"),
+        parsed_W = parse_date_time(string_W, orders = "ymdW"),
+        parsed_y = parse_date_time(string_y, orders = "ymd"),
+        parsed_Y = parse_date_time(string_Y, orders = "Ymd"),
+        parsed_R = parse_date_time(string_R, orders = "ymdR"),
+        parsed_T = parse_date_time(string_T, orders = "ymdT")
+      ) %>%
+      collect(),
+    test_df
+  )
+
+  # Some formats are not supported on Windows
+  if (!tolower(Sys.info()[["sysname"]]) == "windows") {
+    compare_dplyr_binding(
+      .input %>%
+        mutate(
+          parsed_a = parse_date_time(string_a, orders = "%Y-%m-%d-%a"),
+          parsed_A = parse_date_time(string_A, orders = "%Y-%m-%d-%A"),
+          parsed_b = parse_date_time(string_b, orders = "%Y-%m-%d-%b"),
+          parsed_B = parse_date_time(string_B, orders = "%Y-%m-%d-%B"),
+          parsed_Om = parse_date_time(string_Om, orders = "%Y-%Om-%d"),
+          parsed_p = parse_date_time(string_p, orders = "%Y-%m-%d-%p"),
+          parsed_r = parse_date_time(string_r, orders = "%Y-%m-%d-%r")
+        ) %>%
+        collect(),
+      test_df
+    )
+
+    compare_dplyr_binding(
+      .input %>%
+        mutate(
+          parsed_a = parse_date_time(string_a, orders = "ymda"),
+          parsed_A = parse_date_time(string_A, orders = "ymdA"),
+          parsed_b = parse_date_time(string_b, orders = "ymdb"),
+          parsed_B = parse_date_time(string_B, orders = "ymdB"),
+          parsed_Om = parse_date_time(string_Om, orders = "yOmd"),
+          parsed_p = parse_date_time(string_p, orders = "ymdp"),
+          parsed_r = parse_date_time(string_r, orders = "ymdr")
+        ) %>%
+        collect(),
+      test_df
+    )
+
+    compare_dplyr_binding(
+      .input %>%
+        mutate(
+          parsed_date_ymd = parse_date_time(string_1, orders = "Y-%b-d-%T")
+        ) %>%
+        collect(),
+      tibble::tibble(string_1 = c("2022-Feb-11-12:23:45", NA))
+    )
+  }
+
+})
+
 test_that("lubridate's fast_strptime", {
   compare_dplyr_binding(
     .input %>%
@@ -2643,6 +2755,19 @@ test_that("parse_date_time with `exact = TRUE`, and with regular R objects", {
 })
 
 test_that("build_formats() and build_format_from_order()", {
+
+  ymd_formats <- c(
+    "%y-%m-%d", "%Y-%m-%d", "%y-%B-%d", "%Y-%B-%d", "%y-%b-%d", "%Y-%b-%d",
+    "%y%m%d", "%Y%m%d", "%y%B%d", "%Y%B%d", "%y%b%d", "%Y%b%d"
+  )
+
+  ymd_hms_formats <- c(
+    "%y-%m-%d-%H-%M-%S", "%Y-%m-%d-%H-%M-%S", "%y-%B-%d-%H-%M-%S",
+    "%Y-%B-%d-%H-%M-%S", "%y-%b-%d-%H-%M-%S", "%Y-%b-%d-%H-%M-%S",
+    "%y%m%d%H%M%S", "%Y%m%d%H%M%S", "%y%B%d%H%M%S", "%Y%B%d%H%M%S",
+    "%y%b%d%H%M%S", "%Y%b%d%H%M%S"
+  )
+
   expect_equal(
     build_formats(c("ym", "myd", "%Y-%d-%m")),
     c(
@@ -2660,20 +2785,11 @@ test_that("build_formats() and build_format_from_order()", {
 
   expect_equal(
     build_formats("ymd_HMS"),
-    c(
-      "%y-%m-%d-%H-%M-%S", "%Y-%m-%d-%H-%M-%S", "%y-%B-%d-%H-%M-%S",
-      "%Y-%B-%d-%H-%M-%S", "%y-%b-%d-%H-%M-%S", "%Y-%b-%d-%H-%M-%S",
-      "%y%m%d%H%M%S", "%Y%m%d%H%M%S", "%y%B%d%H%M%S", "%Y%B%d%H%M%S",
-      "%y%b%d%H%M%S", "%Y%b%d%H%M%S"
-    )
+    ymd_hms_formats
   )
 
   # when order is one of "yq", "qy", "ym" or "my" the data is augmented to "ymd"
   # or "ydm" and the formats are built accordingly
-  ymd_formats <- c(
-    "%y-%m-%d", "%Y-%m-%d", "%y-%B-%d", "%Y-%B-%d", "%y-%b-%d", "%Y-%b-%d",
-    "%y%m%d", "%Y%m%d", "%y%B%d", "%Y%B%d", "%y%b%d", "%Y%b%d"
-  )
   expect_equal(
     build_formats("yq"),
     ymd_formats
@@ -2696,11 +2812,6 @@ test_that("build_formats() and build_format_from_order()", {
   )
 
   expect_equal(
-    build_formats(c("yOm", "yOmd")),
-    c("%y-%Om-%d", "%Y-%Om-%d", "%y%Om%d", "%Y%Om%d")
-  )
-
-  expect_equal(
     build_formats("my"),
     c(
       "%m-%y-%d", "%B-%y-%d", "%b-%y-%d", "%m-%Y-%d", "%B-%Y-%d", "%b-%Y-%d",
@@ -2710,30 +2821,35 @@ test_that("build_formats() and build_format_from_order()", {
 
   expect_equal(
     build_format_from_order("abp"),
-    c("%a-%m-%p", "%a-%B-%p", "%a-%b-%p", "%a%m%p", "%a%B%p", "%a%b%p")
+    c(
+      "%a-%m-%p", "%A-%m-%p", "%a-%B-%p", "%A-%B-%p", "%a-%b-%p", "%A-%b-%p",
+      "%a%m%p", "%A%m%p", "%a%B%p", "%A%B%p", "%a%b%p", "%A%b%p"
+    )
   )
 
   expect_error(
-    build_formats(c("vup", "ymd")),
-    '"vup" `orders` not supported in Arrow'
+    build_formats(c("vu", "ymd")),
+    '"vu" `orders` not supported in Arrow'
+  )
+
+  expect_equal(
+    build_formats("wIpz"),
+    c("%w-%I-%p-%z", "%w%I%p%z")
+  )
+
+  expect_equal(
+    build_formats("yOmd"),
+    ymd_formats
   )
 
   expect_equal(
     build_format_from_order("ymd"),
-    c(
-      "%y-%m-%d", "%Y-%m-%d", "%y-%B-%d", "%Y-%B-%d", "%y-%b-%d", "%Y-%b-%d",
-      "%y%m%d", "%Y%m%d", "%y%B%d", "%Y%B%d", "%y%b%d", "%Y%b%d"
-    )
+    ymd_formats
   )
 
   expect_equal(
     build_format_from_order("ymdHMS"),
-    c(
-      "%y-%m-%d-%H-%M-%S", "%Y-%m-%d-%H-%M-%S", "%y-%B-%d-%H-%M-%S",
-      "%Y-%B-%d-%H-%M-%S", "%y-%b-%d-%H-%M-%S", "%Y-%b-%d-%H-%M-%S",
-      "%y%m%d%H%M%S", "%Y%m%d%H%M%S", "%y%B%d%H%M%S", "%Y%B%d%H%M%S",
-      "%y%b%d%H%M%S", "%Y%b%d%H%M%S"
-    )
+    ymd_hms_formats
   )
 
   expect_equal(
@@ -2759,9 +2875,14 @@ test_that("build_formats() and build_format_from_order()", {
   expect_equal(
     build_formats("y-%b-d-%T"),
     c(
-      "%y-%m-%d-%H-%M-%S", "%Y-%m-%d-%H-%M-%S", "%y-%B-%d-%H-%M-%S", "%Y-%B-%d-%H-%M-%S",
-      "%y-%b-%d-%H-%M-%S", "%Y-%b-%d-%H-%M-%S", "%y%m%d%H%M%S", "%Y%m%d%H%M%S",
-      "%y%B%d%H%M%S", "%Y%B%d%H%M%S", "%y%b%d%H%M%S", "%Y%b%d%H%M%S"
+      "%y-%m-%d-%I-%M-%S-%p", "%Y-%m-%d-%I-%M-%S-%p", "%y-%B-%d-%I-%M-%S-%p", "%Y-%B-%d-%I-%M-%S-%p",
+      "%y-%b-%d-%I-%M-%S-%p", "%Y-%b-%d-%I-%M-%S-%p", "%y-%m-%d-%H-%M-%S", "%Y-%m-%d-%H-%M-%S",
+      "%y-%B-%d-%H-%M-%S", "%Y-%B-%d-%H-%M-%S", "%y-%b-%d-%H-%M-%S", "%Y-%b-%d-%H-%M-%S",
+      "%y-%m-%d-%H-%M-%OS", "%Y-%m-%d-%H-%M-%OS", "%y-%B-%d-%H-%M-%OS", "%Y-%B-%d-%H-%M-%OS",
+      "%y-%b-%d-%H-%M-%OS", "%Y-%b-%d-%H-%M-%OS", "%y%m%d%I%M%S%p", "%Y%m%d%I%M%S%p",
+      "%y%B%d%I%M%S%p", "%Y%B%d%I%M%S%p", "%y%b%d%I%M%S%p", "%Y%b%d%I%M%S%p", "%y%m%d%H%M%S",
+      "%Y%m%d%H%M%S", "%y%B%d%H%M%S", "%Y%B%d%H%M%S", "%y%b%d%H%M%S", "%Y%b%d%H%M%S", "%y%m%d%H%M%OS",
+      "%Y%m%d%H%M%OS", "%y%B%d%H%M%OS", "%Y%B%d%H%M%OS", "%y%b%d%H%M%OS", "%Y%b%d%H%M%OS"
     )
   )
 

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -152,13 +152,14 @@ test_that("strptime", {
   )
 
   tz <- "Pacific/Marquesas"
-  times <- seq(as.POSIXct("1999-02-07", tz = tz), as.POSIXct("2000-01-01", tz = tz), by = "hour")
-  times <- c(as.POSIXct("1999-12-31T12:34:56.01", tz = "UTC"))
+  set.seed(42)
+  times <- seq(as.POSIXct("1999-02-07", tz = tz), as.POSIXct("2000-01-01", tz = tz), by = "sec")
+  times <- sample(times, 100)
 
   # The following formats are currently not supported by strptime: %q %Op
   formats <- c(
     "%a", "%A", "%b", "%B", "%d", "%H", "%j", "%m", "%Om", "%T", "%OS", "%I%p",
-    "%S", "%q", "%M", "%p", "%U", "%w", "%W", "%y", "%Y", "%r", "%R", "%T%z"
+    "%S", "%q", "%M", "%I%p", "%U", "%w", "%W", "%y", "%Y", "%r", "%R", "%T%z"
   )
   base_format <- c("%Y-%m-%d")
 

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -2659,7 +2659,7 @@ test_that("build_formats() and build_format_from_order()", {
     )
   )
 
-  # when order is one of "yq", "qy", "ym" or"my" the data is augmented to "ymd"
+  # when order is one of "yq", "qy", "ym" or "my" the data is augmented to "ymd"
   # or "ydm" and the formats are built accordingly
   ymd_formats <- c(
     "%y-%m-%d", "%Y-%m-%d", "%y-%B-%d", "%Y-%B-%d", "%y-%b-%d", "%Y-%b-%d",
@@ -2687,6 +2687,11 @@ test_that("build_formats() and build_format_from_order()", {
   )
 
   expect_equal(
+    build_formats(c("yOm", "yOmd")),
+    c("%y-%Om-%d", "%Y-%Om-%d", "%y%Om%d", "%Y%Om%d")
+  )
+
+  expect_equal(
     build_formats("my"),
     c(
       "%m-%y-%d", "%B-%y-%d", "%b-%y-%d", "%m-%Y-%d", "%B-%Y-%d", "%b-%Y-%d",
@@ -2696,12 +2701,7 @@ test_that("build_formats() and build_format_from_order()", {
 
   expect_equal(
     build_format_from_order("abp"),
-    c("%a", "%b","%p", "%a", "%b", "%p")
-  )
-
-  expect_equal(
-    build_format_from_order("uYM"),
-    c("%y-%M", "%Y-%M", "%y%M", "%Y%M")
+    c("%a-%m-%p", "%a-%B-%p", "%a-%b-%p", "%a%m%p", "%a%B%p", "%a%b%p")
   )
 
   expect_error(
@@ -2749,7 +2749,11 @@ test_that("build_formats() and build_format_from_order()", {
 
   expect_equal(
     build_formats("y-%b-d-%T"),
-    c("%y-%b-%d-%H-%M-%S", "%Y-%b-%d-%H-%M-%S", "%y%b%d%H%M%S", "%Y%b%d%H%M%S")
+    c(
+      "%y-%m-%d-%H-%M-%S", "%Y-%m-%d-%H-%M-%S", "%y-%B-%d-%H-%M-%S", "%Y-%B-%d-%H-%M-%S",
+      "%y-%b-%d-%H-%M-%S", "%Y-%b-%d-%H-%M-%S", "%y%m%d%H%M%S", "%Y%m%d%H%M%S",
+      "%y%B%d%H%M%S", "%Y%B%d%H%M%S", "%y%b%d%H%M%S", "%Y%b%d%H%M%S"
+    )
   )
 
   expect_equal(

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -156,7 +156,7 @@ test_that("strptime", {
   times <- seq(as.POSIXct("1999-02-07", tz = tz), as.POSIXct("2000-01-01", tz = tz), by = "sec")
   times <- sample(times, 100)
 
-  # The following formats are currently not supported by strptime: %q %Op
+  # %Op format is currently not supported by strptime
   formats <- c(
     "%a", "%A", "%b", "%B", "%d", "%H", "%j", "%m", "%Om", "%T", "%OS", "%I%p",
     "%S", "%q", "%M", "%I%p", "%U", "%w", "%W", "%y", "%Y", "%r", "%R", "%T%z"

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -150,6 +150,30 @@ test_that("strptime", {
     as.POSIXct(tstamp),
     ignore_attr = "tzone"
   )
+
+  tz <- "Pacific/Marquesas"
+  times <- seq(as.POSIXct("1999-02-07", tz = tz), as.POSIXct("2000-01-01", tz = tz), by = "hour")
+  times <- c(as.POSIXct("1999-12-31T12:34:56.01", tz = "UTC"))
+
+  # The following formats are currently not supported by strptime: %q %Op
+  formats <- c("%a", "%A", "%b", "%B", "%d", "%H", "%j", "%m", "%Om", "%T", "%OS", "%I%p",
+               "%S", "%q", "%M", "%p", "%U", "%w", "%W", "%y", "%Y", "%r", "%R", "%T%z")
+  base_format <- c("%Y-%m-%d")
+
+  for (fmt in formats) {
+    fmt <- paste(base_format, fmt)
+    test_df <- tibble::tibble(x = strftime(times, format = fmt))
+    expect_equal(
+      test_df %>%
+        arrow_table() %>%
+          mutate(x = strptime(x, format = fmt)) %>%
+          collect(),
+      test_df %>%
+        mutate(x = strptime(x, format = fmt)) %>%
+        mutate(x = as.POSIXct(x)) %>%
+        collect()
+    )
+  }
 })
 
 test_that("strptime returns NA when format doesn't match the data", {

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -2832,6 +2832,11 @@ test_that("build_formats() and build_format_from_order()", {
     '"vu" `orders` not supported in Arrow'
   )
 
+  expect_error(
+    build_formats(c("abc")),
+    '"abc" `orders` not supported in Arrow'
+  )
+
   expect_equal(
     build_formats("wIpz"),
     c("%w-%I-%p-%z", "%w%I%p%z")

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -157,14 +157,23 @@ test_that("strptime", {
   times <- sample(times, 100)
 
   # %Op format is currently not supported by strptime
-  formats <- c(
-    "%a", "%A", "%b", "%B", "%d", "%H", "%j", "%m", "%Om", "%T", "%OS", "%I%p",
-    "%S", "%q", "%M", "%I%p", "%U", "%w", "%W", "%y", "%Y", "%r", "%R", "%T%z"
-  )
-  formats2 <- c(
-    "a", "A", "b", "B", "d", "H", "j", "m", "Om", "T", "OS", "Ip",
-    "S", "q", "M", "Ip", "U", "w", "W", "y", "Y", "r", "R", "Tz"
-  )
+  # We support a subset of flags on Windows
+  if (tolower(Sys.info()[["sysname"]]) == "windows") {
+    formats <- c(
+      "%d", "%H", "%j", "%m", "%T", "%S", "%q", "%M", "%U", "%w", "%W", "%y", "%Y", "%R"
+    )
+    formats2 <- c("d", "H", "j", "m", "T", "S", "q", "M", "U", "w", "W", "y", "Y", "R")
+  } else {
+    formats <- c(
+      "%a", "%A", "%b", "%B", "%d", "%H", "%j", "%m", "%Om", "%T", "%OS", "%I%p",
+      "%S", "%q", "%M", "%U", "%w", "%W", "%y", "%Y", "%r", "%R", "%T%z"
+    )
+    formats2 <- c(
+      "a", "A", "b", "B", "d", "H", "j", "m", "Om", "T", "OS", "Ip",
+      "S", "q", "M", "U", "w", "W", "y", "Y", "r", "R", "Tz"
+    )
+  }
+
   base_format <- c("%Y-%m-%d")
   base_format2 <- c("ymd")
 
@@ -200,10 +209,10 @@ test_that("strptime", {
   compare_dplyr_binding(
     .input %>%
       mutate(
-        parsed_date_ymd = parse_date_time(string_1, orders = "Y-%b-d-%T")
+        parsed_date_ymd = parse_date_time(string_1, orders = "Y-%m-d-%T")
       ) %>%
       collect(),
-    tibble::tibble(string_1 = c("2022-Feb-11-12:23:45", NA))
+    tibble::tibble(string_1 = c("2022-02-11-12:23:45", NA))
   )
 
 })

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -174,8 +174,8 @@ test_that("strptime", {
     )
   }
 
-  base_format <- c("%Y-%m-%d")
-  base_format2 <- c("ymd")
+  base_format <- "%Y-%m-%d"
+  base_format2 <- "ymd"
 
   for (fmt in formats) {
     fmt <- paste(base_format, fmt)

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -156,8 +156,10 @@ test_that("strptime", {
   times <- c(as.POSIXct("1999-12-31T12:34:56.01", tz = "UTC"))
 
   # The following formats are currently not supported by strptime: %q %Op
-  formats <- c("%a", "%A", "%b", "%B", "%d", "%H", "%j", "%m", "%Om", "%T", "%OS", "%I%p",
-               "%S", "%q", "%M", "%p", "%U", "%w", "%W", "%y", "%Y", "%r", "%R", "%T%z")
+  formats <- c(
+    "%a", "%A", "%b", "%B", "%d", "%H", "%j", "%m", "%Om", "%T", "%OS", "%I%p",
+    "%S", "%q", "%M", "%p", "%U", "%w", "%W", "%y", "%Y", "%r", "%R", "%T%z"
+  )
   base_format <- c("%Y-%m-%d")
 
   for (fmt in formats) {
@@ -169,8 +171,7 @@ test_that("strptime", {
           mutate(x = strptime(x, format = fmt)) %>%
           collect(),
       test_df %>%
-        mutate(x = strptime(x, format = fmt)) %>%
-        mutate(x = as.POSIXct(x)) %>%
+        mutate(x = as.POSIXct(strptime(x, format = fmt))) %>%
         collect()
     )
   }


### PR DESCRIPTION
This is to resolve [ARROW-16653](https://issues.apache.org/jira/browse/ARROW-16653).

Please note the intent here is to map out currently available formats via a new test. That is to support [ARROW-16395](https://issues.apache.org/jira/browse/ARROW-16395) which will add `ymd_hms() ymd_hm() ymd_h() dmy_hms() dmy_hm() dmy_h() mdy_hms() mdy_hm() mdy_h() ydm_hms() ydm_hm() ydm_h()`.

Currently most [lubridate supported flags](https://lubridate.tidyverse.org/reference/parse_date_time.html#details) are available and this adds a test. Remaining are `%q` and `%Op` that we don't need to resolve [ARROW-16395](https://issues.apache.org/jira/browse/ARROW-16395). We could open a ticket for adding support for the two remaining flags to C++ `strptime` or wait for users to request them.