### PR TITLE
MINOR: [Go][CI] Increase workflow timeout due to benchmarking

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -45,7 +45,7 @@ jobs:
     name: AMD64 Debian 11 Go ${{ matrix.go }}
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -216,7 +216,7 @@ jobs:
     name: AMD64 macOS 11 Go ${{ matrix.go }}
     runs-on: macos-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
With the added benchmarking running, the Go workflows occasionally take longer than the 30 minutes, so we need to increase the workflow timeout time.