### PR TITLE
ARROW-17659: [Java] Populate JDBC schema name metadata when config.shouldIncludeMetadata provided

### DIFF
--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/Constants.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/Constants.java
@@ -24,6 +24,7 @@ public class Constants {
   private Constants() {}
 
   public static final String SQL_CATALOG_NAME_KEY = "SQL_CATALOG_NAME";
+  public static final String SQL_SCHEMA_NAME_KEY = "SQL_SCHEMA_NAME";
   public static final String SQL_TABLE_NAME_KEY = "SQL_TABLE_NAME";
   public static final String SQL_COLUMN_NAME_KEY = "SQL_COLUMN_NAME";
   public static final String SQL_TYPE_KEY = "SQL_TYPE";

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
@@ -253,6 +253,7 @@ public class JdbcToArrowUtils {
       if (config.shouldIncludeMetadata()) {
         metadata = new HashMap<>();
         metadata.put(Constants.SQL_CATALOG_NAME_KEY, rsmd.getCatalogName(i));
+        metadata.put(Constants.SQL_SCHEMA_NAME_KEY, rsmd.getSchemaName(i));
         metadata.put(Constants.SQL_TABLE_NAME_KEY, rsmd.getTableName(i));
         metadata.put(Constants.SQL_COLUMN_NAME_KEY, columnName);
         metadata.put(Constants.SQL_TYPE_KEY, rsmd.getColumnTypeName(i));

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowTestHelper.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowTestHelper.java
@@ -324,9 +324,10 @@ public class JdbcToArrowTestHelper {
       Map<String, String> metadata = fields.get(i - 1).getMetadata();
 
       assertNotNull(metadata);
-      assertEquals(4, metadata.size());
+      assertEquals(5, metadata.size());
 
       assertEquals(rsmd.getCatalogName(i), metadata.get(Constants.SQL_CATALOG_NAME_KEY));
+      assertEquals(rsmd.getSchemaName(i), metadata.get(Constants.SQL_SCHEMA_NAME_KEY));
       assertEquals(rsmd.getTableName(i), metadata.get(Constants.SQL_TABLE_NAME_KEY));
       assertEquals(rsmd.getColumnLabel(i), metadata.get(Constants.SQL_COLUMN_NAME_KEY));
       assertEquals(rsmd.getColumnTypeName(i), metadata.get(Constants.SQL_TYPE_KEY));

--- a/java/adapter/jdbc/src/test/resources/h2/expectedSchemaWithCommentsAndJdbcMeta.json
+++ b/java/adapter/jdbc/src/test/resources/h2/expectedSchemaWithCommentsAndJdbcMeta.json
@@ -9,11 +9,8 @@
     },
     "children" : [ ],
     "metadata" : [ {
-      "value" : "Record identifier",
-      "key" : "comment"
-    }, {
-      "value" : "TABLE1",
-      "key" : "SQL_TABLE_NAME"
+      "value" : "PUBLIC",
+      "key" : "SQL_SCHEMA_NAME"
     }, {
       "value" : "JDBCTOARROWTEST?CHARACTERENCODING=UTF-8",
       "key" : "SQL_CATALOG_NAME"
@@ -23,6 +20,12 @@
     }, {
       "value" : "BIGINT",
       "key" : "SQL_TYPE"
+    }, {
+      "value" : "Record identifier",
+      "key" : "comment"
+    }, {
+      "value" : "TABLE1",
+      "key" : "SQL_TABLE_NAME"
     } ]
   }, {
     "name" : "NAME",
@@ -32,11 +35,8 @@
     },
     "children" : [ ],
     "metadata" : [ {
-      "value" : "Name of record",
-      "key" : "comment"
-    }, {
-      "value" : "TABLE1",
-      "key" : "SQL_TABLE_NAME"
+      "value" : "PUBLIC",
+      "key" : "SQL_SCHEMA_NAME"
     }, {
       "value" : "JDBCTOARROWTEST?CHARACTERENCODING=UTF-8",
       "key" : "SQL_CATALOG_NAME"
@@ -46,6 +46,12 @@
     }, {
       "value" : "VARCHAR",
       "key" : "SQL_TYPE"
+    }, {
+      "value" : "Name of record",
+      "key" : "comment"
+    }, {
+      "value" : "TABLE1",
+      "key" : "SQL_TABLE_NAME"
     } ]
   }, {
     "name" : "COLUMN1",
@@ -55,6 +61,9 @@
     },
     "children" : [ ],
     "metadata" : [ {
+      "value" : "PUBLIC",
+      "key" : "SQL_SCHEMA_NAME"
+    }, {
       "value" : "TABLE1",
       "key" : "SQL_TABLE_NAME"
     }, {
@@ -77,11 +86,8 @@
     },
     "children" : [ ],
     "metadata" : [ {
-      "value" : "Informative description of columnN",
-      "key" : "comment"
-    }, {
-      "value" : "TABLE1",
-      "key" : "SQL_TABLE_NAME"
+      "value" : "PUBLIC",
+      "key" : "SQL_SCHEMA_NAME"
     }, {
       "value" : "JDBCTOARROWTEST?CHARACTERENCODING=UTF-8",
       "key" : "SQL_CATALOG_NAME"
@@ -91,6 +97,12 @@
     }, {
       "value" : "INTEGER",
       "key" : "SQL_TYPE"
+    }, {
+      "value" : "Informative description of columnN",
+      "key" : "comment"
+    }, {
+      "value" : "TABLE1",
+      "key" : "SQL_TABLE_NAME"
     } ]
   } ],
   "metadata" : [ {


### PR DESCRIPTION
Current implementation include [catalog,table,column,type](https://github.com/apache/arrow/blob/master/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java#L248) metadata, but schema metadata field is missing. In terms of PostgreSQL catalog - is database, schema - namespace inside database, so catalog name is insufficient for table addressing without schema.

Proposed changes is + metadata.put(Constants.SQL_SCHEMA_KEY, rsmd.getSchemaName(i));