### PR TITLE
ARROW-17306: [C++] Provide an optimized `GetFileInfoGenerator` specialization for `LocalFileSystem`

### DIFF
--- a/cpp/src/arrow/filesystem/CMakeLists.txt
+++ b/cpp/src/arrow/filesystem/CMakeLists.txt
@@ -28,14 +28,14 @@ add_arrow_test(filesystem-test
                EXTRA_LABELS
                filesystem)
 
-if(ARROW_BUILD_BENCHMARKS AND ARROW_PARQUET)
-    add_arrow_benchmark(localfs_benchmark
-                        PREFIX
-                        "arrow-filesystem"
-                        SOURCES
-                        localfs_benchmark.cc
-                        STATIC_LINK_LIBS
-                        ${ARROW_BENCHMARK_LINK_LIBS})
+if(ARROW_BUILD_BENCHMARKS)
+  add_arrow_benchmark(localfs_benchmark
+                      PREFIX
+                      "arrow-filesystem"
+                      SOURCES
+                      localfs_benchmark.cc
+                      STATIC_LINK_LIBS
+                      ${ARROW_BENCHMARK_LINK_LIBS})
 endif()
 
 if(ARROW_GCS)

--- a/cpp/src/arrow/filesystem/CMakeLists.txt
+++ b/cpp/src/arrow/filesystem/CMakeLists.txt
@@ -28,6 +28,16 @@ add_arrow_test(filesystem-test
                EXTRA_LABELS
                filesystem)
 
+if(ARROW_BUILD_BENCHMARKS AND ARROW_PARQUET)
+    add_arrow_benchmark(localfs_benchmark
+                        PREFIX
+                        "arrow-filesystem"
+                        SOURCES
+                        localfs_benchmark.cc
+                        STATIC_LINK_LIBS
+                        ${ARROW_BENCHMARK_LINK_LIBS})
+endif()
+
 if(ARROW_GCS)
   add_arrow_test(gcsfs_test
                  EXTRA_LABELS

--- a/cpp/src/arrow/filesystem/localfs.cc
+++ b/cpp/src/arrow/filesystem/localfs.cc
@@ -243,7 +243,7 @@ LocalFileSystemOptions LocalFileSystemOptions::Defaults() {
 }
 
 bool LocalFileSystemOptions::Equals(const LocalFileSystemOptions& other) const {
-  return use_mmap == other.use_mmap;
+  return use_mmap == other.use_mmap && directory_readahead == other.directory_readahead;
 }
 
 Result<LocalFileSystemOptions> LocalFileSystemOptions::FromUri(

--- a/cpp/src/arrow/filesystem/localfs.cc
+++ b/cpp/src/arrow/filesystem/localfs.cc
@@ -365,10 +365,9 @@ class AsyncStatSelector {
 
     ARROW_ASSIGN_OR_RAISE(
         auto base_dir, arrow::internal::PlatformFilename::FromString(selector.base_dir));
-    ARROW_RETURN_NOT_OK(
-        DoDiscovery(std::move(base_dir), 0, std::move(selector),
-                    std::make_shared<DiscoveryState>(std::move(file_gen.producer())),
-                    io_context, fs_opts.file_info_batch_size));
+    ARROW_RETURN_NOT_OK(DoDiscovery(std::move(base_dir), 0, std::move(selector),
+                                    std::make_shared<DiscoveryState>(file_gen.producer()),
+                                    io_context, fs_opts.file_info_batch_size));
 
     return file_gen;
   }

--- a/cpp/src/arrow/filesystem/localfs.cc
+++ b/cpp/src/arrow/filesystem/localfs.cc
@@ -17,6 +17,7 @@
 
 #include <chrono>
 #include <cstring>
+#include <memory>
 #include <sstream>
 #include <utility>
 
@@ -29,12 +30,15 @@
 #include <sys/stat.h>
 #endif
 
+#include "arrow/filesystem/filesystem.h"
 #include "arrow/filesystem/localfs.h"
 #include "arrow/filesystem/path_util.h"
+#include "arrow/filesystem/type_fwd.h"
 #include "arrow/filesystem/util_internal.h"
 #include "arrow/io/file.h"
+#include "arrow/io/type_fwd.h"
+#include "arrow/util/async_generator.h"
 #include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
 #include "arrow/util/uri.h"
 #include "arrow/util/windows_fixup.h"
 
@@ -308,6 +312,242 @@ Result<std::vector<FileInfo>> LocalFileSystem::GetFileInfo(const FileSelector& s
   std::vector<FileInfo> results;
   RETURN_NOT_OK(StatSelector(fn, select, 0, &results));
   return results;
+}
+
+namespace {
+
+/// Workhorse for streaming async implementation of `GetFileInfo`
+/// (`GetFileInfoGenerator`).
+///
+/// There are two variants of async discovery functions suported:
+/// 1. `DiscoverDirectoryFiles`, which parallelizes traversal of individual directories
+///    so that each directory results are yielded as a separate `FileInfoGenerator` via
+///    an underlying `DiscoveryImplIterator`, which delivers items in chunks (default size
+///    is 1K items).
+/// 2. `DiscoverDirectoriesFlattened`, which forwards execution to the
+///    `DiscoverDirectoryFiles`, with the difference that the results from individual
+///    sub-directory iterators are merged into the single FileInfoGenerator stream.
+///
+/// The implementation makes use of additional attributes in `LocalFileSystemOptions`,
+/// such as `directory_readahead`, which can be used to tune algorithm
+/// behavior and adjust how many directories can be processed in parallel.
+/// This option is disabled by default, so that individual directories are processed
+/// in serial manner via `MakeConcatenatedGenerator` under the hood.
+class AsyncStatSelector {
+ public:
+  using FileInfoGeneratorProducer = PushGenerator<FileInfoGenerator>::Producer;
+
+  /// Discovery state, which is shared among all `DiscoveryImplGenerator`:s,
+  /// spawned by a single discovery operation (`DiscoverDirectoryFiles()`).
+  ///
+  /// The sole purpose of this struct is to handle automatic closing the
+  /// producer side of the resulting `FileInfoGenerator`. I.e. the producer
+  /// is kept alive until all discovery iterators are exhausted, in which case
+  /// `producer.Close()` is called automatically when ref-count for the state
+  /// reaches zero (which is equivalent to finishing the file discovery
+  /// process).
+  struct DiscoveryState {
+    FileInfoGeneratorProducer producer;
+
+    explicit DiscoveryState(FileInfoGeneratorProducer p) : producer(std::move(p)) {}
+    ~DiscoveryState() { producer.Close(); }
+  };
+
+  /// The main procedure to start async streaming discovery using a given `FileSelector`.
+  ///
+  /// The result is a two-level generator, i.e. "generator of FileInfoGenerator:s",
+  /// where each individual generator represents an FileInfo item stream from coming an
+  /// individual sub-directory under the selector's `base_dir`.
+  static Result<AsyncGenerator<FileInfoGenerator>> DiscoverDirectoryFiles(
+      FileSelector selector, LocalFileSystemOptions fs_opts,
+      const io::IOContext& io_context) {
+    PushGenerator<FileInfoGenerator> file_gen;
+
+    ARROW_ASSIGN_OR_RAISE(
+        auto base_dir, arrow::internal::PlatformFilename::FromString(selector.base_dir));
+    ARROW_RETURN_NOT_OK(
+        DoDiscovery(std::move(base_dir), 0, std::move(selector),
+                    std::make_shared<DiscoveryState>(std::move(file_gen.producer())),
+                    io_context, fs_opts.file_info_batch_size));
+
+    return file_gen;
+  }
+
+  /// Version of `DiscoverDirectoryFiles` which flattens the stream of generators
+  /// into a single FileInfoGenerator stream.
+  /// Makes use of `LocalFileSystemOptions::directory_readahead` to determine how much
+  /// readahead should happen.
+  static arrow::Result<FileInfoGenerator> DiscoverDirectoriesFlattened(
+      FileSelector selector, LocalFileSystemOptions fs_opts,
+      const io::IOContext& io_context) {
+    int32_t dir_readahead = fs_opts.directory_readahead;
+    ARROW_ASSIGN_OR_RAISE(
+        auto part_gen,
+        DiscoverDirectoryFiles(std::move(selector), std::move(fs_opts), io_context));
+    return dir_readahead > 1
+               ? MakeSequencedMergedGenerator(std::move(part_gen), dir_readahead)
+               : MakeConcatenatedGenerator(std::move(part_gen));
+  }
+
+ private:
+  /// The class, which implements iterator interface to traverse a given
+  /// directory at the fixed nesting depth, and possibly recurses into
+  /// sub-directories (if specified by the selector), spawning more
+  /// `DiscoveryImplIterators`, which feed their data into a single producer.
+  class DiscoveryImplIterator {
+    const PlatformFilename dir_fn_;
+    const int32_t nesting_depth_;
+    const FileSelector selector_;
+    const uint32_t file_info_batch_size_;
+
+    const io::IOContext& io_context_;
+    std::shared_ptr<DiscoveryState> discovery_state_;
+    FileInfoVector current_chunk_;
+    std::vector<PlatformFilename> child_fns_;
+    size_t idx_ = 0;
+    bool initialized_ = false;
+
+   public:
+    DiscoveryImplIterator(PlatformFilename dir_fn, int32_t nesting_depth,
+                          FileSelector selector,
+                          std::shared_ptr<DiscoveryState> discovery_state,
+                          const io::IOContext& io_context, uint32_t file_info_batch_size)
+        : dir_fn_(std::move(dir_fn)),
+          nesting_depth_(nesting_depth),
+          selector_(std::move(selector)),
+          file_info_batch_size_(file_info_batch_size),
+          io_context_(io_context),
+          discovery_state_(std::move(discovery_state)) {}
+
+    /// Pre-initialize the iterator by listing directory contents and caching
+    /// in the current instance.
+    Status Initialize() {
+      auto result = arrow::internal::ListDir(dir_fn_);
+      if (!result.ok()) {
+        auto status = result.status();
+        if (selector_.allow_not_found && status.IsIOError()) {
+          ARROW_ASSIGN_OR_RAISE(bool exists, FileExists(dir_fn_));
+          if (!exists) {
+            return Status::OK();
+          }
+        }
+        return status;
+      }
+      child_fns_ = result.MoveValueUnsafe();
+
+      const size_t dirent_count = child_fns_.size();
+      current_chunk_.reserve(dirent_count >= file_info_batch_size_ ? file_info_batch_size_
+                                                                   : dirent_count);
+
+      initialized_ = true;
+      return Status::OK();
+    }
+
+    Result<FileInfoVector> Next() {
+      if (!initialized_) {
+        auto init = Initialize();
+        if (!init.ok()) {
+          return Finish(init);
+        }
+      }
+      while (idx_ < child_fns_.size()) {
+        auto full_fn = dir_fn_.Join(child_fns_[idx_++]);
+        auto res = StatFile(full_fn.ToNative());
+        if (!res.ok()) {
+          return Finish(res.status());
+        }
+
+        auto info = res.MoveValueUnsafe();
+
+        // Try to recurse into subdirectories, if needed.
+        if (info.type() == FileType::Directory &&
+            nesting_depth_ < selector_.max_recursion && selector_.recursive) {
+          auto status = DoDiscovery(std::move(full_fn), nesting_depth_ + 1, selector_,
+                                    discovery_state_, io_context_, file_info_batch_size_);
+          if (!status.ok()) {
+            return Finish(status);
+          }
+        }
+        // Everything is ok. Add the item to the current chunk of data.
+        current_chunk_.emplace_back(std::move(info));
+        // Keep `current_chunk_` as large, as `batch_size_`.
+        // Otherwise, yield the complete chunk to the caller.
+        if (current_chunk_.size() == file_info_batch_size_) {
+          FileInfoVector yield_vec = std::move(current_chunk_);
+          const size_t items_left = child_fns_.size() - idx_;
+          current_chunk_.reserve(
+              items_left >= file_info_batch_size_ ? file_info_batch_size_ : items_left);
+          return yield_vec;
+        }
+      }  // while (idx_ < child_fns_.size())
+
+      // Flush out remaining items
+      if (!current_chunk_.empty()) {
+        return std::move(current_chunk_);
+      }
+      return Finish();
+    }
+
+   private:
+    /// Release reference to shared discovery state and return iteration end
+    /// marker to indicate that this iterator is exhausted.
+    Result<FileInfoVector> Finish(Status status = Status::OK()) {
+      discovery_state_.reset();
+      ARROW_RETURN_NOT_OK(status);
+      return IterationEnd<FileInfoVector>();
+    }
+  };
+
+  /// Create an instance of  `DiscoveryImplIterator` under the hood for the
+  /// specified directory, wrap it in the `BackgroundGenerator`  and feed
+  /// the results to the main producer queue.
+  ///
+  /// Each `DiscoveryImplIterator` maintains a reference to `DiscoveryState`,
+  /// which simply wraps the producer to keep it alive for the lifetime
+  /// of this iterator. When all references to `DiscoveryState` are invalidated,
+  /// the producer is closed automatically.
+  static Status DoDiscovery(const PlatformFilename& dir_fn, int32_t nesting_depth,
+                            FileSelector selector,
+                            std::shared_ptr<DiscoveryState> discovery_state,
+                            const io::IOContext& io_context,
+                            int32_t file_info_batch_size) {
+    ARROW_RETURN_IF(discovery_state->producer.is_closed(),
+                    arrow::Status::Cancelled("Discovery cancelled"));
+
+    // Note, that here we use `MakeTransferredGenerator()` with the same
+    // target executor (io executor) as the current iterator is running on.
+    //
+    // This is done on purpose, since typically the user of
+    // `GetFileInfoGenerator()` would want to perform some more IO on the
+    // produced results (e.g. read the files, examine metadata etc.).
+    // So, it is preferable to execute the attached continuations on the same
+    // executor, which belongs to the IO thread pool.
+    ARROW_ASSIGN_OR_RAISE(
+        auto gen,
+        MakeBackgroundGenerator(Iterator<FileInfoVector>(DiscoveryImplIterator(
+                                    std::move(dir_fn), nesting_depth, std::move(selector),
+                                    discovery_state, io_context, file_info_batch_size)),
+                                io_context.executor()));
+    gen = MakeTransferredGenerator(std::move(gen), io_context.executor());
+    ARROW_RETURN_IF(!discovery_state->producer.Push(std::move(gen)),
+                    arrow::Status::Cancelled("Discovery cancelled"));
+    return arrow::Status::OK();
+  }
+};
+
+}  // anonymous namespace
+
+FileInfoGenerator LocalFileSystem::GetFileInfoGenerator(const FileSelector& select) {
+  auto path_status = ValidatePath(select.base_dir);
+  if (!path_status.ok()) {
+    return MakeFailingGenerator<FileInfoVector>(path_status);
+  }
+  auto fileinfo_gen =
+      AsyncStatSelector::DiscoverDirectoriesFlattened(select, options(), io_context_);
+  if (!fileinfo_gen.ok()) {
+    return MakeFailingGenerator<FileInfoVector>(fileinfo_gen.status());
+  }
+  return fileinfo_gen.MoveValueUnsafe();
 }
 
 Status LocalFileSystem::CreateDir(const std::string& path, bool recursive) {

--- a/cpp/src/arrow/filesystem/localfs.cc
+++ b/cpp/src/arrow/filesystem/localfs.cc
@@ -243,7 +243,8 @@ LocalFileSystemOptions LocalFileSystemOptions::Defaults() {
 }
 
 bool LocalFileSystemOptions::Equals(const LocalFileSystemOptions& other) const {
-  return use_mmap == other.use_mmap && directory_readahead == other.directory_readahead;
+  return use_mmap == other.use_mmap && directory_readahead == other.directory_readahead &&
+         file_info_batch_size == other.file_info_batch_size;
 }
 
 Result<LocalFileSystemOptions> LocalFileSystemOptions::FromUri(

--- a/cpp/src/arrow/filesystem/localfs.h
+++ b/cpp/src/arrow/filesystem/localfs.h
@@ -87,6 +87,7 @@ class ARROW_EXPORT LocalFileSystem : public FileSystem {
   /// \endcond
   Result<FileInfo> GetFileInfo(const std::string& path) override;
   Result<std::vector<FileInfo>> GetFileInfo(const FileSelector& select) override;
+  FileInfoGenerator GetFileInfoGenerator(const FileSelector& select) override;
 
   Status CreateDir(const std::string& path, bool recursive = true) override;
 

--- a/cpp/src/arrow/filesystem/localfs.h
+++ b/cpp/src/arrow/filesystem/localfs.h
@@ -35,13 +35,22 @@ namespace fs {
 /// Options for the LocalFileSystem implementation.
 struct ARROW_EXPORT LocalFileSystemOptions {
   static constexpr int32_t kDefaultDirectoryReadahead = 16;
+  static constexpr int32_t kDefaultFileInfoBatchSize = 1000;
 
   /// Whether OpenInputStream and OpenInputFile return a mmap'ed file,
   /// or a regular one.
   bool use_mmap = false;
+
+  /// Options related to `GetFileInfoGenerator` interface.
+
   /// How many directories should be processed in parallel
   /// by the `GetFileInfoGenerator` impl.
   int32_t directory_readahead = kDefaultDirectoryReadahead;
+  /// Specifies how much entries shall be aggregated into
+  /// a single FileInfoVector chunk by the `GetFileInfoGenerator` impl, which
+  /// is the result of `stat`:ing individual dirents, obtained by the call to
+  /// `internal::ListDir`.
+  int32_t file_info_batch_size = kDefaultFileInfoBatchSize;
 
   /// \brief Initialize with defaults
   static LocalFileSystemOptions Defaults();

--- a/cpp/src/arrow/filesystem/localfs.h
+++ b/cpp/src/arrow/filesystem/localfs.h
@@ -43,13 +43,18 @@ struct ARROW_EXPORT LocalFileSystemOptions {
 
   /// Options related to `GetFileInfoGenerator` interface.
 
-  /// How many directories should be processed in parallel
-  /// by the `GetFileInfoGenerator` impl.
+  /// EXPERIMENTAL: The maximum number of directories processed in parallel
+  /// by `GetFileInfoGenerator`.
   int32_t directory_readahead = kDefaultDirectoryReadahead;
-  /// Specifies how much entries shall be aggregated into
-  /// a single FileInfoVector chunk by the `GetFileInfoGenerator` impl, which
-  /// is the result of `stat`:ing individual dirents, obtained by the call to
-  /// `internal::ListDir`.
+
+  /// EXPERIMENTAL: The maximum number of entries aggregated into each
+  /// FileInfoVector chunk by `GetFileInfoGenerator`.
+  ///
+  /// Since each FileInfo entry needs a separate `stat` system call, a
+  /// directory with a very large number of files may take a lot of time to
+  /// process entirely. By generating a FileInfoVector after this chunk
+  /// size is reached, we ensure FileInfo entries can start being consumed
+  /// from the FileInfoGenerator with less initial latency.
   int32_t file_info_batch_size = kDefaultFileInfoBatchSize;
 
   /// \brief Initialize with defaults

--- a/cpp/src/arrow/filesystem/localfs.h
+++ b/cpp/src/arrow/filesystem/localfs.h
@@ -34,9 +34,14 @@ namespace fs {
 
 /// Options for the LocalFileSystem implementation.
 struct ARROW_EXPORT LocalFileSystemOptions {
+  static constexpr int32_t kDefaultDirectoryReadahead = 16;
+
   /// Whether OpenInputStream and OpenInputFile return a mmap'ed file,
   /// or a regular one.
   bool use_mmap = false;
+  /// How many directories should be processed in parallel
+  /// by the `GetFileInfoGenerator` impl.
+  int32_t directory_readahead = kDefaultDirectoryReadahead;
 
   /// \brief Initialize with defaults
   static LocalFileSystemOptions Defaults();

--- a/cpp/src/arrow/filesystem/localfs_benchmark.cc
+++ b/cpp/src/arrow/filesystem/localfs_benchmark.cc
@@ -19,16 +19,14 @@
 
 #include "benchmark/benchmark.h"
 
-#include <arrow/status.h>
-#include <arrow/testing/random.h>
-#include <arrow/util/async_generator.h>
-#include <arrow/util/string_view.h>
 #include "arrow/filesystem/localfs.h"
 #include "arrow/io/file.h"
+#include "arrow/status.h"
 #include "arrow/table.h"
 #include "arrow/testing/future_util.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/random.h"
+#include "arrow/util/async_generator.h"
 #include "arrow/util/formatting.h"
 #include "arrow/util/io_util.h"
 #include "arrow/util/make_unique.h"

--- a/cpp/src/arrow/filesystem/localfs_benchmark.cc
+++ b/cpp/src/arrow/filesystem/localfs_benchmark.cc
@@ -1,0 +1,148 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <memory>
+
+#include "benchmark/benchmark.h"
+
+#include <arrow/status.h>
+#include <arrow/testing/random.h>
+#include <arrow/util/async_generator.h>
+#include <arrow/util/string_view.h>
+#include "arrow/filesystem/localfs.h"
+#include "arrow/io/file.h"
+#include "arrow/table.h"
+#include "arrow/testing/future_util.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/testing/random.h"
+#include "arrow/util/formatting.h"
+#include "arrow/util/io_util.h"
+#include "arrow/util/make_unique.h"
+#include "arrow/util/string_view.h"
+
+namespace arrow {
+
+namespace fs {
+
+using arrow::internal::make_unique;
+using arrow::internal::TemporaryDir;
+
+/// Set up hierarchical directory structure to test asynchronous
+/// file discovery interface (GetFileInfoGenerator()) in the LocalFileSystem
+/// class.
+///
+/// The main routine of the class is `InitializeDatasetStructure()`, which
+/// does the following:
+/// 1. Create `num_files_` empty files under specified root directory.
+/// 2. Create `num_dirs_` additional sub-directories in the current dir.
+/// 3. Check if the specified recursion limit is reached (controlled by `nesting_depth_`).
+///   a. Return if recursion limit reached.
+///   b. Recurse into each sub-directory and perform steps above, increasing current
+///      nesting level.
+class LocalFSFixture : public benchmark::Fixture {
+ public:
+  void SetUp(const benchmark::State& state) override {
+    ASSERT_OK_AND_ASSIGN(tmp_dir_, TemporaryDir::Make("localfs-test-"));
+
+    auto options = LocalFileSystemOptions::Defaults();
+    fs_ = make_unique<LocalFileSystem>(options);
+
+    InitializeDatasetStructure(0, tmp_dir_->path());
+  }
+
+  void InitializeDatasetStructure(size_t cur_nesting_level,
+                                  arrow::internal::PlatformFilename cur_root_dir) {
+    ASSERT_OK(arrow::internal::CreateDir(cur_root_dir));
+
+    arrow::internal::StringFormatter<Int32Type> format;
+    for (size_t i = 0; i < num_files_; ++i) {
+      std::string fname = "file_";
+      format(i, [&fname](util::string_view formatted) {
+        fname.append(formatted.data(), formatted.size());
+      });
+      ASSERT_OK_AND_ASSIGN(auto path, cur_root_dir.Join(std::move(fname)));
+      ASSERT_OK(MakeEmptyFile(path.ToString()));
+    }
+
+    if (cur_nesting_level == nesting_depth_) {
+      return;
+    }
+
+    for (size_t i = 0; i < num_dirs_; ++i) {
+      std::string dirname = "dir_";
+      format(i, [&dirname](util::string_view formatted) {
+        dirname.append(formatted.data(), formatted.size());
+      });
+      ASSERT_OK_AND_ASSIGN(auto path, cur_root_dir.Join(std::move(dirname)));
+      InitializeDatasetStructure(cur_nesting_level + 1, std::move(path));
+    }
+  }
+
+  Status MakeEmptyFile(const std::string& path) {
+    return io::FileOutputStream::Open(path).status();
+  }
+
+ protected:
+  std::unique_ptr<TemporaryDir> tmp_dir_;
+  std::unique_ptr<LocalFileSystem> fs_;
+
+  const size_t nesting_depth_ = 2;
+  const size_t num_dirs_ = 10;
+  const size_t num_files_ = 1000;
+};
+
+/// Benchmark for `LocalFileSystem::GetFileInfoGenerator()` performance.
+///
+/// The test function is executed for each combination (cartesian product)
+/// of input arguments tuple (directory_readahead, file_info_batch_size)
+/// to test both internal parallelism and batching.
+BENCHMARK_DEFINE_F(LocalFSFixture, AsyncFileDiscovery)
+(benchmark::State& st) {
+  size_t total_file_count = 0;
+
+  for (auto _ : st) {
+    // Instantiate LocalFileSystem with custom options for directory readahead
+    // and file info batch size.
+    auto options = LocalFileSystemOptions::Defaults();
+    options.directory_readahead = static_cast<int32_t>(st.range(0));
+    options.file_info_batch_size = static_cast<int32_t>(st.range(1));
+    auto test_fs = make_unique<LocalFileSystem>(options);
+    // Create recursive FileSelector pointing to the root of the temporary
+    // directory, which was set up by the fixture earlier.
+    FileSelector select;
+    select.base_dir = tmp_dir_->path().ToString();
+    select.recursive = true;
+    auto file_gen = test_fs->GetFileInfoGenerator(std::move(select));
+    // Trigger fetching from the generator and count all received FileInfo:s.
+    auto visit_fut =
+        VisitAsyncGenerator(file_gen, [&total_file_count](const FileInfoVector& fv) {
+          total_file_count += fv.size();
+          return Status::OK();
+        });
+    ASSERT_FINISHES_OK(visit_fut);
+  }
+  st.SetItemsProcessed(total_file_count);
+}
+BENCHMARK_REGISTER_F(LocalFSFixture, AsyncFileDiscovery)
+    ->ArgNames({"directory_readahead", "file_info_batch_size"})
+    ->ArgsProduct({{1, 4, 16}, {100, 1000}})
+    ->UseRealTime()
+    ->Unit(benchmark::kMillisecond);
+
+}  // namespace fs
+
+}  // namespace arrow

--- a/cpp/src/arrow/filesystem/type_fwd.h
+++ b/cpp/src/arrow/filesystem/type_fwd.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace arrow {
 namespace fs {
 


### PR DESCRIPTION
Introduce a specialization of `GetFileInfoGenerator` in the `LocalFileSystem` class.

This implementation tries to improves performance by hiding latencies at two levels:
1. Child directories can be readahead so that listing directories entries from disk can be achieved in parallel with other work;
2. Directory entries can be `stat`'ed and yielded in chunks so that the `FileInfoGenerator` consumer can start receiving entries before a large directory is fully processed.

Both mechanisms can be tuned using dedicated parameters in `LocalFileSystemOptions`.

Signed-off-by: Pavel Solodovnikov <pavel.al.solodovnikov@gmail.com>
Co-Authored-by: Igor Seliverstov <iseliverstov@querifylabs.com>