### PR TITLE
ARROW-18373: Fix component drop-down, add license text

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 name: Bug Report
 description: File a bug report
 labels: ["Type: bug"]
@@ -13,8 +30,8 @@ body:
   - type: dropdown
     id: component
     attributes:
-      label: Component
-      description: Which component is principally affected?
+      label: Component(s)
+      multiple: true
       options:
         - Archery
         - Benchmarking
@@ -23,9 +40,7 @@ body:
         - C++
         - C++ - Gandiva
         - C++ - Plasma
-        - Compute IR
         - Continuous Integration
-        - Dart
         - Developer Tools
         - Documentation
         - FlightRPC
@@ -36,20 +51,14 @@ body:
         - Integration
         - Java
         - JavaScript
-        - Julia
         - MATLAB
         - Packaging
         - Parquet
         - Python
         - R
         - Ruby
-        - Rust
-        - Rust - Ballista
-        - Rust - DataFusion
-        - SQL
         - Swift
         - Website
-        - Wiki
         - Other
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,5 +1,22 @@
-name: Feature Request
-description: Request a new feature
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Enhancement Request
+description: Request an enhancement to the project
 labels: ["Type: enhancement"]
 assignees: []
 body:
@@ -10,14 +27,14 @@ body:
   - type: textarea
     id: description
     attributes:
-      label: Describe the feature requested.
+      label: Describe the enhancement requested
     validations:
       required: true
   - type: dropdown
     id: component
     attributes:
-      label: Component
-      description: Which component does the feature most apply to?
+      label: Component(s)
+      multiple: true
       options:
         - Archery
         - Benchmarking
@@ -26,9 +43,7 @@ body:
         - C++
         - C++ - Gandiva
         - C++ - Plasma
-        - Compute IR
         - Continuous Integration
-        - Dart
         - Developer Tools
         - Documentation
         - FlightRPC
@@ -39,20 +54,14 @@ body:
         - Integration
         - Java
         - JavaScript
-        - Julia
         - MATLAB
         - Packaging
         - Parquet
         - Python
         - R
         - Ruby
-        - Rust
-        - Rust - Ballista
-        - Rust - DataFusion
-        - SQL
         - Swift
         - Website
-        - Wiki
         - Other
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/usage_question.yaml
+++ b/.github/ISSUE_TEMPLATE/usage_question.yaml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 name: Usage Question
 description: Ask a question
 labels: ["Type: usage"]
@@ -5,27 +22,39 @@ assignees: []
 body:
   - type: markdown
     attributes:
-      value: |
-        While we enable issues as a mechanism for new contributors and passers-by who are unfamiliar with Apache Software Foundation projects to ask questions and interact with the project, we encourage users to ask such questions on public mailing lists:
+      value: >
+        While we enable issues as a mechanism for new contributors and passers-by who 
+        are unfamiliar with Apache Software Foundation projects to ask questions and 
+        interact with the project, we encourage users to ask such questions on public 
+        mailing lists:
         
-        * Development discussions: dev@arrow.apache.org (first subscribe by sending an e-mail to dev-subscribe@arrow.apache.org).
+        * Development discussions: dev@arrow.apache.org (first subscribe by sending an 
+        e-mail to dev-subscribe@arrow.apache.org).
+        
+        * User discussions: user@arrow.apache.org (first subscribe by sending an e-mail 
+        to user-subscribe@arrow.apache.org).
+        
+        * Mailing list archives: https://arrow.apache.org/community/
+        
+        
+        Do not be surprised by responses to issues raised here directing you to those 
+        mailing lists, or to report a bug or feature request here.
 
-        * User discussions: user@arrow.apache.org (first subscribe by sending an e-mail to user-subscribe@arrow.apache.org).
-        
-        Do not be surprised by responses to issues raised here directing you to those mailing lists, or to report a bug or feature request here.
 
         Thank you!
   - type: textarea
     id: description
     attributes:
-      label: Describe the usage question you have. Please include as many useful details as possible.
+      label: > 
+        Describe the usage question you have. Please include as many useful details as 
+        possible.
     validations:
       required: true
   - type: dropdown
     id: component
     attributes:
-      label: Component
-      description: Which component does your question relate to?
+      label: Component(s)
+      multiple: true
       options:
         - Archery
         - Benchmarking
@@ -34,9 +63,7 @@ body:
         - C++
         - C++ - Gandiva
         - C++ - Plasma
-        - Compute IR
         - Continuous Integration
-        - Dart
         - Developer Tools
         - Documentation
         - FlightRPC
@@ -47,20 +74,14 @@ body:
         - Integration
         - Java
         - JavaScript
-        - Julia
         - MATLAB
         - Packaging
         - Parquet
         - Python
         - R
         - Ruby
-        - Rust
-        - Rust - Ballista
-        - Rust - DataFusion
-        - SQL
         - Swift
         - Website
-        - Wiki
         - Other
     validations:
       required: true

--- a/dev/release/rat_exclude_files.txt
+++ b/dev/release/rat_exclude_files.txt
@@ -7,9 +7,6 @@
 *.csv
 *.json
 *.snap
-.github/ISSUE_TEMPLATE/bug_report.yaml
-.github/ISSUE_TEMPLATE/feature_request.yaml
-.github/ISSUE_TEMPLATE/usage_question.yaml
 ci/etc/rprofile
 ci/etc/*.patch
 ci/vcpkg/*.patch


### PR DESCRIPTION
https://github.com/toddfarmer/test-arrow-config/issues/new/choose has updated templates deployed for easier review.