### PR TITLE
ARROW-17406: [C++] Failing to build the C++ Lib with tests

### DIFF
--- a/ci/conda_env_cpp.txt
+++ b/ci/conda_env_cpp.txt
@@ -17,9 +17,9 @@
 
 aws-sdk-cpp=1.8.186
 benchmark>=1.6.0
-# 1.82 warns about C++14 requirement
+# Versions >1.80 warn about C++14 requirement
 # which errors the build with -Werror=cpp
-boost-cpp>=1.68.0,<1.82
+boost-cpp>=1.68.0,<1.80.0
 brotli
 bzip2
 c-ares

--- a/ci/conda_env_cpp.txt
+++ b/ci/conda_env_cpp.txt
@@ -17,6 +17,8 @@
 
 aws-sdk-cpp=1.8.186
 benchmark>=1.6.0
+# 1.82 warns about C++14 requirement
+# which errors the build with -Werror=cpp
 boost-cpp>=1.68.0,<1.82
 brotli
 bzip2

--- a/ci/conda_env_cpp.txt
+++ b/ci/conda_env_cpp.txt
@@ -17,7 +17,7 @@
 
 aws-sdk-cpp=1.8.186
 benchmark>=1.6.0
-boost-cpp>=1.68.0
+boost-cpp>=1.68.0,<1.82
 brotli
 bzip2
 c-ares


### PR DESCRIPTION
Ref: https://issues.apache.org/jira/browse/ARROW-17406

Pin `boost-cpp` to a version which doesn't raise warning.