### PR TITLE
MINOR: [Java] ArrowBuf#setOne should have int64 params

### DIFF
--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/ArrowBuf.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/ArrowBuf.java
@@ -1184,7 +1184,7 @@ public final class ArrowBuf implements AutoCloseable {
    * @param length length of bytes to set.
    * @return this ArrowBuf
    */
-  public ArrowBuf setOne(int index, int length) {
+  public ArrowBuf setOne(long index, long length) {
     if (length != 0) {
       this.checkIndex(index, length);
       MemoryUtil.UNSAFE.setMemory(this.addr + index, length, (byte) 0xff);

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/ArrowBuf.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/ArrowBuf.java
@@ -1183,6 +1183,23 @@ public final class ArrowBuf implements AutoCloseable {
    *              this ArrowBuf has access to)
    * @param length length of bytes to set.
    * @return this ArrowBuf
+   * @deprecated use {@link ArrowBuf#setOne(long, long)} instead.
+   */
+  @Deprecated
+  public ArrowBuf setOne(int index, int length) {
+    if (length != 0) {
+      this.checkIndex(index, length);
+      MemoryUtil.UNSAFE.setMemory(this.addr + index, length, (byte) 0xff);
+    }
+    return this;
+  }
+
+  /**
+   * Sets all bits to one in the specified range.
+   * @param index index index (0 based relative to the portion of memory
+   *              this ArrowBuf has access to)
+   * @param length length of bytes to set.
+   * @return this ArrowBuf
    */
   public ArrowBuf setOne(long index, long length) {
     if (length != 0) {


### PR DESCRIPTION
`ArrowBuf#setOne` should have int64 params