### PR TITLE
ARROW-17071: [C++][Compute] Fixing off-by-one error in hash join node

### DIFF
--- a/cpp/src/arrow/compute/exec/util.h
+++ b/cpp/src/arrow/compute/exec/util.h
@@ -335,7 +335,7 @@ class TailSkipForSIMD {
   static int FixSelection(int64_t num_rows_safe, int num_selected,
                           const uint16_t* selection) {
     int num_selected_safe = num_selected;
-    while (num_selected_safe > 0 && selection[num_selected_safe] >= num_rows_safe) {
+    while (num_selected_safe > 0 && selection[num_selected_safe - 1] >= num_rows_safe) {
       --num_selected_safe;
     }
     return num_selected_safe;

--- a/cpp/src/arrow/compute/light_array.cc
+++ b/cpp/src/arrow/compute/light_array.cc
@@ -237,6 +237,8 @@ Status ResizableArrayData::ResizeFixedLengthBuffers(int num_rows_new) {
         buffers_[kValidityBuffer],
         AllocateResizableBuffer(
             bit_util::BytesForBits(num_rows_allocated_new) + kNumPaddingBytes, pool_));
+    memset(mutable_data(kValidityBuffer), 0,
+           bit_util::BytesForBits(num_rows_allocated_new) + kNumPaddingBytes);
     if (column_metadata.is_fixed_length) {
       if (column_metadata.fixed_length == 0) {
         ARROW_ASSIGN_OR_RAISE(
@@ -244,6 +246,8 @@ Status ResizableArrayData::ResizeFixedLengthBuffers(int num_rows_new) {
             AllocateResizableBuffer(
                 bit_util::BytesForBits(num_rows_allocated_new) + kNumPaddingBytes,
                 pool_));
+        memset(mutable_data(kFixedLengthBuffer), 0,
+               bit_util::BytesForBits(num_rows_allocated_new) + kNumPaddingBytes);
       } else {
         ARROW_ASSIGN_OR_RAISE(
             buffers_[kFixedLengthBuffer],
@@ -267,13 +271,22 @@ Status ResizableArrayData::ResizeFixedLengthBuffers(int num_rows_new) {
     ARROW_DCHECK(buffers_[kValidityBuffer] != NULLPTR &&
                  buffers_[kVariableLengthBuffer] != NULLPTR);
 
+    int64_t bytes_for_bits_before =
+        bit_util::BytesForBits(num_rows_allocated_) + kNumPaddingBytes;
+    int64_t bytes_for_bits_after =
+        bit_util::BytesForBits(num_rows_allocated_new) + kNumPaddingBytes;
+
     RETURN_NOT_OK(buffers_[kValidityBuffer]->Resize(
         bit_util::BytesForBits(num_rows_allocated_new) + kNumPaddingBytes));
+    memset(mutable_data(kValidityBuffer) + bytes_for_bits_before, 0,
+           bytes_for_bits_after - bytes_for_bits_before);
 
     if (column_metadata.is_fixed_length) {
       if (column_metadata.fixed_length == 0) {
         RETURN_NOT_OK(buffers_[kFixedLengthBuffer]->Resize(
             bit_util::BytesForBits(num_rows_allocated_new) + kNumPaddingBytes));
+        memset(mutable_data(kFixedLengthBuffer) + bytes_for_bits_before, 0,
+               bytes_for_bits_after - bytes_for_bits_before);
       } else {
         RETURN_NOT_OK(buffers_[kFixedLengthBuffer]->Resize(
             num_rows_allocated_new * column_metadata.fixed_length + kNumPaddingBytes));


### PR DESCRIPTION
Fixing off-by-one error in hash join node.
Zeroing allocated bit vectors in hash join node to fix another valgrind error.