### PR TITLE
ARROW-17176: [Rust] Activate generate_decimal256_case integration test for rust

### DIFF
--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -1602,8 +1602,7 @@ def get_generated_json_files(tempdir=None):
 
         generate_decimal256_case()
         .skip_category('Go')  # TODO(ARROW-7948): Decimal + Go
-        .skip_category('JS')
-        .skip_category('Rust'),
+        .skip_category('JS'),
 
         generate_datetime_case(),
 


### PR DESCRIPTION
arrow-rs has added decimal256 support recently. We should activate generate_decimal256_case integration test.
