### PR TITLE
MINOR: Temporary pin Python to 3.10 on AMD64 macOS 11 Python 3 job

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.10'
       - name: Checkout Arrow
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -149,6 +149,10 @@ jobs:
       CMAKE_ARGS: "-DPython3_EXECUTABLE=/usr/local/bin/python3"
       PYARROW_TEST_LARGE_MEMORY: ON
     steps:
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.10
       - name: Checkout Arrow
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This is currently only to test if the failing job will pass.