### PR TITLE
ARROW-18184: [C++] Improve JSON parser benchmarks

### DIFF
--- a/cpp/src/arrow/json/parser_benchmark.cc
+++ b/cpp/src/arrow/json/parser_benchmark.cc
@@ -104,7 +104,7 @@ static void ChunkJSONPrettyPrinted(
   options.newlines_in_values = true;
   options.explicit_schema = schema(TestFields());
 
-  auto json = GenerateTestData(options.explicit_schema, num_rows, /*pretty=*/ true);
+  auto json = GenerateTestData(options.explicit_schema, num_rows, /*pretty=*/true);
   BenchmarkJSONChunking(state, std::make_shared<Buffer>(json), options);
 }
 
@@ -221,10 +221,7 @@ BENCHMARK(ReadJSONBlockWithSchemaMultiThread)->UseRealTime();
 BENCHMARK(ParseJSONFields)
     // NOTE: "sparsity" is the proportion of missing fields from 0-10
     ->ArgNames({"ordered", "schema", "sparsity", "num_fields"})
-    // Ordered/unordered fields with/without an explicit schema
-    ->ArgsProduct({{1, 0}, {1, 0}, {0}, {10, 100, 1000}})
-    // Non-contiguous ordered fields with/without an explicit schema
-    ->ArgsProduct({{1}, {1, 0}, {1, 9}, {10, 100, 1000}});
+    ->ArgsProduct({{1, 0}, {1, 0}, {0, 1, 9}, {10, 100, 1000}});
 
 }  // namespace json
 }  // namespace arrow

--- a/cpp/src/arrow/json/parser_benchmark.cc
+++ b/cpp/src/arrow/json/parser_benchmark.cc
@@ -104,7 +104,7 @@ static void ChunkJSONPrettyPrinted(
   options.newlines_in_values = true;
   options.explicit_schema = schema(TestFields());
 
-  auto json = GenerateTestData(options.explicit_schema, num_rows, true);
+  auto json = GenerateTestData(options.explicit_schema, num_rows, /*pretty=*/ true);
   BenchmarkJSONChunking(state, std::make_shared<Buffer>(json), options);
 }
 
@@ -187,7 +187,7 @@ static void ReadJSONBlockWithSchemaMultiThread(
   BenchmarkReadJSONBlockWithSchema(state, true);
 }
 
-static void ParseFields(benchmark::State& state) {  // NOLINT non-const reference
+static void ParseJSONFields(benchmark::State& state) {  // NOLINT non-const reference
   const bool ordered = !!state.range(0);
   const bool with_schema = !!state.range(1);
   const double sparsity = state.range(2) / 10.0;
@@ -218,9 +218,9 @@ BENCHMARK(ParseJSONBlockWithSchema);
 BENCHMARK(ReadJSONBlockWithSchemaSingleThread);
 BENCHMARK(ReadJSONBlockWithSchemaMultiThread)->UseRealTime();
 
-BENCHMARK(ParseFields)
+BENCHMARK(ParseJSONFields)
     // NOTE: "sparsity" is the proportion of missing fields from 0-10
-    ->ArgNames({"ordered", "schema", "sparsity", "n"})
+    ->ArgNames({"ordered", "schema", "sparsity", "num_fields"})
     // Ordered/unordered fields with/without an explicit schema
     ->ArgsProduct({{1, 0}, {1, 0}, {0}, {10, 100, 1000}})
     // Non-contiguous ordered fields with/without an explicit schema

--- a/cpp/src/arrow/json/parser_benchmark.cc
+++ b/cpp/src/arrow/json/parser_benchmark.cc
@@ -94,7 +94,7 @@ static void BenchmarkJSONChunking(benchmark::State& state,  // NOLINT non-const 
   }
 
   state.SetBytesProcessed(state.iterations() * json->size());
-  state.counters["json_size"] = json->size();
+  state.counters["json_size"] = static_cast<double>(json->size());
 }
 
 static void ChunkJSONPrettyPrinted(
@@ -162,7 +162,7 @@ static void BenchmarkJSONReading(benchmark::State& state,  // NOLINT non-const r
   }
 
   state.SetBytesProcessed(state.iterations() * json.size());
-  state.counters["json_size"] = json.size();
+  state.counters["json_size"] = static_cast<double>(json.size());
 }
 
 static void BenchmarkReadJSONBlockWithSchema(

--- a/cpp/src/arrow/json/parser_benchmark.cc
+++ b/cpp/src/arrow/json/parser_benchmark.cc
@@ -17,7 +17,7 @@
 
 #include "benchmark/benchmark.h"
 
-#include <string>
+#include <unordered_set>
 
 #include "arrow/json/chunker.h"
 #include "arrow/json/options.h"
@@ -30,29 +30,62 @@
 namespace arrow {
 namespace json {
 
-std::shared_ptr<Schema> TestSchema() {
-  return schema({field("int", int32()), field("str", utf8())});
-}
+constexpr int kSeed = 0x432432;
 
-constexpr int seed = 0x432432;
-
-std::string TestJsonData(int num_rows, bool pretty = false) {
-  std::default_random_engine engine(seed);
+template <typename Input>
+std::string GenerateTestData(const Input& input, int num_rows,
+                             const GenerateOptions& options, bool pretty = false) {
+  std::default_random_engine engine(kSeed);
   std::string json;
   for (int i = 0; i < num_rows; ++i) {
     StringBuffer sb;
     Writer writer(sb);
-    ABORT_NOT_OK(Generate(TestSchema(), engine, &writer));
+    ABORT_NOT_OK(Generate(input, engine, &writer, options));
     json += pretty ? PrettyPrint(sb.GetString()) : sb.GetString();
     json += "\n";
   }
-
   return json;
 }
 
-static void BenchmarkJSONChunking(benchmark::State& state,
+template <typename Input>
+std::string GenerateTestData(const Input& input, int num_rows, bool pretty = false) {
+  return GenerateTestData(input, num_rows, GenerateOptions::Defaults(), pretty);
+}
+
+FieldVector GenerateTestFields(int num_fields, int mean_name_length) {
+  const std::shared_ptr<DataType> types[] = {boolean(), int64(), float64(), utf8()};
+
+  std::default_random_engine engine(kSeed);
+
+  std::poisson_distribution<int> length_dist(mean_name_length);
+  std::uniform_int_distribution<uint16_t> char_dist(32, 126);
+  std::uniform_int_distribution<size_t> type_dist(0, std::size(types) - 1);
+
+  std::unordered_set<std::string> names;
+  names.reserve(num_fields);
+
+  while (static_cast<int>(names.size()) < num_fields) {
+    auto length = length_dist(engine);
+    if (!length) continue;
+    std::string name(length, '\0');
+    for (auto& ch : name) ch = static_cast<char>(char_dist(engine));
+    names.emplace(std::move(name));
+  }
+
+  FieldVector fields;
+  fields.reserve(num_fields);
+  for (const auto& name : names) {
+    fields.push_back(field(name, types[type_dist(engine)]));
+  }
+
+  return fields;
+}
+
+FieldVector TestFields() { return {field("int", int32()), field("str", utf8())}; }
+
+static void BenchmarkJSONChunking(benchmark::State& state,  // NOLINT non-const reference
                                   const std::shared_ptr<Buffer>& json,
-                                  ParseOptions options) {  // NOLINT non-const reference
+                                  ParseOptions options) {
   auto chunker = MakeChunker(options);
 
   for (auto _ : state) {
@@ -69,9 +102,9 @@ static void ChunkJSONPrettyPrinted(
 
   auto options = ParseOptions::Defaults();
   options.newlines_in_values = true;
-  options.explicit_schema = TestSchema();
+  options.explicit_schema = schema(TestFields());
 
-  auto json = TestJsonData(num_rows, /* pretty */ true);
+  auto json = GenerateTestData(options.explicit_schema, num_rows, true);
   BenchmarkJSONChunking(state, std::make_shared<Buffer>(json), options);
 }
 
@@ -81,15 +114,15 @@ static void ChunkJSONLineDelimited(
 
   auto options = ParseOptions::Defaults();
   options.newlines_in_values = false;
-  options.explicit_schema = TestSchema();
+  options.explicit_schema = schema(TestFields());
 
-  auto json = TestJsonData(num_rows);
+  auto json = GenerateTestData(options.explicit_schema, num_rows);
   BenchmarkJSONChunking(state, std::make_shared<Buffer>(json), options);
   state.SetBytesProcessed(0);
 }
 
 static void BenchmarkJSONParsing(benchmark::State& state,  // NOLINT non-const reference
-                                 const std::shared_ptr<Buffer>& json, int32_t num_rows,
+                                 const std::shared_ptr<Buffer>& json,
                                  ParseOptions options) {
   for (auto _ : state) {
     std::unique_ptr<BlockParser> parser;
@@ -107,15 +140,15 @@ static void ParseJSONBlockWithSchema(
   const int32_t num_rows = 5000;
   auto options = ParseOptions::Defaults();
   options.unexpected_field_behavior = UnexpectedFieldBehavior::Error;
-  options.explicit_schema = TestSchema();
+  options.explicit_schema = schema(TestFields());
 
-  auto json = TestJsonData(num_rows);
-  BenchmarkJSONParsing(state, std::make_shared<Buffer>(json), num_rows, options);
+  auto json = GenerateTestData(options.explicit_schema, num_rows);
+  BenchmarkJSONParsing(state, std::make_shared<Buffer>(json), options);
 }
 
 static void BenchmarkJSONReading(benchmark::State& state,  // NOLINT non-const reference
-                                 const std::string& json, int32_t num_rows,
-                                 ReadOptions read_options, ParseOptions parse_options) {
+                                 const std::string& json, ReadOptions read_options,
+                                 ParseOptions parse_options) {
   for (auto _ : state) {
     std::shared_ptr<io::InputStream> input;
     ABORT_NOT_OK(MakeStream(json, &input));
@@ -130,17 +163,18 @@ static void BenchmarkJSONReading(benchmark::State& state,  // NOLINT non-const r
 }
 
 static void BenchmarkReadJSONBlockWithSchema(
-    benchmark::State& state, bool use_threads) {  // NOLINT non-const reference
+    benchmark::State& state,  // NOLINT non-const reference
+    bool use_threads) {
   const int32_t num_rows = 500000;
   auto read_options = ReadOptions::Defaults();
   read_options.use_threads = use_threads;
 
   auto parse_options = ParseOptions::Defaults();
   parse_options.unexpected_field_behavior = UnexpectedFieldBehavior::Error;
-  parse_options.explicit_schema = TestSchema();
+  parse_options.explicit_schema = schema(TestFields());
 
-  auto json = TestJsonData(num_rows);
-  BenchmarkJSONReading(state, json, num_rows, read_options, parse_options);
+  auto json = GenerateTestData(parse_options.explicit_schema, num_rows);
+  BenchmarkJSONReading(state, json, read_options, parse_options);
 }
 
 static void ReadJSONBlockWithSchemaSingleThread(
@@ -153,12 +187,44 @@ static void ReadJSONBlockWithSchemaMultiThread(
   BenchmarkReadJSONBlockWithSchema(state, true);
 }
 
+static void ParseFields(benchmark::State& state) {  // NOLINT non-const reference
+  const bool ordered = !!state.range(0);
+  const bool with_schema = !!state.range(1);
+  const double sparsity = state.range(2) / 10.0;
+  const auto num_fields = static_cast<int>(state.range(3));
+
+  const int32_t num_rows = 1000;
+
+  auto fields = GenerateTestFields(num_fields, 10);
+
+  auto parse_options = ParseOptions::Defaults();
+  if (with_schema) {
+    parse_options.explicit_schema = schema(fields);
+    parse_options.unexpected_field_behavior = UnexpectedFieldBehavior::Error;
+  }
+
+  auto gen_options = GenerateOptions::Defaults();
+  gen_options.field_probability = 1.0 - sparsity;
+  gen_options.randomize_field_order = !ordered;
+
+  auto json = GenerateTestData(fields, num_rows, gen_options);
+  BenchmarkJSONParsing(state, std::make_shared<Buffer>(json), parse_options);
+}
+
 BENCHMARK(ChunkJSONPrettyPrinted);
 BENCHMARK(ChunkJSONLineDelimited);
 BENCHMARK(ParseJSONBlockWithSchema);
 
 BENCHMARK(ReadJSONBlockWithSchemaSingleThread);
 BENCHMARK(ReadJSONBlockWithSchemaMultiThread)->UseRealTime();
+
+BENCHMARK(ParseFields)
+    // NOTE: "sparsity" is the proportion of missing fields from 0-10
+    ->ArgNames({"ordered", "schema", "sparsity", "n"})
+    // Ordered/unordered fields with/without an explicit schema
+    ->ArgsProduct({{1, 0}, {1, 0}, {0}, {10, 100, 1000}})
+    // Non-contiguous ordered fields with/without an explicit schema
+    ->ArgsProduct({{1}, {1, 0}, {1, 9}, {10, 100, 1000}});
 
 }  // namespace json
 }  // namespace arrow


### PR DESCRIPTION
See: [ARROW-18184](https://issues.apache.org/jira/browse/ARROW-18184).

For context, this is based on [pull/14100](https://github.com/apache/arrow/pull/14100).

This enhances the capabilities of the existing random JSON generators and adds benchmark coverage for ordered/unordered fields, missing fields, and inferred schemas over a range of field counts.