### PR TITLE
ARROW-17953: [Archery] Add archery docker info command

### DIFF
--- a/dev/archery/archery/docker/cli.py
+++ b/dev/archery/archery/docker/cli.py
@@ -310,6 +310,6 @@ def docker_compose_info(obj, service_name, only):
         click.echo(f'Service name {service_name} could not be found', err=True)
         sys.exit(1)
     else:
-        click.echo(f'Service {service_name} docker compose config:')
+        click.echo(f'Service {service_name} docker-compose config:')
         output = "\n".join(compose.info(service, only))
         click.echo(output)

--- a/dev/archery/archery/docker/cli.py
+++ b/dev/archery/archery/docker/cli.py
@@ -304,24 +304,11 @@ def docker_compose_info(obj, service_name, only):
     the docker-compose. Look at `archery docker images` output for names.
     """
     compose = obj['compose']
-
-    def expand(k, filters=None, prefix=' '):
-        for key, value in k.items():
-            if hasattr(value, 'items'):
-                keep_filters = filters
-                if key == filters or filters is None:
-                    click.echo(f'{prefix}- {key}')
-                    # Keep showing this specific key as parent matched filter
-                    keep_filters = None
-                expand(value, keep_filters, prefix + " ")
-            else:
-                if key == filters or filters is None:
-                    click.echo(f'{prefix}- {key}: {value}')
-
     try:
         service = compose.config.raw_config["services"][service_name]
     except KeyError:
         click.echo(f'Service name {service_name} could not be found')
     else:
         click.echo(f'Service {service_name} docker compose config:')
-        expand(service, only)
+        output = "\n".join(compose.info(service, only))
+        click.echo(output)

--- a/dev/archery/archery/docker/cli.py
+++ b/dev/archery/archery/docker/cli.py
@@ -289,3 +289,20 @@ def docker_compose_images(obj):
     click.echo('Available images:')
     for image in compose.images():
         click.echo(f' - {image}')
+
+@docker.command('info')
+@click.option('--service', '-s', 'service_name', required=True,
+              help='Service name to show info')
+@click.pass_obj
+def docker_compose_info(obj, service_name):
+    """List the available docker-compose images."""
+    compose = obj['compose']
+    click.echo(f'Service {service_name} docker compose config:')
+    def expand(k, prefix=' '):
+        if hasattr(k, 'items'):
+            for key, value in k.items():
+                click.echo(f'{prefix}- {key}')
+                expand(value, prefix + " ")
+        else:
+            click.echo(f'{prefix}- {k}')
+    expand(compose.config.raw_config["services"][service_name])

--- a/dev/archery/archery/docker/cli.py
+++ b/dev/archery/archery/docker/cli.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import os
+import sys
 
 import click
 
@@ -293,11 +294,11 @@ def docker_compose_images(obj):
 
 @docker.command('info')
 @click.argument('service_name')
-@click.option('--only', '-o', required=False,
+@click.option('--show', '-s', required=False,
               help="Show only specific docker-compose key. Examples of keys:"
                    " command, environment, build, dockerfile")
 @click.pass_obj
-def docker_compose_info(obj, service_name, only):
+def docker_compose_info(obj, service_name, show):
     """Show docker-compose definition info for service_name.
 
     SERVICE_NAME is the name of the docker service defined on
@@ -311,5 +312,5 @@ def docker_compose_info(obj, service_name, only):
         sys.exit(1)
     else:
         click.echo(f'Service {service_name} docker-compose config:')
-        output = "\n".join(compose.info(service, only))
+        output = "\n".join(compose.info(service, show))
         click.echo(output)

--- a/dev/archery/archery/docker/cli.py
+++ b/dev/archery/archery/docker/cli.py
@@ -307,7 +307,8 @@ def docker_compose_info(obj, service_name, only):
     try:
         service = compose.config.raw_config["services"][service_name]
     except KeyError:
-        click.echo(f'Service name {service_name} could not be found')
+        click.echo(f'Service name {service_name} could not be found', err=True)
+        sys.exit(1)
     else:
         click.echo(f'Service {service_name} docker compose config:')
         output = "\n".join(compose.info(service, only))

--- a/dev/archery/archery/docker/core.py
+++ b/dev/archery/archery/docker/core.py
@@ -431,5 +431,8 @@ class DockerCompose(Command):
                 output.extend(self.info(value, temp_filters, prefix + "  "))
             else:
                 if key == filters or filters is None:
-                    output.append(f'{prefix} {key}: {value}')
+                    output.append(
+                        f'{prefix} {key}: ' +
+                        f'{value if value is not None else "<inherited>"}'
+                    )
         return output

--- a/dev/archery/archery/docker/core.py
+++ b/dev/archery/archery/docker/core.py
@@ -424,12 +424,12 @@ class DockerCompose(Command):
             if hasattr(value, 'items'):
                 temp_filters = filters
                 if key == filters or filters is None:
-                    output.append(f'{prefix}- {key}')
+                    output.append(f'{prefix} {key}')
                     # Keep showing this specific key
                     # as parent matched filter
                     temp_filters = None
-                output.extend(self.info(value, temp_filters, prefix + " "))
+                output.extend(self.info(value, temp_filters, prefix + "  "))
             else:
                 if key == filters or filters is None:
-                    output.append(f'{prefix}- {key}: {value}')
+                    output.append(f'{prefix} {key}: {value}')
         return output

--- a/dev/archery/archery/docker/core.py
+++ b/dev/archery/archery/docker/core.py
@@ -95,12 +95,12 @@ class ComposeConfig:
         """
         yaml = YAML()
         with config_path.open() as fp:
-            config = yaml.load(fp)
+            self.raw_config = yaml.load(fp)
 
-        services = config['services'].keys()
-        self.hierarchy = dict(flatten(config.get('x-hierarchy', {})))
-        self.limit_presets = config.get('x-limit-presets', {})
-        self.with_gpus = config.get('x-with-gpus', [])
+        services = self.raw_config['services'].keys()
+        self.hierarchy = dict(flatten(self.raw_config.get('x-hierarchy', {})))
+        self.limit_presets = self.raw_config.get('x-limit-presets', {})
+        self.with_gpus = self.raw_config.get('x-with-gpus', [])
         nodes = self.hierarchy.keys()
         errors = []
 

--- a/dev/archery/archery/docker/core.py
+++ b/dev/archery/archery/docker/core.py
@@ -417,3 +417,19 @@ class DockerCompose(Command):
 
     def images(self):
         return sorted(self.config.hierarchy.keys())
+
+    def info(self, key_name, filters=None, prefix=' '):
+        output = []
+        for key, value in key_name.items():
+            if hasattr(value, 'items'):
+                temp_filters = filters
+                if key == filters or filters is None:
+                    output.append(f'{prefix}- {key}')
+                    # Keep showing this specific key
+                    # as parent matched filter
+                    temp_filters = None
+                output.extend(self.info(value, temp_filters, prefix + " "))
+            else:
+                if key == filters or filters is None:
+                    output.append(f'{prefix}- {key}: {value}')
+        return output

--- a/dev/archery/archery/docker/tests/test_docker.py
+++ b/dev/archery/archery/docker/tests/test_docker.py
@@ -529,3 +529,28 @@ def test_listing_images(arrow_compose_path):
         'ubuntu-cuda',
         'ubuntu-ruby',
     ]
+
+
+def test_service_info(arrow_compose_path):
+    compose = DockerCompose(arrow_compose_path)
+    service = compose.config.raw_config["services"]["conda-cpp"]
+    assert compose.info(service) == [
+        " - image: org/conda-cpp",
+        " - build",
+        "  - context: .",
+        "  - dockerfile: ci/docker/conda-cpp.dockerfile"
+    ]
+
+
+def test_service_info_filters(arrow_compose_path):
+    compose = DockerCompose(arrow_compose_path)
+    service = compose.config.raw_config["services"]["conda-cpp"]
+    assert compose.info(service, filters="dockerfile") == [
+        "  - dockerfile: ci/docker/conda-cpp.dockerfile"
+    ]
+
+
+def test_service_info_non_existing_filters(arrow_compose_path):
+    compose = DockerCompose(arrow_compose_path)
+    service = compose.config.raw_config["services"]["conda-cpp"]
+    assert compose.info(service, filters="non-existing") == []

--- a/dev/archery/archery/docker/tests/test_docker.py
+++ b/dev/archery/archery/docker/tests/test_docker.py
@@ -114,6 +114,11 @@ services:
 arrow_compose_yml = """
 version: '3.5'
 
+x-sccache: &sccache
+  AWS_ACCESS_KEY_ID:
+  AWS_SECRET_ACCESS_KEY:
+  SCCACHE_BUCKET:
+
 x-with-gpus:
   - ubuntu-cuda
 
@@ -162,6 +167,8 @@ services:
     image: org/ubuntu-cpp-cmake32
   ubuntu-c-glib:
     image: org/ubuntu-c-glib
+    environment:
+      <<: [*sccache]
   ubuntu-ruby:
     image: org/ubuntu-ruby
   ubuntu-cuda:
@@ -554,3 +561,14 @@ def test_service_info_non_existing_filters(arrow_compose_path):
     compose = DockerCompose(arrow_compose_path)
     service = compose.config.raw_config["services"]["conda-cpp"]
     assert compose.info(service, filters="non-existing") == []
+
+
+def test_service_info_inherited_env(arrow_compose_path):
+    compose = DockerCompose(arrow_compose_path)
+    service = compose.config.raw_config["services"]["ubuntu-c-glib"]
+    assert compose.info(service, filters="environment") == [
+        "  environment",
+        "    AWS_ACCESS_KEY_ID: <inherited>",
+        "    AWS_SECRET_ACCESS_KEY: <inherited>",
+        "    SCCACHE_BUCKET: <inherited>"
+    ]

--- a/dev/archery/archery/docker/tests/test_docker.py
+++ b/dev/archery/archery/docker/tests/test_docker.py
@@ -535,10 +535,10 @@ def test_service_info(arrow_compose_path):
     compose = DockerCompose(arrow_compose_path)
     service = compose.config.raw_config["services"]["conda-cpp"]
     assert compose.info(service) == [
-        " - image: org/conda-cpp",
-        " - build",
-        "  - context: .",
-        "  - dockerfile: ci/docker/conda-cpp.dockerfile"
+        "  image: org/conda-cpp",
+        "  build",
+        "    context: .",
+        "    dockerfile: ci/docker/conda-cpp.dockerfile"
     ]
 
 
@@ -546,7 +546,7 @@ def test_service_info_filters(arrow_compose_path):
     compose = DockerCompose(arrow_compose_path)
     service = compose.config.raw_config["services"]["conda-cpp"]
     assert compose.info(service, filters="dockerfile") == [
-        "  - dockerfile: ci/docker/conda-cpp.dockerfile"
+        "    dockerfile: ci/docker/conda-cpp.dockerfile"
     ]
 
 


### PR DESCRIPTION
Some usage examples:

```
$ archery docker info debian-go-cgo --show command
Service debian-go-cgo docker compose config:
 - command: /bin/bash -c "
  /arrow/ci/scripts/go_build.sh /arrow &&
  /arrow/ci/scripts/go_test.sh /arrow"
```
or
```
$ archery docker info debian-go-cgo
Service debian-go-cgo docker compose config:
 - image: ${REPO}:${ARCH}-debian-${DEBIAN}-go-${GO}-cgo
 - build
  - context: .
  - dockerfile: ci/docker/debian-go-cgo.dockerfile
  - cache_from: ['${REPO}:${ARCH}-debian-${DEBIAN}-go-${GO}-cgo']
  - args
   - base: ${REPO}:${ARCH}-debian-${DEBIAN}-go-${GO}
 - shm_size: 2G
 - volumes: ['.:/arrow:delegated', '${DOCKER_VOLUME_PREFIX}debian-ccache:/ccache:delegated']
 - environment
  - ARROW_GO_TESTCGO: 1
 - command: /bin/bash -c "
  /arrow/ci/scripts/go_build.sh /arrow &&
  /arrow/ci/scripts/go_test.sh /arrow"
```
or
```
$ archery docker info ubuntu-cuda-cpp --show environment
Service ubuntu-cuda-cpp docker compose config:
 - environment
  - ARROW_BUILD_STATIC: OFF
  - ARROW_CUDA: ON
  - ARROW_GANDIVA: OFF
  - ARROW_GCS: OFF
  - ARROW_ORC: OFF
  - ARROW_S3: OFF
  - ARROW_SUBSTRAIT: OFF
  - ARROW_WITH_OPENTELEMETRY: OFF
  - CCACHE_COMPILERCHECK: content
  - CCACHE_COMPRESS: 1
  - CCACHE_COMPRESSLEVEL: 6
  - CCACHE_MAXSIZE: 1G
  - CCACHE_DIR: /ccache

```
_edited only the commands to reflect the change of the command --show_