### PR TITLE
MINOR: [R] Adapt stringr::str_c mapping for upcoming release

### DIFF
--- a/r/R/dplyr-funcs-string.R
+++ b/r/R/dplyr-funcs-string.R
@@ -196,7 +196,7 @@ register_bindings_string_join <- function() {
         msg = "str_c() with the collapse argument is not yet supported in Arrow"
       )
       if (!inherits(sep, "Expression")) {
-        assert_that(!is.na(sep), msg = "Invalid separator")
+        assert_that(!is.na(sep), msg = "`sep` must be a single string, not `NA`.")
       }
       arrow_string_join_function(NullHandlingBehavior$EMIT_NULL)(..., sep)
     },

--- a/r/R/dplyr-funcs-string.R
+++ b/r/R/dplyr-funcs-string.R
@@ -195,6 +195,9 @@ register_bindings_string_join <- function() {
         is.null(collapse),
         msg = "str_c() with the collapse argument is not yet supported in Arrow"
       )
+      if (!inherits(sep, "Expression")) {
+        assert_that(!is.na(sep), msg = "Invalid separator")
+      }
       arrow_string_join_function(NullHandlingBehavior$EMIT_NULL)(..., sep)
     },
     notes = "the `collapse` argument is not yet supported"

--- a/r/tests/testthat/test-dplyr-funcs-string.R
+++ b/r/tests/testthat/test-dplyr-funcs-string.R
@@ -143,7 +143,7 @@ test_that("paste, paste0, and str_c", {
   # In next release of stringr (late 2022), str_c also errors
   expect_error(
     call_binding("str_c", x, y, sep = NA_character_),
-    "Invalid separator"
+    "`sep` must be a single string, not `NA`."
   )
 
   # sep passed in dots to paste0 (which doesn't take a sep argument)

--- a/r/tests/testthat/test-dplyr-funcs-string.R
+++ b/r/tests/testthat/test-dplyr-funcs-string.R
@@ -140,12 +140,10 @@ test_that("paste, paste0, and str_c", {
     call_binding("paste", x, y, sep = NA_character_),
     "Invalid separator"
   )
-  # emits null in str_c() (consistent with stringr::str_c())
-  compare_dplyr_binding(
-    .input %>%
-      transmute(str_c(x, y, sep = NA_character_)) %>%
-      collect(),
-    df
+  # In next release of stringr (late 2022), str_c also errors
+  expect_error(
+    call_binding("str_c", x, y, sep = NA_character_),
+    "Invalid separator"
   )
 
   # sep passed in dots to paste0 (which doesn't take a sep argument)


### PR DESCRIPTION
Previously, `str_c(sep = NA)` would just emit `NA`, but in the upcoming stringr release, it will error. 

cc @hadley 