### PR TITLE
GH-14916: [C++] Remove the API declaration about "ConcatenateBuffers"

### DIFF
--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -505,10 +505,6 @@ ARROW_EXPORT
 Result<std::shared_ptr<Buffer>> ConcatenateBuffers(const BufferVector& buffers,
                                                    MemoryPool* pool = NULLPTR);
 
-ARROW_EXPORT
-Status ConcatenateBuffers(const BufferVector& buffers, MemoryPool* pool,
-                          std::shared_ptr<Buffer>* out);
-
 /// @}
 
 }  // namespace arrow


### PR DESCRIPTION
The API is deprecated since v0.17 and the implementation has been removed in https://github.com/apache/arrow/commit/ab93ba1f901ad6a2ce3d34404e6b46d2539507db

* Closes: #14916