### PR TITLE
GH-14949: [CI][Release] Output script's stdout on failure

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -98,6 +98,7 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: |
+          gem install test-unit
           pip install cython setuptools six pytest jira
       - name: Run Release Test
         env:

--- a/dev/release/01-prepare-test.rb
+++ b/dev/release/01-prepare-test.rb
@@ -54,7 +54,9 @@ class PrepareTest < Test::Unit::TestCase
   def test_linux_packages
     user = "Arrow Developers"
     email = "dev@arrow.apache.org"
-    prepare("LINUX_PACKAGES", "DEBFULLNAME" => user, "DEBEMAIL" => email)
+    stdout = prepare("LINUX_PACKAGES",
+                     "DEBFULLNAME" => user,
+                     "DEBEMAIL" => email)
     changes = parse_patch(git("log", "-n", "1", "-p"))
     sampled_changes = changes.collect do |change|
       {
@@ -91,7 +93,7 @@ class PrepareTest < Test::Unit::TestCase
         ],
       },
     ]
-    assert_equal(expected_changes, sampled_changes)
+    assert_equal(expected_changes, sampled_changes, "Output:\n#{stdout}")
   end
 
   def test_version_pre_tag
@@ -273,8 +275,9 @@ class PrepareTest < Test::Unit::TestCase
       }
     end
 
-    prepare("VERSION_PRE_TAG")
+    stdout = prepare("VERSION_PRE_TAG")
     assert_equal(expected_changes.sort_by {|diff| diff[:path]},
-                 parse_patch(git("log", "-n", "1", "-p")))
+                 parse_patch(git("log", "-n", "1", "-p")),
+                 "Output:\n#{stdout}")
   end
 end

--- a/dev/release/post-11-bump-versions-test.rb
+++ b/dev/release/post-11-bump-versions-test.rb
@@ -44,7 +44,7 @@ class PostBumpVersionsTest < Test::Unit::TestCase
     else
       additional_env = {}
     end
-    env = { "BUMP_DEFAULT" => "0" }
+    env = {"BUMP_DEFAULT" => "0"}
     targets.each do |target|
       env["BUMP_#{target}"] = "1"
     end
@@ -259,13 +259,14 @@ class PostBumpVersionsTest < Test::Unit::TestCase
       }
     end
 
-    bump_versions("VERSION_POST_TAG")
+    stdout = bump_versions("VERSION_POST_TAG")
     assert_equal(expected_changes.sort_by {|diff| diff[:path]},
-                 parse_patch(git("log", "-n", "1", "-p")))
+                 parse_patch(git("log", "-n", "1", "-p")),
+                 "Output:\n#{stdout}")
   end
 
   def test_deb_package_names
-    bump_versions("DEB_PACKAGE_NAMES")
+    stdout = bump_versions("DEB_PACKAGE_NAMES")
     changes = parse_patch(git("log", "-n", "1", "-p"))
     sampled_changes = changes.collect do |change|
       first_hunk = change[:hunks][0]
@@ -299,15 +300,15 @@ class PostBumpVersionsTest < Test::Unit::TestCase
         path: "dev/tasks/tasks.yml",
       },
     ]
-    assert_equal(expected_changes, sampled_changes)
+    assert_equal(expected_changes, sampled_changes, "Output:\n#{stdout}")
   end
 
   def test_linux_packages
     name = "Arrow Developers"
     email = "dev@arrow.apache.org"
-    bump_versions("LINUX_PACKAGES",
-                  "DEBFULLNAME" => name,
-                  "DEBEMAIL" => email)
+    stdout = bump_versions("LINUX_PACKAGES",
+                           "DEBFULLNAME" => name,
+                           "DEBEMAIL" => email)
 
     release_time_string = git("log",
                               "--format=%aI",
@@ -367,6 +368,7 @@ class PostBumpVersionsTest < Test::Unit::TestCase
       },
     ]
     assert_equal(expected_changes,
-                 parse_patch(git("log", "-n", "1", "-p")))
+                 parse_patch(git("log", "-n", "1", "-p")),
+                 "Output:\n#{stdout}")
   end
 end


### PR DESCRIPTION
This doesn't solve GH-14949 (CI failure) because it's a problem of  MojoHaus Versions Maven Plugin: https://github.com/mojohaus/versions/issues/848

This adds more debug information on test failure.
* Closes: #14949