### PR TITLE
MINOR: [Dev] Add triage users

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -20,9 +20,9 @@ github:
   homepage: https://arrow.apache.org/
   collaborators:
     - assignUser
+    - milesgranger
     - raulcd
     - toddfarmer
-    - milesgranger
 
 notifications:
   commits:      commits@arrow.apache.org

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -22,6 +22,7 @@ github:
     - assignUser
     - raulcd
     - toddfarmer
+    - milesgranger
 
 notifications:
   commits:      commits@arrow.apache.org


### PR DESCRIPTION
Similarly as https://github.com/apache/arrow/pull/14719

@milesgranger has been contributing regularly the last few months both in PRs (https://github.com/apache/arrow/commits?author=milesgranger) as issue triage. Adding him to the collaborators (triage role) enables him to do that on github as well (disclaimer: Miles is a colleague of mine).