### PR TITLE
ARROW-17993: [CI][Release] Use Node.js 16 LTS for verify-rc-source-*-conda-*

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -836,7 +836,7 @@ test_js() {
   show_header "Build and test JavaScript libraries"
 
   maybe_setup_nodejs || exit 1
-  maybe_setup_conda nodejs=17 || exit 1
+  maybe_setup_conda nodejs=18 || exit 1
 
   if ! command -v yarn &> /dev/null; then
     npm install -g yarn

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -836,7 +836,7 @@ test_js() {
   show_header "Build and test JavaScript libraries"
 
   maybe_setup_nodejs || exit 1
-  maybe_setup_conda nodejs=18 || exit 1
+  maybe_setup_conda nodejs=16 || exit 1
 
   if ! command -v yarn &> /dev/null; then
     npm install -g yarn


### PR DESCRIPTION
Because Node.js 17 and expect 29.1.2 are conflicted.

https://github.com/ursacomputing/crossbow/actions/runs/3224409421/jobs/5275509496#step:6:759

    error expect@29.1.2: The engine "node" is incompatible with this
    module. Expected version "^14.15.0 || ^16.10.0 || >=18.0.0". Got
    "17.9.0"