### PR TITLE
ARROW-17112: [Java] Fix a failure of TestArrowReaderWriter.testFileFooterSizeOverflow on s390x

### DIFF
--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowReaderWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowReaderWriter.java
@@ -897,7 +897,7 @@ public class TestArrowReaderWriter {
     System.arraycopy(magicBytes, 0, data, 0, ArrowMagic.MAGIC_LENGTH);
     int footerLength = Integer.MAX_VALUE;
     byte[] footerLengthBytes =
-            ByteBuffer.allocate(4).order(ByteOrder.nativeOrder()).putInt(footerLength).array();
+            ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt(footerLength).array();
     int footerOffset = data.length - ArrowMagic.MAGIC_LENGTH - 4;
     System.arraycopy(footerLengthBytes, 0, data, footerOffset, 4);
     System.arraycopy(magicBytes, 0, data, footerOffset + 4, ArrowMagic.MAGIC_LENGTH);


### PR DESCRIPTION
`TestArrowReaderWriter.testFileFooterSizeOverflow` in arrow-vectors always causes a failure on s390x. This is because the test code stores footer length in platform native-endian buffer while footer length is stored as little-endian in a footer.

This PR fixes only the test code.
