### PR TITLE
MINOR: [Ruby] Fixed credential information of ClickHouse API

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -65,12 +65,12 @@ Suppose you have your data available via HTTP. Let's connect to demo ClickHouse 
 require 'net/http'
 
 params = {
-  query: "SELECT WatchID as watch FROM hits_v1 LIMIT 10 FORMAT Arrow",
-  user: "playground",
-  password: "clickhouse",
-  database: "datasets"
+  query: "SELECT WatchID as watch FROM hits LIMIT 10 FORMAT Arrow",
+  user: "play",
+  password: "",
+  database: "default"
 }
-uri = URI('https://play-api.clickhouse.com:8443')
+uri = URI('https://play.clickhouse.com:443/')
 uri.query = URI.encode_www_form(params)
 resp = Net::HTTP.get(uri)
 table = Arrow::Table.load(Arrow::Buffer.new(resp))


### PR DESCRIPTION
## What I did
- Fixed credential information of ClickHouse API at README.md
    - Latest Information was changed
    - https://clickhouse.com/docs/ru/getting-started/playground/

## What I checked
- I ran the command in my local environment.

```ruby
# red-arrow.rb
params = {
  query: "SELECT WatchID as watch FROM hits LIMIT 10 FORMAT Arrow",
  user: "play",
  password: "",
  database: "default"
}
uri = URI('https://play.clickhouse.com:443/')
uri.query = URI.encode_www_form(params)
resp = Net::HTTP.get(uri)
table = Arrow::Table.load(Arrow::Buffer.new(resp))
p table
```
```console
% ruby red-arrow.rb
#<Arrow::Table:0x11f8e0c18 ptr=0x11f6dced0>
                      watch
 0      8120543446287442873
 1      9110818468285196899
 2      8156744413230856864
 3      5206346422301499756
 4      6308646140879811077
 5      6635790769678439148
 6      4894690465724379622
 7      6864353419233967042
 8      8740403056911509777
 9      8924809397503602651
```