### PR TITLE
GH-14927 : [Dev] Crossbow submit does not work with fine grained PATs 

### DIFF
--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -200,7 +200,7 @@ class GitRemoteCallbacks(PygitRemoteCallbacks):
 
         if (allowed_types &
                 pygit2.credentials.GIT_CREDENTIAL_USERPASS_PLAINTEXT):
-            return pygit2.UserPass(self.token, 'x-oauth-basic')
+            return pygit2.UserPass('x-oauth-basic', self.token)
         else:
             return None
 


### PR DESCRIPTION
The old variant with token passed as name does only work for classic PATS, passing the token as password works for both classic and fine grained PATs.
* Closes: #14927