### PR TITLE
ARROW-16212: [C++][Python] Register Multiple Kernels for a UDF

### DIFF
--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2647,8 +2647,8 @@ def register_scalar_function(func, function_name, function_doc, in_arg_types,
     ...     return pc.add(array, 1, memory_pool=ctx.memory_pool)
     >>>
     >>> func_name = "py_add_func"
-    >>> in_types = {"array": pa.int64()}
-    >>> out_type = pa.int64()
+    >>> in_types = [{"array": pa.int64()}]
+    >>> out_type = [pa.int64()]
     >>> pc.register_scalar_function(add_constant, func_name, func_doc,
     ...                   in_types, out_type)
     >>>

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2683,7 +2683,7 @@ def register_scalar_function(func, function_name, function_doc, in_arg_types,
     num_args = -1
     if not isinstance(in_arg_types, list):
         raise TypeError(
-            "in_arg_types must be a list of dictionaries of DataTypes")
+            "in_arg_types must be a list of dictionaries of DataType")
     if not isinstance(out_types, list):
         raise TypeError("out_types must be a list of DataTypes")
     # each input_type dict in input_types list must
@@ -2693,7 +2693,7 @@ def register_scalar_function(func, function_name, function_doc, in_arg_types,
         num_args = len(in_arg_types[0])
     else:
         raise TypeError(
-            "Elements in in_arg_types must be a dictionary of DataTypes")
+            "Elements in in_arg_types must be a dictionary of DataType")
 
     for in_types in in_arg_types:
         if isinstance(in_types, dict):
@@ -2702,7 +2702,7 @@ def register_scalar_function(func, function_name, function_doc, in_arg_types,
                     pyarrow_unwrap_data_type(ensure_type(in_type)))
         else:
             raise TypeError(
-                "in_types must be a dictionary of DataType")
+                "Elements in in_arg_types must be a dictionary of DataType")
         vec_c_in_types.push_back(move(c_in_types))
 
     c_arity = CArity(<int> num_args, func_spec.varargs)
@@ -2719,10 +2719,6 @@ def register_scalar_function(func, function_name, function_doc, in_arg_types,
     c_func_doc = _make_function_doc(function_doc)
     for out_type in out_types:
         c_out_types.push_back(pyarrow_unwrap_data_type(ensure_type(out_type)))
-
-    print("out types : ", len(out_types))
-    print("in types : ", vec_c_in_types.size())
-    print("in types : ", vec_c_in_types.at(0).size())
 
     c_options.func_name = c_func_name
     c_options.arity = c_arity

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2685,7 +2685,7 @@ def register_scalar_function(func, function_name, function_doc, in_arg_types,
         raise TypeError(
             "in_arg_types must be a list of dictionaries of DataType")
     if not isinstance(out_types, list):
-        raise TypeError("out_types must be a list of DataTypes")
+        raise TypeError("out_types must be a list of DataType")
     # each input_type dict in input_types list must
     # have same arg_names
     if isinstance(in_arg_types[0], dict):

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2632,7 +2632,9 @@ def register_scalar_function(func, function_name, function_doc, in_arg_types,
         arguments specified here determines the function
         arity.
     out_types : List[DataType]
-        Output types of the function.
+        A list of output types of the function.
+        Corresponding to the input types, the output type of
+        the function can be varied.
 
     Examples
     --------

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2814,8 +2814,8 @@ cdef extern from "arrow/python/udf.h" namespace "arrow::py":
         c_string func_name
         CArity arity
         CFunctionDoc func_doc
-        vector[shared_ptr[CDataType]] input_types
-        shared_ptr[CDataType] output_type
+        vector[vector[shared_ptr[CDataType]]] input_arg_types
+        vector[shared_ptr[CDataType]] output_types
 
     CStatus RegisterScalarFunction(PyObject* function,
                                    function[CallbackUdf] wrapper, const CScalarUdfOptions& options)

--- a/python/pyarrow/src/arrow/python/udf.cc
+++ b/python/pyarrow/src/arrow/python/udf.cc
@@ -107,7 +107,7 @@ Status RegisterScalarFunction(PyObject* user_function, ScalarUdfWrapperCallback 
     return Status::Invalid("input_arg_types and output_types should be equal in size");
   }
   // adding kernels
-  for(size_t idx=0 ; idx < num_kernels; idx++) {
+  for(size_t idx=0; idx < num_kernels; idx++) {
     const auto& opt_input_types = options.input_arg_types[idx];
     std::vector<compute::InputType> input_types;
     for (const auto& in_dtype : opt_input_types) {

--- a/python/pyarrow/src/arrow/python/udf.cc
+++ b/python/pyarrow/src/arrow/python/udf.cc
@@ -18,7 +18,6 @@
 #include "arrow/python/udf.h"
 #include "arrow/compute/function.h"
 #include "arrow/python/common.h"
-#include "arrow/util/logging.h"
 
 namespace arrow {
 

--- a/python/pyarrow/src/arrow/python/udf.cc
+++ b/python/pyarrow/src/arrow/python/udf.cc
@@ -113,7 +113,7 @@ Status RegisterScalarFunction(PyObject* user_function, ScalarUdfWrapperCallback 
     for (const auto& in_dtype : opt_input_types) {
       input_types.emplace_back(in_dtype);
     }
-    const auto opts_out_type = options.output_types[idx];
+    const auto& opts_out_type = options.output_types[idx];
     compute::OutputType output_type(opts_out_type);
     auto udf_data = std::make_shared<PythonUdf>(
       wrapper, std::make_shared<OwnedRefNoGIL>(user_function), opts_out_type);

--- a/python/pyarrow/src/arrow/python/udf.h
+++ b/python/pyarrow/src/arrow/python/udf.h
@@ -37,8 +37,8 @@ struct ARROW_PYTHON_EXPORT ScalarUdfOptions {
   std::string func_name;
   compute::Arity arity;
   compute::FunctionDoc func_doc;
-  std::vector<std::shared_ptr<DataType>> input_types;
-  std::shared_ptr<DataType> output_type;
+  std::vector<std::vector<std::shared_ptr<DataType>>> input_arg_types;
+  std::vector<std::shared_ptr<DataType>> output_types;
 };
 
 /// \brief A context passed as the first argument of scalar UDF functions.

--- a/python/pyarrow/tests/test_udf.py
+++ b/python/pyarrow/tests/test_udf.py
@@ -337,7 +337,7 @@ def test_registration_errors():
                                     None)
 
     # validate input type
-    expected_expr = "in_arg_types must be a list of dictionaries of DataTypes"
+    expected_expr = "in_arg_types must be a list of dictionaries of DataType"
     with pytest.raises(TypeError, match=expected_expr):
         pc.register_scalar_function(test_reg_function,
                                     "test_input_function", doc, None,
@@ -509,15 +509,12 @@ def test_input_lifetime(unary_func_fixture):
 
 
 def test_multi_kernel_registration():
-    """
-    Register a unary scalar function.
-    """
     def unary_function(ctx, x):
         return pc.cast(pc.call_function("multiply", [x, 2],
                                         memory_pool=ctx.memory_pool), x.type)
-    func_name = "y=x*1"
-    unary_doc = {"summary": "add function",
-                 "description": "test add function"}
+    func_name = "y=x*2"
+    unary_doc = {"summary": "multiply by two function",
+                 "description": "test multiply function"}
     input_types = [
         {"array": pa.int8()},
         {"array": pa.int16()},
@@ -548,28 +545,20 @@ def test_multi_kernel_registration():
 
 
 def test_invalid_multi_kernel_registration():
-    """
-    Register a unary scalar function.
-    """
     def unary_function(ctx, x):
-        return pc.cast(pc.call_function("multiply", [x, 2],
-                                        memory_pool=ctx.memory_pool), x.type)
-    func_name = "y=x*1"
-    unary_doc = {"summary": "add function",
-                 "description": "test add function"}
+        return x
+    func_name = "y=x"
+    unary_doc = {"summary": "pass value function",
+                 "description": "test function"}
     input_types = [
         {"array": pa.int8()},
-        {"array": pa.int16()},
-        {"array": pa.float32()},
-        {"array": pa.float64()}
+        {"array": pa.int16()}
     ]
 
     output_types = [
         pa.int8(),
         pa.int16(),
-        pa.int64(),
-        pa.float32(),
-        pa.float64()
+        pa.int64()
     ]
     error_msg = "input_arg_types and output_types should be equal in size"
     with pytest.raises(pa.lib.ArrowInvalid, match=error_msg):

--- a/python/pyarrow/tests/test_udf.py
+++ b/python/pyarrow/tests/test_udf.py
@@ -350,7 +350,7 @@ def test_registration_errors():
                                     in_names, None)
 
     # validate input type
-    expected_expr = "in_arg_types must be a list of DataType"
+    expected_expr = "in_arg_types must be a list of list of DataType"
     with pytest.raises(TypeError, match=expected_expr):
         pc.register_scalar_function(test_reg_function,
                                     "test_input_function", doc, None,

--- a/python/pyarrow/tests/test_udf.py
+++ b/python/pyarrow/tests/test_udf.py
@@ -325,8 +325,8 @@ def test_registration_errors():
         "summary": "test udf input",
         "description": "parameters are validated"
     }
-    in_types = [[pa.int64()]]
-    in_names = ["scalar"]
+    in_types = []
+    in_names = []
     out_types = [pa.int64()]
 
     def test_reg_function(context):
@@ -334,7 +334,7 @@ def test_registration_errors():
 
     with pytest.raises(TypeError):
         pc.register_scalar_function(test_reg_function,
-                                    None, doc, in_types,
+                                    None, doc, in_types, in_names,
                                     out_types)
 
     # validate function
@@ -367,6 +367,25 @@ def test_registration_errors():
     with pytest.raises(KeyError, match=expected_expr):
         pc.register_scalar_function(test_reg_function,
                                     "test_reg_function", doc, [[]], [],
+                                    out_types)
+
+    # mismatching input_types and input_names
+
+    doc = {
+        "summary": "test udf input types and names",
+        "description": "parameters are validated"
+    }
+    in_types = [[pa.int64()]]
+    in_names = ["a1", "a2"]
+    out_types = [pa.int64()]
+
+    def test_inputs_function(context, a1):
+        return pc.add(a1, a1)
+    expected_expr = "in_arg_names and input types per kernel must contain same " \
+        + "number of elements"
+    with pytest.raises(ValueError, match=expected_expr):
+        pc.register_scalar_function(test_inputs_function,
+                                    "test_inputs_function", doc, in_types, in_names,
                                     out_types)
 
 

--- a/python/pyarrow/tests/test_udf.py
+++ b/python/pyarrow/tests/test_udf.py
@@ -330,7 +330,7 @@ def test_registration_errors():
                                     out_types)
 
     # validate output type
-    expected_expr = "out_types must be a list of DataTypes"
+    expected_expr = "out_types must be a list of DataType"
     with pytest.raises(TypeError, match=expected_expr):
         pc.register_scalar_function(test_reg_function,
                                     "test_output_function", doc, in_types,

--- a/python/pyarrow/tests/test_udf.py
+++ b/python/pyarrow/tests/test_udf.py
@@ -325,7 +325,7 @@ def test_registration_errors():
         "summary": "test udf input",
         "description": "parameters are validated"
     }
-    in_types = []
+    in_types = [[]]
     in_names = []
     out_types = [pa.int64()]
 

--- a/python/pyarrow/tests/test_udf.py
+++ b/python/pyarrow/tests/test_udf.py
@@ -381,12 +381,12 @@ def test_registration_errors():
 
     def test_inputs_function(context, a1):
         return pc.add(a1, a1)
-    expected_expr = "in_arg_names and input types per kernel must contain same " \
-        + "number of elements"
+    expected_expr = "in_arg_names and input types per kernel " \
+        + "must contain same number of elements"
     with pytest.raises(ValueError, match=expected_expr):
         pc.register_scalar_function(test_inputs_function,
-                                    "test_inputs_function", doc, in_types, in_names,
-                                    out_types)
+                                    "test_inputs_function", doc,
+                                    in_types, in_names, out_types)
 
 
 def test_varargs_function_validation(varargs_func_fixture):

--- a/python/pyarrow/tests/test_udf.py
+++ b/python/pyarrow/tests/test_udf.py
@@ -54,8 +54,8 @@ def unary_func_fixture():
     pc.register_scalar_function(unary_function,
                                 func_name,
                                 unary_doc,
-                                {"array": pa.int64()},
-                                pa.int64())
+                                [{"array": pa.int64()}],
+                                [pa.int64()])
     return unary_function, func_name
 
 
@@ -73,10 +73,12 @@ def binary_func_fixture():
     pc.register_scalar_function(binary_function,
                                 func_name,
                                 binary_doc,
-                                {"m": pa.int64(),
-                                 "x": pa.int64(),
-                                 },
-                                pa.int64())
+                                [
+                                    {"m": pa.int64(),
+                                     "x": pa.int64(),
+                                     }
+                                ],
+                                [pa.int64()])
     return binary_function, func_name
 
 
@@ -96,12 +98,12 @@ def ternary_func_fixture():
     pc.register_scalar_function(ternary_function,
                                 func_name,
                                 ternary_doc,
-                                {
+                                [{
                                     "array1": pa.int64(),
                                     "array2": pa.int64(),
                                     "array3": pa.int64(),
-                                },
-                                pa.int64())
+                                }],
+                                [pa.int64()])
     return ternary_function, func_name
 
 
@@ -123,11 +125,11 @@ def varargs_func_fixture():
     pc.register_scalar_function(varargs_function,
                                 func_name,
                                 varargs_doc,
-                                {
+                                [{
                                     "array1": pa.int64(),
                                     "array2": pa.int64(),
-                                },
-                                pa.int64())
+                                }],
+                                [pa.int64()])
     return varargs_function, func_name
 
 
@@ -148,8 +150,8 @@ def nullary_func_fixture():
     pc.register_scalar_function(nullary_func,
                                 func_name,
                                 func_doc,
-                                {},
-                                pa.int64())
+                                [{}],
+                                [pa.int64()])
 
     return nullary_func, func_name
 
@@ -164,14 +166,14 @@ def wrong_output_type_func_fixture():
         return 42
 
     func_name = "test_wrong_output_type"
-    in_types = {}
-    out_type = pa.int64()
+    in_types = [{}]
+    out_types = [pa.int64()]
     doc = {
         "summary": "return wrong output type",
         "description": ""
     }
     pc.register_scalar_function(wrong_output_type, func_name, doc,
-                                in_types, out_type)
+                                in_types, out_types)
     return wrong_output_type, func_name
 
 
@@ -184,15 +186,15 @@ def wrong_output_datatype_func_fixture():
     def wrong_output_datatype(ctx, array):
         return pc.call_function("add", [array, 1])
     func_name = "test_wrong_output_datatype"
-    in_types = {"array": pa.int64()}
+    in_types = [{"array": pa.int64()}]
     # The actual output DataType will be int64.
-    out_type = pa.int16()
+    out_types = [pa.int16()]
     doc = {
         "summary": "return wrong output datatype",
         "description": ""
     }
     pc.register_scalar_function(wrong_output_datatype, func_name, doc,
-                                in_types, out_type)
+                                in_types, out_types)
     return wrong_output_datatype, func_name
 
 
@@ -206,14 +208,14 @@ def wrong_signature_func_fixture():
         return pa.scalar(1, type=pa.int64())
 
     func_name = "test_wrong_signature"
-    in_types = {}
-    out_type = pa.int64()
+    in_types = [{}]
+    out_types = [pa.int64()]
     doc = {
         "summary": "UDF with wrong signature",
         "description": ""
     }
     pc.register_scalar_function(wrong_signature, func_name, doc,
-                                in_types, out_type)
+                                in_types, out_types)
     return wrong_signature, func_name
 
 
@@ -230,7 +232,7 @@ def raising_func_fixture():
         "description": ""
     }
     pc.register_scalar_function(raising_func, func_name, doc,
-                                {}, pa.int64())
+                                [{}], [pa.int64()])
     return raising_func, func_name
 
 
@@ -311,8 +313,8 @@ def test_registration_errors():
         "summary": "test udf input",
         "description": "parameters are validated"
     }
-    in_types = {"scalar": pa.int64()}
-    out_type = pa.int64()
+    in_types = [{"scalar": pa.int64()}]
+    out_types = [pa.int64()]
 
     def test_reg_function(context):
         return pa.array([10])
@@ -320,39 +322,39 @@ def test_registration_errors():
     with pytest.raises(TypeError):
         pc.register_scalar_function(test_reg_function,
                                     None, doc, in_types,
-                                    out_type)
+                                    out_types)
 
     # validate function
     with pytest.raises(TypeError, match="func must be a callable"):
         pc.register_scalar_function(None, "test_none_function", doc, in_types,
-                                    out_type)
+                                    out_types)
 
     # validate output type
-    expected_expr = "DataType expected, got <class 'NoneType'>"
+    expected_expr = "out_types must be a list of DataTypes"
     with pytest.raises(TypeError, match=expected_expr):
         pc.register_scalar_function(test_reg_function,
                                     "test_output_function", doc, in_types,
                                     None)
 
     # validate input type
-    expected_expr = "in_types must be a dictionary of DataType"
+    expected_expr = "in_arg_types must be a list of dictionaries of DataTypes"
     with pytest.raises(TypeError, match=expected_expr):
         pc.register_scalar_function(test_reg_function,
                                     "test_input_function", doc, None,
-                                    out_type)
+                                    out_types)
 
     # register an already registered function
     # first registration
     pc.register_scalar_function(test_reg_function,
-                                "test_reg_function", doc, {},
-                                out_type)
+                                "test_reg_function", doc, [{}],
+                                out_types)
     # second registration
     expected_expr = "Already have a function registered with name:" \
         + " test_reg_function"
     with pytest.raises(KeyError, match=expected_expr):
         pc.register_scalar_function(test_reg_function,
-                                    "test_reg_function", doc, {},
-                                    out_type)
+                                    "test_reg_function", doc, [{}],
+                                    out_types)
 
 
 def test_varargs_function_validation(varargs_func_fixture):
@@ -366,8 +368,8 @@ def test_varargs_function_validation(varargs_func_fixture):
 
 def test_function_doc_validation():
     # validate arity
-    in_types = {"scalar": pa.int64()}
-    out_type = pa.int64()
+    in_types = [{"scalar": pa.int64()}]
+    out_type = [pa.int64()]
 
     # doc with no summary
     func_doc = {
@@ -396,7 +398,7 @@ def test_function_doc_validation():
 
 
 def test_nullary_function(nullary_func_fixture):
-    # XXX the Python compute layer API doesn't let us override batch_length,
+    # the Python compute layer API doesn't let us override batch_length,
     # so only test with the default value of 1.
     check_scalar_function(nullary_func_fixture, [], run_in_dataset=False,
                           batch_length=1)
@@ -435,8 +437,8 @@ def test_wrong_datatype_declaration():
         return val
 
     func_name = "test_wrong_datatype_declaration"
-    in_types = {"array": pa.int64()}
-    out_type = {}
+    in_types = [{"array": pa.int64()}]
+    out_type = [{}]
     doc = {
         "summary": "test output value",
         "description": "test output"
@@ -452,8 +454,8 @@ def test_wrong_input_type_declaration():
         return val
 
     func_name = "test_wrong_input_type_declaration"
-    in_types = {"array": None}
-    out_type = pa.int64()
+    in_types = [{"array": None}]
+    out_types = [pa.int64()]
     doc = {
         "summary": "test invalid input type",
         "description": "invalid input function"
@@ -461,7 +463,7 @@ def test_wrong_input_type_declaration():
     with pytest.raises(TypeError,
                        match="DataType expected, got <class 'NoneType'>"):
         pc.register_scalar_function(identity, func_name, doc,
-                                    in_types, out_type)
+                                    in_types, out_types)
 
 
 def test_udf_context(unary_func_fixture):
@@ -504,3 +506,75 @@ def test_input_lifetime(unary_func_fixture):
     # Calling a UDF should not have kept `v` alive longer than required
     v = None
     assert proxy_pool.bytes_allocated() == 0
+
+
+def test_multi_kernel_registration():
+    """
+    Register a unary scalar function.
+    """
+    def unary_function(ctx, x):
+        return pc.cast(pc.call_function("multiply", [x, 2],
+                                        memory_pool=ctx.memory_pool), x.type)
+    func_name = "y=x*1"
+    unary_doc = {"summary": "add function",
+                 "description": "test add function"}
+    input_types = [
+        {"array": pa.int8()},
+        {"array": pa.int16()},
+        {"array": pa.int32()},
+        {"array": pa.int64()},
+        {"array": pa.float32()},
+        {"array": pa.float64()}
+    ]
+
+    output_types = [
+        pa.int8(),
+        pa.int16(),
+        pa.int32(),
+        pa.int64(),
+        pa.float32(),
+        pa.float64()
+    ]
+    pc.register_scalar_function(unary_function,
+                                func_name,
+                                unary_doc,
+                                input_types,
+                                output_types)
+
+    for out_type in output_types:
+        assert pc.call_function(func_name,
+                                [pa.array([10, 20], out_type)]) \
+            == pa.array([20, 40], out_type)
+
+
+def test_invalid_multi_kernel_registration():
+    """
+    Register a unary scalar function.
+    """
+    def unary_function(ctx, x):
+        return pc.cast(pc.call_function("multiply", [x, 2],
+                                        memory_pool=ctx.memory_pool), x.type)
+    func_name = "y=x*1"
+    unary_doc = {"summary": "add function",
+                 "description": "test add function"}
+    input_types = [
+        {"array": pa.int8()},
+        {"array": pa.int16()},
+        {"array": pa.float32()},
+        {"array": pa.float64()}
+    ]
+
+    output_types = [
+        pa.int8(),
+        pa.int16(),
+        pa.int64(),
+        pa.float32(),
+        pa.float64()
+    ]
+    error_msg = "input_arg_types and output_types should be equal in size"
+    with pytest.raises(pa.lib.ArrowInvalid, match=error_msg):
+        pc.register_scalar_function(unary_function,
+                                    func_name,
+                                    unary_doc,
+                                    input_types,
+                                    output_types)


### PR DESCRIPTION
This PR includes the support for multi-kernel registration with Scalar UDFs for Python.