### PR TITLE
ARROW-17079: Show HTTP status code for unknown S3 errors

### DIFF
--- a/cpp/src/arrow/filesystem/s3_internal.h
+++ b/cpp/src/arrow/filesystem/s3_internal.h
@@ -152,12 +152,12 @@ Status ErrorToStatus(const std::string& prefix, const std::string& operation,
   // XXX Handle fine-grained error types
   // See
   // https://sdk.amazonaws.com/cpp/api/LATEST/namespace_aws_1_1_s3.html#ae3f82f8132b619b6e91c88a9f1bde371
-  auto error = S3ErrorToString(static_cast<Aws::S3::S3Errors>(error.GetErrorType()));
+  auto status = S3ErrorToString(static_cast<Aws::S3::S3Errors>(error.GetErrorType()));
   if (error.GetErrorType() == Aws::S3::S3Errors::UNKNOWN) {
-    error += " (http status " + std::to_string(error.GetResponseCode()) + ")";
+    status += " (http status " + std::to_string(error.GetResponseCode()) + ")";
   }
   return Status::IOError(
-      prefix, "AWS Error ", error,
+      prefix, "AWS Error ", status,
       " during ", operation, " operation: ", error.GetMessage());
 }
 

--- a/cpp/src/arrow/filesystem/s3_internal.h
+++ b/cpp/src/arrow/filesystem/s3_internal.h
@@ -152,8 +152,9 @@ Status ErrorToStatus(const std::string& prefix, const std::string& operation,
   // XXX Handle fine-grained error types
   // See
   // https://sdk.amazonaws.com/cpp/api/LATEST/namespace_aws_1_1_s3.html#ae3f82f8132b619b6e91c88a9f1bde371
-  auto status = S3ErrorToString(static_cast<Aws::S3::S3Errors>(error.GetErrorType()));
-  if (error.GetErrorType() == Aws::S3::S3Errors::UNKNOWN) {
+  auto error_type = static_cast<Aws::S3::S3Errors>(error.GetErrorType());
+  auto status = S3ErrorToString(error_type);
+  if (error_type == Aws::S3::S3Errors::UNKNOWN) {
     status += " (http status " + std::to_string(error.GetResponseCode()) + ")";
   }
   return Status::IOError(

--- a/cpp/src/arrow/filesystem/s3_internal.h
+++ b/cpp/src/arrow/filesystem/s3_internal.h
@@ -152,10 +152,12 @@ Status ErrorToStatus(const std::string& prefix, const std::string& operation,
   // XXX Handle fine-grained error types
   // See
   // https://sdk.amazonaws.com/cpp/api/LATEST/namespace_aws_1_1_s3.html#ae3f82f8132b619b6e91c88a9f1bde371
+  auto error = S3ErrorToString(static_cast<Aws::S3::S3Errors>(error.GetErrorType()));
+  if (error.GetErrorType() == Aws::S3::S3Errors::UNKNOWN) {
+    error += " (http status " + std::to_string(error.GetResponseCode()) + ")";
+  }
   return Status::IOError(
-      prefix, "AWS Error ",
-      S3ErrorToString(static_cast<Aws::S3::S3Errors>(error.GetErrorType())),
-      " (http status ", static_cast<int>(error.GetResponseCode()), ")",
+      prefix, "AWS Error ", error,
       " during ", operation, " operation: ", error.GetMessage());
 }
 

--- a/cpp/src/arrow/filesystem/s3_internal.h
+++ b/cpp/src/arrow/filesystem/s3_internal.h
@@ -154,8 +154,9 @@ Status ErrorToStatus(const std::string& prefix, const std::string& operation,
   // https://sdk.amazonaws.com/cpp/api/LATEST/namespace_aws_1_1_s3.html#ae3f82f8132b619b6e91c88a9f1bde371
   return Status::IOError(
       prefix, "AWS Error ",
-      S3ErrorToString(static_cast<Aws::S3::S3Errors>(error.GetErrorType())), " during ",
-      operation, " operation: ", error.GetMessage());
+      S3ErrorToString(static_cast<Aws::S3::S3Errors>(error.GetErrorType())),
+      " (http status code: ", static_cast<int>(error.GetResponseCode()), ")",
+      " during ", operation, " operation: ", error.GetMessage());
 }
 
 template <typename ErrorType, typename... Args>

--- a/cpp/src/arrow/filesystem/s3_internal.h
+++ b/cpp/src/arrow/filesystem/s3_internal.h
@@ -155,7 +155,8 @@ Status ErrorToStatus(const std::string& prefix, const std::string& operation,
   auto error_type = static_cast<Aws::S3::S3Errors>(error.GetErrorType());
   auto status = S3ErrorToString(error_type);
   if (error_type == Aws::S3::S3Errors::UNKNOWN) {
-    status += " (http status " + std::to_string(static_cast<int>(error.GetResponseCode())) + ")";
+    status += " (http status " +
+              std::to_string(static_cast<int>(error.GetResponseCode())) + ")";
   }
   return Status::IOError(prefix, "AWS Error ", status, " during ", operation,
                          " operation: ", error.GetMessage());

--- a/cpp/src/arrow/filesystem/s3_internal.h
+++ b/cpp/src/arrow/filesystem/s3_internal.h
@@ -155,11 +155,10 @@ Status ErrorToStatus(const std::string& prefix, const std::string& operation,
   auto error_type = static_cast<Aws::S3::S3Errors>(error.GetErrorType());
   auto status = S3ErrorToString(error_type);
   if (error_type == Aws::S3::S3Errors::UNKNOWN) {
-    status += " (http status " + std::to_string(error.GetResponseCode()) + ")";
+    status += " (http status " + std::to_string(static_cast<int>(error.GetResponseCode())) + ")";
   }
-  return Status::IOError(
-      prefix, "AWS Error ", status,
-      " during ", operation, " operation: ", error.GetMessage());
+  return Status::IOError(prefix, "AWS Error ", status, " during ", operation,
+                         " operation: ", error.GetMessage());
 }
 
 template <typename ErrorType, typename... Args>

--- a/cpp/src/arrow/filesystem/s3_internal.h
+++ b/cpp/src/arrow/filesystem/s3_internal.h
@@ -153,12 +153,12 @@ Status ErrorToStatus(const std::string& prefix, const std::string& operation,
   // See
   // https://sdk.amazonaws.com/cpp/api/LATEST/namespace_aws_1_1_s3.html#ae3f82f8132b619b6e91c88a9f1bde371
   auto error_type = static_cast<Aws::S3::S3Errors>(error.GetErrorType());
-  auto status = S3ErrorToString(error_type);
+  std::stringstream ss;
+  ss << S3ErrorToString(error_type);
   if (error_type == Aws::S3::S3Errors::UNKNOWN) {
-    status += " (http status " +
-              std::to_string(static_cast<int>(error.GetResponseCode())) + ")";
+    ss << " (http status " << static_cast<int>(error.GetResponseCode()) << ")";
   }
-  return Status::IOError(prefix, "AWS Error ", status, " during ", operation,
+  return Status::IOError(prefix, "AWS Error ", ss.str(), " during ", operation,
                          " operation: ", error.GetMessage());
 }
 

--- a/cpp/src/arrow/filesystem/s3_internal.h
+++ b/cpp/src/arrow/filesystem/s3_internal.h
@@ -155,7 +155,7 @@ Status ErrorToStatus(const std::string& prefix, const std::string& operation,
   return Status::IOError(
       prefix, "AWS Error ",
       S3ErrorToString(static_cast<Aws::S3::S3Errors>(error.GetErrorType())),
-      " (http status code: ", static_cast<int>(error.GetResponseCode()), ")",
+      " (http status ", static_cast<int>(error.GetResponseCode()), ")",
       " during ", operation, " operation: ", error.GetMessage());
 }
 

--- a/cpp/src/arrow/filesystem/s3_internal.h
+++ b/cpp/src/arrow/filesystem/s3_internal.h
@@ -156,7 +156,7 @@ Status ErrorToStatus(const std::string& prefix, const std::string& operation,
   std::stringstream ss;
   ss << S3ErrorToString(error_type);
   if (error_type == Aws::S3::S3Errors::UNKNOWN) {
-    ss << " (http status " << static_cast<int>(error.GetResponseCode()) << ")";
+    ss << " (HTTP status " << static_cast<int>(error.GetResponseCode()) << ")";
   }
   return Status::IOError(prefix, "AWS Error ", ss.str(), " during ", operation,
                          " operation: ", error.GetMessage());


### PR DESCRIPTION
This is the last change I propose to improve our S3 error message.

For certain errors, unfortunately the AWS SDK is doing a poor job in propagating the error and just reports UNKNOWN (see https://github.com/aws/aws-sdk-cpp/blob/1614bce979a201ada1e3436358edb7bd1834b5d6/aws-cpp-sdk-core/source/client/AWSClient.cpp#L77), in these cases the HTTP status code can be an important source to find out what is going wrong (and is also reported by boto3).

This has the downside of cluttering the error message a bit more, but in general this information will be very valuable to diagnose the problem. Given that we now have the API call and the HTTP status error, in general there is good documentation on the internet that helps diagnose the problem.

Before:

> When getting information for key 'test.csv' in bucket 'pcmoritz-test-bucket-arrow-errors': AWS Error UNKNOWN during HeadObject call: No response body.

After:

> When getting information for key 'test.csv' in bucket 'pcmoritz-test-bucket-arrow-errors': AWS Error UNKNOWN **(HTTP status 400)** during HeadObject call: No response body.