### PR TITLE
ARROW-16226: [C++] Add better coverage for filesystem tell.

### DIFF
--- a/cpp/src/arrow/filesystem/test_util.cc
+++ b/cpp/src/arrow/filesystem/test_util.cc
@@ -979,6 +979,7 @@ void GenericFileSystemTest::TestOpenInputStream(FileSystem* fs) {
   ASSERT_OK_AND_ASSIGN(buffer, stream->Read(1));
   AssertBufferEqual(*buffer, "");
   ASSERT_OK_AND_EQ(9, stream->Tell());
+  ASSERT_OK(stream->Close());
 
   ASSERT_OK_AND_ASSIGN(stream, fs->OpenInputStream("AB/abc"));
   ASSERT_OK(stream->Advance(4));
@@ -1077,8 +1078,8 @@ void GenericFileSystemTest::TestOpenInputFile(FileSystem* fs) {
   ASSERT_OK_AND_ASSIGN(buffer, file->Read(6));
   AssertBufferEqual(*buffer, "other ");
   // Should return the same slice independent of the current position
-  ASSERT_OK_AND_ASSIGN(buffer, file->ReadAt(0, 4));
-  AssertBufferEqual(*buffer, "some");
+  ASSERT_OK_AND_ASSIGN(buffer, file->ReadAt(2, 3));
+  AssertBufferEqual(*buffer, "me ");
   ASSERT_OK_AND_EQ(15, file->GetSize());
   ASSERT_OK(file->Close());
   ASSERT_RAISES(Invalid, file->ReadAt(1, 1));  // Stream is closed

--- a/cpp/src/arrow/filesystem/test_util.cc
+++ b/cpp/src/arrow/filesystem/test_util.cc
@@ -974,7 +974,7 @@ void GenericFileSystemTest::TestOpenInputStream(FileSystem* fs) {
   ASSERT_OK_AND_EQ(0, stream->Tell());
   ASSERT_OK_AND_ASSIGN(buffer, stream->Read(4));
   AssertBufferEqual(*buffer, "some");
-  ASSERT_OK_AND_ASSIGN(buffer, stream->Read(6));
+  ASSERT_OK_AND_ASSIGN(buffer, stream->Read(6 /*Remaining + 1*/));
   AssertBufferEqual(*buffer, " data");
   ASSERT_OK_AND_ASSIGN(buffer, stream->Read(1));
   AssertBufferEqual(*buffer, "");

--- a/cpp/src/arrow/filesystem/test_util.cc
+++ b/cpp/src/arrow/filesystem/test_util.cc
@@ -971,12 +971,20 @@ void GenericFileSystemTest::TestOpenInputStream(FileSystem* fs) {
   ASSERT_OK_AND_ASSIGN(stream, fs->OpenInputStream("AB/abc"));
   ASSERT_OK_AND_ASSIGN(auto metadata, stream->ReadMetadata());
   // XXX we cannot really test anything more about metadata...
+  ASSERT_OK_AND_EQ(0, stream->Tell());
   ASSERT_OK_AND_ASSIGN(buffer, stream->Read(4));
   AssertBufferEqual(*buffer, "some");
   ASSERT_OK_AND_ASSIGN(buffer, stream->Read(6));
   AssertBufferEqual(*buffer, " data");
   ASSERT_OK_AND_ASSIGN(buffer, stream->Read(1));
   AssertBufferEqual(*buffer, "");
+  ASSERT_OK_AND_EQ(9, stream->Tell());
+
+  ASSERT_OK_AND_ASSIGN(stream, fs->OpenInputStream("AB/abc"));
+  ASSERT_OK(stream->Advance(4));
+  ASSERT_OK_AND_EQ(4, stream->Tell());
+  ASSERT_OK_AND_ASSIGN(buffer, stream->Read(6 /*Remaining + 1*/));
+  AssertBufferEqual(*buffer, " data");
   ASSERT_OK(stream->Close());
   ASSERT_RAISES(Invalid, stream->Read(1));  // Stream is closed
 
@@ -1056,6 +1064,15 @@ void GenericFileSystemTest::TestOpenInputFile(FileSystem* fs) {
   std::shared_ptr<io::RandomAccessFile> file;
   std::shared_ptr<Buffer> buffer;
   ASSERT_OK_AND_ASSIGN(file, fs->OpenInputFile("AB/abc"));
+  ASSERT_OK_AND_EQ(0, file->Tell());
+  ASSERT_OK(file->Seek(10));
+  ASSERT_OK_AND_EQ(10, file->Tell());
+  ASSERT_OK_AND_ASSIGN(buffer, file->Read(6 /*Remaining + 1*/));
+  AssertBufferEqual(*buffer, " data");
+  ASSERT_OK_AND_ASSIGN(buffer, file->Read(1));
+  AssertBufferEqual(*buffer, "");
+  ASSERT_OK_AND_EQ(15, file->Tell());
+  // Should return the same slice independent of the current position
   ASSERT_OK_AND_ASSIGN(buffer, file->ReadAt(5, 6));
   AssertBufferEqual(*buffer, "other ");
   ASSERT_OK_AND_EQ(15, file->GetSize());

--- a/cpp/src/arrow/filesystem/test_util.cc
+++ b/cpp/src/arrow/filesystem/test_util.cc
@@ -1072,9 +1072,13 @@ void GenericFileSystemTest::TestOpenInputFile(FileSystem* fs) {
   ASSERT_OK_AND_ASSIGN(buffer, file->Read(1));
   AssertBufferEqual(*buffer, "");
   ASSERT_OK_AND_EQ(15, file->Tell());
-  // Should return the same slice independent of the current position
-  ASSERT_OK_AND_ASSIGN(buffer, file->ReadAt(5, 6));
+  ASSERT_OK(file->Seek(5));
+  ASSERT_OK_AND_EQ(5, file->Tell());
+  ASSERT_OK_AND_ASSIGN(buffer, file->Read(6));
   AssertBufferEqual(*buffer, "other ");
+  // Should return the same slice independent of the current position
+  ASSERT_OK_AND_ASSIGN(buffer, file->ReadAt(0, 4));
+  AssertBufferEqual(*buffer, "some");
   ASSERT_OK_AND_EQ(15, file->GetSize());
   ASSERT_OK(file->Close());
   ASSERT_RAISES(Invalid, file->ReadAt(1, 1));  // Stream is closed


### PR DESCRIPTION
Based on [ARROW-16226](https://issues.apache.org/jira/browse/ARROW-16226).

Adds coverage to GenericFileSystemTest::TestOpenInput(Stream|File) for validating Tell() and reads after seeking.