### PR TITLE
GH-15007: [CI][RPM] Ignore import failed key

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow-release/Rakefile
+++ b/dev/tasks/linux-packages/apache-arrow-release/Rakefile
@@ -47,9 +47,12 @@ class ApacheArrowReleasePackageTask < PackageTask
       File.open(keys_path, "w") do |keys_file|
         is_ed25519_key = false
         deny_lists = [
-          # "rpmkeys --import" reports error for this key.
+          # "rpmkeys --import" reports error for these keys.
           # It seems that a subkey of this key may be related. (Is SHA1 bad?)
           "8CAAD602",
+          # https://github.com/apache/arrow/issues/15007
+          # It seems that a subkey of this key may be related.
+          "B90EB64A3AF15545EC8A7B8803F0D5EA3790810C",
         ]
         is_denyed_key = false
         keys.each_line do |line|
@@ -60,6 +63,12 @@ class ApacheArrowReleasePackageTask < PackageTask
           when /\Apub\s+[^\/]+\/([\h]+)\s/
             short_finger_print = $1
             if deny_lists.include?(short_finger_print)
+              is_denyed_key = true
+              next
+            end
+          when /\A\s+([\h]+)$/
+            long_finger_print = $1
+            if deny_lists.include?(long_finger_print)
               is_denyed_key = true
               next
             end


### PR DESCRIPTION
I don't know why but the following key can't be imported by RPM ("rpmkeys --import"):

almalinux-8-amd64:

https://github.com/ursacomputing/crossbow/actions/runs/3711543280/jobs/6292083831#step:9:578

    Importing GPG key 0x3790810C:
     Userid     : "Raphael Jaen Taylor-Davies <r.taylordavies@googlemail.com>"
     Fingerprint: B90E B64A 3AF1 5545 EC8A 7B88 03F0 D5EA 3790 810C
     From       : /etc/pki/rpm-gpg/RPM-GPG-KEY-Apache-Arrow

It may be related to
https://bugzilla.redhat.com/show_bug.cgi?id=1941098 but I don't know the real problem...
* Closes: #15007