### PR TITLE
ARROW-17429: [R] Error messages are not helpful of read_csv_arrow with col_types option

### DIFF
--- a/r/R/dplyr-collect.R
+++ b/r/R/dplyr-collect.R
@@ -24,8 +24,8 @@ collect.arrow_dplyr_query <- function(x, as_data_frame = TRUE, ...) {
     # n = 4 because we want the error to show up as being from collect()
     # and not handle_csv_read_error()
     error = function(e, call = caller_env(n = 4)) {
-      handle_csv_read_error(e, x$.data$schema, call)
       handle_augmented_field_misuse(e, call)
+      handle_csv_read_error(e, x$.data$schema, call)
       abort(conditionMessage(e), call = call)
     }
   )

--- a/r/R/util.R
+++ b/r/R/util.R
@@ -225,8 +225,8 @@ handle_csv_read_error <- function(e, schema, call) {
         "header being read in as data."
       )
     )
-    abort(msg, call = call)
   }
+  abort(msg, call = call)
 }
 
 # This function only raises an error if

--- a/r/tests/testthat/test-csv.R
+++ b/r/tests/testthat/test-csv.R
@@ -610,3 +610,15 @@ test_that("read_csv_arrow() can read sub-second timestamps with col_types T sett
   expected <- as.POSIXct(tbl$time, tz = "UTC")
   expect_equal(df$time, expected, ignore_attr = "tzone")
 })
+
+test_that("read_csv_arrow() can't read timestamps with time zone, with the col_types T setting (ARROW-15602)", {
+  tbl <- tibble::tibble(time = c("1970-01-01T12:00:00+12:00"))
+  csv_file <- tempfile()
+  on.exit(unlink(csv_file))
+  write.csv(tbl, csv_file, row.names = FALSE)
+
+  expect_error(
+    read_csv_arrow(csv_file, col_types = "T", col_names = "time", skip = 1),
+    "CSV conversion error to timestamp\\[ns\\]: expected no zone offset in"
+  )
+})


### PR DESCRIPTION
This PR solves the problem introduced by #12826 and adds a test case to prevent the problem from being reintroduced.
The test case was copied from #13877 that discovered this problem.

Note that this PR only maintains the behavior of the currently released version, as a version containing this issue has not yet been released.