### PR TITLE
ARROW-18380: [Dev] Update dev_pr GitHub workflows to accept both GitHub issues and JIRA

### DIFF
--- a/.github/workflows/dev_pr.yml
+++ b/.github/workflows/dev_pr.yml
@@ -36,6 +36,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
   
 jobs:
   process:

--- a/.github/workflows/dev_pr.yml
+++ b/.github/workflows/dev_pr.yml
@@ -66,7 +66,7 @@ jobs:
             const script = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/dev_pr/title_check.js`);
             script({github, context});
 
-      - name: Check Jira Issue
+      - name: Check Issue
         if: |
           (github.event.action == 'opened' ||
            github.event.action == 'edited')
@@ -75,7 +75,7 @@ jobs:
           debug: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const script = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/dev_pr/jira_check.js`);
+            const script = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/dev_pr/issue_check.js`);
             script({github, context});
 
       - name: Assign GitHub labels

--- a/.github/workflows/dev_pr/helpers.js
+++ b/.github/workflows/dev_pr/helpers.js
@@ -18,37 +18,33 @@
 const https = require('https');
 
 /**
- * Given the title of a PullRequest return the ID of the JIRA or GitHub issue
+ * Given the title of a PullRequest return the Issue
+ *
  * @param {String} title 
- * @returns {String} the ID of the associated JIRA or GitHub issue
+ * @returns {Issue} or null if no issue detected.
+ *
+ * @typedef {Object} Issue
+ * @property {string} kind - The kind of issue: minor, jira or github
+ * @property {string} id   - The id of the issue:
+ *                            ARROW-XXXX, PARQUET-XXXX for jira
+ *                            The numeric issue id for github
  */
-function detectIssueID(title) {
+function detectIssue(title) {
     if (!title) {
         return null;
     }
-    const matched = /^(WIP:?\s*)?((ARROW|PARQUET)-\d+)/.exec(title);
+    if (title.startsWith("MINOR: ")) {
+        return {"kind": "minor"};
+    }
+    const matched_jira = /^(WIP:?\s*)?((ARROW|PARQUET)-\d+)/.exec(title);
+    if (matched_jira) {
+        return {"kind": "jira", "id": matched_jira[2]};
+    }
     const matched_gh = /^(WIP:?\s*)?(GH-)(\d+)/.exec(title);
-    if (matched) {
-        return matched[2];
-    } else if (matched_gh) {
-        return matched_gh[3]
+    if (matched_gh) {
+        return {"kind": "github", "id": matched_gh[3]};
     }
     return null;
-}
-
-/**
- * Given the title of a PullRequest checks if it contains a JIRA issue ID
- * @param {String} title 
- * @returns {Boolean} true if it starts with a JIRA ID or MINOR:
- */
-function haveJIRAID(title) {
-    if (!title) {
-      return false;
-    }
-    if (title.startsWith("MINOR: ")) {
-      return true;
-    }
-    return /^(WIP:?\s*)?(ARROW|PARQUET)-\d+/.test(title);
 }
 
 /**
@@ -91,25 +87,8 @@ async function getJiraInfo(jiraID) {
     }
 }
 
-/**
- * Given the title of a PullRequest checks if it contains a GitHub issue ID
- * @param {String} title
- * @returns {Boolean} true if title starts with a GitHub ID or MINOR:
- */
- function haveGitHubIssueID(title) {
-    if (!title) {
-      return false;
-    }
-    if (title.startsWith("MINOR: ")) {
-      return true;
-    }
-    return /^(WIP:?\s*)?(GH)-\d+/.test(title);
-}
-
 module.exports = {
-    detectIssueID,
-    haveJIRAID,
+    detectIssue,
     getJiraInfo,
-    haveGitHubIssueID,
     getGitHubInfo
 };

--- a/.github/workflows/dev_pr/helpers.js
+++ b/.github/workflows/dev_pr/helpers.js
@@ -40,9 +40,9 @@ function detectIssue(title) {
     if (matched_jira) {
         return {"kind": "jira", "id": matched_jira[2]};
     }
-    const matched_gh = /^(WIP:?\s*)?(GH-)(\d+)/.exec(title);
+    const matched_gh = /^(WIP:?\s*)?GH-(\d+)/.exec(title);
     if (matched_gh) {
-        return {"kind": "github", "id": matched_gh[3]};
+        return {"kind": "github", "id": matched_gh[2]};
     }
     return null;
 }

--- a/.github/workflows/dev_pr/issue_check.js
+++ b/.github/workflows/dev_pr/issue_check.js
@@ -138,24 +138,23 @@ async function assignGitHubIssue(github, context, pullRequestNumber, issueInfo) 
  */
 async function verifyGitHubIssue(github, context, pullRequestNumber, issueID) {
     const issueInfo = await helpers.getGitHubInfo(github, context, issueID, pullRequestNumber);
-    if (issueInfo) {
-        if (!issueInfo.assignees.length) {
-            await assignGitHubIssue(github, context, pullRequestNumber, issueInfo);
-        }
-        if(!issueInfo.labels.length) {
-            await github.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pullRequestNumber,
-                body: ":warning: GitHub issue #" + issueID + " **has no labels in GitHub**, please add labels for components."
-            })
-        }
-    } else {
+    if (!issueInfo) {
         await github.issues.createComment({
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: pullRequestNumber,
             body: ":x: GitHub issue #" + issueID + " could not be retrieved."
+        })
+    }
+    if (!issueInfo.assignees.length) {
+        await assignGitHubIssue(github, context, pullRequestNumber, issueInfo);
+    }
+    if(!issueInfo.labels.filter((label) => label.startsWith("Component:")).length) {
+        await github.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: pullRequestNumber,
+            body: ":warning: GitHub issue #" + issueID + " **has no components**, please add labels for components."
         })
     }
 }

--- a/.github/workflows/dev_pr/issue_check.js
+++ b/.github/workflows/dev_pr/issue_check.js
@@ -41,7 +41,7 @@ async function verifyJIRAIssue(github, context, pullRequestNumber, jiraID) {
 }
 
 /**
- * Adds a comment to add components ticket in JIRA.
+ * Adds a comment to add components on the JIRA ticket.
  *
  * @param {Object} github
  * @param {Object} context
@@ -72,7 +72,7 @@ async function commentMissingComponents(github, context, pullRequestNumber) {
 }
 
 /**
- * Adds a comment to start ticket in JIRA.
+ * Adds a comment to start the ticket in JIRA.
  *
  * @param {Object} github
  * @param {Object} context

--- a/.github/workflows/dev_pr/issue_check.js
+++ b/.github/workflows/dev_pr/issue_check.js
@@ -17,6 +17,16 @@
 
 const helpers = require("./helpers.js");
 
+/**
+ * Performs checks on the JIRA Issue:
+ * - The issue is started in JIRA.
+ * - The issue contains components.
+ *
+ * @param {Object} github
+ * @param {Object} context
+ * @param {String} pullRequestNumber
+ * @param {String} jiraID
+ */
 async function verifyJIRAIssue(github, context, pullRequestNumber, jiraID) {
     const ticketInfo = await helpers.getJiraInfo(jiraID);
     if(!ticketInfo["fields"]["components"].length) {
@@ -30,6 +40,13 @@ async function verifyJIRAIssue(github, context, pullRequestNumber, jiraID) {
     }
 }
 
+/**
+ * Adds a comment to add components ticket in JIRA.
+ *
+ * @param {Object} github
+ * @param {Object} context
+ * @param {String} pullRequestNumber
+ */
 async function commentMissingComponents(github, context, pullRequestNumber) {
     const {data: comments} = await github.issues.listComments({
         owner: context.repo.owner,
@@ -54,6 +71,13 @@ async function commentMissingComponents(github, context, pullRequestNumber) {
     }
 }
 
+/**
+ * Adds a comment to start ticket in JIRA.
+ *
+ * @param {Object} github
+ * @param {Object} context
+ * @param {String} pullRequestNumber
+ */
 async function commentNotStartedTicket(github, context, pullRequestNumber) {
     const {data: comments} = await github.issues.listComments({
         owner: context.repo.owner,
@@ -78,6 +102,14 @@ async function commentNotStartedTicket(github, context, pullRequestNumber) {
     }
 }
 
+/**
+ * Assigns the Github Issue to the PR creator.
+ *
+ * @param {Object} github
+ * @param {Object} context
+ * @param {String} pullRequestNumber
+ * @param {Object} issueInfo
+ */
 async function assignGitHubIssue(github, context, pullRequestNumber, issueInfo) {
     await github.issues.addAssignees({
         owner: context.repo.owner,
@@ -93,6 +125,17 @@ async function assignGitHubIssue(github, context, pullRequestNumber, issueInfo) 
     });
 }
 
+/**
+ * Performs checks on the GitHub Issue:
+ * - The issue is assigned to someone. If not assign it gets automatically
+ *   assigned to the PR creator.
+ * - The issue contains any label.
+ *
+ * @param {Object} github
+ * @param {Object} context
+ * @param {String} pullRequestNumber
+ * @param {String} issueID
+ */
 async function verifyGitHubIssue(github, context, pullRequestNumber, issueID) {
     const issueInfo = await helpers.getGitHubInfo(github, context, issueID, pullRequestNumber);
     if (issueInfo) {

--- a/.github/workflows/dev_pr/issue_check.js
+++ b/.github/workflows/dev_pr/issue_check.js
@@ -149,7 +149,7 @@ async function verifyGitHubIssue(github, context, pullRequestNumber, issueID) {
     if (!issueInfo.assignees.length) {
         await assignGitHubIssue(github, context, pullRequestNumber, issueInfo);
     }
-    if(!issueInfo.labels.filter((label) => label.startsWith("Component:")).length) {
+    if(!issueInfo.labels.filter((label) => label.name.startsWith("Component:")).length) {
         await github.issues.createComment({
             owner: context.repo.owner,
             repo: context.repo.repo,

--- a/.github/workflows/dev_pr/link.js
+++ b/.github/workflows/dev_pr/link.js
@@ -54,16 +54,16 @@ async function commentJIRAURL(github, context, pullRequestNumber, jiraID) {
 async function commentGitHubURL(github, context, pullRequestNumber, issueID) {
   // Make the call to ensure issue exists before adding comment
   const issueInfo = await helpers.getGitHubInfo(github, context, issueID, pullRequestNumber);
-  // TODO: Check if comment is already there
-  //if (await haveComment(github, context, pullRequestNumber, jiraURL)) {
-  //  return;
-  //}
+  const message = "* Github Issue: #" + issueInfo.number
+  if (await haveComment(github, context, pullRequestNumber, message)) {
+    return;
+  }
   if (issueInfo){
     await github.issues.createComment({
       owner: context.repo.owner,
       repo: context.repo.repo,
       issue_number: pullRequestNumber,
-      body: "* Github Issue: #" + issueInfo.number
+      body: message
     });
   }
 }

--- a/.github/workflows/dev_pr/link.js
+++ b/.github/workflows/dev_pr/link.js
@@ -56,16 +56,19 @@ async function haveComment(github, context, pullRequestNumber, message) {
  * @param {String} jiraID
  */
 async function commentJIRAURL(github, context, pullRequestNumber, jiraID) {
+  const issueInfo = await helpers.getJiraInfo(jiraID);
   const jiraURL = `https://issues.apache.org/jira/browse/${jiraID}`;
   if (await haveComment(github, context, pullRequestNumber, jiraURL)) {
     return;
   }
-  await github.issues.createComment({
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    issue_number: pullRequestNumber,
-    body: jiraURL
-  });
+  if (issueInfo){
+    await github.issues.createComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: pullRequestNumber,
+      body: jiraURL
+    });
+  }
 }
 
 /**

--- a/.github/workflows/dev_pr/link.js
+++ b/.github/workflows/dev_pr/link.js
@@ -18,7 +18,16 @@
 const helpers = require("./helpers.js");
 
 
-async function haveComment(github, context, pullRequestNumber, body) {
+/**
+ * Checks whether message is present on Pull Request list of comments.
+ *
+ * @param {Object} github
+ * @param {Object} context
+ * @param {String} pullRequestNumber
+ * @param {String} message
+ * @returns {Boolean} true if message was found.
+ */
+async function haveComment(github, context, pullRequestNumber, message) {
   const options = {
     owner: context.repo.owner,
     repo: context.repo.repo,
@@ -27,7 +36,7 @@ async function haveComment(github, context, pullRequestNumber, body) {
   };
   while (true) {
     const response = await github.issues.listComments(options);
-    if (response.data.some(comment => comment.body === body)) {
+    if (response.data.some(comment => comment.body === message)) {
       return true;
     }
     if (!/;\s*rel="next"/.test(response.headers.link || "")) {
@@ -38,6 +47,14 @@ async function haveComment(github, context, pullRequestNumber, body) {
   return false;
 }
 
+/**
+ * Adds a comment on the Pull Request linking the JIRA issue.
+ *
+ * @param {Object} github
+ * @param {Object} context
+ * @param {String} pullRequestNumber
+ * @param {String} jiraID
+ */
 async function commentJIRAURL(github, context, pullRequestNumber, jiraID) {
   const jiraURL = `https://issues.apache.org/jira/browse/${jiraID}`;
   if (await haveComment(github, context, pullRequestNumber, jiraURL)) {
@@ -51,6 +68,14 @@ async function commentJIRAURL(github, context, pullRequestNumber, jiraID) {
   });
 }
 
+/**
+ * Adds a comment on the Pull Request linking the GitHub issue.
+ *
+ * @param {Object} github
+ * @param {Object} context
+ * @param {String} pullRequestNumber - String containing numeric id of PR
+ * @param {String} issueID - String containing numeric id of the github issue
+ */
 async function commentGitHubURL(github, context, pullRequestNumber, issueID) {
   // Make the call to ensure issue exists before adding comment
   const issueInfo = await helpers.getGitHubInfo(github, context, issueID, pullRequestNumber);
@@ -71,10 +96,12 @@ async function commentGitHubURL(github, context, pullRequestNumber, issueID) {
 module.exports = async ({github, context}) => {
   const pullRequestNumber = context.payload.number;
   const title = context.payload.pull_request.title;
-  const issueID = helpers.detectIssueID(title);
-  if (helpers.haveJIRAID(title)) {
-    await commentJIRAURL(github, context, pullRequestNumber, issueID);
-  } else if (helpers.haveGitHubIssueID(title)) {
-    await commentGitHubURL(github, context, pullRequestNumber, issueID);
+  const issue = helpers.detectIssue(title);
+  if (issue){
+    if (issue.kind == "jira") {
+      await commentJIRAURL(github, context, pullRequestNumber, issue.id);
+    } else if (issue.kind == "github") {
+      await commentGitHubURL(github, context, pullRequestNumber, issue.id);
+    }
   }
 };

--- a/.github/workflows/dev_pr/link.js
+++ b/.github/workflows/dev_pr/link.js
@@ -51,11 +51,30 @@ async function commentJIRAURL(github, context, pullRequestNumber, jiraID) {
   });
 }
 
+async function commentGitHubURL(github, context, pullRequestNumber, issueID) {
+  // Make the call to ensure issue exists before adding comment
+  const issueInfo = await helpers.getGitHubInfo(github, context, issueID, pullRequestNumber);
+  // TODO: Check if comment is already there
+  //if (await haveComment(github, context, pullRequestNumber, jiraURL)) {
+  //  return;
+  //}
+  if (issueInfo){
+    await github.issues.createComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: pullRequestNumber,
+      body: "* Github Issue: #" + issueInfo.number
+    });
+  }
+}
+
 module.exports = async ({github, context}) => {
   const pullRequestNumber = context.payload.number;
   const title = context.payload.pull_request.title;
-  const jiraID = helpers.detectJIRAID(title);
-  if (jiraID) {
-    await commentJIRAURL(github, context, pullRequestNumber, jiraID);
+  const issueID = helpers.detectIssueID(title);
+  if (helpers.haveJIRAID(title)) {
+    await commentJIRAURL(github, context, pullRequestNumber, issueID);
+  } else if (helpers.haveGitHubIssueID(title)) {
+    await commentGitHubURL(github, context, pullRequestNumber, issueID);
   }
 };

--- a/.github/workflows/dev_pr/title_check.js
+++ b/.github/workflows/dev_pr/title_check.js
@@ -41,7 +41,8 @@ async function commentOpenGitHubIssue(github, context, pullRequestNumber) {
 module.exports = async ({github, context}) => {
   const pullRequestNumber = context.payload.number;
   const title = context.payload.pull_request.title;
-  if (!helpers.haveJIRAID(title) || !helpers.haveGitHubIssueID(title)) {
+  const issue = helpers.detectIssue(title)
+  if (!issue) {
     await commentOpenGitHubIssue(github, context, pullRequestNumber);
   }
 };

--- a/.github/workflows/dev_pr/title_check.js
+++ b/.github/workflows/dev_pr/title_check.js
@@ -18,7 +18,7 @@
 const fs = require("fs");
 const helpers = require("./helpers.js");
 
-async function commentOpenJIRAIssue(github, context, pullRequestNumber) {
+async function commentOpenGitHubIssue(github, context, pullRequestNumber) {
   const {data: comments} = await github.issues.listComments({
     owner: context.repo.owner,
     repo: context.repo.repo,
@@ -41,7 +41,7 @@ async function commentOpenJIRAIssue(github, context, pullRequestNumber) {
 module.exports = async ({github, context}) => {
   const pullRequestNumber = context.payload.number;
   const title = context.payload.pull_request.title;
-  if (!helpers.haveJIRAID(title)) {
-    await commentOpenJIRAIssue(github, context, pullRequestNumber);
+  if (!helpers.haveJIRAID(title) || !helpers.haveGitHubIssueID(title)) {
+    await commentOpenGitHubIssue(github, context, pullRequestNumber);
   }
 };

--- a/.github/workflows/dev_pr/title_check.md
+++ b/.github/workflows/dev_pr/title_check.md
@@ -34,6 +34,7 @@ or
 In the case of old issues on JIRA the title also supports:
 
     ARROW-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}
+    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}
 
 See also:
 

--- a/.github/workflows/dev_pr/title_check.md
+++ b/.github/workflows/dev_pr/title_check.md
@@ -19,17 +19,21 @@
 
 Thanks for opening a pull request!
 
-If this is not a [minor PR](https://github.com/apache/arrow/blob/master/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on JIRA? https://issues.apache.org/jira/browse/ARROW
+If this is not a [minor PR](https://github.com/apache/arrow/blob/master/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose
 
-Opening JIRAs ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.
+Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.
 
-Then could you also rename pull request title in the following format?
+Then could you also rename the pull request title in the following format?
 
-    ARROW-${JIRA_ID}: [${COMPONENT}] ${SUMMARY}
+    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}
 
 or
 
     MINOR: [${COMPONENT}] ${SUMMARY}
+
+In the case of old issues on JIRA the title also supports:
+
+    ARROW-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}
 
 See also:
 


### PR DESCRIPTION
This might require to be done once the merge_arrow_pr.sh script is also updated. Updating the merge PR script is tracked on GitHub for the migration here: #14720 

I have tested this new workflow on my fork with the following PRs and issues on my fork.
Example of valid issue: https://github.com/raulcd/arrow/pull/41
Example of issues without labels or assignees: https://github.com/raulcd/arrow/pull/42 or https://github.com/raulcd/arrow/pull/43
Example of issue with non existent GH issue: https://github.com/raulcd/arrow/pull/45