### PR TITLE
GH-15115: [R][CI] pyarrow tests fail on macos 10.13 due to missing pyarrow wheel

### DIFF
--- a/r/tests/testthat/test-python.R
+++ b/r/tests/testthat/test-python.R
@@ -24,6 +24,8 @@ test_that("install_pyarrow", {
   skip_if_not_installed("reticulate")
   # PyArrow doesn't support Python 3.6 or earlier
   skip_on_python_older_than("3.7")
+  # no pyarrow wheels for macos 10.13
+  skip_if(Sys.info()["sysname"] == "Darwin" && Sys.info()["release"] < 14)
 
   venv <- try(reticulate::virtualenv_create("arrow-test"))
   # Bail out if virtualenv isn't available

--- a/r/tests/testthat/test-python.R
+++ b/r/tests/testthat/test-python.R
@@ -25,7 +25,7 @@ test_that("install_pyarrow", {
   # PyArrow doesn't support Python 3.6 or earlier
   skip_on_python_older_than("3.7")
   # no pyarrow wheels for macos 10.13
-  skip_if(Sys.info()["sysname"] == "Darwin" && Sys.info()["release"] < 14)
+  skip_if(Sys.info()["sysname"] == "Darwin" && Sys.info()["release"] < 18)
 
   venv <- try(reticulate::virtualenv_create("arrow-test"))
   # Bail out if virtualenv isn't available


### PR DESCRIPTION

* Closes: #15115