### PR TITLE
ARROW-17485: [R] Allow TRUE/FALSE to the compression option of `write_feather` (`write_ipc_file`)

### DIFF
--- a/r/R/feather.R
+++ b/r/R/feather.R
@@ -40,7 +40,9 @@
 #' "uncompressed". "zstd" is the other available codec and generally has better
 #' compression ratios in exchange for slower read and write performance.
 #' "lz4" is shorthand for the "lz4_frame" codec.
-#' See [codec_is_available()] for details. This option is not supported for V1.
+#' See [codec_is_available()] for details.
+#' `TRUE` and `FALSE` can also be used in place of "default" and "uncompressed".
+#' This option is not supported for V1.
 #' @param compression_level If `compression` is "zstd", you may
 #' specify an integer compression level. If omitted, the compression codec's
 #' default compression level is used.
@@ -73,6 +75,9 @@ write_feather <- function(x,
   # Handle and validate options before touching data
   version <- as.integer(version)
   assert_that(version %in% 1:2)
+
+  if (isTRUE(compression)) compression <- "default"
+  if (isFALSE(compression)) compression <- "uncompressed"
 
   # TODO(ARROW-17221): if (missing(compression)), we could detect_compression(sink) here
   compression <- match.arg(compression)

--- a/r/man/write_feather.Rd
+++ b/r/man/write_feather.Rd
@@ -39,7 +39,9 @@ random row access. Default is 64K. This option is not supported for V1.}
 "uncompressed". "zstd" is the other available codec and generally has better
 compression ratios in exchange for slower read and write performance.
 "lz4" is shorthand for the "lz4_frame" codec.
-See \code{\link[=codec_is_available]{codec_is_available()}} for details. This option is not supported for V1.}
+See \code{\link[=codec_is_available]{codec_is_available()}} for details.
+\code{TRUE} and \code{FALSE} can also be used in place of "default" and "uncompressed".
+This option is not supported for V1.}
 
 \item{compression_level}{If \code{compression} is "zstd", you may
 specify an integer compression level. If omitted, the compression codec's

--- a/r/tests/testthat/test-feather.R
+++ b/r/tests/testthat/test-feather.R
@@ -73,7 +73,13 @@ expect_feather_roundtrip <- function(write_fun) {
 test_that("feather read/write round trip", {
   expect_feather_roundtrip(function(x, f) write_feather(x, f, version = 1))
   expect_feather_roundtrip(function(x, f) write_feather(x, f, version = 2))
+  expect_feather_roundtrip(function(x, f) write_feather(x, f, version = 2, compression = TRUE))
+  expect_feather_roundtrip(function(x, f) write_feather(x, f, version = 2, compression = "uncompressed"))
+  expect_feather_roundtrip(function(x, f) write_feather(x, f, version = 2, compression = FALSE))
   expect_feather_roundtrip(function(x, f) write_ipc_file(x, f))
+  expect_feather_roundtrip(function(x, f) write_ipc_file(x, f, compression = TRUE))
+  expect_feather_roundtrip(function(x, f) write_ipc_file(x, f, compression = "uncompressed"))
+  expect_feather_roundtrip(function(x, f) write_ipc_file(x, f, compression = FALSE))
   expect_feather_roundtrip(function(x, f) write_feather(x, f, chunk_size = 32))
   expect_feather_roundtrip(function(x, f) write_ipc_file(x, f, chunk_size = 32))
   if (codec_is_available("lz4")) {


### PR DESCRIPTION
Allows `TRUE` and `FALSE` to be used in place of `"default"` or `"uncompressed"`; `FALSE` is much easier to type than `"uncompressed"` and less likely to be typod.