### PR TITLE
GH-33336: [C++][Parquet] Avoid UB on unaligned load

### DIFF
--- a/cpp/src/arrow/util/ubsan.h
+++ b/cpp/src/arrow/util/ubsan.h
@@ -53,34 +53,33 @@ inline T* MakeNonNull(T* maybe_null = NULLPTR) {
 }
 
 template <typename T>
-inline typename std::enable_if<std::is_trivial<T>::value, T>::type SafeLoadAs(
+inline std::enable_if_t<std::is_trivially_copyable_v<T>, T> SafeLoadAs(
     const uint8_t* unaligned) {
-  typename std::remove_const<T>::type ret;
+  std::remove_const_t<T> ret;
   std::memcpy(&ret, unaligned, sizeof(T));
   return ret;
 }
 
 template <typename T>
-inline typename std::enable_if<std::is_trivial<T>::value, T>::type SafeLoad(
-    const T* unaligned) {
-  typename std::remove_const<T>::type ret;
+inline std::enable_if_t<std::is_trivially_copyable_v<T>, T> SafeLoad(const T* unaligned) {
+  std::remove_const_t<T> ret;
   std::memcpy(&ret, unaligned, sizeof(T));
   return ret;
 }
 
 template <typename U, typename T>
-inline typename std::enable_if<std::is_trivial<T>::value && std::is_trivial<U>::value &&
-                                   sizeof(T) == sizeof(U),
-                               U>::type
+inline std::enable_if_t<std::is_trivially_copyable_v<T> &&
+                            std::is_trivially_copyable_v<U> && sizeof(T) == sizeof(U),
+                        U>
 SafeCopy(T value) {
-  typename std::remove_const<U>::type ret;
+  std::remove_const_t<U> ret;
   std::memcpy(&ret, &value, sizeof(T));
   return ret;
 }
 
 template <typename T>
-inline typename std::enable_if<std::is_trivial<T>::value, void>::type SafeStore(
-    void* unaligned, T value) {
+inline std::enable_if_t<std::is_trivially_copyable_v<T>, void> SafeStore(void* unaligned,
+                                                                         T value) {
   std::memcpy(unaligned, &value, sizeof(T));
 }
 

--- a/cpp/src/parquet/statistics.cc
+++ b/cpp/src/parquet/statistics.cc
@@ -42,6 +42,7 @@ using arrow::default_memory_pool;
 using arrow::MemoryPool;
 using arrow::internal::checked_cast;
 using arrow::util::SafeCopy;
+using arrow::util::SafeLoad;
 
 namespace parquet {
 namespace {
@@ -353,7 +354,7 @@ class TypedComparatorImpl : virtual public TypedComparator<DType> {
     T max = Helper::DefaultMax();
 
     for (int64_t i = 0; i < length; i++) {
-      auto val = values[i];
+      const auto val = SafeLoad(values + i);
       min = Helper::Min(type_length_, min, Helper::Coalesce(val, Helper::DefaultMin()));
       max = Helper::Max(type_length_, max, Helper::Coalesce(val, Helper::DefaultMax()));
     }
@@ -372,7 +373,7 @@ class TypedComparatorImpl : virtual public TypedComparator<DType> {
     ::arrow::internal::VisitSetBitRunsVoid(
         valid_bits, valid_bits_offset, length, [&](int64_t position, int64_t length) {
           for (int64_t i = 0; i < length; i++) {
-            const auto val = values[i + position];
+            const auto val = SafeLoad(values + i + position);
             min = Helper::Min(type_length_, min,
                               Helper::Coalesce(val, Helper::DefaultMin()));
             max = Helper::Max(type_length_, max,


### PR DESCRIPTION
Some gcc versions (such as 6.3.0) may emit an aligned-only load instruction, but the Parquet writer can be called with unaligned buffers.
* Closes: #33336