### PR TITLE
MINOR: [Go][CI][Benchmarking] Add timeout to go benchmarks

### DIFF
--- a/ci/scripts/go_bench.sh
+++ b/ci/scripts/go_bench.sh
@@ -41,7 +41,10 @@ pushd ${source_dir}
 go test -bench=. -benchmem -run=^$ ./... | tee bench_stat.dat
 
 if verlte "1.18" "${ver#go}"; then
-    go test -bench=. -benchmem -run=^$ ./arrow/compute | tee bench_stat_compute.dat
+    # lots of benchmarks, they can take a while
+    # the timeout is for *ALL* benchmarks together,
+    # not per benchmark
+    go test -timeout 20m -bench=. -benchmem -run=^$ ./arrow/compute | tee bench_stat_compute.dat
 fi
 
 popd


### PR DESCRIPTION
As mentioned by @kou here: https://github.com/apache/arrow/pull/14952#issuecomment-1352401925 it looks like we crossed a threshold on the Go benchmarks and have added enough benchmarks for the Compute module that they are collectively taking more than 10m to run (which is the default timeout). So this updates the timeout used for running the benchmarks to 20 minutes.

CC @austin3dickey 