### PR TITLE
MINOR: [Go] fill in field names of struct literal

### DIFF
--- a/go/arrow/array/interval_test.go
+++ b/go/arrow/array/interval_test.go
@@ -156,7 +156,9 @@ func TestDayTimeArray(t *testing.T) {
 	defer mem.AssertSize(t, 0)
 
 	var (
-		want   = []arrow.DayTimeInterval{{1, 1}, {2, 2}, {3, 3}, {4, 4}}
+		want = []arrow.DayTimeInterval{
+			{Days: 1, Milliseconds: 1}, {Days: 2, Milliseconds: 2},
+			{Days: 3, Milliseconds: 3}, {Days: 4, Milliseconds: 4}}
 		valids = []bool{true, true, false, true}
 	)
 
@@ -240,7 +242,9 @@ func TestDayTimeIntervalBuilder_Empty(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
 	defer mem.AssertSize(t, 0)
 
-	want := []arrow.DayTimeInterval{{1, 1}, {2, 2}, {3, 3}, {4, 4}}
+	want := []arrow.DayTimeInterval{
+		{Days: 1, Milliseconds: 1}, {Days: 2, Milliseconds: 2},
+		{Days: 3, Milliseconds: 3}, {Days: 4, Milliseconds: 4}}
 
 	b := array.NewDayTimeIntervalBuilder(mem)
 	defer b.Release()
@@ -282,9 +286,11 @@ func TestMonthDayNanoArray(t *testing.T) {
 
 	var (
 		want = []arrow.MonthDayNanoInterval{
-			{1, 1, 1000}, {2, 2, 2000}, {3, 3, 3000}, {4, 4, 4000},
-			{0, 0, 0}, {-1, -2, -300}, {math.MaxInt32, math.MinInt32, math.MaxInt64},
-			{math.MinInt32, math.MaxInt32, math.MinInt64},
+			{Months: 1, Days: 1, Nanoseconds: 1000}, {Months: 2, Days: 2, Nanoseconds: 2000},
+			{Months: 3, Days: 3, Nanoseconds: 3000}, {Months: 4, Days: 4, Nanoseconds: 4000},
+			{Months: 0, Days: 0, Nanoseconds: 0}, {Months: -1, Days: -2, Nanoseconds: -300},
+			{Months: math.MaxInt32, Days: math.MinInt32, Nanoseconds: math.MaxInt64},
+			{Months: math.MinInt32, Days: math.MaxInt32, Nanoseconds: math.MinInt64},
 		}
 		valids = []bool{true, true, false, true, true, true, false, true}
 	)
@@ -370,7 +376,11 @@ func TestMonthDayNanoIntervalBuilder_Empty(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
 	defer mem.AssertSize(t, 0)
 
-	want := []arrow.MonthDayNanoInterval{{1, 1, 1000}, {2, 2, 2000}, {3, 3, 3000}, {4, 4, 4000}}
+	want := []arrow.MonthDayNanoInterval{
+		{Months: 1, Days: 1, Nanoseconds: 1000},
+		{Months: 2, Days: 2, Nanoseconds: 2000},
+		{Months: 3, Days: 3, Nanoseconds: 3000},
+		{Months: 4, Days: 4, Nanoseconds: 4000}}
 
 	b := array.NewMonthDayNanoIntervalBuilder(mem)
 	defer b.Release()


### PR DESCRIPTION
I just wanted the annoying "Problems" number to go away by fixing this little lint situation that was annoying me by saying that the struct literal was using un-keyed fields.

This is an extremely minor simple change.