### PR TITLE
MINOR: [Archery] Fix crossbow nightly reports URL

### DIFF
--- a/dev/archery/archery/crossbow/tests/fixtures/chat-report-extra-message-failure.txt
+++ b/dev/archery/archery/crossbow/tests/fixtures/chat-report-extra-message-failure.txt
@@ -1,5 +1,5 @@
 
-*<https://crossbow.voltrondata.com|Archery crossbow report> for <https://github.com/apache/crossbow/branches/all?query=ursabot-1|ursabot-1>*
+*<http://crossbow.voltrondata.com|Archery crossbow report> for <https://github.com/apache/crossbow/branches/all?query=ursabot-1|ursabot-1>*
 
 :x: *1 failed jobs*
 - <https://github.com/apache/crossbow/runs/2|wheel-osx-cp37m>

--- a/dev/archery/archery/crossbow/tests/fixtures/chat-report-extra-message-success.txt
+++ b/dev/archery/archery/crossbow/tests/fixtures/chat-report-extra-message-success.txt
@@ -1,5 +1,5 @@
 
-*<https://crossbow.voltrondata.com|Archery crossbow report> for <https://github.com/apache/crossbow/branches/all?query=ursabot-1|ursabot-1>*
+*<http://crossbow.voltrondata.com|Archery crossbow report> for <https://github.com/apache/crossbow/branches/all?query=ursabot-1|ursabot-1>*
 
 
 :tada: *4 successful jobs*

--- a/dev/archery/archery/crossbow/tests/fixtures/chat-report.txt
+++ b/dev/archery/archery/crossbow/tests/fixtures/chat-report.txt
@@ -1,5 +1,5 @@
 
-*<https://crossbow.voltrondata.com|Archery crossbow report> for <https://github.com/apache/crossbow/branches/all?query=ursabot-1|ursabot-1>*
+*<http://crossbow.voltrondata.com|Archery crossbow report> for <https://github.com/apache/crossbow/branches/all?query=ursabot-1|ursabot-1>*
 
 :x: *1 failed jobs*
 - <https://github.com/apache/crossbow/runs/2|wheel-osx-cp37m>

--- a/dev/archery/archery/crossbow/tests/fixtures/email-report.txt
+++ b/dev/archery/archery/crossbow/tests/fixtures/email-report.txt
@@ -4,7 +4,7 @@ Subject: [NIGHTLY] Arrow Build Report for Job ursabot-1: 2 failed, 1 pending
 
 Arrow Build Report for Job ursabot-1
 
-See https://crossbow.voltrondata.com/ for more information.
+See http://crossbow.voltrondata.com/ for more information.
 
 All tasks: https://github.com/apache/crossbow/branches/all?query=ursabot-1
 

--- a/dev/archery/archery/templates/chat_nightly_report.txt.j2
+++ b/dev/archery/archery/templates/chat_nightly_report.txt.j2
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #}
-*<https://crossbow.voltrondata.com|Archery crossbow report> for <{{ report.url(report.job.branch) }}|{{ report.job.branch }}>*
+*<http://crossbow.voltrondata.com|Archery crossbow report> for <{{ report.url(report.job.branch) }}|{{ report.job.branch }}>*
 {% if report.tasks_by_state["failure"] %}
 :x: *{{ report.tasks_by_state["failure"] | length }} failed jobs*
 {% for task_name, task in report.tasks_by_state["failure"] | dictsort -%}

--- a/dev/archery/archery/templates/email_nightly_report.txt.j2
+++ b/dev/archery/archery/templates/email_nightly_report.txt.j2
@@ -24,7 +24,7 @@ Subject: [NIGHTLY] Arrow Build Report for Job {{report.job.branch}}: {{ (report.
 
 Arrow Build Report for Job {{ report.job.branch }}
 
-See https://crossbow.voltrondata.com/ for more information.
+See http://crossbow.voltrondata.com/ for more information.
 
 All tasks: {{ report.url(report.job.branch) }}
 {% if report.tasks_by_state["failure"] %}


### PR DESCRIPTION
Crossbow nightly reports page was moved to S3 instead of being served as a static page on GitHub pages. All our links on the reports, chat and email, are currently not working because we currently only support http instead of https.