### PR TITLE
ARROW-16612: [R] Fix compression inference from filename

### DIFF
--- a/r/R/csv.R
+++ b/r/R/csv.R
@@ -721,13 +721,9 @@ write_csv_arrow <- function(x,
       x <- as_record_batch_reader(x),
       error = function(e) {
         abort(
-          c(
-            paste0(
-              paste(
-                "x must be an object of class 'data.frame', 'RecordBatch',",
-                "'Dataset', 'Table', or 'RecordBatchReader' not '"
-              ), class(x)[[1]], "'."
-            )
+          paste0(
+            "x must be an object of class 'data.frame', 'RecordBatch', ",
+            "'Dataset', 'Table', or 'RecordBatchReader' not '", class(x)[1], "'."
           )
         )
       }

--- a/r/R/csv.R
+++ b/r/R/csv.R
@@ -699,7 +699,6 @@ write_csv_arrow <- function(x,
     )
   }
 
-  # default values are considered missing by base R
   if (missing(include_header) && !missing(col_names)) {
     include_header <- col_names
   }
@@ -712,16 +711,31 @@ write_csv_arrow <- function(x,
   }
 
   x_out <- x
-  if (is.data.frame(x)) {
-    x <- Table$create(x)
-  }
-
-  if (inherits(x, c("Dataset", "arrow_dplyr_query"))) {
-    x <- Scanner$create(x)$ToRecordBatchReader()
+  if (!inherits(x, "ArrowTabular")) {
+    tryCatch(
+      x <- as_record_batch_reader(x),
+      error = function(e) {
+        abort(
+          c(
+            paste0(
+              paste(
+                "x must be an object of class 'data.frame', 'RecordBatch',",
+                "'Dataset', 'Table', or 'RecordBatchReader' not '"
+              ), class(x)[[1]], "'."
+            )
+          )
+        )
+      }
+    )
   }
 
   if (!inherits(sink, "OutputStream")) {
+    compression <- detect_compression(sink)
     sink <- make_output_stream(sink)
+    if (compression != "uncompressed") {
+      # TODO: accept compression and compression_level as args
+      sink <- CompressedOutputStream$create(sink, codec = compression)
+    }
     on.exit(sink$close())
   }
 
@@ -731,17 +745,6 @@ write_csv_arrow <- function(x,
     csv___WriteCSV__Table(x, write_options, sink)
   } else if (inherits(x, c("RecordBatchReader"))) {
     csv___WriteCSV__RecordBatchReader(x, write_options, sink)
-  } else {
-    abort(
-      c(
-        paste0(
-          paste(
-            "x must be an object of class 'data.frame', 'RecordBatch',",
-            "'Dataset', 'Table', or 'RecordBatchReader' not '"
-          ), class(x)[[1]], "'."
-        )
-      )
-    )
   }
 
   invisible(x_out)

--- a/r/R/csv.R
+++ b/r/R/csv.R
@@ -188,7 +188,12 @@ read_delim_arrow <- function(file,
   }
 
   if (!inherits(file, "InputStream")) {
+    compression <- detect_compression(file)
     file <- make_readable_file(file)
+    if (compression != "uncompressed") {
+      # TODO: accept compression and compression_level as args
+      file <- CompressedInputStream$create(file, compression)
+    }
     on.exit(file$close())
   }
   reader <- CsvTableReader$create(

--- a/r/R/feather.R
+++ b/r/R/feather.R
@@ -41,8 +41,6 @@
 #' compression ratios in exchange for slower read and write performance.
 #' "lz4" is shorthand for the "lz4_frame" codec.
 #' See [codec_is_available()] for details. This option is not supported for V1.
-#' If `compression` is not provided and `sink` is a file path with an extension
-#' of `.lz4` or `.zst`, the compression codec will be inferred from it.
 #' @param compression_level If `compression` is "zstd", you may
 #' specify an integer compression level. If omitted, the compression codec's
 #' default compression level is used.
@@ -76,16 +74,7 @@ write_feather <- function(x,
   version <- as.integer(version)
   assert_that(version %in% 1:2)
 
-  if (missing(compression)) {
-    # IPC compression is in the writer itself, not by wrapping
-    # the sink in a CompressedOutputStream, which make_output_stream() does
-    # if the filename ends in a compression extension. So handle the ext
-    # here before passing to make_output_stream()
-    comp <- detect_compression(sink)
-    if (comp != "uncompressed") {
-      compression <- comp
-    }
-  }
+  # TODO(ARROW-17221): if (missing(compression)), we could detect_compression(sink) here
   compression <- match.arg(compression)
   chunk_size <- as.integer(chunk_size)
   assert_that(chunk_size > 0)
@@ -142,7 +131,7 @@ write_feather <- function(x,
 write_ipc_file <- function(x,
                            sink,
                            chunk_size = 65536L,
-                           compression = c("default", "lz4", "uncompressed", "zstd"),
+                           compression = c("default", "lz4", "lz4_frame", "uncompressed", "zstd"),
                            compression_level = NULL) {
   mc <- match.call()
   mc$version <- 2

--- a/r/R/feather.R
+++ b/r/R/feather.R
@@ -161,7 +161,7 @@ write_ipc_file <- function(x,
 #'
 #' @inheritParams read_ipc_stream
 #' @inheritParams read_delim_arrow
-#' @param ... additional parameters, passed to [make_readable_file()].
+#' @inheritParams make_readable_file
 #'
 #' @return A `data.frame` if `as_data_frame` is `TRUE` (the default), or an
 #' Arrow [Table] otherwise
@@ -177,11 +177,13 @@ write_ipc_file <- function(x,
 #' dim(df)
 #' # Can select columns
 #' df <- read_feather(tf, col_select = starts_with("d"))
-read_feather <- function(file, col_select = NULL, as_data_frame = TRUE, ...) {
+read_feather <- function(file, col_select = NULL, as_data_frame = TRUE, mmap = TRUE) {
   if (!inherits(file, "RandomAccessFile")) {
     # Compression is handled inside the IPC file format, so we don't need
     # to detect from the file extension and wrap in a CompressedInputStream
-    file <- make_readable_file(file, compression = "uncompressed", ...)
+    # TODO: Why is this the only read_format() functions that allows passing
+    # mmap to make_readable_file?
+    file <- make_readable_file(file, mmap)
     on.exit(file$close())
   }
   reader <- FeatherReader$create(file)

--- a/r/R/io.R
+++ b/r/R/io.R
@@ -344,6 +344,7 @@ detect_compression <- function(path) {
     gz = "gzip",
     lz4 = "lz4",
     zst = "zstd",
+    snappy = "snappy",
     "uncompressed"
   )
 }

--- a/r/R/ipc-stream.R
+++ b/r/R/ipc-stream.R
@@ -23,11 +23,6 @@
 #' a "stream" format and a "file" format, known as Feather. `write_ipc_stream()`
 #' and [write_feather()] write those formats, respectively.
 #'
-#' `write_arrow()`, a wrapper around `write_ipc_stream()` and `write_feather()`
-#' with some nonstandard behavior, is deprecated. You should explicitly choose
-#' the function that will write the desired IPC format (stream or file) since
-#' either can be written to a file or `OutputStream`.
-#'
 #' @inheritParams write_feather
 #' @param ... extra parameters passed to `write_feather()`.
 #'
@@ -86,11 +81,6 @@ write_to_raw <- function(x, format = c("stream", "file")) {
 #' (IPC)](https://arrow.apache.org/docs/format/Columnar.html#serialization-and-interprocess-communication-ipc):
 #' a "stream" format and a "file" format, known as Feather. `read_ipc_stream()`
 #' and [read_feather()] read those formats, respectively.
-#'
-#' `read_arrow()`, a wrapper around `read_ipc_stream()` and `read_feather()`,
-#' is deprecated. You should explicitly choose
-#' the function that will read the desired IPC format (stream or file) since
-#' a file or `InputStream` may contain either.
 #'
 #' @param file A character file name or URI, `raw` vector, an Arrow input stream,
 #' or a `FileSystem` with path (`SubTreeFileSystem`).

--- a/r/R/json.R
+++ b/r/R/json.R
@@ -44,7 +44,12 @@ read_json_arrow <- function(file,
                             schema = NULL,
                             ...) {
   if (!inherits(file, "InputStream")) {
+    compression <- detect_compression(file)
     file <- make_readable_file(file)
+    if (compression != "uncompressed") {
+      # TODO: accept compression and compression_level as args
+      file <- CompressedInputStream$create(file, compression)
+    }
     on.exit(file$close())
   }
   tab <- JsonTableReader$create(file, schema = schema, ...)$Read()

--- a/r/R/parquet.R
+++ b/r/R/parquet.R
@@ -162,17 +162,13 @@ write_parquet <- function(x,
   x <- as_writable_table(x)
 
   if (!inherits(sink, "OutputStream")) {
-    if (missing(compression) && is.string(sink)) {
-      # Parquet handles compression in the writer itself, not by wrapping
-      # the sink in a CompressedOutputStream, which make_output_stream() does
-      # if the filename ends in a compression extension. So handle the ext
-      # here before passing to make_output_stream()
+    if (missing(compression)) {
       comp <- detect_compression(sink)
       if (comp != "uncompressed") {
         compression <- comp
       }
     }
-    sink <- make_output_stream(sink, compression = "uncompressed")
+    sink <- make_output_stream(sink)
     on.exit(sink$close())
   }
 

--- a/r/R/parquet.R
+++ b/r/R/parquet.R
@@ -36,6 +36,12 @@
 read_parquet <- function(file,
                          col_select = NULL,
                          as_data_frame = TRUE,
+                         # TODO: for consistency with other readers/writers,
+                         # these properties should be enumerated as args here,
+                         # and ParquetArrowReaderProperties$create() should
+                         # accept them, as with ParquetWriterProperties.
+                         # Assembling `props` yourself is something you do with
+                         # ParquetFileReader but not here.
                          props = ParquetArrowReaderProperties$create(),
                          ...) {
   if (!inherits(file, "RandomAccessFile")) {

--- a/r/R/parquet.R
+++ b/r/R/parquet.R
@@ -41,7 +41,7 @@ read_parquet <- function(file,
   if (!inherits(file, "RandomAccessFile")) {
     # Compression is handled inside the parquet file format, so we don't need
     # to detect from the file extension and wrap in a CompressedInputStream
-    file <- make_readable_file(file, compression = "uncompressed")
+    file <- make_readable_file(file)
     on.exit(file$close())
   }
   reader <- ParquetFileReader$create(file, props = props, ...)

--- a/r/R/parquet.R
+++ b/r/R/parquet.R
@@ -134,10 +134,6 @@ read_parquet <- function(file,
 #' disable compression, set `compression = "uncompressed"`.
 #' Note that "uncompressed" columns may still have dictionary encoding.
 #'
-#' If `compression` is not provided and `sink` is a file path with an extension
-#' indicating compression, such as `.gz` or `.snappy`, the compression codec
-#' will be inferred from it.
-#'
 #' @return the input `x` invisibly.
 #' @seealso [ParquetFileWriter] for a lower-level interface to Parquet writing.
 #' @examplesIf arrow_with_parquet()
@@ -168,12 +164,7 @@ write_parquet <- function(x,
   x <- as_writable_table(x)
 
   if (!inherits(sink, "OutputStream")) {
-    if (missing(compression)) {
-      comp <- detect_compression(sink)
-      if (comp != "uncompressed") {
-        compression <- comp
-      }
-    }
+    # TODO(ARROW-17221): if (missing(compression)), we could detect_compression(sink) here
     sink <- make_output_stream(sink)
     on.exit(sink$close())
   }

--- a/r/R/parquet.R
+++ b/r/R/parquet.R
@@ -128,6 +128,10 @@ read_parquet <- function(file,
 #' disable compression, set `compression = "uncompressed"`.
 #' Note that "uncompressed" columns may still have dictionary encoding.
 #'
+#' If `compression` is not provided and `sink` is a file path with an extension
+#' indicating compression, such as `.gz` or `.snappy`, the compression codec
+#' will be inferred from it.
+#'
 #' @return the input `x` invisibly.
 #' @seealso [ParquetFileWriter] for a lower-level interface to Parquet writing.
 #' @examplesIf arrow_with_parquet()

--- a/r/man/make_readable_file.Rd
+++ b/r/man/make_readable_file.Rd
@@ -4,21 +4,12 @@
 \alias{make_readable_file}
 \title{Handle a range of possible input sources}
 \usage{
-make_readable_file(file, mmap = TRUE, compression = NULL, filesystem = NULL)
+make_readable_file(file, mmap = TRUE)
 }
 \arguments{
 \item{file}{A character file name, \code{raw} vector, or an Arrow input stream}
 
 \item{mmap}{Logical: whether to memory-map the file (default \code{TRUE})}
-
-\item{compression}{If the file is compressed, created a \link{CompressedInputStream}
-with this compression codec, either a \link{Codec} or the string name of one.
-If \code{NULL} (default) and \code{file} is a string file name, the function will try
-to infer compression from the file extension.}
-
-\item{filesystem}{If not \code{NULL}, \code{file} will be opened via the
-\code{filesystem$OpenInputFile()} filesystem method, rather than the \code{io} module's
-\code{MemoryMappedFile} or \code{ReadableFile} constructors.}
 }
 \value{
 An \code{InputStream} or a subclass of one.

--- a/r/man/read_feather.Rd
+++ b/r/man/read_feather.Rd
@@ -5,9 +5,9 @@
 \alias{read_ipc_file}
 \title{Read a Feather file (an Arrow IPC file)}
 \usage{
-read_feather(file, col_select = NULL, as_data_frame = TRUE, ...)
+read_feather(file, col_select = NULL, as_data_frame = TRUE, mmap = TRUE)
 
-read_ipc_file(file, col_select = NULL, as_data_frame = TRUE, ...)
+read_ipc_file(file, col_select = NULL, as_data_frame = TRUE, mmap = TRUE)
 }
 \arguments{
 \item{file}{A character file name or URI, \code{raw} vector, an Arrow input stream,
@@ -24,7 +24,7 @@ of columns, as used in \code{dplyr::select()}.}
 \item{as_data_frame}{Should the function return a \code{data.frame} (default) or
 an Arrow \link{Table}?}
 
-\item{...}{additional parameters, passed to \code{\link[=make_readable_file]{make_readable_file()}}.}
+\item{mmap}{Logical: whether to memory-map the file (default \code{TRUE})}
 }
 \value{
 A \code{data.frame} if \code{as_data_frame} is \code{TRUE} (the default), or an

--- a/r/man/read_ipc_stream.Rd
+++ b/r/man/read_ipc_stream.Rd
@@ -27,12 +27,6 @@ Apache Arrow defines two formats for \href{https://arrow.apache.org/docs/format/
 a "stream" format and a "file" format, known as Feather. \code{read_ipc_stream()}
 and \code{\link[=read_feather]{read_feather()}} read those formats, respectively.
 }
-\details{
-\code{read_arrow()}, a wrapper around \code{read_ipc_stream()} and \code{read_feather()},
-is deprecated. You should explicitly choose
-the function that will read the desired IPC format (stream or file) since
-a file or \code{InputStream} may contain either.
-}
 \seealso{
 \code{\link[=write_feather]{write_feather()}} for writing IPC files. \link{RecordBatchReader} for a
 lower-level interface.

--- a/r/man/write_feather.Rd
+++ b/r/man/write_feather.Rd
@@ -38,7 +38,9 @@ random row access. Default is 64K. This option is not supported for V1.}
 "lz4" if LZ4 is available in your build of the Arrow C++ library, otherwise
 "uncompressed". "zstd" is the other available codec and generally has better
 compression ratios in exchange for slower read and write performance
-See \code{\link[=codec_is_available]{codec_is_available()}}. This option is not supported for V1.}
+See \code{\link[=codec_is_available]{codec_is_available()}}. This option is not supported for V1.
+If \code{compression} is not provided and \code{sink} is a file path with an extension
+of \code{.lz4} or \code{.zst}, the compression codec will be inferred from it.}
 
 \item{compression_level}{If \code{compression} is "zstd", you may
 specify an integer compression level. If omitted, the compression codec's

--- a/r/man/write_feather.Rd
+++ b/r/man/write_feather.Rd
@@ -18,7 +18,7 @@ write_ipc_file(
   x,
   sink,
   chunk_size = 65536L,
-  compression = c("default", "lz4", "uncompressed", "zstd"),
+  compression = c("default", "lz4", "lz4_frame", "uncompressed", "zstd"),
   compression_level = NULL
 )
 }
@@ -39,9 +39,7 @@ random row access. Default is 64K. This option is not supported for V1.}
 "uncompressed". "zstd" is the other available codec and generally has better
 compression ratios in exchange for slower read and write performance.
 "lz4" is shorthand for the "lz4_frame" codec.
-See \code{\link[=codec_is_available]{codec_is_available()}} for details. This option is not supported for V1.
-If \code{compression} is not provided and \code{sink} is a file path with an extension
-of \code{.lz4} or \code{.zst}, the compression codec will be inferred from it.}
+See \code{\link[=codec_is_available]{codec_is_available()}} for details. This option is not supported for V1.}
 
 \item{compression_level}{If \code{compression} is "zstd", you may
 specify an integer compression level. If omitted, the compression codec's

--- a/r/man/write_feather.Rd
+++ b/r/man/write_feather.Rd
@@ -10,7 +10,7 @@ write_feather(
   sink,
   version = 2,
   chunk_size = 65536L,
-  compression = c("default", "lz4", "uncompressed", "zstd"),
+  compression = c("default", "lz4", "lz4_frame", "uncompressed", "zstd"),
   compression_level = NULL
 )
 
@@ -37,8 +37,9 @@ random row access. Default is 64K. This option is not supported for V1.}
 \item{compression}{Name of compression codec to use, if any. Default is
 "lz4" if LZ4 is available in your build of the Arrow C++ library, otherwise
 "uncompressed". "zstd" is the other available codec and generally has better
-compression ratios in exchange for slower read and write performance
-See \code{\link[=codec_is_available]{codec_is_available()}}. This option is not supported for V1.
+compression ratios in exchange for slower read and write performance.
+"lz4" is shorthand for the "lz4_frame" codec.
+See \code{\link[=codec_is_available]{codec_is_available()}} for details. This option is not supported for V1.
 If \code{compression} is not provided and \code{sink} is a file path with an extension
 of \code{.lz4} or \code{.zst}, the compression codec will be inferred from it.}
 

--- a/r/man/write_ipc_stream.Rd
+++ b/r/man/write_ipc_stream.Rd
@@ -22,12 +22,6 @@ Apache Arrow defines two formats for \href{https://arrow.apache.org/docs/format/
 a "stream" format and a "file" format, known as Feather. \code{write_ipc_stream()}
 and \code{\link[=write_feather]{write_feather()}} write those formats, respectively.
 }
-\details{
-\code{write_arrow()}, a wrapper around \code{write_ipc_stream()} and \code{write_feather()}
-with some nonstandard behavior, is deprecated. You should explicitly choose
-the function that will write the desired IPC format (stream or file) since
-either can be written to a file or \code{OutputStream}.
-}
 \examples{
 tf <- tempfile()
 on.exit(unlink(tf))

--- a/r/man/write_parquet.Rd
+++ b/r/man/write_parquet.Rd
@@ -92,10 +92,6 @@ are almost always included. See \code{\link[=codec_is_available]{codec_is_availa
 The default "snappy" is used if available, otherwise "uncompressed". To
 disable compression, set \code{compression = "uncompressed"}.
 Note that "uncompressed" columns may still have dictionary encoding.
-
-If \code{compression} is not provided and \code{sink} is a file path with an extension
-indicating compression, such as \code{.gz} or \code{.snappy}, the compression codec
-will be inferred from it.
 }
 \examples{
 \dontshow{if (arrow_with_parquet()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}

--- a/r/man/write_parquet.Rd
+++ b/r/man/write_parquet.Rd
@@ -92,6 +92,10 @@ are almost always included. See \code{\link[=codec_is_available]{codec_is_availa
 The default "snappy" is used if available, otherwise "uncompressed". To
 disable compression, set \code{compression = "uncompressed"}.
 Note that "uncompressed" columns may still have dictionary encoding.
+
+If \code{compression} is not provided and \code{sink} is a file path with an extension
+indicating compression, such as \code{.gz} or \code{.snappy}, the compression codec
+will be inferred from it.
 }
 \examples{
 \dontshow{if (arrow_with_parquet()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}

--- a/r/tests/testthat/test-compressed.R
+++ b/r/tests/testthat/test-compressed.R
@@ -40,6 +40,14 @@ test_that("Codec attributes", {
   expect_error(cod$level)
 })
 
+test_that("Default compression_level for zstd", {
+  skip_if_not_available("zstd")
+  cod <- Codec$create("zstd")
+  expect_equal(cod$name, "zstd")
+  # TODO: implement $level
+  expect_error(cod$level)
+})
+
 test_that("can write Buffer to CompressedOutputStream and read back in CompressedInputStream", {
   skip_if_not_available("gzip")
   buf <- buffer(as.raw(sample(0:255, size = 1024, replace = TRUE)))

--- a/r/tests/testthat/test-csv.R
+++ b/r/tests/testthat/test-csv.R
@@ -566,8 +566,6 @@ test_that("read/write compressed file successfully", {
   skip_if_not_available("gzip")
   tfgz <- tempfile(fileext = ".csv.gz")
   tf <- tempfile(fileext = ".csv")
-  on.exit(unlink(tf))
-  on.exit(unlink(tfgz))
 
   write_csv_arrow(tbl, tf)
   write_csv_arrow(tbl, tfgz)
@@ -575,6 +573,14 @@ test_that("read/write compressed file successfully", {
 
   expect_identical(
     read_csv_arrow(tfgz),
+    tbl
+  )
+  skip_if_not_available("lz4")
+  tflz4 <- tempfile(fileext = ".csv.lz4")
+  write_csv_arrow(tbl, tflz4)
+  expect_false(file.size(tfgz) == file.size(tflz4))
+  expect_identical(
+    read_csv_arrow(tflz4),
     tbl
   )
 })

--- a/r/tests/testthat/test-csv.R
+++ b/r/tests/testthat/test-csv.R
@@ -585,6 +585,21 @@ test_that("read/write compressed file successfully", {
   )
 })
 
+test_that("read/write compressed filesystem path", {
+  skip_if_not_available("zstd")
+  tfzst <- tempfile(fileext = ".csv.zst")
+  fs <- SubTreeFileSystem$create(paste0("file://", tfzst))
+  write_csv_arrow(tbl, fs)
+
+  tf <- tempfile(fileext = ".csv")
+  write_csv_arrow(tbl, tf)
+  expect_lt(file.size(tfzst), file.size(tf))
+  expect_identical(
+    read_csv_arrow(fs),
+    tbl
+  )
+})
+
 test_that("read_csv_arrow() can read sub-second timestamps with col_types T setting (ARROW-15599)", {
   tbl <- tibble::tibble(time = c("2018-10-07 19:04:05.000", "2018-10-07 19:04:05.001"))
   tf <- tempfile()

--- a/r/tests/testthat/test-csv.R
+++ b/r/tests/testthat/test-csv.R
@@ -588,7 +588,7 @@ test_that("read/write compressed file successfully", {
 test_that("read/write compressed filesystem path", {
   skip_if_not_available("zstd")
   tfzst <- tempfile(fileext = ".csv.zst")
-  fs <- SubTreeFileSystem$create(paste0("file://", tfzst))
+  fs <- LocalFileSystem$create()$path(tfzst)
   write_csv_arrow(tbl, fs)
 
   tf <- tempfile(fileext = ".csv")

--- a/r/tests/testthat/test-feather.R
+++ b/r/tests/testthat/test-feather.R
@@ -207,6 +207,23 @@ test_that("read_feather requires RandomAccessFile and errors nicely otherwise (A
   )
 })
 
+test_that("write_feather() detects compression from filename", {
+  skip_if_not_available("lz4")
+  explicit <- tempfile(fileext = ".arrow")
+  implicit <- tempfile(fileext = ".arrow.lz4")
+  write_feather(mtcars, explicit, compression = "lz4")
+  write_feather(mtcars, implicit)
+  expect_equal(file.size(explicit), file.size(implicit))
+})
+
+test_that("read_feather() handles compression in filename", {
+  skip_if_not_available("lz4")
+  df <- tibble::tibble(x = 1:5)
+  implicit <- tempfile(fileext = ".parquet.lz4")
+  write_feather(df, implicit)
+  expect_equal(read_feather(implicit), df)
+})
+
 test_that("read_feather() and write_feather() accept connection objects", {
   skip_if_not(CanRunWithCapturedR())
 

--- a/r/tests/testthat/test-feather.R
+++ b/r/tests/testthat/test-feather.R
@@ -207,21 +207,20 @@ test_that("read_feather requires RandomAccessFile and errors nicely otherwise (A
   )
 })
 
-test_that("write_feather() detects compression from filename", {
-  skip_if_not_available("lz4")
-  explicit <- tempfile(fileext = ".arrow")
-  implicit <- tempfile(fileext = ".arrow.lz4")
-  write_feather(mtcars, explicit, compression = "lz4")
-  write_feather(mtcars, implicit)
-  expect_equal(file.size(explicit), file.size(implicit))
+test_that("write_feather() does not detect compression from filename", {
+  # TODO(ARROW-17221): should this be supported?
+  without <- tempfile(fileext = ".arrow")
+  with_zst <- tempfile(fileext = ".arrow.zst")
+  write_feather(mtcars, without)
+  write_feather(mtcars, with_zst)
+  expect_equal(file.size(without), file.size(with_zst))
 })
 
-test_that("read_feather() handles compression in filename", {
-  skip_if_not_available("lz4")
+test_that("read_feather() handles (ignores) compression in filename", {
   df <- tibble::tibble(x = 1:5)
-  implicit <- tempfile(fileext = ".parquet.lz4")
-  write_feather(df, implicit)
-  expect_equal(read_feather(implicit), df)
+  f <- tempfile(fileext = ".parquet.zst")
+  write_feather(df, f)
+  expect_equal(read_feather(f), df)
 })
 
 test_that("read_feather() and write_feather() accept connection objects", {

--- a/r/tests/testthat/test-parquet.R
+++ b/r/tests/testthat/test-parquet.R
@@ -185,6 +185,23 @@ test_that("write_parquet() defaults to snappy compression", {
   expect_equal(file.size(tmp1), file.size(tmp2))
 })
 
+test_that("write_parquet() detects compression from filename", {
+  skip_if_not_available("gzip")
+  explicit <- tempfile(fileext = ".parquet")
+  implicit <- tempfile(fileext = ".parquet.gz")
+  write_parquet(mtcars, explicit, compression = "gzip")
+  write_parquet(mtcars, implicit)
+  expect_equal(file.size(explicit), file.size(implicit))
+})
+
+test_that("read_parquet() handles compression in filename", {
+  skip_if_not_available("gzip")
+  df <- tibble::tibble(x = 1:5)
+  implicit <- tempfile(fileext = ".parquet.gz")
+  write_parquet(df, implicit)
+  expect_equal(read_parquet(implicit), df)
+})
+
 test_that("Factors are preserved when writing/reading from Parquet", {
   fct <- factor(c("a", "b"), levels = c("c", "a", "b"))
   ord <- factor(c("a", "b"), levels = c("c", "a", "b"), ordered = TRUE)

--- a/r/tests/testthat/test-parquet.R
+++ b/r/tests/testthat/test-parquet.R
@@ -185,21 +185,20 @@ test_that("write_parquet() defaults to snappy compression", {
   expect_equal(file.size(tmp1), file.size(tmp2))
 })
 
-test_that("write_parquet() detects compression from filename", {
-  skip_if_not_available("gzip")
-  explicit <- tempfile(fileext = ".parquet")
-  implicit <- tempfile(fileext = ".parquet.gz")
-  write_parquet(mtcars, explicit, compression = "gzip")
-  write_parquet(mtcars, implicit)
-  expect_equal(file.size(explicit), file.size(implicit))
+test_that("write_parquet() does not detect compression from filename", {
+  # TODO(ARROW-17221): should this be supported?
+  without <- tempfile(fileext = ".parquet")
+  with_gz <- tempfile(fileext = ".parquet.gz")
+  write_parquet(mtcars, without)
+  write_parquet(mtcars, with_gz)
+  expect_equal(file.size(with_gz), file.size(without))
 })
 
-test_that("read_parquet() handles compression in filename", {
-  skip_if_not_available("gzip")
+test_that("read_parquet() handles (ignores) compression in filename", {
   df <- tibble::tibble(x = 1:5)
-  implicit <- tempfile(fileext = ".parquet.gz")
-  write_parquet(df, implicit)
-  expect_equal(read_parquet(implicit), df)
+  f <- tempfile(fileext = ".parquet.gz")
+  write_parquet(df, f)
+  expect_equal(read_parquet(f), df)
 })
 
 test_that("Factors are preserved when writing/reading from Parquet", {


### PR DESCRIPTION
This is actually a much larger change than the original issue. 

* ~Infer compression from the file extension in `write_parquet()` and pass it to ParquetFileWriter rather than write to a CompressedOutputStream, and don't wrap the in a CompressedInputStream in `read_parquet()` because that doesn't work (and isn't how compression works for Parquet). Previously, reading from a file with extension `.parquet.gz` etc. would error unless you opened an input stream yourself. This is the original report from ARROW-16612.~ Cut and moved to [ARROW-17221](https://issues.apache.org/jira/browse/ARROW-17221) for future consideration.
* Likewise for `read_feather()` and `write_feather()`, which also support compression within the file itself and not around it.
* Since the whole "detect compression and wrap in a compressed stream" feature seems limited to CSV and JSON, and in making the changes here I was having to hack around that feature, I refactored to pull it out of the internal functions `make_readable_file()` and `make_output_stream()` and do it only in the csv/json functions.
* In the process of refactoring, I noticed and fixed two bugs: (1) no matter what compression extension you provided to `make_output_stream()`, you would get a gzip-compressed stream because we weren't actually passing the codec to `CompressedOutputStream$create()`; (2) `.lz4` actually needs to be mapped to the "lz4_frame" codec; attempting to write a CSV to a `CompressedOutputStream$create(codec = "lz4")` raises an error. Neither were caught because our tests for this feature only tested gzip.
* The refactoring should also mean that ARROW-16619 (inferring compression from URL), as well as from SubTreeFileSystem (S3 buckets etc.), is also supported.