### PR TITLE
GH-14961: [Ruby] Use newer extpp for C++17

### DIFF
--- a/ruby/red-arrow/ext/arrow/extconf.rb
+++ b/ruby/red-arrow/ext/arrow/extconf.rb
@@ -38,8 +38,6 @@ checking_for(checking_message("Homebrew")) do
   end
 end
 
-$CXXFLAGS += " -std=c++17 "
-
 unless required_pkg_config_package([
                                      "arrow",
                                      Arrow::Version::MAJOR,

--- a/ruby/red-arrow/red-arrow.gemspec
+++ b/ruby/red-arrow/red-arrow.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.extensions = ["ext/arrow/extconf.rb"]
 
   spec.add_runtime_dependency("bigdecimal", ">= 3.1.0")
-  spec.add_runtime_dependency("extpp", ">= 0.0.7")
+  spec.add_runtime_dependency("extpp", ">= 0.1.1")
   spec.add_runtime_dependency("gio2", ">= 3.5.0")
   spec.add_runtime_dependency("native-package-installer")
   spec.add_runtime_dependency("pkg-config")


### PR DESCRIPTION
Recent extpp support C++17. We can remove C++17 workaround with recent extpp.
* Closes: #14961