### PR TITLE
ARROW-16904: [C++] min/max not deterministic if Parquet files have multiple row groups

### DIFF
--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -109,6 +109,10 @@ class ARROW_EXPORT ProjectNodeOptions : public ExecNodeOptions {
 };
 
 /// \brief Make a node which aggregates input batches, optionally grouped by keys.
+///
+/// If the keys attribute is a non-empty vector, then each aggregate in `aggregates` is
+/// expected to be a HashAggregate function. If the keys attribute is an empty vector,
+/// then each aggregate is assumed to be a ScalarAggregate function.
 class ARROW_EXPORT AggregateNodeOptions : public ExecNodeOptions {
  public:
   explicit AggregateNodeOptions(std::vector<Aggregate> aggregates,

--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -935,31 +935,28 @@ TEST(ExecPlanExecution, SourceGroupedSum) {
 
 TEST(ExecPlanExecution, SourceMinMaxScalar) {
   // Regression test for ARROW-16904
-  for (bool parallel : { false, true }) {
+  for (bool parallel : {false, true}) {
     SCOPED_TRACE(parallel ? "parallel/merged" : "serial");
 
     auto input = MakeGroupableBatches(/*multiplicity=*/parallel ? 100 : 1);
     auto minmax_opts = std::make_shared<ScalarAggregateOptions>();
-    auto expected_value = StructScalar::Make(
-        ScalarVector{ScalarFromJSON(int32(), R"(-8)"), ScalarFromJSON(int32(), R"(12)")},
-        {"min","max"});
-    auto expected_result = ExecBatch::Make({*expected_value});
+    auto expected_result = ExecBatch::Make(
+        {ScalarFromJSON(struct_({field("min", int32()), field("max", int32())}),
+                        R"({"min": -8, "max": 12})")});
 
     ASSERT_OK_AND_ASSIGN(auto plan, ExecPlan::Make());
     AsyncGenerator<util::optional<ExecBatch>> sink_gen;
 
     // NOTE: Test `ScalarAggregateNode` by omitting `keys` attribute
-    ASSERT_OK(
-      Declaration::Sequence({
-        {"source",
-         SourceNodeOptions {input.schema, input.gen(parallel, /*slow=*/false)}},
-        {"aggregate", AggregateNodeOptions{/*aggregates=*/{{"min_max",
-                                                           std::move(minmax_opts),
-                                                           "i32", "min_max"}},
-                                           /*keys=*/{}}},
-        {"sink", SinkNodeOptions{&sink_gen}}
-      })
-      .AddToPlan(plan.get()));
+    ASSERT_OK(Declaration::Sequence(
+                  {{"source",
+                    SourceNodeOptions{input.schema, input.gen(parallel, /*slow=*/false)}},
+                   {"aggregate", AggregateNodeOptions{
+                                     /*aggregates=*/{{"min_max", std::move(minmax_opts),
+                                                      "i32", "min_max"}},
+                                     /*keys=*/{}}},
+                   {"sink", SinkNodeOptions{&sink_gen}}})
+                  .AddToPlan(plan.get()));
 
     ASSERT_THAT(StartAndCollect(plan.get(), sink_gen),
                 Finishes(ResultWith(UnorderedElementsAreArray({*expected_result}))));

--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -933,6 +933,57 @@ TEST(ExecPlanExecution, SourceGroupedSum) {
   }
 }
 
+TEST(ExecPlanExecution, SourceMinMaxScalar) {
+  for (bool parallel : { false, true }) {
+    SCOPED_TRACE(parallel ? "parallel/merged" : "serial");
+
+    auto input           = MakeGroupableBatches(/*multiplicity=*/parallel ? 100 : 1);
+    auto minmax_opts     = std::make_shared<ScalarAggregateOptions>();
+    auto expected_result = ExecBatch::Make({
+      *StructScalar::Make(
+          ScalarVector {
+             ScalarFromJSON(int32(), R"(-8)")
+            ,ScalarFromJSON(int32(), R"(12)")
+          }
+         ,{ "min", "max" }
+       )
+    });
+
+    ASSERT_OK_AND_ASSIGN(auto plan, ExecPlan::Make());
+    AsyncGenerator<util::optional<ExecBatch>> sink_gen;
+
+    // NOTE: Test `ScalarAggregateNode` by omitting `keys` attribute
+    ASSERT_OK(
+      Declaration::Sequence({
+         {
+             "source"
+            ,SourceNodeOptions {
+                input.schema
+               ,input.gen(parallel, /*slow=*/false)
+             }
+         }
+        ,{
+            "aggregate"
+           ,AggregateNodeOptions {
+               /*aggregates=*/{
+                 { "min_max", std::move(minmax_opts), "i32", "min_max" }
+               }
+              ,/*keys=*/{}
+            }
+         }
+        ,{ "sink", SinkNodeOptions{ &sink_gen } }
+      }).AddToPlan(plan.get())
+    );
+
+    ASSERT_THAT(
+       StartAndCollect(plan.get(), sink_gen)
+      ,Finishes(ResultWith(
+         UnorderedElementsAreArray({ *expected_result })
+       ))
+    );
+  }
+}
+
 TEST(ExecPlanExecution, NestedSourceFilter) {
   for (bool parallel : {false, true}) {
     SCOPED_TRACE(parallel ? "parallel/merged" : "serial");

--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -934,6 +934,7 @@ TEST(ExecPlanExecution, SourceGroupedSum) {
 }
 
 TEST(ExecPlanExecution, SourceMinMaxScalar) {
+  // Regression test for ARROW-16904
   for (bool parallel : { false, true }) {
     SCOPED_TRACE(parallel ? "parallel/merged" : "serial");
 

--- a/cpp/src/arrow/compute/kernels/aggregate_basic_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic_internal.h
@@ -459,9 +459,7 @@ struct MinMaxImpl : public ScalarAggregator {
       for (int64_t i = 0; i < arr.length(); i++) {
         local.MergeOne(arr.GetView(i));
       }
-    }
-
-    else if (local.has_nulls && options.skip_nulls) {
+    } else if (local.has_nulls && options.skip_nulls) {
       local += ConsumeWithNulls(arr);
     }
 

--- a/cpp/src/arrow/compute/kernels/aggregate_basic_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic_internal.h
@@ -441,12 +441,12 @@ struct MinMaxImpl : public ScalarAggregator {
     this->count += scalar.is_valid;
 
     if (local.has_nulls && !options.skip_nulls) {
-      this->state = local;
+      this->state += local;
       return Status::OK();
     }
 
     local.MergeOne(internal::UnboxScalar<ArrowType>::Unbox(scalar));
-    this->state = local;
+    this->state += local;
     return Status::OK();
   }
 
@@ -458,7 +458,7 @@ struct MinMaxImpl : public ScalarAggregator {
     this->count += arr.length() - null_count;
 
     if (local.has_nulls && !options.skip_nulls) {
-      this->state = local;
+      this->state += local;
       return Status::OK();
     }
 
@@ -469,7 +469,7 @@ struct MinMaxImpl : public ScalarAggregator {
         local.MergeOne(arr.GetView(i));
       }
     }
-    this->state = local;
+    this->state += local;
     return Status::OK();
   }
 
@@ -586,7 +586,7 @@ struct BooleanMinMaxImpl : public MinMaxImpl<BooleanType, SimdLevel> {
     local.has_nulls = null_count > 0;
     this->count += valid_count;
     if (local.has_nulls && !options.skip_nulls) {
-      this->state = local;
+      this->state += local;
       return Status::OK();
     }
 
@@ -595,7 +595,7 @@ struct BooleanMinMaxImpl : public MinMaxImpl<BooleanType, SimdLevel> {
     local.max = true_count > 0;
     local.min = false_count == 0;
 
-    this->state = local;
+    this->state += local;
     return Status::OK();
   }
 
@@ -605,7 +605,7 @@ struct BooleanMinMaxImpl : public MinMaxImpl<BooleanType, SimdLevel> {
     local.has_nulls = !scalar.is_valid;
     this->count += scalar.is_valid;
     if (local.has_nulls && !options.skip_nulls) {
-      this->state = local;
+      this->state += local;
       return Status::OK();
     }
 
@@ -614,7 +614,7 @@ struct BooleanMinMaxImpl : public MinMaxImpl<BooleanType, SimdLevel> {
     local.max = true_count > 0;
     local.min = false_count == 0;
 
-    this->state = local;
+    this->state += local;
     return Status::OK();
   }
 };

--- a/cpp/src/arrow/compute/kernels/aggregate_basic_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic_internal.h
@@ -440,12 +440,10 @@ struct MinMaxImpl : public ScalarAggregator {
     local.has_nulls = !scalar.is_valid;
     this->count += scalar.is_valid;
 
-    if (local.has_nulls && !options.skip_nulls) {
-      this->state += local;
-      return Status::OK();
+    if (!local.has_nulls || options.skip_nulls) {
+      local.MergeOne(internal::UnboxScalar<ArrowType>::Unbox(scalar));
     }
 
-    local.MergeOne(internal::UnboxScalar<ArrowType>::Unbox(scalar));
     this->state += local;
     return Status::OK();
   }
@@ -457,18 +455,16 @@ struct MinMaxImpl : public ScalarAggregator {
     local.has_nulls = null_count > 0;
     this->count += arr.length() - null_count;
 
-    if (local.has_nulls && !options.skip_nulls) {
-      this->state += local;
-      return Status::OK();
-    }
-
-    if (local.has_nulls) {
-      local += ConsumeWithNulls(arr);
-    } else {  // All true values
+    if (!local.has_nulls) {
       for (int64_t i = 0; i < arr.length(); i++) {
         local.MergeOne(arr.GetView(i));
       }
     }
+
+    else if (local.has_nulls && options.skip_nulls) {
+      local += ConsumeWithNulls(arr);
+    }
+
     this->state += local;
     return Status::OK();
   }
@@ -585,15 +581,12 @@ struct BooleanMinMaxImpl : public MinMaxImpl<BooleanType, SimdLevel> {
 
     local.has_nulls = null_count > 0;
     this->count += valid_count;
-    if (local.has_nulls && !options.skip_nulls) {
-      this->state += local;
-      return Status::OK();
+    if (!local.has_nulls || options.skip_nulls) {
+      const auto true_count = arr.true_count();
+      const auto false_count = valid_count - true_count;
+      local.max = true_count > 0;
+      local.min = false_count == 0;
     }
-
-    const auto true_count = arr.true_count();
-    const auto false_count = valid_count - true_count;
-    local.max = true_count > 0;
-    local.min = false_count == 0;
 
     this->state += local;
     return Status::OK();
@@ -604,15 +597,12 @@ struct BooleanMinMaxImpl : public MinMaxImpl<BooleanType, SimdLevel> {
 
     local.has_nulls = !scalar.is_valid;
     this->count += scalar.is_valid;
-    if (local.has_nulls && !options.skip_nulls) {
-      this->state += local;
-      return Status::OK();
+    if (!local.has_nulls || options.skip_nulls) {
+      const int true_count = scalar.is_valid && scalar.value;
+      const int false_count = scalar.is_valid && !scalar.value;
+      local.max = true_count > 0;
+      local.min = false_count == 0;
     }
-
-    const int true_count = scalar.is_valid && scalar.value;
-    const int false_count = scalar.is_valid && !scalar.value;
-    local.max = true_count > 0;
-    local.min = false_count == 0;
 
     this->state += local;
     return Status::OK();

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -1563,7 +1563,7 @@ TEST_F(TestBooleanMinMaxKernel, Basics) {
 TYPED_TEST_SUITE(TestIntegerMinMaxKernel, PhysicalIntegralArrowTypes);
 TYPED_TEST(TestIntegerMinMaxKernel, Basics) {
   ScalarAggregateOptions options;
-  std::vector<std::string> chunked_input1 = {"[5, 1, 2, 3, 4]", "[9, 1, null, 3, 4]"};
+  std::vector<std::string> chunked_input1 = {"[5, 1, 2, 3, 4]", "[9, 8, null, 3, 4]"};
   std::vector<std::string> chunked_input2 = {"[5, null, 2, 3, 4]", "[9, 1, 2, 3, 4]"};
   std::vector<std::string> chunked_input3 = {"[5, 1, 2, 3, null]", "[9, 1, null, 3, 4]"};
   auto item_ty = default_type_instance<TypeParam>();

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -619,7 +619,7 @@ test_that("UnionDataset handles InMemoryDatasets", {
 })
 
 test_that("scalar aggregates with many batches", {
-  test_data             <- data.frame(val=1:1e7)
+  test_data <- data.frame(val=1:1e7)
   expected_result_distr <- (
     sapply(1:100, function (iter_ndx) {
       test_data                              %>%

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -618,6 +618,31 @@ test_that("UnionDataset handles InMemoryDatasets", {
   expect_equal(actual, expected)
 })
 
+test_that("scalar aggregates with many batches", {
+  test_data             <- data.frame(val=1:1e7)
+  expected_result_distr <- (
+    sapply(1:100, function (iter_ndx) {
+      test_data                              %>%
+        dplyr::summarise(min_val = min(val)) %>%
+        dplyr::collect()                     %>%
+        dplyr::pull(min_val)
+    }) %>% table()
+  )
+
+  ds_tmpfile <- tempfile('test-aggregate', fileext='.parquet')
+  arrow::write_parquet(test_data, ds_tmpfile)
+  actual_result_distr <- (
+    sapply(1:100, function (iter_ndx) {
+      arrow::open_dataset(ds_tmpfile)        %>%
+        dplyr::summarise(min_val = min(val)) %>%
+        dplyr::collect()                     %>%
+        dplyr::pull(min_val)
+    }) %>% table()
+  )
+
+  expect_equal(actual_result_distr, expected_result_distr)
+})
+
 test_that("map_batches", {
   ds <- open_dataset(dataset_dir, partitioning = "part")
 

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -619,25 +619,27 @@ test_that("UnionDataset handles InMemoryDatasets", {
 })
 
 test_that("scalar aggregates with many batches", {
-  test_data <- data.frame(val=1:1e7)
+  test_data <- data.frame(val = 1:1e7)
   expected_result_distr <- (
-    sapply(1:100, function (iter_ndx) {
+    sapply(1:100, function(iter_ndx) {
       test_data                              %>%
         dplyr::summarise(min_val = min(val)) %>%
         dplyr::collect()                     %>%
         dplyr::pull(min_val)
-    }) %>% table()
+    }) %>%
+      table()
   )
 
-  ds_tmpfile <- tempfile('test-aggregate', fileext='.parquet')
+  ds_tmpfile <- tempfile("test-aggregate", fileext = ".parquet")
   arrow::write_parquet(test_data, ds_tmpfile)
   actual_result_distr <- (
-    sapply(1:100, function (iter_ndx) {
+    sapply(1:100, function(iter_ndx) {
       arrow::open_dataset(ds_tmpfile)        %>%
         dplyr::summarise(min_val = min(val)) %>%
         dplyr::collect()                     %>%
         dplyr::pull(min_val)
-    }) %>% table()
+    }) %>%
+      table()
   )
 
   expect_equal(actual_result_distr, expected_result_distr)


### PR DESCRIPTION
The min/max aggregate compute kernels seemed to discard their state between partitions, so they would only aggregate the last partition they see (in each thread).

This is the simplest change I could come up with to fix this, but honestly I'm not sure why the `local` variable even exists. It seems to me it could just be replaced with `this->state` directly, since there doesn't seem to be any failure path where `this->state` isn't updated from `local`. Am I missing something?

ETA: I tried to make a test case for this, only to find that there is already a test case for this. In that case however, it seems that the merging of the partition results is done by `Merge`'ing the result of separate `Consume` calls, rather than chaining multiple `Consume` calls. I'm not sure how to trigger the latter behavior from a normal C++ test case.