### PR TITLE
MINOR: [R] Add note about the deprecated `type()` function

### DIFF
--- a/r/R/type.R
+++ b/r/R/type.R
@@ -58,6 +58,10 @@ FLOAT_TYPES <- c("float16", "float32", "float64", "halffloat", "float", "double"
 
 #' Infer the arrow Array type from an R object
 #'
+#' Infer the arrow Array type from an R object.
+#'
+#' [type()] is deprecated in favor of [infer_type()].
+#'
 #' @param x an R object (usually a vector) to be converted to an [Array] or
 #'   [ChunkedArray].
 #' @param ... Passed to S3 methods

--- a/r/man/infer_type.Rd
+++ b/r/man/infer_type.Rd
@@ -19,7 +19,10 @@ type(x)
 An arrow \link[=data-type]{data type}
 }
 \description{
-Infer the arrow Array type from an R object
+Infer the arrow Array type from an R object.
+}
+\details{
+\code{\link[=type]{type()}} is deprecated in favor of \code{\link[=infer_type]{infer_type()}}.
 }
 \examples{
 infer_type(1:10)


### PR DESCRIPTION
The `type()` function was deprecated in #12817 (ARROW-15168), but the documentation did not indicate that it had been deprecated.