### PR TITLE
ARROW-17273: [Go][CSV] Add Timestamp, Date32, Date64 format support to csv.Writer

### DIFF
--- a/go/arrow/csv/common.go
+++ b/go/arrow/csv/common.go
@@ -168,6 +168,7 @@ func validate(schema *arrow.Schema) {
 		case *arrow.Float32Type, *arrow.Float64Type:
 		case *arrow.StringType:
 		case *arrow.TimestampType:
+		case *arrow.Date32Type, *arrow.Date64Type:
 		default:
 			panic(fmt.Errorf("arrow/csv: field %d (%s) has invalid data type %T", i, f.Name, ft))
 		}

--- a/go/arrow/csv/writer.go
+++ b/go/arrow/csv/writer.go
@@ -188,6 +188,35 @@ func (w *Writer) Write(record arrow.Record) error {
 					recs[i][j] = w.nullValue
 				}
 			}
+		case *arrow.Date32Type:
+			arr := col.(*array.Date32)
+			for i := 0; i < arr.Len(); i++ {
+				if arr.IsValid(i) {
+					recs[i][j] = arr.Value(i).FormattedString()
+				} else {
+					recs[i][j] = w.nullValue
+				}
+			}
+		case *arrow.Date64Type:
+			arr := col.(*array.Date64)
+			for i := 0; i < arr.Len(); i++ {
+				if arr.IsValid(i) {
+					recs[i][j] = arr.Value(i).FormattedString()
+				} else {
+					recs[i][j] = w.nullValue
+				}
+			}
+
+		case *arrow.TimestampType:
+			arr := col.(*array.Timestamp)
+			t := w.schema.Field(j).Type.(*arrow.TimestampType)
+			for i := 0; i < arr.Len(); i++ {
+				if arr.IsValid(i) {
+					recs[i][j] = arr.Value(i).ToTime(t.Unit).Format("2006-01-02 15:04:05.999999999")
+				} else {
+					recs[i][j] = w.nullValue
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Newly supported types

- Date32
- Date64
- Timestamp

csv.Reader currently supports Timestamps. Not adding Date32/64 support to CSV as the default behavior will stay the same and parse as the broadest `timestamp` type

https://issues.apache.org/jira/browse/ARROW-17273