### PR TITLE
GH-33670: [GLib] Add `GArrowProjectNodeOptions`

### DIFF
--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -156,6 +156,24 @@ GArrowSourceNodeOptions *
 garrow_source_node_options_new_table(GArrowTable *table);
 
 
+#define GARROW_TYPE_PROJECT_NODE_OPTIONS (garrow_project_node_options_get_type())
+G_DECLARE_DERIVABLE_TYPE(GArrowProjectNodeOptions,
+                         garrow_project_node_options,
+                         GARROW,
+                         PROJECT_NODE_OPTIONS,
+                         GArrowExecuteNodeOptions)
+struct _GArrowProjectNodeOptionsClass
+{
+  GArrowExecuteNodeOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_11_0
+GArrowProjectNodeOptions *
+garrow_project_node_options_new(GList *expressions,
+                                gchar **names,
+                                gsize n_names);
+
+
 #define GARROW_TYPE_AGGREGATION (garrow_aggregation_get_type())
 G_DECLARE_DERIVABLE_TYPE(GArrowAggregation,
                          garrow_aggregation,
@@ -321,6 +339,12 @@ GArrowExecuteNode *
 garrow_execute_plan_build_source_node(GArrowExecutePlan *plan,
                                       GArrowSourceNodeOptions *options,
                                       GError **error);
+GARROW_AVAILABLE_IN_11_0
+GArrowExecuteNode *
+garrow_execute_plan_build_project_node(GArrowExecutePlan *plan,
+                                       GArrowExecuteNode *input,
+                                       GArrowProjectNodeOptions *options,
+                                       GError **error);
 GARROW_AVAILABLE_IN_6_0
 GArrowExecuteNode *
 garrow_execute_plan_build_aggregate_node(GArrowExecutePlan *plan,

--- a/c_glib/test/test-project-node.rb
+++ b/c_glib/test/test-project-node.rb
@@ -1,0 +1,83 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestProjectNode < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def execute_plan(options)
+    plan = Arrow::ExecutePlan.new
+    numbers = build_int8_array([1, 2, 3, 4, 5])
+    strings = build_string_array(["a", "b", "a", "b", "a"])
+    table = build_table(number: numbers,
+                        string: strings)
+    source_node_options = Arrow::SourceNodeOptions.new(table)
+    source_node = plan.build_source_node(source_node_options)
+    project_node = plan.build_project_node(source_node, options)
+    sink_node_options = Arrow::SinkNodeOptions.new
+    sink_node = plan.build_sink_node(project_node,
+                                     sink_node_options)
+    plan.validate
+    plan.start
+    plan.wait
+    reader = sink_node_options.get_reader(project_node.output_schema)
+    table = reader.read_all
+    plan.stop
+    table
+  end
+
+  def test_expressions
+    three_scalar = Arrow::Int8Scalar.new(3)
+    three_datum = Arrow::ScalarDatum.new(three_scalar)
+    expressions = [
+      Arrow::FieldExpression.new("number"),
+      Arrow::CallExpression.new("multiply",
+                                [
+                                  Arrow::FieldExpression.new("number"),
+                                  Arrow::LiteralExpression.new(three_datum),
+                                ]),
+    ]
+    options = Arrow::ProjectNodeOptions.new(expressions)
+    assert_equal(build_table("number" => [
+                               build_int8_array([1, 2, 3, 4, 5]),
+                             ],
+                             "multiply(number, 3)" => [
+                               build_int8_array([3, 6, 9, 12, 15]),
+                             ]),
+                 execute_plan(options))
+  end
+
+  def test_names
+    three_scalar = Arrow::Int8Scalar.new(3)
+    three_datum = Arrow::ScalarDatum.new(three_scalar)
+    expressions = [
+      Arrow::CallExpression.new("multiply",
+                                [
+                                  Arrow::FieldExpression.new("number"),
+                                  Arrow::LiteralExpression.new(three_datum),
+                                ]),
+      Arrow::FieldExpression.new("number"),
+    ]
+    options = Arrow::ProjectNodeOptions.new(expressions, ["number * 3"])
+    assert_equal(build_table("number * 3" => [
+                               build_int8_array([3, 6, 9, 12, 15]),
+                             ],
+                             "number" => [
+                               build_int8_array([1, 2, 3, 4, 5]),
+                             ]),
+                 execute_plan(options))
+  end
+end


### PR DESCRIPTION
# Which issue does this PR close?

Closes #33670

# Rationale for this change

It's needed to create a project node in GLib.

# What changes are included in this PR?

Add a binding for `arrow::compute::ProjectNodeOptions`.

# Are these changes tested?

Yes.

# Are there any user-facing changes?

Yes.
* Closes: #33670