### PR TITLE
GH-15043: [Python] [Docs] Update docstring for pyarrow.decompress

### DIFF
--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -2088,7 +2088,7 @@ cdef class Codec(_Weakrefable):
             out_buf.resize(output_length)
             return out_buf
 
-    def decompress(self, object buf, decompressed_size=None, asbytes=False,
+    def decompress(self, object buf, decompressed_size, asbytes=False,
                    memory_pool=None):
         """
         Decompress data from buffer-like object.
@@ -2096,9 +2096,8 @@ cdef class Codec(_Weakrefable):
         Parameters
         ----------
         buf : pyarrow.Buffer, bytes, or memoryview-compatible object
-        decompressed_size : int, default None
-            If not specified, will be computed if the codec is able to
-            determine the uncompressed buffer size.
+        decompressed_size : int
+            Size of the decompressed result
         asbytes : boolean, default False
             Return result as Python bytes object, otherwise Buffer
         memory_pool : MemoryPool, default None

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -2088,7 +2088,7 @@ cdef class Codec(_Weakrefable):
             out_buf.resize(output_length)
             return out_buf
 
-    def decompress(self, object buf, decompressed_size, asbytes=False,
+    def decompress(self, object buf, decompressed_size=None, asbytes=False,
                    memory_pool=None):
         """
         Decompress data from buffer-like object.
@@ -2096,7 +2096,7 @@ cdef class Codec(_Weakrefable):
         Parameters
         ----------
         buf : pyarrow.Buffer, bytes, or memoryview-compatible object
-        decompressed_size : int
+        decompressed_size : int, default None
             Size of the decompressed result
         asbytes : boolean, default False
             Return result as Python bytes object, otherwise Buffer
@@ -2119,7 +2119,7 @@ cdef class Codec(_Weakrefable):
 
         if decompressed_size is None:
             raise ValueError(
-                "Must pass decompressed_size for {} codec".format(self)
+                "Must pass decompressed_size"
             )
 
         output_size = decompressed_size
@@ -2183,8 +2183,7 @@ def decompress(object buf, decompressed_size=None, codec='lz4',
     buf : pyarrow.Buffer, bytes, or memoryview-compatible object
         Input object to decompress data from.
     decompressed_size : int, default None
-        If not specified, will be computed if the codec is able to determine
-        the uncompressed buffer size.
+        Size of the decompressed result
     codec : str, default 'lz4'
         Compression codec.
         Supported types: {'brotli, 'gzip', 'lz4', 'lz4_raw', 'snappy', 'zstd'}


### PR DESCRIPTION
I opted to keep `decompressed_size` optional to reduce churn (optional->required->optional) if we ever add in detection/estimation for certain codecs in the future. Let me know what you think.
* Closes: #15043