### PR TITLE
ARROW-17453: [Go][C++][Parquet] Inconsistent Data with Repetition Levels

### DIFF
--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -752,8 +752,11 @@ class ColumnReaderImplBase {
       repetition_level_decoder_.SetDataV2(page.repetition_levels_byte_length(),
                                           max_rep_level_,
                                           static_cast<int>(num_buffered_values_), buffer);
-      buffer += page.repetition_levels_byte_length();
     }
+    // ARROW-17453: Even if max_rep_level_ is 0, there may still be
+    // repetition level bytes written and/or reported in the header by
+    // some writers (e.g. Athena)
+    buffer += page.repetition_levels_byte_length();
 
     if (max_def_level_ > 0) {
       definition_level_decoder_.SetDataV2(page.definition_levels_byte_length(),

--- a/cpp/src/parquet/column_reader_test.cc
+++ b/cpp/src/parquet/column_reader_test.cc
@@ -361,7 +361,7 @@ TEST_F(TestPrimitiveReader, TestReadValuesMissing) {
 TEST_F(TestPrimitiveReader, TestRepetitionLvlBytesWithMaxRepetitionZero) {
   constexpr int batch_size = 4;
   max_def_level_ = 1;
-  max_rep_level_ = 0
+  max_rep_level_ = 0;
   NodePtr type = schema::Int32("a", Repetition::OPTIONAL);
   const ColumnDescriptor descr(type, max_def_level_, max_rep_level_);
   // Bytes here came from the example parquet file in ARROW-17453's int32
@@ -370,8 +370,8 @@ TEST_F(TestPrimitiveReader, TestRepetitionLvlBytesWithMaxRepetitionZero) {
   // though the max rep level is 0. If that byte isn't skipped then
   // we get def levels of [1, 1, 0, 0] instead of the correct [1, 1, 1, 0].
   const std::vector<uint8_t> page_data{0x3,  0x3, 0x7, 0x80, 0x1, 0x4, 0x3,
-                                          0x18, 0x1, 0x2, 0x0,  0x0, 0x0, 0xc,
-                                          0x0,  0x0, 0x0, 0x0,  0x0, 0x0, 0x0};
+                                       0x18, 0x1, 0x2, 0x0,  0x0, 0x0, 0xc,
+                                       0x0,  0x0, 0x0, 0x0,  0x0, 0x0, 0x0};
 
   std::shared_ptr<DataPageV2> data_page =
       std::make_shared<DataPageV2>(Buffer::Wrap(page_data.data(), page_data.size()), 4, 1,

--- a/cpp/src/parquet/column_reader_test.cc
+++ b/cpp/src/parquet/column_reader_test.cc
@@ -361,10 +361,15 @@ TEST_F(TestPrimitiveReader, TestReadValuesMissing) {
 TEST_F(TestPrimitiveReader, TestRepetitionLvlBytesWithMaxRepetitionZero) {
   constexpr int batch_size = 4;
   max_def_level_ = 1;
-  max_rep_level_ = 0;
+  max_rep_level_ = 0
   NodePtr type = schema::Int32("a", Repetition::OPTIONAL);
   const ColumnDescriptor descr(type, max_def_level_, max_rep_level_);
-  const std::array<uint8_t, 21> page_data{0x3,  0x3, 0x7, 0x80, 0x1, 0x4, 0x3,
+  // Bytes here came from the example parquet file in ARROW-17453's int32
+  // column which was delta bit-packed. The key part is the first three
+  // bytes: the page header reports 1 byte for repetition levels even
+  // though the max rep level is 0. If that byte isn't skipped then
+  // we get def levels of [1, 1, 0, 0] instead of the correct [1, 1, 1, 0].
+  const std::vector<uint8_t> page_data{0x3,  0x3, 0x7, 0x80, 0x1, 0x4, 0x3,
                                           0x18, 0x1, 0x2, 0x0,  0x0, 0x0, 0xc,
                                           0x0,  0x0, 0x0, 0x0,  0x0, 0x0, 0x0};
 

--- a/go/parquet/file/column_reader.go
+++ b/go/parquet/file/column_reader.go
@@ -279,8 +279,12 @@ func (c *columnChunkReader) initLevelDecodersV2(page *DataPageV2) (int64, error)
 
 	if c.descr.MaxRepetitionLevel() > 0 {
 		c.repetitionDecoder.SetDataV2(page.repLvlByteLen, c.descr.MaxRepetitionLevel(), int(c.numBuffered), buf)
-		buf = buf[page.repLvlByteLen:]
 	}
+	// ARROW-17453: Some writers will write repetition levels even when
+	// the max repetition level is 0, so we should respect the value
+	// in the page header regardless of whether MaxRepetitionLevel is 0
+	// or not.
+	buf = buf[page.repLvlByteLen:]
 
 	if c.descr.MaxDefinitionLevel() > 0 {
 		c.definitionDecoder.SetDataV2(page.defLvlByteLen, c.descr.MaxDefinitionLevel(), int(c.numBuffered), buf)

--- a/go/parquet/internal/encoding/delta_bit_packing.go
+++ b/go/parquet/internal/encoding/delta_bit_packing.go
@@ -50,7 +50,8 @@ type deltaBitPackDecoder struct {
 	deltaBitWidths *memory.Buffer
 	deltaBitWidth  byte
 
-	lastVal int64
+	totalValues uint64
+	lastVal     int64
 }
 
 // returns the number of bytes read so far
@@ -85,13 +86,8 @@ func (d *deltaBitPackDecoder) SetData(nvalues int, data []byte) error {
 		return xerrors.New("parquet: eof exception")
 	}
 
-	var totalValues uint64
-	if totalValues, ok = d.bitdecoder.GetVlqInt(); !ok {
+	if d.totalValues, ok = d.bitdecoder.GetVlqInt(); !ok {
 		return xerrors.New("parquet: eof exception")
-	}
-
-	if int(totalValues) != d.nvals {
-		return xerrors.New("parquet: mismatch between number of values and count in data header")
 	}
 
 	if d.lastVal, ok = d.bitdecoder.GetZigZagVlqInt(); !ok {


### PR DESCRIPTION
Both the C++ and Go parquet implementations assumed that if the max repetition level was 0, that there were no bytes to be skipped when initializing decoders for `DataPageV2` but the Parquet files produced by Athena in this case had repetition bytes to be skipped before getting the definition level bytes. Since the byte wasn't skipped, the wrong values were decoded for Definition levels.

In the case of the Go implementation, it made additional assumptions that proved to be incorrect on top of the same bug.

This fixes both of them to properly respect the repetition level byte length reported in the DataPageV2 header.