### PR TITLE
GH-14791: [JS] Fix BitmapBufferBuilder size truncation

### DIFF
--- a/js/jest.config.js
+++ b/js/jest.config.js
@@ -16,38 +16,46 @@
 // under the License.
 
 export default {
-  verbose: false,
-  testEnvironment: "node",
-  globals: {
-    "ts-jest": {
-      diagnostics: false,
-      tsconfig: "test/tsconfig.json",
-      useESM: true,
+    verbose: false,
+    testEnvironment: "node",
+    rootDir: ".",
+    roots: [
+        "<rootDir>/test/",
+    ],
+    extensionsToTreatAsEsm: [".ts"],
+    moduleFileExtensions: ["js", "mjs", "ts"],
+    coverageReporters: ["lcov", "json",],
+    coveragePathIgnorePatterns: [
+        "fb\\/.*\\.(js|ts)$",
+        "test\\/.*\\.(ts|js)$",
+        "/node_modules/",
+    ],
+    moduleNameMapper: {
+        "^apache-arrow$": "<rootDir>/src/Arrow.node",
+        "^apache-arrow(.*)": "<rootDir>/src$1",
+        "^(\\.{1,2}/.*)\\.js$": "$1",
     },
-  },
-  rootDir: ".",
-  roots: ["<rootDir>/test/"],
-  preset: "ts-jest/presets/default-esm",
-  moduleFileExtensions: ["mjs", "js", "ts"],
-  coverageReporters: ["lcov", "json"],
-  coveragePathIgnorePatterns: [
-    "fb\\/.*\\.(js|ts)$",
-    "test\\/.*\\.(ts|js)$",
-    "/node_modules/",
-  ],
-  transform: {
-    "^.+\\.js$": "ts-jest",
-    "^.+\\.ts$": "ts-jest",
-  },
-  transformIgnorePatterns: [
-    "/targets/(es5|es2015|esnext|apache-arrow)/",
-    "/node_modules/(?!@openpgp/web-stream-tools)/",
-  ],
-  testRegex: "(.*(-|\\.)(test|spec)s?)\\.(ts|js)$",
-  testMatch: null,
-  moduleNameMapper: {
-    "^apache-arrow$": "<rootDir>/src/Arrow.node",
-    "^apache-arrow(.*)": "<rootDir>/src$1",
-    "^(\\.{1,2}/.*)\\.js$": "$1",
-  },
+    testRegex: "(.*(-|\\.)(test|spec)s?)\\.(ts|js)$",
+    transform: {
+        "^.+\\.js$": [
+            "ts-jest",
+            {
+                diagnostics: false,
+                tsconfig: "test/tsconfig.json",
+                useESM: true,
+            },
+        ],
+        "^.+\\.ts$": [
+            "ts-jest",
+            {
+                diagnostics: false,
+                tsconfig: "test/tsconfig.json",
+                useESM: true,
+            },
+        ],
+    },
+    transformIgnorePatterns: [
+        "/targets/(es5|es2015|esnext|apache-arrow)/",
+        "/node_modules/(?!@openpgp/web-stream-tools)/",
+    ],
 };

--- a/js/jestconfigs/jest.apache-arrow.config.js
+++ b/js/jestconfigs/jest.apache-arrow.config.js
@@ -20,16 +20,28 @@ import config from "../jest.config.js";
 export default {
     ...config,
     rootDir: "../",
-    preset: "ts-jest",
     moduleFileExtensions: ["js", "ts"],
-    globals: {
-        "ts-jest": {
-            diagnostics: false,
-            tsconfig: "<rootDir>/test/tsconfig/tsconfig.apache-arrow.json",
-        },
-    },
     moduleNameMapper: {
         "^apache-arrow(.*)": "<rootDir>/targets/apache-arrow$1",
         "^(\\.{1,2}/.*)\\.js$": "$1",
+    },
+    transform: {
+        ...config.transform,
+        "^.+\\.js$": [
+            "ts-jest",
+            {
+                diagnostics: false,
+                tsconfig: "<rootDir>/test/tsconfig/tsconfig.apache-arrow.json",
+                useESM: true,
+            },
+        ],
+        "^.+\\.ts$": [
+            "ts-jest",
+            {
+                diagnostics: false,
+                tsconfig: "<rootDir>/test/tsconfig/tsconfig.apache-arrow.json",
+                useESM: true,
+            },
+        ],
     },
 };

--- a/js/jestconfigs/jest.coverage.config.js
+++ b/js/jestconfigs/jest.coverage.config.js
@@ -22,11 +22,23 @@ export default {
     rootDir: "../",
     collectCoverage: true,
     reporters: undefined,
-    globals: {
-        "ts-jest": {
-            diagnostics: false,
-            tsconfig: "<rootDir>/test/tsconfig/tsconfig.coverage.json",
-            useESM: true,
-        },
+    transform: {
+        ...config.transform,
+        "^.+\\.js$": [
+            "ts-jest",
+            {
+                diagnostics: false,
+                tsconfig: "<rootDir>/test/tsconfig/tsconfig.coverage.json",
+                useESM: true,
+            },
+        ],
+        "^.+\\.ts$": [
+            "ts-jest",
+            {
+                diagnostics: false,
+                tsconfig: "<rootDir>/test/tsconfig/tsconfig.coverage.json",
+                useESM: true,
+            },
+        ],
     },
 };

--- a/js/jestconfigs/jest.es2015.cjs.config.js
+++ b/js/jestconfigs/jest.es2015.cjs.config.js
@@ -20,16 +20,26 @@ import config from "../jest.config.js";
 export default {
     ...config,
     rootDir: "../",
-    preset: "ts-jest",
     moduleFileExtensions: ["js", "ts"],
-    globals: {
-        "ts-jest": {
-            diagnostics: false,
-            tsconfig: "<rootDir>/test/tsconfig/tsconfig.es2015.cjs.json",
-        },
-    },
     moduleNameMapper: {
         "^apache-arrow(.*)": "<rootDir>/targets/es2015/cjs$1",
         "^(\\.{1,2}/.*)\\.js$": "$1",
+    },
+    transform: {
+        ...config.transform,
+        "^.+\\.js$": [
+            "ts-jest",
+            {
+                diagnostics: false,
+                tsconfig: "<rootDir>/test/tsconfig/tsconfig.es2015.cjs.json",
+            },
+        ],
+        "^.+\\.ts$": [
+            "ts-jest",
+            {
+                diagnostics: false,
+                tsconfig: "<rootDir>/test/tsconfig/tsconfig.es2015.cjs.json",
+            },
+        ],
     },
 };

--- a/js/jestconfigs/jest.es2015.esm.config.js
+++ b/js/jestconfigs/jest.es2015.esm.config.js
@@ -20,16 +20,28 @@ import config from "../jest.config.js";
 export default {
     ...config,
     rootDir: "../",
-    globals: {
-        "ts-jest": {
-            diagnostics: false,
-            tsconfig: "<rootDir>/test/tsconfig/tsconfig.es2015.esm.json",
-            useESM: true,
-        },
-    },
     moduleNameMapper: {
         "^apache-arrow(.*)": "<rootDir>/targets/es2015/esm$1",
         tslib: "tslib/tslib.es6.js",
         "^(\\.{1,2}/.*)\\.js$": "$1",
+    },
+    transform: {
+        ...config.transform,
+        "^.+\\.js$": [
+            "ts-jest",
+            {
+                diagnostics: false,
+                tsconfig: "<rootDir>/test/tsconfig/tsconfig.es2015.esm.json",
+                useESM: true,
+            },
+        ],
+        "^.+\\.ts$": [
+            "ts-jest",
+            {
+                diagnostics: false,
+                tsconfig: "<rootDir>/test/tsconfig/tsconfig.es2015.esm.json",
+                useESM: true,
+            },
+        ],
     },
 };

--- a/js/jestconfigs/jest.es2015.umd.config.js
+++ b/js/jestconfigs/jest.es2015.umd.config.js
@@ -20,16 +20,26 @@ import config from "../jest.config.js";
 export default {
     ...config,
     rootDir: "../",
-    preset: "ts-jest",
     moduleFileExtensions: ["js", "ts"],
-    globals: {
-        "ts-jest": {
-            diagnostics: false,
-            tsconfig: "<rootDir>/test/tsconfig/tsconfig.es2015.umd.json",
-        },
-    },
     moduleNameMapper: {
         "^apache-arrow": "<rootDir>/targets/es2015/umd/Arrow.js",
         "^(\\.{1,2}/.*)\\.js$": "$1",
+    },
+    transform: {
+        ...config.transform,
+        "^.+\\.js$": [
+            "ts-jest",
+            {
+                diagnostics: false,
+                tsconfig: "<rootDir>/test/tsconfig/tsconfig.es2015.umd.json",
+            },
+        ],
+        "^.+\\.ts$": [
+            "ts-jest",
+            {
+                diagnostics: false,
+                tsconfig: "<rootDir>/test/tsconfig/tsconfig.es2015.umd.json",
+            },
+        ],
     },
 };

--- a/js/jestconfigs/jest.es5.cjs.config.js
+++ b/js/jestconfigs/jest.es5.cjs.config.js
@@ -20,16 +20,26 @@ import config from "../jest.config.js";
 export default {
     ...config,
     rootDir: "../",
-    preset: "ts-jest",
     moduleFileExtensions: ["js", "ts"],
-    globals: {
-        "ts-jest": {
-            diagnostics: false,
-            tsconfig: "<rootDir>/test/tsconfig/tsconfig.es5.cjs.json",
-        },
-    },
     moduleNameMapper: {
         "^apache-arrow(.*)": "<rootDir>/targets/es5/cjs$1",
         "^(\\.{1,2}/.*)\\.js$": "$1",
+    },
+    transform: {
+        ...config.transform,
+        "^.+\\.js$": [
+            "ts-jest",
+            {
+                diagnostics: false,
+                tsconfig: "<rootDir>/test/tsconfig/tsconfig.es5.cjs.json",
+            },
+        ],
+        "^.+\\.ts$": [
+            "ts-jest",
+            {
+                diagnostics: false,
+                tsconfig: "<rootDir>/test/tsconfig/tsconfig.es5.cjs.json",
+            },
+        ],
     },
 };

--- a/js/jestconfigs/jest.es5.esm.config.js
+++ b/js/jestconfigs/jest.es5.esm.config.js
@@ -20,16 +20,28 @@ import config from "../jest.config.js";
 export default {
     ...config,
     rootDir: "../",
-    globals: {
-        "ts-jest": {
-            diagnostics: false,
-            tsconfig: "<rootDir>/test/tsconfig/tsconfig.es5.esm.json",
-            useESM: true,
-        },
-    },
     moduleNameMapper: {
         "^apache-arrow(.*)": "<rootDir>/targets/es5/esm$1",
         tslib: "tslib/tslib.es6.js",
         "^(\\.{1,2}/.*)\\.js$": "$1",
+    },
+    transform: {
+        ...config.transform,
+        "^.+\\.js$": [
+            "ts-jest",
+            {
+                diagnostics: false,
+                tsconfig: "<rootDir>/test/tsconfig/tsconfig.es5.esm.json",
+                useESM: true,
+            },
+        ],
+        "^.+\\.ts$": [
+            "ts-jest",
+            {
+                diagnostics: false,
+                tsconfig: "<rootDir>/test/tsconfig/tsconfig.es5.esm.json",
+                useESM: true,
+            },
+        ],
     },
 };

--- a/js/jestconfigs/jest.es5.umd.config.js
+++ b/js/jestconfigs/jest.es5.umd.config.js
@@ -20,16 +20,26 @@ import config from "../jest.config.js";
 export default {
     ...config,
     rootDir: "../",
-    preset: "ts-jest",
     moduleFileExtensions: ["js", "ts"],
-    globals: {
-        "ts-jest": {
-            diagnostics: false,
-            tsconfig: "<rootDir>/test/tsconfig/tsconfig.es5.umd.json",
-        },
-    },
     moduleNameMapper: {
         "^apache-arrow": "<rootDir>/targets/es5/umd/Arrow.js",
         "^(\\.{1,2}/.*)\\.js$": "$1",
+    },
+    transform: {
+        ...config.transform,
+        "^.+\\.js$": [
+            "ts-jest",
+            {
+                diagnostics: false,
+                tsconfig: "<rootDir>/test/tsconfig/tsconfig.es5.umd.json",
+            },
+        ],
+        "^.+\\.ts$": [
+            "ts-jest",
+            {
+                diagnostics: false,
+                tsconfig: "<rootDir>/test/tsconfig/tsconfig.es5.umd.json",
+            },
+        ],
     },
 };

--- a/js/jestconfigs/jest.esnext.cjs.config.js
+++ b/js/jestconfigs/jest.esnext.cjs.config.js
@@ -20,16 +20,26 @@ import config from "../jest.config.js";
 export default {
     ...config,
     rootDir: "../",
-    preset: "ts-jest",
     moduleFileExtensions: ["js", "ts"],
-    globals: {
-        "ts-jest": {
-            diagnostics: false,
-            tsconfig: "<rootDir>/test/tsconfig/tsconfig.esnext.cjs.json",
-        },
-    },
     moduleNameMapper: {
         "^apache-arrow(.*)": "<rootDir>/targets/esnext/cjs$1",
         "^(\\.{1,2}/.*)\\.js$": "$1",
+    },
+    transform: {
+        ...config.transform,
+        "^.+\\.js$": [
+            "ts-jest",
+            {
+                diagnostics: false,
+                tsconfig: "<rootDir>/test/tsconfig/tsconfig.esnext.cjs.json",
+            },
+        ],
+        "^.+\\.ts$": [
+            "ts-jest",
+            {
+                diagnostics: false,
+                tsconfig: "<rootDir>/test/tsconfig/tsconfig.esnext.cjs.json",
+            },
+        ],
     },
 };

--- a/js/jestconfigs/jest.esnext.esm.config.js
+++ b/js/jestconfigs/jest.esnext.esm.config.js
@@ -20,16 +20,28 @@ import config from "../jest.config.js";
 export default {
     ...config,
     rootDir: "../",
-    globals: {
-        "ts-jest": {
-            diagnostics: false,
-            tsconfig: "<rootDir>/test/tsconfig/tsconfig.esnext.esm.json",
-            useESM: true,
-        },
-    },
     moduleNameMapper: {
         "^apache-arrow(.*)": "<rootDir>/targets/esnext/esm$1",
         tslib: "tslib/tslib.es6.js",
         "^(\\.{1,2}/.*)\\.js$": "$1",
+    },
+    transform: {
+        ...config.transform,
+        "^.+\\.js$": [
+            "ts-jest",
+            {
+                diagnostics: false,
+                tsconfig: "<rootDir>/test/tsconfig/tsconfig.esnext.esm.json",
+                useESM: true,
+            },
+        ],
+        "^.+\\.ts$": [
+            "ts-jest",
+            {
+                diagnostics: false,
+                tsconfig: "<rootDir>/test/tsconfig/tsconfig.esnext.esm.json",
+                useESM: true,
+            },
+        ],
     },
 };

--- a/js/jestconfigs/jest.esnext.umd.config.js
+++ b/js/jestconfigs/jest.esnext.umd.config.js
@@ -20,16 +20,26 @@ import config from "../jest.config.js";
 export default {
     ...config,
     rootDir: "../",
-    preset: "ts-jest",
     moduleFileExtensions: ["js", "ts"],
-    globals: {
-        "ts-jest": {
-            diagnostics: false,
-            tsconfig: "<rootDir>/test/tsconfig/tsconfig.esnext.umd.json",
-        },
-    },
     moduleNameMapper: {
         "^apache-arrow": "<rootDir>/targets/esnext/umd/Arrow.js",
         "^(\\.{1,2}/.*)\\.js$": "$1",
+    },
+    transform: {
+        ...config.transform,
+        "^.+\\.js$": [
+            "ts-jest",
+            {
+                diagnostics: false,
+                tsconfig: "<rootDir>/test/tsconfig/tsconfig.esnext.umd.json",
+            },
+        ],
+        "^.+\\.ts$": [
+            "ts-jest",
+            {
+                diagnostics: false,
+                tsconfig: "<rootDir>/test/tsconfig/tsconfig.esnext.umd.json",
+            },
+        ],
     },
 };

--- a/js/jestconfigs/jest.src.config.js
+++ b/js/jestconfigs/jest.src.config.js
@@ -20,11 +20,23 @@ import config from "../jest.config.js";
 export default {
     ...config,
     rootDir: "../",
-    globals: {
-        "ts-jest": {
-            diagnostics: false,
-            tsconfig: "<rootDir>/test/tsconfig/tsconfig.src.json",
-            useESM: true,
-        },
+    transform: {
+        ...config.transform,
+        "^.+\\.js$": [
+            "ts-jest",
+            {
+                diagnostics: false,
+                tsconfig: "<rootDir>/test/tsconfig/tsconfig.src.json",
+                useESM: true,
+            },
+        ],
+        "^.+\\.ts$": [
+            "ts-jest",
+            {
+                diagnostics: false,
+                tsconfig: "<rootDir>/test/tsconfig/tsconfig.src.json",
+                useESM: true,
+            },
+        ],
     },
 };

--- a/js/jestconfigs/jest.ts.config.js
+++ b/js/jestconfigs/jest.ts.config.js
@@ -20,16 +20,28 @@ import config from "../jest.config.js";
 export default {
     ...config,
     rootDir: "../",
-    globals: {
-        "ts-jest": {
-            diagnostics: false,
-            tsconfig: "<rootDir>/test/tsconfig/tsconfig.ts.json",
-            useESM: true,
-        },
-    },
     moduleNameMapper: {
         "^apache-arrow$": "<rootDir>/targets/ts/Arrow.node",
         "^apache-arrow(.*)": "<rootDir>/targets/ts$1",
         "^(\\.{1,2}/.*)\\.js$": "$1",
+    },
+    transform: {
+        ...config.transform,
+        "^.+\\.js$": [
+            "ts-jest",
+            {
+                diagnostics: false,
+                tsconfig: "<rootDir>/test/tsconfig/tsconfig.ts.json",
+                useESM: true,
+            },
+        ],
+        "^.+\\.ts$": [
+            "ts-jest",
+            {
+                diagnostics: false,
+                tsconfig: "<rootDir>/test/tsconfig/tsconfig.ts.json",
+                useESM: true,
+            },
+        ],
     },
 };

--- a/js/src/bin/arrow2csv.ts
+++ b/js/src/bin/arrow2csv.ts
@@ -178,10 +178,10 @@ function batchesToString(state: ToStringState, schema: Schema) {
                 maxColWidths = state.maxColWidths;
                 for (const row of batch) {
                     if (state.closed) { break; } else if (!row) { continue; }
-                    if (rowId++ % 350 === 0) {
+                    if (rowId % 350 === 0) {
                         this.push(`${formatRow(header, maxColWidths, sep)}\n`);
                     }
-                    this.push(`${formatRow([rowId, ...row.toArray()].map(v => valueToString(v)), maxColWidths, sep)}\n`);
+                    this.push(`${formatRow([rowId++, ...row.toArray()].map(v => valueToString(v)), maxColWidths, sep)}\n`);
                 }
             }
             cb();

--- a/js/test/generate-test-data.ts
+++ b/js/test/generate-test-data.ts
@@ -655,7 +655,7 @@ function createVariableWidthOffsets(length: number, nullBitmap: Uint8Array, max 
             offsets[i + 1] = offsets[i];
         } else {
             do {
-                offsets[i + 1] = Math.min(max, offsets[i] + (Math.trunc(rand() * stride)));
+                offsets[i + 1] = Math.min(max, offsets[i] + Math.max(10, Math.trunc(rand() * stride)));
             } while (!allowEmpty && offsets[i + 1] === offsets[i]);
         }
     });

--- a/js/test/generate-test-data.ts
+++ b/js/test/generate-test-data.ts
@@ -638,7 +638,7 @@ function iterateBitmap(length: number, bitmap: Uint8Array, fn: (index: number, v
 
 function createBitmap(length: number, nullCount: number) {
     const nulls = Object.create(null) as { [key: number]: boolean };
-    const bytes = new Uint8Array((((length >> 3) + 7) & ~7) || 8).fill(255);
+    const bytes = new Uint8Array((Math.ceil(length / 8) + 63) & ~63).fill(255);
     for (let i, j = -1; ++j < nullCount;) {
         // eslint-disable-next-line unicorn/prefer-math-trunc
         while (nulls[i = (rand() * length) | 0]);

--- a/js/test/unit/builders/builder-tests.ts
+++ b/js/test/unit/builders/builder-tests.ts
@@ -75,6 +75,7 @@ function validateBuilder(generate: (length?: number, nullCount?: number, ...args
     for (let i = -1; ++i < 1;) {
         validateBuilderWithNullValues(`no nulls`, [], generate(100, 0));
         validateBuilderWithNullValues(`with nulls`, [null], generate(100));
+        validateBuilderWithNullValues(`with nulls (length=518)`, [null], generate(518));
         if (DataType.isUtf8(type)) {
             validateBuilderWithNullValues(`with \\0`, ['\0'], generate(100));
             validateBuilderWithNullValues(`with n/a`, ['n/a'], generate(100));


### PR DESCRIPTION
* https://github.com/apache/arrow/commit/730e9c5f924448c2d8a0c2951c57c6ed5715e86f updates `ts-jest` configuration to remove deprecation warnings
* https://github.com/apache/arrow/commit/e4d83f2fb2beac9e4e214ef888767c149f558124 updates `print-buffer-alignment.js`  debug utility for latest APIs
* https://github.com/apache/arrow/commit/3b9d18c62c4c3769aa12cdaba8109efc64359348 updates `arrow2csv` to print zero-based rowIds
* https://github.com/apache/arrow/commit/b6c42f30773dcf9a13683ce585c3f9cd1a3ad78b fixes https://github.com/apache/arrow/issues/14791


* Closes: #14791