### PR TITLE
ARROW-18305: [R] Fix for dev purrr

### DIFF
--- a/r/R/metadata.R
+++ b/r/R/metadata.R
@@ -86,9 +86,11 @@ apply_arrow_r_metadata <- function(x, r_metadata) {
             call. = FALSE
           )
         } else {
-          x <- map2(x, columns_metadata, function(.x, .y) {
-            apply_arrow_r_metadata(.x, .y)
-          })
+          if (length(x) > 0) {
+            x <- map2(x, columns_metadata, function(.x, .y) {
+              apply_arrow_r_metadata(.x, .y)
+            })
+          }
         }
         x
       }


### PR DESCRIPTION
The recycling rules in map2() are now stricter, so we need to check that `x` actually has columns before applying the metadata.

I also mildly refactored the test to make it easier to run in isolation; I'm happy to revert those changes if desired.