### PR TITLE
GH-14856: [CI] Azure builds fail with docker permission error

### DIFF
--- a/dev/tasks/docker-tests/azure.linux.yml
+++ b/dev/tasks/docker-tests/azure.linux.yml
@@ -30,12 +30,6 @@ jobs:
   {% endif %}
 
   steps:
-  - task: DockerInstaller@0
-    displayName: Docker Installer
-    inputs:
-      dockerVersion: 17.09.0-ce
-      releaseType: stable
-
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '3.8'


### PR DESCRIPTION
The azure runners are now based on the GHA images and have docker preinstalled. Removing the `DockerInstaller` task seems to solve the issue https://dev.azure.com/ursacomputing/crossbow/_build/results?buildId=41026&view=logs&j=0da5d1d9-276d-5173-c4c4-9d4d4ed14fdb
* Closes: #14856