### PR TITLE
GH-15025: [CI][C++][Homebrew] Ensure removing Python related commands

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -158,6 +158,11 @@ jobs:
           submodules: recursive
       - name: Install Dependencies
         run: |
+          rm -f /usr/local/bin/2to3 || :
+          rm -f /usr/local/bin/idle3 || :
+          rm -f /usr/local/bin/pydoc3 || :
+          rm -f /usr/local/bin/python3 || :
+          rm -f /usr/local/bin/python3-config || :
           brew update --preinstall
           brew bundle --file=cpp/Brewfile
       - name: Install MinIO

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -162,7 +162,11 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: |
-          rm -f /usr/local/bin/2to3
+          rm -f /usr/local/bin/2to3 || :
+          rm -f /usr/local/bin/idle3 || :
+          rm -f /usr/local/bin/pydoc3 || :
+          rm -f /usr/local/bin/python3 || :
+          rm -f /usr/local/bin/python3-config || :
           brew update --preinstall
           brew install --overwrite git
           brew bundle --file=cpp/Brewfile

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -142,10 +142,11 @@ jobs:
       - name: Install Homebrew Dependencies
         shell: bash
         run: |
-          rm -f /usr/local/bin/2to3*
-          rm -f /usr/local/bin/idle*
-          rm -f /usr/local/bin/pydoc3*
-          rm -f /usr/local/bin/python3*
+          rm -f /usr/local/bin/2to3 || :
+          rm -f /usr/local/bin/idle3 || :
+          rm -f /usr/local/bin/pydoc3 || :
+          rm -f /usr/local/bin/python3 || :
+          rm -f /usr/local/bin/python3-config || :
           brew update --preinstall
           brew install --overwrite git
           brew bundle --file=cpp/Brewfile


### PR DESCRIPTION
If they exist and Homebrew's Python formula is updated, the update is failed:

https://github.com/apache/arrow/actions/runs/3729475663/jobs/6325425516

    ==> Pouring python@3.10--3.10.9.monterey.bottle.tar.gz
    Error: The `brew link` step did not complete successfully
    The formula built, but is not symlinked into /usr/local
    Could not symlink bin/2to3
    Target /usr/local/bin/2to3
    already exists. You may want to remove it:
      rm '/usr/local/bin/2to3'

    To force the link and overwrite all conflicting files:
      brew link --overwrite python@3.10

    To list all files that would be deleted:
      brew link --overwrite --dry-run python@3.10

    Possible conflicting files are:
    /usr/local/bin/2to3 -> /Library/Frameworks/Python.framework/Versions/3.11/bin/2to3
    /usr/local/bin/idle3 -> /Library/Frameworks/Python.framework/Versions/3.11/bin/idle3
    /usr/local/bin/pydoc3 -> /Library/Frameworks/Python.framework/Versions/3.11/bin/pydoc3
    /usr/local/bin/python3 -> /Library/Frameworks/Python.framework/Versions/3.11/bin/python3
    /usr/local/bin/python3-config -> /Library/Frameworks/Python.framework/Versions/3.11/bin/python3-config
* Closes: #15025