### PR TITLE
ARROW-18052: [Python] Support passing create_dir thru pq.write_to_dataset

### DIFF
--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -3060,6 +3060,7 @@ def write_to_dataset(table, root_path, partition_cols=None,
                      partitioning=None, basename_template=None,
                      use_threads=None, file_visitor=None,
                      existing_data_behavior=None,
+                     create_dir=True,
                      **kwargs):
     """Wrapper around dataset.write_dataset (when use_legacy_dataset=False) or
     parquet.write_table (when use_legacy_dataset=True) for writing a Table to
@@ -3161,6 +3162,9 @@ def write_to_dataset(table, root_path, partition_cols=None,
         the entire directory will be deleted.  This allows you to overwrite
         old partitions completely.
         This option is only supported for use_legacy_dataset=False.
+    create_dir : bool, default True
+        If False, directories will not be created.  This can be useful for
+        filesystems that do not require directories.
     **kwargs : dict,
         When use_legacy_dataset=False, used as additional kwargs for
         `dataset.write_dataset` function (passed to
@@ -3284,7 +3288,7 @@ def write_to_dataset(table, root_path, partition_cols=None,
             file_visitor=file_visitor,
             basename_template=basename_template,
             existing_data_behavior=existing_data_behavior,
-            max_rows_per_group=row_group_size)
+            max_rows_per_group=row_group_size, create_dir=create_dir)
         return
 
     # warnings and errors when using legacy implementation

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -21,6 +21,7 @@ from concurrent import futures
 from contextlib import nullcontext
 from functools import partial, reduce
 
+import inspect
 import json
 from collections.abc import Collection
 import numpy as np
@@ -3060,7 +3061,6 @@ def write_to_dataset(table, root_path, partition_cols=None,
                      partitioning=None, basename_template=None,
                      use_threads=None, file_visitor=None,
                      existing_data_behavior=None,
-                     create_dir=True,
                      **kwargs):
     """Wrapper around dataset.write_dataset (when use_legacy_dataset=False) or
     parquet.write_table (when use_legacy_dataset=True) for writing a Table to
@@ -3162,14 +3162,11 @@ def write_to_dataset(table, root_path, partition_cols=None,
         the entire directory will be deleted.  This allows you to overwrite
         old partitions completely.
         This option is only supported for use_legacy_dataset=False.
-    create_dir : bool, default True
-        If False, directories will not be created.  This can be useful for
-        filesystems that do not require directories.
     **kwargs : dict,
         When use_legacy_dataset=False, used as additional kwargs for
-        `dataset.write_dataset` function (passed to
-        `ParquetFileFormat.make_write_options`). See the docstring
-        of `write_table` for the available options.
+        `dataset.write_dataset` function for matching kwargs, and remainder to
+        `ParquetFileFormat.make_write_options`. See the docstring
+        of `write_table` and `dataset.write_dataset` for the available options.
         When use_legacy_dataset=True, used as additional kwargs for
         `parquet.write_table` function (See docstring for `write_table`
         or `ParquetWriter` for more information).
@@ -3241,22 +3238,20 @@ def write_to_dataset(table, root_path, partition_cols=None,
     if not use_legacy_dataset:
         import pyarrow.dataset as ds
 
-        # extract non-file format options
-        schema = kwargs.pop("schema", None)
-        use_threads = kwargs.pop("use_threads", True)
-        chunk_size = kwargs.pop("chunk_size", None)
-        row_group_size = kwargs.pop("row_group_size", None)
-
-        row_group_size = (
-            row_group_size if row_group_size is not None else chunk_size
+        # extract write_dataset specific options
+        # reset assumed to go to make_write_options
+        write_dataset_kwargs = dict()
+        for key in inspect.signature(ds.write_dataset).parameters:
+            if key in kwargs:
+                write_dataset_kwargs[key] = kwargs.pop(key)
+        write_dataset_kwargs['max_rows_per_group'] = kwargs.pop(
+            'row_group_size', kwargs.pop("chunk_size", None)
         )
-
         # raise for unsupported keywords
         msg = (
             "The '{}' argument is not supported with the new dataset "
             "implementation."
         )
-
         if metadata_collector is not None:
             def file_visitor(written_file):
                 metadata_collector.append(written_file.metadata)
@@ -3288,7 +3283,7 @@ def write_to_dataset(table, root_path, partition_cols=None,
             file_visitor=file_visitor,
             basename_template=basename_template,
             existing_data_behavior=existing_data_behavior,
-            max_rows_per_group=row_group_size, create_dir=create_dir)
+            **write_dataset_kwargs)
         return
 
     # warnings and errors when using legacy implementation

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -16,11 +16,13 @@
 # under the License.
 
 import datetime
+import inspect
 import os
 import pathlib
 
 import numpy as np
 import pytest
+import unittest.mock as mock
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -1880,3 +1882,29 @@ def test_write_to_dataset_conflicting_keywords(tempdir):
                             use_legacy_dataset=False,
                             metadata_collector=[],
                             file_visitor=lambda x: x)
+
+
+@pytest.mark.dataset
+@pytest.mark.parametrize("write_dataset_kwarg", (
+    ("create_dir", True),
+    ("create_dir", False),
+))
+def test_write_to_dataset_kwargs_passed(tempdir, write_dataset_kwarg):
+    """Verify kwargs in pq.write_to_dataset are passed onto ds.write_dataset"""
+    import pyarrow.dataset as ds
+
+    table = pa.table({"a": [1, 2, 3]})
+    path = tempdir / 'out.parquet'
+
+    signature = inspect.signature(ds.write_dataset)
+    key, arg = write_dataset_kwarg
+
+    # kwarg not in pq.write_to_dataset, but will be passed to ds.write_dataset
+    assert key not in inspect.signature(pq.write_to_dataset).parameters
+    assert key in signature.parameters
+
+    with mock.patch.object(ds, "write_dataset", autospec=True)\
+            as mock_write_dataset:
+        pq.write_to_dataset(table, path, **{key: arg})
+        _name, _args, kwargs = mock_write_dataset.mock_calls[0]
+        assert kwargs[key] == arg


### PR DESCRIPTION
Will fix [ARROW-18052](https://issues.apache.org/jira/browse/ARROW-18052)

Should likely need a test, but curious if we should add another `write_dataset_kwargs`(?) collection parameter for `pq.write_to_dataset` for those kwargs that ought to be passed onto `ds.write_dataset`.