### PR TITLE
GH-32605: [C#] Extend ArrowBuffer.BitmapBuilder to improve performance of array concatenation

### DIFF
--- a/csharp/src/Apache.Arrow/Arrays/ArrayDataConcatenator.cs
+++ b/csharp/src/Apache.Arrow/Arrays/ArrayDataConcatenator.cs
@@ -156,10 +156,7 @@ namespace Apache.Arrow
                     int length = arrayData.Length;
                     ReadOnlySpan<byte> span = arrayData.Buffers[bufferIndex].Span;
 
-                    for (int i = 0; i < length; i++)
-                    {
-                        builder.Append(span.IsEmpty || BitUtility.GetBit(span, i));
-                    }
+                    builder.Append(span, length);
                 }
 
                 return builder.Build(_allocator);

--- a/csharp/src/Apache.Arrow/Arrays/PrimitiveArrayBuilder.cs
+++ b/csharp/src/Apache.Arrow/Arrays/PrimitiveArrayBuilder.cs
@@ -141,7 +141,8 @@ namespace Apache.Arrow
         {
             int len = ValueBuffer.Length;
             ValueBuffer.Append(span);
-            ValidityBuffer.AppendRange(Enumerable.Repeat(true, ValueBuffer.Length - len));
+            int additionalBitsCount = ValueBuffer.Length - len;
+            ValidityBuffer.Reserve(additionalBitsCount).AppendRange(Enumerable.Repeat(true, additionalBitsCount));
             return Instance;
         }
 
@@ -149,7 +150,8 @@ namespace Apache.Arrow
         {
             int len = ValueBuffer.Length;
             ValueBuffer.AppendRange(values);
-            ValidityBuffer.AppendRange(Enumerable.Repeat(true, ValueBuffer.Length - len));
+            var additionalBitsCount = ValueBuffer.Length - len;
+            ValidityBuffer.Reserve(additionalBitsCount).AppendRange(Enumerable.Repeat(true, additionalBitsCount));
             return Instance;
         }
 

--- a/csharp/src/Apache.Arrow/ArrowBuffer.BitmapBuilder.cs
+++ b/csharp/src/Apache.Arrow/ArrowBuffer.BitmapBuilder.cs
@@ -17,7 +17,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Apache.Arrow.Memory;
-using FlatBuffers;
 
 namespace Apache.Arrow
 {
@@ -70,6 +69,7 @@ namespace Apache.Arrow
                 Memory = new byte[BitUtility.ByteCount(capacity)];
                 Capacity = capacity;
             }
+
             /// <summary>
             /// Append a single bit.
             /// </summary>

--- a/csharp/src/Apache.Arrow/ArrowBuffer.BitmapBuilder.cs
+++ b/csharp/src/Apache.Arrow/ArrowBuffer.BitmapBuilder.cs
@@ -70,7 +70,6 @@ namespace Apache.Arrow
                 Memory = new byte[BitUtility.ByteCount(capacity)];
                 Capacity = capacity;
             }
-                        
             /// <summary>
             /// Append a single bit.
             /// </summary>

--- a/csharp/test/Apache.Arrow.Tests/ArrowBufferBitmapBuilderTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowBufferBitmapBuilderTests.cs
@@ -95,6 +95,105 @@ namespace Apache.Arrow.Tests
             }
         }
 
+        public class AppendSpan
+        {
+            [Theory]
+            [InlineData(new byte[] { 0b00000110 }, 4, 4, 2, 2)]    
+            [InlineData(new byte[] { 0b11111110 }, 4, 4, 3, 1)]
+            [InlineData(new byte[] { 0b11111110, 0b00000001 }, 9, 9, 8, 1)]
+            [InlineData(new byte[] { 0b11111001, 0b00000001 }, 9, 9, 7, 2)]
+            public void BitsAreAppendedToEmptyBuilder(byte[] bytesToAppend,
+                int validBits,
+                int expectedLength,
+                int expectedSetBitCount,
+                int expectedUnsetBitCount)
+            {
+                // Arrange
+                var builder = new ArrowBuffer.BitmapBuilder();
+
+                // Act
+                var actualReturnValue = builder.Append(new Span<byte>(bytesToAppend), validBits);
+
+                // Assert
+                Assert.Equal(builder, actualReturnValue);
+                Assert.Equal(expectedLength, builder.Length);
+                Assert.True(builder.Capacity >= expectedLength);
+                Assert.Equal(expectedSetBitCount, builder.SetBitCount);
+                Assert.Equal(expectedUnsetBitCount, builder.UnsetBitCount);
+
+            }
+
+            [Theory]
+            [InlineData(new byte[] { 6 }, 4, 12, 10, 2)]
+            [InlineData(new byte[] { 254 }, 4, 12, 11, 1)]
+            [InlineData(new byte[] { 254, 1 }, 9, 17, 16, 1)]
+            [InlineData(new byte[] { 249, 1 }, 9, 17, 15, 2)]
+            public void BitsAreAppendedToBuilderContainingByteAllignedData(byte[] bytesToAppend,
+                int validBits,
+                int expectedLength,
+                int expectedSetBitCount,
+                int expectedUnsetBitCount)
+            {
+                // Arrange
+                var builder = new ArrowBuffer.BitmapBuilder();
+                builder.AppendRange(Enumerable.Repeat(true, 8));
+
+                // Act
+                var actualReturnValue = builder.Append(new Span<byte>(bytesToAppend), validBits);
+
+                // Assert
+                Assert.Equal(builder, actualReturnValue);
+                Assert.Equal(expectedLength, builder.Length);
+                Assert.True(builder.Capacity >= expectedLength);
+                Assert.Equal(expectedSetBitCount, builder.SetBitCount);
+                Assert.Equal(expectedUnsetBitCount, builder.UnsetBitCount);
+            }
+
+            [Theory]
+            [InlineData(new byte[] { 6 }, 4, 13, 11, 2)]
+            [InlineData(new byte[] { 254 }, 4, 13, 12, 1)]
+            [InlineData(new byte[] { 254, 1 }, 9, 18, 17, 1)]
+            [InlineData(new byte[] { 249, 1 }, 9, 18, 16, 2)]
+            public void BitsAreAppendedToBuilderContainingNotAllignedData(byte[] bytesToAppend,
+                int validBits,
+                int expectedLength,
+                int expectedSetBitCount,
+                int expectedUnsetBitCount)
+            {
+                // Arrange
+                var builder = new ArrowBuffer.BitmapBuilder();
+                builder.AppendRange(Enumerable.Repeat(true, 9));
+
+                // Act
+                var actualReturnValue = builder.Append(new Span<byte>(bytesToAppend), validBits);
+
+                // Assert
+                Assert.Equal(builder, actualReturnValue);
+                Assert.Equal(expectedLength, builder.Length);
+                Assert.True(builder.Capacity >= expectedLength);
+                Assert.Equal(expectedSetBitCount, builder.SetBitCount);
+                Assert.Equal(expectedUnsetBitCount, builder.UnsetBitCount);
+            }
+
+            [Fact]
+            public void EmptySpanAppendsCorrectNumberOfBits()
+            {
+                // Arrange
+                var builder = new ArrowBuffer.BitmapBuilder();
+                builder.AppendRange(Enumerable.Repeat(true, 8));
+
+                // Act
+                var actualReturnValue = builder.Append(Span<byte>.Empty, 8);
+
+                // Assert
+                Assert.Equal(builder, actualReturnValue);
+                Assert.Equal(16, builder.Length);
+                Assert.True(builder.Capacity >= 16);
+                Assert.Equal(16, builder.SetBitCount);
+                Assert.Equal(0, builder.UnsetBitCount);
+            }
+        }
+
         public class AppendRange
         {
             [Theory]

--- a/csharp/test/Apache.Arrow.Tests/ArrowBufferBitmapBuilderTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowBufferBitmapBuilderTests.cs
@@ -192,6 +192,18 @@ namespace Apache.Arrow.Tests
                 Assert.Equal(16, builder.SetBitCount);
                 Assert.Equal(0, builder.UnsetBitCount);
             }
+
+            [Fact]
+            public void ThrowsWhenLengthIsTooBig()
+            {
+                // Arrange
+                var builder = new ArrowBuffer.BitmapBuilder();
+                builder.AppendRange(Enumerable.Repeat(true, 8));
+
+                // Act
+                Assert.Throws<ArgumentException>(() => builder.Append(new byte[] { 0b0010111 }, 9));
+                Assert.Throws<ArgumentException>(() => builder.Append(new byte[] { 0, 1, 3, 4 }, 33));
+            }
         }
 
         public class AppendRange


### PR DESCRIPTION
Extend ArrowBuffer.BitmapBuilder with Append method overloaded with ReadOnlySpan<byte> parameter. 

This allows to add validity bits to the builder more efficiently (especially for cases when initial validity bits are added to newly created empty builder).  More over it makes BitmapBuilder API more consistent (for example ArrowBuffer.Builder<T> does have such method).

Currently adding new bits to existing bitmap is implemented in ArrayDataConcatenator, Code adds bit by bit in a cycle converting each to a boolean value:

for (int i = 0; i < length; i++)
{
    builder.Append(span.IsEmpty || BitUtility.GetBit(span, i));
}
* Closes: #32605