### PR TITLE
ARROW-17699: [R] Add better error message for if a non-schema passed into open_dataset()

### DIFF
--- a/r/R/dataset-format.R
+++ b/r/R/dataset-format.R
@@ -128,6 +128,13 @@ CsvFileFormat$create <- function(...,
 
   options <- list(...)
   schema <- options[["schema"]]
+  if (!is.null(schema) && !inherits(schema, "Schema")) {
+    abort(paste0(
+      "`schema` must be an object of class 'Schema' not '",
+      class(schema)[1],
+      "'."
+    ))
+  }
 
   column_names <- read_options$column_names
   schema_names <- names(schema)

--- a/r/tests/testthat/test-dataset-csv.R
+++ b/r/tests/testthat/test-dataset-csv.R
@@ -380,3 +380,13 @@ test_that("skip argument in open_dataset", {
   )
   expect_equal(collect(ds), tbl)
 })
+
+test_that("error message if non-schema passed in as schema to open_dataset", {
+
+  # passing in the schema function, not an actual schema
+  expect_error(
+    open_dataset(csv_dir, format = "csv", schema = schema),
+    regexp = "`schema` must be an object of class 'Schema' not 'function'.",
+    fixed = TRUE
+  )
+})


### PR DESCRIPTION
Example below shows what happens if the `schema()` function is passed in as the `schema` argument via the `...` argument to `open_dataset()`.

Before (a later check for something else catches it, this giving a misleading message):

```
library(dplyr)
library(arrow)
tf <- tempfile()
dir.create(tf)
write_dataset(mtcars, tf, format = "csv")
open_dataset(tf, format = "csv", schema = schema) %>% collect()
#> Error in `CsvFileFormat$create()`:
#> ! Values in `column_names` must match `schema` field names
#> ✖ `column_names` and `schema` field names match but are not in the same order
```

After (more accurate error message): 

```
library(dplyr)
library(arrow)
tf <- tempfile()
dir.create(tf)
write_dataset(mtcars, tf, format = "csv")
open_dataset(tf, format = "csv", schema = schema) %>% collect()
#> Error in `CsvFileFormat$create()`:
#> ! `schema` must be an object of class 'Schema' not 'function'.
```