### PR TITLE
GH-15059: [C++][Acero] populate guarantee columns from expression intstead of fragment

### DIFF
--- a/cpp/src/arrow/dataset/dataset.h
+++ b/cpp/src/arrow/dataset/dataset.h
@@ -65,9 +65,12 @@ struct ARROW_DS_EXPORT FragmentSelectionColumn {
 /// The paths in this selection should be referring to the fragment schema.  This class
 /// contains a virtual destructor as it is expected evolution strategies will need to
 /// extend this to add any information needed to later evolve the batches.
-class FragmentSelection {
+///
+/// For example, in the basic evolution strategy, we keep track of which columns
+/// were missing from the file so that we can fill those in with null when evolving.
+class ARROW_DS_EXPORT FragmentSelection {
  public:
-  FragmentSelection(std::vector<FragmentSelectionColumn> columns)
+  explicit FragmentSelection(std::vector<FragmentSelectionColumn> columns)
       : columns_(std::move(columns)) {}
   virtual ~FragmentSelection() = default;
   /// The columns that should be loaded from the fragment

--- a/cpp/src/arrow/dataset/dataset.h
+++ b/cpp/src/arrow/dataset/dataset.h
@@ -58,8 +58,23 @@ struct ARROW_DS_EXPORT FragmentSelectionColumn {
   /// when reading from CSV, if we know the target type of the column, we can
   /// convert from string to the target type as we read.
   DataType* requested_type;
-  /// \brief The index in the output selection of this column
-  int selection_index;
+};
+
+/// \brief A list of columns that should be loaded from a fragment
+///
+/// The paths in this selection should be referring to the fragment schema.  This class
+/// contains a virtual destructor as it is expected evolution strategies will need to
+/// extend this to add any information needed to later evolve the batches.
+class FragmentSelection {
+ public:
+  FragmentSelection(std::vector<FragmentSelectionColumn> columns)
+      : columns_(std::move(columns)) {}
+  virtual ~FragmentSelection() = default;
+  /// The columns that should be loaded from the fragment
+  const std::vector<FragmentSelectionColumn>& columns() const { return columns_; }
+
+ private:
+  std::vector<FragmentSelectionColumn> columns_;
 };
 
 /// \brief Instructions for scanning a particular fragment
@@ -86,7 +101,7 @@ struct ARROW_DS_EXPORT FragmentScanRequest {
   /// to satisfy these columns.  If a format cannot partially read a nested
   /// column (e.g. JSON) then it must apply the column selection (in memory)
   /// before returning the scanned batch.
-  std::vector<FragmentSelectionColumn> columns;
+  std::shared_ptr<FragmentSelection> fragment_selection;
   /// \brief Options specific to the format being scanned
   const FragmentScanOptions* format_scan_options;
 };
@@ -274,7 +289,7 @@ class ARROW_DS_EXPORT FragmentEvolutionStrategy {
   /// For example, if the user wants fields 2 & 4 of the dataset schema and
   /// in this fragment the field 2 is missing and the field 4 is at index 1 then
   /// this should return {1}
-  virtual Result<std::vector<FragmentSelectionColumn>> DevolveSelection(
+  virtual Result<std::unique_ptr<FragmentSelection>> DevolveSelection(
       const std::vector<FieldPath>& dataset_schema_selection) const = 0;
 
   /// \brief Return a filter expression bound to the fragment schema given
@@ -302,7 +317,7 @@ class ARROW_DS_EXPORT FragmentEvolutionStrategy {
   virtual Result<compute::ExecBatch> EvolveBatch(
       const std::shared_ptr<RecordBatch>& batch,
       const std::vector<FieldPath>& dataset_selection,
-      const std::vector<FragmentSelectionColumn>& selection) const = 0;
+      const FragmentSelection& selection) const = 0;
 
   /// \brief Return a string description of this strategy
   virtual std::string ToString() const = 0;

--- a/cpp/src/arrow/dataset/file_csv.cc
+++ b/cpp/src/arrow/dataset/file_csv.cc
@@ -95,7 +95,7 @@ class CsvFileScanner : public FragmentScanner {
     auto convert_options = csv_options.convert_options;
     std::vector<std::string> columns;
     std::unordered_map<std::string, std::shared_ptr<DataType>> column_types;
-    for (const auto& scan_column : scan_request.columns) {
+    for (const auto& scan_column : scan_request.fragment_selection->columns()) {
       if (scan_column.path.indices().size() != 1) {
         return Status::Invalid("CSV reader does not supported nested references");
       }

--- a/cpp/src/arrow/dataset/file_json.cc
+++ b/cpp/src/arrow/dataset/file_json.cc
@@ -85,7 +85,7 @@ class JsonFragmentScanner : public FragmentScanner {
     std::unordered_set<int> indices;
     indices.reserve(inspected.column_names.size());
 
-    for (const auto& scan_column : scan_request.columns) {
+    for (const auto& scan_column : scan_request.fragment_selection->columns()) {
       const auto index = scan_column.path[0];
 
       if (!indices.emplace(index).second) continue;

--- a/cpp/src/arrow/dataset/scan_node.cc
+++ b/cpp/src/arrow/dataset/scan_node.cc
@@ -24,6 +24,7 @@
 
 #include "arrow/compute/exec/exec_plan.h"
 #include "arrow/compute/exec/expression.h"
+#include "arrow/compute/exec/expression_internal.h"
 #include "arrow/compute/exec/query_context.h"
 #include "arrow/compute/exec/util.h"
 #include "arrow/dataset/scanner.h"
@@ -87,6 +88,12 @@ Future<AsyncGenerator<std::shared_ptr<Fragment>>> GetFragments(Dataset* dataset,
 /// simple iteration of paths or, if the dataset is described with wildcards, this may
 /// involve I/O for listing and walking directory paths.  There is one listing io-task
 /// per dataset.
+///
+/// If a fragment has a guarantee we may use that expression to reduce the columns that
+/// we need to load from disk.  For example, if the guarantee is x==7 then we don't need
+/// to load the column x from disk and can instead populate x with the scalar 7.  If the
+/// fragment on disk actually had a column x, and the value was not 7, then we will prefer
+/// the guarantee in this invalid case.
 ///
 /// Ths next step is to fetch the metadata for the fragment.  For some formats (e.g.
 /// CSV) this may be quite simple (get the size of the file).  For other formats (e.g.
@@ -186,10 +193,16 @@ class ScanNode : public cp::ExecNode, public cp::TracedNode {
 
   Status Init() override { return Status::OK(); }
 
+  struct KnownValue {
+    std::size_t index;
+    Datum value;
+  };
+
   struct ScanState {
     std::mutex mutex;
     std::shared_ptr<FragmentScanner> fragment_scanner;
     std::unique_ptr<FragmentEvolutionStrategy> fragment_evolution;
+    std::vector<KnownValue> known_values;
     FragmentScanRequest scan_request;
   };
 
@@ -218,14 +231,38 @@ class ScanNode : public cp::ExecNode, public cp::TracedNode {
 
     std::string_view name() const override { return name_; }
 
+    compute::ExecBatch AddKnownValues(compute::ExecBatch batch) {
+      if (scan_->known_values.empty()) {
+        return batch;
+      }
+      std::vector<Datum> with_known_values;
+      int num_combined_cols =
+          static_cast<int>(batch.values.size() + scan_->known_values.size());
+      with_known_values.reserve(num_combined_cols);
+      auto known_values_itr = scan_->known_values.cbegin();
+      auto batch_itr = batch.values.begin();
+      for (int i = 0; i < num_combined_cols; i++) {
+        if (known_values_itr != scan_->known_values.end() &&
+            static_cast<int>(known_values_itr->index) == i) {
+          with_known_values.push_back(known_values_itr->value);
+          known_values_itr++;
+        } else {
+          with_known_values.push_back(std::move(*batch_itr));
+          batch_itr++;
+        }
+      }
+      return compute::ExecBatch(std::move(with_known_values), batch.length);
+    }
+
     Status HandleBatch(const std::shared_ptr<RecordBatch>& batch) {
       ARROW_ASSIGN_OR_RAISE(
           compute::ExecBatch evolved_batch,
-          scan_->fragment_evolution->EvolveBatch(batch, node_->options_.columns,
-                                                 scan_->scan_request.columns));
+          scan_->fragment_evolution->EvolveBatch(
+              batch, node_->options_.columns, *scan_->scan_request.fragment_selection));
+      compute::ExecBatch with_known_values = AddKnownValues(std::move(evolved_batch));
       node_->plan_->query_context()->ScheduleTask(
-          [node = node_, evolved_batch = std::move(evolved_batch)] {
-            return node->output_->InputReceived(node, std::move(evolved_batch));
+          [node = node_, output_batch = std::move(with_known_values)] {
+            return node->output_->InputReceived(node, output_batch);
           },
           "ScanNode::ProcessMorsel");
       return Status::OK();
@@ -257,13 +294,67 @@ class ScanNode : public cp::ExecNode, public cp::TracedNode {
 
     std::string_view name() const override { return name_; }
 
+    struct ExtractedKnownValues {
+      // Columns that must be loaded from the fragment
+      std::vector<FieldPath> remaining_columns;
+      // Columns whose value is already known from the partition guarantee
+      std::vector<KnownValue> known_values;
+    };
+
+    Result<ExtractedKnownValues> ExtractKnownValuesFromGuarantee(
+        const compute::Expression& guarantee) {
+      ARROW_ASSIGN_OR_RAISE(
+          compute::KnownFieldValues part_values,
+          compute::ExtractKnownFieldValues(fragment->partition_expression()));
+      ExtractedKnownValues extracted;
+      for (std::size_t i = 0; i < node->options_.columns.size(); i++) {
+        const auto& field_path = node->options_.columns[i];
+        FieldRef field_ref(field_path);
+        auto existing = part_values.map.find(FieldRef(field_path));
+        if (existing == part_values.map.end()) {
+          // Column not in our known values, we must load from fragment
+          extracted.remaining_columns.push_back(field_path);
+        } else {
+          ARROW_ASSIGN_OR_RAISE(const std::shared_ptr<Field>& field,
+                                field_path.Get(*node->options_.dataset->schema()));
+          Result<Datum> maybe_casted = compute::Cast(existing->second, field->type());
+          if (!maybe_casted.ok()) {
+            // TODO(weston) In theory this should be preventable.  The dataset and
+            // partitioning schemas are known at the beginning of the scan and we could
+            // compare the two and discover that they are incompatible.
+            //
+            // Provide some context here as this error can be confusing
+            return Status::Invalid(
+                "The dataset schema defines the field ", field_path, " as type ",
+                field->type()->ToString(), " but a partition column was found with type ",
+                existing->second.type()->ToString(), " which cannot be safely cast");
+          }
+          extracted.known_values.push_back({i, *maybe_casted});
+        }
+      }
+      return std::move(extracted);
+    }
+
     Future<> BeginScan(const std::shared_ptr<InspectedFragment>& inspected_fragment) {
+      // Based on the fragment's guarantee we may not need to retrieve all the columns
+      compute::Expression fragment_filter = node->options_.filter;
+      ARROW_ASSIGN_OR_RAISE(
+          compute::Expression filter_minus_part,
+          compute::SimplifyWithGuarantee(std::move(fragment_filter),
+                                         fragment->partition_expression()));
+
+      ARROW_ASSIGN_OR_RAISE(
+          ExtractedKnownValues extracted,
+          ExtractKnownValuesFromGuarantee(fragment->partition_expression()));
+
       // Now that we have an inspected fragment we need to use the dataset's evolution
       // strategy to figure out how to scan it
       scan_state->fragment_evolution =
           node->options_.dataset->evolution_strategy()->GetStrategy(
               *node->options_.dataset, *fragment, *inspected_fragment);
-      ARROW_RETURN_NOT_OK(InitFragmentScanRequest());
+      ARROW_RETURN_NOT_OK(InitFragmentScanRequest(extracted.remaining_columns,
+                                                  filter_minus_part,
+                                                  std::move(extracted.known_values)));
       return fragment
           ->BeginScan(scan_state->scan_request, *inspected_fragment,
                       node->options_.format_options,
@@ -302,20 +393,22 @@ class ScanNode : public cp::ExecNode, public cp::TracedNode {
 
     // Take the dataset options, and the fragment evolution, and figure out exactly how
     // we should scan the fragment itself.
-    Status InitFragmentScanRequest() {
+    Status InitFragmentScanRequest(const std::vector<FieldPath>& desired_columns,
+                                   const compute::Expression& filter,
+                                   std::vector<KnownValue> known_values) {
       ARROW_ASSIGN_OR_RAISE(
-          scan_state->scan_request.columns,
-          scan_state->fragment_evolution->DevolveSelection(node->options_.columns));
+          scan_state->scan_request.fragment_selection,
+          scan_state->fragment_evolution->DevolveSelection(desired_columns));
       ARROW_ASSIGN_OR_RAISE(
           compute::Expression devolution_guarantee,
-          scan_state->fragment_evolution->GetGuarantee(node->options_.columns));
-      ARROW_ASSIGN_OR_RAISE(
-          compute::Expression simplified_filter,
-          compute::SimplifyWithGuarantee(node->options_.filter, devolution_guarantee));
+          scan_state->fragment_evolution->GetGuarantee(desired_columns));
+      ARROW_ASSIGN_OR_RAISE(compute::Expression simplified_filter,
+                            compute::SimplifyWithGuarantee(filter, devolution_guarantee));
       ARROW_ASSIGN_OR_RAISE(
           scan_state->scan_request.filter,
           scan_state->fragment_evolution->DevolveFilter(std::move(simplified_filter)));
       scan_state->scan_request.format_scan_options = node->options_.format_options;
+      scan_state->known_values = std::move(known_values);
       return Status::OK();
     }
 

--- a/cpp/src/arrow/util/io_util.cc
+++ b/cpp/src/arrow/util/io_util.cc
@@ -135,11 +135,11 @@ std::basic_string<CharT> ReplaceChars(std::basic_string<CharT> s, CharT find, Ch
   return s;
 }
 
-Result<NativePathString> StringToNative(const std::string& s) {
+Result<NativePathString> StringToNative(std::string_view s) {
 #if _WIN32
   return ::arrow::util::UTF8ToWideString(s);
 #else
-  return s;
+  return std::string(s);
 #endif
 }
 
@@ -193,7 +193,7 @@ NativePathString NativeParent(const NativePathString& s) {
   }
 }
 
-Status ValidatePath(const std::string& s) {
+Status ValidatePath(std::string_view s) {
   if (s.find_first_of('\0') != std::string::npos) {
     return Status::Invalid("Embedded NUL char in path: '", s, "'");
   }
@@ -589,7 +589,7 @@ Result<PlatformFilename> PlatformFilename::Real() const {
   return PlatformFilename(std::move(real));
 }
 
-Result<PlatformFilename> PlatformFilename::FromString(const std::string& file_name) {
+Result<PlatformFilename> PlatformFilename::FromString(std::string_view file_name) {
   RETURN_NOT_OK(ValidatePath(file_name));
   ARROW_ASSIGN_OR_RAISE(auto ns, StringToNative(file_name));
   return PlatformFilename(std::move(ns));
@@ -603,8 +603,9 @@ PlatformFilename PlatformFilename::Join(const PlatformFilename& child) const {
   }
 }
 
-Result<PlatformFilename> PlatformFilename::Join(const std::string& child_name) const {
-  ARROW_ASSIGN_OR_RAISE(auto child, PlatformFilename::FromString(child_name));
+Result<PlatformFilename> PlatformFilename::Join(std::string_view child_name) const {
+  ARROW_ASSIGN_OR_RAISE(auto child,
+                        PlatformFilename::FromString(std::string(child_name)));
   return Join(child);
 }
 

--- a/cpp/src/arrow/util/io_util.h
+++ b/cpp/src/arrow/util/io_util.h
@@ -68,8 +68,8 @@ class ARROW_EXPORT PlatformFilename {
   Result<PlatformFilename> Real() const;
 
   // These functions can fail for character encoding reasons.
-  static Result<PlatformFilename> FromString(const std::string& file_name);
-  Result<PlatformFilename> Join(const std::string& child_name) const;
+  static Result<PlatformFilename> FromString(std::string_view file_name);
+  Result<PlatformFilename> Join(std::string_view child_name) const;
 
   PlatformFilename Join(const PlatformFilename& child_name) const;
 

--- a/cpp/src/arrow/util/utf8.cc
+++ b/cpp/src/arrow/util/utf8.cc
@@ -126,7 +126,7 @@ namespace {
 // Some platforms (such as old MinGWs) don't have the <codecvt> header,
 // so call into a vendored utf8 implementation instead.
 
-std::wstring UTF8ToWideStringInternal(const std::string_view& source) {
+std::wstring UTF8ToWideStringInternal(std::string_view source) {
   std::wstring ws;
 #if WCHAR_MAX > 0xFFFF
   ::utf8::utf8to32(source.begin(), source.end(), std::back_inserter(ws));

--- a/cpp/src/arrow/util/utf8.cc
+++ b/cpp/src/arrow/util/utf8.cc
@@ -126,7 +126,7 @@ namespace {
 // Some platforms (such as old MinGWs) don't have the <codecvt> header,
 // so call into a vendored utf8 implementation instead.
 
-std::wstring UTF8ToWideStringInternal(const std::string& source) {
+std::wstring UTF8ToWideStringInternal(const std::string_view& source) {
   std::wstring ws;
 #if WCHAR_MAX > 0xFFFF
   ::utf8::utf8to32(source.begin(), source.end(), std::back_inserter(ws));
@@ -148,7 +148,7 @@ std::string WideStringToUTF8Internal(const std::wstring& source) {
 
 }  // namespace
 
-Result<std::wstring> UTF8ToWideString(const std::string& source) {
+Result<std::wstring> UTF8ToWideString(const std::string_view& source) {
   try {
     return UTF8ToWideStringInternal(source);
   } catch (std::exception& e) {

--- a/cpp/src/arrow/util/utf8.cc
+++ b/cpp/src/arrow/util/utf8.cc
@@ -148,7 +148,7 @@ std::string WideStringToUTF8Internal(const std::wstring& source) {
 
 }  // namespace
 
-Result<std::wstring> UTF8ToWideString(const std::string_view& source) {
+Result<std::wstring> UTF8ToWideString(std::string_view source) {
   try {
     return UTF8ToWideStringInternal(source);
   } catch (std::exception& e) {

--- a/cpp/src/arrow/util/utf8.h
+++ b/cpp/src/arrow/util/utf8.h
@@ -31,7 +31,7 @@ namespace util {
 
 // Convert a UTF8 string to a wstring (either UTF16 or UTF32, depending
 // on the wchar_t width).
-ARROW_EXPORT Result<std::wstring> UTF8ToWideString(const std::string_view& source);
+ARROW_EXPORT Result<std::wstring> UTF8ToWideString(std::string_view source);
 
 // Similarly, convert a wstring to a UTF8 string.
 ARROW_EXPORT Result<std::string> WideStringToUTF8(const std::wstring& source);

--- a/cpp/src/arrow/util/utf8.h
+++ b/cpp/src/arrow/util/utf8.h
@@ -31,7 +31,7 @@ namespace util {
 
 // Convert a UTF8 string to a wstring (either UTF16 or UTF32, depending
 // on the wchar_t width).
-ARROW_EXPORT Result<std::wstring> UTF8ToWideString(const std::string& source);
+ARROW_EXPORT Result<std::wstring> UTF8ToWideString(const std::string_view& source);
 
 // Similarly, convert a wstring to a UTF8 string.
 ARROW_EXPORT Result<std::string> WideStringToUTF8(const std::wstring& source);


### PR DESCRIPTION
If a fragment has a guarantee like `x == 5` then we don't need to load the column `x` from disk and can instead just use the scalar `5`.  This is not just a performance improvement.  In many cases, users will create partitioned datasets without actually storing the partition value as a separate column (e.g. the file `my_dataset/x=5/foo.parquet` will not have a column named `x`)
* Closes: #15059