### PR TITLE
ARROW-17046 [Python] improve documentation of pyarrow.parquet.write_to_dataset function

### DIFF
--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -3018,7 +3018,7 @@ def write_to_dataset(table, root_path, partition_cols=None,
                      use_threads=None, file_visitor=None,
                      existing_data_behavior=None,
                      **kwargs):
-    """Wrapper around dataset.write_dataset (when use_legacy_dataset=False) or 
+    """Wrapper around dataset.write_dataset (when use_legacy_dataset=False) or
     parquet.write_table (when use_legacy_dataset=True) for writing a Table to
     Parquet format by partitions.
     For each combination of partition columns and values,
@@ -3053,9 +3053,9 @@ def write_to_dataset(table, root_path, partition_cols=None,
         A callback function that takes the partition key(s) as an argument
         and allow you to override the partition filename. If nothing is
         passed, the filename will consist of a uuid.
-        This option is only supported for use_legacy_dataset=True. When 
-        use_legacy_dataset=None and this option is specified, use_legacy_dataset
-        will be set to True.
+        This option is only supported for use_legacy_dataset=True.
+        When use_legacy_dataset=None and this option is specified,
+        use_legacy_datase will be set to True.
     use_legacy_dataset : bool
         Default is False. Set to True to use the the legacy behaviour
         (this option is deprecated, and the legacy implementation will be
@@ -3119,10 +3119,10 @@ def write_to_dataset(table, root_path, partition_cols=None,
         old partitions completely.
         This option is only supported for use_legacy_dataset=False.
     **kwargs : dict,
-        When use_legacy_dataset=False, used as additional kwargs for 
-        `pyarrow.dataset.write_dataset` function (See docstring for 
+        When use_legacy_dataset=False, used as additional kwargs for
+        `pyarrow.dataset.write_dataset` function (See docstring for
         `write_dataset` or `ParquetFileFormat` for more information).
-        When use_legacy_dataset=True, used as additional kwargs for 
+        When use_legacy_dataset=True, used as additional kwargs for
         `pyarrow.parquet.write_table` function (See docstring for `write_table`
         or `ParquetWriter` for more information).
         Using `metadata_collector` in kwargs allows one to collect the

--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -3120,8 +3120,9 @@ def write_to_dataset(table, root_path, partition_cols=None,
         This option is only supported for use_legacy_dataset=False.
     **kwargs : dict,
         When use_legacy_dataset=False, used as additional kwargs for
-        `pyarrow.dataset.write_dataset` function (See docstring for
-        `write_dataset` or `ParquetFileFormat` for more information).
+        `pyarrow.dataset.write_dataset` function (passed to
+        `ParquetFileFormat.make_write_options`). See the docstring
+        of `write_table` for the available options.
         When use_legacy_dataset=True, used as additional kwargs for
         `pyarrow.parquet.write_table` function (See docstring for `write_table`
         or `ParquetWriter` for more information).

--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -3064,6 +3064,7 @@ def write_to_dataset(table, root_path, partition_cols=None,
     use_threads : bool, default True
         Write files in parallel. If enabled, then maximum parallelism will be
         used determined by the number of available CPU cores.
+        This option is only supported for use_legacy_dataset=False.
     schema : Schema, optional
     partitioning : Partitioning or list[str], optional
         The partitioning scheme specified with the

--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -3254,8 +3254,6 @@ def write_to_dataset(table, root_path, partition_cols=None,
         "'use_legacy_dataset=False' while constructing the "
         "ParquetDataset."
     )
-    if schema is not None:
-        raise ValueError(msg2.format("schema"))
     if partitioning is not None:
         raise ValueError(msg2.format("partitioning"))
     if use_threads is not None:
@@ -3313,7 +3311,7 @@ def write_to_dataset(table, root_path, partition_cols=None,
             full_path = '/'.join([root_path, relative_path])
             with fs.open(full_path, 'wb') as f:
                 write_table(subtable, f, metadata_collector=metadata_collector,
-                            **kwargs)
+                            schema=schema, **kwargs)
             if metadata_collector is not None:
                 metadata_collector[-1].set_file_path(relative_path)
     else:
@@ -3324,7 +3322,7 @@ def write_to_dataset(table, root_path, partition_cols=None,
         full_path = '/'.join([root_path, outfile])
         with fs.open(full_path, 'wb') as f:
             write_table(table, f, metadata_collector=metadata_collector,
-                        **kwargs)
+                        schema=schema, **kwargs)
         if metadata_collector is not None:
             metadata_collector[-1].set_file_path(outfile)
 

--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -3018,7 +3018,8 @@ def write_to_dataset(table, root_path, partition_cols=None,
                      use_threads=None, file_visitor=None,
                      existing_data_behavior=None,
                      **kwargs):
-    """Wrapper around parquet.write_table for writing a Table to
+    """Wrapper around dataset.write_dataset (when use_legacy_dataset=False) or 
+    parquet.write_table (when use_legacy_dataset=True) for writing a Table to
     Parquet format by partitions.
     For each combination of partition columns and values,
     a subdirectories are created in the following
@@ -3066,6 +3067,7 @@ def write_to_dataset(table, root_path, partition_cols=None,
         used determined by the number of available CPU cores.
         This option is only supported for use_legacy_dataset=False.
     schema : Schema, optional
+        This option is only supported for use_legacy_dataset=False.
     partitioning : Partitioning or list[str], optional
         The partitioning scheme specified with the
         ``pyarrow.dataset.partitioning()`` function or a list of field names.
@@ -3254,6 +3256,8 @@ def write_to_dataset(table, root_path, partition_cols=None,
         "'use_legacy_dataset=False' while constructing the "
         "ParquetDataset."
     )
+    if schema is not None:
+        raise ValueError(msg2.format("schema"))
     if partitioning is not None:
         raise ValueError(msg2.format("partitioning"))
     if use_threads is not None:
@@ -3311,7 +3315,7 @@ def write_to_dataset(table, root_path, partition_cols=None,
             full_path = '/'.join([root_path, relative_path])
             with fs.open(full_path, 'wb') as f:
                 write_table(subtable, f, metadata_collector=metadata_collector,
-                            schema=schema, **kwargs)
+                            **kwargs)
             if metadata_collector is not None:
                 metadata_collector[-1].set_file_path(relative_path)
     else:
@@ -3322,7 +3326,7 @@ def write_to_dataset(table, root_path, partition_cols=None,
         full_path = '/'.join([root_path, outfile])
         with fs.open(full_path, 'wb') as f:
             write_table(table, f, metadata_collector=metadata_collector,
-                        schema=schema, **kwargs)
+                        **kwargs)
         if metadata_collector is not None:
             metadata_collector[-1].set_file_path(outfile)
 

--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -3118,7 +3118,7 @@ def write_to_dataset(table, root_path, partition_cols=None,
     **kwargs : dict,
         When use_legacy_dataset=False, used as additional kwargs for 
         `pyarrow.dataset.write_dataset` function (See docstring for 
-        write_dataset or ParquetFileFormat for more information).
+        `write_dataset` or `ParquetFileFormat` for more information).
         When use_legacy_dataset=True, used as additional kwargs for 
         `pyarrow.parquet.write_table` function (See docstring for `write_table`
         or `ParquetWriter` for more information).

--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -3049,6 +3049,7 @@ def write_to_dataset(table, root_path, partition_cols=None,
         Column names by which to partition the dataset.
         Columns are partitioned in the order they are given
     partition_filename_cb : callable,
+        (This option is used only when `use_legacy_dataset` is True.)
         A callback function that takes the partition key(s) as an argument
         and allow you to override the partition filename. If nothing is
         passed, the filename will consist of a uuid.
@@ -3063,16 +3064,19 @@ def write_to_dataset(table, root_path, partition_cols=None,
         used determined by the number of available CPU cores.
     schema : Schema, optional
     partitioning : Partitioning or list[str], optional
+        (This option is used only when `use_legacy_dataset` is False.)
         The partitioning scheme specified with the
         ``pyarrow.dataset.partitioning()`` function or a list of field names.
         When providing a list of field names, you can use
         ``partitioning_flavor`` to drive which partitioning type should be
         used.
     basename_template : str, optional
+        (This option is used only when `use_legacy_dataset` is False.)
         A template string used to generate basenames of written data files.
         The token '{i}' will be replaced with an automatically incremented
         integer. If not specified, it defaults to "guid-{i}.parquet".
     file_visitor : function
+        (This option is used only when `use_legacy_dataset` is False.)
         If set, this function will be called with a WrittenFile instance
         for each file created during the call.  This object will have both
         a path attribute and a metadata attribute.
@@ -3093,13 +3097,9 @@ def write_to_dataset(table, root_path, partition_cols=None,
                 visited_paths.append(written_file.path)
     existing_data_behavior : 'overwrite_or_ignore' | 'error' | \
 'delete_matching'
+        (This option is used only when `use_legacy_dataset` is False.)
         Controls how the dataset will handle data that already exists in
         the destination. The default behaviour is 'overwrite_or_ignore'.
-
-        Only used in the new code path using the new Arrow Dataset API
-        (``use_legacy_dataset=False``). In case the legacy implementation
-        is selected the parameter is ignored as the old implementation does
-        not support it (only has the default behaviour).
 
         'overwrite_or_ignore' will ignore any existing data and will
         overwrite files with the same name as an output file.  Other
@@ -3114,8 +3114,11 @@ def write_to_dataset(table, root_path, partition_cols=None,
         the entire directory will be deleted.  This allows you to overwrite
         old partitions completely.
     **kwargs : dict,
-        Additional kwargs for write_table function. See docstring for
-        `write_table` or `ParquetWriter` for more information.
+        When `use_legacy_dataset` is False, used as additional kwargs for 
+        `pyarrow.dataset.ParquetFileFormat.make_write_options` function.
+        When `use_legacy_dataset` is True, used as additional kwargs for 
+        `pyarrow.parquet.write_table` function (See docstring for `write_table`
+        or `ParquetWriter` for more information.)
         Using `metadata_collector` in kwargs allows one to collect the
         file metadata instances of dataset pieces. The file paths in the
         ColumnChunkMetaData will be set relative to `root_path`.

--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -3120,11 +3120,11 @@ def write_to_dataset(table, root_path, partition_cols=None,
         This option is only supported for use_legacy_dataset=False.
     **kwargs : dict,
         When use_legacy_dataset=False, used as additional kwargs for
-        `pyarrow.dataset.write_dataset` function (passed to
+        `dataset.write_dataset` function (passed to
         `ParquetFileFormat.make_write_options`). See the docstring
         of `write_table` for the available options.
         When use_legacy_dataset=True, used as additional kwargs for
-        `pyarrow.parquet.write_table` function (See docstring for `write_table`
+        `parquet.write_table` function (See docstring for `write_table`
         or `ParquetWriter` for more information).
         Using `metadata_collector` in kwargs allows one to collect the
         file metadata instances of dataset pieces. The file paths in the

--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -3049,10 +3049,12 @@ def write_to_dataset(table, root_path, partition_cols=None,
         Column names by which to partition the dataset.
         Columns are partitioned in the order they are given
     partition_filename_cb : callable,
-        (This option is used only when `use_legacy_dataset` is True.)
         A callback function that takes the partition key(s) as an argument
         and allow you to override the partition filename. If nothing is
         passed, the filename will consist of a uuid.
+        This option is only supported for use_legacy_dataset=True. When 
+        use_legacy_dataset=None and this option is specified, use_legacy_dataset
+        will be set to True.
     use_legacy_dataset : bool
         Default is False. Set to True to use the the legacy behaviour
         (this option is deprecated, and the legacy implementation will be
@@ -3064,19 +3066,18 @@ def write_to_dataset(table, root_path, partition_cols=None,
         used determined by the number of available CPU cores.
     schema : Schema, optional
     partitioning : Partitioning or list[str], optional
-        (This option is used only when `use_legacy_dataset` is False.)
         The partitioning scheme specified with the
         ``pyarrow.dataset.partitioning()`` function or a list of field names.
         When providing a list of field names, you can use
         ``partitioning_flavor`` to drive which partitioning type should be
         used.
+        This option is only supported for use_legacy_dataset=False.
     basename_template : str, optional
-        (This option is used only when `use_legacy_dataset` is False.)
         A template string used to generate basenames of written data files.
         The token '{i}' will be replaced with an automatically incremented
         integer. If not specified, it defaults to "guid-{i}.parquet".
+        This option is only supported for use_legacy_dataset=False.
     file_visitor : function
-        (This option is used only when `use_legacy_dataset` is False.)
         If set, this function will be called with a WrittenFile instance
         for each file created during the call.  This object will have both
         a path attribute and a metadata attribute.
@@ -3095,9 +3096,9 @@ def write_to_dataset(table, root_path, partition_cols=None,
 
             def file_visitor(written_file):
                 visited_paths.append(written_file.path)
+        This option is only supported for use_legacy_dataset=False.
     existing_data_behavior : 'overwrite_or_ignore' | 'error' | \
 'delete_matching'
-        (This option is used only when `use_legacy_dataset` is False.)
         Controls how the dataset will handle data that already exists in
         the destination. The default behaviour is 'overwrite_or_ignore'.
 
@@ -3113,12 +3114,14 @@ def write_to_dataset(table, root_path, partition_cols=None,
         dataset.  The first time each partition directory is encountered
         the entire directory will be deleted.  This allows you to overwrite
         old partitions completely.
+        This option is only supported for use_legacy_dataset=False.
     **kwargs : dict,
-        When `use_legacy_dataset` is False, used as additional kwargs for 
-        `pyarrow.dataset.ParquetFileFormat.make_write_options` function.
-        When `use_legacy_dataset` is True, used as additional kwargs for 
+        When use_legacy_dataset=False, used as additional kwargs for 
+        `pyarrow.dataset.write_dataset` function (See docstring for 
+        write_dataset or ParquetFileFormat for more information).
+        When use_legacy_dataset=True, used as additional kwargs for 
         `pyarrow.parquet.write_table` function (See docstring for `write_table`
-        or `ParquetWriter` for more information.)
+        or `ParquetWriter` for more information).
         Using `metadata_collector` in kwargs allows one to collect the
         file metadata instances of dataset pieces. The file paths in the
         ColumnChunkMetaData will be set relative to `root_path`.


### PR DESCRIPTION
This patch is an attempt to make the documentation of `pyarrow.parquet.write_to_dataset` function clearer so that the user can easily learn
- Which parameters are used by the new code path and which ones are used by the legacy code path
- How kwargs are handled. That is, which underlying function that `pyarrow.parquet.write_to_dataset` is a wrapper around they are passed to