### PR TITLE
ARROW-18348: [CI][Release][Yum] redhat-rpm-config is needed on AlmaLinux 9

### DIFF
--- a/dev/release/verify-yum.sh
+++ b/dev/release/verify-yum.sh
@@ -73,6 +73,7 @@ case "${distribution}-${distribution_version}" in
     ;;
   almalinux-*)
     distribution_prefix="almalinux"
+    ruby_devel_packages+=(redhat-rpm-config)
     ;;
   amzn-2)
     distribution_prefix="amazon-linux"


### PR DESCRIPTION
https://github.com/ursacomputing/crossbow/actions/runs/3485133283/jobs/5830385419#step:7:1909

    Building native extensions. This could take a while...
    ERROR:  Error installing gobject-introspection:
          ERROR: Failed to build gem native extension.

        current directory: /usr/local/share/gems/gems/glib2-4.0.3/ext/glib2
    /usr/bin/ruby -I /usr/share/rubygems -r ./siteconf20221117-855-v8bktd.rb extconf.rb
    checking for --enable-debug-build option... no
    checking for -Wall option to compiler... *** extconf.rb failed ***
    Could not create Makefile due to some reason, probably lack of necessary
    libraries and/or headers.  Check the mkmf.log file for more details.  You may
    need configuration options.

    Provided configuration options:
          --with-opt-dir
          --without-opt-dir
          --with-opt-include
          --without-opt-include=${opt-dir}/include
          --with-opt-lib
          --without-opt-lib=${opt-dir}/lib64
          --with-make-prog
          --without-make-prog
          --srcdir=.
          --curdir
          --ruby=/usr/bin/$(RUBY_BASE_NAME)
          --enable-debug-build
          --disable-debug-build
    /usr/share/ruby/mkmf.rb:471:in `try_do': The compiler failed to generate an executable file. (RuntimeError)
    You have to install development tools first.
          from /usr/share/ruby/mkmf.rb:597:in `block in try_compile'
          from /usr/share/ruby/mkmf.rb:546:in `with_werror'
          from /usr/share/ruby/mkmf.rb:597:in `try_compile'
          from /usr/local/share/gems/gems/glib2-4.0.3/lib/mkmf-gnome.rb:65:in `block in try_compiler_option'
          from /usr/share/ruby/mkmf.rb:971:in `block in checking_for'
          from /usr/share/ruby/mkmf.rb:361:in `block (2 levels) in postpone'
          from /usr/share/ruby/mkmf.rb:331:in `open'
          from /usr/share/ruby/mkmf.rb:361:in `block in postpone'
          from /usr/share/ruby/mkmf.rb:331:in `open'
          from /usr/share/ruby/mkmf.rb:357:in `postpone'
          from /usr/share/ruby/mkmf.rb:970:in `checking_for'
          from /usr/local/share/gems/gems/glib2-4.0.3/lib/mkmf-gnome.rb:64:in `try_compiler_option'
          from /usr/local/share/gems/gems/glib2-4.0.3/lib/mkmf-gnome.rb:74:in `<top (required)>'
          from <internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:85:in `require'
          from <internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:85:in `require'
          from extconf.rb:27:in `<main>'

    To see why this extension failed to compile, please check the mkmf.log which can be found here:

      /usr/local/lib64/gems/ruby/glib2-4.0.3/mkmf.log

    extconf failed, exit code 1

    Gem files will remain installed in /usr/local/share/gems/gems/glib2-4.0.3 for inspection.
    Results logged to /usr/local/lib64/gems/ruby/glib2-4.0.3/gem_make.out