### PR TITLE
GH-14940: [Go][Parquet] Fix Encryption Column writing

### DIFF
--- a/go/parquet/encryption_read_config_test.go
+++ b/go/parquet/encryption_read_config_test.go
@@ -99,6 +99,7 @@ type TestDecryptionSuite struct {
 	colEncryptionKey1   string
 	colEncryptionKey2   string
 	fileName            string
+	rowsPerRG           int
 }
 
 func (d *TestDecryptionSuite) TearDownSuite() {
@@ -117,6 +118,7 @@ func (d *TestDecryptionSuite) SetupSuite() {
 	d.colEncryptionKey1 = ColumnEncryptionKey1
 	d.colEncryptionKey2 = ColumnEncryptionKey2
 	d.fileName = FileName
+	d.rowsPerRG = 50 // same as write encryption test
 
 	d.createDecryptionConfigs()
 }
@@ -180,6 +182,7 @@ func (d *TestDecryptionSuite) decryptFile(filename string, decryptConfigNum int)
 
 		// get rowgroup meta
 		rgMeta := fileMetadata.RowGroup(r)
+		d.EqualValues(d.rowsPerRG, rgMeta.NumRows())
 
 		valuesRead := 0
 		rowsRead := int64(0)
@@ -193,6 +196,7 @@ func (d *TestDecryptionSuite) decryptFile(filename string, decryptConfigNum int)
 
 		// get column chunk metadata for boolean column
 		boolMd, _ := rgMeta.ColumnChunk(0)
+		d.EqualValues(d.rowsPerRG, boolMd.NumValues())
 
 		// Read all rows in column
 		i := 0
@@ -220,6 +224,7 @@ func (d *TestDecryptionSuite) decryptFile(filename string, decryptConfigNum int)
 		int32reader := colReader.(*file.Int32ColumnChunkReader)
 
 		int32md, _ := rgMeta.ColumnChunk(1)
+		d.EqualValues(d.rowsPerRG, int32md.NumValues())
 		// Read all rows in column
 		i = 0
 		for int32reader.HasNext() {
@@ -245,6 +250,8 @@ func (d *TestDecryptionSuite) decryptFile(filename string, decryptConfigNum int)
 		int64reader := colReader.(*file.Int64ColumnChunkReader)
 
 		int64md, _ := rgMeta.ColumnChunk(2)
+		// repeated column, we should have 2*d.rowsPerRG values
+		d.EqualValues(2*d.rowsPerRG, int64md.NumValues())
 		// Read all rows in column
 		i = 0
 		for int64reader.HasNext() {

--- a/go/parquet/file/page_writer.go
+++ b/go/parquet/file/page_writer.go
@@ -182,8 +182,10 @@ func (pw *serializedPageWriter) updateEncryption(moduleType int8) error {
 		pw.metaEncryptor.UpdateAad(encryption.CreateModuleAad(pw.metaEncryptor.FileAad(), moduleType, pw.rgOrdinal, pw.columnOrdinal, -1))
 	case encryption.DictPageModule:
 		pw.dataEncryptor.UpdateAad(encryption.CreateModuleAad(pw.dataEncryptor.FileAad(), moduleType, pw.rgOrdinal, pw.columnOrdinal, -1))
+	default:
+		return xerrors.New("unknown module type in updateencryption")
 	}
-	return xerrors.New("unknown module type in updateencryption")
+	return nil
 }
 
 func (pw *serializedPageWriter) Close(hasDict, fallback bool) error {


### PR DESCRIPTION
Missed a `default` causing a fall through to always return an error that wasn't being returned through and checked. 

Test updated to validate number of values/rows written. Error is now propagated through if encountered.
* Closes: #14940