### PR TITLE
ARROW-17589: [Docs] Clarify that C data interface is not strictly for within a single process

### DIFF
--- a/docs/source/format/CDataInterface.rst
+++ b/docs/source/format/CDataInterface.rst
@@ -52,6 +52,8 @@ Goals
   support where sufficient), with little initial investment.
 * Allow zero-copy sharing of Arrow data between independent runtimes
   and components running in the same process.
+* Allow zero-copy sharing of Arrow data between independent processes
+  that can access the same memory address space.
 * Match the Arrow array concepts closely to avoid the development of
   yet another marshalling layer.
 * Avoid the need for one-to-one adaptation layers such as the limited
@@ -68,7 +70,10 @@ Non-goals
 
 * Expose a C API mimicking operations available in higher-level runtimes
   (such as C++, Java...).
-* Data sharing between distinct processes or storage persistence.
+* Data sharing between distinct processes that cannot access the same
+  memory address space.
+* Reading or writing Arrow data in persistent storage.
+* Exchanging Arrow data across a network.
 
 
 Comparison with the Arrow IPC format

--- a/docs/source/format/CStreamInterface.rst
+++ b/docs/source/format/CStreamInterface.rst
@@ -26,7 +26,7 @@ The Arrow C stream interface
 The C stream interface builds on the structures defined in the
 :ref:`C data interface <c-data-interface>` and combines them into a higher-level
 specification so as to ease the communication of streaming data within a single
-process.
+process or a single memory address space.
 
 Semantics
 =========


### PR DESCRIPTION
This makes some minor changes to the docs to clarify that the fundamental requirement for using the C data interface and C stream interface is not that all the components be necessarily running in the same process. It’s that they are able to access the same memory address space.