### PR TITLE
ARROW-17480: [Java] add setNull() to FieldVector interface

### DIFF
--- a/java/vector/src/main/codegen/templates/DenseUnionVector.java
+++ b/java/vector/src/main/codegen/templates/DenseUnionVector.java
@@ -940,4 +940,13 @@ public class DenseUnionVector extends AbstractContainerVector implements FieldVe
       }
     }
   }
+
+  /**
+   * Set the element at the given index to null. For DenseUnionVector, it is a no-op as nulls are not supported at the
+   * top level, and isNull() always returns false. Nullability is only handled at the level of individual child vectors.
+   *
+   * @param index position of element
+   */
+  @Override
+  public void setNull(int index) {}
 }

--- a/java/vector/src/main/codegen/templates/DenseUnionVector.java
+++ b/java/vector/src/main/codegen/templates/DenseUnionVector.java
@@ -950,6 +950,6 @@ public class DenseUnionVector extends AbstractContainerVector implements FieldVe
    */
   @Override
   public void setNull(int index) {
-    throw new UnsupportedOperationException("The method setNull() is not supported on DenseUnionVector.")
+    throw new UnsupportedOperationException("The method setNull() is not supported on DenseUnionVector.");
   }
 }

--- a/java/vector/src/main/codegen/templates/DenseUnionVector.java
+++ b/java/vector/src/main/codegen/templates/DenseUnionVector.java
@@ -942,11 +942,14 @@ public class DenseUnionVector extends AbstractContainerVector implements FieldVe
   }
 
   /**
-   * Set the element at the given index to null. For DenseUnionVector, it is a no-op as nulls are not supported at the
-   * top level, and isNull() always returns false. Nullability is only handled at the level of individual child vectors.
+   * Set the element at the given index to null. For DenseUnionVector, it throws an UnsupportedOperationException
+   * as nulls are not supported at the top level and isNull() always returns false.
    *
    * @param index position of element
+   * @throws UnsupportedOperationException whenever invoked
    */
   @Override
-  public void setNull(int index) {}
+  public void setNull(int index) {
+    throw new UnsupportedOperationException("The method setNull() is not supported on DenseUnionVector.")
+  }
 }

--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -851,4 +851,13 @@ public class UnionVector extends AbstractContainerVector implements FieldVector 
         }
       }
     }
+
+  /**
+   * Set the element at the given index to null. For DenseUnionVector, it is a no-op as nulls are not supported at the
+   * top level, and isNull() always returns false. Nullability is only handled at the level of individual child vectors.
+   *
+   * @param index position of element
+   */
+  @Override
+  public void setNull(int index) {}
 }

--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -853,11 +853,14 @@ public class UnionVector extends AbstractContainerVector implements FieldVector 
     }
 
   /**
-   * Set the element at the given index to null. For UnionVector, it is a no-op as nulls are not supported at the
-   * top level, and isNull() always returns false. Nullability is only handled at the level of individual child vectors.
+   * Set the element at the given index to null. For UnionVector, it throws an UnsupportedOperationException
+   * as nulls are not supported at the top level and isNull() always returns false.
    *
    * @param index position of element
+   * @throws UnsupportedOperationException whenever invoked
    */
   @Override
-  public void setNull(int index) {}
+  public void setNull(int index) {
+    throw new UnsupportedOperationException("The method setNull() is not supported on UnionVector.")
+  }
 }

--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -853,7 +853,7 @@ public class UnionVector extends AbstractContainerVector implements FieldVector 
     }
 
   /**
-   * Set the element at the given index to null. For DenseUnionVector, it is a no-op as nulls are not supported at the
+   * Set the element at the given index to null. For UnionVector, it is a no-op as nulls are not supported at the
    * top level, and isNull() always returns false. Nullability is only handled at the level of individual child vectors.
    *
    * @param index position of element

--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -861,6 +861,6 @@ public class UnionVector extends AbstractContainerVector implements FieldVector 
    */
   @Override
   public void setNull(int index) {
-    throw new UnsupportedOperationException("The method setNull() is not supported on UnionVector.")
+    throw new UnsupportedOperationException("The method setNull() is not supported on UnionVector.");
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/ExtensionTypeVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ExtensionTypeVector.java
@@ -195,6 +195,11 @@ public abstract class ExtensionTypeVector<T extends ValueVector & FieldVector> e
   }
 
   @Override
+  public void setNull(int index) {
+    underlyingVector.setNull(index);
+  }
+
+  @Override
   public void initializeChildrenFromFields(List<Field> children) {
     underlyingVector.initializeChildrenFromFields(children);
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/FieldVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/FieldVector.java
@@ -90,4 +90,11 @@ public interface FieldVector extends ValueVector {
    * @return buffer address
    */
   long getOffsetBufferAddress();
+
+  /**
+   * Sets the value at index to null.
+   *
+   * @param index the value to change
+   */
+  void setNull(int index);
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/FieldVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/FieldVector.java
@@ -92,7 +92,7 @@ public interface FieldVector extends ValueVector {
   long getOffsetBufferAddress();
 
   /**
-   * Sets the value at index to null.
+   * Set the element at the given index to null.
    *
    * @param index the value to change
    */

--- a/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
@@ -262,6 +262,15 @@ public class NullVector implements FieldVector {
     return this.valueCount;
   }
 
+
+  /**
+   * Set the element at the given index to null. In a NullVector, this is a no-op.
+   *
+   * @param index position of element
+   */
+  @Override
+  public void setNull(int index) {}
+
   @Override
   public boolean isNull(int index) {
     return true;


### PR DESCRIPTION
Implemented setNull for vector types where it was not supported (including the abstract ExtensionTypeVector class), and added it to the FieldVector interface.

The change makes it possible to call setNull() on arbitrary field vectors without casting. 