### PR TITLE
ARROW-18053: [Dev] Fix a bug that merge_arrow_pr.py doesn't detect Co-authored-by:

### DIFF
--- a/dev/archery/archery/utils/lint.py
+++ b/dev/archery/archery/utils/lint.py
@@ -191,6 +191,7 @@ def python_linter(src, fix=False):
                 "python/pyarrow/**/*.pxd",
                 "python/pyarrow/**/*.pxi",
                 "python/examples/**/*.py",
+                "dev/*.py",
                 "dev/archery/**/*.py",
                 "dev/release/**/*.py"]
     files = [setup_py]

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -398,7 +397,8 @@ class PullRequest(object):
             email = author['email']
             return f'{name} <{email}>'
         commit_authors = [format_commit_author(commit) for commit in commits]
-        co_authored_by_re = re.compile(r'^Co-authored-by:\s*(.*)')
+        co_authored_by_re = re.compile(
+            r'^Co-authored-by:\s*(.*)', re.MULTILINE)
 
         def extract_co_authors(commit):
             message = commit['commit']['message']


### PR DESCRIPTION
For example, Co-authored-by: in
https://github.com/apache/arrow/pull/14381/commits/41b7f26a3631c5c6cfa3abd369fbf39263cfb536 isn't detected.