### PR TITLE
ARROW-18028: [Dev][Archery][Crossbow] Always use GitHub Action's run page URL in PR comment

### DIFF
--- a/dev/archery/archery/crossbow/reports.py
+++ b/dev/archery/archery/crossbow/reports.py
@@ -269,12 +269,11 @@ class EmailReport(JinjaReport):
 
 class CommentReport(Report):
 
-    _markdown_badge = '[![{title}]({badge})]({url})'
+    _markdown_badge = '[![{title}]({badge})]({{url}})'
 
     badges = {
         'github': _markdown_badge.format(
             title='Github Actions',
-            url='https://github.com/{repo}/actions?query=branch:{branch}',
             badge=(
                 'https://github.com/{repo}/workflows/Crossbow/'
                 'badge.svg?branch={branch}'
@@ -282,36 +281,28 @@ class CommentReport(Report):
         ),
         'azure': _markdown_badge.format(
             title='Azure',
-            url=(
-                'https://dev.azure.com/{repo}/_build/latest'
-                '?definitionId=1&branchName={branch}'
-            ),
             badge=(
                 'https://dev.azure.com/{repo}/_apis/build/status/'
                 '{repo_dotted}?branchName={branch}'
             )
         ),
         'travis': _markdown_badge.format(
-            title='TravisCI',
-            url='https://app.travis-ci.com/github/{repo}/branches',
+            title='Travis CI',
             badge='https://img.shields.io/travis/{repo}/{branch}.svg'
         ),
         'circle': _markdown_badge.format(
             title='CircleCI',
-            url='https://circleci.com/gh/{repo}/tree/{branch}',
             badge=(
                 'https://img.shields.io/circleci/build/github'
                 '/{repo}/{branch}.svg'
             )
         ),
         'appveyor': _markdown_badge.format(
-            title='Appveyor',
-            url='https://ci.appveyor.com/project/{repo}/history',
+            title='AppVeyor',
             badge='https://img.shields.io/appveyor/ci/{repo}/{branch}.svg'
         ),
         'drone': _markdown_badge.format(
             title='Drone',
-            url='https://cloud.drone.io/{repo}',
             badge='https://img.shields.io/drone/build/{repo}/{branch}.svg'
         ),
     }
@@ -338,7 +329,8 @@ class CommentReport(Report):
                 badge = template.format(
                     repo=self.crossbow_repo,
                     repo_dotted=self.crossbow_repo.replace('/', '.'),
-                    branch=branch
+                    branch=branch,
+                    url=self.task_url(task)
                 )
             except KeyError:
                 badge = 'unsupported CI service `{}`'.format(task.ci)

--- a/dev/archery/archery/crossbow/tests/fixtures/crossbow-success-message.md
+++ b/dev/archery/archery/crossbow/tests/fixtures/crossbow-success-message.md
@@ -4,7 +4,7 @@ Submitted crossbow builds: [{repo} @ {branch}](https://github.com/{repo}/branche
 
 |Task|Status|
 |----|------|
-|docker-cpp-cmake32|[![CircleCI](https://img.shields.io/circleci/build/github/{repo}/{branch}-circle-docker-cpp-cmake32.svg)](https://circleci.com/gh/{repo}/tree/{branch}-circle-docker-cpp-cmake32)|
-|wheel-osx-cp36m|[![TravisCI](https://img.shields.io/travis/{repo}/{branch}-travis-wheel-osx-cp36m.svg)](https://app.travis-ci.com/github/{repo}/branches)|
-|wheel-osx-cp37m|[![TravisCI](https://img.shields.io/travis/{repo}/{branch}-travis-wheel-osx-cp37m.svg)](https://app.travis-ci.com/github/{repo}/branches)|
-|wheel-win-cp36m|[![Appveyor](https://img.shields.io/appveyor/ci/{repo}/{branch}-appveyor-wheel-win-cp36m.svg)](https://ci.appveyor.com/project/{repo}/history)|
+|docker-cpp-cmake32|[![CircleCI](https://img.shields.io/circleci/build/github/{repo}/{branch}-circle-docker-cpp-cmake32.svg)](https://github.com/apache/crossbow/runs/1)|
+|wheel-osx-cp36m|[![Travis CI](https://img.shields.io/travis/{repo}/{branch}-travis-wheel-osx-cp36m.svg)](https://github.com/apache/crossbow/runs/3)|
+|wheel-osx-cp37m|[![Travis CI](https://img.shields.io/travis/{repo}/{branch}-travis-wheel-osx-cp37m.svg)](https://github.com/apache/crossbow/runs/2)|
+|wheel-win-cp36m|[![AppVeyor](https://img.shields.io/appveyor/ci/{repo}/{branch}-appveyor-wheel-win-cp36m.svg)](https://github.com/apache/crossbow/runs/4)|


### PR DESCRIPTION
We always use
https://app.travis-ci.com/github/ursacomputing/crossbow/branches for URL of jobs that ran on Travis CI. For example:
https://github.com/apache/arrow/pull/14300#issuecomment-1269440972

It's inconvenient because we need to find the target build by ourselves.

We use another URL for job URL in nightly build report e-mail. It's GitHub Action's run page URL. For example:
https://github.com/ursacomputing/crossbow/runs/8841634652

This change uses GitHub Action's run page URL in PR comment too.