### PR TITLE
MINOR: [C++][Docs] Fixing a typo in scanner MaterializedFields function docs

### DIFF
--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -123,7 +123,7 @@ struct ARROW_DS_EXPORT ScanOptions {
   /// filter expression. Examples:
   ///
   /// - `SELECT a, b WHERE a < 2 && c > 1` => ["a", "b", "a", "c"]
-  /// - `SELECT a + b < 3 WHERE a > 1` => ["a", "b"]
+  /// - `SELECT a + b < 3 WHERE a > 1` => ["a", "b", "a"]
   ///
   /// This is needed for expression where a field may not be directly
   /// used in the final projection but is still required to evaluate the


### PR DESCRIPTION
There is a typo in the one of the expressions and fixed in this PR.