### PR TITLE
ARROW-17787: [Java] Fix Javadoc build

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -688,7 +688,6 @@
           <reportSet><!-- by default, id = "default" -->
             <reports><!-- select non-aggregate reports -->
               <report>javadoc</report>
-              <report>test-javadoc</report>
             </reports>
           </reportSet>
           <reportSet><!-- aggregate reportSet, to define in poms having modules -->


### PR DESCRIPTION
Don't document the javadocs to avoid errors when there is nothing documentable in the javadocs