### PR TITLE
ARROW-16995: [CI][C++][MinGW]  Don't cache site-packages

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -350,12 +350,12 @@ jobs:
             --output-document /usr/local/bin/minio.exe \
             https://dl.min.io/server/minio/release/windows-amd64/archive/minio.RELEASE.2022-05-26T05-48-41Z
           chmod +x /usr/local/bin/minio.exe
-      - name: Cache Python packages
+      - name: Cache Python wheels
         uses: actions/cache@v2
         with:
-          path: "d:/a/_temp/msys64/mingw${{ matrix.mingw-n-bits }}/lib/python*/site-packages"
-          key: cpp-gcs-testbench-mingw${{ matrix.mingw-n-bits }}-${{ hashFiles('ci/scripts/install_gcs_testbench.sh') }}
-          restore-keys: cpp-gcs-testbench-mingw${{ matrix.mingw-n-bits }}-
+          path: "${{ env.PIP_CACHE_DIR }}"
+          key: cpp-wheels-mingw${{ matrix.mingw-n-bits }}-${{ hashFiles('ci/scripts/install_gcs_testbench.sh') }}
+          restore-keys: cpp-wheels-mingw${{ matrix.mingw-n-bits }}-
       - name: Install Google Cloud Storage Testbench
         shell: msys2 {0}
         run: |
@@ -363,7 +363,8 @@ jobs:
       - name: Test
         shell: msys2 {0}
         run: |
-          python_version=$(python -c "import sys; print('.'.join(map(str, sys.version_info[0:2])))")
+          python3 -c 'import numpy; print(numpy.version.version)'
+          python_version=$(python3 -c "import sys; print('.'.join(map(str, sys.version_info[0:2])))")
           export PYTHONHOME="$(cygpath --windows ${MINGW_PREFIX})\lib\python${python_version}"
           PYTHONPATH="${PYTHONHOME}"
           PYTHONPATH="${PYTHONPATH};${PYTHONHOME}\lib-dynload"

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -363,7 +363,6 @@ jobs:
       - name: Test
         shell: msys2 {0}
         run: |
-          python3 -c 'import numpy; print(numpy.version.version)'
           python_version=$(python3 -c "import sys; print('.'.join(map(str, sys.version_info[0:2])))")
           export PYTHONHOME="$(cygpath --windows ${MINGW_PREFIX})\lib\python${python_version}"
           PYTHONPATH="${PYTHONHOME}"

--- a/ci/scripts/msys2_setup.sh
+++ b/ci/scripts/msys2_setup.sh
@@ -82,3 +82,4 @@ pacman \
 
 "$(dirname $0)/ccache_setup.sh"
 echo "CCACHE_DIR=$(cygpath --absolute --windows ccache)" >> $GITHUB_ENV
+echo "PIP_CACHE_DIR=$(pip cache dir)" >> $GITHUB_ENV


### PR DESCRIPTION
It may revert updated Python related MSYS2 packages such as
python-numpy. This caches built wheels instead.