### PR TITLE
ARROW-17521: [Python] Add python bindings for NamedTableProvider for Substrait consumer

### DIFF
--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -644,7 +644,7 @@ Declaration Declaration::Sequence(std::vector<Declaration> decls) {
 }
 
 bool Declaration::IsValid(ExecFactoryRegistry* registry) const {
-  return registry->GetFactory(this->factory_name).ok() && this->options != nullptr;
+  return !this->factory_name.empty() && this->options != nullptr;
 }
 
 namespace internal {

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -643,6 +643,10 @@ Declaration Declaration::Sequence(std::vector<Declaration> decls) {
   return out;
 }
 
+bool Declaration::IsValid(ExecFactoryRegistry* registry) const {
+  return registry->GetFactory(this->factory_name).ok() && this->options != nullptr;
+}
+
 namespace internal {
 
 void RegisterSourceNode(ExecFactoryRegistry*);

--- a/cpp/src/arrow/compute/exec/exec_plan.h
+++ b/cpp/src/arrow/compute/exec/exec_plan.h
@@ -451,6 +451,8 @@ inline Result<ExecNode*> MakeExecNode(
 struct ARROW_EXPORT Declaration {
   using Input = util::Variant<ExecNode*, Declaration>;
 
+  Declaration() {}
+
   Declaration(std::string factory_name, std::vector<Input> inputs,
               std::shared_ptr<ExecNodeOptions> options, std::string label)
       : factory_name{std::move(factory_name)},
@@ -513,6 +515,9 @@ struct ARROW_EXPORT Declaration {
 
   Result<ExecNode*> AddToPlan(ExecPlan* plan, ExecFactoryRegistry* registry =
                                                   default_exec_factory_registry()) const;
+
+  // Validate a declaration
+  bool IsValid(ExecFactoryRegistry* registry = default_exec_factory_registry()) const;
 
   std::string factory_name;
   std::vector<Input> inputs;

--- a/cpp/src/arrow/engine/substrait/function_test.cc
+++ b/cpp/src/arrow/engine/substrait/function_test.cc
@@ -132,8 +132,8 @@ void CheckValidTestCases(const std::vector<FunctionTestCase>& valid_cases) {
     ASSERT_FINISHES_OK(plan->finished());
 
     // Could also modify the Substrait plan with an emit to drop the leading columns
-    ASSERT_OK_AND_ASSIGN(output_table,
-                         output_table->SelectColumns({output_table->num_columns() - 1}));
+    int result_column = output_table->num_columns() - 1;  // last column holds result
+    ASSERT_OK_AND_ASSIGN(output_table, output_table->SelectColumns({result_column}));
 
     ASSERT_OK_AND_ASSIGN(
         std::shared_ptr<Table> expected_output,

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -140,6 +140,9 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel, const ExtensionSet&
         }
         ARROW_ASSIGN_OR_RAISE(compute::Declaration source_decl,
                               named_table_provider(table_names));
+        if (!source_decl.IsValid()) {
+          return Status::Invalid("Invalid NamedTable Source");
+        }
         return ProcessEmit(std::move(read),
                            DeclarationInfo{std::move(source_decl), base_schema},
                            std::move(base_schema));

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -135,6 +135,9 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel, const ExtensionSet&
         const substrait::ReadRel::NamedTable& named_table = read.named_table();
         std::vector<std::string> table_names(named_table.names().begin(),
                                              named_table.names().end());
+        if (table_names.empty()) {
+          return Status::Invalid("names for NamedTable not provided");
+        }
         ARROW_ASSIGN_OR_RAISE(compute::Declaration source_decl,
                               named_table_provider(table_names));
         return ProcessEmit(std::move(read),

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -1924,7 +1924,6 @@ TEST(Substrait, BasicPlanRoundTripping) {
 
   ASSERT_OK_AND_ASSIGN(auto tempdir,
                        arrow::internal::TemporaryDir::Make("substrait-tempdir-"));
-  std::cout << "file_path_str " << tempdir->path().ToString() << std::endl;
   ASSERT_OK_AND_ASSIGN(auto file_path, tempdir->path().Join(file_name));
   std::string file_path_str = file_path.ToString();
 
@@ -2189,7 +2188,7 @@ TEST(Substrait, ProjectRel) {
               }
             },
             "namedTable": {
-                     "names": []
+              "names": ["A"]
             }
           }
         }
@@ -2313,7 +2312,7 @@ TEST(Substrait, ProjectRelOnFunctionWithEmit) {
               }
             },
             "namedTable": {
-                     "names": []
+              "names": ["A"]
             }
           }
         }
@@ -2396,7 +2395,7 @@ TEST(Substrait, ReadRelWithEmit) {
           }
         },
         "namedTable": {
-          "names" : []
+          "names" : ["A"]
         }
       }
     }
@@ -2501,7 +2500,7 @@ TEST(Substrait, FilterRelWithEmit) {
               }
             },
             "namedTable": {
-              "names" : []
+              "names" : ["A"]
             }
           }
         }
@@ -2885,7 +2884,7 @@ TEST(Substrait, AggregateRel) {
                 }
               },
               "namedTable" : {
-                "names": []
+                "names": ["A"]
               }
             }
           },
@@ -3004,7 +3003,7 @@ TEST(Substrait, AggregateRelEmit) {
                 }
               },
               "namedTable" : {
-                "names" : []
+                "names" : ["A"]
               }
             }
           },

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -1076,17 +1076,15 @@ TEST(Substrait, GetRecordBatchReader) {
   GTEST_SKIP() << "ARROW-16392: Substrait File URI not supported for Windows";
 #else
   ASSERT_OK_AND_ASSIGN(std::string substrait_json, GetSubstraitJSON());
-  PythonTableProvider table_provider;
-  test_with_registries(
-      [&substrait_json, table_provider](ExtensionIdRegistry* ext_id_reg,
-                                        compute::FunctionRegistry* func_registry) {
-        ASSERT_OK_AND_ASSIGN(auto buf, SerializeJsonPlan(substrait_json));
-        ASSERT_OK_AND_ASSIGN(auto reader, ExecuteSerializedPlan(*buf, table_provider));
-        ASSERT_OK_AND_ASSIGN(auto table, Table::FromRecordBatchReader(reader.get()));
-        // Note: assuming the binary.parquet file contains fixed amount of records
-        // in case of a test failure, re-evalaute the content in the file
-        EXPECT_EQ(table->num_rows(), 12);
-      });
+  test_with_registries([&substrait_json](ExtensionIdRegistry* ext_id_reg,
+                                         compute::FunctionRegistry* func_registry) {
+    ASSERT_OK_AND_ASSIGN(auto buf, SerializeJsonPlan(substrait_json));
+    ASSERT_OK_AND_ASSIGN(auto reader, ExecuteSerializedPlan(*buf));
+    ASSERT_OK_AND_ASSIGN(auto table, Table::FromRecordBatchReader(reader.get()));
+    // Note: assuming the binary.parquet file contains fixed amount of records
+    // in case of a test failure, re-evalaute the content in the file
+    EXPECT_EQ(table->num_rows(), 12);
+  });
 #endif
 }
 
@@ -1095,13 +1093,11 @@ TEST(Substrait, InvalidPlan) {
     "relations": [
     ]
   })";
-  PythonTableProvider table_provider;
-  test_with_registries(
-      [&substrait_json, table_provider](ExtensionIdRegistry* ext_id_reg,
-                                        compute::FunctionRegistry* func_registry) {
-        ASSERT_OK_AND_ASSIGN(auto buf, SerializeJsonPlan(substrait_json));
-        ASSERT_RAISES(Invalid, ExecuteSerializedPlan(*buf, table_provider));
-      });
+  test_with_registries([&substrait_json](ExtensionIdRegistry* ext_id_reg,
+                                         compute::FunctionRegistry* func_registry) {
+    ASSERT_OK_AND_ASSIGN(auto buf, SerializeJsonPlan(substrait_json));
+    ASSERT_RAISES(Invalid, ExecuteSerializedPlan(*buf));
+  });
 }
 
 TEST(Substrait, JoinPlanBasic) {

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -1076,15 +1076,17 @@ TEST(Substrait, GetRecordBatchReader) {
   GTEST_SKIP() << "ARROW-16392: Substrait File URI not supported for Windows";
 #else
   ASSERT_OK_AND_ASSIGN(std::string substrait_json, GetSubstraitJSON());
-  test_with_registries([&substrait_json](ExtensionIdRegistry* ext_id_reg,
-                                         compute::FunctionRegistry* func_registry) {
-    ASSERT_OK_AND_ASSIGN(auto buf, SerializeJsonPlan(substrait_json));
-    ASSERT_OK_AND_ASSIGN(auto reader, ExecuteSerializedPlan(*buf));
-    ASSERT_OK_AND_ASSIGN(auto table, Table::FromRecordBatchReader(reader.get()));
-    // Note: assuming the binary.parquet file contains fixed amount of records
-    // in case of a test failure, re-evalaute the content in the file
-    EXPECT_EQ(table->num_rows(), 12);
-  });
+  PythonTableProvider table_provider;
+  test_with_registries(
+      [&substrait_json, table_provider](ExtensionIdRegistry* ext_id_reg,
+                                        compute::FunctionRegistry* func_registry) {
+        ASSERT_OK_AND_ASSIGN(auto buf, SerializeJsonPlan(substrait_json));
+        ASSERT_OK_AND_ASSIGN(auto reader, ExecuteSerializedPlan(*buf, table_provider));
+        ASSERT_OK_AND_ASSIGN(auto table, Table::FromRecordBatchReader(reader.get()));
+        // Note: assuming the binary.parquet file contains fixed amount of records
+        // in case of a test failure, re-evalaute the content in the file
+        EXPECT_EQ(table->num_rows(), 12);
+      });
 #endif
 }
 
@@ -1093,11 +1095,13 @@ TEST(Substrait, InvalidPlan) {
     "relations": [
     ]
   })";
-  test_with_registries([&substrait_json](ExtensionIdRegistry* ext_id_reg,
-                                         compute::FunctionRegistry* func_registry) {
-    ASSERT_OK_AND_ASSIGN(auto buf, SerializeJsonPlan(substrait_json));
-    ASSERT_RAISES(Invalid, ExecuteSerializedPlan(*buf));
-  });
+  PythonTableProvider table_provider;
+  test_with_registries(
+      [&substrait_json, table_provider](ExtensionIdRegistry* ext_id_reg,
+                                        compute::FunctionRegistry* func_registry) {
+        ASSERT_OK_AND_ASSIGN(auto buf, SerializeJsonPlan(substrait_json));
+        ASSERT_RAISES(Invalid, ExecuteSerializedPlan(*buf, table_provider));
+      });
 }
 
 TEST(Substrait, JoinPlanBasic) {

--- a/cpp/src/arrow/engine/substrait/util.cc
+++ b/cpp/src/arrow/engine/substrait/util.cc
@@ -63,8 +63,12 @@ class SubstraitSinkConsumer : public compute::SinkNodeConsumer {
 class SubstraitExecutor {
  public:
   explicit SubstraitExecutor(std::shared_ptr<compute::ExecPlan> plan,
-                             compute::ExecContext exec_context)
-      : plan_(std::move(plan)), plan_started_(false), exec_context_(exec_context) {}
+                             compute::ExecContext exec_context,
+                             const ConversionOptions& conversion_options = {})
+      : plan_(std::move(plan)),
+        plan_started_(false),
+        exec_context_(exec_context),
+        conversion_options_(conversion_options) {}
 
   ~SubstraitExecutor() { ARROW_UNUSED(this->Close()); }
 
@@ -95,8 +99,8 @@ class SubstraitExecutor {
       return sink_consumer_;
     };
     ARROW_ASSIGN_OR_RAISE(
-        declarations_,
-        engine::DeserializePlans(substrait_buffer, consumer_factory, registry));
+        declarations_, engine::DeserializePlans(substrait_buffer, consumer_factory,
+                                                registry, nullptr, conversion_options_));
     return Status::OK();
   }
 
@@ -107,6 +111,7 @@ class SubstraitExecutor {
   bool plan_started_;
   compute::ExecContext exec_context_;
   std::shared_ptr<SubstraitSinkConsumer> sink_consumer_;
+  const ConversionOptions& conversion_options_;
 };
 
 }  // namespace
@@ -120,6 +125,36 @@ Result<std::shared_ptr<RecordBatchReader>> ExecuteSerializedPlan(
   ARROW_ASSIGN_OR_RAISE(auto plan, compute::ExecPlan::Make(&exec_context));
   SubstraitExecutor executor(std::move(plan), exec_context);
   RETURN_NOT_OK(executor.Init(substrait_buffer, extid_registry));
+  ARROW_ASSIGN_OR_RAISE(auto sink_reader, executor.Execute());
+  // check closing here, not in destructor, to expose error to caller
+  RETURN_NOT_OK(executor.Close());
+  return sink_reader;
+}
+
+Result<std::shared_ptr<RecordBatchReader>> ExecuteSerializedPlan(
+    const Buffer& substrait_buffer, PythonTableProvider& table_provider,
+    const std::vector<std::string>& provider_names, const ExtensionIdRegistry* registry,
+    compute::FunctionRegistry* func_registry) {
+  // TODO(ARROW-15732)
+  // retrieve input table from table provider
+  std::shared_ptr<Table> input_table = table_provider(provider_names);
+
+  NamedTableProvider named_table_provider =
+      [input_table](const std::vector<std::string>&) {
+        std::shared_ptr<compute::ExecNodeOptions> options =
+            std::make_shared<compute::TableSourceNodeOptions>(input_table);
+        return compute::Declaration("table_source", {}, options,
+                                    "substrait_table_provider_source");
+      };
+
+  ConversionOptions conversion_options;
+  conversion_options.named_table_provider = std::move(named_table_provider);
+
+  compute::ExecContext exec_context(arrow::default_memory_pool(),
+                                    ::arrow::internal::GetCpuThreadPool(), func_registry);
+  ARROW_ASSIGN_OR_RAISE(auto plan, compute::ExecPlan::Make(&exec_context));
+  SubstraitExecutor executor(std::move(plan), exec_context);
+  RETURN_NOT_OK(executor.Init(substrait_buffer, registry));
   ARROW_ASSIGN_OR_RAISE(auto sink_reader, executor.Execute());
   // check closing here, not in destructor, to expose error to caller
   RETURN_NOT_OK(executor.Close());

--- a/cpp/src/arrow/engine/substrait/util.cc
+++ b/cpp/src/arrow/engine/substrait/util.cc
@@ -117,41 +117,27 @@ class SubstraitExecutor {
 }  // namespace
 
 Result<std::shared_ptr<RecordBatchReader>> ExecuteSerializedPlan(
-    const Buffer& substrait_buffer, const ExtensionIdRegistry* extid_registry,
-    compute::FunctionRegistry* func_registry) {
-  // TODO(ARROW-15732)
-  compute::ExecContext exec_context(arrow::default_memory_pool(),
-                                    ::arrow::internal::GetCpuThreadPool(), func_registry);
-  ARROW_ASSIGN_OR_RAISE(auto plan, compute::ExecPlan::Make(&exec_context));
-  SubstraitExecutor executor(std::move(plan), exec_context);
-  RETURN_NOT_OK(executor.Init(substrait_buffer, extid_registry));
-  ARROW_ASSIGN_OR_RAISE(auto sink_reader, executor.Execute());
-  // check closing here, not in destructor, to expose error to caller
-  RETURN_NOT_OK(executor.Close());
-  return sink_reader;
-}
-
-Result<std::shared_ptr<RecordBatchReader>> ExecuteSerializedPlan(
-    const Buffer& substrait_buffer, PythonTableProvider& table_provider,
+    const Buffer& substrait_buffer, const PythonTableProvider& table_provider,
     const ExtensionIdRegistry* registry, compute::FunctionRegistry* func_registry) {
   // TODO(ARROW-15732)
   // retrieve input table from table provider
-
-  NamedTableProvider named_table_provider =
-      [table_provider](
-          const std::vector<std::string>& names) -> Result<compute::Declaration> {
-    if (names.empty()) {
-      return Status::Invalid("names for NamedTable not provided");
-    }
-    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Table> input_table, table_provider(names));
-    std::shared_ptr<compute::ExecNodeOptions> options =
-        std::make_shared<compute::TableSourceNodeOptions>(input_table);
-    return compute::Declaration("table_source", {}, options,
-                                "substrait_table_provider_source");
-  };
-
   ConversionOptions conversion_options;
-  conversion_options.named_table_provider = std::move(named_table_provider);
+  if (table_provider) {
+    NamedTableProvider named_table_provider =
+        [table_provider](
+            const std::vector<std::string>& names) -> Result<compute::Declaration> {
+      if (names.empty()) {
+        return Status::Invalid("names for NamedTable not provided");
+      }
+      ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Table> input_table, table_provider(names));
+      std::shared_ptr<compute::ExecNodeOptions> options =
+          std::make_shared<compute::TableSourceNodeOptions>(input_table);
+      return compute::Declaration("table_source", {}, options,
+                                  "substrait_table_provider_source");
+    };
+
+    conversion_options.named_table_provider = std::move(named_table_provider);
+  }
 
   compute::ExecContext exec_context(arrow::default_memory_pool(),
                                     ::arrow::internal::GetCpuThreadPool(), func_registry);

--- a/cpp/src/arrow/engine/substrait/util.cc
+++ b/cpp/src/arrow/engine/substrait/util.cc
@@ -126,9 +126,6 @@ Result<std::shared_ptr<RecordBatchReader>> ExecuteSerializedPlan(
     NamedTableProvider named_table_provider =
         [table_provider](
             const std::vector<std::string>& names) -> Result<compute::Declaration> {
-      if (names.empty()) {
-        return Status::Invalid("names for NamedTable not provided");
-      }
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Table> input_table, table_provider(names));
       std::shared_ptr<compute::ExecNodeOptions> options =
           std::make_shared<compute::TableSourceNodeOptions>(input_table);

--- a/cpp/src/arrow/engine/substrait/util.cc
+++ b/cpp/src/arrow/engine/substrait/util.cc
@@ -140,6 +140,9 @@ Result<std::shared_ptr<RecordBatchReader>> ExecuteSerializedPlan(
   NamedTableProvider named_table_provider =
       [table_provider](
           const std::vector<std::string>& names) -> Result<compute::Declaration> {
+    if (names.empty()) {
+      return Status::Invalid("names for NamedTable not provided");
+    }
     ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Table> input_table, table_provider(names));
     std::shared_ptr<compute::ExecNodeOptions> options =
         std::make_shared<compute::TableSourceNodeOptions>(input_table);

--- a/cpp/src/arrow/engine/substrait/util.cc
+++ b/cpp/src/arrow/engine/substrait/util.cc
@@ -153,7 +153,7 @@ Result<std::shared_ptr<RecordBatchReader>> ExecuteSerializedPlan(
   compute::ExecContext exec_context(arrow::default_memory_pool(),
                                     ::arrow::internal::GetCpuThreadPool(), func_registry);
   ARROW_ASSIGN_OR_RAISE(auto plan, compute::ExecPlan::Make(&exec_context));
-  SubstraitExecutor executor(std::move(plan), exec_context);
+  SubstraitExecutor executor(std::move(plan), exec_context, conversion_options);
   RETURN_NOT_OK(executor.Init(substrait_buffer, registry));
   ARROW_ASSIGN_OR_RAISE(auto sink_reader, executor.Execute());
   // check closing here, not in destructor, to expose error to caller

--- a/cpp/src/arrow/engine/substrait/util.h
+++ b/cpp/src/arrow/engine/substrait/util.h
@@ -20,6 +20,7 @@
 #include <memory>
 #include "arrow/compute/registry.h"
 #include "arrow/engine/substrait/api.h"
+#include "arrow/engine/substrait/options.h"
 #include "arrow/util/iterator.h"
 #include "arrow/util/optional.h"
 
@@ -27,9 +28,20 @@ namespace arrow {
 
 namespace engine {
 
+using PythonTableProvider =
+    std::function<std::shared_ptr<Table>(const std::vector<std::string>&)>;
+
 /// \brief Retrieve a RecordBatchReader from a Substrait plan.
 ARROW_ENGINE_EXPORT Result<std::shared_ptr<RecordBatchReader>> ExecuteSerializedPlan(
     const Buffer& substrait_buffer, const ExtensionIdRegistry* registry = NULLPTR,
+    compute::FunctionRegistry* func_registry = NULLPTR);
+
+/// \brief Retrieve a RecordBatchReader from a Substrait plan.
+/// Allows to use NamedT
+ARROW_ENGINE_EXPORT Result<std::shared_ptr<RecordBatchReader>> ExecuteSerializedPlan(
+    const Buffer& substrait_buffer, PythonTableProvider& table_provider,
+    const std::vector<std::string>& provider_names,
+    const ExtensionIdRegistry* registry = NULLPTR,
     compute::FunctionRegistry* func_registry = NULLPTR);
 
 /// \brief Get a Serialized Plan from a Substrait JSON plan.

--- a/cpp/src/arrow/engine/substrait/util.h
+++ b/cpp/src/arrow/engine/substrait/util.h
@@ -32,7 +32,6 @@ using PythonTableProvider =
     std::function<Result<std::shared_ptr<Table>>(const std::vector<std::string>&)>;
 
 /// \brief Retrieve a RecordBatchReader from a Substrait plan.
-/// Allows to use NamedTableProvider in Substrait plan execution.
 ARROW_ENGINE_EXPORT Result<std::shared_ptr<RecordBatchReader>> ExecuteSerializedPlan(
     const Buffer& substrait_buffer, const PythonTableProvider& table_provider,
     const ExtensionIdRegistry* registry = NULLPTR,

--- a/cpp/src/arrow/engine/substrait/util.h
+++ b/cpp/src/arrow/engine/substrait/util.h
@@ -32,14 +32,9 @@ using PythonTableProvider =
     std::function<Result<std::shared_ptr<Table>>(const std::vector<std::string>&)>;
 
 /// \brief Retrieve a RecordBatchReader from a Substrait plan.
-ARROW_ENGINE_EXPORT Result<std::shared_ptr<RecordBatchReader>> ExecuteSerializedPlan(
-    const Buffer& substrait_buffer, const ExtensionIdRegistry* registry = NULLPTR,
-    compute::FunctionRegistry* func_registry = NULLPTR);
-
-/// \brief Retrieve a RecordBatchReader from a Substrait plan.
 /// Allows to use NamedTableProvider in Substrait plan execution.
 ARROW_ENGINE_EXPORT Result<std::shared_ptr<RecordBatchReader>> ExecuteSerializedPlan(
-    const Buffer& substrait_buffer, PythonTableProvider& table_provider,
+    const Buffer& substrait_buffer, const PythonTableProvider& table_provider,
     const ExtensionIdRegistry* registry = NULLPTR,
     compute::FunctionRegistry* func_registry = NULLPTR);
 

--- a/cpp/src/arrow/engine/substrait/util.h
+++ b/cpp/src/arrow/engine/substrait/util.h
@@ -37,7 +37,7 @@ ARROW_ENGINE_EXPORT Result<std::shared_ptr<RecordBatchReader>> ExecuteSerialized
     compute::FunctionRegistry* func_registry = NULLPTR);
 
 /// \brief Retrieve a RecordBatchReader from a Substrait plan.
-/// Allows to use NamedT
+/// Allows to use NamedTableProvider in Substrait plan execution.
 ARROW_ENGINE_EXPORT Result<std::shared_ptr<RecordBatchReader>> ExecuteSerializedPlan(
     const Buffer& substrait_buffer, PythonTableProvider& table_provider,
     const ExtensionIdRegistry* registry = NULLPTR,

--- a/cpp/src/arrow/engine/substrait/util.h
+++ b/cpp/src/arrow/engine/substrait/util.h
@@ -37,6 +37,11 @@ ARROW_ENGINE_EXPORT Result<std::shared_ptr<RecordBatchReader>> ExecuteSerialized
     const ExtensionIdRegistry* registry = NULLPTR,
     compute::FunctionRegistry* func_registry = NULLPTR);
 
+ARROW_ENGINE_EXPORT Result<std::shared_ptr<RecordBatchReader>> ExecuteSerializedPlan(
+    const Buffer& substrait_buffer, const ExtensionIdRegistry* registry = NULLPTR,
+    compute::FunctionRegistry* func_registry = NULLPTR,
+    const ConversionOptions& conversion_options = {});
+
 /// \brief Get a Serialized Plan from a Substrait JSON plan.
 /// This is a helper method for Python tests.
 ARROW_ENGINE_EXPORT Result<std::shared_ptr<Buffer>> SerializeJsonPlan(

--- a/cpp/src/arrow/engine/substrait/util.h
+++ b/cpp/src/arrow/engine/substrait/util.h
@@ -31,12 +31,6 @@ namespace engine {
 using PythonTableProvider =
     std::function<Result<std::shared_ptr<Table>>(const std::vector<std::string>&)>;
 
-/// \brief Retrieve a RecordBatchReader from a Substrait plan.
-ARROW_ENGINE_EXPORT Result<std::shared_ptr<RecordBatchReader>> ExecuteSerializedPlan(
-    const Buffer& substrait_buffer, const PythonTableProvider& table_provider,
-    const ExtensionIdRegistry* registry = NULLPTR,
-    compute::FunctionRegistry* func_registry = NULLPTR);
-
 ARROW_ENGINE_EXPORT Result<std::shared_ptr<RecordBatchReader>> ExecuteSerializedPlan(
     const Buffer& substrait_buffer, const ExtensionIdRegistry* registry = NULLPTR,
     compute::FunctionRegistry* func_registry = NULLPTR,

--- a/cpp/src/arrow/engine/substrait/util.h
+++ b/cpp/src/arrow/engine/substrait/util.h
@@ -29,7 +29,7 @@ namespace arrow {
 namespace engine {
 
 using PythonTableProvider =
-    std::function<std::shared_ptr<Table>(const std::vector<std::string>&)>;
+    std::function<Result<std::shared_ptr<Table>>(const std::vector<std::string>&)>;
 
 /// \brief Retrieve a RecordBatchReader from a Substrait plan.
 ARROW_ENGINE_EXPORT Result<std::shared_ptr<RecordBatchReader>> ExecuteSerializedPlan(
@@ -40,7 +40,6 @@ ARROW_ENGINE_EXPORT Result<std::shared_ptr<RecordBatchReader>> ExecuteSerialized
 /// Allows to use NamedT
 ARROW_ENGINE_EXPORT Result<std::shared_ptr<RecordBatchReader>> ExecuteSerializedPlan(
     const Buffer& substrait_buffer, PythonTableProvider& table_provider,
-    const std::vector<std::string>& provider_names,
     const ExtensionIdRegistry* registry = NULLPTR,
     compute::FunctionRegistry* func_registry = NULLPTR);
 

--- a/python/pyarrow/_exec_plan.pyx
+++ b/python/pyarrow/_exec_plan.pyx
@@ -92,7 +92,7 @@ cdef execplan(inputs, output_type, vector[CDeclaration] plan, c_bool use_threads
             node_factory = "table_source"
             c_in_table = pyarrow_unwrap_table(ipt)
             c_tablesourceopts = make_shared[CTableSourceNodeOptions](
-                c_in_table, 1 << 20)
+                c_in_table)
             c_input_node_opts = static_pointer_cast[CExecNodeOptions, CTableSourceNodeOptions](
                 c_tablesourceopts)
         elif isinstance(ipt, Dataset):

--- a/python/pyarrow/_substrait.pyx
+++ b/python/pyarrow/_substrait.pyx
@@ -26,32 +26,27 @@ from pyarrow.includes.libarrow cimport *
 from pyarrow.includes.libarrow_substrait cimport *
 
 
-cdef shared_ptr[CTable] _process_named_table(dict named_args, const std_vector[c_string]& names):
-    cdef:
-        c_string c_name
-    py_names = []
-
-    for i in range(names.size()):
-        c_name = names[i]
-        py_names.append(frombytes(c_name))
-    return pyarrow_unwrap_table(named_args["provider"](py_names))
-
-
 cdef CDeclaration _create_named_table_provider(dict named_args, const std_vector[c_string]& names):
     cdef:
+        c_string c_name
         shared_ptr[CTable] c_in_table
         shared_ptr[CTableSourceNodeOptions] c_tablesourceopts
         shared_ptr[CExecNodeOptions] c_input_node_opts
         vector[CDeclaration.Input] no_c_inputs
-    
-    c_in_table = _process_named_table(named_args, names)
+
+    py_names = []
+    for i in range(names.size()):
+        c_name = names[i]
+        py_names.append(frombytes(c_name))
+
+    py_table = named_args["provider"](py_names)    
+    c_in_table = pyarrow_unwrap_table(py_table)
     c_tablesourceopts = make_shared[CTableSourceNodeOptions](
-                c_in_table, 1 << 20)
+        c_in_table, 1 << 20)
     c_input_node_opts = static_pointer_cast[CExecNodeOptions, CTableSourceNodeOptions](
-                c_tablesourceopts)
+        c_tablesourceopts)
     return CDeclaration(tobytes("table_source"),
-                             no_c_inputs, c_input_node_opts)
-    
+                        no_c_inputs, c_input_node_opts)
 
 
 def run_query(plan, table_provider=None):
@@ -123,97 +118,6 @@ def run_query(plan, table_provider=None):
         RecordBatchReader reader
         c_string c_str_plan
         shared_ptr[CBuffer] c_buf_plan
-        function[named_table_provider] c_table_provider
-
-    c_buf_plan = pyarrow_unwrap_buffer(plan)
-
-    if table_provider is not None:
-        named_table_args = {
-            "provider": table_provider
-        }
-        c_table_provider = BindFunction[named_table_provider](
-            &_process_named_table, named_table_args)
-
-    with nogil:
-        c_res_reader = ExecuteSerializedPlan(
-            deref(c_buf_plan), c_table_provider)
-
-    c_reader = GetResultValue(c_res_reader)
-
-    reader = RecordBatchReader.__new__(RecordBatchReader)
-    reader.reader = c_reader
-    return reader
-
-def run_query1(plan, table_provider=None):
-    """
-    Execute a Substrait plan and read the results as a RecordBatchReader.
-
-    Parameters
-    ----------
-    plan : Buffer
-        The serialized Substrait plan to execute.
-    table_provider : object (optional)
-        A function to resolve any NamedTable relation to a table.
-        The function will receive a single argument which will be a list
-        of strings representing the table name and should return a pyarrow.Table.
-
-    Returns
-    -------
-    RecordBatchReader
-        A reader containing the result of the executed query
-
-    Examples
-    --------
-    >>> import pyarrow as pa
-    >>> from pyarrow.lib import tobytes
-    >>> import pyarrow.substrait as substrait
-    >>> test_table_1 = pa.Table.from_pydict({"x": [1, 2, 3]})
-    >>> test_table_2 = pa.Table.from_pydict({"x": [4, 5, 6]})
-    >>> def table_provider(names):
-    ...     if not names:
-    ...        raise Exception("No names provided")
-    ...     elif names[0] == "t1":
-    ...        return test_table_1
-    ...     elif names[1] == "t2":
-    ...        return test_table_2
-    ...     else:
-    ...        raise Exception("Unrecognized table name")
-    ... 
-    >>> substrait_query = '''
-    ...         {
-    ...             "relations": [
-    ...             {"rel": {
-    ...                 "read": {
-    ...                 "base_schema": {
-    ...                     "struct": {
-    ...                     "types": [
-    ...                                 {"i64": {}}
-    ...                             ]
-    ...                     },
-    ...                     "names": [
-    ...                             "x"
-    ...                             ]
-    ...                 },
-    ...                 "namedTable": {
-    ...                         "names": ["t1"]
-    ...                 }
-    ...                 }
-    ...             }}
-    ...             ]
-    ...         }
-    ... '''
-    >>> buf = pa._substrait._parse_json_plan(tobytes(substrait_query))
-    >>> pa.substrait.run_query_with_provider(buf, table_provider)
-    <pyarrow.lib.RecordBatchReader object at 0x100dcaf10>
-    """
-
-    cdef:
-        CResult[shared_ptr[CRecordBatchReader]] c_res_reader
-        shared_ptr[CRecordBatchReader] c_reader
-        RecordBatchReader reader
-        c_string c_str_plan
-        shared_ptr[CBuffer] c_buf_plan
-        function[named_table_provider] c_table_provider
         function[CNamedTableProvider] c_named_table_provider
         CConversionOptions c_conversion_options
 

--- a/python/pyarrow/_substrait.pyx
+++ b/python/pyarrow/_substrait.pyx
@@ -39,10 +39,9 @@ cdef CDeclaration _create_named_table_provider(dict named_args, const std_vector
         c_name = names[i]
         py_names.append(frombytes(c_name))
 
-    py_table = named_args["provider"](py_names)    
+    py_table = named_args["provider"](py_names)
     c_in_table = pyarrow_unwrap_table(py_table)
-    c_tablesourceopts = make_shared[CTableSourceNodeOptions](
-        c_in_table, 1 << 20)
+    c_tablesourceopts = make_shared[CTableSourceNodeOptions](c_in_table)
     c_input_node_opts = static_pointer_cast[CExecNodeOptions, CTableSourceNodeOptions](
         c_tablesourceopts)
     return CDeclaration(tobytes("table_source"),

--- a/python/pyarrow/_substrait.pyx
+++ b/python/pyarrow/_substrait.pyx
@@ -107,8 +107,12 @@ def run_query(plan, table_provider=None):
     ...         }
     ... '''
     >>> buf = pa._substrait._parse_json_plan(tobytes(substrait_query))
-    >>> pa.substrait.run_query_with_provider(buf, table_provider)
-    <pyarrow.lib.RecordBatchReader object at 0x100dcaf10>
+    >>> reader = pa.substrait.run_query(buf, table_provider)
+    >>> reader.read_all()
+    pyarrow.Table
+    x: int64
+    ----
+    x: [[1,2,3]]
     """
 
     cdef:

--- a/python/pyarrow/_substrait.pyx
+++ b/python/pyarrow/_substrait.pyx
@@ -36,22 +36,22 @@ cdef shared_ptr[CTable] _process_named_table(dict named_args, const std_vector[c
         py_names.append(frombytes(c_name))
     return pyarrow_unwrap_table(named_args["provider"](py_names))
 
+
 cdef CDeclaration _create_named_table_provider(dict named_args, const std_vector[c_string]& names):
     cdef:
         shared_ptr[CTable] c_in_table
         shared_ptr[CTableSourceNodeOptions] c_tablesourceopts
         shared_ptr[CExecNodeOptions] c_input_node_opts
         vector[CDeclaration.Input] no_c_inputs
-        CDeclaration c_declaration
     
     c_in_table = _process_named_table(named_args, names)
     c_tablesourceopts = make_shared[CTableSourceNodeOptions](
                 c_in_table, 1 << 20)
     c_input_node_opts = static_pointer_cast[CExecNodeOptions, CTableSourceNodeOptions](
                 c_tablesourceopts)
-    c_declaration = CDeclaration(tobytes("table_source"),
+    return CDeclaration(tobytes("table_source"),
                              no_c_inputs, c_input_node_opts)
-    return c_declaration
+    
 
 
 def run_query(plan, table_provider=None):

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2574,6 +2574,7 @@ cdef extern from "arrow/compute/exec/exec_plan.h" namespace "arrow::compute" nog
         c_string label
         vector[Input] inputs
 
+        CDeclaration()
         CDeclaration(c_string factory_name, CExecNodeOptions options)
         CDeclaration(c_string factory_name, vector[Input] inputs, shared_ptr[CExecNodeOptions] options)
 

--- a/python/pyarrow/includes/libarrow_substrait.pxd
+++ b/python/pyarrow/includes/libarrow_substrait.pxd
@@ -22,13 +22,13 @@ from libcpp.vector cimport vector as std_vector
 from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport *
 
-ctypedef CResult[shared_ptr[CTable]] named_table_provider(const std_vector[c_string]&)
+# ctypedef CResult[shared_ptr[CTable]] named_table_provider(const std_vector[c_string]&)
 
 ctypedef CResult[CDeclaration] CNamedTableProvider(const std_vector[c_string]&)
 
 cdef extern from "arrow/engine/substrait/options.h" namespace "arrow::engine" nogil:
     cdef enum ConversionStrictness \
-            "arrow::engine::ConversionStrictness" :
+            "arrow::engine::ConversionStrictness":
         EXACT_ROUNDTRIP \
             "arrow::engine::ConversionStrictness::EXACT_ROUNDTRIP"
         PRESERVE_STRUCTURE \
@@ -51,8 +51,6 @@ cdef extern from "arrow/engine/substrait/extension_set.h" \
 
 
 cdef extern from "arrow/engine/substrait/util.h" namespace "arrow::engine" nogil:
-    CResult[shared_ptr[CRecordBatchReader]] ExecuteSerializedPlan(const CBuffer& substrait_buffer,
-        const function[named_table_provider] table_provider)
     CResult[shared_ptr[CRecordBatchReader]] ExecuteSerializedPlan(
         const CBuffer& substrait_buffer, const ExtensionIdRegistry* registry,
         CFunctionRegistry* func_registry, const CConversionOptions& conversion_options)

--- a/python/pyarrow/includes/libarrow_substrait.pxd
+++ b/python/pyarrow/includes/libarrow_substrait.pxd
@@ -25,8 +25,7 @@ from pyarrow.includes.libarrow cimport *
 ctypedef CResult[shared_ptr[CTable]] named_table_provider(const std_vector[c_string]&)
 
 cdef extern from "arrow/engine/substrait/util.h" namespace "arrow::engine" nogil:
-    CResult[shared_ptr[CRecordBatchReader]] ExecuteSerializedPlan(const CBuffer& substrait_buffer)
-    CResult[shared_ptr[CRecordBatchReader]] ExecuteSerializedPlan(const CBuffer& substrait_buffer, function[named_table_provider] table_provider)
+    CResult[shared_ptr[CRecordBatchReader]] ExecuteSerializedPlan(const CBuffer& substrait_buffer, const function[named_table_provider] table_provider)
     CResult[shared_ptr[CBuffer]] SerializeJsonPlan(const c_string& substrait_json)
 
 cdef extern from "arrow/engine/substrait/extension_set.h" \

--- a/python/pyarrow/includes/libarrow_substrait.pxd
+++ b/python/pyarrow/includes/libarrow_substrait.pxd
@@ -34,3 +34,5 @@ cdef extern from "arrow/engine/substrait/extension_set.h" \
         std_vector[c_string] GetSupportedSubstraitFunctions()
 
     ExtensionIdRegistry* default_extension_id_registry()
+
+ctypedef shared_ptr[CTable] named_table_provider(const std_vector[c_string]&)

--- a/python/pyarrow/includes/libarrow_substrait.pxd
+++ b/python/pyarrow/includes/libarrow_substrait.pxd
@@ -22,8 +22,6 @@ from libcpp.vector cimport vector as std_vector
 from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport *
 
-# ctypedef CResult[shared_ptr[CTable]] named_table_provider(const std_vector[c_string]&)
-
 ctypedef CResult[CDeclaration] CNamedTableProvider(const std_vector[c_string]&)
 
 cdef extern from "arrow/engine/substrait/options.h" namespace "arrow::engine" nogil:

--- a/python/pyarrow/includes/libarrow_substrait.pxd
+++ b/python/pyarrow/includes/libarrow_substrait.pxd
@@ -22,9 +22,11 @@ from libcpp.vector cimport vector as std_vector
 from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport *
 
+ctypedef CResult[shared_ptr[CTable]] named_table_provider(const std_vector[c_string]&)
 
 cdef extern from "arrow/engine/substrait/util.h" namespace "arrow::engine" nogil:
     CResult[shared_ptr[CRecordBatchReader]] ExecuteSerializedPlan(const CBuffer& substrait_buffer)
+    CResult[shared_ptr[CRecordBatchReader]] ExecuteSerializedPlan(const CBuffer& substrait_buffer, function[named_table_provider] table_provider)
     CResult[shared_ptr[CBuffer]] SerializeJsonPlan(const c_string& substrait_json)
 
 cdef extern from "arrow/engine/substrait/extension_set.h" \
@@ -34,5 +36,3 @@ cdef extern from "arrow/engine/substrait/extension_set.h" \
         std_vector[c_string] GetSupportedSubstraitFunctions()
 
     ExtensionIdRegistry* default_extension_id_registry()
-
-ctypedef shared_ptr[CTable] named_table_provider(const std_vector[c_string]&)

--- a/python/pyarrow/includes/libarrow_substrait.pxd
+++ b/python/pyarrow/includes/libarrow_substrait.pxd
@@ -24,9 +24,22 @@ from pyarrow.includes.libarrow cimport *
 
 ctypedef CResult[shared_ptr[CTable]] named_table_provider(const std_vector[c_string]&)
 
-cdef extern from "arrow/engine/substrait/util.h" namespace "arrow::engine" nogil:
-    CResult[shared_ptr[CRecordBatchReader]] ExecuteSerializedPlan(const CBuffer& substrait_buffer, const function[named_table_provider] table_provider)
-    CResult[shared_ptr[CBuffer]] SerializeJsonPlan(const c_string& substrait_json)
+ctypedef CResult[CDeclaration] CNamedTableProvider(const std_vector[c_string]&)
+
+cdef extern from "arrow/engine/substrait/options.h" namespace "arrow::engine" nogil:
+    cdef enum ConversionStrictness \
+            "arrow::engine::ConversionStrictness" :
+        EXACT_ROUNDTRIP \
+            "arrow::engine::ConversionStrictness::EXACT_ROUNDTRIP"
+        PRESERVE_STRUCTURE \
+            "arrow::engine::ConversionStrictness::PRESERVE_STRUCTURE"
+        BEST_EFFORT \
+            "arrow::engine::ConversionStrictness::BEST_EFFORT"
+
+    cdef cppclass CConversionOptions \
+            "arrow::engine::ConversionOptions":
+        ConversionStrictness conversion_strictness
+        function[CNamedTableProvider] named_table_provider
 
 cdef extern from "arrow/engine/substrait/extension_set.h" \
         namespace "arrow::engine" nogil:
@@ -35,3 +48,13 @@ cdef extern from "arrow/engine/substrait/extension_set.h" \
         std_vector[c_string] GetSupportedSubstraitFunctions()
 
     ExtensionIdRegistry* default_extension_id_registry()
+
+
+cdef extern from "arrow/engine/substrait/util.h" namespace "arrow::engine" nogil:
+    CResult[shared_ptr[CRecordBatchReader]] ExecuteSerializedPlan(const CBuffer& substrait_buffer,
+        const function[named_table_provider] table_provider)
+    CResult[shared_ptr[CRecordBatchReader]] ExecuteSerializedPlan(
+        const CBuffer& substrait_buffer, const ExtensionIdRegistry* registry,
+        CFunctionRegistry* func_registry, const CConversionOptions& conversion_options)
+
+    CResult[shared_ptr[CBuffer]] SerializeJsonPlan(const c_string& substrait_json)

--- a/python/pyarrow/substrait.py
+++ b/python/pyarrow/substrait.py
@@ -18,5 +18,4 @@
 from pyarrow._substrait import (  # noqa
     get_supported_functions,
     run_query,
-    run_query_with_provider,
 )

--- a/python/pyarrow/substrait.py
+++ b/python/pyarrow/substrait.py
@@ -18,4 +18,5 @@
 from pyarrow._substrait import (  # noqa
     get_supported_functions,
     run_query,
+    run_query_with_provider,
 )

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -207,4 +207,7 @@ def test_named_table():
     table_name = "t1"
     query = tobytes(substrait_query.replace(
         "TABLE_NAME_PLACEHOLDER", table_name))
-    pa.substrait.run_query_with_provider(query, table_provider)
+    buf = pa._substrait._parse_json_plan(tobytes(query))
+    reader = pa.substrait.run_query_with_provider(buf, table_provider)
+    res_tb = reader.read_all()
+    print(res_tb)

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -165,11 +165,12 @@ def test_get_supported_functions():
                         'functions_arithmetic.yaml', 'add')
     assert has_function(supported_functions,
                         'functions_arithmetic.yaml', 'sum')
-    
+
+
 def test_named_table():
     test_table_1 = pa.Table.from_pydict({"x": [1, 2, 3]})
     test_table_2 = pa.Table.from_pydict({"x": [4, 5, 6]})
-    
+
     def table_provider(names):
         if not names:
             raise Exception("No names provided")
@@ -179,7 +180,7 @@ def test_named_table():
             return test_table_2
         else:
             raise Exception("Unrecognized table name")
-        
+
     substrait_query = """
     {
         "relations": [
@@ -203,6 +204,7 @@ def test_named_table():
         ]
     }
     """
-    table_name = ""
-    query = tobytes(substrait_query.replace("TABLE_NAME_PLACEHOLDER", path))
-    pa.substrait.run_query(query, table_provider=table_provider)
+    table_name = "t1"
+    query = tobytes(substrait_query.replace(
+        "TABLE_NAME_PLACEHOLDER", table_name))
+    pa.substrait.run_query_with_provider(query, table_provider)

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -197,17 +197,15 @@ def test_named_table():
                         ]
             },
             "namedTable": {
-                    "names": ["TABLE_NAME_PLACEHOLDER"]
+                    "names": ["t1"]
             }
             }
         }}
         ]
     }
     """
-    table_name = "t1"
-    query = tobytes(substrait_query.replace(
-        "TABLE_NAME_PLACEHOLDER", table_name))
-    buf = pa._substrait._parse_json_plan(tobytes(query))
+
+    buf = pa._substrait._parse_json_plan(tobytes(substrait_query))
     reader = pa.substrait.run_query(buf, table_provider)
     res_tb = reader.read_all()
     assert res_tb == test_table_1
@@ -240,18 +238,15 @@ def test_named_table_invalid_table_name():
                         ]
             },
             "namedTable": {
-                    "names": ["TABLE_NAME_PLACEHOLDER"]
+                    "names": ["t3"]
             }
             }
         }}
         ]
     }
     """
-    table_name = "t3"
-    query = tobytes(substrait_query.replace(
-        "TABLE_NAME_PLACEHOLDER", table_name))
-    buf = pa._substrait._parse_json_plan(tobytes(query))
 
+    buf = pa._substrait._parse_json_plan(tobytes(substrait_query))
     exec_message = "TableSourceNode requires table which is not null"
     with pytest.raises(ArrowInvalid, match=exec_message):
         substrait.run_query(buf, table_provider)
@@ -295,42 +290,4 @@ def test_named_table_empty_names():
     buf = pa._substrait._parse_json_plan(tobytes(query))
     exec_message = "names for NamedTable not provided"
     with pytest.raises(ArrowInvalid, match=exec_message):
-        substrait.run_query(buf, table_provider)
-
-
-def test_named_table_no_named_table():
-    test_table_1 = pa.Table.from_pydict({"x": [1, 2, 3]})
-
-    def table_provider(names):
-        if not names:
-            raise Exception("No names provided")
-        elif names[0] == "t1":
-            return test_table_1
-        else:
-            raise Exception("Unrecognized table name")
-
-    substrait_query = """
-    {
-        "relations": [
-        {"rel": {
-            "read": {
-            "base_schema": {
-                "struct": {
-                "types": [
-                            {"i64": {}}
-                        ]
-                },
-                "names": [
-                        "x"
-                        ]
-            }
-            }
-        }}
-        ]
-    }
-    """
-    query = tobytes(substrait_query)
-    buf = pa._substrait._parse_json_plan(tobytes(query))
-    exec_message = "substrait::ReadRel with read_type other than LocalFiles"
-    with pytest.raises(pa.lib.ArrowNotImplementedError, match=exec_message):
         substrait.run_query(buf, table_provider)

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -208,6 +208,6 @@ def test_named_table():
     query = tobytes(substrait_query.replace(
         "TABLE_NAME_PLACEHOLDER", table_name))
     buf = pa._substrait._parse_json_plan(tobytes(query))
-    reader = pa.substrait.run_query_with_provider(buf, table_provider)
+    reader = pa.substrait.run_query(buf, table_provider)
     res_tb = reader.read_all()
     print(res_tb)

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -251,6 +251,7 @@ def test_named_table_invalid_table_name():
     query = tobytes(substrait_query.replace(
         "TABLE_NAME_PLACEHOLDER", table_name))
     buf = pa._substrait._parse_json_plan(tobytes(query))
+
     exec_message = "TableSourceNode requires table which is not null"
     with pytest.raises(ArrowInvalid, match=exec_message):
         substrait.run_query(buf, table_provider)

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -247,7 +247,7 @@ def test_named_table_invalid_table_name():
     """
 
     buf = pa._substrait._parse_json_plan(tobytes(substrait_query))
-    exec_message = "TableSourceNode requires table which is not null"
+    exec_message = "Invalid NamedTable Source"
     with pytest.raises(ArrowInvalid, match=exec_message):
         substrait.run_query(buf, table_provider)
 


### PR DESCRIPTION
This PR includes a basic version to use NamedTable feature in Substrait. The idea is to provide the flexibility to write Python tests with in-memory PyArrow tables. 