### PR TITLE
ARROW-18137: [Python][Docs] adding info about TableGroupBy.aggregation with empty list

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -5282,6 +5282,7 @@ class TableGroupBy:
 list[tuple(str, str, FunctionOptions)]
             List of tuples made of aggregation column names followed
             by function names and optionally aggregation function options.
+            Pass empty list to imitate drop_duplicates pandas function.
 
         Returns
         -------
@@ -5301,6 +5302,11 @@ list[tuple(str, str, FunctionOptions)]
         keys: string
         ----
         values_sum: [[3,7,5]]
+        keys: [["a","b","c"]]
+        >>> t.group_by("keys").aggregate([])
+        pyarrow.Table
+        keys: string
+        ----
         keys: [["a","b","c"]]
         """
         columns = [a[0] for a in aggregations]

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -5282,7 +5282,7 @@ class TableGroupBy:
 list[tuple(str, str, FunctionOptions)]
             List of tuples made of aggregation column names followed
             by function names and optionally aggregation function options.
-            Pass empty list to imitate drop_duplicates pandas function.
+            Pass empty list to get a single row for each group.
 
         Returns
         -------


### PR DESCRIPTION
I have realized that pandas drop_duplicates functionality can be easily emulated with group_by(...).aggregate([]) and is much faster than to_pandas().drop_duplicates()

Please consider this addition to documentation.