### PR TITLE
MINOR: [C++][Docs] Adds link in "Using Arrow C++ in your own project" to Arrow install page

### DIFF
--- a/docs/source/cpp/build_system.rst
+++ b/docs/source/cpp/build_system.rst
@@ -23,7 +23,8 @@ Using Arrow C++ in your own project
 ===================================
 
 This section assumes you already have the Arrow C++ libraries on your
-system, either after installing them using a package manager or after
+system, either after `installing them using a package manager
+<https://arrow.apache.org/install/>`_ or after
 :ref:`building them yourself <building-arrow-cpp>`.
 
 The recommended way to integrate the Arrow C++ libraries in your own


### PR DESCRIPTION
Currently, users of the C++ documentation have to go find the commands and availability for installing Arrow in their package manager of choice themselves. While this is only a small irritation, it's easily fixed by adding a link to the install page. This PR adds said link.