### PR TITLE
ARROW-16211: [C++][Python] Unregister compute functions

### DIFF
--- a/python/pyarrow/_compute.pxd
+++ b/python/pyarrow/_compute.pxd
@@ -27,6 +27,12 @@ cdef class ScalarUdfContext(_Weakrefable):
 
     cdef void init(self, const CScalarUdfContext& c_context)
 
+cdef class FunctionRegistry(_Weakrefable):
+    cdef:
+        CFunctionRegistry* registry
+    
+    cdef void init(self, const unique_ptr[CFunctionRegistry]& registry)
+
 cdef class FunctionOptions(_Weakrefable):
     cdef:
         shared_ptr[CFunctionOptions] wrapped

--- a/python/pyarrow/_compute.pxd
+++ b/python/pyarrow/_compute.pxd
@@ -30,8 +30,6 @@ cdef class ScalarUdfContext(_Weakrefable):
 cdef class FunctionRegistry(_Weakrefable):
     cdef:
         CFunctionRegistry* registry
-    
-    cdef void init(self, const unique_ptr[CFunctionRegistry]& registry)
 
 cdef class FunctionOptions(_Weakrefable):
     cdef:

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -525,19 +525,6 @@ def function_registry():
     return _global_func_registry
 
 
-def make_registry(parent):
-    cdef:
-        FunctionRegistry new_rg
-        FunctionRegistry parent_rg
-    if parent is None:
-        return function_registry()
-    else:
-        parent_rg = <FunctionRegistry>(parent)
-        new_rg = FunctionRegistry.__new__(FunctionRegistry)
-        new_rg.registry = CFunctionRegistry.Make(parent_rg.registry).release()
-        return new_rg
-
-
 def get_function(name):
     """
     Get a function by name.
@@ -2581,6 +2568,12 @@ def register_scalar_function(func, function_name, function_doc, in_types,
         arity.
     out_type : DataType
         Output type of the function.
+    registry: FunctionRegistry
+        FunctionRegistry with which the function will be registered.
+        The default value is set to the global function registry.
+        This is an optional feature to allow grouping functions into
+        different registeries to enable removing functions if they 
+        are not intended to be used further.
 
     Examples
     --------

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -75,6 +75,7 @@ from pyarrow._compute import (  # noqa
     # Functions
     call_function,
     function_registry,
+    make_registry,
     get_function,
     list_functions,
     _group_by,

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -75,7 +75,6 @@ from pyarrow._compute import (  # noqa
     # Functions
     call_function,
     function_registry,
-    make_registry,
     get_function,
     list_functions,
     _group_by,

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1955,6 +1955,10 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
             const c_string& name) const
         vector[c_string] GetFunctionNames() const
         int num_functions() const
+        
+        @staticmethod
+        unique_ptr[CFunctionRegistry] Make(CFunctionRegistry* parent)
+
 
     CFunctionRegistry* GetFunctionRegistry()
 
@@ -2762,6 +2766,7 @@ cdef extern from "arrow/python/udf.h" namespace "arrow::py":
     cdef cppclass CScalarUdfContext" arrow::py::ScalarUdfContext":
         CMemoryPool *pool
         int64_t batch_length
+        CFunctionRegistry *registry
 
     cdef cppclass CScalarUdfOptions" arrow::py::ScalarUdfOptions":
         c_string func_name
@@ -2769,6 +2774,7 @@ cdef extern from "arrow/python/udf.h" namespace "arrow::py":
         CFunctionDoc func_doc
         vector[shared_ptr[CDataType]] input_types
         shared_ptr[CDataType] output_type
+        CFunctionRegistry* registry
 
     CStatus RegisterScalarFunction(PyObject* function,
                                    function[CallbackUdf] wrapper, const CScalarUdfOptions& options)

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1955,10 +1955,9 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
             const c_string& name) const
         vector[c_string] GetFunctionNames() const
         int num_functions() const
-        
+
         @staticmethod
         unique_ptr[CFunctionRegistry] Make(CFunctionRegistry* parent)
-
 
     CFunctionRegistry* GetFunctionRegistry()
 

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1853,6 +1853,7 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
         CExecContext()
         CExecContext(CMemoryPool* pool)
         CExecContext(CMemoryPool* pool, CExecutor* exc)
+        CExecContext(CMemoryPool* pool, CExecutor* exc, CFunctionRegistry* rgr)
 
         CMemoryPool* memory_pool() const
         CExecutor* executor()

--- a/python/pyarrow/src/arrow/python/udf.cc
+++ b/python/pyarrow/src/arrow/python/udf.cc
@@ -115,8 +115,7 @@ Status RegisterScalarFunction(PyObject* user_function, ScalarUdfWrapperCallback 
   kernel.mem_allocation = compute::MemAllocation::NO_PREALLOCATE;
   kernel.null_handling = compute::NullHandling::COMPUTED_NO_PREALLOCATE;
   RETURN_NOT_OK(scalar_func->AddKernel(std::move(kernel)));
-  auto registry = compute::GetFunctionRegistry();
-  RETURN_NOT_OK(registry->AddFunction(std::move(scalar_func)));
+  RETURN_NOT_OK(options.registry->AddFunction(std::move(scalar_func)));
   return Status::OK();
 }
 

--- a/python/pyarrow/src/arrow/python/udf.h
+++ b/python/pyarrow/src/arrow/python/udf.h
@@ -39,6 +39,7 @@ struct ARROW_PYTHON_EXPORT ScalarUdfOptions {
   compute::FunctionDoc func_doc;
   std::vector<std::shared_ptr<DataType>> input_types;
   std::shared_ptr<DataType> output_type;
+  compute::FunctionRegistry* registry;
 };
 
 /// \brief A context passed as the first argument of scalar UDF functions.

--- a/python/pyarrow/tests/test_udf.py
+++ b/python/pyarrow/tests/test_udf.py
@@ -504,3 +504,30 @@ def test_input_lifetime(unary_func_fixture):
     # Calling a UDF should not have kept `v` alive longer than required
     v = None
     assert proxy_pool.bytes_allocated() == 0
+
+def test_function_registry():
+    def f1(ctx, x):
+        return pc.call_function("add", [x, 1],
+                                memory_pool=ctx.memory_pool)
+    func_name = "f1"
+    unary_doc = {"summary": "add function",
+                 "description": "test add function"}
+    default_registry = pc.function_registry()
+    registry1 = pc.make_registry(default_registry)
+    
+    print(type(registry1))
+    print(registry1.get_function("add"))
+    # pc.register_scalar_function(f1,
+    #                             func_name,
+    #                             unary_doc,
+    #                             {"array": pa.int64()},
+    #                             pa.int64(),
+    #                             registry1)
+    
+    # assert pc.get_function(func_name).name == func_name
+    
+    # parent_registry = None
+    
+    # print(pc.get_function(func_name))
+    
+    


### PR DESCRIPTION
This PR includes a modification to the function registry usage in existing UDF implementation. This allows users to create functions in a given function registry by leveraging the nested function registry approach introduced before. This provides the ability to isolate a group of functions for a defined registry. When functions needs to be removed, deleting the registry including those functions would remove the functions too. 

This is not exactly unregistering functions, but a different approach which serves the same purpose. 