### PR TITLE
MINOR: [C++][Docs] Fix broken URL in C++ Building docs

### DIFF
--- a/docs/source/developers/cpp/building.rst
+++ b/docs/source/developers/cpp/building.rst
@@ -298,7 +298,7 @@ Unity builds
 ~~~~~~~~~~~~
 
 The CMake
-`unity builds <https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html/>`_
+`unity builds <https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html>`_
 option can make full builds significantly faster, but it also increases the
 memory requirements.  Consider turning it on (using ``-DCMAKE_UNITY_BUILD=ON``)
 if memory consumption is not an issue.


### PR DESCRIPTION
### Rationale for this change

Prior to this change, a link in [Building Arrow C++](https://arrow.apache.org/docs/developers/cpp/building.html) to the CMake UNITY_BUILD docs 404s due to a typo. This change fixes that.

### Are these changes tested?

No, this is a very minor change and I have a high level of confidence in it.

### Are there any user-facing changes?

No.