### PR TITLE
ARROW-18135: [C++] Avoid warnings that ExecBatch::length may be uninitialized

### DIFF
--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -602,9 +602,7 @@ Future<std::vector<ExecBatch>> DeclarationToExecBatchesAsync(Declaration declara
       .Then([collected_fut, exec_plan]() -> Result<std::vector<ExecBatch>> {
         ARROW_ASSIGN_OR_RAISE(auto collected, collected_fut.result());
         return ::arrow::internal::MapVector(
-            [](std::optional<ExecBatch> batch) {
-              return ARROW_PREDICT_TRUE(batch) ? std::move(*batch) : ExecBatch();
-            },
+            [](std::optional<ExecBatch> batch) { return batch.value_or(ExecBatch()); },
             std::move(collected));
       });
 }

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -602,7 +602,9 @@ Future<std::vector<ExecBatch>> DeclarationToExecBatchesAsync(Declaration declara
       .Then([collected_fut, exec_plan]() -> Result<std::vector<ExecBatch>> {
         ARROW_ASSIGN_OR_RAISE(auto collected, collected_fut.result());
         return ::arrow::internal::MapVector(
-            [](std::optional<ExecBatch> batch) { return std::move(*batch); },
+            [](std::optional<ExecBatch> batch) {
+              return ARROW_PREDICT_TRUE(batch) ? std::move(*batch) : ExecBatch();
+            },
             std::move(collected));
       });
 }

--- a/cpp/src/arrow/compute/exec/test_util.cc
+++ b/cpp/src/arrow/compute/exec/test_util.cc
@@ -189,7 +189,9 @@ Future<std::vector<ExecBatch>> StartAndCollect(
       .Then([collected_fut]() -> Result<std::vector<ExecBatch>> {
         ARROW_ASSIGN_OR_RAISE(auto collected, collected_fut.result());
         return ::arrow::internal::MapVector(
-            [](std::optional<ExecBatch> batch) { return std::move(*batch); },
+            [](std::optional<ExecBatch> batch) {
+              return ARROW_PREDICT_TRUE(batch) ? std::move(*batch) : ExecBatch();
+            },
             std::move(collected));
       });
 }

--- a/cpp/src/arrow/compute/exec/test_util.cc
+++ b/cpp/src/arrow/compute/exec/test_util.cc
@@ -189,9 +189,7 @@ Future<std::vector<ExecBatch>> StartAndCollect(
       .Then([collected_fut]() -> Result<std::vector<ExecBatch>> {
         ARROW_ASSIGN_OR_RAISE(auto collected, collected_fut.result());
         return ::arrow::internal::MapVector(
-            [](std::optional<ExecBatch> batch) {
-              return ARROW_PREDICT_TRUE(batch) ? std::move(*batch) : ExecBatch();
-            },
+            [](std::optional<ExecBatch> batch) { return batch.value_or(ExecBatch()); },
             std::move(collected));
       });
 }

--- a/cpp/src/arrow/compute/kernels/hash_aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate_test.cc
@@ -152,7 +152,9 @@ Result<Datum> GroupByUsingExecPlan(const BatchesWithSchema& input,
           .Then([collected_fut]() -> Result<std::vector<ExecBatch>> {
             ARROW_ASSIGN_OR_RAISE(auto collected, collected_fut.result());
             return ::arrow::internal::MapVector(
-                [](std::optional<ExecBatch> batch) { return std::move(*batch); },
+                [](std::optional<ExecBatch> batch) {
+                  return ARROW_PREDICT_TRUE(batch) ? std::move(*batch) : ExecBatch();
+                },
                 std::move(collected));
           });
 

--- a/cpp/src/arrow/compute/kernels/hash_aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate_test.cc
@@ -153,7 +153,7 @@ Result<Datum> GroupByUsingExecPlan(const BatchesWithSchema& input,
             ARROW_ASSIGN_OR_RAISE(auto collected, collected_fut.result());
             return ::arrow::internal::MapVector(
                 [](std::optional<ExecBatch> batch) {
-                  return ARROW_PREDICT_TRUE(batch) ? std::move(*batch) : ExecBatch();
+                  return batch.value_or(ExecBatch());
                 },
                 std::move(collected));
           });

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -2157,7 +2157,10 @@ struct TestPlan {
         .Then([collected_fut]() -> Result<std::vector<compute::ExecBatch>> {
           ARROW_ASSIGN_OR_RAISE(auto collected, collected_fut.result());
           return ::arrow::internal::MapVector(
-              [](std::optional<compute::ExecBatch> batch) { return std::move(*batch); },
+              [](std::optional<compute::ExecBatch> batch) {
+                return ARROW_PREDICT_TRUE(batch) ? std::move(*batch)
+                                                 : compute::ExecBatch();
+              },
               std::move(collected));
         });
   }

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -2158,8 +2158,7 @@ struct TestPlan {
           ARROW_ASSIGN_OR_RAISE(auto collected, collected_fut.result());
           return ::arrow::internal::MapVector(
               [](std::optional<compute::ExecBatch> batch) {
-                return ARROW_PREDICT_TRUE(batch) ? std::move(*batch)
-                                                 : compute::ExecBatch();
+                return batch.value_or(compute::ExecBatch());
               },
               std::move(collected));
         });


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/ARROW-18135