### PR TITLE
MINOR: [R] Update BugReports field in DESCRIPTION

### DIFF
--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -23,7 +23,7 @@ Description: 'Apache' 'Arrow' <https://arrow.apache.org/> is a cross-language
 Depends: R (>= 3.4)
 License: Apache License (>= 2.0)
 URL: https://github.com/apache/arrow/, https://arrow.apache.org/docs/r/
-BugReports: https://issues.apache.org/jira/projects/ARROW/issues
+BugReports: https://github.com/apache/arrow/issues
 Encoding: UTF-8
 Language: en-US
 SystemRequirements: C++17; for AWS S3 support on Linux, libcurl and openssl (optional)


### PR DESCRIPTION
Issue tracking was moved from Jira to GitHub.

References:

- https://lists.apache.org/thread/nkzbg0481k0dt0l2wq9b2k60kpg5hk62
- https://github.com/apache/arrow/issues/14542

### Rationale for this change

The BugReports field should point to the best place for users to go to submit bugs. See [R: Bug Reporting in R](https://www.r-project.org/bugs.html#:~:text=Some%20packages%20have%20a%20bug%20submission%20page%2C%20such%20as%20an%20issue%20tracker%20on%20GitHub%2C%20listed%20under%20the%20BugReports%20field%20in%20the%20package%20description.).

### Are these changes tested?

No.

### Are there any user-facing changes?

No.