### PR TITLE
ARROW-18072: [C++] Can't use bundled ORC with CMake 3.10

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -4338,13 +4338,18 @@ macro(build_orc)
   set_target_properties(orc::liborc
                         PROPERTIES IMPORTED_LOCATION "${ORC_STATIC_LIB}"
                                    INTERFACE_INCLUDE_DIRECTORIES "${ORC_INCLUDE_DIR}")
-  target_link_libraries(orc::liborc INTERFACE LZ4::lz4 ZLIB::ZLIB ${ARROW_ZSTD_LIBZSTD}
-                                              ${Snappy_TARGET})
+  set(ORC_LINK_LIBRARIES LZ4::lz4 ZLIB::ZLIB ${ARROW_ZSTD_LIBZSTD} ${Snappy_TARGET})
   if(NOT MSVC)
     if(NOT APPLE)
-      target_link_libraries(orc::liborc INTERFACE Threads::Threads)
+      list(APPEND ORC_LINK_LIBRARIES Threads::Threads)
     endif()
-    target_link_libraries(orc::liborc INTERFACE ${CMAKE_DL_LIBS})
+    list(APPEND ORC_LINK_LIBRARIES ${CMAKE_DL_LIBS})
+  endif()
+  if(CMAKE_VERSION VERSION_LESS 3.11)
+    set_target_properties(orc::liborc PROPERTIES INTERFACE_LINK_LIBRARIES
+                                                 "${ORC_LINK_LIBRARIES}")
+  else()
+    target_link_libraries(orc::liborc INTERFACE ${ORC_LINK_LIBRARIES})
   endif()
 
   add_dependencies(toolchain orc_ep)


### PR DESCRIPTION
Because CMake 3.10 doesn't support target_link_libraries() against an IMPORTED target:

https://cmake.org/cmake/help/latest/release/3.11.html#commands

> The target_link_libraries() command learned to set the
> INTERFACE_LINK_LIBRARIES property on Imported Targets.