### PR TITLE
MINOR: [Docs][Java] Fix a link to IPC RecordBatch message

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowRecordBatch.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowRecordBatch.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
 import com.google.flatbuffers.FlatBufferBuilder;
 
 /**
- * POJO representation of a RecordBatch IPC message (https://arrow.apache.org/docs/format/IPC.html).
+ * POJO representation of a RecordBatch IPC message (https://arrow.apache.org/docs/format/Columnar.html#recordbatch-message).
  */
 public class ArrowRecordBatch implements ArrowMessage {
 


### PR DESCRIPTION
The link used to lead to the page that says 

> The contents of this document have relocated to the main [Columnar Specification](https://arrow.apache.org/docs/format/Columnar.html#format-columnar) page.

now the link leads to the exact place in the documentation