### PR TITLE
ARROW-18056: [Ruby] Add support for building Arrow::Table from {name: Arrow::Tensor}

### DIFF
--- a/ruby/red-arrow/lib/arrow/array.rb
+++ b/ruby/red-arrow/lib/arrow/array.rb
@@ -47,7 +47,15 @@ module Arrow
             nil
           end
         else
-          nil
+          if value.respond_to?(:to_arrow_array)
+            begin
+              value.to_arrow_array
+            rescue RangeError
+              nil
+            end
+          else
+            nil
+          end
         end
       end
     end
@@ -100,6 +108,10 @@ module Arrow
     end
 
     def to_arrow
+      self
+    end
+
+    def to_arrow_array
       self
     end
 

--- a/ruby/red-arrow/lib/arrow/data-type.rb
+++ b/ruby/red-arrow/lib/arrow/data-type.rb
@@ -188,9 +188,13 @@ module Arrow
       end
     end
 
-    def build_array(values)
+    def array_class
       base_name = self.class.name.gsub(/DataType\z/, "")
-      builder_class = self.class.const_get("#{base_name}ArrayBuilder")
+      ::Arrow.const_get("#{base_name}Array")
+    end
+
+    def build_array(values)
+      builder_class = array_class.builder_class
       args = [values]
       args.unshift(self) unless builder_class.buildable?(args)
       builder_class.build(*args)

--- a/ruby/red-arrow/lib/arrow/raw-table-converter.rb
+++ b/ruby/red-arrow/lib/arrow/raw-table-converter.rb
@@ -35,7 +35,11 @@ module Arrow
         fields = []
         @values = []
         @raw_table.each do |name, array|
-          array = ArrayBuilder.build(array) if array.is_a?(::Array)
+          if array.respond_to?(:to_arrow_array)
+            array = array.to_arrow_array
+          elsif array.is_a?(::Array)
+            array = ArrayBuilder.build(array)
+          end
           fields << Field.new(name.to_s, array.value_data_type)
           @values << array
         end

--- a/ruby/red-arrow/lib/arrow/raw-table-converter.rb
+++ b/ruby/red-arrow/lib/arrow/raw-table-converter.rb
@@ -37,7 +37,8 @@ module Arrow
         @raw_table.each do |name, array|
           if array.respond_to?(:to_arrow_array)
             array = array.to_arrow_array
-          elsif array.is_a?(::Array)
+          else
+            array = array.to_ary if array.respond_to?(:to_ary)
             array = ArrayBuilder.build(array)
           end
           fields << Field.new(name.to_s, array.value_data_type)

--- a/ruby/red-arrow/lib/arrow/tensor.rb
+++ b/ruby/red-arrow/lib/arrow/tensor.rb
@@ -150,5 +150,15 @@ module Arrow
     def to_arrow
       self
     end
+
+    def to_arrow_array
+      if n_dimensions != 1
+        raise RangeError, "must be 1 dimensional tensor: #{shape.inspect}"
+      end
+      value_data_type.array_class.new(size,
+                                      buffer,
+                                      nil,
+                                      0)
+    end
   end
 end

--- a/ruby/red-arrow/test/test-table.rb
+++ b/ruby/red-arrow/test/test-table.rb
@@ -45,6 +45,15 @@ class TableTest < Test::Unit::TestCase
       assert_equal(Arrow::Table.new(numbers: Arrow::UInt8Array.new([1, 2, 3])),
                    Arrow::Table.new(numbers: Arrow::Tensor.new([1, 2, 3])))
     end
+
+    test("{Symbol: #to_ary}") do
+      array_like = Object.new
+      def array_like.to_ary
+        [1, 2, 3]
+      end
+      assert_equal(Arrow::Table.new(numbers: Arrow::UInt8Array.new([1, 2, 3])),
+                   Arrow::Table.new(numbers: array_like))
+    end
   end
 
   test("#columns") do

--- a/ruby/red-arrow/test/test-table.rb
+++ b/ruby/red-arrow/test/test-table.rb
@@ -40,6 +40,13 @@ class TableTest < Test::Unit::TestCase
     @table = Arrow::Table.new(schema, [@count_array, @visible_array])
   end
 
+  sub_test_case(".new") do
+    test("{Symbol: Arrow::Tensor}") do
+      assert_equal(Arrow::Table.new(numbers: Arrow::UInt8Array.new([1, 2, 3])),
+                   Arrow::Table.new(numbers: Arrow::Tensor.new([1, 2, 3])))
+    end
+  end
+
   test("#columns") do
     assert_equal([
                    Arrow::Column.new(@table, 0),

--- a/ruby/red-arrow/test/test-tensor.rb
+++ b/ruby/red-arrow/test/test-tensor.rb
@@ -279,5 +279,19 @@ class TensorTest < Test::Unit::TestCase
         end
       end
     end
+
+    sub_test_case("#to_arrow_array") do
+      test("1 dimension") do
+        assert_equal(Arrow::UInt8Array.new([1, 2, 3]),
+                     Arrow::Tensor.new([1, 2, 3]).to_arrow_array)
+      end
+
+      test("2 dimensions") do
+        message = "must be 1 dimensional tensor: [3, 1]"
+        assert_raise(RangeError.new(message)) do
+          Arrow::Tensor.new([[1], [2], [3]]).to_arrow_array
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
New #to_arrow_array protocol is also introduced.