### PR TITLE
ARROW-16984: [Ruby] Add support for installing Apache Arrow GLib automatically on Fedora

### DIFF
--- a/ruby/red-arrow-cuda/dependency-check/Rakefile
+++ b/ruby/red-arrow-cuda/dependency-check/Rakefile
@@ -38,8 +38,8 @@ namespace :dependency do
                                     ArrowCUDA::Version::MAJOR,
                                     ArrowCUDA::Version::MINOR,
                                     ArrowCUDA::Version::MICRO)
-      unless NativePackageInstaller.install(:debian => "libarrow-cuda-glib-dev",
-                                            :redhat => "arrow-cuda-glib-devel")
+      unless NativePackageInstaller.install(debian: "libarrow-cuda-glib-dev",
+                                            redhat: "arrow-cuda-glib-devel")
         exit(false)
       end
     end

--- a/ruby/red-arrow-dataset/dependency-check/Rakefile
+++ b/ruby/red-arrow-dataset/dependency-check/Rakefile
@@ -38,8 +38,9 @@ namespace :dependency do
                                     ArrowDataset::Version::MAJOR,
                                     ArrowDataset::Version::MINOR,
                                     ArrowDataset::Version::MICRO)
-      unless NativePackageInstaller.install(:debian => "libarrow-dataset-glib-dev",
-                                            :redhat => "arrow-dataset-glib-devel")
+      unless NativePackageInstaller.install(debian: "libarrow-dataset-glib-dev",
+                                            fedora: "libarrow-dataset-glib-devel",
+                                            redhat: "arrow-dataset-glib-devel")
         exit(false)
       end
     end

--- a/ruby/red-arrow-flight/dependency-check/Rakefile
+++ b/ruby/red-arrow-flight/dependency-check/Rakefile
@@ -38,8 +38,9 @@ namespace :dependency do
                                     ArrowFlight::Version::MAJOR,
                                     ArrowFlight::Version::MINOR,
                                     ArrowFlight::Version::MICRO)
-      unless NativePackageInstaller.install(:debian => "libarrow-flight-glib-dev",
-                                            :redhat => "arrow-flight-glib-devel")
+      unless NativePackageInstaller.install(debian: "libarrow-flight-glib-dev",
+                                            fedora: "libarrow-flight-glib-devel",
+                                            redhat: "arrow-flight-glib-devel")
         exit(false)
       end
     end

--- a/ruby/red-arrow/ext/arrow/extconf.rb
+++ b/ruby/red-arrow/ext/arrow/extconf.rb
@@ -45,9 +45,10 @@ unless required_pkg_config_package([
                                      Arrow::Version::MICRO,
                                    ],
                                    debian: "libarrow-dev",
-                                   redhat: "arrow-devel",
+                                   fedora: "libarrow-devel",
                                    homebrew: "apache-arrow",
-                                   msys2: "arrow")
+                                   msys2: "arrow",
+                                   redhat: "arrow-devel")
   exit(false)
 end
 
@@ -58,9 +59,10 @@ unless required_pkg_config_package([
                                      Arrow::Version::MICRO,
                                    ],
                                    debian: "libarrow-glib-dev",
-                                   redhat: "arrow-glib-devel",
+                                   fedora: "libarrow-glib-devel",
                                    homebrew: "apache-arrow-glib",
-                                   msys2: "arrow")
+                                   msys2: "arrow",
+                                   redhat: "arrow-glib-devel")
   exit(false)
 end
 

--- a/ruby/red-gandiva/dependency-check/Rakefile
+++ b/ruby/red-gandiva/dependency-check/Rakefile
@@ -38,8 +38,8 @@ namespace :dependency do
                                     Gandiva::Version::MAJOR,
                                     Gandiva::Version::MINOR,
                                     Gandiva::Version::MICRO)
-      unless NativePackageInstaller.install(:debian => "libgandiva-glib-dev",
-                                            :redhat => "gandiva-glib-devel")
+      unless NativePackageInstaller.install(debian: "libgandiva-glib-dev",
+                                            redhat: "gandiva-glib-devel")
         exit(false)
       end
     end

--- a/ruby/red-parquet/dependency-check/Rakefile
+++ b/ruby/red-parquet/dependency-check/Rakefile
@@ -38,8 +38,8 @@ namespace :dependency do
                                     Parquet::Version::MAJOR,
                                     Parquet::Version::MINOR,
                                     Parquet::Version::MICRO)
-      unless NativePackageInstaller.install(:debian => "libparquet-glib-dev",
-                                            :redhat => "parquet-glib-devel")
+      unless NativePackageInstaller.install(debian: "libparquet-glib-dev",
+                                            redhat: "parquet-glib-devel")
         exit(false)
       end
     end

--- a/ruby/red-plasma/dependency-check/Rakefile
+++ b/ruby/red-plasma/dependency-check/Rakefile
@@ -38,8 +38,8 @@ namespace :dependency do
                                     Plasma::Version::MAJOR,
                                     Plasma::Version::MINOR,
                                     Plasma::Version::MICRO)
-      unless NativePackageInstaller.install(:debian => "libplasma-glib-dev",
-                                            :redhat => "plasma-glib-devel")
+      unless NativePackageInstaller.install(debian: "libplasma-glib-dev",
+                                            redhat: "plasma-glib-devel")
         exit(false)
       end
     end


### PR DESCRIPTION
Fedora 37 or later will ship Apache Arrow GLib as libarrow-glib-devel:
https://packages.fedoraproject.org/pkgs/libarrow/

Other components such as Apache Arrow Dataset and Apache Arrow Flight
will be shipped too.