### PR TITLE
MINOR: [C++] Fix unity build error

### DIFF
--- a/cpp/src/arrow/compute/exec/bloom_filter.h
+++ b/cpp/src/arrow/compute/exec/bloom_filter.h
@@ -249,7 +249,7 @@ class ARROW_EXPORT BlockedBloomFilter {
 // b) It is preferred for small and medium size Bloom filters, because it skips extra
 // synchronization related steps from parallel variant (partitioning and taking locks).
 //
-enum class ARROW_EXPORT BloomFilterBuildStrategy {
+enum class BloomFilterBuildStrategy {
   SINGLE_THREADED = 0,
   PARALLEL = 1,
 };


### PR DESCRIPTION
```
/arrow/cpp/src/arrow/compute/exec/bloom_filter.h:252:25: error: type attributes ignored after type is already defined [-Werror=attributes]
  252 | enum class ARROW_EXPORT BloomFilterBuildStrategy {
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~
```