### PR TITLE
ARROW-18340: [Python] PyArrow C++ header files no longer always included in installed pyarrow

### DIFF
--- a/python/pyarrow/tests/test_cpp_internals.py
+++ b/python/pyarrow/tests/test_cpp_internals.py
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from pathlib import Path
-import os
+import os.path
+from os.path import join as pjoin
 
 from pyarrow._pyarrow_cpp_tests import get_cpp_tests
 
@@ -41,12 +41,10 @@ def test_pyarrow_include():
     # created. Either with PyArrow C++ header files or with
     # Arrow C++ and PyArrow C++ header files together
 
-    cwd = os.getcwd()
-    pyarrow_include = os.path.join(cwd, 'pyarrow', 'include')
+    source = os.path.dirname(os.path.abspath(__file__))
+    pyarrow_dir = os.path.abspath(os.path.join(source, '..'))
+    pyarrow_include = os.path.join(pyarrow_dir, 'include')
     pyarrow_cpp_include = os.path.join(pyarrow_include, 'arrow', 'python')
 
-    obj_include = Path(pyarrow_include)
-    obj_python_include = Path(pyarrow_cpp_include)
-
-    assert obj_include.exists()
-    assert obj_python_include.exists()
+    assert os.path.exists(pyarrow_include)
+    assert os.path.exists(pyarrow_cpp_include)

--- a/python/pyarrow/tests/test_cpp_internals.py
+++ b/python/pyarrow/tests/test_cpp_internals.py
@@ -15,6 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from pathlib import Path
+import os
+
 from pyarrow._pyarrow_cpp_tests import get_cpp_tests
 
 
@@ -31,3 +34,19 @@ def inject_cpp_tests(ns):
 
 
 inject_cpp_tests(globals())
+
+
+def test_pyarrow_include():
+    # We need to make sure that pyarrow/include is always
+    # created. Either with PyArrow C++ header files or with
+    # Arrow C++ and PyArrow C++ header files together
+
+    cwd = os.getcwd()
+    pyarrow_include = os.path.join(cwd, 'pyarrow', 'include')
+    pyarrow_cpp_include = os.path.join(pyarrow_include, 'arrow', 'python')
+
+    obj_include = Path(pyarrow_include)
+    obj_python_include = Path(pyarrow_cpp_include)
+
+    assert obj_include.exists()
+    assert obj_python_include.exists()

--- a/python/pyarrow/tests/test_cpp_internals.py
+++ b/python/pyarrow/tests/test_cpp_internals.py
@@ -42,9 +42,9 @@ def test_pyarrow_include():
     # Arrow C++ and PyArrow C++ header files together
 
     source = os.path.dirname(os.path.abspath(__file__))
-    pyarrow_dir = os.path.abspath(os.path.join(source, '..'))
-    pyarrow_include = os.path.join(pyarrow_dir, 'include')
-    pyarrow_cpp_include = os.path.join(pyarrow_include, 'arrow', 'python')
+    pyarrow_dir = os.path.abspath(pjoin(source, '..'))
+    pyarrow_include = pjoin(pyarrow_dir, 'include')
+    pyarrow_cpp_include = pjoin(pyarrow_include, 'arrow', 'python')
 
     assert os.path.exists(pyarrow_include)
     assert os.path.exists(pyarrow_cpp_include)

--- a/python/pyarrow/tests/test_cpp_internals.py
+++ b/python/pyarrow/tests/test_cpp_internals.py
@@ -42,7 +42,7 @@ def test_pyarrow_include():
     # Arrow C++ and PyArrow C++ header files together
 
     source = os.path.dirname(os.path.abspath(__file__))
-    pyarrow_dir = os.path.abspath(pjoin(source, '..'))
+    pyarrow_dir = pjoin(source, '..')
     pyarrow_include = pjoin(pyarrow_dir, 'include')
     pyarrow_cpp_include = pjoin(pyarrow_include, 'arrow', 'python')
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -436,18 +436,8 @@ class build_ext(_build_ext):
             else:
                 build_prefix = self.build_type
 
-            # Copy PyArrow headers to pyarrow/include
             pyarrow_include = pjoin(build_lib, 'pyarrow', 'include')
-            def copy_pyarrow_cpp_headers():
-                pyarrow_cpp_include = pjoin(pyarrow_cpp_home, 'include')
-                if os.path.exists(pjoin(pyarrow_include, 'arrow', 'python')):
-                    shutil.rmtree(pjoin(pyarrow_include, 'arrow', 'python'))
-                shutil.copytree(pjoin(pyarrow_cpp_include, 'arrow', 'python'),
-                                pjoin(pyarrow_include, 'arrow', 'python'))
-            copy_pyarrow_cpp_headers()
-
-            # Move Arrow C++ and Pyarrow C++ headers to pyarrow/include
-            # if bundled build is specified
+            # Move Arrow C++ headers to pyarrow/include
             if self.bundle_arrow_cpp or self.bundle_arrow_cpp_headers:
                 arrow_cpp_include = pjoin(build_prefix, 'include')
                 print('Bundling includes: ' + arrow_cpp_include)
@@ -455,9 +445,14 @@ class build_ext(_build_ext):
                     shutil.rmtree(pyarrow_include)
                 shutil.move(arrow_cpp_include, pyarrow_include)
 
-                # pyarrow/include file is first deleted in the previous step
-                # so we need to add the PyArrow C++ include folder again
-                copy_pyarrow_cpp_headers()
+            # Move PyArrow headers to pyarrow/include
+            pyarrow_cpp_include = pjoin(pyarrow_cpp_home, 'include')
+            print('Moving PyArrow C++ includes: ' +
+                  pjoin(pyarrow_include, 'arrow', 'python'))
+            if os.path.exists(pjoin(pyarrow_include, 'arrow', 'python')):
+                shutil.rmtree(pjoin(pyarrow_include, 'arrow', 'python'))
+            shutil.move(pjoin(pyarrow_cpp_include, 'arrow', 'python'),
+                        pjoin(pyarrow_include, 'arrow', 'python'))
 
             # Move the built C-extension to the place expected by the Python
             # build

--- a/python/setup.py
+++ b/python/setup.py
@@ -447,12 +447,12 @@ class build_ext(_build_ext):
 
             # Move PyArrow headers to pyarrow/include
             pyarrow_cpp_include = pjoin(pyarrow_cpp_home, 'include')
-            print('Moving PyArrow C++ includes: ' +
-                  pjoin(pyarrow_include, 'arrow', 'python'))
-            if os.path.exists(pjoin(pyarrow_include, 'arrow', 'python')):
-                shutil.rmtree(pjoin(pyarrow_include, 'arrow', 'python'))
+            pyarrow_include_sub = pjoin(pyarrow_include, 'arrow', 'python')
+            print('Moving PyArrow C++ includes: ' + pyarrow_include_sub)
+            if os.path.exists(pyarrow_include_sub):
+                shutil.rmtree(pyarrow_include_sub)
             shutil.move(pjoin(pyarrow_cpp_include, 'arrow', 'python'),
-                        pjoin(pyarrow_include, 'arrow', 'python'))
+                        pyarrow_include_sub)
 
             # Move the built C-extension to the place expected by the Python
             # build

--- a/python/setup.py
+++ b/python/setup.py
@@ -436,19 +436,28 @@ class build_ext(_build_ext):
             else:
                 build_prefix = self.build_type
 
+            # Copy PyArrow headers to pyarrow/include
+            pyarrow_include = pjoin(build_lib, 'pyarrow', 'include')
+            def copy_pyarrow_cpp_headers():
+                pyarrow_cpp_include = pjoin(pyarrow_cpp_home, 'include')
+                if os.path.exists(pjoin(pyarrow_include, 'arrow', 'python')):
+                    shutil.rmtree(pjoin(pyarrow_include, 'arrow', 'python'))
+                shutil.copytree(pjoin(pyarrow_cpp_include, 'arrow', 'python'),
+                                pjoin(pyarrow_include, 'arrow', 'python'))
+            copy_pyarrow_cpp_headers()
+
+            # Move Arrow C++ and Pyarrow C++ headers to pyarrow/include
+            # if bundled build is specified
             if self.bundle_arrow_cpp or self.bundle_arrow_cpp_headers:
                 arrow_cpp_include = pjoin(build_prefix, 'include')
                 print('Bundling includes: ' + arrow_cpp_include)
-                pyarrow_include = pjoin(build_lib, 'pyarrow', 'include')
                 if os.path.exists(pyarrow_include):
                     shutil.rmtree(pyarrow_include)
                 shutil.move(arrow_cpp_include, pyarrow_include)
 
                 # pyarrow/include file is first deleted in the previous step
                 # so we need to add the PyArrow C++ include folder again
-                pyarrow_cpp_include = pjoin(pyarrow_cpp_home, 'include')
-                shutil.move(pjoin(pyarrow_cpp_include, 'arrow', 'python'),
-                            pjoin(pyarrow_include, 'arrow', 'python'))
+                copy_pyarrow_cpp_headers()
 
             # Move the built C-extension to the place expected by the Python
             # build


### PR DESCRIPTION
This PR adds code to `_run_cmake` to always copy PyArrow C++ header files to `pyarrow/iclude`.