### PR TITLE
ARROW-15691: [Dev] Update archery to work with either master or main as default branch

### DIFF
--- a/.github/workflows/archery.yml
+++ b/.github/workflows/archery.yml
@@ -65,7 +65,9 @@ jobs:
         run: pip install pytest responses -e dev/archery[all]
       - name: Archery Unittests
         working-directory: dev/archery
-        run: pytest -v archery
+        run: |
+          DEFAULT_BRANCH=${{ github.event.repository.default_branch }}
+          pytest -v archery
       - name: Archery Docker Validation
         run: archery docker check-config
       - name: Crossbow Check Config

--- a/.github/workflows/archery.yml
+++ b/.github/workflows/archery.yml
@@ -55,9 +55,7 @@ jobs:
           fetch-depth: 0
       - name: Git Fixup
         shell: bash
-        run: |
-          DEFAULT_BRANCH=${{ github.event.repository.default_branch }}
-          git branch $DEFAULT_BRANCH origin/$DEFAULT_BRANCH || true
+        run: git branch $DEFAULT_BRANCH origin/$DEFAULT_BRANCH || true
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -68,7 +66,7 @@ jobs:
         run: pip install pytest responses -e dev/archery[all]
       - name: Archery Unittests
         working-directory: dev/archery
-        run: pytest -rs --enable-integration -v archery
+        run: pytest -v archery
       - name: Archery Docker Validation
         run: archery docker check-config
       - name: Crossbow Check Config

--- a/.github/workflows/archery.yml
+++ b/.github/workflows/archery.yml
@@ -68,7 +68,7 @@ jobs:
         run: pip install pytest responses -e dev/archery[all]
       - name: Archery Unittests
         working-directory: dev/archery
-        run: pytest -v archery
+        run: pytest -rs -v archery
       - name: Archery Docker Validation
         run: archery docker check-config
       - name: Crossbow Check Config

--- a/.github/workflows/archery.yml
+++ b/.github/workflows/archery.yml
@@ -68,7 +68,7 @@ jobs:
         run: pip install pytest responses -e dev/archery[all]
       - name: Archery Unittests
         working-directory: dev/archery
-        run: pytest -rs -v archery
+        run: pytest -rs --enable-integration -v archery
       - name: Archery Docker Validation
         run: archery docker check-config
       - name: Crossbow Check Config

--- a/.github/workflows/archery.yml
+++ b/.github/workflows/archery.yml
@@ -31,6 +31,9 @@ on:
       - 'dev/tasks/**'
       - 'docker-compose.yml'
 
+env:
+  DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true
@@ -65,9 +68,7 @@ jobs:
         run: pip install pytest responses -e dev/archery[all]
       - name: Archery Unittests
         working-directory: dev/archery
-        run: |
-          DEFAULT_BRANCH=${{ github.event.repository.default_branch }}
-          pytest -v archery
+        run: pytest -v archery
       - name: Archery Docker Validation
         run: archery docker check-config
       - name: Crossbow Check Config

--- a/.github/workflows/archery.yml
+++ b/.github/workflows/archery.yml
@@ -32,7 +32,7 @@ on:
       - 'docker-compose.yml'
 
 env:
-  DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+  ARCHERY_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
@@ -55,7 +55,7 @@ jobs:
           fetch-depth: 0
       - name: Git Fixup
         shell: bash
-        run: git branch $DEFAULT_BRANCH origin/$DEFAULT_BRANCH || true
+        run: git branch $ARCHERY_DEFAULT_BRANCH origin/$ARCHERY_DEFAULT_BRANCH || true
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -50,6 +50,11 @@ permissions:
 
 env:
   DOCKER_VOLUME_PREFIX: ".docker/"
+<<<<<<< HEAD
+=======
+  ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
+  ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+>>>>>>> 9f0281356 (Only add DEFAULT_BRANCH environment variable to archery docker command in integration.yml)
 
 jobs:
 
@@ -85,6 +90,7 @@ jobs:
         env:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: archery docker run -e ARCHERY_INTEGRATION_WITH_RUST=1 conda-integration
       - name: Docker Push
         if: success() && github.event_name == 'push' && github.repository == 'apache/arrow'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -87,7 +87,7 @@ jobs:
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         run: >
           archery docker run -e ARCHERY_INTEGRATION_WITH_RUST=1 -e
-          DEFAULT_BRANCH=${{ github.event.repository.default_branch }}
+          ARCHERY_DEFAULT_BRANCH=${{ github.event.repository.default_branch }}
           conda-integration
       - name: Docker Push
         if: success() && github.event_name == 'push' && github.repository == 'apache/arrow'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -50,11 +50,6 @@ permissions:
 
 env:
   DOCKER_VOLUME_PREFIX: ".docker/"
-<<<<<<< HEAD
-=======
-  ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
-  ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
->>>>>>> 9f0281356 (Only add DEFAULT_BRANCH environment variable to archery docker command in integration.yml)
 
 jobs:
 
@@ -87,18 +82,13 @@ jobs:
       - name: Setup Archery
         run: pip install -e dev/archery[docker]
       - name: Execute Docker Build
-<<<<<<< HEAD
         env:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-        run: archery docker run -e ARCHERY_INTEGRATION_WITH_RUST=1 conda-integration
-=======
         run: >
           archery docker run -e ARCHERY_INTEGRATION_WITH_RUST=1 -e
           DEFAULT_BRANCH=${{ github.event.repository.default_branch }}
           conda-integration
->>>>>>> 2600c98a1 (In integration.yml, fix multi-line symbol.)
       - name: Docker Push
         if: success() && github.event_name == 'push' && github.repository == 'apache/arrow'
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -87,11 +87,18 @@ jobs:
       - name: Setup Archery
         run: pip install -e dev/archery[docker]
       - name: Execute Docker Build
+<<<<<<< HEAD
         env:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: archery docker run -e ARCHERY_INTEGRATION_WITH_RUST=1 conda-integration
+=======
+        run: >
+          archery docker run -e ARCHERY_INTEGRATION_WITH_RUST=1 -e
+          DEFAULT_BRANCH=${{ github.event.repository.default_branch }}
+          conda-integration
+>>>>>>> 2600c98a1 (In integration.yml, fix multi-line symbol.)
       - name: Docker Push
         if: success() && github.event_name == 'push' && github.repository == 'apache/arrow'
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -86,9 +86,10 @@ jobs:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         run: >
-          archery docker run -e ARCHERY_INTEGRATION_WITH_RUST=1 -e
-          ARCHERY_DEFAULT_BRANCH=${{ github.event.repository.default_branch }}
-          conda-integration
+          archery docker run
+             -e ARCHERY_DEFAULT_BRANCH=${{ github.event.repository.default_branch }}
+             -e ARCHERY_INTEGRATION_WITH_RUST=1
+             conda-integration
       - name: Docker Push
         if: success() && github.event_name == 'push' && github.repository == 'apache/arrow'
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -86,9 +86,9 @@ jobs:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         run: >
-          archery docker run
-            -e ARCHERY_DEFAULT_BRANCH=${{ github.event.repository.default_branch }}
-            -e ARCHERY_INTEGRATION_WITH_RUST=1
+          archery docker run \
+            -e ARCHERY_DEFAULT_BRANCH=${{ github.event.repository.default_branch }} \
+            -e ARCHERY_INTEGRATION_WITH_RUST=1 \
             conda-integration
       - name: Docker Push
         if: success() && github.event_name == 'push' && github.repository == 'apache/arrow'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -87,9 +87,9 @@ jobs:
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         run: >
           archery docker run
-             -e ARCHERY_DEFAULT_BRANCH=${{ github.event.repository.default_branch }}
-             -e ARCHERY_INTEGRATION_WITH_RUST=1
-             conda-integration
+            -e ARCHERY_DEFAULT_BRANCH=${{ github.event.repository.default_branch }}
+            -e ARCHERY_INTEGRATION_WITH_RUST=1
+            conda-integration
       - name: Docker Push
         if: success() && github.event_name == 'push' && github.repository == 'apache/arrow'
         env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -185,9 +185,10 @@ install:
 
 script:
   - |
+    GITHUB_DEFAULT_BRANCH_NAME=git rev-parse --abbrev-ref origin/HEAD | sed s@origin/@@
     archery docker run \
       ${DOCKER_RUN_ARGS} \
-      -e DEFAULT_BRANCH=${{ github.event.repository.default_branch }} \
+      -e DEFAULT_BRANCH=${GITHUB_DEFAULT_BRANCH_NAME} \
       --volume ${PWD}/build:/build \
       ${DOCKER_IMAGE_ID}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -184,7 +184,7 @@ install:
   - sudo -H pip3 install -e dev/archery[docker]
 
 script:
-  - export DEFAULT_BRANCH=$(git rev-parse --abbrev-ref origin/HEAD | sed s@origin/@@)
+  - export ARCHERY_DEFAULT_BRANCH=$(git rev-parse --abbrev-ref origin/HEAD | sed s@origin/@@)
   - |
     archery docker run \
       ${DOCKER_RUN_ARGS} \

--- a/.travis.yml
+++ b/.travis.yml
@@ -184,11 +184,10 @@ install:
   - sudo -H pip3 install -e dev/archery[docker]
 
 script:
+  - export DEFAULT_BRANCH=$(git rev-parse --abbrev-ref origin/HEAD | sed s@origin/@@)
   - |
-    GITHUB_DEFAULT_BRANCH_NAME=git rev-parse --abbrev-ref origin/HEAD | sed s@origin/@@
     archery docker run \
       ${DOCKER_RUN_ARGS} \
-      -e DEFAULT_BRANCH=${GITHUB_DEFAULT_BRANCH_NAME} \
       --volume ${PWD}/build:/build \
       ${DOCKER_IMAGE_ID}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -187,6 +187,7 @@ script:
   - |
     archery docker run \
       ${DOCKER_RUN_ARGS} \
+      -e DEFAULT_BRANCH=${{ github.event.repository.default_branch }} \
       --volume ${PWD}/build:/build \
       ${DOCKER_IMAGE_ID}
 

--- a/ci/scripts/install_dask.sh
+++ b/ci/scripts/install_dask.sh
@@ -26,10 +26,7 @@ fi
 
 dask=$1
 
-# Get Git default branch name
-DEFAULT_BRANCH="$(git rev-parse --abbrev-ref origin/HEAD | sed s@origin/@@)"
-
-if [ "${dask}" = "${DEFAULT_BRANCH}" ]; then
+if [ "${dask}" = "upstream_devel" ]; then
   pip install https://github.com/dask/dask/archive/main.tar.gz#egg=dask[dataframe]
 elif [ "${dask}" = "latest" ]; then
   pip install dask[dataframe]

--- a/ci/scripts/install_dask.sh
+++ b/ci/scripts/install_dask.sh
@@ -26,7 +26,10 @@ fi
 
 dask=$1
 
-if [ "${dask}" = "master" ]; then
+# Get Git default branch name
+DEFAULT_BRANCH="$(git rev-parse --abbrev-ref origin/HEAD | sed s@origin/@@)"
+
+if [ "${dask}" = "${DEFAULT_BRANCH}" ]; then
   pip install https://github.com/dask/dask/archive/main.tar.gz#egg=dask[dataframe]
 elif [ "${dask}" = "latest" ]; then
   pip install dask[dataframe]

--- a/ci/scripts/install_pandas.sh
+++ b/ci/scripts/install_pandas.sh
@@ -35,10 +35,7 @@ else
   pip install numpy==${numpy}
 fi
 
-# Get Git default branch name
-DEFAULT_BRANCH="$(git rev-parse --abbrev-ref origin/HEAD | sed s@origin/@@)"
-
-if [ "${pandas}" = "${DEFAULT_BRANCH}" ]; then
+if [ "${pandas}" = "upstream_devel" ]; then
   pip install git+https://github.com/pandas-dev/pandas.git --no-build-isolation
 elif [ "${pandas}" = "nightly" ]; then
   pip install --extra-index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple --pre pandas

--- a/ci/scripts/install_pandas.sh
+++ b/ci/scripts/install_pandas.sh
@@ -35,7 +35,10 @@ else
   pip install numpy==${numpy}
 fi
 
-if [ "${pandas}" = "master" ]; then
+# Get Git default branch name
+DEFAULT_BRANCH="$(git rev-parse --abbrev-ref origin/HEAD | sed s@origin/@@)"
+
+if [ "${pandas}" = "${DEFAULT_BRANCH}" ]; then
   pip install git+https://github.com/pandas-dev/pandas.git --no-build-isolation
 elif [ "${pandas}" = "nightly" ]; then
   pip install --extra-index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple --pre pandas

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -529,7 +529,7 @@ def benchmark_run(ctx, rev_or_path, src, preserve, output, cmake_extras,
               help="Hide counters field in diff report.")
 @click.argument("contender", metavar="[<contender>",
                 default=ArrowSources.WORKSPACE, required=False)
-@click.argument("baseline", metavar="[<baseline>]]", default="origin/master",
+@click.argument("baseline", metavar="[<baseline>]]", default="origin/HEAD",
                 required=False)
 @click.pass_context
 def benchmark_diff(ctx, src, preserve, output, language, cmake_extras,
@@ -542,7 +542,8 @@ def benchmark_diff(ctx, src, preserve, output, language, cmake_extras,
 
     The caller can optionally specify both the contender and the baseline. If
     unspecified, the contender will default to the current workspace (like git)
-    and the baseline will default to master.
+    and the baseline will default to the mainline development branch (i.e.
+    default git branch).
 
     Each target (contender or baseline) can either be a git revision
     (commit, tag, special values like HEAD) or a cmake build directory. This
@@ -559,12 +560,12 @@ def benchmark_diff(ctx, src, preserve, output, language, cmake_extras,
     Examples:
 
     \b
-    # Compare workspace (contender) with master (baseline)
+    # Compare workspace (contender) against the mainline development branch (baseline)
     \b
     archery benchmark diff
 
     \b
-    # Compare master (contender) with latest version (baseline)
+    # Compare the mainline development branch (contender) against the latest version (baseline)
     \b
     export LAST=$(git tag -l "apache-arrow-[0-9]*" | sort -rV | head -1)
     \b

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -560,12 +560,14 @@ def benchmark_diff(ctx, src, preserve, output, language, cmake_extras,
     Examples:
 
     \b
-    # Compare workspace (contender) against the mainline development branch (baseline)
+    # Compare workspace (contender) against the mainline development branch
+    # (baseline)
     \b
     archery benchmark diff
 
     \b
-    # Compare the mainline development branch (contender) against the latest version (baseline)
+    # Compare the mainline development branch (contender) against the latest
+    # version (baseline)
     \b
     export LAST=$(git tag -l "apache-arrow-[0-9]*" | sort -rV | head -1)
     \b

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -571,7 +571,7 @@ def benchmark_diff(ctx, src, preserve, output, language, cmake_extras,
     \b
     export LAST=$(git tag -l "apache-arrow-[0-9]*" | sort -rV | head -1)
     \b
-    archery benchmark diff master "$LAST"
+    archery benchmark diff <default-branch> "$LAST"
 
     \b
     # Compare g++7 (contender) with clang++-8 (baseline) builds

--- a/dev/archery/archery/crossbow/cli.py
+++ b/dev/archery/archery/crossbow/cli.py
@@ -155,6 +155,7 @@ def submit(obj, tasks, groups, params, job_prefix, config_path, arrow_version,
         queue.push()
         click.echo('Pushed job identifier is: `{}`'.format(job.branch))
 
+
 @crossbow.command()
 @click.option('--base-branch', default=None,
               help='Set base branch for the PR.')

--- a/dev/archery/archery/crossbow/cli.py
+++ b/dev/archery/archery/crossbow/cli.py
@@ -155,14 +155,8 @@ def submit(obj, tasks, groups, params, job_prefix, config_path, arrow_version,
         queue.push()
         click.echo('Pushed job identifier is: `{}`'.format(job.branch))
 
-
-# Get the default branch name from the repository
-arrow_source_dir = ArrowSources.find()
-repo = Repo(arrow_source_dir.path)
-
-
 @crossbow.command()
-@click.option('--base-branch', default=repo.default_branch_name,
+@click.option('--base-branch', default=None,
               help='Set base branch for the PR.')
 @click.option('--create-pr', is_flag=True, default=False,
               help='Create GitHub Pull Request')
@@ -194,6 +188,13 @@ def verify_release_candidate(obj, base_branch, create_pr,
                              verify_wheels):
     # The verify-release-candidate command will create a PR (or find one)
     # and add the verify-rc* comment to trigger the verify tasks
+
+    # Default value for base_branch is the repository's default branch name
+    if base_branch is None:
+        # Get the default branch name from the repository
+        arrow_source_dir = ArrowSources.find()
+        repo = Repo(arrow_source_dir.path)
+        base_branch = repo.default_branch_name
 
     # Redefine Arrow repo to use the correct arrow remote.
     arrow = Repo(path=obj['arrow'].path, remote_url=remote)

--- a/dev/archery/archery/crossbow/cli.py
+++ b/dev/archery/archery/crossbow/cli.py
@@ -190,15 +190,14 @@ def verify_release_candidate(obj, base_branch, create_pr,
     # The verify-release-candidate command will create a PR (or find one)
     # and add the verify-rc* comment to trigger the verify tasks
 
+    # Redefine Arrow repo to use the correct arrow remote.
+    arrow = Repo(path=obj['arrow'].path, remote_url=remote)
+
     # Default value for base_branch is the repository's default branch name
     if base_branch is None:
         # Get the default branch name from the repository
-        arrow_source_dir = ArrowSources.find()
-        repo = Repo(arrow_source_dir.path)
-        base_branch = repo.default_branch_name
-
-    # Redefine Arrow repo to use the correct arrow remote.
-    arrow = Repo(path=obj['arrow'].path, remote_url=remote)
+        base_branch = arrow.default_branch_name
+    
     response = arrow.github_pr(title=pr_title, head=head_branch,
                                base=base_branch, body=pr_body,
                                github_token=obj['queue'].github_token,

--- a/dev/archery/archery/crossbow/cli.py
+++ b/dev/archery/archery/crossbow/cli.py
@@ -96,7 +96,7 @@ def check_config(obj, config_path):
                    'locally. Examples: https://github.com/apache/arrow or '
                    'https://github.com/kszucs/arrow.')
 @click.option('--arrow-branch', '-b', default=None,
-              help='Give the branch name explicitly, e.g. master, ARROW-1949.')
+              help='Give the branch name explicitly, e.g. ARROW-1949.')
 @click.option('--arrow-sha', '-t', default=None,
               help='Set commit SHA or Tag name explicitly, e.g. f67a515, '
                    'apache-arrow-0.11.1.')
@@ -225,7 +225,7 @@ def verify_release_candidate(obj, base_branch, create_pr,
                    'locally. Examples: https://github.com/apache/arrow or '
                    'https://github.com/kszucs/arrow.')
 @click.option('--arrow-branch', '-b', default=None,
-              help='Give the branch name explicitly, e.g. master, ARROW-1949.')
+              help='Give the branch name explicitly, e.g. ARROW-1949.')
 @click.option('--arrow-sha', '-t', default=None,
               help='Set commit SHA or Tag name explicitly, e.g. f67a515, '
                    'apache-arrow-0.11.1.')

--- a/dev/archery/archery/crossbow/cli.py
+++ b/dev/archery/archery/crossbow/cli.py
@@ -16,8 +16,10 @@
 # under the License.
 
 from pathlib import Path
+from pickle import TRUE
 import time
 import sys
+import pygit2
 
 import click
 
@@ -155,9 +157,12 @@ def submit(obj, tasks, groups, params, job_prefix, config_path, arrow_version,
         queue.push()
         click.echo('Pushed job identifier is: `{}`'.format(job.branch))
 
+# Get the default branch name from the repository
+arrow_source_dir = ArrowSources.find()
+repo = Repo(arrow_source_dir.path)
 
 @crossbow.command()
-@click.option('--base-branch', default="master",
+@click.option('--base-branch', default=repo.default_branch_name,
               help='Set base branch for the PR.')
 @click.option('--create-pr', is_flag=True, default=False,
               help='Create GitHub Pull Request')

--- a/dev/archery/archery/crossbow/cli.py
+++ b/dev/archery/archery/crossbow/cli.py
@@ -197,7 +197,7 @@ def verify_release_candidate(obj, base_branch, create_pr,
     if base_branch is None:
         # Get the default branch name from the repository
         base_branch = arrow.default_branch_name
-    
+
     response = arrow.github_pr(title=pr_title, head=head_branch,
                                base=base_branch, body=pr_body,
                                github_token=obj['queue'].github_token,

--- a/dev/archery/archery/crossbow/cli.py
+++ b/dev/archery/archery/crossbow/cli.py
@@ -16,10 +16,8 @@
 # under the License.
 
 from pathlib import Path
-from pickle import TRUE
 import time
 import sys
-import pygit2
 
 import click
 
@@ -157,9 +155,11 @@ def submit(obj, tasks, groups, params, job_prefix, config_path, arrow_version,
         queue.push()
         click.echo('Pushed job identifier is: `{}`'.format(job.branch))
 
+
 # Get the default branch name from the repository
 arrow_source_dir = ArrowSources.find()
 repo = Repo(arrow_source_dir.path)
+
 
 @crossbow.command()
 @click.option('--base-branch', default=repo.default_branch_name,

--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -372,7 +372,8 @@ class Repo:
                 target_name_tokenized = target_name.split("/")
                 default_branch_name = target_name_tokenized[-1]
             except:
-                raise RuntimeError('DEFAULT_BRANCH environment variable is not set. Git repository does not contain \'refs/remotes/origin/HEAD\' reference.')
+                raise RuntimeError(
+                    'DEFAULT_BRANCH environment variable is not set. Git repository does not contain \'refs/remotes/origin/HEAD\' reference.')
 
         return default_branch_name
 

--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -28,6 +28,7 @@ import uuid
 from io import StringIO
 from pathlib import Path
 from datetime import date
+import warnings
 
 import jinja2
 from ruamel.yaml import YAML
@@ -372,10 +373,14 @@ class Repo:
                 target_name_tokenized = target_name.split("/")
                 default_branch_name = target_name_tokenized[-1]
             except KeyError:
-                raise RuntimeError(
-                    'Unable to determine default branch name: DEFAULT_BRANCH '
-                    'environment variable is not set. Git repository does not '
-                    'contain a \'refs/remotes/origin/HEAD\' reference.')
+                # TODO: ARROW-18011 to track changing the hard coded default
+                # value from "master" to "main".
+                default_branch_name = "master"
+                warnings.warn('Unable to determine default branch name: '
+                    'DEFAULT_BRANCH environment variable is not set. Git '
+                    'repository does not contain a \'refs/remotes/origin/HEAD\''
+                    ' reference. Setting the default branch name to ' +
+                    default_branch_name, RuntimeWarning)
 
         return default_branch_name
 

--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -363,11 +363,15 @@ class Repo:
 
     @property
     def default_branch_name(self):
+        print("Remotes:")
         for remote in self.repo.remotes:
             print(remote.name)
-        # for ref in self.repo.references.objects:
-        #     print(ref.target)
-        print(self.repo.resolve_refish('origin/HEAD'))
+        for ref in self.repo.references.objects:
+            print("ref.target" + ref.target)
+            print("ref.raw_target" + ref.raw_target)
+            print("ref.shorthand" + ref.shorthand)
+            print("ref.raw_shorthand" + ref.raw_shorthand)
+            print("ref.name" + ref.name)
         ref_obj = self.repo.references["refs/remotes/origin/HEAD"]
         target_name = ref_obj.target
         target_name_tokenized = target_name.split("/")

--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -363,9 +363,11 @@ class Repo:
 
     @property
     def default_branch_name(self):
-        print("Remotes:")
-        for remote in self.repo.remotes:
-            print(remote.name)
+        default_branch_name = os.getenv("DEFAULT_BRANCH")
+        print("**********default_branch_name" + default_branch_name)
+        # print("Remotes:")
+        # for remote in self.repo.remotes:
+        #     print(remote.name)
         # for ref in self.repo.references.objects:
         #     print(ref.target)
         #     print(ref.raw_target)
@@ -373,12 +375,13 @@ class Repo:
         #     print(ref.raw_shorthand)
         #     print(ref.name)
         #     print("\n")
-        for branch in self.repo.branches:
-            print(branch)
-        ref_obj = self.repo.references["refs/remotes/origin/HEAD"]
-        target_name = ref_obj.target
-        target_name_tokenized = target_name.split("/")
-        return target_name_tokenized[-1]
+        # for branch in self.repo.branches:
+        #     print(branch)
+        # ref_obj = self.repo.references["refs/remotes/origin/HEAD"]
+        # target_name = ref_obj.target
+        # target_name_tokenized = target_name.split("/")
+        # return target_name_tokenized[-1]
+        return default_branch_name
 
     def create_tree(self, files):
         builder = self.repo.TreeBuilder()

--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -366,13 +366,15 @@ class Repo:
         print("Remotes:")
         for remote in self.repo.remotes:
             print(remote.name)
-        for ref in self.repo.references.objects:
-            print(ref.target)
-            print(ref.raw_target)
-            print(ref.shorthand)
-            print(ref.raw_shorthand)
-            print(ref.name)
-            print("\n")
+        # for ref in self.repo.references.objects:
+        #     print(ref.target)
+        #     print(ref.raw_target)
+        #     print(ref.shorthand)
+        #     print(ref.raw_shorthand)
+        #     print(ref.name)
+        #     print("\n")
+        for branch in self.repo.branches:
+            print(branch)
         ref_obj = self.repo.references["refs/remotes/origin/HEAD"]
         target_name = ref_obj.target
         target_name_tokenized = target_name.split("/")

--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -373,9 +373,9 @@ class Repo:
                 default_branch_name = target_name_tokenized[-1]
             except KeyError:
                 raise RuntimeError(
-                    'DEFAULT_BRANCH environment variable is not set. Git '
-                    'repository does not contain a '
-                    '\'refs/remotes/origin/HEAD\' reference.')
+                    'Unable to determine default branch name: DEFAULT_BRANCH '
+                    'environment variable is not set. Git repository does not '
+                    'contain a \'refs/remotes/origin/HEAD\' reference.')
 
         return default_branch_name
 

--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -365,15 +365,17 @@ class Repo:
     def default_branch_name(self):
         default_branch_name = os.getenv("DEFAULT_BRANCH")
 
-        if default_branch_name == None:
+        if default_branch_name is None:
             try:
                 ref_obj = self.repo.references["refs/remotes/origin/HEAD"]
                 target_name = ref_obj.target
                 target_name_tokenized = target_name.split("/")
                 default_branch_name = target_name_tokenized[-1]
-            except:
+            except KeyError:
                 raise RuntimeError(
-                    'DEFAULT_BRANCH environment variable is not set. Git repository does not contain \'refs/remotes/origin/HEAD\' reference.')
+                    'DEFAULT_BRANCH environment variable is not set. Git '
+                    'repository does not contain a '
+                    '\'refs/remotes/origin/HEAD\' reference.')
 
         return default_branch_name
 

--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -364,7 +364,7 @@ class Repo:
     @property
     def default_branch_name(self):
         default_branch_name = os.getenv("DEFAULT_BRANCH")
-        print("**********default_branch_name" + default_branch_name)
+        print(default_branch_name)
         # print("Remotes:")
         # for remote in self.repo.remotes:
         #     print(remote.name)

--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -363,6 +363,10 @@ class Repo:
 
     @property
     def default_branch_name(self):
+        for remote in self.repo.remotes:
+            print(remote.name)
+        for ref in self.repo.references.objects:
+            print(ref.target)
         ref_obj = self.repo.references["refs/remotes/origin/HEAD"]
         target_name = ref_obj.target
         target_name_tokenized = target_name.split("/")

--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -364,23 +364,16 @@ class Repo:
     @property
     def default_branch_name(self):
         default_branch_name = os.getenv("DEFAULT_BRANCH")
-        print(default_branch_name)
-        # print("Remotes:")
-        # for remote in self.repo.remotes:
-        #     print(remote.name)
-        # for ref in self.repo.references.objects:
-        #     print(ref.target)
-        #     print(ref.raw_target)
-        #     print(ref.shorthand)
-        #     print(ref.raw_shorthand)
-        #     print(ref.name)
-        #     print("\n")
-        # for branch in self.repo.branches:
-        #     print(branch)
-        # ref_obj = self.repo.references["refs/remotes/origin/HEAD"]
-        # target_name = ref_obj.target
-        # target_name_tokenized = target_name.split("/")
-        # return target_name_tokenized[-1]
+
+        if default_branch_name == None:
+            try:
+                ref_obj = self.repo.references["refs/remotes/origin/HEAD"]
+                target_name = ref_obj.target
+                target_name_tokenized = target_name.split("/")
+                default_branch_name = target_name_tokenized[-1]
+            except:
+                raise RuntimeError('DEFAULT_BRANCH environment variable is not set. Git repository does not contain \'refs/remotes/origin/HEAD\' reference.')
+
         return default_branch_name
 
     def create_tree(self, files):

--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -367,11 +367,12 @@ class Repo:
         for remote in self.repo.remotes:
             print(remote.name)
         for ref in self.repo.references.objects:
-            print("ref.target" + ref.target)
-            print("ref.raw_target" + ref.raw_target)
-            print("ref.shorthand" + ref.shorthand)
-            print("ref.raw_shorthand" + ref.raw_shorthand)
-            print("ref.name" + ref.name)
+            print(ref.target)
+            print(ref.raw_target)
+            print(ref.shorthand)
+            print(ref.raw_shorthand)
+            print(ref.name)
+            print("\n")
         ref_obj = self.repo.references["refs/remotes/origin/HEAD"]
         target_name = ref_obj.target
         target_name_tokenized = target_name.split("/")

--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -364,7 +364,7 @@ class Repo:
 
     @property
     def default_branch_name(self):
-        default_branch_name = os.getenv("DEFAULT_BRANCH")
+        default_branch_name = os.getenv("ARCHERY_DEFAULT_BRANCH")
 
         if default_branch_name is None:
             try:
@@ -377,10 +377,11 @@ class Repo:
                 # value from "master" to "main".
                 default_branch_name = "master"
                 warnings.warn('Unable to determine default branch name: '
-                    'DEFAULT_BRANCH environment variable is not set. Git '
-                    'repository does not contain a \'refs/remotes/origin/HEAD\''
-                    ' reference. Setting the default branch name to ' +
-                    default_branch_name, RuntimeWarning)
+                              'ARCHERY_DEFAULT_BRANCH environment variable is '
+                              'not set. Git repository does not contain a '
+                              '\'refs/remotes/origin/HEAD\'reference. Setting '
+                              'the default branch name to' +
+                              default_branch_name, RuntimeWarning)
 
         return default_branch_name
 

--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -133,7 +133,7 @@ def _render_jinja_template(searchpath, template, params):
 
 # configurations for setting up branch skipping
 # - appveyor has a feature to skip builds without an appveyor.yml
-# - travis reads from the master branch and applies the rules
+# - travis reads from the default branch and applies the rules
 # - circle requires the configuration to be present on all branch, even ones
 #   that are configured to be skipped
 # - azure skips branches without azure-pipelines.yml by default

--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -365,8 +365,9 @@ class Repo:
     def default_branch_name(self):
         for remote in self.repo.remotes:
             print(remote.name)
-        for ref in self.repo.references.objects:
-            print(ref.target)
+        # for ref in self.repo.references.objects:
+        #     print(ref.target)
+        print(self.repo.resolve_refish('origin/HEAD'))
         ref_obj = self.repo.references["refs/remotes/origin/HEAD"]
         target_name = ref_obj.target
         target_name_tokenized = target_name.split("/")

--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -380,7 +380,7 @@ class Repo:
                               'ARCHERY_DEFAULT_BRANCH environment variable is '
                               'not set. Git repository does not contain a '
                               '\'refs/remotes/origin/HEAD\'reference. Setting '
-                              'the default branch name to' +
+                              'the default branch name to ' +
                               default_branch_name, RuntimeWarning)
 
         return default_branch_name

--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -572,8 +572,8 @@ class Repo:
 
     def github_pr(self, title, head=None, base=None, body=None,
                   github_token=None, create=False):
-        # Default value for base is the default_branch name()
-        base = self.default_branch_name() if base is None else base
+        # Default value for base is the default_branch_name
+        base = self.default_branch_name if base is None else base
         github_token = github_token or self.github_token
         repo = self.as_github_repo(github_token=github_token)
         if create:

--- a/dev/archery/archery/docker/cli.py
+++ b/dev/archery/archery/docker/cli.py
@@ -217,7 +217,8 @@ def docker_run(obj, image, command, *, env, user, force_pull, force_build,
     PYTHON=3.8 archery docker run conda-python
 
     # disable the cache only for the leaf image
-    PANDAS=main archery docker run --no-leaf-cache conda-python-pandas
+    PANDAS=upstream_devel archery docker run --no-leaf-cache
+    conda-python-pandas
 
     # entirely skip building the image
     archery docker run --no-pull --no-build conda-python

--- a/dev/archery/archery/docker/cli.py
+++ b/dev/archery/archery/docker/cli.py
@@ -217,7 +217,7 @@ def docker_run(obj, image, command, *, env, user, force_pull, force_build,
     PYTHON=3.8 archery docker run conda-python
 
     # disable the cache only for the leaf image
-    PANDAS=master archery docker run --no-leaf-cache conda-python-pandas
+    PANDAS=main archery docker run --no-leaf-cache conda-python-pandas
 
     # entirely skip building the image
     archery docker run --no-pull --no-build conda-python

--- a/dev/archery/archery/docker/cli.py
+++ b/dev/archery/archery/docker/cli.py
@@ -217,8 +217,8 @@ def docker_run(obj, image, command, *, env, user, force_pull, force_build,
     PYTHON=3.8 archery docker run conda-python
 
     # disable the cache only for the leaf image
-    PANDAS=upstream_devel archery docker run --no-leaf-cache
-    conda-python-pandas
+    PANDAS=upstream_devel archery docker run --no-leaf-cache \
+        conda-python-pandas
 
     # entirely skip building the image
     archery docker run --no-pull --no-build conda-python

--- a/dev/archery/archery/docker/tests/test_docker.py
+++ b/dev/archery/archery/docker/tests/test_docker.py
@@ -259,12 +259,12 @@ def test_arrow_example_validation_passes(arrow_compose_path):
 def test_compose_default_params_and_env(arrow_compose_path):
     compose = DockerCompose(arrow_compose_path, params=dict(
         UBUNTU='18.04',
-        DASK='main'
+        DASK='upstream_devel'
     ))
     assert compose.config.dotenv == arrow_compose_env
     assert compose.config.params == {
         'UBUNTU': '18.04',
-        'DASK': 'main',
+        'DASK': 'upstream_devel',
     }
 
 
@@ -492,7 +492,7 @@ def test_compose_push(arrow_compose_path):
 def test_compose_error(arrow_compose_path):
     compose = DockerCompose(arrow_compose_path, params=dict(
         PYTHON='3.8',
-        PANDAS='main'
+        PANDAS='upstream_devel'
     ))
 
     error = subprocess.CalledProcessError(99, [])
@@ -503,7 +503,7 @@ def test_compose_error(arrow_compose_path):
     exception_message = str(exc.value)
     assert "exited with a non-zero exit code 99" in exception_message
     assert "PANDAS: latest" in exception_message
-    assert "export PANDAS=main" in exception_message
+    assert "export PANDAS=upstream_devel" in exception_message
 
 
 def test_image_with_gpu(arrow_compose_path):

--- a/dev/archery/archery/docker/tests/test_docker.py
+++ b/dev/archery/archery/docker/tests/test_docker.py
@@ -259,12 +259,12 @@ def test_arrow_example_validation_passes(arrow_compose_path):
 def test_compose_default_params_and_env(arrow_compose_path):
     compose = DockerCompose(arrow_compose_path, params=dict(
         UBUNTU='18.04',
-        DASK='master'
+        DASK='main'
     ))
     assert compose.config.dotenv == arrow_compose_env
     assert compose.config.params == {
         'UBUNTU': '18.04',
-        'DASK': 'master',
+        'DASK': 'main',
     }
 
 
@@ -492,7 +492,7 @@ def test_compose_push(arrow_compose_path):
 def test_compose_error(arrow_compose_path):
     compose = DockerCompose(arrow_compose_path, params=dict(
         PYTHON='3.8',
-        PANDAS='master'
+        PANDAS='main'
     ))
 
     error = subprocess.CalledProcessError(99, [])
@@ -503,7 +503,7 @@ def test_compose_error(arrow_compose_path):
     exception_message = str(exc.value)
     assert "exited with a non-zero exit code 99" in exception_message
     assert "PANDAS: latest" in exception_message
-    assert "export PANDAS=master" in exception_message
+    assert "export PANDAS=main" in exception_message
 
 
 def test_image_with_gpu(arrow_compose_path):

--- a/dev/archery/archery/release/core.py
+++ b/dev/archery/archery/release/core.py
@@ -226,6 +226,7 @@ class Commit:
     def title(self):
         return self._title
 
+
 class DefaultBranchName(object):
     def __new__(self):
         if not hasattr(self, 'instance'):
@@ -233,12 +234,14 @@ class DefaultBranchName(object):
             arrow = ArrowSources.find()
             arrow = ArrowSources.find()
             repo = Repo(arrow.path)
-            remotes = repo.remotes
             origin = repo.remotes["origin"]
             origin_refs = origin.refs
-            origin_head = origin_refs["HEAD"] # git.RemoteReference object to origin/HEAD
-            origin_head_reference = origin_head.reference # git.RemoteReference object to origin/main
-            origin_head_name = origin_head_reference.name # Should return "origin/main" or "origin/master"
+            # git.RemoteReference object to origin/HEAD
+            origin_head = origin_refs["HEAD"]
+            # git.RemoteReference object to origin/main
+            origin_head_reference = origin_head.reference
+            # Should return "origin/main" or "origin/master"
+            origin_head_name = origin_head_reference.name
             origin_head_name_tokenized = origin_head_name.split("/")
             self.default_branch_name = origin_head_name_tokenized[-1]
         return self.instance

--- a/dev/archery/archery/release/core.py
+++ b/dev/archery/archery/release/core.py
@@ -364,7 +364,7 @@ class Release:
 
     @cached_property
     def default_branch(self):
-        default_branch_name = os.getenv("DEFAULT_BRANCH")
+        default_branch_name = os.getenv("ARCHERY_DEFAULT_BRANCH")
 
         if default_branch_name is None:
             try:
@@ -393,10 +393,11 @@ class Release:
                 # value from "master" to "main".
                 default_branch_name = "master"
                 warnings.warn('Unable to determine default branch name: '
-                    'DEFAULT_BRANCH environment variable is not set. Git '
-                    'repository does not contain a \'refs/remotes/origin/HEAD\''
-                    ' reference. Setting the default branch name to ' +
-                    default_branch_name, RuntimeWarning)
+                              'ARCHERY_DEFAULT_BRANCH environment variable is '
+                              'not set. Git repository does not contain a '
+                              '\'refs/remotes/origin/HEAD\'reference. Setting '
+                              'the default branch name to' +
+                              default_branch_name, RuntimeWarning)
 
         return default_branch_name
 

--- a/dev/archery/archery/release/core.py
+++ b/dev/archery/archery/release/core.py
@@ -361,6 +361,10 @@ class Release:
         commit_range = f"{lower}..{upper}"
         return list(map(Commit, self.repo.iter_commits(commit_range)))
 
+    @property
+    def base_branch(self):
+        return "master"
+
     def curate(self, minimal=False):
         # handle commits with parquet issue key specially and query them from
         # jira and add it to the issues
@@ -422,9 +426,9 @@ class Release:
         return JiraChangelog(release=self, categories=categories)
 
     def commits_to_pick(self, exclude_already_applied=True):
-        # collect commits applied on the main branch since the root of the
+        # collect commits applied on the default branch since the root of the
         # maintenance branch (the previous major release)
-        commit_range = f"{self.previous.tag}..master"
+        commit_range = f"{self.previous.tag}..{self.base_branch}"
 
         # keeping the original order of the commits helps to minimize the merge
         # conflicts during cherry-picks

--- a/dev/archery/archery/release/core.py
+++ b/dev/archery/archery/release/core.py
@@ -18,11 +18,11 @@
 from abc import abstractmethod
 from collections import defaultdict
 import functools
-import re
+import os
 import pathlib
+import re
 import shelve
 import warnings
-import os
 
 from git import Repo
 from jira import JIRA

--- a/dev/archery/archery/release/core.py
+++ b/dev/archery/archery/release/core.py
@@ -237,7 +237,7 @@ class DefaultBranchName(object):
 
             if default_branch_name == None:
                 try:
-                    # Set up repo object 
+                    # Set up repo object
                     arrow = ArrowSources.find()
                     repo = Repo(arrow.path)
                     origin = repo.remotes["origin"]
@@ -256,11 +256,12 @@ class DefaultBranchName(object):
                     # The last token is the default branch name
                     default_branch_name = origin_head_name_tokenized[-1]
                 except:
-                    raise RuntimeError('DEFAULT_BRANCH environment variable is not set. Git repository does not contain \'refs/remotes/origin/HEAD\' reference.')
+                    raise RuntimeError(
+                        'DEFAULT_BRANCH environment variable is not set. Git repository does not contain \'refs/remotes/origin/HEAD\' reference.')
 
             # Set default branch as class property
             self.default_branch_name = default_branch_name
-            
+
         return self.instance
 
     @property

--- a/dev/archery/archery/release/core.py
+++ b/dev/archery/archery/release/core.py
@@ -243,7 +243,7 @@ class DefaultBranchName(object):
                     repo = Repo(arrow.path)
                     origin = repo.remotes["origin"]
                     origin_refs = origin.refs
-                    
+
                     print("repo.remotes:")
                     for remote in repo.remotes:
                         print(remote)
@@ -419,7 +419,7 @@ class Release:
         return list(map(Commit, self.repo.iter_commits(commit_range)))
 
     @property
-    def base_branch(self):
+    def default_branch(self):
         default_branch_name = DefaultBranchName()
         return default_branch_name.value()
 
@@ -486,8 +486,8 @@ class Release:
     def commits_to_pick(self, exclude_already_applied=True):
         # collect commits applied on the default branch since the root of the
         # maintenance branch (the previous major release)
-        print(self.base_branch)
-        commit_range = f"{self.previous.tag}..{self.base_branch}"
+        print(self.default_branch)
+        commit_range = f"{self.previous.tag}..{self.default_branch}"
 
         # keeping the original order of the commits helps to minimize the merge
         # conflicts during cherry-picks

--- a/dev/archery/archery/release/core.py
+++ b/dev/archery/archery/release/core.py
@@ -226,6 +226,27 @@ class Commit:
     def title(self):
         return self._title
 
+class DefaultBranchName(object):
+    def __new__(self):
+        if not hasattr(self, 'instance'):
+            self.instance = super(DefaultBranchName, self).__new__(self)
+            arrow = ArrowSources.find()
+            arrow = ArrowSources.find()
+            repo = Repo(arrow.path)
+            remotes = repo.remotes
+            origin = repo.remotes["origin"]
+            origin_refs = origin.refs
+            origin_head = origin_refs["HEAD"] # git.RemoteReference object to origin/HEAD
+            origin_head_reference = origin_head.reference # git.RemoteReference object to origin/main
+            origin_head_name = origin_head_reference.name # Should return "origin/main" or "origin/master"
+            origin_head_name_tokenized = origin_head_name.split("/")
+            self.default_branch_name = origin_head_name_tokenized[-1]
+        return self.instance
+
+    @property
+    def value(self):
+        return self.default_branch_name
+
 
 class Release:
 
@@ -363,7 +384,8 @@ class Release:
 
     @property
     def base_branch(self):
-        return "master"
+        default_branch_name = DefaultBranchName()
+        return default_branch_name.value()
 
     def curate(self, minimal=False):
         # handle commits with parquet issue key specially and query them from
@@ -480,7 +502,8 @@ class MajorRelease(Release):
 
     @property
     def base_branch(self):
-        return "master"
+        default_branch_name = DefaultBranchName()
+        return default_branch_name.value()
 
     @cached_property
     def siblings(self):

--- a/dev/archery/archery/release/core.py
+++ b/dev/archery/archery/release/core.py
@@ -475,6 +475,7 @@ class Release:
     def commits_to_pick(self, exclude_already_applied=True):
         # collect commits applied on the default branch since the root of the
         # maintenance branch (the previous major release)
+        print(self.base_branch)
         commit_range = f"{self.previous.tag}..{self.base_branch}"
 
         # keeping the original order of the commits helps to minimize the merge

--- a/dev/archery/archery/release/core.py
+++ b/dev/archery/archery/release/core.py
@@ -259,9 +259,9 @@ class DefaultBranchName(object):
                     default_branch_name = origin_head_name_tokenized[-1]
                 except KeyError:
                     raise RuntimeError(
-                        'DEFAULT_BRANCH environment variable is not set. Git '
-                        'repository does not contain a'
-                        '\'refs/remotes/origin/HEAD\' reference.')
+                    'Unable to determine default branch name: DEFAULT_BRANCH '
+                    'environment variable is not set. Git repository does not '
+                    'contain a \'refs/remotes/origin/HEAD\' reference.')
 
             # Set default branch as class property
             self.default_branch_name = default_branch_name

--- a/dev/archery/archery/release/core.py
+++ b/dev/archery/archery/release/core.py
@@ -389,10 +389,14 @@ class Release:
                 # The last token is the default branch name
                 default_branch_name = origin_head_name_tokenized[-1]
             except KeyError:
-                raise RuntimeError(
-                    'Unable to determine default branch name: DEFAULT_BRANCH '
-                    'environment variable is not set. Git repository does not '
-                    'contain a \'refs/remotes/origin/HEAD\' reference.')
+                # TODO: ARROW-18011 to track changing the hard coded default
+                # value from "master" to "main".
+                default_branch_name = "master"
+                warnings.warn('Unable to determine default branch name: '
+                    'DEFAULT_BRANCH environment variable is not set. Git '
+                    'repository does not contain a \'refs/remotes/origin/HEAD\''
+                    ' reference. Setting the default branch name to ' +
+                    default_branch_name, RuntimeWarning)
 
         return default_branch_name
 

--- a/dev/archery/archery/release/core.py
+++ b/dev/archery/archery/release/core.py
@@ -236,12 +236,21 @@ class DefaultBranchName(object):
             default_branch_name = os.getenv("DEFAULT_BRANCH")
 
             if default_branch_name is None:
+                print("default_branch_name could not be determined by the environment variable")
                 try:
                     # Set up repo object
                     arrow = ArrowSources.find()
                     repo = Repo(arrow.path)
                     origin = repo.remotes["origin"]
                     origin_refs = origin.refs
+                    
+                    print("repo.remotes:")
+                    for remote in repo.remotes:
+                        print(remote)
+
+                    print("origin.refs:")
+                    for ref in origin.refs:
+                        print(ref)
 
                     # Get git.RemoteReference object to origin/HEAD
                     origin_head = origin_refs["HEAD"]
@@ -249,6 +258,8 @@ class DefaultBranchName(object):
                     # Get git.RemoteReference object to origin/main or
                     # origin/master
                     origin_head_reference = origin_head.reference
+
+                    print(origin_head_reference)
 
                     # Get string value of remote head reference, should return
                     # "origin/main" or "origin/master"

--- a/dev/archery/archery/release/core.py
+++ b/dev/archery/archery/release/core.py
@@ -235,7 +235,7 @@ class DefaultBranchName(object):
 
             default_branch_name = os.getenv("DEFAULT_BRANCH")
 
-            if default_branch_name == None:
+            if default_branch_name is None:
                 try:
                     # Set up repo object
                     arrow = ArrowSources.find()
@@ -243,21 +243,25 @@ class DefaultBranchName(object):
                     origin = repo.remotes["origin"]
                     origin_refs = origin.refs
 
-                    # git.RemoteReference object to origin/HEAD
+                    # Get git.RemoteReference object to origin/HEAD
                     origin_head = origin_refs["HEAD"]
 
-                    # git.RemoteReference object to origin/main or origin/master
+                    # Get git.RemoteReference object to origin/main or
+                    # origin/master
                     origin_head_reference = origin_head.reference
 
-                    # Should return "origin/main" or "origin/master"
+                    # Get string value of remote head reference, should return
+                    # "origin/main" or "origin/master"
                     origin_head_name = origin_head_reference.name
                     origin_head_name_tokenized = origin_head_name.split("/")
 
                     # The last token is the default branch name
                     default_branch_name = origin_head_name_tokenized[-1]
-                except:
+                except KeyError:
                     raise RuntimeError(
-                        'DEFAULT_BRANCH environment variable is not set. Git repository does not contain \'refs/remotes/origin/HEAD\' reference.')
+                        'DEFAULT_BRANCH environment variable is not set. Git '
+                        'repository does not contain a'
+                        '\'refs/remotes/origin/HEAD\' reference.')
 
             # Set default branch as class property
             self.default_branch_name = default_branch_name

--- a/dev/archery/archery/release/core.py
+++ b/dev/archery/archery/release/core.py
@@ -236,7 +236,6 @@ class DefaultBranchName(object):
             default_branch_name = os.getenv("DEFAULT_BRANCH")
 
             if default_branch_name is None:
-                print("default_branch_name could not be determined by the environment variable")
                 try:
                     # Set up repo object
                     arrow = ArrowSources.find()
@@ -244,22 +243,12 @@ class DefaultBranchName(object):
                     origin = repo.remotes["origin"]
                     origin_refs = origin.refs
 
-                    print("repo.remotes:")
-                    for remote in repo.remotes:
-                        print(remote)
-
-                    print("origin.refs:")
-                    for ref in origin.refs:
-                        print(ref)
-
                     # Get git.RemoteReference object to origin/HEAD
                     origin_head = origin_refs["HEAD"]
 
                     # Get git.RemoteReference object to origin/main or
                     # origin/master
                     origin_head_reference = origin_head.reference
-
-                    print(origin_head_reference)
 
                     # Get string value of remote head reference, should return
                     # "origin/main" or "origin/master"
@@ -420,8 +409,8 @@ class Release:
 
     @property
     def default_branch(self):
-        default_branch_name = DefaultBranchName()
-        return default_branch_name.value()
+        dbn = DefaultBranchName()
+        return dbn.value
 
     def curate(self, minimal=False):
         # handle commits with parquet issue key specially and query them from
@@ -486,7 +475,6 @@ class Release:
     def commits_to_pick(self, exclude_already_applied=True):
         # collect commits applied on the default branch since the root of the
         # maintenance branch (the previous major release)
-        print(self.default_branch)
         commit_range = f"{self.previous.tag}..{self.default_branch}"
 
         # keeping the original order of the commits helps to minimize the merge

--- a/dev/archery/archery/release/core.py
+++ b/dev/archery/archery/release/core.py
@@ -232,7 +232,6 @@ class DefaultBranchName(object):
         if not hasattr(self, 'instance'):
             self.instance = super(DefaultBranchName, self).__new__(self)
             arrow = ArrowSources.find()
-            arrow = ArrowSources.find()
             repo = Repo(arrow.path)
             origin = repo.remotes["origin"]
             origin_refs = origin.refs

--- a/dev/archery/archery/release/core.py
+++ b/dev/archery/archery/release/core.py
@@ -367,18 +367,18 @@ class Release:
         default_branch_name = os.getenv("ARCHERY_DEFAULT_BRANCH")
 
         if default_branch_name is None:
-            try:
-                # Set up repo object
-                arrow = ArrowSources.find()
-                repo = Repo(arrow.path)
-                origin = repo.remotes["origin"]
-                origin_refs = origin.refs
+            # Set up repo object
+            arrow = ArrowSources.find()
+            repo = Repo(arrow.path)
+            origin = repo.remotes["origin"]
+            origin_refs = origin.refs
 
+            try:
                 # Get git.RemoteReference object to origin/HEAD
+                # If the reference does not exist, a KeyError will be thrown
                 origin_head = origin_refs["HEAD"]
 
-                # Get git.RemoteReference object to origin/main or
-                # origin/master
+                # Get git.RemoteReference object to origin/default-branch-name
                 origin_head_reference = origin_head.reference
 
                 # Get string value of remote head reference, should return
@@ -389,6 +389,7 @@ class Release:
                 # The last token is the default branch name
                 default_branch_name = origin_head_name_tokenized[-1]
             except KeyError:
+                # Use a hard-coded default value to set default_branch_name
                 # TODO: ARROW-18011 to track changing the hard coded default
                 # value from "master" to "main".
                 default_branch_name = "master"

--- a/dev/archery/archery/release/core.py
+++ b/dev/archery/archery/release/core.py
@@ -396,7 +396,7 @@ class Release:
                               'ARCHERY_DEFAULT_BRANCH environment variable is '
                               'not set. Git repository does not contain a '
                               '\'refs/remotes/origin/HEAD\'reference. Setting '
-                              'the default branch name to' +
+                              'the default branch name to ' +
                               default_branch_name, RuntimeWarning)
 
         return default_branch_name

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1492,7 +1492,7 @@ tasks:
                                                                      ("3.7", "latest", "latest", False),
                                                                      ("3.8", "latest", "latest", False),
                                                                      ("3.8", "nightly", "nightly", False),
-                                                                     ("3.9", "master", "nightly", False)] %}
+                                                                     ("3.9", "upstream_devel", "nightly", False)] %}
   test-conda-python-{{ python_version }}-pandas-{{ pandas_version }}:
     ci: github
     template: docker-tests/github.linux.yml
@@ -1512,7 +1512,7 @@ tasks:
       image: conda-python-pandas
 {% endfor %}
 
-{% for dask_version in ["latest", "master"] %}
+{% for dask_version in ["latest", "upstream_devel"] %}
   test-conda-python-3.9-dask-{{ dask_version }}:
     ci: github
     template: docker-tests/github.linux.yml

--- a/docs/source/developers/continuous_integration/docker.rst
+++ b/docs/source/developers/continuous_integration/docker.rst
@@ -85,13 +85,13 @@ where the leaf image is ``conda-python-pandas``.
 
 .. code:: bash
 
-    PANDAS=master archery docker run --no-leaf-cache conda-python-pandas
+    PANDAS=upstream_devel archery docker run --no-leaf-cache conda-python-pandas
 
 Which translates to:
 
 .. code:: bash
 
-    export PANDAS=master
+    export PANDAS=upstream_devel
     docker-compose pull --ignore-pull-failures conda-cpp
     docker-compose pull --ignore-pull-failures conda-python
     docker-compose build conda-cpp
@@ -102,7 +102,7 @@ Which translates to:
 Note that it doesn't pull the conda-python-pandas image and disable the cache
 when building it.
 
-``PANDAS`` is a `build parameter <Docker Build Parameters>`_, see the
+``PANDAS`` is a :ref:`build parameter <docker-build-parameters>`, see the
 defaults in the .env file.
 
 **To entirely skip building the image:**
@@ -178,6 +178,7 @@ image when building Glib, Ruby, R and Python bindings.
 This reduces duplication and streamlines maintenance, but makes the
 docker-compose configuration more complicated.
 
+.. _docker-build-parameters:
 Docker Build Parameters
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/developers/continuous_integration/docker.rst
+++ b/docs/source/developers/continuous_integration/docker.rst
@@ -103,7 +103,7 @@ Note that it doesn't pull the conda-python-pandas image and disable the cache
 when building it.
 
 ``PANDAS`` is a :ref:`build parameter <docker-build-parameters>`, see the
-defaults in the .env file.
+defaults in the ``.env`` file.
 
 **To entirely skip building the image:**
 

--- a/docs/source/developers/continuous_integration/docker.rst
+++ b/docs/source/developers/continuous_integration/docker.rst
@@ -179,6 +179,7 @@ This reduces duplication and streamlines maintenance, but makes the
 docker-compose configuration more complicated.
 
 .. _docker-build-parameters:
+
 Docker Build Parameters
 ~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
# Overview
The goal of this pull request is to update `archery` to work with a repository default branch named `master` or `main`, as part of the effort to rename the Apache Arrow repository's default branch to `main`. The parent Jira ticket can be found [here](https://issues.apache.org/jira/browse/ARROW-15689). 

# Implementation
- Update the language of the top level `archery`, `crossbow`, and `docker` command line interface code to reference the mainline development branch (default git branch) generically. 
- Update comments that reference the `master` branch.
- Update the `crossbow` benchmarking examples to generically specify the `<default-branch>` rather than a hard-coded value.
- In `.github/workflows/integration.yml`, add an environment variable `DEFAULT_BRANCH` to the `archery` command in the "Execute Docker Build" step, so that `archery` can reliably access the default branch value.
- In `.github/workflows/archery.yml`, add an environment variable `DEFAULT_BRANCH` for all steps. This environment variable was already used by the `Git Fixup` step. It will also be used by the `Archery Unittests` step.
- Add a property, `default_branch_name`, to the `Repo` class in `dev/archery/archery/crossbow/core.py` for computing the default branch name. 
  - If specified, the `DEFAULT_BRANCH` environment variable, takes precedent in determining the default branch name (this is for overriding the git-based heuristic and qualifying in CI).
  - Otherwise, `pygit2` is used to get the default branch name via the Apache Arrow repository's `origin` remote `HEAD` reference. This is a heuristic, but in most cases, the `HEAD` reference of the remote points to the default branch. 
- Add a cached property, default_branch to the `Release` class in `dev/archery/archery/release/core.py` for computing the default branch name. Similar to the `default_branch_name` property for `Repo` in `archery/archery/crossbow/core.py`:
  - If specified, the `DEFAULT_BRANCH` environment variable, takes precedent in determining the default branch name (this is for qualifying in CI).
  - Otherwise, similar to the previous step,`GitPython` is used to get the default branch name via the Apache Arrow repository's `origin` remote `HEAD` reference.
  - Modify the `PANDAS` and `DASK` Docker Build Parameter value for indicating the upstream development branch to `upstream_devel`.
  - Updated Development Running Docker Builds documentation to reflect the above change and fixed a broken link.

#### Out of scope:
- There are remaining instances of `master` in the test fixtures files in `dev/archery/archery/test/fixtures`. It appears that the data only refers to external repositories, such as `ursa-labs/ursabot`, which currently uses `master`, so these instances were not modified.

# Testing
- Ran the `archery` and `crossbow` commands in local clones of both the `mathworks/arrow` and `apache/arrow` repositories.
- Confirmed that the GitHub CI jobs pass.
- We are unsure how to locally qualify the changes to the `release` component, but the `release` tests pass in CI.
- Ran a sample `archery docker` command after setting the `PANDAS` environment variable to confirm that the correct version of Pandas is used.

# Future Directions
1. Added Jira task to update the pull request merge script to work with both `master` and `main` ([ARROW-17777](https://issues.apache.org/jira/browse/ARROW-17777))
2. Added Jira task to update the default value for the default branch name, if it cannot be determined via an environment variable, `ARCHERY_DEFAULT_BRANCH`, or from the repository's remote head reference. ([ARROW-18011](https://issues.apache.org/jira/browse/ARROW-18011))

# Notes
Thank you @kevingurney for your help with this pull request!