### PR TITLE
ARROW-16870: [C++] Fix link issues with ldd and clang for flight examples

### DIFF
--- a/cpp/examples/arrow/CMakeLists.txt
+++ b/cpp/examples/arrow/CMakeLists.txt
@@ -36,10 +36,14 @@ if(ARROW_FLIGHT)
   # we'll violate ODR for gRPC symbols
   if(ARROW_GRPC_USE_SHARED)
     set(FLIGHT_EXAMPLES_LINK_LIBS arrow_flight_shared)
-    # We don't directly use symbols from the reflection library, so
-    # ensure the linker still links to it
-    set(GRPC_REFLECTION_LINK_LIBS -Wl,--no-as-needed gRPC::grpc++_reflection
-                                  -Wl,--as-needed)
+    if(APPLE)
+      set(GRPC_REFLECTION_LINK_LIBS gRPC::grpc++_reflection)
+    else()
+      # We don't directly use symbols from the reflection library, so
+      # ensure the linker still links to it
+      set(GRPC_REFLECTION_LINK_LIBS -Wl,--no-as-needed gRPC::grpc++_reflection
+                                    -Wl,--as-needed)
+    endif()
   elseif(NOT ARROW_BUILD_STATIC)
     message(FATAL_ERROR "Statically built gRPC requires ARROW_BUILD_STATIC=ON")
   else()


### PR DESCRIPTION
It seems `ldd` doesn't like this flag `--no-as-needed`, so the arrow flight example cannot build on macOS with clang. This minor PR tries to fix that.
I was able to build the arrow flight example and run without issues:
`./flight-grpc-example -port 8086`
Notes:
```bash
clang++ --version
Apple clang version 14.0.0 (clang-1400.0.29.102)
```