### PR TITLE
ARROW-17733: [C++] Take index_width into account when filling nulls in index buffer

### DIFF
--- a/cpp/src/arrow/array/concatenate.cc
+++ b/cpp/src/arrow/array/concatenate.cc
@@ -311,8 +311,8 @@ class ConcatenateImpl {
                                                   /*dest_offset=*/position, run.length,
                                                   transpose_map));
           } else {
-            std::fill(out_data + position,
-                      out_data + position + (run.length * index_width), 0x00);
+            std::fill(out_data + (position * index_width),
+                      out_data + (position + run.length) * index_width, 0x00);
           }
 
           position += run.length;

--- a/cpp/src/arrow/array/concatenate_test.cc
+++ b/cpp/src/arrow/array/concatenate_test.cc
@@ -542,7 +542,9 @@ TEST_F(ConcatenateTest, OffsetOverflow) {
 TEST_F(ConcatenateTest, DictionaryConcatenateWithEmptyUint16) {
   auto dict_type = dictionary(uint16(), utf8());
   auto dict_one = DictArrayFromJSON(dict_type, "[]", "[]");
-  auto dict_two = DictArrayFromJSON(dict_type, "[0, 1, null]", "[\"A0\", \"A1\"]");
+  auto dict_two = DictArrayFromJSON(
+      dict_type, "[0, 1, null, null, null, null]",
+      "[\"A0\", \"A1\"]");
   ASSERT_OK_AND_ASSIGN(auto concat_actual, Concatenate({dict_one, dict_two}));
 
   AssertArraysEqual(*dict_two, *concat_actual);

--- a/cpp/src/arrow/array/concatenate_test.cc
+++ b/cpp/src/arrow/array/concatenate_test.cc
@@ -540,6 +540,7 @@ TEST_F(ConcatenateTest, OffsetOverflow) {
 }
 
 TEST_F(ConcatenateTest, DictionaryConcatenateWithEmptyUint16) {
+  // Regression test for ARROW-17733
   auto dict_type = dictionary(uint16(), utf8());
   auto dict_one = DictArrayFromJSON(dict_type, "[]", "[]");
   auto dict_two =

--- a/cpp/src/arrow/array/concatenate_test.cc
+++ b/cpp/src/arrow/array/concatenate_test.cc
@@ -542,9 +542,8 @@ TEST_F(ConcatenateTest, OffsetOverflow) {
 TEST_F(ConcatenateTest, DictionaryConcatenateWithEmptyUint16) {
   auto dict_type = dictionary(uint16(), utf8());
   auto dict_one = DictArrayFromJSON(dict_type, "[]", "[]");
-  auto dict_two = DictArrayFromJSON(
-      dict_type, "[0, 1, null, null, null, null]",
-      "[\"A0\", \"A1\"]");
+  auto dict_two =
+      DictArrayFromJSON(dict_type, "[0, 1, null, null, null, null]", "[\"A0\", \"A1\"]");
   ASSERT_OK_AND_ASSIGN(auto concat_actual, Concatenate({dict_one, dict_two}));
 
   AssertArraysEqual(*dict_two, *concat_actual);

--- a/cpp/src/arrow/array/concatenate_test.cc
+++ b/cpp/src/arrow/array/concatenate_test.cc
@@ -539,4 +539,13 @@ TEST_F(ConcatenateTest, OffsetOverflow) {
   ASSERT_RAISES(Invalid, Concatenate({fake_long, fake_long}).status());
 }
 
+TEST_F(ConcatenateTest, DictionaryConcatenateWithEmptyUint16) {
+  auto dict_type = dictionary(uint16(), utf8());
+  auto dict_one = DictArrayFromJSON(dict_type, "[]", "[]");
+  auto dict_two = DictArrayFromJSON(dict_type, "[0, 1, null]", "[\"A0\", \"A1\"]");
+  ASSERT_OK_AND_ASSIGN(auto concat_actual, Concatenate({dict_one, dict_two}));
+
+  AssertArraysEqual(*dict_two, *concat_actual);
+}
+
 }  // namespace arrow


### PR DESCRIPTION
Take into account index_width when offsetting by position into out_data. Otherwise we offset position bytes into the array, but we want to offset position places into the array.