### PR TITLE
ARROW-17990: [C++] Restore -mbmi2 flag

### DIFF
--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -200,7 +200,7 @@ if(ARROW_HAVE_RUNTIME_AVX2)
   set_source_files_properties(level_conversion_bmi2.cc
                               PROPERTIES SKIP_PRECOMPILE_HEADERS ON
                                          COMPILE_FLAGS
-                                         "${ARROW_AVX2_FLAG} -DARROW_HAVE_BMI2 ${CXX_FLAGS_RELEASE}"
+                                         "${ARROW_AVX2_FLAG} -DARROW_HAVE_BMI2 -mbmi2 ${CXX_FLAGS_RELEASE}"
   )
 endif()
 


### PR DESCRIPTION
https://github.com/apache/arrow/pull/14342 removed -mbmi2 flag accidentally. It should not be removed. If we remove it, a build error is occurred on macOS High Sierra.

https://github.com/ursacomputing/crossbow/actions/runs/3225397138/jobs/5278904264#step:13:7034

    /Users/voltrondata/tmp/hbtmp/apache-arrow-20221011-35535-3alkwv/cpp/src/parquet/level_conversion_inc.h:278:10:
    error: always_inline function '_pext_u64' requires target feature
    'bmi2', but would be inlined into function 'ExtractBits' that is
    compiled without support for 'bmi2'
      return _pext_u64(bitmap, select_bitmap);
             ^