### PR TITLE
ARROW-18126: [Python] Remove ARROW_BUILD_DIR in building pyarrow C++

### DIFF
--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -404,13 +404,6 @@ variable to 1.
 To set the number of threads used to compile PyArrow's C++/Cython components,
 set the ``PYARROW_PARALLEL`` environment variable.
 
-.. note::
-
-   If you used a different directory name for building Arrow C++ (by default it is
-   named "build"), then you should also set the environment variable
-   ``ARROW_BUILD_DIR='name_of_build_dir'``. This way
-   PyArrow can find the Arrow C++ built files.
-
 If you wish to delete stale PyArrow build artifacts before rebuilding, navigate
 to the ``arrow/python`` folder and run ``git clean -Xfd .``.
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -245,9 +245,6 @@ class build_ext(_build_ext):
         # The directory for the module being built
         build_dir = pjoin(os.getcwd(), 'build', 'cpp')
 
-        # The directory containing Arrow C++ build
-        arrow_build_dir = os.environ.get('ARROW_BUILD_DIR', 'build')
-
         if not os.path.isdir(build_dir):
             self.mkpath(build_dir)
 
@@ -255,7 +252,6 @@ class build_ext(_build_ext):
         with changed_dir(build_dir):
             # cmake args
             cmake_options = [
-                '-DARROW_BUILD_DIR=' + str(arrow_build_dir),
                 '-DCMAKE_BUILD_TYPE=' + str(self.build_type.lower()),
                 '-DCMAKE_INSTALL_LIBDIR=lib',
                 '-DCMAKE_INSTALL_PREFIX=' + str(pyarrow_cpp_home),


### PR DESCRIPTION
Remove all instances of `ARROW_BUILD_DIR` environment variable that was aded in the PyArrow refactoring PR https://github.com/apache/arrow/pull/13311.