### PR TITLE
GH-14844: [Java] Short circuit null checks when comparing non null field types

### DIFF
--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/VectorValueComparator.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/VectorValueComparator.java
@@ -89,10 +89,10 @@ public abstract class VectorValueComparator<V extends ValueVector> {
     this.vector1 = vector1;
     this.vector2 = vector2;
 
-    final boolean v1MayHaveNulls = vector1.getField().getFieldType().isNullable() ||
-            vector1.getValidityBuffer() == null;
-    final boolean v2MayHaveNulls = vector2.getField().getFieldType().isNullable() ||
-            vector2.getValidityBuffer() == null;
+    final boolean v1MayHaveNulls = vector1.getField().getFieldType().isNullable() &&
+            vector1.getValidityBuffer() != null;
+    final boolean v2MayHaveNulls = vector2.getField().getFieldType().isNullable() &&
+            vector2.getValidityBuffer() != null;
 
     this.checkNullsOnCompare = v1MayHaveNulls || v2MayHaveNulls;
   }

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/VectorValueComparator.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/VectorValueComparator.java
@@ -89,8 +89,11 @@ public abstract class VectorValueComparator<V extends ValueVector> {
     this.vector1 = vector1;
     this.vector2 = vector2;
 
-    final boolean v1MayHaveNulls = vector1.getField().getFieldType().isNullable();
-    final boolean v2MayHaveNulls = vector2.getField().getFieldType().isNullable();
+    final boolean v1MayHaveNulls = vector1.getField().getFieldType().isNullable() ||
+            vector1.getValidityBuffer() == null;
+    final boolean v2MayHaveNulls = vector2.getField().getFieldType().isNullable() ||
+            vector2.getValidityBuffer() == null;
+
     this.checkNullsOnCompare = v1MayHaveNulls || v2MayHaveNulls;
   }
 

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/VectorValueComparator.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/VectorValueComparator.java
@@ -41,6 +41,18 @@ public abstract class VectorValueComparator<V extends ValueVector> {
    */
   protected int valueWidth;
 
+
+  private boolean checkNullsOnCompare = true;
+
+  /**
+   * This value is true by default and re-computed when vectors are attached to the comparator. If both vectors cannot
+   * contain nulls then this value is {@code false} and calls to {@code compare(i1, i2)} are short-circuited
+   * to {@code compareNotNull(i1, i2)} thereby speeding up comparisons resulting in faster sorts etc.
+   */
+  public boolean checkNullsOnCompare() {
+    return this.checkNullsOnCompare;
+  }
+
   /**
    * Constructor for variable-width vectors.
    */
@@ -76,6 +88,10 @@ public abstract class VectorValueComparator<V extends ValueVector> {
   public void attachVectors(V vector1, V vector2) {
     this.vector1 = vector1;
     this.vector2 = vector2;
+
+    final boolean v1MayHaveNulls = vector1.getField().getFieldType().isNullable();
+    final boolean v2MayHaveNulls = vector2.getField().getFieldType().isNullable();
+    this.checkNullsOnCompare = v1MayHaveNulls || v2MayHaveNulls;
   }
 
   /**
@@ -87,17 +103,19 @@ public abstract class VectorValueComparator<V extends ValueVector> {
    *     values are equal.
    */
   public int compare(int index1, int index2) {
-    boolean isNull1 = vector1.isNull(index1);
-    boolean isNull2 = vector2.isNull(index2);
+    if (checkNullsOnCompare) {
+      boolean isNull1 = vector1.isNull(index1);
+      boolean isNull2 = vector2.isNull(index2);
 
-    if (isNull1 || isNull2) {
-      if (isNull1 && isNull2) {
-        return 0;
-      } else if (isNull1) {
-        // null is smaller
-        return -1;
-      } else {
-        return 1;
+      if (isNull1 || isNull2) {
+        if (isNull1 && isNull2) {
+          return 0;
+        } else if (isNull1) {
+          // null is smaller
+          return -1;
+        } else {
+          return 1;
+        }
       }
     }
     return compareNotNull(index1, index2);

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/VectorValueComparator.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/VectorValueComparator.java
@@ -89,12 +89,20 @@ public abstract class VectorValueComparator<V extends ValueVector> {
     this.vector1 = vector1;
     this.vector2 = vector2;
 
-    final boolean v1MayHaveNulls = vector1.getField().getFieldType().isNullable() &&
-            vector1.getValidityBuffer() != null;
-    final boolean v2MayHaveNulls = vector2.getField().getFieldType().isNullable() &&
-            vector2.getValidityBuffer() != null;
+    final boolean v1MayHaveNulls = mayHaveNulls(vector1);
+    final boolean v2MayHaveNulls = mayHaveNulls(vector2);
 
     this.checkNullsOnCompare = v1MayHaveNulls || v2MayHaveNulls;
+  }
+
+  private boolean mayHaveNulls(V v) {
+    if (v.getValueCount() == 0) {
+      return true;
+    }
+    if (! v.getField().isNullable()) {
+      return false;
+    }
+    return v.getNullCount() > 0;
   }
 
   /**

--- a/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestDefaultVectorComparator.java
+++ b/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestDefaultVectorComparator.java
@@ -397,6 +397,9 @@ public class TestDefaultVectorComparator {
   public void testCheckNullsOnCompareIsFalseForNonNullableVector() {
     try (IntVector vec = new IntVector("not nullable",
             FieldType.notNullable(new ArrowType.Int(32, false)), allocator)) {
+
+      ValueVectorDataPopulator.setVector(vec, 1, 2, 3, 4);
+
       final VectorValueComparator<IntVector> comparator = DefaultVectorComparators.createDefaultComparator(vec);
       comparator.attachVector(vec);
 
@@ -411,8 +414,50 @@ public class TestDefaultVectorComparator {
          IntVector vec2 = new IntVector("not-nullable", FieldType.notNullable(
                  new ArrowType.Int(32, false)), allocator)
     ) {
+
+      ValueVectorDataPopulator.setVector(vec, 1, null, 3, 4);
+      ValueVectorDataPopulator.setVector(vec2, 1, 2, 3, 4);
+
       final VectorValueComparator<IntVector> comparator = DefaultVectorComparators.createDefaultComparator(vec);
       comparator.attachVector(vec);
+      assertTrue(comparator.checkNullsOnCompare());
+
+      comparator.attachVectors(vec, vec2);
+      assertTrue(comparator.checkNullsOnCompare());
+    }
+  }
+
+  @Test
+  public void testCheckNullsOnCompareIsFalseWithNoNulls() {
+    try (IntVector vec = new IntVector("nullable", FieldType.nullable(
+            new ArrowType.Int(32, false)), allocator);
+         IntVector vec2 = new IntVector("also-nullable", FieldType.nullable(
+                 new ArrowType.Int(32, false)), allocator)
+    ) {
+
+      // no null values
+      ValueVectorDataPopulator.setVector(vec, 1, 2, 3, 4);
+      ValueVectorDataPopulator.setVector(vec2, 1, 2, 3, 4);
+
+      final VectorValueComparator<IntVector> comparator = DefaultVectorComparators.createDefaultComparator(vec);
+      comparator.attachVector(vec);
+      assertFalse(comparator.checkNullsOnCompare());
+
+      comparator.attachVectors(vec, vec2);
+      assertFalse(comparator.checkNullsOnCompare());
+    }
+  }
+
+  @Test
+  public void testCheckNullsOnCompareIsTrueWithEmptyVectors() {
+    try (IntVector vec = new IntVector("nullable", FieldType.nullable(
+            new ArrowType.Int(32, false)), allocator);
+         IntVector vec2 = new IntVector("also-nullable", FieldType.nullable(
+                 new ArrowType.Int(32, false)), allocator)
+    ) {
+
+      final VectorValueComparator<IntVector> comparator = DefaultVectorComparators.createDefaultComparator(vec);
+      comparator.attachVector(vec2);
       assertTrue(comparator.checkNullsOnCompare());
 
       comparator.attachVectors(vec, vec2);


### PR DESCRIPTION
Relates to #14844 

To avoid expensive checks for null values when the vectors cannot contain nulls, a flag is set when a vector is attached to indicate if a null check is needed when `compare(idx1, idx2)` is called. If it isn't then the call will immediately redirect to `compareNotNull(index1, index2)`.
* Closes: #14844