### PR TITLE
ARROW-17930: [CI][C++] Valgrind failure in PrintValue<arrow::dataset::ScannerTestParams>

### DIFF
--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -429,6 +429,12 @@ struct ScannerTestParams {
   }
 };
 
+std::ostream& operator<<(std::ostream& out, const ScannerTestParams& params) {
+  out << (params.slow ? "slow-" : "fast-") << params.num_fragments << "f-"
+      << params.num_batches << "b";
+  return out;
+}
+
 constexpr int kRowsPerTestBatch = 1024;
 
 std::shared_ptr<Schema> ScannerTestSchema() {


### PR DESCRIPTION
Addresses [ARROW-17930](https://issues.apache.org/jira/browse/ARROW-17930).

Not terribly obvious, but this seems to fix the issue.