### PR TITLE
ARROW-17340: [Go] Use `T.TempDir` to create temporary test directory

### DIFF
--- a/go/arrow/arrio/arrio_test.go
+++ b/go/arrow/arrio/arrio_test.go
@@ -64,11 +64,7 @@ func (k copyKind) check(t *testing.T, f *os.File, mem memory.Allocator, schema *
 }
 
 func TestCopy(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "go-arrow-copy-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	for _, tc := range []struct {
 		name     string

--- a/go/arrow/internal/arrjson/arrjson_test.go
+++ b/go/arrow/internal/arrjson/arrjson_test.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"io"
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/apache/arrow/go/v10/arrow/array"
@@ -46,11 +45,7 @@ func TestReadWrite(t *testing.T) {
 	wantJSONs["extension"] = makeExtensionsWantJSONs()
 	wantJSONs["dictionary"] = makeDictionaryWantJSONs()
 
-	tempDir, err := ioutil.TempDir("", "go-arrow-read-write-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	for name, recs := range arrdata.Records {
 		t.Run(name, func(t *testing.T) {

--- a/go/arrow/ipc/cmd/arrow-cat/main_test.go
+++ b/go/arrow/ipc/cmd/arrow-cat/main_test.go
@@ -31,11 +31,7 @@ import (
 )
 
 func TestCatStream(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "go-arrow-cat-stream-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	for _, tc := range []struct {
 		name string
@@ -229,11 +225,7 @@ record 3...
 }
 
 func TestCatFile(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "go-arrow-cat-file-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	for _, tc := range []struct {
 		name   string

--- a/go/arrow/ipc/cmd/arrow-file-to-stream/main_test.go
+++ b/go/arrow/ipc/cmd/arrow-file-to-stream/main_test.go
@@ -19,7 +19,6 @@ package main
 import (
 	"io"
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/apache/arrow/go/v10/arrow/internal/arrdata"
@@ -27,11 +26,7 @@ import (
 )
 
 func TestFileToStream(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "go-arrow-file-to-stream-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	for name, recs := range arrdata.Records {
 		t.Run(name, func(t *testing.T) {

--- a/go/arrow/ipc/cmd/arrow-json-integration-test/main_test.go
+++ b/go/arrow/ipc/cmd/arrow-json-integration-test/main_test.go
@@ -26,11 +26,7 @@ import (
 )
 
 func TestIntegration(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "go-arrow-integration-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	const verbose = true
 	for name, recs := range arrdata.Records {

--- a/go/arrow/ipc/cmd/arrow-ls/main_test.go
+++ b/go/arrow/ipc/cmd/arrow-ls/main_test.go
@@ -31,11 +31,7 @@ import (
 )
 
 func TestLsStream(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "go-arrow-ls-stream-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	for _, tc := range []struct {
 		name string
@@ -174,11 +170,7 @@ records: 3
 }
 
 func TestLsFile(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "go-arrow-ls-file-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	for _, tc := range []struct {
 		stream bool

--- a/go/arrow/ipc/cmd/arrow-stream-to-file/main_test.go
+++ b/go/arrow/ipc/cmd/arrow-stream-to-file/main_test.go
@@ -19,7 +19,6 @@ package main
 import (
 	"io"
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/apache/arrow/go/v10/arrow/internal/arrdata"
@@ -27,11 +26,7 @@ import (
 )
 
 func TestStreamToFile(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "go-arrow-stream-to-file-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	for name, recs := range arrdata.Records {
 		t.Run(name, func(t *testing.T) {

--- a/go/arrow/ipc/cmd/arrow-stream-to-file/main_test.go
+++ b/go/arrow/ipc/cmd/arrow-stream-to-file/main_test.go
@@ -55,6 +55,7 @@ func TestStreamToFile(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			defer o.Close()
 
 			err = processStream(o, f)
 			if err != nil {

--- a/go/arrow/ipc/file_test.go
+++ b/go/arrow/ipc/file_test.go
@@ -19,7 +19,6 @@ package ipc_test
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/apache/arrow/go/v10/arrow/internal/arrdata"
@@ -28,11 +27,7 @@ import (
 )
 
 func TestFile(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "go-arrow-file-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	for name, recs := range arrdata.Records {
 		t.Run(name, func(t *testing.T) {
@@ -53,11 +48,7 @@ func TestFile(t *testing.T) {
 }
 
 func TestFileCompressed(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "go-arrow-file-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	compressTypes := []flatbuf.CompressionType{
 		flatbuf.CompressionTypeLZ4_FRAME, flatbuf.CompressionTypeZSTD,

--- a/go/arrow/ipc/stream_test.go
+++ b/go/arrow/ipc/stream_test.go
@@ -19,7 +19,6 @@ package ipc_test
 import (
 	"io"
 	"io/ioutil"
-	"os"
 	"strconv"
 	"testing"
 
@@ -29,11 +28,7 @@ import (
 )
 
 func TestStream(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "go-arrow-stream-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	for name, recs := range arrdata.Records {
 		t.Run(name, func(t *testing.T) {
@@ -64,11 +59,7 @@ func TestStream(t *testing.T) {
 }
 
 func TestStreamCompressed(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "go-arrow-stream-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	compressTypes := []flatbuf.CompressionType{
 		flatbuf.CompressionTypeLZ4_FRAME, flatbuf.CompressionTypeZSTD,


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	if err != nil {
		t.Fatal(err)
	}
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```