### PR TITLE
MINOR: Suppress nightly java build uploads on a fork

### DIFF
--- a/.github/workflows/java_nightly.yml
+++ b/.github/workflows/java_nightly.yml
@@ -32,6 +32,7 @@ on:
     - cron: '0 14 * * *'
 jobs:
   upload:
+    if: github.repository == 'apache/arrow'
     env:
       PREFIX: ${{ github.event.inputs.prefix || ''}}
       CROSSBOW_GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Similar to [this earlier PR](https://github.com/apache/arrow/pull/13457), but for Java.