### PR TITLE
ARROW-17253: [Python] Detect iterator exception instead of crashing

### DIFF
--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -1114,13 +1114,17 @@ Status ConvertToSequenceAndInferSize(PyObject* obj, PyObject** seq, int64_t* siz
     RETURN_IF_PYERROR();
     for (i = 0; i < n; i++) {
       PyObject* item = PyIter_Next(iter);
-      if (!item) break;
+      if (!item) {
+        // either an error occurred or the iterator ended
+        RETURN_IF_PYERROR();
+        break;
+      }
       PyList_SET_ITEM(lst, i, item);
     }
     // Shrink list if len(iterator) < size
     if (i < n && PyList_SetSlice(lst, i, n, NULL)) {
       Py_DECREF(lst);
-      return Status::UnknownError("failed to resize list");
+      RETURN_IF_PYERROR();
     }
     *seq = lst;
     *size = std::min<int64_t>(i, *size);

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -125,6 +125,14 @@ def test_infinite_iterator():
     assert arr1.equals(expected)
 
 
+def test_failing_iterator():
+    with pytest.raises(ZeroDivisionError):
+        pa.array((1 // 0 for x in range(10)))
+    # ARROW-17253
+    with pytest.raises(ZeroDivisionError):
+        pa.array((1 // 0 for x in range(10)), size=10)
+
+
 def _as_list(xs):
     return xs
 


### PR DESCRIPTION
When `pa.array` is given a generator that raises an exception, ensure the exception is correctly detected, even when an explicit size is also given.