### PR TITLE
ARROW-16431: [C++][Python] Improve AppendRowGroups error when schemas differ

### DIFF
--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -690,9 +690,9 @@ class FileMetaData::FileMetaDataImpl {
   }
 
   void AppendRowGroups(const std::unique_ptr<FileMetaDataImpl>& other) {
-    auto diff_msg = std::make_shared<std::stringstream>();
-    if (!schema()->Equals(*other->schema(), diff_msg)) {
-      auto msg = "AppendRowGroups requires equal schemas.\n" + diff_msg->str();
+    std::ostringstream diff_output;
+    if (!schema()->Equals(*other->schema(), &diff_output)) {
+      auto msg = "AppendRowGroups requires equal schemas.\n" + diff_output.str();
       throw ParquetException(msg);
     }
 

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -692,7 +692,8 @@ class FileMetaData::FileMetaDataImpl {
   void AppendRowGroups(const std::unique_ptr<FileMetaDataImpl>& other) {
     auto diff_msg = std::make_shared<std::stringstream>();
     if (!schema()->Equals(*other->schema(), diff_msg)) {
-      throw ParquetException(diff_msg->str());
+      auto msg = "AppendRowGroups requires equal schemas.\n" + diff_msg->str();
+      throw ParquetException(msg);
     }
 
     // ARROW-13654: `other` may point to self, be careful not to enter an infinite loop

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -690,8 +690,9 @@ class FileMetaData::FileMetaDataImpl {
   }
 
   void AppendRowGroups(const std::unique_ptr<FileMetaDataImpl>& other) {
-    if (!schema()->Equals(*other->schema())) {
-      throw ParquetException("AppendRowGroups requires equal schemas.");
+    auto diff_msg = std::make_shared<std::stringstream>();
+    if (!schema()->Equals(*other->schema(), diff_msg)) {
+      throw ParquetException(diff_msg->str());
     }
 
     // ARROW-13654: `other` may point to self, be careful not to enter an infinite loop

--- a/cpp/src/parquet/schema.cc
+++ b/cpp/src/parquet/schema.cc
@@ -795,12 +795,27 @@ void SchemaDescriptor::Init(NodePtr schema) {
 }
 
 bool SchemaDescriptor::Equals(const SchemaDescriptor& other) const {
+  return this->Equals(other, nullptr);
+}
+
+bool SchemaDescriptor::Equals(
+    const SchemaDescriptor& other,
+    std::shared_ptr<std::stringstream> diff_msg = NULLPTR) const {
   if (this->num_columns() != other.num_columns()) {
+    if (diff_msg != nullptr) {
+      *diff_msg.get() << "This schema has " << this->num_columns()
+                      << " columns, other has " << other.num_columns();
+    }
     return false;
   }
 
   for (int i = 0; i < this->num_columns(); ++i) {
     if (!this->Column(i)->Equals(*other.Column(i))) {
+      if (diff_msg != nullptr) {
+        *diff_msg.get() << "These two columns differ:" << std::endl
+                        << this->Column(i)->ToString() << std::endl
+                        << other.Column(i)->ToString();
+      }
       return false;
     }
   }

--- a/cpp/src/parquet/schema.cc
+++ b/cpp/src/parquet/schema.cc
@@ -794,27 +794,22 @@ void SchemaDescriptor::Init(NodePtr schema) {
   }
 }
 
-bool SchemaDescriptor::Equals(const SchemaDescriptor& other) const {
-  return this->Equals(other, nullptr);
-}
-
-bool SchemaDescriptor::Equals(
-    const SchemaDescriptor& other,
-    std::shared_ptr<std::stringstream> diff_msg = NULLPTR) const {
+bool SchemaDescriptor::Equals(const SchemaDescriptor& other,
+                              std::ostream* diff_output) const {
   if (this->num_columns() != other.num_columns()) {
-    if (diff_msg != nullptr) {
-      *diff_msg.get() << "This schema has " << this->num_columns()
-                      << " columns, other has " << other.num_columns();
+    if (diff_output != nullptr) {
+      *diff_output << "This schema has " << this->num_columns() << " columns, other has "
+                   << other.num_columns();
     }
     return false;
   }
 
   for (int i = 0; i < this->num_columns(); ++i) {
     if (!this->Column(i)->Equals(*other.Column(i))) {
-      if (diff_msg != nullptr) {
-        *diff_msg.get() << "These two columns differ at index: " << i << std::endl
-                        << this->Column(i)->ToString() << std::endl
-                        << other.Column(i)->ToString();
+      if (diff_output != nullptr) {
+        *diff_output << "The two columns with index " << i << " differ." << std::endl
+                     << this->Column(i)->ToString() << std::endl
+                     << other.Column(i)->ToString() << std::endl;
       }
       return false;
     }

--- a/cpp/src/parquet/schema.cc
+++ b/cpp/src/parquet/schema.cc
@@ -812,7 +812,7 @@ bool SchemaDescriptor::Equals(
   for (int i = 0; i < this->num_columns(); ++i) {
     if (!this->Column(i)->Equals(*other.Column(i))) {
       if (diff_msg != nullptr) {
-        *diff_msg.get() << "These two columns differ:" << std::endl
+        *diff_msg.get() << "These two columns differ at index: " << i << std::endl
                         << this->Column(i)->ToString() << std::endl
                         << other.Column(i)->ToString();
       }

--- a/cpp/src/parquet/schema.h
+++ b/cpp/src/parquet/schema.h
@@ -432,9 +432,7 @@ class PARQUET_EXPORT SchemaDescriptor {
   // Get the index of a column by its node, or negative value if not found.
   int ColumnIndex(const schema::Node& node) const;
 
-  bool Equals(const SchemaDescriptor& other) const;
-  bool Equals(const SchemaDescriptor& other,
-              std::shared_ptr<std::stringstream> diff_msg) const;
+  bool Equals(const SchemaDescriptor& other, std::ostream* diff_output = NULLPTR) const;
 
   // The number of physical columns appearing in the file
   int num_columns() const { return static_cast<int>(leaves_.size()); }

--- a/cpp/src/parquet/schema.h
+++ b/cpp/src/parquet/schema.h
@@ -433,6 +433,8 @@ class PARQUET_EXPORT SchemaDescriptor {
   int ColumnIndex(const schema::Node& node) const;
 
   bool Equals(const SchemaDescriptor& other) const;
+  bool Equals(const SchemaDescriptor& other,
+              std::shared_ptr<std::stringstream> diff_msg) const;
 
   // The number of physical columns appearing in the file
   int num_columns() const { return static_cast<int>(leaves_.size()); }

--- a/python/pyarrow/tests/parquet/test_metadata.py
+++ b/python/pyarrow/tests/parquet/test_metadata.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import io
 import datetime
 import decimal
 from collections import OrderedDict
@@ -433,7 +434,7 @@ def test_write_metadata(tempdir):
     assert parquet_meta_mult.num_row_groups == 2
 
     # append metadata with different schema raises an error
-    with pytest.raises(RuntimeError, match="requires equal schemas"):
+    with pytest.raises(RuntimeError, match="These two columns differ:"):
         pq.write_metadata(
             pa.schema([("a", "int32"), ("b", "null")]),
             path, metadata_collector=[parquet_meta, parquet_meta]
@@ -580,3 +581,30 @@ def test_metadata_equals():
     match = "Argument 'other' has incorrect type"
     with pytest.raises(TypeError, match=match):
         original_metadata.equals(None)
+
+
+@pytest.mark.parametrize("t1,t2,expected", (
+    ({'col1': range(10)}, {'col1': range(10)}, None),
+    ({'col1': range(10)}, {'col2': range(10)}, "These two columns differ:"),
+    ({'col1': range(10), 'col2': range(10)}, {'col3': range(10)},
+     "This schema has 2 columns, other has 1")
+))
+def test_metadata_append_row_groups_diff(t1, t2, expected):
+    table1 = pa.table(t1)
+    table2 = pa.table(t2)
+
+    buf1 = io.BytesIO()
+    buf2 = io.BytesIO()
+    pq.write_table(table1, buf1)
+    pq.write_table(table2, buf2)
+    buf1.seek(0)
+    buf2.seek(0)
+
+    meta1 = pq.ParquetFile(buf1).metadata
+    meta2 = pq.ParquetFile(buf2).metadata
+
+    if expected:
+        with pytest.raises(RuntimeError, match=expected):
+            meta1.append_row_groups(meta2)
+    else:
+        meta1.append_row_groups(meta2)

--- a/python/pyarrow/tests/parquet/test_metadata.py
+++ b/python/pyarrow/tests/parquet/test_metadata.py
@@ -15,10 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import io
 import datetime
 import decimal
 from collections import OrderedDict
+import io
 
 import numpy as np
 import pytest
@@ -435,7 +435,7 @@ def test_write_metadata(tempdir):
 
     # append metadata with different schema raises an error
     msg = ("AppendRowGroups requires equal schemas.\n"
-           "These two columns differ at index: 0")
+           "The two columns with index 0 differ.")
     with pytest.raises(RuntimeError, match=msg):
         pq.write_metadata(
             pa.schema([("a", "int32"), ("b", "null")]),
@@ -585,14 +585,14 @@ def test_metadata_equals():
         original_metadata.equals(None)
 
 
-@pytest.mark.parametrize("t1,t2,expected", (
+@pytest.mark.parametrize("t1,t2,expected_error", (
     ({'col1': range(10)}, {'col1': range(10)}, None),
     ({'col1': range(10)}, {'col2': range(10)},
-     "These two columns differ at index: 0"),
+     "The two columns with index 0 differ."),
     ({'col1': range(10), 'col2': range(10)}, {'col3': range(10)},
      "This schema has 2 columns, other has 1")
 ))
-def test_metadata_append_row_groups_diff(t1, t2, expected):
+def test_metadata_append_row_groups_diff(t1, t2, expected_error):
     table1 = pa.table(t1)
     table2 = pa.table(t2)
 
@@ -606,10 +606,10 @@ def test_metadata_append_row_groups_diff(t1, t2, expected):
     meta1 = pq.ParquetFile(buf1).metadata
     meta2 = pq.ParquetFile(buf2).metadata
 
-    if expected:
+    if expected_error:
         # Error clearly defines it's happening at append row groups call
         prefix = "AppendRowGroups requires equal schemas.\n"
-        with pytest.raises(RuntimeError, match=prefix + expected):
+        with pytest.raises(RuntimeError, match=prefix + expected_error):
             meta1.append_row_groups(meta2)
     else:
         meta1.append_row_groups(meta2)


### PR DESCRIPTION
Fix [ARROW-16431](https://issues.apache.org/jira/browse/ARROW-16431)

Feel free to opine on specific error messages or the implementation as a whole. 👌 

Examples

```python
# meta1 and meta2 differ in column types
meta1.append_row_groups(meta2)
*** RuntimeError: AppendRowGroups requires equal schemas.
The two columns with index 0 differ.
column descriptor = {
  name: col1,
  path: col1,
  physical_type: INT64,
  converted_type: NONE,
  logical_type: None,
  max_definition_level: 1,
  max_repetition_level: 0,
}
column descriptor = {
  name: col2,
  path: col2,
  physical_type: INT64,
  converted_type: NONE,
  logical_type: None,
  max_definition_level: 1,
  max_repetition_level: 0,
}


# meta1 and meta2 differ in number of columns
meta1.append_row_groups(meta2)
*** RuntimeError: This schema has 2 columns, other has 1
```