### PR TITLE
ARROW-16665: [Release] Update binary submit to track binary submission tasks on automatically created PR

### DIFF
--- a/dev/archery/archery/crossbow/cli.py
+++ b/dev/archery/archery/crossbow/cli.py
@@ -299,26 +299,25 @@ def status(obj, job_name, fetch, task_filters):
               help='OAuth token to create comments in the arrow repo. '
                    'Only necessary if --track-on-pr-titled is set.')
 @click.option('--job-name', required=True)
-@click.option('--track-on-pr-titled', default=None,
+@click.option('--pr-title', required=True,
               help='Track the job submitted on PR with given title')
 @click.pass_obj
 def report_pr(obj, arrow_remote, crossbow, fetch, github_token, job_name,
-              track_on_pr_titled):
+              pr_title):
     arrow = obj['arrow']
     queue = obj['queue']
     if fetch:
         queue.fetch()
     job = queue.get(job_name)
 
-    if track_on_pr_titled:
-        report = CommentReport(job, crossbow_repo=crossbow)
-        target_arrow = Repo(path=arrow.path, remote_url=arrow_remote)
-        pull_request = target_arrow.github_pr(title=track_on_pr_titled,
-                                              github_token=github_token,
-                                              create=False)
-        # render the response comment's content on the PR
-        pull_request.create_comment(report.show())
-        click.echo(f'Job is tracked on PR {pull_request.html_url}')
+    report = CommentReport(job, crossbow_repo=crossbow)
+    target_arrow = Repo(path=arrow.path, remote_url=arrow_remote)
+    pull_request = target_arrow.github_pr(title=pr_title,
+                                          github_token=github_token,
+                                          create=False)
+    # render the response comment's content on the PR
+    pull_request.create_comment(report.show())
+    click.echo(f'Job is tracked on PR {pull_request.html_url}')
 
 
 @crossbow.command()

--- a/dev/archery/archery/crossbow/cli.py
+++ b/dev/archery/archery/crossbow/cli.py
@@ -170,7 +170,7 @@ def submit(obj, tasks, groups, params, job_prefix, config_path, arrow_version,
             pull_request.create_comment(report.show())
             click.echo(f'Job is tracked on PR {pull_request.html_url}')
         else:
-            click.echo(f'Job is not tracked on PR. Repo not found')
+            click.echo('Job is not tracked on PR. Repo not found')
 
     if no_push:
         click.echo('Branches and commits created but not pushed: `{}`'

--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -542,7 +542,7 @@ class Repo:
                         'Unsupported upload method {}'.format(method)
                     )
 
-    def github_pr(self, title, head, base="master", body=None,
+    def github_pr(self, title, head=None, base="master", body=None,
                   github_token=None, create=False):
         github_token = github_token or self.github_token
         repo = self.as_github_repo(github_token=github_token)

--- a/dev/release/03-binary-submit.sh
+++ b/dev/release/03-binary-submit.sh
@@ -51,4 +51,4 @@ archery crossbow report-pr \
     --no-fetch \
     --arrow-remote "https://github.com/${ARROW_REPOSITORY}" \
     --job-name ${job_name} \
-    --track-on-pr-titled "WIP: [Release] Verify ${release_candidate_branch}"
+    --pr-title "WIP: [Release] Verify ${release_candidate_branch}"

--- a/dev/release/03-binary-submit.sh
+++ b/dev/release/03-binary-submit.sh
@@ -42,5 +42,13 @@ archery crossbow submit \
     --arrow-version ${version_with_rc} \
     --arrow-remote "https://github.com/${ARROW_REPOSITORY}" \
     --arrow-branch ${ARROW_BRANCH} \
-    --group packaging \
+    --group packaging
+
+# archery will add a comment to the automatically generated PR to track
+# the submitted jobs
+job_name=$(archery crossbow latest-prefix ${crossbow_job_prefix})
+archery crossbow report-pr \
+    --no-fetch \
+    --arrow-remote "https://github.com/${ARROW_REPOSITORY}" \
+    --job-name ${job_name} \
     --track-on-pr-titled "WIP: [Release] Verify ${release_candidate_branch}"

--- a/dev/release/03-binary-submit.sh
+++ b/dev/release/03-binary-submit.sh
@@ -42,4 +42,5 @@ archery crossbow submit \
     --arrow-version ${version_with_rc} \
     --arrow-remote "https://github.com/${ARROW_REPOSITORY}" \
     --arrow-branch ${ARROW_BRANCH} \
-    --group packaging
+    --group packaging \
+    --track-on-pr-titled "WIP: [Release] Verify ${release_candidate_branch}"


### PR DESCRIPTION
This PR updated the binary submission job to also generate badges to track the jobs on the newly created PR to track release verification tasks.
I have tested locally with the following:
```
archery crossbow submit \
    --no-fetch \
    --job-prefix raul-testing-tracking-crossbow-job \
    --arrow-version 8.0.0-rc0 \
    --arrow-remote "https://github.com/apache/arrow" \
    --arrow-branch apache-arrow-8.0.0 \
    --group example \
    --track-on-pr-titled "WIP: Investigate verify rc linux failures"
```
and the comments generated can be seen on the expected PR: https://github.com/apache/arrow/pull/13478#issuecomment-1184509765 
I've had an issue with the submission of jobs due to a CROSSBOW token but this is for the `queue.push()` which hasn't been changed.