### PR TITLE
ARROW-17151: [Docs] Pin docs theme to delay dark mode update

### DIFF
--- a/ci/conda_env_sphinx.txt
+++ b/ci/conda_env_sphinx.txt
@@ -20,7 +20,7 @@ breathe
 doxygen
 ipython
 numpydoc
-pydata-sphinx-theme
+pydata-sphinx-theme==0.8
 sphinx-design
 sphinx>=4.2
 sphinx-copybutton

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@
 breathe
 ipython
 numpydoc
-pydata-sphinx-theme
+pydata-sphinx-theme==0.8
 sphinx-design
 sphinx-copybutton
 sphinx>=4.2

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -503,6 +503,27 @@ except ImportError:
     flight_enabled = False
     pyarrow.flight = sys.modules['pyarrow.flight'] = mock.Mock()
 
+try:
+    import pyarrow.orc
+    orc_enabled = True
+except ImportError:
+    orc_enabled = False
+    pyarrow.orc = sys.modules['pyarrow.orc'] = mock.Mock()
+
+try:
+    import pyarrow.parquet.encryption
+    parquet_encryption_enabled = True
+except ImportError:
+    parquet_encryption_enabled = False
+    pyarrow.parquet.encryption = sys.modules['pyarrow.parquet.encryption'] = mock.Mock()
+
+try:
+    import pyarrow.plasma
+    plasma_enabled = True
+except ImportError:
+    plasma_enabled = False
+    pyarrow.plasma = sys.modules['pyarrow.plasma'] = mock.Mock()
+
 
 def setup(app):
     # Use a config value to indicate whether CUDA API docs can be generated.


### PR DESCRIPTION
The new 0.9 release added changes to enable dark mode and an updated light mode. We likely don't have time to make the necessary adaptions to the style changes, so for now I propose pinning the theme version. ARROW-17152 will follow up and fix any style issues needed to enable the new theme.

I've also included changes to allow building the documentation site without requiring ORC, Parquet Encryption, and Plasma. These are quick fixes and I expect a more robust solution to be implemented in ARROW-17076.