### PR TITLE
ARROW-18265: [C++][Python] Support FieldRef to work with ListElement

### DIFF
--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -1067,6 +1067,10 @@ struct FieldPathGetImpl {
       return Status::Invalid("empty indices cannot be traversed");
     }
 
+    auto IsBaseListType = [](const DataType& type) {
+      return dynamic_cast<const BaseListType*>(&type) != nullptr;
+    };
+
     int depth = 0;
     const T* out = nullptr;
     for (int index : path->indices()) {
@@ -1079,10 +1083,10 @@ struct FieldPathGetImpl {
         // The index here is used in the kernel to grab the specific list element.
         // Children then are fields from list type, and out will be the children from
         // that field, thus index 0.
-        if (out != nullptr && (*out)->type()->id() == Type::LIST) {
+        if (out != nullptr && IsBaseListType(*(*out)->type())) {
           children = get_children(*out);
           index = 0;
-        } else if (out == nullptr && parent != nullptr && parent->id() == Type::LIST) {
+        } else if (out == nullptr && parent != nullptr && IsBaseListType(*parent)) {
           // For the first iteration (out == nullptr), if the parent is a list type
           // then we certainly want to get the type of the list item. The specific
           // kernel implemention will use the actual index to grab a specific list item.

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1624,7 +1624,8 @@ class ARROW_EXPORT FieldPath {
   Result<std::shared_ptr<Field>> Get(const Schema& schema) const;
   Result<std::shared_ptr<Field>> Get(const Field& field) const;
   Result<std::shared_ptr<Field>> Get(const DataType& type) const;
-  Result<std::shared_ptr<Field>> Get(const FieldVector& fields) const;
+  Result<std::shared_ptr<Field>> Get(const FieldVector& fields,
+                                     const DataType* parent = NULLPTR) const;
 
   static Result<std::shared_ptr<Schema>> GetAll(const Schema& schema,
                                                 const std::vector<FieldPath>& paths);
@@ -1762,7 +1763,8 @@ class ARROW_EXPORT FieldRef : public util::EqualityComparable<FieldRef> {
   std::vector<FieldPath> FindAll(const Schema& schema) const;
   std::vector<FieldPath> FindAll(const Field& field) const;
   std::vector<FieldPath> FindAll(const DataType& type) const;
-  std::vector<FieldPath> FindAll(const FieldVector& fields) const;
+  std::vector<FieldPath> FindAll(const FieldVector& fields,
+                                 const DataType* parent = NULLPTR) const;
 
   /// \brief Convenience function which applies FindAll to arg's type or schema.
   std::vector<FieldPath> FindAll(const ArrayData& array) const;

--- a/cpp/src/arrow/type_test.cc
+++ b/cpp/src/arrow/type_test.cc
@@ -435,40 +435,48 @@ TEST(TestFieldRef, DotPathRoundTrip) {
 }
 
 TEST(TestFieldRef, NestedWithList) {
-  // Single list type
-  auto type =
-      struct_({field("c", list(struct_({field("d", int32()), field("e", int8())})))});
-  // Note numeric values here go unused, outside of indicating a further step, during
-  // FindAll, only used by kernels for which list element to take. When FindAll encounters
-  // a list, it assumes the list value type.
-  // Not b/c they are numeric, but they are the position referencing a specific list
-  // element.
-  EXPECT_THAT(FieldRef("c", 0, "d").FindAll(*type), ElementsAre(FieldPath{0, 0, 0}));
-  EXPECT_THAT(FieldRef("c", 0, "e").FindAll(*type), ElementsAre(FieldPath{0, 0, 1}));
-  EXPECT_THAT(FieldRef("c", 1, "d").FindAll(*type), ElementsAre(FieldPath{0, 1, 0}));
-  EXPECT_THAT(FieldRef("c", 1, "e").FindAll(*type), ElementsAre(FieldPath{0, 1, 1}));
+  // bit of indirection to satisfy list / large_list variants
+  auto gen_type = [](std::shared_ptr<DataType> (*f)(const std::shared_ptr<DataType>&)) {
+    return f;
+  };
 
-  // Double list and nested
-  type = struct_({field("a", list(type)), field("b", list(type))});
-  EXPECT_THAT(FieldRef("a", 0, "c", 0, "d").FindAll(*type),
-              ElementsAre(FieldPath{0, 0, 0, 0, 0}));
-  EXPECT_THAT(FieldRef("b", 1, "c", 1, "e").FindAll(*type),
-              ElementsAre(FieldPath{1, 1, 0, 1, 1}));
+  for (auto list_type : {gen_type(list), gen_type(large_list)}) {
+    // Single list type
+    auto type = struct_(
+        {field("c", list_type(struct_({field("d", int32()), field("e", int8())})))});
 
-  // Again, noting the 1 and 3 indexes refer to the specific list element
-  // and are not used in getting the type, only that its presence indicates
-  // further drilling into the list value type is needed.
-  // The values are used however in the kernel implementations for selecting
-  // from the specific list element.
-  ASSERT_OK_AND_ASSIGN(auto field, FieldPath({0, 0, 0, 0, 0}).Get(*type))
-  ASSERT_EQ(field->type(), int32());
-  ASSERT_OK_AND_ASSIGN(field, FieldPath({0, 1, 0, 1, 0}).Get(*type));
-  ASSERT_EQ(field->type(), int32());
+    // Note numeric values here go unused, outside of indicating a further step, during
+    // FindAll, only used by kernels for which list element to take. When FindAll
+    // encounters a list, it assumes the list value type. Not b/c they are numeric, but
+    // they are the position referencing a specific list element.
+    EXPECT_THAT(FieldRef("c", 0, "d").FindAll(*type), ElementsAre(FieldPath{0, 0, 0}));
+    EXPECT_THAT(FieldRef("c", 0, "e").FindAll(*type), ElementsAre(FieldPath{0, 0, 1}));
+    EXPECT_THAT(FieldRef("c", 1, "d").FindAll(*type), ElementsAre(FieldPath{0, 1, 0}));
+    EXPECT_THAT(FieldRef("c", 1, "e").FindAll(*type), ElementsAre(FieldPath{0, 1, 1}));
 
-  ASSERT_OK_AND_ASSIGN(field, FieldPath({1, 0, 0, 0, 1}).Get(*type));
-  ASSERT_EQ(field->type(), int8());
-  ASSERT_OK_AND_ASSIGN(field, FieldPath({1, 1, 0, 1, 1}).Get(*type));
-  ASSERT_EQ(field->type(), int8());
+    // Double list, variable and fixed
+    type = struct_({field("a", list_type(type)), field("b", fixed_size_list(type, 2))});
+
+    EXPECT_THAT(FieldRef("a", 0, "c", 0, "d").FindAll(*type),
+                ElementsAre(FieldPath{0, 0, 0, 0, 0}));
+    EXPECT_THAT(FieldRef("b", 1, "c", 1, "e").FindAll(*type),
+                ElementsAre(FieldPath{1, 1, 0, 1, 1}));
+
+    // Again, noting the 1 and 3 indexes refer to the specific list element
+    // and are not used in getting the type, only that its presence indicates
+    // further drilling into the list value type is needed.
+    // The values are used however in the kernel implementations for selecting
+    // from the specific list element.
+    ASSERT_OK_AND_ASSIGN(auto field, FieldPath({0, 0, 0, 0, 0}).Get(*type))
+    ASSERT_EQ(field->type(), int32());
+    ASSERT_OK_AND_ASSIGN(field, FieldPath({0, 1, 0, 1, 0}).Get(*type));
+    ASSERT_EQ(field->type(), int32());
+
+    ASSERT_OK_AND_ASSIGN(field, FieldPath({1, 0, 0, 0, 1}).Get(*type));
+    ASSERT_EQ(field->type(), int8());
+    ASSERT_OK_AND_ASSIGN(field, FieldPath({1, 1, 0, 1, 1}).Get(*type));
+    ASSERT_EQ(field->type(), int8());
+  }
 }
 
 TEST(TestFieldPath, Nested) {

--- a/cpp/src/arrow/type_test.cc
+++ b/cpp/src/arrow/type_test.cc
@@ -453,6 +453,7 @@ TEST(TestFieldRef, NestedWithList) {
     EXPECT_THAT(FieldRef("c", 0, "e").FindAll(*type), ElementsAre(FieldPath{0, 0, 1}));
     EXPECT_THAT(FieldRef("c", 1, "d").FindAll(*type), ElementsAre(FieldPath{0, 1, 0}));
     EXPECT_THAT(FieldRef("c", 1, "e").FindAll(*type), ElementsAre(FieldPath{0, 1, 1}));
+    ASSERT_TRUE(FieldRef("c", "non-integer", "e").FindAll(*type).empty());
 
     // Double list, variable and fixed
     type = struct_({field("a", list_type(type)), field("b", fixed_size_list(type, 2))});
@@ -475,6 +476,18 @@ TEST(TestFieldRef, NestedWithList) {
     ASSERT_OK_AND_ASSIGN(field, FieldPath({1, 0, 0, 0, 1}).Get(*type));
     ASSERT_EQ(field->type(), int8());
     ASSERT_OK_AND_ASSIGN(field, FieldPath({1, 1, 0, 1, 1}).Get(*type));
+    ASSERT_EQ(field->type(), int8());
+
+    // leading list type
+    type = list_type(type);
+    EXPECT_THAT(FieldRef(1, "a", 0, "c", 0, "d").FindAll(*type),
+                ElementsAre(FieldPath{1, 0, 0, 0, 0, 0}));
+    EXPECT_THAT(FieldRef(0, "b", 1, "c", 1, "e").FindAll(*type),
+                ElementsAre(FieldPath{0, 1, 1, 0, 1, 1}));
+
+    ASSERT_OK_AND_ASSIGN(field, FieldPath({0, 1, 0, 0, 0, 1}).Get(*type));
+    ASSERT_EQ(field->type(), int8());
+    ASSERT_OK_AND_ASSIGN(field, FieldPath({1, 1, 1, 0, 1, 1}).Get(*type));
     ASSERT_EQ(field->type(), int8());
   }
 }

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -2731,8 +2731,16 @@ def test_struct_fields_options():
     ([0, 1, 1], ["hi"]),
     ('.a[1].c', ["hi"])
 ))
-def test_struct_field_list_path(path, expected):
-    arr = pa.array([{'a': [{'b': 1}, {'c': 'hi'}]}])
+@pytest.mark.parametrize("list_type", (
+    lambda v: pa.list_(v),
+    lambda v: pa.list_(v, 2),
+    lambda v: pa.large_list(v)
+))
+def test_struct_field_list_path(path, expected, list_type):
+    type = pa.struct([pa.field('a', list_type(
+        pa.struct([pa.field('b', pa.int8()),
+                   pa.field('c', pa.string())])))])
+    arr = pa.array([{'a': [{'b': 1}, {'c': 'hi'}]}], type)
     out = pc.struct_field(arr, path)
     assert out == pa.array(expected).cast(out.type)
 

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -2721,6 +2721,22 @@ def test_struct_fields_options():
     # assert pc.struct_field(arr) == arr
 
 
+@pytest.mark.parametrize("path,expected", (
+    ([0, 0, 0], [1]),
+    ('.a[0].b', [1]),
+    ([0, 0, 1], [None]),
+    ('.a[0].c', [None]),
+    ([0, 1, 0], [None]),
+    ('.a[1].b', [None]),
+    ([0, 1, 1], ["hi"]),
+    ('.a[1].c', ["hi"])
+))
+def test_struct_field_list_path(path, expected):
+    arr = pa.array([{'a': [{'b': 1}, {'c': 'hi'}]}])
+    out = pc.struct_field(arr, path)
+    assert out == pa.array(expected).cast(out.type)
+
+
 def test_case_when():
     assert pc.case_when(pc.make_struct([True, False, None],
                                        [False, True, None]),


### PR DESCRIPTION
Will fix [ARROW-18265](https://issues.apache.org/jira/browse/ARROW-18265)

- [x] Support list types other than `Type::LIST`
- [x] Add C++ tests

Example
```python
In [1]: arr = pa.array([{'a': [{'b': 1}, {'c': 'hi'}]}])

In [2]: pc.struct_field(arr, '.a[1].c')
Out[2]:
<pyarrow.lib.StringArray object at 0x7efbc741f040>
[
  "hi"
]

In [3]: pc.struct_field(arr, '.a[0].b')
Out[3]:
<pyarrow.lib.Int64Array object at 0x7efc77398fa0>
[
  1
]

In [4]:
```