### PR TITLE
ARROW-18061: [CI][R] Reduce number of jobs on every commit

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -183,8 +183,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        # - { rtools: 40, arch: 'mingw32' }
-        # - { rtools: 40, arch: 'mingw64' }
         - { rtools: 40, arch: 'ucrt64' }
     steps:
       - run: git config --global core.autocrlf false
@@ -235,7 +233,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        # - { rtools: 40, rversion: "4.1" }
         - { rtools: 42, rversion: "4.2" }
         - { rtools: 42, rversion: "devel" }
     env:
@@ -248,18 +245,6 @@ jobs:
         with:
           fetch-depth: 0
       - run: mkdir r/windows
-      - name: Download artifacts
-        if: ${{ matrix.config.rtools != 42 }}
-        uses: actions/download-artifact@v3
-        with:
-          name: libarrow-rtools${{ matrix.config.rtools }}-mingw32.zip
-          path: r/windows
-      - name: Download artifacts
-        if: ${{ matrix.config.rtools !=42 }}
-        uses: actions/download-artifact@v3
-        with:
-          name: libarrow-rtools${{ matrix.config.rtools }}-mingw64.zip
-          path: r/windows
       - name: Download artifacts
         if: ${{ matrix.config.rtools == 42 }}
         uses: actions/download-artifact@v3

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -60,7 +60,7 @@ jobs:
       matrix:
         r: ["4.2"]
         ubuntu: [20.04]
-        force-tests: ["true", "false"]
+        force-tests: ["true"]
     env:
       R: ${{ matrix.r }}
       UBUNTU: ${{ matrix.ubuntu }}
@@ -126,7 +126,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { org: "rstudio", image: "r-base", tag: "4.0-centos7", devtoolset: "8" }
           - { org: "rhub", image: "debian-gcc-devel", tag: "latest", devtoolset: "" }
     env:
       R_ORG: ${{ matrix.config.org }}
@@ -184,8 +183,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - { rtools: 40, arch: 'mingw32' }
-        - { rtools: 40, arch: 'mingw64' }
+        # - { rtools: 40, arch: 'mingw32' }
+        # - { rtools: 40, arch: 'mingw64' }
         - { rtools: 40, arch: 'ucrt64' }
     steps:
       - run: git config --global core.autocrlf false
@@ -236,7 +235,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - { rtools: 40, rversion: "4.1" }
+        # - { rtools: 40, rversion: "4.1" }
         - { rtools: 42, rversion: "4.2" }
         - { rtools: 42, rversion: "devel" }
     env:


### PR DESCRIPTION
* Force tests: `true` fully contains all tests in the `false` version, so false is redundant
* The CentOS 7 job previously was useful to catch gcc 4.8 issues, but that's no longer a problem, and the CentOS with devtoolset-8 variant is already tested nightly
* The Windows builds can be pruned if we test only on current release and development version, which only use UCRT. We test the older build nightly in the `r-binary-packages` workflow