### PR TITLE
GH-14819: [CI][RPM] Add workaround for build failure on CentOS 9 Stream

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow/yum/centos-9-stream/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/yum/centos-9-stream/Dockerfile
@@ -65,3 +65,11 @@ RUN \
     vala \
     zlib-devel && \
   dnf clean ${quiet} all
+
+# Workaround: We can remove this once redhat-rpm-config uses "annobin"
+# not "gcc-annobin".
+RUN \
+  sed \
+    -i \
+    -e 's/gcc-annobin/annobin/g' \
+    /usr/lib/rpm/redhat/redhat-annobin-select-gcc-built-plugin


### PR DESCRIPTION
Closes: #14819

https://github.com/ursacomputing/crossbow/actions/runs/3590866755/jobs/6044735050#step:6:1864

    CMake Error at /usr/share/cmake/Modules/CMakeTestCCompiler.cmake:66 (message):
      The C compiler

        "/opt/rh/gcc-toolset-12/root/usr/bin/gcc"

      is not able to compile a simple test program.

      It fails with the following output:

        Change Dir: ...

        Run Build Command(s):...
        gmake[1]: Entering directory ...
        Building C object CMakeFiles/cmTC_427a1.dir/testCCompiler.c.o
    -- Check for working C compiler: /opt/rh/gcc-toolset-12/root/usr/bin/gcc - broken
        /opt/rh/gcc-toolset-12/root/usr/bin/gcc -O2 -flto=auto
        -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe
        -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2
        -Wp,-D_GLIBCXX_ASSERTIONS
        -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1
        -fstack-protector-strong
        -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64
        -march=x86-64-v2 -mtune=generic -fasynchronous-unwind-tables
        -fstack-clash-protection -fcf-protection -o
        CMakeFiles/cmTC_427a1.dir/testCCompiler.c.o -c
        /root/rpmbuild/BUILD/apache-arrow-11.0.0.dev189/cpp/redhat-linux-build/CMakeFiles/CMakeTmp/testCCompiler.c

        cc1: fatal error: inaccessible plugin file
        /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/plugin/gcc-annobin.so
        expanded from short plugin name gcc-annobin: No such file or
        directory
* Closes: #14819