### PR TITLE
ARROW-17360: [Python] Reorder columns in pyarrow.feather.read_table

### DIFF
--- a/python/pyarrow/orc.py
+++ b/python/pyarrow/orc.py
@@ -185,7 +185,9 @@ class ORCFile:
         columns = self._select_names(columns)
         table = self.reader.read(columns=columns)
         # follow exact order / selection of names
-        return table.select(columns)
+        if columns:
+            table = table.select(columns)
+        return table
 
 
 _orc_writer_args_docs = """file_version : {"0.11", "0.12"}, default "0.12"

--- a/python/pyarrow/orc.py
+++ b/python/pyarrow/orc.py
@@ -183,7 +183,9 @@ class ORCFile:
             Content of the file as a Table.
         """
         columns = self._select_names(columns)
-        return self.reader.read(columns=columns)
+        table = self.reader.read(columns=columns)
+        # follow exact order / selection of names
+        return table.select(columns)
 
 
 _orc_writer_args_docs = """file_version : {"0.11", "0.12"}, default "0.12"

--- a/python/pyarrow/tests/test_orc.py
+++ b/python/pyarrow/tests/test_orc.py
@@ -642,10 +642,18 @@ def test_read_orc_column_order(tempdir):
     table = pa.table({"a": [1, 2, 3], "b": ["a", "b", "c"]})
     path = str(tempdir / 'test.orc')
     orc.write_table(table, path)
-    result = orc.read_table(path, columns=['b', 'a'])
 
+    result = orc.read_table(path, columns=['b', 'a'])
     expected_schema = pa.schema([
         ("b", pa.string()),
         ("a", pa.int64()),
+    ])
+    assert result.schema == expected_schema
+
+    # Should not error in case columns=None
+    result = orc.read_table(path)
+    expected_schema = pa.schema([
+        ("a", pa.int64()),
+        ("b", pa.string()),
     ])
     assert result.schema == expected_schema

--- a/python/pyarrow/tests/test_orc.py
+++ b/python/pyarrow/tests/test_orc.py
@@ -634,3 +634,18 @@ def test_orc_writer_with_null_arrays(tempdir):
     table = pa.table({"int64": a, "utf8": b})
     with pytest.raises(pa.ArrowNotImplementedError):
         orc.write_table(table, path)
+
+
+def test_read_orc_column_order(tempdir):
+    from pyarrow import orc
+
+    table = pa.table({"a": [1, 2, 3], "b": ["a", "b", "c"]})
+    path = str(tempdir / 'test.orc')
+    orc.write_table(table, path)
+    result = orc.read_table(path, columns=['b', 'a'])
+
+    expected_schema = pa.schema([
+        ("b", pa.string()),
+        ("a", pa.int64()),
+    ])
+    assert result.schema == expected_schema


### PR DESCRIPTION
Before this PR:
```python
table = pa.table({"a": [1, 2, 3], "b": ["a", "b", "c"]})
orc.write_table(table, 'example.orc')
orc.read_table('example.orc', columns=['b', 'a'])
# pyarrow.Table
# a: int64
# b: string
# ----
# a: [[1,2,3]]
# b: [["a","b","c"]]
```

After this PR:
```python
table = pa.table({"a": [1, 2, 3], "b": ["a", "b", "c"]})
orc.write_table(table, 'example.orc')
orc.read_table('example.orc', columns=['b', 'a'])
# pyarrow.Table
# b: string
# a: int64
# ----
# b: [["a","b","c"]]
# a: [[1,2,3]]
```