### PR TITLE
ARROW-17410: [JS][Integration] Downgrade zlib for integration

### DIFF
--- a/ci/docker/conda-integration.dockerfile
+++ b/ci/docker/conda-integration.dockerfile
@@ -35,7 +35,8 @@ RUN mamba install -q -y \
         maven=${maven} \
         nodejs=${node} \
         yarn \
-        openjdk=${jdk} && \
+        openjdk=${jdk} \
+        zlib=1.2.11 && \
     mamba clean --all --force-pkgs-dirs
 
 # Install Rust with only the needed components

--- a/ci/docker/conda-integration.dockerfile
+++ b/ci/docker/conda-integration.dockerfile
@@ -27,6 +27,8 @@ ARG go=1.15
 
 # Install Archery and integration dependencies
 COPY ci/conda_env_archery.txt /arrow/ci/
+
+# Pin zlib to 1.2.11 due to ARROW-17410 until the patch is released
 RUN mamba install -q -y \
         --file arrow/ci/conda_env_archery.txt \
         "python>=3.7" \
@@ -36,7 +38,7 @@ RUN mamba install -q -y \
         nodejs=${node} \
         yarn \
         openjdk=${jdk} \
-        zlib=1.2.11 && \
+        zlib=1.2.11 && \ 
     mamba clean --all --force-pkgs-dirs
 
 # Install Rust with only the needed components


### PR DESCRIPTION
Downgrading to `zlib=1.2.11` fixes the existing issue as reported in https://github.com/madler/zlib/issues/613 until the patch is released.