### PR TITLE
ARROW-16547: [Python] to_pandas fails with FixedOffset timezones when timestamp_as_object is used

### DIFF
--- a/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
+++ b/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
@@ -1077,17 +1077,22 @@ struct ObjectWriterVisitor {
 
       // convert the timezone naive datetime object to timezone aware
       // first: replacing timezone with timezone.utc
-      PyObject *args = PyTuple_New(0);
-      PyObject *keywords = PyDict_New();
+      PyObject* args = PyTuple_New(0);
+      PyObject* keywords = PyDict_New();
       PyDict_SetItemString(keywords, "tzinfo", PyDateTime_TimeZone_UTC);
-      PyObject* datetime_utc;
-      datetime_utc = PyObject_CallMethod(naive_datetime, "replace", "O", args, keywords);
+      PyObject* naive_datetime_replace =
+          PyObject_GetAttrString(naive_datetime, "replace");
+      PyObject* datetime_utc = PyObject_Call(naive_datetime_replace, args, keywords);
       // second: adjust the datetime to tzinfo timezone
-      *out = PyObject_CallMethod(datetime_utc, "astimezone", "O", tzinfo.obj());
+      PyObject* astimezone = PyObject_GetAttrString(datetime_utc, "astimezone");
+      *out = PyObject_CallOneArg(astimezone, tzinfo.obj());
+
       // arguments for replace method and the timezone naive object are no longer required
       Py_DECREF(args);
       Py_DECREF(keywords);
+      Py_DECREF(naive_datetime_replace);
       Py_DECREF(datetime_utc);
+      Py_DECREF(astimezone);
       Py_DECREF(naive_datetime);
       RETURN_IF_PYERROR();
 

--- a/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
+++ b/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
@@ -1076,13 +1076,15 @@ struct ObjectWriterVisitor {
       RETURN_NOT_OK(ConvertTimezoneNaive(value, &naive_datetime));
 
       // convert the timezone naive datetime object to timezone aware
-      // first: replacing timezone with timezone.utc
+      // two step conversion of the datetime mimics Python's code:
+      // dt.replace(tzinfo=datetime.timezone.utc).astimezone(tzinfo)
+      // first step: replacing timezone with timezone.utc (replace method)
       OwnedRef args(PyTuple_New(0));
       OwnedRef keywords(PyDict_New());
       PyDict_SetItemString(keywords.obj(), "tzinfo", PyDateTime_TimeZone_UTC);
       OwnedRef naive_datetime_replace(PyObject_GetAttrString(naive_datetime, "replace"));
       OwnedRef datetime_utc(PyObject_Call(naive_datetime_replace.obj(), args.obj(), keywords.obj()));
-      // second: adjust the datetime to tzinfo timezone
+      // second step: adjust the datetime to tzinfo timezone (astimezone method)
       OwnedRef astimezone(PyObject_GetAttrString(datetime_utc.obj(), "astimezone"));
       *out = PyObject_CallOneArg(astimezone.obj(), tzinfo.obj());
 

--- a/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
+++ b/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
@@ -1077,22 +1077,16 @@ struct ObjectWriterVisitor {
 
       // convert the timezone naive datetime object to timezone aware
       // first: replacing timezone with timezone.utc
-      PyObject* args = PyTuple_New(0);
-      PyObject* keywords = PyDict_New();
-      PyDict_SetItemString(keywords, "tzinfo", PyDateTime_TimeZone_UTC);
-      PyObject* naive_datetime_replace =
-          PyObject_GetAttrString(naive_datetime, "replace");
-      PyObject* datetime_utc = PyObject_Call(naive_datetime_replace, args, keywords);
+      OwnedRef args(PyTuple_New(0));
+      OwnedRef keywords(PyDict_New());
+      PyDict_SetItemString(keywords.obj(), "tzinfo", PyDateTime_TimeZone_UTC);
+      OwnedRef naive_datetime_replace(PyObject_GetAttrString(naive_datetime, "replace"));
+      OwnedRef datetime_utc(PyObject_Call(naive_datetime_replace.obj(), args.obj(), keywords.obj()));
       // second: adjust the datetime to tzinfo timezone
-      PyObject* astimezone = PyObject_GetAttrString(datetime_utc, "astimezone");
-      *out = PyObject_CallOneArg(astimezone, tzinfo.obj());
+      OwnedRef astimezone(PyObject_GetAttrString(datetime_utc.obj(), "astimezone"));
+      *out = PyObject_CallOneArg(astimezone.obj(), tzinfo.obj());
 
-      // arguments for replace method and the timezone naive object are no longer required
-      Py_DECREF(args);
-      Py_DECREF(keywords);
-      Py_DECREF(naive_datetime_replace);
-      Py_DECREF(datetime_utc);
-      Py_DECREF(astimezone);
+      // the timezone naive object is no longer required
       Py_DECREF(naive_datetime);
       RETURN_IF_PYERROR();
 

--- a/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
+++ b/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
@@ -1085,10 +1085,7 @@ struct ObjectWriterVisitor {
       OwnedRef naive_datetime_replace(PyObject_GetAttrString(naive_datetime, "replace"));
       OwnedRef datetime_utc(PyObject_Call(naive_datetime_replace.obj(), args.obj(), keywords.obj()));
       // second step: adjust the datetime to tzinfo timezone (astimezone method)
-      OwnedRef args_astimezone(PyTuple_New(1));
-      PyTuple_SetItem(args_astimezone.obj(), 0, tzinfo.obj());
-      OwnedRef astimezone(PyObject_GetAttrString(datetime_utc.obj(), "astimezone"));
-      *out = PyObject_CallObject(astimezone.obj(), args_astimezone.obj());
+      *out = PyObject_CallMethod(datetime_utc.obj(), "astimezone", "O", tzinfo.obj());
 
       // the timezone naive object is no longer required
       Py_DECREF(naive_datetime);

--- a/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
+++ b/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
@@ -1085,8 +1085,10 @@ struct ObjectWriterVisitor {
       OwnedRef naive_datetime_replace(PyObject_GetAttrString(naive_datetime, "replace"));
       OwnedRef datetime_utc(PyObject_Call(naive_datetime_replace.obj(), args.obj(), keywords.obj()));
       // second step: adjust the datetime to tzinfo timezone (astimezone method)
+      OwnedRef args_astimezone(PyTuple_New(1));
+      PyTuple_SetItem(args_astimezone.obj(), 0, tzinfo.obj());
       OwnedRef astimezone(PyObject_GetAttrString(datetime_utc.obj(), "astimezone"));
-      *out = PyObject_CallOneArg(astimezone.obj(), tzinfo.obj());
+      *out = PyObject_CallObject(astimezone.obj(), args_astimezone.obj());
 
       // the timezone naive object is no longer required
       Py_DECREF(naive_datetime);

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -4479,9 +4479,7 @@ def test_timestamp_as_object_pytz_offset():
     timezone = pytz.FixedOffset(120)
     dt = timezone.localize(datetime.datetime(2022, 5, 12, 16, 57))
 
-    timestamps = pa.array([dt])
-    names = ["timestamp_col"]
-    table = pa.Table.from_arrays([timestamps], names=names)
+    table = pa.table({"timestamp_col": pa.array([dt])})
 
     expected = table.to_pandas()
     result = table.to_pandas(timestamp_as_object=True)

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -4479,12 +4479,11 @@ def test_timestamp_as_object_pytz_offset():
     timezone = pytz.FixedOffset(120)
     dt = timezone.localize(datetime.datetime(2022, 5, 12, 16, 57))
 
-    table = pa.table({"timestamp_col": pa.array([dt])})
-
-    expected = table.to_pandas()
+    timestamps = pa.array([dt])
+    names = ["timestamp_col"]
+    table = pa.Table.from_arrays([timestamps], names=names)
     result = table.to_pandas(timestamp_as_object=True)
-    # Not checking equality in dtype as the result is an object
-    tm.assert_frame_equal(expected, result, check_dtype=False)
+    assert result == [dt]
 
 
 def test_threaded_pandas_import():

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -4472,7 +4472,7 @@ def test_timestamp_as_object_non_nanosecond(resolution, tz, dt):
         assert result[0] == expected
 
 
-def test_timestamp_as_object_pytz_offset():
+def test_timestamp_as_object_fixed_offset():
     # ARROW-16547 to_pandas with timestamp_as_object=True and FixedOffset
     pytz = pytest.importorskip("pytz")
     import datetime

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -4472,6 +4472,23 @@ def test_timestamp_as_object_non_nanosecond(resolution, tz, dt):
         assert result[0] == expected
 
 
+def test_timestamp_as_object_pytz_offset():
+    # ARROW-16547 to_pandas with timestamp_as_object=True and FixedOffset
+    pytz = pytest.importorskip("pytz")
+    import datetime
+    timezone = pytz.FixedOffset(120)
+    dt = timezone.localize(datetime.datetime(2022, 5, 12, 16, 57))
+
+    timestamps = pa.array([dt])
+    names = ["timestamp_col"]
+    table = pa.Table.from_arrays([timestamps], names=names)
+
+    expected = table.to_pandas()
+    result = table.to_pandas(timestamp_as_object=True)
+    # Not checking equality in dtype as the result is an object
+    tm.assert_frame_equal(expected, result, check_dtype=False)
+
+
 def test_threaded_pandas_import():
     invoke_script("pandas_threaded_import.py")
 

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -4479,11 +4479,9 @@ def test_timestamp_as_object_pytz_offset():
     timezone = pytz.FixedOffset(120)
     dt = timezone.localize(datetime.datetime(2022, 5, 12, 16, 57))
 
-    timestamps = pa.array([dt])
-    names = ["timestamp_col"]
-    table = pa.Table.from_arrays([timestamps], names=names)
+    table = pa.table({"timestamp_col": pa.array([dt])})
     result = table.to_pandas(timestamp_as_object=True)
-    assert result == [dt]
+    assert pa.table(result) == table
 
 
 def test_threaded_pandas_import():


### PR DESCRIPTION
This PR tries to substitute `fromutc` method in `ConvertTimezoneAware ` (arrow_to_pandas.cc) as it errors when `tzinfo` is an instance of `pytz` timezone. Basically does the change from:
```python
tzinfo.fromutc(dt)
```
to
```python
dt.replace(tzinfo=datetime.timezone.utc).astimezone(tzinfo)
```
but in C++.

Thank you @milesgranger for the help!