### PR TITLE
ARROW-14635: [Python][C++] implement fadvise

### DIFF
--- a/cpp/src/arrow/filesystem/localfs.cc
+++ b/cpp/src/arrow/filesystem/localfs.cc
@@ -439,8 +439,8 @@ Result<std::shared_ptr<io::OutputStream>> OpenOutputStreamGeneric(const std::str
   RETURN_NOT_OK(ValidatePath(path));
   ARROW_ASSIGN_OR_RAISE(auto fn, PlatformFilename::FromString(path));
   const bool write_only = true;
-  ARROW_ASSIGN_OR_RAISE(
-      auto fd, ::arrow::internal::FileOpenWritable(fn, write_only, truncate, append));
+  ARROW_ASSIGN_OR_RAISE(auto fd, ::arrow::internal::FileOpenWritable(
+                                     fn, write_only, truncate, append, !reuse));
   int raw_fd = fd.Detach();
   auto maybe_stream = io::FileOutputStream::Open(raw_fd, reuse);
   if (!maybe_stream.ok()) {

--- a/cpp/src/arrow/filesystem/localfs.cc
+++ b/cpp/src/arrow/filesystem/localfs.cc
@@ -439,6 +439,8 @@ Result<std::shared_ptr<io::OutputStream>> OpenOutputStreamGeneric(const std::str
   RETURN_NOT_OK(ValidatePath(path));
   ARROW_ASSIGN_OR_RAISE(auto fn, PlatformFilename::FromString(path));
   const bool write_only = true;
+  // When reuse is false we need to open the file in sync mmode because fadvise
+  // will not drop the data from the cache unless it has finished writing.
   ARROW_ASSIGN_OR_RAISE(auto fd, ::arrow::internal::FileOpenWritable(
                                      fn, write_only, truncate, append, !reuse));
   int raw_fd = fd.Detach();

--- a/cpp/src/arrow/filesystem/localfs.h
+++ b/cpp/src/arrow/filesystem/localfs.h
@@ -38,7 +38,7 @@ struct ARROW_EXPORT LocalFileSystemOptions {
   /// or a regular one.
   bool use_mmap = false;
   /// If false, will try to circumvent page cache by using posix_fadvise
-  /// This only works on linux right now. There will be a performance 
+  /// This only works on linux right now. There will be a performance
   /// degradation for small writes. The degradation is more severe the smaller
   /// the write is.
   bool reuse = true;

--- a/cpp/src/arrow/filesystem/localfs.h
+++ b/cpp/src/arrow/filesystem/localfs.h
@@ -38,7 +38,9 @@ struct ARROW_EXPORT LocalFileSystemOptions {
   /// or a regular one.
   bool use_mmap = false;
   /// If false, will try to circumvent page cache by using posix_fadvise
-  /// This only works on linux right now.
+  /// This only works on linux right now. There will be a performance 
+  /// degradation for small writes. The degradation is more severe the smaller
+  /// the write is.
   bool reuse = true;
   /// \brief Initialize with defaults
   static LocalFileSystemOptions Defaults();

--- a/cpp/src/arrow/filesystem/localfs.h
+++ b/cpp/src/arrow/filesystem/localfs.h
@@ -37,6 +37,8 @@ struct ARROW_EXPORT LocalFileSystemOptions {
   /// Whether OpenInputStream and OpenInputFile return a mmap'ed file,
   /// or a regular one.
   bool use_mmap = false;
+  /// If false, will try to circumvent page cache by using posix_fadvise
+  /// This only works on linux right now.
   bool reuse = true;
   /// \brief Initialize with defaults
   static LocalFileSystemOptions Defaults();

--- a/cpp/src/arrow/filesystem/localfs.h
+++ b/cpp/src/arrow/filesystem/localfs.h
@@ -37,7 +37,7 @@ struct ARROW_EXPORT LocalFileSystemOptions {
   /// Whether OpenInputStream and OpenInputFile return a mmap'ed file,
   /// or a regular one.
   bool use_mmap = false;
-
+  bool reuse = true;
   /// \brief Initialize with defaults
   static LocalFileSystemOptions Defaults();
 

--- a/cpp/src/arrow/filesystem/localfs_test.cc
+++ b/cpp/src/arrow/filesystem/localfs_test.cc
@@ -152,7 +152,17 @@ class TestLocalFSGenericMMap : public TestLocalFSGeneric<CommonPathFormatter> {
   }
 };
 
+class TestLocalFSGenericReuse : public TestLocalFSGeneric<CommonPathFormatter> {
+ protected:
+  LocalFileSystemOptions options() override {
+    auto options = LocalFileSystemOptions::Defaults();
+    options.reuse = false;
+    return options;
+  }
+};
+
 GENERIC_FS_TEST_FUNCTIONS(TestLocalFSGenericMMap);
+GENERIC_FS_TEST_FUNCTIONS(TestLocalFSGenericReuse);
 
 ////////////////////////////////////////////////////////////////////////////
 // Concrete LocalFileSystem tests

--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -28,7 +28,6 @@
 #else
 #include <fcntl.h>
 #include <sys/mman.h>
-#include <unistd.h>
 #include <unistd.h>  // IWYU pragma: keep
 #endif
 

--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -28,6 +28,7 @@
 #else
 #include <fcntl.h>
 #include <sys/mman.h>
+#include <unistd.h>
 #include <unistd.h>  // IWYU pragma: keep
 #endif
 
@@ -168,17 +169,16 @@ class OSFile {
     if (length < 0) {
       return Status::IOError("Length must be non-negative");
     }
-    if(reuse_){
-        return ::arrow::internal::FileWrite(fd_.fd(), reinterpret_cast<const uint8_t*>(data),
-                                        length);
+    if (reuse_) {
+      return ::arrow::internal::FileWrite(fd_.fd(),
+                                          reinterpret_cast<const uint8_t*>(data), length);
     } else {
-        auto status = ::arrow::internal::FileWrite(fd_.fd(), reinterpret_cast<const uint8_t*>(data),
-                                        length);
-        posix_fadvise(fd_.fd(), written, length, POSIX_FADV_DONTNEED);
-        written += length;
-        return status;
+      auto status = ::arrow::internal::FileWrite(
+          fd_.fd(), reinterpret_cast<const uint8_t*>(data), length);
+      posix_fadvise(fd_.fd(), written, length, POSIX_FADV_DONTNEED);
+      written += length;
+      return status;
     }
-    
   }
 
   int fd() const { return fd_.fd(); }

--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -170,7 +170,7 @@ class OSFile {
       return Status::IOError("Length must be non-negative");
     }
     auto status = ::arrow::internal::FileWrite(
-          fd_.fd(), reinterpret_cast<const uint8_t*>(data), length);
+        fd_.fd(), reinterpret_cast<const uint8_t*>(data), length);
 #ifdef __linux__
     if (reuse_) {
       return status;

--- a/cpp/src/arrow/io/file.h
+++ b/cpp/src/arrow/io/file.h
@@ -54,6 +54,7 @@ class ARROW_EXPORT FileOutputStream : public OutputStream {
   /// \brief Open a file descriptor for writing.  The underlying file isn't
   /// truncated.
   /// \param[in] fd file descriptor
+  /// \param[in] reuse should we use the page cache for the write
   /// \return an open FileOutputStream
   ///
   /// The file descriptor becomes owned by the OutputStream, and will be closed

--- a/cpp/src/arrow/io/file.h
+++ b/cpp/src/arrow/io/file.h
@@ -58,7 +58,7 @@ class ARROW_EXPORT FileOutputStream : public OutputStream {
   ///
   /// The file descriptor becomes owned by the OutputStream, and will be closed
   /// on Close() or destruction.
-  static Result<std::shared_ptr<FileOutputStream>> Open(int fd);
+  static Result<std::shared_ptr<FileOutputStream>> Open(int fd, bool reuse = true);
 
   // OutputStream interface
   Status Close() override;

--- a/cpp/src/arrow/io/file.h
+++ b/cpp/src/arrow/io/file.h
@@ -54,7 +54,9 @@ class ARROW_EXPORT FileOutputStream : public OutputStream {
   /// \brief Open a file descriptor for writing.  The underlying file isn't
   /// truncated.
   /// \param[in] fd file descriptor
-  /// \param[in] reuse should we use the page cache for the write
+  /// \param[in] reuse if false the written data will not be kept in the OS page cache.
+  /// This will have some negative impact on write throughput but can be used during large
+  /// writes to avoid evicting more important data from the page cache.
   /// \return an open FileOutputStream
   ///
   /// The file descriptor becomes owned by the OutputStream, and will be closed

--- a/cpp/src/arrow/util/io_util.cc
+++ b/cpp/src/arrow/util/io_util.cc
@@ -1117,7 +1117,7 @@ Result<FileDescriptor> FileOpenWritable(const PlatformFilename& file_name,
 #else
   int oflag = O_CREAT;
   if (sync) {
-    oflag |= O_SYNC;
+    oflag |= O_DSYNC;
   }
   if (truncate) {
     oflag |= O_TRUNC;

--- a/cpp/src/arrow/util/io_util.cc
+++ b/cpp/src/arrow/util/io_util.cc
@@ -1072,7 +1072,8 @@ Result<FileDescriptor> FileOpenReadable(const PlatformFilename& file_name) {
 }
 
 Result<FileDescriptor> FileOpenWritable(const PlatformFilename& file_name,
-                                        bool write_only, bool truncate, bool append) {
+                                        bool write_only, bool truncate, bool append,
+                                        bool sync) {
   FileDescriptor fd;
 
 #if defined(_WIN32)
@@ -1115,7 +1116,9 @@ Result<FileDescriptor> FileOpenWritable(const PlatformFilename& file_name,
   fd = FileDescriptor(ret);
 #else
   int oflag = O_CREAT;
-
+  if (sync) {
+    oflag |= O_SYNC;
+  }
   if (truncate) {
     oflag |= O_TRUNC;
   }

--- a/cpp/src/arrow/util/io_util.h
+++ b/cpp/src/arrow/util/io_util.h
@@ -164,7 +164,7 @@ Result<FileDescriptor> FileOpenReadable(const PlatformFilename& file_name);
 ARROW_EXPORT
 Result<FileDescriptor> FileOpenWritable(const PlatformFilename& file_name,
                                         bool write_only = true, bool truncate = true,
-                                        bool append = false);
+                                        bool append = false, bool sync = false);
 
 /// Read from current file position.  Return number of bytes read.
 ARROW_EXPORT

--- a/python/pyarrow/_fs.pyx
+++ b/python/pyarrow/_fs.pyx
@@ -783,8 +783,10 @@ cdef class LocalFileSystem(FileSystem):
         Whether open_input_stream and open_input_file should return
         a mmap'ed file or a regular file.
     reuse : bool, default True
-        If set to False, will use posix_fadvise to (try) not use the page cache.
-        This will only work on Linux!!
+        If false, will try to circumvent page cache by using posix_fadvise
+        This only works on linux right now. There will be a performance 
+        degradation for small writes. The degradation is more severe the smaller
+        the write is.
 
     Examples
     --------

--- a/python/pyarrow/_fs.pyx
+++ b/python/pyarrow/_fs.pyx
@@ -784,6 +784,7 @@ cdef class LocalFileSystem(FileSystem):
         a mmap'ed file or a regular file.
     reuse : bool, default True
         If set to False, will use posix_fadvise to (try) not use the page cache.
+        This will only work on Linux!!
 
     Examples
     --------

--- a/python/pyarrow/_fs.pyx
+++ b/python/pyarrow/_fs.pyx
@@ -782,6 +782,8 @@ cdef class LocalFileSystem(FileSystem):
     use_mmap : bool, default False
         Whether open_input_stream and open_input_file should return
         a mmap'ed file or a regular file.
+    reuse : bool, default True
+        If set to False, will use posix_fadvise to (try) not use the page cache.
 
     Examples
     --------
@@ -884,13 +886,14 @@ cdef class LocalFileSystem(FileSystem):
     <FileInfo for '/tmp/local_fs-copy.dat': type=FileType.NotFound>
     """
 
-    def __init__(self, *, use_mmap=False):
+    def __init__(self, *, use_mmap=False, reuse=True):
         cdef:
             CLocalFileSystemOptions opts
             shared_ptr[CLocalFileSystem] fs
 
         opts = CLocalFileSystemOptions.Defaults()
         opts.use_mmap = use_mmap
+        opts.reuse = reuse
 
         fs = make_shared[CLocalFileSystem](opts)
         self.init(<shared_ptr[CFileSystem]> fs)
@@ -908,7 +911,7 @@ cdef class LocalFileSystem(FileSystem):
     def __reduce__(self):
         cdef CLocalFileSystemOptions opts = self.localfs.options()
         return LocalFileSystem._reconstruct, (dict(
-            use_mmap=opts.use_mmap),)
+            use_mmap=opts.use_mmap, reuse=opts.reuse),)
 
 
 cdef class SubTreeFileSystem(FileSystem):

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -100,6 +100,7 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
 
     cdef cppclass CLocalFileSystemOptions "arrow::fs::LocalFileSystemOptions":
         c_bool use_mmap
+        c_bool reuse
 
         @staticmethod
         CLocalFileSystemOptions Defaults()

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -191,6 +191,16 @@ def localfs_with_mmap(request, tempdir):
 
 
 @pytest.fixture
+def localfs_with_fadvise(request, tempdir):
+    return dict(
+        fs=LocalFileSystem(reuse=False),
+        pathfn=lambda p: (tempdir / p).as_posix(),
+        allow_move_dir=True,
+        allow_append_to_file=True,
+    )
+
+
+@pytest.fixture
 def subtree_localfs(request, tempdir, localfs):
     return dict(
         fs=SubTreeFileSystem(str(tempdir), localfs['fs']),
@@ -365,6 +375,10 @@ def py_fsspec_s3fs(request, s3_server):
     pytest.param(
         pytest.lazy_fixture('localfs_with_mmap'),
         id='LocalFileSystem(use_mmap=True)'
+    ),
+    pytest.param(
+        pytest.lazy_fixture('localfs_with_fadvise'),
+        id='LocalFileSystem(reuse=False)'
     ),
     pytest.param(
         pytest.lazy_fixture('subtree_localfs'),
@@ -1005,7 +1019,7 @@ def test_open_output_stream_metadata(fs, pathfn):
 
 def test_localfs_options():
     # LocalFileSystem instantiation
-    LocalFileSystem(use_mmap=False)
+    LocalFileSystem(use_mmap=False, reuse=True)
 
     with pytest.raises(TypeError):
         LocalFileSystem(xxx=False)


### PR DESCRIPTION
After: https://github.com/apache/arrow/pull/13640, seems like O_DIRECT is not a good idea, so let's use posix_fadvise to control the page cache to address the issue mentioned in: https://issues.apache.org/jira/browse/ARROW-14635.

To test it, use the simple python script below: 
```
SIZE = 1024 * 1024
N = 1024 * 10

import pyarrow.fs as fs
#da  = fs.LocalFileSystem(reuse=False) #this will turn on fadvise and disable page cache for the writes
da  = fs.LocalFileSystem(reuse=True)
s = da.open_output_stream("bump")
a = bytes("1","utf-8") * SIZE
for i in range(N):
    s.write(a)
s.close()
```