### PR TITLE
GH-15040: [C++] Improve pkg-config support for ARROW_BUILD_SHARED=OFF

### DIFF
--- a/ci/scripts/r_install_system_dependencies.sh
+++ b/ci/scripts/r_install_system_dependencies.sh
@@ -35,81 +35,9 @@ if [ "$ARROW_S3" == "ON" ] || [ "$ARROW_GCS" == "ON" ] || [ "$ARROW_R_DEV" == "T
   fi
 
   # Install curl and OpenSSL for S3/GCS support
-  #
-  # We need to install all dependencies explicitly to use "pkg-config
-  # --static --libs libcurl" result. Because libcurl-dev/libcurl-devel
-  # don't depend on packages that are only needed for "pkg-config
-  # --static".
   case "$PACKAGE_MANAGER" in
     apt-get)
-      # "pkg-config --static --libs libcurl" has
-      #   * -lnghttp2
-      #   * -lidn2
-      #   * -lrtmp
-      #   * -lssh or -lssh2
-      #   * -lpsl
-      #   * -lssl
-      #   * -lcrypto
-      #   * -lgssapi_krb5
-      #   * -lkrb5
-      #   * -lk5crypto
-      #   * -lcom_err
-      #   * -lldap
-      #   * -llber
-      #   * -lzstd
-      #   * -lbrotlidec
-      #   * -lz
-      apt-get install -y \
-              libbrotli-dev \
-              libcurl4-openssl-dev \
-              libidn2-dev \
-              libkrb5-dev \
-              libldap-dev \
-              libnghttp2-dev \
-              libpsl-dev \
-              librtmp-dev \
-              libssh-dev \
-              libssh2-1-dev \
-              libssl-dev \
-              libzstd-dev
-      ;;
-    dnf|yum)
-      # "pkg-config --static --libs libcurl" has -lidl, -lssh2 and -lldap
-      $PACKAGE_MANAGER install -y \
-                       libcurl-devel \
-                       libidn-devel \
-                       libssh2-devel \
-                       openldap-devel \
-                       openssl-devel
-      ;;
-    zypper)
-      # "pkg-config --static --libs libcurl" has
-      #   * -lnghttp2
-      #   * -lidn2
-      #   * -lssh
-      #   * -lpsl
-      #   * -lssl
-      #   * -lcrypto
-      #   * -lgssapi_krb5
-      #   * -lkrb5
-      #   * -lk5crypto
-      #   * -lcom_err
-      #   * -lldap
-      #   * -llber
-      #   * -lzstd
-      #   * -lbrotlidec
-      #   * -lz
-      $PACKAGE_MANAGER install -y \
-                       krb5-devel \
-                       libbrotli-devel \
-                       libcurl-devel \
-                       libidn2-devel \
-                       libnghttp2-devel \
-                       libpsl-devel \
-                       libssh-devel \
-                       libzstd-devel \
-                       openldap2-devel \
-                       openssl-devel
+      apt-get install -y libcurl4-openssl-dev libssl-dev
       ;;
     *)
       $PACKAGE_MANAGER install -y libcurl-devel openssl-devel

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -489,10 +489,11 @@ endif()
 include(BuildUtils)
 enable_testing()
 
-# For arrow.pc. Requires.private and Libs.private are used when
-# "pkg-config --libs --static arrow" is used.
-set(ARROW_PC_REQUIRES_PRIVATE)
-set(ARROW_PC_LIBS_PRIVATE)
+# For arrow.pc. Cflags.private, Libs.private and Requires.private are
+# used when "pkg-config --cflags --libs --static arrow" is used.
+set(ARROW_PC_CFLAGS_PRIVATE " -DARROW_STATIC")
+set(ARROW_PC_LIBS_PRIVATE "")
+set(ARROW_PC_REQUIRES_PRIVATE "")
 
 include(ThirdpartyToolchain)
 

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -579,6 +579,23 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND ${CMAKE_SYSTEM_PROCESSOR} MATCHES "
   string(APPEND ARROW_PC_LIBS_PRIVATE " -latomic")
 endif()
 
+# If libarrow.a is only built, "pkg-config --cflags --libs arrow"
+# outputs build flags for static linking not shared
+# linking. ARROW_PC_* except ARROW_PC_*_PRIVATE are for the static
+# linking case.
+if(NOT ARROW_BUILD_SHARED AND ARROW_BUILD_STATIC)
+  set(ARROW_PC_CFLAGS "${ARROW_PC_CFLAGS_PRIVATE}")
+  set(ARROW_PC_CFLAGS_PRIVATE "")
+  set(ARROW_PC_LIBS "${ARROW_PC_LIBS_PRIVATE}")
+  set(ARROW_PC_LIBS_PRIVATE "")
+  set(ARROW_PC_REQUIRES "${ARROW_PC_REQUIRES_PRIVATE}")
+  set(ARROW_PC_REQUIRES_PRIVATE "")
+else()
+  set(ARROW_PC_CFLAGS "")
+  set(ARROW_PC_LIBS "")
+  set(ARROW_PC_REQUIRES "")
+endif()
+
 add_arrow_lib(arrow
               CMAKE_PACKAGE_NAME
               Arrow

--- a/cpp/src/arrow/arrow.pc.in
+++ b/cpp/src/arrow/arrow.pc.in
@@ -26,8 +26,9 @@ full_so_version=@ARROW_FULL_SO_VERSION@
 Name: Apache Arrow
 Description: Arrow is a set of technologies that enable big-data systems to process and move data fast.
 Version: @ARROW_VERSION@
+Requires:@ARROW_PC_REQUIRES@
 Requires.private:@ARROW_PC_REQUIRES_PRIVATE@
-Libs: -L${libdir} -larrow
+Libs: -L${libdir} -larrow@ARROW_PC_LIBS@
 Libs.private:@ARROW_PC_LIBS_PRIVATE@
-Cflags: -I${includedir}
-Cflags.private: -DARROW_STATIC
+Cflags: -I${includedir}@ARROW_PC_CFLAGS@
+Cflags.private:@ARROW_PC_CFLAGS_PRIVATE@

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -141,6 +141,10 @@ jobs:
         r_version:
           - { rtools: "{{ macros.r_release.rt }}", r: "{{ macros.r_release.ver }}" }
           - { rtools: "{{ macros.r_oldrel.rt }}", r: "{{ macros.r_oldrel.ver }}" }
+        excludes:
+          # purrr 1.0.0 doesn't work with R oldrel on Windows?
+          - platform: { runs_on: 'windows-latest', name: "Windows"}
+            r_version: { rtools: "{{ macros.r_oldrel.rt }}", r: "{{ macros.r_oldrel.ver }}" }
     steps:
       - uses: r-lib/actions/setup-r@v2
         # expression marker prevents the ! being parsed as yaml tag

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -141,8 +141,8 @@ jobs:
         r_version:
           - { rtools: "{{ macros.r_release.rt }}", r: "{{ macros.r_release.ver }}" }
           - { rtools: "{{ macros.r_oldrel.rt }}", r: "{{ macros.r_oldrel.ver }}" }
-        excludes:
-          # purrr 1.0.0 doesn't work with R oldrel on Windows?
+        exclude:
+          # GH-15080: purrr 1.0.0 doesn't work with R oldrel on Windows
           - platform: { runs_on: 'windows-latest', name: "Windows"}
             r_version: { rtools: "{{ macros.r_oldrel.rt }}", r: "{{ macros.r_oldrel.ver }}" }
     steps:

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -942,7 +942,8 @@ tasks:
       - r-lib__libarrow__bin__centos-7__arrow-{no_rc_r_version}\.zip
       - r-lib__libarrow__bin__ubuntu-18.04__arrow-{no_rc_r_version}\.zip
       - r-lib__libarrow__bin__ubuntu-22.04__arrow-{no_rc_r_version}\.zip
-      - r-pkg__bin__windows__contrib__4.1__arrow_{no_rc_r_version}\.zip
+      # GH-15080: purrr 1.0.0 doesn't work with R oldrel on Windows
+      # - r-pkg__bin__windows__contrib__4.1__arrow_{no_rc_r_version}\.zip
       - r-pkg__bin__windows__contrib__4.2__arrow_{no_rc_r_version}\.zip
       - r-pkg__bin__macosx__contrib__4.1__arrow_{no_rc_r_version}\.tgz
       - r-pkg__bin__macosx__contrib__4.2__arrow_{no_rc_r_version}\.tgz

--- a/r/configure
+++ b/r/configure
@@ -203,7 +203,7 @@ else
               ${LIB_DIR}/pkgconfig/*.pc
             rm -f ${LIB_DIR}/pkgconfig/*.pc.bak
           fi
-          PKG_CONFIG="${PKG_CONFIG} --static --silence-errors"
+          PKG_CONFIG="${PKG_CONFIG} --silence-errors"
           PKG_CFLAGS="`${PKG_CONFIG} --cflags ${PKG_CONFIG_NAME}` $PKG_CFLAGS"
           PKG_DIRS="`${PKG_CONFIG} --libs-only-L ${PKG_CONFIG_NAME}`"
           PKG_LIBS="`${PKG_CONFIG} --libs-only-l --libs-only-other ${PKG_CONFIG_NAME}`"


### PR DESCRIPTION
If `ARROW_BUILD_SHARED=OFF` is specified, `pkg-config --cflags --libs arrow` doesn't work. Because `pkg-config --cflags --libs arrow` misses build options for static linking. Users need to specify `pkg-config --cflags --libs --static arrow` for static linking even when `ARROW_BUILD_SHARED=OFF` is specified.

This change adds support for `pkg-config --cflags --libs arrow` with `ARROW_BUILD_SHARED=OFF`. The command outputs build options for linking against `libarrow.a`. But these build options don't use static linking for dependencies. On the other hand, `pkg-config --cflags --libs --static arrow` still use static linking for all libraries including Apache Arrow C++ and its dependencies.

With this change, Apache Arrow R doesn't need to use `pkg-config --static`. Because `pkg-config --cflags --libs arrow` works for both of `libarrow.so` and `libarrow.a`.
* Closes: #15040