### PR TITLE
ARROW-17247: [C++][Docs] Include visibilty to ExecPlan APIs in Acero Docs

### DIFF
--- a/cpp/src/arrow/compute/api.h
+++ b/cpp/src/arrow/compute/api.h
@@ -28,7 +28,6 @@
 #include "arrow/compute/api_scalar.h"     // IWYU pragma: export
 #include "arrow/compute/api_vector.h"     // IWYU pragma: export
 #include "arrow/compute/cast.h"           // IWYU pragma: export
-#include "arrow/compute/exec.h"           // IWYU pragma: export
 #include "arrow/compute/function.h"       // IWYU pragma: export
 #include "arrow/compute/kernel.h"         // IWYU pragma: export
 #include "arrow/compute/registry.h"       // IWYU pragma: export
@@ -52,3 +51,9 @@
 /// @}
 
 #include "arrow/compute/row/grouper.h"  // IWYU pragma: export
+
+/// \defgroup execnode-components Components associated with ExecNode
+/// @{
+/// @}
+
+#include "arrow/compute/exec.h"  // IWYU pragma: export

--- a/cpp/src/arrow/compute/api.h
+++ b/cpp/src/arrow/compute/api.h
@@ -47,6 +47,12 @@
 
 #include "arrow/compute/exec/options.h"  // IWYU pragma: export
 
+/// \defgroup execnode-components Execution plan entities
+/// @{
+/// @}
+
+#include "arrow/compute/exec/options.h"  // IWYU pragma: export
+
 /// \defgroup execnode-row Utilities for working with data in a row-major format
 /// @{
 /// @}

--- a/cpp/src/arrow/compute/api.h
+++ b/cpp/src/arrow/compute/api.h
@@ -47,12 +47,6 @@
 
 #include "arrow/compute/exec/options.h"  // IWYU pragma: export
 
-/// \defgroup execnode-components Execution plan entities
-/// @{
-/// @}
-
-#include "arrow/compute/exec/options.h"  // IWYU pragma: export
-
 /// \defgroup execnode-row Utilities for working with data in a row-major format
 /// @{
 /// @}

--- a/cpp/src/arrow/compute/exec.h
+++ b/cpp/src/arrow/compute/exec.h
@@ -174,6 +174,10 @@ class ARROW_EXPORT SelectionVector {
 /// TODO: Datum uses arrow/util/variant.h which may be a bit heavier-weight
 /// than is desirable for this class. Microbenchmarks would help determine for
 /// sure. See ARROW-8928.
+
+/// \addtogroup execnode-components
+/// @{
+
 struct ARROW_EXPORT ExecBatch {
   ExecBatch() = default;
   ExecBatch(std::vector<Datum> values, int64_t length)
@@ -399,6 +403,8 @@ struct ARROW_EXPORT ExecSpan {
   int64_t length = 0;
   std::vector<ExecValue> values;
 };
+
+/// @}
 
 /// \defgroup compute-call-function One-shot calls to compute functions
 ///

--- a/cpp/src/arrow/compute/exec/exec_plan.h
+++ b/cpp/src/arrow/compute/exec/exec_plan.h
@@ -38,6 +38,9 @@ namespace arrow {
 
 namespace compute {
 
+/// \addtogroup execnode-components
+/// @{
+
 class ARROW_EXPORT ExecPlan : public std::enable_shared_from_this<ExecPlan> {
  public:
   // This allows operators to rely on signed 16-bit indices
@@ -533,6 +536,8 @@ ARROW_EXPORT
 Result<std::function<Future<util::optional<ExecBatch>>()>> MakeReaderGenerator(
     std::shared_ptr<RecordBatchReader> reader, arrow::internal::Executor* io_executor,
     int max_q = kDefaultBackgroundMaxQ, int q_restart = kDefaultBackgroundQRestart);
+
+/// @}
 
 }  // namespace compute
 }  // namespace arrow

--- a/docs/source/cpp/api/compute.rst
+++ b/docs/source/cpp/api/compute.rst
@@ -70,6 +70,11 @@ Streaming Execution Operators
    :members:
    :undoc-members:
 
+.. doxygengroup:: execnode-components
+   :content-only:
+   :members:
+   :undoc-members:
+
 Execution Plan Expressions
 --------------------------
 


### PR DESCRIPTION
This PR includes a documentation update to visibility of `exec.h` components. 