### PR TITLE
ARROW-16857: [C++] Adding Project Relation ToProto

### DIFF
--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -453,7 +453,8 @@ arrow::Status ScanProjectSinkExample(cp::ExecContext& exec_context) {
 
   auto options = std::make_shared<arrow::dataset::ScanOptions>();
   // projection
-  cp::Expression a_times_2 = cp::call("multiply", {cp::field_ref("a"), cp::literal(2)});
+  cp::Expression a_times_2 =
+      cp::call("multiply", {cp::field_ref("a"), cp::field_ref("a")});
   options->projection = cp::project({}, {});
 
   cp::ExecNode* scan;

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -453,8 +453,7 @@ arrow::Status ScanProjectSinkExample(cp::ExecContext& exec_context) {
 
   auto options = std::make_shared<arrow::dataset::ScanOptions>();
   // projection
-  cp::Expression a_times_2 =
-      cp::call("multiply", {cp::field_ref("a"), cp::field_ref("a")});
+  cp::Expression a_times_2 = cp::call("multiply", {cp::field_ref("a"), cp::literal(2)});
   options->projection = cp::project({}, {});
 
   cp::ExecNode* scan;

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -59,7 +59,6 @@
 #include "arrow/util/string.h"
 #include "arrow/util/uri.h"
 
-#include <memory>
 #include <numeric>
 
 namespace arrow {
@@ -732,8 +731,6 @@ Result<std::shared_ptr<Schema>> ExtractSchemaToBind(const compute::Declaration& 
       } else if (auto* literal = bound_expr->literal()) {
         project_field =
             field("field_" + std::to_string(num_fields_before_proj + i), literal->type());
-      } else {
-        return Status::NotImplemented("Unsupported expression type");
       }
       ARROW_ASSIGN_OR_RAISE(
           bind_schema, bind_schema->AddField(
@@ -889,7 +886,7 @@ Result<std::unique_ptr<substrait::ProjectRel>> ProjectRelationConverter(
 
   // set an emit to only output the result of the expressions passed in
   std::vector<int> emit_fields(expressions.size());
-  std::iota(emit_fields.begin(), emit_fields.end(), schema->num_fields());
+  std::iota(emit_fields.begin(), emit_fields.end(), schema->num_fields() - 1);
   ARROW_ASSIGN_OR_RAISE(auto rel_common, GetRelCommonEmit(emit_fields));
   project_rel->set_allocated_common(rel_common.release());
   return std::move(project_rel);

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -819,7 +819,7 @@ Result<std::unique_ptr<substrait::FilterRel>> FilterRelationConverter(
 Result<std::unique_ptr<substrait::ProjectRel>> ProjectRelationConverter(
     const std::shared_ptr<Schema>& schema, const compute::Declaration& declaration,
     ExtensionSet* ext_set, const ConversionOptions& conversion_options) {
-  auto project_rel = make_unique<substrait::ProjectRel>();
+  auto project_rel = std::make_unique<substrait::ProjectRel>();
   const auto& project_node_options =
       checked_cast<const compute::ProjectNodeOptions&>(*declaration.options);
 

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -770,7 +770,7 @@ Result<std::unique_ptr<substrait::ReadRel>> NamedTableRelationConverter(
   return std::move(read_rel);
 }
 
-std::unique_ptr<substrait::RelCommon> GetRelCommonEmit(std::vector<int>& emit_fields) {
+std::unique_ptr<substrait::RelCommon> MakeRelCommonEmit(std::vector<int>& emit_fields) {
   auto rel_common = std::make_unique<substrait::RelCommon>();
   auto rel_common_emit = std::make_unique<substrait::RelCommon::Emit>();
   for (const auto& emit_field : emit_fields) {
@@ -883,8 +883,9 @@ Result<std::unique_ptr<substrait::ProjectRel>> ProjectRelationConverter(
 
   // set an emit to only output the result of the expressions passed in
   std::vector<int> emit_fields(expressions.size());
-  std::iota(emit_fields.begin(), emit_fields.end(), schema->num_fields() - 1);
-  auto rel_common = GetRelCommonEmit(emit_fields);
+  std::iota(emit_fields.begin(), emit_fields.end(),
+            schema->num_fields() - expressions.size());
+  auto rel_common = MakeRelCommonEmit(emit_fields);
   project_rel->set_allocated_common(rel_common.release());
   return std::move(project_rel);
 }

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -732,6 +732,8 @@ Result<std::shared_ptr<Schema>> ExtractSchemaToBind(const compute::Declaration& 
       } else if (auto* literal = bound_expr->literal()) {
         project_field =
             field("field_" + std::to_string(num_fields_before_proj + i), literal->type());
+      } else {
+        return Status::NotImplemented("Unsupported expression type");
       }
       ARROW_ASSIGN_OR_RAISE(
           bind_schema, bind_schema->AddField(

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -884,7 +884,7 @@ Result<std::unique_ptr<substrait::ProjectRel>> ProjectRelationConverter(
   // set an emit to only output the result of the expressions passed in
   std::vector<int> emit_fields(expressions.size());
   std::iota(emit_fields.begin(), emit_fields.end(),
-            schema->num_fields() - expressions.size());
+            static_cast<size_t>(schema->num_fields()) - expressions.size());
   auto rel_common = MakeRelCommonEmit(emit_fields);
   project_rel->set_allocated_common(rel_common.release());
   return std::move(project_rel);

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -831,7 +831,7 @@ Result<std::unique_ptr<substrait::ProjectRel>> ProjectRelationConverter(
   auto declr_input = declaration.inputs[0];
   ARROW_ASSIGN_OR_RAISE(
       auto input_rel,
-      ToProto(util::get<compute::Declaration>(declr_input), ext_set, conversion_options));
+      ToProto(std::get<compute::Declaration>(declr_input), ext_set, conversion_options));
 
   for (const auto& expr : project_node_options.expressions) {
     compute::Expression bound_expression;

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -4133,7 +4133,7 @@ TEST(Substrait, SetRelationBasic) {
 
   compute::SortOptions sort_options(
       {compute::SortKey("A", compute::SortOrder::Ascending)});
-  CheckRoundTripResult(dummy_schema, std::move(expected_table), exec_context, buf, {},
+  CheckRoundTripResult(std::move(expected_table), exec_context, buf, {},
                        conversion_options, &sort_options);
 }
 

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -2412,7 +2412,7 @@ TEST(Substrait, FilterProjectPlanRoundTripping) {
       auto sink_decls,
       DeserializePlans(
           *serialized_plan, [] { return kNullConsumer; }, ext_id_reg, &ext_set));
-  // project declaration
+  // assert project declaration
   auto roundtripped_project = sink_decls[0].inputs[0].get<compute::Declaration>();
   // assert project declaration
   // Note: the provided expressions for Substrait declaration only contains one
@@ -2420,7 +2420,7 @@ TEST(Substrait, FilterProjectPlanRoundTripping) {
   // provided expression. Since the output expressions from the deserialized relation
   // contains fields which weren't used in the project expression.
   AssertProjectRelation(*roundtripped_project, acero_project_exprs, project_schema);
-  // scan declaration
+  // assert scan declaration
   auto roundtripped_scan = roundtripped_project->inputs[0].get<compute::Declaration>();
   AssertScanRelation(*roundtripped_scan, dataset, dummy_schema);
   // assert results

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -2290,9 +2290,6 @@ TEST(SubstraitRoundTrip, BasicPlanEndToEnd) {
 }
 
 TEST(Substrait, FilterProjectPlanRoundTripping) {
-#ifdef _WIN32
-  GTEST_SKIP() << "ARROW-16392: Substrait File URI not supported for Windows";
-#endif
   compute::ExecContext exec_context;
   arrow::dataset::internal::Initialize();
 

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -130,6 +130,60 @@ Result<std::shared_ptr<Table>> GetTableFromPlan(
   return table;
 }
 
+void AssertScanRelation(const compute::Declaration& output_scan,
+                        const std::shared_ptr<dataset::Dataset>& expected_dataset,
+                        const std::shared_ptr<Schema> schema) {
+  const auto& dataset_opts =
+      checked_cast<const dataset::ScanNodeOptions&>(*(output_scan.options));
+  const auto& output_ds = dataset_opts.dataset;
+  ASSERT_TRUE(output_ds->schema()->Equals(*schema));
+  ASSERT_OK_AND_ASSIGN(auto output_frgs, output_ds->GetFragments());
+  ASSERT_OK_AND_ASSIGN(auto expected_frgs, expected_dataset->GetFragments());
+
+  auto output_frg_vec = IteratorToVector(std::move(output_frgs));
+  auto expected_frg_vec = IteratorToVector(std::move(expected_frgs));
+  ASSERT_EQ(expected_frg_vec.size(), output_frg_vec.size());
+  int64_t idx = 0;
+  for (auto fragment : expected_frg_vec) {
+    const auto* l_frag = checked_cast<const dataset::FileFragment*>(fragment.get());
+    const auto* r_frag =
+        checked_cast<const dataset::FileFragment*>(output_frg_vec[idx++].get());
+    ASSERT_TRUE(l_frag->Equals(*r_frag));
+  }
+}
+
+void AssertFilterRelation(
+    const compute::Declaration& output_filter, const std::string& filter_func_name,
+    const std::pair<const std::string&, const std::string&>& filter_args,
+    const std::shared_ptr<Schema>& schema) {
+  const auto& filter_opts =
+      checked_cast<const compute::FilterNodeOptions&>(*(output_filter.options));
+  auto filter_expr = filter_opts.filter_expression;
+
+  if (auto* call = filter_expr.call()) {
+    EXPECT_EQ(call->function_name, filter_func_name);
+    auto args = call->arguments;
+    auto left_index = args[0].field_ref()->field_path()->indices()[0];
+    EXPECT_EQ(schema->field_names()[left_index], filter_args.first);
+    auto right_index = args[1].field_ref()->field_path()->indices()[0];
+    EXPECT_EQ(schema->field_names()[right_index], filter_args.second);
+  }
+}
+
+void AssertPlanExecutionResult(const std::shared_ptr<Table> expected_table,
+                               const compute::Declaration& source_declaration,
+                               const std::shared_ptr<Schema>& schema,
+                               compute::ExecContext& exec_context) {
+  arrow::AsyncGenerator<util::optional<compute::ExecBatch>> sink_gen;
+  auto sink_node_options = compute::SinkNodeOptions{&sink_gen};
+  auto sink_declaration = compute::Declaration({"sink", sink_node_options, "e"});
+  auto declarations =
+      compute::Declaration::Sequence({source_declaration, sink_declaration});
+  ASSERT_OK_AND_ASSIGN(auto output_table,
+                       GetTableFromPlan(declarations, sink_gen, exec_context, schema));
+  ASSERT_TRUE(expected_table->Equals(*output_table));
+}
+
 class NullSinkNodeConsumer : public compute::SinkNodeConsumer {
  public:
   Status Init(const std::shared_ptr<Schema>&, compute::BackpressureControl*,
@@ -2146,39 +2200,14 @@ TEST(SubstraitRoundTrip, BasicPlan) {
           *serialized_plan, [] { return kNullConsumer; }, ext_id_reg, &ext_set));
   // filter declaration
   const auto& roundtripped_filter =
-      std::get<compute::Declaration>(sink_decls[0].inputs[0]);
-  const auto& filter_opts =
-      checked_cast<const compute::FilterNodeOptions&>(*(roundtripped_filter.options));
-  auto roundtripped_expr = filter_opts.filter_expression;
-
-  if (auto* call = roundtripped_expr.call()) {
-    EXPECT_EQ(call->function_name, "equal");
-    auto args = call->arguments;
-    auto left_index = args[0].field_ref()->field_path()->indices()[0];
-    EXPECT_EQ(dummy_schema->field_names()[left_index], filter_col_left);
-    auto right_index = args[1].field_ref()->field_path()->indices()[0];
-    EXPECT_EQ(dummy_schema->field_names()[right_index], filter_col_right);
-  }
-  // scan declaration
-  const auto& roundtripped_scan =
-      std::get<compute::Declaration>(roundtripped_filter.inputs[0]);
-  const auto& dataset_opts =
-      checked_cast<const dataset::ScanNodeOptions&>(*(roundtripped_scan.options));
-  const auto& roundripped_ds = dataset_opts.dataset;
-  EXPECT_TRUE(roundripped_ds->schema()->Equals(*dummy_schema));
-  ASSERT_OK_AND_ASSIGN(auto roundtripped_frgs, roundripped_ds->GetFragments());
-  ASSERT_OK_AND_ASSIGN(auto expected_frgs, dataset->GetFragments());
-
-  auto roundtrip_frg_vec = IteratorToVector(std::move(roundtripped_frgs));
-  auto expected_frg_vec = IteratorToVector(std::move(expected_frgs));
-  EXPECT_EQ(expected_frg_vec.size(), roundtrip_frg_vec.size());
-  int64_t idx = 0;
-  for (auto fragment : expected_frg_vec) {
-    const auto* l_frag = checked_cast<const dataset::FileFragment*>(fragment.get());
-    const auto* r_frag =
-        checked_cast<const dataset::FileFragment*>(roundtrip_frg_vec[idx++].get());
-    EXPECT_TRUE(l_frag->Equals(*r_frag));
-  }
+          std::get<compute::Declaration>(sink_decls[0].inputs[0]);
+  std::pair<const std::string&, const std::string&> filter_args(filter_col_left,
+                                                                filter_col_right);
+  AssertFilterRelation(roundtripped_filter, "equal", std::move(filter_args),
+                       dummy_schema);
+  // assert scan declaration
+  auto roundtripped_scan = roundtripped_filter->inputs[0].get<compute::Declaration>();
+  AssertScanRelation(*roundtripped_scan, dataset, dummy_schema);
 }
 
 TEST(SubstraitRoundTrip, BasicPlanEndToEnd) {
@@ -2255,43 +2284,111 @@ TEST(SubstraitRoundTrip, BasicPlanEndToEnd) {
       auto sink_decls,
       DeserializePlans(
           *serialized_plan, [] { return kNullConsumer; }, ext_id_reg, &ext_set));
-  // filter declaration
+  // assert filter declaration
   auto& roundtripped_filter = std::get<compute::Declaration>(sink_decls[0].inputs[0]);
-  const auto& filter_opts =
-      checked_cast<const compute::FilterNodeOptions&>(*(roundtripped_filter.options));
-  auto roundtripped_expr = filter_opts.filter_expression;
+  std::pair<const std::string&, const std::string&> filter_args(filter_col_left,
+                                                                filter_col_right);
+  AssertFilterRelation(roundtripped_filter, "equal", std::move(filter_args),
+                       dummy_schema);
+  // assert scan declaration
+  auto roundtripped_scan = roundtripped_filter->inputs[0].get<compute::Declaration>();
+  AssertScanRelation(*roundtripped_scan, dataset, dummy_schema);
+  // assert results
+  AssertPlanExecutionResult(expected_table, *roundtripped_filter, dummy_schema,
+                            exec_context);
+}
 
-  if (auto* call = roundtripped_expr.call()) {
-    EXPECT_EQ(call->function_name, "equal");
+TEST(Substrait, FilterProjectPlanRoundTripping) {
+#ifdef _WIN32
+  GTEST_SKIP() << "ARROW-16392: Substrait File URI not supported for Windows";
+#endif
+  compute::ExecContext exec_context;
+  arrow::dataset::internal::Initialize();
+
+  auto dummy_schema = schema(
+      {field("key", int32()), field("shared", int32()), field("distinct", int32())});
+
+  // creating a dummy dataset using a dummy table
+  auto table = TableFromJSON(dummy_schema, {R"([
+      [1, 1, 10],
+      [3, 4, 20]
+    ])",
+                                            R"([
+      [0, 2, 1],
+      [1, 3, 2],
+      [4, 1, 3],
+      [3, 1, 3],
+      [1, 2, 5]
+    ])",
+                                            R"([
+      [2, 2, 12],
+      [5, 3, 12],
+      [1, 3, 12]
+    ])"});
+
+  auto format = std::make_shared<arrow::dataset::IpcFileFormat>();
+  auto filesystem = std::make_shared<fs::LocalFileSystem>();
+  const std::string file_name = "serde_test.arrow";
+
+  ASSERT_OK_AND_ASSIGN(auto tempdir,
+                       arrow::internal::TemporaryDir::Make("substrait-tempdir-"));
+  ASSERT_OK_AND_ASSIGN(auto file_path, tempdir->path().Join(file_name));
+  std::string file_path_str = file_path.ToString();
+
+  ARROW_EXPECT_OK(WriteIpcData(file_path_str, filesystem, table));
+
+  std::vector<fs::FileInfo> files;
+  const std::vector<std::string> f_paths = {file_path_str};
+
+  for (const auto& f_path : f_paths) {
+    ASSERT_OK_AND_ASSIGN(auto f_file, filesystem->GetFileInfo(f_path));
+    files.push_back(std::move(f_file));
+  }
+
+  ASSERT_OK_AND_ASSIGN(auto ds_factory, dataset::FileSystemDatasetFactory::Make(
+                                            filesystem, std::move(files), format, {}));
+  ASSERT_OK_AND_ASSIGN(auto dataset, ds_factory->Finish(dummy_schema));
+
+  auto scan_options = std::make_shared<dataset::ScanOptions>();
+  scan_options->projection = compute::project({}, {});
+  compute::Expression a_times_2 = compute::call(
+      "multiply", {compute::field_ref("shared"), compute::field_ref("distinct")});
+
+  arrow::AsyncGenerator<util::optional<compute::ExecBatch>> sink_gen;
+
+  auto declarations = compute::Declaration::Sequence(
+      {compute::Declaration(
+           {"scan", dataset::ScanNodeOptions{dataset, scan_options}, "s"}),
+       compute::Declaration({"project", compute::ProjectNodeOptions{{a_times_2}}, "p"}),
+       compute::Declaration({"sink", compute::SinkNodeOptions{&sink_gen}, "e"})});
+
+  std::shared_ptr<ExtensionIdRegistry> sp_ext_id_reg = MakeExtensionIdRegistry();
+  ExtensionIdRegistry* ext_id_reg = sp_ext_id_reg.get();
+  ExtensionSet ext_set(ext_id_reg);
+
+  ASSERT_OK_AND_ASSIGN(auto serialized_plan, SerializePlan(declarations, &ext_set));
+
+  ASSERT_OK_AND_ASSIGN(
+      auto sink_decls,
+      DeserializePlans(
+          *serialized_plan, [] { return kNullConsumer; }, ext_id_reg, &ext_set));
+  // filter declaration
+  auto roundtripped_project = sink_decls[0].inputs[0].get<compute::Declaration>();
+  const auto& project_opts =
+      checked_cast<const compute::ProjectNodeOptions&>(*(roundtripped_project->options));
+  auto roundtripped_exprs = project_opts.expressions;
+
+  if (auto* call = roundtripped_exprs[0].call()) {
+    EXPECT_EQ(call->function_name, "multiply");
     auto args = call->arguments;
     auto left_index = args[0].field_ref()->field_path()->indices()[0];
-    EXPECT_EQ(dummy_schema->field_names()[left_index], filter_col_left);
+    EXPECT_EQ(dummy_schema->field_names()[left_index], "shared");
     auto right_index = args[1].field_ref()->field_path()->indices()[0];
-    EXPECT_EQ(dummy_schema->field_names()[right_index], filter_col_right);
+    EXPECT_EQ(dummy_schema->field_names()[right_index], "distinct");
   }
   // scan declaration
-  const auto& roundtripped_scan =
-      std::get<compute::Declaration>(roundtripped_filter.inputs[0]);
-  const auto& dataset_opts =
-      checked_cast<const dataset::ScanNodeOptions&>(*(roundtripped_scan.options));
-  const auto& roundripped_ds = dataset_opts.dataset;
-  EXPECT_TRUE(roundripped_ds->schema()->Equals(*dummy_schema));
-  ASSERT_OK_AND_ASSIGN(auto roundtripped_frgs, roundripped_ds->GetFragments());
-  ASSERT_OK_AND_ASSIGN(auto expected_frgs, dataset->GetFragments());
-
-  auto roundtrip_frg_vec = IteratorToVector(std::move(roundtripped_frgs));
-  auto expected_frg_vec = IteratorToVector(std::move(expected_frgs));
-  EXPECT_EQ(expected_frg_vec.size(), roundtrip_frg_vec.size());
-  int64_t idx = 0;
-  for (auto fragment : expected_frg_vec) {
-    const auto* l_frag = checked_cast<const dataset::FileFragment*>(fragment.get());
-    const auto* r_frag =
-        checked_cast<const dataset::FileFragment*>(roundtrip_frg_vec[idx++].get());
-    EXPECT_TRUE(l_frag->Equals(*r_frag));
-  }
-  ASSERT_OK_AND_ASSIGN(auto rnd_trp_table,
-                       GetTableFromPlan(roundtripped_filter, exec_context, dummy_schema));
-  EXPECT_TRUE(expected_table->Equals(*rnd_trp_table));
+  auto roundtripped_scan = roundtripped_project->inputs[0].get<compute::Declaration>();
+  AssertScanRelation(*roundtripped_scan, dataset, dummy_schema);
 }
 
 TEST(SubstraitRoundTrip, FilterNamedTable) {

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -106,7 +106,7 @@ void WriteIpcData(const std::string& path,
 }
 
 Result<std::shared_ptr<Table>> GetTableFromPlan(
-    compute::Declaration& other_declrs, compute::ExecContext& exec_context,
+    const compute::Declaration& other_declrs, compute::ExecContext& exec_context,
     const std::shared_ptr<Schema>& output_schema) {
   ARROW_ASSIGN_OR_RAISE(auto plan, compute::ExecPlan::Make(&exec_context));
 
@@ -197,13 +197,8 @@ void AssertPlanExecutionResult(const std::shared_ptr<Table> expected_table,
                                const compute::Declaration& source_declaration,
                                const std::shared_ptr<Schema>& schema,
                                compute::ExecContext& exec_context) {
-  arrow::AsyncGenerator<util::optional<compute::ExecBatch>> sink_gen;
-  auto sink_node_options = compute::SinkNodeOptions{&sink_gen};
-  auto sink_declaration = compute::Declaration({"sink", sink_node_options, "e"});
-  auto declarations =
-      compute::Declaration::Sequence({source_declaration, sink_declaration});
   ASSERT_OK_AND_ASSIGN(auto output_table,
-                       GetTableFromPlan(declarations, sink_gen, exec_context, schema));
+                       GetTableFromPlan(source_declaration, exec_context, schema));
   ASSERT_TRUE(expected_table->Equals(*output_table));
 }
 
@@ -2290,7 +2285,7 @@ TEST(SubstraitRoundTrip, BasicPlanEndToEnd) {
   auto declarations = compute::Declaration::Sequence(
       {compute::Declaration(
            {"scan", dataset::ScanNodeOptions{dataset, scan_options}, "s"}),
-       compute::Declaration({"filter", compute::FilterNodeOptions{filter}, "f"})});
+       compute::Declaration({"filter", compute::FilterNodeOptions{filter_expr}, "f"})});
 
   ASSERT_OK_AND_ASSIGN(auto expected_table,
                        GetTableFromPlan(declarations, exec_context, dummy_schema));
@@ -2354,7 +2349,7 @@ TEST(Substrait, FilterProjectPlanRoundTripping) {
   ASSERT_OK_AND_ASSIGN(auto file_path, tempdir->path().Join(file_name));
   std::string file_path_str = file_path.ToString();
 
-  ARROW_EXPECT_OK(WriteIpcData(file_path_str, filesystem, table));
+  WriteIpcData(file_path_str, filesystem, table);
 
   std::vector<fs::FileInfo> files;
   const std::vector<std::string> f_paths = {file_path_str};
@@ -2382,14 +2377,11 @@ TEST(Substrait, FilterProjectPlanRoundTripping) {
       compute::field_ref("distinct"), project_expr};
   std::vector<compute::Expression> substrait_project_exprs = {project_expr};
 
-  arrow::AsyncGenerator<util::optional<compute::ExecBatch>> sink_gen;
-
   auto acero_declarations = compute::Declaration::Sequence(
       {compute::Declaration(
            {"scan", dataset::ScanNodeOptions{dataset, scan_options}, "s"}),
        compute::Declaration(
-           {"project", compute::ProjectNodeOptions{acero_project_exprs}, "p"}),
-       compute::Declaration({"sink", compute::SinkNodeOptions{&sink_gen}, "e"})});
+           {"project", compute::ProjectNodeOptions{acero_project_exprs}, "p"})});
 
   // adding the project expression field to schema
   ASSERT_OK_AND_ASSIGN(auto project_schema,
@@ -2398,7 +2390,7 @@ TEST(Substrait, FilterProjectPlanRoundTripping) {
 
   ASSERT_OK_AND_ASSIGN(
       auto expected_table,
-      GetTableFromPlan(acero_declarations, sink_gen, exec_context, project_schema));
+      GetTableFromPlan(acero_declarations, exec_context, project_schema));
 
   std::shared_ptr<ExtensionIdRegistry> sp_ext_id_reg = MakeExtensionIdRegistry();
   ExtensionIdRegistry* ext_id_reg = sp_ext_id_reg.get();
@@ -2411,8 +2403,7 @@ TEST(Substrait, FilterProjectPlanRoundTripping) {
       {compute::Declaration(
            {"scan", dataset::ScanNodeOptions{dataset, scan_options}, "s"}),
        compute::Declaration(
-           {"project", compute::ProjectNodeOptions{substrait_project_exprs}, "p"}),
-       compute::Declaration({"sink", compute::SinkNodeOptions{&sink_gen}, "e"})});
+           {"project", compute::ProjectNodeOptions{substrait_project_exprs}, "p"})});
 
   ASSERT_OK_AND_ASSIGN(auto serialized_plan,
                        SerializePlan(substrait_declarations, &ext_set));

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -152,33 +152,13 @@ void AssertScanRelation(const compute::Declaration& output_scan,
   }
 }
 
-void AssertExpressionCall(const std::shared_ptr<Schema> schema,
-                          const compute::Expression output_expr,
-                          const compute::Expression& expected_expr) {
-  if (auto* out_call = output_expr.call()) {
-    if (auto* exp_call = expected_expr.call()) {
-      ASSERT_EQ(out_call->function_name, exp_call->function_name);
-      auto out_args = out_call->arguments;
-      auto exp_args = exp_call->arguments;
-      ASSERT_EQ(out_args.size(), exp_args.size());
-      int exp_id = 0;
-      for (const auto& arg : exp_args) {
-        // auto lhs = out_args[exp_id++].field_ref()->field_path()->indices()[0];
-        // ASSERT_EQ(schema->field_names()[lhs], *(arg.field_ref()->name()));
-        ASSERT_TRUE(arg.Equals(out_args[exp_id++]));
-      }
-    } else {
-    }
-  }
-}
-
 void AssertFilterRelation(const compute::Declaration& output_filter,
                           const compute::Expression& exp_filter_expr,
                           const std::shared_ptr<Schema>& schema) {
   const auto& filter_opts =
       checked_cast<const compute::FilterNodeOptions&>(*(output_filter.options));
   auto out_filter_expr = filter_opts.filter_expression;
-  AssertExpressionCall(schema, out_filter_expr, exp_filter_expr);
+  ASSERT_TRUE(out_filter_expr.Equals(exp_filter_expr));
 }
 
 void AssertProjectRelation(const compute::Declaration& output_projection,
@@ -190,7 +170,7 @@ void AssertProjectRelation(const compute::Declaration& output_projection,
   int expr_id = 0;
   ASSERT_EQ(out_expressions.size(), exp_expressions.size());
   for (const auto& out_expr : out_expressions) {
-    AssertExpressionCall(schema, out_expr, exp_expressions[expr_id++]);
+    ASSERT_TRUE(out_expr.Equals(exp_expressions[expr_id++]));
   }
 }
 

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -2377,7 +2377,7 @@ TEST(Substrait, FilterProjectPlanRoundTripping) {
   // emit node used in the serialization outputs the 4th column since the
   // 0, 1, 2 original columns from the input data and 4th column being the
   // projected column.
-  auto expec_project_expr = {compute::field_ref(FieldPath({4}))};
+  auto expec_project_expr = {compute::field_ref(FieldPath({3}))};
   AssertProjectRelation(roundtripped_emit_project, expec_project_expr, project_schema);
 
   // assert projection declaration

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -2197,11 +2197,11 @@ TEST(SubstraitRoundTrip, BasicPlan) {
           *serialized_plan, [] { return kNullConsumer; }, ext_id_reg, &ext_set));
   // assert filter declaration
   const auto& roundtripped_filter =
-          std::get<compute::Declaration>(sink_decls[0].inputs[0]);
+      std::get<compute::Declaration>(sink_decls[0].inputs[0]);
   AssertFilterRelation(roundtripped_filter, std::move(filter_expr), dummy_schema);
   // assert scan declaration
-  auto roundtripped_scan = roundtripped_filter->inputs[0].get<compute::Declaration>();
-  AssertScanRelation(*roundtripped_scan, dataset, dummy_schema);
+  auto roundtripped_scan = std::get<compute::Declaration>(roundtripped_filter.inputs[0]);
+  AssertScanRelation(roundtripped_scan, dataset, dummy_schema);
 }
 
 TEST(SubstraitRoundTrip, BasicPlanEndToEnd) {
@@ -2277,13 +2277,15 @@ TEST(SubstraitRoundTrip, BasicPlanEndToEnd) {
       DeserializePlans(
           *serialized_plan, [] { return kNullConsumer; }, ext_id_reg, &ext_set));
   // assert filter declaration
-  auto& roundtripped_filter = std::get<compute::Declaration>(sink_decls[0].inputs[0]);
+  const auto& roundtripped_filter =
+      std::get<compute::Declaration>(sink_decls[0].inputs[0]);
   AssertFilterRelation(roundtripped_filter, std::move(filter_expr), dummy_schema);
   // assert scan declaration
-  auto roundtripped_scan = roundtripped_filter->inputs[0].get<compute::Declaration>();
-  AssertScanRelation(*roundtripped_scan, dataset, dummy_schema);
+  const auto& roundtripped_scan =
+      std::get<compute::Declaration>(roundtripped_filter.inputs[0]);
+  AssertScanRelation(roundtripped_scan, dataset, dummy_schema);
   // assert results
-  AssertPlanExecutionResult(expected_table, *roundtripped_filter, dummy_schema,
+  AssertPlanExecutionResult(expected_table, roundtripped_filter, dummy_schema,
                             exec_context);
 }
 
@@ -2388,18 +2390,20 @@ TEST(Substrait, FilterProjectPlanRoundTripping) {
       DeserializePlans(
           *serialized_plan, [] { return kNullConsumer; }, ext_id_reg, &ext_set));
   // assert project declaration
-  auto roundtripped_project = sink_decls[0].inputs[0].get<compute::Declaration>();
+  const auto& roundtripped_project =
+      std::get<compute::Declaration>(sink_decls[0].inputs[0]);
   // assert project declaration
   // Note: the provided expressions for Substrait declaration only contains one
   // expression, but substrait produces expressions for the existing number of fields plus
   // provided expression. Since the output expressions from the deserialized relation
   // contains fields which weren't used in the project expression.
-  AssertProjectRelation(*roundtripped_project, acero_project_fp_exprs, project_schema);
+  AssertProjectRelation(roundtripped_project, acero_project_fp_exprs, project_schema);
   // assert scan declaration
-  auto roundtripped_scan = roundtripped_project->inputs[0].get<compute::Declaration>();
-  AssertScanRelation(*roundtripped_scan, dataset, dummy_schema);
+  const auto& roundtripped_scan =
+      std::get<compute::Declaration>(roundtripped_project.inputs[0]);
+  AssertScanRelation(roundtripped_scan, dataset, dummy_schema);
   // assert results
-  AssertPlanExecutionResult(expected_table, *roundtripped_project, project_schema,
+  AssertPlanExecutionResult(expected_table, roundtripped_project, project_schema,
                             exec_context);
 }
 


### PR DESCRIPTION
This PR contains an extension to the roundtrip test support for Acero-Substrait. In this extension, the Project relation roundtrip integration and tests are added.