### PR TITLE
ARROW-17615: [C++][Packaging] Remove check_required_components from configure_package_config_file

### DIFF
--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -155,7 +155,8 @@ function(arrow_install_cmake_package PACKAGE_NAME EXPORT_NAME)
   set(CONFIG_CMAKE "${PACKAGE_NAME}Config.cmake")
   set(BUILT_CONFIG_CMAKE "${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_CMAKE}")
   configure_package_config_file("${CONFIG_CMAKE}.in" "${BUILT_CONFIG_CMAKE}"
-                                INSTALL_DESTINATION "${ARROW_CMAKE_DIR}/${PACKAGE_NAME}")
+                                INSTALL_DESTINATION "${ARROW_CMAKE_DIR}/${PACKAGE_NAME}"
+                                NO_CHECK_REQUIRED_COMPONENTS_MACRO)
   set(CONFIG_VERSION_CMAKE "${PACKAGE_NAME}ConfigVersion.cmake")
   set(BUILT_CONFIG_VERSION_CMAKE "${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_VERSION_CMAKE}")
   write_basic_package_version_file("${BUILT_CONFIG_VERSION_CMAKE}"

--- a/docs/source/cpp/build_system.rst
+++ b/docs/source/cpp/build_system.rst
@@ -51,7 +51,7 @@ file into an executable linked with the Arrow C++ shared library:
    find_package(Arrow REQUIRED)
 
    add_executable(my_example my_example.cc)
-   target_link_libraries(my_example PRIVATE arrow_shared)
+   target_link_libraries(my_example PRIVATE Arrow::arrow_shared)
 
 Available variables and targets
 -------------------------------
@@ -67,8 +67,8 @@ CMake variables:
 In addition, it will have created some targets that you can link against
 (note these are plain strings, not variables):
 
-* ``arrow_shared`` links to the Arrow shared libraries
-* ``arrow_static`` links to the Arrow static libraries
+* ``Arrow::arrow_shared`` links to the Arrow shared libraries
+* ``Arrow::arrow_static`` links to the Arrow static libraries
 
 In most cases, it is recommended to use the Arrow shared libraries.
 

--- a/docs/source/java/cdata.rst
+++ b/docs/source/java/cdata.rst
@@ -438,7 +438,7 @@ CMakeLists.txt definition file:
    include_directories(${JNI_INCLUDE_DIRS})
    set(CMAKE_CXX_STANDARD 11)
    add_executable(${PROJECT_NAME} main.cpp)
-   target_link_libraries(cdatacpptojava PRIVATE arrow_shared)
+   target_link_libraries(cdatacpptojava PRIVATE Arrow::arrow_shared)
    target_link_libraries(cdatacpptojava PRIVATE ${JNI_LIBRARIES})
 
 **Result**


### PR DESCRIPTION
The problem is only reproducible when using REQUIRED components on the find_package call:
```
find_package(Arrow REQUIRED COMPONENTS dataset flight parquet) 
```
due to the following macro automatically generated from [configure_package_config_file](https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html)

```
macro(check_required_components _NAME)
  foreach(comp ${${_NAME}_FIND_COMPONENTS})
    if(NOT ${_NAME}_${comp}_FOUND)
      if(${_NAME}_FIND_REQUIRED_${comp})
        set(${_NAME}_FOUND FALSE)
      endif()
    endif()
  endforeach()
endmacro()
```

A possible solution is to add the `NO_CHECK_REQUIRED_COMPONENTS_MACRO`