### PR TITLE
GH-15259:  [CI] component assignment fails due to typo

### DIFF
--- a/.github/workflows/issue_bot.yml
+++ b/.github/workflows/issue_bot.yml
@@ -49,7 +49,7 @@ jobs:
             });
 
             // this removes non-existent labels
-            let component_labels = component_labels.filter(
+            component_labels = component_labels.filter(
               label => repo_labels.data.some(repo_label => repo_label.name === label)
             );
           


### PR DESCRIPTION
I had to disable the filtering while testing on my fork as it does not have the new labels, so I missed the typo.
* Closes: #15259