### PR TITLE
GH-14965: [C++] Enable Substrait ReadRel Projection in Acero

### DIFF
--- a/cpp/src/arrow/engine/substrait/expression_internal.cc
+++ b/cpp/src/arrow/engine/substrait/expression_internal.cc
@@ -1195,6 +1195,7 @@ Result<std::vector<compute::Expression>> FromProto(
 Result<std::vector<compute::Expression>> FromProto(
     const ::substrait::Expression::MaskExpression& mask_expr, const ExtensionSet& ext_set,
     const ConversionOptions& conversion_options) {
+  // TODO::Vibhatha consider bool maintain_singular_struct = 2;
   if (mask_expr.has_select()) {
     // class Expression_MaskExpression_StructSelect final :
     return FromProto(mask_expr.select(), ext_set, conversion_options);

--- a/cpp/src/arrow/engine/substrait/expression_internal.cc
+++ b/cpp/src/arrow/engine/substrait/expression_internal.cc
@@ -1165,11 +1165,13 @@ Result<std::vector<compute::Expression>> FromProto(
   std::vector<compute::Expression> proj_exprs;
   if (struct_item.has_child()) {
     // class Expression_MaskExpression_Select final :
+    std::cout << "Struct Item has child" << std::endl;
     auto mask_expr_select = struct_item.child();
     ARROW_ASSIGN_OR_RAISE(proj_exprs,
                           FromProto(mask_expr_select, ext_set, conversion_options));
   }
   if (struct_item.field() >= 0) {
+    std::cout << "Struct Item Just have a field" << std::endl;
     int32_t field = struct_item.field();
     proj_exprs.push_back(compute::field_ref(field));
   }
@@ -1195,7 +1197,7 @@ Result<std::vector<compute::Expression>> FromProto(
 Result<std::vector<compute::Expression>> FromProto(
     const ::substrait::Expression::MaskExpression& mask_expr, const ExtensionSet& ext_set,
     const ConversionOptions& conversion_options) {
-  // TODO::Vibhatha consider bool maintain_singular_struct = 2;
+  // TODO(vibhatha) consider bool maintain_singular_struct = 2;
   if (mask_expr.has_select()) {
     // class Expression_MaskExpression_StructSelect final :
     return FromProto(mask_expr.select(), ext_set, conversion_options);

--- a/cpp/src/arrow/engine/substrait/expression_internal.h
+++ b/cpp/src/arrow/engine/substrait/expression_internal.h
@@ -56,5 +56,21 @@ ARROW_ENGINE_EXPORT
 Result<SubstraitCall> FromProto(const substrait::AggregateFunction&, bool is_hash,
                                 const ExtensionSet&, const ConversionOptions&);
 
+Result<std::vector<compute::Expression>> FromProto(
+    const ::substrait::Expression::MaskExpression::Select& mask_expr_select,
+    const ExtensionSet& ext_set, const ConversionOptions& conversion_options);
+
+Result<std::vector<compute::Expression>> FromProto(
+    const ::substrait::Expression::MaskExpression::StructItem& struct_item,
+    const ExtensionSet& ext_set, const ConversionOptions& conversion_options);
+
+Result<std::vector<compute::Expression>> FromProto(
+    const ::substrait::Expression::MaskExpression::StructSelect& struct_select,
+    const ExtensionSet& ext_set, const ConversionOptions& conversion_options);
+
+Result<std::vector<compute::Expression>> FromProto(
+    const ::substrait::Expression::MaskExpression& mask_expr, const ExtensionSet& ext_set,
+    const ConversionOptions& conversion_options);
+
 }  // namespace engine
 }  // namespace arrow

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -150,6 +150,37 @@ Status DiscoverFilesFromDir(const std::shared_ptr<fs::LocalFileSystem>& local_fs
   return Status::OK();
 }
 
+void ExtractStructSelect(
+    const ::substrait::Expression::MaskExpression::StructSelect& struct_select) {
+  for (int idx = 0; idx < struct_select.struct_items_size(); idx++) {
+    ::substrait::Expression::MaskExpression::StructItem struct_item =
+        struct_select.struct_items(idx);
+    if (struct_item.has_child()) {
+      std::cout << "has Child" << std::endl;
+      ::substrait::Expression::MaskExpression::Select child = struct_item.child();
+      if (child.has_struct_()) {
+        ::substrait::Expression::MaskExpression::StructSelect child_struct_select =
+            child.struct_();
+      } else if (child.has_list()) {
+      } else if (child.has_map()) {
+      }
+    } else {
+      int32_t field = struct_item.field();
+      std::cout << "Field : " << field << std::endl;
+    }
+  }
+}
+
+void ToProto(const ::substrait::Expression::MaskExpression& mask_expr) {
+  if (mask_expr.has_select()) {
+    std::cout << "read.projection().has_select() == " << mask_expr.has_select()
+              << std::endl;
+    ::substrait::Expression::MaskExpression::StructSelect struct_select =
+        mask_expr.select();
+    std::cout << "Struct Item Size: " << struct_select.struct_items_size() << std::endl;
+  }
+}
+
 Result<DeclarationInfo> FromProto(const substrait::Rel& rel, const ExtensionSet& ext_set,
                                   const ConversionOptions& conversion_options) {
   static bool dataset_init = false;
@@ -176,6 +207,8 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel, const ExtensionSet&
       }
 
       if (read.has_projection()) {
+        ::substrait::Expression::MaskExpression mask_expr = read.projection();
+        ReadProjectionToAcero(mask_expr);
         return Status::NotImplemented("substrait::ReadRel::projection");
       }
 

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -152,7 +152,7 @@ Status DiscoverFilesFromDir(const std::shared_ptr<fs::LocalFileSystem>& local_fs
 
 Result<std::vector<compute::Expression>> ExtractStructSelect(
     const ::substrait::Expression::MaskExpression::StructSelect& struct_select) {
-  int struct_items_size = struct_select.struct_items_size(); 
+  int struct_items_size = struct_select.struct_items_size();
   std::vector<compute::Expression> project_exprs;
   project_exprs.reserve(struct_items_size);
   for (int idx = 0; idx < struct_items_size; idx++) {
@@ -166,7 +166,8 @@ Result<std::vector<compute::Expression>> ExtractStructSelect(
             child.struct_();
         return ExtractStructSelect(child_struct_select);
       } else if (child.has_list()) {
-        return Status::NotImplemented("substrait::Expression::MaskExpression::ListSelect");
+        return Status::NotImplemented(
+            "substrait::Expression::MaskExpression::ListSelect");
       } else if (child.has_map()) {
         return Status::NotImplemented("substrait::Expression::MaskExpression::MapSelect");
       } else {
@@ -181,7 +182,8 @@ Result<std::vector<compute::Expression>> ExtractStructSelect(
   return std::move(project_exprs);
 }
 
-Result<std::vector<compute::Expression>> FromProtoMaskExpression(const ::substrait::Expression::MaskExpression& mask_expr) {
+Result<std::vector<compute::Expression>> FromProtoMaskExpression(
+    const ::substrait::Expression::MaskExpression& mask_expr) {
   if (mask_expr.has_select()) {
     std::cout << "read.projection().has_select() == " << mask_expr.has_select()
               << std::endl;
@@ -223,11 +225,11 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel, const ExtensionSet&
         ::substrait::Expression::MaskExpression mask_expr = read.projection();
         ARROW_ASSIGN_OR_RAISE(auto proj_exprs, FromProtoMaskExpression(mask_expr));
         std::cout << "Proj Expr: " << std::endl;
-        for(const auto& expr: proj_exprs) {
+        for (const auto& expr : proj_exprs) {
           std::cout << expr.ToString() << std::endl;
         }
         scan_options->projection = compute::project({proj_exprs}, {});
-        //return Status::NotImplemented("substrait::ReadRel::projection");
+        // return Status::NotImplemented("substrait::ReadRel::projection");
       }
 
       if (read.has_named_table()) {

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -150,7 +150,7 @@ Status DiscoverFilesFromDir(const std::shared_ptr<fs::LocalFileSystem>& local_fs
   return Status::OK();
 }
 
-void ExtractStructSelect(
+Result<compute::Expression> ExtractStructSelect(
     const ::substrait::Expression::MaskExpression::StructSelect& struct_select) {
   for (int idx = 0; idx < struct_select.struct_items_size(); idx++) {
     ::substrait::Expression::MaskExpression::StructItem struct_item =
@@ -162,7 +162,9 @@ void ExtractStructSelect(
         ::substrait::Expression::MaskExpression::StructSelect child_struct_select =
             child.struct_();
       } else if (child.has_list()) {
+        return Status::NotImplemented("substrait::Expression::MaskExpression::ListSelect not supported");
       } else if (child.has_map()) {
+        return Status::NotImplemented("substrait::Expression::MaskExpression::MapSelect not supported");
       }
     } else {
       int32_t field = struct_item.field();
@@ -171,7 +173,7 @@ void ExtractStructSelect(
   }
 }
 
-void ToProto(const ::substrait::Expression::MaskExpression& mask_expr) {
+Result<compute::Expression> FromProto(const ::substrait::Expression::MaskExpression& mask_expr) {
   if (mask_expr.has_select()) {
     std::cout << "read.projection().has_select() == " << mask_expr.has_select()
               << std::endl;

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -4504,13 +4504,10 @@ TEST(SubstraitRoundTrip, ScanProjection) {
   // don't use a function.
   scan_options->projection = compute::project({compute::field_ref("shared")}, {"shared"});
 
+  auto declarations = compute::Declaration::Sequence({compute::Declaration(
+      {"scan", dataset::ScanNodeOptions{dataset, scan_options}, "s"})});
 
-  auto declarations = compute::Declaration::Sequence(
-      {compute::Declaration(
-           {"scan", dataset::ScanNodeOptions{dataset, scan_options}, "s"})});
-  
-
-  //auto output_schema = schema({field("shared", int32())});
+  // auto output_schema = schema({field("shared", int32())});
   ASSERT_OK_AND_ASSIGN(auto expected_table,
                        GetTableFromPlan(declarations, exec_context, dummy_schema));
   std::cout << "Output" << std::endl;

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -3810,5 +3810,643 @@ TEST(Substrait, ReadRelWithGlobFiles) {
                        buf, {}, {}, &options);
 }
 
+/// Testig ReadRel Project
+
+TEST(SubstraitRoundTrip, ReadRelProjectIssue) {
+  compute::ExecContext exec_context;
+  auto orders_schema =
+      schema({field("O_ORDERKEY", int32()), field("O_CUSTKEY", int32()),
+              field("O_ORDERSTATUS", utf8()), field("O_TOTALPRICE", decimal128(15, 2)),
+              field("O_ORDERDATE", date32()), field("O_ORDERPRIORITY", utf8()),
+              field("O_CLERK", utf8()), field("O_SHIPPRIORITY", int32()),
+              field("O_COMMENT", utf8())});
+
+  // creating a dummy dataset using a dummy table
+  auto orders = TableFromJSON(orders_schema, {R"([
+      [1, 1, "S1", "1.25", 0, "P0", "C1", 0, "CM1"]
+  ])"});
+
+  auto customer_schema =
+      schema({field("C_CUSTKEY", int32()), field("C_NAME", utf8()),
+              field("C_ADDRESS", utf8()), field("C_NATIONKEY", int32()),
+              field("C_PHONE", utf8()), field("C_ACCTBAL", decimal128(15, 2)),
+              field("C_MKTSEGMENT", utf8()), field("C_COMMENT", utf8())});
+
+  auto customer = TableFromJSON(customer_schema, {R"([
+      [1, "CUS1", "A1", 10, "PH1", "250.21", "MSG1", "CM1"]
+  ])"});
+
+  std::string substrait_json = R"({
+    "extensionUris": [
+        {
+        "extension_uri_anchor": 0,
+        "uri": ")" + std::string(kSubstraitComparisonFunctionsUri) +
+                               R"("
+      }
+    ],
+    "extensions": [
+        {
+            "extensionFunction": {
+                "extensionUriReference": 1,
+                "name": "equal:any_any"
+            }
+        }
+    ],
+    "relations": [
+        {
+            "root": {
+                "input": {
+                    "project": {
+                        "common": {
+                            "emit": {
+                                "outputMapping": [
+                                    17
+                                ]
+                            }
+                        },
+                        "input": {
+                            "join": {
+                                "common": {
+                                    "direct": {}
+                                },
+                                "left": {
+                                    "read": {
+                                        "common": {
+                                            "direct": {}
+                                        },
+                                        "baseSchema": {
+                                            "names": [
+                                                "O_ORDERKEY",
+                                                "O_CUSTKEY",
+                                                "O_ORDERSTATUS",
+                                                "O_TOTALPRICE",
+                                                "O_ORDERDATE",
+                                                "O_ORDERPRIORITY",
+                                                "O_CLERK",
+                                                "O_SHIPPRIORITY",
+                                                "O_COMMENT"
+                                            ],
+                                            "struct": {
+                                                "types": [
+                                                    {
+                                                        "i32": {
+                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                    },
+                                                    {
+                                                        "i32": {
+                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                    },
+                                                    {
+                                                        "string": {
+                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                    },
+                                                    {
+                                                        "decimal": {
+                                                            "scale": 2,
+                                                            "precision": 15,
+                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                    },
+                                                    {
+                                                        "date": {
+                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                    },
+                                                    {
+                                                        "string": {
+                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                    },
+                                                    {
+                                                        "string": {
+                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                    },
+                                                    {
+                                                        "i32": {
+                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                    },
+                                                    {
+                                                        "string": {
+                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                    }
+                                                ],
+                                                "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                        },
+                                        "namedTable": {
+                                            "names": [
+                                                "ORDERS"
+                                            ]
+                                        }
+                                    }
+                                },
+                                "right": {
+                                    "read": {
+                                        "common": {
+                                            "direct": {}
+                                        },
+                                        "baseSchema": {
+                                            "names": [
+                                                "C_CUSTKEY",
+                                                "C_NAME",
+                                                "C_ADDRESS",
+                                                "C_NATIONKEY",
+                                                "C_PHONE",
+                                                "C_ACCTBAL",
+                                                "C_MKTSEGMENT",
+                                                "C_COMMENT"
+                                            ],
+                                            "struct": {
+                                                "types": [
+                                                    {
+                                                        "i32": {
+                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                    },
+                                                    {
+                                                        "string": {
+                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                    },
+                                                    {
+                                                        "string": {
+                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                    },
+                                                    {
+                                                        "i32": {
+                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                    },
+                                                    {
+                                                        "string": {
+                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                    },
+                                                    {
+                                                        "decimal": {
+                                                            "scale": 2,
+                                                            "precision": 15,
+                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                    },
+                                                    {
+                                                        "string": {
+                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                    },
+                                                    {
+                                                        "string": {
+                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                    }
+                                                ],
+                                                "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                        },
+                                        "namedTable": {
+                                            "names": [
+                                                "CUSTOMER"
+                                            ]
+                                        }
+                                    }
+                                },
+                                "expression": {
+                                    "scalarFunction": {
+                                        "outputType": {
+                                            "bool": {
+                                                "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                        },
+                                        "arguments": [
+                                            {
+                                                "value": {
+                                                    "selection": {
+                                                        "directReference": {
+                                                            "structField": {
+                                                                "field": 1
+                                                            }
+                                                        },
+                                                        "rootReference": {}
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "value": {
+                                                    "selection": {
+                                                        "directReference": {
+                                                            "structField": {
+                                                                "field": 9
+                                                            }
+                                                        },
+                                                        "rootReference": {}
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "type": "JOIN_TYPE_INNER"
+                            }
+                        },
+                        "expressions": [
+                            {
+                                "selection": {
+                                    "directReference": {
+                                        "structField": {
+                                            "field": 1
+                                        }
+                                    },
+                                    "rootReference": {}
+                                }
+                            }
+                        ]
+                    }
+                },
+                "names": [
+                    "O_CUSTKEY"
+                ]
+            }
+        }
+    ]
+})";
+
+  ASSERT_OK_AND_ASSIGN(auto buf,
+                       internal::SubstraitFromJSON("Plan", substrait_json,
+                                                   /*ignore_unknown_fields=*/false));
+
+  auto output_schema = schema({field("O_CUSTKEY", int32())});
+
+  NamedTableProvider table_provider = [&](const std::vector<std::string>& names) {
+    std::shared_ptr<compute::ExecNodeOptions> options;
+    if (std::find(names.begin(), names.end(), "ORDERS") != names.end()) {
+      options = std::make_shared<compute::TableSourceNodeOptions>(orders);
+    } else if (std::find(names.begin(), names.end(), "CUSTOMER") != names.end()) {
+      options = std::make_shared<compute::TableSourceNodeOptions>(customer);
+    }
+    return compute::Declaration("table_source", {}, options, "mock_source");
+  };
+
+  ConversionOptions conversion_options;
+  conversion_options.named_table_provider = std::move(table_provider);
+
+  std::shared_ptr<ExtensionIdRegistry> sp_ext_id_reg = MakeExtensionIdRegistry();
+  ExtensionIdRegistry* ext_id_reg = sp_ext_id_reg.get();
+  ExtensionSet ext_set(ext_id_reg);
+  ASSERT_OK_AND_ASSIGN(auto sink_decls, DeserializePlans(
+                                            *buf, [] { return kNullConsumer; },
+                                            ext_id_reg, &ext_set, conversion_options));
+  auto& other_declrs = std::get<compute::Declaration>(sink_decls[0].inputs[0]);
+
+  ASSERT_OK_AND_ASSIGN(auto output_table,
+                       GetTableFromPlan(other_declrs, exec_context, output_schema));
+
+  std::cout << "Output " << std::endl;
+  std::cout << output_table->ToString() << std::endl;
+  // auto array = ArrayFromJSON(date32(), "[1234, 5678, 9012, 1, 2, 3]");
+  // std::cout << "Data32" << std::endl;
+  // std::cout << array->ToString() << std::endl;
+}
+
+TEST(SubstraitRoundTrip, ReadRelProjectIssueDuckDB) {
+  compute::ExecContext exec_context;
+  auto orders_schema =
+      schema({field("O_ORDERKEY", int32()), field("O_CUSTKEY", int32()),
+              field("O_ORDERSTATUS", utf8()), field("O_TOTALPRICE", decimal128(15, 2)),
+              field("O_ORDERDATE", date32()), field("O_ORDERPRIORITY", utf8()),
+              field("O_CLERK", utf8()), field("O_SHIPPRIORITY", int32()),
+              field("O_COMMENT", utf8())});
+
+  // creating a dummy dataset using a dummy table
+  auto orders = TableFromJSON(orders_schema, {R"([
+      [1, 1, "S1", "1.25", 0, "P0", "C1", 0, "CM1"]
+  ])"});
+
+  auto customer_schema =
+      schema({field("C_CUSTKEY", int32()), field("C_NAME", utf8()),
+              field("C_ADDRESS", utf8()), field("C_NATIONKEY", int32()),
+              field("C_PHONE", utf8()), field("C_ACCTBAL", decimal128(15, 2)),
+              field("C_MKTSEGMENT", utf8()), field("C_COMMENT", utf8())});
+
+  auto customer = TableFromJSON(customer_schema, {R"([
+      [1, "CUS1", "A1", 10, "PH1", "250.21", "MSG1", "CM1"]
+  ])"});
+
+  std::string substrait_json = R"({
+    "extensionUris": [
+        {
+        "extension_uri_anchor": 0,
+        "uri": ")" + std::string(kSubstraitComparisonFunctionsUri) +
+                               R"("
+      }
+    ],
+    "extensions": [
+        {
+            "extensionFunction": {
+                "extensionUriReference": 1,
+                "name": "equal:any_any"
+            }
+        }
+    ],
+    "relations": [
+        {
+            "root": {
+                "input": {
+                    "project": {
+                        "input": {
+                            "project": {
+                                "input": {
+                                    "join": {
+                                        "left": {
+                                            "read": {
+                                                "baseSchema": {
+                                                    "names": [
+                                                        "o_orderkey",
+                                                        "o_custkey",
+                                                        "o_orderstatus",
+                                                        "o_totalprice",
+                                                        "o_orderdate",
+                                                        "o_orderpriority",
+                                                        "o_clerk",
+                                                        "o_shippriority",
+                                                        "o_comment"
+                                                    ],
+                                                    "struct": {
+                                                        "types": [
+                                                            {
+                                                                "i32": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "i32": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "varchar": {
+                                                                    "length": 1,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "decimal": {
+                                                                    "scale": 2,
+                                                                    "precision": 15,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "date": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "varchar": {
+                                                                    "length": 15,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "varchar": {
+                                                                    "length": 15,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "i32": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "varchar": {
+                                                                    "length": 78,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            }
+                                                        ],
+                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                },
+                                                "projection": {
+                                                    "select": {
+                                                        "structItems": [
+                                                            {
+                                                                "field": 1
+                                                            }
+                                                        ]
+                                                    },
+                                                    "maintainSingularStruct": true
+                                                },
+                                                "namedTable": {
+                                                    "names": [
+                                                        "orders"
+                                                    ]
+                                                }
+                                            }
+                                        },
+                                        "right": {
+                                            "read": {
+                                                "baseSchema": {
+                                                    "names": [
+                                                        "c_custkey",
+                                                        "c_name",
+                                                        "c_address",
+                                                        "c_nationkey",
+                                                        "c_phone",
+                                                        "c_acctbal",
+                                                        "c_mktsegment",
+                                                        "c_comment"
+                                                    ],
+                                                    "struct": {
+                                                        "types": [
+                                                            {
+                                                                "i32": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "varchar": {
+                                                                    "length": 18,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "varchar": {
+                                                                    "length": 40,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "i32": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "varchar": {
+                                                                    "length": 15,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "decimal": {
+                                                                    "scale": 2,
+                                                                    "precision": 15,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "varchar": {
+                                                                    "length": 10,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "varchar": {
+                                                                    "length": 116,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            }
+                                                        ],
+                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                },
+                                                "projection": {
+                                                    "select": {
+                                                        "structItems": [
+                                                            {}
+                                                        ]
+                                                    },
+                                                    "maintainSingularStruct": true
+                                                },
+                                                "namedTable": {
+                                                    "names": [
+                                                        "customer"
+                                                    ]
+                                                }
+                                            }
+                                        },
+                                        "expression": {
+                                            "scalarFunction": {
+                                                "functionReference": 1,
+                                                "outputType": {
+                                                    "bool": {
+                                                        "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                },
+                                                "arguments": [
+                                                    {
+                                                        "value": {
+                                                            "selection": {
+                                                                "directReference": {
+                                                                    "structField": {}
+                                                                },
+                                                                "rootReference": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    {
+                                                        "value": {
+                                                            "selection": {
+                                                                "directReference": {
+                                                                    "structField": {
+                                                                        "field": 1
+                                                                    }
+                                                                },
+                                                                "rootReference": {}
+                                                            }
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "type": "JOIN_TYPE_INNER"
+                                    }
+                                },
+                                "expressions": [
+                                    {
+                                        "selection": {
+                                            "directReference": {
+                                                "structField": {}
+                                            },
+                                            "rootReference": {}
+                                        }
+                                    },
+                                    {
+                                        "selection": {
+                                            "directReference": {
+                                                "structField": {
+                                                    "field": 1
+                                                }
+                                            },
+                                            "rootReference": {}
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "expressions": [
+                            {
+                                "selection": {
+                                    "directReference": {
+                                        "structField": {}
+                                    },
+                                    "rootReference": {}
+                                }
+                            }
+                        ]
+                    }
+                },
+                "names": [
+                    "o_custkey"
+                ]
+            }
+        }
+    ]
+})";
+
+  ASSERT_OK_AND_ASSIGN(auto buf,
+                       internal::SubstraitFromJSON("Plan", substrait_json,
+                                                   /*ignore_unknown_fields=*/false));
+
+  auto output_schema = schema({field("O_CUSTKEY", int32())});
+
+  NamedTableProvider table_provider = [&](const std::vector<std::string>& names) {
+    std::shared_ptr<compute::ExecNodeOptions> options;
+    if (std::find(names.begin(), names.end(), "ORDERS") != names.end()) {
+      options = std::make_shared<compute::TableSourceNodeOptions>(orders);
+    } else if (std::find(names.begin(), names.end(), "CUSTOMER") != names.end()) {
+      options = std::make_shared<compute::TableSourceNodeOptions>(customer);
+    }
+    return compute::Declaration("table_source", {}, options, "mock_source");
+  };
+
+  ConversionOptions conversion_options;
+  conversion_options.named_table_provider = std::move(table_provider);
+
+  std::shared_ptr<ExtensionIdRegistry> sp_ext_id_reg = MakeExtensionIdRegistry();
+  ExtensionIdRegistry* ext_id_reg = sp_ext_id_reg.get();
+  ExtensionSet ext_set(ext_id_reg);
+  ASSERT_OK_AND_ASSIGN(auto sink_decls, DeserializePlans(
+                                            *buf, [] { return kNullConsumer; },
+                                            ext_id_reg, &ext_set, conversion_options));
+  auto& other_declrs = std::get<compute::Declaration>(sink_decls[0].inputs[0]);
+
+  ASSERT_OK_AND_ASSIGN(auto output_table,
+                       GetTableFromPlan(other_declrs, exec_context, output_schema));
+
+  std::cout << "Output " << std::endl;
+  std::cout << output_table->ToString() << std::endl;
+  // auto array = ArrayFromJSON(date32(), "[1234, 5678, 9012, 1, 2, 3]");
+  // std::cout << "Data32" << std::endl;
+  // std::cout << array->ToString() << std::endl;
+}
+
 }  // namespace engine
 }  // namespace arrow

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -4115,6 +4115,12 @@ TEST(SubstraitRoundTrip, ReadRelProjectIssue) {
 }
 
 TEST(SubstraitRoundTrip, ScanPushdownProject) {
+  // TODO: the way I have interpreted this plan is wrong
+  // In the pushdown filter, only have to project out the said columns and
+  // leave out the other columns. Then the join would happen on the 0th column
+  // of the first table and the 1st column of the second table. The duckdb definition
+  // has a pushdown filter for this reason so that we don't load the unnecessary data
+  // into memory.
   compute::ExecContext exec_context;
   auto orders_schema =
       schema({field("O_ORDERKEY", int32()), field("O_CUSTKEY", int32()),
@@ -4346,9 +4352,7 @@ TEST(SubstraitRoundTrip, ScanPushdownProject) {
                                                         "value": {
                                                             "selection": {
                                                                 "directReference": {
-                                                                    "structField": {
-                                                                      "field": 1
-                                                                    }
+                                                                    "structField": {}
                                                                 },
                                                                 "rootReference": {}
                                                             }
@@ -4359,7 +4363,7 @@ TEST(SubstraitRoundTrip, ScanPushdownProject) {
                                                             "selection": {
                                                                 "directReference": {
                                                                     "structField": {
-                                                                        "field": 9
+                                                                        "field": 1
                                                                     }
                                                                 },
                                                                 "rootReference": {}


### PR DESCRIPTION
**DO NOT REVIEW**
This draft PR includes a way to handle projection in `substrait::ReadRel`. This is still working in progress and the complete feature is not yet implemented. The current version is a very naive test code in evaluating what needs to be done. The complete PR should include the following.

- [ ] Consuming Substrait `MaskExpression` 
- [x] Integrate `ReadRel` projection with extracted expressions from the consumed `MaskExpression`
- [ ] Test cases to evaluate variations in `MaskExpression` consuming
- [ ] Move `MaskExpression` ToProto to `expreesion_internal.cc`
- [ ] Self Review 1
- [ ] Self Review 2
* Closes: #14965