### PR TITLE
GH-14993: [CI][Conda] Fix missing RECIPE_ROOT variable now expected by conda build

### DIFF
--- a/dev/tasks/conda-recipes/build_steps.sh
+++ b/dev/tasks/conda-recipes/build_steps.sh
@@ -10,18 +10,19 @@
 # benefit from the improvement.
 
 set -xeuo pipefail
+export FEEDSTOCK_ROOT="${FEEDSTOCK_ROOT:-/home/conda/feedstock_root}"
 
 output_dir=${1}
 
 export PYTHONUNBUFFERED=1
-export FEEDSTOCK_ROOT="${FEEDSTOCK_ROOT:-/home/conda/feedstock_root}"
+export RECIPE_ROOT="${RECIPE_ROOT:-/home/conda/recipe_root}"
 export CI_SUPPORT="${FEEDSTOCK_ROOT}/.ci_support"
 export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
 
 cat >~/.condarc <<CONDARC
 
 conda-build:
- root-dir: ${output_dir}
+  root-dir: ${output_dir}
 
 CONDARC
 
@@ -29,12 +30,12 @@ mamba install --update-specs --yes --quiet "conda-forge-ci-setup=3" conda-build 
 mamba update --update-specs --yes --quiet "conda-forge-ci-setup=3" conda-build pip boa -c conda-forge
 
 # set up the condarc
-setup_conda_rc "${FEEDSTOCK_ROOT}" "${FEEDSTOCK_ROOT}" "${CONFIG_FILE}"
+setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 source run_conda_forge_build_setup
 
 # make the build number clobber
-make_build_number "${FEEDSTOCK_ROOT}" "${FEEDSTOCK_ROOT}" "${CONFIG_FILE}"
+make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${HOST_PLATFORM}" != linux-* ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
     EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"

--- a/dev/tasks/conda-recipes/r-arrow/build.sh
+++ b/dev/tasks/conda-recipes/r-arrow/build.sh
@@ -5,6 +5,7 @@ export DISABLE_AUTOBREW=1
 
 # arrow uses C++17
 export ARROW_R_CXXFLAGS="${ARROW_R_CXXFLAGS} -std=c++17"
+export LIBARROW_BUILD=false
 
 if [[ "${target_platform}" == osx-* ]]; then
     # See https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk

--- a/dev/tasks/conda-recipes/r-arrow/build.sh
+++ b/dev/tasks/conda-recipes/r-arrow/build.sh
@@ -12,7 +12,7 @@ if [[ "${target_platform}" == osx-* ]]; then
     export ARROW_R_CXXFLAGS="${ARROW_R_CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
 fi
 
-export PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}"
+export PKG_CONFIG_PATH="${BUILD_PREFIX}/lib/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}"
 
 # ${R_ARGS} necessary to support cross-compilation
 ${R} CMD INSTALL --build r/. ${R_ARGS}

--- a/dev/tasks/conda-recipes/r-arrow/build.sh
+++ b/dev/tasks/conda-recipes/r-arrow/build.sh
@@ -12,7 +12,5 @@ if [[ "${target_platform}" == osx-* ]]; then
     export ARROW_R_CXXFLAGS="${ARROW_R_CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
 fi
 
-export PKG_CONFIG_PATH="${BUILD_PREFIX}/lib/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}"
-
 # ${R_ARGS} necessary to support cross-compilation
 ${R} CMD INSTALL --build r/. ${R_ARGS}

--- a/dev/tasks/conda-recipes/run_docker_build.sh
+++ b/dev/tasks/conda-recipes/run_docker_build.sh
@@ -16,6 +16,7 @@ build_dir=${1}
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
 ARROW_ROOT=$(cd "$THISDIR/../../.."; pwd;)
 FEEDSTOCK_ROOT=$THISDIR
+RECIPE_ROOT=$THISDIR
 
 docker info
 
@@ -64,6 +65,7 @@ docker run ${DOCKER_RUN_ARGS} \
            -v "${ARROW_ROOT}":/arrow:rw,z \
            -v "${build_dir}":/build:rw \
            -e FEEDSTOCK_ROOT="/arrow/dev/tasks/conda-recipes" \
+           -e RECIPE_ROOT="/arrow/dev/tasks/conda-recipes" \
            -e CONFIG \
            -e R_CONFIG \
            -e HOST_USER_ID \

--- a/r/configure
+++ b/r/configure
@@ -25,6 +25,8 @@
 # INCLUDE_DIR and LIB_DIR manually via e.g:
 # R CMD INSTALL --configure-vars='INCLUDE_DIR=/.../include LIB_DIR=/.../lib'
 
+set -x
+
 # Library settings
 PKG_CONFIG_NAME="arrow"
 PKG_DEB_NAME="(unsuppored)"

--- a/r/configure
+++ b/r/configure
@@ -25,8 +25,6 @@
 # INCLUDE_DIR and LIB_DIR manually via e.g:
 # R CMD INSTALL --configure-vars='INCLUDE_DIR=/.../include LIB_DIR=/.../lib'
 
-set -x
-
 # Library settings
 PKG_CONFIG_NAME="arrow"
 PKG_DEB_NAME="(unsuppored)"

--- a/r/configure
+++ b/r/configure
@@ -106,7 +106,7 @@ else
     PKGCONFIG_DIRS=`pkg-config --libs-only-L --silence-errors ${PKG_CONFIG_NAME}`
   fi
 
-  if [ "$PKGCONFIG_CFLAGS" ] && [ "$PKGCONFIG_LIBS" ]; then
+  if [ "$PKGCONFIG_LIBS" != "" ]; then
     FOUND_LIB_DIR=`echo $PKGCONFIG_DIRS | sed -e 's/^-L//'`
     echo "*** Arrow C++ libraries found via pkg-config at $FOUND_LIB_DIR"
     PKG_CFLAGS="$PKGCONFIG_CFLAGS $PKG_CFLAGS"


### PR DESCRIPTION
Fixes #14993


* Closes: #14993