### PR TITLE
GH-20385: [C++][Parquet] Reject partial load of an extension type

### DIFF
--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -844,8 +844,7 @@ Status GetReader(const SchemaField& field, const std::shared_ptr<Field>& arrow_f
     RETURN_NOT_OK(GetReader(field, storage_field, ctx, out));
     if (*out) {
       auto storage_type = (*out)->field()->type();
-      if (!storage_type->Equals(
-              checked_cast<const ExtensionType&>(*arrow_field->type()).storage_type())) {
+      if (!storage_type->Equals(storage_field->type())) {
         return Status::Invalid(
             "Due to column pruning only part of an extension's storage type was loaded.  "
             "An extension type cannot be created without all of its fields");

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -842,7 +842,16 @@ Status GetReader(const SchemaField& field, const std::shared_ptr<Field>& arrow_f
     auto storage_field = arrow_field->WithType(
         checked_cast<const ExtensionType&>(*arrow_field->type()).storage_type());
     RETURN_NOT_OK(GetReader(field, storage_field, ctx, out));
-    *out = std::make_unique<ExtensionReader>(arrow_field, std::move(*out));
+    if (*out) {
+      auto storage_type = (*out)->field()->type();
+      if (!storage_type->Equals(
+              checked_cast<const ExtensionType&>(*arrow_field->type()).storage_type())) {
+        return Status::Invalid(
+            "Due to column pruning only part of an extension's storage type was loaded.  "
+            "An extension type cannot be created without all of its fields");
+      }
+      *out = std::make_unique<ExtensionReader>(arrow_field, std::move(*out));
+    }
     return Status::OK();
   }
 

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -948,6 +948,9 @@ def test_parquet_extension_with_nested_storage(tmpdir):
     assert table.column('lists').type == mylist_array.type
     assert table == orig_table
 
+    with pytest.raises(pa.ArrowInvalid, match='without all of its fields'):
+        pq.ParquetFile(filename).read(columns=['structs.left'])
+
 
 @pytest.mark.parquet
 def test_parquet_nested_extension(tmpdir):


### PR DESCRIPTION
When the parquet reader is performing a partial read it will try and maintain field structure.  So, for example, given a schema of `points: struct<x: int32, y:int32>` and a load of `points.x` it will return `points: struct<x: int32>`.  However, if there is an extension type `points: Point` where `Point` has a storage type `struct<x: int32, y: int32>` then suddenly the reference `points.x` no longer makes sense.
* Closes: #20385