### PR TITLE
PARQUET-2209: [parquet-cpp]  Optimize skip for the case that number of values to skip equals page size

### DIFF
--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -852,7 +852,6 @@ class ColumnReaderImplBase {
     return num_buffered_values_ - num_decoded_values_;
   }
 
-
   const ColumnDescriptor* descr_;
   const int16_t max_def_level_;
   const int16_t max_rep_level_;

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -848,6 +848,11 @@ class ColumnReaderImplBase {
                               static_cast<int>(data_size));
   }
 
+  int64_t available_values_current_page() const {
+    return num_buffered_values_ - num_decoded_values_;
+  }
+
+
   const ColumnDescriptor* descr_;
   const int16_t max_def_level_;
   const int16_t max_rep_level_;
@@ -1150,12 +1155,14 @@ int64_t TypedColumnReaderImpl<DType>::ReadBatchSpaced(
 template <typename DType>
 int64_t TypedColumnReaderImpl<DType>::Skip(int64_t num_values_to_skip) {
   int64_t values_to_skip = num_values_to_skip;
-  while (HasNext() && values_to_skip > 0) {
+  // Optimization: Do not call HasNext() when values_to_skip == 0.
+  while (values_to_skip > 0 && HasNext()) {
     // If the number of values to skip is more than the number of undecoded values, skip
     // the Page.
-    if (values_to_skip > (this->num_buffered_values_ - this->num_decoded_values_)) {
-      values_to_skip -= this->num_buffered_values_ - this->num_decoded_values_;
-      this->num_decoded_values_ = this->num_buffered_values_;
+    const int64_t available_values = this->available_values_current_page();
+    if (values_to_skip >= available_values) {
+      values_to_skip -= available_values;
+      this->ConsumeBufferedValues(available_values);
     } else {
       // We need to read this Page
       // Jump to the right offset in the Page
@@ -1259,10 +1266,6 @@ class TypedRecordReader : public TypedColumnReaderImpl<DType>,
     Reset();
   }
 
-  int64_t available_values_current_page() const {
-    return this->num_buffered_values_ - this->num_decoded_values_;
-  }
-
   // Compute the values capacity in bytes for the given number of elements
   int64_t bytes_for_values(int64_t nitems) const {
     int64_t type_size = GetTypeByteSize(this->descr_->physical_type());
@@ -1301,7 +1304,8 @@ class TypedRecordReader : public TypedColumnReaderImpl<DType>,
 
       /// We perform multiple batch reads until we either exhaust the row group
       /// or observe the desired number of records
-      int64_t batch_size = std::min(level_batch_size, available_values_current_page());
+      int64_t batch_size =
+          std::min(level_batch_size, this->available_values_current_page());
 
       // No more data in column
       if (batch_size == 0) {

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -1482,7 +1482,8 @@ class TypedRecordReader : public TypedColumnReaderImpl<DType>,
       }
 
       // Read some more levels.
-      int64_t batch_size = std::min(level_batch_size, available_values_current_page());
+      int64_t batch_size =
+          std::min(level_batch_size, this->available_values_current_page());
       // No more data in column. This must be an empty page.
       // If we had exhausted the last page, HasNextInternal() must have advanced
       // to the next page. So there must be available values to process.

--- a/cpp/src/parquet/column_reader_test.cc
+++ b/cpp/src/parquet/column_reader_test.cc
@@ -320,7 +320,7 @@ TEST_F(TestPrimitiveReader, TestSkipAroundPageBoundries) {
       values_.begin() + 5.5 * levels_per_page);
   ASSERT_TRUE(vector_equal(sub_values, vresult));
 
-  // 3) skip_size < page_size (skip limited to a single page)
+  // 4) skip_size < page_size (skip limited to a single page)
   // Skip half a page (page 5.5 to 6)
   levels_skipped = reader->Skip(levels_per_page / 2);
   ASSERT_EQ(0.5 * levels_per_page, levels_skipped);
@@ -334,11 +334,11 @@ TEST_F(TestPrimitiveReader, TestSkipAroundPageBoundries) {
       values_.begin() + 6.5 * levels_per_page);
   ASSERT_TRUE(vector_equal(sub_values, vresult));
 
-  // 4) skip_size = 0
+  // 5) skip_size = 0
   levels_skipped = reader->Skip(0);
   ASSERT_EQ(0, levels_skipped);
 
-  // 5) Skip past the end page.
+  // 6) Skip past the end page.
   levels_skipped = reader->Skip(levels_per_page / 2 + 10);
   ASSERT_EQ(levels_per_page / 2, levels_skipped);
 

--- a/cpp/src/parquet/column_reader_test.cc
+++ b/cpp/src/parquet/column_reader_test.cc
@@ -267,7 +267,7 @@ TEST_F(TestPrimitiveReader, TestInt32FlatRepeated) {
 // Tests skipping around page boundaries.
 TEST_F(TestPrimitiveReader, TestSkipAroundPageBoundries) {
   int levels_per_page = 100;
-  int num_pages = 5;
+  int num_pages = 7;
   max_def_level_ = 0;
   max_rep_level_ = 0;
   NodePtr type = schema::Int32("b", Repetition::REQUIRED);
@@ -307,28 +307,40 @@ TEST_F(TestPrimitiveReader, TestSkipAroundPageBoundries) {
       values_.begin() + 4 * levels_per_page);
   ASSERT_TRUE(vector_equal(sub_values, vresult));
 
-  // 3) skip_size < page_size (skip limited to a single page)
-  // Skip half a page (page 4 to 4.5)
-  levels_skipped = reader->Skip(levels_per_page / 2);
-  ASSERT_EQ(0.5 * levels_per_page, levels_skipped);
-  // Read half a page (page 4.5 to 5)
+  // 3) skip_size == page_size (skip page 4 from start of the page to the end)
+  levels_skipped = reader->Skip(levels_per_page);
+  ASSERT_EQ(levels_per_page, levels_skipped);
+  // Read half a page (page 5 to 5.5)
   reader->ReadBatch(levels_per_page / 2, dresult.data(), rresult.data(), vresult.data(),
                     &values_read);
   sub_values.clear();
   sub_values.insert(
       sub_values.end(),
-      values_.begin() + static_cast<int>(4.5 * static_cast<double>(levels_per_page)),
-      values_.end());
+      values_.begin() + static_cast<int>(5 * static_cast<double>(levels_per_page)),
+      values_.begin() + 5.5 * levels_per_page);
+  ASSERT_TRUE(vector_equal(sub_values, vresult));
+
+  // 3) skip_size < page_size (skip limited to a single page)
+  // Skip half a page (page 5.5 to 6)
+  levels_skipped = reader->Skip(levels_per_page / 2);
+  ASSERT_EQ(0.5 * levels_per_page, levels_skipped);
+  // Read half a page (6 to 6.5)
+  reader->ReadBatch(levels_per_page / 2, dresult.data(), rresult.data(), vresult.data(),
+                    &values_read);
+  sub_values.clear();
+  sub_values.insert(
+      sub_values.end(),
+      values_.begin() + static_cast<int>(6 * static_cast<double>(levels_per_page)),
+      values_.begin() + 6.5 * levels_per_page);
   ASSERT_TRUE(vector_equal(sub_values, vresult));
 
   // 4) skip_size = 0
   levels_skipped = reader->Skip(0);
   ASSERT_EQ(0, levels_skipped);
 
-  // 5) Skip past the end page. There are 5 pages and we have either skipped
-  // or read all of them, so there is nothing left to skip.
-  levels_skipped = reader->Skip(10);
-  ASSERT_EQ(0, levels_skipped);
+  // 5) Skip past the end page.
+  levels_skipped = reader->Skip(levels_per_page / 2 + 10);
+  ASSERT_EQ(levels_per_page / 2, levels_skipped);
 
   values_.clear();
   def_levels_.clear();

--- a/cpp/src/parquet/column_reader_test.cc
+++ b/cpp/src/parquet/column_reader_test.cc
@@ -291,7 +291,7 @@ TEST_F(TestPrimitiveReader, TestSkipAroundPageBoundries) {
                     &values_read);
   std::vector<int32_t> sub_values(
       values_.begin() + 2 * levels_per_page,
-      values_.begin() + static_cast<int>(2.5 * static_cast<double>(levels_per_page)));
+      values_.begin() + static_cast<int>(2.5 * levels_per_page));
   ASSERT_TRUE(vector_equal(sub_values, vresult));
 
   // 2) skip_size == page_size (skip across two pages from page 2.5 to 3.5)
@@ -301,10 +301,9 @@ TEST_F(TestPrimitiveReader, TestSkipAroundPageBoundries) {
   reader->ReadBatch(levels_per_page / 2, dresult.data(), rresult.data(), vresult.data(),
                     &values_read);
   sub_values.clear();
-  sub_values.insert(
-      sub_values.end(),
-      values_.begin() + static_cast<int>(3.5 * static_cast<double>(levels_per_page)),
-      values_.begin() + 4 * levels_per_page);
+  sub_values.insert(sub_values.end(),
+                    values_.begin() + static_cast<int>(3.5 * levels_per_page),
+                    values_.begin() + 4 * levels_per_page);
   ASSERT_TRUE(vector_equal(sub_values, vresult));
 
   // 3) skip_size == page_size (skip page 4 from start of the page to the end)
@@ -314,10 +313,9 @@ TEST_F(TestPrimitiveReader, TestSkipAroundPageBoundries) {
   reader->ReadBatch(levels_per_page / 2, dresult.data(), rresult.data(), vresult.data(),
                     &values_read);
   sub_values.clear();
-  sub_values.insert(
-      sub_values.end(),
-      values_.begin() + static_cast<int>(5 * static_cast<double>(levels_per_page)),
-      values_.begin() + 5.5 * levels_per_page);
+  sub_values.insert(sub_values.end(),
+                    values_.begin() + static_cast<int>(5.0 * levels_per_page),
+                    values_.begin() + static_cast<int>(5.5 * levels_per_page));
   ASSERT_TRUE(vector_equal(sub_values, vresult));
 
   // 4) skip_size < page_size (skip limited to a single page)
@@ -328,10 +326,9 @@ TEST_F(TestPrimitiveReader, TestSkipAroundPageBoundries) {
   reader->ReadBatch(levels_per_page / 2, dresult.data(), rresult.data(), vresult.data(),
                     &values_read);
   sub_values.clear();
-  sub_values.insert(
-      sub_values.end(),
-      values_.begin() + static_cast<int>(6 * static_cast<double>(levels_per_page)),
-      values_.begin() + 6.5 * levels_per_page);
+  sub_values.insert(sub_values.end(),
+                    values_.begin() + static_cast<int>(6.0 * levels_per_page),
+                    values_.begin() + static_cast<int>(6.5 * levels_per_page));
   ASSERT_TRUE(vector_equal(sub_values, vresult));
 
   // 5) skip_size = 0


### PR DESCRIPTION
In the current code, we will read this page because we are using > and not >= in the branch that decides to skip the rest of the page.

Also includes minor refactoring to reuse the function available_values_current_page(), and use ConsumeBufferedValues() accordingly.

Benchmark results for when batch size = 100K and  number of values per page = 100K.
```
BEFORE
-------------------------------------------------------------------------------
Benchmark       Time             CPU         Iterations
-------------------------------------------------------------------------------
REQUIRED      96831 ns        96326 ns         1000
OPTIONAL     623897 ns       621734 ns         1000
REPEATED    1006153 ns       997482 ns         1000

AFTER
-------------------------------------------------------------------------------
Benchmark      Time             CPU          Iterations
-------------------------------------------------------------------------------
REQUIRED       2175 ns         2164 ns         1000
OPTIONAL       2743 ns         2719 ns         1000
REPEATED       2368 ns         2424 ns         1000
```