### PR TITLE
ARROW-17784: [C++] Opening a dataset where partitioning variable is already in the dataset should error differently

### DIFF
--- a/cpp/src/arrow/dataset/discovery.cc
+++ b/cpp/src/arrow/dataset/discovery.cc
@@ -252,14 +252,14 @@ Result<std::vector<std::shared_ptr<Schema>>> FileSystemDatasetFactory::InspectSc
           "'. Is this a '", format_->type_name(), "' file?: ", result.status().message());
     }
 
-    if (partition_schema->num_fields()) {
-      auto field_check =
-          result->get()->CanReferenceFieldsByNames(partition_schema->field_names());
-      if (ARROW_PREDICT_FALSE(field_check.ok())) {
-        return Status::Invalid(
-            "Error creating dataset. Partitioning field(s) present in fragment.");
-      }
-    }
+    // if (partition_schema->num_fields()) {
+    //   auto field_check =
+    //       result->get()->CanReferenceFieldsByNames(partition_schema->field_names());
+    //   if (ARROW_PREDICT_FALSE(field_check.ok())) {
+    //     return Status::Invalid(
+    //         "Error creating dataset. Partitioning field(s) present in fragment.");
+    //   }
+    // }
 
     schemas.push_back(result.MoveValueUnsafe());
   }

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -2114,7 +2114,7 @@ Result<std::shared_ptr<Schema>> UnifySchemas(
     return Status::Invalid("Can't unify schema with duplicate field names.");
   }
 
-  SchemaBuilder builder{schemas[0], SchemaBuilder::CONFLICT_MERGE, field_merge_options};
+  SchemaBuilder builder{schemas[0], SchemaBuilder::CONFLICT_APPEND, field_merge_options};
 
   for (size_t i = 1; i < schemas.size(); i++) {
     const auto& schema = schemas[i];

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -2114,7 +2114,7 @@ Result<std::shared_ptr<Schema>> UnifySchemas(
     return Status::Invalid("Can't unify schema with duplicate field names.");
   }
 
-  SchemaBuilder builder{schemas[0], SchemaBuilder::CONFLICT_APPEND, field_merge_options};
+  SchemaBuilder builder{schemas[0], SchemaBuilder::CONFLICT_MERGE, field_merge_options};
 
   for (size_t i = 1; i < schemas.size(); i++) {
     const auto& schema = schemas[i];

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -684,6 +684,7 @@ def test_partitioning():
         names=["f1", "f2", "part"]
     )
     partitioning_schema = pa.schema([("part", pa.string())])
+    modified_partitioning_schema = pa.schema([("f1", pa.int64())])
     for klass in [ds.DirectoryPartitioning, ds.HivePartitioning,
                   ds.FilenamePartitioning]:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -694,6 +695,13 @@ def test_partitioning():
                                    partitioning=partitioning)
             load_back_table = load_back.to_table()
             assert load_back_table.equals(table)
+
+        # test roundtrip with different partitioning field
+            with pytest.raises(pa.ArrowInvalid):
+                load_back = ds.dataset(tempdir, format='ipc',
+                                       partitioning=klass(
+                                           modified_partitioning_schema)
+                                       )
 
 
 def test_expression_arithmetic_operators():


### PR DESCRIPTION
This PR adds the feature of raising invalid status if the fragment schema and partitioning schema have any common fields, i.e. provided partitioning schema for reading is not the one used for writing.