### PR TITLE
ARROW-18048: [Dev][Archery][Crossbow] Comment bot waits for a while before generate a report

### DIFF
--- a/dev/archery/archery/bot.py
+++ b/dev/archery/archery/bot.py
@@ -20,6 +20,7 @@ import shlex
 from pathlib import Path
 from functools import partial
 import tempfile
+import time
 
 import click
 import github
@@ -232,8 +233,10 @@ def _clone_arrow_and_crossbow(dest, crossbow_repo, pull_request):
               help='Additional task parameters for rendering the CI templates')
 @click.option('--arrow-version', '-v', default=None,
               help='Set target version explicitly.')
+@click.option('--wait', default=60,
+              help='Wait the specified seconds before generating a report.')
 @click.pass_obj
-def submit(obj, tasks, groups, params, arrow_version):
+def submit(obj, tasks, groups, params, arrow_version, wait):
     """
     Submit crossbow testing tasks.
 
@@ -268,6 +271,10 @@ def submit(obj, tasks, groups, params, arrow_version):
         # add the job to the crossbow queue and push to the remote repository
         queue.put(job, prefix="actions", increment_job_id=False)
         queue.push()
+
+        # # wait for tasks of the job are triggered to collect more
+        # # suitable task URLs
+        time.sleep(wait)
 
         # render the response comment's content
         report = CommentReport(job, crossbow_repo=crossbow_repo)

--- a/dev/archery/archery/bot.py
+++ b/dev/archery/archery/bot.py
@@ -20,7 +20,6 @@ import shlex
 from pathlib import Path
 from functools import partial
 import tempfile
-import time
 
 import click
 import github
@@ -272,12 +271,9 @@ def submit(obj, tasks, groups, params, arrow_version, wait):
         queue.put(job, prefix="actions", increment_job_id=False)
         queue.push()
 
-        # # wait for tasks of the job are triggered to collect more
-        # # suitable task URLs
-        time.sleep(wait)
-
         # render the response comment's content
-        report = CommentReport(job, crossbow_repo=crossbow_repo)
+        report = CommentReport(job, crossbow_repo=crossbow_repo,
+                               wait_for_task=wait)
 
         # send the response
         pull_request.create_issue_comment(report.show())


### PR DESCRIPTION
If we generate a report immediately after we submit CI tasks, the generated report doesn't have suitable task CI task URL. Because CI tasks aren't started. We need to wait for a while before we generate a report to collect suitable CI task URLs.

Before:
https://github.com/apache/arrow/pull/14409#issuecomment-1278396923

https://github.com/ursacomputing/crossbow/tree/actions-1e49219a52-github-r-binary-packages is used.

After:
https://github.com/apache/arrow/pull/14409#issuecomment-1278625825

https://github.com/ursacomputing/crossbow/actions/runs/3248297802/jobs/5329340988 is used.