### PR TITLE
GH-33787: [C++] arrow/cpp/src/arrow/util/cpu_info.cc:  the -Werror triggers an error: statement has no effect [-Werror=unused-value]

### DIFF
--- a/cpp/src/arrow/util/cpu_info.cc
+++ b/cpp/src/arrow/util/cpu_info.cc
@@ -366,6 +366,7 @@ int64_t LinuxParseCpuFlags(const std::string& values) {
 #elif defined(CPUINFO_ARCH_ARM)
     {"asimd", CpuInfo::ASIMD},
 #endif
+    {"", 0},
   };
   const int64_t num_flags = sizeof(flag_mappings) / sizeof(flag_mappings[0]);
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/master/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
arrow::internal::anonymous-namespace::LinuxParseCpuFlags(const std::string& values)
Building at the s390x with the -Werror triggers an error: arrow/cpp/src/arrow/util/cpu_info.cc:155:3:
error: statement has no effect [-Werror=unused-value] (347a88f). This PR will add a default zero value to the array flag_mappings[].
Fixes https://github.com/apache/arrow/issues/33787.


### What changes are included in this PR?
b3e9651e660bbed2dec93f556d4574341e4f5bbe


### Are these changes tested?
Run tests @ s390x Ubuntu 22.04


### Are there any user-facing changes?
No
* Closes: #33787