### PR TITLE
ARROW-17973: [C++] Expression::ToString wrong for nullary function call

### DIFF
--- a/cpp/src/arrow/compute/exec/expression.cc
+++ b/cpp/src/arrow/compute/exec/expression.cc
@@ -196,11 +196,11 @@ std::string Expression::ToString() const {
 
   if (call->options) {
     out += call->options->ToString();
-    out.resize(out.size() + 1);
-  } else {
-    out.resize(out.size() - 1);
+  } else if (call->arguments.size()) {
+    out.resize(out.size() - 2);
   }
-  out.back() = ')';
+
+  out += ')';
   return out;
 }
 

--- a/cpp/src/arrow/compute/exec/expression_test.cc
+++ b/cpp/src/arrow/compute/exec/expression_test.cc
@@ -311,6 +311,9 @@ TEST(Expression, ToString) {
                 })
                 .ToString(),
             "{a=a, renamed_a=a, three=3, b=" + in_12.ToString() + "}");
+
+  EXPECT_EQ(call("round", {literal(3.14)}, compute::RoundOptions()).ToString(),
+            "round(3.14, {ndigits=0, round_mode=HALF_TO_EVEN})");
 }
 
 TEST(Expression, Equality) {

--- a/cpp/src/arrow/compute/exec/expression_test.cc
+++ b/cpp/src/arrow/compute/exec/expression_test.cc
@@ -284,8 +284,7 @@ TEST(Expression, ToString) {
       "allow_time_overflow=false, allow_decimal_truncate=false, "
       "allow_float_truncate=false, allow_invalid_utf8=false})");
 
-  // NB: corrupted for nullary functions but we don't have any of those
-  EXPECT_EQ(call("widgetify", {}).ToString(), "widgetif)");
+  EXPECT_EQ(call("widgetify", {}).ToString(), "widgetify()");
   EXPECT_EQ(
       call("widgetify", {literal(1)}, std::make_shared<WidgetifyOptions>()).ToString(),
       "widgetify(1, widgetify)");

--- a/cpp/src/arrow/compute/exec/expression_test.cc
+++ b/cpp/src/arrow/compute/exec/expression_test.cc
@@ -314,6 +314,8 @@ TEST(Expression, ToString) {
 
   EXPECT_EQ(call("round", {literal(3.14)}, compute::RoundOptions()).ToString(),
             "round(3.14, {ndigits=0, round_mode=HALF_TO_EVEN})");
+  EXPECT_EQ(call("random", {}, compute::RandomOptions()).ToString(),
+            "random({initializer=SystemRandom, seed=0})");
 }
 
 TEST(Expression, Equality) {


### PR DESCRIPTION
This PR fixes the `ToString()` method in the `Expression` class to handle functions with no arguments.