### PR TITLE
ARROW-16989: [C++] Substrait ProjectRel is interpreted incorrectly

### DIFF
--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -52,8 +52,8 @@ Status CheckRelCommon(const RelMessage& rel) {
   return Status::OK();
 }
 
-Result<compute::Declaration> FromProto(const substrait::Rel& rel,
-                                       const ExtensionSet& ext_set) {
+Result<DeclarationInfo> FromProto(const substrait::Rel& rel,
+                                  const ExtensionSet& ext_set) {
   static bool dataset_init = false;
   if (!dataset_init) {
     dataset_init = true;
@@ -180,10 +180,13 @@ Result<compute::Declaration> FromProto(const substrait::Rel& rel,
                                                  std::move(filesystem), std::move(files),
                                                  std::move(format), {}));
 
+      auto num_columns = base_schema->fields().size();
       ARROW_ASSIGN_OR_RAISE(auto ds, ds_factory->Finish(std::move(base_schema)));
 
-      return compute::Declaration{
-          "scan", dataset::ScanNodeOptions{std::move(ds), std::move(scan_options)}};
+      return DeclarationInfo{
+          compute::Declaration{
+              "scan", dataset::ScanNodeOptions{std::move(ds), std::move(scan_options)}},
+          num_columns};
     }
 
     case substrait::Rel::RelTypeCase::kFilter: {
@@ -200,10 +203,12 @@ Result<compute::Declaration> FromProto(const substrait::Rel& rel,
       }
       ARROW_ASSIGN_OR_RAISE(auto condition, FromProto(filter.condition(), ext_set));
 
-      return compute::Declaration::Sequence({
-          std::move(input),
-          {"filter", compute::FilterNodeOptions{std::move(condition)}},
-      });
+      return DeclarationInfo{
+          compute::Declaration::Sequence({
+              std::move(input.declaration),
+              {"filter", compute::FilterNodeOptions{std::move(condition)}},
+          }),
+          input.num_columns};
     }
 
     case substrait::Rel::RelTypeCase::kProject: {
@@ -215,16 +220,24 @@ Result<compute::Declaration> FromProto(const substrait::Rel& rel,
       }
       ARROW_ASSIGN_OR_RAISE(auto input, FromProto(project.input(), ext_set));
 
+      // NOTE: Substrait ProjectRels *append* columns, while Acero's project node replaces
+      // them. Therefore, we need to prefix all the current columns for compatibility.
       std::vector<compute::Expression> expressions;
+      for (size_t i = 0; i < input.num_columns; i++) {
+        expressions.emplace_back(compute::field_ref(FieldRef(static_cast<int>(i))));
+      }
       for (const auto& expr : project.expressions()) {
         expressions.emplace_back();
         ARROW_ASSIGN_OR_RAISE(expressions.back(), FromProto(expr, ext_set));
       }
 
-      return compute::Declaration::Sequence({
-          std::move(input),
-          {"project", compute::ProjectNodeOptions{std::move(expressions)}},
-      });
+      auto num_columns = expressions.size();
+      return DeclarationInfo{
+          compute::Declaration::Sequence({
+              std::move(input.declaration),
+              {"project", compute::ProjectNodeOptions{std::move(expressions)}},
+          }),
+          num_columns};
     }
 
     case substrait::Rel::RelTypeCase::kJoin: {
@@ -304,9 +317,10 @@ Result<compute::Declaration> FromProto(const substrait::Rel& rel,
       join_options.join_type = join_type;
       join_options.key_cmp = {join_key_cmp};
       compute::Declaration join_dec{"hashjoin", std::move(join_options)};
-      join_dec.inputs.emplace_back(std::move(left));
-      join_dec.inputs.emplace_back(std::move(right));
-      return std::move(join_dec);
+      auto num_columns = left.num_columns + right.num_columns;
+      join_dec.inputs.emplace_back(std::move(left.declaration));
+      join_dec.inputs.emplace_back(std::move(right.declaration));
+      return DeclarationInfo{std::move(join_dec), num_columns};
     }
 
     default:

--- a/cpp/src/arrow/engine/substrait/relation_internal.h
+++ b/cpp/src/arrow/engine/substrait/relation_internal.h
@@ -36,7 +36,7 @@ struct DeclarationInfo {
   compute::Declaration declaration;
 
   /// The number of columns returned by the declaration.
-  size_t num_columns;
+  int num_columns;
 };
 
 ARROW_ENGINE_EXPORT

--- a/cpp/src/arrow/engine/substrait/relation_internal.h
+++ b/cpp/src/arrow/engine/substrait/relation_internal.h
@@ -30,8 +30,17 @@
 namespace arrow {
 namespace engine {
 
+/// Information resulting from converting a Substrait relation.
+struct DeclarationInfo {
+  /// The compute declaration produced thus far.
+  compute::Declaration declaration;
+
+  /// The number of columns returned by the declaration.
+  size_t num_columns;
+};
+
 ARROW_ENGINE_EXPORT
-Result<compute::Declaration> FromProto(const substrait::Rel&, const ExtensionSet&);
+Result<DeclarationInfo> FromProto(const substrait::Rel&, const ExtensionSet&);
 
 }  // namespace engine
 }  // namespace arrow


### PR DESCRIPTION
A Substrait ProjectRel *appends* columns to the dataset, while Acero's project node replaces them (emit clauses are instead used to remove or swizzle columns). This PR prefixes the current columns in the project node to make the two compatible.

I don't think a declaration includes information about the number of columns it generates, so I had to refactor a little bit to have relation ToProto return a struct of the declaration and the number of columns, in order to know how many columns to replicate. I expect this struct to grow in importance and features when ARROW-16986 is addressed.