### PR TITLE
MINOR: [CI][Java] Speed up JNI build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1558,6 +1558,9 @@ services:
     shm_size: *shm-size
     environment:
       <<: *ccache
+      ARROW_BUILD_TESTS: "OFF"
+      ARROW_S3: "OFF"
+      ARROW_SUBSTRAIT: "OFF"
     volumes:
       - .:/arrow:delegated
       - ${DOCKER_VOLUME_PREFIX}maven-cache:/root/.m2:delegated


### PR DESCRIPTION
Currently, Java JNI builds on Github Actions can take one hour due to a very long Arrow C++ build phase
(example: https://github.com/apache/arrow/runs/7881918943?check_suite_focus=true#step:6:3512).

Disable unused Arrow C++ components so as to make the C++ build faster.