### PR TITLE
ARROW-16757: [C++][FOLLOWUP] Fix mingw32 RTools 4.0 build by removing usage of alignas

### DIFF
--- a/cpp/src/arrow/array/data.cc
+++ b/cpp/src/arrow/array/data.cc
@@ -219,7 +219,7 @@ void FillZeroLengthArray(const DataType* type, ArraySpan* span) {
   span->length = 0;
   int num_buffers = GetNumBuffers(*type);
   for (int i = 0; i < num_buffers; ++i) {
-    span->buffers[i].data = span->scratch_space;
+    span->buffers[i].data = reinterpret_cast<uint8_t*>(span->scratch_space);
     span->buffers[i].size = 0;
   }
 
@@ -270,7 +270,7 @@ void ArraySpan::FillFromScalar(const Scalar& value) {
     }
   } else if (is_base_binary_like(type_id)) {
     const auto& scalar = checked_cast<const BaseBinaryScalar&>(value);
-    this->buffers[1].data = this->scratch_space;
+    this->buffers[1].data = reinterpret_cast<uint8_t*>(this->scratch_space);
     const uint8_t* data_buffer = nullptr;
     int64_t data_size = 0;
     if (scalar.is_valid) {
@@ -328,7 +328,7 @@ void ArraySpan::FillFromScalar(const Scalar& value) {
     // First buffer is kept null since unions have no validity vector
     this->buffers[0] = {};
 
-    this->buffers[1].data = this->scratch_space;
+    this->buffers[1].data = reinterpret_cast<uint8_t*>(this->scratch_space);
     this->buffers[1].size = 1;
     int8_t* type_codes = reinterpret_cast<int8_t*>(this->scratch_space);
     type_codes[0] = checked_cast<const UnionScalar&>(value).type_code;

--- a/cpp/src/arrow/array/data.h
+++ b/cpp/src/arrow/array/data.h
@@ -269,7 +269,7 @@ struct ARROW_EXPORT ArraySpan {
   // 16 bytes of scratch space to enable this ArraySpan to be a view onto
   // scalar values including binary scalars (where we need to create a buffer
   // that looks like two 32-bit or 64-bit offsets)
-  alignas(64) uint8_t scratch_space[16];
+  uint64_t scratch_space[2];
 
   ArraySpan() = default;
 

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -383,6 +383,10 @@ int64_t ExecSpanIterator::GetNextChunkSpan(int64_t iteration_size, ExecSpan* spa
       continue;
     }
     const ChunkedArray* arg = args_->at(i).chunked_array().get();
+    if (arg->num_chunks() == 0) {
+      iteration_size = 0;
+      continue;
+    }
     const Array* current_chunk;
     while (true) {
       current_chunk = arg->chunk(chunk_indexes_[i]).get();


### PR DESCRIPTION
Using `alignas(64)` (instead of `alignas(8)`) seemed to break this build. 