### PR TITLE
ARROW-17079: [C++] Raise proper error message instead of error code for S3 errors

### DIFF
--- a/cpp/src/arrow/filesystem/s3_internal.h
+++ b/cpp/src/arrow/filesystem/s3_internal.h
@@ -88,7 +88,7 @@ inline bool IsAlreadyExists(const Aws::Client::AWSError<Aws::S3::S3Errors>& erro
           error_type == Aws::S3::S3Errors::BUCKET_ALREADY_OWNED_BY_YOU);
 }
 
-std::string S3ErrorToString(Aws::S3::S3Errors error_type) {
+inline std::string S3ErrorToString(Aws::S3::S3Errors error_type) {
   switch (error_type) {
 #define S3_ERROR_CASE(NAME)     \
   case Aws::S3::S3Errors::NAME: \

--- a/cpp/src/arrow/filesystem/s3_internal.h
+++ b/cpp/src/arrow/filesystem/s3_internal.h
@@ -175,7 +175,7 @@ Status ErrorToStatus(const std::string& prefix, const std::string& operation,
   // See
   // https://sdk.amazonaws.com/cpp/api/LATEST/namespace_aws_1_1_s3.html#ae3f82f8132b619b6e91c88a9f1bde371
   return Status::IOError(prefix, "AWS Error ",
-			 S3ErrorToString(static_cast<int>(error.GetErrorType())),
+                         S3ErrorToString(static_cast<int>(error.GetErrorType())),
                          " during ", operation, " operation: ", error.GetMessage());
 }
 

--- a/cpp/src/arrow/filesystem/s3_internal.h
+++ b/cpp/src/arrow/filesystem/s3_internal.h
@@ -88,7 +88,7 @@ inline bool IsAlreadyExists(const Aws::Client::AWSError<Aws::S3::S3Errors>& erro
           error_type == Aws::S3::S3Errors::BUCKET_ALREADY_OWNED_BY_YOU);
 }
 
-std::string_view S3ErrorToString(Aws::S3::S3Errors error_type) {
+std::string S3ErrorToString(Aws::S3::S3Errors error_type) {
   switch (error_type) {
 #define S3_ERROR_CASE(NAME)     \
   case Aws::S3::S3Errors::NAME: \

--- a/cpp/src/arrow/filesystem/s3_internal.h
+++ b/cpp/src/arrow/filesystem/s3_internal.h
@@ -90,9 +90,9 @@ inline bool IsAlreadyExists(const Aws::Client::AWSError<Aws::S3::S3Errors>& erro
 
 std::string_view S3ErrorToString(Aws::S3::S3Errors error_type) {
   switch (error_type) {
-#define S3_ERROR_CASE(NAME) \
-    case Aws::S3::S3Errors::NAME: \
-      return # NAME;
+#define S3_ERROR_CASE(NAME)     \
+  case Aws::S3::S3Errors::NAME: \
+    return # NAME;
 
     S3_ERROR_CASE(INCOMPLETE_SIGNATURE)
     S3_ERROR_CASE(INTERNAL_FAILURE)
@@ -144,9 +144,10 @@ Status ErrorToStatus(const std::string& prefix, const std::string& operation,
   // XXX Handle fine-grained error types
   // See
   // https://sdk.amazonaws.com/cpp/api/LATEST/namespace_aws_1_1_s3.html#ae3f82f8132b619b6e91c88a9f1bde371
-  return Status::IOError(prefix, "AWS Error ",
-                         S3ErrorToString(static_cast<Aws::S3::S3Errors>(error.GetErrorType())),
-                         " during ", operation, " operation: ", error.GetMessage());
+  return Status::IOError(
+      prefix, "AWS Error ",
+      S3ErrorToString(static_cast<Aws::S3::S3Errors>(error.GetErrorType())), " during ",
+      operation, " operation: ", error.GetMessage());
 }
 
 template <typename ErrorType, typename... Args>

--- a/cpp/src/arrow/filesystem/s3_internal.h
+++ b/cpp/src/arrow/filesystem/s3_internal.h
@@ -88,6 +88,84 @@ inline bool IsAlreadyExists(const Aws::Client::AWSError<Aws::S3::S3Errors>& erro
           error_type == Aws::S3::S3Errors::BUCKET_ALREADY_OWNED_BY_YOU);
 }
 
+std::string S3ErrorToString(int error_type) {
+  switch (static_cast<Aws::S3::S3Errors>(error_type)) {
+    case Aws::S3::S3Errors::INCOMPLETE_SIGNATURE:
+      return "INCOMPLETE_SIGNATURE";
+    case Aws::S3::S3Errors::INTERNAL_FAILURE:
+      return "INTERNAL_FAILURE";
+    case Aws::S3::S3Errors::INVALID_ACTION:
+      return "INVALID_ACTION";
+    case Aws::S3::S3Errors::INVALID_CLIENT_TOKEN_ID:
+      return "INVALID_CLIENT_TOKEN_ID";
+    case Aws::S3::S3Errors::INVALID_PARAMETER_COMBINATION:
+      return "INVALID_PARAMETER_COMBINATION";
+    case Aws::S3::S3Errors::INVALID_QUERY_PARAMETER:
+      return "INVALID_QUERY_PARAMETER";
+    case Aws::S3::S3Errors::INVALID_PARAMETER_VALUE:
+      return "INVALID_PARAMETER_VALUE";
+    case Aws::S3::S3Errors::MISSING_ACTION:
+      return "MISSING_ACTION";
+    case Aws::S3::S3Errors::MISSING_AUTHENTICATION_TOKEN:
+      return "MISSING_AUTHENTICATION_TOKEN";
+    case Aws::S3::S3Errors::MISSING_PARAMETER:
+      return "MISSING_PARAMETER";
+    case Aws::S3::S3Errors::OPT_IN_REQUIRED:
+      return "OPT_IN_REQUIRED";
+    case Aws::S3::S3Errors::REQUEST_EXPIRED:
+      return "REQUEST_EXPIRED";
+    case Aws::S3::S3Errors::SERVICE_UNAVAILABLE:
+      return "SERVICE_UNAVAILABLE";
+    case Aws::S3::S3Errors::THROTTLING:
+      return "THROTTLING";
+    case Aws::S3::S3Errors::VALIDATION:
+      return "VALIDATION";
+    case Aws::S3::S3Errors::ACCESS_DENIED:
+      return "ACCESS_DENIED";
+    case Aws::S3::S3Errors::RESOURCE_NOT_FOUND:
+      return "RESOURCE_NOT_FOUND";
+    case Aws::S3::S3Errors::UNRECOGNIZED_CLIENT:
+      return "UNRECOGNIZED_CLIENT";
+    case Aws::S3::S3Errors::MALFORMED_QUERY_STRING:
+      return "MALFORMED_QUERY_STRING";
+    case Aws::S3::S3Errors::SLOW_DOWN:
+      return "SLOW_DOWN";
+    case Aws::S3::S3Errors::REQUEST_TIME_TOO_SKEWED:
+      return "REQUEST_TIME_TOO_SKEWED";
+    case Aws::S3::S3Errors::INVALID_SIGNATURE:
+      return "INVALID_SIGNATURE";
+    case Aws::S3::S3Errors::SIGNATURE_DOES_NOT_MATCH:
+      return "SIGNATURE_DOES_NOT_MATCH";
+    case Aws::S3::S3Errors::INVALID_ACCESS_KEY_ID:
+      return "INVALID_ACCESS_KEY_ID";
+    case Aws::S3::S3Errors::REQUEST_TIMEOUT:
+      return "REQUEST_TIMEOUT";
+    case Aws::S3::S3Errors::NETWORK_CONNECTION:
+      return "NETWORK_CONNECTION";
+    case Aws::S3::S3Errors::UNKNOWN:
+      return "UNKNOWN";
+    case Aws::S3::S3Errors::BUCKET_ALREADY_EXISTS:
+      return "BUCKET_ALREADY_EXISTS";
+    case Aws::S3::S3Errors::BUCKET_ALREADY_OWNED_BY_YOU:
+      return "BUCKET_ALREADY_OWNED_BY_YOU";
+    case Aws::S3::S3Errors::INVALID_OBJECT_STATE:
+      return "INVALID_OBJECT_STATE";
+    case Aws::S3::S3Errors::NO_SUCH_BUCKET:
+      return "NO_SUCH_BUCKET";
+    case Aws::S3::S3Errors::NO_SUCH_KEY:
+      return "NO_SUCH_KEY";
+    case Aws::S3::S3Errors::NO_SUCH_UPLOAD:
+      return "NO_SUCH_UPLOAD";
+    case Aws::S3::S3Errors::OBJECT_ALREADY_IN_ACTIVE_TIER:
+      return "OBJECT_ALREADY_IN_ACTIVE_TIER";
+    case Aws::S3::S3Errors::OBJECT_NOT_IN_ACTIVE_TIER:
+      return "OBJECT_NOT_IN_ACTIVE_TIER";
+    default:
+      DCHECK(false);
+      return "[code " + std::to_string(error_type) + "]";
+  }
+}
+
 // TODO qualify error messages with a prefix indicating context
 // (e.g. "When completing multipart upload to bucket 'xxx', key 'xxx': ...")
 template <typename ErrorType>
@@ -96,9 +174,9 @@ Status ErrorToStatus(const std::string& prefix, const std::string& operation,
   // XXX Handle fine-grained error types
   // See
   // https://sdk.amazonaws.com/cpp/api/LATEST/namespace_aws_1_1_s3.html#ae3f82f8132b619b6e91c88a9f1bde371
-  return Status::IOError(prefix, "AWS Error [code ",
-                         static_cast<int>(error.GetErrorType()), "] during ", operation,
-                         " operation: ", error.GetMessage());
+  return Status::IOError(prefix, "AWS Error ",
+			 S3ErrorToString(static_cast<int>(error.GetErrorType())),
+                         " during ", operation, " operation: ", error.GetMessage());
 }
 
 template <typename ErrorType, typename... Args>

--- a/cpp/src/arrow/filesystem/s3_internal.h
+++ b/cpp/src/arrow/filesystem/s3_internal.h
@@ -123,7 +123,15 @@ inline std::string S3ErrorToString(Aws::S3::S3Errors error_type) {
     S3_ERROR_CASE(UNKNOWN)
     S3_ERROR_CASE(BUCKET_ALREADY_EXISTS)
     S3_ERROR_CASE(BUCKET_ALREADY_OWNED_BY_YOU)
-    S3_ERROR_CASE(INVALID_OBJECT_STATE)
+    // The following is the most recent addition to S3Errors
+    // and is not supported yet for some versions of the SDK
+    // that Apache Arrow is using. This is not a big deal
+    // since this error will happen only in very specialized
+    // settings and we will print the correct numerical error
+    // code as per the "default" case down below. We should
+    // put it back once the SDK has been upgraded in all
+    // Apache Arrow build configurations.
+    // S3_ERROR_CASE(INVALID_OBJECT_STATE)
     S3_ERROR_CASE(NO_SUCH_BUCKET)
     S3_ERROR_CASE(NO_SUCH_KEY)
     S3_ERROR_CASE(NO_SUCH_UPLOAD)

--- a/cpp/src/arrow/filesystem/s3_internal.h
+++ b/cpp/src/arrow/filesystem/s3_internal.h
@@ -88,81 +88,51 @@ inline bool IsAlreadyExists(const Aws::Client::AWSError<Aws::S3::S3Errors>& erro
           error_type == Aws::S3::S3Errors::BUCKET_ALREADY_OWNED_BY_YOU);
 }
 
-std::string S3ErrorToString(int error_type) {
-  switch (static_cast<Aws::S3::S3Errors>(error_type)) {
-    case Aws::S3::S3Errors::INCOMPLETE_SIGNATURE:
-      return "INCOMPLETE_SIGNATURE";
-    case Aws::S3::S3Errors::INTERNAL_FAILURE:
-      return "INTERNAL_FAILURE";
-    case Aws::S3::S3Errors::INVALID_ACTION:
-      return "INVALID_ACTION";
-    case Aws::S3::S3Errors::INVALID_CLIENT_TOKEN_ID:
-      return "INVALID_CLIENT_TOKEN_ID";
-    case Aws::S3::S3Errors::INVALID_PARAMETER_COMBINATION:
-      return "INVALID_PARAMETER_COMBINATION";
-    case Aws::S3::S3Errors::INVALID_QUERY_PARAMETER:
-      return "INVALID_QUERY_PARAMETER";
-    case Aws::S3::S3Errors::INVALID_PARAMETER_VALUE:
-      return "INVALID_PARAMETER_VALUE";
-    case Aws::S3::S3Errors::MISSING_ACTION:
-      return "MISSING_ACTION";
-    case Aws::S3::S3Errors::MISSING_AUTHENTICATION_TOKEN:
-      return "MISSING_AUTHENTICATION_TOKEN";
-    case Aws::S3::S3Errors::MISSING_PARAMETER:
-      return "MISSING_PARAMETER";
-    case Aws::S3::S3Errors::OPT_IN_REQUIRED:
-      return "OPT_IN_REQUIRED";
-    case Aws::S3::S3Errors::REQUEST_EXPIRED:
-      return "REQUEST_EXPIRED";
-    case Aws::S3::S3Errors::SERVICE_UNAVAILABLE:
-      return "SERVICE_UNAVAILABLE";
-    case Aws::S3::S3Errors::THROTTLING:
-      return "THROTTLING";
-    case Aws::S3::S3Errors::VALIDATION:
-      return "VALIDATION";
-    case Aws::S3::S3Errors::ACCESS_DENIED:
-      return "ACCESS_DENIED";
-    case Aws::S3::S3Errors::RESOURCE_NOT_FOUND:
-      return "RESOURCE_NOT_FOUND";
-    case Aws::S3::S3Errors::UNRECOGNIZED_CLIENT:
-      return "UNRECOGNIZED_CLIENT";
-    case Aws::S3::S3Errors::MALFORMED_QUERY_STRING:
-      return "MALFORMED_QUERY_STRING";
-    case Aws::S3::S3Errors::SLOW_DOWN:
-      return "SLOW_DOWN";
-    case Aws::S3::S3Errors::REQUEST_TIME_TOO_SKEWED:
-      return "REQUEST_TIME_TOO_SKEWED";
-    case Aws::S3::S3Errors::INVALID_SIGNATURE:
-      return "INVALID_SIGNATURE";
-    case Aws::S3::S3Errors::SIGNATURE_DOES_NOT_MATCH:
-      return "SIGNATURE_DOES_NOT_MATCH";
-    case Aws::S3::S3Errors::INVALID_ACCESS_KEY_ID:
-      return "INVALID_ACCESS_KEY_ID";
-    case Aws::S3::S3Errors::REQUEST_TIMEOUT:
-      return "REQUEST_TIMEOUT";
-    case Aws::S3::S3Errors::NETWORK_CONNECTION:
-      return "NETWORK_CONNECTION";
-    case Aws::S3::S3Errors::UNKNOWN:
-      return "UNKNOWN";
-    case Aws::S3::S3Errors::BUCKET_ALREADY_EXISTS:
-      return "BUCKET_ALREADY_EXISTS";
-    case Aws::S3::S3Errors::BUCKET_ALREADY_OWNED_BY_YOU:
-      return "BUCKET_ALREADY_OWNED_BY_YOU";
-    case Aws::S3::S3Errors::INVALID_OBJECT_STATE:
-      return "INVALID_OBJECT_STATE";
-    case Aws::S3::S3Errors::NO_SUCH_BUCKET:
-      return "NO_SUCH_BUCKET";
-    case Aws::S3::S3Errors::NO_SUCH_KEY:
-      return "NO_SUCH_KEY";
-    case Aws::S3::S3Errors::NO_SUCH_UPLOAD:
-      return "NO_SUCH_UPLOAD";
-    case Aws::S3::S3Errors::OBJECT_ALREADY_IN_ACTIVE_TIER:
-      return "OBJECT_ALREADY_IN_ACTIVE_TIER";
-    case Aws::S3::S3Errors::OBJECT_NOT_IN_ACTIVE_TIER:
-      return "OBJECT_NOT_IN_ACTIVE_TIER";
+std::string_view S3ErrorToString(Aws::S3::S3Errors error_type) {
+  switch (error_type) {
+#define S3_ERROR_CASE(NAME) \
+    case Aws::S3::S3Errors::NAME: \
+      return # NAME;
+
+    S3_ERROR_CASE(INCOMPLETE_SIGNATURE)
+    S3_ERROR_CASE(INTERNAL_FAILURE)
+    S3_ERROR_CASE(INVALID_ACTION)
+    S3_ERROR_CASE(INVALID_CLIENT_TOKEN_ID)
+    S3_ERROR_CASE(INVALID_PARAMETER_COMBINATION)
+    S3_ERROR_CASE(INVALID_QUERY_PARAMETER)
+    S3_ERROR_CASE(INVALID_PARAMETER_VALUE)
+    S3_ERROR_CASE(MISSING_ACTION)
+    S3_ERROR_CASE(MISSING_AUTHENTICATION_TOKEN)
+    S3_ERROR_CASE(MISSING_PARAMETER)
+    S3_ERROR_CASE(OPT_IN_REQUIRED)
+    S3_ERROR_CASE(REQUEST_EXPIRED)
+    S3_ERROR_CASE(SERVICE_UNAVAILABLE)
+    S3_ERROR_CASE(THROTTLING)
+    S3_ERROR_CASE(VALIDATION)
+    S3_ERROR_CASE(ACCESS_DENIED)
+    S3_ERROR_CASE(RESOURCE_NOT_FOUND)
+    S3_ERROR_CASE(UNRECOGNIZED_CLIENT)
+    S3_ERROR_CASE(MALFORMED_QUERY_STRING)
+    S3_ERROR_CASE(SLOW_DOWN)
+    S3_ERROR_CASE(REQUEST_TIME_TOO_SKEWED)
+    S3_ERROR_CASE(INVALID_SIGNATURE)
+    S3_ERROR_CASE(SIGNATURE_DOES_NOT_MATCH)
+    S3_ERROR_CASE(INVALID_ACCESS_KEY_ID)
+    S3_ERROR_CASE(REQUEST_TIMEOUT)
+    S3_ERROR_CASE(NETWORK_CONNECTION)
+    S3_ERROR_CASE(UNKNOWN)
+    S3_ERROR_CASE(BUCKET_ALREADY_EXISTS)
+    S3_ERROR_CASE(BUCKET_ALREADY_OWNED_BY_YOU)
+    S3_ERROR_CASE(INVALID_OBJECT_STATE)
+    S3_ERROR_CASE(NO_SUCH_BUCKET)
+    S3_ERROR_CASE(NO_SUCH_KEY)
+    S3_ERROR_CASE(NO_SUCH_UPLOAD)
+    S3_ERROR_CASE(OBJECT_ALREADY_IN_ACTIVE_TIER)
+    S3_ERROR_CASE(OBJECT_NOT_IN_ACTIVE_TIER)
+
+#undef S3_ERROR_CASE
     default:
-      DCHECK(false);
-      return "[code " + std::to_string(error_type) + "]";
+      return "[code " + std::to_string(static_cast<int>(error_type)) + "]";
   }
 }
 
@@ -175,7 +145,7 @@ Status ErrorToStatus(const std::string& prefix, const std::string& operation,
   // See
   // https://sdk.amazonaws.com/cpp/api/LATEST/namespace_aws_1_1_s3.html#ae3f82f8132b619b6e91c88a9f1bde371
   return Status::IOError(prefix, "AWS Error ",
-			 S3ErrorToString(static_cast<int>(error.GetErrorType())),
+			 S3ErrorToString(static_cast<Aws::S3::S3Errors>(error.GetErrorType())),
                          " during ", operation, " operation: ", error.GetMessage());
 }
 

--- a/cpp/src/arrow/filesystem/s3_internal.h
+++ b/cpp/src/arrow/filesystem/s3_internal.h
@@ -92,7 +92,7 @@ inline std::string S3ErrorToString(Aws::S3::S3Errors error_type) {
   switch (error_type) {
 #define S3_ERROR_CASE(NAME)     \
   case Aws::S3::S3Errors::NAME: \
-    return # NAME;
+    return #NAME;
 
     S3_ERROR_CASE(INCOMPLETE_SIGNATURE)
     S3_ERROR_CASE(INTERNAL_FAILURE)


### PR DESCRIPTION
Part 2 to bring our S3 error messages up to the same standard as the ones from boto3.

The error types are from https://github.com/aws/aws-sdk-cpp/blob/main/aws-cpp-sdk-s3/include/aws/s3/S3Errors.h#L16 -- unfortunately the AWS C++ doesn't seem to have a way to get the errors programmatically from the error codes so we had to hand code them.
The new error format is:

> When getting information for key 'test.csv' in bucket 'pcmoritz-test-bucket-arrow-errors': AWS Error **ACCESS_DENIED** during HeadObject operation: No response body.

The old format was:

> When getting information for key 'test.csv' in bucket 'pcmoritz-test-bucket-arrow-errors': AWS Error **[code 15]** during HeadObject operation: No response body.