### PR TITLE
GH-15092: [CI][C++][Homebrew] Ensure removing Python related commands (again)

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -158,10 +158,10 @@ jobs:
           submodules: recursive
       - name: Install Dependencies
         run: |
-          rm -f /usr/local/bin/2to3 || :
-          rm -f /usr/local/bin/idle3 || :
-          rm -f /usr/local/bin/pydoc3 || :
-          rm -f /usr/local/bin/python3 || :
+          rm -f /usr/local/bin/2to3* || :
+          rm -f /usr/local/bin/idle3* || :
+          rm -f /usr/local/bin/pydoc3* || :
+          rm -f /usr/local/bin/python3* || :
           rm -f /usr/local/bin/python3-config || :
           brew update --preinstall
           brew bundle --file=cpp/Brewfile

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -162,10 +162,10 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: |
-          rm -f /usr/local/bin/2to3 || :
-          rm -f /usr/local/bin/idle3 || :
-          rm -f /usr/local/bin/pydoc3 || :
-          rm -f /usr/local/bin/python3 || :
+          rm -f /usr/local/bin/2to3* || :
+          rm -f /usr/local/bin/idle3* || :
+          rm -f /usr/local/bin/pydoc3* || :
+          rm -f /usr/local/bin/python3* || :
           rm -f /usr/local/bin/python3-config || :
           brew update --preinstall
           brew install --overwrite git

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -142,10 +142,10 @@ jobs:
       - name: Install Homebrew Dependencies
         shell: bash
         run: |
-          rm -f /usr/local/bin/2to3 || :
-          rm -f /usr/local/bin/idle3 || :
-          rm -f /usr/local/bin/pydoc3 || :
-          rm -f /usr/local/bin/python3 || :
+          rm -f /usr/local/bin/2to3* || :
+          rm -f /usr/local/bin/idle3* || :
+          rm -f /usr/local/bin/pydoc3* || :
+          rm -f /usr/local/bin/python3* || :
           rm -f /usr/local/bin/python3-config || :
           brew update --preinstall
           brew install --overwrite git


### PR DESCRIPTION
This is a bug at the same place as #15025 . We must remove `2to3-3.11 ` for this time.

```
==> Pouring python@3.11--3.11.1.monterey.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/2to3-3.11
Target /usr/local/bin/2to3-3.11
already exists. You may want to remove it:
  rm '/usr/local/bin/2to3-3.11'
```

* Closes: #15092