### PR TITLE
GH-14945: [Ruby] Add support for macOS 12 / Xcode 14

### DIFF
--- a/ruby/red-arrow/ext/arrow/extconf.rb
+++ b/ruby/red-arrow/ext/arrow/extconf.rb
@@ -77,4 +77,15 @@ end
   add_depend_package_path(name, source_dir, build_dir)
 end
 
+case RUBY_PLATFORM
+when /darwin/
+  symbols_in_external_bundles = [
+    "_rbgerr_gerror2exception",
+    "_rbgobj_instance_from_ruby_object",
+  ]
+  symbols_in_external_bundles.each do |symbol|
+    $DLDFLAGS << " -Wl,-U,#{symbol}"
+  end
+end
+
 create_makefile("arrow")


### PR DESCRIPTION
Xcode 14 shows a warning for "-undefined dynamic_lookup".

We need to use "-U${external_symbol_in_dynamic_loaded_library}" explicitly for all external symbols in dynamic loaded library without "-undefined dynamic_lookup".

In Red Arrow case, we use some symbols in Ruby/GLib2.
* Closes: #14945