### PR TITLE
MINOR: [R] Remove trailing whitespace in flight tests

### DIFF
--- a/r/tests/testthat/test-python-flight.R
+++ b/r/tests/testthat/test-python-flight.R
@@ -37,13 +37,13 @@ if (process_is_running("demo_flight_server")) {
       regexp = 'data must be a "data.frame", "Table", or "RecordBatch"'
     )
   })
-  
+
   test_that("flight_put with max_chunksize", {
     flight_put(client, example_data, path = flight_obj, max_chunksize = 1)
     expect_true(flight_path_exists(client, flight_obj))
     expect_true(flight_obj %in% list_flights(client))
     expect_warning(
-      flight_put(client, record_batch(example_data), path = flight_obj, max_chunksize = 123), 
+      flight_put(client, record_batch(example_data), path = flight_obj, max_chunksize = 123),
       regexp = "`max_chunksize` is not supported for flight_put with RecordBatch"
     )
     expect_error(


### PR DESCRIPTION
After #13267 there is some trailing whitespace left over in one of the files.