### PR TITLE
ARROW-18383: [C++] Avoid global variables for thread pools and at-fork handlers

### DIFF
--- a/cpp/src/arrow/util/thread_pool.cc
+++ b/cpp/src/arrow/util/thread_pool.cc
@@ -535,6 +535,7 @@ std::shared_ptr<ThreadPool> ThreadPool::MakeCpuThreadPool() {
 }
 
 ThreadPool* GetCpuThreadPool() {
+  // Avoid using a global variable because of initialization order issues (ARROW-18383)
   static std::shared_ptr<ThreadPool> singleton = ThreadPool::MakeCpuThreadPool();
   return singleton.get();
 }


### PR DESCRIPTION
Initialization order of module globals is undefined.
    
In a particular case, the IO thread pool would first be instantiated at library load, registering an at-fork handler.
Then, only after, the at-fork handlers would be initialized, losing the handler registered just before.
