### PR TITLE
ARROW-17888: [Docs] Add reference of the cookbook contrib page to New Contributor's Guide

### DIFF
--- a/docs/source/developers/guide/index.rst
+++ b/docs/source/developers/guide/index.rst
@@ -147,11 +147,23 @@ of adding a basic feature.
 If you are ready you can start with building Arrow or choose to follow
 one of the :ref:`tutorial-index` on writing an R binding or Python feature.
 
-You can also take a look at the :ref:`documentation` or
-:ref:`other-resources` section.
+Different ways to contribute
+============================
+
+There are lots of ways to contribute to the project besides writing code!
+
+* Improving the **documentation** is a great way to start contributing!
+  For more information visit :ref:`documentation` section of the guide.
+
+* **Apache Arrow Cookbooks** are a collection of recipes presenting different
+  functionalities of Apache Arrow project. They are also a great way to start
+  contributing. For more information visit
+  `How to contribute to Apache Arrow Cookbook <https://github.com/apache/arrow-cookbook/blob/main/CONTRIBUTING.md>`_
+  located in the Apache Arrow Cookbook repository.
+
+You can also welcome take a look at :ref:`other-resources` section.
 
 **We want to encourage everyone to contribute to Arrow!**
-
 
 Full Table of Contents
 ======================

--- a/docs/source/developers/guide/index.rst
+++ b/docs/source/developers/guide/index.rst
@@ -161,7 +161,7 @@ and completing different tasks using Apache Arrow. They are also a great way to 
   `How to contribute to Apache Arrow Cookbook <https://github.com/apache/arrow-cookbook/blob/main/CONTRIBUTING.md>`_
   located in the Apache Arrow Cookbook repository.
 
-You can also welcome take a look at :ref:`other-resources` section.
+You are also welcome to take a look at :ref:`other-resources` section.
 
 **We want to encourage everyone to contribute to Arrow!**
 

--- a/docs/source/developers/guide/index.rst
+++ b/docs/source/developers/guide/index.rst
@@ -155,8 +155,8 @@ There are lots of ways to contribute to the project besides writing code!
 * Improving the **documentation** is a great way to start contributing!
   For more information visit :ref:`documentation` section of the guide.
 
-* **Apache Arrow Cookbooks** are a collection of recipes presenting different
-  functionalities of Apache Arrow project. They are also a great way to start
+* **Apache Arrow Cookbooks** are a collection of recipes for solving various problems 
+and completing different tasks using Apache Arrow. They are also a great way to start
   contributing. For more information visit
   `How to contribute to Apache Arrow Cookbook <https://github.com/apache/arrow-cookbook/blob/main/CONTRIBUTING.md>`_
   located in the Apache Arrow Cookbook repository.


### PR DESCRIPTION
This PR adds a reference for Apache Arrow Cookbook contributing info page to the New Contributor's Guide.

![Screenshot 2022-09-30 at 15 27 21](https://user-images.githubusercontent.com/16418547/193280252-9974705d-20f0-4833-bfa2-11c2ef4ed87d.png)
