### PR TITLE
ARROW-17061: [Python][Substrait] Acero consumer is unable to consume count function from substrait query plan

### DIFF
--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -170,6 +170,8 @@ def test_get_supported_functions():
     assert has_function(supported_functions,
                         'functions_arithmetic.yaml', 'sum')
 
+# TODO: add a test suite to check the integrated functions
+
 
 @pytest.mark.skipif(sys.platform == 'win32',
                     reason="ARROW-16392: file based URI is" +


### PR DESCRIPTION
This PR is **WORK IN PROGRESS**. 

Testing the functions integrated to the Acero-Substrait via Python test cases.
Started possibly to test out a bug, but planning on re-iterating this into a function test suite.