### PR TITLE
ARROW-18144: [C++] Improve JSONTypeError error message in testing

### DIFF
--- a/cpp/src/arrow/ipc/json_simple.cc
+++ b/cpp/src/arrow/ipc/json_simple.cc
@@ -63,11 +63,29 @@ using ::arrow::internal::checked_pointer_cast;
 namespace {
 
 constexpr auto kParseFlags = rj::kParseFullPrecisionFlag | rj::kParseNanAndInfFlag;
-constexpr std::array<const char*, 7> kJsonTypeNames{"null",  "false",  "true",  "object",
-                                                    "array", "string", "number"};
+const char* JsonTypeNames(rj::Type json_type) {
+  switch (json_type) {
+    case rapidjson::kNullType:
+      return "null";
+    case rapidjson::kFalseType:
+      return "false";
+    case rapidjson::kTrueType:
+      return "true";
+    case rapidjson::kObjectType:
+      return "object";
+    case rapidjson::kArrayType:
+      return "array";
+    case rapidjson::kStringType:
+      return "string";
+    case rapidjson::kNumberType:
+      return "number";
+    default:
+      return "unknown";
+  }
+}
 Status JSONTypeError(const char* expected_type, rj::Type json_type) {
   return Status::Invalid("Expected ", expected_type, " or null, got JSON type ",
-                         kJsonTypeNames[json_type]);
+                         JsonTypeNames(json_type));
 }
 
 class Converter {

--- a/cpp/src/arrow/ipc/json_simple.cc
+++ b/cpp/src/arrow/ipc/json_simple.cc
@@ -63,10 +63,11 @@ using ::arrow::internal::checked_pointer_cast;
 namespace {
 
 constexpr auto kParseFlags = rj::kParseFullPrecisionFlag | rj::kParseNanAndInfFlag;
-
+constexpr std::array<const char*, 7> kJsonTypeNames{"null",  "false",  "true",  "object",
+                                                    "array", "string", "number"};
 Status JSONTypeError(const char* expected_type, rj::Type json_type) {
   return Status::Invalid("Expected ", expected_type, " or null, got JSON type ",
-                         json_type);
+                         kJsonTypeNames[json_type]);
 }
 
 class Converter {

--- a/cpp/src/arrow/ipc/json_simple.cc
+++ b/cpp/src/arrow/ipc/json_simple.cc
@@ -63,7 +63,8 @@ using ::arrow::internal::checked_pointer_cast;
 namespace {
 
 constexpr auto kParseFlags = rj::kParseFullPrecisionFlag | rj::kParseNanAndInfFlag;
-const char* JsonTypeNames(rj::Type json_type) {
+
+const char* JsonTypeName(rj::Type json_type) {
   switch (json_type) {
     case rapidjson::kNullType:
       return "null";
@@ -83,9 +84,10 @@ const char* JsonTypeNames(rj::Type json_type) {
       return "unknown";
   }
 }
+
 Status JSONTypeError(const char* expected_type, rj::Type json_type) {
   return Status::Invalid("Expected ", expected_type, " or null, got JSON type ",
-                         JsonTypeNames(json_type));
+                         JsonTypeName(json_type));
 }
 
 class Converter {


### PR DESCRIPTION
If there is a type error, ArrayFromJSON returns an error message like 
```Invalid: Expected unsigned int or null, got JSON type 4```
where JSON type 4 is a value of type rapidjson::Type enum. It is better to print type names rather than enum values such as 
```Invalid: Expected unsigned int or null, got JSON type array```