### PR TITLE
ARROW-17287: [C++] Create scan node that doesn't rely on the merged generator

### DIFF
--- a/cpp/src/arrow/compute/exec/exec_plan.h
+++ b/cpp/src/arrow/compute/exec/exec_plan.h
@@ -488,32 +488,32 @@ struct ARROW_EXPORT Declaration {
 /// This method will add a sink node to the declaration to collect results into a
 /// table.  It will then create an ExecPlan from the declaration, start the exec plan,
 /// block until the plan has finished, and return the created table.
-Result<std::shared_ptr<Table>> DeclarationToTable(
+ARROW_EXPORT Result<std::shared_ptr<Table>> DeclarationToTable(
     Declaration declaration, ExecContext* exec_context = default_exec_context());
 
 /// \brief Asynchronous version of \see DeclarationToTable
-Future<std::shared_ptr<Table>> DeclarationToTableAsync(
+ARROW_EXPORT Future<std::shared_ptr<Table>> DeclarationToTableAsync(
     Declaration declaration, ExecContext* exec_context = default_exec_context());
 
 /// \brief Utility method to run a declaration and collect the results into ExecBatch
 /// vector
 ///
 /// \see DeclarationToTable for details
-Result<std::vector<ExecBatch>> DeclarationToExecBatches(
+ARROW_EXPORT Result<std::vector<ExecBatch>> DeclarationToExecBatches(
     Declaration declaration, ExecContext* exec_context = default_exec_context());
 
 /// \brief Asynchronous version of \see DeclarationToExecBatches
-Future<std::vector<ExecBatch>> DeclarationToExecBatchesAsync(
+ARROW_EXPORT Future<std::vector<ExecBatch>> DeclarationToExecBatchesAsync(
     Declaration declaration, ExecContext* exec_context = default_exec_context());
 
 /// \brief Utility method to run a declaration and collect the results into a vector
 ///
 /// \see DeclarationToTable for details
-Result<std::vector<std::shared_ptr<RecordBatch>>> DeclarationToBatches(
+ARROW_EXPORT Result<std::vector<std::shared_ptr<RecordBatch>>> DeclarationToBatches(
     Declaration declaration, ExecContext* exec_context = default_exec_context());
 
 /// \brief Asynchronous version of \see DeclarationToBatches
-Future<std::vector<std::shared_ptr<RecordBatch>>> DeclarationToBatchesAsync(
+ARROW_EXPORT Future<std::vector<std::shared_ptr<RecordBatch>>> DeclarationToBatchesAsync(
     Declaration declaration, ExecContext* exec_context = default_exec_context());
 
 /// \brief Wrap an ExecBatch generator in a RecordBatchReader.

--- a/cpp/src/arrow/compute/exec/exec_plan.h
+++ b/cpp/src/arrow/compute/exec/exec_plan.h
@@ -483,6 +483,39 @@ struct ARROW_EXPORT Declaration {
   std::string label;
 };
 
+/// \brief Utility method to run a declaration and collect the results into a table
+///
+/// This method will add a sink node to the declaration to collect results into a
+/// table.  It will then create an ExecPlan from the declaration, start the exec plan,
+/// block until the plan has finished, and return the created table.
+Result<std::shared_ptr<Table>> DeclarationToTable(
+    Declaration declaration, ExecContext* exec_context = default_exec_context());
+
+/// \brief Asynchronous version of \see DeclarationToTable
+Future<std::shared_ptr<Table>> DeclarationToTableAsync(
+    Declaration declaration, ExecContext* exec_context = default_exec_context());
+
+/// \brief Utility method to run a declaration and collect the results into ExecBatch
+/// vector
+///
+/// \see DeclarationToTable for details
+Result<std::vector<ExecBatch>> DeclarationToExecBatches(
+    Declaration declaration, ExecContext* exec_context = default_exec_context());
+
+/// \brief Asynchronous version of \see DeclarationToExecBatches
+Future<std::vector<ExecBatch>> DeclarationToExecBatchesAsync(
+    Declaration declaration, ExecContext* exec_context = default_exec_context());
+
+/// \brief Utility method to run a declaration and collect the results into a vector
+///
+/// \see DeclarationToTable for details
+Result<std::vector<std::shared_ptr<RecordBatch>>> DeclarationToBatches(
+    Declaration declaration, ExecContext* exec_context = default_exec_context());
+
+/// \brief Asynchronous version of \see DeclarationToBatches
+Future<std::vector<std::shared_ptr<RecordBatch>>> DeclarationToBatchesAsync(
+    Declaration declaration, ExecContext* exec_context = default_exec_context());
+
 /// \brief Wrap an ExecBatch generator in a RecordBatchReader.
 ///
 /// The RecordBatchReader does not impose any ordering on emitted batches.

--- a/cpp/src/arrow/compute/exec/expression.cc
+++ b/cpp/src/arrow/compute/exec/expression.cc
@@ -77,9 +77,15 @@ Expression call(std::string function, std::vector<Expression> arguments,
   return Expression(std::move(call));
 }
 
-const Datum* Expression::literal() const { return std::get_if<Datum>(impl_.get()); }
+const Datum* Expression::literal() const {
+  if (impl_ == nullptr) return nullptr;
+
+  return std::get_if<Datum>(impl_.get());
+}
 
 const Expression::Parameter* Expression::parameter() const {
+  if (impl_ == nullptr) return nullptr;
+
   return std::get_if<Parameter>(impl_.get());
 }
 
@@ -91,6 +97,8 @@ const FieldRef* Expression::field_ref() const {
 }
 
 const Expression::Call* Expression::call() const {
+  if (impl_ == nullptr) return nullptr;
+
   return std::get_if<Call>(impl_.get());
 }
 

--- a/cpp/src/arrow/compute/exec/expression.h
+++ b/cpp/src/arrow/compute/exec/expression.h
@@ -279,53 +279,6 @@ ARROW_EXPORT Expression or_(Expression lhs, Expression rhs);
 ARROW_EXPORT Expression or_(const std::vector<Expression>&);
 ARROW_EXPORT Expression not_(Expression operand);
 
-/// Modify an Expression with pre-order and post-order visitation.
-/// `pre` will be invoked on each Expression. `pre` will visit Calls before their
-/// arguments, `post_call` will visit Calls (and no other Expressions) after their
-/// arguments. Visitors should return the Identical expression to indicate no change; this
-/// will prevent unnecessary construction in the common case where a modification is not
-/// possible/necessary/...
-///
-/// If an argument was modified, `post_call` visits a reconstructed Call with the modified
-/// arguments but also receives a pointer to the unmodified Expression as a second
-/// argument. If no arguments were modified the unmodified Expression* will be nullptr.
-template <typename PreVisit, typename PostVisitCall>
-Result<Expression> Modify(Expression expr, const PreVisit& pre,
-                          const PostVisitCall& post_call) {
-  ARROW_ASSIGN_OR_RAISE(expr, Result<Expression>(pre(std::move(expr))));
-
-  auto call = expr.call();
-  if (!call) return expr;
-
-  bool at_least_one_modified = false;
-  std::vector<Expression> modified_arguments;
-
-  for (size_t i = 0; i < call->arguments.size(); ++i) {
-    ARROW_ASSIGN_OR_RAISE(auto modified_argument,
-                          Modify(call->arguments[i], pre, post_call));
-
-    if (Identical(modified_argument, call->arguments[i])) {
-      continue;
-    }
-
-    if (!at_least_one_modified) {
-      modified_arguments = call->arguments;
-      at_least_one_modified = true;
-    }
-
-    modified_arguments[i] = std::move(modified_argument);
-  }
-
-  if (at_least_one_modified) {
-    // reconstruct the call expression with the modified arguments
-    auto modified_call = *call;
-    modified_call.arguments = std::move(modified_arguments);
-    return post_call(Expression(std::move(modified_call)), &expr);
-  }
-
-  return post_call(std::move(expr), nullptr);
-}
-
 /// @}
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/exec/expression.h
+++ b/cpp/src/arrow/compute/exec/expression.h
@@ -100,6 +100,8 @@ class ARROW_EXPORT Expression {
   // XXX someday
   // Result<PipelineGraph> GetPipelines();
 
+  bool is_valid() const { return impl_ != NULLPTR; }
+
   /// Access a Call or return nullptr if this expression is not a call
   const Call* call() const;
   /// Access a Datum or return nullptr if this expression is not a literal
@@ -276,6 +278,53 @@ ARROW_EXPORT Expression and_(const std::vector<Expression>&);
 ARROW_EXPORT Expression or_(Expression lhs, Expression rhs);
 ARROW_EXPORT Expression or_(const std::vector<Expression>&);
 ARROW_EXPORT Expression not_(Expression operand);
+
+/// Modify an Expression with pre-order and post-order visitation.
+/// `pre` will be invoked on each Expression. `pre` will visit Calls before their
+/// arguments, `post_call` will visit Calls (and no other Expressions) after their
+/// arguments. Visitors should return the Identical expression to indicate no change; this
+/// will prevent unnecessary construction in the common case where a modification is not
+/// possible/necessary/...
+///
+/// If an argument was modified, `post_call` visits a reconstructed Call with the modified
+/// arguments but also receives a pointer to the unmodified Expression as a second
+/// argument. If no arguments were modified the unmodified Expression* will be nullptr.
+template <typename PreVisit, typename PostVisitCall>
+Result<Expression> Modify(Expression expr, const PreVisit& pre,
+                          const PostVisitCall& post_call) {
+  ARROW_ASSIGN_OR_RAISE(expr, Result<Expression>(pre(std::move(expr))));
+
+  auto call = expr.call();
+  if (!call) return expr;
+
+  bool at_least_one_modified = false;
+  std::vector<Expression> modified_arguments;
+
+  for (size_t i = 0; i < call->arguments.size(); ++i) {
+    ARROW_ASSIGN_OR_RAISE(auto modified_argument,
+                          Modify(call->arguments[i], pre, post_call));
+
+    if (Identical(modified_argument, call->arguments[i])) {
+      continue;
+    }
+
+    if (!at_least_one_modified) {
+      modified_arguments = call->arguments;
+      at_least_one_modified = true;
+    }
+
+    modified_arguments[i] = std::move(modified_argument);
+  }
+
+  if (at_least_one_modified) {
+    // reconstruct the call expression with the modified arguments
+    auto modified_call = *call;
+    modified_call.arguments = std::move(modified_arguments);
+    return post_call(Expression(std::move(modified_call)), &expr);
+  }
+
+  return post_call(std::move(expr), nullptr);
+}
 
 /// @}
 

--- a/cpp/src/arrow/compute/exec/expression_internal.h
+++ b/cpp/src/arrow/compute/exec/expression_internal.h
@@ -287,52 +287,5 @@ inline Result<std::shared_ptr<compute::Function>> GetFunction(
   return GetCastFunction(*to_type);
 }
 
-/// Modify an Expression with pre-order and post-order visitation.
-/// `pre` will be invoked on each Expression. `pre` will visit Calls before their
-/// arguments, `post_call` will visit Calls (and no other Expressions) after their
-/// arguments. Visitors should return the Identical expression to indicate no change; this
-/// will prevent unnecessary construction in the common case where a modification is not
-/// possible/necessary/...
-///
-/// If an argument was modified, `post_call` visits a reconstructed Call with the modified
-/// arguments but also receives a pointer to the unmodified Expression as a second
-/// argument. If no arguments were modified the unmodified Expression* will be nullptr.
-template <typename PreVisit, typename PostVisitCall>
-Result<Expression> Modify(Expression expr, const PreVisit& pre,
-                          const PostVisitCall& post_call) {
-  ARROW_ASSIGN_OR_RAISE(expr, Result<Expression>(pre(std::move(expr))));
-
-  auto call = expr.call();
-  if (!call) return expr;
-
-  bool at_least_one_modified = false;
-  std::vector<Expression> modified_arguments;
-
-  for (size_t i = 0; i < call->arguments.size(); ++i) {
-    ARROW_ASSIGN_OR_RAISE(auto modified_argument,
-                          Modify(call->arguments[i], pre, post_call));
-
-    if (Identical(modified_argument, call->arguments[i])) {
-      continue;
-    }
-
-    if (!at_least_one_modified) {
-      modified_arguments = call->arguments;
-      at_least_one_modified = true;
-    }
-
-    modified_arguments[i] = std::move(modified_argument);
-  }
-
-  if (at_least_one_modified) {
-    // reconstruct the call expression with the modified arguments
-    auto modified_call = *call;
-    modified_call.arguments = std::move(modified_arguments);
-    return post_call(Expression(std::move(modified_call)), &expr);
-  }
-
-  return post_call(std::move(expr), nullptr);
-}
-
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/exec/expression_internal.h
+++ b/cpp/src/arrow/compute/exec/expression_internal.h
@@ -287,5 +287,52 @@ inline Result<std::shared_ptr<compute::Function>> GetFunction(
   return GetCastFunction(*to_type);
 }
 
+/// Modify an Expression with pre-order and post-order visitation.
+/// `pre` will be invoked on each Expression. `pre` will visit Calls before their
+/// arguments, `post_call` will visit Calls (and no other Expressions) after their
+/// arguments. Visitors should return the Identical expression to indicate no change; this
+/// will prevent unnecessary construction in the common case where a modification is not
+/// possible/necessary/...
+///
+/// If an argument was modified, `post_call` visits a reconstructed Call with the modified
+/// arguments but also receives a pointer to the unmodified Expression as a second
+/// argument. If no arguments were modified the unmodified Expression* will be nullptr.
+template <typename PreVisit, typename PostVisitCall>
+Result<Expression> Modify(Expression expr, const PreVisit& pre,
+                          const PostVisitCall& post_call) {
+  ARROW_ASSIGN_OR_RAISE(expr, Result<Expression>(pre(std::move(expr))));
+
+  auto call = expr.call();
+  if (!call) return expr;
+
+  bool at_least_one_modified = false;
+  std::vector<Expression> modified_arguments;
+
+  for (size_t i = 0; i < call->arguments.size(); ++i) {
+    ARROW_ASSIGN_OR_RAISE(auto modified_argument,
+                          Modify(call->arguments[i], pre, post_call));
+
+    if (Identical(modified_argument, call->arguments[i])) {
+      continue;
+    }
+
+    if (!at_least_one_modified) {
+      modified_arguments = call->arguments;
+      at_least_one_modified = true;
+    }
+
+    modified_arguments[i] = std::move(modified_argument);
+  }
+
+  if (at_least_one_modified) {
+    // reconstruct the call expression with the modified arguments
+    auto modified_call = *call;
+    modified_call.arguments = std::move(modified_arguments);
+    return post_call(Expression(std::move(modified_call)), &expr);
+  }
+
+  return post_call(std::move(expr), nullptr);
+}
+
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/exec/filter_node.cc
+++ b/cpp/src/arrow/compute/exec/filter_node.cc
@@ -38,8 +38,8 @@ namespace {
 class FilterNode : public MapNode {
  public:
   FilterNode(ExecPlan* plan, std::vector<ExecNode*> inputs,
-             std::shared_ptr<Schema> output_schema, Expression filter, bool async_mode)
-      : MapNode(plan, std::move(inputs), std::move(output_schema), async_mode),
+             std::shared_ptr<Schema> output_schema, Expression filter)
+      : MapNode(plan, std::move(inputs), std::move(output_schema)),
         filter_(std::move(filter)) {}
 
   static Result<ExecNode*> Make(ExecPlan* plan, std::vector<ExecNode*> inputs,
@@ -61,8 +61,7 @@ class FilterNode : public MapNode {
                                filter_expression.type()->ToString());
     }
     return plan->EmplaceNode<FilterNode>(plan, std::move(inputs), std::move(schema),
-                                         std::move(filter_expression),
-                                         filter_options.async_mode);
+                                         std::move(filter_expression));
   }
 
   const char* kind_name() const override { return "FilterNode"; }

--- a/cpp/src/arrow/compute/exec/map_node.cc
+++ b/cpp/src/arrow/compute/exec/map_node.cc
@@ -76,9 +76,6 @@ void MapNode::StopProducing(ExecNode* output) {
 
 void MapNode::StopProducing() {
   EVENT(span_, "StopProducing");
-  if (executor_) {
-    this->stop_source_.RequestStop();
-  }
   if (input_counter_.Cancel()) {
     this->Finish();
   }

--- a/cpp/src/arrow/compute/exec/map_node.cc
+++ b/cpp/src/arrow/compute/exec/map_node.cc
@@ -34,16 +34,10 @@ namespace arrow {
 namespace compute {
 
 MapNode::MapNode(ExecPlan* plan, std::vector<ExecNode*> inputs,
-                 std::shared_ptr<Schema> output_schema, bool async_mode)
+                 std::shared_ptr<Schema> output_schema)
     : ExecNode(plan, std::move(inputs), /*input_labels=*/{"target"},
                std::move(output_schema),
-               /*num_outputs=*/1) {
-  if (async_mode) {
-    executor_ = plan_->exec_context()->executor();
-  } else {
-    executor_ = nullptr;
-  }
-}
+               /*num_outputs=*/1) {}
 
 void MapNode::ErrorReceived(ExecNode* input, Status error) {
   DCHECK_EQ(input, inputs_[0]);

--- a/cpp/src/arrow/compute/exec/map_node.h
+++ b/cpp/src/arrow/compute/exec/map_node.h
@@ -69,9 +69,6 @@ class ARROW_EXPORT MapNode : public ExecNode {
  protected:
   // Counter for the number of batches received
   AtomicCounter input_counter_;
-
-  // Variable used to cancel remaining tasks in the executor
-  StopSource stop_source_;
 };
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/exec/map_node.h
+++ b/cpp/src/arrow/compute/exec/map_node.h
@@ -45,7 +45,7 @@ namespace compute {
 class ARROW_EXPORT MapNode : public ExecNode {
  public:
   MapNode(ExecPlan* plan, std::vector<ExecNode*> inputs,
-          std::shared_ptr<Schema> output_schema, bool async_mode);
+          std::shared_ptr<Schema> output_schema);
 
   void ErrorReceived(ExecNode* input, Status error) override;
 
@@ -69,8 +69,6 @@ class ARROW_EXPORT MapNode : public ExecNode {
  protected:
   // Counter for the number of batches received
   AtomicCounter input_counter_;
-
-  ::arrow::internal::Executor* executor_;
 
   // Variable used to cancel remaining tasks in the executor
   StopSource stop_source_;

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -84,11 +84,10 @@ class ARROW_EXPORT TableSourceNodeOptions : public ExecNodeOptions {
 /// excluded in the batch emitted by this node.
 class ARROW_EXPORT FilterNodeOptions : public ExecNodeOptions {
  public:
-  explicit FilterNodeOptions(Expression filter_expression, bool async_mode = true)
-      : filter_expression(std::move(filter_expression)), async_mode(async_mode) {}
+  explicit FilterNodeOptions(Expression filter_expression)
+      : filter_expression(std::move(filter_expression)) {}
 
   Expression filter_expression;
-  bool async_mode;
 };
 
 /// \brief Make a node which executes expressions on input batches, producing new batches.
@@ -100,14 +99,11 @@ class ARROW_EXPORT FilterNodeOptions : public ExecNodeOptions {
 class ARROW_EXPORT ProjectNodeOptions : public ExecNodeOptions {
  public:
   explicit ProjectNodeOptions(std::vector<Expression> expressions,
-                              std::vector<std::string> names = {}, bool async_mode = true)
-      : expressions(std::move(expressions)),
-        names(std::move(names)),
-        async_mode(async_mode) {}
+                              std::vector<std::string> names = {})
+      : expressions(std::move(expressions)), names(std::move(names)) {}
 
   std::vector<Expression> expressions;
   std::vector<std::string> names;
-  bool async_mode;
 };
 
 /// \brief Make a node which aggregates input batches, optionally grouped by keys.

--- a/cpp/src/arrow/compute/exec/project_node.cc
+++ b/cpp/src/arrow/compute/exec/project_node.cc
@@ -41,9 +41,8 @@ namespace {
 class ProjectNode : public MapNode {
  public:
   ProjectNode(ExecPlan* plan, std::vector<ExecNode*> inputs,
-              std::shared_ptr<Schema> output_schema, std::vector<Expression> exprs,
-              bool async_mode)
-      : MapNode(plan, std::move(inputs), std::move(output_schema), async_mode),
+              std::shared_ptr<Schema> output_schema, std::vector<Expression> exprs)
+      : MapNode(plan, std::move(inputs), std::move(output_schema)),
         exprs_(std::move(exprs)) {}
 
   static Result<ExecNode*> Make(ExecPlan* plan, std::vector<ExecNode*> inputs,
@@ -72,8 +71,7 @@ class ProjectNode : public MapNode {
       ++i;
     }
     return plan->EmplaceNode<ProjectNode>(plan, std::move(inputs),
-                                          schema(std::move(fields)), std::move(exprs),
-                                          project_options.async_mode);
+                                          schema(std::move(fields)), std::move(exprs));
   }
 
   const char* kind_name() const override { return "ProjectNode"; }

--- a/cpp/src/arrow/compute/exec/util.cc
+++ b/cpp/src/arrow/compute/exec/util.cc
@@ -399,7 +399,7 @@ Status TableSinkNodeConsumer::Consume(ExecBatch batch) {
 }
 
 Future<> TableSinkNodeConsumer::Finish() {
-  ARROW_ASSIGN_OR_RAISE(*out_, Table::FromRecordBatches(batches_));
+  ARROW_ASSIGN_OR_RAISE(*out_, Table::FromRecordBatches(schema_, batches_));
   return Status::OK();
 }
 

--- a/cpp/src/arrow/compute/exec/util.h
+++ b/cpp/src/arrow/compute/exec/util.h
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "arrow/buffer.h"
+#include "arrow/compute/exec/expression.h"
 #include "arrow/compute/exec/options.h"
 #include "arrow/compute/type_fwd.h"
 #include "arrow/memory_pool.h"
@@ -360,6 +361,53 @@ struct ARROW_EXPORT TableSinkNodeConsumer : public SinkNodeConsumer {
   std::vector<std::shared_ptr<RecordBatch>> batches_;
   util::Mutex consume_mutex_;
 };
+
+/// Modify an Expression with pre-order and post-order visitation.
+/// `pre` will be invoked on each Expression. `pre` will visit Calls before their
+/// arguments, `post_call` will visit Calls (and no other Expressions) after their
+/// arguments. Visitors should return the Identical expression to indicate no change; this
+/// will prevent unnecessary construction in the common case where a modification is not
+/// possible/necessary/...
+///
+/// If an argument was modified, `post_call` visits a reconstructed Call with the modified
+/// arguments but also receives a pointer to the unmodified Expression as a second
+/// argument. If no arguments were modified the unmodified Expression* will be nullptr.
+template <typename PreVisit, typename PostVisitCall>
+Result<Expression> ModifyExpression(Expression expr, const PreVisit& pre,
+                                    const PostVisitCall& post_call) {
+  ARROW_ASSIGN_OR_RAISE(expr, Result<Expression>(pre(std::move(expr))));
+
+  auto call = expr.call();
+  if (!call) return expr;
+
+  bool at_least_one_modified = false;
+  std::vector<Expression> modified_arguments;
+
+  for (size_t i = 0; i < call->arguments.size(); ++i) {
+    ARROW_ASSIGN_OR_RAISE(auto modified_argument,
+                          ModifyExpression(call->arguments[i], pre, post_call));
+
+    if (Identical(modified_argument, call->arguments[i])) {
+      continue;
+    }
+
+    if (!at_least_one_modified) {
+      modified_arguments = call->arguments;
+      at_least_one_modified = true;
+    }
+
+    modified_arguments[i] = std::move(modified_argument);
+  }
+
+  if (at_least_one_modified) {
+    // reconstruct the call expression with the modified arguments
+    auto modified_call = *call;
+    modified_call.arguments = std::move(modified_arguments);
+    return post_call(Expression(std::move(modified_call)), &expr);
+  }
+
+  return post_call(std::move(expr), nullptr);
+}
 
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/exec/util.h
+++ b/cpp/src/arrow/compute/exec/util.h
@@ -406,7 +406,7 @@ Result<Expression> ModifyExpression(Expression expr, const PreVisit& pre,
     return post_call(Expression(std::move(modified_call)), &expr);
   }
 
-  return post_call(std::move(expr), nullptr);
+  return post_call(std::move(expr), NULLPTR);
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/dataset/CMakeLists.txt
+++ b/cpp/src/arrow/dataset/CMakeLists.txt
@@ -28,7 +28,8 @@ set(ARROW_DATASET_SRCS
     partition.cc
     plan.cc
     projector.cc
-    scanner.cc)
+    scanner.cc
+    scan_node.cc)
 
 set(ARROW_DATASET_STATIC_LINK_LIBS)
 set(ARROW_DATASET_SHARED_LINK_LIBS)

--- a/cpp/src/arrow/dataset/dataset.cc
+++ b/cpp/src/arrow/dataset/dataset.cc
@@ -422,8 +422,8 @@ class BasicFragmentEvolution : public FragmentEvolutionStrategy {
         ds_to_frag_map.push_back(column_idx_itr->second);
       }
     }
-    return ::arrow::internal::make_unique<BasicFragmentEvolution>(
-        std::move(ds_to_frag_map), dataset_schema.get());
+    return std::make_unique<BasicFragmentEvolution>(std::move(ds_to_frag_map),
+                                                    dataset_schema.get());
   }
 };
 
@@ -441,7 +441,7 @@ class BasicDatasetEvolutionStrategy : public DatasetEvolutionStrategy {
 }  // namespace
 
 std::unique_ptr<DatasetEvolutionStrategy> MakeBasicDatasetEvolutionStrategy() {
-  return ::arrow::internal::make_unique<BasicDatasetEvolutionStrategy>();
+  return std::make_unique<BasicDatasetEvolutionStrategy>();
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/dataset.cc
+++ b/cpp/src/arrow/dataset/dataset.cc
@@ -18,6 +18,7 @@
 #include <memory>
 #include <utility>
 
+#include "arrow/compute/exec/expression_internal.h"
 #include "arrow/dataset/dataset.h"
 #include "arrow/dataset/dataset_internal.h"
 #include "arrow/dataset/scanner.h"
@@ -331,7 +332,7 @@ class BasicFragmentEvolution : public FragmentEvolutionStrategy {
     if (missing_fields.size() == 1) {
       return missing_fields[0];
     }
-    return compute::and_(missing_fields);
+    return compute::and_(std::move(missing_fields));
   }
 
   Result<std::vector<FragmentSelectionColumn>> DevolveSelection(

--- a/cpp/src/arrow/dataset/dataset.cc
+++ b/cpp/src/arrow/dataset/dataset.cc
@@ -18,7 +18,7 @@
 #include <memory>
 #include <utility>
 
-#include "arrow/compute/exec/expression_internal.h"
+#include "arrow/compute/exec/util.h"
 #include "arrow/dataset/dataset.h"
 #include "arrow/dataset/dataset_internal.h"
 #include "arrow/dataset/scanner.h"
@@ -357,7 +357,7 @@ class BasicFragmentEvolution : public FragmentEvolutionStrategy {
 
   Result<compute::Expression> DevolveFilter(
       const compute::Expression& filter) const override {
-    return compute::Modify(
+    return compute::ModifyExpression(
         filter,
         [&](compute::Expression expr) -> Result<compute::Expression> {
           const FieldRef* ref = expr.field_ref();

--- a/cpp/src/arrow/dataset/dataset.cc
+++ b/cpp/src/arrow/dataset/dataset.cc
@@ -24,6 +24,7 @@
 #include "arrow/table.h"
 #include "arrow/util/async_generator.h"
 #include "arrow/util/bit_util.h"
+#include "arrow/util/byte_size.h"
 #include "arrow/util/iterator.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/thread_pool.h"
@@ -34,10 +35,21 @@ using internal::checked_pointer_cast;
 
 namespace dataset {
 
+const compute::Expression Fragment::kNoPartitionInformation = compute::literal(true);
+
 Fragment::Fragment(compute::Expression partition_expression,
                    std::shared_ptr<Schema> physical_schema)
     : partition_expression_(std::move(partition_expression)),
       physical_schema_(std::move(physical_schema)) {}
+
+Future<std::shared_ptr<InspectedFragment>> Fragment::InspectFragment() {
+  return Status::NotImplemented("Inspect fragment");
+}
+
+Future<std::shared_ptr<FragmentScanner>> Fragment::BeginScan(
+    const FragmentScanRequest& request, const InspectedFragment& inspected_fragment) {
+  return Status::NotImplemented("New scan method");
+}
 
 Result<std::shared_ptr<Schema>> Fragment::ReadPhysicalSchema() {
   {
@@ -139,6 +151,37 @@ Future<std::optional<int64_t>> InMemoryFragment::CountRows(
     total += batch->num_rows();
   }
   return Future<std::optional<int64_t>>::MakeFinished(total);
+}
+
+Future<std::shared_ptr<InspectedFragment>> InMemoryFragment::InspectFragment() {
+  return std::make_shared<InspectedFragment>(physical_schema_->field_names());
+}
+
+class InMemoryFragment::Scanner : public FragmentScanner {
+ public:
+  explicit Scanner(InMemoryFragment* fragment) : fragment_(fragment) {}
+
+  Future<std::shared_ptr<RecordBatch>> ScanBatch(int batch_number) override {
+    return Future<std::shared_ptr<RecordBatch>>::MakeFinished(
+        fragment_->record_batches_[batch_number]);
+  }
+
+  int64_t EstimatedDataBytes(int batch_number) override {
+    return arrow::util::TotalBufferSize(*fragment_->record_batches_[batch_number]);
+  }
+
+  int NumBatches() override {
+    return static_cast<int>(fragment_->record_batches_.size());
+  }
+
+ private:
+  InMemoryFragment* fragment_;
+};
+
+Future<std::shared_ptr<FragmentScanner>> InMemoryFragment::BeginScan(
+    const FragmentScanRequest& request, const InspectedFragment& inspected_fragment) {
+  return Future<std::shared_ptr<FragmentScanner>>::MakeFinished(
+      std::make_shared<InMemoryFragment::Scanner>(this));
 }
 
 Dataset::Dataset(std::shared_ptr<Schema> schema, compute::Expression partition_expression)
@@ -263,6 +306,142 @@ Result<std::shared_ptr<Dataset>> UnionDataset::ReplaceSchema(
 
 Result<FragmentIterator> UnionDataset::GetFragmentsImpl(compute::Expression predicate) {
   return GetFragmentsFromDatasets(children_, predicate);
+}
+
+namespace {
+
+class BasicFragmentEvolution : public FragmentEvolutionStrategy {
+ public:
+  BasicFragmentEvolution(std::vector<int> ds_to_frag_map, Schema* dataset_schema)
+      : ds_to_frag_map(std::move(ds_to_frag_map)), dataset_schema(dataset_schema) {}
+
+  Result<compute::Expression> GetGuarantee(
+      const std::vector<FieldPath>& dataset_schema_selection) const override {
+    std::vector<compute::Expression> missing_fields;
+    for (const FieldPath& path : dataset_schema_selection) {
+      int top_level_field_idx = path[0];
+      if (ds_to_frag_map[top_level_field_idx] < 0) {
+        missing_fields.push_back(
+            compute::is_null(compute::field_ref(top_level_field_idx)));
+      }
+    }
+    if (missing_fields.empty()) {
+      return compute::literal(true);
+    }
+    if (missing_fields.size() == 1) {
+      return missing_fields[0];
+    }
+    return compute::and_(missing_fields);
+  }
+
+  Result<std::vector<FragmentSelectionColumn>> DevolveSelection(
+      const std::vector<FieldPath>& dataset_schema_selection) const override {
+    std::vector<FragmentSelectionColumn> desired_columns;
+    for (std::size_t selection_idx = 0; selection_idx < dataset_schema_selection.size();
+         selection_idx++) {
+      const FieldPath& path = dataset_schema_selection[selection_idx];
+      int top_level_field_idx = path[0];
+      int dest_top_level_idx = ds_to_frag_map[top_level_field_idx];
+      if (dest_top_level_idx >= 0) {
+        ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Field> field, path.Get(*dataset_schema));
+        std::vector<int> dest_path_indices(path.indices());
+        dest_path_indices[0] = dest_top_level_idx;
+        desired_columns.push_back(
+            FragmentSelectionColumn{FieldPath(dest_path_indices), field->type().get(),
+                                    static_cast<int>(selection_idx)});
+      }
+    }
+    return std::move(desired_columns);
+  };
+
+  Result<compute::Expression> DevolveFilter(
+      const compute::Expression& filter) const override {
+    return compute::Modify(
+        filter,
+        [&](compute::Expression expr) -> Result<compute::Expression> {
+          const FieldRef* ref = expr.field_ref();
+          if (ref) {
+            ARROW_ASSIGN_OR_RAISE(FieldPath path, ref->FindOne(*dataset_schema));
+            int top_level_idx = path[0];
+            std::vector<int> modified_indices(path.indices());
+            modified_indices[0] = ds_to_frag_map[top_level_idx];
+            if (modified_indices[0] < 0) {
+              return Status::Invalid(
+                  "Filter cannot be applied.  It refers to a missing field ",
+                  ref->ToString(),
+                  " in a way that cannot be satisfied even though we know that field is "
+                  "null");
+            }
+            return compute::field_ref(FieldRef(std::move(modified_indices)));
+          }
+          return std::move(expr);
+        },
+        [](compute::Expression expr, compute::Expression* old_expr) { return expr; });
+  };
+
+  Result<compute::ExecBatch> EvolveBatch(
+      const std::shared_ptr<RecordBatch>& batch,
+      const std::vector<FieldPath>& dataset_selection,
+      const std::vector<FragmentSelectionColumn>& selection) const override {
+    std::vector<Datum> columns(dataset_selection.size());
+    DCHECK_EQ(batch->num_columns(), static_cast<int>(selection.size()));
+    // First go through and populate the columns we retrieved
+    for (int idx = 0; idx < batch->num_columns(); idx++) {
+      columns[selection[idx].selection_index] = batch->column(idx);
+    }
+    // Next go through and fill in the null columns
+    for (std::size_t idx = 0; idx < dataset_selection.size(); idx++) {
+      int top_level_idx = dataset_selection[idx][0];
+      if (ds_to_frag_map[top_level_idx] < 0) {
+        columns[idx] = MakeNullScalar(
+            dataset_schema->field(static_cast<int>(top_level_idx))->type());
+      }
+    }
+    return compute::ExecBatch(columns, batch->num_rows());
+  };
+
+  std::string ToString() const override { return "basic-fragment-evolution"; }
+
+  std::vector<int> ds_to_frag_map;
+  Schema* dataset_schema;
+
+  static std::unique_ptr<BasicFragmentEvolution> Make(
+      const std::shared_ptr<Schema>& dataset_schema,
+      const std::vector<std::string>& fragment_column_names) {
+    std::vector<int> ds_to_frag_map;
+    std::unordered_map<std::string, int> column_names_map;
+    for (size_t i = 0; i < fragment_column_names.size(); i++) {
+      column_names_map[fragment_column_names[i]] = static_cast<int>(i);
+    }
+    for (int idx = 0; idx < dataset_schema->num_fields(); idx++) {
+      const std::string& field_name = dataset_schema->field(idx)->name();
+      auto column_idx_itr = column_names_map.find(field_name);
+      if (column_idx_itr == column_names_map.end()) {
+        ds_to_frag_map.push_back(-1);
+      } else {
+        ds_to_frag_map.push_back(column_idx_itr->second);
+      }
+    }
+    return ::arrow::internal::make_unique<BasicFragmentEvolution>(
+        std::move(ds_to_frag_map), dataset_schema.get());
+  }
+};
+
+class BasicDatasetEvolutionStrategy : public DatasetEvolutionStrategy {
+  std::unique_ptr<FragmentEvolutionStrategy> GetStrategy(
+      const Dataset& dataset, const Fragment& fragment,
+      const InspectedFragment& inspected_fragment) override {
+    return BasicFragmentEvolution::Make(dataset.schema(),
+                                        inspected_fragment.column_names);
+  }
+
+  std::string ToString() const override { return "basic-dataset-evolution"; }
+};
+
+}  // namespace
+
+std::unique_ptr<DatasetEvolutionStrategy> MakeBasicDatasetEvolutionStrategy() {
+  return ::arrow::internal::make_unique<BasicDatasetEvolutionStrategy>();
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/dataset.h
+++ b/cpp/src/arrow/dataset/dataset.h
@@ -30,6 +30,7 @@
 #include "arrow/dataset/type_fwd.h"
 #include "arrow/dataset/visibility.h"
 #include "arrow/util/async_generator_fwd.h"
+#include "arrow/util/future.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/mutex.h"
 
@@ -43,17 +44,91 @@ namespace dataset {
 
 using RecordBatchGenerator = std::function<Future<std::shared_ptr<RecordBatch>>()>;
 
+/// \brief Description of a column to scan
+struct FragmentSelectionColumn {
+  /// \brief The path to the column to load
+  FieldPath path;
+  /// \brief The type of the column in the dataset schema
+  ///
+  /// A format may choose to ignore this field completely.  For example, when
+  /// reading from IPC the reader can just return the column in the data type
+  /// that is stored on disk.  There is no point in doing anything special.
+  ///
+  /// However, some formats may be capable of casting on the fly.  For example,
+  /// when reading from CSV, if we know the target type of the column, we can
+  /// convert from string to the target type as we read.
+  DataType* requested_type;
+  /// \brief The index in the output selection of this column
+  int selection_index;
+};
+/// \brief Instructions for scanning a particular fragment
+///
+/// The fragment scan request is dervied from ScanV2Options.  The main
+/// difference is that the scan options are based on the dataset schema
+/// while the fragment request is based on the fragment schema.
+struct FragmentScanRequest {
+  /// \brief A row filter
+  ///
+  /// The filter expression should be written against the fragment schema.
+  ///
+  /// \see ScanV2Options for details on how this filter should be applied
+  compute::Expression filter = compute::literal(true);
+
+  /// \brief The columns to scan
+  ///
+  /// These indices refer to the fragment schema
+  ///
+  /// Note: This is NOT a simple list of top-level column indices.
+  /// For more details \see ScanV2Options
+  ///
+  /// If possible a fragment should only read from disk the data needed
+  /// to satisfy these columns.  If a format cannot partially read a nested
+  /// column (e.g. JSON) then it must apply the column selection (in memory)
+  /// before returning the scanned batch.
+  std::vector<FragmentSelectionColumn> columns;
+  /// \brief Options specific to the format being scanned
+  FragmentScanOptions* format_scan_options;
+};
+
+class FragmentScanner {
+ public:
+  /// This instance will only be destroyed after all ongoing scan futures
+  /// have been completed.
+  ///
+  /// This means any callbacks created as part of the scan can safely
+  /// capture `this`
+  virtual ~FragmentScanner() = default;
+  /// \brief Scan a batch of data from the file
+  /// \param batch_number The index of the batch to read
+  virtual Future<std::shared_ptr<RecordBatch>> ScanBatch(int batch_number) = 0;
+  /// \brief Calculate an estimate of how many data bytes the given batch will represent
+  ///
+  /// "Data bytes" should be the total size of all the buffers once the data has been
+  /// decoded into the Arrow format.
+  virtual int64_t EstimatedDataBytes(int batch_number) = 0;
+  /// \brief The number of batches in the fragment to scan
+  virtual int NumBatches() = 0;
+};
+
+struct InspectedFragment {
+  explicit InspectedFragment(std::vector<std::string> column_names)
+      : column_names(std::move(column_names)) {}
+  std::vector<std::string> column_names;
+};
+
 /// \brief A granular piece of a Dataset, such as an individual file.
 ///
 /// A Fragment can be read/scanned separately from other fragments. It yields a
-/// collection of RecordBatches when scanned, encapsulated in one or more
-/// ScanTasks.
+/// collection of RecordBatches when scanned
 ///
 /// Note that Fragments have well defined physical schemas which are reconciled by
 /// the Datasets which contain them; these physical schemas may differ from a parent
 /// Dataset's schema and the physical schemas of sibling Fragments.
 class ARROW_DS_EXPORT Fragment : public std::enable_shared_from_this<Fragment> {
  public:
+  /// \brief An expression that represents no known partition information
+  static const compute::Expression kNoPartitionInformation;
+
   /// \brief Return the physical schema of the Fragment.
   ///
   /// The physical schema is also called the writer schema.
@@ -64,6 +139,17 @@ class ARROW_DS_EXPORT Fragment : public std::enable_shared_from_this<Fragment> {
   /// An asynchronous version of Scan
   virtual Result<RecordBatchGenerator> ScanBatchesAsync(
       const std::shared_ptr<ScanOptions>& options) = 0;
+
+  /// \brief Inspect a fragment to learn basic information
+  ///
+  /// This will be called before a scan and a fragment should attach whatever
+  /// information will be needed to figure out an evolution strategy.  This information
+  /// will then be passed to the call to BeginScan
+  virtual Future<std::shared_ptr<InspectedFragment>> InspectFragment();
+
+  /// \brief Start a scan operation
+  virtual Future<std::shared_ptr<FragmentScanner>> BeginScan(
+      const FragmentScanRequest& request, const InspectedFragment& inspected_fragment);
 
   /// \brief Count the number of rows in this fragment matching the filter using metadata
   /// only. That is, this method may perform I/O, but will not load data.
@@ -119,6 +205,7 @@ class ARROW_DS_EXPORT FragmentScanOptions {
 /// RecordBatch.
 class ARROW_DS_EXPORT InMemoryFragment : public Fragment {
  public:
+  class Scanner;
   InMemoryFragment(std::shared_ptr<Schema> schema, RecordBatchVector record_batches,
                    compute::Expression = compute::literal(true));
   explicit InMemoryFragment(RecordBatchVector record_batches,
@@ -129,6 +216,11 @@ class ARROW_DS_EXPORT InMemoryFragment : public Fragment {
   Future<std::optional<int64_t>> CountRows(
       compute::Expression predicate,
       const std::shared_ptr<ScanOptions>& options) override;
+
+  Future<std::shared_ptr<InspectedFragment>> InspectFragment() override;
+  Future<std::shared_ptr<FragmentScanner>> BeginScan(
+      const FragmentScanRequest& request,
+      const InspectedFragment& inspected_fragment) override;
 
   std::string type_name() const override { return "in-memory"; }
 
@@ -141,6 +233,80 @@ class ARROW_DS_EXPORT InMemoryFragment : public Fragment {
 /// @}
 
 using FragmentGenerator = AsyncGenerator<std::shared_ptr<Fragment>>;
+
+/// \brief Rules for converting the dataset schema to and from fragment schemas
+class ARROW_DS_EXPORT FragmentEvolutionStrategy {
+ public:
+  /// This instance will only be destroyed when all scan operations for the
+  /// fragment have completed.
+  virtual ~FragmentEvolutionStrategy() = default;
+  /// \brief A guarantee that applies to all batches of this fragment
+  ///
+  /// For example, if a fragment is missing one of the fields in the dataset
+  /// schema then a typical evolution strategy is to set that field to null.
+  ///
+  /// So if the column at index 3 is missing then the guarantee is
+  /// FieldRef(3) == null
+  ///
+  /// Individual field guarantees should be AND'd together and returned
+  /// as a single expression.
+  virtual Result<compute::Expression> GetGuarantee(
+      const std::vector<FieldPath>& dataset_schema_selection) const = 0;
+
+  /// \brief Return a fragment schema selection given a dataset schema selection
+  ///
+  /// For example, if the user wants fields 2 & 4 of the dataset schema and
+  /// in this fragment the field 2 is missing and the field 4 is at index 1 then
+  /// this should return {1}
+  virtual Result<std::vector<FragmentSelectionColumn>> DevolveSelection(
+      const std::vector<FieldPath>& dataset_schema_selection) const = 0;
+
+  /// \brief Return a filter expression bound to the fragment schema given
+  ///        a filter expression bound to the dataset schema
+  ///
+  /// The dataset scan filter will first be simplified by the guarantee returned
+  /// by GetGuarantee.  This means an evolution that only handles dropping or casting
+  /// fields doesn't need to do anything here except return the given filter.
+  ///
+  /// On the other hand, an evolution that is doing some kind of aliasing will likely
+  /// need to convert field references in the filter to the aliased field references
+  /// where appropriate.
+  virtual Result<compute::Expression> DevolveFilter(
+      const compute::Expression& filter) const = 0;
+
+  /// \brief Convert a batch from the fragment schema to the dataset schema
+  ///
+  /// Typically this involves casting columns from the data type stored on disk
+  /// to the data type of the dataset schema.  For example, this fragment might
+  /// have columns stored as int32 and the dataset schema might have int64 for
+  /// the column.  In this case we should cast the column from int32 to int64.
+  ///
+  /// Note: A fragment may perform this cast as the data is read from disk.  In
+  /// that case a cast might not be needed.
+  virtual Result<compute::ExecBatch> EvolveBatch(
+      const std::shared_ptr<RecordBatch>& batch,
+      const std::vector<FieldPath>& dataset_selection,
+      const std::vector<FragmentSelectionColumn>& selection) const = 0;
+
+  /// \brief Return a string description of this strategy
+  virtual std::string ToString() const = 0;
+};
+
+/// \brief Lookup to create a FragmentEvolutionStrategy for a given fragment
+class ARROW_DS_EXPORT DatasetEvolutionStrategy {
+ public:
+  virtual ~DatasetEvolutionStrategy() = default;
+  /// \brief Create a strategy for evolving from the given fragment
+  ///        to the schema of the given dataset
+  virtual std::unique_ptr<FragmentEvolutionStrategy> GetStrategy(
+      const Dataset& dataset, const Fragment& fragment,
+      const InspectedFragment& inspected_fragment) = 0;
+
+  /// \brief Return a string description of this strategy
+  virtual std::string ToString() const = 0;
+};
+
+std::unique_ptr<DatasetEvolutionStrategy> MakeBasicDatasetEvolutionStrategy();
 
 /// \brief A container of zero or more Fragments.
 ///
@@ -178,6 +344,9 @@ class ARROW_DS_EXPORT Dataset : public std::enable_shared_from_this<Dataset> {
   virtual Result<std::shared_ptr<Dataset>> ReplaceSchema(
       std::shared_ptr<Schema> schema) const = 0;
 
+  /// \brief Rules used by this dataset to handle schema evolution
+  DatasetEvolutionStrategy* evolution_strategy() { return evolution_strategy_.get(); }
+
   virtual ~Dataset() = default;
 
  protected:
@@ -201,6 +370,8 @@ class ARROW_DS_EXPORT Dataset : public std::enable_shared_from_this<Dataset> {
 
   std::shared_ptr<Schema> schema_;
   compute::Expression partition_expression_ = compute::literal(true);
+  std::unique_ptr<DatasetEvolutionStrategy> evolution_strategy_ =
+      MakeBasicDatasetEvolutionStrategy();
 };
 
 /// \addtogroup dataset-implementations

--- a/cpp/src/arrow/dataset/dataset.h
+++ b/cpp/src/arrow/dataset/dataset.h
@@ -45,7 +45,7 @@ namespace dataset {
 using RecordBatchGenerator = std::function<Future<std::shared_ptr<RecordBatch>>()>;
 
 /// \brief Description of a column to scan
-struct FragmentSelectionColumn {
+struct ARROW_DS_EXPORT FragmentSelectionColumn {
   /// \brief The path to the column to load
   FieldPath path;
   /// \brief The type of the column in the dataset schema
@@ -61,12 +61,13 @@ struct FragmentSelectionColumn {
   /// \brief The index in the output selection of this column
   int selection_index;
 };
+
 /// \brief Instructions for scanning a particular fragment
 ///
 /// The fragment scan request is dervied from ScanV2Options.  The main
 /// difference is that the scan options are based on the dataset schema
 /// while the fragment request is based on the fragment schema.
-struct FragmentScanRequest {
+struct ARROW_DS_EXPORT FragmentScanRequest {
   /// \brief A row filter
   ///
   /// The filter expression should be written against the fragment schema.
@@ -90,7 +91,8 @@ struct FragmentScanRequest {
   FragmentScanOptions* format_scan_options;
 };
 
-class FragmentScanner {
+/// \brief An iterator-like object that can yield batches created from a fragment
+class ARROW_DS_EXPORT FragmentScanner {
  public:
   /// This instance will only be destroyed after all ongoing scan futures
   /// have been completed.
@@ -110,7 +112,16 @@ class FragmentScanner {
   virtual int NumBatches() = 0;
 };
 
-struct InspectedFragment {
+/// \brief Information learned about a fragment through inspection
+///
+/// This information can be used to figure out which fields need
+/// to be read from a file and how the data read in should be evolved
+/// to match the dataset schema.
+///
+/// For example, from a CSV file we can inspect and learn the column
+/// names and use those column names to determine which columns to load
+/// from the CSV file.
+struct ARROW_DS_EXPORT InspectedFragment {
   explicit InspectedFragment(std::vector<std::string> column_names)
       : column_names(std::move(column_names)) {}
   std::vector<std::string> column_names;

--- a/cpp/src/arrow/dataset/dataset.h
+++ b/cpp/src/arrow/dataset/dataset.h
@@ -317,7 +317,8 @@ class ARROW_DS_EXPORT DatasetEvolutionStrategy {
   virtual std::string ToString() const = 0;
 };
 
-std::unique_ptr<DatasetEvolutionStrategy> MakeBasicDatasetEvolutionStrategy();
+ARROW_DS_EXPORT std::unique_ptr<DatasetEvolutionStrategy>
+MakeBasicDatasetEvolutionStrategy();
 
 /// \brief A container of zero or more Fragments.
 ///

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -476,8 +476,8 @@ class TeeNode : public compute::MapNode {
   TeeNode(compute::ExecPlan* plan, std::vector<compute::ExecNode*> inputs,
           std::shared_ptr<Schema> output_schema,
           std::unique_ptr<internal::DatasetWriter> dataset_writer,
-          FileSystemDatasetWriteOptions write_options, bool async_mode)
-      : MapNode(plan, std::move(inputs), std::move(output_schema), async_mode),
+          FileSystemDatasetWriteOptions write_options)
+      : MapNode(plan, std::move(inputs), std::move(output_schema)),
         dataset_writer_(std::move(dataset_writer)),
         write_options_(std::move(write_options)) {
     std::unique_ptr<util::AsyncTaskScheduler::Throttle> serial_throttle =
@@ -503,8 +503,8 @@ class TeeNode : public compute::MapNode {
         internal::DatasetWriter::Make(write_options, plan->async_scheduler()));
 
     return plan->EmplaceNode<TeeNode>(plan, std::move(inputs), std::move(schema),
-                                      std::move(dataset_writer), std::move(write_options),
-                                      /*async_mode=*/true);
+                                      std::move(dataset_writer),
+                                      std::move(write_options));
   }
 
   const char* kind_name() const override { return "TeeNode"; }

--- a/cpp/src/arrow/dataset/plan.cc
+++ b/cpp/src/arrow/dataset/plan.cc
@@ -33,6 +33,7 @@ void Initialize() {
     auto registry = compute::default_exec_factory_registry();
     if (registry) {
       InitializeScanner(registry);
+      InitializeScannerV2(registry);
       InitializeDatasetWriter(registry);
     }
   });

--- a/cpp/src/arrow/dataset/scan_node.cc
+++ b/cpp/src/arrow/dataset/scan_node.cc
@@ -181,12 +181,7 @@ class ScanNode : public cp::ExecNode {
   [[noreturn]] void ErrorReceived(cp::ExecNode*, Status) override { NoInputs(); }
   [[noreturn]] void InputFinished(cp::ExecNode*, int) override { NoInputs(); }
 
-  Status Init() override {
-    // batch_output_ =
-    //     ::std::make_unique<UnorderedBatchOutputStrategy>(this,
-    //     outputs_[0]);
-    return Status::OK();
-  }
+  Status Init() override { return Status::OK(); }
 
   struct ScanState {
     std::mutex mutex;
@@ -211,7 +206,7 @@ class ScanNode : public cp::ExecNode {
       // Prevent concurrent calls to ScanBatch which might not be thread safe
       std::lock_guard<std::mutex> lk(scan_->mutex);
       return scan_->fragment_scanner->ScanBatch(batch_index_)
-          .Then([this](const std::shared_ptr<RecordBatch> batch) {
+          .Then([this](const std::shared_ptr<RecordBatch>& batch) {
             return HandleBatch(batch);
           });
     }

--- a/cpp/src/arrow/dataset/scan_node.cc
+++ b/cpp/src/arrow/dataset/scan_node.cc
@@ -1,0 +1,372 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <functional>
+#include <list>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "arrow/compute/exec/exec_plan.h"
+#include "arrow/compute/exec/expression.h"
+#include "arrow/dataset/scanner.h"
+#include "arrow/record_batch.h"
+#include "arrow/result.h"
+#include "arrow/status.h"
+#include "arrow/type.h"
+#include "arrow/util/checked_cast.h"
+#include "arrow/util/make_unique.h"
+#include "arrow/util/tracing_internal.h"
+#include "arrow/util/unreachable.h"
+
+namespace cp = arrow::compute;
+
+namespace arrow {
+
+using internal::checked_cast;
+
+namespace dataset {
+
+namespace {
+
+Result<std::shared_ptr<Schema>> OutputSchemaFromOptions(const ScanV2Options& options) {
+  return FieldPath::GetAll(*options.dataset->schema(), options.columns);
+}
+
+// In the future we should support async scanning of fragments.  The
+// Dataset class doesn't support this yet but we pretend it does here to
+// ease future adoption of the feature.
+AsyncGenerator<std::shared_ptr<Fragment>> GetFragments(Dataset* dataset,
+                                                       cp::Expression predicate) {
+  // In the future the dataset should be responsible for figuring out
+  // the I/O context.  This will allow different I/O contexts to be used
+  // when scanning different datasets.  For example, if we are scanning a
+  // union of a remote dataset and a local dataset.
+  const auto& io_context = io::default_io_context();
+  auto io_executor = io_context.executor();
+  Future<std::shared_ptr<FragmentIterator>> fragments_it_fut =
+      DeferNotOk(io_executor->Submit(
+          [dataset, predicate]() -> Result<std::shared_ptr<FragmentIterator>> {
+            ARROW_ASSIGN_OR_RAISE(FragmentIterator fragments_iter,
+                                  dataset->GetFragments(predicate));
+            return std::make_shared<FragmentIterator>(std::move(fragments_iter));
+          }));
+  Future<AsyncGenerator<std::shared_ptr<Fragment>>> fragments_gen_fut =
+      fragments_it_fut.Then([](const std::shared_ptr<FragmentIterator>& fragments_it)
+                                -> Result<AsyncGenerator<std::shared_ptr<Fragment>>> {
+        ARROW_ASSIGN_OR_RAISE(std::vector<std::shared_ptr<Fragment>> fragments,
+                              fragments_it->ToVector());
+        return MakeVectorGenerator(std::move(fragments));
+      });
+  return MakeFromFuture(std::move(fragments_gen_fut));
+}
+
+/// \brief A node that scans a dataset
+///
+/// The scan node has three groups of io-tasks and one task.
+///
+/// The first io-task (listing) fetches the fragments from the dataset.  This may be a
+/// simple iteration of paths or, if the dataset is described with wildcards, this may
+/// involve I/O for listing and walking directory paths.  There is one listing io-task per
+/// dataset.
+///
+/// Ths next step is to fetch the metadata for the fragment.  For some formats (e.g. CSV)
+/// this may be quite simple (get the size of the file).  For other formats (e.g. parquet)
+/// this is more involved and requires reading data.  There is one metadata io-task per
+/// fragment.  The metadata io-task creates an AsyncGenerator<RecordBatch> from the
+/// fragment.
+///
+/// Once the metadata io-task is done we can issue read io-tasks.  Each read io-task
+/// requests a single batch of data from the disk by pulling the next Future from the
+/// generator.
+///
+/// Finally, when the future is fulfilled, we issue a pipeline task to drive the batch
+/// through the pipeline.
+///
+/// Most of these tasks are io-tasks.  They take very few CPU resources and they run on
+/// the I/O thread pool.  These io-tasks are invisible to the exec plan and so we need to
+/// do some custom scheduling.  We limit how many fragments we read from at any one time.
+/// This is referred to as "fragment readahead".
+///
+/// Within a fragment there is usually also some amount of "row readahead".  This row
+/// readahead is handled by the fragment (and not the scanner) because the exact details
+/// of how it is performed depend on the underlying format.
+///
+/// When a scan node is aborted (StopProducing) we send a cancel signal to any active
+/// fragments.  On destruction we continue consuming the fragments until they complete
+/// (which should be fairly quick since we cancelled the fragment).  This ensures the
+/// I/O work is completely finished before the node is destroyed.
+class ScanNode : public cp::ExecNode {
+ public:
+  ScanNode(cp::ExecPlan* plan, ScanV2Options options,
+           std::shared_ptr<Schema> output_schema)
+      : cp::ExecNode(plan, {}, {}, std::move(output_schema),
+                     /*num_outputs=*/1),
+        options_(options),
+        fragments_throttle_(
+            util::AsyncTaskScheduler::MakeThrottle(options_.fragment_readahead + 1)),
+        batches_throttle_(
+            util::AsyncTaskScheduler::MakeThrottle(options_.target_bytes_readahead + 1)) {
+  }
+
+  static Result<ScanV2Options> NormalizeAndValidate(const ScanV2Options& options,
+                                                    compute::ExecContext* ctx) {
+    ScanV2Options normalized(options);
+    if (!normalized.dataset) {
+      return Status::Invalid("Scan options must include a dataset");
+    }
+
+    if (options.fragment_readahead < 0) {
+      return Status::Invalid(
+          "Fragment readahead may not be less than 0.  Set to 0 to disable readahead");
+    }
+
+    if (options.target_bytes_readahead < 0) {
+      return Status::Invalid(
+          "Batch readahead may not be less than 0.  Set to 0 to disable readahead");
+    }
+
+    if (!normalized.filter.is_valid()) {
+      normalized.filter = compute::literal(true);
+    }
+
+    if (normalized.filter.call() && normalized.filter.IsBound()) {
+      // There is no easy way to make sure a filter was bound agaisnt the same
+      // function registry as the one in ctx so we just require it to be unbound
+      // FIXME - Do we care if it was bound to a different function registry?
+      return Status::Invalid("Scan filter must be unbound");
+    } else if (!normalized.filter.IsBound()) {
+      ARROW_ASSIGN_OR_RAISE(normalized.filter,
+                            normalized.filter.Bind(*options.dataset->schema(), ctx));
+    }  // Else we must have some simple filter like literal(true) which might be bound
+       // but we don't care
+
+    return std::move(normalized);
+  }
+
+  static Result<cp::ExecNode*> Make(cp::ExecPlan* plan, std::vector<cp::ExecNode*> inputs,
+                                    const cp::ExecNodeOptions& options) {
+    RETURN_NOT_OK(ValidateExecNodeInputs(plan, inputs, 0, "ScanNode"));
+    const auto& scan_options = checked_cast<const ScanV2Options&>(options);
+    ARROW_ASSIGN_OR_RAISE(ScanV2Options normalized_options,
+                          NormalizeAndValidate(scan_options, plan->exec_context()));
+    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Schema> output_schema,
+                          OutputSchemaFromOptions(normalized_options));
+    return plan->EmplaceNode<ScanNode>(plan, std::move(normalized_options),
+                                       std::move(output_schema));
+  }
+
+  const char* kind_name() const override { return "ScanNode"; }
+
+  [[noreturn]] static void NoInputs() {
+    Unreachable("no inputs; this should never be called");
+  }
+  [[noreturn]] void InputReceived(cp::ExecNode*, cp::ExecBatch) override { NoInputs(); }
+  [[noreturn]] void ErrorReceived(cp::ExecNode*, Status) override { NoInputs(); }
+  [[noreturn]] void InputFinished(cp::ExecNode*, int) override { NoInputs(); }
+
+  Status Init() override {
+    // batch_output_ =
+    //     ::arrow::internal::make_unique<UnorderedBatchOutputStrategy>(this,
+    //     outputs_[0]);
+    return Status::OK();
+  }
+
+  struct ScanState {
+    std::mutex mutex;
+    std::shared_ptr<FragmentScanner> fragment_scanner;
+    std::unique_ptr<FragmentEvolutionStrategy> fragment_evolution;
+    FragmentScanRequest scan_request;
+  };
+
+  struct ScanBatchTask : util::AsyncTaskScheduler::Task {
+    ScanBatchTask(ScanNode* node, ScanState* scan_state, int batch_index)
+        : node_(node), scan_(scan_state), batch_index_(batch_index) {
+      int64_t cost = scan_state->fragment_scanner->EstimatedDataBytes(batch_index_);
+      // It's possible, though probably a bad idea, for a single batch of a fragment
+      // to be larger than 2GiB.  In that case, it doesn't matter much if we underestimate
+      // because the largest the throttle can be is 2GiB and thus we will be in "one batch
+      // at a time" mode anyways which is the best we can do in this case.
+      cost_ = static_cast<int>(
+          std::min(cost, static_cast<int64_t>(std::numeric_limits<int>::max())));
+    }
+
+    Result<Future<>> operator()(util::AsyncTaskScheduler* scheduler) override {
+      // Prevent concurrent calls to ScanBatch which might not be thread safe
+      std::lock_guard<std::mutex> lk(scan_->mutex);
+      return scan_->fragment_scanner->ScanBatch(batch_index_)
+          .Then([this](const std::shared_ptr<RecordBatch> batch) {
+            return HandleBatch(batch);
+          });
+    }
+
+    Status HandleBatch(const std::shared_ptr<RecordBatch>& batch) {
+      ARROW_ASSIGN_OR_RAISE(
+          compute::ExecBatch evolved_batch,
+          scan_->fragment_evolution->EvolveBatch(batch, node_->options_.columns,
+                                                 scan_->scan_request.columns));
+      node_->outputs_[0]->InputReceived(node_, std::move(evolved_batch));
+      return Status::OK();
+    }
+
+    int cost() const override { return cost_; }
+
+    ScanNode* node_;
+    ScanState* scan_;
+    int batch_index_;
+    int cost_;
+  };
+
+  struct ListFragmentTask : util::AsyncTaskScheduler::Task {
+    ListFragmentTask(ScanNode* node, std::shared_ptr<Fragment> fragment)
+        : node(node), fragment(std::move(fragment)) {}
+
+    Result<Future<>> operator()(util::AsyncTaskScheduler* scheduler) override {
+      return fragment->InspectFragment().Then(
+          [this,
+           scheduler](const std::shared_ptr<InspectedFragment>& inspected_fragment) {
+            return BeginScan(inspected_fragment, scheduler);
+          });
+    }
+
+    Future<> BeginScan(const std::shared_ptr<InspectedFragment>& inspected_fragment,
+                       util::AsyncTaskScheduler* scan_scheduler) {
+      // Now that we have an inspected fragment we need to use the dataset's evolution
+      // strategy to figure out how to scan it
+      scan_state->fragment_evolution =
+          node->options_.dataset->evolution_strategy()->GetStrategy(
+              *node->options_.dataset, *fragment, *inspected_fragment);
+      ARROW_RETURN_NOT_OK(InitFragmentScanRequest());
+      return fragment->BeginScan(scan_state->scan_request, *inspected_fragment)
+          .Then([this, scan_scheduler](
+                    const std::shared_ptr<FragmentScanner>& fragment_scanner) {
+            return AddScanTasks(fragment_scanner, scan_scheduler);
+          });
+    }
+
+    Future<> AddScanTasks(const std::shared_ptr<FragmentScanner>& fragment_scanner,
+                          util::AsyncTaskScheduler* scan_scheduler) {
+      scan_state->fragment_scanner = fragment_scanner;
+      ScanState* state_view = scan_state.get();
+      // Finish callback keeps the scan state alive until all scan tasks done
+      struct StateHolder {
+        Status operator()() { return Status::OK(); }
+        std::unique_ptr<ScanState> scan_state;
+      };
+      util::AsyncTaskScheduler* frag_scheduler = scan_scheduler->MakeSubScheduler(
+          StateHolder{std::move(scan_state)}, node->batches_throttle_.get());
+      for (int i = 0; i < fragment_scanner->NumBatches(); i++) {
+        node->num_batches_.fetch_add(1);
+        frag_scheduler->AddTask(
+            arrow::internal::make_unique<ScanBatchTask>(node, state_view, i));
+      }
+      Future<> list_and_scan_node = frag_scheduler->OnFinished();
+      frag_scheduler->End();
+      // The "list fragments" task doesn't actually end until the fragments are
+      // all scanned.  This allows us to enforce fragment readahead.
+      return list_and_scan_node;
+    }
+
+    // Take the dataset options, and the fragment evolution, and figure out exactly how
+    // we should scan the fragment itself.
+    Status InitFragmentScanRequest() {
+      ARROW_ASSIGN_OR_RAISE(
+          scan_state->scan_request.columns,
+          scan_state->fragment_evolution->DevolveSelection(node->options_.columns));
+      ARROW_ASSIGN_OR_RAISE(
+          compute::Expression devolution_guarantee,
+          scan_state->fragment_evolution->GetGuarantee(node->options_.columns));
+      ARROW_ASSIGN_OR_RAISE(
+          compute::Expression simplified_filter,
+          compute::SimplifyWithGuarantee(node->options_.filter, devolution_guarantee));
+      ARROW_ASSIGN_OR_RAISE(
+          scan_state->scan_request.filter,
+          scan_state->fragment_evolution->DevolveFilter(std::move(simplified_filter)));
+      scan_state->scan_request.format_scan_options = node->options_.format_options;
+      return Status::OK();
+    }
+
+    ScanNode* node;
+    std::shared_ptr<Fragment> fragment;
+    std::unique_ptr<ScanState> scan_state = arrow::internal::make_unique<ScanState>();
+  };
+
+  Status StartProducing() override {
+    START_COMPUTE_SPAN(span_, std::string(kind_name()) + ":" + label(),
+                       {{"node.kind", kind_name()},
+                        {"node.label", label()},
+                        {"node.output_schema", output_schema()->ToString()},
+                        {"node.detail", ToString()}});
+    END_SPAN_ON_FUTURE_COMPLETION(span_, finished_);
+    AsyncGenerator<std::shared_ptr<Fragment>> frag_gen =
+        GetFragments(options_.dataset.get(), options_.filter);
+    util::AsyncTaskScheduler* scan_scheduler = plan_->async_scheduler()->MakeSubScheduler(
+        [this]() {
+          outputs_[0]->InputFinished(this, num_batches_.load());
+          finished_.MarkFinished();
+          return Status::OK();
+        },
+        fragments_throttle_.get());
+    plan_->async_scheduler()->AddAsyncGenerator<std::shared_ptr<Fragment>>(
+        std::move(frag_gen),
+        [this, scan_scheduler](const std::shared_ptr<Fragment>& fragment) {
+          scan_scheduler->AddTask(
+              arrow::internal::make_unique<ListFragmentTask>(this, fragment));
+          return Status::OK();
+        },
+        [scan_scheduler]() {
+          scan_scheduler->End();
+          return Status::OK();
+        });
+    return Status::OK();
+  }
+
+  void PauseProducing(ExecNode* output, int32_t counter) override {
+    // FIXME(TODO)
+    // Need to ressurect AsyncToggle and then all fragment scanners
+    // should share the same toggle
+  }
+
+  void ResumeProducing(ExecNode* output, int32_t counter) override {
+    // FIXME(TODO)
+  }
+
+  void StopProducing(ExecNode* output) override {
+    DCHECK_EQ(output, outputs_[0]);
+    StopProducing();
+  }
+
+  void StopProducing() override {}
+
+ private:
+  ScanV2Options options_;
+  std::atomic<int> num_batches_{0};
+  // std::unique_ptr<BatchOutputStrategy> batch_output_;
+  std::unique_ptr<util::AsyncTaskScheduler::Throttle> fragments_throttle_;
+  std::unique_ptr<util::AsyncTaskScheduler::Throttle> batches_throttle_;
+};
+
+}  // namespace
+
+namespace internal {
+void InitializeScannerV2(arrow::compute::ExecFactoryRegistry* registry) {
+  DCHECK_OK(registry->AddFactory("scan2", ScanNode::Make));
+}
+}  // namespace internal
+}  // namespace dataset
+}  // namespace arrow

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -21,6 +21,7 @@
 #include <condition_variable>
 #include <memory>
 #include <mutex>
+#include <numeric>
 #include <sstream>
 
 #include "arrow/array/array_primitive.h"
@@ -65,6 +66,14 @@ std::vector<FieldRef> ScanOptions::MaterializedFields() const {
   }
 
   return fields;
+}
+
+std::vector<FieldPath> ScanV2Options::AllColumns(const Dataset& dataset) {
+  std::vector<FieldPath> selection(dataset.schema()->num_fields());
+  for (std::size_t i = 0; i < selection.size(); i++) {
+    selection[i] = {static_cast<int>(i)};
+  }
+  return selection;
 }
 
 namespace {

--- a/cpp/src/arrow/dataset/scanner_benchmark.cc
+++ b/cpp/src/arrow/dataset/scanner_benchmark.cc
@@ -96,9 +96,7 @@ std::shared_ptr<Schema> GetSchema() {
 
 size_t GetBytesForSchema() { return sizeof(int32_t) + sizeof(bool); }
 
-void MinimalEndToEndScan(size_t num_batches, size_t batch_size, bool async_mode) {
-  // NB: This test is here for didactic purposes
-
+void MinimalEndToEndScan(size_t num_batches, size_t batch_size) {
   // Specify a MemoryPool and ThreadPool for the ExecPlan
   compute::ExecContext exec_context(default_memory_pool(),
                                     ::arrow::internal::GetCpuThreadPool());
@@ -120,7 +118,7 @@ void MinimalEndToEndScan(size_t num_batches, size_t batch_size, bool async_mode)
 
   auto options = std::make_shared<ScanOptions>();
   // specify the filter
-  compute::Expression b_is_true = field_ref("b");
+  compute::Expression b_is_true = equal(field_ref("b"), literal(true));
   options->filter = b_is_true;
   // for now, specify the projection as the full project expression (eventually this can
   // just be a list of materialized field names)
@@ -134,10 +132,9 @@ void MinimalEndToEndScan(size_t num_batches, size_t batch_size, bool async_mode)
       compute::MakeExecNode("scan", plan.get(), {}, ScanNodeOptions{dataset, options}));
 
   // pipe the scan node into a filter node
-  ASSERT_OK_AND_ASSIGN(
-      compute::ExecNode * filter,
-      compute::MakeExecNode("filter", plan.get(), {scan},
-                            compute::FilterNodeOptions{b_is_true, async_mode}));
+  ASSERT_OK_AND_ASSIGN(compute::ExecNode * filter,
+                       compute::MakeExecNode("filter", plan.get(), {scan},
+                                             compute::FilterNodeOptions{b_is_true}));
 
   // pipe the filter node into a project node
   // NB: we're using the project node factory which preserves fragment/batch index
@@ -146,7 +143,7 @@ void MinimalEndToEndScan(size_t num_batches, size_t batch_size, bool async_mode)
   ASSERT_OK_AND_ASSIGN(
       compute::ExecNode * project,
       compute::MakeExecNode("augmented_project", plan.get(), {filter},
-                            compute::ProjectNodeOptions{{a_times_2}, {}, async_mode}));
+                            compute::ProjectNodeOptions{{a_times_2}, {}}));
 
   // finally, pipe the project node into a sink node
   AsyncGenerator<std::optional<compute::ExecBatch>> sink_gen;
@@ -172,37 +169,157 @@ void MinimalEndToEndScan(size_t num_batches, size_t batch_size, bool async_mode)
   ASSERT_TRUE(plan->finished().Wait(/*seconds=*/1)) << "ExecPlan didn't finish within 1s";
 }
 
+void ScanOnly(
+    size_t num_batches, size_t batch_size, const std::string& factory_name,
+    std::function<Result<std::shared_ptr<compute::ExecNodeOptions>>(size_t, size_t)>
+        options_factory) {
+  compute::ExecContext exec_context(default_memory_pool(),
+                                    ::arrow::internal::GetCpuThreadPool());
+
+  // ensure arrow::dataset node factories are in the registry
+  ::arrow::dataset::internal::Initialize();
+
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<compute::ExecPlan> plan,
+                       compute::ExecPlan::Make(&exec_context));
+
+  RecordBatchVector batches = GetBatches(num_batches, batch_size);
+
+  std::shared_ptr<Dataset> dataset =
+      std::make_shared<InMemoryDataset>(GetSchema(), batches);
+
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<compute::ExecNodeOptions> node_options,
+                       options_factory(num_batches, batch_size));
+
+  // construct the plan
+  ASSERT_OK_AND_ASSIGN(
+      compute::ExecNode * scan,
+      compute::MakeExecNode(factory_name, plan.get(), {}, *node_options));
+  AsyncGenerator<std::optional<compute::ExecBatch>> sink_gen;
+  ASSERT_OK_AND_ASSIGN(compute::ExecNode * sink,
+                       compute::MakeExecNode("sink", plan.get(), {scan},
+                                             compute::SinkNodeOptions{&sink_gen}));
+
+  ASSERT_NE(sink, nullptr);
+
+  // translate sink_gen (async) to sink_reader (sync)
+  std::shared_ptr<RecordBatchReader> sink_reader = compute::MakeGeneratorReader(
+      schema({field("a * 2", int32())}), std::move(sink_gen), exec_context.memory_pool());
+
+  // start the ExecPlan
+  ASSERT_OK(plan->StartProducing());
+
+  // collect sink_reader into a Table
+  ASSERT_OK_AND_ASSIGN(auto collected, Table::FromRecordBatchReader(sink_reader.get()));
+
+  ASSERT_GT(collected->num_rows(), 0);
+
+  // wait 1s for completion
+  ASSERT_TRUE(plan->finished().Wait(/*seconds=*/1)) << "ExecPlan didn't finish within 1s";
+}
+
 static void MinimalEndToEndBench(benchmark::State& state) {
   size_t num_batches = state.range(0);
   size_t batch_size = state.range(1);
-  bool async_mode = state.range(2);
 
   for (auto _ : state) {
-    MinimalEndToEndScan(num_batches, batch_size, async_mode);
+    MinimalEndToEndScan(num_batches, batch_size);
   }
   state.SetItemsProcessed(state.iterations() * num_batches);
   state.SetBytesProcessed(state.iterations() * num_batches * batch_size *
                           GetBytesForSchema());
 }
 
-static const std::vector<int32_t> kWorkload = {100, 1000, 10000, 100000};
+const std::function<Result<std::shared_ptr<compute::ExecNodeOptions>>(size_t, size_t)>
+    kScanFactory = [](size_t num_batches, size_t batch_size) {
+      RecordBatchVector batches = GetBatches(num_batches, batch_size);
+      std::shared_ptr<Dataset> dataset =
+          std::make_shared<InMemoryDataset>(GetSchema(), std::move(batches));
+
+      std::shared_ptr<ScanOptions> options = std::make_shared<ScanOptions>();
+      // specify the filter
+      compute::Expression b_is_true = equal(field_ref("b"), literal(true));
+      options->filter = b_is_true;
+      options->projection = call("make_struct", {field_ref("a"), field_ref("b")},
+                                 compute::MakeStructOptions{{"a", "b"}});
+
+      return std::make_shared<ScanNodeOptions>(std::move(dataset), std::move(options));
+    };
+
+const std::function<Result<std::shared_ptr<compute::ExecNodeOptions>>(size_t, size_t)>
+    kScanV2Factory =
+        [](size_t num_batches,
+           size_t batch_size) -> Result<std::shared_ptr<compute::ExecNodeOptions>> {
+  RecordBatchVector batches = GetBatches(num_batches, batch_size);
+  std::shared_ptr<Schema> sch = GetSchema();
+  std::shared_ptr<Dataset> dataset =
+      std::make_shared<InMemoryDataset>(sch, std::move(batches));
+
+  std::shared_ptr<ScanV2Options> options = std::make_shared<ScanV2Options>(dataset);
+  // specify the filter
+  compute::Expression b_is_true = equal(field_ref("b"), literal(true));
+  options->filter = b_is_true;
+  options->columns = ScanV2Options::AllColumns(*dataset);
+
+  return options;
+};
+
+static constexpr int kScanIdx = 0;
+static constexpr int kScanV2Idx = 1;
+
+static void ScanOnlyBench(benchmark::State& state) {
+  size_t num_batches = state.range(0);
+  size_t batch_size = state.range(1);
+
+  std::function<Result<std::shared_ptr<compute::ExecNodeOptions>>(size_t, size_t)>
+      options_factory;
+  std::string scan_factory = "scan";
+  if (state.range(2) == kScanIdx) {
+    options_factory = kScanFactory;
+  } else if (state.range(2) == kScanV2Idx) {
+    options_factory = kScanV2Factory;
+    scan_factory = "scan2";
+  }
+
+  for (auto _ : state) {
+    ScanOnly(num_batches, batch_size, scan_factory, options_factory);
+  }
+  state.SetItemsProcessed(state.iterations() * num_batches);
+  state.SetBytesProcessed(state.iterations() * num_batches * batch_size *
+                          GetBytesForSchema());
+}
 
 static void MinimalEndToEnd_Customize(benchmark::internal::Benchmark* b) {
-  for (const int32_t num_batches : kWorkload) {
+  for (const int32_t num_batches : {1000}) {
     for (const int batch_size : {10, 100, 1000}) {
-      for (const bool async_mode : {true, false}) {
-        b->Args({num_batches, batch_size, async_mode});
+      b->Args({num_batches, batch_size});
+      RecordBatchVector batches =
+          ::arrow::compute::GenerateBatches(GetSchema(), num_batches, batch_size);
+      StoreBatches(num_batches, batch_size, batches);
+    }
+  }
+  b->ArgNames({"num_batches", "batch_size"});
+  b->UseRealTime();
+}
+
+// FIXME - Combine these two customize blocks by moving the end-to-end to support
+// options factories
+static void ScanOnlyEndToEnd_Customize(benchmark::internal::Benchmark* b) {
+  for (const int32_t num_batches : {1000}) {
+    for (const int batch_size : {10, 100, 1000}) {
+      for (const int scan_idx : {kScanIdx, kScanV2Idx}) {
+        b->Args({num_batches, batch_size, scan_idx});
         RecordBatchVector batches =
             ::arrow::compute::GenerateBatches(GetSchema(), num_batches, batch_size);
         StoreBatches(num_batches, batch_size, batches);
       }
     }
   }
-  b->ArgNames({"num_batches", "batch_size", "async_mode"});
+  b->ArgNames({"num_batches", "batch_size", "scan_alg"});
   b->UseRealTime();
 }
 
 BENCHMARK(MinimalEndToEndBench)->Apply(MinimalEndToEnd_Customize);
+BENCHMARK(ScanOnlyBench)->Apply(ScanOnlyEndToEnd_Customize)->Iterations(100);
 
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -28,6 +28,8 @@
 #include "arrow/compute/cast.h"
 #include "arrow/compute/exec/exec_plan.h"
 #include "arrow/compute/exec/expression_internal.h"
+#include "arrow/compute/exec/test_util.h"
+#include "arrow/dataset/dataset_internal.h"
 #include "arrow/dataset/plan.h"
 #include "arrow/dataset/test_util.h"
 #include "arrow/record_batch.h"
@@ -39,6 +41,7 @@
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/matchers.h"
 #include "arrow/testing/util.h"
+#include "arrow/util/byte_size.h"
 #include "arrow/util/range.h"
 #include "arrow/util/thread_pool.h"
 #include "arrow/util/vector.h"
@@ -52,6 +55,751 @@ using internal::GetCpuThreadPool;
 using internal::Iota;
 
 namespace dataset {
+
+// The basic evolution strategy doesn't really need any info from the dataset
+// or the fragment other than the schema so we just make a dummy dataset/fragment
+// here.
+std::unique_ptr<Dataset> MakeDatasetFromSchema(std::shared_ptr<Schema> sch) {
+  return ::arrow::internal::make_unique<InMemoryDataset>(std::move(sch),
+                                                         RecordBatchVector{});
+}
+
+std::unique_ptr<Fragment> MakeSomeFragment(std::shared_ptr<Schema> sch) {
+  return ::arrow::internal::make_unique<InMemoryFragment>(std::move(sch),
+                                                          RecordBatchVector{});
+}
+
+TEST(BasicEvolution, MissingColumn) {
+  std::unique_ptr<DatasetEvolutionStrategy> strategy =
+      MakeBasicDatasetEvolutionStrategy();
+
+  std::shared_ptr<Schema> dataset_schema =
+      schema({field("A", int32()), field("B", int16()), field("C", int64())});
+  std::unique_ptr<Dataset> dataset = MakeDatasetFromSchema(dataset_schema);
+  std::unique_ptr<Fragment> fragment = MakeSomeFragment(std::move(dataset_schema));
+
+  InspectedFragment inspected{{"A", "B"}};
+  std::unique_ptr<FragmentEvolutionStrategy> fragment_strategy =
+      strategy->GetStrategy(*dataset, *fragment, inspected);
+
+  compute::Expression filter = equal(field_ref("C"), literal(INT64_C(7)));
+  // If, after simplification, a filter somehow still references a missing field
+  // then it is an error.
+  ASSERT_RAISES(Invalid, fragment_strategy->DevolveFilter(filter));
+  std::vector<FieldPath> selection{FieldPath({0}), FieldPath({2})};
+  // Basic strategy should provide is_null guarantee for missing fields
+  compute::Expression expected_guarantee = is_null(field_ref(2));
+  ASSERT_OK_AND_ASSIGN(compute::Expression guarantee,
+                       fragment_strategy->GetGuarantee(selection));
+  ASSERT_EQ(expected_guarantee, guarantee);
+
+  // Basic strategy should drop missing fields from selection
+  ASSERT_OK_AND_ASSIGN(std::vector<FragmentSelectionColumn> devolved_selection,
+                       fragment_strategy->DevolveSelection(selection));
+  ASSERT_EQ(1, devolved_selection.size());
+  ASSERT_EQ(FieldPath({0}), devolved_selection[0].path);
+  ASSERT_EQ(*int32(), *devolved_selection[0].requested_type);
+
+  // Basic strategy should append null column to batches for missing column
+  std::shared_ptr<RecordBatch> devolved_batch =
+      RecordBatchFromJSON(schema({field("A", int32())}), R"([[1], [2], [3]])");
+  ASSERT_OK_AND_ASSIGN(
+      compute::ExecBatch evolved_batch,
+      fragment_strategy->EvolveBatch(devolved_batch, selection, devolved_selection));
+  ASSERT_EQ(2, evolved_batch.values.size());
+  AssertArraysEqual(*devolved_batch->column(0), *evolved_batch[0].make_array());
+  ASSERT_EQ(*MakeNullScalar(int64()), *evolved_batch.values[1].scalar());
+}
+
+TEST(BasicEvolution, ReorderedColumns) {
+  std::unique_ptr<DatasetEvolutionStrategy> strategy =
+      MakeBasicDatasetEvolutionStrategy();
+
+  std::shared_ptr<Schema> dataset_schema =
+      schema({field("A", int32()), field("B", int16()), field("C", int64())});
+  std::unique_ptr<Dataset> dataset = MakeDatasetFromSchema(dataset_schema);
+  std::unique_ptr<Fragment> fragment = MakeSomeFragment(std::move(dataset_schema));
+
+  InspectedFragment inspected{{"C", "B", "A"}};
+  std::unique_ptr<FragmentEvolutionStrategy> fragment_strategy =
+      strategy->GetStrategy(*dataset, *fragment, inspected);
+
+  compute::Expression filter = equal(field_ref("C"), literal(INT64_C(7)));
+  compute::Expression fragment_filter = equal(field_ref(0), literal(INT64_C(7)));
+  // Devolved filter should have updated indices
+  ASSERT_OK_AND_ASSIGN(compute::Expression devolved,
+                       fragment_strategy->DevolveFilter(filter));
+  ASSERT_EQ(fragment_filter, devolved);
+  std::vector<FieldPath> selection{FieldPath({0}), FieldPath({2})};
+  // No guarantees if simply reordering
+  compute::Expression expected_guarantee = literal(true);
+  ASSERT_OK_AND_ASSIGN(compute::Expression guarantee,
+                       fragment_strategy->GetGuarantee(selection));
+  ASSERT_EQ(expected_guarantee, guarantee);
+
+  // Devolved selection should have correct indices
+  ASSERT_OK_AND_ASSIGN(std::vector<FragmentSelectionColumn> devolved_selection,
+                       fragment_strategy->DevolveSelection(selection));
+  ASSERT_EQ(2, devolved_selection.size());
+  ASSERT_EQ(FieldPath({2}), devolved_selection[0].path);
+  ASSERT_EQ(FieldPath({0}), devolved_selection[1].path);
+  ASSERT_EQ(*int32(), *devolved_selection[0].requested_type);
+  ASSERT_EQ(*int64(), *devolved_selection[1].requested_type);
+
+  // Basic strategy should append null column to batches for missing column
+  std::shared_ptr<RecordBatch> devolved_batch = RecordBatchFromJSON(
+      schema({field("C", int64()), field("A", int32())}), R"([[1,4], [2,5], [3,6]])");
+  ASSERT_OK_AND_ASSIGN(
+      compute::ExecBatch evolved_batch,
+      fragment_strategy->EvolveBatch(devolved_batch, selection, devolved_selection));
+  ASSERT_EQ(2, evolved_batch.values.size());
+  AssertArraysEqual(*devolved_batch->column(0), *evolved_batch[0].make_array());
+  AssertArraysEqual(*devolved_batch->column(1), *evolved_batch[1].make_array());
+}
+
+struct MockScanTask {
+  explicit MockScanTask(std::shared_ptr<RecordBatch> batch) : batch(std::move(batch)) {}
+
+  std::shared_ptr<RecordBatch> batch;
+  Future<std::shared_ptr<RecordBatch>> batch_future =
+      Future<std::shared_ptr<RecordBatch>>::Make();
+};
+
+struct MockFragmentScanner : public FragmentScanner {
+  explicit MockFragmentScanner(std::vector<MockScanTask> scan_tasks)
+      : scan_tasks_(std::move(scan_tasks)), has_started_(scan_tasks_.size(), false) {}
+
+  // ### FragmentScanner API ###
+  Future<std::shared_ptr<RecordBatch>> ScanBatch(int batch_number) override {
+    has_started_[batch_number] = true;
+    return scan_tasks_[batch_number].batch_future;
+  }
+  int64_t EstimatedDataBytes(int batch_number) override {
+    return util::TotalBufferSize(*scan_tasks_[batch_number].batch);
+  }
+  int NumBatches() override { return static_cast<int>(scan_tasks_.size()); }
+
+  // ### Unit Test API ###
+  void DeliverBatches(bool slow, const std::vector<MockScanTask>& to_deliver) {
+    for (MockScanTask task : to_deliver) {
+      if (slow) {
+        std::ignore = SleepABitAsync().Then(
+            [task]() mutable { task.batch_future.MarkFinished(task.batch); });
+      } else {
+        task.batch_future.MarkFinished(task.batch);
+      }
+    }
+  }
+
+  void DeliverBatchesInOrder(bool slow) { DeliverBatches(slow, scan_tasks_); }
+
+  void DeliverBatchesRandomly(bool slow, std::default_random_engine* gen) {
+    std::vector<MockScanTask> shuffled_tasks(scan_tasks_);
+    std::shuffle(shuffled_tasks.begin(), shuffled_tasks.end(), *gen);
+    DeliverBatches(slow, shuffled_tasks);
+  }
+
+  bool HasStarted(int batch_number) { return has_started_[batch_number]; }
+  bool HasDelivered(int batch_number) {
+    return scan_tasks_[batch_number].batch_future.is_finished();
+  }
+
+  std::vector<MockScanTask> scan_tasks_;
+  std::vector<bool> has_started_;
+};
+
+struct MockFragment : public Fragment {
+  // ### Fragment API ###
+
+  MockFragment(std::shared_ptr<Schema> fragment_schema,
+               std::vector<MockScanTask> scan_tasks,
+               std::shared_ptr<InspectedFragment> inspected,
+               compute::Expression partition_expression)
+      : Fragment(std::move(partition_expression), std::move(fragment_schema)),
+        fragment_scanner_(std::make_shared<MockFragmentScanner>(std::move(scan_tasks))),
+        inspected_(std::move(inspected)) {}
+
+  Result<RecordBatchGenerator> ScanBatchesAsync(
+      const std::shared_ptr<ScanOptions>& options) override {
+    return Status::Invalid("Not implemented because not needed by unit tests");
+  };
+
+  Future<std::shared_ptr<InspectedFragment>> InspectFragment() override {
+    has_inspected_ = true;
+    return inspected_future_;
+  }
+
+  Future<std::shared_ptr<FragmentScanner>> BeginScan(
+      const FragmentScanRequest& request,
+      const InspectedFragment& inspected_fragment) override {
+    has_started_ = true;
+    seen_request_ = request;
+    return fragment_scanner_future_;
+  }
+
+  Future<std::optional<int64_t>> CountRows(
+      compute::Expression predicate,
+      const std::shared_ptr<ScanOptions>& options) override {
+    return Status::Invalid("Not implemented because not needed by unit tests");
+  }
+
+  std::string type_name() const override { return "mock"; }
+
+  Result<std::shared_ptr<Schema>> ReadPhysicalSchemaImpl() override {
+    return physical_schema_;
+  };
+
+  // ### Unit Test API ###
+
+  void FinishInspection() { inspected_future_.MarkFinished(inspected_); }
+  void FinishScanBegin() { fragment_scanner_future_.MarkFinished(fragment_scanner_); }
+
+  Future<> DeliverInit(bool slow) {
+    if (slow) {
+      return SleepABitAsync().Then([this] {
+        FinishInspection();
+        return SleepABitAsync().Then([this] { FinishScanBegin(); });
+      });
+    } else {
+      FinishInspection();
+      FinishScanBegin();
+      return Future<>::MakeFinished();
+    }
+  }
+
+  void DeliverBatchesInOrder(bool slow) {
+    std::ignore = DeliverInit(slow).Then(
+        [this, slow] { fragment_scanner_->DeliverBatchesInOrder(slow); });
+  }
+
+  Future<> DeliverBatchesRandomly(bool slow, std::default_random_engine* gen) {
+    return DeliverInit(slow).Then(
+        [this, slow, gen] { fragment_scanner_->DeliverBatchesRandomly(slow, gen); });
+  }
+
+  bool has_inspected() { return has_inspected_; }
+  bool has_started() { return has_started_; }
+  bool HasBatchStarted(int batch_index) {
+    return fragment_scanner_->HasStarted(batch_index);
+  }
+  bool HasBatchDelivered(int batch_index) {
+    return fragment_scanner_->HasDelivered(batch_index);
+  }
+
+  std::shared_ptr<MockFragmentScanner> fragment_scanner_;
+  Future<std::shared_ptr<FragmentScanner>> fragment_scanner_future_ =
+      Future<std::shared_ptr<FragmentScanner>>::Make();
+  std::shared_ptr<InspectedFragment> inspected_;
+  Future<std::shared_ptr<InspectedFragment>> inspected_future_ =
+      Future<std::shared_ptr<InspectedFragment>>::Make();
+  bool has_inspected_ = false;
+  bool has_started_ = false;
+  FragmentScanRequest seen_request_;
+};
+
+FragmentVector AsFragmentVector(
+    const std::vector<std::shared_ptr<MockFragment>>& fragments) {
+  FragmentVector frag_vec;
+  frag_vec.insert(frag_vec.end(), fragments.begin(), fragments.end());
+  return frag_vec;
+}
+
+struct MockDataset : public FragmentDataset {
+  MockDataset(std::shared_ptr<Schema> dataset_schema,
+              std::vector<std::shared_ptr<MockFragment>> fragments)
+      : FragmentDataset(std::move(dataset_schema), AsFragmentVector(fragments)),
+        fragments_(std::move(fragments)) {}
+
+  // ### Dataset API ###
+  std::string type_name() const override { return "mock"; }
+
+  Result<std::shared_ptr<Dataset>> ReplaceSchema(
+      std::shared_ptr<Schema> schema) const override {
+    return Status::Invalid("Not needed for unit test");
+  }
+
+  Result<FragmentIterator> GetFragmentsImpl(compute::Expression predicate) override {
+    has_started_ = true;
+    return FragmentDataset::GetFragmentsImpl(std::move(predicate));
+  }
+
+  // ### Unit Test API ###
+  void DeliverBatchesInOrder(bool slow) {
+    for (const auto& fragment : fragments_) {
+      fragment->DeliverBatchesInOrder(slow);
+    }
+  }
+
+  void DeliverBatchesRandomly(bool slow) {
+    const auto seed = ::arrow::internal::GetRandomSeed();
+    std::default_random_engine gen(
+        static_cast<std::default_random_engine::result_type>(seed));
+
+    std::vector<std::shared_ptr<MockFragment>> fragments_shuffled(fragments_);
+    std::shuffle(fragments_shuffled.begin(), fragments_shuffled.end(), gen);
+    std::vector<Future<>> deliver_futures;
+    for (const auto& fragment : fragments_shuffled) {
+      deliver_futures.push_back(fragment->DeliverBatchesRandomly(slow, &gen));
+    }
+    // Need to wait for fragments to finish init so gen stays valid
+    AllComplete(deliver_futures).Wait();
+  }
+
+  bool has_started() { return has_started_; }
+  bool HasStartedFragment(int fragment_index) {
+    return fragments_[fragment_index]->has_started();
+  }
+  bool HasStartedBatch(int fragment_index, int batch_index) {
+    return fragments_[fragment_index]->HasBatchStarted(batch_index);
+  }
+
+  bool has_started_ = false;
+  std::vector<std::shared_ptr<MockFragment>> fragments_;
+};
+
+struct MockDatasetBuilder {
+  explicit MockDatasetBuilder(std::shared_ptr<Schema> dataset_schema)
+      : dataset_schema(std::move(dataset_schema)) {}
+
+  void AddFragment(
+      std::shared_ptr<Schema> fragment_schema,
+      std::unique_ptr<InspectedFragment> inspection = nullptr,
+      compute::Expression partition_expression = Fragment::kNoPartitionInformation) {
+    if (!inspection) {
+      inspection = std::make_unique<InspectedFragment>(fragment_schema->field_names());
+    }
+    fragments.push_back(std::make_shared<MockFragment>(
+        std::move(fragment_schema), std::vector<MockScanTask>(), std::move(inspection),
+        std::move(partition_expression)));
+    active_fragment = fragments[fragments.size() - 1]->fragment_scanner_.get();
+  }
+
+  void AddBatch(std::shared_ptr<RecordBatch> batch) {
+    active_fragment->scan_tasks_.emplace_back(std::move(batch));
+    active_fragment->has_started_.push_back(false);
+  }
+
+  std::unique_ptr<MockDataset> Finish() {
+    return arrow::internal::make_unique<MockDataset>(std::move(dataset_schema),
+                                                     std::move(fragments));
+  }
+
+  std::shared_ptr<Schema> dataset_schema;
+  std::vector<std::shared_ptr<MockFragment>> fragments;
+  MockFragmentScanner* active_fragment = nullptr;
+};
+
+template <typename TYPE,
+          typename = typename std::enable_if<arrow::is_integer_type<TYPE>::value>::type>
+std::shared_ptr<Array> ArrayFromRange(int start, int end, bool add_nulls) {
+  using ArrowBuilderType = typename arrow::TypeTraits<TYPE>::BuilderType;
+  ArrowBuilderType builder;
+  ARROW_EXPECT_OK(builder.Reserve(end - start));
+  for (int val = start; val < end; val++) {
+    if (add_nulls && val % 2 == 0) {
+      builder.UnsafeAppendNull();
+    } else {
+      builder.UnsafeAppend(val);
+    }
+  }
+  EXPECT_OK_AND_ASSIGN(std::shared_ptr<Array> range_arr, builder.Finish());
+  return range_arr;
+}
+
+struct ScannerTestParams {
+  bool slow;
+  int num_fragments;
+  int num_batches;
+
+  std::string ToString() const {
+    std::stringstream ss;
+    ss << (slow ? "slow" : "fast") << num_fragments << "f" << num_batches << "b";
+    return ss.str();
+  }
+
+  static std::string ToTestNameString(
+      const ::testing::TestParamInfo<ScannerTestParams>& info) {
+    return info.param.ToString();
+  }
+
+  static std::vector<ScannerTestParams> Values() {
+    std::vector<ScannerTestParams> values;
+    for (bool slow : {false, true}) {
+      values.push_back({slow, 1, 128});
+      values.push_back({slow, 16, 128});
+    }
+    return values;
+  }
+};
+
+constexpr int kRowsPerTestBatch = 1024;
+
+std::shared_ptr<Schema> ScannerTestSchema() {
+  return schema({field("row_num", int32()), field("filterable", int16()),
+                 field("nested", struct_({field("x", int32()), field("y", int32())}))});
+}
+
+std::shared_ptr<RecordBatch> MakeTestBatch(int idx) {
+  ArrayVector arrays;
+  // Row number
+  arrays.push_back(ArrayFromRange<Int32Type>(idx * kRowsPerTestBatch,
+                                             (idx + 1) * kRowsPerTestBatch,
+                                             /*add_nulls=*/false));
+  // Filterable
+  arrays.push_back(ArrayFromRange<Int16Type>(0, kRowsPerTestBatch,
+                                             /*add_nulls=*/true));
+  // Nested
+  std::shared_ptr<Array> x_vals =
+      ArrayFromRange<Int32Type>(0, kRowsPerTestBatch, /*add_nulls=*/false);
+  std::shared_ptr<Array> y_vals =
+      ArrayFromRange<Int32Type>(0, kRowsPerTestBatch, /*add_nulls=*/true);
+  EXPECT_OK_AND_ASSIGN(std::shared_ptr<Array> nested_arr,
+                       StructArray::Make({std::move(x_vals), std::move(y_vals)},
+                                         {field("x", int32()), field("y", int32())}));
+  arrays.push_back(std::move(nested_arr));
+  return RecordBatch::Make(ScannerTestSchema(), kRowsPerTestBatch, std::move(arrays));
+}
+
+std::unique_ptr<MockDataset> MakeTestDataset(int num_fragments, int batches_per_fragment,
+                                             bool empty = false) {
+  std::shared_ptr<Schema> test_schema = ScannerTestSchema();
+  MockDatasetBuilder dataset_builder(test_schema);
+  for (int i = 0; i < num_fragments; i++) {
+    dataset_builder.AddFragment(
+        test_schema,
+        ::arrow::internal::make_unique<InspectedFragment>(test_schema->field_names()),
+        Fragment::kNoPartitionInformation);
+    for (int j = 0; j < batches_per_fragment; j++) {
+      if (empty) {
+        dataset_builder.AddBatch(
+            RecordBatch::Make(schema({}), kRowsPerTestBatch, ArrayVector{}));
+      } else {
+        dataset_builder.AddBatch(MakeTestBatch(i * batches_per_fragment + j));
+      }
+    }
+  }
+  return dataset_builder.Finish();
+}
+
+class TestScannerBase : public ::testing::TestWithParam<ScannerTestParams> {
+ protected:
+  TestScannerBase() { internal::Initialize(); }
+
+  std::shared_ptr<RecordBatch> MakeExpectedBatch() {
+    RecordBatchVector batches;
+    for (int frag_idx = 0; frag_idx < GetParam().num_fragments; frag_idx++) {
+      for (int batch_idx = 0; batch_idx < GetParam().num_batches; batch_idx++) {
+        batches.push_back(MakeTestBatch(batch_idx + (frag_idx * GetParam().num_batches)));
+      }
+    }
+    EXPECT_OK_AND_ASSIGN(std::shared_ptr<Table> table,
+                         Table::FromRecordBatches(std::move(batches)));
+    EXPECT_OK_AND_ASSIGN(std::shared_ptr<RecordBatch> as_one_batch,
+                         table->CombineChunksToBatch());
+    return as_one_batch;
+  }
+
+  compute::Declaration MakeScanNode(std::shared_ptr<Dataset> dataset) {
+    ScanV2Options options(dataset);
+    options.columns = ScanV2Options::AllColumns(*dataset);
+    return compute::Declaration("scan2", options);
+  }
+
+  RecordBatchVector RunNode(compute::Declaration scan_decl, bool ordered,
+                            MockDataset* mock_dataset) {
+    Future<RecordBatchVector> batches_fut =
+        compute::DeclarationToBatchesAsync(std::move(scan_decl));
+    if (ordered) {
+      mock_dataset->DeliverBatchesInOrder(GetParam().slow);
+    } else {
+      mock_dataset->DeliverBatchesRandomly(GetParam().slow);
+    }
+    EXPECT_FINISHES_OK_AND_ASSIGN(RecordBatchVector record_batches, batches_fut);
+    return record_batches;
+  }
+
+  void CheckScannedBatches(RecordBatchVector batches) {
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<Table> batches_as_table,
+                         Table::FromRecordBatches(std::move(batches)));
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<RecordBatch> combined_data,
+                         batches_as_table->CombineChunksToBatch());
+
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<Array> sort_indices,
+        compute::SortIndices(combined_data->column(0), compute::SortOptions{}));
+    ASSERT_OK_AND_ASSIGN(Datum sorted_data, compute::Take(combined_data, sort_indices));
+
+    std::shared_ptr<RecordBatch> expected_data = MakeExpectedBatch();
+    AssertBatchesEqual(*expected_data, *sorted_data.record_batch());
+  }
+
+  void CheckScanner(bool ordered) {
+    std::shared_ptr<MockDataset> mock_dataset =
+        MakeTestDataset(GetParam().num_fragments, GetParam().num_batches);
+    compute::Declaration scan_decl = MakeScanNode(mock_dataset);
+    RecordBatchVector scanned_batches = RunNode(scan_decl, ordered, mock_dataset.get());
+    CheckScannedBatches(std::move(scanned_batches));
+  }
+};
+
+TEST_P(TestScannerBase, ScanOrdered) { CheckScanner(true); }
+TEST_P(TestScannerBase, ScanUnordered) { CheckScanner(false); }
+
+// FIXME: Add test for scanning no columns
+
+INSTANTIATE_TEST_SUITE_P(BasicNewScannerTests, TestScannerBase,
+                         ::testing::ValuesIn(ScannerTestParams::Values()),
+                         [](const ::testing::TestParamInfo<ScannerTestParams>& info) {
+                           return std::to_string(info.index) + info.param.ToString();
+                         });
+
+void CheckScannerBackpressure(std::shared_ptr<MockDataset> dataset, ScanV2Options options,
+                              int maxConcurrentFragments, int maxConcurrentBatches,
+                              ::arrow::internal::ThreadPool* thread_pool) {
+  // Start scanning
+  compute::Declaration scan_decl = compute::Declaration("scan2", std::move(options));
+  Future<RecordBatchVector> batches_fut =
+      compute::DeclarationToBatchesAsync(std::move(scan_decl));
+
+  auto get_num_inspected = [&] {
+    int num_inspected = 0;
+    for (const auto& frag : dataset->fragments_) {
+      if (frag->has_inspected()) {
+        num_inspected++;
+      }
+    }
+    return num_inspected;
+  };
+  BusyWait(10, [&] {
+    return get_num_inspected() == static_cast<int>(maxConcurrentFragments);
+  });
+  SleepABit();
+  ASSERT_EQ(get_num_inspected(), static_cast<int>(maxConcurrentFragments));
+
+  int total_batches = 0;
+  for (const auto& frag : dataset->fragments_) {
+    total_batches += frag->fragment_scanner_->NumBatches();
+    frag->FinishInspection();
+    frag->FinishScanBegin();
+  }
+
+  int batches_scanned = 0;
+  while (batches_scanned < total_batches) {
+    MockScanTask* next_task_to_deliver = nullptr;
+    thread_pool->WaitForIdle();
+    int batches_started = 0;
+    for (const auto& frag : dataset->fragments_) {
+      for (int i = 0; i < frag->fragment_scanner_->NumBatches(); i++) {
+        if (frag->HasBatchStarted(i)) {
+          batches_started++;
+          if (next_task_to_deliver == nullptr && !frag->HasBatchDelivered(i)) {
+            next_task_to_deliver = &frag->fragment_scanner_->scan_tasks_[i];
+          }
+        }
+      }
+    }
+    ASSERT_LE(batches_started - batches_scanned, maxConcurrentBatches)
+        << " too many scan tasks were allowed to run";
+    ASSERT_NE(next_task_to_deliver, nullptr);
+    next_task_to_deliver->batch_future.MarkFinished(next_task_to_deliver->batch);
+    batches_scanned++;
+  }
+}
+
+TEST(TestNewScanner, Backpressure) {
+  constexpr int kNumFragments = 4;
+  constexpr int kNumBatchesPerFragment = 4;
+  internal::Initialize();
+  std::shared_ptr<MockDataset> test_dataset =
+      MakeTestDataset(kNumFragments, kNumBatchesPerFragment);
+
+  ScanV2Options options(test_dataset);
+
+  // No readahead
+  options.dataset = test_dataset;
+  options.columns = ScanV2Options::AllColumns(*test_dataset);
+  options.fragment_readahead = 0;
+  options.target_bytes_readahead = 0;
+  CheckScannerBackpressure(test_dataset, options, 1, 1,
+                           ::arrow::internal::GetCpuThreadPool());
+
+  // Some readahead
+  test_dataset = MakeTestDataset(kNumFragments, kNumBatchesPerFragment);
+  options = ScanV2Options(test_dataset);
+  options.columns = ScanV2Options::AllColumns(*test_dataset);
+  options.fragment_readahead = 4;
+  // each batch should be 14Ki so 50Ki readahead should yield 3-at-a-time
+  options.target_bytes_readahead = 50 * kRowsPerTestBatch;
+  CheckScannerBackpressure(test_dataset, options, 4, 3,
+                           ::arrow::internal::GetCpuThreadPool());
+}
+
+TEST(TestNewScanner, NestedRead) {
+  // This tests the case where the file format does not support
+  // handling nested reads (e.g. JSON) and so the scanner must
+  // drop the extra data
+  internal::Initialize();
+  std::shared_ptr<Schema> test_schema = ScannerTestSchema();
+  MockDatasetBuilder builder(test_schema);
+  builder.AddFragment(test_schema);
+  std::shared_ptr<RecordBatch> batch = MakeTestBatch(0);
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<Array> nested_col, FieldPath({2, 0}).Get(*batch));
+  std::shared_ptr<RecordBatch> one_column = RecordBatch::Make(
+      schema({field("x", int32())}), batch->num_rows(), ArrayVector{nested_col});
+  builder.AddBatch(std::move(one_column));
+  std::shared_ptr<MockDataset> test_dataset = builder.Finish();
+  test_dataset->DeliverBatchesInOrder(false);
+
+  ScanV2Options options(test_dataset);
+  // nested.x
+  options.columns = {FieldPath({2, 0})};
+  ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<RecordBatch>> batches,
+                       compute::DeclarationToBatches({"scan2", options}));
+  ASSERT_EQ(1, batches.size());
+  for (const auto& batch : batches) {
+    ASSERT_EQ("x", batch->schema()->field(0)->name());
+    ASSERT_EQ(*int32(), *batch->schema()->field(0)->type());
+    ASSERT_EQ(*int32(), *batch->column(0)->type());
+  }
+  const FragmentScanRequest& seen_request = test_dataset->fragments_[0]->seen_request_;
+  ASSERT_EQ(1, seen_request.columns.size());
+  ASSERT_EQ(FieldPath({2, 0}), seen_request.columns[0].path);
+  ASSERT_EQ(*int32(), *seen_request.columns[0].requested_type);
+  ASSERT_EQ(0, seen_request.columns[0].selection_index);
+}
+
+std::shared_ptr<MockDataset> MakePartitionSkipDataset() {
+  std::shared_ptr<Schema> test_schema = ScannerTestSchema();
+  MockDatasetBuilder builder(test_schema);
+  builder.AddFragment(test_schema, /*inspection=*/nullptr,
+                      greater(field_ref("filterable"), literal(50)));
+  builder.AddBatch(MakeTestBatch(0));
+  builder.AddFragment(test_schema, /*inspection=*/nullptr,
+                      less_equal(field_ref("filterable"), literal(50)));
+  builder.AddBatch(MakeTestBatch(1));
+  return builder.Finish();
+}
+
+TEST(TestNewScanner, PartitionSkip) {
+  internal::Initialize();
+  std::shared_ptr<MockDataset> test_dataset = MakePartitionSkipDataset();
+  test_dataset->DeliverBatchesInOrder(false);
+
+  ScanV2Options options(test_dataset);
+  options.columns = ScanV2Options::AllColumns(*test_dataset);
+  options.filter = greater(field_ref("filterable"), literal(75));
+
+  ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<RecordBatch>> batches,
+                       compute::DeclarationToBatches({"scan2", options}));
+  ASSERT_EQ(1, batches.size());
+  AssertBatchesEqual(*MakeTestBatch(0), *batches[0]);
+
+  test_dataset = MakePartitionSkipDataset();
+  test_dataset->DeliverBatchesInOrder(false);
+  options = ScanV2Options(test_dataset);
+  options.columns = ScanV2Options::AllColumns(*test_dataset);
+  options.filter = less(field_ref("filterable"), literal(25));
+
+  ASSERT_OK_AND_ASSIGN(batches, compute::DeclarationToBatches({"scan2", options}));
+  ASSERT_EQ(1, batches.size());
+  AssertBatchesEqual(*MakeTestBatch(1), *batches[0]);
+}
+
+TEST(TestNewScanner, NoFragments) {
+  internal::Initialize();
+  std::shared_ptr<Schema> test_schema = ScannerTestSchema();
+  MockDatasetBuilder builder(test_schema);
+  std::shared_ptr<MockDataset> test_dataset = builder.Finish();
+
+  ScanV2Options options(test_dataset);
+  options.columns = ScanV2Options::AllColumns(*test_dataset);
+  ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<RecordBatch>> batches,
+                       compute::DeclarationToBatches({"scan2", options}));
+  ASSERT_EQ(0, batches.size());
+}
+
+TEST(TestNewScanner, EmptyFragment) {
+  internal::Initialize();
+  std::shared_ptr<Schema> test_schema = ScannerTestSchema();
+  MockDatasetBuilder builder(test_schema);
+  builder.AddFragment(test_schema);
+  std::shared_ptr<MockDataset> test_dataset = builder.Finish();
+  test_dataset->DeliverBatchesInOrder(false);
+
+  ScanV2Options options(test_dataset);
+  options.columns = ScanV2Options::AllColumns(*test_dataset);
+  ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<RecordBatch>> batches,
+                       compute::DeclarationToBatches({"scan2", options}));
+  ASSERT_EQ(0, batches.size());
+}
+
+TEST(TestNewScanner, EmptyBatch) {
+  internal::Initialize();
+  std::shared_ptr<Schema> test_schema = ScannerTestSchema();
+  MockDatasetBuilder builder(test_schema);
+  builder.AddFragment(test_schema);
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<RecordBatch> empty_batch,
+                       RecordBatch::MakeEmpty(test_schema));
+  builder.AddBatch(std::move(empty_batch));
+  std::shared_ptr<MockDataset> test_dataset = builder.Finish();
+  test_dataset->DeliverBatchesInOrder(false);
+
+  ScanV2Options options(test_dataset);
+  options.columns = ScanV2Options::AllColumns(*test_dataset);
+  ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<RecordBatch>> batches,
+                       compute::DeclarationToBatches({"scan2", options}));
+  ASSERT_EQ(0, batches.size());
+}
+
+TEST(TestNewScanner, NoColumns) {
+  constexpr int kNumFragments = 4;
+  constexpr int kNumBatchesPerFragment = 4;
+  internal::Initialize();
+  std::shared_ptr<MockDataset> test_dataset =
+      MakeTestDataset(kNumFragments, kNumBatchesPerFragment, /*empty=*/true);
+  test_dataset->DeliverBatchesInOrder(false);
+
+  ScanV2Options options(test_dataset);
+  ASSERT_OK_AND_ASSIGN(std::vector<compute::ExecBatch> batches,
+                       compute::DeclarationToExecBatches({"scan2", options}));
+  ASSERT_EQ(16, batches.size());
+  for (const auto& batch : batches) {
+    ASSERT_EQ(0, batch.values.size());
+    ASSERT_EQ(kRowsPerTestBatch, batch.length);
+  }
+}
+
+TEST(TestNewScanner, MissingColumn) {
+  internal::Initialize();
+  std::shared_ptr<Schema> test_schema = ScannerTestSchema();
+  MockDatasetBuilder builder(test_schema);
+
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<Schema> missing_schema,
+                       test_schema->RemoveField(2));
+  builder.AddFragment(missing_schema);
+  std::shared_ptr<RecordBatch> batch = MakeTestBatch(0);
+  // Remove column 2 because we are pretending it doesn't exist
+  // in the fragment
+  ASSERT_OK_AND_ASSIGN(batch, batch->RemoveColumn(2));
+  // Remove column 1 because we aren't going to ask for it
+  ASSERT_OK_AND_ASSIGN(batch, batch->RemoveColumn(1));
+  builder.AddBatch(batch);
+
+  std::shared_ptr<MockDataset> test_dataset = builder.Finish();
+  test_dataset->DeliverBatchesInOrder(false);
+
+  ScanV2Options options(test_dataset);
+  options.columns = {FieldPath({0}), FieldPath({2})};
+
+  ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<RecordBatch>> batches,
+                       compute::DeclarationToBatches({"scan2", options}));
+
+  ASSERT_EQ(1, batches.size());
+  AssertArraysEqual(*batch->column(0), *batches[0]->column(0));
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<Array> expected_nulls,
+                       MakeArrayOfNull(test_schema->field(2)->type(), kRowsPerTestBatch));
+  AssertArraysEqual(*expected_nulls, *batches[0]->column(1));
+}
 
 struct TestScannerParams {
   bool use_threads;
@@ -98,8 +846,7 @@ class TestScanner : public DatasetFixtureMixinWithParam<TestScannerParams> {
   }
 
   std::shared_ptr<Scanner> MakeScanner(std::shared_ptr<RecordBatch> batch) {
-    std::vector<std::shared_ptr<RecordBatch>> batches{
-        static_cast<size_t>(GetParam().num_batches), batch};
+    RecordBatchVector batches{static_cast<size_t>(GetParam().num_batches), batch};
 
     DatasetVector children{static_cast<size_t>(GetParam().num_child_datasets),
                            std::make_shared<InMemoryDataset>(batch->schema(), batches)};
@@ -333,7 +1080,7 @@ TEST_P(TestScanner, MaterializeMissingColumn) {
 TEST_P(TestScanner, ToTable) {
   SetSchema({field("i32", int32()), field("f64", float64())});
   auto batch = ConstantArrayGenerator::Zeroes(GetParam().items_per_batch, schema_);
-  std::vector<std::shared_ptr<RecordBatch>> batches{
+  RecordBatchVector batches{
       static_cast<std::size_t>(GetParam().num_batches * GetParam().num_child_datasets),
       batch};
 
@@ -452,7 +1199,7 @@ TEST_P(TestScanner, EmptyFragment) {
   SetSchema({field("i32", int32()), field("f64", float64())});
   auto batch = ConstantArrayGenerator::Zeroes(GetParam().items_per_batch, schema_);
   auto empty_batch = ConstantArrayGenerator::Zeroes(0, schema_);
-  std::vector<std::shared_ptr<RecordBatch>> batches{
+  RecordBatchVector batches{
       static_cast<std::size_t>(GetParam().num_batches * GetParam().num_child_datasets),
       batch};
 
@@ -581,7 +1328,7 @@ TEST_P(TestScanner, CountRowsWithMetadata) {
 TEST_P(TestScanner, ToRecordBatchReader) {
   SetSchema({field("i32", int32()), field("f64", float64())});
   auto batch = ConstantArrayGenerator::Zeroes(GetParam().items_per_batch, schema_);
-  std::vector<std::shared_ptr<RecordBatch>> batches{
+  RecordBatchVector batches{
       static_cast<std::size_t>(GetParam().num_batches * GetParam().num_child_datasets),
       batch};
 

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -60,13 +60,11 @@ namespace dataset {
 // or the fragment other than the schema so we just make a dummy dataset/fragment
 // here.
 std::unique_ptr<Dataset> MakeDatasetFromSchema(std::shared_ptr<Schema> sch) {
-  return ::arrow::internal::make_unique<InMemoryDataset>(std::move(sch),
-                                                         RecordBatchVector{});
+  return std::make_unique<InMemoryDataset>(std::move(sch), RecordBatchVector{});
 }
 
 std::unique_ptr<Fragment> MakeSomeFragment(std::shared_ptr<Schema> sch) {
-  return ::arrow::internal::make_unique<InMemoryFragment>(std::move(sch),
-                                                          RecordBatchVector{});
+  return std::make_unique<InMemoryFragment>(std::move(sch), RecordBatchVector{});
 }
 
 TEST(BasicEvolution, MissingColumn) {
@@ -380,8 +378,7 @@ struct MockDatasetBuilder {
   }
 
   std::unique_ptr<MockDataset> Finish() {
-    return arrow::internal::make_unique<MockDataset>(std::move(dataset_schema),
-                                                     std::move(fragments));
+    return std::make_unique<MockDataset>(std::move(dataset_schema), std::move(fragments));
   }
 
   std::shared_ptr<Schema> dataset_schema;
@@ -466,8 +463,7 @@ std::unique_ptr<MockDataset> MakeTestDataset(int num_fragments, int batches_per_
   MockDatasetBuilder dataset_builder(test_schema);
   for (int i = 0; i < num_fragments; i++) {
     dataset_builder.AddFragment(
-        test_schema,
-        ::arrow::internal::make_unique<InspectedFragment>(test_schema->field_names()),
+        test_schema, std::make_unique<InspectedFragment>(test_schema->field_names()),
         Fragment::kNoPartitionInformation);
     for (int j = 0; j < batches_per_fragment; j++) {
       if (empty) {

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -1092,6 +1092,17 @@ Result<std::shared_ptr<Field>> FieldPath::Get(const FieldVector& fields) const {
   return FieldPathGetImpl::Get(this, fields);
 }
 
+Result<std::shared_ptr<Schema>> FieldPath::GetAll(const Schema& schm,
+                                                  const std::vector<FieldPath>& paths) {
+  std::vector<std::shared_ptr<Field>> fields;
+  fields.reserve(paths.size());
+  for (const auto& path : paths) {
+    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Field> field, path.Get(schm));
+    fields.push_back(std::move(field));
+  }
+  return schema(std::move(fields));
+}
+
 Result<std::shared_ptr<Array>> FieldPath::Get(const RecordBatch& batch) const {
   ARROW_ASSIGN_OR_RAISE(auto data, FieldPathGetImpl::Get(this, batch.column_data()));
   return MakeArray(std::move(data));

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1626,6 +1626,9 @@ class ARROW_EXPORT FieldPath {
   Result<std::shared_ptr<Field>> Get(const DataType& type) const;
   Result<std::shared_ptr<Field>> Get(const FieldVector& fields) const;
 
+  static Result<std::shared_ptr<Schema>> GetAll(const Schema& schema,
+                                                const std::vector<FieldPath>& paths);
+
   /// \brief Retrieve the referenced column from a RecordBatch or Table
   Result<std::shared_ptr<Array>> Get(const RecordBatch& batch) const;
 

--- a/cpp/src/arrow/util/async_util.cc
+++ b/cpp/src/arrow/util/async_util.cc
@@ -282,9 +282,8 @@ class AsyncTaskSchedulerImpl : public AsyncTaskScheduler {
       AbortUnlocked(submit_result.status(), std::move(lk));
       return;
     }
-    // FIXME(C++17, move into lambda?)
-    std::shared_ptr<Task> task_holder = std::move(task);
-    submit_result->AddCallback([this, cost, task_holder](const Status& st) {
+    // Capture `task` to keep it alive until finished
+    submit_result->AddCallback([this, cost, task = std::move(task)](const Status& st) {
       std::unique_lock<std::mutex> lk(mutex_);
       if (!st.ok()) {
         running_tasks_--;

--- a/cpp/src/arrow/util/async_util.cc
+++ b/cpp/src/arrow/util/async_util.cc
@@ -32,7 +32,8 @@ namespace util {
 
 class ThrottleImpl : public AsyncTaskScheduler::Throttle {
  public:
-  explicit ThrottleImpl(int max_concurrent_cost) : available_cost_(max_concurrent_cost) {}
+  explicit ThrottleImpl(int max_concurrent_cost)
+      : max_concurrent_cost_(max_concurrent_cost), available_cost_(max_concurrent_cost) {}
 
   std::optional<Future<>> TryAcquire(int amt) override {
     std::lock_guard<std::mutex> lk(mutex_);
@@ -61,8 +62,11 @@ class ThrottleImpl : public AsyncTaskScheduler::Throttle {
     }
   }
 
+  int Capacity() override { return max_concurrent_cost_; }
+
  private:
   std::mutex mutex_;
+  int max_concurrent_cost_;
   int available_cost_;
   Future<> backoff_;
 };
@@ -151,7 +155,8 @@ class AsyncTaskSchedulerImpl : public AsyncTaskScheduler {
         queue_->Push(std::move(task));
         return true;
       }
-      std::optional<Future<>> maybe_backoff = throttle_->TryAcquire(task->cost());
+      int latched_cost = std::min(task->cost(), throttle_->Capacity());
+      std::optional<Future<>> maybe_backoff = throttle_->TryAcquire(latched_cost);
       if (maybe_backoff) {
         queue_->Push(std::move(task));
         lk.unlock();
@@ -237,7 +242,7 @@ class AsyncTaskSchedulerImpl : public AsyncTaskScheduler {
  private:
   void ContinueTasksUnlocked(std::unique_lock<std::mutex>&& lk) {
     while (!queue_->Empty()) {
-      int next_cost = queue_->Peek().cost();
+      int next_cost = std::min(queue_->Peek().cost(), throttle_->Capacity());
       std::optional<Future<>> maybe_backoff = throttle_->TryAcquire(next_cost);
       if (maybe_backoff) {
         lk.unlock();
@@ -266,6 +271,9 @@ class AsyncTaskSchedulerImpl : public AsyncTaskScheduler {
 
   void DoSubmitTask(std::unique_ptr<Task> task) {
     int cost = task->cost();
+    if (throttle_) {
+      cost = std::min(cost, throttle_->Capacity());
+    }
     Result<Future<>> submit_result = (*task)(this);
     if (!submit_result.ok()) {
       global_abort_->store(true);
@@ -274,7 +282,9 @@ class AsyncTaskSchedulerImpl : public AsyncTaskScheduler {
       AbortUnlocked(submit_result.status(), std::move(lk));
       return;
     }
-    submit_result->AddCallback([this, cost](const Status& st) {
+    // FIXME(C++17, move into lambda?)
+    std::shared_ptr<Task> task_holder = std::move(task);
+    submit_result->AddCallback([this, cost, task_holder](const Status& st) {
       std::unique_lock<std::mutex> lk(mutex_);
       if (!st.ok()) {
         running_tasks_--;

--- a/python/pyarrow/_exec_plan.pyx
+++ b/python/pyarrow/_exec_plan.pyx
@@ -384,7 +384,7 @@ def _filter_table(table, expression, output_type=Table):
 
     c_decl_plan.push_back(
         CDeclaration(tobytes("filter"), CFilterNodeOptions(
-            <CExpression>expr.unwrap(), True
+            <CExpression>expr.unwrap()
         ))
     )
 

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2533,7 +2533,7 @@ cdef extern from "arrow/compute/exec/options.h" namespace "arrow::compute" nogil
         pass
 
     cdef cppclass CFilterNodeOptions "arrow::compute::FilterNodeOptions"(CExecNodeOptions):
-        CFilterNodeOptions(CExpression, c_bool async_mode)
+        CFilterNodeOptions(CExpression)
 
     cdef cppclass CProjectNodeOptions "arrow::compute::ProjectNodeOptions"(CExecNodeOptions):
         CProjectNodeOptions(vector[CExpression] expressions)


### PR DESCRIPTION
**Primary Goal:** Create a scanner that "cancels" properly.  In other words, when the scan node is marked finished then all scan-related thread tasks will be finished.  This is different than the current model where I/O tasks are allowed to keep parts of the scan alive via captures of shared_ptr state.

**Secondary Goal:** Remove our dependency on the merged generator and make the scanner more accessible.  The merged generator is complicated and does not support cancellation, and it currently only understood by a very small set of people.

**Secondary Goal:** Add interfaces for schema evolution.  This wasn't originally a goal but arose from my attempt to codify and normalize what we are currently doing.  These interfaces should eventually allow for things like filling a missing field with a default value or using the parquet column id for field resolution.

Performance isn't a goal for this rework but ideally this should not degrade performance.