### PR TITLE
ARROW-17573: [Go][Parquet] ByteArray statistics can cause memory leak

### DIFF
--- a/go/parquet/metadata/statistics_types.gen.go
+++ b/go/parquet/metadata/statistics_types.gen.go
@@ -1755,7 +1755,9 @@ func NewByteArrayStatisticsFromEncoded(descr *schema.Column, mem memory.Allocato
 }
 
 func (s *ByteArrayStatistics) plainEncode(src parquet.ByteArray) []byte {
-	return src
+	out := make([]byte, len(src))
+	copy(out, src)
+	return out
 }
 
 func (s *ByteArrayStatistics) plainDecode(src []byte) parquet.ByteArray {

--- a/go/parquet/metadata/statistics_types.gen.go.tmpl
+++ b/go/parquet/metadata/statistics_types.gen.go.tmpl
@@ -91,7 +91,9 @@ func New{{.Name}}StatisticsFromEncoded(descr *schema.Column, mem memory.Allocato
 
 func (s *{{.Name}}Statistics) plainEncode(src {{.name}}) []byte {
 {{- if eq .Name "ByteArray"}}
-  return src
+  out := make([]byte, len(src))
+  copy(out, src)
+  return out
 {{- else}}
   s.encoder.(encoding.{{.Name}}Encoder).Put([]{{.name}}{src})
   buf, err := s.encoder.FlushValues()


### PR DESCRIPTION
Fixes #14007 