### PR TITLE
ARROW-15693: [Dev] Update crossbow templates to use master or main

### DIFF
--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -741,6 +741,8 @@ class Target(Serializable):
         self.github_repo = "/".join(_parse_github_user_repo(remote))
         self.version = version
         self.no_rc_version = re.sub(r'-rc\d+\Z', '', version)
+        # TODO: Remove "master" from default_branch after migration to "main".
+        self.default_branch = ['main', 'master']
         # Semantic Versioning 1.0.0: https://semver.org/spec/v1.0.0.html
         #
         # > A pre-release version number MAY be denoted by appending an
@@ -777,6 +779,10 @@ class Target(Serializable):
 
         return cls(head=head, email=email, branch=branch, remote=remote,
                    version=version)
+
+    def is_default_branch(self):
+        ## TODO: Switch the condition to "is" instead of "in" once "master" is removed from "default_branch".
+        return self.branch in self.default_branch
 
 
 class Task(Serializable):

--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -741,7 +741,8 @@ class Target(Serializable):
         self.github_repo = "/".join(_parse_github_user_repo(remote))
         self.version = version
         self.no_rc_version = re.sub(r'-rc\d+\Z', '', version)
-        # TODO(ARROW-17552): Remove "master" from default_branch after migration to "main".
+        # TODO(ARROW-17552): Remove "master" from default_branch after
+        #                    migration to "main".
         self.default_branch = ['main', 'master']
         # Semantic Versioning 1.0.0: https://semver.org/spec/v1.0.0.html
         #
@@ -781,7 +782,8 @@ class Target(Serializable):
                    version=version)
 
     def is_default_branch(self):
-        ## TODO: Switch the condition to "is" instead of "in" once "master" is removed from "default_branch".
+        # TODO(ARROW-17552): Switch the condition to "is" instead of "in"
+        #                    once "master" is removed from "default_branch".
         return self.branch in self.default_branch
 
 

--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -741,7 +741,7 @@ class Target(Serializable):
         self.github_repo = "/".join(_parse_github_user_repo(remote))
         self.version = version
         self.no_rc_version = re.sub(r'-rc\d+\Z', '', version)
-        # TODO: Remove "master" from default_branch after migration to "main".
+        # TODO(ARROW-17552): Remove "master" from default_branch after migration to "main".
         self.default_branch = ['main', 'master']
         # Semantic Versioning 1.0.0: https://semver.org/spec/v1.0.0.html
         #

--- a/dev/tasks/conda-recipes/README.md
+++ b/dev/tasks/conda-recipes/README.md
@@ -64,4 +64,4 @@ copied to the upstream feedstocks.
 
 [arrow-cpp-feedstock]: https://github.com/conda-forge/arrow-cpp-feedstock
 [parquet-cpp-feedstock]: https://github.com/conda-forge/parquet-cpp-feedstock
-[matrix-definition]: https://github.com/conda-forge/arrow-cpp-feedstock/blob/master/.azure-pipelines/azure-pipelines-linux.yml#L12
+[matrix-definition]: https://github.com/conda-forge/arrow-cpp-feedstock/blob/main/.azure-pipelines/azure-pipelines-linux.yml#L12

--- a/dev/tasks/conda-recipes/azure.clean.yml
+++ b/dev/tasks/conda-recipes/azure.clean.yml
@@ -1,3 +1,5 @@
+{% import 'macros.jinja' as macros with context %}
+
 jobs:
 - job: linux
   pool:
@@ -17,12 +19,12 @@ jobs:
     displayName: Install requirements
 
   - script: |
-      {% if arrow.branch == 'master' %}
+      {% if arrow.is_default_branch() %}
       mkdir -p $HOME/.continuum/anaconda-client/tokens/
       echo $(CROSSBOW_ANACONDA_TOKEN) > $HOME/.continuum/anaconda-client/tokens/https%3A%2F%2Fapi.anaconda.org.token
       {% endif %}
       eval "$(conda shell.bash hook)"
       conda activate base
-      python3 arrow/dev/tasks/conda-recipes/clean.py {% if arrow.branch == 'master' %}FORCE{% endif %}
+      python3 arrow/dev/tasks/conda-recipes/clean.py {% if arrow.is_default_branch() %}FORCE{% endif %}
     displayName: Delete outdated packages
 

--- a/dev/tasks/conda-recipes/azure.clean.yml
+++ b/dev/tasks/conda-recipes/azure.clean.yml
@@ -1,4 +1,19 @@
-{% import 'macros.jinja' as macros with context %}
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 jobs:
 - job: linux

--- a/dev/tasks/docker-tests/github.linux.yml
+++ b/dev/tasks/docker-tests/github.linux.yml
@@ -62,7 +62,7 @@ jobs:
           path: arrow/r/check/arrow.Rcheck/tests/testthat.Rout*
           if-no-files-found: ignore
 
-    {% if arrow.branch == 'master' %}
+    {% if arrow.is_default_branch() %}
       {{ macros.github_login_dockerhub()|indent }}
       - name: Push Docker Image
         shell: bash

--- a/dev/tasks/homebrew-formulae/apache-arrow-glib.rb
+++ b/dev/tasks/homebrew-formulae/apache-arrow-glib.rb
@@ -24,7 +24,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# https://github.com/Homebrew/homebrew-core/blob/master/Formula/apache-arrow-glib.rb
+# https://github.com/Homebrew/homebrew-core/blob/-/Formula/apache-arrow-glib.rb
 
 class ApacheArrowGlib < Formula
   desc "GLib bindings for Apache Arrow"

--- a/dev/tasks/homebrew-formulae/apache-arrow.rb
+++ b/dev/tasks/homebrew-formulae/apache-arrow.rb
@@ -24,7 +24,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# https://github.com/Homebrew/homebrew-core/blob/master/Formula/apache-arrow.rb
+# https://github.com/Homebrew/homebrew-core/blob/-/Formula/apache-arrow.rb
 
 class ApacheArrow < Formula
   desc "Columnar in-memory analytics layer designed to accelerate big data"

--- a/dev/tasks/homebrew-formulae/autobrew/apache-arrow.rb
+++ b/dev/tasks/homebrew-formulae/autobrew/apache-arrow.rb
@@ -15,8 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# https://github.com/autobrew/homebrew-core/blob/master/Formula/apache-arrow.rb
-
+# https://github.com/autobrew/homebrew-core/blob/-/Formula/apache-arrow.rb
 class ApacheArrow < Formula
   desc "Columnar in-memory analytics layer designed to accelerate big data"
   homepage "https://arrow.apache.org/"

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           name: ubuntu-shared-lib
           path: arrow-shared-libs-linux.tar.gz
-    {% if arrow.branch == 'master' %}
+    {% if arrow.is_default_branch() %}
       {{ macros.github_login_dockerhub()|indent }}
       - name: Push Docker Image
         shell: bash

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -111,7 +111,7 @@ on:
 {% endmacro %}
 
 {%- macro github_upload_gemfury(pattern) -%}
-  {%- if arrow.branch == 'master' -%}
+  {%- if arrow.is_default_branch() -%}
   - name: Upload package to Gemfury
     shell: bash
     run: |
@@ -157,7 +157,7 @@ on:
 {% endmacro %}
 
 {%- macro azure_upload_anaconda(pattern) -%}
-  {%- if arrow.branch == 'master' -%}
+  {%- if arrow.is_default_branch() -%}
   - task: CondaEnvironment@1
     inputs:
       packageSpecs: 'anaconda-client'
@@ -216,7 +216,7 @@ on:
 {% endmacro %}
 
 {%- macro travis_upload_gemfury(pattern) -%}
-  {%- if arrow.branch == 'master' -%}
+  {%- if arrow.is_default_branch() -%}
   - |
     WHEEL_PATH=$(echo arrow/python/repaired_wheels/*.whl)
     curl \
@@ -243,7 +243,7 @@ on:
           continue
         fi
         # Pin the current commit in the formula to test so that
-        # we're not always pulling from master
+        # we're not always pulling from the tip of the default branch
         sed -i '' -E \
           -e 's@https://github.com/apache/arrow.git"$@{{ arrow.remote }}.git", revision: "{{ arrow.head }}"@' \
           ${formula}
@@ -284,7 +284,7 @@ on:
 {% endmacro %}
 
 {%- macro github_test_r_src_pkg() -%}
-  source("https://raw.githubusercontent.com/apache/arrow/master/ci/etc/rprofile")
+  source("https://raw.githubusercontent.com/apache/arrow/HEAD/ci/etc/rprofile")
 
   install.packages(
     "arrow",

--- a/dev/tasks/nightlies.sample.yml
+++ b/dev/tasks/nightlies.sample.yml
@@ -16,7 +16,7 @@
 # under the License.
 
 # this travis configuration can be used to submit cron scheduled tasks
-# 1. copy this file to one of crossbow's branch (master for example) with
+# 1. copy this file to one of crossbow's branches with
 #    filename .travis.yml
 # 2. setup daily cron jobs for that particular branch, see travis'
 #    documentation https://docs.travis-ci.com/user/cron-jobs/

--- a/dev/tasks/python-sdist/github.yml
+++ b/dev/tasks/python-sdist/github.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build sdist
         run: |
           archery docker run python-sdist
-          {% if arrow.branch == 'master' %}
+          {% if arrow.is_default_branch() %}
           archery docker push python-sdist || :
           {% endif %}
         env:

--- a/dev/tasks/python-wheels/github.linux.amd64.yml
+++ b/dev/tasks/python-wheels/github.linux.amd64.yml
@@ -47,7 +47,7 @@ jobs:
       {{ macros.github_upload_releases("arrow/python/repaired_wheels/*.whl")|indent }}
       {{ macros.github_upload_gemfury("arrow/python/repaired_wheels/*.whl")|indent }}
 
-      {% if arrow.branch == 'master' %}
+      {% if arrow.is_default_branch() %}
       - name: Push Docker Image
         shell: bash
         run: |

--- a/dev/tasks/python-wheels/github.windows.yml
+++ b/dev/tasks/python-wheels/github.windows.yml
@@ -67,7 +67,7 @@ jobs:
       {{ macros.github_upload_releases("arrow/python/dist/*.whl")|indent }}
       {{ macros.github_upload_gemfury("arrow/python/dist/*.whl")|indent }}
 
-      {% if arrow.branch == 'master' %}
+      {% if arrow.is_default_branch() %}
       - name: Push Docker Image
         shell: cmd
         run: |

--- a/dev/tasks/python-wheels/travis.linux.arm64.yml
+++ b/dev/tasks/python-wheels/travis.linux.arm64.yml
@@ -66,7 +66,7 @@ after_success:
   {{ macros.travis_upload_releases("arrow/python/repaired_wheels/*.whl") }}
   {{ macros.travis_upload_gemfury("arrow/python/repaired_wheels/*.whl") }}
 
-  {% if arrow.branch == 'master' %}
+  {% if arrow.is_default_branch() %}
   # Push the docker image to dockerhub
   - archery docker push python-wheel-manylinux-{{ manylinux_version }}
   - archery docker push python-wheel-manylinux-test-unittests

--- a/dev/tasks/r/github.linux.rchk.yml
+++ b/dev/tasks/r/github.linux.rchk.yml
@@ -48,7 +48,7 @@ jobs:
           docker run -v `pwd`/packages:/rchk/packages kalibera/rchk:latest /rchk/packages/arrow_*.tar.gz |& tee rchk.out
       - name: Confirm that rchk has no errors
         # Suspicious call, [UP], and [PB] are all of the error types currently at
-        # https://github.com/kalibera/cran-checks/tree/master/rchk/results
+        # https://github.com/kalibera/cran-checks/tree/HEAD/rchk/results
         # though this might not be exhaustive, there does not appear to be a way to have rchk return an error code
         # CRAN also will remove some of the outputs (especially those related to Rcpp and strptime, e.g.
         # ERROR: too many states (abstraction error?))

--- a/dev/tasks/r/github.macos.brew.yml
+++ b/dev/tasks/r/github.macos.brew.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Install apache-arrow
         run: |
+          # TODO: Update the TODO for ARROW-16907 below to refer to main instead of master
+          #       after migrating the default branch to main.
           # TODO(ARROW-16907): apache/arrow@master seems to be installed already
           # so this does nothing on a branch/PR
           brew install -v --HEAD apache-arrow

--- a/dev/tasks/verify-rc/github.linux.amd64.docker.yml
+++ b/dev/tasks/verify-rc/github.linux.amd64.docker.yml
@@ -43,7 +43,7 @@ jobs:
             -e TEST_{{ target|upper }}=1 \
             {{ distro }}-verify-rc
 
-    {% if arrow.branch == 'master' %}
+    {% if arrow.is_default_branch() %}
       {{ macros.github_login_dockerhub()|indent }}
       - name: Push Docker Image
         shell: bash


### PR DESCRIPTION
# Overview

This pull request:

1. Removes hard-coded dependencies on "master" as the default branch name in the crossbow infrastructure and CI template files.

# Implementation

1. Removed comment/text references to "master" branch, including URLs to other repositories.
2. Modified `core.py` to add a new `default_branch` property and a new method `is_default_branch`, for checking whether on the default branch, to the `Target` class.
3. Modified CI template files to use the new `is_default_branch` function to check whether on the default branch.

# Testing

1. Using [lafiona/crossbow](https://github.com/lafiona/crossbow) as a queue repository for qualification.
2. Ran modified template jobs. All failures appeared to be unrelated to the changes.
3. The branch names for all relevant qualification jobs are prefixed with `build-34-*`. 
4. Example of a passing job: [https://github.com/lafiona/crossbow/actions/runs/2920227769](https://github.com/lafiona/crossbow/actions/runs/2920227769)
5. Example of a failing job: [https://github.com/lafiona/crossbow/runs/7998190113](https://github.com/lafiona/crossbow/runs/7998190113) - in this example, the *"Push Docker Image"* workflow step is not included, since we are not on the default branch. The failure appears to be related to issues fetching R package resources and not related to the default branch checking logic. There were a variety of other kinds of failures, but none of them appear related to the default branch checking logic.

# Future Directions

1. Remove "master" from `default_branch` name property of `Target` class.
2. Remove all remaining uses of "master" terminology in crossbow.
3. [ARROW-17512](https://issues.apache.org/jira/browse/ARROW-17512): Address minor issues with crossbow documentation.

# Notes

1. Thank you to @lafiona for her help with this pull request!
2. Due to unexpected technical issues, we opened this pull request as a follow up to https://github.com/apache/arrow/pull/13750. Please see https://github.com/apache/arrow/pull/13750 for more discussion regarding qualification efforts.