### PR TITLE
ARROW-17830: [C++][Gandiva] Temporarily pin LLVM version on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,7 +49,8 @@ environment:
     ARCH: "64"
     ARROW_BUILD_FLIGHT: "ON"
     ARROW_BUILD_FLIGHT_SQL: "ON"
-    ARROW_BUILD_GANDIVA: "ON"
+    # ARROW-17830 Temporarily disable Gandiva on Appveyor due to a bug in Conda's packaging of LLVM.
+    ARROW_BUILD_GANDIVA: "OFF"
     ARROW_GCS: "ON"
     ARROW_S3: "ON"
     GENERATOR: Ninja

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,8 +49,7 @@ environment:
     ARCH: "64"
     ARROW_BUILD_FLIGHT: "ON"
     ARROW_BUILD_FLIGHT_SQL: "ON"
-    # ARROW-17830 Temporarily disable Gandiva on Appveyor due to a bug in Conda's packaging of LLVM.
-    ARROW_BUILD_GANDIVA: "OFF"
+    ARROW_BUILD_GANDIVA: "ON"
     ARROW_GCS: "ON"
     ARROW_S3: "ON"
     GENERATOR: Ninja

--- a/ci/conda_env_gandiva_win.txt
+++ b/ci/conda_env_gandiva_win.txt
@@ -15,5 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-clangdev
-llvmdev
+# ARROW-17830 Temporarily pin LLVM version on Appveyor due to a bug in Conda's packaging of LLVM 15.
+clangdev<15
+llvmdev<15


### PR DESCRIPTION
Temporarily pin LLVM version on Appveyor due to a bug in Conda's packaging of LLVM.