### PR TITLE
ARROW-17296: [Python] Update serialized metadata size in pyarrow.parquet.read_metadata doctest

### DIFF
--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -3419,7 +3419,7 @@ def read_metadata(where, memory_map=False, decryption_properties=None):
       num_rows: 3
       num_row_groups: 1
       format_version: 2.6
-      serialized_size: 561
+      serialized_size: 562
     """
     return ParquetFile(where, memory_map=memory_map,
                        decryption_properties=decryption_properties).metadata

--- a/python/pyarrow/parquet/__init__.py
+++ b/python/pyarrow/parquet/__init__.py
@@ -3419,7 +3419,7 @@ def read_metadata(where, memory_map=False, decryption_properties=None):
       num_rows: 3
       num_row_groups: 1
       format_version: 2.6
-      serialized_size: 562
+      serialized_size: ...
     """
     return ParquetFile(where, memory_map=memory_map,
                        decryption_properties=decryption_properties).metadata


### PR DESCRIPTION
This should remain correct until we hit major version 100 (or make changes that otherwise affect the metadata size)