### PR TITLE
ARROW-17571: [Benchmarks] Default build for PyArrow seems to be debug

### DIFF
--- a/dev/conbench_envs/benchmarks.env
+++ b/dev/conbench_envs/benchmarks.env
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+CMAKE_BUILD_TYPE=release
 ARROW_BUILD_TESTS=OFF
 ARROW_BUILD_TYPE=release
 ARROW_DEPENDENCY_SOURCE=AUTO


### PR DESCRIPTION
This PR tries to change PyArrow to be built in release and not in debug mode for Benchmarks builds.