### PR TITLE
ARROW-18391: [R] Fix the version selector dropdown in the dev docs

### DIFF
--- a/r/pkgdown/templates/navbar.html
+++ b/r/pkgdown/templates/navbar.html
@@ -1,0 +1,37 @@
+{{#navbar}}
+<nav class="navbar fixed-top navbar-{{{type}}} navbar-expand-lg bg-{{{bg}}}">
+  <div class="container">
+    {{#includes}}{{{before_title}}}{{/includes}}
+    <a class="navbar-brand me-2" href="{{#site}}{{root}}{{/site}}index.html">{{#site}}{{title}}{{/site}}</a>
+
+    <span class = "version">
+      <small class="nav-text {{#development}}text-{{version_label}}{{/development}} me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{#development}}{{version_tooltip}}{{/development}}">{{#package}}{{version}}{{/package}}</small>
+    </span>
+
+    {{#includes}}{{{before_navbar}}}{{/includes}}
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="{{#translate}}{{toggle_nav}}{{/translate}}">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+
+    <div id="navbar" class="collapse navbar-collapse ms-3">
+      {{#left}}
+      <ul class="navbar-nav me-auto">
+      {{{.}}}
+      </ul>
+      {{/left}}
+
+      <form class="form-inline my-2 my-lg-0" role="search">
+        <input type="search" class="form-control me-sm-2" aria-label="{{#translate}}{{toggle_nav}}{{/translate}}" name="search-input" data-search-index="{{#site}}{{root}}{{/site}}search.json" id="search-input" placeholder="{{#translate}}{{search_for}}{{/translate}}" autocomplete="off">
+      </form>
+
+      {{#right}}
+      <ul class="navbar-nav">
+      {{{.}}}
+      </ul>
+      {{/right}}
+    </div>
+
+    {{#includes}}{{{after_navbar}}}{{/includes}}
+  </div>
+</nav>
+{{/navbar}}

--- a/r/pkgdown/templates/navbar.html
+++ b/r/pkgdown/templates/navbar.html
@@ -35,3 +35,4 @@
   </div>
 </nav>
 {{/navbar}}
+


### PR DESCRIPTION
For context, this overrides the default navbar HTML with a custom version which makes a single change - adding a span called "version" which the JS will override.  An identically-named span existed in the template used with Bootstrap 3, which is why no JavaScript changes were needed.  This approach is almost identical to that in this PR to the pkgdown package which implements the same thing: https://github.com/r-lib/pkgdown/pull/2072 

I built this locally, and it appears to have successfully added the dropdown back in.

![image](https://user-images.githubusercontent.com/13715823/205083695-e718c7e5-1dc1-4742-9ce8-f773611b8ab7.png)
