### PR TITLE
ARROW-17829: [Python] Avoid pandas groupby deprecation warning write_to_dataset

### DIFF
--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -3343,6 +3343,11 @@ def write_to_dataset(table, root_path, partition_cols=None,
             if col in partition_cols:
                 subschema = subschema.remove(subschema.get_field_index(col))
 
+        # ARROW-17829: avoid deprecation warnings for df.groupby
+        # https://github.com/pandas-dev/pandas/issues/42795
+        if len(partition_keys) == 1:
+            partition_keys = partition_keys[0]
+
         for keys, subgroup in data_df.groupby(partition_keys):
             if not isinstance(keys, tuple):
                 keys = (keys,)

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -194,7 +194,7 @@ def multisourcefs(request):
 
     # create one with hive partitioning by color
     mockfs.create_dir('hive_color')
-    for part, chunk in df_d.groupby(["color"]):
+    for part, chunk in df_d.groupby("color"):
         folder = 'hive_color/color={}'.format(*part)
         path = '{}/chunk.parquet'.format(folder)
         mockfs.create_dir(folder)

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -195,7 +195,7 @@ def multisourcefs(request):
     # create one with hive partitioning by color
     mockfs.create_dir('hive_color')
     for part, chunk in df_d.groupby("color"):
-        folder = 'hive_color/color={}'.format(*part)
+        folder = 'hive_color/color={}'.format(part)
         path = '{}/chunk.parquet'.format(folder)
         mockfs.create_dir(folder)
         with mockfs.open_output_stream(path) as out:


### PR DESCRIPTION
This PR is looking at the deprecation warning from Pandas 1.5.0 connected to length 1 tuple used in the `groupby()` operation, see https://github.com/pandas-dev/pandas/issues/42795.

Currently we use `groupby` operation with a length 1 tuple in:
- `multisourcefs()` fixture in `test_dataset.py`:
https://github.com/apache/arrow/blob/466018084861f86a9171803c6d689e9c1c1efb5a/python/pyarrow/tests/test_dataset.py#L197
- `write_to_dataset()` in `pyarrow/parquet/core.py`:
https://github.com/apache/arrow/blob/466018084861f86a9171803c6d689e9c1c1efb5a/python/pyarrow/parquet/core.py#L3346-L3348

This PR fixes the the test and adds a check in `parquet/core.py` to avoid the warning.