### PR TITLE
MINOR: [CI][C++] Update testing submodule

### DIFF
--- a/cpp/src/arrow/builder_benchmark.cc
+++ b/cpp/src/arrow/builder_benchmark.cc
@@ -36,6 +36,7 @@ namespace arrow {
 
 using ValueType = int64_t;
 using VectorType = std::vector<ValueType>;
+
 constexpr int64_t kNumberOfElements = 256 * 512;
 
 static VectorType AlmostU8CompressibleVector() {


### PR DESCRIPTION
PR #13781 moved back the testing submodule to an old changeset by mistake, which subsequently broke multiple CI builds.

(added a dummy C++ change to trigger CI)