### PR TITLE
ARROW-17500: [Go] Kernel and KernelContext interfaces

### DIFF
--- a/go/arrow/compute/expression.go
+++ b/go/arrow/compute/expression.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/apache/arrow/go/v10/arrow"
 	"github.com/apache/arrow/go/v10/arrow/array"
+	"github.com/apache/arrow/go/v10/arrow/compute/internal"
 	"github.com/apache/arrow/go/v10/arrow/internal/debug"
 	"github.com/apache/arrow/go/v10/arrow/ipc"
 	"github.com/apache/arrow/go/v10/arrow/memory"
@@ -375,7 +376,7 @@ func (c *Call) Hash() uint64 {
 	h.WriteString(c.funcName)
 	c.cachedHash = h.Sum64()
 	for _, arg := range c.args {
-		c.cachedHash = hashCombine(c.cachedHash, arg.Hash())
+		c.cachedHash = internal.HashCombine(c.cachedHash, arg.Hash())
 	}
 	return c.cachedHash
 }

--- a/go/arrow/compute/internal/hash_util.go
+++ b/go/arrow/compute/internal/hash_util.go
@@ -14,11 +14,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package compute
+package internal
+
+import "hash/maphash"
+
+var hashSeed = maphash.MakeSeed()
 
 // ADAPTED FROM HASH UTILITIES FOR BOOST
 
-func hashCombine(seed, value uint64) uint64 {
+func HashCombine(seed, value uint64) uint64 {
 	seed ^= value + 0x9e3779b9 + (seed << 6) + (seed >> 2)
 	return seed
 }

--- a/go/arrow/compute/internal/kernel.go
+++ b/go/arrow/compute/internal/kernel.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/apache/arrow/go/v10/arrow"
 	"github.com/apache/arrow/go/v10/arrow/bitutil"
+	"github.com/apache/arrow/go/v10/arrow/internal/debug"
 	"github.com/apache/arrow/go/v10/arrow/memory"
-	"github.com/apache/arrow/go/v10/parquet/internal/debug"
 	"golang.org/x/exp/constraints"
 	"golang.org/x/exp/slices"
 )
@@ -90,7 +90,7 @@ type sameTypeIDMatcher struct {
 }
 
 func (s sameTypeIDMatcher) Matches(typ arrow.DataType) bool { return s.accepted == typ.ID() }
-func (s *sameTypeIDMatcher) Equals(other TypeMatcher) bool {
+func (s sameTypeIDMatcher) Equals(other TypeMatcher) bool {
 	if s == other {
 		return true
 	}

--- a/go/arrow/compute/internal/kernel.go
+++ b/go/arrow/compute/internal/kernel.go
@@ -1,0 +1,420 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"hash/maphash"
+	"strings"
+
+	"github.com/apache/arrow/go/v10/arrow"
+	"github.com/apache/arrow/go/v10/arrow/bitutil"
+	"github.com/apache/arrow/go/v10/arrow/memory"
+	"golang.org/x/exp/constraints"
+	"golang.org/x/exp/slices"
+)
+
+type ctxAllocKey struct{}
+
+func WithAllocator(ctx context.Context, mem memory.Allocator) context.Context {
+	return context.WithValue(ctx, ctxAllocKey{}, mem)
+}
+
+func GetAllocator(ctx context.Context) memory.Allocator {
+	mem, ok := ctx.Value(ctxAllocKey{}).(memory.Allocator)
+	if !ok {
+		return memory.DefaultAllocator
+	}
+	return mem
+}
+
+type Kernel interface {
+	GetInitFn() KernelInitFn
+	GetSig() *KernelSignature
+}
+
+type KernelCtx struct {
+	Ctx    context.Context
+	Kernel Kernel
+	State  KernelState
+}
+
+func (k *KernelCtx) Allocate(bufsize int) *memory.Buffer {
+	buf := memory.NewResizableBuffer(GetAllocator(k.Ctx))
+	buf.Resize(bufsize)
+	return buf
+}
+
+func (k *KernelCtx) AllocateBitmap(nbits int64) *memory.Buffer {
+	nbytes := bitutil.BytesForBits(nbits)
+	return k.Allocate(int(nbytes))
+}
+
+type TypeMatcher interface {
+	fmt.Stringer
+	Matches(typ arrow.DataType) bool
+	Equals(other TypeMatcher) bool
+}
+
+type sameTypeIDMatcher struct {
+	accepted arrow.Type
+}
+
+func (s sameTypeIDMatcher) Matches(typ arrow.DataType) bool { return s.accepted == typ.ID() }
+func (s *sameTypeIDMatcher) Equals(other TypeMatcher) bool {
+	if s == other {
+		return true
+	}
+
+	o, ok := other.(*sameTypeIDMatcher)
+	if !ok {
+		return false
+	}
+
+	return s.accepted == o.accepted
+}
+
+func (s sameTypeIDMatcher) String() string {
+	return "Type::" + s.accepted.String()
+}
+
+func SameTypeID(id arrow.Type) TypeMatcher { return &sameTypeIDMatcher{id} }
+
+type timeUnitMatcher struct {
+	id   arrow.Type
+	unit arrow.TimeUnit
+}
+
+func (s timeUnitMatcher) Matches(typ arrow.DataType) bool {
+	if typ.ID() != s.id {
+		return false
+	}
+	return s.unit == typ.(arrow.TemporalWithUnit).TimeUnit()
+}
+
+func (s timeUnitMatcher) String() string {
+	return strings.ToLower(s.id.String()) + "(" + s.unit.String() + ")"
+}
+
+func (s *timeUnitMatcher) Equals(other TypeMatcher) bool {
+	if s == other {
+		return true
+	}
+
+	o, ok := other.(*timeUnitMatcher)
+	if !ok {
+		return false
+	}
+	return o.id == s.id && o.unit == s.unit
+}
+
+func TimestampTypeUnit(unit arrow.TimeUnit) TypeMatcher {
+	return &timeUnitMatcher{arrow.TIMESTAMP, unit}
+}
+func Time32TypeUnit(unit arrow.TimeUnit) TypeMatcher {
+	return &timeUnitMatcher{arrow.TIME32, unit}
+}
+func Time64TypeUnit(unit arrow.TimeUnit) TypeMatcher {
+	return &timeUnitMatcher{arrow.TIME64, unit}
+}
+func DurationTypeUnit(unit arrow.TimeUnit) TypeMatcher {
+	return &timeUnitMatcher{arrow.DURATION, unit}
+}
+
+type integerMatcher struct{}
+
+func (integerMatcher) String() string                  { return "integer" }
+func (integerMatcher) Matches(typ arrow.DataType) bool { return arrow.IsInteger(typ.ID()) }
+func (integerMatcher) Equals(other TypeMatcher) bool {
+	_, ok := other.(integerMatcher)
+	return ok
+}
+
+type binaryLikeMatcher struct{}
+
+func (binaryLikeMatcher) String() string                  { return "binary-like" }
+func (binaryLikeMatcher) Matches(typ arrow.DataType) bool { return arrow.IsBinaryLike(typ.ID()) }
+func (binaryLikeMatcher) Equals(other TypeMatcher) bool {
+	_, ok := other.(binaryLikeMatcher)
+	return ok
+}
+
+type largeBinaryLikeMatcher struct{}
+
+func (largeBinaryLikeMatcher) String() string { return "large-binary-like" }
+func (largeBinaryLikeMatcher) Matches(typ arrow.DataType) bool {
+	return arrow.IsLargeBinaryLike(typ.ID())
+}
+func (largeBinaryLikeMatcher) Equals(other TypeMatcher) bool {
+	_, ok := other.(largeBinaryLikeMatcher)
+	return ok
+}
+
+type fsbLikeMatcher struct{}
+
+func (fsbLikeMatcher) String() string                  { return "fixed-size-binary-like" }
+func (fsbLikeMatcher) Matches(typ arrow.DataType) bool { return arrow.IsFixedSizeBinary(typ.ID()) }
+func (fsbLikeMatcher) Equals(other TypeMatcher) bool {
+	_, ok := other.(fsbLikeMatcher)
+	return ok
+}
+
+func Integer() TypeMatcher             { return integerMatcher{} }
+func BinaryLike() TypeMatcher          { return binaryLikeMatcher{} }
+func LargeBinaryLike() TypeMatcher     { return largeBinaryLikeMatcher{} }
+func FixedSizeBinaryLike() TypeMatcher { return fsbLikeMatcher{} }
+
+type primitiveMatcher struct{}
+
+func (primitiveMatcher) String() string                  { return "primitive" }
+func (primitiveMatcher) Matches(typ arrow.DataType) bool { return arrow.IsPrimitive(typ.ID()) }
+func (primitiveMatcher) Equals(other TypeMatcher) bool {
+	_, ok := other.(primitiveMatcher)
+	return ok
+}
+
+func Primitive() TypeMatcher { return primitiveMatcher{} }
+
+type InputKind int8
+
+const (
+	InputAny InputKind = iota
+	InputExact
+	InputUseMatcher
+)
+
+type InputType struct {
+	Kind    InputKind
+	Type    arrow.DataType
+	Matcher TypeMatcher
+}
+
+func NewExactInput(dt arrow.DataType) InputType { return InputType{Kind: InputExact, Type: dt} }
+func NewMatchedInput(match TypeMatcher) InputType {
+	return InputType{Kind: InputUseMatcher, Matcher: match}
+}
+func NewIDInput(id arrow.Type) InputType { return NewMatchedInput(SameTypeID(id)) }
+
+func (it InputType) String() string {
+	switch it.Kind {
+	case InputAny:
+		return "any"
+	case InputUseMatcher:
+		return it.Matcher.String()
+	case InputExact:
+		return it.Type.String()
+	}
+	return ""
+}
+
+func (it *InputType) Equals(other *InputType) bool {
+	if it == other {
+		return true
+	}
+
+	if it.Kind != other.Kind {
+		return false
+	}
+
+	switch it.Kind {
+	case InputAny:
+		return true
+	case InputExact:
+		return arrow.TypeEqual(it.Type, other.Type)
+	case InputUseMatcher:
+		return it.Matcher.Equals(other.Matcher)
+	default:
+		return false
+	}
+}
+
+func (it InputType) Hash() uint64 {
+	var h maphash.Hash
+
+	h.SetSeed(hashSeed)
+	result := HashCombine(h.Sum64(), uint64(it.Kind))
+	switch it.Kind {
+	case InputExact:
+		result = HashCombine(result, arrow.HashType(hashSeed, it.Type))
+	}
+	return result
+}
+
+func (it InputType) Matches(dt arrow.DataType) bool {
+	switch it.Kind {
+	case InputExact:
+		return arrow.TypeEqual(it.Type, dt)
+	case InputUseMatcher:
+		return it.Matcher.Matches(dt)
+	default:
+		return true
+	}
+}
+
+type ResolveKind int8
+
+const (
+	ResolveFixed ResolveKind = iota
+	ResolveComputed
+)
+
+type TypeResolver = func(*KernelCtx, []arrow.DataType) (arrow.DataType, error)
+
+type OutputType struct {
+	Kind     ResolveKind
+	Type     arrow.DataType
+	Resolver TypeResolver
+}
+
+func NewOutputType(dt arrow.DataType) OutputType {
+	return OutputType{Kind: ResolveFixed, Type: dt}
+}
+
+func NewComputedOutputType(resolver TypeResolver) OutputType {
+	return OutputType{Kind: ResolveComputed, Resolver: resolver}
+}
+
+func (o OutputType) String() string {
+	if o.Kind == ResolveFixed {
+		return o.Type.String()
+	}
+	return "computed"
+}
+
+func (o OutputType) Resolve(ctx *KernelCtx, types []arrow.DataType) (arrow.DataType, error) {
+	switch o.Kind {
+	case ResolveFixed:
+		return o.Type, nil
+	}
+
+	return o.Resolver(ctx, types)
+}
+
+type NullHandling int8
+
+const (
+	NullIntersection NullHandling = iota
+	NullComputedPrealloc
+	NullComputedNoPrealloc
+	NullNoOutput
+)
+
+type MemAlloc int8
+
+const (
+	MemPrealloc MemAlloc = iota
+	MemNoPrealloc
+)
+
+type Options interface{}
+
+type KernelState any
+
+type KernelInitArgs struct {
+	Kernel  Kernel
+	Inputs  []arrow.DataType
+	Options Options
+}
+
+type KernelInitFn = func(*KernelCtx, KernelInitArgs) (KernelState, error)
+
+type KernelSignature struct {
+	InputTypes []InputType
+	OutType    OutputType
+	IsVarArgs  bool
+
+	hashCode uint64
+}
+
+func (k KernelSignature) String() string {
+	var b strings.Builder
+	if k.IsVarArgs {
+		b.WriteString("varargs[")
+	} else {
+		b.WriteByte('(')
+	}
+
+	for i, t := range k.InputTypes {
+		if i != 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(t.String())
+	}
+	if k.IsVarArgs {
+		b.WriteString("*]")
+	} else {
+		b.WriteByte(')')
+	}
+
+	b.WriteString(" -> ")
+	b.WriteString(k.OutType.String())
+	return b.String()
+}
+
+func (k KernelSignature) Equals(other KernelSignature) bool {
+	if k.IsVarArgs != other.IsVarArgs {
+		return false
+	}
+
+	return slices.EqualFunc(k.InputTypes, other.InputTypes, func(e1, e2 InputType) bool {
+		return e1.Equals(&e2)
+	})
+}
+
+func (k *KernelSignature) Hash() uint64 {
+	if k.hashCode != 0 {
+		return k.hashCode
+	}
+
+	var h maphash.Hash
+	h.SetSeed(hashSeed)
+	result := h.Sum64()
+	for _, typ := range k.InputTypes {
+		result = HashCombine(result, typ.Hash())
+	}
+	k.hashCode = result
+	return result
+}
+
+func (k KernelSignature) MatchesInputs(types []arrow.DataType) bool {
+	switch k.IsVarArgs {
+	case true:
+		for i, t := range types {
+			if !k.InputTypes[min(i, len(k.InputTypes)-1)].Matches(t) {
+				return false
+			}
+		}
+	case false:
+		if len(types) != len(k.InputTypes) {
+			return false
+		}
+		for i, t := range types {
+			if !k.InputTypes[i].Matches(t) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func min[T constraints.Ordered](a, b T) T {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/go/arrow/compute/internal/kernel_test.go
+++ b/go/arrow/compute/internal/kernel_test.go
@@ -1,0 +1,552 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apache/arrow/go/v10/arrow"
+	"github.com/apache/arrow/go/v10/arrow/array"
+	"github.com/apache/arrow/go/v10/arrow/compute"
+	"github.com/apache/arrow/go/v10/arrow/compute/internal"
+	"github.com/apache/arrow/go/v10/arrow/memory"
+	"github.com/apache/arrow/go/v10/arrow/scalar"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTypeMatcherSameTypeID(t *testing.T) {
+	matcher := internal.SameTypeID(arrow.DECIMAL128)
+	assert.True(t, matcher.Matches(&arrow.Decimal128Type{Precision: 12, Scale: 2}))
+	assert.False(t, matcher.Matches(arrow.PrimitiveTypes.Int8))
+
+	assert.Equal(t, "Type::DECIMAL128", matcher.String())
+
+	assert.True(t, matcher.Equals(matcher))
+	assert.True(t, matcher.Equals(internal.SameTypeID(arrow.DECIMAL)))
+	assert.False(t, matcher.Equals(internal.SameTypeID(arrow.TIMESTAMP)))
+	assert.False(t, matcher.Equals(internal.Time32TypeUnit(arrow.Microsecond)))
+}
+
+func TestTypeMatcherTimestampTypeUnit(t *testing.T) {
+	matcher := internal.TimestampTypeUnit(arrow.Millisecond)
+	matcher2 := internal.Time32TypeUnit(arrow.Millisecond)
+	matcher3 := internal.Time64TypeUnit(arrow.Microsecond)
+	matcher4 := internal.DurationTypeUnit(arrow.Microsecond)
+
+	assert.True(t, matcher.Matches(arrow.FixedWidthTypes.Timestamp_ms))
+	assert.True(t, matcher.Matches(&arrow.TimestampType{Unit: arrow.Millisecond, TimeZone: "utc"}))
+	assert.False(t, matcher.Matches(arrow.FixedWidthTypes.Timestamp_s))
+	assert.False(t, matcher.Matches(arrow.FixedWidthTypes.Time32ms))
+	assert.True(t, matcher2.Matches(arrow.FixedWidthTypes.Time32ms))
+
+	assert.True(t, matcher3.Matches(arrow.FixedWidthTypes.Time64us))
+	assert.False(t, matcher3.Matches(arrow.FixedWidthTypes.Time64ns))
+	assert.True(t, matcher4.Matches(arrow.FixedWidthTypes.Duration_us))
+	assert.False(t, matcher4.Matches(arrow.FixedWidthTypes.Duration_ms))
+
+	// check String() representation
+	assert.Equal(t, "timestamp(s)", internal.TimestampTypeUnit(arrow.Second).String())
+	assert.Equal(t, "timestamp(ms)", internal.TimestampTypeUnit(arrow.Millisecond).String())
+	assert.Equal(t, "timestamp(us)", internal.TimestampTypeUnit(arrow.Microsecond).String())
+	assert.Equal(t, "timestamp(ns)", internal.TimestampTypeUnit(arrow.Nanosecond).String())
+
+	// equals implementation
+	assert.True(t, matcher.Equals(matcher))
+	assert.True(t, matcher.Equals(internal.TimestampTypeUnit(arrow.Millisecond)))
+	assert.False(t, matcher.Equals(internal.TimestampTypeUnit(arrow.Microsecond)))
+	assert.False(t, matcher.Equals(internal.Time32TypeUnit(arrow.Millisecond)))
+	assert.False(t, matcher3.Equals(matcher2))
+	assert.False(t, matcher4.Equals(matcher3))
+	assert.True(t, matcher4.Equals(internal.DurationTypeUnit(arrow.Microsecond)))
+	assert.False(t, matcher.Equals(internal.SameTypeID(arrow.TIMESTAMP)))
+}
+
+func TestIntegerMatcher(t *testing.T) {
+	match := internal.Integer()
+
+	assert.Equal(t, "integer", match.String())
+	assert.True(t, match.Matches(arrow.PrimitiveTypes.Int8))
+	assert.True(t, match.Matches(arrow.PrimitiveTypes.Uint64))
+	assert.True(t, match.Equals(internal.Integer()))
+	assert.False(t, match.Equals(internal.BinaryLike()))
+}
+
+func TestBinaryLikeMatcher(t *testing.T) {
+	match := internal.BinaryLike()
+
+	assert.Equal(t, "binary-like", match.String())
+	assert.True(t, match.Matches(arrow.BinaryTypes.String))
+	assert.True(t, match.Matches(arrow.BinaryTypes.Binary))
+	assert.False(t, match.Matches(arrow.BinaryTypes.LargeString))
+	assert.False(t, match.Matches(arrow.BinaryTypes.LargeBinary))
+	assert.False(t, match.Equals(internal.LargeBinaryLike()))
+	assert.True(t, match.Equals(internal.BinaryLike()))
+}
+
+func TestLargeBinaryLikeMatcher(t *testing.T) {
+	match := internal.LargeBinaryLike()
+
+	assert.Equal(t, "large-binary-like", match.String())
+	assert.False(t, match.Matches(arrow.BinaryTypes.String))
+	assert.False(t, match.Matches(arrow.BinaryTypes.Binary))
+	assert.True(t, match.Matches(arrow.BinaryTypes.LargeString))
+	assert.True(t, match.Matches(arrow.BinaryTypes.LargeBinary))
+	assert.True(t, match.Equals(internal.LargeBinaryLike()))
+	assert.False(t, match.Equals(internal.BinaryLike()))
+}
+
+func TestFixedSizeBinaryMatcher(t *testing.T) {
+	match := internal.FixedSizeBinaryLike()
+
+	assert.Equal(t, "fixed-size-binary-like", match.String())
+	assert.False(t, match.Matches(arrow.BinaryTypes.String))
+	assert.True(t, match.Matches(&arrow.Decimal128Type{Precision: 12, Scale: 5}))
+	assert.True(t, match.Matches(&arrow.Decimal256Type{Precision: 12, Scale: 10}))
+	assert.True(t, match.Matches(&arrow.FixedSizeBinaryType{}))
+	assert.False(t, match.Equals(internal.LargeBinaryLike()))
+	assert.True(t, match.Equals(internal.FixedSizeBinaryLike()))
+}
+
+func TestPrimitiveMatcher(t *testing.T) {
+	match := internal.Primitive()
+
+	assert.Equal(t, "primitive", match.String())
+	assert.True(t, match.Equals(internal.Primitive()))
+
+	types := []arrow.DataType{
+		arrow.FixedWidthTypes.Boolean,
+		arrow.PrimitiveTypes.Uint8,
+		arrow.PrimitiveTypes.Int8,
+		arrow.PrimitiveTypes.Uint16,
+		arrow.PrimitiveTypes.Int16,
+		arrow.PrimitiveTypes.Uint32,
+		arrow.PrimitiveTypes.Int32,
+		arrow.PrimitiveTypes.Uint64,
+		arrow.PrimitiveTypes.Int64,
+		arrow.FixedWidthTypes.Float16,
+		arrow.PrimitiveTypes.Float32,
+		arrow.PrimitiveTypes.Float64,
+		arrow.FixedWidthTypes.Date32,
+		arrow.FixedWidthTypes.Date64,
+		arrow.FixedWidthTypes.Time32ms,
+		arrow.FixedWidthTypes.Time64ns,
+		arrow.FixedWidthTypes.Timestamp_ms,
+		arrow.FixedWidthTypes.Duration_ms,
+		arrow.FixedWidthTypes.MonthInterval,
+		arrow.FixedWidthTypes.DayTimeInterval,
+		arrow.FixedWidthTypes.MonthDayNanoInterval,
+	}
+
+	for _, typ := range types {
+		assert.True(t, match.Matches(typ))
+	}
+
+	assert.False(t, match.Matches(arrow.Null))
+}
+
+func TestInputTypeAnyType(t *testing.T) {
+	var ty internal.InputType
+	assert.Equal(t, internal.InputAny, ty.Kind)
+}
+
+func TestInputType(t *testing.T) {
+	ty1 := internal.NewExactInput(arrow.PrimitiveTypes.Int8)
+	assert.Equal(t, internal.InputExact, ty1.Kind)
+	assert.True(t, arrow.TypeEqual(arrow.PrimitiveTypes.Int8, ty1.Type))
+	assert.Equal(t, "int8", ty1.String())
+
+	ty2 := internal.NewIDInput(arrow.DECIMAL)
+	assert.Equal(t, internal.InputUseMatcher, ty2.Kind)
+	assert.Equal(t, "Type::DECIMAL128", ty2.String())
+	assert.True(t, ty2.Matcher.Matches(&arrow.Decimal128Type{Precision: 12, Scale: 2}))
+	assert.False(t, ty2.Matcher.Matches(arrow.PrimitiveTypes.Int16))
+
+	ty3 := internal.NewMatchedInput(internal.TimestampTypeUnit(arrow.Microsecond))
+	assert.Equal(t, "timestamp(us)", ty3.String())
+
+	var ty4 internal.InputType
+	assert.Equal(t, "any", ty4.String())
+	// InputAny matches anything
+	assert.True(t, ty4.Matches((arrow.DataType)(nil)))
+}
+
+func TestInputTypeEquals(t *testing.T) {
+	t1 := internal.NewExactInput(arrow.PrimitiveTypes.Int8)
+	t2 := internal.NewExactInput(arrow.PrimitiveTypes.Int8)
+	t3 := internal.NewExactInput(arrow.PrimitiveTypes.Int32)
+
+	t5 := internal.NewIDInput(arrow.DECIMAL)
+	t6 := internal.NewIDInput(arrow.DECIMAL)
+
+	assert.True(t, t1.Equals(&t2))
+	assert.False(t, t1.Equals(&t3))
+	assert.False(t, t1.Equals(&t5))
+	assert.True(t, t5.Equals(&t5))
+	assert.True(t, t5.Equals(&t6))
+
+	var ty internal.InputType
+	assert.True(t, ty.Equals(&internal.InputType{Kind: internal.InputAny}))
+
+	// for now, an ID matcher for arrow.INT32 and a ExactInput for
+	// arrow.PrimitiveTypes.Int32 are treated as being different.
+	// this could be made equivalent later if desireable
+
+	// check that field metadata is excluded from equality checks
+	t7 := internal.NewExactInput(arrow.ListOfField(
+		arrow.Field{Name: "item", Type: arrow.BinaryTypes.String,
+			Nullable: true, Metadata: arrow.NewMetadata([]string{"foo"}, []string{"bar"})}))
+	t8 := internal.NewExactInput(arrow.ListOf(arrow.BinaryTypes.String))
+	assert.True(t, t7.Equals(&t8))
+}
+
+func TestInputTypeHash(t *testing.T) {
+	var (
+		t0 internal.InputType
+		t1 = internal.NewExactInput(arrow.PrimitiveTypes.Int8)
+		t2 = internal.NewIDInput(arrow.DECIMAL)
+	)
+
+	// these checks try to determine first of all whether hash
+	// always returns the same value, and whether the elements
+	// of the type are all incorporated into the hash
+	assert.Equal(t, t0.Hash(), t0.Hash())
+	assert.Equal(t, t1.Hash(), t1.Hash())
+	assert.Equal(t, t2.Hash(), t2.Hash())
+	assert.NotEqual(t, t0.Hash(), t1.Hash())
+	assert.NotEqual(t, t0.Hash(), t2.Hash())
+	assert.NotEqual(t, t1.Hash(), t2.Hash())
+}
+
+func TestInputTypeMatches(t *testing.T) {
+	in1 := internal.NewExactInput(arrow.PrimitiveTypes.Int8)
+
+	assert.True(t, in1.Matches(arrow.PrimitiveTypes.Int8))
+	assert.False(t, in1.Matches(arrow.PrimitiveTypes.Int16))
+
+	in2 := internal.NewIDInput(arrow.DECIMAL)
+	assert.True(t, in2.Matches(&arrow.Decimal128Type{Precision: 12, Scale: 2}))
+
+	ty2 := &arrow.Decimal128Type{Precision: 12, Scale: 2}
+	ty3 := arrow.PrimitiveTypes.Float64
+
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	arr2 := array.MakeArrayOfNull(mem, ty2, 1)
+	arr3 := array.MakeArrayOfNull(mem, ty3, 1)
+	defer arr2.Release()
+	defer arr3.Release()
+
+	scalar2, err := scalar.GetScalar(arr2, 0)
+	assert.NoError(t, err)
+
+	datumArr := compute.NewDatum(arr2)
+	defer datumArr.Release()
+	datumScalar := compute.NewDatum(scalar2)
+	defer datumScalar.Release()
+
+	assert.False(t, in2.Matches(ty3))
+	assert.False(t, in2.Matches(arr3.DataType()))
+}
+
+func TestOutputType(t *testing.T) {
+	ty1 := internal.NewOutputType(arrow.PrimitiveTypes.Int8)
+	assert.Equal(t, internal.ResolveFixed, ty1.Kind)
+	assert.True(t, arrow.TypeEqual(arrow.PrimitiveTypes.Int8, ty1.Type))
+
+	dummyResolver := func(_ *internal.KernelCtx, args []arrow.DataType) (arrow.DataType, error) {
+		return arrow.PrimitiveTypes.Int32, nil
+	}
+
+	ty2 := internal.NewComputedOutputType(dummyResolver)
+	assert.Equal(t, internal.ResolveComputed, ty2.Kind)
+
+	outType2, err := ty2.Resolve(nil, nil)
+	assert.NoError(t, err)
+	assert.Same(t, arrow.PrimitiveTypes.Int32, outType2)
+
+	ty3 := ty1
+	assert.Equal(t, internal.ResolveFixed, ty3.Kind)
+	assert.True(t, arrow.TypeEqual(ty1.Type, ty3.Type))
+
+	ty4 := ty2
+	assert.Equal(t, internal.ResolveComputed, ty4.Kind)
+	outType4, err := ty4.Resolve(nil, nil)
+	assert.NoError(t, err)
+	assert.Same(t, arrow.PrimitiveTypes.Int32, outType4)
+
+	assert.Equal(t, "int8", ty3.String())
+	assert.Equal(t, "computed", ty4.String())
+}
+
+func TestOutputTypeResolve(t *testing.T) {
+	ty1 := internal.NewOutputType(arrow.PrimitiveTypes.Int32)
+
+	result, err := ty1.Resolve(nil, nil)
+	assert.NoError(t, err)
+	assert.Same(t, arrow.PrimitiveTypes.Int32, result)
+
+	result, err = ty1.Resolve(nil, []arrow.DataType{arrow.PrimitiveTypes.Int8})
+	assert.NoError(t, err)
+	assert.Same(t, arrow.PrimitiveTypes.Int32, result)
+
+	result, err = ty1.Resolve(nil, []arrow.DataType{arrow.PrimitiveTypes.Int8, arrow.PrimitiveTypes.Int8})
+	assert.NoError(t, err)
+	assert.Same(t, arrow.PrimitiveTypes.Int32, result)
+
+	resolver := func(_ *internal.KernelCtx, args []arrow.DataType) (arrow.DataType, error) {
+		return args[0], nil
+	}
+	ty2 := internal.NewComputedOutputType(resolver)
+
+	result, err = ty2.Resolve(nil, []arrow.DataType{arrow.BinaryTypes.String})
+	assert.NoError(t, err)
+	assert.Same(t, arrow.BinaryTypes.String, result)
+
+	// type resolver that returns an error
+	ty3 := internal.NewComputedOutputType(func(_ *internal.KernelCtx, dt []arrow.DataType) (arrow.DataType, error) {
+		// checking the value types versus the function arity should be validated
+		// elsewhere. this is just for illustration purposes
+		if len(dt) == 0 {
+			return nil, fmt.Errorf("%w: need at least one argument", arrow.ErrInvalid)
+		}
+		return dt[0], nil
+	})
+
+	_, err = ty3.Resolve(nil, []arrow.DataType{})
+	assert.ErrorIs(t, err, arrow.ErrInvalid)
+
+	// resolver returns a fixed value
+	ty4 := internal.NewComputedOutputType(func(*internal.KernelCtx, []arrow.DataType) (arrow.DataType, error) {
+		return arrow.PrimitiveTypes.Int32, nil
+	})
+	result, err = ty4.Resolve(nil, []arrow.DataType{arrow.PrimitiveTypes.Int8})
+	assert.NoError(t, err)
+	assert.Same(t, arrow.PrimitiveTypes.Int32, result)
+	result, err = ty4.Resolve(nil, []arrow.DataType{})
+	assert.NoError(t, err)
+	assert.Same(t, arrow.PrimitiveTypes.Int32, result)
+}
+
+func TestKernelSignatureEquals(t *testing.T) {
+	sig1 := internal.KernelSignature{
+		InputTypes: []internal.InputType{},
+		OutType:    internal.NewOutputType(arrow.BinaryTypes.String)}
+	sig1Copy := internal.KernelSignature{
+		InputTypes: []internal.InputType{},
+		OutType:    internal.NewOutputType(arrow.BinaryTypes.String)}
+	sig2 := internal.KernelSignature{
+		InputTypes: []internal.InputType{
+			internal.NewExactInput(arrow.PrimitiveTypes.Int8)},
+		OutType: internal.NewOutputType(arrow.BinaryTypes.String),
+	}
+
+	// output type doesn't matter (for now)
+	sig3 := internal.KernelSignature{
+		InputTypes: []internal.InputType{
+			internal.NewExactInput(arrow.PrimitiveTypes.Int8)},
+		OutType: internal.NewOutputType(arrow.PrimitiveTypes.Int32),
+	}
+
+	sig4 := internal.KernelSignature{
+		InputTypes: []internal.InputType{
+			internal.NewExactInput(arrow.PrimitiveTypes.Int8),
+			internal.NewExactInput(arrow.PrimitiveTypes.Int16),
+		},
+		OutType: internal.NewOutputType(arrow.BinaryTypes.String),
+	}
+	sig4Copy := internal.KernelSignature{
+		InputTypes: []internal.InputType{
+			internal.NewExactInput(arrow.PrimitiveTypes.Int8),
+			internal.NewExactInput(arrow.PrimitiveTypes.Int16),
+		},
+		OutType: internal.NewOutputType(arrow.BinaryTypes.String),
+	}
+	sig5 := internal.KernelSignature{
+		InputTypes: []internal.InputType{
+			internal.NewExactInput(arrow.PrimitiveTypes.Int8),
+			internal.NewExactInput(arrow.PrimitiveTypes.Int16),
+			internal.NewExactInput(arrow.PrimitiveTypes.Int32),
+		},
+		OutType: internal.NewOutputType(arrow.BinaryTypes.String),
+	}
+
+	assert.True(t, sig1.Equals(sig1))
+	assert.True(t, sig2.Equals(sig3))
+	assert.False(t, sig3.Equals(sig4))
+
+	// different sig objects but same sig
+	assert.True(t, sig1.Equals(sig1Copy))
+	assert.True(t, sig4.Equals(sig4Copy))
+
+	// match first 2 args, but not third
+	assert.False(t, sig4.Equals(sig5))
+}
+
+func TestKernelSignatureVarArgsEqual(t *testing.T) {
+	sig1 := internal.KernelSignature{
+		InputTypes: []internal.InputType{internal.NewExactInput(arrow.PrimitiveTypes.Int8)},
+		OutType:    internal.NewOutputType(arrow.BinaryTypes.String),
+		IsVarArgs:  true,
+	}
+	sig2 := internal.KernelSignature{
+		InputTypes: []internal.InputType{internal.NewExactInput(arrow.PrimitiveTypes.Int8)},
+		OutType:    internal.NewOutputType(arrow.BinaryTypes.String),
+		IsVarArgs:  true,
+	}
+	sig3 := internal.KernelSignature{
+		InputTypes: []internal.InputType{internal.NewExactInput(arrow.PrimitiveTypes.Int8)},
+		OutType:    internal.NewOutputType(arrow.BinaryTypes.String),
+	}
+
+	assert.True(t, sig1.Equals(sig2))
+	assert.False(t, sig2.Equals(sig3))
+}
+
+func TestKernelSignatureHash(t *testing.T) {
+	sig1 := internal.KernelSignature{
+		InputTypes: []internal.InputType{},
+		OutType:    internal.NewOutputType(arrow.BinaryTypes.String),
+	}
+	sig2 := internal.KernelSignature{
+		InputTypes: []internal.InputType{internal.NewExactInput(arrow.PrimitiveTypes.Int8)},
+		OutType:    internal.NewOutputType(arrow.BinaryTypes.String),
+	}
+	sig3 := internal.KernelSignature{
+		InputTypes: []internal.InputType{
+			internal.NewExactInput(arrow.PrimitiveTypes.Int8),
+			internal.NewExactInput(arrow.PrimitiveTypes.Int32)},
+		OutType: internal.NewOutputType(arrow.BinaryTypes.String),
+	}
+
+	assert.Equal(t, sig1.Hash(), sig1.Hash())
+	assert.Equal(t, sig2.Hash(), sig2.Hash())
+	assert.NotEqual(t, sig1.Hash(), sig2.Hash())
+	assert.NotEqual(t, sig2.Hash(), sig3.Hash())
+}
+
+func TestKernelSignatureMatchesInputs(t *testing.T) {
+	// () -> boolean
+	sig1 := internal.KernelSignature{
+		OutType: internal.NewOutputType(arrow.FixedWidthTypes.Boolean)}
+
+	assert.True(t, sig1.MatchesInputs([]arrow.DataType{}))
+	assert.False(t, sig1.MatchesInputs([]arrow.DataType{arrow.PrimitiveTypes.Int8}))
+
+	// (int8, decimal) -> boolean
+	sig2 := internal.KernelSignature{
+		InputTypes: []internal.InputType{
+			internal.NewExactInput(arrow.PrimitiveTypes.Int8),
+			internal.NewIDInput(arrow.DECIMAL)},
+		OutType: internal.NewOutputType(arrow.FixedWidthTypes.Boolean),
+	}
+	assert.False(t, sig2.MatchesInputs([]arrow.DataType{}))
+	assert.False(t, sig2.MatchesInputs([]arrow.DataType{arrow.PrimitiveTypes.Int8}))
+	assert.True(t, sig2.MatchesInputs([]arrow.DataType{
+		arrow.PrimitiveTypes.Int8,
+		&arrow.Decimal128Type{Precision: 12, Scale: 2}}))
+
+	// (int8, int32) -> boolean
+	sig3 := internal.KernelSignature{
+		InputTypes: []internal.InputType{
+			internal.NewExactInput(arrow.PrimitiveTypes.Int8),
+			internal.NewExactInput(arrow.PrimitiveTypes.Int32),
+		},
+		OutType: internal.NewOutputType(arrow.FixedWidthTypes.Boolean),
+	}
+	assert.False(t, sig3.MatchesInputs(nil))
+	assert.True(t, sig3.MatchesInputs([]arrow.DataType{arrow.PrimitiveTypes.Int8, arrow.PrimitiveTypes.Int32}))
+	assert.False(t, sig3.MatchesInputs([]arrow.DataType{arrow.PrimitiveTypes.Int8, arrow.PrimitiveTypes.Int16}))
+}
+
+func TestKernelSignatureVarArgsMatchesInputs(t *testing.T) {
+	{
+		sig := internal.KernelSignature{
+			InputTypes: []internal.InputType{internal.NewExactInput(arrow.PrimitiveTypes.Int8)},
+			OutType:    internal.NewOutputType(arrow.BinaryTypes.String),
+			IsVarArgs:  true,
+		}
+
+		args := []arrow.DataType{arrow.PrimitiveTypes.Int8}
+		assert.True(t, sig.MatchesInputs(args))
+		args = append(args, arrow.PrimitiveTypes.Int8, arrow.PrimitiveTypes.Int8)
+		assert.True(t, sig.MatchesInputs(args))
+		args = append(args, arrow.PrimitiveTypes.Int32)
+		assert.False(t, sig.MatchesInputs(args))
+	}
+	{
+		sig := internal.KernelSignature{
+			InputTypes: []internal.InputType{
+				internal.NewExactInput(arrow.PrimitiveTypes.Int8),
+				internal.NewExactInput(arrow.BinaryTypes.String),
+			},
+			OutType:   internal.NewOutputType(arrow.BinaryTypes.String),
+			IsVarArgs: true,
+		}
+
+		args := []arrow.DataType{arrow.PrimitiveTypes.Int8}
+		assert.True(t, sig.MatchesInputs(args))
+		args = append(args, arrow.BinaryTypes.String, arrow.BinaryTypes.String)
+		assert.True(t, sig.MatchesInputs(args))
+		args = append(args, arrow.PrimitiveTypes.Int32)
+		assert.False(t, sig.MatchesInputs(args))
+	}
+}
+
+func TestKernelSignatureToString(t *testing.T) {
+	inTypes := []internal.InputType{
+		internal.NewExactInput(arrow.PrimitiveTypes.Int8),
+		internal.NewIDInput(arrow.DECIMAL),
+		internal.NewExactInput(arrow.BinaryTypes.String),
+	}
+
+	sig := internal.KernelSignature{
+		InputTypes: inTypes, OutType: internal.NewOutputType(arrow.BinaryTypes.String),
+	}
+	assert.Equal(t, "(int8, Type::DECIMAL128, utf8) -> utf8", sig.String())
+
+	outType := internal.NewComputedOutputType(func(*internal.KernelCtx, []arrow.DataType) (arrow.DataType, error) {
+		return nil, arrow.ErrInvalid
+	})
+	sig2 := internal.KernelSignature{
+		InputTypes: []internal.InputType{
+			internal.NewExactInput(arrow.PrimitiveTypes.Int8),
+			internal.NewIDInput(arrow.DECIMAL)},
+		OutType: outType,
+	}
+	assert.Equal(t, "(int8, Type::DECIMAL128) -> computed", sig2.String())
+}
+
+func TestKernelSignatureVarArgsToString(t *testing.T) {
+	sig1 := internal.KernelSignature{
+		InputTypes: []internal.InputType{
+			internal.NewExactInput(arrow.PrimitiveTypes.Int8)},
+		OutType:   internal.NewOutputType(arrow.BinaryTypes.String),
+		IsVarArgs: true,
+	}
+	assert.Equal(t, "varargs[int8*] -> utf8", sig1.String())
+
+	sig2 := internal.KernelSignature{
+		InputTypes: []internal.InputType{
+			internal.NewExactInput(arrow.BinaryTypes.String),
+			internal.NewExactInput(arrow.PrimitiveTypes.Int8)},
+		OutType:   internal.NewOutputType(arrow.BinaryTypes.String),
+		IsVarArgs: true,
+	}
+	assert.Equal(t, "varargs[utf8, int8*] -> utf8", sig2.String())
+}

--- a/go/arrow/errors.go
+++ b/go/arrow/errors.go
@@ -1,0 +1,23 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package arrow
+
+import "errors"
+
+var (
+	ErrInvalid = errors.New("invalid")
+)


### PR DESCRIPTION
This implements the interface for Kernels along with a `KernelSignature` struct and the type matching for `InputType` and `OutputType` via a `TypeMatcher` interface. Along with tests for all of the above.