### PR TITLE
ARROW-17230: [C++] Fix DeserializePlan, add additional option validation

### DIFF
--- a/cpp/src/arrow/compute/exec/sink_node.cc
+++ b/cpp/src/arrow/compute/exec/sink_node.cc
@@ -271,6 +271,10 @@ class ConsumingSinkNode : public ExecNode, public BackpressureControl {
     RETURN_NOT_OK(ValidateExecNodeInputs(plan, inputs, 1, "SinkNode"));
 
     const auto& sink_options = checked_cast<const ConsumingSinkNodeOptions&>(options);
+    if (!sink_options.consumer) {
+      return Status::Invalid("A SinkNodeConsumer is required");
+    }
+
     return plan->EmplaceNode<ConsumingSinkNode>(plan, std::move(inputs),
                                                 std::move(sink_options.consumer),
                                                 std::move(sink_options.names));

--- a/cpp/src/arrow/dataset/dataset_writer.cc
+++ b/cpp/src/arrow/dataset/dataset_writer.cc
@@ -398,6 +398,12 @@ Status ValidateBasenameTemplate(util::string_view basename_template) {
 
 Status ValidateOptions(const FileSystemDatasetWriteOptions& options) {
   ARROW_RETURN_NOT_OK(ValidateBasenameTemplate(options.basename_template));
+  if (!options.file_write_options) {
+    return Status::Invalid("Must provide file_write_options");
+  }
+  if (!options.filesystem) {
+    return Status::Invalid("Must provide filesystem");
+  }
   if (options.max_rows_per_group <= 0) {
     return Status::Invalid("max_rows_per_group must be a positive number");
   }

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -436,6 +436,10 @@ Result<compute::ExecNode*> MakeWriteNode(compute::ExecPlan* plan,
       write_node_options.custom_metadata;
   const FileSystemDatasetWriteOptions& write_options = write_node_options.write_options;
 
+  if (!write_options.partitioning) {
+    return Status::Invalid("Must provide partitioning");
+  }
+
   ARROW_ASSIGN_OR_RAISE(auto dataset_writer,
                         internal::DatasetWriter::Make(write_options));
 

--- a/cpp/src/arrow/engine/substrait/serde.h
+++ b/cpp/src/arrow/engine/substrait/serde.h
@@ -71,7 +71,7 @@ ARROW_ENGINE_EXPORT Result<std::vector<compute::Declaration>> DeserializePlans(
 /// Plan is returned here.
 /// \return an ExecNode corresponding to the single toplevel relation in the Substrait
 /// Plan
-Result<compute::ExecPlan> DeserializePlan(
+Result<std::shared_ptr<compute::ExecPlan>> DeserializePlan(
     const Buffer& buf, const std::shared_ptr<compute::SinkNodeConsumer>& consumer,
     const ExtensionIdRegistry* registry = NULLPTR, ExtensionSet* ext_set_out = NULLPTR);
 
@@ -111,7 +111,7 @@ ARROW_ENGINE_EXPORT Result<std::vector<compute::Declaration>> DeserializePlans(
 /// Plan is returned here.
 /// \return a vector of ExecNode declarations, one for each toplevel relation in the
 /// Substrait Plan
-ARROW_ENGINE_EXPORT Result<compute::ExecPlan> DeserializePlan(
+ARROW_ENGINE_EXPORT Result<std::shared_ptr<compute::ExecPlan>> DeserializePlan(
     const Buffer& buf, const std::shared_ptr<dataset::WriteNodeOptions>& write_options,
     const ExtensionIdRegistry* registry = NULLPTR, ExtensionSet* ext_set_out = NULLPTR);
 


### PR DESCRIPTION
- DeserializePlan's signature was a guaranteed use-after-free
- Check that the write options are actually filled out
- Don't call the consumer factory twice per declaration
- Don't ignore plan construction errors
- Actually attempt to run the plans we make