### PR TITLE
ARROW-17423: [CI][C++] Fix building CUDA docker images

### DIFF
--- a/.env
+++ b/.env
@@ -54,7 +54,7 @@ UBUNTU=20.04
 
 # Default versions for various dependencies
 CLANG_TOOLS=12
-CUDA=9.1
+CUDA=11.4.0
 DASK=latest
 DOTNET=6.0
 GCC_VERSION=""

--- a/.env
+++ b/.env
@@ -54,7 +54,7 @@ UBUNTU=20.04
 
 # Default versions for various dependencies
 CLANG_TOOLS=12
-CUDA=11.4.0
+CUDA=11.0.3
 DASK=latest
 DOTNET=6.0
 GCC_VERSION=""

--- a/dev/archery/archery/docker/core.py
+++ b/dev/archery/archery/docker/core.py
@@ -24,6 +24,7 @@ from dotenv import dotenv_values
 from ruamel.yaml import YAML
 
 from ..utils.command import Command, default_bin
+from ..utils.source import arrow_path
 from ..compat import _ensure_path
 
 
@@ -49,18 +50,6 @@ _arch_alias_mapping = {
     'amd64': 'x86_64',
     'arm64v8': 'aarch64',
 }
-
-_arrow_root = os.environ.get(
-    'ARROW_ROOT',
-    os.path.abspath(__file__).rsplit("/", 5)[0]
-)
-
-
-def _arrow_path(path):
-    """
-    Return full path to a file given its path inside the Arrow repo.
-    """
-    return os.path.join(_arrow_root, path)
 
 
 class UndefinedImage(Exception):
@@ -300,7 +289,7 @@ class DockerCompose(Command):
 
                 args.extend([
                     '--output', 'type=docker',
-                    '-f', _arrow_path(service['build']['dockerfile']),
+                    '-f', arrow_path(service['build']['dockerfile']),
                     '-t', service['image'],
                     service['build'].get('context', '.')
                 ])
@@ -312,7 +301,7 @@ class DockerCompose(Command):
                 for img in cache_from:
                     args.append('--cache-from="{}"'.format(img))
                 args.extend([
-                    '-f', _arrow_path(service['build']['dockerfile']),
+                    '-f', arrow_path(service['build']['dockerfile']),
                     '-t', service['image'],
                     service['build'].get('context', '.')
                 ])

--- a/dev/archery/archery/docker/tests/test_docker.py
+++ b/dev/archery/archery/docker/tests/test_docker.py
@@ -509,7 +509,7 @@ def test_image_with_gpu(arrow_compose_path):
             "-e", "OTHER_ENV=2",
             "-v", "/host:/container:rw",
             "org/ubuntu-cuda",
-            '/bin/bash -c "echo 1 > /tmp/dummy && cat /tmp/dummy"'
+            "/bin/bash", "-c", "echo 1 > /tmp/dummy && cat /tmp/dummy",
         ]
     ]
     with assert_docker_calls(compose, expected_calls):

--- a/dev/archery/archery/integration/runner.py
+++ b/dev/archery/archery/integration/runner.py
@@ -35,8 +35,8 @@ from .tester_rust import RustTester
 from .tester_java import JavaTester
 from .tester_js import JSTester
 from .tester_csharp import CSharpTester
-from .util import (ARROW_ROOT_DEFAULT, guid, SKIP_ARROW, SKIP_FLIGHT,
-                   printer)
+from .util import guid, SKIP_ARROW, SKIP_FLIGHT, printer
+from ..utils.source import ARROW_ROOT_DEFAULT
 from . import datagen
 
 

--- a/dev/archery/archery/integration/tester_cpp.py
+++ b/dev/archery/archery/integration/tester_cpp.py
@@ -20,7 +20,8 @@ import os
 import subprocess
 
 from .tester import Tester
-from .util import run_cmd, ARROW_ROOT_DEFAULT, log
+from .util import run_cmd, log
+from ..utils.source import ARROW_ROOT_DEFAULT
 
 
 _EXE_PATH = os.environ.get(

--- a/dev/archery/archery/integration/tester_csharp.py
+++ b/dev/archery/archery/integration/tester_csharp.py
@@ -18,7 +18,8 @@
 import os
 
 from .tester import Tester
-from .util import run_cmd, ARROW_ROOT_DEFAULT, log
+from .util import run_cmd, log
+from ..utils.source import ARROW_ROOT_DEFAULT
 
 
 _EXE_PATH = os.path.join(

--- a/dev/archery/archery/integration/tester_java.py
+++ b/dev/archery/archery/integration/tester_java.py
@@ -20,7 +20,8 @@ import os
 import subprocess
 
 from .tester import Tester
-from .util import run_cmd, ARROW_ROOT_DEFAULT, log
+from .util import run_cmd, log
+from ..utils.source import ARROW_ROOT_DEFAULT
 
 
 def load_version_from_pom():

--- a/dev/archery/archery/integration/tester_js.py
+++ b/dev/archery/archery/integration/tester_js.py
@@ -18,7 +18,9 @@
 import os
 
 from .tester import Tester
-from .util import run_cmd, ARROW_ROOT_DEFAULT, log
+from .util import run_cmd, log
+from ..utils.source import ARROW_ROOT_DEFAULT
+
 
 _EXE_PATH = os.path.join(ARROW_ROOT_DEFAULT, 'js/bin')
 _VALIDATE = os.path.join(_EXE_PATH, 'integration.js')

--- a/dev/archery/archery/integration/tester_rust.py
+++ b/dev/archery/archery/integration/tester_rust.py
@@ -20,7 +20,8 @@ import os
 import subprocess
 
 from .tester import Tester
-from .util import run_cmd, ARROW_ROOT_DEFAULT, log
+from .util import run_cmd, log
+from ..utils.source import ARROW_ROOT_DEFAULT
 
 
 _EXE_PATH = os.path.join(ARROW_ROOT_DEFAULT, "rust/target/debug")

--- a/dev/archery/archery/integration/util.py
+++ b/dev/archery/archery/integration/util.py
@@ -17,7 +17,6 @@
 
 import contextlib
 import io
-import os
 import random
 import socket
 import subprocess
@@ -35,11 +34,6 @@ def guid():
 # SKIP categories
 SKIP_ARROW = 'arrow'
 SKIP_FLIGHT = 'flight'
-
-ARROW_ROOT_DEFAULT = os.environ.get(
-    'ARROW_ROOT',
-    os.path.abspath(__file__).rsplit("/", 5)[0]
-)
 
 
 class _Printer:

--- a/dev/archery/archery/utils/source.py
+++ b/dev/archery/archery/utils/source.py
@@ -22,6 +22,19 @@ import subprocess
 from .git import git
 
 
+ARROW_ROOT_DEFAULT = os.environ.get(
+    'ARROW_ROOT',
+    Path(__file__).resolve().parents[4]
+)
+
+
+def arrow_path(path):
+    """
+    Return full path to a file given its path inside the Arrow repo.
+    """
+    return os.path.join(ARROW_ROOT_DEFAULT, path)
+
+
 class InvalidArrowSource(Exception):
     pass
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -489,7 +489,14 @@ services:
     ulimits: *ulimits
     environment:
       <<: *ccache
+      ARROW_BUILD_STATIC: "OFF"
       ARROW_CUDA: "ON"
+      ARROW_GANDIVA: "OFF"
+      ARROW_GCS: "OFF"
+      ARROW_ORC: "OFF"
+      ARROW_S3: "OFF"
+      ARROW_SUBSTRAIT: "OFF"
+      ARROW_WITH_OPENTELEMETRY: "OFF"
     volumes: *ubuntu-volumes
     command: *cpp-command
 


### PR DESCRIPTION
* Update the CUDA runtime version as CUDA 9.1 images are not available anymore
* Fix passing child command arguments to "docker run"

Checked locally under a Ubuntu 20.04 host with:
```
UBUNTU=18.04 archery --debug docker run ubuntu-cuda-cpp
UBUNTU=20.04 archery --debug docker run ubuntu-cuda-cpp
```