### PR TITLE
ARROW-17544: [C++][Python] Add support for S3 Bucket versioning

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -277,6 +277,13 @@ class ARROW_EXPORT S3FileSystem : public FileSystem {
   /// a custom readahead strategy to avoid idle waits.
   Result<std::shared_ptr<io::InputStream>> OpenInputStream(
       const std::string& path) override;
+
+  /// Create a sequential input stream for reading from a S3 object,
+  /// using a version identifier.
+  Result<std::shared_ptr<io::InputStream>> OpenInputStreamWithVersion(
+      const std::string& path,
+      const std::string& version);
+
   /// Create a sequential input stream for reading from a S3 object.
   ///
   /// This override avoids a HEAD request by assuming the FileInfo
@@ -288,6 +295,11 @@ class ARROW_EXPORT S3FileSystem : public FileSystem {
   /// See OpenInputStream for performance notes.
   Result<std::shared_ptr<io::RandomAccessFile>> OpenInputFile(
       const std::string& path) override;
+
+  Result<std::shared_ptr<io::RandomAccessFile>> OpenInputFileWithVersion(
+      const std::string& path,
+      const std::string& version);
+
   /// Create a random access file for reading from a S3 object.
   ///
   /// This override avoids a HEAD request by assuming the FileInfo

--- a/cpp/src/arrow/io/buffered.cc
+++ b/cpp/src/arrow/io/buffered.cc
@@ -245,6 +245,10 @@ Status BufferedOutputStream::Flush() { return impl_->Flush(); }
 
 std::shared_ptr<OutputStream> BufferedOutputStream::raw() const { return impl_->raw(); }
 
+Result<std::shared_ptr<const KeyValueMetadata>> BufferedOutputStream::ReadMetadata() {
+  return impl_->raw()->ReadMetadata();
+}
+
 // ----------------------------------------------------------------------
 // BufferedInputStream implementation
 

--- a/cpp/src/arrow/io/buffered.h
+++ b/cpp/src/arrow/io/buffered.h
@@ -82,6 +82,8 @@ class ARROW_EXPORT BufferedOutputStream : public OutputStream {
   /// \brief Return the underlying raw output stream.
   std::shared_ptr<OutputStream> raw() const;
 
+  Result<std::shared_ptr<const KeyValueMetadata>> ReadMetadata() override;
+
  private:
   explicit BufferedOutputStream(std::shared_ptr<OutputStream> raw, MemoryPool* pool);
 

--- a/cpp/src/arrow/io/interfaces.cc
+++ b/cpp/src/arrow/io/interfaces.cc
@@ -117,6 +117,10 @@ Result<std::shared_ptr<const KeyValueMetadata>> InputStream::ReadMetadata() {
   return std::shared_ptr<const KeyValueMetadata>{};
 }
 
+Result<std::shared_ptr<const KeyValueMetadata>> OutputStream::ReadMetadata() {
+  return std::shared_ptr<const KeyValueMetadata>{};
+}
+
 // Default ReadMetadataAsync() implementation: simply issue the read on the context's
 // executor
 Future<std::shared_ptr<const KeyValueMetadata>> InputStream::ReadMetadataAsync(

--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -205,6 +205,17 @@ class ARROW_EXPORT Readable {
 };
 
 class ARROW_EXPORT OutputStream : virtual public FileInterface, public Writable {
+ public:
+  /// \brief Read and return stream metadata
+  ///
+  /// If the stream implementation doesn't support metadata, empty metadata
+  /// is returned.  Note that it is allowed to return a null pointer rather
+  /// than an allocated empty metadata.
+  ///
+  /// The metadata may be populated by the stream being closed.
+  ///
+  virtual Result<std::shared_ptr<const KeyValueMetadata>> ReadMetadata();
+
  protected:
   OutputStream() = default;
 };

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1274,7 +1274,7 @@ cdef extern from "arrow/io/api.h" namespace "arrow::io" nogil:
 
     cdef cppclass COutputStream" arrow::io::OutputStream"(FileInterface,
                                                           Writable):
-        pass
+        CResult[shared_ptr[const CKeyValueMetadata]] ReadMetadata()
 
     cdef cppclass CInputStream" arrow::io::InputStream"(FileInterface,
                                                         Readable):

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -201,6 +201,12 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
                                   const int load_frequency)
 
     cdef cppclass CS3FileSystem "arrow::fs::S3FileSystem"(CFileSystem):
+
+        CResult[shared_ptr[CRandomAccessFile]] OpenInputFileWithVersion(
+            const c_string& path, const c_string& version)
+        CResult[shared_ptr[CInputStream]] OpenInputStreamWithVersion(
+            const c_string& path, const c_string& version)
+
         @staticmethod
         CResult[shared_ptr[CS3FileSystem]] Make(const CS3Options& options)
         CS3Options options()

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -244,9 +244,14 @@ cdef class NativeFile(_Weakrefable):
         cdef:
             shared_ptr[const CKeyValueMetadata] c_metadata
 
-        handle = self.get_input_stream()
-        with nogil:
-            c_metadata = GetResultValue(handle.get().ReadMetadata())
+        if self.is_readable:
+            read_handle = self.get_input_stream()
+            with nogil:
+                c_metadata = GetResultValue(read_handle.get().ReadMetadata())
+        else:
+            write_handle = self.output_stream
+            with nogil:
+                c_metadata = GetResultValue(write_handle.get().ReadMetadata())
 
         metadata = {}
         if c_metadata.get() != nullptr:

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -992,6 +992,10 @@ def test_open_output_stream_metadata(fs, pathfn):
     with fs.open_output_stream(p, metadata=metadata) as f:
         f.write(data)
 
+    if fs.type_name in ['s3']:
+        write_metadata = f.metadata()
+        assert "ETag" in write_metadata
+
     with fs.open_input_stream(p) as f:
         assert f.read() == data
         got_metadata = f.metadata()


### PR DESCRIPTION
Add support for S3 bucket versioning for both C++ and Python
interfaces.

As described at:

https://issues.apache.org/jira/browse/ARROW-17544