### PR TITLE
GH-15246: [R] Now saving row names

### DIFF
--- a/r/R/metadata.R
+++ b/r/R/metadata.R
@@ -125,9 +125,9 @@ apply_arrow_r_metadata <- function(x, r_metadata) {
 remove_attributes <- function(x) {
   removed_attributes <- character()
   if (identical(class(x), c("tbl_df", "tbl", "data.frame"))) {
-    removed_attributes <- c("class", "row.names", "names")
+    removed_attributes <- c("class", "names")
   } else if (inherits(x, "data.frame")) {
-    removed_attributes <- c("row.names", "names")
+    removed_attributes <- "names"
   } else if (inherits(x, "factor")) {
     removed_attributes <- c("class", "levels")
   } else if (inherits(x, c("integer64", "Date", "arrow_binary", "arrow_large_binary"))) {


### PR DESCRIPTION
Not sure why `row.names` was ever removed.
[This is the commit](https://github.com/sirensolutions/arrow/commit/a6d531a3f409706d7dcde4562913c8589be3402a#diff-659e9fa6b66e5a72b4e3f9ac79ffddf08f92d9ea3d7aa45bd8c73b9a022fa2e5) that added the entire metadata.R, it seems a part of an unrelated effort. 
I believe the other attributes listed in `removed_attributes` were removed because they're serialized/deserialized by other means. `row.names` doesn't belong there.

* Closes: #15246