### PR TITLE
MINOR: [Archery] Add collaborators to list of roles with access to trigger bot tasks

### DIFF
--- a/dev/archery/archery/bot.py
+++ b/dev/archery/archery/bot.py
@@ -143,7 +143,7 @@ class CommentBot:
             # https://developer.github.com/v4/enum/commentauthorassociation/
             # Checking  privileges here enables the bot to respond
             # without relying on the handler.
-            allowed_roles = {'OWNER', 'MEMBER', 'CONTRIBUTOR'}
+            allowed_roles = {'OWNER', 'MEMBER', 'CONTRIBUTOR', 'COLLABORATOR'}
             if payload['comment']['author_association'] not in allowed_roles:
                 raise EventError(
                     "Only contributors can submit requests to this bot. "


### PR DESCRIPTION
I've been added as triager but now if I try to trigger crossbow tasks they fail with permissions issues:
https://github.com/apache/arrow/pull/14715#issuecomment-1326243342
```
Only contributors can submit requests to this bot. Please ask someone from the community for help with getting the first commit in.
The Archery job run can be found at: https://github.com/apache/arrow/actions/runs/3539688563
```
This should fix the issue