### PR TITLE
ARROW-16996: [Java] Configure Netty/GRPC/Protobuf base on BOM configuration + upgrade of dependencies by CVE

### DIFF
--- a/docs/source/developers/java/building.rst
+++ b/docs/source/developers/java/building.rst
@@ -186,11 +186,6 @@ Arrow repository, and update the following settings:
   Settings > Build, Execution, Deployment > Compiler > Java Compiler and disable
   "Use '--release' option for cross-compilation (Java 9 and later)". Otherwise
   you will get an error like "package sun.misc does not exist".
-* You may need to disable the ``linux-netty-native`` or ``mac-netty-native``
-  profile in the Maven tool window if you get an error like the following::
-
-    Unresolved dependency: 'io.netty:netty-transport-native-unix-common:jar:4.1.72.Final'
-
 * If using IntelliJ's Maven integration to build, you may need to change
   ``<fork>`` to ``false`` in the pom.xml files due to an `IntelliJ bug
   <https://youtrack.jetbrains.com/issue/IDEA-278903>`__.

--- a/java/flight/flight-core/pom.xml
+++ b/java/flight/flight-core/pom.xml
@@ -53,27 +53,22 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty</artifactId>
-      <version>${dep.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-core</artifactId>
-      <version>${dep.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-context</artifactId>
-      <version>${dep.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>
-      <version>${dep.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>${dep.netty-tcnative.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
@@ -82,12 +77,10 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
-      <version>${dep.netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport</artifactId>
-      <version>${dep.netty.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -96,17 +89,14 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
-      <version>${dep.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>${dep.protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-api</artifactId>
-      <version>${dep.grpc.version}</version>
     </dependency>
 
     <dependency>
@@ -224,10 +214,10 @@
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>0.6.1</version>
         <configuration>
-          <protocArtifact>com.google.protobuf:protoc:${dep.protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+          <protocArtifact>com.google.protobuf:protoc:${dep.protobuf-bom.version}:exe:${os.detected.classifier}</protocArtifact>
           <clearOutputDirectory>false</clearOutputDirectory>
           <pluginId>grpc-java</pluginId>
-          <pluginArtifact>io.grpc:protoc-gen-grpc-java:${dep.grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+          <pluginArtifact>io.grpc:protoc-gen-grpc-java:${dep.grpc-bom.version}:exe:${os.detected.classifier}</pluginArtifact>
         </configuration>
         <executions>
           <execution>
@@ -257,6 +247,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.3.0</version><!--This verify step require an up to date maven-dependency-plugin-->
         <executions>
           <execution>
             <id>analyze</id>
@@ -275,7 +266,7 @@
       <plugin> <!-- add generated sources to classpath -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>1.9.1</version>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <id>add-generated-sources-to-classpath</id>
@@ -323,7 +314,6 @@
         <dependency>
           <groupId>io.netty</groupId>
           <artifactId>netty-transport-native-unix-common</artifactId>
-          <version>${dep.netty.version}</version>
           <classifier>${os.detected.name}-${os.detected.arch}</classifier>
         </dependency>
       </dependencies>
@@ -339,7 +329,6 @@
         <dependency>
           <groupId>io.netty</groupId>
           <artifactId>netty-transport-native-unix-common</artifactId>
-          <version>${dep.netty.version}</version>
           <classifier>${os.detected.name}-${os.detected.arch}</classifier>
         </dependency>
       </dependencies>

--- a/java/flight/flight-core/pom.xml
+++ b/java/flight/flight-core/pom.xml
@@ -247,7 +247,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.3.0</version><!--This verify step require an up to date maven-dependency-plugin-->
+        <version>3.3.0</version>
         <executions>
           <execution>
             <id>analyze</id>
@@ -266,7 +266,7 @@
       <plugin> <!-- add generated sources to classpath -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>1.9.1</version>
         <executions>
           <execution>
             <id>add-generated-sources-to-classpath</id>
@@ -302,36 +302,4 @@
       </plugin>
     </plugins>
   </build>
-  <profiles>
-    <profile>
-      <id>linux-netty-native</id>
-      <activation>
-        <os>
-          <family>linux</family>
-        </os>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-transport-native-unix-common</artifactId>
-          <classifier>${os.detected.name}-${os.detected.arch}</classifier>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>mac-netty-native</id>
-      <activation>
-        <os>
-          <family>mac</family>
-        </os>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-transport-native-unix-common</artifactId>
-          <classifier>${os.detected.name}-${os.detected.arch}</classifier>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
 </project>

--- a/java/flight/flight-grpc/pom.xml
+++ b/java/flight/flight-grpc/pom.xml
@@ -50,12 +50,10 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-core</artifactId>
-      <version>${dep.grpc.version}</version>
     </dependency>
      <dependency>
        <groupId>io.grpc</groupId>
        <artifactId>grpc-stub</artifactId>
-       <version>${dep.grpc.version}</version>
      </dependency>
     <dependency>
       <groupId>org.apache.arrow</groupId>
@@ -72,7 +70,6 @@
      <dependency>
        <groupId>io.grpc</groupId>
        <artifactId>grpc-protobuf</artifactId>
-       <version>${dep.grpc.version}</version>
      </dependency>
      <dependency>
        <groupId>com.google.guava</groupId>
@@ -81,12 +78,10 @@
      <dependency>
        <groupId>com.google.protobuf</groupId>
        <artifactId>protobuf-java</artifactId>
-       <version>${dep.protobuf.version}</version>
      </dependency>
      <dependency>
        <groupId>io.grpc</groupId>
        <artifactId>grpc-api</artifactId>
-       <version>${dep.grpc.version}</version>
      </dependency>
   </dependencies>
 
@@ -105,10 +100,10 @@
           <artifactId>protobuf-maven-plugin</artifactId>
           <version>0.6.1</version>
           <configuration>
-            <protocArtifact>com.google.protobuf:protoc:${dep.protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+            <protocArtifact>com.google.protobuf:protoc:${dep.protobuf-bom.version}:exe:${os.detected.classifier}</protocArtifact>
             <clearOutputDirectory>false</clearOutputDirectory>
             <pluginId>grpc-java</pluginId>
-            <pluginArtifact>io.grpc:protoc-gen-grpc-java:${dep.grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+            <pluginArtifact>io.grpc:protoc-gen-grpc-java:${dep.grpc-bom.version}:exe:${os.detected.classifier}</pluginArtifact>
           </configuration>
           <executions>
             <execution>

--- a/java/flight/flight-integration-tests/pom.xml
+++ b/java/flight/flight-integration-tests/pom.xml
@@ -48,7 +48,6 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>${dep.protobuf.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>

--- a/java/flight/flight-sql/pom.xml
+++ b/java/flight/flight-sql/pom.xml
@@ -60,7 +60,6 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>
-      <version>${dep.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -69,17 +68,14 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
-      <version>${dep.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>${dep.protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-api</artifactId>
-      <version>${dep.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.arrow</groupId>

--- a/java/flight/pom.xml
+++ b/java/flight/pom.xml
@@ -24,12 +24,6 @@
 
     <packaging>pom</packaging>
 
-    <properties>
-        <dep.grpc.version>1.44.1</dep.grpc.version>
-        <dep.netty-tcnative.version>2.0.46.Final</dep.netty-tcnative.version>
-        <dep.protobuf.version>3.19.4</dep.protobuf.version>
-    </properties>
-
     <modules>
         <module>flight-core</module>
         <module>flight-grpc</module>
@@ -46,10 +40,10 @@
                     <version>0.6.1</version>
                     <configuration>
                         <protocArtifact>
-                            com.google.protobuf:protoc:${dep.protobuf.version}:exe:${os.detected.classifier}
+                            com.google.protobuf:protoc:${dep.protobuf-bom.version}:exe:${os.detected.classifier}
                         </protocArtifact>
                         <pluginId>grpc-java</pluginId>
-                        <pluginArtifact>io.grpc:protoc-gen-grpc-java:${dep.grpc.version}:exe:${os.detected.classifier}
+                        <pluginArtifact>io.grpc:protoc-gen-grpc-java:${dep.grpc-bom.version}:exe:${os.detected.classifier}
                         </pluginArtifact>
                     </configuration>
                 </plugin>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -33,7 +33,9 @@
     <dep.junit.jupiter.version>5.4.0</dep.junit.jupiter.version>
     <dep.slf4j.version>1.7.25</dep.slf4j.version>
     <dep.guava.version>30.1.1-jre</dep.guava.version>
-    <dep.netty.version>4.1.72.Final</dep.netty.version>
+    <dep.netty-bom.version>4.1.78.Final</dep.netty-bom.version>
+    <dep.grpc-bom.version>1.47.0</dep.grpc-bom.version>
+    <dep.protobuf-bom.version>3.21.2</dep.protobuf-bom.version>
     <dep.jackson-bom.version>2.13.2.20220328</dep.jackson-bom.version>
     <dep.hadoop.version>2.7.1</dep.hadoop.version>
     <dep.fbs.version>1.12.0</dep.fbs.version>
@@ -525,21 +527,6 @@
         <version>${dep.guava.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-handler</artifactId>
-        <version>${dep.netty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-buffer</artifactId>
-        <version>${dep.netty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-common</artifactId>
-        <version>${dep.netty.version}</version>
-      </dependency>
-      <dependency>
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
         <version>3.0.2</version>
@@ -575,6 +562,27 @@
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
         <version>${dep.jackson-bom.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${dep.netty-bom.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-bom</artifactId>
+        <version>${dep.grpc-bom.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-bom</artifactId>
+        <version>${dep.protobuf-bom.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
- Configure Netty/GRPC/Protobuf base on BOM Bill Of Material configuration to dependencies versions be added by configuration (https://github.com/netty/netty/issues/5994).
- Upgrade Netty/GRPC/Protobuf dependencies. Netty [CVE](https://github.com/advisories/GHSA-269q-hmxg-m83q) 