### PR TITLE
ARROW-17385: [Integration] Revert "Re-enable Rust integration case"

### DIFF
--- a/dev/archery/archery/integration/runner.py
+++ b/dev/archery/archery/integration/runner.py
@@ -430,6 +430,7 @@ def run_all_tests(with_cpp=True, with_java=True, with_js=True,
         Scenario(
             "middleware",
             description="Ensure headers are propagated via middleware.",
+            skip={"Rust"}   # TODO(ARROW-10961): tonic upgrade needed
         ),
         Scenario(
             "flight_sql",


### PR DESCRIPTION
Reverts apache/arrow#13852 since it ended up with the wrong commit message