### PR TITLE
ARROW-17932: [C++] Implement streaming RecordBatchReader for JSON

### DIFF
--- a/cpp/src/arrow/json/reader.cc
+++ b/cpp/src/arrow/json/reader.cc
@@ -42,9 +42,148 @@ namespace arrow {
 using std::string_view;
 
 using internal::checked_cast;
+using internal::Executor;
 using internal::GetCpuThreadPool;
 using internal::TaskGroup;
 using internal::ThreadPool;
+
+namespace json {
+namespace {
+
+struct JSONBlock {
+  std::shared_ptr<Buffer> partial;
+  std::shared_ptr<Buffer> completion;
+  std::shared_ptr<Buffer> whole;
+  int64_t index = -1;
+};
+
+struct DecodedBlock {
+  std::shared_ptr<RecordBatch> record_batch;
+  int64_t num_bytes = 0;
+  int64_t index = -1;
+};
+
+Result<std::shared_ptr<RecordBatch>> ToRecordBatch(const StructArray& converted) {
+  std::vector<std::shared_ptr<Array>> columns;
+  columns.reserve(converted.num_fields());
+  for (const auto& f : converted.fields()) columns.push_back(f);
+  return RecordBatch::Make(schema(converted.type()->fields()), converted.length(),
+                           std::move(columns));
+}
+
+auto ToRecordBatch(const Array& converted) {
+  return ToRecordBatch(checked_cast<const StructArray&>(converted));
+}
+
+Result<std::shared_ptr<Array>> ParseBlock(const JSONBlock& block,
+                                          const ParseOptions& parse_options,
+                                          MemoryPool* pool, int64_t* out_size = nullptr) {
+  std::unique_ptr<BlockParser> parser;
+  RETURN_NOT_OK(BlockParser::Make(pool, parse_options, &parser));
+
+  int64_t size = block.partial->size() + block.completion->size() + block.whole->size();
+  RETURN_NOT_OK(parser->ReserveScalarStorage(size));
+
+  if (block.partial->size() || block.completion->size()) {
+    std::shared_ptr<Buffer> straddling;
+    if (!block.completion->size()) {
+      straddling = block.partial;
+    } else if (!block.partial->size()) {
+      straddling = block.completion;
+    } else {
+      ARROW_ASSIGN_OR_RAISE(straddling,
+                            ConcatenateBuffers({block.partial, block.completion}, pool));
+    }
+    RETURN_NOT_OK(parser->Parse(straddling));
+  }
+  if (block.whole->size()) {
+    RETURN_NOT_OK(parser->Parse(block.whole));
+  }
+
+  std::shared_ptr<Array> parsed;
+  RETURN_NOT_OK(parser->Finish(&parsed));
+
+  if (out_size) *out_size = size;
+
+  return parsed;
+}
+
+// Utility for incrementally generating chunked JSON blocks from source buffers
+//
+// Note: Retains state from prior calls
+class BlockReader {
+ public:
+  BlockReader(std::unique_ptr<Chunker> chunker, std::shared_ptr<Buffer> first_buffer)
+      : chunker_(std::move(chunker)),
+        partial_(std::make_shared<Buffer>("")),
+        buffer_(std::move(first_buffer)) {}
+
+  // Compose an iterator from a source iterator
+  template <typename... Args>
+  static Iterator<JSONBlock> MakeIterator(Iterator<std::shared_ptr<Buffer>> buf_it,
+                                          Args&&... args) {
+    auto reader = std::make_shared<BlockReader>(std::forward<Args>(args)...);
+    Transformer<std::shared_ptr<Buffer>, JSONBlock> transformer =
+        [reader](std::shared_ptr<Buffer> next_buffer) {
+          return (*reader)(std::move(next_buffer));
+        };
+    return MakeTransformedIterator(std::move(buf_it), transformer);
+  }
+
+  // Compose a callable generator from a source generator
+  template <typename... Args>
+  static AsyncGenerator<JSONBlock> MakeGenerator(
+      AsyncGenerator<std::shared_ptr<Buffer>> buf_gen, Args&&... args) {
+    auto reader = std::make_shared<BlockReader>(std::forward<Args>(args)...);
+    Transformer<std::shared_ptr<Buffer>, JSONBlock> transformer =
+        [reader](std::shared_ptr<Buffer> next_buffer) {
+          return (*reader)(std::move(next_buffer));
+        };
+    return MakeTransformedGenerator(std::move(buf_gen), transformer);
+  }
+
+  Result<TransformFlow<JSONBlock>> operator()(std::shared_ptr<Buffer> next_buffer) {
+    if (!buffer_) return TransformFinish();
+
+    std::shared_ptr<Buffer> whole, completion, next_partial;
+    if (!next_buffer) {
+      // End of file reached => compute completion from penultimate block
+      RETURN_NOT_OK(chunker_->ProcessFinal(partial_, buffer_, &completion, &whole));
+    } else {
+      std::shared_ptr<Buffer> starts_with_whole;
+      // Get completion of partial from previous block.
+      RETURN_NOT_OK(chunker_->ProcessWithPartial(partial_, buffer_, &completion,
+                                                 &starts_with_whole));
+      // Get all whole objects entirely inside the current buffer
+      RETURN_NOT_OK(chunker_->Process(starts_with_whole, &whole, &next_partial));
+    }
+
+    buffer_ = std::move(next_buffer);
+    return TransformYield(JSONBlock{std::exchange(partial_, next_partial),
+                                    std::move(completion), std::move(whole), index_++});
+  }
+
+ private:
+  std::unique_ptr<Chunker> chunker_;
+  std::shared_ptr<Buffer> partial_;
+  std::shared_ptr<Buffer> buffer_;
+  int64_t index_ = 0;
+};
+
+}  // namespace
+}  // namespace json
+
+template <>
+struct IterationTraits<json::JSONBlock> {
+  static json::JSONBlock End() { return json::JSONBlock{}; }
+  static bool IsEnd(const json::JSONBlock& val) { return val.index < 0; }
+};
+
+template <>
+struct IterationTraits<json::DecodedBlock> {
+  static json::DecodedBlock End() { return json::DecodedBlock{}; }
+  static bool IsEnd(const json::DecodedBlock& val) { return val.index < 0; }
+};
 
 namespace json {
 
@@ -57,56 +196,30 @@ class TableReaderImpl : public TableReader,
       : pool_(pool),
         read_options_(read_options),
         parse_options_(parse_options),
-        chunker_(MakeChunker(parse_options_)),
         task_group_(std::move(task_group)) {}
 
   Status Init(std::shared_ptr<io::InputStream> input) {
     ARROW_ASSIGN_OR_RAISE(auto it,
                           io::MakeInputStreamIterator(input, read_options_.block_size));
     return MakeReadaheadIterator(std::move(it), task_group_->parallelism())
-        .Value(&block_iterator_);
+        .Value(&buffer_iterator_);
   }
 
   Result<std::shared_ptr<Table>> Read() override {
-    RETURN_NOT_OK(MakeBuilder());
-
-    ARROW_ASSIGN_OR_RAISE(auto block, block_iterator_.Next());
-    if (block == nullptr) {
+    ARROW_ASSIGN_OR_RAISE(auto buffer, buffer_iterator_.Next());
+    if (buffer == nullptr) {
       return Status::Invalid("Empty JSON file");
     }
 
-    auto self = shared_from_this();
-    auto empty = std::make_shared<Buffer>("");
+    RETURN_NOT_OK(MakeBuilder());
 
-    int64_t block_index = 0;
-    std::shared_ptr<Buffer> partial = empty;
-
-    while (block != nullptr) {
-      std::shared_ptr<Buffer> next_block, whole, completion, next_partial;
-
-      ARROW_ASSIGN_OR_RAISE(next_block, block_iterator_.Next());
-
-      if (next_block == nullptr) {
-        // End of file reached => compute completion from penultimate block
-        RETURN_NOT_OK(chunker_->ProcessFinal(partial, block, &completion, &whole));
-      } else {
-        std::shared_ptr<Buffer> starts_with_whole;
-        // Get completion of partial from previous block.
-        RETURN_NOT_OK(chunker_->ProcessWithPartial(partial, block, &completion,
-                                                   &starts_with_whole));
-
-        // Get all whole objects entirely inside the current buffer
-        RETURN_NOT_OK(chunker_->Process(starts_with_whole, &whole, &next_partial));
-      }
-
-      // Launch parse task
-      task_group_->Append([self, partial, completion, whole, block_index] {
-        return self->ParseAndInsert(partial, completion, whole, block_index);
-      });
-      block_index++;
-
-      partial = next_partial;
-      block = next_block;
+    auto block_it = BlockReader::MakeIterator(
+        std::move(buffer_iterator_), MakeChunker(parse_options_), std::move(buffer));
+    while (true) {
+      ARROW_ASSIGN_OR_RAISE(auto block, block_it.Next());
+      if (IsIterationEnd(block)) break;
+      task_group_->Append(
+          [self = shared_from_this(), block] { return self->ParseAndInsert(block); });
     }
 
     std::shared_ptr<ChunkedArray> array;
@@ -128,43 +241,17 @@ class TableReaderImpl : public TableReader,
     return MakeChunkedArrayBuilder(task_group_, pool_, promotion_graph, type, &builder_);
   }
 
-  Status ParseAndInsert(const std::shared_ptr<Buffer>& partial,
-                        const std::shared_ptr<Buffer>& completion,
-                        const std::shared_ptr<Buffer>& whole, int64_t block_index) {
-    std::unique_ptr<BlockParser> parser;
-    RETURN_NOT_OK(BlockParser::Make(pool_, parse_options_, &parser));
-    RETURN_NOT_OK(parser->ReserveScalarStorage(partial->size() + completion->size() +
-                                               whole->size()));
-
-    if (partial->size() != 0 || completion->size() != 0) {
-      std::shared_ptr<Buffer> straddling;
-      if (partial->size() == 0) {
-        straddling = completion;
-      } else if (completion->size() == 0) {
-        straddling = partial;
-      } else {
-        ARROW_ASSIGN_OR_RAISE(straddling,
-                              ConcatenateBuffers({partial, completion}, pool_));
-      }
-      RETURN_NOT_OK(parser->Parse(straddling));
-    }
-
-    if (whole->size() != 0) {
-      RETURN_NOT_OK(parser->Parse(whole));
-    }
-
-    std::shared_ptr<Array> parsed;
-    RETURN_NOT_OK(parser->Finish(&parsed));
-    builder_->Insert(block_index, field("", parsed->type()), parsed);
+  Status ParseAndInsert(const JSONBlock& block) {
+    ARROW_ASSIGN_OR_RAISE(auto parsed, ParseBlock(block, parse_options_, pool_));
+    builder_->Insert(block.index, field("", parsed->type()), parsed);
     return Status::OK();
   }
 
   MemoryPool* pool_;
   ReadOptions read_options_;
   ParseOptions parse_options_;
-  std::unique_ptr<Chunker> chunker_;
   std::shared_ptr<TaskGroup> task_group_;
-  Iterator<std::shared_ptr<Buffer>> block_iterator_;
+  Iterator<std::shared_ptr<Buffer>> buffer_iterator_;
   std::shared_ptr<ChunkedArrayBuilder> builder_;
 };
 
@@ -204,14 +291,188 @@ Result<std::shared_ptr<RecordBatch>> ParseOne(ParseOptions options,
   builder->Insert(0, field("", type), parsed);
   std::shared_ptr<ChunkedArray> converted_chunked;
   RETURN_NOT_OK(builder->Finish(&converted_chunked));
-  const auto& converted = checked_cast<const StructArray&>(*converted_chunked->chunk(0));
 
-  std::vector<std::shared_ptr<Array>> columns(converted.num_fields());
-  for (int i = 0; i < converted.num_fields(); ++i) {
-    columns[i] = converted.field(i);
+  return ToRecordBatch(*converted_chunked->chunk(0));
+}
+
+namespace {
+
+// Callable object for decoding a pre-chunked JSON block into a RecordBatch
+class BlockDecoder {
+ public:
+  BlockDecoder(MemoryPool* pool, const ParseOptions& parse_options)
+      : pool_(pool),
+        parse_options_(parse_options),
+        conversion_type_(parse_options_.explicit_schema
+                             ? struct_(parse_options_.explicit_schema->fields())
+                             : struct_({})),
+        promotion_graph_(parse_options_.unexpected_field_behavior ==
+                                 UnexpectedFieldBehavior::InferType
+                             ? GetPromotionGraph()
+                             : nullptr) {}
+
+  Result<DecodedBlock> operator()(const JSONBlock& block) const {
+    int64_t num_bytes;
+    ARROW_ASSIGN_OR_RAISE(auto unconverted,
+                          ParseBlock(block, parse_options_, pool_, &num_bytes));
+
+    std::shared_ptr<ChunkedArrayBuilder> builder;
+    RETURN_NOT_OK(MakeChunkedArrayBuilder(TaskGroup::MakeSerial(), pool_,
+                                          promotion_graph_, conversion_type_, &builder));
+    builder->Insert(0, field("", unconverted->type()), unconverted);
+
+    std::shared_ptr<ChunkedArray> chunked;
+    RETURN_NOT_OK(builder->Finish(&chunked));
+    ARROW_ASSIGN_OR_RAISE(auto batch, ToRecordBatch(*chunked->chunk(0)));
+
+    return DecodedBlock{std::move(batch), num_bytes, block.index};
   }
-  return RecordBatch::Make(schema(converted.type()->fields()), converted.length(),
-                           std::move(columns));
+
+ private:
+  MemoryPool* pool_;
+  ParseOptions parse_options_;
+  std::shared_ptr<DataType> conversion_type_;
+  const PromotionGraph* promotion_graph_;
+};
+
+}  // namespace
+
+class StreamingReaderImpl : public StreamingReader,
+                            public std::enable_shared_from_this<StreamingReaderImpl> {
+ public:
+  StreamingReaderImpl(io::IOContext io_context, Executor* executor,
+                      const ReadOptions& read_options, const ParseOptions& parse_options)
+      : io_context_(std::move(io_context)),
+        executor_(executor),
+        read_options_(read_options),
+        parse_options_(parse_options),
+        bytes_processed_(std::make_shared<std::atomic<int64_t>>(0)) {}
+
+  Future<> Init(std::shared_ptr<io::InputStream> input) {
+    ARROW_ASSIGN_OR_RAISE(auto it,
+                          io::MakeInputStreamIterator(input, read_options_.block_size));
+    ARROW_ASSIGN_OR_RAISE(auto bg_it,
+                          MakeBackgroundGenerator(std::move(it), io_context_.executor()));
+    auto buf_gen = MakeTransferredGenerator(bg_it, executor_);
+    // We pre-fetch the first buffer during instantiation to resolve the schema and ensure
+    // the stream isn't empty
+    return buf_gen().Then(
+        [self = shared_from_this(), buf_gen](const std::shared_ptr<Buffer>& buffer) {
+          return self->InitFromFirstBuffer(buffer, buf_gen);
+        });
+  }
+
+  std::shared_ptr<Schema> schema() const override {
+    return parse_options_.explicit_schema;
+  }
+
+  Status ReadNext(std::shared_ptr<RecordBatch>* out) override {
+    auto future = ReadNextAsync();
+    auto result = future.result();
+    return std::move(result).Value(out);
+  }
+
+  Future<std::shared_ptr<RecordBatch>> ReadNextAsync() override {
+    return record_batch_gen_();
+  }
+
+  int64_t bytes_read() const override { return bytes_processed_->load(); }
+
+ private:
+  Future<> InitFromFirstBuffer(const std::shared_ptr<Buffer>& buffer,
+                               AsyncGenerator<std::shared_ptr<Buffer>> buf_gen) {
+    if (!buffer) return Status::Invalid("Empty JSON stream");
+
+    // Generator for pre-chunked JSON data
+    auto block_gen = BlockReader::MakeGenerator(std::move(buf_gen),
+                                                MakeChunker(parse_options_), buffer);
+    // Decoder for the first block using the initial parse options
+    auto decoder = BlockDecoder(io_context_.pool(), parse_options_);
+
+    return block_gen().Then(
+        [self = shared_from_this(), block_gen, decoder](JSONBlock block) -> Future<> {
+          // Skip any initial empty record batches so we can try to get a useful schema
+          int64_t skipped_bytes = 0;
+          ARROW_ASSIGN_OR_RAISE(auto decoded, decoder(block));
+          while (!IsIterationEnd(decoded) && !decoded.record_batch->num_rows()) {
+            skipped_bytes = decoded.num_bytes;
+            auto fut = block_gen();
+            ARROW_ASSIGN_OR_RAISE(block, fut.result());
+            if (IsIterationEnd(block)) {
+              decoded = IterationEnd<DecodedBlock>();
+            } else {
+              ARROW_ASSIGN_OR_RAISE(decoded, decoder(block));
+              decoded.num_bytes += skipped_bytes;
+            }
+          }
+          return self->InitFromFirstDecoded(decoded, block_gen);
+        });
+  }
+
+  Future<> InitFromFirstDecoded(const DecodedBlock& decoded,
+                                AsyncGenerator<JSONBlock> block_gen) {
+    // End of stream and no non-empty batches were yielded, so just return empty ones
+    if (IsIterationEnd(decoded)) {
+      record_batch_gen_ = MakeEmptyGenerator<std::shared_ptr<RecordBatch>>();
+      parse_options_.explicit_schema = nullptr;
+      return Status::OK();
+    }
+
+    // Use the schema from the first batch as the basis for all future reads. If type
+    // inference wasn't requested then this should be the same as the provided
+    // explicit_schema. Otherwise, ignore unexpected fields for future batches to ensure
+    // their schemas are consistent
+    parse_options_.explicit_schema = decoded.record_batch->schema();
+    if (parse_options_.unexpected_field_behavior == UnexpectedFieldBehavior::InferType) {
+      parse_options_.unexpected_field_behavior = UnexpectedFieldBehavior::Ignore;
+    }
+
+    // The final decoder, which uses the resolved parse options for type deduction
+    auto decoded_gen = MakeMappedGenerator(
+        std::move(block_gen), BlockDecoder(io_context_.pool(), parse_options_));
+    if (read_options_.use_threads) {
+      decoded_gen =
+          MakeReadaheadGenerator(std::move(decoded_gen), executor_->GetCapacity());
+    }
+    // Return the batch we just read on first invocation
+    decoded_gen = MakeGeneratorStartsWith({decoded}, std::move(decoded_gen));
+
+    // Compose the final generator
+    record_batch_gen_ = MakeMappedGenerator(
+        std::move(decoded_gen),
+        [bytes_processed = bytes_processed_](const DecodedBlock& decoded) {
+          bytes_processed->fetch_add(decoded.num_bytes);
+          return decoded.record_batch;
+        });
+    record_batch_gen_ =
+        MakeCancellable(std::move(record_batch_gen_), io_context_.stop_token());
+
+    return Status::OK();
+  }
+
+  io::IOContext io_context_;
+  Executor* executor_;
+  ReadOptions read_options_;
+  ParseOptions parse_options_;
+  AsyncGenerator<std::shared_ptr<RecordBatch>> record_batch_gen_;
+  std::shared_ptr<std::atomic<int64_t>> bytes_processed_;
+};
+
+Future<std::shared_ptr<StreamingReader>> StreamingReader::MakeAsync(
+    io::IOContext io_context, std::shared_ptr<io::InputStream> input, Executor* executor,
+    const ReadOptions& read_options, const ParseOptions& parse_options) {
+  auto reader = std::make_shared<StreamingReaderImpl>(io_context, executor, read_options,
+                                                      parse_options);
+  return reader->Init(input).Then(
+      [reader] { return std::static_pointer_cast<StreamingReader>(reader); });
+}
+
+Result<std::shared_ptr<StreamingReader>> StreamingReader::Make(
+    io::IOContext io_context, std::shared_ptr<io::InputStream> input,
+    const ReadOptions& read_options, const ParseOptions& parse_options) {
+  auto future = StreamingReader::MakeAsync(io_context, input, GetCpuThreadPool(),
+                                           read_options, parse_options);
+  return future.result();
 }
 
 }  // namespace json

--- a/cpp/src/arrow/json/reader.h
+++ b/cpp/src/arrow/json/reader.h
@@ -59,41 +59,55 @@ ARROW_EXPORT Result<std::shared_ptr<RecordBatch>> ParseOne(ParseOptions options,
 ///
 /// The supplied `ParseOptions` are used to determine a schema, based either on a
 /// provided explicit schema or inferred from the first non-empty block.
-/// Afterwards, the schema is frozen and unexpected fields will be ignored on
-/// subsequent reads (unless `UnexpectedFieldBehavior::Error` was specified).
+/// Afterwards, the target schema is frozen. If `UnexpectedFieldBehavior::InferType` is
+/// specified, unexpected fields will only be inferred for the first block. Afterwards
+/// they'll be treated as errors.
 ///
 /// For each block, the reader will launch its subsequent parsing/decoding task on the
 /// given `cpu_executor` - potentially in parallel. If `ReadOptions::use_threads` is
 /// specified, readahead will be applied to these tasks in accordance with the executor's
-/// capacity.
+/// capacity. If an executor is not provided, the global thread pool will be used.
 class ARROW_EXPORT StreamingReader : public RecordBatchReader {
  public:
   virtual ~StreamingReader() = default;
 
   /// \brief Read the next `RecordBatch` asynchronously
-  ///
   /// This function is async-reentrant (but not synchronously reentrant)
   virtual Future<std::shared_ptr<RecordBatch>> ReadNextAsync() = 0;
 
-  /// \brief Return the number of bytes which have been read and processed
-  ///
-  /// The returned number includes JSON bytes which the StreamingReader has finished
-  /// processing, but not bytes for which some processing (e.g. JSON parsing or conversion
-  /// to Arrow layout) is still ongoing.
-  [[nodiscard]] virtual int64_t bytes_read() const = 0;
+  /// Get the number of bytes which have been succesfully converted to record batches
+  /// and consumed
+  [[nodiscard]] virtual int64_t bytes_processed() const = 0;
 
-  /// \brief Create a `StreamingReader` instance asynchronously
+  /// \brief Create a `StreamingReader` from an `InputStream`
+  /// Blocks until the initial batch is loaded
   ///
-  /// This involves some I/O as the first batch must be loaded during the creation process
-  /// so it is returned as a future
-  static Future<std::shared_ptr<StreamingReader>> MakeAsync(
-      std::shared_ptr<io::InputStream> stream, io::IOContext io_context,
-      ::arrow::internal::Executor* cpu_executor, const ReadOptions&, const ParseOptions&);
-
-  /// \brief Create a `StreamingReader` instance
+  /// \param[in] stream JSON source stream
+  /// \param[in] read_options Options for reading
+  /// \param[in] parse_options Options for chunking, parsing, and conversion
+  /// \param[in] io_context Context for IO operations (optional)
+  /// \param[in] cpu_executor Executor for computation tasks (optional)
+  /// \return The initialized reader
   static Result<std::shared_ptr<StreamingReader>> Make(
-      std::shared_ptr<io::InputStream> stream, io::IOContext io_context,
-      ::arrow::internal::Executor* cpu_executor, const ReadOptions&, const ParseOptions&);
+      std::shared_ptr<io::InputStream> stream, const ReadOptions& read_options,
+      const ParseOptions& parse_options,
+      const io::IOContext& io_context = io::default_io_context(),
+      ::arrow::internal::Executor* cpu_executor = NULLPTR);
+
+  /// \brief Create a `StreamingReader` from an `InputStream` asynchronously
+  /// Returned future completes after loading the first batch
+  ///
+  /// \param[in] stream JSON source stream
+  /// \param[in] read_options Options for reading
+  /// \param[in] parse_options Options for chunking, parsing, and conversion
+  /// \param[in] io_context Context for IO operations (optional)
+  /// \param[in] cpu_executor Executor for computation tasks (optional)
+  /// \return Future for the initialized reader
+  static Future<std::shared_ptr<StreamingReader>> MakeAsync(
+      std::shared_ptr<io::InputStream> stream, const ReadOptions& read_options,
+      const ParseOptions& parse_options,
+      const io::IOContext& io_context = io::default_io_context(),
+      ::arrow::internal::Executor* cpu_executor = NULLPTR);
 };
 
 }  // namespace json

--- a/cpp/src/arrow/json/reader.h
+++ b/cpp/src/arrow/json/reader.h
@@ -75,8 +75,8 @@ class ARROW_EXPORT StreamingReader : public RecordBatchReader {
   virtual ~StreamingReader() = default;
 
   /// \brief Read the next `RecordBatch` asynchronously
-  /// If threading is enabled, this function is async-reentrant (but not synchronously
-  /// reentrant).
+  /// This function is async-reentrant (but not synchronously reentrant). However, if
+  /// threading is disabled, this will block until completion.
   virtual Future<std::shared_ptr<RecordBatch>> ReadNextAsync() = 0;
 
   /// Get the number of bytes which have been succesfully converted to record batches

--- a/cpp/src/arrow/json/reader.h
+++ b/cpp/src/arrow/json/reader.h
@@ -19,12 +19,13 @@
 
 #include <memory>
 
-#include "arrow/io/interfaces.h"
+#include "arrow/io/type_fwd.h"
 #include "arrow/json/options.h"
 #include "arrow/record_batch.h"
 #include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/util/macros.h"
+#include "arrow/util/type_fwd.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {

--- a/cpp/src/arrow/json/reader.h
+++ b/cpp/src/arrow/json/reader.h
@@ -56,8 +56,9 @@ ARROW_EXPORT Result<std::shared_ptr<RecordBatch>> ParseOne(ParseOptions options,
 /// `ReadOptions::block_size`). Each block is converted to a `RecordBatch`. Yielded
 /// batches have a consistent schema but may differ in row count.
 ///
-/// The supplied `ParseOptions` are used to determine a schema on the first non-empty
-/// block. Afterwards, the schema is frozen and unexpected fields will be ignored on
+/// The supplied `ParseOptions` are used to determine a schema, based either on a
+/// provided explicit schema or inferred from the first non-empty block.
+/// Afterwards, the schema is frozen and unexpected fields will be ignored on
 /// subsequent reads (unless `UnexpectedFieldBehavior::Error` was specified).
 ///
 /// For each block, the reader will launch its subsequent parsing/decoding task on the

--- a/cpp/src/arrow/json/reader.h
+++ b/cpp/src/arrow/json/reader.h
@@ -63,16 +63,20 @@ ARROW_EXPORT Result<std::shared_ptr<RecordBatch>> ParseOne(ParseOptions options,
 /// specified, unexpected fields will only be inferred for the first block. Afterwards
 /// they'll be treated as errors.
 ///
-/// For each block, the reader will launch its subsequent parsing/decoding task on the
-/// given `cpu_executor` - potentially in parallel. If `ReadOptions::use_threads` is
-/// specified, readahead will be applied to these tasks in accordance with the executor's
-/// capacity. If an executor is not provided, the global thread pool will be used.
+/// If `ReadOptions::use_threads` is `true`, each block's parsing/decoding task will be
+/// parallelized on the given `cpu_executor` (with readahead corresponding to the
+/// executor's capacity). If an executor isn't provided, the global thread pool will be
+/// used.
+///
+/// If `ReadOptions::use_threads` is `false`, computations will be run on the calling
+/// thread and `cpu_executor` will be ignored.
 class ARROW_EXPORT StreamingReader : public RecordBatchReader {
  public:
   virtual ~StreamingReader() = default;
 
   /// \brief Read the next `RecordBatch` asynchronously
-  /// This function is async-reentrant (but not synchronously reentrant)
+  /// If threading is enabled, this function is async-reentrant (but not synchronously
+  /// reentrant).
   virtual Future<std::shared_ptr<RecordBatch>> ReadNextAsync() = 0;
 
   /// Get the number of bytes which have been succesfully converted to record batches

--- a/cpp/src/arrow/json/reader_test.cc
+++ b/cpp/src/arrow/json/reader_test.cc
@@ -363,6 +363,7 @@ class StreamingReaderTest : public ::testing::TestWithParam<bool> {
                              std::shared_ptr<RecordBatch>* out) {
     ASSERT_OK(reader->ReadNext(out));
     ASSERT_FALSE(IsIterationEnd(*out));
+    ASSERT_OK((**out).ValidateFull());
   }
   static void AssertReadEnd(const std::shared_ptr<StreamingReader>& reader) {
     std::shared_ptr<RecordBatch> out;
@@ -790,6 +791,7 @@ TEST_P(StreamingReaderTest, AsyncReentrancy) {
   EXPECT_EQ(batches.size(), static_cast<size_t>(expected.num_batches));
 
   ASSERT_OK_AND_ASSIGN(auto table, Table::FromRecordBatches(batches));
+  ASSERT_OK(table->ValidateFull());
   ASSERT_TABLES_EQUAL(*expected.table, *table);
 }
 

--- a/docs/source/cpp/api/formats.rst
+++ b/docs/source/cpp/api/formats.rst
@@ -67,6 +67,9 @@ Line-separated JSON
 .. doxygenclass:: arrow::json::TableReader
    :members:
 
+.. doxygenclass:: arrow::json::StreamingReader
+   :members:
+
 .. _cpp-api-parquet:
 
 Parquet reader

--- a/docs/source/cpp/json.rst
+++ b/docs/source/cpp/json.rst
@@ -102,12 +102,11 @@ may be passed via :class:`~ParseOptions`.
       }
       std::shared_ptr<arrow::json::StreamingReader> reader = *result;
 
-      std::shared_ptr<arrow::RecordBatch> batch;
       for (arrow::Result<std::shared_ptr<arrow::RecordBatch>> maybe_batch : *reader) {
          if (!maybe_batch.ok()) {
             // Handle read/parse error
          }
-         batch = *maybe_batch;
+         std::shared_ptr<arrow::RecordBatch> batch = *maybe_batch;
          // Operate on each batch...
       }
    }

--- a/docs/source/cpp/json.rst
+++ b/docs/source/cpp/json.rst
@@ -24,17 +24,24 @@
 Reading JSON files
 ==================
 
-Arrow allows reading line-separated JSON files as Arrow tables.  Each
-independent JSON object in the input file is converted to a row in
-the target Arrow table.
+Line-separated JSON files can either be read as a single Arrow Table
+with a :class:`~TableReader` or streamed as RecordBatches with a
+:class:`~StreamingReader`.
+
+Both of these readers require an :class:`arrow::io::InputStream` instance
+representing the input file. Their behavior can be customized using a
+combination of :class:`~ReadOptions`, :class:`~ParseOptions`, and
+other parameters.
 
 .. seealso::
    :ref:`JSON reader API reference <cpp-api-json>`.
 
-Basic usage
+TableReader
 ===========
 
-A JSON file is read from a :class:`~arrow::io::InputStream`.
+Reads an entire file in one shot as a :class:`~arrow::Table`. Each
+independent JSON object in the input file is converted to a row in
+the output table.
 
 .. code-block:: cpp
 
@@ -66,6 +73,49 @@ A JSON file is read from a :class:`~arrow::io::InputStream`.
       }
    }
 
+StreamingReader
+===============
+
+Reads a file incrementally in fixed-size blocks, each yielding a
+:class:`~arrow::RecordBatch`. Each independent JSON object in a block
+is converted to a row in the output batch.
+
+All batches adhere to a consistent :class:`~arrow:Schema`, which is
+derived from the first loaded batch.
+
+.. code-block:: cpp
+
+   #include "arrow/json/api.h"
+
+   {
+      // ...
+      auto read_options = arrow::json::ReadOptions::Defaults();
+      auto parse_options = arrow::json::ParseOptions::Defaults();
+
+      std::shared_ptr<arrow::io::InputStream> stream;
+      auto result = arrow::json::StreamingReader::Make(stream,
+                                                       read_options,
+                                                       parse_options);
+      if (!result.ok()) {
+         // Handle instantiation error
+      }
+      std::shared_ptr<arrow::json::StreamingReader> reader = *result;
+
+      std::shared_ptr<arrow::RecordBatch> batch;
+      while (true) {
+         arrow::Status status = reader->ReadNext(&batch);
+
+         if (!status.ok()) {
+            // Handle read/parse error
+         }
+
+         if (batch == nullptr) {
+            // Handle end of file
+            break;
+         }
+      }
+   }
+
 Data types
 ==========
 
@@ -75,7 +125,7 @@ objects.  The fields of top-level objects are taken to represent columns
 in the Arrow data.  For each name/value pair in a JSON object, there are
 two possible modes of deciding the output data type:
 
-* if the name is in :class:`ConvertOptions::explicit_schema`,
+* if the name is in :member:`ParseOptions::explicit_schema`,
   conversion of the JSON value to the corresponding Arrow data type is
   attempted;
 

--- a/docs/source/cpp/json.rst
+++ b/docs/source/cpp/json.rst
@@ -39,7 +39,7 @@ other parameters.
 TableReader
 ===========
 
-Reads an entire file in one shot as a :class:`~arrow::Table`. Each
+:class:`~TableReader` reads an entire file in one shot as a :class:`~arrow::Table`. Each
 independent JSON object in the input file is converted to a row in
 the output table.
 
@@ -76,7 +76,7 @@ the output table.
 StreamingReader
 ===============
 
-Reads a file incrementally in fixed-size blocks, each yielding a
+:class:`~StreamingReader` reads a file incrementally from blocks of a roughly equal byte size, each yielding a
 :class:`~arrow::RecordBatch`. Each independent JSON object in a block
 is converted to a row in the output batch.
 
@@ -104,7 +104,7 @@ may be passed via :class:`~ParseOptions`.
 
       std::shared_ptr<arrow::RecordBatch> batch;
       for (arrow::Result<std::shared_ptr<arrow::RecordBatch>> maybe_batch : *reader) {
-         if (!result.ok()) {
+         if (!maybe_batch.ok()) {
             // Handle read/parse error
          }
          batch = *maybe_batch;

--- a/docs/source/cpp/json.rst
+++ b/docs/source/cpp/json.rst
@@ -81,7 +81,8 @@ Reads a file incrementally in fixed-size blocks, each yielding a
 is converted to a row in the output batch.
 
 All batches adhere to a consistent :class:`~arrow:Schema`, which is
-derived from the first loaded batch.
+derived from the first loaded batch. Alternatively, an explicit schema
+may be passed via :class:`~ParseOptions`.
 
 .. code-block:: cpp
 
@@ -102,17 +103,12 @@ derived from the first loaded batch.
       std::shared_ptr<arrow::json::StreamingReader> reader = *result;
 
       std::shared_ptr<arrow::RecordBatch> batch;
-      while (true) {
-         arrow::Status status = reader->ReadNext(&batch);
-
-         if (!status.ok()) {
+      for (arrow::Result<std::shared_ptr<arrow::RecordBatch>> maybe_batch : *reader) {
+         if (!result.ok()) {
             // Handle read/parse error
          }
-
-         if (batch == nullptr) {
-            // Handle end of file
-            break;
-         }
+         batch = *maybe_batch;
+         // Operate on each batch...
       }
    }
 


### PR DESCRIPTION
See: [ARROW-17932](https://issues.apache.org/jira/browse/ARROW-17932).

Adds a `json::StreamingReader` class (modeled after `csv::StreamingReader`) with an async-reentrant interface and support for parallel block decoding.

Some parts of the existing `TableReader` implementation have been refactored to utilize the new facilities.