### PR TITLE
GH-15289: [Ruby] Return self when saving Table to csv

### DIFF
--- a/ruby/red-arrow/lib/arrow/table-saver.rb
+++ b/ruby/red-arrow/lib/arrow/table-saver.rb
@@ -51,6 +51,7 @@ module Arrow
         raise ArgumentError, message
       end
       __send__(custom_save_method)
+      @table
     end
 
     private

--- a/ruby/red-arrow/test/test-table.rb
+++ b/ruby/red-arrow/test/test-table.rb
@@ -720,6 +720,11 @@ class TableTest < Test::Unit::TestCase
                                            schema: @table.schema))
           end
 
+          test("csv, return value") do
+            output = create_output(".csv")
+            assert_equal(@table, @table.save(output))
+          end
+
           test("csv.gz") do
             output = create_output(".csv.gz")
             @table.save(output)


### PR DESCRIPTION
# Rationale for this change

Change return value of Table#save when saving Table to csv files.

# What changes are included in this PR?

Change return value to self (`@table`).

# Are these changes tested?

Add test for saving to csv.

# Are there any user-facing changes?

Return value of Table#save is undetermined.

* Closes: #15289