### PR TITLE
ARROW-17771: [Docs][Python] Add the use of CONDA_DLL_SEARCH_MODIFICATION_ENABLE to the docs

### DIFF
--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -558,6 +558,7 @@ Now, we can build pyarrow:
 
    $ pushd arrow\python
    $ set PYARROW_WITH_PARQUET=1
+   $ set CONDA_DLL_SEARCH_MODIFICATION_ENABLE=1
    $ python setup.py build_ext --inplace
    $ popd
 
@@ -565,6 +566,14 @@ Now, we can build pyarrow:
 
    For building pyarrow, the above defined environment variables need to also
    be set. Remember this if to want to re-build ``pyarrow`` after your initial build.
+
+.. note::
+
+   In case you are following this steps and are therefore using Python
+   version < 3.10 together with Conda, then ``CONDA_DLL_SEARCH_MODIFICATION_ENABLE``
+   environment variable needs to be set to ``1``.
+
+   If you are using Python 3.10 or newer then this environment variable is not needed.
 
 Then run the unit tests with:
 

--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -569,11 +569,8 @@ Now, we can build pyarrow:
 
 .. note::
 
-   In case you are following the above steps and are therefore using Python
-   version < 3.10 together with Conda, then ``CONDA_DLL_SEARCH_MODIFICATION_ENABLE``
-   environment variable needs to be set to ``1``.
-
-   If you are using Python 3.10 or newer then this environment variable is not needed.
+   If you are using Conda with Python 3.9 or earlier, you must
+   set ``CONDA_DLL_SEARCH_MODIFICATION_ENABLE=1``.
 
 Then run the unit tests with:
 

--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -569,7 +569,7 @@ Now, we can build pyarrow:
 
 .. note::
 
-   In case you are following this steps and are therefore using Python
+   In case you are following the above steps and are therefore using Python
    version < 3.10 together with Conda, then ``CONDA_DLL_SEARCH_MODIFICATION_ENABLE``
    environment variable needs to be set to ``1``.
 


### PR DESCRIPTION
This PR adds info to the Python dev docs about the need to use `CONDA_DLL_SEARCH_MODIFICATION_ENABLE=1` in Python versions < 3.10.

![Screenshot 2022-10-04 at 09 00 54](https://user-images.githubusercontent.com/16418547/193755270-d289d3b0-55a5-4c70-b2ab-0d6ca3a2ecbe.png)