### PR TITLE
ARROW-17764: [CI][C++] "#include <optional>" is missing

### DIFF
--- a/cpp/src/arrow/flight/sql/types.h
+++ b/cpp/src/arrow/flight/sql/types.h
@@ -19,6 +19,7 @@
 
 #include <cstdint>
 #include <iosfwd>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <variant>


### PR DESCRIPTION
https://github.com/ursacomputing/crossbow/actions/runs/3073442125/jobs/4965573117#step:5:8420

    FAILED: src/arrow/flight/sql/CMakeFiles/arrow_flight_sql_objlib.dir/sql_info_internal.cc.o
    /usr/bin/c++ .../arrow/cpp/src/arrow/flight/sql/sql_info_internal.cc
    In file included from /arrow/cpp/src/arrow/flight/sql/sql_info_internal.h:20,
                     from /arrow/cpp/src/arrow/flight/sql/sql_info_internal.cc:18:
    /arrow/cpp/src/arrow/flight/sql/types.h:899:8: error: 'optional' in namespace 'std' does not name a template type
      899 |   std::optional<std::string> catalog;
          |        ^~~~~~~~
    /arrow/cpp/src/arrow/flight/sql/types.h:29:1: note: 'std::optional' is defined in header '<optional>'; did you forget to '#include <optional>'?
       28 | #include "arrow/type_fwd.h"
      +++ |+#include <optional>
       29 |
    /arrow/cpp/src/arrow/flight/sql/types.h:901:8: error: 'optional' in namespace 'std' does not name a template type
      901 |   std::optional<std::string> db_schema;
          |        ^~~~~~~~
    /arrow/cpp/src/arrow/flight/sql/types.h:901:3: note: 'std::optional' is defined in header '<optional>'; did you forget to '#include <optional>'?
      901 |   std::optional<std::string> db_schema;
          |   ^~~