### PR TITLE
ARROW-17217: [Docs][Python] Adding pandas as required dependency

### DIFF
--- a/ci/conda_env_sphinx.txt
+++ b/ci/conda_env_sphinx.txt
@@ -26,3 +26,4 @@ sphinx>=4.2
 sphinx-copybutton
 # Requirement for doctest-cython
 pytest-cython
+pandas

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,3 +9,4 @@ pydata-sphinx-theme==0.8
 sphinx-design
 sphinx-copybutton
 sphinx>=4.2
+pandas


### PR DESCRIPTION
Pandas seems to be a build requirement for documentation, but is not listed in conda or pip definitions.