### PR TITLE
ARROW-18043: [R] Properly instantiate empty arrays of extension types in Table__from_schema

### DIFF
--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -2028,8 +2028,8 @@ Table__from_record_batches <- function(batches, schema_sxp) {
   .Call(`_arrow_Table__from_record_batches`, batches, schema_sxp)
 }
 
-Table__from_schema <- function(schema_sxp) {
-  .Call(`_arrow_Table__from_schema`, schema_sxp)
+Table__from_schema <- function(schema) {
+  .Call(`_arrow_Table__from_schema`, schema)
 }
 
 Table__ReferencedBufferSize <- function(table) {

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -5109,11 +5109,11 @@ BEGIN_CPP11
 END_CPP11
 }
 // table.cpp
-std::shared_ptr<arrow::Table> Table__from_schema(SEXP schema_sxp);
-extern "C" SEXP _arrow_Table__from_schema(SEXP schema_sxp_sexp){
+std::shared_ptr<arrow::Table> Table__from_schema(const std::shared_ptr<arrow::Schema>& schema);
+extern "C" SEXP _arrow_Table__from_schema(SEXP schema_sexp){
 BEGIN_CPP11
-	arrow::r::Input<SEXP>::type schema_sxp(schema_sxp_sexp);
-	return cpp11::as_sexp(Table__from_schema(schema_sxp));
+	arrow::r::Input<const std::shared_ptr<arrow::Schema>&>::type schema(schema_sexp);
+	return cpp11::as_sexp(Table__from_schema(schema));
 END_CPP11
 }
 // table.cpp

--- a/r/tests/testthat/test-Table.R
+++ b/r/tests/testthat/test-Table.R
@@ -695,7 +695,11 @@ test_that("num_rows method not susceptible to integer overflow", {
 })
 
 test_that("can create empty table from schema", {
-  schema <- schema(col1 = float64(), col2 = string())
+  schema <- schema(
+    col1 = float64(),
+    col2 = string(),
+    col3 = vctrs_extension_type(integer())
+  )
   out <- Table$create(schema = schema)
   expect_r6_class(out, "Table")
   expect_equal(nrow(out), 0)


### PR DESCRIPTION
This PR supports the following:

``` r
library(arrow, warn.conflicts = FALSE)
#> Some features are not enabled in this build of Arrow. Run `arrow_info()` for more information.

schema_with_ext_type <- schema(
  x = int32(),
  y = vctrs_extension_type(integer())
)

as_arrow_table(schema_with_ext_type)
#> Table
#> 0 rows x 2 columns
#> $x <int32>
#> $y <integer(0)>
```

<sup>Created on 2022-10-26 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

It's a little bit cheating, though, because the previous approach is more true to what `ChunkedArray::MakeEmpty()` does. Is there a downside here to creating a `ChunkedArray` with zero chunks (as opposed to a `ChunkedArray()` with one empty chunk)? If there is we can probably work around it via creating an empty array of the storage type and wrapping it.