### PR TITLE
GH-15096: [C++] Substrait ProjectRel Emit Optimization

### DIFF
--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -116,6 +116,44 @@ Result<DeclarationInfo> ProcessEmit(const RelMessage& rel,
     return no_emit_declr;
   }
 }
+/// In the specialization, a single ProjectNode is being used to
+/// get the Acero relation with or without emit.
+template <>
+Result<DeclarationInfo> ProcessEmit(const substrait::ProjectRel& rel,
+                                    const DeclarationInfo& project_declr,
+                                    const std::shared_ptr<Schema>& input_schema) {
+  if (rel.has_common()) {
+    switch (rel.common().emit_kind_case()) {
+      case substrait::RelCommon::EmitKindCase::kDirect:
+        return project_declr;
+      case substrait::RelCommon::EmitKindCase::kEmit: {
+        const auto& emit = rel.common().emit();
+        int emit_size = emit.output_mapping_size();
+        const auto& proj_options = checked_cast<const compute::ProjectNodeOptions&>(
+            *project_declr.declaration.options);
+        FieldVector emit_fields(emit_size);
+        std::vector<compute::Expression> emit_proj_exprs(emit_size);
+        for (int i = 0; i < emit_size; i++) {
+          int32_t map_id = emit.output_mapping(i);
+          emit_fields[i] = input_schema->field(map_id);
+          emit_proj_exprs[i] = std::move(proj_options.expressions[map_id]);
+        }
+        // Note: DeclarationInfo is created by considering the input to the
+        // ProjectRel and the ProjectNodeOptions are set by only considering
+        // what is in the emit expression in Substrait.
+        return DeclarationInfo{
+            compute::Declaration::Sequence(
+                {std::get<compute::Declaration>(project_declr.declaration.inputs[0]),
+                 {"project", compute::ProjectNodeOptions{std::move(emit_proj_exprs)}}}),
+            schema(std::move(emit_fields))};
+      }
+      default:
+        return Status::Invalid("Invalid emit case");
+    }
+  } else {
+    return project_declr;
+  }
+}
 
 template <typename RelMessage>
 Status CheckRelCommon(const RelMessage& rel,

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -227,10 +227,12 @@ int CountProjectNodeOptionsInDeclarations(const compute::Declaration& input) {
   }
   return counter;
 }
-/// Validate the number of expected ProjectNodes when an emit is associated with
-/// relations.
-void ValidateEmit(int expected_projections, const std::shared_ptr<Buffer>& buf,
-                  const ConversionOptions& conversion_options) {
+/// Validate the number of expected ProjectNodes
+///
+/// Project nodes are sometimes added by emit elements and we may want to
+/// verify that we are not adding too many
+void ValidateNumProjectNodes(int expected_projections, const std::shared_ptr<Buffer>& buf,
+                             const ConversionOptions& conversion_options) {
   std::shared_ptr<ExtensionIdRegistry> sp_ext_id_reg = MakeExtensionIdRegistry();
   ExtensionIdRegistry* ext_id_reg = sp_ext_id_reg.get();
   ExtensionSet ext_set(ext_id_reg);
@@ -2572,7 +2574,7 @@ TEST(SubstraitRoundTrip, ProjectRelOnFunctionWithEmit) {
 
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
-  ValidateEmit(1, buf, conversion_options);
+  ValidateNumProjectNodes(1, buf, conversion_options);
   CheckRoundTripResult(std::move(expected_table), buf,
                        /*include_columns=*/{}, conversion_options);
 }
@@ -2771,7 +2773,7 @@ TEST(SubstraitRoundTrip, ProjectRelOnFunctionWithAllEmit) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  ValidateEmit(2, buf, conversion_options);
+  ValidateNumProjectNodes(2, buf, conversion_options);
 
   CheckRoundTripResult(std::move(expected_table), buf,
                        /*include_columns=*/{}, conversion_options);
@@ -2830,7 +2832,7 @@ TEST(SubstraitRoundTrip, ReadRelWithEmit) {
 
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
-  ValidateEmit(1, buf, conversion_options);
+  ValidateNumProjectNodes(1, buf, conversion_options);
   CheckRoundTripResult(std::move(expected_table), buf,
                        /*include_columns=*/{}, conversion_options);
 }
@@ -2947,7 +2949,7 @@ TEST(SubstraitRoundTrip, FilterRelWithEmit) {
 
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
-  ValidateEmit(1, buf, conversion_options);
+  ValidateNumProjectNodes(1, buf, conversion_options);
   CheckRoundTripResult(std::move(expected_table), buf,
                        /*include_columns=*/{}, conversion_options);
 }
@@ -3247,7 +3249,7 @@ TEST(SubstraitRoundTrip, JoinRelWithEmit) {
 
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
-  ValidateEmit(1, buf, conversion_options);
+  ValidateNumProjectNodes(1, buf, conversion_options);
   CheckRoundTripResult(std::move(expected_table), buf,
                        /*include_columns=*/{}, conversion_options);
 }
@@ -3469,7 +3471,7 @@ TEST(SubstraitRoundTrip, AggregateRelEmit) {
 
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
-  ValidateEmit(1, buf, conversion_options);
+  ValidateNumProjectNodes(1, buf, conversion_options);
   CheckRoundTripResult(std::move(expected_table), buf,
                        /*include_columns=*/{}, conversion_options);
 }
@@ -3572,7 +3574,7 @@ TEST(Substrait, IsthmusPlan) {
   ASSERT_OK_AND_ASSIGN(auto buf,
                        internal::SubstraitFromJSON("Plan", substrait_json,
                                                    /*ignore_unknown_fields=*/false));
-  ValidateEmit(1, buf, conversion_options);
+  ValidateNumProjectNodes(1, buf, conversion_options);
   auto expected_table = TableFromJSON(test_schema, {"[[2], [3], [6]]"});
   CheckRoundTripResult(std::move(expected_table), buf,
                        /*include_columns=*/{}, conversion_options);
@@ -3736,7 +3738,7 @@ TEST(Substrait, ProjectWithMultiFieldExpressions) {
 
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
-  ValidateEmit(1, buf, conversion_options);
+  ValidateNumProjectNodes(1, buf, conversion_options);
   CheckRoundTripResult(std::move(expected_table), buf,
                        /*include_columns=*/{}, conversion_options);
 }
@@ -3822,7 +3824,7 @@ TEST(Substrait, NestedProjectWithMultiFieldExpressions) {
 
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
-  ValidateEmit(2, buf, conversion_options);
+  ValidateNumProjectNodes(2, buf, conversion_options);
   CheckRoundTripResult(std::move(expected_table), buf,
                        /*include_columns=*/{}, conversion_options);
 }
@@ -3909,7 +3911,7 @@ TEST(Substrait, NestedEmitProjectWithMultiFieldExpressions) {
 
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
-  ValidateEmit(2, buf, conversion_options);
+  ValidateNumProjectNodes(2, buf, conversion_options);
   CheckRoundTripResult(std::move(expected_table), buf,
                        /*include_columns=*/{}, conversion_options);
 }
@@ -4114,7 +4116,7 @@ TEST(Substrait, RootRelationOutputNames) {
 
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
-  ValidateEmit(1, buf, conversion_options);
+  ValidateNumProjectNodes(1, buf, conversion_options);
   CheckRoundTripResult(std::move(expected_table), buf,
                        /*include_columns=*/{}, conversion_options);
 }
@@ -4416,7 +4418,7 @@ TEST(Substrait, PlanWithAsOfJoinExtension) {
   conversion_options.named_table_provider = std::move(table_provider);
 
   ASSERT_OK_AND_ASSIGN(auto buf, internal::SubstraitFromJSON("Plan", substrait_json));
-  ValidateEmit(1, buf, conversion_options);
+  ValidateNumProjectNodes(1, buf, conversion_options);
   ASSERT_OK_AND_ASSIGN(
       auto out_schema,
       compute::asofjoin::MakeOutputSchema(

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -223,8 +223,7 @@ int CountProjectNodeOptionsInDeclarations(const compute::Declaration& input) {
   }
   const auto& inputs = input.inputs;
   for (const auto& in : inputs) {
-    return counter +
-           CountProjectNodeOptionsInDeclarations(std::get<compute::Declaration>(in));
+    counter += CountProjectNodeOptionsInDeclarations(std::get<compute::Declaration>(in));
   }
   return counter;
 }

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -2663,7 +2663,7 @@ TEST(SubstraitRoundTrip, ProjectRelOnFunctionWithAllEmit) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(expected_table), exec_context, buf,
+  CheckRoundTripResult(std::move(expected_table), buf,
                        /*include_columns=*/{}, conversion_options);
 }
 


### PR DESCRIPTION
This PR introduces an optimization to remove the additional `ProjectNode` used in handling emit feature for `ProjectRel`.

* Closes: #15096