### PR TITLE
MINOR: [Release] Add seccomp=undefined to APT verification

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -213,6 +213,7 @@ test_apt() {
         ;;
     esac
     if ! docker run --rm -v "${ARROW_DIR}":/arrow:delegated \
+           --security-opt="seccomp=unconfined" \
            "${target}" \
            /arrow/dev/release/verify-apt.sh \
            "${VERSION}" \


### PR DESCRIPTION
Needed to avoid 'Failed to close file descriptor for child process'. The other Docker invocations already have it, but not this one.