### PR TITLE
GH-15023: [CI][Packaging][macOS][Java] Use llvm@14 to avoid libz3.dylib linkage

### DIFF
--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -82,6 +82,12 @@ jobs:
           # aws-sdk-cpp and bundled aws-sdk-cpp. We uninstall Homebrew's
           # aws-sdk-cpp to ensure using only bundled aws-sdk-cpp.
           brew uninstall aws-sdk-cpp
+          # We want to link z3 statically but Homebrew's LLVM lists
+          # shared z3 in its CMake package. We rewrite it to use
+          # static z3.
+          sed -i'' \
+            -e 's/libz3\.dylib/libz3.a/g' \
+            $(brew --prefix llvm)/lib/cmake/llvm/LLVMExports.cmake
           brew bundle --file=arrow/java/Brewfile
       - name: Build C++ libraries
         env:

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -85,7 +85,7 @@ jobs:
           # We want to link z3 statically but Homebrew's LLVM lists
           # shared z3 in its CMake package. We rewrite it to use
           # static z3.
-          llvm_package=$(grep -E -o 'llvm[^"]*' cpp/Brewfile)
+          llvm_package=$(grep -E -o 'llvm[^"]*' arrow/cpp/Brewfile)
           sed -i'' \
             -e 's/libz3\.dylib/libz3.a/g' \
             $(brew --prefix ${llvm_package})/lib/cmake/llvm/LLVMExports.cmake

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -85,9 +85,10 @@ jobs:
           # We want to link z3 statically but Homebrew's LLVM lists
           # shared z3 in its CMake package. We rewrite it to use
           # static z3.
+          llvm_package=$(grep -E -o 'llvm[^"]*' cpp/Brewfile)
           sed -i'' \
             -e 's/libz3\.dylib/libz3.a/g' \
-            $(brew --prefix llvm)/lib/cmake/llvm/LLVMExports.cmake
+            $(brew --prefix ${llvm_package})/lib/cmake/llvm/LLVMExports.cmake
           brew bundle --file=arrow/java/Brewfile
       - name: Build C++ libraries
         env:

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -85,10 +85,17 @@ jobs:
           # We want to link z3 statically but Homebrew's LLVM lists
           # shared z3 in its CMake package. We rewrite it to use
           # static z3.
+          set -x
           llvm_package=$(grep -E -o 'llvm[^"]*' arrow/cpp/Brewfile)
           sed -i'' \
             -e 's/libz3\.dylib/libz3.a/g' \
             $(brew --prefix ${llvm_package})/lib/cmake/llvm/LLVMExports.cmake
+          if [ -f $(brew --prefix llvm)/lib/cmake/llvm/LLVMExports.cmake ]; then
+            sed -i'' \
+              -e 's/libz3\.dylib/libz3.a/g' \
+              $(brew --prefix llvm)/lib/cmake/llvm/LLVMExports.cmake
+          fi
+          set +x
           brew bundle --file=arrow/java/Brewfile
       - name: Build C++ libraries
         env:

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -82,7 +82,10 @@ jobs:
           # building both shared and static libraries at once.
           # See also: Z3_BUILD_LIBZ3_SHARED in
           # https://github.com/Z3Prover/z3/blob/master/README-CMake.md
-          brew uninstall llvm
+          #
+          # If llvm is installed, Apache Arrow C++ uses llvm rather than
+          # llvm@14 because llvm is newer than llvm@14.
+          brew uninstall llvm || :
           brew bundle --file=arrow/cpp/Brewfile
           # We want to link aws-sdk-cpp statically but Homebrew's
           # aws-sdk-cpp provides only shared library. If we have

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -75,6 +75,14 @@ jobs:
         run: pip install -e arrow/dev/archery[all]
       - name: Install dependencies
         run: |
+          # We want to use llvm@14 to avoid shared z3
+          # dependency. llvm@14 doesn't depend on z3 and llvm depends
+          # on z3. And Homebrew's z3 provides only shared library. It
+          # doesn't provides static z3 because z3's CMake doesn't accept
+          # building both shared and static libraries at once.
+          # See also: Z3_BUILD_LIBZ3_SHARED in
+          # https://github.com/Z3Prover/z3/blob/master/README-CMake.md
+          brew uninstall llvm
           brew bundle --file=arrow/cpp/Brewfile
           # We want to link aws-sdk-cpp statically but Homebrew's
           # aws-sdk-cpp provides only shared library. If we have
@@ -82,21 +90,6 @@ jobs:
           # aws-sdk-cpp and bundled aws-sdk-cpp. We uninstall Homebrew's
           # aws-sdk-cpp to ensure using only bundled aws-sdk-cpp.
           brew uninstall aws-sdk-cpp
-          # We want to link z3 statically but Homebrew's LLVM lists
-          # shared z3 in its CMake package. We rewrite it to use
-          # static z3.
-          set -x
-          llvm_package=$(grep -E -o 'llvm[^"]*' arrow/cpp/Brewfile)
-          sed -i'' \
-            -e 's/libz3\.dylib/libz3.a/g' \
-            $(brew --prefix ${llvm_package})/lib/cmake/llvm/LLVMExports.cmake
-          if [ -f $(brew --prefix llvm)/lib/cmake/llvm/LLVMExports.cmake ]; then
-            sed -i'' \
-              -e 's/libz3\.dylib/libz3.a/g' \
-              $(brew --prefix llvm)/lib/cmake/llvm/LLVMExports.cmake
-            ls -lah $(brew --prefix)/lib/
-          fi
-          set +x
           brew bundle --file=arrow/java/Brewfile
       - name: Build C++ libraries
         env:

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -94,6 +94,7 @@ jobs:
             sed -i'' \
               -e 's/libz3\.dylib/libz3.a/g' \
               $(brew --prefix llvm)/lib/cmake/llvm/LLVMExports.cmake
+            ls -lah $(brew --prefix)/lib/
           fi
           set +x
           brew bundle --file=arrow/java/Brewfile


### PR DESCRIPTION

* Closes: #15023