### PR TITLE
ARROW-17643: [R] Latest duckdb release is causing test failure

### DIFF
--- a/r/tests/testthat/test-duckdb.R
+++ b/r/tests/testthat/test-duckdb.R
@@ -202,6 +202,10 @@ dbExecute(con, "PRAGMA threads=2")
 on.exit(dbDisconnect(con, shutdown = TRUE), add = TRUE)
 
 test_that("Joining, auto-cleanup enabled", {
+  # ARROW-17643: A change in duckdb 0.5.0 caused this test to fail but will
+  # be fixed in the next release.
+  skip_if_not(packageVersion("duckdb") > "0.5.0")
+
   ds <- InMemoryDataset$create(example_data)
 
   table_one_name <- "my_arrow_table_1"


### PR DESCRIPTION
#14065 experimented with ways to solve this from Arrow's end; however, the fix in https://github.com/duckdb/duckdb/pull/4712 is probably more robust. Even if that fix doesn't make it in to the next DuckDB release, when that happens this test will start failing again in case we/I forget to check.