### PR TITLE
MINOR: [C++] Mark TypeHolder operator bool() as const

### DIFF
--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -236,7 +236,7 @@ struct ARROW_EXPORT TypeHolder {
 
   const DataType& operator*() const { return *this->type; }
 
-  operator bool() { return this->type != NULLPTR; }
+  operator bool() const { return this->type != NULLPTR; }
 
   bool operator==(const TypeHolder& other) const {
     if (type == other.type) return true;


### PR DESCRIPTION
To be able to use it when the `TypeHolder` is const.