### PR TITLE
GH-15126: [R] purrr::rerun was deprecated in purrr 1.0.0

### DIFF
--- a/r/tests/testthat/test-chunked-array.R
+++ b/r/tests/testthat/test-chunked-array.R
@@ -189,10 +189,10 @@ test_that("ChunkedArray handles NaN", {
 
 test_that("ChunkedArray supports logical vectors (ARROW-3341)", {
   # with NA
-  data <- purrr::rerun(3, sample(c(TRUE, FALSE, NA), 100, replace = TRUE))
+  data <- purrr::map(1:3, ~ sample(c(TRUE, FALSE, NA), 100, replace = TRUE))
   expect_chunked_roundtrip(data, bool())
   # without NA
-  data <- purrr::rerun(3, sample(c(TRUE, FALSE), 100, replace = TRUE))
+  data <- purrr::map(1:3, ~ sample(c(TRUE, FALSE), 100, replace = TRUE))
   expect_chunked_roundtrip(data, bool())
 })
 


### PR DESCRIPTION

* Closes: #15126