### PR TITLE
ARROW-17804: [Go][CSV] Add Date32 and Time32 parsers

### DIFF
--- a/go/arrow/csv/common.go
+++ b/go/arrow/csv/common.go
@@ -159,7 +159,7 @@ func WithNullWriter(null string) Option {
 	}
 }
 
-// WithBoolWriter override the default bool formatter with a fucntion that returns
+// WithBoolWriter override the default bool formatter with a function that returns
 //  a string representaton of bool states. i.e. True, False, 1, 0
 func WithBoolWriter(fmtr func(bool) string) Option {
 	return func(cfg config) {


### PR DESCRIPTION
Given the recent addition of inferring schemas for CSVs, it should be able to parse all the types that can be inferred