### PR TITLE
GH-14736: [C++][Python] Ensure no validity bitmap in UnionArray::SetData

### DIFF
--- a/cpp/src/arrow/array/array_nested.cc
+++ b/cpp/src/arrow/array/array_nested.cc
@@ -681,6 +681,9 @@ void SparseUnionArray::SetData(std::shared_ptr<ArrayData> data) {
   this->UnionArray::SetData(std::move(data));
   ARROW_CHECK_EQ(data_->type->id(), Type::SPARSE_UNION);
   ARROW_CHECK_EQ(data_->buffers.size(), 2);
+
+  // No validity bitmap
+  data_->buffers[0] = nullptr;
 }
 
 void DenseUnionArray::SetData(const std::shared_ptr<ArrayData>& data) {
@@ -688,6 +691,9 @@ void DenseUnionArray::SetData(const std::shared_ptr<ArrayData>& data) {
 
   ARROW_CHECK_EQ(data_->type->id(), Type::DENSE_UNION);
   ARROW_CHECK_EQ(data_->buffers.size(), 3);
+
+  // No validity bitmap
+  data_->buffers[0] = nullptr;
 
   raw_value_offsets_ = data->GetValuesSafe<int32_t>(2, /*offset=*/0);
 }

--- a/cpp/src/arrow/array/array_nested.cc
+++ b/cpp/src/arrow/array/array_nested.cc
@@ -681,9 +681,6 @@ void SparseUnionArray::SetData(std::shared_ptr<ArrayData> data) {
   this->UnionArray::SetData(std::move(data));
   ARROW_CHECK_EQ(data_->type->id(), Type::SPARSE_UNION);
   ARROW_CHECK_EQ(data_->buffers.size(), 2);
-
-  // No validity bitmap
-  ARROW_CHECK_EQ(data_->buffers[0], nullptr);
 }
 
 void DenseUnionArray::SetData(const std::shared_ptr<ArrayData>& data) {
@@ -691,9 +688,6 @@ void DenseUnionArray::SetData(const std::shared_ptr<ArrayData>& data) {
 
   ARROW_CHECK_EQ(data_->type->id(), Type::DENSE_UNION);
   ARROW_CHECK_EQ(data_->buffers.size(), 3);
-
-  // No validity bitmap
-  ARROW_CHECK_EQ(data_->buffers[0], nullptr);
 
   raw_value_offsets_ = data->GetValuesSafe<int32_t>(2, /*offset=*/0);
 }

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1277,7 +1277,8 @@ def test_union_arrays_with_validity_map():
             type=union.type, length=len(union), buffers=buffers,
             offset=0, children=[union.field(0), union.field(1)])
 
-        # Validity map doesn't affect children
+        # Validity map doesn't affect children, and was set to null
+        assert union_with_validity_bitmap.buffers()[0] is None
         assert union_with_validity_bitmap.field(0) == union.field(0)
         assert union_with_validity_bitmap.field(1) == union.field(1)
 


### PR DESCRIPTION
Will close #14736 
* Closes: #14736