### PR TITLE
ARROW-17736: [C++] Added a fallback name resolution mechanism to the Substrait producer.

### DIFF
--- a/cpp/src/arrow/engine/substrait/expression_internal.cc
+++ b/cpp/src/arrow/engine/substrait/expression_internal.cc
@@ -19,8 +19,8 @@
 
 #include "arrow/engine/substrait/expression_internal.h"
 
-#include <utility>
 #include <memory>
+#include <utility>
 
 #include "arrow/builder.h"
 #include "arrow/compute/exec/expression.h"
@@ -36,6 +36,21 @@ namespace arrow {
 using internal::checked_cast;
 
 namespace engine {
+
+namespace {
+
+Id NormalizeFunctionName(Id id) {
+  // Substrait plans encode the types into the function name so it might look like
+  // add:opt_i32_i32.  We don't care about  the :opt_i32_i32 so we just trim it
+  std::string_view func_name = id.name;
+  std::size_t colon_index = func_name.find_first_of(':');
+  if (colon_index != std::string_view::npos) {
+    func_name = func_name.substr(0, colon_index);
+  }
+  return {id.uri, func_name};
+}
+
+}  // namespace
 
 Status DecodeArg(const substrait::FunctionArgument& arg, uint32_t idx,
                  SubstraitCall* call, const ExtensionSet& ext_set,
@@ -112,6 +127,7 @@ Result<SubstraitCall> FromProto(const substrait::AggregateFunction& func, bool i
   ARROW_ASSIGN_OR_RAISE(auto output_type_and_nullable,
                         FromProto(func.output_type(), ext_set, conversion_options));
   ARROW_ASSIGN_OR_RAISE(Id id, ext_set.DecodeFunction(func.function_reference()));
+  id = NormalizeFunctionName(id);
   SubstraitCall call(id, output_type_and_nullable.first, output_type_and_nullable.second,
                      is_hash);
   for (int i = 0; i < func.arguments_size(); i++) {
@@ -248,7 +264,9 @@ Result<compute::Expression> FromProto(const substrait::Expression& expr,
 
       ARROW_ASSIGN_OR_RAISE(Id function_id,
                             ext_set.DecodeFunction(scalar_fn.function_reference()));
+      function_id = NormalizeFunctionName(function_id);
       ExtensionIdRegistry::SubstraitCallToArrow function_converter;
+
       if (function_id.uri.empty() || function_id.uri[0] == '/') {
         // Currently the Substrait project has not aligned on a standard URI and often
         // seems to use /.  In that case we fall back to name-only matching.

--- a/cpp/src/arrow/engine/substrait/expression_internal.cc
+++ b/cpp/src/arrow/engine/substrait/expression_internal.cc
@@ -256,9 +256,8 @@ Result<compute::Expression> FromProto(const substrait::Expression& expr,
             function_converter,
             ext_set.registry()->GetSubstraitCallToArrowFallback(function_id.name));
       } else {
-        ARROW_ASSIGN_OR_RAISE(
-            ExtensionIdRegistry::SubstraitCallToArrow function_converter,
-            ext_set.registry()->GetSubstraitCallToArrow(function_id));
+        ARROW_ASSIGN_OR_RAISE(function_converter,
+                              ext_set.registry()->GetSubstraitCallToArrow(function_id));
       }
       ARROW_ASSIGN_OR_RAISE(
           SubstraitCall substrait_call,

--- a/cpp/src/arrow/engine/substrait/extension_set.cc
+++ b/cpp/src/arrow/engine/substrait/extension_set.cc
@@ -534,6 +534,21 @@ struct ExtensionIdRegistryImpl : ExtensionIdRegistry {
     return maybe_converter->second;
   }
 
+  Result<SubstraitCallToArrow> GetSubstraitCallToArrowFallback(
+      util::string_view function_name) const override {
+    for (const auto& converter_item : substrait_to_arrow_) {
+      if (converter_item.first.name == function_name) {
+        return converter_item.second;
+      }
+    }
+    if (parent_) {
+      return parent_->GetSubstraitCallToArrowFallback(function_name);
+    }
+    return Status::NotImplemented(
+        "No conversion function exists to convert the Substrait function ", function_name,
+        " to an Arrow call expression");
+  }
+
   Result<SubstraitAggregateToArrow> GetSubstraitAggregateToArrow(
       Id substrait_function_id) const override {
     auto maybe_converter = substrait_to_arrow_agg_.find(substrait_function_id);
@@ -547,6 +562,21 @@ struct ExtensionIdRegistryImpl : ExtensionIdRegistry {
           " to an Arrow aggregate");
     }
     return maybe_converter->second;
+  }
+
+  Result<SubstraitAggregateToArrow> GetSubstraitAggregateToArrowFallback(
+      util::string_view function_name) const override {
+    for (const auto& converter_item : substrait_to_arrow_agg_) {
+      if (converter_item.first.name == function_name) {
+        return converter_item.second;
+      }
+    }
+    if (parent_) {
+      return parent_->GetSubstraitAggregateToArrowFallback(function_name);
+    }
+    return Status::NotImplemented(
+        "No conversion function exists to convert the Substrait aggregate function ",
+        function_name, " to an Arrow call expression");
   }
 
   Result<ArrowToSubstraitCall> GetArrowToSubstraitCall(

--- a/cpp/src/arrow/engine/substrait/extension_set.cc
+++ b/cpp/src/arrow/engine/substrait/extension_set.cc
@@ -30,9 +30,6 @@ namespace arrow {
 namespace engine {
 namespace {
 
-// TODO(ARROW-16988): replace this with EXACT_ROUNDTRIP mode
-constexpr bool kExactRoundTrip = true;
-
 struct TypePtrHashEq {
   template <typename Ptr>
   size_t operator()(const Ptr& type) const {
@@ -212,7 +209,8 @@ Status ExtensionSet::AddUri(Id id) {
 Result<ExtensionSet> ExtensionSet::Make(
     std::unordered_map<uint32_t, std::string_view> uris,
     std::unordered_map<uint32_t, Id> type_ids,
-    std::unordered_map<uint32_t, Id> function_ids, const ExtensionIdRegistry* registry) {
+    std::unordered_map<uint32_t, Id> function_ids,
+    const ConversionOptions& conversion_options, const ExtensionIdRegistry* registry) {
   ExtensionSet set(default_extension_id_registry());
   set.registry_ = registry;
 
@@ -221,7 +219,7 @@ Result<ExtensionSet> ExtensionSet::Make(
     if (maybe_uri_internal) {
       set.uris_[uri.first] = *maybe_uri_internal;
     } else {
-      if (kExactRoundTrip) {
+      if (conversion_options.strictness == ConversionStrictness::EXACT_ROUNDTRIP) {
         return Status::Invalid(
             "Plan contained a URI that the extension registry is unaware of: ",
             uri.second);
@@ -251,7 +249,7 @@ Result<ExtensionSet> ExtensionSet::Make(
     if (maybe_id_internal) {
       set.functions_[function_id.first] = *maybe_id_internal;
     } else {
-      if (kExactRoundTrip) {
+      if (conversion_options.strictness == ConversionStrictness::EXACT_ROUNDTRIP) {
         return Status::Invalid(
             "Plan contained a function id that the extension registry is unaware of: ",
             function_id.second.uri, "#", function_id.second.name);

--- a/cpp/src/arrow/engine/substrait/extension_set.cc
+++ b/cpp/src/arrow/engine/substrait/extension_set.cc
@@ -119,9 +119,7 @@ class IdStorageImpl : public IdStorage {
   std::list<std::string> owned_names_;
 };
 
-std::unique_ptr<IdStorage> IdStorage::Make() {
-  return std::make_unique<IdStorageImpl>();
-}
+std::unique_ptr<IdStorage> IdStorage::Make() { return std::make_unique<IdStorageImpl>(); }
 
 Result<std::optional<std::string_view>> SubstraitCall::GetEnumArg(uint32_t index) const {
   if (index >= size_) {
@@ -533,7 +531,7 @@ struct ExtensionIdRegistryImpl : ExtensionIdRegistry {
   }
 
   Result<SubstraitCallToArrow> GetSubstraitCallToArrowFallback(
-      util::string_view function_name) const override {
+      std::string_view function_name) const override {
     for (const auto& converter_item : substrait_to_arrow_) {
       if (converter_item.first.name == function_name) {
         return converter_item.second;
@@ -563,7 +561,7 @@ struct ExtensionIdRegistryImpl : ExtensionIdRegistry {
   }
 
   Result<SubstraitAggregateToArrow> GetSubstraitAggregateToArrowFallback(
-      util::string_view function_name) const override {
+      std::string_view function_name) const override {
     for (const auto& converter_item : substrait_to_arrow_agg_) {
       if (converter_item.first.name == function_name) {
         return converter_item.second;

--- a/cpp/src/arrow/engine/substrait/extension_set.h
+++ b/cpp/src/arrow/engine/substrait/extension_set.h
@@ -253,6 +253,20 @@ class ARROW_ENGINE_EXPORT ExtensionIdRegistry {
   /// \return A converter function or an invalid status if no converter is registered
   virtual Result<SubstraitCallToArrow> GetSubstraitCallToArrow(
       Id substrait_function_id) const = 0;
+
+  /// \brief Similar to \see GetSubstraitCallToArrow but only uses the name
+  ///
+  /// There may be multiple functions with the same name and this will return
+  /// the first.  This is slower than GetSubstraitCallToArrow and should only
+  /// be used when the plan does not include a URI (or the URI is "/")
+  virtual Result<SubstraitCallToArrow> GetSubstraitCallToArrowFallback(
+      util::string_view function_name) const = 0;
+
+  /// \brief Similar to \see GetSubstraitAggregateToArrow but only uses the name
+  ///
+  /// \see GetSubstraitCallToArrowFallback for details on the fallback behavior
+  virtual Result<SubstraitAggregateToArrow> GetSubstraitAggregateToArrowFallback(
+      util::string_view function_name) const = 0;
 };
 
 constexpr std::string_view kArrowExtTypesUri =

--- a/cpp/src/arrow/engine/substrait/extension_set.h
+++ b/cpp/src/arrow/engine/substrait/extension_set.h
@@ -261,13 +261,13 @@ class ARROW_ENGINE_EXPORT ExtensionIdRegistry {
   /// the first.  This is slower than GetSubstraitCallToArrow and should only
   /// be used when the plan does not include a URI (or the URI is "/")
   virtual Result<SubstraitCallToArrow> GetSubstraitCallToArrowFallback(
-      util::string_view function_name) const = 0;
+      std::string_view function_name) const = 0;
 
   /// \brief Similar to \see GetSubstraitAggregateToArrow but only uses the name
   ///
   /// \see GetSubstraitCallToArrowFallback for details on the fallback behavior
   virtual Result<SubstraitAggregateToArrow> GetSubstraitAggregateToArrowFallback(
-      util::string_view function_name) const = 0;
+      std::string_view function_name) const = 0;
 };
 
 constexpr std::string_view kArrowExtTypesUri =

--- a/cpp/src/arrow/engine/substrait/extension_set.h
+++ b/cpp/src/arrow/engine/substrait/extension_set.h
@@ -32,6 +32,7 @@
 
 #include "arrow/compute/api_aggregate.h"
 #include "arrow/compute/exec/expression.h"
+#include "arrow/engine/substrait/options.h"
 #include "arrow/engine/substrait/visibility.h"
 #include "arrow/result.h"
 #include "arrow/type_fwd.h"
@@ -353,6 +354,7 @@ class ARROW_ENGINE_EXPORT ExtensionSet {
       std::unordered_map<uint32_t, std::string_view> uris,
       std::unordered_map<uint32_t, Id> type_ids,
       std::unordered_map<uint32_t, Id> function_ids,
+      const ConversionOptions& conversion_options,
       const ExtensionIdRegistry* = default_extension_id_registry());
 
   const std::unordered_map<uint32_t, std::string_view>& uris() const { return uris_; }

--- a/cpp/src/arrow/engine/substrait/plan_internal.cc
+++ b/cpp/src/arrow/engine/substrait/plan_internal.cc
@@ -88,6 +88,7 @@ Status AddExtensionSetToPlan(const ExtensionSet& ext_set, substrait::Plan* plan)
 }
 
 Result<ExtensionSet> GetExtensionSetFromPlan(const substrait::Plan& plan,
+                                             const ConversionOptions& conversion_options,
                                              const ExtensionIdRegistry* registry) {
   if (registry == NULLPTR) {
     registry = default_extension_id_registry();
@@ -128,7 +129,7 @@ Result<ExtensionSet> GetExtensionSetFromPlan(const substrait::Plan& plan,
   }
 
   return ExtensionSet::Make(std::move(uris), std::move(type_ids), std::move(function_ids),
-                            registry);
+                            conversion_options, registry);
 }
 
 Result<std::unique_ptr<substrait::Plan>> PlanToProto(

--- a/cpp/src/arrow/engine/substrait/plan_internal.h
+++ b/cpp/src/arrow/engine/substrait/plan_internal.h
@@ -50,7 +50,7 @@ Status AddExtensionSetToPlan(const ExtensionSet& ext_set, substrait::Plan* plan)
 /// correspond to Substrait's URI/name pairs
 ARROW_ENGINE_EXPORT
 Result<ExtensionSet> GetExtensionSetFromPlan(
-    const substrait::Plan& plan,
+    const substrait::Plan& plan, const ConversionOptions& conversion_options,
     const ExtensionIdRegistry* registry = default_extension_id_registry());
 
 /// \brief Serialize a declaration into a substrait::Plan.

--- a/cpp/src/arrow/engine/substrait/serde.cc
+++ b/cpp/src/arrow/engine/substrait/serde.cc
@@ -145,7 +145,8 @@ Result<std::vector<compute::Declaration>> DeserializePlans(
     const ConversionOptions& conversion_options) {
   ARROW_ASSIGN_OR_RAISE(auto plan, ParseFromBuffer<substrait::Plan>(buf));
 
-  ARROW_ASSIGN_OR_RAISE(auto ext_set, GetExtensionSetFromPlan(plan, registry));
+  ARROW_ASSIGN_OR_RAISE(auto ext_set,
+                        GetExtensionSetFromPlan(plan, conversion_options, registry));
 
   std::vector<compute::Declaration> sink_decls;
   for (const substrait::PlanRel& plan_rel : plan.relations()) {

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -95,7 +95,10 @@ Result<std::shared_ptr<Table>> GetTableFromPlan(
 
   RETURN_NOT_OK(plan->Validate());
   RETURN_NOT_OK(plan->StartProducing());
-  return arrow::Table::FromRecordBatchReader(sink_reader.get());
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Table> table,
+                        arrow::Table::FromRecordBatchReader(sink_reader.get()));
+  RETURN_NOT_OK(plan->finished().status());
+  return table;
 }
 
 class NullSinkNodeConsumer : public compute::SinkNodeConsumer {

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -3078,7 +3078,7 @@ TEST(Substrait, AggregateRelEmit) {
                        buf, {}, conversion_options);
 }
 
-TEST(Substrait, IsthmustPlan) {
+TEST(Substrait, IsthmusPlan) {
   // This is a plan generated from Isthmus
   // isthmus -c "CREATE TABLE T1(foo int)" "SELECT foo + 1 FROM T1"
   //


### PR DESCRIPTION
This will only be used if the URI part of the function reference is empty or /.  This is for compatibility with Isthmus which still hasn't decided what to use for the URI portion.  Longer term we may remove this.  Or we may leave it in as a utility for developers of new functions that don't want to have to worry about the URI initially.