### PR TITLE
MINOR: [PARQUET] Clean up Skip method naming rows->values

### DIFF
--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -1133,8 +1133,8 @@ template <typename DType>
 int64_t TypedColumnReaderImpl<DType>::Skip(int64_t num_values_to_skip) {
   int64_t values_to_skip = num_values_to_skip;
   while (HasNext() && values_to_skip > 0) {
-    // If the number of values to skip is more than the number of undecoded values, skip the
-    // Page.
+    // If the number of values to skip is more than the number of undecoded values, skip
+    // the Page.
     if (values_to_skip > (this->num_buffered_values_ - this->num_decoded_values_)) {
       values_to_skip -= this->num_buffered_values_ - this->num_decoded_values_;
       this->num_decoded_values_ = this->num_buffered_values_;

--- a/cpp/src/parquet/column_reader.h
+++ b/cpp/src/parquet/column_reader.h
@@ -218,10 +218,13 @@ class TypedColumnReader : public ColumnReader {
                                   int64_t valid_bits_offset, int64_t* levels_read,
                                   int64_t* values_read, int64_t* null_count) = 0;
 
-  // Skip reading values.
+  // Skip reading values. This method will work for both repeated and
+  // non-repeated fields. Note that this method is skipping values and not
+  // records. This distinction is important for repeated fields, meaning that
+  // we are not skipping over the values to the next record. We are skipping
+  // through them. So after the skip the iterator could be in the middle of a
+  // repeated field.
   // Returns the number of values skipped.
-  // This function will NOT skip rows, and repeated fields may have multiple values
-  // corresponding to the same row.
   virtual int64_t Skip(int64_t num_values_to_skip) = 0;
 
   // Read a batch of repetition levels, definition levels, and indices from the

--- a/cpp/src/parquet/column_reader.h
+++ b/cpp/src/parquet/column_reader.h
@@ -222,9 +222,10 @@ class TypedColumnReader : public ColumnReader {
   // Skip reading values. This method will work for both repeated and
   // non-repeated fields. Note that this method is skipping values and not
   // records. This distinction is important for repeated fields, meaning that
-  // we are not skipping over the values to the next record. We are skipping
-  // through them. So after the skip the iterator could be in the middle of a
-  // repeated field.
+  // we are not skipping over the values to the next record. For example,
+  // consider the following two consecutive records containing one repeated field:
+  // {[1, 2, 3]}, {[4, 5]}. If we Skip(2), our next read value will be 3, which
+  // is inside the first record.
   // Returns the number of values skipped.
   virtual int64_t Skip(int64_t num_values_to_skip) = 0;
 

--- a/cpp/src/parquet/column_reader.h
+++ b/cpp/src/parquet/column_reader.h
@@ -104,12 +104,12 @@ class PARQUET_EXPORT PageReader {
   virtual ~PageReader() = default;
 
   static std::unique_ptr<PageReader> Open(
-      std::shared_ptr<ArrowInputStream> stream, int64_t total_num_rows,
+      std::shared_ptr<ArrowInputStream> stream, int64_t total_num_values,
       Compression::type codec, bool always_compressed = false,
       ::arrow::MemoryPool* pool = ::arrow::default_memory_pool(),
       const CryptoContext* ctx = NULLPTR);
   static std::unique_ptr<PageReader> Open(std::shared_ptr<ArrowInputStream> stream,
-                                          int64_t total_num_rows, Compression::type codec,
+                                          int64_t total_num_values, Compression::type codec,
                                           const ReaderProperties& properties,
                                           bool always_compressed = false,
                                           const CryptoContext* ctx = NULLPTR);
@@ -218,9 +218,11 @@ class TypedColumnReader : public ColumnReader {
                                   int64_t valid_bits_offset, int64_t* levels_read,
                                   int64_t* values_read, int64_t* null_count) = 0;
 
-  // Skip reading levels
-  // Returns the number of levels skipped
-  virtual int64_t Skip(int64_t num_rows_to_skip) = 0;
+  // Skip reading values.
+  // Returns the number of values skipped.
+  // This function will NOT skip rows, and repeated fields may have multiple values
+  // corresponding to the same row.
+  virtual int64_t Skip(int64_t num_values_to_skip) = 0;
 
   // Read a batch of repetition levels, definition levels, and indices from the
   // column. And read the dictionary if a dictionary page is encountered during

--- a/cpp/src/parquet/column_reader.h
+++ b/cpp/src/parquet/column_reader.h
@@ -109,7 +109,8 @@ class PARQUET_EXPORT PageReader {
       ::arrow::MemoryPool* pool = ::arrow::default_memory_pool(),
       const CryptoContext* ctx = NULLPTR);
   static std::unique_ptr<PageReader> Open(std::shared_ptr<ArrowInputStream> stream,
-                                          int64_t total_num_values, Compression::type codec,
+                                          int64_t total_num_values,
+                                          Compression::type codec,
                                           const ReaderProperties& properties,
                                           bool always_compressed = false,
                                           const CryptoContext* ctx = NULLPTR);

--- a/cpp/src/parquet/column_reader_test.cc
+++ b/cpp/src/parquet/column_reader_test.cc
@@ -229,7 +229,7 @@ class TestPrimitiveReader : public ::testing::Test {
 };
 
 TEST_F(TestPrimitiveReader, TestInt32FlatRequired) {
-  int levels_per_page = 100;
+  int levels_per_page = 10;
   int num_pages = 50;
   max_def_level_ = 0;
   max_rep_level_ = 0;


### PR DESCRIPTION
The Skip method is skipping values and not rows. "values" is used throughout the code interchangeably with levels. Repeated fields may have multiple values, thus the use of "rows" is not accurate because we are not skipping over the values from the repeated field to the next row.

Similarly, two other variables total_num_rows_ and seen_num_rows_ actually refer to values and not rows. So I updated them as well.

I will add more tests for the Skip method that will clarify this behavior for repeated fields in a separate change.