### PR TITLE
MINOR: [C++] Replaced uint32_t with uint64_t in BackpressureOptions constructor

### DIFF
--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -143,7 +143,7 @@ struct ARROW_EXPORT BackpressureOptions {
   ///                        queue has fewer than resume_if_below items.
   /// \param pause_if_above The producer should pause producing if the backpressure
   ///                       queue has more than pause_if_above items
-  BackpressureOptions(uint32_t resume_if_below, uint32_t pause_if_above)
+  BackpressureOptions(uint64_t resume_if_below, uint64_t pause_if_above)
       : resume_if_below(resume_if_below), pause_if_above(pause_if_above) {}
 
   static BackpressureOptions DefaultBackpressure() {


### PR DESCRIPTION
In the `BackpressureOptions` constructor the arguments are in `uint32_t` format, but the member variables are in `uint64_t`. Fixing it in this PR.