### PR TITLE
GH-26394: [Python] Don't use target_include_directories() for imported target

### DIFF
--- a/cpp/cmake_modules/FindNumPy.cmake
+++ b/cpp/cmake_modules/FindNumPy.cmake
@@ -96,5 +96,11 @@ find_package_message(NUMPY
 set(NUMPY_FOUND TRUE)
 
 add_library(Python3::NumPy INTERFACE IMPORTED)
-target_include_directories(Python3::NumPy INTERFACE ${NUMPY_INCLUDE_DIRS})
+if(CMAKE_VERSION VERSION_LESS 3.11)
+    target_include_directories(Python3::NumPy PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+        ${NUMPY_INCLUDE_DIRS})
+    set_target_properties(Python3::Module PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+else()
+    target_include_directories(Python3::NumPy INTERFACE ${NUMPY_INCLUDE_DIRS})
+endif()
 target_link_libraries(Python3::NumPy INTERFACE Python3::Module)

--- a/cpp/cmake_modules/FindNumPy.cmake
+++ b/cpp/cmake_modules/FindNumPy.cmake
@@ -97,9 +97,10 @@ set(NUMPY_FOUND TRUE)
 
 add_library(Python3::NumPy INTERFACE IMPORTED)
 if(CMAKE_VERSION VERSION_LESS 3.11)
-    set_target_properties(Python3::NumPy PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
-        ${NUMPY_INCLUDE_DIRS})
+    set_target_properties(Python3::NumPy PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${NUMPY_INCLUDE_DIRS}"
+        INTERFACE_LINK_LIBRARIES Python3::Module)
 else()
     target_include_directories(Python3::NumPy INTERFACE ${NUMPY_INCLUDE_DIRS})
+    target_link_libraries(Python3::NumPy INTERFACE Python3::Module)
 endif()
-target_link_libraries(Python3::NumPy INTERFACE Python3::Module)

--- a/cpp/cmake_modules/FindNumPy.cmake
+++ b/cpp/cmake_modules/FindNumPy.cmake
@@ -97,9 +97,8 @@ set(NUMPY_FOUND TRUE)
 
 add_library(Python3::NumPy INTERFACE IMPORTED)
 if(CMAKE_VERSION VERSION_LESS 3.11)
-    target_include_directories(Python3::NumPy PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+    set_target_properties(Python3::NumPy PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
         ${NUMPY_INCLUDE_DIRS})
-    set_target_properties(Python3::Module PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
 else()
     target_include_directories(Python3::NumPy INTERFACE ${NUMPY_INCLUDE_DIRS})
 endif()

--- a/cpp/cmake_modules/FindPythonLibsNew.cmake
+++ b/cpp/cmake_modules/FindPythonLibsNew.cmake
@@ -218,7 +218,12 @@ find_package_message(PYTHON
     "${PYTHON_EXECUTABLE}${PYTHON_VERSION}")
 
 add_library(Python3::Module SHARED IMPORTED)
-target_include_directories(Python3::Module INTERFACE ${PYTHON_INCLUDE_DIRS})
+if(CMAKE_VERSION VERSION_LESS 3.11)
+  set_target_properties(Python3::Module PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+      ${PYTHON_INCLUDE_DIRS})
+else()
+  target_include_directories(Python3::Module INTERFACE ${PYTHON_INCLUDE_DIRS})
+endif()
 set_target_properties(Python3::Module PROPERTIES
     IMPORTED_LOCATION "${PYTHON_LIBRARIES}"
     IMPORTED_IMPLIB "${PYTHON_LIBRARIES}")


### PR DESCRIPTION
# Which issue does this PR close?

Closes #26394

# Rationale for this change

We require at least CMake 3.5 for now.

# What changes are included in this PR?

Add workaround for CMake < 3.11.

# Are these changes tested?

Yes.

# Are there any user-facing changes?

No.
* Closes: #26394