### PR TITLE
ARROW-18074: [CI] Running ctest for PyArrow C++ not needed anymore

### DIFF
--- a/ci/scripts/python_test.sh
+++ b/ci/scripts/python_test.sh
@@ -55,14 +55,5 @@ export PYARROW_TEST_ORC
 export PYARROW_TEST_PARQUET
 export PYARROW_TEST_S3
 
-# Testing PyArrow C++
-if [ "${ARROW_BUILD_TESTS}" == "ON" ]; then
-  pushd ${test_dir}
-  ctest \
-      --output-on-failure \
-      --parallel ${n_jobs} \
-      --timeout 300
-  popd
-fi
 # Testing PyArrow
 pytest -r s ${PYTEST_ARGS} --pyargs pyarrow


### PR DESCRIPTION
As https://github.com/apache/arrow/pull/14117 is merged separate run of `ctest` for `PyArrow C++` tests is not needed anymore and is removed in this PR.