### PR TITLE
ARROW-17450 : [C++][Parquet] Support RLE decode for boolean datatype

### DIFF
--- a/cpp/src/arrow/util/bpacking.cc
+++ b/cpp/src/arrow/util/bpacking.cc
@@ -153,13 +153,14 @@ struct Unpack32DynamicFunction {
   using FunctionType = decltype(&unpack32_default);
 
   static std::vector<std::pair<DispatchLevel, FunctionType>> implementations() {
-    return {
-      { DispatchLevel::NONE, unpack32_default }
+    return {{DispatchLevel::NONE, unpack32_default}
 #if defined(ARROW_HAVE_RUNTIME_AVX2)
-      , { DispatchLevel::AVX2, unpack32_avx2 }
+            ,
+            {DispatchLevel::AVX2, unpack32_avx2}
 #endif
 #if defined(ARROW_HAVE_RUNTIME_AVX512)
-      , { DispatchLevel::AVX512, unpack32_avx512 }
+            ,
+            {DispatchLevel::AVX512, unpack32_avx512}
 #endif
     };
   }

--- a/cpp/src/arrow/util/bpacking.cc
+++ b/cpp/src/arrow/util/bpacking.cc
@@ -153,14 +153,13 @@ struct Unpack32DynamicFunction {
   using FunctionType = decltype(&unpack32_default);
 
   static std::vector<std::pair<DispatchLevel, FunctionType>> implementations() {
-    return {{DispatchLevel::NONE, unpack32_default}
+    return {
+      { DispatchLevel::NONE, unpack32_default }
 #if defined(ARROW_HAVE_RUNTIME_AVX2)
-            ,
-            {DispatchLevel::AVX2, unpack32_avx2}
+      , { DispatchLevel::AVX2, unpack32_avx2 }
 #endif
 #if defined(ARROW_HAVE_RUNTIME_AVX512)
-            ,
-            {DispatchLevel::AVX512, unpack32_avx512}
+      , { DispatchLevel::AVX512, unpack32_avx512 }
 #endif
     };
   }

--- a/cpp/src/arrow/util/endian.h
+++ b/cpp/src/arrow/util/endian.h
@@ -122,28 +122,28 @@ static inline void ByteSwap(void* dst, const void* src, int len) {
 #if ARROW_LITTLE_ENDIAN
 template <typename T, typename = internal::EnableIfIsOneOf<
                           T, int64_t, uint64_t, int32_t, uint32_t, int16_t, uint16_t,
-                          uint8_t, int8_t, float, double>>
+                          uint8_t, int8_t, float, double, bool>>
 static inline T ToBigEndian(T value) {
   return ByteSwap(value);
 }
 
 template <typename T, typename = internal::EnableIfIsOneOf<
                           T, int64_t, uint64_t, int32_t, uint32_t, int16_t, uint16_t,
-                          uint8_t, int8_t, float, double>>
+                          uint8_t, int8_t, float, double, bool>>
 static inline T ToLittleEndian(T value) {
   return value;
 }
 #else
 template <typename T, typename = internal::EnableIfIsOneOf<
                           T, int64_t, uint64_t, int32_t, uint32_t, int16_t, uint16_t,
-                          uint8_t, int8_t, float, double>>
+                          uint8_t, int8_t, float, double, bool>>
 static inline T ToBigEndian(T value) {
   return value;
 }
 
 template <typename T, typename = internal::EnableIfIsOneOf<
                           T, int64_t, uint64_t, int32_t, uint32_t, int16_t, uint16_t,
-                          uint8_t, int8_t, float, double>>
+                          uint8_t, int8_t, float, double, bool>>
 static inline T ToLittleEndian(T value) {
   return ByteSwap(value);
 }
@@ -153,28 +153,28 @@ static inline T ToLittleEndian(T value) {
 #if ARROW_LITTLE_ENDIAN
 template <typename T, typename = internal::EnableIfIsOneOf<
                           T, int64_t, uint64_t, int32_t, uint32_t, int16_t, uint16_t,
-                          uint8_t, int8_t, float, double>>
+                          uint8_t, int8_t, float, double, bool>>
 static inline T FromBigEndian(T value) {
   return ByteSwap(value);
 }
 
 template <typename T, typename = internal::EnableIfIsOneOf<
                           T, int64_t, uint64_t, int32_t, uint32_t, int16_t, uint16_t,
-                          uint8_t, int8_t, float, double>>
+                          uint8_t, int8_t, float, double, bool>>
 static inline T FromLittleEndian(T value) {
   return value;
 }
 #else
 template <typename T, typename = internal::EnableIfIsOneOf<
                           T, int64_t, uint64_t, int32_t, uint32_t, int16_t, uint16_t,
-                          uint8_t, int8_t, float, double>>
+                          uint8_t, int8_t, float, double, bool>>
 static inline T FromBigEndian(T value) {
   return value;
 }
 
 template <typename T, typename = internal::EnableIfIsOneOf<
                           T, int64_t, uint64_t, int32_t, uint32_t, int16_t, uint16_t,
-                          uint8_t, int8_t, float, double>>
+                          uint8_t, int8_t, float, double, bool>>
 static inline T FromLittleEndian(T value) {
   return ByteSwap(value);
 }

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -801,6 +801,12 @@ class ColumnReaderImplBase {
           decoders_[static_cast<int>(encoding)] = std::move(decoder);
           break;
         }
+        case Encoding::RLE: {
+          auto decoder = MakeTypedDecoder<DType>(Encoding::RLE, descr_);
+          current_decoder_ = decoder.get();
+          decoders_[static_cast<int>(encoding)] = std::move(decoder);
+          break;
+        }
         case Encoding::RLE_DICTIONARY:
           throw ParquetException("Dictionary page must be before data page.");
 

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -1146,8 +1146,7 @@ int PlainDecoder<DType>::Decode(T* buffer, int max_values) {
   return max_values;
 }
 
-class PlainBooleanDecoder : public DecoderImpl,
-                            virtual public TypedDecoder<BooleanType> {
+class PlainBooleanDecoder : public DecoderImpl, virtual public TypedDecoder<BooleanType> {
  public:
   explicit PlainBooleanDecoder(const ColumnDescriptor* descr);
   void SetData(int num_values, const uint8_t* data, int len) override;

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -2387,17 +2387,16 @@ class RleBooleanDecoder : public DecoderImpl, virtual public BooleanDecoder {
   int Decode(bool* buffer, int max_values) override {
     max_values = std::min(max_values, num_values_);
 
-
-if (decoder_->GetBatch(buffer, max_values) != max_values) {
-     ParquetException::EofException();
-}
+    if (decoder_->GetBatch(buffer, max_values) != max_values) {
+      ParquetException::EofException();
+    }
     num_values_ -= max_values;
     return max_values;
   }
 
-    int Decode(uint8_t* buffer, int max_values) override {
-        ParquetException::NYI("Decode with uint8_t for RleBooleanDecoder");
-    }
+  int Decode(uint8_t* buffer, int max_values) override {
+    ParquetException::NYI("Decode with uint8_t for RleBooleanDecoder");
+  }
 
   int DecodeArrow(int num_values, int null_count, const uint8_t* valid_bits,
                   int64_t valid_bits_offset,

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -1147,14 +1147,11 @@ int PlainDecoder<DType>::Decode(T* buffer, int max_values) {
 }
 
 class PlainBooleanDecoder : public DecoderImpl,
-                            virtual public TypedDecoder<BooleanType>,
-                            virtual public BooleanDecoder {
+                            virtual public TypedDecoder<BooleanType> {
  public:
   explicit PlainBooleanDecoder(const ColumnDescriptor* descr);
   void SetData(int num_values, const uint8_t* data, int len) override;
 
-  // Two flavors of bool decoding
-  int Decode(uint8_t* buffer, int max_values) override;
   int Decode(bool* buffer, int max_values) override;
   int DecodeArrow(int num_values, int null_count, const uint8_t* valid_bits,
                   int64_t valid_bits_offset,
@@ -1203,24 +1200,6 @@ inline int PlainBooleanDecoder::DecodeArrow(
     int num_values, int null_count, const uint8_t* valid_bits, int64_t valid_bits_offset,
     typename EncodingTraits<BooleanType>::DictAccumulator* builder) {
   ParquetException::NYI("dictionaries of BooleanType");
-}
-
-int PlainBooleanDecoder::Decode(uint8_t* buffer, int max_values) {
-  max_values = std::min(max_values, num_values_);
-  bool val;
-  ::arrow::internal::BitmapWriter bit_writer(buffer, 0, max_values);
-  for (int i = 0; i < max_values; ++i) {
-    if (!bit_reader_->GetValue(1, &val)) {
-      ParquetException::EofException();
-    }
-    if (val) {
-      bit_writer.Set();
-    }
-    bit_writer.Next();
-  }
-  bit_writer.Finish();
-  num_values_ -= max_values;
-  return max_values;
 }
 
 int PlainBooleanDecoder::Decode(bool* buffer, int max_values) {
@@ -2358,7 +2337,7 @@ class DeltaLengthByteArrayDecoder : public DecoderImpl,
 // ----------------------------------------------------------------------
 // RLE_BOOLEAN_DECODER
 
-class RleBooleanDecoder : public DecoderImpl, virtual public BooleanDecoder {
+class RleBooleanDecoder : public DecoderImpl, virtual public TypedDecoder<BooleanType> {
  public:
   explicit RleBooleanDecoder(const ColumnDescriptor* descr)
       : DecoderImpl(descr, Encoding::RLE) {}
@@ -2392,10 +2371,6 @@ class RleBooleanDecoder : public DecoderImpl, virtual public BooleanDecoder {
     }
     num_values_ -= max_values;
     return max_values;
-  }
-
-  int Decode(uint8_t* buffer, int max_values) override {
-    ParquetException::NYI("Decode with uint8_t for RleBooleanDecoder");
   }
 
   int DecodeArrow(int num_values, int null_count, const uint8_t* valid_bits,

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -2379,7 +2379,7 @@ class RleBooleanDecoder : public DecoderImpl, virtual public BooleanDecoder {
                              std::to_string(num_bytes) + " (corrupt data page?)");
     }
 
-    const uint8_t* decoder_data = data + 4;
+    auto decoder_data = data + 4;
     decoder_ = std::make_shared<::arrow::util::RleDecoder>(decoder_data, num_bytes,
                                                            /*bit_width=*/1);
   }

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -2356,6 +2356,83 @@ class DeltaLengthByteArrayDecoder : public DecoderImpl,
 };
 
 // ----------------------------------------------------------------------
+// RLE_BOOLEAN_DECODER
+
+class RleBooleanDecoder : public DecoderImpl,  virtual public BooleanDecoder {
+
+  public:
+    explicit RleBooleanDecoder(const ColumnDescriptor* descr)
+            :DecoderImpl(descr, Encoding::RLE) {}
+
+    void SetData(int num_values, const uint8_t* data, int len) override {
+      num_values_ = num_values;
+      int32_t num_bytes = 0;
+
+      if (len < 4) {
+        throw ParquetException("Received invalid length (corrupt data page?)");
+      }
+      // Load the first 4 bytes, which indicates the legnth
+      num_bytes = ::arrow::util::SafeLoadAs<int32_t>(data);
+      if (num_bytes < 0 || num_bytes > len - 4) {
+        throw ParquetException("Received invalid number of bytes (corrupt data page?)");
+      }
+
+      const uint8_t* decoder_data = data + 4;
+      if (len == 0) {
+        // Initialize dummy decoder to avoid crashes later on
+        decoder_ = std::make_shared<::arrow::util::RleDecoder>(decoder_data, num_bytes, /*bit_width=*/1);
+        return;
+      }
+
+      decoder_ = std::make_shared<::arrow::util::RleDecoder>(decoder_data, num_bytes, /*bit_width=*/1);
+    }
+
+    int Decode(bool* buffer, int max_values) override {
+      max_values = std::min(max_values, num_values_);
+      int val =0;
+
+      for (int i = 0; i < max_values; ++i) {
+        if (!decoder_->Get(&val)) {
+          throw ParquetException("Unable to parse bits (corrupt data page?)");
+        }
+        if (val) {
+          buffer[i] = true;
+        } else {
+          buffer[i] = false;
+        }
+      }
+      num_values_ -= max_values;
+      return max_values;
+    }
+
+    int Decode(uint8_t* buffer, int max_values) {
+      max_values = std::min(max_values, num_values_);
+      if (!decoder_->GetBatch(buffer, max_values)) {
+          ParquetException::EofException();
+      }
+
+      num_values_ -= max_values;
+      return max_values;
+    }
+
+    int DecodeArrow(int num_values, int null_count, const uint8_t* valid_bits,
+                    int64_t valid_bits_offset,
+                    typename EncodingTraits<BooleanType>::Accumulator* out) override {
+      ParquetException::NYI("DecodeArrow for RleBooleanDecoder");
+    }
+
+    int DecodeArrow(
+        int num_values, int null_count, const uint8_t* valid_bits,
+        int64_t valid_bits_offset,
+        typename EncodingTraits<BooleanType>::DictAccumulator* builder) override {
+      ParquetException::NYI("DecodeArrow for RleBooleanDecoder");
+    }
+
+  private:
+    std::shared_ptr<::arrow::util::RleDecoder> decoder_;
+};
+
+// ----------------------------------------------------------------------
 // DELTA_BYTE_ARRAY
 
 class DeltaByteArrayDecoder : public DecoderImpl,
@@ -2762,6 +2839,11 @@ std::unique_ptr<Decoder> MakeDecoder(Type::type type_num, Encoding::type encodin
       return std::make_unique<DeltaLengthByteArrayDecoder>(descr);
     }
     throw ParquetException("DELTA_LENGTH_BYTE_ARRAY only supports BYTE_ARRAY");
+  } else if (encoding == Encoding::RLE) {
+    if (type_num == Type::BOOLEAN) {
+      return std::unique_ptr<Decoder>(new RleBooleanDecoder(descr));
+    }
+    throw ParquetException("RLE encoding only supports BINARY");
   } else {
     ParquetException::NYI("Selected encoding is not supported");
   }

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -2390,7 +2390,7 @@ class RleBooleanDecoder : public DecoderImpl, virtual public BooleanDecoder {
 
     for (int i = 0; i < max_values; ++i) {
       if (!decoder_->Get(&val)) {
-        throw ParquetException("Unable to parse bits (corrupt data page?)");
+        throw ParquetException("Unable to parse bits for position (0 based) : " + std::to_string(i) + " (corrupt data page?)");
       }
       if (val) {
         buffer[i] = true;
@@ -2402,9 +2402,9 @@ class RleBooleanDecoder : public DecoderImpl, virtual public BooleanDecoder {
     return max_values;
   }
 
-  int Decode(uint8_t* buffer, int max_values) {
+  int Decode(uint8_t* buffer, int max_values) override {
     max_values = std::min(max_values, num_values_);
-    if (!decoder_->GetBatch(buffer, max_values)) {
+    if (decoder_->GetBatch(buffer, max_values) != max_values) {
       ParquetException::EofException();
     }
 

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -2390,7 +2390,8 @@ class RleBooleanDecoder : public DecoderImpl, virtual public BooleanDecoder {
 
     for (int i = 0; i < max_values; ++i) {
       if (!decoder_->Get(&val)) {
-        throw ParquetException("Unable to parse bits for position (0 based) : " + std::to_string(i) + " (corrupt data page?)");
+        throw ParquetException("Unable to parse bits for position (0 based) : " +
+                               std::to_string(i) + " (corrupt data page?)");
       }
       if (val) {
         buffer[i] = true;

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -2374,7 +2374,7 @@ class RleBooleanDecoder : public DecoderImpl, virtual public BooleanDecoder {
     // Load the first 4 bytes in little-endian, which indicates the length
     num_bytes =
         ::arrow::bit_util::ToLittleEndian(::arrow::util::SafeLoadAs<uint32_t>(data));
-    if (num_bytes < 0 || num_bytes > (uint32_t)(len - 4)) {
+    if (num_bytes < 0 || num_bytes > static_cast<uint32_t>(len - 4)) {
       throw ParquetException("Received invalid number of bytes : " +
                              std::to_string(num_bytes) + " (corrupt data page?)");
     }

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -2386,32 +2386,18 @@ class RleBooleanDecoder : public DecoderImpl, virtual public BooleanDecoder {
 
   int Decode(bool* buffer, int max_values) override {
     max_values = std::min(max_values, num_values_);
-    int val = 0;
 
-    for (int i = 0; i < max_values; ++i) {
-      if (!decoder_->Get(&val)) {
-        throw ParquetException("Unable to parse bits for position (0 based) : " +
-                               std::to_string(i) + " (corrupt data page?)");
-      }
-      if (val) {
-        buffer[i] = true;
-      } else {
-        buffer[i] = false;
-      }
-    }
+
+if (decoder_->GetBatch(buffer, max_values) != max_values) {
+     ParquetException::EofException();
+}
     num_values_ -= max_values;
     return max_values;
   }
 
-  int Decode(uint8_t* buffer, int max_values) override {
-    max_values = std::min(max_values, num_values_);
-    if (decoder_->GetBatch(buffer, max_values) != max_values) {
-      ParquetException::EofException();
+    int Decode(uint8_t* buffer, int max_values) override {
+        ParquetException::NYI("Decode with uint8_t for RleBooleanDecoder");
     }
-
-    num_values_ -= max_values;
-    return max_values;
-  }
 
   int DecodeArrow(int num_values, int null_count, const uint8_t* valid_bits,
                   int64_t valid_bits_offset,

--- a/cpp/src/parquet/encoding.h
+++ b/cpp/src/parquet/encoding.h
@@ -65,7 +65,7 @@ using FLBAEncoder = TypedEncoder<FLBAType>;
 template <typename DType>
 class TypedDecoder;
 
-class BooleanDecoder;
+using BooleanDecoder = TypedDecoder<BooleanType>;
 using Int32Decoder = TypedDecoder<Int32Type>;
 using Int64Decoder = TypedDecoder<Int64Type>;
 using Int96Decoder = TypedDecoder<Int96Type>;
@@ -393,12 +393,6 @@ class DictDecoder : virtual public TypedDecoder<DType> {
 
 // ----------------------------------------------------------------------
 // TypedEncoder specializations, traits, and factory functions
-
-class BooleanDecoder : virtual public TypedDecoder<BooleanType> {
- public:
-  using TypedDecoder<BooleanType>::Decode;
-  virtual int Decode(uint8_t* buffer, int max_values) = 0;
-};
 
 class FLBADecoder : virtual public TypedDecoder<FLBAType> {
  public:

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -54,7 +54,9 @@ namespace test {
 
 TEST(VectorBooleanTest, TestEncodeDecode) {
   // PARQUET-454
-  int nvalues = 10000;
+  const int nvalues = 10000;
+  bool decode_buffer[nvalues] = {false};
+
   int nbytes = static_cast<int>(bit_util::BytesForBits(nvalues));
 
   std::vector<bool> draws;
@@ -70,16 +72,13 @@ TEST(VectorBooleanTest, TestEncodeDecode) {
   std::shared_ptr<Buffer> encode_buffer = encoder->FlushValues();
   ASSERT_EQ(nbytes, encode_buffer->size());
 
-  std::vector<uint8_t> decode_buffer(nbytes);
-  const uint8_t* decode_data = &decode_buffer[0];
-
   decoder->SetData(nvalues, encode_buffer->data(),
                    static_cast<int>(encode_buffer->size()));
-  int values_decoded = decoder->Decode(&decode_buffer[0], nvalues);
+ int values_decoded = decoder->Decode(&decode_buffer[0], nvalues);
   ASSERT_EQ(nvalues, values_decoded);
 
   for (int i = 0; i < nvalues; ++i) {
-    ASSERT_EQ(draws[i], ::arrow::bit_util::GetBit(decode_data, i)) << i;
+    ASSERT_EQ(draws[i], decode_buffer[i]);
   }
 }
 

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -74,7 +74,7 @@ TEST(VectorBooleanTest, TestEncodeDecode) {
 
   decoder->SetData(nvalues, encode_buffer->data(),
                    static_cast<int>(encode_buffer->size()));
- int values_decoded = decoder->Decode(&decode_buffer[0], nvalues);
+  int values_decoded = decoder->Decode(&decode_buffer[0], nvalues);
   ASSERT_EQ(nvalues, values_decoded);
 
   for (int i = 0; i < nvalues; ++i) {

--- a/cpp/src/parquet/level_comparison.cc
+++ b/cpp/src/parquet/level_comparison.cc
@@ -44,10 +44,10 @@ struct GreaterThanDynamicFunction {
   using FunctionType = decltype(&GreaterThanBitmap);
 
   static std::vector<std::pair<DispatchLevel, FunctionType>> implementations() {
-    return {
-      { DispatchLevel::NONE, standard::GreaterThanBitmapImpl }
+    return {{DispatchLevel::NONE, standard::GreaterThanBitmapImpl}
 #if defined(ARROW_HAVE_RUNTIME_AVX2)
-      , { DispatchLevel::AVX2, GreaterThanBitmapAvx2 }
+            ,
+            {DispatchLevel::AVX2, GreaterThanBitmapAvx2}
 #endif
     };
   }
@@ -57,10 +57,10 @@ struct MinMaxDynamicFunction {
   using FunctionType = decltype(&FindMinMax);
 
   static std::vector<std::pair<DispatchLevel, FunctionType>> implementations() {
-    return {
-      { DispatchLevel::NONE, standard::FindMinMaxImpl }
+    return {{DispatchLevel::NONE, standard::FindMinMaxImpl}
 #if defined(ARROW_HAVE_RUNTIME_AVX2)
-      , { DispatchLevel::AVX2, FindMinMaxAvx2 }
+            ,
+            {DispatchLevel::AVX2, FindMinMaxAvx2}
 #endif
     };
   }

--- a/cpp/src/parquet/level_comparison.cc
+++ b/cpp/src/parquet/level_comparison.cc
@@ -44,10 +44,10 @@ struct GreaterThanDynamicFunction {
   using FunctionType = decltype(&GreaterThanBitmap);
 
   static std::vector<std::pair<DispatchLevel, FunctionType>> implementations() {
-    return {{DispatchLevel::NONE, standard::GreaterThanBitmapImpl}
+    return {
+      { DispatchLevel::NONE, standard::GreaterThanBitmapImpl }
 #if defined(ARROW_HAVE_RUNTIME_AVX2)
-            ,
-            {DispatchLevel::AVX2, GreaterThanBitmapAvx2}
+      , { DispatchLevel::AVX2, GreaterThanBitmapAvx2 }
 #endif
     };
   }
@@ -57,10 +57,10 @@ struct MinMaxDynamicFunction {
   using FunctionType = decltype(&FindMinMax);
 
   static std::vector<std::pair<DispatchLevel, FunctionType>> implementations() {
-    return {{DispatchLevel::NONE, standard::FindMinMaxImpl}
+    return {
+      { DispatchLevel::NONE, standard::FindMinMaxImpl }
 #if defined(ARROW_HAVE_RUNTIME_AVX2)
-            ,
-            {DispatchLevel::AVX2, FindMinMaxAvx2}
+      , { DispatchLevel::AVX2, FindMinMaxAvx2 }
 #endif
     };
   }

--- a/cpp/src/parquet/reader_test.cc
+++ b/cpp/src/parquet/reader_test.cc
@@ -217,7 +217,8 @@ TEST_F(TestBooleanRLE, TestBatchRead) {
   const int16_t num_nulls = 2;
   int16_t def_levels[batch_size];
   int16_t rep_levels[batch_size];
-  bool values[batch_size - num_nulls];
+  bool values[batch_size];
+  std::fill_n(values, batch_size, false);
 
   auto levels_read =
       col->ReadBatch(batch_size, def_levels, rep_levels, values, &curr_batch_read);
@@ -232,7 +233,7 @@ TEST_F(TestBooleanRLE, TestBatchRead) {
               testing::ElementsAre(1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1));
 
   // Validate inserted data is as expected
-  ASSERT_THAT(values, testing::ElementsAre(1, 0, 1, 1, 0, 0, 1, 1, 1, 0, 0, 1, 1, 0, 1));
+  ASSERT_THAT(values, testing::ElementsAre(1, 0, 1, 1, 0, 0, 1, 1, 1, 0, 0, 1, 1, 0, 1, 0 ,0));
 
   // Loop through rest of the values and assert batch_size read
   for (int i = batch_size; i < nvalues; i = i + batch_size) {

--- a/cpp/src/parquet/reader_test.cc
+++ b/cpp/src/parquet/reader_test.cc
@@ -146,15 +146,20 @@ TEST_F(TestBooleanRLE, TestBooleanScanner) {
 
   bool val = false;
   bool is_null = false;
-  for (int i = 0; i < 8; i++) {
+
+  // For this file, 3rd index value is null
+  int expectedNull[8] = {false, false, true, false, false, false, false, false};
+  bool expectedValue[8] = {true, false, false, true, true, false, false, true};
+
+for (int i = 0; i < 8; i++) {
     ASSERT_TRUE(scanner->HasNext());
     ASSERT_TRUE(scanner->NextValue(&val, &is_null));
 
-    // For this file, 3rd index value is null
-    if (i == 2) {
-      ASSERT_TRUE(is_null);
-    } else {
-      ASSERT_FALSE(is_null);
+    ASSERT_EQ(expectedNull[i], is_null);
+
+    // Only validate val if not null
+    if (!is_null) {
+      ASSERT_EQ(expectedValue[i], val);
     }
   }
 

--- a/cpp/src/parquet/reader_test.cc
+++ b/cpp/src/parquet/reader_test.cc
@@ -126,16 +126,15 @@ void CheckRowGroupMetadata(const RowGroupMetaData* rg_metadata,
   }
 }
 
-
 class TestBooleanRLE : public ::testing::Test {
-public:
+ public:
   void SetUp() {
     reader_ = ParquetFileReader::OpenFile(data_file("rle_boolean_encoding.parquet"));
   }
 
   void TearDown() {}
 
-protected:
+ protected:
   std::unique_ptr<ParquetFileReader> reader_;
 };
 
@@ -152,10 +151,10 @@ TEST_F(TestBooleanRLE, TestBooleanScanner) {
     ASSERT_TRUE(scanner->NextValue(&val, &is_null));
 
     // For this file, 3rd index value is null
-    if (i==2) {
-        ASSERT_TRUE(is_null);
+    if (i == 2) {
+      ASSERT_TRUE(is_null);
     } else {
-        ASSERT_FALSE(is_null);
+      ASSERT_FALSE(is_null);
     }
   }
 
@@ -181,8 +180,7 @@ TEST_F(TestBooleanRLE, TestBatchRead) {
   // Check if the column is encoded with RLE
   auto col_chunk = group->metadata()->ColumnChunk(0);
   ASSERT_TRUE(std::find(col_chunk->encodings().begin(), col_chunk->encodings().end(),
-                        Encoding::RLE) !=
-  col_chunk->encodings().end());
+                        Encoding::RLE) != col_chunk->encodings().end());
 
   // Assert column has values to be read
   ASSERT_TRUE(col->HasNext());
@@ -194,11 +192,12 @@ TEST_F(TestBooleanRLE, TestBatchRead) {
   bool values[batch_size];
 
   auto levels_read =
-          col->ReadBatch(batch_size, def_levels, rep_levels, values, &curr_batch_read);
+      col->ReadBatch(batch_size, def_levels, rep_levels, values, &curr_batch_read);
   ASSERT_EQ(batch_size, levels_read);
 
-  // Since one value is a null value, expect batches read to be one less than indicated batch_size
-  ASSERT_EQ(batch_size-1, curr_batch_read);
+  // Since one value is a null value, expect batches read to be one less than indicated
+  // batch_size
+  ASSERT_EQ(batch_size - 1, curr_batch_read);
 
   // 3rd index is null value
   ASSERT_THAT(def_levels, testing::ElementsAre(1, 1, 0, 1, 1, 1, 1, 1));

--- a/cpp/src/parquet/reader_test.cc
+++ b/cpp/src/parquet/reader_test.cc
@@ -151,7 +151,7 @@ TEST_F(TestBooleanRLE, TestBooleanScanner) {
   int expectedNull[8] = {false, false, true, false, false, false, false, false};
   bool expectedValue[8] = {true, false, false, true, true, false, false, true};
 
-for (int i = 0; i < 8; i++) {
+  for (int i = 0; i < 8; i++) {
     ASSERT_TRUE(scanner->HasNext());
     ASSERT_TRUE(scanner->NextValue(&val, &is_null));
 

--- a/cpp/src/parquet/reader_test.cc
+++ b/cpp/src/parquet/reader_test.cc
@@ -189,7 +189,7 @@ TEST_F(TestBooleanRLE, TestBatchRead) {
   const int16_t batch_size = 8;
   int16_t def_levels[batch_size];
   int16_t rep_levels[batch_size];
-  bool values[batch_size];
+  bool values[batch_size-1];
 
   auto levels_read =
       col->ReadBatch(batch_size, def_levels, rep_levels, values, &curr_batch_read);
@@ -203,7 +203,7 @@ TEST_F(TestBooleanRLE, TestBatchRead) {
   ASSERT_THAT(def_levels, testing::ElementsAre(1, 1, 0, 1, 1, 1, 1, 1));
 
   // Validate inserted data is as expected
-  ASSERT_THAT(values, testing::ElementsAre(1, 0, 1, 1, 0, 0, 1, 0));
+  ASSERT_THAT(values, testing::ElementsAre(1, 0, 1, 1, 0, 0, 1));
 
   // Now read past the end of the file
   ASSERT_FALSE(col->HasNext());

--- a/cpp/src/parquet/reader_test.cc
+++ b/cpp/src/parquet/reader_test.cc
@@ -233,7 +233,8 @@ TEST_F(TestBooleanRLE, TestBatchRead) {
               testing::ElementsAre(1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1));
 
   // Validate inserted data is as expected
-  ASSERT_THAT(values, testing::ElementsAre(1, 0, 1, 1, 0, 0, 1, 1, 1, 0, 0, 1, 1, 0, 1, 0 ,0));
+  ASSERT_THAT(values,
+              testing::ElementsAre(1, 0, 1, 1, 0, 0, 1, 1, 1, 0, 0, 1, 1, 0, 1, 0, 0));
 
   // Loop through rest of the values and assert batch_size read
   for (int i = batch_size; i < nvalues; i = i + batch_size) {

--- a/cpp/src/parquet/reader_test.cc
+++ b/cpp/src/parquet/reader_test.cc
@@ -189,7 +189,7 @@ TEST_F(TestBooleanRLE, TestBatchRead) {
   const int16_t batch_size = 8;
   int16_t def_levels[batch_size];
   int16_t rep_levels[batch_size];
-  bool values[batch_size-1];
+  bool values[batch_size - 1];
 
   auto levels_read =
       col->ReadBatch(batch_size, def_levels, rep_levels, values, &curr_batch_read);


### PR DESCRIPTION
Currently, parquet-cpp does not support columns encoded with RLE. Although the users of RLE are quite sparse with uses of one of the 3 types [Repetition and definition levels, dictionary indices and boolean values in data pages], [Parquet-encodings](https://parquet.apache.org/docs/file-format/data-pages/encodings/). Some implementations do encode this directly on boolean columns (Athena on AWS). Even though there is encoding and decoding support for repetition and definition levels, there is no support for boolean column with RLE. 



This PR integrates the column scanning to support columns with RLE. The first 4 bytes of the data length are size of the encoded data, which is parsed first and then passes to decoder. 

Added two tests with RLE boolean encoded parquet file to validate that values can be parsed individually and in a batch. 
