### PR TITLE
ARROW-18321: [R] Add tests for binary_slice kernel

### DIFF
--- a/r/R/dplyr-funcs-string.R
+++ b/r/R/dplyr-funcs-string.R
@@ -495,8 +495,19 @@ register_bindings_string_other <- function() {
         stop <- 0
       }
 
+      # if the input is a string we use "utf8_slice_codeunits"; if the
+      # input is binary we use "binary_slice". This does not consider
+      # a binary Scalar.
+      x_is_binary <- inherits(x, "ArrowObject") &&
+        x$type_id() %in% c(Type$BINARY, Type$LARGE_BINARY, Type$FIXED_SIZE_BINARY)
+      if (x_is_binary) {
+        fun <- "binary_slice"
+      } else {
+        fun <- "utf8_slice_codeunits"
+      }
+
       Expression$create(
-        "utf8_slice_codeunits",
+        fun,
         x,
         # we don't need to subtract 1 from `stop` as C++ counts exclusively
         # which effectively cancels out the difference in indexing between R & C++

--- a/r/tests/testthat/test-compute-vector.R
+++ b/r/tests/testthat/test-compute-vector.R
@@ -83,6 +83,27 @@ test_that("logic ops with Array", {
   )
 })
 
+test_that("binary slice kernel with Array", {
+  binary_array <- Array$create(
+    iconv(c("a", "ab", "abc", "abcd"), toRaw = TRUE),
+    type = binary()
+  )
+
+  result <- call_function(
+    "binary_slice",
+    binary_array,
+    options = list(start = 0, stop = 1)
+  )
+  expect_equal(result$cast(string()), Array$create(c("a", "a", "a", "a")))
+
+  result <- call_function(
+    "binary_slice",
+    binary_array,
+    options = list(start = -1)
+  )
+  expect_equal(result$cast(string()), Array$create(c("a", "b", "c", "d")))
+})
+
 test_that("logic ops with ChunkedArray", {
   truth <- expand.grid(left = c(TRUE, FALSE, NA), right = c(TRUE, FALSE, NA))
   a_left <- ChunkedArray$create(truth$left)

--- a/r/tests/testthat/test-dplyr-funcs-string.R
+++ b/r/tests/testthat/test-dplyr-funcs-string.R
@@ -954,7 +954,7 @@ test_that("str_pad", {
   )
 })
 
-test_that("substr", {
+test_that("substr with string()", {
   df <- tibble(x = "Apache Arrow")
 
   compare_dplyr_binding(
@@ -1031,6 +1031,31 @@ test_that("substr", {
   expect_error(
     call_binding("substr", "Apache Arrow", 1, c(2, 3)),
     "`stop` must be length 1 - other lengths are not supported in Arrow"
+  )
+})
+
+test_that("substr with binary()", {
+  batch <- record_batch(x = list(charToRaw("Apache Arrow")))
+
+  # Check a field reference input
+  expect_identical(
+    batch %>%
+      transmute(y = substr(x, 1, 3)) %>%
+      collect() %>%
+      # because of the arrow_binary class
+      mutate(y = unclass(y)),
+    tibble::tibble(y = list(charToRaw("Apa")))
+  )
+
+  # Check a Scalar input
+  scalar <- Scalar$create(batch$x)
+  expect_identical(
+    batch %>%
+      transmute(y = substr(scalar, 1, 3)) %>%
+      collect() %>%
+      # because of the arrow_binary class
+      mutate(y = unclass(y)),
+    tibble::tibble(y = list(charToRaw("Apa")))
   )
 })
 


### PR DESCRIPTION
This PR adds a test for the kernel implemented in ARROW-17301 (#14550).

Are there any R functions that map to this? (i.e., is there any `register_binding()` we should do for an R function?)