### PR TITLE
ARROW-14045  [R] Support for .keep_all = TRUE with distinct()

### DIFF
--- a/r/R/dplyr-distinct.R
+++ b/r/R/dplyr-distinct.R
@@ -30,12 +30,9 @@ distinct.arrow_dplyr_query <- function(.data, ..., .keep_all = FALSE) {
     .data <- dplyr::group_by(.data, !!!syms(names(.data)))
   }
   if (isTRUE(.keep_all)) {
-    # (TODO) `.keep_all = TRUE` can return first row value, but this implementation
-    # do not always return it because `hash_one` skips rows if they contain null value.
-    # If group vars do not uniquely determine return values of each cols,
-    # the result will become different from the original.
-    # If NOT, this option may distroy data.
-    warning(".keep_all = TRUE currently not guarantee to take first row value in each cols.")
+    # (TODO) `.keep_all = TRUE` return first row value, but this implementation
+    # do NOT always return the same result because `hash_one` skips rows if they contain null value.
+    # This option may distroy data if the first row of each group contain null value.
     keeps <- names(.data)[!(names(.data) %in% .data$group_by_vars)]
     # `one()` is wrapper for calling "hash_one" function (implemented ARROW-13993)
     # `USAGE: summarize(x = one(x), y = one(y) ...)` for x, y in non-group cols

--- a/r/R/dplyr-distinct.R
+++ b/r/R/dplyr-distinct.R
@@ -30,9 +30,11 @@ distinct.arrow_dplyr_query <- function(.data, ..., .keep_all = FALSE) {
     .data <- dplyr::group_by(.data, !!!syms(names(.data)))
   }
   if (isTRUE(.keep_all)) {
-    # (TODO) `.keep_all = TRUE` return first row value, but this implementation
-    # do NOT always return the same result because `hash_one` skips rows if they contain null value.
-    # This option may distroy data if the first row of each group contain null value.
+    # (TODO) `.keep_all = TRUE` return first row value,
+    # but this implementation do NOT always return the same result
+    # because `hash_one` skips rows if they contain null value.
+    # Skipping null values is happened by each cols,
+    # so this option has possiblity to destory data.
     keeps <- names(.data)[!(names(.data) %in% .data$group_by_vars)]
     # `one()` is wrapper for calling "hash_one" function (implemented ARROW-13993)
     # `USAGE: summarize(x = one(x), y = one(y) ...)` for x, y in non-group cols

--- a/r/R/dplyr-distinct.R
+++ b/r/R/dplyr-distinct.R
@@ -29,7 +29,7 @@ distinct.arrow_dplyr_query <- function(.data, ..., .keep_all = FALSE) {
     # distinct() with no vars specified means distinct across all cols
     .data <- dplyr::group_by(.data, !!!syms(names(.data)))
   }
-  if (.keep_all == TRUE) {
+  if (isTRUE(.keep_all)) {
     # (TODO) `.keep_all = TRUE` can return first row value, but this implementation
     # do not always return it because `hash_one` skips rows if they contain null value.
     # If group vars do not uniquely determine return values of each cols,

--- a/r/R/dplyr-summarize.R
+++ b/r/R/dplyr-summarize.R
@@ -159,6 +159,13 @@ register_bindings_aggregate <- function() {
       options = list(skip_nulls = na.rm, min_count = 0L)
     )
   })
+  register_binding_agg("one", function(...) {
+    list(
+      fun = "one",
+      data = ensure_one_arg(list2(...), "one"),
+      options = list()
+    )
+  })
 }
 
 # we register 2 versions of the "::" binding - one for use with agg_funcs

--- a/r/src/compute.cpp
+++ b/r/src/compute.cpp
@@ -188,6 +188,14 @@ std::shared_ptr<arrow::compute::FunctionOptions> make_compute_options(
     return out;
   }
 
+  if (func_name == "one" || func_name == "hash_one") {
+    // (TODO) FunctionOption for `hash_one` has not been implemented yet, so ScalarAggregateOptions is used tentatively here. 
+    using Options = arrow::compute::ScalarAggregateOptions;
+    auto out = std::make_shared<Options>(Options::Defaults());
+
+    return out;
+  }
+
   if (func_name == "tdigest" || func_name == "hash_tdigest") {
     using Options = arrow::compute::TDigestOptions;
     auto out = std::make_shared<Options>(Options::Defaults());

--- a/r/src/compute.cpp
+++ b/r/src/compute.cpp
@@ -176,7 +176,8 @@ std::shared_ptr<arrow::compute::FunctionOptions> make_compute_options(
       func_name == "hash_approximate_median" || func_name == "mean" ||
       func_name == "hash_mean" || func_name == "min_max" || func_name == "hash_min_max" ||
       func_name == "min" || func_name == "hash_min" || func_name == "max" ||
-      func_name == "hash_max" || func_name == "sum" || func_name == "hash_sum") {
+      func_name == "hash_max" || func_name == "sum" || func_name == "hash_sum" ||
+      func_name == "hash_one" || func_name == "one") {
     using Options = arrow::compute::ScalarAggregateOptions;
     auto out = std::make_shared<Options>(Options::Defaults());
     if (!Rf_isNull(options["min_count"])) {
@@ -185,15 +186,6 @@ std::shared_ptr<arrow::compute::FunctionOptions> make_compute_options(
     if (!Rf_isNull(options["skip_nulls"])) {
       out->skip_nulls = cpp11::as_cpp<bool>(options["skip_nulls"]);
     }
-    return out;
-  }
-
-  if (func_name == "one" || func_name == "hash_one") {
-    // (TODO) FunctionOption for `hash_one` has not been implemented yet, so
-    // ScalarAggregateOptions is used tentatively here.
-    using Options = arrow::compute::ScalarAggregateOptions;
-    auto out = std::make_shared<Options>(Options::Defaults());
-
     return out;
   }
 

--- a/r/src/compute.cpp
+++ b/r/src/compute.cpp
@@ -189,7 +189,8 @@ std::shared_ptr<arrow::compute::FunctionOptions> make_compute_options(
   }
 
   if (func_name == "one" || func_name == "hash_one") {
-    // (TODO) FunctionOption for `hash_one` has not been implemented yet, so ScalarAggregateOptions is used tentatively here. 
+    // (TODO) FunctionOption for `hash_one` has not been implemented yet, so
+    // ScalarAggregateOptions is used tentatively here.
     using Options = arrow::compute::ScalarAggregateOptions;
     auto out = std::make_shared<Options>(Options::Defaults());
 


### PR DESCRIPTION
I have experimentally implemented .keep_all = TRUE using [`hash_one`](https://issues.apache.org/jira/browse/ARROW-13993). This implementation will not pass the test skipped currently.

There are two known issues. 
First, since `hash_one` is currently executed for each field, data may be corrupted if fields contain nulls (i.e., nulls are skipped and changed to other values, this may generate rows that did not exist in original data). It will be a serious problem when group vars can not uniquely determine one row.  `.keep_all = TRUE` will make a warning about this, but I'm concerned that the user may miss it.
Second, it does not support the factor type. This may be solved when FunctionOption for hash_one is implemented. `ScalarAggregateOptions` is tantavitively used.