### PR TITLE
MINOR: [C++][Parquet] Rephrase decimal annotation

### DIFF
--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -3443,8 +3443,8 @@ TEST(ArrowReadWrite, Decimal256AsInt) {
   auto table = ::arrow::Table::Make(::arrow::schema({field("root", type)}), {array});
 
   parquet::WriterProperties::Builder builder;
-  // Enforce integer type to store short decimal type
-  auto writer_properties = builder.enable_short_decimal_stored_as_integer()->build();
+  // Allow small decimals to be stored as int32 or int64.
+  auto writer_properties = builder.enable_store_decimal_as_integer()->build();
   auto props_store_schema = ArrowWriterProperties::Builder().store_schema()->build();
 
   CheckConfiguredRoundtrip(table, table, writer_properties, props_store_schema);
@@ -4821,8 +4821,8 @@ class TestIntegerAnnotateDecimalTypeParquetIO : public TestParquetIO<TestType> {
     auto arrow_schema = ::arrow::schema({::arrow::field("a", values->type())});
 
     parquet::WriterProperties::Builder builder;
-    // Enforce integer type to store short decimal type
-    auto writer_properties = builder.enable_short_decimal_stored_as_integer()->build();
+    // Allow small decimals to be stored as int32 or int64.
+    auto writer_properties = builder.enable_store_decimal_as_integer()->build();
     std::shared_ptr<SchemaDescriptor> parquet_schema;
     ASSERT_OK_NO_THROW(ToParquetSchema(arrow_schema.get(), *writer_properties,
                                        *default_arrow_writer_properties(),

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -3443,8 +3443,8 @@ TEST(ArrowReadWrite, Decimal256AsInt) {
   auto table = ::arrow::Table::Make(::arrow::schema({field("root", type)}), {array});
 
   parquet::WriterProperties::Builder builder;
-  // Enforce integer type to annotate decimal type
-  auto writer_properties = builder.enable_integer_annotate_decimal()->build();
+  // Enforce integer type to store short decimal type
+  auto writer_properties = builder.enable_short_decimal_stored_as_integer()->build();
   auto props_store_schema = ArrowWriterProperties::Builder().store_schema()->build();
 
   CheckConfiguredRoundtrip(table, table, writer_properties, props_store_schema);
@@ -4821,8 +4821,8 @@ class TestIntegerAnnotateDecimalTypeParquetIO : public TestParquetIO<TestType> {
     auto arrow_schema = ::arrow::schema({::arrow::field("a", values->type())});
 
     parquet::WriterProperties::Builder builder;
-    // Enforce integer type to annotate decimal type
-    auto writer_properties = builder.enable_integer_annotate_decimal()->build();
+    // Enforce integer type to store short decimal type
+    auto writer_properties = builder.enable_short_decimal_stored_as_integer()->build();
     std::shared_ptr<SchemaDescriptor> parquet_schema;
     ASSERT_OK_NO_THROW(ToParquetSchema(arrow_schema.get(), *writer_properties,
                                        *default_arrow_writer_properties(),

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -357,7 +357,8 @@ Status FieldToNode(const std::string& name, const std::shared_ptr<Field>& field,
       const auto& decimal_type = static_cast<const ::arrow::DecimalType&>(*field->type());
       precision = decimal_type.precision();
       scale = decimal_type.scale();
-      if (properties.integer_annotate_decimal() && 1 <= precision && precision <= 18) {
+      if (properties.store_short_decimal_as_integer() && 1 <= precision &&
+          precision <= 18) {
         type = precision <= 9 ? ParquetType ::INT32 : ParquetType ::INT64;
       } else {
         type = ParquetType::FIXED_LEN_BYTE_ARRAY;

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -357,8 +357,7 @@ Status FieldToNode(const std::string& name, const std::shared_ptr<Field>& field,
       const auto& decimal_type = static_cast<const ::arrow::DecimalType&>(*field->type());
       precision = decimal_type.precision();
       scale = decimal_type.scale();
-      if (properties.store_short_decimal_as_integer() && 1 <= precision &&
-          precision <= 18) {
+      if (properties.store_decimal_as_integer() && 1 <= precision && precision <= 18) {
         type = precision <= 9 ? ParquetType ::INT32 : ParquetType ::INT64;
       } else {
         type = ParquetType::FIXED_LEN_BYTE_ARRAY;

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -456,7 +456,7 @@ class PARQUET_EXPORT WriterProperties {
     ///
     /// In Parquet, DECIMAL can be stored in any of the following physical types:
     /// - int32: for 1 <= precision <= 9.
-    /// - int64: for 1 <= precision <= 18; precision < 10 will produce a warning.
+    /// - int64: for 10 <= precision <= 18.
     /// - fixed_len_byte_array: precision is limited by the array size.
     ///   Length n can store <= floor(log_10(2^(8*n - 1) - 1)) base-10 digits.
     /// - binary: precision is unlimited. The minimum number of bytes to store

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -459,8 +459,8 @@ class PARQUET_EXPORT WriterProperties {
     /// - int64: for 1 <= precision <= 18; precision < 10 will produce a warning.
     /// - fixed_len_byte_array: precision is limited by the array size.
     ///   Length n can store <= floor(log_10(2^(8*n - 1) - 1)) base-10 digits.
-    /// - binary: precision is not limited, but is required. The minimum number
-    ///   of bytes to store the unscaled value should be used.
+    /// - binary: precision is unlimited. The minimum number of bytes to store
+    ///   the unscaled value is used.
     ///
     /// By default, this is DISABLED and all decimal types annotate fixed_len_byte_array.
     ///
@@ -469,8 +469,7 @@ class PARQUET_EXPORT WriterProperties {
     /// - int64: for 10 <= precision <= 18.
     /// - fixed_len_byte_array: for precision > 18.
     ///
-    /// As a consequence, decimal columns stored in integer types are more compact
-    /// but in a risk that the parquet file may not be readable by other implementations.
+    /// As a consequence, decimal columns stored in integer types are more compact.
     Builder* enable_store_decimal_as_integer() {
       store_decimal_as_integer_ = true;
       return this;

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -201,7 +201,7 @@ class PARQUET_EXPORT WriterProperties {
           version_(ParquetVersion::PARQUET_2_4),
           data_page_version_(ParquetDataPageVersion::V1),
           created_by_(DEFAULT_CREATED_BY),
-          store_short_decimal_as_integer_(false) {}
+          store_decimal_as_integer_(false) {}
     virtual ~Builder() {}
 
     /// Specify the memory pool for the writer. Default default_memory_pool.
@@ -452,17 +452,15 @@ class PARQUET_EXPORT WriterProperties {
       return this->disable_statistics(path->ToDotString());
     }
 
-    /// Enable decimal logical type with 1 <= precision <= 18 to be stored as
-    /// integer physical type.
+    /// Allow decimals with 1 <= precision <= 18 to be stored as integers.
     ///
-    /// According to the specs, DECIMAL can be used to annotate the following types:
+    /// In Parquet, DECIMAL can be stored in any of the following physical types:
     /// - int32: for 1 <= precision <= 9.
     /// - int64: for 1 <= precision <= 18; precision < 10 will produce a warning.
     /// - fixed_len_byte_array: precision is limited by the array size.
     ///   Length n can store <= floor(log_10(2^(8*n - 1) - 1)) base-10 digits.
-    /// - binary: precision is not limited, but is required. precision is not limited,
-    ///   but is required. The minimum number of bytes to store the unscaled value
-    ///   should be used.
+    /// - binary: precision is not limited, but is required. The minimum number
+    ///   of bytes to store the unscaled value should be used.
     ///
     /// By default, this is DISABLED and all decimal types annotate fixed_len_byte_array.
     ///
@@ -472,10 +470,9 @@ class PARQUET_EXPORT WriterProperties {
     /// - fixed_len_byte_array: for precision > 18.
     ///
     /// As a consequence, decimal columns stored in integer types are more compact
-    /// but in a risk that the parquet file may not be readable by previous Arrow C++
-    /// versions or other implementations.
-    Builder* enable_short_decimal_stored_as_integer() {
-      store_short_decimal_as_integer_ = true;
+    /// but in a risk that the parquet file may not be readable by other implementations.
+    Builder* enable_store_decimal_as_integer() {
+      store_decimal_as_integer_ = true;
       return this;
     }
 
@@ -483,8 +480,8 @@ class PARQUET_EXPORT WriterProperties {
     /// integer physical type.
     ///
     /// Default disabled.
-    Builder* disable_short_decimal_stored_as_integer() {
-      store_short_decimal_as_integer_ = false;
+    Builder* disable_store_decimal_as_integer() {
+      store_decimal_as_integer_ = false;
       return this;
     }
 
@@ -513,7 +510,7 @@ class PARQUET_EXPORT WriterProperties {
           pool_, dictionary_pagesize_limit_, write_batch_size_, max_row_group_length_,
           pagesize_, version_, created_by_, std::move(file_encryption_properties_),
           default_column_properties_, column_properties, data_page_version_,
-          store_short_decimal_as_integer_));
+          store_decimal_as_integer_));
     }
 
    private:
@@ -525,7 +522,7 @@ class PARQUET_EXPORT WriterProperties {
     ParquetVersion::type version_;
     ParquetDataPageVersion data_page_version_;
     std::string created_by_;
-    bool store_short_decimal_as_integer_;
+    bool store_decimal_as_integer_;
 
     std::shared_ptr<FileEncryptionProperties> file_encryption_properties_;
 
@@ -556,9 +553,7 @@ class PARQUET_EXPORT WriterProperties {
 
   inline std::string created_by() const { return parquet_created_by_; }
 
-  inline bool store_short_decimal_as_integer() const {
-    return store_short_decimal_as_integer_;
-  }
+  inline bool store_decimal_as_integer() const { return store_decimal_as_integer_; }
 
   inline Encoding::type dictionary_index_encoding() const {
     if (parquet_version_ == ParquetVersion::PARQUET_1_0) {
@@ -637,7 +632,7 @@ class PARQUET_EXPORT WriterProperties {
         parquet_data_page_version_(data_page_version),
         parquet_version_(version),
         parquet_created_by_(created_by),
-        store_short_decimal_as_integer_(store_short_decimal_as_integer),
+        store_decimal_as_integer_(store_short_decimal_as_integer),
         file_encryption_properties_(file_encryption_properties),
         default_column_properties_(default_column_properties),
         column_properties_(column_properties) {}
@@ -650,7 +645,7 @@ class PARQUET_EXPORT WriterProperties {
   ParquetDataPageVersion parquet_data_page_version_;
   ParquetVersion::type parquet_version_;
   std::string parquet_created_by_;
-  bool store_short_decimal_as_integer_;
+  bool store_decimal_as_integer_;
 
   std::shared_ptr<FileEncryptionProperties> file_encryption_properties_;
 


### PR DESCRIPTION
### What changes are included in this PR?

- Rename the function in the writer properties to `enable_short_decimal_stored_as_integer`.
- Rephrase the comment to explain the behavior in detail.