### PR TITLE
ARROW-16988: [C++] Introduce Substrait ToProto/FromProto conversion options

### DIFF
--- a/cpp/src/arrow/engine/substrait/expression_internal.h
+++ b/cpp/src/arrow/engine/substrait/expression_internal.h
@@ -23,6 +23,7 @@
 
 #include "arrow/compute/type_fwd.h"
 #include "arrow/engine/substrait/extension_set.h"
+#include "arrow/engine/substrait/options.h"
 #include "arrow/engine/substrait/visibility.h"
 #include "arrow/type_fwd.h"
 
@@ -32,18 +33,22 @@ namespace arrow {
 namespace engine {
 
 ARROW_ENGINE_EXPORT
-Result<compute::Expression> FromProto(const substrait::Expression&, const ExtensionSet&);
+Result<compute::Expression> FromProto(const substrait::Expression&, const ExtensionSet&,
+                                      const ConversionOptions&);
 
 ARROW_ENGINE_EXPORT
 Result<std::unique_ptr<substrait::Expression>> ToProto(const compute::Expression&,
-                                                       ExtensionSet*);
+                                                       ExtensionSet*,
+                                                       const ConversionOptions&);
 
 ARROW_ENGINE_EXPORT
-Result<Datum> FromProto(const substrait::Expression::Literal&, const ExtensionSet&);
+Result<Datum> FromProto(const substrait::Expression::Literal&, const ExtensionSet&,
+                        const ConversionOptions&);
 
 ARROW_ENGINE_EXPORT
 Result<std::unique_ptr<substrait::Expression::Literal>> ToProto(const Datum&,
-                                                                ExtensionSet*);
+                                                                ExtensionSet*,
+                                                                const ConversionOptions&);
 
 }  // namespace engine
 }  // namespace arrow

--- a/cpp/src/arrow/engine/substrait/options.h
+++ b/cpp/src/arrow/engine/substrait/options.h
@@ -54,10 +54,11 @@ enum class ConversionStrictness {
   BEST_EFFORT,
 };
 
-/// Options that control the conversion between Substrait and Acero representations of a plan.
+/// Options that control the conversion between Substrait and Acero representations of a
+/// plan.
 struct ConversionOptions {
   /// \brief How strictly the converter should adhere to the structure of the input.
-  ConversionStrictness strictness = ConversionStrictness::EXACT_ROUNDTRIP;
+  ConversionStrictness strictness = ConversionStrictness::BEST_EFFORT;
 };
 
 }  // namespace engine

--- a/cpp/src/arrow/engine/substrait/options.h
+++ b/cpp/src/arrow/engine/substrait/options.h
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// This API is EXPERIMENTAL.
+
+#pragma once
+
+namespace arrow {
+namespace engine {
+
+/// How strictly to adhere to the input structure when converting between Substrait and
+/// Acero representations of a plan. This allows the user to trade conversion accuracy
+/// for performance and lenience.
+enum class ConversionStrictness {
+  /// Prevent information loss by rejecting incoming plans that use features or contain
+  /// metadata that cannot be exactly represented in the output format in a way that
+  /// will round-trip. Relations/nodes must map one-to-one.
+  PEDANTIC,
+
+  /// When an incoming plan uses a feature that cannot be exactly represented in the
+  /// output format, attempt to emulate that feature as opposed to immediately
+  /// rejecting the plan. For example, a Substrait SortRel with a complex sort key
+  /// expression may be emulated using a project-order-project triple. Relations/nodes
+  /// will thus map one-to-many.
+  PRESERVE_STRUCTURE,
+
+  /// Attempt to prevent performance-related regressions caused by differences in how
+  /// operations are represented in the input and output format, by allowing for
+  /// optimizations that cross structural boundaries. For example, the converter may
+  /// collapse chains of project nodes into one.
+  BEST_EFFORT,
+};
+
+/// Controls how to convert between Substrait and Acero representations of a plan.
+struct ConversionOptions {
+  /// Controls how strictly the converter is to adhere to the structure of the input.
+  ConversionStrictness strictness = ConversionStrictness::PEDANTIC;
+};
+
+}  // namespace engine
+}  // namespace arrow

--- a/cpp/src/arrow/engine/substrait/options.h
+++ b/cpp/src/arrow/engine/substrait/options.h
@@ -54,9 +54,9 @@ enum class ConversionStrictness {
   BEST_EFFORT,
 };
 
-/// Controls how to convert between Substrait and Acero representations of a plan.
+/// Options that control the conversion between Substrait and Acero representations of a plan.
 struct ConversionOptions {
-  /// Controls how strictly the converter is to adhere to the structure of the input.
+  /// \brief How strictly the converter should adhere to the structure of the input.
   ConversionStrictness strictness = ConversionStrictness::EXACT_ROUNDTRIP;
 };
 

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -340,7 +340,8 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel, const ExtensionSet&
         return Status::Invalid("substrait::AggregateRel with no input relation");
       }
 
-      ARROW_ASSIGN_OR_RAISE(auto input, FromProto(aggregate.input(), ext_set));
+      ARROW_ASSIGN_OR_RAISE(auto input,
+                            FromProto(aggregate.input(), ext_set, conversion_options));
 
       if (aggregate.groupings_size() > 1) {
         return Status::NotImplemented(
@@ -351,8 +352,8 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel, const ExtensionSet&
       auto group = aggregate.groupings(0);
       keys.reserve(group.grouping_expressions_size());
       for (int exp_id = 0; exp_id < group.grouping_expressions_size(); exp_id++) {
-        ARROW_ASSIGN_OR_RAISE(auto expr,
-                              FromProto(group.grouping_expressions(exp_id), ext_set));
+        ARROW_ASSIGN_OR_RAISE(auto expr, FromProto(group.grouping_expressions(exp_id),
+                                                   ext_set, conversion_options));
         const auto* field_ref = expr.field_ref();
         if (field_ref) {
           keys.emplace_back(std::move(*field_ref));
@@ -381,8 +382,8 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel, const ExtensionSet&
           auto func_name = std::string(func_record.id.name);
           // aggregate target
           auto subs_func_args = agg_func.arguments(0);
-          ARROW_ASSIGN_OR_RAISE(auto field_expr,
-                                FromProto(subs_func_args.value(), ext_set));
+          ARROW_ASSIGN_OR_RAISE(auto field_expr, FromProto(subs_func_args.value(),
+                                                           ext_set, conversion_options));
           auto target = field_expr.field_ref();
           if (!target) {
             return Status::Invalid(

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -52,8 +52,8 @@ Status CheckRelCommon(const RelMessage& rel) {
   return Status::OK();
 }
 
-Result<DeclarationInfo> FromProto(const substrait::Rel& rel,
-                                  const ExtensionSet& ext_set) {
+Result<DeclarationInfo> FromProto(const substrait::Rel& rel, const ExtensionSet& ext_set,
+                                  const ConversionOptions& conversion_options) {
   static bool dataset_init = false;
   if (!dataset_init) {
     dataset_init = true;
@@ -65,13 +65,15 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel,
       const auto& read = rel.read();
       RETURN_NOT_OK(CheckRelCommon(read));
 
-      ARROW_ASSIGN_OR_RAISE(auto base_schema, FromProto(read.base_schema(), ext_set));
+      ARROW_ASSIGN_OR_RAISE(auto base_schema,
+                            FromProto(read.base_schema(), ext_set, conversion_options));
 
       auto scan_options = std::make_shared<dataset::ScanOptions>();
       scan_options->use_threads = true;
 
       if (read.has_filter()) {
-        ARROW_ASSIGN_OR_RAISE(scan_options->filter, FromProto(read.filter(), ext_set));
+        ARROW_ASSIGN_OR_RAISE(scan_options->filter,
+                              FromProto(read.filter(), ext_set, conversion_options));
       }
 
       if (read.has_projection()) {
@@ -196,12 +198,14 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel,
       if (!filter.has_input()) {
         return Status::Invalid("substrait::FilterRel with no input relation");
       }
-      ARROW_ASSIGN_OR_RAISE(auto input, FromProto(filter.input(), ext_set));
+      ARROW_ASSIGN_OR_RAISE(auto input,
+                            FromProto(filter.input(), ext_set, conversion_options));
 
       if (!filter.has_condition()) {
         return Status::Invalid("substrait::FilterRel with no condition expression");
       }
-      ARROW_ASSIGN_OR_RAISE(auto condition, FromProto(filter.condition(), ext_set));
+      ARROW_ASSIGN_OR_RAISE(auto condition,
+                            FromProto(filter.condition(), ext_set, conversion_options));
 
       return DeclarationInfo{
           compute::Declaration::Sequence({
@@ -218,7 +222,8 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel,
       if (!project.has_input()) {
         return Status::Invalid("substrait::ProjectRel with no input relation");
       }
-      ARROW_ASSIGN_OR_RAISE(auto input, FromProto(project.input(), ext_set));
+      ARROW_ASSIGN_OR_RAISE(auto input,
+                            FromProto(project.input(), ext_set, conversion_options));
 
       // NOTE: Substrait ProjectRels *append* columns, while Acero's project node replaces
       // them. Therefore, we need to prefix all the current columns for compatibility.
@@ -229,7 +234,8 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel,
       }
       for (const auto& expr : project.expressions()) {
         expressions.emplace_back();
-        ARROW_ASSIGN_OR_RAISE(expressions.back(), FromProto(expr, ext_set));
+        ARROW_ASSIGN_OR_RAISE(expressions.back(),
+                              FromProto(expr, ext_set, conversion_options));
       }
 
       auto num_columns = static_cast<int>(expressions.size());
@@ -279,14 +285,17 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel,
           return Status::Invalid("Unsupported join type");
       }
 
-      ARROW_ASSIGN_OR_RAISE(auto left, FromProto(join.left(), ext_set));
-      ARROW_ASSIGN_OR_RAISE(auto right, FromProto(join.right(), ext_set));
+      ARROW_ASSIGN_OR_RAISE(auto left,
+                            FromProto(join.left(), ext_set, conversion_options));
+      ARROW_ASSIGN_OR_RAISE(auto right,
+                            FromProto(join.right(), ext_set, conversion_options));
 
       if (!join.has_expression()) {
         return Status::Invalid("substrait::JoinRel with no expression");
       }
 
-      ARROW_ASSIGN_OR_RAISE(auto expression, FromProto(join.expression(), ext_set));
+      ARROW_ASSIGN_OR_RAISE(auto expression,
+                            FromProto(join.expression(), ext_set, conversion_options));
 
       const auto* callptr = expression.call();
       if (!callptr) {

--- a/cpp/src/arrow/engine/substrait/relation_internal.h
+++ b/cpp/src/arrow/engine/substrait/relation_internal.h
@@ -21,6 +21,7 @@
 
 #include "arrow/compute/exec/exec_plan.h"
 #include "arrow/engine/substrait/extension_types.h"
+#include "arrow/engine/substrait/options.h"
 #include "arrow/engine/substrait/serde.h"
 #include "arrow/engine/substrait/visibility.h"
 #include "arrow/type_fwd.h"
@@ -40,7 +41,8 @@ struct DeclarationInfo {
 };
 
 ARROW_ENGINE_EXPORT
-Result<DeclarationInfo> FromProto(const substrait::Rel&, const ExtensionSet&);
+Result<DeclarationInfo> FromProto(const substrait::Rel&, const ExtensionSet&,
+                                  const ConversionOptions&);
 
 }  // namespace engine
 }  // namespace arrow

--- a/cpp/src/arrow/engine/substrait/serde.h
+++ b/cpp/src/arrow/engine/substrait/serde.h
@@ -28,6 +28,7 @@
 #include "arrow/compute/exec/options.h"
 #include "arrow/dataset/file_base.h"
 #include "arrow/engine/substrait/extension_set.h"
+#include "arrow/engine/substrait/options.h"
 #include "arrow/engine/substrait/visibility.h"
 #include "arrow/result.h"
 #include "arrow/util/string_view.h"
@@ -51,11 +52,13 @@ using ConsumerFactory = std::function<std::shared_ptr<compute::SinkNodeConsumer>
 /// \param[in] registry an extension-id-registry to use, or null for the default one.
 /// \param[out] ext_set_out if non-null, the extension mapping used by the Substrait
 /// Plan is returned here.
+/// \param[in] conversion_options options to control how the conversion is to be done.
 /// \return a vector of ExecNode declarations, one for each toplevel relation in the
 /// Substrait Plan
 ARROW_ENGINE_EXPORT Result<std::vector<compute::Declaration>> DeserializePlans(
     const Buffer& buf, const ConsumerFactory& consumer_factory,
-    const ExtensionIdRegistry* registry = NULLPTR, ExtensionSet* ext_set_out = NULLPTR);
+    const ExtensionIdRegistry* registry = NULLPTR, ExtensionSet* ext_set_out = NULLPTR,
+    const ConversionOptions& conversion_options = {});
 
 /// \brief Deserializes a single-relation Substrait Plan message to an execution plan
 ///
@@ -68,12 +71,14 @@ ARROW_ENGINE_EXPORT Result<std::vector<compute::Declaration>> DeserializePlans(
 /// relation
 /// \param[in] registry an extension-id-registry to use, or null for the default one.
 /// \param[out] ext_set_out if non-null, the extension mapping used by the Substrait
+/// \param[in] conversion_options options to control how the conversion is to be done.
 /// Plan is returned here.
 /// \return an ExecNode corresponding to the single toplevel relation in the Substrait
 /// Plan
 Result<std::shared_ptr<compute::ExecPlan>> DeserializePlan(
     const Buffer& buf, const std::shared_ptr<compute::SinkNodeConsumer>& consumer,
-    const ExtensionIdRegistry* registry = NULLPTR, ExtensionSet* ext_set_out = NULLPTR);
+    const ExtensionIdRegistry* registry = NULLPTR, ExtensionSet* ext_set_out = NULLPTR,
+    const ConversionOptions& conversion_options = {});
 
 /// Factory function type for generating the write options of a node consuming the batches
 /// produced by each toplevel Substrait relation when deserializing a Substrait Plan.
@@ -91,11 +96,13 @@ using WriteOptionsFactory = std::function<std::shared_ptr<dataset::WriteNodeOpti
 /// \param[in] registry an extension-id-registry to use, or null for the default one.
 /// \param[out] ext_set_out if non-null, the extension mapping used by the Substrait
 /// Plan is returned here.
+/// \param[in] conversion_options options to control how the conversion is to be done.
 /// \return a vector of ExecNode declarations, one for each toplevel relation in the
 /// Substrait Plan
 ARROW_ENGINE_EXPORT Result<std::vector<compute::Declaration>> DeserializePlans(
     const Buffer& buf, const WriteOptionsFactory& write_options_factory,
-    const ExtensionIdRegistry* registry = NULLPTR, ExtensionSet* ext_set_out = NULLPTR);
+    const ExtensionIdRegistry* registry = NULLPTR, ExtensionSet* ext_set_out = NULLPTR,
+    const ConversionOptions& conversion_options = {});
 
 /// \brief Deserializes a single-relation Substrait Plan message to an execution plan
 ///
@@ -109,11 +116,13 @@ ARROW_ENGINE_EXPORT Result<std::vector<compute::Declaration>> DeserializePlans(
 /// \param[in] registry an extension-id-registry to use, or null for the default one.
 /// \param[out] ext_set_out if non-null, the extension mapping used by the Substrait
 /// Plan is returned here.
+/// \param[in] conversion_options options to control how the conversion is to be done.
 /// \return a vector of ExecNode declarations, one for each toplevel relation in the
 /// Substrait Plan
 ARROW_ENGINE_EXPORT Result<std::shared_ptr<compute::ExecPlan>> DeserializePlan(
     const Buffer& buf, const std::shared_ptr<dataset::WriteNodeOptions>& write_options,
-    const ExtensionIdRegistry* registry = NULLPTR, ExtensionSet* ext_set_out = NULLPTR);
+    const ExtensionIdRegistry* registry = NULLPTR, ExtensionSet* ext_set_out = NULLPTR,
+    const ConversionOptions& conversion_options = {});
 
 /// \brief Deserializes a Substrait Type message to the corresponding Arrow type
 ///
@@ -121,21 +130,25 @@ ARROW_ENGINE_EXPORT Result<std::shared_ptr<compute::ExecPlan>> DeserializePlan(
 /// message
 /// \param[in] ext_set the extension mapping to use, normally provided by the
 /// surrounding Plan message
+/// \param[in] conversion_options options to control how the conversion is to be done.
 /// \return the corresponding Arrow data type
 ARROW_ENGINE_EXPORT
-Result<std::shared_ptr<DataType>> DeserializeType(const Buffer& buf,
-                                                  const ExtensionSet& ext_set);
+Result<std::shared_ptr<DataType>> DeserializeType(
+    const Buffer& buf, const ExtensionSet& ext_set,
+    const ConversionOptions& conversion_options = {});
 
 /// \brief Serializes an Arrow type to a Substrait Type message
 ///
 /// \param[in] type the Arrow data type to serialize
 /// \param[in,out] ext_set the extension mapping to use; may be updated to add a
 /// mapping for the given type
+/// \param[in] conversion_options options to control how the conversion is to be done.
 /// \return a buffer containing the protobuf serialization of the corresponding Substrait
 /// Type message
 ARROW_ENGINE_EXPORT
-Result<std::shared_ptr<Buffer>> SerializeType(const DataType& type,
-                                              ExtensionSet* ext_set);
+Result<std::shared_ptr<Buffer>> SerializeType(
+    const DataType& type, ExtensionSet* ext_set,
+    const ConversionOptions& conversion_options = {});
 
 /// \brief Deserializes a Substrait NamedStruct message to an Arrow schema
 ///
@@ -143,21 +156,25 @@ Result<std::shared_ptr<Buffer>> SerializeType(const DataType& type,
 /// NamedStruct message
 /// \param[in] ext_set the extension mapping to use, normally provided by the
 /// surrounding Plan message
+/// \param[in] conversion_options options to control how the conversion is to be done.
 /// \return the corresponding Arrow schema
 ARROW_ENGINE_EXPORT
-Result<std::shared_ptr<Schema>> DeserializeSchema(const Buffer& buf,
-                                                  const ExtensionSet& ext_set);
+Result<std::shared_ptr<Schema>> DeserializeSchema(
+    const Buffer& buf, const ExtensionSet& ext_set,
+    const ConversionOptions& conversion_options = {});
 
 /// \brief Serializes an Arrow schema to a Substrait NamedStruct message
 ///
 /// \param[in] schema the Arrow schema to serialize
 /// \param[in,out] ext_set the extension mapping to use; may be updated to add
 /// mappings for the types used in the schema
+/// \param[in] conversion_options options to control how the conversion is to be done.
 /// \return a buffer containing the protobuf serialization of the corresponding Substrait
 /// NamedStruct message
 ARROW_ENGINE_EXPORT
-Result<std::shared_ptr<Buffer>> SerializeSchema(const Schema& schema,
-                                                ExtensionSet* ext_set);
+Result<std::shared_ptr<Buffer>> SerializeSchema(
+    const Schema& schema, ExtensionSet* ext_set,
+    const ConversionOptions& conversion_options = {});
 
 /// \brief Deserializes a Substrait Expression message to a compute expression
 ///
@@ -165,21 +182,25 @@ Result<std::shared_ptr<Buffer>> SerializeSchema(const Schema& schema,
 /// Expression message
 /// \param[in] ext_set the extension mapping to use, normally provided by the
 /// surrounding Plan message
+/// \param[in] conversion_options options to control how the conversion is to be done.
 /// \return the corresponding Arrow compute expression
 ARROW_ENGINE_EXPORT
-Result<compute::Expression> DeserializeExpression(const Buffer& buf,
-                                                  const ExtensionSet& ext_set);
+Result<compute::Expression> DeserializeExpression(
+    const Buffer& buf, const ExtensionSet& ext_set,
+    const ConversionOptions& conversion_options = {});
 
 /// \brief Serializes an Arrow compute expression to a Substrait Expression message
 ///
 /// \param[in] expr the Arrow compute expression to serialize
 /// \param[in,out] ext_set the extension mapping to use; may be updated to add
 /// mappings for the types used in the expression
+/// \param[in] conversion_options options to control how the conversion is to be done.
 /// \return a buffer containing the protobuf serialization of the corresponding Substrait
 /// Expression message
 ARROW_ENGINE_EXPORT
-Result<std::shared_ptr<Buffer>> SerializeExpression(const compute::Expression& expr,
-                                                    ExtensionSet* ext_set);
+Result<std::shared_ptr<Buffer>> SerializeExpression(
+    const compute::Expression& expr, ExtensionSet* ext_set,
+    const ConversionOptions& conversion_options = {});
 
 /// \brief Deserializes a Substrait Rel (relation) message to an ExecNode declaration
 ///
@@ -187,9 +208,11 @@ Result<std::shared_ptr<Buffer>> SerializeExpression(const compute::Expression& e
 /// Rel message
 /// \param[in] ext_set the extension mapping to use, normally provided by the
 /// surrounding Plan message
+/// \param[in] conversion_options options to control how the conversion is to be done.
 /// \return the corresponding ExecNode declaration
 ARROW_ENGINE_EXPORT Result<compute::Declaration> DeserializeRelation(
-    const Buffer& buf, const ExtensionSet& ext_set);
+    const Buffer& buf, const ExtensionSet& ext_set,
+    const ConversionOptions& conversion_options = {});
 
 namespace internal {
 

--- a/cpp/src/arrow/engine/substrait/type_internal.h
+++ b/cpp/src/arrow/engine/substrait/type_internal.h
@@ -22,6 +22,7 @@
 #include <utility>
 
 #include "arrow/engine/substrait/extension_set.h"
+#include "arrow/engine/substrait/options.h"
 #include "arrow/engine/substrait/visibility.h"
 #include "arrow/type_fwd.h"
 
@@ -32,18 +33,20 @@ namespace engine {
 
 ARROW_ENGINE_EXPORT
 Result<std::pair<std::shared_ptr<DataType>, bool>> FromProto(const substrait::Type&,
-                                                             const ExtensionSet&);
+                                                             const ExtensionSet&,
+                                                             const ConversionOptions&);
 
 ARROW_ENGINE_EXPORT
 Result<std::unique_ptr<substrait::Type>> ToProto(const DataType&, bool nullable,
-                                                 ExtensionSet*);
+                                                 ExtensionSet*, const ConversionOptions&);
 
 ARROW_ENGINE_EXPORT
 Result<std::shared_ptr<Schema>> FromProto(const substrait::NamedStruct&,
-                                          const ExtensionSet&);
+                                          const ExtensionSet&, const ConversionOptions&);
 
 ARROW_ENGINE_EXPORT
-Result<std::unique_ptr<substrait::NamedStruct>> ToProto(const Schema&, ExtensionSet*);
+Result<std::unique_ptr<substrait::NamedStruct>> ToProto(const Schema&, ExtensionSet*,
+                                                        const ConversionOptions&);
 
 inline std::string TimestampTzTimezoneString() { return "UTC"; }
 


### PR DESCRIPTION
This introduces the conversion options structure described in the associated JIRA. In the interest of keeping this small, no behavior has been modified to make use of the options yet; the newly added options can only be used to relax the conversion semantics, so the current implementation already satisfies all of them. I'll submit followup issues for features that can make use of the relaxed semantics (ETA: most already existed, so I linked those instead).