### PR TITLE
ARROW-17039: [C++] Partition schema() method is not const supported.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "cpp/submodules/parquet-testing"]
 	path = cpp/submodules/parquet-testing
 	url = https://github.com/apache/parquet-testing.git
+[submodule "testing"]
+	path = testing
+	url = https://github.com/apache/arrow-testing

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "cpp/submodules/parquet-testing"]
 	path = cpp/submodules/parquet-testing
 	url = https://github.com/apache/parquet-testing.git
-[submodule "testing"]
-	path = testing
-	url = https://github.com/apache/arrow-testing

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -88,7 +88,7 @@ class ARROW_DS_EXPORT Partitioning {
   static std::shared_ptr<Partitioning> Default();
 
   /// \brief The partition schema.
-  const std::shared_ptr<Schema>& schema() { return schema_; }
+  const std::shared_ptr<Schema>& schema() const { return schema_; }
 
  protected:
   explicit Partitioning(std::shared_ptr<Schema> schema) : schema_(std::move(schema)) {}


### PR DESCRIPTION
This is a trivial change but non-trivial in usage. The context is discussed in the JIRA. 