### PR TITLE
ARROW-17272: [Dev] Pass --add-opens in integration tests

### DIFF
--- a/dev/archery/archery/integration/tester_java.py
+++ b/dev/archery/archery/integration/tester_java.py
@@ -55,10 +55,10 @@ _ARROW_FLIGHT_JAR = os.environ.get(
     ),
 )
 _ARROW_FLIGHT_SERVER = (
-    "org.apache.arrow.flight.integration.tests." "IntegrationTestServer"
+    "org.apache.arrow.flight.integration.tests.IntegrationTestServer"
 )
 _ARROW_FLIGHT_CLIENT = (
-    "org.apache.arrow.flight.integration.tests." "IntegrationTestClient"
+    "org.apache.arrow.flight.integration.tests.IntegrationTestClient"
 )
 
 
@@ -70,10 +70,24 @@ class JavaTester(Tester):
 
     name = 'Java'
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Detect whether we're on Java 8 or Java 9+
+        self._java_opts = _JAVA_OPTS[:]
+        proc = subprocess.run(
+            ['java', '--add-opens'],
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            text=True)
+        if 'Unrecognized option: --add-opens' not in proc.stderr:
+            # Java 9+
+            self._java_opts.append(
+                '--add-opens=java.base/java.nio=ALL-UNNAMED')
+
     def _run(self, arrow_path=None, json_path=None, command='VALIDATE'):
         cmd = (
             ['java'] +
-            _JAVA_OPTS +
+            self._java_opts +
             ['-cp', _ARROW_TOOLS_JAR, 'org.apache.arrow.tools.Integration']
         )
 
@@ -98,7 +112,7 @@ class JavaTester(Tester):
 
     def stream_to_file(self, stream_path, file_path):
         cmd = (
-            ['java'] + _JAVA_OPTS + [
+            ['java'] + self._java_opts + [
                 '-cp',
                 _ARROW_TOOLS_JAR,
                 'org.apache.arrow.tools.StreamToFile',
@@ -112,7 +126,7 @@ class JavaTester(Tester):
 
     def file_to_stream(self, file_path, stream_path):
         cmd = (
-            ['java'] + _JAVA_OPTS + [
+            ['java'] + self._java_opts + [
                 '-cp',
                 _ARROW_TOOLS_JAR,
                 'org.apache.arrow.tools.FileToStream',
@@ -126,9 +140,10 @@ class JavaTester(Tester):
 
     def flight_request(self, port, json_path=None, scenario_name=None):
         cmd = (
-            ['java'] + _JAVA_OPTS + ['-cp', _ARROW_FLIGHT_JAR,
-                                     _ARROW_FLIGHT_CLIENT, '-port', str(port)]
-        )
+            ['java'] + self._java_opts + [
+                '-cp', _ARROW_FLIGHT_JAR, _ARROW_FLIGHT_CLIENT, '-port', str(
+                    port)
+            ])
 
         if json_path:
             cmd.extend(('-j', json_path))
@@ -145,7 +160,7 @@ class JavaTester(Tester):
     def flight_server(self, scenario_name=None):
         cmd = (
             ['java'] +
-            _JAVA_OPTS +
+            self._java_opts +
             ['-cp', _ARROW_FLIGHT_JAR, _ARROW_FLIGHT_SERVER, '-port', '0']
         )
         if scenario_name:


### PR DESCRIPTION
This affects Java 16+ due to JEP 396 which now forces us to pass `--add-opens`. Detect the presence of Java >8 and pass the flag in the integration runner.