### PR TITLE
MINOR: [Python][Docs] Improved grammatical error at line 33

### DIFF
--- a/docs/source/python/index.rst
+++ b/docs/source/python/index.rst
@@ -30,7 +30,7 @@ The Arrow Python bindings (also named "PyArrow") have first-class integration
 with NumPy, pandas, and built-in Python objects. They are based on the C++
 implementation of Arrow.
 
-Here will we detail the usage of the Python API for Arrow and the leaf
+Here we will detail the usage of the Python API for Arrow and the leaf
 libraries that add additional functionality such as reading Apache Parquet
 files into Arrow structures.
 


### PR DESCRIPTION
Improved grammar in line 33.

Before: "Here will we detail..."
Change: "Here we will detail..."