### PR TITLE
ARROW-17496: [Go] Fix Nightly Build

### DIFF
--- a/go/arrow/flight/flightsql/example/sql_batch_reader.go
+++ b/go/arrow/flight/flightsql/example/sql_batch_reader.go
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build go1.17
-// +build go1.17
+//go:build go1.18
+// +build go1.18
 
 package example
 

--- a/go/arrow/flight/flightsql/example/sqlite_info.go
+++ b/go/arrow/flight/flightsql/example/sqlite_info.go
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build go1.17
-// +build go1.17
+//go:build go1.18
+// +build go1.18
 
 package example
 

--- a/go/arrow/flight/flightsql/example/sqlite_server.go
+++ b/go/arrow/flight/flightsql/example/sqlite_server.go
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build go1.17
-// +build go1.17
+//go:build go1.18
+// +build go1.18
 
 // Package example contains a FlightSQL Server implementation using
 // sqlite as the backing engine.
@@ -30,9 +30,10 @@
 // package, it's easy to swap them out if desired as the modernc.org/sqlite
 // package is slower than go-sqlite3.
 //
-// One other important note is that modernc.org/sqlite only works in go
-// 1.17+ so this entire package is given the build constraint to only
-// build when using go1.17 or higher
+// One other important note is that modernc.org/sqlite only works
+// correctly (specifically pragma_table_info) in go 1.18+ so this
+// entire package is given the build constraint to only build when
+// using go1.18 or higher
 package example
 
 import (

--- a/go/arrow/flight/flightsql/example/sqlite_tables_schema_batch_reader.go
+++ b/go/arrow/flight/flightsql/example/sqlite_tables_schema_batch_reader.go
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build go1.17
-// +build go1.17
+//go:build go1.18
+// +build go1.18
 
 package example
 

--- a/go/arrow/flight/flightsql/example/type_info.go
+++ b/go/arrow/flight/flightsql/example/type_info.go
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build go1.17
-// +build go1.17
+//go:build go1.18
+// +build go1.18
 
 package example
 

--- a/go/arrow/flight/flightsql/sqlite_server_test.go
+++ b/go/arrow/flight/flightsql/sqlite_server_test.go
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build go1.17
-// +build go1.17
+//go:build go1.18
+// +build go1.18
 
 package flightsql_test
 


### PR DESCRIPTION
Turns out that the `pragma_table_info` function in modernc.org/sqlite's package doesn't work correctly in go1.17 either, only in go1.18. As this is only used for testing and the example sqlite flightsql server, rather than anything needed in the flightsql package itself, the bulid failure is easily solved by marking the example and its tests to be only built in go1.18.

As we already have a git workflow that runs with go1.18, the CI will still continue to test the example code, but mamba builds using go1.17 won't break anymore.