### PR TITLE
MINOR: [R] Fix broken link in R developer setup vignette

### DIFF
--- a/r/vignettes/developers/setup.Rmd
+++ b/r/vignettes/developers/setup.Rmd
@@ -462,4 +462,4 @@ guide](https://arrow.apache.org/docs/developers/cpp/building.html).
 
 ## Other installation issues
 
-There are a number of scripts that are triggered when the arrow R package is installed. For package users who are not interacting with the underlying code, these should all just work without configuration and pull in the most complete pieces (e.g. official binaries that we host). However, knowing about these scripts can help package developers troubleshoot if things go wrong in them or things go wrong in an install.  See [the installation vignette](./install.html#how-dependencies-are-resolved) for more information.
+There are a number of scripts that are triggered when the arrow R package is installed. For package users who are not interacting with the underlying code, these should all just work without configuration and pull in the most complete pieces (e.g. official binaries that we host). However, knowing about these scripts can help package developers troubleshoot if things go wrong in them or things go wrong in an install.  See [the installation details vignette](./install_details.html) for more information.

--- a/r/vignettes/developers/setup.Rmd
+++ b/r/vignettes/developers/setup.Rmd
@@ -462,4 +462,4 @@ guide](https://arrow.apache.org/docs/developers/cpp/building.html).
 
 ## Other installation issues
 
-There are a number of scripts that are triggered when the arrow R package is installed. For package users who are not interacting with the underlying code, these should all just work without configuration and pull in the most complete pieces (e.g. official binaries that we host). However, knowing about these scripts can help package developers troubleshoot if things go wrong in them or things go wrong in an install.  See [the installation details vignette](./install_details.html) for more information.
+There are a number of scripts that are triggered when the arrow R package is installed. For package users who are not interacting with the underlying code, these should all just work without configuration and pull in the most complete pieces (e.g. official binaries that we host). However, knowing about these scripts can help package developers troubleshoot if things go wrong in them or things go wrong in an install.  See [the article on R package installation](./install_details.html) for more information.


### PR DESCRIPTION
The link in the final section of the [Developer environment setup](https://arrow.apache.org/docs/dev/r/articles/developers/setup.html#other-installation-issues) docs 404s and this points the link to the installation details vignette. I think this is what was intended but let me know.