### PR TITLE
ARROW-17927: [C++] Avoid hitting thread limits in stress tests

### DIFF
--- a/cpp/src/arrow/testing/gtest_util.cc
+++ b/cpp/src/arrow/testing/gtest_util.cc
@@ -833,6 +833,12 @@ struct AsyncSleeper {
         lock.lock();
       }
     }
+    // Drain queue when finishing
+    auto events = std::move(state->events);
+    lock.unlock();
+    for (auto&& event : events) {
+      event.future.MarkFinished(Status::Cancelled("Async sleep cancelled at shutdown"));
+    }
   }
 
 #ifdef _WIN32


### PR DESCRIPTION
Non-trivial use of SleepAsync() and SleepABitAsync() could end up running hundreds of threads at once, which could hit resource limits on some CI configurations.