### PR TITLE
GH-15292: [C++] Typeclass alias is missing in ExtensionArray

### DIFF
--- a/cpp/src/arrow/extension_type.h
+++ b/cpp/src/arrow/extension_type.h
@@ -103,6 +103,7 @@ class ARROW_EXPORT ExtensionType : public DataType {
 /// \brief Base array class for user-defined extension types
 class ARROW_EXPORT ExtensionArray : public Array {
  public:
+  using TypeClass = ExtensionType;
   /// \brief Construct an ExtensionArray from an ArrayData.
   ///
   /// The ArrayData must have the right ExtensionType.


### PR DESCRIPTION
# Which issue does this PR close?

<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/master/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of old issues on JIRA the title also supports:

    ARROW-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}
    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->
Closes #15292 

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

All array classes have the `using TypeClass = xxx` type alias except for ExtensionArray.

With the alias, it will be easier to write templated inline visitors such as the following code block:

```Cpp
class ExampleVisitor {
 public:
  template <typename T>
  Status Visit(const T& arr) {
    if constexpr (arrow::is_number_type<typename T::TypeClass>::value) {
      ///
    } else {
      ///
    }
    return Status::OK();
  }
};
```

Current it fails to compile with message: `No type named 'TypeClass' in 'arrow::ExtensionArray'`.
* Closes: #15292