### PR TITLE
ARROW-17823: [C++] Revert std::make_shared change for CUDA

### DIFF
--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -169,7 +169,7 @@ class CudaContext::Impl {
           "cuIpcGetMemHandle",
           cuIpcGetMemHandle(&cu_handle, reinterpret_cast<CUdeviceptr>(data)));
     }
-    return std::make_shared<CudaIpcMemHandle>(size, &cu_handle);
+    return std::shared_ptr<CudaIpcMemHandle>(new CudaIpcMemHandle(size, &cu_handle));
   }
 
   Status OpenIpcBuffer(const CudaIpcMemHandle& ipc_handle, uint8_t** out) {
@@ -247,14 +247,14 @@ std::shared_ptr<MemoryManager> CudaDevice::default_memory_manager() {
 
 Result<std::shared_ptr<CudaContext>> CudaDevice::GetContext() {
   // XXX should we cache a default context in CudaDevice instance?
-  auto context = std::make_shared<CudaContext>();
+  auto context = std::shared_ptr<CudaContext>(new CudaContext());
   auto self = checked_pointer_cast<CudaDevice>(shared_from_this());
   RETURN_NOT_OK(context->impl_->Init(self));
   return context;
 }
 
 Result<std::shared_ptr<CudaContext>> CudaDevice::GetSharedContext(void* handle) {
-  auto context = std::make_shared<CudaContext>();
+  auto context = std::shared_ptr<CudaContext>(new CudaContext());
   auto self = checked_pointer_cast<CudaDevice>(shared_from_this());
   RETURN_NOT_OK(context->impl_->InitShared(self, reinterpret_cast<CUcontext>(handle)));
   return context;
@@ -286,7 +286,7 @@ Result<std::shared_ptr<CudaDevice>> AsCudaDevice(const std::shared_ptr<Device>& 
 
 std::shared_ptr<CudaMemoryManager> CudaMemoryManager::Make(
     const std::shared_ptr<Device>& device) {
-  return std::make_shared<CudaMemoryManager>(device);
+  return std::shared_ptr<CudaMemoryManager>(new CudaMemoryManager(device));
 }
 
 std::shared_ptr<CudaDevice> CudaMemoryManager::cuda_device() const {
@@ -476,7 +476,7 @@ class CudaDeviceManager::Impl {
   Result<std::shared_ptr<CudaDevice>> MakeDevice(int device_number) {
     DeviceProperties props;
     RETURN_NOT_OK(props.Init(device_number));
-    return std::make_shared<CudaDevice>({std::move(props)});
+    return std::shared_ptr<CudaDevice>(new CudaDevice({std::move(props)}));
   }
 
  private:

--- a/cpp/src/arrow/gpu/cuda_memory.cc
+++ b/cpp/src/arrow/gpu/cuda_memory.cc
@@ -73,7 +73,7 @@ CudaIpcMemHandle::~CudaIpcMemHandle() {}
 
 Result<std::shared_ptr<CudaIpcMemHandle>> CudaIpcMemHandle::FromBuffer(
     const void* opaque_handle) {
-  return std::make_shared<CudaIpcMemHandle>(opaque_handle);
+  return std::shared_ptr<CudaIpcMemHandle>(new CudaIpcMemHandle(opaque_handle));
 }
 
 Result<std::shared_ptr<Buffer>> CudaIpcMemHandle::Serialize(MemoryPool* pool) const {


### PR DESCRIPTION
This is a follow-up of #14216. We can't use std::make_shared for CUDA related classes because their constructors aren't public.