### PR TITLE
ARROW-17084: [R] Install the package before linting

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -333,7 +333,8 @@ jobs:
             ARROW_R_DEV = TRUE,
             "_R_CHECK_FORCE_SUGGESTS_" = FALSE
           )
-          pak::pak("local::.")
+          # we use pak for package installation since it is faster, safer and more convenient
+          pak::local_install()
           pak::pak("lintr")
           lintr::expect_lint_free()
       - name: Dump install logs

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -327,6 +327,7 @@ jobs:
         shell: Rscript {0}
         working-directory: r
         run: |
+          pak::pak(".")
           pak::pak("lintr")
           lintr::expect_lint_free()
       - name: Dump install logs

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -327,6 +327,12 @@ jobs:
         shell: Rscript {0}
         working-directory: r
         run: |
+          Sys.setenv(
+            RWINLIB_LOCAL = file.path(Sys.getenv("GITHUB_WORKSPACE"), "r", "windows", "libarrow.zip"),
+            MAKEFLAGS = paste0("-j", parallel::detectCores()),
+            ARROW_R_DEV = TRUE,
+            "_R_CHECK_FORCE_SUGGESTS_" = FALSE
+          )
           pak::pak("local::.")
           pak::pak("lintr")
           lintr::expect_lint_free()

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -327,7 +327,7 @@ jobs:
         shell: Rscript {0}
         working-directory: r
         run: |
-          pak::pak(".")
+          pak::pak("local::.")
           pak::pak("lintr")
           lintr::expect_lint_free()
       - name: Dump install logs

--- a/r/tests/testthat/test-dplyr-glimpse.R
+++ b/r/tests/testthat/test-dplyr-glimpse.R
@@ -17,7 +17,7 @@
 
 # The glimpse output for tests with `example_data` is different on R < 3.6
 # because the `lgl` column is generated with `sample()` and the RNG
-# algorithm is different in older R versions. 
+# algorithm is different in older R versions.
 skip_on_r_older_than("3.6")
 
 library(dplyr, warn.conflicts = FALSE)


### PR DESCRIPTION
The package should be installed before running `lintr::ling_package()` or `lintr::expect_lint_free()` (our case), otherwise we could encounter some false positives.

See https://github.com/r-lib/lintr/issues/352#issuecomment-587004345 and https://github.com/r-lib/lintr/issues/406#issuecomment-534601141
