### PR TITLE
ARROW-18033: [CI] Use $GITHUB_OUTPUT instead of set-output

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -174,7 +174,7 @@ jobs:
       - name: ccache info
         id: ccache-info
         run: |
-          echo "::set-output name=cache-dir::$(ccache --get-config cache_dir)"
+          echo "cache-dir=$(ccache --get-config cache_dir)" >> $GITHUB_OUTPUT
       - name: Cache ccache
         uses: actions/cache@v3
         with:
@@ -270,7 +270,7 @@ jobs:
         id: ccache-info
         shell: bash
         run: |
-          echo "::set-output name=cache-dir::$(ccache --get-config cache_dir)"
+          echo "cache-dir=$(ccache --get-config cache_dir)" >> $GITHUB_OUTPUT
       - name: Cache ccache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -161,7 +161,7 @@ jobs:
       - name: ccache info
         id: ccache-info
         run: |
-          echo "::set-output name=cache-dir::$(ccache --get-config cache_dir)"
+          echo "cache-dir=$(ccache --get-config cache_dir)" >> $GITHUB_OUTPUT
       - name: Cache ccache
         uses: actions/cache@v3
         with:
@@ -274,7 +274,8 @@ jobs:
       - name: RubyGems info
         id: rubygems-info
         run: |
-          Write-Output "::set-output name=gem-dir::$(ridk exec gem env gemdir)"
+          Write-Output "gem-dir=$(ridk exec gem env gemdir)" | `
+            Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
       - name: Cache RubyGems
         uses: actions/cache@v3
         with:

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -40,7 +40,7 @@ jobs:
         id: save-version
         shell: bash
         run: |
-          echo "::set-output name=pkg_version::$(grep ^Version arrow/r/DESCRIPTION | sed s/Version:\ //)"
+          echo "pkg_version=$(grep ^Version arrow/r/DESCRIPTION | sed s/Version:\ //)" >> $GITHUB_OUTPUT
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -215,14 +215,14 @@ jobs:
 
           # encode contrib.url for artifact name
           cmd <- paste0(
-            "::set-output name=path::",
+            "path=",
             gsub(
               "/", "__",
               contrib.url("", type = "binary")
             ),
             "\n"
           )
-          cat(cmd)
+          cat(cmd, file = Sys.getenv("GITHUB_OUTPUT"), append = TRUE)
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Because set-output is deprecated.

See also:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/