### PR TITLE
ARROW-17715: [CI][C++] reduce the parallelism for cmake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,8 +111,8 @@ jobs:
           "
         # The LLVM's APT repository causes download error for s390x binary
         # We should use the LLVM provided by the default APT repository
-        CLANG_TOOLS: "10"
-        LLVM: "10"
+        CLANG_TOOLS: "13"
+        LLVM: "13"
         UBUNTU: "20.04"
 
     - name: "Go on s390x"

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,9 +97,11 @@ jobs:
           -e ARROW_FLIGHT=ON
           -e ARROW_GANDIVA=OFF
           -e ARROW_GCS=OFF
+          -e ARROW_JEMALLOC=OFF
           -e ARROW_MIMALLOC=OFF
           -e ARROW_ORC=OFF
           -e ARROW_PARQUET=OFF
+          -e ARROW_PLASMA=OFF
           -e ARROW_S3=OFF
           -e ARROW_SUBSTRAIT=OFF
           -e CMAKE_BUILD_PARALLEL_LEVEL=1
@@ -151,9 +153,11 @@ jobs:
           -e ARROW_FLIGHT=ON
           -e ARROW_GANDIVA=OFF
           -e ARROW_GCS=OFF
+          -e ARROW_JEMALLOC=OFF
           -e ARROW_MIMALLOC=OFF
           -e ARROW_ORC=OFF
           -e ARROW_PARQUET=OFF
+          -e ARROW_PLASMA=OFF
           -e ARROW_PYTHON=ON
           -e ARROW_S3=OFF
           -e CMAKE_BUILD_PARALLEL_LEVEL=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,14 +93,16 @@ jobs:
         # aws-sdk-cpp.
         DOCKER_RUN_ARGS: >-
           "
+          -e ARROW_COMPUTE=OFF
           -e ARROW_FLIGHT=ON
+          -e ARROW_GANDIVA=OFF
           -e ARROW_GCS=OFF
           -e ARROW_MIMALLOC=OFF
           -e ARROW_ORC=OFF
           -e ARROW_PARQUET=OFF
           -e ARROW_S3=OFF
           -e ARROW_SUBSTRAIT=OFF
-          -e CMAKE_BUILD_PARALLEL_LEVEL=2
+          -e CMAKE_BUILD_PARALLEL_LEVEL=1
           -e CMAKE_UNITY_BUILD=ON
           -e PARQUET_BUILD_EXAMPLES=OFF
           -e PARQUET_BUILD_EXECUTABLES=OFF
@@ -144,14 +146,16 @@ jobs:
         # aws-sdk-cpp.
         DOCKER_RUN_ARGS: >-
           "
+          -e ARROW_COMPUTE=OFF
           -e ARROW_FLIGHT=ON
+          -e ARROW_GANDIVA=OFF
           -e ARROW_GCS=OFF
           -e ARROW_MIMALLOC=OFF
           -e ARROW_ORC=OFF
           -e ARROW_PARQUET=OFF
           -e ARROW_PYTHON=ON
           -e ARROW_S3=OFF
-          -e CMAKE_BUILD_PARALLEL_LEVEL=2
+          -e CMAKE_BUILD_PARALLEL_LEVEL=1
           -e CMAKE_UNITY_BUILD=ON
           -e PARQUET_BUILD_EXAMPLES=OFF
           -e PARQUET_BUILD_EXECUTABLES=OFF

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,6 +111,7 @@ jobs:
           "
         # The LLVM's APT repository causes download error for s390x binary
         # We should use the LLVM provided by the default APT repository
+        CLANG_TOOLS: "10"
         LLVM: "10"
         UBUNTU: "20.04"
 


### PR DESCRIPTION
Current setting causes timeout during C++ compilation.