### PR TITLE
ARROW-8567: [Python] Fix a bug that pa.array() may ignore "safe=False"

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -79,10 +79,10 @@ cdef _ndarray_to_array(object values, object mask, DataType type,
         shared_ptr[CDataType] c_type
         CCastOptions cast_options = CCastOptions(safe)
 
-    if safe:
-        c_type = _ndarray_to_type(values, type)
-    else:
+    if type and not safe:
         c_type = _ndarray_to_type(values, None)
+    else:
+        c_type = _ndarray_to_type(values, type)
 
     with nogil:
         check_status(NdarrayToArrow(pool, values, mask, from_pandas,
@@ -92,7 +92,7 @@ cdef _ndarray_to_array(object values, object mask, DataType type,
         array = pyarrow_wrap_chunked_array(chunked_out)
     else:
         array = pyarrow_wrap_array(chunked_out.get().chunk(0))
-    if not safe:
+    if type and not safe:
         array = array.cast(type, safe=safe)
     return array
 

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1224,7 +1224,7 @@ def test_union_array_slice():
             assert arr[i:j].to_pylist() == lst[i:j]
 
 
-def _check_cast_case(case, *, safe=True, check_array_construction=True):
+def _check_cast_case(case, *, safe=True):
     in_data, in_type, out_data, out_type = case
     if isinstance(out_data, pa.Array):
         assert out_data.type == out_type
@@ -1244,9 +1244,8 @@ def _check_cast_case(case, *, safe=True, check_array_construction=True):
 
     # constructing an array with out type which optionally involves casting
     # for more see ARROW-1949
-    if check_array_construction:
-        in_arr = pa.array(in_data, type=out_type, safe=safe)
-        assert in_arr.equals(expected)
+    in_arr = pa.array(in_data, type=out_type, safe=safe)
+    assert in_arr.equals(expected)
 
 
 def test_cast_integers_safe():
@@ -1441,9 +1440,7 @@ def test_decimal_to_int_value_out_of_bounds():
                            match='Integer value out of bounds'):
             _check_cast_case(case)
 
-        # XXX `safe=False` can be ignored when constructing an array
-        # from a sequence of Python objects (ARROW-8567)
-        _check_cast_case(case, safe=False, check_array_construction=False)
+        _check_cast_case(case, safe=False)
 
 
 def test_decimal_to_int_non_integer():


### PR DESCRIPTION
The root cause of this problem is that ConvertPySequence ignores safe=False option when type is specified. There are two ways to resolve this:

- Add support for safe=False option in ConvertPySequence
- First, convert a Python List to a pyarrow.Array with type=None and then cast with type and safe=False like `pa.array([Decimal('1234')], pa.int8(), safe=False)` -> `pa.array([Decimal('1234')]).cast(pa.int8(), safe=False)`

I took the latter approach because the approach can avoid reimplementation. However, the approach needs more CPU and memory resources.