### PR TITLE
ARROW-17598: [C++] Skip memory_benchmark if SIMD level is NEON

### DIFF
--- a/cpp/src/arrow/io/CMakeLists.txt
+++ b/cpp/src/arrow/io/CMakeLists.txt
@@ -36,8 +36,8 @@ add_arrow_test(memory_test PREFIX "arrow-io")
 
 add_arrow_benchmark(file_benchmark PREFIX "arrow-io")
 
-if(NOT (${ARROW_SIMD_LEVEL} STREQUAL "NONE") AND
-   NOT (${ARROW_SIMD_LEVEL} STREQUAL "NEON"))
+if(NOT (${ARROW_SIMD_LEVEL} STREQUAL "NONE") AND NOT (${ARROW_SIMD_LEVEL} STREQUAL "NEON"
+                                                     ))
   # This benchmark either requires SSE4.2 or ARMV8 SIMD to be enabled
   add_arrow_benchmark(memory_benchmark PREFIX "arrow-io")
 endif()

--- a/cpp/src/arrow/io/CMakeLists.txt
+++ b/cpp/src/arrow/io/CMakeLists.txt
@@ -36,7 +36,8 @@ add_arrow_test(memory_test PREFIX "arrow-io")
 
 add_arrow_benchmark(file_benchmark PREFIX "arrow-io")
 
-if(NOT (${ARROW_SIMD_LEVEL} STREQUAL "NONE"))
+if(NOT (${ARROW_SIMD_LEVEL} STREQUAL "NONE") AND
+   NOT (${ARROW_SIMD_LEVEL} STREQUAL "NEON"))
   # This benchmark either requires SSE4.2 or ARMV8 SIMD to be enabled
   add_arrow_benchmark(memory_benchmark PREFIX "arrow-io")
 endif()


### PR DESCRIPTION
Added an extra check if SIMD_LEVEL is "NEON" because
arrow/io/memory_benchmark does not provide definitions for those SIMD
instructions.