### PR TITLE
ARROW-18382: [C++] Set ADDRESS_SANITIZER in fuzzing builds

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -384,8 +384,9 @@ if(NOT ARROW_BUILD_EXAMPLES)
   set(NO_EXAMPLES 1)
 endif()
 
-if(NOT ARROW_FUZZING)
-  set(NO_FUZZING 1)
+if(ARROW_FUZZING)
+  # Fuzzing builds enable ASAN without setting our home-grown option for it.
+  add_definitions(-DADDRESS_SANITIZER)
 endif()
 
 if(ARROW_LARGE_MEMORY_TESTS)

--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -871,7 +871,7 @@ function(ADD_FUZZ_TARGET REL_FUZZING_NAME)
     message(SEND_ERROR "Error: unrecognized arguments: ${ARG_UNPARSED_ARGUMENTS}")
   endif()
 
-  if(NO_FUZZING)
+  if(NOT ARROW_FUZZING)
     return()
   endif()
 


### PR DESCRIPTION
This will silence a spurious reported leak in OSS-Fuzz builds.