### PR TITLE
MINOR: [C++] Fix StringFormatter type error in localfs_benchmark

### DIFF
--- a/cpp/src/arrow/filesystem/localfs_benchmark.cc
+++ b/cpp/src/arrow/filesystem/localfs_benchmark.cc
@@ -66,7 +66,7 @@ class LocalFSFixture : public benchmark::Fixture {
                                   arrow::internal::PlatformFilename cur_root_dir) {
     ASSERT_OK(arrow::internal::CreateDir(cur_root_dir));
 
-    arrow::internal::StringFormatter<DoubleType> format;
+    arrow::internal::StringFormatter<Int64Type> format;
     for (size_t i = 0; i < num_files_; ++i) {
       std::string fname = "file_";
       format(i, [&fname](util::string_view formatted) {

--- a/cpp/src/arrow/filesystem/localfs_benchmark.cc
+++ b/cpp/src/arrow/filesystem/localfs_benchmark.cc
@@ -67,7 +67,7 @@ class LocalFSFixture : public benchmark::Fixture {
 
     for (size_t i = 0; i < num_files_; ++i) {
       ASSERT_OK_AND_ASSIGN(auto path,
-                           cur_root_dir.Join(std::string {"file_" + std::to_string(i)}));
+                           cur_root_dir.Join(std::string{"file_" + std::to_string(i)}));
       ASSERT_OK(MakeEmptyFile(path.ToString()));
     }
 
@@ -77,7 +77,7 @@ class LocalFSFixture : public benchmark::Fixture {
 
     for (size_t i = 0; i < num_dirs_; ++i) {
       ASSERT_OK_AND_ASSIGN(auto path,
-                           cur_root_dir.Join(std::string {"dir_" + std::to_string(i)}));
+                           cur_root_dir.Join(std::string{"dir_" + std::to_string(i)}));
       InitializeDatasetStructure(cur_nesting_level + 1, std::move(path));
     }
   }

--- a/cpp/src/arrow/filesystem/localfs_benchmark.cc
+++ b/cpp/src/arrow/filesystem/localfs_benchmark.cc
@@ -27,7 +27,6 @@
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/random.h"
 #include "arrow/util/async_generator.h"
-#include "arrow/util/formatting.h"
 #include "arrow/util/io_util.h"
 #include "arrow/util/make_unique.h"
 #include "arrow/util/string_view.h"

--- a/cpp/src/arrow/filesystem/localfs_benchmark.cc
+++ b/cpp/src/arrow/filesystem/localfs_benchmark.cc
@@ -66,13 +66,9 @@ class LocalFSFixture : public benchmark::Fixture {
                                   arrow::internal::PlatformFilename cur_root_dir) {
     ASSERT_OK(arrow::internal::CreateDir(cur_root_dir));
 
-    arrow::internal::StringFormatter<Int64Type> format;
     for (size_t i = 0; i < num_files_; ++i) {
-      std::string fname = "file_";
-      format(i, [&fname](util::string_view formatted) {
-        fname.append(formatted.data(), formatted.size());
-      });
-      ASSERT_OK_AND_ASSIGN(auto path, cur_root_dir.Join(std::move(fname)));
+      ASSERT_OK_AND_ASSIGN(auto path,
+                           cur_root_dir.Join(std::string {"file_" + std::to_string(i)}));
       ASSERT_OK(MakeEmptyFile(path.ToString()));
     }
 
@@ -81,11 +77,8 @@ class LocalFSFixture : public benchmark::Fixture {
     }
 
     for (size_t i = 0; i < num_dirs_; ++i) {
-      std::string dirname = "dir_";
-      format(i, [&dirname](util::string_view formatted) {
-        dirname.append(formatted.data(), formatted.size());
-      });
-      ASSERT_OK_AND_ASSIGN(auto path, cur_root_dir.Join(std::move(dirname)));
+      ASSERT_OK_AND_ASSIGN(auto path,
+                           cur_root_dir.Join(std::string {"dir_" + std::to_string(i)}));
       InitializeDatasetStructure(cur_nesting_level + 1, std::move(path));
     }
   }

--- a/cpp/src/arrow/filesystem/localfs_benchmark.cc
+++ b/cpp/src/arrow/filesystem/localfs_benchmark.cc
@@ -66,7 +66,7 @@ class LocalFSFixture : public benchmark::Fixture {
                                   arrow::internal::PlatformFilename cur_root_dir) {
     ASSERT_OK(arrow::internal::CreateDir(cur_root_dir));
 
-    arrow::internal::StringFormatter<Int32Type> format;
+    arrow::internal::StringFormatter<DoubleType> format;
     for (size_t i = 0; i < num_files_; ++i) {
       std::string fname = "file_";
       format(i, [&fname](util::string_view formatted) {


### PR DESCRIPTION
since size_t is passed as the first argument to the StringFormatter, it
needs to be templated with Int64Type instead of Int32Type