### PR TITLE
GH-15012: [Packaging][deb] Use system Protobuf for Debian GNU/Linux bookworm

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow/Rakefile
+++ b/dev/tasks/linux-packages/apache-arrow/Rakefile
@@ -128,9 +128,8 @@ class ApacheArrowPackageTask < PackageTask
   end
 
   def apt_prepare_debian_control_protobuf(control, target)
-    # Flight requires Protobuf 3.15.0 or later but Debian GNU/Linux
-    # bookwarm and Ubuntu 22.04 don't provide Protobuf 3.15.0 or later
-    # yet.
+    # Flight requires Protobuf 3.15.0 or later but Ubuntu 22.04
+    # doesn't provide Protobuf 3.15.0 or later yet.
     #
     # See also:
     #   * cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -144,7 +143,8 @@ class ApacheArrowPackageTask < PackageTask
     # enough resource to build with Flight.
     #
     # So, we can use system Protobuf only for arm64 for now.
-    if target.end_with?("-arm64")
+    case target
+    when /\Adebian-bookworm/, /-arm64\z/
       use_system_protobuf = ""
     else
       use_system_protobuf = "#"


### PR DESCRIPTION
libprotobuf-dev on Debian GNU/Linux bookworm is now 3.21.11:

https://packages.debian.org/search?keywords=libprotobuf-dev

We can use it for our package.

This fixes the following package test failure:

https://github.com/ursacomputing/crossbow/actions/runs/3719263437/jobs/6308012451

    -- Could NOT find Protobuf (missing: Protobuf_LIBRARIES Protobuf_INCLUDE_DIR)
    CMake Error at CMakeLists.txt:24 (find_package):
      Found package configuration file:

        /usr/lib/x86_64-linux-gnu/cmake/Arrow/ArrowConfig.cmake

      but it set Arrow_FOUND to FALSE so package "Arrow" is considered to be NOT
      FOUND.  Reason given by package:

      Arrow could not be found because dependency ProtobufAlt could not be found.

    -- Configuring incomplete, errors occurred!
* Closes: #15012