### PR TITLE
ARROW-17086: [C++] Install java/dataset include file and fix debug build failed by compiler flag

### DIFF
--- a/cpp/src/gandiva/jni/expression_registry_helper.cc
+++ b/cpp/src/gandiva/jni/expression_registry_helper.cc
@@ -152,7 +152,7 @@ Java_org_apache_arrow_gandiva_evaluator_ExpressionRegistryJniHelper_getGandivaSu
     types::ExtGandivaType* gandiva_data_type = gandiva_data_types.add_datatype();
     ArrowToProtobuf(type, gandiva_data_type);
   }
-  auto size = gandiva_data_types.ByteSizeLong();
+  auto size = static_cast<int>(gandiva_data_types.ByteSizeLong());
   std::unique_ptr<jbyte[]> buffer{new jbyte[size]};
   gandiva_data_types.SerializeToArray(reinterpret_cast<void*>(buffer.get()), size);
   jbyteArray ret = env->NewByteArray(size);
@@ -181,7 +181,7 @@ Java_org_apache_arrow_gandiva_evaluator_ExpressionRegistryJniHelper_getGandivaSu
       ArrowToProtobuf(param_type, proto_param_type);
     }
   }
-  auto size = gandiva_functions.ByteSizeLong();
+  auto size = static_cast<int>(gandiva_functions.ByteSizeLong());
   std::unique_ptr<jbyte[]> buffer{new jbyte[size]};
   gandiva_functions.SerializeToArray(reinterpret_cast<void*>(buffer.get()), size);
   jbyteArray ret = env->NewByteArray(size);

--- a/java/dataset/src/main/cpp/CMakeLists.txt
+++ b/java/dataset/src/main/cpp/CMakeLists.txt
@@ -63,3 +63,6 @@ add_arrow_test(dataset_jni_test
                jni_util.cc
                EXTRA_INCLUDES
                ${JNI_INCLUDE_DIRS})
+               
+install(FILES jni_util.h
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/jni/dataset")

--- a/java/dataset/src/main/cpp/CMakeLists.txt
+++ b/java/dataset/src/main/cpp/CMakeLists.txt
@@ -64,5 +64,4 @@ add_arrow_test(dataset_jni_test
                EXTRA_INCLUDES
                ${JNI_INCLUDE_DIRS})
                
-install(FILES jni_util.h
-        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/jni/dataset")
+install(FILES jni_util.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/jni/dataset")

--- a/java/dataset/src/main/cpp/CMakeLists.txt
+++ b/java/dataset/src/main/cpp/CMakeLists.txt
@@ -63,5 +63,5 @@ add_arrow_test(dataset_jni_test
                jni_util.cc
                EXTRA_INCLUDES
                ${JNI_INCLUDE_DIRS})
-               
+
 install(FILES jni_util.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/jni/dataset")

--- a/java/dataset/src/main/cpp/jni_util.cc
+++ b/java/dataset/src/main/cpp/jni_util.cc
@@ -321,9 +321,9 @@ arrow::Result<jbyteArray> ToSchemaByteArray(JNIEnv* env,
       std::shared_ptr<arrow::Buffer> buffer,
       arrow::ipc::SerializeSchema(*schema, arrow::default_memory_pool()))
 
-  jbyteArray out = env->NewByteArray(buffer->size());
+  jbyteArray out = env->NewByteArray(static_cast<int>(buffer->size()));
   auto src = reinterpret_cast<const jbyte*>(buffer->data());
-  env->SetByteArrayRegion(out, 0, buffer->size(), src);
+  env->SetByteArrayRegion(out, 0, static_cast<int>(buffer->size()), src);
   return out;
 }
 

--- a/java/dataset/src/main/cpp/jni_wrapper.cc
+++ b/java/dataset/src/main/cpp/jni_wrapper.cc
@@ -49,8 +49,8 @@ class JniPendingException : public std::runtime_error {
   explicit JniPendingException(const std::string& arg, jthrowable cause)
       : runtime_error(arg), cause_(cause) {}
 
-  const jthrowable GetCause() const { return cause_; }
-  const bool HasCause() const { return cause_ != nullptr; }
+  jthrowable GetCause() const { return cause_; }
+  bool HasCause() const { return cause_ != nullptr; }
 
  private:
   jthrowable cause_;


### PR DESCRIPTION
Arrow8 will install jni_util.h, but Arrow9 not, cause our project fail when upgraded to Arrow 9

And if use cmake --preset ninja-debug \
        -DARROW_BUILD_SHARED=ON \
        -DARROW_GANDIVA_JAVA=ON \
        -DARROW_GANDIVA=ON
it will failed with this error, fix it
arrow/cpp/src/gandiva/jni/expression_registry_helper.cc:157:78: error: implicit conversion loses integer precision: 'unsigned long' to 'int' [-Werror,-Wshorten-64-to-32]
  gandiva_data_types.SerializeToArray(reinterpret_cast<void*>(buffer.get()), size);