### PR TITLE
ARROW-18094: [Dev][CI] Make nightly group as an alias of nightly-*

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -139,24 +139,7 @@ groups:
 {######################## Tasks to run regularly #############################}
 
   nightly:
-    - verify-rc-source-*
-    - almalinux-*
-    - amazon-linux-*
-    - debian-*
-    - ubuntu-*
-    - centos-*
-    - conan-*
-    - conda-*
-    - java-jars
-    # List the homebrews explicitly because we don't care about running homebrew-cpp-autobrew
-    - homebrew-cpp
-    - homebrew-r-autobrew
-    - homebrew-r-brew
-    - nuget
-    - test-*
-    - example-*
-    - wheel-*
-    - python-sdist
+    - nightly-*
 
   nightly-tests:
     - test-*


### PR DESCRIPTION
We use "nightly-*" groups not "nightly" group for our nightly CI. So we need to use "crossbow submit -g nightly-tests -g nightly-packaging -g nightly-release" to run nightly jobs when we want to run nightly jobs before we merge a pull request.

But it's inconvenient and easy to mistake. For example, some developers use "crossbow submit -g nightly" to run nightly jobs.

How about make "nightly" group as an alias of "nightly-*" groups to improve developer experience?