### PR TITLE
ARROW-17050: [CI] Use -y flag on mamba install to not ask for confirmation

### DIFF
--- a/ci/docker/conda-cpp.dockerfile
+++ b/ci/docker/conda-cpp.dockerfile
@@ -26,7 +26,7 @@ RUN /arrow/ci/scripts/install_minio.sh latest /opt/conda
 COPY ci/conda_env_cpp.txt \
      ci/conda_env_gandiva.txt \
      /arrow/ci/
-RUN mamba install \
+RUN mamba install -q -y \
         --file arrow/ci/conda_env_cpp.txt \
         --file arrow/ci/conda_env_gandiva.txt \
         compilers \

--- a/ci/docker/conda-integration.dockerfile
+++ b/ci/docker/conda-integration.dockerfile
@@ -27,7 +27,7 @@ ARG go=1.15
 
 # Install Archery and integration dependencies
 COPY ci/conda_env_archery.txt /arrow/ci/
-RUN mamba install -q \
+RUN mamba install -q -y \
         --file arrow/ci/conda_env_archery.txt \
         "python>=3.7" \
         numpy \

--- a/ci/docker/conda-python-hdfs.dockerfile
+++ b/ci/docker/conda-python-hdfs.dockerfile
@@ -22,7 +22,7 @@ FROM ${repo}:${arch}-conda-python-${python}
 
 ARG jdk=8
 ARG maven=3.5
-RUN mamba install -q \
+RUN mamba install -q -y \
         maven=${maven} \
         openjdk=${jdk} \
         pandas && \

--- a/ci/docker/conda-python-jpype.dockerfile
+++ b/ci/docker/conda-python-jpype.dockerfile
@@ -22,7 +22,7 @@ FROM ${repo}:${arch}-conda-python-${python}
 
 ARG jdk=11
 ARG maven=3.6
-RUN mamba install -q \
+RUN mamba install -q -y \
         maven=${maven} \
         openjdk=${jdk} \
         jpype1 && \

--- a/ci/docker/conda-python-kartothek.dockerfile
+++ b/ci/docker/conda-python-kartothek.dockerfile
@@ -21,7 +21,7 @@ ARG python=3.8
 FROM ${repo}:${arch}-conda-python-${python}
 
 # install kartothek dependencies from conda-forge
-RUN mamba install -c conda-forge -q \
+RUN mamba install -c conda-forge -q -y \
         attrs \
         click \
         cloudpickle \

--- a/ci/docker/conda-python-spark.dockerfile
+++ b/ci/docker/conda-python-spark.dockerfile
@@ -23,7 +23,7 @@ FROM ${repo}:${arch}-conda-python-${python}
 ARG jdk=8
 ARG maven=3.5
 
-RUN mamba install -q \
+RUN mamba install -q -y \
         openjdk=${jdk} \
         maven=${maven} \
         pandas && \

--- a/ci/docker/conda-python-turbodbc.dockerfile
+++ b/ci/docker/conda-python-turbodbc.dockerfile
@@ -30,7 +30,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     rm -rf /var/lib/apt/lists/*
 
 # install turbodbc dependencies from conda-forge
-RUN mamba install -c conda-forge -q \
+RUN mamba install -c conda-forge -q -y \
         pybind11 \
         pytest-cov \
         mock \

--- a/ci/docker/conda-python.dockerfile
+++ b/ci/docker/conda-python.dockerfile
@@ -24,7 +24,7 @@ ARG python=3.8
 COPY ci/conda_env_python.txt \
      ci/conda_env_sphinx.txt \
      /arrow/ci/
-RUN mamba install -q \
+RUN mamba install -q -y \
         --file arrow/ci/conda_env_python.txt \
         --file arrow/ci/conda_env_sphinx.txt \
         $([ "$python" == "3.7" ] && echo "pickle5") \


### PR DESCRIPTION
When locally building the `conda-cpp-valgrind` docker image I've realised we are prompting for confirmation:

```
#10 12.35 Confirm changes: [Y/n] 
#10 88.01  
```
We should use the -y flag when using mamba install:
```
  -y, --yes             Do not ask for confirmation.
```
With this change we are no longer seeing the `Confirm changes` message from mamba.