### PR TITLE
ARROW-18247: [JS] fix: RangeError crash in Vector.toArray()

### DIFF
--- a/js/src/vector.ts
+++ b/js/src/vector.ts
@@ -255,9 +255,9 @@ export class Vector<T extends DataType = any> {
                 switch (data.length) {
                     case 0: return new ArrayType();
                     case 1: return data[0].values.subarray(0, length * stride);
-                    default: return data.reduce((memo, { values }) => {
-                        memo.array.set(values, memo.offset);
-                        memo.offset += values.length;
+                    default: return data.reduce((memo, { values, length: chunk_length }) => {
+                        memo.array.set(values.subarray(0, chunk_length * stride), memo.offset);
+                        memo.offset += chunk_length * stride;
                         return memo;
                     }, { array: new ArrayType(length * stride), offset: 0 }).array;
                 }

--- a/js/test/unit/vector/vector-tests.ts
+++ b/js/test/unit/vector/vector-tests.ts
@@ -213,8 +213,8 @@ describe(`ListVector`, () => {
 
 describe(`toArray()`, () => {
     test(`when some data blobs have been padded`, () => {
-        const d1 = vectorFromArray([...Array(16).keys()]);
-        const d2 = vectorFromArray([...Array(10).keys()]);
+        const d1 = vectorFromArray([...new Array(16).keys()]);
+        const d2 = vectorFromArray([...new Array(10).keys()]);
 
         // Padding has been added
         expect(d2.length < d2.data.length)

--- a/js/test/unit/vector/vector-tests.ts
+++ b/js/test/unit/vector/vector-tests.ts
@@ -236,7 +236,7 @@ describe(`toArray()`, () => {
         let array = Array.from(vector.toArray());
         expect(array).toHaveLength(6 * 2);
         expect(Array.from(array)).toMatchObject([0, 0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0]);
-    })
+    });
 });
 
 // Creates some basic tests for the given vector.

--- a/js/test/unit/vector/vector-tests.ts
+++ b/js/test/unit/vector/vector-tests.ts
@@ -217,7 +217,7 @@ describe(`toArray()`, () => {
         const d2 = vectorFromArray([...new Array(10).keys()]);
 
         // Padding has been added
-        expect(d2.length).toBeLessThan(d2.data.length);
+        expect(d2.length).toBeLessThan(d2.data[0].buffers[1].length);
 
         const vector = new Vector([d1, d2]);
 

--- a/js/test/unit/vector/vector-tests.ts
+++ b/js/test/unit/vector/vector-tests.ts
@@ -217,7 +217,7 @@ describe(`toArray()`, () => {
         const d2 = vectorFromArray([...new Array(10).keys()]);
 
         // Padding has been added
-        expect(d2.length < d2.data.length)
+        expect(d2.length).toBeLessThan(d2.data.length);
 
         const vector = new Vector([d1, d2]);
 

--- a/js/test/unit/vector/vector-tests.ts
+++ b/js/test/unit/vector/vector-tests.ts
@@ -16,7 +16,7 @@
 // under the License.
 
 import {
-    Bool, DateDay, DateMillisecond, Dictionary, Float64, Int32, List, makeVector, Struct, Utf8, util, Vector, vectorFromArray
+    Bool, DateDay, DateMillisecond, Dictionary, Float64, Int32, List, makeVector, Struct, Timestamp, TimeUnit, Utf8, util, Vector, vectorFromArray
 } from 'apache-arrow';
 
 describe(`makeVectorFromArray`, () => {
@@ -209,6 +209,34 @@ describe(`ListVector`, () => {
             expect(vector.get(i)!.toJSON()).toEqual(value);
         }
     });
+});
+
+describe(`toArray()`, () => {
+    test(`when some data blobs have been padded`, () => {
+        const d1 = vectorFromArray([...Array(16).keys()]);
+        const d2 = vectorFromArray([...Array(10).keys()]);
+
+        // Padding has been added
+        expect(d2.length < d2.data.length)
+
+        const vector = new Vector([d1, d2]);
+
+        // This used to crash with "RangeError: offset is out of bounds"
+        // https://issues.apache.org/jira/browse/ARROW-18247
+        const array = vector.toArray();
+        expect(array).toHaveLength(26);
+    });
+
+    test(`when stride is 2`, () => {
+        let d1 = vectorFromArray([0, 1, 2], new Timestamp(TimeUnit.MILLISECOND)).data[0];
+        let d2 = vectorFromArray([3, 4, 5], new Timestamp(TimeUnit.MILLISECOND)).data[0];
+
+        const vector = new Vector([d1, d2]);
+
+        let array = Array.from(vector.toArray());
+        expect(array).toHaveLength(6 * 2);
+        expect(Array.from(array)).toMatchObject([0, 0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0]);
+    })
 });
 
 // Creates some basic tests for the given vector.


### PR DESCRIPTION
This fixes a bug which happens when a Vector has been created with multiple data blobs and at least one of them has been padded.

See https://observablehq.com/d/14488c116b338560 for a reproduction of the error and more details.