### PR TITLE
ARROW-17991: [Python] [C++] Added compression support to pyarrow.dataset.ipc format.

### DIFF
--- a/cpp/src/arrow/dataset/file_ipc.h
+++ b/cpp/src/arrow/dataset/file_ipc.h
@@ -28,6 +28,7 @@
 #include "arrow/io/type_fwd.h"
 #include "arrow/ipc/type_fwd.h"
 #include "arrow/result.h"
+#include "arrow/ipc/feather.h"
 
 namespace arrow {
 namespace dataset {
@@ -83,8 +84,7 @@ class ARROW_DS_EXPORT IpcFragmentScanOptions : public FragmentScanOptions {
 
 class ARROW_DS_EXPORT IpcFileWriteOptions : public FileWriteOptions {
  public:
-  /// Options passed to ipc::MakeFileWriter. use_threads is ignored
-  std::shared_ptr<ipc::IpcWriteOptions> options;
+  std::shared_ptr<ipc::feather::WriteProperties> properties;
 
   /// custom_metadata written to the file's footer
   std::shared_ptr<const KeyValueMetadata> metadata;

--- a/python/pyarrow/_dataset.pxd
+++ b/python/pyarrow/_dataset.pxd
@@ -124,6 +124,13 @@ cdef class FileFragment(Fragment):
     cdef void init(self, const shared_ptr[CFragment]& sp)
 
 
+cdef class IpcWriteProperties(_Weakrefable):
+    cdef:
+        unique_ptr[CFeatherProperties] properties
+
+    @staticmethod
+    cdef IpcWriteProperties wrap(CFeatherProperties properties)
+
 cdef class Partitioning(_Weakrefable):
 
     cdef:

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -26,7 +26,6 @@ from pyarrow._dataset import (  # noqa
     Dataset,
     DatasetFactory,
     DirectoryPartitioning,
-    FeatherFileFormat,
     FilenamePartitioning,
     FileFormat,
     FileFragment,
@@ -287,8 +286,6 @@ def _ensure_format(obj):
         return ParquetFileFormat()
     elif obj in {"ipc", "arrow"}:
         return IpcFileFormat()
-    elif obj == "feather":
-        return FeatherFileFormat()
     elif obj == "csv":
         return CsvFileFormat()
     elif obj == "orc":

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1508,6 +1508,18 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
         CMetadataVersion_V3" arrow::ipc::MetadataVersion::V3"
         CMetadataVersion_V4" arrow::ipc::MetadataVersion::V4"
         CMetadataVersion_V5" arrow::ipc::MetadataVersion::V5"
+    
+    cdef cppclass CFeatherProperties" arrow::ipc::feather::WriteProperties":
+        int version
+        int chunksize
+        CCompressionType compression
+        int compression_level
+        
+        CFeatherProperties()
+        CFeatherProperties(CFeatherProperties&&)
+        
+        @staticmethod
+        CFeatherProperties Defaults()
 
     cdef cppclass CIpcWriteOptions" arrow::ipc::IpcWriteOptions":
         c_bool allow_64bit
@@ -1520,6 +1532,9 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
         c_bool use_threads
         c_bool emit_dictionary_deltas
         c_bool unify_dictionaries
+        
+        CIpcWriteOptions()
+        CIpcWriteOptions(CIpcWriteOptions&&)
 
         @staticmethod
         CIpcWriteOptions Defaults()

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -256,7 +256,7 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
 
     cdef cppclass CIpcFileWriteOptions \
             "arrow::dataset::IpcFileWriteOptions"(CFileWriteOptions):
-        pass
+        shared_ptr[CFeatherProperties] properties
 
     cdef cppclass CIpcFileFormat "arrow::dataset::IpcFileFormat"(
             CFileFormat):

--- a/python/pyarrow/includes/libarrow_feather.pxd
+++ b/python/pyarrow/includes/libarrow_feather.pxd
@@ -20,18 +20,12 @@
 from pyarrow.includes.libarrow cimport (CCompressionType, CStatus, CTable,
                                         COutputStream, CResult, shared_ptr,
                                         vector, CRandomAccessFile, CSchema,
-                                        c_string, CIpcReadOptions)
+                                        c_string, CIpcReadOptions, CFeatherProperties)
 
 
 cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
     int kFeatherV1Version" arrow::ipc::feather::kFeatherV1Version"
     int kFeatherV2Version" arrow::ipc::feather::kFeatherV2Version"
-
-    cdef cppclass CFeatherProperties" arrow::ipc::feather::WriteProperties":
-        int version
-        int chunksize
-        CCompressionType compression
-        int compression_level
 
     CStatus WriteFeather" arrow::ipc::feather::WriteTable" \
         (const CTable& table, COutputStream* out,


### PR DESCRIPTION
The normal pyarrow feather writer supports setting a small set of properties when writing: compression, compression_level and chunk_size. These are stored in a struct, `ipc::feather::WriteProperties`. In this PR I've used this same struct to add the compression options to the dataset ipc writer.
Note that this is different from the struct `ipc::IpcWriteOptions` and also from `dataset::IpcFileWriteOptions`. When creating the writer, `WriteProperties` is used to overwrite the default options in `ipc::IpcWriteOptions` for compression, the same way as happens in `ipc::feather::WriteTable`.

The alternative is to mimic the way it works for CSV, and expose `ipc::IpcWriteOptions` in python. But the the dataset ipc writer would have more functionality. Also there's a bunch of property in it that I think don't make sense to use in python. Lastly, the compression codec in that struct needs to be initialized by calling some C++ code that must be run when setting the compression.