### PR TITLE
ARROW-18103: [Packaging][deb][RPM] Fix upload artifacts patterns

### DIFF
--- a/dev/tasks/linux-packages/github.linux.amd64.yml
+++ b/dev/tasks/linux-packages/github.linux.amd64.yml
@@ -44,7 +44,6 @@ jobs:
           rake version:update
           rake docker:pull || :
           rake --trace {{ task_namespace }}:build BUILD_DIR=build
-          sudo rm -rf */*/build
           popd
         env:
           APT_TARGETS: {{ target }}
@@ -103,5 +102,5 @@ jobs:
           ARROW_VERSION: {{ arrow.version }}
           YUM_TARGETS: {{ target }}
 
-      {% set patterns = upload_extensions | format_all("arrow/dev/tasks/linux-packages/**/*{}") %}
+      {% set patterns = upload_extensions | format_all("arrow/dev/tasks/linux-packages/*/*/repositories/**/*{}") %}
       {{ macros.github_upload_releases(patterns)|indent }}

--- a/dev/tasks/linux-packages/travis.linux.arm64.yml
+++ b/dev/tasks/linux-packages/travis.linux.arm64.yml
@@ -160,5 +160,5 @@ script:
   - popd
 
 after_success:
-  {% set patterns = upload_extensions | format_all("arrow/dev/tasks/linux-packages/**/*{}") %}
+  {% set patterns = upload_extensions | format_all("arrow/dev/tasks/linux-packages/*/*/repositories/**/*{}") %}
   {{ macros.travis_upload_releases(patterns) }}


### PR DESCRIPTION
The current patterns may match multiple files that have the same base name. For example:

* `arrow/dev/tasks/linux-packages/apache-arrow/apt/repositories/debian/pool/bookworm/main/a/apache-arrow/libarrow-glib-dev_10.0.0.dev480-1_arm64.deb`
* `arrow/dev/tasks/linux-packages/apache-arrow/apt/build/debian-bookworm-arm64/libgandiva-glib-dev_10.0.0.dev480-1_arm64.deb`

The latter (`**/build/**`) is an artifact in a build directory. We should use only the former (`**/repositories/**`) that is an artifact for upload.
