### PR TITLE
ARROW-17536: [Packaging][RPM][Gandiva] Fix build error on CentOS Stream 9

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow/yum/centos-9-stream/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/yum/centos-9-stream/Dockerfile
@@ -18,12 +18,15 @@
 ARG FROM=quay.io/centos/centos:stream9
 FROM ${FROM}
 
+ENV SCL=gcc-toolset-12
+
 ARG DEBUG
 
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
   dnf install -y ${quiet} epel-release && \
   dnf install --enablerepo=crb -y ${quiet} \
+    ${SCL} \
     bison \
     boost-devel \
     brotli-devel \


### PR DESCRIPTION
LLVM is built with gcc-toolset-12 and it can't be used with the
default g++. We also need to use gcc-toolset-12.

Error message:

    /usr/bin/ld: .../libgandiva.so.1000: undefined reference to
    `std::__glibcxx_assert_fail(char const*, int, char const*, char const*)'