### PR TITLE
ARROW-17163: [C++] Revert installation of jni_util.h

### DIFF
--- a/java/dataset/src/main/cpp/CMakeLists.txt
+++ b/java/dataset/src/main/cpp/CMakeLists.txt
@@ -63,5 +63,3 @@ add_arrow_test(dataset_jni_test
                jni_util.cc
                EXTRA_INCLUDES
                ${JNI_INCLUDE_DIRS})
-
-install(FILES jni_util.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/jni/dataset")


### PR DESCRIPTION
PR #13614 installed jni_util.h to match earlier behavior, but
the downstream Gluten project is no longer depending on it and
we never intended to expose this header, so don't install it.