### PR TITLE
ARROW-17299: [C++][Python] Expose the Scanner kDefaultBatchReadahead and kDefaultFragmentReadahead parameters

### DIFF
--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -826,20 +826,29 @@ Status ScannerBuilder::UseThreads(bool use_threads) {
   return Status::OK();
 }
 
-Status ScannerBuilder::FragmentReadahead(int fragment_readahead) {
-  if (fragment_readahead <= 0) {
-    return Status::Invalid("FragmentReadahead must be greater than 0, got ",
-                           fragment_readahead);
-  }
-  scan_options_->fragment_readahead = fragment_readahead;
-  return Status::OK();
-}
-
 Status ScannerBuilder::BatchSize(int64_t batch_size) {
   if (batch_size <= 0) {
     return Status::Invalid("BatchSize must be greater than 0, got ", batch_size);
   }
   scan_options_->batch_size = batch_size;
+  return Status::OK();
+}
+
+Status ScannerBuilder::BatchReadahead(int32_t batch_readahead) {
+  if (batch_readahead < 0) {
+    return Status::Invalid("BatchReadahead must be greater than or equal 0, got ",
+                           batch_readahead);
+  }
+  scan_options_->batch_readahead = batch_readahead;
+  return Status::OK();
+}
+
+Status ScannerBuilder::FragmentReadahead(int32_t fragment_readahead) {
+  if (fragment_readahead < 0) {
+    return Status::Invalid("FragmentReadahead must be greater than or equal 0, got ",
+                           fragment_readahead);
+  }
+  scan_options_->fragment_readahead = fragment_readahead;
   return Status::OK();
 }
 

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -394,7 +394,7 @@ class ARROW_DS_EXPORT ScannerBuilder {
   /// \brief Set the number of fragments to read ahead
   ///
   /// \param[in] fragment_readahead How many fragments to read ahead
-  /// \returns An error if this number is less than 0.
+  /// \returns an error if this number is less than 0.
   ///
   /// This option provides a control on the RAM vs IO tradeoff.
   Status FragmentReadahead(int32_t fragment_readahead);

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -396,7 +396,7 @@ class ARROW_DS_EXPORT ScannerBuilder {
   /// \param[in] fragment_readahead How many fragments to read ahead
   /// \returns an error if this number is less than 0.
   ///
-  /// This option provides a control on the RAM vs IO tradeoff.
+  /// This option provides a control on the RAM vs I/O tradeoff.
   Status FragmentReadahead(int32_t fragment_readahead);
 
   /// \brief Set the pool from which materialized and scanned arrays will be allocated.

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -373,9 +373,6 @@ class ARROW_DS_EXPORT ScannerBuilder {
   ///        ThreadPool found in ScanOptions;
   Status UseThreads(bool use_threads = true);
 
-  /// \brief Limit how many fragments the scanner will read at once
-  Status FragmentReadahead(int fragment_readahead);
-
   /// \brief Set the maximum number of rows per RecordBatch.
   ///
   /// \param[in] batch_size the maximum number of rows.
@@ -383,6 +380,23 @@ class ARROW_DS_EXPORT ScannerBuilder {
   ///
   /// This option provides a control limiting the memory owned by any RecordBatch.
   Status BatchSize(int64_t batch_size);
+
+  /// \brief Set the number of batches to read aheadw ithin a file.
+  ///
+  /// \param[in] batch_readahead How many batches to read ahead within a file,
+  ///  might not work for all formats. refer to comments above.
+  /// \returns An error if this number is less than 0.
+  ///
+  /// This option provides a control on RAM vs IO tradeoff.
+  Status BatchReadahead(int32_t batch_readahead);
+
+  /// \brief Set the number of How many files to read ahead
+  ///
+  /// \param[in] fragment_readahead How many files to read ahead
+  /// \returns An error if this number is less than 0.
+  ///
+  /// This option provides a control on RAM vs IO tradeoff.
+  Status FragmentReadahead(int32_t fragment_readahead);
 
   /// \brief Set the pool from which materialized and scanned arrays will be allocated.
   Status Pool(MemoryPool* pool);

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -381,7 +381,7 @@ class ARROW_DS_EXPORT ScannerBuilder {
   /// This option provides a control limiting the memory owned by any RecordBatch.
   Status BatchSize(int64_t batch_size);
 
-  /// \brief Set the number of batches to read aheadw ithin a file.
+  /// \brief Set the number of batches to read ahead within a file.
   ///
   /// \param[in] batch_readahead How many batches to read ahead within a file,
   ///  might not work for all formats. refer to comments above.

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -396,7 +396,7 @@ class ARROW_DS_EXPORT ScannerBuilder {
   /// \param[in] fragment_readahead How many fragments to read ahead
   /// \returns An error if this number is less than 0.
   ///
-  /// This option provides a control on RAM vs IO tradeoff.
+  /// This option provides a control on the RAM vs IO tradeoff.
   Status FragmentReadahead(int32_t fragment_readahead);
 
   /// \brief Set the pool from which materialized and scanned arrays will be allocated.

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -384,15 +384,15 @@ class ARROW_DS_EXPORT ScannerBuilder {
   /// \brief Set the number of batches to read ahead within a file.
   ///
   /// \param[in] batch_readahead How many batches to read ahead within a file,
-  ///  might not work for all formats. refer to comments above.
+  ///  might not work for all formats. 
   /// \returns An error if this number is less than 0.
   ///
-  /// This option provides a control on RAM vs IO tradeoff.
+  /// This option provides a control on RAM vs I/O tradeoff.
   Status BatchReadahead(int32_t batch_readahead);
 
-  /// \brief Set the number of How many files to read ahead
+  /// \brief Set the number of fragments to read ahead
   ///
-  /// \param[in] fragment_readahead How many files to read ahead
+  /// \param[in] fragment_readahead How many fragments to read ahead
   /// \returns An error if this number is less than 0.
   ///
   /// This option provides a control on RAM vs IO tradeoff.

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -383,12 +383,11 @@ class ARROW_DS_EXPORT ScannerBuilder {
 
   /// \brief Set the number of batches to read ahead within a fragment.
   ///
-  /// \param[in] batch_readahead How many batches to read ahead within a fragment,
-  ///  might not work for all formats.
-  /// \returns An error if this number is less than 0.
+  /// \param[in] batch_readahead How many batches to read ahead within a fragment
+  /// \returns an error if this number is less than 0.
   ///
-  /// This option provides a control on RAM vs I/O tradeoff.
-  /// It might not be support by all file formats, in which case it will
+  /// This option provides a control on the RAM vs I/O tradeoff.
+  /// It might not be supported by all file formats, in which case it will
   /// simply be ignored.
   Status BatchReadahead(int32_t batch_readahead);
 

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -82,7 +82,7 @@ struct ARROW_DS_EXPORT ScanOptions {
   /// Maximum row count for scanned batches.
   int64_t batch_size = kDefaultBatchSize;
 
-  /// How many batches to read ahead within a file
+  /// How many batches to read ahead within a fragment.
   ///
   /// Set to 0 to disable batch readahead
   ///
@@ -381,13 +381,15 @@ class ARROW_DS_EXPORT ScannerBuilder {
   /// This option provides a control limiting the memory owned by any RecordBatch.
   Status BatchSize(int64_t batch_size);
 
-  /// \brief Set the number of batches to read ahead within a file.
+  /// \brief Set the number of batches to read ahead within a fragment.
   ///
-  /// \param[in] batch_readahead How many batches to read ahead within a file,
-  ///  might not work for all formats. 
+  /// \param[in] batch_readahead How many batches to read ahead within a fragment,
+  ///  might not work for all formats.
   /// \returns An error if this number is less than 0.
   ///
   /// This option provides a control on RAM vs I/O tradeoff.
+  /// It might not be support by all file formats, in which case it will
+  /// simply be ignored.
   Status BatchReadahead(int32_t batch_readahead);
 
   /// \brief Set the number of fragments to read ahead

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -2347,7 +2347,7 @@ cdef class Scanner(_Weakrefable):
             RAM usage but could also improve IO utilization.
         fragment_readahead : int, default 4
             The number of files to read ahead. Increasing this number will increase
-            RAM usage but also improve IO utilization.
+            RAM usage but could also improve IO utilization.
         use_threads : bool, default True
             If enabled, then maximum parallelism will be used determined by
             the number of available CPU cores.

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -2261,10 +2261,10 @@ cdef class Scanner(_Weakrefable):
         called to reduce their size.
     batch_readahead : int, default 16
         The number of batches to read ahead in a file. Increasing this number 
-        will increase RAM usage but also improve IO utilization.
+        will increase RAM usage but could also improve IO utilization.
     fragment_readahead : int, default 4
         The number of files to read ahead. Increasing this number will increase
-        RAM usage but also improve IO utilization.
+        RAM usage but could also improve IO utilization.
     use_threads : bool, default True
         If enabled, then maximum parallelism will be used determined by
         the number of available CPU cores.

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -2430,8 +2430,8 @@ cdef class Scanner(_Weakrefable):
             called to reduce their size.
         batch_readahead : int, default 16
             The number of batches to read ahead in a file. This might not work
-            for all file formats like CSV. Increasing this number will increase
-            RAM usage but also improve IO utilization.
+            for all file formats. Increasing this number will increase
+            RAM usage but could also improve IO utilization.
         use_threads : bool, default True
             If enabled, then maximum parallelism will be used determined by
             the number of available CPU cores.

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -2260,9 +2260,8 @@ cdef class Scanner(_Weakrefable):
         record batches are overflowing memory then this method can be
         called to reduce their size.
     batch_readahead : int, default 16
-        The number of batches to read ahead in a file. This might not work
-        for all file formats like CSV. Increasing this number will increase
-        RAM usage but also improve IO utilization.
+        The number of batches to read ahead in a file. Increasing this number 
+        will increase RAM usage but also improve IO utilization.
     fragment_readahead : int, default 4
         The number of files to read ahead. Increasing this number will increase
         RAM usage but also improve IO utilization.

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -2168,11 +2168,14 @@ cdef class TaggedRecordBatchIterator(_Weakrefable):
 
 
 _DEFAULT_BATCH_SIZE = 2**17
-
+_DEFAULT_BATCH_READAHEAD = 16
+_DEFAULT_FRAGMENT_READAHEAD = 4
 
 cdef void _populate_builder(const shared_ptr[CScannerBuilder]& ptr,
                             object columns=None, Expression filter=None,
                             int batch_size=_DEFAULT_BATCH_SIZE,
+                            int batch_readahead=_DEFAULT_BATCH_READAHEAD,
+                            int fragment_readahead=_DEFAULT_FRAGMENT_READAHEAD,
                             bint use_threads=True, MemoryPool memory_pool=None,
                             FragmentScanOptions fragment_scan_options=None)\
         except *:
@@ -2207,6 +2210,8 @@ cdef void _populate_builder(const shared_ptr[CScannerBuilder]& ptr,
             )
 
     check_status(builder.BatchSize(batch_size))
+    check_status(builder.BatchReadahead(batch_readahead))
+    check_status(builder.FragmentReadahead(fragment_readahead))
     check_status(builder.UseThreads(use_threads))
     if memory_pool:
         check_status(builder.Pool(maybe_unbox_memory_pool(memory_pool)))
@@ -2254,6 +2259,13 @@ cdef class Scanner(_Weakrefable):
         The maximum row count for scanned record batches. If scanned
         record batches are overflowing memory then this method can be
         called to reduce their size.
+    batch_readahead : int, default 16
+        The number of batches to read ahead in a file. This might not work
+        for all file formats like CSV. Increasing this number will increase
+        RAM usage but also improve IO utilization.
+    fragment_readahead : int, default 4
+        The number of files to read ahead. Increasing this number will increase
+        RAM usage but also improve IO utilization.
     use_threads : bool, default True
         If enabled, then maximum parallelism will be used determined by
         the number of available CPU cores.
@@ -2291,6 +2303,8 @@ cdef class Scanner(_Weakrefable):
                      MemoryPool memory_pool=None,
                      object columns=None, Expression filter=None,
                      int batch_size=_DEFAULT_BATCH_SIZE,
+                     int batch_readahead=_DEFAULT_BATCH_READAHEAD,
+                     int fragment_readahead=_DEFAULT_FRAGMENT_READAHEAD,
                      FragmentScanOptions fragment_scan_options=None):
         """
         Create Scanner from Dataset,
@@ -2328,6 +2342,13 @@ cdef class Scanner(_Weakrefable):
             The maximum row count for scanned record batches. If scanned
             record batches are overflowing memory then this method can be
             called to reduce their size.
+        batch_readahead : int, default 16
+            The number of batches to read ahead in a file. This might not work
+            for all file formats like CSV. Increasing this number will increase
+            RAM usage but also improve IO utilization.
+        fragment_readahead : int, default 4
+            The number of files to read ahead. Increasing this number will increase
+            RAM usage but also improve IO utilization.
         use_threads : bool, default True
             If enabled, then maximum parallelism will be used determined by
             the number of available CPU cores.
@@ -2354,7 +2375,8 @@ cdef class Scanner(_Weakrefable):
 
         builder = make_shared[CScannerBuilder](dataset.unwrap(), options)
         _populate_builder(builder, columns=columns, filter=filter,
-                          batch_size=batch_size, use_threads=use_threads,
+                          batch_size=batch_size, batch_readahead=batch_readahead,
+                          fragment_readahead=fragment_readahead, use_threads=use_threads,
                           memory_pool=memory_pool,
                           fragment_scan_options=fragment_scan_options)
 
@@ -2367,6 +2389,7 @@ cdef class Scanner(_Weakrefable):
                       MemoryPool memory_pool=None,
                       object columns=None, Expression filter=None,
                       int batch_size=_DEFAULT_BATCH_SIZE,
+                      int batch_readahead=_DEFAULT_BATCH_READAHEAD,
                       FragmentScanOptions fragment_scan_options=None):
         """
         Create Scanner from Fragment,
@@ -2406,6 +2429,10 @@ cdef class Scanner(_Weakrefable):
             The maximum row count for scanned record batches. If scanned
             record batches are overflowing memory then this method can be
             called to reduce their size.
+        batch_readahead : int, default 16
+            The number of batches to read ahead in a file. This might not work
+            for all file formats like CSV. Increasing this number will increase
+            RAM usage but also improve IO utilization.
         use_threads : bool, default True
             If enabled, then maximum parallelism will be used determined by
             the number of available CPU cores.
@@ -2435,7 +2462,9 @@ cdef class Scanner(_Weakrefable):
         builder = make_shared[CScannerBuilder](pyarrow_unwrap_schema(schema),
                                                fragment.unwrap(), options)
         _populate_builder(builder, columns=columns, filter=filter,
-                          batch_size=batch_size, use_threads=use_threads,
+                          batch_size=batch_size, batch_readahead=batch_readahead,
+                          fragment_readahead=_DEFAULT_FRAGMENT_READAHEAD,
+                          use_threads=use_threads,
                           memory_pool=memory_pool,
                           fragment_scan_options=fragment_scan_options)
 
@@ -2508,7 +2537,8 @@ cdef class Scanner(_Weakrefable):
                           FutureWarning)
 
         _populate_builder(builder, columns=columns, filter=filter,
-                          batch_size=batch_size, use_threads=use_threads,
+                          batch_size=batch_size, batch_readahead=_DEFAULT_BATCH_READAHEAD,
+                          fragment_readahead=_DEFAULT_FRAGMENT_READAHEAD, use_threads=use_threads,
                           memory_pool=memory_pool,
                           fragment_scan_options=fragment_scan_options)
         scanner = GetResultValue(builder.get().Finish())

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -2343,8 +2343,8 @@ cdef class Scanner(_Weakrefable):
             called to reduce their size.
         batch_readahead : int, default 16
             The number of batches to read ahead in a file. This might not work
-            for all file formats like CSV. Increasing this number will increase
-            RAM usage but also improve IO utilization.
+            for all file formats. Increasing this number will increase
+            RAM usage but could also improve IO utilization.
         fragment_readahead : int, default 4
             The number of files to read ahead. Increasing this number will increase
             RAM usage but also improve IO utilization.

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -122,6 +122,8 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         CStatus UseThreads(c_bool use_threads)
         CStatus Pool(CMemoryPool* pool)
         CStatus BatchSize(int64_t batch_size)
+        CStatus BatchReadahead(int32_t batch_readahead)
+        CStatus FragmentReadahead(int32_t fragment_readahead)
         CStatus FragmentScanOptions(
             shared_ptr[CFragmentScanOptions] fragment_scan_options)
         CResult[shared_ptr[CScanner]] Finish()

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -427,7 +427,7 @@ def test_dataset(dataset, dataset_reader):
 def test_scanner_options(dataset):
     scanner = dataset.to_batches(fragment_readahead=16, batch_readahead=8)
     batch = next(scanner)
-    assert batch.num_columns == 1
+    assert batch.num_columns == 7
 
 
 @pytest.mark.parquet

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -424,13 +424,10 @@ def test_dataset(dataset, dataset_reader):
 
 
 @pytest.mark.parquet
-def test_scanner_options(dataset, dataset_reader):
-    scanner = dataset_reader.scanner(
-        dataset, memory_pool=pa.default_memory_pool())
-    assert isinstance(scanner, ds.Scanner)
-    for batch in scanner.to_batches(fragment_readahead=16, batch_readahead=8):
-        assert batch.num_columns == 1
-        assert batch.schema == scanner.projected_schema
+def test_scanner_options(dataset):
+    scanner = dataset.to_batches(fragment_readahead=16, batch_readahead=8)
+    batch = next(scanner)
+    assert batch.num_columns == 1
 
 
 @pytest.mark.parquet

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -424,6 +424,16 @@ def test_dataset(dataset, dataset_reader):
 
 
 @pytest.mark.parquet
+def test_scanner_options(dataset, dataset_reader):
+    scanner = dataset_reader.scanner(
+        dataset, memory_pool=pa.default_memory_pool())
+    assert isinstance(scanner, ds.Scanner)
+    for batch in scanner.to_batches(fragment_readahead=16, batch_readahead=8):
+        assert batch.num_columns == 1
+        assert batch.schema == scanner.projected_schema
+
+
+@pytest.mark.parquet
 def test_scanner(dataset, dataset_reader):
     scanner = dataset_reader.scanner(
         dataset, memory_pool=pa.default_memory_pool())


### PR DESCRIPTION
This exposes the Fragment Readahead and Batch Readahead flags in the C++ Scanner to the user in Python.

This can be used to finetune RAM usage and IO utilization during downloading large files from S3 or other network sources. I believe the default settings are overly conservative for small RAM settings and I observe less than 20% IO utilization on some instances on AWS. 

The Python API is exposed only to methods where these flags make sense. Scanning from a RecordBatchIterator won't need those these flags nor will those flags make sense. Only the latter flag makes sense for making a scanner from a fragment. 

To test this, set up an i3.2xlarge instance on AWS: 

```
import pyarrow
import pyarrow.dataset as ds
import pyarrow.csv as csv
import time
pyarrow.set_cpu_count(8)
pyarrow.set_io_thread_count(16)
lineitem_scheme = ["l_orderkey","l_partkey","l_suppkey","l_linenumber","l_quantity","l_extendedprice",
"l_discount","l_tax","l_returnflag","l_linestatus","l_shipdate","l_commitdate","l_receiptdate","l_shipinstruct",
"l_shipmode","l_comment", "null"]
csv_format = ds.CsvFileFormat(read_options=csv.ReadOptions(column_names=lineitem_scheme, block_size= 32 * 1024 * 1024), parse_options=csv.ParseOptions(delimiter="|"))
dataset = ds.dataset("s3://TPC",format=csv_format)
s = dataset.to_batches(batch_size=1000000000)
while count < 100:
    z = next(s)
```
For our purposes let's just make the TPC dataset consist of hundreds of Parquet files each with one row group. (something that Spark would generate). This script would get somewhere around 1Gbps. If you now do
```
s = dataset.to_batches(batch_size=1000000000, fragment_readahead=16)
```
You can get to 2.5Gbps which is the advertised steady rate cap for this instance type.
