### PR TITLE
ARROW-18325: [Docs][Python] Add Python 3.11 to python/install.rst

### DIFF
--- a/docs/source/python/install.rst
+++ b/docs/source/python/install.rst
@@ -28,7 +28,7 @@ using a 64-bit system.
 Python Compatibility
 --------------------
 
-PyArrow is currently compatible with Python 3.7, 3.8, 3.9 and 3.10.
+PyArrow is currently compatible with Python 3.7, 3.8, 3.9, 3.10 and 3.11.
 
 Using Conda
 -----------


### PR DESCRIPTION
Add Python 3.11 to the Python Compatibility section in the PyArrow install documentation.