### PR TITLE
ARROW-16871: [R] Implement exp() and sqrt() in Arrow dplyr queries

### DIFF
--- a/r/R/arrow-datum.R
+++ b/r/R/arrow-datum.R
@@ -123,7 +123,7 @@ Math.ArrowDatum <- function(x, ..., base = exp(1), digits = 0) {
       x,
       options = list(ndigits = digits, round_mode = RoundMode$HALF_TO_EVEN)
     ),
-    sqrt = eval_array_expression("power_checked", x, 0.5),
+    sqrt = eval_array_expression("sqrt_checked", x),
     exp = eval_array_expression("power_checked", exp(1), x),
     signif = ,
     expm1 = ,

--- a/r/R/dplyr-funcs-math.R
+++ b/r/R/dplyr-funcs-math.R
@@ -80,18 +80,18 @@ register_bindings_math <- function() {
       options = list(ndigits = digits, round_mode = RoundMode$HALF_TO_EVEN)
     )
   })
-  
+
   register_binding("sqrt", function(x) {
     build_expr(
       "sqrt_checked",
       x
     )
   })
-  
+
   register_binding("exp", function(x) {
     build_expr(
       "power_checked",
-      exp(1), 
+      exp(1),
       x
     )
   })

--- a/r/R/dplyr-funcs-math.R
+++ b/r/R/dplyr-funcs-math.R
@@ -81,16 +81,14 @@ register_bindings_math <- function() {
     )
   })
   
-  register_binding("sqrt", function(x, ...) {
-    # accepts and ignores ... for consistency with base::trunc()
+  register_binding("sqrt", function(x) {
     build_expr(
       "sqrt_checked",
       x
     )
   })
   
-  register_binding("exp", function(x, ...) {
-    # accepts and ignores ... for consistency with base::trunc()
+  register_binding("exp", function(x) {
     build_expr(
       "power_checked",
       exp(1), 

--- a/r/R/dplyr-funcs-math.R
+++ b/r/R/dplyr-funcs-math.R
@@ -80,4 +80,21 @@ register_bindings_math <- function() {
       options = list(ndigits = digits, round_mode = RoundMode$HALF_TO_EVEN)
     )
   })
+  
+  register_binding("sqrt", function(x, ...) {
+    # accepts and ignores ... for consistency with base::trunc()
+    build_expr(
+      "sqrt_checked",
+      x
+    )
+  })
+  
+  register_binding("exp", function(x, ...) {
+    # accepts and ignores ... for consistency with base::trunc()
+    build_expr(
+      "power_checked",
+      exp(1), 
+      x
+    )
+  })
 }

--- a/r/tests/testthat/test-dplyr-funcs-math.R
+++ b/r/tests/testthat/test-dplyr-funcs-math.R
@@ -330,3 +330,25 @@ test_that("floor division maintains type consistency with R", {
     df
   )
 })
+
+test_that("exp()", {
+  df <- tibble(x = c(1:5, NA))
+  
+  compare_dplyr_binding(
+    .input %>%
+      mutate(y = exp(x)) %>%
+      collect(),
+    df
+  )
+})
+
+test_that("sqrt()", {
+  df <- tibble(x = c(1:5, NA))
+  
+  compare_dplyr_binding(
+    .input %>%
+      mutate(y = sqrt(x)) %>%
+      collect(),
+    df
+  )
+})

--- a/r/tests/testthat/test-dplyr-funcs-math.R
+++ b/r/tests/testthat/test-dplyr-funcs-math.R
@@ -333,7 +333,7 @@ test_that("floor division maintains type consistency with R", {
 
 test_that("exp()", {
   df <- tibble(x = c(1:5, NA))
-  
+
   compare_dplyr_binding(
     .input %>%
       mutate(y = exp(x)) %>%
@@ -344,7 +344,7 @@ test_that("exp()", {
 
 test_that("sqrt()", {
   df <- tibble(x = c(1:5, NA))
-  
+
   compare_dplyr_binding(
     .input %>%
       mutate(y = sqrt(x)) %>%


### PR DESCRIPTION
In response to https://issues.apache.org/jira/browse/ARROW-16871
- implement `sqrt` and `exp` bindings for `dplyr`
- change `sqrt` in `arrow-datum.R` to use `sqrt_checked` rather than `power_checked`
-  write tests for `sqrt` and `exp`