### PR TITLE
ARROW-17543: [R] Fix bug for NULL type 0-length vectors in array creation

### DIFF
--- a/r/R/array.R
+++ b/r/R/array.R
@@ -176,6 +176,9 @@ Array$create <- function(x, type = NULL) {
   if (!is.null(type)) {
     type <- as_type(type)
   }
+  if (is.null(x) && is.null(type)) {
+    type <- null()
+  }
   if (inherits(x, "Scalar")) {
     out <- x$as_array()
     if (!is.null(type)) {

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -180,6 +180,11 @@ test_that("Array support null type (ARROW-7064)", {
   expect_array_roundtrip(vctrs::unspecified(10), null())
 })
 
+test_that("Array support 0-length NULL vectors (Arrow-17543)", {
+  expect_equal(Array$create(c())$type, null())
+  expect_equal(Array$create(NULL)$type, null())
+})
+
 test_that("Array supports logical vectors (ARROW-3341)", {
   # with NA
   x <- sample(c(TRUE, FALSE, NA), 1000, replace = TRUE)

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -181,8 +181,8 @@ test_that("Array support null type (ARROW-7064)", {
 })
 
 test_that("Array support 0-length NULL vectors (Arrow-17543)", {
-  expect_equal(Array$create(c())$type, null())
-  expect_equal(Array$create(NULL)$type, null())
+  expect_type_equal(Array$create(c()), null())
+  expect_type_equal(Array$create(NULL), null())
 })
 
 test_that("Array supports logical vectors (ARROW-3341)", {


### PR DESCRIPTION
Added the suggested check in ```Array$create()``` from the JIRA issue, that if both the ```x``` and ```type``` are ```NULL``` then the type is manually assigned to ```arrow::null()```.

Added unit tests that captured the bug before I applied the fix and now pass.