### PR TITLE
GH-33666: [R] Remove extraneous argument to semi_join

### DIFF
--- a/r/R/dplyr-join.R
+++ b/r/R/dplyr-join.R
@@ -116,9 +116,8 @@ semi_join.arrow_dplyr_query <- function(x,
                                         y,
                                         by = NULL,
                                         copy = FALSE,
-                                        suffix = c(".x", ".y"),
                                         ...) {
-  do_join(x, y, by, copy, suffix, ..., join_type = "LEFT_SEMI")
+  do_join(x, y, by, copy, ..., join_type = "LEFT_SEMI")
 }
 semi_join.Dataset <- semi_join.ArrowTabular <- semi_join.RecordBatchReader <- semi_join.arrow_dplyr_query
 

--- a/r/R/dplyr-join.R
+++ b/r/R/dplyr-join.R
@@ -116,8 +116,9 @@ semi_join.arrow_dplyr_query <- function(x,
                                         y,
                                         by = NULL,
                                         copy = FALSE,
+                                        suffix = c(".x", ".y"),
                                         ...) {
-  do_join(x, y, by, copy, ..., join_type = "LEFT_SEMI")
+  do_join(x, y, by, copy, suffix, ..., join_type = "LEFT_SEMI")
 }
 semi_join.Dataset <- semi_join.ArrowTabular <- semi_join.RecordBatchReader <- semi_join.arrow_dplyr_query
 

--- a/r/tests/testthat/test-dplyr-join.R
+++ b/r/tests/testthat/test-dplyr-join.R
@@ -82,7 +82,7 @@ test_that("left_join with join_by", {
       left_join(
         to_join %>%
           rename(the_grouping = some_grouping),
-          join_by(some_grouping == the_grouping)
+        join_by(some_grouping == the_grouping)
       ) %>%
       collect(),
     left
@@ -244,7 +244,6 @@ test_that("semi_join", {
       collect(),
     left
   )
-
 })
 
 test_that("anti_join", {

--- a/r/tests/testthat/test-dplyr-join.R
+++ b/r/tests/testthat/test-dplyr-join.R
@@ -240,17 +240,11 @@ test_that("full_join", {
 test_that("semi_join", {
   compare_dplyr_binding(
     .input %>%
-      semi_join(to_join, by = "some_grouping", keep = TRUE) %>%
+      semi_join(to_join, by = "some_grouping") %>%
       collect(),
     left
   )
 
-  compare_dplyr_binding(
-    .input %>%
-      semi_join(to_join, by = "some_grouping", keep = FALSE) %>%
-      collect(),
-    left
-  )
 })
 
 test_that("anti_join", {


### PR DESCRIPTION
This PR removes the `keep` argument from the test for `semi_join()`, which are causing the unit tests to fail.  It also removes the argument `suffix` argument (which is not part of the dplyr function signature) from the function signature here.

Closes: #33666