### PR TITLE
MINOR: [C++] Replace std::random_shuffle with std::shuffle

### DIFF
--- a/cpp/src/arrow/adapters/orc/adapter_test.cc
+++ b/cpp/src/arrow/adapters/orc/adapter_test.cc
@@ -173,7 +173,7 @@ void RandWeakComposition(int64_t n, T sum, std::vector<U>* out) {
     return static_cast<U>(res);
   });
   (*out)[n - 1] += remaining_sum;
-  std::random_shuffle(out->begin(), out->end());
+  std::shuffle(out->begin(), out->end(), gen);
 }
 
 std::shared_ptr<ChunkedArray> GenerateRandomChunkedArray(


### PR DESCRIPTION
`std::random_shuffle` was deprecated in C++14 and removed altogether in C++17 in favor of `std::shuffle`. The codebase only uses these shuffling functions in tests and benchmarks and `std::shuffle` is used in all instances except this one.