### PR TITLE
ARROW-18282: [C++][Python] Support step >= 1 in list_slice kernel

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_nested.cc
@@ -109,14 +109,14 @@ int64_t MaxSliceLength(const int64_t start, const int64_t stop, const int64_t st
   }
 
   // Get the raw length with any remainder after dividing by step
-  auto length = std::floor((stopf - startf) / stepf);
+  auto length = (stopf - startf) / stepf;
 
   // Any remainder from the step into length then it is not evenly split by step
   // and will need one extra in length.
-  if (fmod(length, stepf) > 0.0) {
+  if (length > std::floor(length)) {
     ++length;
   }
-  return static_cast<int64_t>(length);
+  return static_cast<int64_t>(std::floor(length));
 }
 
 template <typename Type>

--- a/cpp/src/arrow/compute/kernels/scalar_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_nested.cc
@@ -106,11 +106,11 @@ int64_t MaxSliceLength(const int64_t start, const int64_t stop, const int64_t st
     return 1;
   }
 
-  auto length = static_cast<int64_t>(std::floor((stopf - startf) / stepf));
-  if (fmod(static_cast<float>(length), stepf) > 0.0) {
+  auto length = std::floor((stopf - startf) / stepf);
+  if (fmod(length, stepf) > 0.0) {
     ++length;
   }
-  return length;
+  return static_cast<int64_t>(length);
 }
 
 template <typename Type>

--- a/cpp/src/arrow/compute/kernels/scalar_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_nested.cc
@@ -102,7 +102,6 @@ int64_t MaxSliceLength(const int64_t start, const int64_t stop, const int64_t st
   const auto stopf = static_cast<float>(stop);
   const auto stepf = static_cast<float>(step);
 
-  // Get the raw length with any remainder after dividing by step
   auto length = std::ceil((stopf - startf) / stepf);
   return static_cast<int64_t>(length);
 }

--- a/cpp/src/arrow/compute/kernels/scalar_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_nested.cc
@@ -106,7 +106,7 @@ int MaxSliceLength(std::slice slice) {
     return 1;
   }
 
-  int length = std::floor((size - start) / stride);
+  auto length = static_cast<int>(std::floor((size - start) / stride));
   if (fmod(static_cast<float>(length), stride) > 0.0) {
     ++length;
   }
@@ -243,7 +243,7 @@ struct ListSlice {
         RETURN_NOT_OK(
             value_builder->AppendArraySlice(*list_values, cursor + opts->start, 1));
       }
-      cursor += opts->step;
+      cursor += static_cast<offset_type>(opts->step);
     }
     return Status::OK();
   }

--- a/cpp/src/arrow/compute/kernels/scalar_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_nested.cc
@@ -102,20 +102,8 @@ int64_t MaxSliceLength(const int64_t start, const int64_t stop, const int64_t st
   const auto stopf = static_cast<float>(stop);
   const auto stepf = static_cast<float>(step);
 
-  // length not considering step, is less than step then
-  // the length will be 1; the index of start.
-  if (stopf - startf <= stepf) {
-    return 1;
-  }
-
   // Get the raw length with any remainder after dividing by step
-  auto length = (stopf - startf) / stepf;
-
-  // Any remainder from the step into length then it is not evenly split by step
-  // and will need one extra in length.
-  if (length > std::floor(length)) {
-    ++length;
-  }
+  auto length = std::ceil((stopf - startf) / stepf);
   return static_cast<int64_t>(std::floor(length));
 }
 

--- a/cpp/src/arrow/compute/kernels/scalar_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_nested.cc
@@ -102,11 +102,17 @@ int64_t MaxSliceLength(const int64_t start, const int64_t stop, const int64_t st
   const auto stopf = static_cast<float>(stop);
   const auto stepf = static_cast<float>(step);
 
+  // length not considering step, is less than step then
+  // the length will be 1; the index of start.
   if (stopf - startf <= stepf) {
     return 1;
   }
 
+  // Get the raw length with any remainder after dividing by step
   auto length = std::floor((stopf - startf) / stepf);
+
+  // Any remainder from the step into length then it is not evenly split by step
+  // and will need one extra in length.
   if (fmod(length, stepf) > 0.0) {
     ++length;
   }

--- a/cpp/src/arrow/compute/kernels/scalar_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_nested.cc
@@ -261,7 +261,7 @@ Result<TypeHolder> MakeListSliceResolve(KernelContext* ctx,
           "Unable to produce FixedSizeListArray without `stop` being set.");
     }
     const auto length = MaxSliceLength(opts.start, opts.stop.value(), opts.step);
-    return fixed_size_list(value_type, length);
+    return fixed_size_list(value_type, static_cast<int32_t>(length));
   } else {
     // Returning large list if that's what we got in and didn't ask for fixed size
     if (list_type->id() == Type::LARGE_LIST) {

--- a/cpp/src/arrow/compute/kernels/scalar_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_nested.cc
@@ -104,7 +104,7 @@ int64_t MaxSliceLength(const int64_t start, const int64_t stop, const int64_t st
 
   // Get the raw length with any remainder after dividing by step
   auto length = std::ceil((stopf - startf) / stepf);
-  return static_cast<int64_t>(std::floor(length));
+  return static_cast<int64_t>(length);
 }
 
 template <typename Type>

--- a/cpp/src/arrow/compute/kernels/scalar_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_nested.cc
@@ -148,8 +148,9 @@ struct ListSlice {
     // construct array values
     if (return_fixed_size_list) {
       const auto length = MaxSliceLength(opts.start, opts.stop.value(), opts.step);
-      RETURN_NOT_OK(
-          MakeBuilder(ctx->memory_pool(), fixed_size_list(value_type, length), &builder));
+      RETURN_NOT_OK(MakeBuilder(ctx->memory_pool(),
+                                fixed_size_list(value_type, static_cast<int32_t>(length)),
+                                &builder));
       RETURN_NOT_OK(BuildArray<FixedSizeListBuilder>(batch, opts, *builder));
     } else {
       if constexpr (std::is_same_v<Type, LargeListType>) {

--- a/cpp/src/arrow/compute/kernels/scalar_nested_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_nested_test.cc
@@ -199,6 +199,20 @@ TEST(TestScalarNested, ListSliceFixedOutput) {
       args.step = 3;
       expected = ArrayFromJSON(fixed_size_list(value_type, 1), "[[1], [4], [6], null]");
       CheckScalarUnary("list_slice", input, expected, &args);
+
+      args.start = 0;
+      args.stop = 5;
+      args.step = 2;
+      expected = ArrayFromJSON(fixed_size_list(value_type, 3),
+                               "[[1, 3, null], [4, null, null], [6, null, null], null]");
+      CheckScalarUnary("list_slice", input, expected, &args);
+
+      args.start = 0;
+      args.stop = 6;
+      args.step = 3;
+      expected = ArrayFromJSON(fixed_size_list(value_type, 2),
+                               "[[1, null], [4, null], [6, null], null]");
+      CheckScalarUnary("list_slice", input, expected, &args);
     }
   }
 }

--- a/cpp/src/arrow/compute/kernels/scalar_nested_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_nested_test.cc
@@ -180,6 +180,25 @@ TEST(TestScalarNested, ListSliceFixedOutput) {
       expected = ArrayFromJSON(fixed_size_list(value_type, 2),
                                "[[1, 3], [4, null], [6, null], null]");
       CheckScalarUnary("list_slice", input, expected, &args);
+
+      // More checks for step slicing start/stop/step combinations
+      args.start = 1;
+      args.stop = 3;
+      args.step = 2;
+      expected =
+          ArrayFromJSON(fixed_size_list(value_type, 1), "[[2], [5], [null], null]");
+      CheckScalarUnary("list_slice", input, expected, &args);
+
+      args.start = 2;
+      expected =
+          ArrayFromJSON(fixed_size_list(value_type, 1), "[[3], [null], [null], null]");
+      CheckScalarUnary("list_slice", input, expected, &args);
+
+      args.start = 0;
+      args.stop = 2;
+      args.step = 3;
+      expected = ArrayFromJSON(fixed_size_list(value_type, 1), "[[1], [4], [6], null]");
+      CheckScalarUnary("list_slice", input, expected, &args);
     }
   }
 }

--- a/cpp/src/arrow/compute/kernels/scalar_nested_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_nested_test.cc
@@ -289,6 +289,13 @@ TEST(TestScalarNested, ListSliceBadParameters) {
   EXPECT_RAISES_WITH_MESSAGE_THAT(
       NotImplemented, ::testing::HasSubstr("Slicing to end not yet implemented"),
       CallFunction("list_slice", {input}, &args));
+  // Catch step must be >= 1
+  args.start = 0;
+  args.stop = 2;
+  args.step = 0;
+  EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid,
+                                  ::testing::HasSubstr("`step` must be >= 1, got: 0"),
+                                  CallFunction("list_slice", {input}, &args));
 }
 
 TEST(TestScalarNested, StructField) {

--- a/cpp/src/arrow/compute/kernels/scalar_nested_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_nested_test.cc
@@ -134,6 +134,11 @@ TEST(TestScalarNested, ListSliceVariableOutput) {
     args.stop = 4;
     expected = ArrayFromJSON(list(value_type), "[[3], [], [], null]");
     CheckScalarUnary("list_slice", input, expected, &args);
+
+    args.start = 0;
+    args.stop = 4;
+    args.step = 2;
+    expected = ArrayFromJSON(list(value_type), "[[1, 3], [4], [6], null]");
   }
 
   // Verify passing `return_fixed_size_list=false` with fixed size input
@@ -167,6 +172,13 @@ TEST(TestScalarNested, ListSliceFixedOutput) {
       args.stop = 4;
       expected = ArrayFromJSON(fixed_size_list(value_type, 2),
                                "[[3, null], [null, null], [null, null], null]");
+      CheckScalarUnary("list_slice", input, expected, &args);
+
+      args.start = 0;
+      args.stop = 4;
+      args.step = 2;
+      expected = ArrayFromJSON(fixed_size_list(value_type, 2),
+                               "[[1, 3], [4, null], [6, null], null]");
       CheckScalarUnary("list_slice", input, expected, &args);
     }
   }
@@ -243,13 +255,6 @@ TEST(TestScalarNested, ListSliceBadParameters) {
   args.return_fixed_size_list = false;
   EXPECT_RAISES_WITH_MESSAGE_THAT(
       NotImplemented, ::testing::HasSubstr("Slicing to end not yet implemented"),
-      CallFunction("list_slice", {input}, &args));
-  // step other than `1` not implmented
-  args.stop = 2;
-  args.step = 2;
-  EXPECT_RAISES_WITH_MESSAGE_THAT(
-      NotImplemented,
-      ::testing::HasSubstr("Setting `step` to anything other than 1 is not supported"),
       CallFunction("list_slice", {input}, &args));
 }
 

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -2955,18 +2955,21 @@ def test_cast_table_raises():
     (1, 2, [[2], [5], [None], None]),
     (2, 4, [[3, None], [None, None], [None, None], None])
 ))
+@pytest.mark.parametrize("step", (1, 2))
 @pytest.mark.parametrize("value_type", (pa.string, pa.int16, pa.float64))
 @pytest.mark.parametrize("list_type", (pa.list_, pa.large_list, "fixed"))
-def test_list_slice_output_fixed(start, stop, expected, value_type, list_type):
+def test_list_slice_output_fixed(start, stop, step, expected, value_type,
+                                 list_type):
     if list_type == "fixed":
         arr = pa.array([[1, 2, 3], [4, 5, None], [6, None, None], None],
                        pa.list_(pa.int8(), 3)).cast(pa.list_(value_type(), 3))
     else:
         arr = pa.array([[1, 2, 3], [4, 5], [6], None],
                        pa.list_(pa.int8())).cast(list_type(value_type()))
-    result = pc.list_slice(arr, start, stop, return_fixed_size_list=True)
-    pylist = result.cast(pa.list_(pa.int8(), stop-start)).to_pylist()
-    assert pylist == expected
+    result = pc.list_slice(arr, start, stop, step, return_fixed_size_list=True)
+    pylist = result.cast(pa.list_(pa.int8(),
+                         result.type.list_size)).to_pylist()
+    assert pylist == [e[::step] if e else e for e in expected]
 
 
 @pytest.mark.parametrize("start,stop", (
@@ -2975,9 +2978,10 @@ def test_list_slice_output_fixed(start, stop, expected, value_type, list_type):
     (1, 2,),
     (2, 4,)
 ))
+@pytest.mark.parametrize("step", (1, 2))
 @pytest.mark.parametrize("value_type", (pa.string, pa.int16, pa.float64))
 @pytest.mark.parametrize("list_type", (pa.list_, pa.large_list, "fixed"))
-def test_list_slice_output_variable(start, stop, value_type, list_type):
+def test_list_slice_output_variable(start, stop, step, value_type, list_type):
     if list_type == "fixed":
         data = [[1, 2, 3], [4, 5, None], [6, None, None], None]
         arr = pa.array(
@@ -2992,13 +2996,14 @@ def test_list_slice_output_variable(start, stop, value_type, list_type):
     if list_type == "fixed":
         list_type = pa.list_  # non fixed output type
 
-    result = pc.list_slice(arr, start, stop, return_fixed_size_list=False)
+    result = pc.list_slice(arr, start, stop, step,
+                           return_fixed_size_list=False)
     assert result.type == list_type(value_type())
 
     pylist = result.cast(pa.list_(pa.int8())).to_pylist()
 
     # Variable output slicing follows Python's slice semantics
-    expected = [d[start:stop] if d is not None else None for d in data]
+    expected = [d[start:stop:step] if d is not None else None for d in data]
     assert pylist == expected
 
 
@@ -3029,12 +3034,6 @@ def test_list_slice_bad_parameters():
     with pytest.raises(pa.ArrowInvalid, match=msg):
         pc.list_slice(arr, 0, 0)  # start == stop?
 
-    # TODO(ARROW-18282): support step in slicing
-    msg = "Setting `step` to anything other than 1 is not supported; "\
-        "got step=2"
-    with pytest.raises(NotImplementedError, match=msg):
-        pc.list_slice(arr, 0, 1, step=2)
-
     # TODO(ARROW-18280): support stop == None; slice to end
     # This fails first at resolve, b/c it doesn't now how big the
     # resulting FixedSizeListArray item size will be
@@ -3047,3 +3046,10 @@ def test_list_slice_bad_parameters():
     msg = "Slicing to end not yet implemented*"
     with pytest.raises(NotImplementedError, match=msg):
         pc.list_slice(arr, 0, return_fixed_size_list=False)
+
+    # Step not >= 1
+    msg = "`step` must be >= 1, got: "
+    with pytest.raises(pa.ArrowInvalid, match=msg + "0"):
+        pc.list_slice(arr, 0, 1, step=0)
+    with pytest.raises(pa.ArrowInvalid, match=msg + "-1"):
+        pc.list_slice(arr, 0, 1, step=-1)


### PR DESCRIPTION
Will fix [ARROW-18282](https://issues.apache.org/jira/browse/ARROW-18282)

Example:
```python
In [1]: a = pa.array([[1, 2], [3, 4, 5], [6, 7, 8, 9]])

In [2]: pc.list_slice(a, 0, 4, step=2, return_fixed_size_list=True)
Out[2]:
<pyarrow.lib.FixedSizeListArray object at 0x7f6cc0a2ace0>
[
  [
    1,
    null
  ],
  [
    3,
    5
  ],
  [
    6,
    8
  ]
]

In [3]: pc.list_slice(a, 0, 4, step=2, return_fixed_size_list=False)
Out[3]:
<pyarrow.lib.ListArray object at 0x7f6cc0adc5e0>
[
  [
    1
  ],
  [
    3,
    5
  ],
  [
    6,
    8
  ]
]
```