### PR TITLE
ARROW-18157: [Dev][Archery] "archery docker run" sets env var to None when inherited

### DIFF
--- a/dev/archery/archery/docker/core.py
+++ b/dev/archery/archery/docker/core.py
@@ -342,7 +342,8 @@ class DockerCompose(Command):
 
             # append env variables from the compose conf
             for k, v in service.get('environment', {}).items():
-                args.extend(['-e', '{}={}'.format(k, v)])
+                if v is not None:
+                    args.extend(['-e', '{}={}'.format(k, v)])
 
             # append volumes from the compose conf
             for v in service.get('volumes', []):


### PR DESCRIPTION
This would occur when:
* an environment variable is set to inherited in `docker-compose.yml`
* the variable isn't set in the calling environment
* Archery uses `docker` instead of `docker-compose` to run the container (for example because it's a GPU job)