### PR TITLE
GH-33777: [R] Nightly builds failing due to dataset test not being skipped on builds without datasets module

### DIFF
--- a/r/tests/testthat/test-dplyr-query.R
+++ b/r/tests/testthat/test-dplyr-query.R
@@ -742,6 +742,7 @@ test_that("Can use nested field refs", {
   )
 
   # Now with Dataset: make sure column pushdown in ScanNode works
+  skip_if_not_available("dataset")
   expect_equal(
     nested_data %>%
       InMemoryDataset$create() %>%


### PR DESCRIPTION
The minimal builds were failing due to a new test which requires the datasets module; I've just skipped this test on builds where this module isn't installed.

* Closes: #33777