### PR TITLE
GH-33600: [Go][Parquet] Panic in bitmap writer

### DIFF
--- a/go/parquet/file/column_writer_types.gen.go
+++ b/go/parquet/file/column_writer_types.gen.go
@@ -136,9 +136,9 @@ func (w *Int32ColumnChunkWriter) WriteBatchSpaced(values []int32, defLevels, rep
 		}
 
 		if w.bitsBuffer != nil {
-			w.writeValuesSpaced(vals, batch, w.bitsBuffer.Bytes(), 0)
+			w.writeValuesSpaced(vals, info.batchNum, batch, w.bitsBuffer.Bytes(), 0)
 		} else {
-			w.writeValuesSpaced(vals, batch, validBits, validBitsOffset+valueOffset)
+			w.writeValuesSpaced(vals, info.batchNum, batch, validBits, validBitsOffset+valueOffset)
 		}
 		w.commitWriteAndCheckPageLimit(batch, info.numSpaced())
 		valueOffset += info.numSpaced()
@@ -154,8 +154,8 @@ func (w *Int32ColumnChunkWriter) writeValues(values []int32, numNulls int64) {
 	}
 }
 
-func (w *Int32ColumnChunkWriter) writeValuesSpaced(spacedValues []int32, numValues int64, validBits []byte, validBitsOffset int64) {
-	if len(spacedValues) != int(numValues) {
+func (w *Int32ColumnChunkWriter) writeValuesSpaced(spacedValues []int32, numRead, numValues int64, validBits []byte, validBitsOffset int64) {
+	if len(spacedValues) != int(numRead) {
 		w.currentEncoder.(encoding.Int32Encoder).PutSpaced(spacedValues, validBits, validBitsOffset)
 	} else {
 		w.currentEncoder.(encoding.Int32Encoder).Put(spacedValues)
@@ -294,9 +294,9 @@ func (w *Int64ColumnChunkWriter) WriteBatchSpaced(values []int64, defLevels, rep
 		}
 
 		if w.bitsBuffer != nil {
-			w.writeValuesSpaced(vals, batch, w.bitsBuffer.Bytes(), 0)
+			w.writeValuesSpaced(vals, info.batchNum, batch, w.bitsBuffer.Bytes(), 0)
 		} else {
-			w.writeValuesSpaced(vals, batch, validBits, validBitsOffset+valueOffset)
+			w.writeValuesSpaced(vals, info.batchNum, batch, validBits, validBitsOffset+valueOffset)
 		}
 		w.commitWriteAndCheckPageLimit(batch, info.numSpaced())
 		valueOffset += info.numSpaced()
@@ -312,8 +312,8 @@ func (w *Int64ColumnChunkWriter) writeValues(values []int64, numNulls int64) {
 	}
 }
 
-func (w *Int64ColumnChunkWriter) writeValuesSpaced(spacedValues []int64, numValues int64, validBits []byte, validBitsOffset int64) {
-	if len(spacedValues) != int(numValues) {
+func (w *Int64ColumnChunkWriter) writeValuesSpaced(spacedValues []int64, numRead, numValues int64, validBits []byte, validBitsOffset int64) {
+	if len(spacedValues) != int(numRead) {
 		w.currentEncoder.(encoding.Int64Encoder).PutSpaced(spacedValues, validBits, validBitsOffset)
 	} else {
 		w.currentEncoder.(encoding.Int64Encoder).Put(spacedValues)
@@ -452,9 +452,9 @@ func (w *Int96ColumnChunkWriter) WriteBatchSpaced(values []parquet.Int96, defLev
 		}
 
 		if w.bitsBuffer != nil {
-			w.writeValuesSpaced(vals, batch, w.bitsBuffer.Bytes(), 0)
+			w.writeValuesSpaced(vals, info.batchNum, batch, w.bitsBuffer.Bytes(), 0)
 		} else {
-			w.writeValuesSpaced(vals, batch, validBits, validBitsOffset+valueOffset)
+			w.writeValuesSpaced(vals, info.batchNum, batch, validBits, validBitsOffset+valueOffset)
 		}
 		w.commitWriteAndCheckPageLimit(batch, info.numSpaced())
 		valueOffset += info.numSpaced()
@@ -470,8 +470,8 @@ func (w *Int96ColumnChunkWriter) writeValues(values []parquet.Int96, numNulls in
 	}
 }
 
-func (w *Int96ColumnChunkWriter) writeValuesSpaced(spacedValues []parquet.Int96, numValues int64, validBits []byte, validBitsOffset int64) {
-	if len(spacedValues) != int(numValues) {
+func (w *Int96ColumnChunkWriter) writeValuesSpaced(spacedValues []parquet.Int96, numRead, numValues int64, validBits []byte, validBitsOffset int64) {
+	if len(spacedValues) != int(numRead) {
 		w.currentEncoder.(encoding.Int96Encoder).PutSpaced(spacedValues, validBits, validBitsOffset)
 	} else {
 		w.currentEncoder.(encoding.Int96Encoder).Put(spacedValues)
@@ -610,9 +610,9 @@ func (w *Float32ColumnChunkWriter) WriteBatchSpaced(values []float32, defLevels,
 		}
 
 		if w.bitsBuffer != nil {
-			w.writeValuesSpaced(vals, batch, w.bitsBuffer.Bytes(), 0)
+			w.writeValuesSpaced(vals, info.batchNum, batch, w.bitsBuffer.Bytes(), 0)
 		} else {
-			w.writeValuesSpaced(vals, batch, validBits, validBitsOffset+valueOffset)
+			w.writeValuesSpaced(vals, info.batchNum, batch, validBits, validBitsOffset+valueOffset)
 		}
 		w.commitWriteAndCheckPageLimit(batch, info.numSpaced())
 		valueOffset += info.numSpaced()
@@ -628,8 +628,8 @@ func (w *Float32ColumnChunkWriter) writeValues(values []float32, numNulls int64)
 	}
 }
 
-func (w *Float32ColumnChunkWriter) writeValuesSpaced(spacedValues []float32, numValues int64, validBits []byte, validBitsOffset int64) {
-	if len(spacedValues) != int(numValues) {
+func (w *Float32ColumnChunkWriter) writeValuesSpaced(spacedValues []float32, numRead, numValues int64, validBits []byte, validBitsOffset int64) {
+	if len(spacedValues) != int(numRead) {
 		w.currentEncoder.(encoding.Float32Encoder).PutSpaced(spacedValues, validBits, validBitsOffset)
 	} else {
 		w.currentEncoder.(encoding.Float32Encoder).Put(spacedValues)
@@ -768,9 +768,9 @@ func (w *Float64ColumnChunkWriter) WriteBatchSpaced(values []float64, defLevels,
 		}
 
 		if w.bitsBuffer != nil {
-			w.writeValuesSpaced(vals, batch, w.bitsBuffer.Bytes(), 0)
+			w.writeValuesSpaced(vals, info.batchNum, batch, w.bitsBuffer.Bytes(), 0)
 		} else {
-			w.writeValuesSpaced(vals, batch, validBits, validBitsOffset+valueOffset)
+			w.writeValuesSpaced(vals, info.batchNum, batch, validBits, validBitsOffset+valueOffset)
 		}
 		w.commitWriteAndCheckPageLimit(batch, info.numSpaced())
 		valueOffset += info.numSpaced()
@@ -786,8 +786,8 @@ func (w *Float64ColumnChunkWriter) writeValues(values []float64, numNulls int64)
 	}
 }
 
-func (w *Float64ColumnChunkWriter) writeValuesSpaced(spacedValues []float64, numValues int64, validBits []byte, validBitsOffset int64) {
-	if len(spacedValues) != int(numValues) {
+func (w *Float64ColumnChunkWriter) writeValuesSpaced(spacedValues []float64, numRead, numValues int64, validBits []byte, validBitsOffset int64) {
+	if len(spacedValues) != int(numRead) {
 		w.currentEncoder.(encoding.Float64Encoder).PutSpaced(spacedValues, validBits, validBitsOffset)
 	} else {
 		w.currentEncoder.(encoding.Float64Encoder).Put(spacedValues)
@@ -929,9 +929,9 @@ func (w *BooleanColumnChunkWriter) WriteBatchSpaced(values []bool, defLevels, re
 		}
 
 		if w.bitsBuffer != nil {
-			w.writeValuesSpaced(vals, batch, w.bitsBuffer.Bytes(), 0)
+			w.writeValuesSpaced(vals, info.batchNum, batch, w.bitsBuffer.Bytes(), 0)
 		} else {
-			w.writeValuesSpaced(vals, batch, validBits, validBitsOffset+valueOffset)
+			w.writeValuesSpaced(vals, info.batchNum, batch, validBits, validBitsOffset+valueOffset)
 		}
 		w.commitWriteAndCheckPageLimit(batch, info.numSpaced())
 		valueOffset += info.numSpaced()
@@ -947,8 +947,8 @@ func (w *BooleanColumnChunkWriter) writeValues(values []bool, numNulls int64) {
 	}
 }
 
-func (w *BooleanColumnChunkWriter) writeValuesSpaced(spacedValues []bool, numValues int64, validBits []byte, validBitsOffset int64) {
-	if len(spacedValues) != int(numValues) {
+func (w *BooleanColumnChunkWriter) writeValuesSpaced(spacedValues []bool, numRead, numValues int64, validBits []byte, validBitsOffset int64) {
+	if len(spacedValues) != int(numRead) {
 		w.currentEncoder.(encoding.BooleanEncoder).PutSpaced(spacedValues, validBits, validBitsOffset)
 	} else {
 		w.currentEncoder.(encoding.BooleanEncoder).Put(spacedValues)
@@ -1087,9 +1087,9 @@ func (w *ByteArrayColumnChunkWriter) WriteBatchSpaced(values []parquet.ByteArray
 		}
 
 		if w.bitsBuffer != nil {
-			w.writeValuesSpaced(vals, batch, w.bitsBuffer.Bytes(), 0)
+			w.writeValuesSpaced(vals, info.batchNum, batch, w.bitsBuffer.Bytes(), 0)
 		} else {
-			w.writeValuesSpaced(vals, batch, validBits, validBitsOffset+valueOffset)
+			w.writeValuesSpaced(vals, info.batchNum, batch, validBits, validBitsOffset+valueOffset)
 		}
 		w.commitWriteAndCheckPageLimit(batch, info.numSpaced())
 		valueOffset += info.numSpaced()
@@ -1105,8 +1105,8 @@ func (w *ByteArrayColumnChunkWriter) writeValues(values []parquet.ByteArray, num
 	}
 }
 
-func (w *ByteArrayColumnChunkWriter) writeValuesSpaced(spacedValues []parquet.ByteArray, numValues int64, validBits []byte, validBitsOffset int64) {
-	if len(spacedValues) != int(numValues) {
+func (w *ByteArrayColumnChunkWriter) writeValuesSpaced(spacedValues []parquet.ByteArray, numRead, numValues int64, validBits []byte, validBitsOffset int64) {
+	if len(spacedValues) != int(numRead) {
 		w.currentEncoder.(encoding.ByteArrayEncoder).PutSpaced(spacedValues, validBits, validBitsOffset)
 	} else {
 		w.currentEncoder.(encoding.ByteArrayEncoder).Put(spacedValues)
@@ -1245,9 +1245,9 @@ func (w *FixedLenByteArrayColumnChunkWriter) WriteBatchSpaced(values []parquet.F
 		}
 
 		if w.bitsBuffer != nil {
-			w.writeValuesSpaced(vals, batch, w.bitsBuffer.Bytes(), 0)
+			w.writeValuesSpaced(vals, info.batchNum, batch, w.bitsBuffer.Bytes(), 0)
 		} else {
-			w.writeValuesSpaced(vals, batch, validBits, validBitsOffset+valueOffset)
+			w.writeValuesSpaced(vals, info.batchNum, batch, validBits, validBitsOffset+valueOffset)
 		}
 		w.commitWriteAndCheckPageLimit(batch, info.numSpaced())
 		valueOffset += info.numSpaced()
@@ -1263,8 +1263,8 @@ func (w *FixedLenByteArrayColumnChunkWriter) writeValues(values []parquet.FixedL
 	}
 }
 
-func (w *FixedLenByteArrayColumnChunkWriter) writeValuesSpaced(spacedValues []parquet.FixedLenByteArray, numValues int64, validBits []byte, validBitsOffset int64) {
-	if len(spacedValues) != int(numValues) {
+func (w *FixedLenByteArrayColumnChunkWriter) writeValuesSpaced(spacedValues []parquet.FixedLenByteArray, numRead, numValues int64, validBits []byte, validBitsOffset int64) {
+	if len(spacedValues) != int(numRead) {
 		w.currentEncoder.(encoding.FixedLenByteArrayEncoder).PutSpaced(spacedValues, validBits, validBitsOffset)
 	} else {
 		w.currentEncoder.(encoding.FixedLenByteArrayEncoder).Put(spacedValues)

--- a/go/parquet/file/column_writer_types.gen.go
+++ b/go/parquet/file/column_writer_types.gen.go
@@ -136,9 +136,9 @@ func (w *Int32ColumnChunkWriter) WriteBatchSpaced(values []int32, defLevels, rep
 		}
 
 		if w.bitsBuffer != nil {
-			w.writeValuesSpaced(vals, info.batchNum, w.bitsBuffer.Bytes(), 0)
+			w.writeValuesSpaced(vals, batch, w.bitsBuffer.Bytes(), 0)
 		} else {
-			w.writeValuesSpaced(vals, info.batchNum, validBits, validBitsOffset+valueOffset)
+			w.writeValuesSpaced(vals, batch, validBits, validBitsOffset+valueOffset)
 		}
 		w.commitWriteAndCheckPageLimit(batch, info.numSpaced())
 		valueOffset += info.numSpaced()
@@ -294,9 +294,9 @@ func (w *Int64ColumnChunkWriter) WriteBatchSpaced(values []int64, defLevels, rep
 		}
 
 		if w.bitsBuffer != nil {
-			w.writeValuesSpaced(vals, info.batchNum, w.bitsBuffer.Bytes(), 0)
+			w.writeValuesSpaced(vals, batch, w.bitsBuffer.Bytes(), 0)
 		} else {
-			w.writeValuesSpaced(vals, info.batchNum, validBits, validBitsOffset+valueOffset)
+			w.writeValuesSpaced(vals, batch, validBits, validBitsOffset+valueOffset)
 		}
 		w.commitWriteAndCheckPageLimit(batch, info.numSpaced())
 		valueOffset += info.numSpaced()
@@ -452,9 +452,9 @@ func (w *Int96ColumnChunkWriter) WriteBatchSpaced(values []parquet.Int96, defLev
 		}
 
 		if w.bitsBuffer != nil {
-			w.writeValuesSpaced(vals, info.batchNum, w.bitsBuffer.Bytes(), 0)
+			w.writeValuesSpaced(vals, batch, w.bitsBuffer.Bytes(), 0)
 		} else {
-			w.writeValuesSpaced(vals, info.batchNum, validBits, validBitsOffset+valueOffset)
+			w.writeValuesSpaced(vals, batch, validBits, validBitsOffset+valueOffset)
 		}
 		w.commitWriteAndCheckPageLimit(batch, info.numSpaced())
 		valueOffset += info.numSpaced()
@@ -610,9 +610,9 @@ func (w *Float32ColumnChunkWriter) WriteBatchSpaced(values []float32, defLevels,
 		}
 
 		if w.bitsBuffer != nil {
-			w.writeValuesSpaced(vals, info.batchNum, w.bitsBuffer.Bytes(), 0)
+			w.writeValuesSpaced(vals, batch, w.bitsBuffer.Bytes(), 0)
 		} else {
-			w.writeValuesSpaced(vals, info.batchNum, validBits, validBitsOffset+valueOffset)
+			w.writeValuesSpaced(vals, batch, validBits, validBitsOffset+valueOffset)
 		}
 		w.commitWriteAndCheckPageLimit(batch, info.numSpaced())
 		valueOffset += info.numSpaced()
@@ -768,9 +768,9 @@ func (w *Float64ColumnChunkWriter) WriteBatchSpaced(values []float64, defLevels,
 		}
 
 		if w.bitsBuffer != nil {
-			w.writeValuesSpaced(vals, info.batchNum, w.bitsBuffer.Bytes(), 0)
+			w.writeValuesSpaced(vals, batch, w.bitsBuffer.Bytes(), 0)
 		} else {
-			w.writeValuesSpaced(vals, info.batchNum, validBits, validBitsOffset+valueOffset)
+			w.writeValuesSpaced(vals, batch, validBits, validBitsOffset+valueOffset)
 		}
 		w.commitWriteAndCheckPageLimit(batch, info.numSpaced())
 		valueOffset += info.numSpaced()
@@ -929,9 +929,9 @@ func (w *BooleanColumnChunkWriter) WriteBatchSpaced(values []bool, defLevels, re
 		}
 
 		if w.bitsBuffer != nil {
-			w.writeValuesSpaced(vals, info.batchNum, w.bitsBuffer.Bytes(), 0)
+			w.writeValuesSpaced(vals, batch, w.bitsBuffer.Bytes(), 0)
 		} else {
-			w.writeValuesSpaced(vals, info.batchNum, validBits, validBitsOffset+valueOffset)
+			w.writeValuesSpaced(vals, batch, validBits, validBitsOffset+valueOffset)
 		}
 		w.commitWriteAndCheckPageLimit(batch, info.numSpaced())
 		valueOffset += info.numSpaced()
@@ -1087,9 +1087,9 @@ func (w *ByteArrayColumnChunkWriter) WriteBatchSpaced(values []parquet.ByteArray
 		}
 
 		if w.bitsBuffer != nil {
-			w.writeValuesSpaced(vals, info.batchNum, w.bitsBuffer.Bytes(), 0)
+			w.writeValuesSpaced(vals, batch, w.bitsBuffer.Bytes(), 0)
 		} else {
-			w.writeValuesSpaced(vals, info.batchNum, validBits, validBitsOffset+valueOffset)
+			w.writeValuesSpaced(vals, batch, validBits, validBitsOffset+valueOffset)
 		}
 		w.commitWriteAndCheckPageLimit(batch, info.numSpaced())
 		valueOffset += info.numSpaced()
@@ -1245,9 +1245,9 @@ func (w *FixedLenByteArrayColumnChunkWriter) WriteBatchSpaced(values []parquet.F
 		}
 
 		if w.bitsBuffer != nil {
-			w.writeValuesSpaced(vals, info.batchNum, w.bitsBuffer.Bytes(), 0)
+			w.writeValuesSpaced(vals, batch, w.bitsBuffer.Bytes(), 0)
 		} else {
-			w.writeValuesSpaced(vals, info.batchNum, validBits, validBitsOffset+valueOffset)
+			w.writeValuesSpaced(vals, batch, validBits, validBitsOffset+valueOffset)
 		}
 		w.commitWriteAndCheckPageLimit(batch, info.numSpaced())
 		valueOffset += info.numSpaced()

--- a/go/parquet/file/column_writer_types.gen.go.tmpl
+++ b/go/parquet/file/column_writer_types.gen.go.tmpl
@@ -141,9 +141,9 @@ func (w *{{.Name}}ColumnChunkWriter) WriteBatchSpaced(values []{{.name}}, defLev
     }
 
     if w.bitsBuffer != nil {
-      w.writeValuesSpaced(vals, info.batchNum, w.bitsBuffer.Bytes(), 0)
+      w.writeValuesSpaced(vals, batch, w.bitsBuffer.Bytes(), 0)
     } else {
-      w.writeValuesSpaced(vals, info.batchNum, validBits, validBitsOffset+valueOffset)
+      w.writeValuesSpaced(vals, batch, validBits, validBitsOffset+valueOffset)
     }
     w.commitWriteAndCheckPageLimit(batch, info.numSpaced())
     valueOffset += info.numSpaced()

--- a/go/parquet/file/column_writer_types.gen.go.tmpl
+++ b/go/parquet/file/column_writer_types.gen.go.tmpl
@@ -141,9 +141,9 @@ func (w *{{.Name}}ColumnChunkWriter) WriteBatchSpaced(values []{{.name}}, defLev
     }
 
     if w.bitsBuffer != nil {
-      w.writeValuesSpaced(vals, batch, w.bitsBuffer.Bytes(), 0)
+      w.writeValuesSpaced(vals, info.batchNum, batch, w.bitsBuffer.Bytes(), 0)
     } else {
-      w.writeValuesSpaced(vals, batch, validBits, validBitsOffset+valueOffset)
+      w.writeValuesSpaced(vals, info.batchNum, batch, validBits, validBitsOffset+valueOffset)
     }
     w.commitWriteAndCheckPageLimit(batch, info.numSpaced())
     valueOffset += info.numSpaced()
@@ -160,8 +160,8 @@ func (w *{{.Name}}ColumnChunkWriter) writeValues(values []{{.name}}, numNulls in
   }
 }
 
-func (w *{{.Name}}ColumnChunkWriter) writeValuesSpaced(spacedValues []{{.name}}, numValues int64, validBits []byte, validBitsOffset int64) {
-  if len(spacedValues) != int(numValues) {
+func (w *{{.Name}}ColumnChunkWriter) writeValuesSpaced(spacedValues []{{.name}}, numRead, numValues int64, validBits []byte, validBitsOffset int64) {
+  if len(spacedValues) != int(numRead) {
     w.currentEncoder.(encoding.{{.Name}}Encoder).PutSpaced(spacedValues, validBits, validBitsOffset)
   } else {
     w.currentEncoder.(encoding.{{.Name}}Encoder).Put(spacedValues)

--- a/go/parquet/pqarrow/column_readers.go
+++ b/go/parquet/pqarrow/column_readers.go
@@ -393,7 +393,7 @@ func (lr *listReader) BuildArray(lenBound int64) (*arrow.Chunked, error) {
 	// definition levels when building out the bitmap. So the upper bound
 	// to make sure we have the space for is the worst case scenario,
 	// the upper bound is the value of the last offset + the nullcount
-	arr, err := lr.itemRdr.BuildArray(int64(offsetData[int(validityIO.Read)]) + validityIO.NullCount)
+	arr, err := lr.itemRdr.BuildArray(int64(offsetData[int(validityIO.Read)]) + validityIO.NullCount + 1)
 	if err != nil {
 		return nil, err
 	}

--- a/go/parquet/pqarrow/column_readers.go
+++ b/go/parquet/pqarrow/column_readers.go
@@ -286,7 +286,7 @@ func (sr *structReader) BuildArray(lenBound int64) (*arrow.Chunked, error) {
 	childArrData := make([]arrow.ArrayData, 0)
 	// gather children arrays and def levels
 	for _, child := range sr.children {
-		field, err := child.BuildArray(validityIO.Read)
+		field, err := child.BuildArray(validityIO.Read + validityIO.NullCount + 1)
 		if err != nil {
 			return nil, err
 		}

--- a/go/parquet/pqarrow/column_readers.go
+++ b/go/parquet/pqarrow/column_readers.go
@@ -286,7 +286,7 @@ func (sr *structReader) BuildArray(lenBound int64) (*arrow.Chunked, error) {
 	childArrData := make([]arrow.ArrayData, 0)
 	// gather children arrays and def levels
 	for _, child := range sr.children {
-		field, err := child.BuildArray(validityIO.Read + validityIO.NullCount + 1)
+		field, err := child.BuildArray(lenBound)
 		if err != nil {
 			return nil, err
 		}
@@ -393,7 +393,7 @@ func (lr *listReader) BuildArray(lenBound int64) (*arrow.Chunked, error) {
 	// definition levels when building out the bitmap. So the upper bound
 	// to make sure we have the space for is the worst case scenario,
 	// the upper bound is the value of the last offset + the nullcount
-	arr, err := lr.itemRdr.BuildArray(int64(offsetData[int(validityIO.Read)]) + validityIO.NullCount + 1)
+	arr, err := lr.itemRdr.BuildArray(int64(offsetData[int(validityIO.Read)]) + validityIO.NullCount)
 	if err != nil {
 		return nil, err
 	}

--- a/go/parquet/pqarrow/encode_arrow_test.go
+++ b/go/parquet/pqarrow/encode_arrow_test.go
@@ -1324,7 +1324,7 @@ func (ps *ParquetIOTestSuite) TestNullableListOfStruct() {
 	ps.roundTripTable(expected, false)
 }
 
-func (ps *ParquetIOTestSuite) TestStructWithListOf8Structs() {
+func (ps *ParquetIOTestSuite) TestStructWithListOfStructs() {
 	bldr := array.NewStructBuilder(memory.DefaultAllocator, arrow.StructOf(
 		arrow.Field{
 			Name: "l",
@@ -1345,6 +1345,53 @@ func (ps *ParquetIOTestSuite) TestStructWithListOf8Structs() {
 	for i := 0; i < 8; i++ {
 		stBldr.Append(true)
 		aBldr.Append(strconv.Itoa(i))
+	}
+
+	arr := bldr.NewArray()
+	defer arr.Release()
+
+	field := arrow.Field{Name: "x", Type: arr.DataType(), Nullable: true}
+	expected := array.NewTable(arrow.NewSchema([]arrow.Field{field}, nil),
+		[]arrow.Column{*arrow.NewColumn(field, arrow.NewChunked(field.Type, []arrow.Array{arr}))}, -1)
+	defer expected.Release()
+
+	ps.roundTripTable(expected, false)
+}
+
+func (ps *ParquetIOTestSuite) TestStructWithListOfNestedStructs() {
+	bldr := array.NewStructBuilder(memory.DefaultAllocator, arrow.StructOf(
+		arrow.Field{
+			Nullable: true,
+			Name:     "l",
+			Type: arrow.ListOf(arrow.StructOf(
+				arrow.Field{
+					Nullable: true,
+					Name:     "a",
+					Type: arrow.StructOf(
+						arrow.Field{
+							Nullable: true,
+							Name:     "b",
+							Type:     arrow.BinaryTypes.String,
+						},
+					),
+				},
+			)),
+		},
+	))
+	defer bldr.Release()
+
+	lBldr := bldr.FieldBuilder(0).(*array.ListBuilder)
+	stBldr := lBldr.ValueBuilder().(*array.StructBuilder)
+	aBldr := stBldr.FieldBuilder(0).(*array.StructBuilder)
+	bBldr := aBldr.FieldBuilder(0).(*array.StringBuilder)
+
+	bldr.AppendNull()
+	bldr.Append(true)
+	lBldr.Append(true)
+	for i := 0; i < 8; i++ {
+		stBldr.Append(true)
+		aBldr.Append(true)
+		bBldr.Append(strconv.Itoa(i))
 	}
 
 	arr := bldr.NewArray()

--- a/go/parquet/pqarrow/encode_arrow_test.go
+++ b/go/parquet/pqarrow/encode_arrow_test.go
@@ -1324,6 +1324,40 @@ func (ps *ParquetIOTestSuite) TestNullableListOfStruct() {
 	ps.roundTripTable(expected, false)
 }
 
+func (ps *ParquetIOTestSuite) TestStructWithListOf8Structs() {
+	bldr := array.NewStructBuilder(memory.DefaultAllocator, arrow.StructOf(
+		arrow.Field{
+			Name: "l",
+			Type: arrow.ListOf(arrow.StructOf(
+				arrow.Field{Name: "a", Type: arrow.BinaryTypes.String},
+			)),
+		},
+	))
+	defer bldr.Release()
+
+	lBldr := bldr.FieldBuilder(0).(*array.ListBuilder)
+	stBldr := lBldr.ValueBuilder().(*array.StructBuilder)
+	aBldr := stBldr.FieldBuilder(0).(*array.StringBuilder)
+
+	bldr.AppendNull()
+	bldr.Append(true)
+	lBldr.Append(true)
+	for i := 0; i < 8; i++ {
+		stBldr.Append(true)
+		aBldr.Append(strconv.Itoa(i))
+	}
+
+	arr := bldr.NewArray()
+	defer arr.Release()
+
+	field := arrow.Field{Name: "x", Type: arr.DataType(), Nullable: true}
+	expected := array.NewTable(arrow.NewSchema([]arrow.Field{field}, nil),
+		[]arrow.Column{*arrow.NewColumn(field, arrow.NewChunked(field.Type, []arrow.Array{arr}))}, -1)
+	defer expected.Release()
+
+	ps.roundTripTable(expected, false)
+}
+
 func TestParquetArrowIO(t *testing.T) {
 	suite.Run(t, new(ParquetIOTestSuite))
 }

--- a/go/parquet/pqarrow/encode_arrow_test.go
+++ b/go/parquet/pqarrow/encode_arrow_test.go
@@ -1324,40 +1324,6 @@ func (ps *ParquetIOTestSuite) TestNullableListOfStruct() {
 	ps.roundTripTable(expected, false)
 }
 
-func (ps *ParquetIOTestSuite) TestStructWithListOfStructs() {
-	bldr := array.NewStructBuilder(memory.DefaultAllocator, arrow.StructOf(
-		arrow.Field{
-			Name: "l",
-			Type: arrow.ListOf(arrow.StructOf(
-				arrow.Field{Name: "a", Type: arrow.BinaryTypes.String},
-			)),
-		},
-	))
-	defer bldr.Release()
-
-	lBldr := bldr.FieldBuilder(0).(*array.ListBuilder)
-	stBldr := lBldr.ValueBuilder().(*array.StructBuilder)
-	aBldr := stBldr.FieldBuilder(0).(*array.StringBuilder)
-
-	bldr.AppendNull()
-	bldr.Append(true)
-	lBldr.Append(true)
-	for i := 0; i < 8; i++ {
-		stBldr.Append(true)
-		aBldr.Append(strconv.Itoa(i))
-	}
-
-	arr := bldr.NewArray()
-	defer arr.Release()
-
-	field := arrow.Field{Name: "x", Type: arr.DataType(), Nullable: true}
-	expected := array.NewTable(arrow.NewSchema([]arrow.Field{field}, nil),
-		[]arrow.Column{*arrow.NewColumn(field, arrow.NewChunked(field.Type, []arrow.Array{arr}))}, -1)
-	defer expected.Release()
-
-	ps.roundTripTable(expected, false)
-}
-
 func (ps *ParquetIOTestSuite) TestStructWithListOfNestedStructs() {
 	bldr := array.NewStructBuilder(memory.DefaultAllocator, arrow.StructOf(
 		arrow.Field{


### PR DESCRIPTION
There is still a panic in go's bitmap writer, but specifically for when the list contains a multiple of 8 structs (the outer struct starting with null is also required).

Not sure where the off by one actually is, I somewhat blindly based this PR on https://github.com/apache/arrow/pull/14183
* Closes: #33600