### PR TITLE
ARROW-18225: [Python] Fully support filesystem in parquet.write_metadata

### DIFF
--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -3429,6 +3429,9 @@ def write_metadata(schema, where, metadata_collector=None, filesystem=None,
     """
     filesystem, where = _resolve_filesystem_and_path(where, filesystem)
 
+    if hasattr(where, "seek"):  # file-like
+        cursor_position = where.tell()
+
     writer = ParquetWriter(where, schema, filesystem, **kwargs)
     writer.close()
 
@@ -3436,6 +3439,9 @@ def write_metadata(schema, where, metadata_collector=None, filesystem=None,
         # ParquetWriter doesn't expose the metadata until it's written. Write
         # it and read it again.
         metadata = read_metadata(where, filesystem=filesystem)
+        if hasattr(where, "seek"):
+            where.seek(cursor_position)  # file-like, set cursor back.
+
         for m in metadata_collector:
             metadata.append_row_groups(m)
         if filesystem is not None:

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -3429,10 +3429,14 @@ def write_metadata(schema, where, metadata_collector=None, **kwargs):
     if metadata_collector is not None:
         # ParquetWriter doesn't expose the metadata until it's written. Write
         # it and read it again.
-        metadata = read_metadata(where)
+        metadata = read_metadata(where, filesystem=kwargs.get("filesystem"))
         for m in metadata_collector:
             metadata.append_row_groups(m)
-        metadata.write_metadata_file(where)
+        if "filesystem" in kwargs and not hasattr(where, "write"):
+            with kwargs["filesystem"].open_output_stream(where) as f:
+                metadata.write_metadata_file(f)
+        else:
+            metadata.write_metadata_file(where)
 
 
 def read_metadata(where, memory_map=False, decryption_properties=None,

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -3427,6 +3427,8 @@ def write_metadata(schema, where, metadata_collector=None, filesystem=None,
     ...     table.schema, 'dataset_metadata/_metadata',
     ...     metadata_collector=metadata_collector)
     """
+    filesystem, where = _resolve_filesystem_and_path(where, filesystem)
+
     writer = ParquetWriter(where, schema, filesystem, **kwargs)
     writer.close()
 
@@ -3436,8 +3438,6 @@ def write_metadata(schema, where, metadata_collector=None, filesystem=None,
         metadata = read_metadata(where, filesystem=filesystem)
         for m in metadata_collector:
             metadata.append_row_groups(m)
-        if filesystem is not None:
-            filesystem, where = _resolve_filesystem_and_path(where, filesystem)
         metadata.write_metadata_file(where)
 
 

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -3438,7 +3438,11 @@ def write_metadata(schema, where, metadata_collector=None, filesystem=None,
         metadata = read_metadata(where, filesystem=filesystem)
         for m in metadata_collector:
             metadata.append_row_groups(m)
-        metadata.write_metadata_file(where)
+        if filesystem is not None:
+            with filesystem.open_output_stream(where) as f:
+                metadata.write_metadata_file(f)
+        else:
+            metadata.write_metadata_file(where)
 
 
 def read_metadata(where, memory_map=False, decryption_properties=None,

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -35,6 +35,8 @@ from pyarrow.tests.parquet.common import (
 from pyarrow.util import guid
 from pyarrow.vendored.version import Version
 
+import unittest.mock as mock
+
 try:
     import pyarrow.parquet as pq
     from pyarrow.tests.parquet.common import (
@@ -1300,6 +1302,33 @@ def _test_write_to_dataset_with_partitions(base_path,
     for col in partition_by:
         output_df[col] = output_df[col].astype('category')
     tm.assert_frame_equal(output_df, input_df)
+
+
+def test_write_metadata_with_without_filesystem(tempdir):
+    meta1 = tempdir / "meta1"
+    meta2 = tempdir / "meta2"
+    count = 0
+
+    class MockLocalFileSystem(fs.LocalFileSystem):
+        """Mock fails to find attrs from direct cython ext."""
+        pass
+
+    table = pa.table({"col": range(5)})
+    filesystem = MockLocalFileSystem()
+
+    with mock.patch.object(MockLocalFileSystem,
+                           "open_output_stream",
+                           wraps=filesystem.open_output_stream) \
+            as mock_open_output_stream:
+
+        pq.write_metadata(table.schema, meta1)
+        mock_open_output_stream.assert_not_called()
+
+        # open_output_stream used before final `write_metadata_file` call
+        pq.write_metadata(table.schema, meta2, filesystem=filesystem)
+        mock_open_output_stream.assert_called()
+
+    assert meta1.read_bytes() == meta2.read_bytes()
 
 
 def _test_write_to_dataset_no_partitions(base_path,

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -35,8 +35,6 @@ from pyarrow.tests.parquet.common import (
 from pyarrow.util import guid
 from pyarrow.vendored.version import Version
 
-import unittest.mock as mock
-
 try:
     import pyarrow.parquet as pq
     from pyarrow.tests.parquet.common import (
@@ -1307,7 +1305,6 @@ def _test_write_to_dataset_with_partitions(base_path,
 def test_write_metadata_with_without_filesystem(tempdir):
     meta1 = tempdir / "meta1"
     meta2 = tempdir / "meta2"
-    count = 0
 
     class MockLocalFileSystem(fs.LocalFileSystem):
         """Mock fails to find attrs from direct cython ext."""

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -19,6 +19,7 @@ import datetime
 import inspect
 import os
 import pathlib
+from unittest import mock
 
 import numpy as np
 import pytest

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -19,7 +19,6 @@ import datetime
 import inspect
 import os
 import pathlib
-from unittest import mock
 
 import numpy as np
 import pytest
@@ -1301,32 +1300,6 @@ def _test_write_to_dataset_with_partitions(base_path,
     for col in partition_by:
         output_df[col] = output_df[col].astype('category')
     tm.assert_frame_equal(output_df, input_df)
-
-
-def test_write_metadata_with_without_filesystem(tempdir):
-    meta1 = tempdir / "meta1"
-    meta2 = tempdir / "meta2"
-
-    class MockLocalFileSystem(fs.LocalFileSystem):
-        """Mock fails to find attrs from direct cython ext."""
-        pass
-
-    table = pa.table({"col": range(5)})
-    filesystem = MockLocalFileSystem()
-
-    with mock.patch.object(MockLocalFileSystem,
-                           "open_output_stream",
-                           wraps=filesystem.open_output_stream) \
-            as mock_open_output_stream:
-
-        pq.write_metadata(table.schema, meta1)
-        mock_open_output_stream.assert_not_called()
-
-        # open_output_stream used before final `write_metadata_file` call
-        pq.write_metadata(table.schema, meta2, filesystem=filesystem)
-        mock_open_output_stream.assert_called()
-
-    assert meta1.read_bytes() == meta2.read_bytes()
 
 
 def _test_write_to_dataset_no_partitions(base_path,

--- a/python/pyarrow/tests/parquet/test_metadata.py
+++ b/python/pyarrow/tests/parquet/test_metadata.py
@@ -636,7 +636,7 @@ def test_write_metadata_with_without_filesystem(tempdir):
 
     # Used the mock filesystem to resolve opening an output stream
     pq.write_metadata(table.schema, meta2, [], filesystem=filesystem)
-    assert called == 1
+    assert called == 2
 
     # Can resolve URI
     pq.write_metadata(table.schema, meta3.as_uri(), [])

--- a/python/pyarrow/tests/parquet/test_metadata.py
+++ b/python/pyarrow/tests/parquet/test_metadata.py
@@ -626,6 +626,7 @@ def test_write_metadata_with_without_filesystem(tempdir):
     meta1 = tempdir / "meta1"
     meta2 = tempdir / "meta2"
     meta3 = tempdir / "meta3"
+    meta4 = tempdir / "meta4"
 
     table = pa.table({"col": range(5)})
     filesystem = MockLocalFileSystem()
@@ -641,4 +642,9 @@ def test_write_metadata_with_without_filesystem(tempdir):
     # Can resolve URI
     pq.write_metadata(table.schema, meta3.as_uri(), [])
 
-    assert meta1.read_bytes() == meta2.read_bytes() == meta3.read_bytes()
+    # Take a file-like obj all the way thru?
+    with meta4.open('wb+') as meta4_stream:
+        pq.write_metadata(table.schema, meta4_stream, [])
+
+    assert meta1.read_bytes() == meta2.read_bytes() \
+        == meta3.read_bytes() == meta4.read_bytes()

--- a/python/pyarrow/tests/parquet/test_metadata.py
+++ b/python/pyarrow/tests/parquet/test_metadata.py
@@ -615,64 +615,34 @@ def test_metadata_append_row_groups_diff(t1, t2, expected_error):
         meta1.append_row_groups(meta2)
 
 
-def test_write_metadata_with_without_filesystem(tempdir):
-
-    class MockLocalFileSystem(LocalFileSystem):
-        def open_output_stream(self, *args, **kwargs):
-            nonlocal called
-            called += 1
-            return super().open_output_stream(*args, **kwargs)
+@pytest.mark.s3
+def test_write_metadata_fs_file_combinations(tempdir, s3_example_s3fs):
+    s3_fs, s3_path = s3_example_s3fs
 
     meta1 = tempdir / "meta1"
     meta2 = tempdir / "meta2"
     meta3 = tempdir / "meta3"
     meta4 = tempdir / "meta4"
-    meta5 = tempdir / "meta5"
+    meta5 = f"{s3_path}/meta5"
 
     table = pa.table({"col": range(5)})
-    filesystem = MockLocalFileSystem()
-    called = 0
 
     # plain local path
     pq.write_metadata(table.schema, meta1, [])
 
-    # Used the mock filesystem to resolve opening an output stream
-    pq.write_metadata(table.schema, meta2, [], filesystem=filesystem)
-    assert called == 2
+    # Used the localfilesystem to resolve opening an output stream
+    pq.write_metadata(table.schema, meta2, [], filesystem=LocalFileSystem())
 
-    # Can resolve URI
+    # Can resolve local file URI
     pq.write_metadata(table.schema, meta3.as_uri(), [])
 
     # Take a file-like obj all the way thru?
     with meta4.open('wb+') as meta4_stream:
         pq.write_metadata(table.schema, meta4_stream, [])
 
+    # S3FileSystem
+    pq.write_metadata(table.schema, meta5, [], filesystem=s3_fs)
+
     assert meta1.read_bytes() == meta2.read_bytes() \
-        == meta3.read_bytes() == meta4.read_bytes()
-
-    try:
-        from pyarrow.fs import S3FileSystem
-    except ImportError:
-        return
-
-    class MockS3FileSystem(S3FileSystem):
-        """Not going to actually write to S3"""
-
-        def open_input_file(self, path, *args, **kwargs):
-            assert path == s3_uri
-            return meta5.open('rb')
-
-        def open_output_stream(self, path, *args, **kwargs):
-            nonlocal called
-            assert path == s3_uri
-            called += 1
-            return meta5.open('wb')
-
-    s3_uri = "some-bucket/path.parquet"
-    filesystem = MockS3FileSystem()
-
-    # URI with filesystem
-    pq.write_metadata(table.schema, s3_uri, [], filesystem=filesystem)
-    assert called == 4
-
-    assert meta1.read_bytes() == meta5.read_bytes()
+        == meta3.read_bytes() == meta4.read_bytes() \
+        == s3_fs.open(meta5).read()


### PR DESCRIPTION
Will fix [ARROW-18225](https://issues.apache.org/jira/browse/ARROW-18225)