### PR TITLE
MINOR: [C++] Fix a potential overflow in the asof join node when OnKey values are very small

### DIFF
--- a/cpp/src/arrow/compute/exec/asof_join_node.cc
+++ b/cpp/src/arrow/compute/exec/asof_join_node.cc
@@ -781,8 +781,9 @@ class AsofJoinNode : public ExecNode {
     // Prune memo entries that have expired (to bound memory consumption)
     if (!lhs.Empty()) {
       for (size_t i = 1; i < state_.size(); ++i) {
-        OnType min_value = std::min<OnType>(0, lhs.GetLatestTime() - tolerance_);
-        state_[i]->RemoveMemoEntriesWithLesserTime(min_value);
+        if (lhs.GetLatestTime() > tolerance_) {
+          state_[i]->RemoveMemoEntriesWithLesserTime(lhs.GetLatestTime() - tolerance_);
+        }
       }
     }
 

--- a/cpp/src/arrow/compute/exec/asof_join_node.cc
+++ b/cpp/src/arrow/compute/exec/asof_join_node.cc
@@ -781,7 +781,8 @@ class AsofJoinNode : public ExecNode {
     // Prune memo entries that have expired (to bound memory consumption)
     if (!lhs.Empty()) {
       for (size_t i = 1; i < state_.size(); ++i) {
-        state_[i]->RemoveMemoEntriesWithLesserTime(lhs.GetLatestTime() - tolerance_);
+        OnType min_value = std::min<OnType>(0, lhs.GetLatestTime() - tolerance_);
+        state_[i]->RemoveMemoEntriesWithLesserTime(min_value);
       }
     }
 


### PR DESCRIPTION
This isn't likely to happen in the real world (unless the OnKey is something other than timestamps) but is encountered by a number of our unit tests.