### PR TITLE
MINOR: [Ruby] Fix wrong English

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -19,7 +19,7 @@
 
 # Apache Arrow Ruby
 
-These are the official Ruby bindings for Apache Arrow.
+Here are the official Ruby bindings for Apache Arrow.
 
 [Red Arrow](https://github.com/apache/arrow/tree/master/ruby/red-arrow) is the base Apache Arrow bindings.
 

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -19,7 +19,7 @@
 
 # Apache Arrow Ruby
 
-There are the official Ruby bindings for Apache Arrow.
+These are the official Ruby bindings for Apache Arrow.
 
 [Red Arrow](https://github.com/apache/arrow/tree/master/ruby/red-arrow) is the base Apache Arrow bindings.
 


### PR DESCRIPTION
Change "There are the [...]" to "These are the [...]". Incorrect wording in previous README.