### PR TITLE
[Go] Cherry-pick changes for OTEL to maintenance branch

### DIFF
--- a/dev/release/test-helper.rb
+++ b/dev/release/test-helper.rb
@@ -109,7 +109,11 @@ module VersionDetectable
     @next_so_version = compute_so_version(@next_version)
     r_description = top_dir + "r" + "DESCRIPTION"
     @previous_version = r_description.read[/^Version: (.+?)\.9000$/, 1]
-    @previous_compatible_version = @previous_version.split(".")[0, 2].join(".")
+    if @previous_version
+      @previous_compatible_version = @previous_version.split(".")[0, 2].join(".")
+    else
+      @previous_compatible_version = nil
+    end
   end
 
   def compute_so_version(version)

--- a/go/arrow/array/list.go
+++ b/go/arrow/array/list.go
@@ -154,7 +154,7 @@ func (a *List) Release() {
 
 func (a *List) ValueOffsets(i int) (start, end int64) {
 	debug.Assert(i >= 0 && i < a.array.data.length, "index out of range")
-	start, end = int64(a.offsets[i]), int64(a.offsets[i+1])
+	start, end = int64(a.offsets[i+a.data.offset]), int64(a.offsets[i+a.data.offset+1])
 	return
 }
 

--- a/go/arrow/ipc/compression.go
+++ b/go/arrow/ipc/compression.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/apache/arrow/go/v10/arrow/internal/debug"
 	"github.com/apache/arrow/go/v10/arrow/internal/flatbuf"
+	"github.com/apache/arrow/go/v10/arrow/memory"
 	"github.com/klauspost/compress/zstd"
 	"github.com/pierrec/lz4/v4"
 )
@@ -117,4 +118,18 @@ func getDecompressor(codec flatbuf.CompressionType) decompressor {
 		return &zstdDecompressor{dec}
 	}
 	return nil
+}
+
+type bufferWriter struct {
+	buf *memory.Buffer
+	pos int
+}
+
+func (bw *bufferWriter) Write(p []byte) (n int, err error) {
+	if bw.pos+len(p) >= bw.buf.Cap() {
+		bw.buf.Reserve(bw.pos + len(p))
+	}
+	n = copy(bw.buf.Buf()[bw.pos:], p)
+	bw.pos += n
+	return
 }

--- a/go/arrow/ipc/ipc_test.go
+++ b/go/arrow/ipc/ipc_test.go
@@ -19,9 +19,11 @@ package ipc_test
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"math/rand"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -481,4 +483,140 @@ func encodeDecodeIpcStream(t *testing.T,
 		return nil, ipcReader, err
 	}
 	return json, ipcReader, nil
+}
+
+func Example_mapSlice() {
+	mem := memory.DefaultAllocator
+	dt := arrow.MapOf(arrow.BinaryTypes.String, arrow.BinaryTypes.String)
+	schema := arrow.NewSchema([]arrow.Field{{
+		Name: "map",
+		Type: dt,
+	}}, nil)
+
+	arr, _, err := array.FromJSON(mem, dt, strings.NewReader(`[
+		[{"key": "index1", "value": "main2"}],
+		[{"key": "index3", "value": "main4"}, {"key": "tag_int", "value": ""}],
+		[{"key":"index5","value":"main6"},{"key":"tag_int","value":""}],
+		[{"key":"index6","value":"main7"},{"key":"tag_int","value":""}],
+		[{"key":"index7","value":"main8"},{"key":"tag_int","value":""}],
+		[{"key":"index8","value":"main9"}]
+	]`))
+	if err != nil {
+		panic(err)
+	}
+	defer arr.Release()
+
+	rec := array.NewRecord(schema, []arrow.Array{arr}, int64(arr.Len()))
+	defer rec.Release()
+	rec2 := rec.NewSlice(1, 2)
+	defer rec2.Release()
+
+	var buf bytes.Buffer
+	w := ipc.NewWriter(&buf, ipc.WithSchema(rec.Schema()))
+	if err := w.Write(rec2); err != nil {
+		panic(err)
+	}
+	if err := w.Close(); err != nil {
+		panic(err)
+	}
+
+	r, err := ipc.NewReader(&buf)
+	if err != nil {
+		panic(err)
+	}
+	defer r.Release()
+
+	r.Next()
+	fmt.Println(r.Record())
+
+	// Output:
+	// record:
+	//   schema:
+	//   fields: 1
+	//     - map: type=map<utf8, utf8>
+	//   rows: 1
+	//   col[0][map]: [{["index3" "tag_int"] ["main4" ""]}]
+}
+
+func Example_listSlice() {
+	mem := memory.DefaultAllocator
+	dt := arrow.ListOf(arrow.BinaryTypes.String)
+	schema := arrow.NewSchema([]arrow.Field{{
+		Name: "list",
+		Type: dt,
+	}}, nil)
+
+	arr, _, err := array.FromJSON(mem, dt, strings.NewReader(`[
+		["index1"], 
+		["index3", "tag_int"], ["index5", "tag_int"],
+		["index6", "tag_int"], ["index7", "tag_int"], 
+		["index7", "tag_int"],
+		["index8"]
+	]`))
+	if err != nil {
+		panic(err)
+	}
+	defer arr.Release()
+
+	rec := array.NewRecord(schema, []arrow.Array{arr}, int64(arr.Len()))
+	defer rec.Release()
+	rec2 := rec.NewSlice(1, 2)
+	defer rec2.Release()
+
+	var buf bytes.Buffer
+	w := ipc.NewWriter(&buf, ipc.WithSchema(rec.Schema()))
+	if err := w.Write(rec2); err != nil {
+		panic(err)
+	}
+	if err := w.Close(); err != nil {
+		panic(err)
+	}
+
+	r, err := ipc.NewReader(&buf)
+	if err != nil {
+		panic(err)
+	}
+	defer r.Release()
+
+	r.Next()
+	fmt.Println(r.Record())
+
+	// Output:
+	// record:
+	//   schema:
+	//   fields: 1
+	//     - list: type=list<item: utf8, nullable>
+	//   rows: 1
+	//   col[0][list]: [["index3" "tag_int"]]
+}
+
+func TestIpcEmptyMap(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	dt := arrow.MapOf(arrow.BinaryTypes.String, arrow.BinaryTypes.String)
+	schema := arrow.NewSchema([]arrow.Field{{
+		Name: "map",
+		Type: dt,
+	}}, nil)
+
+	arr, _, err := array.FromJSON(mem, dt, strings.NewReader(`[]`))
+	require.NoError(t, err)
+	defer arr.Release()
+
+	rec := array.NewRecord(schema, []arrow.Array{arr}, int64(arr.Len()))
+	defer rec.Release()
+
+	var buf bytes.Buffer
+	w := ipc.NewWriter(&buf, ipc.WithSchema(rec.Schema()))
+	require.NoError(t, w.Write(rec))
+	assert.NoError(t, w.Close())
+
+	r, err := ipc.NewReader(&buf)
+	require.NoError(t, err)
+	defer r.Release()
+
+	assert.True(t, r.Next())
+	assert.Zero(t, r.Record().NumRows())
+	assert.True(t, arrow.TypeEqual(dt, r.Record().Column(0).DataType()))
 }

--- a/go/arrow/ipc/writer.go
+++ b/go/arrow/ipc/writer.go
@@ -649,44 +649,7 @@ func (w *recordEncoder) visit(p *Payload, arr arrow.Array) error {
 			}
 		}
 		w.depth++
-	case *arrow.MapType:
-		arr := arr.(*array.Map)
-		voffsets, err := w.getZeroBasedValueOffsets(arr)
-		if err != nil {
-			return fmt.Errorf("could not retrieve zero-based value offsets for array %T: %w", arr, err)
-		}
-		p.body = append(p.body, voffsets)
-
-		w.depth--
-		var (
-			values        = arr.ListValues()
-			mustRelease   = false
-			values_offset int64
-			values_length int64
-		)
-		defer func() {
-			if mustRelease {
-				values.Release()
-			}
-		}()
-
-		if voffsets != nil {
-			values_offset = int64(arr.Offsets()[0])
-			values_length = int64(arr.Offsets()[arr.Len()]) - values_offset
-		}
-
-		if len(arr.Offsets()) != 0 || values_length < int64(values.Len()) {
-			// must also slice the values
-			values = array.NewSlice(values, values_offset, values_length)
-			mustRelease = true
-		}
-		err = w.visit(p, values)
-
-		if err != nil {
-			return fmt.Errorf("could not visit list element for array %T: %w", arr, err)
-		}
-		w.depth++
-	case *arrow.ListType, *arrow.LargeListType:
+	case *arrow.MapType, *arrow.ListType, *arrow.LargeListType:
 		arr := arr.(array.ListLike)
 		voffsets, err := w.getZeroBasedValueOffsets(arr)
 		if err != nil {

--- a/go/arrow/ipc/writer.go
+++ b/go/arrow/ipc/writer.go
@@ -665,7 +665,7 @@ func (w *recordEncoder) visit(p *Payload, arr arrow.Array) error {
 			values        = arr.ListValues()
 			mustRelease   = false
 			values_offset int64
-			values_length int64
+			values_end    int64
 		)
 		defer func() {
 			if mustRelease {
@@ -675,13 +675,12 @@ func (w *recordEncoder) visit(p *Payload, arr arrow.Array) error {
 
 		if arr.Len() > 0 && voffsets != nil {
 			values_offset, _ = arr.ValueOffsets(0)
-			_, values_length = arr.ValueOffsets(arr.Len() - 1)
-			values_length -= values_offset
+			_, values_end = arr.ValueOffsets(arr.Len() - 1)
 		}
 
-		if arr.Len() != 0 || values_length < int64(values.Len()) {
+		if arr.Len() != 0 || values_end < int64(values.Len()) {
 			// must also slice the values
-			values = array.NewSlice(values, values_offset, values_length)
+			values = array.NewSlice(values, values_offset, values_end)
 			mustRelease = true
 		}
 		err = w.visit(p, values)


### PR DESCRIPTION
As discussed on #14883 and the mailing list, cherry-picking fixes back to v10 maintenance branch for unofficial source release for Open Telemetry to utilize until the v11 release in mid-january.

CC @lquerel 