### PR TITLE
MINOR: [Release] Add RC number and version to verify release candidate success message

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -1198,5 +1198,5 @@ test_binary_distribution
 
 TEST_SUCCESS=yes
 
-echo "Release candidate number: ${RC_NUMBER} for version: ${VERSION} looks good!"
+echo "Release candidate ${VERSION}-RC${RC_NUMBER} looks good!"
 exit 0

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -1198,5 +1198,5 @@ test_binary_distribution
 
 TEST_SUCCESS=yes
 
-echo 'Release candidate looks good!'
+echo "Release candidate number: ${RC_NUMBER} for version: ${VERSION} looks good!"
 exit 0


### PR DESCRIPTION
I've tested locally when verifying 10.0.1 rc 0:
```
Release candidate number: 0 for version: 10.0.1 looks good!
```