### PR TITLE
MINOR: [Developer] Add triage users

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,6 +18,10 @@
 github:
   description: "Apache Arrow is a multi-language toolbox for accelerated data interchange and in-memory processing"
   homepage: https://arrow.apache.org/
+  collaborators:
+    - assignUser
+    - raulcd
+    - toddfarmer
 
 notifications:
   commits:      commits@arrow.apache.org


### PR DESCRIPTION
This PR adds @raulcd @toddfarmer and me as "triage users" ([INFRA docs](https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features#Git.asf.yamlfeatures-AssigningexternalcollaboratorswiththetriageroleonGitHub)). This gives us permissions to manage issues.  

@toddfarmer has been spearheading the JIRA -> Github migration and @raulcd and me will need to work on the release and merge scripts to adapt them to the migration.