### PR TITLE
ARROW-16395: [R] Implement lubridate's parsers with year, month, and day, hour, minute, and second components

### DIFF
--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -587,13 +587,15 @@ register_bindings_datetime_parsers <- function() {
 
   parser_map_factory <- function(order) {
     force(order)
-    function(x, tz = NULL) {
+    function(x, quiet = TRUE, tz = NULL, locale = NULL, truncated = 0) {
+      if (!is.null(locale)) {
+        arrow_not_supported("`locale`")
+      }
       # Parsers returning datetimes return UTC by default and never return dates.
       if (is.null(tz) && nchar(order) > 3) {
         tz <- "UTC"
       }
-
-      parse_x <- call_binding("parse_date_time", x, order, tz)
+      parse_x <- call_binding("parse_date_time", x, order, tz, truncated, quiet)
       if (is.null(tz)) {
         # we cast so we can mimic the behaviour of the `tz` argument in lubridate
         # "If NULL (default), a Date object is returned. Otherwise a POSIXct with

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -579,11 +579,20 @@ register_bindings_datetime_parsers <- function() {
     }
   })
 
-  ymd_parser_vec <- c("ymd", "ydm", "mdy", "myd", "dmy", "dym", "ym", "my", "yq")
+  parser_vec <- c(
+    "ymd", "ydm", "mdy", "myd", "dmy", "dym", "ym", "my", "yq",
+    "ymd_HMS", "ymd_HM", "ymd_H", "dmy_HMS", "dmy_HM", "dmy_H",
+    "mdy_HMS", "mdy_HM", "mdy_H", "ydm_HMS", "ydm_HM", "ydm_H"
+  )
 
-  ymd_parser_map_factory <- function(order) {
+  parser_map_factory <- function(order) {
     force(order)
     function(x, tz = NULL) {
+      # Parsers returning datetimes return UTC by default and never return dates.
+      if (is.null(tz) && nchar(order) > 3) {
+        tz <- "UTC"
+      }
+
       parse_x <- call_binding("parse_date_time", x, order, tz)
       if (is.null(tz)) {
         # we cast so we can mimic the behaviour of the `tz` argument in lubridate
@@ -595,10 +604,10 @@ register_bindings_datetime_parsers <- function() {
     }
   }
 
-  for (ymd_order in ymd_parser_vec) {
+  for (order in parser_vec) {
     register_binding(
-      paste0("lubridate::", ymd_order),
-      ymd_parser_map_factory(ymd_order)
+      paste0("lubridate::", tolower(order)),
+      parser_map_factory(order)
     )
   }
 

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -2222,6 +2222,26 @@ test_that("parse_date_time with hours, minutes and seconds components", {
     test_dates_times
   )
 
+  compare_dplyr_binding(
+    .input %>%
+      mutate(
+        ymd_hms_dttm = ymd_hms(ymd_hms_string),
+        ymd_hm_dttm = ymd_hm(ymd_hm_string),
+        ymd_h_dttm = ymd_h(ymd_h_string),
+        dmy_hms_dttm = dmy_hms(dmy_hms_string),
+        dmy_hm_dttm = dmy_hm(dmy_hm_string),
+        dmy_h_dttm = dmy_h(dmy_h_string),
+        mdy_hms_dttm = mdy_hms(mdy_hms_string),
+        mdy_hm_dttm = mdy_hm(mdy_hm_string),
+        mdy_h_dttm = mdy_h(mdy_h_string),
+        ydm_hms_dttm = ydm_hms(ydm_hms_string),
+        ydm_hm_dttm = ydm_hm(ydm_hm_string),
+        ydm_h_dttm = ydm_h(ydm_h_string)
+      ) %>%
+      collect(),
+    test_dates_times
+  )
+
   # parse_date_time with timezone
   pm_tz <- "Pacific/Marquesas"
   compare_dplyr_binding(
@@ -2239,6 +2259,26 @@ test_that("parse_date_time with hours, minutes and seconds components", {
         ydm_hms_dttm = parse_date_time(ydm_hms_string, orders = "ydm_HMS", tz = pm_tz),
         ydm_hm_dttm = parse_date_time(ydm_hm_string, orders = "ydm_HM", tz = pm_tz),
         ydm_h_dttm = parse_date_time(ydm_h_string, orders = "ydm_H", tz = pm_tz)
+      ) %>%
+      collect(),
+    test_dates_times
+  )
+
+  compare_dplyr_binding(
+    .input %>%
+      mutate(
+        ymd_hms_dttm = ymd_hms(ymd_hms_string, tz = pm_tz),
+        ymd_hm_dttm = ymd_hm(ymd_hm_string, tz = pm_tz),
+        ymd_h_dttm = ymd_h(ymd_h_string, tz = pm_tz),
+        dmy_hms_dttm = dmy_hms(dmy_hms_string, tz = pm_tz),
+        dmy_hm_dttm = dmy_hm(dmy_hm_string, tz = pm_tz),
+        dmy_h_dttm = dmy_h(dmy_h_string, tz = pm_tz),
+        mdy_hms_dttm = mdy_hms(mdy_hms_string, tz = pm_tz),
+        mdy_hm_dttm = mdy_hm(mdy_hm_string, tz = pm_tz),
+        mdy_h_dttm = mdy_h(mdy_h_string, tz = pm_tz),
+        ydm_hms_dttm = ydm_hms(ydm_hms_string, tz = pm_tz),
+        ydm_hm_dttm = ydm_hm(ydm_hm_string, tz = pm_tz),
+        ydm_h_dttm = ydm_h(ydm_h_string, tz = pm_tz),
       ) %>%
       collect(),
     test_dates_times
@@ -2315,6 +2355,26 @@ test_that("parse_date_time with month names and HMS", {
         ydm_hms_dttm = parse_date_time(ydm_hms_string, orders = "ydm_HMS"),
         ydm_hm_dttm  = parse_date_time(ydm_hm_string, orders = "ydmHM"),
         ydm_h_dttm   = parse_date_time(ydm_h_string, orders = "ydm_H")
+      ) %>%
+      collect(),
+    test_dates_times2
+  )
+
+  compare_dplyr_binding(
+    .input %>%
+      mutate(
+        ymd_hms_dttm = ymd_hms(ymd_hms_string),
+        ymd_hm_dttm  = ymd_hm(ymd_hm_string),
+        ymd_h_dttm   = ymd_h(ymd_h_string),
+        dmy_hms_dttm = dmy_hms(dmy_hms_string),
+        dmy_hm_dttm  = dmy_hm(dmy_hm_string),
+        dmy_h_dttm   = dmy_h(dmy_h_string),
+        mdy_hms_dttm = mdy_hms(mdy_hms_string),
+        mdy_hm_dttm  = mdy_hm(mdy_hm_string),
+        mdy_h_dttm   = mdy_h(mdy_h_string),
+        ydm_hms_dttm = ydm_hms(ydm_hms_string),
+        ydm_hm_dttm  = ydm_hm(ydm_hm_string),
+        ydm_h_dttm   = ydm_h(ydm_h_string)
       ) %>%
       collect(),
     test_dates_times2
@@ -2512,6 +2572,26 @@ test_that("build_formats() and build_format_from_order()", {
       "%Y-%B-%d-%H-%M-%S", "%y-%b-%d-%H-%M-%S", "%Y-%b-%d-%H-%M-%S",
       "%y%m%d%H%M%S", "%Y%m%d%H%M%S", "%y%B%d%H%M%S", "%Y%B%d%H%M%S",
       "%y%b%d%H%M%S", "%Y%b%d%H%M%S"
+    )
+  )
+
+  expect_equal(
+    build_format_from_order("ymdHM"),
+    c(
+      "%y-%m-%d-%H-%M", "%Y-%m-%d-%H-%M", "%y-%B-%d-%H-%M",
+      "%Y-%B-%d-%H-%M", "%y-%b-%d-%H-%M", "%Y-%b-%d-%H-%M",
+      "%y%m%d%H%M", "%Y%m%d%H%M", "%y%B%d%H%M", "%Y%B%d%H%M",
+      "%y%b%d%H%M", "%Y%b%d%H%M"
+    )
+  )
+
+  expect_equal(
+    build_format_from_order("ymdH"),
+    c(
+      "%y-%m-%d-%H", "%Y-%m-%d-%H", "%y-%B-%d-%H",
+      "%Y-%B-%d-%H", "%y-%b-%d-%H", "%Y-%b-%d-%H",
+      "%y%m%d%H", "%Y%m%d%H", "%y%B%d%H", "%Y%B%d%H",
+      "%y%b%d%H", "%Y%b%d%H"
     )
   )
 })

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -2284,6 +2284,26 @@ test_that("parse_date_time with hours, minutes and seconds components", {
     test_dates_times
   )
 
+  compare_dplyr_binding(
+    .input %>%
+      mutate(
+        ymd_hms_dttm = ymd_hms("2022-07-19 20:24:43"),
+        ymd_hm_dttm = ymd_hm("2022-07-19 20:24"),
+        ymd_h_dttm = ymd_h("2022-07-19 20"),
+        dmy_hms_dttm = dmy_hms("19-07-2022 20:24:43"),
+        dmy_hm_dttm = dmy_hm("19-07-2022 20:24"),
+        dmy_h_dttm = dmy_h("19-07-2022 20"),
+        mdy_hms_dttm = mdy_hms("07-19-2022 20:24:43"),
+        mdy_hm_dttm = mdy_hm("07-19-2022 20:24"),
+        mdy_h_dttm = mdy_h("07-19-2022 20"),
+        ydm_hms_dttm = ydm_hms("2022-19-07 20:24:43"),
+        ydm_hm_dttm = ydm_hm("2022-19-07 20:24"),
+        ydm_h_dttm = ydm_h("2022-19-07 20")
+      ) %>%
+      collect(),
+    test_dates_times
+  )
+
   # test ymd_ims
   compare_dplyr_binding(
     .input %>%
@@ -2375,6 +2395,26 @@ test_that("parse_date_time with month names and HMS", {
         ydm_hms_dttm = ydm_hms(ydm_hms_string),
         ydm_hm_dttm  = ydm_hm(ydm_hm_string),
         ydm_h_dttm   = ydm_h(ydm_h_string)
+      ) %>%
+      collect(),
+    test_dates_times2
+  )
+
+  compare_dplyr_binding(
+    .input %>%
+      mutate(
+        ymd_hms_dttm = ymd_hms("2022-June-19 20:24:43"),
+        ymd_hm_dttm = ymd_hm("2022-June-19 20:24"),
+        ymd_h_dttm = ymd_h("2022-June-19 20"),
+        dmy_hms_dttm = dmy_hms("19-June-2022 20:24:43"),
+        dmy_hm_dttm = dmy_hm("19-June-2022 20:24"),
+        dmy_h_dttm = dmy_h("19-June-2022 20"),
+        mdy_hms_dttm = mdy_hms("June-19-2022 20:24:43"),
+        mdy_hm_dttm = mdy_hm("June-19-2022 20:24"),
+        mdy_h_dttm = mdy_h("June-19-2022 20"),
+        ydm_hms_dttm = ydm_hms("2022-19-June 20:24:43"),
+        ydm_hm_dttm = ydm_hm("2022-19-June 20:24"),
+        ydm_h_dttm = ydm_h("2022-19-June 20")
       ) %>%
       collect(),
     test_dates_times2


### PR DESCRIPTION
This is to resolve [ARROW-16395](https://issues.apache.org/jira/browse/ARROW-16395).