### PR TITLE
ARROW-17567: [C++] Avoid internal compiler error with gcc 7 and c++17

### DIFF
--- a/cpp/src/arrow/compute/kernels/aggregate_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_internal.h
@@ -164,6 +164,7 @@ enable_if_t<std::is_floating_point<SumType>::value, SumType> SumArray(
 
   // reduce summation of one block (may be smaller than kBlockSize) from leaf node
   // continue reducing to upper level if two summations are ready for non-leaf node
+  // (capture `levels` by value because of ARROW-17567)
   auto reduce = [&, levels](SumType block_sum) {
     int cur_level = 0;
     uint64_t cur_level_mask = 1ULL;

--- a/cpp/src/arrow/compute/kernels/aggregate_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_internal.h
@@ -164,7 +164,7 @@ enable_if_t<std::is_floating_point<SumType>::value, SumType> SumArray(
 
   // reduce summation of one block (may be smaller than kBlockSize) from leaf node
   // continue reducing to upper level if two summations are ready for non-leaf node
-  auto reduce = [&](SumType block_sum) {
+  auto reduce = [&, levels](SumType block_sum) {
     int cur_level = 0;
     uint64_t cur_level_mask = 1ULL;
     sum[cur_level] += block_sum;

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
@@ -67,8 +67,10 @@ struct SetLookupState : public KernelState {
     auto visit_valid = [&](T v) {
       const auto memo_size = static_cast<int32_t>(memo_index_to_value_index.size());
       int32_t unused_memo_index;
-      auto on_found = [&](int32_t memo_index) { DCHECK_LT(memo_index, memo_size); };
-      auto on_not_found = [&](int32_t memo_index) {
+      auto on_found = [&, memo_size](int32_t memo_index) {
+        DCHECK_LT(memo_index, memo_size);
+      };
+      auto on_not_found = [&, memo_size](int32_t memo_index) {
         DCHECK_EQ(memo_index, memo_size);
         memo_index_to_value_index.push_back(index);
       };
@@ -79,8 +81,10 @@ struct SetLookupState : public KernelState {
     };
     auto visit_null = [&]() {
       const auto memo_size = static_cast<int32_t>(memo_index_to_value_index.size());
-      auto on_found = [&](int32_t memo_index) { DCHECK_LT(memo_index, memo_size); };
-      auto on_not_found = [&](int32_t memo_index) {
+      auto on_found = [&, memo_size](int32_t memo_index) {
+        DCHECK_LT(memo_index, memo_size);
+      };
+      auto on_not_found = [&, memo_size](int32_t memo_index) {
         DCHECK_EQ(memo_index, memo_size);
         memo_index_to_value_index.push_back(index);
       };

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
@@ -67,7 +67,7 @@ struct SetLookupState : public KernelState {
     auto visit_valid = [&](T v) {
       const auto memo_size = static_cast<int32_t>(memo_index_to_value_index.size());
       int32_t unused_memo_index;
-      // (capture `memo_index` by value because of ARROW-17567
+      // (capture `memo_size` by value because of ARROW-17567)
       auto on_found = [&, memo_size](int32_t memo_index) {
         DCHECK_LT(memo_index, memo_size);
       };

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
@@ -67,6 +67,7 @@ struct SetLookupState : public KernelState {
     auto visit_valid = [&](T v) {
       const auto memo_size = static_cast<int32_t>(memo_index_to_value_index.size());
       int32_t unused_memo_index;
+      // (capture `memo_index` by value because of ARROW-17567
       auto on_found = [&, memo_size](int32_t memo_index) {
         DCHECK_LT(memo_index, memo_size);
       };


### PR DESCRIPTION
The current compute kernel fails to compile with gcc6/7 and c++14/17, due to a known bug of gcc. It is triggered when a const integer is capture by reference in a lambda function, and is parenthesized in that lambda code. Capturing the const ints by value fixes this issue.

See also:  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=83204 and https://github.com/kokkos/kokkos-kernels/issues/349