### PR TITLE
ARROW-18270: [Python] Remove gcc 4.9 compatibility code

### DIFF
--- a/cpp/src/arrow/util/regex.h
+++ b/cpp/src/arrow/util/regex.h
@@ -1,0 +1,51 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cassert>
+#include <initializer_list>
+#include <regex>
+#include <string_view>
+#include <type_traits>
+
+#include "arrow/util/visibility.h"
+
+namespace arrow {
+namespace internal {
+
+/// Match regex against target and produce string_views out of matches.
+bool RegexMatch(const std::regex& regex, std::string_view target,
+                std::initializer_list<std::string_view*> out_matches) {
+  assert(regex.mark_count() == out_matches.size());
+
+  std::match_results<decltype(target.begin())> match;
+  if (!std::regex_match(target.begin(), target.end(), match, regex)) {
+    return false;
+  }
+
+  // Match #0 is the whole matched sequence
+  assert(regex.mark_count() + 1 == match.size());
+  auto out_it = out_matches.begin();
+  for (size_t i = 1; i < match.size(); ++i) {
+    **out_it++ = target.substr(match.position(i), match.length(i));
+  }
+  return true;
+}
+
+}  // namespace internal
+}  // namespace arrow

--- a/cpp/src/arrow/util/string_test.cc
+++ b/cpp/src/arrow/util/string_test.cc
@@ -16,6 +16,7 @@
 // under the License.
 
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -23,6 +24,7 @@
 
 #include "arrow/status.h"
 #include "arrow/testing/gtest_util.h"
+#include "arrow/util/regex.h"
 #include "arrow/util/string.h"
 
 namespace arrow {
@@ -192,6 +194,27 @@ TEST(EndsWith, Basics) {
   ASSERT_FALSE(EndsWith(abcdef, abc));
   ASSERT_FALSE(EndsWith(def, abcdef));
   ASSERT_FALSE(EndsWith(abcdef, abc));
+}
+
+TEST(RegexMatch, Basics) {
+  std::regex regex("a+(b*)(c+)d+");
+  std::string_view b, c;
+
+  ASSERT_FALSE(RegexMatch(regex, "", {&b, &c}));
+  ASSERT_FALSE(RegexMatch(regex, "ad", {&b, &c}));
+  ASSERT_FALSE(RegexMatch(regex, "bc", {&b, &c}));
+
+  auto check_match = [&](std::string_view target, std::string_view expected_b,
+                         std::string_view expected_c) {
+    b = c = "!!!";  // dummy init value
+    ASSERT_TRUE(RegexMatch(regex, target, {&b, &c}));
+    ASSERT_EQ(b, expected_b);
+    ASSERT_EQ(c, expected_c);
+  };
+
+  check_match("abcd", "b", "c");
+  check_match("acd", "", "c");
+  check_match("abbcccd", "bb", "ccc");
 }
 
 }  // namespace internal


### PR DESCRIPTION
We can use std::regex now that we needn't support gcc 4.9 anymore.