### PR TITLE
MINOR: [R] Simplify compare_dplyr_binding test helper

### DIFF
--- a/r/tests/testthat/helper-expectation.R
+++ b/r/tests/testthat/helper-expectation.R
@@ -69,29 +69,18 @@ verify_output <- function(...) {
 #' Ensure that dplyr methods on Arrow objects return the same as for data frames
 #'
 #' This function compares the output of running a dplyr expression on a tibble
-#' or data.frame object against the output of the same expression run on
-#' Arrow Table and RecordBatch objects.
-#'
+#' or data.frame object against the output of the same expression run on a Table
 #'
 #' @param expr A dplyr pipeline which must have `.input` as its start
 #' @param tbl A tibble or data.frame which will be substituted for `.input`
-#' @param skip_record_batch The skip message to show (if you should skip the
-#' RecordBatch test)
-#' @param skip_table The skip message to show (if you should skip the Table test)
-#' @param warning The expected warning from the RecordBatch and Table comparison
-#'  paths, passed to `expect_warning()`. Special values:
+#' @param warning The expected warning from Arrow evaluation
+#'  path, passed to `expect_warning()`. Special values:
 #'     * `NA` (the default) for ensuring no warning message
 #'     * `TRUE` is a special case to mean to check for the
 #'      "not supported in Arrow; pulling data into R" message.
 #' @param ... additional arguments, passed to `expect_equal()`
-compare_dplyr_binding <- function(expr,
-                                  tbl,
-                                  skip_record_batch = NULL,
-                                  skip_table = NULL,
-                                  warning = NA,
-                                  ...) {
-
-  # Quote the contents of `expr` so that we can evaluate it a few different ways
+compare_dplyr_binding <- function(expr, tbl, warning = NA, ...) {
+  # Quote the contents of `expr` so that we can evaluate it twice
   expr <- rlang::enquo(expr)
   # Get the expected output by evaluating expr on the .input data.frame using regular dplyr
   expected <- rlang::eval_tidy(expr, rlang::new_data_mask(rlang::env(.input = tbl)))
@@ -101,39 +90,15 @@ compare_dplyr_binding <- function(expr,
     warning <- "not supported in Arrow; pulling data into R"
   }
 
-  skip_msg <- NULL
-
-  # Evaluate `expr` on a RecordBatch object and compare with `expected`
-  if (is.null(skip_record_batch)) {
-    expect_warning(
-      via_batch <- rlang::eval_tidy(
-        expr,
-        rlang::new_data_mask(rlang::env(.input = record_batch(tbl)))
-      ),
-      warning
-    )
-    expect_equal(via_batch, expected, ...)
-  } else {
-    skip_msg <- c(skip_msg, skip_record_batch)
-  }
-
   # Evaluate `expr` on a Table object and compare with `expected`
-  if (is.null(skip_table)) {
-    expect_warning(
-      via_table <- rlang::eval_tidy(
-        expr,
-        rlang::new_data_mask(rlang::env(.input = arrow_table(tbl)))
-      ),
-      warning
-    )
-    expect_equal(via_table, expected, ...)
-  } else {
-    skip_msg <- c(skip_msg, skip_table)
-  }
-
-  if (!is.null(skip_msg)) {
-    skip(paste(skip_msg, collapse = "\n"))
-  }
+  expect_warning(
+    via_table <- rlang::eval_tidy(
+      expr,
+      rlang::new_data_mask(rlang::env(.input = arrow_table(tbl)))
+    ),
+    warning
+  )
+  expect_equal(via_table, expected, ...)
 }
 
 #' Assert that Arrow dplyr methods error in the same way as methods on data.frame
@@ -145,9 +110,7 @@ compare_dplyr_binding <- function(expr,
 #' @param expr A dplyr pipeline which must have `.input` as its start
 #' @param tbl A tibble or data.frame which will be substituted for `.input`
 #' @param ... additional arguments, passed to `expect_error()`
-compare_dplyr_error <- function(expr,
-                                tbl,
-                                ...) {
+compare_dplyr_error <- function(expr, tbl, ...) {
   # ensure we have supplied tbl
   force(tbl)
 


### PR DESCRIPTION
A long time ago, dplyr expressions on Tables and RecordBatches were evaluated by calling compute functions on (Chunked)Arrays, calling Slice or Filter methods on the Tables/RBs, etc. So to make sure that all C++ bindings were exposed correctly, we needed to test that operations worked on both Tables and RecordBatches. 

Today, everything goes through ExecPlans, and RecordBatches get wrapped in Tables in creating TableSourceNodes: https://github.com/apache/arrow/blob/master/r/R/query-engine.R#L63. So as long as we are able to create a Table from a RecordBatch (tested elsewhere), the query evaluation is identical. This means we don't need to test every dplyr query twice.

On my machine, this cuts off a little more than 1/3 of the running time of the dplyr tests, or about 20 seconds. The bigger benefit IMO is that when there is a failure in one of these expectations, you'll only get it once instead of twice, so it will be less confusing to see what's up. 