### PR TITLE
GH-33638: [C++] Removing ExecPlan::Make deprecation warning

### DIFF
--- a/cpp/src/arrow/compute/exec/exec_plan.h
+++ b/cpp/src/arrow/compute/exec/exec_plan.h
@@ -61,12 +61,10 @@ class ARROW_EXPORT ExecPlan : public std::enable_shared_from_this<ExecPlan> {
       ExecContext exec_context = *threaded_exec_context(),
       std::shared_ptr<const KeyValueMetadata> metadata = NULLPTR);
 
-  ARROW_DEPRECATED("Deprecated in 11.0.0. Use version that takes ExecContext by value.")
   static Result<std::shared_ptr<ExecPlan>> Make(
       QueryOptions options, ExecContext* exec_context,
       std::shared_ptr<const KeyValueMetadata> metadata = NULLPTR);
 
-  ARROW_DEPRECATED("Deprecated in 11.0.0. Use version that takes ExecContext by value.")
   static Result<std::shared_ptr<ExecPlan>> Make(
       ExecContext* exec_context,
       std::shared_ptr<const KeyValueMetadata> metadata = NULLPTR);

--- a/r/src/compute-exec.cpp
+++ b/r/src/compute-exec.cpp
@@ -44,11 +44,8 @@ std::shared_ptr<compute::ExecPlan> ExecPlan_create(bool use_threads) {
   // TODO(weston) using gc_context() in this way is deprecated.  Once ordering has
   // been added we can probably entirely remove all reference to ExecPlan from R
   // in favor of DeclarationToXyz
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   auto plan = ValueOrStop(
       compute::ExecPlan::Make(use_threads ? &threaded_context : gc_context()));
-#pragma GCC diagnostic pop
   return plan;
 }
 


### PR DESCRIPTION
See issue for rationale
* Closes: #33638