### PR TITLE
ARROW-17686: [C++] Add custom ToPrint to AsofJoinBasicTest

### DIFF
--- a/cpp/src/arrow/compute/exec/asof_join_node_test.cc
+++ b/cpp/src/arrow/compute/exec/asof_join_node_test.cc
@@ -633,6 +633,10 @@ struct BasicTest {
 
 using AsofJoinBasicParams = std::tuple<std::function<void(BasicTest&)>, std::string>;
 
+void PrintTo(const AsofJoinBasicParams& x, ::std::ostream* os) {
+  *os << "AsofJoinBasicParams: " << std::get<1>(x);
+}
+
 struct AsofJoinBasicTest : public testing::TestWithParam<AsofJoinBasicParams> {};
 
 class AsofJoinTest : public testing::Test {};


### PR DESCRIPTION
Add a simple printer compatible with [gtest printers](https://github.com/google/googletest/blob/main/googletest/include/gtest/gtest-printers.h), hopefully this will solve some issues with valgrind (3.13.0) on ubuntu 18.04 running the unit test `arrow-compute-asof-join-node-test`.

Jira ticket: https://issues.apache.org/jira/browse/ARROW-17686