### PR TITLE
ARROW-17991: [Python] [C++] Adding support for IpcWriteOptions to the dataset ipc file writer

### DIFF
--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1170,12 +1170,14 @@ cdef class IpcFileWriteOptions(FileWriteOptions):
 
     @property
     def write_options(self):
-        return IpcWriteOptions.wrap(deref(self.ipc_options.options))
+        out = IpcWriteOptions()
+        out.options = CIpcWriteOptions(move(deref(self.ipc_options.options)))
+        return out
 
     @write_options.setter
     def write_options(self, IpcWriteOptions write_options not None):
         self.ipc_options.options.reset(
-            new CIpcWriteOptions(deref(write_options.options)))
+            new CIpcWriteOptions(write_options.options))
 
     cdef void init(self, const shared_ptr[CFileWriteOptions]& sp):
         FileWriteOptions.init(self, sp)
@@ -1193,7 +1195,7 @@ cdef class IpcFileFormat(FileFormat):
     def make_write_options(self, **kwargs):
         cdef IpcFileWriteOptions opts = \
             <IpcFileWriteOptions> FileFormat.make_write_options(self)
-        opts.options = IpcWriteOptions(**kwargs)
+        opts.write_options = IpcWriteOptions(**kwargs)
         return opts
 
     @property

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1171,13 +1171,13 @@ cdef class IpcFileWriteOptions(FileWriteOptions):
     @property
     def write_options(self):
         out = IpcWriteOptions()
-        out.options = CIpcWriteOptions(deref(self.ipc_options.options))
+        out.c_options = CIpcWriteOptions(deref(self.ipc_options.options))
         return out
 
     @write_options.setter
     def write_options(self, IpcWriteOptions write_options not None):
         self.ipc_options.options.reset(
-            new CIpcWriteOptions(write_options.options))
+            new CIpcWriteOptions(write_options.c_options))
 
     cdef void init(self, const shared_ptr[CFileWriteOptions]& sp):
         FileWriteOptions.init(self, sp)

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1171,7 +1171,7 @@ cdef class IpcFileWriteOptions(FileWriteOptions):
     @property
     def write_options(self):
         out = IpcWriteOptions()
-        out.options = CIpcWriteOptions(move(deref(self.ipc_options.options)))
+        out.options = CIpcWriteOptions(deref(self.ipc_options.options))
         return out
 
     @write_options.setter

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1191,7 +1191,7 @@ cdef class IpcFileFormat(FileFormat):
 
     def equals(self, IpcFileFormat other):
         return True
-    
+
     def make_write_options(self, **kwargs):
         cdef IpcFileWriteOptions opts = \
             <IpcFileWriteOptions> FileFormat.make_write_options(self)

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1520,6 +1520,9 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
         c_bool use_threads
         c_bool emit_dictionary_deltas
         c_bool unify_dictionaries
+        
+        CIpcWriteOptions()
+        CIpcWriteOptions(CIpcWriteOptions&&)
 
         @staticmethod
         CIpcWriteOptions Defaults()

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1520,7 +1520,7 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
         c_bool use_threads
         c_bool emit_dictionary_deltas
         c_bool unify_dictionaries
-        
+
         CIpcWriteOptions()
         CIpcWriteOptions(CIpcWriteOptions&&)
 

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -256,7 +256,7 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
 
     cdef cppclass CIpcFileWriteOptions \
             "arrow::dataset::IpcFileWriteOptions"(CFileWriteOptions):
-        pass
+        shared_ptr[CIpcWriteOptions] options
 
     cdef cppclass CIpcFileFormat "arrow::dataset::IpcFileFormat"(
             CFileFormat):

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -243,9 +243,14 @@ cdef class IpcWriteOptions(_Weakrefable):
         if value is None:
             self.c_options.codec.reset()
         elif isinstance(value, str):
+            codec_type = _ensure_compression(value)
+            if codec_type != CCompressionType_ZSTD and codec_type != CCompressionType_LZ4_FRAME:
+                raise ValueError("Compression type must be lz4, zstd or None")
             self.c_options.codec = shared_ptr[CCodec](GetResultValue(
-                CCodec.Create(_ensure_compression(value))).release())
+                CCodec.Create(codec_type)).release())
         elif isinstance(value, Codec):
+            if value.name != "lz4" and value.name != "zstd":
+                raise ValueError("Compression type must be lz4, zstd or None")
             self.c_options.codec = (<Codec>value).wrapped
         else:
             raise TypeError(

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -274,7 +274,7 @@ cdef class IpcWriteOptions(_Weakrefable):
     @unify_dictionaries.setter
     def unify_dictionaries(self, bint value):
         self.options.unify_dictionaries = value
-    
+
 
 cdef class Message(_Weakrefable):
     """

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -197,7 +197,7 @@ cdef class IpcWriteOptions(_Weakrefable):
                  compression=None, bint use_threads=True,
                  bint emit_dictionary_deltas=False,
                  bint unify_dictionaries=False):
-        self.c_options = CIpcWriteOptions.Defaults()
+        self.options.reset(new CIpcWriteOptions(CIpcWriteOptions.Defaults()))
         self.allow_64bit = allow_64bit
         self.use_legacy_format = use_legacy_format
         self.metadata_version = metadata_version
@@ -209,71 +209,77 @@ cdef class IpcWriteOptions(_Weakrefable):
 
     @property
     def allow_64bit(self):
-        return self.c_options.allow_64bit
+        return deref(self.options).allow_64bit
 
     @allow_64bit.setter
     def allow_64bit(self, bint value):
-        self.c_options.allow_64bit = value
+        deref(self.options).allow_64bit = value
 
     @property
     def use_legacy_format(self):
-        return self.c_options.write_legacy_ipc_format
+        return deref(self.options).write_legacy_ipc_format
 
     @use_legacy_format.setter
     def use_legacy_format(self, bint value):
-        self.c_options.write_legacy_ipc_format = value
+        deref(self.options).write_legacy_ipc_format = value
 
     @property
     def metadata_version(self):
-        return _wrap_metadata_version(self.c_options.metadata_version)
+        return _wrap_metadata_version(deref(self.options).metadata_version)
 
     @metadata_version.setter
     def metadata_version(self, value):
-        self.c_options.metadata_version = _unwrap_metadata_version(value)
+        deref(self.options).metadata_version = _unwrap_metadata_version(value)
 
     @property
     def compression(self):
-        if self.c_options.codec == nullptr:
+        if deref(self.options).codec == nullptr:
             return None
         else:
-            return frombytes(self.c_options.codec.get().name())
+            return frombytes(deref(self.options).codec.get().name())
 
     @compression.setter
     def compression(self, value):
         if value is None:
-            self.c_options.codec.reset()
+            deref(self.options).codec.reset()
         elif isinstance(value, str):
-            self.c_options.codec = shared_ptr[CCodec](GetResultValue(
+            deref(self.options).codec = shared_ptr[CCodec](GetResultValue(
                 CCodec.Create(_ensure_compression(value))).release())
         elif isinstance(value, Codec):
-            self.c_options.codec = (<Codec>value).wrapped
+            deref(self.options).codec = (<Codec>value).wrapped
         else:
             raise TypeError(
                 "Property `compression` must be None, str, or pyarrow.Codec")
 
     @property
     def use_threads(self):
-        return self.c_options.use_threads
+        return deref(self.options).use_threads
 
     @use_threads.setter
     def use_threads(self, bint value):
-        self.c_options.use_threads = value
+        deref(self.options).use_threads = value
 
     @property
     def emit_dictionary_deltas(self):
-        return self.c_options.emit_dictionary_deltas
+        return deref(self.options).emit_dictionary_deltas
 
     @emit_dictionary_deltas.setter
     def emit_dictionary_deltas(self, bint value):
-        self.c_options.emit_dictionary_deltas = value
+        deref(self.options).emit_dictionary_deltas = value
 
     @property
     def unify_dictionaries(self):
-        return self.c_options.unify_dictionaries
+        return deref(self.options).unify_dictionaries
 
     @unify_dictionaries.setter
     def unify_dictionaries(self, bint value):
-        self.c_options.unify_dictionaries = value
+        deref(self.options).unify_dictionaries = value
+    
+    @staticmethod
+    cdef IpcWriteOptions wrap(CIpcWriteOptions options):
+        out = IpcWriteOptions()
+        out.options.reset(new CIpcWriteOptions(move(options)))
+        return out
 
 
 cdef class Message(_Weakrefable):
@@ -555,7 +561,7 @@ cdef class _RecordBatchStreamWriter(_CRecordBatchWriter):
         cdef:
             shared_ptr[COutputStream] c_sink
 
-        self.options = options.c_options
+        self.options = deref(options.options)
         get_writer(sink, &c_sink)
         with nogil:
             self.writer = GetResultValue(
@@ -826,7 +832,7 @@ cdef class _RecordBatchFileWriter(_RecordBatchStreamWriter):
         cdef:
             shared_ptr[COutputStream] c_sink
 
-        self.options = options.c_options
+        self.options = deref(options.options)
         get_writer(sink, &c_sink)
         with nogil:
             self.writer = GetResultValue(

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -197,7 +197,7 @@ cdef class IpcWriteOptions(_Weakrefable):
                  compression=None, bint use_threads=True,
                  bint emit_dictionary_deltas=False,
                  bint unify_dictionaries=False):
-        self.options = CIpcWriteOptions.Defaults()
+        self.c_options = CIpcWriteOptions.Defaults()
         self.allow_64bit = allow_64bit
         self.use_legacy_format = use_legacy_format
         self.metadata_version = metadata_version
@@ -209,71 +209,71 @@ cdef class IpcWriteOptions(_Weakrefable):
 
     @property
     def allow_64bit(self):
-        return self.options.allow_64bit
+        return self.c_options.allow_64bit
 
     @allow_64bit.setter
     def allow_64bit(self, bint value):
-        self.options.allow_64bit = value
+        self.c_options.allow_64bit = value
 
     @property
     def use_legacy_format(self):
-        return self.options.write_legacy_ipc_format
+        return self.c_options.write_legacy_ipc_format
 
     @use_legacy_format.setter
     def use_legacy_format(self, bint value):
-        self.options.write_legacy_ipc_format = value
+        self.c_options.write_legacy_ipc_format = value
 
     @property
     def metadata_version(self):
-        return _wrap_metadata_version(self.options.metadata_version)
+        return _wrap_metadata_version(self.c_options.metadata_version)
 
     @metadata_version.setter
     def metadata_version(self, value):
-        self.options.metadata_version = _unwrap_metadata_version(value)
+        self.c_options.metadata_version = _unwrap_metadata_version(value)
 
     @property
     def compression(self):
-        if self.options.codec == nullptr:
+        if self.c_options.codec == nullptr:
             return None
         else:
-            return frombytes(self.options.codec.get().name())
+            return frombytes(self.c_options.codec.get().name())
 
     @compression.setter
     def compression(self, value):
         if value is None:
-            self.options.codec.reset()
+            self.c_options.codec.reset()
         elif isinstance(value, str):
-            self.options.codec = shared_ptr[CCodec](GetResultValue(
+            self.c_options.codec = shared_ptr[CCodec](GetResultValue(
                 CCodec.Create(_ensure_compression(value))).release())
         elif isinstance(value, Codec):
-            self.options.codec = (<Codec>value).wrapped
+            self.c_options.codec = (<Codec>value).wrapped
         else:
             raise TypeError(
                 "Property `compression` must be None, str, or pyarrow.Codec")
 
     @property
     def use_threads(self):
-        return self.options.use_threads
+        return self.c_options.use_threads
 
     @use_threads.setter
     def use_threads(self, bint value):
-        self.options.use_threads = value
+        self.c_options.use_threads = value
 
     @property
     def emit_dictionary_deltas(self):
-        return self.options.emit_dictionary_deltas
+        return self.c_options.emit_dictionary_deltas
 
     @emit_dictionary_deltas.setter
     def emit_dictionary_deltas(self, bint value):
-        self.options.emit_dictionary_deltas = value
+        self.c_options.emit_dictionary_deltas = value
 
     @property
     def unify_dictionaries(self):
-        return self.options.unify_dictionaries
+        return self.c_options.unify_dictionaries
 
     @unify_dictionaries.setter
     def unify_dictionaries(self, bint value):
-        self.options.unify_dictionaries = value
+        self.c_options.unify_dictionaries = value
 
 
 cdef class Message(_Weakrefable):
@@ -555,7 +555,7 @@ cdef class _RecordBatchStreamWriter(_CRecordBatchWriter):
         cdef:
             shared_ptr[COutputStream] c_sink
 
-        self.options = options.options
+        self.options = options.c_options
         get_writer(sink, &c_sink)
         with nogil:
             self.writer = GetResultValue(
@@ -826,7 +826,7 @@ cdef class _RecordBatchFileWriter(_RecordBatchStreamWriter):
         cdef:
             shared_ptr[COutputStream] c_sink
 
-        self.options = options.options
+        self.options = options.c_options
         get_writer(sink, &c_sink)
         with nogil:
             self.writer = GetResultValue(

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -197,7 +197,7 @@ cdef class IpcWriteOptions(_Weakrefable):
                  compression=None, bint use_threads=True,
                  bint emit_dictionary_deltas=False,
                  bint unify_dictionaries=False):
-        self.options.reset(new CIpcWriteOptions(CIpcWriteOptions.Defaults()))
+        self.options = CIpcWriteOptions.Defaults()
         self.allow_64bit = allow_64bit
         self.use_legacy_format = use_legacy_format
         self.metadata_version = metadata_version
@@ -209,78 +209,72 @@ cdef class IpcWriteOptions(_Weakrefable):
 
     @property
     def allow_64bit(self):
-        return deref(self.options).allow_64bit
+        return self.options.allow_64bit
 
     @allow_64bit.setter
     def allow_64bit(self, bint value):
-        deref(self.options).allow_64bit = value
+        self.options.allow_64bit = value
 
     @property
     def use_legacy_format(self):
-        return deref(self.options).write_legacy_ipc_format
+        return self.options.write_legacy_ipc_format
 
     @use_legacy_format.setter
     def use_legacy_format(self, bint value):
-        deref(self.options).write_legacy_ipc_format = value
+        self.options.write_legacy_ipc_format = value
 
     @property
     def metadata_version(self):
-        return _wrap_metadata_version(deref(self.options).metadata_version)
+        return _wrap_metadata_version(self.options.metadata_version)
 
     @metadata_version.setter
     def metadata_version(self, value):
-        deref(self.options).metadata_version = _unwrap_metadata_version(value)
+        self.options.metadata_version = _unwrap_metadata_version(value)
 
     @property
     def compression(self):
-        if deref(self.options).codec == nullptr:
+        if self.options.codec == nullptr:
             return None
         else:
-            return frombytes(deref(self.options).codec.get().name())
+            return frombytes(self.options.codec.get().name())
 
     @compression.setter
     def compression(self, value):
         if value is None:
-            deref(self.options).codec.reset()
+            self.options.codec.reset()
         elif isinstance(value, str):
-            deref(self.options).codec = shared_ptr[CCodec](GetResultValue(
+            self.options.codec = shared_ptr[CCodec](GetResultValue(
                 CCodec.Create(_ensure_compression(value))).release())
         elif isinstance(value, Codec):
-            deref(self.options).codec = (<Codec>value).wrapped
+            self.options.codec = (<Codec>value).wrapped
         else:
             raise TypeError(
                 "Property `compression` must be None, str, or pyarrow.Codec")
 
     @property
     def use_threads(self):
-        return deref(self.options).use_threads
+        return self.options.use_threads
 
     @use_threads.setter
     def use_threads(self, bint value):
-        deref(self.options).use_threads = value
+        self.options.use_threads = value
 
     @property
     def emit_dictionary_deltas(self):
-        return deref(self.options).emit_dictionary_deltas
+        return self.options.emit_dictionary_deltas
 
     @emit_dictionary_deltas.setter
     def emit_dictionary_deltas(self, bint value):
-        deref(self.options).emit_dictionary_deltas = value
+        self.options.emit_dictionary_deltas = value
 
     @property
     def unify_dictionaries(self):
-        return deref(self.options).unify_dictionaries
+        return self.options.unify_dictionaries
 
     @unify_dictionaries.setter
     def unify_dictionaries(self, bint value):
-        deref(self.options).unify_dictionaries = value
+        self.options.unify_dictionaries = value
     
-    @staticmethod
-    cdef IpcWriteOptions wrap(CIpcWriteOptions options):
-        out = IpcWriteOptions()
-        out.options.reset(new CIpcWriteOptions(move(options)))
-        return out
-
 
 cdef class Message(_Weakrefable):
     """
@@ -561,7 +555,7 @@ cdef class _RecordBatchStreamWriter(_CRecordBatchWriter):
         cdef:
             shared_ptr[COutputStream] c_sink
 
-        self.options = deref(options.options)
+        self.options = options.options
         get_writer(sink, &c_sink)
         with nogil:
             self.writer = GetResultValue(
@@ -832,7 +826,7 @@ cdef class _RecordBatchFileWriter(_RecordBatchStreamWriter):
         cdef:
             shared_ptr[COutputStream] c_sink
 
-        self.options = deref(options.options)
+        self.options = options.options
         get_writer(sink, &c_sink)
         with nogil:
             self.writer = GetResultValue(

--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -40,7 +40,7 @@ cdef class _Weakrefable:
 cdef class IpcWriteOptions(_Weakrefable):
     cdef:
         CIpcWriteOptions options
-        
+
 
 cdef class IpcReadOptions(_Weakrefable):
     cdef:

--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -39,7 +39,7 @@ cdef class _Weakrefable:
 
 cdef class IpcWriteOptions(_Weakrefable):
     cdef:
-        CIpcWriteOptions options
+        CIpcWriteOptions c_options
 
 
 cdef class IpcReadOptions(_Weakrefable):

--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -39,10 +39,8 @@ cdef class _Weakrefable:
 
 cdef class IpcWriteOptions(_Weakrefable):
     cdef:
-        unique_ptr[CIpcWriteOptions] options
+        CIpcWriteOptions options
         
-    @staticmethod
-    cdef IpcWriteOptions wrap(CIpcWriteOptions options)
 
 cdef class IpcReadOptions(_Weakrefable):
     cdef:

--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -39,7 +39,10 @@ cdef class _Weakrefable:
 
 cdef class IpcWriteOptions(_Weakrefable):
     cdef:
-        CIpcWriteOptions c_options
+        unique_ptr[CIpcWriteOptions] options
+        
+    @staticmethod
+    cdef IpcWriteOptions wrap(CIpcWriteOptions options)
 
 cdef class IpcReadOptions(_Weakrefable):
     cdef:

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -3248,13 +3248,24 @@ def test_feather_format(tempdir, dataset_reader):
     "brotli"  # not supported
 ])
 def test_feather_format_compressed(tempdir, compression, dataset_reader):
-    table = pa.table({'a': pa.array([1, 2, 3], type="int8"),
-                      'b': pa.array([.1, .2, .3], type="float64")})
-    if not pa.Codec.is_available(compression)
+    table = pa.table({'a': pa.array([0]*300, type="int8"),
+                      'b': pa.array([.1, .2, .3]*100, type="float64")})
+    if not pa.Codec.is_available(compression):
         pytest.skip()
-    basedir = tempdir / "feather_dataset"
+
+    basedir = tempdir / "feather_dataset_compressed"
     basedir.mkdir()
     file_format = ds.IpcFileFormat()
+
+    uncompressed_basedir = tempdir / "feather_dataset_uncompressed"
+    uncompressed_basedir.mkdir()
+    ds.write_dataset(
+        table,
+        str(uncompressed_basedir / "data.arrow"),
+        format=file_format,
+        file_options=file_format.make_write_options(compression=None)
+    )
+
     if compression == "brotli":
         with pytest.raises(ValueError, match="Compression type"):
             write_options = file_format.make_write_options(
@@ -3275,6 +3286,12 @@ def test_feather_format_compressed(tempdir, compression, dataset_reader):
     dataset = ds.dataset(basedir, format=ds.IpcFileFormat())
     result = dataset_reader.to_table(dataset)
     assert result.equals(table)
+
+    compressed_file = basedir / "data.arrow" / "part-0.arrow"
+    compressed_size = compressed_file.stat().st_size
+    uncompressed_file = uncompressed_basedir / "data.arrow" / "part-0.arrow"
+    uncompressed_size = uncompressed_file.stat().st_size
+    assert compressed_size < uncompressed_size
 
 
 def _create_parquet_dataset_simple(root_path):

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -3241,6 +3241,31 @@ def test_feather_format(tempdir, dataset_reader):
         dataset_reader.to_table(ds.dataset(basedir, format="feather"))
 
 
+@pytest.mark.pandas
+@pytest.mark.parametrize("compression", [
+    "lz4",
+    "zstd",
+])
+def test_feather_format_compressed(tempdir, compression, dataset_reader):
+    table = pa.table({'a': pa.array([1, 2, 3], type="int8"),
+                      'b': pa.array([.1, .2, .3], type="float64")})
+
+    basedir = tempdir / "feather_dataset"
+    basedir.mkdir()
+    file_format = ds.IpcFileFormat()
+    write_options = file_format.make_write_options(compression=compression)
+    ds.write_dataset(
+        table,
+        str(basedir / "data.arrow"),
+        format=file_format,
+        file_options=write_options
+    )
+
+    dataset = ds.dataset(basedir, format=ds.IpcFileFormat())
+    result = dataset_reader.to_table(dataset)
+    assert result.equals(table)
+
+
 def _create_parquet_dataset_simple(root_path):
     """
     Creates a simple (flat files, no nested partitioning) Parquet dataset

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -3245,6 +3245,7 @@ def test_feather_format(tempdir, dataset_reader):
 @pytest.mark.parametrize("compression", [
     "lz4",
     "zstd",
+    "brotli"  # not supported
 ])
 def test_feather_format_compressed(tempdir, compression, dataset_reader):
     table = pa.table({'a': pa.array([1, 2, 3], type="int8"),
@@ -3253,6 +3254,14 @@ def test_feather_format_compressed(tempdir, compression, dataset_reader):
     basedir = tempdir / "feather_dataset"
     basedir.mkdir()
     file_format = ds.IpcFileFormat()
+    if compression == "brotli":
+        with pytest.raises(ValueError, match="Compression type"):
+            write_options = file_format.make_write_options(compression=compression)
+        with pytest.raises(ValueError, match="Compression type"):
+            codec = pa.Codec(compression)
+            write_options = file_format.make_write_options(compression=codec)
+        return
+
     write_options = file_format.make_write_options(compression=compression)
     ds.write_dataset(
         table,

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -3250,13 +3250,15 @@ def test_feather_format(tempdir, dataset_reader):
 def test_feather_format_compressed(tempdir, compression, dataset_reader):
     table = pa.table({'a': pa.array([1, 2, 3], type="int8"),
                       'b': pa.array([.1, .2, .3], type="float64")})
-
+    if not pa.Codec.is_available(compression)
+        pytest.skip()
     basedir = tempdir / "feather_dataset"
     basedir.mkdir()
     file_format = ds.IpcFileFormat()
     if compression == "brotli":
         with pytest.raises(ValueError, match="Compression type"):
-            write_options = file_format.make_write_options(compression=compression)
+            write_options = file_format.make_write_options(
+                compression=compression)
         with pytest.raises(ValueError, match="Compression type"):
             codec = pa.Codec(compression)
             write_options = file_format.make_write_options(compression=codec)


### PR DESCRIPTION
This PR adds the option to pass a populated `IpcWriteOptions` object along with the dataset writer. This allows the user to specify a compression type when writing out .arrow files. 
Note that this makes the dataset ipc writer support more configuration options than the normal ipc writer, so we'll probably follow up on this and make them more consistent again.