### PR TITLE
ARROW-6459: [C++] Remove "python" from conda_env_cpp.txt

### DIFF
--- a/ci/conda_env_cpp.txt
+++ b/ci/conda_env_cpp.txt
@@ -38,7 +38,6 @@ ninja
 #    https://github.com/conda-forge/google-cloud-cpp-feedstock/issues/28
 nlohmann_json
 pkg-config
-python
 rapidjson
 re2
 snappy


### PR DESCRIPTION
This PR tries to remove python from the dependency list for cpp CI builds.

There is also a question of keeping Python as a dependency in the Arrow C++ for linting purposes, see https://github.com/apache/arrow/blob/47314c3999d7b7a7f9167c6ed6793da756c411a1/cpp/CMakeLists.txt#L179-L192