### PR TITLE
ARROW-17040: [Go] Add a new StructBuilder constructor to support some specific use cases

### DIFF
--- a/go/arrow/array/struct.go
+++ b/go/arrow/array/struct.go
@@ -182,16 +182,20 @@ func NewStructBuilder(mem memory.Allocator, dtype *arrow.StructType) *StructBuil
 }
 
 // UnsafeNewStructBuilderFromFields returns a builder, using the provided memory allocator, fields and corresponding
-// initialized builders.
+// initialized builders. This method is unsafe because the caller must ensure that the fields and builders are
+// compatible and that the builder are the same length.
+//
+// Use case: Can be used by libraries that implement their own Arrow builders tree and ensure by themselves the
+// validation of fields and builders.
 func UnsafeNewStructBuilderFromFields(mem memory.Allocator, fields []arrow.Field, builders []Builder) *StructBuilder {
-	var length int
-	for i, b := range builders {
-		if i == 0 {
-			length = b.Len()
-		} else if b.Len() != length {
-			panic("builders must have the same length")
-		}
+	if len(fields) != len(builders) {
+		panic("fields and builders must be the same length")
 	}
+	if len(builders) == 0 {
+		panic("builders must not be empty")
+	}
+	length := builders[0].Len()
+
 	builder := &StructBuilder{
 		builder: builder{refCount: 1, mem: mem},
 		dtype:   arrow.StructOf(fields...),


### PR DESCRIPTION
Currently, the `NewStructBuilder` constructor takes a struct data type and creates the constructor hierarchy itself. While interesting in most cases, this approach is not easy to integrate with some libraries.

This PR introduces a new constructor `UnsafeNewStructBuilderFromFields`. `UnsafeNewStructBuilderFromFields` returns a builder, using the provided memory allocator, the corresponding initialized fields and constructors. This method is unsafe because the caller must ensure that the fields and constructors are compatible and that the builders have the same length. 

Use case: Can be used by libraries that implement their own Arrow builders tree and ensure the validation of fields and builders by themselves.

Jira issue: https://issues.apache.org/jira/browse/ARROW-17040 