### PR TITLE
ARROW-17509: [C++] Simplify async scheduler by removing the need to call End

### DIFF
--- a/cpp/examples/arrow/engine_substrait_consumption.cc
+++ b/cpp/examples/arrow/engine_substrait_consumption.cc
@@ -32,7 +32,8 @@ class IgnoringConsumer : public cp::SinkNodeConsumer {
   explicit IgnoringConsumer(size_t tag) : tag_{tag} {}
 
   arrow::Status Init(const std::shared_ptr<arrow::Schema>& schema,
-                     cp::BackpressureControl* backpressure_control) override {
+                     cp::BackpressureControl* backpressure_control,
+                     cp::ExecPlan* plan) override {
     return arrow::Status::OK();
   }
 

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -583,7 +583,8 @@ arrow::Status SourceConsumingSinkExample(cp::ExecContext& exec_context) {
         : batches_seen(batches_seen), finish(std::move(finish)) {}
 
     arrow::Status Init(const std::shared_ptr<arrow::Schema>& schema,
-                       cp::BackpressureControl* backpressure_control) override {
+                       cp::BackpressureControl* backpressure_control,
+                       cp::ExecPlan* plan) override {
       return arrow::Status::OK();
     }
 

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -114,7 +114,7 @@ struct ExecPlanImpl : public ExecPlan {
     return task_scheduler_->StartTaskGroup(GetThreadIndex(), task_group_id, num_tasks);
   }
 
-  util::AsyncTaskScheduler* async_scheduler() { return async_scheduler_.get(); }
+  util::AsyncTaskScheduler* async_scheduler() { return async_scheduler_; }
 
   Status Validate() const {
     if (nodes_.empty()) {
@@ -127,85 +127,89 @@ struct ExecPlanImpl : public ExecPlan {
   }
 
   Status StartProducing() {
-    START_COMPUTE_SPAN(span_, "ExecPlan", {{"plan", ToString()}});
-#ifdef ARROW_WITH_OPENTELEMETRY
-    if (HasMetadata()) {
-      auto pairs = metadata().get()->sorted_pairs();
-      opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> span =
-          ::arrow::internal::tracing::UnwrapSpan(span_.details.get());
-      std::for_each(std::begin(pairs), std::end(pairs),
-                    [span](std::pair<std::string, std::string> const& pair) {
-                      span->SetAttribute(pair.first, pair.second);
-                    });
-    }
-#endif
     if (started_) {
       return Status::Invalid("restarted ExecPlan");
     }
-
-    std::vector<Future<>> futures;
-    for (auto& n : nodes_) {
-      RETURN_NOT_OK(n->Init());
-      futures.push_back(n->finished());
-    }
-
-    AllFinished(futures).AddCallback([this](const Status& st) {
-      error_st_ = st;
-      EndTaskGroup();
-    });
-
-    task_scheduler_->RegisterEnd();
-    int num_threads = 1;
-    bool sync_execution = true;
-    if (auto executor = exec_context()->executor()) {
-      num_threads = executor->GetCapacity();
-      sync_execution = false;
-    }
-    RETURN_NOT_OK(task_scheduler_->StartScheduling(
-        0 /* thread_index */,
-        [this](std::function<Status(size_t)> fn) -> Status {
-          return this->ScheduleTask(std::move(fn));
-        },
-        /*concurrent_tasks=*/2 * num_threads, sync_execution));
-
     started_ = true;
-    // producers precede consumers
-    sorted_nodes_ = TopoSort();
 
-    Status st = Status::OK();
+    // We call StartProducing on each of the nodes.  The source nodes should generally
+    // start scheduling some tasks during this call.
+    //
+    // If no source node schedules any tasks (e.g. they do all their word synchronously as
+    // part of StartProducing) then the plan may be finished before we return from this
+    // call.
+    Future<> scheduler_finished =
+        util::AsyncTaskScheduler::Make([this](util::AsyncTaskScheduler* async_scheduler) {
+          this->async_scheduler_ = async_scheduler;
+          START_COMPUTE_SPAN(span_, "ExecPlan", {{"plan", ToString()}});
+#ifdef ARROW_WITH_OPENTELEMETRY
+          if (HasMetadata()) {
+            auto pairs = metadata().get()->sorted_pairs();
+            opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> span =
+                ::arrow::internal::tracing::UnwrapSpan(span_.details.get());
+            std::for_each(std::begin(pairs), std::end(pairs),
+                          [span](std::pair<std::string, std::string> const& pair) {
+                            span->SetAttribute(pair.first, pair.second);
+                          });
+          }
+#endif
+          // TODO(weston) The entire concept of ExecNode::finished() will hopefully go
+          // away soon (or at least be replaced by a sub-scheduler to facilitate OT)
+          for (auto& n : nodes_) {
+            RETURN_NOT_OK(n->Init());
+            async_scheduler->AddSimpleTask([&] { return n->finished(); });
+          }
 
-    using rev_it = std::reverse_iterator<NodeVector::iterator>;
-    for (rev_it it(sorted_nodes_.end()), end(sorted_nodes_.begin()); it != end; ++it) {
-      auto node = *it;
+          task_scheduler_->RegisterEnd();
+          int num_threads = 1;
+          bool sync_execution = true;
+          if (auto executor = exec_context()->executor()) {
+            num_threads = executor->GetCapacity();
+            sync_execution = false;
+          }
+          RETURN_NOT_OK(task_scheduler_->StartScheduling(
+              0 /* thread_index */,
+              [this](std::function<Status(size_t)> fn) -> Status {
+                return this->ScheduleTask(std::move(fn));
+              },
+              /*concurrent_tasks=*/2 * num_threads, sync_execution));
 
-      EVENT(span_, "StartProducing:" + node->label(),
-            {{"node.label", node->label()}, {"node.kind_name", node->kind_name()}});
-      st = node->StartProducing();
-      EVENT(span_, "StartProducing:" + node->label(), {{"status", st.ToString()}});
-      if (!st.ok()) {
-        // Stop nodes that successfully started, in reverse order
-        stopped_ = true;
-        StopProducingImpl(it.base(), sorted_nodes_.end());
-        for (NodeVector::iterator fw_it = sorted_nodes_.begin(); fw_it != it.base();
-             ++fw_it) {
-          Future<> fut = (*fw_it)->finished();
-          if (!fut.is_finished()) fut.MarkFinished();
-        }
-        return st;
-      }
-    }
-    return st;
-  }
+          // producers precede consumers
+          sorted_nodes_ = TopoSort();
 
-  void EndTaskGroup() {
-    bool expected = false;
-    if (group_ended_.compare_exchange_strong(expected, true)) {
-      async_scheduler_->End();
-      async_scheduler_->OnFinished().AddCallback([this](const Status& st) {
-        MARK_SPAN(span_, error_st_ & st);
-        END_SPAN(span_);
-        finished_.MarkFinished(error_st_ & st);
-      });
+          Status st = Status::OK();
+
+          using rev_it = std::reverse_iterator<NodeVector::iterator>;
+          for (rev_it it(sorted_nodes_.end()), end(sorted_nodes_.begin()); it != end;
+               ++it) {
+            auto node = *it;
+
+            EVENT(span_, "StartProducing:" + node->label(),
+                  {{"node.label", node->label()}, {"node.kind_name", node->kind_name()}});
+            st = node->StartProducing();
+            EVENT(span_, "StartProducing:" + node->label(), {{"status", st.ToString()}});
+            if (!st.ok()) {
+              // Stop nodes that successfully started, in reverse order
+              stopped_ = true;
+              StopProducingImpl(it.base(), sorted_nodes_.end());
+              for (NodeVector::iterator fw_it = sorted_nodes_.begin(); fw_it != it.base();
+                   ++fw_it) {
+                Future<> fut = (*fw_it)->finished();
+                if (!fut.is_finished()) fut.MarkFinished();
+              }
+              return st;
+            }
+          }
+          return st;
+        });
+    scheduler_finished.AddCallback(
+        [this](const Status& st) { finished_.MarkFinished(st); });
+    // TODO(weston) Do we really need to return status here?  Could we change this return
+    // to void?
+    if (finished_.is_finished()) {
+      return finished_.status();
+    } else {
+      return Status::OK();
     }
   }
 
@@ -331,9 +335,7 @@ struct ExecPlanImpl : public ExecPlan {
   std::shared_ptr<const KeyValueMetadata> metadata_;
 
   ThreadIndexer thread_indexer_;
-  std::atomic<bool> group_ended_{false};
-  std::unique_ptr<util::AsyncTaskScheduler> async_scheduler_ =
-      util::AsyncTaskScheduler::Make();
+  util::AsyncTaskScheduler* async_scheduler_ = nullptr;
   std::unique_ptr<TaskScheduler> task_scheduler_ = TaskScheduler::Make();
 };
 

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -213,8 +213,9 @@ class ARROW_EXPORT SinkNodeConsumer {
   /// This will be run once the schema is finalized as the plan is starting and
   /// before any calls to Consume.  A common use is to save off the schema so that
   /// batches can be interpreted.
+  /// TODO(ARROW-17837) Move ExecPlan* plan to query context
   virtual Status Init(const std::shared_ptr<Schema>& schema,
-                      BackpressureControl* backpressure_control) = 0;
+                      BackpressureControl* backpressure_control, ExecPlan* plan) = 0;
   /// \brief Consume a batch of data
   virtual Status Consume(ExecBatch batch) = 0;
   /// \brief Signal to the consumer that the last batch has been delivered

--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -665,20 +665,9 @@ TEST(ExecPlanExecution, ConsumingSinkError) {
                     SourceNodeOptions(basic_data.schema, basic_data.gen(false, false))},
                    {"consuming_sink", ConsumingSinkNodeOptions(consumer)}})
                   .AddToPlan(plan.get()));
-    ASSERT_OK_AND_ASSIGN(
-        auto source,
-        MakeExecNode("source", plan.get(), {},
-                     SourceNodeOptions(basic_data.schema, basic_data.gen(false, false))));
-    ASSERT_OK(MakeExecNode("consuming_sink", plan.get(), {source},
-                           ConsumingSinkNodeOptions(consumer)));
-    // If we fail at init we see it during StartProducing.  Other
-    // failures are not seen until we start running.
-    if (std::dynamic_pointer_cast<InitErrorConsumer>(consumer)) {
-      ASSERT_RAISES(Invalid, plan->StartProducing());
-    } else {
-      ASSERT_OK(plan->StartProducing());
-      ASSERT_FINISHES_AND_RAISES(Invalid, plan->finished());
-    }
+    // Since the source node is not parallel the entire plan is run during StartProducing
+    ASSERT_RAISES(Invalid, plan->StartProducing());
+    ASSERT_FINISHES_AND_RAISES(Invalid, plan->finished());
   }
 }
 

--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -519,7 +519,7 @@ TEST(ExecPlanExecution, SourceConsumingSink) {
             : batches_seen(batches_seen), finish(std::move(finish)) {}
 
         Status Init(const std::shared_ptr<Schema>& schema,
-                    BackpressureControl* backpressure_control) override {
+                    BackpressureControl* backpressure_control, ExecPlan* plan) override {
           return Status::OK();
         }
 
@@ -593,7 +593,7 @@ TEST(ExecPlanExecution, ConsumingSinkNames) {
   struct SchemaKeepingConsumer : public SinkNodeConsumer {
     std::shared_ptr<Schema> schema_;
     Status Init(const std::shared_ptr<Schema>& schema,
-                BackpressureControl* backpressure_control) override {
+                BackpressureControl* backpressure_control, ExecPlan* plan) override {
       schema_ = schema;
       return Status::OK();
     }
@@ -631,7 +631,7 @@ TEST(ExecPlanExecution, ConsumingSinkNames) {
 TEST(ExecPlanExecution, ConsumingSinkError) {
   struct InitErrorConsumer : public SinkNodeConsumer {
     Status Init(const std::shared_ptr<Schema>& schema,
-                BackpressureControl* backpressure_control) override {
+                BackpressureControl* backpressure_control, ExecPlan* plan) override {
       return Status::Invalid("XYZ");
     }
     Status Consume(ExecBatch batch) override { return Status::OK(); }
@@ -639,7 +639,7 @@ TEST(ExecPlanExecution, ConsumingSinkError) {
   };
   struct ConsumeErrorConsumer : public SinkNodeConsumer {
     Status Init(const std::shared_ptr<Schema>& schema,
-                BackpressureControl* backpressure_control) override {
+                BackpressureControl* backpressure_control, ExecPlan* plan) override {
       return Status::OK();
     }
     Status Consume(ExecBatch batch) override { return Status::Invalid("XYZ"); }
@@ -647,7 +647,7 @@ TEST(ExecPlanExecution, ConsumingSinkError) {
   };
   struct FinishErrorConsumer : public SinkNodeConsumer {
     Status Init(const std::shared_ptr<Schema>& schema,
-                BackpressureControl* backpressure_control) override {
+                BackpressureControl* backpressure_control, ExecPlan* plan) override {
       return Status::OK();
     }
     Status Consume(ExecBatch batch) override { return Status::OK(); }

--- a/cpp/src/arrow/compute/exec/sink_node.cc
+++ b/cpp/src/arrow/compute/exec/sink_node.cc
@@ -303,7 +303,7 @@ class ConsumingSinkNode : public ExecNode, public BackpressureControl {
       }
       output_schema = schema(std::move(fields));
     }
-    RETURN_NOT_OK(consumer_->Init(output_schema, this));
+    RETURN_NOT_OK(consumer_->Init(output_schema, this, plan_));
     return Status::OK();
   }
 

--- a/cpp/src/arrow/compute/exec/sink_node.cc
+++ b/cpp/src/arrow/compute/exec/sink_node.cc
@@ -376,10 +376,18 @@ class ConsumingSinkNode : public ExecNode, public BackpressureControl {
 
  protected:
   void Finish(const Status& finish_st) {
-    consumer_->Finish().AddCallback([this, finish_st](const Status& st) {
-      // Prefer the plan error over the consumer error
-      Status final_status = finish_st & st;
-      finished_.MarkFinished(std::move(final_status));
+    plan_->async_scheduler()->AddSimpleTask([this, &finish_st] {
+      return consumer_->Finish().Then(
+          [this, finish_st]() {
+            finished_.MarkFinished(finish_st);
+            return finish_st;
+          },
+          [this, finish_st](const Status& st) {
+            // Prefer the plan error over the consumer error
+            Status final_status = finish_st & st;
+            finished_.MarkFinished(final_status);
+            return final_status;
+          });
     });
   }
 

--- a/cpp/src/arrow/compute/exec/util.cc
+++ b/cpp/src/arrow/compute/exec/util.cc
@@ -384,7 +384,8 @@ size_t ThreadIndexer::Check(size_t thread_index) {
 }
 
 Status TableSinkNodeConsumer::Init(const std::shared_ptr<Schema>& schema,
-                                   BackpressureControl* backpressure_control) {
+                                   BackpressureControl* backpressure_control,
+                                   ExecPlan* plan) {
   // If the user is collecting into a table then backpressure is meaningless
   ARROW_UNUSED(backpressure_control);
   schema_ = schema;

--- a/cpp/src/arrow/compute/exec/util.h
+++ b/cpp/src/arrow/compute/exec/util.h
@@ -350,7 +350,7 @@ struct ARROW_EXPORT TableSinkNodeConsumer : public SinkNodeConsumer {
   TableSinkNodeConsumer(std::shared_ptr<Table>* out, MemoryPool* pool)
       : out_(out), pool_(pool) {}
   Status Init(const std::shared_ptr<Schema>& schema,
-              BackpressureControl* backpressure_control) override;
+              BackpressureControl* backpressure_control, ExecPlan* plan) override;
   Status Consume(ExecBatch batch) override;
   Future<> Finish() override;
 

--- a/cpp/src/arrow/dataset/dataset_writer.cc
+++ b/cpp/src/arrow/dataset/dataset_writer.cc
@@ -18,7 +18,6 @@
 #include "arrow/dataset/dataset_writer.h"
 
 #include <deque>
-#include <iostream>
 #include <memory>
 #include <mutex>
 #include <unordered_map>
@@ -132,12 +131,12 @@ class DatasetWriterFileQueue {
                                   DatasetWriterState* writer_state)
       : options_(options), schema_(schema), writer_state_(writer_state) {}
 
-  void Start(std::unique_ptr<util::AsyncTaskScheduler::Holder> scheduler,
+  void Start(std::unique_ptr<util::AsyncTaskGroup> file_tasks,
              const std::string& filename) {
-    scheduler_ = std::move(scheduler);
+    file_tasks_ = std::move(file_tasks);
     // Because the scheduler runs one task at a time we know the writer will
     // be opened before any attempt to write
-    scheduler_->Get()->AddSimpleTask([this, filename] {
+    file_tasks_->AddSimpleTask([this, filename] {
       Executor* io_executor = options_.filesystem->io_context().executor();
       return DeferNotOk(io_executor->Submit([this, filename]() {
         ARROW_ASSIGN_OR_RAISE(writer_, OpenWriter(options_, schema_, filename));
@@ -176,7 +175,7 @@ class DatasetWriterFileQueue {
   }
 
   void ScheduleBatch(std::shared_ptr<RecordBatch> batch) {
-    scheduler_->Get()->AddSimpleTask([self = this, batch = std::move(batch)]() {
+    file_tasks_->AddSimpleTask([self = this, batch = std::move(batch)]() {
       return self->WriteNext(std::move(batch));
     });
   }
@@ -210,12 +209,11 @@ class DatasetWriterFileQueue {
     while (!staged_batches_.empty()) {
       RETURN_NOT_OK(PopAndDeliverStagedBatch());
     }
-    std::cout << "Closing file scheduler: " << scheduler_->Get() << std::endl;
     // At this point all write tasks have been added.  Because the scheduler
     // is a 1-task FIFO we know this task will run at the very end and can
     // add it now.
-    scheduler_->Get()->AddSimpleTask([this] { return DoFinish(); });
-    scheduler_->Reset();
+    file_tasks_->AddSimpleTask([this] { return DoFinish(); });
+    file_tasks_.reset();
     return Status::OK();
   }
 
@@ -250,7 +248,7 @@ class DatasetWriterFileQueue {
   // point they are merged together and added to write_queue_
   std::deque<std::shared_ptr<RecordBatch>> staged_batches_;
   uint64_t rows_currently_staged_ = 0;
-  std::unique_ptr<util::AsyncTaskScheduler::Holder> scheduler_ = nullptr;
+  std::unique_ptr<util::AsyncTaskGroup> file_tasks_ = nullptr;
 };
 
 struct WriteTask {
@@ -322,27 +320,22 @@ class DatasetWriterDirectoryQueue {
     auto file_queue =
         std::make_unique<DatasetWriterFileQueue>(schema_, write_options_, writer_state_);
     DatasetWriterFileQueue* file_queue_view = file_queue.get();
-    std::unique_ptr<util::AsyncTaskScheduler::Throttle> throttle =
-        util::AsyncTaskScheduler::MakeThrottle(1);
-    util::AsyncTaskScheduler::Throttle* throttle_view = throttle.get();
-    auto file_finish_task = [self = this, file_queue = std::move(file_queue),
-                             throttle = std::move(throttle)](Status) {
-      std::cout << "Ending file scheduler\n";
+    // Create a dedicated throttle for write jobs to this file and keep it alive until we
+    // are finished and have closed the file.
+    std::shared_ptr<util::ThrottledAsyncTaskScheduler> file_throttled =
+        util::ThrottledAsyncTaskScheduler::Make(scheduler_, 1);
+    util::AsyncTaskScheduler* file_throttled_view = file_throttled.get();
+    auto file_finish_task = [self = this, file_throttled = std::move(file_throttled),
+                             file_queue = std::move(file_queue)]() {
       self->writer_state_->open_files_throttle.Release(1);
       return Status::OK();
     };
-    std::unique_ptr<util::AsyncTaskScheduler::Holder> scheduler =
-        scheduler_->MakeSubScheduler(
-            [&](util::AsyncTaskScheduler* file_scheduler) {
-              std::cout << "Created file scheduler: " << file_scheduler << std::endl;
-              if (init_future_.is_valid()) {
-                file_scheduler->AddSimpleTask(
-                    [init_future = init_future_]() { return init_future; });
-              }
-              return Status::OK();
-            },
-            std::move(file_finish_task), throttle_view);
-    file_queue_view->Start(std::move(scheduler), filename);
+    std::unique_ptr<util::AsyncTaskGroup> file_tasks =
+        util::AsyncTaskGroup::Make(file_throttled_view, std::move(file_finish_task));
+    if (init_future_.is_valid()) {
+      file_tasks->AddSimpleTask([init_future = init_future_]() { return init_future; });
+    }
+    file_queue_view->Start(std::move(file_tasks), filename);
     return file_queue_view;
   }
 
@@ -489,15 +482,28 @@ uint64_t CalculateMaxRowsStaged(uint64_t max_rows_queued) {
 
 class DatasetWriter::DatasetWriterImpl {
  public:
-  DatasetWriterImpl(FileSystemDatasetWriteOptions write_options, uint64_t max_rows_queued)
-      : write_options_(std::move(write_options)),
+  DatasetWriterImpl(FileSystemDatasetWriteOptions write_options,
+                    util::AsyncTaskScheduler* scheduler,
+                    std::function<void()> pause_callback,
+                    std::function<void()> resume_callback,
+                    std::function<void()> finish_callback, uint64_t max_rows_queued)
+      : scheduler_(scheduler),
+        write_throttle_(util::ThrottledAsyncTaskScheduler::Make(scheduler_, 1)),
+        write_tasks_(
+            util::AsyncTaskGroup::Make(write_throttle_.get(),
+                                       [finish_callback = std::move(finish_callback)] {
+                                         finish_callback();
+                                         return Status::OK();
+                                       })),
+        write_options_(std::move(write_options)),
         writer_state_(max_rows_queued, write_options_.max_open_files,
-                      CalculateMaxRowsStaged(max_rows_queued)) {}
+                      CalculateMaxRowsStaged(max_rows_queued)),
+        pause_callback_(std::move(pause_callback)),
+        resume_callback_(std::move(resume_callback)) {}
 
-  void Start(util::AsyncTaskScheduler* scheduler) { scheduler_ = scheduler; }
-
-  Future<> WriteRecordBatch(std::shared_ptr<RecordBatch> batch,
-                            const std::string& directory, const std::string& prefix) {
+  Future<> WriteAndCheckBackpressure(std::shared_ptr<RecordBatch> batch,
+                                     const std::string& directory,
+                                     const std::string& prefix) {
     if (batch->num_rows() == 0) {
       return Future<>::MakeFinished();
     }
@@ -510,11 +516,33 @@ class DatasetWriter::DatasetWriterImpl {
     }
   }
 
-  Status Finish() {
-    for (const auto& directory_queue : directory_queues_) {
-      ARROW_RETURN_NOT_OK(directory_queue.second->Finish());
-    }
-    return Status::OK();
+  void WriteRecordBatch(std::shared_ptr<RecordBatch> batch, const std::string& directory,
+                        const std::string& prefix) {
+    write_tasks_->AddSimpleTask([this, batch = std::move(batch), directory,
+                                 prefix]() mutable {
+      Future<> has_room = WriteAndCheckBackpressure(std::move(batch), directory, prefix);
+      if (!has_room.is_finished()) {
+        // We don't have to worry about sequencing backpressure here since
+        // task_group_ serves as our sequencer.  If batches continue to arrive after
+        // we pause they will queue up in task_group_ until we free up and call
+        // Resume
+        pause_callback_();
+        return has_room.Then([this] { resume_callback_(); });
+      }
+      return has_room;
+    });
+  }
+
+  void Finish() {
+    write_tasks_->AddSimpleTask([this]() -> Result<Future<>> {
+      for (const auto& directory_queue : directory_queues_) {
+        ARROW_RETURN_NOT_OK(directory_queue.second->Finish());
+      }
+      // This task is purely synchronous but we add it to write_tasks_ for the throttling
+      // task group benefits.
+      return Future<>::MakeFinished();
+    });
+    write_tasks_.reset();
   }
 
  protected:
@@ -579,8 +607,13 @@ class DatasetWriter::DatasetWriterImpl {
   }
 
   util::AsyncTaskScheduler* scheduler_ = nullptr;
+  std::shared_ptr<util::ThrottledAsyncTaskScheduler> write_throttle_;
+  std::unique_ptr<util::AsyncTaskGroup> write_tasks_;
+  Future<> finish_fut_ = Future<>::Make();
   FileSystemDatasetWriteOptions write_options_;
   DatasetWriterState writer_state_;
+  std::function<void()> pause_callback_;
+  std::function<void()> resume_callback_;
   std::unordered_map<std::string, std::shared_ptr<DatasetWriterDirectoryQueue>>
       directory_queues_;
   std::mutex mutex_;
@@ -588,31 +621,35 @@ class DatasetWriter::DatasetWriterImpl {
 };
 
 DatasetWriter::DatasetWriter(FileSystemDatasetWriteOptions write_options,
+                             util::AsyncTaskScheduler* scheduler,
+                             std::function<void()> pause_callback,
+                             std::function<void()> resume_callback,
+                             std::function<void()> finish_callback,
                              uint64_t max_rows_queued)
-    : impl_(std::make_unique<DatasetWriterImpl>(std::move(write_options),
-                                                max_rows_queued)) {}
+    : impl_(std::make_unique<DatasetWriterImpl>(
+          std::move(write_options), scheduler, std::move(pause_callback),
+          std::move(resume_callback), std::move(finish_callback), max_rows_queued)) {}
 
 Result<std::unique_ptr<DatasetWriter>> DatasetWriter::Make(
-    FileSystemDatasetWriteOptions write_options, uint64_t max_rows_queued) {
+    FileSystemDatasetWriteOptions write_options, util::AsyncTaskScheduler* scheduler,
+    std::function<void()> pause_callback, std::function<void()> resume_callback,
+    std::function<void()> finish_callback, uint64_t max_rows_queued) {
   RETURN_NOT_OK(ValidateOptions(write_options));
   RETURN_NOT_OK(EnsureDestinationValid(write_options));
-  return std::unique_ptr<DatasetWriter>(
-      new DatasetWriter(std::move(write_options), max_rows_queued));
+  return std::unique_ptr<DatasetWriter>(new DatasetWriter(
+      std::move(write_options), scheduler, std::move(pause_callback),
+      std::move(resume_callback), std::move(finish_callback), max_rows_queued));
 }
 
 DatasetWriter::~DatasetWriter() = default;
 
-void DatasetWriter::Start(util::AsyncTaskScheduler* scheduler) {
-  impl_->Start(scheduler);
-}
-
-Future<> DatasetWriter::WriteRecordBatch(std::shared_ptr<RecordBatch> batch,
-                                         const std::string& directory,
-                                         const std::string& prefix) {
+void DatasetWriter::WriteRecordBatch(std::shared_ptr<RecordBatch> batch,
+                                     const std::string& directory,
+                                     const std::string& prefix) {
   return impl_->WriteRecordBatch(std::move(batch), directory, prefix);
 }
 
-Status DatasetWriter::Finish() { return impl_->Finish(); }
+void DatasetWriter::Finish() { impl_->Finish(); }
 
 }  // namespace internal
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/dataset_writer.h
+++ b/cpp/src/arrow/dataset/dataset_writer.h
@@ -50,17 +50,12 @@ class ARROW_DS_EXPORT DatasetWriter {
   /// \param max_rows_queued max # of rows allowed to be queued before the dataset_writer
   ///                        will ask for backpressure
   static Result<std::unique_ptr<DatasetWriter>> Make(
-      FileSystemDatasetWriteOptions write_options,
+      FileSystemDatasetWriteOptions write_options, util::AsyncTaskScheduler* scheduler,
+      std::function<void()> pause_callback, std::function<void()> resume_callback,
+      std::function<void()> finish_callback,
       uint64_t max_rows_queued = kDefaultDatasetWriterMaxRowsQueued);
 
   ~DatasetWriter();
-
-  /// \brief Start the dataset writer
-  ///
-  /// The dataset writer must be started before any batches can be written.
-  ///
-  /// \param scheduler a scheduler that the dataset writer will schedule its tasks on
-  void Start(util::AsyncTaskScheduler* scheduler);
 
   /// \brief Write a batch to the dataset
   /// \param[in] batch The batch to write
@@ -86,14 +81,17 @@ class ARROW_DS_EXPORT DatasetWriter {
   /// 1000 batches go to the same directory and then the 1001st batch goes to a different
   /// directory.  The only way to get two parallel writes immediately would be to queue
   /// all 1000 pending writes to the first directory.
-  Future<> WriteRecordBatch(std::shared_ptr<RecordBatch> batch,
-                            const std::string& directory, const std::string& prefix = "");
+  void WriteRecordBatch(std::shared_ptr<RecordBatch> batch, const std::string& directory,
+                        const std::string& prefix = "");
 
   /// Finish all pending writes and close any open files
-  Status Finish();
+  void Finish();
 
  protected:
   DatasetWriter(FileSystemDatasetWriteOptions write_options,
+                util::AsyncTaskScheduler* scheduler, std::function<void()> pause_callback,
+                std::function<void()> resume_callback,
+                std::function<void()> finish_callback,
                 uint64_t max_rows_queued = kDefaultDatasetWriterMaxRowsQueued);
 
   class DatasetWriterImpl;

--- a/cpp/src/arrow/dataset/dataset_writer.h
+++ b/cpp/src/arrow/dataset/dataset_writer.h
@@ -50,10 +50,17 @@ class ARROW_DS_EXPORT DatasetWriter {
   /// \param max_rows_queued max # of rows allowed to be queued before the dataset_writer
   ///                        will ask for backpressure
   static Result<std::unique_ptr<DatasetWriter>> Make(
-      FileSystemDatasetWriteOptions write_options, util::AsyncTaskScheduler* scheduler,
+      FileSystemDatasetWriteOptions write_options,
       uint64_t max_rows_queued = kDefaultDatasetWriterMaxRowsQueued);
 
   ~DatasetWriter();
+
+  /// \brief Start the dataset writer
+  ///
+  /// The dataset writer must be started before any batches can be written.
+  ///
+  /// \param scheduler a scheduler that the dataset writer will schedule its tasks on
+  void Start(util::AsyncTaskScheduler* scheduler);
 
   /// \brief Write a batch to the dataset
   /// \param[in] batch The batch to write
@@ -87,7 +94,6 @@ class ARROW_DS_EXPORT DatasetWriter {
 
  protected:
   DatasetWriter(FileSystemDatasetWriteOptions write_options,
-                util::AsyncTaskScheduler* scheduler,
                 uint64_t max_rows_queued = kDefaultDatasetWriterMaxRowsQueued);
 
   class DatasetWriterImpl;

--- a/cpp/src/arrow/dataset/dataset_writer_test.cc
+++ b/cpp/src/arrow/dataset/dataset_writer_test.cc
@@ -81,13 +81,18 @@ class DatasetWriterTestFixture : public testing::Test {
     };
     std::shared_ptr<FileFormat> format = std::make_shared<IpcFileFormat>();
     write_options_.file_write_options = format->DefaultWriteOptions();
-    scheduler_ = util::AsyncTaskScheduler::Make();
+    scheduler_finished_ =
+        util::AsyncTaskScheduler::Make([&](util::AsyncTaskScheduler* scheduler) {
+          scheduler_ = scheduler;
+          scheduler->AddSimpleTask([&] { return test_done_with_tasks_; });
+          return Status::OK();
+        });
   }
 
   void EndWriterChecked(DatasetWriter* writer) {
     ASSERT_OK(writer->Finish());
-    scheduler_->End();
-    ASSERT_FINISHES_OK(scheduler_->OnFinished());
+    test_done_with_tasks_.MarkFinished();
+    ASSERT_FINISHES_OK(scheduler_finished_);
   }
 
   std::shared_ptr<fs::GatedMockFilesystem> UseGatedFs() {
@@ -202,14 +207,16 @@ class DatasetWriterTestFixture : public testing::Test {
   std::shared_ptr<Schema> schema_;
   std::vector<std::string> pre_finish_visited_;
   std::vector<std::string> post_finish_visited_;
-  std::unique_ptr<util::AsyncTaskScheduler> scheduler_;
+  Future<> test_done_with_tasks_ = Future<>::Make();
+  util::AsyncTaskScheduler* scheduler_;
+  Future<> scheduler_finished_;
   FileSystemDatasetWriteOptions write_options_;
   uint64_t counter_ = 0;
 };
 
 TEST_F(DatasetWriterTestFixture, Basic) {
-  EXPECT_OK_AND_ASSIGN(auto dataset_writer,
-                       DatasetWriter::Make(write_options_, scheduler_.get()));
+  EXPECT_OK_AND_ASSIGN(auto dataset_writer, DatasetWriter::Make(write_options_));
+  dataset_writer->Start(scheduler_);
   Future<> queue_fut = dataset_writer->WriteRecordBatch(MakeBatch(100), "");
   AssertFinished(queue_fut);
   EndWriterChecked(dataset_writer.get());
@@ -217,8 +224,8 @@ TEST_F(DatasetWriterTestFixture, Basic) {
 }
 
 TEST_F(DatasetWriterTestFixture, BasicFilePrefix) {
-  EXPECT_OK_AND_ASSIGN(auto dataset_writer,
-                       DatasetWriter::Make(write_options_, scheduler_.get()));
+  EXPECT_OK_AND_ASSIGN(auto dataset_writer, DatasetWriter::Make(write_options_));
+  dataset_writer->Start(scheduler_);
   Future<> queue_fut = dataset_writer->WriteRecordBatch(MakeBatch(100), "", "1_");
   AssertFinished(queue_fut);
   EndWriterChecked(dataset_writer.get());
@@ -226,8 +233,8 @@ TEST_F(DatasetWriterTestFixture, BasicFilePrefix) {
 }
 
 TEST_F(DatasetWriterTestFixture, BasicFileDirectoryPrefix) {
-  EXPECT_OK_AND_ASSIGN(auto dataset_writer,
-                       DatasetWriter::Make(write_options_, scheduler_.get()));
+  EXPECT_OK_AND_ASSIGN(auto dataset_writer, DatasetWriter::Make(write_options_));
+  dataset_writer->Start(scheduler_);
   Future<> queue_fut = dataset_writer->WriteRecordBatch(MakeBatch(100), "a", "1_");
   AssertFinished(queue_fut);
   EndWriterChecked(dataset_writer.get());
@@ -237,20 +244,20 @@ TEST_F(DatasetWriterTestFixture, BasicFileDirectoryPrefix) {
 TEST_F(DatasetWriterTestFixture, DirectoryCreateFails) {
   // This should fail to be created
   write_options_.base_dir = "///doesnotexist";
-  EXPECT_OK_AND_ASSIGN(auto dataset_writer,
-                       DatasetWriter::Make(write_options_, scheduler_.get()));
+  EXPECT_OK_AND_ASSIGN(auto dataset_writer, DatasetWriter::Make(write_options_));
+  dataset_writer->Start(scheduler_);
   Future<> queue_fut = dataset_writer->WriteRecordBatch(MakeBatch(100), "a", "1_");
   AssertFinished(queue_fut);
   ASSERT_OK(dataset_writer->Finish());
-  scheduler_->End();
-  ASSERT_FINISHES_AND_RAISES(Invalid, scheduler_->OnFinished());
+  test_done_with_tasks_.MarkFinished();
+  ASSERT_FINISHES_AND_RAISES(Invalid, scheduler_finished_);
 }
 
 TEST_F(DatasetWriterTestFixture, MaxRowsOneWrite) {
   write_options_.max_rows_per_file = 10;
   write_options_.max_rows_per_group = 10;
-  EXPECT_OK_AND_ASSIGN(auto dataset_writer,
-                       DatasetWriter::Make(write_options_, scheduler_.get()));
+  EXPECT_OK_AND_ASSIGN(auto dataset_writer, DatasetWriter::Make(write_options_));
+  dataset_writer->Start(scheduler_);
   Future<> queue_fut = dataset_writer->WriteRecordBatch(MakeBatch(35), "");
   AssertFinished(queue_fut);
   EndWriterChecked(dataset_writer.get());
@@ -263,8 +270,8 @@ TEST_F(DatasetWriterTestFixture, MaxRowsOneWrite) {
 TEST_F(DatasetWriterTestFixture, MaxRowsManyWrites) {
   write_options_.max_rows_per_file = 10;
   write_options_.max_rows_per_group = 10;
-  EXPECT_OK_AND_ASSIGN(auto dataset_writer,
-                       DatasetWriter::Make(write_options_, scheduler_.get()));
+  EXPECT_OK_AND_ASSIGN(auto dataset_writer, DatasetWriter::Make(write_options_));
+  dataset_writer->Start(scheduler_);
   ASSERT_FINISHES_OK(dataset_writer->WriteRecordBatch(MakeBatch(3), ""));
   ASSERT_FINISHES_OK(dataset_writer->WriteRecordBatch(MakeBatch(3), ""));
   ASSERT_FINISHES_OK(dataset_writer->WriteRecordBatch(MakeBatch(3), ""));
@@ -278,8 +285,8 @@ TEST_F(DatasetWriterTestFixture, MaxRowsManyWrites) {
 
 TEST_F(DatasetWriterTestFixture, MinRowGroup) {
   write_options_.min_rows_per_group = 20;
-  EXPECT_OK_AND_ASSIGN(auto dataset_writer,
-                       DatasetWriter::Make(write_options_, scheduler_.get()));
+  EXPECT_OK_AND_ASSIGN(auto dataset_writer, DatasetWriter::Make(write_options_));
+  dataset_writer->Start(scheduler_);
   // Test hitting the limit exactly and inexactly
   ASSERT_FINISHES_OK(dataset_writer->WriteRecordBatch(MakeBatch(5), ""));
   ASSERT_FINISHES_OK(dataset_writer->WriteRecordBatch(MakeBatch(5), ""));
@@ -297,8 +304,8 @@ TEST_F(DatasetWriterTestFixture, MinRowGroup) {
 
 TEST_F(DatasetWriterTestFixture, MaxRowGroup) {
   write_options_.max_rows_per_group = 10;
-  EXPECT_OK_AND_ASSIGN(auto dataset_writer,
-                       DatasetWriter::Make(write_options_, scheduler_.get()));
+  EXPECT_OK_AND_ASSIGN(auto dataset_writer, DatasetWriter::Make(write_options_));
+  dataset_writer->Start(scheduler_);
   // Test hitting the limit exactly and inexactly
   ASSERT_FINISHES_OK(dataset_writer->WriteRecordBatch(MakeBatch(10), ""));
   ASSERT_FINISHES_OK(dataset_writer->WriteRecordBatch(MakeBatch(15), ""));
@@ -311,8 +318,8 @@ TEST_F(DatasetWriterTestFixture, MaxRowGroup) {
 TEST_F(DatasetWriterTestFixture, MinAndMaxRowGroup) {
   write_options_.max_rows_per_group = 10;
   write_options_.min_rows_per_group = 10;
-  EXPECT_OK_AND_ASSIGN(auto dataset_writer,
-                       DatasetWriter::Make(write_options_, scheduler_.get()));
+  EXPECT_OK_AND_ASSIGN(auto dataset_writer, DatasetWriter::Make(write_options_));
+  dataset_writer->Start(scheduler_);
   // Test hitting the limit exactly and inexactly
   ASSERT_FINISHES_OK(dataset_writer->WriteRecordBatch(MakeBatch(10), ""));
   ASSERT_FINISHES_OK(dataset_writer->WriteRecordBatch(MakeBatch(15), ""));
@@ -327,8 +334,8 @@ TEST_F(DatasetWriterTestFixture, MinRowGroupBackpressure) {
   // enough data to form a min row group and we fill up the dataset writer (it should
   // auto-evict)
   write_options_.min_rows_per_group = 10;
-  EXPECT_OK_AND_ASSIGN(auto dataset_writer,
-                       DatasetWriter::Make(write_options_, scheduler_.get(), 100));
+  EXPECT_OK_AND_ASSIGN(auto dataset_writer, DatasetWriter::Make(write_options_, 100));
+  dataset_writer->Start(scheduler_);
   std::vector<ExpectedFile> expected_files;
   for (int i = 0; i < 12; i++) {
     expected_files.push_back({"testdir/" + std::to_string(i) + "/chunk-0.arrow",
@@ -343,8 +350,8 @@ TEST_F(DatasetWriterTestFixture, ConcurrentWritesSameFile) {
   // Use a gated filesystem to queue up many writes behind a file open to make sure the
   // file isn't opened multiple times.
   auto gated_fs = UseGatedFs();
-  EXPECT_OK_AND_ASSIGN(auto dataset_writer,
-                       DatasetWriter::Make(write_options_, scheduler_.get()));
+  EXPECT_OK_AND_ASSIGN(auto dataset_writer, DatasetWriter::Make(write_options_));
+  dataset_writer->Start(scheduler_);
   for (int i = 0; i < 10; i++) {
     Future<> queue_fut = dataset_writer->WriteRecordBatch(MakeBatch(10), "");
     AssertFinished(queue_fut);
@@ -361,8 +368,8 @@ TEST_F(DatasetWriterTestFixture, ConcurrentWritesDifferentFiles) {
   constexpr int NBATCHES = 6;
   auto gated_fs = UseGatedFs();
   std::vector<ExpectedFile> expected_files;
-  EXPECT_OK_AND_ASSIGN(auto dataset_writer,
-                       DatasetWriter::Make(write_options_, scheduler_.get()));
+  EXPECT_OK_AND_ASSIGN(auto dataset_writer, DatasetWriter::Make(write_options_));
+  dataset_writer->Start(scheduler_);
   for (int i = 0; i < NBATCHES; i++) {
     std::string i_str = std::to_string(i);
     expected_files.push_back(ExpectedFile{"testdir/part" + i_str + "/chunk-0.arrow",
@@ -380,8 +387,8 @@ TEST_F(DatasetWriterTestFixture, ConcurrentWritesDifferentFiles) {
 TEST_F(DatasetWriterTestFixture, MaxOpenFiles) {
   auto gated_fs = UseGatedFs();
   write_options_.max_open_files = 2;
-  EXPECT_OK_AND_ASSIGN(auto dataset_writer,
-                       DatasetWriter::Make(write_options_, scheduler_.get()));
+  EXPECT_OK_AND_ASSIGN(auto dataset_writer, DatasetWriter::Make(write_options_));
+  dataset_writer->Start(scheduler_);
 
   ASSERT_FINISHES_OK(dataset_writer->WriteRecordBatch(MakeBatch(10), "part0"));
   ASSERT_FINISHES_OK(dataset_writer->WriteRecordBatch(MakeBatch(10), "part1"));
@@ -412,8 +419,8 @@ TEST_F(DatasetWriterTestFixture, NoExistingDirectory) {
   write_options_.filesystem = filesystem_;
   write_options_.existing_data_behavior = ExistingDataBehavior::kDeleteMatchingPartitions;
   write_options_.base_dir = "testdir/subdir";
-  EXPECT_OK_AND_ASSIGN(auto dataset_writer,
-                       DatasetWriter::Make(write_options_, scheduler_.get()));
+  EXPECT_OK_AND_ASSIGN(auto dataset_writer, DatasetWriter::Make(write_options_));
+  dataset_writer->Start(scheduler_);
   Future<> queue_fut = dataset_writer->WriteRecordBatch(MakeBatch(100), "");
   AssertFinished(queue_fut);
   EndWriterChecked(dataset_writer.get());
@@ -430,8 +437,8 @@ TEST_F(DatasetWriterTestFixture, DeleteExistingData) {
   filesystem_ = std::dynamic_pointer_cast<MockFileSystem>(fs);
   write_options_.filesystem = filesystem_;
   write_options_.existing_data_behavior = ExistingDataBehavior::kDeleteMatchingPartitions;
-  EXPECT_OK_AND_ASSIGN(auto dataset_writer,
-                       DatasetWriter::Make(write_options_, scheduler_.get()));
+  EXPECT_OK_AND_ASSIGN(auto dataset_writer, DatasetWriter::Make(write_options_));
+  dataset_writer->Start(scheduler_);
   Future<> queue_fut = dataset_writer->WriteRecordBatch(MakeBatch(100), "");
   AssertFinished(queue_fut);
   EndWriterChecked(dataset_writer.get());
@@ -449,8 +456,8 @@ TEST_F(DatasetWriterTestFixture, PartitionedDeleteExistingData) {
   filesystem_ = std::dynamic_pointer_cast<MockFileSystem>(fs);
   write_options_.filesystem = filesystem_;
   write_options_.existing_data_behavior = ExistingDataBehavior::kDeleteMatchingPartitions;
-  EXPECT_OK_AND_ASSIGN(auto dataset_writer,
-                       DatasetWriter::Make(write_options_, scheduler_.get()));
+  EXPECT_OK_AND_ASSIGN(auto dataset_writer, DatasetWriter::Make(write_options_));
+  dataset_writer->Start(scheduler_);
   Future<> queue_fut = dataset_writer->WriteRecordBatch(MakeBatch(100), "part0");
   AssertFinished(queue_fut);
   EndWriterChecked(dataset_writer.get());
@@ -469,8 +476,8 @@ TEST_F(DatasetWriterTestFixture, LeaveExistingData) {
   filesystem_ = std::dynamic_pointer_cast<MockFileSystem>(fs);
   write_options_.filesystem = filesystem_;
   write_options_.existing_data_behavior = ExistingDataBehavior::kOverwriteOrIgnore;
-  EXPECT_OK_AND_ASSIGN(auto dataset_writer,
-                       DatasetWriter::Make(write_options_, scheduler_.get()));
+  EXPECT_OK_AND_ASSIGN(auto dataset_writer, DatasetWriter::Make(write_options_));
+  dataset_writer->Start(scheduler_);
   Future<> queue_fut = dataset_writer->WriteRecordBatch(MakeBatch(100), "");
   AssertFinished(queue_fut);
   EndWriterChecked(dataset_writer.get());
@@ -487,7 +494,7 @@ TEST_F(DatasetWriterTestFixture, ErrOnExistingData) {
                      fs::File("testdir/chunk-5.arrow"), fs::File("testdir/blah.txt")}));
   filesystem_ = std::dynamic_pointer_cast<MockFileSystem>(fs);
   write_options_.filesystem = filesystem_;
-  ASSERT_RAISES(Invalid, DatasetWriter::Make(write_options_, scheduler_.get()));
+  ASSERT_RAISES(Invalid, DatasetWriter::Make(write_options_));
   AssertEmptyFiles(
       {"testdir/chunk-0.arrow", "testdir/chunk-5.arrow", "testdir/blah.txt"});
 
@@ -500,7 +507,7 @@ TEST_F(DatasetWriterTestFixture, ErrOnExistingData) {
   filesystem_ = std::dynamic_pointer_cast<MockFileSystem>(fs2);
   write_options_.filesystem = filesystem_;
   write_options_.base_dir = "testdir";
-  ASSERT_RAISES(Invalid, DatasetWriter::Make(write_options_, scheduler_.get()));
+  ASSERT_RAISES(Invalid, DatasetWriter::Make(write_options_));
   AssertEmptyFiles({"testdir/part-0.arrow"});
 }
 

--- a/cpp/src/arrow/dataset/dataset_writer_test.cc
+++ b/cpp/src/arrow/dataset/dataset_writer_test.cc
@@ -89,6 +89,13 @@ class DatasetWriterTestFixture : public testing::Test {
         });
   }
 
+  void TearDown() override {
+    if (!test_done_with_tasks_.is_finished()) {
+      test_done_with_tasks_.MarkFinished();
+      ASSERT_FINISHES_OK(scheduler_finished_);
+    }
+  }
+
   void EndWriterChecked(DatasetWriter* writer) {
     ASSERT_OK(writer->Finish());
     test_done_with_tasks_.MarkFinished();

--- a/cpp/src/arrow/dataset/scan_node.cc
+++ b/cpp/src/arrow/dataset/scan_node.cc
@@ -118,12 +118,7 @@ class ScanNode : public cp::ExecNode {
            std::shared_ptr<Schema> output_schema)
       : cp::ExecNode(plan, {}, {}, std::move(output_schema),
                      /*num_outputs=*/1),
-        options_(options),
-        fragments_throttle_(
-            util::AsyncTaskScheduler::MakeThrottle(options_.fragment_readahead + 1)),
-        batches_throttle_(
-            util::AsyncTaskScheduler::MakeThrottle(options_.target_bytes_readahead + 1)) {
-  }
+        options_(options) {}
 
   static Result<ScanV2Options> NormalizeAndValidate(const ScanV2Options& options,
                                                     compute::ExecContext* ctx) {
@@ -190,7 +185,7 @@ class ScanNode : public cp::ExecNode {
     FragmentScanRequest scan_request;
   };
 
-  struct ScanBatchTask : util::AsyncTaskScheduler::Task {
+  struct ScanBatchTask : public util::AsyncTaskScheduler::Task {
     ScanBatchTask(ScanNode* node, ScanState* scan_state, int batch_index)
         : node_(node), scan_(scan_state), batch_index_(batch_index) {
       int64_t cost = scan_state->fragment_scanner->EstimatedDataBytes(batch_index_);
@@ -202,7 +197,7 @@ class ScanNode : public cp::ExecNode {
           std::min(cost, static_cast<int64_t>(std::numeric_limits<int>::max())));
     }
 
-    Result<Future<>> operator()(util::AsyncTaskScheduler* scheduler) override {
+    Result<Future<>> operator()() override {
       // Prevent concurrent calls to ScanBatch which might not be thread safe
       std::lock_guard<std::mutex> lk(scan_->mutex);
       return scan_->fragment_scanner->ScanBatch(batch_index_)
@@ -235,16 +230,14 @@ class ScanNode : public cp::ExecNode {
     ListFragmentTask(ScanNode* node, std::shared_ptr<Fragment> fragment)
         : node(node), fragment(std::move(fragment)) {}
 
-    Result<Future<>> operator()(util::AsyncTaskScheduler* scheduler) override {
+    Result<Future<>> operator()() override {
       return fragment->InspectFragment().Then(
-          [this,
-           scheduler](const std::shared_ptr<InspectedFragment>& inspected_fragment) {
-            return BeginScan(inspected_fragment, scheduler);
+          [this](const std::shared_ptr<InspectedFragment>& inspected_fragment) {
+            return BeginScan(inspected_fragment);
           });
     }
 
-    Future<> BeginScan(const std::shared_ptr<InspectedFragment>& inspected_fragment,
-                       util::AsyncTaskScheduler* scan_scheduler) {
+    Future<> BeginScan(const std::shared_ptr<InspectedFragment>& inspected_fragment) {
       // Now that we have an inspected fragment we need to use the dataset's evolution
       // strategy to figure out how to scan it
       scan_state->fragment_evolution =
@@ -252,20 +245,18 @@ class ScanNode : public cp::ExecNode {
               *node->options_.dataset, *fragment, *inspected_fragment);
       ARROW_RETURN_NOT_OK(InitFragmentScanRequest());
       return fragment->BeginScan(scan_state->scan_request, *inspected_fragment)
-          .Then([this, scan_scheduler](
-                    const std::shared_ptr<FragmentScanner>& fragment_scanner) {
-            return AddScanTasks(fragment_scanner, scan_scheduler);
+          .Then([this](const std::shared_ptr<FragmentScanner>& fragment_scanner) {
+            return AddScanTasks(fragment_scanner);
           });
     }
 
-    Future<> AddScanTasks(const std::shared_ptr<FragmentScanner>& fragment_scanner,
-                          util::AsyncTaskScheduler* scan_scheduler) {
+    Future<> AddScanTasks(const std::shared_ptr<FragmentScanner>& fragment_scanner) {
       scan_state->fragment_scanner = fragment_scanner;
       ScanState* state_view = scan_state.get();
       Future<> list_and_scan_done = Future<>::Make();
       // Finish callback keeps the scan state alive until all scan tasks done
       struct StateHolder {
-        Status operator()(Status) {
+        Status operator()() {
           list_and_scan_done.MarkFinished();
           return Status::OK();
         }
@@ -273,17 +264,14 @@ class ScanNode : public cp::ExecNode {
         std::unique_ptr<ScanState> scan_state;
       };
 
-      scan_scheduler->MakeSubScheduler(
-          [&](util::AsyncTaskScheduler* frag_scheduler) {
-            for (int i = 0; i < fragment_scanner->NumBatches(); i++) {
-              node->num_batches_.fetch_add(1);
-              frag_scheduler->AddTask(
-                  std::make_unique<ScanBatchTask>(node, state_view, i));
-            }
-            return Status::OK();
-          },
-          StateHolder{list_and_scan_done, std::move(scan_state)},
-          node->batches_throttle_.get());
+      std::unique_ptr<util::AsyncTaskGroup> scan_tasks = util::AsyncTaskGroup::Make(
+          node->batches_throttle_.get(),
+          StateHolder{list_and_scan_done, std::move(scan_state)});
+      for (int i = 0; i < fragment_scanner->NumBatches(); i++) {
+        node->num_batches_.fetch_add(1);
+        scan_tasks->AddTask(std::make_unique<ScanBatchTask>(node, state_view, i));
+      }
+      return Status::OK();
       // The "list fragments" task doesn't actually end until the fragments are
       // all scanned.  This allows us to enforce fragment readahead.
       return list_and_scan_done;
@@ -320,26 +308,26 @@ class ScanNode : public cp::ExecNode {
                         {"node.output_schema", output_schema()->ToString()},
                         {"node.detail", ToString()}});
     END_SPAN_ON_FUTURE_COMPLETION(span_, finished_);
+    fragments_throttle_ = util::ThrottledAsyncTaskScheduler::Make(
+        plan_->async_scheduler(), options_.fragment_readahead + 1);
+    batches_throttle_ = util::ThrottledAsyncTaskScheduler::Make(
+        plan_->async_scheduler(), options_.target_bytes_readahead + 1);
     AsyncGenerator<std::shared_ptr<Fragment>> frag_gen =
         GetFragments(options_.dataset.get(), options_.filter);
-    plan_->async_scheduler()->MakeSubScheduler(
-        [&](util::AsyncTaskScheduler* scan_scheduler) {
-          scan_scheduler->AddAsyncGenerator<std::shared_ptr<Fragment>>(
-              std::move(frag_gen),
-              [this, scan_scheduler](const std::shared_ptr<Fragment>& fragment) {
-                scan_scheduler->AddTask(
-                    std::make_unique<ListFragmentTask>(this, fragment));
-                return Status::OK();
-              },
-              [](Status) { return Status::OK(); });
-          return Status::OK();
-        },
-        [this](Status st) {
+    std::shared_ptr<util::AsyncTaskGroup> fragment_tasks =
+        util::AsyncTaskGroup::Make(fragments_throttle_.get(), [this]() {
           outputs_[0]->InputFinished(this, num_batches_.load());
           finished_.MarkFinished();
           return Status::OK();
+        });
+    fragment_tasks->AddAsyncGenerator<std::shared_ptr<Fragment>>(
+        std::move(frag_gen),
+        [this, fragment_tasks =
+                   std::move(fragment_tasks)](const std::shared_ptr<Fragment>& fragment) {
+          fragment_tasks->AddTask(std::make_unique<ListFragmentTask>(this, fragment));
+          return Status::OK();
         },
-        fragments_throttle_.get());
+        []() { return Status::OK(); });
     return Status::OK();
   }
 
@@ -361,8 +349,8 @@ class ScanNode : public cp::ExecNode {
  private:
   ScanV2Options options_;
   std::atomic<int> num_batches_{0};
-  std::unique_ptr<util::AsyncTaskScheduler::Throttle> fragments_throttle_;
-  std::unique_ptr<util::AsyncTaskScheduler::Throttle> batches_throttle_;
+  std::shared_ptr<util::ThrottledAsyncTaskScheduler> fragments_throttle_;
+  std::shared_ptr<util::ThrottledAsyncTaskScheduler> batches_throttle_;
 };
 
 }  // namespace

--- a/cpp/src/arrow/engine/substrait/function_test.cc
+++ b/cpp/src/arrow/engine/substrait/function_test.cc
@@ -147,8 +147,7 @@ void CheckErrorTestCases(const std::vector<FunctionTestCase>& error_cases) {
     std::shared_ptr<Table> output_table;
     ASSERT_OK_AND_ASSIGN(std::shared_ptr<compute::ExecPlan> plan,
                          PlanFromTestCase(test_case, &output_table));
-    ASSERT_OK(plan->StartProducing());
-    ASSERT_FINISHES_AND_RAISES(Invalid, plan->finished());
+    ASSERT_RAISES(Invalid, plan->StartProducing());
   }
 }
 

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -103,7 +103,8 @@ Result<std::shared_ptr<Table>> GetTableFromPlan(
 
 class NullSinkNodeConsumer : public compute::SinkNodeConsumer {
  public:
-  Status Init(const std::shared_ptr<Schema>&, compute::BackpressureControl*) override {
+  Status Init(const std::shared_ptr<Schema>&, compute::BackpressureControl*,
+              compute::ExecPlan* plan) override {
     return Status::OK();
   }
   Status Consume(compute::ExecBatch exec_batch) override { return Status::OK(); }

--- a/cpp/src/arrow/engine/substrait/util.cc
+++ b/cpp/src/arrow/engine/substrait/util.cc
@@ -43,7 +43,8 @@ class SubstraitSinkConsumer : public compute::SinkNodeConsumer {
   }
 
   Status Init(const std::shared_ptr<Schema>& schema,
-              compute::BackpressureControl* backpressure_control) override {
+              compute::BackpressureControl* backpressure_control,
+              compute::ExecPlan* plan) override {
     schema_ = schema;
     return Status::OK();
   }

--- a/cpp/src/arrow/flight/sql/example/acero_server.cc
+++ b/cpp/src/arrow/flight/sql/example/acero_server.cc
@@ -40,8 +40,8 @@ namespace {
 ///   fulfill the Flight SQL API contract.
 class GetSchemaSinkNodeConsumer : public compute::SinkNodeConsumer {
  public:
-  Status Init(const std::shared_ptr<Schema>& schema,
-              compute::BackpressureControl*) override {
+  Status Init(const std::shared_ptr<Schema>& schema, compute::BackpressureControl*,
+              compute::ExecPlan* plan) override {
     schema_ = schema;
     return Status::OK();
   }
@@ -62,8 +62,8 @@ class QueuingSinkNodeConsumer : public compute::SinkNodeConsumer {
  public:
   QueuingSinkNodeConsumer() : schema_(nullptr), finished_(false) {}
 
-  Status Init(const std::shared_ptr<Schema>& schema,
-              compute::BackpressureControl*) override {
+  Status Init(const std::shared_ptr<Schema>& schema, compute::BackpressureControl*,
+              compute::ExecPlan* plan) override {
     schema_ = schema;
     return Status::OK();
   }

--- a/cpp/src/arrow/util/async_util.cc
+++ b/cpp/src/arrow/util/async_util.cc
@@ -117,12 +117,6 @@ class FifoQueue : public ThrottledAsyncTaskScheduler::Queue {
   std::list<std::unique_ptr<Task>> tasks_;
 };
 
-class AlreadyFailedScheduler : public AsyncTaskScheduler {
- public:
-  explicit AlreadyFailedScheduler(Status failure_reason) {}
-  bool AddTask(std::unique_ptr<Task> task) override { return false; }
-};
-
 class AsyncTaskSchedulerImpl : public AsyncTaskScheduler {
  public:
   using Task = AsyncTaskScheduler::Task;

--- a/cpp/src/arrow/util/async_util.cc
+++ b/cpp/src/arrow/util/async_util.cc
@@ -129,7 +129,7 @@ class AlreadyFailedScheduler : public AsyncTaskScheduler {
  private:
   class HolderImpl : public AsyncTaskScheduler::Holder {
    public:
-    HolderImpl(std::unique_ptr<AlreadyFailedScheduler> scheduler)
+    explicit HolderImpl(std::unique_ptr<AlreadyFailedScheduler> scheduler)
         : scheduler_(std::move(scheduler)) {}
     ~HolderImpl() override { scheduler_.reset(); }
     void Reset() override { scheduler_.reset(); }
@@ -407,7 +407,7 @@ class AsyncTaskSchedulerImpl : public AsyncTaskScheduler {
 
   class HolderImpl : public AsyncTaskScheduler::Holder {
    public:
-    HolderImpl(std::weak_ptr<AsyncTaskSchedulerImpl> scheduler)
+    explicit HolderImpl(std::weak_ptr<AsyncTaskSchedulerImpl> scheduler)
         : scheduler_(std::move(scheduler)) {}
     ~HolderImpl() override { EndIfNeeded(); }
     void Reset() override { EndIfNeeded(); }

--- a/cpp/src/arrow/util/async_util.h
+++ b/cpp/src/arrow/util/async_util.h
@@ -153,7 +153,7 @@ class ARROW_EXPORT AsyncTaskScheduler {
                        StopToken stop_token = StopToken::Unstoppable());
 };
 
-class ThrottledAsyncTaskScheduler : public AsyncTaskScheduler {
+class ARROW_EXPORT ThrottledAsyncTaskScheduler : public AsyncTaskScheduler {
  public:
   /// An interface for a task queue
   ///
@@ -263,7 +263,7 @@ class ThrottledAsyncTaskScheduler : public AsyncTaskScheduler {
 /// For example, when scanning, we need to keep the file reader alive while all scan
 /// tasks run for a given file, and then we can gracefully close it when we finish the
 /// file.
-class AsyncTaskGroup : public AsyncTaskScheduler {
+class ARROW_EXPORT AsyncTaskGroup : public AsyncTaskScheduler {
  public:
   /// Destructor for the task group
   ///

--- a/cpp/src/arrow/util/async_util.h
+++ b/cpp/src/arrow/util/async_util.h
@@ -53,7 +53,7 @@ namespace util {
 /// a simple task group.
 ///
 /// A task scheduler starts with an initial task.  That task, and all subsequent tasks
-/// are free to add subtasks.  Once all submitted tasks finsih the scheduler will
+/// are free to add subtasks.  Once all submitted tasks finish the scheduler will
 /// finish.  Note, it is not an error to add additional tasks after a scheduler has
 /// aborted. These tasks will be ignored and never submitted.  The scheduler returns a
 /// future which will complete when all submitted tasks have finished executing.  Once all

--- a/cpp/src/arrow/util/async_util.h
+++ b/cpp/src/arrow/util/async_util.h
@@ -234,8 +234,6 @@ class ARROW_EXPORT ThrottledAsyncTaskScheduler : public AsyncTaskScheduler {
   /// Tasks added via this view will be subjected to the throttle and, if the tasks cannot
   /// run immediately, will be placed into a queue.
   ///
-  /// Using a throttled view after the underlying scheduler has finished is invalid.
-  ///
   /// Although a shared_ptr is returned it should generally be assumed that the caller
   /// is being given exclusive ownership.  The shared_ptr is used to share the view with
   /// queued and submitted tasks and the lifetime of those is unpredictable.  It is
@@ -282,9 +280,6 @@ class ARROW_EXPORT AsyncTaskGroup : public AsyncTaskScheduler {
  public:
   /// Destructor for the task group
   ///
-  /// The finish callback will not run until the task group is destroyed and all
-  /// tasks are finished so you will generally want to eagerly call this at some point
-  ///
   /// The destructor might trigger the finish callback.  If the finish callback fails
   /// then the error will be reported as a task on the scheduler.
   ///
@@ -295,6 +290,10 @@ class ARROW_EXPORT AsyncTaskGroup : public AsyncTaskScheduler {
   /// If the scheduler has aborted then the finish callback will not run.
   ~AsyncTaskGroup() = default;
   /// Create an async task group
+  ///
+  /// The finish callback will not run until the task group is destroyed and all
+  /// tasks are finished so you will generally want to reset / destroy the returned
+  /// unique_ptr at some point.
   ///
   /// \param scheduler The underlying scheduler to submit tasks to
   /// \param finish_callback A callback that will be run only after the task group has

--- a/cpp/src/arrow/util/async_util.h
+++ b/cpp/src/arrow/util/async_util.h
@@ -319,7 +319,7 @@ class ARROW_EXPORT AsyncTaskGroup : public AsyncTaskScheduler {
 /// \param queue the queue to use when tasks cannot be submitted
 /// \param finish_callback A callback that will be run only after the task group has
 ///                  been destroyed and all tasks added by the group have finished
-std::unique_ptr<ThrottledAsyncTaskScheduler> MakeThrottledAsyncTaskGroup(
+ARROW_EXPORT std::unique_ptr<ThrottledAsyncTaskScheduler> MakeThrottledAsyncTaskGroup(
     AsyncTaskScheduler* target, int max_concurrent_cost,
     std::unique_ptr<ThrottledAsyncTaskScheduler::Queue> queue,
     FnOnce<Status()> finish_callback);

--- a/cpp/src/arrow/util/async_util.h
+++ b/cpp/src/arrow/util/async_util.h
@@ -19,6 +19,7 @@
 
 #include <atomic>
 #include <functional>
+#include <list>
 #include <memory>
 
 #include "arrow/result.h"
@@ -49,46 +50,25 @@ namespace util {
 /// By default the scheduler will submit the task (execute the synchronous part) as
 /// soon as it is added, assuming the underlying thread pool hasn't terminated or the
 /// scheduler hasn't aborted.  In this mode, the scheduler is simply acting as
-/// a task group (keeping track of the ongoing work).
-///
-/// This can be used to provide structured concurrency for asynchronous development.
-/// A task group created at a high level can be distributed amongst low level components
-/// which register work to be completed.  The high level job can then wait for all work
-/// to be completed before cleaning up.
+/// a simple task group.
 ///
 /// A task scheduler starts with an initial task.  That task, and all subsequent tasks
 /// are free to add subtasks.  Once all submitted tasks finsih the scheduler will
 /// finish.  Note, it is not an error to add additional tasks after a scheduler has
-/// aborted. These tasks will be ignored and never submitted.  The scheduler has a future
-/// which will complete all submitted tasks have finished executing.  Once all tasks have
-/// been finsihed the scheduler should no longer be used in any capacity.
+/// aborted. These tasks will be ignored and never submitted.  The scheduler returns a
+/// future which will complete when all submitted tasks have finished executing.  Once all
+/// tasks have been finsihed the scheduler is invalid and should no longer be used.
 ///
 /// Task failure (either the synchronous portion or the asynchronous portion) will cause
 /// the scheduler to enter an aborted state.  The first such failure will be reported in
 /// the final task future.
-///
-/// It is also possible to limit the number of concurrent tasks the scheduler will
-/// execute. This is done by setting a throttle.  The throttle initially assumes all
-/// tasks are equal but a custom cost can be supplied when scheduling a task (e.g. based
-/// on the total I/O cost of the task, or the expected RAM utilization of the task)
-///
-/// When the total number of running tasks is limited then scheduler priority may also
-/// become a consideration.  By default the scheduler runs with a FIFO queue but a custom
-/// task queue can be provided.  One could, for example, use a priority queue to control
-/// the order in which tasks are executed.
-///
-/// It is common to have multiple stages of execution.  For example, when scanning, we
-/// first inspect each fragment (the inspect stage) to figure out the row groups and then
-/// we scan row groups (the scan stage) to read in the data.  This sort of multi-stage
-/// execution should be represented as two seperate task groups.  The first task group can
-/// then have a custom finish callback which ends the second task group.
 class ARROW_EXPORT AsyncTaskScheduler {
  public:
   /// Destructor for AsyncTaskScheduler
   ///
   /// The lifetime of the task scheduled is managed automatically.  The scheduler
   /// will remain valid while any tasks are running (and can always be safely accessed)
-  /// within tasks) and will be destroyed as soon as all tasks have finsihed.
+  /// within tasks) and will be destroyed as soon as all tasks have finished.
   virtual ~AsyncTaskScheduler() = default;
   /// An interface for a task
   ///
@@ -105,16 +85,76 @@ class ARROW_EXPORT AsyncTaskScheduler {
     /// resource (e.g. I/O thread pool).
     ///
     /// If this call fails then the scheduler will enter an aborted state.
-    virtual Result<Future<>> operator()(AsyncTaskScheduler* scheduler) = 0;
+    virtual Result<Future<>> operator()() = 0;
     /// The cost of the task
     ///
-    /// The scheduler limits the total number of concurrent tasks based
-    /// on cost.  A custom cost may be used, for example, if you would like
-    /// to limit the number of tasks based on the total expected RAM usage of
-    /// the tasks (this is done in the scanner)
+    /// A ThrottledAsyncTaskScheduler can be used to limit the number of concurrent tasks.
+    /// A custom cost may be used, for example, if you would like to limit the number of
+    /// tasks based on the total expected RAM usage of the tasks (this is done in the
+    /// scanner)
     virtual int cost() const { return 1; }
   };
 
+  /// Add a task to the scheduler
+  ///
+  /// If the scheduler is in an aborted state this call will return false and the task
+  /// will never be run.  This is harmless and does not need to be guarded against.
+  ///
+  /// The return value for this call can usually be ignored.  There is little harm in
+  /// attempting to add tasks to an aborted scheduler.  It is only included for callers
+  /// that want to avoid future task generation to save effort.
+  ///
+  /// \return true if the task was submitted or queued, false if the task was ignored
+  virtual bool AddTask(std::unique_ptr<Task> task) = 0;
+
+  /// Adds an async generator to the scheduler
+  ///
+  /// The async generator will be visited, one item at a time.  Submitting a task
+  /// will consist of polling the generator for the next future.  The generator's future
+  /// will then represent the task itself.
+  ///
+  /// This visits the task serially without readahead.  If readahead or parallelism
+  /// is desired then it should be added in the generator itself.
+  ///
+  /// The generator itself will be kept alive until all tasks have been completed.
+  /// However, if the scheduler is aborted, the generator will be destroyed as soon as the
+  /// next item would be requested.
+  template <typename T>
+  bool AddAsyncGenerator(std::function<Future<T>()> generator,
+                         std::function<Status(const T&)> visitor,
+                         FnOnce<Status()> finish_callback);
+
+  template <typename Callable>
+  struct SimpleTask : public Task {
+    explicit SimpleTask(Callable callable) : callable(std::move(callable)) {}
+    Result<Future<>> operator()() override { return callable(); }
+    Callable callable;
+  };
+
+  /// Add a task with cost 1 to the scheduler
+  ///
+  /// \see AddTask for details
+  template <typename Callable>
+  bool AddSimpleTask(Callable callable) {
+    return AddTask(std::make_unique<SimpleTask<Callable>>(std::move(callable)));
+  }
+
+  /// Construct a scheduler
+  ///
+  /// \param initial_task The initial task which is responsible for adding
+  ///        the first subtasks to the scheduler.
+  /// \param stop_token An optional stop token that will allow cancellation of the
+  ///        scheduler.  This will be checked before each task is submitted and, in the
+  ///        event of a cancellation, the scheduler will enter an aborted state. This is
+  ///        a graceful cancellation and submitted tasks will still complete.
+  /// \return A future that will be completed when the initial task and all subtasks have
+  ///         finished.
+  static Future<> Make(FnOnce<Status(AsyncTaskScheduler*)> initial_task,
+                       StopToken stop_token = StopToken::Unstoppable());
+};
+
+class ThrottledAsyncTaskScheduler : public AsyncTaskScheduler {
+ public:
   /// An interface for a task queue
   ///
   /// A queue's methods will not be called concurrently
@@ -152,225 +192,179 @@ class ARROW_EXPORT AsyncTaskScheduler {
     /// The size of the largest task that can run
     ///
     /// Incoming tasks will have their cost latched to this value to ensure
-    /// they can still run (although they will generally be the only thing allowed to
+    /// they can still run (although they will be the only thing allowed to
     /// run at that time).
     virtual int Capacity() = 0;
+
+    /// Pause the throttle
+    ///
+    /// Any tasks that have been submitted already will continue.  However, no new tasks
+    /// will be run until the throttle is resumed.
+    virtual void Pause() = 0;
+    /// Resume the throttle
+    ///
+    /// Allows taks to be submitted again.  If there is a max_concurrent_cost limit then
+    /// it will still apply.
+    virtual void Resume() = 0;
   };
-  /// Create a throttle
-  ///
-  /// This throttle is used to limit how many tasks can run at once.  The
-  /// user should keep the throttle alive for the lifetime of the scheduler.
-  /// The same throttle can be used in multiple schedulers.
-  static std::unique_ptr<Throttle> MakeThrottle(int max_concurrent_cost);
 
-  /// Add a task to the scheduler
+  /// Pause the throttle
   ///
-  /// If the scheduler is in an aborted state this call will return false and the task
-  /// will never be run.  This is harmless and does not need to be guarded against.
+  /// Any tasks that have been submitted already will continue.  However, no new tasks
+  /// will be run until the throttle is resumed.
+  virtual void Pause() = 0;
+  /// Resume the throttle
   ///
-  /// If there are no limits on the number of concurrent tasks then the submit function
-  /// will be run immediately.
-  ///
-  /// Otherwise, if there is a throttle, and it is full, then this task will be inserted
-  /// into the scheduler's queue and submitted later when there is space.
-  ///
-  /// The return value for this call can usually be ignored.  There is little harm in
-  /// attempting to add tasks to an aborted scheduler.  It is only included for callers
-  /// that want to avoid future task generation.
-  ///
-  /// \return true if the task was submitted or queued, false if the task was ignored
-  virtual bool AddTask(std::unique_ptr<Task> task) = 0;
+  /// Allows taks to be submitted again.  If there is a max_concurrent_cost limit then
+  /// it will still apply.
+  virtual void Resume() = 0;
 
-  /// Adds an async generator to the scheduler
+  /// Create a throttled view of a scheduler
   ///
-  /// The async generator will be visited, one item at a time.  Submitting a task
-  /// will consist of polling the generator for the next future.  The generator's future
-  /// will then represent the task itself.
+  /// Tasks added via this view will be subjected to the throttle and, if the tasks cannot
+  /// run immediately, will be placed into a queue.
   ///
-  /// This visits the task serially without readahead.  If readahead or parallelism
-  /// is desired then it should be added in the generator itself.
+  /// Using a throttled view after the underlying scheduler has finished is invalid.
   ///
-  /// The tasks will be submitted to a subscheduler which will be ended when the generator
-  /// is exhausted.
+  /// Although a shared_ptr is returned it should generally be assumed that the caller
+  /// is being given exclusive ownership.  The shared_ptr is used to share the view with
+  /// queued and submitted tasks and the lifetime of those is unpredictable.  It is
+  /// important the caller keep the returned pointer alive for as long as they plan to add
+  /// tasks to the view.
   ///
-  /// The generator itself will be kept alive until all tasks have been completed.
-  /// However, if the scheduler is aborted, the generator will be destroyed as soon as the
-  /// next item would be requested.
-  template <typename T>
-  bool AddAsyncGenerator(std::function<Future<T>()> generator,
-                         std::function<Status(const T&)> visitor,
-                         FnOnce<Status(Status)> finish_callback) {
-    struct State {
-      State(std::function<Future<T>()> generator, std::function<Status(const T&)> visitor,
-            AsyncTaskScheduler* scheduler)
-          : generator(std::move(generator)),
-            visitor(std::move(visitor)),
-            scheduler(scheduler) {}
-      std::function<Future<T>()> generator;
-      std::function<Status(const T&)> visitor;
-      AsyncTaskScheduler* scheduler;
-    };
-    struct SubmitTask : public Task {
-      explicit SubmitTask(std::unique_ptr<State> state_holder)
-          : state_holder(std::move(state_holder)) {}
+  /// \param max_concurrent_cost The maximum amount of cost allowed to run at any one time
+  ///
+  /// If a task is added that has a cost greater than max_concurrent_cost then its cost
+  /// will be reduced to max_concurrent_cost so that it is still possible for the task to
+  /// run.
+  ///
+  /// \param queue The queue to use when tasks cannot be submitted
+  ///
+  /// By default a FIFO queue will be used.  However, a custom queue can be provided if
+  /// some tasks have higher priority than other tasks.
+  static std::shared_ptr<ThrottledAsyncTaskScheduler> Make(
+      AsyncTaskScheduler* scheduler, int max_concurrent_cost,
+      std::unique_ptr<Queue> queue = NULLPTR);
 
-      struct SubmitTaskCallback {
-        SubmitTaskCallback(std::unique_ptr<State> state_holder, Future<> task_completion)
-            : state_holder(std::move(state_holder)),
-              task_completion(std::move(task_completion)) {}
-        void operator()(const Result<T>& maybe_item) {
-          if (!maybe_item.ok()) {
-            task_completion.MarkFinished(maybe_item.status());
-            return;
-          }
-          const auto& item = *maybe_item;
-          if (IsIterationEnd(item)) {
-            task_completion.MarkFinished();
-            return;
-          }
-          Status visit_st = state_holder->visitor(item);
-          if (!visit_st.ok()) {
-            task_completion.MarkFinished(std::move(visit_st));
-            return;
-          }
-          state_holder->scheduler->AddTask(
-              std::make_unique<SubmitTask>(std::move(state_holder)));
+  /// @brief Create a ThrottledAsyncTaskScheduler using a custom throttle
+  ///
+  /// \see Make
+  static std::shared_ptr<ThrottledAsyncTaskScheduler> MakeWithCustomThrottle(
+      AsyncTaskScheduler* scheduler, std::unique_ptr<Throttle> throttle,
+      std::unique_ptr<Queue> queue = NULLPTR);
+};
+
+/// A utility to keep track of a collection of tasks
+///
+/// Often it is useful to keep track of some state that only needs to stay alive
+/// for some small collection of tasks, or to perform some kind of final cleanup
+/// when a collection of tasks is finished.
+///
+/// For example, when scanning, we need to keep the file reader alive while all scan
+/// tasks run for a given file, and then we can gracefully close it when we finish the
+/// file.
+class AsyncTaskGroup : public AsyncTaskScheduler {
+ public:
+  /// Destructor for the task group
+  ///
+  /// The finish callback will not run until the task group is destroyed and all
+  /// tasks are finished so you will generally want to eagerly call this at some point
+  ///
+  /// The destructor might trigger the finish callback.  If the finish callback fails
+  /// then the error will be reported as a task on the scheduler.
+  ///
+  /// Failure to destroy the async task group will not prevent the scheduler from
+  /// finishing.  If the scheduler finishes before the async task group is done then
+  /// the finish callback will be run immediately when the async task group finishes.
+  ///
+  /// If the scheduler has aborted then the finish callback will not run.
+  ~AsyncTaskGroup() = default;
+  /// Create an async task group
+  ///
+  /// \param scheduler The underlying scheduler to submit tasks to
+  /// \param finish_callback A callback that will be run only after the task group has
+  ///                        been destroyed and all tasks added by the group have
+  ///                        finished.
+  ///
+  /// Note: in error scenarios the finish callback may not run.  However, it will still,
+  /// of course, be destroyed.
+  static std::unique_ptr<AsyncTaskGroup> Make(AsyncTaskScheduler* scheduler,
+                                              FnOnce<Status()> finish_callback);
+};
+
+template <typename T>
+bool AsyncTaskScheduler::AddAsyncGenerator(std::function<Future<T>()> generator,
+                                           std::function<Status(const T&)> visitor,
+                                           FnOnce<Status()> finish_callback) {
+  struct State {
+    State(std::function<Future<T>()> generator, std::function<Status(const T&)> visitor,
+          std::unique_ptr<AsyncTaskGroup> task_group)
+        : generator(std::move(generator)),
+          visitor(std::move(visitor)),
+          task_group(std::move(task_group)) {}
+    std::function<Future<T>()> generator;
+    std::function<Status(const T&)> visitor;
+    std::unique_ptr<AsyncTaskGroup> task_group;
+  };
+  struct SubmitTask : public Task {
+    explicit SubmitTask(std::unique_ptr<State> state_holder)
+        : state_holder(std::move(state_holder)) {}
+
+    struct SubmitTaskCallback {
+      SubmitTaskCallback(std::unique_ptr<State> state_holder, Future<> task_completion)
+          : state_holder(std::move(state_holder)),
+            task_completion(std::move(task_completion)) {}
+      void operator()(const Result<T>& maybe_item) {
+        if (!maybe_item.ok()) {
+          task_completion.MarkFinished(maybe_item.status());
+          return;
+        }
+        const auto& item = *maybe_item;
+        if (IsIterationEnd(item)) {
           task_completion.MarkFinished();
+          return;
         }
-        std::unique_ptr<State> state_holder;
-        Future<> task_completion;
-      };
-
-      Result<Future<>> operator()(AsyncTaskScheduler* scheduler) {
-        Future<> task = Future<>::Make();
-        // Consume as many items as we can (those that are already finished)
-        // synchronously to avoid recursion / stack overflow.
-        while (true) {
-          Future<T> next = state_holder->generator();
-          if (next.TryAddCallback(
-                  [&] { return SubmitTaskCallback(std::move(state_holder), task); })) {
-            return task;
-          }
-          ARROW_ASSIGN_OR_RAISE(T item, next.result());
-          if (IsIterationEnd(item)) {
-            task.MarkFinished();
-            return task;
-          }
-          ARROW_RETURN_NOT_OK(state_holder->visitor(item));
+        Status visit_st = state_holder->visitor(item);
+        if (!visit_st.ok()) {
+          task_completion.MarkFinished(std::move(visit_st));
+          return;
         }
+        state_holder->task_group->AddTask(
+            std::make_unique<SubmitTask>(std::move(state_holder)));
+        task_completion.MarkFinished();
       }
       std::unique_ptr<State> state_holder;
+      Future<> task_completion;
     };
-    MakeSubScheduler(
-        [&](AsyncTaskScheduler* generator_scheduler) {
-          std::unique_ptr<State> state_holder = std::make_unique<State>(
-              std::move(generator), std::move(visitor), generator_scheduler);
-          generator_scheduler->AddTask(
-              std::make_unique<SubmitTask>(std::move(state_holder)));
-          return Status::OK();
-        },
-        std::move(finish_callback));
-    return true;
-  }
 
-  template <typename Callable>
-  struct SimpleTask : public Task {
-    explicit SimpleTask(Callable callable) : callable(std::move(callable)) {}
-    Result<Future<>> operator()(AsyncTaskScheduler* scheduler) override {
-      return callable();
+    Result<Future<>> operator()() {
+      Future<> task = Future<>::Make();
+      // Consume as many items as we can (those that are already finished)
+      // synchronously to avoid recursion / stack overflow.
+      while (true) {
+        Future<T> next = state_holder->generator();
+        if (next.TryAddCallback(
+                [&] { return SubmitTaskCallback(std::move(state_holder), task); })) {
+          return task;
+        }
+        ARROW_ASSIGN_OR_RAISE(T item, next.result());
+        if (IsIterationEnd(item)) {
+          task.MarkFinished();
+          return task;
+        }
+        ARROW_RETURN_NOT_OK(state_holder->visitor(item));
+      }
     }
-    Callable callable;
+    std::unique_ptr<State> state_holder;
   };
-
-  template <typename Callable>
-  bool AddSimpleTask(Callable callable) {
-    return AddTask(std::make_unique<SimpleTask<Callable>>(std::move(callable)));
-  }
-
-  class Holder {
-   public:
-    Holder() = default;
-    virtual ~Holder() = default;
-    ARROW_DEFAULT_MOVE_AND_ASSIGN(Holder);
-    ARROW_DISALLOW_COPY_AND_ASSIGN(Holder);
-    virtual void Reset() = 0;
-    virtual AsyncTaskScheduler* Get() = 0;
-  };
-
-  /// Create a sub-scheduler for tracking a subset of tasks
-  ///
-  /// The parent scheduler will manage the lifetime of the sub-scheduler.  It will
-  /// be destroyed once it is finished.
-  ///
-  /// Often some state needs to be associated with a subset of tasks.
-  /// For example, when scanning a dataset we need to keep a file reader
-  /// alive for all of the read tasks for each file. A sub-scheduler can be used to do
-  /// this.
-  ///
-  /// This method returns a control that can be used to manage the lifetime of the
-  /// sub-scheduler.  Callers are free to ignore this return value and the sub-scheduler
-  /// will end when it runs out of tasks.  However, there are times when the full set of
-  /// tasks is not known in advance.  For example, when writing a dataset to a file we
-  /// create a sub-scheduler for the file.  We do not know how many batches will be
-  /// written to a file and there may be long gaps when we have no batches to write to the
-  /// file (and thus no tasks in the scheduler).  In this case a reference to the
-  /// holder can be used to keep the sub-scheduler alive.
-  ///
-  /// Eagerly resetting the returned holder is always optional.  The returned holder will
-  /// not keep the sub-scheduler alive longer than the parent scheduler.  Once the parent
-  /// and child scheduler have run out of tasks the sub-scheduler will be destroyed (the
-  /// holder will be invalidated and can still safely be destroyed after this).
-  ///
-  /// To summarize:
-  ///
-  ///   Ignored holder: The sub-scheduler will end as soon as the initial task (and all
-  ///                   subsequent child tasks) finish.  Use this if you know all the work
-  ///                   that needs to be done up front.
-  ///   Holder kept "forever": The sub-scheduler will be destroyed when the parent
-  ///                   scheduler is destroyed.  Do this for a "peer" scheduler whose
-  ///                   lifetime is the same as the parent but has a special queue or
-  ///                   throttle.
-  ///   Holder eagerly reset: The sub-scheduler will be destroyed as soon as it runs out
-  ///                   of tasks after the holder is reset.  This is done in the file
-  ///                   writing example above when we realize we have finished with a file
-  ///                   because we hit the max rows limit (which might happen well before
-  ///                   the plan ends) so that we can close the file once all remaining
-  ///                   write tasks wrap up.
-  ///
-  /// If either the parent scheduler or the sub-scheduler encounter an error
-  /// then they will both enter an aborted state (this is a shared state).
-  /// Finish callbacks will always be run only when the sub-scheduler's tasks
-  /// have all been completed.
-  ///
-  /// The parent scheduler will not complete until the sub-scheduler's
-  /// tasks (and finish callback) have all executed.
-  ///
-  /// A sub-scheduler can share the same throttle as its parent but it
-  /// can also have its own unique throttle or no throttle
-  virtual std::unique_ptr<Holder> MakeSubScheduler(
-      FnOnce<Status(AsyncTaskScheduler*)> initial_task,
-      FnOnce<Status(Status)> finish_callback, Throttle* throttle = NULLPTR,
-      std::unique_ptr<Queue> queue = NULLPTR) = 0;
-
-  /// Construct a scheduler
-  ///
-  /// \param initial_task The initial task which is responsible for adding
-  ///        the first subtasks to the scheduler.
-  /// \param throttle A throttle to control how many tasks will be submitted at one time.
-  ///        The default (nullptr) will always submit tasks when they are added.
-  /// \param queue A queue to control task order.  Only used if throttle != nullptr.
-  ///        The default (nullptr) will use a FIFO queue if there is a throttle.
-  /// \param stop_token An optional stop token that will allow cancellation of the
-  ///        scheduler.  This will be checked before each task is submitted and, in the
-  ///        event of a cancellation, the scheduler will enter an aborted state. This is
-  ///        a graceful cancellation and submitted tasks will still complete.
-  /// \return A future that will be completed when the initial task and all subtasks have
-  ///         finished.
-  static Future<> Make(FnOnce<Status(AsyncTaskScheduler*)> initial_task,
-                       Throttle* throttle = NULLPTR,
-                       std::unique_ptr<Queue> queue = NULLPTR,
-                       StopToken stop_token = StopToken::Unstoppable());
-};
+  std::unique_ptr<AsyncTaskGroup> task_group =
+      AsyncTaskGroup::Make(this, std::move(finish_callback));
+  AsyncTaskGroup* task_group_view = task_group.get();
+  std::unique_ptr<State> state_holder = std::make_unique<State>(
+      std::move(generator), std::move(visitor), std::move(task_group));
+  task_group_view->AddTask(std::make_unique<SubmitTask>(std::move(state_holder)));
+  return true;
+}
 
 }  // namespace util
 }  // namespace arrow

--- a/cpp/src/arrow/util/async_util_test.cc
+++ b/cpp/src/arrow/util/async_util_test.cc
@@ -39,26 +39,32 @@
 namespace arrow {
 namespace util {
 
+FnOnce<Status(Status)> EmptyFinishCallback() {
+  return [](Status) { return Status::OK(); };
+}
+
 TEST(AsyncTaskScheduler, ShouldScheduleConcurrentTasks) {
+  // A basic test to make sure we schedule the right number of concurrent tasks
   constexpr int kMaxConcurrentTasks = 2;
   constexpr int kTotalNumTasks = kMaxConcurrentTasks + 1;
   std::unique_ptr<AsyncTaskScheduler::Throttle> throttle =
       AsyncTaskScheduler::MakeThrottle(kMaxConcurrentTasks);
-  // A basic test to make sure we schedule the right number of concurrent tasks
-  std::unique_ptr<AsyncTaskScheduler> task_group =
-      AsyncTaskScheduler::Make(throttle.get());
   Future<> futures[kTotalNumTasks];
   bool submitted[kTotalNumTasks];
-  for (int i = 0; i < kTotalNumTasks; i++) {
-    futures[i] = Future<>::Make();
-    submitted[i] = false;
-    task_group->AddSimpleTask([&, i] {
-      submitted[i] = true;
-      return futures[i];
-    });
-  }
-  task_group->End();
-  AssertNotFinished(task_group->OnFinished());
+  Future<> finished = AsyncTaskScheduler::Make(
+      [&](AsyncTaskScheduler* scheduler) {
+        for (int i = 0; i < kTotalNumTasks; i++) {
+          futures[i] = Future<>::Make();
+          submitted[i] = false;
+          scheduler->AddSimpleTask([&, i] {
+            submitted[i] = true;
+            return futures[i];
+          });
+        }
+        return Status::OK();
+      },
+      throttle.get());
+  AssertNotFinished(finished);
   for (int i = 0; i < kTotalNumTasks; i++) {
     if (i < kMaxConcurrentTasks) {
       ASSERT_TRUE(submitted[i]);
@@ -73,89 +79,91 @@ TEST(AsyncTaskScheduler, ShouldScheduleConcurrentTasks) {
       ASSERT_TRUE(submitted[j + kMaxConcurrentTasks]);
     }
   }
-  ASSERT_FINISHES_OK(task_group->OnFinished());
+  ASSERT_FINISHES_OK(finished);
 }
 
-TEST(AsyncTaskScheduler, Abandoned) {
-  // The goal here is to ensure that an abandoned scheduler aborts.
-  // It should block until all submitted tasks finish.  It should not
-  // submit any pending tasks.
-  bool submitted_task_finished = false;
-  bool pending_task_submitted = false;
-  AsyncTaskScheduler* weak_scheduler;
-  std::unique_ptr<AsyncTaskScheduler::Throttle> throttle =
-      AsyncTaskScheduler::MakeThrottle(1);
-  Future<> finished_fut;
-  Future<> first_task = Future<>::Make();
-  std::thread delete_scheduler_thread;
-  {
-    std::unique_ptr<AsyncTaskScheduler> scheduler =
-        AsyncTaskScheduler::Make(throttle.get());
-    weak_scheduler = scheduler.get();
-    finished_fut = scheduler->OnFinished();
-    // This task will start and should finish
-    scheduler->AddSimpleTask([&, first_task] {
-      return first_task.Then([&] { submitted_task_finished = true; });
-    });
-    // This task will never be submitted
-    scheduler->AddSimpleTask([&] {
-      pending_task_submitted = true;
-      return Future<>::MakeFinished();
-    });
-    // We don't want to finish the first task until after the scheduler has been abandoned
-    // and entered an aborted state.  However, deleting the scheduler blocks until the
-    // first task is finished.  So we trigger the delete on a separate thread.
-    struct DeleteSchedulerTask {
-      void operator()() { scheduler.reset(); }
-      std::unique_ptr<AsyncTaskScheduler> scheduler;
-    };
-    delete_scheduler_thread = std::thread(DeleteSchedulerTask{std::move(scheduler)});
-  }
-  // Here we are waiting for the scheduler to enter aborted state.  Once aborted the
-  // scheduler will no longer accept new tasks and will return false.
-  BusyWait(10, [&] { return weak_scheduler->IsEnded(); });
-  // Now that the scheduler deletion is in progress we should be able to finish the
-  // first task and be confident the second task should not be submitted.
-  first_task.MarkFinished();
-  ASSERT_FINISHES_AND_RAISES(UnknownError, finished_fut);
-  delete_scheduler_thread.join();
-  ASSERT_TRUE(submitted_task_finished);
-  ASSERT_FALSE(pending_task_submitted);
+TEST(AsyncTaskScheduler, SubSchedulerHolderLeftForever) {
+  // This tests the "peer scheduler" case where a sub-scheduler
+  // holder is left forever (and thus should end when the parent
+  // scheduler ends)
+  Future<> parent_scheduler_task = Future<>::Make();
+  Future<> child_scheduler_task = Future<>::Make();
+  // Holder kept alive outside of any task scheduler.
+  std::shared_ptr<AsyncTaskScheduler::Holder> holder;
+  Future<> finished = AsyncTaskScheduler::Make([&](AsyncTaskScheduler* scheduler) {
+    scheduler->AddSimpleTask([&] { return parent_scheduler_task; });
+    holder = scheduler->MakeSubScheduler(
+        [&](AsyncTaskScheduler* sub_scheduler) {
+          sub_scheduler->AddSimpleTask([&] { return child_scheduler_task; });
+          return Status::OK();
+        },
+        EmptyFinishCallback());
+    return Status::OK();
+  });
+  parent_scheduler_task.MarkFinished();
+  child_scheduler_task.MarkFinished();
+  ASSERT_FINISHES_OK(finished);
+
+  // Holder destroyed when parent scheduler destroyed
+  parent_scheduler_task = Future<>::Make();
+  child_scheduler_task = Future<>::Make();
+  finished = AsyncTaskScheduler::Make([&](AsyncTaskScheduler* scheduler) {
+    scheduler->AddSimpleTask([&] { return parent_scheduler_task; });
+    std::shared_ptr<AsyncTaskScheduler::Holder> inner_holder =
+        scheduler->MakeSubScheduler(
+            [&](AsyncTaskScheduler* sub_scheduler) {
+              sub_scheduler->AddSimpleTask([&] { return child_scheduler_task; });
+              return Status::OK();
+            },
+            EmptyFinishCallback());
+    return Status::OK();
+  });
+  child_scheduler_task.MarkFinished();
+  parent_scheduler_task.MarkFinished();
+  ASSERT_FINISHES_OK(finished);
 }
 
 TEST(AsyncTaskScheduler, TaskStaysAliveUntilFinished) {
-  std::unique_ptr<AsyncTaskScheduler> scheduler = AsyncTaskScheduler::Make();
-  Future<> task = Future<>::Make();
   bool my_task_destroyed = false;
-  struct MyTask : public AsyncTaskScheduler::Task {
-    MyTask(bool* my_task_destroyed_ptr, Future<> task_fut)
-        : my_task_destroyed_ptr(my_task_destroyed_ptr), task_fut(std::move(task_fut)) {}
-    ~MyTask() { *my_task_destroyed_ptr = true; }
-    Result<Future<>> operator()(AsyncTaskScheduler*) { return task_fut; }
-    bool* my_task_destroyed_ptr;
-    Future<> task_fut;
-  };
-  scheduler->AddTask(std::make_unique<MyTask>(&my_task_destroyed, task));
+  Future<> task = Future<>::Make();
+  Future<> finished = AsyncTaskScheduler::Make([&](AsyncTaskScheduler* scheduler) {
+    struct MyTask : public AsyncTaskScheduler::Task {
+      MyTask(bool* my_task_destroyed_ptr, Future<> task_fut)
+          : my_task_destroyed_ptr(my_task_destroyed_ptr), task_fut(std::move(task_fut)) {}
+      ~MyTask() { *my_task_destroyed_ptr = true; }
+      Result<Future<>> operator()(AsyncTaskScheduler*) { return task_fut; }
+      bool* my_task_destroyed_ptr;
+      Future<> task_fut;
+    };
+    scheduler->AddTask(std::make_unique<MyTask>(&my_task_destroyed, task));
+    return Status::OK();
+  });
   SleepABit();
   ASSERT_FALSE(my_task_destroyed);
   task.MarkFinished();
   ASSERT_TRUE(my_task_destroyed);
-  scheduler->End();
-  ASSERT_FINISHES_OK(scheduler->OnFinished());
+  ASSERT_FINISHES_OK(finished);
 }
 
-TEST(AsyncTaskScheduler, TaskFailsAfterEnd) {
-  std::unique_ptr<AsyncTaskScheduler> scheduler = AsyncTaskScheduler::Make();
+TEST(AsyncTaskScheduler, InitialTaskAddsNothing) {
+  Future<> finished = AsyncTaskScheduler::Make(
+      [&](AsyncTaskScheduler* scheduler) { return Status::OK(); });
+  ASSERT_FINISHES_OK(finished);
+}
+
+TEST(AsyncTaskScheduler, InitialTaskFails) {
   Future<> task = Future<>::Make();
-  scheduler->AddSimpleTask([task] { return task; });
-  scheduler->End();
-  AssertNotFinished(scheduler->OnFinished());
-  task.MarkFinished(Status::Invalid("XYZ"));
-  ASSERT_FINISHES_AND_RAISES(Invalid, scheduler->OnFinished());
-}
+  Future<> finished = AsyncTaskScheduler::Make([&](AsyncTaskScheduler* scheduler) {
+    EXPECT_TRUE(scheduler->AddSimpleTask([&]() { return task; }));
+    return Status::Invalid("XYZ");
+  });
+  AssertNotFinished(finished);
+  task.MarkFinished();
+  ASSERT_FINISHES_AND_RAISES(Invalid, finished);
 
-FnOnce<Status(Status)> EmptyFinishCallback() {
-  return [](Status) { return Status::OK(); };
+  finished = AsyncTaskScheduler::Make(
+      [&](AsyncTaskScheduler* scheduler) { return Status::Invalid("XYZ"); });
+  ASSERT_FINISHES_AND_RAISES(Invalid, finished);
 }
 
 #ifndef ARROW_VALGRIND
@@ -163,167 +171,163 @@ TEST(AsyncTaskScheduler, FailingTaskStress) {
   // Test many tasks failing at the same time
   constexpr int kNumTasks = 256;
   for (int i = 0; i < kNumTasks; i++) {
-    std::unique_ptr<AsyncTaskScheduler> scheduler = AsyncTaskScheduler::Make();
-    ASSERT_TRUE(scheduler->AddSimpleTask([] { return SleepABitAsync(); }));
-    ASSERT_TRUE(scheduler->AddSimpleTask(
-        [] { return SleepABitAsync().Then([]() { return Status::Invalid("XYZ"); }); }));
-    scheduler->End();
-    ASSERT_FINISHES_AND_RAISES(Invalid, scheduler->OnFinished());
+    Future<> finished = AsyncTaskScheduler::Make([&](AsyncTaskScheduler* scheduler) {
+      EXPECT_TRUE(scheduler->AddSimpleTask([] { return SleepABitAsync(); }));
+      EXPECT_TRUE(scheduler->AddSimpleTask(
+          [] { return SleepABitAsync().Then([]() { return Status::Invalid("XYZ"); }); }));
+      return Status::OK();
+    });
+    ASSERT_FINISHES_AND_RAISES(Invalid, finished);
   }
   for (int i = 0; i < kNumTasks; i++) {
-    std::unique_ptr<AsyncTaskScheduler> scheduler = AsyncTaskScheduler::Make();
-    {
-      std::shared_ptr<AsyncTaskScheduler> sub_scheduler =
-          scheduler->MakeSubScheduler(EmptyFinishCallback());
-      ASSERT_TRUE(sub_scheduler->AddSimpleTask([] { return SleepABitAsync(); }));
-      ASSERT_TRUE(sub_scheduler->AddSimpleTask(
-          [] { return SleepABitAsync().Then([]() { return Status::Invalid("XYZ"); }); }));
-    }
-    scheduler->End();
-    ASSERT_FINISHES_AND_RAISES(Invalid, scheduler->OnFinished());
+    Future<> finished = AsyncTaskScheduler::Make([&](AsyncTaskScheduler* scheduler) {
+      scheduler->MakeSubScheduler(
+          [&](AsyncTaskScheduler* sub_scheduler) {
+            EXPECT_TRUE(sub_scheduler->AddSimpleTask([] { return SleepABitAsync(); }));
+            EXPECT_TRUE(sub_scheduler->AddSimpleTask([] {
+              return SleepABitAsync().Then([]() { return Status::Invalid("XYZ"); });
+            }));
+            return Status::OK();
+          },
+          EmptyFinishCallback());
+      return Status::OK();
+    });
+    ASSERT_FINISHES_AND_RAISES(Invalid, finished);
   }
   // Test many schedulers failing at the same time (also a mixture of failing due
   // to global abort racing with local task failure)
   constexpr int kNumSchedulers = 32;
   for (int i = 0; i < kNumTasks; i++) {
-    std::unique_ptr<AsyncTaskScheduler> scheduler = AsyncTaskScheduler::Make();
-    std::vector<Future<>> tests;
-    for (int i = 0; i < kNumSchedulers; i++) {
-      tests.push_back(SleepABitAsync().Then([&] {
-        std::shared_ptr<AsyncTaskScheduler> sub_scheduler =
-            scheduler->MakeSubScheduler(EmptyFinishCallback());
-        std::ignore = sub_scheduler->AddSimpleTask([] {
-          return SleepABitAsync().Then([]() { return Status::Invalid("XYZ"); });
-        });
-      }));
-    }
-    AllComplete(std::move(tests)).Wait();
-    scheduler->End();
-    ASSERT_FINISHES_AND_RAISES(Invalid, scheduler->OnFinished());
+    Future<> finished = AsyncTaskScheduler::Make([&](AsyncTaskScheduler* scheduler) {
+      std::vector<Future<>> tests;
+      for (int i = 0; i < kNumSchedulers; i++) {
+        tests.push_back(SleepABitAsync().Then([&] {
+          scheduler->MakeSubScheduler(
+              [&](AsyncTaskScheduler* sub_scheduler) {
+                std::ignore = sub_scheduler->AddSimpleTask([] {
+                  return SleepABitAsync().Then([]() { return Status::Invalid("XYZ"); });
+                });
+                return Status::OK();
+              },
+              EmptyFinishCallback());
+        }));
+      }
+      AllComplete(std::move(tests)).Wait();
+      return Status::OK();
+    });
+    ASSERT_FINISHES_AND_RAISES(Invalid, finished);
   }
 }
 #endif
 
 TEST(AsyncTaskScheduler, SubSchedulerFinishCallback) {
   bool finish_callback_ran = false;
-  std::unique_ptr<AsyncTaskScheduler> scheduler = AsyncTaskScheduler::Make();
-  {
-    std::shared_ptr<AsyncTaskScheduler> sub_scheduler =
-        scheduler->MakeSubScheduler([&](Status) {
+  Future<> finished = AsyncTaskScheduler::Make([&](AsyncTaskScheduler* scheduler) {
+    scheduler->MakeSubScheduler(
+        [&](AsyncTaskScheduler* sub_scheduler) {
+          EXPECT_FALSE(finish_callback_ran);
+          return Status::OK();
+        },
+        [&](Status) {
           finish_callback_ran = true;
           return Status::OK();
         });
-    ASSERT_FALSE(finish_callback_ran);
-  }
-  ASSERT_TRUE(finish_callback_ran);
-  scheduler->End();
-  ASSERT_FINISHES_OK(scheduler->OnFinished());
+    return Status::OK();
+  });
+  EXPECT_TRUE(finish_callback_ran);
+  ASSERT_FINISHES_OK(finished);
 
   // Finish callback should run even if sub scheduler never starts any tasks
+  // because the parent scheduler was already aborted
   finish_callback_ran = false;
-  scheduler = AsyncTaskScheduler::Make();
-  ASSERT_TRUE(scheduler->AddSimpleTask([] { return Status::Invalid("XYZ"); }));
-  {
-    std::shared_ptr<AsyncTaskScheduler> sub_scheduler =
-        scheduler->MakeSubScheduler([&](Status) {
-          finish_callback_ran = true;
-          return Status::OK();
-        });
-  }
-  scheduler->End();
-  ASSERT_FINISHES_AND_RAISES(Invalid, scheduler->OnFinished());
+  finished = AsyncTaskScheduler::Make([&](AsyncTaskScheduler* scheduler) {
+    EXPECT_TRUE(scheduler->AddSimpleTask([] { return Status::Invalid("XYZ"); }));
+    {
+      scheduler->MakeSubScheduler(
+          [&](AsyncTaskScheduler* sub_scheduler) {
+            EXPECT_FALSE(finish_callback_ran);
+            return Status::OK();
+          },
+          [&](Status) {
+            finish_callback_ran = true;
+            return Status::OK();
+          });
+    }
+    return Status::OK();
+  });
+  ASSERT_FINISHES_AND_RAISES(Invalid, finished);
   ASSERT_TRUE(finish_callback_ran);
 
-  // Finish callback should run even if scheduler aborts
+  // Finish callback should run even if scheduler is in aborted state when the
+  // sub-scheduler finishes
   finish_callback_ran = false;
-  scheduler = AsyncTaskScheduler::Make();
-  {
-    std::shared_ptr<AsyncTaskScheduler> sub_scheduler =
-        scheduler->MakeSubScheduler([&](Status) {
-          finish_callback_ran = true;
-          return Status::OK();
-        });
-
-    ASSERT_TRUE(sub_scheduler->AddSimpleTask([] { return Status::Invalid("XYZ"); }));
-  }
-  ASSERT_TRUE(finish_callback_ran);
-  scheduler->End();
-  ASSERT_FINISHES_AND_RAISES(Invalid, scheduler->OnFinished());
-}
-
-TEST(AsyncTaskScheduler, SubSchedulerFinishAbort) {
-  bool finish_callback_ran = false;
-  std::unique_ptr<AsyncTaskScheduler> scheduler = AsyncTaskScheduler::Make();
-  {
-    std::shared_ptr<AsyncTaskScheduler> sub_scheduler =
-        scheduler->MakeSubScheduler([&](Status) {
-          finish_callback_ran = true;
-          return Status::Invalid("XYZ");
-        });
-    ASSERT_FALSE(finish_callback_ran);
-  }
-  ASSERT_TRUE(finish_callback_ran);
-  scheduler->End();
-  ASSERT_FINISHES_AND_RAISES(Invalid, scheduler->OnFinished());
+  finished = AsyncTaskScheduler::Make([&](AsyncTaskScheduler* scheduler) {
+    {
+      Future<> task = Future<>::Make();
+      scheduler->AddSimpleTask([&] { return task; });
+      scheduler->MakeSubScheduler(
+          [&](AsyncTaskScheduler* sub_scheduler) mutable {
+            task.MarkFinished(Status::Invalid("XYZ"));
+            EXPECT_FALSE(finish_callback_ran);
+            return Status::OK();
+          },
+          [&](Status) {
+            finish_callback_ran = true;
+            return Status::OK();
+          });
+    }
+    EXPECT_TRUE(finish_callback_ran);
+    return Status::OK();
+  });
+  ASSERT_FINISHES_AND_RAISES(Invalid, finished);
 }
 
 TEST(AsyncTaskScheduler, SubSchedulerNoticesParentAbort) {
-  std::unique_ptr<AsyncTaskScheduler> parent = AsyncTaskScheduler::Make();
-  std::unique_ptr<AsyncTaskScheduler::Throttle> child_throttle =
-      AsyncTaskScheduler::MakeThrottle(1);
-  {
-    std::shared_ptr<AsyncTaskScheduler> child =
-        parent->MakeSubScheduler(EmptyFinishCallback(), child_throttle.get());
-
-    Future<> task = Future<>::Make();
-    bool was_submitted = false;
-    ASSERT_TRUE(child->AddSimpleTask([task] { return task; }));
-    ASSERT_TRUE(child->AddSimpleTask([&was_submitted] {
-      was_submitted = true;
-      return Future<>::MakeFinished();
-    }));
-    ASSERT_TRUE(parent->AddSimpleTask([] { return Status::Invalid("XYZ"); }));
-    ASSERT_FALSE(child->AddSimpleTask([task] { return task; }));
-    task.MarkFinished();
-  }
-  parent->End();
-  ASSERT_FINISHES_AND_RAISES(Invalid, parent->OnFinished());
-}
-
-TEST(AsyncTaskScheduler, SubSchedulerNoTasks) {
-  // An unended sub-scheduler should keep the parent scheduler unfinished even if there
-  // there are no tasks.
-  std::unique_ptr<AsyncTaskScheduler> parent = AsyncTaskScheduler::Make();
-  {
-    std::shared_ptr<AsyncTaskScheduler> child =
-        parent->MakeSubScheduler(EmptyFinishCallback());
-    parent->End();
-    AssertNotFinished(parent->OnFinished());
-  }
-  ASSERT_FINISHES_OK(parent->OnFinished());
+  Future<> finished = AsyncTaskScheduler::Make([&](AsyncTaskScheduler* parent) {
+    std::unique_ptr<AsyncTaskScheduler::Throttle> child_throttle =
+        AsyncTaskScheduler::MakeThrottle(1);
+    parent->MakeSubScheduler(
+        [&](AsyncTaskScheduler* child) {
+          Future<> task = Future<>::Make();
+          bool was_submitted = false;
+          EXPECT_TRUE(child->AddSimpleTask([task] { return task; }));
+          EXPECT_TRUE(child->AddSimpleTask([&was_submitted] {
+            was_submitted = true;
+            return Future<>::MakeFinished();
+          }));
+          EXPECT_TRUE(parent->AddSimpleTask([] { return Status::Invalid("XYZ"); }));
+          EXPECT_FALSE(child->AddSimpleTask([task] { return task; }));
+          task.MarkFinished();
+          return Status::OK();
+        },
+        EmptyFinishCallback(), child_throttle.get());
+    return Status::OK();
+  });
+  ASSERT_FINISHES_AND_RAISES(Invalid, finished);
 }
 
 TEST(AsyncTaskScheduler, AsyncGenerator) {
   for (bool slow : {false, true}) {
-    ARROW_SCOPED_TRACE("Slow: ", slow);
-    std::unique_ptr<AsyncTaskScheduler> scheduler = AsyncTaskScheduler::Make();
     std::vector<TestInt> values{1, 2, 3};
     std::vector<TestInt> seen_values{};
-    AsyncGenerator<TestInt> generator = MakeVectorGenerator<TestInt>(values);
-    if (slow) {
-      generator = util::SlowdownABit(generator);
-    }
-    std::function<Status(const TestInt&)> visitor = [&](const TestInt& val) {
-      seen_values.push_back(val);
+    ARROW_SCOPED_TRACE("Slow: ", slow);
+    Future<> finished = AsyncTaskScheduler::Make([&](AsyncTaskScheduler* scheduler) {
+      AsyncGenerator<TestInt> generator = MakeVectorGenerator<TestInt>(values);
+      if (slow) {
+        generator = util::SlowdownABit(generator);
+      }
+      std::function<Status(const TestInt&)> visitor = [&](const TestInt& val) {
+        seen_values.push_back(val);
+        return Status::OK();
+      };
+      scheduler->AddAsyncGenerator(std::move(generator), std::move(visitor),
+                                   EmptyFinishCallback());
       return Status::OK();
-    };
-    scheduler->AddAsyncGenerator(std::move(generator), std::move(visitor),
-                                 EmptyFinishCallback());
-    scheduler->End();
-    ASSERT_FINISHES_OK(scheduler->OnFinished());
+    });
+    ASSERT_FINISHES_OK(finished);
     ASSERT_EQ(seen_values, values);
   }
-}  // namespace util
+}
 
 class CustomThrottle : public AsyncTaskScheduler::Throttle {
  public:
@@ -346,33 +350,38 @@ TEST(AsyncTaskScheduler, EndWaitsForAddedButNotSubmittedTasks) {
   /// If a scheduler ends then unsubmitted tasks should still be executed
   std::unique_ptr<AsyncTaskScheduler::Throttle> throttle =
       AsyncTaskScheduler::MakeThrottle(1);
-  std::unique_ptr<AsyncTaskScheduler> task_group =
-      AsyncTaskScheduler::Make(throttle.get());
   Future<> slow_task = Future<>::Make();
   bool was_run = false;
-  ASSERT_TRUE(task_group->AddSimpleTask([slow_task] { return slow_task; }));
-  ASSERT_TRUE(task_group->AddSimpleTask([&was_run] {
-    was_run = true;
-    return Future<>::MakeFinished();
-  }));
-  ASSERT_FALSE(was_run);
-  task_group->End();
+  Future<> finished = AsyncTaskScheduler::Make(
+      [&](AsyncTaskScheduler* scheduler) {
+        EXPECT_TRUE(scheduler->AddSimpleTask([slow_task] { return slow_task; }));
+        EXPECT_TRUE(scheduler->AddSimpleTask([&was_run] {
+          was_run = true;
+          return Future<>::MakeFinished();
+        }));
+        EXPECT_FALSE(was_run);
+        return Status::OK();
+      },
+      throttle.get());
   slow_task.MarkFinished();
-  ASSERT_FINISHES_OK(task_group->OnFinished());
+  ASSERT_FINISHES_OK(finished);
   ASSERT_TRUE(was_run);
 
   /// Same test but block task by custom throttle
   auto custom_throttle = std::make_unique<CustomThrottle>();
-  task_group = AsyncTaskScheduler::Make(custom_throttle.get());
   was_run = false;
-  ASSERT_TRUE(task_group->AddSimpleTask([&was_run] {
-    was_run = true;
-    return Future<>::MakeFinished();
-  }));
-  ASSERT_FALSE(was_run);
-  task_group->End();
+  finished = AsyncTaskScheduler::Make(
+      [&](AsyncTaskScheduler* scheduler) {
+        EXPECT_TRUE(scheduler->AddSimpleTask([&was_run] {
+          was_run = true;
+          return Future<>::MakeFinished();
+        }));
+        EXPECT_FALSE(was_run);
+        return Status::OK();
+      },
+      custom_throttle.get());
   custom_throttle->Unlock();
-  ASSERT_FINISHES_OK(task_group->OnFinished());
+  ASSERT_FINISHES_OK(finished);
   ASSERT_TRUE(was_run);
 }
 
@@ -385,11 +394,9 @@ TEST(AsyncTaskScheduler, TaskWithCostBiggerThanThrottle) {
   constexpr int kThrottleCapacity = 5;
   std::unique_ptr<AsyncTaskScheduler::Throttle> throttle =
       AsyncTaskScheduler::MakeThrottle(kThrottleCapacity);
-  std::unique_ptr<AsyncTaskScheduler> task_group =
-      AsyncTaskScheduler::Make(throttle.get());
   bool task_submitted = false;
+  Future<> blocking_task = Future<>::Make();
   Future<> task = Future<>::Make();
-
   struct ExpensiveTask : AsyncTaskScheduler::Task {
     ExpensiveTask(bool* task_submitted, Future<> task)
         : task_submitted(task_submitted), task(std::move(task)) {}
@@ -401,11 +408,14 @@ TEST(AsyncTaskScheduler, TaskWithCostBiggerThanThrottle) {
     bool* task_submitted;
     Future<> task;
   };
-
-  Future<> blocking_task = Future<>::Make();
-  task_group->AddSimpleTask([&] { return blocking_task; });
-  task_group->AddTask(std::make_unique<ExpensiveTask>(&task_submitted, task));
-  task_group->End();
+  Future<> finished = AsyncTaskScheduler::Make(
+      [&](AsyncTaskScheduler* scheduler) {
+        EXPECT_TRUE(scheduler->AddSimpleTask([&] { return blocking_task; }));
+        EXPECT_TRUE(
+            scheduler->AddTask(std::make_unique<ExpensiveTask>(&task_submitted, task)));
+        return Status::OK();
+      },
+      throttle.get());
 
   // Task should not be submitted initially because blocking_task (even though
   // it has a cost of 1) is preventing it.
@@ -414,78 +424,81 @@ TEST(AsyncTaskScheduler, TaskWithCostBiggerThanThrottle) {
   // One blocking_task is out of the way the task is free to run
   ASSERT_TRUE(task_submitted);
   task.MarkFinished();
-  ASSERT_FINISHES_OK(task_group->OnFinished());
+  ASSERT_FINISHES_OK(finished);
 }
 
 TEST(AsyncTaskScheduler, TaskFinishesAfterError) {
   /// If a task fails it shouldn't impact previously submitted tasks
-  std::unique_ptr<AsyncTaskScheduler> task_group = AsyncTaskScheduler::Make();
   Future<> fut1 = Future<>::Make();
-  ASSERT_TRUE(task_group->AddSimpleTask([fut1] { return fut1; }));
-  ASSERT_TRUE(task_group->AddSimpleTask(
-      [] { return Future<>::MakeFinished(Status::Invalid("XYZ")); }));
-  task_group->End();
-  Future<> finished_fut = task_group->OnFinished();
-  AssertNotFinished(finished_fut);
+  Future<> finished = AsyncTaskScheduler::Make([&](AsyncTaskScheduler* scheduler) {
+    EXPECT_TRUE(scheduler->AddSimpleTask([fut1] { return fut1; }));
+    EXPECT_TRUE(scheduler->AddSimpleTask(
+        [] { return Future<>::MakeFinished(Status::Invalid("XYZ")); }));
+    return Status::OK();
+  });
+  AssertNotFinished(finished);
   fut1.MarkFinished();
-  ASSERT_FINISHES_AND_RAISES(Invalid, finished_fut);
+  ASSERT_FINISHES_AND_RAISES(Invalid, finished);
 }
 
 TEST(AsyncTaskScheduler, FailAfterAdd) {
   /// If a task fails it shouldn't impact tasks that have been submitted
   /// even if they were submitted later
-  std::unique_ptr<AsyncTaskScheduler> task_group = AsyncTaskScheduler::Make();
   Future<> will_fail = Future<>::Make();
-  ASSERT_TRUE(task_group->AddSimpleTask([will_fail] { return will_fail; }));
   Future<> added_later_and_passes = Future<>::Make();
-  ASSERT_TRUE(task_group->AddSimpleTask(
-      [added_later_and_passes] { return added_later_and_passes; }));
-  will_fail.MarkFinished(Status::Invalid("XYZ"));
-  ASSERT_FALSE(task_group->AddSimpleTask([] { return Future<>::Make(); }));
-  task_group->End();
-  Future<> finished_fut = task_group->OnFinished();
-  AssertNotFinished(finished_fut);
+  Future<> finished = AsyncTaskScheduler::Make([&](AsyncTaskScheduler* scheduler) {
+    EXPECT_TRUE(scheduler->AddSimpleTask([will_fail] { return will_fail; }));
+    EXPECT_TRUE(scheduler->AddSimpleTask(
+        [added_later_and_passes] { return added_later_and_passes; }));
+    will_fail.MarkFinished(Status::Invalid("XYZ"));
+    EXPECT_FALSE(scheduler->AddSimpleTask([] { return Future<>::Make(); }));
+    return Status::OK();
+  });
+  AssertNotFinished(finished);
   added_later_and_passes.MarkFinished();
-  AssertFinished(finished_fut);
-  ASSERT_FINISHES_AND_RAISES(Invalid, finished_fut);
+  ASSERT_FINISHES_AND_RAISES(Invalid, finished);
 }
 
 TEST(AsyncTaskScheduler, PurgeUnsubmitted) {
   // If a task fails then unsubmitted tasks should not be executed
   std::unique_ptr<AsyncTaskScheduler::Throttle> throttle =
       AsyncTaskScheduler::MakeThrottle(1);
-  std::unique_ptr<AsyncTaskScheduler> task_group =
-      AsyncTaskScheduler::Make(throttle.get());
   Future<> will_fail = Future<>::Make();
-  ASSERT_TRUE(task_group->AddSimpleTask([will_fail] { return will_fail; }));
   bool was_submitted = false;
-  ASSERT_TRUE(task_group->AddSimpleTask([&was_submitted] {
-    was_submitted = true;
-    return Future<>::MakeFinished();
-  }));
-  will_fail.MarkFinished(Status::Invalid("XYZ"));
-  task_group->End();
-  Future<> finished_fut = task_group->OnFinished();
-  ASSERT_FINISHES_AND_RAISES(Invalid, finished_fut);
+  Future<> finished = AsyncTaskScheduler::Make(
+      [&](AsyncTaskScheduler* scheduler) {
+        EXPECT_TRUE(scheduler->AddSimpleTask([will_fail] { return will_fail; }));
+        EXPECT_TRUE(scheduler->AddSimpleTask([&was_submitted] {
+          was_submitted = true;
+          return Future<>::MakeFinished();
+        }));
+        will_fail.MarkFinished(Status::Invalid("XYZ"));
+        return Status::OK();
+      },
+      throttle.get());
+  ASSERT_FINISHES_AND_RAISES(Invalid, finished);
   ASSERT_FALSE(was_submitted);
 
-  // Purge might still be needed when in the ended state too
+  // Purge might still be needed when done with initial task too
   throttle = AsyncTaskScheduler::MakeThrottle(2);
-  task_group = AsyncTaskScheduler::Make(throttle.get());
   will_fail = Future<>::Make();
   Future<> slow_task_that_passes = Future<>::Make();
-  ASSERT_TRUE(task_group->AddSimpleTask([will_fail] { return will_fail; }));
-  ASSERT_TRUE(task_group->AddSimpleTask(
-      [slow_task_that_passes] { return slow_task_that_passes; }));
   was_submitted = false;
-  ASSERT_TRUE(task_group->AddSimpleTask([&was_submitted] {
-    was_submitted = true;
-    return Future<>::MakeFinished();
-  }));
-  task_group->End();
+  finished = AsyncTaskScheduler::Make(
+      [&](AsyncTaskScheduler* scheduler) {
+        EXPECT_TRUE(scheduler->AddSimpleTask([will_fail] { return will_fail; }));
+        EXPECT_TRUE(scheduler->AddSimpleTask(
+            [slow_task_that_passes] { return slow_task_that_passes; }));
+        EXPECT_TRUE(scheduler->AddSimpleTask([&was_submitted] {
+          was_submitted = true;
+          return Future<>::MakeFinished();
+        }));
+        return Status::OK();
+      },
+      throttle.get());
   will_fail.MarkFinished(Status::Invalid("XYZ"));
   slow_task_that_passes.MarkFinished();
-  ASSERT_FINISHES_AND_RAISES(Invalid, task_group->OnFinished());
+  ASSERT_FINISHES_AND_RAISES(Invalid, finished);
   ASSERT_FALSE(was_submitted);
 }
 
@@ -499,19 +512,22 @@ TEST(AsyncTaskScheduler, FifoStress) {
     std::atomic<bool> middle_task_run{false};
     std::unique_ptr<AsyncTaskScheduler::Throttle> throttle =
         AsyncTaskScheduler::MakeThrottle(1);
-    std::unique_ptr<AsyncTaskScheduler> task_group =
-        AsyncTaskScheduler::Make(throttle.get());
-    task_group->AddSimpleTask([] { return SleepABitAsync(); });
-    task_group->AddSimpleTask([&] {
-      middle_task_run = true;
-      return Future<>::MakeFinished();
-    });
-    SleepABit();
-    task_group->AddSimpleTask([&] {
-      EXPECT_TRUE(middle_task_run);
-      return Future<>::MakeFinished();
-    });
-    task_group->End();
+    Future<> finished = AsyncTaskScheduler::Make(
+        [&](AsyncTaskScheduler* scheduler) {
+          scheduler->AddSimpleTask([] { return SleepABitAsync(); });
+          scheduler->AddSimpleTask([&] {
+            middle_task_run = true;
+            return Future<>::MakeFinished();
+          });
+          SleepABit();
+          scheduler->AddSimpleTask([&] {
+            EXPECT_TRUE(middle_task_run);
+            return Future<>::MakeFinished();
+          });
+          return Status::OK();
+        },
+        throttle.get());
+    ASSERT_FINISHES_OK(finished);
   }
 }
 
@@ -522,21 +538,23 @@ TEST(AsyncTaskScheduler, MaxConcurrentTasksStress) {
   for (int i = 0; i < kNumIters; i++) {
     std::unique_ptr<AsyncTaskScheduler::Throttle> throttle =
         AsyncTaskScheduler::MakeThrottle(kNumConcurrentTasks);
-    std::unique_ptr<AsyncTaskScheduler> task_group =
-        AsyncTaskScheduler::Make(throttle.get());
     std::atomic<int> num_tasks_running{0};
-    for (int task_idx = 0; task_idx < kNumTasks; task_idx++) {
-      task_group->AddSimpleTask([&num_tasks_running, kNumConcurrentTasks] {
-        if (num_tasks_running.fetch_add(1) > kNumConcurrentTasks) {
-          ADD_FAILURE() << "More than " << kNumConcurrentTasks
-                        << " tasks were allowed to run concurrently";
-        }
-        return SleepABitAsync().Then(
-            [&num_tasks_running] { num_tasks_running.fetch_sub(1); });
-      });
-    }
-    task_group->End();
-    ASSERT_FINISHES_OK(task_group->OnFinished());
+    Future<> finished = AsyncTaskScheduler::Make(
+        [&](AsyncTaskScheduler* scheduler) {
+          for (int task_idx = 0; task_idx < kNumTasks; task_idx++) {
+            scheduler->AddSimpleTask([&num_tasks_running, kNumConcurrentTasks] {
+              if (num_tasks_running.fetch_add(1) > kNumConcurrentTasks) {
+                ADD_FAILURE() << "More than " << kNumConcurrentTasks
+                              << " tasks were allowed to run concurrently";
+              }
+              return SleepABitAsync().Then(
+                  [&num_tasks_running] { num_tasks_running.fetch_sub(1); });
+            });
+          }
+          return Status::OK();
+        },
+        throttle.get());
+    ASSERT_FINISHES_OK(finished);
   }
 }
 
@@ -553,28 +571,32 @@ TEST(AsyncTaskScheduler, ScanningStress) {
   constexpr int kExpectedBatchesScanned = kNumFragments * kBatchesPerFragment;
 
   for (int i = 0; i < kNumIters; i++) {
-    std::unique_ptr<AsyncTaskScheduler::Throttle> batch_limit =
-        AsyncTaskScheduler::MakeThrottle(kNumConcurrentTasks);
-    std::unique_ptr<AsyncTaskScheduler> listing_scheduler = AsyncTaskScheduler::Make();
     std::atomic<int> batches_scanned{0};
-    std::atomic<int> fragments_scanned{0};
     auto scan_batch = [&] { batches_scanned++; };
     auto submit_scan = [&]() { return SleepABitAsync().Then(scan_batch); };
-    auto list_fragment = [&]() {
-      std::shared_ptr<AsyncTaskScheduler> batch_scheduler =
-          listing_scheduler->MakeSubScheduler(EmptyFinishCallback(), batch_limit.get());
-      for (int i = 0; i < kBatchesPerFragment; i++) {
-        ASSERT_TRUE(batch_scheduler->AddSimpleTask(submit_scan));
-      }
-      if (++fragments_scanned == kNumFragments) {
-        listing_scheduler->End();
-      }
-    };
-    auto submit_list_fragment = [&]() { return SleepABitAsync().Then(list_fragment); };
-    for (int frag_idx = 0; frag_idx < kNumFragments; frag_idx++) {
-      ASSERT_TRUE(listing_scheduler->AddSimpleTask(submit_list_fragment));
-    }
-    ASSERT_FINISHES_OK(listing_scheduler->OnFinished());
+    std::unique_ptr<AsyncTaskScheduler::Throttle> batch_limit =
+        AsyncTaskScheduler::MakeThrottle(kNumConcurrentTasks);
+    Future<> finished =
+        AsyncTaskScheduler::Make([&](AsyncTaskScheduler* listing_scheduler) {
+          auto list_fragment = [&, listing_scheduler]() {
+            listing_scheduler->MakeSubScheduler(
+                [&](AsyncTaskScheduler* batch_scheduler) {
+                  for (int i = 0; i < kBatchesPerFragment; i++) {
+                    EXPECT_TRUE(batch_scheduler->AddSimpleTask(submit_scan));
+                  }
+                  return Status::OK();
+                },
+                EmptyFinishCallback(), batch_limit.get());
+          };
+          auto submit_list_fragment = [&]() {
+            return SleepABitAsync().Then(list_fragment);
+          };
+          for (int frag_idx = 0; frag_idx < kNumFragments; frag_idx++) {
+            EXPECT_TRUE(listing_scheduler->AddSimpleTask(submit_list_fragment));
+          }
+          return Status::OK();
+        });
+    ASSERT_FINISHES_OK(finished);
     ASSERT_EQ(kExpectedBatchesScanned, batches_scanned.load());
   }
 }
@@ -627,24 +649,28 @@ TEST(AsyncTaskScheduler, Priority) {
   constexpr int kNumConcurrentTasks = 8;
   std::unique_ptr<AsyncTaskScheduler::Throttle> throttle =
       AsyncTaskScheduler::MakeThrottle(kNumConcurrentTasks);
-  auto task_group =
-      AsyncTaskScheduler::Make(throttle.get(), std::make_unique<PriorityQueue>());
 
   std::shared_ptr<GatingTask> gate = GatingTask::Make();
   int submit_order[kNumTasks];
   std::atomic<int> order_index{0};
 
-  for (int task_idx = 0; task_idx < kNumTasks; task_idx++) {
-    int priority = task_idx;
-    std::function<Result<Future<>>()> task_exec = [&, priority]() -> Result<Future<>> {
-      submit_order[order_index++] = priority;
-      return gate->AsyncTask();
-    };
-    auto task = std::make_unique<TaskWithPriority>(task_exec, priority);
-    task_group->AddTask(std::move(task));
-  }
-  task_group->End();
-  AssertNotFinished(task_group->OnFinished());
+  Future<> finished = AsyncTaskScheduler::Make(
+      [&](AsyncTaskScheduler* scheduler) {
+        for (int task_idx = 0; task_idx < kNumTasks; task_idx++) {
+          int priority = task_idx;
+          std::function<Result<Future<>>()> task_exec = [&,
+                                                         priority]() -> Result<Future<>> {
+            submit_order[order_index++] = priority;
+            return gate->AsyncTask();
+          };
+          auto task = std::make_unique<TaskWithPriority>(task_exec, priority);
+          scheduler->AddTask(std::move(task));
+        }
+        return Status::OK();
+      },
+      throttle.get(), std::make_unique<PriorityQueue>());
+
+  AssertNotFinished(finished);
 
   ASSERT_OK(gate->WaitForRunning(kNumConcurrentTasks));
   ASSERT_OK(gate->Unlock());

--- a/cpp/src/arrow/util/async_util_test.cc
+++ b/cpp/src/arrow/util/async_util_test.cc
@@ -286,8 +286,7 @@ TEST(AsyncTaskScheduler, AsyncGenerator) {
         seen_values.push_back(val);
         return Status::OK();
       };
-      scheduler->AddAsyncGenerator(std::move(generator), std::move(visitor),
-                                   [] { return Status::OK(); });
+      scheduler->AddAsyncGenerator(std::move(generator), std::move(visitor));
       return Status::OK();
     });
     ASSERT_FINISHES_OK(finished);

--- a/cpp/src/arrow/util/cancel.h
+++ b/cpp/src/arrow/util/cancel.h
@@ -64,7 +64,18 @@ class ARROW_EXPORT StopToken {
   // A trivial token that never propagates any stop request
   static StopToken Unstoppable() { return StopToken(); }
 
-  // Producer API (the side that gets asked to stopped)
+  /// \brief Check if the stop source has been cancelled.
+  ///
+  /// Producers should call this method, whenever convenient, to check and
+  /// see if they should stop producing early (i.e. have been cancelled).
+  /// Failure to call this method often enough will lead to an unresponsive
+  /// cancellation.
+  ///
+  /// This is part of the producer API (the side that gets asked to stop)
+  /// This method is thread-safe
+  ///
+  /// \return An OK status if the stop source has not been cancelled or a
+  ///         cancel error if the source has been cancelled.
   Status Poll() const;
   bool IsStopRequested() const;
 

--- a/r/src/compute-exec.cpp
+++ b/r/src/compute-exec.cpp
@@ -474,7 +474,8 @@ class AccumulatingConsumer : public compute::SinkNodeConsumer {
   const std::vector<std::shared_ptr<arrow::RecordBatch>>& batches() { return batches_; }
 
   arrow::Status Init(const std::shared_ptr<arrow::Schema>& schema,
-                     compute::BackpressureControl* backpressure_control) override {
+                     compute::BackpressureControl* backpressure_control,
+                     compute::ExecPlan* exec_plan) override {
     schema_ = schema;
     return arrow::Status::OK();
   }


### PR DESCRIPTION
This call to end was a foot-gun because failing to call End on a scheduler would lead to deadlock.  This led to numerous situations where one would accidentally fail to call End because of some kind of error or exceptional behavior.

Now the call to end is no longer required.  The scheduler has also been simplified by breaking into three different concepts.  The root scheduler runs a bunch of tasks until there are no more tasks and then automatically ends.

A throttle can wrap a scheduler and throttle task execution, deferring tasks to a queue if there is no space for new tasks.

A task group tracks a group of tasks and runs a finish callback when all the tasks in that group have finished.