### PR TITLE
GH-15080: [CI][R] Re-enable binary package job for R 4.1 on Windows

### DIFF
--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -141,10 +141,6 @@ jobs:
         r_version:
           - { rtools: "{{ macros.r_release.rt }}", r: "{{ macros.r_release.ver }}" }
           - { rtools: "{{ macros.r_oldrel.rt }}", r: "{{ macros.r_oldrel.ver }}" }
-        exclude:
-          # GH-15080: purrr 1.0.0 doesn't work with R oldrel on Windows
-          - platform: { runs_on: 'windows-latest', name: "Windows"}
-            r_version: { rtools: "{{ macros.r_oldrel.rt }}", r: "{{ macros.r_oldrel.ver }}" }
     steps:
       - uses: r-lib/actions/setup-r@v2
         # expression marker prevents the ! being parsed as yaml tag

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -942,8 +942,7 @@ tasks:
       - r-lib__libarrow__bin__centos-7__arrow-{no_rc_r_version}\.zip
       - r-lib__libarrow__bin__ubuntu-18.04__arrow-{no_rc_r_version}\.zip
       - r-lib__libarrow__bin__ubuntu-22.04__arrow-{no_rc_r_version}\.zip
-      # GH-15080: purrr 1.0.0 doesn't work with R oldrel on Windows
-      # - r-pkg__bin__windows__contrib__4.1__arrow_{no_rc_r_version}\.zip
+      - r-pkg__bin__windows__contrib__4.1__arrow_{no_rc_r_version}\.zip
       - r-pkg__bin__windows__contrib__4.2__arrow_{no_rc_r_version}\.zip
       - r-pkg__bin__macosx__contrib__4.1__arrow_{no_rc_r_version}\.tgz
       - r-pkg__bin__macosx__contrib__4.2__arrow_{no_rc_r_version}\.tgz


### PR DESCRIPTION
# Which issue does this PR close?

purrr 1.0.1 is released on cran

Closes #15080 
* Closes: #15080