### PR TITLE
ARROW-18151: [CI] Avoid unnecessary redirect for some conda URLs 

### DIFF
--- a/dev/tasks/nightlies.sample.yml
+++ b/dev/tasks/nightlies.sample.yml
@@ -36,7 +36,7 @@ before_install:
     - |
       echo ""
       echo "Installing a fresh version of Miniconda."
-      MINICONDA_URL="https://repo.continuum.io/miniconda"
+      MINICONDA_URL="https://repo.anaconda.com/miniconda"
       MINICONDA_FILE="Miniconda3-latest-Linux-x86_64.sh"
       curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b

--- a/python/examples/minimal_build/build_conda.sh
+++ b/python/examples/minimal_build/build_conda.sh
@@ -46,7 +46,7 @@ function setup_miniconda() {
   conda info -a
 
   conda config --set show_channel_urls True
-  conda config --add channels https://repo.anaconda.io/pkgs/free
+  conda config --add channels https://repo.anaconda.com/pkgs/free
   conda config --add channels conda-forge
 
   conda create -y -n pyarrow-$PYTHON -c conda-forge \

--- a/python/examples/minimal_build/build_conda.sh
+++ b/python/examples/minimal_build/build_conda.sh
@@ -34,7 +34,7 @@ git config --global --add safe.directory $ARROW_ROOT
 # Run these only once
 
 function setup_miniconda() {
-  MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
+  MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh"
   wget -O miniconda.sh $MINICONDA_URL
   bash miniconda.sh -b -p $MINICONDA
   rm -f miniconda.sh
@@ -46,7 +46,7 @@ function setup_miniconda() {
   conda info -a
 
   conda config --set show_channel_urls True
-  conda config --add channels https://repo.continuum.io/pkgs/free
+  conda config --add channels https://repo.anaconda.io/pkgs/free
   conda config --add channels conda-forge
 
   conda create -y -n pyarrow-$PYTHON -c conda-forge \


### PR DESCRIPTION
Fixes the unnecessary redirects:
```
--2022-10-25 08:44:33--  https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
Resolving repo.continuum.io (repo.continuum.io)... 104.18.200.79, 104.18.201.79, 2606:4700::6812:c84f, ...
Connecting to repo.continuum.io (repo.continuum.io)|104.18.200.79|:443... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh [following]
--2022-10-25 08:44:34--  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
Resolving repo.anaconda.com (repo.anaconda.com)... 104.16.131.3, 104.16.130.3, 2606:4700::6810:8303, ...
Connecting to repo.anaconda.com (repo.anaconda.com)|104.16.131.3|:443... connected.
HTTP request sent, awaiting response... 200 OK
 ```