### PR TITLE
ARROW-18068: [Dev][Archery][Crossbow] Comment bot only waits for task if link is not available

### DIFF
--- a/dev/archery/archery/crossbow/reports.py
+++ b/dev/archery/archery/crossbow/reports.py
@@ -68,7 +68,9 @@ class Report:
         return '{}/tree/{}'.format(self.repo_url, branch)
 
     def task_url(self, task):
-        if self._wait_for_task:
+        # Only wait if the link to the actual build is not present.
+        if not task.status().build_links and self._wait_for_task:
+            print("Waiting for task")
             time.sleep(self._wait_for_task)
         if task.status().build_links:
             # show link to the actual build, some CI providers implement

--- a/dev/archery/archery/crossbow/reports.py
+++ b/dev/archery/archery/crossbow/reports.py
@@ -68,13 +68,16 @@ class Report:
         return '{}/tree/{}'.format(self.repo_url, branch)
 
     def task_url(self, task):
-        # Only wait if the link to the actual build is not present.
-        if not task.status().build_links and self._wait_for_task:
+        build_links = task.status().build_links
+        # Only wait if the link to the actual build is not present
+        # and refresh task status.
+        if not build_links and self._wait_for_task:
             time.sleep(self._wait_for_task)
-        if task.status().build_links:
+            build_links = task.status(force_query=True).build_links
+        if build_links:
             # show link to the actual build, some CI providers implement
             # the statuses API others implement the checks API, retrieve any.
-            return task.status().build_links[0]
+            return build_links[0]
         else:
             # show link to the branch if no status build link was found.
             return self.branch_url(task.branch)

--- a/dev/archery/archery/crossbow/reports.py
+++ b/dev/archery/archery/crossbow/reports.py
@@ -70,7 +70,6 @@ class Report:
     def task_url(self, task):
         # Only wait if the link to the actual build is not present.
         if not task.status().build_links and self._wait_for_task:
-            print("Waiting for task")
             time.sleep(self._wait_for_task)
         if task.status().build_links:
             # show link to the actual build, some CI providers implement


### PR DESCRIPTION
This has been tested on my own fork. Previous to the PR if the comment for the bot contained multiple tasks we were waiting multiple times, see log for the comment bot and the new log I added here https://github.com/raulcd/arrow/actions/runs/3260111092/jobs/5353427827#step:6:99 , output:
```
Waiting for task
Waiting for task
Waiting for task
Waiting for task
```
Comment triggered on this PR on my own fork:
https://github.com/raulcd/arrow/pull/10

Once the fix is applied the same comment bot only waits once (the first one because the task url is not available) log here https://github.com/raulcd/arrow/actions/runs/3260112211/jobs/5353429747#step:6:99, output:
```
Waiting for task
```
Comment bot triggered on this PR on my own fork:
https://github.com/raulcd/arrow/pull/12 