### PR TITLE
ARROW-18205: [C++] Substrait consumer is not converting right side references correctly on joins

### DIFF
--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -479,13 +479,6 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel, const ExtensionSet&
             callptr->function_name);
       }
 
-      // TODO: ARROW-16624 Add Suffix support for Substrait
-      const auto* left_keys = callptr->arguments[0].field_ref();
-      const auto* right_keys = callptr->arguments[1].field_ref();
-      if (!left_keys || !right_keys) {
-        return Status::Invalid("Left keys for join cannot be null");
-      }
-
       // Create output schema from left, right relations and join keys
       FieldVector combined_fields = left.output_schema->fields();
       const FieldVector& right_fields = right.output_schema->fields();
@@ -493,8 +486,31 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel, const ExtensionSet&
                              right_fields.end());
       std::shared_ptr<Schema> join_schema = schema(std::move(combined_fields));
 
+      // adjust the join_keys according to Substrait definition where
+      // the join fields are defined by considering the `join_schema` which
+      // is the combination of the left and right relation schema.
+
+      // TODO: ARROW-16624 Add Suffix support for Substrait
+      const auto* left_keys = callptr->arguments[0].field_ref();
+      const auto* right_keys = callptr->arguments[1].field_ref();
+      // Validating JoinKeys
+      if (!left_keys || !right_keys) {
+        return Status::Invalid("Left keys for join cannot be null");
+      }
+      // TODO: verify this validation
+      if (!left_keys->IsFieldPath() || !right_keys->IsFieldPath()) {
+        return Status::Invalid("Join keys must be FieldPaths");
+      }
+      int num_left_fields = left.output_schema->num_fields();
+      const auto* right_field_path = right_keys->field_path();
+      std::vector<int> adjusted_field_indices;
+      adjusted_field_indices.reserve(join_schema->num_fields() - num_left_fields);
+      for (size_t idx = 0; idx < right_field_path->indices().size(); idx++) {
+        adjusted_field_indices.push_back((*right_field_path)[idx] - num_left_fields);
+      }
+      FieldPath adjusted_right_keys(adjusted_field_indices);
       compute::HashJoinNodeOptions join_options{{std::move(*left_keys)},
-                                                {std::move(*right_keys)}};
+                                                {std::move(adjusted_right_keys)}};
       join_options.join_type = join_type;
       join_options.key_cmp = {join_key_cmp};
       compute::Declaration join_dec{"hashjoin", std::move(join_options)};

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -2714,7 +2714,7 @@ TEST(Substrait, JoinRelEndToEnd) {
                 "selection": {
                   "directReference": {
                     "structField": {
-                      "field": 0
+                      "field": 2
                     }
                   },
                   "rootReference": {
@@ -2871,7 +2871,7 @@ TEST(Substrait, JoinRelWithEmit) {
                 "selection": {
                   "directReference": {
                     "structField": {
-                      "field": 0
+                      "field": 2
                     }
                   },
                   "rootReference": {


### PR DESCRIPTION
This PR includes modification to the existing join key conversion logic and updated test cases.