### PR TITLE
MINOR: [Go][CI][Benchmarking] Debian Benchmarking uses incorrect Go version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -82,6 +82,13 @@ jobs:
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         continue-on-error: true
         run: archery docker push debian-go
+      - name: Install Go ${{ matrix.go }} for Benchmarks
+        if: success() && github.event_name == 'push' && github.repository == 'apache/arrow'
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+          cache: true
+          cache-dependency-path: go/go.sum
       - name: Run Benchmarks
         if: success() && github.event_name == 'push' && github.repository == 'apache/arrow'
         env:

--- a/ci/scripts/go_bench.sh
+++ b/ci/scripts/go_bench.sh
@@ -38,14 +38,10 @@ source_dir=${1}/go
 export PARQUET_TEST_DATA=${1}/cpp/submodules/parquet-testing/data
 pushd ${source_dir}
 
-go test -bench=. -benchmem -run=^$ ./... | tee bench_stat.dat
-
-if verlte "1.18" "${ver#go}"; then
-    # lots of benchmarks, they can take a while
-    # the timeout is for *ALL* benchmarks together,
-    # not per benchmark
-    go test -timeout 20m -bench=. -benchmem -run=^$ ./arrow/compute | tee bench_stat_compute.dat
-fi
+# lots of benchmarks, they can take a while
+# the timeout is for *ALL* benchmarks together,
+# not per benchmark
+go test -bench=. -benchmem -timeout 20m -run=^$ ./... | tee bench_stat.dat
 
 popd
 


### PR DESCRIPTION
The Go 1.17 build/run for Debian uses the docker image to run the tests, which will have the correct Go version, but uses the Runner's version of Go for running the benchmarking. As a result, the Go1.17 run wasn't using Go1.17 for the benchmark runs. 

In addition because the compute package is no longer an entirely separate module, it's not necessary to explicitly have the `go_bench.sh` script separately invoke the compute package's benchmarks. They will be included with `./...` when run with Go >= 1.18