### PR TITLE
ARROW-18409: [GLib][Plasma] Suppress deprecated warning in building plasma-glib

### DIFF
--- a/c_glib/plasma-glib/meson.build
+++ b/c_glib/plasma-glib/meson.build
@@ -49,6 +49,7 @@ dependencies = [
 ]
 cpp_args = [
   '-DG_LOG_DOMAIN="Plasma"',
+  '-D_PLASMA_NO_DEPRECATE',
 ]
 pkg_config_requires = [
   'plasma',


### PR DESCRIPTION
If we always get "Plasma is deprecated since Arrow 10.0.0. ..." warning from plasma/common.h, we can't use -Dwerror=true Meson option with plama-glib.