### PR TITLE
ARROW-17169: [Go][Parquet] Panic in bitmap writer with Nullable List of Struct

### DIFF
--- a/go/parquet/pqarrow/column_readers.go
+++ b/go/parquet/pqarrow/column_readers.go
@@ -388,7 +388,12 @@ func (lr *listReader) BuildArray(lenBound int64) (*arrow.Chunked, error) {
 		return nil, err
 	}
 
-	arr, err := lr.itemRdr.BuildArray(int64(offsetData[int(validityIO.Read)]))
+	// if the parent (itemRdr) has nulls and is a nested type like list
+	// then we need BuildArray to account for that with the number of
+	// definition levels when building out the bitmap. So the upper bound
+	// to make sure we have the space for is the worst case scenario,
+	// the upper bound is the value of the last offset + the nullcount
+	arr, err := lr.itemRdr.BuildArray(int64(offsetData[int(validityIO.Read)]) + validityIO.NullCount)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When building the Nullable List of Struct column for record reading we didn't account for the worst-case scenario for building the final array. We need to handle the upper bound case of `offsetData[validityIO.Read]`+`validityIO.NullCount`