### PR TITLE
ARROW-17977: [CI][C++] Don't use LLVM 14 or later on Debian i386

### DIFF
--- a/ci/docker/debian-10-cpp.dockerfile
+++ b/ci/docker/debian-10-cpp.dockerfile
@@ -25,20 +25,32 @@ RUN \
     /etc/apt/sources.list.d/backports.list
 
 ARG llvm
+# We can't use LLVM 14 or later from apt.llvm.org on i386 because LLVM
+# 14 or later dropped support for i386.
 RUN apt-get update -y -q && \
+    apt-get install -y -q --no-install-recommends \
+        dpkg-dev && \
+    latest_available_llvm_i386=13 && \
+    if [ $(dpkg-architecture -qDEB_HOST_ARCH) = "i386" -a \
+         "${llvm}" -gt "${latest_available_llvm_i386}" ]; then \
+        available_llvm="${latest_available_llvm_i386}"; \
+    else \
+        available_llvm="${llvm}"; \
+    fi && \
+    apt-get update -y -q && \
     apt-get install -y -q --no-install-recommends \
         apt-transport-https \
         ca-certificates \
         gnupg \
         wget && \
     wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-    echo "deb https://apt.llvm.org/buster/ llvm-toolchain-buster-${llvm} main" > \
+    echo "deb https://apt.llvm.org/buster/ llvm-toolchain-buster-${available_llvm} main" > \
         /etc/apt/sources.list.d/llvm.list && \
     apt-get update -y -q && \
     apt-get install -y -q --no-install-recommends \
         autoconf \
         ccache \
-        clang-${llvm} \
+        clang-${available_llvm} \
         cmake \
         curl \
         g++ \
@@ -60,7 +72,7 @@ RUN apt-get update -y -q && \
         libssl-dev \
         libthrift-dev \
         libutf8proc-dev \
-        llvm-${llvm}-dev \
+        llvm-${available_llvm}-dev \
         make \
         ninja-build \
         nlohmann-json3-dev \

--- a/ci/docker/debian-11-cpp.dockerfile
+++ b/ci/docker/debian-11-cpp.dockerfile
@@ -22,20 +22,32 @@ ARG arch
 ENV DEBIAN_FRONTEND noninteractive
 
 ARG llvm
+# We can't use LLVM 14 or later from apt.llvm.org on i386 because LLVM
+# 14 or later dropped support for i386.
 RUN apt-get update -y -q && \
+    apt-get install -y -q --no-install-recommends \
+        dpkg-dev && \
+    latest_available_llvm_i386=13 && \
+    if [ $(dpkg-architecture -qDEB_HOST_ARCH) = "i386" -a \
+         "${llvm}" -gt "${latest_available_llvm_i386}" ]; then \
+        available_llvm="${latest_available_llvm_i386}"; \
+    else \
+        available_llvm="${llvm}"; \
+    fi && \
+    apt-get update -y -q && \
     apt-get install -y -q --no-install-recommends \
         apt-transport-https \
         ca-certificates \
         gnupg \
         wget && \
     wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-    echo "deb https://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-${llvm} main" > \
+    echo "deb https://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-${available_llvm} main" > \
         /etc/apt/sources.list.d/llvm.list && \
     apt-get update -y -q && \
     apt-get install -y -q --no-install-recommends \
         autoconf \
         ccache \
-        clang-${llvm} \
+        clang-${available_llvm} \
         cmake \
         curl \
         g++ \
@@ -59,7 +71,7 @@ RUN apt-get update -y -q && \
         libthrift-dev \
         libutf8proc-dev \
         libzstd-dev \
-        llvm-${llvm}-dev \
+        llvm-${available_llvm}-dev \
         make \
         ninja-build \
         nlohmann-json3-dev \


### PR DESCRIPTION
Because LLVM 14 or later doesn't provide .deb for i386 at apt.llvm.org.