### PR TITLE
ARROW-16424: [C++] Use Uri to parse substrait ReadRel file path

### DIFF
--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -276,7 +276,6 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel, const ExtensionSet&
             } else if (file_info.type() == fs::FileType::Directory) {
               RETURN_NOT_OK(DiscoverFilesFromDir(filesystem, item_uri.path(), files));
             }
-
             break;
           }
 

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -98,14 +98,15 @@ Status CheckRelCommon(const RelMessage& rel) {
 
 // Other helper functions
 Status DiscoverFilesFromDir(const std::shared_ptr<fs::LocalFileSystem>& local_fs,
-                            const std::string& dirpath, std::vector<fs::FileInfo> *rel_fpaths) {
+                            const std::string& dirpath,
+                            std::vector<fs::FileInfo> *rel_fpaths) {
   // Define a selector for a recursive descent
   fs::FileSelector selector;
   selector.base_dir = dirpath;
   selector.recursive = true;
 
   ARROW_ASSIGN_OR_RAISE(auto file_infos, local_fs->GetFileInfo(selector));
-  std::move(file_infos.begin(), file_infos.end(), std::back_inserter(rel_fpaths));
+  std::move(file_infos.begin(), file_infos.end(), std::back_inserter(*rel_fpaths));
 
   return Status::OK();
 }

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -43,7 +43,6 @@ using internal::UriFromAbsolutePath;
 
 namespace engine {
 
-
 // Validation functions
 
 template <typename RelMessage>
@@ -126,8 +125,7 @@ Status CheckReadRelation(const substrait::ReadRel& rel,
   }
 
   if (rel.local_files().has_advanced_extension()) {
-    return Status::NotImplemented(
-        "substrait::ReadRel::LocalFiles::advanced_extension");
+    return Status::NotImplemented("substrait::ReadRel::LocalFiles::advanced_extension");
   }
 
   return Status::OK();
@@ -154,20 +152,17 @@ Status CheckFileItem(const substrait::ReadRel::LocalFiles::FileOrFiles& file_ite
 
 Status CheckFilePathUri(const ::arrow::internal::Uri& uri) {
   if (!uri.is_file_scheme()) {
-    return Status::NotImplemented("substrait::ReadRel::LocalFiles item (",
-                                  uri.ToString(),
+    return Status::NotImplemented("substrait::ReadRel::LocalFiles item (", uri.ToString(),
                                   ") with non-filesystem scheme (file:///)");
   }
 
   if (uri.port() != -1) {
-    return Status::NotImplemented("substrait::ReadRel::LocalFiles item (",
-                                  uri.ToString(),
+    return Status::NotImplemented("substrait::ReadRel::LocalFiles item (", uri.ToString(),
                                   ") should not have a port number in path");
   }
 
   if (!uri.query_string().empty()) {
-    return Status::NotImplemented("substrait::ReadRel::LocalFiles item (",
-                                  uri.ToString(),
+    return Status::NotImplemented("substrait::ReadRel::LocalFiles item (", uri.ToString(),
                                   ") should not have a query string in path");
   }
 
@@ -176,8 +171,7 @@ Status CheckFilePathUri(const ::arrow::internal::Uri& uri) {
 
 // Other helper functions
 Status DiscoverFilesFromDir(std::shared_ptr<fs::LocalFileSystem>& local_fs,
-                            std::string dirpath,
-                            std::vector<fs::FileInfo>& rel_fpaths) {
+                            std::string dirpath, std::vector<fs::FileInfo>& rel_fpaths) {
   // Define a selector for a recursive descent
   fs::FileSelector selector;
   selector.base_dir = dirpath;
@@ -319,15 +313,13 @@ Result<DeclarationInfo> FromReadRelation(const substrait::ReadRel& rel,
   }
 
   // Create a dataset via a dataset factory
-  ARROW_ASSIGN_OR_RAISE(auto ds_factory,
-    dataset::FileSystemDatasetFactory::Make(
-      std::move(filesystem), std::move(files), std::move(format), {}
-    )
-  );
+  ARROW_ASSIGN_OR_RAISE(auto ds_factory, dataset::FileSystemDatasetFactory::Make(
+                                             std::move(filesystem), std::move(files),
+                                             std::move(format), {}));
 
   ARROW_ASSIGN_OR_RAISE(auto ds, ds_factory->Finish(base_schema));
 
-  DeclarationInfo scan_declaration {
+  DeclarationInfo scan_declaration{
       compute::Declaration{"scan", dataset::ScanNodeOptions{ds, scan_options}},
       base_schema};
 

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -96,7 +96,6 @@ Status CheckRelCommon(const RelMessage& rel) {
   return Status::OK();
 }
 
->>>>>>> 54094ebc8 (ARROW-16424: undid FromProto re-organization)
 // Other helper functions
 Status DiscoverFilesFromDir(std::shared_ptr<fs::LocalFileSystem>& local_fs,
                             std::string dirpath, std::vector<fs::FileInfo>& rel_fpaths) {

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -249,8 +249,8 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel, const ExtensionSet&
           default:
             // TODO: maybe check for ".feather" or ".arrows"?
             return Status::NotImplemented(
-              "unsupported file format ",
-              "(see substrait::ReadRel::LocalFiles::FileOrFiles::file_format)");
+                "unsupported file format ",
+                "(see substrait::ReadRel::LocalFiles::FileOrFiles::file_format)");
         }
 
         // Handle the URI as appropriate

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -99,7 +99,7 @@ Status CheckRelCommon(const RelMessage& rel) {
 // Other helper functions
 Status DiscoverFilesFromDir(const std::shared_ptr<fs::LocalFileSystem>& local_fs,
                             const std::string& dirpath,
-                            std::vector<fs::FileInfo> *rel_fpaths) {
+                            std::vector<fs::FileInfo>* rel_fpaths) {
   // Define a selector for a recursive descent
   fs::FileSelector selector;
   selector.base_dir = dirpath;
@@ -283,7 +283,7 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel, const ExtensionSet&
               case fs::FileType::Unknown:
                 [[fallthrough]];
               default:
-                return Status::NotImplemented("unsupported: URI path is of unknown file type.");
+                return Status::NotImplemented("URI path is of unknown file type.");
             }
             break;
           }

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -106,7 +106,11 @@ Status DiscoverFilesFromDir(const std::shared_ptr<fs::LocalFileSystem>& local_fs
   selector.recursive = true;
 
   ARROW_ASSIGN_OR_RAISE(auto file_infos, local_fs->GetFileInfo(selector));
-  std::move(file_infos.begin(), file_infos.end(), std::back_inserter(*rel_fpaths));
+  for (auto& file_info : file_infos) {
+    if (file_info.IsFile()) {
+      rel_fpaths->push_back(file_info);
+    }
+  }
 
   return Status::OK();
 }

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -97,8 +97,8 @@ Status CheckRelCommon(const RelMessage& rel) {
 }
 
 // Other helper functions
-Status DiscoverFilesFromDir(std::shared_ptr<fs::LocalFileSystem>& local_fs,
-                            std::string dirpath, std::vector<fs::FileInfo>& rel_fpaths) {
+Status DiscoverFilesFromDir(const std::shared_ptr<fs::LocalFileSystem>& local_fs,
+                            const std::string& dirpath, std::vector<fs::FileInfo> *rel_fpaths) {
   // Define a selector for a recursive descent
   fs::FileSelector selector;
   selector.base_dir = dirpath;

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -107,7 +107,7 @@ Status DiscoverFilesFromDir(const std::shared_ptr<fs::LocalFileSystem>& local_fs
   ARROW_ASSIGN_OR_RAISE(auto file_infos, local_fs->GetFileInfo(selector));
   for (auto& file_info : file_infos) {
     if (file_info.IsFile()) {
-      rel_fpaths->push_back(file_info);
+      rel_fpaths->push_back(std::move(file_info));
     }
   }
 
@@ -139,7 +139,6 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel, const ExtensionSet&
                               FromProto(read.filter(), ext_set, conversion_options));
       }
 
-      // NOTE: scan_options->projection is not used by the scanner and thus can't be used
       if (read.has_projection()) {
         return Status::NotImplemented("substrait::ReadRel::projection");
       }
@@ -227,7 +226,7 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel, const ExtensionSet&
         if (!item_uri.is_file_scheme()) {
           return Status::NotImplemented("substrait::ReadRel::LocalFiles item (",
                                         item_uri.ToString(),
-                                        ") with non-filesystem scheme (file:///)");
+                                        ") does not have file scheme (file:///)");
         }
 
         if (item_uri.port() != -1) {
@@ -250,7 +249,6 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel, const ExtensionSet&
             format = std::make_shared<dataset::IpcFileFormat>();
             break;
           default:
-            // TODO: maybe check for ".feather" or ".arrows"?
             return Status::NotImplemented(
                 "unsupported file format ",
                 "(see substrait::ReadRel::LocalFiles::FileOrFiles::file_format)");

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -302,7 +302,7 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel, const ExtensionSet&
           compute::Declaration{"scan", dataset::ScanNodeOptions{ds, scan_options}},
           base_schema};
 
-      return ProcessEmit(std::move(rel), std::move(scan_declaration),
+      return ProcessEmit(std::move(read), std::move(scan_declaration),
                          std::move(base_schema));
     }
 

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -43,8 +43,6 @@ using internal::UriFromAbsolutePath;
 
 namespace engine {
 
-// Validation functions
-
 template <typename RelMessage>
 Result<std::vector<compute::Expression>> GetEmitInfo(
     const RelMessage& rel, const std::shared_ptr<Schema>& schema) {
@@ -98,77 +96,7 @@ Status CheckRelCommon(const RelMessage& rel) {
   return Status::OK();
 }
 
-Status CheckReadRelation(const substrait::ReadRel& rel,
-                         const ConversionOptions& conversion_options) {
-  // NOTE: scan_options->projection is not used by the scanner and thus can't be used
-  if (rel.has_projection()) {
-    return Status::NotImplemented("substrait::ReadRel::projection");
-  }
-
-  if (rel.has_named_table()) {
-    if (!conversion_options.named_table_provider) {
-      return Status::Invalid(
-          "plan contained a named table but a NamedTableProvider has not been "
-          "configured");
-    }
-
-    if (rel.named_table().names().empty()) {
-      return Status::Invalid("names for NamedTable not provided");
-    }
-
-    return Status::OK();
-  }
-
-  if (!rel.has_local_files()) {
-    return Status::NotImplemented(
-        "substrait::ReadRel with read_type other than LocalFiles");
-  }
-
-  if (rel.local_files().has_advanced_extension()) {
-    return Status::NotImplemented("substrait::ReadRel::LocalFiles::advanced_extension");
-  }
-
-  return Status::OK();
-}
-
-Status CheckFileItem(const substrait::ReadRel::LocalFiles::FileOrFiles& file_item) {
-  if (file_item.partition_index() != 0) {
-    return Status::NotImplemented(
-        "non-default substrait::ReadRel::LocalFiles::FileOrFiles::partition_index");
-  }
-
-  if (file_item.start() != 0) {
-    return Status::NotImplemented(
-        "non-default substrait::ReadRel::LocalFiles::FileOrFiles::start offset");
-  }
-
-  if (file_item.length() != 0) {
-    return Status::NotImplemented(
-        "non-default substrait::ReadRel::LocalFiles::FileOrFiles::length");
-  }
-
-  return Status::OK();
-}
-
-Status CheckFilePathUri(const ::arrow::internal::Uri& uri) {
-  if (!uri.is_file_scheme()) {
-    return Status::NotImplemented("substrait::ReadRel::LocalFiles item (", uri.ToString(),
-                                  ") with non-filesystem scheme (file:///)");
-  }
-
-  if (uri.port() != -1) {
-    return Status::NotImplemented("substrait::ReadRel::LocalFiles item (", uri.ToString(),
-                                  ") should not have a port number in path");
-  }
-
-  if (!uri.query_string().empty()) {
-    return Status::NotImplemented("substrait::ReadRel::LocalFiles item (", uri.ToString(),
-                                  ") should not have a query string in path");
-  }
-
-  return Status::OK();
-}
-
+>>>>>>> 54094ebc8 (ARROW-16424: undid FromProto re-organization)
 // Other helper functions
 Status DiscoverFilesFromDir(std::shared_ptr<fs::LocalFileSystem>& local_fs,
                             std::string dirpath, std::vector<fs::FileInfo>& rel_fpaths) {
@@ -183,147 +111,6 @@ Status DiscoverFilesFromDir(std::shared_ptr<fs::LocalFileSystem>& local_fs,
   return Status::OK();
 }
 
-// Function that implements "FromProto" for a substrait::ReadRel (read relation)
-Result<DeclarationInfo> FromReadRelation(const substrait::ReadRel& rel,
-                                         const ExtensionSet& ext_set,
-                                         const ConversionOptions& conversion_options) {
-  // Validate the defined read relation
-  RETURN_NOT_OK(CheckReadRelation(rel, conversion_options));
-
-  // Get the base schema for the read relation
-  ARROW_ASSIGN_OR_RAISE(auto base_schema,
-                        FromProto(rel.base_schema(), ext_set, conversion_options));
-
-  auto scan_options = std::make_shared<dataset::ScanOptions>();
-  scan_options->use_threads = true;
-
-  if (rel.has_filter()) {
-    ARROW_ASSIGN_OR_RAISE(scan_options->filter,
-                          FromProto(rel.filter(), ext_set, conversion_options));
-  }
-
-  if (rel.has_named_table()) {
-    const NamedTableProvider& named_provider = conversion_options.named_table_provider;
-    const substrait::ReadRel::NamedTable& named_table = rel.named_table();
-    std::vector<std::string> table_names(named_table.names().begin(),
-                                         named_table.names().end());
-
-    ARROW_ASSIGN_OR_RAISE(compute::Declaration source_decl, named_provider(table_names));
-    if (!source_decl.IsValid()) {
-      return Status::Invalid("Invalid NamedTable Source");
-    }
-
-    return ProcessEmit(std::move(rel),
-                       DeclarationInfo{std::move(source_decl), base_schema},
-                       std::move(base_schema));
-  }
-
-  // Determine format based on the first FileOrFiles item
-  std::shared_ptr<dataset::FileFormat> format;
-  if (rel.local_files().items().size() > 0) {
-    const auto& first_file = rel.local_files().items(0);
-
-    switch (first_file.file_format_case()) {
-      case substrait::ReadRel::LocalFiles::FileOrFiles::kParquet:
-        format = std::make_shared<dataset::ParquetFileFormat>();
-        break;
-
-      case substrait::ReadRel::LocalFiles::FileOrFiles::kArrow:
-        format = std::make_shared<dataset::IpcFileFormat>();
-        break;
-
-      default:
-        // TODO: maybe check for ".feather" or ".arrows"?
-        return Status::NotImplemented(
-            "unsupported file format ",
-            "(see substrait::ReadRel::LocalFiles::FileOrFiles::file_format)");
-    }
-  }
-
-  // Use a filesystem instance to gather each file
-  auto filesystem = std::make_shared<fs::LocalFileSystem>();
-  std::vector<fs::FileInfo> files;
-  for (const auto& item : rel.local_files().items()) {
-    // Validate properties of the `FileOrFiles` item
-    RETURN_NOT_OK(CheckFileItem(item));
-
-    // Extract and parse the read relation's source URI
-    ::arrow::internal::Uri item_uri;
-    switch (item.path_type_case()) {
-      case substrait::ReadRel::LocalFiles::FileOrFiles::kUriPath:
-        RETURN_NOT_OK(item_uri.Parse(item.uri_path()));
-        break;
-
-      case substrait::ReadRel::LocalFiles::FileOrFiles::kUriFile:
-        RETURN_NOT_OK(item_uri.Parse(item.uri_file()));
-        break;
-
-      case substrait::ReadRel::LocalFiles::FileOrFiles::kUriFolder:
-        RETURN_NOT_OK(item_uri.Parse(item.uri_folder()));
-        break;
-
-      default:
-        RETURN_NOT_OK(item_uri.Parse(item.uri_path_glob()));
-        break;
-    }
-
-    // Validate the URI before processing
-    RETURN_NOT_OK(CheckFilePathUri(item_uri));
-
-    // Handle the URI as appropriate
-    switch (item.path_type_case()) {
-      case substrait::ReadRel::LocalFiles::FileOrFiles::kUriFile: {
-        files.emplace_back(item_uri.path(), fs::FileType::File);
-        break;
-      }
-
-      case substrait::ReadRel::LocalFiles::FileOrFiles::kUriFolder: {
-        RETURN_NOT_OK(DiscoverFilesFromDir(filesystem, item_uri.path(), files));
-        break;
-      }
-
-      case substrait::ReadRel::LocalFiles::FileOrFiles::kUriPath: {
-        // Let the filesystem API decide for us if the URI is a file or a directory
-        ARROW_ASSIGN_OR_RAISE(auto file_info, filesystem->GetFileInfo(item_uri.path()));
-
-        // push the FileInfo if it's a file; else, recurse into the directory
-        if (file_info.type() == fs::FileType::File) {
-          files.push_back(std::move(file_info));
-        } else if (file_info.type() == fs::FileType::Directory) {
-          RETURN_NOT_OK(DiscoverFilesFromDir(filesystem, item_uri.path(), files));
-        }
-
-        break;
-      }
-
-      case substrait::ReadRel::LocalFiles::FileOrFiles::kUriPathGlob: {
-        ARROW_ASSIGN_OR_RAISE(auto globbed_files,
-                              fs::internal::GlobFiles(filesystem, item_uri.path()));
-        std::move(globbed_files.begin(), globbed_files.end(), std::back_inserter(files));
-        break;
-      }
-
-      default: {
-        return Status::Invalid("Unrecognized file type in LocalFiles");
-      }
-    }
-  }
-
-  // Create a dataset via a dataset factory
-  ARROW_ASSIGN_OR_RAISE(auto ds_factory, dataset::FileSystemDatasetFactory::Make(
-                                             std::move(filesystem), std::move(files),
-                                             std::move(format), {}));
-
-  ARROW_ASSIGN_OR_RAISE(auto ds, ds_factory->Finish(base_schema));
-
-  DeclarationInfo scan_declaration{
-      compute::Declaration{"scan", dataset::ScanNodeOptions{ds, scan_options}},
-      base_schema};
-
-  return ProcessEmit(std::move(rel), std::move(scan_declaration),
-                     std::move(base_schema));
-}
-
 Result<DeclarationInfo> FromProto(const substrait::Rel& rel, const ExtensionSet& ext_set,
                                   const ConversionOptions& conversion_options) {
   static bool dataset_init = false;
@@ -334,10 +121,191 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel, const ExtensionSet&
 
   switch (rel.rel_type_case()) {
     case substrait::Rel::RelTypeCase::kRead: {
-      const auto& read_rel = rel.read();
-      RETURN_NOT_OK(CheckRelCommon(read_rel));
+      const auto& read = rel.read();
+      RETURN_NOT_OK(CheckRelCommon(read));
 
-      return FromReadRelation(read_rel, ext_set, conversion_options);
+      // Get the base schema for the read relation
+      ARROW_ASSIGN_OR_RAISE(auto base_schema,
+                            FromProto(read.base_schema(), ext_set, conversion_options));
+
+      auto scan_options = std::make_shared<dataset::ScanOptions>();
+      scan_options->use_threads = true;
+
+      if (read.has_filter()) {
+        ARROW_ASSIGN_OR_RAISE(scan_options->filter,
+                              FromProto(read.filter(), ext_set, conversion_options));
+      }
+
+      // NOTE: scan_options->projection is not used by the scanner and thus can't be used
+      if (read.has_projection()) {
+        return Status::NotImplemented("substrait::ReadRel::projection");
+      }
+
+      if (read.has_named_table()) {
+        if (!conversion_options.named_table_provider) {
+          return Status::Invalid(
+              "plan contained a named table but a NamedTableProvider has not been "
+              "configured");
+        }
+
+        if (read.named_table().names().empty()) {
+          return Status::Invalid("names for NamedTable not provided");
+        }
+
+        const NamedTableProvider& named_table_provider =
+            conversion_options.named_table_provider;
+        const substrait::ReadRel::NamedTable& named_table = read.named_table();
+        std::vector<std::string> table_names(named_table.names().begin(),
+                                             named_table.names().end());
+        ARROW_ASSIGN_OR_RAISE(compute::Declaration source_decl,
+                              named_table_provider(table_names));
+
+        if (!source_decl.IsValid()) {
+          return Status::Invalid("Invalid NamedTable Source");
+        }
+
+        return ProcessEmit(std::move(read),
+                           DeclarationInfo{std::move(source_decl), base_schema},
+                           std::move(base_schema));
+      }
+
+      if (!read.has_local_files()) {
+        return Status::NotImplemented(
+            "substrait::ReadRel with read_type other than LocalFiles");
+      }
+
+      if (read.local_files().has_advanced_extension()) {
+        return Status::NotImplemented(
+            "substrait::ReadRel::LocalFiles::advanced_extension");
+      }
+
+      std::shared_ptr<dataset::FileFormat> format;
+      auto filesystem = std::make_shared<fs::LocalFileSystem>();
+      std::vector<fs::FileInfo> files;
+
+      for (const auto& item : read.local_files().items()) {
+        // Validate properties of the `FileOrFiles` item
+        if (item.partition_index() != 0) {
+          return Status::NotImplemented(
+              "non-default substrait::ReadRel::LocalFiles::FileOrFiles::partition_index");
+        }
+
+        if (item.start() != 0) {
+          return Status::NotImplemented(
+              "non-default substrait::ReadRel::LocalFiles::FileOrFiles::start offset");
+        }
+
+        if (item.length() != 0) {
+          return Status::NotImplemented(
+              "non-default substrait::ReadRel::LocalFiles::FileOrFiles::length");
+        }
+
+        // Extract and parse the read relation's source URI
+        ::arrow::internal::Uri item_uri;
+        switch (item.path_type_case()) {
+          case substrait::ReadRel::LocalFiles::FileOrFiles::kUriPath:
+            RETURN_NOT_OK(item_uri.Parse(item.uri_path()));
+            break;
+
+          case substrait::ReadRel::LocalFiles::FileOrFiles::kUriFile:
+            RETURN_NOT_OK(item_uri.Parse(item.uri_file()));
+            break;
+
+          case substrait::ReadRel::LocalFiles::FileOrFiles::kUriFolder:
+            RETURN_NOT_OK(item_uri.Parse(item.uri_folder()));
+            break;
+
+          default:
+            RETURN_NOT_OK(item_uri.Parse(item.uri_path_glob()));
+            break;
+        }
+
+        // Validate the URI before processing
+        if (!item_uri.is_file_scheme()) {
+          return Status::NotImplemented("substrait::ReadRel::LocalFiles item (",
+                                        uri.ToString(),
+                                        ") with non-filesystem scheme (file:///)");
+        }
+
+        if (item_uri.port() != -1) {
+          return Status::NotImplemented("substrait::ReadRel::LocalFiles item (",
+                                        item_uri.ToString(),
+                                        ") should not have a port number in path");
+        }
+
+        if (!item_uri.query_string().empty()) {
+          return Status::NotImplemented("substrait::ReadRel::LocalFiles item (",
+                                        item_uri.ToString(),
+                                        ") should not have a query string in path");
+        }
+
+        switch (item.file_format_case()) {
+          case substrait::ReadRel::LocalFiles::FileOrFiles::kParquet:
+            format = std::make_shared<dataset::ParquetFileFormat>();
+            break;
+          case substrait::ReadRel::LocalFiles::FileOrFiles::kArrow:
+            format = std::make_shared<dataset::IpcFileFormat>();
+            break;
+          default:
+            // TODO: maybe check for ".feather" or ".arrows"?
+            return Status::NotImplemented(
+              "unsupported file format ",
+              "(see substrait::ReadRel::LocalFiles::FileOrFiles::file_format)");
+        }
+
+        // Handle the URI as appropriate
+        switch (item.path_type_case()) {
+          case substrait::ReadRel::LocalFiles::FileOrFiles::kUriFile: {
+            files.emplace_back(item_uri.path(), fs::FileType::File);
+            break;
+          }
+
+          case substrait::ReadRel::LocalFiles::FileOrFiles::kUriFolder: {
+            RETURN_NOT_OK(DiscoverFilesFromDir(filesystem, item_uri.path(), files));
+            break;
+          }
+
+          case substrait::ReadRel::LocalFiles::FileOrFiles::kUriPath: {
+            // Let the filesystem API decide for us if the URI is a file or a directory
+            ARROW_ASSIGN_OR_RAISE(auto file_info,
+                                  filesystem->GetFileInfo(item_uri.path()));
+
+            // push the FileInfo if it's a file; else, recurse into the directory
+            if (file_info.type() == fs::FileType::File) {
+              files.push_back(std::move(file_info));
+            } else if (file_info.type() == fs::FileType::Directory) {
+              RETURN_NOT_OK(DiscoverFilesFromDir(filesystem, item_uri.path(), files));
+            }
+
+            break;
+          }
+
+          case substrait::ReadRel::LocalFiles::FileOrFiles::kUriPathGlob: {
+            ARROW_ASSIGN_OR_RAISE(auto globbed_files,
+                                  fs::internal::GlobFiles(filesystem, item_uri.path()));
+            std::move(globbed_files.begin(), globbed_files.end(),
+                      std::back_inserter(files));
+            break;
+          }
+
+          default: {
+            return Status::Invalid("Unrecognized file type in LocalFiles");
+          }
+        }
+      }
+
+      ARROW_ASSIGN_OR_RAISE(auto ds_factory, dataset::FileSystemDatasetFactory::Make(
+                                                 std::move(filesystem), std::move(files),
+                                                 std::move(format), {}));
+
+      ARROW_ASSIGN_OR_RAISE(auto ds, ds_factory->Finish(base_schema));
+
+      DeclarationInfo scan_declaration{
+          compute::Declaration{"scan", dataset::ScanNodeOptions{ds, scan_options}},
+          base_schema};
+
+      return ProcessEmit(std::move(rel), std::move(scan_declaration),
+                         std::move(base_schema));
     }
 
     case substrait::Rel::RelTypeCase::kFilter: {

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -222,7 +222,7 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel, const ExtensionSet&
         // Validate the URI before processing
         if (!item_uri.is_file_scheme()) {
           return Status::NotImplemented("substrait::ReadRel::LocalFiles item (",
-                                        uri.ToString(),
+                                        item_uri.ToString(),
                                         ") with non-filesystem scheme (file:///)");
         }
 

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -96,7 +96,6 @@ Status CheckRelCommon(const RelMessage& rel) {
   return Status::OK();
 }
 
-// Other helper functions
 Status DiscoverFilesFromDir(const std::shared_ptr<fs::LocalFileSystem>& local_fs,
                             const std::string& dirpath,
                             std::vector<fs::FileInfo>* rel_fpaths) {

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -987,9 +987,6 @@ Result<std::string> GetSubstraitJSON() {
 }
 
 TEST(Substrait, DeserializeWithConsumerFactory) {
-#ifdef _WIN32
-  GTEST_SKIP() << "ARROW-16392: Substrait File URI not supported for Windows";
-#else
   ASSERT_OK_AND_ASSIGN(std::string substrait_json, GetSubstraitJSON());
   ASSERT_OK_AND_ASSIGN(auto buf, SerializeJsonPlan(substrait_json));
   ASSERT_OK_AND_ASSIGN(auto declarations,
@@ -1006,13 +1003,9 @@ TEST(Substrait, DeserializeWithConsumerFactory) {
 
   ASSERT_OK(plan->StartProducing());
   ASSERT_FINISHES_OK(plan->finished());
-#endif
 }
 
 TEST(Substrait, DeserializeSinglePlanWithConsumerFactory) {
-#ifdef _WIN32
-  GTEST_SKIP() << "ARROW-16392: Substrait File URI not supported for Windows";
-#else
   ASSERT_OK_AND_ASSIGN(std::string substrait_json, GetSubstraitJSON());
   ASSERT_OK_AND_ASSIGN(auto buf, SerializeJsonPlan(substrait_json));
   ASSERT_OK_AND_ASSIGN(std::shared_ptr<compute::ExecPlan> plan,
@@ -1026,13 +1019,9 @@ TEST(Substrait, DeserializeSinglePlanWithConsumerFactory) {
 
   ASSERT_OK(plan->StartProducing());
   ASSERT_FINISHES_OK(plan->finished());
-#endif
 }
 
 TEST(Substrait, DeserializeWithWriteOptionsFactory) {
-#ifdef _WIN32
-  GTEST_SKIP() << "ARROW-16392: Substrait File URI not supported for Windows";
-#else
   dataset::internal::Initialize();
   fs::TimePoint mock_now = std::chrono::system_clock::now();
   fs::FileInfo testdir = ::arrow::fs::Dir("testdir");
@@ -1069,7 +1058,6 @@ TEST(Substrait, DeserializeWithWriteOptionsFactory) {
 
   ASSERT_OK(plan->StartProducing());
   ASSERT_FINISHES_OK(plan->finished());
-#endif
 }
 
 static void test_with_registries(
@@ -1084,9 +1072,6 @@ static void test_with_registries(
 }
 
 TEST(Substrait, GetRecordBatchReader) {
-#ifdef _WIN32
-  GTEST_SKIP() << "ARROW-16392: Substrait File URI not supported for Windows";
-#else
   ASSERT_OK_AND_ASSIGN(std::string substrait_json, GetSubstraitJSON());
   test_with_registries([&substrait_json](ExtensionIdRegistry* ext_id_reg,
                                          compute::FunctionRegistry* func_registry) {
@@ -1097,7 +1082,6 @@ TEST(Substrait, GetRecordBatchReader) {
     // in case of a test failure, re-evalaute the content in the file
     EXPECT_EQ(table->num_rows(), 12);
   });
-#endif
 }
 
 TEST(Substrait, InvalidPlan) {

--- a/cpp/src/arrow/util/uri.cc
+++ b/cpp/src/arrow/util/uri.cc
@@ -151,6 +151,8 @@ Uri& Uri::operator=(Uri&& u) {
 
 std::string Uri::scheme() const { return TextRangeToString(impl_->uri_.scheme); }
 
+bool Uri::is_file_scheme() const { return impl_->is_file_uri_; }
+
 std::string Uri::host() const { return TextRangeToString(impl_->uri_.hostText); }
 
 bool Uri::has_host() const { return IsTextRangeSet(impl_->uri_.hostText); }

--- a/cpp/src/arrow/util/uri.h
+++ b/cpp/src/arrow/util/uri.h
@@ -45,6 +45,9 @@ class ARROW_EXPORT Uri {
   /// explicit scheme.
   std::string scheme() const;
 
+  /// Convenience function that returns true if the scheme() is "file"
+  bool is_file_scheme() const;
+
   /// Whether the URI has an explicit host name.  This may return true if
   /// the URI has an empty host (e.g. "file:///tmp/foo"), while it returns
   /// false is the URI has not host component at all (e.g. "file:/tmp/foo").

--- a/cpp/src/arrow/util/uri_test.cc
+++ b/cpp/src/arrow/util/uri_test.cc
@@ -293,13 +293,13 @@ TEST(Uri, FileScheme) {
   // Absolute paths
   // (no authority)
   check_file_no_host("file:/", "/");
-  check_file_no_host("file:/foo/bar", "/foo/bar");
+  check_file_no_host("file:/foo1/bar", "/foo1/bar");
   // (empty authority)
   check_file_no_host("file:///", "/");
-  check_file_no_host("file:///foo/bar", "/foo/bar");
+  check_file_no_host("file:///foo2/bar", "/foo2/bar");
   // (not file scheme)
   check_notfile_no_host("s3:/", "/");
-  check_notfile_no_host("s3:///foo/bar", "/foo/bar");
+  check_notfile_no_host("s3:///foo3/bar", "/foo3/bar");
   // (non-empty authority)
   check_file_with_host("file://localhost/", "localhost", "/");
   check_file_with_host("file://localhost/foo/bar", "localhost", "/foo/bar");
@@ -316,11 +316,11 @@ TEST(Uri, FileScheme) {
   check_file_no_host("file:/C:/", "C:/");
   check_file_no_host("file:/C:/foo/bar", "C:/foo/bar");
   // (empty authority)
-  check_file_no_host("file:///C:/", "C:/");
-  check_file_no_host("file:///C:/foo/bar", "C:/foo/bar");
-  // (not file scheme)
-  check_notfile_no_host("hive:///C:/", "C:/");
-  check_notfile_no_host("hive:/C:/foo/bar", "C:/foo/bar");
+  check_file_no_host("file:///D:/", "D:/");
+  check_file_no_host("file:///D:/foo/bar", "D:/foo/bar");
+  // (not file scheme; so slash is prepended)
+  check_notfile_no_host("hive:///E:/", "/E:/");
+  check_notfile_no_host("hive:/E:/foo/bar", "/E:/foo/bar");
   // (non-empty authority)
   check_file_with_host("file://server/share/", "server", "/share/");
   check_file_with_host("file://server/share/foo/bar", "server", "/share/foo/bar");

--- a/cpp/src/arrow/util/uri_test.cc
+++ b/cpp/src/arrow/util/uri_test.cc
@@ -257,6 +257,7 @@ TEST(Uri, FileScheme) {
 
   auto check_no_host = [&](std::string uri_string, std::string path) -> void {
     ASSERT_OK(uri.Parse(uri_string));
+    ASSERT_TRUE(uri.is_file_scheme());
     ASSERT_EQ(uri.scheme(), "file");
     ASSERT_EQ(uri.host(), "");
     ASSERT_EQ(uri.path(), path);
@@ -267,6 +268,7 @@ TEST(Uri, FileScheme) {
   auto check_with_host = [&](std::string uri_string, std::string host,
                              std::string path) -> void {
     ASSERT_OK(uri.Parse(uri_string));
+    ASSERT_TRUE(uri.is_file_scheme());
     ASSERT_EQ(uri.scheme(), "file");
     ASSERT_EQ(uri.host(), host);
     ASSERT_EQ(uri.path(), path);

--- a/cpp/src/arrow/util/uri_test.cc
+++ b/cpp/src/arrow/util/uri_test.cc
@@ -255,7 +255,7 @@ TEST(Uri, FileScheme) {
   // https://tools.ietf.org/html/rfc8089
   Uri uri;
 
-  auto check_no_host = [&](std::string uri_string, std::string path) -> void {
+  auto check_file_no_host = [&](std::string uri_string, std::string path) -> void {
     ASSERT_OK(uri.Parse(uri_string));
     ASSERT_TRUE(uri.is_file_scheme());
     ASSERT_EQ(uri.scheme(), "file");
@@ -265,8 +265,18 @@ TEST(Uri, FileScheme) {
     ASSERT_EQ(uri.password(), "");
   };
 
-  auto check_with_host = [&](std::string uri_string, std::string host,
-                             std::string path) -> void {
+  auto check_notfile_no_host = [&](std::string uri_string, std::string path) -> void {
+    ASSERT_OK(uri.Parse(uri_string));
+    ASSERT_FALSE(uri.is_file_scheme());
+    ASSERT_NE(uri.scheme(), "file");
+    ASSERT_EQ(uri.host(), "");
+    ASSERT_EQ(uri.path(), path);
+    ASSERT_EQ(uri.username(), "");
+    ASSERT_EQ(uri.password(), "");
+  };
+
+  auto check_file_with_host = [&](std::string uri_string, std::string host,
+                                  std::string path) -> void {
     ASSERT_OK(uri.Parse(uri_string));
     ASSERT_TRUE(uri.is_file_scheme());
     ASSERT_EQ(uri.scheme(), "file");
@@ -282,16 +292,19 @@ TEST(Uri, FileScheme) {
 
   // Absolute paths
   // (no authority)
-  check_no_host("file:/", "/");
-  check_no_host("file:/foo/bar", "/foo/bar");
+  check_file_no_host("file:/", "/");
+  check_file_no_host("file:/foo/bar", "/foo/bar");
   // (empty authority)
-  check_no_host("file:///", "/");
-  check_no_host("file:///foo/bar", "/foo/bar");
+  check_file_no_host("file:///", "/");
+  check_file_no_host("file:///foo/bar", "/foo/bar");
+  // (not file scheme)
+  check_notfile_no_host("s3:/", "/");
+  check_notfile_no_host("s3:///foo/bar", "/foo/bar");
   // (non-empty authority)
-  check_with_host("file://localhost/", "localhost", "/");
-  check_with_host("file://localhost/foo/bar", "localhost", "/foo/bar");
-  check_with_host("file://hostname.com/", "hostname.com", "/");
-  check_with_host("file://hostname.com/foo/bar", "hostname.com", "/foo/bar");
+  check_file_with_host("file://localhost/", "localhost", "/");
+  check_file_with_host("file://localhost/foo/bar", "localhost", "/foo/bar");
+  check_file_with_host("file://hostname.com/", "hostname.com", "/");
+  check_file_with_host("file://hostname.com/foo/bar", "hostname.com", "/foo/bar");
 
 #ifdef _WIN32
   // Relative paths
@@ -300,14 +313,17 @@ TEST(Uri, FileScheme) {
 
   // Absolute paths
   // (no authority)
-  check_no_host("file:/C:/", "C:/");
-  check_no_host("file:/C:/foo/bar", "C:/foo/bar");
+  check_file_no_host("file:/C:/", "C:/");
+  check_file_no_host("file:/C:/foo/bar", "C:/foo/bar");
   // (empty authority)
-  check_no_host("file:///C:/", "C:/");
-  check_no_host("file:///C:/foo/bar", "C:/foo/bar");
+  check_file_no_host("file:///C:/", "C:/");
+  check_file_no_host("file:///C:/foo/bar", "C:/foo/bar");
+  // (not file scheme)
+  check_notfile_no_host("hive:///C:/", "C:/");
+  check_notfile_no_host("hive:/C:/foo/bar", "C:/foo/bar");
   // (non-empty authority)
-  check_with_host("file://server/share/", "server", "/share/");
-  check_with_host("file://server/share/foo/bar", "server", "/share/foo/bar");
+  check_file_with_host("file://server/share/", "server", "/share/");
+  check_file_with_host("file://server/share/foo/bar", "server", "/share/foo/bar");
 #endif
 }
 

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -16,7 +16,6 @@
 # under the License.
 
 import os
-import sys
 import pytest
 
 import pyarrow as pa

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -40,9 +40,6 @@ def _write_dummy_data_to_disk(tmpdir, file_name, table):
     return path
 
 
-@pytest.mark.skipif(sys.platform == 'win32',
-                    reason="ARROW-16392: file based URI is" +
-                    " not fully supported for Windows")
 def test_run_serialized_query(tmpdir):
     substrait_query = """
     {
@@ -115,9 +112,6 @@ def test_invalid_plan():
         substrait.run_query(buf)
 
 
-@pytest.mark.skipif(sys.platform == 'win32',
-                    reason="ARROW-16392: file based URI is" +
-                    " not fully supported for Windows")
 def test_binary_conversion_with_json_options(tmpdir):
     substrait_query = """
     {


### PR DESCRIPTION
A PR to subsume #13390

I tried to add on to #13390, but then I rebased and now it seems really complicated to add to that PR.

This PR primarily uses `Uri` to parse file URIs extracted from `substrait::ReadRel`. This occurs when `FromProto` is called on a `Relation` that is a read type (`ReadRel`). Additionally, to make `FromProto` a bit more readable, I moved the code for this case into a separate function, `FromReadRelation`. This function has the following overall flow:

1. Validate ReadRel
2. Initialize FileFormat from the 1st file URI
3. foreach file URI:
    1. Validate the proto URI
    2. Parse using the Uri class
    3. Validate the Uri (should be a `file:///` path)
    4. Accumulate `FileInfo` instances using `LocalFileSystem`
4. return DeclarationInfo for dataset scan over the file URIs


Validation functions are prefixed with `Check` to match `CheckRelCommon`.