### PR TITLE
GH-15134: [Ruby] Specify -mmacox-version-min=10.14 explicitly for old Xcode

### DIFF
--- a/ruby/red-arrow/ext/arrow/extconf.rb
+++ b/ruby/red-arrow/ext/arrow/extconf.rb
@@ -84,6 +84,9 @@ when /darwin/
   symbols_in_external_bundles.each do |symbol|
     $DLDFLAGS << " -Wl,-U,#{symbol}"
   end
+  mmacosx_version_min = "-mmacosx-version-min=10.14"
+  $CFLAGS << " #{mmacosx_version_min}"
+  $CXXFLAGS << " #{mmacosx_version_min}"
 end
 
 create_makefile("arrow")


### PR DESCRIPTION
This suppresses the following error with old Xcode:

    /tmp/local/include/arrow/type.h:1745:36: error:
    'get<arrow::FieldPath, arrow::FieldPath, std::string,
    std::vector<arrow::FieldRef>>' is unavailable: introduced in macOS
    10.13
        if (IsFieldPath()) return std::get<FieldPath>(impl_).indices().size() > 1;
                                       ^
* Closes: #15134