### PR TITLE
ARROW-15938: [C++][Compute] Fixing HashJoinBasicImpl in case of zero batches on build side

### DIFF
--- a/cpp/src/arrow/compute/exec/hash_join_node_test.cc
+++ b/cpp/src/arrow/compute/exec/hash_join_node_test.cc
@@ -1298,6 +1298,15 @@ void TestHashJoinDictionaryHelper(
     }
   }
 
+  // Instead of sending 2 batches of size 0 we should not send any batches
+  // at all to more accurately simulate real world use cases
+  if (l_length == 0) {
+    l_batches.batches.resize(0);
+  }
+  if (r_length == 0) {
+    r_batches.batches.resize(0);
+  }
+
   auto exec_ctx = arrow::internal::make_unique<ExecContext>(
       default_memory_pool(), parallel ? arrow::internal::GetCpuThreadPool() : nullptr);
   ASSERT_OK_AND_ASSIGN(auto plan, ExecPlan::Make(exec_ctx.get()));


### PR DESCRIPTION
Hash join implementation using HashJoinBasicImpl class was missing initialization in case of no batches one the build side.
Initialization of a few data structures, mainly two RowEncoder instances for holding key and payload columns for rows on build side, was missing inside BuildHashTable_exec_task, the method responsible for transforming accumulated batches on build side of the hash join into a hash table. 

The initialization of RowEncoder inserts a single special row containing null values for all columns. This special row is accessed when outputting probe side rows with no matches in case of left outer and full outer join (these joins are supposed in that case to output nulls in place of all fields that would come from build side).

Interestingly, the initialization was present in a similar case when batches were present on build side but all of them included zero rows. I modified the code to use the same code path for both these logically equivalent cases: a) zero build side batches and b) non-zero batches but with zero rows each.