### PR TITLE
ARROW-17583: [C++][Python] Changed datawidth of WrittenFile.size to int64 to match C++ code

### DIFF
--- a/python/pyarrow/_dataset.pxd
+++ b/python/pyarrow/_dataset.pxd
@@ -161,4 +161,4 @@ cdef class WrittenFile(_Weakrefable):
     # the written file.
     cdef public object metadata
     # The size of the file in bytes
-    cdef public int size
+    cdef public int64_t size


### PR DESCRIPTION
To fix an exception while writing large parquet files:
```
Traceback (most recent call last):
  File "pyarrow/_dataset_parquet.pyx", line 165, in pyarrow._dataset_parquet.ParquetFileFormat._finish_write
  File "pyarrow/dataset.pyx", line 2695, in pyarrow._dataset.WrittenFile.init_
OverflowError: value too large to convert to int
Exception ignored in: 'pyarrow._dataset._filesystemdataset_write_visitor'
```