### PR TITLE
MINOR: [R][Docs] Add note about conversion from JSON types to Arrow types

### DIFF
--- a/r/R/json.R
+++ b/r/R/json.R
@@ -23,7 +23,7 @@
 #' If passed a path, will detect and handle compression from the file extension
 #' (e.g. `.json.gz`).
 #'
-#' Arrow data types are inferred from the JSON types and values of each column:
+#' If `schema` is not provided, Arrow data types are inferred from the data:
 #' - JSON null values convert to the [null()] type, but can fall back to any other type.
 #' - JSON booleans convert to [boolean()].
 #' - JSON numbers convert to [int64()], falling back to [float64()] if a non-integer is encountered.

--- a/r/R/json.R
+++ b/r/R/json.R
@@ -21,7 +21,19 @@
 #' data frame or Arrow Table.
 #'
 #' If passed a path, will detect and handle compression from the file extension
-#' (e.g. `.json.gz`). Accepts explicit or implicit nulls.
+#' (e.g. `.json.gz`).
+#'
+#' Arrow data types are inferred from the JSON types and values of each column:
+#' - JSON null values convert to the [null()] type, but can fall back to any other type.
+#' - JSON booleans convert to [boolean()].
+#' - JSON numbers convert to [int64()], falling back to [float64()] if a non-integer is encountered.
+#' - JSON strings of the kind "YYYY-MM-DD" and "YYYY-MM-DD hh:mm:ss" convert to [`timestamp(unit = "s")`][timestamp()],
+#'   falling back to [utf8()] if a conversion error occurs.
+#' - JSON arrays convert to a [list_of()] type, and inference proceeds recursively on the JSON arrays' values.
+#' - Nested JSON objects convert to a [struct()] type, and inference proceeds recursively on the JSON objects' values.
+#'
+#' When `as_data_frame = FALSE`, Arrow types are further converted to R types.
+#' See `vignette("arrow", package = "arrow")` for details.
 #'
 #' @inheritParams read_delim_arrow
 #' @param schema [Schema] that describes the table.
@@ -37,7 +49,7 @@
 #'     { "hello": 3.25, "world": null }
 #'     { "hello": 0.0, "world": true, "yo": null }
 #'   ', tf, useBytes = TRUE)
-#' df <- read_json_arrow(tf)
+#' read_json_arrow(tf)
 read_json_arrow <- function(file,
                             col_select = NULL,
                             as_data_frame = TRUE,

--- a/r/man/read_json_arrow.Rd
+++ b/r/man/read_json_arrow.Rd
@@ -41,7 +41,21 @@ data frame or Arrow Table.
 }
 \details{
 If passed a path, will detect and handle compression from the file extension
-(e.g. \code{.json.gz}). Accepts explicit or implicit nulls.
+(e.g. \code{.json.gz}).
+
+Arrow data types are inferred from the JSON types and values of each column:
+\itemize{
+\item JSON null values convert to the \code{\link[=null]{null()}} type, but can fall back to any other type.
+\item JSON booleans convert to \code{\link[=boolean]{boolean()}}.
+\item JSON numbers convert to \code{\link[=int64]{int64()}}, falling back to \code{\link[=float64]{float64()}} if a non-integer is encountered.
+\item JSON strings of the kind "YYYY-MM-DD" and "YYYY-MM-DD hh:mm:ss" convert to \code{\link[=timestamp]{timestamp(unit = "s")}},
+falling back to \code{\link[=utf8]{utf8()}} if a conversion error occurs.
+\item JSON arrays convert to a \code{\link[=list_of]{list_of()}} type, and inference proceeds recursively on the JSON arrays' values.
+\item Nested JSON objects convert to a \code{\link[=struct]{struct()}} type, and inference proceeds recursively on the JSON objects' values.
+}
+
+When \code{as_data_frame = FALSE}, Arrow types are further converted to R types.
+See \code{vignette("arrow", package = "arrow")} for details.
 }
 \examples{
 \dontshow{if (arrow_with_json()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
@@ -52,6 +66,6 @@ writeLines('
     { "hello": 3.25, "world": null }
     { "hello": 0.0, "world": true, "yo": null }
   ', tf, useBytes = TRUE)
-df <- read_json_arrow(tf)
+read_json_arrow(tf)
 \dontshow{\}) # examplesIf}
 }

--- a/r/man/read_json_arrow.Rd
+++ b/r/man/read_json_arrow.Rd
@@ -43,7 +43,7 @@ data frame or Arrow Table.
 If passed a path, will detect and handle compression from the file extension
 (e.g. \code{.json.gz}).
 
-Arrow data types are inferred from the JSON types and values of each column:
+If \code{schema} is not provided, Arrow data types are inferred from the data:
 \itemize{
 \item JSON null values convert to the \code{\link[=null]{null()}} type, but can fall back to any other type.
 \item JSON booleans convert to \code{\link[=boolean]{boolean()}}.


### PR DESCRIPTION
Add note about conversion from JSON types to Arrow types.
These documents were copied from `docs/source/python/json.rst` with modifications.

Also, show the data frame in the example to make it easier to understand how the conversion is performed.