### PR TITLE
GH-15045: [CI][conda] don't build pyarrow in r-jobs 

### DIFF
--- a/dev/tasks/conda-recipes/arrow-cpp/bld-pyarrow.bat
+++ b/dev/tasks/conda-recipes/arrow-cpp/bld-pyarrow.bat
@@ -1,5 +1,9 @@
 @echo on
-pushd "%SRC_DIR%"\python
+
+:: arrow-CI: don't build pyarrow for R-builds (which only needs libarrow)
+if NOT "%R_CONFIG%"=="" (
+  exit /b 0
+)
 
 @rem the symlinks for cmake modules don't work here
 @rem NOTE: In contrast to conda-forge, they work here as we clone from git.
@@ -34,6 +38,8 @@ if "%cuda_compiler_version%"=="None" (
 ) else (
     set "PYARROW_WITH_CUDA=1"
 )
+
+pushd "%SRC_DIR%"\python
 
 %PYTHON%   setup.py ^
            build_ext ^

--- a/dev/tasks/conda-recipes/arrow-cpp/build-pyarrow.sh
+++ b/dev/tasks/conda-recipes/arrow-cpp/build-pyarrow.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
+set -ex
 
-set -e
-set -x
+# arrow-CI: don't build pyarrow for R-builds (which only needs libarrow)
+if [[ -n "${R_CONFIG}" ]]; then
+    exit 0
+fi
 
 # Build dependencies
 export ARROW_HOME=$PREFIX

--- a/dev/tasks/conda-recipes/azure.osx.yml
+++ b/dev/tasks/conda-recipes/azure.osx.yml
@@ -59,7 +59,7 @@ jobs:
       source activate base
       set -e
       set +x
-      if [[ "${CONFIG}" == osx_arm* ]]; then
+      if [[ "${CONFIG}" == osx_arm* ]] || [[ -n "${R_CONFIG}" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
       fi
       conda build arrow-cpp \

--- a/dev/tasks/conda-recipes/azure.win.yml
+++ b/dev/tasks/conda-recipes/azure.win.yml
@@ -57,7 +57,10 @@ jobs:
 
     - script: |
         call activate base
-        conda.exe mambabuild arrow-cpp parquet-cpp -m .ci_support\%CONFIG%.yaml
+        if NOT "%R_CONFIG%"=="" (
+          set "EXTRA_CB_OPTIONS= --no-test"
+        )
+        conda.exe mambabuild arrow-cpp parquet-cpp -m .ci_support\%CONFIG%.yaml %EXTRA_CB_OPTIONS%
       displayName: Build Arrow recipe
       workingDirectory: arrow\dev\tasks\conda-recipes
       env:

--- a/dev/tasks/conda-recipes/build_steps.sh
+++ b/dev/tasks/conda-recipes/build_steps.sh
@@ -39,6 +39,9 @@ make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${HOST_PLATFORM}" != linux-* ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
     EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+elif [[ -n "${R_CONFIG}" ]]; then
+    # arrow-CI: pyarrow not built for R-builds, so don't try to test it
+    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
 fi
 
 export CONDA_BLD_PATH="${output_dir}"


### PR DESCRIPTION
Follow-up to #15014 

Fixes #15045
* Closes: #15045