### PR TITLE
GH-14872: [R] arrow returns wrong variable content when multiple group_by/summarise statements are used

### DIFF
--- a/r/tests/testthat/test-dplyr-group-by.R
+++ b/r/tests/testthat/test-dplyr-group-by.R
@@ -52,6 +52,16 @@ test_that("group_by supports creating/renaming", {
   )
 })
 
+test_that("group_by supports re-grouping by overlapping groups", {
+  compare_dplyr_binding(
+    .input %>%
+      group_by(chr, int) %>%
+      group_by(int, dbl) |>
+      collect(),
+    tbl
+  )
+})
+
 test_that("ungroup", {
   compare_dplyr_binding(
     .input %>%

--- a/r/tests/testthat/test-dplyr-group-by.R
+++ b/r/tests/testthat/test-dplyr-group-by.R
@@ -60,6 +60,14 @@ test_that("group_by supports re-grouping by overlapping groups", {
       collect(),
     tbl
   )
+
+  compare_dplyr_binding(
+    .input %>%
+      group_by(chr, int) %>%
+      group_by(int, chr = "some new value") %>%
+      collect(),
+    tbl
+  )
 })
 
 test_that("ungroup", {

--- a/r/tests/testthat/test-dplyr-group-by.R
+++ b/r/tests/testthat/test-dplyr-group-by.R
@@ -56,7 +56,7 @@ test_that("group_by supports re-grouping by overlapping groups", {
   compare_dplyr_binding(
     .input %>%
       group_by(chr, int) %>%
-      group_by(int, dbl) |>
+      group_by(int, dbl) %>%
       collect(),
     tbl
   )


### PR DESCRIPTION
Reprex using CRAN arrow:

``` r
library(arrow, warn.conflicts = FALSE)
library(dplyr, warn.conflicts = FALSE)

mtcars |>
  arrow_table() |>
  select(mpg, cyl) |> 
  group_by(mpg, cyl) |>
  group_by(cyl, value = "foo") |>
  collect()
#> # A tibble: 32 × 4
#> # Groups:   cyl, value [3]
#>      mpg   cyl value `"foo"`
#>    <dbl> <dbl> <dbl> <chr>  
#>  1  21       6     6 foo    
#>  2  21       6     6 foo    
#>  3  22.8     4     4 foo    
#>  4  21.4     6     6 foo    
#>  5  18.7     8     8 foo    
#>  6  18.1     6     6 foo    
#>  7  14.3     8     8 foo    
#>  8  24.4     4     4 foo    
#>  9  22.8     4     4 foo    
#> 10  19.2     6     6 foo    
#> # … with 22 more rows
```

<sup>Created on 2022-12-09 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

After this PR:

``` r
library(arrow, warn.conflicts = FALSE)
#> Some features are not enabled in this build of Arrow. Run `arrow_info()` for more information.
library(dplyr, warn.conflicts = FALSE)

mtcars |>
  arrow_table() |>
  select(mpg, cyl) |> 
  group_by(mpg, cyl) |>
  group_by(cyl, value = "foo") |>
  collect()
#> # A tibble: 32 × 3
#> # Groups:   cyl, value [3]
#>      mpg   cyl value
#>    <dbl> <dbl> <chr>
#>  1  21       6 foo  
#>  2  21       6 foo  
#>  3  22.8     4 foo  
#>  4  21.4     6 foo  
#>  5  18.7     8 foo  
#>  6  18.1     6 foo  
#>  7  14.3     8 foo  
#>  8  24.4     4 foo  
#>  9  22.8     4 foo  
#> 10  19.2     6 foo  
#> # … with 22 more rows
```

<sup>Created on 2022-12-09 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
* Closes: #14872