### PR TITLE
ARROW-18098 [C++] Vector kernel for "intersecting" two arrays

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -446,6 +446,7 @@ if(ARROW_COMPUTE)
        compute/kernels/vector_array_sort.cc
        compute/kernels/vector_cumulative_ops.cc
        compute/kernels/vector_hash.cc
+       compute/kernels/vector_intersect.cc
        compute/kernels/vector_nested.cc
        compute/kernels/vector_replace.cc
        compute/kernels/vector_selection.cc

--- a/cpp/src/arrow/compute/api_vector.h
+++ b/cpp/src/arrow/compute/api_vector.h
@@ -269,6 +269,19 @@ Result<Datum> Filter(const Datum& values, const Datum& filter,
                      const FilterOptions& options = FilterOptions::Defaults(),
                      ExecContext* ctx = NULLPTR);
 
+/// \brief Find the intersection of two arrays
+///
+/// Return the sorted, unique values that are in both of the input arrays.
+///
+/// \param[in] array1
+/// \param[in] array2
+/// \return Array with intersected values
+ARROW_EXPORT
+Result<Datum> Intersect(
+    const Datum& array1,
+    const Datum& array2,
+    ExecContext* ctx = NULLPTR);
+
 namespace internal {
 
 // These internal functions are implemented in kernels/vector_selection.cc

--- a/cpp/src/arrow/compute/kernels/CMakeLists.txt
+++ b/cpp/src/arrow/compute/kernels/CMakeLists.txt
@@ -50,6 +50,7 @@ add_arrow_compute_test(vector_test
                        SOURCES
                        vector_cumulative_ops_test.cc
                        vector_hash_test.cc
+                       vector_intersect_test.cc
                        vector_nested_test.cc
                        vector_replace_test.cc
                        vector_selection_test.cc

--- a/cpp/src/arrow/compute/kernels/vector_intersect.cc
+++ b/cpp/src/arrow/compute/kernels/vector_intersect.cc
@@ -1,0 +1,139 @@
+#include "arrow/array/builder_base.h"
+#include "arrow/compute/api_vector.h"
+#include "arrow/compute/kernels/vector_sort_internal.h"
+#include "arrow/compute/registry.h"
+#include "arrow/result.h"
+#include "arrow/util/hashing.h"
+#include "arrow/visitor.h"
+
+namespace arrow {
+namespace compute {
+namespace internal {
+namespace {
+
+class Intersector : public TypeVisitor {
+ public:
+  Intersector(ExecContext* ctx, const Array& arr1, const Array& arr2, Datum* output)
+      : TypeVisitor(),
+        ctx_(ctx),
+        arr1_(arr1),
+        arr2_(arr2),
+        physical_type_(GetPhysicalType(arr1.type())),
+        output_(output) {}
+
+  Status Run() { return physical_type_->Accept(this); }
+
+// TODO(wayd): we should just use VISIT_SORTABLE_PHYSICAL_TYPES
+// but BooleanType returned const qualifiers that were
+// getting discarded when constructing the buffer for the output
+#define VISIT_INTERSECTABLE_PHYSICAL_TYPES(VISIT) \
+  VISIT(Int8Type)                            \
+  VISIT(Int16Type)                           \
+  VISIT(Int32Type)                           \
+  VISIT(Int64Type)                           \
+  VISIT(UInt8Type)                           \
+  VISIT(UInt16Type)                          \
+  VISIT(UInt32Type)                          \
+  VISIT(UInt64Type)                          \
+  VISIT(FloatType)                           \
+  VISIT(DoubleType)                          \
+  VISIT(BinaryType)                          \
+  VISIT(LargeBinaryType)                     \
+  VISIT(FixedSizeBinaryType)                 \
+  VISIT(Decimal128Type)                      \
+  VISIT(Decimal256Type)
+
+#define VISIT(TYPE) \
+  Status Visit(const TYPE& type) { return IntersectInternal<TYPE>(); }
+
+  VISIT_INTERSECTABLE_PHYSICAL_TYPES(VISIT)
+
+#undef VISIT
+
+  template <typename InType>
+  Status IntersectInternal() {
+    using ArrayType = typename TypeTraits<InType>::ArrayType;
+    using PhysicalType = typename GetViewType<InType>::PhysicalType;
+
+    ARROW_ASSIGN_OR_RAISE(auto uniqs1, CallFunction("unique", {arr1_}));
+    ARROW_ASSIGN_OR_RAISE(auto uniqs2, CallFunction("unique", {arr2_}));
+
+    const ArrayVector arrays{uniqs1.make_array(), uniqs2.make_array()};
+    const ChunkedArray chunked_arr(arrays);
+    ARROW_ASSIGN_OR_RAISE(
+        auto sort_indices,
+        ::arrow::compute::SortIndices(chunked_arr, SortOrder::Ascending, ctx_));
+    ARROW_ASSIGN_OR_RAISE(auto sorted,
+                          ::arrow::compute::Take(Datum(chunked_arr), sort_indices,
+                                                 TakeOptions::Defaults(), ctx_));
+
+    std::vector<PhysicalType> keep{};
+    const stl::ChunkedArrayIterator<ArrayType> iterator(*sorted.chunked_array());
+    for (auto i = 0; i < chunked_arr.length() - 1; i++) {
+      if (iterator[i] == iterator[i + 1]) {
+        keep.push_back(*iterator[i]);
+      }
+    }
+
+    auto out_type = arr1_.type();
+    auto length = keep.size();
+    std::vector<std::shared_ptr<Buffer>> buffers(2);
+
+    buffers[1] = arrow::Buffer::Copy(arrow::Buffer::Wrap(keep), arrow::default_cpu_memory_manager()).ValueOrDie();
+    auto out = std::make_shared<ArrayData>(out_type, length, buffers, 0);
+    *output_ = Datum(out);
+
+    return arrow::Status::OK();
+  }
+
+  ExecContext* ctx_;
+  const Array& arr1_;
+  const Array& arr2_;
+  const std::shared_ptr<DataType> physical_type_;
+  Datum* output_;
+};
+
+const FunctionDoc intersect_doc("Find the intersection of two arrays",
+                                "This function computes the intersection of two arrays.",
+                                {"array1", "array2"});
+
+class IntersectMetaFunction : public MetaFunction {
+ public:
+  IntersectMetaFunction() : MetaFunction("intersect", Arity::Binary(), intersect_doc) {}
+
+  Result<Datum> ExecuteImpl(const std::vector<Datum>& args,
+                            const FunctionOptions* options,
+                            ExecContext* ctx) const {
+    // FunctionOptions are currently discarded
+    // TODO(wayd): ensure args[0] and args[1] are the same
+    switch (args[0].kind()) {
+      case Datum::ARRAY: {
+        return Intersect(*args[0].make_array(), *args[1].make_array(), ctx);
+      } break;
+      default:
+        break;
+    }
+
+    return Status::NotImplemented(
+        "Unsupported types for intersect operation: "
+        "values=",
+        args[0].ToString(), args[1].ToString());
+  }
+
+ private:
+  Result<Datum> Intersect(const Array& arr1, const Array& arr2, ExecContext* ctx) const {
+    Datum output;
+    Intersector intersector(ctx, arr1, arr2, &output);
+    ARROW_RETURN_NOT_OK(intersector.Run());
+    return output;
+  }
+};
+}  // namespace
+
+void RegisterVectorIntersect(FunctionRegistry* registry) {
+  DCHECK_OK(registry->AddFunction(std::make_shared<IntersectMetaFunction>()));
+}
+
+}  // namespace internal
+}  // namespace compute
+}  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/vector_intersect_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_intersect_test.cc
@@ -1,0 +1,93 @@
+#include <gtest/gtest.h>
+
+#include "arrow/compute/api_vector.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/type.h"
+
+namespace arrow {
+namespace compute {
+
+void AssertIntersect(const std::shared_ptr<Array>& array1,
+                     const std::shared_ptr<Array>& array2,
+                     const std::shared_ptr<Array>& expected) {
+  ASSERT_OK_AND_ASSIGN(auto actual, CallFunction("intersect", {array1, array2}));
+  AssertDatumsEqual(expected, actual, /*verbose=*/true);
+}
+
+void AssertIntersectEmpty(std::shared_ptr<DataType> type) {
+  AssertIntersect(ArrayFromJSON(type, "[]"), ArrayFromJSON(type, "[]"),
+                  ArrayFromJSON(type, "[]"));
+  // AssertIntersect(ArrayFromJSON(type, "[null]"), ArrayFromJSON(type, "[null]"),
+  // ArrayFromJSON(type, "[]"));
+}
+
+TEST(TestIntersect, IntersectReal) {
+  for (auto real_type : ::arrow::FloatingPointTypes()) {
+    AssertIntersectEmpty(real_type);
+    auto array1 = ArrayFromJSON(real_type, "[1.1, 2.2, 3.2, 4.2, 5.4]");
+    auto array2 = ArrayFromJSON(real_type, "[2.2, 5.4, 3.2]");
+    auto expected = ArrayFromJSON(real_type, "[2.2, 3.2, 5.4]");
+
+    AssertIntersect(array1, array2, expected);
+  }
+}
+
+TEST(TestIntersect, IntersectIntegral) {
+  for (auto integer_type : ::arrow::IntTypes()) {
+    AssertIntersectEmpty(integer_type);
+    auto array1 = ArrayFromJSON(integer_type, "[1, 2, 3, 4, 5]");
+    auto array2 = ArrayFromJSON(integer_type, "[2, 5, 3]");
+    auto expected = ArrayFromJSON(integer_type, "[2, 3, 5]");
+
+    AssertIntersect(array1, array2, expected);
+  }
+}
+
+/*
+TEST(TestIntersect, IntersectBool) {
+  for (auto integer_type : ::arrow::IntTypes()) {
+    AssertIntersectEmpty(boolean());
+    auto array1 = ArrayFromJSON(boolean(), "[false, true]");
+    auto array2 = ArrayFromJSON(boolean(), "[false]");
+    auto expected = ArrayFromJSON(boolean(), "[false]");
+
+    AssertIntersect(array1, array2, expected);
+  }
+}
+
+TEST(TestIntersect, IntersectTemporal) {
+  for (auto temporal_type : ::arrow::TemporalTypes()) {
+    AssertIntersectEmpty(temporal_type);
+    auto array1 = ArrayFromJSON(temporal_type, "[1, 2, 3, 4, 5]");
+    auto array2 = ArrayFromJSON(temporal_type, "[2, 5, 3]");
+    auto expected = ArrayFromJSON(temporal_type, "[2, 3, 5]");
+
+    AssertIntersect(array1, array2, expected);
+  }
+}
+*/
+
+TEST(TestIntersect, IntersectStrings) {
+  for (auto string_type : ::arrow::StringTypes()) {
+    AssertIntersectEmpty(string_type);
+    auto array1 = ArrayFromJSON(string_type, R"(["b", "c", "a", "", "d"])");
+    auto array2 = ArrayFromJSON(string_type, R"(["c", "d", "a"])");
+    auto expected = ArrayFromJSON(string_type, R"(["a", "c", "d"])");
+
+    AssertIntersect(array1, array2, expected);
+  }
+}
+
+TEST(TestIntersect, IntersectFixedSizeBinary) {
+  auto binary_type = fixed_size_binary(3);
+  AssertIntersectEmpty(binary_type);
+
+  auto array1 = ArrayFromJSON(binary_type, R"(["bbb", "ccc", "aaa", "   ", "dddd"])");
+  auto array2 = ArrayFromJSON(binary_type, R"(["ccc", "ddd", "aaa"])");
+  auto expected = ArrayFromJSON(binary_type, R"(["aaa", "ccc", "ddd"])");
+
+  AssertIntersect(array1, array2, expected);
+}
+
+}  // namespace compute
+}  // namespace arrow

--- a/cpp/src/arrow/compute/registry.cc
+++ b/cpp/src/arrow/compute/registry.cc
@@ -297,6 +297,7 @@ static std::unique_ptr<FunctionRegistry> CreateBuiltInRegistry() {
   RegisterVectorReplace(registry.get());
   RegisterVectorSelection(registry.get());
   RegisterVectorSort(registry.get());
+  RegisterVectorIntersect(registry.get());
 
   RegisterVectorOptions(registry.get());
 

--- a/cpp/src/arrow/compute/registry_internal.h
+++ b/cpp/src/arrow/compute/registry_internal.h
@@ -49,6 +49,7 @@ void RegisterVectorNested(FunctionRegistry* registry);
 void RegisterVectorReplace(FunctionRegistry* registry);
 void RegisterVectorSelection(FunctionRegistry* registry);
 void RegisterVectorSort(FunctionRegistry* registry);
+void RegisterVectorIntersect(FunctionRegistry* registry);
 
 void RegisterVectorOptions(FunctionRegistry* registry);
 


### PR DESCRIPTION
@jorisvandenbossche 

I've commented out a few things that aren't yet working, which I'd summarize as:

1. Null Handling - by default numpy's intersect1d discards NaN, but here NULL would be returned. Its worth discussing whether we want NULL to be included here or not; I _think_ we should and give the user the ability to control where it appears via SortOptions
2. Boolean Type - had issues with the call to Buffer::Wrap complaining that the `const` qualifer on the vector was being discarded. Didn't fully troubleshoot this, but wasn't sure an intersect on BooleanTypes is all that useful either
3. Temporal Types - got a segfault that I need to trouble shoot. 

There likely is a better way of constructing the result that could naturally solve issues 2 and 3 above.