### PR TITLE
ARROW-18051: [C++] Enable tests skipped by ARROW-16392

### DIFF
--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -1887,9 +1887,6 @@ TEST(Substrait, AggregateBadPhase) {
 }
 
 TEST(Substrait, BasicPlanRoundTripping) {
-#ifdef _WIN32
-  GTEST_SKIP() << "ARROW-16392: Substrait File URI not supported for Windows";
-#endif
   compute::ExecContext exec_context;
   arrow::dataset::internal::Initialize();
 
@@ -2001,9 +1998,6 @@ TEST(Substrait, BasicPlanRoundTripping) {
 }
 
 TEST(Substrait, BasicPlanRoundTrippingEndToEnd) {
-#ifdef _WIN32
-  GTEST_SKIP() << "ARROW-16392: Substrait File URI not supported for Windows";
-#endif
   compute::ExecContext exec_context;
   arrow::dataset::internal::Initialize();
 
@@ -2126,9 +2120,6 @@ NamedTableProvider AlwaysProvideSameTable(std::shared_ptr<Table> table) {
 }
 
 TEST(Substrait, ProjectRel) {
-#ifdef _WIN32
-  GTEST_SKIP() << "ARROW-16392: Substrait File URI not supported for Windows";
-#endif
   compute::ExecContext exec_context;
   auto dummy_schema =
       schema({field("A", int32()), field("B", int32()), field("C", int32())});
@@ -2241,9 +2232,6 @@ TEST(Substrait, ProjectRel) {
 }
 
 TEST(Substrait, ProjectRelOnFunctionWithEmit) {
-#ifdef _WIN32
-  GTEST_SKIP() << "ARROW-16392: Substrait File URI not supported for Windows";
-#endif
   compute::ExecContext exec_context;
   auto dummy_schema =
       schema({field("A", int32()), field("B", int32()), field("C", int32())});
@@ -2360,9 +2348,6 @@ TEST(Substrait, ProjectRelOnFunctionWithEmit) {
 }
 
 TEST(Substrait, ReadRelWithEmit) {
-#ifdef _WIN32
-  GTEST_SKIP() << "ARROW-16392: Substrait File URI not supported for Windows";
-#endif
   compute::ExecContext exec_context;
   auto dummy_schema =
       schema({field("A", int32()), field("B", int32()), field("C", int32())});
@@ -2419,9 +2404,6 @@ TEST(Substrait, ReadRelWithEmit) {
 }
 
 TEST(Substrait, FilterRelWithEmit) {
-#ifdef _WIN32
-  GTEST_SKIP() << "ARROW-16392: Substrait File URI not supported for Windows";
-#endif
   compute::ExecContext exec_context;
   auto dummy_schema = schema({field("A", int32()), field("B", int32()),
                               field("C", int32()), field("D", int32())});
@@ -2537,9 +2519,6 @@ TEST(Substrait, FilterRelWithEmit) {
 }
 
 TEST(Substrait, JoinRelEndToEnd) {
-#ifdef _WIN32
-  GTEST_SKIP() << "ARROW-16392: Substrait File URI not supported for Windows";
-#endif
   compute::ExecContext exec_context;
   auto left_schema = schema({field("A", int32()), field("B", int32())});
 
@@ -2687,9 +2666,6 @@ TEST(Substrait, JoinRelEndToEnd) {
 }
 
 TEST(Substrait, JoinRelWithEmit) {
-#ifdef _WIN32
-  GTEST_SKIP() << "ARROW-16392: Substrait File URI not supported for Windows";
-#endif
   compute::ExecContext exec_context;
   auto left_schema = schema({field("A", int32()), field("B", int32())});
 
@@ -2839,9 +2815,6 @@ TEST(Substrait, JoinRelWithEmit) {
 }
 
 TEST(Substrait, AggregateRel) {
-#ifdef _WIN32
-  GTEST_SKIP() << "ARROW-16392: Substrait File URI not supported for Windows";
-#endif
   compute::ExecContext exec_context;
   auto dummy_schema =
       schema({field("A", int32()), field("B", int32()), field("C", int32())});
@@ -2948,9 +2921,6 @@ TEST(Substrait, AggregateRel) {
 }
 
 TEST(Substrait, AggregateRelEmit) {
-#ifdef _WIN32
-  GTEST_SKIP() << "ARROW-16392: Substrait File URI not supported for Windows";
-#endif
   compute::ExecContext exec_context;
   auto dummy_schema =
       schema({field("A", int32()), field("B", int32()), field("C", int32())});

--- a/cpp/src/arrow/flight/sql/acero_test.cc
+++ b/cpp/src/arrow/flight/sql/acero_test.cc
@@ -140,10 +140,6 @@ TEST_F(TestAcero, GetSqlInfo) {
 }
 
 TEST_F(TestAcero, Scan) {
-#ifdef _WIN32
-  GTEST_SKIP() << "ARROW-16392: Substrait File URI not supported for Windows";
-#endif
-
   FlightCallOptions call_options;
   ASSERT_OK_AND_ASSIGN(auto serialized_plan, MakeSubstraitPlan());
 
@@ -169,10 +165,6 @@ TEST_F(TestAcero, Scan) {
 }
 
 TEST_F(TestAcero, Update) {
-#ifdef _WIN32
-  GTEST_SKIP() << "ARROW-16392: Substrait File URI not supported for Windows";
-#endif
-
   FlightCallOptions call_options;
   ASSERT_OK_AND_ASSIGN(auto serialized_plan, MakeSubstraitPlan());
   SubstraitPlan plan{serialized_plan->ToString(), /*version=*/"0.6.0"};
@@ -182,10 +174,6 @@ TEST_F(TestAcero, Update) {
 }
 
 TEST_F(TestAcero, Prepare) {
-#ifdef _WIN32
-  GTEST_SKIP() << "ARROW-16392: Substrait File URI not supported for Windows";
-#endif
-
   FlightCallOptions call_options;
   ASSERT_OK_AND_ASSIGN(auto serialized_plan, MakeSubstraitPlan());
   SubstraitPlan plan{serialized_plan->ToString(), /*version=*/"0.6.0"};
@@ -217,10 +205,6 @@ TEST_F(TestAcero, Prepare) {
 }
 
 TEST_F(TestAcero, Transactions) {
-#ifdef _WIN32
-  GTEST_SKIP() << "ARROW-16392: Substrait File URI not supported for Windows";
-#endif
-
   FlightCallOptions call_options;
   ASSERT_OK_AND_ASSIGN(auto serialized_plan, MakeSubstraitPlan());
   Transaction handle("fake-id");


### PR DESCRIPTION
Removing skip test macros from the C++ tests.