### PR TITLE
ARROW-17066: [C++][Python][Substrait] "ignore_unknown_fields" should be specified when converting JSON to binary

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "cpp/submodules/parquet-testing"]
 	path = cpp/submodules/parquet-testing
 	url = https://github.com/apache/parquet-testing.git
+[submodule "testing"]
+	path = testing
+	url = https://github.com/apache/arrow-testing

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "cpp/submodules/parquet-testing"]
 	path = cpp/submodules/parquet-testing
 	url = https://github.com/apache/parquet-testing.git
-[submodule "testing"]
-	path = testing
-	url = https://github.com/apache/arrow-testing

--- a/cpp/src/arrow/engine/substrait/serde.cc
+++ b/cpp/src/arrow/engine/substrait/serde.cc
@@ -320,9 +320,11 @@ Result<std::shared_ptr<Buffer>> SubstraitFromJSON(util::string_view type_name,
 
   std::string out;
   google::protobuf::io::StringOutputStream out_stream{&out};
-
+  google::protobuf::util::JsonParseOptions json_opts;
+  json_opts.ignore_unknown_fields = true;
   auto status = google::protobuf::util::JsonToBinaryStream(
-      GetGeneratedTypeResolver(), type_url, &json_stream, &out_stream);
+      GetGeneratedTypeResolver(), type_url, &json_stream, &out_stream,
+      std::move(json_opts));
 
   if (!status.ok()) {
     return Status::Invalid("JsonToBinaryStream returned ", status);

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -33,6 +33,13 @@ except ImportError:
 pytestmark = [pytest.mark.dataset, pytest.mark.substrait]
 
 
+def _write_dummy_data_to_disk(tmpdir, file_name, table):
+    path = os.path.join(str(tmpdir), file_name)
+    with pa.ipc.RecordBatchFileWriter(path, schema=table.schema) as writer:
+        writer.write_table(table)
+    return path
+
+
 @pytest.mark.skipif(sys.platform == 'win32',
                     reason="ARROW-16392: file based URI is" +
                     " not fully supported for Windows")
@@ -66,11 +73,9 @@ def test_run_serialized_query(tmpdir):
     }
     """
     # TODO: replace with ipc when the support is finalized in C++
-    path = os.path.join(str(tmpdir), 'substrait_data.arrow')
+    file_name = "read_data.arrow"
     table = pa.table([[1, 2, 3, 4, 5]], names=['foo'])
-    with pa.ipc.RecordBatchFileWriter(path, schema=table.schema) as writer:
-        writer.write_table(table)
-
+    path = _write_dummy_data_to_disk(tmpdir, file_name, table)
     query = tobytes(substrait_query.replace("FILENAME_PLACEHOLDER", path))
 
     buf = pa._substrait._parse_json_plan(query)
@@ -97,87 +102,46 @@ def test_invalid_plan():
 @pytest.mark.skipif(sys.platform == 'win32',
                     reason="ARROW-16392: file based URI is" +
                     " not fully supported for Windows")
-def test_binary_conversion_with_json_options():
-    query = """
+def test_binary_conversion_with_json_options(tmpdir):
+    substrait_query = """
     {
-     "relations": [{
-       "rel": {
-         "aggregate": {
-           "input": {
-             "read": {
-               "base_schema": {
-                 "names": ["A", "B", "C"],
-                 "struct": {
-                   "types": [{
-                     "i32": {}
-                   }, {
-                     "i32": {}
-                   }, {
-                     "i32": {}
-                   }]
-                 }
-               },
-               "local_files": {
-                 "items": [
-                   {
-                     "uri_file": "file:///tmp/dat.parquet",
-                     "parquet": {}
-                   }
-                 ]
-               }
-             }
-           },
-           "groupings": [{
-             "groupingExpressions": [{
-               "selection": {
-                 "directReference": {
-                   "structField": {
-                     "field": 0
-                   }
-                 }
-               }
-             }]
-           }],
-           "measures": [{
-             "measure": {
-               "functionReference": 0,
-               "arguments": [{
-                 "value": {
-                   "selection": {
-                     "directReference": {
-                       "structField": {
-                         "field": 1
-                       }
-                     }
-                   }
-                 }
-             }],
-               "sorts": [],
-               "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-               "outputType": {
-                 "i64": {}
-               }
-             }
-           }]
-         }
-       }
-     }],
-     "extensionUris": [{
-       "extension_uri_anchor": 0,
-       "uri": "https://github.com/apache/arrow/blob/master/format/substrait/extension_types.yaml"
-     }],
-     "extensions": [{
-       "extension_function": {
-         "extension_uri_reference": 0,
-         "function_anchor": 0,
-         "name": "hash_count"
-       }
-     }],
+        "relations": [
+        {"rel": {
+            "read": {
+            "base_schema": {
+                "struct": {
+                "types": [
+                            {"i64": {}}
+                        ]
+                },
+                "names": [
+                        "bar"
+                        ]
+            },
+            "local_files": {
+                "items": [
+                {
+                    "uri_file": "file://FILENAME_PLACEHOLDER",
+                    "arrow": {},
+                    "metadata" : {
+                      "created_by" : {},
+                    }
+                }
+                ]
+            }
+            }
+        }}
+        ]
     }
     """
 
+    file_name = "binary_json_data.arrow"
+    table = pa.table([[1, 2, 3, 4, 5]], names=['bar'])
+    path = _write_dummy_data_to_disk(tmpdir, file_name, table)
+    query = tobytes(substrait_query.replace("FILENAME_PLACEHOLDER", path))
     buf = pa._substrait._parse_json_plan(tobytes(query))
 
-    exec_message = "Function https://github.com/apache/arrow/blob/master/format/substrait/extension_types.yaml#hash_count not found"
-    with pytest.raises(ArrowInvalid, match=exec_message):
-        substrait.run_query(buf)
+    reader = substrait.run_query(buf)
+    res_tb = reader.read_all()
+
+    assert table.select(["bar"]) == res_tb.select(["bar"])

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -72,7 +72,7 @@ def test_run_serialized_query(tmpdir):
         ]
     }
     """
-    # TODO: replace with ipc when the support is finalized in C++
+
     file_name = "read_data.arrow"
     table = pa.table([[1, 2, 3, 4, 5]], names=['foo'])
     path = _write_dummy_data_to_disk(tmpdir, file_name, table)


### PR DESCRIPTION
Substrait is continously changing and it introduces may unknown fields in the consumed plan. Since it is not practical to support all these fields simultaneously, we have to include a way to ignore such fields. To support that, the `ignore_unknown_fields` is added to the `JsonParseOptions`.
