### PR TITLE
ARROW-17181: [Docs][Python] Scalar UDF Experimental Documentation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "cpp/submodules/parquet-testing"]
 	path = cpp/submodules/parquet-testing
 	url = https://github.com/apache/parquet-testing.git
+[submodule "testing"]
+	path = testing
+	url = https://github.com/apache/arrow-testing

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "cpp/submodules/parquet-testing"]
 	path = cpp/submodules/parquet-testing
 	url = https://github.com/apache/parquet-testing.git
-[submodule "testing"]
-	path = testing
-	url = https://github.com/apache/arrow-testing

--- a/docs/source/python/api/compute.rst
+++ b/docs/source/python/api/compute.rst
@@ -555,3 +555,12 @@ Compute Options
    TrimOptions
    VarianceOptions
    WeekOptions
+
+Custom Functions
+----------------
+
+.. autosummary::
+   :toctree: ../generated/
+
+   register_scalar_function
+   ScalarUdfContext

--- a/docs/source/python/api/compute.rst
+++ b/docs/source/python/api/compute.rst
@@ -556,8 +556,8 @@ Compute Options
    VarianceOptions
    WeekOptions
 
-Custom Functions
-----------------
+User-Defined Functions
+----------------------
 
 .. autosummary::
    :toctree: ../generated/

--- a/docs/source/python/compute.rst
+++ b/docs/source/python/compute.rst
@@ -391,7 +391,7 @@ To register a UDF, a function name, function docs and input types and output typ
    import pyarrow.compute as pc
    function_name = "regression"
    function_docs = {
-      "summary": "Calculate y based on m, x and c values",
+      "summary": "Calculate y = mx + c",
       "description": "Obtaining output of a linear scalar function"
    }
    input_types = {

--- a/docs/source/python/compute.rst
+++ b/docs/source/python/compute.rst
@@ -403,8 +403,9 @@ To register a UDF, a function name, function docs and input types and output typ
    }
    output_type = pa.int64()
 
-   def linear_calculation(ctx, m, x, c):
-      return pc.add(pc.multiply(m, x), c)
+   def affine_calculation(ctx, m, x, c):
+       temp = pc.multiply(m, x, memory_pool=ctx.memory_pool)
+       return pc.add(temp, c, memory_pool=ctx.memory_pool)
 
    pc.register_scalar_function(linear_calculation, 
                                function_name,

--- a/docs/source/python/compute.rst
+++ b/docs/source/python/compute.rst
@@ -385,8 +385,9 @@ using their registered function name.
 
 UDF support is limited to scalar functions. A scalar function is a function which
 executes elementwise operations on arrays or scalars. In general, the output of a
-scalar function do not depend on the order of values in the arguments. Note that 
-such functions have a rough correspondence to the functions used in SQL expressions.
+scalar function does not depend on the order of values in the arguments. Note that
+such functions have a rough correspondence to the functions used in SQL expressions,
+or to NumPy `universal functions <https://numpy.org/doc/stable/reference/ufuncs.html>`_.
 
 To register a UDF, a function name, function docs, input types and
 output type need to be defined. Using :func:`pyarrow.compute.register_scalar_function`,
@@ -431,7 +432,7 @@ output type need to be defined. Using :func:`pyarrow.compute.register_scalar_fun
                               output_type)
    
 
-The implementation of a user-defined function always takes first *context*
+The implementation of a user-defined function always takes a first *context*
 parameter (named ``ctx`` in the example above) which is an instance of
 :class:`pyarrow.compute.ScalarUdfContext`.
 This context exposes several useful attributes, particularly a

--- a/docs/source/python/compute.rst
+++ b/docs/source/python/compute.rst
@@ -438,7 +438,6 @@ Considering a series of scalar inputs,
 
 .. code-block:: python
 
-   >>> import pyarrow as pa
    >>> import pyarrow.compute as pc
    >>> function_name = "affine_with_python"
    >>> function_docs = {
@@ -469,10 +468,9 @@ Considering a series of scalar inputs,
    >>> pc.call_function(function_name, [pa.scalar(10.1), pa.scalar(10.2), pa.scalar(20.2)])
    <pyarrow.DoubleScalar: 123.22>
 
-When all the inputs are scalar, the input is a size=1 array and the values has to be properly
-treated within the UDF. And also make sure to include the final output as a size=1 array.
+In case of all scalar inputs, make sure to return the final output as an array.
 
-UDFs can be used with tabular data by using `dataset` API and apply a UDF function on the
+More generally, UDFs can be used with tabular data by using `dataset` API and apply a UDF function on a
 dataset.
 
 .. code-block:: python

--- a/docs/source/python/compute.rst
+++ b/docs/source/python/compute.rst
@@ -376,7 +376,8 @@ User-Defined Functions
 ======================
 
 .. warning::
-   User-defined functions only supports scalar functions and the current version is experimental.
+   This API is **experimental**.
+   Also, only scalar functions can currently be user-defined.
 
 To use a user-defined-function (UDF), either the experimental `dataset` API options can be used or the
 function can be directly called using :func:`pyarrow.compute.call_function`. 

--- a/docs/source/python/compute.rst
+++ b/docs/source/python/compute.rst
@@ -417,7 +417,7 @@ To register a UDF, a function name, function docs and input types and output typ
    first parameter of any user-defined-function. The idea is to make available passing required
    meta-data across an application which would be important for UDFs.
 
-Calling a UDF directly using :func:`pyarrow.compute.call_function`,
+You can call a user-defined function directly using :func:`pyarrow.compute.call_function`:
 
 .. code-block:: python
 

--- a/docs/source/python/compute.rst
+++ b/docs/source/python/compute.rst
@@ -392,7 +392,9 @@ To register a UDF, a function name, function docs and input types and output typ
    function_name = "regression"
    function_docs = {
       "summary": "Calculate y = mx + c",
-      "description": "Obtaining output of a linear scalar function"
+      "description":
+          "Compute the affine function y = mx + c.\n"
+          "This function takes three inputs, m, x and c, in order."
    }
    input_types = {
       "m" : pa.int64(),

--- a/docs/source/python/compute.rst
+++ b/docs/source/python/compute.rst
@@ -428,8 +428,9 @@ You can call a user-defined function directly using :func:`pyarrow.compute.call_
    Note that when the passed values to a function are all scalars, internally each scalar 
    is passed as an array of size 1.
 
-UDFs can be used with tabular data by using `dataset` API and apply a UDF function on the
-dataset.
+More generally, user-defined functions are usable everywhere a compute function
+can be referred to by its name. For example, they can be called on a dataset's
+column using :meth:`Expression._call`:
 
 .. code-block:: python
 

--- a/docs/source/python/compute.rst
+++ b/docs/source/python/compute.rst
@@ -412,10 +412,12 @@ To register a UDF, a function name, function docs and input types and output typ
                                input_types,
                                output_type)
 
-.. note::
-   There is a default parameter, `ctx` which is refers to a context object and it should be the
-   first parameter of any user-defined-function. The idea is to make available passing required
-   meta-data across an application which would be important for UDFs.
+The implementation of a user-defined function always takes a first *context*
+parameter (named ``ctx`` in the example above) which is an instance of
+:class:`pyarrow.compute.ScalarUdfContext`.
+This context exposes several useful attributes, particularly a
+:attr:`~pyarrow.compute.ScalarUdfContext.memory_pool` to be used for
+allocations in the context of the user-defined function.
 
 You can call a user-defined function directly using :func:`pyarrow.compute.call_function`:
 

--- a/docs/source/python/compute.rst
+++ b/docs/source/python/compute.rst
@@ -403,14 +403,9 @@ To register a UDF, a function name, function docs and input types and output typ
    }
    output_type = pa.float64()
 
-<<<<<<< HEAD
-   def affine_calculation(ctx, m, x, c):
+   def affine(ctx, m, x, c):
        temp = pc.multiply(m, x, memory_pool=ctx.memory_pool)
        return pc.add(temp, c, memory_pool=ctx.memory_pool)
-=======
-   def affine(ctx, m, x, c):
-      return pc.add(pc.multiply(m, x), c)
->>>>>>> 5a2c81946 (adding a new example to show case the scalar limitations')
 
    pc.register_scalar_function(affine, 
                                function_name,
@@ -429,8 +424,8 @@ You can call a user-defined function directly using :func:`pyarrow.compute.call_
 
 .. code-block:: python
 
-   >>> res = pc.call_function("affine", [pa.scalar(2), pa.scalar(10), pa.scalar(5)])
-   25
+   >>> pc.call_function("affine", [pa.scalar(2.5), pa.scalar(10.5), pa.scalar(5.5)])
+   <pyarrow.DoubleScalar: 31.75>
 
 .. note::
    Note that when the passed values to a function are all scalars, internally each scalar 
@@ -487,7 +482,7 @@ dataset.
    >>> data_table = pa.Table.from_pydict(sample_data)
    >>> dataset = ds.dataset(data_table)
    >>> func_args = [pc.scalar(5.2), ds.field("total_amount($)"), pc.scalar(2.1)]
-   >>> result_table = dataset.to_table(
+   >>> dataset.to_table(
    ...             columns={
    ...                 'total_amount_projected($)': ds.field('')._call("affine", func_args),
    ...                 'total_amount($)': ds.field('total_amount($)'),

--- a/docs/source/python/compute.rst
+++ b/docs/source/python/compute.rst
@@ -384,7 +384,7 @@ Those functions can then be called from Python as well as C++ (and potentially
 any other implementation wrapping Arrow C++, such as the R ``arrow`` package`)
 using their registered function name.
 
-To register a UDF, a function name, function docs and input types and output type needs to be defined.
+To register a UDF, a function name, function docs and input types and output type need to be defined.
 
 .. code-block:: python
 

--- a/docs/source/python/compute.rst
+++ b/docs/source/python/compute.rst
@@ -379,8 +379,10 @@ User-Defined Functions
    This API is **experimental**.
    Also, only scalar functions can currently be user-defined.
 
-To use a user-defined-function (UDF), either the experimental `dataset` API options can be used or the
-function can be directly called using :func:`pyarrow.compute.call_function`. 
+PyArrow allows defining and registering custom compute functions in Python.
+Those functions can then be called from Python as well as C++ (and potentially
+any other implementation wrapping Arrow C++, such as the R ``arrow`` package`)
+using their registered function name.
 
 To register a UDF, a function name, function docs and input types and output type needs to be defined.
 

--- a/python/pyarrow/src/udf.h
+++ b/python/pyarrow/src/udf.h
@@ -41,8 +41,7 @@ struct ARROW_PYTHON_EXPORT ScalarUdfOptions {
   std::shared_ptr<DataType> output_type;
 };
 
-/// \brief A context defined to hold meta-data required in
-/// scalar UDF execution.
+/// \brief A context passed as the first argument of scalar UDF functions.
 struct ARROW_PYTHON_EXPORT ScalarUdfContext {
   MemoryPool* pool;
   int64_t batch_length;

--- a/python/pyarrow/src/udf.h
+++ b/python/pyarrow/src/udf.h
@@ -41,6 +41,8 @@ struct ARROW_PYTHON_EXPORT ScalarUdfOptions {
   std::shared_ptr<DataType> output_type;
 };
 
+/// \brief A context defined to hold meta-data required in
+/// scalar UDF execution.
 struct ARROW_PYTHON_EXPORT ScalarUdfContext {
   MemoryPool* pool;
   int64_t batch_length;


### PR DESCRIPTION
This PR contains Python Scalar UDF documentation as an experimental version of docs. 
At the moment we only support Scalar UDFs and the code snippets include how to use
UDFs with PyArrow.