### PR TITLE
GH-14920: [C++][CMake] Add missing -latomic to Arrow CMake package

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -578,6 +578,8 @@ endif()
 # See also: https://issues.apache.org/jira/browse/ARROW-12860
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND ${CMAKE_SYSTEM_PROCESSOR} MATCHES "armv7")
   string(APPEND ARROW_PC_LIBS_PRIVATE " -latomic")
+  list(APPEND ARROW_SHARED_INSTALL_INTERFACE_LIBS "atomic")
+  list(APPEND ARROW_STATIC_INSTALL_INTERFACE_LIBS "atomic")
 endif()
 
 # If libarrow.a is only built, "pkg-config --cflags --libs arrow"


### PR DESCRIPTION
-latomic is needed for Raspberry PI. Arrow CMake package should specify it.
* Closes: #14920