### PR TITLE
MINOR: [Java][CI] Fix grep for new nightlies versioning

### DIFF
--- a/.github/workflows/java_nightly.yml
+++ b/.github/workflows/java_nightly.yml
@@ -103,7 +103,7 @@ jobs:
           fi
           PATTERN_TO_GET_LIB_AND_VERSION='([a-z].+)-([0-9]+.[0-9]+.[0-9]+-SNAPSHOT)'
           mkdir -p repo/org/apache/arrow/
-          for LIBRARY in $(ls binaries/$PREFIX/java-jars | grep -E '.jar|.pom' | grep dev); do
+          for LIBRARY in $(ls binaries/$PREFIX/java-jars | grep -E '.jar|.pom' | grep SNAPSHOT); do
             [[ $LIBRARY =~ $PATTERN_TO_GET_LIB_AND_VERSION ]]
             mkdir -p repo/org/apache/arrow/${BASH_REMATCH[1]}/${BASH_REMATCH[2]}
             mkdir -p repo/org/apache/arrow/${BASH_REMATCH[1]}/${DATE}


### PR DESCRIPTION
I've noticed that the latest Java nightlies where not uploaded https://nightlies.apache.org/arrow/java/org/apache/arrow/arrow-c-data/. I missed to update the grep on this PR: https://github.com/apache/arrow/pull/14135

I have now tested locally the bash script to validate the repo structure will now be generated correctly:
```
repo
└── org
    └── apache
        └── arrow
            ├── arrow-algorithm
            │   ├── 10.0.0-SNAPSHOT
            │   │   ├── arrow-algorithm-10.0.0-SNAPSHOT.jar
            │   │   ├── arrow-algorithm-10.0.0-SNAPSHOT-javadoc.jar
            │   │   ├── arrow-algorithm-10.0.0-SNAPSHOT.pom
            │   │   ├── arrow-algorithm-10.0.0-SNAPSHOT-sources.jar
            │   │   └── arrow-algorithm-10.0.0-SNAPSHOT-tests.jar
            │   └── 2022-09-18
            │       ├── arrow-algorithm-10.0.0-SNAPSHOT.jar
            │       ├── arrow-algorithm-10.0.0-SNAPSHOT-javadoc.jar
            │       ├── arrow-algorithm-10.0.0-SNAPSHOT.pom
            │       ├── arrow-algorithm-10.0.0-SNAPSHOT-sources.jar
            │       └── arrow-algorithm-10.0.0-SNAPSHOT-tests.jar
            ├── arrow-avro
            │   ├── 10.0.0-SNAPSHOT
            │   │   ├── arrow-avro-10.0.0-SNAPSHOT.jar
            │   │   ├── arrow-avro-10.0.0-SNAPSHOT-javadoc.jar
            │   │   ├── arrow-avro-10.0.0-SNAPSHOT.pom
            │   │   ├── arrow-avro-10.0.0-SNAPSHOT-sources.jar
            │   │   └── arrow-avro-10.0.0-SNAPSHOT-tests.jar
            │   └── 2022-09-18
            │       ├── arrow-avro-10.0.0-SNAPSHOT.jar
            │       ├── arrow-avro-10.0.0-SNAPSHOT-javadoc.jar
            │       ├── arrow-avro-10.0.0-SNAPSHOT.pom
            │       ├── arrow-avro-10.0.0-SNAPSHOT-sources.jar
            │       └── arrow-avro-10.0.0-SNAPSHOT-tests.jar
...
```