### PR TITLE
ARROW-16807: [C++][R] count distinct incorrectly merges state

### DIFF
--- a/cpp/src/arrow/compute/kernels/aggregate_basic.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic.cc
@@ -156,7 +156,8 @@ struct CountDistinctImpl : public ScalarAggregator {
 
   Status MergeFrom(KernelContext*, KernelState&& src) override {
     const auto& other_state = checked_cast<const CountDistinctImpl&>(src);
-    this->non_nulls += other_state.non_nulls;
+    this->memo_table_->MergeTable(*(other_state.memo_table_));
+    this->non_nulls = this->memo_table_->size();
     this->has_nulls = this->has_nulls || other_state.has_nulls;
     return Status::OK();
   }

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -962,10 +962,9 @@ class TestCountDistinctKernel : public ::testing::Test {
     EXPECT_THAT(CallFunction("count_distinct", {input}, &all), one);
   }
 
-  void CheckChunkedArr( const std::shared_ptr<DataType> &type
-                       ,const std::vector<std::string>  &json
-                       ,int64_t                          expected_all
-                       ,bool                             has_nulls = true) {
+  void CheckChunkedArr(const std::shared_ptr<DataType>& type,
+                       const std::vector<std::string>& json, int64_t expected_all,
+                       bool has_nulls = true) {
     Check(ChunkedArrayFromJSON(type, json), expected_all, has_nulls);
   }
 
@@ -976,58 +975,66 @@ class TestCountDistinctKernel : public ::testing::Test {
 
 TEST_F(TestCountDistinctKernel, AllChunkedArrayTypesWithNulls) {
   // Boolean
-  CheckChunkedArr(boolean(), {"[]" , "[]"}, 0, /*has_nulls=*/false);
+  CheckChunkedArr(boolean(), {"[]", "[]"}, 0, /*has_nulls=*/false);
   CheckChunkedArr(boolean(), {"[true, null]", "[false, null, false]", "[true]"}, 3);
 
   // Number
   for (auto ty : NumericTypes()) {
-    CheckChunkedArr(ty,{"[1, 1, null, 2]","[5, 8, 9, 9, null, 10]","[6, 6, 8, 9, 10]"},8);
-    CheckChunkedArr(ty,{"[1, 1, 8, 2]","[5, 8, 9, 9, 10]","[10, 6, 6]"},7,/*has_nulls=*/false);
+    CheckChunkedArr(ty, {"[1, 1, null, 2]", "[5, 8, 9, 9, null, 10]", "[6, 6, 8, 9, 10]"},
+                    8);
+    CheckChunkedArr(ty, {"[1, 1, 8, 2]", "[5, 8, 9, 9, 10]", "[10, 6, 6]"}, 7,
+                    /*has_nulls=*/false);
   }
 
   // Date
-  CheckChunkedArr(date32(),{"[0, 11016]", "[0, null, 14241, 14241, null]"},4);
-  CheckChunkedArr(date64(),{"[0, null]", "[0, null, 0, 0, 1262217600000]"},3);
+  CheckChunkedArr(date32(), {"[0, 11016]", "[0, null, 14241, 14241, null]"}, 4);
+  CheckChunkedArr(date64(), {"[0, null]", "[0, null, 0, 0, 1262217600000]"}, 3);
 
   // Time
-  CheckChunkedArr(time32(TimeUnit::SECOND),{"[ 0, 11, 0, null]", "[14, 14, null]"},4);
-  CheckChunkedArr(time32(TimeUnit::MILLI),{"[ 0, 11000, 0]", "[null, 11000, 11000]"},3);
+  CheckChunkedArr(time32(TimeUnit::SECOND), {"[ 0, 11, 0, null]", "[14, 14, null]"}, 4);
+  CheckChunkedArr(time32(TimeUnit::MILLI), {"[ 0, 11000, 0]", "[null, 11000, 11000]"}, 3);
 
-  CheckChunkedArr(time64(TimeUnit::MICRO),{"[84203999999, 0, null, 84203999999]", "[0]"},3);
-  CheckChunkedArr(time64(TimeUnit::NANO),{"[11715003000000, 0, null, 0, 0]", "[0, 0, null]"},3);
+  CheckChunkedArr(time64(TimeUnit::MICRO), {"[84203999999, 0, null, 84203999999]", "[0]"},
+                  3);
+  CheckChunkedArr(time64(TimeUnit::NANO),
+                  {"[11715003000000, 0, null, 0, 0]", "[0, 0, null]"}, 3);
 
   // Timestamp & Duration
   for (auto u : TimeUnit::values()) {
-    CheckChunkedArr(duration(u),{"[123456789, null, 987654321]", "[123456789, null]"},3);
+    CheckChunkedArr(duration(u), {"[123456789, null, 987654321]", "[123456789, null]"},
+                    3);
 
     CheckChunkedArr(duration(u),
-                    {"[123456789, 987654321, 123456789, 123456789]","[123456789]"},2,
+                    {"[123456789, 987654321, 123456789, 123456789]", "[123456789]"}, 2,
                     /*has_nulls=*/false);
 
-    auto ts = std::vector<std::string> {R"(["2009-12-31T04:20:20", "2009-12-31T04:20:20"])",
-               R"(["2020-01-01", null])",R"(["2020-01-01", null])"};
-    CheckChunkedArr(timestamp(u),                      ts, 3);
+    auto ts =
+        std::vector<std::string>{R"(["2009-12-31T04:20:20", "2009-12-31T04:20:20"])",
+                                 R"(["2020-01-01", null])", R"(["2020-01-01", null])"};
+    CheckChunkedArr(timestamp(u), ts, 3);
     CheckChunkedArr(timestamp(u, "Pacific/Marquesas"), ts, 3);
   }
 
   // Interval
-  CheckChunkedArr(month_interval(),{"[9012, 5678, null, 9012]", "[5678, null, 9012]"},3);
-  CheckChunkedArr(day_time_interval(),{"[[0, 1], [0, 1]]","[null, [0, 1], [1234, 5678]]"},3);
-  CheckChunkedArr(month_day_nano_interval(),{"[[0, 1, 2]]", "[[0, 1, 2], null, [0, 1, 2]]"},2);
+  CheckChunkedArr(month_interval(), {"[9012, 5678, null, 9012]", "[5678, null, 9012]"},
+                  3);
+  CheckChunkedArr(day_time_interval(),
+                  {"[[0, 1], [0, 1]]", "[null, [0, 1], [1234, 5678]]"}, 3);
+  CheckChunkedArr(month_day_nano_interval(),
+                  {"[[0, 1, 2]]", "[[0, 1, 2], null, [0, 1, 2]]"}, 2);
 
   // Binary & String & Fixed binary
-  auto samples = std::vector<std::string> {R"([null, "abc", null])",
-                                           R"(["abc", "abc", "cba"])",
-                                           R"(["bca", "cba", null])"};
+  auto samples = std::vector<std::string>{
+      R"([null, "abc", null])", R"(["abc", "abc", "cba"])", R"(["bca", "cba", null])"};
 
-  CheckChunkedArr(            binary(), samples, 4);
-  CheckChunkedArr(      large_binary(), samples, 4);
-  CheckChunkedArr(              utf8(), samples, 4);
-  CheckChunkedArr(        large_utf8(), samples, 4);
+  CheckChunkedArr(binary(), samples, 4);
+  CheckChunkedArr(large_binary(), samples, 4);
+  CheckChunkedArr(utf8(), samples, 4);
+  CheckChunkedArr(large_utf8(), samples, 4);
   CheckChunkedArr(fixed_size_binary(3), samples, 4);
 
   // Decimal
-  samples =  {R"(["12345.679", "98765.421"])", R"([null, "12345.679", "98765.421"])"};
+  samples = {R"(["12345.679", "98765.421"])", R"([null, "12345.679", "98765.421"])"};
   CheckChunkedArr(decimal128(21, 3), samples, 3);
   CheckChunkedArr(decimal256(13, 3), samples, 3);
 }

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -962,10 +962,75 @@ class TestCountDistinctKernel : public ::testing::Test {
     EXPECT_THAT(CallFunction("count_distinct", {input}, &all), one);
   }
 
+  void CheckChunkedArr( const std::shared_ptr<DataType> &type
+                       ,const std::vector<std::string>  &json
+                       ,int64_t                          expected_all
+                       ,bool                             has_nulls = true) {
+    Check(ChunkedArrayFromJSON(type, json), expected_all, has_nulls);
+  }
+
   CountOptions only_valid{CountOptions::ONLY_VALID};
   CountOptions only_null{CountOptions::ONLY_NULL};
   CountOptions all{CountOptions::ALL};
 };
+
+TEST_F(TestCountDistinctKernel, AllChunkedArrayTypesWithNulls) {
+  // Boolean
+  CheckChunkedArr(boolean(), {"[]" , "[]"}, 0, /*has_nulls=*/false);
+  CheckChunkedArr(boolean(), {"[true, null]", "[false, null, false]", "[true]"}, 3);
+
+  // Number
+  for (auto ty : NumericTypes()) {
+    CheckChunkedArr(ty,{"[1, 1, null, 2]","[5, 8, 9, 9, null, 10]","[6, 6, 8, 9, 10]"},8);
+    CheckChunkedArr(ty,{"[1, 1, 8, 2]","[5, 8, 9, 9, 10]","[10, 6, 6]"},7,/*has_nulls=*/false);
+  }
+
+  // Date
+  CheckChunkedArr(date32(),{"[0, 11016]", "[0, null, 14241, 14241, null]"},4);
+  CheckChunkedArr(date64(),{"[0, null]", "[0, null, 0, 0, 1262217600000]"},3);
+
+  // Time
+  CheckChunkedArr(time32(TimeUnit::SECOND),{"[ 0, 11, 0, null]", "[14, 14, null]"},4);
+  CheckChunkedArr(time32(TimeUnit::MILLI),{"[ 0, 11000, 0]", "[null, 11000, 11000]"},3);
+
+  CheckChunkedArr(time64(TimeUnit::MICRO),{"[84203999999, 0, null, 84203999999]", "[0]"},3);
+  CheckChunkedArr(time64(TimeUnit::NANO),{"[11715003000000, 0, null, 0, 0]", "[0, 0, null]"},3);
+
+  // Timestamp & Duration
+  for (auto u : TimeUnit::values()) {
+    CheckChunkedArr(duration(u),{"[123456789, null, 987654321]", "[123456789, null]"},3);
+
+    CheckChunkedArr(duration(u),
+                    {"[123456789, 987654321, 123456789, 123456789]","[123456789]"},2,
+                    /*has_nulls=*/false);
+
+    auto ts = std::vector<std::string> {R"(["2009-12-31T04:20:20", "2009-12-31T04:20:20"])",
+               R"(["2020-01-01", null])",R"(["2020-01-01", null])"};
+    CheckChunkedArr(timestamp(u),                      ts, 3);
+    CheckChunkedArr(timestamp(u, "Pacific/Marquesas"), ts, 3);
+  }
+
+  // Interval
+  CheckChunkedArr(month_interval(),{"[9012, 5678, null, 9012]", "[5678, null, 9012]"},3);
+  CheckChunkedArr(day_time_interval(),{"[[0, 1], [0, 1]]","[null, [0, 1], [1234, 5678]]"},3);
+  CheckChunkedArr(month_day_nano_interval(),{"[[0, 1, 2]]", "[[0, 1, 2], null, [0, 1, 2]]"},2);
+
+  // Binary & String & Fixed binary
+  auto samples = std::vector<std::string> {R"([null, "abc", null])",
+                                           R"(["abc", "abc", "cba"])",
+                                           R"(["bca", "cba", null])"};
+
+  CheckChunkedArr(            binary(), samples, 4);
+  CheckChunkedArr(      large_binary(), samples, 4);
+  CheckChunkedArr(              utf8(), samples, 4);
+  CheckChunkedArr(        large_utf8(), samples, 4);
+  CheckChunkedArr(fixed_size_binary(3), samples, 4);
+
+  // Decimal
+  samples =  {R"(["12345.679", "98765.421"])", R"([null, "12345.679", "98765.421"])"};
+  CheckChunkedArr(decimal128(21, 3), samples, 3);
+  CheckChunkedArr(decimal256(13, 3), samples, 3);
+}
 
 TEST_F(TestCountDistinctKernel, AllArrayTypesWithNulls) {
   // Boolean

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -343,6 +343,22 @@ struct UnboxScalar<Type, enable_if_has_string_view<Type>> {
   using T = util::string_view;
   static T Unbox(const Scalar& val) {
     if (!val.is_valid) return util::string_view();
+
+    switch (val.type->id()) {
+      case arrow::Type::DECIMAL128: {
+        return util::string_view(checked_cast<const Decimal128Scalar&>(val).view());
+        break;
+      }
+
+      case arrow::Type::DECIMAL256: {
+        return util::string_view(checked_cast<const Decimal256Scalar&>(val).view());
+        break;
+      }
+
+      default:
+        break;
+    }
+
     return util::string_view(*checked_cast<const BaseBinaryScalar&>(val).value);
   }
 };

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -343,23 +343,7 @@ struct UnboxScalar<Type, enable_if_has_string_view<Type>> {
   using T = util::string_view;
   static T Unbox(const Scalar& val) {
     if (!val.is_valid) return util::string_view();
-
-    switch (val.type->id()) {
-      case arrow::Type::DECIMAL128: {
-        return util::string_view(checked_cast<const Decimal128Scalar&>(val).view());
-        break;
-      }
-
-      case arrow::Type::DECIMAL256: {
-        return util::string_view(checked_cast<const Decimal256Scalar&>(val).view());
-        break;
-      }
-
-      default:
-        break;
-    }
-
-    return util::string_view(*checked_cast<const BaseBinaryScalar&>(val).value);
+    return checked_cast<const ::arrow::internal::PrimitiveScalarBase&>(val).view();
   }
 };
 

--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -433,14 +433,12 @@ class ScalarMemoTable : public MemoTable {
       return ScalarHelper<Scalar, 0>::CompareScalars(value, payload->value);
     };
 
-    hash_t val_hash   = ComputeHash(value);
-    auto   hash_entry = hash_table_.Lookup(val_hash, cmp_func);
+    hash_t val_hash = ComputeHash(value);
+    auto hash_entry = hash_table_.Lookup(val_hash, cmp_func);
 
     // Insert if it wasn't found; otherwise, we're done
     if (!hash_entry.second) {
-      RETURN_NOT_OK(
-        hash_table_.Insert(hash_entry.first, val_hash, { value, size() })
-      );
+      RETURN_NOT_OK(hash_table_.Insert(hash_entry.first, val_hash, {value, size()}));
     }
 
     return Status::OK();
@@ -507,17 +505,13 @@ class ScalarMemoTable : public MemoTable {
  public:
   // defined here so that `HashTableType` is visible
   // Merge entries from `other_table` into `this->hash_table_`.
-  void MergeTable(ScalarMemoTable &other_table) {
-    HashTableType &other_hashtable = other_table.hash_table_;
+  void MergeTable(ScalarMemoTable& other_table) {
+    HashTableType& other_hashtable = other_table.hash_table_;
 
-    other_hashtable.VisitEntries(
-      [=](const HashTableEntry *other_entry) {
-        ARROW_WARN_NOT_OK(
-           this->MaybeInsert(other_entry->payload.value)
-          ,"Merging ScalarMemoTable"
-        );
-      }
-    );
+    other_hashtable.VisitEntries([=](const HashTableEntry* other_entry) {
+      ARROW_WARN_NOT_OK(this->MaybeInsert(other_entry->payload.value),
+                        "Merging ScalarMemoTable");
+    });
   }
 };
 
@@ -581,7 +575,7 @@ class SmallScalarMemoTable : public MemoTable {
 
   Status MaybeInsert(const Scalar& value) {
     auto value_index = AsIndex(value);
-    auto memo_index  = value_to_index_[value_index];
+    auto memo_index = value_to_index_[value_index];
 
     if (memo_index == kKeyNotFound) {
       memo_index = static_cast<int32_t>(index_to_value_.size());
@@ -619,8 +613,8 @@ class SmallScalarMemoTable : public MemoTable {
   int32_t size() const override { return static_cast<int32_t>(index_to_value_.size()); }
 
   // Merge entries from `other_table` into `this`.
-  void MergeTable(SmallScalarMemoTable &other_table) {
-    for (const Scalar &other_val : other_table.index_to_value_) {
+  void MergeTable(SmallScalarMemoTable& other_table) {
+    for (const Scalar& other_val : other_table.index_to_value_) {
       auto insert_status = this->MaybeInsert(other_val);
       if (not insert_status.ok()) {
         ARROW_WARN_NOT_OK(insert_status, "Merging SmallScalarMemoTable");
@@ -744,24 +738,20 @@ class BinaryMemoTable : public MemoTable {
   }
 
   Status MaybeInsert(const util::string_view& value) {
-    const void *val_data   = value.data();
-    auto        val_length = static_cast<builder_offset_type>(value.length());
+    const void* val_data = value.data();
+    auto val_length = static_cast<builder_offset_type>(value.length());
 
-    hash_t      val_hash   = ComputeStringHash<0>(val_data, val_length);
-    auto        hash_entry = Lookup(val_hash, val_data, val_length);
+    hash_t val_hash = ComputeStringHash<0>(val_data, val_length);
+    auto hash_entry = Lookup(val_hash, val_data, val_length);
 
     if (!hash_entry.second) {
       // Insert string value
       RETURN_NOT_OK(
-        binary_builder_.Append(static_cast<const char*>(val_data), val_length)
-      );
+          binary_builder_.Append(static_cast<const char*>(val_data), val_length));
 
       // Insert hash entry
-      RETURN_NOT_OK(
-        hash_table_.Insert(
-          const_cast<HashTableEntry*>(hash_entry.first), val_hash, { size() }
-        )
-      );
+      RETURN_NOT_OK(hash_table_.Insert(const_cast<HashTableEntry*>(hash_entry.first),
+                                       val_hash, {size()}));
     }
 
     return Status::OK();
@@ -910,16 +900,10 @@ class BinaryMemoTable : public MemoTable {
   }
 
  public:
-  void MergeTable(BinaryMemoTable &other_table) {
-    other_table.VisitValues(
-       0
-      ,[=](const util::string_view &other_value) {
-         ARROW_WARN_NOT_OK(
-            this->MaybeInsert(other_value)
-           ,"Merging BinaryMemoTable"
-        );
-       }
-    );
+  void MergeTable(BinaryMemoTable& other_table) {
+    other_table.VisitValues(0, [=](const util::string_view& other_value) {
+      ARROW_WARN_NOT_OK(this->MaybeInsert(other_value), "Merging BinaryMemoTable");
+    });
   }
 };
 

--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -428,6 +428,24 @@ class ScalarMemoTable : public MemoTable {
         value, [](int32_t i) {}, [](int32_t i) {}, out_memo_index);
   }
 
+  Status MaybeInsert(const Scalar& value) {
+    auto cmp_func = [value](const Payload* payload) -> bool {
+      return ScalarHelper<Scalar, 0>::CompareScalars(value, payload->value);
+    };
+
+    hash_t val_hash   = ComputeHash(value);
+    auto   hash_entry = hash_table_.Lookup(val_hash, cmp_func);
+
+    // Insert if it wasn't found; otherwise, we're done
+    if (!hash_entry.second) {
+      RETURN_NOT_OK(
+        hash_table_.Insert(hash_entry.first, val_hash, { value, size() })
+      );
+    }
+
+    return Status::OK();
+  }
+
   int32_t GetNull() const { return null_index_; }
 
   template <typename Func1, typename Func2>
@@ -484,6 +502,22 @@ class ScalarMemoTable : public MemoTable {
 
   hash_t ComputeHash(const Scalar& value) const {
     return ScalarHelper<Scalar, 0>::ComputeHash(value);
+  }
+
+ public:
+  // defined here so that `HashTableType` is visible
+  // Merge entries from `other_table` into `this->hash_table_`.
+  void MergeTable(ScalarMemoTable &other_table) {
+    HashTableType &other_hashtable = other_table.hash_table_;
+
+    other_hashtable.VisitEntries(
+      [=](const HashTableEntry *other_entry) {
+        ARROW_WARN_NOT_OK(
+           this->MaybeInsert(other_entry->payload.value)
+          ,"Merging ScalarMemoTable"
+        );
+      }
+    );
   }
 };
 
@@ -545,6 +579,22 @@ class SmallScalarMemoTable : public MemoTable {
         value, [](int32_t i) {}, [](int32_t i) {}, out_memo_index);
   }
 
+  Status MaybeInsert(const Scalar& value) {
+    auto value_index = AsIndex(value);
+    auto memo_index  = value_to_index_[value_index];
+
+    if (memo_index == kKeyNotFound) {
+      memo_index = static_cast<int32_t>(index_to_value_.size());
+
+      index_to_value_.push_back(value);
+      value_to_index_[value_index] = memo_index;
+
+      DCHECK_LT(memo_index, cardinality + 1);
+    }
+
+    return Status::OK();
+  }
+
   int32_t GetNull() const { return value_to_index_[cardinality]; }
 
   template <typename Func1, typename Func2>
@@ -567,6 +617,16 @@ class SmallScalarMemoTable : public MemoTable {
   // The number of entries in the memo table
   // (which is also 1 + the largest memo index)
   int32_t size() const override { return static_cast<int32_t>(index_to_value_.size()); }
+
+  // Merge entries from `other_table` into `this`.
+  void MergeTable(SmallScalarMemoTable &other_table) {
+    for (const Scalar &other_val : other_table.index_to_value_) {
+      auto insert_status = this->MaybeInsert(other_val);
+      if (not insert_status.ok()) {
+        ARROW_WARN_NOT_OK(insert_status, "Merging SmallScalarMemoTable");
+      }
+    }
+  }
 
   // Copy values starting from index `start` into `out_data`
   void CopyValues(int32_t start, Scalar* out_data) const {
@@ -681,6 +741,30 @@ class BinaryMemoTable : public MemoTable {
 
   int32_t GetOrInsertNull() {
     return GetOrInsertNull([](int32_t i) {}, [](int32_t i) {});
+  }
+
+  Status MaybeInsert(const util::string_view& value) {
+    const void *val_data   = value.data();
+    auto        val_length = static_cast<builder_offset_type>(value.length());
+
+    hash_t      val_hash   = ComputeStringHash<0>(val_data, val_length);
+    auto        hash_entry = Lookup(val_hash, val_data, val_length);
+
+    if (!hash_entry.second) {
+      // Insert string value
+      RETURN_NOT_OK(
+        binary_builder_.Append(static_cast<const char*>(val_data), val_length)
+      );
+
+      // Insert hash entry
+      RETURN_NOT_OK(
+        hash_table_.Insert(
+          const_cast<HashTableEntry*>(hash_entry.first), val_hash, { size() }
+        )
+      );
+    }
+
+    return Status::OK();
   }
 
   // The number of entries in the memo table
@@ -823,6 +907,19 @@ class BinaryMemoTable : public MemoTable {
       return lhs == rhs;
     };
     return hash_table_.Lookup(h, cmp_func);
+  }
+
+ public:
+  void MergeTable(BinaryMemoTable &other_table) {
+    other_table.VisitValues(
+       0
+      ,[=](const util::string_view &other_value) {
+         ARROW_WARN_NOT_OK(
+            this->MaybeInsert(other_value)
+           ,"Merging BinaryMemoTable"
+        );
+       }
+    );
   }
 };
 

--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -489,14 +489,14 @@ class ScalarMemoTable : public MemoTable {
  public:
   // defined here so that `HashTableType` is visible
   // Merge entries from `other_table` into `this->hash_table_`.
-  Status MergeTable(ScalarMemoTable& other_table) {
-    HashTableType& other_hashtable = other_table.hash_table_;
+  Status MergeTable(const ScalarMemoTable& other_table) {
+    const HashTableType& other_hashtable = other_table.hash_table_;
 
     other_hashtable.VisitEntries([this](const HashTableEntry* other_entry) {
       int32_t unused;
       DCHECK_OK(this->GetOrInsert(other_entry->payload.value, &unused));
     });
-    // TODO: implement proper (and perhaps more performant) error handling
+    // TODO: ARROW-17074 - implement proper error handling
     return Status::OK();
   }
 };
@@ -583,7 +583,7 @@ class SmallScalarMemoTable : public MemoTable {
   int32_t size() const override { return static_cast<int32_t>(index_to_value_.size()); }
 
   // Merge entries from `other_table` into `this`.
-  Status MergeTable(SmallScalarMemoTable& other_table) {
+  Status MergeTable(const SmallScalarMemoTable& other_table) {
     for (const Scalar& other_val : other_table.index_to_value_) {
       int32_t unused;
       RETURN_NOT_OK(this->GetOrInsert(other_val, &unused));
@@ -849,7 +849,7 @@ class BinaryMemoTable : public MemoTable {
   }
 
  public:
-  Status MergeTable(BinaryMemoTable& other_table) {
+  Status MergeTable(const BinaryMemoTable& other_table) {
     other_table.VisitValues(0, [this](const util::string_view& other_value) {
       int32_t unused;
       DCHECK_OK(this->GetOrInsert(other_value, &unused));

--- a/r/tests/testthat/test-dplyr-summarize.R
+++ b/r/tests/testthat/test-dplyr-summarize.R
@@ -224,6 +224,7 @@ test_that("n_distinct() with many batches", {
 
 	ds <- open_dataset(tf)
 	expect_true(ds %>% summarise(n_distinct(sex, na.rm = FALSE)) %>% collect() == 5)
+	expect_true(ds %>% collect() %>% summarise(n_distinct(sex, na.rm = FALSE)) == 5)
 })
 
 test_that("n_distinct() on dataset", {

--- a/r/tests/testthat/test-dplyr-summarize.R
+++ b/r/tests/testthat/test-dplyr-summarize.R
@@ -223,8 +223,8 @@ test_that("n_distinct() with many batches", {
 	write_parquet(dplyr::starwars, tf, chunk_size = 20)
 
 	ds <- open_dataset(tf)
-	expect_true(ds %>% summarise(n_distinct(sex, na.rm = FALSE)) %>% collect() == 5)
-	expect_true(ds %>% collect() %>% summarise(n_distinct(sex, na.rm = FALSE)) == 5)
+	expect_equal(ds %>% summarise(n_distinct(sex, na.rm = FALSE)) %>% collect(),
+	             ds %>% collect() %>% summarise(n_distinct(sex, na.rm = FALSE)))
 })
 
 test_that("n_distinct() on dataset", {

--- a/r/tests/testthat/test-dplyr-summarize.R
+++ b/r/tests/testthat/test-dplyr-summarize.R
@@ -218,6 +218,14 @@ test_that("Group by any/all", {
   )
 })
 
+test_that("n_distinct() with many batches", {
+	tf <- tempfile()
+	write_parquet(dplyr::starwars, tf, chunk_size = 20)
+
+	ds <- open_dataset(tf)
+	expect_true(ds %>% summarise(n_distinct(sex, na.rm = FALSE)) %>% collect() == 5)
+})
+
 test_that("n_distinct() on dataset", {
   # With groupby
   compare_dplyr_binding(

--- a/r/tests/testthat/test-dplyr-summarize.R
+++ b/r/tests/testthat/test-dplyr-summarize.R
@@ -219,12 +219,12 @@ test_that("Group by any/all", {
 })
 
 test_that("n_distinct() with many batches", {
-	tf <- tempfile()
-	write_parquet(dplyr::starwars, tf, chunk_size = 20)
+  tf <- tempfile()
+  write_parquet(dplyr::starwars, tf, chunk_size = 20)
 
-	ds <- open_dataset(tf)
-	expect_equal(ds %>% summarise(n_distinct(sex, na.rm = FALSE)) %>% collect(),
-	             ds %>% collect() %>% summarise(n_distinct(sex, na.rm = FALSE)))
+  ds <- open_dataset(tf)
+  expect_equal(ds %>% summarise(n_distinct(sex, na.rm = FALSE)) %>% collect(),
+               ds %>% collect() %>% summarise(n_distinct(sex, na.rm = FALSE)))
 })
 
 test_that("n_distinct() on dataset", {


### PR DESCRIPTION
This addresses a bug where the `count_distinct` function simply added counts when merging state. The correct logic would be to return the number of distinct elements after both states have been merged.

State for count_distinct is backed by a MemoTable, which is then backed by a HashTable. To properly merge state, this PR adds 2 functions to each MemoTable: `MaybeInsert` and `MergeTable`. The MaybeInsert function handles simplified logic for inserting an element into the MemoTable. The MergeTable function handles iteration over elements in the MemoTable _to be merged_.

This PR also adds an R test and a C++ test. The R test mirrors what was provided in ARROW-16807. The C++ test, `AllChunkedArrayTypesWithNulls`, mirrors another C++ test, `AllArrayTypesWithNulls`, but uses chunked arrays for test data.