### PR TITLE
ARROW-16000: [C++][Python] Dataset: Alternative implementation for adding transcoding function option to CSV scanner

### DIFF
--- a/cpp/src/arrow/dataset/file_csv.cc
+++ b/cpp/src/arrow/dataset/file_csv.cc
@@ -187,7 +187,7 @@ static inline Future<std::shared_ptr<csv::StreamingReader>> OpenReaderAsync(
       auto fragment_scan_options,
       GetFragmentScanOptions<CsvFragmentScanOptions>(
           kCsvTypeName, scan_options.get(), format.default_fragment_scan_options));
-  auto reader_options = fragment_scan_options->read_options;
+  ARROW_ASSIGN_OR_RAISE(auto reader_options, GetReadOptions(format, scan_options));
   ARROW_ASSIGN_OR_RAISE(auto input, source.OpenCompressed());
   if (fragment_scan_options->stream_transform_func) {
     ARROW_ASSIGN_OR_RAISE(input, fragment_scan_options->stream_transform_func(input));
@@ -299,7 +299,7 @@ Future<util::optional<int64_t>> CsvFileFormat::CountRows(
       auto fragment_scan_options,
       GetFragmentScanOptions<CsvFragmentScanOptions>(
           kCsvTypeName, options.get(), self->default_fragment_scan_options));
-  auto read_options = fragment_scan_options->read_options;
+  ARROW_ASSIGN_OR_RAISE(auto read_options, GetReadOptions(*self, options));
   ARROW_ASSIGN_OR_RAISE(auto input, file->source().OpenCompressed());
   if (fragment_scan_options->stream_transform_func) {
     ARROW_ASSIGN_OR_RAISE(input, fragment_scan_options->stream_transform_func(input));

--- a/cpp/src/arrow/dataset/file_csv.h
+++ b/cpp/src/arrow/dataset/file_csv.h
@@ -73,6 +73,9 @@ class ARROW_DS_EXPORT CsvFileFormat : public FileFormat {
 struct ARROW_DS_EXPORT CsvFragmentScanOptions : public FragmentScanOptions {
   std::string type_name() const override { return kCsvTypeName; }
 
+  using StreamWrapFunc = std::function<Result<std::shared_ptr<io::InputStream>>(
+      std::shared_ptr<io::InputStream>)>;
+
   /// CSV conversion options
   csv::ConvertOptions convert_options = csv::ConvertOptions::Defaults();
 
@@ -80,6 +83,13 @@ struct ARROW_DS_EXPORT CsvFragmentScanOptions : public FragmentScanOptions {
   ///
   /// Note that use_threads is always ignored.
   csv::ReadOptions read_options = csv::ReadOptions::Defaults();
+
+  /// Optional stream wrapping function
+  ///
+  /// If defined, all open dataset file fragments will be passed
+  /// through this function.  One possible use case is to transparently
+  /// transcode all input files from a given character set to utf8.
+  StreamWrapFunc stream_transform_func{};
 };
 
 class ARROW_DS_EXPORT CsvFileWriteOptions : public FileWriteOptions {

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -832,8 +832,13 @@ cdef class FileFormat(_Weakrefable):
 
     @property
     def default_fragment_scan_options(self):
-        return FragmentScanOptions.wrap(
+        dfso = FragmentScanOptions.wrap(
             self.wrapped.get().default_fragment_scan_options)
+        # CsvFileFormat stores a Python-specific encoding field that needs
+        # to be restored because it does not exist in the C struct
+        if self.encoding is not None:
+            dfso.encoding = self.encoding
+        return dfso
 
     @default_fragment_scan_options.setter
     def default_fragment_scan_options(self, FragmentScanOptions options):
@@ -1172,6 +1177,10 @@ cdef class CsvFileFormat(FileFormat):
     """
     cdef:
         CCsvFileFormat* csv_format
+        # The encoding field in ReadOptions does not exist
+        # in the C struct. We need to store it here and override it when
+        # reading read_options or default_fragment_scan_options
+        public object encoding
 
     # Avoid mistakingly creating attributes
     __slots__ = ()
@@ -1199,9 +1208,12 @@ cdef class CsvFileFormat(FileFormat):
             raise TypeError('`default_fragment_scan_options` must be either '
                             'a dictionary or an instance of '
                             'CsvFragmentScanOptions')
-        else :
+        else:
             # default_fragment_scan_options is needed to add a transcoder
             self.default_fragment_scan_options = CsvFragmentScanOptions()
+        if read_options is not None:
+            self.default_fragment_scan_options.encoding = read_options.encoding
+            self.encoding = read_options.encoding
 
     cdef void init(self, const shared_ptr[CFileFormat]& sp):
         FileFormat.init(self, sp)
@@ -1224,6 +1236,8 @@ cdef class CsvFileFormat(FileFormat):
     cdef _set_default_fragment_scan_options(self, FragmentScanOptions options):
         if options.type_name == 'csv':
             self.csv_format.default_fragment_scan_options = options.wrapped
+            self.default_fragment_scan_options.encoding = options.encoding
+            self.encoding = options.encoding
         else:
             super()._set_default_fragment_scan_options(options)
 
@@ -1255,17 +1269,21 @@ cdef class CsvFragmentScanOptions(FragmentScanOptions):
 
     cdef:
         CCsvFragmentScanOptions* csv_options
-        object encoding
+        # The encoding field in ReadOptions does not exist
+        # in the C struct. We need to store it here and override it when
+        # reading read_options
+        public object encoding
 
     # Avoid mistakingly creating attributes
     __slots__ = ()
 
     def __init__(self, ConvertOptions convert_options=None,
-                 ReadOptions read_options=None):
+                 ReadOptions read_options=None, encoding='utf8'):
         self.init(shared_ptr[CFragmentScanOptions](
             new CCsvFragmentScanOptions()))
         if convert_options is not None:
             self.convert_options = convert_options
+        self.encoding = encoding
         if read_options is not None:
             self.read_options = read_options
             self.encoding = read_options.encoding
@@ -1286,29 +1304,29 @@ cdef class CsvFragmentScanOptions(FragmentScanOptions):
     def read_options(self):
         read_options = ReadOptions.wrap(self.csv_options.read_options)
         if self.encoding is not None:
-            # The encoding field in ReadOptions does not exist
-            # in the C struct. Re-set it here.
             read_options.encoding = self.encoding
         return read_options
 
     @read_options.setter
     def read_options(self, ReadOptions read_options not None):
         self.csv_options.read_options = deref(read_options.options)
+        self.encoding = read_options.encoding
 
     def add_transcoder(self, src_encoding, dest_encoding):
         if src_encoding != dest_encoding:
             self.csv_options.stream_transform_func = deref(
-                    make_streamwrap_func(src_encoding, dest_encoding))
+                make_streamwrap_func(src_encoding, dest_encoding))
 
     def equals(self, CsvFragmentScanOptions other):
         return (
             other and
             self.convert_options.equals(other.convert_options) and
-            self.read_options.equals(other.read_options))
+            self.read_options.equals(other.read_options) and
+            self.encoding == other.encoding)
 
     def __reduce__(self):
         return CsvFragmentScanOptions, (self.convert_options,
-                                        self.read_options)
+                                        self.read_options, self.encoding)
 
 
 cdef class CsvFileWriteOptions(FileWriteOptions):

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1172,6 +1172,7 @@ cdef class CsvFileFormat(FileFormat):
     """
     cdef:
         CCsvFileFormat* csv_format
+        public object encoding
 
     # Avoid mistakingly creating attributes
     __slots__ = ()
@@ -1179,7 +1180,7 @@ cdef class CsvFileFormat(FileFormat):
     def __init__(self, ParseOptions parse_options=None,
                  default_fragment_scan_options=None,
                  ConvertOptions convert_options=None,
-                 ReadOptions read_options=None):
+                 ReadOptions read_options=None, encoding=None):
         self.init(shared_ptr[CFileFormat](new CCsvFileFormat()))
         if parse_options is not None:
             self.parse_options = parse_options
@@ -1199,6 +1200,8 @@ cdef class CsvFileFormat(FileFormat):
             raise TypeError('`default_fragment_scan_options` must be either '
                             'a dictionary or an instance of '
                             'CsvFragmentScanOptions')
+        # Python-specific option
+        self.encoding = encoding
 
     cdef void init(self, const shared_ptr[CFileFormat]& sp):
         FileFormat.init(self, sp)
@@ -1228,7 +1231,8 @@ cdef class CsvFileFormat(FileFormat):
         return (
             self.parse_options.equals(other.parse_options) and
             self.default_fragment_scan_options ==
-            other.default_fragment_scan_options)
+            other.default_fragment_scan_options and
+            self.encoding == other.encoding)
 
     def __reduce__(self):
         return CsvFileFormat, (self.parse_options,

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1178,9 +1178,9 @@ cdef class CsvFileFormat(FileFormat):
     """
     cdef:
         CCsvFileFormat* csv_format
-        # The encoding field in ReadOptions does not exist
-        # in the C++ struct. We need to store it here and override it when
-        # reading read_options or default_fragment_scan_options
+        # The encoding field in ReadOptions does not exist in the C++ struct.
+        # We need to store it here and override it when reading 
+        # default_fragment_scan_options.read_options
         public ReadOptions read_options_py
 
     # Avoid mistakingly creating attributes
@@ -1209,9 +1209,6 @@ cdef class CsvFileFormat(FileFormat):
             raise TypeError('`default_fragment_scan_options` must be either '
                             'a dictionary or an instance of '
                             'CsvFragmentScanOptions')
-        else:
-            # default_fragment_scan_options is needed to add a transcoder
-            self.default_fragment_scan_options = CsvFragmentScanOptions()
         if read_options is not None:
             self.read_options_py = read_options
 
@@ -1269,9 +1266,8 @@ cdef class CsvFragmentScanOptions(FragmentScanOptions):
 
     cdef:
         CCsvFragmentScanOptions* csv_options
-        # The encoding field in ReadOptions does not exist
-        # in the C++ struct. We need to store it here and override it when
-        # reading read_options
+        # The encoding field in ReadOptions does not exist in the C++ struct. 
+        # We need to store it here and override it when reading read_options
         ReadOptions read_options_py
 
     # Avoid mistakingly creating attributes

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1169,6 +1169,9 @@ cdef class CsvFileFormat(FileFormat):
         General read options.
     default_fragment_scan_options : CsvFragmentScanOptions
         Default options for fragments scan.
+    encoding : str, optional (default 'utf8')
+        The character encoding of the CSV data.  Columns that cannot
+        decode using this encoding can still be read as Binary.
     """
     cdef:
         CCsvFileFormat* csv_format

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1306,9 +1306,9 @@ cdef class CsvFragmentScanOptions(FragmentScanOptions):
     def read_options(self, ReadOptions read_options not None):
         self.csv_options.read_options = deref(read_options.options)
         self._read_options_py = read_options
-        if read_options.encoding != 'utf8':
+        if codecs.lookup(read_options.encoding).name != 'utf-8':
             self.csv_options.stream_transform_func = deref(
-                make_streamwrap_func(read_options.encoding, 'utf8'))
+                make_streamwrap_func(read_options.encoding, 'utf-8'))
 
     def equals(self, CsvFragmentScanOptions other):
         return (

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1180,7 +1180,8 @@ cdef class CsvFileFormat(FileFormat):
     def __init__(self, ParseOptions parse_options=None,
                  default_fragment_scan_options=None,
                  ConvertOptions convert_options=None,
-                 ReadOptions read_options=None, encoding='utf8'):
+                 ReadOptions read_options=None,
+                 encoding='utf8'):
         self.init(shared_ptr[CFileFormat](new CCsvFileFormat()))
         if parse_options is not None:
             self.parse_options = parse_options
@@ -1200,6 +1201,9 @@ cdef class CsvFileFormat(FileFormat):
             raise TypeError('`default_fragment_scan_options` must be either '
                             'a dictionary or an instance of '
                             'CsvFragmentScanOptions')
+        else :
+            # default_fragment_scan_options is needed to add a transcoder
+            self.default_fragment_scan_options = CsvFragmentScanOptions()
         # Python-specific option
         self.encoding = encoding
 

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1179,7 +1179,7 @@ cdef class CsvFileFormat(FileFormat):
     cdef:
         CCsvFileFormat* csv_format
         # The encoding field in ReadOptions does not exist in the C++ struct.
-        # We need to store it here and override it when reading 
+        # We need to store it here and override it when reading
         # default_fragment_scan_options.read_options
         public ReadOptions read_options_py
 
@@ -1266,7 +1266,7 @@ cdef class CsvFragmentScanOptions(FragmentScanOptions):
 
     cdef:
         CCsvFragmentScanOptions* csv_options
-        # The encoding field in ReadOptions does not exist in the C++ struct. 
+        # The encoding field in ReadOptions does not exist in the C++ struct.
         # We need to store it here and override it when reading read_options
         ReadOptions read_options_py
 

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1321,8 +1321,7 @@ cdef class CsvFragmentScanOptions(FragmentScanOptions):
         return (
             other and
             self.convert_options.equals(other.convert_options) and
-            self.read_options.equals(other.read_options) and
-            self.encoding == other.encoding)
+            self.read_options.equals(other.read_options))
 
     def __reduce__(self):
         return CsvFragmentScanOptions, (self.convert_options,

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1180,7 +1180,7 @@ cdef class CsvFileFormat(FileFormat):
     def __init__(self, ParseOptions parse_options=None,
                  default_fragment_scan_options=None,
                  ConvertOptions convert_options=None,
-                 ReadOptions read_options=None, encoding=None):
+                 ReadOptions read_options=None, encoding='utf8'):
         self.init(shared_ptr[CFileFormat](new CCsvFileFormat()))
         if parse_options is not None:
             self.parse_options = parse_options

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1310,7 +1310,7 @@ cdef class CsvFragmentScanOptions(FragmentScanOptions):
     def read_options(self, ReadOptions read_options not None):
         self.csv_options.read_options = deref(read_options.options)
         self.read_options_py = read_options
-        if (read_options.encoding != 'utf8'):
+        if read_options.encoding != 'utf8':
             self.csv_options.stream_transform_func = deref(
                 make_streamwrap_func(read_options.encoding, 'utf8'))
 

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1238,40 +1238,6 @@ cdef class CsvFileFormat(FileFormat):
         return f"<CsvFileFormat parse_options={self.parse_options}>"
 
 
-# From io.pxi
-def py_buffer(object obj):
-    """
-    Construct an Arrow buffer from a Python bytes-like or buffer-like object
-
-    Parameters
-    ----------
-    obj : object
-        the object from which the buffer should be constructed.
-    """
-    cdef shared_ptr[CBuffer] buf
-    buf = GetResultValue(PyBuffer.FromPyObject(obj))
-    return pyarrow_wrap_buffer(buf)
-
-
-# From io.pxi
-cdef void _cb_transform(transform_func, const shared_ptr[CBuffer]& src,
-                        shared_ptr[CBuffer]* dest) except *:
-    py_dest = transform_func(pyarrow_wrap_buffer(src))
-    dest[0] = pyarrow_unwrap_buffer(py_buffer(py_dest))
-
-
-# from io.pxi
-class Transcoder:
-
-    def __init__(self, decoder, encoder):
-        self._decoder = decoder
-        self._encoder = encoder
-
-    def __call__(self, buf):
-        final = len(buf) == 0
-        return self._encoder.encode(self._decoder.decode(buf, final), final)
-
-
 cdef class CsvFragmentScanOptions(FragmentScanOptions):
     """
     Scan-specific options for CSV fragments.
@@ -1319,24 +1285,12 @@ cdef class CsvFragmentScanOptions(FragmentScanOptions):
     def read_options(self, ReadOptions read_options not None):
         self.csv_options.read_options = deref(read_options.options)
 
-    cdef transform_encoding(self, src_encoding):
-        cdef:
-            CTransformInputStreamVTable vtable
-
-        src_codec = codecs.lookup(src_encoding)
-        dest_codec = codecs.lookup("utf8")
-        if src_codec.name == dest_codec.name:
-            # Avoid losing performance on no-op transcoding
-            # (encoding errors won't be detected)
+    def add_transcoder(self, src_encoding, dest_encoding):
+        if src_encoding == dest_encoding:
             return
 
-        vtable.transform = _cb_transform
-        self.csv_options.stream_transform_func = makeStreamTransformFunc(move(vtable),
-                    Transcoder(src_codec.incrementaldecoder(),
-                    dest_codec.incrementalencoder()))
-
-    def stream_transform_func(self, src_encoding):
-        self.transform_encoding(src_encoding)
+        self.csv_options.stream_transform_func = deref(
+            make_streamwrap_func(src_encoding, dest_encoding))
 
     def equals(self, CsvFragmentScanOptions other):
         return (

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -433,7 +433,8 @@ def _filesystem_dataset(source, schema=None, filesystem=None,
     FileSystemDataset
     """
     format = _ensure_format(format or 'parquet')
-    format.default_fragment_scan_options.add_transcoder(encoding, "utf8")
+    if format.default_fragment_scan_options.type_name == 'csv':
+        format.default_fragment_scan_options.add_transcoder(encoding, "utf8")
 
     partitioning = _ensure_partitioning(partitioning)
 

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -433,11 +433,6 @@ def _filesystem_dataset(source, schema=None, filesystem=None,
     FileSystemDataset
     """
     format = _ensure_format(format or 'parquet')
-    if isinstance(format, CsvFileFormat):
-        format.default_fragment_scan_options.add_transcoder(
-            format.default_fragment_scan_options.read_options.encoding,
-            "utf8")
-
     partitioning = _ensure_partitioning(partitioning)
 
     if isinstance(source, (list, tuple)):

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -422,7 +422,7 @@ def _ensure_single_source(path, filesystem=None):
 def _filesystem_dataset(source, schema=None, filesystem=None,
                         partitioning=None, format=None,
                         partition_base_dir=None, exclude_invalid_files=None,
-                        selector_ignore_prefixes=None, encoding='utf8'):
+                        selector_ignore_prefixes=None):
     """
     Create a FileSystemDataset which can be used to build a Dataset.
 
@@ -434,7 +434,8 @@ def _filesystem_dataset(source, schema=None, filesystem=None,
     """
     format = _ensure_format(format or 'parquet')
     if format.default_fragment_scan_options.type_name == 'csv':
-        format.default_fragment_scan_options.add_transcoder(encoding, "utf8")
+        format.default_fragment_scan_options.add_transcoder(format.encoding, 
+                                                            "utf8")
 
     partitioning = _ensure_partitioning(partitioning)
 
@@ -542,7 +543,7 @@ def parquet_dataset(metadata_path, schema=None, filesystem=None, format=None,
 
 def dataset(source, schema=None, format=None, filesystem=None,
             partitioning=None, partition_base_dir=None,
-            exclude_invalid_files=None, ignore_prefixes=None, encoding='utf8'):
+            exclude_invalid_files=None, ignore_prefixes=None):
     """
     Open a dataset.
 

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -435,8 +435,8 @@ def _filesystem_dataset(source, schema=None, filesystem=None,
     format = _ensure_format(format or 'parquet')
     if isinstance(format, CsvFileFormat):
         format.default_fragment_scan_options.add_transcoder(
-                format.default_fragment_scan_options.read_options.encoding,
-                                                            "utf8")
+            format.default_fragment_scan_options.read_options.encoding,
+            "utf8")
 
     partitioning = _ensure_partitioning(partitioning)
 

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -422,7 +422,7 @@ def _ensure_single_source(path, filesystem=None):
 def _filesystem_dataset(source, schema=None, filesystem=None,
                         partitioning=None, format=None,
                         partition_base_dir=None, exclude_invalid_files=None,
-                        selector_ignore_prefixes=None):
+                        selector_ignore_prefixes=None, encoding='utf8'):
     """
     Create a FileSystemDataset which can be used to build a Dataset.
 
@@ -433,6 +433,9 @@ def _filesystem_dataset(source, schema=None, filesystem=None,
     FileSystemDataset
     """
     format = _ensure_format(format or 'parquet')
+    if encoding != 'utf8':
+        format.default_fragment_scan_options.stream_transform_func(encoding)
+
     partitioning = _ensure_partitioning(partitioning)
 
     if isinstance(source, (list, tuple)):
@@ -539,7 +542,7 @@ def parquet_dataset(metadata_path, schema=None, filesystem=None, format=None,
 
 def dataset(source, schema=None, format=None, filesystem=None,
             partitioning=None, partition_base_dir=None,
-            exclude_invalid_files=None, ignore_prefixes=None):
+            exclude_invalid_files=None, ignore_prefixes=None, encoding='utf8'):
     """
     Open a dataset.
 
@@ -742,7 +745,8 @@ RecordBatch or Table, iterable of RecordBatch, RecordBatchReader, or URI
         format=format,
         partition_base_dir=partition_base_dir,
         exclude_invalid_files=exclude_invalid_files,
-        selector_ignore_prefixes=ignore_prefixes
+        selector_ignore_prefixes=ignore_prefixes,
+        encoding=encoding
     )
 
     if _is_path_like(source):

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -746,8 +746,7 @@ RecordBatch or Table, iterable of RecordBatch, RecordBatchReader, or URI
         format=format,
         partition_base_dir=partition_base_dir,
         exclude_invalid_files=exclude_invalid_files,
-        selector_ignore_prefixes=ignore_prefixes,
-        encoding=encoding
+        selector_ignore_prefixes=ignore_prefixes
     )
 
     if _is_path_like(source):

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -433,8 +433,7 @@ def _filesystem_dataset(source, schema=None, filesystem=None,
     FileSystemDataset
     """
     format = _ensure_format(format or 'parquet')
-    if encoding != 'utf8':
-        format.default_fragment_scan_options.stream_transform_func(encoding)
+    format.default_fragment_scan_options.add_transcoder(encoding, "utf8")
 
     partitioning = _ensure_partitioning(partitioning)
 

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -433,7 +433,7 @@ def _filesystem_dataset(source, schema=None, filesystem=None,
     FileSystemDataset
     """
     format = _ensure_format(format or 'parquet')
-    if format.default_fragment_scan_options.type_name == 'csv':
+    if isinstance(format, CsvFileFormat):
         format.default_fragment_scan_options.add_transcoder(format.encoding, 
                                                             "utf8")
 

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -434,7 +434,8 @@ def _filesystem_dataset(source, schema=None, filesystem=None,
     """
     format = _ensure_format(format or 'parquet')
     if isinstance(format, CsvFileFormat):
-        format.default_fragment_scan_options.add_transcoder(format.encoding, 
+        format.default_fragment_scan_options.add_transcoder(
+                format.default_fragment_scan_options.read_options.encoding,
                                                             "utf8")
 
     partitioning = _ensure_partitioning(partitioning)

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1382,8 +1382,8 @@ cdef extern from "arrow/io/api.h" namespace "arrow::io" nogil:
         shared_ptr[CInputStream] wrapped, CTransformInputStreamVTable vtable,
         object method_arg)
 
-    shared_ptr[function[StreamWrapFunc]] makeStreamTransformFunc \
-        "arrow::py::makeStreamTransformFunc"(
+    shared_ptr[function[StreamWrapFunc]] MakeStreamTransformFunc \
+        "arrow::py::MakeStreamTransformFunc"(
         CTransformInputStreamVTable vtable,
         object method_arg)
 

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1379,6 +1379,14 @@ cdef extern from "arrow/io/api.h" namespace "arrow::io" nogil:
         shared_ptr[CInputStream] wrapped, CTransformInputStreamVTable vtable,
         object method_arg)
 
+    ctypedef CResult[shared_ptr[CInputStream]] StreamWrapFunc(
+        shared_ptr[CInputStream])
+
+    function[StreamWrapFunc] makeStreamTransformFunc \
+        "arrow::py::makeStreamTransformFunc"(
+        CTransformInputStreamVTable vtable,
+        object method_arg)
+
     # ----------------------------------------------------------------------
     # HDFS
 

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1212,6 +1212,9 @@ cdef extern from "arrow/builder.h" namespace "arrow" nogil:
 ctypedef void CallbackTransform(object, const shared_ptr[CBuffer]& src,
                                 shared_ptr[CBuffer]* dest)
 
+ctypedef CResult[shared_ptr[CInputStream]] StreamWrapFunc(
+    shared_ptr[CInputStream])
+
 
 cdef extern from "arrow/util/cancel.h" namespace "arrow" nogil:
     cdef cppclass CStopToken "arrow::StopToken":
@@ -1379,10 +1382,7 @@ cdef extern from "arrow/io/api.h" namespace "arrow::io" nogil:
         shared_ptr[CInputStream] wrapped, CTransformInputStreamVTable vtable,
         object method_arg)
 
-    ctypedef CResult[shared_ptr[CInputStream]] StreamWrapFunc(
-        shared_ptr[CInputStream])
-
-    function[StreamWrapFunc] makeStreamTransformFunc \
+    shared_ptr[function[StreamWrapFunc]] makeStreamTransformFunc \
         "arrow::py::makeStreamTransformFunc"(
         CTransformInputStreamVTable vtable,
         object method_arg)

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -277,6 +277,7 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
             "arrow::dataset::CsvFragmentScanOptions"(CFragmentScanOptions):
         CCSVConvertOptions convert_options
         CCSVReadOptions read_options
+        function[StreamWrapFunc] stream_transform_func
 
     cdef cppclass CPartitioning "arrow::dataset::Partitioning":
         c_string type_name() const

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1605,7 +1605,7 @@ cdef shared_ptr[function[StreamWrapFunc]] make_streamwrap_func(
     vtable.transform = _cb_transform
     src_codec = codecs.lookup(src_encoding)
     dest_codec = codecs.lookup(dest_encoding)
-    return makeStreamTransformFunc(move(vtable),
+    return MakeStreamTransformFunc(move(vtable),
                                    Transcoder(src_codec.incrementaldecoder(),
                                    dest_codec.incrementalencoder()))
 

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1589,12 +1589,12 @@ cdef shared_ptr[function[StreamWrapFunc]] make_streamwrap_func(
     Create a function that will add a transcoding transformation to a stream.
     Data from that stream will be decoded according to ``src_encoding`` and
     then re-encoded according to ``dest_encoding``.
-    The created function can be used to wrap streams once they are created.
+    The created function can be used to wrap streams.
 
     Parameters
     ----------
     src_encoding : str
-        The codec to use when reading data data.
+        The codec to use when reading data.
     dest_encoding : str
         The codec to use for emitted data.
     """
@@ -1621,7 +1621,7 @@ def transcoding_input_stream(stream, src_encoding, dest_encoding):
     stream : NativeFile
         The stream to which the transformation should be applied.
     src_encoding : str
-        The codec to use when reading data data.
+        The codec to use when reading data.
     dest_encoding : str
         The codec to use for emitted data.
     """

--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -536,6 +536,9 @@ cdef shared_ptr[CInputStream] native_transcoding_input_stream(
     shared_ptr[CInputStream] stream, src_encoding,
     dest_encoding) except *
 
+cdef shared_ptr[function[StreamWrapFunc]] make_streamwrap_func(
+        src_encoding, dest_encoding) except *
+
 # Default is allow_none=False
 cpdef DataType ensure_type(object type, bint allow_none=*)
 

--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -537,7 +537,7 @@ cdef shared_ptr[CInputStream] native_transcoding_input_stream(
     dest_encoding) except *
 
 cdef shared_ptr[function[StreamWrapFunc]] make_streamwrap_func(
-        src_encoding, dest_encoding) except *
+    src_encoding, dest_encoding) except *
 
 # Default is allow_none=False
 cpdef DataType ensure_type(object type, bint allow_none=*)

--- a/python/pyarrow/src/io.cc
+++ b/python/pyarrow/src/io.cc
@@ -370,14 +370,14 @@ std::shared_ptr<::arrow::io::InputStream> MakeTransformInputStream(
   return std::make_shared<TransformInputStream>(std::move(wrapped), std::move(transform));
 }
 
-std::function<Result<std::shared_ptr<io::InputStream>>(std::shared_ptr<io::InputStream>)>
-makeStreamTransformFunc(TransformInputStreamVTable vtable, PyObject* handler) {
-  std::function<Result<std::shared_ptr<io::InputStream>>(
-      std::shared_ptr<io::InputStream>)>
-      func = [=](std::shared_ptr<::arrow::io::InputStream> wrapped) {
-        return MakeTransformInputStream(wrapped, vtable, handler);
-      };
-  return func;
+std::shared_ptr<StreamWrapFunc> makeStreamTransformFunc(TransformInputStreamVTable vtable,
+                                                        PyObject* handler) {
+  TransformInputStream::TransformFunc transform(
+      TransformFunctionWrapper{std::move(vtable.transform), handler});
+  StreamWrapFunc func = [transform](std::shared_ptr<::arrow::io::InputStream> wrapped) {
+    return std::make_shared<TransformInputStream>(wrapped, transform);
+  };
+  return std::make_shared<StreamWrapFunc>(func);
 }
 
 }  // namespace py

--- a/python/pyarrow/src/io.cc
+++ b/python/pyarrow/src/io.cc
@@ -370,7 +370,7 @@ std::shared_ptr<::arrow::io::InputStream> MakeTransformInputStream(
   return std::make_shared<TransformInputStream>(std::move(wrapped), std::move(transform));
 }
 
-std::shared_ptr<StreamWrapFunc> makeStreamTransformFunc(TransformInputStreamVTable vtable,
+std::shared_ptr<StreamWrapFunc> MakeStreamTransformFunc(TransformInputStreamVTable vtable,
                                                         PyObject* handler) {
   TransformInputStream::TransformFunc transform(
       TransformFunctionWrapper{std::move(vtable.transform), handler});

--- a/python/pyarrow/src/io.cc
+++ b/python/pyarrow/src/io.cc
@@ -370,5 +370,15 @@ std::shared_ptr<::arrow::io::InputStream> MakeTransformInputStream(
   return std::make_shared<TransformInputStream>(std::move(wrapped), std::move(transform));
 }
 
+std::function<Result<std::shared_ptr<io::InputStream>>(std::shared_ptr<io::InputStream>)>
+makeStreamTransformFunc(TransformInputStreamVTable vtable, PyObject* handler) {
+  std::function<Result<std::shared_ptr<io::InputStream>>(
+      std::shared_ptr<io::InputStream>)>
+      func = [=](std::shared_ptr<::arrow::io::InputStream> wrapped) {
+        return MakeTransformInputStream(wrapped, vtable, handler);
+      };
+  return func;
+}
+
 }  // namespace py
 }  // namespace arrow

--- a/python/pyarrow/src/io.h
+++ b/python/pyarrow/src/io.h
@@ -112,5 +112,8 @@ std::shared_ptr<::arrow::io::InputStream> MakeTransformInputStream(
     std::shared_ptr<::arrow::io::InputStream> wrapped, TransformInputStreamVTable vtable,
     PyObject* arg);
 
+std::function<Result<std::shared_ptr<io::InputStream>>(std::shared_ptr<io::InputStream>)>
+makeStreamTransformFunc(TransformInputStreamVTable vtable, PyObject* handler);
+
 }  // namespace py
 }  // namespace arrow

--- a/python/pyarrow/src/io.h
+++ b/python/pyarrow/src/io.h
@@ -112,8 +112,9 @@ std::shared_ptr<::arrow::io::InputStream> MakeTransformInputStream(
     std::shared_ptr<::arrow::io::InputStream> wrapped, TransformInputStreamVTable vtable,
     PyObject* arg);
 
-std::function<Result<std::shared_ptr<io::InputStream>>(std::shared_ptr<io::InputStream>)>
-makeStreamTransformFunc(TransformInputStreamVTable vtable, PyObject* handler);
-
+using StreamWrapFunc = std::function<Result<std::shared_ptr<io::InputStream>>(
+    std::shared_ptr<io::InputStream>)>;
+std::shared_ptr<StreamWrapFunc> makeStreamTransformFunc(TransformInputStreamVTable vtable,
+                                                        PyObject* handler);
 }  // namespace py
 }  // namespace arrow

--- a/python/pyarrow/src/io.h
+++ b/python/pyarrow/src/io.h
@@ -114,6 +114,7 @@ std::shared_ptr<::arrow::io::InputStream> MakeTransformInputStream(
 
 using StreamWrapFunc = std::function<Result<std::shared_ptr<io::InputStream>>(
     std::shared_ptr<io::InputStream>)>;
+ARROW_PYTHON_EXPORT
 std::shared_ptr<StreamWrapFunc> MakeStreamTransformFunc(TransformInputStreamVTable vtable,
                                                         PyObject* handler);
 }  // namespace py

--- a/python/pyarrow/src/io.h
+++ b/python/pyarrow/src/io.h
@@ -114,7 +114,7 @@ std::shared_ptr<::arrow::io::InputStream> MakeTransformInputStream(
 
 using StreamWrapFunc = std::function<Result<std::shared_ptr<io::InputStream>>(
     std::shared_ptr<io::InputStream>)>;
-std::shared_ptr<StreamWrapFunc> makeStreamTransformFunc(TransformInputStreamVTable vtable,
+std::shared_ptr<StreamWrapFunc> MakeStreamTransformFunc(TransformInputStreamVTable vtable,
                                                         PyObject* handler);
 }  // namespace py
 }  // namespace arrow

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -3130,6 +3130,46 @@ def test_csv_fragment_options(tempdir, dataset_reader):
         pa.table({'col0': pa.array(['foo', 'spam', 'MYNULL'])}))
 
 
+def test_encoding(tempdir, dataset_reader):
+    path = str(tempdir / 'test.csv')
+
+    for encoding, input_rows, expected_table in [
+        ('latin-1', b"a,b\nun,\xe9l\xe9phant", {'a': ["un"],
+            'b': [b"\xe9l\xe9phant"]}),
+        ('utf16', b'\x00a\x00,\x00b\x00\n\x00u\x00n\x00,\x00\xe9\x00l\x00\xe9\x00p\x00h\x00a\x00n\x00t\x00',
+        {'a': [b"\x00u\x00n"], 'b': [b"\x00\xe9\x00l\x00\xe9\x00p\x00h\x00a\x00n\x00t\x00"]})
+    ]:
+
+        with open(path, 'wb') as sink:
+            sink.write(input_rows)
+
+        # Interpret as binary data:
+        expected_binary_schema = pa.schema([('a', pa.string()),
+             ('b', pa.binary())])
+        expected_binary_table = pa.table(expected_table, schema=expected_binary_schema)
+
+        # Reading in binary should still work
+        dataset_binary = ds.dataset(path, format='csv')
+        assert dataset_binary.to_table().equals(expected_binary_table)
+
+        # Interpret as utf8:
+        expected_schema = pa.schema([("a", pa.string()), ("b", pa.string())])
+        expected_table = pa.table({'a': ["un"],
+            'b': ["éléphant"]}, schema=expected_schema)
+
+        # Reading as string without specifying encoding should produce an error
+        dataset = ds.dataset(path, format='csv', schema=expected_schema)
+        with pytest.raises(pyarrow.lib.ArrowInvalid, match="invalid UTF8"):
+            result = dataset_reader.to_table(dataset)
+
+        # Setting the encoding in the read_options should transcode the data
+        read_options = pa.csv.ReadOptions(encoding=encoding)
+        file_format = ds.CsvFileFormat(read_options=read_options)
+        dataset_transcoded = ds.dataset(path, format=file_format)
+        assert dataset_transcoded.schema.equals(expected_schema)
+        assert dataset_transcoded.to_table().equals(expected_table)
+
+
 def test_feather_format(tempdir, dataset_reader):
     from pyarrow.feather import write_feather
 

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -3133,41 +3133,36 @@ def test_csv_fragment_options(tempdir, dataset_reader):
 def test_encoding(tempdir, dataset_reader):
     path = str(tempdir / 'test.csv')
 
-    for encoding, input_rows, expected_table in [
-        ('latin-1', b"a,b\nun,\xe9l\xe9phant", {'a': ["un"],
-            'b': [b"\xe9l\xe9phant"]}),
-        ('utf16', b'\x00a\x00,\x00b\x00\n\x00u\x00n\x00,\x00\xe9\x00l\x00\xe9\x00p\x00h\x00a\x00n\x00t\x00',
-        {'a': [b"\x00u\x00n"], 'b': [b"\x00\xe9\x00l\x00\xe9\x00p\x00h\x00a\x00n\x00t\x00"]})
-    ]:
+    with open(path, 'wb') as sink:
+        sink.write(b"a,b\nun,\xe9l\xe9phant")
 
-        with open(path, 'wb') as sink:
-            sink.write(input_rows)
+    # Interpret as binary data:
+    expected_binary_schema = pa.schema([('a', pa.string()),
+                                        ('b', pa.binary())])
+    expected_binary_table = pa.table({'a': ["un"],
+                                      'b': [b"\xe9l\xe9phant"]},
+                                     schema=expected_binary_schema)
 
-        # Interpret as binary data:
-        expected_binary_schema = pa.schema([('a', pa.string()),
-             ('b', pa.binary())])
-        expected_binary_table = pa.table(expected_table, schema=expected_binary_schema)
+    # Reading in binary should still work
+    dataset_binary = ds.dataset(path, format='csv')
+    assert dataset_binary.to_table().equals(expected_binary_table)
 
-        # Reading in binary should still work
-        dataset_binary = ds.dataset(path, format='csv')
-        assert dataset_binary.to_table().equals(expected_binary_table)
+    # Interpret as utf8:
+    expected_schema = pa.schema([("a", pa.string()), ("b", pa.string())])
+    expected_table = pa.table({'a': ["un"],
+                               'b': ["éléphant"]}, schema=expected_schema)
 
-        # Interpret as utf8:
-        expected_schema = pa.schema([("a", pa.string()), ("b", pa.string())])
-        expected_table = pa.table({'a': ["un"],
-            'b': ["éléphant"]}, schema=expected_schema)
+    # Reading as string without specifying encoding should produce an error
+    dataset = ds.dataset(path, format='csv', schema=expected_schema)
+    with pytest.raises(pyarrow.lib.ArrowInvalid, match="invalid UTF8"):
+        dataset_reader.to_table(dataset)
 
-        # Reading as string without specifying encoding should produce an error
-        dataset = ds.dataset(path, format='csv', schema=expected_schema)
-        with pytest.raises(pyarrow.lib.ArrowInvalid, match="invalid UTF8"):
-            result = dataset_reader.to_table(dataset)
-
-        # Setting the encoding in the read_options should transcode the data
-        read_options = pa.csv.ReadOptions(encoding=encoding)
-        file_format = ds.CsvFileFormat(read_options=read_options)
-        dataset_transcoded = ds.dataset(path, format=file_format)
-        assert dataset_transcoded.schema.equals(expected_schema)
-        assert dataset_transcoded.to_table().equals(expected_table)
+    # Setting the encoding in the read_options should transcode the data
+    read_options = pa.csv.ReadOptions(encoding='latin-1')
+    file_format = ds.CsvFileFormat(read_options=read_options)
+    dataset_transcoded = ds.dataset(path, format=file_format)
+    assert dataset_transcoded.schema.equals(expected_schema)
+    assert dataset_transcoded.to_table().equals(expected_table)
 
 
 def test_feather_format(tempdir, dataset_reader):

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -3133,36 +3133,41 @@ def test_csv_fragment_options(tempdir, dataset_reader):
 def test_encoding(tempdir, dataset_reader):
     path = str(tempdir / 'test.csv')
 
-    with open(path, 'wb') as sink:
-        sink.write(b"a,b\nun,\xe9l\xe9phant")
+    for encoding, input_rows, expected_table in [
+        ('latin-1', b"a,b\nun,\xe9l\xe9phant", {'a': ["un"],
+            'b': [b"\xe9l\xe9phant"]}),
+        ('utf16', b'\x00a\x00,\x00b\x00\n\x00u\x00n\x00,\x00\xe9\x00l\x00\xe9\x00p\x00h\x00a\x00n\x00t\x00',
+        {'a': [b"\x00u\x00n"], 'b': [b"\x00\xe9\x00l\x00\xe9\x00p\x00h\x00a\x00n\x00t\x00"]})
+    ]:
 
-    # Interpret as binary data:
-    expected_binary_schema = pa.schema([('a', pa.string()),
-                                        ('b', pa.binary())])
-    expected_binary_table = pa.table({'a': ["un"],
-                                      'b': [b"\xe9l\xe9phant"]},
-                                     schema=expected_binary_schema)
+        with open(path, 'wb') as sink:
+            sink.write(input_rows)
 
-    # Reading in binary should still work
-    dataset_binary = ds.dataset(path, format='csv')
-    assert dataset_binary.to_table().equals(expected_binary_table)
+        # Interpret as binary data:
+        expected_binary_schema = pa.schema([('a', pa.string()),
+             ('b', pa.binary())])
+        expected_binary_table = pa.table(expected_table, schema=expected_binary_schema)
 
-    # Interpret as utf8:
-    expected_schema = pa.schema([("a", pa.string()), ("b", pa.string())])
-    expected_table = pa.table({'a': ["un"],
-                               'b': ["éléphant"]}, schema=expected_schema)
+        # Reading in binary should still work
+        dataset_binary = ds.dataset(path, format='csv')
+        assert dataset_binary.to_table().equals(expected_binary_table)
 
-    # Reading as string without specifying encoding should produce an error
-    dataset = ds.dataset(path, format='csv', schema=expected_schema)
-    with pytest.raises(pyarrow.lib.ArrowInvalid, match="invalid UTF8"):
-        dataset_reader.to_table(dataset)
+        # Interpret as utf8:
+        expected_schema = pa.schema([("a", pa.string()), ("b", pa.string())])
+        expected_table = pa.table({'a': ["un"],
+            'b': ["éléphant"]}, schema=expected_schema)
 
-    # Setting the encoding in the read_options should transcode the data
-    read_options = pa.csv.ReadOptions(encoding='latin-1')
-    file_format = ds.CsvFileFormat(read_options=read_options)
-    dataset_transcoded = ds.dataset(path, format=file_format)
-    assert dataset_transcoded.schema.equals(expected_schema)
-    assert dataset_transcoded.to_table().equals(expected_table)
+        # Reading as string without specifying encoding should produce an error
+        dataset = ds.dataset(path, format='csv', schema=expected_schema)
+        with pytest.raises(pyarrow.lib.ArrowInvalid, match="invalid UTF8"):
+            result = dataset_reader.to_table(dataset)
+
+        # Setting the encoding in the read_options should transcode the data
+        read_options = pa.csv.ReadOptions(encoding=encoding)
+        file_format = ds.CsvFileFormat(read_options=read_options)
+        dataset_transcoded = ds.dataset(path, format=file_format)
+        assert dataset_transcoded.schema.equals(expected_schema)
+        assert dataset_transcoded.to_table().equals(expected_table)
 
 
 def test_feather_format(tempdir, dataset_reader):

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -3133,13 +3133,10 @@ def test_csv_fragment_options(tempdir, dataset_reader):
 def test_encoding(tempdir, dataset_reader):
     path = str(tempdir / 'test.csv')
 
-    for encoding, input_rows, expected_table in [
-        ('latin-1', b"a,b\nun,\xe9l\xe9phant",
-         {'a': ["un"], 'b': [b"\xe9l\xe9phant"]}),
+    for encoding, input_rows in [
+        ('latin-1', b"a,b\nun,\xe9l\xe9phant"),
         ('utf16', b'\xff\xfea\x00,\x00b\x00\n\x00u\x00n\x00,'
-         b'\x00\xe9\x00l\x00\xe9\x00p\x00h\x00a\x00n\x00t\x00',
-         {'a': [b"\x00u\x00n"],
-          'b': [b"\x00\xe9\x00l\x00\xe9\x00p\x00h\x00a\x00n\x00t\x00"]})
+         b'\x00\xe9\x00l\x00\xe9\x00p\x00h\x00a\x00n\x00t\x00'),
     ]:
 
         with open(path, 'wb') as sink:


### PR DESCRIPTION
This is an alternative version of https://github.com/apache/arrow/pull/13709, to compare what the best approach is.

Instead of extending the C++ ReadOptions struct with an `encoding` field, this implementations adds a python version of the ReadOptions object to both `CsvFileFormat` and `CsvFragmentScanOptions`. The reason it is needed in both places, is to prevent these kinds of inconsistencies:
```
>>> import pyarrow.dataset as ds
>>> import pyarrow.csv as csv
>>> ro =csv.ReadOptions(encoding='iso8859')
>>> fo = ds.CsvFileFormat(read_options=ro)
>>> fo.default_fragment_scan_options.read_options.encoding
'utf8'
```