### PR TITLE
ARROW-14656: [Python] Add sorting for StructArray

### DIFF
--- a/cpp/src/arrow/compute/kernels/chunked_internal.h
+++ b/cpp/src/arrow/compute/kernels/chunked_internal.h
@@ -61,6 +61,19 @@ struct ResolvedChunk<Array> {
   bool IsNull() const { return array->IsNull(index); }
 };
 
+// ResolvedChunk specialization for StructArray
+template <>
+struct ResolvedChunk<StructArray> {
+  // The target struct in chunked array.
+  const StructArray* array;
+  // The field index in the target struct.
+  const int64_t index;
+
+  ResolvedChunk(const StructArray* array, int64_t index) : array(array), index(index) {}
+
+  bool IsNull() const { return array->field(0)->IsNull(index); }
+};
+
 struct ChunkedArrayResolver : protected ::arrow::internal::ChunkResolver {
   ChunkedArrayResolver(const ChunkedArrayResolver& other)
       : ::arrow::internal::ChunkResolver(other.chunks_), chunks_(other.chunks_) {}

--- a/cpp/src/arrow/compute/kernels/chunked_internal.h
+++ b/cpp/src/arrow/compute/kernels/chunked_internal.h
@@ -64,14 +64,14 @@ struct ResolvedChunk<Array> {
 // ResolvedChunk specialization for StructArray
 template <>
 struct ResolvedChunk<StructArray> {
-  // The target struct in chunked array.
+  // The target structarray in chunked array.
   const StructArray* array;
-  // The field index in the target struct.
+  // The index in the target array.
   const int64_t index;
 
   ResolvedChunk(const StructArray* array, int64_t index) : array(array), index(index) {}
 
-  bool IsNull() const { return array->field(0)->IsNull(index); }
+  bool IsNull() const { return array->field(static_cast<int>(index)) == nullptr; }
 };
 
 struct ChunkedArrayResolver : protected ::arrow::internal::ChunkResolver {

--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -188,9 +188,7 @@ class ChunkedArraySorter : public TypeVisitor {
     return Status::OK();
   }
 
-  Status Visit(const StructType&) override {
-    return SortInternal<StructType>();
-  }
+  Status Visit(const StructType&) override { return SortInternal<StructType>(); }
 
  private:
   template <typename Type>

--- a/cpp/src/arrow/compute/kernels/vector_sort_internal.h
+++ b/cpp/src/arrow/compute/kernels/vector_sort_internal.h
@@ -480,10 +480,31 @@ class NestedValuesComparator {
       return Status::OK();
     }
 
+    // ResolvedChunk<StructArray> Prepare overload
+    Status Prepare(const ResolvedChunk<StructArray>& chunk_left,
+                  const ResolvedChunk<StructArray>&) {
+      return Prepare(*chunk_left.array);
+    }
+
+    // ResolvedChunk<StructArray> Compare overload
+    int Compare(const ResolvedChunk<StructArray>& chunk_left,
+                const ResolvedChunk<StructArray>& chunk_right, uint64_t field_index) {
+      std::shared_ptr<Array> field_left =
+          chunk_left.array->field(static_cast<int>(field_index));
+      std::shared_ptr<Array> field_right =
+          chunk_right.array->field(static_cast<int>(field_index));
+      return comparators_[field_index]->Compare(*field_left, *field_right, chunk_left.index,
+                                                chunk_right.index);
+    }
+
   private:
     struct NestedValueComparator {
       virtual int Compare(Array const &array, uint64_t offset, 
                           uint64_t leftidx, uint64_t rightidx) = 0;
+
+      virtual int Compare(Array const& left_array, Array const& right_array,
+                        uint64_t leftidx, uint64_t rightidx) = 0;
+
       virtual ~NestedValueComparator() = default;
     };
 
@@ -497,6 +518,22 @@ class NestedValuesComparator {
         const FieldArrayType& values = checked_cast<const FieldArrayType&>(array);
         auto left_value = GetView::LogicalValue(values.GetView(leftidx - offset));
         auto right_value = GetView::LogicalValue(values.GetView(rightidx - offset));
+        if (left_value == right_value)
+          return 0;
+        else if (left_value < right_value)
+          return -1;
+        else
+          return 1;
+      }
+
+      virtual int Compare(Array const& left_array, Array const& right_array,
+                        uint64_t leftidx, uint64_t rightidx) {
+        const FieldArrayType& left_values = checked_cast<const FieldArrayType&>(left_array);
+        const FieldArrayType& right_values =
+            checked_cast<const FieldArrayType&>(right_array);
+        auto left_value = GetView::LogicalValue(left_values.GetView(leftidx));
+        auto right_value = GetView::LogicalValue(right_values.GetView(rightidx));
+
         if (left_value == right_value)
           return 0;
         else if (left_value < right_value)
@@ -541,6 +578,43 @@ class NestedValuesComparator {
     };
 
   std::vector<std::shared_ptr<NestedValueComparator>> comparators_;
+};
+
+template <typename ArrayType>
+struct ResolvedChunkComparator {
+  bool Compare(const ChunkedArrayResolver& chunk_resolver, uint64_t left,
+               uint64_t right) {
+    const auto chunk_left = chunk_resolver.Resolve<ArrayType>(left);
+    const auto chunk_right = chunk_resolver.Resolve<ArrayType>(right);
+    return chunk_left.Value() < chunk_right.Value();
+  }
+};
+
+template <>
+struct ResolvedChunkComparator<StructArray> {
+  bool Compare(const ChunkedArrayResolver& chunk_resolver, uint64_t left,
+               uint64_t right) {
+    const auto chunk_left = chunk_resolver.Resolve<StructArray>(left);
+    const auto chunk_right = chunk_resolver.Resolve<StructArray>(right);
+    NestedValuesComparator nested_values_comparator;
+    auto status = nested_values_comparator.Prepare(chunk_left, chunk_right);
+
+    if (!status.ok()) {
+      return false;
+    }
+
+    for (int i = 0; i < chunk_left.array->num_fields(); i++) {
+      int val = nested_values_comparator.Compare(chunk_left, chunk_right, i);
+
+      if (val == 0) {
+        continue;
+      }
+
+      return val == -1;
+    }
+
+    return false;
+  }
 };
 
 }  // namespace internal

--- a/cpp/src/arrow/compute/kernels/vector_sort_internal.h
+++ b/cpp/src/arrow/compute/kernels/vector_sort_internal.h
@@ -456,6 +456,93 @@ Status SortChunkedArray(ExecContext* ctx, uint64_t* indices_begin, uint64_t* ind
                         const ChunkedArray& values, SortOrder sort_order,
                         NullPlacement null_placement);
 
+class NestedValuesComparator {
+  public:
+    // StructArray Compare overload
+    int Compare(StructArray const& array, uint64_t field_index, uint64_t offset,
+                uint64_t leftrowidx, uint64_t rightrowidx) {
+      std::shared_ptr<Array> field = array.field(static_cast<int>(field_index));
+      return comparators_[field_index]->Compare(*field, offset, leftrowidx, rightrowidx);
+    }
+
+    // StructArray Prepare overload
+    Status Prepare(StructArray const& array) {
+      auto fields = array.fields();
+      for (auto field = fields.begin(); field != fields.end(); field++) {
+        std::shared_ptr<DataType> physical_type = GetPhysicalType((*field)->type());
+        NestedComparatorFactory comparator_factory = NestedComparatorFactory();
+        std::shared_ptr<NestedValueComparator> current_field_comparator;
+        ARROW_ASSIGN_OR_RAISE(
+            current_field_comparator,
+            NestedComparatorFactory().MakeFieldComparator(*physical_type));
+        comparators_.push_back(current_field_comparator);
+      }
+      return Status::OK();
+    }
+
+  private:
+    struct NestedValueComparator {
+      virtual int Compare(Array const &array, uint64_t offset, 
+                          uint64_t leftidx, uint64_t rightidx) = 0;
+      virtual ~NestedValueComparator() = default;
+    };
+
+    template <typename Type>
+    struct ConcreteNestedValueComparator : NestedValueComparator {
+      using FieldArrayType = typename TypeTraits<Type>::ArrayType;
+      using GetView = GetViewType<Type>;
+
+      virtual int Compare(Array const &array, uint64_t offset, 
+                          uint64_t leftidx, uint64_t rightidx) {
+        const FieldArrayType& values = checked_cast<const FieldArrayType&>(array);
+        auto left_value = GetView::LogicalValue(values.GetView(leftidx - offset));
+        auto right_value = GetView::LogicalValue(values.GetView(rightidx - offset));
+        if (left_value == right_value)
+          return 0;
+        else if (left_value < right_value)
+          return -1;
+        else
+          return 1;
+      }
+    };
+
+    /** 
+     * Internal use factory whose purpose is to detect the right type
+     * of comparator that should be built to be able to compare two
+     * nested values in the same field or column
+     */
+    struct NestedComparatorFactory {
+      Result<std::shared_ptr<NestedValueComparator>> MakeFieldComparator(DataType const &physical_type) {
+          RETURN_NOT_OK(VisitTypeInline(physical_type, this));
+          DCHECK_NE(current_field_comparator_, nullptr);
+          return std::move(current_field_comparator_);
+      }
+
+    #define VISIT(TYPE) \
+      Status Visit(const TYPE& type) { return VisitGeneric(type); }
+
+        VISIT_SORTABLE_PHYSICAL_TYPES(VISIT)
+    #undef VISIT
+
+      Status Visit(const DataType& type) {
+        return Status::TypeError("Unsupported type for NestedComparatorFactory: ",
+                                type.ToString());
+      }
+
+      template <typename Type>
+      Status VisitGeneric(const Type&) {
+        current_field_comparator_ = std::shared_ptr<NestedValueComparator>(
+          new ConcreteNestedValueComparator<Type>()
+        );
+        return Status::OK();
+      }
+
+      std::shared_ptr<NestedValueComparator> current_field_comparator_;
+    };
+
+  std::vector<std::shared_ptr<NestedValueComparator>> comparators_;
+};
+
 }  // namespace internal
 }  // namespace compute
 }  // namespace arrow

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1402,6 +1402,22 @@ cdef class Array(_PandasConvertible):
         """
         return _pc().index(self, value, start, end, memory_pool=memory_pool)
 
+    def sort(self, order="ascending"):
+        """
+        Sort the Array
+
+        Parameters
+        ----------
+        order : "ascending" or "descending"
+            The order of the sorting.
+
+        Returns
+        -------
+        result : Array
+        """
+        indices = _pc().sort_indices(self, sort_keys=[("", order)])
+        return self.take(indices)
+
     def _to_pandas(self, options, types_mapper=None, **kwargs):
         return _array_like_to_pandas(self, options, types_mapper=types_mapper)
 
@@ -2745,6 +2761,29 @@ cdef class StructArray(Array):
         cdef Array result = pyarrow_wrap_array(GetResultValue(c_result))
         result.validate()
         return result
+
+    def sort(self, order="ascending", fieldname=None):
+        """
+        Sort the StructArray
+
+        Parameters
+        ----------
+        order : "ascending" or "descending"
+            The order of the sorting.
+        fieldname : str or None, default None
+            If to sort the array by one of its fields
+            or by the whole array.
+
+        Returns
+        -------
+        result : StructArray
+        """
+        if fieldname is not None:
+            tosort = self.field(fieldname)
+        else:
+            tosort = self
+        indices = _pc().sort_indices(tosort, sort_keys=[("", order)])
+        return self.take(indices)
 
 
 cdef class ExtensionArray(Array):

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -433,6 +433,20 @@ cdef class ChunkedArray(_PandasConvertible):
 
         return result
 
+    def sort(self, order="ascending"):
+        """
+        Sort the ChunkedArray
+        Parameters
+        ----------
+        order : "ascending" or "descending"
+            The order of the sorting.
+        Returns
+        -------
+        result : ChunkedArray
+        """
+        indices = _pc().sort_indices(self, sort_keys=[("", order)])
+        return self.take(indices)
+
     def _to_pandas(self, options, types_mapper=None, **kwargs):
         return _array_like_to_pandas(self, options, types_mapper=types_mapper)
 

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -436,10 +436,12 @@ cdef class ChunkedArray(_PandasConvertible):
     def sort(self, order="ascending"):
         """
         Sort the ChunkedArray
+
         Parameters
         ----------
         order : "ascending" or "descending"
             The order of the sorting.
+
         Returns
         -------
         result : ChunkedArray

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -725,6 +725,77 @@ def test_struct_array_from_chunked():
         pa.StructArray.from_arrays([chunked_arr], ["foo"])
 
 
+def test_array_sort():
+    arr = pa.array([5, 7, 35], type=pa.int64())
+    sorted_arr = arr.sort("descending")
+    assert sorted_arr.to_pylist() == [35, 7, 5]
+
+    arr = pa.chunked_array([[1, 2, 3], [4, 5, 6]])
+    sorted_arr = arr.sort("descending")
+    assert sorted_arr.to_pylist() == [6, 5, 4, 3, 2, 1]
+
+
+def test_struct_array_sort():
+    arr = pa.StructArray.from_arrays([
+        pa.array([5, 7, 7, 35], type=pa.int64()),
+        pa.array(["foo", "car", "bar", "foobar"])
+    ], names=["a", "b"])
+
+    sorted_arr = arr.sort("descending", fieldname="a")
+    assert sorted_arr.to_pylist() == [
+        {"a": 35, "b": "foobar"},
+        {"a": 7, "b": "car"},
+        {"a": 7, "b": "bar"},
+        {"a": 5, "b": "foo"},
+    ]
+
+    sorted_arr = arr.sort("descending")
+    assert sorted_arr.to_pylist() == [
+        {"a": 35, "b": "foobar"},
+        {"a": 7, "b": "car"},
+        {"a": 7, "b": "bar"},
+        {"a": 5, "b": "foo"},
+    ]
+
+    sorted_arr = arr.sort("ascending")
+    assert sorted_arr.to_pylist() == [
+        {"a": 5, "b": "foo"},
+        {"a": 7, "b": "bar"},
+        {"a": 7, "b": "car"},
+        {"a": 35, "b": "foobar"},
+    ]
+
+
+def test_struct_chunked_array_sort():
+    arr1 = pa.StructArray.from_arrays([
+        pa.array([5, 7], type=pa.int64()),
+        pa.array(["foo", "car"])
+    ], names=["a", "b"])
+
+    arr2 = pa.StructArray.from_arrays([
+        pa.array([7, 35], type=pa.int64()),
+        pa.array(["bar", "foobar"])
+    ], names=["a", "b"])
+
+    chunked_arr = pa.chunked_array([arr1, arr2])
+
+    sorted_arr = chunked_arr.sort("descending")
+    assert sorted_arr.to_pylist() == [
+        {"a": 35, "b": "foobar"},
+        {"a": 7, "b": "car"},
+        {"a": 7, "b": "bar"},
+        {"a": 5, "b": "foo"},
+    ]
+
+    sorted_arr = chunked_arr.sort("ascending")
+    assert sorted_arr.to_pylist() == [
+        {"a": 5, "b": "foo"},
+        {"a": 7, "b": "bar"},
+        {"a": 7, "b": "car"},
+        {"a": 35, "b": "foobar"},
+    ]
+
+
 @pytest.mark.parametrize("offset", (0, 1))
 def test_dictionary_from_buffers(offset):
     a = pa.array(["one", "two", "three", "two", "one"]).dictionary_encode()

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -877,6 +877,7 @@ def test_struct_chunked_array_sort():
         {"a": 2, "b": 1, "c": "mouse"}
     ]
 
+
 @pytest.mark.parametrize("offset", (0, 1))
 def test_dictionary_from_buffers(offset):
     a = pa.array(["one", "two", "three", "two", "one"]).dictionary_encode()

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -768,13 +768,13 @@ def test_struct_array_sort():
 
 def test_struct_chunked_array_sort():
     arr1 = pa.StructArray.from_arrays([
-        pa.array([5, 7], type=pa.int64()),
-        pa.array(["foo", "car"])
+        pa.array([5, 7, 8], type=pa.int64()),
+        pa.array(["foo", "car", "far"])
     ], names=["a", "b"])
 
     arr2 = pa.StructArray.from_arrays([
-        pa.array([7, 35], type=pa.int64()),
-        pa.array(["bar", "foobar"])
+        pa.array([7, 35, 9], type=pa.int64()),
+        pa.array(["bar", "foobar", "tar"])
     ], names=["a", "b"])
 
     chunked_arr = pa.chunked_array([arr1, arr2])
@@ -782,6 +782,8 @@ def test_struct_chunked_array_sort():
     sorted_arr = chunked_arr.sort("descending")
     assert sorted_arr.to_pylist() == [
         {"a": 35, "b": "foobar"},
+        {"a": 9, "b": "tar"},
+        {"a": 8, "b": "far"},
         {"a": 7, "b": "car"},
         {"a": 7, "b": "bar"},
         {"a": 5, "b": "foo"},
@@ -792,9 +794,88 @@ def test_struct_chunked_array_sort():
         {"a": 5, "b": "foo"},
         {"a": 7, "b": "bar"},
         {"a": 7, "b": "car"},
+        {"a": 8, "b": "far"},
+        {"a": 9, "b": "tar"},
         {"a": 35, "b": "foobar"},
     ]
 
+    arr1 = pa.StructArray.from_arrays([
+        pa.array(["foo", "car", "tar"]),
+        pa.array([5, 7, 8], type=pa.int64())
+    ], names=["a", "b"])
+
+    arr2 = pa.StructArray.from_arrays([
+        pa.array(["bar", "foobar", "far"]),
+        pa.array([7, 35, 9], type=pa.int64())
+    ], names=["a", "b"])
+
+    chunked_arr = pa.chunked_array([arr1, arr2])
+
+    sorted_arr = chunked_arr.sort("ascending")
+    assert sorted_arr.to_pylist() == [
+        {"a": "bar", "b": 7},
+        {"a": "car", "b": 7},
+        {"a": "far", "b": 9},
+        {"a": "foo", "b": 5},
+        {"a": "foobar", "b": 35},
+        {"a": "tar", "b": 8},
+    ]
+
+    sorted_arr = chunked_arr.sort("descending")
+    assert sorted_arr.to_pylist() == [
+        {"a": "tar", "b": 8},
+        {"a": "foobar", "b": 35},
+        {"a": "foo", "b": 5},
+        {"a": "far", "b": 9},
+        {"a": "car", "b": 7},
+        {"a": "bar", "b": 7},
+    ]
+
+    arr1 = pa.StructArray.from_arrays([
+        pa.array([5, 5, 5], type=pa.int64()),
+        pa.array([3, 2, 2], type=pa.int64()),
+        pa.array(["foo", "car", "tar"])
+    ], names=["a", "b", "c"])
+
+    arr2 = pa.StructArray.from_arrays([
+        pa.array([5, 5, 2], type=pa.int64()),
+        pa.array([2, 8, 3], type=pa.int64()),
+        pa.array(["bar", "foobar", "far"])
+    ], names=["a", "b", "c"])
+
+    arr3 = pa.StructArray.from_arrays([
+        pa.array([5, 5, 2], type=pa.int64()),
+        pa.array([2, 8, 1], type=pa.int64()),
+        pa.array(["cat", "dog", "mouse"])
+    ], names=["a", "b", "c"])
+
+    chunked_arr = pa.chunked_array([arr1, arr2, arr3])
+
+    sorted_arr = chunked_arr.sort("ascending")
+    assert sorted_arr.to_pylist() == [
+        {"a": 2, "b": 1, "c": "mouse"},
+        {"a": 2, "b": 3, "c": "far"},
+        {"a": 5, "b": 2, "c": "bar"},
+        {"a": 5, "b": 2, "c": "car"},
+        {"a": 5, "b": 2, "c": "cat"},
+        {"a": 5, "b": 2, "c": "tar"},
+        {"a": 5, "b": 3, "c": "foo"},
+        {"a": 5, "b": 8, "c": "dog"},
+        {"a": 5, "b": 8, "c": "foobar"}
+    ]
+
+    sorted_arr = chunked_arr.sort("descending")
+    assert sorted_arr.to_pylist() == [
+        {"a": 5, "b": 8, "c": "foobar"},
+        {"a": 5, "b": 8, "c": "dog"},
+        {"a": 5, "b": 3, "c": "foo"},
+        {"a": 5, "b": 2, "c": "tar"},
+        {"a": 5, "b": 2, "c": "cat"},
+        {"a": 5, "b": 2, "c": "car"},
+        {"a": 5, "b": 2, "c": "bar"},
+        {"a": 2, "b": 3, "c": "far"},
+        {"a": 2, "b": 1, "c": "mouse"}
+    ]
 
 @pytest.mark.parametrize("offset", (0, 1))
 def test_dictionary_from_buffers(offset):


### PR DESCRIPTION
This is the first PR for https://github.com/apache/arrow/pull/11659 (splitting up this PR into multiple PRs). This PR adds a sort helper function for the array, chunked_array and array of structs (StructArray) and chunked array of structs sorting.

A `NestedValuesComparator` is added which is planned to be a common comparator for anything that has nested fields and columns. Follow up PRs will update the Table, RecordBatch etc sorting implementations to use this `NestedValuesComparator`.

Related issue: https://github.com/apache/arrow/issues/33206