### PR TITLE
ARROW-4709: [C++] Optimize for ordered JSON fields

### DIFF
--- a/cpp/src/arrow/json/parser.cc
+++ b/cpp/src/arrow/json/parser.cc
@@ -352,7 +352,9 @@ class RawArrayBuilder<Kind::kObject> {
 
   BuilderPtr field_builder(int index) const { return field_infos_[index].builder; }
 
-  void field_builder(int index, BuilderPtr builder) { field_infos_[index].builder = builder; }
+  void field_builder(int index, BuilderPtr builder) {
+    field_infos_[index].builder = builder;
+  }
 
   Status Finish(std::function<Status(BuilderPtr, std::shared_ptr<Array>*)> finish_child,
                 std::shared_ptr<Array>* out) {

--- a/cpp/src/arrow/json/parser.cc
+++ b/cpp/src/arrow/json/parser.cc
@@ -329,7 +329,7 @@ class RawArrayBuilder<Kind::kObject> {
 
   Status AppendNull(int64_t count) { return null_bitmap_builder_.Append(count, false); }
 
-  int GetFieldIndex(string_view name) {
+  int GetFieldIndex(std::string_view name) {
     // Predict that the field is known and immediately follows the last one. Otherwise,
     // fall back to the hash table lookup from now on
     if (expect_index_ < num_fields() &&
@@ -360,7 +360,7 @@ class RawArrayBuilder<Kind::kObject> {
 
   int num_fields() const { return static_cast<int>(field_infos_.size()); }
 
-  string_view field_name(int index) const { return field_infos_[index].name; }
+  std::string_view field_name(int index) const { return field_infos_[index].name; }
 
   BuilderPtr field_builder(int index) const { return field_infos_[index].builder; }
 
@@ -395,13 +395,13 @@ class RawArrayBuilder<Kind::kObject> {
 
  private:
   struct FieldInfo {
-    string_view name;
+    std::string_view name;
     BuilderPtr builder;
   };
 
   std::forward_list<std::string> name_store_;
   std::vector<FieldInfo> field_infos_;
-  std::unordered_map<string_view, int> name_to_index_;
+  std::unordered_map<std::string_view, int> name_to_index_;
   TypedBufferBuilder<bool> null_bitmap_builder_;
   int expect_index_ = 0;
 };

--- a/cpp/src/arrow/json/parser.cc
+++ b/cpp/src/arrow/json/parser.cc
@@ -346,11 +346,13 @@ class RawArrayBuilder<Kind::kObject> {
   }
 
   int AddField(std::string name, BuilderPtr builder) {
-    auto name_ptr = make_unique<std::string>(std::move(name));
-    auto result = name_to_index_.emplace(*name_ptr, num_fields());
+    FieldInfo info;
+    info.name = arrow::internal::make_unique<std::string>(std::move(name));
+    info.builder = builder;
+    auto result = name_to_index_.emplace(*info.name, num_fields());
     // Only append the field if a new insertion happened
     if (ARROW_PREDICT_TRUE(result.second)) {
-      field_infos_.push_back({std::move(name_ptr), builder});
+      field_infos_.push_back(std::move(info));
     }
     return result.first->second;
   }


### PR DESCRIPTION
Addresses [ARROW-4709](https://issues.apache.org/jira/browse/ARROW-4709).

Main features:
- The builder maintains a tracking index for random-access key prediction but falls back to the map on unordered/sparse field sets
- Key strings are interned in an outer `BuildContext` class so all subsequent lookups use `string_view`
- Removes the expensive `unordered_map` -> `vector` transform in `Finish`