### PR TITLE
GH-33671: [GLib] Add `garrow_chunked_array_new_empty()`

### DIFF
--- a/c_glib/arrow-glib/chunked-array.cpp
+++ b/c_glib/arrow-glib/chunked-array.cpp
@@ -35,13 +35,14 @@ G_BEGIN_DECLS
  * makes a list of #GArrowArrays one logical large array.
  */
 
-typedef struct GArrowChunkedArrayPrivate_ {
+struct GArrowChunkedArrayPrivate {
   std::shared_ptr<arrow::ChunkedArray> chunked_array;
-} GArrowChunkedArrayPrivate;
+  GArrowDataType *data_type;
+};
 
 enum {
-  PROP_0,
-  PROP_CHUNKED_ARRAY
+  PROP_CHUNKED_ARRAY = 1,
+  PROP_DATA_TYPE,
 };
 
 G_DEFINE_TYPE_WITH_PRIVATE(GArrowChunkedArray,
@@ -52,6 +53,19 @@ G_DEFINE_TYPE_WITH_PRIVATE(GArrowChunkedArray,
   static_cast<GArrowChunkedArrayPrivate *>(           \
      garrow_chunked_array_get_instance_private(       \
        GARROW_CHUNKED_ARRAY(obj)))
+
+static void
+garrow_chunked_array_dispose(GObject *object)
+{
+  auto priv = GARROW_CHUNKED_ARRAY_GET_PRIVATE(object);
+
+  if (priv->data_type) {
+    g_object_unref(priv->data_type);
+    priv->data_type = nullptr;
+  }
+
+  G_OBJECT_CLASS(garrow_chunked_array_parent_class)->dispose(object);
+}
 
 static void
 garrow_chunked_array_finalize(GObject *object)
@@ -75,6 +89,9 @@ garrow_chunked_array_set_property(GObject *object,
   case PROP_CHUNKED_ARRAY:
     priv->chunked_array =
       *static_cast<std::shared_ptr<arrow::ChunkedArray> *>(g_value_get_pointer(value));
+    break;
+  case PROP_DATA_TYPE:
+    priv->data_type = GARROW_DATA_TYPE(g_value_dup_object(value));
     break;
   default:
     G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
@@ -110,6 +127,7 @@ garrow_chunked_array_class_init(GArrowChunkedArrayClass *klass)
 
   gobject_class = G_OBJECT_CLASS(klass);
 
+  gobject_class->dispose      = garrow_chunked_array_dispose;
   gobject_class->finalize     = garrow_chunked_array_finalize;
   gobject_class->set_property = garrow_chunked_array_set_property;
   gobject_class->get_property = garrow_chunked_array_get_property;
@@ -120,16 +138,26 @@ garrow_chunked_array_class_init(GArrowChunkedArrayClass *klass)
                               static_cast<GParamFlags>(G_PARAM_WRITABLE |
                                                        G_PARAM_CONSTRUCT_ONLY));
   g_object_class_install_property(gobject_class, PROP_CHUNKED_ARRAY, spec);
+
+  spec = g_param_spec_object("data-type",
+                             "Data type",
+                             "The data type of this chunked array",
+                             GARROW_TYPE_DATA_TYPE,
+                             static_cast<GParamFlags>(G_PARAM_WRITABLE |
+                                                      G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property(gobject_class, PROP_DATA_TYPE, spec);
 }
 
 /**
  * garrow_chunked_array_new:
  * @chunks: (element-type GArrowArray): The array chunks.
+ * @error: (nullable): Return location for a #GError or %NULL.
  *
- * Returns: A newly created #GArrowChunkedArray.
+ * Returns: (nullable):
+ *   A newly created #GArrowChunkedArray or %NULL on error.
  */
 GArrowChunkedArray *
-garrow_chunked_array_new(GList *chunks)
+garrow_chunked_array_new(GList *chunks, GError **error)
 {
   std::vector<std::shared_ptr<arrow::Array>> arrow_chunks;
   for (GList *node = chunks; node; node = node->next) {
@@ -137,9 +165,37 @@ garrow_chunked_array_new(GList *chunks)
     arrow_chunks.push_back(garrow_array_get_raw(chunk));
   }
 
-  auto arrow_chunked_array =
-    std::make_shared<arrow::ChunkedArray>(arrow_chunks);
-  return garrow_chunked_array_new_raw(&arrow_chunked_array);
+  auto arrow_chunked_array_result = arrow::ChunkedArray::Make(arrow_chunks);
+  if (garrow::check(error, arrow_chunked_array_result, "[chunked-array][new]")) {
+    auto arrow_chunked_array = *arrow_chunked_array_result;
+    return garrow_chunked_array_new_raw(&arrow_chunked_array);
+  } else {
+    return nullptr;
+  }
+}
+
+/**
+ * garrow_chunked_array_new_empty:
+ * @data_type: The #GArrowDataType of this chunked array.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (nullable):
+ *   A newly created empty #GArrowChunkedArray or %NULL on error.
+ *
+ * Since: 11.0.0
+ */
+GArrowChunkedArray *
+garrow_chunked_array_new_empty(GArrowDataType *data_type, GError **error)
+{
+  auto arrow_data_type = garrow_data_type_get_raw(data_type);
+  auto arrow_chunked_array_result =
+    arrow::ChunkedArray::MakeEmpty(arrow_data_type);
+  if (garrow::check(error, arrow_chunked_array_result, "[chunked-array][new]")) {
+    auto arrow_chunked_array = *arrow_chunked_array_result;
+    return garrow_chunked_array_new_raw(&arrow_chunked_array);
+  } else {
+    return nullptr;
+  }
 }
 
 /**
@@ -174,9 +230,14 @@ garrow_chunked_array_equal(GArrowChunkedArray *chunked_array,
 GArrowDataType *
 garrow_chunked_array_get_value_data_type(GArrowChunkedArray *chunked_array)
 {
-  auto arrow_chunked_array = garrow_chunked_array_get_raw(chunked_array);
-  auto arrow_type = arrow_chunked_array->type();
-  return garrow_data_type_new_raw(&arrow_type);
+  auto priv = GARROW_CHUNKED_ARRAY_GET_PRIVATE(chunked_array);
+  if (!priv->data_type) {
+    auto arrow_chunked_array = garrow_chunked_array_get_raw(chunked_array);
+    auto arrow_type = arrow_chunked_array->type();
+    priv->data_type = garrow_data_type_new_raw(&arrow_type);
+  }
+  g_object_ref(priv->data_type);
+  return priv->data_type;
 }
 
 /**
@@ -353,11 +414,21 @@ garrow_chunked_array_combine(GArrowChunkedArray *chunked_array, GError **error)
 G_END_DECLS
 
 GArrowChunkedArray *
-garrow_chunked_array_new_raw(std::shared_ptr<arrow::ChunkedArray> *arrow_chunked_array)
+garrow_chunked_array_new_raw(
+  std::shared_ptr<arrow::ChunkedArray> *arrow_chunked_array)
+{
+  return garrow_chunked_array_new_raw(arrow_chunked_array, nullptr);
+}
+
+GArrowChunkedArray *
+garrow_chunked_array_new_raw(
+  std::shared_ptr<arrow::ChunkedArray> *arrow_chunked_array,
+  GArrowDataType *data_type)
 {
   auto chunked_array =
     GARROW_CHUNKED_ARRAY(g_object_new(GARROW_TYPE_CHUNKED_ARRAY,
                                       "chunked-array", arrow_chunked_array,
+                                      "data-type", data_type,
                                       NULL));
   return chunked_array;
 }

--- a/c_glib/arrow-glib/chunked-array.h
+++ b/c_glib/arrow-glib/chunked-array.h
@@ -24,7 +24,13 @@
 
 G_BEGIN_DECLS
 
-GArrowChunkedArray *garrow_chunked_array_new(GList *chunks);
+GArrowChunkedArray *
+garrow_chunked_array_new(GList *chunks,
+                         GError **error);
+GARROW_AVAILABLE_IN_11_0
+GArrowChunkedArray *
+garrow_chunked_array_new_empty(GArrowDataType *data_type,
+                               GError **error);
 
 gboolean garrow_chunked_array_equal(GArrowChunkedArray *chunked_array,
                                     GArrowChunkedArray *other_chunked_array);

--- a/c_glib/arrow-glib/chunked-array.hpp
+++ b/c_glib/arrow-glib/chunked-array.hpp
@@ -23,5 +23,12 @@
 
 #include <arrow-glib/chunked-array.h>
 
-GArrowChunkedArray *garrow_chunked_array_new_raw(std::shared_ptr<arrow::ChunkedArray> *arrow_chunked_array);
-std::shared_ptr<arrow::ChunkedArray> garrow_chunked_array_get_raw(GArrowChunkedArray *chunked_array);
+GArrowChunkedArray *
+garrow_chunked_array_new_raw(
+  std::shared_ptr<arrow::ChunkedArray> *arrow_chunked_array);
+GArrowChunkedArray *
+garrow_chunked_array_new_raw(
+  std::shared_ptr<arrow::ChunkedArray> *arrow_chunked_array,
+  GArrowDataType *data_type);
+std::shared_ptr<arrow::ChunkedArray>
+garrow_chunked_array_get_raw(GArrowChunkedArray *chunked_array);

--- a/c_glib/test/test-chunked-array.rb
+++ b/c_glib/test/test-chunked-array.rb
@@ -18,6 +18,12 @@
 class TestChunkedArray < Test::Unit::TestCase
   include Helper::Buildable
 
+  def test_empty
+    chunked_array = Arrow::ChunkedArray.new(Arrow::BooleanDataType.new)
+    assert_equal(Arrow::BooleanDataType.new,
+                 chunked_array.value_data_type)
+  end
+
   def test_equal
     chunks1 = [
       build_boolean_array([true, false]),


### PR DESCRIPTION
# Which issue does this PR close?

Closes #33671

# Rationale for this change

There is no API to create an empty chunked array.

# What changes are included in this PR?

Add a binding for `arrow::ChunkedArray::MakeEmpty()`.

# Are these changes tested?

Yes.

# Are there any user-facing changes?

Yes.
* Closes: #33671