### PR TITLE
ARROW-17172: [C++][Python] test_cython_api fails on windows

### DIFF
--- a/ci/appveyor-cpp-setup.bat
+++ b/ci/appveyor-cpp-setup.bat
@@ -55,6 +55,7 @@ mamba update -q -y -c conda-forge --all || exit /B
 @rem Create conda environment
 @rem
 
+set CONDA_DLL_SEARCH_MODIFICATION_ENABLE=1
 set CONDA_PACKAGES=
 
 if "%ARROW_BUILD_GANDIVA%" == "ON" (

--- a/ci/appveyor-cpp-setup.bat
+++ b/ci/appveyor-cpp-setup.bat
@@ -55,6 +55,11 @@ mamba update -q -y -c conda-forge --all || exit /B
 @rem Create conda environment
 @rem
 
+@rem Workaround for ARROW-17172
+@rem Due to failing test_cython_api() import of an external module in the
+@rem subprocess this env var is added for os.add_dll_directory to work as
+@rem expected in the conda environment and for the import to succeed.
+@rem See: https://github.com/ContinuumIO/anaconda-issues/issues/12475
 set CONDA_DLL_SEARCH_MODIFICATION_ENABLE=1
 set CONDA_PACKAGES=
 

--- a/ci/appveyor-cpp-setup.bat
+++ b/ci/appveyor-cpp-setup.bat
@@ -56,10 +56,8 @@ mamba update -q -y -c conda-forge --all || exit /B
 @rem
 
 @rem Workaround for ARROW-17172
-@rem Due to failing test_cython_api() import of an external module in the
-@rem subprocess this env var is added for os.add_dll_directory to work as
-@rem expected in the conda environment and for the import to succeed.
-@rem See: https://github.com/ContinuumIO/anaconda-issues/issues/12475
+@rem This seems necessary for test_cython.py to succeed, otherwise
+@rem the extension module being built would fail loading in a subprocess.
 set CONDA_DLL_SEARCH_MODIFICATION_ENABLE=1
 set CONDA_PACKAGES=
 

--- a/ci/appveyor-cpp-setup.bat
+++ b/ci/appveyor-cpp-setup.bat
@@ -55,7 +55,6 @@ mamba update -q -y -c conda-forge --all || exit /B
 @rem Create conda environment
 @rem
 
-set CONDA_DLL_SEARCH_MODIFICATION_ENABLE=1
 set CONDA_PACKAGES=
 
 if "%ARROW_BUILD_GANDIVA%" == "ON" (

--- a/python/pyarrow/tests/test_cython.py
+++ b/python/pyarrow/tests/test_cython.py
@@ -81,8 +81,6 @@ def check_cython_example_module(mod):
         mod.cast_scalar(scal, pa.list_(pa.int64()))
 
 
-@pytest.mark.skipif(sys.platform == "win32",
-                    reason="ARROW-17172: currently fails on windows")
 @pytest.mark.cython
 def test_cython_api(tmpdir):
     """


### PR DESCRIPTION
Tis PR adds `CONDA_DLL_SEARCH_MODIFICATION_ENABLE=1` to the AppVeyor setup to make `test_cython.py` succeed as the extension module being built fails loading in a subprocess otherwise.