### PR TITLE
GH-14863: [C++] Add appender functions to array builders that can take optionals

### DIFF
--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -1221,6 +1221,22 @@ TYPED_TEST(TestPrimitiveBuilder, TestAppendNull) {
   }
 }
 
+TYPED_TEST(TestPrimitiveBuilder, TestAppendOptional) {
+  int64_t size = 1000;
+  for (int64_t i = 0; i < size; ++i) {
+    ASSERT_OK(this->builder_->AppendOrNull(std::nullopt));
+    ASSERT_EQ(i + 1, this->builder_->null_count());
+  }
+
+  std::shared_ptr<Array> out;
+  FinishAndCheckPadding(this->builder_.get(), &out);
+  auto result = checked_pointer_cast<typename TypeParam::ArrayType>(out);
+
+  for (int64_t i = 0; i < size; ++i) {
+    ASSERT_TRUE(result->IsNull(i)) << i;
+  }
+}
+
 TYPED_TEST(TestPrimitiveBuilder, TestAppendNulls) {
   const int64_t size = 10;
   ASSERT_OK(this->builder_->AppendNulls(size));

--- a/cpp/src/arrow/array/builder_base.h
+++ b/cpp/src/arrow/array/builder_base.h
@@ -41,11 +41,15 @@ namespace internal {
 template <class Builder, class V>
 class ArrayBuilderExtraOps {
  public:
+  /// \brief Append a value from an optional or null if it has no value.
   Status AppendOrNull(const std::optional<V>& value) {
     auto* self = static_cast<Builder*>(this);
     return value.has_value() ? self->Append(*value) : self->AppendNull();
   }
 
+  /// \brief Append a value from an optional or null if it has no value.
+  ///
+  /// Unsafe methods don't check existing size.
   void UnsafeAppendOrNull(const std::optional<V>& value) {
     auto* self = static_cast<Builder*>(this);
     return value.has_value() ? self->UnsafeAppend(*value) : self->UnsafeAppendNull();

--- a/cpp/src/arrow/array/builder_base.h
+++ b/cpp/src/arrow/array/builder_base.h
@@ -36,6 +36,24 @@
 
 namespace arrow {
 
+namespace internal {
+
+template <class Builder, class V>
+class ArrayBuilderExtraOps {
+ public:
+  Status AppendOrNull(const std::optional<V>& value) {
+    auto* self = static_cast<Builder*>(this);
+    return value.has_value() ? self->Append(*value) : self->AppendNull();
+  }
+
+  void UnsafeAppendOrNull(const std::optional<V>& value) {
+    auto* self = static_cast<Builder*>(this);
+    return value.has_value() ? self->UnsafeAppend(*value) : self->UnsafeAppendNull();
+  }
+};
+
+}  // namespace internal
+
 /// \defgroup numeric-builders Concrete builder subclasses for numeric types
 /// @{
 /// @}

--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -49,7 +49,9 @@ namespace arrow {
 // Binary and String
 
 template <typename TYPE>
-class BaseBinaryBuilder : public ArrayBuilder {
+class BaseBinaryBuilder
+    : public ArrayBuilder,
+      public internal::ArrayBuilderExtraOps<BaseBinaryBuilder<TYPE>, std::string_view> {
  public:
   using TypeClass = TYPE;
   using offset_type = typename TypeClass::offset_type;

--- a/cpp/src/arrow/array/builder_primitive.h
+++ b/cpp/src/arrow/array/builder_primitive.h
@@ -77,7 +77,9 @@ class ARROW_EXPORT NullBuilder : public ArrayBuilder {
 
 /// Base class for all Builders that emit an Array of a scalar numerical type.
 template <typename T>
-class NumericBuilder : public ArrayBuilder {
+class NumericBuilder
+    : public ArrayBuilder,
+      public internal::ArrayBuilderExtraOps<NumericBuilder<T>, typename T::c_type> {
  public:
   using TypeClass = T;
   using value_type = typename T::c_type;
@@ -349,7 +351,9 @@ using DurationBuilder = NumericBuilder<DurationType>;
 
 /// @}
 
-class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
+class ARROW_EXPORT BooleanBuilder
+    : public ArrayBuilder,
+      public internal::ArrayBuilderExtraOps<BooleanBuilder, bool> {
  public:
   using TypeClass = BooleanType;
   using value_type = bool;

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -670,11 +670,7 @@ struct BinaryScalarMinMax {
         }
       }
 
-      if (result) {
-        RETURN_NOT_OK(builder.Append(*result));
-      } else {
-        builder.UnsafeAppendNull();
-      }
+      RETURN_NOT_OK(builder.AppendOrNull(result));
     }
 
     std::shared_ptr<Array> string_array;

--- a/cpp/src/arrow/testing/matchers.h
+++ b/cpp/src/arrow/testing/matchers.h
@@ -431,9 +431,9 @@ DataEqMatcher DataEqArray(T type, const std::vector<std::optional<ValueType>>& v
 
   for (auto value : values) {
     if (need_safe_append) {
-      builder.UnsafeAppendOrNull(value);
-    } else {
       DCHECK_OK(builder.AppendOrNull(value));
+    } else {
+      builder.UnsafeAppendOrNull(value);
     }
   }
 

--- a/cpp/src/arrow/testing/matchers.h
+++ b/cpp/src/arrow/testing/matchers.h
@@ -430,14 +430,10 @@ DataEqMatcher DataEqArray(T type, const std::vector<std::optional<ValueType>>& v
   static const bool need_safe_append = !is_fixed_width(T::type_id);
 
   for (auto value : values) {
-    if (value) {
-      if (need_safe_append) {
-        builder.UnsafeAppend(*value);
-      } else {
-        DCHECK_OK(builder.Append(*value));
-      }
+    if (need_safe_append) {
+      builder.UnsafeAppendOrNull(value);
     } else {
-      builder.UnsafeAppendNull();
+      DCHECK_OK(builder.AppendOrNull(value));
     }
   }
 


### PR DESCRIPTION
This adds more member functions (different names) to some concrete implementations of `ArrayBuilder`.

* Closes: #14863