### PR TITLE
ARROW-17507: [Dev][CI][R] GHA "autotune" doesn't work

### DIFF
--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -64,10 +64,9 @@ jobs:
         run: |
           set -ex
           DEFAULT_BRANCH=${{ github.event.repository.default_branch }}
-          git remote add upstream https://github.com/apache/arrow
-          git fetch upstream
+
           changed() {
-            git diff --name-only HEAD..upstream/$DEFAULT_BRANCH | grep -e "$1" >/dev/null 2>&1
+            git diff --name-only $DEFAULT_BRANCH... | grep -e "$1" >/dev/null 2>&1
           }
           if changed '^r/.*\.R$'; then
             echo "R_DOCS=true" >> $GITHUB_ENV
@@ -82,7 +81,7 @@ jobs:
           if changed '^r/src'; then
             echo "CLANG_FORMAT_R=true" >> $GITHUB_ENV
           fi
-      - name: Ensure clang-format has the appropriate versoin
+      - name: Ensure clang-format has the appropriate version
         if: env.CMAKE_FORMAT == 'true' ||
           env.CLANG_FORMAT_CPP == 'true' ||
           env.CLANG_FORMAT_R == 'true' ||
@@ -124,18 +123,16 @@ jobs:
         run: |
           source("ci/etc/rprofile")
           install.packages(c("remotes", "roxygen2"))
-          # We currently need dev roxygen2 (> 7.1.1) until they release
-          remotes::install_github("r-lib/roxygen2")
           remotes::install_deps("r")
           roxygen2::roxygenize("r")
       - name: Style R code
         if: env.R_CODE == 'true' || endsWith(github.event.comment.body, 'everything')
         shell: Rscript {0}
         run: |
-          changed_files <- system("git diff --name-only HEAD..upstream/${{ github.event.repository.default_branch }} 2>&1", intern = TRUE)
+          changed_files <- system("git diff --name-only ${{ github.event.repository.default_branch }}... 2>&1", intern = TRUE)
           # only grab the .R files under r/
           changed_files <- grep('^r/.*\\.R$', changed_files, value = TRUE)
-          # remove latin1 which is unstylable due to encoding and codegen.R which is unique
+          # remove codegen.R and other possible exclusions
           changed_files <- changed_files[!changed_files %in% file.path("r", source("r/.styler_excludes.R")$value)]
           source("ci/etc/rprofile")
           install.packages(c("remotes", "styler"))

--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -64,9 +64,11 @@ jobs:
         run: |
           set -ex
           DEFAULT_BRANCH=${{ github.event.repository.default_branch }}
+          git remote add upstream https://github.com/apache/arrow
+          git fetch upstream
 
           changed() {
-            git diff --name-only $DEFAULT_BRANCH... | grep -e "$1" >/dev/null 2>&1
+            git diff --name-only upstream/$DEFAULT_BRANCH... | grep -e "$1" >/dev/null 2>&1
           }
           if changed '^r/.*\.R$'; then
             echo "R_DOCS=true" >> $GITHUB_ENV
@@ -129,7 +131,7 @@ jobs:
         if: env.R_CODE == 'true' || endsWith(github.event.comment.body, 'everything')
         shell: Rscript {0}
         run: |
-          changed_files <- system("git diff --name-only ${{ github.event.repository.default_branch }}... 2>&1", intern = TRUE)
+          changed_files <- system("git diff --name-only upstream/${{ github.event.repository.default_branch }}... 2>&1", intern = TRUE)
           # only grab the .R files under r/
           changed_files <- grep('^r/.*\\.R$', changed_files, value = TRUE)
           # remove codegen.R and other possible exclusions


### PR DESCRIPTION
The `changed` function was giving back the changed files between PR HEAD and master HEAD which is not what the actual intention was: a list of files changed within the PR. This is what caused the superfluous triggering of R steps as reported in the jira. These than failed due to API rate limits due to a github install of roxygen2 which is no longer necessary as a newer version is now on CRAN.
