### PR TITLE
ARROW-17407: [Doc][FlightRPC] Flight/gRPC best practices

### DIFF
--- a/docs/source/cpp/flight.rst
+++ b/docs/source/cpp/flight.rst
@@ -206,9 +206,9 @@ Also see `best gRPC practices`_ and available `gRPC keys`_.
 Re-use clients whenever possible
 --------------------------------
 
-Closing clients causes gRPC to close and clean up connections which can take
-several seconds per connection. This will stall server and client threads if
-done too frequently. Client reuse will avoid this issue.
+Creating and closing clients requires setup and teardown on the client and
+server side which can take away from actually handling RPCs. Reuse clients
+whenever possible to avoid this. Note that clients are thread-safe.
 
 Don’t round-robin load balance
 ------------------------------
@@ -250,7 +250,7 @@ allocated by gRPC or by the application that the system allocator was holding
 on to. This can be adjusted in platform-specific ways; see an investigation
 in JIRA for an example of how this works on Linux/glibc.
 
-malloc can be explicitly told to dump caches. See ARROW-16697_ as an example.
+glibc malloc can be explicitly told to dump caches. See ARROW-16697_ as an example.
 
 Excessive traffic
 -----------------
@@ -291,8 +291,8 @@ Limiting DoPut Batch Size
 
 You may wish to limit the maximum size a client can submit to a server through
 DoPut, to prevent a request from taking up too much memory on the server. On
-the client-side, set ``write_size_limit_bytes`` on ``FlightClientOptions``. On the
-server-side, set the gRPC option ``GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH``.
+the client-side, set :member:`arrow::flight::FlightClientOptions::write_size_limit_bytes`.
+On the server-side, set the gRPC option ``GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH``.
 The client-side option will return an error that can be retried with smaller batches,
 while the server-side limit will close out the connection. Setting both can be wise, since
 the former provides a better user experience but the latter may be necessary to defend

--- a/docs/source/cpp/flight.rst
+++ b/docs/source/cpp/flight.rst
@@ -260,10 +260,9 @@ threads are not necessarily cleaned up (a "cached thread pool" in Java parlance)
 glibc malloc clears some per thread state and the default tuning never clears
 caches in some workloads.
 
-gRPC's default behavior allows one server to accept many connections from many
+gRPC's default behaviour allows one server to accept many connections from many
 different clients, but if requests do a lot of work (as they may under Flight),
-the server may not be able to keep up. Configuring the server to limit the number
-of clients and reject requests more proactively, and configuring clients to retry
+the server may not be able to keep up. Configuring clients to retry
 with backoff (and potentially connect to a different node), would give more
 consistent quality of service.
 

--- a/docs/source/cpp/flight.rst
+++ b/docs/source/cpp/flight.rst
@@ -172,6 +172,8 @@ request/response. On the server, they can inspect incoming headers and
 fail the request; hence, they can be used to implement custom
 authentication methods.
 
+.. _flight-best-practices:
+
 Best practices
 ==============
 
@@ -179,7 +181,7 @@ gRPC
 ----
 
 When using default gRPC transport options can be passed to it via
-:func:`arrow::flight::FlightClientOptions.generic_options`. For example:
+:member:`arrow::flight::FlightClientOptions::generic_options`. For example:
 
 .. code-block:: cpp
 
@@ -187,12 +189,11 @@ When using default gRPC transport options can be passed to it via
    // Set a very low limit at the gRPC layer to fail all calls
    options.generic_options.emplace_back(GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH, 4);
 
-See available `gRPC keys_`.
-Best gRPC practices are described here_.
+Also see `best gRPC practices`_ and available `gRPC keys`_.
 
 
 Re-use clients whenever possible
-
+--------------------------------
 
 Closing clients causes gRPC to close and clean up connections which can take
 several seconds per connection. This will stall server and client threads if
@@ -257,17 +258,18 @@ different node. Not everyone gets serviced but quality of service stays consiste
 Closing unresponsive connections
 --------------------------------
 
-* A stale connection can be closed using FlightCallOptions.stop_token. This requires
-recording the stop token at connection establishment time.
-* Use client timeout
-* here is a long standing ticket for a per-write/per-read timeout instead of a per
-call timeout (ARROW-6062_), but this is not (easily) possible to implement with the
-blocking gRPC API. For now one can also do something like set up a background thread
-that calls cancel() on a timer and have the main thread reset the timer every time a
-write operation completes successfully (that means one needs to use to_batches() +
-write_batch and not write_table).
+1. A stale connection can be closed using
+   :member:`arrow::flight::FlightClientOptions::stop_token`. This requires recording the
+   stop token at connection establishment time.
+2. Use client timeout.
+3. There is a long standing ticket for a per-write/per-read timeout instead of a per
+   call timeout (ARROW-6062_), but this is not (easily) possible to implement with the
+   blocking gRPC API. For now one can also do something like set up a background thread
+   that calls cancel() on a timer and have the main thread reset the timer every time a
+   write operation completes successfully (that means one needs to use to_batches() +
+   write_batch and not write_table).
 
-.. _here: https://grpc.io/docs/guides/performance/#general
+.. _best gRPC practices: https://grpc.io/docs/guides/performance/#general
 .. _gRPC keys: https://grpc.github.io/grpc/cpp/group__grpc__arg__keys.html
 .. _ARROW-15764: https://issues.apache.org/jira/browse/ARROW-15764
 .. _ARROW-16697: https://issues.apache.org/jira/browse/ARROW-16697

--- a/docs/source/cpp/flight.rst
+++ b/docs/source/cpp/flight.rst
@@ -244,7 +244,7 @@ such as whether free memory is returned to the system, is dependent
 on the allocator that gRPC uses (usually the system allocator).
 
 A quick way of testing: attach to the process with a debugger and call
-malloc_trim, or call :func:`ReleaseUnused <arrow::MemoryPool::ReleaseUnused>`
+``malloc_trim``, or call :func:`ReleaseUnused <arrow::MemoryPool::ReleaseUnused>`
 on the system pool. If memory usage drops, then likely, there is memory
 allocated by gRPC or by the application that the system allocator was holding
 on to. This can be adjusted in platform-specific ways; see an investigation
@@ -289,7 +289,7 @@ consistent quality of service.
 Limiting DoPut Batch Size
 --------------------------
 
-You may wish to limit the maximum size a client can submit to a server through
+You may wish to limit the maximum batch size a client can submit to a server through
 DoPut, to prevent a request from taking up too much memory on the server. On
 the client-side, set :member:`arrow::flight::FlightClientOptions::write_size_limit_bytes`.
 On the server-side, set the gRPC option ``GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH``.

--- a/docs/source/cpp/flight.rst
+++ b/docs/source/cpp/flight.rst
@@ -180,7 +180,7 @@ Best practices
 gRPC
 ----
 
-When using default gRPC transport options can be passed to it via
+When using the default gRPC transport, options can be passed to it via
 :member:`arrow::flight::FlightClientOptions::generic_options`. For example:
 
 .. tab-set::
@@ -208,7 +208,8 @@ Re-use clients whenever possible
 
 Creating and closing clients requires setup and teardown on the client and
 server side which can take away from actually handling RPCs. Reuse clients
-whenever possible to avoid this. Note that clients are thread-safe.
+whenever possible to avoid this. Note that clients are thread-safe, so a
+single client can be shared across multiple threads.
 
 Don’t round-robin load balance
 ------------------------------
@@ -347,7 +348,7 @@ Closing unresponsive connections
    be hard to choose a timeout for the entire operation. Instead, what is often
    desired is a per-read or per-write timeout so that the operation fails if it
    isn't making progress. This can be implemented with a background thread that
-   calls cancel() on a timer, with the main thread resetting the timer every time
+   calls Cancel() on a timer, with the main thread resetting the timer every time
    an operation completes successfully. For a fully-worked out example, see the
    Cookbook.
    

--- a/docs/source/cpp/flight.rst
+++ b/docs/source/cpp/flight.rst
@@ -217,8 +217,8 @@ Don’t round-robin load balance
 every server, causing an unexpected number of open connections and depleting
 server resources.
 
-Debugging disconnects
----------------------
+Debugging connection issues
+---------------------------
 
 When facing unexpected disconnects on long running connections use netstat to
 monitor the number of open connections. If number of connections is much
@@ -235,7 +235,7 @@ Hence, to detect connection errors when creating a client, some sort
 of dummy RPC should be made.
 
 Memory management
------------------------
+-----------------
 
 Flight tries to reuse allocations made by gRPC to avoid redundant
 data copies. However, this means that those allocations may not
@@ -248,9 +248,8 @@ A quick way of testing: attach to the process with a debugger and call
 on the system pool. If memory usage drops, then likely, there is memory
 allocated by gRPC or by the application that the system allocator was holding
 on to. This can be adjusted in platform-specific ways; see an investigation
-in JIRA for an example of how this works on Linux/glibc.
-
-glibc malloc can be explicitly told to dump caches. See ARROW-16697_ as an example.
+in ARROW-16697_ for an example of how this works on Linux/glibc. glibc malloc
+can be explicitly told to dump caches.
 
 Excessive traffic
 -----------------
@@ -301,9 +300,9 @@ against impolite clients.
 Closing unresponsive connections
 --------------------------------
 
-1. A stale connection can be closed using
+1. A stale call can be closed using
    :member:`arrow::flight::FlightClientOptions::stop_token`. This requires recording the
-   stop token at connection establishment time.
+   stop token at call establishment time.
 
    .. tab-set::
 

--- a/docs/source/cpp/flight.rst
+++ b/docs/source/cpp/flight.rst
@@ -213,7 +213,7 @@ done too frequently. Client reuse will avoid this issue.
 Don’t round-robin load balance
 ------------------------------
 
-`Round robin balancing`_ means every client can have an open connection to
+`Round robin load balancing`_ means every client can have an open connection to
 every server, causing an unexpected number of open connections and depleting
 server resources.
 
@@ -272,6 +272,7 @@ consistent quality of service.
    .. tab-item:: C++
 
       .. code-block:: cpp
+
          auto options = FlightClientOptions::Defaults();
          // Set the minimum time between subsequent connection attempts.
          options.generic_options.emplace_back(GRPC_ARG_MIN_RECONNECT_BACKOFF_MS, 2000);
@@ -340,6 +341,7 @@ Closing unresponsive connections
          .. code-block:: python
 
             options = pyarrow.flight.FlightCallOptions(timeout=0.2)
+            result = client.do_action(action, options=options)
 
 
 3. Client timeouts are not great for long-running streaming calls, where it may
@@ -356,7 +358,7 @@ Closing unresponsive connections
 
 .. _best gRPC practices: https://grpc.io/docs/guides/performance/#general
 .. _gRPC keys: https://grpc.github.io/grpc/cpp/group__grpc__arg__keys.html
-.. _Round-robin load balancing: https://github.com/grpc/grpc/blob/master/doc/load-balancing.md#round_robin
+.. _Round robin load balancing: https://github.com/grpc/grpc/blob/master/doc/load-balancing.md#round_robin
 .. _ARROW-15764: https://issues.apache.org/jira/browse/ARROW-15764
 .. _ARROW-16697: https://issues.apache.org/jira/browse/ARROW-16697
 .. _ARROW-6062: https://issues.apache.org/jira/browse/ARROW-6062

--- a/docs/source/cpp/flight.rst
+++ b/docs/source/cpp/flight.rst
@@ -302,7 +302,7 @@ Closing unresponsive connections
 --------------------------------
 
 1. A stale call can be closed using
-   :member:`arrow::flight::FlightClientOptions::stop_token`. This requires recording the
+   :member:`arrow::flight::FlightCallOptions::stop_token`. This requires recording the
    stop token at call establishment time.
 
    .. tab-set::

--- a/docs/source/java/flight.rst
+++ b/docs/source/java/flight.rst
@@ -201,6 +201,11 @@ request/response. On the server, they can inspect incoming headers and
 fail the request; hence, they can be used to implement custom
 authentication methods.
 
+Best practices
+==============
+
+TODO
+
 .. _`FlightClient`: https://arrow.apache.org/docs/java/reference/org/apache/arrow/flight/FlightClient.html
 .. _`FlightProducer`: https://arrow.apache.org/docs/java/reference/org/apache/arrow/flight/FlightProducer.html
 .. _`FlightServer`: https://arrow.apache.org/docs/java/reference/org/apache/arrow/flight/FlightServer.html

--- a/docs/source/java/flight.rst
+++ b/docs/source/java/flight.rst
@@ -201,10 +201,9 @@ request/response. On the server, they can inspect incoming headers and
 fail the request; hence, they can be used to implement custom
 authentication methods.
 
-Best practices
-==============
+:ref:`Flight best practices <flight-best-practices>`
+====================================================
 
-TODO
 
 .. _`FlightClient`: https://arrow.apache.org/docs/java/reference/org/apache/arrow/flight/FlightClient.html
 .. _`FlightProducer`: https://arrow.apache.org/docs/java/reference/org/apache/arrow/flight/FlightProducer.html

--- a/docs/source/python/flight.rst
+++ b/docs/source/python/flight.rst
@@ -129,7 +129,5 @@ request/response. On the server, they can inspect incoming headers and
 fail the request; hence, they can be used to implement custom
 authentication methods.
 
-Best practices
-==============
-
-TODO
+:ref:`Flight best practices <flight-best-practices>`
+====================================================

--- a/docs/source/python/flight.rst
+++ b/docs/source/python/flight.rst
@@ -128,3 +128,8 @@ Middleware are fairly limited, but they can add headers to a
 request/response. On the server, they can inspect incoming headers and
 fail the request; hence, they can be used to implement custom
 authentication methods.
+
+Best practices
+==============
+
+TODO

--- a/go/arrow/flight/doc.go
+++ b/go/arrow/flight/doc.go
@@ -55,6 +55,7 @@
 // ListFlights endpoint is largely just implemented as a normal GRPC stream
 // endpoint and can hit transfer bottlenecks if used too much. To estimate data
 // transfer bottleneck:
+//
 // 5k schemas will serialize to about 1-5 MB/call. Assuming a gRPC localhost
 // bottleneck of 3GB/s you can at best serve 600-3000 clients/s.
 //

--- a/go/arrow/flight/doc.go
+++ b/go/arrow/flight/doc.go
@@ -56,24 +56,23 @@
 // Excessive traffic
 //
 // There are basically two ways to handle excessive traffic:
-// * unbounded thread pool -> everyone gets serviced, but it might take forever.
-// This is what you are seeing now.
-// bounded thread pool -> Reject connections / requests when under load, and have
+// * unbounded goroutines -> everyone gets serviced, but it might take forever.
+// This is what you are seeing now. Default behaviour.
+// * bounded thread pool -> Reject connections / requests when under load, and have
 // clients retry with backoff. This also gives an opportunity to retry with a
 // different node. Not everyone gets serviced but quality of service stays consistent.
+// Can be set with https://pkg.go.dev/google.golang.org/grpc#NumStreamWorkers
 //
 // Closing unresponsive connections
 //
-// * A stale connection can be closed using CallOptions.stop_token. This requires
-// recording the stop token at connection establishment time.
-// * Use client timeout
+// * Connection timeout (https://pkg.go.dev/context#WithTimeout) or
+// (https://pkg.go.dev/context#WithCancel) can be set via context.Context.
 // * There is a long standing ticket for a per-write/per-read timeout instead of a per
 // call timeout (https://issues.apache.org/jira/browse/ARROW-6062), but this is not
 // (easily) possible to implement with the blocking gRPC API. For now one can also do
 // something like set up a background thread that calls cancel() on a timer and have
 // the main thread reset the timer every time a write operation completes successfully
 // (that means one needs to use to_batches() + write_batch and not write_table).
-// * context.Context can be passed to requests to provide (https://pkg.go.dev/context#WithTimeout) or
-// (https://pkg.go.dev/context#WithCancel).
+
 
 package flight

--- a/go/arrow/flight/doc.go
+++ b/go/arrow/flight/doc.go
@@ -50,19 +50,6 @@
 // give you the actual error until you first try to make a call. This can cause
 // error being reported at unexpected times.
 //
-// Use ListFlights sparingly
-//
-// ListFlights endpoint is largely just implemented as a normal GRPC stream
-// endpoint and can hit transfer bottlenecks if used too much. To estimate data
-// transfer bottleneck:
-//
-// 5k schemas will serialize to about 1-5 MB/call. Assuming a gRPC localhost
-// bottleneck of 3GB/s you can at best serve 600-3000 clients/s.
-//
-// https://issues.apache.org/jira/browse/ARROW-15764 proposes a caching
-// optimisation for server side, but it was not yet implemented.
-//
-//
 // Memory cache client-side
 //
 // Flight uses gRPC allocator wherever possible.

--- a/go/arrow/flight/doc.go
+++ b/go/arrow/flight/doc.go
@@ -1,0 +1,98 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Here we list best practices and common pitfalls for Arrow Flight usage.
+//
+// GRPC
+//
+// When using gRPC for transport all client methods take an optional list
+// of gRPC CallOptions: https://pkg.go.dev/google.golang.org/grpc#CallOption.
+// Additional headers can be used or read via
+// https://pkg.go.dev/google.golang.org/grpc@v1.48.0/metadata with the context.
+// Also see available gRPC keys
+// (https://grpc.github.io/grpc/cpp/group__grpc__arg__keys.html) and a list of
+// best gRPC practices (https://grpc.io/docs/guides/performance/#general).
+//
+// Re-use clients whenever possible
+//
+// Closing clients causes gRPC to close and clean up connections which can take
+// several seconds per connection. This will stall server and client threads if
+// done too frequently. Client reuse will avoid this issue.
+//
+// Don’t round-robin load balance
+//
+// Round robin balancing can cause every client to have an open connection to
+// every server causing an unexpected number of open connections and a depletion
+// of resources.
+//
+// Debugging
+//
+// Use netstat to see the number of open connections.
+// For debug use env GODEBUG=http2debug=1 or GODEBUG=http2debug=2 for verbose
+// http2 logs (using 2 is more verbose with frame dumps). This will print the
+// initial headers (on both sides) so you can see if grpc established the
+// connection or not. It will also print when a message is sent, so you can tell
+// if the connection is open or not.
+// Note: "connect" isn't really a connect and we’ve observed that gRPC does not
+// give you the actual error until you first try to make a call. This can cause
+// error being reported at unexpected times.
+//
+// Use ListFlights sparingly
+//
+// ListFlights endpoint is largely just implemented as a normal GRPC stream
+// endpoint and can hit transfer bottlenecks if used too much. To estimate data
+// transfer bottleneck:
+// 5k schemas will serialize to about 1-5 MB/call. Assuming a gRPC localhost
+// bottleneck of 3GB/s you can at best serve 600-3000 clients/s.
+//
+// https://issues.apache.org/jira/browse/ARROW-15764 proposes a caching
+// optimisation for server side, but it was not yet implemented.
+//
+//
+// Memory cache client-side
+//
+// Flight uses gRPC allocator wherever possible.
+//
+// gRPC will spawn an unbounded number of threads for concurrent clients. Those
+// threads are not necessarily cleaned up (cached thread pool in java parlance).
+// glibc malloc clears some per thread state and the default tuning never clears
+// caches in some workloads. But you can explicitly tell malloc to dump caches.
+// See https://issues.apache.org/jira/browse/ARROW-16697 as an example.
+//
+// A quick way of testing: attach to the process with a debugger and call malloc_trim
+//
+//
+// Excessive traffic
+//
+// There are basically two ways to handle excessive traffic:
+// * unbounded thread pool -> everyone gets serviced, but it might take forever.
+// This is what you are seeing now.
+// bounded thread pool -> Reject connections / requests when under load, and have
+// clients retry with backoff. This also gives an opportunity to retry with a
+// different node. Not everyone gets serviced but quality of service stays consistent.
+//
+// Closing unresponsive connections
+//
+// * A stale connection can be closed using CallOptions.stop_token. This requires
+// recording the stop token at connection establishment time.
+// * Use client timeout
+// * here is a long standing ticket for a per-write/per-read timeout instead of a per
+// call timeout (https://issues.apache.org/jira/browse/ARROW-6062), but this is not
+// (easily) possible to implement with the blocking gRPC API. For now one can also do
+// something like set up a background thread that calls cancel() on a timer and have
+// the main thread reset the timer every time a write operation completes successfully
+// (that means one needs to use to_batches() + write_batch and not write_table).
+package flight

--- a/go/arrow/flight/doc.go
+++ b/go/arrow/flight/doc.go
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package flight contains server and client implementations for the Arrow Flight RPC
+//
 // Here we list best practices and common pitfalls for Arrow Flight usage.
 //
 // GRPC
@@ -46,22 +48,10 @@
 // initial headers (on both sides) so you can see if grpc established the
 // connection or not. It will also print when a message is sent, so you can tell
 // if the connection is open or not.
+//
 // Note: "connect" isn't really a connect and we’ve observed that gRPC does not
 // give you the actual error until you first try to make a call. This can cause
 // error being reported at unexpected times.
-//
-// Memory cache client-side
-//
-// Flight uses gRPC allocator wherever possible.
-//
-// gRPC will spawn an unbounded number of threads for concurrent clients. Those
-// threads are not necessarily cleaned up (cached thread pool in java parlance).
-// glibc malloc clears some per thread state and the default tuning never clears
-// caches in some workloads. But you can explicitly tell malloc to dump caches.
-// See https://issues.apache.org/jira/browse/ARROW-16697 as an example.
-//
-// A quick way of testing: attach to the process with a debugger and call malloc_trim
-//
 //
 // Excessive traffic
 //
@@ -77,10 +67,13 @@
 // * A stale connection can be closed using CallOptions.stop_token. This requires
 // recording the stop token at connection establishment time.
 // * Use client timeout
-// * here is a long standing ticket for a per-write/per-read timeout instead of a per
+// * There is a long standing ticket for a per-write/per-read timeout instead of a per
 // call timeout (https://issues.apache.org/jira/browse/ARROW-6062), but this is not
 // (easily) possible to implement with the blocking gRPC API. For now one can also do
 // something like set up a background thread that calls cancel() on a timer and have
 // the main thread reset the timer every time a write operation completes successfully
 // (that means one needs to use to_batches() + write_batch and not write_table).
+// * context.Context can be passed to requests to provide (https://pkg.go.dev/context#WithTimeout) or
+// (https://pkg.go.dev/context#WithCancel).
+
 package flight

--- a/go/go.sum
+++ b/go/go.sum
@@ -149,6 +149,7 @@ github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PK
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+github.com/yuin/goldmark v1.4.13 h1:fVcFKWvrslecOb/tg+Cc05dkeYx540o0FuFt3nUVDoE=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=

--- a/go/parquet/doc.go
+++ b/go/parquet/doc.go
@@ -17,7 +17,7 @@
 // Package parquet provides an implementation of Apache Parquet for Go.
 //
 // Apache Parquet is an open-source columnar data storage format using the record
-// shredding and assembly algorithm to accomodate complex data structures which
+// shredding and assembly algorithm to accommodate complex data structures which
 // can then be used to efficiently store the data.
 //
 // This implementation is a native go implementation for reading and writing the

--- a/r/vignettes/flight.Rmd
+++ b/r/vignettes/flight.Rmd
@@ -85,3 +85,8 @@ client %>%
 Because `flight_get()` returns an Arrow data structure, you can directly pipe
 its result into a [dplyr](https://dplyr.tidyverse.org/) workflow.
 See `vignette("dataset", package = "arrow")` for more information on working with Arrow objects via a dplyr interface.
+
+Best practices
+==============
+
+TODO

--- a/r/vignettes/flight.Rmd
+++ b/r/vignettes/flight.Rmd
@@ -86,7 +86,4 @@ Because `flight_get()` returns an Arrow data structure, you can directly pipe
 its result into a [dplyr](https://dplyr.tidyverse.org/) workflow.
 See `vignette("dataset", package = "arrow")` for more information on working with Arrow objects via a dplyr interface.
 
-Best practices
-==============
-
-TODO
+# [Flight best practices](../cpp/flight.html#best-practices)


### PR DESCRIPTION
We want to provide best practices and debugging section in:

[cpp flight docs](https://arrow.apache.org/docs/cpp/flight.html)
[python flight docs](https://arrow.apache.org/docs/python/flight.html)
[java flight docs](https://arrow.apache.org/docs/java/flight.html)
[R flight docs](https://arrow.apache.org/docs/r/articles/flight.html)