### PR TITLE
ARROW-17351: [C++][Compute] Implement a parser for Expressions

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -402,6 +402,7 @@ if(ARROW_COMPUTE)
        compute/exec/order_by_impl.cc
        compute/exec/partition_util.cc
        compute/exec/options.cc
+       compute/exec/parsing.cc
        compute/exec/project_node.cc
        compute/exec/query_context.cc
        compute/exec/sink_node.cc

--- a/cpp/src/arrow/compute/exec/expression.h
+++ b/cpp/src/arrow/compute/exec/expression.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <string_view>
 #include <memory>
 #include <string>
 #include <utility>
@@ -127,6 +128,8 @@ class ARROW_EXPORT Expression {
   explicit Expression(Call call);
   explicit Expression(Datum literal);
   explicit Expression(Parameter parameter);
+
+  static Result<Expression> FromString(std::string_view expr);
 
  private:
   using Impl = std::variant<Datum, Parameter, Call>;

--- a/cpp/src/arrow/compute/exec/expression.h
+++ b/cpp/src/arrow/compute/exec/expression.h
@@ -19,9 +19,9 @@
 
 #pragma once
 
-#include <string_view>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <variant>
 #include <vector>

--- a/cpp/src/arrow/compute/exec/expression.h
+++ b/cpp/src/arrow/compute/exec/expression.h
@@ -129,6 +129,20 @@ class ARROW_EXPORT Expression {
   explicit Expression(Datum literal);
   explicit Expression(Parameter parameter);
 
+  /*
+    Grammar:
+    Expr -> FieldRef | Literal | Call
+
+    FieldRef -> Field | Field FieldRef
+    Field -> . Name | [ Number ]
+
+    Literal -> $ TypeName : Value
+
+    Call -> Name ( ExprList )
+    ExprList -> Expr | Expr , ExprList
+
+    Name, TypeName, Value, and Number take the obvious values
+   */
   static Result<Expression> FromString(std::string_view expr);
 
  private:

--- a/cpp/src/arrow/compute/exec/expression_test.cc
+++ b/cpp/src/arrow/compute/exec/expression_test.cc
@@ -1564,7 +1564,7 @@ TEST(Expression, SerializationRoundTrips) {
 }
 
 TEST(Expression, ParseBasic) {
-  const char* expr_str = "(add $int32:1 !.i32_0)";
+  const char* expr_str = "add($int32:1, .i32_0)";
   ASSERT_OK_AND_ASSIGN(Expression expr, Expression::FromString(expr_str));
   ExecBatch batch = ExecBatchFromJSON({int32(), int32()}, "[[1, 2], [1, 2]]");
   std::shared_ptr<Schema> sch =

--- a/cpp/src/arrow/compute/exec/expression_test.cc
+++ b/cpp/src/arrow/compute/exec/expression_test.cc
@@ -28,10 +28,10 @@
 #include <gtest/gtest.h>
 
 #include "arrow/compute/exec/expression_internal.h"
+#include "arrow/compute/exec/test_util.h"
 #include "arrow/compute/function_internal.h"
 #include "arrow/compute/registry.h"
 #include "arrow/testing/gtest_util.h"
-#include "arrow/compute/exec/test_util.h"
 
 using testing::HasSubstr;
 using testing::UnorderedElementsAreArray;
@@ -1563,20 +1563,20 @@ TEST(Expression, SerializationRoundTrips) {
                          equal(field_ref("beta"), literal(3.25f))}));
 }
 
-    TEST(Expression, ParseBasic)
-    {
-        const char *expr_str = "(add $int32:1 !.i32_0)";
-        ASSERT_OK_AND_ASSIGN(
-            Expression expr, Expression::FromString(expr_str));
-        ExecBatch batch = ExecBatchFromJSON({ int32(), int32() }, "[[1, 2], [1, 2]]");
-        std::shared_ptr<Schema> sch = schema({ field("i32_0", int32()), field("i32_1", int32()) });
-        ASSERT_OK_AND_ASSIGN(expr, expr.Bind(*sch.get()));
-        ASSERT_OK_AND_ASSIGN(Datum result, ExecuteScalarExpression(expr, batch));
-        const int32_t *vals = reinterpret_cast<const int32_t *>(result.array()->buffers[1]->data());
-        ASSERT_EQ(result.array()->length, 2);
-        ASSERT_EQ(vals[0], 2);
-        ASSERT_EQ(vals[1], 2);
-    } 
+TEST(Expression, ParseBasic) {
+  const char* expr_str = "(add $int32:1 !.i32_0)";
+  ASSERT_OK_AND_ASSIGN(Expression expr, Expression::FromString(expr_str));
+  ExecBatch batch = ExecBatchFromJSON({int32(), int32()}, "[[1, 2], [1, 2]]");
+  std::shared_ptr<Schema> sch =
+      schema({field("i32_0", int32()), field("i32_1", int32())});
+  ASSERT_OK_AND_ASSIGN(expr, expr.Bind(*sch.get()));
+  ASSERT_OK_AND_ASSIGN(Datum result, ExecuteScalarExpression(expr, batch));
+  const int32_t* vals =
+      reinterpret_cast<const int32_t*>(result.array()->buffers[1]->data());
+  ASSERT_EQ(result.array()->length, 2);
+  ASSERT_EQ(vals[0], 2);
+  ASSERT_EQ(vals[1], 2);
+}
 
 TEST(Projection, AugmentWithNull) {
   // NB: input contains *no columns* except i32

--- a/cpp/src/arrow/compute/exec/expression_test.cc
+++ b/cpp/src/arrow/compute/exec/expression_test.cc
@@ -31,6 +31,7 @@
 #include "arrow/compute/function_internal.h"
 #include "arrow/compute/registry.h"
 #include "arrow/testing/gtest_util.h"
+#include "arrow/compute/exec/test_util.h"
 
 using testing::HasSubstr;
 using testing::UnorderedElementsAreArray;
@@ -1561,6 +1562,21 @@ TEST(Expression, SerializationRoundTrips) {
                          equal(field_ref("alpha"), literal(int32_t(0))),
                          equal(field_ref("beta"), literal(3.25f))}));
 }
+
+    TEST(Expression, ParseBasic)
+    {
+        const char *expr_str = "(add $int32:1 !.i32_0)";
+        ASSERT_OK_AND_ASSIGN(
+            Expression expr, Expression::FromString(expr_str));
+        ExecBatch batch = ExecBatchFromJSON({ int32(), int32() }, "[[1, 2], [1, 2]]");
+        std::shared_ptr<Schema> sch = schema({ field("i32_0", int32()), field("i32_1", int32()) });
+        ASSERT_OK_AND_ASSIGN(expr, expr.Bind(*sch.get()));
+        ASSERT_OK_AND_ASSIGN(Datum result, ExecuteScalarExpression(expr, batch));
+        const int32_t *vals = reinterpret_cast<const int32_t *>(result.array()->buffers[1]->data());
+        ASSERT_EQ(result.array()->length, 2);
+        ASSERT_EQ(vals[0], 2);
+        ASSERT_EQ(vals[1], 2);
+    } 
 
 TEST(Projection, AugmentWithNull) {
   // NB: input contains *no columns* except i32

--- a/cpp/src/arrow/compute/exec/parsing.cc
+++ b/cpp/src/arrow/compute/exec/parsing.cc
@@ -27,8 +27,8 @@
 
 namespace arrow {
 namespace compute {
-constexpr const char* kWhitespaces = " \f\n\r\t\v";
 static void ConsumeWhitespace(std::string_view& view) {
+  constexpr const char* kWhitespaces = " \f\n\r\t\v";
   size_t first_nonwhitespace = view.find_first_not_of(kWhitespaces);
   view.remove_prefix(first_nonwhitespace);
 }
@@ -211,6 +211,7 @@ static Result<Expression> ParseCall(std::string_view& expr) {
 
   std::vector<Expression> args;
   do {
+    ConsumeWhitespace(expr);
     if (expr.empty()) return Status::Invalid("Found unterminated expression");
     if (expr[0] == ')') break;
     ARROW_ASSIGN_OR_RAISE(Expression arg, ParseExpr(expr));

--- a/cpp/src/arrow/compute/exec/parsing.cc
+++ b/cpp/src/arrow/compute/exec/parsing.cc
@@ -1,0 +1,338 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <charconv>
+#include <unordered_map>
+#include <string_view>
+#include <cctype>
+#include <type_traits>
+
+#include "arrow/type_fwd.h"
+#include "arrow/util/logging.h"
+#include "arrow/compute/exec/expression.h"
+
+namespace arrow
+{
+    namespace compute
+    {
+        constexpr const char *kWhitespaces = " \f\n\r\t\v";
+        static void ConsumeWhitespace(std::string_view &view)
+        {
+            size_t first_nonwhitespace = view.find_first_not_of(kWhitespaces);
+            view.remove_prefix(first_nonwhitespace);
+        }
+
+        static std::string_view TrimUntilNextSeparator(std::string_view &view)
+        {
+            constexpr const char *separators = " \f\n\r\t\v)";
+            size_t separator = view.find_first_of(separators);
+            std::string_view result = view.substr(0, separator);
+            view.remove_prefix(separator);
+            return result;
+        }
+
+        static const std::unordered_map<std::string_view, std::shared_ptr<DataType>> kNameToSimpleType =
+        {
+            { "null", null() },
+            { "boolean", boolean() },
+            { "int8", int8() },
+            { "int16", int16() },
+            { "int32", int32() },
+            { "int64", int64() },
+            { "uint8", uint8() },
+            { "uint16", uint16() },
+            { "uint32", uint32() },
+            { "uint64", uint64() },
+            { "float16", float16() },
+            { "float32", float32() },
+            { "float64", float64() },
+            { "utf8", utf8() },
+            { "large_utf8", large_utf8() },
+            { "binary", binary() },
+            { "large_binary", large_binary() },
+            { "date32", date32() },
+            { "date64", date64() },
+            { "day_time_interval", day_time_interval() },
+            { "month_interval", month_interval() },
+            { "month_day_nano_interval", month_day_nano_interval() },
+        };
+
+        static Result<std::shared_ptr<DataType>> ParseDataType(std::string_view &type);
+
+        // Takes the args list not including the enclosing parentheses
+        using InstantiateTypeFn = std::add_pointer_t<Result<std::shared_ptr<DataType>>(std::string_view &)>;
+
+        static Result<int32_t> ParseInt32(std::string_view &args)
+        {
+            ConsumeWhitespace(args);
+            int32_t result;
+            auto [finish, ec] = std::from_chars(args.begin(), args.end(), result);
+            if(ec == std::errc::invalid_argument)
+                return Status::Invalid("Could not parse ", args, " as an int32!");
+
+            args.remove_prefix(finish - args.begin());
+            return result;
+        }
+
+        static Status ParseComma(std::string_view &args)
+        {
+            ConsumeWhitespace(args);
+            if(args.empty() || args[0] != ',')
+                return Status::Invalid("Expected comma-separated args list near ", args);
+            args.remove_prefix(1);
+            return Status::OK();
+        }
+
+        static Result<std::shared_ptr<DataType>> ParseFixedSizeBinary(std::string_view &args)
+        {
+            ARROW_ASSIGN_OR_RAISE(int32_t byte_width, ParseInt32(args));
+            return fixed_size_binary(byte_width);
+        }
+
+        static Result<std::pair<int32_t, int32_t>> ParseDecimalArgs(std::string_view &args)
+        {
+            ARROW_ASSIGN_OR_RAISE(int32_t precision, ParseInt32(args));
+            RETURN_NOT_OK(ParseComma(args));
+            ARROW_ASSIGN_OR_RAISE(int32_t scale, ParseInt32(args));
+            return std::pair<int32_t, int32_t>(precision, scale);
+        }
+
+        static Result<std::shared_ptr<DataType>> ParseDecimal(std::string_view &args)
+        {
+            ARROW_ASSIGN_OR_RAISE(auto ps, ParseDecimalArgs(args));
+            return decimal(ps.first, ps.second);
+        }
+
+        static Result<std::shared_ptr<DataType>> ParseDecimal128(std::string_view &args)
+        {
+            ARROW_ASSIGN_OR_RAISE(auto ps, ParseDecimalArgs(args));
+            return decimal128(ps.first, ps.second);
+        }
+
+        static Result<std::shared_ptr<DataType>> ParseDecimal256(std::string_view &args)
+        {
+            ARROW_ASSIGN_OR_RAISE(auto ps, ParseDecimalArgs(args));
+            return decimal256(ps.first, ps.second);
+        }
+
+        static Result<std::shared_ptr<DataType>> ParseList(std::string_view &args)
+        {
+            ARROW_ASSIGN_OR_RAISE(std::shared_ptr<DataType> list_type, ParseDataType(args));
+            return list(std::move(list_type));
+        }
+
+        static Result<std::shared_ptr<DataType>> ParseLargeList(std::string_view &args)
+        {
+            ARROW_ASSIGN_OR_RAISE(std::shared_ptr<DataType> list_type, ParseDataType(args));
+            return large_list(std::move(list_type));
+        }
+
+        static Result<std::shared_ptr<DataType>> ParseMap(std::string_view &args)
+        {
+            ARROW_ASSIGN_OR_RAISE(std::shared_ptr<DataType> key_type, ParseDataType(args));
+            RETURN_NOT_OK(ParseComma(args));
+            ARROW_ASSIGN_OR_RAISE(std::shared_ptr<DataType> value_type, ParseDataType(args));
+            return map(std::move(key_type), std::move(value_type));
+        }
+
+        static Result<std::shared_ptr<DataType>> ParseFixedSizeList(std::string_view &args)
+        {
+            ARROW_ASSIGN_OR_RAISE(std::shared_ptr<DataType> list_type, ParseDataType(args));
+            RETURN_NOT_OK(ParseComma(args));
+            ARROW_ASSIGN_OR_RAISE(int32_t size, ParseInt32(args));
+            return fixed_size_list(std::move(list_type), size);
+        }
+
+        static Result<TimeUnit::type> ParseTimeUnit(std::string_view &args)
+        {
+            ConsumeWhitespace(args);
+            if(args.empty())
+                return Status::Invalid("Expected a time unit near ", args);
+
+            const std::string_view options[4] = { "SECOND", "MILLI", "MICRO", "NANO" };
+            for(size_t i = 0; i < 4; i++)
+            {
+                if(args.find(options[i]) == 0)
+                {
+                    args.remove_prefix(options[i].size());
+                    return TimeUnit::values()[i];
+                }
+            }
+            return Status::Invalid("Unrecognized TimeUnit ", args);
+        }
+
+        static Result<std::shared_ptr<DataType>> ParseDuration(std::string_view &args)
+        {
+            ARROW_ASSIGN_OR_RAISE(TimeUnit::type unit, ParseTimeUnit(args));
+            return duration(unit);
+        } 
+
+        static Result<std::shared_ptr<DataType>> ParseTimestamp(std::string_view &args)
+        {
+            ARROW_ASSIGN_OR_RAISE(TimeUnit::type unit, ParseTimeUnit(args));
+            return timestamp(unit);
+        } 
+
+        static Result<std::shared_ptr<DataType>> ParseTime32(std::string_view &args)
+        {
+            ARROW_ASSIGN_OR_RAISE(TimeUnit::type unit, ParseTimeUnit(args));
+            return time32(unit);
+        } 
+
+        static Result<std::shared_ptr<DataType>> ParseTime64(std::string_view &args)
+        {
+            ARROW_ASSIGN_OR_RAISE(TimeUnit::type unit, ParseTimeUnit(args));
+            return time64(unit);
+        }
+
+        static Result<std::shared_ptr<DataType>> ParseDictionary(std::string_view &args)
+        {
+            ARROW_ASSIGN_OR_RAISE(std::shared_ptr<DataType> key_type, ParseDataType(args));
+            RETURN_NOT_OK(ParseComma(args));
+            ARROW_ASSIGN_OR_RAISE(std::shared_ptr<DataType> value_type, ParseDataType(args));
+            return dictionary(std::move(key_type), std::move(value_type));
+        }
+
+        static const std::unordered_map<std::string_view, InstantiateTypeFn> kNameToParameterizedType =
+        {
+            { "fixed_size_binary", ParseFixedSizeBinary },
+            { "decimal", ParseDecimal },
+            { "decimal128", ParseDecimal128 },
+            { "decimal256", ParseDecimal256 },
+            { "list", ParseList },
+            { "large_list", ParseLargeList },
+            { "map", ParseMap },
+            { "fixed_size_list", ParseFixedSizeList },
+            { "duration", ParseDuration },
+            { "timestamp", ParseTimestamp },
+            { "time32", ParseTime32 },
+            { "time64", ParseTime64 },
+            { "dictionary", ParseDictionary },
+        };
+
+        static Result<Expression> ParseExpr(std::string_view &expr);
+
+        static Result<Expression> ParseCall(std::string_view &expr)
+        {
+            ConsumeWhitespace(expr);
+            if(expr.empty())
+                return Status::Invalid("Found unterminated expression");
+
+            std::string_view function_name = TrimUntilNextSeparator(expr);
+
+            std::vector<Expression> args;
+            do
+            {
+                if(expr.empty())
+                    return Status::Invalid("Found unterminated expression");
+                if(expr[0] == ')')
+                    break;
+                ARROW_ASSIGN_OR_RAISE(Expression arg, ParseExpr(expr));
+                args.emplace_back(std::move(arg));
+            } while(true);
+
+            return call(std::string(function_name), std::move(args));
+        }
+
+        static Result<Expression> ParseFieldRef(std::string_view &expr)
+        {
+            if(expr.empty() || std::isspace(expr[0]))
+                return Status::Invalid("Found an empty named fieldref");
+
+            std::string_view dot_path = TrimUntilNextSeparator(expr);
+            ARROW_ASSIGN_OR_RAISE(FieldRef field,
+                                  FieldRef::FromDotPath(dot_path));
+            return field_ref(std::move(field));
+        }
+
+        static Result<std::shared_ptr<DataType>> ParseParameterizedDataType(std::string_view &type)
+        {
+            size_t lparen = type.find_first_of("(");
+            if(lparen == std::string_view::npos)
+                return Status::Invalid("Unknown type ", type);
+
+            std::string_view base_type_name = type.substr(0, lparen);
+            type.remove_prefix(lparen + 1);
+            auto it = kNameToParameterizedType.find(base_type_name);
+            if(it == kNameToParameterizedType.end())
+                return Status::Invalid("Unknown base type name ", base_type_name);
+
+            ARROW_ASSIGN_OR_RAISE(std::shared_ptr<DataType> parsed_type, it->second(type));
+            ConsumeWhitespace(type);
+            if(type.empty() || type[0] != ')')
+                return Status::Invalid("Unterminated data type arg list!");
+            type.remove_prefix(1);
+            return parsed_type;
+        }
+
+        static Result<std::shared_ptr<DataType>> ParseDataType(std::string_view &type)
+        {
+            auto it = kNameToSimpleType.find(type);
+            if(it == kNameToSimpleType.end())
+                return ParseParameterizedDataType(type);
+            return it->second;
+        }
+
+        static Result<Expression> ParseLiteral(std::string_view &expr)
+        {
+            size_t colon = expr.find_first_of(":");
+            std::string_view type_name = expr.substr(0, colon);
+            expr.remove_prefix(colon);
+            if(expr.empty())
+                return Status::Invalid("Found an unterminated literal!");
+
+            ARROW_DCHECK_EQ(expr[0], ':');
+            expr.remove_prefix(1);
+
+            std::string_view value = TrimUntilNextSeparator(expr);
+            
+            ARROW_ASSIGN_OR_RAISE(
+                std::shared_ptr<DataType> type,
+                ParseDataType(type_name));
+
+            ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
+                                  Scalar::Parse(type, value));
+            return literal(std::move(scalar));
+        }
+
+        static Result<Expression> ParseExpr(std::string_view &expr)
+        {
+            ConsumeWhitespace(expr);
+            if(expr.empty())
+                return Status::Invalid("Expression is empty!");
+
+            char expr_start = expr[0];
+            expr.remove_prefix(1);
+            switch(expr_start)
+            {
+            case '(':
+                return ParseCall(expr);
+            case '!':
+                return ParseFieldRef(expr);
+            case '$':
+                return ParseLiteral(expr);
+            default:
+                return Status::Invalid("Invalid start of expression");
+            }
+        }
+
+        Result<Expression> Expression::FromString(std::string_view expr)
+        {
+            return ParseExpr(expr);
+        }
+    }
+}

--- a/cpp/src/arrow/compute/exec/parsing.cc
+++ b/cpp/src/arrow/compute/exec/parsing.cc
@@ -15,324 +15,282 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <charconv>
-#include <unordered_map>
-#include <string_view>
 #include <cctype>
+#include <charconv>
+#include <string_view>
 #include <type_traits>
+#include <unordered_map>
 
+#include "arrow/compute/exec/expression.h"
 #include "arrow/type_fwd.h"
 #include "arrow/util/logging.h"
-#include "arrow/compute/exec/expression.h"
 
-namespace arrow
-{
-    namespace compute
-    {
-        constexpr const char *kWhitespaces = " \f\n\r\t\v";
-        static void ConsumeWhitespace(std::string_view &view)
-        {
-            size_t first_nonwhitespace = view.find_first_not_of(kWhitespaces);
-            view.remove_prefix(first_nonwhitespace);
-        }
-
-        static std::string_view TrimUntilNextSeparator(std::string_view &view)
-        {
-            constexpr const char *separators = " \f\n\r\t\v)";
-            size_t separator = view.find_first_of(separators);
-            std::string_view result = view.substr(0, separator);
-            view.remove_prefix(separator);
-            return result;
-        }
-
-        static const std::unordered_map<std::string_view, std::shared_ptr<DataType>> kNameToSimpleType =
-        {
-            { "null", null() },
-            { "boolean", boolean() },
-            { "int8", int8() },
-            { "int16", int16() },
-            { "int32", int32() },
-            { "int64", int64() },
-            { "uint8", uint8() },
-            { "uint16", uint16() },
-            { "uint32", uint32() },
-            { "uint64", uint64() },
-            { "float16", float16() },
-            { "float32", float32() },
-            { "float64", float64() },
-            { "utf8", utf8() },
-            { "large_utf8", large_utf8() },
-            { "binary", binary() },
-            { "large_binary", large_binary() },
-            { "date32", date32() },
-            { "date64", date64() },
-            { "day_time_interval", day_time_interval() },
-            { "month_interval", month_interval() },
-            { "month_day_nano_interval", month_day_nano_interval() },
-        };
-
-        static Result<std::shared_ptr<DataType>> ParseDataType(std::string_view &type);
-
-        // Takes the args list not including the enclosing parentheses
-        using InstantiateTypeFn = std::add_pointer_t<Result<std::shared_ptr<DataType>>(std::string_view &)>;
-
-        static Result<int32_t> ParseInt32(std::string_view &args)
-        {
-            ConsumeWhitespace(args);
-            int32_t result;
-            auto [finish, ec] = std::from_chars(args.begin(), args.end(), result);
-            if(ec == std::errc::invalid_argument)
-                return Status::Invalid("Could not parse ", args, " as an int32!");
-
-            args.remove_prefix(finish - args.begin());
-            return result;
-        }
-
-        static Status ParseComma(std::string_view &args)
-        {
-            ConsumeWhitespace(args);
-            if(args.empty() || args[0] != ',')
-                return Status::Invalid("Expected comma-separated args list near ", args);
-            args.remove_prefix(1);
-            return Status::OK();
-        }
-
-        static Result<std::shared_ptr<DataType>> ParseFixedSizeBinary(std::string_view &args)
-        {
-            ARROW_ASSIGN_OR_RAISE(int32_t byte_width, ParseInt32(args));
-            return fixed_size_binary(byte_width);
-        }
-
-        static Result<std::pair<int32_t, int32_t>> ParseDecimalArgs(std::string_view &args)
-        {
-            ARROW_ASSIGN_OR_RAISE(int32_t precision, ParseInt32(args));
-            RETURN_NOT_OK(ParseComma(args));
-            ARROW_ASSIGN_OR_RAISE(int32_t scale, ParseInt32(args));
-            return std::pair<int32_t, int32_t>(precision, scale);
-        }
-
-        static Result<std::shared_ptr<DataType>> ParseDecimal(std::string_view &args)
-        {
-            ARROW_ASSIGN_OR_RAISE(auto ps, ParseDecimalArgs(args));
-            return decimal(ps.first, ps.second);
-        }
-
-        static Result<std::shared_ptr<DataType>> ParseDecimal128(std::string_view &args)
-        {
-            ARROW_ASSIGN_OR_RAISE(auto ps, ParseDecimalArgs(args));
-            return decimal128(ps.first, ps.second);
-        }
-
-        static Result<std::shared_ptr<DataType>> ParseDecimal256(std::string_view &args)
-        {
-            ARROW_ASSIGN_OR_RAISE(auto ps, ParseDecimalArgs(args));
-            return decimal256(ps.first, ps.second);
-        }
-
-        static Result<std::shared_ptr<DataType>> ParseList(std::string_view &args)
-        {
-            ARROW_ASSIGN_OR_RAISE(std::shared_ptr<DataType> list_type, ParseDataType(args));
-            return list(std::move(list_type));
-        }
-
-        static Result<std::shared_ptr<DataType>> ParseLargeList(std::string_view &args)
-        {
-            ARROW_ASSIGN_OR_RAISE(std::shared_ptr<DataType> list_type, ParseDataType(args));
-            return large_list(std::move(list_type));
-        }
-
-        static Result<std::shared_ptr<DataType>> ParseMap(std::string_view &args)
-        {
-            ARROW_ASSIGN_OR_RAISE(std::shared_ptr<DataType> key_type, ParseDataType(args));
-            RETURN_NOT_OK(ParseComma(args));
-            ARROW_ASSIGN_OR_RAISE(std::shared_ptr<DataType> value_type, ParseDataType(args));
-            return map(std::move(key_type), std::move(value_type));
-        }
-
-        static Result<std::shared_ptr<DataType>> ParseFixedSizeList(std::string_view &args)
-        {
-            ARROW_ASSIGN_OR_RAISE(std::shared_ptr<DataType> list_type, ParseDataType(args));
-            RETURN_NOT_OK(ParseComma(args));
-            ARROW_ASSIGN_OR_RAISE(int32_t size, ParseInt32(args));
-            return fixed_size_list(std::move(list_type), size);
-        }
-
-        static Result<TimeUnit::type> ParseTimeUnit(std::string_view &args)
-        {
-            ConsumeWhitespace(args);
-            if(args.empty())
-                return Status::Invalid("Expected a time unit near ", args);
-
-            const std::string_view options[4] = { "SECOND", "MILLI", "MICRO", "NANO" };
-            for(size_t i = 0; i < 4; i++)
-            {
-                if(args.find(options[i]) == 0)
-                {
-                    args.remove_prefix(options[i].size());
-                    return TimeUnit::values()[i];
-                }
-            }
-            return Status::Invalid("Unrecognized TimeUnit ", args);
-        }
-
-        static Result<std::shared_ptr<DataType>> ParseDuration(std::string_view &args)
-        {
-            ARROW_ASSIGN_OR_RAISE(TimeUnit::type unit, ParseTimeUnit(args));
-            return duration(unit);
-        } 
-
-        static Result<std::shared_ptr<DataType>> ParseTimestamp(std::string_view &args)
-        {
-            ARROW_ASSIGN_OR_RAISE(TimeUnit::type unit, ParseTimeUnit(args));
-            return timestamp(unit);
-        } 
-
-        static Result<std::shared_ptr<DataType>> ParseTime32(std::string_view &args)
-        {
-            ARROW_ASSIGN_OR_RAISE(TimeUnit::type unit, ParseTimeUnit(args));
-            return time32(unit);
-        } 
-
-        static Result<std::shared_ptr<DataType>> ParseTime64(std::string_view &args)
-        {
-            ARROW_ASSIGN_OR_RAISE(TimeUnit::type unit, ParseTimeUnit(args));
-            return time64(unit);
-        }
-
-        static Result<std::shared_ptr<DataType>> ParseDictionary(std::string_view &args)
-        {
-            ARROW_ASSIGN_OR_RAISE(std::shared_ptr<DataType> key_type, ParseDataType(args));
-            RETURN_NOT_OK(ParseComma(args));
-            ARROW_ASSIGN_OR_RAISE(std::shared_ptr<DataType> value_type, ParseDataType(args));
-            return dictionary(std::move(key_type), std::move(value_type));
-        }
-
-        static const std::unordered_map<std::string_view, InstantiateTypeFn> kNameToParameterizedType =
-        {
-            { "fixed_size_binary", ParseFixedSizeBinary },
-            { "decimal", ParseDecimal },
-            { "decimal128", ParseDecimal128 },
-            { "decimal256", ParseDecimal256 },
-            { "list", ParseList },
-            { "large_list", ParseLargeList },
-            { "map", ParseMap },
-            { "fixed_size_list", ParseFixedSizeList },
-            { "duration", ParseDuration },
-            { "timestamp", ParseTimestamp },
-            { "time32", ParseTime32 },
-            { "time64", ParseTime64 },
-            { "dictionary", ParseDictionary },
-        };
-
-        static Result<Expression> ParseExpr(std::string_view &expr);
-
-        static Result<Expression> ParseCall(std::string_view &expr)
-        {
-            ConsumeWhitespace(expr);
-            if(expr.empty())
-                return Status::Invalid("Found unterminated expression");
-
-            std::string_view function_name = TrimUntilNextSeparator(expr);
-
-            std::vector<Expression> args;
-            do
-            {
-                if(expr.empty())
-                    return Status::Invalid("Found unterminated expression");
-                if(expr[0] == ')')
-                    break;
-                ARROW_ASSIGN_OR_RAISE(Expression arg, ParseExpr(expr));
-                args.emplace_back(std::move(arg));
-            } while(true);
-
-            return call(std::string(function_name), std::move(args));
-        }
-
-        static Result<Expression> ParseFieldRef(std::string_view &expr)
-        {
-            if(expr.empty() || std::isspace(expr[0]))
-                return Status::Invalid("Found an empty named fieldref");
-
-            std::string_view dot_path = TrimUntilNextSeparator(expr);
-            ARROW_ASSIGN_OR_RAISE(FieldRef field,
-                                  FieldRef::FromDotPath(dot_path));
-            return field_ref(std::move(field));
-        }
-
-        static Result<std::shared_ptr<DataType>> ParseParameterizedDataType(std::string_view &type)
-        {
-            size_t lparen = type.find_first_of("(");
-            if(lparen == std::string_view::npos)
-                return Status::Invalid("Unknown type ", type);
-
-            std::string_view base_type_name = type.substr(0, lparen);
-            type.remove_prefix(lparen + 1);
-            auto it = kNameToParameterizedType.find(base_type_name);
-            if(it == kNameToParameterizedType.end())
-                return Status::Invalid("Unknown base type name ", base_type_name);
-
-            ARROW_ASSIGN_OR_RAISE(std::shared_ptr<DataType> parsed_type, it->second(type));
-            ConsumeWhitespace(type);
-            if(type.empty() || type[0] != ')')
-                return Status::Invalid("Unterminated data type arg list!");
-            type.remove_prefix(1);
-            return parsed_type;
-        }
-
-        static Result<std::shared_ptr<DataType>> ParseDataType(std::string_view &type)
-        {
-            auto it = kNameToSimpleType.find(type);
-            if(it == kNameToSimpleType.end())
-                return ParseParameterizedDataType(type);
-            return it->second;
-        }
-
-        static Result<Expression> ParseLiteral(std::string_view &expr)
-        {
-            size_t colon = expr.find_first_of(":");
-            std::string_view type_name = expr.substr(0, colon);
-            expr.remove_prefix(colon);
-            if(expr.empty())
-                return Status::Invalid("Found an unterminated literal!");
-
-            ARROW_DCHECK_EQ(expr[0], ':');
-            expr.remove_prefix(1);
-
-            std::string_view value = TrimUntilNextSeparator(expr);
-            
-            ARROW_ASSIGN_OR_RAISE(
-                std::shared_ptr<DataType> type,
-                ParseDataType(type_name));
-
-            ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
-                                  Scalar::Parse(type, value));
-            return literal(std::move(scalar));
-        }
-
-        static Result<Expression> ParseExpr(std::string_view &expr)
-        {
-            ConsumeWhitespace(expr);
-            if(expr.empty())
-                return Status::Invalid("Expression is empty!");
-
-            char expr_start = expr[0];
-            expr.remove_prefix(1);
-            switch(expr_start)
-            {
-            case '(':
-                return ParseCall(expr);
-            case '!':
-                return ParseFieldRef(expr);
-            case '$':
-                return ParseLiteral(expr);
-            default:
-                return Status::Invalid("Invalid start of expression");
-            }
-        }
-
-        Result<Expression> Expression::FromString(std::string_view expr)
-        {
-            return ParseExpr(expr);
-        }
-    }
+namespace arrow {
+namespace compute {
+constexpr const char* kWhitespaces = " \f\n\r\t\v";
+static void ConsumeWhitespace(std::string_view& view) {
+  size_t first_nonwhitespace = view.find_first_not_of(kWhitespaces);
+  view.remove_prefix(first_nonwhitespace);
 }
+
+static std::string_view TrimUntilNextSeparator(std::string_view& view) {
+  constexpr const char* separators = " \f\n\r\t\v)";
+  size_t separator = view.find_first_of(separators);
+  std::string_view result = view.substr(0, separator);
+  view.remove_prefix(separator);
+  return result;
+}
+
+static const std::unordered_map<std::string_view, std::shared_ptr<DataType>>
+    kNameToSimpleType = {
+        {"null", null()},
+        {"boolean", boolean()},
+        {"int8", int8()},
+        {"int16", int16()},
+        {"int32", int32()},
+        {"int64", int64()},
+        {"uint8", uint8()},
+        {"uint16", uint16()},
+        {"uint32", uint32()},
+        {"uint64", uint64()},
+        {"float16", float16()},
+        {"float32", float32()},
+        {"float64", float64()},
+        {"utf8", utf8()},
+        {"large_utf8", large_utf8()},
+        {"binary", binary()},
+        {"large_binary", large_binary()},
+        {"date32", date32()},
+        {"date64", date64()},
+        {"day_time_interval", day_time_interval()},
+        {"month_interval", month_interval()},
+        {"month_day_nano_interval", month_day_nano_interval()},
+};
+
+static Result<std::shared_ptr<DataType>> ParseDataType(std::string_view& type);
+
+// Takes the args list not including the enclosing parentheses
+using InstantiateTypeFn =
+    std::add_pointer_t<Result<std::shared_ptr<DataType>>(std::string_view&)>;
+
+static Result<int32_t> ParseInt32(std::string_view& args) {
+  ConsumeWhitespace(args);
+  int32_t result;
+  auto [finish, ec] = std::from_chars(args.begin(), args.end(), result);
+  if (ec == std::errc::invalid_argument)
+    return Status::Invalid("Could not parse ", args, " as an int32!");
+
+  args.remove_prefix(finish - args.begin());
+  return result;
+}
+
+static Status ParseComma(std::string_view& args) {
+  ConsumeWhitespace(args);
+  if (args.empty() || args[0] != ',')
+    return Status::Invalid("Expected comma-separated args list near ", args);
+  args.remove_prefix(1);
+  return Status::OK();
+}
+
+static Result<std::shared_ptr<DataType>> ParseFixedSizeBinary(std::string_view& args) {
+  ARROW_ASSIGN_OR_RAISE(int32_t byte_width, ParseInt32(args));
+  return fixed_size_binary(byte_width);
+}
+
+static Result<std::pair<int32_t, int32_t>> ParseDecimalArgs(std::string_view& args) {
+  ARROW_ASSIGN_OR_RAISE(int32_t precision, ParseInt32(args));
+  RETURN_NOT_OK(ParseComma(args));
+  ARROW_ASSIGN_OR_RAISE(int32_t scale, ParseInt32(args));
+  return std::pair<int32_t, int32_t>(precision, scale);
+}
+
+static Result<std::shared_ptr<DataType>> ParseDecimal(std::string_view& args) {
+  ARROW_ASSIGN_OR_RAISE(auto ps, ParseDecimalArgs(args));
+  return decimal(ps.first, ps.second);
+}
+
+static Result<std::shared_ptr<DataType>> ParseDecimal128(std::string_view& args) {
+  ARROW_ASSIGN_OR_RAISE(auto ps, ParseDecimalArgs(args));
+  return decimal128(ps.first, ps.second);
+}
+
+static Result<std::shared_ptr<DataType>> ParseDecimal256(std::string_view& args) {
+  ARROW_ASSIGN_OR_RAISE(auto ps, ParseDecimalArgs(args));
+  return decimal256(ps.first, ps.second);
+}
+
+static Result<std::shared_ptr<DataType>> ParseList(std::string_view& args) {
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<DataType> list_type, ParseDataType(args));
+  return list(std::move(list_type));
+}
+
+static Result<std::shared_ptr<DataType>> ParseLargeList(std::string_view& args) {
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<DataType> list_type, ParseDataType(args));
+  return large_list(std::move(list_type));
+}
+
+static Result<std::shared_ptr<DataType>> ParseMap(std::string_view& args) {
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<DataType> key_type, ParseDataType(args));
+  RETURN_NOT_OK(ParseComma(args));
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<DataType> value_type, ParseDataType(args));
+  return map(std::move(key_type), std::move(value_type));
+}
+
+static Result<std::shared_ptr<DataType>> ParseFixedSizeList(std::string_view& args) {
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<DataType> list_type, ParseDataType(args));
+  RETURN_NOT_OK(ParseComma(args));
+  ARROW_ASSIGN_OR_RAISE(int32_t size, ParseInt32(args));
+  return fixed_size_list(std::move(list_type), size);
+}
+
+static Result<TimeUnit::type> ParseTimeUnit(std::string_view& args) {
+  ConsumeWhitespace(args);
+  if (args.empty()) return Status::Invalid("Expected a time unit near ", args);
+
+  const std::string_view options[4] = {"SECOND", "MILLI", "MICRO", "NANO"};
+  for (size_t i = 0; i < 4; i++) {
+    if (args.find(options[i]) == 0) {
+      args.remove_prefix(options[i].size());
+      return TimeUnit::values()[i];
+    }
+  }
+  return Status::Invalid("Unrecognized TimeUnit ", args);
+}
+
+static Result<std::shared_ptr<DataType>> ParseDuration(std::string_view& args) {
+  ARROW_ASSIGN_OR_RAISE(TimeUnit::type unit, ParseTimeUnit(args));
+  return duration(unit);
+}
+
+static Result<std::shared_ptr<DataType>> ParseTimestamp(std::string_view& args) {
+  ARROW_ASSIGN_OR_RAISE(TimeUnit::type unit, ParseTimeUnit(args));
+  return timestamp(unit);
+}
+
+static Result<std::shared_ptr<DataType>> ParseTime32(std::string_view& args) {
+  ARROW_ASSIGN_OR_RAISE(TimeUnit::type unit, ParseTimeUnit(args));
+  return time32(unit);
+}
+
+static Result<std::shared_ptr<DataType>> ParseTime64(std::string_view& args) {
+  ARROW_ASSIGN_OR_RAISE(TimeUnit::type unit, ParseTimeUnit(args));
+  return time64(unit);
+}
+
+static Result<std::shared_ptr<DataType>> ParseDictionary(std::string_view& args) {
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<DataType> key_type, ParseDataType(args));
+  RETURN_NOT_OK(ParseComma(args));
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<DataType> value_type, ParseDataType(args));
+  return dictionary(std::move(key_type), std::move(value_type));
+}
+
+static const std::unordered_map<std::string_view, InstantiateTypeFn>
+    kNameToParameterizedType = {
+        {"fixed_size_binary", ParseFixedSizeBinary},
+        {"decimal", ParseDecimal},
+        {"decimal128", ParseDecimal128},
+        {"decimal256", ParseDecimal256},
+        {"list", ParseList},
+        {"large_list", ParseLargeList},
+        {"map", ParseMap},
+        {"fixed_size_list", ParseFixedSizeList},
+        {"duration", ParseDuration},
+        {"timestamp", ParseTimestamp},
+        {"time32", ParseTime32},
+        {"time64", ParseTime64},
+        {"dictionary", ParseDictionary},
+};
+
+static Result<Expression> ParseExpr(std::string_view& expr);
+
+static Result<Expression> ParseCall(std::string_view& expr) {
+  ConsumeWhitespace(expr);
+  if (expr.empty()) return Status::Invalid("Found unterminated expression");
+
+  std::string_view function_name = TrimUntilNextSeparator(expr);
+
+  std::vector<Expression> args;
+  do {
+    if (expr.empty()) return Status::Invalid("Found unterminated expression");
+    if (expr[0] == ')') break;
+    ARROW_ASSIGN_OR_RAISE(Expression arg, ParseExpr(expr));
+    args.emplace_back(std::move(arg));
+  } while (true);
+
+  return call(std::string(function_name), std::move(args));
+}
+
+static Result<Expression> ParseFieldRef(std::string_view& expr) {
+  if (expr.empty() || std::isspace(expr[0]))
+    return Status::Invalid("Found an empty named fieldref");
+
+  std::string_view dot_path = TrimUntilNextSeparator(expr);
+  ARROW_ASSIGN_OR_RAISE(FieldRef field, FieldRef::FromDotPath(dot_path));
+  return field_ref(std::move(field));
+}
+
+static Result<std::shared_ptr<DataType>> ParseParameterizedDataType(
+    std::string_view& type) {
+  size_t lparen = type.find_first_of("(");
+  if (lparen == std::string_view::npos) return Status::Invalid("Unknown type ", type);
+
+  std::string_view base_type_name = type.substr(0, lparen);
+  type.remove_prefix(lparen + 1);
+  auto it = kNameToParameterizedType.find(base_type_name);
+  if (it == kNameToParameterizedType.end())
+    return Status::Invalid("Unknown base type name ", base_type_name);
+
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<DataType> parsed_type, it->second(type));
+  ConsumeWhitespace(type);
+  if (type.empty() || type[0] != ')')
+    return Status::Invalid("Unterminated data type arg list!");
+  type.remove_prefix(1);
+  return parsed_type;
+}
+
+static Result<std::shared_ptr<DataType>> ParseDataType(std::string_view& type) {
+  auto it = kNameToSimpleType.find(type);
+  if (it == kNameToSimpleType.end()) return ParseParameterizedDataType(type);
+  return it->second;
+}
+
+static Result<Expression> ParseLiteral(std::string_view& expr) {
+  size_t colon = expr.find_first_of(":");
+  std::string_view type_name = expr.substr(0, colon);
+  expr.remove_prefix(colon);
+  if (expr.empty()) return Status::Invalid("Found an unterminated literal!");
+
+  ARROW_DCHECK_EQ(expr[0], ':');
+  expr.remove_prefix(1);
+
+  std::string_view value = TrimUntilNextSeparator(expr);
+
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<DataType> type, ParseDataType(type_name));
+
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar, Scalar::Parse(type, value));
+  return literal(std::move(scalar));
+}
+
+static Result<Expression> ParseExpr(std::string_view& expr) {
+  ConsumeWhitespace(expr);
+  if (expr.empty()) return Status::Invalid("Expression is empty!");
+
+  char expr_start = expr[0];
+  expr.remove_prefix(1);
+  switch (expr_start) {
+    case '(':
+      return ParseCall(expr);
+    case '!':
+      return ParseFieldRef(expr);
+    case '$':
+      return ParseLiteral(expr);
+    default:
+      return Status::Invalid("Invalid start of expression");
+  }
+}
+
+Result<Expression> Expression::FromString(std::string_view expr) {
+  return ParseExpr(expr);
+}
+}  // namespace compute
+}  // namespace arrow

--- a/cpp/src/arrow/compute/exec/parsing.cc
+++ b/cpp/src/arrow/compute/exec/parsing.cc
@@ -76,11 +76,11 @@ using InstantiateTypeFn =
 static Result<int32_t> ParseInt32(std::string_view& args) {
   ConsumeWhitespace(args);
   int32_t result;
-  auto [finish, ec] = std::from_chars(args.begin(), args.end(), result);
+  auto [finish, ec] = std::from_chars(args.data(), args.data() + args.size(), result);
   if (ec == std::errc::invalid_argument)
     return Status::Invalid("Could not parse ", args, " as an int32!");
 
-  args.remove_prefix(finish - args.begin());
+  args.remove_prefix(finish - args.data());
   return result;
 }
 

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -1235,14 +1235,12 @@ void FieldRef::Flatten(std::vector<FieldRef> children) {
   }
 }
 
-Result<FieldRef> FieldRef::FromDotPath(const std::string& dot_path_arg) {
-  if (dot_path_arg.empty()) {
-    return FieldRef();
+Result<FieldRef> FieldRef::FromDotPath(std::string_view dot_path) {
+  if (dot_path.empty()) {
+    return Status::Invalid("Dot path was empty");
   }
 
   std::vector<FieldRef> children;
-
-  std::string_view dot_path = dot_path_arg;
 
   auto parse_name = [&] {
     std::string name;
@@ -1289,7 +1287,7 @@ Result<FieldRef> FieldRef::FromDotPath(const std::string& dot_path_arg) {
       case '[': {
         auto subscript_end = dot_path.find_first_not_of("0123456789");
         if (subscript_end == std::string_view::npos || dot_path[subscript_end] != ']') {
-          return Status::Invalid("Dot path '", dot_path_arg,
+          return Status::Invalid("Dot path '", dot_path,
                                  "' contained an unterminated index");
         }
         children.emplace_back(std::atoi(dot_path.data()));
@@ -1297,7 +1295,7 @@ Result<FieldRef> FieldRef::FromDotPath(const std::string& dot_path_arg) {
         continue;
       }
       default:
-        return Status::Invalid("Dot path must begin with '[' or '.', got '", dot_path_arg,
+        return Status::Invalid("Dot path must begin with '[' or '.', got '", dot_path,
                                "'");
     }
   }

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -1236,6 +1236,7 @@ void FieldRef::Flatten(std::vector<FieldRef> children) {
 }
 
 Result<FieldRef> FieldRef::FromDotPath(std::string_view dot_path) {
+  std::string_view original_dot_path = dot_path;
   if (dot_path.empty()) {
     return Status::Invalid("Dot path was empty");
   }
@@ -1287,7 +1288,7 @@ Result<FieldRef> FieldRef::FromDotPath(std::string_view dot_path) {
       case '[': {
         auto subscript_end = dot_path.find_first_not_of("0123456789");
         if (subscript_end == std::string_view::npos || dot_path[subscript_end] != ']') {
-          return Status::Invalid("Dot path '", dot_path,
+          return Status::Invalid("Dot path '", original_dot_path,
                                  "' contained an unterminated index");
         }
         children.emplace_back(std::atoi(dot_path.data()));
@@ -1295,8 +1296,8 @@ Result<FieldRef> FieldRef::FromDotPath(std::string_view dot_path) {
         continue;
       }
       default:
-        return Status::Invalid("Dot path must begin with '[' or '.', got '", dot_path,
-                               "'");
+        return Status::Invalid("Dot path must begin with '[' or '.', got '",
+                               original_dot_path, "'");
     }
   }
 

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1723,7 +1723,7 @@ class ARROW_EXPORT FieldRef : public util::EqualityComparable<FieldRef> {
   /// Note: When parsing a name, a '\' preceding any other character will be dropped from
   /// the resulting name. Therefore if a name must contain the characters '.', '\', or '['
   /// those must be escaped with a preceding '\'.
-  static Result<FieldRef> FromDotPath(const std::string& dot_path);
+  static Result<FieldRef> FromDotPath(const std::string_view dot_path);
   std::string ToDotPath() const;
 
   bool Equals(const FieldRef& other) const { return impl_ == other.impl_; }


### PR DESCRIPTION
I've seen a few people on the mailing list asking for something like this and I've wanted it myself, so I went ahead and implemented a parser for a lisp-like way of generating Expressions. Calls are of the form `(<fn> <args>)`, scalars are of the form `$type:value`, and field refs are of the form `!<dot path>`. 