### PR TITLE
ARROW-17252: [R] Intermittent valgrind failure

### DIFF
--- a/r/R/compute.R
+++ b/r/R/compute.R
@@ -344,7 +344,7 @@ cast_options <- function(safe = TRUE, ...) {
 #' @return `NULL`, invisibly
 #' @export
 #'
-#' @examplesIf arrow_with_dataset() && identical(Sys.getenv("R_ARROW_COLLECT_WITH_UDF"), "true")
+#' @examplesIf arrow_with_dataset() && identical(Sys.getenv("NOT_CRAN"), "true")
 #' library(dplyr, warn.conflicts = FALSE)
 #'
 #' some_model <- lm(mpg ~ disp + cyl, data = mtcars)

--- a/r/R/compute.R
+++ b/r/R/compute.R
@@ -358,15 +358,10 @@ cast_options <- function(safe = TRUE, ...) {
 #'   auto_convert = TRUE
 #' )
 #'
-#' # User-defined functions require some special handling
-#' # in the query engine which currently require an opt-in using
-#' # the R_ARROW_COLLECT_WITH_UDF environment variable.
-#' Sys.setenv(R_ARROW_COLLECT_WITH_UDF = "true")
 #' as_arrow_table(mtcars) %>%
 #'   transmute(mpg, mpg_predicted = mtcars_predict_mpg(disp, cyl)) %>%
 #'   collect() %>%
 #'   head()
-#' Sys.unsetenv("R_ARROW_COLLECT_WITH_UDF")
 #'
 register_scalar_function <- function(name, fun, in_type, out_type,
                                      auto_convert = FALSE) {
@@ -389,6 +384,13 @@ register_scalar_function <- function(name, fun, in_type, out_type,
     function(...) build_expr(name, ...),
     update_cache = TRUE
   )
+
+  # User-defined functions require some special handling
+  # in the query engine which currently require an opt-in using
+  # the R_ARROW_COLLECT_WITH_UDF environment variable while this
+  # behaviour is stabilized.
+  # TODO(ARROW-17178) remove the need for this!
+  Sys.setenv(R_ARROW_COLLECT_WITH_UDF = "true")
 
   invisible(NULL)
 }

--- a/r/R/compute.R
+++ b/r/R/compute.R
@@ -344,7 +344,7 @@ cast_options <- function(safe = TRUE, ...) {
 #' @return `NULL`, invisibly
 #' @export
 #'
-#' @examplesIf arrow_with_dataset()
+#' @examplesIf arrow_with_dataset() && identical(Sys.getenv("R_ARROW_COLLECT_WITH_UDF"), "true")
 #' library(dplyr, warn.conflicts = FALSE)
 #'
 #' some_model <- lm(mpg ~ disp + cyl, data = mtcars)
@@ -358,10 +358,15 @@ cast_options <- function(safe = TRUE, ...) {
 #'   auto_convert = TRUE
 #' )
 #'
+#' # User-defined functions require some special handling
+#' # in the query engine which currently require an opt-in using
+#' # the R_ARROW_COLLECT_WITH_UDF environment variable.
+#' Sys.setenv(R_ARROW_COLLECT_WITH_UDF = "true")
 #' as_arrow_table(mtcars) %>%
 #'   transmute(mpg, mpg_predicted = mtcars_predict_mpg(disp, cyl)) %>%
 #'   collect() %>%
 #'   head()
+#' Sys.unsetenv("R_ARROW_COLLECT_WITH_UDF")
 #'
 register_scalar_function <- function(name, fun, in_type, out_type,
                                      auto_convert = FALSE) {

--- a/r/R/table.R
+++ b/r/R/table.R
@@ -331,5 +331,12 @@ as_arrow_table.arrow_dplyr_query <- function(x, ...) {
   # See query-engine.R for ExecPlan/Nodes
   plan <- ExecPlan$create()
   final_node <- plan$Build(x)
-  plan$Run(final_node, as_table = TRUE)
+
+  run_with_event_loop <- identical(
+    Sys.getenv("R_ARROW_COLLECT_WITH_UDF", ""),
+    "true"
+  )
+
+  result <- plan$Run(final_node, as_table = run_with_event_loop)
+  as_arrow_table(result)
 }

--- a/r/man/register_scalar_function.Rd
+++ b/r/man/register_scalar_function.Rd
@@ -48,7 +48,7 @@ stateless and return output with the same shape (i.e., the same number
 of rows) as the input.
 }
 \examples{
-\dontshow{if (arrow_with_dataset() && identical(Sys.getenv("R_ARROW_COLLECT_WITH_UDF"), "true")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (arrow_with_dataset() && identical(Sys.getenv("NOT_CRAN"), "true")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(dplyr, warn.conflicts = FALSE)
 
 some_model <- lm(mpg ~ disp + cyl, data = mtcars)

--- a/r/man/register_scalar_function.Rd
+++ b/r/man/register_scalar_function.Rd
@@ -48,7 +48,7 @@ stateless and return output with the same shape (i.e., the same number
 of rows) as the input.
 }
 \examples{
-\dontshow{if (arrow_with_dataset()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (arrow_with_dataset() && identical(Sys.getenv("R_ARROW_COLLECT_WITH_UDF"), "true")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(dplyr, warn.conflicts = FALSE)
 
 some_model <- lm(mpg ~ disp + cyl, data = mtcars)
@@ -62,9 +62,14 @@ register_scalar_function(
   auto_convert = TRUE
 )
 
+# User-defined functions require some special handling
+# in the query engine which currently require an opt-in using
+# the R_ARROW_COLLECT_WITH_UDF environment variable.
+Sys.setenv(R_ARROW_COLLECT_WITH_UDF = "true")
 as_arrow_table(mtcars) \%>\%
   transmute(mpg, mpg_predicted = mtcars_predict_mpg(disp, cyl)) \%>\%
   collect() \%>\%
   head()
+Sys.unsetenv("R_ARROW_COLLECT_WITH_UDF")
 \dontshow{\}) # examplesIf}
 }

--- a/r/man/register_scalar_function.Rd
+++ b/r/man/register_scalar_function.Rd
@@ -62,14 +62,9 @@ register_scalar_function(
   auto_convert = TRUE
 )
 
-# User-defined functions require some special handling
-# in the query engine which currently require an opt-in using
-# the R_ARROW_COLLECT_WITH_UDF environment variable.
-Sys.setenv(R_ARROW_COLLECT_WITH_UDF = "true")
 as_arrow_table(mtcars) \%>\%
   transmute(mpg, mpg_predicted = mtcars_predict_mpg(disp, cyl)) \%>\%
   collect() \%>\%
   head()
-Sys.unsetenv("R_ARROW_COLLECT_WITH_UDF")
 \dontshow{\}) # examplesIf}
 }

--- a/r/tests/testthat/test-compute.R
+++ b/r/tests/testthat/test-compute.R
@@ -81,6 +81,8 @@ test_that("arrow_scalar_function() works with auto_convert = TRUE", {
 
 test_that("register_scalar_function() adds a compute function to the registry", {
   skip_if_not(CanRunWithCapturedR())
+  # until R_ARROW_COLLECT_WITH_UDF is no longer needed to slience valgrind
+  skip_on_linux_devel()
 
   register_scalar_function(
     "times_32",

--- a/r/tests/testthat/test-compute.R
+++ b/r/tests/testthat/test-compute.R
@@ -106,14 +106,14 @@ test_that("register_scalar_function() adds a compute function to the registry", 
     Scalar$create(32L, float64())
   )
 
-  withr::with_envvar(list(R_ARROW_COLLECT_WITH_UDF = "true"), {
-    expect_identical(
-      record_batch(a = 1L) %>%
-        dplyr::mutate(b = times_32(a)) %>%
-        dplyr::collect(),
-      tibble::tibble(a = 1L, b = 32.0)
-    )
-  })
+  expect_identical(
+    record_batch(a = 1L) %>%
+      dplyr::mutate(b = times_32(a)) %>%
+      dplyr::collect(),
+    tibble::tibble(a = 1L, b = 32.0)
+  )
+
+  Sys.unsetenv("R_ARROW_COLLECT_WITH_UDF")
 })
 
 test_that("arrow_scalar_function() with bad return type errors", {
@@ -148,6 +148,9 @@ test_that("arrow_scalar_function() with bad return type errors", {
     call_function("times_32_bad_return_type_scalar", Array$create(1L)),
     "Expected return Array or Scalar with type 'double'"
   )
+
+  # TODO(ARROW-17178) remove the need for this!
+  Sys.unsetenv("R_ARROW_COLLECT_WITH_UDF")
 })
 
 test_that("register_user_defined_function() can register multiple kernels", {
@@ -208,6 +211,9 @@ test_that("register_user_defined_function() errors for unsupported specification
     ),
     "Kernels for user-defined function must accept the same number of arguments"
   )
+
+  # TODO(ARROW-17178) remove the need for this!
+  Sys.unsetenv("R_ARROW_COLLECT_WITH_UDF")
 })
 
 test_that("user-defined functions work during multi-threaded execution", {
@@ -245,26 +251,27 @@ test_that("user-defined functions work during multi-threaded execution", {
   )
   on.exit(unregister_binding("times_32", update_cache = TRUE))
 
-  withr::with_envvar(list(R_ARROW_COLLECT_WITH_UDF = "true"), {
-    # check a regular collect()
-    result <- open_dataset(tf_dataset) %>%
-      dplyr::mutate(fun_result = times_32(value)) %>%
-      dplyr::collect() %>%
-      dplyr::arrange(row_num)
+  # check a regular collect()
+  result <- open_dataset(tf_dataset) %>%
+    dplyr::mutate(fun_result = times_32(value)) %>%
+    dplyr::collect() %>%
+    dplyr::arrange(row_num)
 
-    expect_identical(result$fun_result, example_df$value * 32)
+  expect_identical(result$fun_result, example_df$value * 32)
 
-    # check a write_dataset()
-    open_dataset(tf_dataset) %>%
-      dplyr::mutate(fun_result = times_32(value)) %>%
-      write_dataset(tf_dest)
+  # check a write_dataset()
+  open_dataset(tf_dataset) %>%
+    dplyr::mutate(fun_result = times_32(value)) %>%
+    write_dataset(tf_dest)
 
-    result2 <- dplyr::collect(open_dataset(tf_dest)) %>%
-      dplyr::arrange(row_num) %>%
-      dplyr::collect()
+  result2 <- dplyr::collect(open_dataset(tf_dest)) %>%
+    dplyr::arrange(row_num) %>%
+    dplyr::collect()
 
-    expect_identical(result2$fun_result, example_df$value * 32)
-  })
+  expect_identical(result2$fun_result, example_df$value * 32)
+
+  # TODO(ARROW-17178) remove the need for this!
+  Sys.unsetenv("R_ARROW_COLLECT_WITH_UDF")
 })
 
 test_that("user-defined error when called from an unsupported context", {
@@ -314,4 +321,7 @@ test_that("user-defined error when called from an unsupported context", {
       "Call to R \\(.*?\\) from a non-R thread from an unsupported context"
     )
   }
+
+  # TODO(ARROW-17178) remove the need for this!
+  Sys.unsetenv("R_ARROW_COLLECT_WITH_UDF")
 })

--- a/r/tests/testthat/test-compute.R
+++ b/r/tests/testthat/test-compute.R
@@ -81,7 +81,8 @@ test_that("arrow_scalar_function() works with auto_convert = TRUE", {
 
 test_that("register_scalar_function() adds a compute function to the registry", {
   skip_if_not(CanRunWithCapturedR())
-  # TODO(ARROW-17178): remove when user-defined function execution is stabilized
+  # TODO(ARROW-17178): User-defined function-friendly ExecPlan execution has
+  # occasional valgrind errors
   skip_on_linux_devel()
 
   register_scalar_function(
@@ -212,8 +213,10 @@ test_that("register_user_defined_function() errors for unsupported specification
 test_that("user-defined functions work during multi-threaded execution", {
   skip_if_not(CanRunWithCapturedR())
   skip_if_not_available("dataset")
-  # Snappy has a UBSan issue: https://github.com/google/snappy/pull/148
-  # TODO(ARROW-17178): remove when user-defined function execution is stabilized
+  # Skip on linux devel because:
+  # TODO(ARROW-17283): Snappy has a UBSan issue that is fixed in the dev version
+  # TODO(ARROW-17178): User-defined function-friendly ExecPlan execution has
+  # occasional valgrind errors
   skip_on_linux_devel()
 
   n_rows <- 10000

--- a/r/tests/testthat/test-compute.R
+++ b/r/tests/testthat/test-compute.R
@@ -91,7 +91,11 @@ test_that("register_scalar_function() adds a compute function to the registry", 
     int32(), float64(),
     auto_convert = TRUE
   )
-  on.exit(unregister_binding("times_32", update_cache = TRUE))
+  on.exit({
+    unregister_binding("times_32", update_cache = TRUE)
+    # TODO(ARROW-17178) remove the need for this!
+    Sys.unsetenv("R_ARROW_COLLECT_WITH_UDF")
+  })
 
   expect_true("times_32" %in% names(asNamespace("arrow")$.cache$functions))
   expect_true("times_32" %in% list_compute_functions())
@@ -112,8 +116,6 @@ test_that("register_scalar_function() adds a compute function to the registry", 
       dplyr::collect(),
     tibble::tibble(a = 1L, b = 32.0)
   )
-
-  Sys.unsetenv("R_ARROW_COLLECT_WITH_UDF")
 })
 
 test_that("arrow_scalar_function() with bad return type errors", {
@@ -125,9 +127,11 @@ test_that("arrow_scalar_function() with bad return type errors", {
     int32(),
     float64()
   )
-  on.exit(
+  on.exit({
     unregister_binding("times_32_bad_return_type_array", update_cache = TRUE)
-  )
+    # TODO(ARROW-17178) remove the need for this!
+    Sys.unsetenv("R_ARROW_COLLECT_WITH_UDF")
+  })
 
   expect_error(
     call_function("times_32_bad_return_type_array", Array$create(1L)),
@@ -140,20 +144,19 @@ test_that("arrow_scalar_function() with bad return type errors", {
     int32(),
     float64()
   )
-  on.exit(
+  on.exit({
     unregister_binding("times_32_bad_return_type_scalar", update_cache = TRUE)
-  )
+    # TODO(ARROW-17178) remove the need for this!
+    Sys.unsetenv("R_ARROW_COLLECT_WITH_UDF")
+  })
 
   expect_error(
     call_function("times_32_bad_return_type_scalar", Array$create(1L)),
     "Expected return Array or Scalar with type 'double'"
   )
-
-  # TODO(ARROW-17178) remove the need for this!
-  Sys.unsetenv("R_ARROW_COLLECT_WITH_UDF")
 })
 
-test_that("register_user_defined_function() can register multiple kernels", {
+test_that("register_scalar_function() can register multiple kernels", {
   skip_if_not(CanRunWithCapturedR())
 
   register_scalar_function(
@@ -163,7 +166,11 @@ test_that("register_user_defined_function() can register multiple kernels", {
     out_type = function(in_types) in_types[[1]],
     auto_convert = TRUE
   )
-  on.exit(unregister_binding("times_32", update_cache = TRUE))
+  on.exit({
+    unregister_binding("times_32", update_cache = TRUE)
+    # TODO(ARROW-17178) remove the need for this!
+    Sys.unsetenv("R_ARROW_COLLECT_WITH_UDF")
+  })
 
   expect_equal(
     call_function("times_32", Scalar$create(1L, int32())),
@@ -181,7 +188,10 @@ test_that("register_user_defined_function() can register multiple kernels", {
   )
 })
 
-test_that("register_user_defined_function() errors for unsupported specifications", {
+test_that("register_scalar_function() errors for unsupported specifications", {
+  # TODO(ARROW-17178) remove the need for this!
+  on.exit(Sys.unsetenv("R_ARROW_COLLECT_WITH_UDF"))
+
   expect_error(
     register_scalar_function(
       "no_kernels",
@@ -211,9 +221,6 @@ test_that("register_user_defined_function() errors for unsupported specification
     ),
     "Kernels for user-defined function must accept the same number of arguments"
   )
-
-  # TODO(ARROW-17178) remove the need for this!
-  Sys.unsetenv("R_ARROW_COLLECT_WITH_UDF")
 })
 
 test_that("user-defined functions work during multi-threaded execution", {
@@ -249,7 +256,11 @@ test_that("user-defined functions work during multi-threaded execution", {
     float64(),
     auto_convert = TRUE
   )
-  on.exit(unregister_binding("times_32", update_cache = TRUE))
+  on.exit({
+    unregister_binding("times_32", update_cache = TRUE)
+    # TODO(ARROW-17178) remove the need for this!
+    Sys.unsetenv("R_ARROW_COLLECT_WITH_UDF")
+  })
 
   # check a regular collect()
   result <- open_dataset(tf_dataset) %>%
@@ -269,9 +280,6 @@ test_that("user-defined functions work during multi-threaded execution", {
     dplyr::collect()
 
   expect_identical(result2$fun_result, example_df$value * 32)
-
-  # TODO(ARROW-17178) remove the need for this!
-  Sys.unsetenv("R_ARROW_COLLECT_WITH_UDF")
 })
 
 test_that("user-defined error when called from an unsupported context", {
@@ -285,7 +293,11 @@ test_that("user-defined error when called from an unsupported context", {
     float64(),
     auto_convert = TRUE
   )
-  on.exit(unregister_binding("times_32", update_cache = TRUE))
+  on.exit({
+    unregister_binding("times_32", update_cache = TRUE)
+    # TODO(ARROW-17178) remove the need for this!
+    Sys.unsetenv("R_ARROW_COLLECT_WITH_UDF")
+  })
 
   stream_plan_with_udf <- function() {
    record_batch(a = 1:1000) %>%
@@ -321,7 +333,4 @@ test_that("user-defined error when called from an unsupported context", {
       "Call to R \\(.*?\\) from a non-R thread from an unsupported context"
     )
   }
-
-  # TODO(ARROW-17178) remove the need for this!
-  Sys.unsetenv("R_ARROW_COLLECT_WITH_UDF")
 })

--- a/r/tests/testthat/test-compute.R
+++ b/r/tests/testthat/test-compute.R
@@ -81,7 +81,7 @@ test_that("arrow_scalar_function() works with auto_convert = TRUE", {
 
 test_that("register_scalar_function() adds a compute function to the registry", {
   skip_if_not(CanRunWithCapturedR())
-  # until R_ARROW_COLLECT_WITH_UDF is no longer needed to slience valgrind
+  # TODO(ARROW-17178): remove when user-defined function execution is stabilized
   skip_on_linux_devel()
 
   register_scalar_function(
@@ -213,6 +213,7 @@ test_that("user-defined functions work during multi-threaded execution", {
   skip_if_not(CanRunWithCapturedR())
   skip_if_not_available("dataset")
   # Snappy has a UBSan issue: https://github.com/google/snappy/pull/148
+  # TODO(ARROW-17178): remove when user-defined function execution is stabilized
   skip_on_linux_devel()
 
   n_rows <- 10000


### PR DESCRIPTION
This PR fixes intermittent leaks that occur after one of the changes from ARROW-16444: when we drain the `RecordBatchReader` that is emitted from the plan too quickly, it seems, some parts of the plan can leak (I don't know why this happens).

I tried removing various pieces of the `RunWithCapturedR()` changes (see #13746) but the only thing that removes the errors completely is draining the resulting `RecordBatchReader` from R (i.e., `reader$read_table()`) instead of in C++ (i.e., `reader->ToTable()`). Unfortunately, for user-defined functions to work in a plan we need a C++ level `reader->ToTable()`. I took the approach here of disabling the C++ level read by default, requiring a user to opt in to the version of `collect()` that works with a UDF. It's not ideal, but definitely safer (and more clearly marks the user-defined function behaviour as experimental).

I was able to replicate the original leaks but they are few and far between...our tests just happen to create and destroy many, many exec plans and something about the CI environment seems to trigger these more reliably (although the errors don't always occur there, either). Most of the leaks are small but there were some instances where an entire `Table` leaked.