### PR TITLE
GH-33760: [R][C++] Handle nested field refs in scanner 

### DIFF
--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -460,8 +460,8 @@ ExecNode_output_schema <- function(node) {
   .Call(`_arrow_ExecNode_output_schema`, node)
 }
 
-ExecNode_Scan <- function(plan, dataset, filter, materialized_field_names) {
-  .Call(`_arrow_ExecNode_Scan`, plan, dataset, filter, materialized_field_names)
+ExecNode_Scan <- function(plan, dataset, filter, projection) {
+  .Call(`_arrow_ExecNode_Scan`, plan, dataset, filter, projection)
 }
 
 ExecPlan_Write <- function(plan, final_node, metadata, file_write_options, filesystem, base_dir, partitioning, basename_template, existing_data_behavior, max_partitions, max_open_files, max_rows_per_file, min_rows_per_group, max_rows_per_group) {
@@ -1086,10 +1086,6 @@ compute___expr__call <- function(func_name, argument_list, options) {
 
 compute___expr__is_field_ref <- function(x) {
   .Call(`_arrow_compute___expr__is_field_ref`, x)
-}
-
-field_names_in_expression <- function(x) {
-  .Call(`_arrow_field_names_in_expression`, x)
 }
 
 compute___expr__get_field_ref_name <- function(x) {
@@ -2095,3 +2091,4 @@ SetIOThreadPoolCapacity <- function(threads) {
 Array__infer_type <- function(x) {
   .Call(`_arrow_Array__infer_type`, x)
 }
+

--- a/r/R/query-engine.R
+++ b/r/R/query-engine.R
@@ -34,11 +34,7 @@ ExecPlan <- R6Class("ExecPlan",
         if (isTRUE(filter)) {
           filter <- Expression$scalar(TRUE)
         }
-        # Use FieldsInExpression to find all from dataset$selected_columns
-        colnames <- unique(unlist(map(
-          dataset$selected_columns,
-          field_names_in_expression
-        )))
+        projection <- dataset$selected_columns
         dataset <- dataset$.data
         assert_is(dataset, "Dataset")
       } else {
@@ -46,10 +42,10 @@ ExecPlan <- R6Class("ExecPlan",
         # Just a dataset, not a query, so there's no predicates to push down
         # so set some defaults
         filter <- Expression$scalar(TRUE)
-        colnames <- names(dataset)
+        projection <- make_field_refs(colnames)
       }
 
-      out <- ExecNode_Scan(self, dataset, filter, colnames %||% character(0))
+      out <- ExecNode_Scan(self, dataset, filter, projection)
       # Hold onto the source data's schema so we can preserve schema metadata
       # in the resulting Scan/Write
       out$extras$source_schema <- dataset$schema

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -990,18 +990,18 @@ END_CPP11
 }
 // compute-exec.cpp
 #if defined(ARROW_R_WITH_DATASET)
-std::shared_ptr<compute::ExecNode> ExecNode_Scan(const std::shared_ptr<compute::ExecPlan>& plan, const std::shared_ptr<ds::Dataset>& dataset, const std::shared_ptr<compute::Expression>& filter, std::vector<std::string> materialized_field_names);
-extern "C" SEXP _arrow_ExecNode_Scan(SEXP plan_sexp, SEXP dataset_sexp, SEXP filter_sexp, SEXP materialized_field_names_sexp){
+std::shared_ptr<compute::ExecNode> ExecNode_Scan(const std::shared_ptr<compute::ExecPlan>& plan, const std::shared_ptr<ds::Dataset>& dataset, const std::shared_ptr<compute::Expression>& filter, cpp11::list projection);
+extern "C" SEXP _arrow_ExecNode_Scan(SEXP plan_sexp, SEXP dataset_sexp, SEXP filter_sexp, SEXP projection_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<compute::ExecPlan>&>::type plan(plan_sexp);
 	arrow::r::Input<const std::shared_ptr<ds::Dataset>&>::type dataset(dataset_sexp);
 	arrow::r::Input<const std::shared_ptr<compute::Expression>&>::type filter(filter_sexp);
-	arrow::r::Input<std::vector<std::string>>::type materialized_field_names(materialized_field_names_sexp);
-	return cpp11::as_sexp(ExecNode_Scan(plan, dataset, filter, materialized_field_names));
+	arrow::r::Input<cpp11::list>::type projection(projection_sexp);
+	return cpp11::as_sexp(ExecNode_Scan(plan, dataset, filter, projection));
 END_CPP11
 }
 #else
-extern "C" SEXP _arrow_ExecNode_Scan(SEXP plan_sexp, SEXP dataset_sexp, SEXP filter_sexp, SEXP materialized_field_names_sexp){
+extern "C" SEXP _arrow_ExecNode_Scan(SEXP plan_sexp, SEXP dataset_sexp, SEXP filter_sexp, SEXP projection_sexp){
 	Rf_error("Cannot call ExecNode_Scan(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
 }
 #endif
@@ -2737,14 +2737,6 @@ extern "C" SEXP _arrow_compute___expr__is_field_ref(SEXP x_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<compute::Expression>&>::type x(x_sexp);
 	return cpp11::as_sexp(compute___expr__is_field_ref(x));
-END_CPP11
-}
-// expression.cpp
-std::vector<std::string> field_names_in_expression(const std::shared_ptr<compute::Expression>& x);
-extern "C" SEXP _arrow_field_names_in_expression(SEXP x_sexp){
-BEGIN_CPP11
-	arrow::r::Input<const std::shared_ptr<compute::Expression>&>::type x(x_sexp);
-	return cpp11::as_sexp(field_names_in_expression(x));
 END_CPP11
 }
 // expression.cpp
@@ -5587,7 +5579,6 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_compute___expr__equals", (DL_FUNC) &_arrow_compute___expr__equals, 2}, 
 		{ "_arrow_compute___expr__call", (DL_FUNC) &_arrow_compute___expr__call, 3}, 
 		{ "_arrow_compute___expr__is_field_ref", (DL_FUNC) &_arrow_compute___expr__is_field_ref, 1}, 
-		{ "_arrow_field_names_in_expression", (DL_FUNC) &_arrow_field_names_in_expression, 1}, 
 		{ "_arrow_compute___expr__get_field_ref_name", (DL_FUNC) &_arrow_compute___expr__get_field_ref_name, 1}, 
 		{ "_arrow_compute___expr__field_ref", (DL_FUNC) &_arrow_compute___expr__field_ref, 1}, 
 		{ "_arrow_compute___expr__nested_field_ref", (DL_FUNC) &_arrow_compute___expr__nested_field_ref, 2}, 

--- a/r/src/expression.cpp
+++ b/r/src/expression.cpp
@@ -52,25 +52,6 @@ bool compute___expr__is_field_ref(const std::shared_ptr<compute::Expression>& x)
 }
 
 // [[arrow::export]]
-std::vector<std::string> field_names_in_expression(
-    const std::shared_ptr<compute::Expression>& x) {
-  std::vector<std::string> out;
-  std::vector<arrow::FieldRef> nested;
-
-  auto field_refs = FieldsInExpression(*x);
-  for (auto f : field_refs) {
-    if (f.IsNested()) {
-      // We keep the top-level field name.
-      nested = *f.nested_refs();
-      out.push_back(*nested[0].name());
-    } else {
-      out.push_back(*f.name());
-    }
-  }
-  return out;
-}
-
-// [[arrow::export]]
 std::string compute___expr__get_field_ref_name(
     const std::shared_ptr<compute::Expression>& x) {
   if (auto field_ref = x->field_ref()) {

--- a/r/tests/testthat/test-dplyr-query.R
+++ b/r/tests/testthat/test-dplyr-query.R
@@ -742,6 +742,7 @@ test_that("Can use nested field refs", {
   )
 
   # Now with Dataset: make sure column pushdown in ScanNode works
+  skip_if_not_available("dataset")
   expect_equal(
     nested_data %>%
       InMemoryDataset$create() %>%


### PR DESCRIPTION
### Rationale for this change

Followup to https://github.com/apache/arrow/pull/19706/files#r1073391100 with the goal of deleting and simplifying some code. As it turned out, it was more about moving code from the R bindings to the C++ library.

### Are there any user-facing changes?

Not for R users, but this fixes a bug in the dataset C++ library where nested field refs could not be handled by the scanner.

* Closes: #33760