### PR TITLE
GH-15094: [CI][Release][Ruby] Install Bundler by APT

### DIFF
--- a/dev/release/setup-ubuntu.sh
+++ b/dev/release/setup-ubuntu.sh
@@ -53,6 +53,7 @@ esac
 
 apt-get install -y -q --no-install-recommends \
   build-essential \
+  bundler \
   clang \
   cmake \
   curl \


### PR DESCRIPTION
Because the latest Bundler doesn't work with (EOL-ed) Ruby 2.5 on Ubuntu 18.04.
* Closes: #15094