### PR TITLE
MINOR: [C++] Fix spacing in temporal cast error message

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_cast_temporal.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_temporal.cc
@@ -419,12 +419,12 @@ struct ParseTimestamp {
       if (expect_timezone) {
         *st = Status::Invalid(
             "Failed to parse string: '", val, "' as a scalar of type ", type.ToString(),
-            "expected a zone offset. If these timestamps "
+            ": expected a zone offset. If these timestamps "
             "are in local time, cast to timestamp without timezone, then "
             "call assume_timezone.");
       } else {
         *st = Status::Invalid("Failed to parse string: '", val, "' as a scalar of type ",
-                              type.ToString(), "expected no zone offset");
+                              type.ToString(), ": expected no zone offset.");
       }
     }
     return result;


### PR DESCRIPTION
Currently you get an error like "ArrowInvalid: Failed to parse string: '2021-01-02 00:00:00+01:00' as a scalar of type timestamp[s]expected no zone offset"