### PR TITLE
ARROW-15328: [C++][Docs] Streaming CSV reader missing from documentation

### DIFF
--- a/docs/source/cpp/csv.rst
+++ b/docs/source/cpp/csv.rst
@@ -35,7 +35,7 @@ Reading CSV files
 
 Data in a CSV file can either be read in as a single Arrow Table using
 :class:`~arrow::csv::TableReader` or streamed as RecordBatches using
-:class:`~arrow::csv::StreamingReader`. See :ref:`Tradeoffs <tradeoffs>` for a
+:class:`~arrow::csv::StreamingReader`. See :ref:`Tradeoffs <cpp-csv-tradeoffs>` for a
 discussion of the tradeoffs between the two methods.
 
 TableReader
@@ -128,7 +128,7 @@ Behavior of :class:`~arrow::csv::StreamingReader` can be customized using a
 combination of :class:`~arrow::csv::ReadOptrions`,
 :class:`~arrow::csv::ParseOptions`, and :class:`~arrow::csv::ConvertOptions`.
 
-.. _tradeoffs:
+.. _cpp-csv-tradeoffs:
 
 Tradeoffs
 ---------
@@ -137,7 +137,7 @@ The choice between using :class:`~arrow::csv::TableReader` or :class:`~arrow::cs
 will depend on your use case but two caveats are worth pointing out:
 
 1. :class:`~arrow::csv::TableReader` is capable of using multiple threads (See
-   :ref:`Performance <performance>`) whereas
+   :ref:`Performance <cpp-csv-performance>`) whereas
    :class:`~arrow::csv::StreamingReader` is always single-threaded and will
    ignore :member:`ReadOptions::use_threads`.
 2. :class:`~arrow::csv::StreamingReader` performs type inference off the first
@@ -353,7 +353,7 @@ Write Options
 The format of written CSV files can be customized via :class:`~arrow::csv::WriteOptions`.
 Currently few options are available; more will be added in future releases.
 
-.. _performance:
+.. _cpp-csv-performance:
 
 Performance
 ===========

--- a/docs/source/cpp/csv.rst
+++ b/docs/source/cpp/csv.rst
@@ -38,11 +38,13 @@ Data in a CSV file can either be read in as a single Arrow Table using
 :class:`~arrow::csv::StreamingReader`. See :ref:`Tradeoffs <cpp-csv-tradeoffs>` for a
 discussion of the tradeoffs between the two methods.
 
+Both these readers require an :class:`arrow::io::InputStream` instance
+representing the input file. Their behavior can be customized using a
+combination of :class:`~arrow::csv::ReadOptions`,
+:class:`~arrow::csv::ParseOptions`, and :class:`~arrow::csv::ConvertOptions`.
+
 TableReader
 -----------
-
-The :class:`~arrow::csv::TableReader` class requires an
-:class:`::arrow::io::InputStream` instance representing the input file.
 
 .. code-block:: cpp
 
@@ -78,15 +80,8 @@ The :class:`~arrow::csv::TableReader` class requires an
       std::shared_ptr<arrow::Table> table = *maybe_table;
    }
 
-Behavior of :class:`~arrow::csv::TableReader` can be customized using a
-combination of :class:`~arrow::csv::ReadOptions`,
-:class:`~arrow::csv::ParseOptions`, and :class:`~arrow::csv::ConvertOptions`.
-
 StreamingReader
 ---------------
-
-The :class:`~arrow::csv::StreamingReader` class requires an
-:class:`::arrow::io::InputStream` instance representing the input file.
 
 .. code-block:: cpp
 
@@ -123,10 +118,6 @@ The :class:`~arrow::csv::StreamingReader` class requires an
         // Handle end of file
       }
    }
-
-Behavior of :class:`~arrow::csv::StreamingReader` can be customized using a
-combination of :class:`~arrow::csv::ReadOptrions`,
-:class:`~arrow::csv::ParseOptions`, and :class:`~arrow::csv::ConvertOptions`.
 
 .. _cpp-csv-tradeoffs:
 

--- a/docs/source/cpp/csv.rst
+++ b/docs/source/cpp/csv.rst
@@ -112,7 +112,11 @@ StreamingReader
       std::shared_ptr<RecordBatch> batch;
 
       // Attempt to read the first RecordBatch
-      reader->ReadNext(&batch);
+      arrow::Status status = reader->ReadNext(&batch);
+
+      if (!status.ok()) {
+        // Handle read error
+      }
 
       if (batch == NULL) {
         // Handle end of file

--- a/docs/source/cpp/csv.rst
+++ b/docs/source/cpp/csv.rst
@@ -133,15 +133,18 @@ combination of :class:`~arrow::csv::ReadOptrions`,
 Tradeoffs
 ---------
 
-The choice between using :class:`~arrow::csv::TableReader` or :class:`~arrow::csv::StreamingReader`
-will depend on your use case but two caveats are worth pointing out:
+The choice between using :class:`~arrow::csv::TableReader` or
+:class:`~arrow::csv::StreamingReader` will depend on your use case but two
+caveats are worth pointing out:
 
 1. :class:`~arrow::csv::TableReader` is capable of using multiple threads (See
    :ref:`Performance <cpp-csv-performance>`) whereas
    :class:`~arrow::csv::StreamingReader` is always single-threaded and will
    ignore :member:`ReadOptions::use_threads`.
 2. :class:`~arrow::csv::StreamingReader` performs type inference off the first
-   block that's read in, after which point the types are frozen. Either set :member:`ReadOptions::block_size` to a large enough value or use :member:`ConvertOptions::column_types` to set the desired data types
+   block that's read in, after which point the types are frozen. Either set
+   :member:`ReadOptions::block_size` to a large enough value or use
+   :member:`ConvertOptions::column_types` to set the desired data types
    explicitly.
 
 Writing CSV files

--- a/docs/source/cpp/csv.rst
+++ b/docs/source/cpp/csv.rst
@@ -25,15 +25,24 @@ Reading and Writing CSV files
 =============================
 
 Arrow provides a fast CSV reader allowing ingestion of external data
-as Arrow tables.
+as Arrow Tables or streamed as Arrow RecordBatches.
 
 .. seealso::
    :ref:`CSV reader/writer API reference <cpp-api-csv>`.
 
-Basic usage
-===========
+Reading CSV files
+=================
 
-A CSV file is read from a :class:`~arrow::io::InputStream`.
+Data in a CSV file can either be read in as a single Arrow Table using
+:class:`~arrow::csv::TableReader` or streamed as RecordBatches using
+:class:`~arrow::csv::StreamingReader`. See :ref:`Tradeoffs <tradeoffs>` for a
+discussion of the tradeoffs between the two methods.
+
+TableReader
+-----------
+
+The :class:`~arrow::csv::TableReader` class requires an
+:class:`::arrow::io::InputStream` instance representing the input file.
 
 .. code-block:: cpp
 
@@ -56,18 +65,87 @@ A CSV file is read from a :class:`~arrow::io::InputStream`.
                                       parse_options,
                                       convert_options);
       if (!maybe_reader.ok()) {
-         // Handle TableReader instantiation error...
+        // Handle TableReader instantiation error...
       }
       std::shared_ptr<arrow::csv::TableReader> reader = *maybe_reader;
 
       // Read table from CSV file
       auto maybe_table = reader->Read();
       if (!maybe_table.ok()) {
-         // Handle CSV read error
-         // (for example a CSV syntax error or failed type conversion)
+        // Handle CSV read error
+        // (for example a CSV syntax error or failed type conversion)
       }
       std::shared_ptr<arrow::Table> table = *maybe_table;
    }
+
+Behavior of :class:`~arrow::csv::TableReader` can be customized using a
+combination of :class:`~arrow::csv::ReadOptions`,
+:class:`~arrow::csv::ParseOptions`, and :class:`~arrow::csv::ConvertOptions`.
+
+StreamingReader
+---------------
+
+The :class:`~arrow::csv::StreamingReader` class requires an
+:class:`::arrow::io::InputStream` instance representing the input file.
+
+.. code-block:: cpp
+
+   #include "arrow/csv/api.h"
+
+   {
+      // ...
+      arrow::io::IOContext io_context = arrow::io::default_io_context();
+      std::shared_ptr<arrow::io::InputStream> input = ...;
+
+      auto read_options = arrow::csv::ReadOptions::Defaults();
+      auto parse_options = arrow::csv::ParseOptions::Defaults();
+      auto convert_options = arrow::csv::ConvertOptions::Defaults();
+
+      // Instantiate StreamingReader from input stream and options
+      auto maybe_reader =
+        arrow::csv::StreamingReader::Make(io_context,
+                                          input,
+                                          read_options,
+                                          parse_options,
+                                          convert_options);
+      if (!maybe_reader.ok()) {
+        // Handle StreamingReader instantiation error...
+      }
+      std::shared_ptr<arrow::csv::StreamingReader> reader = *maybe_reader;
+
+      // Set aside a RecordBatch pointer for re-use while streaming
+      std::shared_ptr<RecordBatch> batch;
+
+      // Attempt to read the first RecordBatch
+      reader->ReadNext(&batch);
+
+      if (batch == NULL) {
+        // Handle end of file
+      }
+   }
+
+Behavior of :class:`~arrow::csv::StreamingReader` can be customized using a
+combination of :class:`~arrow::csv::ReadOptrions`,
+:class:`~arrow::csv::ParseOptions`, and :class:`~arrow::csv::ConvertOptions`.
+
+.. _tradeoffs:
+
+Tradeoffs
+---------
+
+The choice between using :class:`~arrow::csv::TableReader` or :class:`~arrow::csv::StreamingReader`
+will depend on your use case but two caveats are worth pointing out:
+
+1. :class:`~arrow::csv::TableReader` is capable of using multiple threads (See
+   :ref:`Performance <performance>`) whereas
+   :class:`~arrow::csv::StreamingReader` is always single-threaded and will
+   ignore :member:`ReadOptions::use_threads`.
+2. :class:`~arrow::csv::StreamingReader` performs type inference off the first
+   block that's read in, after which point the types are frozen. Either set :member:`ReadOptions::block_size` to a large enough value or use :member:`ConvertOptions::column_types` to set the desired data types
+   explicitly.
+
+Writing CSV files
+=================
 
 A CSV file is written to a :class:`~arrow::io::OutputStream`.
 
@@ -275,11 +353,13 @@ Write Options
 The format of written CSV files can be customized via :class:`~arrow::csv::WriteOptions`.
 Currently few options are available; more will be added in future releases.
 
+.. _performance:
+
 Performance
 ===========
 
-By default, the CSV reader will parallelize reads in order to exploit all
-CPU cores on your machine.  You can change this setting in
+By default, :class:`~arrow::csv::TableReader` will parallelize reads in order to
+exploit all CPU cores on your machine.  You can change this setting in
 :member:`ReadOptions::use_threads`.  A reasonable expectation is at least
 100 MB/s per core on a performant desktop or laptop computer (measured in
 source CSV bytes, not target Arrow data bytes).

--- a/docs/source/cpp/csv.rst
+++ b/docs/source/cpp/csv.rst
@@ -145,7 +145,8 @@ but there are a few tradeoffs to be aware of:
 2. **Speed:** When reading the entire contents of a CSV,
    :class:`~arrow::csv::TableReader` will tend to be faster than
    :class:`~arrow::csv::StreamingReader` because it makes better use of
-   available cores.
+   available cores. See :ref:`Performance <cpp-csv-performance>` for more
+   details.
 3. **Flexibility:** :class:`~arrow::csv::StreamingReader` might be considered
    less flexible than :class:`~arrow::csv::TableReader` because it performs type
    inference only on the first block that's read in, after which point the types

--- a/docs/source/cpp/csv.rst
+++ b/docs/source/cpp/csv.rst
@@ -111,15 +111,20 @@ StreamingReader
       // Set aside a RecordBatch pointer for re-use while streaming
       std::shared_ptr<RecordBatch> batch;
 
-      // Attempt to read the first RecordBatch
-      arrow::Status status = reader->ReadNext(&batch);
+      while (true) {
+          // Attempt to read the first RecordBatch
+          arrow::Status status = reader->ReadNext(&batch);
 
-      if (!status.ok()) {
-        // Handle read error
-      }
+          if (!status.ok()) {
+            // Handle read error
+          }
 
-      if (batch == NULL) {
-        // Handle end of file
+          if (batch == NULL) {
+            // Handle end of file
+            break;
+          }
+
+          // Do something with the batch
       }
    }
 

--- a/docs/source/cpp/csv.rst
+++ b/docs/source/cpp/csv.rst
@@ -25,7 +25,7 @@ Reading and Writing CSV files
 =============================
 
 Arrow provides a fast CSV reader allowing ingestion of external data
-as Arrow Tables or streamed as Arrow RecordBatches.
+to create Arrow Tables or a stream of Arrow RecordBatches.
 
 .. seealso::
    :ref:`CSV reader/writer API reference <cpp-api-csv>`.

--- a/docs/source/cpp/csv.rst
+++ b/docs/source/cpp/csv.rst
@@ -135,12 +135,11 @@ Tradeoffs
 
 The choice between using :class:`~arrow::csv::TableReader` or
 :class:`~arrow::csv::StreamingReader` will depend on your use case but two
-caveats are worth pointing out:
+tradeoffs are worth pointing out:
 
-1. :class:`~arrow::csv::TableReader` is capable of using multiple threads (See
-   :ref:`Performance <cpp-csv-performance>`) whereas
-   :class:`~arrow::csv::StreamingReader` is always single-threaded and will
-   ignore :member:`ReadOptions::use_threads`.
+1. When reading the entire contents of a CSV, :class:`~arrow::csv::TableReader`
+   will tend to be more performant than :class:`~arrow::csv::StreamingReader`
+   because it makes better use of available cores.
 2. :class:`~arrow::csv::StreamingReader` performs type inference off the first
    block that's read in, after which point the types are frozen. Either set
    :member:`ReadOptions::block_size` to a large enough value or use

--- a/docs/source/cpp/csv.rst
+++ b/docs/source/cpp/csv.rst
@@ -137,20 +137,21 @@ The choice between using :class:`~arrow::csv::TableReader` or
 :class:`~arrow::csv::StreamingReader` will ultimately depend on the use case
 but there are a few tradeoffs to be aware of:
 
-1. **Memory usage:** :class:`~arrow::csv::TableReader` loads all of the data into memory at once
-   and, depending on the amount of data, may require considerably more memory
-   than :class:`~arrow::csv::StreamingReader` which only loads one
-   :class:`~arrow::RecordBatch` at a time. This is likely to be the most
-   significant tradeoff for users.
-2. **Speed:** When reading the entire contents of a CSV, :class:`~arrow::csv::TableReader`
-   will tend to be faster than :class:`~arrow::csv::StreamingReader` because it
-   makes better use of available cores.
-3. **Flexibility:** :class:`~arrow::csv::StreamingReader` might be considered
+1. **Memory usage:** :class:`~arrow::csv::TableReader` loads all of the data
+   into memory at once and, depending on the amount of data, may require
+   considerably more memory than :class:`~arrow::csv::StreamingReader` which
+   only loads one :class:`~arrow::RecordBatch` at a time. This is likely to be
+   the most significant tradeoff for users.
+3. **Speed:** When reading the entire contents of a CSV,
+   :class:`~arrow::csv::TableReader` will tend to be faster than
+   :class:`~arrow::csv::StreamingReader` because it makes better use of
+   available cores.
+4. **Flexibility:** :class:`~arrow::csv::StreamingReader` might be considered
    less flexible than :class:`~arrow::csv::TableReader` because it performs type
    inference only on the first block that's read in, after which point the types
-   are frozen and any data in subsequent blocks not matching those types will
-   cause an error. Note that this can be remedied either by setting
-   :member:`ReadOptions::block_size` to a large enough value or by using
+   are frozen and any data in subsequent blocks that cannot be converted to
+   those types will cause an error. Note that this can be remedied either by
+   setting :member:`ReadOptions::block_size` to a large enough value or by using
    :member:`ConvertOptions::column_types` to set the desired data types
    explicitly.
 

--- a/docs/source/cpp/csv.rst
+++ b/docs/source/cpp/csv.rst
@@ -134,15 +134,23 @@ Tradeoffs
 ---------
 
 The choice between using :class:`~arrow::csv::TableReader` or
-:class:`~arrow::csv::StreamingReader` will depend on your use case but two
-tradeoffs are worth pointing out:
+:class:`~arrow::csv::StreamingReader` will ultimately depend on the use case
+but there are a few tradeoffs to be aware of:
 
-1. When reading the entire contents of a CSV, :class:`~arrow::csv::TableReader`
-   will tend to be more performant than :class:`~arrow::csv::StreamingReader`
-   because it makes better use of available cores.
-2. :class:`~arrow::csv::StreamingReader` performs type inference off the first
-   block that's read in, after which point the types are frozen. Either set
-   :member:`ReadOptions::block_size` to a large enough value or use
+1. **Memory usage:** :class:`~arrow::csv::TableReader` loads all of the data into memory at once
+   and, depending on the amount of data, may require considerably more memory
+   than :class:`~arrow::csv::StreamingReader` which only loads one
+   :class:`~arrow::RecordBatch` at a time. This is likely to be the most
+   significant tradeoff for users.
+2. **Speed:** When reading the entire contents of a CSV, :class:`~arrow::csv::TableReader`
+   will tend to be faster than :class:`~arrow::csv::StreamingReader` because it
+   makes better use of available cores.
+3. **Flexibility:** :class:`~arrow::csv::StreamingReader` might be considered
+   less flexible than :class:`~arrow::csv::TableReader` because it performs type
+   inference only on the first block that's read in, after which point the types
+   are frozen and any data in subsequent blocks not matching those types will
+   cause an error. Note that this can be remedied either by setting
+   :member:`ReadOptions::block_size` to a large enough value or by using
    :member:`ConvertOptions::column_types` to set the desired data types
    explicitly.
 

--- a/docs/source/cpp/csv.rst
+++ b/docs/source/cpp/csv.rst
@@ -142,11 +142,11 @@ but there are a few tradeoffs to be aware of:
    considerably more memory than :class:`~arrow::csv::StreamingReader` which
    only loads one :class:`~arrow::RecordBatch` at a time. This is likely to be
    the most significant tradeoff for users.
-3. **Speed:** When reading the entire contents of a CSV,
+2. **Speed:** When reading the entire contents of a CSV,
    :class:`~arrow::csv::TableReader` will tend to be faster than
    :class:`~arrow::csv::StreamingReader` because it makes better use of
    available cores.
-4. **Flexibility:** :class:`~arrow::csv::StreamingReader` might be considered
+3. **Flexibility:** :class:`~arrow::csv::StreamingReader` might be considered
    less flexible than :class:`~arrow::csv::TableReader` because it performs type
    inference only on the first block that's read in, after which point the types
    are frozen and any data in subsequent blocks that cannot be converted to


### PR DESCRIPTION
Updates the C++ CSV reader docs to include documenting and an example of the streaming CSV reader (StreamingReader), as per the suggestion in [ARROW-15328](https://issues.apache.org/jira/browse/ARROW-15328). 

@westonpace could you look at this and let me know if this is what you were thinking?