### PR TITLE
ARROW-17701: [C++][Gandiva] Add support for untyped node

### DIFF
--- a/cpp/src/gandiva/node.h
+++ b/cpp/src/gandiva/node.h
@@ -66,7 +66,7 @@ class GANDIVA_EXPORT LiteralNode : public Node {
 
   std::string ToString() const override {
     std::stringstream ss;
-    if (return_type_ == nullptr) {
+    if (return_type_ == NULLPTR) {
       ss << "(const untyped) " << gandiva::ToString(holder_);
       return ss.str();
     }
@@ -133,7 +133,7 @@ class GANDIVA_EXPORT FunctionNode : public Node {
 
   std::string ToString() const override {
     std::stringstream ss;
-    ss << ((return_type() == nullptr) ? "untyped"
+    ss << ((return_type() == NULLPTR) ? "untyped"
                                       : descriptor()->return_type()->ToString())
        << " " << descriptor()->name() << "(";
     bool skip_comma = true;

--- a/cpp/src/gandiva/node.h
+++ b/cpp/src/gandiva/node.h
@@ -66,6 +66,11 @@ class GANDIVA_EXPORT LiteralNode : public Node {
 
   std::string ToString() const override {
     std::stringstream ss;
+    if (return_type_ == nullptr) {
+      ss << "(const untyped) " << gandiva::ToString(holder_);
+      return ss.str();
+    }
+
     ss << "(const " << return_type()->ToString() << ") ";
     if (is_null()) {
       ss << std::string("null");
@@ -128,7 +133,9 @@ class GANDIVA_EXPORT FunctionNode : public Node {
 
   std::string ToString() const override {
     std::stringstream ss;
-    ss << descriptor()->return_type()->ToString() << " " << descriptor()->name() << "(";
+    ss << ((return_type() == nullptr) ? "untyped"
+                                      : descriptor()->return_type()->ToString())
+       << " " << descriptor()->name() << "(";
     bool skip_comma = true;
     for (auto& child : children()) {
       if (skip_comma) {


### PR DESCRIPTION
The parser will first emit untyped literal and function nodes before type inference. We need to update the ToString method of Gandiva nodes to avoid seg fault.

Other methods aren't affected because untyped nodes are only used inside the parser.