### PR TITLE
GH-33610: [Dev] Do not allow ARROW prefixed tickets to be merged nor used on PR titles

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,9 +20,8 @@ or
 
     MINOR: [${COMPONENT}] ${SUMMARY}
 
-In the case of old issues on JIRA the title also supports:
+In the case of PARQUET issues on JIRA the title also supports:
 
-    ARROW-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}
     PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}
 
 -->

--- a/.github/workflows/dev_pr/helpers.js
+++ b/.github/workflows/dev_pr/helpers.js
@@ -26,7 +26,7 @@ const https = require('https');
  * @typedef {Object} Issue
  * @property {string} kind - The kind of issue: minor, jira or github
  * @property {string} id   - The id of the issue:
- *                            ARROW-XXXX, PARQUET-XXXX for jira
+ *                            PARQUET-XXXX for jira
  *                            The numeric issue id for github
  */
 function detectIssue(title) {
@@ -36,7 +36,7 @@ function detectIssue(title) {
     if (title.startsWith("MINOR: ")) {
         return {"kind": "minor"};
     }
-    const matched_jira = /^(WIP:?\s*)?((ARROW|PARQUET)-\d+)/.exec(title);
+    const matched_jira = /^(WIP:?\s*)?((PARQUET)-\d+)/.exec(title);
     if (matched_jira) {
         return {"kind": "jira", "id": matched_jira[2]};
     }

--- a/.github/workflows/dev_pr/title_check.md
+++ b/.github/workflows/dev_pr/title_check.md
@@ -31,9 +31,8 @@ or
 
     MINOR: [${COMPONENT}] ${SUMMARY}
 
-In the case of old issues on JIRA the title also supports:
+In the case of PARQUET issues on JIRA the title also supports:
 
-    ARROW-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}
     PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}
 
 See also:


### PR DESCRIPTION
Now that all issues from JIRA are migrated to GitHub we should always use the GH corresponding issue on the PR title
* Closes: #33610