### PR TITLE
ARROW-17369: [Java][CI] Automatically build dependant libraries for s390x

### DIFF
--- a/ci/scripts/java_build.sh
+++ b/ci/scripts/java_build.sh
@@ -35,7 +35,7 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
   mkdir -p ${ARROW_HOME}/lib
 
   pushd ${ARROW_HOME}/
-  protover=$(mvn help:evaluate -Dexpression=dep.protobuf-bom.version -q -DforceStdout)
+  protover=$(MAVEN_OPTS="-Xint" mvn help:evaluate -Dexpression=dep.protobuf-bom.version -q -DforceStdout)
   if [[ $? -ne 0 ]]; then
     echo "Error at protobuf: $protover"
     exit 1
@@ -62,7 +62,7 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
   export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${ARROW_HOME}/lib
 
   pushd ${ARROW_HOME}/
-  grpcver=$(mvn help:evaluate -Dexpression=dep.grpc-bom.version -q -DforceStdout)
+  grpcver=$(MAVEN_OPTS="-Xint" mvn help:evaluate -Dexpression=dep.grpc-bom.version -q -DforceStdout)
   if [[ $? -ne 0 ]]; then
     echo "Error at grpc: $grpcver"
     exit 1

--- a/ci/scripts/java_build.sh
+++ b/ci/scripts/java_build.sh
@@ -34,7 +34,7 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
   artifactory_base_url="https://apache.jfrog.io/artifactory/arrow"
   mkdir -p ${ARROW_HOME}/lib
 
-  pushd ${ARROW_HOME}
+  pushd ${ARROW_HOME}/
   protover=$(mvn help:evaluate -Dexpression=dep.protobuf-bom.version -q -DforceStdout)
   if [[ $? -ne 0 ]]; then
     echo "Error at protobuf: $protover"
@@ -61,7 +61,7 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
   cp lib*.so.* ${ARROW_HOME}/lib
   export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${ARROW_HOME}/lib
 
-  pushd ${ARROW_HOME}
+  pushd ${ARROW_HOME}/
   grpcver=$(mvn help:evaluate -Dexpression=dep.grpc-bom.version -q -DforceStdout)
   if [[ $? -ne 0 ]]; then
     echo "Error at grpc: $grpcver"

--- a/ci/scripts/java_build.sh
+++ b/ci/scripts/java_build.sh
@@ -45,7 +45,7 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
   protover=$(echo $protover | sed "s/^[0-9]*.//")
   popd
   ${wget} https://github.com/protocolbuffers/protobuf/releases/download/v${protover}/protobuf-all-${protover}.tar.gz
-  ${tar} xf protobuf-all-${protover}.tar.gz
+  ${tar} -xf protobuf-all-${protover}.tar.gz
   pushd protobuf-${protover}
   ./configure
   make -j 2
@@ -73,7 +73,7 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
   fi
   popd
   ${wget} https://github.com/grpc/grpc-java/archive/refs/tags/v${grpcver}.tar.gz
-  ${tar} xf v${grpcver}.tar.gz
+  ${tar} -xf v${grpcver}.tar.gz
   pushd grpc-java-${grpcver}
   echo skipAndroid=true >> gradle.properties
   CXXFLAGS="-I${ARROW_HOME}/protobuf-${protover}/src" LDFLAGS="-L${ARROW_HOME}/protobuf-${protover}/src/.libs" ./gradlew java_pluginExecutable --no-daemon

--- a/ci/scripts/java_build.sh
+++ b/ci/scripts/java_build.sh
@@ -30,10 +30,6 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
   # Since some files for s390_64 are not available at maven central,
   # download packages and build libraries here
 
-  # download required packages for building libraries
-  apt-get install -y -q --no-install-recommends \
-      g++
-
   mvn_install="mvn install:install-file"
   wget="wget"
   tar="tar --no-same-owner --no-same-permissions"
@@ -51,7 +47,10 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
   ${wget} https://github.com/protocolbuffers/protobuf/releases/download/v${protover}/protobuf-all-${protover}.tar.gz
   ${tar} -xf protobuf-all-${protover}.tar.gz
   pushd protobuf-${protover}
-  ./configure
+  which gcc
+  which g++
+  ls -al /usr/bin/g*
+  CC=gcc CXX=g++ ./configure
   make -j 2
   # protoc requires libprotoc.so.* libprotobuf.so.*
   cp ./src/.libs/libprotoc.so.* ./src/.libs/libprotobuf.so.* ${ARROW_HOME}/lib

--- a/ci/scripts/java_build.sh
+++ b/ci/scripts/java_build.sh
@@ -34,13 +34,13 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
   artifactory_base_url="https://apache.jfrog.io/artifactory/arrow"
   mkdir -p ${ARROW_HOME}/lib
 
-  pushd ${ARROW_HOME}/
-  protover=$(MAVEN_OPTS="-Xint" mvn help:evaluate -Dexpression=dep.protobuf-bom.version -q -DforceStdout)
+  protover=$(mvn help:evaluate -Dexpression=dep.protobuf-bom.version -q -DforceStdout)
   if [[ $? -ne 0 ]]; then
     echo "Error at protobuf: $protover"
     exit 1
   fi
   protover=echo $protover | sed "s/^[0-9]*.//"
+  pushd ${ARROW_HOME}/
   wget https://github.com/protocolbuffers/protobuf/releases/download/v${protover}/protobuf-all-${protover}.tar.gz
   tar xf protobuf-all-${protover}.tar.gz
   cd protobuf-${protover}
@@ -61,12 +61,12 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
   cp lib*.so.* ${ARROW_HOME}/lib
   export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${ARROW_HOME}/lib
 
-  pushd ${ARROW_HOME}/
-  grpcver=$(MAVEN_OPTS="-Xint" mvn help:evaluate -Dexpression=dep.grpc-bom.version -q -DforceStdout)
+  grpcver=$(mvn help:evaluate -Dexpression=dep.grpc-bom.version -q -DforceStdout)
   if [[ $? -ne 0 ]]; then
     echo "Error at grpc: $grpcver"
     exit 1
   fi
+  pushd ${ARROW_HOME}/
   wget https://github.com/grpc/grpc-java/archive/refs/tags/v${grpcver}.tar.gz
   tar xf v${grpcver}.tar.gz
   cd grpc-java-${grpcver}

--- a/ci/scripts/java_build.sh
+++ b/ci/scripts/java_build.sh
@@ -31,6 +31,7 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
   # download packages and build libraries here
 
   # download required packages for building libraries
+  apt-get update -y -q && \
   apt-get install -y -q --no-install-recommends \
       bazel \
       g++ \

--- a/ci/scripts/java_build.sh
+++ b/ci/scripts/java_build.sh
@@ -31,11 +31,8 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
   # download packages and build libraries here
 
   # download required packages for building libraries
-  apt-get update -y -q && \
   apt-get install -y -q --no-install-recommends \
-      bazel \
-      g++ \
-      gcc
+      gcc g++
 
   mvn_install="mvn install:install-file"
   wget="wget"

--- a/ci/scripts/java_build.sh
+++ b/ci/scripts/java_build.sh
@@ -32,7 +32,7 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
 
   # download required packages for building libraries
   apt-get install -y -q --no-install-recommends \
-      gcc g++
+      g++
 
   mvn_install="mvn install:install-file"
   wget="wget"

--- a/ci/scripts/java_build.sh
+++ b/ci/scripts/java_build.sh
@@ -31,6 +31,7 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
   # download pre-build files from Artifactory and install them explicitly
   mvn_install="mvn install:install-file"
   wget="wget"
+  tar="tar --no-same-owner --no-same-permissions"
   artifactory_base_url="https://apache.jfrog.io/artifactory/arrow"
   mkdir -p ${ARROW_HOME}/lib
 
@@ -43,8 +44,8 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
   fi
   protover=$(echo $protover | sed "s/^[0-9]*.//")
   popd
-  wget https://github.com/protocolbuffers/protobuf/releases/download/v${protover}/protobuf-all-${protover}.tar.gz
-  tar xf protobuf-all-${protover}.tar.gz
+  ${wget} https://github.com/protocolbuffers/protobuf/releases/download/v${protover}/protobuf-all-${protover}.tar.gz
+  ${tar} xf protobuf-all-${protover}.tar.gz
   pushd protobuf-${protover}
   ./configure
   make -j 2
@@ -71,8 +72,8 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
     exit 1
   fi
   popd
-  wget https://github.com/grpc/grpc-java/archive/refs/tags/v${grpcver}.tar.gz
-  tar xf v${grpcver}.tar.gz
+  ${wget} https://github.com/grpc/grpc-java/archive/refs/tags/v${grpcver}.tar.gz
+  ${tar} xf v${grpcver}.tar.gz
   pushd grpc-java-${grpcver}
   echo skipAndroid=true >> gradle.properties
   CXXFLAGS="-I${ARROW_HOME}/protobuf-${protover}/src" LDFLAGS="-L${ARROW_HOME}/protobuf-${protover}/src/.libs" ./gradlew java_pluginExecutable --no-daemon

--- a/ci/scripts/java_build.sh
+++ b/ci/scripts/java_build.sh
@@ -41,7 +41,7 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
     echo "Error at protobuf: $protover"
     exit 1
   fi
-  protover=echo $protover | sed "s/^[0-9]*.//"
+  protover=$(echo $protover | sed "s/^[0-9]*.//")
   popd
   wget https://github.com/protocolbuffers/protobuf/releases/download/v${protover}/protobuf-all-${protover}.tar.gz
   tar xf protobuf-all-${protover}.tar.gz

--- a/ci/scripts/java_build.sh
+++ b/ci/scripts/java_build.sh
@@ -28,11 +28,17 @@ java_jni_dist_dir=${3}
 
 if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
   # Since some files for s390_64 are not available at maven central,
-  # download pre-build files from Artifactory and install them explicitly
+  # download packages and build libraries here
+
+  # download required packages for building libraries
+  apt-get install -y -q --no-install-recommends \
+      bazel \
+      g++ \
+      gcc
+
   mvn_install="mvn install:install-file"
   wget="wget"
   tar="tar --no-same-owner --no-same-permissions"
-  artifactory_base_url="https://apache.jfrog.io/artifactory/arrow"
   mkdir -p ${ARROW_HOME}/lib
 
   pushd ${ARROW_HOME}/
@@ -54,7 +60,6 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
   cp ./src/.libs/protoc ${ARROW_HOME}/lib
   popd
 
-  artifactory_dir="protoc-binary"
   group="com.google.protobuf"
   artifact="protoc"
   classifier="linux-s390_64"
@@ -80,7 +85,6 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
   cp ./compiler/build/exe/java_plugin/protoc-gen-grpc-java ${ARROW_HOME}/lib
   popd
 
-  artifactory_dir="protoc-gen-grpc-java-binary"
   group="io.grpc"
   artifact="protoc-gen-grpc-java"
   classifier="linux-s390_64"

--- a/ci/scripts/java_build.sh
+++ b/ci/scripts/java_build.sh
@@ -47,9 +47,9 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
   ${wget} https://github.com/protocolbuffers/protobuf/releases/download/v${protover}/protobuf-all-${protover}.tar.gz
   ${tar} -xf protobuf-all-${protover}.tar.gz
   pushd protobuf-${protover}
+  ls -al /usr/bin/g*
   which gcc
   which g++
-  ls -al /usr/bin/g*
   CC=gcc CXX=g++ ./configure
   make -j 2
   # protoc requires libprotoc.so.* libprotobuf.so.*

--- a/ci/scripts/java_build.sh
+++ b/ci/scripts/java_build.sh
@@ -33,10 +33,15 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
   wget="wget"
   artifactory_base_url="https://apache.jfrog.io/artifactory/arrow"
 
+  ver=$(mvn help:evaluate -Dexpression=dep.protobuf-bom.version -q -DforceStdout)
+  if [[ $? -ne 0 ]]; then
+    echo "Error at protobuf: $ver"
+    exit 1
+  fi
+  ver=echo $ver | sed "s/^[0-9]*.//"
   artifactory_dir="protoc-binary"
   group="com.google.protobuf"
   artifact="protoc"
-  ver="21.2"
   classifier="linux-s390_64"
   extension="exe"
   # target=${artifact}-${ver}-${classifier}.${extension}
@@ -51,10 +56,14 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
   cp lib*.so.${libver} ${ARROW_HOME}/lib
   export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${ARROW_HOME}/lib
 
+  ver=$(mvn help:evaluate -Dexpression=dep.grpc-bom.version -q -DforceStdout)
+  if [[ $? -ne 0 ]]; then
+    echo "Error at grpc: $ver"
+    exit 1
+  fi
   artifactory_dir="protoc-gen-grpc-java-binary"
   group="io.grpc"
   artifact="protoc-gen-grpc-java"
-  ver="1.47.0"
   classifier="linux-s390_64"
   extension="exe"
   # target=${artifact}-${ver}-${classifier}.${extension}


### PR DESCRIPTION
The current ci for Java s390x required manual maintenance for dependant libraries version. This PR extracts dependent library versions from pom.xml and builds necessary native libraries and commands.