### PR TITLE
PARQUET-2232: [C++]  Add an api to ColumnChunkMetaData to indicate if the column chunk uses a bloom filter

### DIFF
--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -279,7 +279,7 @@ class ColumnChunkMetaData::ColumnChunkMetaDataImpl {
   const std::vector<PageEncodingStats>& encoding_stats() const { return encoding_stats_; }
 
   inline std::optional<int64_t> bloom_filter_offset() const {
-    if(column_metadata_->__isset.bloom_filter_offset) {
+    if (column_metadata_->__isset.bloom_filter_offset) {
       return column_metadata_->bloom_filter_offset;
     }
     return std::nullopt;

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -278,8 +278,11 @@ class ColumnChunkMetaData::ColumnChunkMetaDataImpl {
 
   const std::vector<PageEncodingStats>& encoding_stats() const { return encoding_stats_; }
 
-  inline bool has_bloom_filter() const {
-    return column_metadata_->__isset.bloom_filter_offset;
+  inline std::optional<int64_t> bloom_filter_offset() const {
+    if(column_metadata_->__isset.bloom_filter_offset) {
+      return column_metadata_->bloom_filter_offset;
+    }
+    return std::nullopt;
   }
 
   inline bool has_dictionary_page() const {
@@ -391,8 +394,8 @@ std::shared_ptr<Statistics> ColumnChunkMetaData::statistics() const {
 
 bool ColumnChunkMetaData::is_stats_set() const { return impl_->is_stats_set(); }
 
-bool ColumnChunkMetaData::has_bloom_filter() const {
-  return impl_->has_bloom_filter();
+std::optional<int64_t> ColumnChunkMetaData::bloom_filter_offset() const {
+  return impl_->bloom_filter_offset();
 }
 
 bool ColumnChunkMetaData::has_dictionary_page() const {

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -278,6 +278,10 @@ class ColumnChunkMetaData::ColumnChunkMetaDataImpl {
 
   const std::vector<PageEncodingStats>& encoding_stats() const { return encoding_stats_; }
 
+  inline bool has_bloom_filter() const {
+    return column_metadata_->__isset.bloom_filter_offset;
+  }
+
   inline bool has_dictionary_page() const {
     return column_metadata_->__isset.dictionary_page_offset;
   }
@@ -386,6 +390,10 @@ std::shared_ptr<Statistics> ColumnChunkMetaData::statistics() const {
 }
 
 bool ColumnChunkMetaData::is_stats_set() const { return impl_->is_stats_set(); }
+
+bool ColumnChunkMetaData::has_bloom_filter() const {
+  return impl_->has_bloom_filter();
+}
 
 bool ColumnChunkMetaData::has_dictionary_page() const {
   return impl_->has_dictionary_page();

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -171,7 +171,7 @@ class PARQUET_EXPORT ColumnChunkMetaData {
 
   const std::vector<Encoding::type>& encodings() const;
   const std::vector<PageEncodingStats>& encoding_stats() const;
-  bool has_bloom_filter() const;
+  std::optional<int64_t> bloom_filter_offset() const;
   bool has_dictionary_page() const;
   int64_t dictionary_page_offset() const;
   int64_t data_page_offset() const;

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -171,6 +171,7 @@ class PARQUET_EXPORT ColumnChunkMetaData {
 
   const std::vector<Encoding::type>& encodings() const;
   const std::vector<PageEncodingStats>& encoding_stats() const;
+  bool has_bloom_filter() const;
   bool has_dictionary_page() const;
   int64_t dictionary_page_offset() const;
   int64_t data_page_offset() const;

--- a/cpp/src/parquet/metadata_test.cc
+++ b/cpp/src/parquet/metadata_test.cc
@@ -294,6 +294,18 @@ TEST(Metadata, TestKeyValueMetadata) {
   EXPECT_TRUE(f_accessor->key_value_metadata()->Equals(*kvmeta));
 }
 
+TEST(Metadata, TestHasBloomFilter) {
+  std::string dir_string(parquet::test::get_data_dir());
+  std::string path = dir_string + "/data_index_bloom_encoding_stats.parquet";
+  auto reader = ParquetFileReader::OpenFile(path, false);
+  auto file_metadata = reader->metadata();
+  ASSERT_EQ(1, file_metadata->num_row_groups());
+  auto row_group_metadata = file_metadata->RowGroup(0);
+  ASSERT_EQ(1, row_group_metadata->num_columns());
+  auto col_chunk_metadata = row_group_metadata->ColumnChunk(0);
+  ASSERT_TRUE(col_chunk_metadata->has_bloom_filter());
+}
+
 TEST(Metadata, TestReadPageIndex) {
   std::string dir_string(parquet::test::get_data_dir());
   std::string path = dir_string + "/alltypes_tiny_pages.parquet";
@@ -329,6 +341,7 @@ TEST(Metadata, TestReadPageIndex) {
     ASSERT_TRUE(oi_location.has_value());
     ASSERT_EQ(oi_offsets.at(i), oi_location->offset);
     ASSERT_EQ(oi_lengths.at(i), oi_location->length);
+    ASSERT_FALSE(col_chunk_metadata->has_bloom_filter());
   }
 }
 

--- a/cpp/src/parquet/metadata_test.cc
+++ b/cpp/src/parquet/metadata_test.cc
@@ -303,7 +303,9 @@ TEST(Metadata, TestHasBloomFilter) {
   auto row_group_metadata = file_metadata->RowGroup(0);
   ASSERT_EQ(1, row_group_metadata->num_columns());
   auto col_chunk_metadata = row_group_metadata->ColumnChunk(0);
-  ASSERT_TRUE(col_chunk_metadata->has_bloom_filter());
+  auto bloom_filter_offset = col_chunk_metadata->bloom_filter_offset();
+  ASSERT_TRUE(bloom_filter_offset.has_value());
+  ASSERT_EQ(192, bloom_filter_offset);
 }
 
 TEST(Metadata, TestReadPageIndex) {
@@ -341,7 +343,7 @@ TEST(Metadata, TestReadPageIndex) {
     ASSERT_TRUE(oi_location.has_value());
     ASSERT_EQ(oi_offsets.at(i), oi_location->offset);
     ASSERT_EQ(oi_lengths.at(i), oi_location->length);
-    ASSERT_FALSE(col_chunk_metadata->has_bloom_filter());
+    ASSERT_FALSE(col_chunk_metadata->bloom_filter_offset().has_value());
   }
 }
 


### PR DESCRIPTION
Although bloom filter is not fully supported in parquet-cpp for now, it can be useful to provide an api that tells if a column chunk is using bloom filters. This would lead to better understanding of file characteristics.

Changes are tested with unit tests.

Thanks.