### PR TITLE
GH-14981: [R] Forward compatibility with dplyr::join_by() 

### DIFF
--- a/r/R/dplyr-join.R
+++ b/r/R/dplyr-join.R
@@ -136,6 +136,17 @@ handle_join_by <- function(by, x, y) {
   if (is.null(by)) {
     return(set_names(intersect(names(x), names(y))))
   }
+  if (inherits(by, "dplyr_join_by")) {
+    if (!all(by$condition == "==" & by$filter == "none")) {
+      abort(
+        paste0(
+          "Inequality conditions and helper functions ",
+          "are not supported in `join_by()` expressions."
+        )
+      )
+    }
+    by <- set_names(by$y, by$x)
+  }
   stopifnot(is.character(by))
   if (is.null(names(by))) {
     by <- set_names(by)


### PR DESCRIPTION
# Which issue does this PR close?

Closes #14981

# Rationale for this change

dplyr 1.1.0 introduces a new function `join_by()` for specifying join conditions. This PR adds support for `join_by()` in dplyr joins on Arrow objects. The support is limited only to equality conditions. Code added in this PR throws an error if the user specifies inequality conditions or uses helper functions in `join_by()`.

https://www.tidyverse.org/blog/2022/11/dplyr-1-1-0-is-coming-soon/#join-improvements

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

- Code to handle `join_by()` in dplyr joins on Arrow objects with equality conditions
- Tests of handling of `join_by()`, which are skipped when the version of dplyr is less than `1.0.99.9000` which is the current version number of the development version of dplyr on GitHub which that become version `1.1.0` on CRAN.


# Are these changes tested?

Yes

# Are there any user-facing changes?

Yes, the new dplyr syntax for specifying join conditions is supported, but use of this new syntax is optional. The old dplyr join syntax will continue to work. There are no breaking changes in this PR.
* Closes: #14981