### PR TITLE
ARROW-17770: [C++][Gandiva] Fix const correctness of Gandiva projector Evaluate

### DIFF
--- a/cpp/src/gandiva/annotator.cc
+++ b/cpp/src/gandiva/annotator.cc
@@ -65,7 +65,7 @@ int Annotator::AddHolderPointer(void* holder) {
 
 void Annotator::PrepareBuffersForField(const FieldDescriptor& desc,
                                        const arrow::ArrayData& array_data,
-                                       EvalBatch* eval_batch, bool is_output) {
+                                       EvalBatch* eval_batch, bool is_output) const {
   int buffer_idx = 0;
 
   // The validity buffer is optional. Use nullptr if it does not have one.
@@ -94,7 +94,7 @@ void Annotator::PrepareBuffersForField(const FieldDescriptor& desc,
 }
 
 EvalBatchPtr Annotator::PrepareEvalBatch(const arrow::RecordBatch& record_batch,
-                                         const ArrayDataVector& out_vector) {
+                                         const ArrayDataVector& out_vector) const {
   EvalBatchPtr eval_batch = std::make_shared<EvalBatch>(
       record_batch.num_rows(), buffer_count_, local_bitmap_count_);
 

--- a/cpp/src/gandiva/annotator.h
+++ b/cpp/src/gandiva/annotator.h
@@ -54,13 +54,13 @@ class GANDIVA_EXPORT Annotator {
   /// Return a pointer to the underlying array containing the holder pointers
   /// This should only be called after expr decomposition when all the holder
   /// pointers are added
-  void** GetHolderPointersArray() { return holder_pointers_.data(); }
+  const void* const* GetHolderPointersArray() const { return holder_pointers_.data(); }
 
   /// Prepare an eval batch for the incoming record batch.
   EvalBatchPtr PrepareEvalBatch(const arrow::RecordBatch& record_batch,
-                                const ArrayDataVector& out_vector);
+                                const ArrayDataVector& out_vector) const;
 
-  int buffer_count() { return buffer_count_; }
+  int buffer_count() const { return buffer_count_; }
 
  private:
   /// Annotate a field and return the descriptor.
@@ -70,7 +70,7 @@ class GANDIVA_EXPORT Annotator {
   /// contents are represent by the annotated descriptor 'desc'.
   void PrepareBuffersForField(const FieldDescriptor& desc,
                               const arrow::ArrayData& array_data, EvalBatch* eval_batch,
-                              bool is_output);
+                              bool is_output) const;
 
   /// The list of input/output buffers (includes bitmap buffers, value buffers and
   /// offset buffers).

--- a/cpp/src/gandiva/bitmap_accumulator.cc
+++ b/cpp/src/gandiva/bitmap_accumulator.cc
@@ -36,7 +36,7 @@ void BitMapAccumulator::ComputeResult(uint8_t* dst_bitmap) {
 
 /// Compute the intersection of multiple bitmaps.
 void BitMapAccumulator::IntersectBitMaps(uint8_t* dst_map,
-                                         const std::vector<uint8_t*>& src_maps,
+                                         const std::vector<const uint8_t*>& src_maps,
                                          const std::vector<int64_t>& src_map_offsets,
                                          int64_t num_records) {
   int64_t num_words = (num_records + 63) / 64;  // aligned to 8-byte.

--- a/cpp/src/gandiva/bitmap_accumulator.h
+++ b/cpp/src/gandiva/bitmap_accumulator.h
@@ -65,13 +65,14 @@ class GANDIVA_EXPORT BitMapAccumulator : public DexDefaultVisitor {
 
   /// Compute the intersection of the accumulated bitmaps (with offsets) and save the
   /// result in dst_bmap.
-  static void IntersectBitMaps(uint8_t* dst_map, const std::vector<uint8_t*>& src_maps,
+  static void IntersectBitMaps(uint8_t* dst_map,
+                               const std::vector<const uint8_t*>& src_maps,
                                const std::vector<int64_t>& src_maps_offsets,
                                int64_t num_records);
 
  private:
   const EvalBatch& eval_batch_;
-  std::vector<uint8_t*> src_maps_;
+  std::vector<const uint8_t*> src_maps_;
   std::vector<int64_t> src_map_offsets_;
   bool all_invalid_;
 };

--- a/cpp/src/gandiva/bitmap_accumulator_test.cc
+++ b/cpp/src/gandiva/bitmap_accumulator_test.cc
@@ -33,7 +33,7 @@ namespace gandiva {
 class TestBitMapAccumulator : public ::testing::Test {
  protected:
   void FillBitMap(uint8_t* bmap, uint32_t seed, int nrecords);
-  void ByteWiseIntersectBitMaps(uint8_t* dst, const std::vector<uint8_t*>& srcs,
+  void ByteWiseIntersectBitMaps(uint8_t* dst, const std::vector<const uint8_t*>& srcs,
                                 const std::vector<int64_t>& srcOffsets, int nrecords);
 };
 
@@ -42,7 +42,7 @@ void TestBitMapAccumulator::FillBitMap(uint8_t* bmap, uint32_t seed, int nbytes)
 }
 
 void TestBitMapAccumulator::ByteWiseIntersectBitMaps(
-    uint8_t* dst, const std::vector<uint8_t*>& srcs,
+    uint8_t* dst, const std::vector<const uint8_t*>& srcs,
     const std::vector<int64_t>& srcOffsets, int nrecords) {
   if (srcs.empty()) {
     arrow::bit_util::SetBitsTo(dst, 0, nrecords, true);
@@ -67,7 +67,7 @@ TEST_F(TestBitMapAccumulator, TestIntersectBitMaps) {
   }
 
   for (int i = 0; i < 4; i++) {
-    std::vector<uint8_t*> src_bitmap_ptrs;
+    std::vector<const uint8_t*> src_bitmap_ptrs;
     std::vector<int64_t> src_bitmap_offsets(i, 0);
     for (int j = 0; j < i; ++j) {
       src_bitmap_ptrs.push_back(src_bitmaps[j]);
@@ -92,7 +92,7 @@ TEST_F(TestBitMapAccumulator, TestIntersectBitMapsWithOffset) {
   }
 
   for (int i = 0; i < 4; i++) {
-    std::vector<uint8_t*> src_bitmap_ptrs;
+    std::vector<const uint8_t*> src_bitmap_ptrs;
     std::vector<int64_t> src_bitmap_offsets;
     for (int j = 0; j < i; ++j) {
       src_bitmap_ptrs.push_back(src_bitmaps[j]);

--- a/cpp/src/gandiva/compiled_expr.h
+++ b/cpp/src/gandiva/compiled_expr.h
@@ -25,7 +25,7 @@
 namespace gandiva {
 
 using EvalFunc = int (*)(uint8_t** buffers, int64_t* offsets, uint8_t** local_bitmaps,
-                         void** holder_ptrs, const uint8_t* selection_buffer,
+                         const void* const* holder_ptrs, const uint8_t* selection_buffer,
                          int64_t execution_ctx_ptr, int64_t record_count);
 
 /// \brief Tracks the compiled state for one expression.

--- a/cpp/src/gandiva/eval_batch.h
+++ b/cpp/src/gandiva/eval_batch.h
@@ -44,13 +44,20 @@ class EvalBatch {
 
   int64_t num_records() const { return num_records_; }
 
-  uint8_t** GetBufferArray() const { return buffers_array_.get(); }
+  const uint8_t* const* GetBufferArray() const { return buffers_array_.get(); }
+  uint8_t** GetBufferArray() { return buffers_array_.get(); }
 
-  int64_t* GetBufferOffsetArray() const { return buffer_offsets_array_.get(); }
+  const int64_t* GetBufferOffsetArray() const { return buffer_offsets_array_.get(); }
+  int64_t* GetBufferOffsetArray() { return buffer_offsets_array_.get(); }
 
   int GetNumBuffers() const { return num_buffers_; }
 
-  uint8_t* GetBuffer(int idx) const {
+  const uint8_t* GetBuffer(int idx) const {
+    DCHECK(idx <= num_buffers_);
+    return (buffers_array_.get())[idx];
+  }
+
+  uint8_t* GetBuffer(int idx) {
     DCHECK(idx <= num_buffers_);
     return (buffers_array_.get())[idx];
   }
@@ -72,16 +79,21 @@ class EvalBatch {
     return local_bitmaps_holder_->GetLocalBitMapSize();
   }
 
-  uint8_t* GetLocalBitMap(int idx) const {
+  const uint8_t* GetLocalBitMap(int idx) const {
+    DCHECK(idx <= GetNumLocalBitMaps());
+    return local_bitmaps_holder_->GetLocalBitMap(idx);
+  }
+  uint8_t* GetLocalBitMap(int idx) {
     DCHECK(idx <= GetNumLocalBitMaps());
     return local_bitmaps_holder_->GetLocalBitMap(idx);
   }
 
-  uint8_t** GetLocalBitMapArray() const {
+  const uint8_t* const* GetLocalBitMapArray() const {
     return local_bitmaps_holder_->GetLocalBitMapArray();
   }
+  uint8_t** GetLocalBitMapArray() { return local_bitmaps_holder_->GetLocalBitMapArray(); }
 
-  ExecutionContext* GetExecutionContext() const { return execution_context_.get(); }
+  const ExecutionContext* GetExecutionContext() const { return execution_context_.get(); }
 
  private:
   /// number of records in the current batch.

--- a/cpp/src/gandiva/llvm_generator.h
+++ b/cpp/src/gandiva/llvm_generator.h
@@ -68,13 +68,13 @@ class GANDIVA_EXPORT LLVMGenerator {
   /// \brief Execute the built expression against the provided arguments for
   /// default mode.
   Status Execute(const arrow::RecordBatch& record_batch,
-                 const ArrayDataVector& output_vector);
+                 const ArrayDataVector& output_vector) const;
 
   /// \brief Execute the built expression against the provided arguments for
   /// all modes. Only works on the records specified in the selection_vector.
   Status Execute(const arrow::RecordBatch& record_batch,
                  const SelectionVector* selection_vector,
-                 const ArrayDataVector& output_vector);
+                 const ArrayDataVector& output_vector) const;
 
   SelectionVector::Mode selection_vector_mode() { return selection_vector_mode_; }
   LLVMTypes* types() { return engine_->types(); }
@@ -233,11 +233,11 @@ class GANDIVA_EXPORT LLVMGenerator {
   ///
   /// \param[in] compiled_expr the compiled expression (includes the bitmap indices to be
   ///            used for computing the validity bitmap of the result).
-  /// \param[in] eval_batch (includes input/output buffer addresses)
   /// \param[in] selection_vector the list of selected positions
+  /// \param[in,out] eval_batch (includes input/output buffer addresses)
   void ComputeBitMapsForExpr(const CompiledExpr& compiled_expr,
-                             const EvalBatch& eval_batch,
-                             const SelectionVector* selection_vector);
+                             const SelectionVector* selection_vector,
+                             EvalBatch* eval_batch) const;
 
   /// Replace the %T in the trace msg with the correct type corresponding to 'type'
   /// eg. %d for int32, %ld for int64, ..

--- a/cpp/src/gandiva/projector.cc
+++ b/cpp/src/gandiva/projector.cc
@@ -114,13 +114,13 @@ Status Projector::Make(SchemaPtr schema, const ExpressionVector& exprs,
 }
 
 Status Projector::Evaluate(const arrow::RecordBatch& batch,
-                           const ArrayDataVector& output_data_vecs) {
+                           const ArrayDataVector& output_data_vecs) const {
   return Evaluate(batch, nullptr, output_data_vecs);
 }
 
 Status Projector::Evaluate(const arrow::RecordBatch& batch,
                            const SelectionVector* selection_vector,
-                           const ArrayDataVector& output_data_vecs) {
+                           const ArrayDataVector& output_data_vecs) const {
   ARROW_RETURN_NOT_OK(ValidateEvaluateArgsCommon(batch));
 
   if (output_data_vecs.size() != output_fields_.size()) {
@@ -149,13 +149,13 @@ Status Projector::Evaluate(const arrow::RecordBatch& batch,
 }
 
 Status Projector::Evaluate(const arrow::RecordBatch& batch, arrow::MemoryPool* pool,
-                           arrow::ArrayVector* output) {
+                           arrow::ArrayVector* output) const {
   return Evaluate(batch, nullptr, pool, output);
 }
 
 Status Projector::Evaluate(const arrow::RecordBatch& batch,
                            const SelectionVector* selection_vector,
-                           arrow::MemoryPool* pool, arrow::ArrayVector* output) {
+                           arrow::MemoryPool* pool, arrow::ArrayVector* output) const {
   ARROW_RETURN_NOT_OK(ValidateEvaluateArgsCommon(batch));
   ARROW_RETURN_IF(output == nullptr, Status::Invalid("Output must be non-null."));
   ARROW_RETURN_IF(pool == nullptr, Status::Invalid("Memory pool must be non-null."));
@@ -185,7 +185,8 @@ Status Projector::Evaluate(const arrow::RecordBatch& batch,
 
 // TODO : handle complex vectors (list/map/..)
 Status Projector::AllocArrayData(const DataTypePtr& type, int64_t num_records,
-                                 arrow::MemoryPool* pool, ArrayDataPtr* array_data) {
+                                 arrow::MemoryPool* pool,
+                                 ArrayDataPtr* array_data) const {
   arrow::Status astatus;
   std::vector<std::shared_ptr<arrow::Buffer>> buffers;
 
@@ -227,7 +228,7 @@ Status Projector::AllocArrayData(const DataTypePtr& type, int64_t num_records,
   return Status::OK();
 }
 
-Status Projector::ValidateEvaluateArgsCommon(const arrow::RecordBatch& batch) {
+Status Projector::ValidateEvaluateArgsCommon(const arrow::RecordBatch& batch) const {
   ARROW_RETURN_IF(!batch.schema()->Equals(*schema_),
                   Status::Invalid("Schema in RecordBatch must match schema in Make()"));
   ARROW_RETURN_IF(batch.num_rows() == 0,
@@ -238,7 +239,7 @@ Status Projector::ValidateEvaluateArgsCommon(const arrow::RecordBatch& batch) {
 
 Status Projector::ValidateArrayDataCapacity(const arrow::ArrayData& array_data,
                                             const arrow::Field& field,
-                                            int64_t num_records) {
+                                            int64_t num_records) const {
   ARROW_RETURN_IF(array_data.buffers.size() < 2,
                   Status::Invalid("ArrayData must have at least 2 buffers"));
 

--- a/cpp/src/gandiva/projector.h
+++ b/cpp/src/gandiva/projector.h
@@ -85,7 +85,7 @@ class GANDIVA_EXPORT Projector {
   /// \param[in] pool memory pool used to allocate output arrays (if required).
   /// \param[out] output the vector of allocated/populated arrays.
   Status Evaluate(const arrow::RecordBatch& batch, arrow::MemoryPool* pool,
-                  arrow::ArrayVector* output);
+                  arrow::ArrayVector* output) const;
 
   /// Evaluate the specified record batch, and populate the output arrays. The output
   /// arrays of sufficient capacity must be allocated by the caller.
@@ -93,7 +93,7 @@ class GANDIVA_EXPORT Projector {
   /// \param[in] batch the record batch. schema should be the same as the one in 'Make'
   /// \param[in,out] output vector of arrays, the arrays are allocated by the caller and
   ///                populated by Evaluate.
-  Status Evaluate(const arrow::RecordBatch& batch, const ArrayDataVector& output);
+  Status Evaluate(const arrow::RecordBatch& batch, const ArrayDataVector& output) const;
 
   /// Evaluate the specified record batch, and return the allocated and populated output
   /// arrays. The output arrays will be allocated from the memory pool 'pool', and added
@@ -105,7 +105,7 @@ class GANDIVA_EXPORT Projector {
   /// \param[out] output the vector of allocated/populated arrays.
   Status Evaluate(const arrow::RecordBatch& batch,
                   const SelectionVector* selection_vector, arrow::MemoryPool* pool,
-                  arrow::ArrayVector* output);
+                  arrow::ArrayVector* output) const;
 
   /// Evaluate the specified record batch, and populate the output arrays at the filtered
   /// positions. The output arrays of sufficient capacity must be allocated by the caller.
@@ -115,7 +115,8 @@ class GANDIVA_EXPORT Projector {
   /// \param[in,out] output vector of arrays, the arrays are allocated by the caller and
   ///                 populated by Evaluate.
   Status Evaluate(const arrow::RecordBatch& batch,
-                  const SelectionVector* selection_vector, const ArrayDataVector& output);
+                  const SelectionVector* selection_vector,
+                  const ArrayDataVector& output) const;
 
   std::string DumpIR();
 
@@ -129,14 +130,14 @@ class GANDIVA_EXPORT Projector {
 
   /// Allocate an ArrowData of length 'length'.
   Status AllocArrayData(const DataTypePtr& type, int64_t num_records,
-                        arrow::MemoryPool* pool, ArrayDataPtr* array_data);
+                        arrow::MemoryPool* pool, ArrayDataPtr* array_data) const;
 
   /// Validate that the ArrayData has sufficient capacity to accommodate 'num_records'.
   Status ValidateArrayDataCapacity(const arrow::ArrayData& array_data,
-                                   const arrow::Field& field, int64_t num_records);
+                                   const arrow::Field& field, int64_t num_records) const;
 
   /// Validate the common args for Evaluate() APIs.
-  Status ValidateEvaluateArgsCommon(const arrow::RecordBatch& batch);
+  Status ValidateEvaluateArgsCommon(const arrow::RecordBatch& batch) const;
 
   std::unique_ptr<LLVMGenerator> llvm_generator_;
   SchemaPtr schema_;


### PR DESCRIPTION
I was trying to figure out the thread-safeness of Gandiva projector evaluation, i.e., whether I can use a single Projector to evaluate multiple inputs concurrently. I assumed it isn't safe because the Evaluate function is not marked const. However, as far as I understand, the Evaluate function merely executes a compiled function on the input, which doesn't modify a project's internal states and should be const.