### PR TITLE
GH-26209: [Ruby] Add support for Ruby 2.5

### DIFF
--- a/ruby/red-arrow-dataset/lib/arrow-dataset/arrow-table-loadable.rb
+++ b/ruby/red-arrow-dataset/lib/arrow-dataset/arrow-table-loadable.rb
@@ -42,7 +42,7 @@ module ArrowDataset
         factory.file_system_uri = uri
         finish_options = FinishOptions.new
         FinishOptions.instance_methods(false).each do |method|
-          next unless method.end_with?("=")
+          next unless method.to_s.end_with?("=")
           value = options.delete(method[0..-2].to_sym)
           next if value.nil?
           finish_options.public_send(method, value)

--- a/ruby/red-arrow/lib/arrow/table.rb
+++ b/ruby/red-arrow/lib/arrow/table.rb
@@ -507,7 +507,7 @@ module Arrow
     #
     # @since 7.0.0
     def join(right, keys=nil, type: :inner, left_outputs: nil, right_outputs: nil)
-      keys ||= column_names.intersection(right.column_names)
+      keys ||= (column_names & right.column_names)
       plan = ExecutePlan.new
       left_node = plan.build_source_node(self)
       right_node = plan.build_source_node(right)

--- a/ruby/red-arrow/test/test-table.rb
+++ b/ruby/red-arrow/test/test-table.rb
@@ -1129,7 +1129,7 @@ visible: false
                                     ]),
                    table1.join(table2,
                                {left: "left_key", right: :right_key},
-                               **{}))
+                               type: :inner))
     end
 
     test("keys: {left: [String, Symbol], right: [Symbol, String]}") do
@@ -1152,7 +1152,7 @@ visible: false
                                  left: ["left_key1", :left_key2],
                                  right: [:right_key1, "right_key2"],
                                },
-                               **{}))
+                               type: :inner))
     end
 
     test("type:") do


### PR DESCRIPTION
# Which issue does this PR close?

Closes #26209

# Rationale for this change

Ruby 2.5 was EOL but Ubuntu 18.04 still uses Ruby 2.5. Note that Ubuntu 18.04 will reach EOL on 2023-04.

# What changes are included in this PR?

Ruby 2.5 compatible implementation and tests.

# Are these changes tested?

Yes

# Are there any user-facing changes?

No.

* Closes: #26209