### PR TITLE
ARROW-17992: [CI][C++][Conda] Remove needless clangdev/llvmdev pinnings

### DIFF
--- a/dev/tasks/conda-recipes/arrow-cpp/meta.yaml
+++ b/dev/tasks/conda-recipes/arrow-cpp/meta.yaml
@@ -184,9 +184,9 @@ outputs:
         - {{ compiler("cuda") }}  # [cuda_compiler_version != "None"]
       host:
         - {{ pin_subpackage('arrow-cpp', exact=True) }}
-        - clangdev 10  # [not (osx and arm64)]
+        - clangdev  # [not (osx and arm64)]
         - cython
-        - llvmdev 10   # [not (osx and arm64)]
+        - llvmdev   # [not (osx and arm64)]
         - numpy
         - openssl
         - python
@@ -262,9 +262,9 @@ outputs:
       host:
         - {{ pin_subpackage('arrow-cpp', exact=True) }}
         - {{ pin_subpackage('pyarrow', exact=True) }}
-        - clangdev 10  # [not (osx and arm64)]
+        - clangdev  # [not (osx and arm64)]
         - cython
-        - llvmdev 10   # [not (osx and arm64)]
+        - llvmdev   # [not (osx and arm64)]
         - numpy
         - python
         - openssl

--- a/dev/tasks/conda-recipes/arrow-cpp/meta.yaml
+++ b/dev/tasks/conda-recipes/arrow-cpp/meta.yaml
@@ -81,8 +81,8 @@ outputs:
         - google-cloud-cpp  # [linux]
         - grpc-cpp
         - libprotobuf
-        - clangdev  # [not (osx and arm64)]
-        - llvmdev   # [not (osx and arm64)]
+        - clangdev >=11 # [not (osx and arm64)]
+        - llvmdev >=11  # [not (osx and arm64)]
         - libutf8proc
         - lz4-c
         - numpy
@@ -184,9 +184,9 @@ outputs:
         - {{ compiler("cuda") }}  # [cuda_compiler_version != "None"]
       host:
         - {{ pin_subpackage('arrow-cpp', exact=True) }}
-        - clangdev  # [not (osx and arm64)]
+        - clangdev >=11 # [not (osx and arm64)]
         - cython
-        - llvmdev   # [not (osx and arm64)]
+        - llvmdev >=11  # [not (osx and arm64)]
         - numpy
         - openssl
         - python
@@ -262,9 +262,9 @@ outputs:
       host:
         - {{ pin_subpackage('arrow-cpp', exact=True) }}
         - {{ pin_subpackage('pyarrow', exact=True) }}
-        - clangdev  # [not (osx and arm64)]
+        - clangdev >=11 # [not (osx and arm64)]
         - cython
-        - llvmdev   # [not (osx and arm64)]
+        - llvmdev >=11  # [not (osx and arm64)]
         - numpy
         - python
         - openssl

--- a/dev/tasks/conda-recipes/arrow-cpp/meta.yaml
+++ b/dev/tasks/conda-recipes/arrow-cpp/meta.yaml
@@ -81,8 +81,8 @@ outputs:
         - google-cloud-cpp  # [linux]
         - grpc-cpp
         - libprotobuf
-        - clangdev 10  # [not (osx and arm64)]
-        - llvmdev 10   # [not (osx and arm64)]
+        - clangdev  # [not (osx and arm64)]
+        - llvmdev   # [not (osx and arm64)]
         - libutf8proc
         - lz4-c
         - numpy


### PR DESCRIPTION
We need clang 11 or later for Gandiva.

https://dev.azure.com/ursacomputing/crossbow/_build/results?buildId=37098&view=logs&j=4c86bc1b-1091-5192-4404-c74dfaad23e7&t=41795ef0-6501-5db4-3ad4-33c0cf085626&l=1001

    [6/94] Generating decimal_ops.bc
    FAILED: src/gandiva/precompiled/decimal_ops.bc
    D:/bld/arrow-cpp-ext_1665469353844/work/cpp/build/src/gandiva/precompiled/decimal_ops.bc
    cmd.exe /C "cd /D
    D:\bld\arrow-cpp-ext_1665469353844\work\cpp\build\src\gandiva\precompiled
    && D:\bld\arrow-cpp-ext_1665469353844\_h_env\Library\bin\clang.exe
    -std=c++17 -fms-compatibility -fms-compatibility-version=19.20
    -DGANDIVA_IR -DNDEBUG -DARROW_STATIC -DGANDIVA_STATIC
    -fno-use-cxa-atexit -emit-llvm -O3 -c
    D:/bld/arrow-cpp-ext_1665469353844/work/cpp/src/gandiva/precompiled/decimal_ops.cc
    -o
    D:/bld/arrow-cpp-ext_1665469353844/work/cpp/build/src/gandiva/precompiled/decimal_ops.bc
    -ID:/bld/arrow-cpp-ext_1665469353844/work/cpp/src
    -ID:/bld/arrow-cpp-ext_1665469353844/work/cpp/build/src
    -ID:/bld/arrow-cpp-ext_1665469353844/_h_env/Library/include"
    In file included from
    D:/bld/arrow-cpp-ext_1665469353844/work/cpp/src/gandiva/precompiled/decimal_ops.cc:20:
    In file included from
    D:/bld/arrow-cpp-ext_1665469353844/work/cpp/src\gandiva/precompiled/decimal_ops.h:20:
    In file included from C:\Program Files (x86)\Microsoft Visual
    Studio\2019\Enterprise\VC\Tools\MSVC\14.29.30133\include\cstdint:9:
    C:\Program Files (x86)\Microsoft Visual
    Studio\2019\Enterprise\VC\Tools\MSVC\14.29.30133\include\yvals_core.h:571:2:
    error: STL1000: Unexpected compiler version, expected Clang 11.0.0
    or newer.
    #error STL1000: Unexpected compiler version, expected Clang 11.0.0 or newer.
     ^

This was added by me in #13892 but I can't remember why I pinned to 10...