### PR TITLE
ARROW-16669: [Go][CI] Test failure on ARM for pqarrow

### DIFF
--- a/go/parquet/pqarrow/reader_writer_test.go
+++ b/go/parquet/pqarrow/reader_writer_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 const alternateOrNA = -1
-const SIZELEN = 10 * 1024 * 1024
+const SIZELEN = 1024 * 1024
 
 func randomUint8(size, truePct int, sampleVals [2]uint8, seed uint64) []uint8 {
 	ret := make([]uint8, size)


### PR DESCRIPTION
By shrinking the size of the test cases used for the `pqarrow` module's row tests from `10 * 1024 * 1024` to just `1024 * 1024`  this should keep the RSS needs for the ARM build with the `-race` tag down low enough to avoid intermittent failures in the Travis CI builds.

CC @guyuqi 