### PR TITLE
ARROW-17584: [Go] Use unsafe.Slice from Go 1.17

### DIFF
--- a/go/arrow/bitutil/bitutil.go
+++ b/go/arrow/bitutil/bitutil.go
@@ -150,15 +150,12 @@ const (
 )
 
 func bytesToUint64(b []byte) []uint64 {
+	if cap(b) < uint64SizeBytes {
+		return nil
+	}
+
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-
-	var res []uint64
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len / uint64SizeBytes
-	s.Cap = h.Cap / uint64SizeBytes
-
-	return res
+	return unsafe.Slice((*uint64)(unsafe.Pointer(h.Data)), cap(b)/uint64SizeBytes)[:len(b)/uint64SizeBytes]
 }
 
 var (

--- a/go/arrow/type_traits_decimal128.go
+++ b/go/arrow/type_traits_decimal128.go
@@ -49,26 +49,14 @@ func (decimal128Traits) PutValue(b []byte, v decimal128.Num) {
 func (decimal128Traits) CastFromBytes(b []byte) []decimal128.Num {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []decimal128.Num
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len / Decimal128SizeBytes
-	s.Cap = h.Cap / Decimal128SizeBytes
-
-	return res
+	return unsafe.Slice((*decimal128.Num)(unsafe.Pointer(h.Data)), cap(b)/Decimal128SizeBytes)[:len(b)/Decimal128SizeBytes]
 }
 
 // CastToBytes reinterprets the slice b to a slice of bytes.
 func (decimal128Traits) CastToBytes(b []decimal128.Num) []byte {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []byte
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len * Decimal128SizeBytes
-	s.Cap = h.Cap * Decimal128SizeBytes
-
-	return res
+	return unsafe.Slice((*byte)(unsafe.Pointer(h.Data)), cap(b)*Decimal128SizeBytes)[:len(b)*Decimal128SizeBytes]
 }
 
 // Copy copies src to dst.

--- a/go/arrow/type_traits_decimal256.go
+++ b/go/arrow/type_traits_decimal256.go
@@ -46,25 +46,13 @@ func (decimal256Traits) PutValue(b []byte, v decimal256.Num) {
 func (decimal256Traits) CastFromBytes(b []byte) []decimal256.Num {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []decimal256.Num
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len / Decimal256SizeBytes
-	s.Cap = h.Cap / Decimal256SizeBytes
-
-	return res
+	return unsafe.Slice((*decimal256.Num)(unsafe.Pointer(h.Data)), cap(b)/Decimal256SizeBytes)[:len(b)/Decimal256SizeBytes]
 }
 
 func (decimal256Traits) CastToBytes(b []decimal256.Num) []byte {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []byte
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	s.Data = h.Data
-	s.Len = h.Len * Decimal256SizeBytes
-	s.Cap = h.Cap * Decimal256SizeBytes
-
-	return res
+	return unsafe.Slice((*byte)(unsafe.Pointer(h.Data)), cap(b)*Decimal256SizeBytes)[:len(b)*Decimal256SizeBytes]
 }
 
 func (decimal256Traits) Copy(dst, src []decimal256.Num) { copy(dst, src) }

--- a/go/arrow/type_traits_float16.go
+++ b/go/arrow/type_traits_float16.go
@@ -20,8 +20,8 @@ import (
 	"reflect"
 	"unsafe"
 
-	"github.com/apache/arrow/go/v10/arrow/float16"
 	"github.com/apache/arrow/go/v10/arrow/endian"
+	"github.com/apache/arrow/go/v10/arrow/float16"
 )
 
 // Float16 traits
@@ -48,26 +48,14 @@ func (float16Traits) PutValue(b []byte, v float16.Num) {
 func (float16Traits) CastFromBytes(b []byte) []float16.Num {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []float16.Num
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len / Float16SizeBytes
-	s.Cap = h.Cap / Float16SizeBytes
-
-	return res
+	return unsafe.Slice((*float16.Num)(unsafe.Pointer(h.Data)), cap(b)/Float16SizeBytes)[:len(b)/Float16SizeBytes]
 }
 
 // CastToBytes reinterprets the slice b to a slice of bytes.
 func (float16Traits) CastToBytes(b []float16.Num) []byte {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []byte
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len * Float16SizeBytes
-	s.Cap = h.Cap * Float16SizeBytes
-
-	return res
+	return unsafe.Slice((*byte)(unsafe.Pointer(h.Data)), cap(b)*Float16SizeBytes)[:len(b)*Float16SizeBytes]
 }
 
 // Copy copies src to dst.

--- a/go/arrow/type_traits_interval.go
+++ b/go/arrow/type_traits_interval.go
@@ -59,26 +59,14 @@ func (monthTraits) PutValue(b []byte, v MonthInterval) {
 func (monthTraits) CastFromBytes(b []byte) []MonthInterval {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []MonthInterval
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len / MonthIntervalSizeBytes
-	s.Cap = h.Cap / MonthIntervalSizeBytes
-
-	return res
+	return unsafe.Slice((*MonthInterval)(unsafe.Pointer(h.Data)), cap(b)/MonthIntervalSizeBytes)[:len(b)/MonthIntervalSizeBytes]
 }
 
 // CastToBytes reinterprets the slice b to a slice of bytes.
 func (monthTraits) CastToBytes(b []MonthInterval) []byte {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []byte
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len * MonthIntervalSizeBytes
-	s.Cap = h.Cap * MonthIntervalSizeBytes
-
-	return res
+	return unsafe.Slice((*byte)(unsafe.Pointer(h.Data)), cap(b)*MonthIntervalSizeBytes)[:len(b)*MonthIntervalSizeBytes]
 }
 
 // Copy copies src to dst.
@@ -108,26 +96,14 @@ func (daytimeTraits) PutValue(b []byte, v DayTimeInterval) {
 func (daytimeTraits) CastFromBytes(b []byte) []DayTimeInterval {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []DayTimeInterval
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len / DayTimeIntervalSizeBytes
-	s.Cap = h.Cap / DayTimeIntervalSizeBytes
-
-	return res
+	return unsafe.Slice((*DayTimeInterval)(unsafe.Pointer(h.Data)), cap(b)/DayTimeIntervalSizeBytes)[:len(b)/DayTimeIntervalSizeBytes]
 }
 
 // CastToBytes reinterprets the slice b to a slice of bytes.
 func (daytimeTraits) CastToBytes(b []DayTimeInterval) []byte {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []byte
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len * DayTimeIntervalSizeBytes
-	s.Cap = h.Cap * DayTimeIntervalSizeBytes
-
-	return res
+	return unsafe.Slice((*byte)(unsafe.Pointer(h.Data)), cap(b)*DayTimeIntervalSizeBytes)[:len(b)*DayTimeIntervalSizeBytes]
 }
 
 // Copy copies src to dst.
@@ -158,26 +134,14 @@ func (monthDayNanoTraits) PutValue(b []byte, v MonthDayNanoInterval) {
 func (monthDayNanoTraits) CastFromBytes(b []byte) []MonthDayNanoInterval {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []MonthDayNanoInterval
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len / MonthDayNanoIntervalSizeBytes
-	s.Cap = h.Cap / MonthDayNanoIntervalSizeBytes
-
-	return res
+	return unsafe.Slice((*MonthDayNanoInterval)(unsafe.Pointer(h.Data)), cap(b)/MonthDayNanoIntervalSizeBytes)[:len(b)/MonthDayNanoIntervalSizeBytes]
 }
 
 // CastToBytes reinterprets the slice b to a slice of bytes.
 func (monthDayNanoTraits) CastToBytes(b []MonthDayNanoInterval) []byte {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []byte
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len * MonthDayNanoIntervalSizeBytes
-	s.Cap = h.Cap * MonthDayNanoIntervalSizeBytes
-
-	return res
+	return unsafe.Slice((*byte)(unsafe.Pointer(h.Data)), cap(b)*MonthDayNanoIntervalSizeBytes)[:len(b)*MonthDayNanoIntervalSizeBytes]
 }
 
 // Copy copies src to dst.

--- a/go/arrow/type_traits_numeric.gen.go
+++ b/go/arrow/type_traits_numeric.gen.go
@@ -68,26 +68,14 @@ func (int64Traits) PutValue(b []byte, v int64) {
 func (int64Traits) CastFromBytes(b []byte) []int64 {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []int64
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len / Int64SizeBytes
-	s.Cap = h.Cap / Int64SizeBytes
-
-	return res
+	return unsafe.Slice((*int64)(unsafe.Pointer(h.Data)), cap(b)/Int64SizeBytes)[:len(b)/Int64SizeBytes]
 }
 
 // CastToBytes reinterprets the slice b to a slice of bytes.
 func (int64Traits) CastToBytes(b []int64) []byte {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []byte
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len * Int64SizeBytes
-	s.Cap = h.Cap * Int64SizeBytes
-
-	return res
+	return unsafe.Slice((*byte)(unsafe.Pointer(h.Data)), cap(b)*Int64SizeBytes)[:len(b)*Int64SizeBytes]
 }
 
 // Copy copies src to dst.
@@ -116,26 +104,14 @@ func (uint64Traits) PutValue(b []byte, v uint64) {
 func (uint64Traits) CastFromBytes(b []byte) []uint64 {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []uint64
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len / Uint64SizeBytes
-	s.Cap = h.Cap / Uint64SizeBytes
-
-	return res
+	return unsafe.Slice((*uint64)(unsafe.Pointer(h.Data)), cap(b)/Uint64SizeBytes)[:len(b)/Uint64SizeBytes]
 }
 
 // CastToBytes reinterprets the slice b to a slice of bytes.
 func (uint64Traits) CastToBytes(b []uint64) []byte {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []byte
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len * Uint64SizeBytes
-	s.Cap = h.Cap * Uint64SizeBytes
-
-	return res
+	return unsafe.Slice((*byte)(unsafe.Pointer(h.Data)), cap(b)*Uint64SizeBytes)[:len(b)*Uint64SizeBytes]
 }
 
 // Copy copies src to dst.
@@ -164,26 +140,14 @@ func (float64Traits) PutValue(b []byte, v float64) {
 func (float64Traits) CastFromBytes(b []byte) []float64 {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []float64
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len / Float64SizeBytes
-	s.Cap = h.Cap / Float64SizeBytes
-
-	return res
+	return unsafe.Slice((*float64)(unsafe.Pointer(h.Data)), cap(b)/Float64SizeBytes)[:len(b)/Float64SizeBytes]
 }
 
 // CastToBytes reinterprets the slice b to a slice of bytes.
 func (float64Traits) CastToBytes(b []float64) []byte {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []byte
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len * Float64SizeBytes
-	s.Cap = h.Cap * Float64SizeBytes
-
-	return res
+	return unsafe.Slice((*byte)(unsafe.Pointer(h.Data)), cap(b)*Float64SizeBytes)[:len(b)*Float64SizeBytes]
 }
 
 // Copy copies src to dst.
@@ -212,26 +176,14 @@ func (int32Traits) PutValue(b []byte, v int32) {
 func (int32Traits) CastFromBytes(b []byte) []int32 {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []int32
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len / Int32SizeBytes
-	s.Cap = h.Cap / Int32SizeBytes
-
-	return res
+	return unsafe.Slice((*int32)(unsafe.Pointer(h.Data)), cap(b)/Int32SizeBytes)[:len(b)/Int32SizeBytes]
 }
 
 // CastToBytes reinterprets the slice b to a slice of bytes.
 func (int32Traits) CastToBytes(b []int32) []byte {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []byte
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len * Int32SizeBytes
-	s.Cap = h.Cap * Int32SizeBytes
-
-	return res
+	return unsafe.Slice((*byte)(unsafe.Pointer(h.Data)), cap(b)*Int32SizeBytes)[:len(b)*Int32SizeBytes]
 }
 
 // Copy copies src to dst.
@@ -260,26 +212,14 @@ func (uint32Traits) PutValue(b []byte, v uint32) {
 func (uint32Traits) CastFromBytes(b []byte) []uint32 {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []uint32
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len / Uint32SizeBytes
-	s.Cap = h.Cap / Uint32SizeBytes
-
-	return res
+	return unsafe.Slice((*uint32)(unsafe.Pointer(h.Data)), cap(b)/Uint32SizeBytes)[:len(b)/Uint32SizeBytes]
 }
 
 // CastToBytes reinterprets the slice b to a slice of bytes.
 func (uint32Traits) CastToBytes(b []uint32) []byte {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []byte
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len * Uint32SizeBytes
-	s.Cap = h.Cap * Uint32SizeBytes
-
-	return res
+	return unsafe.Slice((*byte)(unsafe.Pointer(h.Data)), cap(b)*Uint32SizeBytes)[:len(b)*Uint32SizeBytes]
 }
 
 // Copy copies src to dst.
@@ -308,26 +248,14 @@ func (float32Traits) PutValue(b []byte, v float32) {
 func (float32Traits) CastFromBytes(b []byte) []float32 {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []float32
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len / Float32SizeBytes
-	s.Cap = h.Cap / Float32SizeBytes
-
-	return res
+	return unsafe.Slice((*float32)(unsafe.Pointer(h.Data)), cap(b)/Float32SizeBytes)[:len(b)/Float32SizeBytes]
 }
 
 // CastToBytes reinterprets the slice b to a slice of bytes.
 func (float32Traits) CastToBytes(b []float32) []byte {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []byte
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len * Float32SizeBytes
-	s.Cap = h.Cap * Float32SizeBytes
-
-	return res
+	return unsafe.Slice((*byte)(unsafe.Pointer(h.Data)), cap(b)*Float32SizeBytes)[:len(b)*Float32SizeBytes]
 }
 
 // Copy copies src to dst.
@@ -356,26 +284,14 @@ func (int16Traits) PutValue(b []byte, v int16) {
 func (int16Traits) CastFromBytes(b []byte) []int16 {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []int16
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len / Int16SizeBytes
-	s.Cap = h.Cap / Int16SizeBytes
-
-	return res
+	return unsafe.Slice((*int16)(unsafe.Pointer(h.Data)), cap(b)/Int16SizeBytes)[:len(b)/Int16SizeBytes]
 }
 
 // CastToBytes reinterprets the slice b to a slice of bytes.
 func (int16Traits) CastToBytes(b []int16) []byte {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []byte
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len * Int16SizeBytes
-	s.Cap = h.Cap * Int16SizeBytes
-
-	return res
+	return unsafe.Slice((*byte)(unsafe.Pointer(h.Data)), cap(b)*Int16SizeBytes)[:len(b)*Int16SizeBytes]
 }
 
 // Copy copies src to dst.
@@ -404,26 +320,14 @@ func (uint16Traits) PutValue(b []byte, v uint16) {
 func (uint16Traits) CastFromBytes(b []byte) []uint16 {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []uint16
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len / Uint16SizeBytes
-	s.Cap = h.Cap / Uint16SizeBytes
-
-	return res
+	return unsafe.Slice((*uint16)(unsafe.Pointer(h.Data)), cap(b)/Uint16SizeBytes)[:len(b)/Uint16SizeBytes]
 }
 
 // CastToBytes reinterprets the slice b to a slice of bytes.
 func (uint16Traits) CastToBytes(b []uint16) []byte {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []byte
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len * Uint16SizeBytes
-	s.Cap = h.Cap * Uint16SizeBytes
-
-	return res
+	return unsafe.Slice((*byte)(unsafe.Pointer(h.Data)), cap(b)*Uint16SizeBytes)[:len(b)*Uint16SizeBytes]
 }
 
 // Copy copies src to dst.
@@ -452,26 +356,14 @@ func (int8Traits) PutValue(b []byte, v int8) {
 func (int8Traits) CastFromBytes(b []byte) []int8 {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []int8
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len / Int8SizeBytes
-	s.Cap = h.Cap / Int8SizeBytes
-
-	return res
+	return unsafe.Slice((*int8)(unsafe.Pointer(h.Data)), cap(b)/Int8SizeBytes)[:len(b)/Int8SizeBytes]
 }
 
 // CastToBytes reinterprets the slice b to a slice of bytes.
 func (int8Traits) CastToBytes(b []int8) []byte {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []byte
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len * Int8SizeBytes
-	s.Cap = h.Cap * Int8SizeBytes
-
-	return res
+	return unsafe.Slice((*byte)(unsafe.Pointer(h.Data)), cap(b)*Int8SizeBytes)[:len(b)*Int8SizeBytes]
 }
 
 // Copy copies src to dst.
@@ -500,26 +392,14 @@ func (uint8Traits) PutValue(b []byte, v uint8) {
 func (uint8Traits) CastFromBytes(b []byte) []uint8 {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []uint8
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len / Uint8SizeBytes
-	s.Cap = h.Cap / Uint8SizeBytes
-
-	return res
+	return unsafe.Slice((*uint8)(unsafe.Pointer(h.Data)), cap(b)/Uint8SizeBytes)[:len(b)/Uint8SizeBytes]
 }
 
 // CastToBytes reinterprets the slice b to a slice of bytes.
 func (uint8Traits) CastToBytes(b []uint8) []byte {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []byte
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len * Uint8SizeBytes
-	s.Cap = h.Cap * Uint8SizeBytes
-
-	return res
+	return unsafe.Slice((*byte)(unsafe.Pointer(h.Data)), cap(b)*Uint8SizeBytes)[:len(b)*Uint8SizeBytes]
 }
 
 // Copy copies src to dst.
@@ -548,26 +428,14 @@ func (timestampTraits) PutValue(b []byte, v Timestamp) {
 func (timestampTraits) CastFromBytes(b []byte) []Timestamp {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []Timestamp
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len / TimestampSizeBytes
-	s.Cap = h.Cap / TimestampSizeBytes
-
-	return res
+	return unsafe.Slice((*Timestamp)(unsafe.Pointer(h.Data)), cap(b)/TimestampSizeBytes)[:len(b)/TimestampSizeBytes]
 }
 
 // CastToBytes reinterprets the slice b to a slice of bytes.
 func (timestampTraits) CastToBytes(b []Timestamp) []byte {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []byte
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len * TimestampSizeBytes
-	s.Cap = h.Cap * TimestampSizeBytes
-
-	return res
+	return unsafe.Slice((*byte)(unsafe.Pointer(h.Data)), cap(b)*TimestampSizeBytes)[:len(b)*TimestampSizeBytes]
 }
 
 // Copy copies src to dst.
@@ -596,26 +464,14 @@ func (time32Traits) PutValue(b []byte, v Time32) {
 func (time32Traits) CastFromBytes(b []byte) []Time32 {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []Time32
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len / Time32SizeBytes
-	s.Cap = h.Cap / Time32SizeBytes
-
-	return res
+	return unsafe.Slice((*Time32)(unsafe.Pointer(h.Data)), cap(b)/Time32SizeBytes)[:len(b)/Time32SizeBytes]
 }
 
 // CastToBytes reinterprets the slice b to a slice of bytes.
 func (time32Traits) CastToBytes(b []Time32) []byte {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []byte
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len * Time32SizeBytes
-	s.Cap = h.Cap * Time32SizeBytes
-
-	return res
+	return unsafe.Slice((*byte)(unsafe.Pointer(h.Data)), cap(b)*Time32SizeBytes)[:len(b)*Time32SizeBytes]
 }
 
 // Copy copies src to dst.
@@ -644,26 +500,14 @@ func (time64Traits) PutValue(b []byte, v Time64) {
 func (time64Traits) CastFromBytes(b []byte) []Time64 {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []Time64
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len / Time64SizeBytes
-	s.Cap = h.Cap / Time64SizeBytes
-
-	return res
+	return unsafe.Slice((*Time64)(unsafe.Pointer(h.Data)), cap(b)/Time64SizeBytes)[:len(b)/Time64SizeBytes]
 }
 
 // CastToBytes reinterprets the slice b to a slice of bytes.
 func (time64Traits) CastToBytes(b []Time64) []byte {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []byte
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len * Time64SizeBytes
-	s.Cap = h.Cap * Time64SizeBytes
-
-	return res
+	return unsafe.Slice((*byte)(unsafe.Pointer(h.Data)), cap(b)*Time64SizeBytes)[:len(b)*Time64SizeBytes]
 }
 
 // Copy copies src to dst.
@@ -692,26 +536,14 @@ func (date32Traits) PutValue(b []byte, v Date32) {
 func (date32Traits) CastFromBytes(b []byte) []Date32 {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []Date32
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len / Date32SizeBytes
-	s.Cap = h.Cap / Date32SizeBytes
-
-	return res
+	return unsafe.Slice((*Date32)(unsafe.Pointer(h.Data)), cap(b)/Date32SizeBytes)[:len(b)/Date32SizeBytes]
 }
 
 // CastToBytes reinterprets the slice b to a slice of bytes.
 func (date32Traits) CastToBytes(b []Date32) []byte {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []byte
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len * Date32SizeBytes
-	s.Cap = h.Cap * Date32SizeBytes
-
-	return res
+	return unsafe.Slice((*byte)(unsafe.Pointer(h.Data)), cap(b)*Date32SizeBytes)[:len(b)*Date32SizeBytes]
 }
 
 // Copy copies src to dst.
@@ -740,26 +572,14 @@ func (date64Traits) PutValue(b []byte, v Date64) {
 func (date64Traits) CastFromBytes(b []byte) []Date64 {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []Date64
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len / Date64SizeBytes
-	s.Cap = h.Cap / Date64SizeBytes
-
-	return res
+	return unsafe.Slice((*Date64)(unsafe.Pointer(h.Data)), cap(b)/Date64SizeBytes)[:len(b)/Date64SizeBytes]
 }
 
 // CastToBytes reinterprets the slice b to a slice of bytes.
 func (date64Traits) CastToBytes(b []Date64) []byte {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []byte
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len * Date64SizeBytes
-	s.Cap = h.Cap * Date64SizeBytes
-
-	return res
+	return unsafe.Slice((*byte)(unsafe.Pointer(h.Data)), cap(b)*Date64SizeBytes)[:len(b)*Date64SizeBytes]
 }
 
 // Copy copies src to dst.
@@ -788,26 +608,14 @@ func (durationTraits) PutValue(b []byte, v Duration) {
 func (durationTraits) CastFromBytes(b []byte) []Duration {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []Duration
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len / DurationSizeBytes
-	s.Cap = h.Cap / DurationSizeBytes
-
-	return res
+	return unsafe.Slice((*Duration)(unsafe.Pointer(h.Data)), cap(b)/DurationSizeBytes)[:len(b)/DurationSizeBytes]
 }
 
 // CastToBytes reinterprets the slice b to a slice of bytes.
 func (durationTraits) CastToBytes(b []Duration) []byte {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []byte
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len * DurationSizeBytes
-	s.Cap = h.Cap * DurationSizeBytes
-
-	return res
+	return unsafe.Slice((*byte)(unsafe.Pointer(h.Data)), cap(b)*DurationSizeBytes)[:len(b)*DurationSizeBytes]
 }
 
 // Copy copies src to dst.

--- a/go/arrow/type_traits_numeric.gen.go.tmpl
+++ b/go/arrow/type_traits_numeric.gen.go.tmpl
@@ -68,26 +68,14 @@ func ({{.name}}Traits) PutValue(b []byte, v {{.Type}}) {
 func ({{.name}}Traits) CastFromBytes(b []byte) []{{.Type}} {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []{{.Type}}
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len/{{.Name}}SizeBytes
-	s.Cap = h.Cap/{{.Name}}SizeBytes
-
-	return res
+	return unsafe.Slice((*{{.Type}})(unsafe.Pointer(h.Data)), cap(b)/{{.Name}}SizeBytes)[:len(b)/{{.Name}}SizeBytes]
 }
 
 // CastToBytes reinterprets the slice b to a slice of bytes.
 func ({{.name}}Traits) CastToBytes(b []{{.Type}}) []byte {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []byte
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len*{{.Name}}SizeBytes
-	s.Cap = h.Cap*{{.Name}}SizeBytes
-
-	return res
+	return unsafe.Slice((*byte)(unsafe.Pointer(h.Data)), cap(b)*{{.Name}}SizeBytes)[:len(b)*{{.Name}}SizeBytes]
 }
 
 // Copy copies src to dst.

--- a/go/parquet/types.go
+++ b/go/parquet/types.go
@@ -97,25 +97,13 @@ func (int96Traits) BytesRequired(n int) int { return Int96SizeBytes * n }
 func (int96Traits) CastFromBytes(b []byte) []Int96 {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []Int96
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len / Int96SizeBytes
-	s.Cap = h.Cap / Int96SizeBytes
-
-	return res
+	return unsafe.Slice((*Int96)(unsafe.Pointer(h.Data)), cap(b)/Int96SizeBytes)[:len(b)/Int96SizeBytes]
 }
 
 func (int96Traits) CastToBytes(b []Int96) []byte {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []byte
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len * Int96SizeBytes
-	s.Cap = h.Cap * Int96SizeBytes
-
-	return res
+	return unsafe.Slice((*byte)(unsafe.Pointer(h.Data)), cap(b)*Int96SizeBytes)[:len(b)*Int96SizeBytes]
 }
 
 // ByteArray is a type to be utilized for representing the Parquet ByteArray physical type, represented as a byte slice
@@ -140,13 +128,7 @@ func (byteArrayTraits) BytesRequired(n int) int {
 func (byteArrayTraits) CastFromBytes(b []byte) []ByteArray {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []ByteArray
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len / ByteArraySizeBytes
-	s.Cap = h.Cap / ByteArraySizeBytes
-
-	return res
+	return unsafe.Slice((*ByteArray)(unsafe.Pointer(h.Data)), cap(b)/ByteArraySizeBytes)[:len(b)/ByteArraySizeBytes]
 }
 
 // FixedLenByteArray is a go type to represent a FixedLengthByteArray as a byte slice
@@ -171,13 +153,7 @@ func (fixedLenByteArrayTraits) BytesRequired(n int) int {
 func (fixedLenByteArrayTraits) CastFromBytes(b []byte) []FixedLenByteArray {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
-	var res []FixedLenByteArray
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = h.Len / FixedLenByteArraySizeBytes
-	s.Cap = h.Cap / FixedLenByteArraySizeBytes
-
-	return res
+	return unsafe.Slice((*FixedLenByteArray)(unsafe.Pointer(h.Data)), cap(b)/FixedLenByteArraySizeBytes)[:len(b)/FixedLenByteArraySizeBytes]
 }
 
 // Creating our own enums allows avoiding the transitive dependency on the


### PR DESCRIPTION
The current use of `reflect.SliceHeader` fields makes the code less portable than it could be.  For example, it is not possible to build with [TinyGo](https://tinygo.org/) where the slice header fields have different types.

This change proposes using `unsafe.Slice` from Go 1.17 as an alternative.

The tests are still failing for me, so I'm guessing that the changes aren't yet entirely correct.  I'll open as a draft PR in hopes of working out any issues.

cc @zeroshade 
