### PR TITLE
GH-15141: [C++] fix for unstable test due to unstable sort

### DIFF
--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -808,7 +808,9 @@ TEST(ExecPlanExecution, StressSourceOrderBy) {
                            TableFromExecBatches(input_schema, random_data.batches));
       ASSERT_OK_AND_ASSIGN(auto sort_indices, SortIndices(original, options));
       ASSERT_OK_AND_ASSIGN(auto expected, Take(original, sort_indices));
-      AssertTablesEqual(*actual, *expected.table());
+      AssertSchemaEqual(actual->schema(), expected.table()->schema());
+      AssertArraysEqual(*actual->column(0)->chunk(0),
+                        *expected.table()->column(0)->chunk(0));
     }
   }
 }


### PR DESCRIPTION
The sorting done by orderby is not stable.  This means, given the input:

a | b
--- | ---
1 | false
1 | true

the test could have generated both `[false, true]` and `[true, false]` for the `b` column.  We likely did not encounter this before https://github.com/apache/arrow/commit/498b645e1d09306bf5399a9a019a5caa99513815 because the entire thing was run serially (even though there was a `parallel` option it was not setup correctly).

Now that things are properly running parallel the results are non-deterministic.  We could remove the `b` column but I feel it is a better stress test to have at least one payload column.  So I changed the test to only compare the key array and not the payload array.
* Closes: #15141