### PR TITLE
ARROW-15602: [R][Docs] Update docs to explain how to read timestamp with timezone columns

### DIFF
--- a/r/R/csv.R
+++ b/r/R/csv.R
@@ -143,6 +143,15 @@
 #' read_csv_arrow(tf, schema = schema(x = int32(), y = utf8()), skip = 1)
 #' read_csv_arrow(tf, col_types = schema(y = utf8()))
 #' read_csv_arrow(tf, col_types = "ic", col_names = c("x", "y"), skip = 1)
+#'
+#' # Note that you can't read a string representing a timestampe with time zone as a timestampe type without time zone.
+#' write.csv(data.frame(x = "1970-01-01T12:00:00+12:00"), file = tf, row.names = FALSE)
+#' try(read_csv_arrow(tf, skip = 1, col_names = "x", col_types = "T"))
+#' # The timestampe with time zone type must be specified with the `schema()` function.
+#' read_csv_arrow(
+#'   tf, skip = 1, col_names = "x",
+#'   col_types = schema(x = timestamp(unit = "us", timezone = "UTC"))
+#' )
 read_delim_arrow <- function(file,
                              delim = ",",
                              quote = '"',

--- a/r/R/csv.R
+++ b/r/R/csv.R
@@ -54,17 +54,17 @@
 #' single string, one character per column, where the characters map to Arrow
 #' types analogously to the `readr` type mapping:
 #'
-#' * "c": `utf8()`
-#' * "i": `int32()`
-#' * "n": `float64()`
-#' * "d": `float64()`
-#' * "l": `bool()`
-#' * "f": `dictionary()`
-#' * "D": `date32()`
-#' * "T": `timestamp(unit = "ns")`
-#' * "t": `time32()` (The `unit` arg is set to the default value `"ms"`)
-#' * "_": `null()`
-#' * "-": `null()`
+#' * "c": [utf8()]
+#' * "i": [int32()]
+#' * "n": [float64()]
+#' * "d": [float64()]
+#' * "l": [bool()]
+#' * "f": [dictionary()]
+#' * "D": [date32()]
+#' * "T": [`timestamp(unit = "ns")`][timestamp()]
+#' * "t": [time32()] (The `unit` arg is set to the default value `"ms"`)
+#' * "_": [null()]
+#' * "-": [null()]
 #' * "?": infer the type from the data
 #'
 #' If you use the compact string representation for `col_types`, you must also

--- a/r/R/csv.R
+++ b/r/R/csv.R
@@ -144,12 +144,14 @@
 #' read_csv_arrow(tf, col_types = schema(y = utf8()))
 #' read_csv_arrow(tf, col_types = "ic", col_names = c("x", "y"), skip = 1)
 #'
-#' # Note that you can't read a string representing a timestampe with time zone as a timestampe type without time zone.
+#' # Note that if a timestamp column contains time zones, type inference won't work,
+#' # whether automatic or via the string "T" `col_types` specification.
+#' # To parse timestamps with time zones, provide a [Schema] to `col_types`
+#' # and specify the time zone in the type object:
+#' tf <- tempfile()
 #' write.csv(data.frame(x = "1970-01-01T12:00:00+12:00"), file = tf, row.names = FALSE)
-#' try(read_csv_arrow(tf, skip = 1, col_names = "x", col_types = "T"))
-#' # The timestampe with time zone type must be specified with the `schema()` function.
 #' read_csv_arrow(
-#'   tf, skip = 1, col_names = "x",
+#'   tf,
 #'   col_types = schema(x = timestamp(unit = "us", timezone = "UTC"))
 #' )
 read_delim_arrow <- function(file,

--- a/r/man/read_delim_arrow.Rd
+++ b/r/man/read_delim_arrow.Rd
@@ -180,17 +180,17 @@ that \code{readr} uses to the \code{col_types} argument. This means you provide 
 single string, one character per column, where the characters map to Arrow
 types analogously to the \code{readr} type mapping:
 \itemize{
-\item "c": \code{utf8()}
-\item "i": \code{int32()}
-\item "n": \code{float64()}
-\item "d": \code{float64()}
-\item "l": \code{bool()}
-\item "f": \code{dictionary()}
-\item "D": \code{date32()}
-\item "T": \code{timestamp(unit = "ns")}
-\item "t": \code{time32()} (The \code{unit} arg is set to the default value \code{"ms"})
-\item "_": \code{null()}
-\item "-": \code{null()}
+\item "c": \code{\link[=utf8]{utf8()}}
+\item "i": \code{\link[=int32]{int32()}}
+\item "n": \code{\link[=float64]{float64()}}
+\item "d": \code{\link[=float64]{float64()}}
+\item "l": \code{\link[=bool]{bool()}}
+\item "f": \code{\link[=dictionary]{dictionary()}}
+\item "D": \code{\link[=date32]{date32()}}
+\item "T": \code{\link[=timestamp]{timestamp(unit = "ns")}}
+\item "t": \code{\link[=time32]{time32()}} (The \code{unit} arg is set to the default value \code{"ms"})
+\item "_": \code{\link[=null]{null()}}
+\item "-": \code{\link[=null]{null()}}
 \item "?": infer the type from the data
 }
 

--- a/r/man/read_delim_arrow.Rd
+++ b/r/man/read_delim_arrow.Rd
@@ -220,12 +220,14 @@ read_csv_arrow(tf, schema = schema(x = int32(), y = utf8()), skip = 1)
 read_csv_arrow(tf, col_types = schema(y = utf8()))
 read_csv_arrow(tf, col_types = "ic", col_names = c("x", "y"), skip = 1)
 
-# Note that you can't read a string representing a timestampe with time zone as a timestampe type without time zone.
+# Note that if a timestamp column contains time zones, type inference won't work,
+# whether automatic or via the string "T" `col_types` specification.
+# To parse timestamps with time zones, provide a [Schema] to `col_types`
+# and specify the time zone in the type object:
+tf <- tempfile()
 write.csv(data.frame(x = "1970-01-01T12:00:00+12:00"), file = tf, row.names = FALSE)
-try(read_csv_arrow(tf, skip = 1, col_names = "x", col_types = "T"))
-# The timestampe with time zone type must be specified with the `schema()` function.
 read_csv_arrow(
-  tf, skip = 1, col_names = "x",
+  tf,
   col_types = schema(x = timestamp(unit = "us", timezone = "UTC"))
 )
 }

--- a/r/man/read_delim_arrow.Rd
+++ b/r/man/read_delim_arrow.Rd
@@ -219,4 +219,13 @@ write.csv(data.frame(x = c(1, 3), y = c(2, 4)), file = tf, row.names = FALSE)
 read_csv_arrow(tf, schema = schema(x = int32(), y = utf8()), skip = 1)
 read_csv_arrow(tf, col_types = schema(y = utf8()))
 read_csv_arrow(tf, col_types = "ic", col_names = c("x", "y"), skip = 1)
+
+# Note that you can't read a string representing a timestampe with time zone as a timestampe type without time zone.
+write.csv(data.frame(x = "1970-01-01T12:00:00+12:00"), file = tf, row.names = FALSE)
+try(read_csv_arrow(tf, skip = 1, col_names = "x", col_types = "T"))
+# The timestampe with time zone type must be specified with the `schema()` function.
+read_csv_arrow(
+  tf, skip = 1, col_names = "x",
+  col_types = schema(x = timestamp(unit = "us", timezone = "UTC"))
+)
 }

--- a/r/tests/testthat/test-csv.R
+++ b/r/tests/testthat/test-csv.R
@@ -228,7 +228,7 @@ test_that("read_csv_arrow() can read timestamps", {
   # work with schema to specify timestamp with time zone type
   tbl <- tibble::tibble(time = "1970-01-01T12:00:00+12:00")
   write.csv(tbl, tf, row.names = FALSE)
-  df <- read_csv_arrow(tf2, col_types = schema(time = timestamp(unit = "us", timezone = "UTC")))
+  df <- read_csv_arrow(tf, col_types = schema(time = timestamp(unit = "us", timezone = "UTC")))
   expect_equal(df, tibble::tibble(time = as.POSIXct("1970-01-01 00:00:00", tz = "UTC")))
 })
 
@@ -614,7 +614,7 @@ test_that("read_csv_arrow() can read sub-second timestamps with col_types T sett
   expect_equal(df$time, expected, ignore_attr = "tzone")
 })
 
-test_that("Shows a error message when trying to read a timestamp with time zone with col_types = T (ARROW-17429)", {
+test_that("Shows an error message when trying to read a timestamp with time zone with col_types = T (ARROW-17429)", {
   tbl <- tibble::tibble(time = c("1970-01-01T12:00:00+12:00"))
   csv_file <- tempfile()
   on.exit(unlink(csv_file))

--- a/r/tests/testthat/test-csv.R
+++ b/r/tests/testthat/test-csv.R
@@ -610,3 +610,15 @@ test_that("read_csv_arrow() can read sub-second timestamps with col_types T sett
   expected <- as.POSIXct(tbl$time, tz = "UTC")
   expect_equal(df$time, expected, ignore_attr = "tzone")
 })
+
+test_that("read_csv_arrow() can't read timestamps with time zone, with the col_types T setting (ARROW-15602)", {
+  tbl <- tibble::tibble(time = c("1970-01-01T12:00:00+12:00"))
+  csv_file <- tempfile()
+  on.exit(unlink(csv_file))
+  write.csv(tbl, csv_file, row.names = FALSE)
+
+  expect_error(
+    read_csv_arrow(csv_file, col_types = "T", col_names = "time", skip = 1),
+    "CSV conversion error to timestamp\\[ns\\]: expected no zone offset in"
+  )
+})

--- a/r/tests/testthat/test-csv.R
+++ b/r/tests/testthat/test-csv.R
@@ -614,7 +614,7 @@ test_that("read_csv_arrow() can read sub-second timestamps with col_types T sett
   expect_equal(df$time, expected, ignore_attr = "tzone")
 })
 
-test_that("read_csv_arrow() can't read timestamps with time zone, with the col_types T setting (ARROW-15602)", {
+test_that("Shows a error message when trying to read a timestamp with time zone with col_types = T (ARROW-17429)", {
   tbl <- tibble::tibble(time = c("1970-01-01T12:00:00+12:00"))
   csv_file <- tempfile()
   on.exit(unlink(csv_file))

--- a/r/tests/testthat/test-csv.R
+++ b/r/tests/testthat/test-csv.R
@@ -225,8 +225,11 @@ test_that("read_csv_arrow() can read timestamps", {
   # time zones are being read in as time zone-naive, hence ignore_attr = "tzone"
   expect_equal(tbl, df, ignore_attr = "tzone")
 
-  df <- read_csv_arrow(tf, col_types = "T", col_names = "time", skip = 1)
-  expect_equal(tbl, df, ignore_attr = "tzone")
+  # work with schema to specify timestamp with time zone type
+  tbl <- tibble::tibble(time = "1970-01-01T12:00:00+12:00")
+  write.csv(tbl, tf, row.names = FALSE)
+  df <- read_csv_arrow(tf2, col_types = schema(time = timestamp(unit = "us", timezone = "UTC")))
+  expect_equal(df, tibble::tibble(time = as.POSIXct("1970-01-01 00:00:00", tz = "UTC")))
 })
 
 test_that("read_csv_arrow(timestamp_parsers=)", {


### PR DESCRIPTION
If users expect `read_csv_arrow` to behave the same as `readr::read_csv`, they will be confused by the presence or absence of a time zone, so adds a note is provided in the example.
Adds the same example to the test to verify that the error occurs.

Also update the type description to link to the Arrow type documentation.