### PR TITLE
ARROW-17510: [CI][C++][Windows][MSVC] Use ccache

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -193,7 +193,7 @@ jobs:
     name: AMD64 ${{ matrix.name }} C++17
     runs-on: ${{ matrix.os }}
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
-    timeout-minutes: 45
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -202,14 +202,12 @@ jobs:
         include:
           - os: windows-2019
             name: Windows 2019
-            generator: Visual Studio 16 2019
     env:
       ARROW_BOOST_USE_SHARED: OFF
       ARROW_BUILD_BENCHMARKS: ON
       ARROW_BUILD_SHARED: ON
       ARROW_BUILD_STATIC: OFF
       ARROW_BUILD_TESTS: ON
-      ARROW_CXXFLAGS: "/std:c++17"
       ARROW_DATASET: ON
       ARROW_FLIGHT: OFF
       ARROW_HDFS: ON
@@ -227,11 +225,13 @@ jobs:
       ARROW_WITH_ZLIB: ON
       ARROW_WITH_ZSTD: ON
       BOOST_SOURCE: BUNDLED
-      CMAKE_ARGS: '-A x64 -DOPENSSL_ROOT_DIR=C:\Program Files\OpenSSL-Win64'
-      CMAKE_GENERATOR: ${{ matrix.generator }}
+      CMAKE_CXX_STANDARD: "17"
+      CMAKE_GENERATOR: Ninja
       CMAKE_INSTALL_LIBDIR: bin
       CMAKE_INSTALL_PREFIX: /usr
       CMAKE_UNITY_BUILD: ON
+      OPENSSL_ROOT_DIR: >-
+        C:\Program Files\OpenSSL-Win64
       NPROC: 3
     steps:
       - name: Disable Crash Dialogs
@@ -254,9 +254,30 @@ jobs:
       - name: Download Timezone Database
         shell: bash
         run: ci/scripts/download_tz_database.sh
-      - name: Build
+      - name: Install ccache
         shell: bash
-        run: ci/scripts/cpp_build.sh $(pwd) $(pwd)/build
+        run: |
+          ci/scripts/install_ccache.sh 4.6.2 /usr
+      - name: Setup ccache
+        shell: bash
+        run: |
+          ci/scripts/ccache_setup.sh
+      - name: ccache info
+        id: ccache-info
+        shell: bash
+        run: |
+          echo "::set-output name=cache-dir::$(ccache --get-config cache_dir)"
+      - name: Cache ccache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.ccache-info.outputs.cache-dir }}
+          key: cpp-ccache-windows-${{ hashFiles('cpp/**') }}
+          restore-keys: cpp-ccache-windows-
+      - name: Build
+        shell: cmd
+        run: |
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+          bash -c "ci/scripts/cpp_build.sh $(pwd) $(pwd)/build"
       - name: Test
         shell: bash
         run: ci/scripts/cpp_test.sh $(pwd) $(pwd)/build

--- a/ci/scripts/install_ccache.sh
+++ b/ci/scripts/install_ccache.sh
@@ -26,20 +26,33 @@ fi
 
 version=$1
 prefix=$2
-url="https://github.com/ccache/ccache/archive/v${version}.tar.gz"
 
-mkdir /tmp/ccache
-wget -q ${url} -O - | tar -xzf - --directory /tmp/ccache --strip-components=1
+mkdir -p /tmp/ccache
+case $(uname) in
+  MINGW64*)
+    url="https://github.com/ccache/ccache/releases/download/v${version}/ccache-${version}-windows-x86_64.zip"
+    pushd /tmp/ccache
+    curl --fail --location --remote-name ${url}
+    unzip -j ccache-${version}-windows-x86_64.zip
+    chmod +x ccache.exe
+    mv ccache.exe ${prefix}/bin/
+    popd
+    ;;
+  *)
+    url="https://github.com/ccache/ccache/archive/v${version}.tar.gz"
 
-mkdir /tmp/ccache/build
-pushd /tmp/ccache/build
-cmake \
-  -GNinja \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_INSTALL_PREFIX=${prefix} \
-  -DZSTD_FROM_INTERNET=ON \
-  ..
-ninja install
-popd
+    wget -q ${url} -O - | tar -xzf - --directory /tmp/ccache --strip-components=1
 
+    mkdir /tmp/ccache/build
+    pushd /tmp/ccache/build
+    cmake \
+      -GNinja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_PREFIX=${prefix} \
+      -DZSTD_FROM_INTERNET=ON \
+      ..
+    ninja install
+    popd
+    ;;
+esac
 rm -rf /tmp/ccache

--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -205,6 +205,24 @@ if(WIN32)
     #   * https://developercommunity.visualstudio.com/content/problem/1249671/stdc17-generates-warning-compiling-windowsh.html
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} /wd5105")
 
+    if(ARROW_USE_CCACHE)
+      foreach(c_flag
+              CMAKE_CXX_FLAGS
+              CMAKE_CXX_FLAGS_RELEASE
+              CMAKE_CXX_FLAGS_DEBUG
+              CMAKE_CXX_FLAGS_MINSIZEREL
+              CMAKE_CXX_FLAGS_RELWITHDEBINFO
+              CMAKE_C_FLAGS
+              CMAKE_C_FLAGS_RELEASE
+              CMAKE_C_FLAGS_DEBUG
+              CMAKE_C_FLAGS_MINSIZEREL
+              CMAKE_C_FLAGS_RELWITHDEBINFO)
+        # ccache doesn't work with /Zi.
+        # See also: https://github.com/ccache/ccache/issues/1040
+        string(REPLACE "/Zi" "/Z7" ${c_flag} "${${c_flag}}")
+      endforeach()
+    endif()
+
     if(ARROW_USE_STATIC_CRT)
       foreach(c_flag
               CMAKE_CXX_FLAGS
@@ -217,7 +235,7 @@ if(WIN32)
               CMAKE_C_FLAGS_DEBUG
               CMAKE_C_FLAGS_MINSIZEREL
               CMAKE_C_FLAGS_RELWITHDEBINFO)
-        string(REPLACE "/MD" "-MT" ${c_flag} "${${c_flag}}")
+        string(REPLACE "/MD" "/MT" ${c_flag} "${${c_flag}}")
       endforeach()
     endif()
 


### PR DESCRIPTION
ccache supports MSVC since 4.6.0:

https://ccache.dev/releasenotes.html#_ccache_4_6

> Added support for caching calls to Microsoft Visual C++ (MSVC) and
> clang-cl (MSVC compatibility for Clang).

* no ccache: 22m23s: https://github.com/apache/arrow/runs/7983003808
* not cached: 39m35s: https://github.com/kou/arrow/runs/7984875241
* cached: 9m31s: https://github.com/kou/arrow/runs/7985401473