### PR TITLE
ARROW-18025: [C++][Python] SubstraitSinkConsumer should handle backpressure

### DIFF
--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -314,8 +314,8 @@ arrow::Status ScanSinkExample(cp::ExecContext& exec_context) {
   arrow::AsyncGenerator<std::optional<cp::ExecBatch>> sink_gen;
   std::shared_ptr<arrow::Schema> output_schema;
   ARROW_RETURN_NOT_OK(
-      cp::MakeExecNode("sink", plan.get(), {scan}, 
-      cp::SinkNodeOptions{&sink_gen, {}, NULLPTR, &output_schema}));
+      cp::MakeExecNode("sink", plan.get(), {scan},
+                       cp::SinkNodeOptions{&sink_gen, {}, NULLPTR, &output_schema}));
 
   return ExecutePlanAndCollectAsTable(exec_context, plan, output_schema, sink_gen);
 }

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -164,10 +164,12 @@ class ARROW_EXPORT SinkNodeOptions : public ExecNodeOptions {
  public:
   explicit SinkNodeOptions(std::function<Future<std::optional<ExecBatch>>()>* generator,
                            BackpressureOptions backpressure = {},
-                           BackpressureMonitor** backpressure_monitor = NULLPTR)
+                           BackpressureMonitor** backpressure_monitor = NULLPTR,
+                           std::shared_ptr<Schema>* output_schema = NULLPTR)
       : generator(generator),
         backpressure(std::move(backpressure)),
-        backpressure_monitor(backpressure_monitor) {}
+        backpressure_monitor(backpressure_monitor),
+        output_schema(output_schema) {}
 
   /// \brief A pointer to a generator of batches.
   ///
@@ -186,6 +188,8 @@ class ARROW_EXPORT SinkNodeOptions : public ExecNodeOptions {
   /// the amount of data currently queued in the sink node.  This is an optional utility
   /// and backpressure can be applied even if this is not used.
   BackpressureMonitor** backpressure_monitor;
+  /// TODO: remove if not working
+  std::shared_ptr<Schema>* output_schema;
 };
 
 /// \brief Control used by a SinkNodeConsumer to pause & resume

--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -243,26 +243,23 @@ TEST(ExecPlanExecution, SinkWithOutpuSchemaOption) {
 
     for (bool parallel : {false, true}) {
       SCOPED_TRACE(parallel ? "parallel" : "single threaded");
-        ASSERT_OK_AND_ASSIGN(auto plan, ExecPlan::Make());
-        AsyncGenerator<std::optional<ExecBatch>> sink_gen;
+      ASSERT_OK_AND_ASSIGN(auto plan, ExecPlan::Make());
+      AsyncGenerator<std::optional<ExecBatch>> sink_gen;
 
-        auto basic_data = MakeBasicBatches();
+      auto basic_data = MakeBasicBatches();
 
-        std::shared_ptr<Schema> output_schema;
+      std::shared_ptr<Schema> output_schema;
 
-        ASSERT_OK(Declaration::Sequence(
-                      {
-                          {"source", SourceNodeOptions{basic_data.schema,
-                                                        basic_data
-                                                        .gen(parallel, slow)}},
-                          {"sink", SinkNodeOptions{&sink_gen,
-                          {}, NULLPTR, &output_schema}},
-                      })
-                      .AddToPlan(plan.get()));
-        ASSERT_THAT(StartAndCollect(plan.get(), sink_gen),
-                    Finishes(ResultWith(
-                      UnorderedElementsAreArray(basic_data.batches))));
-        ASSERT_TRUE(output_schema->Equals(*basic_data.schema));
+      ASSERT_OK(Declaration::Sequence(
+                    {
+                        {"source", SourceNodeOptions{basic_data.schema,
+                                                     basic_data.gen(parallel, slow)}},
+                        {"sink", SinkNodeOptions{&sink_gen, {}, NULLPTR, &output_schema}},
+                    })
+                    .AddToPlan(plan.get()));
+      ASSERT_THAT(StartAndCollect(plan.get(), sink_gen),
+                  Finishes(ResultWith(UnorderedElementsAreArray(basic_data.batches))));
+      ASSERT_TRUE(output_schema->Equals(*basic_data.schema));
     }
   }
 }

--- a/cpp/src/arrow/compute/exec/sink_node.cc
+++ b/cpp/src/arrow/compute/exec/sink_node.cc
@@ -126,10 +126,9 @@ class SinkNode : public ExecNode {
 
     const auto& sink_options = checked_cast<const SinkNodeOptions&>(options);
     RETURN_NOT_OK(ValidateOptions(sink_options));
-    return plan->EmplaceNode<SinkNode>(plan, std::move(inputs), sink_options.generator,
-                                       sink_options.backpressure,
-                                       sink_options.backpressure_monitor,
-                                       sink_options.output_schema);
+    return plan->EmplaceNode<SinkNode>(
+        plan, std::move(inputs), sink_options.generator, sink_options.backpressure,
+        sink_options.backpressure_monitor, sink_options.output_schema);
   }
 
   const char* kind_name() const override { return "SinkNode"; }
@@ -140,7 +139,7 @@ class SinkNode : public ExecNode {
                         {"node.detail", ToString()},
                         {"node.kind", kind_name()}});
     END_SPAN_ON_FUTURE_COMPLETION(span_, finished_);
-    if(output_schema_) {
+    if (output_schema_) {
       *output_schema_ = inputs_[0]->output_schema();
     }
     return Status::OK();

--- a/cpp/src/arrow/engine/substrait/serde.cc
+++ b/cpp/src/arrow/engine/substrait/serde.cc
@@ -109,7 +109,7 @@ DeclarationFactory MakeConsumingSinkDeclarationFactory(
 }
 
 DeclarationFactory MakeSinkDeclarationFactory(
- const SinkOptionsFactory& sink_options_factory) {
+    const SinkOptionsFactory& sink_options_factory) {
   return [&sink_options_factory](
              compute::Declaration input,
              std::vector<std::string> names) -> Result<compute::Declaration> {
@@ -208,8 +208,8 @@ Result<std::vector<compute::Declaration>> DeserializePlans(
     const Buffer& buf, const SinkOptionsFactory& sink_options_factory,
     const ExtensionIdRegistry* registry, ExtensionSet* ext_set_out,
     const ConversionOptions& conversion_options) {
-  return DeserializePlans(buf, MakeSinkDeclarationFactory(sink_options_factory),
-                          registry, ext_set_out, conversion_options);
+  return DeserializePlans(buf, MakeSinkDeclarationFactory(sink_options_factory), registry,
+                          ext_set_out, conversion_options);
 }
 
 namespace {

--- a/cpp/src/arrow/engine/substrait/serde.h
+++ b/cpp/src/arrow/engine/substrait/serde.h
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "arrow/compute/type_fwd.h"
+#include "arrow/compute/exec/options.h"
 #include "arrow/dataset/type_fwd.h"
 #include "arrow/engine/substrait/options.h"
 #include "arrow/engine/substrait/type_fwd.h"
@@ -136,6 +137,31 @@ ARROW_ENGINE_EXPORT Result<std::vector<compute::Declaration>> DeserializePlans(
 /// Substrait Plan
 ARROW_ENGINE_EXPORT Result<std::shared_ptr<compute::ExecPlan>> DeserializePlan(
     const Buffer& buf, const std::shared_ptr<dataset::WriteNodeOptions>& write_options,
+    const ExtensionIdRegistry* registry = NULLPTR, ExtensionSet* ext_set_out = NULLPTR,
+    const ConversionOptions& conversion_options = {});
+
+
+/// TODO: add documentation
+
+using SinkOptionsFactory = std::function<std::shared_ptr<compute::SinkNodeOptions>()>;
+
+/// \brief Deserializes a single-relation Substrait Plan message to an execution plan
+///
+/// The output of the single Substrait relation will be extracted from the generator
+/// in the SinkNodeOptions.
+///
+/// \param[in] buf a buffer containing the protobuf serialization of a Substrait Plan
+/// message
+/// \param[in] sink_options_factory factory function for generating sink node options 
+/// of a node collecting the batches produced by each toplevel Substrait relation
+/// \param[in] registry an extension-id-registry to use, or null for the default one.
+/// \param[out] ext_set_out if non-null, the extension mapping used by the Substrait
+/// Plan is returned here.
+/// \param[in] conversion_options options to control how the conversion is to be done.
+/// \return a vector of ExecNode declarations, one for each toplevel relation in the
+/// Substrait Plan
+ARROW_ENGINE_EXPORT Result<std::vector<compute::Declaration>> DeserializePlans(
+    const Buffer& buf, const SinkOptionsFactory& sink_options_factory,
     const ExtensionIdRegistry* registry = NULLPTR, ExtensionSet* ext_set_out = NULLPTR,
     const ConversionOptions& conversion_options = {});
 

--- a/cpp/src/arrow/engine/substrait/serde.h
+++ b/cpp/src/arrow/engine/substrait/serde.h
@@ -25,8 +25,8 @@
 #include <string_view>
 #include <vector>
 
-#include "arrow/compute/type_fwd.h"
 #include "arrow/compute/exec/options.h"
+#include "arrow/compute/type_fwd.h"
 #include "arrow/dataset/type_fwd.h"
 #include "arrow/engine/substrait/options.h"
 #include "arrow/engine/substrait/type_fwd.h"
@@ -140,7 +140,6 @@ ARROW_ENGINE_EXPORT Result<std::shared_ptr<compute::ExecPlan>> DeserializePlan(
     const ExtensionIdRegistry* registry = NULLPTR, ExtensionSet* ext_set_out = NULLPTR,
     const ConversionOptions& conversion_options = {});
 
-
 /// TODO: add documentation
 
 using SinkOptionsFactory = std::function<std::shared_ptr<compute::SinkNodeOptions>()>;
@@ -152,7 +151,7 @@ using SinkOptionsFactory = std::function<std::shared_ptr<compute::SinkNodeOption
 ///
 /// \param[in] buf a buffer containing the protobuf serialization of a Substrait Plan
 /// message
-/// \param[in] sink_options_factory factory function for generating sink node options 
+/// \param[in] sink_options_factory factory function for generating sink node options
 /// of a node collecting the batches produced by each toplevel Substrait relation
 /// \param[in] registry an extension-id-registry to use, or null for the default one.
 /// \param[out] ext_set_out if non-null, the extension mapping used by the Substrait

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -1157,7 +1157,8 @@ TEST(Substrait, GetRecordBatchReader) {
   test_with_registries([&substrait_json](ExtensionIdRegistry* ext_id_reg,
                                          compute::FunctionRegistry* func_registry) {
     ASSERT_OK_AND_ASSIGN(auto buf, SerializeJsonPlan(substrait_json));
-    ASSERT_OK_AND_ASSIGN(auto reader, ExecuteSerializedPlan(*buf));
+    ASSERT_OK_AND_ASSIGN(auto reader,
+                         ExecuteSerializedPlan(*buf, false));
     ASSERT_OK_AND_ASSIGN(auto table, Table::FromRecordBatchReader(reader.get()));
     // Note: assuming the binary.parquet file contains fixed amount of records
     // in case of a test failure, re-evalaute the content in the file
@@ -1174,8 +1175,8 @@ TEST(Substrait, GetRecordBatchReaderWithBackPressure) {
                                       ::arrow::internal::GetCpuThreadPool(),
                                       func_registry);
     ASSERT_OK_AND_ASSIGN(auto plan, compute::ExecPlan::Make(&exec_context));
-    ASSERT_OK_AND_ASSIGN(
-        auto reader, ExecuteSerializedPlanWithBackPressure(plan, &exec_context, *buf));
+    ASSERT_OK_AND_ASSIGN(auto reader,
+                         ExecuteSerializedPlan(*buf, true, plan, &exec_context));
     ASSERT_OK_AND_ASSIGN(auto table, Table::FromRecordBatchReader(reader.get()));
     // Note: assuming the binary.parquet file contains fixed amount of records
     // in case of a test failure, re-evalaute the content in the file

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -1165,6 +1165,22 @@ TEST(Substrait, GetRecordBatchReader) {
   });
 }
 
+TEST(Substrait, GetRecordBatchReaderV2) {
+  ASSERT_OK_AND_ASSIGN(std::string substrait_json, GetSubstraitJSON());
+  test_with_registries([&substrait_json](ExtensionIdRegistry* ext_id_reg,
+                                         compute::FunctionRegistry* func_registry) {
+    ASSERT_OK_AND_ASSIGN(auto buf, SerializeJsonPlan(substrait_json));
+    compute::ExecContext exec_context(arrow::default_memory_pool(),
+                                    ::arrow::internal::GetCpuThreadPool(), func_registry);
+    ASSERT_OK_AND_ASSIGN(auto plan, compute::ExecPlan::Make(&exec_context));
+    ASSERT_OK_AND_ASSIGN(auto reader, ExecuteSerializedPlan(plan, exec_context, *buf));
+    ASSERT_OK_AND_ASSIGN(auto table, Table::FromRecordBatchReader(reader.get()));
+    // Note: assuming the binary.parquet file contains fixed amount of records
+    // in case of a test failure, re-evalaute the content in the file
+    EXPECT_EQ(table->num_rows(), 12);
+  });
+}
+
 TEST(Substrait, InvalidPlan) {
   std::string substrait_json = R"({
     "relations": [

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -1157,8 +1157,7 @@ TEST(Substrait, GetRecordBatchReader) {
   test_with_registries([&substrait_json](ExtensionIdRegistry* ext_id_reg,
                                          compute::FunctionRegistry* func_registry) {
     ASSERT_OK_AND_ASSIGN(auto buf, SerializeJsonPlan(substrait_json));
-    ASSERT_OK_AND_ASSIGN(auto reader,
-                         ExecuteSerializedPlan(*buf, false));
+    ASSERT_OK_AND_ASSIGN(auto reader, ExecuteSerializedPlan(*buf, false));
     ASSERT_OK_AND_ASSIGN(auto table, Table::FromRecordBatchReader(reader.get()));
     // Note: assuming the binary.parquet file contains fixed amount of records
     // in case of a test failure, re-evalaute the content in the file

--- a/cpp/src/arrow/engine/substrait/util.cc
+++ b/cpp/src/arrow/engine/substrait/util.cc
@@ -148,17 +148,18 @@ class SubstraitExecutor {
 Result<std::shared_ptr<RecordBatchReader>> ExecuteSerializedPlan(
     const Buffer& substrait_buffer, const bool handle_backpressure,
     std::shared_ptr<compute::ExecPlan> plan, compute::ExecContext* exec_context,
-    const ExtensionIdRegistry* registry, 
-    compute::FunctionRegistry* func_registry,
+    const ExtensionIdRegistry* registry, compute::FunctionRegistry* func_registry,
     const ConversionOptions& conversion_options) {
   if (!exec_context) {
-    exec_context = new compute::ExecContext(arrow::default_memory_pool(),
-                                    ::arrow::internal::GetCpuThreadPool(), func_registry);
+    exec_context =
+        new compute::ExecContext(arrow::default_memory_pool(),
+                                 ::arrow::internal::GetCpuThreadPool(), func_registry);
   }
   if (plan == nullptr) {
     ARROW_ASSIGN_OR_RAISE(plan, compute::ExecPlan::Make(exec_context));
   }
-  SubstraitExecutor executor(std::move(plan), exec_context, conversion_options, handle_backpressure);
+  SubstraitExecutor executor(std::move(plan), exec_context, conversion_options,
+                             handle_backpressure);
   RETURN_NOT_OK(executor.Init(substrait_buffer, registry));
   ARROW_ASSIGN_OR_RAISE(auto sink_reader, executor.Execute());
   // check closing here, not in destructor, to expose error to caller

--- a/cpp/src/arrow/engine/substrait/util.h
+++ b/cpp/src/arrow/engine/substrait/util.h
@@ -37,6 +37,13 @@ ARROW_ENGINE_EXPORT Result<std::shared_ptr<RecordBatchReader>> ExecuteSerialized
     compute::FunctionRegistry* func_registry = NULLPTR,
     const ConversionOptions& conversion_options = {});
 
+ARROW_ENGINE_EXPORT Result<std::shared_ptr<RecordBatchReader>> ExecuteSerializedPlan(
+    std::shared_ptr<compute::ExecPlan> plan,
+    compute::ExecContext exec_context,
+    const Buffer& substrait_buffer, const ExtensionIdRegistry* registry = NULLPTR,
+    const ConversionOptions& conversion_options = {});
+
+
 /// \brief Get a Serialized Plan from a Substrait JSON plan.
 /// This is a helper method for Python tests.
 ARROW_ENGINE_EXPORT Result<std::shared_ptr<Buffer>> SerializeJsonPlan(

--- a/cpp/src/arrow/engine/substrait/util.h
+++ b/cpp/src/arrow/engine/substrait/util.h
@@ -37,12 +37,12 @@ ARROW_ENGINE_EXPORT Result<std::shared_ptr<RecordBatchReader>> ExecuteSerialized
     compute::FunctionRegistry* func_registry = NULLPTR,
     const ConversionOptions& conversion_options = {});
 
-ARROW_ENGINE_EXPORT Result<std::shared_ptr<RecordBatchReader>> ExecuteSerializedPlan(
-    std::shared_ptr<compute::ExecPlan> plan,
-    compute::ExecContext exec_context,
-    const Buffer& substrait_buffer, const ExtensionIdRegistry* registry = NULLPTR,
-    const ConversionOptions& conversion_options = {});
-
+ARROW_ENGINE_EXPORT Result<std::shared_ptr<RecordBatchReader>>
+ExecuteSerializedPlanWithBackPressure(std::shared_ptr<compute::ExecPlan>& plan,
+                                      compute::ExecContext* exec_context,
+                                      const Buffer& substrait_buffer,
+                                      const ExtensionIdRegistry* registry = NULLPTR,
+                                      const ConversionOptions& conversion_options = {});
 
 /// \brief Get a Serialized Plan from a Substrait JSON plan.
 /// This is a helper method for Python tests.

--- a/cpp/src/arrow/engine/substrait/util.h
+++ b/cpp/src/arrow/engine/substrait/util.h
@@ -34,7 +34,7 @@ using PythonTableProvider =
 
 ARROW_ENGINE_EXPORT Result<std::shared_ptr<RecordBatchReader>> ExecuteSerializedPlan(
     const Buffer& substrait_buffer, const bool handle_backpressure = false,
-    std::shared_ptr<compute::ExecPlan> plan = NULLPTR, 
+    std::shared_ptr<compute::ExecPlan> plan = NULLPTR,
     compute::ExecContext* exec_context = NULLPTR,
     const ExtensionIdRegistry* registry = NULLPTR,
     compute::FunctionRegistry* func_registry = NULLPTR,

--- a/cpp/src/arrow/engine/substrait/util.h
+++ b/cpp/src/arrow/engine/substrait/util.h
@@ -33,16 +33,12 @@ using PythonTableProvider =
     std::function<Result<std::shared_ptr<Table>>(const std::vector<std::string>&)>;
 
 ARROW_ENGINE_EXPORT Result<std::shared_ptr<RecordBatchReader>> ExecuteSerializedPlan(
-    const Buffer& substrait_buffer, const ExtensionIdRegistry* registry = NULLPTR,
+    const Buffer& substrait_buffer, const bool handle_backpressure = false,
+    std::shared_ptr<compute::ExecPlan> plan = NULLPTR, 
+    compute::ExecContext* exec_context = NULLPTR,
+    const ExtensionIdRegistry* registry = NULLPTR,
     compute::FunctionRegistry* func_registry = NULLPTR,
     const ConversionOptions& conversion_options = {});
-
-ARROW_ENGINE_EXPORT Result<std::shared_ptr<RecordBatchReader>>
-ExecuteSerializedPlanWithBackPressure(std::shared_ptr<compute::ExecPlan>& plan,
-                                      compute::ExecContext* exec_context,
-                                      const Buffer& substrait_buffer,
-                                      const ExtensionIdRegistry* registry = NULLPTR,
-                                      const ConversionOptions& conversion_options = {});
 
 /// \brief Get a Serialized Plan from a Substrait JSON plan.
 /// This is a helper method for Python tests.

--- a/python/pyarrow/includes/libarrow_substrait.pxd
+++ b/python/pyarrow/includes/libarrow_substrait.pxd
@@ -19,6 +19,8 @@
 
 from libcpp.vector cimport vector as std_vector
 
+from libcpp cimport bool as c_bool
+
 from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport *
 
@@ -50,7 +52,12 @@ cdef extern from "arrow/engine/substrait/extension_set.h" \
 
 cdef extern from "arrow/engine/substrait/util.h" namespace "arrow::engine" nogil:
     CResult[shared_ptr[CRecordBatchReader]] ExecuteSerializedPlan(
-        const CBuffer& substrait_buffer, const ExtensionIdRegistry* registry,
-        CFunctionRegistry* func_registry, const CConversionOptions& conversion_options)
+        const CBuffer& substrait_buffer,
+        const c_bool handle_backpressure,
+        shared_ptr[CExecPlan] plan,
+        CExecContext* c_exec_context,
+        const ExtensionIdRegistry* registry,
+        CFunctionRegistry* func_registry,
+        const CConversionOptions& conversion_options)
 
     CResult[shared_ptr[CBuffer]] SerializeJsonPlan(const c_string& substrait_json)

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -84,222 +84,222 @@ def test_run_serialized_query(tmpdir):
     assert table.select(["foo"]) == res_tb.select(["foo"])
 
 
-# @pytest.mark.parametrize("query", (pa.py_buffer(b'buffer'), b"bytes", 1))
-# def test_run_query_input_types(tmpdir, query):
+@pytest.mark.parametrize("query", (pa.py_buffer(b'buffer'), b"bytes", 1))
+def test_run_query_input_types(tmpdir, query):
 
-#     # Passing unsupported type, like int, will not segfault.
-#     if not isinstance(query, (pa.Buffer, bytes)):
-#         msg = f"Expected 'pyarrow.Buffer' or bytes, got '{type(query)}'"
-#         with pytest.raises(TypeError, match=msg):
-#             substrait.run_query(query)
-#         return
+    # Passing unsupported type, like int, will not segfault.
+    if not isinstance(query, (pa.Buffer, bytes)):
+        msg = f"Expected 'pyarrow.Buffer' or bytes, got '{type(query)}'"
+        with pytest.raises(TypeError, match=msg):
+            substrait.run_query(query)
+        return
 
-#     # Otherwise error for invalid query
-#     msg = "ParseFromZeroCopyStream failed for substrait.Plan"
-#     with pytest.raises(OSError, match=msg):
-#         substrait.run_query(query)
-
-
-# def test_invalid_plan():
-#     query = """
-#     {
-#         "relations": [
-#         ]
-#     }
-#     """
-#     buf = pa._substrait._parse_json_plan(tobytes(query))
-#     exec_message = "Empty substrait plan is passed."
-#     with pytest.raises(ArrowInvalid, match=exec_message):
-#         substrait.run_query(buf)
+    # Otherwise error for invalid query
+    msg = "ParseFromZeroCopyStream failed for substrait.Plan"
+    with pytest.raises(OSError, match=msg):
+        substrait.run_query(query)
 
 
-# def test_binary_conversion_with_json_options(tmpdir):
-#     substrait_query = """
-#     {
-#         "relations": [
-#         {"rel": {
-#             "read": {
-#             "base_schema": {
-#                 "struct": {
-#                 "types": [
-#                             {"i64": {}}
-#                         ]
-#                 },
-#                 "names": [
-#                         "bar"
-#                         ]
-#             },
-#             "local_files": {
-#                 "items": [
-#                 {
-#                     "uri_file": "FILENAME_PLACEHOLDER",
-#                     "arrow": {},
-#                     "metadata" : {
-#                       "created_by" : {},
-#                     }
-#                 }
-#                 ]
-#             }
-#             }
-#         }}
-#         ]
-#     }
-#     """
-
-#     file_name = "binary_json_data.arrow"
-#     table = pa.table([[1, 2, 3, 4, 5]], names=['bar'])
-#     path = _write_dummy_data_to_disk(tmpdir, file_name, table)
-#     query = tobytes(substrait_query.replace(
-#         "FILENAME_PLACEHOLDER", pathlib.Path(path).as_uri()))
-#     buf = pa._substrait._parse_json_plan(tobytes(query))
-
-#     reader = substrait.run_query(buf)
-#     res_tb = reader.read_all()
-
-#     assert table.select(["bar"]) == res_tb.select(["bar"])
+def test_invalid_plan():
+    query = """
+    {
+        "relations": [
+        ]
+    }
+    """
+    buf = pa._substrait._parse_json_plan(tobytes(query))
+    exec_message = "Empty substrait plan is passed."
+    with pytest.raises(ArrowInvalid, match=exec_message):
+        substrait.run_query(buf)
 
 
-# # Substrait has not finalized what the URI should be for standard functions
-# # In the meantime, lets just check the suffix
-# def has_function(fns, ext_file, fn_name):
-#     suffix = f'{ext_file}#{fn_name}'
-#     for fn in fns:
-#         if fn.endswith(suffix):
-#             return True
-#     return False
+def test_binary_conversion_with_json_options(tmpdir):
+    substrait_query = """
+    {
+        "relations": [
+        {"rel": {
+            "read": {
+            "base_schema": {
+                "struct": {
+                "types": [
+                            {"i64": {}}
+                        ]
+                },
+                "names": [
+                        "bar"
+                        ]
+            },
+            "local_files": {
+                "items": [
+                {
+                    "uri_file": "FILENAME_PLACEHOLDER",
+                    "arrow": {},
+                    "metadata" : {
+                      "created_by" : {},
+                    }
+                }
+                ]
+            }
+            }
+        }}
+        ]
+    }
+    """
+
+    file_name = "binary_json_data.arrow"
+    table = pa.table([[1, 2, 3, 4, 5]], names=['bar'])
+    path = _write_dummy_data_to_disk(tmpdir, file_name, table)
+    query = tobytes(substrait_query.replace(
+        "FILENAME_PLACEHOLDER", pathlib.Path(path).as_uri()))
+    buf = pa._substrait._parse_json_plan(tobytes(query))
+
+    reader = substrait.run_query(buf)
+    res_tb = reader.read_all()
+
+    assert table.select(["bar"]) == res_tb.select(["bar"])
 
 
-# def test_get_supported_functions():
-#     supported_functions = pa._substrait.get_supported_functions()
-#     # It probably doesn't make sense to exhaustively verfiy this list but
-#     # we can check a sample aggregate and a sample non-aggregate entry
-#     assert has_function(supported_functions,
-#                         'functions_arithmetic.yaml', 'add')
-#     assert has_function(supported_functions,
-#                         'functions_arithmetic.yaml', 'sum')
+# Substrait has not finalized what the URI should be for standard functions
+# In the meantime, lets just check the suffix
+def has_function(fns, ext_file, fn_name):
+    suffix = f'{ext_file}#{fn_name}'
+    for fn in fns:
+        if fn.endswith(suffix):
+            return True
+    return False
 
 
-# def test_named_table():
-#     test_table_1 = pa.Table.from_pydict({"x": [1, 2, 3]})
-#     test_table_2 = pa.Table.from_pydict({"x": [4, 5, 6]})
-
-#     def table_provider(names):
-#         if not names:
-#             raise Exception("No names provided")
-#         elif names[0] == "t1":
-#             return test_table_1
-#         elif names[1] == "t2":
-#             return test_table_2
-#         else:
-#             raise Exception("Unrecognized table name")
-
-#     substrait_query = """
-#     {
-#         "relations": [
-#         {"rel": {
-#             "read": {
-#             "base_schema": {
-#                 "struct": {
-#                 "types": [
-#                             {"i64": {}}
-#                         ]
-#                 },
-#                 "names": [
-#                         "x"
-#                         ]
-#             },
-#             "namedTable": {
-#                     "names": ["t1"]
-#             }
-#             }
-#         }}
-#         ]
-#     }
-#     """
-
-#     buf = pa._substrait._parse_json_plan(tobytes(substrait_query))
-#     reader = pa.substrait.run_query(buf, table_provider)
-#     res_tb = reader.read_all()
-#     assert res_tb == test_table_1
+def test_get_supported_functions():
+    supported_functions = pa._substrait.get_supported_functions()
+    # It probably doesn't make sense to exhaustively verfiy this list but
+    # we can check a sample aggregate and a sample non-aggregate entry
+    assert has_function(supported_functions,
+                        'functions_arithmetic.yaml', 'add')
+    assert has_function(supported_functions,
+                        'functions_arithmetic.yaml', 'sum')
 
 
-# def test_named_table_invalid_table_name():
-#     test_table_1 = pa.Table.from_pydict({"x": [1, 2, 3]})
+def test_named_table():
+    test_table_1 = pa.Table.from_pydict({"x": [1, 2, 3]})
+    test_table_2 = pa.Table.from_pydict({"x": [4, 5, 6]})
 
-#     def table_provider(names):
-#         if not names:
-#             raise Exception("No names provided")
-#         elif names[0] == "t1":
-#             return test_table_1
-#         else:
-#             raise Exception("Unrecognized table name")
+    def table_provider(names):
+        if not names:
+            raise Exception("No names provided")
+        elif names[0] == "t1":
+            return test_table_1
+        elif names[1] == "t2":
+            return test_table_2
+        else:
+            raise Exception("Unrecognized table name")
 
-#     substrait_query = """
-#     {
-#         "relations": [
-#         {"rel": {
-#             "read": {
-#             "base_schema": {
-#                 "struct": {
-#                 "types": [
-#                             {"i64": {}}
-#                         ]
-#                 },
-#                 "names": [
-#                         "x"
-#                         ]
-#             },
-#             "namedTable": {
-#                     "names": ["t3"]
-#             }
-#             }
-#         }}
-#         ]
-#     }
-#     """
+    substrait_query = """
+    {
+        "relations": [
+        {"rel": {
+            "read": {
+            "base_schema": {
+                "struct": {
+                "types": [
+                            {"i64": {}}
+                        ]
+                },
+                "names": [
+                        "x"
+                        ]
+            },
+            "namedTable": {
+                    "names": ["t1"]
+            }
+            }
+        }}
+        ]
+    }
+    """
 
-#     buf = pa._substrait._parse_json_plan(tobytes(substrait_query))
-#     exec_message = "Invalid NamedTable Source"
-#     with pytest.raises(ArrowInvalid, match=exec_message):
-#         substrait.run_query(buf, table_provider)
+    buf = pa._substrait._parse_json_plan(tobytes(substrait_query))
+    reader = pa.substrait.run_query(buf, table_provider)
+    res_tb = reader.read_all()
+    assert res_tb == test_table_1
 
 
-# def test_named_table_empty_names():
-#     test_table_1 = pa.Table.from_pydict({"x": [1, 2, 3]})
+def test_named_table_invalid_table_name():
+    test_table_1 = pa.Table.from_pydict({"x": [1, 2, 3]})
 
-#     def table_provider(names):
-#         if not names:
-#             raise Exception("No names provided")
-#         elif names[0] == "t1":
-#             return test_table_1
-#         else:
-#             raise Exception("Unrecognized table name")
+    def table_provider(names):
+        if not names:
+            raise Exception("No names provided")
+        elif names[0] == "t1":
+            return test_table_1
+        else:
+            raise Exception("Unrecognized table name")
 
-#     substrait_query = """
-#     {
-#         "relations": [
-#         {"rel": {
-#             "read": {
-#             "base_schema": {
-#                 "struct": {
-#                 "types": [
-#                             {"i64": {}}
-#                         ]
-#                 },
-#                 "names": [
-#                         "x"
-#                         ]
-#             },
-#             "namedTable": {
-#                     "names": []
-#             }
-#             }
-#         }}
-#         ]
-#     }
-#     """
-#     query = tobytes(substrait_query)
-#     buf = pa._substrait._parse_json_plan(tobytes(query))
-#     exec_message = "names for NamedTable not provided"
-#     with pytest.raises(ArrowInvalid, match=exec_message):
-#         substrait.run_query(buf, table_provider)
+    substrait_query = """
+    {
+        "relations": [
+        {"rel": {
+            "read": {
+            "base_schema": {
+                "struct": {
+                "types": [
+                            {"i64": {}}
+                        ]
+                },
+                "names": [
+                        "x"
+                        ]
+            },
+            "namedTable": {
+                    "names": ["t3"]
+            }
+            }
+        }}
+        ]
+    }
+    """
+
+    buf = pa._substrait._parse_json_plan(tobytes(substrait_query))
+    exec_message = "Invalid NamedTable Source"
+    with pytest.raises(ArrowInvalid, match=exec_message):
+        substrait.run_query(buf, table_provider)
+
+
+def test_named_table_empty_names():
+    test_table_1 = pa.Table.from_pydict({"x": [1, 2, 3]})
+
+    def table_provider(names):
+        if not names:
+            raise Exception("No names provided")
+        elif names[0] == "t1":
+            return test_table_1
+        else:
+            raise Exception("Unrecognized table name")
+
+    substrait_query = """
+    {
+        "relations": [
+        {"rel": {
+            "read": {
+            "base_schema": {
+                "struct": {
+                "types": [
+                            {"i64": {}}
+                        ]
+                },
+                "names": [
+                        "x"
+                        ]
+            },
+            "namedTable": {
+                    "names": []
+            }
+            }
+        }}
+        ]
+    }
+    """
+    query = tobytes(substrait_query)
+    buf = pa._substrait._parse_json_plan(tobytes(query))
+    exec_message = "names for NamedTable not provided"
+    with pytest.raises(ArrowInvalid, match=exec_message):
+        substrait.run_query(buf, table_provider)

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -84,222 +84,222 @@ def test_run_serialized_query(tmpdir):
     assert table.select(["foo"]) == res_tb.select(["foo"])
 
 
-@pytest.mark.parametrize("query", (pa.py_buffer(b'buffer'), b"bytes", 1))
-def test_run_query_input_types(tmpdir, query):
+# @pytest.mark.parametrize("query", (pa.py_buffer(b'buffer'), b"bytes", 1))
+# def test_run_query_input_types(tmpdir, query):
 
-    # Passing unsupported type, like int, will not segfault.
-    if not isinstance(query, (pa.Buffer, bytes)):
-        msg = f"Expected 'pyarrow.Buffer' or bytes, got '{type(query)}'"
-        with pytest.raises(TypeError, match=msg):
-            substrait.run_query(query)
-        return
+#     # Passing unsupported type, like int, will not segfault.
+#     if not isinstance(query, (pa.Buffer, bytes)):
+#         msg = f"Expected 'pyarrow.Buffer' or bytes, got '{type(query)}'"
+#         with pytest.raises(TypeError, match=msg):
+#             substrait.run_query(query)
+#         return
 
-    # Otherwise error for invalid query
-    msg = "ParseFromZeroCopyStream failed for substrait.Plan"
-    with pytest.raises(OSError, match=msg):
-        substrait.run_query(query)
-
-
-def test_invalid_plan():
-    query = """
-    {
-        "relations": [
-        ]
-    }
-    """
-    buf = pa._substrait._parse_json_plan(tobytes(query))
-    exec_message = "Empty substrait plan is passed."
-    with pytest.raises(ArrowInvalid, match=exec_message):
-        substrait.run_query(buf)
+#     # Otherwise error for invalid query
+#     msg = "ParseFromZeroCopyStream failed for substrait.Plan"
+#     with pytest.raises(OSError, match=msg):
+#         substrait.run_query(query)
 
 
-def test_binary_conversion_with_json_options(tmpdir):
-    substrait_query = """
-    {
-        "relations": [
-        {"rel": {
-            "read": {
-            "base_schema": {
-                "struct": {
-                "types": [
-                            {"i64": {}}
-                        ]
-                },
-                "names": [
-                        "bar"
-                        ]
-            },
-            "local_files": {
-                "items": [
-                {
-                    "uri_file": "FILENAME_PLACEHOLDER",
-                    "arrow": {},
-                    "metadata" : {
-                      "created_by" : {},
-                    }
-                }
-                ]
-            }
-            }
-        }}
-        ]
-    }
-    """
-
-    file_name = "binary_json_data.arrow"
-    table = pa.table([[1, 2, 3, 4, 5]], names=['bar'])
-    path = _write_dummy_data_to_disk(tmpdir, file_name, table)
-    query = tobytes(substrait_query.replace(
-        "FILENAME_PLACEHOLDER", pathlib.Path(path).as_uri()))
-    buf = pa._substrait._parse_json_plan(tobytes(query))
-
-    reader = substrait.run_query(buf)
-    res_tb = reader.read_all()
-
-    assert table.select(["bar"]) == res_tb.select(["bar"])
+# def test_invalid_plan():
+#     query = """
+#     {
+#         "relations": [
+#         ]
+#     }
+#     """
+#     buf = pa._substrait._parse_json_plan(tobytes(query))
+#     exec_message = "Empty substrait plan is passed."
+#     with pytest.raises(ArrowInvalid, match=exec_message):
+#         substrait.run_query(buf)
 
 
-# Substrait has not finalized what the URI should be for standard functions
-# In the meantime, lets just check the suffix
-def has_function(fns, ext_file, fn_name):
-    suffix = f'{ext_file}#{fn_name}'
-    for fn in fns:
-        if fn.endswith(suffix):
-            return True
-    return False
+# def test_binary_conversion_with_json_options(tmpdir):
+#     substrait_query = """
+#     {
+#         "relations": [
+#         {"rel": {
+#             "read": {
+#             "base_schema": {
+#                 "struct": {
+#                 "types": [
+#                             {"i64": {}}
+#                         ]
+#                 },
+#                 "names": [
+#                         "bar"
+#                         ]
+#             },
+#             "local_files": {
+#                 "items": [
+#                 {
+#                     "uri_file": "FILENAME_PLACEHOLDER",
+#                     "arrow": {},
+#                     "metadata" : {
+#                       "created_by" : {},
+#                     }
+#                 }
+#                 ]
+#             }
+#             }
+#         }}
+#         ]
+#     }
+#     """
+
+#     file_name = "binary_json_data.arrow"
+#     table = pa.table([[1, 2, 3, 4, 5]], names=['bar'])
+#     path = _write_dummy_data_to_disk(tmpdir, file_name, table)
+#     query = tobytes(substrait_query.replace(
+#         "FILENAME_PLACEHOLDER", pathlib.Path(path).as_uri()))
+#     buf = pa._substrait._parse_json_plan(tobytes(query))
+
+#     reader = substrait.run_query(buf)
+#     res_tb = reader.read_all()
+
+#     assert table.select(["bar"]) == res_tb.select(["bar"])
 
 
-def test_get_supported_functions():
-    supported_functions = pa._substrait.get_supported_functions()
-    # It probably doesn't make sense to exhaustively verfiy this list but
-    # we can check a sample aggregate and a sample non-aggregate entry
-    assert has_function(supported_functions,
-                        'functions_arithmetic.yaml', 'add')
-    assert has_function(supported_functions,
-                        'functions_arithmetic.yaml', 'sum')
+# # Substrait has not finalized what the URI should be for standard functions
+# # In the meantime, lets just check the suffix
+# def has_function(fns, ext_file, fn_name):
+#     suffix = f'{ext_file}#{fn_name}'
+#     for fn in fns:
+#         if fn.endswith(suffix):
+#             return True
+#     return False
 
 
-def test_named_table():
-    test_table_1 = pa.Table.from_pydict({"x": [1, 2, 3]})
-    test_table_2 = pa.Table.from_pydict({"x": [4, 5, 6]})
-
-    def table_provider(names):
-        if not names:
-            raise Exception("No names provided")
-        elif names[0] == "t1":
-            return test_table_1
-        elif names[1] == "t2":
-            return test_table_2
-        else:
-            raise Exception("Unrecognized table name")
-
-    substrait_query = """
-    {
-        "relations": [
-        {"rel": {
-            "read": {
-            "base_schema": {
-                "struct": {
-                "types": [
-                            {"i64": {}}
-                        ]
-                },
-                "names": [
-                        "x"
-                        ]
-            },
-            "namedTable": {
-                    "names": ["t1"]
-            }
-            }
-        }}
-        ]
-    }
-    """
-
-    buf = pa._substrait._parse_json_plan(tobytes(substrait_query))
-    reader = pa.substrait.run_query(buf, table_provider)
-    res_tb = reader.read_all()
-    assert res_tb == test_table_1
+# def test_get_supported_functions():
+#     supported_functions = pa._substrait.get_supported_functions()
+#     # It probably doesn't make sense to exhaustively verfiy this list but
+#     # we can check a sample aggregate and a sample non-aggregate entry
+#     assert has_function(supported_functions,
+#                         'functions_arithmetic.yaml', 'add')
+#     assert has_function(supported_functions,
+#                         'functions_arithmetic.yaml', 'sum')
 
 
-def test_named_table_invalid_table_name():
-    test_table_1 = pa.Table.from_pydict({"x": [1, 2, 3]})
+# def test_named_table():
+#     test_table_1 = pa.Table.from_pydict({"x": [1, 2, 3]})
+#     test_table_2 = pa.Table.from_pydict({"x": [4, 5, 6]})
 
-    def table_provider(names):
-        if not names:
-            raise Exception("No names provided")
-        elif names[0] == "t1":
-            return test_table_1
-        else:
-            raise Exception("Unrecognized table name")
+#     def table_provider(names):
+#         if not names:
+#             raise Exception("No names provided")
+#         elif names[0] == "t1":
+#             return test_table_1
+#         elif names[1] == "t2":
+#             return test_table_2
+#         else:
+#             raise Exception("Unrecognized table name")
 
-    substrait_query = """
-    {
-        "relations": [
-        {"rel": {
-            "read": {
-            "base_schema": {
-                "struct": {
-                "types": [
-                            {"i64": {}}
-                        ]
-                },
-                "names": [
-                        "x"
-                        ]
-            },
-            "namedTable": {
-                    "names": ["t3"]
-            }
-            }
-        }}
-        ]
-    }
-    """
+#     substrait_query = """
+#     {
+#         "relations": [
+#         {"rel": {
+#             "read": {
+#             "base_schema": {
+#                 "struct": {
+#                 "types": [
+#                             {"i64": {}}
+#                         ]
+#                 },
+#                 "names": [
+#                         "x"
+#                         ]
+#             },
+#             "namedTable": {
+#                     "names": ["t1"]
+#             }
+#             }
+#         }}
+#         ]
+#     }
+#     """
 
-    buf = pa._substrait._parse_json_plan(tobytes(substrait_query))
-    exec_message = "Invalid NamedTable Source"
-    with pytest.raises(ArrowInvalid, match=exec_message):
-        substrait.run_query(buf, table_provider)
+#     buf = pa._substrait._parse_json_plan(tobytes(substrait_query))
+#     reader = pa.substrait.run_query(buf, table_provider)
+#     res_tb = reader.read_all()
+#     assert res_tb == test_table_1
 
 
-def test_named_table_empty_names():
-    test_table_1 = pa.Table.from_pydict({"x": [1, 2, 3]})
+# def test_named_table_invalid_table_name():
+#     test_table_1 = pa.Table.from_pydict({"x": [1, 2, 3]})
 
-    def table_provider(names):
-        if not names:
-            raise Exception("No names provided")
-        elif names[0] == "t1":
-            return test_table_1
-        else:
-            raise Exception("Unrecognized table name")
+#     def table_provider(names):
+#         if not names:
+#             raise Exception("No names provided")
+#         elif names[0] == "t1":
+#             return test_table_1
+#         else:
+#             raise Exception("Unrecognized table name")
 
-    substrait_query = """
-    {
-        "relations": [
-        {"rel": {
-            "read": {
-            "base_schema": {
-                "struct": {
-                "types": [
-                            {"i64": {}}
-                        ]
-                },
-                "names": [
-                        "x"
-                        ]
-            },
-            "namedTable": {
-                    "names": []
-            }
-            }
-        }}
-        ]
-    }
-    """
-    query = tobytes(substrait_query)
-    buf = pa._substrait._parse_json_plan(tobytes(query))
-    exec_message = "names for NamedTable not provided"
-    with pytest.raises(ArrowInvalid, match=exec_message):
-        substrait.run_query(buf, table_provider)
+#     substrait_query = """
+#     {
+#         "relations": [
+#         {"rel": {
+#             "read": {
+#             "base_schema": {
+#                 "struct": {
+#                 "types": [
+#                             {"i64": {}}
+#                         ]
+#                 },
+#                 "names": [
+#                         "x"
+#                         ]
+#             },
+#             "namedTable": {
+#                     "names": ["t3"]
+#             }
+#             }
+#         }}
+#         ]
+#     }
+#     """
+
+#     buf = pa._substrait._parse_json_plan(tobytes(substrait_query))
+#     exec_message = "Invalid NamedTable Source"
+#     with pytest.raises(ArrowInvalid, match=exec_message):
+#         substrait.run_query(buf, table_provider)
+
+
+# def test_named_table_empty_names():
+#     test_table_1 = pa.Table.from_pydict({"x": [1, 2, 3]})
+
+#     def table_provider(names):
+#         if not names:
+#             raise Exception("No names provided")
+#         elif names[0] == "t1":
+#             return test_table_1
+#         else:
+#             raise Exception("Unrecognized table name")
+
+#     substrait_query = """
+#     {
+#         "relations": [
+#         {"rel": {
+#             "read": {
+#             "base_schema": {
+#                 "struct": {
+#                 "types": [
+#                             {"i64": {}}
+#                         ]
+#                 },
+#                 "names": [
+#                         "x"
+#                         ]
+#             },
+#             "namedTable": {
+#                     "names": []
+#             }
+#             }
+#         }}
+#         ]
+#     }
+#     """
+#     query = tobytes(substrait_query)
+#     buf = pa._substrait._parse_json_plan(tobytes(query))
+#     exec_message = "names for NamedTable not provided"
+#     with pytest.raises(ArrowInvalid, match=exec_message):
+#         substrait.run_query(buf, table_provider)


### PR DESCRIPTION
**DO NOT REVIEW**
Drafted for discussion

**TODO**

- [ ] Self review
- [ ] Refactor `schema` usage for `SinkNodeOptions` to `sink_schema`
- [ ] Backpressure Python test
- [ ] Backpressure C++ test