### PR TITLE
ARROW-17620: [R] as_arrow_array() ignores type for StructArrays

### DIFF
--- a/r/R/array.R
+++ b/r/R/array.R
@@ -303,7 +303,7 @@ as_arrow_array.data.frame <- function(x, ..., type = NULL) {
     fields <- type$fields()
     names <- map_chr(fields, "name")
     types <- map(fields, "type")
-    arrays <- Map(as_arrow_array, x, types)
+    arrays <- Map(as_arrow_array, x, type = types)
     names(arrays) <- names
 
     # TODO(ARROW-16266): a hack because there is no StructArray$create() yet

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -1118,7 +1118,7 @@ test_that("as_arrow_array() works for nested extension types", {
   nested_plain <- tibble::tibble(x = 1:5)
   extension_array <- vctrs_extension_array(nested_plain)
   expect_equal(
-    as_arrow_array(nested, type = extension_array$type),
+    as_arrow_array(nested_plain, type = extension_array$type),
     extension_array
   )
 })
@@ -1147,7 +1147,7 @@ test_that("Array$create() calls as_arrow_array() for nested extension types", {
   nested_plain <- tibble::tibble(x = 1:5)
   extension_array <- vctrs_extension_array(nested_plain)
   expect_equal(
-    Array$create(nested, type = extension_array$type),
+    Array$create(nested_plain, type = extension_array$type),
     extension_array
   )
 })

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -531,7 +531,6 @@ test_that("Array$create() can handle data frame with custom struct type (not inf
   type <- struct(x = float64(), y = int16())
   a <- Array$create(df, type = type)
   expect_type_equal(a$type, type)
-  
   type <- struct(x = float64(), y = int16(), z = int32())
   expect_error(
     Array$create(df, type = type),

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -532,6 +532,9 @@ test_that("Array$create() can handle data frame with custom struct type (not inf
   a <- Array$create(df, type = type)
   expect_type_equal(a$type, type)
 
+  ## as_arrow_array respects `type` argument (ARROW-17620)
+  expect_type_equal(a, as_arrow_array(df, type = type))
+  
   type <- struct(x = float64(), y = int16(), z = int32())
   expect_error(
     Array$create(df, type = type),

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -531,9 +531,6 @@ test_that("Array$create() can handle data frame with custom struct type (not inf
   type <- struct(x = float64(), y = int16())
   a <- Array$create(df, type = type)
   expect_type_equal(a$type, type)
-
-  ## as_arrow_array respects `type` argument (ARROW-17620)
-  expect_type_equal(a, as_arrow_array(df, type = type))
   
   type <- struct(x = float64(), y = int16(), z = int32())
   expect_error(
@@ -1031,6 +1028,14 @@ test_that("as_arrow_array() default method calls Array$create()", {
     as_arrow_array(1:10, type = float64()),
     Array$create(1:10, type = float64())
   )
+})
+
+test_that("as_arrow_array respects `type` argument (ARROW-17620)", {
+  df <- tibble::tibble(x = 1:10, y = 1:10)
+  type <- struct(x = float64(), y = int16())
+  a <- Array$create(df, type = type)
+
+  expect_type_equal(a, as_arrow_array(df, type = type))
 })
 
 test_that("as_arrow_array() works for Array", {


### PR DESCRIPTION
As described in https://issues.apache.org/jira/browse/ARROW-17620, `as_arrow_array()` ignores user-provided types passed by the `type` argument.

This PR explicitly adds the `type` name argument to the `Map` call. Currently, the argument gets passed to the ellipsis and gets ignored.

I also added a test. Let me know if there is a better place for it (or a better test).