### PR TITLE
ARROW-17639: [R] infer_type() fails for lists where the first element is NULL

### DIFF
--- a/r/src/type_infer.cpp
+++ b/r/src/type_infer.cpp
@@ -203,6 +203,8 @@ std::shared_ptr<arrow::DataType> InferArrowType(SEXP x) {
         return InferArrowTypeFromVector<STRSXP>(x);
       case VECSXP:
         return InferArrowTypeFromVector<VECSXP>(x);
+      case NILSXP:
+        return null();
       default:
         cpp11::stop("Cannot infer type from vector");
     }

--- a/r/src/type_infer.cpp
+++ b/r/src/type_infer.cpp
@@ -165,8 +165,13 @@ std::shared_ptr<arrow::DataType> InferArrowTypeFromVector<VECSXP>(SEXP x) {
         cpp11::stop(
             "Requires at least one element to infer the values' type of a list vector");
       }
-
-      ptype = VECTOR_ELT(x, 0);
+      // Iterate through the vector until we get a non-null result
+      for (R_xlen_t i = 0; i < XLENGTH(x); i++) {
+        ptype = VECTOR_ELT(x, i);
+        if (!Rf_isNull(ptype)) {
+          break;
+        }
+      }
     }
 
     return arrow::list(InferArrowType(ptype));

--- a/r/tests/testthat/test-type.R
+++ b/r/tests/testthat/test-type.R
@@ -293,3 +293,14 @@ test_that("type() is deprecated", {
   )
   expect_equal(a_type, a$type)
 })
+
+test_that("infer_type() infers type for lists starting with NULL - ARROW-17639", {
+
+  null_list = list(NULL, c(2,3), c(4,5))
+  infer_type(x)
+
+  expect_equal(
+    infer_type(null_list),
+    list_of(float64())
+  )
+})

--- a/r/tests/testthat/test-type.R
+++ b/r/tests/testthat/test-type.R
@@ -298,7 +298,7 @@ test_that("infer_type() infers type for lists starting with NULL - ARROW-17639",
   null_start_list <- list(NULL, c(2, 3), c(4, 5))
 
   expect_equal(
-    infer_type(null_list),
+    infer_type(null_start_list),
     list_of(float64())
   )
 

--- a/r/tests/testthat/test-type.R
+++ b/r/tests/testthat/test-type.R
@@ -295,12 +295,17 @@ test_that("type() is deprecated", {
 })
 
 test_that("infer_type() infers type for lists starting with NULL - ARROW-17639", {
-
-  null_list = list(NULL, c(2,3), c(4,5))
-  infer_type(x)
+  null_start_list <- list(NULL, c(2, 3), c(4, 5))
 
   expect_equal(
     infer_type(null_list),
     list_of(float64())
+  )
+
+  totally_null_list <- list(NULL, NULL, NULL)
+
+  expect_equal(
+    infer_type(totally_null_list),
+    list_of(null())
   )
 })


### PR DESCRIPTION
This PR updates the internals of type inference on lists; instead of looking at the type of the first element, we instead iterate through all elements until we find a non-null element.