### PR TITLE
ARROW-17815: [Python] Warn, not error out, when SetSignalStopSource fails

### DIFF
--- a/python/pyarrow/includes/common.pxd
+++ b/python/pyarrow/includes/common.pxd
@@ -121,6 +121,8 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         c_bool IsSerializationError()
         c_bool IsCancelled()
 
+        void Warn()
+
     cdef cppclass CStatusDetail "arrow::StatusDetail":
         c_string ToString()
 


### PR DESCRIPTION
In complex scenarios, the global signal-receiving StopSource may have already been created.