### PR TITLE
ARROW-17841: [C++][Gandiva] Minimize LLVM dependency targets

### DIFF
--- a/ci/conda_env_gandiva_win.txt
+++ b/ci/conda_env_gandiva_win.txt
@@ -15,5 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-clangdev
-llvmdev
+# ARROW-17830 Temporarily pin LLVM version on Appveyor due to a bug in Conda's packaging of LLVM 15.
+clangdev<15
+llvmdev<15

--- a/ci/conda_env_gandiva_win.txt
+++ b/ci/conda_env_gandiva_win.txt
@@ -15,6 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# ARROW-17830 Temporarily pin LLVM version on Appveyor due to a bug in Conda's packaging of LLVM 15.
-clangdev<15
-llvmdev<15
+clangdev
+llvmdev

--- a/cpp/cmake_modules/FindLLVMAlt.cmake
+++ b/cpp/cmake_modules/FindLLVMAlt.cmake
@@ -74,16 +74,7 @@ endif()
 
 if(LLVM_FOUND)
   # Find the libraries that correspond to the LLVM components
-  llvm_map_components_to_libnames(LLVM_LIBS
-                                  core
-                                  mcjit
-                                  native
-                                  ipo
-                                  bitreader
-                                  target
-                                  linker
-                                  analysis
-                                  debuginfodwarf)
+  llvm_map_components_to_libnames(LLVM_LIBS mcjit native ipo)
 
   find_program(LLVM_LINK_EXECUTABLE llvm-link HINTS ${LLVM_TOOLS_BINARY_DIR})
 


### PR DESCRIPTION
Some currently depended LLVM targets can be removed.