### PR TITLE
ARROW-16911: [C++] Add Equals method to Partitioning

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "cpp/submodules/parquet-testing"]
 	path = cpp/submodules/parquet-testing
 	url = https://github.com/apache/parquet-testing.git
+[submodule "testing"]
+	path = testing
+	url = https://github.com/apache/arrow-testing

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "cpp/submodules/parquet-testing"]
 	path = cpp/submodules/parquet-testing
 	url = https://github.com/apache/parquet-testing.git
-[submodule "testing"]
-	path = testing
-	url = https://github.com/apache/arrow-testing

--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -131,7 +131,7 @@ bool KeyValuePartitioning::Equals(const Partitioning& other) const {
   int64_t idx = 0;
   for (const auto& array : dictionaries_) {
     const auto& other_array = other_dictionaries[idx++];
-    bool match = (array == NULLPTR && other_array == NULLPTR) ||
+    bool match = (array == nullptr && other_array == nullptr) ||
                  (array && other_array && array->Equals(other_array));
     if (!match) {
       return false;

--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -82,6 +82,11 @@ std::shared_ptr<Partitioning> Partitioning::Default() {
 
     std::string type_name() const override { return "default"; }
 
+    bool Equals(const Partitioning& other) const override {
+      // TODO: implement Equals
+      return false;
+    }
+
     Result<compute::Expression> Parse(const std::string& path) const override {
       return compute::literal(true);
     }

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -71,7 +71,7 @@ class ARROW_DS_EXPORT Partitioning : public util::EqualityComparable<Partitionin
   /// \brief The name identifying the kind of partitioning
   virtual std::string type_name() const = 0;
 
-  /// \brief determines if partiioning is exactly equal
+  //// \brief Return whether the partitionings are equal
   virtual bool Equals(const Partitioning& other) const {
     return schema_->Equals(other.schema_, false);
   }

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -72,7 +72,7 @@ class ARROW_DS_EXPORT Partitioning : public util::EqualityComparable<Partitionin
   virtual std::string type_name() const = 0;
 
   /// \brief determines if partiioning is exactly equal
-  virtual bool Equals(const Partitioning& other) const = 0;
+  virtual bool Equals(const Partitioning& other, bool check_metadata = false) const = 0;
 
   /// \brief If the input batch shares any fields with this partitioning,
   /// produce sub-batches which satisfy mutually exclusive Expressions.
@@ -184,7 +184,7 @@ class ARROW_DS_EXPORT KeyValuePartitioning : public Partitioning {
 
   const ArrayVector& dictionaries() const { return dictionaries_; }
 
-  bool Equals(const Partitioning& other) const override;
+  bool Equals(const Partitioning& other, bool check_metadata = false) const override;
 
  protected:
   KeyValuePartitioning(std::shared_ptr<Schema> schema, ArrayVector dictionaries,
@@ -316,9 +316,9 @@ class ARROW_DS_EXPORT FunctionPartitioning : public Partitioning {
 
   std::string type_name() const override { return name_; }
 
-  bool Equals(const Partitioning& other) const override {
-    // TODO: implement Equals
-    return false;
+  bool Equals(const Partitioning& other, bool check_metadata) const override {
+    return ::arrow::internal::checked_cast<const FunctionPartitioning&>(other)
+               .type_name() == type_name();
   }
 
   Result<compute::Expression> Parse(const std::string& path) const override {

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -72,8 +72,8 @@ class ARROW_DS_EXPORT Partitioning : public util::EqualityComparable<Partitionin
   virtual std::string type_name() const = 0;
 
   /// \brief determines if partiioning is exactly equal
-  virtual bool Equals(const Partitioning& other, bool check_metadata = false) const {
-    return schema_->Equals(other.schema_, check_metadata);
+  virtual bool Equals(const Partitioning& other) const {
+    return schema_->Equals(other.schema_, false);
   }
 
   /// \brief If the input batch shares any fields with this partitioning,
@@ -186,7 +186,7 @@ class ARROW_DS_EXPORT KeyValuePartitioning : public Partitioning {
 
   const ArrayVector& dictionaries() const { return dictionaries_; }
 
-  bool Equals(const Partitioning& other, bool check_metadata = false) const override;
+  bool Equals(const Partitioning& other) const override;
 
  protected:
   KeyValuePartitioning(std::shared_ptr<Schema> schema, ArrayVector dictionaries,
@@ -231,7 +231,7 @@ class ARROW_DS_EXPORT DirectoryPartitioning : public KeyValuePartitioning {
 
   std::string type_name() const override { return "directory"; }
 
-  bool Equals(const Partitioning& other, bool check_metadata) const override;
+  bool Equals(const Partitioning& other) const override;
 
   /// \brief Create a factory for a directory partitioning.
   ///
@@ -292,7 +292,7 @@ class ARROW_DS_EXPORT HivePartitioning : public KeyValuePartitioning {
   static Result<util::optional<Key>> ParseKey(const std::string& segment,
                                               const HivePartitioningOptions& options);
 
-  bool Equals(const Partitioning& other, bool check_metadata) const override;
+  bool Equals(const Partitioning& other) const override;
 
   /// \brief Create a factory for a hive partitioning.
   static std::shared_ptr<PartitioningFactory> MakeFactory(
@@ -322,10 +322,7 @@ class ARROW_DS_EXPORT FunctionPartitioning : public Partitioning {
 
   std::string type_name() const override { return name_; }
 
-  bool Equals(const Partitioning& other, bool check_metadata) const override {
-    return ::arrow::internal::checked_cast<const FunctionPartitioning&>(other)
-               .type_name() == type_name();
-  }
+  bool Equals(const Partitioning& other) const override { return false; }
 
   Result<compute::Expression> Parse(const std::string& path) const override {
     return parse_impl_(path);
@@ -369,7 +366,7 @@ class ARROW_DS_EXPORT FilenamePartitioning : public KeyValuePartitioning {
   static std::shared_ptr<PartitioningFactory> MakeFactory(
       std::vector<std::string> field_names, PartitioningFactoryOptions = {});
 
-  bool Equals(const Partitioning& other, bool check_metadata = false) const override;
+  bool Equals(const Partitioning& other) const override;
 
  private:
   Result<std::vector<Key>> ParseKeys(const std::string& path) const override;

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -73,7 +73,7 @@ class ARROW_DS_EXPORT Partitioning : public util::EqualityComparable<Partitionin
 
   //// \brief Return whether the partitionings are equal
   virtual bool Equals(const Partitioning& other) const {
-    return schema_->Equals(other.schema_, false);
+    return schema_->Equals(other.schema_, /*check_metadata=*/false);
   }
 
   /// \brief If the input batch shares any fields with this partitioning,

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -72,7 +72,9 @@ class ARROW_DS_EXPORT Partitioning : public util::EqualityComparable<Partitionin
   virtual std::string type_name() const = 0;
 
   /// \brief determines if partiioning is exactly equal
-  virtual bool Equals(const Partitioning& other, bool check_metadata = false) const = 0;
+  virtual bool Equals(const Partitioning& other, bool check_metadata = false) const {
+    return schema_->Equals(other.schema_, check_metadata);
+  }
 
   /// \brief If the input batch shares any fields with this partitioning,
   /// produce sub-batches which satisfy mutually exclusive Expressions.
@@ -229,6 +231,8 @@ class ARROW_DS_EXPORT DirectoryPartitioning : public KeyValuePartitioning {
 
   std::string type_name() const override { return "directory"; }
 
+  bool Equals(const Partitioning& other, bool check_metadata) const override;
+
   /// \brief Create a factory for a directory partitioning.
   ///
   /// \param[in] field_names The names for the partition fields. Types will be
@@ -287,6 +291,8 @@ class ARROW_DS_EXPORT HivePartitioning : public KeyValuePartitioning {
 
   static Result<util::optional<Key>> ParseKey(const std::string& segment,
                                               const HivePartitioningOptions& options);
+
+  bool Equals(const Partitioning& other, bool check_metadata) const override;
 
   /// \brief Create a factory for a hive partitioning.
   static std::shared_ptr<PartitioningFactory> MakeFactory(
@@ -362,6 +368,8 @@ class ARROW_DS_EXPORT FilenamePartitioning : public KeyValuePartitioning {
   ///     inferred.
   static std::shared_ptr<PartitioningFactory> MakeFactory(
       std::vector<std::string> field_names, PartitioningFactoryOptions = {});
+
+  bool Equals(const Partitioning& other, bool check_metadata = false) const override;
 
  private:
   Result<std::vector<Key>> ParseKeys(const std::string& path) const override;

--- a/cpp/src/arrow/dataset/partition_test.cc
+++ b/cpp/src/arrow/dataset/partition_test.cc
@@ -244,9 +244,12 @@ TEST_F(TestPartitioning, FilenamePartitioningEquals) {
       schema({field("sigma", int32()), field("beta", utf8())}));
   auto another_part = std::make_shared<FilenamePartitioning>(
       schema({field("sigma", int64()), field("beta", utf8())}));
+  auto some_other_part = std::make_shared<FilenamePartitioning>(
+      schema({field("sigma", int64()), field("beta", utf8())}));
   EXPECT_TRUE(part->Equals(*part));
   EXPECT_FALSE(part->Equals(*other_part));
   EXPECT_FALSE(other_part->Equals(*another_part));
+  EXPECT_TRUE(another_part->Equals(*some_other_part));
 }
 
 TEST_F(TestPartitioning, DirectoryPartitioningFormat) {
@@ -465,10 +468,13 @@ TEST_F(TestPartitioning, HivePartitioningEquals) {
       schema({field("alpha", int32()), field("beta", float32())}), other_vector, "xyz");
   auto some_part = std::make_shared<HivePartitioning>(
       schema({field("alpha", int32()), field("beta", float32())}), array_vector, "abc");
+  auto match_part = std::make_shared<HivePartitioning>(
+      schema({field("alpha", int32()), field("beta", float32())}), array_vector, "xyz");
   EXPECT_TRUE(part->Equals(*part));
   EXPECT_FALSE(part->Equals(*other_part));
   EXPECT_FALSE(part->Equals(*another_part));
   EXPECT_FALSE(part->Equals(*some_part));
+  EXPECT_TRUE(part->Equals(*match_part));
 }
 
 TEST_F(TestPartitioning, CrossCheckPartitioningEquals) {
@@ -1023,16 +1029,6 @@ TEST_F(TestPartitioning, Range) {
                          less(field_ref("y"), literal(1.5))),
                     and_(greater(field_ref("z"), literal(1.5)),
                          less_equal(field_ref("z"), literal(3.0)))}));
-}
-
-TEST_F(TestPartitioning, RangePartitoningEquals) {
-  auto part = std::make_shared<RangePartitioning>(
-      schema({field("x", float64()), field("y", float64()), field("z", float64())}));
-  auto other_part = std::make_shared<RangePartitioning>(
-      schema({field("a", float64()), field("y", float64()), field("z", float64())}));
-
-  EXPECT_FALSE(part->Equals(*other_part));
-  EXPECT_TRUE(part->Equals(*part));
 }
 
 TEST(TestStripPrefixAndFilename, Basic) {

--- a/cpp/src/arrow/dataset/partition_test.cc
+++ b/cpp/src/arrow/dataset/partition_test.cc
@@ -891,9 +891,8 @@ class RangePartitioning : public Partitioning {
 
   std::string type_name() const override { return "range"; }
 
-  bool Equals(const Partitioning& other) const override {
-    // TODO: implement Equals
-    return false;
+  bool Equals(const Partitioning& other, bool check_metadata) const override {
+    return checked_cast<const RangePartitioning&>(other).type_name() == type_name();
   }
 
   Result<compute::Expression> Parse(const std::string& path) const override {

--- a/cpp/src/arrow/dataset/partition_test.cc
+++ b/cpp/src/arrow/dataset/partition_test.cc
@@ -211,8 +211,8 @@ TEST_F(TestPartitioning, DirectoryPartitioningEquals) {
       schema({field("alpha", int32()), field("beta", utf8())}));
   auto other = std::make_shared<DirectoryPartitioning>(
       schema({field("alpha", int32()), field("beta", utf8())}));
-  EXPECT_TRUE(part->Equals(*part, true));
-  EXPECT_FALSE(part->Equals(*other, true));
+  EXPECT_TRUE(part->Equals(*part));
+  EXPECT_FALSE(part->Equals(*other));
 }
 
 TEST_F(TestPartitioning, FilenamePartitioning) {
@@ -236,8 +236,8 @@ TEST_F(TestPartitioning, FilenamePartitioningEquals) {
       schema({field("alpha", int32()), field("beta", utf8())}));
   auto other_part = std::make_shared<FilenamePartitioning>(
       schema({field("sigma", int32()), field("beta", utf8())}));
-  EXPECT_TRUE(part->Equals(*part, true));
-  EXPECT_FALSE(part->Equals(*other_part, true));
+  EXPECT_TRUE(part->Equals(*part));
+  EXPECT_FALSE(part->Equals(*other_part));
 }
 
 TEST_F(TestPartitioning, DirectoryPartitioningFormat) {
@@ -454,10 +454,10 @@ TEST_F(TestPartitioning, HivePartitioningEquals) {
       schema({field("alpha", int32()), field("beta", float32())}), ArrayVector(), "xyz");
   auto some_part = std::make_shared<HivePartitioning>(
       schema({field("alpha", int32()), field("beta", float32())}), array_vector, "abc");
-  EXPECT_TRUE(part->Equals(*part, true));
-  EXPECT_FALSE(part->Equals(*other_part, true));
-  EXPECT_FALSE(part->Equals(*another_part, true));
-  EXPECT_FALSE(part->Equals(*some_part, true));
+  EXPECT_TRUE(part->Equals(*part));
+  EXPECT_FALSE(part->Equals(*other_part));
+  EXPECT_FALSE(part->Equals(*another_part));
+  EXPECT_FALSE(part->Equals(*some_part));
 }
 
 TEST_F(TestPartitioning, HivePartitioningFormat) {
@@ -925,12 +925,12 @@ class RangePartitioning : public Partitioning {
 
   std::string type_name() const override { return "range"; }
 
-  bool Equals(const Partitioning& other, bool check_metadata) const override {
+  bool Equals(const Partitioning& other) const override {
     if (this == &other) {
       return true;
     }
     return checked_cast<const RangePartitioning&>(other).type_name() == type_name() &&
-           Partitioning::Equals(other, check_metadata);
+           Partitioning::Equals(other);
   }
 
   Result<compute::Expression> Parse(const std::string& path) const override {
@@ -1001,14 +1001,14 @@ TEST_F(TestPartitioning, Range) {
                          less_equal(field_ref("z"), literal(3.0)))}));
 }
 
-TEST_F(TestPartitioning, RangeEquals) {
+TEST_F(TestPartitioning, RangePartitoningEquals) {
   auto part = std::make_shared<RangePartitioning>(
       schema({field("x", float64()), field("y", float64()), field("z", float64())}));
   auto other_part = std::make_shared<RangePartitioning>(
       schema({field("a", float64()), field("y", float64()), field("z", float64())}));
 
-  EXPECT_FALSE(part->Equals(*other_part, false));
-  EXPECT_TRUE(part->Equals(*part, true));
+  EXPECT_FALSE(part->Equals(*other_part));
+  EXPECT_TRUE(part->Equals(*part));
 }
 
 TEST(TestStripPrefixAndFilename, Basic) {

--- a/cpp/src/arrow/dataset/partition_test.cc
+++ b/cpp/src/arrow/dataset/partition_test.cc
@@ -458,8 +458,10 @@ TEST_F(TestPartitioning, HivePartitioning) {
 
 TEST_F(TestPartitioning, HivePartitioningEquals) {
   const auto& array_vector = ArrayVector();
-  const auto& other_vector = {ArrayFromJSON(utf8(), R"(["foo", "bar", "baz"])"),
-                              ArrayFromJSON(utf8(), R"(["bar", "foo", "baz"])")};
+  std::vector<std::shared_ptr<arrow::Array>> other_vector;
+  other_vector.reserve(2);
+  other_vector.push_back(ArrayFromJSON(utf8(), R"(["foo", "bar", "baz"])"));
+  other_vector.push_back(ArrayFromJSON(utf8(), R"(["bar", "foo", "baz"])"));
   auto part = std::make_shared<HivePartitioning>(
       schema({field("alpha", int32()), field("beta", float32())}), array_vector, "xyz");
   auto other_part = std::make_shared<HivePartitioning>(

--- a/cpp/src/arrow/dataset/partition_test.cc
+++ b/cpp/src/arrow/dataset/partition_test.cc
@@ -891,6 +891,11 @@ class RangePartitioning : public Partitioning {
 
   std::string type_name() const override { return "range"; }
 
+  bool Equals(const Partitioning& other) const override {
+    // TODO: implement Equals
+    return false;
+  }
+
   Result<compute::Expression> Parse(const std::string& path) const override {
     std::vector<compute::Expression> ranges;
 

--- a/cpp/src/arrow/dataset/partition_test.cc
+++ b/cpp/src/arrow/dataset/partition_test.cc
@@ -458,8 +458,7 @@ TEST_F(TestPartitioning, HivePartitioning) {
 
 TEST_F(TestPartitioning, HivePartitioningEquals) {
   const auto& array_vector = ArrayVector();
-  std::vector<std::shared_ptr<arrow::Array>> other_vector;
-  other_vector.reserve(2);
+  std::vector<std::shared_ptr<arrow::Array>> other_vector(2);
   other_vector.push_back(ArrayFromJSON(utf8(), R"(["foo", "bar", "baz"])"));
   other_vector.push_back(ArrayFromJSON(utf8(), R"(["bar", "foo", "baz"])"));
   auto part = std::make_shared<HivePartitioning>(

--- a/cpp/src/arrow/dataset/partition_test.cc
+++ b/cpp/src/arrow/dataset/partition_test.cc
@@ -458,9 +458,9 @@ TEST_F(TestPartitioning, HivePartitioning) {
 
 TEST_F(TestPartitioning, HivePartitioningEquals) {
   const auto& array_vector = ArrayVector();
-  std::vector<std::shared_ptr<arrow::Array>> other_vector(2);
-  other_vector.push_back(ArrayFromJSON(utf8(), R"(["foo", "bar", "baz"])"));
-  other_vector.push_back(ArrayFromJSON(utf8(), R"(["bar", "foo", "baz"])"));
+  ArrayVector other_vector(2);
+  other_vector[0] = ArrayFromJSON(utf8(), R"(["foo", "bar", "baz"])");
+  other_vector[1] = ArrayFromJSON(utf8(), R"(["bar", "foo", "baz"])");
   auto part = std::make_shared<HivePartitioning>(
       schema({field("alpha", int32()), field("beta", float32())}), array_vector, "xyz");
   auto other_part = std::make_shared<HivePartitioning>(


### PR DESCRIPTION
Adding `Equals` method to `Partitioning` class and extended classes. Also include a few test cases. 