### PR TITLE
GH-15151: [C++] ]Adding RecordBatchReaderSource to solve an issue in R API

### DIFF
--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -784,10 +784,9 @@ arrow::Status RecordBatchReaderSourceSinkExample() {
   std::shared_ptr<arrow::RecordBatchReader> reader =
       std::make_shared<arrow::TableBatchReader>(table);
 
-  ARROW_ASSIGN_OR_RAISE(
-      cp::ExecNode * source,
-      cp::MakeExecNode("record_batch_reader_source", plan.get(), {},
-                       cp::RecordBatchReaderSourceNodeOptions{table->schema(), reader}));
+  ARROW_ASSIGN_OR_RAISE(cp::ExecNode * source,
+                        cp::MakeExecNode("record_batch_reader_source", plan.get(), {},
+                                         cp::RecordBatchReaderSourceNodeOptions{reader}));
   ARROW_RETURN_NOT_OK(cp::MakeExecNode(
       "order_by_sink", plan.get(), {source},
       cp::OrderBySinkNodeOptions{

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -772,9 +772,6 @@ arrow::Status TableSinkExample() {
 /// receiving data from a TableRecordBatchReader.
 
 arrow::Status RecordBatchReaderSourceSinkExample() {
-  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<cp::ExecPlan> plan,
-                        cp::ExecPlan::Make(*cp::threaded_exec_context()));
-
   ARROW_ASSIGN_OR_RAISE(auto table, GetTable());
   std::shared_ptr<arrow::RecordBatchReader> reader =
       std::make_shared<arrow::TableBatchReader>(table);
@@ -783,7 +780,7 @@ arrow::Status RecordBatchReaderSourceSinkExample() {
   return ExecutePlanAndCollectAsTable(std::move(reader_source));
 }
 
-// (Doc section: Table Sink Example)
+// (Doc section: RecordBatchReaderSource Example)
 
 enum ExampleMode {
   SOURCE_SINK = 0,

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -128,13 +128,9 @@ class ARROW_EXPORT SchemaSourceNodeOptions : public ExecNodeOptions {
 
 class ARROW_EXPORT RecordBatchReaderSourceNodeOptions : public ExecNodeOptions {
  public:
-  RecordBatchReaderSourceNodeOptions(std::shared_ptr<Schema> schema,
-                                     std::shared_ptr<RecordBatchReader> reader,
+  RecordBatchReaderSourceNodeOptions(std::shared_ptr<RecordBatchReader> reader,
                                      arrow::internal::Executor* io_executor = NULLPTR)
-      : schema(schema), reader(std::move(reader)), io_executor(io_executor) {}
-
-  /// \brief The schema of the record batches from the iterator
-  std::shared_ptr<Schema> schema;
+      : reader(std::move(reader)), io_executor(io_executor) {}
 
   /// \brief The RecordBatchReader which acts as the data source
   std::shared_ptr<RecordBatchReader> reader;

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -136,10 +136,10 @@ class ARROW_EXPORT RecordBatchReaderSourceNodeOptions : public ExecNodeOptions {
   /// \brief The schema of the record batches from the iterator
   std::shared_ptr<Schema> schema;
 
-  /// \brief A maker of an iterator which acts as the data source
+  /// \brief The RecordBatchReader which acts as the data source
   std::shared_ptr<RecordBatchReader> reader;
 
-  /// \brief The executor to use for scanning the iterator
+  /// \brief The executor to use for the reader
   ///
   /// Defaults to the default I/O executor.
   arrow::internal::Executor* io_executor;

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -126,6 +126,25 @@ class ARROW_EXPORT SchemaSourceNodeOptions : public ExecNodeOptions {
   arrow::internal::Executor* io_executor;
 };
 
+class ARROW_EXPORT RecordBatchReaderSourceNodeOptions : public ExecNodeOptions {
+ public:
+  RecordBatchReaderSourceNodeOptions(std::shared_ptr<Schema> schema,
+                                     std::shared_ptr<RecordBatchReader> reader,
+                                     arrow::internal::Executor* io_executor = NULLPTR)
+      : schema(schema), reader(std::move(reader)), io_executor(io_executor) {}
+
+  /// \brief The schema of the record batches from the iterator
+  std::shared_ptr<Schema> schema;
+
+  /// \brief A maker of an iterator which acts as the data source
+  std::shared_ptr<RecordBatchReader> reader;
+
+  /// \brief The executor to use for scanning the iterator
+  ///
+  /// Defaults to the default I/O executor.
+  arrow::internal::Executor* io_executor;
+};
+
 using ArrayVectorIteratorMaker = std::function<Iterator<std::shared_ptr<ArrayVector>>()>;
 /// \brief An extended Source node which accepts a schema and array-vectors
 class ARROW_EXPORT ArrayVectorSourceNodeOptions
@@ -143,11 +162,6 @@ class ARROW_EXPORT ExecBatchSourceNodeOptions
 using RecordBatchIteratorMaker = std::function<Iterator<std::shared_ptr<RecordBatch>>()>;
 /// \brief An extended Source node which accepts a schema and record-batches
 class ARROW_EXPORT RecordBatchSourceNodeOptions
-    : public SchemaSourceNodeOptions<RecordBatchIteratorMaker> {
-  using SchemaSourceNodeOptions::SchemaSourceNodeOptions;
-};
-
-class ARROW_EXPORT RecordBatchReaderSourceNodeOptions
     : public SchemaSourceNodeOptions<RecordBatchIteratorMaker> {
   using SchemaSourceNodeOptions::SchemaSourceNodeOptions;
 };

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -147,6 +147,11 @@ class ARROW_EXPORT RecordBatchSourceNodeOptions
   using SchemaSourceNodeOptions::SchemaSourceNodeOptions;
 };
 
+class ARROW_EXPORT RecordBatchReaderSourceNodeOptions
+    : public SchemaSourceNodeOptions<RecordBatchIteratorMaker> {
+  using SchemaSourceNodeOptions::SchemaSourceNodeOptions;
+};
+
 /// \brief Make a node which excludes some rows from batches passed through it
 ///
 /// filter_expression will be evaluated against each batch which is pushed to

--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -364,7 +364,6 @@ void TestRecordBatchReaderSourceSinkError(
     std::function<Result<std::shared_ptr<RecordBatchReader>>(const BatchesWithSchema&)>
         to_reader) {
   ASSERT_OK_AND_ASSIGN(auto plan, ExecPlan::Make());
-  std::shared_ptr<Schema> no_schema;
   auto source_factory_name = "record_batch_reader_source";
   auto exp_batches = MakeBasicBatches();
   ASSERT_OK_AND_ASSIGN(std::shared_ptr<RecordBatchReader> reader, to_reader(exp_batches));

--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -354,7 +354,7 @@ void TestRecordBatchReaderSourceSink(
 
   auto exp_batches = MakeBasicBatches();
   ASSERT_OK_AND_ASSIGN(std::shared_ptr<RecordBatchReader> reader, to_reader(exp_batches));
-  RecordBatchReaderSourceNodeOptions options{reader, io::internal::GetIOThreadPool()};
+  RecordBatchReaderSourceNodeOptions options{reader};
   ASSERT_OK(Declaration::Sequence({
                                       {"record_batch_reader_source", options},
                                       {"sink", SinkNodeOptions{&sink_gen}},

--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -354,7 +354,7 @@ void TestRecordBatchReaderSourceSink(
                          to_reader(exp_batches));
     RecordBatchReaderSourceNodeOptions options{reader};
     Declaration plan("record_batch_reader_source", std::move(options));
-    ASSERT_OK_AND_ASSIGN(auto result, DeclarationToExecBatches(plan, false));
+    ASSERT_OK_AND_ASSIGN(auto result, DeclarationToExecBatches(plan, parallel));
     AssertExecBatchesEqualIgnoringOrder(result.schema, result.batches,
                                         exp_batches.batches);
   }

--- a/cpp/src/arrow/compute/exec/source_node.cc
+++ b/cpp/src/arrow/compute/exec/source_node.cc
@@ -409,10 +409,6 @@ struct RecordBatchSourceNode
 
 const char RecordBatchSourceNode::kKindName[] = "RecordBatchSourceNode";
 
-/// RecordBatchReaderSourceNode Start
-
-/// RecordBatchReaderSourceNode End
-
 struct ExecBatchSourceNode
     : public SchemaSourceNode<ExecBatchSourceNode, ExecBatchSourceNodeOptions> {
   using ExecBatchSchemaSourceNode =

--- a/cpp/src/arrow/compute/exec/source_node.cc
+++ b/cpp/src/arrow/compute/exec/source_node.cc
@@ -340,11 +340,11 @@ struct RecordBatchReaderSourceNode : public SourceNode {
     auto& reader = cast_options.reader;
     auto io_executor = cast_options.io_executor;
 
-    if (reader == NULLPTR) {
+    if (reader == nullptr) {
       return Status::Invalid(kKindName, " requires a reader which is not null");
     }
 
-    if (io_executor == NULLPTR) {
+    if (io_executor == nullptr) {
       io_executor = io::internal::GetIOThreadPool();
     }
 
@@ -356,10 +356,9 @@ struct RecordBatchReaderSourceNode : public SourceNode {
   static Result<arrow::AsyncGenerator<std::optional<ExecBatch>>> MakeGenerator(
       const std::shared_ptr<RecordBatchReader>& reader,
       arrow::internal::Executor* io_executor) {
-    const auto& schema = reader->schema();
     auto to_exec_batch =
-        [schema](const std::shared_ptr<RecordBatch>& batch) -> std::optional<ExecBatch> {
-      if (batch == NULLPTR || *batch->schema() != *schema) {
+        [](const std::shared_ptr<RecordBatch>& batch) -> std::optional<ExecBatch> {
+      if (batch == NULLPTR) {
         return std::nullopt;
       }
       return std::optional<ExecBatch>(ExecBatch(*batch));

--- a/cpp/src/arrow/compute/exec/test_util.cc
+++ b/cpp/src/arrow/compute/exec/test_util.cc
@@ -290,6 +290,18 @@ Result<std::vector<std::shared_ptr<RecordBatch>>> ToRecordBatches(
   return record_batches;
 }
 
+Result<std::shared_ptr<RecordBatchReader>> ToRecordBatcheReader(
+    const BatchesWithSchema& batches_with_schema) {
+  std::vector<std::shared_ptr<RecordBatch>> record_batches;
+  for (auto batch : batches_with_schema.batches) {
+    ARROW_ASSIGN_OR_RAISE(auto record_batch,
+                          batch.ToRecordBatch(batches_with_schema.schema));
+    record_batches.push_back(record_batch);
+  }
+  ARROW_ASSIGN_OR_RAISE(auto table, Table::FromRecordBatches(std::move(record_batches)));
+  return std::make_shared<arrow::TableBatchReader>(std::move(table));
+}
+
 Result<std::shared_ptr<Table>> SortTableOnAllFields(const std::shared_ptr<Table>& tab) {
   std::vector<SortKey> sort_keys;
   for (int i = 0; i < tab->num_columns(); i++) {

--- a/cpp/src/arrow/compute/exec/test_util.cc
+++ b/cpp/src/arrow/compute/exec/test_util.cc
@@ -296,7 +296,7 @@ Result<std::shared_ptr<RecordBatchReader>> ToRecordBatchReader(
   for (auto batch : batches_with_schema.batches) {
     ARROW_ASSIGN_OR_RAISE(auto record_batch,
                           batch.ToRecordBatch(batches_with_schema.schema));
-    record_batches.push_back(record_batch);
+    record_batches.push_back(std::move(record_batch));
   }
   ARROW_ASSIGN_OR_RAISE(auto table, Table::FromRecordBatches(std::move(record_batches)));
   return std::make_shared<arrow::TableBatchReader>(std::move(table));

--- a/cpp/src/arrow/compute/exec/test_util.cc
+++ b/cpp/src/arrow/compute/exec/test_util.cc
@@ -273,8 +273,7 @@ Result<std::vector<std::shared_ptr<ExecBatch>>> ToExecBatches(
     const BatchesWithSchema& batches_with_schema) {
   std::vector<std::shared_ptr<ExecBatch>> exec_batches;
   for (auto batch : batches_with_schema.batches) {
-    auto exec_batch = std::make_shared<ExecBatch>(batch);
-    exec_batches.push_back(exec_batch);
+    exec_batches.push_back(std::make_shared<ExecBatch>(batch));
   }
   return exec_batches;
 }
@@ -285,7 +284,7 @@ Result<std::vector<std::shared_ptr<RecordBatch>>> ToRecordBatches(
   for (auto batch : batches_with_schema.batches) {
     ARROW_ASSIGN_OR_RAISE(auto record_batch,
                           batch.ToRecordBatch(batches_with_schema.schema));
-    record_batches.push_back(record_batch);
+    record_batches.push_back(std::move(record_batch));
   }
   return record_batches;
 }

--- a/cpp/src/arrow/compute/exec/test_util.cc
+++ b/cpp/src/arrow/compute/exec/test_util.cc
@@ -290,7 +290,7 @@ Result<std::vector<std::shared_ptr<RecordBatch>>> ToRecordBatches(
   return record_batches;
 }
 
-Result<std::shared_ptr<RecordBatchReader>> ToRecordBatcheReader(
+Result<std::shared_ptr<RecordBatchReader>> ToRecordBatchReader(
     const BatchesWithSchema& batches_with_schema) {
   std::vector<std::shared_ptr<RecordBatch>> record_batches;
   for (auto batch : batches_with_schema.batches) {

--- a/cpp/src/arrow/compute/exec/test_util.h
+++ b/cpp/src/arrow/compute/exec/test_util.h
@@ -128,6 +128,10 @@ Result<std::vector<std::shared_ptr<RecordBatch>>> ToRecordBatches(
     const BatchesWithSchema& batches);
 
 ARROW_TESTING_EXPORT
+Result<std::shared_ptr<RecordBatchReader>> ToRecordBatcheReader(
+    const BatchesWithSchema& batches_with_schema);
+
+ARROW_TESTING_EXPORT
 Result<std::vector<std::shared_ptr<ArrayVector>>> ToArrayVectors(
     const BatchesWithSchema& batches_with_schema);
 

--- a/cpp/src/arrow/compute/exec/test_util.h
+++ b/cpp/src/arrow/compute/exec/test_util.h
@@ -128,7 +128,7 @@ Result<std::vector<std::shared_ptr<RecordBatch>>> ToRecordBatches(
     const BatchesWithSchema& batches);
 
 ARROW_TESTING_EXPORT
-Result<std::shared_ptr<RecordBatchReader>> ToRecordBatcheReader(
+Result<std::shared_ptr<RecordBatchReader>> ToRecordBatchReader(
     const BatchesWithSchema& batches_with_schema);
 
 ARROW_TESTING_EXPORT

--- a/r/src/compute-exec.cpp
+++ b/r/src/compute-exec.cpp
@@ -30,15 +30,6 @@
 #include <iostream>
 #include <optional>
 
-// GH-15151: Best path forward to make this available without a hack like this one
-namespace arrow {
-namespace io {
-namespace internal {
-arrow::internal::ThreadPool* GetIOThreadPool();
-}
-}  // namespace io
-}  // namespace arrow
-
 namespace compute = ::arrow::compute;
 
 std::shared_ptr<compute::FunctionOptions> make_compute_options(std::string func_name,
@@ -459,12 +450,8 @@ std::shared_ptr<compute::ExecNode> ExecNode_Union(
 std::shared_ptr<compute::ExecNode> ExecNode_SourceNode(
     const std::shared_ptr<compute::ExecPlan>& plan,
     const std::shared_ptr<arrow::RecordBatchReader>& reader) {
-  arrow::compute::SourceNodeOptions options{
-      /*output_schema=*/reader->schema(),
-      /*generator=*/ValueOrStop(
-          compute::MakeReaderGenerator(reader, arrow::io::internal::GetIOThreadPool()))};
-
-  return MakeExecNodeOrStop("source", plan.get(), {}, options);
+  arrow::compute::RecordBatchReaderSourceNodeOptions options{reader};
+  return MakeExecNodeOrStop("record_batch_reader_source", plan.get(), {}, options);
 }
 
 // [[arrow::export]]


### PR DESCRIPTION
This PR includes the factory `record_batch_reader_source` for the Acero. This is a source node which takes in a `RecordBatchReader` as the data source along an executor which gives the freedom to choose the threadpool required for the execution. Also an example shows how this can be used in Acero.

- [x] Self-review
* Closes: #15151