### PR TITLE
GH-14745: [R] {rlang} dependency must be at least version 1.0.0 because of check_dots_empty

### DIFF
--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     methods,
     purrr,
     R6,
-    rlang,
+    rlang (>= 1.0.0),
     stats,
     tidyselect (>= 1.0.0),
     utils,

--- a/r/tests/testthat/_snaps/dataset-write.md
+++ b/r/tests/testthat/_snaps/dataset-write.md
@@ -2,8 +2,9 @@
 
     Code
       write_dataset(df, dst_dir, format = "feather", compression = "snappy")
-    Error <rlang_error>
-      `compression` is not a valid argument for your chosen `format`.
+    Condition
+      Error in `check_additional_args()`:
+      ! `compression` is not a valid argument for your chosen `format`.
       i You could try using `codec` instead of `compression`.
       i Supported arguments: `use_legacy_format`, `metadata_version`, `codec`, and `null_fallback`.
 
@@ -11,39 +12,44 @@
 
     Code
       write_dataset(df, dst_dir, format = "feather", nonsensical_arg = "blah-blah")
-    Error <rlang_error>
-      `nonsensical_arg` is not a valid argument for your chosen `format`.
+    Condition
+      Error in `check_additional_args()`:
+      ! `nonsensical_arg` is not a valid argument for your chosen `format`.
       i Supported arguments: `use_legacy_format`, `metadata_version`, `codec`, and `null_fallback`.
 
 ---
 
     Code
       write_dataset(df, dst_dir, format = "arrow", nonsensical_arg = "blah-blah")
-    Error <rlang_error>
-      `nonsensical_arg` is not a valid argument for your chosen `format`.
+    Condition
+      Error in `check_additional_args()`:
+      ! `nonsensical_arg` is not a valid argument for your chosen `format`.
       i Supported arguments: `use_legacy_format`, `metadata_version`, `codec`, and `null_fallback`.
 
 ---
 
     Code
       write_dataset(df, dst_dir, format = "ipc", nonsensical_arg = "blah-blah")
-    Error <rlang_error>
-      `nonsensical_arg` is not a valid argument for your chosen `format`.
+    Condition
+      Error in `check_additional_args()`:
+      ! `nonsensical_arg` is not a valid argument for your chosen `format`.
       i Supported arguments: `use_legacy_format`, `metadata_version`, `codec`, and `null_fallback`.
 
 ---
 
     Code
       write_dataset(df, dst_dir, format = "csv", nonsensical_arg = "blah-blah")
-    Error <rlang_error>
-      `nonsensical_arg` is not a valid argument for your chosen `format`.
+    Condition
+      Error in `check_additional_args()`:
+      ! `nonsensical_arg` is not a valid argument for your chosen `format`.
       i Supported arguments: `include_header` and `batch_size`.
 
 ---
 
     Code
       write_dataset(df, dst_dir, format = "parquet", nonsensical_arg = "blah-blah")
-    Error <rlang_error>
-      `nonsensical_arg` is not a valid argument for your chosen `format`.
+    Condition
+      Error in `check_additional_args()`:
+      ! `nonsensical_arg` is not a valid argument for your chosen `format`.
       i Supported arguments: `chunk_size`, `version`, `compression`, `compression_level`, `use_dictionary`, `write_statistics`, `data_page_size`, `use_deprecated_int96_timestamps`, `coerce_timestamps`, and `allow_truncated_timestamps`.
 

--- a/r/tests/testthat/_snaps/dplyr-glimpse.md
+++ b/r/tests/testthat/_snaps/dplyr-glimpse.md
@@ -87,7 +87,7 @@
 
     Code
       example_data %>% as_record_batch_reader() %>% glimpse()
-    Message <simpleMessage>
+    Message
       Cannot glimpse() data from a RecordBatchReader because it can only be read one time; call `as_arrow_table()` to consume it first.
     Output
       RecordBatchReader
@@ -103,7 +103,7 @@
 
     Code
       example_data %>% as_record_batch_reader() %>% select(int) %>% glimpse()
-    Message <simpleMessage>
+    Message
       Cannot glimpse() data from a RecordBatchReader because it can only be read one time. Call `compute()` to evaluate the query first.
     Output
       RecordBatchReader (query)
@@ -131,7 +131,7 @@
 
     Code
       ds %>% summarize(max(int)) %>% glimpse()
-    Message <simpleMessage>
+    Message
       This query requires a full table scan, so glimpse() may be expensive. Call `compute()` to evaluate the query first.
     Output
       FileSystemDataset (query)

--- a/r/tests/testthat/_snaps/dplyr-join.md
+++ b/r/tests/testthat/_snaps/dplyr-join.md
@@ -2,8 +2,9 @@
 
     Code
       left_join(arrow_table(example_data), arrow_table(example_data), by = "made_up_colname")
-    Error <rlang_error>
-      Join columns must be present in data.
+    Condition
+      Error in `handle_join_by()`:
+      ! Join columns must be present in data.
       x `made_up_colname` not present in x.
       x `made_up_colname` not present in y.
 
@@ -11,8 +12,9 @@
 
     Code
       left_join(arrow_table(example_data), arrow_table(example_data), by = c(int = "made_up_colname"))
-    Error <rlang_error>
-      Join columns must be present in data.
+    Condition
+      Error in `handle_join_by()`:
+      ! Join columns must be present in data.
       x `made_up_colname` not present in y.
 
 ---
@@ -20,8 +22,9 @@
     Code
       left_join(arrow_table(example_data), arrow_table(example_data), by = c(
         made_up_colname = "int"))
-    Error <rlang_error>
-      Join columns must be present in data.
+    Condition
+      Error in `handle_join_by()`:
+      ! Join columns must be present in data.
       x `made_up_colname` not present in x.
 
 ---
@@ -29,8 +32,9 @@
     Code
       left_join(arrow_table(example_data), arrow_table(example_data), by = c(
         "made_up_colname1", "made_up_colname2"))
-    Error <rlang_error>
-      Join columns must be present in data.
+    Condition
+      Error in `handle_join_by()`:
+      ! Join columns must be present in data.
       x `made_up_colname1` and `made_up_colname2` not present in x.
       x `made_up_colname1` and `made_up_colname2` not present in y.
 
@@ -39,8 +43,9 @@
     Code
       left_join(arrow_table(example_data), arrow_table(example_data), by = c(
         made_up_colname1 = "made_up_colname2"))
-    Error <rlang_error>
-      Join columns must be present in data.
+    Condition
+      Error in `handle_join_by()`:
+      ! Join columns must be present in data.
       x `made_up_colname1` not present in x.
       x `made_up_colname2` not present in y.
 


### PR DESCRIPTION
The function rlang::check_dots_empty() is used in this package. That function only became available in rlang version 1.0.0, so that version should be specified as the minimum