### PR TITLE
ARROW-17113: [Java] Fail loudly in static initializer blocks

### DIFF
--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/AddWritableBuffer.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/AddWritableBuffer.java
@@ -72,7 +72,7 @@ public class AddWritableBuffer {
       tmpBufChainOut = tmpBufChainOut2;
 
     } catch (Exception ex) {
-      ex.printStackTrace();
+      new RuntimeException("Failed to initialize AddWritableBuffer, falling back to slow path", ex).printStackTrace();
     }
 
     bufConstruct = tmpConstruct;

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/GetReadableBuffer.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/GetReadableBuffer.java
@@ -51,7 +51,7 @@ public class GetReadableBuffer {
       tmpField = f;
       tmpClazz = clazz;
     } catch (Exception e) {
-      e.printStackTrace();
+      new RuntimeException("Failed to initialize GetReadableBuffer, falling back to slow path", e).printStackTrace();
     }
     READABLE_BUFFER = tmpField;
     BUFFER_INPUT_STREAM = tmpClazz;

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/MemoryUtil.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/MemoryUtil.java
@@ -133,7 +133,11 @@ public class MemoryUtil {
       }
       DIRECT_BUFFER_CONSTRUCTOR = directBufferConstructor;
     } catch (Throwable e) {
-      throw new RuntimeException("Failed to initialize MemoryUtil.", e);
+      // This exception will get swallowed, but it's necessary for the static analysis that ensures
+      // the static fields above get initialized
+      final RuntimeException failure = new RuntimeException("Failed to initialize MemoryUtil", e);
+      failure.printStackTrace();
+      throw failure;
     }
   }
 

--- a/java/memory/memory-netty/src/main/java/io/netty/buffer/UnsafeDirectLittleEndian.java
+++ b/java/memory/memory-netty/src/main/java/io/netty/buffer/UnsafeDirectLittleEndian.java
@@ -31,16 +31,7 @@ import io.netty.util.internal.PlatformDependent;
  * Netty classes and underlying Netty memory management.
  */
 public class UnsafeDirectLittleEndian extends WrappedByteBuf {
-
-  public static final boolean ASSERT_ENABLED;
   private static final AtomicLong ID_GENERATOR = new AtomicLong(0);
-
-  static {
-    boolean isAssertEnabled = false;
-    assert isAssertEnabled = true;
-    ASSERT_ENABLED = isAssertEnabled;
-  }
-
   public final long id = ID_GENERATOR.incrementAndGet();
   private final AbstractByteBuf wrapped;
   private final long memoryAddress;


### PR DESCRIPTION
- MemoryUtil will print a stack trace to the console on failure (since Arrow won't really work without it)
- Flight utility classes will print a stack trace but won't prevent class initialization (it will just fall back to the "slow" path)