### PR TITLE
ARROW-18117: [C++] Fix static bundle build

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -3900,7 +3900,7 @@ macro(build_grpc)
        gRPC::grpc
        gRPC::grpcpp_for_bundling
        gRPC::upb)
-  if(ABS_VENDORED)
+  if(ABSL_VENDORED)
     list(APPEND ARROW_BUNDLED_STATIC_LIBS ${GRPC_GPR_ABSL_LIBRARIES})
   endif()
 endmacro()


### PR DESCRIPTION
Which prevents `libarrow_bundled_dependencies` to contain all required symbols.