### PR TITLE
ARROW-17794: [Java] Force delete jni lib file on JVM exit

### DIFF
--- a/java/c/src/main/java/org/apache/arrow/c/jni/JniLoader.java
+++ b/java/c/src/main/java/org/apache/arrow/c/jni/JniLoader.java
@@ -81,6 +81,7 @@ public class JniLoader {
     final String libraryToLoad = System.mapLibraryName(name);
     try {
       File temp = File.createTempFile("jnilib-", ".tmp", new File(System.getProperty("java.io.tmpdir")));
+      temp.deleteOnExit();
       try (final InputStream is = JniWrapper.class.getClassLoader().getResourceAsStream(libraryToLoad)) {
         if (is == null) {
           throw new FileNotFoundException(libraryToLoad);

--- a/java/dataset/src/main/java/org/apache/arrow/dataset/jni/JniLoader.java
+++ b/java/dataset/src/main/java/org/apache/arrow/dataset/jni/JniLoader.java
@@ -29,8 +29,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.io.FileUtils;
-
 /**
  * The JniLoader for Dataset API's native implementation.
  */
@@ -81,7 +79,7 @@ public final class JniLoader {
     final String libraryToLoad = System.mapLibraryName(name);
     try {
       File temp = File.createTempFile("jnilib-", ".tmp", new File(System.getProperty("java.io.tmpdir")));
-      FileUtils.forceDeleteOnExit(temp);
+      temp.deleteOnExit();
       try (final InputStream is
                = JniWrapper.class.getClassLoader().getResourceAsStream(libraryToLoad)) {
         if (is == null) {

--- a/java/dataset/src/main/java/org/apache/arrow/dataset/jni/JniLoader.java
+++ b/java/dataset/src/main/java/org/apache/arrow/dataset/jni/JniLoader.java
@@ -29,6 +29,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.io.FileUtils;
+
 /**
  * The JniLoader for Dataset API's native implementation.
  */
@@ -79,6 +81,7 @@ public final class JniLoader {
     final String libraryToLoad = System.mapLibraryName(name);
     try {
       File temp = File.createTempFile("jnilib-", ".tmp", new File(System.getProperty("java.io.tmpdir")));
+      FileUtils.forceDeleteOnExit(temp);
       try (final InputStream is
                = JniWrapper.class.getClassLoader().getResourceAsStream(libraryToLoad)) {
         if (is == null) {


### PR DESCRIPTION
Use `File.deleteOnExit` to delete jni lib file on JVM exit. `File.deleteOnExit` actually add a shut down hook to make sure file delte.