### PR TITLE
ARROW-18284: [Python][Docs] Add missing CMAKE_PREFIX_PATH to allow setup.py CMake invocations to find Arrow CMake package

### DIFF
--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -287,6 +287,7 @@ about our build toolchain:
 
    $ export ARROW_HOME=$(pwd)/dist
    $ export LD_LIBRARY_PATH=$(pwd)/dist/lib:$LD_LIBRARY_PATH
+   $ export CMAKE_PREFIX_PATH=$ARROW_HOME:$CMAKE_PREFIX_PATH
 
 Build and test
 --------------


### PR DESCRIPTION
Following along the build documentation CMake was unable to find the arrow installation when the documentation gets to the point of invoking setup.py. This should fix that and prevent errors like:

```sh
CMake Error at /home/willayd/mambaforge/envs/pyarrow-dev/share/cmake-3.24/Modules/CMakeFindDependencyMacro.cmake:47 (find_package):
  By not providing "FindArrow.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "Arrow", but
  CMake did not find one.

  Could not find a package configuration file provided by "Arrow" with any of
  the following names:

    ArrowConfig.cmake
    arrow-config.cmake

  Add the installation prefix of "Arrow" to CMAKE_PREFIX_PATH or set
  "Arrow_DIR" to a directory containing one of the above files.  If "Arrow"
  provides a separate development package or SDK, be sure it has been
  installed.
Call Stack (most recent call first):
  build/dist/lib/cmake/ArrowPython/ArrowPythonConfig.cmake:54 (find_dependency)
  CMakeLists.txt:239 (find_package
```