### PR TITLE
ARROW-18047: [Dev][Archery][Crossbow] Queue.put() should use Job.queue setter

### DIFF
--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -664,7 +664,7 @@ class Queue(Repo):
             raise CrossbowError('`job.branch` is automatically generated, '
                                 'thus it must be blank')
 
-        job._queue = self
+        job.queue = self
         if increment_job_id:
             # auto increment and set next job id, e.g. build-85
             job.branch = self._next_job_id(prefix)


### PR DESCRIPTION
This fixes the following error with comment bot:

https://github.com/apache/arrow/actions/runs/3246777470/jobs/5325931408#step:5:101

    ERROR:archery:'NoneType' object has no attribute 'github_commit'
    Traceback (most recent call last):
      File "/home/runner/work/arrow/arrow/arrow/dev/archery/archery/bot.py", line 153, in handle_issue_comment
        self.handler(command, issue=issue, pull_request=pull,
      File "/home/runner/work/arrow/arrow/arrow/dev/archery/archery/bot.py", line 56, in __call__
        return self.invoke(ctx)
      File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/click/core.py", line 1657, in invoke
        return _process_result(sub_ctx.command.invoke(sub_ctx))
      File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/click/core.py", line 1657, in invoke
        return _process_result(sub_ctx.command.invoke(sub_ctx))
      File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/click/core.py", line 1404, in invoke
        return ctx.invoke(self.callback, **ctx.params)
      File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/click/core.py", line 760, in invoke
        return __callback(*args, **kwargs)
      File "/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/click/decorators.py", line 38, in new_func
        return f(get_current_context().obj, *args, **kwargs)
      File "/home/runner/work/arrow/arrow/arrow/dev/archery/archery/bot.py", line 276, in submit
        pull_request.create_issue_comment(report.show())
      File "/home/runner/work/arrow/arrow/arrow/dev/archery/archery/crossbow/reports.py", line 333, in show
        url=self.task_url(task)
      File "/home/runner/work/arrow/arrow/arrow/dev/archery/archery/crossbow/reports.py", line 69, in task_url
        if task.status().build_links:
      File "/home/runner/work/arrow/arrow/arrow/dev/archery/archery/crossbow/core.py", line 869, in status
        github_commit = self._queue.github_commit(self.commit)
    AttributeError: 'NoneType' object has no attribute 'github_commit'