### PR TITLE
ARROW-18208 [JS] Fixes crash when inferring objects with string-valued keys nested in an array

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -5,6 +5,11 @@
     "arrow2csv": "bin/arrow2csv.js"
   },
   "type": "module",
+  "exports": {
+      ".": "targets/esnext/esm/arrow.dom.mjs",
+      "./*": "targets/esnext/esm/*"
+  },
+  "main": "index.ts",
   "scripts": {
     "lerna": "lerna",
     "test": "cross-env NODE_NO_WARNINGS=1 gulp test",

--- a/js/src/builder.ts
+++ b/js/src/builder.ts
@@ -237,6 +237,7 @@ export abstract class Builder<T extends DataType = any, TNull = any> {
      * @returns {this} The updated `Builder` instance.
      */
     public set(index: number, value: T['TValue'] | TNull) {
+	console.log("Oh my oh my", this._isValid)
         if (this.setValid(index, this.isValid(value))) {
             this.setValue(index, value);
         }
@@ -367,6 +368,7 @@ export abstract class VariableWidthBuilder<T extends Binary | Utf8 | List | Map_
         const pending = this._pending || (this._pending = new Map());
         const current = pending.get(index);
         current && (this._pendingLength -= current.length);
+	console.log("OH FUCK FUCK FUCK", index, value)
         this._pendingLength += (value instanceof MapRow) ? value[kKeys].length : value.length;
         pending.set(index, value);
     }

--- a/js/src/builder/struct.ts
+++ b/js/src/builder/struct.ts
@@ -25,10 +25,16 @@ import { Struct, TypeMap } from '../type.js';
 export class StructBuilder<T extends TypeMap = any, TNull = any> extends Builder<Struct<T>, TNull> {
     public setValue(index: number, value: Struct<T>['TValue']) {
         const { children, type } = this;
+	console.log("YOINK", value)
+	console.log(index)
+	console.log(children)
         switch (Array.isArray(value) || value.constructor) {
             case true: return type.children.forEach((_, i) => children[i].set(index, value[i]));
             case Map: return type.children.forEach((f, i) => children[i].set(index, value.get(f.name)));
-            default: return type.children.forEach((f, i) => children[i].set(index, value[f.name]));
+            default: return type.children.forEach((f, i) => {
+		    console.log("in the belly of the whale", f.name,  f, i)
+		    children[i].set(index, value[f.name])
+	    });
         }
     }
 

--- a/js/src/factories.ts
+++ b/js/src/factories.ts
@@ -105,7 +105,14 @@ export function tableFromJSON<T extends Record<string, unknown>>(array: T[]): Ta
 
 /** @ignore */
 function inferType<T extends readonly unknown[]>(values: T): JavaScriptArrayDataType<T>;
-function inferType(value: readonly unknown[]): dtypes.DataType {
+function inferType(values: unknown[], path?: string[], cache?:Map<string[], dtypes.DataType>): dtypes.DataType;
+function inferType(value: readonly unknown[], path?: string[], cache?: Map<string[], dtypes.DataType>): dtypes.DataType {
+    if(!path) {
+    	path = []
+    }
+    if(!cache) {
+    	cache = new Map()
+    }
     if (value.length === 0) { return new dtypes.Null; }
     let nullsCount = 0;
     let arraysCount = 0;
@@ -139,7 +146,12 @@ function inferType(value: readonly unknown[]): dtypes.DataType {
     if (numbersCount + nullsCount === value.length) {
         return new dtypes.Float64;
     } else if (stringsCount + nullsCount === value.length) {
-        return new dtypes.Dictionary(new dtypes.Utf8, new dtypes.Int32);
+        if (cache.has(path)) {
+          return cache.get(path)!
+        }
+        const d =  new dtypes.Dictionary(new dtypes.Utf8, new dtypes.Int32);
+        cache.set(path, d)
+        return d
     } else if (bigintsCount + nullsCount === value.length) {
         return new dtypes.Int64;
     } else if (booleansCount + nullsCount === value.length) {
@@ -148,8 +160,8 @@ function inferType(value: readonly unknown[]): dtypes.DataType {
         return new dtypes.DateMillisecond;
     } else if (arraysCount + nullsCount === value.length) {
         const array = value as Array<unknown>[];
-        const childType = inferType(array[array.findIndex((ary) => ary != null)]);
-        if (array.every((ary) => ary == null || compareTypes(childType, inferType(ary)))) {
+        const childType = inferType(array[array.findIndex((ary) => ary != null)], path, cache);
+        if (array.every((ary) => ary == null || compareTypes(childType, inferType(ary, path, cache)))) {
             return new dtypes.List(new Field('', childType, true));
         }
     } else if (objectsCount + nullsCount === value.length) {
@@ -158,7 +170,9 @@ function inferType(value: readonly unknown[]): dtypes.DataType {
             for (const key of Object.keys(row)) {
                 if (!fields.has(key) && row[key] != null) {
                     // use the type inferred for the first instance of a found key
-                    fields.set(key, new Field(key, inferType([row[key]]), true));
+		    path.push(key)
+                    fields.set(key, new Field(key, inferType([row[key]], path, cache), true));
+		    path.pop()
                 }
             }
         }

--- a/js/src/factories.ts
+++ b/js/src/factories.ts
@@ -83,7 +83,7 @@ export function vectorFromArray(init: any, type?: dtypes.DataType) {
     if (init instanceof Data || init instanceof Vector || init.type instanceof dtypes.DataType || ArrayBuffer.isView(init)) {
         return makeVector(init as any);
     }
-    const options: IterableBuilderOptions = { type: type ?? inferType(init), nullValues: [null] };
+    const options: IterableBuilderOptions = { type: type ?? inferType(init), nullValues: [null, undefined] };
     const chunks = [...builderThroughIterable(options)(init)];
     const vector = chunks.length === 1 ? chunks[0] : chunks.reduce((a, b) => a.concat(b));
     if (dtypes.DataType.isDictionary(vector.type)) {
@@ -229,6 +229,7 @@ export function builderThroughIterable<T extends dtypes.DataType = any, TNull = 
         let numChunks = 0;
         const builder = makeBuilder(options);
         for (const value of source) {
+	    console.log("OH NO", value)
             if (builder.append(value)[sizeProperty] >= highWaterMark) {
                 ++numChunks && (yield builder.toVector());
             }

--- a/js/test/unit/table/table-test.ts
+++ b/js/test/unit/table/table-test.ts
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Bool, Dictionary, Float32, Float64, Int32, Int8, makeTable, tableFromArrays, tableFromJSON } from 'apache-arrow';
+import { Bool, Dictionary, Float32, Float64, Int32, Int8, List, makeTable, Struct, tableFromArrays, tableFromJSON } from 'apache-arrow';
 
 describe('makeTable()', () => {
     test(`creates a new Table from Typed Arrays`, () => {
@@ -78,4 +78,21 @@ describe('tableFromJSON()', () => {
         expect(table.getChild('b')!.type).toBeInstanceOf(Bool);
         expect(table.getChild('c')!.type).toBeInstanceOf(Dictionary);
     });
+
+    test(`creates table from objects with string values nested in an array`, () => {
+	const table = tableFromJSON([{
+		a: [
+			{
+				b: "hi",
+			}
+		]
+	}])
+
+	const list = table.getChild('a')!
+        expect(list.type).toBeInstanceOf(List);
+	const struct = list.getChildAt(0)!
+        expect(struct.type).toBeInstanceOf(Struct);
+	const b = struct.getChild('b')!
+        expect(b.type).toBeInstanceOf(Dictionary);
+    })
 });


### PR DESCRIPTION
resolves: https://issues.apache.org/jira/browse/ARROW-18208

