### PR TITLE
GH-14824: [CI] r-binary-packages should only upload artifacts if all tests succeed 

### DIFF
--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -355,7 +355,7 @@ jobs:
 
   upload-binaries:
     # Only upload binaries if all tests pass.
-    needs: [ r-packages, test-source, test-linux-binary, test-centos-binary]
+    needs: [r-packages, test-source, test-linux-binary, test-centos-binary]
     name: Upload artifacts
     runs-on: ubuntu-latest
     steps:

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -355,7 +355,7 @@ jobs:
 
   upload-binaries:
     # Only upload binaries if all tests pass.
-    needs: [ r-packages, test-source, test-linux-binary]
+    needs: [ r-packages, test-source, test-linux-binary, test-centos-binary]
     name: Upload artifacts
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION

* Closes: #14824