### PR TITLE
GH-33209: [C++] Support for reading JSON Datasets

### DIFF
--- a/cpp/src/arrow/dataset/CMakeLists.txt
+++ b/cpp/src/arrow/dataset/CMakeLists.txt
@@ -46,6 +46,10 @@ if(ARROW_CSV)
   set(ARROW_DATASET_SRCS ${ARROW_DATASET_SRCS} file_csv.cc)
 endif()
 
+if(ARROW_JSON)
+  set(ARROW_DATASET_SRCS ${ARROW_DATASET_SRCS} file_json.cc)
+endif()
+
 if(ARROW_ORC)
   set(ARROW_DATASET_SRCS ${ARROW_DATASET_SRCS} file_orc.cc)
 endif()
@@ -146,6 +150,10 @@ add_arrow_dataset_test(scanner_test)
 
 if(ARROW_CSV)
   add_arrow_dataset_test(file_csv_test)
+endif()
+
+if(ARROW_JSON)
+  add_arrow_dataset_test(file_json_test)
 endif()
 
 if(ARROW_ORC)

--- a/cpp/src/arrow/dataset/file_json.cc
+++ b/cpp/src/arrow/dataset/file_json.cc
@@ -1,0 +1,291 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/dataset/file_json.h"
+#include "arrow/dataset/dataset_internal.h"
+#include "arrow/io/buffered.h"
+#include "arrow/json/chunker.h"
+#include "arrow/json/parser.h"
+#include "arrow/json/reader.h"
+#include "arrow/util/checked_cast.h"
+#include "arrow/util/logging.h"
+
+namespace arrow {
+
+using internal::checked_cast;
+using internal::checked_pointer_cast;
+
+namespace dataset {
+
+namespace {
+
+using ReaderPtr = std::shared_ptr<json::StreamingReader>;
+
+Result<std::shared_ptr<StructType>> ParseToStructType(
+    std::string_view data, const json::ParseOptions& parse_options, MemoryPool* pool) {
+  if (!pool) pool = default_memory_pool();
+
+  auto full_buffer = std::make_shared<Buffer>(data);
+  std::shared_ptr<Buffer> buffer, partial;
+  auto chunker = json::MakeChunker(parse_options);
+  RETURN_NOT_OK(chunker->Process(full_buffer, &buffer, &partial));
+
+  std::unique_ptr<json::BlockParser> parser;
+  RETURN_NOT_OK(json::BlockParser::Make(pool, parse_options, &parser));
+  RETURN_NOT_OK(parser->Parse(buffer));
+  std::shared_ptr<Array> parsed;
+  RETURN_NOT_OK(parser->Finish(&parsed));
+
+  return checked_pointer_cast<StructType>(parsed->type());
+}
+
+Result<std::shared_ptr<Schema>> ParseToSchema(std::string_view data,
+                                              const json::ParseOptions& parse_options,
+                                              MemoryPool* pool) {
+  ARROW_ASSIGN_OR_RAISE(auto type, ParseToStructType(data, parse_options, pool));
+  return ::arrow::schema(type->fields());
+}
+
+// Converts a FieldPath to a FieldRef consisting exclusively of field names.
+//
+// The resulting FieldRef can be used to lookup the corresponding field in any schema
+// regardless of missing/unordered fields. The input path is assumed to be valid for the
+// given schema.
+FieldRef ToUniversalRef(const FieldPath& path, const Schema& schema) {
+  std::vector<FieldRef> refs;
+  refs.reserve(path.indices().size());
+
+  const FieldVector* fields = &schema.fields();
+  for (auto it = path.begin(); it != path.end(); ++it) {
+    DCHECK_LT(*it, static_cast<int>(fields->size()));
+    const auto& child_field = *(*fields)[*it];
+    refs.push_back(FieldRef(child_field.name()));
+    if (it + 1 != path.end()) {
+      auto&& child_type = checked_cast<const StructType&>(*child_field.type());
+      fields = &child_type.fields();
+    }
+  }
+
+  return refs.empty()       ? FieldRef()
+         : refs.size() == 1 ? refs[0]
+                            : FieldRef(std::move(refs));
+}
+
+int TopLevelIndex(const FieldRef& ref, const Schema& schema) {
+  if (const auto* name = ref.name()) {
+    return schema.GetFieldIndex(*name);
+  } else if (const auto* path = ref.field_path()) {
+    DCHECK(!path->empty());
+    return (*path)[0];
+  }
+  const auto* nested_refs = ref.nested_refs();
+  DCHECK(nested_refs && !nested_refs->empty());
+  return TopLevelIndex((*nested_refs)[0], schema);
+}
+
+// Make a new schema consisting only of the top-level fields in the dataset schema that:
+//  (a) Have children that require materialization
+//  (b) Have children present in `physical_schema`
+//
+// The resulting schema can be used in reader instantiation to ignore unused fields. Note
+// that `physical_schema` is only of structural importance and its data types are ignored
+// when constructing the final schema.
+Result<std::shared_ptr<Schema>> GetPartialSchema(const ScanOptions& scan_options,
+                                                 const Schema& physical_schema) {
+  auto dataset_schema = scan_options.dataset_schema;
+  DCHECK_NE(dataset_schema, nullptr);
+  const auto max_num_fields = static_cast<size_t>(dataset_schema->num_fields());
+
+  std::vector<bool> selected(max_num_fields, false);
+  std::vector<int> toplevel_indices;
+  toplevel_indices.reserve(max_num_fields);
+
+  for (const auto& ref : scan_options.MaterializedFields()) {
+    auto index = TopLevelIndex(ref, *dataset_schema);
+    DCHECK_GE(index, 0);
+    if (selected[index]) continue;
+
+    // Determine if the field exists in the physical schema before selecting it
+    bool found;
+    if (!ref.IsNested()) {
+      const auto& name = dataset_schema->field(index)->name();
+      found = physical_schema.GetFieldIndex(name) != -1;
+    } else {
+      // Check if the nested field is present in the physical schema. If so, we load its
+      // entire top-level field
+      ARROW_ASSIGN_OR_RAISE(auto path, ref.FindOne(*dataset_schema));
+      auto universal_ref = ToUniversalRef(path, *dataset_schema);
+      ARROW_ASSIGN_OR_RAISE(auto match, universal_ref.FindOneOrNone(physical_schema));
+      found = !match.empty();
+    }
+
+    if (!found) continue;
+
+    toplevel_indices.push_back(index);
+    selected[index] = true;
+    // All fields in the dataset schema require materialization, so return early
+    if (toplevel_indices.size() == max_num_fields) {
+      return dataset_schema;
+    }
+  }
+
+  FieldVector fields;
+  fields.reserve(toplevel_indices.size());
+  std::sort(toplevel_indices.begin(), toplevel_indices.end());
+  for (auto index : toplevel_indices) {
+    fields.push_back(dataset_schema->field(index));
+  }
+
+  return ::arrow::schema(std::move(fields));
+}
+
+Result<std::shared_ptr<JsonFragmentScanOptions>> GetJsonFormatOptions(
+    const JsonFileFormat& format, const ScanOptions* scan_options) {
+  return GetFragmentScanOptions<JsonFragmentScanOptions>(
+      kJsonTypeName, scan_options, format.default_fragment_scan_options);
+}
+
+Result<Future<ReaderPtr>> DoOpenReader(
+    const FileSource& source, const JsonFileFormat& format,
+    const std::shared_ptr<ScanOptions>& scan_options = nullptr) {
+  ARROW_ASSIGN_OR_RAISE(auto json_options,
+                        GetJsonFormatOptions(format, scan_options.get()));
+
+  struct State {
+    State(const JsonFragmentScanOptions& json_options,
+          const std::shared_ptr<ScanOptions>& scan_options)
+        : parse_options(json_options.parse_options),
+          read_options(json_options.read_options),
+          scan_options(scan_options) {
+      // We selectively ignore some user options, primarily those that will influence the
+      // output schema.
+      parse_options.explicit_schema = nullptr;
+      parse_options.unexpected_field_behavior = json::UnexpectedFieldBehavior::InferType;
+      // We don't wish to contend with the scanner's CPU threads if multiple fragments are
+      // being scanned in parallel, so fragment-level parallelism gets conditionally
+      // disabled.
+      if (this->scan_options && this->scan_options->use_threads) {
+        read_options.use_threads = false;
+      }
+    }
+    json::ParseOptions parse_options;
+    json::ReadOptions read_options;
+    std::shared_ptr<const ScanOptions> scan_options;
+    std::shared_ptr<io::InputStream> stream;
+  };
+
+  auto state = std::make_shared<State>(*json_options, scan_options);
+  ARROW_ASSIGN_OR_RAISE(state->stream, source.OpenCompressed());
+  ARROW_ASSIGN_OR_RAISE(
+      state->stream,
+      io::BufferedInputStream::Create(state->read_options.block_size,
+                                      default_memory_pool(), std::move(state->stream)));
+
+  auto maybe_future = state->stream->io_context().executor()->Submit(
+      [state = std::move(state)]() -> Future<ReaderPtr> {
+        if (state->scan_options && state->scan_options->dataset_schema) {
+          // Inspect the first block before anything else, so we can derive an explicit
+          // schema for the reader based on the dataset schema.
+          ARROW_ASSIGN_OR_RAISE(auto first_block,
+                                state->stream->Peek(state->read_options.block_size));
+          ARROW_ASSIGN_OR_RAISE(auto physical_schema,
+                                ParseToSchema(first_block, state->parse_options,
+                                              state->scan_options->pool));
+          ARROW_ASSIGN_OR_RAISE(state->parse_options.explicit_schema,
+                                GetPartialSchema(*state->scan_options, *physical_schema));
+          state->parse_options.unexpected_field_behavior =
+              json::UnexpectedFieldBehavior::Ignore;
+        }
+        return json::StreamingReader::MakeAsync(
+            std::move(state->stream), state->read_options, state->parse_options);
+      });
+  ARROW_ASSIGN_OR_RAISE(auto future, maybe_future);
+  return future.Then([](const ReaderPtr& reader) -> Result<ReaderPtr> { return reader; },
+                     [path = source.path()](const Status& error) -> Result<ReaderPtr> {
+                       return error.WithMessage("Could not open JSON input source '",
+                                                path, "': ", error);
+                     });
+}
+
+Future<ReaderPtr> OpenReaderAsync(
+    const FileSource& source, const JsonFileFormat& format,
+    const std::shared_ptr<ScanOptions>& scan_options = nullptr) {
+  return DeferNotOk(DoOpenReader(source, format, scan_options));
+}
+
+Result<ReaderPtr> OpenReader(const FileSource& source, const JsonFileFormat& format,
+                             const std::shared_ptr<ScanOptions>& scan_options = nullptr) {
+  return OpenReaderAsync(source, format, scan_options).result();
+}
+
+Result<RecordBatchGenerator> MakeBatchGenerator(
+    const JsonFileFormat& format, const std::shared_ptr<ScanOptions>& scan_options,
+    const std::shared_ptr<FileFragment>& file) {
+  ARROW_ASSIGN_OR_RAISE(auto future, DoOpenReader(file->source(), format, scan_options));
+  auto maybe_reader = future.result();
+  // Defer errors that occured during reader instantiation since they're likely related to
+  // batch-processing.
+  if (!maybe_reader.ok()) {
+    return MakeFailingGenerator<std::shared_ptr<RecordBatch>>(maybe_reader.status());
+  }
+  return [reader = *std::move(maybe_reader)] { return reader->ReadNextAsync(); };
+}
+
+}  // namespace
+
+JsonFileFormat::JsonFileFormat()
+    : FileFormat(std::make_shared<JsonFragmentScanOptions>()) {}
+
+bool JsonFileFormat::Equals(const FileFormat& other) const {
+  return type_name() == other.type_name();
+}
+
+Result<bool> JsonFileFormat::IsSupported(const FileSource& source) const {
+  RETURN_NOT_OK(source.Open().status());
+  return OpenReader(source, *this, nullptr).ok();
+}
+
+Result<std::shared_ptr<Schema>> JsonFileFormat::Inspect(const FileSource& source) const {
+  ARROW_ASSIGN_OR_RAISE(auto reader, OpenReader(source, *this));
+  return reader->schema();
+}
+
+Result<RecordBatchGenerator> JsonFileFormat::ScanBatchesAsync(
+    const std::shared_ptr<ScanOptions>& scan_options,
+    const std::shared_ptr<FileFragment>& file) const {
+  ARROW_ASSIGN_OR_RAISE(auto gen, MakeBatchGenerator(*this, scan_options, file));
+  return MakeChunkedBatchGenerator(std::move(gen), scan_options->batch_size);
+}
+
+Future<std::optional<int64_t>> JsonFileFormat::CountRows(
+    const std::shared_ptr<FileFragment>& file, compute::Expression predicate,
+    const std::shared_ptr<ScanOptions>& scan_options) {
+  if (ExpressionHasFieldRefs(predicate)) {
+    return Future<std::optional<int64_t>>::MakeFinished(std::nullopt);
+  }
+  ARROW_ASSIGN_OR_RAISE(auto gen, MakeBatchGenerator(*this, scan_options, file));
+  auto count = std::make_shared<int64_t>(0);
+  return VisitAsyncGenerator(std::move(gen),
+                             [count](const std::shared_ptr<RecordBatch>& batch) {
+                               *count += batch->num_rows();
+                               return Status::OK();
+                             })
+      .Then([count]() -> std::optional<int64_t> { return *count; });
+}
+
+}  // namespace dataset
+}  // namespace arrow

--- a/cpp/src/arrow/dataset/file_json.cc
+++ b/cpp/src/arrow/dataset/file_json.cc
@@ -103,8 +103,7 @@ class JsonFragmentScanner : public FragmentScanner {
         [num_batches, block_size](
             const ReaderPtr& reader) -> Result<std::shared_ptr<FragmentScanner>> {
           return std::make_shared<JsonFragmentScanner>(reader, num_batches, block_size);
-        },
-        [](const Status& e) -> Result<std::shared_ptr<FragmentScanner>> { return e; });
+        });
   }
 
  private:

--- a/cpp/src/arrow/dataset/file_json.cc
+++ b/cpp/src/arrow/dataset/file_json.cc
@@ -99,11 +99,10 @@ class JsonFragmentScanner : public FragmentScanner {
     auto future = json::StreamingReader::MakeAsync(
         inspected.stream, format_options.read_options, parse_options,
         io::default_io_context(), cpu_executor);
-    return future.Then(
-        [num_batches, block_size](
-            const ReaderPtr& reader) -> Result<std::shared_ptr<FragmentScanner>> {
-          return std::make_shared<JsonFragmentScanner>(reader, num_batches, block_size);
-        });
+    return future.Then([num_batches, block_size](const ReaderPtr& reader)
+                           -> Result<std::shared_ptr<FragmentScanner>> {
+      return std::make_shared<JsonFragmentScanner>(reader, num_batches, block_size);
+    });
   }
 
  private:

--- a/cpp/src/arrow/dataset/file_json.h
+++ b/cpp/src/arrow/dataset/file_json.h
@@ -1,0 +1,86 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "arrow/dataset/dataset.h"
+#include "arrow/dataset/file_base.h"
+#include "arrow/dataset/type_fwd.h"
+#include "arrow/dataset/visibility.h"
+#include "arrow/ipc/type_fwd.h"
+#include "arrow/json/options.h"
+#include "arrow/status.h"
+#include "arrow/util/compression.h"
+
+namespace arrow::dataset {
+
+/// \addtogroup dataset-file-formats
+///
+/// @{
+
+constexpr char kJsonTypeName[] = "json";
+
+/// \brief A FileFormat implementation that reads from JSON files
+class ARROW_DS_EXPORT JsonFileFormat : public FileFormat {
+ public:
+  JsonFileFormat();
+
+  std::string type_name() const override { return kJsonTypeName; }
+
+  bool Equals(const FileFormat& other) const override;
+
+  Result<bool> IsSupported(const FileSource& source) const override;
+
+  Result<std::shared_ptr<Schema>> Inspect(const FileSource& source) const override;
+
+  Result<RecordBatchGenerator> ScanBatchesAsync(
+      const std::shared_ptr<ScanOptions>& scan_options,
+      const std::shared_ptr<FileFragment>& file) const override;
+
+  Future<std::optional<int64_t>> CountRows(
+      const std::shared_ptr<FileFragment>& file, compute::Expression predicate,
+      const std::shared_ptr<ScanOptions>& scan_options) override;
+
+  Result<std::shared_ptr<FileWriter>> MakeWriter(
+      std::shared_ptr<io::OutputStream> destination, std::shared_ptr<Schema> schema,
+      std::shared_ptr<FileWriteOptions> options,
+      fs::FileLocator destination_locator) const override {
+    return Status::NotImplemented("Writing JSON files is not currently supported");
+  }
+
+  std::shared_ptr<FileWriteOptions> DefaultWriteOptions() override { return NULLPTR; }
+};
+
+/// \brief Per-scan options for JSON fragments
+struct ARROW_DS_EXPORT JsonFragmentScanOptions : public FragmentScanOptions {
+  std::string type_name() const override { return kJsonTypeName; }
+
+  /// @brief Options that affect JSON parsing
+  ///
+  /// Note: `explicit_schema` and `unexpected_field_behavior` are ignored.
+  json::ParseOptions parse_options = json::ParseOptions::Defaults();
+
+  /// @brief Options that affect JSON reading
+  json::ReadOptions read_options = json::ReadOptions::Defaults();
+};
+
+/// @}
+
+}  // namespace arrow::dataset

--- a/cpp/src/arrow/dataset/file_json.h
+++ b/cpp/src/arrow/dataset/file_json.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "arrow/dataset/dataset.h"
@@ -26,8 +27,10 @@
 #include "arrow/dataset/visibility.h"
 #include "arrow/ipc/type_fwd.h"
 #include "arrow/json/options.h"
+#include "arrow/result.h"
 #include "arrow/status.h"
-#include "arrow/util/compression.h"
+#include "arrow/util/future.h"
+#include "arrow/util/macros.h"
 
 namespace arrow::dataset {
 

--- a/cpp/src/arrow/dataset/file_json.h
+++ b/cpp/src/arrow/dataset/file_json.h
@@ -50,6 +50,15 @@ class ARROW_DS_EXPORT JsonFileFormat : public FileFormat {
 
   Result<std::shared_ptr<Schema>> Inspect(const FileSource& source) const override;
 
+  Future<std::shared_ptr<InspectedFragment>> InspectFragment(
+      const FileSource& source, const FragmentScanOptions* format_options,
+      compute::ExecContext* exec_context) const override;
+
+  Future<std::shared_ptr<FragmentScanner>> BeginScan(
+      const FragmentScanRequest& scan_request, const InspectedFragment& inspected,
+      const FragmentScanOptions* format_options,
+      compute::ExecContext* exec_context) const override;
+
   Result<RecordBatchGenerator> ScanBatchesAsync(
       const std::shared_ptr<ScanOptions>& scan_options,
       const std::shared_ptr<FileFragment>& file) const override;

--- a/cpp/src/arrow/dataset/file_json_test.cc
+++ b/cpp/src/arrow/dataset/file_json_test.cc
@@ -166,7 +166,7 @@ std::shared_ptr<FileSource> ToFileSource(std::string json) {
 template <typename T>
 class JsonScanMixin {
  public:
-  void TestCustomParseOptions() {
+  void TestScanWithCustomParseOptions() {
     auto source = ToFileSource("{\n\"i\":0\n}\n{\n\"i\":1\n}");
     auto fragment = this_->MakeFragment(*source);
     this_->SetSchema({field("i", int64())});
@@ -184,7 +184,7 @@ class JsonScanMixin {
     ASSERT_EQ(num_rows, 2);
   }
 
-  void TestCustomBlockSize() {
+  void TestScanWithCustomBlockSize() {
     auto source = ToFileSource("{\"i\":0}\n{\"i\":1}\n{\"i\":2}");
     auto fragment = this_->MakeFragment(*source);
     this_->SetSchema({field("i", int64())});
@@ -226,8 +226,8 @@ class TestJsonFormat
 class TestJsonFormatV2
     : public FileFormatFixtureMixinV2<JsonFormatHelper, json::kMaxParserNumRows> {};
 
-class TestJsonFormatScan : public FileFormatScanMixin<JsonFormatHelper>,
-                           public JsonScanMixin<TestJsonFormatScan> {
+class TestJsonScan : public FileFormatScanMixin<JsonFormatHelper>,
+                     public JsonScanMixin<TestJsonScan> {
  public:
   void SetJsonOptions(JsonFragmentScanOptions options = {}) {
     opts_->fragment_scan_options =
@@ -235,8 +235,8 @@ class TestJsonFormatScan : public FileFormatScanMixin<JsonFormatHelper>,
   }
 };
 
-class TestJsonFormatScanNode : public FileFormatScanNodeMixin<JsonFormatHelper>,
-                               public JsonScanMixin<TestJsonFormatScanNode> {
+class TestJsonScanNode : public FileFormatScanNodeMixin<JsonFormatHelper>,
+                         public JsonScanMixin<TestJsonScanNode> {
  public:
   void SetSchema(FieldVector fields) { SetDatasetSchema(std::move(fields)); }
 
@@ -277,40 +277,34 @@ TEST_F(TestJsonFormatV2, InspectFailureWithRelevantError) {
 TEST_F(TestJsonFormatV2, CountRows) { TestCountRows(); }
 
 // Common tests for old scanner
-TEST_P(TestJsonFormatScan, Scan) { TestScan(); }
-TEST_P(TestJsonFormatScan, ScanBatchSize) { TestScanBatchSize(); }
-TEST_P(TestJsonFormatScan, ScanProjected) { TestScanProjected(); }
-TEST_P(TestJsonFormatScan, ScanWithDuplicateColumnError) {
-  TestScanWithDuplicateColumnError();
-}
-TEST_P(TestJsonFormatScan, ScanWithVirtualColumn) { TestScanWithVirtualColumn(); }
-TEST_P(TestJsonFormatScan, ScanWithPushdownNulls) { TestScanWithPushdownNulls(); }
-TEST_P(TestJsonFormatScan, ScanProjectedMissingCols) { TestScanProjectedMissingCols(); }
-TEST_P(TestJsonFormatScan, ScanProjectedNested) { TestScanProjectedNested(); }
+TEST_P(TestJsonScan, Scan) { TestScan(); }
+TEST_P(TestJsonScan, ScanBatchSize) { TestScanBatchSize(); }
+TEST_P(TestJsonScan, ScanProjected) { TestScanProjected(); }
+TEST_P(TestJsonScan, ScanWithDuplicateColumnError) { TestScanWithDuplicateColumnError(); }
+TEST_P(TestJsonScan, ScanWithVirtualColumn) { TestScanWithVirtualColumn(); }
+TEST_P(TestJsonScan, ScanWithPushdownNulls) { TestScanWithPushdownNulls(); }
+TEST_P(TestJsonScan, ScanProjectedMissingCols) { TestScanProjectedMissingCols(); }
+TEST_P(TestJsonScan, ScanProjectedNested) { TestScanProjectedNested(); }
 // JSON-specific tests for old scanner
-TEST_P(TestJsonFormatScan, CustomParseOptions) { TestCustomParseOptions(); }
-TEST_P(TestJsonFormatScan, CustomBlockSize) { TestCustomBlockSize(); }
-TEST_P(TestJsonFormatScan, ScanWithParallelDecoding) { TestScanWithParallelDecoding(); }
+TEST_P(TestJsonScan, ScanWithCustomParseOptions) { TestScanWithCustomParseOptions(); }
+TEST_P(TestJsonScan, ScanWithCustomBlockSize) { TestScanWithCustomBlockSize(); }
+TEST_P(TestJsonScan, ScanWithParallelDecoding) { TestScanWithParallelDecoding(); }
 
-INSTANTIATE_TEST_SUITE_P(TestJsonScan, TestJsonFormatScan,
+INSTANTIATE_TEST_SUITE_P(TestJsonScan, TestJsonScan,
                          ::testing::ValuesIn(TestFormatParams::Values()),
                          TestFormatParams::ToTestNameString);
 
 // Common tests for new scanner
-TEST_P(TestJsonFormatScanNode, Scan) { TestScan(); }
-TEST_P(TestJsonFormatScanNode, ScanMissingFilterField) { TestScanMissingFilterField(); }
-TEST_P(TestJsonFormatScanNode, ScanProjected) { TestScanProjected(); }
-TEST_P(TestJsonFormatScanNode, ScanProjectedMissingColumns) {
-  TestScanProjectedMissingCols();
-}
+TEST_P(TestJsonScanNode, Scan) { TestScan(); }
+TEST_P(TestJsonScanNode, ScanMissingFilterField) { TestScanMissingFilterField(); }
+TEST_P(TestJsonScanNode, ScanProjected) { TestScanProjected(); }
+TEST_P(TestJsonScanNode, ScanProjectedMissingColumns) { TestScanProjectedMissingCols(); }
 // JSON-specific tests for new scanner
-TEST_P(TestJsonFormatScanNode, CustomParseOptions) { TestCustomParseOptions(); }
-TEST_P(TestJsonFormatScanNode, CustomBlockSize) { TestCustomBlockSize(); }
-TEST_P(TestJsonFormatScanNode, ScanWithParallelDecoding) {
-  TestScanWithParallelDecoding();
-}
+TEST_P(TestJsonScanNode, ScanWithCustomParseOptions) { TestScanWithCustomParseOptions(); }
+TEST_P(TestJsonScanNode, ScanWithCustomBlockSize) { TestScanWithCustomBlockSize(); }
+TEST_P(TestJsonScanNode, ScanWithParallelDecoding) { TestScanWithParallelDecoding(); }
 
-INSTANTIATE_TEST_SUITE_P(TestJsonScanNode, TestJsonFormatScanNode,
+INSTANTIATE_TEST_SUITE_P(TestJsonScanNode, TestJsonScanNode,
                          ::testing::ValuesIn(TestFormatParams::Values()),
                          TestFormatParams::ToTestNameString);
 

--- a/cpp/src/arrow/dataset/file_json_test.cc
+++ b/cpp/src/arrow/dataset/file_json_test.cc
@@ -191,6 +191,10 @@ class JsonScanMixin {
 
     JsonFragmentScanOptions json_options;
     json_options.parse_options.newlines_in_values = true;
+    // These options would raise errors if used, but they should be ignored
+    json_options.parse_options.explicit_schema = schema({field("x", utf8())});
+    json_options.parse_options.unexpected_field_behavior =
+        json::UnexpectedFieldBehavior::Error;
     this_->SetJsonOptions(std::move(json_options));
 
     int64_t num_rows = 0;

--- a/cpp/src/arrow/dataset/file_json_test.cc
+++ b/cpp/src/arrow/dataset/file_json_test.cc
@@ -17,7 +17,7 @@
 
 #include "arrow/dataset/file_json.h"
 
-#include "arrow/dataset/test_util.h"
+#include "arrow/dataset/test_util_internal.h"
 #include "arrow/filesystem/mockfs.h"
 #include "arrow/json/parser.h"
 #include "arrow/json/rapidjson_defs.h"

--- a/cpp/src/arrow/dataset/file_json_test.cc
+++ b/cpp/src/arrow/dataset/file_json_test.cc
@@ -1,0 +1,192 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/dataset/file_json.h"
+
+#include "arrow/dataset/test_util.h"
+#include "arrow/filesystem/mockfs.h"
+#include "arrow/json/parser.h"
+#include "arrow/json/rapidjson_defs.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/testing/util.h"
+
+#include "rapidjson/writer.h"
+
+namespace arrow {
+
+using internal::checked_cast;
+
+namespace dataset {
+
+namespace rj = arrow::rapidjson;
+
+#define CASE(TYPE_CLASS)                            \
+  case TYPE_CLASS##Type::type_id: {                 \
+    const TYPE_CLASS##Type* concrete_ptr = nullptr; \
+    return visitor->Visit(concrete_ptr);            \
+  }
+
+template <typename VISITOR>
+static Status VisitWriteableTypeId(Type::type id, VISITOR* visitor) {
+  switch (id) {
+    ARROW_GENERATE_FOR_ALL_NUMERIC_TYPES(CASE)
+    CASE(Boolean)
+    CASE(Struct)
+    default:
+      return Status::NotImplemented("TypeId: ", id);
+  }
+}
+
+#undef CASE
+
+// There's currently no proper API for writing JSON files, which is reflected in the JSON
+// dataset API as well. However, this ad-hoc implementation is good enough for the shared
+// format test fixtures
+struct WriteVisitor {
+  static Status OK(bool ok) { return ok ? Status::OK() : Status::Invalid(""); }
+
+  template <typename T>
+  enable_if_physical_signed_integer<T, Status> Visit(const T*) {
+    const auto& scalar = checked_cast<const NumericScalar<T>&>(scalar_);
+    return OK(writer_.Int64(scalar.value));
+  }
+
+  template <typename T>
+  enable_if_physical_unsigned_integer<T, Status> Visit(const T*) {
+    const auto& scalar = checked_cast<const NumericScalar<T>&>(scalar_);
+    return OK(writer_.Uint64(scalar.value));
+  }
+
+  template <typename T>
+  enable_if_physical_floating_point<T, Status> Visit(const T*) {
+    const auto& scalar = checked_cast<const NumericScalar<T>&>(scalar_);
+    return OK(writer_.Double(scalar.value));
+  }
+
+  Status Visit(const BooleanType*) {
+    const auto& scalar = checked_cast<const BooleanScalar&>(scalar_);
+    return OK(writer_.Bool(scalar.value));
+  }
+
+  Status Visit(const StructType*) {
+    const auto& scalar = checked_cast<const StructScalar&>(scalar_);
+    const auto& type = checked_cast<const StructType&>(*scalar.type);
+    DCHECK_EQ(type.num_fields(), static_cast<int>(scalar.value.size()));
+
+    RETURN_NOT_OK(OK(writer_.StartObject()));
+
+    for (int i = 0; i < type.num_fields(); ++i) {
+      const auto& name = type.field(i)->name();
+      RETURN_NOT_OK(
+          OK(writer_.Key(name.data(), static_cast<rj::SizeType>(name.length()))));
+
+      const auto& child = *scalar.value[i];
+      if (!child.is_valid) {
+        RETURN_NOT_OK(OK(writer_.Null()));
+        continue;
+      }
+
+      WriteVisitor visitor{writer_, child};
+      RETURN_NOT_OK(VisitWriteableTypeId(child.type->id(), &visitor));
+    }
+
+    RETURN_NOT_OK(OK(writer_.EndObject(type.num_fields())));
+    return Status::OK();
+  }
+
+  rj::Writer<rj::StringBuffer>& writer_;
+  const Scalar& scalar_;
+};
+
+Result<std::string> WriteJson(const StructScalar& scalar) {
+  rj::StringBuffer sink;
+  rj::Writer<rj::StringBuffer> writer(sink);
+  WriteVisitor visitor{writer, scalar};
+  RETURN_NOT_OK(VisitWriteableTypeId(Type::STRUCT, &visitor));
+  return sink.GetString();
+}
+
+class JsonFormatHelper {
+ public:
+  using FormatType = JsonFileFormat;
+
+  static Result<std::shared_ptr<Buffer>> Write(RecordBatchReader* reader) {
+    ARROW_ASSIGN_OR_RAISE(auto scalars, ToScalars(reader));
+    std::string out;
+    for (const auto& scalar : scalars) {
+      ARROW_ASSIGN_OR_RAISE(auto json, WriteJson(*scalar));
+      out += json + "\n";
+    }
+    return Buffer::FromString(std::move(out));
+  }
+
+  static std::shared_ptr<FormatType> MakeFormat() {
+    return std::make_shared<FormatType>();
+  }
+
+ private:
+  static Result<std::vector<std::shared_ptr<StructScalar>>> ToScalars(
+      RecordBatchReader* reader) {
+    std::vector<std::shared_ptr<StructScalar>> scalars;
+    for (auto maybe_batch : *reader) {
+      ARROW_ASSIGN_OR_RAISE(auto batch, maybe_batch);
+      ARROW_ASSIGN_OR_RAISE(auto array, batch->ToStructArray());
+      for (int i = 0; i < array->length(); ++i) {
+        ARROW_ASSIGN_OR_RAISE(auto scalar, array->GetScalar(i));
+        scalars.push_back(checked_pointer_cast<StructScalar>(std::move(scalar)));
+      }
+    }
+    return scalars;
+  }
+};
+
+class TestJsonFormat
+    : public FileFormatFixtureMixin<JsonFormatHelper, json::kMaxParserNumRows> {};
+
+class TestJsonFormatScan : public FileFormatScanMixin<JsonFormatHelper> {};
+
+TEST_F(TestJsonFormat, Equals) {
+  JsonFileFormat format;
+  ASSERT_TRUE(format.Equals(JsonFileFormat()));
+  ASSERT_FALSE(format.Equals(DummyFileFormat()));
+}
+
+TEST_F(TestJsonFormat, IsSupported) { TestIsSupported(); }
+TEST_F(TestJsonFormat, Inspect) { TestInspect(); }
+TEST_F(TestJsonFormat, FragmentEquals) { TestFragmentEquals(); }
+TEST_F(TestJsonFormat, InspectFailureWithRelevantError) {
+  TestInspectFailureWithRelevantError(StatusCode::Invalid, "JSON");
+}
+TEST_F(TestJsonFormat, CountRows) { TestCountRows(); }
+
+TEST_P(TestJsonFormatScan, Scan) { TestScan(); }
+TEST_P(TestJsonFormatScan, ScanBatchSize) { TestScanBatchSize(); }
+TEST_P(TestJsonFormatScan, ScanProjected) { TestScanProjected(); }
+TEST_P(TestJsonFormatScan, ScanWithDuplicateColumnError) {
+  TestScanWithDuplicateColumnError();
+}
+TEST_P(TestJsonFormatScan, ScanWithVirtualColumn) { TestScanWithVirtualColumn(); }
+TEST_P(TestJsonFormatScan, ScanWithPushdownNulls) { TestScanWithPushdownNulls(); }
+TEST_P(TestJsonFormatScan, ScanProjectedMissingCols) { TestScanProjectedMissingCols(); }
+TEST_P(TestJsonFormatScan, ScanProjectedNested) { TestScanProjectedNested(); }
+
+INSTANTIATE_TEST_SUITE_P(TestJsonScan, TestJsonFormatScan,
+                         ::testing::ValuesIn(TestFormatParams::Values()),
+                         TestFormatParams::ToTestNameString);
+
+}  // namespace dataset
+}  // namespace arrow

--- a/cpp/src/arrow/dataset/file_json_test.cc
+++ b/cpp/src/arrow/dataset/file_json_test.cc
@@ -58,7 +58,10 @@ static Status VisitWriteableTypeId(Type::type id, VISITOR* visitor) {
 // dataset API as well. However, this ad-hoc implementation is good enough for the shared
 // format test fixtures
 struct WriteVisitor {
-  static Status OK(bool ok) { return ok ? Status::OK() : Status::Invalid("Unexpected false return from JSON writer"); }
+  static Status OK(bool ok) {
+    return ok ? Status::OK()
+              : Status::Invalid("Unexpected false return from JSON writer");
+  }
 
   template <typename T>
   enable_if_physical_signed_integer<T, Status> Visit(const T*) {

--- a/cpp/src/arrow/dataset/file_json_test.cc
+++ b/cpp/src/arrow/dataset/file_json_test.cc
@@ -17,6 +17,7 @@
 
 #include "arrow/dataset/file_json.h"
 
+#include "arrow/dataset/plan.h"
 #include "arrow/dataset/test_util_internal.h"
 #include "arrow/filesystem/mockfs.h"
 #include "arrow/json/parser.h"
@@ -159,6 +160,15 @@ class TestJsonFormat
 
 class TestJsonFormatScan : public FileFormatScanMixin<JsonFormatHelper> {};
 
+class TestJsonFormatScanNode : public FileFormatScanNodeMixin<JsonFormatHelper> {
+  void SetUp() override { internal::Initialize(); }
+
+  const FragmentScanOptions* GetFormatOptions() override { return &json_options_; }
+
+ protected:
+  JsonFragmentScanOptions json_options_;
+};
+
 TEST_F(TestJsonFormat, Equals) {
   JsonFileFormat format;
   ASSERT_TRUE(format.Equals(JsonFileFormat()));
@@ -185,6 +195,17 @@ TEST_P(TestJsonFormatScan, ScanProjectedMissingCols) { TestScanProjectedMissingC
 TEST_P(TestJsonFormatScan, ScanProjectedNested) { TestScanProjectedNested(); }
 
 INSTANTIATE_TEST_SUITE_P(TestJsonScan, TestJsonFormatScan,
+                         ::testing::ValuesIn(TestFormatParams::Values()),
+                         TestFormatParams::ToTestNameString);
+
+TEST_P(TestJsonFormatScanNode, Scan) { TestScan(); }
+TEST_P(TestJsonFormatScanNode, ScanMissingFilterField) { TestScanMissingFilterField(); }
+TEST_P(TestJsonFormatScanNode, ScanProjected) { TestScanProjected(); }
+TEST_P(TestJsonFormatScanNode, ScanProjectedMissingColumns) {
+  TestScanProjectedMissingCols();
+}
+
+INSTANTIATE_TEST_SUITE_P(TestJsonScanNode, TestJsonFormatScanNode,
                          ::testing::ValuesIn(TestFormatParams::Values()),
                          TestFormatParams::ToTestNameString);
 

--- a/cpp/src/arrow/dataset/file_json_test.cc
+++ b/cpp/src/arrow/dataset/file_json_test.cc
@@ -58,7 +58,7 @@ static Status VisitWriteableTypeId(Type::type id, VISITOR* visitor) {
 // dataset API as well. However, this ad-hoc implementation is good enough for the shared
 // format test fixtures
 struct WriteVisitor {
-  static Status OK(bool ok) { return ok ? Status::OK() : Status::Invalid(""); }
+  static Status OK(bool ok) { return ok ? Status::OK() : Status::Invalid("Unexpected false return from JSON writer"); }
 
   template <typename T>
   enable_if_physical_signed_integer<T, Status> Visit(const T*) {

--- a/cpp/src/arrow/dataset/test_util_internal.h
+++ b/cpp/src/arrow/dataset/test_util_internal.h
@@ -377,11 +377,13 @@ class FileFormatWriterMixin {
 /// FormatHelper should be a class with these static methods:
 /// std::shared_ptr<Buffer> Write(RecordBatchReader* reader);
 /// std::shared_ptr<FileFormat> MakeFormat();
-template <typename FormatHelper>
+template <typename FormatHelper, int64_t MaxNumRows = -1>
 class FileFormatFixtureMixin : public ::testing::Test {
  public:
-  constexpr static int64_t kBatchSize = 1UL << 12;
   constexpr static int64_t kBatchRepetitions = 1 << 5;
+  constexpr static int64_t kBatchSize =
+      MaxNumRows < 0 ? 1UL << 12 : MaxNumRows / kBatchRepetitions;
+  static_assert(kBatchSize > 0);
 
   FileFormatFixtureMixin()
       : format_(FormatHelper::MakeFormat()), opts_(std::make_shared<ScanOptions>()) {}

--- a/cpp/src/arrow/dataset/test_util_internal.h
+++ b/cpp/src/arrow/dataset/test_util_internal.h
@@ -377,12 +377,11 @@ class FileFormatWriterMixin {
 /// FormatHelper should be a class with these static methods:
 /// std::shared_ptr<Buffer> Write(RecordBatchReader* reader);
 /// std::shared_ptr<FileFormat> MakeFormat();
-template <typename FormatHelper, int64_t MaxNumRows = -1>
+template <typename FormatHelper, int64_t MaxNumRows = (1UL << 17)>
 class FileFormatFixtureMixin : public ::testing::Test {
  public:
   constexpr static int64_t kBatchRepetitions = 1 << 5;
-  constexpr static int64_t kBatchSize =
-      MaxNumRows < 0 ? 1UL << 12 : MaxNumRows / kBatchRepetitions;
+  constexpr static int64_t kBatchSize = MaxNumRows / kBatchRepetitions;
   static_assert(kBatchSize > 0);
 
   FileFormatFixtureMixin()
@@ -937,11 +936,12 @@ class FileFormatScanMixin : public FileFormatFixtureMixin<FormatHelper>,
   using FileFormatFixtureMixin<FormatHelper>::opts_;
 };
 
-template <typename FormatHelper>
+template <typename FormatHelper, int64_t MaxNumRows = (1UL << 17)>
 class FileFormatFixtureMixinV2 : public ::testing::Test {
  public:
-  constexpr static int64_t kBatchSize = 1UL << 12;
   constexpr static int64_t kBatchRepetitions = 1 << 5;
+  constexpr static int64_t kBatchSize = MaxNumRows / kBatchRepetitions;
+  static_assert(kBatchSize > 0);
 
   FileFormatFixtureMixinV2()
       : format_(FormatHelper::MakeFormat()),
@@ -1051,7 +1051,7 @@ class FileFormatFixtureMixinV2 : public ::testing::Test {
         ::testing::AllOf(
             ::testing::HasSubstr(make_error_message("/herp/derp")),
             ::testing::HasSubstr(
-                "Error creating dataset. Could not read schema from '/herp/derp':"),
+                "Error creating dataset. Could not read schema from '/herp/derp'."),
             ::testing::HasSubstr("Is this a '" + format_->type_name() + "' file?")));
   }
 
@@ -1194,6 +1194,23 @@ class FileFormatScanNodeMixin : public FileFormatFixtureMixinV2<FormatHelper>,
         compute::DeclarationToReader(compute::Declaration("scan2", *opts_),
                                      GetParam().use_threads));
     return reader;
+  }
+
+  // Return a batch iterator which scans the fragment through the scanner.
+  //
+  // For interface compatibility with `FileFormatScanMixin`
+  RecordBatchIterator Batches(const std::shared_ptr<Fragment>& fragment,
+                              bool use_readahead = true) {
+    if (!use_readahead) {
+      opts_->target_bytes_readahead = 0;
+      opts_->fragment_readahead = 0;
+    }
+    EXPECT_OK_AND_ASSIGN(auto reader, this->Scan(fragment));
+    struct ReaderIterator {
+      Result<std::shared_ptr<RecordBatch>> Next() { return reader->Next(); }
+      std::unique_ptr<RecordBatchReader> reader;
+    };
+    return RecordBatchIterator(ReaderIterator{std::move(reader)});
   }
 
   // Shared test cases


### PR DESCRIPTION
This adds initial support the JSON file format to the Dataset library. Since there's currently no public API for writing JSON files, this only deals with the reader-side facilities.
* Closes: #33209