### PR TITLE
MINOR: [R][CI] Use `docker.io/library/r-base` instead of `docker.io/rocker/r-base`

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1309,7 +1309,7 @@ tasks:
     ci: azure
     template: r/azure.linux.yml
     params:
-      r_org: rocker
+      r_org: library
       r_image: r-base
       r_tag: latest
       flags: '-e ARROW_DEPENDENCY_SOURCE=BUNDLED'
@@ -1325,7 +1325,7 @@ tasks:
     ci: azure
     template: r/azure.linux.yml
     params:
-      r_org: rocker
+      r_org: library
       r_image: r-base
       r_tag: latest
       flags: '-e TEST_OFFLINE_BUILD=true'
@@ -1352,7 +1352,7 @@ tasks:
       r_custom_ccache: true
 
 {% for r_org, r_image, r_tag in [("rhub", "ubuntu-gcc-release", "latest"),
-                                 ("rocker", "r-base", "latest"),
+                                 ("library", "r-base", "latest"),
                                  ("rstudio", "r-base", "4.2-focal"),
                                  ("rstudio", "r-base", "4.1-opensuse153")] %}
   test-r-{{ r_org }}-{{ r_image }}-{{ r_tag }}:
@@ -1419,7 +1419,7 @@ tasks:
     ci: azure
     template: r/azure.linux.yml
     params:
-      r_org: rocker
+      r_org: library
       r_image: r-base
       r_tag: latest
       flags: "-e LIBARROW_MINIMAL=TRUE"


### PR DESCRIPTION
Unless there is a special reason, it is better to use `docker.io/library/r-base`, Docker Official Images.
It is built from the same source, but `docker.io/library/r-base` is always up-to-date because it is built automatically.