### PR TITLE
ARROW-17518: [CI][Doc][Python] Update glob to detect arrow development version from git

### DIFF
--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -696,7 +696,7 @@ def get_version(root, **kwargs):
 
     # query the calculated version based on the git tags
     kwargs['describe_command'] = (
-        'git describe --dirty --tags --long --match "apache-arrow-[0-9].*"'
+        'git describe --dirty --tags --long --match "apache-arrow-[0-9]*.*"'
     )
     version = parse_git_version(root, **kwargs)
     tag = str(version.tag)

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -51,7 +51,7 @@ except ImportError:
             """
             from setuptools_scm.git import parse
             kwargs['describe_command'] = \
-                "git describe --dirty --tags --long --match 'apache-arrow-[0-9].*'"
+                "git describe --dirty --tags --long --match 'apache-arrow-[0-9]*.*'"
             return parse(root, **kwargs)
         __version__ = setuptools_scm.get_version('../',
                                                  parse=parse_git)

--- a/python/setup.py
+++ b/python/setup.py
@@ -586,7 +586,7 @@ def parse_git(root, **kwargs):
     """
     from setuptools_scm.git import parse
     kwargs['describe_command'] =\
-        'git describe --dirty --tags --long --match "apache-arrow-[0-9].*"'
+        'git describe --dirty --tags --long --match "apache-arrow-[0-9]*.*"'
     return parse(root, **kwargs)
 
 


### PR DESCRIPTION
Reproduced locally:
```
$ git describe --dirty --tags --long --match "apache-arrow-[0-9].*"
apache-arrow-9.0.0.dev-641-g0d5bb92-dirty
$ git describe --dirty --tags --long --match "apache-arrow-[0-9]*.*"
apache-arrow-10.0.0.dev-114-g0d5bb92-dirty
```