### PR TITLE
ARROW-16983: [Go][Parquet] fix EstimatedDataEncodedSize of DeltaByteArrayEncoder

### DIFF
--- a/go/parquet/internal/encoding/delta_byte_array.go
+++ b/go/parquet/internal/encoding/delta_byte_array.go
@@ -39,6 +39,10 @@ type DeltaByteArrayEncoder struct {
 	lastVal parquet.ByteArray
 }
 
+func (enc *DeltaByteArrayEncoder) EstimatedDataEncodedSize() int64 {
+	return enc.prefixEncoder.EstimatedDataEncodedSize() + enc.suffixEncoder.EstimatedDataEncodedSize()
+}
+
 func (enc *DeltaByteArrayEncoder) initEncoders() {
 	enc.prefixEncoder = &DeltaBitPackInt32Encoder{
 		deltaBitPackEncoder: &deltaBitPackEncoder{encoder: newEncoderBase(enc.encoding, nil, enc.mem)}}


### PR DESCRIPTION
`DeltaByteArrayEncoder` extends `encoder` which calculates `EstimatedDataEncodedSize()` by calling `Len()` on its `sink`. `DeltaByteArrayEncoder` however does not write its data out to sink, instead writing out to `prefixEncoder` and `suffixEncoder`, causing EstimatedDataEncodedSize to always return zero, resulting in `FlushCurrentPage` never being called.