### PR TITLE
ARROW-18062: [R] error in CI jobs for R 3.5 and 3.6 when R package being installed

### DIFF
--- a/r/R/dplyr-funcs.R
+++ b/r/R/dplyr-funcs.R
@@ -139,7 +139,6 @@ call_binding_agg <- function(fun_name, ...) {
   agg_funcs[[fun_name]](...)
 }
 
-#' @importFrom stats runif
 create_binding_cache <- function() {
   # Called in .onLoad()
   .cache$docs <- list()
@@ -163,17 +162,6 @@ create_binding_cache <- function() {
   register_bindings_string()
   register_bindings_type()
   register_bindings_augmented()
-
-  # HACK because random() doesn't work (ARROW-17974)
-  register_scalar_function(
-    "_random_along",
-    function(context, x) {
-      Array$create(runif(length(x)))
-    },
-    in_type = schema(x = boolean()),
-    out_type = float64(),
-    auto_convert = FALSE
-  )
 
   # We only create the cache for nse_funcs and not agg_funcs
   .cache$functions <- c(as.list(nse_funcs), arrow_funcs)

--- a/r/tests/testthat/test-dplyr-slice.R
+++ b/r/tests/testthat/test-dplyr-slice.R
@@ -99,8 +99,10 @@ test_that("slice_sample, ungrouped", {
     "weight_by"
   )
 
+  # Let's not take any chances on random failures
+  skip_on_cran()
   # Because this is random (and we only have 10 rows), try several times
-  for (i in 1:10) {
+  for (i in 1:50) {
     sampled_prop <- tab %>%
       slice_sample(prop = .2) %>%
       collect() %>%


### PR DESCRIPTION
Not sure why this behavior would differ between R versions, but it makes sense to move the UDF registration to after the binding registry is created and only do it if slice_sample() is called.