### PR TITLE
ARROW-17519: [R] RTools35 job is failing

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -170,8 +170,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - { rtools: 35, arch: 'mingw32' }
-        - { rtools: 35, arch: 'mingw64' }
         - { rtools: 40, arch: 'mingw32' }
         - { rtools: 40, arch: 'mingw64' }
         - { rtools: 40, arch: 'ucrt64' }
@@ -199,18 +197,10 @@ jobs:
           restore-keys: |
             r-${{ matrix.config.rtools }}-ccache-mingw-${{ matrix.config.arch }}-${{ hashFiles('cpp/src/**/*.cc','cpp/src/**/*.h)') }}-
             r-${{ matrix.config.rtools }}-ccache-mingw-${{ matrix.config.arch }}-
-      # We use the makepkg-mingw setup that is included in rtools40 even when
-      # we use the rtools35 compilers, so we always install R 4.0/Rtools40
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: "4.1"
           rtools-version: 40
-          Ncpus: 2
-      - uses: r-lib/actions/setup-r@v2
-        if: ${{ matrix.config.rtools == 35 }}
-        with:
-          rtools-version: 35
-          r-version: "3.6"
           Ncpus: 2
       - name: Build Arrow C++
         shell: bash
@@ -226,11 +216,6 @@ jobs:
         with:
           name: libarrow-rtools${{ matrix.config.rtools }}-${{ matrix.config.arch }}.zip
           path: libarrow-rtools${{ matrix.config.rtools }}-${{ matrix.config.arch }}.zip
-      # We can remove this when we drop support for Rtools 3.5.
-      - name: Ensure using system tar in actions/cache
-        run: |
-          Write-Output "${Env:windir}\System32" | `
-            Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
   windows-r:
     needs: [windows-cpp]
@@ -242,7 +227,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - { rtools: 35, rversion: "3.6" }
         - { rtools: 40, rversion: "4.1" }
         - { rtools: 42, rversion: "4.2" }
         - { rtools: 42, rversion: "devel" }

--- a/ci/scripts/PKGBUILD
+++ b/ci/scripts/PKGBUILD
@@ -73,12 +73,6 @@ build() {
   # set the appropriate compiler definition.
   export CPPFLAGS="-DUTF8PROC_STATIC"
 
-  export ARROW_GCS=ON
-  export ARROW_S3=ON
-  export ARROW_WITH_RE2=ON
-  # Without this, some compute functionality segfaults in tests
-  export CMAKE_UNITY_BUILD=OFF
-
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     ${MINGW_PREFIX}/bin/cmake.exe \
     ${ARROW_CPP_DIR} \
@@ -90,7 +84,7 @@ build() {
     -DARROW_CSV=ON \
     -DARROW_DATASET=ON \
     -DARROW_FILESYSTEM=ON \
-    -DARROW_GCS="${ARROW_GCS}" \
+    -DARROW_GCS=ON \
     -DARROW_HDFS=OFF \
     -DARROW_JEMALLOC=OFF \
     -DARROW_JSON=ON \
@@ -98,13 +92,13 @@ build() {
     -DARROW_MIMALLOC=ON \
     -DARROW_PACKAGE_PREFIX="${MINGW_PREFIX}" \
     -DARROW_PARQUET=ON \
-    -DARROW_S3="${ARROW_S3}" \
+    -DARROW_S3=ON \
     -DARROW_SNAPPY_USE_SHARED=OFF \
     -DARROW_USE_GLOG=OFF \
     -DARROW_UTF8PROC_USE_SHARED=OFF \
     -DARROW_VERBOSE_THIRDPARTY_BUILD=ON \
     -DARROW_WITH_LZ4=ON \
-    -DARROW_WITH_RE2="${ARROW_WITH_RE2}" \
+    -DARROW_WITH_RE2=ON \
     -DARROW_WITH_SNAPPY=ON \
     -DARROW_WITH_ZLIB=ON \
     -DARROW_WITH_ZSTD=ON \
@@ -114,7 +108,7 @@ build() {
     -DARROW_CXXFLAGS="${CPPFLAGS}" \
     -DCMAKE_BUILD_TYPE="release" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-    -DCMAKE_UNITY_BUILD=${CMAKE_UNITY_BUILD} \
+    -DCMAKE_UNITY_BUILD=OFF \
     -DCMAKE_VERBOSE_MAKEFILE=ON
 
   make -j3

--- a/ci/scripts/PKGBUILD
+++ b/ci/scripts/PKGBUILD
@@ -73,12 +73,6 @@ build() {
   # set the appropriate compiler definition.
   export CPPFLAGS="-DUTF8PROC_STATIC"
 
-  export ARROW_GCS=ON
-  export ARROW_S3=ON
-  export ARROW_WITH_RE2=ON
-  # Without this, some compute functionality segfaults in tests
-  export CMAKE_UNITY_BUILD=OFF
-
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     ${MINGW_PREFIX}/bin/cmake.exe \
     ${ARROW_CPP_DIR} \
@@ -90,7 +84,7 @@ build() {
     -DARROW_CSV=ON \
     -DARROW_DATASET=ON \
     -DARROW_FILESYSTEM=ON \
-    -DARROW_GCS="${ARROW_GCS}" \
+    -DARROW_GCS=ON \
     -DARROW_HDFS=OFF \
     -DARROW_JEMALLOC=OFF \
     -DARROW_JSON=ON \
@@ -98,13 +92,13 @@ build() {
     -DARROW_MIMALLOC=ON \
     -DARROW_PACKAGE_PREFIX="${MINGW_PREFIX}" \
     -DARROW_PARQUET=ON \
-    -DARROW_S3="${ARROW_S3}" \
+    -DARROW_S3=ON \
     -DARROW_SNAPPY_USE_SHARED=OFF \
     -DARROW_USE_GLOG=OFF \
     -DARROW_UTF8PROC_USE_SHARED=OFF \
     -DARROW_VERBOSE_THIRDPARTY_BUILD=ON \
     -DARROW_WITH_LZ4=ON \
-    -DARROW_WITH_RE2="${ARROW_WITH_RE2}" \
+    -DARROW_WITH_RE2=ON \
     -DARROW_WITH_SNAPPY=ON \
     -DARROW_WITH_ZLIB=ON \
     -DARROW_WITH_ZSTD=ON \
@@ -114,7 +108,8 @@ build() {
     -DARROW_CXXFLAGS="${CPPFLAGS}" \
     -DCMAKE_BUILD_TYPE="release" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-    -DCMAKE_UNITY_BUILD=${CMAKE_UNITY_BUILD} \
+    # Without this, some compute functionality segfaults in tests
+    -DCMAKE_UNITY_BUILD=OFF \
     -DCMAKE_VERBOSE_MAKEFILE=ON
 
   make -j3

--- a/ci/scripts/PKGBUILD
+++ b/ci/scripts/PKGBUILD
@@ -73,26 +73,11 @@ build() {
   # set the appropriate compiler definition.
   export CPPFLAGS="-DUTF8PROC_STATIC"
 
-  # This is the difference between rtools-packages and rtools-backports
-  # Remove this when submitting to rtools-packages
-  if [ "$RTOOLS_VERSION" = "35" ]; then
-    export CC="/C/Rtools${MINGW_PREFIX/mingw/mingw_}/bin/gcc"
-    export CXX="/C/Rtools${MINGW_PREFIX/mingw/mingw_}/bin/g++"
-    export PATH="/C/Rtools${MINGW_PREFIX/mingw/mingw_}/bin:$PATH"
-    export CPPFLAGS="${CPPFLAGS} -I${MINGW_PREFIX}/include"
-    export LIBS="-L${MINGW_PREFIX}/libs"
-    export ARROW_GCS=OFF
-    export ARROW_S3=OFF
-    export ARROW_WITH_RE2=OFF
-    # Without this, some dataset functionality segfaults
-    export CMAKE_UNITY_BUILD=ON
-  else
-    export ARROW_GCS=ON
-    export ARROW_S3=ON
-    export ARROW_WITH_RE2=ON
-    # Without this, some compute functionality segfaults in tests
-    export CMAKE_UNITY_BUILD=OFF
-  fi
+  export ARROW_GCS=ON
+  export ARROW_S3=ON
+  export ARROW_WITH_RE2=ON
+  # Without this, some compute functionality segfaults in tests
+  export CMAKE_UNITY_BUILD=OFF
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     ${MINGW_PREFIX}/bin/cmake.exe \

--- a/ci/scripts/PKGBUILD
+++ b/ci/scripts/PKGBUILD
@@ -73,6 +73,12 @@ build() {
   # set the appropriate compiler definition.
   export CPPFLAGS="-DUTF8PROC_STATIC"
 
+  export ARROW_GCS=ON
+  export ARROW_S3=ON
+  export ARROW_WITH_RE2=ON
+  # Without this, some compute functionality segfaults in tests
+  export CMAKE_UNITY_BUILD=OFF
+
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     ${MINGW_PREFIX}/bin/cmake.exe \
     ${ARROW_CPP_DIR} \
@@ -84,7 +90,7 @@ build() {
     -DARROW_CSV=ON \
     -DARROW_DATASET=ON \
     -DARROW_FILESYSTEM=ON \
-    -DARROW_GCS=ON \
+    -DARROW_GCS="${ARROW_GCS}" \
     -DARROW_HDFS=OFF \
     -DARROW_JEMALLOC=OFF \
     -DARROW_JSON=ON \
@@ -92,13 +98,13 @@ build() {
     -DARROW_MIMALLOC=ON \
     -DARROW_PACKAGE_PREFIX="${MINGW_PREFIX}" \
     -DARROW_PARQUET=ON \
-    -DARROW_S3=ON \
+    -DARROW_S3="${ARROW_S3}" \
     -DARROW_SNAPPY_USE_SHARED=OFF \
     -DARROW_USE_GLOG=OFF \
     -DARROW_UTF8PROC_USE_SHARED=OFF \
     -DARROW_VERBOSE_THIRDPARTY_BUILD=ON \
     -DARROW_WITH_LZ4=ON \
-    -DARROW_WITH_RE2=ON \
+    -DARROW_WITH_RE2="${ARROW_WITH_RE2}" \
     -DARROW_WITH_SNAPPY=ON \
     -DARROW_WITH_ZLIB=ON \
     -DARROW_WITH_ZSTD=ON \
@@ -108,8 +114,7 @@ build() {
     -DARROW_CXXFLAGS="${CPPFLAGS}" \
     -DCMAKE_BUILD_TYPE="release" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-    # Without this, some compute functionality segfaults in tests
-    -DCMAKE_UNITY_BUILD=OFF \
+    -DCMAKE_UNITY_BUILD=${CMAKE_UNITY_BUILD} \
     -DCMAKE_VERBOSE_MAKEFILE=ON
 
   make -j3

--- a/r/R/arrow-info.R
+++ b/r/R/arrow-info.R
@@ -82,12 +82,6 @@ arrow_available <- function() {
 #' @rdname arrow_info
 #' @export
 arrow_with_dataset <- function() {
-  if (on_old_windows()) {
-    # 32-bit rtools 3.5 does not properly implement the std::thread expectations
-    # but we can't just disable ARROW_DATASET in that build,
-    # so report it as "off" here.
-    return(FALSE)
-  }
   tryCatch(.Call(`_dataset_available`), error = function(e) {
     return(FALSE)
   })

--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -117,14 +117,6 @@ configure_tzdb <- function() {
   })
 }
 
-on_old_windows <- function() {
-  is_32bit <- .Machine$sizeof.pointer < 8
-  is_old_r <- getRversion() < "4.0.0"
-  is_windows <- tolower(Sys.info()[["sysname"]]) == "windows"
-
-  is_32bit && is_old_r && is_windows
-}
-
 
 # True when the OS is linux + and the R version is development
 # helpful for skipping on Valgrind, and the sanitizer checks (clang + gcc) on cran

--- a/r/README.md
+++ b/r/README.md
@@ -67,6 +67,10 @@ more complete installation, set the environment variable
 `NOT_CRAN=true`. See `vignette("install", package = "arrow")` for
 details.
 
+Version 9.0.0 was the last version to support R 3.6 and lower on Windows. On
+R 3.6 and lower on all platforms, some features may be disabled. 
+See `arrow_info()` for a listing of available features in your build.
+
 ### Installing a development version
 
 Development versions of the package (binary and source) are built

--- a/r/README.md
+++ b/r/README.md
@@ -67,11 +67,6 @@ more complete installation, set the environment variable
 `NOT_CRAN=true`. See `vignette("install", package = "arrow")` for
 details.
 
-For Windows users of R 3.6 and earlier, note that support for AWS S3 is not
-available, and the 32-bit version does not support Arrow Datasets.
-These features are only supported by the `rtools40` toolchain on Windows
-and thus are only available in R >= 4.0.
-
 ### Installing a development version
 
 Development versions of the package (binary and source) are built

--- a/r/README.md
+++ b/r/README.md
@@ -65,11 +65,8 @@ packages that contain the Arrow C++ library. On Linux, source package
 installation will also build necessary C++ dependencies. For a faster,
 more complete installation, set the environment variable
 `NOT_CRAN=true`. See `vignette("install", package = "arrow")` for
-details.
-
-Version 9.0.0 was the last version to support R 3.6 and lower on Windows. On
-R 3.6 and lower on all platforms, some features may be disabled. 
-See `arrow_info()` for a listing of available features in your build.
+details. Note that version 9.0.0 was the last version to support
+R 3.6 and lower on Windows.
 
 ### Installing a development version
 

--- a/r/src/safe-call-into-r-impl.cpp
+++ b/r/src/safe-call-into-r-impl.cpp
@@ -32,13 +32,7 @@ void InitializeMainRThread() { GetMainRThread().Initialize(); }
 // [[arrow::export]]
 bool CanRunWithCapturedR() {
 #if defined(HAS_UNWIND_PROTECT)
-  static int on_old_windows = -1;
-  if (on_old_windows == -1) {
-    cpp11::function on_old_windows_fun = cpp11::package("arrow")["on_old_windows"];
-    on_old_windows = on_old_windows_fun();
-  }
-
-  return !on_old_windows && GetMainRThread().Executor() == nullptr;
+  return GetMainRThread().Executor() == nullptr;
 #else
   return false;
 #endif

--- a/r/src/safe-call-into-r.h
+++ b/r/src/safe-call-into-r.h
@@ -163,7 +163,7 @@ template <typename T>
 arrow::Result<T> RunWithCapturedR(std::function<arrow::Future<T>()> make_arrow_call) {
   if (!CanRunWithCapturedR()) {
     return arrow::Status::NotImplemented(
-        "RunWithCapturedR() without UnwindProtect or on 32-bit Windows + R <= 3.6");
+        "RunWithCapturedR() without UnwindProtect");
   }
 
   if (GetMainRThread().Executor() != nullptr) {

--- a/r/src/safe-call-into-r.h
+++ b/r/src/safe-call-into-r.h
@@ -162,8 +162,7 @@ static inline arrow::Status SafeCallIntoRVoid(std::function<void(void)> fun,
 template <typename T>
 arrow::Result<T> RunWithCapturedR(std::function<arrow::Future<T>()> make_arrow_call) {
   if (!CanRunWithCapturedR()) {
-    return arrow::Status::NotImplemented(
-        "RunWithCapturedR() without UnwindProtect");
+    return arrow::Status::NotImplemented("RunWithCapturedR() without UnwindProtect");
   }
 
   if (GetMainRThread().Executor() != nullptr) {

--- a/r/src/safe-call-into-r.h
+++ b/r/src/safe-call-into-r.h
@@ -28,8 +28,7 @@
 #include <thread>
 
 // Unwind protection was added in R 3.5 and some calls here use it
-// and crash R in older versions (ARROW-16201). Crashes also occur
-// on 32-bit R builds on R 3.6 and lower. Implementation provided
+// and crash R in older versions (ARROW-16201). Implementation provided
 // in safe-call-into-r-impl.cpp so that we can skip some tests
 // when this feature is not provided. This also checks that there
 // is not already an event loop registered (via MainRThread::Executor()),

--- a/r/tests/testthat/test-dataset-csv.R
+++ b/r/tests/testthat/test-dataset-csv.R
@@ -42,10 +42,8 @@ test_that("CSV dataset", {
   expect_r6_class(ds$format, "CsvFileFormat")
   expect_r6_class(ds$filesystem, "LocalFileSystem")
   expect_identical(names(ds), c(names(df1), "part"))
-  if (getRversion() >= "4.0.0") {
-    # CountRows segfaults on RTools35/R 3.6, so don't test it there
-    expect_identical(dim(ds), c(20L, 7L))
-  }
+  expect_identical(dim(ds), c(20L, 7L))
+
   expect_equal(
     ds %>%
       select(string = chr, integer = int, part) %>%

--- a/r/tests/testthat/test-dplyr-arrange.R
+++ b/r/tests/testthat/test-dplyr-arrange.R
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if(on_old_windows())
-
 library(dplyr, warn.conflicts = FALSE)
 
 # randomize order of rows in test data

--- a/r/tests/testthat/test-dplyr-collapse.R
+++ b/r/tests/testthat/test-dplyr-collapse.R
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if(on_old_windows())
-
 withr::local_options(list(arrow.summarise.sort = TRUE))
 
 library(dplyr, warn.conflicts = FALSE)

--- a/r/tests/testthat/test-dplyr-count.R
+++ b/r/tests/testthat/test-dplyr-count.R
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if(on_old_windows())
-
 library(dplyr, warn.conflicts = FALSE)
 
 tbl <- example_data

--- a/r/tests/testthat/test-dplyr-distinct.R
+++ b/r/tests/testthat/test-dplyr-distinct.R
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if(on_old_windows())
-
 library(dplyr, warn.conflicts = FALSE)
 
 tbl <- example_data

--- a/r/tests/testthat/test-dplyr-filter.R
+++ b/r/tests/testthat/test-dplyr-filter.R
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if(on_old_windows())
-
 library(dplyr, warn.conflicts = FALSE)
 library(stringr)
 

--- a/r/tests/testthat/test-dplyr-funcs-conditional.R
+++ b/r/tests/testthat/test-dplyr-funcs-conditional.R
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if(on_old_windows())
-
 library(dplyr, warn.conflicts = FALSE)
 suppressPackageStartupMessages(library(bit64))
 

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if(on_old_windows())
 # In 3.4 the lack of tzone attribute causes spurious failures
 skip_on_r_older_than("3.5")
 

--- a/r/tests/testthat/test-dplyr-funcs-math.R
+++ b/r/tests/testthat/test-dplyr-funcs-math.R
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if(on_old_windows())
-
 library(dplyr, warn.conflicts = FALSE)
 
 

--- a/r/tests/testthat/test-dplyr-funcs-string.R
+++ b/r/tests/testthat/test-dplyr-funcs-string.R
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if(on_old_windows())
 skip_if_not_available("utf8proc")
 
 library(dplyr, warn.conflicts = FALSE)

--- a/r/tests/testthat/test-dplyr-funcs-type.R
+++ b/r/tests/testthat/test-dplyr-funcs-type.R
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if(on_old_windows())
-
 library(dplyr, warn.conflicts = FALSE)
 suppressPackageStartupMessages(library(bit64))
 suppressPackageStartupMessages(library(lubridate))

--- a/r/tests/testthat/test-dplyr-group-by.R
+++ b/r/tests/testthat/test-dplyr-group-by.R
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if(on_old_windows())
-
 library(dplyr, warn.conflicts = FALSE)
 library(stringr)
 

--- a/r/tests/testthat/test-dplyr-join.R
+++ b/r/tests/testthat/test-dplyr-join.R
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if(on_old_windows())
-
 library(dplyr, warn.conflicts = FALSE)
 
 left <- example_data

--- a/r/tests/testthat/test-dplyr-mutate.R
+++ b/r/tests/testthat/test-dplyr-mutate.R
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if(on_old_windows())
-
 library(dplyr, warn.conflicts = FALSE)
 library(stringr)
 

--- a/r/tests/testthat/test-dplyr-query.R
+++ b/r/tests/testthat/test-dplyr-query.R
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if(on_old_windows())
-
 library(dplyr, warn.conflicts = FALSE)
 library(stringr)
 

--- a/r/tests/testthat/test-dplyr-select.R
+++ b/r/tests/testthat/test-dplyr-select.R
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if(on_old_windows())
-
 library(dplyr, warn.conflicts = FALSE)
 library(stringr)
 

--- a/r/tests/testthat/test-dplyr-summarize.R
+++ b/r/tests/testthat/test-dplyr-summarize.R
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if(on_old_windows())
-
 withr::local_options(list(
   arrow.summarise.sort = TRUE,
   rlib_warning_verbosity = "verbose",

--- a/r/tests/testthat/test-dplyr-union.R
+++ b/r/tests/testthat/test-dplyr-union.R
@@ -13,9 +13,6 @@
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
-# under the License.
-
-skip_if(on_old_windows())
 
 library(dplyr, warn.conflicts = FALSE)
 

--- a/r/vignettes/dataset.Rmd
+++ b/r/vignettes/dataset.Rmd
@@ -24,7 +24,7 @@ The total file size is around 37 gigabytes, even in the efficient Parquet file
 format. That's bigger than memory on most people's computers, so you can't just
 read it all in and stack it into a single data frame.
 
-In Windows (for R > 3.6) and macOS binary packages, S3 support is included.
+In Windows and macOS binary packages, S3 support is included.
 On Linux, when installing from source, S3 support is not enabled by default,
 and it has additional system requirements.
 See `vignette("install", package = "arrow")` for details.


### PR DESCRIPTION
This PR removes the RTools35 CI job as it's currently failing and we're about to drop support following the vote to move to C++17.