### PR TITLE
MINOR: [CI][C++] Make CTest timeout configurable

### DIFF
--- a/ci/scripts/cpp_test.sh
+++ b/ci/scripts/cpp_test.sh
@@ -85,7 +85,7 @@ ctest \
     --label-regex unittest \
     --output-on-failure \
     --parallel ${n_jobs} \
-    --timeout 300 \
+    --timeout ${ARROW_CTEST_TIMEOUT:-300} \
     "${ctest_options[@]}" \
     $@
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -577,6 +577,7 @@ services:
       CC: clang-${CLANG_TOOLS}
       CXX: clang++-${CLANG_TOOLS}
       ARROW_BUILD_STATIC: "OFF"
+      ARROW_CTEST_TIMEOUT: 500
       ARROW_ENABLE_TIMING_TESTS:  # inherit
       ARROW_DATASET: "ON"
       ARROW_JEMALLOC: "OFF"


### PR DESCRIPTION
Avoid occasional timeouts in some tests in the Thread Sanitizer build.