### PR TITLE
ARROW-17107: [Java] Fix variable-width vectors in integration JSON writer

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileReader.java
@@ -784,8 +784,10 @@ public class JsonFileReader implements AutoCloseable, DictionaryProvider {
   @Override
   public void close() throws IOException {
     parser.close();
-    for (Dictionary dictionary : dictionaries.values()) {
-      dictionary.getVector().close();
+    if (dictionaries != null) {
+      for (Dictionary dictionary : dictionaries.values()) {
+        dictionary.getVector().close();
+      }
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileWriter.java
@@ -30,6 +30,7 @@ import java.util.Set;
 
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.util.Preconditions;
+import org.apache.arrow.vector.BaseLargeVariableWidthVector;
 import org.apache.arrow.vector.BaseVariableWidthVector;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVectorHelper;
@@ -83,8 +84,10 @@ import com.fasterxml.jackson.core.util.DefaultPrettyPrinter.NopIndenter;
 import com.fasterxml.jackson.databind.MappingJsonFactory;
 
 /**
- * A writer that converts binary Vectors into a JSON format suitable
+ * A writer that converts binary Vectors into an <em>internal, unstable</em> JSON format suitable
  * for integration testing.
+ *
+ * This writer does NOT implement a JSON dataset format like JSONL.
  */
 public class JsonFileWriter implements AutoCloseable {
 
@@ -228,11 +231,21 @@ public class JsonFileWriter implements AutoCloseable {
                   vector.getMinorType() == MinorType.VARBINARY)) {
             writeValueToGenerator(bufferType, vectorBuffer, vectorBuffers.get(v - 1), vector, i);
           } else if (bufferType.equals(OFFSET) && vector.getValueCount() == 0 &&
-              (vector.getMinorType() == MinorType.VARBINARY || vector.getMinorType() == MinorType.VARCHAR)) {
-            ArrowBuf vectorBufferTmp = vector.getAllocator().buffer(4);
-            vectorBufferTmp.setInt(0, 0);
-            writeValueToGenerator(bufferType, vectorBufferTmp, null, vector, i);
-            vectorBufferTmp.close();
+              (vector.getMinorType() == MinorType.LIST || vector.getMinorType() == MinorType.MAP ||
+                  vector.getMinorType() == MinorType.VARBINARY || vector.getMinorType() == MinorType.VARCHAR)) {
+            // Empty vectors may not have allocated an offsets buffer
+            try (ArrowBuf vectorBufferTmp = vector.getAllocator().buffer(4)) {
+              vectorBufferTmp.setInt(0, 0);
+              writeValueToGenerator(bufferType, vectorBufferTmp, null, vector, i);
+            }
+          } else if (bufferType.equals(OFFSET) && vector.getValueCount() == 0 &&
+              (vector.getMinorType() == MinorType.LARGELIST || vector.getMinorType() == MinorType.LARGEVARBINARY ||
+                vector.getMinorType() == MinorType.LARGEVARCHAR)) {
+            // Empty vectors may not have allocated an offsets buffer
+            try (ArrowBuf vectorBufferTmp = vector.getAllocator().buffer(8)) {
+              vectorBufferTmp.setLong(0, 0);
+              writeValueToGenerator(bufferType, vectorBufferTmp, null, vector, i);
+            }
           } else {
             writeValueToGenerator(bufferType, vectorBuffer, null, vector, i);
           }
@@ -267,7 +280,21 @@ public class JsonFileWriter implements AutoCloseable {
     if (bufferType.equals(TYPE)) {
       generator.writeNumber(buffer.getByte(index * TinyIntVector.TYPE_WIDTH));
     } else if (bufferType.equals(OFFSET)) {
-      generator.writeNumber(buffer.getInt(index * BaseVariableWidthVector.OFFSET_WIDTH));
+      switch (vector.getMinorType()) {
+        case VARCHAR:
+        case VARBINARY:
+        case LIST:
+        case MAP:
+          generator.writeNumber(buffer.getInt((long) index * BaseVariableWidthVector.OFFSET_WIDTH));
+          break;
+        case LARGELIST:
+        case LARGEVARBINARY:
+        case LARGEVARCHAR:
+          generator.writeNumber(buffer.getLong((long) index * BaseLargeVariableWidthVector.OFFSET_WIDTH));
+          break;
+        default:
+          throw new IllegalArgumentException("Type has no offset buffer: " + vector.getField());
+      }
     } else if (bufferType.equals(VALIDITY)) {
       generator.writeNumber(vector.isNull(index) ? 0 : 1);
     } else if (bufferType.equals(DATA)) {

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -190,6 +190,41 @@ public class TestValueVector {
     }
   }
 
+  @Test
+  public void testNoOverFlowWithUINT() {
+    try (final UInt8Vector uInt8Vector = new UInt8Vector("uint8", allocator);
+         final UInt4Vector uInt4Vector = new UInt4Vector("uint4", allocator);
+         final UInt1Vector uInt1Vector = new UInt1Vector("uint1", allocator)) {
+
+      long[] longValues = new long[]{Long.MIN_VALUE, Long.MAX_VALUE, -1L};
+      uInt8Vector.allocateNew(3);
+      uInt8Vector.setValueCount(3);
+      for (int i = 0; i < longValues.length; i++) {
+        uInt8Vector.set(i, longValues[i]);
+        long readValue = uInt8Vector.getObjectNoOverflow(i).longValue();
+        assertEquals(readValue, longValues[i]);
+      }
+
+      int[] intValues = new int[]{Integer.MIN_VALUE, Integer.MAX_VALUE, -1};
+      uInt4Vector.allocateNew(3);
+      uInt4Vector.setValueCount(3);
+      for (int i = 0; i < intValues.length; i++) {
+        uInt4Vector.set(i, intValues[i]);
+        int actualValue = (int) UInt4Vector.getNoOverflow(uInt4Vector.getDataBuffer(), i);
+        assertEquals(intValues[i], actualValue);
+      }
+
+      byte[] byteValues = new byte[]{Byte.MIN_VALUE, Byte.MAX_VALUE, -1};
+      uInt1Vector.allocateNew(3);
+      uInt1Vector.setValueCount(3);
+      for (int i = 0; i < byteValues.length; i++) {
+        uInt1Vector.set(i, byteValues[i]);
+        byte actualValue = (byte) UInt1Vector.getNoOverflow(uInt1Vector.getDataBuffer(), i);
+        assertEquals(byteValues[i], actualValue);
+      }
+    }
+  }
+
   @Test /* IntVector */
   public void testFixedType2() {
     try (final IntVector intVector = new IntVector(EMPTY_SCHEMA_PATH, allocator)) {


### PR DESCRIPTION
- Clarify that this is meant to be an internal format
- Fix handling of empty variable-width vectors