### PR TITLE
GH-33779: [R] Nightly builds (R 3.5 and 3.6) failing due to field refs test

### DIFF
--- a/r/tests/testthat/test-expression.R
+++ b/r/tests/testthat/test-expression.R
@@ -148,7 +148,7 @@ test_that("Nested field ref types", {
 })
 
 test_that("Nested field from a non-field-ref (struct_field kernel)", {
-  x <- Expression$scalar(data.frame(a = 1, b = "two"))
+  x <- Expression$scalar(tibble::tibble(a = 1, b = "two"))
   expect_true(inherits(x$a, "Expression"))
   expect_equal(x$a$type(), float64())
   expect_error(x$c, "field 'c' not found in struct<a: double, b: string>")


### PR DESCRIPTION
This PR fixes a test which is failing on R versions < 4.0 due to the use of the function `data.frame()` which had a change in default parameter value for `stringsAsFactors` (from `TRUE` to `FALSE`) in 4.0, and so is behaving differently in these versions.  

I've just swapped out the use of `data.frame()` for `tibble::tibble()` , which we use more prevalently in our tests, and has no such issues on earlier R version.

* Closes: #33779