### PR TITLE
ARROW-18413: [C++][Parquet] Expose page index info from ColumnChunkMetaData

### DIFF
--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -314,16 +314,14 @@ class ColumnChunkMetaData::ColumnChunkMetaDataImpl {
 
   inline std::optional<IndexLocation> GetColumIndexLocation() const {
     if (column_->__isset.column_index_offset && column_->__isset.column_index_length) {
-      return IndexLocation{.index_file_offset_bytes = column_->column_index_offset,
-                           .offset_index_length = column_->column_index_length};
+      return IndexLocation{column_->column_index_offset, column_->column_index_length};
     }
     return std::nullopt;
   }
 
   inline std::optional<IndexLocation> GetOffsetIndexLocation() const {
     if (column_->__isset.offset_index_offset && column_->__isset.offset_index_length) {
-      return IndexLocation{.index_file_offset_bytes = column_->offset_index_offset,
-                           .offset_index_length = column_->offset_index_length};
+      return IndexLocation{column_->offset_index_offset, column_->offset_index_length};
     }
     return std::nullopt;
   }

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -312,6 +312,22 @@ class ColumnChunkMetaData::ColumnChunkMetaDataImpl {
     }
   }
 
+  inline bool has_column_index() const {
+    return column_->__isset.column_index_offset && column_->__isset.column_index_length;
+  }
+
+  inline int64_t column_index_offset() const { return column_->column_index_offset; }
+
+  inline int32_t column_index_length() const { return column_->column_index_length; }
+
+  inline bool has_offset_index() const {
+    return column_->__isset.offset_index_offset && column_->__isset.offset_index_length;
+  }
+
+  inline int64_t offset_index_offset() const { return column_->offset_index_offset; }
+
+  inline int32_t offset_index_length() const { return column_->offset_index_length; }
+
  private:
   mutable std::shared_ptr<Statistics> possible_stats_;
   std::vector<Encoding::type> encodings_;
@@ -418,6 +434,26 @@ int64_t ColumnChunkMetaData::total_compressed_size() const {
 
 std::unique_ptr<ColumnCryptoMetaData> ColumnChunkMetaData::crypto_metadata() const {
   return impl_->crypto_metadata();
+}
+
+bool ColumnChunkMetaData::has_column_index() const { return impl_->has_column_index(); }
+
+int64_t ColumnChunkMetaData::column_index_offset() const {
+  return impl_->column_index_offset();
+}
+
+int32_t ColumnChunkMetaData::column_index_length() const {
+  return impl_->column_index_length();
+}
+
+bool ColumnChunkMetaData::has_offset_index() const { return impl_->has_offset_index(); }
+
+int64_t ColumnChunkMetaData::offset_index_offset() const {
+  return impl_->offset_index_offset();
+}
+
+int32_t ColumnChunkMetaData::offset_index_length() const {
+  return impl_->offset_index_length();
 }
 
 bool ColumnChunkMetaData::Equals(const ColumnChunkMetaData& other) const {

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -312,21 +312,21 @@ class ColumnChunkMetaData::ColumnChunkMetaDataImpl {
     }
   }
 
-  inline bool has_column_index() const {
-    return column_->__isset.column_index_offset && column_->__isset.column_index_length;
+  inline std::optional<IndexLocation> GetColumIndexLocation() const {
+    if (column_->__isset.column_index_offset && column_->__isset.column_index_length) {
+      return IndexLocation{.index_file_offset_bytes = column_->column_index_offset,
+                           .offset_index_length = column_->column_index_length};
+    }
+    return std::nullopt;
   }
 
-  inline int64_t column_index_offset() const { return column_->column_index_offset; }
-
-  inline int32_t column_index_length() const { return column_->column_index_length; }
-
-  inline bool has_offset_index() const {
-    return column_->__isset.offset_index_offset && column_->__isset.offset_index_length;
+  inline std::optional<IndexLocation> GetOffsetIndexLocation() const {
+    if (column_->__isset.offset_index_offset && column_->__isset.offset_index_length) {
+      return IndexLocation{.index_file_offset_bytes = column_->offset_index_offset,
+                           .offset_index_length = column_->offset_index_length};
+    }
+    return std::nullopt;
   }
-
-  inline int64_t offset_index_offset() const { return column_->offset_index_offset; }
-
-  inline int32_t offset_index_length() const { return column_->offset_index_length; }
 
  private:
   mutable std::shared_ptr<Statistics> possible_stats_;
@@ -436,24 +436,12 @@ std::unique_ptr<ColumnCryptoMetaData> ColumnChunkMetaData::crypto_metadata() con
   return impl_->crypto_metadata();
 }
 
-bool ColumnChunkMetaData::has_column_index() const { return impl_->has_column_index(); }
-
-int64_t ColumnChunkMetaData::column_index_offset() const {
-  return impl_->column_index_offset();
+std::optional<IndexLocation> ColumnChunkMetaData::GetColumIndexLocation() const {
+  return impl_->GetColumIndexLocation();
 }
 
-int32_t ColumnChunkMetaData::column_index_length() const {
-  return impl_->column_index_length();
-}
-
-bool ColumnChunkMetaData::has_offset_index() const { return impl_->has_offset_index(); }
-
-int64_t ColumnChunkMetaData::offset_index_offset() const {
-  return impl_->offset_index_offset();
-}
-
-int32_t ColumnChunkMetaData::offset_index_length() const {
-  return impl_->offset_index_length();
+std::optional<IndexLocation> ColumnChunkMetaData::GetOffsetIndexLocation() const {
+  return impl_->GetOffsetIndexLocation();
 }
 
 bool ColumnChunkMetaData::Equals(const ColumnChunkMetaData& other) const {

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -312,14 +312,14 @@ class ColumnChunkMetaData::ColumnChunkMetaDataImpl {
     }
   }
 
-  inline std::optional<IndexLocation> GetColumIndexLocation() const {
+  std::optional<IndexLocation> GetColumIndexLocation() const {
     if (column_->__isset.column_index_offset && column_->__isset.column_index_length) {
       return IndexLocation{column_->column_index_offset, column_->column_index_length};
     }
     return std::nullopt;
   }
 
-  inline std::optional<IndexLocation> GetOffsetIndexLocation() const {
+  std::optional<IndexLocation> GetOffsetIndexLocation() const {
     if (column_->__isset.offset_index_offset && column_->__isset.offset_index_length) {
       return IndexLocation{column_->offset_index_offset, column_->offset_index_length};
     }

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -118,6 +119,12 @@ struct PageEncodingStats {
   int32_t count;
 };
 
+/// \brief Public struct for location to page index in ColumnChunkMetaData.
+struct IndexLocation {
+  int64_t index_file_offset_bytes;
+  int32_t offset_index_length;
+};
+
 /// \brief ColumnChunkMetaData is a proxy around format::ColumnChunkMetaData.
 class PARQUET_EXPORT ColumnChunkMetaData {
  public:
@@ -170,13 +177,8 @@ class PARQUET_EXPORT ColumnChunkMetaData {
   int64_t total_compressed_size() const;
   int64_t total_uncompressed_size() const;
   std::unique_ptr<ColumnCryptoMetaData> crypto_metadata() const;
-
-  bool has_column_index() const;
-  int64_t column_index_offset() const;
-  int32_t column_index_length() const;
-  bool has_offset_index() const;
-  int64_t offset_index_offset() const;
-  int32_t offset_index_length() const;
+  std::optional<IndexLocation> GetColumIndexLocation() const;
+  std::optional<IndexLocation> GetOffsetIndexLocation() const;
 
  private:
   explicit ColumnChunkMetaData(

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -171,6 +171,13 @@ class PARQUET_EXPORT ColumnChunkMetaData {
   int64_t total_uncompressed_size() const;
   std::unique_ptr<ColumnCryptoMetaData> crypto_metadata() const;
 
+  bool has_column_index() const;
+  int64_t column_index_offset() const;
+  int32_t column_index_length() const;
+  bool has_offset_index() const;
+  int64_t offset_index_offset() const;
+  int32_t offset_index_length() const;
+
  private:
   explicit ColumnChunkMetaData(
       const void* metadata, const ColumnDescriptor* descr, int16_t row_group_ordinal,

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -121,8 +121,10 @@ struct PageEncodingStats {
 
 /// \brief Public struct for location to page index in ColumnChunkMetaData.
 struct IndexLocation {
-  int64_t index_file_offset_bytes;
-  int32_t offset_index_length;
+  /// File offset of the given index, in bytes
+  int64_t offset;
+  /// Length of the given index, in bytes
+  int32_t length;
 };
 
 /// \brief ColumnChunkMetaData is a proxy around format::ColumnChunkMetaData.

--- a/cpp/src/parquet/metadata_test.cc
+++ b/cpp/src/parquet/metadata_test.cc
@@ -27,8 +27,6 @@
 #include "parquet/thrift_internal.h"
 #include "parquet/types.h"
 
-#include <array>
-
 namespace parquet {
 
 namespace metadata {
@@ -304,35 +302,33 @@ TEST(Metadata, TestReadPageIndex) {
   ASSERT_EQ(1, file_metadata->num_row_groups());
   auto row_group_metadata = file_metadata->RowGroup(0);
   ASSERT_EQ(13, row_group_metadata->num_columns());
-  std::array<int64_t, 13> ci_offsets = {323583, 327502, 328009, 331928, 335847,
-                                        339766, 350345, 354264, 364843, 384342,
-                                        -1,     386473, 390392};
-  std::array<int32_t, 13> ci_lengths = {3919,  507,   3919, 3919, 3919, 10579, 3919,
-                                        10579, 19499, 2131, -1,   3919, 3919};
-  std::array<int64_t, 13> oi_offsets = {394311, 397814, 398637, 401888, 405139,
-                                        408390, 413670, 416921, 422201, 431936,
-                                        435457, 446002, 449253};
-  std::array<int32_t, 13> oi_lengths = {3503, 823,  3251, 3251,  3251, 5280, 3251,
-                                        5280, 9735, 3521, 10545, 3251, 3251};
+  std::vector<int64_t> ci_offsets = {323583, 327502, 328009, 331928, 335847,
+                                     339766, 350345, 354264, 364843, 384342,
+                                     -1,     386473, 390392};
+  std::vector<int32_t> ci_lengths = {3919,  507,   3919, 3919, 3919, 10579, 3919,
+                                     10579, 19499, 2131, -1,   3919, 3919};
+  std::vector<int64_t> oi_offsets = {394311, 397814, 398637, 401888, 405139,
+                                     408390, 413670, 416921, 422201, 431936,
+                                     435457, 446002, 449253};
+  std::vector<int32_t> oi_lengths = {3503, 823,  3251, 3251,  3251, 5280, 3251,
+                                     5280, 9735, 3521, 10545, 3251, 3251};
   for (int i = 0; i < row_group_metadata->num_columns(); ++i) {
     auto col_chunk_metadata = row_group_metadata->ColumnChunk(i);
-    auto ci_locaiton = col_chunk_metadata->GetColumIndexLocation();
+    auto ci_location = col_chunk_metadata->GetColumIndexLocation();
     if (i == 10) {
       // column_id 10 does not have column index
-      ASSERT_FALSE(ci_locaiton.has_value());
+      ASSERT_FALSE(ci_location.has_value());
     } else {
-      ASSERT_TRUE(ci_locaiton.has_value());
+      ASSERT_TRUE(ci_location.has_value());
     }
-    if (ci_locaiton.has_value()) {
-      ASSERT_EQ(ci_offsets.at(i), ci_locaiton->offset);
-      ASSERT_EQ(ci_lengths.at(i), ci_locaiton->length);
+    if (ci_location.has_value()) {
+      ASSERT_EQ(ci_offsets.at(i), ci_location->offset);
+      ASSERT_EQ(ci_lengths.at(i), ci_location->length);
     }
     auto oi_location = col_chunk_metadata->GetOffsetIndexLocation();
     ASSERT_TRUE(oi_location.has_value());
-    if (oi_location.has_value()) {
-      ASSERT_EQ(oi_offsets.at(i), oi_location->offset);
-      ASSERT_EQ(oi_lengths.at(i), oi_location->length);
-    }
+    ASSERT_EQ(oi_offsets.at(i), oi_location->offset);
+    ASSERT_EQ(oi_lengths.at(i), oi_location->length);
   }
 }
 

--- a/cpp/src/parquet/metadata_test.cc
+++ b/cpp/src/parquet/metadata_test.cc
@@ -20,10 +20,14 @@
 #include <gtest/gtest.h>
 
 #include "arrow/util/key_value_metadata.h"
+#include "parquet/file_reader.h"
 #include "parquet/schema.h"
 #include "parquet/statistics.h"
+#include "parquet/test_util.h"
 #include "parquet/thrift_internal.h"
 #include "parquet/types.h"
+
+#include <array>
 
 namespace parquet {
 
@@ -290,6 +294,46 @@ TEST(Metadata, TestKeyValueMetadata) {
   // Key value metadata
   ASSERT_TRUE(f_accessor->key_value_metadata());
   EXPECT_TRUE(f_accessor->key_value_metadata()->Equals(*kvmeta));
+}
+
+TEST(Metadata, TestReadPageIndex) {
+  std::string dir_string(parquet::test::get_data_dir());
+  std::string path = dir_string + "/alltypes_tiny_pages.parquet";
+  auto reader = ParquetFileReader::OpenFile(path, false);
+  auto file_metadata = reader->metadata();
+  ASSERT_EQ(1, file_metadata->num_row_groups());
+  auto row_group_metadata = file_metadata->RowGroup(0);
+  ASSERT_EQ(13, row_group_metadata->num_columns());
+  std::array<int64_t, 13> ci_offsets = {323583, 327502, 328009, 331928, 335847,
+                                        339766, 350345, 354264, 364843, 384342,
+                                        -1,     386473, 390392};
+  std::array<int32_t, 13> ci_lengths = {3919,  507,   3919, 3919, 3919, 10579, 3919,
+                                        10579, 19499, 2131, -1,   3919, 3919};
+  std::array<int64_t, 13> oi_offsets = {394311, 397814, 398637, 401888, 405139,
+                                        408390, 413670, 416921, 422201, 431936,
+                                        435457, 446002, 449253};
+  std::array<int32_t, 13> oi_lengths = {3503, 823,  3251, 3251,  3251, 5280, 3251,
+                                        5280, 9735, 3521, 10545, 3251, 3251};
+  for (int i = 0; i < row_group_metadata->num_columns(); ++i) {
+    auto col_chunk_metadata = row_group_metadata->ColumnChunk(i);
+    auto ci_locaiton = col_chunk_metadata->GetColumIndexLocation();
+    if (i == 10) {
+      // column_id 10 does not have column index
+      ASSERT_FALSE(ci_locaiton.has_value());
+    } else {
+      ASSERT_TRUE(ci_locaiton.has_value());
+    }
+    if (ci_locaiton.has_value()) {
+      ASSERT_EQ(ci_offsets.at(i), ci_locaiton->offset);
+      ASSERT_EQ(ci_lengths.at(i), ci_locaiton->length);
+    }
+    auto oi_location = col_chunk_metadata->GetOffsetIndexLocation();
+    ASSERT_TRUE(oi_location.has_value());
+    if (oi_location.has_value()) {
+      ASSERT_EQ(oi_offsets.at(i), oi_location->offset);
+      ASSERT_EQ(oi_lengths.at(i), oi_location->length);
+    }
+  }
 }
 
 TEST(ApplicationVersion, Basics) {


### PR DESCRIPTION
This is the first step to support page index of parquet.