### PR TITLE
ARROW-17553: [Go] Enable flight.Server to register additional grpc services

### DIFF
--- a/go/arrow/flight/server.go
+++ b/go/arrow/flight/server.go
@@ -17,13 +17,14 @@
 package flight
 
 import (
-	context "context"
+	"context"
 	"net"
 	"os"
 	"os/signal"
 
 	"github.com/apache/arrow/go/v10/arrow/flight/internal/flight"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
 )
 
 type (
@@ -79,6 +80,12 @@ type Server interface {
 	// RegisterFlightService sets up the handler for the Flight Endpoints as per
 	// normal Grpc setups
 	RegisterFlightService(FlightServer)
+	// ServiceRegistrar wraps a single method that supports service registration.
+	// For example, it may be used to register health check provided by grpc-go.
+	grpc.ServiceRegistrar
+	// ServiceInfoProvider is an interface used to retrieve metadata about the services to expose.
+	// If reflection is enabled on the server, all the endpoints can be invoked using grpcurl.
+	reflection.ServiceInfoProvider
 }
 
 // BaseFlightServer is the base flight server implementation and must be
@@ -249,4 +256,12 @@ func (s *server) RegisterFlightService(svc FlightServer) {
 
 func (s *server) Shutdown() {
 	s.server.GracefulStop()
+}
+
+func (s *server) RegisterService(sd *grpc.ServiceDesc, ss interface{}) {
+	s.server.RegisterService(sd, ss)
+}
+
+func (s *server) GetServiceInfo() map[string]grpc.ServiceInfo {
+	return s.server.GetServiceInfo()
 }


### PR DESCRIPTION
This PR exposes `grpc.ServiceRegistrar` and `reflection.ServiceInfoProvider` in `grpc.Server`. They are needed to register additional gRPC services such as health check and reflection.