### PR TITLE
ARROW-15592: [C++] Add support for custom output field names in a substrait::PlanRel

### DIFF
--- a/cpp/src/arrow/engine/substrait/serde.cc
+++ b/cpp/src/arrow/engine/substrait/serde.cc
@@ -96,22 +96,6 @@ using DeclarationFactory = std::function<Result<compute::Declaration>(
 
 namespace {
 
-compute::Declaration ProjectByNamesDeclaration(compute::Declaration input,
-                                               std::vector<std::string> names) {
-  int names_size = static_cast<int>(names.size());
-  if (names_size == 0) {
-    return input;
-  }
-  std::vector<compute::Expression> expressions;
-  for (int i = 0; i < names_size; i++) {
-    expressions.push_back(compute::field_ref(FieldRef(i)));
-  }
-  return compute::Declaration::Sequence(
-      {std::move(input),
-       {"project",
-        compute::ProjectNodeOptions{std::move(expressions), std::move(names)}}});
-}
-
 DeclarationFactory MakeConsumingSinkDeclarationFactory(
     const ConsumerFactory& consumer_factory) {
   return [&consumer_factory](
@@ -124,9 +108,8 @@ DeclarationFactory MakeConsumingSinkDeclarationFactory(
     std::shared_ptr<compute::ExecNodeOptions> options =
         std::make_shared<compute::ConsumingSinkNodeOptions>(
             compute::ConsumingSinkNodeOptions{std::move(consumer), std::move(names)});
-    compute::Declaration projected = ProjectByNamesDeclaration(input, names);
     return compute::Declaration::Sequence(
-        {std::move(projected), {"consuming_sink", options}});
+        {std::move(input), {"consuming_sink", options}});
   };
 }
 
@@ -139,9 +122,8 @@ DeclarationFactory MakeWriteDeclarationFactory(
     if (options == nullptr) {
       return Status::Invalid("write options factory is exhausted");
     }
-    compute::Declaration projected = ProjectByNamesDeclaration(input, names);
     return compute::Declaration::Sequence(
-        {std::move(projected), {"write", std::move(*options)}});
+        {std::move(input), {"write", std::move(*options)}});
   };
 }
 

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -3916,8 +3916,8 @@ TEST(Substrait, RootRelationOutputNames) {
 
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
-  CheckRoundTripResultTableConsumer(expected_table, exec_context, buf, {},
-                                    conversion_options);
+  CheckRoundTripResult(std::move(output_schema), std::move(expected_table), exec_context,
+                       buf, {}, conversion_options);
 }
 
 }  // namespace engine

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -36,11 +36,11 @@
 #include "arrow/compute/exec/expression.h"
 #include "arrow/compute/exec/expression_internal.h"
 #include "arrow/compute/exec/options.h"
+#include "arrow/compute/exec/util.h"
 #include "arrow/compute/registry.h"
 #include "arrow/compute/type_fwd.h"
 #include "arrow/dataset/dataset.h"
 #include "arrow/dataset/discovery.h"
-#include "arrow/compute/exec/util.h"
 #include "arrow/dataset/file_base.h"
 #include "arrow/dataset/file_ipc.h"
 #include "arrow/dataset/partition.h"
@@ -2341,8 +2341,8 @@ TEST(SubstraitRoundTrip, FilterNamedTable) {
     [2, 2, 60]
   ])"});
 
-  CheckRoundTripResult(std::move(dummy_schema), std::move(expected_table), exec_context,
-                       serialized_plan, {}, conversion_options);
+  CheckRoundTripResult(std::move(expected_table), exec_context, serialized_plan,
+                       /*include_columns=*/{}, conversion_options);
 }
 
 TEST(SubstraitRoundTrip, ProjectRel) {
@@ -2456,8 +2456,8 @@ TEST(SubstraitRoundTrip, ProjectRel) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(expected_table), exec_context, buf, {},
-                       conversion_options);
+  CheckRoundTripResult(std::move(expected_table), exec_context, buf,
+                       /*include_columns=*/{}, conversion_options);
 }
 
 TEST(SubstraitRoundTrip, ProjectRelOnFunctionWithEmit) {
@@ -2575,8 +2575,8 @@ TEST(SubstraitRoundTrip, ProjectRelOnFunctionWithEmit) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(expected_table), exec_context, buf, {},
-                       conversion_options);
+  CheckRoundTripResult(std::move(expected_table), exec_context, buf,
+                       /*include_columns=*/{}, conversion_options);
 }
 
 TEST(SubstraitRoundTrip, ReadRelWithEmit) {
@@ -2634,8 +2634,8 @@ TEST(SubstraitRoundTrip, ReadRelWithEmit) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(expected_table), exec_context, buf, {},
-                       conversion_options);
+  CheckRoundTripResult(std::move(expected_table), exec_context, buf,
+                       /*include_columns=*/{}, conversion_options);
 }
 
 TEST(SubstraitRoundTrip, FilterRelWithEmit) {
@@ -2752,8 +2752,8 @@ TEST(SubstraitRoundTrip, FilterRelWithEmit) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(expected_table), exec_context, buf, {},
-                       conversion_options);
+  CheckRoundTripResult(std::move(expected_table), exec_context, buf,
+                       /*include_columns=*/{}, conversion_options);
 }
 
 TEST(SubstraitRoundTrip, JoinRel) {
@@ -2902,8 +2902,8 @@ TEST(SubstraitRoundTrip, JoinRel) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(expected_table), exec_context, buf, {},
-                       conversion_options);
+  CheckRoundTripResult(std::move(expected_table), exec_context, buf,
+                       /*include_columns=*/{}, conversion_options);
 }
 
 TEST(SubstraitRoundTrip, JoinRelWithEmit) {
@@ -3054,8 +3054,8 @@ TEST(SubstraitRoundTrip, JoinRelWithEmit) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(expected_table), exec_context, buf, {},
-                       conversion_options);
+  CheckRoundTripResult(std::move(expected_table), exec_context, buf,
+                       /*include_columns=*/{}, conversion_options);
 }
 
 TEST(SubstraitRoundTrip, AggregateRel) {
@@ -3163,8 +3163,8 @@ TEST(SubstraitRoundTrip, AggregateRel) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(expected_table), exec_context, buf, {},
-                       conversion_options);
+  CheckRoundTripResult(std::move(expected_table), exec_context, buf,
+                       /*include_columns=*/{}, conversion_options);
 }
 
 TEST(SubstraitRoundTrip, AggregateRelEmit) {
@@ -3278,8 +3278,8 @@ TEST(SubstraitRoundTrip, AggregateRelEmit) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(expected_table), exec_context, buf, {},
-                       conversion_options);
+  CheckRoundTripResult(std::move(expected_table), exec_context, buf,
+                       /*include_columns=*/{}, conversion_options);
 }
 
 TEST(Substrait, IsthmusPlan) {
@@ -3383,7 +3383,7 @@ TEST(Substrait, IsthmusPlan) {
 
   auto expected_table = TableFromJSON(test_schema, {"[[2], [3], [6]]"});
   CheckRoundTripResult(std::move(expected_table), *compute::default_exec_context(), buf,
-                       {}, conversion_options);
+                       /*include_columns=*/{}, conversion_options);
 }
 
 TEST(Substrait, ProjectWithMultiFieldExpressions) {
@@ -3536,8 +3536,8 @@ TEST(Substrait, ProjectWithMultiFieldExpressions) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(expected_table), exec_context, buf, {},
-                       conversion_options);
+  CheckRoundTripResult(std::move(expected_table), exec_context, buf,
+                       /*include_columns=*/{}, conversion_options);
 }
 
 TEST(Substrait, NestedProjectWithMultiFieldExpressions) {
@@ -3623,8 +3623,8 @@ TEST(Substrait, NestedProjectWithMultiFieldExpressions) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(expected_table), exec_context, buf, {},
-                       conversion_options);
+  CheckRoundTripResult(std::move(expected_table), exec_context, buf,
+                       /*include_columns=*/{}, conversion_options);
 }
 
 TEST(Substrait, NestedEmitProjectWithMultiFieldExpressions) {
@@ -3711,8 +3711,8 @@ TEST(Substrait, NestedEmitProjectWithMultiFieldExpressions) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(expected_table), exec_context, buf, {},
-                       conversion_options);
+  CheckRoundTripResult(std::move(expected_table), exec_context, buf,
+                       /*include_columns=*/{}, conversion_options);
 }
 
 TEST(Substrait, ReadRelWithGlobFiles) {
@@ -3805,11 +3805,11 @@ TEST(Substrait, ReadRelWithGlobFiles) {
       }
     }]
   })"));
-  // To avoid unnecessar meta data columns being included in the final result
+  // To avoid unnecessar metadata columns being included in the final result
   std::vector<int> include_columns = {0, 1, 2};
   compute::SortOptions options({compute::SortKey("A", compute::SortOrder::Ascending)});
   CheckRoundTripResult(std::move(expected_table), exec_context, buf,
-                       std::move(include_columns), {}, &options);
+                       std::move(include_columns), /*conversion_options=*/{}, &options);
 }
 
 TEST(Substrait, RootRelationOutputNames) {
@@ -3917,8 +3917,8 @@ TEST(Substrait, RootRelationOutputNames) {
 
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
-  CheckRoundTripResult(std::move(expected_table), exec_context, buf, {},
-                       conversion_options);
+  CheckRoundTripResult(std::move(expected_table), exec_context, buf,
+                       /*include_columns=*/{}, conversion_options);
 }
 
 }  // namespace engine

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -207,8 +207,7 @@ inline compute::Expression UseBoringRefs(const compute::Expression& expr) {
   return compute::Expression{std::move(modified_call)};
 }
 
-void CheckRoundTripResult(const std::shared_ptr<Schema> output_schema,
-                          const std::shared_ptr<Table> expected_table,
+void CheckRoundTripResult(const std::shared_ptr<Table> expected_table,
                           compute::ExecContext& exec_context,
                           std::shared_ptr<Buffer>& buf,
                           const std::vector<int>& include_columns = {},
@@ -223,7 +222,8 @@ void CheckRoundTripResult(const std::shared_ptr<Schema> output_schema,
   auto& other_declrs = std::get<compute::Declaration>(sink_decls[0].inputs[0]);
 
   ASSERT_OK_AND_ASSIGN(auto output_table,
-                       GetTableFromPlan(other_declrs, exec_context, output_schema));
+                       compute::DeclarationToTable(other_declrs, &exec_context));
+
   if (!include_columns.empty()) {
     ASSERT_OK_AND_ASSIGN(output_table, output_table->SelectColumns(include_columns));
   }
@@ -2456,8 +2456,8 @@ TEST(SubstraitRoundTrip, ProjectRel) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(output_schema), std::move(expected_table), exec_context,
-                       buf, {}, conversion_options);
+  CheckRoundTripResult(std::move(expected_table), exec_context, buf, {},
+                       conversion_options);
 }
 
 TEST(SubstraitRoundTrip, ProjectRelOnFunctionWithEmit) {
@@ -2575,8 +2575,8 @@ TEST(SubstraitRoundTrip, ProjectRelOnFunctionWithEmit) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(output_schema), std::move(expected_table), exec_context,
-                       buf, {}, conversion_options);
+  CheckRoundTripResult(std::move(expected_table), exec_context, buf, {},
+                       conversion_options);
 }
 
 TEST(SubstraitRoundTrip, ReadRelWithEmit) {
@@ -2634,8 +2634,8 @@ TEST(SubstraitRoundTrip, ReadRelWithEmit) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(output_schema), std::move(expected_table), exec_context,
-                       buf, {}, conversion_options);
+  CheckRoundTripResult(std::move(expected_table), exec_context, buf, {},
+                       conversion_options);
 }
 
 TEST(SubstraitRoundTrip, FilterRelWithEmit) {
@@ -2752,8 +2752,8 @@ TEST(SubstraitRoundTrip, FilterRelWithEmit) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(output_schema), std::move(expected_table), exec_context,
-                       buf, {}, conversion_options);
+  CheckRoundTripResult(std::move(expected_table), exec_context, buf, {},
+                       conversion_options);
 }
 
 TEST(SubstraitRoundTrip, JoinRel) {
@@ -2902,8 +2902,8 @@ TEST(SubstraitRoundTrip, JoinRel) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(output_schema), std::move(expected_table), exec_context,
-                       buf, {}, conversion_options);
+  CheckRoundTripResult(std::move(expected_table), exec_context, buf, {},
+                       conversion_options);
 }
 
 TEST(SubstraitRoundTrip, JoinRelWithEmit) {
@@ -3054,8 +3054,8 @@ TEST(SubstraitRoundTrip, JoinRelWithEmit) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(output_schema), std::move(expected_table), exec_context,
-                       buf, {}, conversion_options);
+  CheckRoundTripResult(std::move(expected_table), exec_context, buf, {},
+                       conversion_options);
 }
 
 TEST(SubstraitRoundTrip, AggregateRel) {
@@ -3163,8 +3163,8 @@ TEST(SubstraitRoundTrip, AggregateRel) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(output_schema), std::move(expected_table), exec_context,
-                       buf, {}, conversion_options);
+  CheckRoundTripResult(std::move(expected_table), exec_context, buf, {},
+                       conversion_options);
 }
 
 TEST(SubstraitRoundTrip, AggregateRelEmit) {
@@ -3278,8 +3278,8 @@ TEST(SubstraitRoundTrip, AggregateRelEmit) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(output_schema), std::move(expected_table), exec_context,
-                       buf, {}, conversion_options);
+  CheckRoundTripResult(std::move(expected_table), exec_context, buf, {},
+                       conversion_options);
 }
 
 TEST(Substrait, IsthmusPlan) {
@@ -3382,8 +3382,8 @@ TEST(Substrait, IsthmusPlan) {
                                                    /*ignore_unknown_fields=*/false));
 
   auto expected_table = TableFromJSON(test_schema, {"[[2], [3], [6]]"});
-  CheckRoundTripResult(std::move(test_schema), std::move(expected_table),
-                       *compute::default_exec_context(), buf, {}, conversion_options);
+  CheckRoundTripResult(std::move(expected_table), *compute::default_exec_context(), buf,
+                       {}, conversion_options);
 }
 
 TEST(Substrait, ProjectWithMultiFieldExpressions) {
@@ -3536,8 +3536,8 @@ TEST(Substrait, ProjectWithMultiFieldExpressions) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(output_schema), std::move(expected_table), exec_context,
-                       buf, {}, conversion_options);
+  CheckRoundTripResult(std::move(expected_table), exec_context, buf, {},
+                       conversion_options);
 }
 
 TEST(Substrait, NestedProjectWithMultiFieldExpressions) {
@@ -3623,8 +3623,8 @@ TEST(Substrait, NestedProjectWithMultiFieldExpressions) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(output_schema), std::move(expected_table), exec_context,
-                       buf, {}, conversion_options);
+  CheckRoundTripResult(std::move(expected_table), exec_context, buf, {},
+                       conversion_options);
 }
 
 TEST(Substrait, NestedEmitProjectWithMultiFieldExpressions) {
@@ -3711,8 +3711,8 @@ TEST(Substrait, NestedEmitProjectWithMultiFieldExpressions) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(output_schema), std::move(expected_table), exec_context,
-                       buf, {}, conversion_options);
+  CheckRoundTripResult(std::move(expected_table), exec_context, buf, {},
+                       conversion_options);
 }
 
 TEST(Substrait, ReadRelWithGlobFiles) {
@@ -3805,10 +3805,11 @@ TEST(Substrait, ReadRelWithGlobFiles) {
       }
     }]
   })"));
-
+  // To avoid unnecessar meta data columns being included in the final result
+  std::vector<int> include_columns = {0, 1, 2};
   compute::SortOptions options({compute::SortKey("A", compute::SortOrder::Ascending)});
-  CheckRoundTripResult(std::move(dummy_schema), std::move(expected_table), exec_context,
-                       buf, {}, {}, &options);
+  CheckRoundTripResult(std::move(expected_table), exec_context, buf,
+                       std::move(include_columns), {}, &options);
 }
 
 TEST(Substrait, RootRelationOutputNames) {
@@ -3916,8 +3917,8 @@ TEST(Substrait, RootRelationOutputNames) {
 
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
-  CheckRoundTripResult(std::move(output_schema), std::move(expected_table), exec_context,
-                       buf, {}, conversion_options);
+  CheckRoundTripResult(std::move(expected_table), exec_context, buf, {},
+                       conversion_options);
 }
 
 }  // namespace engine


### PR DESCRIPTION
Substrait Plans provide output names in the root relation. This is not completely enabled in the existing Acero-Substrait API and a test case was not there to validate the functionality. To elaborate it's action, a `TableSinkNodeConsumer` is the ideal option. Using this consumer, the PR test shows how the included feature satisfies the requirement. 

PR includes a test case and some minor changes to the existing factories to enable this feature.