### PR TITLE
MINOR: [R][Docs] Fix the note about to read timestamp with timezone column from csv

### DIFF
--- a/r/R/csv.R
+++ b/r/R/csv.R
@@ -144,8 +144,8 @@
 #' read_csv_arrow(tf, col_types = schema(y = utf8()))
 #' read_csv_arrow(tf, col_types = "ic", col_names = c("x", "y"), skip = 1)
 #'
-#' # Note that if a timestamp column contains time zones, type inference won't work,
-#' # whether automatic or via the string "T" `col_types` specification.
+#' # Note that if a timestamp column contains time zones,
+#' # the string "T" `col_types` specification won't work.
 #' # To parse timestamps with time zones, provide a [Schema] to `col_types`
 #' # and specify the time zone in the type object:
 #' tf <- tempfile()

--- a/r/man/read_delim_arrow.Rd
+++ b/r/man/read_delim_arrow.Rd
@@ -220,8 +220,8 @@ read_csv_arrow(tf, schema = schema(x = int32(), y = utf8()), skip = 1)
 read_csv_arrow(tf, col_types = schema(y = utf8()))
 read_csv_arrow(tf, col_types = "ic", col_names = c("x", "y"), skip = 1)
 
-# Note that if a timestamp column contains time zones, type inference won't work,
-# whether automatic or via the string "T" `col_types` specification.
+# Note that if a timestamp column contains time zones,
+# the string "T" `col_types` specification won't work.
 # To parse timestamps with time zones, provide a [Schema] to `col_types`
 # and specify the time zone in the type object:
 tf <- tempfile()


### PR DESCRIPTION
Automatic guessing works to timestamp with timezone (of course, it's automatic, so we don't know which type it actually will be).

``` r
tf <- tempfile()
write.csv(data.frame(x = "1970-01-01T12:00:00+12:00"), file = tf, row.names = FALSE)
arrow::read_csv_arrow(tf, col_types = "?", skip = 1, col_names = "x")
#> # A tibble: 1 × 1
#>   x
#>   <dttm>
#> 1 1970-01-01 00:00:00
```

<sup>Created on 2022-10-14 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>