### PR TITLE
ARROW-17361: [R] dplyr::summarize fails with division when divisor is a variable

### DIFF
--- a/r/tests/testthat/test-dplyr-summarize.R
+++ b/r/tests/testthat/test-dplyr-summarize.R
@@ -739,7 +739,7 @@ test_that("Do things after summarize", {
 })
 
 test_that("Non-field variable references in aggregations", {
-  ds <- Table$create(x = 1:5)
+  ds <- InMemoryDataset$create(data.frame(x = 1:5))
   scale_factor <- 10
   expect_identical(
     ds %>%

--- a/r/tests/testthat/test-dplyr-summarize.R
+++ b/r/tests/testthat/test-dplyr-summarize.R
@@ -738,6 +738,19 @@ test_that("Do things after summarize", {
   )
 })
 
+test_that("Non-field variable references in aggregations", {
+  ds <- Table$create(x = 1:5)
+  scale_factor <- 10
+  expect_identical(
+    ds %>%
+      summarize(value = sum(x) / scale_factor) %>%
+      collect(),
+    ds %>%
+      summarize(value = sum(x) / 10) %>%
+      collect()
+  )
+})
+
 test_that("Expressions on aggregations", {
   # This is what it effectively is
   compare_dplyr_binding(


### PR DESCRIPTION
Before this PR:

``` r
library(dplyr, warn.conflicts = FALSE)
library(arrow, warn.conflicts = FALSE)
#> Some features are not enabled in this build of Arrow. Run `arrow_info()` for more information.

InMemoryDataset$create(data.frame(x = 1:5)) %>%
  summarize(value = sum(x) / 10) %>%
  collect()
#> # A tibble: 1 × 1
#>   value
#>   <dbl>
#> 1   1.5

scale_factor <- 10
InMemoryDataset$create(data.frame(x = 1:5)) %>%
  summarize(value = sum(x) / scale_factor) %>%
  collect()
#> Error: Error in summarize_eval(names(exprs)[i], exprs[[i]], ctx, length(.data$group_by_vars) >  : 
#>   Expression sum(x)/scale_factor is not an aggregate expression or is not supported in Arrow
#> Call collect() first to pull data into R.
```

<sup>Created on 2022-12-13 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

After this PR:

``` r
library(dplyr, warn.conflicts = FALSE)
library(arrow, warn.conflicts = FALSE)
#> Some features are not enabled in this build of Arrow. Run `arrow_info()` for more information.

InMemoryDataset$create(data.frame(x = 1:5)) %>%
  summarize(value = sum(x) / 10) %>%
  collect()
#> # A tibble: 1 × 1
#>   value
#>   <dbl>
#> 1   1.5

scale_factor <- 10
InMemoryDataset$create(data.frame(x = 1:5)) %>%
  summarize(value = sum(x) / scale_factor) %>%
  collect()
#> # A tibble: 1 × 1
#>   value
#>   <dbl>
#> 1   1.5
```

<sup>Created on 2022-12-13 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>