### PR TITLE
MINOR: [Docs] Fix ARROW_USER_SIMD_LEVEL supported values

### DIFF
--- a/docs/source/cpp/env_vars.rst
+++ b/docs/source/cpp/env_vars.rst
@@ -92,7 +92,7 @@ that changing their value later will have an effect.
    Supported values are:
 
    - ``NONE`` disables any runtime-selected SIMD optimization;
-   - ``SSE4.2`` enables any SSE2-based optimizations until SSE4.2 (included);
+   - ``SSE4_2`` enables any SSE2-based optimizations until SSE4.2 (included);
    - ``AVX`` enables any AVX-based optimizations and earlier;
    - ``AVX2`` enables any AVX2-based optimizations and earlier;
    - ``AVX512`` enables any AVX512-based optimizations and earlier.


### PR DESCRIPTION
Substitutes `SSE4.2` with `SSE4_2` in https://arrow.apache.org/docs/dev/cpp/env_vars.html#envvar-ARROW_USER_SIMD_LEVEL.

See https://github.com/apache/arrow/blob/546c3771a209cbcac5e03cf26e07bcd8c9601d5a/cpp/src/arrow/util/cpu_info.cc#L443-L444