### PR TITLE
ARROW-17317: [Release][Docs] Normalize previous document version directory

### DIFF
--- a/dev/release/post-08-docs.sh
+++ b/dev/release/post-08-docs.sh
@@ -81,7 +81,8 @@ tar xvf docs.tar.gz
 rm -f docs.tar.gz
 git checkout docs/c_glib/index.html
 if [ "$is_major_release" = "yes" ] ; then
-  mv docs_temp docs/${previous_version}
+  previous_series=${previous_version%.*}
+  mv docs_temp docs/${previous_series}
 fi
 git add docs
 git commit -m "[Website] Update documentations for ${version}"


### PR DESCRIPTION
We should use X.Y instead of X.Y.Z (e.g.: 8.0 not 8.0.1) for previous version document directory.

See also:
https://github.com/apache/arrow/blob/apache-arrow-9.0.0/dev/release/post-08-docs.sh#L84

The script should accept X.Y.Z such as 8.0.1 and normalize it to X.Y. It'll reduce human error.

See also:

* https://github.com/apache/arrow-site/pull/228#issuecomment-1205997067
* https://github.com/apache/arrow-site/pull/228#issuecomment-1206085602