### PR TITLE
ARROW-17099: [Python] pyarrow build does not support RELWITHDEBINFO build type

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -232,9 +232,9 @@ class build_ext(_build_ext):
 
     def _run_cmake_pyarrow_cpp(self, pyarrow_cpp_home):
         # check if build_type is correctly passed / set
-        if self.build_type.lower() not in ('release', 'debug'):
+        if self.build_type.lower() not in ('release', 'debug', 'relwithdebinfo'):
             raise ValueError("--build-type (or PYARROW_BUILD_TYPE) needs to "
-                             "be 'release' or 'debug'")
+                             "be 'release', 'debug' or 'relwithdebinfo'")
 
         # The directory containing this setup.py
         source = os.path.dirname(os.path.abspath(__file__))
@@ -300,9 +300,9 @@ class build_ext(_build_ext):
 
     def _run_cmake(self, pyarrow_cpp_home):
         # check if build_type is correctly passed / set
-        if self.build_type.lower() not in ('release', 'debug'):
+        if self.build_type.lower() not in ('release', 'debug', 'relwithdebinfo'):
             raise ValueError("--build-type (or PYARROW_BUILD_TYPE) needs to "
-                             "be 'release' or 'debug'")
+                             "be 'release', 'debug' or 'relwithdebinfo'")
 
         # The directory containing this setup.py
         source = os.path.dirname(os.path.abspath(__file__))

--- a/python/setup.py
+++ b/python/setup.py
@@ -232,7 +232,8 @@ class build_ext(_build_ext):
 
     def _run_cmake_pyarrow_cpp(self, pyarrow_cpp_home):
         # check if build_type is correctly passed / set
-        if self.build_type.lower() not in ('release', 'debug', 'relwithdebinfo'):
+        if self.build_type.lower() not in ('release', 'debug',
+                                           'relwithdebinfo'):
             raise ValueError("--build-type (or PYARROW_BUILD_TYPE) needs to "
                              "be 'release', 'debug' or 'relwithdebinfo'")
 
@@ -300,7 +301,8 @@ class build_ext(_build_ext):
 
     def _run_cmake(self, pyarrow_cpp_home):
         # check if build_type is correctly passed / set
-        if self.build_type.lower() not in ('release', 'debug', 'relwithdebinfo'):
+        if self.build_type.lower() not in ('release', 'debug',
+                                           'relwithdebinfo'):
             raise ValueError("--build-type (or PYARROW_BUILD_TYPE) needs to "
                              "be 'release', 'debug' or 'relwithdebinfo'")
 


### PR DESCRIPTION
Add support for `RelWithDebInfo` in the PyArrow build process defined in `setup.py`.