### PR TITLE
ARROW-17288: [C++] Adapt the CSV file format to the new scan API

### DIFF
--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -652,7 +652,6 @@ struct BatchConverter {
         });
   }
 
-  // TODO: Should use exec context owned by the plan
   std::shared_ptr<ExecContext> exec_context;
   AsyncGenerator<std::optional<ExecBatch>> exec_batch_gen;
   std::shared_ptr<Schema> schema;
@@ -679,7 +678,7 @@ Result<AsyncGenerator<std::shared_ptr<RecordBatch>>> DeclarationToRecordBatchGen
 Result<std::unique_ptr<RecordBatchReader>> DeclarationToReader(Declaration declaration,
                                                                bool use_threads) {
   std::shared_ptr<Schema> schema;
-  auto batch_itr = std::make_unique<Iterator<std::shared_ptr<RecordBatch>>>(
+  auto batch_iterator = std::make_unique<Iterator<std::shared_ptr<RecordBatch>>>(
       ::arrow::internal::IterateSynchronously<std::shared_ptr<RecordBatch>>(
           [&](::arrow::internal::Executor* executor)
               -> Result<AsyncGenerator<std::shared_ptr<RecordBatch>>> {
@@ -713,7 +712,7 @@ Result<std::unique_ptr<RecordBatchReader>> DeclarationToReader(Declaration decla
     std::unique_ptr<Iterator<std::shared_ptr<RecordBatch>>> iterator_;
   };
 
-  return std::make_unique<PlanReader>(std::move(schema), std::move(batch_itr));
+  return std::make_unique<PlanReader>(std::move(schema), std::move(batch_iterator));
 }
 
 namespace internal {

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -616,6 +616,106 @@ Result<std::vector<ExecBatch>> DeclarationToExecBatches(Declaration declaration,
   return DeclarationToExecBatchesAsync(std::move(declaration), exec_context).result();
 }
 
+namespace {
+struct BatchConverter {
+  explicit BatchConverter(::arrow::internal::Executor* executor)
+      : exec_context(std::make_shared<ExecContext>(default_memory_pool(), executor)) {}
+
+  ~BatchConverter() {
+    if (!exec_plan) {
+      return;
+    }
+    if (exec_plan->finished().is_finished()) {
+      return;
+    }
+    exec_plan->StopProducing();
+    Status abandoned_status = exec_plan->finished().status();
+    if (!abandoned_status.ok()) {
+      abandoned_status.Warn();
+    }
+  }
+
+  Future<std::shared_ptr<RecordBatch>> operator()() {
+    return exec_batch_gen().Then(
+        [this](const std::optional<ExecBatch>& batch)
+            -> Future<std::shared_ptr<RecordBatch>> {
+          if (batch) {
+            return batch->ToRecordBatch(schema);
+          } else {
+            return exec_plan->finished().Then(
+                []() -> std::shared_ptr<RecordBatch> { return nullptr; });
+          }
+        },
+        [this](const Status& err) {
+          return exec_plan->finished().Then(
+              [err]() -> Result<std::shared_ptr<RecordBatch>> { return err; });
+        });
+  }
+
+  // TODO: Should use exec context owned by the plan
+  std::shared_ptr<ExecContext> exec_context;
+  AsyncGenerator<std::optional<ExecBatch>> exec_batch_gen;
+  std::shared_ptr<Schema> schema;
+  std::shared_ptr<ExecPlan> exec_plan;
+};
+
+Result<AsyncGenerator<std::shared_ptr<RecordBatch>>> DeclarationToRecordBatchGenerator(
+    Declaration declaration, ::arrow::internal::Executor* executor,
+    std::shared_ptr<Schema>* out_schema) {
+  auto converter = std::make_shared<BatchConverter>(executor);
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<ExecPlan> plan,
+                        ExecPlan::Make(converter->exec_context.get()));
+  Declaration with_sink = Declaration::Sequence(
+      {declaration,
+       {"sink", SinkNodeOptions(&converter->exec_batch_gen, &converter->schema)}});
+  ARROW_RETURN_NOT_OK(with_sink.AddToPlan(plan.get()));
+  ARROW_RETURN_NOT_OK(plan->StartProducing());
+  converter->exec_plan = std::move(plan);
+  *out_schema = converter->schema;
+  return [conv = std::move(converter)] { return (*conv)(); };
+}
+}  // namespace
+
+Result<std::unique_ptr<RecordBatchReader>> DeclarationToReader(Declaration declaration,
+                                                               bool use_threads) {
+  std::shared_ptr<Schema> schema;
+  auto batch_itr = std::make_unique<Iterator<std::shared_ptr<RecordBatch>>>(
+      ::arrow::internal::IterateSynchronously<std::shared_ptr<RecordBatch>>(
+          [&](::arrow::internal::Executor* executor)
+              -> Result<AsyncGenerator<std::shared_ptr<RecordBatch>>> {
+            return DeclarationToRecordBatchGenerator(declaration, executor, &schema);
+          },
+          use_threads));
+
+  struct PlanReader : RecordBatchReader {
+    PlanReader(std::shared_ptr<Schema> schema,
+               std::unique_ptr<Iterator<std::shared_ptr<RecordBatch>>> iterator)
+        : schema_(std::move(schema)), iterator_(std::move(iterator)) {}
+
+    std::shared_ptr<Schema> schema() const override { return schema_; }
+
+    Status ReadNext(std::shared_ptr<RecordBatch>* record_batch) override {
+      DCHECK(!!iterator_) << "call to ReadNext on already closed reader";
+      return iterator_->Next().Value(record_batch);
+    }
+
+    Status Close() override {
+      // End plan and read from generator until finished
+      std::shared_ptr<RecordBatch> batch;
+      do {
+        ARROW_RETURN_NOT_OK(ReadNext(&batch));
+      } while (batch != nullptr);
+      iterator_.reset();
+      return Status::OK();
+    }
+
+    std::shared_ptr<Schema> schema_;
+    std::unique_ptr<Iterator<std::shared_ptr<RecordBatch>>> iterator_;
+  };
+
+  return std::make_unique<PlanReader>(std::move(schema), std::move(batch_itr));
+}
+
 namespace internal {
 
 void RegisterSourceNode(ExecFactoryRegistry*);

--- a/cpp/src/arrow/compute/exec/exec_plan.h
+++ b/cpp/src/arrow/compute/exec/exec_plan.h
@@ -517,8 +517,8 @@ ARROW_EXPORT Future<std::vector<std::shared_ptr<RecordBatch>>> DeclarationToBatc
     Declaration declaration, ExecContext* exec_context = default_exec_context());
 
 /// \brief Utility method to run a declaration and return results as a RecordBatchReader
-Result<std::unique_ptr<RecordBatchReader>> DeclarationToReader(Declaration declaration,
-                                                               bool use_threads);
+ARROW_EXPORT Result<std::unique_ptr<RecordBatchReader>> DeclarationToReader(
+    Declaration declaration, bool use_threads);
 
 /// \brief Wrap an ExecBatch generator in a RecordBatchReader.
 ///

--- a/cpp/src/arrow/compute/exec/exec_plan.h
+++ b/cpp/src/arrow/compute/exec/exec_plan.h
@@ -516,6 +516,10 @@ ARROW_EXPORT Result<std::vector<std::shared_ptr<RecordBatch>>> DeclarationToBatc
 ARROW_EXPORT Future<std::vector<std::shared_ptr<RecordBatch>>> DeclarationToBatchesAsync(
     Declaration declaration, ExecContext* exec_context = default_exec_context());
 
+/// \brief Utility method to run a declaration and return results as a RecordBatchReader
+Result<std::unique_ptr<RecordBatchReader>> DeclarationToReader(Declaration declaration,
+                                                               bool use_threads);
+
 /// \brief Wrap an ExecBatch generator in a RecordBatchReader.
 ///
 /// The RecordBatchReader does not impose any ordering on emitted batches.

--- a/cpp/src/arrow/compute/exec/expression.cc
+++ b/cpp/src/arrow/compute/exec/expression.cc
@@ -1213,6 +1213,26 @@ Result<Expression> SimplifyWithGuarantee(Expression expr,
   return expr;
 }
 
+Result<Expression> RemoveNamedRefs(Expression src) {
+  if (!src.IsBound()) {
+    return Status::Invalid("RemoveNamedRefs called on unbound expression");
+  }
+  return ModifyExpression(
+      std::move(src),
+      [](Expression expr) {
+        const Expression::Parameter* param = expr.parameter();
+        if (param && !param->ref.IsFieldPath()) {
+          FieldPath ref_as_path(
+              std::vector<int>(param->indices.begin(), param->indices.end()));
+          return Expression(
+              Expression::Parameter{std::move(ref_as_path), param->type, param->indices});
+        }
+
+        return expr;
+      },
+      [](Expression expr, ...) { return expr; });
+}
+
 // Serialization is accomplished by converting expressions to KeyValueMetadata and storing
 // this in the schema of a RecordBatch. Embedded arrays and scalars are stored in its
 // columns. Finally, the RecordBatch is written to an IPC file.

--- a/cpp/src/arrow/compute/exec/expression.cc
+++ b/cpp/src/arrow/compute/exec/expression.cc
@@ -1219,6 +1219,7 @@ Result<Expression> RemoveNamedRefs(Expression src) {
   }
   return ModifyExpression(
       std::move(src),
+      /*pre=*/
       [](Expression expr) {
         const Expression::Parameter* param = expr.parameter();
         if (param && !param->ref.IsFieldPath()) {
@@ -1230,7 +1231,7 @@ Result<Expression> RemoveNamedRefs(Expression src) {
 
         return expr;
       },
-      [](Expression expr, ...) { return expr; });
+      /*post_call=*/[](Expression expr, ...) { return expr; });
 }
 
 // Serialization is accomplished by converting expressions to KeyValueMetadata and storing

--- a/cpp/src/arrow/compute/exec/expression.h
+++ b/cpp/src/arrow/compute/exec/expression.h
@@ -220,6 +220,10 @@ ARROW_EXPORT
 Result<Expression> SimplifyWithGuarantee(Expression,
                                          const Expression& guaranteed_true_predicate);
 
+/// Replace all named field refs (e.g. "x" or "x.y") with field paths (e.g. [0] or [1,3])
+///
+/// This isn't usually needed and does not offer any simplification by itself.  However,
+/// it can be useful to normalize an expression to paths to make it simpler to work with.
 ARROW_EXPORT Result<Expression> RemoveNamedRefs(Expression expression);
 
 /// @}

--- a/cpp/src/arrow/compute/exec/expression.h
+++ b/cpp/src/arrow/compute/exec/expression.h
@@ -220,6 +220,8 @@ ARROW_EXPORT
 Result<Expression> SimplifyWithGuarantee(Expression,
                                          const Expression& guaranteed_true_predicate);
 
+ARROW_EXPORT Result<Expression> RemoveNamedRefs(Expression expression);
+
 /// @}
 
 // Execution

--- a/cpp/src/arrow/compute/exec/expression_test.cc
+++ b/cpp/src/arrow/compute/exec/expression_test.cc
@@ -929,6 +929,26 @@ TEST(Expression, FoldConstantsBoolean) {
   ExpectFoldsTo(or_(whatever, whatever), whatever);
 }
 
+struct {
+  void operator()(Expression expr, Expression expected,
+                  const Schema& schema = *kBoringSchema) {
+    ASSERT_OK_AND_ASSIGN(expr, expr.Bind(schema));
+    ASSERT_OK_AND_ASSIGN(expected, expected.Bind(schema));
+
+    ASSERT_OK_AND_ASSIGN(auto without_named_refs, RemoveNamedRefs(expr));
+
+    EXPECT_EQ(without_named_refs, expected);
+  }
+} ExpectRemovesRefsTo;
+
+TEST(Expression, RemoveNamedRefs) {
+  ExpectRemovesRefsTo(field_ref("i32"), field_ref(2));
+  ExpectRemovesRefsTo(call("add", {literal(4), field_ref("i32")}),
+                      call("add", {literal(4), field_ref(2)}));
+  auto nested_schema = Schema({field("a", struct_({field("b", int32())}))});
+  ExpectRemovesRefsTo(field_ref({"a", "b"}), field_ref({0, 0}), nested_schema);
+}
+
 TEST(Expression, ExtractKnownFieldValues) {
   struct {
     void operator()(Expression guarantee,

--- a/cpp/src/arrow/compute/exec/expression_test.cc
+++ b/cpp/src/arrow/compute/exec/expression_test.cc
@@ -929,17 +929,15 @@ TEST(Expression, FoldConstantsBoolean) {
   ExpectFoldsTo(or_(whatever, whatever), whatever);
 }
 
-struct {
-  void operator()(Expression expr, Expression expected,
-                  const Schema& schema = *kBoringSchema) {
-    ASSERT_OK_AND_ASSIGN(expr, expr.Bind(schema));
-    ASSERT_OK_AND_ASSIGN(expected, expected.Bind(schema));
+void ExpectRemovesRefsTo(Expression expr, Expression expected,
+                         const Schema& schema = *kBoringSchema) {
+  ASSERT_OK_AND_ASSIGN(expr, expr.Bind(schema));
+  ASSERT_OK_AND_ASSIGN(expected, expected.Bind(schema));
 
-    ASSERT_OK_AND_ASSIGN(auto without_named_refs, RemoveNamedRefs(expr));
+  ASSERT_OK_AND_ASSIGN(auto without_named_refs, RemoveNamedRefs(expr));
 
-    EXPECT_EQ(without_named_refs, expected);
-  }
-} ExpectRemovesRefsTo;
+  EXPECT_EQ(without_named_refs, expected);
+}
 
 TEST(Expression, RemoveNamedRefs) {
   ExpectRemovesRefsTo(field_ref("i32"), field_ref(2));

--- a/cpp/src/arrow/compute/exec/expression_test.cc
+++ b/cpp/src/arrow/compute/exec/expression_test.cc
@@ -1364,6 +1364,10 @@ TEST(Expression, SimplifyWithValidityGuarantee) {
       .WithGuarantee(is_null(field_ref("i32")))
       .Expect(literal(false));
 
+  Simplify{{true_unless_null(field_ref("i32"))}}
+      .WithGuarantee(is_null(field_ref("i32")))
+      .Expect(null_literal(boolean()));
+
   Simplify{is_valid(field_ref("i32"))}
       .WithGuarantee(is_valid(field_ref("i32")))
       .Expect(literal(true));
@@ -1379,6 +1383,21 @@ TEST(Expression, SimplifyWithValidityGuarantee) {
   Simplify{true_unless_null(field_ref("i32"))}
       .WithGuarantee(is_valid(field_ref("i32")))
       .Expect(literal(true));
+
+  Simplify{{equal(field_ref("i32"), literal(7))}}
+      .WithGuarantee(is_null(field_ref("i32")))
+      .Expect(null_literal(boolean()));
+
+  auto i32_is_2_or_null =
+      or_(equal(field_ref("i32"), literal(2)), is_null(field_ref("i32")));
+
+  Simplify{i32_is_2_or_null}
+      .WithGuarantee(is_null(field_ref("i32")))
+      .Expect(literal(true));
+
+  Simplify{{greater(field_ref("i32"), literal(7))}}
+      .WithGuarantee(is_null(field_ref("i32")))
+      .Expect(null_literal(boolean()));
 }
 
 TEST(Expression, SimplifyWithComparisonAndNullableCaveat) {

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -228,6 +228,10 @@ class ARROW_EXPORT SinkNodeOptions : public ExecNodeOptions {
   /// data from the plan.  If this function is not called frequently enough then the sink
   /// node will start to accumulate data and may apply backpressure.
   std::function<Future<std::optional<ExecBatch>>()>* generator;
+  /// \brief A pointer which will be set to the schema of the generated batches
+  ///
+  /// This is optional, if nullptr is passed in then it will be ignored.
+  /// This will be set when the node is added to the plan, before StartProducing is called
   std::shared_ptr<Schema>* schema;
   /// \brief Options to control when to apply backpressure
   ///

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -214,9 +214,11 @@ struct ARROW_EXPORT BackpressureOptions {
 class ARROW_EXPORT SinkNodeOptions : public ExecNodeOptions {
  public:
   explicit SinkNodeOptions(std::function<Future<std::optional<ExecBatch>>()>* generator,
+                           std::shared_ptr<Schema>* schema = NULLPTR,
                            BackpressureOptions backpressure = {},
                            BackpressureMonitor** backpressure_monitor = NULLPTR)
       : generator(generator),
+        schema(schema),
         backpressure(std::move(backpressure)),
         backpressure_monitor(backpressure_monitor) {}
 
@@ -226,6 +228,7 @@ class ARROW_EXPORT SinkNodeOptions : public ExecNodeOptions {
   /// data from the plan.  If this function is not called frequently enough then the sink
   /// node will start to accumulate data and may apply backpressure.
   std::function<Future<std::optional<ExecBatch>>()>* generator;
+  std::shared_ptr<Schema>* schema;
   /// \brief Options to control when to apply backpressure
   ///
   /// This is optional, the default is to never apply backpressure.  If the plan is not

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -214,11 +214,19 @@ struct ARROW_EXPORT BackpressureOptions {
 class ARROW_EXPORT SinkNodeOptions : public ExecNodeOptions {
  public:
   explicit SinkNodeOptions(std::function<Future<std::optional<ExecBatch>>()>* generator,
-                           std::shared_ptr<Schema>* schema = NULLPTR,
+                           std::shared_ptr<Schema>* schema,
                            BackpressureOptions backpressure = {},
                            BackpressureMonitor** backpressure_monitor = NULLPTR)
       : generator(generator),
         schema(schema),
+        backpressure(backpressure),
+        backpressure_monitor(backpressure_monitor) {}
+
+  explicit SinkNodeOptions(std::function<Future<std::optional<ExecBatch>>()>* generator,
+                           BackpressureOptions backpressure = {},
+                           BackpressureMonitor** backpressure_monitor = NULLPTR)
+      : generator(generator),
+        schema(NULLPTR),
         backpressure(std::move(backpressure)),
         backpressure_monitor(backpressure_monitor) {}
 

--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -390,13 +390,14 @@ TEST(ExecPlanExecution, SinkNodeBackpressure) {
   BackpressureMonitor* backpressure_monitor;
   BackpressureOptions backpressure_options(resume_if_below_bytes, pause_if_above_bytes);
   std::shared_ptr<Schema> schema_ = schema({field("data", uint32())});
-  ARROW_EXPECT_OK(compute::Declaration::Sequence(
-                      {
-                          {"source", SourceNodeOptions(schema_, batch_producer)},
-                          {"sink", SinkNodeOptions{&sink_gen, backpressure_options,
-                                                   &backpressure_monitor}},
-                      })
-                      .AddToPlan(plan.get()));
+  ARROW_EXPECT_OK(
+      compute::Declaration::Sequence(
+          {
+              {"source", SourceNodeOptions(schema_, batch_producer)},
+              {"sink", SinkNodeOptions{&sink_gen, /*schema=*/nullptr,
+                                       backpressure_options, &backpressure_monitor}},
+          })
+          .AddToPlan(plan.get()));
   ASSERT_TRUE(backpressure_monitor);
   ARROW_EXPECT_OK(plan->StartProducing());
 

--- a/cpp/src/arrow/dataset/dataset.cc
+++ b/cpp/src/arrow/dataset/dataset.cc
@@ -43,12 +43,14 @@ Fragment::Fragment(compute::Expression partition_expression,
     : partition_expression_(std::move(partition_expression)),
       physical_schema_(std::move(physical_schema)) {}
 
-Future<std::shared_ptr<InspectedFragment>> Fragment::InspectFragment() {
+Future<std::shared_ptr<InspectedFragment>> Fragment::InspectFragment(
+    const FragmentScanOptions* format_options, compute::ExecContext* exec_context) {
   return Status::NotImplemented("Inspect fragment");
 }
 
 Future<std::shared_ptr<FragmentScanner>> Fragment::BeginScan(
-    const FragmentScanRequest& request, const InspectedFragment& inspected_fragment) {
+    const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
+    const FragmentScanOptions* format_options, compute::ExecContext* exec_context) {
   return Status::NotImplemented("New scan method");
 }
 
@@ -154,7 +156,8 @@ Future<std::optional<int64_t>> InMemoryFragment::CountRows(
   return Future<std::optional<int64_t>>::MakeFinished(total);
 }
 
-Future<std::shared_ptr<InspectedFragment>> InMemoryFragment::InspectFragment() {
+Future<std::shared_ptr<InspectedFragment>> InMemoryFragment::InspectFragment(
+    const FragmentScanOptions* format_options, compute::ExecContext* exec_context) {
   return std::make_shared<InspectedFragment>(physical_schema_->field_names());
 }
 
@@ -180,7 +183,8 @@ class InMemoryFragment::Scanner : public FragmentScanner {
 };
 
 Future<std::shared_ptr<FragmentScanner>> InMemoryFragment::BeginScan(
-    const FragmentScanRequest& request, const InspectedFragment& inspected_fragment) {
+    const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
+    const FragmentScanOptions* format_options, compute::ExecContext* exec_context) {
   return Future<std::shared_ptr<FragmentScanner>>::MakeFinished(
       std::make_shared<InMemoryFragment::Scanner>(this));
 }

--- a/cpp/src/arrow/dataset/dataset.h
+++ b/cpp/src/arrow/dataset/dataset.h
@@ -88,7 +88,7 @@ struct ARROW_DS_EXPORT FragmentScanRequest {
   /// before returning the scanned batch.
   std::vector<FragmentSelectionColumn> columns;
   /// \brief Options specific to the format being scanned
-  FragmentScanOptions* format_scan_options;
+  const FragmentScanOptions* format_scan_options;
 };
 
 /// \brief An iterator-like object that can yield batches created from a fragment
@@ -156,11 +156,13 @@ class ARROW_DS_EXPORT Fragment : public std::enable_shared_from_this<Fragment> {
   /// This will be called before a scan and a fragment should attach whatever
   /// information will be needed to figure out an evolution strategy.  This information
   /// will then be passed to the call to BeginScan
-  virtual Future<std::shared_ptr<InspectedFragment>> InspectFragment();
+  virtual Future<std::shared_ptr<InspectedFragment>> InspectFragment(
+      const FragmentScanOptions* format_options, compute::ExecContext* exec_context);
 
   /// \brief Start a scan operation
   virtual Future<std::shared_ptr<FragmentScanner>> BeginScan(
-      const FragmentScanRequest& request, const InspectedFragment& inspected_fragment);
+      const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
+      const FragmentScanOptions* format_options, compute::ExecContext* exec_context);
 
   /// \brief Count the number of rows in this fragment matching the filter using metadata
   /// only. That is, this method may perform I/O, but will not load data.
@@ -228,10 +230,13 @@ class ARROW_DS_EXPORT InMemoryFragment : public Fragment {
       compute::Expression predicate,
       const std::shared_ptr<ScanOptions>& options) override;
 
-  Future<std::shared_ptr<InspectedFragment>> InspectFragment() override;
+  Future<std::shared_ptr<InspectedFragment>> InspectFragment(
+      const FragmentScanOptions* format_options,
+      compute::ExecContext* exec_context) override;
   Future<std::shared_ptr<FragmentScanner>> BeginScan(
-      const FragmentScanRequest& request,
-      const InspectedFragment& inspected_fragment) override;
+      const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
+      const FragmentScanOptions* format_options,
+      compute::ExecContext* exec_context) override;
 
   std::string type_name() const override { return "in-memory"; }
 

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -134,13 +134,13 @@ Future<std::optional<int64_t>> FileFormat::CountRows(
 Future<std::shared_ptr<InspectedFragment>> FileFormat::InspectFragment(
     const FileSource& source, const FragmentScanOptions* format_options,
     compute::ExecContext* exec_context) const {
-  return Status::NotImplemented("The new scanner is not yet supported on this format");
+  return Status::NotImplemented("This format does not yet support the scan2 node");
 }
 
 Future<std::shared_ptr<FragmentScanner>> FileFormat::BeginScan(
     const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
     const FragmentScanOptions* format_options, compute::ExecContext* exec_context) const {
-  return Status::NotImplemented("The new scanner is not yet supported on this format");
+  return Status::NotImplemented("This format does not yet support the scan2 node");
 }
 
 Result<std::shared_ptr<FileFragment>> FileFormat::MakeFragment(

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -65,22 +65,25 @@ class ARROW_DS_EXPORT FileSource : public util::EqualityComparable<FileSource> {
       : buffer_(std::move(buffer)), compression_(compression) {}
 
   using CustomOpen = std::function<Result<std::shared_ptr<io::RandomAccessFile>>()>;
-  explicit FileSource(CustomOpen open, int64_t size)
+  FileSource(CustomOpen open, int64_t size)
       : custom_open_(std::move(open)), custom_size_(size) {}
 
   using CustomOpenWithCompression =
       std::function<Result<std::shared_ptr<io::RandomAccessFile>>(Compression::type)>;
-  explicit FileSource(CustomOpenWithCompression open_with_compression, int64_t size,
-                      Compression::type compression = Compression::UNCOMPRESSED)
+  FileSource(CustomOpenWithCompression open_with_compression, int64_t size,
+             Compression::type compression = Compression::UNCOMPRESSED)
       : custom_open_(std::bind(std::move(open_with_compression), compression)),
         custom_size_(size),
         compression_(compression) {}
 
-  explicit FileSource(std::shared_ptr<io::RandomAccessFile> file, int64_t size,
-                      Compression::type compression = Compression::UNCOMPRESSED)
+  FileSource(std::shared_ptr<io::RandomAccessFile> file, int64_t size,
+             Compression::type compression = Compression::UNCOMPRESSED)
       : custom_open_([=] { return ToResult(file); }),
         custom_size_(size),
         compression_(compression) {}
+
+  explicit FileSource(std::shared_ptr<io::RandomAccessFile> file,
+                      Compression::type compression = Compression::UNCOMPRESSED);
 
   FileSource() : custom_open_(CustomOpen{&InvalidOpen}) {}
 

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -116,6 +116,7 @@ class ARROW_DS_EXPORT FileSource : public util::EqualityComparable<FileSource> {
   Result<std::shared_ptr<io::RandomAccessFile>> Open() const;
 
   /// \brief Get the size (in bytes) of the file or buffer
+  /// If the file is compressed this should be the compressed (on-disk) size.
   int64_t Size() const;
 
   /// \brief Get an InputStream which views this file source (and decompresses if needed)

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -65,18 +65,22 @@ class ARROW_DS_EXPORT FileSource : public util::EqualityComparable<FileSource> {
       : buffer_(std::move(buffer)), compression_(compression) {}
 
   using CustomOpen = std::function<Result<std::shared_ptr<io::RandomAccessFile>>()>;
-  explicit FileSource(CustomOpen open) : custom_open_(std::move(open)) {}
+  explicit FileSource(CustomOpen open, int64_t size)
+      : custom_open_(std::move(open)), custom_size_(size) {}
 
   using CustomOpenWithCompression =
       std::function<Result<std::shared_ptr<io::RandomAccessFile>>(Compression::type)>;
-  explicit FileSource(CustomOpenWithCompression open_with_compression,
+  explicit FileSource(CustomOpenWithCompression open_with_compression, int64_t size,
                       Compression::type compression = Compression::UNCOMPRESSED)
       : custom_open_(std::bind(std::move(open_with_compression), compression)),
+        custom_size_(size),
         compression_(compression) {}
 
-  explicit FileSource(std::shared_ptr<io::RandomAccessFile> file,
+  explicit FileSource(std::shared_ptr<io::RandomAccessFile> file, int64_t size,
                       Compression::type compression = Compression::UNCOMPRESSED)
-      : custom_open_([=] { return ToResult(file); }), compression_(compression) {}
+      : custom_open_([=] { return ToResult(file); }),
+        custom_size_(size),
+        compression_(compression) {}
 
   FileSource() : custom_open_(CustomOpen{&InvalidOpen}) {}
 
@@ -108,6 +112,9 @@ class ARROW_DS_EXPORT FileSource : public util::EqualityComparable<FileSource> {
   /// \brief Get a RandomAccessFile which views this file source
   Result<std::shared_ptr<io::RandomAccessFile>> Open() const;
 
+  /// \brief Get the size (in bytes) of the file or buffer
+  int64_t Size() const;
+
   /// \brief Get an InputStream which views this file source (and decompresses if needed)
   /// \param[in] compression If nullopt, guess the compression scheme from the
   ///     filename, else decompress with the given codec
@@ -126,6 +133,7 @@ class ARROW_DS_EXPORT FileSource : public util::EqualityComparable<FileSource> {
   std::shared_ptr<fs::FileSystem> filesystem_;
   std::shared_ptr<Buffer> buffer_;
   CustomOpen custom_open_;
+  int64_t custom_size_ = 0;
   Compression::type compression_ = Compression::UNCOMPRESSED;
 };
 
@@ -150,6 +158,11 @@ class ARROW_DS_EXPORT FileFormat : public std::enable_shared_from_this<FileForma
   /// \brief Return the schema of the file if possible.
   virtual Result<std::shared_ptr<Schema>> Inspect(const FileSource& source) const = 0;
 
+  /// \brief Learn what we need about the file before we start scanning it
+  virtual Future<std::shared_ptr<InspectedFragment>> InspectFragment(
+      const FileSource& source, const FragmentScanOptions* format_options,
+      compute::ExecContext* exec_context) const;
+
   virtual Result<RecordBatchGenerator> ScanBatchesAsync(
       const std::shared_ptr<ScanOptions>& options,
       const std::shared_ptr<FileFragment>& file) const = 0;
@@ -157,6 +170,11 @@ class ARROW_DS_EXPORT FileFormat : public std::enable_shared_from_this<FileForma
   virtual Future<std::optional<int64_t>> CountRows(
       const std::shared_ptr<FileFragment>& file, compute::Expression predicate,
       const std::shared_ptr<ScanOptions>& options);
+
+  virtual Future<std::shared_ptr<FragmentScanner>> BeginScan(
+      const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
+      const FragmentScanOptions* format_options,
+      compute::ExecContext* exec_context) const;
 
   /// \brief Open a fragment
   virtual Result<std::shared_ptr<FileFragment>> MakeFragment(
@@ -179,6 +197,10 @@ class ARROW_DS_EXPORT FileFormat : public std::enable_shared_from_this<FileForma
 
   /// \brief Get default write options for this format.
   virtual std::shared_ptr<FileWriteOptions> DefaultWriteOptions() = 0;
+
+ protected:
+  explicit FileFormat(std::shared_ptr<FragmentScanOptions> default_fragment_scan_options)
+      : default_fragment_scan_options(std::move(default_fragment_scan_options)) {}
 };
 
 /// \brief A Fragment that is stored in a file with a known format
@@ -190,6 +212,13 @@ class ARROW_DS_EXPORT FileFragment : public Fragment,
   Future<std::optional<int64_t>> CountRows(
       compute::Expression predicate,
       const std::shared_ptr<ScanOptions>& options) override;
+  Future<std::shared_ptr<FragmentScanner>> BeginScan(
+      const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
+      const FragmentScanOptions* format_options,
+      compute::ExecContext* exec_context) override;
+  Future<std::shared_ptr<InspectedFragment>> InspectFragment(
+      const FragmentScanOptions* format_options,
+      compute::ExecContext* exec_context) override;
 
   std::string type_name() const override { return format_->type_name(); }
   std::string ToString() const override { return source_.path(); };

--- a/cpp/src/arrow/dataset/file_csv.cc
+++ b/cpp/src/arrow/dataset/file_csv.cc
@@ -74,7 +74,7 @@ class CsvFileScanner : public FragmentScanner {
         best_guess_bytes_per_batch_(best_guess_bytes_per_batch) {}
 
   Future<std::shared_ptr<RecordBatch>> ScanBatch(int batch_number) override {
-    // We should be called in increasing order but let's verify that in case it changes.
+    // This should be called in increasing order but let's verify that in case it changes.
     // It would be easy enough to handle out of order but no need for that complexity at
     // the moment.
     DCHECK_EQ(scanned_so_far_++, batch_number);

--- a/cpp/src/arrow/dataset/file_csv.cc
+++ b/cpp/src/arrow/dataset/file_csv.cc
@@ -78,8 +78,7 @@ class CsvFileScanner : public FragmentScanner {
     // It would be easy enough to handle out of order but no need for that complexity at
     // the moment.
     DCHECK_EQ(scanned_so_far_++, batch_number);
-    return reader_->ReadNextAsync().Then(
-        [](const std::shared_ptr<RecordBatch>& batch) { return batch; });
+    return reader_->ReadNextAsync();
   }
 
   int64_t EstimatedDataBytes(int batch_number) override {

--- a/cpp/src/arrow/dataset/file_csv.cc
+++ b/cpp/src/arrow/dataset/file_csv.cc
@@ -38,6 +38,7 @@
 #include "arrow/result.h"
 #include "arrow/type.h"
 #include "arrow/util/async_generator.h"
+#include "arrow/util/bit_util.h"
 #include "arrow/util/iterator.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/tracing_internal.h"
@@ -52,9 +53,99 @@ using internal::SerialExecutor;
 
 namespace dataset {
 
+struct CsvInspectedFragment : public InspectedFragment {
+  CsvInspectedFragment(std::vector<std::string> column_names,
+                       std::shared_ptr<io::InputStream> input_stream, int64_t num_bytes)
+      : InspectedFragment(std::move(column_names)),
+        input_stream(std::move(input_stream)),
+        num_bytes(num_bytes) {}
+  // We need to start reading the file in order to figure out the column names and
+  // so we save off the input stream
+  std::shared_ptr<io::InputStream> input_stream;
+  int64_t num_bytes;
+};
+
+class CsvFileScanner : public FragmentScanner {
+ public:
+  CsvFileScanner(std::shared_ptr<csv::StreamingReader> reader, int num_batches,
+                 int64_t best_guess_bytes_per_batch)
+      : reader_(std::move(reader)),
+        num_batches_(num_batches),
+        best_guess_bytes_per_batch_(best_guess_bytes_per_batch) {}
+
+  Future<std::shared_ptr<RecordBatch>> ScanBatch(int batch_number) override {
+    // We should be called in increasing order but let's verify that in case it changes.
+    // It would be easy enough to handle out of order but no need for that complexity at
+    // the moment.
+    DCHECK_EQ(scanned_so_far_++, batch_number);
+    return reader_->ReadNextAsync().Then(
+        [](const std::shared_ptr<RecordBatch>& batch) { return batch; });
+  }
+
+  int64_t EstimatedDataBytes(int batch_number) override {
+    return best_guess_bytes_per_batch_;
+  }
+
+  int NumBatches() override { return num_batches_; }
+
+  static Result<csv::ConvertOptions> GetConvertOptions(
+      const CsvFragmentScanOptions& csv_options, const FragmentScanRequest& scan_request,
+      const CsvInspectedFragment& inspected_fragment) {
+    // We use the convert options given from the user but override which columns we are
+    // looking for.
+    auto convert_options = csv_options.convert_options;
+    std::vector<std::string> columns;
+    std::unordered_map<std::string, std::shared_ptr<DataType>> column_types;
+    for (const auto& scan_column : scan_request.columns) {
+      if (scan_column.path.indices().size() != 1) {
+        return Status::Invalid("CSV reader does not supported nested references");
+      }
+      const std::string& column_name =
+          inspected_fragment.column_names[scan_column.path.indices()[0]];
+      columns.push_back(column_name);
+      column_types[column_name] = scan_column.requested_type->GetSharedPtr();
+    }
+    convert_options.include_columns = std::move(columns);
+    convert_options.column_types = std::move(column_types);
+    return std::move(convert_options);
+  }
+
+  static Future<std::shared_ptr<FragmentScanner>> Make(
+      const CsvFragmentScanOptions& csv_options, const FragmentScanRequest& scan_request,
+      const CsvInspectedFragment& inspected_fragment, Executor* cpu_executor) {
+    auto read_options = csv_options.read_options;
+
+    int num_batches = static_cast<int>(bit_util::CeilDiv(
+        inspected_fragment.num_bytes, static_cast<int64_t>(read_options.block_size)));
+    // Could be better, but a reasonable starting point.  CSV presumably takes up more
+    // space than an in-memory format so this should be conservative.
+    int64_t best_guess_bytes_per_batch = read_options.block_size;
+    ARROW_ASSIGN_OR_RAISE(
+        csv::ConvertOptions convert_options,
+        GetConvertOptions(csv_options, scan_request, inspected_fragment));
+
+    return csv::StreamingReader::MakeAsync(
+               io::default_io_context(), inspected_fragment.input_stream, cpu_executor,
+               read_options, csv_options.parse_options, convert_options)
+        .Then([num_batches, best_guess_bytes_per_batch](
+                  const std::shared_ptr<csv::StreamingReader>& reader)
+                  -> std::shared_ptr<FragmentScanner> {
+          return std::make_shared<CsvFileScanner>(reader, num_batches,
+                                                  best_guess_bytes_per_batch);
+        });
+  }
+
+ private:
+  std::shared_ptr<csv::StreamingReader> reader_;
+  int num_batches_;
+  int64_t best_guess_bytes_per_batch_;
+
+  int scanned_so_far_ = 0;
+};
+
 using RecordBatchGenerator = std::function<Future<std::shared_ptr<RecordBatch>>()>;
 
-Result<std::unordered_set<std::string>> GetColumnNames(
+Result<std::vector<std::string>> GetOrderedColumnNames(
     const csv::ReadOptions& read_options, const csv::ParseOptions& parse_options,
     std::string_view first_block, MemoryPool* pool) {
   // Skip BOM when reading column names (ARROW-14644, ARROW-17382)
@@ -64,13 +155,7 @@ Result<std::unordered_set<std::string>> GetColumnNames(
   size = size - static_cast<uint32_t>(data_no_bom - data);
   first_block = std::string_view(reinterpret_cast<const char*>(data_no_bom), size);
   if (!read_options.column_names.empty()) {
-    std::unordered_set<std::string> column_names;
-    for (const auto& s : read_options.column_names) {
-      if (!column_names.emplace(s).second) {
-        return Status::Invalid("CSV file contained multiple columns named ", s);
-      }
-    }
-    return column_names;
+    return read_options.column_names;
   }
 
   uint32_t parsed_size = 0;
@@ -90,14 +175,14 @@ Result<std::unordered_set<std::string>> GetColumnNames(
     return Status::Invalid("No columns in CSV file");
   }
 
-  std::unordered_set<std::string> column_names;
+  std::vector<std::string> column_names;
 
   if (read_options.autogenerate_column_names) {
     column_names.reserve(parser.num_cols());
     for (int32_t i = 0; i < parser.num_cols(); ++i) {
       std::stringstream ss;
       ss << "f" << i;
-      column_names.emplace(ss.str());
+      column_names.emplace_back(ss.str());
     }
     return column_names;
   }
@@ -105,13 +190,26 @@ Result<std::unordered_set<std::string>> GetColumnNames(
   RETURN_NOT_OK(
       parser.VisitLastRow([&](const uint8_t* data, uint32_t size, bool quoted) -> Status {
         std::string_view view{reinterpret_cast<const char*>(data), size};
-        if (column_names.emplace(std::string(view)).second) {
-          return Status::OK();
-        }
-        return Status::Invalid("CSV file contained multiple columns named ", view);
+        column_names.emplace_back(view);
+        return Status::OK();
       }));
 
   return column_names;
+}
+
+Result<std::unordered_set<std::string>> GetColumnNames(
+    const csv::ReadOptions& read_options, const csv::ParseOptions& parse_options,
+    std::string_view first_block, MemoryPool* pool) {
+  ARROW_ASSIGN_OR_RAISE(
+      std::vector<std::string> ordered_names,
+      GetOrderedColumnNames(read_options, parse_options, first_block, pool));
+  std::unordered_set<std::string> unordered_names;
+  for (const auto& column : ordered_names) {
+    if (!unordered_names.emplace(column).second) {
+      return Status::Invalid("CSV file contained multiple columns named ", column);
+    }
+  }
+  return unordered_names;
 }
 
 static inline Result<csv::ConvertOptions> GetConvertOptions(
@@ -251,6 +349,8 @@ static RecordBatchGenerator GeneratorFromReader(
   return MakeFromFuture(std::move(gen_fut));
 }
 
+CsvFileFormat::CsvFileFormat() : FileFormat(std::make_shared<CsvFragmentScanOptions>()) {}
+
 bool CsvFileFormat::Equals(const FileFormat& format) const {
   if (type_name() != format.type_name()) return false;
 
@@ -310,6 +410,52 @@ Future<std::optional<int64_t>> CsvFileFormat::CountRows(
                              ::arrow::internal::GetCpuThreadPool(), read_options,
                              self->parse_options)
       .Then([](int64_t count) { return std::make_optional<int64_t>(count); });
+}
+
+Future<std::shared_ptr<FragmentScanner>> CsvFileFormat::BeginScan(
+    const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
+    const FragmentScanOptions* format_options, compute::ExecContext* exec_context) const {
+  auto csv_options = static_cast<const CsvFragmentScanOptions*>(format_options);
+  auto csv_fragment = static_cast<const CsvInspectedFragment&>(inspected_fragment);
+  return CsvFileScanner::Make(*csv_options, request, csv_fragment,
+                              exec_context->executor());
+}
+
+Result<std::shared_ptr<InspectedFragment>> DoInspectFragment(
+    const FileSource& source, const CsvFragmentScanOptions& csv_options,
+    compute::ExecContext* exec_context) {
+  ARROW_ASSIGN_OR_RAISE(auto input, source.OpenCompressed());
+  if (csv_options.stream_transform_func) {
+    ARROW_ASSIGN_OR_RAISE(input, csv_options.stream_transform_func(input));
+  }
+  ARROW_ASSIGN_OR_RAISE(
+      input, io::BufferedInputStream::Create(csv_options.read_options.block_size,
+                                             default_memory_pool(), std::move(input)));
+
+  ARROW_ASSIGN_OR_RAISE(std::string_view first_block,
+                        input->Peek(csv_options.read_options.block_size));
+
+  ARROW_ASSIGN_OR_RAISE(
+      std::vector<std::string> column_names,
+      GetOrderedColumnNames(csv_options.read_options, csv_options.parse_options,
+                            first_block, exec_context->memory_pool()));
+  return std::make_shared<CsvInspectedFragment>(std::move(column_names), std::move(input),
+                                                source.Size());
+}
+
+Future<std::shared_ptr<InspectedFragment>> CsvFileFormat::InspectFragment(
+    const FileSource& source, const FragmentScanOptions* format_options,
+    compute::ExecContext* exec_context) const {
+  auto csv_options = static_cast<const CsvFragmentScanOptions*>(format_options);
+  Executor* io_executor;
+  if (source.filesystem()) {
+    io_executor = source.filesystem()->io_context().executor();
+  } else {
+    io_executor = exec_context->executor();
+  }
+  return DeferNotOk(io_executor->Submit([source, csv_options, exec_context]() {
+    return DoInspectFragment(source, *csv_options, exec_context);
+  }));
 }
 
 //

--- a/cpp/src/arrow/dataset/file_csv.h
+++ b/cpp/src/arrow/dataset/file_csv.h
@@ -41,8 +41,11 @@ constexpr char kCsvTypeName[] = "csv";
 /// \brief A FileFormat implementation that reads from and writes to Csv files
 class ARROW_DS_EXPORT CsvFileFormat : public FileFormat {
  public:
+  // TODO(ARROW-18328) Remove this, moved to CsvFragmentScanOptions
   /// Options affecting the parsing of CSV files
   csv::ParseOptions parse_options = csv::ParseOptions::Defaults();
+
+  CsvFileFormat();
 
   std::string type_name() const override { return kCsvTypeName; }
 
@@ -53,9 +56,18 @@ class ARROW_DS_EXPORT CsvFileFormat : public FileFormat {
   /// \brief Return the schema of the file if possible.
   Result<std::shared_ptr<Schema>> Inspect(const FileSource& source) const override;
 
+  Future<std::shared_ptr<FragmentScanner>> BeginScan(
+      const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
+      const FragmentScanOptions* format_options,
+      compute::ExecContext* exec_context) const override;
+
   Result<RecordBatchGenerator> ScanBatchesAsync(
       const std::shared_ptr<ScanOptions>& scan_options,
       const std::shared_ptr<FileFragment>& file) const override;
+
+  Future<std::shared_ptr<InspectedFragment>> InspectFragment(
+      const FileSource& source, const FragmentScanOptions* format_options,
+      compute::ExecContext* exec_context) const override;
 
   Future<std::optional<int64_t>> CountRows(
       const std::shared_ptr<FileFragment>& file, compute::Expression predicate,
@@ -83,6 +95,9 @@ struct ARROW_DS_EXPORT CsvFragmentScanOptions : public FragmentScanOptions {
   ///
   /// Note that use_threads is always ignored.
   csv::ReadOptions read_options = csv::ReadOptions::Defaults();
+
+  /// CSV parse options
+  csv::ParseOptions parse_options = csv::ParseOptions::Defaults();
 
   /// Optional stream wrapping function
   ///

--- a/cpp/src/arrow/dataset/file_ipc.cc
+++ b/cpp/src/arrow/dataset/file_ipc.cc
@@ -124,6 +124,8 @@ static inline Result<ipc::IpcReadOptions> GetReadOptions(
   return options;
 }
 
+IpcFileFormat::IpcFileFormat() : FileFormat(std::make_shared<IpcFragmentScanOptions>()) {}
+
 Result<bool> IpcFileFormat::IsSupported(const FileSource& source) const {
   RETURN_NOT_OK(source.Open().status());
   return OpenReader(source).ok();

--- a/cpp/src/arrow/dataset/file_ipc.h
+++ b/cpp/src/arrow/dataset/file_ipc.h
@@ -43,6 +43,8 @@ class ARROW_DS_EXPORT IpcFileFormat : public FileFormat {
  public:
   std::string type_name() const override { return kIpcTypeName; }
 
+  IpcFileFormat();
+
   bool Equals(const FileFormat& other) const override {
     return type_name() == other.type_name();
   }

--- a/cpp/src/arrow/dataset/file_orc.cc
+++ b/cpp/src/arrow/dataset/file_orc.cc
@@ -142,6 +142,8 @@ class OrcScanTaskIterator {
 
 }  // namespace
 
+OrcFileFormat::OrcFileFormat() : FileFormat(/*default_fragment_scan_options=*/nullptr) {}
+
 Result<bool> OrcFileFormat::IsSupported(const FileSource& source) const {
   RETURN_NOT_OK(source.Open().status());
   return OpenORCReader(source).ok();

--- a/cpp/src/arrow/dataset/file_orc.h
+++ b/cpp/src/arrow/dataset/file_orc.h
@@ -40,6 +40,8 @@ constexpr char kOrcTypeName[] = "orc";
 /// \brief A FileFormat implementation that reads from and writes to ORC files
 class ARROW_DS_EXPORT OrcFileFormat : public FileFormat {
  public:
+  OrcFileFormat();
+
   std::string type_name() const override { return kOrcTypeName; }
 
   bool Equals(const FileFormat& other) const override {

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -306,6 +306,9 @@ Result<bool> IsSupportedParquetFile(const ParquetFileFormat& format,
 
 }  // namespace
 
+ParquetFileFormat::ParquetFileFormat()
+    : FileFormat(std::make_shared<ParquetFragmentScanOptions>()) {}
+
 bool ParquetFileFormat::Equals(const FileFormat& other) const {
   if (other.type_name() != type_name()) return false;
 
@@ -318,10 +321,11 @@ bool ParquetFileFormat::Equals(const FileFormat& other) const {
               other_reader_options.coerce_int96_timestamp_unit);
 }
 
-ParquetFileFormat::ParquetFileFormat(const parquet::ReaderProperties& reader_properties) {
-  auto parquet_scan_options = std::make_shared<ParquetFragmentScanOptions>();
-  *parquet_scan_options->reader_properties = reader_properties;
-  default_fragment_scan_options = std::move(parquet_scan_options);
+ParquetFileFormat::ParquetFileFormat(const parquet::ReaderProperties& reader_properties)
+    : FileFormat(std::make_shared<ParquetFragmentScanOptions>()) {
+  auto* default_scan_opts =
+      static_cast<ParquetFragmentScanOptions*>(default_fragment_scan_options.get());
+  *default_scan_opts->reader_properties = reader_properties;
 }
 
 Result<bool> ParquetFileFormat::IsSupported(const FileSource& source) const {

--- a/cpp/src/arrow/dataset/file_parquet.h
+++ b/cpp/src/arrow/dataset/file_parquet.h
@@ -66,7 +66,7 @@ constexpr char kParquetTypeName[] = "parquet";
 /// \brief A FileFormat implementation that reads from Parquet files
 class ARROW_DS_EXPORT ParquetFileFormat : public FileFormat {
  public:
-  ParquetFileFormat() = default;
+  ParquetFileFormat();
 
   /// Convenience constructor which copies properties from a parquet::ReaderProperties.
   /// memory_pool will be ignored.

--- a/cpp/src/arrow/dataset/file_test.cc
+++ b/cpp/src/arrow/dataset/file_test.cc
@@ -94,6 +94,8 @@ constexpr int kNumBatches = 4;
 constexpr int kRowsPerBatch = 1024;
 class MockFileFormat : public FileFormat {
  public:
+  MockFileFormat() : FileFormat(/*default_fragment_scan_options=*/nullptr) {}
+
   Result<RecordBatchGenerator> ScanBatchesAsync(
       const std::shared_ptr<ScanOptions>& options,
       const std::shared_ptr<FileFragment>& file) const override {

--- a/cpp/src/arrow/dataset/scan_node.cc
+++ b/cpp/src/arrow/dataset/scan_node.cc
@@ -52,29 +52,27 @@ Result<std::shared_ptr<Schema>> OutputSchemaFromOptions(const ScanV2Options& opt
 // In the future we should support async scanning of fragments.  The
 // Dataset class doesn't support this yet but we pretend it does here to
 // ease future adoption of the feature.
-AsyncGenerator<std::shared_ptr<Fragment>> GetFragments(Dataset* dataset,
-                                                       cp::Expression predicate) {
+Future<AsyncGenerator<std::shared_ptr<Fragment>>> GetFragments(Dataset* dataset,
+                                                               cp::Expression predicate) {
   // In the future the dataset should be responsible for figuring out
   // the I/O context.  This will allow different I/O contexts to be used
   // when scanning different datasets.  For example, if we are scanning a
   // union of a remote dataset and a local dataset.
   const auto& io_context = io::default_io_context();
   auto io_executor = io_context.executor();
-  Future<std::shared_ptr<FragmentIterator>> fragments_it_fut =
-      DeferNotOk(io_executor->Submit(
-          [dataset, predicate]() -> Result<std::shared_ptr<FragmentIterator>> {
-            ARROW_ASSIGN_OR_RAISE(FragmentIterator fragments_iter,
-                                  dataset->GetFragments(predicate));
-            return std::make_shared<FragmentIterator>(std::move(fragments_iter));
-          }));
-  Future<AsyncGenerator<std::shared_ptr<Fragment>>> fragments_gen_fut =
-      fragments_it_fut.Then([](const std::shared_ptr<FragmentIterator>& fragments_it)
-                                -> Result<AsyncGenerator<std::shared_ptr<Fragment>>> {
+  return DeferNotOk(
+             io_executor->Submit(
+                 [dataset, predicate]() -> Result<std::shared_ptr<FragmentIterator>> {
+                   ARROW_ASSIGN_OR_RAISE(FragmentIterator fragments_iter,
+                                         dataset->GetFragments(predicate));
+                   return std::make_shared<FragmentIterator>(std::move(fragments_iter));
+                 }))
+      .Then([](const std::shared_ptr<FragmentIterator>& fragments_it)
+                -> Result<AsyncGenerator<std::shared_ptr<Fragment>>> {
         ARROW_ASSIGN_OR_RAISE(std::vector<std::shared_ptr<Fragment>> fragments,
                               fragments_it->ToVector());
         return MakeVectorGenerator(std::move(fragments));
       });
-  return MakeFromFuture(std::move(fragments_gen_fut));
 }
 
 /// \brief A node that scans a dataset
@@ -83,14 +81,14 @@ AsyncGenerator<std::shared_ptr<Fragment>> GetFragments(Dataset* dataset,
 ///
 /// The first io-task (listing) fetches the fragments from the dataset.  This may be a
 /// simple iteration of paths or, if the dataset is described with wildcards, this may
-/// involve I/O for listing and walking directory paths.  There is one listing io-task per
-/// dataset.
+/// involve I/O for listing and walking directory paths.  There is one listing io-task
+/// per dataset.
 ///
-/// Ths next step is to fetch the metadata for the fragment.  For some formats (e.g. CSV)
-/// this may be quite simple (get the size of the file).  For other formats (e.g. parquet)
-/// this is more involved and requires reading data.  There is one metadata io-task per
-/// fragment.  The metadata io-task creates an AsyncGenerator<RecordBatch> from the
-/// fragment.
+/// Ths next step is to fetch the metadata for the fragment.  For some formats (e.g.
+/// CSV) this may be quite simple (get the size of the file).  For other formats (e.g.
+/// parquet) this is more involved and requires reading data.  There is one metadata
+/// io-task per fragment.  The metadata io-task creates an AsyncGenerator<RecordBatch>
+/// from the fragment.
 ///
 /// Once the metadata io-task is done we can issue read io-tasks.  Each read io-task
 /// requests a single batch of data from the disk by pulling the next Future from the
@@ -100,9 +98,9 @@ AsyncGenerator<std::shared_ptr<Fragment>> GetFragments(Dataset* dataset,
 /// through the pipeline.
 ///
 /// Most of these tasks are io-tasks.  They take very few CPU resources and they run on
-/// the I/O thread pool.  These io-tasks are invisible to the exec plan and so we need to
-/// do some custom scheduling.  We limit how many fragments we read from at any one time.
-/// This is referred to as "fragment readahead".
+/// the I/O thread pool.  These io-tasks are invisible to the exec plan and so we need
+/// to do some custom scheduling.  We limit how many fragments we read from at any one
+/// time. This is referred to as "fragment readahead".
 ///
 /// Within a fragment there is usually also some amount of "row readahead".  This row
 /// readahead is handled by the fragment (and not the scanner) because the exact details
@@ -146,11 +144,17 @@ class ScanNode : public cp::ExecNode {
       // function registry as the one in ctx so we just require it to be unbound
       // FIXME - Do we care if it was bound to a different function registry?
       return Status::Invalid("Scan filter must be unbound");
-    } else if (!normalized.filter.IsBound()) {
+    } else {
       ARROW_ASSIGN_OR_RAISE(normalized.filter,
                             normalized.filter.Bind(*options.dataset->schema(), ctx));
+      ARROW_ASSIGN_OR_RAISE(normalized.filter,
+                            compute::RemoveNamedRefs(std::move(normalized.filter)));
     }  // Else we must have some simple filter like literal(true) which might be bound
        // but we don't care
+
+    if (normalized.filter.type()->id() != Type::BOOL) {
+      return Status::Invalid("A scan filter must be a boolean expression");
+    }
 
     return std::move(normalized);
   }
@@ -190,9 +194,10 @@ class ScanNode : public cp::ExecNode {
         : node_(node), scan_(scan_state), batch_index_(batch_index) {
       int64_t cost = scan_state->fragment_scanner->EstimatedDataBytes(batch_index_);
       // It's possible, though probably a bad idea, for a single batch of a fragment
-      // to be larger than 2GiB.  In that case, it doesn't matter much if we underestimate
-      // because the largest the throttle can be is 2GiB and thus we will be in "one batch
-      // at a time" mode anyways which is the best we can do in this case.
+      // to be larger than 2GiB.  In that case, it doesn't matter much if we
+      // underestimate because the largest the throttle can be is 2GiB and thus we will
+      // be in "one batch at a time" mode anyways which is the best we can do in this
+      // case.
       cost_ = static_cast<int>(
           std::min(cost, static_cast<int64_t>(std::numeric_limits<int>::max())));
     }
@@ -231,8 +236,9 @@ class ScanNode : public cp::ExecNode {
         : node(node), fragment(std::move(fragment)) {}
 
     Result<Future<>> operator()() override {
-      return fragment->InspectFragment().Then(
-          [this](const std::shared_ptr<InspectedFragment>& inspected_fragment) {
+      return fragment
+          ->InspectFragment(node->options_.format_options, node->plan_->exec_context())
+          .Then([this](const std::shared_ptr<InspectedFragment>& inspected_fragment) {
             return BeginScan(inspected_fragment);
           });
     }
@@ -244,7 +250,9 @@ class ScanNode : public cp::ExecNode {
           node->options_.dataset->evolution_strategy()->GetStrategy(
               *node->options_.dataset, *fragment, *inspected_fragment);
       ARROW_RETURN_NOT_OK(InitFragmentScanRequest());
-      return fragment->BeginScan(scan_state->scan_request, *inspected_fragment)
+      return fragment
+          ->BeginScan(scan_state->scan_request, *inspected_fragment,
+                      node->options_.format_options, node->plan_->exec_context())
           .Then([this](const std::shared_ptr<FragmentScanner>& fragment_scanner) {
             return AddScanTasks(fragment_scanner);
           });
@@ -301,21 +309,11 @@ class ScanNode : public cp::ExecNode {
     std::unique_ptr<ScanState> scan_state = std::make_unique<ScanState>();
   };
 
-  Status StartProducing() override {
-    START_COMPUTE_SPAN(span_, std::string(kind_name()) + ":" + label(),
-                       {{"node.kind", kind_name()},
-                        {"node.label", label()},
-                        {"node.output_schema", output_schema()->ToString()},
-                        {"node.detail", ToString()}});
-    END_SPAN_ON_FUTURE_COMPLETION(span_, finished_);
-    batches_throttle_ = util::ThrottledAsyncTaskScheduler::Make(
-        plan_->async_scheduler(), options_.target_bytes_readahead + 1);
-    AsyncGenerator<std::shared_ptr<Fragment>> frag_gen =
-        GetFragments(options_.dataset.get(), options_.filter);
+  void ScanFragments(const AsyncGenerator<std::shared_ptr<Fragment>>& frag_gen) {
     std::shared_ptr<util::AsyncTaskScheduler> fragment_tasks =
         util::MakeThrottledAsyncTaskGroup(
-            plan_->async_scheduler(), options_.fragment_readahead + 1, /*queue=*/nullptr,
-            [this]() {
+            plan_->async_scheduler(), options_.fragment_readahead + 1,
+            /*queue=*/nullptr, [this]() {
               outputs_[0]->InputFinished(this, num_batches_.load());
               finished_.MarkFinished();
               return Status::OK();
@@ -326,6 +324,23 @@ class ScanNode : public cp::ExecNode {
           fragment_tasks->AddTask(std::make_unique<ListFragmentTask>(this, fragment));
           return Status::OK();
         });
+  }
+
+  Status StartProducing() override {
+    START_COMPUTE_SPAN(span_, std::string(kind_name()) + ":" + label(),
+                       {{"node.kind", kind_name()},
+                        {"node.label", label()},
+                        {"node.output_schema", output_schema()->ToString()},
+                        {"node.detail", ToString()}});
+    END_SPAN_ON_FUTURE_COMPLETION(span_, finished_);
+    batches_throttle_ = util::ThrottledAsyncTaskScheduler::Make(
+        plan_->async_scheduler(), options_.target_bytes_readahead + 1);
+    plan_->async_scheduler()->AddSimpleTask([this] {
+      return GetFragments(options_.dataset.get(), options_.filter)
+          .Then([this](const AsyncGenerator<std::shared_ptr<Fragment>>& frag_gen) {
+            ScanFragments(frag_gen);
+          });
+    });
     return Status::OK();
   }
 

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -250,7 +250,7 @@ struct ARROW_DS_EXPORT ScanV2Options : public compute::ExecNodeOptions {
   /// one fragment at a time.
   int32_t fragment_readahead = kDefaultFragmentReadahead;
   /// \brief Options specific to the file format
-  const FragmentScanOptions* format_options = nullptr;
+  const FragmentScanOptions* format_options = NULLPTR;
 
   /// \brief Utility method to get a selection representing all columns in a dataset
   static std::vector<FieldPath> AllColumns(const Schema& dataset_schema);

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -178,6 +178,13 @@ struct ARROW_DS_EXPORT ScanV2Options : public compute::ExecNodeOptions {
   ///
   /// A single guarantee-aware filtering operation should generally be applied to all
   /// resulting batches.  The scan node is not responsible for this.
+  ///
+  /// Fields that are referenced by the filter should be included in the `columns` vector.
+  /// The scan node will not automatically fetch fields referenced by the filter
+  /// expression. \see AddFieldsNeededForFilter
+  ///
+  /// If the filter references fields that are not included in `columns` this may or may
+  /// not be an error, depending on the format.
   compute::Expression filter = compute::literal(true);
 
   /// \brief The columns to scan
@@ -243,10 +250,17 @@ struct ARROW_DS_EXPORT ScanV2Options : public compute::ExecNodeOptions {
   /// one fragment at a time.
   int32_t fragment_readahead = kDefaultFragmentReadahead;
   /// \brief Options specific to the file format
-  FragmentScanOptions* format_options;
+  const FragmentScanOptions* format_options = nullptr;
 
   /// \brief Utility method to get a selection representing all columns in a dataset
-  static std::vector<FieldPath> AllColumns(const Dataset& dataset);
+  static std::vector<FieldPath> AllColumns(const Schema& dataset_schema);
+
+  /// \brief Utility method to add fields needed for the current filter
+  ///
+  /// This method adds any fields that are needed by `filter` which are not already
+  /// included in the list of columns.  Any new fields added will be added to the end
+  /// in no particular order.
+  static Status AddFieldsNeededForFilter(ScanV2Options* options);
 };
 
 /// \brief Describes a projection

--- a/cpp/src/arrow/dataset/scanner_benchmark.cc
+++ b/cpp/src/arrow/dataset/scanner_benchmark.cc
@@ -249,7 +249,7 @@ const std::function<Result<std::shared_ptr<compute::ExecNodeOptions>>(size_t, si
   // specify the filter
   compute::Expression b_is_true = equal(field_ref("b"), literal(true));
   options->filter = b_is_true;
-  options->columns = ScanV2Options::AllColumns(*dataset);
+  options->columns = ScanV2Options::AllColumns(*dataset->schema());
 
   return options;
 };
@@ -314,8 +314,8 @@ static void ScanBenchmark_Customize(benchmark::internal::Benchmark* b) {
   b->UseRealTime();
 }
 
-BENCHMARK(MinimalEndToEndBench)->Apply(ScanBenchmark_Customize)->Iterations(10);
-BENCHMARK(ScanOnlyBench)->Apply(ScanBenchmark_Customize)->Iterations(10);
+BENCHMARK(MinimalEndToEndBench)->Apply(ScanBenchmark_Customize);
+BENCHMARK(ScanOnlyBench)->Apply(ScanBenchmark_Customize);
 
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -243,14 +243,17 @@ struct MockFragment : public Fragment {
     return Status::Invalid("Not implemented because not needed by unit tests");
   };
 
-  Future<std::shared_ptr<InspectedFragment>> InspectFragment() override {
+  Future<std::shared_ptr<InspectedFragment>> InspectFragment(
+      const FragmentScanOptions* format_options,
+      compute::ExecContext* exec_context) override {
     has_inspected_ = true;
     return inspected_future_;
   }
 
   Future<std::shared_ptr<FragmentScanner>> BeginScan(
-      const FragmentScanRequest& request,
-      const InspectedFragment& inspected_fragment) override {
+      const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
+      const FragmentScanOptions* format_options,
+      compute::ExecContext* exec_context) override {
     has_started_ = true;
     seen_request_ = request;
     return fragment_scanner_future_;
@@ -525,7 +528,7 @@ class TestScannerBase : public ::testing::TestWithParam<ScannerTestParams> {
 
   compute::Declaration MakeScanNode(std::shared_ptr<Dataset> dataset) {
     ScanV2Options options(dataset);
-    options.columns = ScanV2Options::AllColumns(*dataset);
+    options.columns = ScanV2Options::AllColumns(*dataset->schema());
     return compute::Declaration("scan2", options);
   }
 
@@ -641,7 +644,7 @@ TEST(TestNewScanner, Backpressure) {
 
   // No readahead
   options.dataset = test_dataset;
-  options.columns = ScanV2Options::AllColumns(*test_dataset);
+  options.columns = ScanV2Options::AllColumns(*test_dataset->schema());
   options.fragment_readahead = 0;
   options.target_bytes_readahead = 0;
   CheckScannerBackpressure(test_dataset, options, 1, 1,
@@ -650,7 +653,7 @@ TEST(TestNewScanner, Backpressure) {
   // Some readahead
   test_dataset = MakeTestDataset(kNumFragments, kNumBatchesPerFragment);
   options = ScanV2Options(test_dataset);
-  options.columns = ScanV2Options::AllColumns(*test_dataset);
+  options.columns = ScanV2Options::AllColumns(*test_dataset->schema());
   options.fragment_readahead = 4;
   // each batch should be 14Ki so 50Ki readahead should yield 3-at-a-time
   options.target_bytes_readahead = 50 * kRowsPerTestBatch;
@@ -696,10 +699,10 @@ std::shared_ptr<MockDataset> MakePartitionSkipDataset() {
   std::shared_ptr<Schema> test_schema = ScannerTestSchema();
   MockDatasetBuilder builder(test_schema);
   builder.AddFragment(test_schema, /*inspection=*/nullptr,
-                      greater(field_ref("filterable"), literal(50)));
+                      greater(field_ref({1}), literal(50)));
   builder.AddBatch(MakeTestBatch(0));
   builder.AddFragment(test_schema, /*inspection=*/nullptr,
-                      less_equal(field_ref("filterable"), literal(50)));
+                      less_equal(field_ref({1}), literal(50)));
   builder.AddBatch(MakeTestBatch(1));
   return builder.Finish();
 }
@@ -710,7 +713,7 @@ TEST(TestNewScanner, PartitionSkip) {
   test_dataset->DeliverBatchesInOrder(false);
 
   ScanV2Options options(test_dataset);
-  options.columns = ScanV2Options::AllColumns(*test_dataset);
+  options.columns = ScanV2Options::AllColumns(*test_dataset->schema());
   options.filter = greater(field_ref("filterable"), literal(75));
 
   ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<RecordBatch>> batches,
@@ -721,7 +724,7 @@ TEST(TestNewScanner, PartitionSkip) {
   test_dataset = MakePartitionSkipDataset();
   test_dataset->DeliverBatchesInOrder(false);
   options = ScanV2Options(test_dataset);
-  options.columns = ScanV2Options::AllColumns(*test_dataset);
+  options.columns = ScanV2Options::AllColumns(*test_dataset->schema());
   options.filter = less(field_ref("filterable"), literal(25));
 
   ASSERT_OK_AND_ASSIGN(batches, compute::DeclarationToBatches({"scan2", options}));
@@ -736,7 +739,7 @@ TEST(TestNewScanner, NoFragments) {
   std::shared_ptr<MockDataset> test_dataset = builder.Finish();
 
   ScanV2Options options(test_dataset);
-  options.columns = ScanV2Options::AllColumns(*test_dataset);
+  options.columns = ScanV2Options::AllColumns(*test_dataset->schema());
   ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<RecordBatch>> batches,
                        compute::DeclarationToBatches({"scan2", options}));
   ASSERT_EQ(0, batches.size());
@@ -751,7 +754,7 @@ TEST(TestNewScanner, EmptyFragment) {
   test_dataset->DeliverBatchesInOrder(false);
 
   ScanV2Options options(test_dataset);
-  options.columns = ScanV2Options::AllColumns(*test_dataset);
+  options.columns = ScanV2Options::AllColumns(*test_dataset->schema());
   ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<RecordBatch>> batches,
                        compute::DeclarationToBatches({"scan2", options}));
   ASSERT_EQ(0, batches.size());
@@ -769,7 +772,7 @@ TEST(TestNewScanner, EmptyBatch) {
   test_dataset->DeliverBatchesInOrder(false);
 
   ScanV2Options options(test_dataset);
-  options.columns = ScanV2Options::AllColumns(*test_dataset);
+  options.columns = ScanV2Options::AllColumns(*test_dataset->schema());
   ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<RecordBatch>> batches,
                        compute::DeclarationToBatches({"scan2", options}));
   ASSERT_EQ(0, batches.size());

--- a/cpp/src/arrow/util/thread_pool_test.cc
+++ b/cpp/src/arrow/util/thread_pool_test.cc
@@ -415,7 +415,7 @@ TEST(SerialExecutor, IterateSynchronously) {
 }
 
 struct MockGeneratorFactory {
-  MockGeneratorFactory(Executor** captured_executor)
+  explicit MockGeneratorFactory(Executor** captured_executor)
       : captured_executor(captured_executor) {}
 
   Result<AsyncGenerator<TestInt>> operator()(Executor* executor) {

--- a/cpp/src/arrow/util/thread_pool_test.cc
+++ b/cpp/src/arrow/util/thread_pool_test.cc
@@ -398,6 +398,54 @@ TEST(SerialExecutor, FailingIteratorWithCleanup) {
   ASSERT_TRUE(follow_up_ran);
 }
 
+TEST(SerialExecutor, IterateSynchronously) {
+  for (bool use_threads : {false, true}) {
+    FnOnce<Result<AsyncGenerator<TestInt>>(Executor*)> factory = [](Executor* executor) {
+      AsyncGenerator<TestInt> vector_gen = MakeVectorGenerator<TestInt>({1, 2, 3});
+      return MakeTransferredGenerator(vector_gen, executor);
+    };
+
+    Iterator<TestInt> my_it =
+        IterateSynchronously<TestInt>(std::move(factory), use_threads);
+    ASSERT_EQ(TestInt(1), *my_it.Next());
+    ASSERT_EQ(TestInt(2), *my_it.Next());
+    ASSERT_EQ(TestInt(3), *my_it.Next());
+    AssertIteratorExhausted(my_it);
+  }
+}
+
+struct MockGeneratorFactory {
+  MockGeneratorFactory(Executor** captured_executor)
+      : captured_executor(captured_executor) {}
+
+  Result<AsyncGenerator<TestInt>> operator()(Executor* executor) {
+    *captured_executor = executor;
+    return MakeEmptyGenerator<TestInt>();
+  }
+  Executor** captured_executor;
+};
+
+TEST(SerialExecutor, IterateSynchronouslyFactoryFails) {
+  for (bool use_threads : {false, true}) {
+    FnOnce<Result<AsyncGenerator<TestInt>>(Executor*)> factory = [](Executor* executor) {
+      return Status::Invalid("XYZ");
+    };
+
+    Iterator<TestInt> my_it =
+        IterateSynchronously<TestInt>(std::move(factory), use_threads);
+    ASSERT_RAISES(Invalid, my_it.Next());
+  }
+}
+
+TEST(SerialExecutor, IterateSynchronouslyUsesThreadsIfRequested) {
+  Executor* captured_executor;
+  MockGeneratorFactory gen_factory(&captured_executor);
+  IterateSynchronously<TestInt>(gen_factory, true);
+  ASSERT_EQ(internal::GetCpuThreadPool(), captured_executor);
+  IterateSynchronously<TestInt>(gen_factory, false);
+  ASSERT_NE(internal::GetCpuThreadPool(), captured_executor);
+}
+
 class TransferTest : public testing::Test {
  public:
   internal::Executor* executor() { return mock_executor.get(); }


### PR DESCRIPTION
This also adds a utility method arrow::compute::DeclarationToReader.

This does not fully satisfy ARROW-17288 as it only adapts the CSV file format.  However, this was the most complicated case, and I had to convert some of the common test utilities as well.  So I am hopeful the other formats will be more straightforward.