### PR TITLE
ARROW-17715: [CI][C++][Python] Temporary allow failures for s390x on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -161,6 +161,8 @@ jobs:
 
   allow_failures:
     - name: "Java on s390x"
+    - name: "C++ on s390x"
+    - name: "Python on s390x"
 
 before_install:
   - eval "$(python ci/detect-changes.py)"


### PR DESCRIPTION
The s390x builds currently time out on Travis-CI while compiling Arrow C++.

I'll create a new ticket to follow this up but on the meantime we probably should allow them to fail.