### PR TITLE
ARROW-16974: [GLib] Make C99 compatible

### DIFF
--- a/c_glib/arrow-dataset-glib/dataset-definition.h
+++ b/c_glib/arrow-dataset-glib/dataset-definition.h
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <arrow-glib/arrow-glib.h>
+
+G_BEGIN_DECLS
+
+#define GADATASET_TYPE_DATASET (gadataset_dataset_get_type())
+G_DECLARE_DERIVABLE_TYPE(GADatasetDataset,
+                         gadataset_dataset,
+                         GADATASET,
+                         DATASET,
+                         GObject)
+struct _GADatasetDatasetClass
+{
+  GObjectClass parent_class;
+};
+
+G_END_DECLS

--- a/c_glib/arrow-dataset-glib/dataset.h
+++ b/c_glib/arrow-dataset-glib/dataset.h
@@ -19,23 +19,11 @@
 
 #pragma once
 
+#include <arrow-dataset-glib/dataset-definition.h>
 #include <arrow-dataset-glib/file-format.h>
+#include <arrow-dataset-glib/scanner.h>
 
 G_BEGIN_DECLS
-
-typedef struct _GADatasetScannerBuilder GADatasetScannerBuilder;
-typedef struct _GADatasetScanner GADatasetScanner;
-
-#define GADATASET_TYPE_DATASET (gadataset_dataset_get_type())
-G_DECLARE_DERIVABLE_TYPE(GADatasetDataset,
-                         gadataset_dataset,
-                         GADATASET,
-                         DATASET,
-                         GObject)
-struct _GADatasetDatasetClass
-{
-  GObjectClass parent_class;
-};
 
 GARROW_AVAILABLE_IN_5_0
 GADatasetScannerBuilder *

--- a/c_glib/arrow-dataset-glib/meson.build
+++ b/c_glib/arrow-dataset-glib/meson.build
@@ -28,6 +28,7 @@ sources = files(
 
 c_headers = files(
   'arrow-dataset-glib.h',
+  'dataset-definition.h',
   'dataset-factory.h',
   'dataset.h',
   'file-format.h',

--- a/c_glib/arrow-dataset-glib/scanner.h
+++ b/c_glib/arrow-dataset-glib/scanner.h
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include <arrow-dataset-glib/dataset.h>
+#include <arrow-dataset-glib/dataset-definition.h>
 #include <arrow-dataset-glib/fragment.h>
 
 G_BEGIN_DECLS

--- a/c_glib/arrow-glib/basic-array-definition.h
+++ b/c_glib/arrow-glib/basic-array-definition.h
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <arrow-glib/gobject-type.h>
+
+G_BEGIN_DECLS
+
+#define GARROW_TYPE_ARRAY (garrow_array_get_type())
+G_DECLARE_DERIVABLE_TYPE(GArrowArray,
+                         garrow_array,
+                         GARROW,
+                         ARRAY,
+                         GObject)
+struct _GArrowArrayClass
+{
+  GObjectClass parent_class;
+};
+
+#define GARROW_TYPE_EXTENSION_ARRAY (garrow_extension_array_get_type())
+G_DECLARE_DERIVABLE_TYPE(GArrowExtensionArray,
+                         garrow_extension_array,
+                         GARROW,
+                         EXTENSION_ARRAY,
+                         GArrowArray)
+struct _GArrowExtensionArrayClass
+{
+  GArrowArrayClass parent_class;
+};
+
+G_END_DECLS

--- a/c_glib/arrow-glib/basic-array.h
+++ b/c_glib/arrow-glib/basic-array.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <arrow-glib/basic-array-definition.h>
 #include <arrow-glib/basic-data-type.h>
 #include <arrow-glib/buffer.h>
 #include <arrow-glib/interval.h>
@@ -43,17 +44,6 @@ GARROW_AVAILABLE_IN_5_0
 gboolean
 garrow_equal_options_is_approx(GArrowEqualOptions *options);
 
-
-#define GARROW_TYPE_ARRAY (garrow_array_get_type())
-G_DECLARE_DERIVABLE_TYPE(GArrowArray,
-                         garrow_array,
-                         GARROW,
-                         ARRAY,
-                         GObject)
-struct _GArrowArrayClass
-{
-  GObjectClass parent_class;
-};
 
 GARROW_AVAILABLE_IN_6_0
 GArrowArray *
@@ -764,16 +754,6 @@ gchar *garrow_decimal256_array_format_value(GArrowDecimal256Array *array,
 GArrowDecimal256 *garrow_decimal256_array_get_value(GArrowDecimal256Array *array,
                                                     gint64 i);
 
-#define GARROW_TYPE_EXTENSION_ARRAY (garrow_extension_array_get_type())
-G_DECLARE_DERIVABLE_TYPE(GArrowExtensionArray,
-                         garrow_extension_array,
-                         GARROW,
-                         EXTENSION_ARRAY,
-                         GArrowArray)
-struct _GArrowExtensionArrayClass
-{
-  GArrowArrayClass parent_class;
-};
 
 GARROW_AVAILABLE_IN_3_0
 GArrowArray *

--- a/c_glib/arrow-glib/basic-data-type.h
+++ b/c_glib/arrow-glib/basic-data-type.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <arrow-glib/basic-array-definition.h>
+#include <arrow-glib/chunked-array-definition.h>
 #include <arrow-glib/decimal.h>
 #include <arrow-glib/type.h>
 #include <arrow-glib/version.h>
@@ -619,15 +621,10 @@ GARROW_AVAILABLE_IN_3_0
 gchar *
 garrow_extension_data_type_get_extension_name(GArrowExtensionDataType *data_type);
 
-typedef struct _GArrowArray GArrowArray;
-typedef struct _GArrowExtensionArray GArrowExtensionArray;
-
 GARROW_AVAILABLE_IN_3_0
 GArrowExtensionArray *
 garrow_extension_data_type_wrap_array(GArrowExtensionDataType *data_type,
                                       GArrowArray *storage);
-
-typedef struct _GArrowChunkedArray GArrowChunkedArray;
 
 GARROW_AVAILABLE_IN_3_0
 GArrowChunkedArray *

--- a/c_glib/arrow-glib/chunked-array-definition.h
+++ b/c_glib/arrow-glib/chunked-array-definition.h
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <arrow-glib/gobject-type.h>
+
+G_BEGIN_DECLS
+
+#define GARROW_TYPE_CHUNKED_ARRAY (garrow_chunked_array_get_type())
+G_DECLARE_DERIVABLE_TYPE(GArrowChunkedArray,
+                         garrow_chunked_array,
+                         GARROW,
+                         CHUNKED_ARRAY,
+                         GObject)
+struct _GArrowChunkedArrayClass
+{
+  GObjectClass parent_class;
+};
+
+
+G_END_DECLS

--- a/c_glib/arrow-glib/chunked-array.h
+++ b/c_glib/arrow-glib/chunked-array.h
@@ -20,19 +20,9 @@
 #pragma once
 
 #include <arrow-glib/array.h>
+#include <arrow-glib/chunked-array-definition.h>
 
 G_BEGIN_DECLS
-
-#define GARROW_TYPE_CHUNKED_ARRAY (garrow_chunked_array_get_type())
-G_DECLARE_DERIVABLE_TYPE(GArrowChunkedArray,
-                         garrow_chunked_array,
-                         GARROW,
-                         CHUNKED_ARRAY,
-                         GObject)
-struct _GArrowChunkedArrayClass
-{
-  GObjectClass parent_class;
-};
 
 GArrowChunkedArray *garrow_chunked_array_new(GList *chunks);
 

--- a/c_glib/arrow-glib/compute-definition.h
+++ b/c_glib/arrow-glib/compute-definition.h
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <arrow-glib/gobject-type.h>
+
+G_BEGIN_DECLS
+
+#define GARROW_TYPE_FUNCTION_OPTIONS (garrow_function_options_get_type())
+G_DECLARE_DERIVABLE_TYPE(GArrowFunctionOptions,
+                         garrow_function_options,
+                         GARROW,
+                         FUNCTION_OPTIONS,
+                         GObject)
+struct _GArrowFunctionOptionsClass
+{
+  GObjectClass parent_class;
+};
+
+
+#define GARROW_TYPE_CAST_OPTIONS (garrow_cast_options_get_type())
+G_DECLARE_DERIVABLE_TYPE(GArrowCastOptions,
+                         garrow_cast_options,
+                         GARROW,
+                         CAST_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowCastOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+
+G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <arrow-glib/compute-definition.h>
 #include <arrow-glib/datum.h>
 #include <arrow-glib/reader.h>
 
@@ -38,17 +39,6 @@ struct _GArrowExecuteContextClass
 GARROW_AVAILABLE_IN_1_0
 GArrowExecuteContext *garrow_execute_context_new(void);
 
-
-#define GARROW_TYPE_FUNCTION_OPTIONS (garrow_function_options_get_type())
-G_DECLARE_DERIVABLE_TYPE(GArrowFunctionOptions,
-                         garrow_function_options,
-                         GARROW,
-                         FUNCTION_OPTIONS,
-                         GObject)
-struct _GArrowFunctionOptionsClass
-{
-  GObjectClass parent_class;
-};
 
 GARROW_AVAILABLE_IN_7_0
 gboolean
@@ -365,17 +355,6 @@ GARROW_AVAILABLE_IN_6_0
 void
 garrow_execute_plan_wait(GArrowExecutePlan *plan);
 
-
-#define GARROW_TYPE_CAST_OPTIONS (garrow_cast_options_get_type())
-G_DECLARE_DERIVABLE_TYPE(GArrowCastOptions,
-                         garrow_cast_options,
-                         GARROW,
-                         CAST_OPTIONS,
-                         GArrowFunctionOptions)
-struct _GArrowCastOptionsClass
-{
-  GArrowFunctionOptionsClass parent_class;
-};
 
 GArrowCastOptions *garrow_cast_options_new(void);
 

--- a/c_glib/arrow-glib/meson.build
+++ b/c_glib/arrow-glib/meson.build
@@ -78,9 +78,11 @@ c_headers = files(
   'array.h',
   'array-builder.h',
   'arrow-glib.h',
+  'basic-array-definition.h',
   'basic-array.h',
   'basic-data-type.h',
   'buffer.h',
+  'chunked-array-definition.h',
   'chunked-array.h',
   'codec.h',
   'composite-array.h',
@@ -122,6 +124,7 @@ c_headers += files(
 )
 
 c_headers += files(
+  'compute-definition.h',
   'compute.h',
 )
 

--- a/c_glib/arrow-glib/scalar.cpp
+++ b/c_glib/arrow-glib/scalar.cpp
@@ -19,6 +19,7 @@
 
 #include <arrow-glib/basic-array.hpp>
 #include <arrow-glib/buffer.hpp>
+#include <arrow-glib/compute.h>
 #include <arrow-glib/data-type.hpp>
 #include <arrow-glib/decimal.hpp>
 #include <arrow-glib/error.hpp>

--- a/c_glib/arrow-glib/scalar.h
+++ b/c_glib/arrow-glib/scalar.h
@@ -20,10 +20,9 @@
 #pragma once
 
 #include <arrow-glib/array.h>
+#include <arrow-glib/compute-definition.h>
 
 G_BEGIN_DECLS
-
-typedef struct _GArrowCastOptions GArrowCastOptions;
 
 #define GARROW_TYPE_SCALAR (garrow_scalar_get_type())
 G_DECLARE_DERIVABLE_TYPE(GArrowScalar,

--- a/c_glib/example/meson.build
+++ b/c_glib/example/meson.build
@@ -18,13 +18,17 @@
 # under the License.
 
 executable('build', 'build.c',
-           dependencies: [arrow_glib])
+           dependencies: [arrow_glib],
+           link_language: 'c')
 executable('extension-type', 'extension-type.c',
-           dependencies: [arrow_glib])
+           dependencies: [arrow_glib],
+           link_language: 'c')
 executable('read-file', 'read-file.c',
-           dependencies: [arrow_glib])
+           dependencies: [arrow_glib],
+           link_language: 'c')
 executable('read-stream', 'read-stream.c',
-           dependencies: [arrow_glib])
+           dependencies: [arrow_glib],
+           link_language: 'c')
 
 install_data('README.md',
              'build.c',

--- a/c_glib/meson.build
+++ b/c_glib/meson.build
@@ -20,6 +20,7 @@
 project('arrow-glib', 'c', 'cpp',
         license: 'Apache-2.0',
         default_options: [
+          'c_std=c99',
           'cpp_std=c++11',
         ])
 


### PR DESCRIPTION
We can't use multiple "typedef struct _XXX XXX" in C99.