### PR TITLE
ARROW-18397: [C++] Clear S3 region resolver client at S3 shutdown

### DIFF
--- a/ci/conda_env_cpp.txt
+++ b/ci/conda_env_cpp.txt
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-aws-sdk-cpp=1.9.379
+aws-sdk-cpp=1.10.13
 benchmark>=1.6.0
 boost-cpp>=1.68.0
 brotli

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -336,9 +336,17 @@ Status InitializeS3(const S3GlobalOptions& options);
 ARROW_EXPORT
 Status EnsureS3Initialized();
 
+/// Whether S3 was initialized, and not finalized.
+ARROW_EXPORT
+bool IsS3Initialized();
+
 /// Shutdown the S3 APIs.
 ARROW_EXPORT
 Status FinalizeS3();
+
+/// Ensure the S3 APIs are shutdown, but only if not already done.
+ARROW_EXPORT
+Status EnsureS3Finalized();
 
 ARROW_EXPORT
 Result<std::string> ResolveS3BucketRegion(const std::string& bucket);


### PR DESCRIPTION
This should hopefully suppress a failed assertion on recent AWS SDK versions.

See https://github.com/aws/aws-sdk-cpp/issues/2204 for upstream issue report.