### PR TITLE
ARROW-16700: [C++][R][Datasets] aggregates on partitioning columns

### DIFF
--- a/cpp/src/arrow/compute/exec/expression.h
+++ b/cpp/src/arrow/compute/exec/expression.h
@@ -226,7 +226,8 @@ Result<Expression> SimplifyWithGuarantee(Expression,
 /// RecordBatch which may have missing or incorrectly ordered columns.
 /// Missing fields will be replaced with null scalars.
 ARROW_EXPORT Result<ExecBatch> MakeExecBatch(const Schema& full_schema,
-                                             const Datum& partial);
+                                             const Datum& partial,
+                                             Expression guarantee = literal(true));
 
 /// Execute a scalar expression against the provided state and input ExecBatch. This
 /// expression must be bound.

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -1431,21 +1431,20 @@ DatasetAndBatches MakeBasicDataset() {
 
   const auto physical_schema = SchemaFromColumnNames(dataset_schema, {"a", "b"});
 
-  return DatasetAndBatchesFromJSON(dataset_schema, physical_schema,
+  return DatasetAndBatchesFromJSON(dataset_schema, physical_schema, {
                                    {
-                                       {
-                                           R"([{"a": 1,    "b": null},
-                  {"a": 2,    "b": true}])",
-                                           R"([{"a": null, "b": true},
-                  {"a": 3,    "b": false}])",
-                                       },
-                                       {
-                                           R"([{"a": null, "b": true},
-                  {"a": 4,    "b": false}])",
-                                           R"([{"a": 5,    "b": null},
-                  {"a": 6,    "b": false},
-                  {"a": 7,    "b": false}])",
-                                       },
+                                       R"([{"a": 1,    "b": null},
+                                           {"a": 2,    "b": true}])",
+                                       R"([{"a": null, "b": true},
+                                           {"a": 3,    "b": false}])",
+                                   },
+                                   {
+                                       R"([{"a": null, "b": true},
+                                           {"a": 4,    "b": false}])",
+                                       R"([{"a": 5,    "b": null},
+                                           {"a": 6,    "b": false},
+                                           {"a": 7,    "b": false}])",
+                                   },
                                    },
                                    {
                                        equal(field_ref("c"), literal(23)),

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -1398,8 +1398,7 @@ DatasetAndBatches DatasetAndBatchesFromJSON(
 
       // augment scanned ExecBatch with columns for this fragment's guarantee
       if (!guarantees.empty()) {
-        auto extract_result = ExtractKnownFieldValues(guarantees[frag_ndx]);
-        ARROW_WARN_NOT_OK(extract_result.status(), "ExtractKnownFieldValues failed");
+        EXPECT_OK_AND_ASSIGN(auto extract_result, ExtractKnownFieldValues(guarantees[frag_ndx]));
         for (const auto& known_field : extract_result->map) {
           batches.back().values.emplace_back(known_field.second);
         }

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -1431,25 +1431,27 @@ DatasetAndBatches MakeBasicDataset() {
 
   const auto physical_schema = SchemaFromColumnNames(dataset_schema, {"a", "b"});
 
-  return DatasetAndBatchesFromJSON(dataset_schema, physical_schema, {
-                                   {
-                                       R"([{"a": 1,    "b": null},
-                                           {"a": 2,    "b": true}])",
-                                       R"([{"a": null, "b": true},
-                                           {"a": 3,    "b": false}])",
-                                   },
-                                   {
-                                       R"([{"a": null, "b": true},
-                                           {"a": 4,    "b": false}])",
-                                       R"([{"a": 5,    "b": null},
-                                           {"a": 6,    "b": false},
-                                           {"a": 7,    "b": false}])",
-                                   },
-                                   },
-                                   {
-                                       equal(field_ref("c"), literal(23)),
-                                       equal(field_ref("c"), literal(47)),
-                                   });
+  return DatasetAndBatchesFromJSON(
+      dataset_schema, physical_schema,
+      {
+          {
+              R"([{"a": 1,    "b": null},
+                  {"a": 2,    "b": true}])",
+              R"([{"a": null, "b": true},
+                  {"a": 3,    "b": false}])",
+          },
+          {
+              R"([{"a": null, "b": true},
+                  {"a": 4,    "b": false}])",
+              R"([{"a": 5,    "b": null},
+                  {"a": 6,    "b": false},
+                  {"a": 7,    "b": false}])",
+          },
+      },
+      {
+          equal(field_ref("c"), literal(23)),
+          equal(field_ref("c"), literal(47)),
+      });
 }
 
 DatasetAndBatches MakeNestedDataset() {

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -1397,7 +1397,7 @@ DatasetAndBatches DatasetAndBatchesFromJSON(
       batches.emplace_back(*batch);
 
       // augment scanned ExecBatch with columns for this fragment's guarantee
-      if (not guarantees.empty()) {
+      if (!guarantees.empty()) {
         auto extract_result = ExtractKnownFieldValues(guarantees[frag_ndx]);
         ARROW_WARN_NOT_OK(extract_result.status(), "ExtractKnownFieldValues failed");
         for (const auto& known_field : extract_result->map) {

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -27,6 +27,7 @@
 #include "arrow/compute/api_vector.h"
 #include "arrow/compute/cast.h"
 #include "arrow/compute/exec/exec_plan.h"
+#include "arrow/compute/exec/expression_internal.h"
 #include "arrow/dataset/plan.h"
 #include "arrow/dataset/test_util.h"
 #include "arrow/record_batch.h"
@@ -1358,17 +1359,19 @@ DatasetAndBatches DatasetAndBatchesFromJSON(
     const std::shared_ptr<Schema>& dataset_schema,
     const std::shared_ptr<Schema>& physical_schema,
     const std::vector<std::vector<std::string>>& fragment_batch_strs,
-    const std::vector<compute::Expression>& guarantees,
-    std::function<void(compute::ExecBatch*, const RecordBatch&, size_t guarantee_index)>
-        make_exec_batch = {}) {
+    const std::vector<compute::Expression>& guarantees) {
+  // Expect a guarantee expr for each test fragment
   if (!guarantees.empty()) {
     EXPECT_EQ(fragment_batch_strs.size(), guarantees.size());
   }
+
   RecordBatchVector record_batches;
   FragmentVector fragments;
   fragments.reserve(fragment_batch_strs.size());
-  for (size_t i = 0; i < fragment_batch_strs.size(); i++) {
-    const auto& batch_strs = fragment_batch_strs[i];
+
+  // construct fragments first
+  for (size_t frag_ndx = 0; frag_ndx < fragment_batch_strs.size(); frag_ndx++) {
+    const auto& batch_strs = fragment_batch_strs[frag_ndx];
     RecordBatchVector fragment_batches;
     fragment_batches.reserve(batch_strs.size());
     for (const auto& batch_str : batch_strs) {
@@ -1378,37 +1381,40 @@ DatasetAndBatches DatasetAndBatchesFromJSON(
                           fragment_batches.end());
     fragments.push_back(std::make_shared<InMemoryFragment>(
         physical_schema, std::move(fragment_batches),
-        guarantees.empty() ? literal(true) : guarantees[i]));
+        guarantees.empty() ? literal(true) : guarantees[frag_ndx]));
   }
 
+  // then construct ExecBatches that can reference fields from constructed Fragments
   std::vector<compute::ExecBatch> batches;
   auto batch_it = record_batches.begin();
-  for (size_t fragment_index = 0; fragment_index < fragment_batch_strs.size();
-       ++fragment_index) {
-    for (size_t batch_index = 0; batch_index < fragment_batch_strs[fragment_index].size();
-         ++batch_index) {
+  for (size_t frag_ndx = 0; frag_ndx < fragment_batch_strs.size(); ++frag_ndx) {
+    size_t frag_batch_count = fragment_batch_strs[frag_ndx].size();
+
+    for (size_t batch_index = 0; batch_index < frag_batch_count; ++batch_index) {
       const auto& batch = *batch_it++;
 
       // the scanned ExecBatches will begin with physical columns
       batches.emplace_back(*batch);
 
-      // allow customizing the ExecBatch (e.g. to fill in placeholders for partition
-      // fields)
-      if (make_exec_batch) {
-        make_exec_batch(&batches.back(), *batch, fragment_index);
+      // augment scanned ExecBatch with columns for this fragment's guarantee
+      if (not guarantees.empty()) {
+        auto extract_result = ExtractKnownFieldValues(guarantees[frag_ndx]);
+        ARROW_WARN_NOT_OK(extract_result.status(), "ExtractKnownFieldValues failed");
+        for (const auto& known_field : extract_result->map) {
+          batches.back().values.emplace_back(known_field.second);
+        }
       }
 
       // scanned batches will be augmented with fragment and batch indices
-      batches.back().values.emplace_back(static_cast<int>(fragment_index));
+      batches.back().values.emplace_back(static_cast<int>(frag_ndx));
       batches.back().values.emplace_back(static_cast<int>(batch_index));
 
       // ... and with the last-in-fragment flag
-      batches.back().values.emplace_back(batch_index ==
-                                         fragment_batch_strs[fragment_index].size() - 1);
-      batches.back().values.emplace_back(fragments[fragment_index]->ToString());
+      batches.back().values.emplace_back(batch_index == frag_batch_count - 1);
+      batches.back().values.emplace_back(fragments[frag_ndx]->ToString());
 
       // each batch carries a guarantee inherited from its Fragment's partition expression
-      batches.back().guarantee = fragments[fragment_index]->partition_expression();
+      batches.back().guarantee = fragments[frag_ndx]->partition_expression();
     }
   }
 
@@ -1425,35 +1431,26 @@ DatasetAndBatches MakeBasicDataset() {
 
   const auto physical_schema = SchemaFromColumnNames(dataset_schema, {"a", "b"});
 
-  return DatasetAndBatchesFromJSON(
-      dataset_schema, physical_schema,
-      {
-          {
-              R"([{"a": 1,    "b": null},
+  return DatasetAndBatchesFromJSON(dataset_schema, physical_schema,
+                                   {
+                                       {
+                                           R"([{"a": 1,    "b": null},
                   {"a": 2,    "b": true}])",
-              R"([{"a": null, "b": true},
+                                           R"([{"a": null, "b": true},
                   {"a": 3,    "b": false}])",
-          },
-          {
-              R"([{"a": null, "b": true},
+                                       },
+                                       {
+                                           R"([{"a": null, "b": true},
                   {"a": 4,    "b": false}])",
-              R"([{"a": 5,    "b": null},
+                                           R"([{"a": 5,    "b": null},
                   {"a": 6,    "b": false},
                   {"a": 7,    "b": false}])",
-          },
-      },
-      {
-          equal(field_ref("c"), literal(23)),
-          equal(field_ref("c"), literal(47)),
-      },
-      [](compute::ExecBatch* batch, const RecordBatch&, size_t guarantee_index) {
-        // a placeholder will be inserted for partition field "c"
-        if (guarantee_index == 0) {
-          batch->values.emplace_back(std::make_shared<Int32Scalar>(23));
-        } else {
-          batch->values.emplace_back(std::make_shared<Int32Scalar>(47));
-        }
-      });
+                                       },
+                                   },
+                                   {
+                                       equal(field_ref("c"), literal(23)),
+                                       equal(field_ref("c"), literal(47)),
+                                   });
 }
 
 DatasetAndBatches MakeNestedDataset() {

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -1360,7 +1360,7 @@ DatasetAndBatches DatasetAndBatchesFromJSON(
     const std::shared_ptr<Schema>& physical_schema,
     const std::vector<std::vector<std::string>>& fragment_batch_strs,
     const std::vector<compute::Expression>& guarantees) {
-  // Expect a guarantee expr for each test fragment
+  // If guarantees are provided we must have one for each batch
   if (!guarantees.empty()) {
     EXPECT_EQ(fragment_batch_strs.size(), guarantees.size());
   }

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -1398,8 +1398,9 @@ DatasetAndBatches DatasetAndBatchesFromJSON(
 
       // augment scanned ExecBatch with columns for this fragment's guarantee
       if (!guarantees.empty()) {
-        EXPECT_OK_AND_ASSIGN(auto extract_result, ExtractKnownFieldValues(guarantees[frag_ndx]));
-        for (const auto& known_field : extract_result->map) {
+        EXPECT_OK_AND_ASSIGN(auto known_fields,
+                             ExtractKnownFieldValues(guarantees[frag_ndx]));
+        for (const auto& known_field : known_fields.map) {
           batches.back().values.emplace_back(known_field.second);
         }
       }

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -1431,27 +1431,26 @@ DatasetAndBatches MakeBasicDataset() {
 
   const auto physical_schema = SchemaFromColumnNames(dataset_schema, {"a", "b"});
 
-  return DatasetAndBatchesFromJSON(
-      dataset_schema, physical_schema,
-      {
-          {
-              R"([{"a": 1,    "b": null},
-                  {"a": 2,    "b": true}])",
-              R"([{"a": null, "b": true},
-                  {"a": 3,    "b": false}])",
-          },
-          {
-              R"([{"a": null, "b": true},
-                  {"a": 4,    "b": false}])",
-              R"([{"a": 5,    "b": null},
-                  {"a": 6,    "b": false},
-                  {"a": 7,    "b": false}])",
-          },
-      },
-      {
-          equal(field_ref("c"), literal(23)),
-          equal(field_ref("c"), literal(47)),
-      });
+  return DatasetAndBatchesFromJSON(dataset_schema, physical_schema,
+                                   {
+                                       {
+                                           R"([{"a": 1,    "b": null},
+                                               {"a": 2,    "b": true}])",
+                                           R"([{"a": null, "b": true},
+                                               {"a": 3,    "b": false}])",
+                                       },
+                                       {
+                                           R"([{"a": null, "b": true},
+                                               {"a": 4,    "b": false}])",
+                                           R"([{"a": 5,    "b": null},
+                                               {"a": 6,    "b": false},
+                                               {"a": 7,    "b": false}])",
+                                       },
+                                   },
+                                   {
+                                       equal(field_ref("c"), literal(23)),
+                                       equal(field_ref("c"), literal(47)),
+                                   });
 }
 
 DatasetAndBatches MakeNestedDataset() {


### PR DESCRIPTION
This updates the Scanner node such that it will use the guarantee expression to fill out columns missing from the dataset but guaranteed to be some constant with appropriate scalars, rather than just inserting a null placeholder column. In case both are available, the dataset constructor prefers using the scalar from the guarantee expression over the actual data, since the latter would probably be an array that unnecessarily repeats the constant value.

This is the other part of what was uncovered while analyzing ARROW-16700, the more direct cause being a duplicate of ARROW-16904 (see also https://github.com/apache/arrow/pull/13509 for my fix for that).