### PR TITLE
GH-33783: [C#] Update release verification to use .NET 7.0

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install C#
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: |
+          dotnet-version: >
 	    6.0.x
 	    7.0.x
       - name: Checkout Arrow
@@ -83,7 +83,7 @@ jobs:
       - name: Install C#
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: |
+          dotnet-version: >
 	    6.0.x
 	    7.0.x
       - name: Checkout Arrow
@@ -114,7 +114,7 @@ jobs:
       - name: Install C#
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: |
+          dotnet-version: >
 	    6.0.x
 	    7.0.x
       - name: Checkout Arrow

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -20,14 +20,14 @@ name: C#
 on:
   push:
     paths:
-      - '.github/workflows/csharp.yml'
-      - 'ci/scripts/csharp_*'
-      - 'csharp/**'
+      - ".github/workflows/csharp.yml"
+      - "ci/scripts/csharp_*"
+      - "csharp/**"
   pull_request:
     paths:
-      - '.github/workflows/csharp.yml'
-      - 'ci/scripts/csharp_*'
-      - 'csharp/**'
+      - ".github/workflows/csharp.yml"
+      - "ci/scripts/csharp_*"
+      - "csharp/**"
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
@@ -37,7 +37,6 @@ permissions:
   contents: read
 
 jobs:
-
   ubuntu:
     name: AMD64 Ubuntu 18.04 C# ${{ matrix.dotnet }}
     runs-on: ubuntu-latest
@@ -46,13 +45,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dotnet: ['6.0.x', '7.0.x']
+        dotnet: ["7.0.x"]
     steps:
       - name: Install C#
         uses: actions/setup-dotnet@v2
         with:
           dotnet-version: |
-            6.0.x
             7.0.x
       - name: Checkout Arrow
         uses: actions/checkout@v3
@@ -78,13 +76,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dotnet: ['6.0.x', '7.0.x']
+        dotnet: ["7.0.x"]
     steps:
       - name: Install C#
         uses: actions/setup-dotnet@v2
         with:
           dotnet-version: |
-            6.0.x
             7.0.x
       - name: Checkout Arrow
         uses: actions/checkout@v3
@@ -109,13 +106,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dotnet: ['6.0.x', '7.0.x']
+        dotnet: ["7.0.x"]
     steps:
       - name: Install C#
         uses: actions/setup-dotnet@v2
         with:
           dotnet-version: |
-            6.0.x
             7.0.x
       - name: Checkout Arrow
         uses: actions/checkout@v3

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -51,9 +51,9 @@ jobs:
       - name: Install C#
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: >
-	    6.0.x
-	    7.0.x
+          dotnet-version: |
+            6.0.x
+            7.0.x
       - name: Checkout Arrow
         uses: actions/checkout@v3
         with:
@@ -67,8 +67,8 @@ jobs:
       - name: Test
         shell: bash
         run: ci/scripts/csharp_test.sh $(pwd)
-	env:
-	  DOTNET_VERSION: ${{ matrix.dotnet }}
+        env:
+          DOTNET_VERSION: ${{ matrix.dotnet }}
 
   windows:
     name: AMD64 Windows 2019 18.04 C# ${{ matrix.dotnet }}
@@ -83,9 +83,9 @@ jobs:
       - name: Install C#
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: >
-	    6.0.x
-	    7.0.x
+          dotnet-version: |
+            6.0.x
+            7.0.x
       - name: Checkout Arrow
         uses: actions/checkout@v3
         with:
@@ -98,8 +98,8 @@ jobs:
       - name: Test
         shell: bash
         run: ci/scripts/csharp_test.sh $(pwd)
-	env:
-	  DOTNET_VERSION: ${{ matrix.dotnet }}
+        env:
+          DOTNET_VERSION: ${{ matrix.dotnet }}
 
   macos:
     name: AMD64 macOS 11 C# ${{ matrix.dotnet }}
@@ -114,9 +114,9 @@ jobs:
       - name: Install C#
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: >
-	    6.0.x
-	    7.0.x
+          dotnet-version: |
+            6.0.x
+            7.0.x
       - name: Checkout Arrow
         uses: actions/checkout@v3
         with:
@@ -130,5 +130,5 @@ jobs:
       - name: Test
         shell: bash
         run: ci/scripts/csharp_test.sh $(pwd)
-	env:
-	  DOTNET_VERSION: ${{ matrix.dotnet }}
+        env:
+          DOTNET_VERSION: ${{ matrix.dotnet }}

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -46,12 +46,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dotnet: ['6.0.x']
+        dotnet: ['6.0.x', '7.0.x']
     steps:
       - name: Install C#
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: ${{ matrix.dotnet }}
+          dotnet-version: |
+	    6.0.x
+	    7.0.x
       - name: Checkout Arrow
         uses: actions/checkout@v3
         with:
@@ -65,6 +67,8 @@ jobs:
       - name: Test
         shell: bash
         run: ci/scripts/csharp_test.sh $(pwd)
+	env:
+	  DOTNET_VERSION: ${{ matrix.dotnet }}
 
   windows:
     name: AMD64 Windows 2019 18.04 C# ${{ matrix.dotnet }}
@@ -74,12 +78,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dotnet: ['6.0.x']
+        dotnet: ['6.0.x', '7.0.x']
     steps:
       - name: Install C#
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: ${{ matrix.dotnet }}
+          dotnet-version: |
+	    6.0.x
+	    7.0.x
       - name: Checkout Arrow
         uses: actions/checkout@v3
         with:
@@ -92,6 +98,8 @@ jobs:
       - name: Test
         shell: bash
         run: ci/scripts/csharp_test.sh $(pwd)
+	env:
+	  DOTNET_VERSION: ${{ matrix.dotnet }}
 
   macos:
     name: AMD64 macOS 11 C# ${{ matrix.dotnet }}
@@ -101,12 +109,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dotnet: ['6.0.x']
+        dotnet: ['6.0.x', '7.0.x']
     steps:
       - name: Install C#
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: ${{ matrix.dotnet }}
+          dotnet-version: |
+	    6.0.x
+	    7.0.x
       - name: Checkout Arrow
         uses: actions/checkout@v3
         with:
@@ -120,3 +130,5 @@ jobs:
       - name: Test
         shell: bash
         run: ci/scripts/csharp_test.sh $(pwd)
+	env:
+	  DOTNET_VERSION: ${{ matrix.dotnet }}

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -20,14 +20,14 @@ name: C#
 on:
   push:
     paths:
-      - ".github/workflows/csharp.yml"
-      - "ci/scripts/csharp_*"
-      - "csharp/**"
+      - '.github/workflows/csharp.yml'
+      - 'ci/scripts/csharp_*'
+      - 'csharp/**'
   pull_request:
     paths:
-      - ".github/workflows/csharp.yml"
-      - "ci/scripts/csharp_*"
-      - "csharp/**"
+      - '.github/workflows/csharp.yml'
+      - 'ci/scripts/csharp_*'
+      - 'csharp/**'
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
@@ -37,6 +37,7 @@ permissions:
   contents: read
 
 jobs:
+
   ubuntu:
     name: AMD64 Ubuntu 18.04 C# ${{ matrix.dotnet }}
     runs-on: ubuntu-latest
@@ -45,13 +46,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dotnet: ["7.0.x"]
+        dotnet: ['7.0.x']
     steps:
       - name: Install C#
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: |
-            7.0.x
+          dotnet-version: ${{ matrix.dotnet }}
       - name: Checkout Arrow
         uses: actions/checkout@v3
         with:
@@ -65,8 +65,6 @@ jobs:
       - name: Test
         shell: bash
         run: ci/scripts/csharp_test.sh $(pwd)
-        env:
-          DOTNET_VERSION: ${{ matrix.dotnet }}
 
   windows:
     name: AMD64 Windows 2019 18.04 C# ${{ matrix.dotnet }}
@@ -76,13 +74,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dotnet: ["7.0.x"]
+        dotnet: ['7.0.x']
     steps:
       - name: Install C#
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: |
-            7.0.x
+          dotnet-version: ${{ matrix.dotnet }}
       - name: Checkout Arrow
         uses: actions/checkout@v3
         with:
@@ -95,8 +92,6 @@ jobs:
       - name: Test
         shell: bash
         run: ci/scripts/csharp_test.sh $(pwd)
-        env:
-          DOTNET_VERSION: ${{ matrix.dotnet }}
 
   macos:
     name: AMD64 macOS 11 C# ${{ matrix.dotnet }}
@@ -106,13 +101,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dotnet: ["7.0.x"]
+        dotnet: ['7.0.x']
     steps:
       - name: Install C#
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: |
-            7.0.x
+          dotnet-version: ${{ matrix.dotnet }}
       - name: Checkout Arrow
         uses: actions/checkout@v3
         with:
@@ -126,5 +120,3 @@ jobs:
       - name: Test
         shell: bash
         run: ci/scripts/csharp_test.sh $(pwd)
-        env:
-          DOTNET_VERSION: ${{ matrix.dotnet }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install .NET
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '7.0.x'
       - name: Install Dependencies
         shell: bash
         run: |

--- a/ci/docker/conda-integration.dockerfile
+++ b/ci/docker/conda-integration.dockerfile
@@ -53,7 +53,7 @@ RUN wget -nv -O - https://dl.google.com/go/go${go}.linux-${arch}.tar.gz | tar -x
 
 ENV DOTNET_ROOT=/opt/dotnet \
     PATH=/opt/dotnet:$PATH
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -Channel 6.0 -InstallDir /opt/dotnet
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -Channel 7.0 -InstallDir /opt/dotnet
 
 ENV ARROW_BUILD_INTEGRATION=ON \
     ARROW_BUILD_STATIC=OFF \

--- a/ci/docker/ubuntu-20.04-csharp.dockerfile
+++ b/ci/docker/ubuntu-20.04-csharp.dockerfile
@@ -16,7 +16,7 @@
 # under the License.
 
 ARG arch=amd64
-ARG dotnet=6.0
+ARG dotnet=7.0
 ARG platform=focal
 FROM mcr.microsoft.com/dotnet/sdk:${dotnet}-${platform}-${arch}
 

--- a/ci/scripts/csharp_test.sh
+++ b/ci/scripts/csharp_test.sh
@@ -21,8 +21,14 @@ set -ex
 
 source_dir=${1}/csharp
 
+if [ ${DOTNET_VERSION} = '6.0.x' ]; then
+  FRAMEWORK='net6.0'
+elif [ ${DOTNET_VERSION} = '7.0.x' ]; then
+  FRAMEWORK='net7.0'
+fi
+
 pushd ${source_dir}
-dotnet test
+dotnet test --framework ${FRAMEWORK}
 for pdb in artifacts/Apache.Arrow/*/*/Apache.Arrow.pdb; do
   sourcelink test ${pdb}
 done

--- a/ci/scripts/csharp_test.sh
+++ b/ci/scripts/csharp_test.sh
@@ -21,14 +21,8 @@ set -ex
 
 source_dir=${1}/csharp
 
-if [ ${DOTNET_VERSION} = '6.0.x' ]; then
-  FRAMEWORK='net6.0'
-elif [ ${DOTNET_VERSION} = '7.0.x' ]; then
-  FRAMEWORK='net7.0'
-fi
-
 pushd ${source_dir}
-dotnet test --framework ${FRAMEWORK}
+dotnet test
 for pdb in artifacts/Apache.Arrow/*/*/Apache.Arrow.pdb; do
   sourcelink test ${pdb}
 done

--- a/csharp/examples/FlightAspServerExample/FlightAspServerExample.csproj
+++ b/csharp/examples/FlightAspServerExample/FlightAspServerExample.csproj
@@ -20,7 +20,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>10</LangVersion>

--- a/csharp/examples/FlightClientExample/FlightClientExample.csproj
+++ b/csharp/examples/FlightClientExample/FlightClientExample.csproj
@@ -21,7 +21,7 @@
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/csharp/examples/FluentBuilderExample/FluentBuilderExample.csproj
+++ b/csharp/examples/FluentBuilderExample/FluentBuilderExample.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/csharp/test/Apache.Arrow.Benchmarks/Apache.Arrow.Benchmarks.csproj
+++ b/csharp/test/Apache.Arrow.Benchmarks/Apache.Arrow.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/csharp/test/Apache.Arrow.Flight.TestWeb/Apache.Arrow.Flight.TestWeb.csproj
+++ b/csharp/test/Apache.Arrow.Flight.TestWeb/Apache.Arrow.Flight.TestWeb.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/csharp/test/Apache.Arrow.Flight.TestWeb/Apache.Arrow.Flight.TestWeb.csproj
+++ b/csharp/test/Apache.Arrow.Flight.TestWeb/Apache.Arrow.Flight.TestWeb.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/csharp/test/Apache.Arrow.Flight.Tests/Apache.Arrow.Flight.Tests.csproj
+++ b/csharp/test/Apache.Arrow.Flight.Tests/Apache.Arrow.Flight.Tests.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/csharp/test/Apache.Arrow.Flight.Tests/Apache.Arrow.Flight.Tests.csproj
+++ b/csharp/test/Apache.Arrow.Flight.Tests/Apache.Arrow.Flight.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/csharp/test/Apache.Arrow.IntegrationTest/Apache.Arrow.IntegrationTest.csproj
+++ b/csharp/test/Apache.Arrow.IntegrationTest/Apache.Arrow.IntegrationTest.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/csharp/test/Apache.Arrow.IntegrationTest/Apache.Arrow.IntegrationTest.csproj
+++ b/csharp/test/Apache.Arrow.IntegrationTest/Apache.Arrow.IntegrationTest.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/csharp/test/Apache.Arrow.Tests/Apache.Arrow.Tests.csproj
+++ b/csharp/test/Apache.Arrow.Tests/Apache.Arrow.Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/csharp/test/Apache.Arrow.Tests/Apache.Arrow.Tests.csproj
+++ b/csharp/test/Apache.Arrow.Tests/Apache.Arrow.Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/dev/archery/archery/integration/tester_csharp.py
+++ b/dev/archery/archery/integration/tester_csharp.py
@@ -25,7 +25,7 @@ from ..utils.source import ARROW_ROOT_DEFAULT
 _EXE_PATH = os.path.join(
     ARROW_ROOT_DEFAULT,
     "csharp/artifacts/Apache.Arrow.IntegrationTest",
-    "Debug/net6.0/Apache.Arrow.IntegrationTest",
+    "Debug/net7.0/Apache.Arrow.IntegrationTest",
 )
 
 

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -823,16 +823,7 @@ test_csharp() {
 
   pushd csharp
 
-  # Have to use --list-sdks and not --list-runtimes because the
-  # flight tests use asp net core and it will only run if the SDK
-  # is present
-  if dotnet --list-sdks | grep 6\.0; then
-    dotnet test --framework net6.0
-    TESTS_RUN=1
-  fi
-
-  dotnet test --framework net7.0
-  TESTS_RUN=1
+  dotnet test
 
   if [ "${SOURCE_KIND}" = "local" -o "${SOURCE_KIND}" = "git" ]; then
     dotnet pack -c Release

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -347,18 +347,15 @@ install_csharp() {
 
   show_info "Ensuring that C# is installed..."
 
-  if which dotnet > /dev/null 2>&1; then
+  if dotnet --version | grep 7\.0 > /dev/null 2>&1; then
     local csharp_bin=$(dirname $(which dotnet))
-    if ! which sourcelink > /dev/null 2>&1; then
-      local dotnet_tools_dir=$HOME/.dotnet/tools
-      if [ -d "${dotnet_tools_dir}" ]; then
-        PATH="${dotnet_tools_dir}:$PATH"
-      fi
-    fi
     show_info "Found C# at $(which csharp) (.NET $(dotnet --version))"
   else
+    if which dotnet > /dev/null 2>&1; then
+      show_info "dotnet found but it is the wrong version and will be ignored."
+    fi
     local csharp_bin=${ARROW_TMPDIR}/csharp/bin
-    local dotnet_version=6.0.202
+    local dotnet_version=7.0.102
     local dotnet_platform=
     case "$(uname)" in
       Linux)
@@ -382,10 +379,11 @@ install_csharp() {
   fi
 
   # Ensure to have sourcelink installed
-  if ! which sourcelink > /dev/null 2>&1; then
-    dotnet tool install --tool-path ${csharp_bin} sourcelink
+  if ! dotnet tool list | grep sourcelink > /dev/null 2>&1; then
+    dotnet new tool-manifest
+    dotnet tool install --local sourcelink
     PATH=${csharp_bin}:${PATH}
-    if ! sourcelink --help > /dev/null 2>&1; then
+    if ! dotnet tool run sourcelink --help > /dev/null 2>&1; then
       export DOTNET_ROOT=${csharp_bin}
     fi
   fi
@@ -825,7 +823,16 @@ test_csharp() {
 
   pushd csharp
 
-  dotnet test
+  # Have to use --list-sdks and not --list-runtimes because the
+  # flight tests use asp net core and it will only run if the SDK
+  # is present
+  if dotnet --list-sdks | grep 6\.0; then
+    dotnet test --framework net6.0
+    TESTS_RUN=1
+  fi
+
+  dotnet test --framework net7.0
+  TESTS_RUN=1
 
   if [ "${SOURCE_KIND}" = "local" -o "${SOURCE_KIND}" = "git" ]; then
     dotnet pack -c Release
@@ -835,8 +842,12 @@ test_csharp() {
     mv ../.git dummy.git
   fi
 
-  sourcelink test artifacts/Apache.Arrow/Release/netstandard1.3/Apache.Arrow.pdb
-  sourcelink test artifacts/Apache.Arrow/Release/netcoreapp3.1/Apache.Arrow.pdb
+  if [ "${SOURCE_KIND}" = "local" ]; then
+    echo "Skipping sourelink verification on local build"
+  else
+    dotnet tool run sourcelink test artifacts/Apache.Arrow/Release/netstandard1.3/Apache.Arrow.pdb
+    dotnet tool run sourcelink test artifacts/Apache.Arrow/Release/netcoreapp3.1/Apache.Arrow.pdb
+  fi
 
   popd
 }

--- a/dev/tasks/verify-rc/github.macos.amd64.yml
+++ b/dev/tasks/verify-rc/github.macos.amd64.yml
@@ -60,7 +60,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '7.0.x'
 
       - uses: actions/setup-node@v2-beta
         with:


### PR DESCRIPTION
Update verification script to download and install 7.0 but run tests against 6.0 if the 6.0 SDK is present.  Update examples to use 7.0 only.
* Closes: #33783