### PR TITLE
ARROW-17332: [R] error parsing folder path with accent ('c:/Público') in read_csv_arrow

### DIFF
--- a/r/R/filesystem.R
+++ b/r/R/filesystem.R
@@ -618,7 +618,7 @@ copy_files <- function(from, to, chunk_size = 1024L * 1024L) {
 
 clean_path_abs <- function(path) {
   # Make sure we have a valid, absolute, forward-slashed path for passing to Arrow
-  normalizePath(path, winslash = "/", mustWork = FALSE)
+  enc2utf8(normalizePath(path, winslash = "/", mustWork = FALSE))
 }
 
 clean_path_rel <- function(path) {

--- a/r/src/arrow_types.h
+++ b/r/src/arrow_types.h
@@ -109,9 +109,14 @@ static inline void StopIfNotOk(const Status& status) {
     if (unwind_detail) {
       throw cpp11::unwind_exception(unwind_detail->token);
     } else {
-      // ARROW-13039: be careful not to interpret our error message as a %-format string
+      // We need to translate this to "native" encoding for the error to be
+      // displayed properly using cpp11::stop()
       std::string s = status.ToString();
-      cpp11::stop("%s", s.c_str());
+      cpp11::strings s_utf8 = cpp11::as_sexp(s);
+      const char* s_native = cpp11::safe[Rf_translateChar](s_utf8[0]);
+
+      // ARROW-13039: be careful not to interpret our error message as a %-format string
+      cpp11::stop("%s", s_native);
     }
   }
 }

--- a/r/tests/testthat/test-filesystem.R
+++ b/r/tests/testthat/test-filesystem.R
@@ -129,21 +129,6 @@ test_that("LocalFileSystem + Selector", {
   expect_equal(sum(types == FileType$Directory), 1L)
 })
 
-test_that("clean_path_abs() marks its output as utf-8", {
-  f <- tempfile(fileext = "Público")
-  on.exit(unlink(f))
-
-  file.create(f)
-  f_utf8 <- enc2utf8(normalizePath(f, winslash = "/"))
-  f_latin1 <- iconv(f_utf8, "utf-8", "latin1")
-
-  expect_identical(clean_path_abs(f_utf8), f_utf8)
-  expect_identical(Encoding(clean_path_abs(f_utf8)), Encoding(f_utf8))
-
-  expect_identical(clean_path_abs(f_latin1), f_latin1)
-  expect_identical(Encoding(clean_path_abs(f_latin1)), Encoding(f_utf8))
-})
-
 # This test_that block must be above the two that follow it because S3FileSystem$create
 # uses a slightly different set of cpp code that is R-only, so if there are bugs
 # in the initialization of S3 (e.g. ARROW-14667) they will not be caught because

--- a/r/tests/testthat/test-filesystem.R
+++ b/r/tests/testthat/test-filesystem.R
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-
 test_that("LocalFilesystem", {
   fs <- LocalFileSystem$create()
   expect_identical(fs$type_name, "local")
@@ -128,6 +127,21 @@ test_that("LocalFileSystem + Selector", {
   types <- sapply(infos, function(.x) .x$type)
   expect_equal(sum(types == FileType$File), 2L)
   expect_equal(sum(types == FileType$Directory), 1L)
+})
+
+test_that("clean_path_abs() marks its output as utf-8", {
+  f <- tempfile(fileext = "Público")
+  on.exit(unlink(f))
+
+  file.create(f)
+  f_utf8 <- enc2utf8(normalizePath(f))
+  f_latin1 <- iconv(f_utf8, "utf-8", "latin1")
+
+  expect_identical(clean_path_abs(f_utf8), f_utf8)
+  expect_identical(Encoding(clean_path_abs(f_utf8)), Encoding(f_utf8))
+
+  expect_identical(clean_path_abs(f_latin1), f_latin1)
+  expect_identical(Encoding(clean_path_abs(f_latin1)), Encoding(f_utf8))
 })
 
 # This test_that block must be above the two that follow it because S3FileSystem$create

--- a/r/tests/testthat/test-filesystem.R
+++ b/r/tests/testthat/test-filesystem.R
@@ -134,7 +134,7 @@ test_that("clean_path_abs() marks its output as utf-8", {
   on.exit(unlink(f))
 
   file.create(f)
-  f_utf8 <- enc2utf8(normalizePath(f))
+  f_utf8 <- enc2utf8(normalizePath(f, winslash = "/"))
   f_latin1 <- iconv(f_utf8, "utf-8", "latin1")
 
   expect_identical(clean_path_abs(f_utf8), f_utf8)


### PR DESCRIPTION
This PR fixes a bug that prevented some filenames with non-ASCII characters from being openable. The probable culprit is `normalizePath()`, which does some handling of special characters but does not mark the encoding of its output in a way that cpp11's conversion to `std::string` understands.

Because most of our test environments have UTF-8 as the session encoding, this usually works by accident, and it may work by accident in a latin-1 locale too (judging mostly by the fact that our issue thread is not overflowing with complaints of unopenable files, which may or may not be a good metric).

I've added a test for converting the out the output of `normalizePath()` and making sure it's marked as UTF-8. I'll try to replicate this using Docker, too and see if there's any additional test we could add.

The change here brings arrow in line with what the vroom package does for this operation: https://github.com/tidyverse/vroom/blob/main/R/path.R#L322-L324