### PR TITLE
ARROW-2651: [Python] Fix datetime C API import for PyPy

### DIFF
--- a/python/pyarrow/src/arrow/python/datetime.cc
+++ b/python/pyarrow/src/arrow/python/datetime.cc
@@ -97,6 +97,7 @@ static PyStructSequence_Desc MonthDayNanoTupleDesc = {
 
 }  // namespace
 
+#ifndef PYPY_VERSION
 PyDateTime_CAPI* datetime_api = nullptr;
 
 void InitDatetime() {
@@ -107,6 +108,7 @@ void InitDatetime() {
     Py_FatalError("Could not import datetime C API");
   }
 }
+#endif
 
 // The following code is adapted from
 // https://github.com/numpy/numpy/blob/master/numpy/core/src/multiarray/datetime.c

--- a/python/pyarrow/src/arrow/python/datetime.h
+++ b/python/pyarrow/src/arrow/python/datetime.h
@@ -32,16 +32,22 @@
 // C datetime API.  This is error-prone and potentially costly.
 // Instead, we redefine PyDateTimeAPI to point to a global variable,
 // which is initialized once by calling InitDatetime().
-#define PyDateTimeAPI ::arrow::py::internal::datetime_api
+#ifdef PYPY_VERSION
+#include "datetime.h"
+#else
+  #define PyDateTimeAPI ::arrow::py::internal::datetime_api
+#endif
 
 namespace arrow {
 namespace py {
 namespace internal {
 
+#ifndef PYPY_VERSION
 extern PyDateTime_CAPI* datetime_api;
 
 ARROW_PYTHON_EXPORT
 void InitDatetime();
+#endif
 
 // Returns the MonthDayNano namedtuple type (increments the reference count).
 ARROW_PYTHON_EXPORT

--- a/python/pyarrow/src/arrow/python/datetime.h
+++ b/python/pyarrow/src/arrow/python/datetime.h
@@ -35,7 +35,7 @@
 #ifdef PYPY_VERSION
 #include "datetime.h"
 #else
-  #define PyDateTimeAPI ::arrow::py::internal::datetime_api
+#define PyDateTimeAPI ::arrow::py::internal::datetime_api
 #endif
 
 namespace arrow {

--- a/python/pyarrow/src/arrow/python/pyarrow.cc
+++ b/python/pyarrow/src/arrow/python/pyarrow.cc
@@ -40,7 +40,11 @@ static Status UnwrapError(PyObject* obj, const char* expected_type) {
 }
 
 int import_pyarrow() {
+#ifdef PYPY_VERSION
+PyDateTime_IMPORT;
+#else
   internal::InitDatetime();
+#endif
   return ::import_pyarrow__lib();
 }
 

--- a/python/pyarrow/src/arrow/python/pyarrow.cc
+++ b/python/pyarrow/src/arrow/python/pyarrow.cc
@@ -41,7 +41,7 @@ static Status UnwrapError(PyObject* obj, const char* expected_type) {
 
 int import_pyarrow() {
 #ifdef PYPY_VERSION
-PyDateTime_IMPORT;
+  PyDateTime_IMPORT;
 #else
   internal::InitDatetime();
 #endif


### PR DESCRIPTION
As described in the [ARROW-2651](https://issues.apache.org/jira/browse/ARROW-2651) issue, this patch fixes the C datetime module import mechanism for PyPy. 

This is related to #2089 which was closed in favor of the JIRA issue.