### PR TITLE
GH-15257: [GLib][Dataset] Add GADatasetHivePartitioning

### DIFF
--- a/c_glib/arrow-dataset-glib/partitioning.cpp
+++ b/c_glib/arrow-dataset-glib/partitioning.cpp
@@ -32,10 +32,17 @@ G_BEGIN_DECLS
  * @title: Partitioning classes
  * @include: arrow-dataset-glib/arrow-dataset-glib.h
  *
- * #GADatasetPartitioningOptions is a class for partitioning options.
+ * #GADatasetPartitioningFactoryOptions is a class for partitioning
+ * factory options.
  *
  * #GADatasetPartitioning is a base class for partitioning classes
  * such as #GADatasetDirectoryPartitioning.
+ *
+ * #GADatasetDefaultPartitioning is a class for partitioning that
+ * doesn't partition.
+ *
+ * #GADatasetKeyValuePartitioningOptions is a class for key-value
+ * partitioning options.
  *
  * #GADatasetKeyValuePartitioning is a base class for key-value style
  * partitioning classes such as #GADatasetDirectoryPartitioning.
@@ -43,56 +50,62 @@ G_BEGIN_DECLS
  * #GADatasetDirectoryPartitioning is a class for partitioning that
  * uses directory structure.
  *
+ * #GADatasetHivePartitioningOptions is a class for Hive-style
+ * partitioning options.
+ *
+ * #GADatasetHivePartitioning is a class for partitioning that
+ * uses Hive-style partitioning.
+ *
  * Since: 6.0.0
  */
 
-typedef struct GADatasetPartitioningOptionsPrivate_ {
+struct GADatasetPartitioningFactoryOptionsPrivate {
   gboolean infer_dictionary;
   GArrowSchema *schema;
   GADatasetSegmentEncoding segment_encoding;
-} GADatasetPartitioningOptionsPrivate;
-
-enum {
-  PROP_INFER_DICTIONARY = 1,
-  PROP_SCHEMA,
-  PROP_SEGMENT_ENCODING,
 };
 
-G_DEFINE_TYPE_WITH_PRIVATE(GADatasetPartitioningOptions,
-                           gadataset_partitioning_options,
+enum {
+  PROP_FACTORY_OPTIONS_INFER_DICTIONARY = 1,
+  PROP_FACTORY_OPTIONS_SCHEMA,
+  PROP_FACTORY_OPTIONS_SEGMENT_ENCODING,
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GADatasetPartitioningFactoryOptions,
+                           gadataset_partitioning_factory_options,
                            G_TYPE_OBJECT)
 
-#define GADATASET_PARTITIONING_OPTIONS_GET_PRIVATE(obj)         \
-  static_cast<GADatasetPartitioningOptionsPrivate *>(           \
-    gadataset_partitioning_options_get_instance_private(        \
-      GADATASET_PARTITIONING_OPTIONS(obj)))
+#define GADATASET_PARTITIONING_FACTORY_OPTIONS_GET_PRIVATE(obj)         \
+  static_cast<GADatasetPartitioningFactoryOptionsPrivate *>(            \
+    gadataset_partitioning_factory_options_get_instance_private(        \
+      GADATASET_PARTITIONING_FACTORY_OPTIONS(obj)))
 
 static void
-gadataset_partitioning_options_dispose(GObject *object)
+gadataset_partitioning_factory_options_dispose(GObject *object)
 {
-  auto priv = GADATASET_PARTITIONING_OPTIONS_GET_PRIVATE(object);
+  auto priv = GADATASET_PARTITIONING_FACTORY_OPTIONS_GET_PRIVATE(object);
 
   if (priv->schema) {
     g_object_unref(priv->schema);
     priv->schema = nullptr;
   }
 
-  G_OBJECT_CLASS(gadataset_partitioning_options_parent_class)->dispose(object);
+  G_OBJECT_CLASS(gadataset_partitioning_factory_options_parent_class)->dispose(object);
 }
 
 static void
-gadataset_partitioning_options_set_property(GObject *object,
-                                            guint prop_id,
-                                            const GValue *value,
-                                            GParamSpec *pspec)
+gadataset_partitioning_factory_options_set_property(GObject *object,
+                                                    guint prop_id,
+                                                    const GValue *value,
+                                                    GParamSpec *pspec)
 {
-  auto priv = GADATASET_PARTITIONING_OPTIONS_GET_PRIVATE(object);
+  auto priv = GADATASET_PARTITIONING_FACTORY_OPTIONS_GET_PRIVATE(object);
 
   switch (prop_id) {
-  case PROP_INFER_DICTIONARY:
+  case PROP_FACTORY_OPTIONS_INFER_DICTIONARY:
     priv->infer_dictionary = g_value_get_boolean(value);
     break;
-  case PROP_SCHEMA:
+  case PROP_FACTORY_OPTIONS_SCHEMA:
     {
       auto schema = g_value_get_object(value);
       if (priv->schema == schema) {
@@ -103,14 +116,14 @@ gadataset_partitioning_options_set_property(GObject *object,
         g_object_ref(schema);
         priv->schema = GARROW_SCHEMA(schema);
       } else {
-        priv->schema = NULL;
+        priv->schema = nullptr;
       }
       if (old_schema) {
         g_object_unref(old_schema);
       }
     }
     break;
-  case PROP_SEGMENT_ENCODING:
+  case PROP_FACTORY_OPTIONS_SEGMENT_ENCODING:
     priv->segment_encoding =
       static_cast<GADatasetSegmentEncoding>(g_value_get_enum(value));
     break;
@@ -121,21 +134,21 @@ gadataset_partitioning_options_set_property(GObject *object,
 }
 
 static void
-gadataset_partitioning_options_get_property(GObject *object,
-                                            guint prop_id,
-                                            GValue *value,
-                                            GParamSpec *pspec)
+gadataset_partitioning_factory_options_get_property(GObject *object,
+                                                    guint prop_id,
+                                                    GValue *value,
+                                                    GParamSpec *pspec)
 {
-  auto priv = GADATASET_PARTITIONING_OPTIONS_GET_PRIVATE(object);
+  auto priv = GADATASET_PARTITIONING_FACTORY_OPTIONS_GET_PRIVATE(object);
 
   switch (prop_id) {
-  case PROP_INFER_DICTIONARY:
+  case PROP_FACTORY_OPTIONS_INFER_DICTIONARY:
     g_value_set_boolean(value, priv->infer_dictionary);
     break;
-  case PROP_SCHEMA:
+  case PROP_FACTORY_OPTIONS_SCHEMA:
     g_value_set_object(value, priv->schema);
     break;
-  case PROP_SEGMENT_ENCODING:
+  case PROP_FACTORY_OPTIONS_SEGMENT_ENCODING:
     g_value_set_enum(value, priv->segment_encoding);
     break;
   default:
@@ -145,24 +158,27 @@ gadataset_partitioning_options_get_property(GObject *object,
 }
 
 static void
-gadataset_partitioning_options_init(GADatasetPartitioningOptions *object)
+gadataset_partitioning_factory_options_init(
+  GADatasetPartitioningFactoryOptions *object)
 {
 }
 
 static void
-gadataset_partitioning_options_class_init(
-  GADatasetPartitioningOptionsClass *klass)
+gadataset_partitioning_factory_options_class_init(
+  GADatasetPartitioningFactoryOptionsClass *klass)
 {
   auto gobject_class = G_OBJECT_CLASS(klass);
 
-  gobject_class->dispose = gadataset_partitioning_options_dispose;
-  gobject_class->set_property = gadataset_partitioning_options_set_property;
-  gobject_class->get_property = gadataset_partitioning_options_get_property;
+  gobject_class->dispose = gadataset_partitioning_factory_options_dispose;
+  gobject_class->set_property =
+    gadataset_partitioning_factory_options_set_property;
+  gobject_class->get_property =
+    gadataset_partitioning_factory_options_get_property;
 
   arrow::dataset::PartitioningFactoryOptions default_options;
   GParamSpec *spec;
   /**
-   * GADatasetPartitioningOptions:infer-dictionary:
+   * GADatasetPartitioningFactoryOptions:infer-dictionary:
    *
    * When inferring a schema for partition fields, yield dictionary
    * encoded types instead of plain. This can be more efficient when
@@ -170,7 +186,7 @@ gadataset_partitioning_options_class_init(
    * finished Partitioning will include dictionaries of all unique
    * inspected values for each field.
    *
-   * Since: 6.0.0
+   * Since: 11.0.0
    */
   spec = g_param_spec_boolean("infer-dictionary",
                               "Infer dictionary",
@@ -178,16 +194,18 @@ gadataset_partitioning_options_class_init(
                               "dictionary",
                               default_options.infer_dictionary,
                               static_cast<GParamFlags>(G_PARAM_READWRITE));
-  g_object_class_install_property(gobject_class, PROP_INFER_DICTIONARY, spec);
+  g_object_class_install_property(gobject_class,
+                                  PROP_FACTORY_OPTIONS_INFER_DICTIONARY,
+                                  spec);
 
   /**
-   * GADatasetPartitioningOptions:schema:
+   * GADatasetPartitioningFactoryOptions:schema:
    *
    * Optionally, an expected schema can be provided, in which case
    * inference will only check discovered fields against the schema
    * and update internal state (such as dictionaries).
    *
-   * Since: 6.0.0
+   * Since: 11.0.0
    */
   spec = g_param_spec_object("schema",
                              "Schema",
@@ -195,15 +213,17 @@ gadataset_partitioning_options_class_init(
                              "against the schema and update internal state",
                              GARROW_TYPE_SCHEMA,
                              static_cast<GParamFlags>(G_PARAM_READWRITE));
-  g_object_class_install_property(gobject_class, PROP_SCHEMA, spec);
+  g_object_class_install_property(gobject_class,
+                                  PROP_FACTORY_OPTIONS_SCHEMA,
+                                  spec);
 
   /**
-   * GADatasetPartitioningOptions:segment-encoding:
+   * GADatasetPartitioningFactoryOptions:segment-encoding:
    *
    * After splitting a path into components, decode the path
    * components before parsing according to this scheme.
    *
-   * Since: 6.0.0
+   * Since: 11.0.0
    */
   spec = g_param_spec_enum("segment-encoding",
                            "Segment encoding",
@@ -214,36 +234,38 @@ gadataset_partitioning_options_class_init(
                            static_cast<GADatasetSegmentEncoding>(
                              default_options.segment_encoding),
                            static_cast<GParamFlags>(G_PARAM_READWRITE));
-  g_object_class_install_property(gobject_class, PROP_SEGMENT_ENCODING, spec);
+  g_object_class_install_property(gobject_class,
+                                  PROP_FACTORY_OPTIONS_SEGMENT_ENCODING,
+                                  spec);
 }
 
 /**
- * gadataset_partitioning_options_new:
+ * gadataset_partitioning_factory_options_new:
  *
- * Returns: The newly created #GADatasetPartitioningOptions.
+ * Returns: The newly created #GADatasetPartitioningFactoryOptions.
  *
- * Since: 6.0.0
+ * Since: 11.0.0
  */
-GADatasetPartitioningOptions *
-gadataset_partitioning_options_new(void)
+GADatasetPartitioningFactoryOptions *
+gadataset_partitioning_factory_options_new(void)
 {
-  return GADATASET_PARTITIONING_OPTIONS(
-    g_object_new(GADATASET_TYPE_PARTITIONING_OPTIONS,
-                 NULL));
+  return GADATASET_PARTITIONING_FACTORY_OPTIONS(
+    g_object_new(GADATASET_TYPE_PARTITIONING_FACTORY_OPTIONS,
+                 nullptr));
 }
 
 
-typedef struct GADatasetPartitioningPrivate_ {
+struct GADatasetPartitioningPrivate {
   std::shared_ptr<arrow::dataset::Partitioning> partitioning;
-} GADatasetPartitioningPrivate;
+};
 
 enum {
   PROP_PARTITIONING = 1,
 };
 
-G_DEFINE_TYPE_WITH_PRIVATE(GADatasetPartitioning,
-                           gadataset_partitioning,
-                           G_TYPE_OBJECT)
+G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE(GADatasetPartitioning,
+                                    gadataset_partitioning,
+                                    G_TYPE_OBJECT)
 
 #define GADATASET_PARTITIONING_GET_PRIVATE(obj)         \
   static_cast<GADatasetPartitioningPrivate *>(          \
@@ -304,24 +326,6 @@ gadataset_partitioning_class_init(GADatasetPartitioningClass *klass)
 }
 
 /**
- * gadataset_partitioning_new:
- *
- * Returns: The newly created #GADatasetPartitioning that doesn't
- *   partition.
- *
- * Since: 6.0.0
- */
-GADatasetPartitioning *
-gadataset_partitioning_new(void)
-{
-  auto arrow_partitioning = arrow::dataset::Partitioning::Default();
-  return GADATASET_PARTITIONING(
-    g_object_new(GADATASET_TYPE_PARTITIONING,
-                 "partitioning", &arrow_partitioning,
-                 NULL));
-}
-
-/**
  * gadataset_partitioning_get_type_name:
  * @partitioning: A #GADatasetPartitioning.
  *
@@ -341,9 +345,152 @@ gadataset_partitioning_get_type_name(GADatasetPartitioning *partitioning)
 }
 
 
-G_DEFINE_TYPE(GADatasetKeyValuePartitioning,
-              gadataset_key_value_partitioning,
+G_DEFINE_TYPE(GADatasetDefaultPartitioning,
+              gadataset_default_partitioning,
               GADATASET_TYPE_PARTITIONING)
+
+static void
+gadataset_default_partitioning_init(GADatasetDefaultPartitioning *object)
+{
+}
+
+static void
+gadataset_default_partitioning_class_init(
+  GADatasetDefaultPartitioningClass *klass)
+{
+}
+
+/**
+ * gadataset_default_partitioning_new:
+ *
+ * Returns: The newly created #GADatasetDefaultPartitioning that
+ *   doesn't partition.
+ *
+ * Since: 11.0.0
+ */
+GADatasetDefaultPartitioning *
+gadataset_default_partitioning_new(void)
+{
+  auto arrow_partitioning = arrow::dataset::Partitioning::Default();
+  return GADATASET_DEFAULT_PARTITIONING(
+    gadataset_partitioning_new_raw(&arrow_partitioning));
+}
+
+
+struct GADatasetKeyValuePartitioningOptionsPrivate {
+  GADatasetSegmentEncoding segment_encoding;
+};
+
+enum {
+  PROP_OPTIONS_SEGMENT_ENCODING = 1,
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GADatasetKeyValuePartitioningOptions,
+                           gadataset_key_value_partitioning_options,
+                           G_TYPE_OBJECT)
+
+#define GADATASET_KEY_VALUE_PARTITIONING_OPTIONS_GET_PRIVATE(obj)       \
+  static_cast<GADatasetKeyValuePartitioningOptionsPrivate *>(           \
+    gadataset_key_value_partitioning_options_get_instance_private(      \
+      GADATASET_KEY_VALUE_PARTITIONING_OPTIONS(obj)))
+
+static void
+gadataset_key_value_partitioning_options_set_property(GObject *object,
+                                                      guint prop_id,
+                                                      const GValue *value,
+                                                      GParamSpec *pspec)
+{
+  auto priv = GADATASET_KEY_VALUE_PARTITIONING_OPTIONS_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_OPTIONS_SEGMENT_ENCODING:
+    priv->segment_encoding =
+      static_cast<GADatasetSegmentEncoding>(g_value_get_enum(value));
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gadataset_key_value_partitioning_options_get_property(GObject *object,
+                                                      guint prop_id,
+                                                      GValue *value,
+                                                      GParamSpec *pspec)
+{
+  auto priv = GADATASET_KEY_VALUE_PARTITIONING_OPTIONS_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_OPTIONS_SEGMENT_ENCODING:
+    g_value_set_enum(value, priv->segment_encoding);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gadataset_key_value_partitioning_options_init(
+  GADatasetKeyValuePartitioningOptions *object)
+{
+}
+
+static void
+gadataset_key_value_partitioning_options_class_init(
+  GADatasetKeyValuePartitioningOptionsClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->set_property =
+    gadataset_key_value_partitioning_options_set_property;
+  gobject_class->get_property =
+    gadataset_key_value_partitioning_options_get_property;
+
+  arrow::dataset::KeyValuePartitioningOptions default_options;
+  GParamSpec *spec;
+  /**
+   * GADatasetKeyValuePartitioningOptions:segment-encoding:
+   *
+   * After splitting a path into components, decode the path
+   * components before parsing according to this scheme.
+   *
+   * Since: 11.0.0
+   */
+  spec = g_param_spec_enum("segment-encoding",
+                           "Segment encoding",
+                           "After splitting a path into components, "
+                           "decode the path components before "
+                           "parsing according to this scheme",
+                           GADATASET_TYPE_SEGMENT_ENCODING,
+                           static_cast<GADatasetSegmentEncoding>(
+                             default_options.segment_encoding),
+                           static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class,
+                                  PROP_OPTIONS_SEGMENT_ENCODING,
+                                  spec);
+}
+
+/**
+ * gadataset_key_value_partitioning_options_new:
+ *
+ * Returns: The newly created #GADatasetKeyValuePartitioningOptions.
+ *
+ * Since: 11.0.0
+ */
+GADatasetKeyValuePartitioningOptions *
+gadataset_key_value_partitioning_options_new(void)
+{
+  return GADATASET_KEY_VALUE_PARTITIONING_OPTIONS(
+    g_object_new(GADATASET_TYPE_KEY_VALUE_PARTITIONING_OPTIONS,
+                 nullptr));
+}
+
+
+G_DEFINE_ABSTRACT_TYPE(GADatasetKeyValuePartitioning,
+                       gadataset_key_value_partitioning,
+                       GADATASET_TYPE_PARTITIONING)
 
 static void
 gadataset_key_value_partitioning_init(GADatasetKeyValuePartitioning *object)
@@ -356,6 +503,34 @@ gadataset_key_value_partitioning_class_init(
 {
 }
 
+G_END_DECLS
+template <typename Partitioning, typename PartitioningOptions>
+GADatasetPartitioning *
+garrow_key_value_partitioning_new(
+  GArrowSchema *schema,
+  GList *dictionaries,
+  PartitioningOptions &arrow_options,
+  GError **error)
+{
+  auto arrow_schema = garrow_schema_get_raw(schema);
+  std::vector<std::shared_ptr<arrow::Array>> arrow_dictionaries;
+  for (auto node = dictionaries; node; node = node->next) {
+    auto dictionary = GARROW_ARRAY(node->data);
+    if (dictionary) {
+      arrow_dictionaries.push_back(garrow_array_get_raw(dictionary));
+    } else {
+      arrow_dictionaries.push_back(nullptr);
+    }
+  }
+  auto arrow_partitioning =
+    std::static_pointer_cast<arrow::dataset::Partitioning>(
+      std::make_shared<Partitioning>(
+        arrow_schema,
+        arrow_dictionaries,
+        arrow_options));
+  return gadataset_partitioning_new_raw(&arrow_partitioning);
+}
+G_BEGIN_DECLS
 
 G_DEFINE_TYPE(GADatasetDirectoryPartitioning,
               gadataset_directory_partitioning,
@@ -377,7 +552,7 @@ gadataset_directory_partitioning_class_init(
  * @schema: A #GArrowSchema that describes all partitioned segments.
  * @dictionaries: (nullable) (element-type GArrowArray): A list of #GArrowArray
  *   for dictionary data types in @schema.
- * @options: (nullable): A #GADatasetPartitioningOptions.
+ * @options: (nullable): A #GADatasetKeyValuePartitioningOptions.
  * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: The newly created #GADatasetDirectoryPartitioning on success,
@@ -386,50 +561,267 @@ gadataset_directory_partitioning_class_init(
  * Since: 6.0.0
  */
 GADatasetDirectoryPartitioning *
-gadataset_directory_partitioning_new(GArrowSchema *schema,
-                                     GList *dictionaries,
-                                     GADatasetPartitioningOptions *options,
-                                     GError **error)
+gadataset_directory_partitioning_new(
+  GArrowSchema *schema,
+  GList *dictionaries,
+  GADatasetKeyValuePartitioningOptions *options,
+  GError **error)
 {
-  auto arrow_schema = garrow_schema_get_raw(schema);
-  std::vector<std::shared_ptr<arrow::Array>> arrow_dictionaries;
-  for (auto node = dictionaries; node; node = node->next) {
-    auto dictionary = GARROW_ARRAY(node->data);
-    if (dictionary) {
-      arrow_dictionaries.push_back(garrow_array_get_raw(dictionary));
-    } else {
-      arrow_dictionaries.push_back(nullptr);
-    }
-  }
   arrow::dataset::KeyValuePartitioningOptions arrow_options;
   if (options) {
-    arrow_options =
-      gadataset_partitioning_options_get_raw_key_value_partitioning_options(
-        options);
+    arrow_options = gadataset_key_value_partitioning_options_get_raw(options);
   }
-  auto arrow_partitioning =
-    std::make_shared<arrow::dataset::DirectoryPartitioning>(
-      arrow_schema,
-      arrow_dictionaries,
-      arrow_options);
   return GADATASET_DIRECTORY_PARTITIONING(
-    g_object_new(GADATASET_TYPE_DIRECTORY_PARTITIONING,
-                 "partitioning", &arrow_partitioning,
-                 NULL));
+    garrow_key_value_partitioning_new<arrow::dataset::DirectoryPartitioning>(
+      schema, dictionaries, arrow_options, error));
+}
+
+
+struct GADatasetHivePartitioningOptionsPrivate {
+  gchar *null_fallback;
+};
+
+enum {
+  PROP_OPTIONS_NULL_FALLBACK = 1,
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GADatasetHivePartitioningOptions,
+                           gadataset_hive_partitioning_options,
+                           GADATASET_TYPE_KEY_VALUE_PARTITIONING_OPTIONS)
+
+#define GADATASET_HIVE_PARTITIONING_OPTIONS_GET_PRIVATE(obj)        \
+  static_cast<GADatasetHivePartitioningOptionsPrivate *>(           \
+    gadataset_hive_partitioning_options_get_instance_private(       \
+      GADATASET_HIVE_PARTITIONING_OPTIONS(obj)))
+
+static void
+gadataset_hive_partitioning_options_finalize(GObject *object)
+{
+  auto priv = GADATASET_HIVE_PARTITIONING_OPTIONS_GET_PRIVATE(object);
+
+  if (priv->null_fallback) {
+    g_free(priv->null_fallback);
+    priv->null_fallback = nullptr;
+  }
+
+  G_OBJECT_CLASS(gadataset_hive_partitioning_options_parent_class)->finalize(object);
+}
+
+static void
+gadataset_hive_partitioning_options_set_property(GObject *object,
+                                                 guint prop_id,
+                                                 const GValue *value,
+                                                 GParamSpec *pspec)
+{
+  auto priv = GADATASET_HIVE_PARTITIONING_OPTIONS_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_OPTIONS_NULL_FALLBACK:
+    if (priv->null_fallback == g_value_get_string(value)) {
+      break;
+    }
+    if (priv->null_fallback) {
+      g_free(priv->null_fallback);
+    }
+    priv->null_fallback = g_value_dup_string(value);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gadataset_hive_partitioning_options_get_property(GObject *object,
+                                                 guint prop_id,
+                                                 GValue *value,
+                                                 GParamSpec *pspec)
+{
+  auto priv = GADATASET_HIVE_PARTITIONING_OPTIONS_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_OPTIONS_NULL_FALLBACK:
+    g_value_set_string(value, priv->null_fallback);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+gadataset_hive_partitioning_options_init(
+  GADatasetHivePartitioningOptions *object)
+{
+}
+
+static void
+gadataset_hive_partitioning_options_class_init(
+  GADatasetHivePartitioningOptionsClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->finalize = gadataset_hive_partitioning_options_finalize;
+  gobject_class->set_property = gadataset_hive_partitioning_options_set_property;
+  gobject_class->get_property = gadataset_hive_partitioning_options_get_property;
+
+  arrow::dataset::HivePartitioningOptions default_options;
+  GParamSpec *spec;
+  /**
+   * GADatasetHivePartitioningOptions:null-fallback:
+   *
+   * The fallback string for null. This is used only by
+   * #GADatasetHivePartitioning.
+   *
+   * Since: 11.0.0
+   */
+  spec = g_param_spec_string("null-fallback",
+                             "Null fallback",
+                             "The fallback string for null",
+                             default_options.null_fallback.c_str(),
+                             static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class,
+                                  PROP_OPTIONS_NULL_FALLBACK,
+                                  spec);
+}
+
+/**
+ * gadataset_hive_partitioning_options_new:
+ *
+ * Returns: The newly created #GADatasetHivePartitioningOptions.
+ *
+ * Since: 11.0.0
+ */
+GADatasetHivePartitioningOptions *
+gadataset_hive_partitioning_options_new(void)
+{
+  return GADATASET_HIVE_PARTITIONING_OPTIONS(
+    g_object_new(GADATASET_TYPE_HIVE_PARTITIONING_OPTIONS,
+                 nullptr));
+}
+
+
+G_DEFINE_TYPE(GADatasetHivePartitioning,
+              gadataset_hive_partitioning,
+              GADATASET_TYPE_KEY_VALUE_PARTITIONING)
+
+static void
+gadataset_hive_partitioning_init(GADatasetHivePartitioning *object)
+{
+}
+
+static void
+gadataset_hive_partitioning_class_init(
+  GADatasetHivePartitioningClass *klass)
+{
+}
+
+/**
+ * gadataset_hive_partitioning_new:
+ * @schema: A #GArrowSchema that describes all partitioned segments.
+ * @dictionaries: (nullable) (element-type GArrowArray): A list of #GArrowArray
+ *   for dictionary data types in @schema.
+ * @options: (nullable): A #GADatasetHivePartitioningOptions.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: The newly created #GADatasetHivePartitioning on success,
+ *   %NULL on error.
+ *
+ * Since: 11.0.0
+ */
+GADatasetHivePartitioning *
+gadataset_hive_partitioning_new(GArrowSchema *schema,
+                                GList *dictionaries,
+                                GADatasetHivePartitioningOptions *options,
+                                GError **error)
+{
+  arrow::dataset::HivePartitioningOptions arrow_options;
+  if (options) {
+    arrow_options = gadataset_hive_partitioning_options_get_raw(options);
+  }
+  return GADATASET_HIVE_PARTITIONING(
+    garrow_key_value_partitioning_new<arrow::dataset::HivePartitioning>(
+      schema, dictionaries, arrow_options, error));
+}
+
+/**
+ * gadataset_hive_partitioning_get_null_fallback:
+ *
+ * Returns: The fallback string for null.
+ *
+ *   It should be freed with g_free() when no longer needed.
+ *
+ * Since: 11.0.0
+ */
+gchar *
+gadataset_hive_partitioning_get_null_fallback(
+  GADatasetHivePartitioning *partitioning)
+{
+  auto arrow_partitioning =
+    std::static_pointer_cast<arrow::dataset::HivePartitioning>(
+      gadataset_partitioning_get_raw(GADATASET_PARTITIONING(partitioning)));
+  return g_strdup(arrow_partitioning->null_fallback().c_str());
 }
 
 
 G_END_DECLS
 
-arrow::dataset::KeyValuePartitioningOptions
-gadataset_partitioning_options_get_raw_key_value_partitioning_options(
-  GADatasetPartitioningOptions *options)
+arrow::dataset::PartitioningFactoryOptions
+gadataset_partitioning_factory_options_get_raw(
+  GADatasetPartitioningFactoryOptions *options)
 {
-  auto priv = GADATASET_PARTITIONING_OPTIONS_GET_PRIVATE(options);
+  auto priv = GADATASET_PARTITIONING_FACTORY_OPTIONS_GET_PRIVATE(options);
+  arrow::dataset::PartitioningFactoryOptions arrow_options;
+  arrow_options.infer_dictionary = priv->infer_dictionary;
+  if (priv->schema) {
+    arrow_options.schema = garrow_schema_get_raw(priv->schema);
+  }
+  arrow_options.segment_encoding =
+    static_cast<arrow::dataset::SegmentEncoding>(priv->segment_encoding);
+  return arrow_options;
+}
+
+arrow::dataset::KeyValuePartitioningOptions
+gadataset_key_value_partitioning_options_get_raw(
+  GADatasetKeyValuePartitioningOptions *options)
+{
+  auto priv = GADATASET_KEY_VALUE_PARTITIONING_OPTIONS_GET_PRIVATE(options);
   arrow::dataset::KeyValuePartitioningOptions arrow_options;
   arrow_options.segment_encoding =
     static_cast<arrow::dataset::SegmentEncoding>(priv->segment_encoding);
   return arrow_options;
+}
+
+arrow::dataset::HivePartitioningOptions
+gadataset_hive_partitioning_options_get_raw(
+  GADatasetHivePartitioningOptions *options)
+{
+  auto priv = GADATASET_HIVE_PARTITIONING_OPTIONS_GET_PRIVATE(options);
+  auto arrow_key_value_options =
+    gadataset_key_value_partitioning_options_get_raw(
+      GADATASET_KEY_VALUE_PARTITIONING_OPTIONS(options));
+  arrow::dataset::HivePartitioningOptions arrow_options;
+  arrow_options.segment_encoding = arrow_key_value_options.segment_encoding;
+  arrow_options.null_fallback = priv->null_fallback;
+  return arrow_options;
+}
+
+GADatasetPartitioning *
+gadataset_partitioning_new_raw(
+  std::shared_ptr<arrow::dataset::Partitioning> *arrow_partitioning)
+{
+  GType type = GADATASET_TYPE_PARTITIONING;
+  const auto arrow_type_name = (*arrow_partitioning)->type_name();
+  if (arrow_type_name == "default") {
+    type = GADATASET_TYPE_DEFAULT_PARTITIONING;
+  } else if (arrow_type_name == "directory") {
+    type = GADATASET_TYPE_DIRECTORY_PARTITIONING;
+  } else if (arrow_type_name == "hive") {
+    type = GADATASET_TYPE_HIVE_PARTITIONING;
+  }
+  return GADATASET_PARTITIONING(g_object_new(type,
+                                             "partitioning", arrow_partitioning,
+                                             nullptr));
 }
 
 std::shared_ptr<arrow::dataset::Partitioning>

--- a/c_glib/arrow-dataset-glib/partitioning.h
+++ b/c_glib/arrow-dataset-glib/partitioning.h
@@ -38,21 +38,21 @@ typedef enum {
 } GADatasetSegmentEncoding;
 
 
-#define GADATASET_TYPE_PARTITIONING_OPTIONS   \
-  (gadataset_partitioning_options_get_type())
-G_DECLARE_DERIVABLE_TYPE(GADatasetPartitioningOptions,
-                         gadataset_partitioning_options,
+#define GADATASET_TYPE_PARTITIONING_FACTORY_OPTIONS   \
+  (gadataset_partitioning_factory_options_get_type())
+G_DECLARE_DERIVABLE_TYPE(GADatasetPartitioningFactoryOptions,
+                         gadataset_partitioning_factory_options,
                          GADATASET,
-                         PARTITIONING_OPTIONS,
+                         PARTITIONING_FACTORY_OPTIONS,
                          GObject)
-struct _GADatasetPartitioningOptionsClass
+struct _GADatasetPartitioningFactoryOptionsClass
 {
   GObjectClass parent_class;
 };
 
-GARROW_AVAILABLE_IN_6_0
-GADatasetPartitioningOptions *
-gadataset_partitioning_options_new(void);
+GARROW_AVAILABLE_IN_11_0
+GADatasetPartitioningFactoryOptions *
+gadataset_partitioning_factory_options_new(void);
 
 
 #define GADATASET_TYPE_PARTITIONING (gadataset_partitioning_get_type())
@@ -67,11 +67,42 @@ struct _GADatasetPartitioningClass
 };
 
 GARROW_AVAILABLE_IN_6_0
-GADatasetPartitioning *
-gadataset_partitioning_new(void);
-GARROW_AVAILABLE_IN_6_0
 gchar *
 gadataset_partitioning_get_type_name(GADatasetPartitioning *partitioning);
+
+
+#define GADATASET_TYPE_DEFAULT_PARTITIONING     \
+  (gadataset_default_partitioning_get_type())
+G_DECLARE_DERIVABLE_TYPE(GADatasetDefaultPartitioning,
+                         gadataset_default_partitioning,
+                         GADATASET,
+                         DEFAULT_PARTITIONING,
+                         GADatasetPartitioning)
+struct _GADatasetDefaultPartitioningClass
+{
+  GADatasetPartitioningClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_11_0
+GADatasetDefaultPartitioning *
+gadataset_default_partitioning_new(void);
+
+
+#define GADATASET_TYPE_KEY_VALUE_PARTITIONING_OPTIONS   \
+  (gadataset_key_value_partitioning_options_get_type())
+G_DECLARE_DERIVABLE_TYPE(GADatasetKeyValuePartitioningOptions,
+                         gadataset_key_value_partitioning_options,
+                         GADATASET,
+                         KEY_VALUE_PARTITIONING_OPTIONS,
+                         GObject)
+struct _GADatasetKeyValuePartitioningOptionsClass
+{
+  GObjectClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_11_0
+GADatasetKeyValuePartitioningOptions *
+gadataset_key_value_partitioning_options_new(void);
 
 
 #define GADATASET_TYPE_KEY_VALUE_PARTITIONING   \
@@ -101,10 +132,52 @@ struct _GADatasetDirectoryPartitioningClass
 
 GARROW_AVAILABLE_IN_6_0
 GADatasetDirectoryPartitioning *
-gadataset_directory_partitioning_new(GArrowSchema *schema,
-                                     GList *dictionaries,
-                                     GADatasetPartitioningOptions *options,
-                                     GError **error);
+gadataset_directory_partitioning_new(
+  GArrowSchema *schema,
+  GList *dictionaries,
+  GADatasetKeyValuePartitioningOptions *options,
+  GError **error);
+
+
+#define GADATASET_TYPE_HIVE_PARTITIONING_OPTIONS   \
+  (gadataset_hive_partitioning_options_get_type())
+G_DECLARE_DERIVABLE_TYPE(GADatasetHivePartitioningOptions,
+                         gadataset_hive_partitioning_options,
+                         GADATASET,
+                         HIVE_PARTITIONING_OPTIONS,
+                         GADatasetKeyValuePartitioningOptions)
+struct _GADatasetHivePartitioningOptionsClass
+{
+  GADatasetKeyValuePartitioningOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_11_0
+GADatasetHivePartitioningOptions *
+gadataset_hive_partitioning_options_new(void);
+
+
+#define GADATASET_TYPE_HIVE_PARTITIONING        \
+  (gadataset_hive_partitioning_get_type())
+G_DECLARE_DERIVABLE_TYPE(GADatasetHivePartitioning,
+                         gadataset_hive_partitioning,
+                         GADATASET,
+                         HIVE_PARTITIONING,
+                         GADatasetKeyValuePartitioning)
+struct _GADatasetHivePartitioningClass
+{
+  GADatasetKeyValuePartitioningClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_11_0
+GADatasetHivePartitioning *
+gadataset_hive_partitioning_new(GArrowSchema *schema,
+                                GList *dictionaries,
+                                GADatasetHivePartitioningOptions *options,
+                                GError **error);
+GARROW_AVAILABLE_IN_11_0
+gchar *
+gadataset_hive_partitioning_get_null_fallback(
+  GADatasetHivePartitioning *partitioning);
 
 
 G_END_DECLS

--- a/c_glib/arrow-dataset-glib/partitioning.hpp
+++ b/c_glib/arrow-dataset-glib/partitioning.hpp
@@ -23,9 +23,21 @@
 
 #include <arrow-dataset-glib/partitioning.h>
 
+arrow::dataset::PartitioningFactoryOptions
+gadataset_partitioning_factory_options_get_raw(
+  GADatasetPartitioningFactoryOptions *options);
+
 arrow::dataset::KeyValuePartitioningOptions
-gadataset_partitioning_options_get_raw_key_value_partitioning_options(
-  GADatasetPartitioningOptions *options);
+gadataset_key_value_partitioning_options_get_raw(
+  GADatasetKeyValuePartitioningOptions *options);
+
+arrow::dataset::HivePartitioningOptions
+gadataset_hive_partitioning_options_get_raw(
+  GADatasetHivePartitioningOptions *options);
+
+GADatasetPartitioning *
+gadataset_partitioning_new_raw(
+  std::shared_ptr<arrow::dataset::Partitioning> *arrow_partitioning);
 
 std::shared_ptr<arrow::dataset::Partitioning>
 gadataset_partitioning_get_raw(GADatasetPartitioning *partitioning);

--- a/c_glib/test/dataset/test-partitioning-factory-options.rb
+++ b/c_glib/test/dataset/test-partitioning-factory-options.rb
@@ -15,12 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class TestDatasetPartitioningOptions < Test::Unit::TestCase
+class TestDatasetPartitioningFactoryOptions < Test::Unit::TestCase
   include Helper::Buildable
 
   def setup
     omit("Arrow Dataset is required") unless defined?(ArrowDataset)
-    @options = ArrowDataset::PartitioningOptions.new
+    @options = ArrowDataset::PartitioningFactoryOptions.new
   end
 
   def test_infer_dictionary

--- a/c_glib/test/dataset/test-partitioning.rb
+++ b/c_glib/test/dataset/test-partitioning.rb
@@ -23,12 +23,39 @@ class TestDatasetPartitioning < Test::Unit::TestCase
   end
 
   def test_default
-    assert_equal("default", ArrowDataset::Partitioning.new.type_name)
+    assert_equal("default", ArrowDataset::DefaultPartitioning.new.type_name)
   end
 
   def test_directory
     schema = build_schema(year: Arrow::UInt16DataType.new)
     partitioning = ArrowDataset::DirectoryPartitioning.new(schema)
     assert_equal("directory", partitioning.type_name)
+  end
+
+  def test_directory_options
+    schema = build_schema(year: Arrow::UInt16DataType.new)
+    options = ArrowDataset::KeyValuePartitioningOptions.new
+    options.segment_encoding = :none
+    partitioning = ArrowDataset::DirectoryPartitioning.new(schema,
+                                                           nil,
+                                                           options)
+    assert_equal("directory", partitioning.type_name)
+  end
+
+  def test_hive
+    schema = build_schema(year: Arrow::UInt16DataType.new)
+    partitioning = ArrowDataset::HivePartitioning.new(schema)
+    assert_equal("hive", partitioning.type_name)
+  end
+
+  def test_hive_options
+    schema = build_schema(year: Arrow::UInt16DataType.new)
+    options = ArrowDataset::HivePartitioningOptions.new
+    options.segment_encoding = :none
+    options.null_fallback = "NULL"
+    partitioning = ArrowDataset::HivePartitioning.new(schema,
+                                                      nil,
+                                                      options)
+    assert_equal("NULL", partitioning.null_fallback)
   end
 end


### PR DESCRIPTION
This has some breaking changes:

* `GADatasetPartitioningOptions` -> `GADatasetPartitioningFactoryOptions`
* `gadataset_directory_partitioning_new()` uses `GADatasetKeyValuePartitioningOptions` instead of `GADatasetPartitioningOptions`
* `gadataset_partitioning_new()` -> `gadataset_default_partitioning_new()`
* Closes: #15257