### PR TITLE
ARROW-17823: [C++] Prefer std::make_shared/std::make_unique over constructor with new

### DIFF
--- a/cpp/examples/arrow/compute_register_example.cc
+++ b/cpp/examples/arrow/compute_register_example.cc
@@ -57,7 +57,7 @@ class ExampleFunctionOptions : public cp::FunctionOptions {
 
 std::unique_ptr<cp::FunctionOptions> ExampleFunctionOptionsType::Copy(
     const cp::FunctionOptions&) const {
-  return std::unique_ptr<cp::FunctionOptions>(new ExampleFunctionOptions());
+  return std::make_unique<ExampleFunctionOptions>();
 }
 
 arrow::Status ExampleFunctionImpl(cp::KernelContext* ctx, const cp::ExecSpan& batch,

--- a/cpp/src/arrow/adapters/orc/adapter.cc
+++ b/cpp/src/arrow/adapters/orc/adapter.cc
@@ -530,7 +530,7 @@ ORCFileReader::~ORCFileReader() {}
 
 Result<std::unique_ptr<ORCFileReader>> ORCFileReader::Open(
     const std::shared_ptr<io::RandomAccessFile>& file, MemoryPool* pool) {
-  auto result = std::unique_ptr<ORCFileReader>(new ORCFileReader());
+  auto result = std::unique_ptr<ORCFileReader>(new ORCFileReader);
   RETURN_NOT_OK(result->impl_->Open(file, pool));
   return std::move(result);
 }

--- a/cpp/src/arrow/adapters/orc/adapter.cc
+++ b/cpp/src/arrow/adapters/orc/adapter.cc
@@ -530,7 +530,7 @@ ORCFileReader::~ORCFileReader() {}
 
 Result<std::unique_ptr<ORCFileReader>> ORCFileReader::Open(
     const std::shared_ptr<io::RandomAccessFile>& file, MemoryPool* pool) {
-  auto result = std::unique_ptr<ORCFileReader>(new ORCFileReader);
+  auto result = std::unique_ptr<ORCFileReader>(new ORCFileReader());
   RETURN_NOT_OK(result->impl_->Open(file, pool));
   return std::move(result);
 }

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -1097,7 +1097,7 @@ Result<std::unique_ptr<KernelExecutor>> MakeExecutor(ExecContext* ctx,
                                                      const FunctionOptions* options) {
   DCHECK_EQ(ExecutorType::function_kind, func->kind());
   auto typed_func = checked_cast<const FunctionType*>(func);
-  return std::unique_ptr<KernelExecutor>(new ExecutorType(ctx, typed_func, options));
+  return std::make_unique<ExecutorType>(ctx, typed_func, options);
 }
 
 }  // namespace

--- a/cpp/src/arrow/compute/exec/options.cc
+++ b/cpp/src/arrow/compute/exec/options.cc
@@ -59,8 +59,7 @@ Result<std::shared_ptr<SourceNodeOptions>> SourceNodeOptions::FromTable(
   // Map the RecordBatchReader to a SourceNode
   ARROW_ASSIGN_OR_RAISE(auto batch_gen, MakeReaderGenerator(std::move(reader), exc));
 
-  return std::shared_ptr<SourceNodeOptions>(
-      new SourceNodeOptions(table.schema(), batch_gen));
+  return std::make_shared<SourceNodeOptions>(table.schema(), batch_gen);
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/exec/tpch_node.cc
+++ b/cpp/src/arrow/compute/exec/tpch_node.cc
@@ -3548,7 +3548,7 @@ Result<std::unique_ptr<TpchGen>> TpchGen::Make(ExecPlan* plan, double scale_fact
                                                int64_t batch_size,
                                                std::optional<int64_t> seed) {
   if (!seed.has_value()) seed = GetRandomSeed();
-  return std::unique_ptr<TpchGen>(new TpchGenImpl(plan, scale_factor, batch_size, *seed));
+  return std::make_unique<TpchGenImpl>(plan, scale_factor, batch_size, *seed);
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/compute/exec_test.cc
+++ b/cpp/src/arrow/compute/exec_test.cc
@@ -765,7 +765,7 @@ TEST_F(TestExecSpanIterator, ChunkedArrays) {
 }
 
 TEST_F(TestExecSpanIterator, ZeroLengthInputs) {
-  auto carr = std::shared_ptr<ChunkedArray>(new ChunkedArray({}, int32()));
+  auto carr = std::make_shared<ChunkedArray>(ArrayVector{}, int32());
 
   auto CheckArgs = [&](const ExecBatch& batch) {
     ExecSpanIterator iterator;

--- a/cpp/src/arrow/compute/exec_test.cc
+++ b/cpp/src/arrow/compute/exec_test.cc
@@ -896,7 +896,7 @@ struct ExampleState : public KernelState {
 Result<std::unique_ptr<KernelState>> InitStateful(KernelContext*,
                                                   const KernelInitArgs& args) {
   auto func_options = static_cast<const ExampleOptions*>(args.options);
-  return std::unique_ptr<KernelState>(new ExampleState{func_options->value});
+  return std::make_unique<ExampleState>(func_options->value);
 }
 
 Status ExecStateful(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
@@ -1063,8 +1063,8 @@ TEST_F(TestCallScalarFunction, PreallocationCases) {
 
     // Input is chunked, output has one big chunk
     {
-      auto carr = std::shared_ptr<ChunkedArray>(
-          new ChunkedArray({arr->Slice(0, 10), arr->Slice(10)}));
+      auto carr =
+          std::make_shared<ChunkedArray>(ArrayVector{arr->Slice(0, 10), arr->Slice(10)});
       std::vector<Datum> args = {Datum(carr)};
       ASSERT_OK_AND_ASSIGN(Datum result, CallFunction(func_name, args, exec_ctx_.get()));
       std::shared_ptr<ChunkedArray> actual = result.chunked_array();

--- a/cpp/src/arrow/compute/function_internal.h
+++ b/cpp/src/arrow/compute/function_internal.h
@@ -647,13 +647,13 @@ const FunctionOptionsType* GetFunctionOptionsType(const Properties&... propertie
     }
     Result<std::unique_ptr<FunctionOptions>> FromStructScalar(
         const StructScalar& scalar) const override {
-      auto options = std::unique_ptr<Options>(new Options());
+      auto options = std::make_unique<Options>();
       RETURN_NOT_OK(
           FromStructScalarImpl<Options>(options.get(), scalar, properties_).status_);
       return std::move(options);
     }
     std::unique_ptr<FunctionOptions> Copy(const FunctionOptions& options) const override {
-      auto out = std::unique_ptr<Options>(new Options());
+      auto out = std::make_unique<Options>();
       CopyImpl<Options>(out.get(), checked_cast<const Options&>(options), properties_);
       return std::move(out);
     }

--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -851,7 +851,7 @@ class HivePartitioningFactory : public KeyValuePartitioningFactory {
 
 std::shared_ptr<PartitioningFactory> HivePartitioning::MakeFactory(
     HivePartitioningFactoryOptions options) {
-  return std::shared_ptr<PartitioningFactory>(new HivePartitioningFactory(options));
+  return std::make_shared<HivePartitioningFactory>(options);
 }
 
 std::string StripPrefix(const std::string& path, const std::string& prefix) {

--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -696,14 +696,12 @@ class FilenamePartitioningFactory : public KeyValuePartitioningFactory {
 
 std::shared_ptr<PartitioningFactory> DirectoryPartitioning::MakeFactory(
     std::vector<std::string> field_names, PartitioningFactoryOptions options) {
-  return std::shared_ptr<PartitioningFactory>(
-      new DirectoryPartitioningFactory(std::move(field_names), options));
+  return std::make_shared<DirectoryPartitioningFactory>(std::move(field_names), options);
 }
 
 std::shared_ptr<PartitioningFactory> FilenamePartitioning::MakeFactory(
     std::vector<std::string> field_names, PartitioningFactoryOptions options) {
-  return std::shared_ptr<PartitioningFactory>(
-      new FilenamePartitioningFactory(std::move(field_names), options));
+  return std::make_shared<FilenamePartitioningFactory>(std::move(field_names), options);
 }
 
 bool FilenamePartitioning::Equals(const Partitioning& other) const {

--- a/cpp/src/arrow/filesystem/mockfs.cc
+++ b/cpp/src/arrow/filesystem/mockfs.cc
@@ -431,7 +431,7 @@ class MockFileSystem::Impl {
 MockFileSystem::~MockFileSystem() = default;
 
 MockFileSystem::MockFileSystem(TimePoint current_time, const io::IOContext& io_context) {
-  impl_ = std::unique_ptr<Impl>(new Impl(current_time, io_context.pool()));
+  impl_ = std::make_unique<Impl>(current_time, io_context.pool());
 }
 
 bool MockFileSystem::Equals(const FileSystem& other) const { return this == &other; }

--- a/cpp/src/arrow/flight/client_cookie_middleware.cc
+++ b/cpp/src/arrow/flight/client_cookie_middleware.cc
@@ -27,7 +27,7 @@ class ClientCookieMiddlewareFactory : public ClientMiddlewareFactory {
  public:
   void StartCall(const CallInfo& info, std::unique_ptr<ClientMiddleware>* middleware) {
     ARROW_UNUSED(info);
-    *middleware = std::unique_ptr<ClientMiddleware>(new ClientCookieMiddleware(*this));
+    *middleware = std::make_unique<ClientCookieMiddleware>(*this);
   }
 
  private:

--- a/cpp/src/arrow/flight/flight_internals_test.cc
+++ b/cpp/src/arrow/flight/flight_internals_test.cc
@@ -148,7 +148,7 @@ TEST(FlightTypes, RoundTripTypes) {
   std::vector<FlightEndpoint> endpoints{FlightEndpoint{ticket, {location1, location2}},
                                         FlightEndpoint{ticket, {location3}}};
   ASSERT_OK(MakeFlightInfo(*schema, desc, endpoints, -1, -1, &data));
-  std::unique_ptr<FlightInfo> info = std::unique_ptr<FlightInfo>(new FlightInfo(data));
+  auto info = std::make_unique<FlightInfo>(data);
   ASSERT_OK_AND_ASSIGN(std::string info_serialized, info->SerializeToString());
   ASSERT_OK_AND_ASSIGN(std::unique_ptr<FlightInfo> info_deserialized,
                        FlightInfo::Deserialize(info_serialized));

--- a/cpp/src/arrow/flight/flight_test.cc
+++ b/cpp/src/arrow/flight/flight_test.cc
@@ -288,7 +288,7 @@ class TlsTestServer : public FlightServerBase {
   Status DoAction(const ServerCallContext& context, const Action& action,
                   std::unique_ptr<ResultStream>* result) override {
     auto buf = Buffer::FromString("Hello, world!");
-    *result = std::unique_ptr<ResultStream>(new SimpleResultStream({Result{buf}}));
+    *result = std::make_unique<SimpleResultStream>({Result{buf}});
     return Status::OK();
   }
 };
@@ -632,7 +632,7 @@ class ReportContextTestServer : public FlightServerBase {
     } else {
       buf = Buffer::FromString(((const TracingServerMiddleware*)middleware)->span_id);
     }
-    *result = std::unique_ptr<ResultStream>(new SimpleResultStream({Result{buf}}));
+    *result = std::make_unique<SimpleResultStream>({Result{buf}});
     return Status::OK();
   }
 };
@@ -645,7 +645,7 @@ class ErrorMiddlewareServer : public FlightServerBase {
 
     std::shared_ptr<FlightStatusDetail> flightStatusDetail(
         new FlightStatusDetail(FlightStatusCode::Failed, msg));
-    *result = std::unique_ptr<ResultStream>(new SimpleResultStream({Result{buf}}));
+    *result = std::make_unique<SimpleResultStream>({Result{buf}});
     return Status(StatusCode::ExecutionError, "test failed", flightStatusDetail);
   }
 };
@@ -815,8 +815,7 @@ class TestBasicHeaderAuthMiddleware : public ::testing::Test {
     ASSERT_OK(MakeServer<HeaderAuthTestServer>(
         &server_, &client_,
         [&](FlightServerOptions* options) {
-          options->auth_handler =
-              std::unique_ptr<ServerAuthHandler>(new NoOpAuthHandler());
+          options->auth_handler = std::make_unique<NoOpAuthHandler>();
           options->middleware.push_back({"header-auth-server", header_middleware_});
           options->middleware.push_back({"bearer-auth-server", bearer_middleware_});
           return Status::OK();
@@ -1030,8 +1029,7 @@ TEST_F(TestFlightClient, Close) {
 
 TEST_F(TestAuthHandler, PassAuthenticatedCalls) {
   ASSERT_OK(client_->Authenticate(
-      {},
-      std::unique_ptr<ClientAuthHandler>(new TestClientAuthHandler("user", "p4ssw0rd"))));
+      {}, std::make_unique<TestClientAuthHandler>("user", "p4ssw0rd")));
 
   Status status;
   status = client_->ListFlights().status();
@@ -1101,8 +1099,7 @@ TEST_F(TestAuthHandler, FailUnauthenticatedCalls) {
 
 TEST_F(TestAuthHandler, CheckPeerIdentity) {
   ASSERT_OK(client_->Authenticate(
-      {},
-      std::unique_ptr<ClientAuthHandler>(new TestClientAuthHandler("user", "p4ssw0rd"))));
+      {}, std::make_unique<TestClientAuthHandler>("user", "p4ssw0rd")));
 
   Action action;
   action.type = "who-am-i";

--- a/cpp/src/arrow/flight/flight_test.cc
+++ b/cpp/src/arrow/flight/flight_test.cc
@@ -278,8 +278,8 @@ class AuthTestServer : public FlightServerBase {
                   std::unique_ptr<ResultStream>* result) override {
     auto buf = Buffer::FromString(context.peer_identity());
     auto peer = Buffer::FromString(context.peer());
-    *result = std::unique_ptr<ResultStream>(
-        new SimpleResultStream({Result{buf}, Result{peer}}));
+    *result = std::make_unique<SimpleResultStream>(
+        std::vector<Result>{Result{buf}, Result{peer}});
     return Status::OK();
   }
 };
@@ -288,7 +288,7 @@ class TlsTestServer : public FlightServerBase {
   Status DoAction(const ServerCallContext& context, const Action& action,
                   std::unique_ptr<ResultStream>* result) override {
     auto buf = Buffer::FromString("Hello, world!");
-    *result = std::make_unique<SimpleResultStream>({Result{buf}});
+    *result = std::make_unique<SimpleResultStream>(std::vector<Result>{Result{buf}});
     return Status::OK();
   }
 };
@@ -307,8 +307,8 @@ class TestAuthHandler : public ::testing::Test {
     ASSERT_OK(MakeServer<AuthTestServer>(
         &server_, &client_,
         [](FlightServerOptions* options) {
-          options->auth_handler = std::unique_ptr<ServerAuthHandler>(
-              new TestServerAuthHandler("user", "p4ssw0rd"));
+          options->auth_handler =
+              std::make_unique<TestServerAuthHandler>("user", "p4ssw0rd");
           return Status::OK();
         },
         [](FlightClientOptions* options) { return Status::OK(); }));
@@ -330,8 +330,8 @@ class TestBasicAuthHandler : public ::testing::Test {
     ASSERT_OK(MakeServer<AuthTestServer>(
         &server_, &client_,
         [](FlightServerOptions* options) {
-          options->auth_handler = std::unique_ptr<ServerAuthHandler>(
-              new TestServerBasicAuthHandler("user", "p4ssw0rd"));
+          options->auth_handler =
+              std::make_unique<TestServerBasicAuthHandler>("user", "p4ssw0rd");
           return Status::OK();
         },
         [](FlightClientOptions* options) { return Status::OK(); }));
@@ -632,7 +632,7 @@ class ReportContextTestServer : public FlightServerBase {
     } else {
       buf = Buffer::FromString(((const TracingServerMiddleware*)middleware)->span_id);
     }
-    *result = std::make_unique<SimpleResultStream>({Result{buf}});
+    *result = std::make_unique<SimpleResultStream>(std::vector<Result>{Result{buf}});
     return Status::OK();
   }
 };
@@ -645,7 +645,7 @@ class ErrorMiddlewareServer : public FlightServerBase {
 
     std::shared_ptr<FlightStatusDetail> flightStatusDetail(
         new FlightStatusDetail(FlightStatusCode::Failed, msg));
-    *result = std::make_unique<SimpleResultStream>({Result{buf}});
+    *result = std::make_unique<SimpleResultStream>(std::vector<Result>{Result{buf}});
     return Status(StatusCode::ExecutionError, "test failed", flightStatusDetail);
   }
 };
@@ -1125,9 +1125,8 @@ TEST_F(TestAuthHandler, CheckPeerIdentity) {
 }
 
 TEST_F(TestBasicAuthHandler, PassAuthenticatedCalls) {
-  ASSERT_OK(
-      client_->Authenticate({}, std::unique_ptr<ClientAuthHandler>(
-                                    new TestClientBasicAuthHandler("user", "p4ssw0rd"))));
+  ASSERT_OK(client_->Authenticate(
+      {}, std::make_unique<TestClientBasicAuthHandler>("user", "p4ssw0rd")));
 
   Status status;
   status = client_->ListFlights().status();
@@ -1193,9 +1192,8 @@ TEST_F(TestBasicAuthHandler, FailUnauthenticatedCalls) {
 }
 
 TEST_F(TestBasicAuthHandler, CheckPeerIdentity) {
-  ASSERT_OK(
-      client_->Authenticate({}, std::unique_ptr<ClientAuthHandler>(
-                                    new TestClientBasicAuthHandler("user", "p4ssw0rd"))));
+  ASSERT_OK(client_->Authenticate(
+      {}, std::make_unique<TestClientBasicAuthHandler>("user", "p4ssw0rd")));
 
   Action action;
   action.type = "who-am-i";

--- a/cpp/src/arrow/flight/integration_tests/test_integration.cc
+++ b/cpp/src/arrow/flight/integration_tests/test_integration.cc
@@ -53,7 +53,7 @@ class AuthBasicProtoServer : public FlightServerBase {
                   std::unique_ptr<ResultStream>* result) override {
     // Respond with the authenticated username.
     auto buf = Buffer::FromString(context.peer_identity());
-    *result = std::make_unique<SimpleResultStream>({Result{buf}});
+    *result = std::make_unique<SimpleResultStream>(std::vector<Result>{Result{buf}});
     return Status::OK();
   }
 };
@@ -112,8 +112,8 @@ class AuthBasicProtoScenario : public Scenario {
       return Status::Invalid("Expected UNAUTHENTICATED but got ", detail->ToString());
     }
 
-    auto client_handler = std::unique_ptr<ClientAuthHandler>(
-        new TestClientBasicAuthHandler(kAuthUsername, kAuthPassword));
+    auto client_handler =
+        std::make_unique<TestClientBasicAuthHandler>(kAuthUsername, kAuthPassword);
     RETURN_NOT_OK(client->Authenticate({}, std::move(client_handler)));
     return CheckActionResults(client.get(), action, {kAuthUsername});
   }

--- a/cpp/src/arrow/flight/integration_tests/test_integration.cc
+++ b/cpp/src/arrow/flight/integration_tests/test_integration.cc
@@ -53,7 +53,7 @@ class AuthBasicProtoServer : public FlightServerBase {
                   std::unique_ptr<ResultStream>* result) override {
     // Respond with the authenticated username.
     auto buf = Buffer::FromString(context.peer_identity());
-    *result = std::unique_ptr<ResultStream>(new SimpleResultStream({Result{buf}}));
+    *result = std::make_unique<SimpleResultStream>({Result{buf}});
     return Status::OK();
   }
 };
@@ -191,8 +191,7 @@ class TestClientMiddlewareFactory : public ClientMiddlewareFactory {
  public:
   void StartCall(const CallInfo& info,
                  std::unique_ptr<ClientMiddleware>* middleware) override {
-    *middleware =
-        std::unique_ptr<ClientMiddleware>(new TestClientMiddleware(&received_header_));
+    *middleware = std::make_unique<TestClientMiddleware>(&received_header_);
   }
 
   std::string received_header_;
@@ -214,7 +213,7 @@ class MiddlewareServer : public FlightServerBase {
       std::vector<FlightEndpoint> endpoints{FlightEndpoint{{"foo"}, {location}}};
       ARROW_ASSIGN_OR_RAISE(auto info,
                             FlightInfo::Make(*schema, descriptor, endpoints, -1, -1));
-      *result = std::unique_ptr<FlightInfo>(new FlightInfo(info));
+      *result = std::make_unique<FlightInfo>(info);
       return Status::OK();
     }
     // Fail the call immediately. In some gRPC implementations, this
@@ -386,7 +385,7 @@ class FlightSqlScenarioServer : public sql::FlightSqlServerBase {
     std::vector<FlightEndpoint> endpoints{FlightEndpoint{{handle}, {}}};
     ARROW_ASSIGN_OR_RAISE(auto result,
                           FlightInfo::Make(*schema, descriptor, endpoints, -1, -1));
-    return std::unique_ptr<FlightInfo>(new FlightInfo(result));
+    return std::make_unique<FlightInfo>(result);
   }
 
   arrow::Result<std::unique_ptr<FlightInfo>> GetFlightInfoSubstraitPlan(
@@ -411,7 +410,7 @@ class FlightSqlScenarioServer : public sql::FlightSqlServerBase {
     std::vector<FlightEndpoint> endpoints{FlightEndpoint{{handle}, {}}};
     ARROW_ASSIGN_OR_RAISE(auto result,
                           FlightInfo::Make(*schema, descriptor, endpoints, -1, -1));
-    return std::unique_ptr<FlightInfo>(new FlightInfo(result));
+    return std::make_unique<FlightInfo>(result);
   }
 
   arrow::Result<std::unique_ptr<SchemaResult>> GetSchemaStatement(
@@ -855,13 +854,13 @@ class FlightSqlScenarioServer : public sql::FlightSqlServerBase {
     ARROW_ASSIGN_OR_RAISE(auto result,
                           FlightInfo::Make(*schema, descriptor, endpoints, -1, -1))
 
-    return std::unique_ptr<FlightInfo>(new FlightInfo(result));
+    return std::make_unique<FlightInfo>(result);
   }
 
   arrow::Result<std::unique_ptr<FlightDataStream>> DoGetForTestCase(
       const std::shared_ptr<Schema>& schema) {
     ARROW_ASSIGN_OR_RAISE(auto reader, RecordBatchReader::Make({}, schema));
-    return std::unique_ptr<FlightDataStream>(new RecordBatchStream(reader));
+    return std::make_unique<RecordBatchStream>(reader);
   }
 };
 

--- a/cpp/src/arrow/flight/integration_tests/test_integration_server.cc
+++ b/cpp/src/arrow/flight/integration_tests/test_integration_server.cc
@@ -103,7 +103,7 @@ class FlightIntegrationTestServer : public FlightServerBase {
       flight_data.total_bytes = -1;
       FlightInfo value(flight_data);
 
-      *info = std::unique_ptr<FlightInfo>(new FlightInfo(value));
+      *info = std::make_unique<FlightInfo>(value);
       return Status::OK();
     } else {
       return Status::NotImplemented(request.type);
@@ -119,8 +119,8 @@ class FlightIntegrationTestServer : public FlightServerBase {
     auto flight = data->second;
 
     *data_stream = std::unique_ptr<FlightDataStream>(
-        new NumberingStream(std::unique_ptr<FlightDataStream>(new RecordBatchStream(
-            std::shared_ptr<RecordBatchReader>(new RecordBatchListReader(flight))))));
+        new NumberingStream(std::unique_ptr<FlightDataStream>(
+            new RecordBatchStream(std::make_shared<RecordBatchListReader>(flight)))));
 
     return Status::OK();
   }

--- a/cpp/src/arrow/flight/integration_tests/test_integration_server.cc
+++ b/cpp/src/arrow/flight/integration_tests/test_integration_server.cc
@@ -118,9 +118,10 @@ class FlightIntegrationTestServer : public FlightServerBase {
     }
     auto flight = data->second;
 
-    *data_stream = std::unique_ptr<FlightDataStream>(
-        new NumberingStream(std::unique_ptr<FlightDataStream>(
-            new RecordBatchStream(std::make_shared<RecordBatchListReader>(flight)))));
+    std::unique_ptr<FlightDataStream> record_batch_stream =
+        std::make_unique<RecordBatchStream>(
+            std::make_shared<RecordBatchListReader>(flight));
+    *data_stream = std::make_unique<NumberingStream>(std::move(record_batch_stream));
 
     return Status::OK();
   }

--- a/cpp/src/arrow/flight/perf_server.cc
+++ b/cpp/src/arrow/flight/perf_server.cc
@@ -198,7 +198,7 @@ class FlightPerfServer : public FlightServerBase {
     FlightInfo::Data data;
     RETURN_NOT_OK(
         MakeFlightInfo(*perf_schema_, request, endpoints, total_records, -1, &data));
-    *info = std::unique_ptr<FlightInfo>(new FlightInfo(data));
+    *info = std::make_unique<FlightInfo>(data);
     return Status::OK();
   }
 
@@ -228,7 +228,7 @@ class FlightPerfServer : public FlightServerBase {
                   std::unique_ptr<ResultStream>* result) override {
     if (action.type == "ping") {
       std::shared_ptr<Buffer> buf = Buffer::FromString("ok");
-      *result = std::unique_ptr<ResultStream>(new SimpleResultStream({Result{buf}}));
+      *result = std::make_unique<SimpleResultStream>({Result{buf}});
       return Status::OK();
     }
     return Status::NotImplemented(action.type);

--- a/cpp/src/arrow/flight/perf_server.cc
+++ b/cpp/src/arrow/flight/perf_server.cc
@@ -228,7 +228,7 @@ class FlightPerfServer : public FlightServerBase {
                   std::unique_ptr<ResultStream>* result) override {
     if (action.type == "ping") {
       std::shared_ptr<Buffer> buf = Buffer::FromString("ok");
-      *result = std::make_unique<SimpleResultStream>({Result{buf}});
+      *result = std::make_unique<SimpleResultStream>(std::vector<Result>{Result{buf}});
       return Status::OK();
     }
     return Status::NotImplemented(action.type);

--- a/cpp/src/arrow/flight/sql/example/acero_server.cc
+++ b/cpp/src/arrow/flight/sql/example/acero_server.cc
@@ -204,7 +204,7 @@ class AceroFlightSqlServer : public FlightSqlServerBase {
 
     auto reader = std::make_shared<ConsumerBasedRecordBatchReader>(std::move(plan),
                                                                    std::move(consumer));
-    return std::unique_ptr<FlightDataStream>(new RecordBatchStream(reader));
+    return std::make_unique<RecordBatchStream>(reader);
   }
 
   arrow::Result<int64_t> DoPutCommandSubstraitPlan(
@@ -299,7 +299,7 @@ class AceroFlightSqlServer : public FlightSqlServerBase {
 }  // namespace
 
 arrow::Result<std::unique_ptr<FlightSqlServerBase>> MakeAceroServer() {
-  return std::unique_ptr<AceroFlightSqlServer>(new AceroFlightSqlServer());
+  return std::make_unique<AceroFlightSqlServer>();
 }
 
 }  // namespace acero_example

--- a/cpp/src/arrow/flight/sql/example/sqlite_server.cc
+++ b/cpp/src/arrow/flight/sql/example/sqlite_server.cc
@@ -136,7 +136,7 @@ arrow::Result<std::unique_ptr<FlightDataStream>> DoGetSQLiteQuery(
   std::shared_ptr<SqliteStatementBatchReader> reader;
   ARROW_ASSIGN_OR_RAISE(reader, SqliteStatementBatchReader::Create(statement, schema));
 
-  return std::unique_ptr<FlightDataStream>(new RecordBatchStream(reader));
+  return std::make_unique<RecordBatchStream>(reader);
 }
 
 arrow::Result<std::unique_ptr<FlightInfo>> GetFlightInfoForCommand(
@@ -145,7 +145,7 @@ arrow::Result<std::unique_ptr<FlightInfo>> GetFlightInfoForCommand(
   ARROW_ASSIGN_OR_RAISE(auto result,
                         FlightInfo::Make(*schema, descriptor, endpoints, -1, -1))
 
-  return std::unique_ptr<FlightInfo>(new FlightInfo(result));
+  return std::make_unique<FlightInfo>(result);
 }
 
 std::string PrepareQueryForGetImportedOrExportedKeys(const std::string& filter) {
@@ -320,7 +320,7 @@ class SQLiteFlightSqlServer::Impl {
     ARROW_ASSIGN_OR_RAISE(auto result,
                           FlightInfo::Make(*schema, descriptor, endpoints, -1, -1))
 
-    return std::unique_ptr<FlightInfo>(new FlightInfo(result));
+    return std::make_unique<FlightInfo>(result);
   }
 
   arrow::Result<std::unique_ptr<FlightDataStream>> DoGetStatement(
@@ -336,7 +336,7 @@ class SQLiteFlightSqlServer::Impl {
     std::shared_ptr<SqliteStatementBatchReader> reader;
     ARROW_ASSIGN_OR_RAISE(reader, SqliteStatementBatchReader::Create(statement));
 
-    return std::unique_ptr<FlightDataStream>(new RecordBatchStream(reader));
+    return std::make_unique<RecordBatchStream>(reader);
   }
 
   arrow::Result<std::unique_ptr<FlightInfo>> GetFlightInfoCatalogs(
@@ -358,7 +358,7 @@ class SQLiteFlightSqlServer::Impl {
 
     ARROW_ASSIGN_OR_RAISE(auto reader, RecordBatchReader::Make({batch}));
 
-    return std::unique_ptr<FlightDataStream>(new RecordBatchStream(reader));
+    return std::make_unique<RecordBatchStream>(reader);
   }
 
   arrow::Result<std::unique_ptr<FlightInfo>> GetFlightInfoSchemas(
@@ -383,7 +383,7 @@ class SQLiteFlightSqlServer::Impl {
 
     ARROW_ASSIGN_OR_RAISE(auto reader, RecordBatchReader::Make({batch}));
 
-    return std::unique_ptr<FlightDataStream>(new RecordBatchStream(reader));
+    return std::make_unique<RecordBatchStream>(reader);
   }
 
   arrow::Result<std::unique_ptr<FlightInfo>> GetFlightInfoTables(
@@ -399,7 +399,7 @@ class SQLiteFlightSqlServer::Impl {
                                         : *SqlSchema::GetTablesSchema(),
                          descriptor, endpoints, -1, -1))
 
-    return std::unique_ptr<FlightInfo>(new FlightInfo(result));
+    return std::make_unique<FlightInfo>(result);
   }
 
   arrow::Result<std::unique_ptr<FlightDataStream>> DoGetTables(
@@ -419,7 +419,7 @@ class SQLiteFlightSqlServer::Impl {
       return std::unique_ptr<FlightDataStream>(
           new RecordBatchStream(table_schema_reader));
     } else {
-      return std::unique_ptr<FlightDataStream>(new RecordBatchStream(reader));
+      return std::make_unique<RecordBatchStream>(reader);
     }
   }
 
@@ -516,7 +516,7 @@ class SQLiteFlightSqlServer::Impl {
     std::shared_ptr<SqliteStatementBatchReader> reader;
     ARROW_ASSIGN_OR_RAISE(reader, SqliteStatementBatchReader::Create(statement));
 
-    return std::unique_ptr<FlightDataStream>(new RecordBatchStream(reader));
+    return std::make_unique<RecordBatchStream>(reader);
   }
 
   Status DoPutPreparedStatementQuery(const ServerCallContext& context,
@@ -571,7 +571,7 @@ class SQLiteFlightSqlServer::Impl {
                                       : DoGetTypeInfoResult();
 
     ARROW_ASSIGN_OR_RAISE(auto reader, RecordBatchReader::Make({type_info_result}));
-    return std::unique_ptr<FlightDataStream>(new RecordBatchStream(reader));
+    return std::make_unique<RecordBatchStream>(reader);
   }
 
   arrow::Result<std::unique_ptr<FlightInfo>> GetFlightInfoPrimaryKeys(

--- a/cpp/src/arrow/flight/sql/example/sqlite_server.cc
+++ b/cpp/src/arrow/flight/sql/example/sqlite_server.cc
@@ -416,8 +416,7 @@ class SQLiteFlightSqlServer::Impl {
     if (command.include_schema) {
       std::shared_ptr<SqliteTablesWithSchemaBatchReader> table_schema_reader =
           std::make_shared<SqliteTablesWithSchemaBatchReader>(reader, query, db_);
-      return std::unique_ptr<FlightDataStream>(
-          new RecordBatchStream(table_schema_reader));
+      return std::make_unique<RecordBatchStream>(table_schema_reader);
     } else {
       return std::make_unique<RecordBatchStream>(reader);
     }

--- a/cpp/src/arrow/flight/sql/server.cc
+++ b/cpp/src/arrow/flight/sql/server.cc
@@ -818,8 +818,7 @@ Status FlightSqlServerBase::DoAction(const ServerCallContext& context,
   } else {
     return Status::NotImplemented("Action not implemented: ", action.type);
   }
-  *result_stream =
-      std::unique_ptr<ResultStream>(new SimpleResultStream(std::move(results)));
+  *result_stream = std::make_unique<SimpleResultStream>(std::move(results));
   return Status::OK();
 }
 
@@ -894,7 +893,7 @@ arrow::Result<std::unique_ptr<FlightInfo>> FlightSqlServerBase::GetFlightInfoSql
   ARROW_ASSIGN_OR_RAISE(auto result, FlightInfo::Make(*SqlSchema::GetSqlInfoSchema(),
                                                       descriptor, endpoints, -1, -1))
 
-  return std::unique_ptr<FlightInfo>(new FlightInfo(result));
+  return std::make_unique<FlightInfo>(result);
 }
 
 arrow::Result<std::unique_ptr<FlightInfo>> FlightSqlServerBase::GetFlightInfoXdbcTypeInfo(
@@ -948,7 +947,7 @@ arrow::Result<std::unique_ptr<FlightDataStream>> FlightSqlServerBase::DoGetSqlIn
       RecordBatch::Make(SqlSchema::GetSqlInfoSchema(), row_count, {name, value});
   ARROW_ASSIGN_OR_RAISE(const auto reader, RecordBatchReader::Make({batch}));
 
-  return std::unique_ptr<FlightDataStream>(new RecordBatchStream(reader));
+  return std::make_unique<RecordBatchStream>(reader);
 }
 
 arrow::Result<std::unique_ptr<FlightInfo>> FlightSqlServerBase::GetFlightInfoSchemas(

--- a/cpp/src/arrow/flight/test_definitions.cc
+++ b/cpp/src/arrow/flight/test_definitions.cc
@@ -854,8 +854,8 @@ Status AppMetadataTestServer::DoGet(const ServerCallContext& context,
     RETURN_NOT_OK(ExampleIntBatches(&batches));
   }
   ARROW_ASSIGN_OR_RAISE(auto batch_reader, RecordBatchReader::Make(batches));
-  *data_stream = std::make_unique<FlightDataStream>(
-      NumberingStream(std::make_unique<RecordBatchStream>(batch_reader)));
+  *data_stream = std::make_unique<NumberingStream>(
+      std::make_unique<RecordBatchStream>(batch_reader));
   return Status::OK();
 }
 Status AppMetadataTestServer::DoPut(const ServerCallContext& context,

--- a/cpp/src/arrow/flight/test_definitions.cc
+++ b/cpp/src/arrow/flight/test_definitions.cc
@@ -854,8 +854,8 @@ Status AppMetadataTestServer::DoGet(const ServerCallContext& context,
     RETURN_NOT_OK(ExampleIntBatches(&batches));
   }
   ARROW_ASSIGN_OR_RAISE(auto batch_reader, RecordBatchReader::Make(batches));
-  *data_stream = std::unique_ptr<FlightDataStream>(new NumberingStream(
-      std::unique_ptr<FlightDataStream>(new RecordBatchStream(batch_reader))));
+  *data_stream = std::make_unique<FlightDataStream>(
+      NumberingStream(std::make_unique<RecordBatchStream>(batch_reader)));
   return Status::OK();
 }
 Status AppMetadataTestServer::DoPut(const ServerCallContext& context,
@@ -1011,7 +1011,7 @@ class IpcOptionsTestServer : public FlightServerBase {
     RecordBatchVector batches;
     RETURN_NOT_OK(ExampleNestedBatches(&batches));
     ARROW_ASSIGN_OR_RAISE(auto reader, RecordBatchReader::Make(batches));
-    *data_stream = std::unique_ptr<FlightDataStream>(new RecordBatchStream(reader));
+    *data_stream = std::make_unique<RecordBatchStream>(reader);
     return Status::OK();
   }
 
@@ -1200,7 +1200,7 @@ class CudaTestServer : public FlightServerBase {
                std::unique_ptr<FlightDataStream>* data_stream) override {
     RETURN_NOT_OK(ExampleIntBatches(&batches_));
     ARROW_ASSIGN_OR_RAISE(auto batch_reader, RecordBatchReader::Make(batches_));
-    *data_stream = std::unique_ptr<FlightDataStream>(new RecordBatchStream(batch_reader));
+    *data_stream = std::make_unique<RecordBatchStream>(batch_reader);
     return Status::OK();
   }
 

--- a/cpp/src/arrow/flight/test_util.cc
+++ b/cpp/src/arrow/flight/test_util.cc
@@ -507,7 +507,7 @@ class FlightTestServer : public FlightServerBase {
 };
 
 std::unique_ptr<FlightServerBase> ExampleTestServer() {
-  return std::make_unique<FlightServerBase>();
+  return std::make_unique<FlightTestServer>();
 }
 
 Status MakeFlightInfo(const Schema& schema, const FlightDescriptor& descriptor,

--- a/cpp/src/arrow/flight/test_util.cc
+++ b/cpp/src/arrow/flight/test_util.cc
@@ -205,7 +205,7 @@ class FlightTestServer : public FlightServerBase {
       // For test purposes, if we get criteria, return no results
       flights.clear();
     }
-    *listings = std::unique_ptr<FlightListing>(new SimpleFlightListing(flights));
+    *listings = std::make_unique<SimpleFlightListing>(flights);
     return Status::OK();
   }
 
@@ -221,7 +221,7 @@ class FlightTestServer : public FlightServerBase {
 
     for (const auto& info : flights) {
       if (info.descriptor().Equals(request)) {
-        *out = std::unique_ptr<FlightInfo>(new FlightInfo(info));
+        *out = std::make_unique<FlightInfo>(info);
         return Status::OK();
       }
     }
@@ -241,21 +241,19 @@ class FlightTestServer : public FlightServerBase {
       // Make batch > 2GiB in size
       ARROW_ASSIGN_OR_RAISE(auto batch, VeryLargeBatch());
       ARROW_ASSIGN_OR_RAISE(auto reader, RecordBatchReader::Make({batch}));
-      *data_stream =
-          std::unique_ptr<FlightDataStream>(new RecordBatchStream(std::move(reader)));
+      *data_stream = std::make_unique<RecordBatchStream>(std::move(reader));
       return Status::OK();
     }
     if (request.ticket == "ticket-stream-error") {
       auto reader = std::make_shared<ErrorRecordBatchReader>();
-      *data_stream =
-          std::unique_ptr<FlightDataStream>(new RecordBatchStream(std::move(reader)));
+      *data_stream = std::make_unique<RecordBatchStream>(std::move(reader));
       return Status::OK();
     }
 
     std::shared_ptr<RecordBatchReader> batch_reader;
     RETURN_NOT_OK(GetBatchForFlight(request, &batch_reader));
 
-    *data_stream = std::unique_ptr<FlightDataStream>(new RecordBatchStream(batch_reader));
+    *data_stream = std::make_unique<RecordBatchStream>(batch_reader);
     return Status::OK();
   }
 
@@ -466,13 +464,13 @@ class FlightTestServer : public FlightServerBase {
       result.body = Buffer::FromString(std::move(value));
       results.push_back(result);
     }
-    *out = std::unique_ptr<ResultStream>(new SimpleResultStream(std::move(results)));
+    *out = std::make_unique<SimpleResultStream>(std::move(results));
     return Status::OK();
   }
 
   Status RunAction2(std::unique_ptr<ResultStream>* out) {
     // Empty
-    *out = std::unique_ptr<ResultStream>(new SimpleResultStream({}));
+    *out = std::make_unique<SimpleResultStream>({});
     return Status::OK();
   }
 
@@ -500,8 +498,7 @@ class FlightTestServer : public FlightServerBase {
 
     for (const auto& info : flights) {
       if (info.descriptor().Equals(request)) {
-        *schema =
-            std::unique_ptr<SchemaResult>(new SchemaResult(info.serialized_schema()));
+        *schema = std::make_unique<SchemaResult>(info.serialized_schema());
         return Status::OK();
       }
     }

--- a/cpp/src/arrow/flight/test_util.cc
+++ b/cpp/src/arrow/flight/test_util.cc
@@ -470,7 +470,7 @@ class FlightTestServer : public FlightServerBase {
 
   Status RunAction2(std::unique_ptr<ResultStream>* out) {
     // Empty
-    *out = std::make_unique<SimpleResultStream>({});
+    *out = std::make_unique<SimpleResultStream>(std::vector<Result>{});
     return Status::OK();
   }
 
@@ -507,7 +507,7 @@ class FlightTestServer : public FlightServerBase {
 };
 
 std::unique_ptr<FlightServerBase> ExampleTestServer() {
-  return std::unique_ptr<FlightServerBase>(new FlightTestServer);
+  return std::make_unique<FlightServerBase>();
 }
 
 Status MakeFlightInfo(const Schema& schema, const FlightDescriptor& descriptor,

--- a/cpp/src/arrow/flight/transport/grpc/grpc_client.cc
+++ b/cpp/src/arrow/flight/transport/grpc/grpc_client.cc
@@ -502,7 +502,7 @@ constexpr char kDummyRootCert[] =
 class GrpcClientImpl : public internal::ClientTransport {
  public:
   static arrow::Result<std::unique_ptr<internal::ClientTransport>> Make() {
-    return std::unique_ptr<internal::ClientTransport>(new GrpcClientImpl());
+    return std::make_unique<GrpcClientImpl>();
   }
 
   Status Init(const FlightClientOptions& options, const Location& location,

--- a/cpp/src/arrow/flight/transport/grpc/grpc_client.cc
+++ b/cpp/src/arrow/flight/transport/grpc/grpc_client.cc
@@ -748,8 +748,7 @@ class GrpcClientImpl : public internal::ClientTransport {
     if (options.stop_token.IsStopRequested()) rpc.context.TryCancel();
     RETURN_NOT_OK(options.stop_token.Poll());
 
-    *results = std::unique_ptr<ResultStream>(
-        new SimpleResultStream(std::move(materialized_results)));
+    *results = std::make_unique<SimpleResultStream>(std::move(materialized_results));
     return FromGrpcStatus(stream->Finish(), &rpc.context);
   }
 
@@ -820,8 +819,7 @@ class GrpcClientImpl : public internal::ClientTransport {
     RETURN_NOT_OK(rpc->SetToken(auth_handler_.get()));
     std::shared_ptr<::grpc::ClientReader<pb::FlightData>> stream =
         stub_->DoGet(&rpc->context, pb_ticket);
-    *out = std::unique_ptr<internal::ClientDataStream>(
-        new GrpcClientGetStream(std::move(rpc), std::move(stream)));
+    *out = std::make_unique<GrpcClientGetStream>(std::move(rpc), std::move(stream));
     return Status::OK();
   }
 
@@ -832,8 +830,7 @@ class GrpcClientImpl : public internal::ClientTransport {
     auto rpc = std::make_shared<ClientRpc>(options);
     RETURN_NOT_OK(rpc->SetToken(auth_handler_.get()));
     std::shared_ptr<GrpcStream> stream = stub_->DoPut(&rpc->context);
-    *out = std::unique_ptr<internal::ClientDataStream>(
-        new GrpcClientPutStream(std::move(rpc), std::move(stream)));
+    *out = std::make_unique<GrpcClientPutStream>(std::move(rpc), std::move(stream));
     return Status::OK();
   }
 
@@ -844,8 +841,7 @@ class GrpcClientImpl : public internal::ClientTransport {
     auto rpc = std::make_shared<ClientRpc>(options);
     RETURN_NOT_OK(rpc->SetToken(auth_handler_.get()));
     std::shared_ptr<GrpcStream> stream = stub_->DoExchange(&rpc->context);
-    *out = std::unique_ptr<internal::ClientDataStream>(
-        new GrpcClientExchangeStream(std::move(rpc), std::move(stream)));
+    *out = std::make_unique<GrpcClientExchangeStream>(std::move(rpc), std::move(stream));
     return Status::OK();
   }
 

--- a/cpp/src/arrow/flight/transport/ucx/flight_transport_ucx_test.cc
+++ b/cpp/src/arrow/flight/transport/ucx/flight_transport_ucx_test.cc
@@ -246,7 +246,7 @@ class SimpleTestServer : public FlightServerBase {
     RecordBatchVector batches;
     RETURN_NOT_OK(ExampleIntBatches(&batches));
     auto batch_reader = std::make_shared<BatchIterator>(batches[0]->schema(), batches);
-    *data_stream = std::unique_ptr<FlightDataStream>(new RecordBatchStream(batch_reader));
+    *data_stream = std::make_unique<RecordBatchStream>(batch_reader);
     return Status::OK();
   }
 

--- a/cpp/src/arrow/flight/types.cc
+++ b/cpp/src/arrow/flight/types.cc
@@ -318,7 +318,7 @@ arrow::Result<std::unique_ptr<FlightInfo>> FlightInfo::Deserialize(
   }
   FlightInfo::Data data;
   RETURN_NOT_OK(internal::FromProto(pb_info, &data));
-  return std::unique_ptr<FlightInfo>(new FlightInfo(std::move(data)));
+  return std::make_unique<FlightInfo>(std::move(data));
 }
 
 Status FlightInfo::Deserialize(const std::string& serialized,
@@ -625,7 +625,7 @@ arrow::Result<std::unique_ptr<FlightInfo>> SimpleFlightListing::Next() {
   if (position_ >= static_cast<int>(flights_.size())) {
     return nullptr;
   }
-  return std::unique_ptr<FlightInfo>(new FlightInfo(std::move(flights_[position_++])));
+  return std::make_unique<FlightInfo>(std::move(flights_[position_++]));
 }
 
 SimpleResultStream::SimpleResultStream(std::vector<Result>&& results)
@@ -635,7 +635,7 @@ arrow::Result<std::unique_ptr<Result>> SimpleResultStream::Next() {
   if (position_ >= results_.size()) {
     return nullptr;
   }
-  return std::unique_ptr<Result>(new Result(std::move(results_[position_++])));
+  return std::make_unique<Result>(std::move(results_[position_++]));
 }
 
 bool BasicAuth::Equals(const BasicAuth& other) const {

--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -169,7 +169,7 @@ class CudaContext::Impl {
           "cuIpcGetMemHandle",
           cuIpcGetMemHandle(&cu_handle, reinterpret_cast<CUdeviceptr>(data)));
     }
-    return std::shared_ptr<CudaIpcMemHandle>(new CudaIpcMemHandle(size, &cu_handle));
+    return std::make_shared<CudaIpcMemHandle>(size, &cu_handle);
   }
 
   Status OpenIpcBuffer(const CudaIpcMemHandle& ipc_handle, uint8_t** out) {
@@ -247,14 +247,14 @@ std::shared_ptr<MemoryManager> CudaDevice::default_memory_manager() {
 
 Result<std::shared_ptr<CudaContext>> CudaDevice::GetContext() {
   // XXX should we cache a default context in CudaDevice instance?
-  auto context = std::shared_ptr<CudaContext>(new CudaContext());
+  auto context = std::make_shared<CudaContext>();
   auto self = checked_pointer_cast<CudaDevice>(shared_from_this());
   RETURN_NOT_OK(context->impl_->Init(self));
   return context;
 }
 
 Result<std::shared_ptr<CudaContext>> CudaDevice::GetSharedContext(void* handle) {
-  auto context = std::shared_ptr<CudaContext>(new CudaContext());
+  auto context = std::make_shared<CudaContext>();
   auto self = checked_pointer_cast<CudaDevice>(shared_from_this());
   RETURN_NOT_OK(context->impl_->InitShared(self, reinterpret_cast<CUcontext>(handle)));
   return context;
@@ -286,7 +286,7 @@ Result<std::shared_ptr<CudaDevice>> AsCudaDevice(const std::shared_ptr<Device>& 
 
 std::shared_ptr<CudaMemoryManager> CudaMemoryManager::Make(
     const std::shared_ptr<Device>& device) {
-  return std::shared_ptr<CudaMemoryManager>(new CudaMemoryManager(device));
+  return std::make_shared<CudaMemoryManager>(device);
 }
 
 std::shared_ptr<CudaDevice> CudaMemoryManager::cuda_device() const {
@@ -476,7 +476,7 @@ class CudaDeviceManager::Impl {
   Result<std::shared_ptr<CudaDevice>> MakeDevice(int device_number) {
     DeviceProperties props;
     RETURN_NOT_OK(props.Init(device_number));
-    return std::shared_ptr<CudaDevice>(new CudaDevice({std::move(props)}));
+    return std::make_shared<CudaDevice>({std::move(props)});
   }
 
  private:

--- a/cpp/src/arrow/gpu/cuda_memory.cc
+++ b/cpp/src/arrow/gpu/cuda_memory.cc
@@ -73,7 +73,7 @@ CudaIpcMemHandle::~CudaIpcMemHandle() {}
 
 Result<std::shared_ptr<CudaIpcMemHandle>> CudaIpcMemHandle::FromBuffer(
     const void* opaque_handle) {
-  return std::shared_ptr<CudaIpcMemHandle>(new CudaIpcMemHandle(opaque_handle));
+  return std::make_shared<CudaIpcMemHandle>(opaque_handle);
 }
 
 Result<std::shared_ptr<Buffer>> CudaIpcMemHandle::Serialize(MemoryPool* pool) const {

--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -434,7 +434,7 @@ class MemoryMappedFile::MemoryMap
 
   Status Open(const std::string& path, FileMode::type mode, const int64_t offset = 0,
               const int64_t length = -1) {
-    file_.reset(new OSFile());
+    file_ = std::make_unique<OSFile>();
 
     if (mode != FileMode::READ) {
       // Memory mapping has permission failures if PROT_READ not set

--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -1007,12 +1007,12 @@ class InputStreamMessageReader : public MessageReader, public MessageDecoderList
 };
 
 std::unique_ptr<MessageReader> MessageReader::Open(io::InputStream* stream) {
-  return std::unique_ptr<MessageReader>(new InputStreamMessageReader(stream));
+  return std::make_unique<InputStreamMessageReader>(stream);
 }
 
 std::unique_ptr<MessageReader> MessageReader::Open(
     const std::shared_ptr<io::InputStream>& owned_stream) {
-  return std::unique_ptr<MessageReader>(new InputStreamMessageReader(owned_stream));
+  return std::make_unique<InputStreamMessageReader>(owned_stream);
 }
 
 }  // namespace ipc

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -771,7 +771,7 @@ Result<std::unique_ptr<Message>> GetTensorMessage(const Tensor& tensor,
   std::shared_ptr<Buffer> metadata;
   ARROW_ASSIGN_OR_RAISE(metadata,
                         internal::WriteTensorMessage(*tensor_to_write, 0, options));
-  return std::unique_ptr<Message>(new Message(metadata, tensor_to_write->data()));
+  return std::make_unique<Message>(metadata, tensor_to_write->data());
 }
 
 namespace internal {

--- a/cpp/src/arrow/json/chunker.cc
+++ b/cpp/src/arrow/json/chunker.cc
@@ -177,7 +177,7 @@ std::unique_ptr<Chunker> MakeChunker(const ParseOptions& options) {
   } else {
     delimiter = MakeNewlineBoundaryFinder();
   }
-  return std::unique_ptr<Chunker>(new Chunker(std::move(delimiter)));
+  return std::make_unique<Chunker>(std::move(delimiter));
 }
 
 }  // namespace json

--- a/cpp/src/arrow/memory_pool.cc
+++ b/cpp/src/arrow/memory_pool.cc
@@ -878,7 +878,7 @@ class PoolBuffer final : public ResizableBuffer {
     } else {
       mm = CPUDevice::memory_manager(pool);
     }
-    return std::unique_ptr<PoolBuffer>(new PoolBuffer(std::move(mm), pool));
+    return std::make_unique<PoolBuffer>(std::move(mm), pool);
   }
 
  private:

--- a/cpp/src/arrow/stl_test.cc
+++ b/cpp/src/arrow/stl_test.cc
@@ -231,7 +231,7 @@ TEST(TestTableFromTupleVector, ListType) {
   using tuple_type = std::tuple<std::vector<int64_t>>;
 
   auto expected_schema =
-      std::shared_ptr<Schema>(new Schema({field("column1", list(int64()), false)}));
+      std::make_shared<Schema>(FieldVector{field("column1", list(int64()), false)});
   std::shared_ptr<Array> expected_array =
       ArrayFromJSON(list(int64()), "[[1, 1, 2, 34], [2, -4]]");
   std::shared_ptr<Table> expected_table = Table::Make(expected_schema, {expected_array});
@@ -455,7 +455,7 @@ TEST(TestTupleVectorFromTable, ListType) {
   compute::ExecContext ctx;
   compute::CastOptions cast_options;
   auto expected_schema =
-      std::shared_ptr<Schema>(new Schema({field("column1", list(int64()), false)}));
+      std::make_shared<Schema>(FieldVector{field("column1", list(int64()), false)});
   std::shared_ptr<Array> expected_array =
       ArrayFromJSON(list(int64()), "[[1, 1, 2, 34], [2, -4]]");
   std::shared_ptr<Table> table = Table::Make(expected_schema, {expected_array});
@@ -474,7 +474,7 @@ TEST(TestTupleVectorFromTable, CastingNeeded) {
   compute::ExecContext ctx;
   compute::CastOptions cast_options;
   auto expected_schema =
-      std::shared_ptr<Schema>(new Schema({field("column1", list(int16()), false)}));
+      std::make_shared<Schema>(FieldVector{field("column1", list(int16()), false)});
   std::shared_ptr<Array> expected_array =
       ArrayFromJSON(list(int16()), "[[1, 1, 2, 34], [2, -4]]");
   std::shared_ptr<Table> table = Table::Make(expected_schema, {expected_array});

--- a/cpp/src/arrow/table_builder_test.cc
+++ b/cpp/src/arrow/table_builder_test.cc
@@ -101,7 +101,7 @@ TEST_F(TestRecordBatchBuilder, Basics) {
 
   Int32Builder ex_b0;
   StringBuilder ex_b1;
-  ListBuilder ex_b2(pool_, std::unique_ptr<Int8Builder>(new Int8Builder(pool_)));
+  ListBuilder ex_b2(pool_, std::make_unique<Int8Builder>(pool_));
 
   AppendData(&ex_b0, &ex_b1, &ex_b2);
   ASSERT_OK(ex_b0.Finish(&a0));

--- a/cpp/src/arrow/table_test.cc
+++ b/cpp/src/arrow/table_test.cc
@@ -385,8 +385,8 @@ TEST_F(TestPromoteTableToSchema, FieldsReorderedAfterPromotion) {
 
 TEST_F(TestPromoteTableToSchema, PromoteNullTypeField) {
   const int length = 10;
-  auto metadata =
-      std::shared_ptr<KeyValueMetadata>(new KeyValueMetadata({"foo"}, {"bar"}));
+  auto metadata = std::make_shared<KeyValueMetadata>(std::vector<std::string>{"foo"},
+                                                     std::vector<std::string>{"bar"});
   auto table_with_null_column = MakeTableWithOneNullFilledColumn("field", null(), length)
                                     ->ReplaceSchemaMetadata(metadata);
   auto promoted_schema = schema({field("field", int32())});

--- a/cpp/src/arrow/table_test.cc
+++ b/cpp/src/arrow/table_test.cc
@@ -354,8 +354,8 @@ using TestPromoteTableToSchema = TestTable;
 
 TEST_F(TestPromoteTableToSchema, IdenticalSchema) {
   const int length = 10;
-  auto metadata =
-      std::shared_ptr<KeyValueMetadata>(new KeyValueMetadata({"foo"}, {"bar"}));
+  auto metadata = std::make_shared<KeyValueMetadata>(std::vector<std::string>{"foo"},
+                                                     std::vector<std::string>{"bar"});
   MakeExample1(length);
   std::shared_ptr<Table> table = Table::Make(schema_, arrays_);
 

--- a/cpp/src/arrow/util/async_util_test.cc
+++ b/cpp/src/arrow/util/async_util_test.cc
@@ -437,7 +437,7 @@ TEST(AsyncTaskScheduler, Priority) {
   constexpr int kNumConcurrentTasks = 8;
   std::unique_ptr<AsyncTaskScheduler::Throttle> throttle =
       AsyncTaskScheduler::MakeThrottle(kNumConcurrentTasks);
-  std::unique_ptr<AsyncTaskScheduler> task_group =
+  auto task_group =
       AsyncTaskScheduler::Make(throttle.get(), std::make_unique<PriorityQueue>());
 
   std::shared_ptr<GatingTask> gate = GatingTask::Make();

--- a/cpp/src/arrow/util/compression_brotli.cc
+++ b/cpp/src/arrow/util/compression_brotli.cc
@@ -237,7 +237,7 @@ class BrotliCodec : public Codec {
 }  // namespace
 
 std::unique_ptr<Codec> MakeBrotliCodec(int compression_level) {
-  return std::unique_ptr<Codec>(new BrotliCodec(compression_level));
+  return std::make_unique<BrotliCodec>(compression_level);
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/util/compression_bz2.cc
+++ b/cpp/src/arrow/util/compression_bz2.cc
@@ -279,7 +279,7 @@ class BZ2Codec : public Codec {
 }  // namespace
 
 std::unique_ptr<Codec> MakeBZ2Codec(int compression_level) {
-  return std::unique_ptr<Codec>(new BZ2Codec(compression_level));
+  return std::make_unique<BZ2Codec>(compression_level);
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/util/compression_lz4.cc
+++ b/cpp/src/arrow/util/compression_lz4.cc
@@ -529,15 +529,15 @@ class Lz4HadoopCodec : public Lz4Codec {
 }  // namespace
 
 std::unique_ptr<Codec> MakeLz4FrameCodec(int compression_level) {
-  return std::unique_ptr<Codec>(new Lz4FrameCodec(compression_level));
+  return std::make_unique<Lz4FrameCodec>(compression_level);
 }
 
 std::unique_ptr<Codec> MakeLz4HadoopRawCodec() {
-  return std::unique_ptr<Codec>(new Lz4HadoopCodec());
+  return std::make_unique<Lz4HadoopCodec>();
 }
 
 std::unique_ptr<Codec> MakeLz4RawCodec(int compression_level) {
-  return std::unique_ptr<Codec>(new Lz4Codec(compression_level));
+  return std::make_unique<Lz4Codec>(compression_level);
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/util/compression_snappy.cc
+++ b/cpp/src/arrow/util/compression_snappy.cc
@@ -93,9 +93,7 @@ class SnappyCodec : public Codec {
 
 }  // namespace
 
-std::unique_ptr<Codec> MakeSnappyCodec() {
-  return std::unique_ptr<Codec>(new SnappyCodec());
-}
+std::unique_ptr<Codec> MakeSnappyCodec() { return std::make_unique<SnappyCodec>(); }
 
 }  // namespace internal
 }  // namespace util

--- a/cpp/src/arrow/util/compression_zlib.cc
+++ b/cpp/src/arrow/util/compression_zlib.cc
@@ -499,7 +499,7 @@ class GZipCodec : public Codec {
 }  // namespace
 
 std::unique_ptr<Codec> MakeGZipCodec(int compression_level, GZipFormat::type format) {
-  return std::unique_ptr<Codec>(new GZipCodec(compression_level, format));
+  return std::make_unique<GZipCodec>(compression_level, format);
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/util/compression_zstd.cc
+++ b/cpp/src/arrow/util/compression_zstd.cc
@@ -241,7 +241,7 @@ class ZSTDCodec : public Codec {
 }  // namespace
 
 std::unique_ptr<Codec> MakeZSTDCodec(int compression_level) {
-  return std::unique_ptr<Codec>(new ZSTDCodec(compression_level));
+  return std::make_unique<ZSTDCodec>(compression_level);
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/util/future.cc
+++ b/cpp/src/arrow/util/future.cc
@@ -175,7 +175,7 @@ ConcreteFutureImpl* GetConcreteFuture(FutureImpl* future) {
 }  // namespace
 
 std::unique_ptr<FutureImpl> FutureImpl::Make() {
-  return std::unique_ptr<FutureImpl>(new ConcreteFutureImpl());
+  return std::make_unique<ConcreteFutureImpl>();
 }
 
 std::unique_ptr<FutureImpl> FutureImpl::MakeFinished(FutureState state) {

--- a/cpp/src/arrow/util/future_test.cc
+++ b/cpp/src/arrow/util/future_test.cc
@@ -529,7 +529,7 @@ TEST(FutureStressTest, DeleteAfterWait) {
   constexpr int kNumTasks = 100;
   for (int i = 0; i < kNumTasks; i++) {
     {
-      std::unique_ptr<Future<>> future = std::make_unique<Future<>>(Future<>::Make());
+      auto future = std::make_unique<Future<>>(Future<>::Make());
       std::thread t([&]() {
         SleepABit();
         future->MarkFinished();

--- a/cpp/src/gandiva/interval_holder.h
+++ b/cpp/src/gandiva/interval_holder.h
@@ -67,7 +67,7 @@ class GANDIVA_EXPORT IntervalHolder : public FunctionHolder {
   }
 
   static Status Make(int32_t suppress_errors, std::shared_ptr<INTERVAL_TYPE>* holder) {
-    auto lholder = std::shared_ptr<INTERVAL_TYPE>(new INTERVAL_TYPE(suppress_errors));
+    auto lholder = std::make_shared<INTERVAL_TYPE>(suppress_errors);
 
     *holder = lholder;
     return Status::OK();

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -2651,19 +2651,19 @@ std::unique_ptr<Encoder> MakeEncoder(Type::type type_num, Encoding::type encodin
   if (use_dictionary) {
     switch (type_num) {
       case Type::INT32:
-        return std::unique_ptr<Encoder>(new DictEncoderImpl<Int32Type>(descr, pool));
+        return std::make_unique<DictEncoderImpl<Int32Type>>(descr, pool);
       case Type::INT64:
-        return std::unique_ptr<Encoder>(new DictEncoderImpl<Int64Type>(descr, pool));
+        return std::make_unique<DictEncoderImpl<Int64Type>>(descr, pool);
       case Type::INT96:
-        return std::unique_ptr<Encoder>(new DictEncoderImpl<Int96Type>(descr, pool));
+        return std::make_unique<DictEncoderImpl<Int96Type>>(descr, pool);
       case Type::FLOAT:
-        return std::unique_ptr<Encoder>(new DictEncoderImpl<FloatType>(descr, pool));
+        return std::make_unique<DictEncoderImpl<FloatType>>(descr, pool);
       case Type::DOUBLE:
-        return std::unique_ptr<Encoder>(new DictEncoderImpl<DoubleType>(descr, pool));
+        return std::make_unique<DictEncoderImpl<DoubleType>>(descr, pool);
       case Type::BYTE_ARRAY:
-        return std::unique_ptr<Encoder>(new DictEncoderImpl<ByteArrayType>(descr, pool));
+        return std::make_unique<DictEncoderImpl<ByteArrayType>>(descr, pool);
       case Type::FIXED_LEN_BYTE_ARRAY:
-        return std::unique_ptr<Encoder>(new DictEncoderImpl<FLBAType>(descr, pool));
+        return std::make_unique<DictEncoderImpl<FLBAType>>(descr, pool);
       default:
         DCHECK(false) << "Encoder not implemented";
         break;
@@ -2671,21 +2671,21 @@ std::unique_ptr<Encoder> MakeEncoder(Type::type type_num, Encoding::type encodin
   } else if (encoding == Encoding::PLAIN) {
     switch (type_num) {
       case Type::BOOLEAN:
-        return std::unique_ptr<Encoder>(new PlainEncoder<BooleanType>(descr, pool));
+        return std::make_unique<PlainEncoder<BooleanType>>(descr, pool);
       case Type::INT32:
-        return std::unique_ptr<Encoder>(new PlainEncoder<Int32Type>(descr, pool));
+        return std::make_unique<PlainEncoder<Int32Type>>(descr, pool);
       case Type::INT64:
-        return std::unique_ptr<Encoder>(new PlainEncoder<Int64Type>(descr, pool));
+        return std::make_unique<PlainEncoder<Int64Type>>(descr, pool);
       case Type::INT96:
-        return std::unique_ptr<Encoder>(new PlainEncoder<Int96Type>(descr, pool));
+        return std::make_unique<PlainEncoder<Int96Type>>(descr, pool);
       case Type::FLOAT:
-        return std::unique_ptr<Encoder>(new PlainEncoder<FloatType>(descr, pool));
+        return std::make_unique<PlainEncoder<FloatType>>(descr, pool);
       case Type::DOUBLE:
-        return std::unique_ptr<Encoder>(new PlainEncoder<DoubleType>(descr, pool));
+        return std::make_unique<PlainEncoder<DoubleType>>(descr, pool);
       case Type::BYTE_ARRAY:
-        return std::unique_ptr<Encoder>(new PlainEncoder<ByteArrayType>(descr, pool));
+        return std::make_unique<PlainEncoder<ByteArrayType>>(descr, pool);
       case Type::FIXED_LEN_BYTE_ARRAY:
-        return std::unique_ptr<Encoder>(new PlainEncoder<FLBAType>(descr, pool));
+        return std::make_unique<PlainEncoder<FLBAType>>(descr, pool);
       default:
         DCHECK(false) << "Encoder not implemented";
         break;
@@ -2714,30 +2714,30 @@ std::unique_ptr<Decoder> MakeDecoder(Type::type type_num, Encoding::type encodin
   if (encoding == Encoding::PLAIN) {
     switch (type_num) {
       case Type::BOOLEAN:
-        return std::unique_ptr<Decoder>(new PlainBooleanDecoder(descr));
+        return std::make_unique<PlainBooleanDecoder>(descr);
       case Type::INT32:
-        return std::unique_ptr<Decoder>(new PlainDecoder<Int32Type>(descr));
+        return std::make_unique<PlainDecoder<Int32Type>>(descr);
       case Type::INT64:
-        return std::unique_ptr<Decoder>(new PlainDecoder<Int64Type>(descr));
+        return std::make_unique<PlainDecoder<Int64Type>>(descr);
       case Type::INT96:
-        return std::unique_ptr<Decoder>(new PlainDecoder<Int96Type>(descr));
+        return std::make_unique<PlainDecoder<Int96Type>>(descr);
       case Type::FLOAT:
-        return std::unique_ptr<Decoder>(new PlainDecoder<FloatType>(descr));
+        return std::make_unique<PlainDecoder<FloatType>>(descr);
       case Type::DOUBLE:
-        return std::unique_ptr<Decoder>(new PlainDecoder<DoubleType>(descr));
+        return std::make_unique<PlainDecoder<DoubleType>>(descr);
       case Type::BYTE_ARRAY:
-        return std::unique_ptr<Decoder>(new PlainByteArrayDecoder(descr));
+        return std::make_unique<PlainByteArrayDecoder>(descr);
       case Type::FIXED_LEN_BYTE_ARRAY:
-        return std::unique_ptr<Decoder>(new PlainFLBADecoder(descr));
+        return std::make_unique<PlainFLBADecoder>(descr);
       default:
         break;
     }
   } else if (encoding == Encoding::BYTE_STREAM_SPLIT) {
     switch (type_num) {
       case Type::FLOAT:
-        return std::unique_ptr<Decoder>(new ByteStreamSplitDecoder<FloatType>(descr));
+        return std::make_unique<ByteStreamSplitDecoder<FloatType>>(descr);
       case Type::DOUBLE:
-        return std::unique_ptr<Decoder>(new ByteStreamSplitDecoder<DoubleType>(descr));
+        return std::make_unique<ByteStreamSplitDecoder<DoubleType>>(descr);
       default:
         throw ParquetException("BYTE_STREAM_SPLIT only supports FLOAT and DOUBLE");
         break;
@@ -2745,21 +2745,21 @@ std::unique_ptr<Decoder> MakeDecoder(Type::type type_num, Encoding::type encodin
   } else if (encoding == Encoding::DELTA_BINARY_PACKED) {
     switch (type_num) {
       case Type::INT32:
-        return std::unique_ptr<Decoder>(new DeltaBitPackDecoder<Int32Type>(descr));
+        return std::make_unique<DeltaBitPackDecoder<Int32Type>>(descr);
       case Type::INT64:
-        return std::unique_ptr<Decoder>(new DeltaBitPackDecoder<Int64Type>(descr));
+        return std::make_unique<DeltaBitPackDecoder<Int64Type>>(descr);
       default:
         throw ParquetException("DELTA_BINARY_PACKED only supports INT32 and INT64");
         break;
     }
   } else if (encoding == Encoding::DELTA_BYTE_ARRAY) {
     if (type_num == Type::BYTE_ARRAY) {
-      return std::unique_ptr<Decoder>(new DeltaByteArrayDecoder(descr));
+      return std::make_unique<DeltaByteArrayDecoder>(descr);
     }
     throw ParquetException("DELTA_BYTE_ARRAY only supports BYTE_ARRAY");
   } else if (encoding == Encoding::DELTA_LENGTH_BYTE_ARRAY) {
     if (type_num == Type::BYTE_ARRAY) {
-      return std::unique_ptr<Decoder>(new DeltaLengthByteArrayDecoder(descr));
+      return std::make_unique<DeltaLengthByteArrayDecoder>(descr);
     }
     throw ParquetException("DELTA_LENGTH_BYTE_ARRAY only supports BYTE_ARRAY");
   } else {
@@ -2777,19 +2777,19 @@ std::unique_ptr<Decoder> MakeDictDecoder(Type::type type_num,
     case Type::BOOLEAN:
       ParquetException::NYI("Dictionary encoding not implemented for boolean type");
     case Type::INT32:
-      return std::unique_ptr<Decoder>(new DictDecoderImpl<Int32Type>(descr, pool));
+      return std::make_unique<DictDecoderImpl<Int32Type>>(descr, pool);
     case Type::INT64:
-      return std::unique_ptr<Decoder>(new DictDecoderImpl<Int64Type>(descr, pool));
+      return std::make_unique<DictDecoderImpl<Int64Type>>(descr, pool);
     case Type::INT96:
-      return std::unique_ptr<Decoder>(new DictDecoderImpl<Int96Type>(descr, pool));
+      return std::make_unique<DictDecoderImpl<Int96Type>>(descr, pool);
     case Type::FLOAT:
-      return std::unique_ptr<Decoder>(new DictDecoderImpl<FloatType>(descr, pool));
+      return std::make_unique<DictDecoderImpl<FloatType>>(descr, pool);
     case Type::DOUBLE:
-      return std::unique_ptr<Decoder>(new DictDecoderImpl<DoubleType>(descr, pool));
+      return std::make_unique<DictDecoderImpl<DoubleType>>(descr, pool);
     case Type::BYTE_ARRAY:
-      return std::unique_ptr<Decoder>(new DictByteArrayDecoderImpl(descr, pool));
+      return std::make_unique<DictByteArrayDecoderImpl>(descr, pool);
     case Type::FIXED_LEN_BYTE_ARRAY:
-      return std::unique_ptr<Decoder>(new DictDecoderImpl<FLBAType>(descr, pool));
+      return std::make_unique<DictDecoderImpl<FLBAType>>(descr, pool);
     default:
       break;
   }

--- a/cpp/src/parquet/encoding_benchmark.cc
+++ b/cpp/src/parquet/encoding_benchmark.cc
@@ -682,7 +682,7 @@ class BM_ArrowBinaryDict : public BenchmarkDecodeArrow {
   template <typename PutValuesFunc>
   void DoEncode(PutValuesFunc&& put_values) {
     auto node = schema::ByteArray("name");
-    descr_ = std::unique_ptr<ColumnDescriptor>(new ColumnDescriptor(node, 0, 0));
+    descr_ = std::make_unique<ColumnDescriptor>(node, 0, 0);
 
     auto encoder = MakeTypedEncoder<ByteArrayType>(Encoding::PLAIN,
                                                    /*use_dictionary=*/true, descr_.get());

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -448,7 +448,7 @@ class TestArrowBuilderDecoding : public ::testing::Test {
   }
 
   std::unique_ptr<DictBuilder> CreateDictBuilder() {
-    return std::unique_ptr<DictBuilder>(new DictBuilder(default_memory_pool()));
+    return std::make_unique<DictBuilder>(default_memory_pool());
   }
 
   // Setup encoder/decoder pair for testing with
@@ -931,7 +931,7 @@ class DictEncoding : public TestArrowBuilderDecoding {
  public:
   void SetupEncoderDecoder() override {
     auto node = schema::ByteArray("name");
-    descr_ = std::unique_ptr<ColumnDescriptor>(new ColumnDescriptor(node, 0, 0));
+    descr_ = std::make_unique<ColumnDescriptor>(node, 0, 0);
     encoder_ = MakeTypedEncoder<ByteArrayType>(Encoding::PLAIN, /*use_dictionary=*/true,
                                                descr_.get());
     if (null_count_ == 0) {

--- a/cpp/src/parquet/thrift_internal.h
+++ b/cpp/src/parquet/thrift_internal.h
@@ -401,7 +401,7 @@ class ThriftDeserializer {
     return std::shared_ptr<ThriftBuffer>(
         new ThriftBuffer(buf, len, ThriftBuffer::OBSERVE, conf));
 #else
-    return std::shared_ptr<ThriftBuffer>(new ThriftBuffer(buf, len));
+    return std::make_shared<ThriftBuffer>(buf, len);
 #endif
   }
 

--- a/cpp/src/plasma/client.cc
+++ b/cpp/src/plasma/client.cc
@@ -351,8 +351,7 @@ uint8_t* PlasmaClient::Impl::LookupOrMmap(int fd, int store_fd_val, int64_t map_
   if (entry != mmap_table_.end()) {
     return entry->second->pointer();
   } else {
-    mmap_table_[store_fd_val] =
-        std::unique_ptr<ClientMmapTableEntry>(new ClientMmapTableEntry(fd, map_size));
+    mmap_table_[store_fd_val] = std::make_unique<ClientMmapTableEntry>(fd, map_size);
     return mmap_table_[store_fd_val]->pointer();
   }
 }
@@ -392,8 +391,7 @@ void PlasmaClient::Impl::IncrementObjectCount(const ObjectID& object_id,
   if (elem == objects_in_use_.end()) {
     // Add this object ID to the hash table of object IDs in use. The
     // corresponding call to free happens in PlasmaClient::Release.
-    objects_in_use_[object_id] =
-        std::unique_ptr<ObjectInUseEntry>(new ObjectInUseEntry());
+    objects_in_use_[object_id] = std::make_unique<ObjectInUseEntry>();
     objects_in_use_[object_id]->object = *object;
     objects_in_use_[object_id]->count = 0;
     objects_in_use_[object_id]->is_sealed = is_sealed;

--- a/cpp/src/plasma/events.cc
+++ b/cpp/src/plasma/events.cc
@@ -51,7 +51,7 @@ bool EventLoop::AddFileEvent(int fd, int events, const FileCallback& callback) {
   if (file_callbacks_.find(fd) != file_callbacks_.end()) {
     return false;
   }
-  auto data = std::unique_ptr<FileCallback>(new FileCallback(callback));
+  auto data = std::make_unique<FileCallback>(callback);
   void* context = reinterpret_cast<void*>(data.get());
   // Try to add the file descriptor.
   int err = aeCreateFileEvent(loop_, fd, events, EventLoop::FileEventCallback, context);
@@ -90,7 +90,7 @@ void EventLoop::Shutdown() {
 EventLoop::~EventLoop() { Shutdown(); }
 
 int64_t EventLoop::AddTimer(int64_t timeout, const TimerCallback& callback) {
-  auto data = std::unique_ptr<TimerCallback>(new TimerCallback(callback));
+  auto data = std::make_unique<TimerCallback>(callback);
   void* context = reinterpret_cast<void*>(data.get());
   int64_t timer_id =
       aeCreateTimeEvent(loop_, timeout, EventLoop::TimerEventCallback, context, NULL);

--- a/cpp/src/plasma/protocol.cc
+++ b/cpp/src/plasma/protocol.cc
@@ -583,7 +583,7 @@ Status ReadListReply(const uint8_t* data, size_t size, ObjectTable* objects) {
   DCHECK(VerifyFlatbuffer(message, data, size));
   for (auto const object : *message->objects()) {
     ObjectID object_id = ObjectID::from_binary(object->object_id()->str());
-    auto entry = std::unique_ptr<ObjectTableEntry>(new ObjectTableEntry());
+    auto entry = std::make_unique<ObjectTableEntry>();
     entry->data_size = object->data_size();
     entry->metadata_size = object->metadata_size();
     entry->ref_count = object->ref_count();

--- a/cpp/src/plasma/quota_aware_policy.cc
+++ b/cpp/src/plasma/quota_aware_policy.cc
@@ -60,7 +60,7 @@ bool QuotaAwarePolicy::SetClientQuota(Client* client, int64_t output_memory_quot
   // those objects will be lazily evicted on the next call
   cache_.AdjustCapacity(-output_memory_quota);
   per_client_cache_[client] =
-      std::unique_ptr<LRUCache>(new LRUCache(client->name, output_memory_quota));
+      std::make_unique<LRUCache>(client->name, output_memory_quota);
   return true;
 }
 

--- a/cpp/src/plasma/store.cc
+++ b/cpp/src/plasma/store.cc
@@ -271,7 +271,7 @@ PlasmaError PlasmaStore::CreateObject(const ObjectID& object_id, bool evict_if_f
 #endif
   }
 
-  auto ptr = std::unique_ptr<ObjectTableEntry>(new ObjectTableEntry());
+  auto ptr = std::make_unique<ObjectTableEntry>();
   entry = store_info_.objects.emplace(object_id, std::move(ptr)).first->second.get();
   entry->data_size = data_size;
   entry->metadata_size = metadata_size;


### PR DESCRIPTION
Advantage: readabilty, exception safety and efficiency(only for shared_ptr).

Cases that don't apply: When calling a private/protected constructor within class member function, make_shared/unique can't work.