### PR TITLE
GH-33754: [CI] Install brewfile dependencies for verification task jobs on M1

### DIFF
--- a/dev/tasks/verify-rc/github.macos.arm64.yml
+++ b/dev/tasks/verify-rc/github.macos.arm64.yml
@@ -43,6 +43,8 @@ jobs:
           TEST_DEFAULT: 0
           TEST_{{ target|upper }}: 1
         run: |
+          brew bundle --file=arrow/cpp/Brewfile
+          brew bundle --file=arrow/c_glib/Brewfile
           export PATH="$(brew --prefix node@16)/bin:$PATH"
           export PATH="$(brew --prefix ruby)/bin:$PATH"
           export PKG_CONFIG_PATH="$(brew --prefix ruby)/lib/pkgconfig"


### PR DESCRIPTION
### Rationale for this change

This should fix the verification job failures for M1

### What changes are included in this PR?

The PR ensure installation of our defined `Brewfile` dependencies as part of the verification tasks

### Are these changes tested?

Will be tested via crossbow tasks

### Are there any user-facing changes?

No
* Closes: #33754