### PR TITLE
MINOR: [R][Docs] .feather -> .arrow

### DIFF
--- a/r/vignettes/dataset.Rmd
+++ b/r/vignettes/dataset.Rmd
@@ -359,12 +359,12 @@ system("tree nyc-taxi/feather")
 ```
 ## feather
 ## ├── payment_type=1
-## │   └── part-18.feather
+## │   └── part-18.arrow
 ## ├── payment_type=2
-## │   └── part-19.feather
+## │   └── part-19.arrow
 ## ...
 ## └── payment_type=UNK
-##     └── part-17.feather
+##     └── part-17.arrow
 ##
 ## 18 directories, 23 files
 ```


### PR DESCRIPTION
Updated by ARROW-17088

It maybe better the reference to Feather in the text body should also be changed, but for now I will only correct the extension.