### PR TITLE
ARROW-18337: [R] Possible undesirable handling of POSIXlt objects

### DIFF
--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -1872,10 +1872,6 @@ StructScalar__GetFieldByName <- function(s, name) {
   .Call(`_arrow_StructScalar__GetFieldByName`, s, name)
 }
 
-Scalar__as_vector <- function(scalar) {
-  .Call(`_arrow_Scalar__as_vector`, scalar)
-}
-
 MakeArrayFromScalar <- function(scalar, n) {
   .Call(`_arrow_MakeArrayFromScalar`, scalar, n)
 }

--- a/r/R/scalar.R
+++ b/r/R/scalar.R
@@ -71,9 +71,15 @@
 Scalar <- R6Class("Scalar",
   inherit = ArrowDatum,
   public = list(
-    ToString = function() Scalar__ToString(self),
+    ToString = function() {
+      if (self$type_id() == Type$EXTENSION) {
+        format(self$as_vector())
+      } else {
+        Scalar__ToString(self)
+      }
+    },
     type_id = function() Scalar__type(self)$id,
-    as_vector = function() Scalar__as_vector(self),
+    as_vector = function(length = 1L) self$as_array(length)$as_vector(),
     as_array = function(length = 1L) MakeArrayFromScalar(self, as.integer(length)),
     Equals = function(other, ...) {
       inherits(other, "Scalar") && Scalar__Equals(self, other)

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -4771,14 +4771,6 @@ BEGIN_CPP11
 END_CPP11
 }
 // scalar.cpp
-SEXP Scalar__as_vector(const std::shared_ptr<arrow::Scalar>& scalar);
-extern "C" SEXP _arrow_Scalar__as_vector(SEXP scalar_sexp){
-BEGIN_CPP11
-	arrow::r::Input<const std::shared_ptr<arrow::Scalar>&>::type scalar(scalar_sexp);
-	return cpp11::as_sexp(Scalar__as_vector(scalar));
-END_CPP11
-}
-// scalar.cpp
 std::shared_ptr<arrow::Array> MakeArrayFromScalar(const std::shared_ptr<arrow::Scalar>& scalar, int n);
 extern "C" SEXP _arrow_MakeArrayFromScalar(SEXP scalar_sexp, SEXP n_sexp){
 BEGIN_CPP11
@@ -5748,7 +5740,6 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_Scalar__ToString", (DL_FUNC) &_arrow_Scalar__ToString, 1}, 
 		{ "_arrow_StructScalar__field", (DL_FUNC) &_arrow_StructScalar__field, 2}, 
 		{ "_arrow_StructScalar__GetFieldByName", (DL_FUNC) &_arrow_StructScalar__GetFieldByName, 2}, 
-		{ "_arrow_Scalar__as_vector", (DL_FUNC) &_arrow_Scalar__as_vector, 1}, 
 		{ "_arrow_MakeArrayFromScalar", (DL_FUNC) &_arrow_MakeArrayFromScalar, 2}, 
 		{ "_arrow_Scalar__is_valid", (DL_FUNC) &_arrow_Scalar__is_valid, 1}, 
 		{ "_arrow_Scalar__type", (DL_FUNC) &_arrow_Scalar__type, 1}, 

--- a/r/src/scalar.cpp
+++ b/r/src/scalar.cpp
@@ -58,18 +58,18 @@ std::shared_ptr<arrow::Scalar> StructScalar__GetFieldByName(
 }
 
 // [[arrow::export]]
-SEXP Scalar__as_vector(const std::shared_ptr<arrow::Scalar>& scalar) {
-  auto array = ValueOrStop(arrow::MakeArrayFromScalar(*scalar, 1, gc_memory_pool()));
-
-  // defined in array_to_vector.cpp
-  SEXP Array__as_vector(const std::shared_ptr<arrow::Array>& array);
-  return Array__as_vector(array);
-}
-
-// [[arrow::export]]
 std::shared_ptr<arrow::Array> MakeArrayFromScalar(
     const std::shared_ptr<arrow::Scalar>& scalar, int n) {
-  return ValueOrStop(arrow::MakeArrayFromScalar(*scalar, n, gc_memory_pool()));
+  if (scalar->type->id() == arrow::Type::EXTENSION) {
+    auto extension_scalar = std::dynamic_pointer_cast<arrow::ExtensionScalar>(scalar);
+    auto type = std::dynamic_pointer_cast<arrow::ExtensionType>(scalar->type);
+    auto storage_type = type->storage_type();
+    auto storage = ValueOrStop(
+        arrow::MakeArrayFromScalar(*extension_scalar->value, n, gc_memory_pool()));
+    return type->WrapArray(type, storage);
+  } else {
+    return ValueOrStop(arrow::MakeArrayFromScalar(*scalar, n, gc_memory_pool()));
+  }
 }
 
 // [[arrow::export]]

--- a/r/tests/testthat/test-scalar.R
+++ b/r/tests/testthat/test-scalar.R
@@ -45,7 +45,7 @@ test_that("Scalar print", {
 
 test_that("ExtensionType scalar behaviour", {
   ext_array <- vctrs_extension_array(4)
-  ext_scalar <- arrow::Scalar$create(ext_array)
+  ext_scalar <- Scalar$create(ext_array)
   expect_equal(ext_scalar$as_array(), ext_array)
   expect_identical(ext_scalar$as_vector(), 4)
   expect_identical(ext_scalar$as_vector(10), rep(4, 10))

--- a/r/tests/testthat/test-scalar.R
+++ b/r/tests/testthat/test-scalar.R
@@ -43,6 +43,15 @@ test_that("Scalar print", {
   expect_output(print(Scalar$create(4)), "Scalar\n4")
 })
 
+test_that("ExtensionType scalar behaviour", {
+  ext_array <- vctrs_extension_array(4)
+  ext_scalar <- arrow::Scalar$create(ext_array)
+  expect_equal(ext_scalar$as_array(), ext_array)
+  expect_identical(ext_scalar$as_vector(), 4)
+  expect_identical(ext_scalar$as_vector(10), rep(4, 10))
+  expect_output(print(ext_scalar), "Scalar\n4")
+})
+
 test_that("Creating Scalars of a different type and casting them", {
   expect_equal(Scalar$create(4L, int8())$type, int8())
   expect_equal(Scalar$create(4L)$cast(float32())$type, float32())


### PR DESCRIPTION
Before this PR, an attempt to print an ExtensionScalar would segfault:

```
> arrow::Scalar$create(arrow::vctrs_extension_array(4))
Scalar
/Users/deweydunnington/Desktop/rscratch/arrow/cpp/src/arrow/result.cc:28: ValueOrDie called on an error: NotImplemented: construction from scalar of type numeric(0)
/Users/deweydunnington/Desktop/rscratch/arrow/cpp/src/arrow/array/util.cc:545  VisitTypeInline(*scalar_.type, this)
0   libarrow.1100.0.0.dylib             0x000000014d61dbec _ZN5arrow4util7CerrLog14PrintBackTraceEv + 52
1   libarrow.1100.0.0.dylib             0x000000014d61db68 _ZN5arrow4util7CerrLogD2Ev + 116
2   libarrow.1100.0.0.dylib             0x000000014d61dab4 _ZN5arrow4util7CerrLogD1Ev + 28
3   libarrow.1100.0.0.dylib             0x000000014d61dae0 _ZN5arrow4util7CerrLogD0Ev + 28
4   libarrow.1100.0.0.dylib             0x000000014d61d9a8 _ZN5arrow4util8ArrowLogD2Ev + 96
5   libarrow.1100.0.0.dylib             0x000000014d61d9ec _ZN5arrow4util8ArrowLogD1Ev + 28
6   libarrow.1100.0.0.dylib             0x000000014d30d888 _ZN5arrow8internal14DieWithMessageERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEE + 68
7   libarrow.1100.0.0.dylib             0x000000014d30d900 _ZN5arrow8internal17InvalidValueOrDieERKNS_6StatusE + 76
8   libparquet.1100.0.0.dylib           0x000000010bb250d0 _ZNO5arrow6ResultINSt3__110shared_ptrINS_5ArrayEEEE10ValueOrDieEv + 52
9   libarrow.1100.0.0.dylib             0x000000014d313ff0 _ZNO5arrow6ResultINSt3__110shared_ptrINS_5ArrayEEEEdeEv + 40
10  libarrow.1100.0.0.dylib             0x000000014d313880 _ZNK5arrow6Scalar8ToStringEv + 692
11  arrow.so                            0x0000000103c54fec _arrow_Scalar__ToString + 108
```

After this PR, we get the result of `format(ext_scalar$as_vector())`:

``` r
arrow::Scalar$create(arrow::vctrs_extension_array(4))
#> Scalar
#> 4
```

This came up because the some relatively common (ish) R type POSIXlt is now transformed to an extension array by default:

``` r
arrow::Scalar$create(as.POSIXlt(Sys.time()))
#> Scalar
#> 2023-01-09 14:55:53
```
