### PR TITLE
MINOR: [R][Docs] Use query that cannot be executed by arrow alone as a example of `to_duckdb`

### DIFF
--- a/r/R/duckdb.R
+++ b/r/R/duckdb.R
@@ -47,9 +47,9 @@
 #'
 #' ds %>%
 #'   filter(mpg < 30) %>%
-#'   to_duckdb() %>%
 #'   group_by(cyl) %>%
-#'   summarize(mean_mpg = mean(mpg, na.rm = TRUE))
+#'   to_duckdb() %>%
+#'   slice_min(disp)
 to_duckdb <- function(.data,
                       con = arrow_duck_connection(),
                       table_name = unique_arrow_tablename(),

--- a/r/man/to_duckdb.Rd
+++ b/r/man/to_duckdb.Rd
@@ -47,8 +47,8 @@ ds <- InMemoryDataset$create(mtcars)
 
 ds \%>\%
   filter(mpg < 30) \%>\%
-  to_duckdb() \%>\%
   group_by(cyl) \%>\%
-  summarize(mean_mpg = mean(mpg, na.rm = TRUE))
+  to_duckdb() \%>\%
+  slice_min(disp)
 \dontshow{\}) # examplesIf}
 }


### PR DESCRIPTION
Since `dplyr::summarize` can currently be executed with arrow alone, it makes more sense to use the slice function, as an example of the usefulness of the combination with duckdb.