### PR TITLE
ARROW-18343: [C++] Remove AllocateBitmap() with out parameter

### DIFF
--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -184,10 +184,6 @@ Result<std::shared_ptr<Buffer>> AllocateBitmap(int64_t length, MemoryPool* pool)
   return std::move(buf);
 }
 
-Status AllocateBitmap(MemoryPool* pool, int64_t length, std::shared_ptr<Buffer>* out) {
-  return AllocateBitmap(length, pool).Value(out);
-}
-
 Result<std::shared_ptr<Buffer>> AllocateEmptyBitmap(int64_t length, MemoryPool* pool) {
   ARROW_ASSIGN_OR_RAISE(auto buf, AllocateBuffer(bit_util::BytesForBits(length), pool));
   memset(buf->mutable_data(), 0, static_cast<size_t>(buf->size()));

--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -184,6 +184,10 @@ Result<std::shared_ptr<Buffer>> AllocateBitmap(int64_t length, MemoryPool* pool)
   return std::move(buf);
 }
 
+Status AllocateBitmap(MemoryPool* pool, int64_t length, std::shared_ptr<Buffer>* out) {
+  return AllocateBitmap(length, pool).Value(out);
+}
+
 Result<std::shared_ptr<Buffer>> AllocateEmptyBitmap(int64_t length, MemoryPool* pool) {
   ARROW_ASSIGN_OR_RAISE(auto buf, AllocateBuffer(bit_util::BytesForBits(length), pool));
   memset(buf->mutable_data(), 0, static_cast<size_t>(buf->size()));

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -479,9 +479,6 @@ ARROW_EXPORT
 Result<std::shared_ptr<Buffer>> AllocateBitmap(int64_t length,
                                                MemoryPool* pool = NULLPTR);
 
-ARROW_EXPORT
-Status AllocateBitmap(MemoryPool* pool, int64_t length, std::shared_ptr<Buffer>* out);
-
 /// \brief Allocate a zero-initialized bitmap buffer from a memory pool
 ///
 /// \param[in] length size in bits of bitmap to allocate


### PR DESCRIPTION
This variant of AllocateBitmap had been declared but not defined in several years. It's therefore safe to assume that noone is relying on it.
