### PR TITLE
ARROW-17055: [Java][FlightRPC] Don't duplicate generated Protobuf classes between flight-core and flight-sql

### DIFF
--- a/java/flight/flight-sql/pom.xml
+++ b/java/flight/flight-sql/pom.xml
@@ -58,24 +58,12 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-protobuf</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-stub</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.arrow</groupId>
@@ -121,28 +109,5 @@
       <version>1.4</version>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.xolstice.maven.plugins</groupId>
-        <artifactId>protobuf-maven-plugin</artifactId>
-        <version>0.6.1</version>
-        <executions>
-          <execution>
-            <id>proto-compile</id>
-            <phase>generate-sources</phase>
-            <configuration>
-              <protoSourceRoot>${basedir}/../../../format/</protoSourceRoot>
-            </configuration>
-            <goals>
-              <goal>compile</goal>
-              <goal>compile-custom</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 
 </project>


### PR DESCRIPTION
flight-core and flight-sql jars delivering same class names. 

It seems that the classes generated by Flight.proto gets generated in both flight-sql and flight-core jars. Since these classes get generated in flight-core, and flight-sql is dependent on flight-core, can the generation of Flight.java and FlightServiceGrpc.java be removed from flight-sql and instead rely on it to be pulled directly from flight-core.