### PR TITLE
PARQUET-2206: [parquet-cpp] Microbenchmark for ColumnReader ReadBatch and Skip

### DIFF
--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -385,6 +385,7 @@ endif()
 add_parquet_test(file_deserialize_test SOURCES file_deserialize_test.cc test_util.cc)
 add_parquet_test(schema_test)
 
+add_parquet_benchmark(column_reader_benchmark)
 add_parquet_benchmark(column_io_benchmark)
 add_parquet_benchmark(encoding_benchmark)
 add_parquet_benchmark(level_conversion_benchmark)

--- a/cpp/src/parquet/column_reader_benchmark.cc
+++ b/cpp/src/parquet/column_reader_benchmark.cc
@@ -124,7 +124,6 @@ static void ColumnReaderReadBatchInt32(::benchmark::State& state) {
 }
 
 BENCHMARK(ColumnReaderSkipInt32)
-    ->Iterations(10)
     ->ArgNames({"Repetition", "BatchSize"})
     ->Args({0, 100})
     ->Args({0, 1000})
@@ -140,7 +139,6 @@ BENCHMARK(ColumnReaderSkipInt32)
     ->Args({2, 100000});
 
 BENCHMARK(ColumnReaderReadBatchInt32)
-    ->Iterations(10)
     ->ArgNames({"Repetition", "BatchSize"})
     ->Args({0, 100})
     ->Args({0, 1000})

--- a/cpp/src/parquet/column_reader_benchmark.cc
+++ b/cpp/src/parquet/column_reader_benchmark.cc
@@ -77,14 +77,14 @@ class BenchmarkHelper {
 // - batch_size: sets how many values to read at each call.
 static void ColumnReaderSkipInt32(::benchmark::State& state) {
   const auto repetition = static_cast<Repetition::type>(state.range(0));
-  const int batch_size = state.range(1);
+  const auto batch_size = static_cast<int64_t>(state.range(1));
 
   BenchmarkHelper helper(repetition, /*num_pages=*/16, /*levels_per_page=*/80000);
 
   for (auto _ : state) {
     state.PauseTiming();
     Int32Reader* reader = helper.ResetReader();
-    int values_count = -1;
+    int64_t values_count = -1;
     state.ResumeTiming();
     while (values_count != 0) {
       DoNotOptimize(values_count = reader->Skip(batch_size));
@@ -99,7 +99,7 @@ static void ColumnReaderSkipInt32(::benchmark::State& state) {
 // - batch_size: sets how many values to read at each call.
 static void ColumnReaderReadBatchInt32(::benchmark::State& state) {
   const auto repetition = static_cast<Repetition::type>(state.range(0));
-  const int batch_size = state.range(1);
+  const auto batch_size = static_cast<int64_t>(state.range(1));
 
   BenchmarkHelper helper(repetition, /*num_pages=*/16, /*levels_per_page=*/80000);
 
@@ -110,7 +110,7 @@ static void ColumnReaderReadBatchInt32(::benchmark::State& state) {
   for (auto _ : state) {
     state.PauseTiming();
     Int32Reader* reader = helper.ResetReader();
-    int values_count = -1;
+    int64_t values_count = -1;
     state.ResumeTiming();
     while (values_count != 0) {
       int64_t values_read = 0;

--- a/cpp/src/parquet/column_reader_benchmark.cc
+++ b/cpp/src/parquet/column_reader_benchmark.cc
@@ -1,0 +1,99 @@
+#include "benchmark/benchmark.h"
+#include "parquet/column_page.h"
+#include "parquet/column_reader.h"
+#include "parquet/schema.h"
+#include "parquet/test_util.h"
+#include "parquet/types.h"
+
+namespace parquet {
+
+using parquet::Repetition;
+using parquet::test::MakePages;
+using schema::NodePtr;
+
+namespace benchmark {
+
+static void BM_Skip(::benchmark::State& state) {
+  internal::LevelInfo level_info;
+  level_info.def_level = state.range(0);
+  level_info.rep_level = state.range(1);
+  // If true, tests skip, otherwise tests read.
+  const int skip = state.range(2);
+  const int batch_size = state.range(3);
+
+  Repetition::type repetition = Repetition::REQUIRED;
+  if (level_info.def_level > 0) {
+    repetition = Repetition::OPTIONAL;
+  }
+  if (level_info.rep_level > 0) {
+    repetition = Repetition::REPEATED;
+  }
+  NodePtr type = schema::Int32("b", repetition);
+  const ColumnDescriptor descr(type, level_info.def_level, level_info.rep_level);
+
+  const int num_pages = 5;
+  const int levels_per_page = 100000;
+  // Vectors filled with random rep/defs and values to make pages.
+  std::vector<int32_t> values;
+  std::vector<int16_t> def_levels;
+  std::vector<int16_t> rep_levels;
+  std::vector<uint8_t> data_buffer;
+  std::vector<std::shared_ptr<Page>> pages;
+  MakePages<Int32Type>(&descr, num_pages, levels_per_page, def_levels, rep_levels, values,
+                       data_buffer, pages, Encoding::PLAIN);
+
+  // Vectors to read the values into.
+  std::vector<int32_t> read_values(batch_size, -1);
+  std::vector<int16_t> read_defs(batch_size, -1);
+  std::vector<int16_t> read_reps(batch_size, -1);
+
+  while (state.KeepRunning()) {
+    state.PauseTiming();
+    std::unique_ptr<PageReader> pager;
+    pager.reset(new test::MockPageReader(pages));
+    std::shared_ptr<ColumnReader> column_reader =
+        ColumnReader::Make(&descr, std::move(pager));
+    Int32Reader* reader = static_cast<Int32Reader*>(column_reader.get());
+    int values_count = -1;
+    state.ResumeTiming();
+    while (values_count != 0) {
+      if (skip == 1) {
+        values_count = reader->Skip(batch_size);
+      } else {
+        int64_t values_read = 0;
+        values_count = reader->ReadBatch(batch_size, read_defs.data(), read_reps.data(),
+                                         read_values.data(), &values_read);
+      }
+    }
+  }
+}
+
+BENCHMARK(BM_Skip)
+    ->Iterations(1000)
+    ->Args({0, 0, 0, 1})
+    ->Args({0, 0, 0, 1000})
+    ->Args({0, 0, 0, 10000})
+    ->Args({0, 0, 0, 100000})
+    ->Args({0, 0, 1, 1})
+    ->Args({0, 0, 1, 1000})
+    ->Args({0, 0, 1, 10000})
+    ->Args({0, 0, 1, 100000})
+    ->Args({1, 0, 0, 1})
+    ->Args({1, 0, 0, 1000})
+    ->Args({1, 0, 0, 10000})
+    ->Args({1, 0, 0, 100000})
+    ->Args({1, 0, 1, 1})
+    ->Args({1, 0, 1, 1000})
+    ->Args({1, 0, 1, 10000})
+    ->Args({1, 0, 1, 100000})
+    ->Args({1, 1, 0, 1})
+    ->Args({1, 1, 0, 1000})
+    ->Args({1, 1, 0, 10000})
+    ->Args({1, 1, 0, 100000})
+    ->Args({1, 1, 1, 1})
+    ->Args({1, 1, 1, 1000})
+    ->Args({1, 1, 1, 10000})
+    ->Args({1, 1, 1, 100000});
+
+}  // namespace benchmark
+}  // namespace parquet

--- a/cpp/src/parquet/column_reader_benchmark.cc
+++ b/cpp/src/parquet/column_reader_benchmark.cc
@@ -145,5 +145,5 @@ BENCHMARK(BM_ReadBatch)
     ->Args({2, 10000})
     ->Args({2, 100000});
 
-}  // namespace bemark
+}  // namespace benchmark
 }  // namespace parquet

--- a/cpp/src/parquet/column_reader_benchmark.cc
+++ b/cpp/src/parquet/column_reader_benchmark.cc
@@ -67,9 +67,9 @@ static void BM_Skip(::benchmark::State& state) {
         DoNotOptimize(values_count = reader->Skip(batch_size));
       } else {
         int64_t values_read = 0;
-        DoNotOptimize(values_count = reader->ReadBatch(
-                                     batch_size, read_defs.data(), read_reps.data(),
-                                     read_values.data(), &values_read));
+        DoNotOptimize(values_count = reader->ReadBatch(batch_size, read_defs.data(),
+                                                       read_reps.data(),
+                                                       read_values.data(), &values_read));
       }
     }
   }

--- a/cpp/src/parquet/column_reader_benchmark.cc
+++ b/cpp/src/parquet/column_reader_benchmark.cc
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 #include "benchmark/benchmark.h"
 #include "parquet/column_page.h"
 #include "parquet/column_reader.h"


### PR DESCRIPTION
Adding a micro benchmark for column reader ReadBatch and Skip. Later, I will add benchmarks for RecordReader's ReadRecords and SkipRecords.

Here are the results from my machine: 
```
-------------------------------------------------------------------------------
Benchmark                                     Time             CPU   Iterations
-------------------------------------------------------------------------------
BM_Skip/0/0/0/1/iterations:1000        11250680 ns     11133405 ns         1000
BM_Skip/0/0/0/1000/iterations:1000       134092 ns       134455 ns         1000
BM_Skip/0/0/0/10000/iterations:1000      175717 ns       175677 ns         1000
BM_Skip/0/0/0/100000/iterations:1000     217368 ns       218672 ns         1000
BM_Skip/0/0/1/1/iterations:1000       150319842 ns    149567587 ns         1000
BM_Skip/0/0/1/1000/iterations:1000       244565 ns       244931 ns         1000
BM_Skip/0/0/1/10000/iterations:1000      115395 ns       115924 ns         1000
BM_Skip/0/0/1/100000/iterations:1000     115241 ns       115916 ns         1000
BM_Skip/1/0/0/1/iterations:1000        23289018 ns     23190677 ns         1000
BM_Skip/1/0/0/1000/iterations:1000       622022 ns       621621 ns         1000
BM_Skip/1/0/0/10000/iterations:1000      540981 ns       540620 ns         1000
BM_Skip/1/0/0/100000/iterations:1000     543156 ns       543126 ns         1000
BM_Skip/1/0/1/1/iterations:1000       149224507 ns    148683644 ns         1000
BM_Skip/1/0/1/1000/iterations:1000       805812 ns       805417 ns         1000
BM_Skip/1/0/1/10000/iterations:1000      702999 ns       700108 ns         1000
BM_Skip/1/0/1/100000/iterations:1000     654163 ns       651947 ns         1000
BM_Skip/1/1/0/1/iterations:1000        33160880 ns     33051386 ns         1000
BM_Skip/1/1/0/1000/iterations:1000       999412 ns       998795 ns         1000
BM_Skip/1/1/0/10000/iterations:1000      815868 ns       814927 ns         1000
BM_Skip/1/1/0/100000/iterations:1000     781166 ns       781112 ns         1000
BM_Skip/1/1/1/1/iterations:1000       165600118 ns    164864530 ns         1000
BM_Skip/1/1/1/1000/iterations:1000      1130975 ns      1130252 ns         1000
BM_Skip/1/1/1/10000/iterations:1000     1009628 ns      1009589 ns         1000
BM_Skip/1/1/1/100000/iterations:1000    1029064 ns      1028726 ns         1000
```