### PR TITLE
ARROW-17117: [C++] Add timestamp column datatype support for AsOfJoin

### DIFF
--- a/cpp/src/arrow/compute/exec/asof_join_node.cc
+++ b/cpp/src/arrow/compute/exec/asof_join_node.cc
@@ -650,6 +650,7 @@ class AsofJoinNode : public ExecNode {
       for (int i = 0; i < input_schema->num_fields(); ++i) {
         const auto field = input_schema->field(i);
         if (field->name() == on_field_name) {
+          // Equals must be used when checking for timestamp types.
           if (!field->type()->Equals(TimestampType(TimeUnit::NANO, "UTC")) &&
               kSupportedOnTypes_.find(field->type()) == kSupportedOnTypes_.end()) {
             return Status::Invalid("Unsupported type for on key: ",

--- a/cpp/src/arrow/compute/exec/asof_join_node.cc
+++ b/cpp/src/arrow/compute/exec/asof_join_node.cc
@@ -426,6 +426,10 @@ class CompositeReferenceTable {
                 arrays.at(i_dst_col),
                 (MaterializePrimitiveColumn<arrow::DoubleBuilder, double>(
                     memory_pool, i_table, i_src_col)));
+          } else if (field_type->Equals(arrow::timestamp(TimeUnit::NANO, "UTC"))) {
+            ARROW_ASSIGN_OR_RAISE(
+                arrays.at(i_dst_col),
+                (MaterializeTimestampPrimitiveColumn<int64_t>(memory_pool, i_table, i_src_col)));
           } else {
             ARROW_RETURN_NOT_OK(
                 Status::Invalid("Unsupported data type: ", src_field->name()));
@@ -464,6 +468,25 @@ class CompositeReferenceTable {
                                                             size_t i_table,
                                                             col_index_t i_col) {
     Builder builder(memory_pool);
+    ARROW_RETURN_NOT_OK(builder.Reserve(rows_.size()));
+    for (row_index_t i_row = 0; i_row < rows_.size(); ++i_row) {
+      const auto& ref = rows_[i_row].refs[i_table];
+      if (ref.batch) {
+        builder.UnsafeAppend(
+            ref.batch->column_data(i_col)->template GetValues<PrimitiveType>(1)[ref.row]);
+      } else {
+        builder.UnsafeAppendNull();
+      }
+    }
+    std::shared_ptr<Array> result;
+    ARROW_RETURN_NOT_OK(builder.Finish(&result));
+    return result;
+  }
+
+template <class PrimitiveType>
+  Result<std::shared_ptr<Array>> MaterializeTimestampPrimitiveColumn(
+      MemoryPool* memory_pool, size_t i_table, col_index_t i_col) {
+    TimestampBuilder builder = TimestampBuilder(timestamp(TimeUnit::NANO, "UTC"), memory_pool);
     ARROW_RETURN_NOT_OK(builder.Reserve(rows_.size()));
     for (row_index_t i_row = 0; i_row < rows_.size(); ++i_row) {
       const auto& ref = rows_[i_row].refs[i_table];
@@ -630,8 +653,10 @@ class AsofJoinNode : public ExecNode {
       for (int i = 0; i < input_schema->num_fields(); ++i) {
         const auto field = input_schema->field(i);
         if (field->name() == on_field_name) {
-          if (kSupportedOnTypes_.find(field->type()) == kSupportedOnTypes_.end()) {
-            return Status::Invalid("Unsupported type for on key: ", field->name());
+          if (!field->type()->Equals(TimestampType(TimeUnit::NANO, "UTC")) &&
+              kSupportedOnTypes_.find(field->type()) == kSupportedOnTypes_.end()) {
+            return Status::Invalid("Unsupported type for on key: ",
+                                   field->type()->name());
           }
           // Only add on field from the left table
           if (j == 0) {
@@ -639,7 +664,8 @@ class AsofJoinNode : public ExecNode {
           }
         } else if (field->name() == by_field_name) {
           if (kSupportedByTypes_.find(field->type()) == kSupportedByTypes_.end()) {
-            return Status::Invalid("Unsupported type for by key: ", field->name());
+            return Status::Invalid("Unsupported type for by key: ",
+                                   field->type()->name());
           }
           // Only add by field from the left table
           if (j == 0) {
@@ -647,7 +673,7 @@ class AsofJoinNode : public ExecNode {
           }
         } else {
           if (kSupportedDataTypes_.find(field->type()) == kSupportedDataTypes_.end()) {
-            return Status::Invalid("Unsupported data type: ", field->name());
+            return Status::Invalid("Unsupported data type: ", field->type()->name());
           }
 
           fields.push_back(field);

--- a/cpp/src/arrow/compute/exec/asof_join_node_test.cc
+++ b/cpp/src/arrow/compute/exec/asof_join_node_test.cc
@@ -78,13 +78,14 @@ void DoRunBasicTest(const std::vector<util::string_view>& l_data,
                     const std::vector<util::string_view>& r0_data,
                     const std::vector<util::string_view>& r1_data,
                     const std::vector<util::string_view>& exp_data, int64_t tolerance) {
-  for (std::shared_ptr<arrow::DataType> time_data_type : {int64(), timestamp(TimeUnit::NANO, "UTC")}) {
-    auto l_schema =
-        schema({field("time", time_data_type), field("key", int32()), field("l_v0", float64())});
-    auto r0_schema =
-        schema({field("time", time_data_type), field("key", int32()), field("r0_v0", float64())});
-    auto r1_schema =
-        schema({field("time", time_data_type), field("key", int32()), field("r1_v0", float32())});
+  for (std::shared_ptr<arrow::DataType> time_data_type :
+       {int64(), timestamp(TimeUnit::NANO, "UTC")}) {
+    auto l_schema = schema(
+        {field("time", time_data_type), field("key", int32()), field("l_v0", float64())});
+    auto r0_schema = schema({field("time", time_data_type), field("key", int32()),
+                             field("r0_v0", float64())});
+    auto r1_schema = schema({field("time", time_data_type), field("key", int32()),
+                             field("r1_v0", float32())});
 
     auto exp_schema = schema({
         field("time", time_data_type),
@@ -101,8 +102,8 @@ void DoRunBasicTest(const std::vector<util::string_view>& l_data,
     r1_batches = MakeBatchesFromString(r1_schema, r1_data);
     exp_batches = MakeBatchesFromString(exp_schema, exp_data);
     CheckRunOutput(l_batches, r0_batches, r1_batches, exp_batches, "time", "key",
-                  tolerance);
-    }
+                   tolerance);
+  }
 }
 
 void DoRunInvalidTypeTest(const std::shared_ptr<Schema>& l_schema,

--- a/cpp/src/arrow/compute/exec/asof_join_node_test.cc
+++ b/cpp/src/arrow/compute/exec/asof_join_node_test.cc
@@ -78,29 +78,31 @@ void DoRunBasicTest(const std::vector<util::string_view>& l_data,
                     const std::vector<util::string_view>& r0_data,
                     const std::vector<util::string_view>& r1_data,
                     const std::vector<util::string_view>& exp_data, int64_t tolerance) {
-  auto l_schema =
-      schema({field("time", int64()), field("key", int32()), field("l_v0", float64())});
-  auto r0_schema =
-      schema({field("time", int64()), field("key", int32()), field("r0_v0", float64())});
-  auto r1_schema =
-      schema({field("time", int64()), field("key", int32()), field("r1_v0", float32())});
+  for (std::shared_ptr<arrow::DataType> time_data_type : {int64(), timestamp(TimeUnit::NANO, "UTC")}) {
+    auto l_schema =
+        schema({field("time", time_data_type), field("key", int32()), field("l_v0", float64())});
+    auto r0_schema =
+        schema({field("time", time_data_type), field("key", int32()), field("r0_v0", float64())});
+    auto r1_schema =
+        schema({field("time", time_data_type), field("key", int32()), field("r1_v0", float32())});
 
-  auto exp_schema = schema({
-      field("time", int64()),
-      field("key", int32()),
-      field("l_v0", float64()),
-      field("r0_v0", float64()),
-      field("r1_v0", float32()),
-  });
+    auto exp_schema = schema({
+        field("time", time_data_type),
+        field("key", int32()),
+        field("l_v0", float64()),
+        field("r0_v0", float64()),
+        field("r1_v0", float32()),
+    });
 
-  // Test three table join
-  BatchesWithSchema l_batches, r0_batches, r1_batches, exp_batches;
-  l_batches = MakeBatchesFromString(l_schema, l_data);
-  r0_batches = MakeBatchesFromString(r0_schema, r0_data);
-  r1_batches = MakeBatchesFromString(r1_schema, r1_data);
-  exp_batches = MakeBatchesFromString(exp_schema, exp_data);
-  CheckRunOutput(l_batches, r0_batches, r1_batches, exp_batches, "time", "key",
-                 tolerance);
+    // Test three table join
+    BatchesWithSchema l_batches, r0_batches, r1_batches, exp_batches;
+    l_batches = MakeBatchesFromString(l_schema, l_data);
+    r0_batches = MakeBatchesFromString(r0_schema, r0_data);
+    r1_batches = MakeBatchesFromString(r1_schema, r1_data);
+    exp_batches = MakeBatchesFromString(exp_schema, exp_data);
+    CheckRunOutput(l_batches, r0_batches, r1_batches, exp_batches, "time", "key",
+                  tolerance);
+    }
 }
 
 void DoRunInvalidTypeTest(const std::shared_ptr<Schema>& l_schema,


### PR DESCRIPTION
Previously, AsOfJoin only supported `int64` as it's `on` column. Here, we add support for `arrow::timestamp(TimeUnit::NANO, "UTC")`.

If there is a more generalized way of dealing with particular timestamps, please let me know!