### PR TITLE
MINOR: [R] Should build ignore __pycache__ directory

### DIFF
--- a/r/.Rbuildignore
+++ b/r/.Rbuildignore
@@ -31,4 +31,4 @@ STYLE.md
 ^revdep$
 ^vignettes$
 ^PACKAGING\.md$
-^__pycache__$
+^inst/__pycache__$

--- a/r/.Rbuildignore
+++ b/r/.Rbuildignore
@@ -31,3 +31,4 @@ STYLE.md
 ^revdep$
 ^vignettes$
 ^PACKAGING\.md$
+^__pycache__$


### PR DESCRIPTION
I noticed that the `inst/__pycache__` directory remains in the released R arrow package version 10.0.1.

```r
system.file("__pycache__/demo_flight_server.cpython-38.pyc", package = "arrow")
#> [1] "/usr/local/lib/R/site-library/arrow/__pycache__/demo_flight_server.cpython-38.pyc"
```
