### PR TITLE
GH-15171: [C++] Pass std::string_view by value

### DIFF
--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -480,7 +480,7 @@ class ARROW_EXPORT FixedSizeBinaryBuilder : public ArrayBuilder {
     return Append(reinterpret_cast<const uint8_t*>(value));
   }
 
-  Status Append(const std::string_view& view) {
+  Status Append(std::string_view view) {
     ARROW_RETURN_NOT_OK(Reserve(1));
     UnsafeAppend(view);
     return Status::OK();
@@ -662,7 +662,7 @@ class ARROW_EXPORT ChunkedBinaryBuilder {
     return builder_->Append(value, length);
   }
 
-  Status Append(const std::string_view& value) {
+  Status Append(std::string_view value) {
     return Append(reinterpret_cast<const uint8_t*>(value.data()),
                   static_cast<int32_t>(value.size()));
   }

--- a/cpp/src/arrow/compute/exec/tpch_node_test.cc
+++ b/cpp/src/arrow/compute/exec/tpch_node_test.cc
@@ -98,9 +98,9 @@ void VerifyUniqueKey(std::unordered_set<int32_t>* seen, const Datum& d, int32_t 
   }
 }
 
-void VerifyStringAndNumber_Single(const std::string_view& row,
-                                  const std::string_view& prefix, const int64_t i,
-                                  const int32_t* nums, bool verify_padding) {
+void VerifyStringAndNumber_Single(std::string_view row, std::string_view prefix,
+                                  const int64_t i, const int32_t* nums,
+                                  bool verify_padding) {
   ASSERT_TRUE(StartsWith(row, prefix)) << row << ", prefix=" << prefix << ", i=" << i;
   const char* num_str = row.data() + prefix.size();
   const char* num_str_end = row.data() + row.size();
@@ -128,7 +128,7 @@ void VerifyStringAndNumber_Single(const std::string_view& row,
 // corresponding row in numbers. Some TPC-H data is padded to 9 zeros, which this function
 // can optionally verify as well. This string function verifies fixed width columns.
 void VerifyStringAndNumber_FixedWidth(const Datum& strings, const Datum& numbers,
-                                      int byte_width, const std::string_view& prefix,
+                                      int byte_width, std::string_view prefix,
                                       bool verify_padding = true) {
   int64_t length = strings.length();
   const char* str = reinterpret_cast<const char*>(strings.array()->buffers[1]->data());
@@ -148,8 +148,7 @@ void VerifyStringAndNumber_FixedWidth(const Datum& strings, const Datum& numbers
 
 // Same as above but for variable length columns
 void VerifyStringAndNumber_Varlen(const Datum& strings, const Datum& numbers,
-                                  const std::string_view& prefix,
-                                  bool verify_padding = true) {
+                                  std::string_view prefix, bool verify_padding = true) {
   int64_t length = strings.length();
   const int32_t* offsets =
       reinterpret_cast<const int32_t*>(strings.array()->buffers[1]->data());

--- a/cpp/src/arrow/compute/kernels/scalar_string_internal.h
+++ b/cpp/src/arrow/compute/kernels/scalar_string_internal.h
@@ -351,8 +351,7 @@ struct StringSplitExec {
     return Status::OK();
   }
 
-  Status SplitString(const std::string_view& s, SplitFinder* finder,
-                     BuilderType* builder) {
+  Status SplitString(std::string_view s, SplitFinder* finder, BuilderType* builder) {
     const uint8_t* begin = reinterpret_cast<const uint8_t*>(s.data());
     const uint8_t* end = begin + s.length();
 

--- a/cpp/src/arrow/flight/cookie_internal.cc
+++ b/cpp/src/arrow/flight/cookie_internal.cc
@@ -65,7 +65,7 @@ size_t CaseInsensitiveHash::operator()(const std::string& key) const {
   return std::hash<std::string>{}(upper_string);
 }
 
-Cookie Cookie::Parse(const std::string_view& cookie_header_value) {
+Cookie Cookie::Parse(std::string_view cookie_header_value) {
   // Parse the cookie string. If the cookie has an expiration, record it.
   // If the cookie has a max-age, calculate the current time + max_age and set that as
   // the expiration.

--- a/cpp/src/arrow/flight/cookie_internal.h
+++ b/cpp/src/arrow/flight/cookie_internal.h
@@ -54,7 +54,7 @@ class ARROW_FLIGHT_EXPORT Cookie {
   /// \brief Parse function to parse a cookie header value and return a Cookie object.
   ///
   /// \return Cookie object based on cookie header value.
-  static Cookie Parse(const std::string_view& cookie_header_value);
+  static Cookie Parse(std::string_view cookie_header_value);
 
   /// \brief Parse a cookie header string beginning at the given start_pos and identify
   /// the name and value of an attribute.

--- a/cpp/src/arrow/io/memory.cc
+++ b/cpp/src/arrow/io/memory.cc
@@ -274,7 +274,7 @@ BufferReader::BufferReader(const uint8_t* data, int64_t size)
 BufferReader::BufferReader(const Buffer& buffer)
     : BufferReader(buffer.data(), buffer.size()) {}
 
-BufferReader::BufferReader(const std::string_view& data)
+BufferReader::BufferReader(std::string_view data)
     : BufferReader(reinterpret_cast<const uint8_t*>(data.data()),
                    static_cast<int64_t>(data.size())) {}
 

--- a/cpp/src/arrow/io/memory.h
+++ b/cpp/src/arrow/io/memory.h
@@ -151,7 +151,7 @@ class ARROW_EXPORT BufferReader
 
   /// \brief Instantiate from std::string or std::string_view. Does not
   /// own data
-  explicit BufferReader(const std::string_view& data);
+  explicit BufferReader(std::string_view data);
 
   bool closed() const override;
 

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -60,7 +60,7 @@ void AssertMakeScalar(const Scalar& expected, MakeScalarArgs&&... args) {
   AssertScalarsEqual(expected, *scalar, /*verbose=*/true);
 }
 
-void AssertParseScalar(const std::shared_ptr<DataType>& type, const std::string_view& s,
+void AssertParseScalar(const std::shared_ptr<DataType>& type, std::string_view s,
                        const Scalar& expected) {
   ASSERT_OK_AND_ASSIGN(auto scalar, Scalar::Parse(type, s));
   ASSERT_OK(scalar->Validate());

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -397,7 +397,7 @@ std::string Decimal128::ToString(int32_t scale) const {
 // Iterates over input and for each group of kInt64DecimalDigits multiple out by
 // the appropriate power of 10 necessary to add source parsed as uint64 and
 // then adds the parsed value of source.
-static inline void ShiftAndAdd(const std::string_view& input, uint64_t out[],
+static inline void ShiftAndAdd(std::string_view input, uint64_t out[],
                                size_t out_size) {
   for (size_t posn = 0; posn < input.size();) {
     const size_t group_size = std::min(kInt64DecimalDigits, input.size() - posn);
@@ -508,7 +508,7 @@ inline Status ToArrowStatus(DecimalStatus dstatus, int num_bits) {
 }
 
 template <typename Decimal>
-Status DecimalFromString(const char* type_name, const std::string_view& s, Decimal* out,
+Status DecimalFromString(const char* type_name, std::string_view s, Decimal* out,
                          int32_t* precision, int32_t* scale) {
   if (s.empty()) {
     return Status::Invalid("Empty string cannot be converted to ", type_name);
@@ -573,8 +573,8 @@ Status DecimalFromString(const char* type_name, const std::string_view& s, Decim
 
 }  // namespace
 
-Status Decimal128::FromString(const std::string_view& s, Decimal128* out,
-                              int32_t* precision, int32_t* scale) {
+Status Decimal128::FromString(std::string_view s, Decimal128* out, int32_t* precision,
+                              int32_t* scale) {
   return DecimalFromString("decimal128", s, out, precision, scale);
 }
 
@@ -588,7 +588,7 @@ Status Decimal128::FromString(const char* s, Decimal128* out, int32_t* precision
   return FromString(std::string_view(s), out, precision, scale);
 }
 
-Result<Decimal128> Decimal128::FromString(const std::string_view& s) {
+Result<Decimal128> Decimal128::FromString(std::string_view s) {
   Decimal128 out;
   RETURN_NOT_OK(FromString(s, &out, nullptr, nullptr));
   return std::move(out);
@@ -706,8 +706,8 @@ std::string Decimal256::ToString(int32_t scale) const {
   return str;
 }
 
-Status Decimal256::FromString(const std::string_view& s, Decimal256* out,
-                              int32_t* precision, int32_t* scale) {
+Status Decimal256::FromString(std::string_view s, Decimal256* out, int32_t* precision,
+                              int32_t* scale) {
   return DecimalFromString("decimal256", s, out, precision, scale);
 }
 
@@ -721,7 +721,7 @@ Status Decimal256::FromString(const char* s, Decimal256* out, int32_t* precision
   return FromString(std::string_view(s), out, precision, scale);
 }
 
-Result<Decimal256> Decimal256::FromString(const std::string_view& s) {
+Result<Decimal256> Decimal256::FromString(std::string_view s) {
   Decimal256 out;
   RETURN_NOT_OK(FromString(s, &out, nullptr, nullptr));
   return std::move(out);

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -397,8 +397,7 @@ std::string Decimal128::ToString(int32_t scale) const {
 // Iterates over input and for each group of kInt64DecimalDigits multiple out by
 // the appropriate power of 10 necessary to add source parsed as uint64 and
 // then adds the parsed value of source.
-static inline void ShiftAndAdd(std::string_view input, uint64_t out[],
-                               size_t out_size) {
+static inline void ShiftAndAdd(std::string_view input, uint64_t out[], size_t out_size) {
   for (size_t posn = 0; posn < input.size();) {
     const size_t group_size = std::min(kInt64DecimalDigits, input.size() - posn);
     const uint64_t multiple = kUInt64PowersOfTen[group_size];

--- a/cpp/src/arrow/util/decimal.h
+++ b/cpp/src/arrow/util/decimal.h
@@ -95,13 +95,13 @@ class ARROW_EXPORT Decimal128 : public BasicDecimal128 {
 
   /// \brief Convert a decimal string to a Decimal128 value, optionally including
   /// precision and scale if they're passed in and not null.
-  static Status FromString(const std::string_view& s, Decimal128* out, int32_t* precision,
+  static Status FromString(std::string_view s, Decimal128* out, int32_t* precision,
                            int32_t* scale = NULLPTR);
   static Status FromString(const std::string& s, Decimal128* out, int32_t* precision,
                            int32_t* scale = NULLPTR);
   static Status FromString(const char* s, Decimal128* out, int32_t* precision,
                            int32_t* scale = NULLPTR);
-  static Result<Decimal128> FromString(const std::string_view& s);
+  static Result<Decimal128> FromString(std::string_view s);
   static Result<Decimal128> FromString(const std::string& s);
   static Result<Decimal128> FromString(const char* s);
 
@@ -212,13 +212,13 @@ class ARROW_EXPORT Decimal256 : public BasicDecimal256 {
 
   /// \brief Convert a decimal string to a Decimal256 value, optionally including
   /// precision and scale if they're passed in and not null.
-  static Status FromString(const std::string_view& s, Decimal256* out, int32_t* precision,
+  static Status FromString(std::string_view s, Decimal256* out, int32_t* precision,
                            int32_t* scale = NULLPTR);
   static Status FromString(const std::string& s, Decimal256* out, int32_t* precision,
                            int32_t* scale = NULLPTR);
   static Status FromString(const char* s, Decimal256* out, int32_t* precision,
                            int32_t* scale = NULLPTR);
-  static Result<Decimal256> FromString(const std::string_view& s);
+  static Result<Decimal256> FromString(std::string_view s);
   static Result<Decimal256> FromString(const std::string& s);
   static Result<Decimal256> FromString(const char* s);
 

--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -107,7 +107,7 @@ struct ScalarHelper<Scalar, AlgNum,
     : public ScalarHelperBase<Scalar, AlgNum> {
   // ScalarHelper specialization for std::string_view
 
-  static hash_t ComputeHash(const std::string_view& value) {
+  static hash_t ComputeHash(std::string_view value) {
     return ComputeStringHash<AlgNum>(value.data(), static_cast<int64_t>(value.size()));
   }
 };
@@ -641,7 +641,7 @@ class BinaryMemoTable : public MemoTable {
     }
   }
 
-  int32_t Get(const std::string_view& value) const {
+  int32_t Get(std::string_view value) const {
     return Get(value.data(), static_cast<builder_offset_type>(value.length()));
   }
 
@@ -669,8 +669,8 @@ class BinaryMemoTable : public MemoTable {
   }
 
   template <typename Func1, typename Func2>
-  Status GetOrInsert(const std::string_view& value, Func1&& on_found,
-                     Func2&& on_not_found, int32_t* out_memo_index) {
+  Status GetOrInsert(std::string_view value, Func1&& on_found, Func2&& on_not_found,
+                     int32_t* out_memo_index) {
     return GetOrInsert(value.data(), static_cast<builder_offset_type>(value.length()),
                        std::forward<Func1>(on_found), std::forward<Func2>(on_not_found),
                        out_memo_index);
@@ -682,7 +682,7 @@ class BinaryMemoTable : public MemoTable {
         data, length, [](int32_t i) {}, [](int32_t i) {}, out_memo_index);
   }
 
-  Status GetOrInsert(const std::string_view& value, int32_t* out_memo_index) {
+  Status GetOrInsert(std::string_view value, int32_t* out_memo_index) {
     return GetOrInsert(value.data(), static_cast<builder_offset_type>(value.length()),
                        out_memo_index);
   }
@@ -850,7 +850,7 @@ class BinaryMemoTable : public MemoTable {
 
  public:
   Status MergeTable(const BinaryMemoTable& other_table) {
-    other_table.VisitValues(0, [this](const std::string_view& other_value) {
+    other_table.VisitValues(0, [this](std::string_view other_value) {
       int32_t unused;
       DCHECK_OK(this->GetOrInsert(other_value, &unused));
     });
@@ -918,7 +918,7 @@ struct StringViewHash {
   // std::hash compatible hasher for use with std::unordered_*
   // (the std::hash specialization provided by nonstd constructs std::string
   // temporaries then invokes std::hash<std::string> against those)
-  hash_t operator()(const std::string_view& value) const {
+  hash_t operator()(std::string_view value) const {
     return ComputeStringHash<0>(value.data(), static_cast<int64_t>(value.size()));
   }
 };

--- a/cpp/src/arrow/util/hashing_test.cc
+++ b/cpp/src/arrow/util/hashing_test.cc
@@ -440,7 +440,7 @@ TEST(BinaryMemoTable, Basics) {
   {
     const int32_t start_offset = 1;
     std::vector<std::string> actual;
-    table.VisitValues(start_offset, [&](const std::string_view& v) {
+    table.VisitValues(start_offset, [&](std::string_view v) {
       actual.emplace_back(v.data(), v.length());
     });
     EXPECT_THAT(actual, testing::ElementsAre(B, C, D, E, F, ""));

--- a/cpp/src/arrow/util/utf8.cc
+++ b/cpp/src/arrow/util/utf8.cc
@@ -96,7 +96,7 @@ bool ValidateUTF8(const uint8_t* data, int64_t size) {
   return ValidateUTF8Inline(data, size);
 }
 
-bool ValidateUTF8(const std::string_view& str) { return ValidateUTF8Inline(str); }
+bool ValidateUTF8(std::string_view str) { return ValidateUTF8Inline(str); }
 
 static const uint8_t kBOM[] = {0xEF, 0xBB, 0xBF};
 

--- a/cpp/src/arrow/util/utf8.h
+++ b/cpp/src/arrow/util/utf8.h
@@ -41,7 +41,7 @@ ARROW_EXPORT void InitializeUTF8();
 
 ARROW_EXPORT bool ValidateUTF8(const uint8_t* data, int64_t size);
 
-ARROW_EXPORT bool ValidateUTF8(const std::string_view& str);
+ARROW_EXPORT bool ValidateUTF8(std::string_view str);
 
 // Skip UTF8 byte order mark, if any.
 ARROW_EXPORT

--- a/cpp/src/arrow/util/utf8_internal.h
+++ b/cpp/src/arrow/util/utf8_internal.h
@@ -201,7 +201,7 @@ static inline bool ValidateUTF8Inline(const uint8_t* data, int64_t size) {
   return ARROW_PREDICT_TRUE(state == internal::kUTF8ValidateAccept);
 }
 
-static inline bool ValidateUTF8Inline(const std::string_view& str) {
+static inline bool ValidateUTF8Inline(std::string_view str) {
   const uint8_t* data = reinterpret_cast<const uint8_t*>(str.data());
   const size_t length = str.size();
 
@@ -266,7 +266,7 @@ static inline bool ValidateAscii(const uint8_t* data, int64_t len) {
 #endif
 }
 
-static inline bool ValidateAscii(const std::string_view& str) {
+static inline bool ValidateAscii(std::string_view str) {
   const uint8_t* data = reinterpret_cast<const uint8_t*>(str.data());
   const size_t length = str.size();
 

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -658,7 +658,7 @@ void DictEncoderImpl<DType>::WriteDict(uint8_t* buffer) {
 // ByteArray and FLBA already have the dictionary encoded in their data heaps
 template <>
 void DictEncoderImpl<ByteArrayType>::WriteDict(uint8_t* buffer) {
-  memo_table_.VisitValues(0, [&buffer](const ::std::string_view& v) {
+  memo_table_.VisitValues(0, [&buffer](::std::string_view v) {
     uint32_t len = static_cast<uint32_t>(v.length());
     memcpy(buffer, &len, sizeof(len));
     buffer += sizeof(len);
@@ -669,7 +669,7 @@ void DictEncoderImpl<ByteArrayType>::WriteDict(uint8_t* buffer) {
 
 template <>
 void DictEncoderImpl<FLBAType>::WriteDict(uint8_t* buffer) {
-  memo_table_.VisitValues(0, [&](const ::std::string_view& v) {
+  memo_table_.VisitValues(0, [&](::std::string_view v) {
     DCHECK_EQ(v.length(), static_cast<size_t>(type_length_));
     memcpy(buffer, v.data(), type_length_);
     buffer += type_length_;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/master/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->
Closes #15171. 

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Pass std::string_view by value, not by const-ref
# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

# Are there any user-facing changes?
No.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `breaking-change` label.
-->
* Closes: #15171