### PR TITLE
GH-15074: [Parquet][C++] change 16-bit page_ordinal to 32-bit

### DIFF
--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -261,7 +261,7 @@ class SerializedPageReader : public PageReader {
 
  private:
   void UpdateDecryption(const std::shared_ptr<Decryptor>& decryptor, int8_t module_type,
-                        const std::string& page_aad);
+                        std::string* page_aad);
 
   void InitDecryption();
 
@@ -329,8 +329,7 @@ void SerializedPageReader::InitDecryption() {
 }
 
 void SerializedPageReader::UpdateDecryption(const std::shared_ptr<Decryptor>& decryptor,
-                                            int8_t module_type,
-                                            const std::string& page_aad) {
+                                            int8_t module_type, std::string* page_aad) {
   DCHECK(decryptor != nullptr);
   if (crypto_ctx_.start_decrypt_with_dictionary_page) {
     std::string aad = encryption::CreateModuleAad(
@@ -338,8 +337,8 @@ void SerializedPageReader::UpdateDecryption(const std::shared_ptr<Decryptor>& de
         crypto_ctx_.column_ordinal, kNonPageOrdinal);
     decryptor->UpdateAad(aad);
   } else {
-    encryption::QuickUpdatePageAad(page_aad, page_ordinal_);
-    decryptor->UpdateAad(page_aad);
+    encryption::QuickUpdatePageAad(page_ordinal_, page_aad);
+    decryptor->UpdateAad(*page_aad);
   }
 }
 
@@ -366,7 +365,7 @@ std::shared_ptr<Page> SerializedPageReader::NextPage() {
       try {
         if (crypto_ctx_.meta_decryptor != nullptr) {
           UpdateDecryption(crypto_ctx_.meta_decryptor, encryption::kDictionaryPageHeader,
-                           data_page_header_aad_);
+                           &data_page_header_aad_);
         }
         deserializer.DeserializeMessage(reinterpret_cast<const uint8_t*>(view.data()),
                                         &header_size, &current_page_header_,
@@ -394,7 +393,7 @@ std::shared_ptr<Page> SerializedPageReader::NextPage() {
 
     if (crypto_ctx_.data_decryptor != nullptr) {
       UpdateDecryption(crypto_ctx_.data_decryptor, encryption::kDictionaryPage,
-                       data_page_aad_);
+                       &data_page_aad_);
     }
 
     // Read the compressed data page.

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -291,7 +291,7 @@ class SerializedPageReader : public PageReader {
 
   // The ordinal fields in the context below are used for AAD suffix calculation.
   CryptoContext crypto_ctx_;
-  int16_t page_ordinal_;  // page ordinal does not count the dictionary page
+  int32_t page_ordinal_;  // page ordinal does not count the dictionary page
 
   // Maximum allowed page size
   uint32_t max_page_header_size_;

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -482,12 +482,12 @@ class SerializedPageWriter : public PageWriter {
         break;
       }
       case encryption::kDataPage: {
-        encryption::QuickUpdatePageAad(data_page_aad_, page_ordinal_);
+        encryption::QuickUpdatePageAad(page_ordinal_, &data_page_aad_);
         data_encryptor_->UpdateAad(data_page_aad_);
         break;
       }
       case encryption::kDataPageHeader: {
-        encryption::QuickUpdatePageAad(data_page_header_aad_, page_ordinal_);
+        encryption::QuickUpdatePageAad(page_ordinal_, &data_page_header_aad_);
         meta_encryptor_->UpdateAad(data_page_header_aad_);
         break;
       }

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -516,7 +516,7 @@ class SerializedPageWriter : public PageWriter {
   int64_t data_page_offset_;
   int64_t total_uncompressed_size_;
   int64_t total_compressed_size_;
-  int16_t page_ordinal_;
+  int32_t page_ordinal_;
   int16_t row_group_ordinal_;
   int16_t column_ordinal_;
 

--- a/cpp/src/parquet/encryption/encryption_internal.h
+++ b/cpp/src/parquet/encryption/encryption_internal.h
@@ -124,7 +124,7 @@ std::string CreateModuleAad(const std::string& file_aad, int8_t module_type,
 std::string CreateFooterAad(const std::string& aad_prefix_bytes);
 
 // Update last two bytes of page (or page header) module AAD
-void QuickUpdatePageAad(const std::string& AAD, int32_t new_page_ordinal);
+void QuickUpdatePageAad(int32_t new_page_ordinal, std::string* AAD);
 
 // Wraps OpenSSL RAND_bytes function
 void RandBytes(unsigned char* buf, int num);

--- a/cpp/src/parquet/encryption/encryption_internal.h
+++ b/cpp/src/parquet/encryption/encryption_internal.h
@@ -119,12 +119,12 @@ class AesDecryptor {
 
 std::string CreateModuleAad(const std::string& file_aad, int8_t module_type,
                             int16_t row_group_ordinal, int16_t column_ordinal,
-                            int16_t page_ordinal);
+                            int32_t page_ordinal);
 
 std::string CreateFooterAad(const std::string& aad_prefix_bytes);
 
 // Update last two bytes of page (or page header) module AAD
-void QuickUpdatePageAad(const std::string& AAD, int16_t new_page_ordinal);
+void QuickUpdatePageAad(const std::string& AAD, int32_t new_page_ordinal);
 
 // Wraps OpenSSL RAND_bytes function
 void RandBytes(unsigned char* buf, int num);

--- a/cpp/src/parquet/encryption/encryption_internal_nossl.cc
+++ b/cpp/src/parquet/encryption/encryption_internal_nossl.cc
@@ -99,7 +99,7 @@ int AesDecryptor::CiphertextSizeDelta() {
 
 std::string CreateModuleAad(const std::string& file_aad, int8_t module_type,
                             int16_t row_group_ordinal, int16_t column_ordinal,
-                            int16_t page_ordinal) {
+                            int32_t page_ordinal) {
   ThrowOpenSSLRequiredException();
   return "";
 }
@@ -109,7 +109,7 @@ std::string CreateFooterAad(const std::string& aad_prefix_bytes) {
   return "";
 }
 
-void QuickUpdatePageAad(const std::string& AAD, int16_t new_page_ordinal) {
+void QuickUpdatePageAad(const std::string& AAD, int32_t new_page_ordinal) {
   ThrowOpenSSLRequiredException();
 }
 

--- a/cpp/src/parquet/encryption/encryption_internal_nossl.cc
+++ b/cpp/src/parquet/encryption/encryption_internal_nossl.cc
@@ -109,7 +109,7 @@ std::string CreateFooterAad(const std::string& aad_prefix_bytes) {
   return "";
 }
 
-void QuickUpdatePageAad(const std::string& AAD, int32_t new_page_ordinal) {
+void QuickUpdatePageAad(int32_t new_page_ordinal, std::string* AAD) {
   ThrowOpenSSLRequiredException();
 }
 

--- a/cpp/src/parquet/reader_test.cc
+++ b/cpp/src/parquet/reader_test.cc
@@ -1036,18 +1036,18 @@ TEST(TestFileReader, TestOverflowInt16PageOrdinal) {
     EXPECT_NE(nullptr, column_reader);
     constexpr int kBatchLength = 1024;
     std::array<bool, kBatchLength> boolean_values{};
-    int64_t value_sum = 0;
-    int64_t value_num = 0;
+    int64_t total_values = 0;
+    int64_t values_read = 0;
     do {
-      value_num = 0;
+      values_read = 0;
       column_reader->ReadBatch(kBatchLength, nullptr, nullptr, boolean_values.data(),
-                               &value_num);
-      value_sum += value_num;
-      for (int i = 0; i < value_num; ++i) {
+                               &values_read);
+      total_values += values_read;
+      for (int i = 0; i < values_read; ++i) {
         EXPECT_FALSE(boolean_values[i]);
       }
-    } while (value_num != 0);
-    EXPECT_EQ(40000, value_sum);
+    } while (values_read != 0);
+    EXPECT_EQ(40000, total_values);
   }
   {
     auto page_reader = row_group->GetColumnPageReader(0);


### PR DESCRIPTION
As we mentioned in https://github.com/apache/arrow/issues/15074 . `int16_t page_ordinal` may causing overflow. So, we need to change it to 32-bit.

* [x] Implement the logic
* [x] Testing
  * [x] Upload a file with more than `int16_t` pages in parquet-testing.
* Closes: #15074