### PR TITLE
GH-33621: [Documentation][Developer Tools] Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,8 +28,15 @@
 ## Components
 /c_glib/ @kou
 /cpp/
+/cpp/src/arrow/compute @westonpace
+/cpp/src/arrow/dataset @westonpace
+/cpp/src/arrow/engine @westonpace
 /cpp/src/arrow/flight/ @lidavidm
-/csharp/
+/cpp/src/arrow/util/async* @westonpace
+/cpp/src/arrow/util/future* @westonpace
+/cpp/src/arrow/util/thread* @westonpace
+/cpp/src/skyhook @westonpace 
+/csharp/ @westonpace 
 /go/
 /java/
 /js/

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,7 +40,7 @@
 /go/ @zeroshade
 /java/
 /js/
-/matlab/
+/matlab/ @assignUser 
 /python/
 /python/pyarrow/_flight.pyx @lidavidm
 /r/

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,12 +28,14 @@
 ## Components
 /c_glib/ @kou
 /cpp/
+/cpp/src/arrow/flight/ @lidavidm
 /csharp/
 /go/
 /java/
 /js/
 /matlab/
 /python/
+/python/pyarrow/_flight.pyx @lidavidm
 /r/
 /ruby/ @kou
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,7 +39,7 @@
 /cpp/src/skyhook @westonpace 
 /csharp/ @westonpace 
 /go/ @zeroshade
-/java/
+/java/ @lidavidm 
 /js/ @domoritz @trxcllnt 
 /matlab/ @assignUser 
 /python/

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,7 +37,7 @@
 /cpp/src/arrow/util/thread* @westonpace
 /cpp/src/skyhook @westonpace 
 /csharp/ @westonpace 
-/go/
+/go/ @zeroshade
 /java/
 /js/
 /matlab/

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,11 +23,11 @@
 # documentation about the syntax: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Arrow Format
-/format/
+# /format/
 
 ## Components
 /c_glib/ @kou
-/cpp/
+# /cpp/
 /cpp/src/arrow/compute @westonpace
 /cpp/src/arrow/dataset @westonpace
 /cpp/src/arrow/engine @westonpace
@@ -49,12 +49,12 @@
 /ruby/ @kou
 
 # Docs
-/docs/
-.readthedocs.yml
-*.md
-*.rmd
-*.rst
-*.txt
+# /docs/
+# .readthedocs.yml
+# *.md
+# *.rmd
+# *.rst
+# *.txt
 
 # PR CI and repository files
 /.github/ @assignUser @kou @raulcd
@@ -62,7 +62,7 @@
 .pre-commit-config.yaml @raulcd 
 .travis.yml @assignUser @kou @raulcd
 appveyor.yml @assignUser @kou @raulcd
-.git*
+# .git*
 
 # release scripts, archery etc.
 /ci/ @assignUser @kou @raulcd

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -55,17 +55,19 @@
 *.txt
 
 # PR CI and repository files
-/.github/ @assignUser  @kou
-.asf.yaml @assignUser @kou
-.travis.yml @assignUser @kou
-appveyor.yml @assignUser @kou
+/.github/ @assignUser @kou @raulcd
+.asf.yaml @assignUser @kou @raulcd
+.pre-commit-config.yaml @raulcd 
+.travis.yml @assignUser @kou @raulcd
+appveyor.yml @assignUser @kou @raulcd
 .git*
 
 # release scripts, archery etc.
-/ci/ @assignUser @kou
-/dev/ @assignUser @kou
-.env @assignUser @kou
-docker-compose.yml @assignUser @kou
+/ci/ @assignUser @kou @raulcd
+/dev/ @assignUser @kou @raulcd
+.dockerignore @raulcd 
+.env @assignUser @kou @raulcd
+docker-compose.yml @assignUser @kou @raulcd
 
 # R specific packaging tooling
 /r/configure* @assignUser

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,7 +40,7 @@
 /csharp/ @westonpace 
 /go/ @zeroshade
 /java/
-/js/
+/js/ @domoritz @trxcllnt 
 /matlab/ @assignUser 
 /python/
 /python/pyarrow/_flight.pyx @lidavidm

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,7 +26,7 @@
 /format/
 
 ## Components
-/c_glib/
+/c_glib/ @kou
 /cpp/
 /csharp/
 /go/
@@ -35,7 +35,7 @@
 /matlab/
 /python/
 /r/
-/ruby/
+/ruby/ @kou
 
 # Docs
 /docs/
@@ -46,17 +46,17 @@
 *.txt
 
 # PR CI and repository files
-/.github/ @assignUser 
-.asf.yaml @assignUser
-.travis.yml @assignUser
-appveyor.yml @assignUser
+/.github/ @assignUser  @kou
+.asf.yaml @assignUser @kou
+.travis.yml @assignUser @kou
+appveyor.yml @assignUser @kou
 .git*
 
 # release scripts, archery etc.
-/ci/ @assignUser
-/dev/ @assignUser 
-.env @assignUser
-docker-compose.yml @assignUser
+/ci/ @assignUser @kou
+/dev/ @assignUser @kou
+.env @assignUser @kou
+docker-compose.yml @assignUser @kou
 
 # R specific packaging tooling
 /r/configure* @assignUser

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,7 +42,7 @@
 /java/ @lidavidm 
 /js/ @domoritz @trxcllnt 
 /matlab/ @assignUser 
-/python/
+/python/ @AlenkaF  
 /python/pyarrow/_flight.pyx @lidavidm
 /python/pyarrow/**/*gandiva* @wjones127 
 /r/ @paleolimbot @thisisnic 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,66 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Any committer can add themselves to any  of the path patterns
+# and will subsequently get requested as a reviewer for any PRs 
+# that change matching files.
+#
+# This file uses .gitignore syntax with a few exceptions see the
+# documentation about the syntax: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Arrow Format
+/format/
+
+## Components
+/c_glib/
+/cpp/
+/csharp/
+/go/
+/java/
+/js/
+/matlab/
+/python/
+/r/
+/ruby/
+
+# Docs
+/docs/
+.readthedocs.yml
+*.md
+*.rmd
+*.rst
+*.txt
+
+# PR CI and repository files
+/.github/ @assignUser 
+.asf.yaml @assignUser
+.travis.yml @assignUser
+appveyor.yml @assignUser
+.git*
+
+# release scripts, archery etc.
+/ci/ @assignUser
+/dev/ @assignUser 
+.env @assignUser
+docker-compose.yml @assignUser
+
+# R specific packaging tooling
+/r/configure* @assignUser
+/r/Makefile @assignUser
+/r/PACKAGING.md @assignUser
+/r/tools/ @assignUser
+.Rbuildignore @assignUser

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,7 +45,7 @@
 /python/
 /python/pyarrow/_flight.pyx @lidavidm
 /python/pyarrow/**/*gandiva* @wjones127 
-/r/ @paleolimbot
+/r/ @paleolimbot @thisisnic 
 /ruby/ @kou
 
 # Docs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,6 +35,7 @@
 /cpp/src/arrow/util/async* @westonpace
 /cpp/src/arrow/util/future* @westonpace
 /cpp/src/arrow/util/thread* @westonpace
+/cpp/src/parquet @wjones127
 /cpp/src/skyhook @westonpace 
 /csharp/ @westonpace 
 /go/ @zeroshade
@@ -43,6 +44,7 @@
 /matlab/ @assignUser 
 /python/
 /python/pyarrow/_flight.pyx @lidavidm
+/python/pyarrow/**/*gandiva* @wjones127 
 /r/
 /ruby/ @kou
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,7 +45,7 @@
 /python/
 /python/pyarrow/_flight.pyx @lidavidm
 /python/pyarrow/**/*gandiva* @wjones127 
-/r/
+/r/ @paleolimbot
 /ruby/ @kou
 
 # Docs


### PR DESCRIPTION

# Rationale for this change
CODEOWNERS will lift the burden of finding an initial reviewer for a PR from the contributor and enable committers to basically "subscribe" to a selection of PRs based on their interests/competence within the monorepo without having to watch _all_ notifications for the repo.

# What changes are included in this PR?

I have added a rough structure for the file and added myself to a selection of the patterns. Any committer please feel free to add yourself via suggestion or direct push to this branch.

* Closes: #33621