### PR TITLE
ARROW-17944: [Python] substrait.run_query accept bytes/Buffer and not segfault

### DIFF
--- a/python/pyarrow/_substrait.pyx
+++ b/python/pyarrow/_substrait.pyx
@@ -130,7 +130,7 @@ def run_query(plan, table_provider=None):
         c_buf_plan = pyarrow_unwrap_buffer(plan)
     else:
         raise TypeError(
-            f"Expected '{Buffer}' or bytes, got '{type(plan)}'")
+            f"Expected 'pyarrow.Buffer' or bytes, got '{type(plan)}'")
 
     if table_provider is not None:
         named_table_args = {

--- a/python/pyarrow/_substrait.pyx
+++ b/python/pyarrow/_substrait.pyx
@@ -48,12 +48,7 @@ cdef CDeclaration _create_named_table_provider(dict named_args, const std_vector
                         no_c_inputs, c_input_node_opts)
 
 
-ctypedef fused plan_type:
-    Buffer
-    bytes
-
-
-def run_query(plan_type plan, table_provider=None):
+def run_query(plan, table_provider=None):
     """
     Execute a Substrait plan and read the results as a RecordBatchReader.
 
@@ -131,8 +126,11 @@ def run_query(plan_type plan, table_provider=None):
 
     if isinstance(plan, bytes):
         c_buf_plan = pyarrow_unwrap_buffer(py_buffer(plan))
-    else:
+    elif isinstance(plan, Buffer):
         c_buf_plan = pyarrow_unwrap_buffer(plan)
+    else:
+        raise TypeError(
+            f"Expected '{Buffer}' or bytes, got '{type(plan)}'")
 
     if table_provider is not None:
         named_table_args = {

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -91,7 +91,7 @@ def test_run_query_input_types(tmpdir, query):
 
     # Passing unsupported type, like int, will not segfault.
     if not any(isinstance(query, c) for c in (pa.Buffer, bytes)):
-        msg = f"Expected '{pa.Buffer}' or bytes, got '{type(query)}'"
+        msg = f"Expected 'pyarrow.Buffer' or bytes, got '{type(query)}'"
         with pytest.raises(TypeError, match=msg):
             substrait.run_query(query)
         return

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -90,7 +90,7 @@ def test_run_serialized_query(tmpdir):
 def test_run_query_input_types(tmpdir, query):
 
     # Passing unsupported type, like int, will not segfault.
-    if not any(isinstance(query, c) for c in (pa.Buffer, bytes)):
+    if not isinstance(query, (pa.Buffer, bytes)):
         msg = f"Expected 'pyarrow.Buffer' or bytes, got '{type(query)}'"
         with pytest.raises(TypeError, match=msg):
             substrait.run_query(query)

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -40,10 +40,12 @@ def _write_dummy_data_to_disk(tmpdir, file_name, table):
     return path
 
 
-@pytest.mark.skipif(sys.platform == 'win32',
-                    reason="ARROW-16392: file based URI is" +
-                    " not fully supported for Windows")
-def test_run_serialized_query(tmpdir):
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="ARROW-16392: file based URI is not fully supported for Windows",
+)
+@pytest.mark.parametrize("input_type", ("buffer", "bytes", "unsupported"))
+def test_run_serialized_query(tmpdir, input_type):
     substrait_query = """
     {
         "relations": [
@@ -74,11 +76,21 @@ def test_run_serialized_query(tmpdir):
     """
 
     file_name = "read_data.arrow"
-    table = pa.table([[1, 2, 3, 4, 5]], names=['foo'])
+    table = pa.table([[1, 2, 3, 4, 5]], names=["foo"])
     path = _write_dummy_data_to_disk(tmpdir, file_name, table)
     query = tobytes(substrait_query.replace("FILENAME_PLACEHOLDER", path))
 
     buf = pa._substrait._parse_json_plan(query)
+
+    # Passing unsupported type, like int, will not segfault.
+    if input_type == "unsupported":
+        with pytest.raises(TypeError, match="No matching signature found"):
+            substrait.run_query(1)
+        return
+
+    # Ensure user can pass bytes directly as well.
+    if input_type == "bytes":
+        buf = buf.to_pybytes()
 
     reader = substrait.run_query(buf)
     res_tb = reader.read_all()


### PR DESCRIPTION
Fixes [ARROW-17944](https://issues.apache.org/jira/browse/ARROW-17944)