### PR TITLE
GH-33626: [Packaging][RPM] Don't remove metadata for non-target arch

### DIFF
--- a/dev/release/05-binary-upload.sh
+++ b/dev/release/05-binary-upload.sh
@@ -132,5 +132,6 @@ docker_run \
     GPG_KEY_ID="${GPG_KEY_ID}" \
     RC=${rc} \
     STAGING=${STAGING:-no} \
+    VERBOSE=${VERBOSE:-no} \
     VERSION=${version} \
     YUM_TARGETS=$(IFS=,; echo "${yum_targets[*]}")

--- a/dev/release/post-02-binary.sh
+++ b/dev/release/post-02-binary.sh
@@ -105,5 +105,6 @@ docker_run \
     ARTIFACTS_DIR="${tmp_dir}/artifacts" \
     RC=${rc} \
     STAGING=${STAGING:-no} \
+    VERBOSE=${VERBOSE:-no} \
     VERSION=${version} \
     YUM_TARGETS=$(IFS=,; echo "${yum_targets[*]}")


### PR DESCRIPTION
# Which issue does this PR close?

Closes #33626

# Rationale for this change

ADBC reuses dev/release/05-binary-upload.sh for its RPM packages. ADBC only provides x86_64 packages. ADBC doesn't provide aarch64 packages for now.

In this situation, ADBC release deletes Yum repository metadata for aarch64 unexpectedly. dev/release/05-binary-upload.sh should not touch Yum repository metadata for aarch64 in ADBC release.

# What changes are included in this PR?

Copy Yum repository metadata for non-target architecture as-is.

# Are these changes tested?

Yes.

# Are there any user-facing changes?

No.
* Closes: #33626