### PR TITLE
GH-33801: [Python] Expose C++ ExtensionTypes/ExtensionArrays in pyarrow

### DIFF
--- a/python/pyarrow/tests/extensions.pyx
+++ b/python/pyarrow/tests/extensions.pyx
@@ -1,0 +1,83 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# distutils: language=c++
+# cython: language_level = 3
+
+import pyarrow as pa
+from pyarrow.lib cimport *
+
+cdef extern from * namespace "arrow::py" nogil:
+    """
+    #include "arrow/status.h"
+    #include "arrow/extension_type.h"
+    #include "arrow/ipc/json_simple.h"
+
+    namespace arrow {
+    namespace py {
+
+    class UuidArray : public ExtensionArray {
+    public:
+        using ExtensionArray::ExtensionArray;
+    };
+
+    class UuidType : public ExtensionType {
+    public:
+        UuidType() : ExtensionType(fixed_size_binary(16)) {}
+        std::string extension_name() const override { return "uuid"; }
+
+        bool ExtensionEquals(const ExtensionType& other) const override {
+            return other.extension_name() == this->extension_name();
+        }
+
+        std::shared_ptr<Array> MakeArray(std::shared_ptr<ArrayData> data) const override {
+            return std::make_shared<ExtensionArray>(data);
+        }
+
+        Result<std::shared_ptr<DataType>> Deserialize(
+            std::shared_ptr<DataType> storage_type,
+            const std::string& serialized) const override {
+            return std::make_shared<UuidType>();
+        }
+
+        std::string Serialize() const override { return ""; }
+    };
+
+    std::shared_ptr<DataType> MakeUuidType() {
+        return std::make_shared<UuidType>();
+    }
+
+    std::shared_ptr<Array> MakeUuidArray() {
+        auto uuid_type = MakeUuidType();
+        auto json = "[\\"abcdefghijklmno0\\", \\"0onmlkjihgfedcba\\"]";
+        auto result = ipc::internal::json::ArrayFromJSON(fixed_size_binary(16), json);
+        return ExtensionType::WrapArray(uuid_type, result.ValueOrDie());
+    }
+
+    }  // namespace py
+    }  // namespace arrow
+    """
+
+    cdef shared_ptr[CDataType] CMakeUuidType" arrow::py::MakeUuidType"()
+    cdef shared_ptr[CArray] CMakeUuidArray" arrow::py::MakeUuidArray"()
+
+def _make_uuid_type():
+    return pyarrow_wrap_data_type(CMakeUuidType())
+
+
+def _make_uuid_array():
+    return pyarrow_wrap_array(CMakeUuidArray())

--- a/python/pyarrow/tests/extensions.pyx
+++ b/python/pyarrow/tests/extensions.pyx
@@ -57,8 +57,13 @@ cdef extern from * namespace "arrow::py" nogil:
         std::string Serialize() const override { return ""; }
     };
 
+
     std::shared_ptr<DataType> MakeUuidType() {
         return std::make_shared<UuidType>();
+    }
+
+    void RegisterUuidType() {
+        RegisterExtensionType(std::make_shared<UuidType>());
     }
 
     std::shared_ptr<Array> MakeUuidArray() {
@@ -74,6 +79,11 @@ cdef extern from * namespace "arrow::py" nogil:
 
     cdef shared_ptr[CDataType] CMakeUuidType" arrow::py::MakeUuidType"()
     cdef shared_ptr[CArray] CMakeUuidArray" arrow::py::MakeUuidArray"()
+    cdef void CRegisterUuidType" arrow::py::RegisterUuidType"()
+
+
+def _register_uuid_type():
+    CRegisterUuidType()
 
 
 def _make_uuid_type():

--- a/python/pyarrow/tests/extensions.pyx
+++ b/python/pyarrow/tests/extensions.pyx
@@ -62,10 +62,6 @@ cdef extern from * namespace "arrow::py" nogil:
         return std::make_shared<UuidType>();
     }
 
-    void RegisterUuidType() {
-        RegisterExtensionType(std::make_shared<UuidType>());
-    }
-
     std::shared_ptr<Array> MakeUuidArray() {
         auto uuid_type = MakeUuidType();
         auto json = "[\\"abcdefghijklmno0\\", \\"0onmlkjihgfedcba\\"]";
@@ -73,17 +69,22 @@ cdef extern from * namespace "arrow::py" nogil:
         return ExtensionType::WrapArray(uuid_type, result.ValueOrDie());
     }
 
+    std::once_flag uuid_registered;
+
+    static bool RegisterUuidType() {
+        std::call_once(uuid_registered, RegisterExtensionType,
+                       std::make_shared<UuidType>());
+        return true;
+    }
+
+    static auto uuid_type_registered = RegisterUuidType();
+
     }  // namespace py
     }  // namespace arrow
     """
 
     cdef shared_ptr[CDataType] CMakeUuidType" arrow::py::MakeUuidType"()
     cdef shared_ptr[CArray] CMakeUuidArray" arrow::py::MakeUuidArray"()
-    cdef void CRegisterUuidType" arrow::py::RegisterUuidType"()
-
-
-def _register_uuid_type():
-    CRegisterUuidType()
 
 
 def _make_uuid_type():

--- a/python/pyarrow/tests/extensions.pyx
+++ b/python/pyarrow/tests/extensions.pyx
@@ -75,6 +75,7 @@ cdef extern from * namespace "arrow::py" nogil:
     cdef shared_ptr[CDataType] CMakeUuidType" arrow::py::MakeUuidType"()
     cdef shared_ptr[CArray] CMakeUuidArray" arrow::py::MakeUuidArray"()
 
+
 def _make_uuid_type():
     return pyarrow_wrap_data_type(CMakeUuidType())
 

--- a/python/pyarrow/tests/test_cython.py
+++ b/python/pyarrow/tests/test_cython.py
@@ -163,8 +163,6 @@ def test_cython_api(tmpdir):
                               env=subprocess_env)
 
 
-
-
 @pytest.mark.cython
 def test_visit_strings(tmpdir):
     with tmpdir.as_cwd():

--- a/python/pyarrow/tests/test_cython.py
+++ b/python/pyarrow/tests/test_cython.py
@@ -163,38 +163,6 @@ def test_cython_api(tmpdir):
                               env=subprocess_env)
 
 
-@pytest.mark.cython
-def test_extension_type(tmpdir):
-    with tmpdir.as_cwd():
-        # Set up temporary workspace
-        pyx_file = 'extensions.pyx'
-        shutil.copyfile(os.path.join(here, pyx_file),
-                        os.path.join(str(tmpdir), pyx_file))
-        # Create setup.py file
-        setup_code = setup_template.format(pyx_file=pyx_file,
-                                           compiler_opts=compiler_opts,
-                                           test_ld_path=test_ld_path)
-        with open('setup.py', 'w') as f:
-            f.write(setup_code)
-
-        subprocess_env = test_util.get_modified_env_with_pythonpath()
-
-        # Compile extension module
-        subprocess.check_call([sys.executable, 'setup.py',
-                               'build_ext', '--inplace'],
-                              env=subprocess_env)
-
-    sys.path.insert(0, str(tmpdir))
-    mod = __import__('extensions')
-
-    uuid_type = mod._make_uuid_type()
-    assert uuid_type.extension_name == "uuid"
-    assert uuid_type.storage_type == pa.binary(16)
-
-    array = mod._make_uuid_array()
-    assert array.to_pylist() == [b'abcdefghijklmno0', b'0onmlkjihgfedcba']
-    assert array[0].as_py() == b'abcdefghijklmno0'
-    assert array[1].as_py() == b'0onmlkjihgfedcba'
 
 
 @pytest.mark.cython

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1123,8 +1123,8 @@ def test_cpp_extension_in_python(tmpdir):
     assert array[1].as_py() == b'0onmlkjihgfedcba'
 
     buf = ipc_write_batch(pa.RecordBatch.from_arrays([array], ["uuid"]))
-    del array
 
     batch = ipc_read_batch(buf)
-    array = batch.column(0)
-    assert array.type == uuid_type
+    reconstructed_array = batch.column(0)
+    assert reconstructed_array.type == uuid_type
+    assert reconstructed_array == array

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1120,3 +1120,10 @@ def test_cpp_extension_in_python(tmpdir):
     assert array.to_pylist() == [b'abcdefghijklmno0', b'0onmlkjihgfedcba']
     assert array[0].as_py() == b'abcdefghijklmno0'
     assert array[1].as_py() == b'0onmlkjihgfedcba'
+
+    buf = ipc_write_batch(pa.RecordBatch.from_arrays([array], ["uuid"]))
+    del array
+
+    batch = ipc_read_batch(buf)
+    array = batch.column(0)
+    assert array.type == uuid_type

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1121,6 +1121,8 @@ def test_cpp_extension_in_python(tmpdir):
     assert array[0].as_py() == b'abcdefghijklmno0'
     assert array[1].as_py() == b'0onmlkjihgfedcba'
 
+    pa.register_extension_type(uuid_type)
+
     buf = ipc_write_batch(pa.RecordBatch.from_arrays([array], ["uuid"]))
     del array
 

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -15,9 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import os
 import pickle
+import shutil
+import subprocess
 import weakref
 from uuid import uuid4, UUID
+import sys
 
 import numpy as np
 import pyarrow as pa
@@ -1079,3 +1083,38 @@ def test_array_constructor_from_pandas():
         pd.Series([1, 2, 3], dtype="category"), type=IntegerType()
     )
     assert result.equals(expected)
+
+
+@pytest.mark.cython
+def test_cpp_extension_in_python(tmpdir):
+    from .test_cython import setup_template, compiler_opts, test_ld_path, test_util, here
+    with tmpdir.as_cwd():
+        # Set up temporary workspace
+        pyx_file = 'extensions.pyx'
+        shutil.copyfile(os.path.join(here, pyx_file),
+                        os.path.join(str(tmpdir), pyx_file))
+        # Create setup.py file
+        setup_code = setup_template.format(pyx_file=pyx_file,
+                                           compiler_opts=compiler_opts,
+                                           test_ld_path=test_ld_path)
+        with open('setup.py', 'w') as f:
+            f.write(setup_code)
+
+        subprocess_env = test_util.get_modified_env_with_pythonpath()
+
+        # Compile extension module
+        subprocess.check_call([sys.executable, 'setup.py',
+                               'build_ext', '--inplace'],
+                              env=subprocess_env)
+
+    sys.path.insert(0, str(tmpdir))
+    mod = __import__('extensions')
+
+    uuid_type = mod._make_uuid_type()
+    assert uuid_type.extension_name == "uuid"
+    assert uuid_type.storage_type == pa.binary(16)
+
+    array = mod._make_uuid_array()
+    assert array.to_pylist() == [b'abcdefghijklmno0', b'0onmlkjihgfedcba']
+    assert array[0].as_py() == b'abcdefghijklmno0'
+    assert array[1].as_py() == b'0onmlkjihgfedcba'

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1111,6 +1111,7 @@ def test_cpp_extension_in_python(tmpdir):
     sys.path.insert(0, str(tmpdir))
     mod = __import__('extensions')
 
+    mod._register_uuid_type()
     uuid_type = mod._make_uuid_type()
     assert uuid_type.extension_name == "uuid"
     assert uuid_type.storage_type == pa.binary(16)
@@ -1120,8 +1121,6 @@ def test_cpp_extension_in_python(tmpdir):
     assert array.to_pylist() == [b'abcdefghijklmno0', b'0onmlkjihgfedcba']
     assert array[0].as_py() == b'abcdefghijklmno0'
     assert array[1].as_py() == b'0onmlkjihgfedcba'
-
-    pa.register_extension_type(uuid_type)
 
     buf = ipc_write_batch(pa.RecordBatch.from_arrays([array], ["uuid"]))
     del array

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1115,6 +1115,7 @@ def test_cpp_extension_in_python(tmpdir):
     assert uuid_type.storage_type == pa.binary(16)
 
     array = mod._make_uuid_array()
+    assert array.type == uuid_type
     assert array.to_pylist() == [b'abcdefghijklmno0', b'0onmlkjihgfedcba']
     assert array[0].as_py() == b'abcdefghijklmno0'
     assert array[1].as_py() == b'0onmlkjihgfedcba'

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1111,7 +1111,6 @@ def test_cpp_extension_in_python(tmpdir):
     sys.path.insert(0, str(tmpdir))
     mod = __import__('extensions')
 
-    mod._register_uuid_type()
     uuid_type = mod._make_uuid_type()
     assert uuid_type.extension_name == "uuid"
     assert uuid_type.storage_type == pa.binary(16)

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1087,7 +1087,8 @@ def test_array_constructor_from_pandas():
 
 @pytest.mark.cython
 def test_cpp_extension_in_python(tmpdir):
-    from .test_cython import setup_template, compiler_opts, test_ld_path, test_util, here
+    from .test_cython import (
+        setup_template, compiler_opts, test_ld_path, test_util, here)
     with tmpdir.as_cwd():
         # Set up temporary workspace
         pyx_file = 'extensions.pyx'

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -836,6 +836,27 @@ cdef class BaseExtensionType(DataType):
         DataType.init(self, type)
         self.ext_type = <const CExtensionType*> type.get()
 
+    def __arrow_ext_class__(self):
+        """Return an extension array class to be used for building or
+        deserializing arrays with this extension type.
+
+        This method should return a subclass of the ExtensionArray class. By
+        default, if not specialized in the extension implementation, an
+        extension type array will be a built-in ExtensionArray instance.
+        """
+        return ExtensionArray
+
+    def __arrow_ext_scalar_class__(self):
+        """Return an extension scalar class for building scalars with this
+        extension type.
+
+        This method should return subclass of the ExtensionScalar class. By
+        default, if not specialized in the extension implementation, an
+        extension type scalar will be a built-in ExtensionScalar instance.
+        """
+        return ExtensionScalar
+
+
     @property
     def extension_name(self):
         """
@@ -967,27 +988,6 @@ cdef class ExtensionType(BaseExtensionType):
         return value of ``__arrow_ext_serialize__``).
         """
         return NotImplementedError
-
-    def __arrow_ext_class__(self):
-        """Return an extension array class to be used for building or
-        deserializing arrays with this extension type.
-
-        This method should return a subclass of the ExtensionArray class. By
-        default, if not specialized in the extension implementation, an
-        extension type array will be a built-in ExtensionArray instance.
-        """
-        return ExtensionArray
-
-    def __arrow_ext_scalar_class__(self):
-        """Return an extension scalar class for building scalars with this
-        extension type.
-
-        This method should return subclass of the ExtensionScalar class. By
-        default, if not specialized in the extension implementation, an
-        extension type scalar will be a built-in ExtensionScalar instance.
-        """
-        return ExtensionScalar
-
 
 cdef class PyExtensionType(ExtensionType):
     """

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -956,26 +956,6 @@ cdef class ExtensionType(BaseExtensionType):
         fmt = '{0.__class__.__name__}({1})'
         return fmt.format(self, repr(self.storage_type))
 
-    def __arrow_ext_class__(self):
-        """Return an extension array class to be used for building or
-        deserializing arrays with this extension type.
-
-        This method should return a subclass of the ExtensionArray class. By
-        default, if not specialized in the extension implementation, an
-        extension type array will be a built-in ExtensionArray instance.
-        """
-        return ExtensionArray
-
-    def __arrow_ext_scalar_class__(self):
-        """Return an extension scalar class for building scalars with this
-        extension type.
-
-        This method should return subclass of the ExtensionScalar class. By
-        default, if not specialized in the extension implementation, an
-        extension type scalar will be a built-in ExtensionScalar instance.
-        """
-        return ExtensionScalar
-
     def __arrow_ext_serialize__(self):
         """
         Serialized representation of metadata to reconstruct the type object.
@@ -999,6 +979,26 @@ cdef class ExtensionType(BaseExtensionType):
         return value of ``__arrow_ext_serialize__``).
         """
         return NotImplementedError
+
+    def __arrow_ext_class__(self):
+        """Return an extension array class to be used for building or
+        deserializing arrays with this extension type.
+
+        This method should return a subclass of the ExtensionArray class. By
+        default, if not specialized in the extension implementation, an
+        extension type array will be a built-in ExtensionArray instance.
+        """
+        return ExtensionArray
+
+    def __arrow_ext_scalar_class__(self):
+        """Return an extension scalar class for building scalars with this
+        extension type.
+
+        This method should return subclass of the ExtensionScalar class. By
+        default, if not specialized in the extension implementation, an
+        extension type scalar will be a built-in ExtensionScalar instance.
+        """
+        return ExtensionScalar
 
 cdef class PyExtensionType(ExtensionType):
     """

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -837,22 +837,14 @@ cdef class BaseExtensionType(DataType):
         self.ext_type = <const CExtensionType*> type.get()
 
     def __arrow_ext_class__(self):
-        """Return an extension array class to be used for building or
-        deserializing arrays with this extension type.
-
-        This method should return a subclass of the ExtensionArray class. By
-        default, if not specialized in the extension implementation, an
-        extension type array will be a built-in ExtensionArray instance.
+        """
+        The associated array extension class
         """
         return ExtensionArray
 
     def __arrow_ext_scalar_class__(self):
-        """Return an extension scalar class for building scalars with this
-        extension type.
-
-        This method should return subclass of the ExtensionScalar class. By
-        default, if not specialized in the extension implementation, an
-        extension type scalar will be a built-in ExtensionScalar instance.
+        """
+        The associated scalar class
         """
         return ExtensionScalar
 
@@ -963,6 +955,26 @@ cdef class ExtensionType(BaseExtensionType):
     def __repr__(self):
         fmt = '{0.__class__.__name__}({1})'
         return fmt.format(self, repr(self.storage_type))
+
+    def __arrow_ext_class__(self):
+        """Return an extension array class to be used for building or
+        deserializing arrays with this extension type.
+
+        This method should return a subclass of the ExtensionArray class. By
+        default, if not specialized in the extension implementation, an
+        extension type array will be a built-in ExtensionArray instance.
+        """
+        return ExtensionArray
+
+    def __arrow_ext_scalar_class__(self):
+        """Return an extension scalar class for building scalars with this
+        extension type.
+
+        This method should return subclass of the ExtensionScalar class. By
+        default, if not specialized in the extension implementation, an
+        extension type scalar will be a built-in ExtensionScalar instance.
+        """
+        return ExtensionScalar
 
     def __arrow_ext_serialize__(self):
         """
@@ -1450,8 +1462,8 @@ cdef class Schema(_Weakrefable):
     """
     A named collection of types a.k.a schema. A schema defines the
     column names and types in a record batch or table data structure.
-    They also contain metadata about the columns. For example, schemas 
-    converted from Pandas contain metadata about their original Pandas 
+    They also contain metadata about the columns. For example, schemas
+    converted from Pandas contain metadata about their original Pandas
     types so they can be converted back to the same types.
 
     Warnings

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -856,7 +856,6 @@ cdef class BaseExtensionType(DataType):
         """
         return ExtensionScalar
 
-
     @property
     def extension_name(self):
         """


### PR DESCRIPTION
* Closes #33801 

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

C++ Extension Types are not correctly exposed in pyarrow

### What changes are included in this PR?

`__arrow_ext_class__` and `__arrow_ext_scalar_class__` have been moved from `ExtensionType` to `BaseExtensionType` in types.pxi.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, a test has been added to `test_cython.py`. There may be better locations for this, but the existing cython testing machinery here is useful for generating a C++ extension type on the fly.

### Are there any user-facing changes?

I don't believe there are any user-facing changes as `__arrow_ext_class__` and `__arrow_ext_scalar_class__` are moved into a base class.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `breaking-change` label.
-->