### PR TITLE
ARROW-18185: [C++][Compute] Support KEEP_NULL option for compute::Filter

### DIFF
--- a/cpp/src/arrow/compute/api_vector.cc
+++ b/cpp/src/arrow/compute/api_vector.cc
@@ -63,6 +63,21 @@ struct EnumTraits<FilterOptions::NullSelectionBehavior>
   }
 };
 template <>
+struct EnumTraits<FilterOptions::FilteredValueBehavior>
+    : BasicEnumTraits<FilterOptions::FilteredValueBehavior, FilterOptions::REMOVE,
+                      FilterOptions::KEEP_NULL> {
+  static std::string name() { return "FilterOptions::FilteredValueBehavior"; }
+  static std::string value_name(FilterOptions::FilteredValueBehavior value) {
+    switch (value) {
+      case FilterOptions::REMOVE:
+        return "REMOVE";
+      case FilterOptions::KEEP_NULL:
+        return "KEEP_NULL";
+    }
+    return "<INVALID>";
+  }
+};
+template <>
 struct EnumTraits<DictionaryEncodeOptions::NullEncodingBehavior>
     : BasicEnumTraits<DictionaryEncodeOptions::NullEncodingBehavior,
                       DictionaryEncodeOptions::ENCODE, DictionaryEncodeOptions::MASK> {
@@ -139,7 +154,8 @@ namespace internal {
 namespace {
 using ::arrow::internal::DataMember;
 static auto kFilterOptionsType = GetFunctionOptionsType<FilterOptions>(
-    DataMember("null_selection_behavior", &FilterOptions::null_selection_behavior));
+    DataMember("null_selection_behavior", &FilterOptions::null_selection_behavior),
+    DataMember("filtered_value_behavior", &FilterOptions::filtered_value_behavior));
 static auto kTakeOptionsType = GetFunctionOptionsType<TakeOptions>(
     DataMember("boundscheck", &TakeOptions::boundscheck));
 static auto kDictionaryEncodeOptionsType =
@@ -168,9 +184,11 @@ static auto kRankOptionsType = GetFunctionOptionsType<RankOptions>(
 }  // namespace
 }  // namespace internal
 
-FilterOptions::FilterOptions(NullSelectionBehavior null_selection)
+FilterOptions::FilterOptions(NullSelectionBehavior null_selection,
+                             FilteredValueBehavior filtered_value)
     : FunctionOptions(internal::kFilterOptionsType),
-      null_selection_behavior(null_selection) {}
+      null_selection_behavior(null_selection),
+      filtered_value_behavior(filtered_value) {}
 constexpr char FilterOptions::kTypeName[];
 
 TakeOptions::TakeOptions(bool boundscheck)

--- a/cpp/src/arrow/compute/api_vector.h
+++ b/cpp/src/arrow/compute/api_vector.h
@@ -43,11 +43,22 @@ class ARROW_EXPORT FilterOptions : public FunctionOptions {
     EMIT_NULL,
   };
 
-  explicit FilterOptions(NullSelectionBehavior null_selection = DROP);
+  /// Configure the action taken when a value is filtered
+  enum FilteredValueBehavior {
+    /// The corresponding filtered value will be removed in the output.
+    REMOVE,
+    /// The corresponding filtered value will be null in the output. It shadows
+    /// NullSelectionBehavior since no values are dropped at all.
+    KEEP_NULL,
+  };
+
+  explicit FilterOptions(NullSelectionBehavior null_selection = DROP,
+                         FilteredValueBehavior filtered_value = REMOVE);
   static constexpr char const kTypeName[] = "FilterOptions";
   static FilterOptions Defaults() { return FilterOptions(); }
 
   NullSelectionBehavior null_selection_behavior = DROP;
+  FilteredValueBehavior filtered_value_behavior = REMOVE;
 };
 
 class ARROW_EXPORT TakeOptions : public FunctionOptions {

--- a/cpp/src/arrow/compute/kernels/vector_selection.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection.cc
@@ -793,60 +793,9 @@ inline void PrimitiveFilterImpl<BooleanType>::WriteNull() {
   bit_util::ClearBit(out_data_, out_offset_ + out_position_++);
 }
 
-// // Construct a filter for each type and call Filter on child arrays.
-// Status FilterKeepNullDenseUnionImpl(KernelContext* ctx, const ExecSpan& batch,
-//                                     ExecResult* out) {
-//   const auto& values = batch[0].array;
-//   const auto num_children = values.child_data.size();
-//   const auto* values_types = values.GetValues<int8_t>(1);
-//   std::vector<std::shared_ptr<Buffer>> child_filter_buffers(num_children);
-//   for (size_t i = 0; i < num_children; ++i) {
-//     ARROW_ASSIGN_OR_RAISE(child_filter_buffers[i],
-//                           ctx->AllocateBitmap(values.child_data[i].length));
-//   }
-//   const auto& filter = batch[1].array;
-//   const auto filter_offset = filter.offset;
-//   const auto* filter_is_valid = filter.buffers[0].data;
-//   const auto* filter_data = filter.buffers[1].data;
-//   for (int64_t i = 0; i < filter.length; ++i) {
-//     auto type_index = values_types[i];
-//     std::vector<int64_t> child_positions(num_children, 0);
-//     auto filter_value_is_valid =
-//         filter_is_valid ? bit_util::GetBit(filter_is_valid, i + filter_offset) : true;
-//     if (filter_value_is_valid && bit_util::GetBit(filter_data, i + filter_offset)) {
-//       bit_util::SetBit(child_filter_buffers[type_index]->mutable_data(),
-//                        child_positions[type_index]++);
-//     }
-//   }
-
-//   auto* out_arr = out->array_data().get();
-//   out_arr->length = values.length;
-//   out_arr->offset = values.offset;
-//   for (size_t i : {1, 2}) {
-//     out_arr->buffers[i] = *values.buffers[i].owner;
-//   }
-//   out_arr->child_data.resize(num_children);
-//   for (size_t i = 0; i < num_children; ++i) {
-//     ARROW_ASSIGN_OR_RAISE(
-//         auto filtered_datum,
-//         Filter(values.child_data[i].ToArrayData(),
-//                ArrayData::Make(arrow::boolean(), values.child_data[i].length,
-//                                {child_filter_buffers[i]}),
-//                FilterState::Get(ctx), ctx->exec_context()));
-//     out_arr->child_data[i] = filtered_datum.make_array()->data();
-//   }
-//   ARROW_LOG(INFO) << "values: " << values.ToArray()->ToString();
-//   ARROW_LOG(INFO) << "filter: " << filter.ToArray()->ToString();
-//   ARROW_LOG(INFO) << "out: " << MakeArray(out->array_data())->ToString();
-//   return Status::OK();
-// }
-
 // KEEP_NULL filters only need to construct a new bitmap and shallow copy other buffers
 // and child arrays, except for Dense Union which doesn't have bitmaps
 Status FilterKeepNullImpl(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
-  // if (out->type()->id() == Type::DENSE_UNION) {
-  //   return FilterKeepNullDenseUnionImpl(ctx, batch, out);
-  // }
   const auto& values = batch[0].array;
   const auto* values_is_valid = values.buffers[0].data;
   const auto values_offset = values.offset;

--- a/cpp/src/arrow/compute/kernels/vector_selection.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection.cc
@@ -2514,7 +2514,7 @@ Status FilterExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
   if (filtered_value == FilterOptions::KEEP_NULL &&
       out->type()->id() != Type::DENSE_UNION) {
     return FilterKeepNullImpl(ctx, batch, out);
-  };
+  }
 
   // TODO: where are the values and filter length equality checked?
   int64_t output_length =


### PR DESCRIPTION
The current Filter implementation always drops the filtered values. In some use cases, it's desirable for the output array to have the same size as the inut array. So I added a new option FilterOptions::KEEP_NULL where the filtered values are kept as nulls.

For example, with input [1, 2, 3] and filter [true, false, true], the current implementation will output [1, 3] and with the new option it will output [1, null, 3]

This option is simpler to implement since we only need to construct a new validity bitmap and reuse the input buffers and child arrays. Except for dense union arrays which don't have validity bitmaps.

It is also faster to filter with FilterOptions::KEEP_NULL according to the benchmark result in most cases. So users can choose this option for better performance when dropping filtered values is not required.