### PR TITLE
ARROW-17025:  [Dev] Remove github user name links from merge commit message

### DIFF
--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -426,7 +426,9 @@ class PullRequest(object):
         commit_title = f'{self.title} (#{self.number})'
         commit_message_chunks = []
         if self.body is not None:
-            commit_message_chunks.append(self.body)
+            # avoid github user name references by inserting a space after @
+            body = re.sub(r"@(\w+)", "@ \\1", self.body)
+            commit_message_chunks.append(body)
 
         committer_name = run_cmd("git config --get user.name").strip()
         committer_email = run_cmd("git config --get user.email").strip()


### PR DESCRIPTION
Insert a space between the ``@`` and the username, to avoid it is an actual github reference