### PR TITLE
GH-15200: [C++] Add specific ndigits value for round

### DIFF
--- a/cpp/src/arrow/compute/api_scalar.cc
+++ b/cpp/src/arrow/compute/api_scalar.cc
@@ -330,6 +330,8 @@ static auto kReplaceSubstringOptionsType =
 static auto kRoundOptionsType = GetFunctionOptionsType<RoundOptions>(
     DataMember("ndigits", &RoundOptions::ndigits),
     DataMember("round_mode", &RoundOptions::round_mode));
+static auto kRoundBinaryOptionsType = GetFunctionOptionsType<RoundBinaryOptions>(
+    DataMember("round_mode", &RoundBinaryOptions::round_mode));
 static auto kRoundTemporalOptionsType = GetFunctionOptionsType<RoundTemporalOptions>(
     DataMember("multiple", &RoundTemporalOptions::multiple),
     DataMember("unit", &RoundTemporalOptions::unit),
@@ -497,6 +499,22 @@ RoundOptions::RoundOptions(int64_t ndigits, RoundMode round_mode)
                 "enumerated last with HALF_DOWN being the first among them.");
 }
 constexpr char RoundOptions::kTypeName[];
+
+RoundBinaryOptions::RoundBinaryOptions(RoundMode round_mode)
+    : FunctionOptions(internal::kRoundBinaryOptionsType), round_mode(round_mode) {
+  static_assert(RoundMode::HALF_DOWN > RoundMode::DOWN &&
+                    RoundMode::HALF_DOWN > RoundMode::UP &&
+                    RoundMode::HALF_DOWN > RoundMode::TOWARDS_ZERO &&
+                    RoundMode::HALF_DOWN > RoundMode::TOWARDS_INFINITY &&
+                    RoundMode::HALF_DOWN < RoundMode::HALF_UP &&
+                    RoundMode::HALF_DOWN < RoundMode::HALF_TOWARDS_ZERO &&
+                    RoundMode::HALF_DOWN < RoundMode::HALF_TOWARDS_INFINITY &&
+                    RoundMode::HALF_DOWN < RoundMode::HALF_TO_EVEN &&
+                    RoundMode::HALF_DOWN < RoundMode::HALF_TO_ODD,
+                "Invalid order of round modes. Modes prefixed with HALF need to be "
+                "enumerated last with HALF_DOWN being the first among them.");
+}
+constexpr char RoundBinaryOptions::kTypeName[];
 
 RoundTemporalOptions::RoundTemporalOptions(int multiple, CalendarUnit unit,
                                            bool week_starts_monday,
@@ -681,6 +699,11 @@ SCALAR_EAGER_UNARY(Sign, "sign")
 
 Result<Datum> Round(const Datum& arg, RoundOptions options, ExecContext* ctx) {
   return CallFunction("round", {arg}, &options, ctx);
+}
+
+Result<Datum> RoundBinary(const Datum& arg1, const Datum& arg2,
+                          RoundBinaryOptions options, ExecContext* ctx) {
+  return CallFunction("round_binary", {arg1, arg2}, &options, ctx);
 }
 
 Result<Datum> RoundToMultiple(const Datum& arg, RoundToMultipleOptions options,

--- a/cpp/src/arrow/compute/api_scalar.h
+++ b/cpp/src/arrow/compute/api_scalar.h
@@ -91,6 +91,15 @@ class ARROW_EXPORT RoundOptions : public FunctionOptions {
   RoundMode round_mode;
 };
 
+class ARROW_EXPORT RoundBinaryOptions : public FunctionOptions {
+ public:
+  explicit RoundBinaryOptions(RoundMode round_mode = RoundMode::HALF_TO_EVEN);
+  static constexpr char const kTypeName[] = "RoundBinaryOptions";
+  static RoundBinaryOptions Defaults() { return RoundBinaryOptions(); }
+  /// Rounding and tie-breaking mode
+  RoundMode round_mode;
+};
+
 enum class CalendarUnit : int8_t {
   NANOSECOND,
   MICROSECOND,
@@ -881,6 +890,20 @@ Result<Datum> Sign(const Datum& arg, ExecContext* ctx = NULLPTR);
 ARROW_EXPORT
 Result<Datum> Round(const Datum& arg, RoundOptions options = RoundOptions::Defaults(),
                     ExecContext* ctx = NULLPTR);
+
+/// \brief Round a value to a given precision.
+///
+/// If argument is null the result will be null.
+///
+/// \param[in] arg1 the value rounded
+/// \param[in] arg2 the number of significant digits to round to
+/// \param[in] options rounding options (rounding mode and number of digits), optional
+/// \param[in] ctx the function execution context, optional
+/// \return the element-wise rounded value
+ARROW_EXPORT
+Result<Datum> RoundBinary(const Datum& arg1, const Datum& arg2,
+                          RoundBinaryOptions options = RoundBinaryOptions::Defaults(),
+                          ExecContext* ctx = NULLPTR);
 
 /// \brief Round a value to a given multiple.
 ///

--- a/cpp/src/arrow/compute/kernels/scalar_round.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_round.cc
@@ -25,9 +25,7 @@
 #include "arrow/compare.h"
 #include "arrow/compute/api_scalar.h"
 #include "arrow/compute/cast.h"
-#include "arrow/compute/kernels/base_arithmetic_internal.h"
 #include "arrow/compute/kernels/common.h"
-#include "arrow/compute/kernels/util_internal.h"
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/decimal.h"
@@ -293,6 +291,24 @@ struct RoundOptionsWrapper<RoundOptions> : public OptionsWrapper<RoundOptions> {
 };
 
 template <>
+struct RoundOptionsWrapper<RoundBinaryOptions>
+    : public OptionsWrapper<RoundBinaryOptions> {
+  using OptionsType = RoundBinaryOptions;
+
+  explicit RoundOptionsWrapper(OptionsType options)
+      : OptionsWrapper(std::move(options)) {}
+
+  static Result<std::unique_ptr<KernelState>> Init(KernelContext* ctx,
+                                                   const KernelInitArgs& args) {
+    if (auto options = static_cast<const OptionsType*>(args.options)) {
+      return std::make_unique<RoundOptionsWrapper>(*options);
+    }
+    return Status::Invalid(
+        "Attempted to initialize KernelState from null FunctionOptions");
+  }
+};
+
+template <>
 struct RoundOptionsWrapper<RoundToMultipleOptions>
     : public OptionsWrapper<RoundToMultipleOptions> {
   using OptionsType = RoundToMultipleOptions;
@@ -449,6 +465,127 @@ struct Round<ArrowType, kRoundMode, enable_if_decimal<ArrowType>> {
       return 0;
     }
     return arg;
+  }
+};
+
+template <typename ArrowType, RoundMode RndMode, typename Enable = void>
+struct RoundBinary {
+  using CType = typename TypeTraits<ArrowType>::CType;
+  using State = RoundOptionsWrapper<RoundBinaryOptions>;
+
+  explicit RoundBinary(const State& state, const DataType& out_ty) {}
+
+  template <typename T = ArrowType, typename CType0 = typename TypeTraits<T>::CType0,
+            typename CType1 = typename TypeTraits<T>::CType1>
+  enable_if_floating_value<CType> Call(KernelContext* ctx, CType0 arg0, CType1 arg1,
+                                       Status* st) const {
+    // Do not process Inf or NaN because they will trigger the overflow error at end of
+    // function.
+    if (!std::isfinite(arg0)) {
+      return arg0;
+    }
+
+    // Only positive exponents for powers of 10 are used because combining
+    // multiply and division operations produced more stable rounding than
+    // using multiply-only.  Refer to NumPy's round implementation:
+    // https://github.com/numpy/numpy/blob/7b2f20b406d27364c812f7a81a9c901afbd3600c/numpy/core/src/multiarray/calculation.c#L589
+    double pow10 = RoundUtil::Pow10(std::abs(arg1));
+
+    auto round_val = arg1 >= 0 ? (arg0 * pow10) : (arg0 / pow10);
+    auto frac = round_val - std::floor(round_val);
+    if (frac != T(0)) {
+      // Use std::round() if in tie-breaking mode and scaled value is not 0.5.
+      if ((RndMode >= RoundMode::HALF_DOWN) && (frac != T(0.5))) {
+        round_val = std::round(round_val);
+      } else {
+        round_val = RoundImpl<CType, RndMode>::Round(round_val);
+      }
+      // Equality check is omitted so that the common case of 10^0 (integer rounding)
+      // uses multiply-only
+      round_val = arg1 > 0 ? (round_val / pow10) : (round_val * pow10);
+      if (!std::isfinite(round_val)) {
+        *st = Status::Invalid("overflow occurred during rounding");
+        return arg0;
+      }
+    } else {
+      // If scaled value is an integer, then no rounding is needed.
+      round_val = arg0;
+    }
+    return static_cast<CType0>(round_val);
+  }
+};
+
+template <typename ArrowType, RoundMode kRoundMode>
+struct RoundBinary<ArrowType, kRoundMode, enable_if_decimal<ArrowType>> {
+  using CType = typename TypeTraits<ArrowType>::CType;
+  using State = RoundOptionsWrapper<RoundBinaryOptions>;
+
+  const ArrowType& ty;
+  int32_t pow;
+  // pow10 is "1" for the given decimal scale. Similarly half_pow10 is "0.5".
+  CType half_pow10, neg_half_pow10;
+
+  explicit RoundBinary(const State& state, const DataType& out_ty)
+      : RoundBinary(out_ty) {}
+
+  explicit RoundBinary(const DataType& out_ty)
+      : ty(checked_cast<const ArrowType&>(out_ty)),
+        pow(static_cast<int32_t>(ty.scale() - 0)) {
+    if (pow >= ty.precision() || pow < 0) {
+      half_pow10 = neg_half_pow10 = 0;
+    } else {
+      half_pow10 = CType::GetHalfScaleMultiplier(pow);
+      neg_half_pow10 = -half_pow10;
+    }
+  }
+
+  template <typename T = ArrowType, typename CType0 = typename TypeTraits<T>::CType0,
+            typename CType1 = typename TypeTraits<T>::CType1>
+  enable_if_decimal_value<CType> Call(KernelContext* ctx, CType0 arg0, CType1 arg1,
+                                      Status* st) const {
+    if (pow - arg1 >= ty.precision()) {
+      *st = Status::Invalid("Rounding to ", arg1, " digits will not fit in precision of ",
+                            ty);
+      return 0;
+    } else if (pow < 0) {
+      // no-op, copy output to input
+      return arg0;
+    }
+
+    CType0 pow10 = CType0::GetScaleMultiplier(static_cast<int32_t>(ty.scale() - arg1));
+
+    std::pair<CType, CType> pair;
+    *st = arg0.Divide(pow10).Value(&pair);
+    if (!st->ok()) return arg0;
+    // The remainder is effectively the scaled fractional part after division.
+    const auto& remainder = pair.second;
+    if (remainder == 0) return arg0;
+    if (kRoundMode >= RoundMode::HALF_DOWN) {
+      if (remainder == half_pow10 || remainder == neg_half_pow10) {
+        // On the halfway point, use tiebreaker
+        RoundImpl<CType0, kRoundMode>::Round(&arg0, remainder, pow10, pow);
+      } else if (remainder.Sign() >= 0) {
+        // Positive, round up/down
+        arg0 -= remainder;
+        if (remainder > half_pow10) {
+          arg0 += pow10;
+        }
+      } else {
+        // Negative, round up/down
+        arg0 -= remainder;
+        if (remainder < neg_half_pow10) {
+          arg0 -= pow10;
+        }
+      }
+    } else {
+      RoundImpl<CType0, kRoundMode>::Round(&arg0, remainder, pow10, pow);
+    }
+    if (!arg0.FitsInPrecision(ty.precision())) {
+      *st = Status::Invalid("Rounded value ", arg0.ToString(ty.scale()),
+                            " does not fit in precision of ", ty);
+      return 0;
+    }
+    return arg0;
   }
 };
 
@@ -709,17 +846,6 @@ Result<TypeHolder> ResolveDecimalBinaryOperationOutput(
   return std::move(type);
 }
 
-template <typename Op>
-void AddDecimalUnaryKernels(ScalarFunction* func) {
-  OutputType out_type(FirstType);
-  auto in_type128 = InputType(Type::DECIMAL128);
-  auto in_type256 = InputType(Type::DECIMAL256);
-  auto exec128 = ScalarUnaryNotNull<Decimal128Type, Decimal128Type, Op>::Exec;
-  auto exec256 = ScalarUnaryNotNull<Decimal256Type, Decimal256Type, Op>::Exec;
-  DCHECK_OK(func->AddKernel({in_type128}, out_type, exec128));
-  DCHECK_OK(func->AddKernel({in_type256}, out_type, exec256));
-}
-
 // Generate a kernel given an arithmetic functor
 template <template <typename...> class KernelGenerator, typename OutType, typename Op>
 ArrayKernelExec GenerateArithmeticWithFixedIntOutType(detail::GetTypeId get_id) {
@@ -751,60 +877,25 @@ ArrayKernelExec GenerateArithmeticWithFixedIntOutType(detail::GetTypeId get_id) 
   }
 }
 
-struct ArithmeticFunction : ScalarFunction {
+struct RoundFunction : ScalarFunction {
   using ScalarFunction::ScalarFunction;
 
   Result<const Kernel*> DispatchBest(std::vector<TypeHolder>* types) const override {
     RETURN_NOT_OK(CheckArity(types->size()));
 
-    RETURN_NOT_OK(CheckDecimals(types));
-
     using arrow::compute::detail::DispatchExactImpl;
     if (auto kernel = DispatchExactImpl(this, *types)) return kernel;
 
     EnsureDictionaryDecoded(types);
 
-    // Only promote types for binary functions
-    if (types->size() == 2) {
-      ReplaceNullWithOtherType(types);
-      TimeUnit::type finest_unit;
-      if (CommonTemporalResolution(types->data(), types->size(), &finest_unit)) {
-        ReplaceTemporalTypes(finest_unit, types);
-      } else {
-        if (TypeHolder type = CommonNumeric(*types)) {
-          ReplaceTypes(type, types);
-        }
-      }
-    }
-
     if (auto kernel = DispatchExactImpl(this, *types)) return kernel;
     return arrow::compute::detail::NoMatchingKernel(this, *types);
   }
-
-  Status CheckDecimals(std::vector<TypeHolder>* types) const {
-    if (!HasDecimal(*types)) return Status::OK();
-
-    if (types->size() == 2) {
-      // "add_checked" -> "add"
-      const auto func_name = name();
-      const std::string op = func_name.substr(0, func_name.find("_"));
-      if (op == "add" || op == "subtract") {
-        return CastBinaryDecimalArgs(DecimalPromotion::kAdd, types);
-      } else if (op == "multiply") {
-        return CastBinaryDecimalArgs(DecimalPromotion::kMultiply, types);
-      } else if (op == "divide") {
-        return CastBinaryDecimalArgs(DecimalPromotion::kDivide, types);
-      } else {
-        return Status::Invalid("Invalid decimal function: ", func_name);
-      }
-    }
-    return Status::OK();
-  }
 };
 
-/// An ArithmeticFunction that promotes only decimal arguments to double.
-struct ArithmeticDecimalToFloatingPointFunction : public ArithmeticFunction {
-  using ArithmeticFunction::ArithmeticFunction;
+/// An RoundFunction that promotes only decimal arguments to double.
+struct ArithmeticDecimalToFloatingPointFunction : public RoundFunction {
+  using RoundFunction::RoundFunction;
 
   Result<const Kernel*> DispatchBest(std::vector<TypeHolder>* types) const override {
     RETURN_NOT_OK(CheckArity(types->size()));
@@ -814,60 +905,22 @@ struct ArithmeticDecimalToFloatingPointFunction : public ArithmeticFunction {
 
     EnsureDictionaryDecoded(types);
 
-    if (types->size() == 2) {
-      ReplaceNullWithOtherType(types);
-    }
-
-    for (size_t i = 0; i < types->size(); ++i) {
-      if (is_decimal((*types)[i].type->id())) {
-        (*types)[i] = float64();
-      }
-    }
-
-    if (TypeHolder type = CommonNumeric(*types)) {
-      ReplaceTypes(type, types);
+    // Size of types is checked above.
+    const auto originalType = (*types)[0];
+    if (is_decimal((*types)[0].type->id())) {
+      (*types)[0] = float64();
     }
 
     if (auto kernel = DispatchExactImpl(this, *types)) return kernel;
+
+    (*types)[0] = originalType;
     return arrow::compute::detail::NoMatchingKernel(this, *types);
   }
 };
 
-/// An ArithmeticFunction that promotes only integer arguments to double.
-struct ArithmeticIntegerToFloatingPointFunction : public ArithmeticFunction {
-  using ArithmeticFunction::ArithmeticFunction;
-
-  Result<const Kernel*> DispatchBest(std::vector<TypeHolder>* types) const override {
-    RETURN_NOT_OK(CheckArity(types->size()));
-    RETURN_NOT_OK(CheckDecimals(types));
-
-    using arrow::compute::detail::DispatchExactImpl;
-    if (auto kernel = DispatchExactImpl(this, *types)) return kernel;
-
-    EnsureDictionaryDecoded(types);
-
-    if (types->size() == 2) {
-      ReplaceNullWithOtherType(types);
-    }
-
-    for (size_t i = 0; i < types->size(); ++i) {
-      if (is_integer((*types)[i].type->id())) {
-        (*types)[i] = float64();
-      }
-    }
-
-    if (auto type = CommonNumeric(*types)) {
-      ReplaceTypes(type, types);
-    }
-
-    if (auto kernel = DispatchExactImpl(this, *types)) return kernel;
-    return arrow::compute::detail::NoMatchingKernel(this, *types);
-  }
-};
-
-/// An ArithmeticFunction that promotes integer and decimal arguments to double.
-struct ArithmeticFloatingPointFunction : public ArithmeticFunction {
-  using ArithmeticFunction::ArithmeticFunction;
+/// An RoundFunction that promotes only the first integer argument to double.
+struct RoundIntegerToFloatingPointFunction : public RoundFunction {
+  using RoundFunction::RoundFunction;
 
   Result<const Kernel*> DispatchBest(std::vector<TypeHolder>* types) const override {
     RETURN_NOT_OK(CheckArity(types->size()));
@@ -877,21 +930,40 @@ struct ArithmeticFloatingPointFunction : public ArithmeticFunction {
 
     EnsureDictionaryDecoded(types);
 
-    if (types->size() == 2) {
-      ReplaceNullWithOtherType(types);
-    }
-
-    for (size_t i = 0; i < types->size(); ++i) {
-      if (is_integer((*types)[i].type->id()) || is_decimal((*types)[i].type->id())) {
-        (*types)[i] = float64();
-      }
-    }
-
-    if (auto type = CommonNumeric(*types)) {
-      ReplaceTypes(type, types);
+    // Size of types is checked above.
+    const auto originalType = (*types)[0];
+    if (is_integer((*types)[0].type->id())) {
+      (*types)[0] = float64();
     }
 
     if (auto kernel = DispatchExactImpl(this, *types)) return kernel;
+
+    (*types)[0] = originalType;
+    return arrow::compute::detail::NoMatchingKernel(this, *types);
+  }
+};
+
+/// An RoundFunction that promotes integer and decimal arguments to double.
+struct RoundFloatingPointFunction : public RoundFunction {
+  using RoundFunction::RoundFunction;
+
+  Result<const Kernel*> DispatchBest(std::vector<TypeHolder>* types) const override {
+    RETURN_NOT_OK(CheckArity(types->size()));
+
+    using arrow::compute::detail::DispatchExactImpl;
+    if (auto kernel = DispatchExactImpl(this, *types)) return kernel;
+
+    EnsureDictionaryDecoded(types);
+
+    // Size of types is checked above.
+    const auto originalType = (*types)[0];
+    if (is_integer((*types)[0].type->id()) || is_decimal((*types)[0].type->id())) {
+      (*types)[0] = float64();
+    }
+
+    if (auto kernel = DispatchExactImpl(this, *types)) return kernel;
+
+    (*types)[0] = originalType;
     return arrow::compute::detail::NoMatchingKernel(this, *types);
   }
 };
@@ -906,9 +978,8 @@ void AddNullExec(ScalarFunction* func) {
   DCHECK_OK(func->AddKernel(std::move(input_types), OutputType(null()), NullToNullExec));
 }
 
-template <typename Op, typename FunctionImpl = ArithmeticFunction>
-std::shared_ptr<ScalarFunction> MakeArithmeticFunction(std::string name,
-                                                       FunctionDoc doc) {
+template <typename Op, typename FunctionImpl = RoundFunction>
+std::shared_ptr<ScalarFunction> MakeRoundFunction(std::string name, FunctionDoc doc) {
   auto func = std::make_shared<FunctionImpl>(name, Arity::Binary(), std::move(doc));
   for (const auto& ty : NumericTypes()) {
     auto exec = ArithmeticExecFromOp<ScalarBinaryEqualTypes, Op>(ty);
@@ -918,11 +989,11 @@ std::shared_ptr<ScalarFunction> MakeArithmeticFunction(std::string name,
   return func;
 }
 
-// Like MakeArithmeticFunction, but for arithmetic ops that need to run
+// Like MakeRoundFunction, but for arithmetic ops that need to run
 // only on non-null output.
-template <typename Op, typename FunctionImpl = ArithmeticFunction>
-std::shared_ptr<ScalarFunction> MakeArithmeticFunctionNotNull(std::string name,
-                                                              FunctionDoc doc) {
+template <typename Op, typename FunctionImpl = RoundFunction>
+std::shared_ptr<ScalarFunction> MakeRoundFunctionNotNull(std::string name,
+                                                         FunctionDoc doc) {
   auto func = std::make_shared<FunctionImpl>(name, Arity::Binary(), std::move(doc));
   for (const auto& ty : NumericTypes()) {
     auto exec = ArithmeticExecFromOp<ScalarBinaryNotNullEqualTypes, Op>(ty);
@@ -933,9 +1004,9 @@ std::shared_ptr<ScalarFunction> MakeArithmeticFunctionNotNull(std::string name,
 }
 
 template <typename Op>
-std::shared_ptr<ScalarFunction> MakeUnaryArithmeticFunction(std::string name,
-                                                            FunctionDoc doc) {
-  auto func = std::make_shared<ArithmeticFunction>(name, Arity::Unary(), std::move(doc));
+std::shared_ptr<ScalarFunction> MakeUnaryRoundFunction(std::string name,
+                                                       FunctionDoc doc) {
+  auto func = std::make_shared<RoundFunction>(name, Arity::Unary(), std::move(doc));
   for (const auto& ty : NumericTypes()) {
     auto exec = ArithmeticExecFromOp<ScalarUnary, Op>(ty);
     DCHECK_OK(func->AddKernel({ty}, ty, exec));
@@ -944,13 +1015,13 @@ std::shared_ptr<ScalarFunction> MakeUnaryArithmeticFunction(std::string name,
   return func;
 }
 
-// Like MakeUnaryArithmeticFunction, but for unary arithmetic ops with a fixed
+// Like MakeUnaryRoundFunction, but for unary arithmetic ops with a fixed
 // output type for integral inputs.
 template <typename Op, typename IntOutType>
-std::shared_ptr<ScalarFunction> MakeUnaryArithmeticFunctionWithFixedIntOutType(
+std::shared_ptr<ScalarFunction> MakeUnaryRoundFunctionWithFixedIntOutType(
     std::string name, FunctionDoc doc) {
   auto int_out_ty = TypeTraits<IntOutType>::type_singleton();
-  auto func = std::make_shared<ArithmeticFunction>(name, Arity::Unary(), std::move(doc));
+  auto func = std::make_shared<RoundFunction>(name, Arity::Unary(), std::move(doc));
   for (const auto& ty : NumericTypes()) {
     auto out_ty = arrow::is_floating(ty->id()) ? ty : int_out_ty;
     auto exec = GenerateArithmeticWithFixedIntOutType<ScalarUnary, IntOutType, Op>(ty);
@@ -966,12 +1037,12 @@ std::shared_ptr<ScalarFunction> MakeUnaryArithmeticFunctionWithFixedIntOutType(
   return func;
 }
 
-// Like MakeUnaryArithmeticFunction, but for arithmetic ops that need to run
+// Like MakeUnaryRoundFunction, but for arithmetic ops that need to run
 // only on non-null output.
 template <typename Op>
-std::shared_ptr<ScalarFunction> MakeUnaryArithmeticFunctionNotNull(std::string name,
-                                                                   FunctionDoc doc) {
-  auto func = std::make_shared<ArithmeticFunction>(name, Arity::Unary(), std::move(doc));
+std::shared_ptr<ScalarFunction> MakeUnaryRoundFunctionNotNull(std::string name,
+                                                              FunctionDoc doc) {
+  auto func = std::make_shared<RoundFunction>(name, Arity::Unary(), std::move(doc));
   for (const auto& ty : NumericTypes()) {
     auto exec = ArithmeticExecFromOp<ScalarUnaryNotNull, Op>(ty);
     DCHECK_OK(func->AddKernel({ty}, ty, exec));
@@ -1014,14 +1085,49 @@ struct RoundKernel {
 };
 #undef ROUND_CASE
 
-// Like MakeUnaryArithmeticFunction, but for unary rounding functions that control
+#define ROUND_BINARY_CASE(MODE)                                                \
+  case RoundMode::MODE: {                                                      \
+    using Op = OpImpl<Type, RoundMode::MODE>;                                  \
+    return applicator::ScalarBinaryNotNullStateful<Type, Type, Int32Type, Op>( \
+               Op(state, *out->type()))                                        \
+        .Exec(ctx, batch, out);                                                \
+  }
+
+// Exec the round (binary) kernel for the given types
+template <typename Type, typename OptionsType,
+          template <typename, RoundMode, typename...> class OpImpl>
+struct RoundBinaryKernel {
+  static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
+    using State = RoundOptionsWrapper<OptionsType>;
+    const auto& state = static_cast<const State&>(*ctx->state());
+    switch (state.options.round_mode) {
+      ROUND_BINARY_CASE(DOWN)
+      ROUND_BINARY_CASE(UP)
+      ROUND_BINARY_CASE(TOWARDS_ZERO)
+      ROUND_BINARY_CASE(TOWARDS_INFINITY)
+      ROUND_BINARY_CASE(HALF_DOWN)
+      ROUND_BINARY_CASE(HALF_UP)
+      ROUND_BINARY_CASE(HALF_TOWARDS_ZERO)
+      ROUND_BINARY_CASE(HALF_TOWARDS_INFINITY)
+      ROUND_BINARY_CASE(HALF_TO_EVEN)
+      ROUND_BINARY_CASE(HALF_TO_ODD)
+    }
+    DCHECK(false);
+    return Status::NotImplemented(
+        "Internal implementation error: round mode not implemented: ",
+        state.options.ToString());
+  }
+};
+#undef ROUND_BINARY_CASE
+
+// Like MakeUnaryRoundFunction, but for unary rounding functions that control
 // kernel dispatch based on RoundMode, only on non-null output.
 template <template <typename, RoundMode, typename...> class Op, typename OptionsType>
 std::shared_ptr<ScalarFunction> MakeUnaryRoundFunction(std::string name,
                                                        FunctionDoc doc) {
   using State = RoundOptionsWrapper<OptionsType>;
   static const OptionsType kDefaultOptions = OptionsType::Defaults();
-  auto func = std::make_shared<ArithmeticIntegerToFloatingPointFunction>(
+  auto func = std::make_shared<RoundIntegerToFloatingPointFunction>(
       name, Arity::Unary(), std::move(doc), &kDefaultOptions);
   for (const auto& ty : {float32(), float64(), decimal128(1, 0), decimal256(1, 0)}) {
     auto type_id = ty->id();
@@ -1051,12 +1157,47 @@ std::shared_ptr<ScalarFunction> MakeUnaryRoundFunction(std::string name,
   return func;
 }
 
-// Like MakeUnaryArithmeticFunction, but for signed arithmetic ops that need to run
+template <template <typename, RoundMode, typename...> class Op, typename OptionsType>
+std::shared_ptr<ScalarFunction> MakeBinaryRoundFunction(const std::string& name,
+                                                        FunctionDoc doc) {
+  using State = RoundOptionsWrapper<OptionsType>;
+  static const OptionsType kDefaultOptions = OptionsType::Defaults();
+  auto func = std::make_shared<RoundIntegerToFloatingPointFunction>(
+      name, Arity::Binary(), std::move(doc), &kDefaultOptions);
+  for (const auto& ty : {float32(), float64(), decimal128(1, 0), decimal256(1, 0)}) {
+    auto type_id = ty->id();
+    ArrayKernelExec exec = nullptr;
+    switch (type_id) {
+      case Type::FLOAT:
+        exec = RoundBinaryKernel<FloatType, OptionsType, Op>::Exec;
+        break;
+      case Type::DOUBLE:
+        exec = RoundBinaryKernel<DoubleType, OptionsType, Op>::Exec;
+        break;
+      case Type::DECIMAL128:
+        exec = RoundBinaryKernel<Decimal128Type, OptionsType, Op>::Exec;
+        break;
+      case Type::DECIMAL256:
+        exec = RoundBinaryKernel<Decimal256Type, OptionsType, Op>::Exec;
+        break;
+      default:
+        DCHECK(false);
+        break;
+    }
+    DCHECK_OK(func->AddKernel(
+        {ty, Type::INT32}, is_decimal(type_id) ? OutputType(FirstType) : OutputType(ty),
+        exec, State::Init));
+  }
+  AddNullExec(func.get());
+  return func;
+}
+
+// Like MakeUnaryRoundFunction, but for signed arithmetic ops that need to run
 // only on non-null output.
 template <typename Op>
-std::shared_ptr<ScalarFunction> MakeUnarySignedArithmeticFunctionNotNull(
-    std::string name, FunctionDoc doc) {
-  auto func = std::make_shared<ArithmeticFunction>(name, Arity::Unary(), std::move(doc));
+std::shared_ptr<ScalarFunction> MakeUnarySignedRoundFunctionNotNull(std::string name,
+                                                                    FunctionDoc doc) {
+  auto func = std::make_shared<RoundFunction>(name, Arity::Unary(), std::move(doc));
   for (const auto& ty : NumericTypes()) {
     if (!arrow::is_unsigned_integer(ty->id())) {
       auto exec = ArithmeticExecFromOp<ScalarUnaryNotNull, Op>(ty);
@@ -1070,7 +1211,7 @@ std::shared_ptr<ScalarFunction> MakeUnarySignedArithmeticFunctionNotNull(
 template <typename Op>
 std::shared_ptr<ScalarFunction> MakeBitWiseFunctionNotNull(std::string name,
                                                            FunctionDoc doc) {
-  auto func = std::make_shared<ArithmeticFunction>(name, Arity::Binary(), std::move(doc));
+  auto func = std::make_shared<RoundFunction>(name, Arity::Binary(), std::move(doc));
   for (const auto& ty : IntTypes()) {
     auto exec = TypeAgnosticBitWiseExecFromOp<ScalarBinaryNotNullEqualTypes, Op>(ty);
     DCHECK_OK(func->AddKernel({ty, ty}, ty, exec));
@@ -1082,7 +1223,7 @@ std::shared_ptr<ScalarFunction> MakeBitWiseFunctionNotNull(std::string name,
 template <typename Op>
 std::shared_ptr<ScalarFunction> MakeShiftFunctionNotNull(std::string name,
                                                          FunctionDoc doc) {
-  auto func = std::make_shared<ArithmeticFunction>(name, Arity::Binary(), std::move(doc));
+  auto func = std::make_shared<RoundFunction>(name, Arity::Binary(), std::move(doc));
   for (const auto& ty : IntTypes()) {
     auto exec = ShiftExecFromOp<ScalarBinaryNotNullEqualTypes, Op>(ty);
     DCHECK_OK(func->AddKernel({ty, ty}, ty, exec));
@@ -1091,9 +1232,9 @@ std::shared_ptr<ScalarFunction> MakeShiftFunctionNotNull(std::string name,
   return func;
 }
 
-template <typename Op, typename FunctionImpl = ArithmeticFloatingPointFunction>
-std::shared_ptr<ScalarFunction> MakeUnaryArithmeticFunctionFloatingPoint(
-    std::string name, FunctionDoc doc) {
+template <typename Op, typename FunctionImpl = RoundFloatingPointFunction>
+std::shared_ptr<ScalarFunction> MakeUnaryRoundFunctionFloatingPoint(std::string name,
+                                                                    FunctionDoc doc) {
   auto func = std::make_shared<FunctionImpl>(name, Arity::Unary(), std::move(doc));
   for (const auto& ty : FloatingPointTypes()) {
     auto exec = GenerateArithmeticFloatingPoint<ScalarUnary, Op>(ty);
@@ -1104,69 +1245,16 @@ std::shared_ptr<ScalarFunction> MakeUnaryArithmeticFunctionFloatingPoint(
 }
 
 template <typename Op>
-std::shared_ptr<ScalarFunction> MakeUnaryArithmeticFunctionFloatingPointNotNull(
+std::shared_ptr<ScalarFunction> MakeUnaryRoundFunctionFloatingPointNotNull(
     std::string name, FunctionDoc doc) {
-  auto func = std::make_shared<ArithmeticFloatingPointFunction>(name, Arity::Unary(),
-                                                                std::move(doc));
+  auto func =
+      std::make_shared<RoundFloatingPointFunction>(name, Arity::Unary(), std::move(doc));
   for (const auto& ty : FloatingPointTypes()) {
     auto exec = GenerateArithmeticFloatingPoint<ScalarUnaryNotNull, Op>(ty);
     DCHECK_OK(func->AddKernel({ty}, ty, exec));
   }
   AddNullExec(func.get());
   return func;
-}
-
-template <typename Op>
-std::shared_ptr<ScalarFunction> MakeArithmeticFunctionFloatingPoint(std::string name,
-                                                                    FunctionDoc doc) {
-  auto func = std::make_shared<ArithmeticFloatingPointFunction>(name, Arity::Binary(),
-                                                                std::move(doc));
-  for (const auto& ty : FloatingPointTypes()) {
-    auto exec = GenerateArithmeticFloatingPoint<ScalarBinaryEqualTypes, Op>(ty);
-    DCHECK_OK(func->AddKernel({ty, ty}, ty, exec));
-  }
-  AddNullExec(func.get());
-  return func;
-}
-
-template <typename Op>
-std::shared_ptr<ScalarFunction> MakeArithmeticFunctionFloatingPointNotNull(
-    std::string name, FunctionDoc doc) {
-  auto func = std::make_shared<ArithmeticFloatingPointFunction>(name, Arity::Binary(),
-                                                                std::move(doc));
-  for (const auto& ty : FloatingPointTypes()) {
-    auto output = is_integer(ty->id()) ? float64() : ty;
-    auto exec = GenerateArithmeticFloatingPoint<ScalarBinaryNotNullEqualTypes, Op>(ty);
-    DCHECK_OK(func->AddKernel({ty, ty}, output, exec));
-  }
-  AddNullExec(func.get());
-  return func;
-}
-
-template <template <int64_t> class Op>
-void AddArithmeticFunctionTimeDuration(std::shared_ptr<ScalarFunction> func) {
-  // Add Op(time32, duration) -> time32
-  TimeUnit::type unit = TimeUnit::SECOND;
-  auto exec_1 = ScalarBinary<Time32Type, Time32Type, DurationType, Op<86400>>::Exec;
-  DCHECK_OK(func->AddKernel({time32(unit), duration(unit)}, OutputType(FirstType),
-                            std::move(exec_1)));
-
-  unit = TimeUnit::MILLI;
-  auto exec_2 = ScalarBinary<Time32Type, Time32Type, DurationType, Op<86400000>>::Exec;
-  DCHECK_OK(func->AddKernel({time32(unit), duration(unit)}, OutputType(FirstType),
-                            std::move(exec_2)));
-
-  // Add Op(time64, duration) -> time64
-  unit = TimeUnit::MICRO;
-  auto exec_3 = ScalarBinary<Time64Type, Time64Type, DurationType, Op<86400000000>>::Exec;
-  DCHECK_OK(func->AddKernel({time64(unit), duration(unit)}, OutputType(FirstType),
-                            std::move(exec_3)));
-
-  unit = TimeUnit::NANO;
-  auto exec_4 =
-      ScalarBinary<Time64Type, Time64Type, DurationType, Op<86400000000000>>::Exec;
-  DCHECK_OK(func->AddKernel({time64(unit), duration(unit)}, OutputType(FirstType),
-                            std::move(exec_4)));
 }
 
 const FunctionDoc floor_doc{
@@ -1192,6 +1280,13 @@ const FunctionDoc round_doc{
     {"x"},
     "RoundOptions"};
 
+const FunctionDoc round_binary_doc{
+    "Round to the given precision",
+    ("Options are used to control the rounding mode.\n"
+     "Default behavior is to use the half-to-even rule to break ties."),
+    {"x", "s"},
+    "RoundBinaryOptions"};
+
 const FunctionDoc round_to_multiple_doc{
     "Round to a given multiple",
     ("Options are used to control the rounding multiple and rounding mode.\n"
@@ -1203,8 +1298,7 @@ const FunctionDoc round_to_multiple_doc{
 
 void RegisterScalarRoundArithmetic(FunctionRegistry* registry) {
   auto floor =
-      MakeUnaryArithmeticFunctionFloatingPoint<Floor,
-                                               ArithmeticIntegerToFloatingPointFunction>(
+      MakeUnaryRoundFunctionFloatingPoint<Floor, RoundIntegerToFloatingPointFunction>(
           "floor", floor_doc);
   DCHECK_OK(floor->AddKernel(
       {InputType(Type::DECIMAL128)}, OutputType(FirstType),
@@ -1215,8 +1309,7 @@ void RegisterScalarRoundArithmetic(FunctionRegistry* registry) {
   DCHECK_OK(registry->AddFunction(std::move(floor)));
 
   auto ceil =
-      MakeUnaryArithmeticFunctionFloatingPoint<Ceil,
-                                               ArithmeticIntegerToFloatingPointFunction>(
+      MakeUnaryRoundFunctionFloatingPoint<Ceil, RoundIntegerToFloatingPointFunction>(
           "ceil", ceil_doc);
   DCHECK_OK(ceil->AddKernel(
       {InputType(Type::DECIMAL128)}, OutputType(FirstType),
@@ -1227,8 +1320,7 @@ void RegisterScalarRoundArithmetic(FunctionRegistry* registry) {
   DCHECK_OK(registry->AddFunction(std::move(ceil)));
 
   auto trunc =
-      MakeUnaryArithmeticFunctionFloatingPoint<Trunc,
-                                               ArithmeticIntegerToFloatingPointFunction>(
+      MakeUnaryRoundFunctionFloatingPoint<Trunc, RoundIntegerToFloatingPointFunction>(
           "trunc", trunc_doc);
   DCHECK_OK(trunc->AddKernel(
       {InputType(Type::DECIMAL128)}, OutputType(FirstType),
@@ -1240,6 +1332,10 @@ void RegisterScalarRoundArithmetic(FunctionRegistry* registry) {
 
   auto round = MakeUnaryRoundFunction<Round, RoundOptions>("round", round_doc);
   DCHECK_OK(registry->AddFunction(std::move(round)));
+
+  auto round_binary = MakeBinaryRoundFunction<RoundBinary, RoundBinaryOptions>(
+      "round_binary", round_binary_doc);
+  DCHECK_OK(registry->AddFunction(std::move(round_binary)));
 
   auto round_to_multiple =
       MakeUnaryRoundFunction<RoundToMultiple, RoundToMultipleOptions>(

--- a/cpp/src/arrow/compute/kernels/scalar_round_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_round_arithmetic_test.cc
@@ -18,7 +18,6 @@
 #include <algorithm>
 #include <cmath>
 #include <memory>
-#include <string>
 #include <utility>
 
 #include <gtest/gtest.h>
@@ -113,7 +112,7 @@ class TestBaseUnaryRoundArithmetic : public ::testing::Test {
   // (Array, Array)
   void AssertUnaryOp(UnaryFunction func, const std::shared_ptr<Array>& arg,
                      const std::shared_ptr<Array>& expected) {
-    ASSERT_OK_AND_ASSIGN(auto actual, func(arg, options_, nullptr));
+    ASSERT_OK_AND_ASSIGN(auto actual, func(arg, options_, nullptr))
     ValidateAndAssertApproxEqual(actual.make_array(), expected);
 
     // Also check (Scalar, Scalar) operations
@@ -219,6 +218,189 @@ class TestUnaryRoundUnsigned : public TestUnaryRoundIntegral<T> {};
 template <typename T>
 class TestUnaryRoundFloating : public TestUnaryRound<T> {};
 
+template <typename T, typename OptionsType>
+class TestBaseBinaryRoundArithmetic : public ::testing::Test {
+ protected:
+  using ArrowType = T;
+  using CType = typename ArrowType::c_type;
+
+  static std::shared_ptr<DataType> type_singleton() {
+    return TypeTraits<ArrowType>::type_singleton();
+  }
+
+  using BinaryFunction =
+      std::function<Result<Datum>(const Datum&, const Datum&, OptionsType, ExecContext*)>;
+
+  std::shared_ptr<Scalar> MakeNullScalar() {
+    return arrow::MakeNullScalar(type_singleton());
+  }
+
+  std::shared_ptr<Scalar> MakeScalar(CType value) {
+    return *arrow::MakeScalar(type_singleton(), value);
+  }
+
+    std::shared_ptr<Scalar> MakeInt32Scalar(int32_t value) {
+        return *arrow::MakeScalar(int32(), value);
+    }
+
+  void SetUp() override {}
+
+  // (CScalar, CScalar)
+  void AssertBinaryOp(BinaryFunction func, CType argument, int32_t ndigits,
+                      CType expected) {
+    auto arg = MakeScalar(argument);
+    auto nd = MakeInt32Scalar(ndigits);
+    auto exp = MakeScalar(expected);
+    ASSERT_OK_AND_ASSIGN(auto actual, func(arg, nd, options_, nullptr))
+    AssertScalarsApproxEqual(*exp, *actual.scalar(), /*verbose=*/true);
+  }
+
+  // (Scalar, Scalar)
+  void AssertBinaryOp(BinaryFunction func, const std::shared_ptr<Scalar>& arg,
+                      const std::shared_ptr<Scalar>& ndigits,
+                      const std::shared_ptr<Scalar>& expected) {
+    ASSERT_OK_AND_ASSIGN(auto actual, func(arg, ndigits, options_, nullptr))
+    AssertScalarsApproxEqual(*expected, *actual.scalar(), /*verbose=*/true);
+  }
+
+  // (JSON, JSON)
+  void AssertBinaryOp(BinaryFunction func, const std::string& arg_json, int32_t ndigits,
+                      const std::string& expected_json) {
+    auto arg = ArrayFromJSON(type_singleton(), arg_json);
+    auto nd = MakeInt32Scalar(ndigits);
+    ASSERT_OK_AND_ASSIGN(auto nda, MakeArrayFromScalar(*nd, arg->length()))
+    auto expected = ArrayFromJSON(type_singleton(), expected_json);
+    AssertBinaryOp(func, arg, nda, expected);
+  }
+
+  // (JSON, JSON)
+  void AssertBinaryOp(BinaryFunction func, const std::string& arg_json,
+                      const std::string& ndigits_json, const std::string& expected_json) {
+    auto arg = ArrayFromJSON(type_singleton(), arg_json);
+    auto nd = ArrayFromJSON(int32(), ndigits_json);
+    auto expected = ArrayFromJSON(type_singleton(), expected_json);
+    AssertBinaryOp(func, arg, nd, expected);
+  }
+
+  // (Array, JSON)
+  void AssertBinaryOp(BinaryFunction func, const std::shared_ptr<Array>& arg,
+                      const std::shared_ptr<Array>& ndigits,
+                      const std::string& expected_json) {
+    const auto expected = ArrayFromJSON(type_singleton(), expected_json);
+    AssertBinaryOp(func, arg, ndigits, expected);
+  }
+
+  // (JSON, Array)
+  void AssertBinaryOp(BinaryFunction func, const std::string& arg_json, int32_t ndigits,
+                      const std::shared_ptr<Array>& expected) {
+    auto arg = ArrayFromJSON(type_singleton(), arg_json);
+    auto nd = MakeInt32Scalar(ndigits);
+    ASSERT_OK_AND_ASSIGN(auto nda, MakeArrayFromScalar(*nd, arg->length()))
+    AssertBinaryOp(func, arg, nda, expected);
+  }
+
+  // (Array, Array)
+  void AssertBinaryOp(BinaryFunction func, const std::shared_ptr<Array>& arg,
+                      const std::shared_ptr<Array>& ndigits,
+                      const std::shared_ptr<Array>& expected) {
+    ASSERT_OK_AND_ASSIGN(auto actual, func(arg, ndigits, options_, nullptr))
+    ValidateAndAssertApproxEqual(actual.make_array(), expected);
+
+    // Also check (Scalar, Scalar) operations
+    const int64_t length = expected->length();
+    for (int64_t i = 0; i < length; ++i) {
+      const auto expected_scalar = *expected->GetScalar(i);
+      ASSERT_OK_AND_ASSIGN(
+          actual, func(*arg->GetScalar(i), *ndigits->GetScalar(i), options_, nullptr))
+      AssertScalarsApproxEqual(*expected_scalar, *actual.scalar(), /*verbose=*/true,
+                               equal_options_);
+    }
+  }
+
+  // (CScalar, CScalar)
+  void AssertBinaryOpRaises(BinaryFunction func, CType argument, CType ndigits,
+                            const std::string& expected_msg) {
+    auto arg = MakeScalar(argument);
+    auto nd = MakeInt32Scalar(ndigits);
+    EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, ::testing::HasSubstr(expected_msg),
+                                    func(arg, nd, options_, nullptr));
+  }
+
+  void AssertBinaryOpRaises(BinaryFunction func, const std::string& argument,
+                            const std::string& ndigits, const std::string& expected_msg) {
+    auto arg = ArrayFromJSON(type_singleton(), argument);
+    auto nd = ArrayFromJSON(int32(), ndigits);
+    EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, ::testing::HasSubstr(expected_msg),
+                                    func(arg, nd, options_, nullptr));
+    for (int64_t i = 0; i < arg->length(); i++) {
+      ASSERT_OK_AND_ASSIGN(auto scalar, arg->GetScalar(i))
+      ASSERT_OK_AND_ASSIGN(auto nscalar, nd->GetScalar(i))
+      EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, ::testing::HasSubstr(expected_msg),
+                                      func(scalar, nscalar, options_, nullptr));
+    }
+  }
+
+  void AssertBinaryOpNotImplemented(BinaryFunction func, const std::string& argument,
+                                    const std::string& ndigits) {
+    auto arg = ArrayFromJSON(type_singleton(), argument);
+    auto nd = ArrayFromJSON(int32(), ndigits);
+    const char* expected_msg = "has no kernel matching input types";
+    EXPECT_RAISES_WITH_MESSAGE_THAT(NotImplemented, ::testing::HasSubstr(expected_msg),
+                                    func(arg, nd, options_, nullptr));
+  }
+
+  void ValidateAndAssertApproxEqual(const std::shared_ptr<Array>& actual,
+                                    const std::string& expected) {
+    const auto exp = ArrayFromJSON(type_singleton(), expected);
+    ValidateAndAssertApproxEqual(actual, exp);
+  }
+
+  void ValidateAndAssertApproxEqual(const std::shared_ptr<Array>& actual,
+                                    const std::shared_ptr<Array>& expected) {
+    ValidateOutput(*actual);
+    AssertArraysApproxEqual(*expected, *actual, /*verbose=*/true, equal_options_);
+  }
+
+  void SetNansEqual(bool value = true) {
+    equal_options_ = equal_options_.nans_equal(value);
+  }
+
+  OptionsType options_ = OptionsType();
+  EqualOptions equal_options_ = EqualOptions::Defaults().signed_zeros_equal(false);
+};
+
+// Subclasses of TestBaseBinaryRoundArithmetic for different FunctionOptions.
+template <typename T>
+class TestBinaryRoundArithmetic
+    : public TestBaseBinaryRoundArithmetic<T, RoundBinaryOptions> {
+ protected:
+  using Base = TestBaseBinaryRoundArithmetic<T, RoundBinaryOptions>;
+  using Base::options_;
+
+  void SetRoundMode(RoundMode value) { options_.round_mode = value; }
+};
+
+template <typename T>
+class TestBinaryRound : public TestBaseBinaryRoundArithmetic<T, RoundBinaryOptions> {
+ protected:
+  using Base = TestBaseBinaryRoundArithmetic<T, RoundBinaryOptions>;
+  using Base::options_;
+
+  void SetRoundMode(RoundMode value) { options_.round_mode = value; }
+};
+
+template <typename T>
+class TestBinaryRoundIntegral : public TestBinaryRound<T> {};
+
+template <typename T>
+class TestBinaryRoundSigned : public TestBinaryRoundIntegral<T> {};
+
+template <typename T>
+class TestBinaryRoundUnsigned : public TestBinaryRoundIntegral<T> {};
+
+template <typename T>
+class TestBinaryRoundFloating : public TestBinaryRoundArithmetic<T> {};
+
 template <typename T>
 class TestUnaryRoundToMultiple
     : public TestBaseUnaryRoundArithmetic<T, RoundToMultipleOptions> {
@@ -280,71 +462,10 @@ class TestRoundArithmeticDecimal : public ::testing::Test {
   }
 };
 
-template <typename T>
-class TestBinaryRoundArithmetic : public ::testing::Test {
- protected:
-  using ArrowType = T;
-  using CType = typename ArrowType::c_type;
-
-  static std::shared_ptr<DataType> type_singleton() {
-    return TypeTraits<ArrowType>::type_singleton();
-  }
-
-  using BinaryFunction = std::function<Result<Datum>(const Datum&, const Datum&,
-                                                     ArithmeticOptions, ExecContext*)>;
-
-  void SetUp() override { options_.check_overflow = false; }
-
-  std::shared_ptr<Scalar> MakeNullScalar() {
-    return arrow::MakeNullScalar(type_singleton());
-  }
-
-  std::shared_ptr<Scalar> MakeScalar(CType value) {
-    return *arrow::MakeScalar(type_singleton(), value);
-  }
-
-  void ValidateAndAssertApproxEqual(const std::shared_ptr<Array>& actual,
-                                    const std::string& expected) {
-    ValidateAndAssertApproxEqual(actual, ArrayFromJSON(type_singleton(), expected));
-  }
-
-  void ValidateAndAssertApproxEqual(const std::shared_ptr<Array>& actual,
-                                    const std::shared_ptr<Array>& expected) {
-    ValidateOutput(*actual);
-    AssertArraysApproxEqual(*expected, *actual, /*verbose=*/true, equal_options_);
-  }
-
-  void SetOverflowCheck(bool value = true) { options_.check_overflow = value; }
-
-  void SetNansEqual(bool value = true) {
-    this->equal_options_ = equal_options_.nans_equal(value);
-  }
-
-  ArithmeticOptions options_ = ArithmeticOptions();
-  EqualOptions equal_options_ = EqualOptions::Defaults().signed_zeros_equal(false);
-};
-
-template <typename T>
-class TestBinaryRoundArithmeticIntegral : public TestBinaryRoundArithmetic<T> {};
-
-template <typename T>
-class TestBinaryRoundArithmeticSigned : public TestBinaryRoundArithmeticIntegral<T> {};
-
-template <typename T>
-class TestBinaryRoundArithmeticUnsigned : public TestBinaryRoundArithmeticIntegral<T> {};
-
-template <typename T>
-class TestBinaryRoundArithmeticFloating : public TestBinaryRoundArithmetic<T> {};
-
 TYPED_TEST_SUITE(TestUnaryRoundArithmeticIntegral, IntegralTypes);
 TYPED_TEST_SUITE(TestUnaryRoundArithmeticSigned, SignedIntegerTypes);
 TYPED_TEST_SUITE(TestUnaryRoundArithmeticUnsigned, UnsignedIntegerTypes);
 TYPED_TEST_SUITE(TestUnaryRoundArithmeticFloating, FloatingTypes);
-
-TYPED_TEST_SUITE(TestBinaryRoundArithmeticIntegral, IntegralTypes);
-TYPED_TEST_SUITE(TestBinaryRoundArithmeticSigned, SignedIntegerTypes);
-TYPED_TEST_SUITE(TestBinaryRoundArithmeticUnsigned, UnsignedIntegerTypes);
-TYPED_TEST_SUITE(TestBinaryRoundArithmeticFloating, FloatingTypes);
 
 TEST(TestUnaryRound, DispatchBestRound) {
   // Integer -> Float64
@@ -965,6 +1086,97 @@ TYPED_TEST(TestUnaryRoundFloating, Round) {
   }
 }
 
+TYPED_TEST_SUITE(TestBinaryRoundIntegral, IntegralTypes);
+TYPED_TEST_SUITE(TestBinaryRoundSigned, SignedIntegerTypes);
+TYPED_TEST_SUITE(TestBinaryRoundUnsigned, UnsignedIntegerTypes);
+TYPED_TEST_SUITE(TestBinaryRoundFloating, FloatingTypes);
+
+TYPED_TEST(TestBinaryRoundSigned, Round) {
+  // Test different rounding modes for integer rounding
+  std::string values("[0, 1, -13, -50, 115]");
+  for (const auto& round_mode : kRoundModes) {
+    this->SetRoundMode(round_mode);
+    this->AssertBinaryOp(RoundBinary, values, 0, ArrayFromJSON(float64(), values));
+  }
+
+  // Test different round N-digits for nearest rounding mode
+  std::vector<std::pair<int32_t, std::string>> ndigits_and_expected{{
+      {-2, "[0.0, 0.0, -0.0, -100, 100]"},
+      {-1, "[0.0, 0.0, -10, -50, 120]"},
+      {0, values},
+      {1, values},
+      {2, values},
+  }};
+  this->SetRoundMode(RoundMode::HALF_TOWARDS_INFINITY);
+  for (const auto& pair : ndigits_and_expected) {
+    this->AssertBinaryOp(RoundBinary, values, pair.first,
+                         ArrayFromJSON(float64(), pair.second));
+  }
+}
+
+TYPED_TEST(TestBinaryRoundUnsigned, Round) {
+  // Test different rounding modes for integer rounding
+  std::string values("[0, 1, 13, 50, 115]");
+  for (const auto& round_mode : kRoundModes) {
+    this->SetRoundMode(round_mode);
+    this->AssertBinaryOp(RoundBinary, values, 0, ArrayFromJSON(float64(), values));
+  }
+
+  // Test different round N-digits for nearest rounding mode
+  std::vector<std::pair<int32_t, std::string>> ndigits_and_expected{{
+      {-2, "[0, 0, 0, 100, 100]"},
+      {-1, "[0, 0, 10, 50, 120]"},
+      {0, values},
+      {1, values},
+      {2, values},
+  }};
+  this->SetRoundMode(RoundMode::HALF_TOWARDS_INFINITY);
+  for (const auto& pair : ndigits_and_expected) {
+    this->AssertBinaryOp(RoundBinary, values, pair.first,
+                         ArrayFromJSON(float64(), pair.second));
+  }
+}
+
+TYPED_TEST(TestBinaryRoundFloating, Round) {
+  this->SetNansEqual(true);
+
+  // Test different rounding modes
+  std::string values("[3.2, 3.5, 3.7, 4.5, -3.2, -3.5, -3.7]");
+  std::vector<std::pair<RoundMode, std::string>> rmode_and_expected{{
+      {RoundMode::DOWN, "[3, 3, 3, 4, -4, -4, -4]"},
+      {RoundMode::UP, "[4, 4, 4, 5, -3, -3, -3]"},
+      {RoundMode::TOWARDS_ZERO, "[3, 3, 3, 4, -3, -3, -3]"},
+      {RoundMode::TOWARDS_INFINITY, "[4, 4, 4, 5, -4, -4, -4]"},
+      {RoundMode::HALF_DOWN, "[3, 3, 4, 4, -3, -4, -4]"},
+      {RoundMode::HALF_UP, "[3, 4, 4, 5, -3, -3, -4]"},
+      {RoundMode::HALF_TOWARDS_ZERO, "[3, 3, 4, 4, -3, -3, -4]"},
+      {RoundMode::HALF_TOWARDS_INFINITY, "[3, 4, 4, 5, -3, -4, -4]"},
+      {RoundMode::HALF_TO_EVEN, "[3, 4, 4, 4, -3, -4, -4]"},
+      {RoundMode::HALF_TO_ODD, "[3, 3, 4, 5, -3, -3, -4]"},
+  }};
+  for (const auto& pair : rmode_and_expected) {
+    this->SetRoundMode(pair.first);
+    this->AssertBinaryOp(RoundBinary, "[]", "[]", "[]");
+    this->AssertBinaryOp(RoundBinary, "[null, 0, Inf, -Inf, NaN, -NaN]",
+                         "[0, 0, 0, 0, 0, 0]", "[null, 0, Inf, -Inf, NaN, -NaN]");
+    this->AssertBinaryOp(RoundBinary, values, 0, pair.second);
+  }
+
+  // Test different round N-digits for nearest rounding mode
+  values = "[320, 3.5, 3.075, 4.5, -3.212, -35.1234, -3.045]";
+  std::vector<std::pair<int32_t, std::string>> ndigits_and_expected{{
+      {-2, "[300, 0.0, 0.0, 0.0, -0.0, -0.0, -0.0]"},
+      {-1, "[320, 0.0, 0.0, 0.0, -0.0, -40, -0.0]"},
+      {0, "[320, 4, 3, 5, -3, -35, -3]"},
+      {1, "[320, 3.5, 3.1, 4.5, -3.2, -35.1, -3]"},
+      {2, "[320, 3.5, 3.08, 4.5, -3.21, -35.12, -3.05]"},
+  }};
+  this->SetRoundMode(RoundMode::HALF_TOWARDS_INFINITY);
+  for (const auto& pair : ndigits_and_expected) {
+    this->AssertBinaryOp(RoundBinary, values, pair.first, pair.second);
+  }
+}
+
 TYPED_TEST_SUITE(TestUnaryRoundToMultipleIntegral, IntegralTypes);
 TYPED_TEST_SUITE(TestUnaryRoundToMultipleSigned, SignedIntegerTypes);
 TYPED_TEST_SUITE(TestUnaryRoundToMultipleUnsigned, UnsignedIntegerTypes);
@@ -1063,8 +1275,6 @@ TYPED_TEST(TestUnaryRoundToMultipleFloating, RoundToMultiple) {
   this->AssertUnaryOpRaises(RoundToMultiple, values,
                             "Rounding multiple must be positive");
 }
-
-class TestBinaryRoundArithmeticDecimal : public TestRoundArithmeticDecimal {};
 
 TYPED_TEST(TestUnaryRoundArithmeticSigned, Floor) {
   auto floor = [](const Datum& arg, const ArithmeticOptions&, ExecContext* ctx) {

--- a/cpp/src/arrow/engine/substrait/extension_set.cc
+++ b/cpp/src/arrow/engine/substrait/extension_set.cc
@@ -24,6 +24,7 @@
 #include <sstream>
 #include <unordered_set>
 
+#include "arrow/compute/api_scalar.h"
 #include "arrow/engine/substrait/options.h"
 #include "arrow/type.h"
 #include "arrow/type_fwd.h"
@@ -714,6 +715,11 @@ enum class OverflowBehavior { kSilent = 0, kSaturate, kError };
 static std::vector<std::string> kOverflowOptions = {"SILENT", "SATURATE", "ERROR"};
 static EnumParser<OverflowBehavior> kOverflowParser(kOverflowOptions);
 
+static std::vector<std::string> kRoundModes = {
+    "FLOOR",  "CEILING",          "TRUNCATE",           "AWAY_FROM_ZERO", "TIE_DOWN",
+    "TIE_UP", "TIE_TOWARDS_ZERO", "TIE_AWAY_FROM_ZERO", "TIE_TO_EVEN",    "TIE_TO_ODD"};
+static EnumParser<compute::RoundMode> kRoundModeParser(kRoundModes);
+
 template <typename Enum>
 Result<Enum> ParseOptionOrElse(const SubstraitCall& call, std::string_view option_name,
                                const EnumParser<Enum>& parser,
@@ -787,6 +793,30 @@ ExtensionIdRegistry::SubstraitCallToArrow DecodeOptionlessUncheckedArithmetic(
     ARROW_ASSIGN_OR_RAISE(std::vector<compute::Expression> value_args,
                           GetValueArgs(call, 0));
     return arrow::compute::call(function_name, std::move(value_args));
+  };
+}
+
+ExtensionIdRegistry::SubstraitCallToArrow DecodeBinaryRoundingMode(
+    const std::string& function_name) {
+  return [function_name](const SubstraitCall& call) -> Result<compute::Expression> {
+    ARROW_ASSIGN_OR_RAISE(
+        compute::RoundMode round_mode,
+        ParseOptionOrElse(
+            call, "rounding", kRoundModeParser,
+            {compute::RoundMode::DOWN, compute::RoundMode::UP,
+             compute::RoundMode::TOWARDS_ZERO, compute::RoundMode::TOWARDS_INFINITY,
+             compute::RoundMode::HALF_DOWN, compute::RoundMode::HALF_UP,
+             compute::RoundMode::HALF_TOWARDS_ZERO,
+             compute::RoundMode::HALF_TOWARDS_INFINITY, compute::RoundMode::HALF_TO_EVEN,
+             compute::RoundMode::HALF_TO_ODD},
+            compute::RoundMode::HALF_TOWARDS_INFINITY));
+    ARROW_ASSIGN_OR_RAISE(std::vector<compute::Expression> value_args,
+                          GetValueArgs(call, 0));
+    std::shared_ptr<compute::RoundBinaryOptions> options =
+        std::make_shared<compute::RoundBinaryOptions>();
+    options->round_mode = round_mode;
+    return arrow::compute::call("round_binary", std::move(value_args),
+                                std::move(options));
   };
 }
 
@@ -953,6 +983,9 @@ struct DefaultExtensionIdRegistry : ExtensionIdRegistryImpl {
           AddSubstraitCallToArrow({kSubstraitRoundingFunctionsUri, function_name},
                                   DecodeOptionlessUncheckedArithmetic(function_name)));
     }
+    // Expose only the binary version of round
+    DCHECK_OK(AddSubstraitCallToArrow({kSubstraitRoundingFunctionsUri, "round"},
+                                      DecodeBinaryRoundingMode("round_binary")));
 
     // Basic mappings that need _kleene appended to them
     for (const auto& function_name : {"or", "and"}) {

--- a/cpp/src/arrow/engine/substrait/function_test.cc
+++ b/cpp/src/arrow/engine/substrait/function_test.cc
@@ -15,11 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <algorithm>
-#include <cstddef>
 #include <memory>
 #include <string>
-#include <string_view>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -172,7 +169,7 @@ void CheckErrorTestCases(const std::vector<FunctionTestCase>& error_cases) {
 }
 
 template <typename ErrorMatcher>
-void CheckNonYetImplementedTestCase(const FunctionTestCase& test_case,
+void CheckNotYetImplementedTestCase(const FunctionTestCase& test_case,
                                     ErrorMatcher error_matcher) {
   ARROW_SCOPED_TRACE("func=", test_case.function_id.uri, "#", test_case.function_id.name);
   std::shared_ptr<Table> output_table;
@@ -456,7 +453,41 @@ TEST(FunctionMapping, ValidCases) {
        kNoOptions,
        {float64()},
        "4",
-       float64()}};
+       float64()},
+      {{kSubstraitRoundingFunctionsUri, "round"},
+       {"323.125", "2"},
+       {
+           {"rounding", {"TIE_AWAY_FROM_ZERO"}},
+           {"function", {"0"}},
+       },
+       {float32(), int32()},
+       "323.13",
+       float32()},
+      {{kSubstraitRoundingFunctionsUri, "round"},
+       {"323.125", "-2"},
+       {
+           {"rounding", {"TIE_AWAY_FROM_ZERO"}},
+           {"function", {"0"}},
+       },
+       {float64(), int32()},
+       "300",
+       float64()},
+      {{kSubstraitRoundingFunctionsUri, "round"},
+       {"323.135", "2"},
+       {
+           {"rounding", {"TIE_TO_EVEN"}},
+           {"function", {"0"}},
+       },
+       {float64(), int32()},
+       "323.14",
+       float64()},
+      {{kSubstraitRoundingFunctionsUri, "round"},
+       {"323", "-2"},
+       {{"rounding", {"TIE_AWAY_FROM_ZERO"}}},
+       {int64(), int32()},
+       "300",
+       float64()},
+  };
   CheckValidTestCases(valid_test_cases);
 }
 
@@ -490,7 +521,7 @@ TEST(FunctionMapping, ErrorCases) {
 }
 
 TEST(FunctionMapping, UnrecognizedOptions) {
-  CheckNonYetImplementedTestCase(
+  CheckNotYetImplementedTestCase(
       {{kSubstraitArithmeticFunctionsUri, "add"},
        {"-119", "10"},
        {{"overflow", {"NEW_OVERFLOW_TYPE", "SILENT"}}},
@@ -498,7 +529,7 @@ TEST(FunctionMapping, UnrecognizedOptions) {
        "",
        int8()},
       ::testing::HasSubstr("The value NEW_OVERFLOW_TYPE is not an expected enum value"));
-  CheckNonYetImplementedTestCase(
+  CheckNotYetImplementedTestCase(
       {{kSubstraitArithmeticFunctionsUri, "add"},
        {"-119", "10"},
        {{"overflow", {"SATURATE"}}},


### PR DESCRIPTION
Adds binary round kernel for float types.
Provides fallback for binary round from int types to double. Does not provide fallback for binary round for decimal types.

Minor:
Fixes fallback behavior to only affect the first argument. Corrects fallback error message to display the original type instead of the fallback type when the underlying type cannot be found. Round benchmark changed to be driven like arithmetic benchamrk instead of the string benchmark.

Trivial:
Renames Arithmetic to Round to match the containing module. Removes some unreachable code.

* Closes: #15200