### PR TITLE
ARROW-18118: [Release][Dev] Fix problems in 02-source.sh/03-binary-submit.sh for 10.0.0-rc0

### DIFF
--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -546,7 +546,7 @@ class Repo:
                         'Unsupported upload method {}'.format(method)
                     )
 
-    def github_pr(self, title, head=None, base="master", body=None,
+    def github_pr(self, title, head=None, base=None, body=None,
                   github_token=None, create=False):
         github_token = github_token or self.github_token
         repo = self.as_github_repo(github_token=github_token)

--- a/dev/release/02-source.sh
+++ b/dev/release/02-source.sh
@@ -18,7 +18,7 @@
 # under the License.
 #
 
-set -e
+set -eu
 
 : ${SOURCE_DEFAULT:=1}
 : ${SOURCE_RAT:=${SOURCE_DEFAULT}}
@@ -39,7 +39,7 @@ rc=$2
 
 tag=apache-arrow-${version}
 maint_branch=maint-${version}
-release_candidate_branch="release-${version}-rc${rc_number}"
+rc_branch="release-${version}-rc${rc}"
 tagrc=${tag}-rc${rc}
 rc_url="https://dist.apache.org/repos/dist/dev/arrow/${tagrc}"
 
@@ -129,13 +129,12 @@ fi
 # Create Pull Request and Crossbow comment to run verify source tasks
 if [ ${SOURCE_PR} -gt 0 ]; then
   archery crossbow \
-    --github-token=${ARROW_GITHUB_API_TOKEN} \
     verify-release-candidate \
     --base-branch=${maint_branch} \
     --create-pr \
-    --head-branch=${release_candidate_branch} \
+    --head-branch=${rc_branch} \
     --pr-body="PR to verify Release Candidate" \
-    --pr-title="WIP: [Release] Verify ${release_candidate_branch}" \
+    --pr-title="WIP: [Release] Verify ${rc_branch}" \
     --remote=https://github.com/apache/arrow \
     --rc=${rc} \
     --verify-source \

--- a/dev/release/03-binary-submit.sh
+++ b/dev/release/03-binary-submit.sh
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -e
+set -eu
 
 if [ "$#" -ne 2 ]; then
   echo "Usage: $0 <version> <rc-num>"
@@ -29,6 +29,7 @@ rc_number=$2
 version_with_rc="${version}-rc${rc_number}"
 crossbow_job_prefix="release-${version_with_rc}"
 release_tag="apache-arrow-${version}"
+rc_branch="release-${version_with_rc}"
 
 : ${ARROW_REPOSITORY:="apache/arrow"}
 : ${ARROW_BRANCH:=$release_tag}
@@ -46,9 +47,9 @@ archery crossbow submit \
 
 # archery will add a comment to the automatically generated PR to track
 # the submitted jobs
-job_name=$(archery crossbow latest-prefix ${crossbow_job_prefix})
+job_name=$(archery crossbow latest-prefix --no-fetch ${crossbow_job_prefix})
 archery crossbow report-pr \
     --no-fetch \
     --arrow-remote "https://github.com/${ARROW_REPOSITORY}" \
     --job-name ${job_name} \
-    --pr-title "WIP: [Release] Verify ${release_candidate_branch}"
+    --pr-title "WIP: [Release] Verify ${rc_branch}"

--- a/dev/release/03-binary-submit.sh
+++ b/dev/release/03-binary-submit.sh
@@ -25,8 +25,8 @@ if [ "$#" -ne 2 ]; then
 fi
 
 version=$1
-rc_number=$2
-version_with_rc="${version}-rc${rc_number}"
+rc=$2
+version_with_rc="${version}-rc${rc}"
 crossbow_job_prefix="release-${version_with_rc}"
 release_tag="apache-arrow-${version}"
 rc_branch="release-${version_with_rc}"

--- a/docs/source/developers/release.rst
+++ b/docs/source/developers/release.rst
@@ -61,12 +61,11 @@ generated properly.
         mvn clean install -Papache-release
 
     - Have the build requirements for cpp and c_glib installed.
-    - Set the JIRA_USERNAME and JIRA_PASSWORD environment variables
-    - Set the ARROW_GITHUB_API_TOKEN environment variable to automatically create the verify release Pull Request.
+    - Set the ``JIRA_USERNAME`` and ``JIRA_PASSWORD`` environment variables
+    - Set the ``CROSSBOW_GITHUB_TOKEN`` environment variable to automatically create the verify release Pull Request.
     - Install ``en_US.UTF-8`` locale. You can confirm available locales by ``locale -a``.
     - Install Python 3 as python
     - Create dev/release/.env from dev/release/.env.example. See the comments in dev/release/.env.example how to set each variable.
-    - Request to the Apache INFRA group to be aadded to `Bintray members <https://bintray.com/apache/>`_.
     - Setup :ref:`Crossbow<Crossbow>` as defined.
     - Have Docker and docker-compose installed.
 


### PR DESCRIPTION
SOURCE_PR in dev/release/02-source.sh didn't work because it refers undefined variable (`rc_number` is referred not `rc`). This change includes the following changes including the fix of the undefined variable problem:

- Fix wrong variable use. (Variable name is also changed to adjust other variable names: `release_candidate` -> `rc`)
- The ARROW_GITHUB_API_TOKEN environment variable is used for GitHub Personal Access Token but the CROSSBOW_GITHUB_TOKEN environment variable is used in others. So this also uses CROSSBOW_GITHUB_TOKEN. (Documentation is also updated. This change also includes unrelated minor updates. Sorry.)

dev/release/03-binary-submit.sh didn't work because:

- It refers undefined variable (`release_candidate_branch`).
- `archery crossbow report-pr` searches only `base=master` pull requests. (A verify pull request uses `base=maint-X.Y.Z`.)

This change fixes them. This change also adds `--no-fetch` to `archery crossbow latest-prefix` like other command lines to reduce execution time.