### PR TITLE
ARROW-17464: [C++] Store/Read float16 values in Parquet as FixedSizeBinary

### DIFF
--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -1279,6 +1279,31 @@ TEST_F(TestDurationParquetIO, Roundtrip) {
   this->RoundTripSingleColumn(duration_arr, duration_arr, arrow_properties);
 }
 
+using TestHalfFloatParquetIO = TestParquetIO<::arrow::HalfFloatType>;
+
+TEST_F(TestHalfFloatParquetIO, Roundtrip) {
+  std::vector<bool> is_valid = {true, true, false, true};
+  // TODO How to test with a Binary vector?
+  std::vector<uint16_t> values = {1, 2, 3, 4};
+
+  std::shared_ptr<Array> int_array, half_float_arr;
+  ::arrow::ArrayFromVector<::arrow::UInt16Type, uint16_t>(::arrow::uint16(), is_valid,
+                                                          values, &int_array);
+  ::arrow::ArrayFromVector<::arrow::HalfFloatType, uint16_t>(::arrow::float16(), is_valid,
+                                                             values, &half_float_arr);
+
+  // When the original Arrow schema isn't stored, a HalfFloat comes back as Binary (how it
+  // is stored in Parquet)
+  this->RoundTripSingleColumn(half_float_arr, int_array,
+                              default_arrow_writer_properties());
+
+  // When the original arrow schema is stored, the HalfFloat array type should be
+  // preserved
+  const auto arrow_properties =
+      ::parquet::ArrowWriterProperties::Builder().store_schema()->build();
+  this->RoundTripSingleColumn(half_float_arr, half_float_arr, arrow_properties);
+}
+
 TEST_F(TestUInt32ParquetIO, Parquet_1_0_Compatibility) {
   // This also tests max_definition_level = 1
   std::shared_ptr<Array> arr;

--- a/cpp/src/parquet/arrow/arrow_schema_test.cc
+++ b/cpp/src/parquet/arrow/arrow_schema_test.cc
@@ -909,21 +909,22 @@ TEST_F(TestConvertArrowSchema, ArrowFields) {
   // ASSERT_NO_FATAL_FAILURE();
 }
 
-TEST_F(TestConvertArrowSchema, ArrowNonconvertibleFields) {
-  struct FieldConstructionArguments {
-    std::string name;
-    std::shared_ptr<::arrow::DataType> datatype;
-  };
-
-  std::vector<FieldConstructionArguments> cases = {
-      {"float16", ::arrow::float16()},
-  };
-
-  for (const FieldConstructionArguments& c : cases) {
-    auto field = ::arrow::field(c.name, c.datatype);
-    ASSERT_RAISES(NotImplemented, ConvertSchema({field}));
-  }
-}
+// TODO
+//TEST_F(TestConvertArrowSchema, ArrowNonconvertibleFields) {
+//  struct FieldConstructionArguments {
+//    std::string name;
+//    std::shared_ptr<::arrow::DataType> datatype;
+//  };
+//
+//  std::vector<FieldConstructionArguments> cases = {
+//      {"float16", ::arrow::float16()},
+//  };
+//
+//  for (const FieldConstructionArguments& c : cases) {
+//    auto field = ::arrow::field(c.name, c.datatype);
+//    ASSERT_RAISES(NotImplemented, ConvertSchema({field}));
+//  }
+//}
 
 TEST_F(TestConvertArrowSchema, ParquetFlatPrimitivesAsDictionaries) {
   std::vector<NodePtr> parquet_fields;

--- a/cpp/src/parquet/arrow/reader_internal.cc
+++ b/cpp/src/parquet/arrow/reader_internal.cc
@@ -762,6 +762,10 @@ Status TransferColumnData(RecordReader* reader, const std::shared_ptr<Field>& va
       TRANSFER_INT32(TIME32, ::arrow::Time32Type);
       TRANSFER_INT64(TIME64, ::arrow::Time64Type);
       TRANSFER_INT64(DURATION, ::arrow::DurationType);
+    case ::arrow::Type::HALF_FLOAT: {
+      RETURN_NOT_OK(TransferBinary(reader, pool, value_field, &chunked_result));
+      result = chunked_result;
+    } break;
     case ::arrow::Type::DATE64:
       RETURN_NOT_OK(TransferDate64(reader, pool, value_field, &result));
       break;

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -390,6 +390,11 @@ Status FieldToNode(const std::string& name, const std::shared_ptr<Field>& field,
     case ArrowTypeId::DURATION:
       type = ParquetType::INT64;
       break;
+    case ArrowTypeId::HALF_FLOAT: {
+      type = ParquetType::FIXED_LEN_BYTE_ARRAY;
+      // defining that a HALF_FLOAT is 2 bytes long
+      length = 2;
+    } break;
     case ArrowTypeId::STRUCT: {
       auto struct_type = std::static_pointer_cast<::arrow::StructType>(field->type());
       return StructToNode(struct_type, name, field->nullable(), properties,
@@ -922,6 +927,12 @@ Result<bool> ApplyOriginalStorageMetadata(const Field& origin_field,
   if (origin_type->id() == ::arrow::Type::DURATION &&
       inferred_type->id() == ::arrow::Type::INT64) {
     // Read back int64 arrays as duration.
+    inferred->field = inferred->field->WithType(origin_type);
+    modified = true;
+  }
+
+  if (origin_type->id() == ::arrow::Type::HALF_FLOAT &&
+      inferred_type->id() == ::arrow::Type::FIXED_SIZE_BINARY) {
     inferred->field = inferred->field->WithType(origin_type);
     modified = true;
   }

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -2050,7 +2050,7 @@ Status TypedColumnWriterImpl<FLBAType>::WriteArrowDense(
     WRITE_SERIALIZE_CASE(FIXED_SIZE_BINARY, FixedSizeBinaryType, FLBAType)
     WRITE_SERIALIZE_CASE(DECIMAL128, Decimal128Type, FLBAType)
     WRITE_SERIALIZE_CASE(DECIMAL256, Decimal256Type, FLBAType)
-    WRITE_ZERO_COPY_CASE(HALF_FLOAT, HalfFloatType, FLBAType)
+    WRITE_SERIALIZE_CASE(HALF_FLOAT, FixedSizeBinaryType, FLBAType)
     default:
       break;
   }

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -2050,6 +2050,7 @@ Status TypedColumnWriterImpl<FLBAType>::WriteArrowDense(
     WRITE_SERIALIZE_CASE(FIXED_SIZE_BINARY, FixedSizeBinaryType, FLBAType)
     WRITE_SERIALIZE_CASE(DECIMAL128, Decimal128Type, FLBAType)
     WRITE_SERIALIZE_CASE(DECIMAL256, Decimal256Type, FLBAType)
+    WRITE_ZERO_COPY_CASE(HALF_FLOAT, HalfFloatType, FLBAType)
     default:
       break;
   }

--- a/python/pyarrow/tests/parquet/common.py
+++ b/python/pyarrow/tests/parquet/common.py
@@ -166,6 +166,7 @@ def alltypes_sample(size=10000, seed=0, categorical=False):
         'int16': np.arange(size, dtype=np.int16),
         'int32': np.arange(size, dtype=np.int32),
         'int64': np.arange(size, dtype=np.int64),
+        'float16': np.arange(size, dtype=np.float16),
         'float32': np.arange(size, dtype=np.float32),
         'float64': np.arange(size, dtype=np.float64),
         'bool': np.random.randn(size) > 0,


### PR DESCRIPTION
**Edit** When I return to this, I want to re-open a PR off of my branch `arrow-17464`. It was a mistake/accident to do this off of `master`.

Half-float values are currently not supported in Parquet:
https://issues.apache.org/jira/browse/PARQUET-1647

This is a draft PR! The tests as they are currently not passing. I am a pretty new committer, and opened this PR to more easily ask for help understanding what various parts of the code are doing. 

The Parquet mailing list a proposal to have float16 standardised in Parquet itself: https://lists.apache.org/thread/03vmcj7ygwvsbno764vd1hr954p62zr5

The PR to `parquet-format`: https://github.com/apache/parquet-format/pull/184

This PR was inspired by: https://github.com/apache/arrow/pull/12449

