### PR TITLE
ARROW-17826: [Python] Allow scalars when creating expression from compute kernels

### DIFF
--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2236,9 +2236,8 @@ cdef class Expression(_Weakrefable):
             if not isinstance(argument, Expression):
                 # Attempt to help convert this to an expression
                 try:
-                    import pyarrow.compute as pc
-                    argument = pc.scalar(argument)
-                except (ImportError, ArrowInvalid):
+                    argument = Expression._scalar(argument)
+                except ArrowInvalid:
                     raise TypeError(
                         "only other expressions allowed as arguments")
             c_arguments.push_back((<Expression> argument).expr)

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -2914,12 +2914,14 @@ def test_expression_call_function():
     assert str(pc.round(field, ndigits=1)) == \
         "round(field, {ndigits=1, round_mode=HALF_TO_EVEN})"
 
-    # mixed types are not (yet) allowed
-    with pytest.raises(TypeError):
-        pc.add(field, 1)
+    # Will convert non-expression arguments if possible
+    assert str(pc.add(field, 1)) == "add(field, 1)"
+    assert str(pc.add(field, pa.scalar(1))) == "add(field, 1)"
 
-    with pytest.raises(TypeError):
-        pc.add(1, field)
+    # Invalid pc.scalar input gives original erorr message
+    msg = "only other expressions allowed as arguments"
+    with pytest.raises(TypeError, match=msg):
+        pc.add(field, object)
 
 
 def test_cast_table_raises():


### PR DESCRIPTION
Will fix [ARROW-17826](https://issues.apache.org/jira/browse/ARROW-17826)