### PR TITLE
MINOR: [CI] Use secrets for bucket name in preview-docs job

### DIFF
--- a/dev/tasks/docs/github.linux.yml
+++ b/dev/tasks/docs/github.linux.yml
@@ -51,11 +51,13 @@ jobs:
           # These are only used while generating the page
           rm -rf build/docs/.doctrees
       - name: Upload preview to S3
-        env: 
-          AWS_ACCESS_KEY_ID: {{ '${{ secrets.CROSSBOW_DOCS_AWS_ACCESS_KEY_ID }}' }}
-          AWS_SECRET_ACCESS_KEY: {{ '${{ secrets.CROSSBOW_DOCS_AWS_SECRET_ACCESS_KEY }}' }}
-          AWS_DEFAULT_REGION: us-east-2
-          BUCKET: s3://voltrondata-labs-crossbow-docs
+        env:
+          {%- raw %}
+          AWS_ACCESS_KEY_ID: ${{ secrets.CROSSBOW_DOCS_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CROSSBOW_DOCS_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.CROSSBOW_DOCS_S3_BUCKET_REGION }} 
+          BUCKET: ${{ secrets.CROSSBOW_DOCS_S3_BUCKET }}
+          {% endraw %}
         run: |
           aws s3 cp build/docs/ $BUCKET/pr_docs/{{ pr_number }}/ --recursive
           echo ":open_book: You can find the preview here: https://crossbow.voltrondata.com/pr_docs/{{ pr_number }}" >> $GITHUB_STEP_SUMMARY

--- a/dev/tasks/docs/github.linux.yml
+++ b/dev/tasks/docs/github.linux.yml
@@ -60,4 +60,4 @@ jobs:
           {% endraw %}
         run: |
           aws s3 cp build/docs/ $BUCKET/pr_docs/{{ pr_number }}/ --recursive
-          echo ":open_book: You can find the preview here: https://crossbow.voltrondata.com/pr_docs/{{ pr_number }}" >> $GITHUB_STEP_SUMMARY
+          echo ":open_book: You can find the preview here: http://crossbow.voltrondata.com/pr_docs/{{ pr_number }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
For technical reasons we have to change the s3 bucket, to avoid having to make changes to the workflow in the future I have changed the envvar so they use secrets.

SSL on bucket hosted static sites is non-trivial and not really necessary (it's a static site after all). 

Here a render with the changes:
```yml
      - name: Upload preview to S3
        env:
          AWS_ACCESS_KEY_ID: ${{ secrets.CROSSBOW_DOCS_AWS_ACCESS_KEY_ID }}
          AWS_SECRET_ACCESS_KEY: ${{ secrets.CROSSBOW_DOCS_AWS_SECRET_ACCESS_KEY }}
          AWS_DEFAULT_REGION: ${{ secrets.CROSSBOW_DOCS_S3_BUCKET_REGION }} 
          BUCKET: ${{ secrets.CROSSBOW_DOCS_S3_BUCKET }}
        run: |
          aws s3 cp build/docs/ $BUCKET/pr_docs/master/ --recursive
          echo ":open_book: You can find the preview here: http://crossbow.voltrondata.com/pr_docs/master" >> $GITHUB_STEP_SUMMARY
```
