### PR TITLE
GH-15087: [Release] Slow down downloading RC binaries from GitHub

### DIFF
--- a/dev/release/download_rc_binaries.py
+++ b/dev/release/download_rc_binaries.py
@@ -22,8 +22,10 @@ import concurrent.futures as cf
 import functools
 import json
 import os
+import random
 import re
 import subprocess
+import time
 import urllib.request
 
 
@@ -190,12 +192,18 @@ class GitHub(Downloader):
             print("Already downloaded", dest_path)
             return
 
-        return self._download_url(
+        delay = random.randint(0, 3)
+        print(f"Waiting {delay} seconds to avoid rate limit")
+        time.sleep(delay)
+
+        self._download_url(
             url,
             dest_path,
             extra_args=[
                 "--header",
                 "Accept: application/octet-stream",
+                # Also retry 403s
+                "--retry-all-errors",
             ],
         )
 


### PR DESCRIPTION
GitHub appears to have a rate limit on downloading artifacts from a release, which we easily run into. Adding a bit of a delay appears to avoid this. Also, force cURL itself retry failed downloads.
* Closes: #15087