### PR TITLE
GH-15237: [C++] Add ::arrow::Unreachable() using std::string_view

### DIFF
--- a/cpp/src/arrow/util/unreachable.cc
+++ b/cpp/src/arrow/util/unreachable.cc
@@ -23,6 +23,11 @@
 
 namespace arrow {
 
+[[noreturn]] void Unreachable(const char* message) {
+  DCHECK(false) << message;
+  std::abort();
+}
+
 [[noreturn]] void Unreachable(std::string_view message) {
   DCHECK(false) << message;
   std::abort();

--- a/cpp/src/arrow/util/unreachable.cc
+++ b/cpp/src/arrow/util/unreachable.cc
@@ -19,9 +19,11 @@
 
 #include "arrow/util/logging.h"
 
+#include <string_view>
+
 namespace arrow {
 
-[[noreturn]] void Unreachable(const char* message) {
+[[noreturn]] void Unreachable(std::string_view message) {
   DCHECK(false) << message;
   std::abort();
 }

--- a/cpp/src/arrow/util/unreachable.h
+++ b/cpp/src/arrow/util/unreachable.h
@@ -19,8 +19,10 @@
 
 #include "arrow/util/visibility.h"
 
+#include <string_view>
+
 namespace arrow {
 
-[[noreturn]] ARROW_EXPORT void Unreachable(const char* message = "Unreachable");
+[[noreturn]] ARROW_EXPORT void Unreachable(std::string_view message = "Unreachable");
 
 }  // namespace arrow

--- a/cpp/src/arrow/util/unreachable.h
+++ b/cpp/src/arrow/util/unreachable.h
@@ -23,6 +23,8 @@
 
 namespace arrow {
 
-[[noreturn]] ARROW_EXPORT void Unreachable(std::string_view message = "Unreachable");
+[[noreturn]] ARROW_EXPORT void Unreachable(const char* message = "Unreachable");
+
+[[noreturn]] ARROW_EXPORT void Unreachable(std::string_view message);
 
 }  // namespace arrow


### PR DESCRIPTION
Here I add a std::string_view `::arrow::Unreachable`, because:
1. `Unreachable(std::string(" a") + "b")` all `Unreachable(fmt::format(...))` could be easily used
2. non-c-style string can be used.

For api compatibility, I leave the origin `const char*` Unreachable unchanged.

The cons maybe:
1. abi broken ( Seems no one will use Unreachable like this?)
2. Maybe making compiling a bit slower
* Closes: #15237