### PR TITLE
Added timeout on request.get().This fix is suggested by iCR OpenRefac…

### DIFF
--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -73,7 +73,8 @@ JIRA_API_BASE = "https://issues.apache.org/jira"
 
 
 def get_json(url, headers=None):
-    response = requests.get(url, headers=headers)
+    # OpenRefactory Warning: The 'requests.get' method does not use any 'timeout' threshold which may cause program to hang indefinitely.
+    response = requests.get(url, headers=headers, timeout=100)
     return response.json()
 
 


### PR DESCRIPTION
This issue was detected in the `master` branch of `arrow` project on the version with commit hash `cf2700`. This issue can be addressed as a api usage issue.

**Fixes for api usage issue:**
In file: `dev/merge_arrow_pr.py`, method `get_json` a request is made without a timeout parameter. If the recipient server is unavailable to service the request, [application making the request may stall indefinitely. ](https://docs.python-requests.org/en/master/user/advanced/#timeouts) our intelligent code repair system **iCR** suggested that a timeout value should be added.

This issue was detected by our **OpenRefactory's Intelligent Code Repair (iCR)**. We are running **iCR** on libraries in the `PyPI` repository to identify issues and fix them. You will get more info at: [pypi.openrefactory.com](https://pypi.openrefactory.com/)
