### PR TITLE
GH-15199: [C++][Substrait] Allow AGGREGATION_INVOCATION_UNSPECIFIED as valid invocation

### DIFF
--- a/cpp/src/arrow/engine/substrait/expression_internal.cc
+++ b/cpp/src/arrow/engine/substrait/expression_internal.cc
@@ -147,12 +147,9 @@ Result<SubstraitCall> FromProto(const substrait::AggregateFunction& func, bool i
         EnumToString(func.phase(), *substrait::AggregationPhase_descriptor()),
         "'.  Only INITIAL_TO_RESULT is supported");
   }
-  if (func.invocation() !=
-          substrait::AggregateFunction::AggregationInvocation::
-              AggregateFunction_AggregationInvocation_AGGREGATION_INVOCATION_ALL &&
+  if (func.invocation() != substrait::AggregateFunction::AGGREGATION_INVOCATION_ALL &&
       func.invocation() !=
-          substrait::AggregateFunction::AggregationInvocation::
-              AggregateFunction_AggregationInvocation_AGGREGATION_INVOCATION_UNSPECIFIED) {
+          substrait::AggregateFunction::AGGREGATION_INVOCATION_UNSPECIFIED) {
     return Status::NotImplemented(
         "Unsupported aggregation invocation '",
         EnumToString(func.invocation(),

--- a/cpp/src/arrow/engine/substrait/expression_internal.cc
+++ b/cpp/src/arrow/engine/substrait/expression_internal.cc
@@ -149,7 +149,9 @@ Result<SubstraitCall> FromProto(const substrait::AggregateFunction& func, bool i
   }
   if (func.invocation() !=
       substrait::AggregateFunction::AggregationInvocation::
-          AggregateFunction_AggregationInvocation_AGGREGATION_INVOCATION_ALL) {
+          AggregateFunction_AggregationInvocation_AGGREGATION_INVOCATION_ALL &&
+      func.invocation() != substrait::AggregateFunction::AggregationInvocation::
+          AggregateFunction_AggregationInvocation_AGGREGATION_INVOCATION_UNSPECIFIED) {
     return Status::NotImplemented(
         "Unsupported aggregation invocation '",
         EnumToString(func.invocation(),

--- a/cpp/src/arrow/engine/substrait/expression_internal.cc
+++ b/cpp/src/arrow/engine/substrait/expression_internal.cc
@@ -148,10 +148,11 @@ Result<SubstraitCall> FromProto(const substrait::AggregateFunction& func, bool i
         "'.  Only INITIAL_TO_RESULT is supported");
   }
   if (func.invocation() !=
-      substrait::AggregateFunction::AggregationInvocation::
-          AggregateFunction_AggregationInvocation_AGGREGATION_INVOCATION_ALL &&
-      func.invocation() != substrait::AggregateFunction::AggregationInvocation::
-          AggregateFunction_AggregationInvocation_AGGREGATION_INVOCATION_UNSPECIFIED) {
+          substrait::AggregateFunction::AggregationInvocation::
+              AggregateFunction_AggregationInvocation_AGGREGATION_INVOCATION_ALL &&
+      func.invocation() !=
+          substrait::AggregateFunction::AggregationInvocation::
+              AggregateFunction_AggregationInvocation_AGGREGATION_INVOCATION_UNSPECIFIED) {
     return Status::NotImplemented(
         "Unsupported aggregation invocation '",
         EnumToString(func.invocation(),

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -1723,7 +1723,6 @@ TEST(Substrait, AggregateBasic) {
             }],
               "sorts": [],
               "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-              "invocation": "AGGREGATION_INVOCATION_ALL",
               "outputType": {
                 "i64": {}
               }


### PR DESCRIPTION
In our use of our Substrait, we only accept AGGREGATION_INVOCATION_ALL for aggregation invocations. This is fine, but the spec (as per: https://github.com/substrait-io/substrait/blob/main/proto/substrait/algebra.proto#L1221-L1230) automatically reads AGGREGATION_INVOCATION_UNSPECIFIED as AGGREGATION_INVOCATION_ALL, while we reject it. 

This PR accepts AGGREGATION_INVOCATION_UNSPECIFIED past our error checking. Any requested AGGREGATION_INVOCATION_UNSPECIFIED is thus processed as AGGREGATION_INVOCATION_ALL, with no further functionality changes. The basic aggregation test is modified to test this. 
* Closes: #15199