### PR TITLE
ARROW-17923: [C++] Consider dictionary arrays for special fragment fields

### DIFF
--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -112,7 +112,7 @@ const FieldVector kAugmentedFields{
     field("__fragment_index", int32()),
     field("__batch_index", int32()),
     field("__last_in_fragment", boolean()),
-    field("__filename", dictionary(int32(),utf8())),
+    field("__filename", dictionary(int32(), utf8())),
 };
 
 Result<std::shared_ptr<Schema>> GetProjectedSchemaFromExpression(
@@ -980,11 +980,12 @@ Result<compute::ExecNode*> MakeScanNode(compute::ExecPlan* plan,
         batch->values.emplace_back(partial.record_batch.index);
         batch->values.emplace_back(partial.record_batch.last);
 
-        ARROW_ASSIGN_OR_RAISE(auto filename_string, MakeScalar(utf8(), partial.fragment.value->ToString()));
+        ARROW_ASSIGN_OR_RAISE(auto filename_string,
+                              MakeScalar(utf8(), partial.fragment.value->ToString()));
         ARROW_ASSIGN_OR_RAISE(auto filename_array,
-                                      MakeArrayFromScalar(*(filename_string.get()), 1));
-        auto filename_dict = Datum{DictionaryScalar::Make(MakeScalar<int32_t>(0),
-                                                   std::move(filename_array))};
+                              MakeArrayFromScalar(*(filename_string.get()), 1));
+        auto filename_dict = Datum{
+            DictionaryScalar::Make(MakeScalar<int32_t>(0), std::move(filename_array))};
         batch->values.emplace_back(filename_dict);
         return batch;
       });

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -112,7 +112,7 @@ const FieldVector kAugmentedFields{
     field("__fragment_index", int32()),
     field("__batch_index", int32()),
     field("__last_in_fragment", boolean()),
-    field("__filename", utf8()),
+    field("__filename", dictionary(int32(),utf8())),
 };
 
 Result<std::shared_ptr<Schema>> GetProjectedSchemaFromExpression(
@@ -979,7 +979,13 @@ Result<compute::ExecNode*> MakeScanNode(compute::ExecPlan* plan,
         batch->values.emplace_back(partial.fragment.index);
         batch->values.emplace_back(partial.record_batch.index);
         batch->values.emplace_back(partial.record_batch.last);
-        batch->values.emplace_back(partial.fragment.value->ToString());
+
+        ARROW_ASSIGN_OR_RAISE(auto filename_string, MakeScalar(utf8(), partial.fragment.value->ToString()));
+        ARROW_ASSIGN_OR_RAISE(auto filename_array,
+                                      MakeArrayFromScalar(*(filename_string.get()), 1));
+        auto filename_dict = Datum{DictionaryScalar::Make(MakeScalar<int32_t>(0),
+                                                   std::move(filename_array))};
+        batch->values.emplace_back(filename_dict);
         return batch;
       });
 

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -2211,12 +2211,13 @@ DatasetAndBatches DatasetAndBatchesFromJSON(
 
       // ... and with the last-in-fragment flag
       batches.back().values.emplace_back(batch_index == frag_batch_count - 1);
-      
-      EXPECT_OK_AND_ASSIGN(auto filename_string, MakeScalar(utf8(), fragments[frag_ndx]->ToString()));
+
+      EXPECT_OK_AND_ASSIGN(auto filename_string,
+                           MakeScalar(utf8(), fragments[frag_ndx]->ToString()));
       EXPECT_OK_AND_ASSIGN(auto filename_array,
-                                    MakeArrayFromScalar(*(filename_string.get()), 1));
-      auto filename_dict = Datum{DictionaryScalar::Make(MakeScalar<int32_t>(0),
-                                                  std::move(filename_array))};
+                           MakeArrayFromScalar(*(filename_string.get()), 1));
+      auto filename_dict = Datum{
+          DictionaryScalar::Make(MakeScalar<int32_t>(0), std::move(filename_array))};
       batches.back().values.emplace_back(filename_dict);
 
       // each batch carries a guarantee inherited from its Fragment's partition expression


### PR DESCRIPTION
This PR modifies the `__filename`  field in a dataset fragment to be a `DictionaryScalar` of string instead of a string field.