### PR TITLE
ARROW-14495: [Python] Fix DictionaryArray.from_buffers, should not crash

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -2490,7 +2490,7 @@ cdef class DictionaryArray(Array):
         length : int
             The number of values in the array.
         buffers : List[Buffer]
-            The buffers backing this array.
+            The buffers backing the indices array.
         dictionary : pyarrow.Array, ndarray or pandas.Series
             The array of values referenced by the indices.
         null_count : int, default -1

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -2494,7 +2494,7 @@ cdef class DictionaryArray(Array):
         dictionary : pyarrow.Array, ndarray or pandas.Series
             The array of values referenced by the indices.
         null_count : int, default -1
-            The number of null entries in the array. Negative value means that
+            The number of null entries in the indices array. Negative value means that
             the null count is not known.
         offset : int, default 0
             The array's logical offset (in values, not in bytes) from the

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -2479,6 +2479,55 @@ cdef class DictionaryArray(Array):
         return self._indices
 
     @staticmethod
+    def from_buffers(DataType type, int64_t length, buffers, dictionary,
+                     int64_t null_count=-1, int64_t offset=0, memory_pool=None):
+        """
+        Construct a DictionaryArray from buffers.
+
+        type : pyarrow.DataType
+        length : int
+            The number of values in the array.
+        buffers : List[Buffer]
+            The buffers backing this array.
+        dictionary : pyarrow.Array, ndarray or pandas.Series
+            The array of values referenced by the indices.
+        null_count : int, default -1
+            The number of null entries in the array. Negative value means that
+            the null count is not known.
+        offset : int, default 0
+            The array's logical offset (in values, not in bytes) from the
+            start of each buffer.
+        memory_pool : MemoryPool, default None
+            For memory allocations, if required, otherwise uses default pool.
+        """
+        cdef:
+            Array _dictionary
+            vector[shared_ptr[CBuffer]] c_buffers
+            shared_ptr[CDataType] c_type
+            shared_ptr[CArrayData] c_data
+            shared_ptr[CArray] c_result
+
+        for buf in buffers:
+            c_buffers.push_back(pyarrow_unwrap_buffer(buf))
+
+        if isinstance(dictionary, Array):
+            _dictionary = dictionary
+        else:
+            _dictionary = array(dictionary, memory_pool=memory_pool)
+
+        c_type = pyarrow_unwrap_data_type(type)
+
+        with nogil:
+            c_data = CArrayData.Make(
+                c_type, length, c_buffers, null_count, offset)
+            c_data.get().dictionary = _dictionary.sp_array.get().data()
+            c_result.reset(new CDictionaryArray(c_data))
+
+        cdef Array result = pyarrow_wrap_array(c_result)
+        result.validate()
+        return result
+
+    @staticmethod
     def from_arrays(indices, dictionary, mask=None, bint ordered=False,
                     bint from_pandas=False, bint safe=True,
                     MemoryPool memory_pool=None):

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -250,6 +250,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         CDictionaryArray(const shared_ptr[CDataType]& type,
                          const shared_ptr[CArray]& indices,
                          const shared_ptr[CArray]& dictionary)
+        CDictionaryArray(const shared_ptr[CArrayData]& data)
 
         @staticmethod
         CResult[shared_ptr[CArray]] FromArrays(

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -725,11 +725,13 @@ def test_struct_array_from_chunked():
         pa.StructArray.from_arrays([chunked_arr], ["foo"])
 
 
-def test_dictionary_from_buffers():
+@pytest.mark.parametrize("offset", (0, 1))
+def test_dictionary_from_buffers(offset):
     a = pa.array(["one", "two", "three", "two", "one"]).dictionary_encode()
-    b = pa.DictionaryArray.from_buffers(
-        a.type, len(a), a.indices.buffers(), a.dictionary)
-    assert a == b
+    b = pa.DictionaryArray.from_buffers(a.type, len(a)-offset,
+                                        a.indices.buffers(), a.dictionary,
+                                        offset=offset)
+    assert a[offset:] == b
 
 
 def test_dictionary_from_numpy():

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -725,6 +725,13 @@ def test_struct_array_from_chunked():
         pa.StructArray.from_arrays([chunked_arr], ["foo"])
 
 
+def test_dictionary_from_buffers():
+    a = pa.array(["one", "two", "three", "two", "one"]).dictionary_encode()
+    b = pa.DictionaryArray.from_buffers(
+        a.type, len(a), a.indices.buffers(), a.dictionary)
+    assert a == b
+
+
 def test_dictionary_from_numpy():
     indices = np.repeat([0, 1, 2], 2)
     dictionary = np.array(['foo', 'bar', 'baz'], dtype=object)


### PR DESCRIPTION
Fix [ARROW-14495](https://issues.apache.org/jira/browse/ARROW-14495)