### PR TITLE
MINOR: [Docs][Python] Add example of not nullable type in Schema

### DIFF
--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -3270,10 +3270,12 @@ def schema(fields, metadata=None):
     >>> import pyarrow as pa
     >>> pa.schema([
     ...     ('some_int', pa.int32()),
-    ...     ('some_string', pa.string())
+    ...     ('some_string', pa.string()),
+    ...     pa.field('some_required_string', pa.string(), nullable=False)
     ... ])
     some_int: int32
     some_string: string
+    some_required_string: string not null
     >>> pa.schema([
     ...     pa.field('some_int', pa.int32()),
     ...     pa.field('some_string', pa.string())


### PR DESCRIPTION
It took me a while to figure out from the docs how to use a not nullable type in a schema. The inclusion of strings "nullable", "not null" right on the Schema page makes it more easy to find.
Example like this also makes it more clear the tuple Schema takes is shorthand version of Field.