### PR TITLE
ARROW-17599: [C++] Change the way how arrow reads parquet buffered files

### DIFF
--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -1077,9 +1077,7 @@ class RowGroupGenerator {
       return ::arrow::AsyncGeneratorEnd<RecordBatchGenerator>();
     }
     index_++;
-    BEGIN_PARQUET_CATCH_EXCEPTIONS
     FillReadahead();
-    END_PARQUET_CATCH_EXCEPTIONS
     ReadRequest next = std::move(in_flight_reads_.front());
     DCHECK(!in_flight_reads_.empty());
     in_flight_reads_.pop();
@@ -1114,9 +1112,11 @@ class RowGroupGenerator {
     } else {
       auto ready = ::arrow::Future<>::MakeFinished();
       row_group_read = ready.Then([=]() -> ::arrow::Future<RecordBatchGenerator> {
+        BEGIN_PARQUET_CATCH_EXCEPTIONS
         reader->parquet_reader()->PreBuffer({row_group}, column_indices_,
                                             reader_properties_.io_context(),
                                             reader_properties_.cache_options());
+        END_PARQUET_CATCH_EXCEPTIONS
         auto wait_buffer =
             reader->parquet_reader()->WhenBuffered({row_group}, column_indices);
         wait_buffer.Wait();


### PR DESCRIPTION
Jira ticket: https://issues.apache.org/jira/browse/ARROW-17599
Given that the API of `ReadRangeCache::read` [is retaining the buffer handlers until the end of the file reader](https://issues.apache.org/jira/browse/ARROW-17599?focusedCommentId=17607252&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17607252), we need to change the way how the parquet reader reads buffered data, this is a potential solution [to avoid loading all the row groups in memory](https://issues.apache.org/jira/browse/ARROW-17590).
There are historical reasons for the current design of `ReadRangeCache::read`, this PR will not change that API, instead, this PR will change the way how we are using the pre buffering process for reading parquet files (there will be a similar PR later to change the behavior of the IPC reader as well)
Additionally, this PR will add:
- A unit test to for `ReadRangeCache::read` to make sure `ReadRangeCache` is retaining the memory.
- ~~Update the API doc for the `ReadRangeCache::read` to indicate that the buffer data is outliving until the end of the file reader's scope/life.~~
- A new unit test for the changes in `FileReaderImpl::GetRecordBatchGenerator`