### PR TITLE
ARROW-17476: [Release][Packaging] Make binary uploader reusable from datafusion-c

### DIFF
--- a/dev/release/05-binary-upload.sh
+++ b/dev/release/05-binary-upload.sh
@@ -127,6 +127,9 @@ docker_run \
     APT_TARGETS=$(IFS=,; echo "${apt_targets[*]}") \
     ARTIFACTORY_API_KEY="${ARTIFACTORY_API_KEY}" \
     ARTIFACTS_DIR="${tmp_dir}/artifacts" \
+    DEB_PACKAGE_NAME=${DEB_PACKAGE_NAME:-} \
+    DRY_RUN=${DRY_RUN:-no} \
+    GPG_KEY_ID="${GPG_KEY_ID}" \
     RC=${rc} \
     STAGING=${STAGING:-no} \
     VERSION=${version} \

--- a/dev/release/binary-task.rb
+++ b/dev/release/binary-task.rb
@@ -292,7 +292,7 @@ class BinaryTask
 
     def request(method, headers, url, body: nil, &block)
       request = build_request(method, url, headers, body: body)
-      if ENV["DRY_RUN"]
+      if ENV["DRY_RUN"] == "yes"
         case request
         when Net::HTTP::Get, Net::HTTP::Head
         else
@@ -1302,10 +1302,13 @@ APT::FTPArchive::Release::Description "#{apt_repository_description}";
             Dir.glob("#{source_dir_prefix}*/**/*") do |path|
               next if File.directory?(path)
               base_name = File.basename(path)
-              if base_name.start_with?("apache-arrow-apt-source")
-                package_name = "apache-arrow-apt-source"
-              else
-                package_name = "apache-arrow"
+              package_name = ENV["DEB_PACKAGE_NAME"]
+              if package_name.nil? or package_name.empty?
+                if base_name.start_with?("apache-arrow-apt-source")
+                  package_name = "apache-arrow-apt-source"
+                else
+                  package_name = "apache-arrow"
+                end
               end
               destination_path = [
                 pool_dir,


### PR DESCRIPTION
Binary uploader is dev/release/05-binary-upload.sh and
dev/release/post-02-binary.sh. We need to customize .deb package
name.

This also adds missing environment variable entries.