### PR TITLE
ARROW-18178: [Java] ArrowVectorIterator incorrectly closes Vectors

### DIFF
--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/ArrowVectorIterator.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/ArrowVectorIterator.java
@@ -183,7 +183,8 @@ public class ArrowVectorIterator implements Iterator<VectorSchemaRoot>, AutoClos
   }
 
   /**
-   * Clean up resources.
+   * Clean up resources ONLY WHEN THE {@link VectorSchemaRoot} HOLDING EACH BATCH IS REUSED. If a new VectorSchemaRoot
+   * is created for each batch, each root must be closed manually by the client code.
    */
   @Override
   public void close() {

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/ArrowVectorIterator.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/ArrowVectorIterator.java
@@ -189,7 +189,7 @@ public class ArrowVectorIterator implements Iterator<VectorSchemaRoot>, AutoClos
   public void close() {
     if (config.isReuseVectorSchemaRoot()) {
       nextBatch.close();
+      compositeConsumer.close();
     }
-    compositeConsumer.close();
   }
 }

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/UnreliableMetaDataTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/UnreliableMetaDataTest.java
@@ -113,7 +113,8 @@ public class UnreliableMetaDataTest {
 
     try (ArrowVectorIterator iter = JdbcToArrow.sqlToArrowVectorIterator(rs, config)) {
       while (iter.hasNext()) {
-        iter.next();
+        VectorSchemaRoot root = iter.next();
+        root.close();
       }
     }
   }
@@ -159,7 +160,8 @@ public class UnreliableMetaDataTest {
         .build();
     try (ArrowVectorIterator iter = JdbcToArrow.sqlToArrowVectorIterator(rs, config)) {
       while (iter.hasNext()) {
-        iter.next();
+        VectorSchemaRoot root = iter.next();
+        root.close();
       }
     }
   }
@@ -200,6 +202,7 @@ public class UnreliableMetaDataTest {
         assertEquals(1024, ints.get(0));
         assertFalse(ints.isNull(1));
         assertFalse(iter.hasNext());
+        root.close();
       }
 
       rs.beforeFirst();
@@ -223,6 +226,7 @@ public class UnreliableMetaDataTest {
         assertEquals(1024, ints.get(0));
         assertTrue(ints.isNull(1));
         assertFalse(iter.hasNext());
+        root.close();
       }
 
       rs.beforeFirst();
@@ -245,6 +249,7 @@ public class UnreliableMetaDataTest {
         assertEquals(1024, ints.get(0));
         assertFalse(ints.isNull(1));
         assertFalse(iter.hasNext());
+        root.close();
       }
     }
   }


### PR DESCRIPTION
Prevent vectors from being closed when ArrowVectorIterator closes in the case where the reuseVectorSchemaRoot flag is set to false. 

Test in JDBCToArrowVectorIteratorTest was updated to cover this case. 

Tests in  UnreliableMetaDataTest were modified to manually close VectorSchemaRoots, preventing an unclosed buffer exception being thrown when the RootAllocator was closed. 