### PR TITLE
ARROW-18106: [C++] JSON reader ignores explicit schema with default unexpected_field_behavior="infer"

### DIFF
--- a/cpp/src/arrow/json/chunked_builder.cc
+++ b/cpp/src/arrow/json/chunked_builder.cc
@@ -37,6 +37,7 @@ using internal::checked_cast;
 using internal::TaskGroup;
 
 namespace json {
+namespace {
 
 Status MakeChunkedArrayBuilder(const std::shared_ptr<TaskGroup>& task_group,
                                MemoryPool* pool, const PromotionGraph* promotion_graph,
@@ -484,6 +485,11 @@ Status MakeChunkedArrayBuilder(const std::shared_ptr<TaskGroup>& task_group,
   return Status::OK();
 }
 
+}  // namespace
+
+// This overload is exposed to the user and will only be called once on instantiation to
+// canonicalize any explicitly-defined fields. Such fields won't be subject to
+// type inference/promotion
 Status MakeChunkedArrayBuilder(const std::shared_ptr<TaskGroup>& task_group,
                                MemoryPool* pool, const PromotionGraph* promotion_graph,
                                const std::shared_ptr<DataType>& type,

--- a/cpp/src/arrow/json/chunked_builder.cc
+++ b/cpp/src/arrow/json/chunked_builder.cc
@@ -38,6 +38,12 @@ using internal::TaskGroup;
 
 namespace json {
 
+Status MakeChunkedArrayBuilder(const std::shared_ptr<TaskGroup>& task_group,
+                               MemoryPool* pool, const PromotionGraph* promotion_graph,
+                               const std::shared_ptr<DataType>& type,
+                               bool allow_promotion,
+                               std::shared_ptr<ChunkedArrayBuilder>* out);
+
 class NonNestedChunkedArrayBuilder : public ChunkedArrayBuilder {
  public:
   NonNestedChunkedArrayBuilder(const std::shared_ptr<TaskGroup>& task_group,
@@ -404,7 +410,7 @@ class ChunkedStructArrayBuilder : public ChunkedArrayBuilder {
 
         std::shared_ptr<ChunkedArrayBuilder> child_builder;
         RETURN_NOT_OK(MakeChunkedArrayBuilder(task_group_, pool_, promotion_graph_, type,
-                                              &child_builder));
+                                              /*allow_promotion=*/true, &child_builder));
         child_builders_.emplace_back(std::move(child_builder));
       }
 
@@ -432,14 +438,23 @@ class ChunkedStructArrayBuilder : public ChunkedArrayBuilder {
 Status MakeChunkedArrayBuilder(const std::shared_ptr<TaskGroup>& task_group,
                                MemoryPool* pool, const PromotionGraph* promotion_graph,
                                const std::shared_ptr<DataType>& type,
+                               bool allow_promotion,
                                std::shared_ptr<ChunkedArrayBuilder>* out) {
+  // If a promotion graph is provided, unexpected fields will be allowed - using the graph
+  // recursively for itself and any child fields (via the `allow_promotion` parameter).
+  // Fields provided in the schema will adhere to their corresponding type. However,
+  // structs defined in the schema may obtain unexpected child fields, which will use the
+  // promotion graph as well.
+  //
+  // If a promotion graph is not provided, unexpected fields are always ignored and
+  // type inference never occurs.
   if (type->id() == Type::STRUCT) {
     std::vector<std::pair<std::string, std::shared_ptr<ChunkedArrayBuilder>>>
         child_builders;
     for (const auto& f : type->fields()) {
       std::shared_ptr<ChunkedArrayBuilder> child_builder;
       RETURN_NOT_OK(MakeChunkedArrayBuilder(task_group, pool, promotion_graph, f->type(),
-                                            &child_builder));
+                                            allow_promotion, &child_builder));
       child_builders.emplace_back(f->name(), std::move(child_builder));
     }
     *out = std::make_shared<ChunkedStructArrayBuilder>(task_group, pool, promotion_graph,
@@ -450,20 +465,31 @@ Status MakeChunkedArrayBuilder(const std::shared_ptr<TaskGroup>& task_group,
     const auto& list_type = checked_cast<const ListType&>(*type);
     std::shared_ptr<ChunkedArrayBuilder> value_builder;
     RETURN_NOT_OK(MakeChunkedArrayBuilder(task_group, pool, promotion_graph,
-                                          list_type.value_type(), &value_builder));
+                                          list_type.value_type(), allow_promotion,
+                                          &value_builder));
     *out = std::make_shared<ChunkedListArrayBuilder>(
         task_group, pool, std::move(value_builder), list_type.value_field());
     return Status::OK();
   }
+
+  // Construct the "leaf" builder
   std::shared_ptr<Converter> converter;
   RETURN_NOT_OK(MakeConverter(type, pool, &converter));
-  if (promotion_graph) {
+  if (allow_promotion && promotion_graph) {
     *out = std::make_shared<InferringChunkedArrayBuilder>(task_group, promotion_graph,
                                                           std::move(converter));
   } else {
     *out = std::make_shared<TypedChunkedArrayBuilder>(task_group, std::move(converter));
   }
   return Status::OK();
+}
+
+Status MakeChunkedArrayBuilder(const std::shared_ptr<TaskGroup>& task_group,
+                               MemoryPool* pool, const PromotionGraph* promotion_graph,
+                               const std::shared_ptr<DataType>& type,
+                               std::shared_ptr<ChunkedArrayBuilder>* out) {
+  return MakeChunkedArrayBuilder(task_group, pool, promotion_graph, type,
+                                 /*allow_promotion=*/false, out);
 }
 
 }  // namespace json

--- a/cpp/src/arrow/json/converter.cc
+++ b/cpp/src/arrow/json/converter.cc
@@ -42,8 +42,7 @@ namespace json {
 
 template <typename... Args>
 Status GenericConversionError(const DataType& type, Args&&... args) {
-  return Status::Invalid("Failed of conversion of JSON to ", type,
-                         std::forward<Args>(args)...);
+  return Status::Invalid("Failed to convert JSON to ", type, std::forward<Args>(args)...);
 }
 
 namespace {

--- a/cpp/src/arrow/json/converter_test.cc
+++ b/cpp/src/arrow/json/converter_test.cc
@@ -234,8 +234,7 @@ TEST(ConverterTest, Decimal128And256ScaleError) {
     std::shared_ptr<StructArray> parse_array;
     ASSERT_OK(ParseFromString(options, json_source, &parse_array));
 
-    std::string error_msg = "Failed of conversion of JSON to " +
-                            decimal_type->ToString() +
+    std::string error_msg = "Failed to convert JSON to " + decimal_type->ToString() +
                             ": 30.0123456789001 requires scale 13";
     EXPECT_RAISES_WITH_MESSAGE_THAT(
         Invalid, ::testing::HasSubstr(error_msg),
@@ -256,7 +255,7 @@ TEST(ConverterTest, Decimal128And256PrecisionError) {
     ASSERT_OK(ParseFromString(options, json_source, &parse_array));
 
     std::string error_msg =
-        "Invalid: Failed of conversion of JSON to " + decimal_type->ToString() +
+        "Invalid: Failed to convert JSON to " + decimal_type->ToString() +
         ": 123456789012345678901234567890.0123456789 requires precision 40";
     EXPECT_RAISES_WITH_MESSAGE_THAT(
         Invalid, ::testing::HasSubstr(error_msg),

--- a/cpp/src/arrow/json/reader_test.cc
+++ b/cpp/src/arrow/json/reader_test.cc
@@ -350,8 +350,7 @@ TEST(ReaderTest, FailOnTimeUnitMismatch) {
                         UnexpectedFieldBehavior::InferType}) {
     parse_options.unexpected_field_behavior = behavior;
     EXPECT_RAISES_WITH_MESSAGE_THAT(
-        Invalid,
-        ::testing::StartsWith("Invalid: Failed of conversion of JSON to timestamp[s]"),
+        Invalid, ::testing::StartsWith("Invalid: Failed to convert JSON to timestamp[s]"),
         ReadToTable(json, read_options, parse_options));
   }
 }
@@ -397,8 +396,7 @@ TEST(ReaderTest, InferNestedFieldsWithSchema) {
 
   json += std::string(R"({"a": {"b": "2022-09-05T08:08:46.000"}})") + "\n";
   EXPECT_RAISES_WITH_MESSAGE_THAT(
-      Invalid,
-      ::testing::StartsWith("Invalid: Failed of conversion of JSON to timestamp[s]"),
+      Invalid, ::testing::StartsWith("Invalid: Failed to convert JSON to timestamp[s]"),
       ReadToTable(json, read_options, parse_options));
 }
 
@@ -432,8 +430,7 @@ TEST(ReaderTest, InferNestedFieldsInListWithSchema) {
 
   json += std::string(R"({"a": [{"b": "2022-09-05T08:08:03.000", "c": {}}]})") + "\n";
   EXPECT_RAISES_WITH_MESSAGE_THAT(
-      Invalid,
-      ::testing::StartsWith("Invalid: Failed of conversion of JSON to timestamp[s]"),
+      Invalid, ::testing::StartsWith("Invalid: Failed to convert JSON to timestamp[s]"),
       ReadToTable(json, read_options, parse_options));
 }
 


### PR DESCRIPTION
See: [ARROW-18106](https://issues.apache.org/jira/browse/ARROW-18106)

The current `ChunkedArrayBuilder` always uses the promotion graph for type conversions if it's provided (even for fields in the explicit schema). The bug in question occurs because conversion errors aren't propagated in `InferringChunkedArrayBuilder`. Instead, it will attempt to promote the type on failure, which is undesirable in cases like this.

This PR doesn't change any of that. It only restricts type inference to unexpected fields while fields present in the schema remain "strongly-typed" - so conversion errors for expected fields will still be reported if `UnexpectedFieldBehavior::InferType` is specified.