### PR TITLE
ARROW-17565: [C++] Backward compatible ${PACKAGE}_shared CMake target isn't provided

### DIFF
--- a/cpp/src/arrow/ArrowConfig.cmake.in
+++ b/cpp/src/arrow/ArrowConfig.cmake.in
@@ -108,7 +108,8 @@ macro(arrow_keep_backward_compatibility namespace target_base_name)
   string(TOUPPER ${target_base_name} target_base_name_upper)
 
   if(NOT CMAKE_VERSION VERSION_LESS 3.18)
-    if(TARGET ${namespace}::${target_base_name} AND NOT TARGET ${target_base_name}_shared)
+    if(TARGET ${namespace}::${target_base_name}_shared AND NOT TARGET
+                                                           ${target_base_name}_shared)
       add_library(${target_base_name}_shared ALIAS
                   ${namespace}::${target_base_name}_shared)
     endif()


### PR DESCRIPTION
This is a follow-up of ARROW-12175 / #13892 .

We introduced `${PACKAGE}::` namespace to all exported CMake targets
such as `Arrow::arrow_shared` and `Arrow::arrow_static`, but we also
provided no-namespaced CMake targets such as `arrow_shared` and
`arrow_static` as aliases of namespaced CMake targets.

However, the logic to provide `arrow_shared` was buggy.
