### PR TITLE
ARROW-17011: [C++][Flight] Remove the need for serialization_internal.h inside python/flight.cc

### DIFF
--- a/cpp/src/arrow/flight/types.cc
+++ b/cpp/src/arrow/flight/types.cc
@@ -150,6 +150,12 @@ arrow::Result<std::shared_ptr<Schema>> SchemaResult::GetSchema(
   return ipc::ReadSchema(&schema_reader, dictionary_memo);
 }
 
+arrow::Result<SchemaResult> SchemaResult::Make(const Schema& schema) {
+  std::string schema_in;
+  RETURN_NOT_OK(internal::SchemaToString(schema, &schema_in));
+  return SchemaResult(std::move(schema_in));
+}
+
 Status SchemaResult::GetSchema(ipc::DictionaryMemo* dictionary_memo,
                                std::shared_ptr<Schema>* out) const {
   return GetSchema(dictionary_memo).Value(out);

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -396,6 +396,9 @@ struct ARROW_FLIGHT_EXPORT SchemaResult {
  public:
   explicit SchemaResult(std::string schema) : raw_schema_(std::move(schema)) {}
 
+  /// \brief Factory method to construct a SchemaResult.
+  static arrow::Result<SchemaResult> Make(const Schema& schema);
+
   /// \brief return schema
   /// \param[in,out] dictionary_memo for dictionary bookkeeping, will
   /// be modified

--- a/cpp/src/arrow/python/flight.cc
+++ b/cpp/src/arrow/python/flight.cc
@@ -371,20 +371,18 @@ Status CreateFlightInfo(const std::shared_ptr<arrow::Schema>& schema,
                         int64_t total_records, int64_t total_bytes,
                         std::unique_ptr<arrow::flight::FlightInfo>* out) {
   ARROW_ASSIGN_OR_RAISE(auto result,
-    arrow::flight::FlightInfo::Make(*schema,
-                                    descriptor,
-                                    endpoints,
-                                    total_records,
-                                    total_bytes));
-  *out = std::unique_ptr<arrow::flight::FlightInfo>(new arrow::flight::FlightInfo(std::move(result)));
+                        arrow::flight::FlightInfo::Make(*schema, descriptor, endpoints,
+                                                        total_records, total_bytes));
+  *out = std::unique_ptr<arrow::flight::FlightInfo>(
+      new arrow::flight::FlightInfo(std::move(result)));
   return Status::OK();
 }
 
 Status CreateSchemaResult(const std::shared_ptr<arrow::Schema>& schema,
                           std::unique_ptr<arrow::flight::SchemaResult>* out) {
-  ARROW_ASSIGN_OR_RAISE(auto result,
-    arrow::flight::SchemaResult::Make(*schema));
-  *out = std::unique_ptr<arrow::flight::SchemaResult>(new arrow::flight::SchemaResult(std::move(result)));
+  ARROW_ASSIGN_OR_RAISE(auto result, arrow::flight::SchemaResult::Make(*schema));
+  *out = std::unique_ptr<arrow::flight::SchemaResult>(
+      new arrow::flight::SchemaResult(std::move(result)));
   return Status::OK();
 }
 

--- a/cpp/src/arrow/python/flight.cc
+++ b/cpp/src/arrow/python/flight.cc
@@ -371,24 +371,21 @@ Status CreateFlightInfo(const std::shared_ptr<arrow::Schema>& schema,
                         const std::vector<arrow::flight::FlightEndpoint>& endpoints,
                         int64_t total_records, int64_t total_bytes,
                         std::unique_ptr<arrow::flight::FlightInfo>* out) {
-  arrow::flight::FlightInfo::Data flight_data;
-  RETURN_NOT_OK(arrow::flight::internal::SchemaToString(*schema, &flight_data.schema));
-  flight_data.descriptor = descriptor;
-  flight_data.endpoints = endpoints;
-  flight_data.total_records = total_records;
-  flight_data.total_bytes = total_bytes;
-  arrow::flight::FlightInfo value(flight_data);
-  *out = std::unique_ptr<arrow::flight::FlightInfo>(new arrow::flight::FlightInfo(value));
+  ARROW_ASSIGN_OR_RAISE(auto result,
+    arrow::flight::FlightInfo::Make(*schema,
+                                    descriptor,
+                                    endpoints,
+                                    total_records,
+                                    total_bytes));
+  *out = std::unique_ptr<arrow::flight::FlightInfo>(new arrow::flight::FlightInfo(std::move(result)));
   return Status::OK();
 }
 
 Status CreateSchemaResult(const std::shared_ptr<arrow::Schema>& schema,
                           std::unique_ptr<arrow::flight::SchemaResult>* out) {
-  std::string schema_in;
-  RETURN_NOT_OK(arrow::flight::internal::SchemaToString(*schema, &schema_in));
-  arrow::flight::SchemaResult value(schema_in);
-  *out = std::unique_ptr<arrow::flight::SchemaResult>(
-      new arrow::flight::SchemaResult(value));
+  ARROW_ASSIGN_OR_RAISE(auto result,
+    arrow::flight::SchemaResult::Make(*schema));
+  *out = std::unique_ptr<arrow::flight::SchemaResult>(new arrow::flight::SchemaResult(std::move(result)));
   return Status::OK();
 }
 

--- a/cpp/src/arrow/python/flight.cc
+++ b/cpp/src/arrow/python/flight.cc
@@ -18,7 +18,6 @@
 #include <signal.h>
 #include <utility>
 
-#include "arrow/flight/serialization_internal.h"
 #include "arrow/python/flight.h"
 #include "arrow/util/io_util.h"
 #include "arrow/util/logging.h"


### PR DESCRIPTION
The changes made to flight and python flight in https://github.com/apache/arrow/pull/13311 are moved into this separate PR. The reason for separation is for the changes to be merged before the next release and also to make https://github.com/apache/arrow/pull/13311 less complex.

The changes are same as in the PR mentioned. I hope that the changes in `cpp/src/arrow/python/flight.cc` can serve as a test.

cc @lidavidm @jorisvandenbossche 