### PR TITLE
ARROW-17360: [Python] Order of columns in pyarrow.feather.read_table

### DIFF
--- a/python/pyarrow/orc.py
+++ b/python/pyarrow/orc.py
@@ -175,7 +175,8 @@ class ORCFile:
         columns : list
             If not None, only these columns will be read from the file. A
             column name may be a prefix of a nested field, e.g. 'a' will select
-            'a.b', 'a.c', and 'a.d.e'
+            'a.b', 'a.c', and 'a.d.e'. Output always follows the
+            ordering of the file and not the `columns` list.
 
         Returns
         -------

--- a/python/pyarrow/orc.py
+++ b/python/pyarrow/orc.py
@@ -322,7 +322,8 @@ source : str, pyarrow.NativeFile, or file-like object
 columns : list
     If not None, only these columns will be read from the file. A column
     name may be a prefix of a nested field, e.g. 'a' will select 'a.b',
-    'a.c', and 'a.d.e'. If empty, no columns will be read. Note
+    'a.c', and 'a.d.e'. Output always follows the ordering of the file and
+    not the `columns` list. If empty, no columns will be read. Note
     that the table will still have the correct num_rows set despite having
     no columns.
 filesystem : FileSystem, default None


### PR DESCRIPTION
This PR adds a note about the ordering of the columns in `ORCFile.read()`.