### PR TITLE
GH-33782: [Release] Vote email number of issues is querying JIRA and producing a wrong number

### DIFF
--- a/dev/release/02-source.sh
+++ b/dev/release/02-source.sh
@@ -142,13 +142,14 @@ if [ ${SOURCE_PR} -gt 0 ]; then
 fi
 
 if [ ${SOURCE_VOTE} -gt 0 ]; then
-  graphql_url="https://api.github.com/graphql"
-  curl_options=($graphql_url)
+  gh_api_url="https://api.github.com/graphql"
+
+  curl_options=($gh_api_url)
   curl_options+=(--header "Authorization: Bearer ${ARROW_GITHUB_API_TOKEN}")
   curl_options+=(--data "{\"query\": \"query {search(query: \\\"repo:apache/arrow is:issue is:closed milestone:${version}\\\", type:ISSUE) {issueCount}}\"}")
   n_resolved_issues=$(curl "${curl_options[@]}" | jq ".data.search.issueCount")
 
-  curl_options=($graphql_url)
+  curl_options=($gh_api_url)
   curl_options+=(--header "Authorization: Bearer ${ARROW_GITHUB_API_TOKEN}")
   curl_options+=(--data "{\"query\": \"query {repository(owner: \\\"apache\\\", name: \\\"arrow\\\") {refs(first: 1, refPrefix: \\\"refs/heads/\\\", query: \\\"${rc_branch}\\\") {nodes{associatedPullRequests(first: 1){edges{node{url}}}}}}}\"}")
   verify_pr_url=$(curl "${curl_options[@]}" | jq -r ".data.repository.refs.nodes[0].associatedPullRequests.edges[0].node.url")

--- a/dev/release/test-helper.rb
+++ b/dev/release/test-helper.rb
@@ -19,6 +19,7 @@ require "English"
 require "cgi/util"
 require "fileutils"
 require "find"
+require 'net/http'
 require "json"
 require "open-uri"
 require "rexml/document"


### PR DESCRIPTION
### What changes are included in this PR?

Release RC vote email now gets issue number and verify release PR's url from GitHub's GraphQL API.

### Are these changes tested?

Changes were tested stand-alone from the rest of this script.

### Are there any user-facing changes?

ARROW_GITHUB_API_TOKEN is now mandatory for generating the release vote email.
* Closes: #33782