### PR TITLE
GH-15284: [C++] Use DeclarationToExecBatches in Acero plan tests

### DIFF
--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -898,8 +898,7 @@ TEST(ExecPlanExecution, SourceFilterSink) {
       {{"source", SourceNodeOptions{basic_data.schema, basic_data.gen(/*parallel=*/false,
                                                                       /*slow=*/false)}},
        {"filter", FilterNodeOptions{equal(field_ref("i32"), literal(6))}}});
-  ASSERT_OK_AND_ASSIGN(auto result,
-                       DeclarationToExecBatches(std::move(plan), /*use_threads=*/false));
+  ASSERT_OK_AND_ASSIGN(auto result, DeclarationToExecBatches(std::move(plan)));
   auto exp_batches = {ExecBatchFromJSON({int32(), boolean()}, "[]"),
                       ExecBatchFromJSON({int32(), boolean()}, "[[6, false]]")};
   AssertExecBatchesEqualIgnoringOrder(result.schema, result.batches, exp_batches);
@@ -919,8 +918,7 @@ TEST(ExecPlanExecution, SourceProjectSink) {
   auto exp_batches = {
       ExecBatchFromJSON({boolean(), int32()}, "[[false, null], [true, 5]]"),
       ExecBatchFromJSON({boolean(), int32()}, "[[null, 6], [true, 7], [true, 8]]")};
-  ASSERT_OK_AND_ASSIGN(auto result,
-                       DeclarationToExecBatches(std::move(plan), /*use_threads=*/false));
+  ASSERT_OK_AND_ASSIGN(auto result, DeclarationToExecBatches(std::move(plan)));
   AssertExecBatchesEqualIgnoringOrder(result.schema, result.batches, exp_batches);
 }
 
@@ -1179,8 +1177,7 @@ TEST(ExecPlanExecution, SourceScalarAggSink) {
                      }}});
   auto exp_batches = {ExecBatchFromJSON(
       {int64(), boolean()}, {ArgShape::SCALAR, ArgShape::SCALAR}, "[[22, true]]")};
-  ASSERT_OK_AND_ASSIGN(auto result,
-                       DeclarationToExecBatches(std::move(plan), /*use_threads=*/false));
+  ASSERT_OK_AND_ASSIGN(auto result, DeclarationToExecBatches(std::move(plan)));
   AssertExecBatchesEqualIgnoringOrder(result.schema, result.batches, exp_batches);
 }
 
@@ -1266,8 +1263,7 @@ TEST(ExecPlanExecution, ScalarSourceScalarAggSink) {
            ArgShape::SCALAR},
           R"([[false, true, 6, 5.5, 26250, 0.7637626158259734, 33, 5.0, 0.5833333333333334]])"),
   };
-  ASSERT_OK_AND_ASSIGN(auto result,
-                       DeclarationToExecBatches(std::move(plan), /*use_threads=*/false));
+  ASSERT_OK_AND_ASSIGN(auto result, DeclarationToExecBatches(std::move(plan)));
   AssertExecBatchesEqualIgnoringOrder(result.schema, result.batches, exp_batches);
 }
 
@@ -1403,8 +1399,7 @@ TEST(ExecPlan, RecordBatchReaderSourceSink) {
 
   Declaration plan =
       Declaration::Sequence({{"source", SourceNodeOptions{table->schema(), batch_gen}}});
-  ASSERT_OK_AND_ASSIGN(auto result,
-                       DeclarationToExecBatches(std::move(plan), /*use_threads=*/false));
+  ASSERT_OK_AND_ASSIGN(auto result, DeclarationToExecBatches(std::move(plan)));
   AssertExecBatchesEqualIgnoringOrder(result.schema, result.batches, input.batches);
 }
 
@@ -1417,8 +1412,7 @@ TEST(ExecPlan, SourceEnforcesBatchLimit) {
       {{"source",
         SourceNodeOptions{random_data.schema,
                           random_data.gen(/*parallel=*/false, /*slow=*/false)}}});
-  ASSERT_OK_AND_ASSIGN(auto result,
-                       DeclarationToExecBatches(std::move(plan), /*use_threads=*/false));
+  ASSERT_OK_AND_ASSIGN(auto result, DeclarationToExecBatches(std::move(plan)));
   AssertExecBatchesEqualIgnoringOrder(result.schema, result.batches, random_data.batches);
   for (const auto& batch : result.batches) {
     ASSERT_LE(batch.length, ExecPlan::kMaxBatchSize);

--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -219,7 +219,7 @@ TEST(ExecPlanExecution, SourceSink) {
       SCOPED_TRACE(parallel ? "parallel" : "single threaded");
 
       auto basic_data = MakeBasicBatches();
-      
+
       Declaration plan(
           "source", SourceNodeOptions{basic_data.schema, basic_data.gen(parallel, slow)});
       ASSERT_OK_AND_ASSIGN(auto result,
@@ -312,11 +312,10 @@ void TestSourceSink(
     return MakeVectorIterator<ElementType>(elements);
   };
   Declaration plan(source_factory_name,
-                    OptionsType{exp_batches.schema, element_it_maker});
+                   OptionsType{exp_batches.schema, element_it_maker});
   ASSERT_OK_AND_ASSIGN(auto result,
-                        DeclarationToExecBatches(std::move(plan), /*use_threads=*/false));
-  AssertExecBatchesEqualIgnoringOrder(result.schema, result.batches,
-                                      exp_batches.batches);
+                       DeclarationToExecBatches(std::move(plan), /*use_threads=*/false));
+  AssertExecBatchesEqualIgnoringOrder(result.schema, result.batches, exp_batches.batches);
 }
 
 void TestRecordBatchReaderSourceSink(
@@ -1019,7 +1018,7 @@ TEST(ExecPlanExecution, NestedSourceFilter) {
 
     auto input = MakeNestedBatches();
     auto expected_table = TableFromJSON(input.schema, {R"([])",
-    R"([
+                                                       R"([
       [{"i32": 5, "bool": null}],
       [{"i32": 6, "bool": false}],
       [{"i32": 7, "bool": false}]
@@ -1332,7 +1331,8 @@ TEST(ExecPlanExecution, SelfInnerHashJoinSink) {
 
     auto plan = Declaration("hashjoin", {left, right}, std::move(join_opts));
 
-    ASSERT_OK_AND_ASSIGN(auto result, DeclarationToExecBatches(std::move(plan), parallel));
+    ASSERT_OK_AND_ASSIGN(auto result,
+                         DeclarationToExecBatches(std::move(plan), parallel));
 
     std::vector<ExecBatch> expected = {
         ExecBatchFromJSON({int32(), utf8(), int32(), utf8()}, R"([
@@ -1369,7 +1369,8 @@ TEST(ExecPlanExecution, SelfOuterHashJoinSink) {
 
     auto plan = Declaration("hashjoin", {left, right}, std::move(join_opts));
 
-    ASSERT_OK_AND_ASSIGN(auto result, DeclarationToExecBatches(std::move(plan), parallel));
+    ASSERT_OK_AND_ASSIGN(auto result,
+                         DeclarationToExecBatches(std::move(plan), parallel));
 
     std::vector<ExecBatch> expected = {
         ExecBatchFromJSON({int32(), utf8(), int32(), utf8()}, R"([

--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -1177,10 +1177,8 @@ TEST(ExecPlanExecution, SourceScalarAggSink) {
                          /*aggregates=*/{{"sum", nullptr, "i32", "sum(i32)"},
                                          {"any", nullptr, "bool", "any(bool)"}},
                      }}});
-  auto exp_batches = {
-      ExecBatchFromJSON({int64(), boolean()}, {ArgShape::SCALAR, ArgShape::SCALAR},
-                        "[[22, true]]")
-  };
+  auto exp_batches = {ExecBatchFromJSON(
+      {int64(), boolean()}, {ArgShape::SCALAR, ArgShape::SCALAR}, "[[22, true]]")};
   ASSERT_OK_AND_ASSIGN(auto result,
                        DeclarationToExecBatches(std::move(plan), /*use_threads=*/false));
   AssertExecBatchesEqualIgnoringOrder(result.schema, result.batches, exp_batches);

--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -899,7 +899,7 @@ TEST(ExecPlanExecution, SourceFilterSink) {
                                                                       /*slow=*/false)}},
        {"filter", FilterNodeOptions{equal(field_ref("i32"), literal(6))}}});
   ASSERT_OK_AND_ASSIGN(auto result,
-                       DeclarationToExecBatches(std::move(plan), /*user_threads=*/false));
+                       DeclarationToExecBatches(std::move(plan), /*use_threads=*/false));
   auto exp_batches = {ExecBatchFromJSON({int32(), boolean()}, "[]"),
                       ExecBatchFromJSON({int32(), boolean()}, "[[6, false]]")};
   AssertExecBatchesEqualIgnoringOrder(result.schema, result.batches, exp_batches);

--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -994,8 +994,8 @@ TEST(ExecPlanExecution, SourceMinMaxScalar) {
 
     auto input = MakeGroupableBatches(/*multiplicity=*/parallel ? 100 : 1);
     auto minmax_opts = std::make_shared<ScalarAggregateOptions>();
-    auto ty = struct_({field("min", int32()), field("max", int32())});
-    auto expected_table = TableFromJSON(schema({field("struct", ty)}), {R"([
+    auto min_max_type = struct_({field("min", int32()), field("max", int32())});
+    auto expected_table = TableFromJSON(schema({field("struct", min_max_type)}), {R"([
       [{"min": -8, "max": 12}]
     ])"});
 

--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -1178,7 +1178,7 @@ TEST(ExecPlanExecution, SourceScalarAggSink) {
                      }}});
   auto exp_batches = {
       ExecBatchFromJSON({int64(), boolean()}, {ArgShape::SCALAR, ArgShape::SCALAR},
-                        "[[22, true]]"),
+                        "[[22, true]]")
   };
   ASSERT_OK_AND_ASSIGN(auto result,
                        DeclarationToExecBatches(std::move(plan), /*use_threads=*/false));

--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -1008,6 +1008,7 @@ TEST(ExecPlanExecution, SourceMinMaxScalar) {
               /*keys=*/{}}}});
     ASSERT_OK_AND_ASSIGN(auto result_table,
                          DeclarationToTable(std::move(plan), parallel));
+    // No need to ignore order since there is only 1 row
     AssertTablesEqual(*result_table, *expected_table);
   }
 }


### PR DESCRIPTION
This PR includes a change to the existing test cases in `plan_test.cc` for Acero-based plan evaluation. 

At the moment, using the `StartAndCollect` method and manually passing the `FutureMatcher` and expected results are done and the validation is done on the results obtained from the `StartAndCollect` method. Most of the updated test cases in this PR uses the a common format. 

Replacing that format and using `DeclarationToExecBatches` makes the code more readable and easy to debug. 
### TODO
- [x] Convert other tests with sort options and custom sinks
- [x] Self review 1
- [x] Self review 2
- [x] Check CI Status
- [x] Mark Ready to Review

* Closes: #15284