### PR TITLE
GH-15156: [JS] Fix can't find variable: BigInt64Array

### DIFF
--- a/js/src/type.ts
+++ b/js/src/type.ts
@@ -21,6 +21,7 @@ import { MapRow } from './row/map.js';
 import { StructRow, StructRowProxy } from './row/struct.js';
 import { Long } from 'flatbuffers';
 import { TypedArrayConstructor } from './interfaces.js';
+import { BigInt64Array, BigUint64Array } from './util/compat.js';
 
 import {
     Type,

--- a/js/src/util/pretty.ts
+++ b/js/src/util/pretty.ts
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import { BigInt64Array, BigUint64Array } from './compat.js';
+
 /** @ignore */ const undf = void (0);
 
 /** @ignore */

--- a/js/src/vector.ts
+++ b/js/src/vector.ts
@@ -30,6 +30,7 @@ import {
     wrapChunkedCall2,
     wrapChunkedIndexOf,
 } from './util/chunk.js';
+import { BigInt64Array, BigUint64Array } from './util/compat.js';
 
 import { instance as getVisitor } from './visitor/get.js';
 import { instance as setVisitor } from './visitor/set.js';


### PR DESCRIPTION
Use the `BigInt64Array` and `BigUint64Array` types from `compat.ts` where it wasn't used.

This fixes the `ReferenceError: Can't find variable: BigInt64Array` that appears when the library is used in a browser without that support.

* Closes: #15156