### PR TITLE
ARROW-17832: [Python] Construct MapArray from sequence of dicts (instead of list of tuples)

### DIFF
--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -760,6 +760,11 @@ class PyListConverter : public ListConverter<T, PyConverter, PyConverterTrait> {
       RETURN_NOT_OK(AppendSequence(value));
     } else if (PySet_Check(value) || (Py_TYPE(value) == &PyDictValues_Type)) {
       RETURN_NOT_OK(AppendIterable(value));
+    } else if (PyDict_Check(value) && this->options_.type->name() == "map") {
+      // Branch to support Python Dict with `map` DataType.
+      auto items = PyDict_Items(value);
+      OwnedRef item_ref(items);
+      RETURN_NOT_OK(AppendSequence(items));
     } else {
       return internal::InvalidType(
           value, "was not a sequence or recognized null for conversion to list type");

--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -760,7 +760,7 @@ class PyListConverter : public ListConverter<T, PyConverter, PyConverterTrait> {
       RETURN_NOT_OK(AppendSequence(value));
     } else if (PySet_Check(value) || (Py_TYPE(value) == &PyDictValues_Type)) {
       RETURN_NOT_OK(AppendIterable(value));
-    } else if (PyDict_Check(value) && this->options_.type->name() == "map") {
+    } else if (PyDict_Check(value) && this->options_.type->id() == Type::MAP) {
       // Branch to support Python Dict with `map` DataType.
       auto items = PyDict_Items(value);
       OwnedRef item_ref(items);

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -991,6 +991,18 @@ def test_map_labelled():
     assert len(arr) == 2
 
 
+def test_map_from_dict():
+    # ARROW-17832
+    tup_arr = pa.array([[('a', 1), ('b', 2)], [('c', 3)]],
+                       pa.map_(pa.string(), pa.int64()))
+    dict_arr = pa.array([{'a': 1, 'b': 2}, {'c': 3}],
+                        pa.map_(pa.string(), pa.int64()))
+
+    assert tup_arr.type.key_field == dict_arr.type.key_field
+    assert tup_arr.type.item_field == dict_arr.type.item_field
+    assert tup_arr == dict_arr
+
+
 def test_map_from_arrays():
     offsets_arr = np.array([0, 2, 5, 8], dtype='i4')
     offsets = pa.array(offsets_arr, type='int32')

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -998,9 +998,7 @@ def test_map_from_dict():
     dict_arr = pa.array([{'a': 1, 'b': 2}, {'c': 3}],
                         pa.map_(pa.string(), pa.int64()))
 
-    assert tup_arr.type.key_field == dict_arr.type.key_field
-    assert tup_arr.type.item_field == dict_arr.type.item_field
-    assert tup_arr == dict_arr
+    assert tup_arr.equals(dict_arr)
 
 
 def test_map_from_arrays():


### PR DESCRIPTION
Following snippet now works.
```python
dict_arr = pa.array([{'a': 1, 'b': 2}, {'c': 3}],
                    pa.map_(pa.string(), pa.int64()))
```