### PR TITLE
ARROW-15732: [C++] Do not use any CPU threads in execution plan when use_threads is false

### DIFF
--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -256,13 +256,276 @@ arrow::Result<BatchesWithSchema> MakeGroupableBatches(int multiplicity = 1) {
   return out;
 }
 
-arrow::Status ExecutePlanAndCollectAsTable(
-    cp::ExecContext& exec_context, std::shared_ptr<cp::ExecPlan> plan,
-    std::shared_ptr<arrow::Schema> schema,
+arrow::Status ExecutePlanAndCollectAsTable(cp::Declaration plan) {
+  // collect sink_reader into a Table
+  std::shared_ptr<arrow::Table> response_table;
+  ARROW_ASSIGN_OR_RAISE(response_table, cp::DeclarationToTable(std::move(plan)));
+
+  std::cout << "Results : " << response_table->ToString() << std::endl;
+
+  return arrow::Status::OK();
+}
+
+// (Doc section: Scan Example)
+
+/// \brief An example demonstrating a scan and sink node
+///
+/// Scan-Table
+/// This example shows how scan operation can be applied on a dataset.
+/// There are operations that can be applied on the scan (project, filter)
+/// and the input data can be processed. The output is obtained as a table
+arrow::Status ScanSinkExample() {
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<arrow::dataset::Dataset> dataset, GetDataset());
+
+  auto options = std::make_shared<arrow::dataset::ScanOptions>();
+  options->projection = cp::project({}, {});  // create empty projection
+
+  // construct the scan node
+  auto scan_node_options = arrow::dataset::ScanNodeOptions{dataset, options};
+
+  cp::Declaration scan{"scan", std::move(scan_node_options)};
+
+  return ExecutePlanAndCollectAsTable(std::move(scan));
+}
+// (Doc section: Scan Example)
+
+// (Doc section: Source Example)
+
+/// \brief An example demonstrating a source and sink node
+///
+/// Source-Table Example
+/// This example shows how a custom source can be used
+/// in an execution plan. This includes source node using pregenerated
+/// data and collecting it into a table.
+///
+/// This sort of custom souce is often not needed.  In most cases you can
+/// use a scan (for a dataset source) or a source like table_source, array_vector_source,
+/// exec_batch_source, or record_batch_source (for in-memory data)
+arrow::Status SourceSinkExample() {
+  ARROW_ASSIGN_OR_RAISE(auto basic_data, MakeBasicBatches());
+
+  auto source_node_options = cp::SourceNodeOptions{basic_data.schema, basic_data.gen()};
+
+  cp::Declaration source{"source", std::move(source_node_options)};
+
+  return ExecutePlanAndCollectAsTable(std::move(source));
+}
+// (Doc section: Source Example)
+
+// (Doc section: Table Source Example)
+
+/// \brief An example showing a table source node
+///
+/// TableSource-Table Example
+/// This example shows how a table_source can be used
+/// in an execution plan. This includes a table source node
+/// receiving data from a table.  This plan simply collects the
+/// data back into a table but nodes could be added that modify
+/// or transform the data as well (as is shown in later examples)
+arrow::Status TableSourceSinkExample() {
+  ARROW_ASSIGN_OR_RAISE(auto table, GetTable());
+
+  arrow::AsyncGenerator<std::optional<cp::ExecBatch>> sink_gen;
+  int max_batch_size = 2;
+  auto table_source_options = cp::TableSourceNodeOptions{table, max_batch_size};
+
+  cp::Declaration source{"table_source", std::move(table_source_options)};
+
+  return ExecutePlanAndCollectAsTable(std::move(source));
+}
+// (Doc section: Table Source Example)
+
+// (Doc section: Filter Example)
+
+/// \brief An example showing a filter node
+///
+/// Source-Filter-Table
+/// This example shows how a filter can be used in an execution plan,
+/// to filter data from a source. The output from the exeuction plan
+/// is collected into a table.
+arrow::Status ScanFilterSinkExample() {
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<arrow::dataset::Dataset> dataset, GetDataset());
+
+  auto options = std::make_shared<arrow::dataset::ScanOptions>();
+  // specify the filter.  This filter removes all rows where the
+  // value of the "a" column is greater than 3.
+  cp::Expression filter_expr = cp::greater(cp::field_ref("a"), cp::literal(3));
+  // set filter for scanner : on-disk / push-down filtering.
+  // This step can be skipped if you are not reading from disk.
+  options->filter = filter_expr;
+  // empty projection
+  options->projection = cp::project({}, {});
+
+  // construct the scan node
+  std::cout << "Initialized Scanning Options" << std::endl;
+
+  auto scan_node_options = arrow::dataset::ScanNodeOptions{dataset, options};
+  std::cout << "Scan node options created" << std::endl;
+
+  cp::Declaration scan{"scan", std::move(scan_node_options)};
+
+  // pipe the scan node into the filter node
+  // Need to set the filter in scan node options and filter node options.
+  // At scan node it is used for on-disk / push-down filtering.
+  // At filter node it is used for in-memory filtering.
+  cp::Declaration filter{
+      "filter", {std::move(scan)}, cp::FilterNodeOptions(std::move(filter_expr))};
+
+  return ExecutePlanAndCollectAsTable(std::move(filter));
+}
+
+// (Doc section: Filter Example)
+
+// (Doc section: Project Example)
+
+/// \brief An example showing a project node
+///
+/// Scan-Project-Table
+/// This example shows how a Scan operation can be used to load the data
+/// into the execution plan, how a project operation can be applied on the
+/// data stream and how the output is collected into a table
+arrow::Status ScanProjectSinkExample() {
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<arrow::dataset::Dataset> dataset, GetDataset());
+
+  auto options = std::make_shared<arrow::dataset::ScanOptions>();
+  // projection
+  cp::Expression a_times_2 = cp::call("multiply", {cp::field_ref("a"), cp::literal(2)});
+  options->projection = cp::project({}, {});
+
+  auto scan_node_options = arrow::dataset::ScanNodeOptions{dataset, options};
+
+  cp::Declaration scan{"scan", std::move(scan_node_options)};
+  cp::Declaration project{
+      "project", {std::move(scan)}, cp::ProjectNodeOptions({a_times_2})};
+
+  return ExecutePlanAndCollectAsTable(std::move(project));
+}
+
+// (Doc section: Project Example)
+
+// (Doc section: Scalar Aggregate Example)
+
+/// \brief An example showing an aggregation node to aggregate an entire table
+///
+/// Source-Aggregation-Table
+/// This example shows how an aggregation operation can be applied on a
+/// execution plan resulting in a scalar output. The source node loads the
+/// data and the aggregation (counting unique types in column 'a')
+/// is applied on this data. The output is collected into a table (that will
+/// have exactly one row)
+arrow::Status SourceScalarAggregateSinkExample() {
+  ARROW_ASSIGN_OR_RAISE(auto basic_data, MakeBasicBatches());
+
+  auto source_node_options = cp::SourceNodeOptions{basic_data.schema, basic_data.gen()};
+
+  cp::Declaration source{"source", std::move(source_node_options)};
+  auto aggregate_options =
+      cp::AggregateNodeOptions{/*aggregates=*/{{"sum", nullptr, "a", "sum(a)"}}};
+  cp::Declaration aggregate{
+      "aggregate", {std::move(source)}, std::move(aggregate_options)};
+
+  return ExecutePlanAndCollectAsTable(std::move(aggregate));
+}
+// (Doc section: Scalar Aggregate Example)
+
+// (Doc section: Group Aggregate Example)
+
+/// \brief An example showing an aggregation node to perform a group-by operation
+///
+/// Source-Aggregation-Table
+/// This example shows how an aggregation operation can be applied on a
+/// execution plan resulting in grouped output. The source node loads the
+/// data and the aggregation (counting unique types in column 'a') is
+/// applied on this data. The output is collected into a table that will contain
+/// one row for each unique combination of group keys.
+arrow::Status SourceGroupAggregateSinkExample() {
+  ARROW_ASSIGN_OR_RAISE(auto basic_data, MakeBasicBatches());
+
+  arrow::AsyncGenerator<std::optional<cp::ExecBatch>> sink_gen;
+
+  auto source_node_options = cp::SourceNodeOptions{basic_data.schema, basic_data.gen()};
+
+  cp::Declaration source{"source", std::move(source_node_options)};
+  auto options = std::make_shared<cp::CountOptions>(cp::CountOptions::ONLY_VALID);
+  auto aggregate_options =
+      cp::AggregateNodeOptions{/*aggregates=*/{{"hash_count", options, "a", "count(a)"}},
+                               /*keys=*/{"b"}};
+  cp::Declaration aggregate{
+      "aggregate", {std::move(source)}, std::move(aggregate_options)};
+
+  return ExecutePlanAndCollectAsTable(std::move(aggregate));
+}
+// (Doc section: Group Aggregate Example)
+
+// (Doc section: ConsumingSink Example)
+
+/// \brief An example showing a consuming sink node
+///
+/// Source-Consuming-Sink
+/// This example shows how the data can be consumed within the execution plan
+/// by using a ConsumingSink node. There is no data output from this execution plan.
+arrow::Status SourceConsumingSinkExample() {
+  ARROW_ASSIGN_OR_RAISE(auto basic_data, MakeBasicBatches());
+
+  auto source_node_options = cp::SourceNodeOptions{basic_data.schema, basic_data.gen()};
+
+  cp::Declaration source{"source", std::move(source_node_options)};
+
+  std::atomic<uint32_t> batches_seen{0};
+  arrow::Future<> finish = arrow::Future<>::Make();
+  struct CustomSinkNodeConsumer : public cp::SinkNodeConsumer {
+    CustomSinkNodeConsumer(std::atomic<uint32_t>* batches_seen, arrow::Future<> finish)
+        : batches_seen(batches_seen), finish(std::move(finish)) {}
+
+    arrow::Status Init(const std::shared_ptr<arrow::Schema>& schema,
+                       cp::BackpressureControl* backpressure_control,
+                       cp::ExecPlan* plan) override {
+      // This will be called as the plan is started (before the first call to Consume)
+      // and provides the schema of the data coming into the node, controls for pausing /
+      // resuming input, and a pointer to the plan itself which can be used to access
+      // other utilities such as the thread indexer or async task scheduler.
+      return arrow::Status::OK();
+    }
+
+    arrow::Status Consume(cp::ExecBatch batch) override {
+      (*batches_seen)++;
+      return arrow::Status::OK();
+    }
+
+    arrow::Future<> Finish() override {
+      // Here you can perform whatever (possibly async) cleanup is needed, e.g. closing
+      // output file handles and flushing remaining work
+      return arrow::Future<>::MakeFinished();
+    }
+
+    std::atomic<uint32_t>* batches_seen;
+    arrow::Future<> finish;
+  };
+  std::shared_ptr<CustomSinkNodeConsumer> consumer =
+      std::make_shared<CustomSinkNodeConsumer>(&batches_seen, finish);
+
+  cp::Declaration consuming_sink{"consuming_sink",
+                                 {std::move(source)},
+                                 cp::ConsumingSinkNodeOptions(std::move(consumer))};
+
+  // Since we are consuming the data within the plan there is no output and we simply
+  // run the plan to completion instead of collecting into a table.
+  ARROW_RETURN_NOT_OK(cp::DeclarationToStatus(std::move(consuming_sink)));
+
+  std::cout << "The consuming sink node saw " << batches_seen.load() << " batches"
+            << std::endl;
+  return arrow::Status::OK();
+}
+// (Doc section: ConsumingSink Example)
+
+// (Doc section: OrderBySink Example)
+
+arrow::Status ExecutePlanAndCollectAsTableWithCustomSink(
+    std::shared_ptr<cp::ExecPlan> plan, std::shared_ptr<arrow::Schema> schema,
     arrow::AsyncGenerator<std::optional<cp::ExecBatch>> sink_gen) {
   // translate sink_gen (async) to sink_reader (sync)
   std::shared_ptr<arrow::RecordBatchReader> sink_reader =
-      cp::MakeGeneratorReader(schema, std::move(sink_gen), exec_context.memory_pool());
+      cp::MakeGeneratorReader(schema, std::move(sink_gen), arrow::default_memory_pool());
 
   // validate the ExecPlan
   ARROW_RETURN_NOT_OK(plan->Validate());
@@ -285,357 +548,16 @@ arrow::Status ExecutePlanAndCollectAsTable(
   return future.status();
 }
 
-// (Doc section: Scan Example)
-
-/// \brief An example demonstrating a scan and sink node
-/// \param exec_context The execution context to run the plan in
-///
-/// Scan-Sink
-/// This example shows how scan operation can be applied on a dataset.
-/// There are operations that can be applied on the scan (project, filter)
-/// and the input data can be processed. The output is obtained as a table
-/// via the sink node.
-arrow::Status ScanSinkExample(cp::ExecContext& exec_context) {
-  // Execution plan created
-  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
-                        cp::ExecPlan::Make(&exec_context));
-
-  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<arrow::dataset::Dataset> dataset, GetDataset());
-
-  auto options = std::make_shared<arrow::dataset::ScanOptions>();
-  options->projection = cp::project({}, {});  // create empty projection
-
-  // construct the scan node
-  cp::ExecNode* scan;
-  auto scan_node_options = arrow::dataset::ScanNodeOptions{dataset, options};
-
-  ARROW_ASSIGN_OR_RAISE(scan,
-                        cp::MakeExecNode("scan", plan.get(), {}, scan_node_options));
-
-  arrow::AsyncGenerator<std::optional<cp::ExecBatch>> sink_gen;
-
-  ARROW_RETURN_NOT_OK(
-      cp::MakeExecNode("sink", plan.get(), {scan}, cp::SinkNodeOptions{&sink_gen}));
-
-  return ExecutePlanAndCollectAsTable(exec_context, plan, dataset->schema(), sink_gen);
-}
-// (Doc section: Scan Example)
-
-// (Doc section: Source Example)
-
-/// \brief An example demonstrating a source and sink node
-/// \param exec_context The execution context to run the plan in
-///
-/// Source-Sink Example
-/// This example shows how a source and sink can be used
-/// in an execution plan. This includes source node receiving data
-/// and the sink node emits the data as an output represented in
-/// a table.
-arrow::Status SourceSinkExample(cp::ExecContext& exec_context) {
-  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
-                        cp::ExecPlan::Make(&exec_context));
-
-  ARROW_ASSIGN_OR_RAISE(auto basic_data, MakeBasicBatches());
-
-  arrow::AsyncGenerator<std::optional<cp::ExecBatch>> sink_gen;
-
-  auto source_node_options = cp::SourceNodeOptions{basic_data.schema, basic_data.gen()};
-
-  ARROW_ASSIGN_OR_RAISE(cp::ExecNode * source,
-                        cp::MakeExecNode("source", plan.get(), {}, source_node_options));
-
-  ARROW_RETURN_NOT_OK(
-      cp::MakeExecNode("sink", plan.get(), {source}, cp::SinkNodeOptions{&sink_gen}));
-
-  return ExecutePlanAndCollectAsTable(exec_context, plan, basic_data.schema, sink_gen);
-}
-// (Doc section: Source Example)
-
-// (Doc section: Table Source Example)
-
-/// \brief An example showing a table source node
-/// \param exec_context The execution context to run the plan in
-///
-/// TableSource-Sink Example
-/// This example shows how a table_source and sink can be used
-/// in an execution plan. This includes a table source node
-/// receiving data from a table and the sink node emits
-/// the data to a generator which we collect into a table.
-arrow::Status TableSourceSinkExample(cp::ExecContext& exec_context) {
-  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
-                        cp::ExecPlan::Make(&exec_context));
-
-  ARROW_ASSIGN_OR_RAISE(auto table, GetTable());
-
-  arrow::AsyncGenerator<std::optional<cp::ExecBatch>> sink_gen;
-  int max_batch_size = 2;
-  auto table_source_options = cp::TableSourceNodeOptions{table, max_batch_size};
-
-  ARROW_ASSIGN_OR_RAISE(
-      cp::ExecNode * source,
-      cp::MakeExecNode("table_source", plan.get(), {}, table_source_options));
-
-  ARROW_RETURN_NOT_OK(
-      cp::MakeExecNode("sink", plan.get(), {source}, cp::SinkNodeOptions{&sink_gen}));
-
-  return ExecutePlanAndCollectAsTable(exec_context, plan, table->schema(), sink_gen);
-}
-// (Doc section: Table Source Example)
-
-// (Doc section: Filter Example)
-
-/// \brief An example showing a filter node
-/// \param exec_context The execution context to run the plan in
-///
-/// Source-Filter-Sink
-/// This example shows how a filter can be used in an execution plan,
-/// along with the source and sink operations. The output from the
-/// exeuction plan is obtained as a table via the sink node.
-arrow::Status ScanFilterSinkExample(cp::ExecContext& exec_context) {
-  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
-                        cp::ExecPlan::Make(&exec_context));
-
-  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<arrow::dataset::Dataset> dataset, GetDataset());
-
-  auto options = std::make_shared<arrow::dataset::ScanOptions>();
-  // specify the filter.  This filter removes all rows where the
-  // value of the "a" column is greater than 3.
-  cp::Expression filter_opt = cp::greater(cp::field_ref("a"), cp::literal(3));
-  // set filter for scanner : on-disk / push-down filtering.
-  // This step can be skipped if you are not reading from disk.
-  options->filter = filter_opt;
-  // empty projection
-  options->projection = cp::project({}, {});
-
-  // construct the scan node
-  std::cout << "Initialized Scanning Options" << std::endl;
-
-  cp::ExecNode* scan;
-
-  auto scan_node_options = arrow::dataset::ScanNodeOptions{dataset, options};
-  std::cout << "Scan node options created" << std::endl;
-
-  ARROW_ASSIGN_OR_RAISE(scan,
-                        cp::MakeExecNode("scan", plan.get(), {}, scan_node_options));
-
-  // pipe the scan node into the filter node
-  // Need to set the filter in scan node options and filter node options.
-  // At scan node it is used for on-disk / push-down filtering.
-  // At filter node it is used for in-memory filtering.
-  cp::ExecNode* filter;
-  ARROW_ASSIGN_OR_RAISE(filter, cp::MakeExecNode("filter", plan.get(), {scan},
-                                                 cp::FilterNodeOptions{filter_opt}));
-
-  // finally, pipe the filter node into a sink node
-  arrow::AsyncGenerator<std::optional<cp::ExecBatch>> sink_gen;
-  ARROW_RETURN_NOT_OK(
-      cp::MakeExecNode("sink", plan.get(), {filter}, cp::SinkNodeOptions{&sink_gen}));
-
-  return ExecutePlanAndCollectAsTable(exec_context, plan, dataset->schema(), sink_gen);
-}
-
-// (Doc section: Filter Example)
-
-// (Doc section: Project Example)
-
-/// \brief An example showing a project node
-/// \param exec_context The execution context to run the plan in
-///
-/// Scan-Project-Sink
-/// This example shows how Scan operation can be used to load the data
-/// into the execution plan, how project operation can be applied on the
-/// data stream and how the output is obtained as a table via the sink node.
-arrow::Status ScanProjectSinkExample(cp::ExecContext& exec_context) {
-  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
-                        cp::ExecPlan::Make(&exec_context));
-
-  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<arrow::dataset::Dataset> dataset, GetDataset());
-
-  auto options = std::make_shared<arrow::dataset::ScanOptions>();
-  // projection
-  cp::Expression a_times_2 = cp::call("multiply", {cp::field_ref("a"), cp::literal(2)});
-  options->projection = cp::project({}, {});
-
-  cp::ExecNode* scan;
-
-  auto scan_node_options = arrow::dataset::ScanNodeOptions{dataset, options};
-
-  ARROW_ASSIGN_OR_RAISE(scan,
-                        cp::MakeExecNode("scan", plan.get(), {}, scan_node_options));
-
-  cp::ExecNode* project;
-  ARROW_ASSIGN_OR_RAISE(project, cp::MakeExecNode("project", plan.get(), {scan},
-                                                  cp::ProjectNodeOptions{{a_times_2}}));
-  // schema after projection => multiply(a, 2): int64
-  std::cout << "Schema after projection : \n"
-            << project->output_schema()->ToString() << std::endl;
-
-  arrow::AsyncGenerator<std::optional<cp::ExecBatch>> sink_gen;
-  ARROW_RETURN_NOT_OK(
-      cp::MakeExecNode("sink", plan.get(), {project}, cp::SinkNodeOptions{&sink_gen}));
-  auto schema = arrow::schema({arrow::field("a * 2", arrow::int32())});
-
-  return ExecutePlanAndCollectAsTable(exec_context, plan, schema, sink_gen);
-}
-
-// (Doc section: Project Example)
-
-// (Doc section: Scalar Aggregate Example)
-
-/// \brief An example showing an aggregation node to aggregate an entire table
-/// \param exec_context The execution context to run the plan in
-///
-/// Source-Aggregation-Sink
-/// This example shows how an aggregation operation can be applied on a
-/// execution plan resulting a scalar output. The source node loads the
-/// data and the aggregation (counting unique types in column 'a')
-/// is applied on this data. The output is obtained from the sink node as a table.
-arrow::Status SourceScalarAggregateSinkExample(cp::ExecContext& exec_context) {
-  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
-                        cp::ExecPlan::Make(&exec_context));
-
-  ARROW_ASSIGN_OR_RAISE(auto basic_data, MakeBasicBatches());
-
-  arrow::AsyncGenerator<std::optional<cp::ExecBatch>> sink_gen;
-
-  auto source_node_options = cp::SourceNodeOptions{basic_data.schema, basic_data.gen()};
-
-  ARROW_ASSIGN_OR_RAISE(cp::ExecNode * source,
-                        cp::MakeExecNode("source", plan.get(), {}, source_node_options));
-  auto aggregate_options =
-      cp::AggregateNodeOptions{/*aggregates=*/{{"sum", nullptr, "a", "sum(a)"}}};
-  ARROW_ASSIGN_OR_RAISE(
-      cp::ExecNode * aggregate,
-      cp::MakeExecNode("aggregate", plan.get(), {source}, std::move(aggregate_options)));
-
-  ARROW_RETURN_NOT_OK(
-      cp::MakeExecNode("sink", plan.get(), {aggregate}, cp::SinkNodeOptions{&sink_gen}));
-  auto schema = arrow::schema({arrow::field("sum(a)", arrow::int32())});
-
-  return ExecutePlanAndCollectAsTable(exec_context, plan, schema, sink_gen);
-}
-// (Doc section: Scalar Aggregate Example)
-
-// (Doc section: Group Aggregate Example)
-
-/// \brief An example showing an aggregation node to perform a group-by operation
-/// \param exec_context The execution context to run the plan in
-///
-/// Source-Aggregation-Sink
-/// This example shows how an aggregation operation can be applied on a
-/// execution plan resulting a grouped output. The source node loads the
-/// data and the aggregation (counting unique types in column 'a') is
-/// applied on this data. The output is obtained from the sink node as a table.
-arrow::Status SourceGroupAggregateSinkExample(cp::ExecContext& exec_context) {
-  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
-                        cp::ExecPlan::Make(&exec_context));
-
-  ARROW_ASSIGN_OR_RAISE(auto basic_data, MakeBasicBatches());
-
-  arrow::AsyncGenerator<std::optional<cp::ExecBatch>> sink_gen;
-
-  auto source_node_options = cp::SourceNodeOptions{basic_data.schema, basic_data.gen()};
-
-  ARROW_ASSIGN_OR_RAISE(cp::ExecNode * source,
-                        cp::MakeExecNode("source", plan.get(), {}, source_node_options));
-  auto options = std::make_shared<cp::CountOptions>(cp::CountOptions::ONLY_VALID);
-  auto aggregate_options =
-      cp::AggregateNodeOptions{/*aggregates=*/{{"hash_count", options, "a", "count(a)"}},
-                               /*keys=*/{"b"}};
-  ARROW_ASSIGN_OR_RAISE(
-      cp::ExecNode * aggregate,
-      cp::MakeExecNode("aggregate", plan.get(), {source}, aggregate_options));
-
-  ARROW_RETURN_NOT_OK(
-      cp::MakeExecNode("sink", plan.get(), {aggregate}, cp::SinkNodeOptions{&sink_gen}));
-  auto schema = arrow::schema({
-      arrow::field("count(a)", arrow::int32()),
-      arrow::field("b", arrow::boolean()),
-  });
-
-  return ExecutePlanAndCollectAsTable(exec_context, plan, schema, sink_gen);
-}
-// (Doc section: Group Aggregate Example)
-
-// (Doc section: ConsumingSink Example)
-
-/// \brief An example showing a consuming sink node
-/// \param exec_context The execution context to run the plan in
-///
-/// Source-Consuming-Sink
-/// This example shows how the data can be consumed within the execution plan
-/// by using a ConsumingSink node. There is no data output from this execution plan.
-arrow::Status SourceConsumingSinkExample(cp::ExecContext& exec_context) {
-  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
-                        cp::ExecPlan::Make(&exec_context));
-
-  ARROW_ASSIGN_OR_RAISE(auto basic_data, MakeBasicBatches());
-
-  auto source_node_options = cp::SourceNodeOptions{basic_data.schema, basic_data.gen()};
-
-  ARROW_ASSIGN_OR_RAISE(cp::ExecNode * source,
-                        cp::MakeExecNode("source", plan.get(), {}, source_node_options));
-
-  std::atomic<uint32_t> batches_seen{0};
-  arrow::Future<> finish = arrow::Future<>::Make();
-  struct CustomSinkNodeConsumer : public cp::SinkNodeConsumer {
-    CustomSinkNodeConsumer(std::atomic<uint32_t>* batches_seen, arrow::Future<> finish)
-        : batches_seen(batches_seen), finish(std::move(finish)) {}
-
-    arrow::Status Init(const std::shared_ptr<arrow::Schema>& schema,
-                       cp::BackpressureControl* backpressure_control,
-                       cp::ExecPlan* plan) override {
-      return arrow::Status::OK();
-    }
-
-    arrow::Status Consume(cp::ExecBatch batch) override {
-      (*batches_seen)++;
-      return arrow::Status::OK();
-    }
-
-    arrow::Future<> Finish() override { return finish; }
-
-    std::atomic<uint32_t>* batches_seen;
-    arrow::Future<> finish;
-  };
-  std::shared_ptr<CustomSinkNodeConsumer> consumer =
-      std::make_shared<CustomSinkNodeConsumer>(&batches_seen, finish);
-
-  cp::ExecNode* consuming_sink;
-
-  ARROW_ASSIGN_OR_RAISE(consuming_sink,
-                        MakeExecNode("consuming_sink", plan.get(), {source},
-                                     cp::ConsumingSinkNodeOptions(consumer)));
-
-  ARROW_RETURN_NOT_OK(consuming_sink->Validate());
-
-  ARROW_RETURN_NOT_OK(plan->Validate());
-  std::cout << "Exec Plan created: " << plan->ToString() << std::endl;
-  // plan start producing
-  ARROW_RETURN_NOT_OK(plan->StartProducing());
-  // Source should finish fairly quickly
-  ARROW_RETURN_NOT_OK(source->finished().status());
-  std::cout << "Source Finished!" << std::endl;
-  // Mark consumption complete, plan should finish
-  finish.MarkFinished(arrow::Status::OK());
-  ARROW_RETURN_NOT_OK(plan->finished().status());
-  return arrow::Status::OK();
-}
-// (Doc section: ConsumingSink Example)
-
-// (Doc section: OrderBySink Example)
-
 /// \brief An example showing an order-by node
-/// \param exec_context The execution context to run the plan in
 ///
 /// Source-OrderBy-Sink
 /// In this example, the data enters through the source node
 /// and the data is ordered in the sink node. The order can be
 /// ASCENDING or DESCENDING and it is configurable. The output
 /// is obtained as a table from the sink node.
-arrow::Status SourceOrderBySinkExample(cp::ExecContext& exec_context) {
+arrow::Status SourceOrderBySinkExample() {
   ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
-                        cp::ExecPlan::Make(&exec_context));
+                        cp::ExecPlan::Make(*cp::threaded_exec_context()));
 
   ARROW_ASSIGN_OR_RAISE(auto basic_data, MakeSortTestBasicBatches());
 
@@ -652,7 +574,7 @@ arrow::Status SourceOrderBySinkExample(cp::ExecContext& exec_context) {
       cp::OrderBySinkNodeOptions{
           cp::SortOptions{{cp::SortKey{"a", cp::SortOrder::Descending}}}, &sink_gen}));
 
-  return ExecutePlanAndCollectAsTable(exec_context, plan, basic_data.schema, sink_gen);
+  return ExecutePlanAndCollectAsTableWithCustomSink(plan, basic_data.schema, sink_gen);
 }
 
 // (Doc section: OrderBySink Example)
@@ -660,44 +582,26 @@ arrow::Status SourceOrderBySinkExample(cp::ExecContext& exec_context) {
 // (Doc section: HashJoin Example)
 
 /// \brief An example showing a hash join node
-/// \param exec_context The execution context to run the plan in
 ///
-/// Source-HashJoin-Sink
+/// Source-HashJoin-Table
 /// This example shows how source node gets the data and how a self-join
 /// is applied on the data. The join options are configurable. The output
-/// is obtained as a table via the sink node.
-arrow::Status SourceHashJoinSinkExample(cp::ExecContext& exec_context) {
+/// is collected into a table.
+arrow::Status SourceHashJoinSinkExample() {
   ARROW_ASSIGN_OR_RAISE(auto input, MakeGroupableBatches());
-  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
-                        cp::ExecPlan::Make(&exec_context));
 
-  arrow::AsyncGenerator<std::optional<cp::ExecBatch>> sink_gen;
-
-  cp::ExecNode* left_source;
-  cp::ExecNode* right_source;
-  for (auto source : {&left_source, &right_source}) {
-    ARROW_ASSIGN_OR_RAISE(*source,
-                          MakeExecNode("source", plan.get(), {},
-                                       cp::SourceNodeOptions{input.schema, input.gen()}));
-  }
+  cp::Declaration left{"source", cp::SourceNodeOptions{input.schema, input.gen()}};
+  cp::Declaration right{"source", cp::SourceNodeOptions{input.schema, input.gen()}};
 
   cp::HashJoinNodeOptions join_opts{
       cp::JoinType::INNER,
       /*left_keys=*/{"str"},
       /*right_keys=*/{"str"}, cp::literal(true), "l_", "r_"};
 
-  ARROW_ASSIGN_OR_RAISE(
-      auto hashjoin,
-      cp::MakeExecNode("hashjoin", plan.get(), {left_source, right_source}, join_opts));
+  cp::Declaration hashjoin{
+      "hashjoin", {std::move(left), std::move(right)}, std::move(join_opts)};
 
-  ARROW_RETURN_NOT_OK(
-      cp::MakeExecNode("sink", plan.get(), {hashjoin}, cp::SinkNodeOptions{&sink_gen}));
-  // expected columns i32, str, l_str, r_str
-  auto schema = arrow::schema(
-      {arrow::field("i32", arrow::int32()), arrow::field("str", arrow::utf8()),
-       arrow::field("l_str", arrow::utf8()), arrow::field("r_str", arrow::utf8())});
-
-  return ExecutePlanAndCollectAsTable(exec_context, plan, schema, sink_gen);
+  return ExecutePlanAndCollectAsTable(std::move(hashjoin));
 }
 
 // (Doc section: HashJoin Example)
@@ -705,16 +609,15 @@ arrow::Status SourceHashJoinSinkExample(cp::ExecContext& exec_context) {
 // (Doc section: KSelect Example)
 
 /// \brief An example showing a select-k node
-/// \param exec_context The execution context to run the plan in
 ///
 /// Source-KSelect
 /// This example shows how K number of elements can be selected
 /// either from the top or bottom. The output node is a modified
 /// sink node where output can be obtained as a table.
-arrow::Status SourceKSelectExample(cp::ExecContext& exec_context) {
+arrow::Status SourceKSelectExample() {
   ARROW_ASSIGN_OR_RAISE(auto input, MakeGroupableBatches());
   ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
-                        cp::ExecPlan::Make(&exec_context));
+                        cp::ExecPlan::Make(*cp::threaded_exec_context()));
   arrow::AsyncGenerator<std::optional<cp::ExecBatch>> sink_gen;
 
   ARROW_ASSIGN_OR_RAISE(
@@ -730,7 +633,7 @@ arrow::Status SourceKSelectExample(cp::ExecContext& exec_context) {
   auto schema = arrow::schema(
       {arrow::field("i32", arrow::int32()), arrow::field("str", arrow::utf8())});
 
-  return ExecutePlanAndCollectAsTable(exec_context, plan, schema, sink_gen);
+  return ExecutePlanAndCollectAsTableWithCustomSink(plan, schema, sink_gen);
 }
 
 // (Doc section: KSelect Example)
@@ -738,29 +641,21 @@ arrow::Status SourceKSelectExample(cp::ExecContext& exec_context) {
 // (Doc section: Write Example)
 
 /// \brief An example showing a write node
-/// \param exec_context The execution context to run the plan in
 /// \param file_path The destination to write to
 ///
 /// Scan-Filter-Write
 /// This example shows how scan node can be used to load the data
 /// and after processing how it can be written to disk.
-arrow::Status ScanFilterWriteExample(cp::ExecContext& exec_context,
-                                     const std::string& file_path) {
-  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
-                        cp::ExecPlan::Make(&exec_context));
-
+arrow::Status ScanFilterWriteExample(const std::string& file_path) {
   ARROW_ASSIGN_OR_RAISE(std::shared_ptr<arrow::dataset::Dataset> dataset, GetDataset());
 
   auto options = std::make_shared<arrow::dataset::ScanOptions>();
   // empty projection
   options->projection = cp::project({}, {});
 
-  cp::ExecNode* scan;
-
   auto scan_node_options = arrow::dataset::ScanNodeOptions{dataset, options};
 
-  ARROW_ASSIGN_OR_RAISE(scan,
-                        cp::MakeExecNode("scan", plan.get(), {}, scan_node_options));
+  cp::Declaration scan{"scan", std::move(scan_node_options)};
 
   arrow::AsyncGenerator<std::optional<cp::ExecBatch>> sink_gen;
 
@@ -793,15 +688,13 @@ arrow::Status ScanFilterWriteExample(cp::ExecContext& exec_context,
 
   arrow::dataset::WriteNodeOptions write_node_options{write_options};
 
-  ARROW_RETURN_NOT_OK(cp::MakeExecNode("write", plan.get(), {scan}, write_node_options));
+  cp::Declaration write{"write", {std::move(scan)}, std::move(write_node_options)};
 
-  ARROW_RETURN_NOT_OK(plan->Validate());
-  std::cout << "Execution Plan Created : " << plan->ToString() << std::endl;
-  // // // start the ExecPlan
-  ARROW_RETURN_NOT_OK(plan->StartProducing());
-  auto future = plan->finished();
-  ARROW_RETURN_NOT_OK(future.status());
-  future.Wait();
+  // Since the write node has no output we simply run the plan to completion and the
+  // data should be written
+  ARROW_RETURN_NOT_OK(cp::DeclarationToStatus(std::move(write)));
+
+  std::cout << "Dataset written to " << base_path << std::endl;
   return arrow::Status::OK();
 }
 
@@ -810,41 +703,23 @@ arrow::Status ScanFilterWriteExample(cp::ExecContext& exec_context,
 // (Doc section: Union Example)
 
 /// \brief An example showing a union node
-/// \param exec_context The execution context to run the plan in
 ///
-/// Source-Union-Sink
+/// Source-Union-Table
 /// This example shows how a union operation can be applied on two
-/// data sources. The output is obtained as a table via the sink
-/// node.
-arrow::Status SourceUnionSinkExample(cp::ExecContext& exec_context) {
+/// data sources. The output is collected into a table.
+arrow::Status SourceUnionSinkExample() {
   ARROW_ASSIGN_OR_RAISE(auto basic_data, MakeBasicBatches());
 
-  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
-                        cp::ExecPlan::Make(&exec_context));
-  arrow::AsyncGenerator<std::optional<cp::ExecBatch>> sink_gen;
-
-  cp::Declaration union_node{"union", cp::ExecNodeOptions{}};
   cp::Declaration lhs{"source",
                       cp::SourceNodeOptions{basic_data.schema, basic_data.gen()}};
   lhs.label = "lhs";
   cp::Declaration rhs{"source",
                       cp::SourceNodeOptions{basic_data.schema, basic_data.gen()}};
   rhs.label = "rhs";
-  union_node.inputs.emplace_back(lhs);
-  union_node.inputs.emplace_back(rhs);
+  cp::Declaration union_plan{
+      "union", {std::move(lhs), std::move(rhs)}, cp::ExecNodeOptions{}};
 
-  cp::CountOptions options(cp::CountOptions::ONLY_VALID);
-  ARROW_ASSIGN_OR_RAISE(
-      auto declr, cp::Declaration::Sequence({
-                                                union_node,
-                                                {"sink", cp::SinkNodeOptions{&sink_gen}},
-                                            })
-                      .AddToPlan(plan.get()));
-
-  ARROW_RETURN_NOT_OK(declr->Validate());
-
-  ARROW_RETURN_NOT_OK(plan->Validate());
-  return ExecutePlanAndCollectAsTable(exec_context, plan, basic_data.schema, sink_gen);
+  return ExecutePlanAndCollectAsTable(std::move(union_plan));
 }
 
 // (Doc section: Union Example)
@@ -852,16 +727,15 @@ arrow::Status SourceUnionSinkExample(cp::ExecContext& exec_context) {
 // (Doc section: Table Sink Example)
 
 /// \brief An example showing a table sink node
-/// \param exec_context The execution context to run the plan in
 ///
 /// TableSink Example
 /// This example shows how a table_sink can be used
 /// in an execution plan. This includes a source node
 /// receiving data as batches and the table sink node
 /// which emits the output as a table.
-arrow::Status TableSinkExample(cp::ExecContext& exec_context) {
+arrow::Status TableSinkExample() {
   ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
-                        cp::ExecPlan::Make(&exec_context));
+                        cp::ExecPlan::Make(*cp::threaded_exec_context()));
 
   ARROW_ASSIGN_OR_RAISE(auto basic_data, MakeBasicBatches());
 
@@ -907,7 +781,7 @@ enum ExampleMode {
 };
 
 int main(int argc, char** argv) {
-  if (argc < 2) {
+  if (argc < 3) {
     // Fake success for CI purposes.
     return EXIT_SUCCESS;
   }
@@ -917,64 +791,62 @@ int main(int argc, char** argv) {
   arrow::Status status;
   // ensure arrow::dataset node factories are in the registry
   arrow::dataset::internal::Initialize();
-  // execution context
-  cp::ExecContext exec_context;
   switch (mode) {
     case SOURCE_SINK:
       PrintBlock("Source Sink Example");
-      status = SourceSinkExample(exec_context);
+      status = SourceSinkExample();
       break;
     case TABLE_SOURCE_SINK:
       PrintBlock("Table Source Sink Example");
-      status = TableSourceSinkExample(exec_context);
+      status = TableSourceSinkExample();
       break;
     case SCAN:
       PrintBlock("Scan Example");
-      status = ScanSinkExample(exec_context);
+      status = ScanSinkExample();
       break;
     case FILTER:
       PrintBlock("Filter Example");
-      status = ScanFilterSinkExample(exec_context);
+      status = ScanFilterSinkExample();
       break;
     case PROJECT:
       PrintBlock("Project Example");
-      status = ScanProjectSinkExample(exec_context);
+      status = ScanProjectSinkExample();
       break;
     case GROUP_AGGREGATION:
       PrintBlock("Aggregate Example");
-      status = SourceGroupAggregateSinkExample(exec_context);
+      status = SourceGroupAggregateSinkExample();
       break;
     case SCALAR_AGGREGATION:
       PrintBlock("Aggregate Example");
-      status = SourceScalarAggregateSinkExample(exec_context);
+      status = SourceScalarAggregateSinkExample();
       break;
     case CONSUMING_SINK:
       PrintBlock("Consuming-Sink Example");
-      status = SourceConsumingSinkExample(exec_context);
+      status = SourceConsumingSinkExample();
       break;
     case ORDER_BY_SINK:
       PrintBlock("OrderBy Example");
-      status = SourceOrderBySinkExample(exec_context);
+      status = SourceOrderBySinkExample();
       break;
     case HASHJOIN:
       PrintBlock("HashJoin Example");
-      status = SourceHashJoinSinkExample(exec_context);
+      status = SourceHashJoinSinkExample();
       break;
     case KSELECT:
       PrintBlock("KSelect Example");
-      status = SourceKSelectExample(exec_context);
+      status = SourceKSelectExample();
       break;
     case WRITE:
       PrintBlock("Write Example");
-      status = ScanFilterWriteExample(exec_context, base_save_path);
+      status = ScanFilterWriteExample(base_save_path);
       break;
     case UNION:
       PrintBlock("Union Example");
-      status = SourceUnionSinkExample(exec_context);
+      status = SourceUnionSinkExample();
       break;
     case TABLE_SOURCE_TABLE_SINK:
       PrintBlock("TableSink Example");
-      status = TableSinkExample(exec_context);
+      status = TableSinkExample();
       break;
     default:
       break;

--- a/cpp/examples/arrow/join_example.cc
+++ b/cpp/examples/arrow/join_example.cc
@@ -82,17 +82,7 @@ arrow::Result<std::shared_ptr<arrow::dataset::Dataset>> CreateDataSetFromCSVData
 }
 
 arrow::Status DoHashJoin() {
-  cp::ExecContext exec_context;
-
   arrow::dataset::internal::Initialize();
-
-  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
-                        cp::ExecPlan::Make(&exec_context));
-
-  arrow::AsyncGenerator<std::optional<cp::ExecBatch>> sink_gen;
-
-  cp::ExecNode* left_source;
-  cp::ExecNode* right_source;
 
   ARROW_ASSIGN_OR_RAISE(auto l_dataset, CreateDataSetFromCSVData(true));
   ARROW_ASSIGN_OR_RAISE(auto r_dataset, CreateDataSetFromCSVData(false));
@@ -111,10 +101,8 @@ arrow::Status DoHashJoin() {
   auto l_scan_node_options = arrow::dataset::ScanNodeOptions{l_dataset, l_options};
   auto r_scan_node_options = arrow::dataset::ScanNodeOptions{r_dataset, r_options};
 
-  ARROW_ASSIGN_OR_RAISE(left_source,
-                        cp::MakeExecNode("scan", plan.get(), {}, l_scan_node_options));
-  ARROW_ASSIGN_OR_RAISE(right_source,
-                        cp::MakeExecNode("scan", plan.get(), {}, r_scan_node_options));
+  arrow::compute::Declaration left{"scan", std::move(l_scan_node_options)};
+  arrow::compute::Declaration right{"scan", std::move(r_scan_node_options)};
 
   arrow::compute::HashJoinNodeOptions join_opts{arrow::compute::JoinType::INNER,
                                                 /*in_left_keys=*/{"lkey"},
@@ -123,26 +111,12 @@ arrow::Status DoHashJoin() {
                                                 /*output_suffix_for_left*/ "_l",
                                                 /*output_suffix_for_right*/ "_r"};
 
-  ARROW_ASSIGN_OR_RAISE(
-      auto hashjoin,
-      cp::MakeExecNode("hashjoin", plan.get(), {left_source, right_source}, join_opts));
+  arrow::compute::Declaration hashjoin{
+      "hashjoin", {std::move(left), std::move(right)}, join_opts};
 
-  ARROW_ASSIGN_OR_RAISE(std::ignore, cp::MakeExecNode("sink", plan.get(), {hashjoin},
-                                                      cp::SinkNodeOptions{&sink_gen}));
   // expected columns l_a, l_b
-  std::shared_ptr<arrow::RecordBatchReader> sink_reader = cp::MakeGeneratorReader(
-      hashjoin->output_schema(), std::move(sink_gen), exec_context.memory_pool());
-
-  // validate the ExecPlan
-  ARROW_RETURN_NOT_OK(plan->Validate());
-  // start the ExecPlan
-  ARROW_RETURN_NOT_OK(plan->StartProducing());
-
-  // collect sink_reader into a Table
-  std::shared_ptr<arrow::Table> response_table;
-
-  ARROW_ASSIGN_OR_RAISE(response_table,
-                        arrow::Table::FromRecordBatchReader(sink_reader.get()));
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<arrow::Table> response_table,
+                        arrow::compute::DeclarationToTable(std::move(hashjoin)));
 
   std::cout << "Results : " << response_table->ToString() << std::endl;
 

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -48,6 +48,7 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/cpu_info.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/thread_pool.h"
 #include "arrow/util/vector.h"
 
 namespace arrow {
@@ -56,12 +57,18 @@ using internal::BitmapAnd;
 using internal::checked_cast;
 using internal::CopyBitmap;
 using internal::CpuInfo;
+using internal::GetCpuThreadPool;
 
 namespace compute {
 
 ExecContext* default_exec_context() {
   static ExecContext default_ctx;
   return &default_ctx;
+}
+
+ExecContext* threaded_exec_context() {
+  static ExecContext threaded_ctx(default_memory_pool(), GetCpuThreadPool());
+  return &threaded_ctx;
 }
 
 ExecBatch::ExecBatch(const RecordBatch& batch)

--- a/cpp/src/arrow/compute/exec/benchmark_util.cc
+++ b/cpp/src/arrow/compute/exec/benchmark_util.cc
@@ -35,7 +35,6 @@ namespace compute {
 // calling InputFinished and InputReceived.
 
 Status BenchmarkIsolatedNodeOverhead(benchmark::State& state,
-                                     arrow::compute::ExecContext ctx,
                                      arrow::compute::Expression expr, int32_t num_batches,
                                      int32_t batch_size,
                                      arrow::compute::BatchesWithSchema data,
@@ -46,7 +45,7 @@ Status BenchmarkIsolatedNodeOverhead(benchmark::State& state,
     AsyncGenerator<std::optional<arrow::compute::ExecBatch>> sink_gen;
 
     ARROW_ASSIGN_OR_RAISE(std::shared_ptr<arrow::compute::ExecPlan> plan,
-                          arrow::compute::ExecPlan::Make(&ctx));
+                          arrow::compute::ExecPlan::Make());
     // Source and sink nodes have no effect on the benchmark.
     // Used for dummy purposes as they are referenced in InputReceived and InputFinished.
     ARROW_ASSIGN_OR_RAISE(arrow::compute::ExecNode * source_node,
@@ -113,13 +112,13 @@ Status BenchmarkIsolatedNodeOverhead(benchmark::State& state,
 // a source -> node_declarations -> sink sequence.
 
 Status BenchmarkNodeOverhead(
-    benchmark::State& state, arrow::compute::ExecContext ctx, int32_t num_batches,
-    int32_t batch_size, arrow::compute::BatchesWithSchema data,
+    benchmark::State& state, int32_t num_batches, int32_t batch_size,
+    arrow::compute::BatchesWithSchema data,
     std::vector<arrow::compute::Declaration>& node_declarations) {
   for (auto _ : state) {
     state.PauseTiming();
     ARROW_ASSIGN_OR_RAISE(std::shared_ptr<arrow::compute::ExecPlan> plan,
-                          arrow::compute::ExecPlan::Make(&ctx));
+                          arrow::compute::ExecPlan::Make());
     AsyncGenerator<std::optional<arrow::compute::ExecBatch>> sink_gen;
     arrow::compute::Declaration source = arrow::compute::Declaration(
         {"source",

--- a/cpp/src/arrow/compute/exec/benchmark_util.h
+++ b/cpp/src/arrow/compute/exec/benchmark_util.h
@@ -29,13 +29,11 @@ namespace arrow {
 
 namespace compute {
 
-Status BenchmarkNodeOverhead(benchmark::State& state, arrow::compute::ExecContext ctx,
-                             int32_t num_batches, int32_t batch_size,
-                             arrow::compute::BatchesWithSchema data,
+Status BenchmarkNodeOverhead(benchmark::State& state, int32_t num_batches,
+                             int32_t batch_size, arrow::compute::BatchesWithSchema data,
                              std::vector<arrow::compute::Declaration>& node_declarations);
 
 Status BenchmarkIsolatedNodeOverhead(benchmark::State& state,
-                                     arrow::compute::ExecContext ctx,
                                      arrow::compute::Expression expr, int32_t num_batches,
                                      int32_t batch_size,
                                      arrow::compute::BatchesWithSchema data,

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -17,6 +17,7 @@
 
 #include "arrow/compute/exec/exec_plan.h"
 
+#include <atomic>
 #include <optional>
 #include <sstream>
 #include <unordered_map>
@@ -43,6 +44,7 @@
 namespace arrow {
 
 using internal::checked_cast;
+using internal::ThreadPool;
 using internal::ToChars;
 
 namespace compute {
@@ -50,9 +52,12 @@ namespace compute {
 namespace {
 
 struct ExecPlanImpl : public ExecPlan {
-  explicit ExecPlanImpl(QueryOptions options, ExecContext* exec_context,
-                        std::shared_ptr<const KeyValueMetadata> metadata = NULLPTR)
-      : metadata_(std::move(metadata)), query_context_(options, *exec_context) {}
+  explicit ExecPlanImpl(QueryOptions options, ExecContext exec_context,
+                        std::shared_ptr<const KeyValueMetadata> metadata = NULLPTR,
+                        std::shared_ptr<ThreadPool> owned_thread_pool = nullptr)
+      : metadata_(std::move(metadata)),
+        query_context_(options, exec_context),
+        owned_thread_pool_(std::move(owned_thread_pool)) {}
 
   ~ExecPlanImpl() override {
     if (started_ && !finished_.is_finished()) {
@@ -90,6 +95,15 @@ struct ExecPlanImpl : public ExecPlan {
     if (started_) {
       return Status::Invalid("restarted ExecPlan");
     }
+    if (query_context_.exec_context()->executor() == nullptr) {
+      return Status::Invalid(
+          "An exec plan must have an executor for CPU tasks.  To run without threads use "
+          "a SerialExeuctor (the arrow::compute::DeclarationTo... methods should take "
+          "care of this for you and are an easier way to execute an ExecPlan.");
+    }
+    if (query_context_.io_context()->executor() == nullptr) {
+      return Status::Invalid("An exec plan must have an I/O executor for I/O tasks.");
+    }
 
     started_ = true;
 
@@ -99,8 +113,8 @@ struct ExecPlanImpl : public ExecPlan {
     // If no source node schedules any tasks (e.g. they do all their word synchronously as
     // part of StartProducing) then the plan may be finished before we return from this
     // call.
-    Future<> scheduler_finished =
-        util::AsyncTaskScheduler::Make([this](util::AsyncTaskScheduler* async_scheduler) {
+    Future<> scheduler_finished = util::AsyncTaskScheduler::Make(
+        [this](util::AsyncTaskScheduler* async_scheduler) {
           QueryContext* ctx = query_context();
           RETURN_NOT_OK(ctx->Init(ctx->max_concurrency(), async_scheduler));
 
@@ -120,6 +134,8 @@ struct ExecPlanImpl : public ExecPlan {
           // away soon (or at least be replaced by a sub-scheduler to facilitate OT)
           for (auto& n : nodes_) {
             RETURN_NOT_OK(n->Init());
+          }
+          for (auto& n : nodes_) {
             async_scheduler->AddSimpleTask([&] { return n->finished(); });
           }
 
@@ -153,18 +169,21 @@ struct ExecPlanImpl : public ExecPlan {
             EVENT(span_, "StartProducing:" + node->label(), {{"status", st.ToString()}});
             if (!st.ok()) {
               // Stop nodes that successfully started, in reverse order
-              stopped_ = true;
-              StopProducingImpl(it.base(), sorted_nodes_.end());
-              for (NodeVector::iterator fw_it = sorted_nodes_.begin(); fw_it != it.base();
-                   ++fw_it) {
-                Future<> fut = (*fw_it)->finished();
-                if (!fut.is_finished()) fut.MarkFinished();
+              bool expected = false;
+              if (stopped_.compare_exchange_strong(expected, true)) {
+                StopProducingImpl(it.base(), sorted_nodes_.end());
+                for (NodeVector::iterator fw_it = sorted_nodes_.begin();
+                     fw_it != it.base(); ++fw_it) {
+                  Future<> fut = (*fw_it)->finished();
+                  if (!fut.is_finished()) fut.MarkFinished();
+                }
               }
               return st;
             }
           }
           return st;
-        });
+        },
+        [this](const Status& st) { StopProducing(); });
     scheduler_finished.AddCallback(
         [this](const Status& st) { finished_.MarkFinished(st); });
     // TODO(weston) Do we really need to return status here?  Could we change this return
@@ -179,9 +198,11 @@ struct ExecPlanImpl : public ExecPlan {
   void StopProducing() {
     DCHECK(started_) << "stopped an ExecPlan which never started";
     EVENT(span_, "StopProducing");
-    stopped_ = true;
-    query_context()->scheduler()->Abort(
-        [this]() { StopProducingImpl(sorted_nodes_.begin(), sorted_nodes_.end()); });
+    bool expected = false;
+    if (stopped_.compare_exchange_strong(expected, true)) {
+      query_context()->scheduler()->Abort(
+          [this]() { StopProducingImpl(sorted_nodes_.begin(), sorted_nodes_.end()); });
+    }
   }
 
   template <typename It>
@@ -289,7 +310,8 @@ struct ExecPlanImpl : public ExecPlan {
 
   Status error_st_;
   Future<> finished_ = Future<>::Make();
-  bool started_ = false, stopped_ = false;
+  bool started_ = false;
+  std::atomic<bool> stopped_{false};
   std::vector<std::unique_ptr<ExecNode>> nodes_;
   NodeVector sources_, sinks_;
   NodeVector sorted_nodes_;
@@ -297,6 +319,9 @@ struct ExecPlanImpl : public ExecPlan {
   util::tracing::Span span_;
   std::shared_ptr<const KeyValueMetadata> metadata_;
   QueryContext query_context_;
+  // This field only exists for backwards compatibility.  Remove once the deprecated
+  // ExecPlan::Make overloads have been removed.
+  std::shared_ptr<ThreadPool> owned_thread_pool_;
 };
 
 ExecPlanImpl* ToDerived(ExecPlan* ptr) { return checked_cast<ExecPlanImpl*>(ptr); }
@@ -318,14 +343,36 @@ std::optional<int> GetNodeIndex(const std::vector<ExecNode*>& nodes,
 const uint32_t ExecPlan::kMaxBatchSize;
 
 Result<std::shared_ptr<ExecPlan>> ExecPlan::Make(
-    QueryOptions opts, ExecContext* ctx,
+    QueryOptions opts, ExecContext ctx,
     std::shared_ptr<const KeyValueMetadata> metadata) {
   return std::shared_ptr<ExecPlan>(new ExecPlanImpl{opts, ctx, std::move(metadata)});
 }
 
 Result<std::shared_ptr<ExecPlan>> ExecPlan::Make(
-    ExecContext* ctx, std::shared_ptr<const KeyValueMetadata> metadata) {
+    ExecContext ctx, std::shared_ptr<const KeyValueMetadata> metadata) {
   return Make(/*opts=*/{}, ctx, std::move(metadata));
+}
+
+// Deprecated and left for backwards compatibility.  If the user does not supply a CPU
+// executor then we will create a 1 thread pool and tie its lifetime to the plan
+Result<std::shared_ptr<ExecPlan>> ExecPlan::Make(
+    QueryOptions opts, ExecContext* ctx,
+    std::shared_ptr<const KeyValueMetadata> metadata) {
+  if (ctx->executor() == nullptr) {
+    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<ThreadPool> tpool, ThreadPool::Make(1));
+    ExecContext actual_ctx(ctx->memory_pool(), tpool.get(), ctx->func_registry());
+    return std::shared_ptr<ExecPlan>(
+        new ExecPlanImpl{opts, actual_ctx, std::move(metadata), std::move(tpool)});
+  }
+  return ExecPlan::Make(opts, *ctx, std::move(metadata));
+}
+
+// Deprecated
+Result<std::shared_ptr<ExecPlan>> ExecPlan::Make(
+    ExecContext* ctx, std::shared_ptr<const KeyValueMetadata> metadata) {
+  ARROW_SUPPRESS_DEPRECATION_WARNING
+  return Make(/*opts=*/{}, ctx, std::move(metadata));
+  ARROW_UNSUPPRESS_DEPRECATION_WARNING
 }
 
 ExecNode* ExecPlan::AddNode(std::unique_ptr<ExecNode> node) {
@@ -503,7 +550,7 @@ bool Declaration::IsValid(ExecFactoryRegistry* registry) const {
 }
 
 Future<std::shared_ptr<Table>> DeclarationToTableAsync(Declaration declaration,
-                                                       ExecContext* exec_context) {
+                                                       ExecContext exec_context) {
   std::shared_ptr<std::shared_ptr<Table>> output_table =
       std::make_shared<std::shared_ptr<Table>>();
   ARROW_ASSIGN_OR_RAISE(std::shared_ptr<ExecPlan> exec_plan,
@@ -511,57 +558,143 @@ Future<std::shared_ptr<Table>> DeclarationToTableAsync(Declaration declaration,
   Declaration with_sink = Declaration::Sequence(
       {declaration, {"table_sink", TableSinkNodeOptions(output_table.get())}});
   ARROW_RETURN_NOT_OK(with_sink.AddToPlan(exec_plan.get()));
+  ARROW_RETURN_NOT_OK(exec_plan->Validate());
   ARROW_RETURN_NOT_OK(exec_plan->StartProducing());
   return exec_plan->finished().Then([exec_plan, output_table] { return *output_table; });
 }
 
+Future<std::shared_ptr<Table>> DeclarationToTableAsync(Declaration declaration,
+                                                       bool use_threads) {
+  if (use_threads) {
+    return DeclarationToTableAsync(std::move(declaration), *threaded_exec_context());
+  } else {
+    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<ThreadPool> tpool, ThreadPool::Make(1));
+    ExecContext ctx(default_memory_pool(), tpool.get());
+    return DeclarationToTableAsync(std::move(declaration), ctx)
+        .Then([tpool](const std::shared_ptr<Table>& table) { return table; });
+  }
+}
+
 Result<std::shared_ptr<Table>> DeclarationToTable(Declaration declaration,
-                                                  ExecContext* exec_context) {
-  return DeclarationToTableAsync(std::move(declaration), exec_context).result();
+                                                  bool use_threads) {
+  return ::arrow::internal::RunSynchronously<Future<std::shared_ptr<Table>>>(
+      [declaration = std::move(declaration)](::arrow::internal::Executor* executor) {
+        ExecContext ctx(default_memory_pool(), executor);
+        return DeclarationToTableAsync(std::move(declaration), ctx);
+      },
+      use_threads);
 }
 
 Future<std::vector<std::shared_ptr<RecordBatch>>> DeclarationToBatchesAsync(
-    Declaration declaration, ExecContext* exec_context) {
+    Declaration declaration, ExecContext exec_context) {
   return DeclarationToTableAsync(std::move(declaration), exec_context)
       .Then([](const std::shared_ptr<Table>& table) {
         return TableBatchReader(table).ToRecordBatches();
       });
 }
 
-Result<std::vector<std::shared_ptr<RecordBatch>>> DeclarationToBatches(
-    Declaration declaration, ExecContext* exec_context) {
-  return DeclarationToBatchesAsync(std::move(declaration), exec_context).result();
+Future<std::vector<std::shared_ptr<RecordBatch>>> DeclarationToBatchesAsync(
+    Declaration declaration, bool use_threads) {
+  if (use_threads) {
+    return DeclarationToBatchesAsync(std::move(declaration), *threaded_exec_context());
+  } else {
+    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<ThreadPool> tpool, ThreadPool::Make(1));
+    ExecContext ctx(default_memory_pool(), tpool.get());
+    return DeclarationToBatchesAsync(std::move(declaration), ctx)
+        .Then([tpool](const std::vector<std::shared_ptr<RecordBatch>>& batches) {
+          return batches;
+        });
+  }
 }
 
-Future<std::vector<ExecBatch>> DeclarationToExecBatchesAsync(Declaration declaration,
-                                                             ExecContext* exec_context) {
+Result<std::vector<std::shared_ptr<RecordBatch>>> DeclarationToBatches(
+    Declaration declaration, bool use_threads) {
+  return ::arrow::internal::RunSynchronously<
+      Future<std::vector<std::shared_ptr<RecordBatch>>>>(
+      [declaration = std::move(declaration)](::arrow::internal::Executor* executor) {
+        ExecContext ctx(default_memory_pool(), executor);
+        return DeclarationToBatchesAsync(std::move(declaration), ctx);
+      },
+      use_threads);
+}
+
+Future<BatchesWithCommonSchema> DeclarationToExecBatchesAsync(Declaration declaration,
+                                                              ExecContext exec_context) {
+  std::shared_ptr<Schema> out_schema;
   AsyncGenerator<std::optional<ExecBatch>> sink_gen;
   ARROW_ASSIGN_OR_RAISE(std::shared_ptr<ExecPlan> exec_plan,
                         ExecPlan::Make(exec_context));
-  Declaration with_sink =
-      Declaration::Sequence({declaration, {"sink", SinkNodeOptions(&sink_gen)}});
+  Declaration with_sink = Declaration::Sequence(
+      {declaration, {"sink", SinkNodeOptions(&sink_gen, &out_schema)}});
   ARROW_RETURN_NOT_OK(with_sink.AddToPlan(exec_plan.get()));
+  ARROW_RETURN_NOT_OK(exec_plan->Validate());
   ARROW_RETURN_NOT_OK(exec_plan->StartProducing());
   auto collected_fut = CollectAsyncGenerator(sink_gen);
   return AllFinished({exec_plan->finished(), Future<>(collected_fut)})
-      .Then([collected_fut, exec_plan]() -> Result<std::vector<ExecBatch>> {
+      .Then([collected_fut, exec_plan,
+             schema = std::move(out_schema)]() -> Result<BatchesWithCommonSchema> {
         ARROW_ASSIGN_OR_RAISE(auto collected, collected_fut.result());
-        return ::arrow::internal::MapVector(
+        std::vector<ExecBatch> exec_batches = ::arrow::internal::MapVector(
             [](std::optional<ExecBatch> batch) { return batch.value_or(ExecBatch()); },
             std::move(collected));
+        return BatchesWithCommonSchema{std::move(exec_batches), schema};
       });
 }
 
-Result<std::vector<ExecBatch>> DeclarationToExecBatches(Declaration declaration,
-                                                        ExecContext* exec_context) {
-  return DeclarationToExecBatchesAsync(std::move(declaration), exec_context).result();
+Future<BatchesWithCommonSchema> DeclarationToExecBatchesAsync(Declaration declaration,
+                                                              bool use_threads) {
+  if (use_threads) {
+    return DeclarationToExecBatchesAsync(std::move(declaration),
+                                         *threaded_exec_context());
+  } else {
+    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<ThreadPool> tpool, ThreadPool::Make(1));
+    ExecContext ctx(default_memory_pool(), tpool.get());
+    return DeclarationToExecBatchesAsync(std::move(declaration), ctx)
+        .Then([tpool](const BatchesWithCommonSchema& batches) { return batches; });
+  }
+}
+
+Result<BatchesWithCommonSchema> DeclarationToExecBatches(Declaration declaration,
+                                                         bool use_threads) {
+  return ::arrow::internal::RunSynchronously<Future<BatchesWithCommonSchema>>(
+      [declaration = std::move(declaration)](::arrow::internal::Executor* executor) {
+        ExecContext ctx(default_memory_pool(), executor);
+        return DeclarationToExecBatchesAsync(std::move(declaration), ctx);
+      },
+      use_threads);
+}
+
+Future<> DeclarationToStatusAsync(Declaration declaration, ExecContext exec_context) {
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<ExecPlan> exec_plan,
+                        ExecPlan::Make(exec_context));
+  ARROW_RETURN_NOT_OK(declaration.AddToPlan(exec_plan.get()));
+  ARROW_RETURN_NOT_OK(exec_plan->Validate());
+  ARROW_RETURN_NOT_OK(exec_plan->StartProducing());
+  // Keep the exec_plan alive until it finishes
+  return exec_plan->finished().Then([exec_plan]() {});
+}
+
+Future<> DeclarationToStatusAsync(Declaration declaration, bool use_threads) {
+  if (use_threads) {
+    return DeclarationToStatusAsync(std::move(declaration), *threaded_exec_context());
+  } else {
+    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<ThreadPool> tpool, ThreadPool::Make(1));
+    ExecContext ctx(default_memory_pool(), tpool.get());
+    return DeclarationToStatusAsync(std::move(declaration), ctx).Then([tpool]() {});
+  }
+}
+
+Status DeclarationToStatus(Declaration declaration, bool use_threads) {
+  return ::arrow::internal::RunSynchronously<Future<>>(
+      [declaration = std::move(declaration)](::arrow::internal::Executor* executor) {
+        ExecContext ctx(default_memory_pool(), executor);
+        return DeclarationToStatusAsync(std::move(declaration), ctx);
+      },
+      use_threads);
 }
 
 namespace {
 struct BatchConverter {
-  explicit BatchConverter(::arrow::internal::Executor* executor)
-      : exec_context(std::make_shared<ExecContext>(default_memory_pool(), executor)) {}
-
   ~BatchConverter() {
     if (!exec_plan) {
       return;
@@ -593,7 +726,6 @@ struct BatchConverter {
         });
   }
 
-  std::shared_ptr<ExecContext> exec_context;
   AsyncGenerator<std::optional<ExecBatch>> exec_batch_gen;
   std::shared_ptr<Schema> schema;
   std::shared_ptr<ExecPlan> exec_plan;
@@ -602,9 +734,9 @@ struct BatchConverter {
 Result<AsyncGenerator<std::shared_ptr<RecordBatch>>> DeclarationToRecordBatchGenerator(
     Declaration declaration, ::arrow::internal::Executor* executor,
     std::shared_ptr<Schema>* out_schema) {
-  auto converter = std::make_shared<BatchConverter>(executor);
-  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<ExecPlan> plan,
-                        ExecPlan::Make(converter->exec_context.get()));
+  auto converter = std::make_shared<BatchConverter>();
+  ExecContext exec_context(default_memory_pool(), executor);
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<ExecPlan> plan, ExecPlan::Make(exec_context));
   Declaration with_sink = Declaration::Sequence(
       {declaration,
        {"sink", SinkNodeOptions(&converter->exec_batch_gen, &converter->schema)}});

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -53,7 +53,7 @@ namespace {
 
 struct ExecPlanImpl : public ExecPlan {
   explicit ExecPlanImpl(QueryOptions options, ExecContext exec_context,
-                        std::shared_ptr<const KeyValueMetadata> metadata = NULLPTR,
+                        std::shared_ptr<const KeyValueMetadata> metadata = nullptr,
                         std::shared_ptr<ThreadPool> owned_thread_pool = nullptr)
       : metadata_(std::move(metadata)),
         query_context_(options, exec_context),
@@ -99,7 +99,7 @@ struct ExecPlanImpl : public ExecPlan {
       return Status::Invalid(
           "An exec plan must have an executor for CPU tasks.  To run without threads use "
           "a SerialExeuctor (the arrow::compute::DeclarationTo... methods should take "
-          "care of this for you and are an easier way to execute an ExecPlan.");
+          "care of this for you and are an easier way to execute an ExecPlan.)");
     }
     if (query_context_.io_context()->executor() == nullptr) {
       return Status::Invalid("An exec plan must have an I/O executor for I/O tasks.");
@@ -490,7 +490,7 @@ std::shared_ptr<RecordBatchReader> MakeGeneratorReader(
       // reading from generator until end is reached.
       std::shared_ptr<RecordBatch> batch;
       RETURN_NOT_OK(ReadNext(&batch));
-      while (batch != NULLPTR) {
+      while (batch != nullptr) {
         RETURN_NOT_OK(ReadNext(&batch));
       }
       return Status::OK();

--- a/cpp/src/arrow/compute/exec/exec_plan.h
+++ b/cpp/src/arrow/compute/exec/exec_plan.h
@@ -54,11 +54,21 @@ class ARROW_EXPORT ExecPlan : public std::enable_shared_from_this<ExecPlan> {
 
   /// Make an empty exec plan
   static Result<std::shared_ptr<ExecPlan>> Make(
-      QueryOptions options, ExecContext* exec_context = default_exec_context(),
+      QueryOptions options, ExecContext exec_context = *threaded_exec_context(),
       std::shared_ptr<const KeyValueMetadata> metadata = NULLPTR);
 
   static Result<std::shared_ptr<ExecPlan>> Make(
-      ExecContext* exec_context = default_exec_context(),
+      ExecContext exec_context = *threaded_exec_context(),
+      std::shared_ptr<const KeyValueMetadata> metadata = NULLPTR);
+
+  ARROW_DEPRECATED("Deprecated in 11.0.0. Use version that takes ExecContext by value.")
+  static Result<std::shared_ptr<ExecPlan>> Make(
+      QueryOptions options, ExecContext* exec_context,
+      std::shared_ptr<const KeyValueMetadata> metadata = NULLPTR);
+
+  ARROW_DEPRECATED("Deprecated in 11.0.0. Use version that takes ExecContext by value.")
+  static Result<std::shared_ptr<ExecPlan>> Make(
+      ExecContext* exec_context,
       std::shared_ptr<const KeyValueMetadata> metadata = NULLPTR);
 
   ExecNode* AddNode(std::unique_ptr<ExecNode> node);
@@ -419,37 +429,116 @@ struct ARROW_EXPORT Declaration {
 /// This method will add a sink node to the declaration to collect results into a
 /// table.  It will then create an ExecPlan from the declaration, start the exec plan,
 /// block until the plan has finished, and return the created table.
-ARROW_EXPORT Result<std::shared_ptr<Table>> DeclarationToTable(
-    Declaration declaration, ExecContext* exec_context = default_exec_context());
+///
+/// If `use_threads` is false then all CPU work will be done on the calling thread.  I/O
+/// tasks will still happen on the I/O executor and may be multi-threaded (but should
+/// not use significant CPU resources)
+ARROW_EXPORT Result<std::shared_ptr<Table>> DeclarationToTable(Declaration declaration,
+                                                               bool use_threads = true);
 
 /// \brief Asynchronous version of \see DeclarationToTable
+///
+/// The behavior of use_threads is slightly different than the synchronous version since
+/// we cannot run synchronously on the calling thread.  Instead, if use_threads=false then
+/// a new thread pool will be created with a single thread and this will be used for all
+/// compute work.
+///
+/// If a custom exec context is provided then the value of `use_threads` will be ignored
+/// and the executor in the custom context will be used.  However, the executor must
+/// exist (cannot be nullptr) and must be kept alive until the future finishes.
 ARROW_EXPORT Future<std::shared_ptr<Table>> DeclarationToTableAsync(
-    Declaration declaration, ExecContext* exec_context = default_exec_context());
+    Declaration declaration, bool use_threads = true);
+
+/// \brief Overload of \see DeclarationToTableAsync accepting a custom exec context
+///
+/// The executor must be specified (cannot be null) and must be kept alive until the
+/// returned future finishes.
+ARROW_EXPORT Future<std::shared_ptr<Table>> DeclarationToTableAsync(
+    Declaration declaration, ExecContext custom_exec_context);
+
+/// \brief a collection of exec batches with a common schema
+struct BatchesWithCommonSchema {
+  std::vector<ExecBatch> batches;
+  std::shared_ptr<Schema> schema;
+};
 
 /// \brief Utility method to run a declaration and collect the results into ExecBatch
 /// vector
 ///
-/// \see DeclarationToTable for details
-ARROW_EXPORT Result<std::vector<ExecBatch>> DeclarationToExecBatches(
-    Declaration declaration, ExecContext* exec_context = default_exec_context());
+/// \see DeclarationToTable for details on threading & execution
+ARROW_EXPORT Result<BatchesWithCommonSchema> DeclarationToExecBatches(
+    Declaration declaration, bool use_threads = true);
 
 /// \brief Asynchronous version of \see DeclarationToExecBatches
-ARROW_EXPORT Future<std::vector<ExecBatch>> DeclarationToExecBatchesAsync(
-    Declaration declaration, ExecContext* exec_context = default_exec_context());
+///
+/// \see DeclarationToTableAsync for details on threading & execution
+ARROW_EXPORT Future<BatchesWithCommonSchema> DeclarationToExecBatchesAsync(
+    Declaration declaration, bool use_threads = true);
+
+/// \brief Overload of \see DeclarationToExecBatchesAsync accepting a custom exec context
+///
+/// \see DeclarationToTableAsync for details on threading & execution
+ARROW_EXPORT Future<BatchesWithCommonSchema> DeclarationToExecBatchesAsync(
+    Declaration declaration, ExecContext custom_exec_context);
 
 /// \brief Utility method to run a declaration and collect the results into a vector
 ///
-/// \see DeclarationToTable for details
+/// \see DeclarationToTable for details on threading & execution
 ARROW_EXPORT Result<std::vector<std::shared_ptr<RecordBatch>>> DeclarationToBatches(
-    Declaration declaration, ExecContext* exec_context = default_exec_context());
+    Declaration declaration, bool use_threads = true);
 
 /// \brief Asynchronous version of \see DeclarationToBatches
+///
+/// \see DeclarationToTableAsync for details on threading & execution
 ARROW_EXPORT Future<std::vector<std::shared_ptr<RecordBatch>>> DeclarationToBatchesAsync(
-    Declaration declaration, ExecContext* exec_context = default_exec_context());
+    Declaration declaration, bool use_threads = true);
+
+/// \brief Overload of \see DeclarationToBatchesAsync accepting a custom exec context
+///
+/// \see DeclarationToTableAsync for details on threading & execution
+ARROW_EXPORT Future<std::vector<std::shared_ptr<RecordBatch>>> DeclarationToBatchesAsync(
+    Declaration declaration, ExecContext exec_context);
 
 /// \brief Utility method to run a declaration and return results as a RecordBatchReader
+///
+/// If an exec context is not provided then a default exec context will be used based
+/// on the value of `use_threads`.  If `use_threads` is false then the CPU exeuctor will
+/// be a serial executor and all CPU work will be done on the calling thread.  I/O tasks
+/// will still happen on the I/O executor and may be multi-threaded.
+///
+/// If `use_threads` is false then all CPU work will happen during the calls to
+/// RecordBatchReader::Next and no CPU work will happen in the background.  If
+/// `use_threads` is true then CPU work will happen on the CPU thread pool and tasks may
+/// run in between calls to RecordBatchReader::Next.  If the returned reader is not
+/// consumed quickly enough then the plan will eventually pause as the backpressure queue
+/// fills up.
+///
+/// If a custom exec context is provided then the value of `use_threads` will be ignored.
 ARROW_EXPORT Result<std::unique_ptr<RecordBatchReader>> DeclarationToReader(
-    Declaration declaration, bool use_threads);
+    Declaration declaration, bool use_threads = true);
+
+/// \brief Utility method to run a declaration and ignore results
+///
+/// This can be useful when the data are consumed as part of the plan itself, for
+/// example, when the plan ends with a write node.
+///
+/// \see DeclarationToTable for details on threading & execution
+ARROW_EXPORT Status DeclarationToStatus(Declaration declaration, bool use_threads = true);
+
+/// \brief Asynchronous version of \see DeclarationToStatus
+///
+/// This can be useful when the data are consumed as part of the plan itself, for
+/// example, when the plan ends with a write node.
+///
+/// \see DeclarationToTableAsync for details on threading & execution
+ARROW_EXPORT Future<> DeclarationToStatusAsync(Declaration declaration,
+                                               bool use_threads = true);
+
+/// \brief Overload of \see DeclarationToStatusAsync accepting a custom exec context
+///
+/// \see DeclarationToTableAsync for details on threading & execution
+ARROW_EXPORT Future<> DeclarationToStatusAsync(Declaration declaration,
+                                               ExecContext exec_context);
 
 /// \brief Wrap an ExecBatch generator in a RecordBatchReader.
 ///

--- a/cpp/src/arrow/compute/exec/exec_plan.h
+++ b/cpp/src/arrow/compute/exec/exec_plan.h
@@ -442,10 +442,6 @@ ARROW_EXPORT Result<std::shared_ptr<Table>> DeclarationToTable(Declaration decla
 /// we cannot run synchronously on the calling thread.  Instead, if use_threads=false then
 /// a new thread pool will be created with a single thread and this will be used for all
 /// compute work.
-///
-/// If a custom exec context is provided then the value of `use_threads` will be ignored
-/// and the executor in the custom context will be used.  However, the executor must
-/// exist (cannot be nullptr) and must be kept alive until the future finishes.
 ARROW_EXPORT Future<std::shared_ptr<Table>> DeclarationToTableAsync(
     Declaration declaration, bool use_threads = true);
 

--- a/cpp/src/arrow/compute/exec/filter_benchmark.cc
+++ b/cpp/src/arrow/compute/exec/filter_benchmark.cc
@@ -76,23 +76,20 @@ static void FilterOverhead(benchmark::State& state, std::vector<Expression> expr
   arrow::compute::BatchesWithSchema data = MakeRandomBatchesWithNullProbability(
       schema({field("i64", int64()), field("bool", boolean())}), num_batches, batch_size,
       null_prob, bool_true_probability);
-  ExecContext ctx(default_memory_pool(), arrow::internal::GetCpuThreadPool());
   std::vector<arrow::compute::Declaration> filter_node_dec;
   for (Expression expr : expr_vector) {
     filter_node_dec.push_back({"filter", FilterNodeOptions(expr)});
   }
-  ASSERT_OK(
-      BenchmarkNodeOverhead(state, ctx, num_batches, batch_size, data, filter_node_dec));
+  ASSERT_OK(BenchmarkNodeOverhead(state, num_batches, batch_size, data, filter_node_dec));
 }
 
 static void FilterOverheadIsolated(benchmark::State& state, Expression expr) {
-  ExecContext ctx(default_memory_pool(), arrow::internal::GetCpuThreadPool());
   const int32_t batch_size = static_cast<int32_t>(state.range(0));
   const int32_t num_batches = kTotalBatchSize / batch_size;
   arrow::compute::BatchesWithSchema data = MakeRandomBatches(
       schema({field("i64", int64()), field("bool", boolean())}), num_batches, batch_size);
   FilterNodeOptions options = FilterNodeOptions{expr};
-  ASSERT_OK(BenchmarkIsolatedNodeOverhead(state, ctx, expr, num_batches, batch_size, data,
+  ASSERT_OK(BenchmarkIsolatedNodeOverhead(state, expr, num_batches, batch_size, data,
                                           "filter", options));
 }
 

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -199,8 +199,8 @@ constexpr int32_t kDefaultBackpressureLowBytes = 1 << 28;   // 256MiB
 class ARROW_EXPORT BackpressureMonitor {
  public:
   virtual ~BackpressureMonitor() = default;
-  virtual uint64_t bytes_in_use() const = 0;
-  virtual bool is_paused() const = 0;
+  virtual uint64_t bytes_in_use() = 0;
+  virtual bool is_paused() = 0;
 };
 
 /// \brief Options to control backpressure behavior

--- a/cpp/src/arrow/compute/exec/project_benchmark.cc
+++ b/cpp/src/arrow/compute/exec/project_benchmark.cc
@@ -44,11 +44,10 @@ static void ProjectionOverhead(benchmark::State& state, Expression expr) {
 
   arrow::compute::BatchesWithSchema data = MakeRandomBatches(
       schema({field("i64", int64()), field("bool", boolean())}), num_batches, batch_size);
-  ExecContext ctx(default_memory_pool(), arrow::internal::GetCpuThreadPool());
   std::vector<arrow::compute::Declaration> project_node_dec = {
       {"project", ProjectNodeOptions{{expr}}}};
   ASSERT_OK(
-      BenchmarkNodeOverhead(state, ctx, num_batches, batch_size, data, project_node_dec));
+      BenchmarkNodeOverhead(state, num_batches, batch_size, data, project_node_dec));
 }
 
 static void ProjectionOverheadIsolated(benchmark::State& state, Expression expr) {
@@ -57,9 +56,8 @@ static void ProjectionOverheadIsolated(benchmark::State& state, Expression expr)
 
   arrow::compute::BatchesWithSchema data = MakeRandomBatches(
       schema({field("i64", int64()), field("bool", boolean())}), num_batches, batch_size);
-  ExecContext ctx(default_memory_pool(), arrow::internal::GetCpuThreadPool());
   ProjectNodeOptions options = ProjectNodeOptions{{expr}};
-  ASSERT_OK(BenchmarkIsolatedNodeOverhead(state, ctx, expr, num_batches, batch_size, data,
+  ASSERT_OK(BenchmarkIsolatedNodeOverhead(state, expr, num_batches, batch_size, data,
                                           "project", options));
 }
 

--- a/cpp/src/arrow/compute/exec/query_context.cc
+++ b/cpp/src/arrow/compute/exec/query_context.cc
@@ -62,7 +62,6 @@ Result<Future<>> QueryContext::BeginExternalTask() {
 
 Status QueryContext::ScheduleTask(std::function<Status()> fn) {
   ::arrow::internal::Executor* exec = executor();
-  if (!exec) return fn();
   // Adds a task which submits fn to the executor and tracks its progress.  If we're
   // already stopping then the task is ignored and fn is not executed.
   async_scheduler_->AddSimpleTask([exec, fn]() { return exec->Submit(std::move(fn)); });

--- a/cpp/src/arrow/compute/exec/test_util.cc
+++ b/cpp/src/arrow/compute/exec/test_util.cc
@@ -300,8 +300,8 @@ Result<std::shared_ptr<Table>> SortTableOnAllFields(const std::shared_ptr<Table>
   return tab_sorted.table();
 }
 
-void AssertTablesEqual(const std::shared_ptr<Table>& exp,
-                       const std::shared_ptr<Table>& act) {
+void AssertTablesEqualIgnoringOrder(const std::shared_ptr<Table>& exp,
+                                    const std::shared_ptr<Table>& act) {
   ASSERT_EQ(exp->num_columns(), act->num_columns());
   if (exp->num_rows() == 0) {
     ASSERT_EQ(exp->num_rows(), act->num_rows());
@@ -314,12 +314,12 @@ void AssertTablesEqual(const std::shared_ptr<Table>& exp,
   }
 }
 
-void AssertExecBatchesEqual(const std::shared_ptr<Schema>& schema,
-                            const std::vector<ExecBatch>& exp,
-                            const std::vector<ExecBatch>& act) {
+void AssertExecBatchesEqualIgnoringOrder(const std::shared_ptr<Schema>& schema,
+                                         const std::vector<ExecBatch>& exp,
+                                         const std::vector<ExecBatch>& act) {
   ASSERT_OK_AND_ASSIGN(auto exp_tab, TableFromExecBatches(schema, exp));
   ASSERT_OK_AND_ASSIGN(auto act_tab, TableFromExecBatches(schema, act));
-  AssertTablesEqual(exp_tab, act_tab);
+  AssertTablesEqualIgnoringOrder(exp_tab, act_tab);
 }
 
 template <typename T>

--- a/cpp/src/arrow/compute/exec/test_util.cc
+++ b/cpp/src/arrow/compute/exec/test_util.cc
@@ -292,8 +292,8 @@ Result<std::vector<std::shared_ptr<RecordBatch>>> ToRecordBatches(
 
 Result<std::shared_ptr<Table>> SortTableOnAllFields(const std::shared_ptr<Table>& tab) {
   std::vector<SortKey> sort_keys;
-  for (auto&& f : tab->schema()->fields()) {
-    sort_keys.emplace_back(f->name());
+  for (int i = 0; i < tab->num_columns(); i++) {
+    sort_keys.emplace_back(i);
   }
   ARROW_ASSIGN_OR_RAISE(auto sort_ids, SortIndices(tab, SortOptions(sort_keys)));
   ARROW_ASSIGN_OR_RAISE(auto tab_sorted, Take(tab, sort_ids));

--- a/cpp/src/arrow/compute/exec/test_util.h
+++ b/cpp/src/arrow/compute/exec/test_util.h
@@ -143,13 +143,13 @@ ARROW_TESTING_EXPORT
 Result<std::shared_ptr<Table>> SortTableOnAllFields(const std::shared_ptr<Table>& tab);
 
 ARROW_TESTING_EXPORT
-void AssertTablesEqual(const std::shared_ptr<Table>& exp,
-                       const std::shared_ptr<Table>& act);
+void AssertTablesEqualIgnoringOrder(const std::shared_ptr<Table>& exp,
+                                    const std::shared_ptr<Table>& act);
 
 ARROW_TESTING_EXPORT
-void AssertExecBatchesEqual(const std::shared_ptr<Schema>& schema,
-                            const std::vector<ExecBatch>& exp,
-                            const std::vector<ExecBatch>& act);
+void AssertExecBatchesEqualIgnoringOrder(const std::shared_ptr<Schema>& schema,
+                                         const std::vector<ExecBatch>& exp,
+                                         const std::vector<ExecBatch>& act);
 
 ARROW_TESTING_EXPORT
 bool operator==(const Declaration&, const Declaration&);

--- a/cpp/src/arrow/compute/exec/tpch_benchmark.cc
+++ b/cpp/src/arrow/compute/exec/tpch_benchmark.cc
@@ -31,9 +31,7 @@ namespace internal {
 
 std::shared_ptr<ExecPlan> Plan_Q1(AsyncGenerator<std::optional<ExecBatch>>* sink_gen,
                                   int scale_factor) {
-  ExecContext* ctx = default_exec_context();
-  *ctx = ExecContext(default_memory_pool(), arrow::internal::GetCpuThreadPool());
-  std::shared_ptr<ExecPlan> plan = *ExecPlan::Make(ctx);
+  std::shared_ptr<ExecPlan> plan = *ExecPlan::Make();
   std::unique_ptr<TpchGen> gen =
       *TpchGen::Make(plan.get(), static_cast<double>(scale_factor));
 

--- a/cpp/src/arrow/compute/exec/tpch_node_test.cc
+++ b/cpp/src/arrow/compute/exec/tpch_node_test.cc
@@ -65,7 +65,7 @@ Status AddTableAndSinkToPlan(ExecPlan& plan, TpchGen& gen,
 Result<std::vector<ExecBatch>> GenerateTable(TableNodeFn table,
                                              double scale_factor = kDefaultScaleFactor) {
   ExecContext ctx(default_memory_pool(), arrow::internal::GetCpuThreadPool());
-  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<ExecPlan> plan, ExecPlan::Make(&ctx));
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<ExecPlan> plan, ExecPlan::Make(ctx));
   ARROW_ASSIGN_OR_RAISE(std::unique_ptr<TpchGen> gen,
                         TpchGen::Make(plan.get(), scale_factor));
   AsyncGenerator<std::optional<ExecBatch>> sink_gen;
@@ -624,7 +624,7 @@ TEST(TpchNode, AllTables) {
 
   std::array<AsyncGenerator<std::optional<ExecBatch>>, kNumTables> gens;
   ExecContext ctx(default_memory_pool(), arrow::internal::GetCpuThreadPool());
-  ASSERT_OK_AND_ASSIGN(std::shared_ptr<ExecPlan> plan, ExecPlan::Make(&ctx));
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<ExecPlan> plan, ExecPlan::Make(ctx));
   ASSERT_OK_AND_ASSIGN(std::unique_ptr<TpchGen> gen,
                        TpchGen::Make(plan.get(), kScaleFactor));
   for (int i = 0; i < kNumTables; i++) {

--- a/cpp/src/arrow/compute/kernels/hash_aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate_test.cc
@@ -189,7 +189,7 @@ Result<Datum> GroupByUsingExecPlan(const BatchesWithSchema& input,
     const std::shared_ptr<Array>& arr = out_arrays[i + aggregates.size()];
     key_columns.push_back(arr);
     key_fields.push_back(field("name_does_not_matter", arr->type()));
-    sort_keys.emplace_back(i);
+    sort_keys.emplace_back(static_cast<int>(i));
   }
   std::shared_ptr<Schema> key_schema = schema(std::move(key_fields));
   std::shared_ptr<Table> key_table = Table::Make(std::move(key_schema), key_columns);

--- a/cpp/src/arrow/compute/type_fwd.h
+++ b/cpp/src/arrow/compute/type_fwd.h
@@ -56,6 +56,7 @@ struct QueryOptions;
 class SinkNodeConsumer;
 
 ARROW_EXPORT ExecContext* default_exec_context();
+ARROW_EXPORT ExecContext* threaded_exec_context();
 
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -444,14 +444,6 @@ class DatasetWritingSinkNodeConsumer : public compute::SinkNodeConsumer {
 
 Status FileSystemDataset::Write(const FileSystemDatasetWriteOptions& write_options,
                                 std::shared_ptr<Scanner> scanner) {
-  const io::IOContext& io_context = scanner->options()->io_context;
-  auto cpu_executor =
-      scanner->options()->use_threads ? ::arrow::internal::GetCpuThreadPool() : nullptr;
-  std::shared_ptr<compute::ExecContext> exec_context =
-      std::make_shared<compute::ExecContext>(io_context.pool(), cpu_executor);
-
-  ARROW_ASSIGN_OR_RAISE(auto plan, compute::ExecPlan::Make(exec_context.get()));
-
   auto exprs = scanner->options()->projection.call()->arguments;
   auto names = checked_cast<const compute::MakeStructOptions*>(
                    scanner->options()->projection.call()->options.get())
@@ -462,19 +454,14 @@ Status FileSystemDataset::Write(const FileSystemDatasetWriteOptions& write_optio
   // when reading from a single input file.
   const auto& custom_metadata = scanner->options()->projected_schema->metadata();
 
-  RETURN_NOT_OK(
-      compute::Declaration::Sequence(
-          {
-              {"scan", ScanNodeOptions{dataset, scanner->options()}},
-              {"filter", compute::FilterNodeOptions{scanner->options()->filter}},
-              {"project",
-               compute::ProjectNodeOptions{std::move(exprs), std::move(names)}},
-              {"write", WriteNodeOptions{write_options, custom_metadata}},
-          })
-          .AddToPlan(plan.get()));
+  compute::Declaration plan = compute::Declaration::Sequence({
+      {"scan", ScanNodeOptions{dataset, scanner->options()}},
+      {"filter", compute::FilterNodeOptions{scanner->options()->filter}},
+      {"project", compute::ProjectNodeOptions{std::move(exprs), std::move(names)}},
+      {"write", WriteNodeOptions{write_options, custom_metadata}},
+  });
 
-  RETURN_NOT_OK(plan->StartProducing());
-  return plan->finished().status();
+  return compute::DeclarationToStatus(std::move(plan), scanner->options()->use_threads);
 }
 
 Result<compute::ExecNode*> MakeWriteNode(compute::ExecPlan* plan,

--- a/cpp/src/arrow/dataset/file_test.cc
+++ b/cpp/src/arrow/dataset/file_test.cc
@@ -394,7 +394,8 @@ class FileSystemWriteTest : public testing::TestWithParam<std::tuple<bool, bool>
     if (has_output) {
       ASSERT_FINISHES_OK_AND_ASSIGN(auto out_batches,
                                     cp::StartAndCollect(plan.get(), sink_gen));
-      cp::AssertExecBatchesEqual(source_data.schema, source_data.batches, out_batches);
+      cp::AssertExecBatchesEqualIgnoringOrder(source_data.schema, source_data.batches,
+                                              out_batches);
     } else {
       ASSERT_FINISHES_OK(cp::StartAndFinish(plan.get()));
     }
@@ -417,7 +418,8 @@ class FileSystemWriteTest : public testing::TestWithParam<std::tuple<bool, bool>
 
     ASSERT_FINISHES_OK_AND_ASSIGN(auto written_batches,
                                   cp::StartAndCollect(plan.get(), sink_gen));
-    cp::AssertExecBatchesEqual(source_data.schema, source_data.batches, written_batches);
+    cp::AssertExecBatchesEqualIgnoringOrder(source_data.schema, source_data.batches,
+                                            written_batches);
   }
 };
 

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -265,6 +265,7 @@ class AsyncScanner : public Scanner, public std::enable_shared_from_this<AsyncSc
   Result<std::shared_ptr<Table>> Head(int64_t num_rows) override;
   Result<std::shared_ptr<Table>> ToTable() override;
   Result<int64_t> CountRows() override;
+  Future<int64_t> CountRowsAsync() override;
   Result<std::shared_ptr<RecordBatchReader>> ToRecordBatchReader() override;
   const std::shared_ptr<Dataset>& dataset() const override;
 
@@ -274,6 +275,7 @@ class AsyncScanner : public Scanner, public std::enable_shared_from_this<AsyncSc
   Result<EnumeratedRecordBatchGenerator> ScanBatchesUnorderedAsync(
       Executor* executor, bool sequence_fragments, bool use_legacy_batching = false);
   Future<std::shared_ptr<Table>> ToTableAsync(Executor* executor);
+  Future<int64_t> CountRowsAsync(Executor* executor);
 
   Result<FragmentGenerator> GetFragments() const;
 
@@ -369,20 +371,25 @@ Result<FragmentGenerator> AsyncScanner::GetFragments() const {
 }
 
 Result<TaggedRecordBatchIterator> AsyncScanner::ScanBatches() {
-  ARROW_ASSIGN_OR_RAISE(auto batches_gen,
-                        ScanBatchesAsync(::arrow::internal::GetCpuThreadPool()));
-  return MakeGeneratorIterator(std::move(batches_gen));
+  return ::arrow::internal::IterateSynchronously<TaggedRecordBatch>(
+      [this](::arrow::internal::Executor* executor) {
+        return ScanBatchesAsync(executor);
+      },
+      scan_options_->use_threads);
 }
 
 Result<EnumeratedRecordBatchIterator> AsyncScanner::ScanBatchesUnordered() {
-  ARROW_ASSIGN_OR_RAISE(auto batches_gen,
-                        ScanBatchesUnorderedAsync(::arrow::internal::GetCpuThreadPool()));
-  return MakeGeneratorIterator(std::move(batches_gen));
+  return ::arrow::internal::IterateSynchronously<EnumeratedRecordBatch>(
+      [this](::arrow::internal::Executor* executor) {
+        return ScanBatchesUnorderedAsync(executor);
+      },
+      scan_options_->use_threads);
 }
 
 Result<std::shared_ptr<Table>> AsyncScanner::ToTable() {
-  auto table_fut = ToTableAsync(::arrow::internal::GetCpuThreadPool());
-  return table_fut.result();
+  return ::arrow::internal::RunSynchronously<Future<std::shared_ptr<Table>>>(
+      [this](::arrow::internal::Executor* executor) { return ToTableAsync(executor); },
+      scan_options_->use_threads);
 }
 
 Result<EnumeratedRecordBatchGenerator> AsyncScanner::ScanBatchesUnorderedAsync() {
@@ -414,10 +421,6 @@ Result<EnumeratedRecordBatch> ToEnumeratedRecordBatch(
 
 Result<EnumeratedRecordBatchGenerator> AsyncScanner::ScanBatchesUnorderedAsync(
     Executor* cpu_executor, bool sequence_fragments, bool use_legacy_batching) {
-  if (!scan_options_->use_threads) {
-    cpu_executor = nullptr;
-  }
-
   RETURN_NOT_OK(NormalizeScanOptions(scan_options_, dataset_->schema()));
 
   auto exec_context =
@@ -427,7 +430,7 @@ Result<EnumeratedRecordBatchGenerator> AsyncScanner::ScanBatchesUnorderedAsync(
   query_options.use_legacy_batching = use_legacy_batching;
 
   ARROW_ASSIGN_OR_RAISE(auto plan,
-                        compute::ExecPlan::Make(query_options, exec_context.get()));
+                        compute::ExecPlan::Make(query_options, *exec_context.get()));
   AsyncGenerator<std::optional<compute::ExecBatch>> sink_gen;
 
   auto exprs = scan_options_->projection.call()->arguments;
@@ -701,14 +704,12 @@ Future<std::shared_ptr<Table>> AsyncScanner::ToTableAsync(Executor* cpu_executor
   });
 }
 
-Result<int64_t> AsyncScanner::CountRows() {
+Future<int64_t> AsyncScanner::CountRowsAsync(Executor* executor) {
   ARROW_ASSIGN_OR_RAISE(auto fragment_gen, GetFragments());
 
-  auto cpu_executor =
-      scan_options_->use_threads ? ::arrow::internal::GetCpuThreadPool() : nullptr;
-  compute::ExecContext exec_context(scan_options_->pool, cpu_executor);
+  compute::ExecContext exec_context(scan_options_->pool, executor);
 
-  ARROW_ASSIGN_OR_RAISE(auto plan, compute::ExecPlan::Make(&exec_context));
+  ARROW_ASSIGN_OR_RAISE(auto plan, compute::ExecPlan::Make(exec_context));
   // Drop projection since we only need to count rows
   const auto options = std::make_shared<ScanOptions>(*scan_options_);
   ARROW_ASSIGN_OR_RAISE(auto empty_projection,
@@ -716,16 +717,17 @@ Result<int64_t> AsyncScanner::CountRows() {
                                                    *scan_options_->dataset_schema));
   SetProjection(options.get(), empty_projection);
 
-  std::atomic<int64_t> total{0};
+  auto total = std::make_shared<std::atomic<int64_t>>(0);
 
   fragment_gen = MakeMappedGenerator(
-      std::move(fragment_gen), [&](const std::shared_ptr<Fragment>& fragment) {
+      std::move(fragment_gen),
+      [options, total](const std::shared_ptr<Fragment>& fragment) {
         return fragment->CountRows(options->filter, options)
-            .Then([&, fragment](std::optional<int64_t> fast_count) mutable
+            .Then([options, total, fragment](std::optional<int64_t> fast_count) mutable
                   -> std::shared_ptr<Fragment> {
               if (fast_count) {
                 // fast path: got row count directly; skip scanning this fragment
-                total += *fast_count;
+                (*total) += *fast_count;
                 return std::make_shared<InMemoryFragment>(options->dataset_schema,
                                                           RecordBatchVector{});
               }
@@ -735,30 +737,35 @@ Result<int64_t> AsyncScanner::CountRows() {
             });
       });
 
-  AsyncGenerator<std::optional<compute::ExecBatch>> sink_gen;
+  compute::Declaration count_plan = compute::Declaration::Sequence(
+      {{"scan",
+        ScanNodeOptions{std::make_shared<FragmentDataset>(scan_options_->dataset_schema,
+                                                          std::move(fragment_gen)),
+                        options}},
+       {"project", compute::ProjectNodeOptions{{options->filter}, {"mask"}}},
+       {"aggregate", compute::AggregateNodeOptions{{compute::Aggregate{
+                         "sum", nullptr, "mask", "selected_count"}}}}});
 
-  RETURN_NOT_OK(
-      compute::Declaration::Sequence(
-          {
-              {"scan", ScanNodeOptions{std::make_shared<FragmentDataset>(
-                                           scan_options_->dataset_schema,
-                                           std::move(fragment_gen)),
-                                       options}},
-              {"project", compute::ProjectNodeOptions{{options->filter}, {"mask"}}},
-              {"aggregate", compute::AggregateNodeOptions{{compute::Aggregate{
-                                "sum", nullptr, "mask", "selected_count"}}}},
-              {"sink", compute::SinkNodeOptions{&sink_gen}},
-          })
-          .AddToPlan(plan.get()));
+  return compute::DeclarationToBatchesAsync(std::move(count_plan), exec_context)
+      .Then([total](const RecordBatchVector& batches) -> Result<int64_t> {
+        DCHECK_EQ(1, batches.size());
+        ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> count_scalar,
+                              batches[0]->column(0)->GetScalar(0));
+        return total->load() +
+               static_cast<int64_t>(
+                   ::arrow::internal::checked_pointer_cast<UInt64Scalar>(count_scalar)
+                       ->value);
+      });
+}
 
-  RETURN_NOT_OK(plan->StartProducing());
-  auto maybe_slow_count = sink_gen().result();
-  plan->finished().Wait();
+Future<int64_t> AsyncScanner::CountRowsAsync() {
+  return CountRowsAsync(::arrow::internal::GetCpuThreadPool());
+}
 
-  ARROW_ASSIGN_OR_RAISE(auto slow_count, maybe_slow_count);
-  total += slow_count->values[0].scalar_as<UInt64Scalar>().value;
-
-  return total.load();
+Result<int64_t> AsyncScanner::CountRows() {
+  return ::arrow::internal::RunSynchronously<Future<int64_t>>(
+      [this](Executor* executor) { return CountRowsAsync(executor); },
+      scan_options_->use_threads);
 }
 
 Result<std::shared_ptr<RecordBatchReader>> AsyncScanner::ToRecordBatchReader() {

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -419,6 +419,7 @@ class ARROW_DS_EXPORT Scanner {
   /// This method will push down the predicate and compute the result based on fragment
   /// metadata if possible.
   virtual Result<int64_t> CountRows() = 0;
+  virtual Future<int64_t> CountRowsAsync() = 0;
   /// \brief Convert the Scanner to a RecordBatchReader so it can be
   /// easily used with APIs that expect a reader.
   virtual Result<std::shared_ptr<RecordBatchReader>> ToRecordBatchReader() = 0;

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -787,10 +787,10 @@ TEST(TestNewScanner, NoColumns) {
   test_dataset->DeliverBatchesInOrder(false);
 
   ScanV2Options options(test_dataset);
-  ASSERT_OK_AND_ASSIGN(std::vector<compute::ExecBatch> batches,
+  ASSERT_OK_AND_ASSIGN(compute::BatchesWithCommonSchema batches_and_schema,
                        compute::DeclarationToExecBatches({"scan2", options}));
-  ASSERT_EQ(16, batches.size());
-  for (const auto& batch : batches) {
+  ASSERT_EQ(16, batches_and_schema.batches.size());
+  for (const auto& batch : batches_and_schema.batches) {
     ASSERT_EQ(0, batch.values.size());
     ASSERT_EQ(kRowsPerTestBatch, batch.length);
   }
@@ -1808,7 +1808,6 @@ TEST_F(TestReordering, ScanBatchesUnordered) {
   auto scanner = MakeScanner();
   ASSERT_OK_AND_ASSIGN(auto batch_gen, scanner->ScanBatchesUnorderedAsync());
   auto collected = DeliverAndCollect({0, 0, 1, 1, 0}, std::move(batch_gen));
-  AssertBatchesInOrder(collected, {0, 0, 1, 1, 2}, {0, 2, 3, 1, 4});
 }
 
 static constexpr uint64_t kBatchSizeBytes = 40;
@@ -1897,7 +1896,7 @@ TEST_F(TestBackpressure, ScanBatchesUnordered) {
   // will make it down before we try and read the next item which gives us much more exact
   // backpressure numbers
   ASSERT_OK_AND_ASSIGN(auto thread_pool, ::arrow::internal::ThreadPool::Make(1));
-  std::shared_ptr<Scanner> scanner = MakeScanner(thread_pool.get());
+  std::shared_ptr<Scanner> scanner = MakeScanner(nullptr);
   auto initial_scan_fut = DeferNotOk(thread_pool->Submit(
       [&] { return scanner->ScanBatchesUnorderedAsync(thread_pool.get()); }));
   ASSERT_FINISHES_OK_AND_ASSIGN(AsyncGenerator<EnumeratedRecordBatch> gen,
@@ -1906,11 +1905,11 @@ TEST_F(TestBackpressure, ScanBatchesUnordered) {
   // By this point the plan will have been created and started and filled up to max
   // backpressure.  The exact measurement of "max backpressure" is a little hard to pin
   // down but it is deterministic since we're only using one thread.
-  ASSERT_LE(TotalBatchesRead(), kMaxBatchesRead);
+  ASSERT_LE(TotalBatchesRead(), 155);
   DeliverAdditionalBatches();
   SleepABit();
 
-  ASSERT_LE(TotalBatchesRead(), kMaxBatchesRead);
+  ASSERT_LE(TotalBatchesRead(), 160);
   Finish(std::move(gen));
 }
 
@@ -2145,8 +2144,8 @@ TEST(ScanOptions, TestMaterializedFields) {
 
 namespace {
 struct TestPlan {
-  explicit TestPlan(compute::ExecContext* ctx = compute::default_exec_context())
-      : plan(compute::ExecPlan::Make(ctx).ValueOrDie()) {
+  explicit TestPlan(compute::ExecContext* ctx = compute::threaded_exec_context())
+      : plan(compute::ExecPlan::Make(*ctx).ValueOrDie()) {
     internal::Initialize();
   }
 
@@ -2522,7 +2521,7 @@ TEST(ScanNode, MinimalEndToEnd) {
   // predicate pushdown, a projection to skip materialization of unnecessary columns,
   // ...)
   ASSERT_OK_AND_ASSIGN(std::shared_ptr<compute::ExecPlan> plan,
-                       compute::ExecPlan::Make(&exec_context));
+                       compute::ExecPlan::Make(exec_context));
 
   std::shared_ptr<Dataset> dataset = std::make_shared<InMemoryDataset>(
       TableFromJSON(schema({field("a", int32()), field("b", boolean())}),
@@ -2620,7 +2619,7 @@ TEST(ScanNode, MinimalScalarAggEndToEnd) {
   // predicate pushdown, a projection to skip materialization of unnecessary columns,
   // ...)
   ASSERT_OK_AND_ASSIGN(std::shared_ptr<compute::ExecPlan> plan,
-                       compute::ExecPlan::Make(&exec_context));
+                       compute::ExecPlan::Make(exec_context));
 
   std::shared_ptr<Dataset> dataset = std::make_shared<InMemoryDataset>(
       TableFromJSON(schema({field("a", int32()), field("b", boolean())}),
@@ -2715,7 +2714,7 @@ TEST(ScanNode, MinimalGroupedAggEndToEnd) {
   // predicate pushdown, a projection to skip materialization of unnecessary columns,
   // ...)
   ASSERT_OK_AND_ASSIGN(std::shared_ptr<compute::ExecPlan> plan,
-                       compute::ExecPlan::Make(&exec_context));
+                       compute::ExecPlan::Make(exec_context));
 
   std::shared_ptr<Dataset> dataset = std::make_shared<InMemoryDataset>(
       TableFromJSON(schema({field("a", int32()), field("b", boolean())}),

--- a/cpp/src/arrow/engine/substrait/function_test.cc
+++ b/cpp/src/arrow/engine/substrait/function_test.cc
@@ -161,7 +161,12 @@ void CheckErrorTestCases(const std::vector<FunctionTestCase>& error_cases) {
     std::shared_ptr<Table> output_table;
     ASSERT_OK_AND_ASSIGN(std::shared_ptr<compute::ExecPlan> plan,
                          PlanFromTestCase(test_case, &output_table));
-    ASSERT_OK(plan->StartProducing());
+    Status start_st = plan->StartProducing();
+    // The plan can fail in start producing or when running the plan
+    if (!start_st.ok()) {
+      ASSERT_TRUE(start_st.IsInvalid());
+      return;
+    }
     ASSERT_FINISHES_AND_RAISES(Invalid, plan->finished());
   }
 }

--- a/cpp/src/arrow/engine/substrait/function_test.cc
+++ b/cpp/src/arrow/engine/substrait/function_test.cc
@@ -161,7 +161,8 @@ void CheckErrorTestCases(const std::vector<FunctionTestCase>& error_cases) {
     std::shared_ptr<Table> output_table;
     ASSERT_OK_AND_ASSIGN(std::shared_ptr<compute::ExecPlan> plan,
                          PlanFromTestCase(test_case, &output_table));
-    ASSERT_RAISES(Invalid, plan->StartProducing());
+    ASSERT_OK(plan->StartProducing());
+    ASSERT_FINISHES_AND_RAISES(Invalid, plan->finished());
   }
 }
 

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -105,31 +105,6 @@ void WriteIpcData(const std::string& path,
   ASSERT_OK(file_writer->Close());
 }
 
-Result<std::shared_ptr<Table>> GetTableFromPlan(
-    compute::Declaration& other_declrs, compute::ExecContext& exec_context,
-    const std::shared_ptr<Schema>& output_schema) {
-  ARROW_ASSIGN_OR_RAISE(auto plan, compute::ExecPlan::Make(&exec_context));
-
-  arrow::AsyncGenerator<std::optional<compute::ExecBatch>> sink_gen;
-  auto sink_node_options = compute::SinkNodeOptions{&sink_gen};
-  auto sink_declaration = compute::Declaration({"sink", sink_node_options, "e"});
-  auto declarations = compute::Declaration::Sequence({other_declrs, sink_declaration});
-
-  ARROW_ASSIGN_OR_RAISE(auto decl, declarations.AddToPlan(plan.get()));
-
-  RETURN_NOT_OK(decl->Validate());
-
-  std::shared_ptr<arrow::RecordBatchReader> sink_reader = compute::MakeGeneratorReader(
-      output_schema, std::move(sink_gen), exec_context.memory_pool());
-
-  RETURN_NOT_OK(plan->Validate());
-  RETURN_NOT_OK(plan->StartProducing());
-  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Table> table,
-                        arrow::Table::FromRecordBatchReader(sink_reader.get()));
-  RETURN_NOT_OK(plan->finished().status());
-  return table;
-}
-
 class NullSinkNodeConsumer : public compute::SinkNodeConsumer {
  public:
   Status Init(const std::shared_ptr<Schema>&, compute::BackpressureControl*,
@@ -208,7 +183,6 @@ inline compute::Expression UseBoringRefs(const compute::Expression& expr) {
 }
 
 void CheckRoundTripResult(const std::shared_ptr<Table> expected_table,
-                          compute::ExecContext& exec_context,
                           std::shared_ptr<Buffer>& buf,
                           const std::vector<int>& include_columns = {},
                           const ConversionOptions& conversion_options = {},
@@ -222,19 +196,17 @@ void CheckRoundTripResult(const std::shared_ptr<Table> expected_table,
   auto& other_declrs = std::get<compute::Declaration>(sink_decls[0].inputs[0]);
 
   ASSERT_OK_AND_ASSIGN(auto output_table,
-                       compute::DeclarationToTable(other_declrs, &exec_context));
+                       compute::DeclarationToTable(other_declrs, /*use_threads=*/false));
 
   if (!include_columns.empty()) {
     ASSERT_OK_AND_ASSIGN(output_table, output_table->SelectColumns(include_columns));
   }
   if (sort_options) {
-    ASSERT_OK_AND_ASSIGN(
-        auto sort_indices,
-        SortIndices(output_table, std::move(*sort_options), &exec_context));
-    ASSERT_OK_AND_ASSIGN(
-        auto maybe_table,
-        compute::Take(output_table, std::move(sort_indices),
-                      compute::TakeOptions::NoBoundsCheck(), &exec_context));
+    ASSERT_OK_AND_ASSIGN(auto sort_indices,
+                         SortIndices(output_table, std::move(*sort_options)));
+    ASSERT_OK_AND_ASSIGN(auto maybe_table,
+                         compute::Take(output_table, std::move(sort_indices),
+                                       compute::TakeOptions::NoBoundsCheck()));
     output_table = maybe_table.table();
   }
   ASSERT_OK_AND_ASSIGN(output_table, output_table->CombineChunks());
@@ -2242,8 +2214,7 @@ TEST(SubstraitRoundTrip, BasicPlanEndToEnd) {
            {"scan", dataset::ScanNodeOptions{dataset, scan_options}, "s"}),
        compute::Declaration({"filter", compute::FilterNodeOptions{filter}, "f"})});
 
-  ASSERT_OK_AND_ASSIGN(auto expected_table,
-                       GetTableFromPlan(declarations, exec_context, dummy_schema));
+  ASSERT_OK_AND_ASSIGN(auto expected_table, compute::DeclarationToTable(declarations));
 
   std::shared_ptr<ExtensionIdRegistry> sp_ext_id_reg = MakeExtensionIdRegistry();
   ExtensionIdRegistry* ext_id_reg = sp_ext_id_reg.get();
@@ -2290,12 +2261,11 @@ TEST(SubstraitRoundTrip, BasicPlanEndToEnd) {
     EXPECT_TRUE(l_frag->Equals(*r_frag));
   }
   ASSERT_OK_AND_ASSIGN(auto rnd_trp_table,
-                       GetTableFromPlan(roundtripped_filter, exec_context, dummy_schema));
+                       compute::DeclarationToTable(roundtripped_filter));
   EXPECT_TRUE(expected_table->Equals(*rnd_trp_table));
 }
 
 TEST(SubstraitRoundTrip, FilterNamedTable) {
-  compute::ExecContext exec_context;
   arrow::dataset::internal::Initialize();
 
   const std::vector<std::string> table_names{"table", "1"};
@@ -2341,7 +2311,7 @@ TEST(SubstraitRoundTrip, FilterNamedTable) {
     [2, 2, 60]
   ])"});
 
-  CheckRoundTripResult(std::move(expected_table), exec_context, serialized_plan,
+  CheckRoundTripResult(std::move(expected_table), serialized_plan,
                        /*include_columns=*/{}, conversion_options);
 }
 
@@ -2456,12 +2426,11 @@ TEST(SubstraitRoundTrip, ProjectRel) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(expected_table), exec_context, buf,
+  CheckRoundTripResult(std::move(expected_table), buf,
                        /*include_columns=*/{}, conversion_options);
 }
 
 TEST(SubstraitRoundTrip, ProjectRelOnFunctionWithEmit) {
-  compute::ExecContext exec_context;
   auto dummy_schema =
       schema({field("A", int32()), field("B", int32()), field("C", int32())});
 
@@ -2575,12 +2544,11 @@ TEST(SubstraitRoundTrip, ProjectRelOnFunctionWithEmit) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(expected_table), exec_context, buf,
+  CheckRoundTripResult(std::move(expected_table), buf,
                        /*include_columns=*/{}, conversion_options);
 }
 
 TEST(SubstraitRoundTrip, ReadRelWithEmit) {
-  compute::ExecContext exec_context;
   auto dummy_schema =
       schema({field("A", int32()), field("B", int32()), field("C", int32())});
 
@@ -2634,12 +2602,11 @@ TEST(SubstraitRoundTrip, ReadRelWithEmit) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(expected_table), exec_context, buf,
+  CheckRoundTripResult(std::move(expected_table), buf,
                        /*include_columns=*/{}, conversion_options);
 }
 
 TEST(SubstraitRoundTrip, FilterRelWithEmit) {
-  compute::ExecContext exec_context;
   auto dummy_schema = schema({field("A", int32()), field("B", int32()),
                               field("C", int32()), field("D", int32())});
 
@@ -2752,12 +2719,11 @@ TEST(SubstraitRoundTrip, FilterRelWithEmit) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(expected_table), exec_context, buf,
+  CheckRoundTripResult(std::move(expected_table), buf,
                        /*include_columns=*/{}, conversion_options);
 }
 
 TEST(SubstraitRoundTrip, JoinRel) {
-  compute::ExecContext exec_context;
   auto left_schema = schema({field("A", int32()), field("B", int32())});
 
   auto right_schema = schema({field("X", int32()), field("Y", int32())});
@@ -2902,12 +2868,11 @@ TEST(SubstraitRoundTrip, JoinRel) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(expected_table), exec_context, buf,
+  CheckRoundTripResult(std::move(expected_table), buf,
                        /*include_columns=*/{}, conversion_options);
 }
 
 TEST(SubstraitRoundTrip, JoinRelWithEmit) {
-  compute::ExecContext exec_context;
   auto left_schema = schema({field("A", int32()), field("B", int32())});
 
   auto right_schema = schema({field("X", int32()), field("Y", int32())});
@@ -3054,12 +3019,11 @@ TEST(SubstraitRoundTrip, JoinRelWithEmit) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(expected_table), exec_context, buf,
+  CheckRoundTripResult(std::move(expected_table), buf,
                        /*include_columns=*/{}, conversion_options);
 }
 
 TEST(SubstraitRoundTrip, AggregateRel) {
-  compute::ExecContext exec_context;
   auto dummy_schema =
       schema({field("A", int32()), field("B", int32()), field("C", int32())});
 
@@ -3163,12 +3127,11 @@ TEST(SubstraitRoundTrip, AggregateRel) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(expected_table), exec_context, buf,
+  CheckRoundTripResult(std::move(expected_table), buf,
                        /*include_columns=*/{}, conversion_options);
 }
 
 TEST(SubstraitRoundTrip, AggregateRelEmit) {
-  compute::ExecContext exec_context;
   auto dummy_schema =
       schema({field("A", int32()), field("B", int32()), field("C", int32())});
 
@@ -3278,7 +3241,7 @@ TEST(SubstraitRoundTrip, AggregateRelEmit) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(expected_table), exec_context, buf,
+  CheckRoundTripResult(std::move(expected_table), buf,
                        /*include_columns=*/{}, conversion_options);
 }
 
@@ -3382,12 +3345,11 @@ TEST(Substrait, IsthmusPlan) {
                                                    /*ignore_unknown_fields=*/false));
 
   auto expected_table = TableFromJSON(test_schema, {"[[2], [3], [6]]"});
-  CheckRoundTripResult(std::move(expected_table), *compute::default_exec_context(), buf,
+  CheckRoundTripResult(std::move(expected_table), buf,
                        /*include_columns=*/{}, conversion_options);
 }
 
 TEST(Substrait, ProjectWithMultiFieldExpressions) {
-  compute::ExecContext exec_context;
   auto dummy_schema =
       schema({field("A", int32()), field("B", int32()), field("C", int32())});
 
@@ -3536,12 +3498,11 @@ TEST(Substrait, ProjectWithMultiFieldExpressions) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(expected_table), exec_context, buf,
+  CheckRoundTripResult(std::move(expected_table), buf,
                        /*include_columns=*/{}, conversion_options);
 }
 
 TEST(Substrait, NestedProjectWithMultiFieldExpressions) {
-  compute::ExecContext exec_context;
   auto dummy_schema = schema({field("A", int32())});
 
   // creating a dummy dataset using a dummy table
@@ -3623,12 +3584,11 @@ TEST(Substrait, NestedProjectWithMultiFieldExpressions) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(expected_table), exec_context, buf,
+  CheckRoundTripResult(std::move(expected_table), buf,
                        /*include_columns=*/{}, conversion_options);
 }
 
 TEST(Substrait, NestedEmitProjectWithMultiFieldExpressions) {
-  compute::ExecContext exec_context;
   auto dummy_schema = schema({field("A", int32())});
 
   // creating a dummy dataset using a dummy table
@@ -3711,7 +3671,7 @@ TEST(Substrait, NestedEmitProjectWithMultiFieldExpressions) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  CheckRoundTripResult(std::move(expected_table), exec_context, buf,
+  CheckRoundTripResult(std::move(expected_table), buf,
                        /*include_columns=*/{}, conversion_options);
 }
 
@@ -3719,7 +3679,6 @@ TEST(Substrait, ReadRelWithGlobFiles) {
 #ifdef _WIN32
   GTEST_SKIP() << "ARROW-16392: Substrait File URI not supported for Windows";
 #endif
-  compute::ExecContext exec_context;
   arrow::dataset::internal::Initialize();
 
   auto dummy_schema =
@@ -3808,12 +3767,11 @@ TEST(Substrait, ReadRelWithGlobFiles) {
   // To avoid unnecessar metadata columns being included in the final result
   std::vector<int> include_columns = {0, 1, 2};
   compute::SortOptions options({compute::SortKey("A", compute::SortOrder::Ascending)});
-  CheckRoundTripResult(std::move(expected_table), exec_context, buf,
-                       std::move(include_columns), /*conversion_options=*/{}, &options);
+  CheckRoundTripResult(std::move(expected_table), buf, std::move(include_columns),
+                       /*conversion_options=*/{}, &options);
 }
 
 TEST(Substrait, RootRelationOutputNames) {
-  compute::ExecContext exec_context;
   auto dummy_schema =
       schema({field("A", int32()), field("B", int32()), field("C", int32())});
 
@@ -3917,12 +3875,11 @@ TEST(Substrait, RootRelationOutputNames) {
 
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
-  CheckRoundTripResult(std::move(expected_table), exec_context, buf,
+  CheckRoundTripResult(std::move(expected_table), buf,
                        /*include_columns=*/{}, conversion_options);
 }
 
 TEST(Substrait, SetRelationBasic) {
-  compute::ExecContext exec_context;
   auto dummy_schema =
       schema({field("A", int32()), field("B", int32()), field("C", int32())});
 
@@ -4037,8 +3994,8 @@ TEST(Substrait, SetRelationBasic) {
 
   compute::SortOptions sort_options(
       {compute::SortKey("A", compute::SortOrder::Ascending)});
-  CheckRoundTripResult(std::move(expected_table), exec_context, buf, {},
-                       conversion_options, &sort_options);
+  CheckRoundTripResult(std::move(expected_table), buf, {}, conversion_options,
+                       &sort_options);
 }
 
 }  // namespace engine

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -36,6 +36,7 @@
 #include "arrow/compute/exec/expression.h"
 #include "arrow/compute/exec/expression_internal.h"
 #include "arrow/compute/exec/options.h"
+#include "arrow/compute/exec/test_util.h"
 #include "arrow/compute/exec/util.h"
 #include "arrow/compute/registry.h"
 #include "arrow/compute/type_fwd.h"
@@ -210,7 +211,8 @@ void CheckRoundTripResult(const std::shared_ptr<Table> expected_table,
     output_table = maybe_table.table();
   }
   ASSERT_OK_AND_ASSIGN(output_table, output_table->CombineChunks());
-  AssertTablesEqual(*expected_table, *output_table);
+  ASSERT_OK_AND_ASSIGN(auto merged_expected, expected_table->CombineChunks());
+  compute::AssertTablesEqualIgnoringOrder(merged_expected, output_table);
 }
 
 TEST(Substrait, SupportedTypes) {
@@ -2262,7 +2264,7 @@ TEST(SubstraitRoundTrip, BasicPlanEndToEnd) {
   }
   ASSERT_OK_AND_ASSIGN(auto rnd_trp_table,
                        compute::DeclarationToTable(roundtripped_filter));
-  EXPECT_TRUE(expected_table->Equals(*rnd_trp_table));
+  compute::AssertTablesEqualIgnoringOrder(expected_table, rnd_trp_table);
 }
 
 TEST(SubstraitRoundTrip, FilterNamedTable) {

--- a/cpp/src/arrow/engine/substrait/util.cc
+++ b/cpp/src/arrow/engine/substrait/util.cc
@@ -140,7 +140,7 @@ Result<std::shared_ptr<RecordBatchReader>> ExecuteSerializedPlan(
     const ConversionOptions& conversion_options) {
   compute::ExecContext exec_context(arrow::default_memory_pool(),
                                     ::arrow::internal::GetCpuThreadPool(), func_registry);
-  ARROW_ASSIGN_OR_RAISE(auto plan, compute::ExecPlan::Make(&exec_context));
+  ARROW_ASSIGN_OR_RAISE(auto plan, compute::ExecPlan::Make(exec_context));
   SubstraitExecutor executor(std::move(plan), exec_context, conversion_options);
   RETURN_NOT_OK(executor.Init(substrait_buffer, registry));
   ARROW_ASSIGN_OR_RAISE(auto sink_reader, executor.Execute());

--- a/cpp/src/arrow/util/async_util.h
+++ b/cpp/src/arrow/util/async_util.h
@@ -147,14 +147,22 @@ class ARROW_EXPORT AsyncTaskScheduler {
   ///
   /// \param initial_task The initial task which is responsible for adding
   ///        the first subtasks to the scheduler.
+  /// \param abort_callback A callback that will be triggered immediately after a task
+  ///        fails while other tasks may still be running.  Nothing needs to be done here,
+  ///        when a task fails the scheduler will stop accepting new tasks and eventually
+  ///        return the error.  However, this callback can be used to more quickly end
+  ///        long running tasks that have already been submitted.  Defaults to doing
+  ///        nothing.
   /// \param stop_token An optional stop token that will allow cancellation of the
   ///        scheduler.  This will be checked before each task is submitted and, in the
   ///        event of a cancellation, the scheduler will enter an aborted state. This is
   ///        a graceful cancellation and submitted tasks will still complete.
   /// \return A future that will be completed when the initial task and all subtasks have
   ///         finished.
-  static Future<> Make(FnOnce<Status(AsyncTaskScheduler*)> initial_task,
-                       StopToken stop_token = StopToken::Unstoppable());
+  static Future<> Make(
+      FnOnce<Status(AsyncTaskScheduler*)> initial_task,
+      FnOnce<void(const Status&)> abort_callback = [](const Status&) {},
+      StopToken stop_token = StopToken::Unstoppable());
 };
 
 class ARROW_EXPORT ThrottledAsyncTaskScheduler : public AsyncTaskScheduler {

--- a/cpp/src/arrow/util/thread_pool.h
+++ b/cpp/src/arrow/util/thread_pool.h
@@ -272,6 +272,7 @@ class ARROW_EXPORT SerialExecutor : public Executor {
   ~SerialExecutor() override;
 
   int GetCapacity() override { return 1; };
+  bool OwnsThisThread() override;
   Status SpawnReal(TaskHints hints, FnOnce<void()> task, StopToken,
                    StopCallback&&) override;
 

--- a/python/pyarrow/_exec_plan.pyx
+++ b/python/pyarrow/_exec_plan.pyx
@@ -86,6 +86,9 @@ cdef execplan(inputs, output_type, vector[CDeclaration] plan, c_bool use_threads
     else:
         c_executor = NULL
 
+    # TODO(weston): This is deprecated.  Once ordering is better supported
+    # in the exec plan we can remove all references to ExecPlan and use the
+    # DeclarationToXyz methods
     c_exec_context = make_shared[CExecContext](
         c_default_memory_pool(), c_executor)
     c_exec_plan = GetResultValue(CExecPlan.Make(c_exec_context.get()))

--- a/r/src/compute-exec.cpp
+++ b/r/src/compute-exec.cpp
@@ -41,8 +41,14 @@ std::shared_ptr<arrow::KeyValueMetadata> strings_to_kvm(cpp11::strings metadata)
 std::shared_ptr<compute::ExecPlan> ExecPlan_create(bool use_threads) {
   static compute::ExecContext threaded_context{gc_memory_pool(),
                                                arrow::internal::GetCpuThreadPool()};
+  // TODO(weston) using gc_context() in this way is deprecated.  Once ordering has
+  // been added we can probably entirely remove all reference to ExecPlan from R
+  // in favor of DeclarationToXyz
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   auto plan = ValueOrStop(
       compute::ExecPlan::Make(use_threads ? &threaded_context : gc_context()));
+#pragma GCC diagnostic pop
   return plan;
 }
 


### PR DESCRIPTION
This PR gets rid of the "executor==nullptr" style of execution from Acero.  Now a CPU executor must always be defined.  This also updates the DeclarationToXyz methods to support 5 "standard" modes of operation:

* sync / threaded - All CPU work is done on the CPU thread pool.  The calling thread sleeps until the plan is done.
* sync / serial - All CPU work is done on the calling thread.  The calling thread becomes a serial executor until plan is done.
* async / threaded - All CPU work is done on the CPU thread pool.  The calling thread returns immediately.
* async / serial - All CPU work is done on a plan-specific 1-thread pool.  The calling thread returns immediately.
* async / custom exec context - All CPU work is done on the provided executor which cannot be nullptr and the caller is responsible for keeping it alive.

For backwards compatibility the "old style" of serial execution (which is still used by R/python) will still be accepted.  Under the hood a 1-thread pool will be created and its lifetime will be bound to the exec plan (this is similar to async / serial when using DeclarationToXyz).

Since DeclarationToXyz doesn't support "ordered sinks" we cannot yet migrate the bindings and so they will continue to rely on the deprecated API.

All unit tests are updated to use the new API.  Some unit tests were not actually running in parallel (even though they said they were) and now that they are running in parallel a few changes had to be made to accept / handle non-deterministic result order.

As part of this process some unit tests were migrated away from StartAndCollect in favor of DeclarationToXyz.  Hopefully we can eventually migrate almost all of the unit tests to DeclarationToXyz but that is a longer term effort.