### PR TITLE
ARROW-17538: [C++] Import schema when importing array stream

### DIFF
--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -1786,12 +1786,12 @@ class ArrayStreamBatchReader : public RecordBatchReader {
     }
     std::shared_ptr<Schema> schema;
     struct ArrowSchema c_schema = {};
-    Status status = StatusFromCError(stream, stream->get_schema(stream, &c_schema));
+    auto status = StatusFromCError(stream, stream->get_schema(stream, &c_schema));
     if (status.ok()) {
       status = ImportSchema(&c_schema).Value(&schema);
     }
     if (!status.ok()) {
-      stream->release(stream);
+      ArrowArrayStreamRelease(stream);
       return status;
     }
     return std::make_shared<ArrayStreamBatchReader>(std::move(schema), stream);

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -1744,7 +1744,9 @@ namespace {
 
 class ArrayStreamBatchReader : public RecordBatchReader {
  public:
-  explicit ArrayStreamBatchReader(struct ArrowArrayStream* stream) {
+  explicit ArrayStreamBatchReader(std::shared_ptr<Schema> schema,
+                                  struct ArrowArrayStream* stream)
+      : schema_(std::move(schema)) {
     ArrowArrayStreamMove(stream, &stream_);
     DCHECK(!ArrowArrayStreamIsReleased(&stream_));
   }
@@ -1756,7 +1758,7 @@ class ArrayStreamBatchReader : public RecordBatchReader {
     DCHECK(ArrowArrayStreamIsReleased(&stream_));
   }
 
-  std::shared_ptr<Schema> schema() const override { return CacheSchema(); }
+  std::shared_ptr<Schema> schema() const override { return schema_; }
 
   Status ReadNext(std::shared_ptr<RecordBatch>* batch) override {
     struct ArrowArray c_array;
@@ -1766,7 +1768,7 @@ class ArrayStreamBatchReader : public RecordBatchReader {
       batch->reset();
       return Status::OK();
     } else {
-      return ImportRecordBatch(&c_array, CacheSchema()).Value(batch);
+      return ImportRecordBatch(&c_array, schema_).Value(batch);
     }
   }
 
@@ -1777,17 +1779,30 @@ class ArrayStreamBatchReader : public RecordBatchReader {
     return Status::OK();
   }
 
- private:
-  std::shared_ptr<Schema> CacheSchema() const {
-    if (!schema_) {
-      struct ArrowSchema c_schema;
-      ARROW_CHECK_OK(StatusFromCError(stream_.get_schema(&stream_, &c_schema)));
-      schema_ = ImportSchema(&c_schema).ValueOrDie();
+  static Result<std::shared_ptr<RecordBatchReader>> Make(
+      struct ArrowArrayStream* stream) {
+    if (ArrowArrayStreamIsReleased(stream)) {
+      return Status::Invalid("Cannot import released ArrowArrayStream");
     }
-    return schema_;
+    std::shared_ptr<Schema> schema;
+    struct ArrowSchema c_schema = {};
+    Status status = StatusFromCError(stream, stream->get_schema(stream, &c_schema));
+    if (status.ok()) {
+      status = ImportSchema(&c_schema).Value(&schema);
+    }
+    if (!status.ok()) {
+      stream->release(stream);
+      return status;
+    }
+    return std::make_shared<ArrayStreamBatchReader>(std::move(schema), stream);
   }
 
+ private:
   Status StatusFromCError(int errno_like) const {
+    return StatusFromCError(&stream_, errno_like);
+  }
+
+  static Status StatusFromCError(struct ArrowArrayStream* stream, int errno_like) {
     if (ARROW_PREDICT_TRUE(errno_like == 0)) {
       return Status::OK();
     }
@@ -1807,23 +1822,19 @@ class ArrayStreamBatchReader : public RecordBatchReader {
         code = StatusCode::IOError;
         break;
     }
-    const char* last_error = stream_.get_last_error(&stream_);
-    return Status(code, last_error ? std::string(last_error) : "");
+    const char* last_error = stream->get_last_error(stream);
+    return {code, last_error ? std::string(last_error) : ""};
   }
 
   mutable struct ArrowArrayStream stream_;
-  mutable std::shared_ptr<Schema> schema_;
+  std::shared_ptr<Schema> schema_;
 };
 
 }  // namespace
 
 Result<std::shared_ptr<RecordBatchReader>> ImportRecordBatchReader(
     struct ArrowArrayStream* stream) {
-  if (ArrowArrayStreamIsReleased(stream)) {
-    return Status::Invalid("Cannot import released ArrowArrayStream");
-  }
-  // XXX should we call get_schema() here to avoid crashing on error?
-  return std::make_shared<ArrayStreamBatchReader>(stream);
+  return ArrayStreamBatchReader::Make(stream);
 }
 
 }  // namespace arrow


### PR DESCRIPTION
This lets us check for and report errors instead of crashing.