### PR TITLE
ARROW-17579: [Python] PYARROW_CXXFLAGS ignored?

### DIFF
--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2613,7 +2613,7 @@ def register_scalar_function(func, function_name, function_doc, in_types,
         raise TypeError(
             "in_types must be a dictionary of DataType")
 
-    c_arity = CArity(num_args, func_spec.varargs)
+    c_arity = CArity(<int> num_args, func_spec.varargs)
 
     if "summary" not in function_doc:
         raise ValueError("Function doc must contain a summary")

--- a/python/pyarrow/src/CMakeLists.txt
+++ b/python/pyarrow/src/CMakeLists.txt
@@ -196,6 +196,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Needed compiler flags
 include(SetupCxxFlags)
 
+# Add common flags
+set(CMAKE_CXX_FLAGS "${CXX_COMMON_FLAGS} ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${PYARROW_CXXFLAGS}")
+
 message(STATUS "CMAKE_C_FLAGS: ${CMAKE_C_FLAGS}")
 message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -259,6 +259,7 @@ class build_ext(_build_ext):
                 '-DCMAKE_INSTALL_PREFIX=' + str(pyarrow_cpp_home),
                 '-DPYTHON_EXECUTABLE=' + str(sys.executable),
                 '-DPython3_EXECUTABLE=' + str(sys.executable),
+                '-DPYARROW_CXXFLAGS=' + str(self.cmake_cxxflags),
             ]
 
             # Check for specific options
@@ -337,9 +338,10 @@ class build_ext(_build_ext):
             static_lib_option = ''
 
             cmake_options = [
-                '-DPYTHON_EXECUTABLE=%s' % sys.executable,
-                '-DPython3_EXECUTABLE=%s' % sys.executable,
+                '-DPYTHON_EXECUTABLE=' + str(sys.executable),
+                '-DPython3_EXECUTABLE=' + str(sys.executable),
                 '-DPYARROW_CPP_HOME=' + str(pyarrow_cpp_home),
+                '-DPYARROW_CXXFLAGS=' + str(self.cmake_cxxflags),
                 static_lib_option,
             ]
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -257,8 +257,8 @@ class build_ext(_build_ext):
                 '-DCMAKE_BUILD_TYPE=' + str(self.build_type.lower()),
                 '-DCMAKE_INSTALL_LIBDIR=lib',
                 '-DCMAKE_INSTALL_PREFIX=' + str(pyarrow_cpp_home),
-                '-DPYTHON_EXECUTABLE=' + str(sys.executable),
-                '-DPython3_EXECUTABLE=' + str(sys.executable),
+                '-DPYTHON_EXECUTABLE=' + sys.executable,
+                '-DPython3_EXECUTABLE=' + sys.executable,
                 '-DPYARROW_CXXFLAGS=' + str(self.cmake_cxxflags),
             ]
 
@@ -338,8 +338,8 @@ class build_ext(_build_ext):
             static_lib_option = ''
 
             cmake_options = [
-                '-DPYTHON_EXECUTABLE=' + str(sys.executable),
-                '-DPython3_EXECUTABLE=' + str(sys.executable),
+                '-DPYTHON_EXECUTABLE=' + sys.executable,
+                '-DPython3_EXECUTABLE=' + sys.executable,
                 '-DPYARROW_CPP_HOME=' + str(pyarrow_cpp_home),
                 '-DPYARROW_CXXFLAGS=' + str(self.cmake_cxxflags),
                 static_lib_option,


### PR DESCRIPTION
This PR adds:
- `PYARROW_CXXFLAGS` variable to PyArrow C++ and Pyarrow cmake builds (both defined in `setup.py`)
- a common flags section to `pyarrow/src/CMakeLists.txt` where `CXX_COMMON_FLAGS` and `PYARROW_CXXFLAGS` are added to the `CMAKE_CXX_FLAGS` variable.

Other flags defined in Arrow C++ should be included in PyArrow C++ and PyArrow with `include(SetupCxxFlags)`.

I am not sure if additional flags that are defined in PyArrow, see: https://github.com/apache/arrow/blob/43670af02f0913580fd20e26006fd550d6fdf2da/python/CMakeLists.txt#L134-L174 are needed in PyArrow C++ as they were not used when PyArrow C++ was included in Arrow C++?
cc @pitrou 