### PR TITLE
ARROW-15716: [Dataset][Python] Parse a list of fragment paths to gather filters

### DIFF
--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1425,10 +1425,22 @@ cdef class Partitioning(_Weakrefable):
     cdef inline shared_ptr[CPartitioning] unwrap(self):
         return self.wrapped
 
-    def parse(self, path):
+    def parse(self, paths):
         cdef CResult[CExpression] result
-        result = self.partitioning.Parse(tobytes(path))
-        return Expression.wrap(GetResultValue(result))
+        if isinstance(paths, list):
+            zero_path = paths[0]
+            zero_result = self.partitioning.Parse(tobytes(zero_path))
+            expression = Expression.wrap(GetResultValue(zero_result))
+            for path in paths[1:]:
+                result = self.partitioning.Parse(tobytes(path))
+                expression = expression | Expression.wrap(
+                    GetResultValue(result))
+            return expression
+        elif isinstance(paths, str):
+            result = self.partitioning.Parse(tobytes(paths))
+            return Expression.wrap(GetResultValue(result))
+        else:
+            raise ValueError("paths is a List[str] or str")
 
     @property
     def schema(self):

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -1912,15 +1912,9 @@ def test_write_to_dataset_kwargs_passed(tempdir, write_dataset_kwarg):
 
 @pytest.mark.dataset
 def test_parquet_write_partioning_parser(tempdir):
-    from datetime import datetime
     import pyarrow.dataset as ds
-    df = pd.DataFrame({'a': [datetime(2019, 1, 1, 0),
-                      datetime(2019, 2, 1, 0),
-                      datetime(2019, 1, 1, 0),
-                      datetime(2019, 2, 1, 0),
-                      datetime(2019, 1, 1, 0),
-                      datetime(2019, 2, 1, 0)],
-                       'b': [20, 30, 40, 50, 60, 10]})
+    df = pd.DataFrame({'a' : [1, 2, 1, 2, 3, 4, 5, 1, 2, 4, 7, 8],
+                       'b' : [10, 30, 20, 40, 50, 60, 30, 50, 60, 10, 11, 12]})
     table = pa.Table.from_pandas(df)
     path = tempdir / 'partitioning'
 
@@ -1940,8 +1934,28 @@ def test_parquet_write_partioning_parser(tempdir):
     dataset = ds.dataset(source=path, partitioning=partitioning)
 
     filter_expressions = [dataset.partitioning.parse(path) for path in paths]
-
-    new_table = dataset.to_table(filter=filter_expressions[0])
-    print(table)
+    
+    import operator
+    def reduce(op1, op2, reduction_operator=operator.or_):
+        reduction_operator(op1, op2)
+    
+    def parse_filters(dataset, paths):
+        filter_exprs = [dataset.partitioning.parse(path) for path in paths]
+        print("filter expressions: ")
+        print(filter_exprs)
+        resultant_filter = filter_exprs[0]
+        for exp in filter_exprs[:1]:
+            resultant_filter = reduce(resultant_filter, exp)
+            
+    res_filter = parse_filters(dataset, paths)
+    
+    f1 = ds.field("a") > pc.scalar(3)
+    f2 = ds.field("a") < pc.scalar(8)
+    f11 = ds.field("a") > pc.scalar(3)
+    f22 = ds.field("a") < pc.scalar(6)
+    f3 = f11 & f22
+    print(f3)
+    new_table = dataset.to_table(filter=f3)
+    print(table.to_pandas())
     print("-" * 80)
-    print(new_table)
+    print(new_table.to_pandas())


### PR DESCRIPTION
Updated `parse` function in `Partitioning` to accept a list of paths and produce a single expression.