### PR TITLE
GH-15212: [C++] fix sliced list array writing in ORC

### DIFF
--- a/cpp/src/arrow/adapters/orc/adapter_test.cc
+++ b/cpp/src/arrow/adapters/orc/adapter_test.cc
@@ -536,6 +536,15 @@ TEST_F(TestORCWriterTrivialNoConversion, writeFilledChunkAndSelectField) {
                             &selected_indices);
 }
 
+TEST_F(TestORCWriterTrivialNoConversion, writeSlicedBatch) {
+  std::shared_ptr<Table> table =
+      GenerateRandomTable(table_schema, /*size=*/100, /*min_num_chunks=*/1,
+                          /*max_num_chunks*/ 1, /*probability=*/0);
+  table = table->Slice(20, 60);
+
+  AssertTableWriteReadEqual(table, table, kDefaultSmallMemStreamSize / 16);
+}
+
 class TestORCWriterTrivialWithConversion : public ::testing::Test {
  public:
   TestORCWriterTrivialWithConversion() {

--- a/cpp/src/arrow/adapters/orc/util.cc
+++ b/cpp/src/arrow/adapters/orc/util.cc
@@ -388,21 +388,23 @@ Result<std::shared_ptr<Array>> NormalizeArray(const std::shared_ptr<Array>& arra
       ARROW_ASSIGN_OR_RAISE(auto value_array, NormalizeArray(list_array->values()));
       return std::make_shared<ListArray>(list_array->type(), list_array->length(),
                                          list_array->value_offsets(), value_array,
-                                         list_array->null_bitmap());
+                                         list_array->null_bitmap(),
+                                         list_array->null_count(), list_array->offset());
     }
     case Type::type::LARGE_LIST: {
       auto list_array = checked_pointer_cast<LargeListArray>(array);
       ARROW_ASSIGN_OR_RAISE(auto value_array, NormalizeArray(list_array->values()));
-      return std::make_shared<LargeListArray>(list_array->type(), list_array->length(),
-                                              list_array->value_offsets(), value_array,
-                                              list_array->null_bitmap());
+      return std::make_shared<LargeListArray>(
+          list_array->type(), list_array->length(), list_array->value_offsets(),
+          value_array, list_array->null_bitmap(), list_array->null_count(),
+          list_array->offset());
     }
     case Type::type::FIXED_SIZE_LIST: {
       auto list_array = checked_pointer_cast<FixedSizeListArray>(array);
       ARROW_ASSIGN_OR_RAISE(auto value_array, NormalizeArray(list_array->values()));
-      return std::make_shared<FixedSizeListArray>(list_array->type(),
-                                                  list_array->length(), value_array,
-                                                  list_array->null_bitmap());
+      return std::make_shared<FixedSizeListArray>(
+          list_array->type(), list_array->length(), value_array,
+          list_array->null_bitmap(), list_array->null_count(), list_array->offset());
     }
     case Type::type::MAP: {
       auto map_array = checked_pointer_cast<MapArray>(array);
@@ -410,7 +412,8 @@ Result<std::shared_ptr<Array>> NormalizeArray(const std::shared_ptr<Array>& arra
       ARROW_ASSIGN_OR_RAISE(auto item_array, NormalizeArray(map_array->items()));
       return std::make_shared<MapArray>(map_array->type(), map_array->length(),
                                         map_array->value_offsets(), key_array, item_array,
-                                        map_array->null_bitmap());
+                                        map_array->null_bitmap(), map_array->null_count(),
+                                        map_array->offset());
     }
     default: {
       return array;


### PR DESCRIPTION
Writing sliced list and map arrays will produce incorrect data. This happens because the arrays are recreated using `BaseListArray.values()`, which doesn't account for the offsets, and the offsets was not passed. To fix, I changed to pass along the offsets.
* Closes: #15212