### PR TITLE
MINOR: [Docs][Format] Add link to IPC section on the Columnar page

### DIFF
--- a/docs/source/format/IPC.rst
+++ b/docs/source/format/IPC.rst
@@ -20,5 +20,6 @@
 IPC
 ===
 
-The contents of this document have relocated to the main :ref:`Columnar
-Specification <format_columnar>` page.
+The contents of this document have relocated to the :ref:`Serialization and
+Interprocess Communication (IPC) <format-ipc>` section on the main
+:ref:`Columnar Specification <format_columnar>` page.


### PR DESCRIPTION
### Rationale for this change

Linking directly to the IPC section makes it easier to find what people are looking for.

### What changes are included in this PR?

Adds a link to the section about IPC (on the columnar page) from the IPC page.