### PR TITLE
ARROW-17450: [C++][Parquet] Add support for uint8 boolean decode in addition to bool array

### DIFF
--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -1146,11 +1146,13 @@ int PlainDecoder<DType>::Decode(T* buffer, int max_values) {
   return max_values;
 }
 
-class PlainBooleanDecoder : public DecoderImpl, virtual public TypedDecoder<BooleanType> {
+class PlainBooleanDecoder : public DecoderImpl, virtual public BooleanDecoder {
  public:
   explicit PlainBooleanDecoder(const ColumnDescriptor* descr);
   void SetData(int num_values, const uint8_t* data, int len) override;
 
+  // Two flavors of bool decoding
+  int Decode(uint8_t* buffer, int max_values) override;
   int Decode(bool* buffer, int max_values) override;
   int DecodeArrow(int num_values, int null_count, const uint8_t* valid_bits,
                   int64_t valid_bits_offset,
@@ -1199,6 +1201,24 @@ inline int PlainBooleanDecoder::DecodeArrow(
     int num_values, int null_count, const uint8_t* valid_bits, int64_t valid_bits_offset,
     typename EncodingTraits<BooleanType>::DictAccumulator* builder) {
   ParquetException::NYI("dictionaries of BooleanType");
+}
+
+int PlainBooleanDecoder::Decode(uint8_t* buffer, int max_values) {
+  max_values = std::min(max_values, num_values_);
+  bool val;
+  ::arrow::internal::BitmapWriter bit_writer(buffer, 0, max_values);
+  for (int i = 0; i < max_values; ++i) {
+      if (!bit_reader_->GetValue(1, &val)) {
+          ParquetException::EofException();
+      }
+      if (val) {
+          bit_writer.Set();
+      }
+      bit_writer.Next();
+  }
+  bit_writer.Finish();
+  num_values_ -= max_values;
+  return max_values;
 }
 
 int PlainBooleanDecoder::Decode(bool* buffer, int max_values) {
@@ -2336,7 +2356,7 @@ class DeltaLengthByteArrayDecoder : public DecoderImpl,
 // ----------------------------------------------------------------------
 // RLE_BOOLEAN_DECODER
 
-class RleBooleanDecoder : public DecoderImpl, virtual public TypedDecoder<BooleanType> {
+class RleBooleanDecoder : public DecoderImpl, virtual public BooleanDecoder {
  public:
   explicit RleBooleanDecoder(const ColumnDescriptor* descr)
       : DecoderImpl(descr, Encoding::RLE) {}
@@ -2370,6 +2390,10 @@ class RleBooleanDecoder : public DecoderImpl, virtual public TypedDecoder<Boolea
     }
     num_values_ -= max_values;
     return max_values;
+  }
+
+  int Decode(uint8_t* buffer, int max_values) override {
+    ParquetException::NYI("Decode(uint8_t*, int) for RleBooleanDecoder");
   }
 
   int DecodeArrow(int num_values, int null_count, const uint8_t* valid_bits,

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -1208,13 +1208,13 @@ int PlainBooleanDecoder::Decode(uint8_t* buffer, int max_values) {
   bool val;
   ::arrow::internal::BitmapWriter bit_writer(buffer, 0, max_values);
   for (int i = 0; i < max_values; ++i) {
-      if (!bit_reader_->GetValue(1, &val)) {
-          ParquetException::EofException();
-      }
-      if (val) {
-          bit_writer.Set();
-      }
-      bit_writer.Next();
+    if (!bit_reader_->GetValue(1, &val)) {
+      ParquetException::EofException();
+    }
+    if (val) {
+      bit_writer.Set();
+    }
+    bit_writer.Next();
   }
   bit_writer.Finish();
   num_values_ -= max_values;

--- a/cpp/src/parquet/encoding.h
+++ b/cpp/src/parquet/encoding.h
@@ -398,7 +398,7 @@ class BooleanDecoder : virtual public TypedDecoder<BooleanType> {
  public:
   using TypedDecoder<BooleanType>::Decode;
 
-  /// \brief Decode values into a buffer
+  /// \brief Decode and bit-pack values into a buffer
   ///
   /// \param[in] buffer destination for decoded values
   /// This buffer contains bit-packed values.

--- a/cpp/src/parquet/encoding.h
+++ b/cpp/src/parquet/encoding.h
@@ -395,9 +395,9 @@ class DictDecoder : virtual public TypedDecoder<DType> {
 // TypedEncoder specializations, traits, and factory functions
 
 class BooleanDecoder : virtual public TypedDecoder<BooleanType> {
-public:
-    using TypedDecoder<BooleanType>::Decode;
-    virtual int Decode(uint8_t* buffer, int max_values) = 0;
+ public:
+  using TypedDecoder<BooleanType>::Decode;
+  virtual int Decode(uint8_t* buffer, int max_values) = 0;
 };
 
 class FLBADecoder : virtual public TypedDecoder<FLBAType> {

--- a/cpp/src/parquet/encoding.h
+++ b/cpp/src/parquet/encoding.h
@@ -401,7 +401,7 @@ class BooleanDecoder : virtual public TypedDecoder<BooleanType> {
   /// \brief Decode and bit-pack values into a buffer
   ///
   /// \param[in] buffer destination for decoded values
-  /// This buffer contains bit-packed values.
+  /// This buffer will contain bit-packed values.
   /// \param[in] max_values max values to decode.
   /// \return The number of values decoded. Should be identical to max_values except
   /// at the end of the current data page.

--- a/cpp/src/parquet/encoding.h
+++ b/cpp/src/parquet/encoding.h
@@ -397,6 +397,14 @@ class DictDecoder : virtual public TypedDecoder<DType> {
 class BooleanDecoder : virtual public TypedDecoder<BooleanType> {
  public:
   using TypedDecoder<BooleanType>::Decode;
+
+  /// \brief Decode values into a buffer
+  ///
+  /// \param[in] buffer destination for decoded values
+  /// This buffer contains bit-packed values.
+  /// \param[in] max_values max values to decode.
+  /// \return The number of values decoded. Should be identical to max_values except
+  /// at the end of the current data page.
   virtual int Decode(uint8_t* buffer, int max_values) = 0;
 };
 

--- a/cpp/src/parquet/encoding.h
+++ b/cpp/src/parquet/encoding.h
@@ -65,7 +65,7 @@ using FLBAEncoder = TypedEncoder<FLBAType>;
 template <typename DType>
 class TypedDecoder;
 
-using BooleanDecoder = TypedDecoder<BooleanType>;
+class BooleanDecoder;
 using Int32Decoder = TypedDecoder<Int32Type>;
 using Int64Decoder = TypedDecoder<Int64Type>;
 using Int96Decoder = TypedDecoder<Int96Type>;
@@ -393,6 +393,12 @@ class DictDecoder : virtual public TypedDecoder<DType> {
 
 // ----------------------------------------------------------------------
 // TypedEncoder specializations, traits, and factory functions
+
+class BooleanDecoder : virtual public TypedDecoder<BooleanType> {
+public:
+    using TypedDecoder<BooleanType>::Decode;
+    virtual int Decode(uint8_t* buffer, int max_values) = 0;
+};
 
 class FLBADecoder : virtual public TypedDecoder<FLBAType> {
  public:

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -52,7 +52,7 @@ namespace parquet {
 
 namespace test {
 
-TEST(VectorBooleanTest, TestEncodeDecode) {
+TEST(VectorBooleanTest, TestEncodeBoolDecode) {
   // PARQUET-454
   const int nvalues = 10000;
   bool decode_buffer[nvalues] = {false};
@@ -79,6 +79,38 @@ TEST(VectorBooleanTest, TestEncodeDecode) {
 
   for (int i = 0; i < nvalues; ++i) {
     ASSERT_EQ(draws[i], decode_buffer[i]);
+  }
+}
+
+TEST(VectorBooleanTest, TestEncodeIntDecode) {
+  // PARQUET-454
+  int nvalues = 10000;
+
+  int nbytes = static_cast<int>(bit_util::BytesForBits(nvalues));
+
+  std::vector<bool> draws;
+  ::arrow::random_is_valid(nvalues, 0.5 /* null prob */, &draws, 0 /* seed */);
+
+  std::unique_ptr<BooleanEncoder> encoder =
+          MakeTypedEncoder<BooleanType>(Encoding::PLAIN);
+  encoder->Put(draws, nvalues);
+
+  std::unique_ptr<BooleanDecoder> decoder =
+          MakeTypedDecoder<BooleanType>(Encoding::PLAIN);
+
+  std::shared_ptr<Buffer> encode_buffer = encoder->FlushValues();
+  ASSERT_EQ(nbytes, encode_buffer->size());
+
+  std::vector<uint8_t> decode_buffer(nbytes);
+  const uint8_t* decode_data = &decode_buffer[0];
+
+  decoder->SetData(nvalues, encode_buffer->data(),
+  static_cast<int>(encode_buffer->size()));
+  int values_decoded = decoder->Decode(&decode_buffer[0], nvalues);
+  ASSERT_EQ(nvalues, values_decoded);
+
+  for (int i = 0; i < nvalues; ++i) {
+    ASSERT_EQ(draws[i], ::arrow::bit_util::GetBit(decode_data, i)) << i;
   }
 }
 

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -92,11 +92,11 @@ TEST(VectorBooleanTest, TestEncodeIntDecode) {
   ::arrow::random_is_valid(nvalues, 0.5 /* null prob */, &draws, 0 /* seed */);
 
   std::unique_ptr<BooleanEncoder> encoder =
-          MakeTypedEncoder<BooleanType>(Encoding::PLAIN);
+      MakeTypedEncoder<BooleanType>(Encoding::PLAIN);
   encoder->Put(draws, nvalues);
 
   std::unique_ptr<BooleanDecoder> decoder =
-          MakeTypedDecoder<BooleanType>(Encoding::PLAIN);
+      MakeTypedDecoder<BooleanType>(Encoding::PLAIN);
 
   std::shared_ptr<Buffer> encode_buffer = encoder->FlushValues();
   ASSERT_EQ(nbytes, encode_buffer->size());
@@ -105,7 +105,7 @@ TEST(VectorBooleanTest, TestEncodeIntDecode) {
   const uint8_t* decode_data = &decode_buffer[0];
 
   decoder->SetData(nvalues, encode_buffer->data(),
-  static_cast<int>(encode_buffer->size()));
+                   static_cast<int>(encode_buffer->size()));
   int values_decoded = decoder->Decode(&decode_buffer[0], nvalues);
   ASSERT_EQ(nvalues, values_decoded);
 


### PR DESCRIPTION
Commit [466018084861f86a9171803c6d689e9c1c1efb5a](https://github.com/apache/arrow/commit/466018084861f86a9171803c6d689e9c1c1efb5a) added support for RLE boolean decoder. We refactored some additional code making it streamlined with other cases for decoder. 

However there was a downstream dependency for a Decode function which taken in an array of `uint8` instead of `bool`. To not break any existing workload, adding back support for decode boolean datatype with array of `uint8`