### PR TITLE
ARROW-15584: [C++] Add support for Substrait's RelCommon::Emit

### DIFF
--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -439,6 +439,11 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel, const ExtensionSet&
       if (!left_keys || !right_keys) {
         return Status::Invalid("Left keys for join cannot be null");
       }
+
+      // Create output schema from left, right relations and join keys
+      // std::shared_ptr<Schema> left_schema = left.output_schema;
+      // std::shared_ptr<Schema> right_schema = right.output_schema;
+
       compute::HashJoinNodeOptions join_options{{std::move(*left_keys)},
                                                 {std::move(*right_keys)}};
       join_options.join_type = join_type;

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -59,16 +59,12 @@ Result<std::vector<compute::Expression>> GetEmitInfo(
     int32_t map_id = emit.output_mapping(i);
     proj_field_refs[i] = compute::field_ref(FieldRef(map_id));
   }
-  // TODO: return emit size and expression as a tuple
   return std::move(proj_field_refs);
 }
 
 template <typename RelMessage>
 Status CheckRelCommon(const RelMessage& rel) {
   if (rel.has_common()) {
-    // if (rel.common().has_emit()) {
-    //   return Status::NotImplemented("substrait::RelCommon::Emit");
-    // }
     if (rel.common().has_hint()) {
       return Status::NotImplemented("substrait::RelCommon::Hint");
     }

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -143,9 +143,11 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel, const ExtensionSet&
         const substrait::ReadRel::NamedTable& named_table = read.named_table();
         std::vector<std::string> table_names(named_table.names().begin(),
                                              named_table.names().end());
-        ARROW_ASSIGN_OR_RAISE(compute::Declaration source_decl,
+        ARROW_ASSIGN_OR_RAISE(compute::Declaration no_emit_declaration,
                               named_table_provider(table_names));
-        return DeclarationInfo{std::move(source_decl), base_schema};
+        return ProcessEmit(std::move(read),
+                           DeclarationInfo{std::move(no_emit_declaration), base_schema},
+                           std::move(base_schema));
       }
 
       if (!read.has_local_files()) {

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -465,9 +465,9 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel, const ExtensionSet&
             compute::Declaration::Sequence(
                 {std::move(join_dec),
                  {"project", compute::ProjectNodeOptions{std::move(emit_expressions)}}}),
-            num_columns, join_schema};
+            num_columns, std::move(join_schema)};
       } else {
-        return DeclarationInfo{std::move(join_dec), num_columns, join_schema};
+        return DeclarationInfo{std::move(join_dec), num_columns, std::move(join_schema)};
       }
     }
     case substrait::Rel::RelTypeCase::kAggregate: {

--- a/cpp/src/arrow/engine/substrait/relation_internal.h
+++ b/cpp/src/arrow/engine/substrait/relation_internal.h
@@ -38,6 +38,8 @@ struct DeclarationInfo {
 
   /// The number of columns returned by the declaration.
   int num_columns;
+
+  std::shared_ptr<Schema> output_schema;
 };
 
 /// \brief Convert a Substrait Rel object to an Acero declaration

--- a/cpp/src/arrow/engine/substrait/relation_internal.h
+++ b/cpp/src/arrow/engine/substrait/relation_internal.h
@@ -36,9 +36,6 @@ struct DeclarationInfo {
   /// The compute declaration produced thus far.
   compute::Declaration declaration;
 
-  /// The number of columns returned by the declaration.
-  int num_columns;
-
   std::shared_ptr<Schema> output_schema;
 };
 

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -237,7 +237,7 @@ struct EmitValidate {
         combine_chunks(combine_chunks) {}
   void operator()() {
     for (auto sp_ext_id_reg :
-         {std::shared_ptr<ExtensionIdRegistry>(), substrait::MakeExtensionIdRegistry()}) {
+         {std::shared_ptr<ExtensionIdRegistry>(), MakeExtensionIdRegistry()}) {
       ExtensionIdRegistry* ext_id_reg = sp_ext_id_reg.get();
       ExtensionSet ext_set(ext_id_reg);
       ASSERT_OK_AND_ASSIGN(auto sink_decls,
@@ -2255,7 +2255,7 @@ TEST(Substrait, ProjectRel) {
                   }
                 }
               }
-            }, 
+            },
             {
               "value": {
                 "selection": {
@@ -2573,7 +2573,10 @@ TEST(Substrait, FilterRelWithEmit) {
                   }
                 }
               }
-            }]
+            }],
+            "output_type": {
+              "bool": {}
+            }
           }
         },
         "input" : {
@@ -2610,7 +2613,7 @@ TEST(Substrait, FilterRelWithEmit) {
   "extension_uris": [
       {
         "extension_uri_anchor": 0,
-        "uri": ")" + substrait::default_extension_types_uri() +
+        "uri": ")" + std::string(kSubstraitComparisonFunctionsUri) +
                                R"("
       }
     ],
@@ -2758,7 +2761,10 @@ TEST(Substrait, JoinRelWithEmit) {
                   }
                 }
               }
-            }]
+            }],
+            "output_type": {
+              "bool": {}
+            }
           }
         },
         "type": "JOIN_TYPE_INNER"
@@ -2768,7 +2774,7 @@ TEST(Substrait, JoinRelWithEmit) {
   "extension_uris": [
       {
         "extension_uri_anchor": 0,
-        "uri": ")" + substrait::default_extension_types_uri() +
+        "uri": ")" + std::string(kSubstraitComparisonFunctionsUri) +
                                R"("
       }
     ],

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -250,7 +250,7 @@ struct EmitValidate {
       ASSERT_OK_AND_ASSIGN(auto output_table,
                            GetTableFromPlan(acero_plan, declarations, sink_gen,
                                             exec_context, output_schema));
-      EXPECT_TRUE(expected_table->Equals(*output_table));
+      EXPECT_TRUE(expected_table->Equals(*output_table, true));
     }
   }
   std::shared_ptr<Schema> output_schema;
@@ -2210,6 +2210,7 @@ TEST(Substrait, ProjectRel) {
                        arrow::internal::TemporaryDir::Make("substrait_project_tempdir"));
 
   TempDataGenerator datagen(input_table, file_prefix, tempdir);
+  ASSERT_OK(datagen());
   std::string substrait_file_uri = "file://" + datagen.data_file_path;
 
   std::string substrait_json = R"({
@@ -2300,10 +2301,13 @@ TEST(Substrait, ProjectRel) {
     [1, 1, 10, 2],
     [3, 4, 20, 7]
   ])"});
-  EmitValidate(std::move(output_schema), std::move(expected_table), exec_context, buf);
+  EmitValidate(std::move(output_schema), std::move(expected_table), exec_context, buf)();
 }
 
 TEST(Substrait, ProjectRelOnFunctionWithEmit) {
+#ifdef _WIN32
+  GTEST_SKIP() << "ARROW-16392: Substrait File URI not supported for Windows";
+#endif
   compute::ExecContext exec_context;
   auto dummy_schema =
       schema({field("A", int32()), field("B", int32()), field("C", int32())});
@@ -2319,6 +2323,7 @@ TEST(Substrait, ProjectRelOnFunctionWithEmit) {
                                          "substrait_project_emit_tempdir"));
 
   TempDataGenerator datagen(input_table, file_prefix, tempdir);
+  ASSERT_OK(datagen());
   std::string substrait_file_uri = "file://" + datagen.data_file_path;
 
   std::string substrait_json = R"({
@@ -2413,10 +2418,13 @@ TEST(Substrait, ProjectRelOnFunctionWithEmit) {
       [1, 10, 2],
       [3, 20, 7]
   ])"});
-  EmitValidate(std::move(output_schema), std::move(expected_table), exec_context, buf);
+  EmitValidate(std::move(output_schema), std::move(expected_table), exec_context, buf)();
 }
 
 TEST(Substrait, ReadRelWithEmit) {
+#ifdef _WIN32
+  GTEST_SKIP() << "ARROW-16392: Substrait File URI not supported for Windows";
+#endif
   compute::ExecContext exec_context;
   auto dummy_schema =
       schema({field("A", int32()), field("B", int32()), field("C", int32())});
@@ -2432,6 +2440,7 @@ TEST(Substrait, ReadRelWithEmit) {
   std::string file_prefix = "serde_read_emit_test";
 
   TempDataGenerator datagen(input_table, file_prefix, tempdir);
+  ASSERT_OK(datagen());
   std::string substrait_file_uri = "file://" + datagen.data_file_path;
 
   std::string substrait_json = R"({
@@ -2475,7 +2484,131 @@ TEST(Substrait, ReadRelWithEmit) {
       [1, 10],
       [4, 20]
   ])"});
-  EmitValidate(std::move(output_schema), std::move(expected_table), exec_context, buf);
+  EmitValidate(std::move(output_schema), std::move(expected_table), exec_context, buf)();
+}
+
+TEST(Substrait, FilterRelWithEmit) {
+#ifdef _WIN32
+  GTEST_SKIP() << "ARROW-16392: Substrait File URI not supported for Windows";
+#endif
+  compute::ExecContext exec_context;
+  auto dummy_schema = schema({field("A", int32()), field("B", int32()),
+                              field("C", int32()), field("D", int32())});
+
+  // creating a dummy dataset using a dummy table
+  auto input_table = TableFromJSON(dummy_schema, {R"([
+      [10, 1, 80, 7],
+      [20, 2, 70, 6],
+      [30, 3, 30, 5],
+      [40, 4, 20, 4],
+      [40, 5, 40, 3],
+      [20, 6, 20, 2],
+      [30, 7, 30, 1]
+  ])"});
+
+  ASSERT_OK_AND_ASSIGN(auto tempdir,
+                       arrow::internal::TemporaryDir::Make("substrait_read_tempdir"));
+  std::string file_prefix = "serde_read_emit_test";
+
+  TempDataGenerator datagen(input_table, file_prefix, tempdir);
+  ASSERT_OK(datagen());
+  std::string substrait_file_uri = "file://" + datagen.data_file_path;
+
+  std::string substrait_json = R"({
+  "relations": [{
+    "rel": {
+      "filter": {
+        "common": {
+          "emit": {
+            "outputMapping": [1, 3]
+          }
+        },
+        "condition": {
+          "scalarFunction": {
+            "functionReference": 0,
+            "arguments": [{
+              "value": {
+                "selection": {
+                  "directReference": {
+                    "structField": {
+                      "field": 0
+                    }
+                  },
+                  "rootReference": {
+                  }
+                }
+              }
+            }, {
+              "value": {
+                "selection": {
+                  "directReference": {
+                    "structField": {
+                      "field": 2
+                    }
+                  },
+                  "rootReference": {
+                  }
+                }
+              }
+            }]
+          }
+        },
+        "input" : {
+          "read": {
+            "base_schema": {
+              "names": ["A", "B", "C", "D"],
+                "struct": {
+                "types": [{
+                  "i32": {}
+                }, {
+                  "i32": {}
+                }, {
+                  "i32": {}
+                },{
+                  "i32": {}
+                }]
+              }
+            },
+            "local_files": {
+              "items": [
+                {
+                  "uri_file": ")" +
+                               substrait_file_uri +
+                               R"(",
+                  "parquet": {}
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }],
+  "extension_uris": [
+      {
+        "extension_uri_anchor": 0,
+        "uri": ")" + substrait::default_extension_types_uri() +
+                               R"("
+      }
+    ],
+    "extensions": [
+      {"extension_function": {
+        "extension_uri_reference": 0,
+        "function_anchor": 0,
+        "name": "equal"
+      }}
+    ]
+  })";
+
+  ASSERT_OK_AND_ASSIGN(auto buf, internal::SubstraitFromJSON("Plan", substrait_json));
+  auto output_schema = schema({field("B", int32()), field("D", int32())});
+  auto expected_table = TableFromJSON(output_schema, {R"([
+      [3, 5],
+      [5, 3],
+      [6, 2],
+      [7, 1]
+  ])"});
+  EmitValidate(std::move(output_schema), std::move(expected_table), exec_context, buf)();
 }
 
 }  // namespace engine

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -24,12 +24,10 @@
 #include "arrow/dataset/file_base.h"
 #include "arrow/dataset/file_ipc.h"
 #include "arrow/dataset/file_parquet.h"
-
 #include "arrow/dataset/plan.h"
 #include "arrow/dataset/scanner.h"
 #include "arrow/engine/substrait/extension_types.h"
 #include "arrow/engine/substrait/serde.h"
-
 #include "arrow/engine/substrait/util.h"
 
 #include "arrow/filesystem/localfs.h"
@@ -83,6 +81,31 @@ Result<std::shared_ptr<Table>> GetTableFromPlan(
     arrow::AsyncGenerator<util::optional<compute::ExecBatch>>& sink_gen,
     compute::ExecContext& exec_context, std::shared_ptr<Schema>& output_schema) {
   ARROW_ASSIGN_OR_RAISE(auto plan, compute::ExecPlan::Make(&exec_context));
+  ARROW_ASSIGN_OR_RAISE(auto decl, declarations.AddToPlan(plan.get()));
+
+  RETURN_NOT_OK(decl->Validate());
+
+  std::shared_ptr<arrow::RecordBatchReader> sink_reader = compute::MakeGeneratorReader(
+      output_schema, std::move(sink_gen), exec_context.memory_pool());
+
+  RETURN_NOT_OK(plan->Validate());
+  RETURN_NOT_OK(plan->StartProducing());
+  return arrow::Table::FromRecordBatchReader(sink_reader.get());
+}
+
+Status WriteParquetData(const std::string& path,
+                        const std::shared_ptr<fs::FileSystem> file_system,
+                        const std::shared_ptr<Table> input) {
+  EXPECT_OK_AND_ASSIGN(auto buffer_writer, file_system->OpenOutputStream(path));
+  PARQUET_THROW_NOT_OK(parquet::arrow::WriteTable(*input, arrow::default_memory_pool(),
+                                                  buffer_writer, /*chunk_size*/ 1));
+  return buffer_writer->Close();
+}
+
+Result<std::shared_ptr<Table>> GetTableFromPlan(
+    std::shared_ptr<compute::ExecPlan>& plan, compute::Declaration& declarations,
+    arrow::AsyncGenerator<util::optional<compute::ExecBatch>>& sink_gen,
+    compute::ExecContext& exec_context, std::shared_ptr<Schema>& output_schema) {
   ARROW_ASSIGN_OR_RAISE(auto decl, declarations.AddToPlan(plan.get()));
 
   RETURN_NOT_OK(decl->Validate());
@@ -2101,6 +2124,141 @@ TEST(Substrait, BasicPlanRoundTrippingEndToEnd) {
                        GetTableFromPlan(rnd_trp_declarations, rnd_trp_sink_gen,
                                         exec_context, dummy_schema));
   EXPECT_TRUE(expected_table->Equals(*rnd_trp_table));
+}
+
+TEST(Substrait, ProjectRel) {
+  compute::ExecContext exec_context;
+  auto dummy_schema =
+      schema({field("A", int32()), field("B", int32()), field("C", int32())});
+
+  // creating a dummy dataset using a dummy table
+  auto table = TableFromJSON(dummy_schema, {R"([
+      [1, 1, 10],
+      [3, 4, 20]
+  ])"});
+
+  auto format = std::make_shared<arrow::dataset::ParquetFileFormat>();
+  auto filesystem = std::make_shared<fs::LocalFileSystem>();
+
+  const std::string file_name = "serde_project_test.parquet";
+
+  ASSERT_OK_AND_ASSIGN(auto tempdir,
+                       arrow::internal::TemporaryDir::Make("substrait_project_tempdir"));
+  ASSERT_OK_AND_ASSIGN(auto file_path, tempdir->path().Join(file_name));
+  std::string file_path_str = file_path.ToString();
+
+  std::string toReplace("/T//");
+  size_t pos = file_path_str.find(toReplace);
+  file_path_str.replace(pos, toReplace.length(), "/T/");
+
+  ARROW_EXPECT_OK(WriteParquetData(file_path_str, filesystem, table));
+
+  std::string substrait_file_uri = "file://" + file_path_str;
+
+  std::string substrait_json = R"({
+  "relations": [{
+    "rel": {
+      "project": {
+        "expressions": [
+          {"scalarFunction": {
+            "functionReference": 0,
+            "arguments": [{
+              "value": {
+                "selection": {
+                  "directReference": {
+                    "structField": {
+                      "field": 0
+                    }
+                  },
+                  "rootReference": {
+                  }
+                }
+              }
+            }, {
+              "value": {
+                "selection": {
+                  "directReference": {
+                    "structField": {
+                      "field": 1
+                    }
+                  },
+                  "rootReference": {
+                  }
+                }
+              }
+            }]
+          }
+        },
+        ],
+        "input" : {
+          "read": {
+            "base_schema": {
+              "names": ["A", "B", "C"],
+                "struct": {
+                "types": [{
+                  "i32": {}
+                }, {
+                  "i32": {}
+                }, {
+                  "i32": {}
+                }]
+              }
+            },
+            "local_files": {
+              "items": [
+                {
+                  "uri_file": ")" +
+                               substrait_file_uri +
+                               R"(",
+                  "parquet": {}
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }],
+  "extension_uris": [
+      {
+        "extension_uri_anchor": 0,
+        "uri": ")" + substrait::default_extension_types_uri() +
+                               R"("
+      }
+    ],
+    "extensions": [
+      {"extension_function": {
+        "extension_uri_reference": 0,
+        "function_anchor": 0,
+        "name": "add"
+      }}
+    ]
+  })";
+  ASSERT_OK_AND_ASSIGN(auto buf, internal::SubstraitFromJSON("Plan", substrait_json));
+  for (auto sp_ext_id_reg :
+       {std::shared_ptr<ExtensionIdRegistry>(), substrait::MakeExtensionIdRegistry()}) {
+    ExtensionIdRegistry* ext_id_reg = sp_ext_id_reg.get();
+    ExtensionSet ext_set(ext_id_reg);
+    ASSERT_OK_AND_ASSIGN(auto sink_decls,
+                         DeserializePlans(
+                             *buf, [] { return kNullConsumer; }, ext_id_reg, &ext_set));
+    auto other_declrs = sink_decls[0].inputs[0].get<compute::Declaration>();
+    arrow::AsyncGenerator<util::optional<compute::ExecBatch>> sink_gen;
+    auto sink_node_options = compute::SinkNodeOptions{&sink_gen};
+    auto sink_declaration = compute::Declaration({"sink", sink_node_options, "e"});
+    auto declarations = compute::Declaration::Sequence({*other_declrs, sink_declaration});
+    ASSERT_OK_AND_ASSIGN(auto acero_plan, compute::ExecPlan::Make(&exec_context));
+    auto output_schema = schema({field("A", int32()), field("B", int32()),
+                                 field("C", int32()), field("ADD", int32())});
+    auto expected_table = TableFromJSON(output_schema, {R"([
+      [1, 1, 10, 2],
+      [3, 4, 20, 7]
+    ])"});
+    ASSERT_OK_AND_ASSIGN(auto output_table,
+                         GetTableFromPlan(acero_plan, declarations, sink_gen,
+                                          exec_context, output_schema));
+    EXPECT_TRUE(expected_table->Equals(*output_table));
+  }
 }
 
 }  // namespace engine

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -257,16 +257,6 @@ struct EmitValidate {
       }
       ASSERT_OK_AND_ASSIGN(output_table, output_table->CombineChunks());
       EXPECT_TRUE(expected_table->Equals(*output_table));
-
-      // std::cout << "output" << std::endl;
-      // std::cout << std::string(20, '-') << std::endl;
-      // std::cout << output_table->ToString() << std::endl;
-      // std::cout << std::string(20, '-') << std::endl;
-
-      // std::cout << "expected" << std::endl;
-      // std::cout << std::string(20, '-') << std::endl;
-      // std::cout << expected_table->ToString() << std::endl;
-      // std::cout << std::string(20, '-') << std::endl;
     }
   }
   std::shared_ptr<Schema> output_schema;

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -212,7 +212,9 @@ struct TempDataGenerator {
 
     std::string toReplace("/T//");
     size_t pos = data_file_path.find(toReplace);
-    data_file_path.replace(pos, toReplace.length(), "/T/");
+    if (pos >= 0) {
+      data_file_path.replace(pos, toReplace.length(), "/T/");
+    }
 
     ARROW_EXPECT_OK(WriteParquetData(data_file_path, filesystem, input_table));
     return Status::OK();

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -204,18 +204,9 @@ struct TempDataGenerator {
   Status operator()() {
     auto format = std::make_shared<arrow::dataset::ParquetFileFormat>();
     auto filesystem = std::make_shared<fs::LocalFileSystem>();
-
     const std::string file_name = file_prefix + ".parquet";
-
     ARROW_ASSIGN_OR_RAISE(auto file_path, tempdir->path().Join(file_name));
     data_file_path = file_path.ToString();
-
-    std::string toReplace("/T//");
-    size_t pos = data_file_path.find(toReplace);
-    if (pos >= 0) {
-      data_file_path.replace(pos, toReplace.length(), "/T/");
-    }
-
     ARROW_EXPECT_OK(WriteParquetData(data_file_path, filesystem, input_table));
     return Status::OK();
   }

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -255,7 +255,18 @@ struct EmitValidate {
       if (!include_columns.empty()) {
         ASSERT_OK_AND_ASSIGN(output_table, output_table->SelectColumns(include_columns));
       }
+      ASSERT_OK_AND_ASSIGN(output_table, output_table->CombineChunks());
       EXPECT_TRUE(expected_table->Equals(*output_table));
+
+      std::cout << "output" << std::endl;
+      std::cout << std::string(20, '-') << std::endl;
+      std::cout << output_table->ToString() << std::endl;
+      std::cout << std::string(20, '-') << std::endl;
+
+      std::cout << "expected" << std::endl;
+      std::cout << std::string(20, '-') << std::endl;
+      std::cout << expected_table->ToString() << std::endl;
+      std::cout << std::string(20, '-') << std::endl;
     }
   }
   std::shared_ptr<Schema> output_schema;
@@ -2807,6 +2818,122 @@ TEST(Substrait, JoinRelWithEmit) {
   ])"});
   EmitValidate(std::move(output_schema), std::move(expected_table), exec_context, buf,
                std::move(include_columns))();
+}
+
+TEST(Substrait, AggregateRelEmit) {
+#ifdef _WIN32
+  GTEST_SKIP() << "ARROW-16392: Substrait File URI not supported for Windows";
+#endif
+  compute::ExecContext exec_context;
+  auto dummy_schema =
+      schema({field("A", int32()), field("B", int32()), field("C", int32())});
+
+  // creating a dummy dataset using a dummy table
+  auto input_table = TableFromJSON(dummy_schema, {R"([
+      [10, 1, 80],
+      [20, 2, 70],
+      [30, 3, 30],
+      [40, 4, 20],
+      [40, 5, 40],
+      [20, 6, 20],
+      [30, 7, 30]
+  ])"});
+
+  ASSERT_OK_AND_ASSIGN(auto tempdir,
+                       arrow::internal::TemporaryDir::Make("substrait_agg_tempdir"));
+  std::string file_prefix = "serde_agg_emit_test";
+
+  TempDataGenerator datagen(input_table, file_prefix, tempdir);
+  ASSERT_OK(datagen());
+  std::string substrait_file_uri = "file://" + datagen.data_file_path;
+  std::string substrait_json = R"({
+    "relations": [{
+      "rel": {
+        "aggregate": {
+          "input": {
+            "read": {
+              "base_schema": {
+                "names": ["A", "B", "C"],
+                "struct": {
+                  "types": [{
+                    "i32": {}
+                  }, {
+                    "i32": {}
+                  }, {
+                    "i32": {}
+                  }]
+                }
+              },
+              "local_files": {
+                "items": [
+                  {
+                    "uri_file": ")" +
+                               substrait_file_uri +
+                               R"(",
+                    "parquet": {}
+                  }
+                ]
+              }
+            }
+          },
+          "groupings": [{
+            "groupingExpressions": [{
+              "selection": {
+                "directReference": {
+                  "structField": {
+                    "field": 0
+                  }
+                }
+              }
+            }]
+          }],
+          "measures": [{
+            "measure": {
+              "functionReference": 0,
+              "arguments": [{
+                "value": {
+                  "selection": {
+                    "directReference": {
+                      "structField": {
+                        "field": 2
+                      }
+                    }
+                  }
+                }
+            }],
+              "sorts": [],
+              "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+              "invocation": "AGGREGATION_INVOCATION_ALL",
+              "outputType": {
+                "i64": {}
+              }
+            }
+          }]
+        }
+      }
+    }],
+    "extensionUris": [{
+      "extension_uri_anchor": 0,
+      "uri": "https://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic.yaml"
+    }],
+    "extensions": [{
+      "extension_function": {
+        "extension_uri_reference": 0,
+        "function_anchor": 0,
+        "name": "sum"
+      }
+    }],
+  })";
+
+  ASSERT_OK_AND_ASSIGN(auto buf, internal::SubstraitFromJSON("Plan", substrait_json));
+  auto output_schema = schema({field("aggregates", int64()), field("keys", int32())});
+  auto expected_table = TableFromJSON(output_schema, {R"([
+      [80, 10],
+      [90, 20],
+      [60, 30],
+      [60, 40]
+  ])"});
+  EmitValidate(std::move(output_schema), std::move(expected_table), exec_context, buf)();
 }
 
 }  // namespace engine


### PR DESCRIPTION
Adding emit feature for Substrait plan deserialization. 

This PR covers emits for `read`, `filter`, `project`, `join` and `aggregate` operations.