### PR TITLE
MINOR: [CI] [C++] Pin xsimd version to 8.1.0 in CPP conda env file

### DIFF
--- a/ci/conda_env_cpp.txt
+++ b/ci/conda_env_cpp.txt
@@ -43,7 +43,7 @@ rapidjson
 re2
 snappy
 thrift-cpp>=0.11.0
-xsimd
+xsimd=8.1.0
 zlib
 zstd
 flatbuffers


### PR DESCRIPTION
This fixes local and CI builds that use conda now that xsimd 9.0.0 has been published to [conda-forge](https://anaconda.org/conda-forge/xsimd). `cpp/cmake_modules/ThirdpartyToolchain.cmake` has a strict dependency on xsimd 8.1.0 and this should fix builds until upgrading to xsimd 9.0.0 can be evaluated.