### PR TITLE
GH-15085: [Ruby] Add ColumnContainable#column_names

### DIFF
--- a/ruby/red-arrow/lib/arrow/column-containable.rb
+++ b/ruby/red-arrow/lib/arrow/column-containable.rb
@@ -144,7 +144,7 @@ module Arrow
       end
     end
 
-    # Return column names in this table.
+    # Return column names in this object.
     #
     # @return [::Array<String>] column names.
     # 

--- a/ruby/red-arrow/lib/arrow/column-containable.rb
+++ b/ruby/red-arrow/lib/arrow/column-containable.rb
@@ -143,5 +143,14 @@ module Arrow
         find_column(selector)
       end
     end
+
+    # Return column names in this table.
+    #
+    # @return [::Array<String>] column names.
+    # 
+    # @since 11.0.0
+    def column_names
+      @column_names ||= columns.collect(&:name)
+    end
   end
 end

--- a/ruby/red-arrow/test/test-table.rb
+++ b/ruby/red-arrow/test/test-table.rb
@@ -602,6 +602,18 @@ class TableTest < Test::Unit::TestCase
     end
   end
 
+  sub_test_case("#column_names") do
+    test ("unique") do
+      table = Arrow::Table.new(a: [1], b: [2], c: [3])
+      assert_equal(%w[a b c], table.column_names)
+    end
+
+    test ("duplicated") do
+      table = Arrow::Table.new([["a", [1, 2, 3]], ["a", [4, 5, 6]]])
+      assert_equal(%w[a a], table.column_names)
+    end
+  end
+
   sub_test_case("#save and .load") do
     module SaveLoadFormatTests
       def test_default

--- a/ruby/red-arrow/test/test-table.rb
+++ b/ruby/red-arrow/test/test-table.rb
@@ -603,12 +603,12 @@ class TableTest < Test::Unit::TestCase
   end
 
   sub_test_case("#column_names") do
-    test ("unique") do
+    test("unique") do
       table = Arrow::Table.new(a: [1], b: [2], c: [3])
       assert_equal(%w[a b c], table.column_names)
     end
 
-    test ("duplicated") do
+    test("duplicated") do
       table = Arrow::Table.new([["a", [1, 2, 3]], ["a", [4, 5, 6]]])
       assert_equal(%w[a a], table.column_names)
     end


### PR DESCRIPTION
### What I did

* Add `ColumnContainable#column_names`.
  * Returns `columns.collect(&:name)`.
* Add tests for the tables that have unique keys and same keys.
* Add document.

### What I didn't

* Check whole code to be replaced for it.

### What I checked

* It works as a method Table#keys in RedAmber using refinements.

### Notes for reviewers

* I will search the code which should be replaced if reviewer requested me.

### Related Issue

* Closes: #15085