### PR TITLE
GH-14849: [CI] R install-local builds sometimes fail because sccache times out

### DIFF
--- a/dev/tasks/r/github.macos-linux.local.yml
+++ b/dev/tasks/r/github.macos-linux.local.yml
@@ -52,6 +52,8 @@ jobs:
             >> "$GITHUB_ENV"
         if: contains(matrix.os, 'ubuntu')
       - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
       - name: Install dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/dev/tasks/r/github.macos-linux.local.yml
+++ b/dev/tasks/r/github.macos-linux.local.yml
@@ -69,6 +69,7 @@ jobs:
           ARROW_R_DEV: TRUE
         {{ macros.github_set_sccache_envvars()|indent(8)}}  
         run: |
+          sccache --start-server
           cd arrow/r
           R CMD INSTALL . --install-tests
       - name: Run the tests


### PR DESCRIPTION
Explicitly starting the sccache server prior to the compilation has removed the flakiness in my testing. 
* Closes: #14849