### PR TITLE
ARROW-13454: [C++][Docs] Tables vs Record Batches

### DIFF
--- a/docs/source/cpp/tables-versus-record-batches.svg
+++ b/docs/source/cpp/tables-versus-record-batches.svg
@@ -37,14 +37,15 @@ under the License.
       <rect width="70" height="155" x="10" y="0" fill="orange" />
       <rect width="70" height="155" x="90" y="0" fill="orange" />
       <rect width="70" height="155" x="170" y="0" fill="orange" />
-      <text class="label" x="15" y="20">Chunked Array</text>
-      <g transform="translate(0, 30)">
+      <text class="label" x="15" y="15"><tspan>Chunked</tspan>
+      <tspan x="15" dy="15">Array</tspan></text>
+      <g transform="translate(0, 35)">
         <rect width="60" height="80" x="15" y="0" fill="#555" />
-        <rect width="60" height="35" x="15" y="85" fill="#555" />
-        <rect width="60" height="120" x="95" y="0" fill="#555" />
+        <rect width="60" height="30" x="15" y="85" fill="#555" />
+        <rect width="60" height="115" x="95" y="0" fill="#555" />
         <rect width="60" height="35" x="175" y="0" fill="#555" />
         <rect width="60" height="35" x="175" y="40" fill="#555" />
-        <rect width="60" height="40" x="175" y="80" fill="#555" />
+        <rect width="60" height="35" x="175" y="80" fill="#555" />
         <text class="label light" x="20" y="20">Array</text>
       </g>
     </g>
@@ -73,9 +74,7 @@ under the License.
   </g>
 
   <text class="caption" x="20" y="370">
-    <tspan>A <tspan style="font-weight: bold">Record Batch</tspan> is a common Arrow data structure which can be passed
-      zero-copy between</tspan>
-    <tspan x="20" dy="15"> implementations via the C data interface.</tspan>
+    <tspan>A <tspan style="font-weight: bold">Record Batch</tspan> is a common Arrow data structure which is recognized by all implementations.</tspan>
   </text>
   <style>
     text {

--- a/docs/source/cpp/tables-versus-record-batches.svg
+++ b/docs/source/cpp/tables-versus-record-batches.svg
@@ -1,0 +1,103 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<svg version="1.1" width="600" height="400" xmlns="http://www.w3.org/2000/svg">
+
+  <rect width="100%" height="100%" fill="white" />
+
+  <text id="heading" y="40" x="20">Arrow Table versus Record Batch</text>
+
+  <g transform="translate(20, 60)">
+    <rect width="250" height="260" x="0" y="0" fill="#ddd" />
+    <text class="label" x="10" y="20">Arrow Table</text>
+    <rect width="230" height="60" x="10" y="25" fill="green" />
+    <text class="label light" x="15" y="45">Schema</text>
+    <g transform="translate(0, 50)">
+      <rect width="65" height="30" x="15" y="0" fill="blue" />
+      <rect width="70" height="30" x="90" y="0" fill="blue" />
+      <rect width="65" height="30" x="170" y="0" fill="blue" />
+      <text class="label light" x="25" y="20">Field</text>
+    </g>
+    <g transform="translate(0, 95)">
+      <rect width="70" height="155" x="10" y="0" fill="orange" />
+      <rect width="70" height="155" x="90" y="0" fill="orange" />
+      <rect width="70" height="155" x="170" y="0" fill="orange" />
+      <text class="label" x="15" y="20">Chunked Array</text>
+      <g transform="translate(0, 30)">
+        <rect width="60" height="80" x="15" y="0" fill="#555" />
+        <rect width="60" height="35" x="15" y="85" fill="#555" />
+        <rect width="60" height="120" x="95" y="0" fill="#555" />
+        <rect width="60" height="35" x="175" y="0" fill="#555" />
+        <rect width="60" height="35" x="175" y="40" fill="#555" />
+        <rect width="60" height="40" x="175" y="80" fill="#555" />
+        <text class="label light" x="20" y="20">Array</text>
+      </g>
+    </g>
+  </g>
+
+  <text class="caption" x="20" y="350">A <tspan style="font-weight: bold">Table</tspan> is a C++ data structure,
+    allowing for a mixed chunking structure and very large arrays.</text>
+
+  <g transform="translate(320, 60)">
+    <rect width="250" height="260" x="0" y="0" fill="#ddd" />
+    <text class="label" x="10" y="20">Arrow Record Batch</text>
+    <rect width="230" height="60" x="10" y="25" fill="green" />
+    <text class="label light" x="15" y="45">Schema</text>
+    <g transform="translate(0, 50)">
+      <rect width="65" height="30" x="15" y="0" fill="blue" />
+      <rect width="70" height="30" x="90" y="0" fill="blue" />
+      <rect width="65" height="30" x="170" y="0" fill="blue" />
+      <text class="label light" x="25" y="20">Field</text>
+    </g>
+    <g transform="translate(0, 95)">
+      <rect width="70" height="155" x="10" y="0" fill="#555" />
+      <rect width="70" height="155" x="90" y="0" fill="#555" />
+      <rect width="70" height="155" x="170" y="0" fill="#555" />
+      <text class="label light" x="20" y="20">Array</text>
+    </g>
+  </g>
+
+  <text class="caption" x="20" y="370">
+    <tspan>A <tspan style="font-weight: bold">Record Batch</tspan> is a common Arrow data structure which can be passed
+      zero-copy between</tspan>
+    <tspan x="20" dy="15"> implementations via the C data interface.</tspan>
+  </text>
+  <style>
+    text {
+      font-family: apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial, Noto Sans, Liberation Sans, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji;
+    }
+
+    .label {
+      font-size: 12px;
+      font-weight: bold;
+      fill: #333;
+    }
+
+    .light {
+      fill: #ddd;
+    }
+
+    #heading {
+      font-size: 24px;
+    }
+
+    .caption {
+      font-size: 12px;
+    }
+  </style>
+</svg>

--- a/docs/source/cpp/tables.rst
+++ b/docs/source/cpp/tables.rst
@@ -84,8 +84,8 @@ and computation functions, possibly incremental.
 Record batches can be sent between implementations, such as via 
 :ref:`IPC <format-ipc>` or
 via the :doc:`C Data Interface <../format/CDataInterface>`. Tables and 
-chunked arrays, on the other hand, are concepts in the C++ implementation (and
-its bindings), not in the Arrow format itself, so they aren't directly portable.
+chunked arrays, on the other hand, are concepts in the C++ implementation,
+not in the Arrow format itself, so they aren't directly portable.
 
 However, a table can be converted to and built from a sequence of record 
 batches easily without needing to copy the underlying array buffers.

--- a/docs/source/cpp/tables.rst
+++ b/docs/source/cpp/tables.rst
@@ -81,10 +81,11 @@ and computation functions, possibly incremental.
    :alt: A graphical representation of an Arrow Table and a Record Batch, with
          structure as described in text above.
 
-Because record batches can be represented as a struct array, they can be 
-exported through the C data interface between implementations. Tables and 
-chunked arrays, on the other hand, are concepts in the C++ implementation, not 
-in the Arrow format itself, so they aren't directly portable.
+Record batches can be sent between implementations, such as via 
+:ref:`IPC <format-ipc>` or
+via the :doc:`C Data Interface <../format/CDataInterface>`. Tables and 
+chunked arrays, on the other hand, are concepts in the C++ implementation (and
+its bindings), not in the Arrow format itself, so they aren't directly portable.
 
 However, a table can be converted to and built from a sequence of record 
 batches easily without needing to copy the underlying array buffers.

--- a/docs/source/cpp/tables.rst
+++ b/docs/source/cpp/tables.rst
@@ -77,6 +77,17 @@ has a schema which must match its arrays' datatypes.
 Record batches are a convenient unit of work for various serialization
 and computation functions, possibly incremental.
 
+.. image:: tables-versus-record-batches.svg
+   :alt: A graphical representation of an Arrow Table and a Record Batch, with
+         structure as described in text above.
+
+Because record batches can be represented as a struct array, they can be 
+exported through the C data interface between implementations. Tables and 
+chunked arrays, on the other hand, are concepts in the C++ implementation, not 
+in the Arrow format itself, so they aren't directly portable.
+
+However, a table can be converted to and built from a sequence of record 
+batches easily without needing to copy the underlying array buffers.
 A table can be streamed as an arbitrary number of record batches using
 a :class:`arrow::TableBatchReader`.  Conversely, a logical sequence of
 record batches can be assembled to form a table using one of the

--- a/docs/source/format/Glossary.rst
+++ b/docs/source/format/Glossary.rst
@@ -197,6 +197,10 @@ Glossary
 
        Not part of the columnar format; this term is specific to
        certain language implementations of Arrow (primarily C++ and
-       its bindings).
+       its bindings and Go).
+
+       .. image:: ../cpp/tables-versus-record-batches.svg
+          :alt: A graphical representation of an Arrow Table and a 
+                Record Batch, with structure as described in text above.
 
        .. seealso:: :term:`chunked array`, :term:`record batch`

--- a/docs/source/format/Glossary.rst
+++ b/docs/source/format/Glossary.rst
@@ -196,8 +196,8 @@ Glossary
        different buffers for different indices.
 
        Not part of the columnar format; this term is specific to
-       certain language implementations of Arrow (primarily C++ and
-       its bindings and Go).
+       certain language implementations of Arrow (for example C++ and
+       its bindings, and Go).
 
        .. image:: ../cpp/tables-versus-record-batches.svg
           :alt: A graphical representation of an Arrow Table and a 


### PR DESCRIPTION
Adds a little more explanation of the difference between tables and record batches, as well as a diagram representation.