### PR TITLE
ARROW-16978: [C#] Intermittent Archery Failures

### DIFF
--- a/csharp/src/Apache.Arrow/Extensions/ArrayPoolExtensions.cs
+++ b/csharp/src/Apache.Arrow/Extensions/ArrayPoolExtensions.cs
@@ -42,14 +42,14 @@ namespace Apache.Arrow
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ValueTask RentReturnAsync(this ArrayPool<byte> pool, int length, Func<Memory<byte>, ValueTask> action)
+        public static async ValueTask RentReturnAsync(this ArrayPool<byte> pool, int length, Func<Memory<byte>, ValueTask> action)
         {
             byte[] array = null;
 
             try
             {
                 array = pool.Rent(length);
-                return action(array.AsMemory(0, length));
+                await action(array.AsMemory(0, length));
             }
             finally
             {


### PR DESCRIPTION
RentReturnAsync has a bug where the rented byte[] is getting returned to the pool while the async action is still using it. This causes intermittent failures due to the pooled array's data being overwritten while it is still used.

To fix the issue, we need to await the async action and only return the rented array back to the pool once the async action is complete.