### PR TITLE
ARROW-18420: [C++][Parquet] Introduce ColumnIndex & OffsetIndex

### DIFF
--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -326,6 +326,7 @@ add_parquet_test(internals-test
                  statistics_test.cc
                  encoding_test.cc
                  metadata_test.cc
+                 page_index_test.cc
                  public_api_test.cc
                  types_test.cc
                  test_util.cc)

--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -166,6 +166,7 @@ set(PARQUET_SRCS
     level_conversion.cc
     metadata.cc
     murmur3.cc
+    page_index.cc
     "${ARROW_SOURCE_DIR}/src/generated/parquet_constants.cpp"
     "${ARROW_SOURCE_DIR}/src/generated/parquet_types.cpp"
     platform.cc

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -312,7 +312,7 @@ class ColumnChunkMetaData::ColumnChunkMetaDataImpl {
     }
   }
 
-  std::optional<IndexLocation> GetColumIndexLocation() const {
+  std::optional<IndexLocation> GetColumnIndexLocation() const {
     if (column_->__isset.column_index_offset && column_->__isset.column_index_length) {
       return IndexLocation{column_->column_index_offset, column_->column_index_length};
     }
@@ -434,8 +434,8 @@ std::unique_ptr<ColumnCryptoMetaData> ColumnChunkMetaData::crypto_metadata() con
   return impl_->crypto_metadata();
 }
 
-std::optional<IndexLocation> ColumnChunkMetaData::GetColumIndexLocation() const {
-  return impl_->GetColumIndexLocation();
+std::optional<IndexLocation> ColumnChunkMetaData::GetColumnIndexLocation() const {
+  return impl_->GetColumnIndexLocation();
 }
 
 std::optional<IndexLocation> ColumnChunkMetaData::GetOffsetIndexLocation() const {

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -179,7 +179,7 @@ class PARQUET_EXPORT ColumnChunkMetaData {
   int64_t total_compressed_size() const;
   int64_t total_uncompressed_size() const;
   std::unique_ptr<ColumnCryptoMetaData> crypto_metadata() const;
-  std::optional<IndexLocation> GetColumIndexLocation() const;
+  std::optional<IndexLocation> GetColumnIndexLocation() const;
   std::optional<IndexLocation> GetOffsetIndexLocation() const;
 
  private:

--- a/cpp/src/parquet/metadata_test.cc
+++ b/cpp/src/parquet/metadata_test.cc
@@ -314,7 +314,7 @@ TEST(Metadata, TestReadPageIndex) {
                                      5280, 9735, 3521, 10545, 3251, 3251};
   for (int i = 0; i < row_group_metadata->num_columns(); ++i) {
     auto col_chunk_metadata = row_group_metadata->ColumnChunk(i);
-    auto ci_location = col_chunk_metadata->GetColumIndexLocation();
+    auto ci_location = col_chunk_metadata->GetColumnIndexLocation();
     if (i == 10) {
       // column_id 10 does not have column index
       ASSERT_FALSE(ci_location.has_value());

--- a/cpp/src/parquet/page_index.cc
+++ b/cpp/src/parquet/page_index.cc
@@ -170,6 +170,7 @@ std::unique_ptr<ColumnIndex> ColumnIndex::Make(const ColumnDescriptor& descr,
       return std::make_unique<TypedColumnIndexImpl<FLBAType>>(descr, column_index);
     case Type::UNDEFINED:
       ::arrow::Unreachable("Cannot make ColumnIndex of an unknown type");
+      return nullptr;
   }
 }
 

--- a/cpp/src/parquet/page_index.cc
+++ b/cpp/src/parquet/page_index.cc
@@ -15,9 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "parquet/page_index.h"
 #include "parquet/encoding.h"
-#include "parquet/metadata.h"
+#include "parquet/page_index.h"
+#include "parquet/statistics.h"
 #include "parquet/thrift_internal.h"
 
 #include <map>
@@ -46,154 +46,70 @@ class TypedColumnIndexImpl : public TypedColumnIndex<DType> {
  public:
   using T = typename DType::c_type;
 
-  explicit TypedColumnIndexImpl(const ColumnDescriptor& descr,
-                                const std::vector<bool>& null_pages,
-                                const std::vector<std::string>& min_values,
-                                const std::vector<std::string>& max_values,
-                                const BoundaryOrder& boundary_order,
-                                const bool has_null_count = false,
-                                const std::vector<int64_t>& null_counts = {})
-      : null_pages_(null_pages),
-        encoded_min_values_(min_values),
-        encoded_max_values_(max_values),
-        boundary_order_(boundary_order),
-        has_null_count_(has_null_count),
-        null_counts_(null_counts) {
+  TypedColumnIndexImpl(const ColumnDescriptor& descr,
+                       const format::ColumnIndex& column_index)
+      : column_index_(column_index) {
+    min_values_.reserve(column_index_.null_pages.size());
+    max_values_.reserve(column_index_.null_pages.size());
     // Decode min and max values into a compact form (i.e. w/o null page)
     auto plain_decoder = MakeTypedDecoder<DType>(Encoding::PLAIN, &descr);
     T value;
-    for (size_t i = 0; i < null_pages_.size(); ++i) {
-      if (!null_pages_[i]) {
-        // page index -> min/max slot index
-        page_indexes_.emplace(i, min_values_.size());
-        Decode<DType>(plain_decoder, encoded_min_values_[i], &value);
+    for (size_t i = 0; i < column_index_.null_pages.size(); ++i) {
+      if (column_index_.null_pages[i]) {
+        min_values_.push_back(std::nullopt);
+        max_values_.push_back(std::nullopt);
+      } else {
+        Decode<DType>(plain_decoder, column_index_.min_values[i], &value);
         min_values_.push_back(value);
-        Decode<DType>(plain_decoder, encoded_max_values_[i], &value);
+        Decode<DType>(plain_decoder, column_index_.max_values[i], &value);
         max_values_.push_back(value);
       }
     }
   }
 
-  explicit TypedColumnIndexImpl(const ColumnDescriptor& descr,
-                                const format::ColumnIndex& column_index)
-      : TypedColumnIndexImpl(
-            descr, column_index.null_pages, column_index.min_values,
-            column_index.max_values,
-            static_cast<BoundaryOrder>(static_cast<int>(column_index.boundary_order)),
-            column_index.__isset.null_counts, column_index.null_counts) {}
-
-  int64_t num_pages() const override { return static_cast<int64_t>(null_pages_.size()); }
-
-  bool is_null_page(int64_t page_id) const override {
-    if (page_id >= num_pages()) {
-      throw ParquetException("Page index is out of bound");
-    }
-    return null_pages_[page_id];
+  const std::vector<bool>& null_pages() const override {
+    return column_index_.null_pages;
   }
 
-  BoundaryOrder boundary_order() const override { return boundary_order_; }
-
-  bool has_null_counts() const override { return has_null_count_; }
-
-  int64_t null_count(int64_t page_id) const override {
-    if (page_id >= num_pages()) {
-      throw ParquetException("Page index is out of bound");
-    }
-    return null_counts_[page_id];
+  const std::vector<std::string>& encoded_min_values() const override {
+    return column_index_.min_values;
   }
 
-  T min_value(int64_t page_id) const override {
-    return min_values_[GetMinMaxSlot(page_id)];
+  const std::vector<std::string>& encoded_max_values() const override {
+    return column_index_.max_values;
   }
 
-  T max_value(int64_t page_id) const override {
-    return max_values_[GetMinMaxSlot(page_id)];
+  BoundaryOrder boundary_order() const override {
+    return static_cast<BoundaryOrder>(static_cast<int>(column_index_.boundary_order));
   }
 
-  const std::string& encoded_min(int64_t page_id) const override {
-    if (page_id >= num_pages()) {
-      throw ParquetException("Page index is out of bound");
-    }
-    return encoded_min_values_[page_id];
+  bool has_null_counts() const override { return column_index_.__isset.null_counts; }
+
+  const std::vector<int64_t>& null_counts() const override {
+    return column_index_.null_counts;
   }
 
-  const std::string& encoded_max(int64_t page_id) const override {
-    if (page_id >= num_pages()) {
-      throw ParquetException("Page index is out of bound");
-    }
-    return encoded_max_values_[page_id];
-  }
+  const std::vector<std::optional<T>>& min_values() const override { return min_values_; }
 
-  const std::vector<bool>& null_pages() const override { return null_pages_; }
-
-  const std::vector<int64_t>& null_counts() const override { return null_counts_; }
-
-  const std::vector<T>& min_values() const override { return min_values_; }
-
-  const std::vector<T>& max_values() const override { return max_values_; }
-
-  std::vector<int64_t> GetValidPageIndices() const override {
-    std::vector<int64_t> valid_page_indices;
-    std::for_each(page_indexes_.cbegin(), page_indexes_.cend(),
-                  [&](const std::pair<size_t, size_t>& v) {
-                    valid_page_indices.push_back(v.first);
-                  });
-    return valid_page_indices;
-  }
+  const std::vector<std::optional<T>>& max_values() const override { return max_values_; }
 
  private:
-  size_t GetMinMaxSlot(int64_t page_id) const {
-    if (page_id >= static_cast<int64_t>(null_pages_.size())) {
-      throw ParquetException("Page index is out of bound");
-    }
-    if (null_pages_[page_id]) {
-      throw ParquetException("Cannot get min/max value of null page");
-    }
-    auto iter = page_indexes_.find(page_id);
-    if (iter == page_indexes_.cend()) {
-      throw ParquetException("min/max value is unavailable");
-    }
-    return iter->second;
-  }
-
-  /// Values that are copied directly from the thrift message.
-  std::vector<bool> null_pages_;
-  std::vector<std::string> encoded_min_values_;
-  std::vector<std::string> encoded_max_values_;
-  BoundaryOrder boundary_order_;
-  bool has_null_count_;
-  std::vector<int64_t> null_counts_;
-
-  /// page_id -> slot_id in the buffer of min_values_ & max_values_
-  std::map<size_t, size_t> page_indexes_;
-
-  /// Decoded typed min/max values.
-  std::vector<T> min_values_;
-  std::vector<T> max_values_;
+  /// Wrapped thrift column index.
+  const format::ColumnIndex column_index_;
+  /// Decoded typed min/max values. Null pages are set to std::nullopt.
+  std::vector<std::optional<T>> min_values_;
+  std::vector<std::optional<T>> max_values_;
 };
 
 class OffsetIndexImpl : public OffsetIndex {
  public:
-  explicit OffsetIndexImpl(std::vector<PageLocation> page_locations)
-      : page_locations_(std::move(page_locations)) {}
-
   explicit OffsetIndexImpl(const format::OffsetIndex& offset_index) {
+    page_locations_.reserve(offset_index.page_locations.size());
     for (const auto& page_location : offset_index.page_locations) {
-      page_locations_.emplace_back();
-      auto& location = page_locations_.back();
-      location.offset = page_location.offset;
-      location.compressed_page_size = page_location.compressed_page_size;
-      location.first_row_index = page_location.first_row_index;
+      page_locations_.emplace_back(PageLocation{page_location.offset,
+                                                page_location.compressed_page_size,
+                                                page_location.first_row_index});
     }
-  }
-
-  int64_t num_pages() const override { return page_locations_.size(); }
-
-  const PageLocation& GetPageLocation(int64_t page_id) const override {
-    if (page_id >= num_pages()) {
-      throw ParquetException("Page index is out of bound");
-    }
-    return page_locations_[page_id];
   }
 
   const std::vector<PageLocation>& GetPageLocations() const override {

--- a/cpp/src/parquet/page_index.cc
+++ b/cpp/src/parquet/page_index.cc
@@ -43,7 +43,7 @@ void Decode(std::unique_ptr<typename EncodingTraits<DType>::Decoder>& decoder,
 template <>
 void Decode<ByteArrayType>(std::unique_ptr<ByteArrayDecoder>&, const std::string& src,
                            ByteArray* dst) {
-  DCHECK_LE(src.size(), std::numeric_limits<uint32_t>::max());
+  DCHECK_LE(src.size(), static_cast<size_t>(std::numeric_limits<uint32_t>::max()));
   dst->len = static_cast<uint32_t>(src.size());
   dst->ptr = reinterpret_cast<const uint8_t*>(src.data());
 }

--- a/cpp/src/parquet/page_index.cc
+++ b/cpp/src/parquet/page_index.cc
@@ -56,12 +56,12 @@ class TypedColumnIndexImpl : public TypedColumnIndex<DType> {
   TypedColumnIndexImpl(const ColumnDescriptor& descr,
                        const format::ColumnIndex& column_index)
       : column_index_(column_index) {
-    size_t num_non_null_pages = std::accumulate(
-        column_index_.null_pages.cbegin(), column_index_.null_pages.cend(), 0U,
-        [](size_t num_non_null_pages, bool null_page) {
-          return num_non_null_pages + (null_page ? 0U : 1U);
+    int32_t num_non_null_pages = std::accumulate(
+        column_index_.null_pages.cbegin(), column_index_.null_pages.cend(), 0,
+        [](int32_t num_non_null_pages, bool null_page) {
+          return num_non_null_pages + (null_page ? 0 : 1);
         });
-    if (num_non_null_pages != 0U) {
+    if (num_non_null_pages > 0) {
       min_values_.reserve(num_non_null_pages);
       max_values_.reserve(num_non_null_pages);
       // Decode min and max values into a compact form (i.e. w/o null page)

--- a/cpp/src/parquet/page_index.cc
+++ b/cpp/src/parquet/page_index.cc
@@ -107,8 +107,8 @@ class TypedColumnIndexImpl : public TypedColumnIndex<DType> {
     DCHECK_LE(num_non_null_pages, num_pages);
 
     // Allocate slots for decoded values.
-    min_values_.resize(num_non_null_pages);
-    max_values_.resize(num_non_null_pages);
+    min_values_.resize(num_pages);
+    max_values_.resize(num_pages);
     non_null_page_indices_.reserve(num_non_null_pages);
 
     // Decode min and max values according to the physical type.

--- a/cpp/src/parquet/page_index.cc
+++ b/cpp/src/parquet/page_index.cc
@@ -169,9 +169,10 @@ std::unique_ptr<ColumnIndex> ColumnIndex::Make(const ColumnDescriptor& descr,
     case Type::FIXED_LEN_BYTE_ARRAY:
       return std::make_unique<TypedColumnIndexImpl<FLBAType>>(descr, column_index);
     case Type::UNDEFINED:
-      ::arrow::Unreachable("Cannot make ColumnIndex of an unknown type");
       return nullptr;
   }
+  ::arrow::Unreachable("Cannot make ColumnIndex of an unknown type");
+  return nullptr;
 }
 
 std::unique_ptr<OffsetIndex> OffsetIndex::Make(const void* serialized_index,

--- a/cpp/src/parquet/page_index.cc
+++ b/cpp/src/parquet/page_index.cc
@@ -86,10 +86,12 @@ class TypedColumnIndexImpl : public TypedColumnIndex<DType> {
                        const format::ColumnIndex& column_index)
       : column_index_(column_index) {
     // Make sure the number of pages is valid and it does not overflow to int32_t.
-    if (column_index_.null_pages.size() != column_index_.min_values.size() ||
+    if (ARROW_PREDICT_FALSE(column_index_.null_pages.size() >=
+                            static_cast<size_t>(std::numeric_limits<int32_t>::max())) ||
+        column_index_.null_pages.size() != column_index_.min_values.size() ||
         column_index_.min_values.size() != column_index_.max_values.size() ||
-        ARROW_PREDICT_FALSE(column_index_.null_pages.size() >=
-                            static_cast<size_t>(std::numeric_limits<int32_t>::max()))) {
+        (column_index_.__isset.null_counts &&
+         column_index_.null_counts.size() != column_index_.null_pages.size())) {
       throw ParquetException("Invalid column index");
     }
 

--- a/cpp/src/parquet/page_index.cc
+++ b/cpp/src/parquet/page_index.cc
@@ -15,8 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "parquet/encoding.h"
 #include "parquet/page_index.h"
+#include "parquet/encoding.h"
 #include "parquet/statistics.h"
 #include "parquet/thrift_internal.h"
 

--- a/cpp/src/parquet/page_index.cc
+++ b/cpp/src/parquet/page_index.cc
@@ -1,0 +1,266 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "parquet/page_index.h"
+#include "parquet/encoding.h"
+#include "parquet/metadata.h"
+#include "parquet/thrift_internal.h"
+
+#include <map>
+
+namespace parquet {
+
+namespace {
+
+template <typename DType>
+void PlainDecode(const ColumnDescriptor* descr, const std::string& src,
+                 typename DType::c_type* dst) {
+  auto decoder = MakeTypedDecoder<DType>(Encoding::PLAIN, descr);
+  decoder->SetData(1, reinterpret_cast<const uint8_t*>(src.c_str()),
+                   static_cast<int>(src.size()));
+  decoder->Decode(dst, 1);
+}
+
+template <>
+void PlainDecode<ByteArrayType>(const ColumnDescriptor* descr, const std::string& src,
+                                ByteArray* dst) {
+  dst->len = static_cast<uint32_t>(src.size());
+  dst->ptr = reinterpret_cast<const uint8_t*>(src.c_str());
+}
+
+template <typename DType>
+class TypedColumnIndexImpl : public TypedColumnIndex<DType> {
+ public:
+  using T = typename DType::c_type;
+
+  explicit TypedColumnIndexImpl(const ColumnDescriptor* descr,
+                                const std::vector<bool>& null_pages,
+                                const std::vector<std::string>& min_values,
+                                const std::vector<std::string>& max_values,
+                                const BoundaryOrder& boundary_order,
+                                const bool has_null_count = false,
+                                const std::vector<int64_t>& null_counts = {})
+      : descr_(descr),
+        null_pages_(null_pages),
+        encoded_min_values_(min_values),
+        encoded_max_values_(max_values),
+        boundary_order_(boundary_order),
+        has_null_count_(has_null_count),
+        null_counts_(null_counts) {
+    /// Decode min and max values into a compact form (i.e. w/o null page)
+    DecodeValues(encoded_min_values_, encoded_max_values_);
+  }
+
+  explicit TypedColumnIndexImpl(const ColumnDescriptor* descr,
+                                const format::ColumnIndex& column_index)
+      : TypedColumnIndexImpl(
+            descr, column_index.null_pages, column_index.min_values,
+            column_index.max_values,
+            static_cast<BoundaryOrder>(static_cast<int>(column_index.boundary_order)),
+            column_index.__isset.null_counts, column_index.null_counts) {}
+
+  int64_t num_pages() const override { return static_cast<int64_t>(null_pages_.size()); }
+
+  bool null_page(int64_t page_id) const override {
+    if (page_id >= num_pages()) {
+      throw ParquetException("Page index is out of bound");
+    }
+    return null_pages_[page_id];
+  }
+
+  BoundaryOrder boundary_order() const override { return boundary_order_; }
+
+  bool HasNullCount() const override { return has_null_count_; }
+
+  int64_t null_count(int64_t page_id) const override {
+    if (page_id >= num_pages()) {
+      throw ParquetException("Page index is out of bound");
+    }
+    return null_counts_[page_id];
+  }
+
+  T min_value(int64_t page_id) const override {
+    return min_values_[GetMinMaxSlot(page_id)];
+  }
+
+  T max_value(int64_t page_id) const override {
+    return max_values_[GetMinMaxSlot(page_id)];
+  }
+
+  std::string GetEncodedMin(int64_t page_id) const override {
+    return encoded_min_values_[page_id];
+  }
+
+  std::string GetEncodedMax(int64_t page_id) const override {
+    return encoded_max_values_[page_id];
+  }
+
+  const std::vector<bool>& GetNullPages() const override { return null_pages_; }
+
+  const std::vector<int64_t>& GetNullCounts() const override { return null_counts_; }
+
+  const std::vector<T>& GetMinValues() const override { return min_values_; }
+
+  const std::vector<T>& GetMaxValues() const override { return max_values_; }
+
+  std::vector<int64_t> GetValidPageIndices() const override {
+    std::vector<int64_t> valid_page_indices;
+    std::for_each(page_indexes_.cbegin(), page_indexes_.cend(),
+                  [&](const std::pair<size_t, size_t>& v) {
+                    valid_page_indices.push_back(v.first);
+                  });
+    return valid_page_indices;
+  }
+
+ private:
+  size_t GetMinMaxSlot(int64_t page_id) const {
+    if (page_id >= static_cast<int64_t>(null_pages_.size())) {
+      throw ParquetException("page index is out of bound");
+    }
+    if (null_pages_[page_id]) {
+      throw ParquetException("cannot get min/max value of null page");
+    }
+    auto iter = page_indexes_.find(page_id);
+    if (iter == page_indexes_.cend()) {
+      throw ParquetException("min/max value is unavailable");
+    }
+    return iter->second;
+  }
+
+  void DecodeValues(const std::vector<std::string>& min_values,
+                    const std::vector<std::string>& max_values) {
+    T value;
+    for (size_t i = 0; i < null_pages_.size(); ++i) {
+      if (!null_pages_[i]) {
+        // page index -> min/max slot index
+        page_indexes_.emplace(i, min_values_.size());
+
+        PlainDecode<DType>(descr_, min_values[i], &value);
+        min_values_.push_back(value);
+        PlainDecode<DType>(descr_, max_values[i], &value);
+        max_values_.push_back(value);
+      }
+    }
+  }
+
+  const ColumnDescriptor* descr_;
+  std::vector<bool> null_pages_;
+  std::vector<std::string> encoded_min_values_;
+  std::vector<std::string> encoded_max_values_;
+  /// page_id -> slot_id in the buffer of min_values_ & max_values_
+  std::map<size_t, size_t> page_indexes_;
+  std::vector<T> min_values_;
+  std::vector<T> max_values_;
+  BoundaryOrder boundary_order_;
+  bool has_null_count_;
+  std::vector<int64_t> null_counts_;
+};
+
+class OffsetIndexImpl : public OffsetIndex {
+ public:
+  explicit OffsetIndexImpl(std::vector<PageLocation> page_locations)
+      : page_locations_(std::move(page_locations)) {}
+
+  explicit OffsetIndexImpl(const format::OffsetIndex& offset_index) {
+    for (const auto& page_location : offset_index.page_locations) {
+      page_locations_.emplace_back();
+      auto& location = page_locations_.back();
+      location.offset_ = page_location.offset;
+      location.compressed_page_size_ = page_location.compressed_page_size;
+      location.first_row_index_ = page_location.first_row_index;
+    }
+  }
+
+  int64_t num_pages() const override { return page_locations_.size(); }
+
+  int64_t offset(int64_t page_id) const override {
+    if (page_id >= num_pages()) {
+      throw ParquetException("Page index is out of bound");
+    }
+    return page_locations_[page_id].offset_;
+  }
+
+  int32_t compressed_page_size(int64_t page_id) const override {
+    if (page_id >= num_pages()) {
+      throw ParquetException("Page index is out of bound");
+    }
+    return page_locations_[page_id].compressed_page_size_;
+  }
+
+  int64_t first_row_index(int64_t page_id) const override {
+    if (page_id >= num_pages()) {
+      throw ParquetException("Page index is out of bound");
+    }
+    return page_locations_[page_id].first_row_index_;
+  }
+
+  const std::vector<PageLocation>& GetPageLocations() const override {
+    return page_locations_;
+  }
+
+ private:
+  std::vector<PageLocation> page_locations_;
+};
+
+}  // namespace
+
+// ----------------------------------------------------------------------
+// Public factory functions
+
+std::unique_ptr<ColumnIndex> ColumnIndex::Make(const ColumnDescriptor* descr,
+                                               const void* serialized_index,
+                                               uint32_t* inout_index_len,
+                                               const ReaderProperties& properties) {
+  format::ColumnIndex column_index;
+  ThriftDeserializer deserializer(properties);
+  deserializer.DeserializeMessage(reinterpret_cast<const uint8_t*>(serialized_index),
+                                  inout_index_len, &column_index);
+  switch (descr->physical_type()) {
+    case Type::BOOLEAN:
+      return std::make_unique<TypedColumnIndexImpl<BooleanType>>(descr, column_index);
+    case Type::INT32:
+      return std::make_unique<TypedColumnIndexImpl<Int32Type>>(descr, column_index);
+    case Type::INT64:
+      return std::make_unique<TypedColumnIndexImpl<Int64Type>>(descr, column_index);
+    case Type::INT96:
+      return std::make_unique<TypedColumnIndexImpl<Int96Type>>(descr, column_index);
+    case Type::FLOAT:
+      return std::make_unique<TypedColumnIndexImpl<FloatType>>(descr, column_index);
+    case Type::DOUBLE:
+      return std::make_unique<TypedColumnIndexImpl<DoubleType>>(descr, column_index);
+    case Type::BYTE_ARRAY:
+      return std::make_unique<TypedColumnIndexImpl<ByteArrayType>>(descr, column_index);
+    case Type::FIXED_LEN_BYTE_ARRAY:
+      return std::make_unique<TypedColumnIndexImpl<FLBAType>>(descr, column_index);
+    default:
+      break;
+  }
+  DCHECK(false) << "Should not be able to reach this code";
+  return nullptr;
+}
+
+std::unique_ptr<OffsetIndex> OffsetIndex::Make(const void* serialized_index,
+                                               uint32_t* inout_index_len,
+                                               const ReaderProperties& properties) {
+  format::OffsetIndex offset_index;
+  ThriftDeserializer deserializer(properties);
+  deserializer.DeserializeMessage(reinterpret_cast<const uint8_t*>(serialized_index),
+                                  inout_index_len, &offset_index);
+  return std::make_unique<OffsetIndexImpl>(offset_index);
+}
+
+}  // namespace parquet

--- a/cpp/src/parquet/page_index.h
+++ b/cpp/src/parquet/page_index.h
@@ -69,6 +69,9 @@ class PARQUET_EXPORT ColumnIndex {
   /// `has_null_counts` should be called first to determine if this information is
   /// available.
   virtual const std::vector<int64_t>& null_counts() const = 0;
+
+  /// \brief A vector of page indices for non-null pages.
+  virtual const std::vector<int32_t>& non_null_page_indices() const = 0;
 };
 
 /// \brief Typed implementation of ColumnIndex.
@@ -89,12 +92,6 @@ class PARQUET_EXPORT TypedColumnIndex : public ColumnIndex {
   ///
   /// Just like `min_values`, but for upper bounds instead of lower bounds.
   virtual const std::vector<T>& max_values() const = 0;
-
-  /// \brief A vector of page indices for not-null pages.
-  ///
-  /// It is helpful to understand the original page id in the values returned from
-  /// min_values() and max_values() above.
-  virtual const std::vector<int32_t>& non_null_page_indices() const = 0;
 };
 
 using BoolColumnIndex = TypedColumnIndex<BooleanType>;

--- a/cpp/src/parquet/page_index.h
+++ b/cpp/src/parquet/page_index.h
@@ -31,15 +31,15 @@
 namespace parquet {
 
 /// \brief BoundaryOrder is a proxy around format::BoundaryOrder.
-enum class PARQUET_EXPORT BoundaryOrder { UNORDERED = 0, ASCENDING = 1, DESCENDING = 2 };
+enum class PARQUET_EXPORT BoundaryOrder { Unordered = 0, Ascending = 1, Descending = 2 };
 
 /// \brief ColumnIndex is a proxy around format::ColumnIndex.
 class PARQUET_EXPORT ColumnIndex {
  public:
   /// \brief Create a ColumnIndex from a serialized thrift message.
-  static std::unique_ptr<ColumnIndex> Make(const ColumnDescriptor* descr,
+  static std::unique_ptr<ColumnIndex> Make(const ColumnDescriptor& descr,
                                            const void* serialized_index,
-                                           uint32_t* inout_index_len,
+                                           uint32_t index_len,
                                            const ReaderProperties& properties);
 
   virtual ~ColumnIndex() = default;
@@ -48,29 +48,29 @@ class PARQUET_EXPORT ColumnIndex {
   virtual int64_t num_pages() const = 0;
 
   /// \brief Returns if all values are null in a single page.
-  virtual bool null_page(int64_t page_id) const = 0;
+  virtual bool is_null_page(int64_t page_id) const = 0;
 
   /// \brief Returns whether both min_values and max_values are
   /// orderd and if so, in which direction.
   virtual BoundaryOrder boundary_order() const = 0;
 
   /// \brief Returns if null count is available.
-  virtual bool HasNullCount() const = 0;
+  virtual bool has_null_counts() const = 0;
 
   /// \brief Returns null count for a single page.
   virtual int64_t null_count(int64_t page_id) const = 0;
 
-  /// \brief Returns all null indicator for each page in batch.
-  virtual const std::vector<bool>& GetNullPages() const = 0;
-
-  /// \brief Returns null count for each page in batch.
-  virtual const std::vector<int64_t>& GetNullCounts() const = 0;
-
   /// \brief The minimum value of a single page. Throws if it is null page.
-  virtual std::string GetEncodedMin(int64_t page_id) const = 0;
+  virtual const std::string& encoded_min(int64_t page_id) const = 0;
 
   /// \brief The maximum value of a single page. Throws if it is null page.
-  virtual std::string GetEncodedMax(int64_t page_id) const = 0;
+  virtual const std::string& encoded_max(int64_t page_id) const = 0;
+
+  /// \brief Returns all null indicator for each page in batch.
+  virtual const std::vector<bool>& null_pages() const = 0;
+
+  /// \brief Returns null count for each page in batch.
+  virtual const std::vector<int64_t>& null_counts() const = 0;
 };
 
 /// \brief Typed implementation of ColumnIndex.
@@ -86,10 +86,10 @@ class PARQUET_EXPORT TypedColumnIndex : public ColumnIndex {
   virtual T max_value(int64_t page_id) const = 0;
 
   /// \brief The minimum value of every valid page.
-  virtual const std::vector<T>& GetMinValues() const = 0;
+  virtual const std::vector<T>& min_values() const = 0;
 
   /// \brief The maximum value of every valid page.
-  virtual const std::vector<T>& GetMaxValues() const = 0;
+  virtual const std::vector<T>& max_values() const = 0;
 
   /// \brief Returns list of page index of all valid pages.
   /// It can be used to understand values returned from min_values/max_values.
@@ -107,11 +107,11 @@ using FLBAColumnIndex = TypedColumnIndex<FLBAType>;
 /// \brief PageLocation is a proxy around format::PageLocation.
 struct PARQUET_EXPORT PageLocation {
   /// File offset of the data page.
-  int64_t offset_;
+  int64_t offset;
   /// Total compressed size of the data page and header.
-  int32_t compressed_page_size_;
+  int32_t compressed_page_size;
   // row id of the first row in the page within the row group.
-  int64_t first_row_index_;
+  int64_t first_row_index;
 };
 
 /// \brief OffsetIndex is a proxy around format::OffsetIndex.
@@ -119,7 +119,7 @@ class PARQUET_EXPORT OffsetIndex {
  public:
   /// \brief Create a OffsetIndex from a serialized thrift message.
   static std::unique_ptr<OffsetIndex> Make(const void* serialized_index,
-                                           uint32_t* inout_index_len,
+                                           uint32_t index_len,
                                            const ReaderProperties& properties);
 
   virtual ~OffsetIndex() = default;
@@ -127,14 +127,8 @@ class PARQUET_EXPORT OffsetIndex {
   /// \brief Returns number of pages in this column index.
   virtual int64_t num_pages() const = 0;
 
-  /// \brief Returns offset for a single page.
-  virtual int64_t offset(int64_t page_id) const = 0;
-
-  /// \brief Returns total compressed size for a single page.
-  virtual int32_t compressed_page_size(int64_t page_id) const = 0;
-
-  /// \brief Returns row id of the first row for a single page.
-  virtual int64_t first_row_index(int64_t page_id) const = 0;
+  /// \brief Returns PageLocation of a single page.
+  virtual const PageLocation& GetPageLocation(int64_t page_id) const = 0;
 
   /// \brief Returns all page locations in the offset index.
   virtual const std::vector<PageLocation>& GetPageLocations() const = 0;

--- a/cpp/src/parquet/page_index.h
+++ b/cpp/src/parquet/page_index.h
@@ -17,13 +17,11 @@
 
 #pragma once
 
-#include <optional>
-#include <set>
-#include <vector>
-
 #include "parquet/exception.h"
 #include "parquet/platform.h"
 #include "parquet/schema.h"
+
+#include <vector>
 
 namespace parquet {
 
@@ -72,11 +70,18 @@ class PARQUET_EXPORT TypedColumnIndex : public ColumnIndex {
  public:
   using T = typename DType::c_type;
 
-  /// \brief Returns a list of lower bound for the values of every page.
-  virtual const std::vector<std::optional<T>>& min_values() const = 0;
+  /// \brief Returns a list of lower bound for the values of every non-null page.
+  /// Excluding non-null pages helps binary search if the values are ordered.
+  virtual const std::vector<T>& min_values() const = 0;
 
-  /// \brief Returns a list of upper bound for the values of every page.
-  virtual const std::vector<std::optional<T>>& max_values() const = 0;
+  /// \brief Returns a list of upper bound for the values of every non-null page.
+  /// Excluding non-null pages helps binary search if the values are ordered.
+  virtual const std::vector<T>& max_values() const = 0;
+
+  /// \brief Returns a list of page indices for not-null pages. It is helpful to
+  /// understand the original page id in the values returned from min_values()
+  /// and max_values() above.
+  virtual const std::vector<int32_t> GetNonNullPageIndices() const = 0;
 };
 
 using BoolColumnIndex = TypedColumnIndex<BooleanType>;

--- a/cpp/src/parquet/page_index.h
+++ b/cpp/src/parquet/page_index.h
@@ -1,0 +1,143 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "parquet/platform.h"
+#include "parquet/statistics.h"
+#include "parquet/types.h"
+
+namespace parquet {
+
+/// \brief BoundaryOrder is a proxy around format::BoundaryOrder.
+enum class PARQUET_EXPORT BoundaryOrder { UNORDERED = 0, ASCENDING = 1, DESCENDING = 2 };
+
+/// \brief ColumnIndex is a proxy around format::ColumnIndex.
+class PARQUET_EXPORT ColumnIndex {
+ public:
+  /// \brief Create a ColumnIndex from a serialized thrift message.
+  static std::unique_ptr<ColumnIndex> Make(const ColumnDescriptor* descr,
+                                           const void* serialized_index,
+                                           uint32_t* inout_index_len,
+                                           const ReaderProperties& properties);
+
+  virtual ~ColumnIndex() = default;
+
+  /// \brief Returns number of pages in this column index.
+  virtual int64_t num_pages() const = 0;
+
+  /// \brief Returns if all values are null in a single page.
+  virtual bool null_page(int64_t page_id) const = 0;
+
+  /// \brief Returns whether both min_values and max_values are
+  /// orderd and if so, in which direction.
+  virtual BoundaryOrder boundary_order() const = 0;
+
+  /// \brief Returns if null count is available.
+  virtual bool HasNullCount() const = 0;
+
+  /// \brief Returns null count for a single page.
+  virtual int64_t null_count(int64_t page_id) const = 0;
+
+  /// \brief Returns all null indicator for each page in batch.
+  virtual const std::vector<bool>& GetNullPages() const = 0;
+
+  /// \brief Returns null count for each page in batch.
+  virtual const std::vector<int64_t>& GetNullCounts() const = 0;
+
+  /// \brief The minimum value of a single page. Throws if it is null page.
+  virtual std::string GetEncodedMin(int64_t page_id) const = 0;
+
+  /// \brief The maximum value of a single page. Throws if it is null page.
+  virtual std::string GetEncodedMax(int64_t page_id) const = 0;
+};
+
+/// \brief Typed implementation of ColumnIndex.
+template <typename DType>
+class PARQUET_EXPORT TypedColumnIndex : public ColumnIndex {
+ public:
+  using T = typename DType::c_type;
+
+  /// \brief The minimum value of a single page. Throws if it is null page.
+  virtual T min_value(int64_t page_id) const = 0;
+
+  /// \brief The maximum value of a single page. Throws if it is null page.
+  virtual T max_value(int64_t page_id) const = 0;
+
+  /// \brief The minimum value of every valid page.
+  virtual const std::vector<T>& GetMinValues() const = 0;
+
+  /// \brief The maximum value of every valid page.
+  virtual const std::vector<T>& GetMaxValues() const = 0;
+
+  /// \brief Returns list of page index of all valid pages.
+  /// It can be used to understand values returned from min_values/max_values.
+  virtual std::vector<int64_t> GetValidPageIndices() const = 0;
+};
+
+using BoolColumnIndex = TypedColumnIndex<BooleanType>;
+using Int32ColumnIndex = TypedColumnIndex<Int32Type>;
+using Int64ColumnIndex = TypedColumnIndex<Int64Type>;
+using FloatColumnIndex = TypedColumnIndex<FloatType>;
+using DoubleColumnIndex = TypedColumnIndex<DoubleType>;
+using ByteArrayColumnIndex = TypedColumnIndex<ByteArrayType>;
+using FLBAColumnIndex = TypedColumnIndex<FLBAType>;
+
+/// \brief PageLocation is a proxy around format::PageLocation.
+struct PARQUET_EXPORT PageLocation {
+  /// File offset of the data page.
+  int64_t offset_;
+  /// Total compressed size of the data page and header.
+  int32_t compressed_page_size_;
+  // row id of the first row in the page within the row group.
+  int64_t first_row_index_;
+};
+
+/// \brief OffsetIndex is a proxy around format::OffsetIndex.
+class PARQUET_EXPORT OffsetIndex {
+ public:
+  /// \brief Create a OffsetIndex from a serialized thrift message.
+  static std::unique_ptr<OffsetIndex> Make(const void* serialized_index,
+                                           uint32_t* inout_index_len,
+                                           const ReaderProperties& properties);
+
+  virtual ~OffsetIndex() = default;
+
+  /// \brief Returns number of pages in this column index.
+  virtual int64_t num_pages() const = 0;
+
+  /// \brief Returns offset for a single page.
+  virtual int64_t offset(int64_t page_id) const = 0;
+
+  /// \brief Returns total compressed size for a single page.
+  virtual int32_t compressed_page_size(int64_t page_id) const = 0;
+
+  /// \brief Returns row id of the first row for a single page.
+  virtual int64_t first_row_index(int64_t page_id) const = 0;
+
+  /// \brief Returns all page locations in the offset index.
+  virtual const std::vector<PageLocation>& GetPageLocations() const = 0;
+};
+
+}  // namespace parquet

--- a/cpp/src/parquet/page_index_test.cc
+++ b/cpp/src/parquet/page_index_test.cc
@@ -176,7 +176,7 @@ TEST(PageIndex, ReadDoubleColumnIndex) {
       null_pages, min_values, max_values, has_null_counts, null_counts);
 }
 
-TEST(PageIndex, ByteArrayColumnIndex) {
+TEST(PageIndex, ReadByteArrayColumnIndex) {
   const int column_id = 9;
   const size_t num_pages = 352;
   const BoundaryOrder::type boundary_order = BoundaryOrder::Ascending;
@@ -214,11 +214,11 @@ TEST(PageIndex, ReadBoolColumnIndex) {
       null_pages, min_values, max_values, has_null_counts, null_counts);
 }
 
-namespace {
-FLBA toFLBA(const char* ptr) { return FLBA{reinterpret_cast<const uint8_t*>(ptr)}; }
-}  // namespace
-
 TEST(PageIndex, FixedLengthByteArrayColumnIndex) {
+  auto to_flba = [](const char* ptr) {
+    return FLBA{reinterpret_cast<const uint8_t*>(ptr)};
+  };
+
   const int column_id = 0;
   const size_t num_pages = 10;
   const BoundaryOrder::type boundary_order = BoundaryOrder::Descending;
@@ -230,10 +230,10 @@ TEST(PageIndex, FixedLengthByteArrayColumnIndex) {
                                                  "\x00\x00\x00\x65"};
   const std::vector<const char*> max_literals = {"\x00\x00\x03\xE8", "\x00\x00\x02\x58",
                                                  "\x00\x00\x00\xC8"};
-  const std::vector<FLBA> min_values = {toFLBA(min_literals[0]), toFLBA(min_literals[1]),
-                                        toFLBA(min_literals[2])};
-  const std::vector<FLBA> max_values = {toFLBA(max_literals[0]), toFLBA(max_literals[1]),
-                                        toFLBA(max_literals[2])};
+  const std::vector<FLBA> min_values = {
+      to_flba(min_literals[0]), to_flba(min_literals[1]), to_flba(min_literals[2])};
+  const std::vector<FLBA> max_values = {
+      to_flba(max_literals[0]), to_flba(max_literals[1]), to_flba(max_literals[2])};
 
   TestReadTypedColumnIndex<FLBAType>(
       "fixed_length_byte_array.parquet", column_id, num_pages, boundary_order,
@@ -253,7 +253,7 @@ TEST(PageIndex, ReadColumnIndexWithNullPage) {
   const std::vector<int32_t> max_values = {};
 
   TestReadTypedColumnIndex<Int32Type>(
-      "datapage_v1-corrupt-checksum.parquet", column_id, num_pages, boundary_order,
+      "datapage_v1-uncompressed-checksum.parquet", column_id, num_pages, boundary_order,
       page_indices, null_pages, min_values, max_values, has_null_counts, null_counts);
 }
 

--- a/cpp/src/parquet/page_index_test.cc
+++ b/cpp/src/parquet/page_index_test.cc
@@ -208,4 +208,21 @@ TEST(PageIndex, ReadBoolColumnIndex) {
       null_pages, min_values, max_values, has_null_counts, null_counts);
 }
 
+TEST(PageIndex, ReadColumnIndexWithNullPage) {
+  const int column_id = 0;
+  const size_t num_pages = 2;
+  const BoundaryOrder::type boundary_order = BoundaryOrder::Ascending;
+  const std::vector<size_t> page_indices = {0, 1};
+  const std::vector<bool> null_pages = {true, true};
+  // It seems that the null_counts are malformed.
+  const bool has_null_counts = true;
+  const std::vector<int64_t> null_counts = {-1, -1};
+  const std::vector<int32_t> min_values = {};
+  const std::vector<int32_t> max_values = {};
+
+  TestReadTypedColumnIndex<Int32Type>(
+      "datapage_v1-corrupt-checksum.parquet", column_id, num_pages, boundary_order,
+      page_indices, null_pages, min_values, max_values, has_null_counts, null_counts);
+}
+
 }  // namespace parquet

--- a/cpp/src/parquet/page_index_test.cc
+++ b/cpp/src/parquet/page_index_test.cc
@@ -1,0 +1,208 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "parquet/page_index.h"
+
+#include <gtest/gtest.h>
+
+#include "arrow/io/file.h"
+#include "parquet/file_reader.h"
+#include "parquet/schema.h"
+#include "parquet/test_util.h"
+#include "parquet/thrift_internal.h"
+
+namespace parquet {
+
+TEST(PageIndex, ReadOffsetIndex) {
+  std::string dir_string(parquet::test::get_data_dir());
+  std::string path = dir_string + "/alltypes_tiny_pages.parquet";
+  auto reader = ParquetFileReader::OpenFile(path, false);
+  auto file_metadata = reader->metadata();
+
+  // Get offset index location to column 0 of row group 0.
+  const int row_group_id = 0;
+  const int column_id = 0;
+  ASSERT_LT(row_group_id, file_metadata->num_row_groups());
+  ASSERT_LT(column_id, file_metadata->num_columns());
+  auto index_location = file_metadata->RowGroup(row_group_id)
+                            ->ColumnChunk(column_id)
+                            ->GetOffsetIndexLocation();
+  ASSERT_TRUE(index_location.has_value());
+
+  // Read serialized offset index from the file.
+  std::shared_ptr<::arrow::io::RandomAccessFile> source;
+  PARQUET_ASSIGN_OR_THROW(source, ::arrow::io::ReadableFile::Open(path));
+  PARQUET_ASSIGN_OR_THROW(auto buffer,
+                          source->ReadAt(index_location->offset, index_location->length));
+  PARQUET_THROW_NOT_OK(source->Close());
+
+  // Deserialize offset index.
+  auto properties = default_reader_properties();
+  std::unique_ptr<OffsetIndex> offset_index = OffsetIndex::Make(
+      buffer->data(), static_cast<uint32_t>(buffer->size()), properties);
+
+  // Verify only partial data as it contains 325 pages in total.
+  const size_t num_pages = 325;
+  const std::vector<size_t> page_indices = {0, 100, 200, 300};
+  const std::vector<PageLocation> page_locations = {
+      PageLocation{4, 109, 0}, PageLocation{11480, 133, 2244},
+      PageLocation{22980, 133, 4494}, PageLocation{34480, 133, 6744}};
+
+  ASSERT_EQ(num_pages, offset_index->page_locations().size());
+  for (size_t i = 0; i < page_indices.size(); ++i) {
+    size_t page_id = page_indices.at(i);
+    const auto& read_page_location = offset_index->page_locations().at(page_id);
+    const auto& expected_page_location = page_locations.at(i);
+    ASSERT_EQ(expected_page_location.offset, read_page_location.offset);
+    ASSERT_EQ(expected_page_location.compressed_page_size,
+              read_page_location.compressed_page_size);
+    ASSERT_EQ(expected_page_location.first_row_index, read_page_location.first_row_index);
+  }
+}
+
+template <typename DType, typename T = typename DType::c_type>
+void TestReadTypedColumnIndex(
+    int column_id, size_t num_pages, BoundaryOrder::type boundary_order,
+    const std::vector<size_t>& page_indices, const std::vector<bool>& null_pages,
+    const std::vector<T>& min_values, const std::vector<T>& max_values,
+    bool has_null_counts = false, const std::vector<int64_t>& null_counts = {}) {
+  std::string dir_string(parquet::test::get_data_dir());
+  std::string path = dir_string + "/alltypes_tiny_pages.parquet";
+  auto reader = ParquetFileReader::OpenFile(path, false);
+  auto file_metadata = reader->metadata();
+
+  // Get column index location to a specific column chunk.
+  const int row_group_id = 0;
+  ASSERT_LT(row_group_id, file_metadata->num_row_groups());
+  ASSERT_LT(column_id, file_metadata->num_columns());
+  auto index_location = file_metadata->RowGroup(row_group_id)
+                            ->ColumnChunk(column_id)
+                            ->GetColumnIndexLocation();
+  ASSERT_TRUE(index_location.has_value());
+
+  // Read serialized column index from the file.
+  std::shared_ptr<::arrow::io::RandomAccessFile> source;
+  PARQUET_ASSIGN_OR_THROW(source, ::arrow::io::ReadableFile::Open(path));
+  PARQUET_ASSIGN_OR_THROW(auto buffer,
+                          source->ReadAt(index_location->offset, index_location->length));
+  PARQUET_THROW_NOT_OK(source->Close());
+
+  // Deserialize column index.
+  auto properties = default_reader_properties();
+  auto descr = file_metadata->schema()->Column(column_id);
+  std::unique_ptr<ColumnIndex> column_index = ColumnIndex::Make(
+      *descr, buffer->data(), static_cast<uint32_t>(buffer->size()), properties);
+  auto typed_column_index = dynamic_cast<TypedColumnIndex<DType>*>(column_index.get());
+  ASSERT_TRUE(typed_column_index != nullptr);
+
+  // Verify only partial data as there are too many pages.
+  ASSERT_EQ(num_pages, column_index->null_pages().size());
+  ASSERT_EQ(has_null_counts, column_index->has_null_counts());
+  ASSERT_EQ(boundary_order, column_index->boundary_order());
+  for (size_t i = 0; i < page_indices.size(); ++i) {
+    size_t page_id = page_indices.at(i);
+    ASSERT_EQ(null_pages.at(i), column_index->null_pages().at(page_id));
+    if (has_null_counts) {
+      ASSERT_EQ(null_counts.at(i), column_index->null_counts().at(page_id));
+    }
+    // min/max values are only meaningful for non-null pages.
+    if (!null_pages.at(i)) {
+      if constexpr (std::is_same_v<T, double>) {
+        ASSERT_DOUBLE_EQ(min_values.at(i), typed_column_index->min_values().at(page_id));
+        ASSERT_DOUBLE_EQ(max_values.at(i), typed_column_index->max_values().at(page_id));
+      } else if constexpr (std::is_same_v<T, float>) {
+        ASSERT_FLOAT_EQ(min_values.at(i), typed_column_index->min_values().at(page_id));
+        ASSERT_FLOAT_EQ(max_values.at(i), typed_column_index->max_values().at(page_id));
+      } else {
+        ASSERT_EQ(min_values.at(i), typed_column_index->min_values().at(page_id));
+        ASSERT_EQ(max_values.at(i), typed_column_index->max_values().at(page_id));
+      }
+    }
+  }
+}
+
+TEST(PageIndex, ReadInt64ColumnIndex) {
+  const int column_id = 5;
+  const size_t num_pages = 528;
+  const BoundaryOrder::type boundary_order = BoundaryOrder::Unordered;
+  const std::vector<size_t> page_indices = {0, 99, 426, 520};
+  const std::vector<bool> null_pages = {false, false, false, false};
+  const bool has_null_counts = true;
+  const std::vector<int64_t> null_counts = {0, 0, 0, 0};
+  const std::vector<int64_t> min_values = {0, 10, 0, 0};
+  const std::vector<int64_t> max_values = {90, 90, 80, 70};
+
+  TestReadTypedColumnIndex<Int64Type>(column_id, num_pages, boundary_order, page_indices,
+                                      null_pages, min_values, max_values, has_null_counts,
+                                      null_counts);
+}
+
+TEST(PageIndex, ReadDoubleColumnIndex) {
+  const int column_id = 7;
+  const size_t num_pages = 528;
+  const BoundaryOrder::type boundary_order = BoundaryOrder::Unordered;
+  const std::vector<size_t> page_indices = {0, 51, 212, 527};
+  const std::vector<bool> null_pages = {false, false, false, false};
+  const bool has_null_counts = true;
+  const std::vector<int64_t> null_counts = {0, 0, 0, 0};
+  const std::vector<double> min_values = {-0, 30.3, 10.1, 40.4};
+  const std::vector<double> max_values = {90.9, 90.9, 90.9, 60.6};
+
+  TestReadTypedColumnIndex<DoubleType>(column_id, num_pages, boundary_order, page_indices,
+                                       null_pages, min_values, max_values,
+                                       has_null_counts, null_counts);
+}
+
+TEST(PageIndex, ByteArrayColumnIndex) {
+  const int column_id = 9;
+  const size_t num_pages = 352;
+  const BoundaryOrder::type boundary_order = BoundaryOrder::Ascending;
+  const std::vector<size_t> page_indices = {0, 128, 256};
+  const std::vector<bool> null_pages = {false, false, false};
+  const bool has_null_counts = true;
+  const std::vector<int64_t> null_counts = {0, 0, 0};
+
+  // All min values are "0" and max values are "9".
+  const std::string_view min_value = "0";
+  const std::string_view max_value = "9";
+  const std::vector<ByteArray> min_values = {ByteArray{min_value}, ByteArray{min_value},
+                                             ByteArray{min_value}};
+  const std::vector<ByteArray> max_values = {ByteArray{max_value}, ByteArray{max_value},
+                                             ByteArray{max_value}};
+
+  TestReadTypedColumnIndex<ByteArrayType>(column_id, num_pages, boundary_order,
+                                          page_indices, null_pages, min_values,
+                                          max_values, has_null_counts, null_counts);
+}
+
+TEST(PageIndex, ReadBoolColumnIndex) {
+  const int column_id = 1;
+  const size_t num_pages = 82;
+  const BoundaryOrder::type boundary_order = BoundaryOrder::Ascending;
+  const std::vector<size_t> page_indices = {0, 16, 64};
+  const std::vector<bool> null_pages = {false, false, false};
+  const bool has_null_counts = true;
+  const std::vector<int64_t> null_counts = {0, 0, 0};
+  const std::vector<bool> min_values = {false, false, false};
+  const std::vector<bool> max_values = {true, true, true};
+
+  TestReadTypedColumnIndex<BooleanType>(column_id, num_pages, boundary_order,
+                                        page_indices, null_pages, min_values, max_values,
+                                        has_null_counts, null_counts);
+}
+
+}  // namespace parquet

--- a/cpp/src/parquet/page_index_test.cc
+++ b/cpp/src/parquet/page_index_test.cc
@@ -214,7 +214,7 @@ TEST(PageIndex, ReadBoolColumnIndex) {
       null_pages, min_values, max_values, has_null_counts, null_counts);
 }
 
-TEST(PageIndex, FixedLengthByteArrayColumnIndex) {
+TEST(PageIndex, ReadFixedLengthByteArrayColumnIndex) {
   auto to_flba = [](const char* ptr) {
     return FLBA{reinterpret_cast<const uint8_t*>(ptr)};
   };
@@ -242,19 +242,18 @@ TEST(PageIndex, FixedLengthByteArrayColumnIndex) {
 
 TEST(PageIndex, ReadColumnIndexWithNullPage) {
   const int column_id = 0;
-  const size_t num_pages = 2;
-  const BoundaryOrder::type boundary_order = BoundaryOrder::Ascending;
-  const std::vector<size_t> page_indices = {0, 1};
-  const std::vector<bool> null_pages = {true, true};
-  // It seems that the null_counts are malformed.
+  const size_t num_pages = 10;
+  const BoundaryOrder::type boundary_order = BoundaryOrder::Unordered;
+  const std::vector<size_t> page_indices = {2, 4, 8};
+  const std::vector<bool> null_pages = {true, false, false};
   const bool has_null_counts = true;
-  const std::vector<int64_t> null_counts = {-1, -1};
-  const std::vector<int32_t> min_values = {};
-  const std::vector<int32_t> max_values = {};
+  const std::vector<int64_t> null_counts = {100, 16, 8};
+  const std::vector<int32_t> min_values = {0, -2048691758, -2046900272};
+  const std::vector<int32_t> max_values = {0, 2143189382, 2087168549};
 
   TestReadTypedColumnIndex<Int32Type>(
-      "datapage_v1-uncompressed-checksum.parquet", column_id, num_pages, boundary_order,
-      page_indices, null_pages, min_values, max_values, has_null_counts, null_counts);
+      "int32_with_null_pages.parquet", column_id, num_pages, boundary_order, page_indices,
+      null_pages, min_values, max_values, has_null_counts, null_counts);
 }
 
 }  // namespace parquet

--- a/cpp/src/parquet/page_index_test.cc
+++ b/cpp/src/parquet/page_index_test.cc
@@ -75,13 +75,16 @@ TEST(PageIndex, ReadOffsetIndex) {
 }
 
 template <typename DType, typename T = typename DType::c_type>
-void TestReadTypedColumnIndex(
-    int column_id, size_t num_pages, BoundaryOrder::type boundary_order,
-    const std::vector<size_t>& page_indices, const std::vector<bool>& null_pages,
-    const std::vector<T>& min_values, const std::vector<T>& max_values,
-    bool has_null_counts = false, const std::vector<int64_t>& null_counts = {}) {
+void TestReadTypedColumnIndex(const std::string& file_name, int column_id,
+                              size_t num_pages, BoundaryOrder::type boundary_order,
+                              const std::vector<size_t>& page_indices,
+                              const std::vector<bool>& null_pages,
+                              const std::vector<T>& min_values,
+                              const std::vector<T>& max_values,
+                              bool has_null_counts = false,
+                              const std::vector<int64_t>& null_counts = {}) {
   std::string dir_string(parquet::test::get_data_dir());
-  std::string path = dir_string + "/alltypes_tiny_pages.parquet";
+  std::string path = dir_string + "/" + file_name;
   auto reader = ParquetFileReader::OpenFile(path, false);
   auto file_metadata = reader->metadata();
 
@@ -146,9 +149,9 @@ TEST(PageIndex, ReadInt64ColumnIndex) {
   const std::vector<int64_t> min_values = {0, 10, 0, 0};
   const std::vector<int64_t> max_values = {90, 90, 80, 70};
 
-  TestReadTypedColumnIndex<Int64Type>(column_id, num_pages, boundary_order, page_indices,
-                                      null_pages, min_values, max_values, has_null_counts,
-                                      null_counts);
+  TestReadTypedColumnIndex<Int64Type>(
+      "alltypes_tiny_pages.parquet", column_id, num_pages, boundary_order, page_indices,
+      null_pages, min_values, max_values, has_null_counts, null_counts);
 }
 
 TEST(PageIndex, ReadDoubleColumnIndex) {
@@ -162,9 +165,9 @@ TEST(PageIndex, ReadDoubleColumnIndex) {
   const std::vector<double> min_values = {-0, 30.3, 10.1, 40.4};
   const std::vector<double> max_values = {90.9, 90.9, 90.9, 60.6};
 
-  TestReadTypedColumnIndex<DoubleType>(column_id, num_pages, boundary_order, page_indices,
-                                       null_pages, min_values, max_values,
-                                       has_null_counts, null_counts);
+  TestReadTypedColumnIndex<DoubleType>(
+      "alltypes_tiny_pages.parquet", column_id, num_pages, boundary_order, page_indices,
+      null_pages, min_values, max_values, has_null_counts, null_counts);
 }
 
 TEST(PageIndex, ByteArrayColumnIndex) {
@@ -184,9 +187,9 @@ TEST(PageIndex, ByteArrayColumnIndex) {
   const std::vector<ByteArray> max_values = {ByteArray{max_value}, ByteArray{max_value},
                                              ByteArray{max_value}};
 
-  TestReadTypedColumnIndex<ByteArrayType>(column_id, num_pages, boundary_order,
-                                          page_indices, null_pages, min_values,
-                                          max_values, has_null_counts, null_counts);
+  TestReadTypedColumnIndex<ByteArrayType>(
+      "alltypes_tiny_pages.parquet", column_id, num_pages, boundary_order, page_indices,
+      null_pages, min_values, max_values, has_null_counts, null_counts);
 }
 
 TEST(PageIndex, ReadBoolColumnIndex) {
@@ -200,9 +203,9 @@ TEST(PageIndex, ReadBoolColumnIndex) {
   const std::vector<bool> min_values = {false, false, false};
   const std::vector<bool> max_values = {true, true, true};
 
-  TestReadTypedColumnIndex<BooleanType>(column_id, num_pages, boundary_order,
-                                        page_indices, null_pages, min_values, max_values,
-                                        has_null_counts, null_counts);
+  TestReadTypedColumnIndex<BooleanType>(
+      "alltypes_tiny_pages.parquet", column_id, num_pages, boundary_order, page_indices,
+      null_pages, min_values, max_values, has_null_counts, null_counts);
 }
 
 }  // namespace parquet

--- a/cpp/src/parquet/thrift_internal.h
+++ b/cpp/src/parquet/thrift_internal.h
@@ -100,6 +100,10 @@ static inline Compression::type FromThriftUnsafe(format::CompressionCodec::type 
   }
 }
 
+static inline BoundaryOrder::type FromThriftUnsafe(format::BoundaryOrder::type type) {
+  return static_cast<BoundaryOrder::type>(type);
+}
+
 namespace internal {
 
 template <typename T>
@@ -128,6 +132,11 @@ struct ThriftEnumTypeTraits<::parquet::format::Encoding::type> {
 template <>
 struct ThriftEnumTypeTraits<::parquet::format::PageType::type> {
   using ParquetEnum = PageType;
+};
+
+template <>
+struct ThriftEnumTypeTraits<::parquet::format::BoundaryOrder::type> {
+  using ParquetEnum = BoundaryOrder;
 };
 
 // If the parquet file is corrupted it is possible the enum value decoded

--- a/cpp/src/parquet/types.h
+++ b/cpp/src/parquet/types.h
@@ -532,6 +532,17 @@ class ColumnOrder {
   ColumnOrder::type column_order_;
 };
 
+/// \brief BoundaryOrder is a proxy around format::BoundaryOrder.
+struct BoundaryOrder {
+  enum type {
+    Unordered = 0,
+    Ascending = 1,
+    Descending = 2,
+    // Should always be last element
+    UNDEFINED = 3
+  };
+};
+
 // ----------------------------------------------------------------------
 
 struct ByteArray {

--- a/docs/source/cpp/parquet.rst
+++ b/docs/source/cpp/parquet.rst
@@ -567,3 +567,17 @@ More specifically, Parquet C++ supports:
   supported.
 * EncryptionWithFooterKey and EncryptionWithColumnKey modes.
 * Encrypted Footer and Plaintext Footer modes.
+
+Miscellaneous
+-------------
+
++--------------------------+----------+----------+---------+
+| Feature                  | Reading  | Writing  | Notes   |
++==========================+==========+==========+=========+
+| Column Index             | ✓        |          | \(1)    |
++--------------------------+----------+----------+---------+
+| Offset Index             | ✓        |          | \(1)    |
++--------------------------+----------+----------+---------+
+
+* \(1) Access to the Column and Offset Index structures is provided, but
+  data read APIs do not currently make any use of them.


### PR DESCRIPTION
Basically this patch has defined the interface of `ColumnIndex` and `OffsetIndex`. Implementation classes are also provided to deserialize byte stream, wrap thrift message and provide access to their attributes.

BTW, the naming style throughout the code base looks confusing to me. I have tried to follow what I have understood from the parquet sub-directory. Please correct me if anything is incorrect.