### PR TITLE
ARROW-17853: [Python][CI] Timeout in test_dataset.py::test_write_dataset_s3_put_only

### DIFF
--- a/cpp/src/arrow/dataset/dataset_writer.cc
+++ b/cpp/src/arrow/dataset/dataset_writer.cc
@@ -329,9 +329,9 @@ class DatasetWriterDirectoryQueue {
     };
     util::AsyncTaskScheduler* file_scheduler =
         scheduler_->MakeSubScheduler(std::move(file_finish_task), throttle_view);
-    if (init_task_) {
-      file_scheduler->AddSimpleTask(init_task_);
-      init_task_ = {};
+    if (init_future_.is_valid()) {
+      file_scheduler->AddSimpleTask(
+          [init_future = init_future_]() { return init_future; });
     }
     file_queue_view->Start(file_scheduler, filename);
     return file_queue_view;
@@ -343,21 +343,28 @@ class DatasetWriterDirectoryQueue {
     if (directory_.empty() || !write_options_.create_dir) {
       return;
     }
+    init_future_ = Future<>::Make();
     auto create_dir_cb = [this] {
-      return DeferNotOk(write_options_.filesystem->io_context().executor()->Submit(
-          [this]() { return write_options_.filesystem->CreateDir(directory_); }));
+      return DeferNotOk(
+          write_options_.filesystem->io_context().executor()->Submit([this]() {
+            ARROW_RETURN_NOT_OK(write_options_.filesystem->CreateDir(directory_));
+            init_future_.MarkFinished();
+            return Status::OK();
+          }));
     };
+    std::function<Future<>()> init_task;
     if (write_options_.existing_data_behavior ==
         ExistingDataBehavior::kDeleteMatchingPartitions) {
-      init_task_ = [this, create_dir_cb] {
+      init_task = [this, create_dir_cb] {
         return write_options_.filesystem
             ->DeleteDirContentsAsync(directory_,
                                      /*missing_dir_ok=*/true)
             .Then(create_dir_cb);
       };
     } else {
-      init_task_ = [create_dir_cb] { return create_dir_cb(); };
+      init_task = [create_dir_cb] { return create_dir_cb(); };
     }
+    scheduler_->AddSimpleTask(std::move(init_task));
   }
 
   static Result<std::unique_ptr<DatasetWriterDirectoryQueue>> Make(
@@ -388,7 +395,7 @@ class DatasetWriterDirectoryQueue {
   std::shared_ptr<Schema> schema_;
   const FileSystemDatasetWriteOptions& write_options_;
   DatasetWriterState* writer_state_;
-  std::function<Future<>()> init_task_;
+  Future<> init_future_;
   std::string current_filename_;
   DatasetWriterFileQueue* latest_open_file_ = nullptr;
   uint64_t rows_written_ = 0;

--- a/cpp/src/arrow/dataset/dataset_writer.cc
+++ b/cpp/src/arrow/dataset/dataset_writer.cc
@@ -323,7 +323,7 @@ class DatasetWriterDirectoryQueue {
         util::AsyncTaskScheduler::MakeThrottle(1);
     util::AsyncTaskScheduler::Throttle* throttle_view = throttle.get();
     auto file_finish_task = [self = this, file_queue = std::move(file_queue),
-                             throttle = std::move(throttle)]() {
+                             throttle = std::move(throttle)](Status) {
       self->writer_state_->open_files_throttle.Release(1);
       return Status::OK();
     };

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -484,7 +484,7 @@ class TeeNode : public compute::MapNode {
         util::AsyncTaskScheduler::MakeThrottle(1);
     util::AsyncTaskScheduler::Throttle* serial_throttle_view = serial_throttle.get();
     serial_scheduler_ = plan_->async_scheduler()->MakeSubScheduler(
-        [owned_throttle = std::move(serial_throttle)]() { return Status::OK(); },
+        [owned_throttle = std::move(serial_throttle)](Status) { return Status::OK(); },
         serial_throttle_view);
   }
 

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -519,7 +519,7 @@ class TeeNode : public compute::MapNode {
       MapNode::Finish(std::move(writer_finish_st));
       return;
     }
-    serial_scheduler_->End();
+    serial_scheduler_.reset();
     MapNode::Finish(Status::OK());
   }
 
@@ -581,7 +581,7 @@ class TeeNode : public compute::MapNode {
   // We use a serial scheduler to submit tasks to the dataset writer.  The dataset writer
   // only returns an unfinished future when it needs backpressure.  Using a serial
   // scheduler here ensures we pause while we wait for backpressure to clear
-  util::AsyncTaskScheduler* serial_scheduler_;
+  std::shared_ptr<util::AsyncTaskScheduler> serial_scheduler_;
   int32_t backpressure_counter_ = 0;
 };
 

--- a/cpp/src/arrow/dataset/scan_node.cc
+++ b/cpp/src/arrow/dataset/scan_node.cc
@@ -264,7 +264,7 @@ class ScanNode : public cp::ExecNode {
       ScanState* state_view = scan_state.get();
       // Finish callback keeps the scan state alive until all scan tasks done
       struct StateHolder {
-        Status operator()() { return Status::OK(); }
+        Status operator()(Status) { return Status::OK(); }
         std::unique_ptr<ScanState> scan_state;
       };
       util::AsyncTaskScheduler* frag_scheduler = scan_scheduler->MakeSubScheduler(
@@ -277,6 +277,9 @@ class ScanNode : public cp::ExecNode {
       frag_scheduler->End();
       // The "list fragments" task doesn't actually end until the fragments are
       // all scanned.  This allows us to enforce fragment readahead.
+      if (--node->list_tasks_ == 0) {
+        node->scan_scheduler_->End();
+      }
       return list_and_scan_node;
     }
 
@@ -313,8 +316,8 @@ class ScanNode : public cp::ExecNode {
     END_SPAN_ON_FUTURE_COMPLETION(span_, finished_);
     AsyncGenerator<std::shared_ptr<Fragment>> frag_gen =
         GetFragments(options_.dataset.get(), options_.filter);
-    util::AsyncTaskScheduler* scan_scheduler = plan_->async_scheduler()->MakeSubScheduler(
-        [this]() {
+    scan_scheduler_ = plan_->async_scheduler()->MakeSubScheduler(
+        [this](Status st) {
           outputs_[0]->InputFinished(this, num_batches_.load());
           finished_.MarkFinished();
           return Status::OK();
@@ -322,12 +325,15 @@ class ScanNode : public cp::ExecNode {
         fragments_throttle_.get());
     plan_->async_scheduler()->AddAsyncGenerator<std::shared_ptr<Fragment>>(
         std::move(frag_gen),
-        [this, scan_scheduler](const std::shared_ptr<Fragment>& fragment) {
-          scan_scheduler->AddTask(std::make_unique<ListFragmentTask>(this, fragment));
+        [this](const std::shared_ptr<Fragment>& fragment) {
+          list_tasks_++;
+          scan_scheduler_->AddTask(std::make_unique<ListFragmentTask>(this, fragment));
           return Status::OK();
         },
-        [scan_scheduler]() {
-          scan_scheduler->End();
+        [this](Status) {
+          if (--list_tasks_ == 0) {
+            scan_scheduler_->End();
+          }
           return Status::OK();
         });
     return Status::OK();
@@ -351,6 +357,11 @@ class ScanNode : public cp::ExecNode {
  private:
   ScanV2Options options_;
   std::atomic<int> num_batches_{0};
+  // TODO(ARROW-17509) list_tasks_, and scan_scheduler_ are just
+  // needed to figure out when to end scan_scheduler_.  In the future, we should not need
+  // to call end and these variables can go away.
+  std::atomic<int> list_tasks_{1};
+  util::AsyncTaskScheduler* scan_scheduler_;
   std::unique_ptr<util::AsyncTaskScheduler::Throttle> fragments_throttle_;
   std::unique_ptr<util::AsyncTaskScheduler::Throttle> batches_throttle_;
 };

--- a/cpp/src/arrow/util/async_generator_test.cc
+++ b/cpp/src/arrow/util/async_generator_test.cc
@@ -705,6 +705,7 @@ TEST_P(MergedGeneratorTestFixture, MergedLimitedSubscriptions) {
   AssertGeneratorExhausted(merged);
 }
 
+#ifndef ARROW_VALGRIND
 TEST_P(MergedGeneratorTestFixture, MergedStress) {
   constexpr int NGENERATORS = 10;
   constexpr int NITEMS = 10;
@@ -739,6 +740,7 @@ TEST_P(MergedGeneratorTestFixture, MergedParallelStress) {
     ASSERT_EQ(NITEMS * NGENERATORS, items.size());
   }
 }
+#endif
 
 TEST_P(MergedGeneratorTestFixture, MergedRecursion) {
   // Regression test for an edge case in MergedGenerator. Ensure if

--- a/cpp/src/arrow/util/async_util.cc
+++ b/cpp/src/arrow/util/async_util.cc
@@ -98,13 +98,53 @@ class FifoQueue : public AsyncTaskScheduler::Queue {
   std::list<std::unique_ptr<Task>> tasks_;
 };
 
+class AlreadyFailedScheduler : public AsyncTaskScheduler {
+ public:
+  explicit AlreadyFailedScheduler(Status failure_reason,
+                                  FnOnce<Status(Status)> finish_callback)
+      : failure_reason_(std::move(failure_reason)),
+        finish_callback_(std::move(finish_callback)) {}
+  bool AddTask(std::unique_ptr<Task> task) override { return false; }
+  void End() override {
+    std::ignore = std::move(finish_callback_)(failure_reason_);
+    self.reset();
+  }
+  Future<> OnFinished() const override {
+    DCHECK(false) << "You should not rely on sub-scheduler's OnFinished.  Use a "
+                     "finished callback when creating the sub-scheduler instead";
+    return Future<>::MakeFinished(Status::UnknownError("Unreachable code encountered"));
+  }
+  AsyncTaskScheduler* MakeSubScheduler(FnOnce<Status(Status)> finish_callback,
+                                       Throttle* throttle,
+                                       std::unique_ptr<Queue> queue) override {
+    return AlreadyFailedScheduler::Make(failure_reason_, std::move(finish_callback));
+  }
+  static AsyncTaskScheduler* Make(Status failure,
+                                  FnOnce<Status(Status)> finish_callback) {
+    DCHECK(!failure.ok());
+    std::unique_ptr<AlreadyFailedScheduler> instance =
+        std::make_unique<AlreadyFailedScheduler>(std::move(failure),
+                                                 std::move(finish_callback));
+    AsyncTaskScheduler* view = instance.get();
+    instance->self = std::move(instance);
+    return view;
+  }
+  // This is deleted when ended so there is no possible way for this to return true
+  bool IsEnded() override { return false; }
+
+ private:
+  Status failure_reason_;
+  FnOnce<Status(Status)> finish_callback_;
+  std::unique_ptr<AlreadyFailedScheduler> self;
+};
+
 class AsyncTaskSchedulerImpl : public AsyncTaskScheduler {
  public:
   using Task = AsyncTaskScheduler::Task;
   using Queue = AsyncTaskScheduler::Queue;
 
   AsyncTaskSchedulerImpl(AsyncTaskSchedulerImpl* parent, std::unique_ptr<Queue> queue,
-                         Throttle* throttle, FnOnce<Status()> finish_callback)
+                         Throttle* throttle, FnOnce<Status(Status)> finish_callback)
       : AsyncTaskScheduler(),
         queue_(std::move(queue)),
         throttle_(throttle),
@@ -127,6 +167,9 @@ class AsyncTaskSchedulerImpl : public AsyncTaskScheduler {
         AbortUnlocked(
             Status::UnknownError("AsyncTaskScheduler abandoned before completion"),
             std::move(lk));
+      }
+      if (state_ != State::kEnded) {
+        End();
       }
     }
     finished_.Wait();
@@ -172,16 +215,27 @@ class AsyncTaskSchedulerImpl : public AsyncTaskScheduler {
     return true;
   }
 
-  AsyncTaskScheduler* MakeSubScheduler(FnOnce<Status()> finish_callback,
+  bool IsEnded() override {
+    std::lock_guard lk(mutex_);
+    return state_ == State::kEnded;
+  }
+
+  AsyncTaskScheduler* MakeSubScheduler(FnOnce<Status(Status)> finish_callback,
                                        Throttle* throttle,
                                        std::unique_ptr<Queue> queue) override {
-    std::unique_ptr<AsyncTaskSchedulerImpl> owned_child =
-        std::make_unique<AsyncTaskSchedulerImpl>(this, std::move(queue), throttle,
-                                                 std::move(finish_callback));
-    AsyncTaskScheduler* child = owned_child.get();
+    AsyncTaskScheduler* child;
     std::list<std::unique_ptr<AsyncTaskSchedulerImpl>>::iterator child_itr;
     {
       std::lock_guard<std::mutex> lk(mutex_);
+      DCHECK_NE(state_, State::kEnded)
+          << "Attempt to create a sub-scheduler on an ended parent.";
+      if (state_ != State::kRunning) {
+        return AlreadyFailedScheduler::Make(maybe_error_, std::move(finish_callback));
+      }
+      std::unique_ptr<AsyncTaskSchedulerImpl> owned_child =
+          std::make_unique<AsyncTaskSchedulerImpl>(this, std::move(queue), throttle,
+                                                   std::move(finish_callback));
+      child = owned_child.get();
       running_tasks_++;
       sub_schedulers_.push_back(std::move(owned_child));
       child_itr = --sub_schedulers_.end();
@@ -190,22 +244,17 @@ class AsyncTaskSchedulerImpl : public AsyncTaskScheduler {
     struct Finalizer {
       void operator()(const Status& st) {
         std::unique_lock<std::mutex> lk(self->mutex_);
-        FnOnce<Status()> finish_callback;
-        if (!st.ok()) {
-          self->running_tasks_--;
-          self->AbortUnlocked(st, std::move(lk));
-          return;
-        } else {
-          // We only eagerly erase the sub-scheduler on a successful completion.  This is
-          // because, if the sub-scheduler aborted, then the caller of MakeSubScheduler
-          // might still be planning to call End
-          finish_callback = std::move((*child_itr)->finish_callback_);
-          self->sub_schedulers_.erase(child_itr);
-        }
+        FnOnce<Status(Status)> finish_callback =
+            std::move((*child_itr)->finish_callback_);
+        self->sub_schedulers_.erase(child_itr);
         lk.unlock();
-        Status finish_st = std::move(finish_callback)();
+        Status finish_st = std::move(finish_callback)(st);
         lk.lock();
         self->running_tasks_--;
+        if (!st.ok()) {
+          self->AbortUnlocked(st, std::move(lk));
+          return;
+        }
         if (!finish_st.ok()) {
           self->AbortUnlocked(finish_st, std::move(lk));
           return;
@@ -226,9 +275,6 @@ class AsyncTaskSchedulerImpl : public AsyncTaskScheduler {
 
   void End() override {
     std::unique_lock<std::mutex> lk(mutex_);
-    if (state_ == State::kAborted) {
-      return;
-    }
     state_ = State::kEnded;
     if (running_tasks_ == 0 && (!queue_ || queue_->Empty())) {
       lk.unlock();
@@ -267,8 +313,7 @@ class AsyncTaskSchedulerImpl : public AsyncTaskScheduler {
   }
 
   bool IsFullyFinished() {
-    return state_ != State::kRunning && (!queue_ || queue_->Empty()) &&
-           running_tasks_ == 0;
+    return state_ == State::kEnded && (!queue_ || queue_->Empty()) && running_tasks_ == 0;
   }
 
   bool OnTaskFinished(const Status& st, int task_cost) {
@@ -307,8 +352,8 @@ class AsyncTaskSchedulerImpl : public AsyncTaskScheduler {
     }
     Result<Future<>> submit_result = (*task)(this);
     if (!submit_result.ok()) {
-      global_abort_->store(true);
       std::unique_lock<std::mutex> lk(mutex_);
+      global_abort_->store(true);
       running_tasks_--;
       AbortUnlocked(submit_result.status(), std::move(lk));
       return false;
@@ -337,9 +382,11 @@ class AsyncTaskSchedulerImpl : public AsyncTaskScheduler {
         maybe_error_ = st;
       }
     }
-    if (running_tasks_ == 0) {
+    if (running_tasks_ == 0 && state_ == State::kEnded) {
       lk.unlock();
-      finished_.MarkFinished(std::move(maybe_error_));
+      finished_.MarkFinished(maybe_error_);
+    } else {
+      lk.unlock();
     }
   }
 
@@ -353,7 +400,7 @@ class AsyncTaskSchedulerImpl : public AsyncTaskScheduler {
 
   std::unique_ptr<Queue> queue_;
   Throttle* throttle_;
-  FnOnce<Status()> finish_callback_;
+  FnOnce<Status(Status)> finish_callback_;
 
   Future<> finished_ = Future<>::Make();
   int running_tasks_ = 0;
@@ -375,7 +422,7 @@ class AsyncTaskSchedulerImpl : public AsyncTaskScheduler {
 std::unique_ptr<AsyncTaskScheduler> AsyncTaskScheduler::Make(
     Throttle* throttle, std::unique_ptr<Queue> queue) {
   return std::make_unique<AsyncTaskSchedulerImpl>(nullptr, std::move(queue), throttle,
-                                                  FnOnce<Status()>());
+                                                  FnOnce<Status(Status)>());
 }
 
 }  // namespace util

--- a/cpp/src/arrow/util/async_util.cc
+++ b/cpp/src/arrow/util/async_util.cc
@@ -110,9 +110,10 @@ class AlreadyFailedScheduler : public AsyncTaskScheduler {
     self.reset();
   }
   Future<> OnFinished() const override {
-    DCHECK(false) << "You should not rely on sub-scheduler's OnFinished.  Use a "
-                     "finished callback when creating the sub-scheduler instead";
-    return Future<>::MakeFinished(Status::UnknownError("Unreachable code encountered"));
+    Status::UnknownError(
+        "You should not rely on sub-scheduler's OnFinished.  Use a "
+        "finished callback when creating the sub-scheduler instead")
+        .Abort();
   }
   AsyncTaskScheduler* MakeSubScheduler(FnOnce<Status(Status)> finish_callback,
                                        Throttle* throttle,

--- a/cpp/src/arrow/util/async_util.h
+++ b/cpp/src/arrow/util/async_util.h
@@ -223,7 +223,7 @@ class ARROW_EXPORT AsyncTaskScheduler {
       explicit SubmitTask(std::unique_ptr<State> state_holder)
           : state_holder(std::move(state_holder)) {}
       struct SubmitTaskCallback {
-        SubmitTaskCallback(std::unique_ptr<State> state_holder)
+        explicit SubmitTaskCallback(std::unique_ptr<State> state_holder)
             : state_holder(std::move(state_holder)) {}
         Status operator()(const T& item) {
           if (IsIterationEnd(item)) {

--- a/cpp/src/arrow/util/async_util.h
+++ b/cpp/src/arrow/util/async_util.h
@@ -307,6 +307,11 @@ class ARROW_EXPORT AsyncTaskScheduler {
   static std::unique_ptr<AsyncTaskScheduler> Make(Throttle* throttle = NULLPTR,
                                                   std::unique_ptr<Queue> queue = NULLPTR);
 
+  /// Check to see if the scheduler is currently ended
+  ///
+  /// This method is primarily for testing purposes and won't normally need to be
+  /// called to use the scheduler.  Note that a return value of false is not conclusive as
+  /// the scheudler may end immediately after the call.
   virtual bool IsEnded() = 0;
 };
 

--- a/cpp/src/arrow/util/async_util.h
+++ b/cpp/src/arrow/util/async_util.h
@@ -311,7 +311,7 @@ class ARROW_EXPORT AsyncTaskScheduler {
   ///
   /// This method is primarily for testing purposes and won't normally need to be
   /// called to use the scheduler.  Note that a return value of false is not conclusive as
-  /// the scheudler may end immediately after the call.
+  /// the scheduler may end immediately after the call.
   virtual bool IsEnded() = 0;
 };
 

--- a/cpp/src/arrow/util/async_util_test.cc
+++ b/cpp/src/arrow/util/async_util_test.cc
@@ -160,7 +160,7 @@ FnOnce<Status(Status)> EmptyFinishCallback() {
 
 #ifndef ARROW_VALGRIND
 TEST(AsyncTaskScheduler, FailingTaskStress) {
-  // Test many tasks failling at the same time
+  // Test many tasks failing at the same time
   constexpr int kNumTasks = 256;
   for (int i = 0; i < kNumTasks; i++) {
     std::unique_ptr<AsyncTaskScheduler> scheduler = AsyncTaskScheduler::Make();

--- a/cpp/src/arrow/util/async_util_test.cc
+++ b/cpp/src/arrow/util/async_util_test.cc
@@ -158,6 +158,7 @@ FnOnce<Status(Status)> EmptyFinishCallback() {
   return [](Status) { return Status::OK(); };
 }
 
+#ifndef ARROW_VALGRIND
 TEST(AsyncTaskScheduler, FailingTaskStress) {
   // Test many tasks failling at the same time
   constexpr int kNumTasks = 256;
@@ -201,6 +202,7 @@ TEST(AsyncTaskScheduler, FailingTaskStress) {
     ASSERT_FINISHES_AND_RAISES(Invalid, scheduler->OnFinished());
   }
 }
+#endif
 
 TEST(AsyncTaskScheduler, SubSchedulerFinishCallback) {
   bool finish_callback_ran = false;
@@ -457,6 +459,7 @@ TEST(AsyncTaskScheduler, PurgeUnsubmitted) {
   ASSERT_FALSE(was_submitted);
 }
 
+#ifndef ARROW_VALGRIND
 TEST(AsyncTaskScheduler, FifoStress) {
   // Regresses an issue where adding a task, when the throttle was
   // just cleared, could lead to the added task being run immediately,
@@ -546,6 +549,7 @@ TEST(AsyncTaskScheduler, ScanningStress) {
     ASSERT_EQ(kExpectedBatchesScanned, batches_scanned.load());
   }
 }
+#endif
 
 class TaskWithPriority : public AsyncTaskScheduler::Task {
  public:


### PR DESCRIPTION
This reintroduces the dataset writer change with a fix that should prevent the deadlock.  The python test was unique in that the "create directory" step failed.  My change had made the files writers wait on this step and, if it failed, they were not being properly notified.