### PR TITLE
GH-25633: [CI][Java][macOS] Ensure using bundled RE2

### DIFF
--- a/ci/scripts/java_jni_macos_build.sh
+++ b/ci/scripts/java_jni_macos_build.sh
@@ -133,6 +133,7 @@ archery linking check-dependencies \
   --allow libcurl \
   --allow libgandiva_jni \
   --allow libncurses \
+  --allow libobjc \
   --allow libplasma_java \
   --allow libz \
   libarrow_cdata_jni.dylib \

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -86,6 +86,7 @@ jobs:
           # If llvm is installed, Apache Arrow C++ uses llvm rather than
           # llvm@14 because llvm is newer than llvm@14.
           brew uninstall llvm || :
+
           brew bundle --file=arrow/cpp/Brewfile
           # We want to link aws-sdk-cpp statically but Homebrew's
           # aws-sdk-cpp provides only shared library. If we have
@@ -93,6 +94,12 @@ jobs:
           # aws-sdk-cpp and bundled aws-sdk-cpp. We uninstall Homebrew's
           # aws-sdk-cpp to ensure using only bundled aws-sdk-cpp.
           brew uninstall aws-sdk-cpp
+          # We want to use bundled RE2 for static linking. If
+          # Homebrew's RE2 is installed, its header file may be used.
+          # We uninstall Homebrew's RE2 to ensure using bundled RE2.
+          brew uninstall grpc || : # gRPC depends on RE2
+          brew uninstall re2 || :
+
           brew bundle --file=arrow/java/Brewfile
       - name: Build C++ libraries
         env:


### PR DESCRIPTION
### Rationale for this change

If we have Homebrew's RE2, we may mix re2.h from Homebrew's RE2 and bundled RE2.
If we mix re2.h and libre2.a, we may generate wrong re2::RE2::Options. It may crashes our program.

### What changes are included in this PR?

Ensure removing Homebrew's RE2.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #25633