### PR TITLE
GH-31507: [Python] Address docstrings in Streams and File Access (Stream Classes)

### DIFF
--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1026,6 +1026,8 @@ cdef class OSFile(NativeFile):
 
     Examples
     --------
+    Create a new file to write to:
+
     >>> import pyarrow as pa
     >>> with pa.OSFile('example_osfile.arrow', mode='w') as f:
     ...     f.writable()
@@ -1035,12 +1037,18 @@ cdef class OSFile(NativeFile):
     True
     6
     False
+
+    Open the file to read:
+
     >>> with pa.OSFile('example_osfile.arrow', mode='r') as f:
     ...     f.mode
     ...     f.read()
     ...
     'rb'
     b'OSFile'
+
+    Inspect created OSFile:
+
     >>> pa.OSFile('example_osfile.arrow')
     <pyarrow.OSFile closed=False own_file=False is_seekable=True is_writable=False is_readable=True>
     """

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1068,6 +1068,22 @@ cdef class OSFile(NativeFile):
 cdef class FixedSizeBufferWriter(NativeFile):
     """
     A stream writing to a Arrow buffer.
+
+    Examples
+    --------
+    >>> import pyarrow as pa
+    >>> buf = pa.allocate_buffer(5)
+    >>> bit = b'abcde'
+    >>> writer = pa.FixedSizeBufferWriter(buf)
+    >>> writer.write(bit)
+    5
+    >>> buf.to_pybytes()
+    b'abcde'
+    >>> buf
+    <pyarrow.Buffer address=... size=5 is_cpu=True is_mutable=True>
+    >>> writer
+    <pyarrow.FixedSizeBufferWriter closed=False own_file=False is_seekable=False is_writable=True is_readable=False>
+    >>> writer.close()
     """
 
     def __cinit__(self, Buffer buffer):
@@ -1375,6 +1391,20 @@ def allocate_buffer(int64_t size, MemoryPool memory_pool=None,
 
 
 cdef class BufferOutputStream(NativeFile):
+    """
+    Examples
+    --------
+    >>> import pyarrow as pa
+    >>> f = pa.BufferOutputStream()
+    >>> f.write(b'pyarrow.Buffer')
+    14
+    >>> f.closed
+    False
+    >>> f.getvalue()
+    <pyarrow.Buffer address=... size=14 is_cpu=True is_mutable=True>
+    >>> f.closed
+    True
+    """
 
     cdef:
         shared_ptr[CResizableBuffer] buffer
@@ -1416,6 +1446,26 @@ cdef class BufferReader(NativeFile):
     Parameters
     ----------
     obj : Python bytes or pyarrow.Buffer
+
+    Examples
+    --------
+
+    >>> import pyarrow as pa
+    >>> data = b'reader data'
+    >>> f = pa.BufferReader(data)
+    >>> f.size()
+    11
+    >>> f.read(6)
+    b'reader'
+    >>> f.seek(7)
+    7
+    >>> f.read(15)
+    b'data'
+    >>> f.closed
+    False
+    >>> f.close()
+    >>> f.closed
+    True
     """
     cdef:
         Buffer buffer

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1421,8 +1421,9 @@ def allocate_buffer(int64_t size, MemoryPool memory_pool=None,
 
 cdef class BufferOutputStream(NativeFile):
     """
-    An output stream which writes data in-memory producing a pyarrow.Buffer
-    as a result when ``get.value()`` is called.
+    An output stream that writes to a resizable buffer.
+
+    The buffer is produced as a result when ``get.value()`` is called.
 
     Examples
     --------

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1542,7 +1542,15 @@ cdef class CompressedInputStream(NativeFile):
     buffer with compressed data:
 
     >>> cdata = raw.getvalue()
-    >>> raw = pa.input_stream(cdata)
+    >>> with pa.input_stream(cdata, compression="gzip") as compressed:
+    ...     compressed.read()
+    ...
+    b'Compressed stream'
+
+    which actually translates to the use of ``BufferReader``and
+    ``CompressedInputStream``:
+
+    >>> raw = pa.BufferReader(cdata)
     >>> with pa.CompressedInputStream(raw, "gzip") as compressed:
     ...     compressed.read()
     ...

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1083,9 +1083,8 @@ cdef class FixedSizeBufferWriter(NativeFile):
     --------
     >>> import pyarrow as pa
     >>> buf = pa.allocate_buffer(5)
-    >>> bit = b'abcde'
     >>> writer = pa.FixedSizeBufferWriter(buf)
-    >>> writer.write(bit)
+    >>> writer.write(b'abcde')
     5
     >>> buf.to_pybytes()
     b'abcde'

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1416,8 +1416,14 @@ def allocate_buffer(int64_t size, MemoryPool memory_pool=None,
 
 cdef class BufferOutputStream(NativeFile):
     """
+    An output stream which writes data in-memory producing a pyarrow.Buffer
+    as a result when ``get.value()`` is called.
+
     Examples
     --------
+    Create an output stream, write data to it and finalize it with
+    ``get.value()``:
+
     >>> import pyarrow as pa
     >>> f = pa.BufferOutputStream()
     >>> f.write(b'pyarrow.Buffer')

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -782,6 +782,34 @@ cdef class PythonFile(NativeFile):
     >>> import pyarrow as pa
     >>> pa.PythonFile(io.BytesIO())
     <pyarrow.PythonFile closed=False own_file=False is_seekable=False is_writable=True is_readable=False>
+
+    Create a stream for writing:
+
+    >>> buf = io.BytesIO()
+    >>> f =  pa.PythonFile(buf, mode = 'w')
+    >>> f.writable()
+    True
+    >>> f.write(b'PythonFile')
+    10
+    >>> buf.getvalue()
+    b'PythonFile'
+    >>> f.close()
+    >>> f
+    <pyarrow.PythonFile closed=True own_file=False is_seekable=False is_writable=True is_readable=False>
+
+    Create a stream for reading:
+
+    >>> buf = io.BytesIO(b'PythonFile')
+    >>> f =  pa.PythonFile(buf, mode = 'r')
+    >>> f.mode
+    'rb'
+    >>> f.read()
+    b'PythonFile'
+    >>> f
+    <pyarrow.PythonFile closed=False own_file=False is_seekable=True is_writable=False is_readable=True>
+    >>> f.close()
+    >>> f
+    <pyarrow.PythonFile closed=True own_file=False is_seekable=True is_writable=False is_readable=True>
     """
     cdef:
         object handle
@@ -978,6 +1006,26 @@ def create_memory_map(path, size):
 cdef class OSFile(NativeFile):
     """
     A stream backed by a regular file descriptor.
+
+    Examples
+    --------
+    >>> import pyarrow as pa
+    >>> with pa.OSFile('example_osfile.arrow', mode='w') as f:
+    ...     f.writable()
+    ...     f.write(b'OSFile')
+    ...     f.seekable()
+    ...
+    True
+    6
+    False
+    >>> with pa.OSFile('example_osfile.arrow', mode='r') as f:
+    ...     f.mode
+    ...     f.read()
+    ...
+    'rb'
+    b'OSFile'
+    >>> pa.OSFile('example_osfile.arrow')
+    <pyarrow.OSFile closed=False own_file=False is_seekable=True is_writable=False is_readable=True>
     """
     cdef:
         object path

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -879,6 +879,16 @@ cdef class MemoryMappedFile(NativeFile):
     A stream that represents a memory-mapped file.
 
     Supports 'r', 'r+', 'w' modes.
+
+    Examples
+    --------
+    Create a MemoryMappedFile:
+
+    >>> import pyarrow as pa
+    >>> mmap = pa.create_memory_map('example_mmap.dat', 10)
+    >>> mmap
+    <pyarrow.MemoryMappedFile closed=False own_file=False is_seekable=True is_writable=True is_readable=True>
+    >>> mmap.close()
     """
     cdef:
         shared_ptr[CMemoryMappedFile] handle
@@ -1491,6 +1501,22 @@ cdef class CompressedInputStream(NativeFile):
         Input stream object to wrap with the compression.
     compression : str
         The compression type ("bz2", "brotli", "gzip", "lz4" or "zstd").
+
+    Examples
+    --------
+    >>> import pyarrow as pa
+    >>> data = b"Compressed stream"
+    >>> raw = pa.BufferOutputStream()
+    >>> with pa.CompressedOutputStream(raw, "gzip") as compressed:
+    ...     compressed.write(data)
+    ...
+    17
+    >>> cdata = raw.getvalue()
+    >>> raw = pa.BufferReader(cdata)
+    >>> with pa.CompressedInputStream(raw, "gzip") as compressed:
+    ...     compressed.read()
+    ...
+    b'Compressed stream'
     """
 
     def __init__(self, object stream, str compression not None):
@@ -1518,6 +1544,16 @@ cdef class CompressedOutputStream(NativeFile):
         Input stream object to wrap with the compression.
     compression : str
         The compression type ("bz2", "brotli", "gzip", "lz4" or "zstd").
+
+    Examples
+    --------
+    >>> import pyarrow as pa
+    >>> data = b"Compressed stream"
+    >>> raw = pa.BufferOutputStream()
+    >>> with pa.CompressedOutputStream(raw, "gzip") as compressed:
+    ...     compressed.write(data)
+    ...
+    17
     """
 
     def __init__(self, object stream, str compression not None):

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -882,13 +882,20 @@ cdef class MemoryMappedFile(NativeFile):
 
     Examples
     --------
-    Create a MemoryMappedFile:
+    Create a new file with memory map:
 
     >>> import pyarrow as pa
     >>> mmap = pa.create_memory_map('example_mmap.dat', 10)
     >>> mmap
     <pyarrow.MemoryMappedFile closed=False own_file=False is_seekable=True is_writable=True is_readable=True>
     >>> mmap.close()
+
+    Open an existing file with memory map:
+
+    >>> with pa.memory_map('example_mmap.dat') as mmap:
+    ...     mmap
+    ...
+    <pyarrow.MemoryMappedFile closed=False own_file=False is_seekable=True is_writable=False is_readable=True>
     """
     cdef:
         shared_ptr[CMemoryMappedFile] handle


### PR DESCRIPTION

### Rationale for this change
Ensure docstrings for [Streams and File Access](https://arrow.apache.org/docs/python/api/files.html) - Stream Classes - have an Examples section.

### What changes are included in this PR?
Docstrings are added to listed Stream Classes:
- OSFile
- PythonFile
- BufferReader
- BufferOutputStream
- FixedSizeBufferWriter
- MemoryMappedFile
- CompressedInputStream
- CompressedOutputStream

### Are these changes tested?
Yes, locally with `pytest --doctest-cython --disable-warnings pyarrow` and on the CI with `Python / AMD64 Conda Python 3.9 Sphinx & Numpydoc` build.

### Are there any user-facing changes?
No.
* Closes: #31507