### PR TITLE
ARROW-18412: [C++][R] Windows build fails because of missing ChunkResolver symbols

### DIFF
--- a/cpp/src/arrow/chunk_resolver.h
+++ b/cpp/src/arrow/chunk_resolver.h
@@ -32,7 +32,7 @@ struct ChunkLocation {
 };
 
 // An object that resolves an array chunk depending on a logical index
-struct ChunkResolver {
+struct ARROW_EXPORT ChunkResolver {
   explicit ChunkResolver(const ArrayVector& chunks);
 
   explicit ChunkResolver(const std::vector<const Array*>& chunks);


### PR DESCRIPTION
Fix as suggested by @kou in https://github.com/apache/arrow/pull/14530#issuecomment-1328341447 !