### PR TITLE
GH-15282: [CI][C++] add CLANG_TOOLS variable in .travis.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,8 +66,8 @@ jobs:
           "
         # The LLVM's APT repository doesn't provide arm64 binaries.
         # We should use LLVM provided by Ubuntu.
-        LLVM: "10"
         CLANG_TOOLS: "10"
+        LLVM: "10"
         UBUNTU: "20.04"
 
     - name: "Go on ARM"
@@ -110,8 +110,8 @@ jobs:
           "
         # The LLVM's APT repository causes download error for s390x binary
         # We should use the LLVM provided by the default APT repository
-        LLVM: "10"
         CLANG_TOOLS: "10"
+        LLVM: "10"
         UBUNTU: "20.04"
 
     - name: "Go on s390x"

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,7 @@ jobs:
         # The LLVM's APT repository doesn't provide arm64 binaries.
         # We should use LLVM provided by Ubuntu.
         LLVM: "10"
+        CLANG_TOOLS: "10"
         UBUNTU: "20.04"
 
     - name: "Go on ARM"
@@ -110,6 +111,7 @@ jobs:
         # The LLVM's APT repository causes download error for s390x binary
         # We should use the LLVM provided by the default APT repository
         LLVM: "10"
+        CLANG_TOOLS: "10"
         UBUNTU: "20.04"
 
     - name: "Go on s390x"

--- a/.travis.yml
+++ b/.travis.yml
@@ -160,6 +160,11 @@ jobs:
           -e Protobuf_SOURCE=BUNDLED
           -e gRPC_SOURCE=BUNDLED
           "
+        # The LLVM's APT repository causes download error for s390x binary
+        # We should use the LLVM provided by the default APT repository
+        CLANG_TOOLS: "10"
+        LLVM: "10"
+        UBUNTU: "20.04"
 
   allow_failures:
     - name: "Java on s390x"


### PR DESCRIPTION
# Which issue does this PR close?

<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/master/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of old issues on JIRA the title also supports:

    ARROW-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}
    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

Closes #15282 

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
This change fixes a version error for downloading clang in apt. Recent scripts require two variables `LLVM` and `CLANG_TOOLS` are defined in [`.env`](https://github.com/apache/arrow/blob/master/.env#L56-L57).

* Closes: #15282