### PR TITLE
ARROW-17803: [C++] Use [[nodiscard]]

### DIFF
--- a/cpp/src/arrow/array/array_base.h
+++ b/cpp/src/arrow/array/array_base.h
@@ -207,7 +207,7 @@ class ARROW_EXPORT Array {
  private:
   ARROW_DISALLOW_COPY_AND_ASSIGN(Array);
 
-  ARROW_EXPORT friend void PrintTo(const Array& x, std::ostream* os);
+  ARROW_FRIEND_EXPORT friend void PrintTo(const Array& x, std::ostream* os);
 };
 
 static inline std::ostream& operator<<(std::ostream& os, const Array& x) {

--- a/cpp/src/arrow/compare.h
+++ b/cpp/src/arrow/compare.h
@@ -92,31 +92,31 @@ class EqualOptions {
 };
 
 /// Returns true if the arrays are exactly equal
-bool ARROW_EXPORT ArrayEquals(const Array& left, const Array& right,
+ARROW_EXPORT bool ArrayEquals(const Array& left, const Array& right,
                               const EqualOptions& = EqualOptions::Defaults());
 
 /// Returns true if the arrays are approximately equal. For non-floating point
 /// types, this is equivalent to ArrayEquals(left, right)
-bool ARROW_EXPORT ArrayApproxEquals(const Array& left, const Array& right,
+ARROW_EXPORT bool ArrayApproxEquals(const Array& left, const Array& right,
                                     const EqualOptions& = EqualOptions::Defaults());
 
 /// Returns true if indicated equal-length segment of arrays are exactly equal
-bool ARROW_EXPORT ArrayRangeEquals(const Array& left, const Array& right,
+ARROW_EXPORT bool ArrayRangeEquals(const Array& left, const Array& right,
                                    int64_t start_idx, int64_t end_idx,
                                    int64_t other_start_idx,
                                    const EqualOptions& = EqualOptions::Defaults());
 
 /// Returns true if indicated equal-length segment of arrays are approximately equal
-bool ARROW_EXPORT ArrayRangeApproxEquals(const Array& left, const Array& right,
+ARROW_EXPORT bool ArrayRangeApproxEquals(const Array& left, const Array& right,
                                          int64_t start_idx, int64_t end_idx,
                                          int64_t other_start_idx,
                                          const EqualOptions& = EqualOptions::Defaults());
 
-bool ARROW_EXPORT TensorEquals(const Tensor& left, const Tensor& right,
+ARROW_EXPORT bool TensorEquals(const Tensor& left, const Tensor& right,
                                const EqualOptions& = EqualOptions::Defaults());
 
 /// EXPERIMENTAL: Returns true if the given sparse tensors are exactly equal
-bool ARROW_EXPORT SparseTensorEquals(const SparseTensor& left, const SparseTensor& right,
+ARROW_EXPORT bool SparseTensorEquals(const SparseTensor& left, const SparseTensor& right,
                                      const EqualOptions& = EqualOptions::Defaults());
 
 /// Returns true if the type metadata are exactly equal
@@ -124,22 +124,22 @@ bool ARROW_EXPORT SparseTensorEquals(const SparseTensor& left, const SparseTenso
 /// \param[in] right a DataType
 /// \param[in] check_metadata whether to compare KeyValueMetadata for child
 /// fields
-bool ARROW_EXPORT TypeEquals(const DataType& left, const DataType& right,
+ARROW_EXPORT bool TypeEquals(const DataType& left, const DataType& right,
                              bool check_metadata = true);
 
 /// Returns true if scalars are equal
 /// \param[in] left a Scalar
 /// \param[in] right a Scalar
 /// \param[in] options comparison options
-bool ARROW_EXPORT ScalarEquals(const Scalar& left, const Scalar& right,
+ARROW_EXPORT bool ScalarEquals(const Scalar& left, const Scalar& right,
                                const EqualOptions& options = EqualOptions::Defaults());
 
 /// Returns true if scalars are approximately equal
 /// \param[in] left a Scalar
 /// \param[in] right a Scalar
 /// \param[in] options comparison options
-bool ARROW_EXPORT
-ScalarApproxEquals(const Scalar& left, const Scalar& right,
-                   const EqualOptions& options = EqualOptions::Defaults());
+ARROW_EXPORT bool ScalarApproxEquals(
+    const Scalar& left, const Scalar& right,
+    const EqualOptions& options = EqualOptions::Defaults());
 
 }  // namespace arrow

--- a/cpp/src/arrow/compute/exec.h
+++ b/cpp/src/arrow/compute/exec.h
@@ -246,12 +246,12 @@ struct ARROW_EXPORT ExecBatch {
   }
 
   std::string ToString() const;
-
-  ARROW_EXPORT friend void PrintTo(const ExecBatch&, std::ostream*);
 };
 
 inline bool operator==(const ExecBatch& l, const ExecBatch& r) { return l.Equals(r); }
 inline bool operator!=(const ExecBatch& l, const ExecBatch& r) { return !l.Equals(r); }
+
+ARROW_EXPORT void PrintTo(const ExecBatch&, std::ostream*);
 
 struct ExecValue {
   ArraySpan array = {};

--- a/cpp/src/arrow/compute/exec/expression.h
+++ b/cpp/src/arrow/compute/exec/expression.h
@@ -130,13 +130,13 @@ class ARROW_EXPORT Expression {
   using Impl = std::variant<Datum, Parameter, Call>;
   std::shared_ptr<Impl> impl_;
 
-  ARROW_EXPORT friend bool Identical(const Expression& l, const Expression& r);
-
-  ARROW_EXPORT friend void PrintTo(const Expression&, std::ostream*);
+  ARROW_FRIEND_EXPORT friend bool Identical(const Expression& l, const Expression& r);
 };
 
 inline bool operator==(const Expression& l, const Expression& r) { return l.Equals(r); }
 inline bool operator!=(const Expression& l, const Expression& r) { return !l.Equals(r); }
+
+ARROW_EXPORT void PrintTo(const Expression&, std::ostream*);
 
 // Factories
 

--- a/cpp/src/arrow/datum.h
+++ b/cpp/src/arrow/datum.h
@@ -215,9 +215,9 @@ struct ARROW_EXPORT Datum {
   bool operator!=(const Datum& other) const { return !Equals(other); }
 
   std::string ToString() const;
-
-  ARROW_EXPORT friend void PrintTo(const Datum&, std::ostream*);
 };
+
+ARROW_EXPORT void PrintTo(const Datum&, std::ostream*);
 
 ARROW_EXPORT std::string ToString(Datum::Kind kind);
 

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -226,7 +226,7 @@ class ARROW_EXPORT CPUMemoryManager : public MemoryManager {
   MemoryPool* pool_;
 
   friend std::shared_ptr<MemoryManager> CPUDevice::memory_manager(MemoryPool* pool);
-  friend ARROW_EXPORT std::shared_ptr<MemoryManager> default_cpu_memory_manager();
+  ARROW_FRIEND_EXPORT friend std::shared_ptr<MemoryManager> default_cpu_memory_manager();
 };
 
 /// \brief Return the default CPU MemoryManager instance

--- a/cpp/src/arrow/filesystem/mockfs.h
+++ b/cpp/src/arrow/filesystem/mockfs.h
@@ -38,7 +38,7 @@ struct MockDirInfo {
     return mtime == other.mtime && full_path == other.full_path;
   }
 
-  friend ARROW_EXPORT std::ostream& operator<<(std::ostream&, const MockDirInfo&);
+  ARROW_FRIEND_EXPORT friend std::ostream& operator<<(std::ostream&, const MockDirInfo&);
 };
 
 struct MockFileInfo {
@@ -50,7 +50,7 @@ struct MockFileInfo {
     return mtime == other.mtime && full_path == other.full_path && data == other.data;
   }
 
-  friend ARROW_EXPORT std::ostream& operator<<(std::ostream&, const MockFileInfo&);
+  ARROW_FRIEND_EXPORT friend std::ostream& operator<<(std::ostream&, const MockFileInfo&);
 };
 
 /// A mock FileSystem implementation that holds its contents in memory.

--- a/cpp/src/arrow/io/hdfs.h
+++ b/cpp/src/arrow/io/hdfs.h
@@ -278,7 +278,7 @@ class ARROW_EXPORT HdfsOutputStream : public OutputStream {
   ARROW_DISALLOW_COPY_AND_ASSIGN(HdfsOutputStream);
 };
 
-Status ARROW_EXPORT HaveLibHdfs();
+ARROW_EXPORT Status HaveLibHdfs();
 
 }  // namespace io
 }  // namespace arrow

--- a/cpp/src/arrow/io/hdfs_internal.h
+++ b/cpp/src/arrow/io/hdfs_internal.h
@@ -215,7 +215,7 @@ struct LibHdfsShim {
 };
 
 // TODO(wesm): Remove these exports when we are linking statically
-Status ARROW_EXPORT ConnectLibHdfs(LibHdfsShim** driver);
+ARROW_EXPORT Status ConnectLibHdfs(LibHdfsShim** driver);
 
 }  // namespace internal
 }  // namespace io

--- a/cpp/src/arrow/result.h
+++ b/cpp/src/arrow/result.h
@@ -94,8 +94,7 @@ ARROW_EXPORT void InvalidValueOrDie(const Status& st);
 ///   arrow::Result<int> CalculateFoo();
 /// ```
 template <class T>
-class [[nodiscard]] Result :  // NOLINT(whitespace/braces)
-                              public util::EqualityComparable<Result<T>> {
+class [[nodiscard]] Result : public util::EqualityComparable<Result<T>> {
   template <typename U>
   friend class Result;
 

--- a/cpp/src/arrow/result.h
+++ b/cpp/src/arrow/result.h
@@ -94,7 +94,8 @@ ARROW_EXPORT void InvalidValueOrDie(const Status& st);
 ///   arrow::Result<int> CalculateFoo();
 /// ```
 template <class T>
-class ARROW_MUST_USE_TYPE Result : public util::EqualityComparable<Result<T>> {
+class [[nodiscard]] Result :  // NOLINT(whitespace/braces)
+                              public util::EqualityComparable<Result<T>> {
   template <typename U>
   friend class Result;
 

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -100,8 +100,6 @@ struct ARROW_EXPORT Scalar : public std::enable_shared_from_this<Scalar>,
   // TODO(bkietz) add compute::CastOptions
   Result<std::shared_ptr<Scalar>> CastTo(std::shared_ptr<DataType> to) const;
 
-  ARROW_EXPORT friend void PrintTo(const Scalar& scalar, std::ostream* os);
-
   /// \brief Apply the ScalarVisitor::Visit() method specialized to the scalar type
   Status Accept(ScalarVisitor* visitor) const;
 
@@ -115,6 +113,8 @@ struct ARROW_EXPORT Scalar : public std::enable_shared_from_this<Scalar>,
   Scalar(std::shared_ptr<DataType> type, bool is_valid)
       : type(std::move(type)), is_valid(is_valid) {}
 };
+
+ARROW_EXPORT void PrintTo(const Scalar& scalar, std::ostream* os);
 
 /// \defgroup concrete-scalar-classes Concrete Scalar subclasses
 ///

--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -129,8 +129,9 @@ class ARROW_EXPORT StatusDetail {
 ///
 /// Additionally, if an error occurred, a specific error message is generally
 /// attached.
-class ARROW_MUST_USE_TYPE ARROW_EXPORT Status : public util::EqualityComparable<Status>,
-                                                public util::ToStringOstreamable<Status> {
+class ARROW_EXPORT [[nodiscard]] Status :  // NOLINT(whitespace/braces)
+                                           public util::EqualityComparable<Status>,
+                                           public util::ToStringOstreamable<Status> {
  public:
   // Create a success status.
   Status() noexcept : state_(NULLPTR) {}

--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -129,9 +129,8 @@ class ARROW_EXPORT StatusDetail {
 ///
 /// Additionally, if an error occurred, a specific error message is generally
 /// attached.
-class ARROW_EXPORT [[nodiscard]] Status :  // NOLINT(whitespace/braces)
-                                           public util::EqualityComparable<Status>,
-                                           public util::ToStringOstreamable<Status> {
+class ARROW_EXPORT [[nodiscard]] Status : public util::EqualityComparable<Status>,
+                                          public util::ToStringOstreamable<Status> {
  public:
   // Create a success status.
   Status() noexcept : state_(NULLPTR) {}

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -438,8 +438,6 @@ class ARROW_EXPORT Field : public detail::Fingerprintable,
   std::string ComputeFingerprint() const override;
   std::string ComputeMetadataFingerprint() const override;
 
-  ARROW_EXPORT friend void PrintTo(const Field& field, std::ostream* os);
-
   // Field name
   std::string name_;
 
@@ -454,6 +452,8 @@ class ARROW_EXPORT Field : public detail::Fingerprintable,
 
   ARROW_DISALLOW_COPY_AND_ASSIGN(Field);
 };
+
+ARROW_EXPORT void PrintTo(const Field& field, std::ostream* os);
 
 namespace detail {
 
@@ -1844,9 +1844,9 @@ class ARROW_EXPORT FieldRef : public util::EqualityComparable<FieldRef> {
   void Flatten(std::vector<FieldRef> children);
 
   std::variant<FieldPath, std::string, std::vector<FieldRef>> impl_;
-
-  ARROW_EXPORT friend void PrintTo(const FieldRef& ref, std::ostream* os);
 };
+
+ARROW_EXPORT void PrintTo(const FieldRef& ref, std::ostream* os);
 
 // ----------------------------------------------------------------------
 // Schema
@@ -1955,11 +1955,11 @@ class ARROW_EXPORT Schema : public detail::Fingerprintable,
   std::string ComputeMetadataFingerprint() const override;
 
  private:
-  ARROW_EXPORT friend void PrintTo(const Schema& s, std::ostream* os);
-
   class Impl;
   std::unique_ptr<Impl> impl_;
 };
+
+ARROW_EXPORT void PrintTo(const Schema& s, std::ostream* os);
 
 ARROW_EXPORT
 std::string EndiannessToString(Endianness endianness);

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -514,16 +514,16 @@ std::shared_ptr<DataType> fixed_size_list(const std::shared_ptr<DataType>& value
                                           int32_t list_size);
 /// \brief Return a Duration instance (naming use _type to avoid namespace conflict with
 /// built in time classes).
-std::shared_ptr<DataType> ARROW_EXPORT duration(TimeUnit::type unit);
+ARROW_EXPORT std::shared_ptr<DataType> duration(TimeUnit::type unit);
 
 /// \brief Return a DayTimeIntervalType instance
-std::shared_ptr<DataType> ARROW_EXPORT day_time_interval();
+ARROW_EXPORT std::shared_ptr<DataType> day_time_interval();
 
 /// \brief Return a MonthIntervalType instance
-std::shared_ptr<DataType> ARROW_EXPORT month_interval();
+ARROW_EXPORT std::shared_ptr<DataType> month_interval();
 
 /// \brief Return a MonthDayNanoIntervalType instance
-std::shared_ptr<DataType> ARROW_EXPORT month_day_nano_interval();
+ARROW_EXPORT std::shared_ptr<DataType> month_day_nano_interval();
 
 /// \brief Create a TimestampType instance from its unit
 ARROW_EXPORT
@@ -536,32 +536,32 @@ std::shared_ptr<DataType> timestamp(TimeUnit::type unit, const std::string& time
 /// \brief Create a 32-bit time type instance
 ///
 /// Unit can be either SECOND or MILLI
-std::shared_ptr<DataType> ARROW_EXPORT time32(TimeUnit::type unit);
+ARROW_EXPORT std::shared_ptr<DataType> time32(TimeUnit::type unit);
 
 /// \brief Create a 64-bit time type instance
 ///
 /// Unit can be either MICRO or NANO
-std::shared_ptr<DataType> ARROW_EXPORT time64(TimeUnit::type unit);
+ARROW_EXPORT std::shared_ptr<DataType> time64(TimeUnit::type unit);
 
 /// \brief Create a StructType instance
-std::shared_ptr<DataType> ARROW_EXPORT
-struct_(const std::vector<std::shared_ptr<Field>>& fields);
+ARROW_EXPORT std::shared_ptr<DataType> struct_(
+    const std::vector<std::shared_ptr<Field>>& fields);
 
 /// \brief Create a SparseUnionType instance
-std::shared_ptr<DataType> ARROW_EXPORT sparse_union(FieldVector child_fields,
+ARROW_EXPORT std::shared_ptr<DataType> sparse_union(FieldVector child_fields,
                                                     std::vector<int8_t> type_codes = {});
 /// \brief Create a SparseUnionType instance
-std::shared_ptr<DataType> ARROW_EXPORT
-sparse_union(const ArrayVector& children, std::vector<std::string> field_names = {},
-             std::vector<int8_t> type_codes = {});
+ARROW_EXPORT std::shared_ptr<DataType> sparse_union(
+    const ArrayVector& children, std::vector<std::string> field_names = {},
+    std::vector<int8_t> type_codes = {});
 
 /// \brief Create a DenseUnionType instance
-std::shared_ptr<DataType> ARROW_EXPORT dense_union(FieldVector child_fields,
+ARROW_EXPORT std::shared_ptr<DataType> dense_union(FieldVector child_fields,
                                                    std::vector<int8_t> type_codes = {});
 /// \brief Create a DenseUnionType instance
-std::shared_ptr<DataType> ARROW_EXPORT
-dense_union(const ArrayVector& children, std::vector<std::string> field_names = {},
-            std::vector<int8_t> type_codes = {});
+ARROW_EXPORT std::shared_ptr<DataType> dense_union(
+    const ArrayVector& children, std::vector<std::string> field_names = {},
+    std::vector<int8_t> type_codes = {});
 
 /// \brief Create a DictionaryType instance
 /// \param[in] index_type the type of the dictionary indices (must be
@@ -587,9 +587,9 @@ std::shared_ptr<DataType> dictionary(const std::shared_ptr<DataType>& index_type
 /// \param type the field value type
 /// \param nullable whether the values are nullable, default true
 /// \param metadata any custom key-value metadata, default null
-std::shared_ptr<Field> ARROW_EXPORT
-field(std::string name, std::shared_ptr<DataType> type, bool nullable = true,
-      std::shared_ptr<const KeyValueMetadata> metadata = NULLPTR);
+ARROW_EXPORT std::shared_ptr<Field> field(
+    std::string name, std::shared_ptr<DataType> type, bool nullable = true,
+    std::shared_ptr<const KeyValueMetadata> metadata = NULLPTR);
 
 /// \brief Create a Field instance with metadata
 ///
@@ -598,9 +598,9 @@ field(std::string name, std::shared_ptr<DataType> type, bool nullable = true,
 /// \param name the field name
 /// \param type the field value type
 /// \param metadata any custom key-value metadata
-std::shared_ptr<Field> ARROW_EXPORT
-field(std::string name, std::shared_ptr<DataType> type,
-      std::shared_ptr<const KeyValueMetadata> metadata);
+ARROW_EXPORT std::shared_ptr<Field> field(
+    std::string name, std::shared_ptr<DataType> type,
+    std::shared_ptr<const KeyValueMetadata> metadata);
 
 /// \brief Create a Schema instance
 ///

--- a/cpp/src/arrow/util/byte_size.h
+++ b/cpp/src/arrow/util/byte_size.h
@@ -32,19 +32,19 @@ namespace util {
 ///       byte size of the entire buffer.
 /// Note: If a buffer is referenced multiple times then it will
 ///       only be counted once.
-int64_t ARROW_EXPORT TotalBufferSize(const ArrayData& array_data);
+ARROW_EXPORT int64_t TotalBufferSize(const ArrayData& array_data);
 /// \brief The sum of bytes in each buffer referenced by the array
 /// \see TotalBufferSize(const ArrayData& array_data) for details
-int64_t ARROW_EXPORT TotalBufferSize(const Array& array);
+ARROW_EXPORT int64_t TotalBufferSize(const Array& array);
 /// \brief The sum of bytes in each buffer referenced by the array
 /// \see TotalBufferSize(const ArrayData& array_data) for details
-int64_t ARROW_EXPORT TotalBufferSize(const ChunkedArray& chunked_array);
+ARROW_EXPORT int64_t TotalBufferSize(const ChunkedArray& chunked_array);
 /// \brief The sum of bytes in each buffer referenced by the batch
 /// \see TotalBufferSize(const ArrayData& array_data) for details
-int64_t ARROW_EXPORT TotalBufferSize(const RecordBatch& record_batch);
+ARROW_EXPORT int64_t TotalBufferSize(const RecordBatch& record_batch);
 /// \brief The sum of bytes in each buffer referenced by the table
 /// \see TotalBufferSize(const ArrayData& array_data) for details
-int64_t ARROW_EXPORT TotalBufferSize(const Table& table);
+ARROW_EXPORT int64_t TotalBufferSize(const Table& table);
 
 /// \brief Calculate the buffer ranges referenced by the array
 ///
@@ -57,7 +57,7 @@ int64_t ARROW_EXPORT TotalBufferSize(const Table& table);
 /// The return value will be a struct array corresponding to the schema:
 /// schema({field("start", uint64()), field("offset", uint64()), field("length",
 /// uint64()))
-Result<std::shared_ptr<Array>> ARROW_EXPORT ReferencedRanges(const ArrayData& array_data);
+ARROW_EXPORT Result<std::shared_ptr<Array>> ReferencedRanges(const ArrayData& array_data);
 
 /// \brief Returns the sum of bytes from all buffer ranges referenced
 ///
@@ -69,19 +69,19 @@ Result<std::shared_ptr<Array>> ARROW_EXPORT ReferencedRanges(const ArrayData& ar
 ///
 /// Dictionary arrays will always be counted in their entirety
 /// even if the array only references a portion of the dictionary.
-Result<int64_t> ARROW_EXPORT ReferencedBufferSize(const ArrayData& array_data);
+ARROW_EXPORT Result<int64_t> ReferencedBufferSize(const ArrayData& array_data);
 /// \brief Returns the sum of bytes from all buffer ranges referenced
 /// \see ReferencedBufferSize(const ArrayData& array_data) for details
-Result<int64_t> ARROW_EXPORT ReferencedBufferSize(const Array& array_data);
+ARROW_EXPORT Result<int64_t> ReferencedBufferSize(const Array& array_data);
 /// \brief Returns the sum of bytes from all buffer ranges referenced
 /// \see ReferencedBufferSize(const ArrayData& array_data) for details
-Result<int64_t> ARROW_EXPORT ReferencedBufferSize(const ChunkedArray& array_data);
+ARROW_EXPORT Result<int64_t> ReferencedBufferSize(const ChunkedArray& array_data);
 /// \brief Returns the sum of bytes from all buffer ranges referenced
 /// \see ReferencedBufferSize(const ArrayData& array_data) for details
-Result<int64_t> ARROW_EXPORT ReferencedBufferSize(const RecordBatch& array_data);
+ARROW_EXPORT Result<int64_t> ReferencedBufferSize(const RecordBatch& array_data);
 /// \brief Returns the sum of bytes from all buffer ranges referenced
 /// \see ReferencedBufferSize(const ArrayData& array_data) for details
-Result<int64_t> ARROW_EXPORT ReferencedBufferSize(const Table& array_data);
+ARROW_EXPORT Result<int64_t> ReferencedBufferSize(const Table& array_data);
 
 }  // namespace util
 

--- a/cpp/src/arrow/util/decimal.h
+++ b/cpp/src/arrow/util/decimal.h
@@ -151,8 +151,8 @@ class ARROW_EXPORT Decimal128 : public BasicDecimal128 {
     return ToRealConversion<T>::ToReal(*this, scale);
   }
 
-  friend ARROW_EXPORT std::ostream& operator<<(std::ostream& os,
-                                               const Decimal128& decimal);
+  ARROW_FRIEND_EXPORT friend std::ostream& operator<<(std::ostream& os,
+                                                      const Decimal128& decimal);
 
  private:
   /// Converts internal error code to Status
@@ -267,8 +267,8 @@ class ARROW_EXPORT Decimal256 : public BasicDecimal256 {
     return ToRealConversion<T>::ToReal(*this, scale);
   }
 
-  friend ARROW_EXPORT std::ostream& operator<<(std::ostream& os,
-                                               const Decimal256& decimal);
+  ARROW_FRIEND_EXPORT friend std::ostream& operator<<(std::ostream& os,
+                                                      const Decimal256& decimal);
 
  private:
   /// Converts internal error code to Status

--- a/cpp/src/arrow/util/future.h
+++ b/cpp/src/arrow/util/future.h
@@ -315,7 +315,7 @@ class ARROW_EXPORT FutureImpl : public std::enable_shared_from_this<FutureImpl> 
 /// The consumer API allows querying a Future's current state, wait for it
 /// to complete, and composing futures with callbacks.
 template <typename T>
-class [[nodiscard]] Future {  // NOLINT(whitespace/braces)
+class [[nodiscard]] Future {
  public:
   using ValueType = T;
   using SyncType = typename detail::SyncType<T>::type;

--- a/cpp/src/arrow/util/future.h
+++ b/cpp/src/arrow/util/future.h
@@ -315,7 +315,7 @@ class ARROW_EXPORT FutureImpl : public std::enable_shared_from_this<FutureImpl> 
 /// The consumer API allows querying a Future's current state, wait for it
 /// to complete, and composing futures with callbacks.
 template <typename T>
-class ARROW_MUST_USE_TYPE Future {
+class [[nodiscard]] Future {  // NOLINT(whitespace/braces)
  public:
   using ValueType = T;
   using SyncType = typename detail::SyncType<T>::type;

--- a/cpp/src/arrow/util/int_util.cc
+++ b/cpp/src/arrow/util/int_util.cc
@@ -436,8 +436,8 @@ void TransposeInts(const InputInt* src, OutputInt* dest, int64_t length,
   }
 }
 
-#define INSTANTIATE(SRC, DEST)              \
-  template ARROW_EXPORT void TransposeInts( \
+#define INSTANTIATE(SRC, DEST)                       \
+  template ARROW_TEMPLATE_EXPORT void TransposeInts( \
       const SRC* source, DEST* dest, int64_t length, const int32_t* transpose_map);
 
 #define INSTANTIATE_ALL_DEST(DEST) \

--- a/cpp/src/arrow/util/key_value_metadata.h
+++ b/cpp/src/arrow/util/key_value_metadata.h
@@ -85,14 +85,14 @@ class ARROW_EXPORT KeyValueMetadata {
 /// \brief Create a KeyValueMetadata instance
 ///
 /// \param pairs key-value mapping
-std::shared_ptr<KeyValueMetadata> ARROW_EXPORT
-key_value_metadata(const std::unordered_map<std::string, std::string>& pairs);
+ARROW_EXPORT std::shared_ptr<KeyValueMetadata> key_value_metadata(
+    const std::unordered_map<std::string, std::string>& pairs);
 
 /// \brief Create a KeyValueMetadata instance
 ///
 /// \param keys sequence of metadata keys
 /// \param values sequence of corresponding metadata values
-std::shared_ptr<KeyValueMetadata> ARROW_EXPORT
-key_value_metadata(std::vector<std::string> keys, std::vector<std::string> values);
+ARROW_EXPORT std::shared_ptr<KeyValueMetadata> key_value_metadata(
+    std::vector<std::string> keys, std::vector<std::string> values);
 
 }  // namespace arrow

--- a/cpp/src/arrow/util/macros.h
+++ b/cpp/src/arrow/util/macros.h
@@ -63,21 +63,6 @@
 #define ARROW_PREFETCH(addr)
 #endif
 
-#if (defined(__GNUC__) || defined(__APPLE__))
-#define ARROW_MUST_USE_RESULT __attribute__((warn_unused_result))
-#elif defined(_MSC_VER)
-#define ARROW_MUST_USE_RESULT
-#else
-#define ARROW_MUST_USE_RESULT
-#endif
-
-#if defined(__clang__)
-// Only clang supports warn_unused_result as a type annotation.
-#define ARROW_MUST_USE_TYPE ARROW_MUST_USE_RESULT
-#else
-#define ARROW_MUST_USE_TYPE
-#endif
-
 #if defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER)
 #define ARROW_RESTRICT __restrict
 #else

--- a/cpp/src/arrow/util/thread_pool.h
+++ b/cpp/src/arrow/util/thread_pool.h
@@ -462,7 +462,7 @@ class ARROW_EXPORT ThreadPool : public Executor {
  protected:
   FRIEND_TEST(TestThreadPool, SetCapacity);
   FRIEND_TEST(TestGlobalThreadPool, Capacity);
-  friend ARROW_EXPORT ThreadPool* GetCpuThreadPool();
+  ARROW_FRIEND_EXPORT friend ThreadPool* GetCpuThreadPool();
 
   ThreadPool();
 

--- a/cpp/src/arrow/util/visibility.h
+++ b/cpp/src/arrow/util/visibility.h
@@ -27,10 +27,10 @@
 #endif
 
 #if defined(__cplusplus) && (defined(__GNUC__) || defined(__clang__))
-// Use C++ attribute syntax when possible to avoid GCC parser bug
+// Use C++ attribute syntax where possible to avoid GCC parser bug
 // (https://stackoverflow.com/questions/57993818/gcc-how-to-combine-attribute-dllexport-and-nodiscard-in-a-struct-de)
-#define ARROW_DLLEXPORT [[gnu::dllexport]]  // NOLINT(whitespace/braces)
-#define ARROW_DLLIMPORT [[gnu::dllimport]]  // NOLINT(whitespace/braces)
+#define ARROW_DLLEXPORT [[gnu::dllexport]]
+#define ARROW_DLLIMPORT [[gnu::dllimport]]
 #else
 #define ARROW_DLLEXPORT __declspec(dllexport)
 #define ARROW_DLLIMPORT __declspec(dllimport)
@@ -42,11 +42,12 @@
 #define ARROW_TEMPLATE_EXPORT
 #elif defined(ARROW_EXPORTING)
 #define ARROW_EXPORT ARROW_DLLEXPORT
-#define ARROW_FRIEND_EXPORT ARROW_DLLEXPORT
+// For some reason [[gnu::dllexport]] doesn't work well with friend declarations
+#define ARROW_FRIEND_EXPORT __declspec(dllexport)
 #define ARROW_TEMPLATE_EXPORT ARROW_DLLEXPORT
 #else
 #define ARROW_EXPORT ARROW_DLLIMPORT
-#define ARROW_FRIEND_EXPORT ARROW_DLLIMPORT
+#define ARROW_FRIEND_EXPORT __declspec(dllimport)
 #define ARROW_TEMPLATE_EXPORT ARROW_DLLIMPORT
 #endif
 
@@ -61,10 +62,10 @@
 
 #if defined(__cplusplus) && (defined(__GNUC__) || defined(__clang__))
 #ifndef ARROW_EXPORT
-#define ARROW_EXPORT [[gnu::visibility("default")]]  // NOLINT(whitespace/braces)
+#define ARROW_EXPORT [[gnu::visibility("default")]]
 #endif
 #ifndef ARROW_NO_EXPORT
-#define ARROW_NO_EXPORT [[gnu::visibility("default")]]  // NOLINT(whitespace/braces)
+#define ARROW_NO_EXPORT [[gnu::visibility("hidden")]]
 #endif
 #else
 // Not C++, or not gcc/clang

--- a/cpp/src/arrow/util/visibility.h
+++ b/cpp/src/arrow/util/visibility.h
@@ -18,28 +18,65 @@
 #pragma once
 
 #if defined(_WIN32) || defined(__CYGWIN__)
+// Windows
+
 #if defined(_MSC_VER)
 #pragma warning(disable : 4251)
 #else
 #pragma GCC diagnostic ignored "-Wattributes"
 #endif
 
+#if defined(__cplusplus) && (defined(__GNUC__) || defined(__clang__))
+// Use C++ attribute syntax when possible to avoid GCC parser bug
+// (https://stackoverflow.com/questions/57993818/gcc-how-to-combine-attribute-dllexport-and-nodiscard-in-a-struct-de)
+#define ARROW_DLLEXPORT [[gnu::dllexport]]  // NOLINT(whitespace/braces)
+#define ARROW_DLLIMPORT [[gnu::dllimport]]  // NOLINT(whitespace/braces)
+#else
+#define ARROW_DLLEXPORT __declspec(dllexport)
+#define ARROW_DLLIMPORT __declspec(dllimport)
+#endif
+
 #ifdef ARROW_STATIC
 #define ARROW_EXPORT
+#define ARROW_FRIEND_EXPORT
+#define ARROW_TEMPLATE_EXPORT
 #elif defined(ARROW_EXPORTING)
-#define ARROW_EXPORT __declspec(dllexport)
+#define ARROW_EXPORT ARROW_DLLEXPORT
+#define ARROW_FRIEND_EXPORT ARROW_DLLEXPORT
+#define ARROW_TEMPLATE_EXPORT ARROW_DLLEXPORT
 #else
-#define ARROW_EXPORT __declspec(dllimport)
+#define ARROW_EXPORT ARROW_DLLIMPORT
+#define ARROW_FRIEND_EXPORT ARROW_DLLIMPORT
+#define ARROW_TEMPLATE_EXPORT ARROW_DLLIMPORT
 #endif
 
 #define ARROW_NO_EXPORT
 #define ARROW_FORCE_INLINE __forceinline
-#else  // Not Windows
+
+#else
+
+// Non-Windows
+
+#define ARROW_FORCE_INLINE
+
+#if defined(__cplusplus) && (defined(__GNUC__) || defined(__clang__))
 #ifndef ARROW_EXPORT
-#define ARROW_EXPORT __attribute__((visibility("default")))
+#define ARROW_EXPORT [[gnu::visibility("default")]]  // NOLINT(whitespace/braces)
 #endif
 #ifndef ARROW_NO_EXPORT
-#define ARROW_NO_EXPORT __attribute__((visibility("hidden")))
-#define ARROW_FORCE_INLINE
+#define ARROW_NO_EXPORT [[gnu::visibility("default")]]  // NOLINT(whitespace/braces)
 #endif
+#else
+// Not C++, or not gcc/clang
+#ifndef ARROW_EXPORT
+#define ARROW_EXPORT
+#endif
+#ifndef ARROW_NO_EXPORT
+#define ARROW_NO_EXPORT
+#endif
+#endif
+
+#define ARROW_FRIEND_EXPORT
+#define ARROW_TEMPLATE_EXPORT
+
 #endif  // Non-Windows


### PR DESCRIPTION
C++17 supports the standard attribute `[[nodiscard]]`, use that instead of the clang-specific `__attribute__((warn_unused_result))`.