### PR TITLE
GH-15189: [R] Skip S3 tests on MacOS 10.13

### DIFF
--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -205,6 +205,11 @@ on_linux_dev <- function() {
     grepl("devel", R.version.string)
 }
 
+on_macos_10_13_or_lower <- function() {
+  identical(unname(Sys.info()["sysname"]), "Darwin") &&
+    package_version(unname(Sys.info()["release"])) < "18.0.0"
+}
+
 option_use_threads <- function() {
   !is_false(getOption("arrow.use_threads"))
 }

--- a/r/tests/testthat/helper-skip.R
+++ b/r/tests/testthat/helper-skip.R
@@ -43,7 +43,7 @@ skip_if_not_available <- function(feature) {
   if (feature == "s3") {
     sys_info <- Sys.info()
     is_macos_1013 <- identical(unname(Sys.info()["sysname"]), "Darwin") &&
-      identical(unname(Sys.info()["release"]), "17.7.0")
+      package_version(unname(Sys.info()["release"])) < "18.0.0"
     if (is_macos_1013) {
       skip("curl/ssl runtime on MacOS 10.13 is too old")
     }

--- a/r/tests/testthat/helper-skip.R
+++ b/r/tests/testthat/helper-skip.R
@@ -41,10 +41,7 @@ skip_if_not_available <- function(feature) {
   # curl/ssl on MacOS is too old to support S3 filesystems without
   # crashing when the process exits.
   if (feature == "s3") {
-    sys_info <- Sys.info()
-    is_macos_1013 <- identical(unname(Sys.info()["sysname"]), "Darwin") &&
-      package_version(unname(Sys.info()["release"])) < "18.0.0"
-    if (is_macos_1013) {
+    if (on_macos_10_13_or_lower()) {
       skip("curl/ssl runtime on MacOS 10.13 is too old")
     }
   }

--- a/r/tests/testthat/helper-skip.R
+++ b/r/tests/testthat/helper-skip.R
@@ -38,6 +38,17 @@ skip_if_not_available <- function(feature) {
     skip_on_linux_devel()
   }
 
+  # curl/ssl on MacOS is too old to support S3 filesystems without
+  # crashing when the process exits.
+  if (feature == "s3") {
+    sys_info <- Sys.info()
+    is_macos_1013 <- identical(unname(Sys.info()["sysname"]), "Darwin") &&
+      identical(unname(Sys.info()["release"]), "17.7.0")
+    if (is_macos_1013) {
+      skip("curl/ssl runtime on MacOS 10.13 is too old")
+    }
+  }
+
   yes <- feature %in% names(build_features) && build_features[feature]
   if (!yes) {
     skip(paste("Arrow C++ not built with", feature))

--- a/r/tests/testthat/test-python.R
+++ b/r/tests/testthat/test-python.R
@@ -25,7 +25,7 @@ test_that("install_pyarrow", {
   # PyArrow doesn't support Python 3.6 or earlier
   skip_on_python_older_than("3.7")
   # no pyarrow wheels for macos 10.13
-  skip_if(Sys.info()["sysname"] == "Darwin" && Sys.info()["release"] < 18)
+  skip_if(on_macos_10_13_or_lower())
 
   venv <- try(reticulate::virtualenv_create("arrow-test"))
   # Bail out if virtualenv isn't available

--- a/r/tests/testthat/test-s3-minio.R
+++ b/r/tests/testthat/test-s3-minio.R
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-skip_if_not(arrow_with_s3(), message = "arrow not build with S3 support.")
+skip_if_not_available("s3")
 skip_if_not(nzchar(Sys.which("minio")), message = "minio is not installed.")
 
 library(dplyr)

--- a/r/tests/testthat/test-s3.R
+++ b/r/tests/testthat/test-s3.R
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+skip_if_not_available("s3")
 
 run_these <- tryCatch(
   expr = {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #15189

# Rationale for this change

The curl/ssl runtime on 10.13 results in a segfault when the process exits (even though all tests pass), so we get a spurious failure on our 10.13 runner test.

# What changes are included in this PR?

Updates the `skip_if_not_available()` function to special case the "s3" feature. The "re2" feature is handled similarly to prevent spurious valgrind errors from being reported.

# Are these changes tested?

These changes can only be tested via crossbow + the 10.13 runner (and locally on my own 10.13 machine after the PR is live and can be pulled there).

# Are there any user-facing changes?

Nope!
* Closes: #15189