### PR TITLE
ARROW-17115: [C++] HashJoin fails if it encounters a batch with more than 32Ki rows

### DIFF
--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -348,6 +348,8 @@ util::optional<int> GetNodeIndex(const std::vector<ExecNode*>& nodes,
 
 }  // namespace
 
+const uint32_t ExecPlan::kMaxBatchSize;
+
 Result<std::shared_ptr<ExecPlan>> ExecPlan::Make(
     ExecContext* ctx, std::shared_ptr<const KeyValueMetadata> metadata) {
   return std::shared_ptr<ExecPlan>(new ExecPlanImpl{ctx, metadata});

--- a/cpp/src/arrow/compute/exec/exec_plan.h
+++ b/cpp/src/arrow/compute/exec/exec_plan.h
@@ -40,6 +40,8 @@ namespace compute {
 
 class ARROW_EXPORT ExecPlan : public std::enable_shared_from_this<ExecPlan> {
  public:
+  // This allows operators to rely on signed 16-bit indices
+  static const uint32_t kMaxBatchSize = 1 << 15;
   using NodeVector = std::vector<ExecNode*>;
 
   virtual ~ExecPlan() = default;

--- a/cpp/src/arrow/compute/exec/exec_plan.h
+++ b/cpp/src/arrow/compute/exec/exec_plan.h
@@ -146,10 +146,24 @@ class ARROW_EXPORT ExecPlan : public std::enable_shared_from_this<ExecPlan> {
   /// \brief Return the plan's attached metadata
   std::shared_ptr<const KeyValueMetadata> metadata() const;
 
+  /// \brief Should the plan use a legacy batching strategy
+  ///
+  /// This is currently in place only to support the Scanner::ToTable
+  /// method.  This method relies on batch indices from the scanner
+  /// remaining consistent.  This is impractical in the ExecPlan which
+  /// might slice batches as needed (e.g. for a join)
+  ///
+  /// However, it still works for simple plans and this is the only way
+  /// we have at the moment for maintaining implicit order.
+  bool UseLegacyBatching() const { return use_legacy_batching_; }
+  // For internal use only, see above comment
+  void SetUseLegacyBatching(bool value) { use_legacy_batching_ = value; }
+
   std::string ToString() const;
 
  protected:
   ExecContext* exec_context_;
+  bool use_legacy_batching_ = false;
   explicit ExecPlan(ExecContext* exec_context) : exec_context_(exec_context) {}
 };
 

--- a/cpp/src/arrow/compute/exec/hash_join_node.cc
+++ b/cpp/src/arrow/compute/exec/hash_join_node.cc
@@ -947,6 +947,11 @@ class HashJoinNode : public ExecNode {
 
   Status Init() override {
     RETURN_NOT_OK(ExecNode::Init());
+    if (plan_->UseLegacyBatching()) {
+      return Status::Invalid(
+          "The plan was configured to use legacy batching but contained a join node "
+          "which is incompatible with legacy batching");
+    }
     bool use_sync_execution = !(plan_->exec_context()->executor());
     // TODO(ARROW-15732)
     // Each side of join might have an IO thread being called from. Once this is fixed

--- a/cpp/src/arrow/compute/exec/source_node.cc
+++ b/cpp/src/arrow/compute/exec/source_node.cc
@@ -106,23 +106,39 @@ struct SourceNode : ExecNode {
     }
     auto fut = Loop([this, options] {
                  std::unique_lock<std::mutex> lock(mutex_);
-                 int total_batches = batch_count_++;
                  if (stop_requested_) {
-                   return Future<ControlFlow<int>>::MakeFinished(Break(total_batches));
+                   return Future<ControlFlow<int>>::MakeFinished(Break(batch_count_));
                  }
                  lock.unlock();
 
                  return generator_().Then(
-                     [=](const util::optional<ExecBatch>& maybe_batch)
+                     [=](const util::optional<ExecBatch>& maybe_morsel)
                          -> Future<ControlFlow<int>> {
                        std::unique_lock<std::mutex> lock(mutex_);
-                       if (IsIterationEnd(maybe_batch) || stop_requested_) {
-                         return Break(total_batches);
+                       if (IsIterationEnd(maybe_morsel) || stop_requested_) {
+                         return Break(batch_count_);
                        }
                        lock.unlock();
-                       ExecBatch batch = std::move(*maybe_batch);
+                       ExecBatch morsel = std::move(*maybe_morsel);
+                       int64_t morsel_length = static_cast<int64_t>(morsel.length);
+                       if (morsel_length == 0) {
+                         // For various reasons (e.g. ARROW-13982) we pass empty batches
+                         // through
+                         batch_count_++;
+                       } else {
+                         int num_batches = static_cast<int>(
+                             bit_util::CeilDiv(morsel_length, ExecPlan::kMaxBatchSize));
+                         batch_count_ += num_batches;
+                       }
                        RETURN_NOT_OK(plan_->ScheduleTask([=]() {
-                         outputs_[0]->InputReceived(this, std::move(batch));
+                         int64_t offset = 0;
+                         do {
+                           int64_t batch_size = std::min<int64_t>(
+                               morsel_length - offset, ExecPlan::kMaxBatchSize);
+                           ExecBatch batch = morsel.Slice(offset, batch_size);
+                           offset += batch_size;
+                           outputs_[0]->InputReceived(this, std::move(batch));
+                         } while (offset < morsel.length);
                          return Status::OK();
                        }));
                        lock.lock();
@@ -135,7 +151,7 @@ struct SourceNode : ExecNode {
                      },
                      [=](const Status& error) -> ControlFlow<int> {
                        outputs_[0]->ErrorReceived(this, error);
-                       return Break(total_batches);
+                       return Break(batch_count_);
                      },
                      options);
                })

--- a/cpp/src/arrow/compute/exec/union_node_test.cc
+++ b/cpp/src/arrow/compute/exec/union_node_test.cc
@@ -138,9 +138,6 @@ TEST_F(TestUnionNode, TestNonEmpty) {
     }
   }
 }
-TEST_F(TestUnionNode, TestWithAnEmptyBatch) {
-  this->CheckUnionExecNode(/*num_input_nodes*/ 2, /*num_batches=*/0, /*parallel=*/false);
-}
 
 TEST_F(TestUnionNode, TestEmpty) {
   this->CheckUnionExecNode(/*num_input_nodes*/ 0, /*num_batches=*/0, /*parallel=*/false);

--- a/cpp/src/arrow/compute/exec/union_node_test.cc
+++ b/cpp/src/arrow/compute/exec/union_node_test.cc
@@ -138,6 +138,9 @@ TEST_F(TestUnionNode, TestNonEmpty) {
     }
   }
 }
+TEST_F(TestUnionNode, TestWithAnEmptyBatch) {
+  this->CheckUnionExecNode(/*num_input_nodes*/ 2, /*num_batches=*/0, /*parallel=*/false);
+}
 
 TEST_F(TestUnionNode, TestEmpty) {
   this->CheckUnionExecNode(/*num_input_nodes*/ 0, /*num_batches=*/0, /*parallel=*/false);

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -1816,7 +1816,7 @@ def test_positional_keywords_raises(tempdir):
 @pytest.mark.parquet
 @pytest.mark.pandas
 def test_read_partition_keys_only(tempdir):
-    BATCH_SIZE = 2 ** 17
+    BATCH_SIZE = 2 ** 15
     # This is a regression test for ARROW-15318 which saw issues
     # reading only the partition keys from files with batches larger
     # than the default batch size (e.g. so we need to return two chunks)


### PR DESCRIPTION
The swiss join was correctly breaking up probe side batches but build size batches would get partitioned as-is before any breaking up happened.  That partitioning assumed 16-bit addressable indices and this failed if a build side batch was too large.

Rather than break batches up in the hash-join node I went ahead and started breaking batches up in the source node.  This matches the morsel / batch model and is basically a small precursor for future scheduler changes.

This will have some small end-user impact as the output for larger queries is going to be batched more finely.  However, we were already slicing batches up into 128Ki chunks in the scanner starting with 8.0.0 and so I don't think this is a significant difference.