### PR TITLE
GH-14775: [Go] Fix UnionBuilder.Len implementations

### DIFF
--- a/go/arrow/array/union.go
+++ b/go/arrow/array/union.go
@@ -745,6 +745,9 @@ func (b *unionBuilder) Child(idx int) Builder {
 	return b.children[idx]
 }
 
+// Len returns the current number of elements in the builder.
+func (b *unionBuilder) Len() int { return b.typesBuilder.Len() }
+
 func (b *unionBuilder) Mode() arrow.UnionMode { return b.mode }
 
 func (b *unionBuilder) reserve(elements int, resize func(int)) {

--- a/go/arrow/array/union_test.go
+++ b/go/arrow/array/union_test.go
@@ -625,6 +625,8 @@ func (s *UnionBuilderSuite) appendBasics() {
 	s.appendInt(-10)
 	s.appendDbl(0.5)
 
+	s.Equal(9, s.unionBldr.Len())
+
 	s.actual = s.unionBldr.NewArray().(array.Union)
 	s.NoError(s.actual.ValidateFull())
 	s.createExpectedTypesArr()
@@ -639,6 +641,8 @@ func (s *UnionBuilderSuite) appendNullsAndEmptyValues() {
 	s.unionBldr.AppendNulls(2)
 	s.unionBldr.AppendEmptyValues(2)
 	s.expectedTypes = append(s.expectedTypes, s.I8, s.I8, s.I8)
+
+	s.Equal(8, s.unionBldr.Len())
 
 	s.actual = s.unionBldr.NewArray().(array.Union)
 	s.NoError(s.actual.ValidateFull())
@@ -663,6 +667,8 @@ func (s *UnionBuilderSuite) appendInferred() {
 	s.appendDbl(1.0)
 	s.appendDbl(-1.0)
 	s.appendDbl(0.5)
+
+	s.Equal(9, s.unionBldr.Len())
 
 	s.actual = s.unionBldr.NewArray().(array.Union)
 	s.NoError(s.actual.ValidateFull())
@@ -694,6 +700,8 @@ func (s *UnionBuilderSuite) appendListOfInferred(utyp arrow.UnionType) *array.Li
 	s.DBL = s.unionBldr.AppendChild(s.dblBldr, "dbl")
 	s.EqualValues(2, s.DBL)
 	s.appendDbl(0.5)
+
+	s.Equal(4, s.unionBldr.Len())
 
 	s.createExpectedTypesArr()
 	return listBldr.NewListArray()


### PR DESCRIPTION
(*DenseUnionBuilder).Len and (*SparseUnionBuilder).Len always return 0. They should instead return the number of values appended.

This bug exists because these methods are promoted (via unionBuilder) from (*builder).Len, which reads builder.length, but DenseUnionBuilder and SparseUnionBuilder don't update that field.

Fix by adding a (*unionBuilder).Len implementation that calls unionBuilder.typesBuilder.Len.