### PR TITLE
ARROW-18202: [C++] Reallow regexp replace on empty string

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_string_ascii.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_ascii.cc
@@ -2045,13 +2045,10 @@ struct RegexSubstringReplacer {
         regex_replacement_(options_.pattern, MakeRE2Options<Type>()) {}
 
   Status ReplaceString(std::string_view s, TypedBufferBuilder<uint8_t>* builder) const {
-    if (s.empty()) {
-      // Special-case empty input as s.data() may not be a valid pointer
-      return Status::OK();
-    }
     re2::StringPiece replacement(options_.replacement);
 
-    if (options_.max_replacements == -1) {
+    // If s is empty, then it's essentially global
+    if (options_.max_replacements == -1 || s.empty()) {
       std::string s_copy(s);
       RE2::GlobalReplace(&s_copy, regex_replacement_, replacement);
       return builder->Append(reinterpret_cast<const uint8_t*>(s_copy.data()),

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -1753,6 +1753,11 @@ TYPED_TEST(TestBaseBinaryKernels, ReplaceSubstringRegex) {
   this->CheckUnary("replace_substring_regex", R"(["aaaaaa"])", this->type(),
                    R"(["abaaaaabaaaa"])", &options);
 
+  // ARROW-18202: Allow matching against empty string again
+  options = ReplaceSubstringOptions{"^$", "x"};
+  this->CheckUnary("replace_substring_regex", R"([""])", this->type(), R"(["x"])",
+                   &options);
+
   // ARROW-12774
   options = ReplaceSubstringOptions{"X", "Y"};
   this->CheckUnary("replace_substring_regex",


### PR DESCRIPTION
While not necessarily optimal, it should be possible to replace the regexp match `^$` with something. We changed in 10.0.0 to early return on empty string inputs, breaking this. This PR brings that ability back.