### PR TITLE
ARROW-17065: [Python] Allow using subclassed ExtensionScalar in ExtensionType

### DIFF
--- a/docs/source/python/extending_types.rst
+++ b/docs/source/python/extending_types.rst
@@ -290,7 +290,7 @@ Custom scalar conversion
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you want scalars of your custom extension type to convert to a custom type when
-:meth:`ExtensionScalar.as_py()` is called, you can override the :meth:`ExtensionType.as_py()`
+:meth:`ExtensionScalar.as_py()` is called, you can override the :meth:`ExtensionScalar.as_py()`
 method. For example, if we wanted the above example 3D point type to return a custom
 3D point class instead of a list, we would implement::
 

--- a/docs/source/python/extending_types.rst
+++ b/docs/source/python/extending_types.rst
@@ -290,11 +290,15 @@ Custom scalar conversion
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you want scalars of your custom extension type to convert to a custom type when
-:meth:`ExtensionScalar.as_py()` is called, you can override the :meth:`ExtensionType.scalar_as_py()`
+:meth:`ExtensionScalar.as_py()` is called, you can override the :meth:`ExtensionType.as_py()`
 method. For example, if we wanted the above example 3D point type to return a custom
 3D point class instead of a list, we would implement::
 
     Point3D = namedtuple("Point3D", ["x", "y", "z"])
+
+    class Point3DScalar(pa.ExtensionScalar):
+        def as_py(self) -> Point3D:
+            return Point3D(*self.value.as_py())
 
     class Point3DType(pa.PyExtensionType):
         def __init__(self):
@@ -303,8 +307,8 @@ method. For example, if we wanted the above example 3D point type to return a cu
         def __reduce__(self):
             return Point3DType, ()
 
-        def scalar_as_py(self, scalar: pa.ListScalar) -> Point3D:
-            return Point3D(*scalar.as_py())
+        def __arrow_ext_scalar_class__(self):
+            return Point3DScalar
 
 Arrays built using this extension type now provide scalars that convert to our ``Point3D`` class::
 

--- a/docs/source/python/extending_types.rst
+++ b/docs/source/python/extending_types.rst
@@ -290,7 +290,7 @@ Custom scalar conversion
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you want scalars of your custom extension type to convert to a custom type when
-:meth:`ExtensionScalar.as_py()` is called, you can override the :meth:`ExtensionScalar.as_py()`
+:meth:`ExtensionScalar.as_py()` is called, you can override the :meth:`ExtensionScalar.as_py()` by subclassing :class:`ExtensionScalar`.
 method. For example, if we wanted the above example 3D point type to return a custom
 3D point class instead of a list, we would implement::
 

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -2771,6 +2771,11 @@ cdef class ExtensionArray(Array):
         """
         return self.storage.to_numpy(**kwargs)
 
+    cdef getitem(self, int64_t i):
+        scalar = ExtensionScalar.wrap(GetResultValue(self.ap.GetScalar(i)))
+        return self.type.__arrow_ext_scalar_class__().from_storage(
+            self.type, scalar.value)
+
 
 cdef dict _array_classes = {
     _Type_NA: NullArray,

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -2771,11 +2771,6 @@ cdef class ExtensionArray(Array):
         """
         return self.storage.to_numpy(**kwargs)
 
-    cdef getitem(self, int64_t i):
-        scalar = ExtensionScalar.wrap(GetResultValue(self.ap.GetScalar(i)))
-        return self.type.__arrow_ext_scalar_class__().from_storage(
-            self.type, scalar.value)
-
 
 cdef dict _array_classes = {
     _Type_NA: NullArray,

--- a/python/pyarrow/public-api.pxi
+++ b/python/pyarrow/public-api.pxi
@@ -257,7 +257,7 @@ cdef api object pyarrow_wrap_scalar(const shared_ptr[CScalar]& sp_scalar):
     if data_type.id() not in _scalar_classes:
         raise ValueError('Scalar type not supported')
 
-    klass = _scalar_classes[data_type.id()]
+    klass = get_scalar_class_from_type(sp_scalar.get().type)
 
     cdef Scalar scalar = klass.__new__(klass)
     scalar.init(sp_scalar)

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -902,7 +902,7 @@ cdef class ExtensionScalar(Scalar):
         """
         Return this scalar as a Python object.
         """
-        return self.value if self.value is not None else None
+        return self.value.as_py() if self.value is not None else None
 
     @staticmethod
     def from_storage(BaseExtensionType typ, value):

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -902,22 +902,16 @@ cdef class ExtensionType(BaseExtensionType):
         """
         return ExtensionArray
 
-    def scalar_as_py(self, scalar):
-        """Convert scalar to a Python type.
+    def __arrow_ext_scalar_class__(self):
+        """Return an extension scalar class for building scalars with this
+        extension type.
 
-        This method can be overridden in subclasses to customize what type
-        scalars are converted to.
-
-        Parameters
-        ----------
-        scalar : pyarrow.Scalar
-          Not-None Scalar of storage type to be converted to a Python object.
-
-        Returns
-        -------
-        Scalar value as a native Python object.
+        This method should return subclass of the ExtensionScalar class. By
+        default, if not specialized in the extension implementation, an
+        extension type scalar will be a built-in ExtensionScalar instance.
         """
-        return scalar.as_py()
+        return ExtensionScalar
+
 
 cdef class PyExtensionType(ExtensionType):
     """


### PR DESCRIPTION
This is to resolve [ARROW-17065](https://issues.apache.org/jira/browse/ARROW-17065).