### PR TITLE
GH-15054: [Python] Finalize S3 on pytest exit to prevent shutdown crashes

### DIFF
--- a/python/pyarrow/conftest.py
+++ b/python/pyarrow/conftest.py
@@ -265,3 +265,14 @@ def add_fs(doctest_namespace, request, tmp_path):
         doctest_namespace["local_path"] = str(tmp_path)
         doctest_namespace["path"] = str(path)
     yield
+
+# hookimpl(trylast=True) is required to ensure this runs after session scoped fixtures
+# which may try and use S3.  See https://github.com/pytest-dev/pytest/issues/7484
+@pytest.hookimpl(trylast=True)
+def pytest_sessionfinish(session):
+    print('Session finished, finalizing s3')
+    try:
+        from pyarrow.fs import finalize_s3
+        finalize_s3()
+    except ImportError:
+        pass

--- a/python/pyarrow/conftest.py
+++ b/python/pyarrow/conftest.py
@@ -270,7 +270,6 @@ def add_fs(doctest_namespace, request, tmp_path):
 # which may try and use S3.  See https://github.com/pytest-dev/pytest/issues/7484
 @pytest.hookimpl(trylast=True)
 def pytest_sessionfinish(session):
-    print('Session finished, finalizing s3')
     try:
         from pyarrow.fs import finalize_s3
         finalize_s3()


### PR DESCRIPTION
For some reason destroying an S3Client at shutdown can cause a crash in our tests.  It appears to be because S3's logging is already shut down.  I wouldn't think this would happen because I would think the linker would tear down S3 shared libraries AFTER it tears down Arrow shared libraries.

However, we can also finalize S3 in conftest.py to prevent this crash.

It would still be good to understand the root cause.  Otherwise we need to advise our users to call finalize_s3.
* Closes: #15054