### PR TITLE
GH-14977: [Dev][CI] Add notify-token-expiration to archery

### DIFF
--- a/dev/archery/archery/crossbow/cli.py
+++ b/dev/archery/archery/crossbow/cli.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from datetime import date
 from pathlib import Path
 import time
 import sys
@@ -402,10 +403,10 @@ def report(obj, job_name, sender_name, sender_email, recipient_email,
             smtp_server=smtp_server,
             smtp_port=smtp_port,
             recipient_email=recipient_email,
-            message=email_report.render("text")
+            message=email_report.render("nightly_report")
         )
     else:
-        output.write(email_report.render("text"))
+        output.write(email_report.render("nightly_report"))
 
 
 @crossbow.command()
@@ -589,3 +590,68 @@ def delete_old_branches(obj, dry_run, days, maximum):
             queue.push(batch)
         else:
             print(batch)
+
+
+@crossbow.command()
+@click.option('--days', default=30,
+              help='Notification will be sent if expiration date is '
+                   'closer than the number of days.')
+@click.option('--sender-name', '-n',
+              help='Name to use for report e-mail.')
+@click.option('--sender-email', '-e',
+              help='E-mail to use for report e-mail.')
+@click.option('--recipient-email', '-r',
+              help='Where to send the e-mail report')
+@click.option('--smtp-user', '-u',
+              help='E-mail address to use for SMTP login')
+@click.option('--smtp-password', '-P',
+              help='SMTP password to use for report e-mail.')
+@click.option('--smtp-server', '-s', default='smtp.gmail.com',
+              help='SMTP server to use for report e-mail.')
+@click.option('--smtp-port', '-p', default=465,
+              help='SMTP port to use for report e-mail.')
+@click.option('--send/--dry-run', default=False,
+              help='Just display the report, don\'t send it')
+@click.pass_obj
+def notify_token_expiration(obj, days, sender_name, sender_email,
+                            recipient_email, smtp_user, smtp_password,
+                            smtp_server, smtp_port, send):
+    """
+    Check if token is close to expiration and send email notifying.
+    """
+    output = obj['output']
+    queue = obj['queue']
+
+    token_expiration_date = queue.token_expiration_date()
+    days_left = 0
+    if token_expiration_date:
+        days_left = (token_expiration_date - date.today()).days
+        if days_left > days:
+            output.write("Notification not sent. " +
+                         f"Token will expire in {days_left} days.")
+            return
+
+    class TokenExpirationReport:
+        def __init__(self, token_expiration_date, days_left):
+            self.token_expiration_date = token_expiration_date
+            self.days_left = days_left
+
+    email_report = EmailReport(
+        report=TokenExpirationReport(
+            token_expiration_date or "ALREADY_EXPIRED", days_left),
+        sender_name=sender_name,
+        sender_email=sender_email,
+        recipient_email=recipient_email
+    )
+
+    if send:
+        ReportUtils.send_email(
+            smtp_user=smtp_user,
+            smtp_password=smtp_password,
+            smtp_server=smtp_server,
+            smtp_port=smtp_port,
+            recipient_email=recipient_email,
+            message=email_report.render("token_expiration")
+        )
+    else:
+        output.write(email_report.render("token_expiration"))

--- a/dev/archery/archery/crossbow/cli.py
+++ b/dev/archery/archery/crossbow/cli.py
@@ -644,6 +644,7 @@ def notify_token_expiration(obj, days, sender_name, sender_email,
         recipient_email=recipient_email
     )
 
+    message = email_report.render("token_expiration").strip()
     if send:
         ReportUtils.send_email(
             smtp_user=smtp_user,
@@ -651,7 +652,7 @@ def notify_token_expiration(obj, days, sender_name, sender_email,
             smtp_server=smtp_server,
             smtp_port=smtp_port,
             recipient_email=recipient_email,
-            message=email_report.render("token_expiration")
+            message=message
         )
     else:
-        output.write(email_report.render("token_expiration"))
+        output.write(message)

--- a/dev/archery/archery/crossbow/reports.py
+++ b/dev/archery/archery/crossbow/reports.py
@@ -265,7 +265,8 @@ class ReportUtils:
 
 class EmailReport(JinjaReport):
     templates = {
-        'text': 'email_nightly_report.txt.j2',
+        'nightly_report': 'email_nightly_report.txt.j2',
+        'token_expiration': 'email_token_expiration.txt.j2',
     }
     fields = [
         'report',

--- a/dev/archery/archery/crossbow/tests/test_reports.py
+++ b/dev/archery/archery/crossbow/tests/test_reports.py
@@ -80,7 +80,9 @@ def test_crossbow_email_report(load_fixture):
                                sender_email="sender@arrow.com",
                                recipient_email="recipient@arrow.com")
 
-    assert email_report.render("text") == textwrap.dedent(expected_msg)
+    assert (
+        email_report.render("nightly_report") == textwrap.dedent(expected_msg)
+    )
 
 
 def test_crossbow_export_report(load_fixture):

--- a/dev/archery/archery/templates/email_token_expiration.txt.j2
+++ b/dev/archery/archery/templates/email_token_expiration.txt.j2
@@ -1,0 +1,28 @@
+{#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#}
+{%- if True -%}
+{%- endif -%}
+From: {{ sender_name }} <{{ sender_email }}>
+To: {{ recipient_email }}
+Subject: [CI] Arrow Crossbow Token Expiration in {{ report.token_expiration_date }}
+
+The Arrow Crossbow Token will expire in {{ report.days_left }} days.
+
+Please generate a new Token. Send it to Apache INFRA to update the CROSSBOW_GITHUB_TOKEN.
+Update it on the crossbow repository and in the Azure pipelines.

--- a/dev/archery/archery/templates/email_token_expiration.txt.j2
+++ b/dev/archery/archery/templates/email_token_expiration.txt.j2
@@ -16,8 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #}
-{%- if True -%}
-{%- endif -%}
 From: {{ sender_name }} <{{ sender_email }}>
 To: {{ recipient_email }}
 Subject: [CI] Arrow Crossbow Token Expiration in {{ report.token_expiration_date }}


### PR DESCRIPTION
This can be added to run weekly on crossbow similar to the email report generation tasks.

In the case of a non expired token:
```
$ CROSSBOW_GITHUB_TOKEN=${TOKEN} archery crossbow notify-token-expiration --days 30
Notification not sent. Token will expire in 39 days.
```
In the case of an expired token:
```
$ CROSSBOW_GITHUB_TOKEN=${TOKEN} archery crossbow notify-token-expiration --days 40
From: None <None>
To: None
Subject: [CI] Arrow Crossbow Token Expiration in 2023-01-23

The Arrow Crossbow Token will expire in 39 days.

Please generate a new Token. Send it to Apache INFRA to update the CROSSBOW_GITHUB_TOKEN.
Update it on the crossbow repository and in the Azure pipelines.
```
In the case of a non-existing token:
```
$ CROSSBOW_GITHUB_TOKEN=wrong_token archery crossbow notify-token-expiration --days 40
From: None <None>
To: None
Subject: [CI] Arrow Crossbow Token Expiration in ALREADY_EXPIRED

The Arrow Crossbow Token will expire in 0 days.

Please generate a new Token. Send it to Apache INFRA to update the CROSSBOW_GITHUB_TOKEN.
Update it on the crossbow repository and in the Azure pipelines.
* Closes: #14977