### PR TITLE
GH-33596: [C++][Parquet] Parquet page index read support

### DIFF
--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -130,9 +130,12 @@ set(PARQUET_STATIC_TEST_LINK_LIBS ${PARQUET_MIN_TEST_LIBS} parquet_static thrift
 
 #
 # Generated Thrift sources
-set_source_files_properties(src/generated/parquet_types.cpp src/generated/parquet_types.h
-                            src/generated/parquet_constants.cpp
-                            src/generated/parquet_constants.h
+set(PARQUET_THRIFT_SOURCE_DIR "${ARROW_SOURCE_DIR}/src/generated/")
+
+set_source_files_properties("${PARQUET_THRIFT_SOURCE_DIR}/parquet_types.cpp"
+                            "${PARQUET_THRIFT_SOURCE_DIR}/parquet_types.h"
+                            "${PARQUET_THRIFT_SOURCE_DIR}/parquet_constants.cpp"
+                            "${PARQUET_THRIFT_SOURCE_DIR}/parquet_constants.h"
                             PROPERTIES SKIP_PRECOMPILE_HEADERS ON
                                        SKIP_UNITY_BUILD_INCLUSION ON)
 
@@ -167,8 +170,8 @@ set(PARQUET_SRCS
     metadata.cc
     xxhasher.cc
     page_index.cc
-    "${ARROW_SOURCE_DIR}/src/generated/parquet_constants.cpp"
-    "${ARROW_SOURCE_DIR}/src/generated/parquet_types.cpp"
+    "${PARQUET_THRIFT_SOURCE_DIR}/parquet_constants.cpp"
+    "${PARQUET_THRIFT_SOURCE_DIR}/parquet_types.cpp"
     platform.cc
     printer.cc
     properties.cc
@@ -277,8 +280,8 @@ add_arrow_lib(parquet
 
 if(WIN32 AND NOT (ARROW_TEST_LINKAGE STREQUAL "static"))
   add_library(parquet_test_support STATIC
-              "${ARROW_SOURCE_DIR}/src/generated/parquet_constants.cpp"
-              "${ARROW_SOURCE_DIR}/src/generated/parquet_types.cpp")
+              "${PARQUET_THRIFT_SOURCE_DIR}/parquet_constants.cpp"
+              "${PARQUET_THRIFT_SOURCE_DIR}/parquet_types.cpp")
   target_link_libraries(parquet_test_support thrift::thrift)
   set(PARQUET_SHARED_TEST_LINK_LIBS ${PARQUET_SHARED_TEST_LINK_LIBS} parquet_test_support)
   set(PARQUET_LIBRARIES ${PARQUET_LIBRARIES} parquet_test_support)

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -305,7 +305,12 @@ class SerializedFile : public ParquetFileReader::Contents {
 
   std::shared_ptr<PageIndexReader> GetPageIndexReader() override {
     if (!file_metadata_) {
-      throw ParquetException("Cannot get PageIndexReader as file metadata is not ready");
+      // Usually this won't happen if user calls one of the static Open() functions
+      // to create a ParquetFileReader instance. But if user calls the constructor
+      // directly and calls GetPageIndexReader() before Open() then this could happen.
+      throw ParquetException(
+          "Cannot call GetPageIndexReader() due to missing file metadata. Did you "
+          "forget to call ParquetFileReader::Open() first?");
     }
     if (!page_index_reader_) {
       page_index_reader_ = PageIndexReader::Make(source_.get(), file_metadata_,

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -303,7 +303,7 @@ class SerializedFile : public ParquetFileReader::Contents {
 
   std::shared_ptr<FileMetaData> metadata() const override { return file_metadata_; }
 
-  std::shared_ptr<PageIndexReader> page_index_reader() override {
+  std::shared_ptr<PageIndexReader> GetPageIndexReader() override {
     if (!file_metadata_) {
       throw ParquetException("Cannot get PageIndexReader as file metadata is not ready");
     }
@@ -797,7 +797,7 @@ std::shared_ptr<FileMetaData> ParquetFileReader::metadata() const {
 }
 
 std::shared_ptr<PageIndexReader> ParquetFileReader::page_index_reader() {
-  return contents_->page_index_reader();
+  return contents_->GetPageIndexReader();
 }
 
 std::shared_ptr<RowGroupReader> ParquetFileReader::RowGroup(int i) {

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -796,7 +796,7 @@ std::shared_ptr<FileMetaData> ParquetFileReader::metadata() const {
   return contents_->metadata();
 }
 
-std::shared_ptr<PageIndexReader> ParquetFileReader::page_index_reader() {
+std::shared_ptr<PageIndexReader> ParquetFileReader::GetPageIndexReader() {
   return contents_->GetPageIndexReader();
 }
 

--- a/cpp/src/parquet/file_reader.h
+++ b/cpp/src/parquet/file_reader.h
@@ -32,6 +32,7 @@ namespace parquet {
 
 class ColumnReader;
 class FileMetaData;
+class PageIndexReader;
 class PageReader;
 class RowGroupMetaData;
 
@@ -98,6 +99,7 @@ class PARQUET_EXPORT ParquetFileReader {
     virtual void Close() = 0;
     virtual std::shared_ptr<RowGroupReader> GetRowGroup(int i) = 0;
     virtual std::shared_ptr<FileMetaData> metadata() const = 0;
+    virtual std::shared_ptr<PageIndexReader> page_index_reader() = 0;
   };
 
   ParquetFileReader();
@@ -132,6 +134,9 @@ class PARQUET_EXPORT ParquetFileReader {
 
   // Returns the file metadata. Only one instance is ever created
   std::shared_ptr<FileMetaData> metadata() const;
+
+  // Returns the page index reader. Only one instance is ever created
+  std::shared_ptr<PageIndexReader> page_index_reader();
 
   /// Pre-buffer the specified column indices in all row groups.
   ///

--- a/cpp/src/parquet/file_reader.h
+++ b/cpp/src/parquet/file_reader.h
@@ -99,12 +99,6 @@ class PARQUET_EXPORT ParquetFileReader {
     virtual void Close() = 0;
     virtual std::shared_ptr<RowGroupReader> GetRowGroup(int i) = 0;
     virtual std::shared_ptr<FileMetaData> metadata() const = 0;
-    // Returns a PageIndexReader instance for the parquet file.
-    // If the file does not have page index, nullptr may be returned. Since it pays to
-    // check existence of page index in the file, it is possible to return a non-nullptr
-    // even if page index does not exist. It is the caller's responsibility to check
-    // the return value of follow-up calls to PageIndexReader.
-    // WARNING: The returned PageIndexReader must not outlive the ParquetFileReader.
     virtual std::shared_ptr<PageIndexReader> GetPageIndexReader() = 0;
   };
 
@@ -141,8 +135,16 @@ class PARQUET_EXPORT ParquetFileReader {
   // Returns the file metadata. Only one instance is ever created
   std::shared_ptr<FileMetaData> metadata() const;
 
-  // Returns the page index reader. Only one instance is ever created
-  std::shared_ptr<PageIndexReader> page_index_reader();
+  /// Returns the PageIndexReader. Only one instance is ever created.
+  ///
+  /// If the file does not have the page index, nullptr may be returned.
+  /// Because it pays to check existence of page index in the file, it
+  /// is possible to return a non null value even if page index does
+  /// not exist. It is the caller's responsibility to check the return
+  /// value and follow-up calls to PageIndexReader.
+  ///
+  /// WARNING: The returned PageIndexReader must not outlive the ParquetFileReader.
+  std::shared_ptr<PageIndexReader> GetPageIndexReader();
 
   /// Pre-buffer the specified column indices in all row groups.
   ///

--- a/cpp/src/parquet/file_reader.h
+++ b/cpp/src/parquet/file_reader.h
@@ -99,7 +99,13 @@ class PARQUET_EXPORT ParquetFileReader {
     virtual void Close() = 0;
     virtual std::shared_ptr<RowGroupReader> GetRowGroup(int i) = 0;
     virtual std::shared_ptr<FileMetaData> metadata() const = 0;
-    virtual std::shared_ptr<PageIndexReader> page_index_reader() = 0;
+    // Returns a PageIndexReader instance for the parquet file.
+    // If the file does not have page index, nullptr may be returned. Since it pays to
+    // check existence of page index in the file, it is possible to return a non-nullptr
+    // even if page index does not exist. It is the caller's responsibility to check
+    // the return value of follow-up calls to PageIndexReader.
+    // WARNING: The returned PageIndexReader must not outlive the ParquetFileReader.
+    virtual std::shared_ptr<PageIndexReader> GetPageIndexReader() = 0;
   };
 
   ParquetFileReader();

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -124,7 +124,7 @@ struct IndexLocation {
   /// File offset of the given index, in bytes
   int64_t offset;
   /// Length of the given index, in bytes
-  int32_t length;
+  int64_t length;
 };
 
 /// \brief ColumnChunkMetaData is a proxy around format::ColumnChunkMetaData.

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -124,7 +124,7 @@ struct IndexLocation {
   /// File offset of the given index, in bytes
   int64_t offset;
   /// Length of the given index, in bytes
-  int64_t length;
+  int32_t length;
 };
 
 /// \brief ColumnChunkMetaData is a proxy around format::ColumnChunkMetaData.

--- a/cpp/src/parquet/page_index.cc
+++ b/cpp/src/parquet/page_index.cc
@@ -338,12 +338,10 @@ class PageIndexReaderImpl : public PageIndexReader {
       auto read_range = PageIndexReader::DeterminePageIndexRangesInRowGroup(
           *file_metadata_->RowGroup(row_group_ordinal));
       if (index_selection.column_index && read_range.column_index.has_value()) {
-        read_ranges.emplace_back(::arrow::io::ReadRange{read_range.column_index->offset,
-                                                        read_range.column_index->length});
+        read_ranges.push_back(*read_range.column_index);
       }
       if (index_selection.offset_index && read_range.offset_index.has_value()) {
-        read_ranges.emplace_back(::arrow::io::ReadRange{read_range.offset_index->offset,
-                                                        read_range.offset_index->length});
+        read_ranges.push_back(*read_range.offset_index);
       }
     }
     PARQUET_IGNORE_NOT_OK(input_->WillNeed(read_ranges));
@@ -392,12 +390,10 @@ RowGroupIndexReadRange PageIndexReader::DeterminePageIndexRangesInRowGroup(
 
   RowGroupIndexReadRange read_range;
   if (ci_end != -1) {
-    read_range.column_index =
-        RowGroupIndexReadRange::ReadRange{ci_start, ci_end - ci_start};
+    read_range.column_index = {ci_start, ci_end - ci_start};
   }
   if (oi_end != -1) {
-    read_range.offset_index =
-        RowGroupIndexReadRange::ReadRange{oi_start, oi_end - oi_start};
+    read_range.offset_index = {oi_start, oi_end - oi_start};
   }
   return read_range;
 }

--- a/cpp/src/parquet/page_index.cc
+++ b/cpp/src/parquet/page_index.cc
@@ -338,10 +338,12 @@ class PageIndexReaderImpl : public PageIndexReader {
       auto read_range = PageIndexReader::DeterminePageIndexRangesInRowGroup(
           *file_metadata_->RowGroup(row_group_ordinal));
       if (index_selection.column_index && read_range.column_index.has_value()) {
-        read_ranges.emplace_back(*read_range.column_index);
+        read_ranges.emplace_back(::arrow::io::ReadRange{read_range.column_index->offset,
+                                                        read_range.column_index->length});
       }
       if (index_selection.offset_index && read_range.offset_index.has_value()) {
-        read_ranges.emplace_back(*read_range.offset_index);
+        read_ranges.emplace_back(::arrow::io::ReadRange{read_range.offset_index->offset,
+                                                        read_range.offset_index->length});
       }
     }
     PARQUET_IGNORE_NOT_OK(input_->WillNeed(read_ranges));
@@ -390,10 +392,12 @@ RowGroupIndexReadRange PageIndexReader::DeterminePageIndexRangesInRowGroup(
 
   RowGroupIndexReadRange read_range;
   if (ci_end != -1) {
-    read_range.column_index = ::arrow::io::ReadRange{ci_start, ci_end - ci_start};
+    read_range.column_index =
+        RowGroupIndexReadRange::ReadRange{ci_start, ci_end - ci_start};
   }
   if (oi_end != -1) {
-    read_range.offset_index = ::arrow::io::ReadRange{oi_start, oi_end - oi_start};
+    read_range.offset_index =
+        RowGroupIndexReadRange::ReadRange{oi_start, oi_end - oi_start};
   }
   return read_range;
 }

--- a/cpp/src/parquet/page_index.cc
+++ b/cpp/src/parquet/page_index.cc
@@ -438,13 +438,14 @@ RowGroupIndexReadRange PageIndexReader::DeterminePageIndexRangesInRowGroup(
   auto merge_range = [](const std::optional<IndexLocation>& index_location,
                         int64_t* start, int64_t* end) {
     if (index_location.has_value()) {
-      if (index_location->offset < 0 || index_location->length <= 0) {
-        throw ParquetException("Invalid index location: offset ", index_location->offset,
-                               " length ", index_location->length);
-      }
       int64_t index_end = 0;
-      ::arrow::internal::AddWithOverflow(index_location->offset, index_location->length,
-                                         &index_end);
+      if (index_location->offset < 0 || index_location->length <= 0 ||
+          ::arrow::internal::AddWithOverflow(index_location->offset,
+                                             index_location->length, &index_end)) {
+        throw ParquetException("Invalid page index location: offset ",
+                               index_location->offset, " length ",
+                               index_location->length);
+      }
       *start = std::min(*start, index_location->offset);
       *end = std::max(*end, index_end);
     }

--- a/cpp/src/parquet/page_index.cc
+++ b/cpp/src/parquet/page_index.cc
@@ -379,7 +379,7 @@ class PageIndexReaderImpl : public PageIndexReader {
 
   void WillNeed(const std::vector<int32_t>& row_group_indices,
                 const std::vector<int32_t>& column_indices,
-                IndexSelection index_selection) override {
+                const IndexSelection& index_selection) override {
     std::vector<::arrow::io::ReadRange> read_ranges;
     for (int32_t row_group_ordinal : row_group_indices) {
       auto read_range = PageIndexReader::DeterminePageIndexRangesInRowGroup(

--- a/cpp/src/parquet/page_index.h
+++ b/cpp/src/parquet/page_index.h
@@ -202,9 +202,10 @@ class PARQUET_EXPORT PageIndexReader {
   /// 1) If WillNeed() has not been called for a specific row group and the page index
   ///    exists, follow-up calls to get column index or offset index of all columns in
   ///    this row group SHOULD NOT FAIL, but the performance may not be optimal.
-  /// 2) If WillNeed() has been called for a specific row group, follow-up calls MAY
-  ///    FAIL if columns that are not requested by WillNeed() are requested.
-  /// 3) Later calls to WillNeed() MAY override previous calls of same row groups.
+  /// 2) If WillNeed() has been called for a specific row group, follow-up calls to get
+  ///    page index are limited to columns and index type requested by WillNeed().
+  ///    So it MAY FAIL if columns that are not requested by WillNeed() are requested.
+  /// 3) Later calls to WillNeed() MAY OVERRIDE previous calls of same row groups.
   /// For example,
   /// 1) If WillNeed() is not called for row group 0, then follow-up calls to read
   ///    column index and/or offset index of all columns of row group 0 should not

--- a/cpp/src/parquet/page_index.h
+++ b/cpp/src/parquet/page_index.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "arrow/io/interfaces.h"
 #include "parquet/types.h"
 
 #include <optional>
@@ -159,16 +160,12 @@ struct IndexSelection {
 };
 
 struct RowGroupIndexReadRange {
-  struct ReadRange {
-    int64_t offset;
-    int64_t length;
-  };
   /// Base start and total size of column index of all column chunks in a row group.
   /// If none of the column chunks have column index, it is set to std::nullopt.
-  std::optional<ReadRange> column_index = std::nullopt;
+  std::optional<::arrow::io::ReadRange> column_index = std::nullopt;
   /// Base start and total size of offset index of all column chunks in a row group.
   /// If none of the column chunks have offset index, it is set to std::nullopt.
-  std::optional<ReadRange> offset_index = std::nullopt;
+  std::optional<::arrow::io::ReadRange> offset_index = std::nullopt;
 };
 
 /// \brief Interface for reading the page index for a Parquet file.

--- a/cpp/src/parquet/page_index.h
+++ b/cpp/src/parquet/page_index.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include "arrow/io/interfaces.h"
 #include "parquet/types.h"
 
 #include <optional>
@@ -160,12 +159,16 @@ struct IndexSelection {
 };
 
 struct RowGroupIndexReadRange {
+  struct ReadRange {
+    int64_t offset;
+    int64_t length;
+  };
   /// Base start and total size of column index of all column chunks in a row group.
   /// If none of the column chunks have column index, it is set to std::nullopt.
-  std::optional<::arrow::io::ReadRange> column_index = std::nullopt;
+  std::optional<ReadRange> column_index = std::nullopt;
   /// Base start and total size of offset index of all column chunks in a row group.
   /// If none of the column chunks have offset index, it is set to std::nullopt.
-  std::optional<::arrow::io::ReadRange> offset_index = std::nullopt;
+  std::optional<ReadRange> offset_index = std::nullopt;
 };
 
 /// \brief Interface for reading the page index for a Parquet file.

--- a/cpp/src/parquet/page_index.h
+++ b/cpp/src/parquet/page_index.h
@@ -152,7 +152,7 @@ class PARQUET_EXPORT RowGroupPageIndexReader {
   virtual std::shared_ptr<OffsetIndex> GetOffsetIndex(int32_t i) = 0;
 };
 
-struct IndexSelection {
+struct PageIndexSelection {
   /// Specifies whether to read the column index.
   bool column_index = false;
   /// Specifies whether to read the offset index.
@@ -211,10 +211,10 @@ class PARQUET_EXPORT PageIndexReader {
   ///    column index and/or offset index of all columns of row group 0 should not
   ///    fail if its page index exists.
   /// 2) If WillNeed() is called for columns 0 and 1 for row group 0, then follow-up
-  ///    call to read page index of column 2 for row group 0 WILL FAIL even if its
+  ///    call to read page index of column 2 for row group 0 MAY FAIL even if its
   ///    page index exists.
   /// 3) If WillNeed() is called for row group 0 with offset index only, then
-  ///    follow-up call to read column index of row group 0 WILL FAIL even if
+  ///    follow-up call to read column index of row group 0 MAY FAIL even if
   ///    the column index of this column exists.
   /// 4) If WillNeed() is called for columns 0 and 1 for row group 0, then later
   ///    call to WillNeed() for columns 1 and 2 for row group 0. The later one
@@ -224,10 +224,10 @@ class PARQUET_EXPORT PageIndexReader {
   /// \param[in] row_group_indices list of row group ordinal to read page index later.
   /// \param[in] column_indices list of column ordinal to read page index later. If it is
   ///            empty, it means all columns in the row group will be read.
-  /// \param[in] index_selection tell if any of the page index is required later.
+  /// \param[in] selection which kind of page index is required later.
   virtual void WillNeed(const std::vector<int32_t>& row_group_indices,
                         const std::vector<int32_t>& column_indices,
-                        const IndexSelection& index_selection) = 0;
+                        const PageIndexSelection& selection) = 0;
 
   /// \brief Advise the reader page index of these row groups will not be read any more.
   ///
@@ -238,7 +238,7 @@ class PARQUET_EXPORT PageIndexReader {
   /// not be accessed any more.
   virtual void WillNotNeed(const std::vector<int32_t>& row_group_indices) = 0;
 
-  /// \brief Determines the column index and offset index ranges for the given row group.
+  /// \brief Determine the column index and offset index ranges for the given row group.
   ///
   /// \param[in] row_group_metadata row group metadata to get column chunk metadata.
   /// \param[in] columns list of column ordinals to get page index. If the list is empty,
@@ -246,7 +246,6 @@ class PARQUET_EXPORT PageIndexReader {
   /// \returns RowGroupIndexReadRange of the specified row group. Throws ParquetException
   ///          if the selected column ordinal is out of bound or metadata of page index
   ///          is corrupted.
-  /// found. Returns false when there is absolutely no offsets index for the row group.
   static RowGroupIndexReadRange DeterminePageIndexRangesInRowGroup(
       const RowGroupMetaData& row_group_metadata, const std::vector<int32_t>& columns);
 };

--- a/cpp/src/parquet/page_index.h
+++ b/cpp/src/parquet/page_index.h
@@ -227,7 +227,7 @@ class PARQUET_EXPORT PageIndexReader {
   /// \param[in] index_selection tell if any of the page index is required later.
   virtual void WillNeed(const std::vector<int32_t>& row_group_indices,
                         const std::vector<int32_t>& column_indices,
-                        IndexSelection index_selection) = 0;
+                        const IndexSelection& index_selection) = 0;
 
   /// \brief Advise the reader page index of these row groups will not be read any more.
   ///

--- a/cpp/src/parquet/page_index_test.cc
+++ b/cpp/src/parquet/page_index_test.cc
@@ -256,4 +256,111 @@ TEST(PageIndex, ReadColumnIndexWithNullPage) {
       null_pages, min_values, max_values, has_null_counts, null_counts);
 }
 
+struct PageIndexRanges {
+  int64_t column_index_offset;
+  int64_t column_index_length;
+  int64_t offset_index_offset;
+  int64_t offset_index_length;
+};
+
+using RowGroupRanges = std::vector<PageIndexRanges>;
+
+/// Creates an FileMetaData object w/ single row group based on data in
+/// 'row_group_ranges'. It sets the offsets and sizes of the column index and offset index
+/// members of the row group. It doesn't set the member if the input value is -1.
+std::shared_ptr<FileMetaData> ConstructFakeMetaData(
+    const RowGroupRanges& row_group_ranges) {
+  format::RowGroup row_group;
+  for (auto& page_index_ranges : row_group_ranges) {
+    format::ColumnChunk col_chunk;
+    if (page_index_ranges.column_index_offset != -1) {
+      col_chunk.__set_column_index_offset(page_index_ranges.column_index_offset);
+    }
+    if (page_index_ranges.column_index_length != -1) {
+      col_chunk.__set_column_index_length(
+          static_cast<int32_t>(page_index_ranges.column_index_length));
+    }
+    if (page_index_ranges.offset_index_offset != -1) {
+      col_chunk.__set_offset_index_offset(page_index_ranges.offset_index_offset);
+    }
+    if (page_index_ranges.offset_index_length != -1) {
+      col_chunk.__set_offset_index_length(
+          static_cast<int32_t>(page_index_ranges.offset_index_length));
+    }
+    row_group.columns.push_back(col_chunk);
+  }
+
+  format::FileMetaData metadata;
+  metadata.row_groups.push_back(row_group);
+
+  metadata.schema.emplace_back();
+  schema::NodeVector fields;
+  for (size_t i = 0; i < row_group_ranges.size(); ++i) {
+    fields.push_back(schema::Int64(std::to_string(i)));
+    metadata.schema.emplace_back();
+    fields.back()->ToParquet(&metadata.schema.back());
+  }
+  schema::GroupNode::Make("schema", Repetition::REPEATED, fields)
+      ->ToParquet(&metadata.schema.front());
+
+  auto sink = CreateOutputStream();
+  ThriftSerializer{}.Serialize(&metadata, sink.get());
+  auto buffer = sink->Finish().MoveValueUnsafe();
+  uint32_t len = static_cast<uint32_t>(buffer->size());
+  return FileMetaData::Make(buffer->data(), &len);
+}
+
+/// Validates that 'DeterminePageIndexRangesInRowGroup()' selects the expected file
+/// offsets and sizes or returns false when the row group doesn't have a page index.
+void ValidatePageIndexRange(const RowGroupRanges& row_group_ranges,
+                            bool expected_has_page_index, int expected_ci_start,
+                            int expected_ci_size, int expected_oi_start,
+                            int expected_oi_size) {
+  auto file_metadata = ConstructFakeMetaData(row_group_ranges);
+
+  int64_t ci_start;
+  int64_t ci_size;
+  int64_t oi_start;
+  int64_t oi_size;
+  bool has_column_index;
+  bool has_offset_index;
+  PageIndexReader::DeterminePageIndexRangesInRowGroup(
+      *file_metadata->RowGroup(0), &ci_start, &ci_size, &oi_start, &oi_size,
+      &has_column_index, &has_offset_index);
+  ASSERT_EQ(expected_has_page_index, has_column_index);
+  ASSERT_EQ(expected_has_page_index, has_offset_index);
+  if (expected_has_page_index) {
+    EXPECT_EQ(expected_ci_start, ci_start);
+    EXPECT_EQ(expected_ci_size, ci_size);
+    EXPECT_EQ(expected_oi_start, oi_start);
+    EXPECT_EQ(expected_oi_size, oi_size);
+  }
+}
+
+/// This test constructs a couple of artificial row groups with page index offsets in
+/// them. Then it validates if PageIndexReader::DeterminePageIndexRangesInRowGroup()
+/// properly computes the file range that contains the whole page index.
+TEST(PageIndex, DeterminePageIndexRangesInRowGroup) {
+  // No Column chunks
+  ValidatePageIndexRange({}, false, -1, -1, -1, -1);
+  // No page index at all.
+  ValidatePageIndexRange({{-1, -1, -1, -1}}, false, -1, -1, -1, -1);
+  // Page index for single column chunk.
+  ValidatePageIndexRange({{10, 5, 15, 5}}, true, 10, 5, 15, 5);
+  // Page index for two column chunks.
+  ValidatePageIndexRange({{10, 5, 30, 25}, {15, 15, 50, 20}}, true, 10, 20, 30, 40);
+  // Page index for second column chunk..
+  ValidatePageIndexRange({{-1, -1, -1, -1}, {20, 10, 30, 25}}, true, 20, 10, 30, 25);
+  // Page index for first column chunk.
+  ValidatePageIndexRange({{10, 5, 15, 5}, {-1, -1, -1, -1}}, true, 10, 5, 15, 5);
+  // Missing offset index for first column chunk. Gap in column index.
+  ValidatePageIndexRange({{10, 5, -1, -1}, {20, 10, 30, 25}}, true, 10, 20, 30, 25);
+  // Missing offset index for second column chunk.
+  ValidatePageIndexRange({{10, 5, 25, 5}, {20, 10, -1, -1}}, true, 10, 20, 25, 5);
+  // Three column chunks.
+  ValidatePageIndexRange(
+      {{100, 10, 220, 30}, {110, 25, 250, 10}, {140, 30, 260, 40}, {200, 10, 300, 100}},
+      true, 100, 110, 220, 180);
+}
+
 }  // namespace parquet

--- a/cpp/src/parquet/page_index_test.cc
+++ b/cpp/src/parquet/page_index_test.cc
@@ -313,17 +313,21 @@ std::shared_ptr<FileMetaData> ConstructFakeMetaData(
 /// Validates that 'DeterminePageIndexRangesInRowGroup()' selects the expected file
 /// offsets and sizes or returns false when the row group doesn't have a page index.
 void ValidatePageIndexRange(const RowGroupRanges& row_group_ranges,
-                            bool expected_has_page_index, int expected_ci_start,
+                            const std::vector<int32_t>& column_indices,
+                            bool expected_has_column_index,
+                            bool expected_has_offset_index, int expected_ci_start,
                             int expected_ci_size, int expected_oi_start,
                             int expected_oi_size) {
   auto file_metadata = ConstructFakeMetaData(row_group_ranges);
   auto read_range = PageIndexReader::DeterminePageIndexRangesInRowGroup(
-      *file_metadata->RowGroup(0), {});
-  ASSERT_EQ(expected_has_page_index, read_range.column_index.has_value());
-  ASSERT_EQ(expected_has_page_index, read_range.offset_index.has_value());
-  if (expected_has_page_index) {
+      *file_metadata->RowGroup(0), column_indices);
+  ASSERT_EQ(expected_has_column_index, read_range.column_index.has_value());
+  ASSERT_EQ(expected_has_offset_index, read_range.offset_index.has_value());
+  if (expected_has_column_index) {
     EXPECT_EQ(expected_ci_start, read_range.column_index->offset);
     EXPECT_EQ(expected_ci_size, read_range.column_index->length);
+  }
+  if (expected_has_offset_index) {
     EXPECT_EQ(expected_oi_start, read_range.offset_index->offset);
     EXPECT_EQ(expected_oi_size, read_range.offset_index->length);
   }
@@ -334,25 +338,82 @@ void ValidatePageIndexRange(const RowGroupRanges& row_group_ranges,
 /// properly computes the file range that contains the whole page index.
 TEST(PageIndex, DeterminePageIndexRangesInRowGroup) {
   // No Column chunks
-  ValidatePageIndexRange({}, false, -1, -1, -1, -1);
+  ValidatePageIndexRange({}, {}, false, false, -1, -1, -1, -1);
   // No page index at all.
-  ValidatePageIndexRange({{-1, -1, -1, -1}}, false, -1, -1, -1, -1);
+  ValidatePageIndexRange({{-1, -1, -1, -1}}, {}, false, false, -1, -1, -1, -1);
   // Page index for single column chunk.
-  ValidatePageIndexRange({{10, 5, 15, 5}}, true, 10, 5, 15, 5);
+  ValidatePageIndexRange({{10, 5, 15, 5}}, {}, true, true, 10, 5, 15, 5);
   // Page index for two column chunks.
-  ValidatePageIndexRange({{10, 5, 30, 25}, {15, 15, 50, 20}}, true, 10, 20, 30, 40);
+  ValidatePageIndexRange({{10, 5, 30, 25}, {15, 15, 50, 20}}, {}, true, true, 10, 20, 30,
+                         40);
   // Page index for second column chunk.
-  ValidatePageIndexRange({{-1, -1, -1, -1}, {20, 10, 30, 25}}, true, 20, 10, 30, 25);
+  ValidatePageIndexRange({{-1, -1, -1, -1}, {20, 10, 30, 25}}, {}, true, true, 20, 10, 30,
+                         25);
   // Page index for first column chunk.
-  ValidatePageIndexRange({{10, 5, 15, 5}, {-1, -1, -1, -1}}, true, 10, 5, 15, 5);
+  ValidatePageIndexRange({{10, 5, 15, 5}, {-1, -1, -1, -1}}, {}, true, true, 10, 5, 15,
+                         5);
   // Missing offset index for first column chunk. Gap in column index.
-  ValidatePageIndexRange({{10, 5, -1, -1}, {20, 10, 30, 25}}, true, 10, 20, 30, 25);
+  ValidatePageIndexRange({{10, 5, -1, -1}, {20, 10, 30, 25}}, {}, true, true, 10, 20, 30,
+                         25);
   // Missing offset index for second column chunk.
-  ValidatePageIndexRange({{10, 5, 25, 5}, {20, 10, -1, -1}}, true, 10, 20, 25, 5);
-  // Three column chunks.
+  ValidatePageIndexRange({{10, 5, 25, 5}, {20, 10, -1, -1}}, {}, true, true, 10, 20, 25,
+                         5);
+  // Four column chunks.
   ValidatePageIndexRange(
       {{100, 10, 220, 30}, {110, 25, 250, 10}, {140, 30, 260, 40}, {200, 10, 300, 100}},
-      true, 100, 110, 220, 180);
+      {}, true, true, 100, 110, 220, 180);
+}
+
+/// This test constructs a couple of artificial row groups with page index offsets in
+/// them. Then it validates if PageIndexReader::DeterminePageIndexRangesInRowGroup()
+/// properly computes the file range that contains the page index of selected columns.
+TEST(PageIndex, DeterminePageIndexRangesInRowGroupWithPartialColumnsSelected) {
+  // No page index at all.
+  ValidatePageIndexRange({{-1, -1, -1, -1}}, {0}, false, false, -1, -1, -1, -1);
+  // Page index for single column chunk.
+  ValidatePageIndexRange({{10, 5, 15, 5}}, {0}, true, true, 10, 5, 15, 5);
+  // Page index for the 1st column chunk.
+  ValidatePageIndexRange({{10, 5, 30, 25}, {15, 15, 50, 20}}, {0}, true, true, 10, 5, 30,
+                         25);
+  // Page index for the 2nd column chunk.
+  ValidatePageIndexRange({{10, 5, 30, 25}, {15, 15, 50, 20}}, {1}, true, true, 15, 15, 50,
+                         20);
+  // Only 2nd column is selected among four column chunks.
+  ValidatePageIndexRange(
+      {{100, 10, 220, 30}, {110, 25, 250, 10}, {140, 30, 260, 40}, {200, 10, 300, 100}},
+      {1}, true, true, 110, 25, 250, 10);
+  // Only 2nd and 3rd columns are selected among four column chunks.
+  ValidatePageIndexRange(
+      {{100, 10, 220, 30}, {110, 25, 250, 10}, {140, 30, 260, 40}, {200, 10, 300, 100}},
+      {1, 2}, true, true, 110, 60, 250, 50);
+  // Only 2nd and 4th columns are selected among four column chunks.
+  ValidatePageIndexRange(
+      {{100, 10, 220, 30}, {110, 25, 250, 10}, {140, 30, 260, 40}, {200, 10, 300, 100}},
+      {1, 3}, true, true, 110, 100, 250, 150);
+  // Only 1st, 2nd and 4th columns are selected among four column chunks.
+  ValidatePageIndexRange(
+      {{100, 10, 220, 30}, {110, 25, 250, 10}, {140, 30, 260, 40}, {200, 10, 300, 100}},
+      {0, 1, 3}, true, true, 100, 110, 220, 180);
+  // 3rd column is selected but not present in the row group.
+  EXPECT_THROW(ValidatePageIndexRange({{10, 5, 30, 25}, {15, 15, 50, 20}}, {2}, false,
+                                      false, -1, -1, -1, -1),
+               ParquetException);
+}
+
+/// This test constructs a couple of artificial row groups with page index offsets in
+/// them. Then it validates if PageIndexReader::DeterminePageIndexRangesInRowGroup()
+/// properly detects if column index or offset index is missing.
+TEST(PageIndex, DeterminePageIndexRangesInRowGroupWithMissingPageIndex) {
+  // No column index at all.
+  ValidatePageIndexRange({{-1, -1, 15, 5}}, {}, false, true, -1, -1, 15, 5);
+  // No offset index at all.
+  ValidatePageIndexRange({{10, 5, -1, -1}}, {}, true, false, 10, 5, -1, -1);
+  // No column index at all among two column chunks.
+  ValidatePageIndexRange({{-1, -1, 30, 25}, {-1, -1, 50, 20}}, {}, false, true, -1, -1,
+                         30, 40);
+  // No offset index at all among two column chunks.
+  ValidatePageIndexRange({{10, 5, -1, -1}, {15, 15, -1, -1}}, {}, true, false, 10, 20, -1,
+                         -1);
 }
 
 }  // namespace parquet

--- a/cpp/src/parquet/page_index_test.cc
+++ b/cpp/src/parquet/page_index_test.cc
@@ -318,22 +318,20 @@ void ValidatePageIndexRange(const RowGroupRanges& row_group_ranges,
                             int expected_oi_size) {
   auto file_metadata = ConstructFakeMetaData(row_group_ranges);
 
-  int64_t ci_start;
-  int64_t ci_size;
-  int64_t oi_start;
-  int64_t oi_size;
+  IndexLocation column_index_location;
+  IndexLocation offset_index_location;
   bool has_column_index;
   bool has_offset_index;
   PageIndexReader::DeterminePageIndexRangesInRowGroup(
-      *file_metadata->RowGroup(0), &ci_start, &ci_size, &oi_start, &oi_size,
+      *file_metadata->RowGroup(0), &column_index_location, &offset_index_location,
       &has_column_index, &has_offset_index);
   ASSERT_EQ(expected_has_page_index, has_column_index);
   ASSERT_EQ(expected_has_page_index, has_offset_index);
   if (expected_has_page_index) {
-    EXPECT_EQ(expected_ci_start, ci_start);
-    EXPECT_EQ(expected_ci_size, ci_size);
-    EXPECT_EQ(expected_oi_start, oi_start);
-    EXPECT_EQ(expected_oi_size, oi_size);
+    EXPECT_EQ(expected_ci_start, column_index_location.offset);
+    EXPECT_EQ(expected_ci_size, column_index_location.length);
+    EXPECT_EQ(expected_oi_start, offset_index_location.offset);
+    EXPECT_EQ(expected_oi_size, offset_index_location.length);
   }
 }
 

--- a/cpp/src/parquet/page_index_test.cc
+++ b/cpp/src/parquet/page_index_test.cc
@@ -317,21 +317,15 @@ void ValidatePageIndexRange(const RowGroupRanges& row_group_ranges,
                             int expected_ci_size, int expected_oi_start,
                             int expected_oi_size) {
   auto file_metadata = ConstructFakeMetaData(row_group_ranges);
-
-  IndexLocation column_index_location;
-  IndexLocation offset_index_location;
-  bool has_column_index;
-  bool has_offset_index;
-  PageIndexReader::DeterminePageIndexRangesInRowGroup(
-      *file_metadata->RowGroup(0), &column_index_location, &offset_index_location,
-      &has_column_index, &has_offset_index);
-  ASSERT_EQ(expected_has_page_index, has_column_index);
-  ASSERT_EQ(expected_has_page_index, has_offset_index);
+  auto read_range =
+      PageIndexReader::DeterminePageIndexRangesInRowGroup(*file_metadata->RowGroup(0));
+  ASSERT_EQ(expected_has_page_index, read_range.column_index.has_value());
+  ASSERT_EQ(expected_has_page_index, read_range.offset_index.has_value());
   if (expected_has_page_index) {
-    EXPECT_EQ(expected_ci_start, column_index_location.offset);
-    EXPECT_EQ(expected_ci_size, column_index_location.length);
-    EXPECT_EQ(expected_oi_start, offset_index_location.offset);
-    EXPECT_EQ(expected_oi_size, offset_index_location.length);
+    EXPECT_EQ(expected_ci_start, read_range.column_index->offset);
+    EXPECT_EQ(expected_ci_size, read_range.column_index->length);
+    EXPECT_EQ(expected_oi_start, read_range.offset_index->offset);
+    EXPECT_EQ(expected_oi_size, read_range.offset_index->length);
   }
 }
 

--- a/cpp/src/parquet/page_index_test.cc
+++ b/cpp/src/parquet/page_index_test.cc
@@ -317,8 +317,8 @@ void ValidatePageIndexRange(const RowGroupRanges& row_group_ranges,
                             int expected_ci_size, int expected_oi_start,
                             int expected_oi_size) {
   auto file_metadata = ConstructFakeMetaData(row_group_ranges);
-  auto read_range =
-      PageIndexReader::DeterminePageIndexRangesInRowGroup(*file_metadata->RowGroup(0));
+  auto read_range = PageIndexReader::DeterminePageIndexRangesInRowGroup(
+      *file_metadata->RowGroup(0), {});
   ASSERT_EQ(expected_has_page_index, read_range.column_index.has_value());
   ASSERT_EQ(expected_has_page_index, read_range.offset_index.has_value());
   if (expected_has_page_index) {
@@ -341,7 +341,7 @@ TEST(PageIndex, DeterminePageIndexRangesInRowGroup) {
   ValidatePageIndexRange({{10, 5, 15, 5}}, true, 10, 5, 15, 5);
   // Page index for two column chunks.
   ValidatePageIndexRange({{10, 5, 30, 25}, {15, 15, 50, 20}}, true, 10, 20, 30, 40);
-  // Page index for second column chunk..
+  // Page index for second column chunk.
   ValidatePageIndexRange({{-1, -1, -1, -1}, {20, 10, 30, 25}}, true, 20, 10, 30, 25);
   // Page index for first column chunk.
   ValidatePageIndexRange({{10, 5, 15, 5}, {-1, -1, -1, -1}}, true, 10, 5, 15, 5);

--- a/cpp/src/parquet/reader_test.cc
+++ b/cpp/src/parquet/reader_test.cc
@@ -1061,15 +1061,9 @@ TEST(TestFileReader, TestOverflowInt16PageOrdinal) {
 }
 
 struct PageIndexReaderParam {
-  PageIndexReaderParam(const std::vector<int32_t>& row_group_indices,
-                       const std::vector<int32_t>& column_indices, bool need_column_index,
-                       bool need_offset_index)
-      : row_group_indices(row_group_indices),
-        column_indices(column_indices),
-        index_selection{need_column_index, need_offset_index} {}
   std::vector<int32_t> row_group_indices;
   std::vector<int32_t> column_indices;
-  IndexSelection index_selection;
+  PageIndexSelection index_selection;
 };
 
 class ParameterizedPageIndexReaderTest
@@ -1185,28 +1179,28 @@ TEST_P(ParameterizedPageIndexReaderTest, TestReadPageIndex) {
   EXPECT_EQ(nullptr, column_index);
 }
 
-INSTANTIATE_TEST_SUITE_P(PageIndexReaderTests, ParameterizedPageIndexReaderTest,
-                         ::testing::Values(PageIndexReaderParam({}, {}, true, true),
-                                           PageIndexReaderParam({}, {}, true, false),
-                                           PageIndexReaderParam({}, {}, false, true),
-                                           PageIndexReaderParam({}, {}, false, false),
-                                           PageIndexReaderParam({0}, {}, true, true),
-                                           PageIndexReaderParam({0}, {}, true, false),
-                                           PageIndexReaderParam({0}, {}, false, true),
-                                           PageIndexReaderParam({0}, {}, false, false),
-                                           PageIndexReaderParam({0}, {0}, true, true),
-                                           PageIndexReaderParam({0}, {0}, true, false),
-                                           PageIndexReaderParam({0}, {0}, false, true),
-                                           PageIndexReaderParam({0}, {0}, false, false),
-                                           PageIndexReaderParam({0}, {5}, true, true),
-                                           PageIndexReaderParam({0}, {5}, true, false),
-                                           PageIndexReaderParam({0}, {5}, false, true),
-                                           PageIndexReaderParam({0}, {5}, false, false),
-                                           PageIndexReaderParam({0}, {0, 5}, true, true),
-                                           PageIndexReaderParam({0}, {0, 5}, true, false),
-                                           PageIndexReaderParam({0}, {0, 5}, false, true),
-                                           PageIndexReaderParam({0}, {0, 5}, false,
-                                                                false)));
+INSTANTIATE_TEST_SUITE_P(
+    PageIndexReaderTests, ParameterizedPageIndexReaderTest,
+    ::testing::Values(PageIndexReaderParam{{}, {}, {true, true}},
+                      PageIndexReaderParam{{}, {}, {true, false}},
+                      PageIndexReaderParam{{}, {}, {false, true}},
+                      PageIndexReaderParam{{}, {}, {false, false}},
+                      PageIndexReaderParam{{0}, {}, {true, true}},
+                      PageIndexReaderParam{{0}, {}, {true, false}},
+                      PageIndexReaderParam{{0}, {}, {false, true}},
+                      PageIndexReaderParam{{0}, {}, {false, false}},
+                      PageIndexReaderParam{{0}, {0}, {true, true}},
+                      PageIndexReaderParam{{0}, {0}, {true, false}},
+                      PageIndexReaderParam{{0}, {0}, {false, true}},
+                      PageIndexReaderParam{{0}, {0}, {false, false}},
+                      PageIndexReaderParam{{0}, {5}, {true, true}},
+                      PageIndexReaderParam{{0}, {5}, {true, false}},
+                      PageIndexReaderParam{{0}, {5}, {false, true}},
+                      PageIndexReaderParam{{0}, {5}, {false, false}},
+                      PageIndexReaderParam{{0}, {0, 5}, {true, true}},
+                      PageIndexReaderParam{{0}, {0, 5}, {true, false}},
+                      PageIndexReaderParam{{0}, {0, 5}, {false, true}},
+                      PageIndexReaderParam{{0}, {0, 5}, {false, false}}));
 
 TEST(PageIndexReaderTest, ReadFileWithoutPageIndex) {
   ReaderProperties properties;

--- a/cpp/src/parquet/reader_test.cc
+++ b/cpp/src/parquet/reader_test.cc
@@ -37,6 +37,7 @@
 #include "parquet/file_reader.h"
 #include "parquet/file_writer.h"
 #include "parquet/metadata.h"
+#include "parquet/page_index.h"
 #include "parquet/platform.h"
 #include "parquet/printer.h"
 #include "parquet/test_util.h"
@@ -1058,5 +1059,107 @@ TEST(TestFileReader, TestOverflowInt16PageOrdinal) {
     EXPECT_EQ(40000, page_ordinal);
   }
 }
+
+struct PageIndexReaderParam {
+  PageIndexReaderParam(const std::vector<int32_t>& row_group_indices,
+                       bool need_column_index, bool need_offset_index)
+      : row_group_indices(row_group_indices),
+        index_selection{need_column_index, need_offset_index} {}
+  std::vector<int32_t> row_group_indices;
+  IndexSelection index_selection;
+};
+
+class ParameterizedPageIndexReaderTest
+    : public ::testing::TestWithParam<PageIndexReaderParam> {};
+
+// Test reading a data file with page index.
+TEST_P(ParameterizedPageIndexReaderTest, TestReadPageIndex) {
+  ReaderProperties properties;
+  auto file_reader = ParquetFileReader::OpenFile(data_file("alltypes_tiny_pages.parquet"),
+                                                 /*memory_map=*/false, properties);
+  auto metadata = file_reader->metadata();
+  EXPECT_EQ(1, metadata->num_row_groups());
+  EXPECT_EQ(13, metadata->num_columns());
+
+  // Create the page index reader and provide different read hints.
+  auto page_index_reader = file_reader->GetPageIndexReader();
+  ASSERT_NE(nullptr, page_index_reader);
+  const auto params = GetParam();
+  page_index_reader->WillNeed(params.row_group_indices, params.index_selection);
+  auto row_group_index_reader = page_index_reader->RowGroup(0);
+  ASSERT_NE(nullptr, row_group_index_reader);
+
+  // Verify offset index of column 0 and only partial data as it contains 325 pages.
+  {
+    const size_t num_pages = 325;
+    const std::vector<size_t> page_indices = {0, 100, 200, 300};
+    const std::vector<PageLocation> page_locations = {
+        PageLocation{4, 109, 0}, PageLocation{11480, 133, 2244},
+        PageLocation{22980, 133, 4494}, PageLocation{34480, 133, 6744}};
+
+    auto offset_index = row_group_index_reader->GetOffsetIndex(0);
+    ASSERT_NE(nullptr, offset_index);
+
+    EXPECT_EQ(num_pages, offset_index->page_locations().size());
+    for (size_t i = 0; i < page_indices.size(); ++i) {
+      size_t page_id = page_indices.at(i);
+      const auto& read_page_location = offset_index->page_locations().at(page_id);
+      const auto& expected_page_location = page_locations.at(i);
+      EXPECT_EQ(expected_page_location.offset, read_page_location.offset);
+      EXPECT_EQ(expected_page_location.compressed_page_size,
+                read_page_location.compressed_page_size);
+      EXPECT_EQ(expected_page_location.first_row_index,
+                read_page_location.first_row_index);
+    }
+  }
+
+  // Verify column index of column 5 and only partial data as it contains 528 pages.
+  {
+    const size_t num_pages = 528;
+    const BoundaryOrder::type boundary_order = BoundaryOrder::Unordered;
+    const std::vector<size_t> page_indices = {0, 99, 426, 520};
+    const std::vector<bool> null_pages = {false, false, false, false};
+    const bool has_null_counts = true;
+    const std::vector<int64_t> null_counts = {0, 0, 0, 0};
+    const std::vector<int64_t> min_values = {0, 10, 0, 0};
+    const std::vector<int64_t> max_values = {90, 90, 80, 70};
+
+    auto column_index = row_group_index_reader->GetColumnIndex(5);
+    ASSERT_NE(nullptr, column_index);
+    auto typed_column_index = std::dynamic_pointer_cast<Int64ColumnIndex>(column_index);
+    ASSERT_NE(nullptr, typed_column_index);
+
+    EXPECT_EQ(num_pages, column_index->null_pages().size());
+    EXPECT_EQ(has_null_counts, column_index->has_null_counts());
+    EXPECT_EQ(boundary_order, column_index->boundary_order());
+    for (size_t i = 0; i < page_indices.size(); ++i) {
+      size_t page_id = page_indices.at(i);
+      EXPECT_EQ(null_pages.at(i), column_index->null_pages().at(page_id));
+      if (has_null_counts) {
+        EXPECT_EQ(null_counts.at(i), column_index->null_counts().at(page_id));
+      }
+      if (!null_pages.at(i)) {
+        EXPECT_EQ(min_values.at(i), typed_column_index->min_values().at(page_id));
+        EXPECT_EQ(max_values.at(i), typed_column_index->max_values().at(page_id));
+      }
+    }
+  }
+
+  // Verify null is returned if column index does not exist.
+  {
+    auto column_index = row_group_index_reader->GetColumnIndex(10);
+    EXPECT_EQ(nullptr, column_index);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(PageIndexReaderTests, ParameterizedPageIndexReaderTest,
+                         ::testing::Values(PageIndexReaderParam({0}, true, true),
+                                           PageIndexReaderParam({0}, true, false),
+                                           PageIndexReaderParam({0}, false, true),
+                                           PageIndexReaderParam({0}, false, false),
+                                           PageIndexReaderParam({}, true, true),
+                                           PageIndexReaderParam({}, true, false),
+                                           PageIndexReaderParam({}, false, true),
+                                           PageIndexReaderParam({}, false, false)));
 
 }  // namespace parquet

--- a/cpp/src/parquet/reader_test.cc
+++ b/cpp/src/parquet/reader_test.cc
@@ -1085,7 +1085,7 @@ TEST_P(ParameterizedPageIndexReaderTest, TestReadPageIndex) {
   auto page_index_reader = file_reader->GetPageIndexReader();
   ASSERT_NE(nullptr, page_index_reader);
   const auto params = GetParam();
-  page_index_reader->WillNeed(params.row_group_indices, params.index_selection);
+  page_index_reader->WillNeed(params.row_group_indices, {}, params.index_selection);
   auto row_group_index_reader = page_index_reader->RowGroup(0);
   ASSERT_NE(nullptr, row_group_index_reader);
 


### PR DESCRIPTION
Basically, the patch provides following implementation:
- Define `class RowGroupPageIndexReader` to read page index from a parquet row group. It internally leverages implementation from Apache Impala [link](https://github.com/apache/impala/blob/efa426453a8af3728bc272b9158f5564ce37e0ea/be/src/exec/parquet/parquet-page-index.cc#L41) to merge I/O chunks of page index in the same row group.
- Define `class PageIndexReader` to create `RowGroupPageIndexReader` for each row group.
- `ParquetFileReader` internally creates and caches a single `PageIndexReader` object and exposes it to the end user.

Limitation:
- Reading page index from encrypted parquet file is not yet supported. It takes some effort to understand the specs and will be done in a separate patch after the completion of write logic of page index.
* Closes: #33596