### PR TITLE
GH-33726: [CI][Go] Set host name in Go benchmarks

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -96,6 +96,7 @@ jobs:
           CONBENCH_EMAIL: ${{ secrets.CONBENCH_EMAIL }}
           CONBENCH_PASSWORD: ${{ secrets.CONBENCH_PASS }}
           CONBENCH_REF: ${{ github.ref_name }}
+          CONBENCH_MACHINE_INFO_NAME: amd64-debian-11
         run: |
           pip install benchadapt@git+https://github.com/conbench/conbench.git@main#subdirectory=benchadapt/python
           python ci/scripts/go_bench_adapt.py
@@ -266,6 +267,7 @@ jobs:
           CONBENCH_EMAIL: ${{ secrets.CONBENCH_EMAIL }}
           CONBENCH_PASSWORD: ${{ secrets.CONBENCH_PASS }}
           CONBENCH_REF: ${{ github.ref_name }}
+          CONBENCH_MACHINE_INFO_NAME: amd64-macos-11
         run: |
           pip install benchadapt@git+https://github.com/conbench/conbench.git@main#subdirectory=benchadapt/python
           python ci/scripts/go_bench_adapt.py


### PR DESCRIPTION
Closes #33726; see issue for comprehensive explanation. cc @zeroshade 

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Go benchmarks are sending host names from runners that vary slightly, preventing us from seeing the full history of the benchmarks on Conbench.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Sets host name in Go benchmarks via environment variable so benchmark history will be available on Conbench.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, for the benchadapt code that will pick it up: https://github.com/conbench/conbench/blob/main/benchadapt/python/tests/test_result.py#L107-L114

### Are there any user-facing changes?

No
* Closes: #33726