### PR TITLE
GH-15216: [C++][Parquet] Parquet writer accepts RecordBatch

### DIFF
--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -4982,9 +4982,10 @@ TEST(TestReadWriteArrow, WriteAndReadRecordBatch) {
 
   // Prepare schema
   auto schema = ::arrow::schema(
-      {::arrow::field("a", ::arrow::int64()), ::arrow::field("b", ::arrow::utf8()),
-       ::arrow::field("c", ::arrow::struct_({::arrow::field("c1", ::arrow::int64()),
-                                             ::arrow::field("c2", ::arrow::utf8())}))});
+      {::arrow::field("a", ::arrow::int64()),
+       ::arrow::field("b", ::arrow::struct_({::arrow::field("b1", ::arrow::int64()),
+                                             ::arrow::field("b2", ::arrow::utf8())})),
+       ::arrow::field("c", ::arrow::utf8())});
   std::shared_ptr<SchemaDescriptor> parquet_schema;
   ASSERT_OK_NO_THROW(ToParquetSchema(schema.get(), *writer_properties,
                                      *arrow_writer_properties, &parquet_schema));
@@ -4992,18 +4993,18 @@ TEST(TestReadWriteArrow, WriteAndReadRecordBatch) {
 
   // Prepare data
   auto record_batch = ::arrow::RecordBatchFromJSON(schema, R"([
-      [1,     "alfa",  {"c1": -3,   "c2": "1"}],
-      [null,  "alfa",  {"c1": null, "c2": "22"}],
-      [3,     "beta",  {"c1": -2,   "c2": "333"}],
-      [null,  "gama",  {"c1": null, "c2": null}],
-      [5,     null,    {"c1": -1,   "c2": "-333"}],
-      [6,     "alfa",  {"c1": null, "c2": "-22"}],
-      [7,     "beta",  {"c1": 0,    "c2": "-1"}],
-      [8,     "beta",  {"c1": null, "c2": null}],
-      [9,     null  ,  {"c1": 1,    "c2": "0"}],
-      [null,  "gama",  {"c1": null, "c2": ""}],
-      [11,    "foo",   {"c1": 2,    "c2": "1234"}],
-      [12,    "bar",   {"c1": null, "c2": "4321"}]
+      [1,    {"b1": -3,   "b2": "1"   }, "alfa"],
+      [null, {"b1": null, "b2": "22"  }, "alfa"],
+      [3,    {"b1": -2,   "b2": "333" }, "beta"],
+      [null, {"b1": null, "b2": null  }, "gama"],
+      [5,    {"b1": -1,   "b2": "-333"}, null  ],
+      [6,    {"b1": null, "b2": "-22" }, "alfa"],
+      [7,    {"b1": 0,    "b2": "-1"  }, "beta"],
+      [8,    {"b1": null, "b2": null  }, "beta"],
+      [9,    {"b1": 1,    "b2": "0"   }, null  ],
+      [null, {"b1": null, "b2": ""    }, "gama"],
+      [11,   {"b1": 2,    "b2": "1234"}, "foo" ],
+      [12,   {"b1": null, "b2": "4321"}, "bar" ]
     ])");
 
   // Create writer to write data via RecordBatch.

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -28,6 +28,7 @@
 #include "arrow/array.h"
 #include "arrow/extension_type.h"
 #include "arrow/ipc/writer.h"
+#include "arrow/record_batch.h"
 #include "arrow/table.h"
 #include "arrow/type.h"
 #include "arrow/util/base64.h"
@@ -58,6 +59,7 @@ using arrow::ListArray;
 using arrow::MemoryPool;
 using arrow::NumericArray;
 using arrow::PrimitiveArray;
+using arrow::RecordBatch;
 using arrow::ResizableBuffer;
 using arrow::Result;
 using arrow::Status;
@@ -114,8 +116,10 @@ class ArrowColumnWriterV2 {
   // level_builders should contain one MultipathLevelBuilder per chunk of the
   // Arrow-column to write.
   ArrowColumnWriterV2(std::vector<std::unique_ptr<MultipathLevelBuilder>> level_builders,
-                      int leaf_count, RowGroupWriter* row_group_writer)
+                      int start_leaf_column_index, int leaf_count,
+                      RowGroupWriter* row_group_writer)
       : level_builders_(std::move(level_builders)),
+        start_leaf_column_index_(start_leaf_column_index),
         leaf_count_(leaf_count),
         row_group_writer_(row_group_writer) {}
 
@@ -127,7 +131,12 @@ class ArrowColumnWriterV2 {
   Status Write(ArrowWriteContext* ctx) {
     for (int leaf_idx = 0; leaf_idx < leaf_count_; leaf_idx++) {
       ColumnWriter* column_writer;
-      PARQUET_CATCH_NOT_OK(column_writer = row_group_writer_->NextColumn());
+      if (row_group_writer_->buffered()) {
+        const int column_index = start_leaf_column_index_ + leaf_idx;
+        PARQUET_CATCH_NOT_OK(column_writer = row_group_writer_->column(column_index));
+      } else {
+        PARQUET_CATCH_NOT_OK(column_writer = row_group_writer_->NextColumn());
+      }
       for (auto& level_builder : level_builders_) {
         RETURN_NOT_OK(level_builder->Write(
             leaf_idx, ctx, [&](const MultipathLevelBuilderResult& result) {
@@ -147,7 +156,9 @@ class ArrowColumnWriterV2 {
             }));
       }
 
-      PARQUET_CATCH_NOT_OK(column_writer->Close());
+      if (!row_group_writer_->buffered()) {
+        PARQUET_CATCH_NOT_OK(column_writer->Close());
+      }
     }
     return Status::OK();
   }
@@ -162,13 +173,14 @@ class ArrowColumnWriterV2 {
   // RowGroupWriters (we could construct each builder on demand in that case).
   static ::arrow::Result<std::unique_ptr<ArrowColumnWriterV2>> Make(
       const ChunkedArray& data, int64_t offset, const int64_t size,
-      const SchemaManifest& schema_manifest, RowGroupWriter* row_group_writer) {
+      const SchemaManifest& schema_manifest, RowGroupWriter* row_group_writer,
+      int start_leaf_column_index = -1) {
     int64_t absolute_position = 0;
     int chunk_index = 0;
     int64_t chunk_offset = 0;
     if (data.length() == 0) {
       return std::make_unique<ArrowColumnWriterV2>(
-          std::vector<std::unique_ptr<MultipathLevelBuilder>>{},
+          std::vector<std::unique_ptr<MultipathLevelBuilder>>{}, start_leaf_column_index,
           CalculateLeafCount(data.type().get()), row_group_writer);
     }
     while (chunk_index < data.num_chunks() && absolute_position < offset) {
@@ -192,9 +204,16 @@ class ArrowColumnWriterV2 {
     std::vector<std::unique_ptr<MultipathLevelBuilder>> builders;
     const int leaf_count = CalculateLeafCount(data.type().get());
     bool is_nullable = false;
-    // The row_group_writer hasn't been advanced yet so add 1 to the current
-    // which is the one this instance will start writing for.
-    int column_index = row_group_writer->current_column() + 1;
+
+    int column_index = 0;
+    if (row_group_writer->buffered()) {
+      column_index = start_leaf_column_index;
+    } else {
+      // The row_group_writer hasn't been advanced yet so add 1 to the current
+      // which is the one this instance will start writing for.
+      column_index = row_group_writer->current_column() + 1;
+    }
+
     for (int leaf_offset = 0; leaf_offset < leaf_count; ++leaf_offset) {
       const SchemaField* schema_field = nullptr;
       RETURN_NOT_OK(
@@ -240,13 +259,16 @@ class ArrowColumnWriterV2 {
       }
       values_written += chunk_write_size;
     }
-    return std::make_unique<ArrowColumnWriterV2>(std::move(builders), leaf_count,
-                                                 row_group_writer);
+    return std::make_unique<ArrowColumnWriterV2>(std::move(builders), column_index,
+                                                 leaf_count, row_group_writer);
   }
+
+  int leaf_count() const { return leaf_count_; }
 
  private:
   // One builder per column-chunk.
   std::vector<std::unique_ptr<MultipathLevelBuilder>> level_builders_;
+  int start_leaf_column_index_;
   int leaf_count_;
   RowGroupWriter* row_group_writer_;
 };
@@ -304,12 +326,16 @@ class FileWriterImpl : public FileWriter {
                           int64_t size) override {
     if (arrow_properties_->engine_version() == ArrowWriterProperties::V2 ||
         arrow_properties_->engine_version() == ArrowWriterProperties::V1) {
+      if (row_group_writer_->buffered()) {
+        return Status::Invalid("Cannot write column chunk into the buffered row group.");
+      }
       ARROW_ASSIGN_OR_RAISE(
           std::unique_ptr<ArrowColumnWriterV2> writer,
           ArrowColumnWriterV2::Make(*data, offset, size, schema_manifest_,
                                     row_group_writer_));
       return writer->Write(&column_write_context_);
     }
+
     return Status::NotImplemented("Unknown engine version.");
   }
 
@@ -353,6 +379,40 @@ class FileWriterImpl : public FileWriter {
           PARQUET_IGNORE_NOT_OK(Close()));
     }
     return Status::OK();
+  }
+
+  Status NewBufferedRowGroup() override {
+    if (row_group_writer_ != nullptr) {
+      PARQUET_CATCH_NOT_OK(row_group_writer_->Close());
+    }
+    PARQUET_CATCH_NOT_OK(row_group_writer_ = writer_->AppendBufferedRowGroup());
+    return Status::OK();
+  }
+
+  Status WriteRecordBatch(const RecordBatch& batch) override {
+    if (batch.num_rows() == 0) {
+      return Status::OK();
+    }
+
+    if (row_group_writer_ == nullptr || !row_group_writer_->buffered()) {
+      RETURN_NOT_OK(NewBufferedRowGroup());
+    }
+
+    auto WriteBatch = [&](int64_t offset, int64_t size) {
+      int column_index_start = 0;
+      for (int i = 0; i < batch.num_columns(); i++) {
+        ChunkedArray chunkedArray(batch.column(i));
+        ARROW_ASSIGN_OR_RAISE(
+            std::unique_ptr<ArrowColumnWriterV2> writer,
+            ArrowColumnWriterV2::Make(chunkedArray, offset, size, schema_manifest_,
+                                      row_group_writer_, column_index_start));
+        RETURN_NOT_OK(writer->Write(&column_write_context_));
+        column_index_start += writer->leaf_count();
+      }
+      return Status::OK();
+    };
+
+    return WriteBatch(0, batch.num_rows());
   }
 
   const WriterProperties& properties() const { return *writer_->properties(); }

--- a/cpp/src/parquet/arrow/writer.h
+++ b/cpp/src/parquet/arrow/writer.h
@@ -121,6 +121,16 @@ class PARQUET_EXPORT FileWriter {
   virtual ::arrow::Status NewBufferedRowGroup() = 0;
 
   /// \brief Write a RecordBatch into the buffered row group.
+  ///
+  /// Multiple RecordBatches can be written into the same row group
+  /// through this method.
+  ///
+  /// WriterProperties.max_row_group_length() is respected and a new
+  /// row group will be created if the current row group exceeds the
+  /// limit.
+  ///
+  /// Batches get flushed to the output stream once NewBufferedRowGroup()
+  /// or Close() is called.
   virtual ::arrow::Status WriteRecordBatch(const ::arrow::RecordBatch& batch) = 0;
 
   /// \brief Write the footer and close the file.

--- a/cpp/src/parquet/arrow/writer.h
+++ b/cpp/src/parquet/arrow/writer.h
@@ -27,6 +27,7 @@ namespace arrow {
 
 class Array;
 class ChunkedArray;
+class RecordBatch;
 class Schema;
 class Table;
 
@@ -113,6 +114,14 @@ class PARQUET_EXPORT FileWriter {
   /// \brief Write ColumnChunk in a row group using a ChunkedArray
   virtual ::arrow::Status WriteColumnChunk(
       const std::shared_ptr<::arrow::ChunkedArray>& data) = 0;
+
+  /// \brief Start a new buffered row group.
+  ///
+  /// Returns an error if not all columns have been written.
+  virtual ::arrow::Status NewBufferedRowGroup() = 0;
+
+  /// \brief Write a RecordBatch into the buffered row group.
+  virtual ::arrow::Status WriteRecordBatch(const ::arrow::RecordBatch& batch) = 0;
 
   /// \brief Write the footer and close the file.
   virtual ::arrow::Status Close() = 0;

--- a/cpp/src/parquet/file_writer.cc
+++ b/cpp/src/parquet/file_writer.cc
@@ -62,6 +62,8 @@ int64_t RowGroupWriter::total_bytes_written() const {
   return contents_->total_bytes_written();
 }
 
+bool RowGroupWriter::buffered() const { return contents_->buffered(); }
+
 int RowGroupWriter::current_column() { return contents_->current_column(); }
 
 int RowGroupWriter::num_columns() const { return contents_->num_columns(); }
@@ -176,6 +178,8 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
     }
     return total_bytes_written;
   }
+
+  bool buffered() const override { return buffered_row_group_; }
 
   void Close() override {
     if (!closed_) {

--- a/cpp/src/parquet/file_writer.h
+++ b/cpp/src/parquet/file_writer.h
@@ -56,6 +56,8 @@ class PARQUET_EXPORT RowGroupWriter {
     virtual int64_t total_bytes_written() const = 0;
     // total bytes still compressed but not written
     virtual int64_t total_compressed_bytes() const = 0;
+
+    virtual bool buffered() const = 0;
   };
 
   explicit RowGroupWriter(std::unique_ptr<Contents> contents);
@@ -90,6 +92,10 @@ class PARQUET_EXPORT RowGroupWriter {
 
   int64_t total_bytes_written() const;
   int64_t total_compressed_bytes() const;
+
+  /// Returns whether the current RowGroupWriter is in the buffered mode and is created
+  /// by calling ParquetFileWriter::AppendBufferedRowGroup.
+  bool buffered() const;
 
  private:
   // Holds a pointer to an instance of Contents implementation


### PR DESCRIPTION
 - Parquet arrow::FileWriter supports buffered row group mode.
 - Parquet arrow::FileWriter accepts arrow::RecordBatch.
* Closes: #15216