### PR TITLE
ARROW-17449: [Python] Better repr for Buffer, MemoryPool, NativeFile and Codec

### DIFF
--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -775,7 +775,7 @@ cdef class PythonFile(NativeFile):
     As a downside, there is a non-zero redirection cost in translating
     Arrow stream calls to Python method calls.  Furthermore, Python's
     Global Interpreter Lock may limit parallelism in some situations.
- 
+
     Examples
     --------
     >>> import io

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -122,12 +122,12 @@ cdef class NativeFile(_Weakrefable):
         self.close()
 
     def __repr__(self):
-        name = f"{self.__class__.__module__}.{self.__class__.__name__}"
-        return (f"{name}("
-                f"own_file={self.own_file}, "
-                f"is_seekable={self.is_seekable}, "
-                f"is_writable={self.is_writable}, "
-                f"is_readable={self.is_readable})")
+        name = f"pyarrow.{self.__class__.__name__}"
+        return (f"<{name} "
+                f"own_file={self.own_file} "
+                f"is_seekable={self.is_seekable} "
+                f"is_writable={self.is_writable} "
+                f"is_readable={self.is_readable}>")
 
     @property
     def mode(self):
@@ -1062,12 +1062,12 @@ cdef class Buffer(_Weakrefable):
         return self.size
 
     def __repr__(self):
-        name = f"{self.__class__.__module__}.{self.__class__.__name__}"
-        return (f"{name}("
-                f"address={hex(self.address)}, "
-                f"size={self.size}, "
-                f"is_cpu={self.is_cpu}, "
-                f"is_mutable={self.is_mutable})")
+        name = f"pyarrow.{self.__class__.__name__}"
+        return (f"<{name} "
+                f"address={hex(self.address)} "
+                f"size={self.size} "
+                f"is_cpu={self.is_cpu} "
+                f"is_mutable={self.is_mutable}>")
 
     @property
     def size(self):
@@ -2099,10 +2099,10 @@ cdef class Codec(_Weakrefable):
         return pybuf if asbytes else out_buf
 
     def __repr__(self):
-        name = f"{self.__class__.__module__}.{self.__class__.__name__}"
-        return (f"{name}("
-                f"name={self.name}, "
-                f"compression_level={self.compression_level})")
+        name = f"pyarrow.{self.__class__.__name__}"
+        return (f"<{name} "
+                f"name={self.name} "
+                f"compression_level={self.compression_level}>")
 
 
 def compress(object buf, codec='lz4', asbytes=False, memory_pool=None):

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -124,7 +124,6 @@ cdef class NativeFile(_Weakrefable):
     def __repr__(self):
         name = f"{self.__class__.__module__}.{self.__class__.__name__}"
         return (f"{name}("
-                f"{hex(id(self))}, "
                 f"own_file={self.own_file}, "
                 f"is_seekable={self.is_seekable}, "
                 f"is_writable={self.is_writable}, "
@@ -1065,7 +1064,7 @@ cdef class Buffer(_Weakrefable):
     def __repr__(self):
         name = f"{self.__class__.__module__}.{self.__class__.__name__}"
         return (f"{name}("
-                f"{hex(id(self))}, "
+                f"address={hex(self.address)}, "
                 f"size={self.size}, "
                 f"is_cpu={self.is_cpu}, "
                 f"is_mutable={self.is_mutable})")
@@ -2102,7 +2101,6 @@ cdef class Codec(_Weakrefable):
     def __repr__(self):
         name = f"{self.__class__.__module__}.{self.__class__.__name__}"
         return (f"{name}("
-                f"{hex(id(self))}, "
                 f"name={self.name}, "
                 f"compression_level={self.compression_level})")
 

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -124,6 +124,7 @@ cdef class NativeFile(_Weakrefable):
     def __repr__(self):
         name = f"{self.__class__.__module__}.{self.__class__.__name__}"
         return (f"{name}("
+                f"{hex(id(self))}, "
                 f"own_file={self.own_file}, "
                 f"is_seekable={self.is_seekable}, "
                 f"is_writable={self.is_writable}, "
@@ -1064,6 +1065,7 @@ cdef class Buffer(_Weakrefable):
     def __repr__(self):
         name = f"{self.__class__.__module__}.{self.__class__.__name__}"
         return (f"{name}("
+                f"{hex(id(self))}, "
                 f"size={self.size}, "
                 f"is_cpu={self.is_cpu}, "
                 f"is_mutable={self.is_mutable})")
@@ -2100,6 +2102,7 @@ cdef class Codec(_Weakrefable):
     def __repr__(self):
         name = f"{self.__class__.__module__}.{self.__class__.__name__}"
         return (f"{name}("
+                f"{hex(id(self))}, "
                 f"name={self.name}, "
                 f"compression_level={self.compression_level})")
 

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -121,6 +121,14 @@ cdef class NativeFile(_Weakrefable):
     def __exit__(self, exc_type, exc_value, tb):
         self.close()
 
+    def __repr__(self):
+        name = f"{self.__class__.__module__}.{self.__class__.__name__}"
+        return (f"{name}("
+                f"own_file={self.own_file}, "
+                f"is_seekable={self.is_seekable}, "
+                f"is_writable={self.is_writable}, "
+                f"is_readable={self.is_readable})")
+
     @property
     def mode(self):
         """
@@ -1053,6 +1061,13 @@ cdef class Buffer(_Weakrefable):
     def __len__(self):
         return self.size
 
+    def __repr__(self):
+        name = f"{self.__class__.__module__}.{self.__class__.__name__}"
+        return (f"{name}("
+                f"size={self.size}, "
+                f"is_cpu={self.is_cpu}, "
+                f"is_mutable={self.is_mutable})")
+
     @property
     def size(self):
         """
@@ -1964,7 +1979,9 @@ cdef class Codec(_Weakrefable):
     @property
     def compression_level(self):
         """Returns the compression level parameter of the codec"""
-        return frombytes(self.unwrap().compression_level())
+        if self.name == 'snappy':
+            return None
+        return self.unwrap().compression_level()
 
     def compress(self, object buf, asbytes=False, memory_pool=None):
         """
@@ -2079,6 +2096,12 @@ cdef class Codec(_Weakrefable):
             )
 
         return pybuf if asbytes else out_buf
+
+    def __repr__(self):
+        name = f"{self.__class__.__module__}.{self.__class__.__name__}"
+        return (f"{name}("
+                f"name={self.name}, "
+                f"compression_level={self.compression_level})")
 
 
 def compress(object buf, codec='lz4', asbytes=False, memory_pool=None):

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -124,6 +124,7 @@ cdef class NativeFile(_Weakrefable):
     def __repr__(self):
         name = f"pyarrow.{self.__class__.__name__}"
         return (f"<{name} "
+                f"closed={self.closed} "
                 f"own_file={self.own_file} "
                 f"is_seekable={self.is_seekable} "
                 f"is_writable={self.is_writable} "
@@ -774,6 +775,13 @@ cdef class PythonFile(NativeFile):
     As a downside, there is a non-zero redirection cost in translating
     Arrow stream calls to Python method calls.  Furthermore, Python's
     Global Interpreter Lock may limit parallelism in some situations.
+ 
+    Examples
+    --------
+    >>> import io
+    >>> import pyarrow as pa
+    >>> pa.PythonFile(io.BytesIO())
+    <pyarrow.PythonFile closed=False own_file=False is_seekable=False is_writable=True is_readable=False>
     """
     cdef:
         object handle

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1859,6 +1859,17 @@ cdef class Codec(_Weakrefable):
     ------
     ValueError
         If invalid compression value is passed.
+
+    Examples
+    --------
+    >>> import pyarrow as pa
+    >>> pa.Codec.is_available('gzip')
+    True
+    >>> codec = pa.Codec('gzip')
+    >>> codec.name
+    'gzip'
+    >>> codec.compression_level
+    9
     """
 
     def __init__(self, str compression not None, compression_level=None):

--- a/python/pyarrow/memory.pxi
+++ b/python/pyarrow/memory.pxi
@@ -124,7 +124,7 @@ cdef class ProxyMemoryPool(MemoryPool):
 def default_memory_pool():
     """
     Return the process-global memory pool.
-    
+
     Examples
     --------
     >>> default_memory_pool()

--- a/python/pyarrow/memory.pxi
+++ b/python/pyarrow/memory.pxi
@@ -77,11 +77,11 @@ cdef class MemoryPool(_Weakrefable):
         return frombytes(self.pool.backend_name())
 
     def __repr__(self):
-        name = f"{self.__class__.__module__}.{self.__class__.__name__}"
-        return (f"{name}("
-                f"backend_name={self.backend_name}, "
-                f"bytes_allocated={self.bytes_allocated()}, "
-                f"max_memory={self.max_memory()})")
+        name = f"pyarrow.{self.__class__.__name__}"
+        return (f"<{name} "
+                f"backend_name={self.backend_name} "
+                f"bytes_allocated={self.bytes_allocated()} "
+                f"max_memory={self.max_memory()}>")
 
 cdef CMemoryPool* maybe_unbox_memory_pool(MemoryPool memory_pool):
     if memory_pool is None:

--- a/python/pyarrow/memory.pxi
+++ b/python/pyarrow/memory.pxi
@@ -124,6 +124,11 @@ cdef class ProxyMemoryPool(MemoryPool):
 def default_memory_pool():
     """
     Return the process-global memory pool.
+    
+    Examples
+    --------
+    >>> default_memory_pool()
+    <pyarrow.MemoryPool backend_name=... bytes_allocated=0 max_memory=...>
     """
     cdef:
         MemoryPool pool = MemoryPool.__new__(MemoryPool)

--- a/python/pyarrow/memory.pxi
+++ b/python/pyarrow/memory.pxi
@@ -79,7 +79,6 @@ cdef class MemoryPool(_Weakrefable):
     def __repr__(self):
         name = f"{self.__class__.__module__}.{self.__class__.__name__}"
         return (f"{name}("
-                f"{hex(id(self))}, "
                 f"backend_name={self.backend_name}, "
                 f"bytes_allocated={self.bytes_allocated()}, "
                 f"max_memory={self.max_memory()})")

--- a/python/pyarrow/memory.pxi
+++ b/python/pyarrow/memory.pxi
@@ -76,6 +76,12 @@ cdef class MemoryPool(_Weakrefable):
         """
         return frombytes(self.pool.backend_name())
 
+    def __repr__(self):
+        name = f"{self.__class__.__module__}.{self.__class__.__name__}"
+        return (f"{name}("
+                f"backend_name={self.backend_name}, "
+                f"bytes_allocated={self.bytes_allocated()}, "
+                f"max_memory={self.max_memory()})")
 
 cdef CMemoryPool* maybe_unbox_memory_pool(MemoryPool memory_pool):
     if memory_pool is None:

--- a/python/pyarrow/memory.pxi
+++ b/python/pyarrow/memory.pxi
@@ -79,6 +79,7 @@ cdef class MemoryPool(_Weakrefable):
     def __repr__(self):
         name = f"{self.__class__.__module__}.{self.__class__.__name__}"
         return (f"{name}("
+                f"{hex(id(self))}, "
                 f"backend_name={self.backend_name}, "
                 f"bytes_allocated={self.bytes_allocated()}, "
                 f"max_memory={self.max_memory()})")

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -2013,7 +2013,7 @@ cdef class RecordBatch(_PandasConvertible):
         >>> batch = pa.RecordBatch.from_arrays([n_legs, animals],
         ...                                     names=["n_legs", "animals"])
         >>> batch.serialize()
-        <pyarrow.lib.Buffer object at ...>
+        pyarrow.lib.Buffer(address=..., size=..., is_cpu=True, is_mutable=True)
         """
         cdef shared_ptr[CBuffer] buffer
         cdef CIpcWriteOptions options = CIpcWriteOptions.Defaults()

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -2013,7 +2013,7 @@ cdef class RecordBatch(_PandasConvertible):
         >>> batch = pa.RecordBatch.from_arrays([n_legs, animals],
         ...                                     names=["n_legs", "animals"])
         >>> batch.serialize()
-        pyarrow.lib.Buffer(address=..., size=..., is_cpu=True, is_mutable=True)
+        <pyarrow.Buffer address=0x... size=... is_cpu=True is_mutable=True>
         """
         cdef shared_ptr[CBuffer] buffer
         cdef CIpcWriteOptions options = CIpcWriteOptions.Defaults()

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -719,6 +719,12 @@ def test_compression_level(compression):
     if not Codec.is_available(compression):
         pytest.skip("{} support is not built".format(compression))
 
+    codec = Codec(compression)
+    if codec.name == "snappy":
+        assert codec.compression_level is None
+    else:
+        assert isinstance(codec.compression_level, int)
+
     # These codecs do not support a compression level
     no_level = ['snappy']
     if compression in no_level:

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -2065,7 +2065,7 @@ cdef class Schema(_Weakrefable):
         Write schema to Buffer:
 
         >>> schema.serialize()
-        pyarrow.lib.Buffer(address=..., size=..., is_cpu=True, is_mutable=True)
+        <pyarrow.Buffer address=0x... size=... is_cpu=True is_mutable=True>
         """
         cdef:
             shared_ptr[CBuffer] buffer

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -2065,7 +2065,7 @@ cdef class Schema(_Weakrefable):
         Write schema to Buffer:
 
         >>> schema.serialize()
-        <pyarrow.lib.Buffer object at ...>
+        pyarrow.lib.Buffer(address=..., size=..., is_cpu=True, is_mutable=True)
         """
         cdef:
             shared_ptr[CBuffer] buffer


### PR DESCRIPTION
Example:
```python
In [1]: import io
In [2]: import pyarrow as pa

In [3]: pa.PythonFile(io.BytesIO())
Out[3]: <pyarrow.PythonFile closed=False own_file=False is_seekable=False is_writable=True is_readable=False>

In [4]: pa.Codec('gzip')
Out[4]: <pyarrow.Codec name=gzip compression_level=9>

In [5]: pool = pa.default_memory_pool()
In [6]: pool
Out[6]: <pyarrow.MemoryPool backend_name=jemalloc bytes_allocated=0 max_memory=0>

In [7]: pa.allocate_buffer(1024, memory_pool=pool)
Out[7]: <pyarrow.Buffer address=0x7fd660a08000 size=1024 is_cpu=True is_mutable=True
```