### PR TITLE
GH-33687: [Dev] Fix commit message generation in merge script

### DIFF
--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -576,9 +576,9 @@ class PullRequest(object):
         commit_message_chunks = []
         if self.body is not None:
             # Remove comments (i.e. <-- comment -->) from the pull request description.
-            body = re.sub(r"<!--(.|\s)*-->", "", self.body)
+            body = re.sub(r"<!--.*?-->", "", self.body, flags=re.DOTALL)
             # avoid github user name references by inserting a space after @
-            body = re.sub(r"@(\w+)", "@ \\1", self.body)
+            body = re.sub(r"@(\w+)", "@ \\1", body)
             commit_message_chunks.append(body)
 
         committer_name = run_cmd("git config --get user.name").strip()
@@ -596,9 +596,16 @@ class PullRequest(object):
 
         commit_message = "\n\n".join(commit_message_chunks)
 
+        # Collapse extraneous newlines. We allow two consecutive newlines
+        # (for paragraph breaks) but not more.
+        commit_message = "\n".join(commit_message.splitlines())  # normalize line ends
+        commit_message = re.sub("\n{2,}", "\n\n", commit_message)
+
         if DEBUG:
+            print("*** Commit title ***")
             print(commit_title)
             print()
+            print("*** Commit message ***")
             print(commit_message)
 
         if DEBUG:

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -575,7 +575,7 @@ class PullRequest(object):
         commit_title = f'{self.title} (#{self.number})'
         commit_message_chunks = []
         if self.body is not None:
-            # Remove comments (i.e. <-- comment -->) from the pull request description.
+            # Remove comments (i.e. <-- comment -->) from the PR description.
             body = re.sub(r"<!--.*?-->", "", self.body, flags=re.DOTALL)
             # avoid github user name references by inserting a space after @
             body = re.sub(r"@(\w+)", "@ \\1", body)
@@ -596,9 +596,9 @@ class PullRequest(object):
 
         commit_message = "\n\n".join(commit_message_chunks)
 
-        # Collapse extraneous newlines. We allow two consecutive newlines
-        # (for paragraph breaks) but not more.
-        commit_message = "\n".join(commit_message.splitlines())  # normalize line ends
+        # Normalize line ends and collapse extraneous newlines. We allow two
+        # consecutive newlines for paragraph breaks but not more.
+        commit_message = "\n".join(commit_message.splitlines())
         commit_message = re.sub("\n{2,}", "\n\n", commit_message)
 
         if DEBUG:


### PR DESCRIPTION
* Regex for removing HTML comments was pathologically slow because of greedy pattern matching
* Output of regex replacement was ignored (!)
* Collapse extraneous newlines in generated commit message
* Improve debugging output

* Closes: #33687