### PR TITLE
ARROW-17697: [Python] Fix Cython warning in types.pxi

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -589,6 +589,9 @@ if(PYARROW_GENERATE_COVERAGE)
   set(CYTHON_FLAGS "${CYTHON_FLAGS}" "-Xlinetrace=True")
 endif()
 
+# Error on any warnings not already explicitly ignored.
+set(CYTHON_FLAGS "${CYTHON_FLAGS}" "--warning-errors")
+
 foreach(module ${CYTHON_EXTENSIONS})
   string(REPLACE "." ";" directories ${module})
   list(GET directories -1 module_name)

--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -71,7 +71,7 @@ cdef class DataType(_Weakrefable):
         bytes pep3118_format
 
     cdef void init(self, const shared_ptr[CDataType]& type) except *
-    cdef Field field(self, int i)
+    cpdef Field field(self, i)
 
 
 cdef class ListType(DataType):

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -141,7 +141,9 @@ cdef class DataType(_Weakrefable):
         self.type = type.get()
         self.pep3118_format = _datatype_to_pep3118(self.type)
 
-    cdef Field field(self, int i):
+    cpdef Field field(self, i):
+        if not isinstance(i, int):
+            raise TypeError(f"Expected int index, got type '{type(i)}'")
         cdef int index = <int> _normalize_index(i, self.type.num_fields())
         return pyarrow_wrap_field(self.type.field(index))
 
@@ -505,7 +507,7 @@ cdef class StructType(DataType):
         """
         return self.struct_type.GetFieldIndex(tobytes(name))
 
-    def field(self, i):
+    cpdef Field field(self, i):
         """
         Select a field by its column name or numeric index.
 
@@ -622,7 +624,7 @@ cdef class UnionType(DataType):
         for i in range(len(self)):
             yield self[i]
 
-    def field(self, i):
+    cpdef Field field(self, i):
         """
         Return a child field by its numeric index.
 


### PR DESCRIPTION
Will fix [ARROW-17697](https://issues.apache.org/jira/browse/ARROW-17697)

- Turn warnings into errors 
- Change signature of DataType.field as others like `StructType.field` allowed taking `int` or `str`.