### PR TITLE
MINOR: [C++] Add check for result of MakeExecNode

### DIFF
--- a/cpp/src/arrow/compute/exec/asof_join_benchmark.cc
+++ b/cpp/src/arrow/compute/exec/asof_join_benchmark.cc
@@ -89,7 +89,7 @@ static void TableJoinOverhead(benchmark::State& state,
     ASSERT_OK_AND_ASSIGN(arrow::compute::ExecNode * join_node,
                          MakeExecNode(factory_name, plan.get(), input_nodes, options));
     AsyncGenerator<util::optional<ExecBatch>> sink_gen;
-    MakeExecNode("sink", plan.get(), {join_node}, SinkNodeOptions{&sink_gen});
+    ASSERT_OK(MakeExecNode("sink", plan.get(), {join_node}, SinkNodeOptions{&sink_gen}));
     state.ResumeTiming();
     ASSERT_FINISHES_OK(StartAndCollect(plan.get(), sink_gen));
   }


### PR DESCRIPTION
ARROW-16894 added benchmarks for asof join node. This PR adds a call to `ASSERT_OK` to satisfy the warning that the `Result` returned by `MakeExecNode` was not checked.