### PR TITLE
ARROW-17320: [Python] Refine pyarrow.parquet API exposure

### DIFF
--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -140,7 +140,7 @@ _DNF_filter_doc = """Predicates are expressed in disjunctive normal form (DNF),
     """
 
 
-def _filters_to_expression(filters):
+def filters_to_expression(filters):
     """
     Check if filters are well-formed.
 
@@ -188,6 +188,11 @@ def _filters_to_expression(filters):
         disjunction_members.append(reduce(operator.and_, conjunction_members))
 
     return reduce(operator.or_, disjunction_members)
+
+
+_filters_to_expression = _deprecate_api(
+    "_filters_to_expression", "filters_to_expression",
+    filters_to_expression, "10.0.0")
 
 
 # ----------------------------------------------------------------------
@@ -3531,4 +3536,5 @@ __all__ = (
     "write_table",
     "write_to_dataset",
     "_filters_to_expression",
+    "filters_to_expression",
 )

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -142,9 +142,25 @@ _DNF_filter_doc = """Predicates are expressed in disjunctive normal form (DNF),
 
 def filters_to_expression(filters):
     """
-    Check if filters are well-formed.
+    Check if filters are well-formed and convert to an ``Expression``.
 
-    See _DNF_filter_doc above for more details.
+    Parameters
+    ----------
+    filters : List[Tuple] or List[List[Tuple]]
+
+    Notes
+    -----
+    See internal ``pyarrow._DNF_filter_doc`` attribute for more details.
+
+    Examples
+    --------
+
+    >>> filters_to_expression([('foo', '==', 'bar')])
+    <pyarrow.compute.Expression (foo == "bar")>
+
+    Returns
+    -------
+    pyarrow.compute.Expression
     """
     import pyarrow.dataset as ds
 

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -192,7 +192,7 @@ def filters_to_expression(filters):
 
 _filters_to_expression = _deprecate_api(
     "_filters_to_expression", "filters_to_expression",
-    filters_to_expression, "10.0.0")
+    filters_to_expression, "10.0.0", DeprecationWarning)
 
 
 # ----------------------------------------------------------------------

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -44,7 +44,7 @@ from pyarrow._parquet import (ParquetReader, Statistics,  # noqa
 from pyarrow.fs import (LocalFileSystem, FileSystem,
                         _resolve_filesystem_and_path, _ensure_filesystem)
 from pyarrow import filesystem as legacyfs
-from pyarrow.util import guid, _is_path_like, _stringify_path
+from pyarrow.util import guid, _is_path_like, _stringify_path, _deprecate_api
 
 _URI_STRIP_SCHEMES = ('hdfs',)
 

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -21,7 +21,6 @@ from concurrent import futures
 from contextlib import nullcontext
 from functools import partial, reduce
 
-import sys
 import json
 from collections.abc import Collection
 import numpy as np
@@ -3506,6 +3505,30 @@ def read_schema(where, memory_map=False, decryption_properties=None,
         return file.schema.to_arrow_schema()
 
 
-# re-export everything
-# std `from . import *` ignores symbols with leading `_`
-__all__ = list(sys.modules[__name__].__dict__)
+__all__ = (
+    "ColumnChunkMetaData",
+    "ColumnSchema",
+    "FileDecryptionProperties",
+    "FileEncryptionProperties",
+    "FileMetaData",
+    "ParquetDataset",
+    "ParquetDatasetPiece",
+    "ParquetFile",
+    "ParquetLogicalType",
+    "ParquetManifest",
+    "ParquetPartitions",
+    "ParquetReader",
+    "ParquetSchema",
+    "ParquetWriter",
+    "PartitionSet",
+    "RowGroupMetaData",
+    "Statistics",
+    "read_metadata",
+    "read_pandas",
+    "read_schema",
+    "read_table",
+    "write_metadata",
+    "write_table",
+    "write_to_dataset",
+    "_filters_to_expression",
+)

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -2363,7 +2363,7 @@ class _ParquetDatasetV2:
 
         self._filter_expression = None
         if filters is not None:
-            self._filter_expression = _filters_to_expression(filters)
+            self._filter_expression = filters_to_expression(filters)
 
         # map old filesystems to new one
         if filesystem is not None:

--- a/python/pyarrow/util.py
+++ b/python/pyarrow/util.py
@@ -39,11 +39,11 @@ def implements(f):
     return decorator
 
 
-def _deprecate_api(old_name, new_name, api, next_version):
+def _deprecate_api(old_name, new_name, api, next_version, type=FutureWarning):
     msg = _DEPR_MSG.format(old_name, next_version, new_name)
 
     def wrapper(*args, **kwargs):
-        warnings.warn(msg, FutureWarning)
+        warnings.warn(msg, type)
         return api(*args, **kwargs)
     return wrapper
 


### PR DESCRIPTION
Fixes [ARROW-17320](https://issues.apache.org/jira/browse/ARROW-17320?page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel&focusedCommentId=17577330)

Added a deprecation for `_filters_to_expression` -> `filters_to_expression`, in https://github.com/apache/arrow/pull/14096/commits/c7fdff3b50ca0fe95ae4c771cee81d4d59aa98d0 let me know if that commit should be dropped. :) 