### PR TITLE
ARROW-18322: [Python] Add PYARROW_WITH_FLIGHT to PyArrow C++ cmake

### DIFF
--- a/python/pyarrow/src/CMakeLists.txt
+++ b/python/pyarrow/src/CMakeLists.txt
@@ -253,7 +253,7 @@ if(ARROW_BUILD_STATIC AND MSVC)
   target_compile_definitions(arrow_python_static PUBLIC ARROW_STATIC)
 endif()
 
-if(ARROW_FLIGHT AND ARROW_BUILD_SHARED)
+if(PYARROW_WITH_FLIGHT AND ARROW_FLIGHT AND ARROW_BUILD_SHARED)
    # Must link to shared libarrow_flight: we don't want to link more than one
    # copy of gRPC into the eventual Cython shared object, otherwise gRPC calls
    # fail with weird errors due to multiple copies of global static state (The

--- a/python/setup.py
+++ b/python/setup.py
@@ -270,6 +270,8 @@ class build_ext(_build_ext):
                               'PYARROW_WITH_PARQUET_ENCRYPTION')
             append_cmake_bool(self.with_hdfs,
                               'PYARROW_WITH_HDFS')
+            append_cmake_bool(self.with_flight,
+                              'PYARROW_WITH_FLIGHT')
 
             # Windows
             if self.cmake_generator:


### PR DESCRIPTION
This PR adds the use of `PYARROW_WITH_FLIGHT` environment variable when building PyArrow C++. With this change PyArrow will be able to build successfully even when Arrow C++ is installed without Arrow Flight ([example](https://github.com/OSGeo/gdal/blob/58ab718542a7b5ceb94e3f24a5acc0b18ac1efb2/docker/ubuntu-full/Dockerfile#L223-L231), JFrog artifactory) but `ARROW_FLIGHT` flag is not registered to be set to off.
Note: `PYARROW_WITH_FLIGHT=0` is needed when building PyArrow.

I tested the change on my regular build with Arrow Flight but with removed `libarrow_flight*` libs. Without this patch I get:
```
CMake Error at /Users/alenkafrim/repos/arrow/dist/lib/cmake/ArrowFlight/ArrowFlightTargets.cmake:93 (message):
  The imported target "ArrowFlight::arrow_flight_shared" references the file

     "/Users/alenkafrim/repos/arrow/dist/lib/libarrow_flight.1100.0.0.dylib"

  but this file does not exist.  Possible reasons include:

  * The file was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and contained

     "/Users/alenkafrim/repos/arrow/dist/lib/cmake/ArrowFlight/ArrowFlightTargets.cmake"

  but not all the files it references.

Call Stack (most recent call first):
  /Users/alenkafrim/repos/arrow/dist/lib/cmake/ArrowFlight/ArrowFlightConfig.cmake:56 (include)
  CMakeLists.txt:262 (find_package)
```

With this patch PyArrow builds succesfully.