### PR TITLE
ARROW-16651 : [Python] Casting Table to new schema ignores nullability of fields

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -3403,7 +3403,8 @@ cdef class Table(_PandasConvertible):
 
         for name in field_names:
             if self.schema.field(name).nullable and not target_schema.field(name).nullable:
-                raise RuntimeError("Casting a nullable field {!r} to non-nullable".format(name))
+                raise RuntimeError(
+                    "Casting a nullable field {!r} to non-nullable".format(name))
         for column, field in zip(self.itercolumns(), target_schema):
             casted = column.cast(field.type, safe=safe, options=options)
             newcols.append(casted)

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -3403,7 +3403,7 @@ cdef class Table(_PandasConvertible):
         for column, field in zip(self.itercolumns(), target_schema):
             if not field.nullable and column.null_count > 0:
                 raise ValueError("Casting field {!r} with null values to non-nullable"
-                                   .format(field.name))
+                                 .format(field.name))
             casted = column.cast(field.type, safe=safe, options=options)
             newcols.append(casted)
 

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -3395,11 +3395,15 @@ cdef class Table(_PandasConvertible):
             Field field
             list newcols = []
 
-        if self.schema.names != target_schema.names:
+        field_names = self.schema.names
+        if field_names != target_schema.names:
             raise ValueError("Target schema's field names are not matching "
                              "the table's field names: {!r}, {!r}"
                              .format(self.schema.names, target_schema.names))
 
+        for name in field_names:
+            if self.schema.field(name).nullable and not target_schema.field(name).nullable:
+                raise RuntimeError("Casting a nullable field {!r} to non-nullable".format(name))
         for column, field in zip(self.itercolumns(), target_schema):
             casted = column.cast(field.type, safe=safe, options=options)
             newcols.append(casted)

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -3395,17 +3395,15 @@ cdef class Table(_PandasConvertible):
             Field field
             list newcols = []
 
-        field_names = self.schema.names
-        if field_names != target_schema.names:
+        if self.schema.names != target_schema.names:
             raise ValueError("Target schema's field names are not matching "
                              "the table's field names: {!r}, {!r}"
                              .format(self.schema.names, target_schema.names))
 
-        for name in field_names:
-            if self.schema.field(name).nullable and not target_schema.field(name).nullable:
-                raise RuntimeError(
-                    "Casting a nullable field {!r} to non-nullable".format(name))
         for column, field in zip(self.itercolumns(), target_schema):
+            if column.null_count > 0 and not field.nullable:
+                raise RuntimeError("Casting field {!r} with null values to non-nullable"
+                                   .format(field.name))
             casted = column.cast(field.type, safe=safe, options=options)
             newcols.append(casted)
 

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -3401,8 +3401,8 @@ cdef class Table(_PandasConvertible):
                              .format(self.schema.names, target_schema.names))
 
         for column, field in zip(self.itercolumns(), target_schema):
-            if column.null_count > 0 and not field.nullable:
-                raise RuntimeError("Casting field {!r} with null values to non-nullable"
+            if not field.nullable and column.null_count > 0:
+                raise ValueError("Casting field {!r} with null values to non-nullable"
                                    .format(field.name))
             casted = column.cast(field.type, safe=safe, options=options)
             newcols.append(casted)

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -2201,3 +2201,6 @@ def test_table_cast_invalid():
                             pa.field("b", "bool", nullable=False)])
     with pytest.raises(RuntimeError):
         table.cast(new_schema)
+
+    table = pa.table({'a': [None, 1], 'b': [False, True]})
+    assert table.cast(new_schema).schema == new_schema

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -2199,7 +2199,7 @@ def test_table_cast_invalid():
     table = pa.table({'a': [None, 1], 'b': [None, True]})
     new_schema = pa.schema([pa.field("a", "int64", nullable=True),
                             pa.field("b", "bool", nullable=False)])
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         table.cast(new_schema)
 
     table = pa.table({'a': [None, 1], 'b': [False, True]})

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -2192,3 +2192,12 @@ def test_table_join_many_columns():
         "col6": ["A", "B", None, "Z"],
         "col7": ["A", "B", None, "Z"],
     })
+
+
+def test_table_cast_invalid():
+    # Casting a nullable field to non-nullable should be invalid!
+    table = pa.table({'a': [None, 1], 'b': [None, True]})
+    new_schema = pa.schema([pa.field("a", "int64", nullable=True),
+                            pa.field("b", "bool", nullable=False)])
+    with pytest.raises(RuntimeError):
+        table.cast(new_schema)


### PR DESCRIPTION
```python
table = pa.table({'a': [None, 1], 'b': [None, True]})
new_schema = pa.schema([pa.field("a", "int64", nullable=True), pa.field("b", "bool", nullable=False)])
casted = table.cast(new_schema)

```

Now leads to
```
RuntimeError: Casting field 'b' with null values to non-nullable
```