### PR TITLE
ARROW-18327: [CI][Release] verify-rc-source-*-macos-amd64 are failed

### DIFF
--- a/dev/tasks/verify-rc/github.macos.amd64.yml
+++ b/dev/tasks/verify-rc/github.macos.amd64.yml
@@ -43,6 +43,10 @@ jobs:
       - name: Install System Dependencies
         shell: bash
         run: |
+          rm -f /usr/local/bin/2to3*
+          rm -f /usr/local/bin/idle*
+          rm -f /usr/local/bin/pydoc3*
+          rm -f /usr/local/bin/python3*
           brew update
           brew install --overwrite git
           brew bundle --file=arrow/cpp/Brewfile


### PR DESCRIPTION
https://github.com/ursacomputing/crossbow/actions/runs/3461688619/jobs/5779609972#step:3:127

    ==> Pouring python@3.11--3.11.0.big_sur.bottle.tar.gz
    Error: The `brew link` step did not complete successfully
    The formula built, but is not symlinked into /usr/local
    Could not symlink bin/2to3-3.11
    Target /usr/local/bin/2to3-3.11
    already exists. You may want to remove it:
      rm '/usr/local/bin/2to3-3.11'

    To force the link and overwrite all conflicting files:
      brew link --overwrite python@3.11

    To list all files that would be deleted:
      brew link --overwrite --dry-run python@3.11

    Possible conflicting files are:
    /usr/local/bin/2to3-3.11 -> /Library/Frameworks/Python.framework/Versions/3.11/bin/2to3-3.11
    /usr/local/bin/idle3.11 -> /Library/Frameworks/Python.framework/Versions/3.11/bin/idle3.11
    /usr/local/bin/pydoc3.11 -> /Library/Frameworks/Python.framework/Versions/3.11/bin/pydoc3.11
    /usr/local/bin/python3.11 -> /Library/Frameworks/Python.framework/Versions/3.11/bin/python3.11
    /usr/local/bin/python3.11-config -> /Library/Frameworks/Python.framework/Versions/3.11/bin/python3.11-config