### PR TITLE
ARROW-17142: [Python] Parquet FileMetadata.equals() method segfaults when passed None

### DIFF
--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -680,9 +680,10 @@ cdef class FileMetaData(_Weakrefable):
         -------
         are_equal : bool
         """
-        err_msg = lambda: ("Expected `other` to be of type FileMetaData"
-                           " but found " + str(type(other)))
-        assert isinstance(other, FileMetaData), err_msg()
+        if not isinstance(other, FileMetaData):
+            err_msg = ("Expected `other` to be of type FileMetaData"
+                       " but found " + str(type(other)))
+            raise TypeError(err_msg)
         return self._metadata.Equals(deref(other._metadata))
 
     @property

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -680,6 +680,9 @@ cdef class FileMetaData(_Weakrefable):
         -------
         are_equal : bool
         """
+        err_msg = lambda: ("Expected `other` to be of type FileMetaData"
+                           " but found " + str(type(other)))
+        assert isinstance(other, FileMetaData), err_msg()
         return self._metadata.Equals(deref(other._metadata))
 
     @property

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -667,7 +667,7 @@ cdef class FileMetaData(_Weakrefable):
         except TypeError:
             return NotImplemented
 
-    def equals(self, FileMetaData other):
+    def equals(self, FileMetaData other not None):
         """
         Return whether the two file metadata objects are equal.
 
@@ -680,10 +680,6 @@ cdef class FileMetaData(_Weakrefable):
         -------
         are_equal : bool
         """
-        if not isinstance(other, FileMetaData):
-            err_msg = ("Expected `other` to be of type FileMetaData"
-                       " but found " + str(type(other)))
-            raise TypeError(err_msg)
         return self._metadata.Equals(deref(other._metadata))
 
     @property

--- a/python/pyarrow/tests/parquet/test_metadata.py
+++ b/python/pyarrow/tests/parquet/test_metadata.py
@@ -539,5 +539,6 @@ def test_metadata_equals():
         buf = out.getvalue()
 
     original_metadata = pq.read_metadata(pa.BufferReader(buf))
-    with pytest.raises(TypeError, match="Expected `other` to be of type FileMetaData"):
+    match="Argument 'other' has incorrect type"
+    with pytest.raises(TypeError, match=match):
         original_metadata.equals(None)

--- a/python/pyarrow/tests/parquet/test_metadata.py
+++ b/python/pyarrow/tests/parquet/test_metadata.py
@@ -532,6 +532,7 @@ def test_metadata_exceeds_message_size():
 
     metadata = pq.read_metadata(pa.BufferReader(buf))
 
+
 def test_metadata_equals():
     table = pa.table({"a": [1, 2, 3]})
     with pa.BufferOutputStream() as out:
@@ -539,6 +540,6 @@ def test_metadata_equals():
         buf = out.getvalue()
 
     original_metadata = pq.read_metadata(pa.BufferReader(buf))
-    match="Argument 'other' has incorrect type"
+    match = "Argument 'other' has incorrect type"
     with pytest.raises(TypeError, match=match):
         original_metadata.equals(None)

--- a/python/pyarrow/tests/parquet/test_metadata.py
+++ b/python/pyarrow/tests/parquet/test_metadata.py
@@ -539,5 +539,5 @@ def test_metadata_equals():
         buf = out.getvalue()
 
     original_metadata = pq.read_metadata(pa.BufferReader(buf))
-    with pytest.raises(AssertionError, match="Expected `other` to be of type FileMetaData"):
+    with pytest.raises(TypeError, match="Expected `other` to be of type FileMetaData"):
         original_metadata.equals(None)

--- a/python/pyarrow/tests/parquet/test_metadata.py
+++ b/python/pyarrow/tests/parquet/test_metadata.py
@@ -531,3 +531,13 @@ def test_metadata_exceeds_message_size():
         buf = out.getvalue()
 
     metadata = pq.read_metadata(pa.BufferReader(buf))
+
+def test_metadata_equals():
+    table = pa.table({"a": [1, 2, 3]})
+    with pa.BufferOutputStream() as out:
+        pq.write_table(table, out)
+        buf = out.getvalue()
+
+    original_metadata = pq.read_metadata(pa.BufferReader(buf))
+    with pytest.raises(AssertionError, match="Expected `other` to be of type FileMetaData"):
+        original_metadata.equals(None)


### PR DESCRIPTION
Fixes : https://issues.apache.org/jira/browse/ARROW-17142