### PR TITLE
ARROW-17689: [R] Implement dplyr::across() inside group_by()

### DIFF
--- a/r/R/dplyr-group-by.R
+++ b/r/R/dplyr-group-by.R
@@ -24,32 +24,23 @@ group_by.arrow_dplyr_query <- function(.data,
                                        add = .add,
                                        .drop = dplyr::group_by_drop_default(.data)) {
   .data <- as_adq(.data)
-  new_groups <- enquos(...)
-  # ... can contain expressions (i.e. can add (or rename?) columns) and so we
-  # need to identify those and add them on to the query with mutate. Specifically,
-  # we want to mark as new:
-  #   * expressions (named or otherwise)
-  #   * variables that have new names
-  # All others (i.e. simple references to variables) should not be (re)-added
+  expression_list <- expand_across(.data, quos(...))
+  new_groups <- ensure_named_exprs(expression_list)
 
-  # Identify any groups with names which aren't in names of .data
-  new_group_ind <- map_lgl(new_groups, ~ !(quo_name(.x) %in% names(.data)))
-  # Identify any groups which don't have names
-  named_group_ind <- map_lgl(names(new_groups), nzchar)
-  # Retain any new groups identified above
-  new_groups <- new_groups[new_group_ind | named_group_ind]
   if (length(new_groups)) {
-    # now either use the name that was given in ... or if that is "" then use the expr
-    names(new_groups) <- imap_chr(new_groups, ~ ifelse(.y == "", quo_name(.x), .y))
-
     # Add them to the data
     .data <- dplyr::mutate(.data, !!!new_groups)
   }
-  if (".add" %in% names(formals(dplyr::group_by))) {
-    # For compatibility with dplyr >= 1.0
-    gv <- dplyr::group_by_prepare(.data, ..., .add = .add)$group_names
+
+  if (!".add" %in% names(formals(dplyr::group_by))) {
+    # For compatibility with dplyr < 1.0
+    .add <- add
+  }
+
+  if (.add) {
+    gv <- dplyr::union(.data$group_by_vars, names(new_groups))
   } else {
-    gv <- dplyr::group_by_prepare(.data, ..., add = add)$group_names
+    gv <- names(new_groups)
   }
   .data$group_by_vars <- gv
   .data$drop_empty_groups <- ifelse(length(gv), .drop, dplyr::group_by_drop_default(.data))

--- a/r/R/dplyr-group-by.R
+++ b/r/R/dplyr-group-by.R
@@ -25,10 +25,7 @@ group_by.arrow_dplyr_query <- function(.data,
                                        .drop = dplyr::group_by_drop_default(.data)) {
   if (!missing(add)) {
     .Deprecated(
-      msg = paste(
-        "The `add` argument of `group_by()` is deprecated.",
-        "Please use the `.add` argument instead."
-      )
+      msg = paste("The `add` argument of `group_by()` is deprecated. Please use the `.add` argument instead.")
     )
     .add <- add
   }
@@ -47,6 +44,7 @@ group_by.arrow_dplyr_query <- function(.data,
   } else {
     gv <- names(new_groups)
   }
+
   .data$group_by_vars <- gv %||% character()
   .data$drop_empty_groups <- ifelse(length(gv), .drop, dplyr::group_by_drop_default(.data))
   .data

--- a/r/R/dplyr-group-by.R
+++ b/r/R/dplyr-group-by.R
@@ -21,8 +21,18 @@
 group_by.arrow_dplyr_query <- function(.data,
                                        ...,
                                        .add = FALSE,
-                                       add = .add,
+                                       add = NULL,
                                        .drop = dplyr::group_by_drop_default(.data)) {
+  if (!missing(add)) {
+    .Deprecated(
+      msg = paste(
+        "The `add` argument of `group_by()` is deprecated.",
+        "Please use the `.add` argument instead."
+      )
+    )
+    .add <- add
+  }
+
   .data <- as_adq(.data)
   expression_list <- expand_across(.data, quos(...))
   new_groups <- ensure_named_exprs(expression_list)
@@ -32,13 +42,8 @@ group_by.arrow_dplyr_query <- function(.data,
     .data <- dplyr::mutate(.data, !!!new_groups)
   }
 
-  if (!".add" %in% names(formals(dplyr::group_by))) {
-    # For compatibility with dplyr < 1.0
-    .add <- add
-  }
-
   if (.add) {
-    gv <- dplyr::union(dplyr::group_vars(.data), names(new_groups))
+    gv <- union(dplyr::group_vars(.data), names(new_groups))
   } else {
     gv <- names(new_groups)
   }

--- a/r/R/dplyr-group-by.R
+++ b/r/R/dplyr-group-by.R
@@ -38,11 +38,11 @@ group_by.arrow_dplyr_query <- function(.data,
   }
 
   if (.add) {
-    gv <- dplyr::union(.data$group_by_vars, names(new_groups))
+    gv <- dplyr::union(dplyr::group_vars(.data), names(new_groups))
   } else {
     gv <- names(new_groups)
   }
-  .data$group_by_vars <- gv
+  .data$group_by_vars <- gv %||% character()
   .data$drop_empty_groups <- ifelse(length(gv), .drop, dplyr::group_by_drop_default(.data))
   .data
 }

--- a/r/tests/testthat/test-dplyr-group-by.R
+++ b/r/tests/testthat/test-dplyr-group-by.R
@@ -199,33 +199,33 @@ test_that("group_by() with .add", {
 })
 
 test_that("Can use across() within group_by()", {
-  test_groups <- c("starting_a_fight", "consoling_a_child", "petting_a_dog")
+  test_groups <- c("dbl", "int", "chr")
   compare_dplyr_binding(
     .input %>%
       group_by(across()) %>%
       collect(),
-    example_with_logical_factors
+    tbl
   )
   compare_dplyr_binding(
     .input %>%
-      group_by(across(starts_with("s"))) %>%
+      group_by(across(starts_with("d"))) %>%
       collect(),
-    example_with_logical_factors
+    tbl
   )
   compare_dplyr_binding(
     .input %>%
       group_by(across({{test_groups}})) %>%
       collect(),
-    example_with_logical_factors
+    tbl
   )
 
   # ARROW-12778 - `where()` is not yet supported
   expect_error(
     compare_dplyr_binding(
       .input %>%
-        group_by(across(where(is.double))) %>%
+        group_by(across(where(is.numeric))) %>%
         collect(),
-      example_data
+      tbl
     ),
     "Unsupported selection helper"
   )

--- a/r/tests/testthat/test-dplyr-group-by.R
+++ b/r/tests/testthat/test-dplyr-group-by.R
@@ -171,7 +171,7 @@ test_that("group_by() with .add", {
   compare_dplyr_binding(
     .input %>%
       group_by(dbl2) %>%
-      group_by() %>%
+      group_by(.add = FALSE) %>%
       collect(),
     tbl
   )
@@ -185,7 +185,7 @@ test_that("group_by() with .add", {
   compare_dplyr_binding(
     .input %>%
       group_by(dbl2) %>%
-      group_by(chr) %>%
+      group_by(chr, .add = FALSE) %>%
       collect(),
     tbl
   )
@@ -195,6 +195,22 @@ test_that("group_by() with .add", {
       group_by(chr, .add = TRUE) %>%
       collect(),
     tbl
+  )
+  expect_warning(
+    tbl %>%
+      arrow_table() %>%
+      group_by(add = TRUE) %>%
+      collect(),
+    "The `add` argument of `group_by\\(\\)` is deprecated"
+  )
+  expect_error(
+    suppressWarnings(
+      tbl %>%
+        arrow_table() %>%
+        group_by(add = dbl2) %>%
+        collect()
+    ),
+    "object 'dbl2' not found"
   )
 })
 
@@ -214,7 +230,7 @@ test_that("Can use across() within group_by()", {
   )
   compare_dplyr_binding(
     .input %>%
-      group_by(across({{test_groups}})) %>%
+      group_by(across({{ test_groups }})) %>%
       collect(),
     tbl
   )

--- a/r/tests/testthat/test-dplyr-group-by.R
+++ b/r/tests/testthat/test-dplyr-group-by.R
@@ -166,3 +166,36 @@ test_that("group_by() with namespaced functions", {
     tbl
   )
 })
+
+test_that("Can use across() within group_by()", {
+  test_groups <- c("starting_a_fight", "consoling_a_child", "petting_a_dog")
+  compare_dplyr_binding(
+    .input %>%
+      group_by(across()) %>%
+      collect(),
+    example_with_logical_factors
+  )
+  compare_dplyr_binding(
+    .input %>%
+      group_by(across(starts_with("s"))) %>%
+      collect(),
+    example_with_logical_factors
+  )
+  compare_dplyr_binding(
+    .input %>%
+      group_by(across({{test_groups}})) %>%
+      collect(),
+    example_with_logical_factors
+  )
+
+  # ARROW-12778 - `where()` is not yet supported
+  expect_error(
+    compare_dplyr_binding(
+      .input %>%
+        group_by(across(where(is.double))) %>%
+        collect(),
+      example_data
+    ),
+    "Unsupported selection helper"
+  )
+})

--- a/r/tests/testthat/test-dplyr-group-by.R
+++ b/r/tests/testthat/test-dplyr-group-by.R
@@ -196,6 +196,22 @@ test_that("group_by() with .add", {
       collect(),
     tbl
   )
+  suppressWarnings(compare_dplyr_binding(
+    .input %>%
+      group_by(dbl2) %>%
+      group_by(add = FALSE) %>%
+      collect(),
+    tbl,
+    warning = "deprecated"
+  ))
+  suppressWarnings(compare_dplyr_binding(
+    .input %>%
+      group_by(dbl2) %>%
+      group_by(add = TRUE) %>%
+      collect(),
+    tbl,
+    warning = "deprecated"
+  ))
   expect_warning(
     tbl %>%
       arrow_table() %>%

--- a/r/tests/testthat/test-dplyr-group-by.R
+++ b/r/tests/testthat/test-dplyr-group-by.R
@@ -167,6 +167,37 @@ test_that("group_by() with namespaced functions", {
   )
 })
 
+test_that("group_by() with .add", {
+  compare_dplyr_binding(
+    .input %>%
+      group_by(dbl2) %>%
+      group_by() %>%
+      collect(),
+    tbl
+  )
+  compare_dplyr_binding(
+    .input %>%
+      group_by(dbl2) %>%
+      group_by(.add = TRUE) %>%
+      collect(),
+    tbl
+  )
+  compare_dplyr_binding(
+    .input %>%
+      group_by(dbl2) %>%
+      group_by(chr) %>%
+      collect(),
+    tbl
+  )
+  compare_dplyr_binding(
+    .input %>%
+      group_by(dbl2) %>%
+      group_by(chr, .add = TRUE) %>%
+      collect(),
+    tbl
+  )
+})
+
 test_that("Can use across() within group_by()", {
   test_groups <- c("starting_a_fight", "consoling_a_child", "petting_a_dog")
   compare_dplyr_binding(

--- a/r/tests/testthat/test-dplyr-group-by.R
+++ b/r/tests/testthat/test-dplyr-group-by.R
@@ -196,6 +196,20 @@ test_that("group_by() with .add", {
       collect(),
     tbl
   )
+  compare_dplyr_binding(
+    .input %>%
+      group_by(chr, .add = FALSE) %>%
+      collect(),
+    tbl %>%
+      group_by(dbl2)
+  )
+  compare_dplyr_binding(
+    .input %>%
+      group_by(chr, .add = TRUE) %>%
+      collect(),
+    tbl %>%
+      group_by(dbl2)
+  )
   suppressWarnings(compare_dplyr_binding(
     .input %>%
       group_by(dbl2) %>%


### PR DESCRIPTION
Because the handling of the case `.add = TRUE` and the `add` argument have been changed, test cases for these are also added.