### PR TITLE
GH-33005: [Dev] Update the pull request merge script to work with master or main

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -108,4 +108,6 @@ jobs:
           ci/scripts/release_test.sh $(pwd)
       - name: Run Merge Script Test
         shell: bash
+        env: 
+          MERGE_SCRIPT_DEFAULT_BRANCH_NAME: ${{ github.event.repository.default_branch }} 
         run: pytest -v dev/test_merge_arrow_pr.py

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -108,6 +108,4 @@ jobs:
           ci/scripts/release_test.sh $(pwd)
       - name: Run Merge Script Test
         shell: bash
-        env: 
-          MERGE_SCRIPT_DEFAULT_BRANCH_NAME: ${{ github.event.repository.default_branch }} 
         run: pytest -v dev/test_merge_arrow_pr.py

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -113,21 +113,22 @@ def strip_ci_directives(commit_message):
 
 def git_default_branch_name():
     default_branch_name = os.getenv("MERGE_SCRIPT_DEFAULT_BRANCH_NAME")
-    
+
     if default_branch_name is None:
         try:
-            default_reference = run_cmd("git rev-parse --abbrev-ref origin/HEAD")
+            default_reference = run_cmd(
+                "git rev-parse --abbrev-ref origin/HEAD")
             default_branch_name = default_reference.lstrip("origin/")
         except subprocess.CalledProcessError:
             # TODO: ARROW-18011 to track changing the hard coded default
             # value from "master" to "main".
             default_branch_name = "master"
             warnings.warn('Unable to determine default branch name: '
-                            'MERGE_SCRIPT_DEFAULT_BRANCH_NAME environment '
-                            'variable is not set. Git repository does not '
-                            'contain a \'refs/remotes/origin/HEAD\'reference. '
-                            ' Setting the default branch name to ' +
-                            default_branch_name, RuntimeWarning)
+                          'MERGE_SCRIPT_DEFAULT_BRANCH_NAME environment '
+                          'variable is not set. Git repository does not '
+                          'contain a \'refs/remotes/origin/HEAD\'reference. '
+                          ' Setting the default branch name to ' +
+                          default_branch_name, RuntimeWarning)
 
     return default_branch_name
 

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -110,10 +110,14 @@ def strip_ci_directives(commit_message):
     return _REGEX_CI_DIRECTIVE.sub('', commit_message)
 
 
+def git_default_branch_name():
+    return run_cmd("git rev-parse --abbrev-ref origin/HEAD | sed s@origin/@@")
+
+
 def fix_version_from_branch(branch, versions):
     # Note: Assumes this is a sorted (newest->oldest) list of un-released
     # versions
-    if branch == "master":
+    if branch == git_default_branch_name():
         return versions[-1]
     else:
         branch_ver = branch.replace("branch-", "")

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -111,8 +111,7 @@ def strip_ci_directives(commit_message):
 
 
 def git_default_branch_name():
-    default_reference = run_cmd("git rev-parse --abbrev-ref origin/HEAD")
-    return default_reference.lstrip("origin/")
+    return os.getenv("MERGE_SCRIPT_DEFAULT_BRANCH_NAME")
 
 
 def fix_version_from_branch(branch, versions):

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -118,7 +118,8 @@ def git_default_branch_name():
         try:
             default_reference = run_cmd(
                 "git rev-parse --abbrev-ref origin/HEAD")
-            default_branch_name = default_reference.lstrip("origin/")
+            if default_branch_name.startswith("origin/"):
+                default_branch_name = default_branch_name[len("origin/"):]
             default_branch_name = default_branch_name.rstrip()
         except subprocess.CalledProcessError:
             # TODO: ARROW-18011 to track changing the hard coded default

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -43,7 +43,6 @@ import subprocess
 import sys
 import requests
 import getpass
-import warnings
 
 from six.moves import input
 import six

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -109,6 +109,7 @@ def strip_ci_directives(commit_message):
     # commit message
     return _REGEX_CI_DIRECTIVE.sub('', commit_message)
 
+
 def fix_version_from_branch(versions):
     # Note: Assumes this is a sorted (newest->oldest) list of un-released
     # versions

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -301,7 +301,7 @@ class GitHubIssue(object):
 
 
 def get_candidate_fix_version(mainline_versions,
-                              merge_branches,
+                              merge_branches=None,
                               maintenance_branches=()):
     if merge_branches is None:
         merge_branches = (git_default_branch_name(),)
@@ -670,7 +670,7 @@ def get_primary_author(cmd, distinct_authors):
 
 def prompt_for_fix_version(cmd, issue, maintenance_branches=()):
     default_fix_version = get_candidate_fix_version(
-        issue.current_versions,
+        mainline_versions=issue.current_versions,
         maintenance_branches=maintenance_branches
     )
 

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -326,11 +326,9 @@ def get_candidate_fix_version(mainline_versions,
 
     mainline_versions = [v for v in mainline_versions
                          if f"maint-{v}" not in maintenance_branches]
-    default_fix_versions = [
-        fix_version_from_branch(mainline_versions)
-        for x in merge_branches]
+    default_fix_versions = fix_version_from_branch(mainline_versions)
 
-    return default_fix_versions[0]
+    return default_fix_versions
 
 
 def format_issue_output(issue_type, issue_id, status,

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -119,6 +119,7 @@ def git_default_branch_name():
             default_reference = run_cmd(
                 "git rev-parse --abbrev-ref origin/HEAD")
             default_branch_name = default_reference.lstrip("origin/")
+            default_branch_name = default_branch_name.rstrip()
         except subprocess.CalledProcessError:
             # TODO: ARROW-18011 to track changing the hard coded default
             # value from "master" to "main".

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -118,8 +118,8 @@ def git_default_branch_name():
         try:
             default_reference = run_cmd(
                 "git rev-parse --abbrev-ref origin/HEAD")
-            if default_branch_name.startswith("origin/"):
-                default_branch_name = default_branch_name[len("origin/"):]
+            if default_reference.startswith("origin/"):
+                default_branch_name = default_reference[len("origin/"):]
             default_branch_name = default_branch_name.rstrip()
         except subprocess.CalledProcessError:
             # TODO: ARROW-18011 to track changing the hard coded default
@@ -135,14 +135,10 @@ def git_default_branch_name():
     return default_branch_name
 
 
-def fix_version_from_branch(branch, versions):
+def fix_version_from_branch(versions):
     # Note: Assumes this is a sorted (newest->oldest) list of un-released
     # versions
-    if branch == git_default_branch_name():
-        return versions[-1]
-    else:
-        branch_ver = branch.replace("branch-", "")
-        return [v for v in versions if v.startswith(branch_ver)][-1]
+    return versions[-1]
 
 
 MIGRATION_COMMENT_REGEX = re.compile(
@@ -331,7 +327,7 @@ def get_candidate_fix_version(mainline_versions,
     mainline_versions = [v for v in mainline_versions
                          if f"maint-{v}" not in maintenance_branches]
     default_fix_versions = [
-        fix_version_from_branch(x, mainline_versions)
+        fix_version_from_branch(mainline_versions)
         for x in merge_branches]
 
     return default_fix_versions[0]

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -110,31 +110,6 @@ def strip_ci_directives(commit_message):
     # commit message
     return _REGEX_CI_DIRECTIVE.sub('', commit_message)
 
-
-def git_default_branch_name():
-    default_branch_name = os.getenv("MERGE_SCRIPT_DEFAULT_BRANCH_NAME")
-
-    if default_branch_name is None:
-        try:
-            default_reference = run_cmd(
-                "git rev-parse --abbrev-ref origin/HEAD")
-            if default_reference.startswith("origin/"):
-                default_branch_name = default_reference[len("origin/"):]
-            default_branch_name = default_branch_name.rstrip()
-        except subprocess.CalledProcessError:
-            # TODO: ARROW-18011 to track changing the hard coded default
-            # value from "master" to "main".
-            default_branch_name = "master"
-            warnings.warn('Unable to determine default branch name: '
-                          'MERGE_SCRIPT_DEFAULT_BRANCH_NAME environment '
-                          'variable is not set. Git repository does not '
-                          'contain a \'refs/remotes/origin/HEAD\'reference. '
-                          ' Setting the default branch name to ' +
-                          default_branch_name, RuntimeWarning)
-
-    return default_branch_name
-
-
 def fix_version_from_branch(versions):
     # Note: Assumes this is a sorted (newest->oldest) list of un-released
     # versions
@@ -299,10 +274,7 @@ class GitHubIssue(object):
 
 
 def get_candidate_fix_version(mainline_versions,
-                              merge_branches=None,
                               maintenance_branches=()):
-    if merge_branches is None:
-        merge_branches = (git_default_branch_name(),)
 
     all_versions = [getattr(v, "name", v) for v in mainline_versions]
 

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -302,7 +302,6 @@ def get_candidate_fix_version(mainline_versions,
 
     return default_fix_versions
 
-
 def format_issue_output(issue_type, issue_id, status,
                         summary, assignee, components):
     if not assignee:

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -301,8 +301,11 @@ class GitHubIssue(object):
 
 
 def get_candidate_fix_version(mainline_versions,
-                              merge_branches=('master',),
+                              merge_branches,
                               maintenance_branches=()):
+    if merge_branches is None:
+        merge_branches = (git_default_branch_name(),)
+
     all_versions = [getattr(v, "name", v) for v in mainline_versions]
 
     def version_tuple(x):

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -111,7 +111,8 @@ def strip_ci_directives(commit_message):
 
 
 def git_default_branch_name():
-    return run_cmd("git rev-parse --abbrev-ref origin/HEAD | sed s@origin/@@")
+    default_reference = run_cmd("git rev-parse --abbrev-ref origin/HEAD")
+    return default_reference.lstrip("origin/")
 
 
 def fix_version_from_branch(branch, versions):

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -302,6 +302,7 @@ def get_candidate_fix_version(mainline_versions,
 
     return default_fix_versions
 
+
 def format_issue_output(issue_type, issue_id, status,
                         summary, assignee, components):
     if not assignee:


### PR DESCRIPTION
# Overview
The goal of this pull request is to update the GitHub merge script to work with a repository default branch named `master` or `main`, as part of the effort to rename the Apache Arrow repository's default branch to `main`. The parent Jira ticket can be found [here](https://issues.apache.org/jira/browse/ARROW-15689). 

# Implementation
- In `.github/workflows/dev.yml`, get and pass the default branch name to the merge test script. 
- Added a function named `git_default_branch_name` to `dev/merge_arrow_pr.py`.
- Used `git_default_branch_name` to replace hard-coded usages of `master` in the file.

# Testing
- Ran the `dev/merge_arrow_pr.py` in debug mode to confirm that there are no errors when attempting to merge an existing pull request.
- Ran `test_merge_arrow_pr.py` locally to confirm there are no failures.

# Future Directions
Updated ARROW-18011 to include updating the hard-coded `master` value in `test_merge_arrow_pr.py`.

# Notes
Thank you @kevingurney for your help with this pull request!
* Closes: #33005