### PR TITLE
ARROW-17785: [Java] Suppress flakiness from gRPC in JDBC driver tests

### DIFF
--- a/java/flight/flight-sql-jdbc-driver/pom.xml
+++ b/java/flight/flight-sql-jdbc-driver/pom.xml
@@ -96,12 +96,6 @@
             <version>1.3</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>me.alexpanov</groupId>
-            <artifactId>free-port-finder</artifactId>
-            <version>1.1.1</version>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>commons-io</groupId>

--- a/java/flight/flight-sql-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcConnectionPoolDataSourceTest.java
+++ b/java/flight/flight-sql-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcConnectionPoolDataSourceTest.java
@@ -44,8 +44,6 @@ public class ArrowFlightJdbcConnectionPoolDataSourceTest {
             .build();
 
     FLIGHT_SERVER_TEST_RULE = new FlightServerTestRule.Builder()
-        .host("localhost")
-        .randomPort()
         .authentication(authentication)
         .producer(PRODUCER)
         .build();

--- a/java/flight/flight-sql-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcDriverTest.java
+++ b/java/flight/flight-sql-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcDriverTest.java
@@ -54,8 +54,10 @@ public class ArrowFlightJdbcDriverTest {
         new UserPasswordAuthentication.Builder().user("user1", "pass1").user("user2", "pass2")
             .build();
 
-    FLIGHT_SERVER_TEST_RULE = new FlightServerTestRule.Builder().host("localhost").randomPort()
-        .authentication(authentication).producer(PRODUCER).build();
+    FLIGHT_SERVER_TEST_RULE = new FlightServerTestRule.Builder()
+        .authentication(authentication)
+        .producer(PRODUCER)
+        .build();
   }
 
   private BufferAllocator allocator;

--- a/java/flight/flight-sql-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcFactoryTest.java
+++ b/java/flight/flight-sql-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcFactoryTest.java
@@ -49,8 +49,10 @@ public class ArrowFlightJdbcFactoryTest {
         new UserPasswordAuthentication.Builder().user("user1", "pass1").user("user2", "pass2")
             .build();
 
-    FLIGHT_SERVER_TEST_RULE = new FlightServerTestRule.Builder().host("localhost").randomPort()
-        .authentication(authentication).producer(PRODUCER).build();
+    FLIGHT_SERVER_TEST_RULE = new FlightServerTestRule.Builder()
+        .authentication(authentication)
+        .producer(PRODUCER)
+        .build();
   }
 
   private BufferAllocator allocator;

--- a/java/flight/flight-sql-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTest.java
+++ b/java/flight/flight-sql-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTest.java
@@ -56,8 +56,10 @@ public class ConnectionTest {
             .user(userTest, passTest)
             .build();
 
-    FLIGHT_SERVER_TEST_RULE = new FlightServerTestRule.Builder().host("localhost").randomPort()
-        .authentication(authentication).producer(PRODUCER).build();
+    FLIGHT_SERVER_TEST_RULE = new FlightServerTestRule.Builder()
+        .authentication(authentication)
+        .producer(PRODUCER)
+        .build();
   }
 
   private BufferAllocator allocator;

--- a/java/flight/flight-sql-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTlsTest.java
+++ b/java/flight/flight-sql-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTlsTest.java
@@ -63,8 +63,6 @@ public class ConnectionTlsTest {
             .build();
 
     FLIGHT_SERVER_TEST_RULE = new FlightServerTestRule.Builder()
-        .host("localhost")
-        .randomPort()
         .authentication(authentication)
         .useEncryption(certKey.cert, certKey.key)
         .producer(PRODUCER)

--- a/java/flight/flight-sql-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/ResultSetTest.java
+++ b/java/flight/flight-sql-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/ResultSetTest.java
@@ -160,7 +160,6 @@ public class ResultSetTest {
     try (Statement statement = connection.createStatement();
          ResultSet resultSet = statement.executeQuery(
              CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD)) {
-
       final long maxRowsLimit = 3;
       statement.setLargeMaxRows(maxRowsLimit);
 

--- a/java/flight/flight-sql-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/TokenAuthenticationTest.java
+++ b/java/flight/flight-sql-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/TokenAuthenticationTest.java
@@ -36,8 +36,6 @@ public class TokenAuthenticationTest {
 
   static {
     FLIGHT_SERVER_TEST_RULE = new FlightServerTestRule.Builder()
-        .host("localhost")
-        .randomPort()
         .authentication(new TokenAuthentication.Builder()
             .token("1234")
             .build())


### PR DESCRIPTION
I couldn't reproduce it, so I added a suppression instead. 

In both cases, the error is that the server is uncontactable. That shouldn't happen, but I changed the tests to also bind to port 0 instead of using a potentially flaky free port finder.