### PR TITLE
GH-15287: [Ruby] Merge column and add suffix in Table#join

### DIFF
--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -5195,7 +5195,7 @@ G_END_DECLS
 arrow::Result<arrow::FieldRef>
 garrow_field_reference_resolve_raw(const gchar *reference)
 {
-  if (reference && reference[0] == '.') {
+  if (reference && (reference[0] == '.' || reference[0] == '[')) {
     return arrow::FieldRef::FromDotPath(reference);
   } else {
     arrow::FieldRef arrow_reference(reference);

--- a/ruby/red-arrow/lib/arrow/table.rb
+++ b/ruby/red-arrow/lib/arrow/table.rb
@@ -472,18 +472,22 @@ module Arrow
     #
     #     If both of `left_outputs` and `right_outputs` aren't
     #     specified, all columns in `self` and `right` are
-    #     outputted.
+    #     output.
     #   @param right_outputs [::Array<String, Symbol>] Output columns in
     #     `right`.
     #
     #     If both of `left_outputs` and `right_outputs` aren't
     #     specified, all columns in `self` and `right` are
-    #     outputted.
+    #     output.
     #   @return [Arrow::Table]
     #     The joined `Arrow::Table`.
     #
     # @overload join(right, type: :inner, left_outputs: nil, right_outputs: nil)
-    #   If key(s) are not supplied, common keys in self and right are used.
+    #   If key(s) are not supplied, common keys in self and right are used
+    #     (natural join).
+    #
+    #     Column used as keys are merged and remain in left side
+    #     when both of `left_outputs` and `right_outputs` are `nil`.
     #
     #   @macro join_common_before
     #   @macro join_common_after
@@ -493,12 +497,18 @@ module Arrow
     # @overload join(right, key, type: :inner, left_outputs: nil, right_outputs: nil)
     #   Join right by a key.
     #
+    #     Column used as keys are merged and remain in left side
+    #     when both of `left_outputs` and `right_outputs` are `nil`.
+    #
     #   @macro join_common_before
     #   @param key [String, Symbol] A join key.
     #   @macro join_common_after
     #
-    # @overload join(right, keys, type: :inner, left_outputs: nil, right_outputs: nil)
+    # @overload join(right, keys, type: :inner, left_suffix: "", right_suffix: "",
+    #                left_outputs: nil, right_outputs: nil)
     #   Join right by keys.
+    #
+    #     Column name can be renamed by appending `left_suffix` or `right_suffix`.
     #
     #   @macro join_common_before
     #   @param keys [::Array<String, Symbol>] Join keys.

--- a/ruby/red-arrow/lib/arrow/table.rb
+++ b/ruby/red-arrow/lib/arrow/table.rb
@@ -484,10 +484,10 @@ module Arrow
     #
     # @overload join(right, type: :inner, left_outputs: nil, right_outputs: nil)
     #   If key(s) are not supplied, common keys in self and right are used
-    #     (natural join).
+    #   (natural join).
     #
-    #     Column used as keys are merged and remain in left side
-    #     when both of `left_outputs` and `right_outputs` are `nil`.
+    #   Column used as keys are merged and remain in left side
+    #   when both of `left_outputs` and `right_outputs` are `nil`.
     #
     #   @macro join_common_before
     #   @macro join_common_after
@@ -497,8 +497,8 @@ module Arrow
     # @overload join(right, key, type: :inner, left_outputs: nil, right_outputs: nil)
     #   Join right by a key.
     #
-    #     Column used as keys are merged and remain in left side
-    #     when both of `left_outputs` and `right_outputs` are `nil`.
+    #   Column used as keys are merged and remain in left side
+    #   when both of `left_outputs` and `right_outputs` are `nil`.
     #
     #   @macro join_common_before
     #   @param key [String, Symbol] A join key.
@@ -508,7 +508,7 @@ module Arrow
     #                left_outputs: nil, right_outputs: nil)
     #   Join right by keys.
     #
-    #     Column name can be renamed by appending `left_suffix` or `right_suffix`.
+    #   Column name can be renamed by appending `left_suffix` or `right_suffix`.
     #
     #   @macro join_common_before
     #   @param keys [::Array<String, Symbol>] Join keys.

--- a/ruby/red-arrow/lib/arrow/table.rb
+++ b/ruby/red-arrow/lib/arrow/table.rb
@@ -564,7 +564,7 @@ module Arrow
       table =
         if left_outputs || right_outputs
           table
-        elsif type.end_with?("semi") || type.end_with?("anti")
+        elsif type.to_s.end_with?("semi") || type.to_s.end_with?("anti")
           table
         # For the cases of "#{type}" == "inner" || type.end_with?("outer")
         elsif natural_join

--- a/ruby/red-arrow/lib/arrow/table.rb
+++ b/ruby/red-arrow/lib/arrow/table.rb
@@ -551,20 +551,22 @@ module Arrow
       hash_join_node_options = HashJoinNodeOptions.new(type,
                                                        left_keys,
                                                        right_keys)
+      use_manual_outputs = false
       unless left_outputs.nil?
         hash_join_node_options.left_outputs = left_outputs
+        use_manual_outputs = true
       end
       unless right_outputs.nil?
         hash_join_node_options.right_outputs = right_outputs
+        use_manual_outputs = true
       end
       hash_join_node = plan.build_hash_join_node(left_node,
                                                  right_node,
                                                  hash_join_node_options)
       type_nick = type.nick
-      if (left_outputs or
-          right_outputs or
-          type_nick.end_with?("-semi") or
-          type_nick.end_with?("-anti"))
+      is_filter_join = (type_nick.end_with?("-semi") or
+                        type_nick.end_with?("-anti"))
+      if use_manual_outputs or is_filter_join
         process_node = hash_join_node
       elsif is_natural_join
         process_node = join_merge_keys(plan, hash_join_node, right, keys)

--- a/ruby/red-arrow/lib/arrow/table.rb
+++ b/ruby/red-arrow/lib/arrow/table.rb
@@ -550,21 +550,23 @@ module Arrow
       plan.wait
       reader = sink_node_options.get_reader(hash_join_node.output_schema)
       table = reader.read_all
-      share_input(table)
 
       # merge column if required
-      if left_outputs || right_outputs
-        table
-      elsif type.end_with?("semi") || type.end_with?("anti")
-        table
-      # "#{type}" == "inner" || type.end_with?("outer") from here.
-      elsif org_keys.nil? # natural join
-        merge_columns_in_table(table, keys)
-      elsif keys.is_a?(String) || keys.is_a?(Symbol)
-        merge_columns_in_table(table, [keys.to_s])
-      else
-        table
-      end
+      table =
+        if left_outputs || right_outputs
+          table
+        elsif type.end_with?("semi") || type.end_with?("anti")
+          table
+        # "#{type}" == "inner" || type.end_with?("outer") from here.
+        elsif org_keys.nil? # natural join
+          merge_columns_in_table(table, keys)
+        elsif keys.is_a?(String) || keys.is_a?(Symbol)
+          merge_columns_in_table(table, [keys.to_s])
+        else
+          table
+        end
+      share_input(table)
+      table      
     end
 
     alias_method :to_s_raw, :to_s

--- a/ruby/red-arrow/test/test-table.rb
+++ b/ruby/red-arrow/test/test-table.rb
@@ -1411,5 +1411,26 @@ visible: false
                                left_outputs: table1.column_names,
                                right_outputs: table2.column_names))
     end
+
+    test(":left_suffix and :right_suffix, keys in Array") do
+      table1 = Arrow::Table.new(key1: [1, 1, 2, 2],
+                                key2: [10, 100, 20, 200],
+                                number: [1010, 1100, 2020, 2200])
+      table2 = Arrow::Table.new(key1: [1, 2, 2],
+                                key2: [100, 20, 50],
+                                string: ["1-100", "2-20", "2-50"])
+      assert_equal(Arrow::Table.new([
+                                      ["key1_left", [1, 2]],
+                                      ["key2_left", [100, 20]],
+                                      ["number", [1100, 2020]],
+                                      ["key1_right", [1, 2]],
+                                      ["key2_right", [100, 20]],
+                                      ["string", ["1-100", "2-20"]],
+                                    ]),
+                    table1.join(table2,
+                                ["key1", "key2"],
+                                left_suffix: "_left",
+                                right_suffix: "_right"))
+    end
   end
 end

--- a/ruby/red-arrow/test/test-table.rb
+++ b/ruby/red-arrow/test/test-table.rb
@@ -1324,10 +1324,8 @@ visible: false
       assert_equal(Arrow::Table.new([
                                       ["key", []],
                                       ["string", []],
-                                    ]).to_s,
-                   table1.join(table2, "key", type: :right_anti).to_s)
-      # There is a bug: right_anti result has incorrect chunked array.
-      # Temporarily compare #to_s result.
+                                    ]),
+                   table1.join(table2, "key", type: :right_anti))
     end
 
     test("left_outputs: & right_outputs:") do

--- a/ruby/red-arrow/test/test-table.rb
+++ b/ruby/red-arrow/test/test-table.rb
@@ -1131,7 +1131,7 @@ visible: false
   end
 
   sub_test_case("#join") do
-    test("w/o keys (natural join)") do
+    test("keys: nil (natural join)") do
       table1 = Arrow::Table.new(key: [1, 2, 3],
                                 number: [10, 20, 30])
       table2 = Arrow::Table.new(key: [3, 1],
@@ -1344,7 +1344,7 @@ visible: false
                                right_outputs: ["string"]))
     end
 
-    test("preserve outputs, type: :inner") do
+    test("left_outputs: & type: :inner") do
       table1 = Arrow::Table.new(key: [1, 2, 3],
                                 number: [10, 20, 30])
       table2 = Arrow::Table.new(key: [3, 1],
@@ -1361,7 +1361,7 @@ visible: false
                                right_outputs: table2.column_names))
     end
 
-    test("preserve outputs, type: :left_outer") do
+    test("left_outputs: & type: :left_outer") do
       table1 = Arrow::Table.new(key: [1, 2, 3],
                                 number: [10, 20, 30])
       table2 = Arrow::Table.new(key: [3, 1],
@@ -1378,7 +1378,7 @@ visible: false
                                right_outputs: table2.column_names))
     end
 
-    test("'preserve outputs, type: :right_outer") do
+    test("left_outputs: & type: :right_outer") do
       table1 = Arrow::Table.new(key: [1, 2, 3],
                                 number: [10, 20, 30])
       table2 = Arrow::Table.new(key: [3, 1],
@@ -1395,7 +1395,7 @@ visible: false
                                right_outputs: table2.column_names))
     end
 
-    test("preserve outputs, type: :full_outer") do
+    test("left_outputs: & type: :full_outer") do
       table1 = Arrow::Table.new(key: [1, 2, 3],
                                 number: [10, 20, 30])
       table2 = Arrow::Table.new(key: [3, 1],
@@ -1412,7 +1412,7 @@ visible: false
                                right_outputs: table2.column_names))
     end
 
-    test(":left_suffix and :right_suffix, keys in Array") do
+    test("left_suffix: & keys: [String]") do
       table1 = Arrow::Table.new(key1: [1, 1, 2, 2],
                                 key2: [10, 100, 20, 200],
                                 number: [1010, 1100, 2020, 2200])

--- a/ruby/red-arrow/test/test-table.rb
+++ b/ruby/red-arrow/test/test-table.rb
@@ -1131,7 +1131,7 @@ visible: false
   end
 
   sub_test_case("#join") do
-    test("no keys") do
+    test("w/o keys (natural join)") do
       table1 = Arrow::Table.new(key: [1, 2, 3],
                                 number: [10, 20, 30])
       table2 = Arrow::Table.new(key: [3, 1],
@@ -1139,7 +1139,6 @@ visible: false
       assert_equal(Arrow::Table.new([
                                       ["key", [1, 3]],
                                       ["number", [10, 30]],
-                                      ["key", [1, 3]],
                                       ["string", ["one", "three"]],
                                     ]),
                    table1.join(table2))
@@ -1153,7 +1152,6 @@ visible: false
       assert_equal(Arrow::Table.new([
                                       ["key", [1, 3]],
                                       ["number", [10, 30]],
-                                      ["key", [1, 3]],
                                       ["string", ["one", "three"]],
                                     ]),
                    table1.join(table2, "key"))
@@ -1167,10 +1165,23 @@ visible: false
       assert_equal(Arrow::Table.new([
                                       ["key", [1, 3]],
                                       ["number", [10, 30]],
-                                      ["key", [1, 3]],
                                       ["string", ["one", "three"]],
                                     ]),
                    table1.join(table2, :key))
+    end
+
+    test("keys: [String]") do
+      table1 = Arrow::Table.new(key: [1, 2, 3],
+                                number: [10, 20, 30])
+      table2 = Arrow::Table.new(key: [3, 1],
+                                string: ["three", "one"])
+      assert_equal(Arrow::Table.new([
+                                      ["key", [1, 3]],
+                                      ["number", [10, 30]],
+                                      ["key", [1, 3]],
+                                      ["string", ["one", "three"]],
+                                    ]),
+                   table1.join(table2, ["key"]))
     end
 
     test("keys: [String, Symbol]") do
@@ -1230,7 +1241,7 @@ visible: false
                                type: :inner))
     end
 
-    test("type:") do
+    test("type: :left_outer") do
       table1 = Arrow::Table.new(key: [1, 2, 3],
                                 number: [10, 20, 30])
       table2 = Arrow::Table.new(key: [3, 1],
@@ -1238,10 +1249,85 @@ visible: false
       assert_equal(Arrow::Table.new([
                                       ["key", [1, 3, 2]],
                                       ["number", [10, 30, 20]],
-                                      ["key", [1, 3, nil]],
                                       ["string", ["one", "three", nil]],
                                     ]),
                    table1.join(table2, "key", type: :left_outer))
+    end
+
+    test("type: :right_outer") do
+      table1 = Arrow::Table.new(key: [1, 2, 3],
+                                number: [10, 20, 30])
+      table2 = Arrow::Table.new(key: [3, 1],
+                                string: ["three", "one"])
+      assert_equal(Arrow::Table.new([
+                                      ["key", [1, 3]],
+                                      ["number", [10, 30]],
+                                      ["string", ["one", "three"]],
+                                    ]),
+                   table1.join(table2, "key", type: :right_outer))
+    end
+
+    test("type: :full_outer") do
+      table1 = Arrow::Table.new(key: [1, 2, 3],
+                                number: [10, 20, 30])
+      table2 = Arrow::Table.new(key: [3, 1],
+                                string: ["three", "one"])
+      assert_equal(Arrow::Table.new([
+                                      ["key", [1, 3, 2]],
+                                      ["number", [10, 30, 20]],
+                                      ["string", ["one", "three", nil]],
+                                    ]),
+                   table1.join(table2, "key", type: :full_outer))
+    end
+
+    test("type: :left_semi") do
+      table1 = Arrow::Table.new(key: [1, 2, 3],
+                                number: [10, 20, 30])
+      table2 = Arrow::Table.new(key: [3, 1],
+                                string: ["three", "one"])
+      assert_equal(Arrow::Table.new([
+                                      ["key", [1, 3]],
+                                      ["number", [10, 30]],
+                                    ]),
+                   table1.join(table2, "key", type: :left_semi))
+    end
+
+    test("type: :right_semi") do
+      table1 = Arrow::Table.new(key: [1, 2, 3],
+                                number: [10, 20, 30])
+      table2 = Arrow::Table.new(key: [3, 1],
+                                string: ["three", "one"])
+      assert_equal(Arrow::Table.new([
+                                      ["key", [3, 1]],
+                                      ["string", ["three", "one"]],
+                                    ]),
+                   table1.join(table2, "key", type: :right_semi))
+    end
+
+    test("type: :left_anti") do
+      table1 = Arrow::Table.new(key: [1, 2, 3],
+                                number: [10, 20, 30])
+      table2 = Arrow::Table.new(key: [3, 1],
+                                string: ["three", "one"])
+      assert_equal(Arrow::Table.new([
+                                      ["key", [2]],
+                                      ["number", [20]],
+                                    ]),
+                   table1.join(table2, "key", type: :left_anti))
+    end
+
+    test("type: :right_anti") do
+      table1 = Arrow::Table.new(key: [1, 2, 3],
+                                number: [10, 20, 30])
+      table2 = Arrow::Table.new(key: [3, 1],
+                                string: ["three", "one"])
+      assert_equal(Arrow::Table.new([
+                                      ["key", []],
+                                      ["string", []],
+                                    ]).to_s,
+                   table1.join(table2, "key", type: :right_anti).to_s)
+      # There is a bug: right_anti result has incorrect chunked array.
+      # Temporarily compare #to_s result.
     end
 
     test("left_outputs: & right_outputs:") do
@@ -1256,6 +1342,74 @@ visible: false
                                "key",
                                left_outputs: ["key", "number"],
                                right_outputs: ["string"]))
+    end
+
+    test("preserve outputs, type: :inner") do
+      table1 = Arrow::Table.new(key: [1, 2, 3],
+                                number: [10, 20, 30])
+      table2 = Arrow::Table.new(key: [3, 1],
+                                string: ["three", "one"])
+      assert_equal(Arrow::Table.new([
+                                      ["key", [1, 3]],
+                                      ["number", [10, 30]],
+                                      ["key", [1, 3]],
+                                      ["string", ["one", "three"]]
+                                    ]),
+                   table1.join(table2,
+                               type: :inner,
+                               left_outputs: table1.column_names,
+                               right_outputs: table2.column_names))
+    end
+
+    test("preserve outputs, type: :left_outer") do
+      table1 = Arrow::Table.new(key: [1, 2, 3],
+                                number: [10, 20, 30])
+      table2 = Arrow::Table.new(key: [3, 1],
+                                string: ["three", "one"])
+      assert_equal(Arrow::Table.new([
+                                      ["key", [1, 3, 2]],
+                                      ["number", [10, 30, 20]],
+                                      ["key", [1, 3, nil]],
+                                      ["string", ["one", "three", nil]],
+                                    ]),
+                   table1.join(table2,
+                               type: :left_outer,
+                               left_outputs: table1.column_names,
+                               right_outputs: table2.column_names))
+    end
+
+    test("'preserve outputs, type: :right_outer") do
+      table1 = Arrow::Table.new(key: [1, 2, 3],
+                                number: [10, 20, 30])
+      table2 = Arrow::Table.new(key: [3, 1],
+                                string: ["three", "one"])
+      assert_equal(Arrow::Table.new([
+                                      ["key", [1, 3]],
+                                      ["number", [10, 30]],
+                                      ["key", [1, 3]],
+                                      ["string", ["one", "three"]],
+                                    ]),
+                   table1.join(table2,
+                               type: :right_outer,
+                               left_outputs: table1.column_names,
+                               right_outputs: table2.column_names))
+    end
+
+    test("preserve outputs, type: :full_outer") do
+      table1 = Arrow::Table.new(key: [1, 2, 3],
+                                number: [10, 20, 30])
+      table2 = Arrow::Table.new(key: [3, 1],
+                                string: ["three", "one"])
+      assert_equal(Arrow::Table.new([
+                                      ["key", [1, 3, 2]],
+                                      ["number", [10, 30, 20]],
+                                      ["key", [1, 3, nil]],
+                                      ["string", ["one", "three", nil]],
+                                    ]),
+                   table1.join(table2,
+                               type: :full_outer,
+                               left_outputs: table1.column_names,
+                               right_outputs: table2.column_names))
     end
   end
 end

--- a/ruby/red-arrow/test/test-table.rb
+++ b/ruby/red-arrow/test/test-table.rb
@@ -1322,8 +1322,8 @@ visible: false
       table2 = Arrow::Table.new(key: [3, 1],
                                 string: ["three", "one"])
       assert_equal(Arrow::Table.new([
-                                      ["key", []],
-                                      ["string", []],
+                                      ["key", Arrow::ChunkedArray.new(:uint8)],
+                                      ["string", Arrow::ChunkedArray.new(:string)],
                                     ]),
                    table1.join(table2, "key", type: :right_anti))
     end


### PR DESCRIPTION
# Rationale for this change

Current implementation is always preserve column of join key. It is convenient if columns are merged.

# What changes are included in this PR?

- Columns from left and right are marged if;
  - Join key is a String or a Symbol (<= incompatible Change)
  - Join key is nil (natural join) (<= change in unreleased feature)
- New options `left_suffix=""` and `right_suffix=""` are introduced.
  - If it is empty (by default), join key(s) do not change.
  - If it is not empty, the suffix is appended to join key(s).

# Are these changes tested?

Yes.

# Are there any user-facing changes?

There are incompatible change when join key is a String or a Symbol.

* Closes: #15287