### PR TITLE
ARROW-15540: [C++] Allow the substrait consumer to accept plans with hints and nullable literals

### DIFF
--- a/cpp/src/arrow/engine/substrait/expression_internal.cc
+++ b/cpp/src/arrow/engine/substrait/expression_internal.cc
@@ -295,7 +295,8 @@ Result<compute::Expression> FromProto(const substrait::Expression& expr,
 Result<Datum> FromProto(const substrait::Expression::Literal& lit,
                         const ExtensionSet& ext_set,
                         const ConversionOptions& conversion_options) {
-  if (lit.nullable()) {
+  if (lit.nullable() &&
+      conversion_options.strictness == ConversionStrictness::EXACT_ROUNDTRIP) {
     // FIXME not sure how this field should be interpreted and there's no way to round
     // trip it through arrow
     return Status::Invalid(

--- a/cpp/src/arrow/engine/substrait/serde.cc
+++ b/cpp/src/arrow/engine/substrait/serde.cc
@@ -358,7 +358,8 @@ inline google::protobuf::util::TypeResolver* GetGeneratedTypeResolver() {
 }
 
 Result<std::shared_ptr<Buffer>> SubstraitFromJSON(std::string_view type_name,
-                                                  std::string_view json) {
+                                                  std::string_view json,
+                                                  bool ignore_unknown_fields) {
   std::string type_url = "/substrait." + std::string(type_name);
 
   google::protobuf::io::ArrayInputStream json_stream{json.data(),
@@ -367,7 +368,7 @@ Result<std::shared_ptr<Buffer>> SubstraitFromJSON(std::string_view type_name,
   std::string out;
   google::protobuf::io::StringOutputStream out_stream{&out};
   google::protobuf::util::JsonParseOptions json_opts;
-  json_opts.ignore_unknown_fields = true;
+  json_opts.ignore_unknown_fields = ignore_unknown_fields;
   auto status = google::protobuf::util::JsonToBinaryStream(
       GetGeneratedTypeResolver(), type_url, &json_stream, &out_stream,
       std::move(json_opts));

--- a/cpp/src/arrow/engine/substrait/serde.h
+++ b/cpp/src/arrow/engine/substrait/serde.h
@@ -261,10 +261,17 @@ Status CheckMessagesEquivalent(std::string_view message_name, const Buffer& l_bu
 ///
 /// \param[in] type_name the name of the Substrait message type to convert
 /// \param[in] json the JSON string to convert
+/// \param[in] ignore_unknown_fields if true then unknown fields will be ignored and
+///            will not cause an error
+///
+///            This should generally be true to allow consumption of plans from newer
+///            producers but setting to false can be useful if you are testing
+///            conformance to a specific Substrait version
 /// \return a buffer filled with the binary protobuf serialization of message
 ARROW_ENGINE_EXPORT
 Result<std::shared_ptr<Buffer>> SubstraitFromJSON(std::string_view type_name,
-                                                  std::string_view json);
+                                                  std::string_view json,
+                                                  bool ignore_unknown_fields = false);
 
 /// \brief Utility function to convert a binary protobuf serialization of a Substrait
 /// message to JSON

--- a/cpp/src/arrow/engine/substrait/serde.h
+++ b/cpp/src/arrow/engine/substrait/serde.h
@@ -271,7 +271,7 @@ Status CheckMessagesEquivalent(std::string_view message_name, const Buffer& l_bu
 ARROW_ENGINE_EXPORT
 Result<std::shared_ptr<Buffer>> SubstraitFromJSON(std::string_view type_name,
                                                   std::string_view json,
-                                                  bool ignore_unknown_fields = false);
+                                                  bool ignore_unknown_fields = true);
 
 /// \brief Utility function to convert a binary protobuf serialization of a Substrait
 /// message to JSON


### PR DESCRIPTION
As long as the conversion strictness is not EXACT_ROUNDTRIP we now ignore these fields if present.