### PR TITLE
ARROW-17259: [C++] Do not use shared_ptr<DataType> with kernel function signatures, do less copying of shared_ptrs

### DIFF
--- a/cpp/src/arrow/compute/kernel.cc
+++ b/cpp/src/arrow/compute/kernel.cc
@@ -356,7 +356,7 @@ bool InputType::Matches(const Datum& value) const {
   return Matches(*value.type());
 }
 
-const std::shared_ptr<DataType>& InputType::type() const {
+const DataType* InputType::type() const {
   DCHECK_EQ(InputType::EXACT_TYPE, kind_);
   return type_;
 }
@@ -372,13 +372,13 @@ const TypeMatcher& InputType::type_matcher() const {
 Result<TypeHolder> OutputType::Resolve(KernelContext* ctx,
                                        const std::vector<TypeHolder>& types) const {
   if (kind_ == OutputType::FIXED) {
-    return type_.get();
+    return type_;
   } else {
     return resolver_(ctx, types);
   }
 }
 
-const std::shared_ptr<DataType>& OutputType::type() const {
+const DataType* OutputType::type() const {
   DCHECK_EQ(FIXED, kind_);
   return type_;
 }

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -166,8 +166,11 @@ class ARROW_EXPORT InputType {
   InputType() : kind_(ANY_TYPE) {}
 
   /// \brief Accept an exact value type.
-  InputType(std::shared_ptr<DataType> type)  // NOLINT implicit construction
-      : kind_(EXACT_TYPE), type_(std::move(type)) {}
+  InputType(const DataType* type)  // NOLINT implicit construction
+      : kind_(EXACT_TYPE), type_(type) {}
+
+  InputType(const std::shared_ptr<DataType>& type)  // NOLINT implicit construction
+    : InputType(type.get()) {}
 
   /// \brief Use the passed TypeMatcher to type check.
   InputType(std::shared_ptr<TypeMatcher> type_matcher)  // NOLINT implicit construction
@@ -216,7 +219,7 @@ class ARROW_EXPORT InputType {
   /// \brief For InputType::EXACT_TYPE kind, the exact type that this InputType
   /// must match. Otherwise this function should not be used and will assert in
   /// debug builds.
-  const std::shared_ptr<DataType>& type() const;
+  const DataType* type() const;
 
   /// \brief For InputType::USE_TYPE_MATCHER, the TypeMatcher to be used for
   /// checking the type of a value. Otherwise this function should not be used
@@ -232,7 +235,7 @@ class ARROW_EXPORT InputType {
 
   void MoveInto(InputType&& other) {
     this->kind_ = other.kind_;
-    this->type_ = std::move(other.type_);
+    this->type_ = other.type_;
     this->type_matcher_ = std::move(other.type_matcher_);
   }
 
@@ -261,12 +264,12 @@ class ARROW_EXPORT OutputType {
   using Resolver = Result<TypeHolder> (*)(KernelContext*, const std::vector<TypeHolder>&);
 
   /// \brief Output an exact type
-  OutputType(std::shared_ptr<DataType> type)  // NOLINT implicit construction
-    : kind_(FIXED), type_(type.get()) {}
-
-  /// \brief Output an exact type
   OutputType(const DataType* type)  // NOLINT implicit construction
     : kind_(FIXED), type_(type) {}
+
+  /// \brief Output an exact type
+  OutputType(const std::shared_ptr<DataType>& type)  // NOLINT implicit construction
+    : OutputType(type.get()) {}
 
   /// \brief Output a computed type depending on actual input types
   OutputType(Resolver resolver)  // NOLINT implicit construction

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -239,7 +239,7 @@ class ARROW_EXPORT InputType {
   Kind kind_;
 
   // For EXACT_TYPE Kind
-  std::shared_ptr<DataType> type_;
+  const DataType* type_;
 
   // For USE_TYPE_MATCHER Kind
   std::shared_ptr<TypeMatcher> type_matcher_;
@@ -262,11 +262,15 @@ class ARROW_EXPORT OutputType {
 
   /// \brief Output an exact type
   OutputType(std::shared_ptr<DataType> type)  // NOLINT implicit construction
-      : kind_(FIXED), type_(std::move(type)) {}
+    : kind_(FIXED), type_(type.get()) {}
+
+  /// \brief Output an exact type
+  OutputType(const DataType* type)  // NOLINT implicit construction
+    : kind_(FIXED), type_(type) {}
 
   /// \brief Output a computed type depending on actual input types
   OutputType(Resolver resolver)  // NOLINT implicit construction
-      : kind_(COMPUTED), resolver_(std::move(resolver)) {}
+    : kind_(COMPUTED), resolver_(std::move(resolver)) {}
 
   OutputType(const OutputType& other) {
     this->kind_ = other.kind_;
@@ -276,7 +280,7 @@ class ARROW_EXPORT OutputType {
 
   OutputType(OutputType&& other) {
     this->kind_ = other.kind_;
-    this->type_ = std::move(other.type_);
+    this->type_ = other.type_;
     this->resolver_ = other.resolver_;
   }
 
@@ -290,7 +294,7 @@ class ARROW_EXPORT OutputType {
                              const std::vector<TypeHolder>& args) const;
 
   /// \brief The exact output value type for the FIXED kind.
-  const std::shared_ptr<DataType>& type() const;
+  const DataType* type() const;
 
   /// \brief For use with COMPUTED resolution strategy. It may be more
   /// convenient to invoke this with OutputType::Resolve returned from this
@@ -308,7 +312,7 @@ class ARROW_EXPORT OutputType {
   ResolveKind kind_;
 
   // For FIXED resolution
-  std::shared_ptr<DataType> type_;
+  const DataType* type_;
 
   // For COMPUTED resolution
   Resolver resolver_ = NULLPTR;

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -242,7 +242,7 @@ class ARROW_EXPORT InputType {
   Kind kind_;
 
   // For EXACT_TYPE Kind
-  const DataType* type_;
+  const DataType* type_ = NULLPTR;
 
   // For USE_TYPE_MATCHER Kind
   std::shared_ptr<TypeMatcher> type_matcher_;
@@ -315,7 +315,7 @@ class ARROW_EXPORT OutputType {
   ResolveKind kind_;
 
   // For FIXED resolution
-  const DataType* type_;
+  const DataType* type_ = NULLPTR;
 
   // For COMPUTED resolution
   Resolver resolver_ = NULLPTR;

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -170,7 +170,7 @@ class ARROW_EXPORT InputType {
       : kind_(EXACT_TYPE), type_(type) {}
 
   InputType(const std::shared_ptr<DataType>& type)  // NOLINT implicit construction
-    : InputType(type.get()) {}
+      : InputType(type.get()) {}
 
   /// \brief Use the passed TypeMatcher to type check.
   InputType(std::shared_ptr<TypeMatcher> type_matcher)  // NOLINT implicit construction
@@ -265,15 +265,15 @@ class ARROW_EXPORT OutputType {
 
   /// \brief Output an exact type
   OutputType(const DataType* type)  // NOLINT implicit construction
-    : kind_(FIXED), type_(type) {}
+      : kind_(FIXED), type_(type) {}
 
   /// \brief Output an exact type
   OutputType(const std::shared_ptr<DataType>& type)  // NOLINT implicit construction
-    : OutputType(type.get()) {}
+      : OutputType(type.get()) {}
 
   /// \brief Output a computed type depending on actual input types
   OutputType(Resolver resolver)  // NOLINT implicit construction
-    : kind_(COMPUTED), resolver_(std::move(resolver)) {}
+      : kind_(COMPUTED), resolver_(std::move(resolver)) {}
 
   OutputType(const OutputType& other) {
     this->kind_ = other.kind_;

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -141,6 +141,9 @@ ARROW_EXPORT std::shared_ptr<TypeMatcher> FixedSizeBinaryLike();
 // Type)
 ARROW_EXPORT std::shared_ptr<TypeMatcher> Primitive();
 
+ARROW_EXPORT std::shared_ptr<TypeMatcher> ListOf(Type::type type_id,
+                                                 Type::type list_type = Type::LIST);
+
 }  // namespace match
 
 /// \brief An object used for type-checking arguments to be passed to a kernel
@@ -169,8 +172,7 @@ class ARROW_EXPORT InputType {
   InputType(const DataType* type)  // NOLINT implicit construction
       : kind_(EXACT_TYPE), type_(type) {}
 
-  InputType(const std::shared_ptr<DataType>& type)  // NOLINT implicit construction
-      : InputType(type.get()) {}
+  InputType(const std::shared_ptr<DataType>& type);  // NOLINT implicit construction
 
   /// \brief Use the passed TypeMatcher to type check.
   InputType(std::shared_ptr<TypeMatcher> type_matcher)  // NOLINT implicit construction
@@ -268,8 +270,7 @@ class ARROW_EXPORT OutputType {
       : kind_(FIXED), type_(type) {}
 
   /// \brief Output an exact type
-  OutputType(const std::shared_ptr<DataType>& type)  // NOLINT implicit construction
-      : OutputType(type.get()) {}
+  OutputType(const std::shared_ptr<DataType>& type);  // NOLINT implicit construction
 
   /// \brief Output a computed type depending on actual input types
   OutputType(Resolver resolver)  // NOLINT implicit construction

--- a/cpp/src/arrow/compute/kernel_test.cc
+++ b/cpp/src/arrow/compute/kernel_test.cc
@@ -145,9 +145,11 @@ TEST(InputType, Equals) {
   ASSERT_NE(InputType(int8()), InputType(Type::INT32));
 
   // Check that field metadata excluded from equality checks
-  InputType t9 = list(
+  auto ty9 = list(
       field("item", utf8(), /*nullable=*/true, key_value_metadata({"foo"}, {"bar"})));
-  InputType t10 = list(field("item", utf8()));
+  auto ty10 = list(field("item", utf8()));
+  InputType t9 = ty9.get();
+  InputType t10 = ty10.get();
   ASSERT_TRUE(t9.Equals(t10));
 }
 

--- a/cpp/src/arrow/compute/kernels/aggregate_basic.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic.cc
@@ -812,10 +812,9 @@ void AddMinMaxKernel(KernelInit init, internal::detail::GetTypeId get_id,
   AddAggKernel(std::move(sig), init, func, simd_level);
 }
 
-void AddMinMaxKernels(KernelInit init,
-                      const std::vector<std::shared_ptr<DataType>>& types,
+void AddMinMaxKernels(KernelInit init, const std::vector<const DataType*>& types,
                       ScalarAggregateFunction* func, SimdLevel::type simd_level) {
-  for (const auto& ty : types) {
+  for (const DataType* ty : types) {
     AddMinMaxKernel(init, ty, func, simd_level);
   }
 }

--- a/cpp/src/arrow/compute/kernels/aggregate_basic.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic.cc
@@ -770,7 +770,7 @@ struct IndexInit {
 }  // namespace
 
 void AddBasicAggKernels(KernelInit init,
-                        const std::vector<std::shared_ptr<DataType>>& types,
+                        const std::vector<const DataType*>& types,
                         std::shared_ptr<DataType> out_ty, ScalarAggregateFunction* func,
                         SimdLevel::type simd_level) {
   for (const auto& ty : types) {
@@ -781,7 +781,7 @@ void AddBasicAggKernels(KernelInit init,
 }
 
 void AddScalarAggKernels(KernelInit init,
-                         const std::vector<std::shared_ptr<DataType>>& types,
+                         const std::vector<const DataType*>& types,
                          std::shared_ptr<DataType> out_ty,
                          ScalarAggregateFunction* func) {
   for (const auto& ty : types) {
@@ -791,7 +791,7 @@ void AddScalarAggKernels(KernelInit init,
 }
 
 void AddArrayScalarAggKernels(KernelInit init,
-                              const std::vector<std::shared_ptr<DataType>>& types,
+                              const std::vector<const DataType*>& types,
                               std::shared_ptr<DataType> out_ty,
                               ScalarAggregateFunction* func,
                               SimdLevel::type simd_level = SimdLevel::NONE) {
@@ -923,7 +923,7 @@ void RegisterScalarAggregateBasic(FunctionRegistry* registry) {
 
   func = std::make_shared<ScalarAggregateFunction>("sum", Arity::Unary(), sum_doc,
                                                    &default_scalar_aggregate_options);
-  AddArrayScalarAggKernels(SumInit, {boolean()}, uint64(), func.get());
+  AddArrayScalarAggKernels(SumInit, {boolean().get()}, uint64(), func.get());
   AddAggKernel(KernelSignature::Make({Type::DECIMAL128}, FirstType), SumInit, func.get(),
                SimdLevel::NONE);
   AddAggKernel(KernelSignature::Make({Type::DECIMAL256}, FirstType), SumInit, func.get(),
@@ -931,7 +931,7 @@ void RegisterScalarAggregateBasic(FunctionRegistry* registry) {
   AddArrayScalarAggKernels(SumInit, SignedIntTypes(), int64(), func.get());
   AddArrayScalarAggKernels(SumInit, UnsignedIntTypes(), uint64(), func.get());
   AddArrayScalarAggKernels(SumInit, FloatingPointTypes(), float64(), func.get());
-  AddArrayScalarAggKernels(SumInit, {null()}, int64(), func.get());
+  AddArrayScalarAggKernels(SumInit, {null().get()}, int64(), func.get());
   // Add the SIMD variants for sum
 #if defined(ARROW_HAVE_RUNTIME_AVX2) || defined(ARROW_HAVE_RUNTIME_AVX512)
   auto cpu_info = arrow::internal::CpuInfo::GetInstance();
@@ -950,13 +950,13 @@ void RegisterScalarAggregateBasic(FunctionRegistry* registry) {
 
   func = std::make_shared<ScalarAggregateFunction>("mean", Arity::Unary(), mean_doc,
                                                    &default_scalar_aggregate_options);
-  AddArrayScalarAggKernels(MeanInit, {boolean()}, float64(), func.get());
+  AddArrayScalarAggKernels(MeanInit, {boolean().get()}, float64(), func.get());
   AddArrayScalarAggKernels(MeanInit, NumericTypes(), float64(), func.get());
   AddAggKernel(KernelSignature::Make({Type::DECIMAL128}, FirstType), MeanInit, func.get(),
                SimdLevel::NONE);
   AddAggKernel(KernelSignature::Make({Type::DECIMAL256}, FirstType), MeanInit, func.get(),
                SimdLevel::NONE);
-  AddArrayScalarAggKernels(MeanInit, {null()}, float64(), func.get());
+  AddArrayScalarAggKernels(MeanInit, {null().get()}, float64(), func.get());
   // Add the SIMD variants for mean
 #if defined(ARROW_HAVE_RUNTIME_AVX2)
   if (cpu_info->IsSupported(arrow::internal::CpuInfo::AVX2)) {
@@ -972,7 +972,7 @@ void RegisterScalarAggregateBasic(FunctionRegistry* registry) {
 
   func = std::make_shared<ScalarAggregateFunction>("min_max", Arity::Unary(), min_max_doc,
                                                    &default_scalar_aggregate_options);
-  AddMinMaxKernels(MinMaxInit, {null(), boolean()}, func.get());
+  AddMinMaxKernels(MinMaxInit, {null().get(), boolean().get()}, func.get());
   AddMinMaxKernels(MinMaxInit, NumericTypes(), func.get());
   AddMinMaxKernels(MinMaxInit, TemporalTypes(), func.get());
   AddMinMaxKernels(MinMaxInit, BaseBinaryTypes(), func.get());
@@ -1008,7 +1008,7 @@ void RegisterScalarAggregateBasic(FunctionRegistry* registry) {
 
   func = std::make_shared<ScalarAggregateFunction>("product", Arity::Unary(), product_doc,
                                                    &default_scalar_aggregate_options);
-  AddArrayScalarAggKernels(ProductInit::Init, {boolean()}, uint64(), func.get());
+  AddArrayScalarAggKernels(ProductInit::Init, {boolean().get()}, uint64(), func.get());
   AddArrayScalarAggKernels(ProductInit::Init, SignedIntTypes(), int64(), func.get());
   AddArrayScalarAggKernels(ProductInit::Init, UnsignedIntTypes(), uint64(), func.get());
   AddArrayScalarAggKernels(ProductInit::Init, FloatingPointTypes(), float64(),
@@ -1017,19 +1017,19 @@ void RegisterScalarAggregateBasic(FunctionRegistry* registry) {
                func.get(), SimdLevel::NONE);
   AddAggKernel(KernelSignature::Make({Type::DECIMAL256}, FirstType), ProductInit::Init,
                func.get(), SimdLevel::NONE);
-  AddArrayScalarAggKernels(ProductInit::Init, {null()}, int64(), func.get());
+  AddArrayScalarAggKernels(ProductInit::Init, {null().get()}, int64(), func.get());
   DCHECK_OK(registry->AddFunction(std::move(func)));
 
   // any
   func = std::make_shared<ScalarAggregateFunction>("any", Arity::Unary(), any_doc,
                                                    &default_scalar_aggregate_options);
-  AddArrayScalarAggKernels(AnyInit, {boolean()}, boolean(), func.get());
+  AddArrayScalarAggKernels(AnyInit, {boolean().get()}, boolean(), func.get());
   DCHECK_OK(registry->AddFunction(std::move(func)));
 
   // all
   func = std::make_shared<ScalarAggregateFunction>("all", Arity::Unary(), all_doc,
                                                    &default_scalar_aggregate_options);
-  AddArrayScalarAggKernels(AllInit, {boolean()}, boolean(), func.get());
+  AddArrayScalarAggKernels(AllInit, {boolean().get()}, boolean(), func.get());
   DCHECK_OK(registry->AddFunction(std::move(func)));
 
   // index
@@ -1037,8 +1037,13 @@ void RegisterScalarAggregateBasic(FunctionRegistry* registry) {
   AddBasicAggKernels(IndexInit::Init, BaseBinaryTypes(), int64(), func.get());
   AddBasicAggKernels(IndexInit::Init, PrimitiveTypes(), int64(), func.get());
   AddBasicAggKernels(IndexInit::Init, TemporalTypes(), int64(), func.get());
+
+  auto fsb_example = fixed_size_binary(1);
+  auto decimal128_example = decimal128(1, 0);
+  auto decimal256_example = decimal256(1, 0);
   AddBasicAggKernels(IndexInit::Init,
-                     {fixed_size_binary(1), decimal128(1, 0), decimal256(1, 0), null()},
+                     {fsb_example.get(), decimal128_example.get(),
+                      decimal256_example.get(), null().get()},
                      int64(), func.get());
   DCHECK_OK(registry->AddFunction(std::move(func)));
 }

--- a/cpp/src/arrow/compute/kernels/aggregate_basic_avx2.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic_avx2.cc
@@ -37,7 +37,7 @@ struct MeanImplAvx2 : public MeanImpl<ArrowType, SimdLevel::AVX2> {
 Result<std::unique_ptr<KernelState>> SumInitAvx2(KernelContext* ctx,
                                                  const KernelInitArgs& args) {
   SumLikeInit<SumImplAvx2> visitor(
-      ctx, args.inputs[0].GetSharedPtr(),
+      ctx, args.inputs[0].type,
       static_cast<const ScalarAggregateOptions&>(*args.options));
   return visitor.Create();
 }
@@ -45,7 +45,7 @@ Result<std::unique_ptr<KernelState>> SumInitAvx2(KernelContext* ctx,
 Result<std::unique_ptr<KernelState>> MeanInitAvx2(KernelContext* ctx,
                                                   const KernelInitArgs& args) {
   SumLikeInit<MeanImplAvx2> visitor(
-      ctx, args.inputs[0].GetSharedPtr(),
+      ctx, args.inputs[0].type,
       static_cast<const ScalarAggregateOptions&>(*args.options));
   return visitor.Create();
 }

--- a/cpp/src/arrow/compute/kernels/aggregate_basic_avx512.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic_avx512.cc
@@ -37,7 +37,7 @@ struct MeanImplAvx512 : public MeanImpl<ArrowType, SimdLevel::AVX512> {
 Result<std::unique_ptr<KernelState>> SumInitAvx512(KernelContext* ctx,
                                                    const KernelInitArgs& args) {
   SumLikeInit<SumImplAvx512> visitor(
-      ctx, args.inputs[0].GetSharedPtr(),
+      ctx, args.inputs[0].type,
       static_cast<const ScalarAggregateOptions&>(*args.options));
   return visitor.Create();
 }
@@ -45,7 +45,7 @@ Result<std::unique_ptr<KernelState>> SumInitAvx512(KernelContext* ctx,
 Result<std::unique_ptr<KernelState>> MeanInitAvx512(KernelContext* ctx,
                                                     const KernelInitArgs& args) {
   SumLikeInit<MeanImplAvx512> visitor(
-      ctx, args.inputs[0].GetSharedPtr(),
+      ctx, args.inputs[0].type,
       static_cast<const ScalarAggregateOptions&>(*args.options));
   return visitor.Create();
 }
@@ -77,7 +77,8 @@ void AddMeanAvx512AggKernels(ScalarAggregateFunction* func) {
 
 void AddMinMaxAvx512AggKernels(ScalarAggregateFunction* func) {
   // Enable 32/64 int types for avx512 variants, no advantage on 8/16 int.
-  AddMinMaxKernels(MinMaxInitAvx512, {int32(), uint32(), int64(), uint64()}, func,
+  AddMinMaxKernels(MinMaxInitAvx512,
+                   {int32().get(), uint32().get(), int64().get(), uint64().get()}, func,
                    SimdLevel::AVX512);
   AddMinMaxKernels(MinMaxInitAvx512, TemporalTypes(), func, SimdLevel::AVX512);
   AddMinMaxKernels(MinMaxInitAvx512, BaseBinaryTypes(), func, SimdLevel::AVX2);

--- a/cpp/src/arrow/compute/kernels/aggregate_basic_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic_internal.h
@@ -229,7 +229,9 @@ struct SumLikeInit {
   }
 
   Status Visit(const BooleanType&) {
-    state.reset(new KernelClass<BooleanType>(boolean().get(), options));
+    const DataType* ty =
+        TypeTraits<typename KernelClass<BooleanType>::SumType>::type_singleton().get();
+    state.reset(new KernelClass<BooleanType>(ty, options));
     return Status::OK();
   }
 

--- a/cpp/src/arrow/compute/kernels/aggregate_basic_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic_internal.h
@@ -34,12 +34,12 @@ namespace compute {
 namespace internal {
 
 void AddBasicAggKernels(KernelInit init,
-                        const std::vector<std::shared_ptr<DataType>>& types,
+                        const std::vector<const DataType*>& types,
                         std::shared_ptr<DataType> out_ty, ScalarAggregateFunction* func,
                         SimdLevel::type simd_level = SimdLevel::NONE);
 
 void AddMinMaxKernels(KernelInit init,
-                      const std::vector<std::shared_ptr<DataType>>& types,
+                      const std::vector<const DataType*>& types,
                       ScalarAggregateFunction* func,
                       SimdLevel::type simd_level = SimdLevel::NONE);
 void AddMinMaxKernel(KernelInit init, internal::detail::GetTypeId get_id,

--- a/cpp/src/arrow/compute/kernels/aggregate_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_internal.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "arrow/compute/kernels/util_internal.h"
+#include "arrow/compute/kernels/common.h"
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/bit_run_reader.h"

--- a/cpp/src/arrow/compute/kernels/aggregate_mode.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_mode.cc
@@ -454,7 +454,7 @@ VectorKernel NewModeKernel(Type::type in_type, ArrayKernelExec exec,
   kernel.can_execute_chunkwise = false;
   kernel.output_chunked = false;
   kernel.signature = KernelSignature::Make({InputType(in_type)}, ModeType);
-  kernel.exec = std::move(exec);
+  kernel.exec = exec;
   kernel.exec_chunked = exec_chunked;
   return kernel;
 }

--- a/cpp/src/arrow/compute/kernels/aggregate_mode.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_mode.cc
@@ -22,7 +22,6 @@
 #include "arrow/compute/api_aggregate.h"
 #include "arrow/compute/kernels/aggregate_internal.h"
 #include "arrow/compute/kernels/common.h"
-#include "arrow/compute/kernels/util_internal.h"
 #include "arrow/result.h"
 #include "arrow/stl_allocator.h"
 #include "arrow/type_traits.h"

--- a/cpp/src/arrow/compute/kernels/aggregate_quantile.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_quantile.cc
@@ -21,7 +21,6 @@
 
 #include "arrow/compute/api_aggregate.h"
 #include "arrow/compute/kernels/common.h"
-#include "arrow/compute/kernels/util_internal.h"
 #include "arrow/stl_allocator.h"
 
 namespace arrow {

--- a/cpp/src/arrow/compute/kernels/aggregate_tdigest.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_tdigest.cc
@@ -169,8 +169,7 @@ Result<std::unique_ptr<KernelState>> TDigestInit(KernelContext* ctx,
   return visitor.Create();
 }
 
-void AddTDigestKernels(KernelInit init,
-                       const std::vector<const DataType*>& types,
+void AddTDigestKernels(KernelInit init, const std::vector<const DataType*>& types,
                        ScalarAggregateFunction* func) {
   for (const auto& ty : types) {
     auto sig = KernelSignature::Make({InputType(ty->id())}, float64());
@@ -198,8 +197,8 @@ std::shared_ptr<ScalarAggregateFunction> AddTDigestAggKernels() {
   auto func = std::make_shared<ScalarAggregateFunction>(
       "tdigest", Arity::Unary(), tdigest_doc, &default_tdigest_options);
   AddTDigestKernels(TDigestInit, NumericTypes(), func.get());
-  AddTDigestKernels(TDigestInit, {decimal128(1, 1).get(),
-        decimal256(1, 1).get()}, func.get());
+  AddTDigestKernels(TDigestInit, {decimal128(1, 1).get(), decimal256(1, 1).get()},
+                    func.get());
   return func;
 }
 

--- a/cpp/src/arrow/compute/kernels/aggregate_tdigest.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_tdigest.cc
@@ -170,7 +170,7 @@ Result<std::unique_ptr<KernelState>> TDigestInit(KernelContext* ctx,
 }
 
 void AddTDigestKernels(KernelInit init,
-                       const std::vector<std::shared_ptr<DataType>>& types,
+                       const std::vector<const DataType*>& types,
                        ScalarAggregateFunction* func) {
   for (const auto& ty : types) {
     auto sig = KernelSignature::Make({InputType(ty->id())}, float64());
@@ -198,7 +198,8 @@ std::shared_ptr<ScalarAggregateFunction> AddTDigestAggKernels() {
   auto func = std::make_shared<ScalarAggregateFunction>(
       "tdigest", Arity::Unary(), tdigest_doc, &default_tdigest_options);
   AddTDigestKernels(TDigestInit, NumericTypes(), func.get());
-  AddTDigestKernels(TDigestInit, {decimal128(1, 1), decimal256(1, 1)}, func.get());
+  AddTDigestKernels(TDigestInit, {decimal128(1, 1).get(),
+        decimal256(1, 1).get()}, func.get());
   return func;
 }
 

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -962,10 +962,11 @@ class TestCountDistinctKernel : public ::testing::Test {
     EXPECT_THAT(CallFunction("count_distinct", {input}, &all), one);
   }
 
-  void CheckChunkedArr(const std::shared_ptr<DataType>& type,
+  void CheckChunkedArr(const DataType* type,
                        const std::vector<std::string>& json, int64_t expected_all,
                        bool has_nulls = true) {
-    Check(ChunkedArrayFromJSON(type, json), expected_all, has_nulls);
+    Check(ChunkedArrayFromJSON(type->GetSharedPtr(), json), expected_all,
+          has_nulls);
   }
 
   CountOptions only_valid{CountOptions::ONLY_VALID};

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -942,12 +942,12 @@ class TestCountDistinctKernel : public ::testing::Test {
     CheckScalar("count_distinct", {input}, Expected(expected_all), &all);
   }
 
-  void Check(const std::shared_ptr<DataType>& type, util::string_view json,
-             int64_t expected_all, bool has_nulls = true) {
+  void Check(const TypeHolder& type, util::string_view json, int64_t expected_all,
+             bool has_nulls = true) {
     Check(ArrayFromJSON(type, json), expected_all, has_nulls);
   }
 
-  void Check(const std::shared_ptr<DataType>& type, util::string_view json) {
+  void Check(const TypeHolder& type, util::string_view json) {
     auto input = ScalarFromJSON(type, json);
     auto zero = ResultWith(Expected(0));
     auto one = ResultWith(Expected(1));
@@ -962,11 +962,9 @@ class TestCountDistinctKernel : public ::testing::Test {
     EXPECT_THAT(CallFunction("count_distinct", {input}, &all), one);
   }
 
-  void CheckChunkedArr(const DataType* type,
-                       const std::vector<std::string>& json, int64_t expected_all,
-                       bool has_nulls = true) {
-    Check(ChunkedArrayFromJSON(type->GetSharedPtr(), json), expected_all,
-          has_nulls);
+  void CheckChunkedArr(const TypeHolder& type, const std::vector<std::string>& json,
+                       int64_t expected_all, bool has_nulls = true) {
+    Check(ChunkedArrayFromJSON(type, json), expected_all, has_nulls);
   }
 
   CountOptions only_valid{CountOptions::ONLY_VALID};

--- a/cpp/src/arrow/compute/kernels/aggregate_var_std.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_var_std.cc
@@ -207,8 +207,7 @@ struct VarStdInitState {
   const VarianceOptions& options;
   VarOrStd return_type;
 
-  VarStdInitState(KernelContext* ctx, const DataType& in_type,
-                  const DataType* out_type,
+  VarStdInitState(KernelContext* ctx, const DataType& in_type, const DataType* out_type,
                   const VarianceOptions& options, VarOrStd return_type)
       : ctx(ctx),
         in_type(in_type),
@@ -260,8 +259,7 @@ Result<std::unique_ptr<KernelState>> VarianceInit(KernelContext* ctx,
   return visitor.Create();
 }
 
-void AddVarStdKernels(KernelInit init,
-                      const std::vector<const DataType*>& types,
+void AddVarStdKernels(KernelInit init, const std::vector<const DataType*>& types,
                       ScalarAggregateFunction* func) {
   for (const auto& ty : types) {
     auto sig = KernelSignature::Make({InputType(ty->id())}, float64());
@@ -287,16 +285,15 @@ const FunctionDoc variance_doc{
     {"array"},
     "VarianceOptions"};
 
-namespace {
-
-}  // namespace
+namespace {}  // namespace
 
 std::shared_ptr<ScalarAggregateFunction> AddStddevAggKernels() {
   static auto default_std_options = VarianceOptions::Defaults();
   auto func = std::make_shared<ScalarAggregateFunction>("stddev", Arity::Unary(),
                                                         stddev_doc, &default_std_options);
   AddVarStdKernels(StddevInit, NumericTypes(), func.get());
-  AddVarStdKernels(StddevInit, {decimal128(1, 1).get(), decimal256(1, 1).get()}, func.get());
+  AddVarStdKernels(StddevInit, {decimal128(1, 1).get(), decimal256(1, 1).get()},
+                   func.get());
   return func;
 }
 
@@ -305,8 +302,8 @@ std::shared_ptr<ScalarAggregateFunction> AddVarianceAggKernels() {
   auto func = std::make_shared<ScalarAggregateFunction>(
       "variance", Arity::Unary(), variance_doc, &default_var_options);
   AddVarStdKernels(VarianceInit, NumericTypes(), func.get());
-  AddVarStdKernels(VarianceInit, {decimal128(1, 1).get(),
-        decimal256(1, 1).get()}, func.get());
+  AddVarStdKernels(VarianceInit, {decimal128(1, 1).get(), decimal256(1, 1).get()},
+                   func.get());
   return func;
 }
 

--- a/cpp/src/arrow/compute/kernels/base_arithmetic_internal.h
+++ b/cpp/src/arrow/compute/kernels/base_arithmetic_internal.h
@@ -19,7 +19,6 @@
 
 #include "arrow/compute/api_scalar.h"
 #include "arrow/compute/kernels/common.h"
-#include "arrow/compute/kernels/util_internal.h"
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/decimal.h"

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -941,6 +941,8 @@ struct GetTypeId {
       : id(type->id()) {}
   GetTypeId(const DataType& type)  // NOLINT implicit construction
       : id(type.id()) {}
+  GetTypeId(const DataType* type)  // NOLINT implicit construction
+      : id(type->id()) {}
   GetTypeId(Type::type id)  // NOLINT implicit construction
       : id(id) {}
 };

--- a/cpp/src/arrow/compute/kernels/common.h
+++ b/cpp/src/arrow/compute/kernels/common.h
@@ -33,6 +33,7 @@
 #include "arrow/compute/function.h"
 #include "arrow/compute/kernel.h"
 #include "arrow/compute/kernels/codegen_internal.h"
+#include "arrow/compute/kernels/util_internal.h"
 #include "arrow/compute/registry.h"
 #include "arrow/datum.h"
 #include "arrow/memory_pool.h"

--- a/cpp/src/arrow/compute/kernels/hash_aggregate.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate.cc
@@ -2802,7 +2802,7 @@ void PopulateNumericHashKernels(Result<HashAggregateKernel> make_kernel(const Da
         AddHashAggKernels({null().get(), boolean().get()}, make_kernel, func.get()));
   }
   // Type parameters are ignored
-  DCHECK_OK(AddHashAggKernels(decimal_types, GroupedTDigestFactory::Make, func.get()));
+  DCHECK_OK(AddHashAggKernels(decimal_types, make_kernel, func.get()));
   DCHECK_OK(registry->AddFunction(std::move(func)));
 }
 

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -27,7 +27,6 @@
 #include "arrow/compute/cast.h"
 #include "arrow/compute/kernels/base_arithmetic_internal.h"
 #include "arrow/compute/kernels/common.h"
-#include "arrow/compute/kernels/util_internal.h"
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/decimal.h"
@@ -1393,7 +1392,7 @@ std::shared_ptr<ScalarFunction> MakeUnaryArithmeticFunctionWithFixedIntOutType(
   auto int_out_ty = TypeTraits<IntOutType>::type_singleton();
   auto func = std::make_shared<ArithmeticFunction>(name, Arity::Unary(), std::move(doc));
   for (const auto& ty : NumericTypes()) {
-    auto out_ty = arrow::is_floating(ty->id()) ? ty : int_out_ty;
+    const DataType* out_ty = arrow::is_floating(ty->id()) ? ty : int_out_ty.get();
     auto exec = GenerateArithmeticWithFixedIntOutType<ScalarUnary, IntOutType, Op>(ty);
     DCHECK_OK(func->AddKernel({ty}, out_ty, exec));
   }
@@ -1576,7 +1575,7 @@ std::shared_ptr<ScalarFunction> MakeArithmeticFunctionFloatingPointNotNull(
   auto func = std::make_shared<ArithmeticFloatingPointFunction>(name, Arity::Binary(),
                                                                 std::move(doc));
   for (const auto& ty : FloatingPointTypes()) {
-    auto output = is_integer(ty->id()) ? float64() : ty;
+    const DataType* output = is_integer(ty->id()) ? float64().get() : ty;
     auto exec = GenerateArithmeticFloatingPoint<ScalarBinaryNotNullEqualTypes, Op>(ty);
     DCHECK_OK(func->AddKernel({ty, ty}, output, exec));
   }

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -1984,7 +1984,7 @@ void RegisterScalarArithmetic(FunctionRegistry* registry) {
   for (auto unit : TimeUnit::values()) {
     InputType in_type(match::DurationTypeUnit(unit));
     auto exec = ArithmeticExecFromOp<ScalarBinaryEqualTypes, Add>(Type::DURATION);
-    DCHECK_OK(add->AddKernel({in_type, in_type}, duration(unit), std::move(exec)));
+    DCHECK_OK(add->AddKernel({in_type, in_type}, duration(unit), exec));
   }
 
   AddArithmeticFunctionTimeDuration<AddTimeDuration>(add);
@@ -2011,8 +2011,7 @@ void RegisterScalarArithmetic(FunctionRegistry* registry) {
   for (auto unit : TimeUnit::values()) {
     InputType in_type(match::DurationTypeUnit(unit));
     auto exec = ArithmeticExecFromOp<ScalarBinaryEqualTypes, AddChecked>(Type::DURATION);
-    DCHECK_OK(
-        add_checked->AddKernel({in_type, in_type}, duration(unit), std::move(exec)));
+    DCHECK_OK(add_checked->AddKernel({in_type, in_type}, duration(unit), exec));
   }
 
   AddArithmeticFunctionTimeDuration<AddTimeDurationChecked>(add_checked);
@@ -2029,37 +2028,36 @@ void RegisterScalarArithmetic(FunctionRegistry* registry) {
     InputType in_type(match::TimestampTypeUnit(unit));
     auto exec = ArithmeticExecFromOp<ScalarBinaryEqualTypes, Subtract>(Type::TIMESTAMP);
     DCHECK_OK(subtract->AddKernel({in_type, in_type},
-                                  OutputType::Resolver(ResolveTemporalOutput),
-                                  std::move(exec)));
+                                  OutputType::Resolver(ResolveTemporalOutput), exec));
   }
 
   // Add subtract(timestamp, duration) -> timestamp
   for (auto unit : TimeUnit::values()) {
     InputType in_type(match::TimestampTypeUnit(unit));
     auto exec = ScalarBinary<Int64Type, Int64Type, Int64Type, Subtract>::Exec;
-    DCHECK_OK(subtract->AddKernel({in_type, duration(unit)}, OutputType(FirstType),
-                                  std::move(exec)));
+    DCHECK_OK(
+        subtract->AddKernel({in_type, duration(unit)}, OutputType(FirstType), exec));
   }
 
   // Add subtract(duration, duration) -> duration
   for (auto unit : TimeUnit::values()) {
     InputType in_type(match::DurationTypeUnit(unit));
     auto exec = ArithmeticExecFromOp<ScalarBinaryEqualTypes, Subtract>(Type::DURATION);
-    DCHECK_OK(subtract->AddKernel({in_type, in_type}, duration(unit), std::move(exec)));
+    DCHECK_OK(subtract->AddKernel({in_type, in_type}, duration(unit), exec));
   }
 
   // Add subtract(time32, time32) -> duration
   for (auto unit : {TimeUnit::SECOND, TimeUnit::MILLI}) {
     InputType in_type(match::Time32TypeUnit(unit));
     auto exec = ScalarBinaryEqualTypes<Int64Type, Int32Type, Subtract>::Exec;
-    DCHECK_OK(subtract->AddKernel({in_type, in_type}, duration(unit), std::move(exec)));
+    DCHECK_OK(subtract->AddKernel({in_type, in_type}, duration(unit), exec));
   }
 
   // Add subtract(time64, time64) -> duration
   for (auto unit : {TimeUnit::MICRO, TimeUnit::NANO}) {
     InputType in_type(match::Time64TypeUnit(unit));
     auto exec = ScalarBinaryEqualTypes<Int64Type, Int64Type, Subtract>::Exec;
-    DCHECK_OK(subtract->AddKernel({in_type, in_type}, duration(unit), std::move(exec)));
+    DCHECK_OK(subtract->AddKernel({in_type, in_type}, duration(unit), exec));
   }
 
   // Add subtract(date32, date32) -> duration(TimeUnit::SECOND)
@@ -2088,9 +2086,8 @@ void RegisterScalarArithmetic(FunctionRegistry* registry) {
     InputType in_type(match::TimestampTypeUnit(unit));
     auto exec =
         ArithmeticExecFromOp<ScalarBinaryEqualTypes, SubtractChecked>(Type::TIMESTAMP);
-    DCHECK_OK(subtract_checked->AddKernel({in_type, in_type},
-                                          OutputType::Resolver(ResolveTemporalOutput),
-                                          std::move(exec)));
+    DCHECK_OK(subtract_checked->AddKernel(
+        {in_type, in_type}, OutputType::Resolver(ResolveTemporalOutput), exec));
   }
 
   // Add subtract_checked(timestamp, duration) -> timestamp
@@ -2098,7 +2095,7 @@ void RegisterScalarArithmetic(FunctionRegistry* registry) {
     InputType in_type(match::TimestampTypeUnit(unit));
     auto exec = ScalarBinary<Int64Type, Int64Type, Int64Type, SubtractChecked>::Exec;
     DCHECK_OK(subtract_checked->AddKernel({in_type, duration(unit)},
-                                          OutputType(FirstType), std::move(exec)));
+                                          OutputType(FirstType), exec));
   }
 
   // Add subtract_checked(duration, duration) -> duration
@@ -2106,8 +2103,7 @@ void RegisterScalarArithmetic(FunctionRegistry* registry) {
     InputType in_type(match::DurationTypeUnit(unit));
     auto exec =
         ArithmeticExecFromOp<ScalarBinaryEqualTypes, SubtractChecked>(Type::DURATION);
-    DCHECK_OK(
-        subtract_checked->AddKernel({in_type, in_type}, duration(unit), std::move(exec)));
+    DCHECK_OK(subtract_checked->AddKernel({in_type, in_type}, duration(unit), exec));
   }
 
   // Add subtract_checked(date32, date32) -> duration(TimeUnit::SECOND)
@@ -2128,16 +2124,14 @@ void RegisterScalarArithmetic(FunctionRegistry* registry) {
   for (auto unit : {TimeUnit::SECOND, TimeUnit::MILLI}) {
     InputType in_type(match::Time32TypeUnit(unit));
     auto exec = ScalarBinaryEqualTypes<Int64Type, Int32Type, SubtractChecked>::Exec;
-    DCHECK_OK(
-        subtract_checked->AddKernel({in_type, in_type}, duration(unit), std::move(exec)));
+    DCHECK_OK(subtract_checked->AddKernel({in_type, in_type}, duration(unit), exec));
   }
 
   // Add subtract_checked(time64, time64) -> duration
   for (auto unit : {TimeUnit::MICRO, TimeUnit::NANO}) {
     InputType in_type(match::Time64TypeUnit(unit));
     auto exec = ScalarBinaryEqualTypes<Int64Type, Int64Type, SubtractChecked>::Exec;
-    DCHECK_OK(
-        subtract_checked->AddKernel({in_type, in_type}, duration(unit), std::move(exec)));
+    DCHECK_OK(subtract_checked->AddKernel({in_type, in_type}, duration(unit), exec));
   }
 
   AddArithmeticFunctionTimeDuration<SubtractTimeDurationChecked>(subtract_checked);
@@ -2181,8 +2175,7 @@ void RegisterScalarArithmetic(FunctionRegistry* registry) {
   // Add divide(duration, int64) -> duration
   for (auto unit : TimeUnit::values()) {
     auto exec = ScalarBinaryNotNull<Int64Type, Int64Type, Int64Type, Divide>::Exec;
-    DCHECK_OK(
-        divide->AddKernel({duration(unit), int64()}, duration(unit), std::move(exec)));
+    DCHECK_OK(divide->AddKernel({duration(unit), int64()}, duration(unit), exec));
   }
   DCHECK_OK(registry->AddFunction(std::move(divide)));
 
@@ -2194,8 +2187,7 @@ void RegisterScalarArithmetic(FunctionRegistry* registry) {
   // Add divide_checked(duration, int64) -> duration
   for (auto unit : TimeUnit::values()) {
     auto exec = ScalarBinaryNotNull<Int64Type, Int64Type, Int64Type, DivideChecked>::Exec;
-    DCHECK_OK(divide_checked->AddKernel({duration(unit), int64()}, duration(unit),
-                                        std::move(exec)));
+    DCHECK_OK(divide_checked->AddKernel({duration(unit), int64()}, duration(unit), exec));
   }
 
   DCHECK_OK(registry->AddFunction(std::move(divide_checked)));

--- a/cpp/src/arrow/compute/kernels/scalar_cast_dictionary.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_dictionary.cc
@@ -22,8 +22,8 @@
 
 #include "arrow/array/builder_primitive.h"
 #include "arrow/compute/cast_internal.h"
+#include "arrow/compute/kernels/common.h"
 #include "arrow/compute/kernels/scalar_cast_internal.h"
-#include "arrow/compute/kernels/util_internal.h"
 #include "arrow/util/int_util.h"
 
 namespace arrow {

--- a/cpp/src/arrow/compute/kernels/scalar_cast_internal.h
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_internal.h
@@ -21,7 +21,6 @@
 #include "arrow/compute/cast.h"           // IWYU pragma: export
 #include "arrow/compute/cast_internal.h"  // IWYU pragma: export
 #include "arrow/compute/kernels/common.h"
-#include "arrow/compute/kernels/util_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/compute/kernels/scalar_cast_numeric.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_numeric.cc
@@ -677,7 +677,7 @@ std::shared_ptr<CastFunction> GetCastToDecimal128() {
   // Cast from integer
   for (const DataType* in_ty : IntTypes()) {
     auto exec = GenerateInteger<CastFunctor, Decimal128Type>(in_ty->id());
-    DCHECK_OK(func->AddKernel(in_ty->id(), {in_ty}, sig_out_ty, std::move(exec)));
+    DCHECK_OK(func->AddKernel(in_ty->id(), {in_ty}, sig_out_ty, exec));
   }
 
   // Cast from other decimal
@@ -706,7 +706,7 @@ std::shared_ptr<CastFunction> GetCastToDecimal256() {
   // Cast from integer
   for (const DataType* in_ty : IntTypes()) {
     auto exec = GenerateInteger<CastFunctor, Decimal256Type>(in_ty->id());
-    DCHECK_OK(func->AddKernel(in_ty->id(), {in_ty}, sig_out_ty, std::move(exec)));
+    DCHECK_OK(func->AddKernel(in_ty->id(), {in_ty}, sig_out_ty, exec));
   }
 
   // Cast from other decimal

--- a/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
@@ -377,7 +377,7 @@ void AddNumberToStringCasts(CastFunction* func) {
                             NumericToStringCastFunctor<OutType, BooleanType>::Exec,
                             NullHandling::COMPUTED_NO_PREALLOCATE));
 
-  for (const std::shared_ptr<DataType>& in_ty : NumericTypes()) {
+  for (const DataType* in_ty : NumericTypes()) {
     DCHECK_OK(
         func->AddKernel(in_ty->id(), {in_ty}, out_ty,
                         GenerateNumeric<NumericToStringCastFunctor, OutType>(*in_ty),
@@ -388,7 +388,7 @@ void AddNumberToStringCasts(CastFunction* func) {
 template <typename OutType>
 void AddTemporalToStringCasts(CastFunction* func) {
   auto out_ty = TypeTraits<OutType>::type_singleton();
-  for (const std::shared_ptr<DataType>& in_ty : TemporalTypes()) {
+  for (const DataType* in_ty : TemporalTypes()) {
     DCHECK_OK(
         func->AddKernel(in_ty->id(), {InputType(in_ty->id())}, out_ty,
                         GenerateTemporal<TemporalToStringCastFunctor, OutType>(*in_ty),

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -2214,10 +2214,10 @@ static void CheckStructToStruct(const std::vector<const DataType*>& value_types)
     for (const DataType* dest_value_type : value_types) {
       std::vector<std::string> field_names = {"a", "b"};
       std::shared_ptr<Array> a1, b1, a2, b2;
-      a1 = ArrayFromJSON(src_value_type->GetSharedPtr(), "[1, 2, 3, 4, null]");
-      b1 = ArrayFromJSON(src_value_type->GetSharedPtr(), "[null, 7, 8, 9, 0]");
-      a2 = ArrayFromJSON(dest_value_type->GetSharedPtr(), "[1, 2, 3, 4, null]");
-      b2 = ArrayFromJSON(dest_value_type->GetSharedPtr(), "[null, 7, 8, 9, 0]");
+      a1 = ArrayFromJSON(src_value_type, "[1, 2, 3, 4, null]");
+      b1 = ArrayFromJSON(src_value_type, "[null, 7, 8, 9, 0]");
+      a2 = ArrayFromJSON(dest_value_type, "[1, 2, 3, 4, null]");
+      b2 = ArrayFromJSON(dest_value_type, "[null, 7, 8, 9, 0]");
       ASSERT_OK_AND_ASSIGN(auto src, StructArray::Make({a1, b1}, field_names));
       ASSERT_OK_AND_ASSIGN(auto dest, StructArray::Make({a2, b2}, field_names));
 
@@ -2244,20 +2244,18 @@ static void CheckStructToStructSubset(const std::vector<const DataType*>& value_
       std::vector<std::string> field_names = {"a", "b", "c", "d", "e"};
 
       std::shared_ptr<Array> a1, b1, c1, d1, e1;
-      auto sp_src_type = src_value_type->GetSharedPtr();
-      auto sp_dst_type = dest_value_type->GetSharedPtr();
-      a1 = ArrayFromJSON(sp_src_type, "[1, 2, 5]");
-      b1 = ArrayFromJSON(sp_src_type, "[3, 4, 7]");
-      c1 = ArrayFromJSON(sp_src_type, "[9, 11, 44]");
-      d1 = ArrayFromJSON(sp_src_type, "[6, 51, 49]");
-      e1 = ArrayFromJSON(sp_src_type, "[19, 17, 74]");
+      a1 = ArrayFromJSON(src_value_type, "[1, 2, 5]");
+      b1 = ArrayFromJSON(src_value_type, "[3, 4, 7]");
+      c1 = ArrayFromJSON(src_value_type, "[9, 11, 44]");
+      d1 = ArrayFromJSON(src_value_type, "[6, 51, 49]");
+      e1 = ArrayFromJSON(src_value_type, "[19, 17, 74]");
 
       std::shared_ptr<Array> a2, b2, c2, d2, e2;
-      a2 = ArrayFromJSON(sp_dst_type, "[1, 2, 5]");
-      b2 = ArrayFromJSON(sp_dst_type, "[3, 4, 7]");
-      c2 = ArrayFromJSON(sp_dst_type, "[9, 11, 44]");
-      d2 = ArrayFromJSON(sp_dst_type, "[6, 51, 49]");
-      e2 = ArrayFromJSON(sp_dst_type, "[19, 17, 74]");
+      a2 = ArrayFromJSON(dest_value_type, "[1, 2, 5]");
+      b2 = ArrayFromJSON(dest_value_type, "[3, 4, 7]");
+      c2 = ArrayFromJSON(dest_value_type, "[9, 11, 44]");
+      d2 = ArrayFromJSON(dest_value_type, "[6, 51, 49]");
+      e2 = ArrayFromJSON(dest_value_type, "[19, 17, 74]");
 
       ASSERT_OK_AND_ASSIGN(auto src,
                            StructArray::Make({a1, b1, c1, d1, e1}, field_names));
@@ -2345,20 +2343,18 @@ static void CheckStructToStructSubsetWithNulls(
       std::vector<std::string> field_names = {"a", "b", "c", "d", "e"};
 
       std::shared_ptr<Array> a1, b1, c1, d1, e1;
-      auto sp_src_type = src_value_type->GetSharedPtr();
-      auto sp_dst_type = dest_value_type->GetSharedPtr();
-      a1 = ArrayFromJSON(sp_src_type, "[1, 2, 5]");
-      b1 = ArrayFromJSON(sp_src_type, "[3, null, 7]");
-      c1 = ArrayFromJSON(sp_src_type, "[9, 11, 44]");
-      d1 = ArrayFromJSON(sp_src_type, "[6, 51, null]");
-      e1 = ArrayFromJSON(sp_src_type, "[null, 17, 74]");
+      a1 = ArrayFromJSON(src_value_type, "[1, 2, 5]");
+      b1 = ArrayFromJSON(src_value_type, "[3, null, 7]");
+      c1 = ArrayFromJSON(src_value_type, "[9, 11, 44]");
+      d1 = ArrayFromJSON(src_value_type, "[6, 51, null]");
+      e1 = ArrayFromJSON(src_value_type, "[null, 17, 74]");
 
       std::shared_ptr<Array> a2, b2, c2, d2, e2;
-      a2 = ArrayFromJSON(sp_dst_type, "[1, 2, 5]");
-      b2 = ArrayFromJSON(sp_dst_type, "[3, null, 7]");
-      c2 = ArrayFromJSON(sp_dst_type, "[9, 11, 44]");
-      d2 = ArrayFromJSON(sp_dst_type, "[6, 51, null]");
-      e2 = ArrayFromJSON(sp_dst_type, "[null, 17, 74]");
+      a2 = ArrayFromJSON(dest_value_type, "[1, 2, 5]");
+      b2 = ArrayFromJSON(dest_value_type, "[3, null, 7]");
+      c2 = ArrayFromJSON(dest_value_type, "[9, 11, 44]");
+      d2 = ArrayFromJSON(dest_value_type, "[6, 51, null]");
+      e2 = ArrayFromJSON(dest_value_type, "[null, 17, 74]");
 
       std::shared_ptr<Buffer> null_bitmap;
       BitmapFromVector<int>({0, 1, 0}, &null_bitmap);

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -45,7 +45,7 @@
 #include "arrow/compute/api_vector.h"
 #include "arrow/compute/cast.h"
 #include "arrow/compute/kernel.h"
-#include "arrow/compute/kernels/codegen_internal.h"
+#include "arrow/compute/kernels/common.h"
 #include "arrow/compute/kernels/test_util.h"
 
 namespace arrow {
@@ -2209,16 +2209,15 @@ TEST(Cast, ListToListOptionsPassthru) {
   }
 }
 
-static void CheckStructToStruct(
-    const std::vector<std::shared_ptr<DataType>>& value_types) {
-  for (const auto& src_value_type : value_types) {
-    for (const auto& dest_value_type : value_types) {
+static void CheckStructToStruct(const std::vector<const DataType*>& value_types) {
+  for (const DataType* src_value_type : value_types) {
+    for (const DataType* dest_value_type : value_types) {
       std::vector<std::string> field_names = {"a", "b"};
       std::shared_ptr<Array> a1, b1, a2, b2;
-      a1 = ArrayFromJSON(src_value_type, "[1, 2, 3, 4, null]");
-      b1 = ArrayFromJSON(src_value_type, "[null, 7, 8, 9, 0]");
-      a2 = ArrayFromJSON(dest_value_type, "[1, 2, 3, 4, null]");
-      b2 = ArrayFromJSON(dest_value_type, "[null, 7, 8, 9, 0]");
+      a1 = ArrayFromJSON(src_value_type->GetSharedPtr(), "[1, 2, 3, 4, null]");
+      b1 = ArrayFromJSON(src_value_type->GetSharedPtr(), "[null, 7, 8, 9, 0]");
+      a2 = ArrayFromJSON(dest_value_type->GetSharedPtr(), "[1, 2, 3, 4, null]");
+      b2 = ArrayFromJSON(dest_value_type->GetSharedPtr(), "[null, 7, 8, 9, 0]");
       ASSERT_OK_AND_ASSIGN(auto src, StructArray::Make({a1, b1}, field_names));
       ASSERT_OK_AND_ASSIGN(auto dest, StructArray::Make({a2, b2}, field_names));
 
@@ -2237,27 +2236,29 @@ static void CheckStructToStruct(
 }
 
 static void CheckStructToStructSubset(
-    const std::vector<std::shared_ptr<DataType>>& value_types) {
-  for (const auto& src_value_type : value_types) {
+    const std::vector<const DataType*>& value_types) {
+  for (const DataType* src_value_type : value_types) {
     ARROW_SCOPED_TRACE("From type: ", src_value_type->ToString());
-    for (const auto& dest_value_type : value_types) {
+    for (const DataType* dest_value_type : value_types) {
       ARROW_SCOPED_TRACE("To type: ", dest_value_type->ToString());
 
       std::vector<std::string> field_names = {"a", "b", "c", "d", "e"};
 
       std::shared_ptr<Array> a1, b1, c1, d1, e1;
-      a1 = ArrayFromJSON(src_value_type, "[1, 2, 5]");
-      b1 = ArrayFromJSON(src_value_type, "[3, 4, 7]");
-      c1 = ArrayFromJSON(src_value_type, "[9, 11, 44]");
-      d1 = ArrayFromJSON(src_value_type, "[6, 51, 49]");
-      e1 = ArrayFromJSON(src_value_type, "[19, 17, 74]");
+      auto sp_src_type = src_value_type->GetSharedPtr();
+      auto sp_dst_type = dest_value_type->GetSharedPtr();
+      a1 = ArrayFromJSON(sp_src_type, "[1, 2, 5]");
+      b1 = ArrayFromJSON(sp_src_type, "[3, 4, 7]");
+      c1 = ArrayFromJSON(sp_src_type, "[9, 11, 44]");
+      d1 = ArrayFromJSON(sp_src_type, "[6, 51, 49]");
+      e1 = ArrayFromJSON(sp_src_type, "[19, 17, 74]");
 
       std::shared_ptr<Array> a2, b2, c2, d2, e2;
-      a2 = ArrayFromJSON(dest_value_type, "[1, 2, 5]");
-      b2 = ArrayFromJSON(dest_value_type, "[3, 4, 7]");
-      c2 = ArrayFromJSON(dest_value_type, "[9, 11, 44]");
-      d2 = ArrayFromJSON(dest_value_type, "[6, 51, 49]");
-      e2 = ArrayFromJSON(dest_value_type, "[19, 17, 74]");
+      a2 = ArrayFromJSON(sp_dst_type, "[1, 2, 5]");
+      b2 = ArrayFromJSON(sp_dst_type, "[3, 4, 7]");
+      c2 = ArrayFromJSON(sp_dst_type, "[9, 11, 44]");
+      d2 = ArrayFromJSON(sp_dst_type, "[6, 51, 49]");
+      e2 = ArrayFromJSON(sp_dst_type, "[19, 17, 74]");
 
       ASSERT_OK_AND_ASSIGN(auto src,
                            StructArray::Make({a1, b1, c1, d1, e1}, field_names));
@@ -2336,27 +2337,29 @@ static void CheckStructToStructSubset(
 }
 
 static void CheckStructToStructSubsetWithNulls(
-    const std::vector<std::shared_ptr<DataType>>& value_types) {
-  for (const auto& src_value_type : value_types) {
+    const std::vector<const DataType*>& value_types) {
+  for (const DataType* src_value_type : value_types) {
     ARROW_SCOPED_TRACE("From type: ", src_value_type->ToString());
-    for (const auto& dest_value_type : value_types) {
+    for (const DataType* dest_value_type : value_types) {
       ARROW_SCOPED_TRACE("To type: ", dest_value_type->ToString());
 
       std::vector<std::string> field_names = {"a", "b", "c", "d", "e"};
 
       std::shared_ptr<Array> a1, b1, c1, d1, e1;
-      a1 = ArrayFromJSON(src_value_type, "[1, 2, 5]");
-      b1 = ArrayFromJSON(src_value_type, "[3, null, 7]");
-      c1 = ArrayFromJSON(src_value_type, "[9, 11, 44]");
-      d1 = ArrayFromJSON(src_value_type, "[6, 51, null]");
-      e1 = ArrayFromJSON(src_value_type, "[null, 17, 74]");
+      auto sp_src_type = src_value_type->GetSharedPtr();
+      auto sp_dst_type = dest_value_type->GetSharedPtr();
+      a1 = ArrayFromJSON(sp_src_type, "[1, 2, 5]");
+      b1 = ArrayFromJSON(sp_src_type, "[3, null, 7]");
+      c1 = ArrayFromJSON(sp_src_type, "[9, 11, 44]");
+      d1 = ArrayFromJSON(sp_src_type, "[6, 51, null]");
+      e1 = ArrayFromJSON(sp_src_type, "[null, 17, 74]");
 
       std::shared_ptr<Array> a2, b2, c2, d2, e2;
-      a2 = ArrayFromJSON(dest_value_type, "[1, 2, 5]");
-      b2 = ArrayFromJSON(dest_value_type, "[3, null, 7]");
-      c2 = ArrayFromJSON(dest_value_type, "[9, 11, 44]");
-      d2 = ArrayFromJSON(dest_value_type, "[6, 51, null]");
-      e2 = ArrayFromJSON(dest_value_type, "[null, 17, 74]");
+      a2 = ArrayFromJSON(sp_dst_type, "[1, 2, 5]");
+      b2 = ArrayFromJSON(sp_dst_type, "[3, null, 7]");
+      c2 = ArrayFromJSON(sp_dst_type, "[9, 11, 44]");
+      d2 = ArrayFromJSON(sp_dst_type, "[6, 51, null]");
+      e2 = ArrayFromJSON(sp_dst_type, "[null, 17, 74]");
 
       std::shared_ptr<Buffer> null_bitmap;
       BitmapFromVector<int>({0, 1, 0}, &null_bitmap);

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -2235,8 +2235,7 @@ static void CheckStructToStruct(const std::vector<const DataType*>& value_types)
   }
 }
 
-static void CheckStructToStructSubset(
-    const std::vector<const DataType*>& value_types) {
+static void CheckStructToStructSubset(const std::vector<const DataType*>& value_types) {
   for (const DataType* src_value_type : value_types) {
     ARROW_SCOPED_TRACE("From type: ", src_value_type->ToString());
     for (const DataType* dest_value_type : value_types) {

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -328,7 +328,7 @@ ScalarKernel GetCompareKernel(InputType ty, Type::type compare_type,
 }
 
 template <typename Op>
-void AddPrimitiveCompare(const std::shared_ptr<DataType>& ty, ScalarFunction* func) {
+void AddPrimitiveCompare(const DataType* ty, ScalarFunction* func) {
   ArrayKernelExec exec = GeneratePhysicalNumeric<CompareKernel>(ty);
   ScalarKernel kernel = GetCompareKernel<Op>(ty, ty->id(), exec);
   DCHECK_OK(func->AddKernel(kernel));
@@ -392,11 +392,11 @@ std::shared_ptr<ScalarFunction> MakeCompareFunction(std::string name, FunctionDo
       {boolean(), boolean()}, boolean(),
       applicator::ScalarBinary<BooleanType, BooleanType, BooleanType, Op>::Exec));
 
-  for (const std::shared_ptr<DataType>& ty : NumericTypes()) {
+  for (const DataType* ty : NumericTypes()) {
     AddPrimitiveCompare<Op>(ty, func.get());
   }
-  AddPrimitiveCompare<Op>(date32(), func.get());
-  AddPrimitiveCompare<Op>(date64(), func.get());
+  AddPrimitiveCompare<Op>(date32().get(), func.get());
+  AddPrimitiveCompare<Op>(date64().get(), func.get());
 
   // Add timestamp kernels
   for (auto unit : TimeUnit::values()) {
@@ -425,7 +425,7 @@ std::shared_ptr<ScalarFunction> MakeCompareFunction(std::string name, FunctionDo
     DCHECK_OK(func->AddKernel(GetCompareKernel<Op>(in_type, Type::INT64, exec)));
   }
 
-  for (const std::shared_ptr<DataType>& ty : BaseBinaryTypes()) {
+  for (const DataType* ty : BaseBinaryTypes()) {
     auto exec =
         GenerateVarBinaryBase<applicator::ScalarBinaryEqualTypes, BooleanType, Op>(*ty);
     DCHECK_OK(func->AddKernel({ty, ty}, boolean(), std::move(exec)));

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -428,20 +428,19 @@ std::shared_ptr<ScalarFunction> MakeCompareFunction(std::string name, FunctionDo
   for (const DataType* ty : BaseBinaryTypes()) {
     auto exec =
         GenerateVarBinaryBase<applicator::ScalarBinaryEqualTypes, BooleanType, Op>(*ty);
-    DCHECK_OK(func->AddKernel({ty, ty}, boolean(), std::move(exec)));
+    DCHECK_OK(func->AddKernel({ty, ty}, boolean(), exec));
   }
 
   for (const auto id : {Type::DECIMAL128, Type::DECIMAL256}) {
     auto exec = GenerateDecimal<applicator::ScalarBinaryEqualTypes, BooleanType, Op>(id);
-    DCHECK_OK(
-        func->AddKernel({InputType(id), InputType(id)}, boolean(), std::move(exec)));
+    DCHECK_OK(func->AddKernel({InputType(id), InputType(id)}, boolean(), exec));
   }
 
   {
     auto exec =
         applicator::ScalarBinaryEqualTypes<BooleanType, FixedSizeBinaryType, Op>::Exec;
     auto ty = InputType(Type::FIXED_SIZE_BINARY);
-    DCHECK_OK(func->AddKernel({ty, ty}, boolean(), std::move(exec)));
+    DCHECK_OK(func->AddKernel({ty, ty}, boolean(), exec));
   }
 
   return func;

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -2663,7 +2663,7 @@ void AddPrimitiveCaseWhenKernels(const std::shared_ptr<CaseWhenFunction>& scalar
                                  const std::vector<const DataType*>& types) {
   for (auto&& type : types) {
     auto exec = GenerateTypeAgnosticPrimitive<CaseWhenFunctor>(*type);
-    AddCaseWhenKernel(scalar_function, type, std::move(exec));
+    AddCaseWhenKernel(scalar_function, type, exec);
   }
 }
 
@@ -2671,7 +2671,7 @@ void AddBinaryCaseWhenKernels(const std::shared_ptr<CaseWhenFunction>& scalar_fu
                               const std::vector<const DataType*>& types) {
   for (auto&& type : types) {
     auto exec = GenerateTypeAgnosticVarBinaryBase<CaseWhenFunctor>(*type);
-    AddCaseWhenKernel(scalar_function, type, std::move(exec));
+    AddCaseWhenKernel(scalar_function, type, exec);
   }
 }
 
@@ -2690,7 +2690,7 @@ void AddPrimitiveCoalesceKernels(const std::shared_ptr<ScalarFunction>& scalar_f
                                  const std::vector<const DataType*>& types) {
   for (auto&& type : types) {
     auto exec = GenerateTypeAgnosticPrimitive<CoalesceFunctor>(*type);
-    AddCoalesceKernel(scalar_function, type, std::move(exec));
+    AddCoalesceKernel(scalar_function, type, exec);
   }
 }
 
@@ -2709,7 +2709,7 @@ void AddPrimitiveChooseKernels(const std::shared_ptr<ScalarFunction>& scalar_fun
                                const std::vector<const DataType*>& types) {
   for (auto&& type : types) {
     auto exec = GenerateTypeAgnosticPrimitive<ChooseFunctor>(*type);
-    AddChooseKernel(scalar_function, type, std::move(exec));
+    AddChooseKernel(scalar_function, type, exec);
   }
 }
 

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
@@ -23,6 +23,7 @@
 #include "arrow/array/concatenate.h"
 #include "arrow/compute/api_scalar.h"
 #include "arrow/compute/cast.h"
+#include "arrow/compute/kernels/common.h"
 #include "arrow/compute/kernels/test_util.h"
 #include "arrow/compute/registry.h"
 #include "arrow/testing/gtest_util.h"
@@ -381,18 +382,19 @@ TEST_F(TestIfElseKernel, TimestampTypes) {
 }
 
 TEST_F(TestIfElseKernel, TemporalTypes) {
-  for (const auto& ty : TemporalTypes()) {
+  for (const DataType* ty : TemporalTypes()) {
+    auto shared_ty = ty->GetSharedPtr();
     if (ty->name() == "date64") {
       CheckWithDifferentShapes(
           ArrayFromJSON(boolean(), "[true, true, true, false]"),
-          ArrayFromJSON(ty, "[86400000, 172800000, 259200000, 4]"),
-          ArrayFromJSON(ty, "[5, 6, 7, 691200000]"),
-          ArrayFromJSON(ty, "[86400000, 172800000, 259200000, 691200000]"));
+          ArrayFromJSON(shared_ty, "[86400000, 172800000, 259200000, 4]"),
+          ArrayFromJSON(shared_ty, "[5, 6, 7, 691200000]"),
+          ArrayFromJSON(shared_ty, "[86400000, 172800000, 259200000, 691200000]"));
     } else {
       CheckWithDifferentShapes(ArrayFromJSON(boolean(), "[true, true, true, false]"),
-                               ArrayFromJSON(ty, "[1, 2, 3, 4]"),
-                               ArrayFromJSON(ty, "[5, 6, 7, 8]"),
-                               ArrayFromJSON(ty, "[1, 2, 3, 8]"));
+                               ArrayFromJSON(shared_ty, "[1, 2, 3, 4]"),
+                               ArrayFromJSON(shared_ty, "[5, 6, 7, 8]"),
+                               ArrayFromJSON(shared_ty, "[1, 2, 3, 8]"));
     }
   }
 }

--- a/cpp/src/arrow/compute/kernels/scalar_nested_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_nested_test.cc
@@ -19,6 +19,7 @@
 
 #include "arrow/chunked_array.h"
 #include "arrow/compute/api.h"
+#include "arrow/compute/kernels/common.h"
 #include "arrow/compute/kernels/test_util.h"
 #include "arrow/result.h"
 #include "arrow/testing/gtest_util.h"
@@ -28,7 +29,7 @@
 namespace arrow {
 namespace compute {
 
-static std::shared_ptr<DataType> GetOffsetType(const DataType& type) {
+static std::shared_ptr<DtaType> GetOffsetType(const DataType& type) {
   return type.id() == Type::LIST ? int32() : int64();
 }
 

--- a/cpp/src/arrow/compute/kernels/scalar_nested_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_nested_test.cc
@@ -29,7 +29,7 @@
 namespace arrow {
 namespace compute {
 
-static std::shared_ptr<DtaType> GetOffsetType(const DataType& type) {
+static std::shared_ptr<DataType> GetOffsetType(const DataType& type) {
   return type.id() == Type::LIST ? int32() : int64();
 }
 
@@ -46,8 +46,8 @@ TEST(TestScalarNested, ListValueLength) {
 
 TEST(TestScalarNested, ListElementNonFixedListWithNulls) {
   auto sample = "[[7, 5, 81], [6, null, 4, 7, 8], [3, 12, 2, 0], [1, 9], null]";
-  for (auto ty : NumericTypes()) {
-    for (auto list_type : {list(ty), large_list(ty)}) {
+  for (const DataType* ty : NumericTypes()) {
+    for (auto list_type : {list(ty->GetSharedPtr()), large_list(ty->GetSharedPtr())}) {
       auto input = ArrayFromJSON(list_type, sample);
       auto null_input = ArrayFromJSON(list_type, "[null]");
       for (auto index_type : IntTypes()) {
@@ -64,7 +64,7 @@ TEST(TestScalarNested, ListElementNonFixedListWithNulls) {
 TEST(TestScalarNested, ListElementFixedList) {
   auto sample = "[[7, 5, 81], [6, 4, 8], [3, 12, 2], [1, 43, 87]]";
   for (auto ty : NumericTypes()) {
-    auto input = ArrayFromJSON(fixed_size_list(ty, 3), sample);
+    auto input = ArrayFromJSON(fixed_size_list(ty->GetSharedPtr(), 3), sample);
     for (auto index_type : IntTypes()) {
       auto index = ScalarFromJSON(index_type, "0");
       auto expected = ArrayFromJSON(ty, "[7, 6, 3, 1]");

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
@@ -19,7 +19,6 @@
 #include "arrow/compute/api_scalar.h"
 #include "arrow/compute/cast.h"
 #include "arrow/compute/kernels/common.h"
-#include "arrow/compute/kernels/util_internal.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_writer.h"
 #include "arrow/util/hashing.h"
@@ -418,8 +417,8 @@ Status ExecIsIn(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
 void AddBasicSetLookupKernels(ScalarKernel kernel,
                               const std::shared_ptr<DataType>& out_ty,
                               ScalarFunction* func) {
-  auto AddKernels = [&](const std::vector<std::shared_ptr<DataType>>& types) {
-    for (const std::shared_ptr<DataType>& ty : types) {
+  auto AddKernels = [&](const std::vector<const DataType*>& types) {
+    for (const DataType* ty : types) {
       kernel.signature = KernelSignature::Make({InputType(ty->id())}, out_ty);
       DCHECK_OK(func->AddKernel(kernel));
     }
@@ -428,7 +427,7 @@ void AddBasicSetLookupKernels(ScalarKernel kernel,
   AddKernels(BaseBinaryTypes());
   AddKernels(NumericTypes());
   AddKernels(TemporalTypes());
-  AddKernels({month_day_nano_interval()});
+  AddKernels({month_day_nano_interval().get()});
 
   std::vector<Type::type> other_types = {Type::BOOL, Type::DECIMAL128, Type::DECIMAL256,
                                          Type::FIXED_SIZE_BINARY};

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
@@ -152,11 +152,12 @@ class TestIsInKernelPrimitive : public ::testing::Test {};
 template <typename Type>
 class TestIsInKernelBinary : public ::testing::Test {};
 
-using PrimitiveTypes = ::testing::Types<Int8Type, UInt8Type, Int16Type, UInt16Type,
-                                        Int32Type, UInt32Type, Int64Type, UInt64Type,
-                                        FloatType, DoubleType, Date32Type, Date64Type>;
+using PrimitiveTypeCases =
+    ::testing::Types<Int8Type, UInt8Type, Int16Type, UInt16Type, Int32Type, UInt32Type,
+                     Int64Type, UInt64Type, FloatType, DoubleType, Date32Type,
+                     Date64Type>;
 
-TYPED_TEST_SUITE(TestIsInKernelPrimitive, PrimitiveTypes);
+TYPED_TEST_SUITE(TestIsInKernelPrimitive, PrimitiveTypeCases);
 
 TYPED_TEST(TestIsInKernelPrimitive, IsIn) {
   auto type = TypeTraits<TypeParam>::type_singleton();

--- a/cpp/src/arrow/compute/kernels/scalar_string_ascii.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_ascii.cc
@@ -2476,8 +2476,8 @@ void AddAsciiStringSplitPattern(FunctionRegistry* registry) {
                                                split_pattern_doc);
   for (const auto& ty : BaseBinaryTypes()) {
     auto exec = GenerateVarBinaryToVarBinary<SplitPatternExec, ListType>(ty);
-    DCHECK_OK(
-        func->AddKernel({ty}, {list(ty)}, std::move(exec), SplitPatternState::Init));
+    DCHECK_OK(func->AddKernel({ty}, {list(ty->GetSharedPtr())}, std::move(exec),
+                              SplitPatternState::Init));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
 }
@@ -2547,7 +2547,8 @@ void AddAsciiStringSplitWhitespace(FunctionRegistry* registry) {
 
   for (const auto& ty : StringTypes()) {
     auto exec = GenerateVarBinaryToVarBinary<SplitWhitespaceAsciiExec, ListType>(ty);
-    DCHECK_OK(func->AddKernel({ty}, {list(ty)}, std::move(exec), StringSplitState::Init));
+    DCHECK_OK(func->AddKernel({ty}, {list(ty->GetSharedPtr())}, std::move(exec),
+                              StringSplitState::Init));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
 }
@@ -2614,10 +2615,10 @@ const FunctionDoc split_pattern_regex_doc(
 void AddAsciiStringSplitRegex(FunctionRegistry* registry) {
   auto func = std::make_shared<ScalarFunction>("split_pattern_regex", Arity::Unary(),
                                                split_pattern_regex_doc);
-  for (const auto& ty : BaseBinaryTypes()) {
+  for (const DataType* ty : BaseBinaryTypes()) {
     auto exec = GenerateVarBinaryToVarBinary<SplitRegexExec, ListType>(ty);
-    DCHECK_OK(
-        func->AddKernel({ty}, {list(ty)}, std::move(exec), SplitPatternState::Init));
+    DCHECK_OK(func->AddKernel({ty}, {list(ty->GetSharedPtr())}, std::move(exec),
+                              SplitPatternState::Init));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
 }
@@ -3016,10 +3017,10 @@ const JoinOptions* GetDefaultJoinOptions() {
 
 template <typename ListType>
 void AddBinaryJoinForListType(ScalarFunction* func) {
-  for (const auto& ty : BaseBinaryTypes()) {
+  for (const DataType* ty : BaseBinaryTypes()) {
     auto exec =
         GenerateTypeAgnosticVarBinaryBase<BinaryJoin, ArrayKernelExec, ListType>(*ty);
-    auto list_ty = std::make_shared<ListType>(ty);
+    auto list_ty = std::make_shared<ListType>(ty->GetSharedPtr());
     DCHECK_OK(func->AddKernel({InputType(list_ty), InputType(ty)}, ty, std::move(exec)));
   }
 }

--- a/cpp/src/arrow/compute/kernels/scalar_string_internal.h
+++ b/cpp/src/arrow/compute/kernels/scalar_string_internal.h
@@ -152,7 +152,7 @@ void MakeUnaryStringBatchKernel(
   auto func = std::make_shared<ScalarFunction>(name, Arity::Unary(), std::move(doc));
   for (const auto& ty : StringTypes()) {
     auto exec = GenerateVarBinaryToVarBinary<ExecFunctor>(ty);
-    ScalarKernel kernel{{ty}, ty, std::move(exec)};
+    ScalarKernel kernel{{ty}, ty, exec};
     kernel.mem_allocation = mem_allocation;
     DCHECK_OK(func->AddKernel(std::move(kernel)));
   }
@@ -238,7 +238,7 @@ void AddUnaryStringPredicate(std::string name, FunctionRegistry* registry,
   auto func = std::make_shared<ScalarFunction>(name, Arity::Unary(), std::move(doc));
   for (const auto& ty : StringTypes()) {
     auto exec = GenerateVarBinaryToVarBinary<StringPredicateFunctor, Predicate>(ty);
-    DCHECK_OK(func->AddKernel({ty}, boolean(), std::move(exec)));
+    DCHECK_OK(func->AddKernel({ty}, boolean(), exec));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
 }
@@ -409,6 +409,8 @@ struct StringSplitExec {
 };
 
 using StringSplitState = OptionsWrapper<SplitOptions>;
+
+Result<TypeHolder> OutputListOf(KernelContext*, const std::vector<TypeHolder>& types);
 
 }  // namespace internal
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -1140,7 +1140,7 @@ TYPED_TEST(TestStringKernels, BinaryRepeatWithScalarRepeat) {
   for (const auto& pair : nrepeats_and_expected) {
     auto num_repeat = pair.first;
     auto expected = pair.second;
-    for (const auto& ty : IntTypes()) {
+    for (const DataType* ty : IntTypes()) {
       this->CheckVarArgs("binary_repeat",
                          {values, Datum(*arrow::MakeScalar(ty, num_repeat))},
                          this->type(), expected);

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -28,7 +28,7 @@
 #endif
 
 #include "arrow/compute/api_scalar.h"
-#include "arrow/compute/kernels/codegen_internal.h"
+#include "arrow/compute/kernels/common.h"
 #include "arrow/compute/kernels/test_util.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/type.h"

--- a/cpp/src/arrow/compute/kernels/scalar_string_utf8.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_utf8.cc
@@ -43,7 +43,7 @@ void MakeUnaryStringUTF8TransformKernel(std::string name, FunctionRegistry* regi
   auto func = std::make_shared<ScalarFunction>(name, Arity::Unary(), std::move(doc));
   for (const DataType* ty : StringTypes()) {
     auto exec = GenerateVarBinaryToVarBinary<Transformer>(ty);
-    DCHECK_OK(func->AddKernel({ty}, ty, std::move(exec)));
+    DCHECK_OK(func->AddKernel({ty}, ty, exec));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
 }
@@ -675,12 +675,12 @@ void AddUtf8StringLength(FunctionRegistry* registry) {
       std::make_shared<ScalarFunction>("utf8_length", Arity::Unary(), utf8_length_doc);
   {
     auto exec = applicator::ScalarUnaryNotNull<Int32Type, StringType, Utf8Length>::Exec;
-    DCHECK_OK(func->AddKernel({utf8()}, int32(), std::move(exec)));
+    DCHECK_OK(func->AddKernel({utf8()}, int32(), exec));
   }
   {
     auto exec =
         applicator::ScalarUnaryNotNull<Int64Type, LargeStringType, Utf8Length>::Exec;
-    DCHECK_OK(func->AddKernel({large_utf8()}, int64(), std::move(exec)));
+    DCHECK_OK(func->AddKernel({large_utf8()}, int64(), exec));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
 }
@@ -1073,8 +1073,8 @@ void AddUtf8StringReplaceSlice(FunctionRegistry* registry) {
 
   for (const DataType* ty : StringTypes()) {
     auto exec = GenerateVarBinaryToVarBinary<Utf8ReplaceSlice>(ty);
-    DCHECK_OK(func->AddKernel({ty}, ty, std::move(exec),
-                              ReplaceStringSliceTransformBase::State::Init));
+    DCHECK_OK(
+        func->AddKernel({ty}, ty, exec, ReplaceStringSliceTransformBase::State::Init));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
 }
@@ -1261,8 +1261,7 @@ void AddUtf8StringSlice(FunctionRegistry* registry) {
                                                utf8_slice_codeunits_doc);
   for (const DataType* ty : StringTypes()) {
     auto exec = GenerateVarBinaryToVarBinary<SliceCodeunits>(ty);
-    DCHECK_OK(
-        func->AddKernel({ty}, ty, std::move(exec), SliceCodeunitsTransform::State::Init));
+    DCHECK_OK(func->AddKernel({ty}, ty, exec, SliceCodeunitsTransform::State::Init));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
 }
@@ -1347,8 +1346,7 @@ void AddUtf8StringSplitWhitespace(FunctionRegistry* registry) {
                                        utf8_split_whitespace_doc, &default_options);
   for (const DataType* ty : StringTypes()) {
     auto exec = GenerateVarBinaryToVarBinary<SplitWhitespaceUtf8Exec, ListType>(ty);
-    DCHECK_OK(func->AddKernel({ty}, {list(ty->GetSharedPtr())}, std::move(exec),
-                              StringSplitState::Init));
+    DCHECK_OK(func->AddKernel({ty}, OutputListOf, exec, StringSplitState::Init));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
 }

--- a/cpp/src/arrow/compute/kernels/scalar_string_utf8.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_utf8.cc
@@ -41,7 +41,7 @@ template <template <typename> class Transformer>
 void MakeUnaryStringUTF8TransformKernel(std::string name, FunctionRegistry* registry,
                                         FunctionDoc doc) {
   auto func = std::make_shared<ScalarFunction>(name, Arity::Unary(), std::move(doc));
-  for (const auto& ty : StringTypes()) {
+  for (const DataType* ty : StringTypes()) {
     auto exec = GenerateVarBinaryToVarBinary<Transformer>(ty);
     DCHECK_OK(func->AddKernel({ty}, ty, std::move(exec)));
   }
@@ -1071,7 +1071,7 @@ void AddUtf8StringReplaceSlice(FunctionRegistry* registry) {
   auto func = std::make_shared<ScalarFunction>("utf8_replace_slice", Arity::Unary(),
                                                utf8_replace_slice_doc);
 
-  for (const auto& ty : StringTypes()) {
+  for (const DataType* ty : StringTypes()) {
     auto exec = GenerateVarBinaryToVarBinary<Utf8ReplaceSlice>(ty);
     DCHECK_OK(func->AddKernel({ty}, ty, std::move(exec),
                               ReplaceStringSliceTransformBase::State::Init));
@@ -1259,7 +1259,7 @@ const FunctionDoc utf8_slice_codeunits_doc(
 void AddUtf8StringSlice(FunctionRegistry* registry) {
   auto func = std::make_shared<ScalarFunction>("utf8_slice_codeunits", Arity::Unary(),
                                                utf8_slice_codeunits_doc);
-  for (const auto& ty : StringTypes()) {
+  for (const DataType* ty : StringTypes()) {
     auto exec = GenerateVarBinaryToVarBinary<SliceCodeunits>(ty);
     DCHECK_OK(
         func->AddKernel({ty}, ty, std::move(exec), SliceCodeunitsTransform::State::Init));
@@ -1345,9 +1345,10 @@ void AddUtf8StringSplitWhitespace(FunctionRegistry* registry) {
   auto func =
       std::make_shared<ScalarFunction>("utf8_split_whitespace", Arity::Unary(),
                                        utf8_split_whitespace_doc, &default_options);
-  for (const auto& ty : StringTypes()) {
+  for (const DataType* ty : StringTypes()) {
     auto exec = GenerateVarBinaryToVarBinary<SplitWhitespaceUtf8Exec, ListType>(ty);
-    DCHECK_OK(func->AddKernel({ty}, {list(ty)}, std::move(exec), StringSplitState::Init));
+    DCHECK_OK(func->AddKernel({ty}, {list(ty->GetSharedPtr())}, std::move(exec),
+                              StringSplitState::Init));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
 }

--- a/cpp/src/arrow/compute/kernels/scalar_temporal_binary.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_binary.cc
@@ -340,7 +340,7 @@ struct BinaryTemporalFactory {
   template <typename Duration, typename InType>
   void AddKernel(InputType in_type) {
     auto exec = ExecTemplate<Op, Duration, InType, OutType>::Exec;
-    DCHECK_OK(func->AddKernel({in_type, in_type}, out_type, std::move(exec), init));
+    DCHECK_OK(func->AddKernel({in_type, in_type}, out_type, exec, init));
   }
 };
 

--- a/cpp/src/arrow/compute/kernels/scalar_validity_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_validity_test.cc
@@ -19,6 +19,7 @@
 
 #include "arrow/array.h"
 #include "arrow/compute/api.h"
+#include "arrow/compute/kernels/common.h"
 #include "arrow/compute/kernels/test_util.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/random.h"

--- a/cpp/src/arrow/compute/kernels/util_internal.cc
+++ b/cpp/src/arrow/compute/kernels/util_internal.cc
@@ -50,5 +50,132 @@ int64_t GetTrueCount(const ArraySpan& mask) {
 }
 
 }  // namespace internal
+
+namespace {
+
+std::vector<const DataType*> g_signed_int_types;
+std::vector<const DataType*> g_unsigned_int_types;
+std::vector<const DataType*> g_int_types;
+std::vector<const DataType*> g_floating_types;
+std::vector<const DataType*> g_numeric_types;
+std::vector<const DataType*> g_temporal_types;
+std::vector<const DataType*> g_base_binary_types;
+std::vector<const DataType*> g_internal_types;
+std::vector<const DataType*> g_primitive_types;
+
+std::once_flag static_data_initialized;
+
+template <typename T>
+void Extend(const std::vector<T>& values, std::vector<T>* out) {
+  out->insert(out->end(), values.begin(), values.end());
+}
+
+void InitStaticData() {
+  // Signed int types
+  g_signed_int_types = {int8().get(), int16().get(), int32().get(),
+                             int64().get()};
+
+  // Unsigned int types
+  g_unsigned_int_types = {uint8().get(), uint16().get(), uint32().get(),
+                               uint64().get()};
+
+  // All int types
+  Extend(g_unsigned_int_types, &g_int_types);
+  Extend(g_signed_int_types, &g_int_types);
+
+  // Floating point types
+  g_floating_types = {float32().get(), float64().get()};
+
+  // Numeric types
+  Extend(g_int_types, &g_numeric_types);
+  Extend(g_floating_types, &g_numeric_types);
+
+  // Temporal types
+  g_temporal_types = {date32().get(),
+                      date64().get(),
+                      time32(TimeUnit::SECOND).get(),
+                      time32(TimeUnit::MILLI).get(),
+                      time64(TimeUnit::MICRO).get(),
+                      time64(TimeUnit::NANO).get(),
+                      timestamp(TimeUnit::SECOND).get(),
+                      timestamp(TimeUnit::MILLI).get(),
+                      timestamp(TimeUnit::MICRO).get(),
+                      timestamp(TimeUnit::NANO).get()};
+
+  // Interval types
+  g_interval_types = {day_time_interval().get(), month_interval().get(), month_day_nano_interval().get()};
+
+  // Base binary types (without FixedSizeBinary)
+  g_base_binary_types = {binary().get(), utf8().get(), large_binary().get(), large_utf8().get()};
+
+  // Non-parametric, non-nested types. This also DOES NOT include
+  //
+  // * Decimal
+  // * Fixed Size Binary
+  // * Time32
+  // * Time64
+  // * Timestamp
+  g_primitive_types = {null().get(), boolean().get(), date32().get(), date64().get()};
+  Extend(g_numeric_types, &g_primitive_types);
+  Extend(g_base_binary_types, &g_primitive_types);
+}
+
+}  // namespace
+
+const std::vector<const DataType*>& BaseBinaryTypes() {
+  std::call_once(static_data_initialized, InitStaticData);
+  return g_base_binary_types;
+}
+
+const std::vector<const DataType*>& BinaryTypes() {
+  static std::vector<const DataType*> types = {binary().get(), large_binary().get()};
+  return types;
+}
+
+const std::vector<const DataType*>& StringTypes() {
+  static std::vector<const DataType*> types = {utf8().get(), large_utf8().get()};
+  return types;
+}
+
+const std::vector<const DataType*>& SignedIntTypes() {
+  std::call_once(static_data_initialized, InitStaticData);
+  return g_signed_int_types;
+}
+
+const std::vector<const DataType*>& UnsignedIntTypes() {
+  std::call_once(static_data_initialized, InitStaticData);
+  return g_unsigned_int_types;
+}
+
+const std::vector<const DataType*>& IntTypes() {
+  std::call_once(static_data_initialized, InitStaticData);
+  return g_int_types;
+}
+
+const std::vector<const DataType*>& FloatingPointTypes() {
+  std::call_once(static_data_initialized, InitStaticData);
+  return g_floating_types;
+}
+
+const std::vector<const DataType*>& NumericTypes() {
+  std::call_once(static_data_initialized, InitStaticData);
+  return g_numeric_types;
+}
+
+const std::vector<const DataType*>& TemporalTypes() {
+  std::call_once(static_data_initialized, InitStaticData);
+  return g_temporal_types;
+}
+
+const std::vector<const DataType*>& IntervalTypes() {
+  std::call_once(static_data_initialized, InitStaticData);
+  return g_interval_types;
+}
+
+const std::vector<const DataType*>& PrimitiveTypes() {
+  std::call_once(static_data_initialized, InitStaticData);
+  return g_primitive_types;
+}
+
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/util_internal.cc
+++ b/cpp/src/arrow/compute/kernels/util_internal.cc
@@ -199,7 +199,7 @@ struct PhysicalTypeVisitor {
 }  // namespace
 
 const DataType* GetPhysicalType(const DataType* real_type) {
-  PhysicalTypeVisitor visitor{real_type, {}};
+  PhysicalTypeVisitor visitor{real_type, nullptr};
   ARROW_CHECK_OK(VisitTypeInline(*real_type, &visitor));
   return visitor.result;
 }

--- a/cpp/src/arrow/compute/kernels/util_internal.h
+++ b/cpp/src/arrow/compute/kernels/util_internal.h
@@ -168,5 +168,17 @@ const std::vector<const DataType*>& IntervalTypes();
 ARROW_EXPORT
 const std::vector<const DataType*>& PrimitiveTypes();
 
+/// \brief Return the compatible physical data type
+///
+/// Some types may have distinct logical meanings but the exact same physical
+/// representation.  For example, TimestampType has Int64Type as a physical
+/// type (defined as TimestampType::PhysicalType).
+///
+/// The return value is as follows:
+/// - if a `PhysicalType` alias exists in the concrete type class, return
+///   an instance of `PhysicalType`.
+/// - otherwise, return the input type itself.
+const DataType* GetPhysicalType(const DataType* type);
+
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/util_internal.h
+++ b/cpp/src/arrow/compute/kernels/util_internal.h
@@ -137,5 +137,36 @@ ExecValue GetExecValue(const Datum& value);
 int64_t GetTrueCount(const ArraySpan& mask);
 
 }  // namespace internal
+
+// Helpers to get instances of data types based on general categories
+
+ARROW_EXPORT
+const std::vector<const DataType*>& SignedIntTypes();
+ARROW_EXPORT
+const std::vector<const DataType*>& UnsignedIntTypes();
+ARROW_EXPORT
+const std::vector<const DataType*>& IntTypes();
+ARROW_EXPORT
+const std::vector<const DataType*>& FloatingPointTypes();
+// Number types without boolean
+ARROW_EXPORT
+const std::vector<const DataType*>& NumericTypes();
+// Binary and string-like types (except fixed-size binary)
+ARROW_EXPORT
+const std::vector<const DataType*>& BaseBinaryTypes();
+ARROW_EXPORT
+const std::vector<const DataType*>& BinaryTypes();
+ARROW_EXPORT
+const std::vector<const DataType*>& StringTypes();
+// Temporal types including time and timestamps for each unit
+ARROW_EXPORT
+const std::vector<const DataType*>& TemporalTypes();
+// Interval types
+ARROW_EXPORT
+const std::vector<const DataType*>& IntervalTypes();
+// Integer, floating point, base binary, and temporal
+ARROW_EXPORT
+const std::vector<const DataType*>& PrimitiveTypes();
+
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/vector_cumulative_ops.cc
+++ b/cpp/src/arrow/compute/kernels/vector_cumulative_ops.cc
@@ -181,10 +181,7 @@ void MakeVectorCumulativeFunction(FunctionRegistry* registry, const std::string 
   auto func =
       std::make_shared<VectorFunction>(func_name, Arity::Unary(), doc, &kDefaultOptions);
 
-  std::vector<std::shared_ptr<DataType>> types;
-  types.insert(types.end(), NumericTypes().begin(), NumericTypes().end());
-
-  for (const auto& ty : types) {
+  for (const DataType* ty : NumericTypes()) {
     VectorKernel kernel;
     kernel.can_execute_chunkwise = false;
     kernel.null_handling = NullHandling::type::COMPUTED_NO_PREALLOCATE;

--- a/cpp/src/arrow/compute/kernels/vector_cumulative_ops_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_cumulative_ops_test.cc
@@ -29,6 +29,7 @@
 
 #include "arrow/array/builder_primitive.h"
 #include "arrow/compute/api.h"
+#include "arrow/compute/kernels/common.h"
 #include "arrow/compute/kernels/test_util.h"
 
 namespace arrow {
@@ -36,7 +37,7 @@ namespace compute {
 
 TEST(TestCumulativeSum, Empty) {
   CumulativeSumOptions options;
-  for (auto ty : NumericTypes()) {
+  for (const DataType* ty : NumericTypes()) {
     auto empty_arr = ArrayFromJSON(ty, "[]");
     auto empty_chunked = ChunkedArrayFromJSON(ty, {"[]"});
     CheckVectorUnary("cumulative_sum", empty_arr, empty_arr, &options);
@@ -49,7 +50,7 @@ TEST(TestCumulativeSum, Empty) {
 
 TEST(TestCumulativeSum, AllNulls) {
   CumulativeSumOptions options;
-  for (auto ty : NumericTypes()) {
+  for (const DataType* ty : NumericTypes()) {
     auto nulls_arr = ArrayFromJSON(ty, "[null, null, null]");
     auto nulls_one_chunk = ChunkedArrayFromJSON(ty, {"[null, null, null]"});
     auto nulls_three_chunks = ChunkedArrayFromJSON(ty, {"[null]", "[null]", "[null]"});
@@ -72,7 +73,7 @@ TEST(TestCumulativeSum, ScalarInput) {
   CumulativeSumOptions has_start_no_skip(10);
   CumulativeSumOptions has_start_do_skip(10, true);
 
-  for (auto ty : NumericTypes()) {
+  for (const DataType* ty : NumericTypes()) {
     CheckVectorUnary("cumulative_sum", ScalarFromJSON(ty, "10"),
                      ArrayFromJSON(ty, "[10]"), &no_start_no_skip);
     CheckVectorUnary("cumulative_sum_checked", ScalarFromJSON(ty, "10"),
@@ -167,7 +168,7 @@ TEST(TestCumulativeSum, IntegerOverflow) {
 
 TEST(TestCumulativeSum, NoStartNoSkip) {
   CumulativeSumOptions options;
-  for (auto ty : NumericTypes()) {
+  for (const DataType* ty : NumericTypes()) {
     CheckVectorUnary("cumulative_sum", ArrayFromJSON(ty, "[1, 2, 3, 4, 5, 6]"),
                      ArrayFromJSON(ty, "[1, 3, 6, 10, 15, 21]"), &options);
     CheckVectorUnary("cumulative_sum_checked", ArrayFromJSON(ty, "[1, 2, 3, 4, 5, 6]"),
@@ -212,7 +213,7 @@ TEST(TestCumulativeSum, NoStartNoSkip) {
 
 TEST(TestCumulativeSum, NoStartDoSkip) {
   CumulativeSumOptions options(0, true);
-  for (auto ty : NumericTypes()) {
+  for (const DataType* ty : NumericTypes()) {
     CheckVectorUnary("cumulative_sum", ArrayFromJSON(ty, "[1, 2, 3, 4, 5, 6]"),
                      ArrayFromJSON(ty, "[1, 3, 6, 10, 15, 21]"), &options);
     CheckVectorUnary("cumulative_sum_checked", ArrayFromJSON(ty, "[1, 2, 3, 4, 5, 6]"),
@@ -256,7 +257,7 @@ TEST(TestCumulativeSum, NoStartDoSkip) {
 
 TEST(TestCumulativeSum, HasStartNoSkip) {
   CumulativeSumOptions options(10);
-  for (auto ty : NumericTypes()) {
+  for (const DataType* ty : NumericTypes()) {
     CheckVectorUnary("cumulative_sum", ArrayFromJSON(ty, "[1, 2, 3, 4, 5, 6]"),
                      ArrayFromJSON(ty, "[11, 13, 16, 20, 25, 31]"), &options);
     CheckVectorUnary("cumulative_sum_checked", ArrayFromJSON(ty, "[1, 2, 3, 4, 5, 6]"),
@@ -301,7 +302,7 @@ TEST(TestCumulativeSum, HasStartNoSkip) {
 
 TEST(TestCumulativeSum, HasStartDoSkip) {
   CumulativeSumOptions options(10, true);
-  for (auto ty : NumericTypes()) {
+  for (const DataType* ty : NumericTypes()) {
     CheckVectorUnary("cumulative_sum", ArrayFromJSON(ty, "[1, 2, 3, 4, 5, 6]"),
                      ArrayFromJSON(ty, "[11, 13, 16, 20, 25, 31]"), &options);
     CheckVectorUnary("cumulative_sum_checked", ArrayFromJSON(ty, "[1, 2, 3, 4, 5, 6]"),

--- a/cpp/src/arrow/compute/kernels/vector_hash_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_hash_test.cc
@@ -41,6 +41,7 @@
 #include "arrow/util/decimal.h"
 
 #include "arrow/compute/api.h"
+#include "arrow/compute/kernels/common.h"
 #include "arrow/compute/kernels/test_util.h"
 
 #include "arrow/ipc/json_simple.h"
@@ -685,10 +686,10 @@ TEST_F(TestHashKernel, DictEncodeIntervalMonth) {
 TEST_F(TestHashKernel, DictionaryUniqueAndValueCounts) {
   auto dict_json = "[10, 20, 30, 40]";
   auto dict = ArrayFromJSON(int64(), dict_json);
-  for (auto index_ty : IntTypes()) {
+  for (const DataType* index_ty : IntTypes()) {
     auto indices = ArrayFromJSON(index_ty, "[3, 0, 0, 0, 1, 1, 3, 0, 1, 3, 0, 1]");
 
-    auto dict_ty = dictionary(index_ty, int64());
+    auto dict_ty = dictionary(index_ty->GetSharedPtr(), int64());
 
     auto ex_indices = ArrayFromJSON(index_ty, "[3, 0, 1]");
 

--- a/cpp/src/arrow/compute/kernels/vector_replace.cc
+++ b/cpp/src/arrow/compute/kernels/vector_replace.cc
@@ -18,7 +18,6 @@
 #include "arrow/compute/api_scalar.h"
 #include "arrow/compute/kernels/common.h"
 #include "arrow/compute/kernels/copy_data_internal.h"
-#include "arrow/compute/kernels/util_internal.h"
 #include "arrow/util/bitmap_ops.h"
 
 namespace arrow {

--- a/cpp/src/arrow/compute/kernels/vector_replace.cc
+++ b/cpp/src/arrow/compute/kernels/vector_replace.cc
@@ -812,7 +812,7 @@ void AddKernel(Type::type type_id, std::shared_ptr<KernelSignature> signature,
   }
   kernel.mem_allocation = MemAllocation::type::PREALLOCATE;
   kernel.signature = std::move(signature);
-  kernel.exec = std::move(exec);
+  kernel.exec = exec;
   kernel.exec_chunked = exec_chunked;
   kernel.can_execute_chunkwise = false;
   kernel.output_chunked = false;

--- a/cpp/src/arrow/compute/kernels/vector_selection.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection.cc
@@ -31,7 +31,6 @@
 #include "arrow/chunked_array.h"
 #include "arrow/compute/api_vector.h"
 #include "arrow/compute/kernels/common.h"
-#include "arrow/compute/kernels/util_internal.h"
 #include "arrow/extension_type.h"
 #include "arrow/record_batch.h"
 #include "arrow/result.h"
@@ -2450,17 +2449,17 @@ std::shared_ptr<VectorFunction> MakeIndicesNonZeroFunction(std::string name,
   kernel.exec_chunked = IndicesNonZeroExecChunked;
   kernel.can_execute_chunkwise = false;
 
-  auto AddKernels = [&](const std::vector<std::shared_ptr<DataType>>& types) {
-    for (const std::shared_ptr<DataType>& ty : types) {
+  auto AddKernels = [&](const std::vector<const DataType*>& types) {
+    for (const DataType* ty : types) {
       kernel.signature = KernelSignature::Make({ty}, uint64());
       DCHECK_OK(func->AddKernel(kernel));
     }
   };
 
   AddKernels(NumericTypes());
-  AddKernels({boolean()});
+  AddKernels({boolean().get()});
 
-  for (const auto& ty : {Type::DECIMAL128, Type::DECIMAL256}) {
+  for (Type::type ty : {Type::DECIMAL128, Type::DECIMAL256}) {
     kernel.signature = KernelSignature::Make({ty}, uint64());
     DCHECK_OK(func->AddKernel(kernel));
   }

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -26,6 +26,7 @@
 #include "arrow/array/concatenate.h"
 #include "arrow/chunked_array.h"
 #include "arrow/compute/api.h"
+#include "arrow/compute/kernels/common.h"
 #include "arrow/compute/kernels/test_util.h"
 #include "arrow/table.h"
 #include "arrow/testing/builder.h"

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -1972,7 +1972,7 @@ void AssertRank(const std::shared_ptr<Array>& input, SortOrder order,
   AssertDatumsEqual(expected, actual, /*verbose=*/true);
 }
 
-void AssertRankEmpty(std::shared_ptr<DataType> type, SortOrder order,
+void AssertRankEmpty(const TypeHolder& type, SortOrder order,
                      NullPlacement null_placement, RankOptions::Tiebreaker tiebreaker) {
   AssertRank(ArrayFromJSON(type, "[]"), order, null_placement, tiebreaker,
              ArrayFromJSON(uint64(), "[]"));
@@ -2028,7 +2028,7 @@ void AssertRankAllTiebreakers(const std::shared_ptr<Array>& input) {
 }
 
 TEST(TestRankForReal, RankReal) {
-  for (auto real_type : ::arrow::FloatingPointTypes()) {
+  for (const DataType* real_type : FloatingPointTypes()) {
     for (auto null_placement : AllNullPlacements()) {
       for (auto tiebreaker : AllTiebreakers()) {
         for (auto order : AllOrders()) {
@@ -2046,7 +2046,7 @@ TEST(TestRankForReal, RankReal) {
 }
 
 TEST(TestRankForIntegral, RankIntegral) {
-  for (auto integer_type : ::arrow::IntTypes()) {
+  for (const DataType* integer_type : IntTypes()) {
     for (auto null_placement : AllNullPlacements()) {
       for (auto tiebreaker : AllTiebreakers()) {
         for (auto order : AllOrders()) {
@@ -2132,7 +2132,7 @@ TEST(TestRankForBool, RankBool) {
 }
 
 TEST(TestRankForTemporal, RankTemporal) {
-  for (auto temporal_type : ::arrow::TemporalTypes()) {
+  for (const DataType* temporal_type : TemporalTypes()) {
     for (auto null_placement : AllNullPlacements()) {
       for (auto tiebreaker : AllTiebreakers()) {
         for (auto order : AllOrders()) {
@@ -2148,7 +2148,7 @@ TEST(TestRankForTemporal, RankTemporal) {
 }
 
 TEST(TestRankForStrings, RankStrings) {
-  for (auto string_type : ::arrow::StringTypes()) {
+  for (const DataType* string_type : StringTypes()) {
     for (auto null_placement : AllNullPlacements()) {
       for (auto tiebreaker : AllTiebreakers()) {
         for (auto order : AllOrders()) {

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -18,7 +18,6 @@
 #include <algorithm>
 #include <functional>
 #include <limits>
-#include <memory>
 #include <ostream>
 #include <sstream>
 #include <string>
@@ -29,6 +28,7 @@
 #include "arrow/array/array_decimal.h"
 #include "arrow/array/concatenate.h"
 #include "arrow/compute/api_vector.h"
+#include "arrow/compute/kernels/common.h"
 #include "arrow/compute/kernels/test_util.h"
 #include "arrow/result.h"
 #include "arrow/table.h"
@@ -36,7 +36,6 @@
 #include "arrow/testing/random.h"
 #include "arrow/testing/util.h"
 #include "arrow/type_traits.h"
-#include "arrow/util/logging.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/ipc/json_simple.cc
+++ b/cpp/src/arrow/ipc/json_simple.cc
@@ -124,8 +124,8 @@ class ConcreteConverter : public Converter {
   template <typename BuilderType>
   Status MakeConcreteBuilder(std::shared_ptr<BuilderType>* out) {
     std::unique_ptr<ArrayBuilder> builder;
-    RETURN_NOT_OK(MakeBuilder(default_memory_pool(), this->type_->GetSharedPtr(),
-                              &builder));
+    RETURN_NOT_OK(
+        MakeBuilder(default_memory_pool(), this->type_->GetSharedPtr(), &builder));
     *out = checked_pointer_cast<BuilderType>(std::move(builder));
     DCHECK(*out);
     return Status::OK();
@@ -349,8 +349,8 @@ class TimestampConverter final : public ConcreteConverter<TimestampConverter> {
   explicit TimestampConverter(const DataType* type)
       : timestamp_type_{checked_cast<const TimestampType*>(type)} {
     this->type_ = type;
-    builder_ = std::make_shared<TimestampBuilder>(type->GetSharedPtr(),
-                                                  default_memory_pool());
+    builder_ =
+        std::make_shared<TimestampBuilder>(type->GetSharedPtr(), default_memory_pool());
   }
 
   Status AppendValue(const rj::Value& json_obj) override {
@@ -483,9 +483,7 @@ template <typename BuilderType = typename TypeTraits<FixedSizeBinaryType>::Build
 class FixedSizeBinaryConverter final
     : public ConcreteConverter<FixedSizeBinaryConverter<BuilderType>> {
  public:
-  explicit FixedSizeBinaryConverter(const DataType* type) {
-    this->type_ = type;
-  }
+  explicit FixedSizeBinaryConverter(const DataType* type) { this->type_ = type; }
 
   Status Init() override { return this->MakeConcreteBuilder(&builder_); }
 
@@ -527,9 +525,8 @@ class ListConverter final : public ConcreteConverter<ListConverter<TYPE>> {
     const auto& list_type = checked_cast<const TYPE&>(*this->type_);
     RETURN_NOT_OK(GetConverter(list_type.value_type(), &child_converter_));
     auto child_builder = child_converter_->builder();
-    builder_ =
-        std::make_shared<BuilderType>(default_memory_pool(), child_builder,
-                                      this->type_->GetSharedPtr());
+    builder_ = std::make_shared<BuilderType>(default_memory_pool(), child_builder,
+                                             this->type_->GetSharedPtr());
     return Status::OK();
   }
 
@@ -613,9 +610,8 @@ class FixedSizeListConverter final : public ConcreteConverter<FixedSizeListConve
     list_size_ = list_type.list_size();
     RETURN_NOT_OK(GetConverter(list_type.value_type(), &child_converter_));
     auto child_builder = child_converter_->builder();
-    builder_ = std::make_shared<FixedSizeListBuilder>(default_memory_pool(),
-                                                      child_builder,
-                                                      type_->GetSharedPtr());
+    builder_ = std::make_shared<FixedSizeListBuilder>(
+        default_memory_pool(), child_builder, type_->GetSharedPtr());
     return Status::OK();
   }
 
@@ -655,9 +651,8 @@ class StructConverter final : public ConcreteConverter<StructConverter> {
       child_converters_.push_back(child_converter);
       child_builders.push_back(child_converter->builder());
     }
-    builder_ = std::make_shared<StructBuilder>(type_->GetSharedPtr(),
-                                               default_memory_pool(),
-                                               std::move(child_builders));
+    builder_ = std::make_shared<StructBuilder>(
+        type_->GetSharedPtr(), default_memory_pool(), std::move(child_builders));
     return Status::OK();
   }
 
@@ -736,13 +731,11 @@ class UnionConverter final : public ConcreteConverter<UnionConverter> {
       child_builders.push_back(child_converter->builder());
     }
     if (mode_ == UnionMode::DENSE) {
-      builder_ = std::make_shared<DenseUnionBuilder>(default_memory_pool(),
-                                                     std::move(child_builders),
-                                                     type_->GetSharedPtr());
+      builder_ = std::make_shared<DenseUnionBuilder>(
+          default_memory_pool(), std::move(child_builders), type_->GetSharedPtr());
     } else {
-      builder_ = std::make_shared<SparseUnionBuilder>(default_memory_pool(),
-                                                      std::move(child_builders),
-                                                      type_->GetSharedPtr());
+      builder_ = std::make_shared<SparseUnionBuilder>(
+          default_memory_pool(), std::move(child_builders), type_->GetSharedPtr());
     }
     return Status::OK();
   }
@@ -807,13 +800,13 @@ Status GetDictConverter(const TypeHolder& type, std::shared_ptr<Converter>* out)
 
   const auto value_type = checked_cast<const DictionaryType&>(*type).value_type();
 
-#define SIMPLE_CONVERTER_CASE(ID, CLASS, TYPE)                    \
-  case ID:                                                        \
+#define SIMPLE_CONVERTER_CASE(ID, CLASS, TYPE)                         \
+  case ID:                                                             \
     res = std::make_shared<CLASS<DictionaryBuilder<TYPE>>>(type.type); \
     break;
 
-#define PARAM_CONVERTER_CASE(ID, CLASS, TYPE)                           \
-  case ID:                                                              \
+#define PARAM_CONVERTER_CASE(ID, CLASS, TYPE)                                \
+  case ID:                                                                   \
     res = std::make_shared<CLASS<TYPE, DictionaryBuilder<TYPE>>>(type.type); \
     break;
 
@@ -855,8 +848,8 @@ Status GetConverter(const TypeHolder& type, std::shared_ptr<Converter>* out) {
 
   std::shared_ptr<Converter> res;
 
-#define SIMPLE_CONVERTER_CASE(ID, CLASS) \
-  case ID:                               \
+#define SIMPLE_CONVERTER_CASE(ID, CLASS)      \
+  case ID:                                    \
     res = std::make_shared<CLASS>(type.type); \
     break;
 
@@ -948,13 +941,11 @@ Status ChunkedArrayFromJSON(const TypeHolder& type,
     out_chunks.emplace_back();
     ARROW_ASSIGN_OR_RAISE(out_chunks.back(), ArrayFromJSON(type, chunk_json));
   }
-  *out = std::make_shared<ChunkedArray>(std::move(out_chunks),
-                                        type.GetSharedPtr());
+  *out = std::make_shared<ChunkedArray>(std::move(out_chunks), type.GetSharedPtr());
   return Status::OK();
 }
 
-Status DictArrayFromJSON(const TypeHolder& type,
-                         util::string_view indices_json,
+Status DictArrayFromJSON(const TypeHolder& type, util::string_view indices_json,
                          util::string_view dictionary_json, std::shared_ptr<Array>* out) {
   if (type.id() != Type::DICTIONARY) {
     return Status::TypeError("DictArrayFromJSON requires dictionary type, got ", *type);
@@ -968,11 +959,12 @@ Status DictArrayFromJSON(const TypeHolder& type,
                         ArrayFromJSON(dictionary_type.value_type(), dictionary_json));
 
   return DictionaryArray::FromArrays(type.GetSharedPtr(), std::move(indices),
-                                     std::move(dictionary)).Value(out);
+                                     std::move(dictionary))
+      .Value(out);
 }
 
-Status ScalarFromJSON(const TypeHolder& type,
-                      util::string_view json_string, std::shared_ptr<Scalar>* out) {
+Status ScalarFromJSON(const TypeHolder& type, util::string_view json_string,
+                      std::shared_ptr<Scalar>* out) {
   std::shared_ptr<Converter> converter;
   RETURN_NOT_OK(GetConverter(type.type, &converter));
 
@@ -990,8 +982,8 @@ Status ScalarFromJSON(const TypeHolder& type,
   return array->GetScalar(0).Value(out);
 }
 
-Status DictScalarFromJSON(const TypeHolder& type,
-                          util::string_view index_json, util::string_view dictionary_json,
+Status DictScalarFromJSON(const TypeHolder& type, util::string_view index_json,
+                          util::string_view dictionary_json,
                           std::shared_ptr<Scalar>* out) {
   if (type.id() != Type::DICTIONARY) {
     return Status::TypeError("DictScalarFromJSON requires dictionary type, got ", *type);

--- a/cpp/src/arrow/ipc/json_simple.cc
+++ b/cpp/src/arrow/ipc/json_simple.cc
@@ -560,7 +560,7 @@ class MapConverter final : public ConcreteConverter<MapConverter> {
     auto key_builder = key_converter_->builder();
     auto item_builder = item_converter_->builder();
     builder_ = std::make_shared<MapBuilder>(default_memory_pool(), key_builder,
-                                            item_builder, type_);
+                                            item_builder, type_->GetSharedPtr());
     return Status::OK();
   }
 

--- a/cpp/src/arrow/ipc/json_simple.h
+++ b/cpp/src/arrow/ipc/json_simple.h
@@ -30,39 +30,39 @@
 namespace arrow {
 
 class Array;
-class DataType;
+class TypeHolder;
 
 namespace ipc {
 namespace internal {
 namespace json {
 
 ARROW_EXPORT
-Result<std::shared_ptr<Array>> ArrayFromJSON(const std::shared_ptr<DataType>&,
+Result<std::shared_ptr<Array>> ArrayFromJSON(const TypeHolder& type,
                                              const std::string& json);
 
 ARROW_EXPORT
-Result<std::shared_ptr<Array>> ArrayFromJSON(const std::shared_ptr<DataType>&,
+Result<std::shared_ptr<Array>> ArrayFromJSON(const TypeHolder& type,
                                              util::string_view json);
 
 ARROW_EXPORT
-Result<std::shared_ptr<Array>> ArrayFromJSON(const std::shared_ptr<DataType>&,
+Result<std::shared_ptr<Array>> ArrayFromJSON(const TypeHolder& type,
                                              const char* json);
 
 ARROW_EXPORT
-Status ChunkedArrayFromJSON(const std::shared_ptr<DataType>& type,
+Status ChunkedArrayFromJSON(const TypeHolder& type,
                             const std::vector<std::string>& json_strings,
                             std::shared_ptr<ChunkedArray>* out);
 
 ARROW_EXPORT
-Status DictArrayFromJSON(const std::shared_ptr<DataType>&, util::string_view indices_json,
+Status DictArrayFromJSON(const TypeHolder& type, util::string_view indices_json,
                          util::string_view dictionary_json, std::shared_ptr<Array>* out);
 
 ARROW_EXPORT
-Status ScalarFromJSON(const std::shared_ptr<DataType>&, util::string_view json,
+Status ScalarFromJSON(const TypeHolder& type, util::string_view json,
                       std::shared_ptr<Scalar>* out);
 
 ARROW_EXPORT
-Status DictScalarFromJSON(const std::shared_ptr<DataType>&, util::string_view index_json,
+Status DictScalarFromJSON(const TypeHolder& type, util::string_view index_json,
                           util::string_view dictionary_json,
                           std::shared_ptr<Scalar>* out);
 

--- a/cpp/src/arrow/ipc/json_simple.h
+++ b/cpp/src/arrow/ipc/json_simple.h
@@ -30,7 +30,7 @@
 namespace arrow {
 
 class Array;
-class TypeHolder;
+struct TypeHolder;
 
 namespace ipc {
 namespace internal {
@@ -45,8 +45,7 @@ Result<std::shared_ptr<Array>> ArrayFromJSON(const TypeHolder& type,
                                              util::string_view json);
 
 ARROW_EXPORT
-Result<std::shared_ptr<Array>> ArrayFromJSON(const TypeHolder& type,
-                                             const char* json);
+Result<std::shared_ptr<Array>> ArrayFromJSON(const TypeHolder& type, const char* json);
 
 ARROW_EXPORT
 Status ChunkedArrayFromJSON(const TypeHolder& type,

--- a/cpp/src/arrow/testing/gtest_util.cc
+++ b/cpp/src/arrow/testing/gtest_util.cc
@@ -409,8 +409,7 @@ void AssertDatumsApproxEqual(const Datum& expected, const Datum& actual, bool ve
   }
 }
 
-std::shared_ptr<Array> ArrayFromJSON(const TypeHolder& type,
-                                     util::string_view json) {
+std::shared_ptr<Array> ArrayFromJSON(const TypeHolder& type, util::string_view json) {
   EXPECT_OK_AND_ASSIGN(auto out, ipc::internal::json::ArrayFromJSON(type, json));
   return out;
 }
@@ -441,8 +440,7 @@ std::shared_ptr<RecordBatch> RecordBatchFromJSON(const std::shared_ptr<Schema>& 
   return *RecordBatch::FromStructArray(struct_array);
 }
 
-std::shared_ptr<Scalar> ScalarFromJSON(const TypeHolder& type,
-                                       util::string_view json) {
+std::shared_ptr<Scalar> ScalarFromJSON(const TypeHolder& type, util::string_view json) {
   std::shared_ptr<Scalar> out;
   ABORT_NOT_OK(ipc::internal::json::ScalarFromJSON(type, json, &out));
   return out;

--- a/cpp/src/arrow/testing/gtest_util.cc
+++ b/cpp/src/arrow/testing/gtest_util.cc
@@ -409,13 +409,13 @@ void AssertDatumsApproxEqual(const Datum& expected, const Datum& actual, bool ve
   }
 }
 
-std::shared_ptr<Array> ArrayFromJSON(const std::shared_ptr<DataType>& type,
+std::shared_ptr<Array> ArrayFromJSON(const TypeHolder& type,
                                      util::string_view json) {
   EXPECT_OK_AND_ASSIGN(auto out, ipc::internal::json::ArrayFromJSON(type, json));
   return out;
 }
 
-std::shared_ptr<Array> DictArrayFromJSON(const std::shared_ptr<DataType>& type,
+std::shared_ptr<Array> DictArrayFromJSON(const TypeHolder& type,
                                          util::string_view indices_json,
                                          util::string_view dictionary_json) {
   std::shared_ptr<Array> out;
@@ -424,7 +424,7 @@ std::shared_ptr<Array> DictArrayFromJSON(const std::shared_ptr<DataType>& type,
   return out;
 }
 
-std::shared_ptr<ChunkedArray> ChunkedArrayFromJSON(const std::shared_ptr<DataType>& type,
+std::shared_ptr<ChunkedArray> ChunkedArrayFromJSON(const TypeHolder& type,
                                                    const std::vector<std::string>& json) {
   std::shared_ptr<ChunkedArray> out;
   ABORT_NOT_OK(ipc::internal::json::ChunkedArrayFromJSON(type, json, &out));
@@ -441,14 +441,14 @@ std::shared_ptr<RecordBatch> RecordBatchFromJSON(const std::shared_ptr<Schema>& 
   return *RecordBatch::FromStructArray(struct_array);
 }
 
-std::shared_ptr<Scalar> ScalarFromJSON(const std::shared_ptr<DataType>& type,
+std::shared_ptr<Scalar> ScalarFromJSON(const TypeHolder& type,
                                        util::string_view json) {
   std::shared_ptr<Scalar> out;
   ABORT_NOT_OK(ipc::internal::json::ScalarFromJSON(type, json, &out));
   return out;
 }
 
-std::shared_ptr<Scalar> DictScalarFromJSON(const std::shared_ptr<DataType>& type,
+std::shared_ptr<Scalar> DictScalarFromJSON(const TypeHolder& type,
                                            util::string_view index_json,
                                            util::string_view dictionary_json) {
   std::shared_ptr<Scalar> out;

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -315,11 +315,11 @@ ARROW_TESTING_EXPORT void TestInitialized(const Array& array);
 // ArrayFromJSON: construct an Array from a simple JSON representation
 
 ARROW_TESTING_EXPORT
-std::shared_ptr<Array> ArrayFromJSON(const std::shared_ptr<DataType>&,
+std::shared_ptr<Array> ArrayFromJSON(const TypeHolder&,
                                      util::string_view json);
 
 ARROW_TESTING_EXPORT
-std::shared_ptr<Array> DictArrayFromJSON(const std::shared_ptr<DataType>& type,
+std::shared_ptr<Array> DictArrayFromJSON(const TypeHolder&,
                                          util::string_view indices_json,
                                          util::string_view dictionary_json);
 
@@ -328,15 +328,15 @@ std::shared_ptr<RecordBatch> RecordBatchFromJSON(const std::shared_ptr<Schema>&,
                                                  util::string_view);
 
 ARROW_TESTING_EXPORT
-std::shared_ptr<ChunkedArray> ChunkedArrayFromJSON(const std::shared_ptr<DataType>&,
+std::shared_ptr<ChunkedArray> ChunkedArrayFromJSON(const TypeHolder&,
                                                    const std::vector<std::string>& json);
 
 ARROW_TESTING_EXPORT
-std::shared_ptr<Scalar> ScalarFromJSON(const std::shared_ptr<DataType>&,
+std::shared_ptr<Scalar> ScalarFromJSON(const TypeHolder&,
                                        util::string_view json);
 
 ARROW_TESTING_EXPORT
-std::shared_ptr<Scalar> DictScalarFromJSON(const std::shared_ptr<DataType>&,
+std::shared_ptr<Scalar> DictScalarFromJSON(const TypeHolder&,
                                            util::string_view index_json,
                                            util::string_view dictionary_json);
 

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -315,8 +315,7 @@ ARROW_TESTING_EXPORT void TestInitialized(const Array& array);
 // ArrayFromJSON: construct an Array from a simple JSON representation
 
 ARROW_TESTING_EXPORT
-std::shared_ptr<Array> ArrayFromJSON(const TypeHolder&,
-                                     util::string_view json);
+std::shared_ptr<Array> ArrayFromJSON(const TypeHolder&, util::string_view json);
 
 ARROW_TESTING_EXPORT
 std::shared_ptr<Array> DictArrayFromJSON(const TypeHolder&,
@@ -332,8 +331,7 @@ std::shared_ptr<ChunkedArray> ChunkedArrayFromJSON(const TypeHolder&,
                                                    const std::vector<std::string>& json);
 
 ARROW_TESTING_EXPORT
-std::shared_ptr<Scalar> ScalarFromJSON(const TypeHolder&,
-                                       util::string_view json);
+std::shared_ptr<Scalar> ScalarFromJSON(const TypeHolder&, util::string_view json);
 
 ARROW_TESTING_EXPORT
 std::shared_ptr<Scalar> DictScalarFromJSON(const TypeHolder&,

--- a/cpp/src/arrow/testing/matchers.h
+++ b/cpp/src/arrow/testing/matchers.h
@@ -65,14 +65,14 @@ inline PointeesEqualMatcher PointeesEqual() { return {}; }
 
 class AnyOfJSONMatcher {
  public:
-  AnyOfJSONMatcher(std::shared_ptr<DataType> type, std::string array_json)
-      : type_(std::move(type)), array_json_(std::move(array_json)) {}
+  AnyOfJSONMatcher(const TypeHolder& type, std::string array_json)
+      : type_(type), array_json_(std::move(array_json)) {}
 
   template <typename arg_type>
   operator testing::Matcher<arg_type>() const {  // NOLINT runtime/explicit
     struct Impl : testing::MatcherInterface<const arg_type&> {
-      Impl(std::shared_ptr<DataType> type, std::string array_json)
-          : type_(std::move(type)), array_json_(std::move(array_json)) {
+      Impl(const TypeHolder& type, std::string array_json)
+          : type_(type), array_json_(std::move(array_json)) {
         array = ArrayFromJSON(type_, array_json_);
       }
       void DescribeTo(std::ostream* os) const override {
@@ -104,7 +104,7 @@ class AnyOfJSONMatcher {
                          << "' matches no scalar from " << array->ToString();
         return false;
       }
-      const std::shared_ptr<DataType> type_;
+      const TypeHolder& type_;
       const std::string array_json_;
       std::shared_ptr<Array> array;
     };
@@ -113,13 +113,12 @@ class AnyOfJSONMatcher {
   }
 
  private:
-  const std::shared_ptr<DataType> type_;
+  const TypeHolder& type_;
   const std::string array_json_;
 };
 
-inline AnyOfJSONMatcher AnyOfJSON(std::shared_ptr<DataType> type,
-                                  std::string array_json) {
-  return {std::move(type), std::move(array_json)};
+inline AnyOfJSONMatcher AnyOfJSON(const TypeHolder& type, std::string array_json) {
+  return {type, std::move(array_json)};
 }
 
 template <typename ResultMatcher>

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -370,6 +370,10 @@ std::ostream& operator<<(std::ostream& os, const TypeHolder& type) {
 // ----------------------------------------------------------------------
 // TypeHolder
 
+std::shared_ptr<DataType> TypeHolder::GetSharedPtr() const {
+  return this->type != nullptr ? this->type->GetSharedPtr() : nullptr;
+}
+
 std::string TypeHolder::ToString(const std::vector<TypeHolder>& types) {
   std::stringstream ss;
   ss << "(";
@@ -1972,6 +1976,10 @@ std::string DataType::ComputeMetadataFingerprint() const {
     s += child->metadata_fingerprint() + ";";
   }
   return s;
+}
+
+std::shared_ptr<DataType> DataType::GetSharedPtr() const {
+  return const_cast<DataType*>(this)->shared_from_this();
 }
 
 #define PARAMETER_LESS_FINGERPRINT(TYPE_CLASS)               \

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -2374,14 +2374,32 @@ std::string Decimal256Type::ToString() const {
 namespace {
 
 std::vector<std::shared_ptr<DataType>> g_signed_int_types;
+std::vector<const DataType*> g_signed_int_types_ptrs;
+
 std::vector<std::shared_ptr<DataType>> g_unsigned_int_types;
+std::vector<const DataType*> g_unsigned_int_types_ptrs;
+
 std::vector<std::shared_ptr<DataType>> g_int_types;
+std::vector<const DataType*> g_int_types_ptrs;
+
 std::vector<std::shared_ptr<DataType>> g_floating_types;
+std::vector<const DataType*> g_floating_types_ptrs;
+
 std::vector<std::shared_ptr<DataType>> g_numeric_types;
+std::vector<const DataType*> g_numeric_types_ptrs;
+
 std::vector<std::shared_ptr<DataType>> g_base_binary_types;
+std::vector<const DataType*> g_base_binary_types_ptrs;
+
 std::vector<std::shared_ptr<DataType>> g_temporal_types;
+std::vector<const DataType*> g_temporal_types_ptrs;
+
 std::vector<std::shared_ptr<DataType>> g_interval_types;
+std::vector<const DataType*> g_internal_types_ptrs;
+
 std::vector<std::shared_ptr<DataType>> g_primitive_types;
+std::vector<const DataType*> g_primitive_types_ptrs;
+
 std::once_flag static_data_initialized;
 
 template <typename T>
@@ -2439,59 +2457,59 @@ void InitStaticData() {
 
 }  // namespace
 
-const std::vector<std::shared_ptr<DataType>>& BaseBinaryTypes() {
+const std::vector<const DataType*>& BaseBinaryTypes() {
   std::call_once(static_data_initialized, InitStaticData);
-  return g_base_binary_types;
+  return g_base_binary_types_ptrs;
 }
 
-const std::vector<std::shared_ptr<DataType>>& BinaryTypes() {
+const std::vector<const DataType*>& BinaryTypes() {
   static DataTypeVector types = {binary(), large_binary()};
   return types;
 }
 
-const std::vector<std::shared_ptr<DataType>>& StringTypes() {
+const std::vector<const DataType*>& StringTypes() {
   static DataTypeVector types = {utf8(), large_utf8()};
   return types;
 }
 
-const std::vector<std::shared_ptr<DataType>>& SignedIntTypes() {
+const std::vector<const DataType*>& SignedIntTypes() {
   std::call_once(static_data_initialized, InitStaticData);
-  return g_signed_int_types;
+  return g_signed_int_types_ptrs;
 }
 
-const std::vector<std::shared_ptr<DataType>>& UnsignedIntTypes() {
+const std::vector<const DataType*>& UnsignedIntTypes() {
   std::call_once(static_data_initialized, InitStaticData);
-  return g_unsigned_int_types;
+  return g_unsigned_int_types_ptrs;
 }
 
-const std::vector<std::shared_ptr<DataType>>& IntTypes() {
+const std::vector<const DataType*>& IntTypes() {
   std::call_once(static_data_initialized, InitStaticData);
-  return g_int_types;
+  return g_int_types_ptrs;
 }
 
-const std::vector<std::shared_ptr<DataType>>& FloatingPointTypes() {
+const std::vector<const DataType*>& FloatingPointTypes() {
   std::call_once(static_data_initialized, InitStaticData);
-  return g_floating_types;
+  return g_floating_types_ptrs;
 }
 
-const std::vector<std::shared_ptr<DataType>>& NumericTypes() {
+const std::vector<const DataType*>& NumericTypes() {
   std::call_once(static_data_initialized, InitStaticData);
-  return g_numeric_types;
+  return g_numeric_types_ptrs;
 }
 
-const std::vector<std::shared_ptr<DataType>>& TemporalTypes() {
+const std::vector<const DataType*>& TemporalTypes() {
   std::call_once(static_data_initialized, InitStaticData);
-  return g_temporal_types;
+  return g_temporal_types_ptrs;
 }
 
-const std::vector<std::shared_ptr<DataType>>& IntervalTypes() {
+const std::vector<const DataType*>& IntervalTypes() {
   std::call_once(static_data_initialized, InitStaticData);
-  return g_interval_types;
+  return g_interval_types_ptrs;
 }
 
-const std::vector<std::shared_ptr<DataType>>& PrimitiveTypes() {
+const std::vector<const DataType*>& PrimitiveTypes() {
   std::call_once(static_data_initialized, InitStaticData);
-  return g_primitive_types;
+  return g_primitive_types_ptrs;
 }
 
 const std::vector<TimeUnit::type>& TimeUnit::values() {

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -2194,8 +2194,6 @@ const std::shared_ptr<DataType>& duration(TimeUnit::type unit) {
           std::make_shared<DurationType>(TimeUnit::NANO);
       return result;
     }
-    default:
-      return nullptr;
   }
 }
 
@@ -2236,8 +2234,6 @@ const std::shared_ptr<DataType>& timestamp(TimeUnit::type unit) {
           std::make_shared<TimestampType>(TimeUnit::NANO);
       return result;
     }
-    default:
-      return nullptr;
   }
 }
 
@@ -2259,7 +2255,8 @@ const std::shared_ptr<DataType>& time32(TimeUnit::type unit) {
     }
     default:
       DCHECK(false);
-      return nullptr;
+      static std::shared_ptr<DataType> null_sp;
+      return null_sp;
   }
 }
 
@@ -2277,7 +2274,8 @@ const std::shared_ptr<DataType>& time64(TimeUnit::type unit) {
     }
     default:
       DCHECK(false);
-      return nullptr;
+      static std::shared_ptr<DataType> null_sp;
+      return null_sp;
   }
 }
 

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -2189,7 +2189,8 @@ const std::shared_ptr<DataType>& duration(TimeUnit::type unit) {
           std::make_shared<DurationType>(TimeUnit::MICRO);
       return result;
     }
-    case TimeUnit::NANO: {
+    default: {
+      DCHECK_EQ(unit, TimeUnit::NANO);
       static std::shared_ptr<DataType> result =
           std::make_shared<DurationType>(TimeUnit::NANO);
       return result;
@@ -2229,7 +2230,8 @@ const std::shared_ptr<DataType>& timestamp(TimeUnit::type unit) {
           std::make_shared<TimestampType>(TimeUnit::MICRO);
       return result;
     }
-    case TimeUnit::NANO: {
+    default: {
+      DCHECK_EQ(unit, TimeUnit::NANO);
       static std::shared_ptr<DataType> result =
           std::make_shared<TimestampType>(TimeUnit::NANO);
       return result;

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -187,32 +187,6 @@ std::string ToString(TimeUnit::type unit) {
 
 namespace {
 
-struct PhysicalTypeVisitor {
-  const std::shared_ptr<DataType>& real_type;
-  std::shared_ptr<DataType> result;
-
-  Status Visit(const DataType&) {
-    result = real_type;
-    return Status::OK();
-  }
-
-  template <typename Type, typename PhysicalType = typename Type::PhysicalType>
-  Status Visit(const Type&) {
-    result = TypeTraits<PhysicalType>::type_singleton();
-    return Status::OK();
-  }
-};
-
-}  // namespace
-
-std::shared_ptr<DataType> GetPhysicalType(const std::shared_ptr<DataType>& real_type) {
-  PhysicalTypeVisitor visitor{real_type, {}};
-  ARROW_CHECK_OK(VisitTypeInline(*real_type, &visitor));
-  return std::move(visitor.result);
-}
-
-namespace {
-
 using internal::checked_cast;
 
 // Merges `existing` and `other` if one of them is of NullType, otherwise
@@ -2198,30 +2172,31 @@ std::shared_ptr<DataType> fixed_size_binary(int32_t byte_width) {
   return std::make_shared<FixedSizeBinaryType>(byte_width);
 }
 
-#define RETURN_STATIC_TIME_TYPE(TYPE_NAME)                              \
-  switch (unit) {                                                       \
-    case TimeUnit::SECOND: {                                            \
-      static std::shared_ptr<DataType> result = std::make_shared<TYPE_NAME>(TimeUnit::SECOND); \
-      return result;                                                    \
-    }                                                                   \
-    case TimeUnit::MILLI: {                                             \
-      static std::shared_ptr<DataType> result = std::make_shared<TYPE_NAME>(TimeUnit::MILLI); \
-      return result;                                                    \
-    }                                                                   \
-    case TimeUnit::MICRO: {                                             \
-      static std::shared_ptr<DataType> result = std::make_shared<TYPE_NAME>(TimeUnit::MICRO); \
-      return result;                                                    \
-    }                                                                   \
-    case TimeUnit::NANO: {                                              \
-      static std::shared_ptr<DataType> result = std::make_shared<TYPE_NAME>(TimeUnit::NANO); \
-      return result;                                                    \
-    }                                                                   \
-    default:                                                            \
-      return nullptr;                                                   \
-  }
-
 const std::shared_ptr<DataType>& duration(TimeUnit::type unit) {
-  RETURN_STATIC_TIME_TYPE(DurationType)
+  switch (unit) {
+    case TimeUnit::SECOND: {
+      static std::shared_ptr<DataType> result =
+          std::make_shared<DurationType>(TimeUnit::SECOND);
+      return result;
+    }
+    case TimeUnit::MILLI: {
+      static std::shared_ptr<DataType> result =
+          std::make_shared<DurationType>(TimeUnit::MILLI);
+      return result;
+    }
+    case TimeUnit::MICRO: {
+      static std::shared_ptr<DataType> result =
+          std::make_shared<DurationType>(TimeUnit::MICRO);
+      return result;
+    }
+    case TimeUnit::NANO: {
+      static std::shared_ptr<DataType> result =
+          std::make_shared<DurationType>(TimeUnit::NANO);
+      return result;
+    }
+    default:
+      return nullptr;
+  }
 }
 
 const std::shared_ptr<DataType>& day_time_interval() {
@@ -2240,7 +2215,30 @@ const std::shared_ptr<DataType>& month_interval() {
 }
 
 const std::shared_ptr<DataType>& timestamp(TimeUnit::type unit) {
-  RETURN_STATIC_TIME_TYPE(TimestampType)
+  switch (unit) {
+    case TimeUnit::SECOND: {
+      static std::shared_ptr<DataType> result =
+          std::make_shared<TimestampType>(TimeUnit::SECOND);
+      return result;
+    }
+    case TimeUnit::MILLI: {
+      static std::shared_ptr<DataType> result =
+          std::make_shared<TimestampType>(TimeUnit::MILLI);
+      return result;
+    }
+    case TimeUnit::MICRO: {
+      static std::shared_ptr<DataType> result =
+          std::make_shared<TimestampType>(TimeUnit::MICRO);
+      return result;
+    }
+    case TimeUnit::NANO: {
+      static std::shared_ptr<DataType> result =
+          std::make_shared<TimestampType>(TimeUnit::NANO);
+      return result;
+    }
+    default:
+      return nullptr;
+  }
 }
 
 std::shared_ptr<DataType> timestamp(TimeUnit::type unit, const std::string& timezone) {
@@ -2250,11 +2248,13 @@ std::shared_ptr<DataType> timestamp(TimeUnit::type unit, const std::string& time
 const std::shared_ptr<DataType>& time32(TimeUnit::type unit) {
   switch (unit) {
     case TimeUnit::SECOND: {
-      static std::shared_ptr<DataType> result = std::make_shared<Time32Type>(TimeUnit::SECOND);
+      static std::shared_ptr<DataType> result =
+          std::make_shared<Time32Type>(TimeUnit::SECOND);
       return result;
     }
     case TimeUnit::MILLI: {
-      static std::shared_ptr<DataType> result = std::make_shared<Time32Type>(TimeUnit::MILLI);
+      static std::shared_ptr<DataType> result =
+          std::make_shared<Time32Type>(TimeUnit::MILLI);
       return result;
     }
     default:
@@ -2266,11 +2266,13 @@ const std::shared_ptr<DataType>& time32(TimeUnit::type unit) {
 const std::shared_ptr<DataType>& time64(TimeUnit::type unit) {
   switch (unit) {
     case TimeUnit::MICRO: {
-      static std::shared_ptr<DataType> result = std::make_shared<Time64Type>(TimeUnit::MICRO);
+      static std::shared_ptr<DataType> result =
+          std::make_shared<Time64Type>(TimeUnit::MICRO);
       return result;
     }
     case TimeUnit::NANO: {
-      static std::shared_ptr<DataType> result = std::make_shared<Time64Type>(TimeUnit::NANO);
+      static std::shared_ptr<DataType> result =
+          std::make_shared<Time64Type>(TimeUnit::NANO);
       return result;
     }
     default:

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -2124,31 +2124,31 @@ std::string ToString(TimeUnit::type unit);
 // Helpers to get instances of data types based on general categories
 
 ARROW_EXPORT
-const std::vector<std::shared_ptr<DataType>>& SignedIntTypes();
+const std::vector<const DataType*>& SignedIntTypes();
 ARROW_EXPORT
-const std::vector<std::shared_ptr<DataType>>& UnsignedIntTypes();
+const std::vector<const DataType*>& UnsignedIntTypes();
 ARROW_EXPORT
-const std::vector<std::shared_ptr<DataType>>& IntTypes();
+const std::vector<const DataType*>& IntTypes();
 ARROW_EXPORT
-const std::vector<std::shared_ptr<DataType>>& FloatingPointTypes();
+const std::vector<const DataType*>& FloatingPointTypes();
 // Number types without boolean
 ARROW_EXPORT
-const std::vector<std::shared_ptr<DataType>>& NumericTypes();
+const std::vector<const DataType*>& NumericTypes();
 // Binary and string-like types (except fixed-size binary)
 ARROW_EXPORT
-const std::vector<std::shared_ptr<DataType>>& BaseBinaryTypes();
+const std::vector<const DataType*>& BaseBinaryTypes();
 ARROW_EXPORT
-const std::vector<std::shared_ptr<DataType>>& BinaryTypes();
+const std::vector<const DataType*>& BinaryTypes();
 ARROW_EXPORT
-const std::vector<std::shared_ptr<DataType>>& StringTypes();
+const std::vector<const DataType*>& StringTypes();
 // Temporal types including time and timestamps for each unit
 ARROW_EXPORT
-const std::vector<std::shared_ptr<DataType>>& TemporalTypes();
+const std::vector<const DataType*>& TemporalTypes();
 // Interval types
 ARROW_EXPORT
-const std::vector<std::shared_ptr<DataType>>& IntervalTypes();
+const std::vector<const DataType*>& IntervalTypes();
 // Integer, floating point, base binary, and temporal
 ARROW_EXPORT
-const std::vector<std::shared_ptr<DataType>>& PrimitiveTypes();
+const std::vector<const DataType*>& PrimitiveTypes();
 
 }  // namespace arrow

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -2120,35 +2120,4 @@ ARROW_EXPORT
 std::string ToString(TimeUnit::type unit);
 
 }  // namespace internal
-
-// Helpers to get instances of data types based on general categories
-
-ARROW_EXPORT
-const std::vector<const DataType*>& SignedIntTypes();
-ARROW_EXPORT
-const std::vector<const DataType*>& UnsignedIntTypes();
-ARROW_EXPORT
-const std::vector<const DataType*>& IntTypes();
-ARROW_EXPORT
-const std::vector<const DataType*>& FloatingPointTypes();
-// Number types without boolean
-ARROW_EXPORT
-const std::vector<const DataType*>& NumericTypes();
-// Binary and string-like types (except fixed-size binary)
-ARROW_EXPORT
-const std::vector<const DataType*>& BaseBinaryTypes();
-ARROW_EXPORT
-const std::vector<const DataType*>& BinaryTypes();
-ARROW_EXPORT
-const std::vector<const DataType*>& StringTypes();
-// Temporal types including time and timestamps for each unit
-ARROW_EXPORT
-const std::vector<const DataType*>& TemporalTypes();
-// Interval types
-ARROW_EXPORT
-const std::vector<const DataType*>& IntervalTypes();
-// Integer, floating point, base binary, and temporal
-ARROW_EXPORT
-const std::vector<const DataType*>& PrimitiveTypes();
-
 }  // namespace arrow

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -278,18 +278,6 @@ inline bool operator!=(const DataType& lhs, const DataType& rhs) {
   return !lhs.Equals(rhs);
 }
 
-/// \brief Return the compatible physical data type
-///
-/// Some types may have distinct logical meanings but the exact same physical
-/// representation.  For example, TimestampType has Int64Type as a physical
-/// type (defined as TimestampType::PhysicalType).
-///
-/// The return value is as follows:
-/// - if a `PhysicalType` alias exists in the concrete type class, return
-///   an instance of `PhysicalType`.
-/// - otherwise, return the input type itself.
-std::shared_ptr<DataType> GetPhysicalType(const std::shared_ptr<DataType>& type);
-
 /// \brief Base class for all fixed-width data types
 class ARROW_EXPORT FixedWidthType : public DataType {
  public:

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -190,9 +190,7 @@ class ARROW_EXPORT DataType : public std::enable_shared_from_this<DataType>,
 
   // \brief EXPERIMENTAL: Enable retrieving shared_ptr<DataType> from a const
   // context.
-  std::shared_ptr<DataType> GetSharedPtr() const {
-    return const_cast<DataType*>(this)->shared_from_this();
-  }
+  std::shared_ptr<DataType> GetSharedPtr() const;
 
  protected:
   // Dummy version that returns a null string (indicating not implemented).
@@ -224,14 +222,16 @@ struct ARROW_EXPORT TypeHolder {
   TypeHolder(std::shared_ptr<DataType> owned_type)  // NOLINT implicit construction
       : type(owned_type.get()), owned_type(std::move(owned_type)) {}
 
+  template <typename SubType>
+  TypeHolder(std::shared_ptr<SubType> owned_type)  // NOLINT implicit construction
+      : type(owned_type.get()), owned_type(std::move(owned_type)) {}
+
   TypeHolder(const DataType* type)  // NOLINT implicit construction
       : type(type) {}
 
   Type::type id() const { return this->type->id(); }
 
-  std::shared_ptr<DataType> GetSharedPtr() const {
-    return this->type != NULLPTR ? this->type->GetSharedPtr() : NULLPTR;
-  }
+  std::shared_ptr<DataType> GetSharedPtr() const;
 
   const DataType& operator*() const { return *this->type; }
 

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -514,20 +514,24 @@ std::shared_ptr<DataType> fixed_size_list(const std::shared_ptr<DataType>& value
                                           int32_t list_size);
 /// \brief Return a Duration instance (naming use _type to avoid namespace conflict with
 /// built in time classes).
-std::shared_ptr<DataType> ARROW_EXPORT duration(TimeUnit::type unit);
+ARROW_EXPORT
+const std::shared_ptr<DataType>& duration(TimeUnit::type unit);
 
 /// \brief Return a DayTimeIntervalType instance
-std::shared_ptr<DataType> ARROW_EXPORT day_time_interval();
+ARROW_EXPORT
+const std::shared_ptr<DataType>& day_time_interval();
 
 /// \brief Return a MonthIntervalType instance
-std::shared_ptr<DataType> ARROW_EXPORT month_interval();
+ARROW_EXPORT
+const std::shared_ptr<DataType>& month_interval();
 
 /// \brief Return a MonthDayNanoIntervalType instance
-std::shared_ptr<DataType> ARROW_EXPORT month_day_nano_interval();
+ARROW_EXPORT
+const std::shared_ptr<DataType>& month_day_nano_interval();
 
 /// \brief Create a TimestampType instance from its unit
 ARROW_EXPORT
-std::shared_ptr<DataType> timestamp(TimeUnit::type unit);
+const std::shared_ptr<DataType>& timestamp(TimeUnit::type unit);
 
 /// \brief Create a TimestampType instance from its unit and timezone
 ARROW_EXPORT
@@ -536,12 +540,14 @@ std::shared_ptr<DataType> timestamp(TimeUnit::type unit, const std::string& time
 /// \brief Create a 32-bit time type instance
 ///
 /// Unit can be either SECOND or MILLI
-std::shared_ptr<DataType> ARROW_EXPORT time32(TimeUnit::type unit);
+ARROW_EXPORT
+const std::shared_ptr<DataType>& time32(TimeUnit::type unit);
 
 /// \brief Create a 64-bit time type instance
 ///
 /// Unit can be either MICRO or NANO
-std::shared_ptr<DataType> ARROW_EXPORT time64(TimeUnit::type unit);
+ARROW_EXPORT
+const std::shared_ptr<DataType>& time64(TimeUnit::type unit);
 
 /// \brief Create a StructType instance
 std::shared_ptr<DataType> ARROW_EXPORT

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -593,9 +593,9 @@ std::shared_ptr<DataType> dictionary(const std::shared_ptr<DataType>& index_type
 /// \param type the field value type
 /// \param nullable whether the values are nullable, default true
 /// \param metadata any custom key-value metadata, default null
-std::shared_ptr<Field> ARROW_EXPORT
-field(std::string name, std::shared_ptr<DataType> type, bool nullable = true,
-      std::shared_ptr<const KeyValueMetadata> metadata = NULLPTR);
+ARROW_EXPORT std::shared_ptr<Field> field(
+    std::string name, std::shared_ptr<DataType> type, bool nullable = true,
+    std::shared_ptr<const KeyValueMetadata> metadata = NULLPTR);
 
 /// \brief Create a Field instance with metadata
 ///
@@ -604,9 +604,9 @@ field(std::string name, std::shared_ptr<DataType> type, bool nullable = true,
 /// \param name the field name
 /// \param type the field value type
 /// \param metadata any custom key-value metadata
-std::shared_ptr<Field> ARROW_EXPORT
-field(std::string name, std::shared_ptr<DataType> type,
-      std::shared_ptr<const KeyValueMetadata> metadata);
+ARROW_EXPORT std::shared_ptr<Field> field(
+    std::string name, std::shared_ptr<DataType> type,
+    std::shared_ptr<const KeyValueMetadata> metadata);
 
 /// \brief Create a Schema instance
 ///

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -955,6 +955,10 @@ static inline bool is_base_binary_like(Type::type type_id) {
   return false;
 }
 
+static inline bool is_parameter_free(Type::type type_id) {
+  return is_primitive(type_id) || is_base_binary_like(type_id) || type_id == Type::NA;
+}
+
 static inline bool is_binary_like(Type::type type_id) {
   switch (type_id) {
     case Type::BINARY:

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -36,6 +36,7 @@
 #include "arrow/array/builder_primitive.h"
 #include "arrow/chunked_array.h"
 #include "arrow/compute/api.h"
+#include "arrow/compute/kernels/common.h"
 #include "arrow/io/api.h"
 #include "arrow/record_batch.h"
 #include "arrow/scalar.h"
@@ -3310,9 +3311,13 @@ void DoNestedRequiredRoundtrip(
 }
 
 TEST(ArrowReadWrite, NestedRequiredOuterOptional) {
-  std::vector<std::shared_ptr<DataType>> types = ::arrow::PrimitiveTypes();
-  types.insert(types.end(), ::arrow::TemporalTypes().begin(),
-               ::arrow::TemporalTypes().end());
+  std::vector<std::shared_ptr<DataType>> types;
+  for (const DataType* ty : ::arrow::compute::PrimitiveTypes()) {
+    types.push_back(ty->GetSharedPtr());
+  }
+  for (const DataType* ty : ::arrow::compute::TemporalTypes()) {
+    types.push_back(ty->GetSharedPtr());
+  }
   types.push_back(::arrow::duration(::arrow::TimeUnit::SECOND));
   types.push_back(::arrow::duration(::arrow::TimeUnit::MILLI));
   types.push_back(::arrow::duration(::arrow::TimeUnit::MICRO));


### PR DESCRIPTION
This is something that I've hacked on a little bit while on airplanes and in idle moments for my own curiosity and just cleaned up to turn into a PR. This PR changes `arrow::compute::InputType` to only store `const DataType*` instead of `shared_ptr<DataType>`, which means that we don't have to copy the smart pointers for every kernel and function that's registered. Amazingly, this trims the size of libarrow.so by about 1% (~300KB) because of not having a bunch of inlined shared_ptr code. 

This change does have consequences -- developers need to be careful about creating function signatures with data types that may have temporary storage duration (all of the APIs like `arrow::int64()` return static instances, and I changed `arrow::duration` and some other type factories to return static instances, too). But I think the benefits outweigh the costs. 