### PR TITLE
ARROW-18031: [C++][Parquet] Undefined behavior in bool RLE decoder

### DIFF
--- a/cpp/src/arrow/util/bit_stream_utils.h
+++ b/cpp/src/arrow/util/bit_stream_utils.h
@@ -416,8 +416,7 @@ inline bool BitReader::GetAligned(int num_bytes, T* v) {
     // the LSB of the next byte and move on. If we memcpy + FromLittleEndian
     // as usual, we have potential undefined behavior for bools if the value
     // isn't 0 or 1
-    uint8_t tmp = arrow::bit_util::FromLittleEndian(*(buffer_ + byte_offset_));
-    *v = tmp & 1;
+    *v = *(buffer_ + byte_offset_) & 1;    
   } else {
     memcpy(v, buffer_ + byte_offset_, num_bytes);
     *v = arrow::bit_util::FromLittleEndian(*v);

--- a/cpp/src/arrow/util/bit_stream_utils.h
+++ b/cpp/src/arrow/util/bit_stream_utils.h
@@ -411,8 +411,17 @@ inline bool BitReader::GetAligned(int num_bytes, T* v) {
 
   // Advance byte_offset to next unread byte and read num_bytes
   byte_offset_ += bytes_read;
-  memcpy(v, buffer_ + byte_offset_, num_bytes);
-  *v = arrow::bit_util::FromLittleEndian(*v);
+  if constexpr(std::is_same_v<T, bool>) {
+    // ARROW-18031: if we're trying to get an aligned bool, just check 
+    // the LSB of the next byte and move on. If we memcpy + FromLittleEndian
+    // as usual, we have potential undefined behavior for bools if the value
+    // isn't 0 or 1
+    uint8_t tmp = arrow::bit_util::FromLittleEndian(*(buffer_ + byte_offset_));
+    *v = tmp & 1;
+  } else {
+    memcpy(v, buffer_ + byte_offset_, num_bytes);
+    *v = arrow::bit_util::FromLittleEndian(*v);
+  }
   byte_offset_ += num_bytes;
 
   bit_offset_ = 0;

--- a/cpp/src/arrow/util/bit_stream_utils.h
+++ b/cpp/src/arrow/util/bit_stream_utils.h
@@ -411,12 +411,12 @@ inline bool BitReader::GetAligned(int num_bytes, T* v) {
 
   // Advance byte_offset to next unread byte and read num_bytes
   byte_offset_ += bytes_read;
-  if constexpr(std::is_same_v<T, bool>) {
-    // ARROW-18031: if we're trying to get an aligned bool, just check 
+  if constexpr (std::is_same_v<T, bool>) {
+    // ARROW-18031: if we're trying to get an aligned bool, just check
     // the LSB of the next byte and move on. If we memcpy + FromLittleEndian
     // as usual, we have potential undefined behavior for bools if the value
     // isn't 0 or 1
-    *v = *(buffer_ + byte_offset_) & 1;    
+    *v = *(buffer_ + byte_offset_) & 1;
   } else {
     memcpy(v, buffer_ + byte_offset_, num_bytes);
     *v = arrow::bit_util::FromLittleEndian(*v);


### PR DESCRIPTION
For `BitReader::GetAligned` we need to specialize the behavior for `bool` so that we don't get undefined behavior on potential bad input. Found by the fuzzer.