### PR TITLE
ARROW-17647: [C++] Using better namespace style when using protobuf with Substrait

### DIFF
--- a/cpp/src/arrow/engine/substrait/expression_internal.cc
+++ b/cpp/src/arrow/engine/substrait/expression_internal.cc
@@ -1011,7 +1011,7 @@ Result<std::unique_ptr<substrait::Expression>> ToProto(
     if (arguments[0]->has_selection() &&
         arguments[0]->selection().has_direct_reference()) {
       if (arguments[1]->has_literal() && arguments[1]->literal().literal_type_case() ==
-                                             substrait::Expression_Literal::kI32) {
+                                             substrait::Expression::Literal::kI32) {
         return MakeListElementReference(std::move(arguments[0]),
                                         arguments[1]->literal().i32());
       }

--- a/cpp/src/arrow/engine/substrait/type_internal.cc
+++ b/cpp/src/arrow/engine/substrait/type_internal.cc
@@ -398,7 +398,7 @@ struct DataTypeToProtoImpl {
   template <typename T>
   Status EncodeUserDefined(const T& t) {
     ARROW_ASSIGN_OR_RAISE(auto anchor, ext_set_->EncodeType(t));
-    auto user_defined = internal::make_unique<::substrait::Type_UserDefined>();
+    auto user_defined = internal::make_unique<::substrait::Type::UserDefined>();
     user_defined->set_type_reference(anchor);
     user_defined->set_nullability(nullable_ ? ::substrait::Type::NULLABILITY_NULLABLE
                                             : ::substrait::Type::NULLABILITY_REQUIRED);


### PR DESCRIPTION
This PR includes minor changes to the namespace usage in Substrait integation.