### PR TITLE
ARROW-18113: [C++] Add RandomAccessFile::ReadManyAsync

### DIFF
--- a/cpp/src/arrow/io/file_test.cc
+++ b/cpp/src/arrow/io/file_test.cc
@@ -387,6 +387,26 @@ TEST_F(TestReadableFile, ReadAsync) {
   AssertBufferEqual(*buf2, "test");
 }
 
+TEST_F(TestReadableFile, ReadManyAsync) {
+  MakeTestFile();
+  OpenFile();
+
+  std::vector<ReadRange> ranges = {
+    {1, 3},
+    {2, 5},
+    {4, 2}
+  };
+
+  auto futs = file_->ReadManyAsync(std::move(ranges));
+  ASSERT_EQ(futs.size(), 3);
+  ASSERT_OK_AND_ASSIGN(auto buf1, futs[0].result());
+  ASSERT_OK_AND_ASSIGN(auto buf2, futs[1].result());
+  ASSERT_OK_AND_ASSIGN(auto buf3, futs[2].result());
+  AssertBufferEqual(*buf1, "est");
+  AssertBufferEqual(*buf2, "stdat");
+  AssertBufferEqual(*buf3, "da");
+}
+
 TEST_F(TestReadableFile, SeekingRequired) {
   MakeTestFile();
   OpenFile();

--- a/cpp/src/arrow/io/file_test.cc
+++ b/cpp/src/arrow/io/file_test.cc
@@ -391,13 +391,9 @@ TEST_F(TestReadableFile, ReadManyAsync) {
   MakeTestFile();
   OpenFile();
 
-  std::vector<ReadRange> ranges = {
-    {1, 3},
-    {2, 5},
-    {4, 2}
-  };
-
+  std::vector<ReadRange> ranges = {{1, 3}, {2, 5}, {4, 2}};
   auto futs = file_->ReadManyAsync(std::move(ranges));
+
   ASSERT_EQ(futs.size(), 3);
   ASSERT_OK_AND_ASSIGN(auto buf1, futs[0].result());
   ASSERT_OK_AND_ASSIGN(auto buf2, futs[1].result());

--- a/cpp/src/arrow/io/interfaces.cc
+++ b/cpp/src/arrow/io/interfaces.cc
@@ -176,10 +176,10 @@ Future<std::shared_ptr<Buffer>> RandomAccessFile::ReadAsync(int64_t position,
 }
 
 std::vector<Future<std::shared_ptr<Buffer>>> RandomAccessFile::ReadManyAsync(
-    const IOContext&, const std::vector<ReadRange>& ranges) {
+    const IOContext& ctx, const std::vector<ReadRange>& ranges) {
   std::vector<Future<std::shared_ptr<Buffer>>> ret;
   for (auto r : ranges) {
-    ret.push_back(this->ReadAsync(r.offset, r.length));
+    ret.push_back(this->ReadAsync(ctx, r.offset, r.length));
   }
   return ret;
 }

--- a/cpp/src/arrow/io/interfaces.cc
+++ b/cpp/src/arrow/io/interfaces.cc
@@ -175,6 +175,20 @@ Future<std::shared_ptr<Buffer>> RandomAccessFile::ReadAsync(int64_t position,
   return ReadAsync(io_context(), position, nbytes);
 }
 
+std::vector<Future<std::shared_ptr<Buffer>>> RandomAccessFile::ReadManyAsync(
+    const IOContext&, const std::vector<ReadRange>& ranges) {
+  std::vector<Future<std::shared_ptr<Buffer>>> ret;
+  for (auto r : ranges) {
+    ret.push_back(this->ReadAsync(r.offset, r.length));
+  }
+  return ret;
+}
+
+std::vector<Future<std::shared_ptr<Buffer>>> RandomAccessFile::ReadManyAsync(
+    const std::vector<ReadRange>& ranges) {
+  return ReadManyAsync(io_context(), ranges);
+}
+
 // Default WillNeed() implementation: no-op
 Status RandomAccessFile::WillNeed(const std::vector<ReadRange>& ranges) {
   return Status::OK();

--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -305,6 +305,27 @@ class ARROW_EXPORT RandomAccessFile : public InputStream, public Seekable {
   /// EXPERIMENTAL: Read data asynchronously, using the file's IOContext.
   Future<std::shared_ptr<Buffer>> ReadAsync(int64_t position, int64_t nbytes);
 
+  /// EXPERIMENTAL: Explicit multi-read.
+  /// \brief Request multiple reads at once
+  ///
+  /// The underlying filesystem may optimize these reads by coalescing small reads into
+  /// large reads or by breaking up large reads into multiple parallel smaller reads.  The
+  /// reads should be issued in parallel if it makes sense for the filesystem.
+  ///
+  /// One future will be returned for each input read range.  Multiple returned futures
+  /// may correspond to a single read.  Or, a single returned future may be a combined
+  /// result of several individual reads.
+  ///
+  /// \param[in] ranges The ranges to read
+  /// \return A future that will complete with the data from the requested range is
+  /// available
+  virtual std::vector<Future<std::shared_ptr<Buffer>>> ReadManyAsync(
+     const IOContext&, const std::vector<ReadRange>& ranges);
+
+  /// EXPERIMENTAL: Explicit multi-read, using the file's IOContext.
+  std::vector<Future<std::shared_ptr<Buffer>>> ReadManyAsync(
+     const std::vector<ReadRange>& ranges);
+
   /// EXPERIMENTAL: Inform that the given ranges may be read soon.
   ///
   /// Some implementations might arrange to prefetch some of the data.

--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -320,11 +320,11 @@ class ARROW_EXPORT RandomAccessFile : public InputStream, public Seekable {
   /// \return A future that will complete with the data from the requested range is
   /// available
   virtual std::vector<Future<std::shared_ptr<Buffer>>> ReadManyAsync(
-     const IOContext&, const std::vector<ReadRange>& ranges);
+      const IOContext&, const std::vector<ReadRange>& ranges);
 
   /// EXPERIMENTAL: Explicit multi-read, using the file's IOContext.
   std::vector<Future<std::shared_ptr<Buffer>>> ReadManyAsync(
-     const std::vector<ReadRange>& ranges);
+      const std::vector<ReadRange>& ranges);
 
   /// EXPERIMENTAL: Inform that the given ranges may be read soon.
   ///


### PR DESCRIPTION
This PR adds the new method `RandomAccessFile::ReadManyAsync`: to perform asynchronously multiple reads at once.
The idea for this PR is to provide the new method with its default implementation (which is simply iterating over all the ranges).
The next PRs, will provide specific implementations using coalescing (`internal::CoalesceReadRanges`) for the some `io::RandomAccessFile` concrete classes (e.g. the cloud ones and perhaps the CUDA buffer reader as well).

Related Jira ticket:
https://issues.apache.org/jira/browse/ARROW-18113