### PR TITLE
ARROW-17823: [C++] [Parquet] Prefer std::make_shared/std::make_unique over constructor with new in Parquet

### DIFF
--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -123,8 +123,8 @@ int LevelDecoder::SetData(Encoding::type encoding, int16_t max_level,
       }
       const uint8_t* decoder_data = data + 4;
       if (!rle_decoder_) {
-        rle_decoder_.reset(
-            new ::arrow::util::RleDecoder(decoder_data, num_bytes, bit_width_));
+        rle_decoder_ = std::make_unique<::arrow::util::RleDecoder>(decoder_data,
+                                                                   num_bytes, bit_width_);
       } else {
         rle_decoder_->Reset(decoder_data, num_bytes, bit_width_);
       }
@@ -141,7 +141,8 @@ int LevelDecoder::SetData(Encoding::type encoding, int16_t max_level,
         throw ParquetException("Received invalid number of bytes (corrupt data page?)");
       }
       if (!bit_packed_decoder_) {
-        bit_packed_decoder_.reset(new ::arrow::bit_util::BitReader(data, num_bytes));
+        bit_packed_decoder_ =
+            std::make_unique<::arrow::bit_util::BitReader>(data, num_bytes);
       } else {
         bit_packed_decoder_->Reset(data, num_bytes);
       }
@@ -166,7 +167,8 @@ void LevelDecoder::SetDataV2(int32_t num_bytes, int16_t max_level,
   bit_width_ = bit_util::Log2(max_level + 1);
 
   if (!rle_decoder_) {
-    rle_decoder_.reset(new ::arrow::util::RleDecoder(data, num_bytes, bit_width_));
+    rle_decoder_ =
+        std::make_unique<::arrow::util::RleDecoder>(data, num_bytes, bit_width_);
   } else {
     rle_decoder_->Reset(data, num_bytes, bit_width_);
   }
@@ -1871,7 +1873,7 @@ class FLBARecordReader : public TypedRecordReader<FLBAType>,
     DCHECK_EQ(descr_->physical_type(), Type::FIXED_LEN_BYTE_ARRAY);
     int byte_width = descr_->type_length();
     std::shared_ptr<::arrow::DataType> type = ::arrow::fixed_size_binary(byte_width);
-    builder_.reset(new ::arrow::FixedSizeBinaryBuilder(type, this->pool_));
+    builder_ = std::make_unique<::arrow::FixedSizeBinaryBuilder>(type, this->pool_);
   }
 
   ::arrow::ArrayVector GetBuilderChunks() override {
@@ -1923,7 +1925,7 @@ class ByteArrayChunkedRecordReader : public TypedRecordReader<ByteArrayType>,
                                ::arrow::MemoryPool* pool)
       : TypedRecordReader<ByteArrayType>(descr, leaf_info, pool) {
     DCHECK_EQ(descr_->physical_type(), Type::BYTE_ARRAY);
-    accumulator_.builder.reset(new ::arrow::BinaryBuilder(pool));
+    accumulator_.builder = std::make_unique<::arrow::BinaryBuilder>(pool);
   }
 
   ::arrow::ArrayVector GetBuilderChunks() override {

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -172,13 +172,13 @@ void LevelEncoder::Init(Encoding::type encoding, int16_t max_level,
   encoding_ = encoding;
   switch (encoding) {
     case Encoding::RLE: {
-      rle_encoder_.reset(new RleEncoder(data, data_size, bit_width_));
+      rle_encoder_ = std::make_unique<RleEncoder>(data, data_size, bit_width_);
       break;
     }
     case Encoding::BIT_PACKED: {
       int num_bytes =
           static_cast<int>(bit_util::BytesForBits(num_buffered_values * bit_width_));
-      bit_packed_encoder_.reset(new BitWriter(data, num_bytes));
+      bit_packed_encoder_ = std::make_unique<BitWriter>(data, num_bytes);
       break;
     }
     default:
@@ -268,7 +268,7 @@ class SerializedPageWriter : public PageWriter {
       InitEncryption();
     }
     compressor_ = GetCodec(codec, compression_level);
-    thrift_serializer_.reset(new ThriftSerializer);
+    thrift_serializer_ = std::make_unique<ThriftSerializer>();
   }
 
   int64_t WriteDictionaryPage(const DictionaryPage& page) override {
@@ -548,10 +548,10 @@ class BufferedPageWriter : public PageWriter {
                      std::shared_ptr<Encryptor> data_encryptor = nullptr)
       : final_sink_(std::move(sink)), metadata_(metadata), has_dictionary_pages_(false) {
     in_memory_sink_ = CreateOutputStream(pool);
-    pager_ = std::unique_ptr<SerializedPageWriter>(
-        new SerializedPageWriter(in_memory_sink_, codec, compression_level, metadata,
-                                 row_group_ordinal, current_column_ordinal, pool,
-                                 std::move(meta_encryptor), std::move(data_encryptor)));
+    pager_ = std::make_unique<SerializedPageWriter>(
+        in_memory_sink_, codec, compression_level, metadata, row_group_ordinal,
+        current_column_ordinal, pool, std::move(meta_encryptor),
+        std::move(data_encryptor));
   }
 
   int64_t WriteDictionaryPage(const DictionaryPage& page) override {
@@ -607,15 +607,13 @@ std::unique_ptr<PageWriter> PageWriter::Open(
     bool buffered_row_group, std::shared_ptr<Encryptor> meta_encryptor,
     std::shared_ptr<Encryptor> data_encryptor) {
   if (buffered_row_group) {
-    return std::unique_ptr<PageWriter>(
-        new BufferedPageWriter(std::move(sink), codec, compression_level, metadata,
-                               row_group_ordinal, column_chunk_ordinal, pool,
-                               std::move(meta_encryptor), std::move(data_encryptor)));
+    return std::make_unique<BufferedPageWriter>(
+        std::move(sink), codec, compression_level, metadata, row_group_ordinal,
+        column_chunk_ordinal, pool, std::move(meta_encryptor), std::move(data_encryptor));
   } else {
-    return std::unique_ptr<PageWriter>(
-        new SerializedPageWriter(std::move(sink), codec, compression_level, metadata,
-                                 row_group_ordinal, column_chunk_ordinal, pool,
-                                 std::move(meta_encryptor), std::move(data_encryptor)));
+    return std::make_unique<SerializedPageWriter>(
+        std::move(sink), codec, compression_level, metadata, row_group_ordinal,
+        column_chunk_ordinal, pool, std::move(meta_encryptor), std::move(data_encryptor));
   }
 }
 
@@ -886,9 +884,9 @@ void ColumnWriterImpl::BuildDataPageV1(int64_t definition_levels_rle_size,
     PARQUET_ASSIGN_OR_THROW(
         auto compressed_data_copy,
         compressed_data->CopySlice(0, compressed_data->size(), allocator_));
-    std::unique_ptr<DataPage> page_ptr(new DataPageV1(
+    std::unique_ptr<DataPage> page_ptr = std::make_unique<DataPageV1>(
         compressed_data_copy, static_cast<int32_t>(num_buffered_values_), encoding_,
-        Encoding::RLE, Encoding::RLE, uncompressed_size, page_stats));
+        Encoding::RLE, Encoding::RLE, uncompressed_size, page_stats);
     total_compressed_bytes_ += page_ptr->size() + sizeof(format::PageHeader);
 
     data_pages_.push_back(std::move(page_ptr));
@@ -937,9 +935,9 @@ void ColumnWriterImpl::BuildDataPageV2(int64_t definition_levels_rle_size,
   if (has_dictionary_ && !fallback_) {  // Save pages until end of dictionary encoding
     PARQUET_ASSIGN_OR_THROW(auto data_copy,
                             combined->CopySlice(0, combined->size(), allocator_));
-    std::unique_ptr<DataPage> page_ptr(new DataPageV2(
+    std::unique_ptr<DataPage> page_ptr = std::make_unique<DataPageV2>(
         combined, num_values, null_count, num_values, encoding_, def_levels_byte_length,
-        rep_levels_byte_length, uncompressed_size, pager_->has_compressor(), page_stats));
+        rep_levels_byte_length, uncompressed_size, pager_->has_compressor(), page_stats);
     total_compressed_bytes_ += page_ptr->size() + sizeof(format::PageHeader);
     data_pages_.push_back(std::move(page_ptr));
   } else {

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -1171,7 +1171,7 @@ PlainBooleanDecoder::PlainBooleanDecoder(const ColumnDescriptor* descr)
 
 void PlainBooleanDecoder::SetData(int num_values, const uint8_t* data, int len) {
   num_values_ = num_values;
-  bit_reader_.reset(new bit_util::BitReader(data, len));
+  bit_reader_ = std::make_unique<bit_util::BitReader>(data, len);
 }
 
 int PlainBooleanDecoder::DecodeArrow(
@@ -2372,7 +2372,7 @@ class DeltaBitPackDecoder : public DecoderImpl, virtual public TypedDecoder<DTyp
   // DeltaByteArrayDecoder
   void SetDecoder(int num_values, std::shared_ptr<::arrow::bit_util::BitReader> decoder) {
     this->num_values_ = num_values;
-    decoder_ = decoder;
+    decoder_ = std::move(decoder);
     InitHeader();
   }
 
@@ -3040,11 +3040,9 @@ std::unique_ptr<Encoder> MakeEncoder(Type::type type_num, Encoding::type encodin
   } else if (encoding == Encoding::BYTE_STREAM_SPLIT) {
     switch (type_num) {
       case Type::FLOAT:
-        return std::unique_ptr<Encoder>(
-            new ByteStreamSplitEncoder<FloatType>(descr, pool));
+        return std::make_unique<ByteStreamSplitEncoder<FloatType>>(descr, pool);
       case Type::DOUBLE:
-        return std::unique_ptr<Encoder>(
-            new ByteStreamSplitEncoder<DoubleType>(descr, pool));
+        return std::make_unique<ByteStreamSplitEncoder<DoubleType>>(descr, pool);
       default:
         throw ParquetException("BYTE_STREAM_SPLIT only supports FLOAT and DOUBLE");
         break;
@@ -3052,9 +3050,9 @@ std::unique_ptr<Encoder> MakeEncoder(Type::type type_num, Encoding::type encodin
   } else if (encoding == Encoding::DELTA_BINARY_PACKED) {
     switch (type_num) {
       case Type::INT32:
-        return std::unique_ptr<Encoder>(new DeltaBitPackEncoder<Int32Type>(descr, pool));
+        return std::make_unique<DeltaBitPackEncoder<Int32Type>>(descr, pool);
       case Type::INT64:
-        return std::unique_ptr<Encoder>(new DeltaBitPackEncoder<Int64Type>(descr, pool));
+        return std::make_unique<DeltaBitPackEncoder<Int64Type>>(descr, pool);
       default:
         throw ParquetException(
             "DELTA_BINARY_PACKED encoder only supports INT32 and INT64");
@@ -3123,7 +3121,7 @@ std::unique_ptr<Decoder> MakeDecoder(Type::type type_num, Encoding::type encodin
     throw ParquetException("DELTA_LENGTH_BYTE_ARRAY only supports BYTE_ARRAY");
   } else if (encoding == Encoding::RLE) {
     if (type_num == Type::BOOLEAN) {
-      return std::unique_ptr<Decoder>(new RleBooleanDecoder(descr));
+      return std::make_unique<RleBooleanDecoder>(descr);
     }
     throw ParquetException("RLE encoding only supports BOOLEAN");
   } else {

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -294,9 +294,9 @@ class SerializedFile : public ParquetFileReader::Contents {
   }
 
   std::shared_ptr<RowGroupReader> GetRowGroup(int i) override {
-    std::unique_ptr<SerializedRowGroup> contents(
-        new SerializedRowGroup(source_, cached_source_, source_size_,
-                               file_metadata_.get(), i, properties_, file_decryptor_));
+    std::unique_ptr<SerializedRowGroup> contents = std::make_unique<SerializedRowGroup>(
+        source_, cached_source_, source_size_, file_metadata_.get(), i, properties_,
+        file_decryptor_);
     return std::make_shared<RowGroupReader>(std::move(contents));
   }
 
@@ -728,7 +728,7 @@ std::unique_ptr<ParquetFileReader> ParquetFileReader::Open(
     std::shared_ptr<::arrow::io::RandomAccessFile> source, const ReaderProperties& props,
     std::shared_ptr<FileMetaData> metadata) {
   auto contents = SerializedFile::Open(std::move(source), props, std::move(metadata));
-  std::unique_ptr<ParquetFileReader> result(new ParquetFileReader());
+  std::unique_ptr<ParquetFileReader> result = std::make_unique<ParquetFileReader>();
   result->Open(std::move(contents));
   return result;
 }
@@ -762,7 +762,7 @@ std::unique_ptr<ParquetFileReader> ParquetFileReader::OpenFile(
       completed.MarkFinished(contents.status());
       return;
     }
-    std::unique_ptr<ParquetFileReader> result(new ParquetFileReader());
+    std::unique_ptr<ParquetFileReader> result = std::make_unique<ParquetFileReader>();
     result->Open(fut.MoveResult().MoveValueUnsafe());
     completed.MarkFinished(std::move(result));
   });

--- a/cpp/src/parquet/file_writer.cc
+++ b/cpp/src/parquet/file_writer.cc
@@ -18,6 +18,7 @@
 #include "parquet/file_writer.h"
 
 #include <cstddef>
+#include <memory>
 #include <ostream>
 #include <string>
 #include <utility>
@@ -314,7 +315,7 @@ class FileSerializer : public ParquetFileWriter::Contents {
     std::unique_ptr<RowGroupWriter::Contents> contents(new RowGroupSerializer(
         sink_, rg_metadata, static_cast<int16_t>(num_row_groups_ - 1), properties_.get(),
         buffered_row_group, file_encryptor_.get()));
-    row_group_writer_.reset(new RowGroupWriter(std::move(contents)));
+    row_group_writer_ = std::make_unique<RowGroupWriter>(std::move(contents));
     return row_group_writer_.get();
   }
 
@@ -416,8 +417,8 @@ class FileSerializer : public ParquetFileWriter::Contents {
         }
       }
 
-      file_encryptor_.reset(new InternalFileEncryptor(file_encryption_properties,
-                                                      properties_->memory_pool()));
+      file_encryptor_ = std::make_unique<InternalFileEncryptor>(
+          file_encryption_properties, properties_->memory_pool());
       if (file_encryption_properties->encrypted_footer()) {
         PARQUET_THROW_NOT_OK(sink_->Write(kParquetEMagic, 4));
       } else {

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -164,7 +164,7 @@ std::unique_ptr<ColumnCryptoMetaData> ColumnCryptoMetaData::Make(
 }
 
 ColumnCryptoMetaData::ColumnCryptoMetaData(const uint8_t* metadata)
-    : impl_(new ColumnCryptoMetaDataImpl(
+    : impl_(std::make_unique<ColumnCryptoMetaDataImpl>(
           reinterpret_cast<const format::ColumnCryptoMetaData*>(metadata))) {}
 
 ColumnCryptoMetaData::~ColumnCryptoMetaData() = default;


### PR DESCRIPTION
This patch reuse the arrow issue https://issues.apache.org/jira/browse/ARROW-17823 .

Advantage: readabilty, exception safety and efficiency(only for shared_ptr).

Cases that don't apply: When calling a private/protected constructor within class member function, make_shared/unique can't work.