### PR TITLE
MINOR: [C++] Use the array returned by TweakValidityBit

### DIFF
--- a/cpp/src/arrow/compute/kernels/vector_nested_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_nested_test.cc
@@ -36,9 +36,9 @@ TEST(TestVectorNested, ListFlatten) {
     CheckVectorUnary("list_flatten", input, expected);
 
     // Construct a list with a non-empty null slot
-    TweakValidityBit(input, 0, false);
+    auto tweaked = TweakValidityBit(input, 0, false);
     expected = ArrayFromJSON(int16(), "[2, 3]");
-    CheckVectorUnary("list_flatten", input, expected);
+    CheckVectorUnary("list_flatten", tweaked, expected);
   }
 }
 
@@ -86,9 +86,9 @@ TEST(TestVectorNested, ListParentIndices) {
 
   // Construct a list with a non-empty null slot
   auto input = ArrayFromJSON(list(int16()), "[[0, null, 1], [0, 0], [2, 3], [], [4, 5]]");
-  TweakValidityBit(input, 1, false);
+  auto tweaked = TweakValidityBit(input, 1, false);
   auto expected = ArrayFromJSON(int64(), "[0, 0, 0, 1, 1, 2, 2, 4, 4]");
-  CheckVectorUnary("list_parent_indices", input, expected);
+  CheckVectorUnary("list_parent_indices", tweaked, expected);
 }
 
 TEST(TestVectorNested, ListParentIndicesChunkedArray) {

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -349,7 +349,7 @@ std::shared_ptr<Table> TableFromJSON(const std::shared_ptr<Schema>&,
 // This is useful to force the underlying "value" of null entries to otherwise
 // invalid data and check that errors don't get reported.
 ARROW_TESTING_EXPORT
-[[nodiscard]] std::shared_ptr<Array> TweakValidityBit(const std::shared_ptr<Array>& array,
+std::shared_ptr<Array> TweakValidityBit(const std::shared_ptr<Array>& array,
                                         int64_t index, bool validity);
 
 ARROW_TESTING_EXPORT

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -349,7 +349,7 @@ std::shared_ptr<Table> TableFromJSON(const std::shared_ptr<Schema>&,
 // This is useful to force the underlying "value" of null entries to otherwise
 // invalid data and check that errors don't get reported.
 ARROW_TESTING_EXPORT
-std::shared_ptr<Array> TweakValidityBit(const std::shared_ptr<Array>& array,
+[[nodiscard]] std::shared_ptr<Array> TweakValidityBit(const std::shared_ptr<Array>& array,
                                         int64_t index, bool validity);
 
 ARROW_TESTING_EXPORT


### PR DESCRIPTION
TweakValidityBit returns a new Array so the calling function should use it.
https://github.com/apache/arrow/blob/6cc37cf2d1ba72c46b64fbc7ac499bd0d7296d20/cpp/src/arrow/testing/gtest_util.cc#L568-L579