### PR TITLE
GH-14943: [Python] Fix pyarrow.get_libraries() order

### DIFF
--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -415,7 +415,7 @@ def get_libraries():
     Return list of library names to include in the `libraries` argument for C
     or Cython extensions using pyarrow
     """
-    return ['arrow', 'arrow_python']
+    return ['arrow_python', 'arrow']
 
 
 def create_library_symlinks():


### PR DESCRIPTION
pyarrow.get_libraries() returns ['arrow', 'arrow_python'] but it should be ['arrow_python', 'arrow'] because libarrow_python.so depends on libarrow.so.
* Closes: #14943