### PR TITLE
GH-14923: [C++][Parquet] Fix DELTA_BINARY_PACKED problem on reading the last block with malford bit-width

### DIFF
--- a/cpp/src/arrow/util/bit_stream_utils.h
+++ b/cpp/src/arrow/util/bit_stream_utils.h
@@ -19,10 +19,9 @@
 
 #pragma once
 
-#include <string.h>
-
 #include <algorithm>
 #include <cstdint>
+#include <cstring>
 
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bpacking.h"
@@ -153,7 +152,7 @@ class BitReader {
   /// 'num_bytes'. The value is assumed to be byte-aligned so the stream will
   /// be advanced to the start of the next byte before 'v' is read. Returns
   /// false if there are not enough bytes left.
-  /// Assume the v was stored in buffer_ as a litte-endian format
+  /// Assume the v was stored in buffer_ as a little-endian format
   template <typename T>
   bool GetAligned(int num_bytes, T* v);
 

--- a/cpp/src/arrow/util/bit_stream_utils.h
+++ b/cpp/src/arrow/util/bit_stream_utils.h
@@ -318,7 +318,7 @@ inline bool BitReader::GetValue(int num_bits, T* v) {
 template <typename T>
 inline int BitReader::GetBatch(int num_bits, T* v, int batch_size) {
   DCHECK(buffer_ != NULL);
-  DCHECK_LE(num_bits, static_cast<int>(sizeof(T) * 8));
+  DCHECK_LE(num_bits, static_cast<int>(sizeof(T) * 8)) << "num_bits: " << num_bits;
 
   int bit_offset = bit_offset_;
   int byte_offset = byte_offset_;

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -2456,18 +2456,19 @@ class DeltaBitPackDecoder : public DecoderImpl, virtual public TypedDecoder<DTyp
     // read the bitwidth of each miniblock
     uint8_t* bit_width_data = delta_bit_widths_->mutable_data();
     uint32_t miniblock_values_sum = value_sum_up_to_current_block_;
-    for (uint32_t current_mini_block_idx = 0; current_mini_block_idx < mini_blocks_per_block_; ++current_mini_block_idx) {
+    for (uint32_t current_mini_block_idx = 0;
+         current_mini_block_idx < mini_blocks_per_block_; ++current_mini_block_idx) {
       if (!decoder_->GetAligned<uint8_t>(1, bit_width_data + current_mini_block_idx)) {
         ParquetException::EofException();
       }
 
-      if (bit_width_data[current_mini_block_idx] > kMaxDeltaBitWidth) {
+      if (ARROW_PREDICT_FALSE(bit_width_data[current_mini_block_idx] >
+                              kMaxDeltaBitWidth)) {
         if (miniblock_values_sum <= total_value_count_) {
-          throw ParquetException(
-              "delta bit width " +
-              std::to_string(
-                  bit_width_data[current_mini_block_idx]) +
-              " larger than integer bit width " + std::to_string(kMaxDeltaBitWidth));
+          throw ParquetException("delta bit width " +
+                                 std::to_string(bit_width_data[current_mini_block_idx]) +
+                                 " larger than integer bit width " +
+                                 std::to_string(kMaxDeltaBitWidth));
         } else {
           // according to the parquet standard, we should ignore the bit_width_data here.
           break;

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -2464,15 +2464,14 @@ class DeltaBitPackDecoder : public DecoderImpl, virtual public TypedDecoder<DTyp
 
       if (ARROW_PREDICT_FALSE(bit_width_data[current_mini_block_idx] >
                               kMaxDeltaBitWidth)) {
-        if (miniblock_values_sum <= total_value_count_) {
+        if (miniblock_values_sum < total_value_count_) {
           throw ParquetException("delta bit width " +
                                  std::to_string(bit_width_data[current_mini_block_idx]) +
                                  " larger than integer bit width " +
                                  std::to_string(kMaxDeltaBitWidth));
-        } else {
-          // according to the parquet standard, we should ignore the bit_width_data here.
-          break;
         }
+        // according to the parquet standard, we should ignore the bit_width_data here.
+        // cannot break because still need to read remaining bit-width from decoder.
       }
       miniblock_values_sum += values_per_mini_block_;
     }

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -1398,6 +1398,7 @@ TYPED_TEST(TestDeltaBitPackEncoding, BasicRoundTrip) {
   ASSERT_NO_FATAL_FAILURE(
       this->Execute((values_per_mini_block * values_per_block) + 1, 10));
   ASSERT_NO_FATAL_FAILURE(this->Execute(0, 0));
+  ASSERT_NO_FATAL_FAILURE(this->Execute(65, 1));
   ASSERT_NO_FATAL_FAILURE(this->ExecuteSpaced(
       /*nvalues*/ 1234, /*repeats*/ 1, /*valid_bits_offset*/ 64,
       /*null_probability*/ 0.1));
@@ -1437,14 +1438,19 @@ TEST_F(DeltaBitPackEncoding, MalfordMiniblockBitWidth) {
   auto decoder = MakeTypedDecoder<Int32Type>(Encoding::DELTA_BINARY_PACKED, descr_.get());
   using c_type = parquet::Int32Type::c_type;
 
-  unsigned char good_data[] = "\200\001\004A\237\224\316\362\r\242\220\203-  ";
   int encode_buffer_size = 273;
   int num_values = 65;
-  std::vector<uint8_t> output_bytes = std::vector<uint8_t>(num_values * sizeof(c_type));
-  auto decode_buf = reinterpret_cast<c_type*>(output_bytes.data());
+  c_type* decode_buf = nullptr;
+  std::vector<uint8_t> output_bytes;
+  int values_decoded = 0;
+  /*
+  unsigned char good_data[] = "\200\001\004A\237\224\316\362\r\242\220\203-  ";
+  output_bytes = std::vector<uint8_t>(num_values * sizeof(c_type));
+  decode_buf = reinterpret_cast<c_type*>(output_bytes.data());
   decoder->SetData(num_values, &good_data[0], encode_buffer_size);
-  int values_decoded = decoder->Decode(decode_buf, num_values);
+  values_decoded = decoder->Decode(decode_buf, num_values);
   ASSERT_EQ(num_values, values_decoded);
+  */
 
   unsigned char bad_data[] =
       "\200\001\004A\237\224\316\362\r\242\220\203-  "
@@ -1459,7 +1465,9 @@ TEST_F(DeltaBitPackEncoding, MalfordMiniblockBitWidth) {
       "\255\271f\026\274\033_\333)4";
   output_bytes = std::vector<uint8_t>(num_values * sizeof(c_type));
   decode_buf = reinterpret_cast<c_type*>(output_bytes.data());
-  decoder->SetData(num_values, &bad_data[0], encode_buffer_size);
+   decoder->SetData(num_values, &bad_data[0], encode_buffer_size);
+   values_decoded = decoder->Decode(decode_buf, num_values);
+  ASSERT_EQ(num_values, values_decoded);
 }
 
 }  // namespace test

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -1444,10 +1444,15 @@ TEST_F(DeltaBitPackEncoding, MalfordMiniblockBitWidth) {
   std::vector<uint8_t> output_bytes;
   int values_decoded = 0;
 
+  // Both good_data and bad_data is a DELTA_BINARY_PACKED INT32 Page with 65 values.
+  // For needed miniblocks, there bit-widths are all 32.
+  // There bit-widths for unneeded miniblocks are different:
+  // * good_data's unneeded bit-width is 0.
+  // * bad_data's unneeded bit-width is 165.
   {
     unsigned char good_data[] = "\200\001\004A\237\224\316\362\r\242\220\203-  ";
     unsigned char data_buf[273] = {};
-    memcpy(&data_buf[0], &good_data[0], 15);
+    std::memcpy(&data_buf[0], &good_data[0], 15);
     output_bytes = std::vector<uint8_t>(num_values * sizeof(c_type));
     decode_buf = reinterpret_cast<c_type*>(output_bytes.data());
     decoder->SetData(num_values, &data_buf[0], encode_buffer_size);

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -1449,9 +1449,9 @@ TEST_F(DeltaBitPackEncoding, MalfordMiniblockBitWidth) {
   // There bit-widths for unneeded miniblocks are different:
   // * good_data's unneeded bit-width is 0.
   // * bad_data's unneeded bit-width is 165.
+  unsigned char data_buf[273] = {};
   {
     unsigned char good_data[] = "\200\001\004A\237\224\316\362\r\242\220\203-  ";
-    unsigned char data_buf[273] = {};
     std::memcpy(&data_buf[0], &good_data[0], 15);
     output_bytes = std::vector<uint8_t>(num_values * sizeof(c_type));
     decode_buf = reinterpret_cast<c_type*>(output_bytes.data());
@@ -1473,9 +1473,10 @@ TEST_F(DeltaBitPackEncoding, MalfordMiniblockBitWidth) {
         "\232\340\363\366\306\030\243,5\337\031\005bw\021\017wj\003#Q`\371ʉ\323\300+~="
         "\232W\232\374p\336$\022\211VQ\237>\v1gە'\224\207\262f\247h\363A!"
         "\255\271f\026\274\033_\333)4";
+    std::memcpy(&data_buf[0], &bad_data[0], 222);
     output_bytes = std::vector<uint8_t>(num_values * sizeof(c_type));
     decode_buf = reinterpret_cast<c_type*>(output_bytes.data());
-    decoder->SetData(num_values, &bad_data[0], encode_buffer_size);
+    decoder->SetData(num_values, &data_buf[0], encode_buffer_size);
     values_decoded = decoder->Decode(decode_buf, num_values);
     ASSERT_EQ(num_values, values_decoded);
   }

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -1443,31 +1443,37 @@ TEST_F(DeltaBitPackEncoding, MalfordMiniblockBitWidth) {
   c_type* decode_buf = nullptr;
   std::vector<uint8_t> output_bytes;
   int values_decoded = 0;
-  /*
-  unsigned char good_data[] = "\200\001\004A\237\224\316\362\r\242\220\203-  ";
-  output_bytes = std::vector<uint8_t>(num_values * sizeof(c_type));
-  decode_buf = reinterpret_cast<c_type*>(output_bytes.data());
-  decoder->SetData(num_values, &good_data[0], encode_buffer_size);
-  values_decoded = decoder->Decode(decode_buf, num_values);
-  ASSERT_EQ(num_values, values_decoded);
-  */
 
-  unsigned char bad_data[] =
-      "\200\001\004A\237\224\316\362\r\242\220\203-  "
-      "\245\245\304;`\210'\313\r\270D\316\306h㖀~\372\255\360A\254}\211L\343\373_"
-      "\034®\312Y\036\233<\203\035P\202)\307Y\356\327\024\302!\232\036,"
-      "\271\b\331\353\037e\333\332\315Crm\203\350בOo\001\347\305Z\203G\037\263Y\254\366_"
-      "\"\v\276\242Y\002\374\300\226\231\252C\240\363ۙ\r\334E\314\f\002\255\227\273\307"
-      "\305'\"\033\235\374\250\243\244F\266\254\350\203\304U\036X\331&\210/"
-      "\037\322\321s.\031e/"
-      "\232\340\363\366\306\030\243,5\337\031\005bw\021\017wj\003#Q`\371ʉ\323\300+~="
-      "\232W\232\374p\336$\022\211VQ\237>\v1gە'\224\207\262f\247h\363A!"
-      "\255\271f\026\274\033_\333)4";
-  output_bytes = std::vector<uint8_t>(num_values * sizeof(c_type));
-  decode_buf = reinterpret_cast<c_type*>(output_bytes.data());
-   decoder->SetData(num_values, &bad_data[0], encode_buffer_size);
-   values_decoded = decoder->Decode(decode_buf, num_values);
-  ASSERT_EQ(num_values, values_decoded);
+  {
+    unsigned char good_data[] = "\200\001\004A\237\224\316\362\r\242\220\203-  ";
+    unsigned char data_buf[273] = {};
+    memcpy(&data_buf[0], &good_data[0], 15);
+    output_bytes = std::vector<uint8_t>(num_values * sizeof(c_type));
+    decode_buf = reinterpret_cast<c_type*>(output_bytes.data());
+    decoder->SetData(num_values, &data_buf[0], encode_buffer_size);
+    values_decoded = decoder->Decode(decode_buf, num_values);
+    ASSERT_EQ(num_values, values_decoded);
+  }
+
+  {
+    unsigned char bad_data[] =
+        "\200\001\004A\237\224\316\362\r\242\220\203-  "
+        "\245\245\304;`\210'\313\r\270D\316\306h㖀~\372\255\360A\254}\211L\343\373_"
+        "\034®\312Y\036\233<\203\035P\202)\307Y\356\327\024\302!\232\036,"
+        "\271\b\331\353\037e\333\332\315Crm\203\350בOo\001\347\305Z\203G\037\263Y\254\366"
+        "_"
+        "\"\v\276\242Y\002\374\300\226\231\252C\240\363ۙ\r\334E\314\f\002\255\227\273\307"
+        "\305'\"\033\235\374\250\243\244F\266\254\350\203\304U\036X\331&\210/"
+        "\037\322\321s.\031e/"
+        "\232\340\363\366\306\030\243,5\337\031\005bw\021\017wj\003#Q`\371ʉ\323\300+~="
+        "\232W\232\374p\336$\022\211VQ\237>\v1gە'\224\207\262f\247h\363A!"
+        "\255\271f\026\274\033_\333)4";
+    output_bytes = std::vector<uint8_t>(num_values * sizeof(c_type));
+    decode_buf = reinterpret_cast<c_type*>(output_bytes.data());
+    decoder->SetData(num_values, &bad_data[0], encode_buffer_size);
+    values_decoded = decoder->Decode(decode_buf, num_values);
+    ASSERT_EQ(num_values, values_decoded);
+  }
 }
 
 }  // namespace test

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -1448,7 +1448,7 @@ TYPED_TEST(TestDeltaBitPackEncoding, NonZeroPaddedMiniblockBitWidth) {
 
     // Generate input data with a small half_range to make the header length
     // deterministic (see kHeaderLength).
-    this->InitBoundData(num_values, /*repeats=*/1, /*half_range=*/63);
+    this->InitBoundData(num_values, /*repeats=*/1, /*half_range=*/31);
     ASSERT_EQ(this->num_values_, num_values);
 
     auto encoder = MakeTypedEncoder<TypeParam>(Encoding::DELTA_BINARY_PACKED, false,
@@ -1476,9 +1476,9 @@ TYPED_TEST(TestDeltaBitPackEncoding, NonZeroPaddedMiniblockBitWidth) {
     // - 1 byte for ULEB128-encoded first value
     // (this assumes that num_values and the first value are narrow enough)
     constexpr int kHeaderLength = 5;
-    // After the header, there is a ULEB128-encoded min delta for the first block,
+    // After the header, there is a zigzag ULEB128-encoded min delta for the first block,
     // then the miniblock bitwidths for the first block.
-    // Given a narrow enough range, the ULEB128-encoded min delta is 1 byte long.
+    // Given a narrow enough range, the zigzag ULEB128-encoded min delta is 1 byte long.
     uint8_t* mini_block_bitwidths = data + kHeaderLength + 1;
 
     // Garble padding bytes; decoding should succeed.


### PR DESCRIPTION
Problem is mentioned here: https://github.com/apache/arrow/issues/14923

This patch fixes that issue. And the code is a bit complex.
- Rename variables, since original name is confusing for me. 
  - `block_initialized_` -> `first_block_initialized_`, because it's a mask that indicates that if the first block in page is initialized.
  - `total_value_count_` -> `total_values_remaining_`. Because it's not `total values within a page`, it means `remaing values to be decoded within a page`
  - `values_count_current_mini_block_` -> `values_remaining_current_mini_block_`, ditto
- Add variables
  - `total_value_count_`: the total value numbers within a page.
- Change Syntax
  -  Change `InitBlock()` to `InitBlock()` and `InitMiniBlock`
- Implemention, most logic is in `InitBlock()` and `InitMiniBlock`
- Testing. Thanks @rok. I use a page within 65 values with bitwidth `32 32 165 165`.

And personally, I use the code here for testing:

```c++
   for (uint32_t i = num_miniblocks; i < mini_blocks_per_block_; i++) {
-    bit_width_data[i] = 0;
+    //    bit_width_data[i] = 0;
+    bit_width_data[i] = static_cast<uint8_t>(random());
   }
```

The code works well in both debug and release mode.

* Closes: #14923