### PR TITLE
ARROW-18306: [R] Failing test after compute function updates

### DIFF
--- a/r/tests/testthat/test-compute-vector.R
+++ b/r/tests/testthat/test-compute-vector.R
@@ -116,7 +116,7 @@ test_that("call_function validation", {
       Array$create(c(TRUE, FALSE, TRUE)),
       options = list(keep_na = TRUE)
     ),
-    "arguments must all be the same length"
+    "Arguments for execution of vector kernel function 'array_filter' must all be the same length"
   )
   expect_error(
     call_function("filter",


### PR DESCRIPTION
After [ARROW-17613](https://issues.apache.org/jira/browse/ARROW-17613) (#14043), which made the error message better, we see an error in our tests because the message changed.