### PR TITLE
ARROW-17631: [Java] Propagate table/columns comments into Arrow Schema

### DIFF
--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/Constants.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/Constants.java
@@ -27,5 +27,6 @@ public class Constants {
   public static final String SQL_TABLE_NAME_KEY = "SQL_TABLE_NAME";
   public static final String SQL_COLUMN_NAME_KEY = "SQL_COLUMN_NAME";
   public static final String SQL_TYPE_KEY = "SQL_TYPE";
+  public static final String COMMENT = "comment";
 
 }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/Constants.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/Constants.java
@@ -27,6 +27,5 @@ public class Constants {
   public static final String SQL_TABLE_NAME_KEY = "SQL_TABLE_NAME";
   public static final String SQL_COLUMN_NAME_KEY = "SQL_COLUMN_NAME";
   public static final String SQL_TYPE_KEY = "SQL_TYPE";
-  public static final String COMMENT = "comment";
 
 }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfig.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfig.java
@@ -60,6 +60,8 @@ public final class JdbcToArrowConfig {
   private final Map<String, JdbcFieldInfo> arraySubTypesByColumnName;
   private final Map<Integer, JdbcFieldInfo> explicitTypesByColumnIndex;
   private final Map<String, JdbcFieldInfo> explicitTypesByColumnName;
+  private final String schemaComment;
+  private final Map<Integer, String> columnCommentByColumnIndex;
   private final RoundingMode bigDecimalRoundingMode;
   /**
    * The maximum rowCount to read each time when partially convert data.
@@ -174,6 +176,8 @@ public final class JdbcToArrowConfig {
         jdbcToArrowTypeConverter,
         null,
         null,
+        null,
+        null,
         bigDecimalRoundingMode);
   }
 
@@ -188,6 +192,8 @@ public final class JdbcToArrowConfig {
       Function<JdbcFieldInfo, ArrowType> jdbcToArrowTypeConverter,
       Map<Integer, JdbcFieldInfo> explicitTypesByColumnIndex,
       Map<String, JdbcFieldInfo> explicitTypesByColumnName,
+      String schemaComment,
+      Map<Integer, String> columnCommentByColumnIndex,
       RoundingMode bigDecimalRoundingMode) {
     Preconditions.checkNotNull(allocator, "Memory allocator cannot be null");
     this.allocator = allocator;
@@ -199,6 +205,8 @@ public final class JdbcToArrowConfig {
     this.targetBatchSize = targetBatchSize;
     this.explicitTypesByColumnIndex = explicitTypesByColumnIndex;
     this.explicitTypesByColumnName = explicitTypesByColumnName;
+    this.schemaComment = schemaComment;
+    this.columnCommentByColumnIndex = columnCommentByColumnIndex;
     this.bigDecimalRoundingMode = bigDecimalRoundingMode;
 
     // set up type converter
@@ -310,6 +318,21 @@ public final class JdbcToArrowConfig {
     } else {
       return explicitTypesByColumnName.get(name);
     }
+  }
+
+  /**
+   * Return schema level comment or null if not provided.
+   */
+  public String getSchemaComment() {
+    return schemaComment;
+  }
+
+  /**
+   * Return comment from columnIndex->comment map to metadata 'comment' entry on per field basis
+   * or null if not provided.
+   */
+  public Map<Integer, String> getColumnCommentByColumnIndex() {
+    return columnCommentByColumnIndex;
   }
 
   public RoundingMode getBigDecimalRoundingMode() {

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfig.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfig.java
@@ -60,8 +60,8 @@ public final class JdbcToArrowConfig {
   private final Map<String, JdbcFieldInfo> arraySubTypesByColumnName;
   private final Map<Integer, JdbcFieldInfo> explicitTypesByColumnIndex;
   private final Map<String, JdbcFieldInfo> explicitTypesByColumnName;
-  private final String schemaComment;
-  private final Map<Integer, String> columnCommentByColumnIndex;
+  private final Map<String, String> schemaMetadata;
+  private final Map<Integer, Map<String, String>> columnMetadataByColumnIndex;
   private final RoundingMode bigDecimalRoundingMode;
   /**
    * The maximum rowCount to read each time when partially convert data.
@@ -192,8 +192,8 @@ public final class JdbcToArrowConfig {
       Function<JdbcFieldInfo, ArrowType> jdbcToArrowTypeConverter,
       Map<Integer, JdbcFieldInfo> explicitTypesByColumnIndex,
       Map<String, JdbcFieldInfo> explicitTypesByColumnName,
-      String schemaComment,
-      Map<Integer, String> columnCommentByColumnIndex,
+      Map<String, String> schemaMetadata,
+      Map<Integer, Map<String, String>> columnMetadataByColumnIndex,
       RoundingMode bigDecimalRoundingMode) {
     Preconditions.checkNotNull(allocator, "Memory allocator cannot be null");
     this.allocator = allocator;
@@ -205,8 +205,8 @@ public final class JdbcToArrowConfig {
     this.targetBatchSize = targetBatchSize;
     this.explicitTypesByColumnIndex = explicitTypesByColumnIndex;
     this.explicitTypesByColumnName = explicitTypesByColumnName;
-    this.schemaComment = schemaComment;
-    this.columnCommentByColumnIndex = columnCommentByColumnIndex;
+    this.schemaMetadata = schemaMetadata;
+    this.columnMetadataByColumnIndex = columnMetadataByColumnIndex;
     this.bigDecimalRoundingMode = bigDecimalRoundingMode;
 
     // set up type converter
@@ -323,16 +323,16 @@ public final class JdbcToArrowConfig {
   /**
    * Return schema level comment or null if not provided.
    */
-  public String getSchemaComment() {
-    return schemaComment;
+  public Map<String, String> getSchemaMetadata() {
+    return schemaMetadata;
   }
 
   /**
    * Return comment from columnIndex->comment map to metadata 'comment' entry on per field basis
    * or null if not provided.
    */
-  public Map<Integer, String> getColumnCommentByColumnIndex() {
-    return columnCommentByColumnIndex;
+  public Map<Integer, Map<String, String>> getColumnMetadataByColumnIndex() {
+    return columnMetadataByColumnIndex;
   }
 
   public RoundingMode getBigDecimalRoundingMode() {

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfig.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfig.java
@@ -321,14 +321,14 @@ public final class JdbcToArrowConfig {
   }
 
   /**
-   * Return schema level comment or null if not provided.
+   * Return schema level metadata or null if not provided.
    */
   public Map<String, String> getSchemaMetadata() {
     return schemaMetadata;
   }
 
   /**
-   * Return comment from columnIndex->comment map to metadata 'comment' entry on per field basis
+   * Return metadata from columnIndex->meta map on per field basis
    * or null if not provided.
    */
   public Map<Integer, Map<String, String>> getColumnMetadataByColumnIndex() {

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigBuilder.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigBuilder.java
@@ -40,6 +40,8 @@ public class JdbcToArrowConfigBuilder {
   private Map<String, JdbcFieldInfo> arraySubTypesByColumnName;
   private Map<Integer, JdbcFieldInfo> explicitTypesByColumnIndex;
   private Map<String, JdbcFieldInfo> explicitTypesByColumnName;
+  private String schemaComment;
+  private Map<Integer, String> columnCommentByColumnIndex;
   private int targetBatchSize;
   private Function<JdbcFieldInfo, ArrowType> jdbcToArrowTypeConverter;
   private RoundingMode bigDecimalRoundingMode;
@@ -58,6 +60,8 @@ public class JdbcToArrowConfigBuilder {
     this.arraySubTypesByColumnName = null;
     this.explicitTypesByColumnIndex = null;
     this.explicitTypesByColumnName = null;
+    this.schemaComment = null;
+    this.columnCommentByColumnIndex = null;
     this.bigDecimalRoundingMode = null;
   }
 
@@ -227,6 +231,22 @@ public class JdbcToArrowConfigBuilder {
   }
 
   /**
+   * Set comment for schema as metadata 'comment' entry.
+   */
+  public JdbcToArrowConfigBuilder setSchemaComment(String schemaComment) {
+    this.schemaComment = schemaComment;
+    return this;
+  }
+
+  /**
+   * Set comment from columnIndex->comment map to metadata 'comment' entry on per field basis.
+   */
+  public JdbcToArrowConfigBuilder setColumnCommentByColumnIndex(Map<Integer, String> columnCommentByColumnIndex) {
+    this.columnCommentByColumnIndex = columnCommentByColumnIndex;
+    return this;
+  }
+
+  /**
    * Set the rounding mode used when the scale of the actual value does not match the declared scale.
    * <p>
    * By default, an error is raised in such cases.
@@ -255,6 +275,8 @@ public class JdbcToArrowConfigBuilder {
         jdbcToArrowTypeConverter,
         explicitTypesByColumnIndex,
         explicitTypesByColumnName,
+        schemaComment,
+        columnCommentByColumnIndex,
         bigDecimalRoundingMode);
   }
 }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigBuilder.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigBuilder.java
@@ -40,8 +40,8 @@ public class JdbcToArrowConfigBuilder {
   private Map<String, JdbcFieldInfo> arraySubTypesByColumnName;
   private Map<Integer, JdbcFieldInfo> explicitTypesByColumnIndex;
   private Map<String, JdbcFieldInfo> explicitTypesByColumnName;
-  private String schemaComment;
-  private Map<Integer, String> columnCommentByColumnIndex;
+  private Map<String, String> schemaMetadata;
+  private Map<Integer, Map<String, String>> columnMetadataByColumnIndex;
   private int targetBatchSize;
   private Function<JdbcFieldInfo, ArrowType> jdbcToArrowTypeConverter;
   private RoundingMode bigDecimalRoundingMode;
@@ -60,8 +60,8 @@ public class JdbcToArrowConfigBuilder {
     this.arraySubTypesByColumnName = null;
     this.explicitTypesByColumnIndex = null;
     this.explicitTypesByColumnName = null;
-    this.schemaComment = null;
-    this.columnCommentByColumnIndex = null;
+    this.schemaMetadata = null;
+    this.columnMetadataByColumnIndex = null;
     this.bigDecimalRoundingMode = null;
   }
 
@@ -233,16 +233,17 @@ public class JdbcToArrowConfigBuilder {
   /**
    * Set comment for schema as metadata 'comment' entry.
    */
-  public JdbcToArrowConfigBuilder setSchemaComment(String schemaComment) {
-    this.schemaComment = schemaComment;
+  public JdbcToArrowConfigBuilder setSchemaComment(Map<String, String> schemaMetadata) {
+    this.schemaMetadata = schemaMetadata;
     return this;
   }
 
   /**
    * Set comment from columnIndex->comment map to metadata 'comment' entry on per field basis.
    */
-  public JdbcToArrowConfigBuilder setColumnCommentByColumnIndex(Map<Integer, String> columnCommentByColumnIndex) {
-    this.columnCommentByColumnIndex = columnCommentByColumnIndex;
+  public JdbcToArrowConfigBuilder setColumnCommentByColumnIndex(
+          Map<Integer, Map<String, String>> columnMetadataByColumnIndex) {
+    this.columnMetadataByColumnIndex = columnMetadataByColumnIndex;
     return this;
   }
 
@@ -275,8 +276,8 @@ public class JdbcToArrowConfigBuilder {
         jdbcToArrowTypeConverter,
         explicitTypesByColumnIndex,
         explicitTypesByColumnName,
-        schemaComment,
-        columnCommentByColumnIndex,
+        schemaMetadata,
+        columnMetadataByColumnIndex,
         bigDecimalRoundingMode);
   }
 }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigBuilder.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigBuilder.java
@@ -231,17 +231,17 @@ public class JdbcToArrowConfigBuilder {
   }
 
   /**
-   * Set comment for schema as metadata 'comment' entry.
+   * Set metadata for schema.
    */
-  public JdbcToArrowConfigBuilder setSchemaComment(Map<String, String> schemaMetadata) {
+  public JdbcToArrowConfigBuilder setSchemaMetadata(Map<String, String> schemaMetadata) {
     this.schemaMetadata = schemaMetadata;
     return this;
   }
 
   /**
-   * Set comment from columnIndex->comment map to metadata 'comment' entry on per field basis.
+   * Set metadata from columnIndex->meta map on per field basis.
    */
-  public JdbcToArrowConfigBuilder setColumnCommentByColumnIndex(
+  public JdbcToArrowConfigBuilder setColumnMetadataByColumnIndex(
           Map<Integer, Map<String, String>> columnMetadataByColumnIndex) {
     this.columnMetadataByColumnIndex = columnMetadataByColumnIndex;
     return this;

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
@@ -284,14 +284,7 @@ public class JdbcToArrowUtils {
         fields.add(new Field(columnName, fieldType, children));
       }
     }
-
-    final Map<String, String> schemaMetadata;
-    if (config.getSchemaMetadata() != null && !config.getSchemaMetadata().isEmpty()) {
-      schemaMetadata = config.getSchemaMetadata();
-    } else {
-      schemaMetadata = null;
-    }
-    return new Schema(fields, schemaMetadata);
+    return new Schema(fields, config.getSchemaMetadata());
   }
 
   static JdbcFieldInfo getJdbcFieldInfoForColumn(

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
@@ -244,8 +244,8 @@ public class JdbcToArrowUtils {
     for (int i = 1; i <= columnCount; i++) {
       final String columnName = rsmd.getColumnLabel(i);
 
-      final String columnComment = config.getColumnCommentByColumnIndex() != null ?
-              config.getColumnCommentByColumnIndex().get(i) : null;
+      final Map<String, String> columnMetadata = config.getColumnMetadataByColumnIndex() != null ?
+              config.getColumnMetadataByColumnIndex().get(i) : null;
       final Map<String, String> metadata;
       if (config.shouldIncludeMetadata()) {
         metadata = new HashMap<>();
@@ -253,13 +253,12 @@ public class JdbcToArrowUtils {
         metadata.put(Constants.SQL_TABLE_NAME_KEY, rsmd.getTableName(i));
         metadata.put(Constants.SQL_COLUMN_NAME_KEY, columnName);
         metadata.put(Constants.SQL_TYPE_KEY, rsmd.getColumnTypeName(i));
-        if (columnComment != null && !columnComment.isEmpty()) {
-          metadata.put(Constants.COMMENT, columnComment);
+        if (columnMetadata != null && !columnMetadata.isEmpty()) {
+          metadata.putAll(columnMetadata);
         }
       } else {
-        if (columnComment != null && !columnComment.isEmpty()) {
-          metadata = new HashMap<>();
-          metadata.put(Constants.COMMENT, columnComment);
+        if (columnMetadata != null && !columnMetadata.isEmpty()) {
+          metadata = columnMetadata;
         } else {
           metadata = null;
         }
@@ -287,9 +286,8 @@ public class JdbcToArrowUtils {
     }
 
     final Map<String, String> schemaMetadata;
-    if (config.getSchemaComment() != null && !config.getSchemaComment().isEmpty()) {
-      schemaMetadata = new HashMap<>();
-      schemaMetadata.put(Constants.COMMENT, config.getSchemaComment());
+    if (config.getSchemaMetadata() != null && !config.getSchemaMetadata().isEmpty()) {
+      schemaMetadata = config.getSchemaMetadata();
     } else {
       schemaMetadata = null;
     }

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowCommentMetadataTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowCommentMetadataTest.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.adapter.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.arrow.vector.util.ObjectMapperFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectWriter;
+
+public class JdbcToArrowCommentMetadataTest {
+
+  private final ObjectWriter schemaSerializer = ObjectMapperFactory.newObjectMapper().writerWithDefaultPrettyPrinter();
+  private Connection conn = null;
+
+  /**
+   * This method creates Connection object and DB table and also populate data into table for test.
+   *
+   * @throws SQLException on error
+   * @throws ClassNotFoundException on error
+   */
+  @Before
+  public void setUp() throws SQLException, ClassNotFoundException {
+    String url = "jdbc:h2:mem:JdbcToArrowTest?characterEncoding=UTF-8;INIT=runscript from 'classpath:/h2/comment.sql'";
+    String driver = "org.h2.Driver";
+    Class.forName(driver);
+    conn = DriverManager.getConnection(url);
+  }
+
+  @After
+  public void tearDown() throws SQLException {
+    if (conn != null) {
+      conn.close();
+      conn = null;
+    }
+  }
+
+  @Test
+  public void schemaComment() throws Exception {
+    boolean includeMetadata = false;
+    String schemaJson = schemaSerializer.writeValueAsString(getSchemaWithCommentFromQuery(includeMetadata));
+    String expectedSchema = getExpectedSchema("/h2/expectedSchemaWithComments.json");
+    assertThat(schemaJson).isEqualTo(expectedSchema);
+  }
+
+  @Test
+  public void schemaCommentWithDatabaseMetadata() throws Exception {
+    boolean includeMetadata = true;
+    String schemaJson = schemaSerializer.writeValueAsString(getSchemaWithCommentFromQuery(includeMetadata));
+    String expectedSchema = getExpectedSchema("/h2/expectedSchemaWithCommentsAndJdbcMeta.json");
+    assertThat(schemaJson).isEqualTo(expectedSchema);
+  }
+
+  private Schema getSchemaWithCommentFromQuery(boolean includeMetadata) throws SQLException {
+    DatabaseMetaData metaData = conn.getMetaData();
+    try (Statement statement = conn.createStatement()) {
+      try (ResultSet resultSet = statement.executeQuery("select * from table1")) {
+        ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
+        Map<Integer, String> columnCommentByColumnIndex = getColumnComments(metaData, resultSetMetaData);
+
+        final String tableComment = getTableComment(metaData, "TABLE1");
+        JdbcToArrowConfig config = new JdbcToArrowConfigBuilder()
+                .setAllocator(new RootAllocator()).setSchemaComment(tableComment)
+                .setColumnCommentByColumnIndex(columnCommentByColumnIndex).setIncludeMetadata(includeMetadata).build();
+        return JdbcToArrowUtils.jdbcToArrowSchema(resultSetMetaData, config);
+      }
+    }
+  }
+
+  private Map<Integer, String> getColumnComments(DatabaseMetaData metaData,
+                                                 ResultSetMetaData resultSetMetaData) throws SQLException {
+    Map<Integer, String> columnCommentByColumnIndex = new HashMap<>();
+    for (int columnIdx = 1, columnCount = resultSetMetaData.getColumnCount(); columnIdx <= columnCount; columnIdx++) {
+      String columnComment = getColumnComment(metaData, resultSetMetaData.getTableName(columnIdx),
+              resultSetMetaData.getColumnName(columnIdx));
+      if (columnComment != null && !columnComment.isEmpty()) {
+        columnCommentByColumnIndex.put(columnIdx, columnComment);
+      }
+    }
+    return columnCommentByColumnIndex;
+  }
+
+  private String getTableComment(DatabaseMetaData metaData, String tableName) throws SQLException {
+    try (ResultSet tableMetadata = metaData.getTables("%", "%", tableName, null)) {
+      if (tableMetadata.next()) {
+        return tableMetadata.getString("REMARKS");
+      }
+    }
+    throw new RuntimeException("Table comment not found");
+  }
+
+  private String getColumnComment(DatabaseMetaData metaData, String tableName, String columnName) throws SQLException {
+    try (ResultSet tableMetadata = metaData.getColumns("%", "%", tableName, columnName)) {
+      if (tableMetadata.next()) {
+        return tableMetadata.getString("REMARKS");
+      }
+    }
+    return null;
+  }
+
+  private String getExpectedSchema(String expectedResource) throws java.io.IOException, java.net.URISyntaxException {
+    return new String(Files.readAllBytes(Paths.get(Objects.requireNonNull(
+            JdbcToArrowCommentMetadataTest.class.getResource(expectedResource)).toURI())), StandardCharsets.UTF_8);
+  }
+}

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowCommentMetadataTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowCommentMetadataTest.java
@@ -105,8 +105,8 @@ public class JdbcToArrowCommentMetadataTest {
         String tableName = getTableNameFromResultSetMetaData(resultSetMetaData);
         String tableComment = getTableComment(metaData, tableName);
         JdbcToArrowConfig config = new JdbcToArrowConfigBuilder()
-                .setAllocator(new RootAllocator()).setSchemaComment(Collections.singletonMap(COMMENT, tableComment))
-                .setColumnCommentByColumnIndex(columnCommentByColumnIndex).setIncludeMetadata(includeMetadata).build();
+                .setAllocator(new RootAllocator()).setSchemaMetadata(Collections.singletonMap(COMMENT, tableComment))
+                .setColumnMetadataByColumnIndex(columnCommentByColumnIndex).setIncludeMetadata(includeMetadata).build();
         return JdbcToArrowUtils.jdbcToArrowSchema(resultSetMetaData, config);
       }
     }

--- a/java/adapter/jdbc/src/test/resources/h2/comment.sql
+++ b/java/adapter/jdbc/src/test/resources/h2/comment.sql
@@ -1,0 +1,11 @@
+create table table1(
+  id bigint auto_increment primary key,
+  name varchar(255),
+  column1 boolean,
+  columnN int
+  );
+
+COMMENT ON TABLE table1 IS 'This is super special table with valuable data';
+COMMENT ON COLUMN table1.id IS 'Record identifier';
+COMMENT ON COLUMN table1.name IS 'Name of record';
+COMMENT ON COLUMN table1.columnN IS 'Informative description of columnN';

--- a/java/adapter/jdbc/src/test/resources/h2/comment.sql
+++ b/java/adapter/jdbc/src/test/resources/h2/comment.sql
@@ -1,5 +1,5 @@
 create table table1(
-  id bigint auto_increment primary key,
+  id bigint primary key,
   name varchar(255),
   column1 boolean,
   columnN int

--- a/java/adapter/jdbc/src/test/resources/h2/comment.sql
+++ b/java/adapter/jdbc/src/test/resources/h2/comment.sql
@@ -1,3 +1,13 @@
+--Licensed to the Apache Software Foundation (ASF) under one or more contributor
+--license agreements. See the NOTICE file distributed with this work for additional
+--information regarding copyright ownership. The ASF licenses this file to
+--You under the Apache License, Version 2.0 (the "License"); you may not use
+--this file except in compliance with the License. You may obtain a copy of
+--the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required
+--by applicable law or agreed to in writing, software distributed under the
+--License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+--OF ANY KIND, either express or implied. See the License for the specific
+--language governing permissions and limitations under the License.
 create table table1(
   id bigint primary key,
   name varchar(255),

--- a/java/adapter/jdbc/src/test/resources/h2/expectedSchemaWithComments.json
+++ b/java/adapter/jdbc/src/test/resources/h2/expectedSchemaWithComments.json
@@ -1,0 +1,51 @@
+{
+  "fields" : [ {
+    "name" : "ID",
+    "nullable" : false,
+    "type" : {
+      "name" : "int",
+      "bitWidth" : 64,
+      "isSigned" : true
+    },
+    "children" : [ ],
+    "metadata" : [ {
+      "value" : "Record identifier",
+      "key" : "comment"
+    } ]
+  }, {
+    "name" : "NAME",
+    "nullable" : true,
+    "type" : {
+      "name" : "utf8"
+    },
+    "children" : [ ],
+    "metadata" : [ {
+      "value" : "Name of record",
+      "key" : "comment"
+    } ]
+  }, {
+    "name" : "COLUMN1",
+    "nullable" : true,
+    "type" : {
+      "name" : "bool"
+    },
+    "children" : [ ]
+  }, {
+    "name" : "COLUMNN",
+    "nullable" : true,
+    "type" : {
+      "name" : "int",
+      "bitWidth" : 32,
+      "isSigned" : true
+    },
+    "children" : [ ],
+    "metadata" : [ {
+      "value" : "Informative description of columnN",
+      "key" : "comment"
+    } ]
+  } ],
+  "metadata" : [ {
+    "value" : "This is super special table with valuable data",
+    "key" : "comment"
+  } ]
+}

--- a/java/adapter/jdbc/src/test/resources/h2/expectedSchemaWithCommentsAndJdbcMeta.json
+++ b/java/adapter/jdbc/src/test/resources/h2/expectedSchemaWithCommentsAndJdbcMeta.json
@@ -1,0 +1,100 @@
+{
+  "fields" : [ {
+    "name" : "ID",
+    "nullable" : false,
+    "type" : {
+      "name" : "int",
+      "bitWidth" : 64,
+      "isSigned" : true
+    },
+    "children" : [ ],
+    "metadata" : [ {
+      "value" : "Record identifier",
+      "key" : "comment"
+    }, {
+      "value" : "TABLE1",
+      "key" : "SQL_TABLE_NAME"
+    }, {
+      "value" : "JDBCTOARROWTEST?CHARACTERENCODING=UTF-8",
+      "key" : "SQL_CATALOG_NAME"
+    }, {
+      "value" : "ID",
+      "key" : "SQL_COLUMN_NAME"
+    }, {
+      "value" : "BIGINT",
+      "key" : "SQL_TYPE"
+    } ]
+  }, {
+    "name" : "NAME",
+    "nullable" : true,
+    "type" : {
+      "name" : "utf8"
+    },
+    "children" : [ ],
+    "metadata" : [ {
+      "value" : "Name of record",
+      "key" : "comment"
+    }, {
+      "value" : "TABLE1",
+      "key" : "SQL_TABLE_NAME"
+    }, {
+      "value" : "JDBCTOARROWTEST?CHARACTERENCODING=UTF-8",
+      "key" : "SQL_CATALOG_NAME"
+    }, {
+      "value" : "NAME",
+      "key" : "SQL_COLUMN_NAME"
+    }, {
+      "value" : "VARCHAR",
+      "key" : "SQL_TYPE"
+    } ]
+  }, {
+    "name" : "COLUMN1",
+    "nullable" : true,
+    "type" : {
+      "name" : "bool"
+    },
+    "children" : [ ],
+    "metadata" : [ {
+      "value" : "TABLE1",
+      "key" : "SQL_TABLE_NAME"
+    }, {
+      "value" : "JDBCTOARROWTEST?CHARACTERENCODING=UTF-8",
+      "key" : "SQL_CATALOG_NAME"
+    }, {
+      "value" : "COLUMN1",
+      "key" : "SQL_COLUMN_NAME"
+    }, {
+      "value" : "BOOLEAN",
+      "key" : "SQL_TYPE"
+    } ]
+  }, {
+    "name" : "COLUMNN",
+    "nullable" : true,
+    "type" : {
+      "name" : "int",
+      "bitWidth" : 32,
+      "isSigned" : true
+    },
+    "children" : [ ],
+    "metadata" : [ {
+      "value" : "Informative description of columnN",
+      "key" : "comment"
+    }, {
+      "value" : "TABLE1",
+      "key" : "SQL_TABLE_NAME"
+    }, {
+      "value" : "JDBCTOARROWTEST?CHARACTERENCODING=UTF-8",
+      "key" : "SQL_CATALOG_NAME"
+    }, {
+      "value" : "COLUMNN",
+      "key" : "SQL_COLUMN_NAME"
+    }, {
+      "value" : "INTEGER",
+      "key" : "SQL_TYPE"
+    } ]
+  } ],
+  "metadata" : [ {
+    "value" : "This is super special table with valuable data",
+    "key" : "comment"
+  } ]
+}


### PR DESCRIPTION
Allow user to provide comment in Arrow Schema from  JdbcToArrowConfig . It will be very useful metadata in real life (medium to large scale project) for documentation and maintenance topics. Apache Spark code use "comment" key for such metadata, so this looks like reasonable default name for metadata in Arrow schema too