### PR TITLE
ARROW-18350: [C++] Use std::to_chars instead of std::to_string

### DIFF
--- a/cpp/src/arrow/adapters/orc/util.cc
+++ b/cpp/src/arrow/adapters/orc/util.cc
@@ -31,6 +31,7 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/decimal.h"
 #include "arrow/util/range.h"
+#include "arrow/util/string.h"
 #include "arrow/visit_data_inline.h"
 
 #include "orc/Exceptions.hh"
@@ -43,6 +44,7 @@ namespace liborc = orc;
 namespace arrow {
 
 using internal::checked_cast;
+using internal::ToChars;
 
 namespace adapters {
 namespace orc {
@@ -1020,7 +1022,7 @@ Result<std::shared_ptr<DataType>> GetArrowType(const liborc::Type* type) {
       std::vector<int8_t> type_codes(subtype_count);
       for (int child = 0; child < subtype_count; ++child) {
         ARROW_ASSIGN_OR_RAISE(auto elem_type, GetArrowType(type->getSubtype(child)));
-        fields[child] = field("_union_" + std::to_string(child), std::move(elem_type));
+        fields[child] = field("_union_" + ToChars(child), std::move(elem_type));
         type_codes[child] = static_cast<int8_t>(child);
       }
       return sparse_union(std::move(fields), std::move(type_codes));

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -41,6 +41,7 @@
 #include "arrow/util/logging.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/small_vector.h"
+#include "arrow/util/string.h"
 #include "arrow/util/value_parsing.h"
 #include "arrow/visit_type_inline.h"
 
@@ -56,6 +57,8 @@ using internal::ArrayExportGuard;
 using internal::ArrayExportTraits;
 using internal::SchemaExportGuard;
 using internal::SchemaExportTraits;
+
+using internal::ToChars;
 
 namespace {
 
@@ -334,18 +337,16 @@ struct SchemaExporter {
   Status Visit(const DoubleType& type) { return SetFormat("g"); }
 
   Status Visit(const FixedSizeBinaryType& type) {
-    return SetFormat("w:" + std::to_string(type.byte_width()));
+    return SetFormat("w:" + ToChars(type.byte_width()));
   }
 
   Status Visit(const DecimalType& type) {
     if (type.bit_width() == 128) {
       // 128 is the default bit-width
-      return SetFormat("d:" + std::to_string(type.precision()) + "," +
-                       std::to_string(type.scale()));
+      return SetFormat("d:" + ToChars(type.precision()) + "," + ToChars(type.scale()));
     } else {
-      return SetFormat("d:" + std::to_string(type.precision()) + "," +
-                       std::to_string(type.scale()) + "," +
-                       std::to_string(type.bit_width()));
+      return SetFormat("d:" + ToChars(type.precision()) + "," + ToChars(type.scale()) +
+                       "," + ToChars(type.bit_width()));
     }
   }
 
@@ -441,7 +442,7 @@ struct SchemaExporter {
   Status Visit(const LargeListType& type) { return SetFormat("+L"); }
 
   Status Visit(const FixedSizeListType& type) {
-    return SetFormat("+w:" + std::to_string(type.list_size()));
+    return SetFormat("+w:" + ToChars(type.list_size()));
   }
 
   Status Visit(const StructType& type) { return SetFormat("+s"); }
@@ -468,7 +469,7 @@ struct SchemaExporter {
       if (!first) {
         s += ",";
       }
-      s += std::to_string(code);
+      s += ToChars(code);
       first = false;
     }
     return Status::OK();

--- a/cpp/src/arrow/compute/exec/aggregate.cc
+++ b/cpp/src/arrow/compute/exec/aggregate.cc
@@ -26,9 +26,13 @@
 #include "arrow/compute/row/grouper.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/string.h"
 #include "arrow/util/task_group.h"
 
 namespace arrow {
+
+using internal::ToChars;
+
 namespace compute {
 namespace internal {
 
@@ -150,7 +154,7 @@ Result<Datum> GroupBy(const std::vector<Datum>& arguments, const std::vector<Dat
 
   int i = 0;
   for (const TypeHolder& key_type : key_types) {
-    out_fields.push_back(field("key_" + std::to_string(i++), key_type.GetSharedPtr()));
+    out_fields.push_back(field("key_" + ToChars(i++), key_type.GetSharedPtr()));
   }
 
   ExecSpanIterator key_iterator;

--- a/cpp/src/arrow/compute/exec/asof_join_node.cc
+++ b/cpp/src/arrow/compute/exec/asof_join_node.cc
@@ -39,8 +39,12 @@
 #include "arrow/util/bit_util.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/future.h"
+#include "arrow/util/string.h"
 
 namespace arrow {
+
+using internal::ToChars;
+
 namespace compute {
 
 template <typename T, typename V = typename T::value_type>
@@ -1053,7 +1057,7 @@ class AsofJoinNode : public ExecNode {
     std::vector<std::vector<col_index_t>> indices_of_by_key(
         n_input, std::vector<col_index_t>(n_by));
     for (size_t i = 0; i < n_input; ++i) {
-      input_labels[i] = i == 0 ? "left" : "right_" + std::to_string(i);
+      input_labels[i] = i == 0 ? "left" : "right_" + ToChars(i);
       const Schema& input_schema = *inputs[i]->output_schema();
       ARROW_ASSIGN_OR_RAISE(indices_of_on_key[i],
                             FindColIndex(input_schema, join_options.on_key, "on"));

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -37,12 +37,14 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/key_value_metadata.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/string.h"
 #include "arrow/util/tracing_internal.h"
 #include "arrow/util/vector.h"
 
 namespace arrow {
 
 using internal::checked_cast;
+using internal::ToChars;
 
 namespace compute {
 
@@ -66,7 +68,7 @@ struct ExecPlanImpl : public ExecPlan {
 
   ExecNode* AddNode(std::unique_ptr<ExecNode> node) {
     if (node->label().empty()) {
-      node->SetLabel(std::to_string(auto_label_counter_++));
+      node->SetLabel(ToChars(auto_label_counter_++));
     }
     if (node->num_inputs() == 0) {
       sources_.push_back(node.get());

--- a/cpp/src/arrow/compute/exec/expression.cc
+++ b/cpp/src/arrow/compute/exec/expression.cc
@@ -42,6 +42,7 @@ namespace arrow {
 using internal::checked_cast;
 using internal::checked_pointer_cast;
 using internal::EndsWith;
+using internal::ToChars;
 
 namespace compute {
 
@@ -1202,12 +1203,12 @@ Result<std::shared_ptr<Buffer>> Serialize(const Expression& expr) {
       auto ret = columns_.size();
       ARROW_ASSIGN_OR_RAISE(auto array, MakeArrayFromScalar(scalar, 1));
       columns_.push_back(std::move(array));
-      return std::to_string(ret);
+      return ToChars(ret);
     }
 
     Status VisitFieldRef(const FieldRef& ref) {
       if (ref.nested_refs()) {
-        metadata_->Append("nested_field_ref", std::to_string(ref.nested_refs()->size()));
+        metadata_->Append("nested_field_ref", ToChars(ref.nested_refs()->size()));
         for (const auto& child : *ref.nested_refs()) {
           RETURN_NOT_OK(VisitFieldRef(child));
         }

--- a/cpp/src/arrow/compute/exec/union_node.cc
+++ b/cpp/src/arrow/compute/exec/union_node.cc
@@ -17,7 +17,6 @@
 
 #include <mutex>
 
-#include "arrow/api.h"
 #include "arrow/compute/api.h"
 #include "arrow/compute/exec/exec_plan.h"
 #include "arrow/compute/exec/options.h"
@@ -26,12 +25,14 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/future.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/string.h"
 #include "arrow/util/thread_pool.h"
 #include "arrow/util/tracing_internal.h"
 
 namespace arrow {
 
 using internal::checked_cast;
+using internal::ToChars;
 
 namespace compute {
 

--- a/cpp/src/arrow/compute/kernels/scalar_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_nested.cc
@@ -24,8 +24,12 @@
 #include "arrow/result.h"
 #include "arrow/util/bit_block_counter.h"
 #include "arrow/util/bitmap_generate.h"
+#include "arrow/util/string.h"
 
 namespace arrow {
+
+using internal::ToChars;
+
 namespace compute {
 namespace internal {
 namespace {
@@ -89,7 +93,7 @@ Status GetListElementIndex(const ExecValue& value, T* out) {
 
 template <typename T>
 std::string ToString(const std::optional<T>& o) {
-  return o.has_value() ? std::to_string(*o) : "(nullopt)";
+  return o.has_value() ? ToChars(*o) : "(nullopt)";
 }
 
 template <typename Type>
@@ -524,7 +528,7 @@ Result<TypeHolder> MakeStructResolve(KernelContext* ctx,
     metadata.resize(types.size(), nullptr);
     int i = 0;
     for (auto& name : names) {
-      name = std::to_string(i++);
+      name = ToChars(i++);
     }
   } else if (names.size() != types.size() || nullable.size() != types.size() ||
              metadata.size() != types.size()) {

--- a/cpp/src/arrow/dataset/dataset_writer.cc
+++ b/cpp/src/arrow/dataset/dataset_writer.cc
@@ -32,7 +32,10 @@
 #include "arrow/util/string.h"
 
 namespace arrow {
+
 using internal::Executor;
+using internal::ToChars;
+
 namespace dataset {
 namespace internal {
 
@@ -297,8 +300,8 @@ class DatasetWriterDirectoryQueue {
   }
 
   Result<std::string> GetNextFilename() {
-    auto basename = ::arrow::internal::Replace(
-        write_options_.basename_template, kIntegerToken, std::to_string(file_counter_++));
+    auto basename = ::arrow::internal::Replace(write_options_.basename_template,
+                                               kIntegerToken, ToChars(file_counter_++));
     if (!basename) {
       return Status::Invalid("string interpolation of basename template failed");
     }

--- a/cpp/src/arrow/engine/substrait/expression_internal.cc
+++ b/cpp/src/arrow/engine/substrait/expression_internal.cc
@@ -29,11 +29,13 @@
 #include "arrow/engine/substrait/type_internal.h"
 #include "arrow/result.h"
 #include "arrow/status.h"
+#include "arrow/util/string.h"
 #include "arrow/visit_scalar_inline.h"
 
 namespace arrow {
 
 using internal::checked_cast;
+using internal::ToChars;
 
 namespace engine {
 
@@ -250,7 +252,7 @@ Result<compute::Expression> FromProto(const substrait::Expression& expr,
                               FromProto(if_.then(), ext_set, conversion_options));
         conditions.emplace_back(std::move(compute_if));
         args.emplace_back(std::move(compute_then));
-        condition_names.emplace_back("cond" + std::to_string(++name_counter));
+        condition_names.emplace_back("cond" + ToChars(++name_counter));
       }
       ARROW_ASSIGN_OR_RAISE(auto compute_else,
                             FromProto(if_then.else_(), ext_set, conversion_options));

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -39,6 +39,7 @@ namespace arrow {
 
 using internal::checked_cast;
 using internal::StartsWith;
+using internal::ToChars;
 using internal::UriFromAbsolutePath;
 
 namespace engine {
@@ -389,8 +390,7 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel, const ExtensionSet&
                                 field_ref->FindOne(*input.output_schema));
           ARROW_ASSIGN_OR_RAISE(project_field, field_path.Get(*input.output_schema));
         } else if (auto* literal = des_expr.literal()) {
-          project_field =
-              field("field_" + std::to_string(num_columns + i), literal->type());
+          project_field = field("field_" + ToChars(num_columns + i), literal->type());
         }
         ARROW_ASSIGN_OR_RAISE(
             project_schema,

--- a/cpp/src/arrow/filesystem/gcsfs_internal.cc
+++ b/cpp/src/arrow/filesystem/gcsfs_internal.cc
@@ -28,8 +28,12 @@
 #include "arrow/filesystem/path_util.h"
 #include "arrow/util/io_util.h"
 #include "arrow/util/key_value_metadata.h"
+#include "arrow/util/string.h"
 
 namespace arrow {
+
+using internal::ToChars;
+
 namespace fs {
 namespace internal {
 
@@ -246,7 +250,7 @@ Result<std::shared_ptr<const KeyValueMetadata>> FromObjectMetadata(
   result->Append("selfLink", m.self_link());
   result->Append("name", m.name());
   result->Append("bucket", m.bucket());
-  result->Append("generation", std::to_string(m.generation()));
+  result->Append("generation", ToChars(m.generation()));
   result->Append("Content-Type", m.content_type());
   result->Append("timeCreated", format_time(m.time_created()));
   result->Append("updated", format_time(m.updated()));
@@ -266,7 +270,7 @@ Result<std::shared_ptr<const KeyValueMetadata>> FromObjectMetadata(
     result->Append("timeStorageClassUpdated",
                    format_time(m.time_storage_class_updated()));
   }
-  result->Append("size", std::to_string(m.size()));
+  result->Append("size", ToChars(m.size()));
   result->Append("md5Hash", m.md5_hash());
   result->Append("mediaLink", m.media_link());
   result->Append("Content-Encoding", m.content_encoding());
@@ -282,7 +286,7 @@ Result<std::shared_ptr<const KeyValueMetadata>> FromObjectMetadata(
     result->Append("owner.entityId", m.owner().entity_id);
   }
   result->Append("crc32c", m.crc32c());
-  result->Append("componentCount", std::to_string(m.component_count()));
+  result->Append("componentCount", ToChars(m.component_count()));
   result->Append("etag", m.etag());
   if (m.has_customer_encryption()) {
     result->Append("customerEncryption.encryptionAlgorithm",

--- a/cpp/src/arrow/filesystem/s3_internal.h
+++ b/cpp/src/arrow/filesystem/s3_internal.h
@@ -36,6 +36,7 @@
 #include "arrow/status.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/print.h"
+#include "arrow/util/string.h"
 
 namespace arrow {
 namespace fs {
@@ -156,7 +157,7 @@ inline std::string S3ErrorToString(Aws::S3::S3Errors error_type) {
 
 #undef S3_ERROR_CASE
     default:
-      return "[code " + std::to_string(static_cast<int>(error_type)) + "]";
+      return "[code " + ::arrow::internal::ToChars(static_cast<int>(error_type)) + "]";
   }
 }
 

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -97,6 +97,7 @@
 namespace arrow {
 
 using internal::TaskGroup;
+using internal::ToChars;
 using internal::Uri;
 using io::internal::SubmitIO;
 
@@ -968,7 +969,7 @@ std::shared_ptr<const KeyValueMetadata> GetObjectMetadata(const ObjectResult& re
     }
   };
 
-  md->Append("Content-Length", std::to_string(result.GetContentLength()));
+  md->Append("Content-Length", ToChars(result.GetContentLength()));
   push("Cache-Control", result.GetCacheControl());
   push("Content-Type", result.GetContentType());
   push("Content-Language", result.GetContentLanguage());

--- a/cpp/src/arrow/flight/cookie_internal.cc
+++ b/cpp/src/arrow/flight/cookie_internal.cc
@@ -43,6 +43,9 @@
 const char kCookieExpiresFormat[] = "%d %m %Y %H:%M:%S";
 
 namespace arrow {
+
+using internal::ToChars;
+
 namespace flight {
 namespace internal {
 
@@ -201,7 +204,7 @@ void Cookie::ConvertCookieDate(std::string* date) {
       if ((i + 1) < 10) {
         padded_month = "0";
       }
-      padded_month += std::to_string(i + 1);
+      padded_month += ToChars(i + 1);
 
       // Replace symbolic month with numeric month.
       date->replace(it, months[i].length(), padded_month);

--- a/cpp/src/arrow/flight/sql/column_metadata.cc
+++ b/cpp/src/arrow/flight/sql/column_metadata.cc
@@ -19,10 +19,16 @@
 
 #include <utility>
 
+#include "arrow/util/string.h"
+
 namespace arrow {
+
+using internal::ToChars;
+
 namespace flight {
 namespace sql {
 namespace {
+
 /// \brief Constant variable used to convert boolean true value
 ///        to a string.
 const char* BOOLEAN_TRUE_STR = "1";
@@ -143,13 +149,13 @@ ColumnMetadata::ColumnMetadataBuilder& ColumnMetadata::ColumnMetadataBuilder::Ty
 
 ColumnMetadata::ColumnMetadataBuilder& ColumnMetadata::ColumnMetadataBuilder::Precision(
     int32_t precision) {
-  metadata_map_->Append(ColumnMetadata::kPrecision, std::to_string(precision));
+  metadata_map_->Append(ColumnMetadata::kPrecision, ToChars(precision));
   return *this;
 }
 
 ColumnMetadata::ColumnMetadataBuilder& ColumnMetadata::ColumnMetadataBuilder::Scale(
     int32_t scale) {
-  metadata_map_->Append(ColumnMetadata::kScale, std::to_string(scale));
+  metadata_map_->Append(ColumnMetadata::kScale, ToChars(scale));
   return *this;
 }
 

--- a/cpp/src/arrow/flight/transport/grpc/util_internal.cc
+++ b/cpp/src/arrow/flight/transport/grpc/util_internal.cc
@@ -31,8 +31,12 @@
 #include "arrow/flight/transport.h"
 #include "arrow/flight/types.h"
 #include "arrow/status.h"
+#include "arrow/util/string.h"
 
 namespace arrow {
+
+using internal::ToChars;
+
 namespace flight {
 namespace transport {
 namespace grpc {
@@ -223,7 +227,7 @@ static ::grpc::Status ToRawGrpcStatus(const Status& arrow_status) {
 ::grpc::Status ToGrpcStatus(const Status& arrow_status, ::grpc::ServerContext* ctx) {
   ::grpc::Status status = ToRawGrpcStatus(arrow_status);
   if (!status.ok() && ctx) {
-    const std::string code = std::to_string(static_cast<int>(arrow_status.code()));
+    const std::string code = ToChars(static_cast<int>(arrow_status.code()));
     ctx->AddTrailingMetadata(kGrpcStatusCodeHeader, code);
     ctx->AddTrailingMetadata(kGrpcStatusMessageHeader, arrow_status.message());
     if (arrow_status.detail()) {

--- a/cpp/src/arrow/flight/transport/ucx/ucx_internal.cc
+++ b/cpp/src/arrow/flight/transport/ucx/ucx_internal.cc
@@ -29,9 +29,13 @@
 #include "arrow/util/base64.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/string.h"
 #include "arrow/util/uri.h"
 
 namespace arrow {
+
+using internal::ToChars;
+
 namespace flight {
 namespace transport {
 namespace ucx {
@@ -228,10 +232,10 @@ arrow::Result<HeadersFrame> HeadersFrame::Make(
 
   TransportStatus transport_status = TransportStatus::FromStatus(status);
   all_headers.emplace_back(kHeaderStatus,
-                           std::to_string(static_cast<int32_t>(transport_status.code)));
+                           ToChars(static_cast<int32_t>(transport_status.code)));
   all_headers.emplace_back(kHeaderMessage, std::move(transport_status.message));
   all_headers.emplace_back(kHeaderStatusCode,
-                           std::to_string(static_cast<int32_t>(status.code())));
+                           ToChars(static_cast<int32_t>(status.code())));
   all_headers.emplace_back(kHeaderStatusMessage, status.message());
   if (status.detail()) {
     all_headers.emplace_back(kHeaderStatusDetail, status.detail()->ToString());
@@ -257,7 +261,7 @@ Status HeadersFrame::GetStatus(Status* out) {
   if (!status.ok()) {
     return Status::KeyError("Server did not send status code header ", kHeaderStatusCode);
   }
-  if (code_str == "0") {  // == std::to_string(TransportStatusCode::kOk)
+  if (code_str == "0") {  // == ToChars(TransportStatusCode::kOk)
     *out = Status::OK();
     return Status::OK();
   }

--- a/cpp/src/arrow/flight/transport/ucx/ucx_server.cc
+++ b/cpp/src/arrow/flight/transport/ucx/ucx_server.cc
@@ -36,10 +36,14 @@
 #include "arrow/status.h"
 #include "arrow/util/io_util.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/string.h"
 #include "arrow/util/thread_pool.h"
 #include "arrow/util/uri.h"
 
 namespace arrow {
+
+using internal::ToChars;
+
 namespace flight {
 namespace transport {
 namespace ucx {
@@ -273,8 +277,8 @@ class UcxServerImpl : public arrow::flight::internal::ServerTransport {
         raw_uri += uri.host();
       }
       raw_uri += ":";
-      raw_uri += std::to_string(
-          ntohs(reinterpret_cast<const sockaddr_in*>(&attr.sockaddr)->sin_port));
+      raw_uri +=
+          ToChars(ntohs(reinterpret_cast<const sockaddr_in*>(&attr.sockaddr)->sin_port));
       std::string listen_str;
       ARROW_UNUSED(SockaddrToString(attr.sockaddr).Value(&listen_str));
       FLIGHT_LOG(DEBUG) << "Listening on " << listen_str;
@@ -434,7 +438,7 @@ class UcxServerImpl : public arrow::flight::internal::ServerTransport {
   }
 
   void WorkerLoop(ucp_conn_request_h request) {
-    std::string peer = "unknown:" + std::to_string(counter_++);
+    std::string peer = "unknown:" + ToChars(counter_++);
     {
       ucp_conn_request_attr_t request_attr;
       std::memset(&request_attr, 0, sizeof(request_attr));

--- a/cpp/src/arrow/flight/transport/ucx/util_internal.cc
+++ b/cpp/src/arrow/flight/transport/ucx/util_internal.cc
@@ -32,9 +32,13 @@
 #include "arrow/util/bit_util.h"
 #include "arrow/util/io_util.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/string.h"
 #include "arrow/util/uri.h"
 
 namespace arrow {
+
+using internal::ToChars;
+
 namespace flight {
 namespace transport {
 namespace ucx {
@@ -122,7 +126,7 @@ arrow::Result<std::string> SockaddrToString(const struct sockaddr_storage& addre
   DCHECK_NE(pos, std::string::npos);
   result[pos] = ':';
   result.resize(pos + 1);
-  result += std::to_string(port);
+  result += ToChars(port);
   return result;
 }
 

--- a/cpp/src/arrow/ipc/metadata_internal.cc
+++ b/cpp/src/arrow/ipc/metadata_internal.cc
@@ -38,6 +38,7 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/key_value_metadata.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/string.h"
 #include "arrow/util/ubsan.h"
 #include "arrow/visit_type_inline.h"
 
@@ -51,6 +52,7 @@ namespace arrow {
 
 namespace flatbuf = org::apache::arrow::flatbuf;
 using internal::checked_cast;
+using internal::ToChars;
 
 namespace ipc {
 namespace internal {
@@ -385,8 +387,7 @@ Status ConcreteTypeFromFlatbuffer(flatbuf::Type type, const void* type_data,
       return UnionFromFlatbuffer(static_cast<const flatbuf::Union*>(type_data), children,
                                  out);
     default:
-      return Status::Invalid("Unrecognized type:" +
-                             std::to_string(static_cast<int>(type)));
+      return Status::Invalid("Unrecognized type:" + ToChars(static_cast<int>(type)));
   }
 }
 

--- a/cpp/src/arrow/pretty_print.cc
+++ b/cpp/src/arrow/pretty_print.cc
@@ -49,6 +49,7 @@ namespace arrow {
 
 using internal::checked_cast;
 using internal::StringFormatter;
+using internal::ToChars;
 
 namespace {
 
@@ -566,7 +567,7 @@ class SchemaPrinter : public PrettyPrinter {
       }
 
       Write(metadata.key(i) + ": '" + metadata.value(i).substr(0, truncated_size) +
-            "' + " + std::to_string(size - truncated_size));
+            "' + " + ToChars(size - truncated_size));
     }
   }
 

--- a/cpp/src/arrow/testing/random.cc
+++ b/cpp/src/arrow/testing/random.cc
@@ -45,12 +45,14 @@
 #include "arrow/util/key_value_metadata.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/pcg_random.h"
+#include "arrow/util/string.h"
 #include "arrow/util/value_parsing.h"
 
 namespace arrow {
 
 using internal::checked_cast;
 using internal::checked_pointer_cast;
+using internal::ToChars;
 
 namespace random {
 
@@ -662,8 +664,7 @@ enable_if_parameter_free<ArrowType, T> GetMetadata(const KeyValueMetadata* metad
 std::shared_ptr<Array> RandomArrayGenerator::ArrayOf(std::shared_ptr<DataType> type,
                                                      int64_t size,
                                                      double null_probability) {
-  auto metadata =
-      key_value_metadata({"null_probability"}, {std::to_string(null_probability)});
+  auto metadata = key_value_metadata({"null_probability"}, {ToChars(null_probability)});
   auto field = ::arrow::field("", std::move(type), std::move(metadata));
   return ArrayOf(*field, size);
 }
@@ -880,8 +881,8 @@ std::shared_ptr<Array> RandomArrayGenerator::ArrayOf(const Field& field, int64_t
         ABORT_NOT_OK(Status::Invalid(field.ToString(), ": cannot specify min"));
       if (merged->Contains("max"))
         ABORT_NOT_OK(Status::Invalid(field.ToString(), ": cannot specify max"));
-      merged = merged->Merge(*key_value_metadata(
-          {{"min", "0"}, {"max", std::to_string(values_length - 1)}}));
+      merged = merged->Merge(
+          *key_value_metadata({{"min", "0"}, {"max", ToChars(values_length - 1)}}));
       auto indices = ArrayOf(
           *arrow::field("temporary", dict_type->index_type(), field.nullable(), merged),
           length);

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -43,6 +43,7 @@
 #include "arrow/util/key_value_metadata.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/range.h"
+#include "arrow/util/string.h"
 #include "arrow/util/vector.h"
 #include "arrow/visit_type_inline.h"
 
@@ -1004,7 +1005,7 @@ std::string FieldPath::ToString() const {
 
   std::string repr = "FieldPath(";
   for (auto index : this->indices()) {
-    repr += std::to_string(index) + " ";
+    repr += internal::ToChars(index) + " ";
   }
   repr.back() = ')';
   return repr;
@@ -1311,7 +1312,7 @@ std::string FieldRef::ToDotPath() const {
     std::string operator()(const FieldPath& path) {
       std::string out;
       for (int i : path.indices()) {
-        out += "[" + std::to_string(i) + "]";
+        out += "[" + internal::ToChars(i) + "]";
       }
       return out;
     }
@@ -2388,7 +2389,7 @@ FieldVector FieldsFromArraysAndNames(std::vector<std::string> names,
   int i = 0;
   if (names.empty()) {
     for (const auto& array : arrays) {
-      fields[i] = field(std::to_string(i), array->type());
+      fields[i] = field(internal::ToChars(i), array->type());
       ++i;
     }
   } else {

--- a/cpp/src/arrow/util/formatting.h
+++ b/cpp/src/arrow/util/formatting.h
@@ -34,6 +34,7 @@
 #include "arrow/type_traits.h"
 #include "arrow/util/double_conversion.h"
 #include "arrow/util/macros.h"
+#include "arrow/util/string.h"
 #include "arrow/util/time.h"
 #include "arrow/util/visibility.h"
 #include "arrow/vendored/datetime.h"
@@ -391,7 +392,7 @@ bool IsTimeInRange(Unit duration) {
 template <typename RawValue, typename Appender>
 Return<Appender> FormatOutOfRange(RawValue&& raw_value, Appender&& append) {
   // XXX locale-sensitive but good enough for now
-  std::string formatted = "<value out of range: " + std::to_string(raw_value) + ">";
+  std::string formatted = "<value out of range: " + ToChars(raw_value) + ">";
   return append(std::move(formatted));
 }
 

--- a/cpp/src/arrow/util/int_util.cc
+++ b/cpp/src/arrow/util/int_util.cc
@@ -31,6 +31,7 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/macros.h"
+#include "arrow/util/string.h"
 #include "arrow/util/ubsan.h"
 #include "arrow/visit_type_inline.h"
 
@@ -525,11 +526,6 @@ Status TransposeInts(const DataType& src_type, const DataType& dest_type,
   return transposer(src_type);
 }
 
-template <typename T>
-static std::string FormatInt(T val) {
-  return std::to_string(val);
-}
-
 template <typename IndexCType, bool IsSigned = std::is_signed<IndexCType>::value>
 static Status CheckIndexBoundsImpl(const ArraySpan& values, uint64_t upper_limit) {
   // For unsigned integers, if the values array is larger than the maximum
@@ -555,7 +551,7 @@ static Status CheckIndexBoundsImpl(const ArraySpan& values, uint64_t upper_limit
         if (ARROW_PREDICT_FALSE(block_out_of_bounds)) {
           for (int64_t i = 0; i < length; ++i) {
             if (IsOutOfBounds(values_data[offset + i])) {
-              return Status::IndexError("Index ", FormatInt(values_data[offset + i]),
+              return Status::IndexError("Index ", ToChars(values_data[offset + i]),
                                         " out of bounds");
             }
           }
@@ -609,9 +605,9 @@ Status IntegersInRange(const ArraySpan& values, CType bound_lower, CType bound_u
     return is_valid && (val < bound_lower || val > bound_upper);
   };
   auto GetErrorMessage = [&](CType val) {
-    return Status::Invalid("Integer value ", FormatInt(val),
-                           " not in range: ", FormatInt(bound_lower), " to ",
-                           FormatInt(bound_upper));
+    return Status::Invalid("Integer value ", ToChars(val),
+                           " not in range: ", ToChars(bound_lower), " to ",
+                           ToChars(bound_upper));
   };
 
   const CType* values_data = values.GetValues<CType>(1);

--- a/cpp/src/arrow/util/string.h
+++ b/cpp/src/arrow/util/string.h
@@ -148,7 +148,6 @@ std::string ToChars(T value, Args&&... args) {
     }
     const auto length = res.ptr - out.data();
     assert(length <= static_cast<int64_t>(out.length()));
-    out[length] = 0;
     out.resize(length);
     return out;
   }

--- a/cpp/src/arrow/util/string.h
+++ b/cpp/src/arrow/util/string.h
@@ -22,6 +22,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -100,6 +101,27 @@ std::optional<std::string> Replace(std::string_view s, std::string_view token,
 ARROW_EXPORT
 arrow::Result<bool> ParseBoolean(std::string_view value);
 
+namespace detail {
+template <typename T, typename = void>
+struct can_to_chars : public std::false_type {};
+
+template <typename T>
+struct can_to_chars<
+    T, std::void_t<decltype(std::to_chars(std::declval<char*>(), std::declval<char*>(),
+                                          std::declval<std::remove_reference_t<T>>()))>>
+    : public std::true_type {};
+}  // namespace detail
+
+/// \brief Whether std::to_chars exists for the current value type.
+///
+/// This is useful as some C++ libraries do not implement all specified overloads
+/// for std::to_chars.
+template <typename T>
+constexpr bool HaveToChars() {
+  // (unfortunately std::is_invocable does not support overloaded functions)
+  return detail::can_to_chars<T>::value;
+}
+
 /// \brief An ergonomic wrapper around std::to_chars, returning a std::string
 ///
 /// For most inputs, the std::string result will not incur any heap allocation
@@ -109,21 +131,27 @@ arrow::Result<bool> ParseBoolean(std::string_view value);
 /// and might also be faster.
 template <typename T, typename... Args>
 std::string ToChars(T value, Args&&... args) {
-  // According to various sources, the GNU libstdc++ and Microsoft's C++ STL
-  // allow up to 15 bytes of small string optimization, while clang's libc++
-  // goes up to 22 bytes. Choose the pessimistic value.
-  std::string out(15, 0);
-  auto res = std::to_chars(&out.front(), &out.back(), value, args...);
-  while (res.ec != std::errc{}) {
-    assert(res.ec == std::errc::value_too_large);
-    out.resize(out.capacity() * 2);
-    res = std::to_chars(&out.front(), &out.back(), value, args...);
+  if constexpr (!HaveToChars<T>()) {
+    // Some C++ standard libraries do not yet implement std::to_chars for all types,
+    // in which case we have to fallback to std::string.
+    return std::to_string(value);
+  } else {
+    // According to various sources, the GNU libstdc++ and Microsoft's C++ STL
+    // allow up to 15 bytes of small string optimization, while clang's libc++
+    // goes up to 22 bytes. Choose the pessimistic value.
+    std::string out(15, 0);
+    auto res = std::to_chars(&out.front(), &out.back(), value, args...);
+    while (res.ec != std::errc{}) {
+      assert(res.ec == std::errc::value_too_large);
+      out.resize(out.capacity() * 2);
+      res = std::to_chars(&out.front(), &out.back(), value, args...);
+    }
+    const auto length = res.ptr - out.data();
+    assert(length <= static_cast<int64_t>(out.length()));
+    out[length] = 0;
+    out.resize(length);
+    return out;
   }
-  const auto length = res.ptr - out.data();
-  assert(length <= static_cast<int64_t>(out.length()));
-  out[length] = 0;
-  out.resize(length);
-  return out;
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/util/string.h
+++ b/cpp/src/arrow/util/string.h
@@ -117,10 +117,7 @@ struct can_to_chars<
 /// This is useful as some C++ libraries do not implement all specified overloads
 /// for std::to_chars.
 template <typename T>
-constexpr bool HaveToChars() {
-  // (unfortunately std::is_invocable does not support overloaded functions)
-  return detail::can_to_chars<T>::value;
-}
+inline constexpr bool have_to_chars = detail::can_to_chars<T>::value;
 
 /// \brief An ergonomic wrapper around std::to_chars, returning a std::string
 ///
@@ -131,7 +128,7 @@ constexpr bool HaveToChars() {
 /// and might also be faster.
 template <typename T, typename... Args>
 std::string ToChars(T value, Args&&... args) {
-  if constexpr (!HaveToChars<T>()) {
+  if constexpr (!have_to_chars<T>) {
     // Some C++ standard libraries do not yet implement std::to_chars for all types,
     // in which case we have to fallback to std::string.
     return std::to_string(value);

--- a/cpp/src/arrow/util/string.h
+++ b/cpp/src/arrow/util/string.h
@@ -18,13 +18,16 @@
 #pragma once
 
 #include <cassert>
-#include <charconv>
 #include <optional>
 #include <string>
 #include <string_view>
 #include <type_traits>
 #include <utility>
 #include <vector>
+
+#if __has_include(<charconv>)
+#include <charconv>
+#endif
 
 #include "arrow/result.h"
 #include "arrow/util/visibility.h"
@@ -101,6 +104,8 @@ std::optional<std::string> Replace(std::string_view s, std::string_view token,
 ARROW_EXPORT
 arrow::Result<bool> ParseBoolean(std::string_view value);
 
+#if __has_include(<charconv>)
+
 namespace detail {
 template <typename T, typename = void>
 struct can_to_chars : public std::false_type {};
@@ -149,6 +154,18 @@ std::string ToChars(T value, Args&&... args) {
     return out;
   }
 }
+
+#else  // !__has_include(<charconv>)
+
+template <typename T>
+inline constexpr bool have_to_chars = false;
+
+template <typename T, typename... Args>
+std::string ToChars(T value, Args&&... args) {
+  return std::to_string(value);
+}
+
+#endif
 
 }  // namespace internal
 }  // namespace arrow

--- a/cpp/src/arrow/util/string_test.cc
+++ b/cpp/src/arrow/util/string_test.cc
@@ -236,28 +236,40 @@ TEST(ToChars, Integers) {
 }
 
 TEST(ToChars, FloatingPoint) {
-  ASSERT_EQ(ToChars(0.0f), "0");
-  ASSERT_EQ(ToChars(0.0), "0");
-  ASSERT_EQ(ToChars(-0.0), "-0");
-  ASSERT_EQ(ToChars(0.25), "0.25");
-  ASSERT_EQ(ToChars(-0.25f), "-0.25");
+  if (HaveToChars<double>()) {
+    ASSERT_EQ(ToChars(0.0f), "0");
+    ASSERT_EQ(ToChars(0.0), "0");
+    ASSERT_EQ(ToChars(-0.0), "-0");
+    ASSERT_EQ(ToChars(0.25), "0.25");
+    ASSERT_EQ(ToChars(-0.25f), "-0.25");
 
-  ASSERT_EQ(ToChars(0.1111111111111111), "0.1111111111111111");
-  ASSERT_EQ(ToChars(0.1111111111111111, std::chars_format{}, /*precision=*/3), "0.111");
+    ASSERT_EQ(ToChars(0.1111111111111111), "0.1111111111111111");
+    ASSERT_EQ(ToChars(0.1111111111111111, std::chars_format{}, /*precision=*/3), "0.111");
 
-  // Will overflow any small string optimization
-  auto long_result = ToChars(0.1111111111111111, std::chars_format{}, /*precision=*/40);
-  ASSERT_TRUE(StartsWith(long_result, "0.1111111111111111")) << long_result;
+    // Will overflow any small string optimization
+    auto long_result = ToChars(0.1111111111111111, std::chars_format{}, /*precision=*/40);
+    ASSERT_TRUE(StartsWith(long_result, "0.1111111111111111")) << long_result;
+  } else {
+    // If std::to_chars isn't implemented for floating-point types, we fall back
+    // to std::to_string which may make ad hoc formatting choices, so we cannot
+    // really test much about the result.
+    auto result = ToChars(0.0f);
+    ASSERT_TRUE(StartsWith(result, "0")) << result;
+    result = ToChars(0.25);
+    ASSERT_TRUE(StartsWith(result, "0.25")) << result;
+  }
 }
 
 #if !defined(_WIN32) || defined(NDEBUG)
 
 TEST(ToChars, LocaleIndependent) {
-  // French locale uses the comma as decimal point
-  LocaleGuard locale_guard("fr_FR.UTF-8");
+  if (HaveToChars<double>()) {
+    // French locale uses the comma as decimal point
+    LocaleGuard locale_guard("fr_FR.UTF-8");
 
-  ASSERT_EQ(ToChars(0.25), "0.25");
-  ASSERT_EQ(ToChars(-0.25f), "-0.25");
+    ASSERT_EQ(ToChars(0.25), "0.25");
+    ASSERT_EQ(ToChars(-0.25f), "-0.25");
+  }
 }
 
 #endif  // _WIN32

--- a/cpp/src/arrow/util/string_test.cc
+++ b/cpp/src/arrow/util/string_test.cc
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <cmath>
+#include <limits>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -216,6 +218,49 @@ TEST(RegexMatch, Basics) {
   check_match("acd", "", "c");
   check_match("abbcccd", "bb", "ccc");
 }
+
+TEST(ToChars, Integers) {
+  ASSERT_EQ(ToChars(static_cast<char>(0)), "0");
+  ASSERT_EQ(ToChars(static_cast<unsigned char>(0)), "0");
+  ASSERT_EQ(ToChars(static_cast<int8_t>(0)), "0");
+  ASSERT_EQ(ToChars(static_cast<uint64_t>(0)), "0");
+  ASSERT_EQ(ToChars(1234), "1234");
+  ASSERT_EQ(ToChars(-5678), "-5678");
+
+  ASSERT_EQ(ToChars(1234, /*base=*/2), "10011010010");
+
+  // Beyond pre-allocated result size
+  ASSERT_EQ(ToChars(9223372036854775807LL), "9223372036854775807");
+  ASSERT_EQ(ToChars(-9223372036854775807LL - 1), "-9223372036854775808");
+  ASSERT_EQ(ToChars(18446744073709551615ULL), "18446744073709551615");
+}
+
+TEST(ToChars, FloatingPoint) {
+  ASSERT_EQ(ToChars(0.0f), "0");
+  ASSERT_EQ(ToChars(0.0), "0");
+  ASSERT_EQ(ToChars(-0.0), "-0");
+  ASSERT_EQ(ToChars(0.25), "0.25");
+  ASSERT_EQ(ToChars(-0.25f), "-0.25");
+
+  ASSERT_EQ(ToChars(0.1111111111111111), "0.1111111111111111");
+  ASSERT_EQ(ToChars(0.1111111111111111, std::chars_format{}, /*precision=*/3), "0.111");
+
+  // Will overflow any small string optimization
+  auto long_result = ToChars(0.1111111111111111, std::chars_format{}, /*precision=*/40);
+  ASSERT_TRUE(StartsWith(long_result, "0.1111111111111111")) << long_result;
+}
+
+#if !defined(_WIN32) || defined(NDEBUG)
+
+TEST(ToChars, LocaleIndependent) {
+  // French locale uses the comma as decimal point
+  LocaleGuard locale_guard("fr_FR.UTF-8");
+
+  ASSERT_EQ(ToChars(0.25), "0.25");
+  ASSERT_EQ(ToChars(-0.25f), "-0.25");
+}
+
+#endif  // _WIN32
 
 }  // namespace internal
 }  // namespace arrow

--- a/cpp/src/arrow/util/string_test.cc
+++ b/cpp/src/arrow/util/string_test.cc
@@ -227,16 +227,20 @@ TEST(ToChars, Integers) {
   ASSERT_EQ(ToChars(1234), "1234");
   ASSERT_EQ(ToChars(-5678), "-5678");
 
-  ASSERT_EQ(ToChars(1234, /*base=*/2), "10011010010");
+  if constexpr (have_to_chars<int>) {
+    ASSERT_EQ(ToChars(1234, /*base=*/2), "10011010010");
+  }
 
   // Beyond pre-allocated result size
   ASSERT_EQ(ToChars(9223372036854775807LL), "9223372036854775807");
   ASSERT_EQ(ToChars(-9223372036854775807LL - 1), "-9223372036854775808");
   ASSERT_EQ(ToChars(18446744073709551615ULL), "18446744073709551615");
 
-  // Will overflow any small string optimization
-  ASSERT_EQ(ToChars(18446744073709551615ULL, /*base=*/2),
-            "1111111111111111111111111111111111111111111111111111111111111111");
+  if constexpr (have_to_chars<unsigned long long>) {  // NOLINT: runtime/int
+    // Will overflow any small string optimization
+    ASSERT_EQ(ToChars(18446744073709551615ULL, /*base=*/2),
+              "1111111111111111111111111111111111111111111111111111111111111111");
+  }
 }
 
 TEST(ToChars, FloatingPoint) {

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -46,6 +46,7 @@ using arrow::KeyValueMetadata;
 using arrow::Status;
 using arrow::internal::checked_cast;
 using arrow::internal::EndsWith;
+using arrow::internal::ToChars;
 
 using ArrowType = arrow::DataType;
 using ArrowTypeId = arrow::Type;
@@ -244,7 +245,7 @@ static constexpr char FIELD_ID_KEY[] = "PARQUET:field_id";
 
 std::shared_ptr<::arrow::KeyValueMetadata> FieldIdMetadata(int field_id) {
   if (field_id >= 0) {
-    return ::arrow::key_value_metadata({FIELD_ID_KEY}, {std::to_string(field_id)});
+    return ::arrow::key_value_metadata({FIELD_ID_KEY}, {ToChars(field_id)});
   } else {
     return nullptr;
   }


### PR DESCRIPTION
`std::to_chars` is locale-independent unlike `std::to_string`; it may also be faster.

This PR does neither bother with test and benchmark files, nor with debug output strings.

Unfortunately, some standard libraries don't provide a full implementation of `std::to_chars`, in which case `std::to_string` is still used for the unimplemented input types.