### PR TITLE
ARROW-17052: [C++][Python][FlightRPC] expose flight structures serialize

### DIFF
--- a/cpp/src/arrow/flight/flight_internals_test.cc
+++ b/cpp/src/arrow/flight/flight_internals_test.cc
@@ -83,12 +83,35 @@ TEST(FlightTypes, LocationUnknownScheme) {
 }
 
 TEST(FlightTypes, RoundTripTypes) {
+  ActionType action_type{"action-type1", "action-type1-description"};
+  ASSERT_OK_AND_ASSIGN(std::string action_type_serialized,
+                       action_type.SerializeToString());
+  ASSERT_OK_AND_ASSIGN(ActionType action_type_deserialized,
+                       ActionType::Deserialize(action_type_serialized));
+  ASSERT_TRUE(action_type.Equals(action_type_deserialized));
+
+  Criteria criteria{"criteria1"};
+  ASSERT_OK_AND_ASSIGN(std::string criteria_serialized, criteria.SerializeToString());
+  ASSERT_OK_AND_ASSIGN(Criteria criteria_deserialized,
+                       Criteria::Deserialize(criteria_serialized));
+  ASSERT_EQ(criteria.expression, criteria_deserialized.expression);
+
   Action action{"action1", Buffer::FromString("action1-content")};
   ASSERT_OK_AND_ASSIGN(std::string action_serialized, action.SerializeToString());
   ASSERT_OK_AND_ASSIGN(Action action_deserialized,
                        Action::Deserialize(action_serialized));
   ASSERT_EQ(action.type, action_deserialized.type);
-  ASSERT_TRUE(action.body->Equals(*action_deserialized.body));
+  ASSERT_TRUE((action.body == action_deserialized.body) ||
+              (action.body != nullptr && action_deserialized.body != nullptr &&
+               action.body->Equals(*action_deserialized.body)));
+
+  Result result{Buffer::FromString("result1-content")};
+  ASSERT_OK_AND_ASSIGN(std::string result_serialized, result.SerializeToString());
+  ASSERT_OK_AND_ASSIGN(Result result_deserialized,
+                       Result::Deserialize(result_serialized));
+  ASSERT_TRUE((result.body == result_deserialized.body) ||
+              (result.body != nullptr && result_deserialized.body != nullptr &&
+               result.body->Equals(*result_deserialized.body)));
 
   Ticket ticket{"foo"};
   ASSERT_OK_AND_ASSIGN(std::string ticket_serialized, ticket.SerializeToString());

--- a/cpp/src/arrow/flight/flight_internals_test.cc
+++ b/cpp/src/arrow/flight/flight_internals_test.cc
@@ -88,51 +88,55 @@ TEST(FlightTypes, RoundTripTypes) {
                        action_type.SerializeToString());
   ASSERT_OK_AND_ASSIGN(ActionType action_type_deserialized,
                        ActionType::Deserialize(action_type_serialized));
-  ASSERT_TRUE(action_type.Equals(action_type_deserialized));
+  ASSERT_EQ(action_type, action_type_deserialized);
 
   Criteria criteria{"criteria1"};
   ASSERT_OK_AND_ASSIGN(std::string criteria_serialized, criteria.SerializeToString());
   ASSERT_OK_AND_ASSIGN(Criteria criteria_deserialized,
                        Criteria::Deserialize(criteria_serialized));
-  ASSERT_EQ(criteria.expression, criteria_deserialized.expression);
+  ASSERT_EQ(criteria, criteria_deserialized);
 
   Action action{"action1", Buffer::FromString("action1-content")};
   ASSERT_OK_AND_ASSIGN(std::string action_serialized, action.SerializeToString());
   ASSERT_OK_AND_ASSIGN(Action action_deserialized,
                        Action::Deserialize(action_serialized));
-  ASSERT_EQ(action.type, action_deserialized.type);
-  ASSERT_TRUE(action.body->Equals(*action_deserialized.body));
+  ASSERT_EQ(action, action_deserialized);
 
   Result result{Buffer::FromString("result1-content")};
   ASSERT_OK_AND_ASSIGN(std::string result_serialized, result.SerializeToString());
   ASSERT_OK_AND_ASSIGN(Result result_deserialized,
                        Result::Deserialize(result_serialized));
-  ASSERT_TRUE(result.body->Equals(*result_deserialized.body));
+  ASSERT_EQ(result, result_deserialized);
+
+  BasicAuth basic_auth{"username1", "password1"};
+  ASSERT_OK_AND_ASSIGN(std::string basic_auth_serialized, basic_auth.SerializeToString());
+  ASSERT_OK_AND_ASSIGN(BasicAuth basic_auth_deserialized,
+                       BasicAuth::Deserialize(basic_auth_serialized));
+  ASSERT_EQ(basic_auth, basic_auth_deserialized);
 
   SchemaResult schema_result{"schema_result1"};
   ASSERT_OK_AND_ASSIGN(std::string schema_result_serialized,
                        schema_result.SerializeToString());
   ASSERT_OK_AND_ASSIGN(SchemaResult schema_result_deserialized,
                        SchemaResult::Deserialize(schema_result_serialized));
-  ASSERT_EQ(schema_result.serialized_schema(),
-            schema_result_deserialized.serialized_schema());
+  ASSERT_EQ(schema_result, schema_result_deserialized);
 
   Ticket ticket{"foo"};
   ASSERT_OK_AND_ASSIGN(std::string ticket_serialized, ticket.SerializeToString());
   ASSERT_OK_AND_ASSIGN(Ticket ticket_deserialized,
                        Ticket::Deserialize(ticket_serialized));
-  ASSERT_EQ(ticket.ticket, ticket_deserialized.ticket);
+  ASSERT_EQ(ticket, ticket_deserialized);
 
   FlightDescriptor desc = FlightDescriptor::Command("select * from foo;");
   ASSERT_OK_AND_ASSIGN(std::string desc_serialized, desc.SerializeToString());
   ASSERT_OK_AND_ASSIGN(FlightDescriptor desc_deserialized,
                        FlightDescriptor::Deserialize(desc_serialized));
-  ASSERT_TRUE(desc.Equals(desc_deserialized));
+  ASSERT_EQ(desc, desc_deserialized);
 
   desc = FlightDescriptor::Path({"a", "b", "test.arrow"});
   ASSERT_OK_AND_ASSIGN(desc_serialized, desc.SerializeToString());
   ASSERT_OK_AND_ASSIGN(desc_deserialized, FlightDescriptor::Deserialize(desc_serialized));
-  ASSERT_TRUE(desc.Equals(desc_deserialized));
+  ASSERT_EQ(desc, desc_deserialized);
 
   FlightInfo::Data data;
   std::shared_ptr<Schema> schema =
@@ -148,7 +152,7 @@ TEST(FlightTypes, RoundTripTypes) {
   ASSERT_OK_AND_ASSIGN(std::string info_serialized, info->SerializeToString());
   ASSERT_OK_AND_ASSIGN(std::unique_ptr<FlightInfo> info_deserialized,
                        FlightInfo::Deserialize(info_serialized));
-  ASSERT_TRUE(info->descriptor().Equals(info_deserialized->descriptor()));
+  ASSERT_EQ(info->descriptor(), info_deserialized->descriptor());
   ASSERT_EQ(info->endpoints(), info_deserialized->endpoints());
   ASSERT_EQ(info->total_records(), info_deserialized->total_records());
   ASSERT_EQ(info->total_bytes(), info_deserialized->total_bytes());
@@ -158,7 +162,7 @@ TEST(FlightTypes, RoundTripTypes) {
                        flight_endpoint.SerializeToString());
   ASSERT_OK_AND_ASSIGN(FlightEndpoint flight_endpoint_deserialized,
                        FlightEndpoint::Deserialize(flight_endpoint_serialized));
-  ASSERT_TRUE(flight_endpoint.Equals(flight_endpoint_deserialized));
+  ASSERT_EQ(flight_endpoint, flight_endpoint_deserialized);
 }
 
 TEST(FlightTypes, RoundtripStatus) {

--- a/cpp/src/arrow/flight/flight_internals_test.cc
+++ b/cpp/src/arrow/flight/flight_internals_test.cc
@@ -83,6 +83,13 @@ TEST(FlightTypes, LocationUnknownScheme) {
 }
 
 TEST(FlightTypes, RoundTripTypes) {
+  Action action{"action1", Buffer::FromString("action1-content")};
+  ASSERT_OK_AND_ASSIGN(std::string action_serialized, action.SerializeToString());
+  ASSERT_OK_AND_ASSIGN(Action action_deserialized,
+                       Action::Deserialize(action_serialized));
+  ASSERT_EQ(action.type, action_deserialized.type);
+  ASSERT_TRUE(action.body->Equals(*action_deserialized.body));
+
   Ticket ticket{"foo"};
   ASSERT_OK_AND_ASSIGN(std::string ticket_serialized, ticket.SerializeToString());
   ASSERT_OK_AND_ASSIGN(Ticket ticket_deserialized,

--- a/cpp/src/arrow/flight/flight_internals_test.cc
+++ b/cpp/src/arrow/flight/flight_internals_test.cc
@@ -113,6 +113,14 @@ TEST(FlightTypes, RoundTripTypes) {
               (result.body != nullptr && result_deserialized.body != nullptr &&
                result.body->Equals(*result_deserialized.body)));
 
+  SchemaResult schema_result{"schema_result1"};
+  ASSERT_OK_AND_ASSIGN(std::string schema_result_serialized,
+                       schema_result.SerializeToString());
+  ASSERT_OK_AND_ASSIGN(SchemaResult schema_result_deserialized,
+                       SchemaResult::Deserialize(schema_result_serialized));
+  ASSERT_EQ(schema_result.serialized_schema(),
+            schema_result_deserialized.serialized_schema());
+
   Ticket ticket{"foo"};
   ASSERT_OK_AND_ASSIGN(std::string ticket_serialized, ticket.SerializeToString());
   ASSERT_OK_AND_ASSIGN(Ticket ticket_deserialized,
@@ -148,6 +156,13 @@ TEST(FlightTypes, RoundTripTypes) {
   ASSERT_EQ(info->endpoints(), info_deserialized->endpoints());
   ASSERT_EQ(info->total_records(), info_deserialized->total_records());
   ASSERT_EQ(info->total_bytes(), info_deserialized->total_bytes());
+
+  FlightEndpoint flight_endpoint{ticket, {location1, location2}};
+  ASSERT_OK_AND_ASSIGN(std::string flight_endpoint_serialized,
+                       flight_endpoint.SerializeToString());
+  ASSERT_OK_AND_ASSIGN(FlightEndpoint flight_endpoint_deserialized,
+                       FlightEndpoint::Deserialize(flight_endpoint_serialized));
+  ASSERT_TRUE(flight_endpoint.Equals(flight_endpoint_deserialized));
 }
 
 TEST(FlightTypes, RoundtripStatus) {

--- a/cpp/src/arrow/flight/flight_internals_test.cc
+++ b/cpp/src/arrow/flight/flight_internals_test.cc
@@ -101,17 +101,13 @@ TEST(FlightTypes, RoundTripTypes) {
   ASSERT_OK_AND_ASSIGN(Action action_deserialized,
                        Action::Deserialize(action_serialized));
   ASSERT_EQ(action.type, action_deserialized.type);
-  ASSERT_TRUE((action.body == action_deserialized.body) ||
-              (action.body != nullptr && action_deserialized.body != nullptr &&
-               action.body->Equals(*action_deserialized.body)));
+  ASSERT_TRUE(action.body->Equals(*action_deserialized.body));
 
   Result result{Buffer::FromString("result1-content")};
   ASSERT_OK_AND_ASSIGN(std::string result_serialized, result.SerializeToString());
   ASSERT_OK_AND_ASSIGN(Result result_deserialized,
                        Result::Deserialize(result_serialized));
-  ASSERT_TRUE((result.body == result_deserialized.body) ||
-              (result.body != nullptr && result_deserialized.body != nullptr &&
-               result.body->Equals(*result_deserialized.body)));
+  ASSERT_TRUE(result.body->Equals(*result_deserialized.body));
 
   SchemaResult schema_result{"schema_result1"};
   ASSERT_OK_AND_ASSIGN(std::string schema_result_serialized,

--- a/cpp/src/arrow/flight/serialization_internal.h
+++ b/cpp/src/arrow/flight/serialization_internal.h
@@ -60,6 +60,7 @@ Status FromProto(const pb::SchemaResult& pb_result, std::string* result);
 Status FromProto(const pb::BasicAuth& pb_basic_auth, BasicAuth* info);
 
 Status ToProto(const FlightDescriptor& descr, pb::FlightDescriptor* pb_descr);
+Status ToProto(const FlightEndpoint& endpoint, pb::FlightEndpoint* pb_endpoint);
 Status ToProto(const FlightInfo& info, pb::FlightInfo* pb_info);
 Status ToProto(const ActionType& type, pb::ActionType* pb_type);
 Status ToProto(const Action& action, pb::Action* pb_action);

--- a/cpp/src/arrow/flight/types.cc
+++ b/cpp/src/arrow/flight/types.cc
@@ -168,7 +168,7 @@ arrow::Result<std::string> SchemaResult::SerializeToString() const {
 
   std::string out;
   if (!pb_schema_result.SerializeToString(&out)) {
-    return Status::IOError("Serialized schema-result exceeded 2 GiB limit");
+    return Status::IOError("Serialized SchemaResult exceeded 2 GiB limit");
   }
   return out;
 }

--- a/cpp/src/arrow/flight/types.cc
+++ b/cpp/src/arrow/flight/types.cc
@@ -182,7 +182,7 @@ arrow::Result<SchemaResult> SchemaResult::Deserialize(
   google::protobuf::io::ArrayInputStream input(serialized.data(),
                                                static_cast<int>(serialized.size()));
   if (!pb_schema_result.ParseFromZeroCopyStream(&input)) {
-    return Status::Invalid("Not a valid schema-result");
+    return Status::Invalid("Not a valid SchemaResult");
   }
   SchemaResult out;
   RETURN_NOT_OK(internal::FromProto(pb_schema_result, &out));
@@ -195,7 +195,7 @@ arrow::Result<std::string> FlightDescriptor::SerializeToString() const {
 
   std::string out;
   if (!pb_descriptor.SerializeToString(&out)) {
-    return Status::IOError("Serialized descriptor exceeded 2 GiB limit");
+    return Status::IOError("Serialized FlightDescriptor exceeded 2 GiB limit");
   }
   return out;
 }
@@ -213,7 +213,7 @@ arrow::Result<FlightDescriptor> FlightDescriptor::Deserialize(
   google::protobuf::io::ArrayInputStream input(serialized.data(),
                                                static_cast<int>(serialized.size()));
   if (!pb_descriptor.ParseFromZeroCopyStream(&input)) {
-    return Status::Invalid("Not a valid descriptor");
+    return Status::Invalid("Not a valid FlightDescriptor");
   }
   FlightDescriptor out;
   RETURN_NOT_OK(internal::FromProto(pb_descriptor, &out));
@@ -233,7 +233,7 @@ arrow::Result<std::string> Ticket::SerializeToString() const {
 
   std::string out;
   if (!pb_ticket.SerializeToString(&out)) {
-    return Status::IOError("Serialized ticket exceeded 2 GiB limit");
+    return Status::IOError("Serialized Ticket exceeded 2 GiB limit");
   }
   return out;
 }
@@ -250,7 +250,7 @@ arrow::Result<Ticket> Ticket::Deserialize(arrow::util::string_view serialized) {
   google::protobuf::io::ArrayInputStream input(serialized.data(),
                                                static_cast<int>(serialized.size()));
   if (!pb_ticket.ParseFromZeroCopyStream(&input)) {
-    return Status::Invalid("Not a valid ticket");
+    return Status::Invalid("Not a valid Ticket");
   }
   Ticket out;
   RETURN_NOT_OK(internal::FromProto(pb_ticket, &out));
@@ -403,7 +403,7 @@ arrow::Result<std::string> FlightEndpoint::SerializeToString() const {
 
   std::string out;
   if (!pb_flight_endpoint.SerializeToString(&out)) {
-    return Status::IOError("Serialized flight-endpoint exceeded 2 GiB limit");
+    return Status::IOError("Serialized FlightEndpoint exceeded 2 GiB limit");
   }
   return out;
 }
@@ -417,7 +417,7 @@ arrow::Result<FlightEndpoint> FlightEndpoint::Deserialize(
   google::protobuf::io::ArrayInputStream input(serialized.data(),
                                                static_cast<int>(serialized.size()));
   if (!pb_flight_endpoint.ParseFromZeroCopyStream(&input)) {
-    return Status::Invalid("Not a valid flight-endpoint");
+    return Status::Invalid("Not a valid FlightEndpoint");
   }
   FlightEndpoint out;
   RETURN_NOT_OK(internal::FromProto(pb_flight_endpoint, &out));
@@ -434,7 +434,7 @@ arrow::Result<std::string> ActionType::SerializeToString() const {
 
   std::string out;
   if (!pb_action_type.SerializeToString(&out)) {
-    return Status::IOError("Serialized action-type exceeded 2 GiB limit");
+    return Status::IOError("Serialized ActionType exceeded 2 GiB limit");
   }
   return out;
 }
@@ -447,7 +447,7 @@ arrow::Result<ActionType> ActionType::Deserialize(arrow::util::string_view seria
   google::protobuf::io::ArrayInputStream input(serialized.data(),
                                                static_cast<int>(serialized.size()));
   if (!pb_action_type.ParseFromZeroCopyStream(&input)) {
-    return Status::Invalid("Not a valid action-type");
+    return Status::Invalid("Not a valid ActionType");
   }
   ActionType out;
   RETURN_NOT_OK(internal::FromProto(pb_action_type, &out));
@@ -460,7 +460,7 @@ arrow::Result<std::string> Criteria::SerializeToString() const {
 
   std::string out;
   if (!pb_criteria.SerializeToString(&out)) {
-    return Status::IOError("Serialized criteria exceeded 2 GiB limit");
+    return Status::IOError("Serialized Criteria exceeded 2 GiB limit");
   }
   return out;
 }
@@ -473,7 +473,7 @@ arrow::Result<Criteria> Criteria::Deserialize(arrow::util::string_view serialize
   google::protobuf::io::ArrayInputStream input(serialized.data(),
                                                static_cast<int>(serialized.size()));
   if (!pb_criteria.ParseFromZeroCopyStream(&input)) {
-    return Status::Invalid("Not a valid criteria");
+    return Status::Invalid("Not a valid Criteria");
   }
   Criteria out;
   RETURN_NOT_OK(internal::FromProto(pb_criteria, &out));
@@ -486,7 +486,7 @@ arrow::Result<std::string> Action::SerializeToString() const {
 
   std::string out;
   if (!pb_action.SerializeToString(&out)) {
-    return Status::IOError("Serialized action exceeded 2 GiB limit");
+    return Status::IOError("Serialized Action exceeded 2 GiB limit");
   }
   return out;
 }
@@ -499,7 +499,7 @@ arrow::Result<Action> Action::Deserialize(arrow::util::string_view serialized) {
   google::protobuf::io::ArrayInputStream input(serialized.data(),
                                                static_cast<int>(serialized.size()));
   if (!pb_action.ParseFromZeroCopyStream(&input)) {
-    return Status::Invalid("Not a valid action");
+    return Status::Invalid("Not a valid Action");
   }
   Action out;
   RETURN_NOT_OK(internal::FromProto(pb_action, &out));
@@ -512,7 +512,7 @@ arrow::Result<std::string> Result::SerializeToString() const {
 
   std::string out;
   if (!pb_result.SerializeToString(&out)) {
-    return Status::IOError("Serialized result exceeded 2 GiB limit");
+    return Status::IOError("Serialized Result exceeded 2 GiB limit");
   }
   return out;
 }
@@ -525,7 +525,7 @@ arrow::Result<Result> Result::Deserialize(arrow::util::string_view serialized) {
   google::protobuf::io::ArrayInputStream input(serialized.data(),
                                                static_cast<int>(serialized.size()));
   if (!pb_result.ParseFromZeroCopyStream(&input)) {
-    return Status::Invalid("Not a valid result");
+    return Status::Invalid("Not a valid Result");
   }
   Result out;
   RETURN_NOT_OK(internal::FromProto(pb_result, &out));

--- a/cpp/src/arrow/flight/types.cc
+++ b/cpp/src/arrow/flight/types.cc
@@ -184,9 +184,7 @@ arrow::Result<SchemaResult> SchemaResult::Deserialize(
   if (!pb_schema_result.ParseFromZeroCopyStream(&input)) {
     return Status::Invalid("Not a valid SchemaResult");
   }
-  SchemaResult out;
-  RETURN_NOT_OK(internal::FromProto(pb_schema_result, &out));
-  return out;
+  return SchemaResult{pb_schema_result.schema()};
 }
 
 arrow::Result<std::string> FlightDescriptor::SerializeToString() const {

--- a/cpp/src/arrow/flight/types.cc
+++ b/cpp/src/arrow/flight/types.cc
@@ -162,6 +162,33 @@ Status SchemaResult::GetSchema(ipc::DictionaryMemo* dictionary_memo,
   return GetSchema(dictionary_memo).Value(out);
 }
 
+arrow::Result<std::string> SchemaResult::SerializeToString() const {
+  pb::SchemaResult pb_schema_result;
+  RETURN_NOT_OK(internal::ToProto(*this, &pb_schema_result));
+
+  std::string out;
+  if (!pb_schema_result.SerializeToString(&out)) {
+    return Status::IOError("Serialized schema-result exceeded 2 GiB limit");
+  }
+  return out;
+}
+
+arrow::Result<SchemaResult> SchemaResult::Deserialize(
+    arrow::util::string_view serialized) {
+  pb::SchemaResult pb_schema_result;
+  if (serialized.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
+    return Status::Invalid("Serialized SchemaResult size should not exceed 2 GiB");
+  }
+  google::protobuf::io::ArrayInputStream input(serialized.data(),
+                                               static_cast<int>(serialized.size()));
+  if (!pb_schema_result.ParseFromZeroCopyStream(&input)) {
+    return Status::Invalid("Not a valid schema-result");
+  }
+  SchemaResult out;
+  RETURN_NOT_OK(internal::FromProto(pb_schema_result, &out));
+  return out;
+}
+
 arrow::Result<std::string> FlightDescriptor::SerializeToString() const {
   pb::FlightDescriptor pb_descriptor;
   RETURN_NOT_OK(internal::ToProto(*this, &pb_descriptor));
@@ -370,8 +397,87 @@ bool FlightEndpoint::Equals(const FlightEndpoint& other) const {
   return ticket == other.ticket && locations == other.locations;
 }
 
+arrow::Result<std::string> FlightEndpoint::SerializeToString() const {
+  pb::FlightEndpoint pb_flight_endpoint;
+  RETURN_NOT_OK(internal::ToProto(*this, &pb_flight_endpoint));
+
+  std::string out;
+  if (!pb_flight_endpoint.SerializeToString(&out)) {
+    return Status::IOError("Serialized flight-endpoint exceeded 2 GiB limit");
+  }
+  return out;
+}
+
+arrow::Result<FlightEndpoint> FlightEndpoint::Deserialize(
+    arrow::util::string_view serialized) {
+  pb::FlightEndpoint pb_flight_endpoint;
+  if (serialized.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
+    return Status::Invalid("Serialized FlightEndpoint size should not exceed 2 GiB");
+  }
+  google::protobuf::io::ArrayInputStream input(serialized.data(),
+                                               static_cast<int>(serialized.size()));
+  if (!pb_flight_endpoint.ParseFromZeroCopyStream(&input)) {
+    return Status::Invalid("Not a valid flight-endpoint");
+  }
+  FlightEndpoint out;
+  RETURN_NOT_OK(internal::FromProto(pb_flight_endpoint, &out));
+  return out;
+}
+
 bool ActionType::Equals(const ActionType& other) const {
   return type == other.type && description == other.description;
+}
+
+arrow::Result<std::string> ActionType::SerializeToString() const {
+  pb::ActionType pb_action_type;
+  RETURN_NOT_OK(internal::ToProto(*this, &pb_action_type));
+
+  std::string out;
+  if (!pb_action_type.SerializeToString(&out)) {
+    return Status::IOError("Serialized action-type exceeded 2 GiB limit");
+  }
+  return out;
+}
+
+arrow::Result<ActionType> ActionType::Deserialize(arrow::util::string_view serialized) {
+  pb::ActionType pb_action_type;
+  if (serialized.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
+    return Status::Invalid("Serialized ActionType size should not exceed 2 GiB");
+  }
+  google::protobuf::io::ArrayInputStream input(serialized.data(),
+                                               static_cast<int>(serialized.size()));
+  if (!pb_action_type.ParseFromZeroCopyStream(&input)) {
+    return Status::Invalid("Not a valid action-type");
+  }
+  ActionType out;
+  RETURN_NOT_OK(internal::FromProto(pb_action_type, &out));
+  return out;
+}
+
+arrow::Result<std::string> Criteria::SerializeToString() const {
+  pb::Criteria pb_criteria;
+  RETURN_NOT_OK(internal::ToProto(*this, &pb_criteria));
+
+  std::string out;
+  if (!pb_criteria.SerializeToString(&out)) {
+    return Status::IOError("Serialized criteria exceeded 2 GiB limit");
+  }
+  return out;
+}
+
+arrow::Result<Criteria> Criteria::Deserialize(arrow::util::string_view serialized) {
+  pb::Criteria pb_criteria;
+  if (serialized.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
+    return Status::Invalid("Serialized Criteria size should not exceed 2 GiB");
+  }
+  google::protobuf::io::ArrayInputStream input(serialized.data(),
+                                               static_cast<int>(serialized.size()));
+  if (!pb_criteria.ParseFromZeroCopyStream(&input)) {
+    return Status::Invalid("Not a valid criteria");
+  }
+  Criteria out;
+  RETURN_NOT_OK(internal::FromProto(pb_criteria, &out));
+  return out;
 }
 
 arrow::Result<std::string> Action::SerializeToString() const {
@@ -397,6 +503,32 @@ arrow::Result<Action> Action::Deserialize(arrow::util::string_view serialized) {
   }
   Action out;
   RETURN_NOT_OK(internal::FromProto(pb_action, &out));
+  return out;
+}
+
+arrow::Result<std::string> Result::SerializeToString() const {
+  pb::Result pb_result;
+  RETURN_NOT_OK(internal::ToProto(*this, &pb_result));
+
+  std::string out;
+  if (!pb_result.SerializeToString(&out)) {
+    return Status::IOError("Serialized result exceeded 2 GiB limit");
+  }
+  return out;
+}
+
+arrow::Result<Result> Result::Deserialize(arrow::util::string_view serialized) {
+  pb::Result pb_result;
+  if (serialized.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
+    return Status::Invalid("Serialized Result size should not exceed 2 GiB");
+  }
+  google::protobuf::io::ArrayInputStream input(serialized.data(),
+                                               static_cast<int>(serialized.size()));
+  if (!pb_result.ParseFromZeroCopyStream(&input)) {
+    return Status::Invalid("Not a valid result");
+  }
+  Result out;
+  RETURN_NOT_OK(internal::FromProto(pb_result, &out));
   return out;
 }
 

--- a/cpp/src/arrow/flight/types.cc
+++ b/cpp/src/arrow/flight/types.cc
@@ -162,6 +162,10 @@ Status SchemaResult::GetSchema(ipc::DictionaryMemo* dictionary_memo,
   return GetSchema(dictionary_memo).Value(out);
 }
 
+bool SchemaResult::Equals(const SchemaResult& other) const {
+  return raw_schema_ == other.raw_schema_;
+}
+
 arrow::Result<std::string> SchemaResult::SerializeToString() const {
   pb::SchemaResult pb_schema_result;
   RETURN_NOT_OK(internal::ToProto(*this, &pb_schema_result));
@@ -452,6 +456,10 @@ arrow::Result<ActionType> ActionType::Deserialize(arrow::util::string_view seria
   return out;
 }
 
+bool Criteria::Equals(const Criteria& other) const {
+  return expression == other.expression;
+}
+
 arrow::Result<std::string> Criteria::SerializeToString() const {
   pb::Criteria pb_criteria;
   RETURN_NOT_OK(internal::ToProto(*this, &pb_criteria));
@@ -478,6 +486,11 @@ arrow::Result<Criteria> Criteria::Deserialize(arrow::util::string_view serialize
   return out;
 }
 
+bool Action::Equals(const Action& other) const {
+  return (type == other.type) &&
+         ((body == other.body) || (body && other.body && body->Equals(*other.body)));
+}
+
 arrow::Result<std::string> Action::SerializeToString() const {
   pb::Action pb_action;
   RETURN_NOT_OK(internal::ToProto(*this, &pb_action));
@@ -502,6 +515,10 @@ arrow::Result<Action> Action::Deserialize(arrow::util::string_view serialized) {
   Action out;
   RETURN_NOT_OK(internal::FromProto(pb_action, &out));
   return out;
+}
+
+bool Result::Equals(const Result& other) const {
+  return (body == other.body) || (body && other.body && body->Equals(*other.body));
 }
 
 arrow::Result<std::string> Result::SerializeToString() const {
@@ -622,6 +639,10 @@ arrow::Result<std::unique_ptr<Result>> SimpleResultStream::Next() {
     return nullptr;
   }
   return std::unique_ptr<Result>(new Result(std::move(results_[position_++])));
+}
+
+bool BasicAuth::Equals(const BasicAuth& other) const {
+  return (username == other.username) && (password == other.password);
 }
 
 arrow::Result<BasicAuth> BasicAuth::Deserialize(arrow::util::string_view serialized) {

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -163,6 +163,18 @@ struct ARROW_FLIGHT_EXPORT Action {
 
   /// The action content as a Buffer
   std::shared_ptr<Buffer> body;
+
+  /// \brief Get the wire-format representation of this type.
+  ///
+  /// Useful when interoperating with non-Flight systems (e.g. REST
+  /// services) that may want to return Flight types.
+  arrow::Result<std::string> SerializeToString() const;
+
+  /// \brief Parse the wire-format representation of this type.
+  ///
+  /// Useful when interoperating with non-Flight systems (e.g. REST
+  /// services) that may want to return Flight types.
+  static arrow::Result<Action> Deserialize(arrow::util::string_view serialized);
 };
 
 /// \brief Opaque result returned after executing an action

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -460,6 +460,7 @@ struct ARROW_FLIGHT_EXPORT FlightPayload {
 /// \brief Schema result returned after a schema request RPC
 struct ARROW_FLIGHT_EXPORT SchemaResult {
  public:
+  SchemaResult() = default;
   explicit SchemaResult(std::string schema) : raw_schema_(std::move(schema)) {}
 
   /// \brief Factory method to construct a SchemaResult.

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -161,6 +161,15 @@ struct ARROW_FLIGHT_EXPORT Criteria {
   /// Opaque criteria expression, dependent on server implementation
   std::string expression;
 
+  bool Equals(const Criteria& other) const;
+
+  friend bool operator==(const Criteria& left, const Criteria& right) {
+    return left.Equals(right);
+  }
+  friend bool operator!=(const Criteria& left, const Criteria& right) {
+    return !(left == right);
+  }
+
   /// \brief Serialize this message to its wire-format representation.
   arrow::Result<std::string> SerializeToString() const;
 
@@ -176,6 +185,15 @@ struct ARROW_FLIGHT_EXPORT Action {
   /// The action content as a Buffer
   std::shared_ptr<Buffer> body;
 
+  bool Equals(const Action& other) const;
+
+  friend bool operator==(const Action& left, const Action& right) {
+    return left.Equals(right);
+  }
+  friend bool operator!=(const Action& left, const Action& right) {
+    return !(left == right);
+  }
+
   /// \brief Serialize this message to its wire-format representation.
   arrow::Result<std::string> SerializeToString() const;
 
@@ -186,6 +204,15 @@ struct ARROW_FLIGHT_EXPORT Action {
 /// \brief Opaque result returned after executing an action
 struct ARROW_FLIGHT_EXPORT Result {
   std::shared_ptr<Buffer> body;
+
+  bool Equals(const Result& other) const;
+
+  friend bool operator==(const Result& left, const Result& right) {
+    return left.Equals(right);
+  }
+  friend bool operator!=(const Result& left, const Result& right) {
+    return !(left == right);
+  }
 
   /// \brief Serialize this message to its wire-format representation.
   arrow::Result<std::string> SerializeToString() const;
@@ -198,6 +225,15 @@ struct ARROW_FLIGHT_EXPORT Result {
 struct ARROW_FLIGHT_EXPORT BasicAuth {
   std::string username;
   std::string password;
+
+  bool Equals(const BasicAuth& other) const;
+
+  friend bool operator==(const BasicAuth& left, const BasicAuth& right) {
+    return left.Equals(right);
+  }
+  friend bool operator!=(const BasicAuth& left, const BasicAuth& right) {
+    return !(left == right);
+  }
 
   /// \brief Deserialize this message from its wire-format representation.
   static arrow::Result<BasicAuth> Deserialize(arrow::util::string_view serialized);
@@ -442,7 +478,16 @@ struct ARROW_FLIGHT_EXPORT SchemaResult {
 
   const std::string& serialized_schema() const { return raw_schema_; }
 
-    /// \brief Serialize this message to its wire-format representation.
+  bool Equals(const SchemaResult& other) const;
+
+  friend bool operator==(const SchemaResult& left, const SchemaResult& right) {
+    return left.Equals(right);
+  }
+  friend bool operator!=(const SchemaResult& left, const SchemaResult& right) {
+    return !(left == right);
+  }
+
+  /// \brief Serialize this message to its wire-format representation.
   arrow::Result<std::string> SerializeToString() const;
 
   /// \brief Deserialize this message from its wire-format representation.

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -148,12 +148,24 @@ struct ARROW_FLIGHT_EXPORT ActionType {
   friend bool operator!=(const ActionType& left, const ActionType& right) {
     return !(left == right);
   }
+
+  /// \brief Serialize this message to its wire-format representation.
+  arrow::Result<std::string> SerializeToString() const;
+
+  /// \brief Deserialize this message from its wire-format representation.
+  static arrow::Result<ActionType> Deserialize(arrow::util::string_view serialized);
 };
 
 /// \brief Opaque selection criteria for ListFlights RPC
 struct ARROW_FLIGHT_EXPORT Criteria {
   /// Opaque criteria expression, dependent on server implementation
   std::string expression;
+
+  /// \brief Serialize this message to its wire-format representation.
+  arrow::Result<std::string> SerializeToString() const;
+
+  /// \brief Deserialize this message from its wire-format representation.
+  static arrow::Result<Criteria> Deserialize(arrow::util::string_view serialized);
 };
 
 /// \brief An action to perform with the DoAction RPC
@@ -164,22 +176,22 @@ struct ARROW_FLIGHT_EXPORT Action {
   /// The action content as a Buffer
   std::shared_ptr<Buffer> body;
 
-  /// \brief Get the wire-format representation of this type.
-  ///
-  /// Useful when interoperating with non-Flight systems (e.g. REST
-  /// services) that may want to return Flight types.
+  /// \brief Serialize this message to its wire-format representation.
   arrow::Result<std::string> SerializeToString() const;
 
-  /// \brief Parse the wire-format representation of this type.
-  ///
-  /// Useful when interoperating with non-Flight systems (e.g. REST
-  /// services) that may want to return Flight types.
+  /// \brief Deserialize this message from its wire-format representation.
   static arrow::Result<Action> Deserialize(arrow::util::string_view serialized);
 };
 
 /// \brief Opaque result returned after executing an action
 struct ARROW_FLIGHT_EXPORT Result {
   std::shared_ptr<Buffer> body;
+
+  /// \brief Serialize this message to its wire-format representation.
+  arrow::Result<std::string> SerializeToString() const;
+
+  /// \brief Deserialize this message from its wire-format representation.
+  static arrow::Result<Result> Deserialize(arrow::util::string_view serialized);
 };
 
 /// \brief message for simple auth
@@ -389,6 +401,12 @@ struct ARROW_FLIGHT_EXPORT FlightEndpoint {
   friend bool operator!=(const FlightEndpoint& left, const FlightEndpoint& right) {
     return !(left == right);
   }
+
+  /// \brief Serialize this message to its wire-format representation.
+  arrow::Result<std::string> SerializeToString() const;
+
+  /// \brief Deserialize this message from its wire-format representation.
+  static arrow::Result<FlightEndpoint> Deserialize(arrow::util::string_view serialized);
 };
 
 /// \brief Staging data structure for messages about to be put on the wire
@@ -423,6 +441,12 @@ struct ARROW_FLIGHT_EXPORT SchemaResult {
                    std::shared_ptr<Schema>* out) const;
 
   const std::string& serialized_schema() const { return raw_schema_; }
+
+    /// \brief Serialize this message to its wire-format representation.
+  arrow::Result<std::string> SerializeToString() const;
+
+  /// \brief Deserialize this message from its wire-format representation.
+  static arrow::Result<SchemaResult> Deserialize(arrow::util::string_view serialized);
 
  private:
   std::string raw_schema_;

--- a/python/pyarrow/_flight.pyx
+++ b/python/pyarrow/_flight.pyx
@@ -375,7 +375,7 @@ cdef class Result(_Weakrefable):
         return result
 
     def __eq__(self, Result other):
-        return self.result.get() == other.result.get()
+        return deref(self.result.get()) == deref(other.result.get())
 
 
 cdef class BasicAuth(_Weakrefable):
@@ -418,7 +418,7 @@ cdef class BasicAuth(_Weakrefable):
         return GetResultValue(self.basic_auth.get().SerializeToString())
 
     def __eq__(self, BasicAuth other):
-        return self.basic_auth.get() == other.basic_auth.get()
+        return deref(self.basic_auth.get()) == deref(other.basic_auth.get())
 
 
 class DescriptorType(enum.Enum):
@@ -813,10 +813,13 @@ cdef class SchemaResult(_Weakrefable):
         services) that may want to return Flight types.
 
         """
-        # cdef SchemaResult result = SchemaResult.__new__(SchemaResult)
-        # result.result.reset(new CSchemaResult(GetResultValue(
-        #     CSchemaResult.Deserialize(tobytes(serialized)))))
-        # return result
+        cdef SchemaResult result = SchemaResult.__new__(SchemaResult)
+        result.result.reset(new CSchemaResult(GetResultValue(
+            CSchemaResult.Deserialize(tobytes(serialized)))))
+        return result
+
+    def __eq__(self, SchemaResult other):
+        return deref(self.result.get()) == deref(other.result.get())
 
 
 cdef class FlightInfo(_Weakrefable):

--- a/python/pyarrow/_flight.pyx
+++ b/python/pyarrow/_flight.pyx
@@ -328,28 +328,6 @@ class ActionType(_ActionType):
         """
         return Action(self.type, buf)
 
-    def serialize(self):
-        """Get the wire-format representation of this type.
-
-        Useful when interoperating with non-Flight systems (e.g. REST
-        services) that may want to return Flight types.
-
-        """
-        return GetResultValue(self.action.SerializeToString())
-
-    @classmethod
-    def deserialize(cls, serialized):
-        """Parse the wire-format representation of this type.
-
-        Useful when interoperating with non-Flight systems (e.g. REST
-        services) that may want to return Flight types.
-
-        """
-        cdef ActionType action_type = ActionType.__new__(ActionType)
-        action_type.type,action_type.description = move(GetResultValue(
-            CActionType.Deserialize(tobytes(serialized))))
-        return action_type
-
 
 cdef class Result(_Weakrefable):
     """A result from executing an Action."""
@@ -388,9 +366,9 @@ cdef class Result(_Weakrefable):
         services) that may want to return Flight types.
 
         """
-        cdef Result result = Result.__new__(Result)
-        result.result = move(GetResultValue(
-            CFlightResult.Deserialize(tobytes(serialized))))
+        result = Result()
+        check_flight_status(
+            CFlightResult.Deserialize(serialized).Value(result.result.get()))
         return result
 
 
@@ -826,9 +804,9 @@ cdef class SchemaResult(_Weakrefable):
         services) that may want to return Flight types.
 
         """
-        cdef SchemaResult result = SchemaResult.__new__(SchemaResult)
-        result.result = move(GetResultValue(
-            CSchemaResult.Deserialize(tobytes(serialized))))
+        result = SchemaResult()
+        check_flight_status(
+            CSchemaResult.Deserialize(serialized).Value(result.result.get()))
         return result
 
 

--- a/python/pyarrow/_flight.pyx
+++ b/python/pyarrow/_flight.pyx
@@ -289,6 +289,28 @@ cdef class Action(_Weakrefable):
                 type(action)))
         return (<Action> action).action
 
+    def serialize(self):
+        """Get the wire-format representation of this type.
+
+        Useful when interoperating with non-Flight systems (e.g. REST
+        services) that may want to return Flight types.
+
+        """
+        return GetResultValue(self.action.SerializeToString())
+
+    @classmethod
+    def deserialize(cls, serialized):
+        """Parse the wire-format representation of this type.
+
+        Useful when interoperating with non-Flight systems (e.g. REST
+        services) that may want to return Flight types.
+
+        """
+        cdef Action action = Action.__new__(Action)
+        action.action = GetResultValue(
+            CAction.Deserialize(tobytes(serialized)))
+        return action
+
 
 _ActionType = collections.namedtuple('_ActionType', ['type', 'description'])
 
@@ -305,6 +327,28 @@ class ActionType(_ActionType):
             An Arrow buffer or Python bytes or bytes-like object.
         """
         return Action(self.type, buf)
+
+    def serialize(self):
+        """Get the wire-format representation of this type.
+
+        Useful when interoperating with non-Flight systems (e.g. REST
+        services) that may want to return Flight types.
+
+        """
+        return GetResultValue(self.action.SerializeToString())
+
+    @classmethod
+    def deserialize(cls, serialized):
+        """Parse the wire-format representation of this type.
+
+        Useful when interoperating with non-Flight systems (e.g. REST
+        services) that may want to return Flight types.
+
+        """
+        cdef ActionType action_type = ActionType.__new__(ActionType)
+        action_type.type,action_type.description = move(GetResultValue(
+            CActionType.Deserialize(tobytes(serialized))))
+        return action_type
 
 
 cdef class Result(_Weakrefable):
@@ -326,6 +370,28 @@ cdef class Result(_Weakrefable):
     def body(self):
         """Get the Buffer containing the result."""
         return pyarrow_wrap_buffer(self.result.get().body)
+
+    def serialize(self):
+        """Get the wire-format representation of this type.
+
+        Useful when interoperating with non-Flight systems (e.g. REST
+        services) that may want to return Flight types.
+
+        """
+        return GetResultValue(self.result.get().SerializeToString())
+
+    @classmethod
+    def deserialize(cls, serialized):
+        """Parse the wire-format representation of this type.
+
+        Useful when interoperating with non-Flight systems (e.g. REST
+        services) that may want to return Flight types.
+
+        """
+        cdef Result result = Result.__new__(Result)
+        result.result = move(GetResultValue(
+            CFlightResult.Deserialize(tobytes(serialized))))
+        return result
 
 
 cdef class BasicAuth(_Weakrefable):
@@ -686,6 +752,28 @@ cdef class FlightEndpoint(_Weakrefable):
         return [Location.wrap(location)
                 for location in self.endpoint.locations]
 
+    def serialize(self):
+        """Get the wire-format representation of this type.
+
+        Useful when interoperating with non-Flight systems (e.g. REST
+        services) that may want to return Flight types.
+
+        """
+        return GetResultValue(self.endpoint.SerializeToString())
+
+    @classmethod
+    def deserialize(cls, serialized):
+        """Parse the wire-format representation of this type.
+
+        Useful when interoperating with non-Flight systems (e.g. REST
+        services) that may want to return Flight types.
+
+        """
+        cdef FlightEndpoint endpoint = FlightEndpoint.__new__(FlightEndpoint)
+        endpoint.endpoint = GetResultValue(
+            CFlightEndpoint.Deserialize(tobytes(serialized)))
+        return endpoint
+
     def __repr__(self):
         return "<FlightEndpoint ticket: {!r} locations: {!r}>".format(
             self.ticket, self.locations)
@@ -720,6 +808,28 @@ cdef class SchemaResult(_Weakrefable):
 
         check_flight_status(self.result.get().GetSchema(&dummy_memo).Value(&schema))
         return pyarrow_wrap_schema(schema)
+
+    def serialize(self):
+        """Get the wire-format representation of this type.
+
+        Useful when interoperating with non-Flight systems (e.g. REST
+        services) that may want to return Flight types.
+
+        """
+        return GetResultValue(self.result.get().SerializeToString())
+
+    @classmethod
+    def deserialize(cls, serialized):
+        """Parse the wire-format representation of this type.
+
+        Useful when interoperating with non-Flight systems (e.g. REST
+        services) that may want to return Flight types.
+
+        """
+        cdef SchemaResult result = SchemaResult.__new__(SchemaResult)
+        result.result = move(GetResultValue(
+            CSchemaResult.Deserialize(tobytes(serialized))))
+        return result
 
 
 cdef class FlightInfo(_Weakrefable):

--- a/python/pyarrow/_flight.pyx
+++ b/python/pyarrow/_flight.pyx
@@ -311,6 +311,11 @@ cdef class Action(_Weakrefable):
             CAction.Deserialize(tobytes(serialized)))
         return action
 
+    def __eq__(self, Action other):
+        # TODO (qhoang): question for myself, do we need to push this down
+        # to C++ for checking with body as well (similar to Ticker, e.g.)
+        return self.action.type == other.action.type
+
 
 _ActionType = collections.namedtuple('_ActionType', ['type', 'description'])
 

--- a/python/pyarrow/includes/libarrow_flight.pxd
+++ b/python/pyarrow/includes/libarrow_flight.pxd
@@ -28,15 +28,27 @@ cdef extern from "arrow/flight/api.h" namespace "arrow" nogil:
     cdef cppclass CActionType" arrow::flight::ActionType":
         c_string type
         c_string description
+        CResult[c_string] SerializeToString()
+
+        @staticmethod
+        CResult[CActionType] Deserialize(const c_string& serialized)
 
     cdef cppclass CAction" arrow::flight::Action":
         c_string type
         shared_ptr[CBuffer] body
+        CResult[c_string] SerializeToString()
+
+        @staticmethod
+        CResult[CAction] Deserialize(const c_string& serialized)
 
     cdef cppclass CFlightResult" arrow::flight::Result":
         CFlightResult()
         CFlightResult(CFlightResult)
         shared_ptr[CBuffer] body
+        CResult[c_string] SerializeToString()
+
+        @staticmethod
+        CResult[CFlightResult] Deserialize(const c_string& serialized)
 
     cdef cppclass CBasicAuth" arrow::flight::BasicAuth":
         CBasicAuth()
@@ -86,6 +98,10 @@ cdef extern from "arrow/flight/api.h" namespace "arrow" nogil:
     cdef cppclass CCriteria" arrow::flight::Criteria":
         CCriteria()
         c_string expression
+        CResult[c_string] SerializeToString()
+
+        @staticmethod
+        CResult[CCriteria] Deserialize(const c_string& serialized)
 
     cdef cppclass CLocation" arrow::flight::Location":
         CLocation()
@@ -111,6 +127,10 @@ cdef extern from "arrow/flight/api.h" namespace "arrow" nogil:
         vector[CLocation] locations
 
         bint operator==(CFlightEndpoint)
+        CResult[c_string] SerializeToString()
+
+        @staticmethod
+        CResult[CFlightEndpoint] Deserialize(const c_string& serialized)
 
     cdef cppclass CFlightInfo" arrow::flight::FlightInfo":
         CFlightInfo(CFlightInfo info)
@@ -128,6 +148,10 @@ cdef extern from "arrow/flight/api.h" namespace "arrow" nogil:
     cdef cppclass CSchemaResult" arrow::flight::SchemaResult":
         CSchemaResult(CSchemaResult result)
         CResult[shared_ptr[CSchema]] GetSchema(CDictionaryMemo* memo)
+        CResult[c_string] SerializeToString()
+
+        @staticmethod
+        CResult[CSchemaResult] Deserialize(const c_string& serialized)
 
     cdef cppclass CFlightListing" arrow::flight::FlightListing":
         CResult[unique_ptr[CFlightInfo]] Next()

--- a/python/pyarrow/includes/libarrow_flight.pxd
+++ b/python/pyarrow/includes/libarrow_flight.pxd
@@ -150,6 +150,7 @@ cdef extern from "arrow/flight/api.h" namespace "arrow" nogil:
             const c_string& serialized)
 
     cdef cppclass CSchemaResult" arrow::flight::SchemaResult":
+        CSchemaResult()
         CSchemaResult(CSchemaResult result)
         CResult[shared_ptr[CSchema]] GetSchema(CDictionaryMemo* memo)
         bint operator==(CSchemaResult)

--- a/python/pyarrow/includes/libarrow_flight.pxd
+++ b/python/pyarrow/includes/libarrow_flight.pxd
@@ -28,6 +28,7 @@ cdef extern from "arrow/flight/api.h" namespace "arrow" nogil:
     cdef cppclass CActionType" arrow::flight::ActionType":
         c_string type
         c_string description
+        bint operator==(CActionType)
         CResult[c_string] SerializeToString()
 
         @staticmethod
@@ -36,6 +37,7 @@ cdef extern from "arrow/flight/api.h" namespace "arrow" nogil:
     cdef cppclass CAction" arrow::flight::Action":
         c_string type
         shared_ptr[CBuffer] body
+        bint operator==(CAction)
         CResult[c_string] SerializeToString()
 
         @staticmethod
@@ -45,6 +47,7 @@ cdef extern from "arrow/flight/api.h" namespace "arrow" nogil:
         CFlightResult()
         CFlightResult(CFlightResult)
         shared_ptr[CBuffer] body
+        bint operator==(CFlightResult)
         CResult[c_string] SerializeToString()
 
         @staticmethod
@@ -56,7 +59,7 @@ cdef extern from "arrow/flight/api.h" namespace "arrow" nogil:
         CBasicAuth(CBasicAuth)
         c_string username
         c_string password
-
+        bint operator==(CBasicAuth)
         CResult[c_string] SerializeToString()
 
         @staticmethod
@@ -80,11 +83,11 @@ cdef extern from "arrow/flight/api.h" namespace "arrow" nogil:
         CDescriptorType type
         c_string cmd
         vector[c_string] path
+        bint operator==(CFlightDescriptor)
         CResult[c_string] SerializeToString()
 
         @staticmethod
         CResult[CFlightDescriptor] Deserialize(const c_string& serialized)
-        bint operator==(CFlightDescriptor)
 
     cdef cppclass CTicket" arrow::flight::Ticket":
         CTicket()
@@ -98,6 +101,7 @@ cdef extern from "arrow/flight/api.h" namespace "arrow" nogil:
     cdef cppclass CCriteria" arrow::flight::Criteria":
         CCriteria()
         c_string expression
+        bint operator==(CCriteria)
         CResult[c_string] SerializeToString()
 
         @staticmethod
@@ -148,6 +152,7 @@ cdef extern from "arrow/flight/api.h" namespace "arrow" nogil:
     cdef cppclass CSchemaResult" arrow::flight::SchemaResult":
         CSchemaResult(CSchemaResult result)
         CResult[shared_ptr[CSchema]] GetSchema(CDictionaryMemo* memo)
+        bint operator==(CSchemaResult)
         CResult[c_string] SerializeToString()
 
         @staticmethod

--- a/python/pyarrow/tests/test_flight.py
+++ b/python/pyarrow/tests/test_flight.py
@@ -1563,10 +1563,20 @@ def test_roundtrip_types():
     action = flight.Action("action1", b"action1-body")
     assert action == flight.Action.deserialize(action.serialize())
 
-    #TODO (qhoang): this is still a draft
-
     ticket = flight.Ticket("foo")
     assert ticket == flight.Ticket.deserialize(ticket.serialize())
+
+    result = flight.Result(b"result1")
+    result2 = flight.Result.deserialize(result.serialize())
+    assert result.body == result2.body
+
+    basic_auth = flight.BasicAuth("username1", "password1")
+    basic_auth2 = flight.BasicAuth.deserialize(basic_auth.serialize())
+    assert basic_auth.username == basic_auth2.username
+    assert basic_auth.password == basic_auth2.password
+
+    schema_result = flight.SchemaResult(pa.schema([('a', pa.int32())]))
+    # schema_result2 = flight.SchemaResult.deserialize(schema_result.serialize())
 
     desc = flight.FlightDescriptor.for_command("test")
     assert desc == flight.FlightDescriptor.deserialize(desc.serialize())
@@ -1597,6 +1607,7 @@ def test_roundtrip_types():
     endpoint = flight.FlightEndpoint(
         ticket, ['grpc://test', flight.Location.for_grpc_tcp('localhost', 5005)])
     assert endpoint == flight.FlightEndpoint.deserialize(endpoint.serialize())
+
 
 def test_roundtrip_errors():
     """Ensure that Flight errors propagate from server to client."""

--- a/python/pyarrow/tests/test_flight.py
+++ b/python/pyarrow/tests/test_flight.py
@@ -1603,7 +1603,9 @@ def test_roundtrip_types():
     assert info.endpoints == info2.endpoints
 
     endpoint = flight.FlightEndpoint(
-        ticket, ['grpc://test', flight.Location.for_grpc_tcp('localhost', 5005)])
+        ticket,
+        ['grpc://test', flight.Location.for_grpc_tcp('localhost', 5005)]
+    )
     assert endpoint == flight.FlightEndpoint.deserialize(endpoint.serialize())
 
 

--- a/python/pyarrow/tests/test_flight.py
+++ b/python/pyarrow/tests/test_flight.py
@@ -1567,16 +1567,14 @@ def test_roundtrip_types():
     assert ticket == flight.Ticket.deserialize(ticket.serialize())
 
     result = flight.Result(b"result1")
-    result2 = flight.Result.deserialize(result.serialize())
-    assert result.body == result2.body
+    assert result == flight.Result.deserialize(result.serialize())
 
     basic_auth = flight.BasicAuth("username1", "password1")
-    basic_auth2 = flight.BasicAuth.deserialize(basic_auth.serialize())
-    assert basic_auth.username == basic_auth2.username
-    assert basic_auth.password == basic_auth2.password
+    assert basic_auth == flight.BasicAuth.deserialize(basic_auth.serialize())
 
     schema_result = flight.SchemaResult(pa.schema([('a', pa.int32())]))
-    # schema_result2 = flight.SchemaResult.deserialize(schema_result.serialize())
+    assert schema_result == flight.SchemaResult.deserialize(
+        schema_result.serialize())
 
     desc = flight.FlightDescriptor.for_command("test")
     assert desc == flight.FlightDescriptor.deserialize(desc.serialize())

--- a/python/pyarrow/tests/test_flight.py
+++ b/python/pyarrow/tests/test_flight.py
@@ -1560,6 +1560,11 @@ def test_cancel_do_get_threaded():
 
 def test_roundtrip_types():
     """Make sure serializable types round-trip."""
+    action = flight.Action("action1", b"action1-body")
+    assert action == flight.Action.deserialize(action.serialize())
+
+    #TODO (qhoang): this is still a draft
+
     ticket = flight.Ticket("foo")
     assert ticket == flight.Ticket.deserialize(ticket.serialize())
 
@@ -1589,6 +1594,9 @@ def test_roundtrip_types():
     assert info.total_records == info2.total_records
     assert info.endpoints == info2.endpoints
 
+    endpoint = flight.FlightEndpoint(
+        ticket, ['grpc://test', flight.Location.for_grpc_tcp('localhost', 5005)])
+    assert endpoint == flight.FlightEndpoint.deserialize(endpoint.serialize())
 
 def test_roundtrip_errors():
     """Ensure that Flight errors propagate from server to client."""


### PR DESCRIPTION
Expose serialize and deserialize for flight structures in C++ and Python: Action, ActionType, Criteria, FlightEndpoint, Result and SchemaResult

Notes of no change on Cython binding for:
* Criteria and PutResult (FlightClient::DoPutResult) aren't exposed directly
* ActionType is implemented with named-tuple