### PR TITLE
ARROW-17240: [CI][Release] Verify wheels in nightly CI

### DIFF
--- a/ci/docker/almalinux-8-verify-rc.dockerfile
+++ b/ci/docker/almalinux-8-verify-rc.dockerfile
@@ -18,40 +18,7 @@
 ARG arch=amd64
 FROM ${arch}/almalinux:8
 
-# A script to install dependencies required for release
-# verification Red Hat Enterprise Linux 8 clones in particular
-# on AlmaLinux 8 and Rocky Linux 8
-
-RUN dnf -y install 'dnf-command(config-manager)' && \
-    dnf config-manager --set-enabled powertools && \
-    dnf -y update && \
-    dnf -y module disable nodejs && \
-    dnf -y module enable nodejs:16 && \
-    dnf -y module disable ruby && \
-    dnf -y module enable ruby:2.7 && \
-    dnf -y groupinstall "Development Tools" && \
-    dnf -y install \
-        cmake \
-        git \
-        gobject-introspection-devel \
-        java-1.8.0-openjdk-devel \
-        libcurl-devel \
-        llvm-devel \
-        llvm-toolset \
-        maven \
-        ncurses-devel \
-        ninja-build \
-        nodejs \
-        openssl-devel \
-        python38-devel \
-        python38-pip \
-        ruby-devel \
-        sqlite-devel \
-        wget \
-        which && \
+COPY dev/release/setup-rhel-rebuilds.sh /
+RUN /setup-rhel-rebuilds.sh && \
+    rm /setup-rhel-rebuilds.sh && \
     dnf -y clean all
-
-RUN python3 -m pip install -U pip && \
-    alternatives --set python /usr/bin/python3
-
-RUN npm install -g yarn

--- a/dev/release/setup-rhel-rebuilds.sh
+++ b/dev/release/setup-rhel-rebuilds.sh
@@ -21,6 +21,8 @@
 # verification Red Hat Enterprise Linux 8 clones in particular
 # on AlmaLinux 8 and Rocky Linux 8
 
+set -exu
+
 dnf -y install 'dnf-command(config-manager)'
 dnf config-manager --set-enabled powertools
 dnf -y update
@@ -49,5 +51,8 @@ dnf -y install \
   vala-devel \
   wget \
   which
+
 npm install -g yarn
+
+python3 -m pip install -U pip
 alternatives --set python /usr/bin/python3

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -1089,7 +1089,7 @@ test_wheels() {
 
   local wheels_dir=
   if [ "${SOURCE_KIND}" = "local" ]; then
-    wheels_dir="${ARROW_SOURCE_DIR}/binaries/wheels"
+    wheels_dir="${ARROW_SOURCE_DIR}/python/repaired_wheels"
   else
     local download_dir=${ARROW_TMPDIR}/binaries
     mkdir -p ${download_dir}

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -1014,7 +1014,7 @@ test_linux_wheels() {
     local arch="x86_64"
   fi
 
-  local python_versions="3.7m 3.8 3.9 3.10"
+  local python_versions="${TEST_PYTHON_VERSIONS:-3.7m 3.8 3.9 3.10}"
   local platform_tags="manylinux_2_17_${arch}.manylinux2014_${arch}"
 
   for python in ${python_versions}; do
@@ -1087,23 +1087,31 @@ test_wheels() {
   show_header "Downloading Python wheels"
   maybe_setup_conda python || exit 1
 
-  local download_dir=${ARROW_TMPDIR}/binaries
-  mkdir -p ${download_dir}
-
-  if [ "$(uname)" == "Darwin" ]; then
-    local filter_regex=.*macosx.*
+  local wheels_dir=
+  if [ "${SOURCE_KIND}" = "local" ]; then
+    wheels_dir="${ARROW_SOURCE_DIR}/binaries/wheels"
   else
-    local filter_regex=.*manylinux.*
+    local download_dir=${ARROW_TMPDIR}/binaries
+    mkdir -p ${download_dir}
+
+    if [ "$(uname)" == "Darwin" ]; then
+      local filter_regex=.*macosx.*
+    else
+      local filter_regex=.*manylinux.*
+    fi
+
+    ${PYTHON:-python3} \
+      $SOURCE_DIR/download_rc_binaries.py $VERSION $RC_NUMBER \
+      --package_type python \
+      --regex=${filter_regex} \
+      --dest=${download_dir}
+
+    verify_dir_artifact_signatures ${download_dir}
+
+    wheels_dir=${download_dir}/python-rc/${VERSION}-rc${RC_NUMBER}
   fi
 
-  ${PYTHON:-python3} $SOURCE_DIR/download_rc_binaries.py $VERSION $RC_NUMBER \
-         --package_type python \
-         --regex=${filter_regex} \
-         --dest=${download_dir}
-
-  verify_dir_artifact_signatures ${download_dir}
-
-  pushd ${download_dir}/python-rc/${VERSION}-rc${RC_NUMBER}
+  pushd ${wheels_dir}
 
   if [ "$(uname)" == "Darwin" ]; then
     test_macos_wheels

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -1023,7 +1023,7 @@ test_linux_wheels() {
       show_header "Testing Python ${pyver} wheel for platform ${platform}"
       CONDA_ENV=wheel-${pyver}-${platform} PYTHON_VERSION=${pyver} maybe_setup_conda || exit 1
       VENV_ENV=wheel-${pyver}-${platform} PYTHON_VERSION=${pyver} maybe_setup_virtualenv || continue
-      pip install pyarrow-${VERSION}-cp${pyver/.}-cp${python/.}-${platform}.whl
+      pip install pyarrow-${TEST_PYARROW_VERSION:-${VERSION}}-cp${pyver/.}-cp${python/.}-${platform}.whl
       INSTALL_PYARROW=OFF ARROW_GCS=${check_gcs} ${ARROW_DIR}/ci/scripts/python_wheel_unix_test.sh ${ARROW_SOURCE_DIR}
     done
   done

--- a/dev/tasks/python-wheels/github.linux.amd64.yml
+++ b/dev/tasks/python-wheels/github.linux.amd64.yml
@@ -21,7 +21,7 @@
 
 jobs:
   build:
-    name: "Build wheels for manylinux {{ manylinux_version }}"
+    name: "Build wheel for manylinux {{ manylinux_version }}"
     runs-on: ubuntu-latest
     env:
       # archery uses these environment variables
@@ -32,17 +32,17 @@ jobs:
       {{ macros.github_checkout_arrow()|indent }}
       {{ macros.github_install_archery()|indent }}
 
-      - name: Build wheels
+      - name: Build wheel
         shell: bash
         run: archery docker run -e SETUPTOOLS_SCM_PRETEND_VERSION={{ arrow.no_rc_version }} python-wheel-manylinux-{{ manylinux_version }}
 
       - uses: actions/upload-artifact@v3
         with:
-          name: wheels
+          name: wheel
           path: arrow/python/repaired_wheels/*.whl
 
       # TODO(kszucs): auditwheel show
-      - name: Test wheels
+      - name: Test wheel
         shell: bash
         run: |
           archery docker run python-wheel-manylinux-test-imports
@@ -61,7 +61,7 @@ jobs:
       {% endif %}
 
   test:
-    name: "Test wheels for manylinux {{ manylinux_version }} on {{ '${{ matrix.distribution }}' }} {{ '${{ matrix.version }}' }}"
+    name: "Test wheel for manylinux {{ manylinux_version }} on {{ '${{ matrix.distribution }}' }} {{ '${{ matrix.version }}' }}"
     needs:
       - build
     runs-on: ubuntu-latest
@@ -100,7 +100,7 @@ jobs:
           echo '${{ matrix.distribution }}=${{ matrix.version }}' | \
             tr 'a-z' 'A-Z' >> $GITHUB_ENV
           mkdir -p arrow/binaries/wheels/
-          mv arrow/python/repaired_wheels/*.whl arrow/binaries/wheels/
+          mv *.whl arrow/binaries/wheels/
           {% endraw %}
       - name: Build wheel
         shell: bash

--- a/dev/tasks/python-wheels/github.linux.amd64.yml
+++ b/dev/tasks/python-wheels/github.linux.amd64.yml
@@ -21,7 +21,7 @@
 
 jobs:
   build:
-    name: "Build wheel for Manylinux {{ manylinux_version }}"
+    name: "Build wheels for manylinux {{ manylinux_version }}"
     runs-on: ubuntu-latest
     env:
       # archery uses these environment variables
@@ -31,14 +31,18 @@ jobs:
     steps:
       {{ macros.github_checkout_arrow()|indent }}
       {{ macros.github_install_archery()|indent }}
-      {{ macros.github_login_dockerhub()|indent }}
 
-      - name: Build wheel
+      - name: Build wheels
         shell: bash
         run: archery docker run -e SETUPTOOLS_SCM_PRETEND_VERSION={{ arrow.no_rc_version }} python-wheel-manylinux-{{ manylinux_version }}
 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: arrow/python/repaired_wheels/*.whl
+
       # TODO(kszucs): auditwheel show
-      - name: Test wheel
+      - name: Test wheels
         shell: bash
         run: |
           archery docker run python-wheel-manylinux-test-imports
@@ -48,9 +52,81 @@ jobs:
       {{ macros.github_upload_gemfury("arrow/python/repaired_wheels/*.whl")|indent }}
 
       {% if arrow.is_default_branch() %}
+      {{ macros.github_login_dockerhub()|indent }}
       - name: Push Docker Image
         shell: bash
         run: |
           archery docker push python-wheel-manylinux-{{ manylinux_version }}
           archery docker push python-wheel-manylinux-test-unittests
+      {% endif %}
+
+  test:
+    name: "Test wheels for manylinux {{ manylinux_version }} on {{ '${{ matrix.distribution }}' }} {{ '${{ matrix.version }}' }}"
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    env:
+      # archery uses these environment variables
+      ARCH: amd64
+      PYTHON: "{{ python_version }}"
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - distribution: conda
+            version: latest
+          - distribution: almalinux
+            version: "8"
+          - distribution: ubuntu
+            version: "18.04"
+          - distribution: ubuntu
+            version: "20.04"
+          - distribution: ubuntu
+            version: "22.04"
+
+    steps:
+      {{ macros.github_checkout_arrow(1, false)|indent }}
+      {{ macros.github_install_archery()|indent }}
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: wheels
+
+      - name: Prepare
+        shell: bash
+        run: |
+          {% raw %}
+          echo '${{ matrix.distribution }}=${{ matrix.version }}' | \
+            tr 'a-z' 'A-Z' >> $GITHUB_ENV
+          mkdir -p arrow/binaries/wheels/
+          mv arrow/python/repaired_wheels/*.whl arrow/binaries/wheels/
+          {% endraw %}
+      - name: Build wheel
+        shell: bash
+        run: |
+          {% raw %}
+          case "${PYTHON}" in
+            3.7)
+              python_version=${PYTHON}m
+              ;;
+            *)
+              python_version=${PYTHON}
+              ;;
+          esac
+          archery docker run \
+            -e TEST_DEFAULT=0 \
+            -e TEST_PYTHON_VERSIONS=${python_version} \
+            -e TEST_WHEELS=1 \
+            ${{ matrix.distribution }}-verify-rc
+          {% endraw %}
+
+      {% if arrow.is_default_branch() %}
+      {{ macros.github_login_dockerhub()|indent }}
+      - name: Push Docker Image
+        shell: bash
+        run: |
+          {% raw %}
+          archery docker push ${{ matrix.distribution }}-verify-rc
+          {% endraw %}
       {% endif %}

--- a/dev/tasks/python-wheels/github.linux.amd64.yml
+++ b/dev/tasks/python-wheels/github.linux.amd64.yml
@@ -102,9 +102,10 @@ jobs:
           mkdir -p arrow/binaries/wheels/
           mv *.whl arrow/binaries/wheels/
           {% endraw %}
-      - name: Build wheel
+      - name: Test wheel
         shell: bash
         run: |
+          pyarrow_version={{ arrow.no_rc_version }}
           {% raw %}
           case "${PYTHON}" in
             3.7)
@@ -116,6 +117,7 @@ jobs:
           esac
           archery docker run \
             -e TEST_DEFAULT=0 \
+            -e TEST_PYARROW_VERSION=${pyarrow_version} \
             -e TEST_PYTHON_VERSIONS=${python_version} \
             -e TEST_WHEELS=1 \
             ${{ matrix.distribution }}-verify-rc

--- a/dev/tasks/python-wheels/github.linux.amd64.yml
+++ b/dev/tasks/python-wheels/github.linux.amd64.yml
@@ -91,7 +91,7 @@ jobs:
 
       - uses: actions/download-artifact@v3
         with:
-          name: wheels
+          name: wheel
 
       - name: Prepare
         shell: bash

--- a/dev/tasks/python-wheels/github.linux.amd64.yml
+++ b/dev/tasks/python-wheels/github.linux.amd64.yml
@@ -69,7 +69,7 @@ jobs:
       # archery uses these environment variables
       ARCH: amd64
       PYTHON: "{{ python_version }}"
-    timeout-minutes: 20
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/dev/tasks/python-wheels/github.linux.amd64.yml
+++ b/dev/tasks/python-wheels/github.linux.amd64.yml
@@ -31,6 +31,7 @@ jobs:
     steps:
       {{ macros.github_checkout_arrow()|indent }}
       {{ macros.github_install_archery()|indent }}
+      {{ macros.github_login_dockerhub()|indent }}
 
       - name: Build wheel
         shell: bash
@@ -48,87 +49,83 @@ jobs:
           archery docker run python-wheel-manylinux-test-imports
           archery docker run python-wheel-manylinux-test-unittests
 
+      - name: Test wheel on AlmaLinux 8
+        shell: bash
+        if: |
+          '{{ python_version }}' == '3.8'
+        env:
+          ALMALINUX: "8"
+        run: |
+          archery docker run \
+            -e TEST_DEFAULT=0 \
+            -e TEST_PYARROW_VERSION={{ arrow.no_rc_version }} \
+            -e TEST_PYTHON_VERSIONS={{ python_version }} \
+            -e TEST_WHEELS=1 \
+            almalinux-verify-rc
+
+      - name: Test wheel on Ubuntu 18.04
+        shell: bash
+        if: |
+          '{{ python_version }}' == '3.8'
+        env:
+          UBUNTU: "18.04"
+        run: |
+          archery docker run \
+            -e TEST_DEFAULT=0 \
+            -e TEST_PYARROW_VERSION={{ arrow.no_rc_version }} \
+            -e TEST_PYTHON_VERSIONS={{ python_version }} \
+            -e TEST_WHEELS=1 \
+            ubuntu-verify-rc
+
+      - name: Test wheel on Ubuntu 18.04
+        shell: bash
+        if: |
+          '{{ python_version }}' == '3.8'
+        env:
+          UBUNTU: "18.04"
+        run: |
+          archery docker run \
+            -e TEST_DEFAULT=0 \
+            -e TEST_PYARROW_VERSION={{ arrow.no_rc_version }} \
+            -e TEST_PYTHON_VERSIONS={{ python_version }} \
+            -e TEST_WHEELS=1 \
+            ubuntu-verify-rc
+
+      - name: Test wheel on Ubuntu 20.04
+        shell: bash
+        if: |
+          '{{ python_version }}' == '3.8'
+        env:
+          UBUNTU: "20.04"
+        run: |
+          archery docker run \
+            -e TEST_DEFAULT=0 \
+            -e TEST_PYARROW_VERSION={{ arrow.no_rc_version }} \
+            -e TEST_PYTHON_VERSIONS={{ python_version }} \
+            -e TEST_WHEELS=1 \
+            ubuntu-verify-rc
+
+      - name: Test wheel on Ubuntu 22.04
+        shell: bash
+        if: |
+          '{{ python_version }}' == '3.10'
+        env:
+          UBUNTU: "22.04"
+        run: |
+          archery docker run \
+            -e TEST_DEFAULT=0 \
+            -e TEST_PYARROW_VERSION={{ arrow.no_rc_version }} \
+            -e TEST_PYTHON_VERSIONS={{ python_version }} \
+            -e TEST_WHEELS=1 \
+            ubuntu-verify-rc
+
       {{ macros.github_upload_releases("arrow/python/repaired_wheels/*.whl")|indent }}
       {{ macros.github_upload_gemfury("arrow/python/repaired_wheels/*.whl")|indent }}
 
       {% if arrow.is_default_branch() %}
-      {{ macros.github_login_dockerhub()|indent }}
       - name: Push Docker Image
         shell: bash
         run: |
           archery docker push python-wheel-manylinux-{{ manylinux_version }}
           archery docker push python-wheel-manylinux-test-unittests
-      {% endif %}
-
-  test:
-    name: "Test wheel for manylinux {{ manylinux_version }} on {{ '${{ matrix.distribution }}' }} {{ '${{ matrix.version }}' }}"
-    needs:
-      - build
-    runs-on: ubuntu-latest
-    env:
-      # archery uses these environment variables
-      ARCH: amd64
-      PYTHON: "{{ python_version }}"
-    timeout-minutes: 10
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - distribution: conda
-            version: latest
-          - distribution: almalinux
-            version: "8"
-          - distribution: ubuntu
-            version: "18.04"
-          - distribution: ubuntu
-            version: "20.04"
-          - distribution: ubuntu
-            version: "22.04"
-
-    steps:
-      {{ macros.github_checkout_arrow(1, false)|indent }}
-      {{ macros.github_install_archery()|indent }}
-
-      - uses: actions/download-artifact@v3
-        with:
-          name: wheel
-
-      - name: Prepare
-        shell: bash
-        run: |
-          {% raw %}
-          echo '${{ matrix.distribution }}=${{ matrix.version }}' | \
-            tr 'a-z' 'A-Z' >> $GITHUB_ENV
-          mkdir -p arrow/binaries/wheels/
-          mv *.whl arrow/binaries/wheels/
-          {% endraw %}
-      - name: Test wheel
-        shell: bash
-        run: |
-          pyarrow_version={{ arrow.no_rc_version }}
-          {% raw %}
-          case "${PYTHON}" in
-            3.7)
-              python_version=${PYTHON}m
-              ;;
-            *)
-              python_version=${PYTHON}
-              ;;
-          esac
-          archery docker run \
-            -e TEST_DEFAULT=0 \
-            -e TEST_PYARROW_VERSION=${pyarrow_version} \
-            -e TEST_PYTHON_VERSIONS=${python_version} \
-            -e TEST_WHEELS=1 \
-            ${{ matrix.distribution }}-verify-rc
-          {% endraw %}
-
-      {% if arrow.is_default_branch() %}
-      {{ macros.github_login_dockerhub()|indent }}
-      - name: Push Docker Image
-        shell: bash
-        run: |
-          {% raw %}
-          archery docker push ${{ matrix.distribution }}-verify-rc
-          {% endraw %}
       {% endif %}

--- a/dev/tasks/python-wheels/github.osx.amd64.yml
+++ b/dev/tasks/python-wheels/github.osx.amd64.yml
@@ -33,7 +33,7 @@ env:
 
 jobs:
   build:
-    name: Build wheel for macOS
+    name: Build wheel for Python {{ python_version }} on macOS
     runs-on: macos-latest
     env:
       VCPKG_BINARY_SOURCES: 'clear;nuget,GitHub,readwrite'
@@ -103,6 +103,11 @@ jobs:
           pip install --upgrade pip wheel
           PYTHON=python arrow/ci/scripts/python_wheel_macos_build.sh x86_64 $(pwd)/arrow $(pwd)/build
 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: wheel
+          path: arrow/python/repaired_wheels/*.whl
+
       - name: Test Wheel
         shell: bash
         run: |
@@ -115,3 +120,52 @@ jobs:
 
       {{ macros.github_upload_releases("arrow/python/repaired_wheels/*.whl")|indent }}
       {{ macros.github_upload_gemfury("arrow/python/repaired_wheels/*.whl")|indent }}
+
+  test:
+    {% raw %}
+    name: "Test wheel for macOS on ${{ matrix.runs-on }} (USE_CONDA=${{ matrix.use-conda }})"
+    {% endraw %}
+    needs:
+      - build
+    {% raw %}
+    runs-on: ${{ matrix.runs-on }}
+    {% endraw %}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on:
+          - macos-11
+          - macos-12
+        use-conda:
+          - "0"
+          - "1"
+    steps:
+      {{ macros.github_checkout_arrow(1, false)|indent }}
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: wheel
+
+      - name: Prepare
+        shell: bash
+        run: |
+          mkdir -p arrow/binaries/wheels/
+          mv *.whl arrow/binaries/wheels/
+      - name: Test wheel
+        shell: bash
+        env:
+          TEST_DEFAULT: "0"
+          TEST_PYARROW_VERSION: "{{ arrow.no_rc_version }}"
+          TEST_WHEEL: "1"
+        run: |
+          case "${PYTHON_VERSION}" in
+            3.7)
+              python_version=${PYTHON_VERSION}m
+              ;;
+            *)
+              python_version=${PYTHON_VERSION}
+              ;;
+          esac
+          export TEST_PYTHON_VERSIONS=${python_version}
+          arrow/dev/release/verify-release-candidate.sh

--- a/dev/tasks/python-wheels/github.osx.amd64.yml
+++ b/dev/tasks/python-wheels/github.osx.amd64.yml
@@ -110,50 +110,6 @@ jobs:
 
       - name: Test Wheel
         shell: bash
-        run: |
-          $PYTHON -m venv test-env
-          source test-env/bin/activate
-          pip install --upgrade pip wheel
-          pip install -r arrow/python/requirements-wheel-test.txt
-          PYTHON=python arrow/ci/scripts/install_gcs_testbench.sh default
-          arrow/ci/scripts/python_wheel_unix_test.sh $(pwd)/arrow
-
-      {{ macros.github_upload_releases("arrow/python/repaired_wheels/*.whl")|indent }}
-      {{ macros.github_upload_gemfury("arrow/python/repaired_wheels/*.whl")|indent }}
-
-  test:
-    {% raw %}
-    name: "Test wheel for macOS on ${{ matrix.runs-on }} (USE_CONDA=${{ matrix.use-conda }})"
-    {% endraw %}
-    needs:
-      - build
-    {% raw %}
-    runs-on: ${{ matrix.runs-on }}
-    {% endraw %}
-    timeout-minutes: 10
-    strategy:
-      fail-fast: false
-      matrix:
-        runs-on:
-          - macos-11
-          - macos-12
-        use-conda:
-          - "0"
-          - "1"
-    steps:
-      {{ macros.github_checkout_arrow(1, false)|indent }}
-
-      - uses: actions/download-artifact@v3
-        with:
-          name: wheel
-
-      - name: Prepare
-        shell: bash
-        run: |
-          mkdir -p arrow/binaries/wheels/
-          mv *.whl arrow/binaries/wheels/
-      - name: Test wheel
-        shell: bash
         env:
           TEST_DEFAULT: "0"
           TEST_PYARROW_VERSION: "{{ arrow.no_rc_version }}"
@@ -169,3 +125,6 @@ jobs:
           esac
           export TEST_PYTHON_VERSIONS=${python_version}
           arrow/dev/release/verify-release-candidate.sh
+
+      {{ macros.github_upload_releases("arrow/python/repaired_wheels/*.whl")|indent }}
+      {{ macros.github_upload_gemfury("arrow/python/repaired_wheels/*.whl")|indent }}

--- a/dev/tasks/python-wheels/github.osx.arm64.yml
+++ b/dev/tasks/python-wheels/github.osx.arm64.yml
@@ -39,7 +39,7 @@ env:
 
 jobs:
   build:
-    name: Build wheel for OS X
+    name: Build wheel for Python {{ python_version }} on macOS
     runs-on: ["self-hosted", "macOS", "arm64"]
     steps:
       - name: Cleanup
@@ -127,6 +127,11 @@ jobs:
           mv $fused_wheel arrow/python/repaired_wheels/${fused_wheel/x86_64/universal2}
       {% endif %}
 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: wheel
+          path: arrow/python/repaired_wheels/*.whl
+
       - name: Test Wheel on ARM64
         shell: bash
         env:
@@ -174,3 +179,31 @@ jobs:
           CROSSBOW_GITHUB_TOKEN: {{ "${{ secrets.CROSSBOW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}" }}
 
       {{ macros.github_upload_gemfury("arrow/python/repaired_wheels/*.whl")|indent }}
+
+  test:
+    name: Test wheel for Python {{ python_version }} on macOS
+    needs:
+      - build
+    runs-on: ["self-hosted", "macOS", "arm64"]
+    timeout-minutes: 10
+    steps:
+      {{ macros.github_checkout_arrow(1, false)|indent }}
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: wheel
+
+      - name: Prepare
+        shell: bash
+        run: |
+          mkdir -p arrow/binaries/wheels/
+          mv *.whl arrow/binaries/wheels/
+      - name: Test wheel
+        shell: bash
+        env:
+          TEST_DEFAULT: "0"
+          TEST_WHEEL: "1"
+          TEST_PYARROW_VERSION: "{{ arrow.no_rc_version }}"
+          TEST_PYTHON_VERSIONS: "{{ python_version }}"
+        run: |
+          arrow/dev/release/verify-release-candidate.sh

--- a/dev/tasks/python-wheels/github.osx.arm64.yml
+++ b/dev/tasks/python-wheels/github.osx.arm64.yml
@@ -67,7 +67,7 @@ jobs:
         env:
           VCPKG_DEFAULT_TRIPLET: arm64-osx-static-release
         run: |
-            vcpkg install \
+          vcpkg install \
             --clean-after-build \
             --x-install-root=${VCPKG_ROOT}/installed \
             --x-manifest-root=arrow/ci/vcpkg \
@@ -85,14 +85,14 @@ jobs:
           $PYTHON -m venv build-arm64-env
           source build-arm64-env/bin/activate
           pip install --upgrade pip wheel
-           arrow/ci/scripts/python_wheel_macos_build.sh arm64 $(pwd)/arrow $(pwd)/build
+          arrow/ci/scripts/python_wheel_macos_build.sh arm64 $(pwd)/arrow $(pwd)/build
 
       {% if arch == "universal2" %}
       - name: Install AMD64 Packages
         env:
           VCPKG_DEFAULT_TRIPLET: amd64-osx-static-release
         run: |
-            vcpkg install \
+          vcpkg install \
             --clean-after-build \
             --x-install-root=${VCPKG_ROOT}/installed \
             --x-manifest-root=arrow/ci/vcpkg \
@@ -169,41 +169,13 @@ jobs:
           source crossbow-env/bin/activate
           arch -x86_64 pip install -e arrow/dev/archery[crossbow-upload]
           arch -x86_64 archery crossbow \
-          --queue-path $(pwd) \
-          --queue-remote {{ queue_remote_url }} \
-          upload-artifacts \
-          --sha {{ task.branch }} \
-          --tag {{ task.tag }} \
-          "arrow/python/repaired_wheels/*.whl"
+            --queue-path $(pwd) \
+            --queue-remote {{ queue_remote_url }} \
+            upload-artifacts \
+            --sha {{ task.branch }} \
+            --tag {{ task.tag }} \
+            "arrow/python/repaired_wheels/*.whl"
         env:
           CROSSBOW_GITHUB_TOKEN: {{ "${{ secrets.CROSSBOW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}" }}
 
       {{ macros.github_upload_gemfury("arrow/python/repaired_wheels/*.whl")|indent }}
-
-  test:
-    name: Test wheel for Python {{ python_version }} on macOS
-    needs:
-      - build
-    runs-on: ["self-hosted", "macOS", "arm64"]
-    timeout-minutes: 10
-    steps:
-      {{ macros.github_checkout_arrow(1, false)|indent }}
-
-      - uses: actions/download-artifact@v3
-        with:
-          name: wheel
-
-      - name: Prepare
-        shell: bash
-        run: |
-          mkdir -p arrow/binaries/wheels/
-          mv *.whl arrow/binaries/wheels/
-      - name: Test wheel
-        shell: bash
-        env:
-          TEST_DEFAULT: "0"
-          TEST_WHEEL: "1"
-          TEST_PYARROW_VERSION: "{{ arrow.no_rc_version }}"
-          TEST_PYTHON_VERSIONS: "{{ python_version }}"
-        run: |
-          arrow/dev/release/verify-release-candidate.sh

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1074,15 +1074,6 @@ tasks:
     params:
       github_runner: "macos-{{ macos_version }}"
       target: "wheels"
-
-  verify-rc-binaries-wheels-macos-{{ macos_version }}-amd64-conda:
-    ci: github
-    template: verify-rc/github.macos.amd64.yml
-    params:
-      env:
-        USE_CONDA: 1
-      github_runner: "macos-{{ macos_version }}"
-      target: "wheels"
   {% endfor %}
 
   verify-rc-binaries-wheels-macos-11-arm64:

--- a/dev/tasks/verify-rc/github.linux.amd64.docker.yml
+++ b/dev/tasks/verify-rc/github.linux.amd64.docker.yml
@@ -21,7 +21,7 @@
 
 jobs:
   test:
-    name: "Verify release candidate {{ distro }} source"
+    name: "Verify release candidate {{ distro }} {{ target }}"
     runs-on: ubuntu-latest
     {% if env is defined %}
     env:


### PR DESCRIPTION
.deb and .rpm are already verified by the same verification scripts (dev/release/verify-apt.sh and dev/release/verify-yum.sh) but .whl aren't yet.