### PR TITLE
GH-33734: [Go] make compatible with grpc < 1.45

### DIFF
--- a/go/arrow/flight/server.go
+++ b/go/arrow/flight/server.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/apache/arrow/go/v11/arrow/flight/internal/flight"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/reflection"
 )
 
 type (
@@ -64,6 +63,24 @@ func RegisterFlightServiceServer(s grpc.ServiceRegistrar, srv FlightServer) {
 	flight.RegisterFlightServiceServer(s, srv)
 }
 
+// From https://github.com/grpc/grpc-go/blob/4c776ec01572d55249df309251900554b46adb41/reflection/serverreflection.go#L69-L83
+// See "google.golang.org/grpc/reflection" 's reflection.ServiceInfoProvider
+// ServiceInfoProvider is an interface used to retrieve metadata about the
+// services to expose.
+//
+// The reflection service is only interested in the service names, but the
+// signature is this way so that *grpc.Server implements it. So it is okay
+// for a custom implementation to return zero values for the
+// grpc.ServiceInfo values in the map.
+//
+// Experimental
+//
+// Notice: This type is EXPERIMENTAL and may be changed or removed in a
+// later release.
+type serviceInfoProvider interface {
+	GetServiceInfo() map[string]grpc.ServiceInfo
+}
+
 // Server is an interface for hiding some of the grpc specifics to make
 // it slightly easier to manage a flight service, slightly modeled after
 // the C++ implementation
@@ -94,9 +111,9 @@ type Server interface {
 	// ServiceRegistrar wraps a single method that supports service registration.
 	// For example, it may be used to register health check provided by grpc-go.
 	grpc.ServiceRegistrar
-	// ServiceInfoProvider is an interface used to retrieve metadata about the services to expose.
+	// serviceInfoProvider is an interface used to retrieve metadata about the services to expose.
 	// If reflection is enabled on the server, all the endpoints can be invoked using grpcurl.
-	reflection.ServiceInfoProvider
+	serviceInfoProvider
 }
 
 // BaseFlightServer is the base flight server implementation and must be

--- a/go/arrow/flight/server.go
+++ b/go/arrow/flight/server.go
@@ -64,8 +64,10 @@ func RegisterFlightServiceServer(s grpc.ServiceRegistrar, srv FlightServer) {
 }
 
 // From https://github.com/grpc/grpc-go/blob/4c776ec01572d55249df309251900554b46adb41/reflection/serverreflection.go#L69-L83
-// See "google.golang.org/grpc/reflection" 's reflection.ServiceInfoProvider
-// ServiceInfoProvider is an interface used to retrieve metadata about the
+// This interface is inlined to make this arrow library compatible with
+// grpc < 1.45 .
+// See "google.golang.org/grpc/reflection" 's reflection.ServiceInfoProvider .
+// serviceInfoProvider is an interface used to retrieve metadata about the
 // services to expose.
 //
 // The reflection service is only interested in the service names, but the


### PR DESCRIPTION
### Rationale for this change

Define interface from grpc/reflection rather than importing. The interface is marked as experiment, so defining it here is also a step toward improving stability of the go arrow library.

### What changes are included in this PR?

* As above, inlining the interface

### Are these changes tested?

I believe the the change is already tested via:
https://github.com/apache/arrow/blob/c8d6110a26c41966e539e9fa2f5cb8c31dc2f0fe/go/arrow/flight/flight_test.go#L325-L326
And also via confirming via reading https://github.com/grpc/grpc-go/blob/4e4d8288ff4fb99150a526165c767e6fac3bd5ec/Documentation/server-reflection-tutorial.md . However, I have not done any manual testing beyond this.

### Are there any user-facing changes?
No.

### Feedback requested
I'd pasted the code verbatim from: https://github.com/grpc/grpc-go/blob/4c776ec01572d55249df309251900554b46adb41/reflection/serverreflection.go#L69-L83

Should I have pasted only what's necessary and link to that code block instead?