### PR TITLE
GH-14973: [JS] Fixes bug where serialised data types are not JSON valid when using tableFromIPC().toString()

### DIFF
--- a/js/src/table.ts
+++ b/js/src/table.ts
@@ -245,7 +245,7 @@ export class Table<T extends TypeMap = any> {
      * @returns A string representation of the Table rows.
      */
     public toString() {
-        return `[\n  ${this.toArray().join(',\n  ')}\n]`;
+        return JSON.stringify(this.toArray());
     }
 
     /**


### PR DESCRIPTION
This PR fixes the bug reported by #14973 leveraging the native JavaScript `JSON.stringify()` function to serialize an Arrow Table into a valid JSON string. The use of this native function guarantees that all data types will be serialised into valid ones. This allows the reverse operation of deserialising the same string back into a JavaScript object through the use of `JSON.parse()`.
* Closes: #14973