### PR TITLE
ARROW-18379: [Python] Change warnings to _warnings in _plasma_store_entry_point

### DIFF
--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -352,7 +352,7 @@ def _plasma_store_entry_point():
     .. deprecated:: 10.0.0
        Plasma is deprecated since Arrow 10.0.0. It will be removed in 12.0.0 or so.
     """
-    warnings.warn(
+    _warnings.warn(
         "Plasma is deprecated since Arrow 10.0.0. It will be removed in 12.0.0 or so.",
         DeprecationWarning)
 


### PR DESCRIPTION
This PR resolves https://github.com/apache/arrow/issues/14693.