### PR TITLE
GH-33377: [Python] Table.drop should support passing a single column

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -4664,7 +4664,7 @@ cdef class Table(_PandasConvertible):
 
         return pyarrow_wrap_table(c_table)
 
-    def drop(self, columns):
+    def drop_columns(self, columns):
         """
         Drop one or more columns and return a new table.
 
@@ -4693,7 +4693,7 @@ cdef class Table(_PandasConvertible):
 
         Drop one column:
 
-        >>> table.drop("animals")
+        >>> table.drop_columns("animals")
         pyarrow.Table
         n_legs: int64
         ----
@@ -4701,7 +4701,7 @@ cdef class Table(_PandasConvertible):
 
         Drop one or more columns:
 
-        >>> table.drop(["n_legs", "animals"])
+        >>> table.drop_columns(["n_legs", "animals"])
         pyarrow.Table
         ...
         ----
@@ -4725,34 +4725,20 @@ cdef class Table(_PandasConvertible):
 
         return table
 
-    def drop_column(self, name):
+    def drop(self, columns):
         """
-        Create new Table with the named column removed.
+        Alias of Table.drop_columns for backwards compatibility.
 
-        Parameters
-        ----------
-        name : str
-            Name of column to remove.
-
-        Returns
-        -------
-        Table
-            New table without the column.
-
-        Examples
+        Warnings
         --------
-        >>> import pyarrow as pa
-        >>> import pandas as pd
-        >>> df = pd.DataFrame({'n_legs': [2, 4, 5, 100],
-        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
-        >>> table = pa.Table.from_pandas(df)
-        >>> table.drop_column('animals')
-        pyarrow.Table
-        n_legs: int64
-        ----
-        n_legs: [[2,4,5,100]]
+        This API is depreacted in favor of Table.drop_columns.
         """
-        return self.drop(name)
+        import warnings
+        warnings.warn(
+            "Table.drop is deprecated, use Table.drop_columns.",
+            DeprecationWarning)
+
+        return self.drop_column(columns)
 
     def group_by(self, keys):
         """Declare a grouping over the columns of the table.

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -4670,18 +4670,18 @@ cdef class Table(_PandasConvertible):
 
         Parameters
         ----------
-        columns : list of str
-            List of field names referencing existing columns.
+        columns : str or list[str]
+            Field name(s) referencing existing column(s).
 
         Raises
         ------
         KeyError
-            If any of the passed columns name are not existing.
+            If any of the passed column names do not exist.
 
         Returns
         -------
         Table
-            New table without the columns.
+            New table without the column(s).
 
         Examples
         --------
@@ -4693,19 +4693,22 @@ cdef class Table(_PandasConvertible):
 
         Drop one column:
 
-        >>> table.drop(["animals"])
+        >>> table.drop("animals")
         pyarrow.Table
         n_legs: int64
         ----
         n_legs: [[2,4,5,100]]
 
-        Drop more columns:
+        Drop one or more columns:
 
         >>> table.drop(["n_legs", "animals"])
         pyarrow.Table
         ...
         ----
         """
+        if isinstance(columns, str):
+            columns = [columns]
+
         indices = []
         for col in columns:
             idx = self.schema.get_field_index(col)
@@ -4721,6 +4724,35 @@ cdef class Table(_PandasConvertible):
             table = table.remove_column(idx)
 
         return table
+
+    def drop_column(self, name):
+        """
+        Create new Table with the named column removed.
+
+        Parameters
+        ----------
+        name : str
+            Name of column to remove.
+
+        Returns
+        -------
+        Table
+            New table without the column.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'n_legs': [2, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> table.drop_column('animals')
+        pyarrow.Table
+        n_legs: int64
+        ----
+        n_legs: [[2,4,5,100]]
+        """
+        return self.drop(name)
 
     def group_by(self, keys):
         """Declare a grouping over the columns of the table.

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -4725,60 +4725,10 @@ cdef class Table(_PandasConvertible):
 
         return table
 
-    def drop(self, columns):
-        """
-        Drop one or more columns and return a new table.
-
-        Alias of Table.drop_columns for backwards compatibility.
-
-        Parameters
-        ----------
-        columns : str or list[str]
-            Field name(s) referencing existing column(s).
-
-        Raises
-        ------
-        KeyError
-            If any of the passed column names do not exist.
-
-        Returns
-        -------
-        Table
-            New table without the column(s).
-        
-        Warnings
-        --------
-        This API is depreacted in favor of Table.drop_columns.
-
-        Examples
-        --------
-        >>> import pyarrow as pa
-        >>> import pandas as pd
-        >>> df = pd.DataFrame({'n_legs': [2, 4, 5, 100],
-        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
-        >>> table = pa.Table.from_pandas(df)
-
-        Drop one column:
-
-        >>> table.drop("animals")
-        pyarrow.Table
-        n_legs: int64
-        ----
-        n_legs: [[2,4,5,100]]
-
-        Drop one or more columns:
-
-        >>> table.drop(["n_legs", "animals"])
-        pyarrow.Table
-        ...
-        ----
-        """
-        import warnings
-        warnings.warn(
-            "Table.drop is deprecated, use Table.drop_columns.",
-            DeprecationWarning)
-
-        return self.drop_columns(columns)
+    drop = drop_columns
+    """
+    Alias of Table.drop_columns, kept for backwards compatibility.
+    """
 
     def group_by(self, keys):
         """Declare a grouping over the columns of the table.

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -4727,18 +4727,58 @@ cdef class Table(_PandasConvertible):
 
     def drop(self, columns):
         """
-        Alias of Table.drop_columns for backwards compatibility.
+        Drop one or more columns and return a new table.
 
+        (Alias of Table.drop_columns for backwards compatibility.)
+
+        Parameters
+        ----------
+        columns : str or list[str]
+            Field name(s) referencing existing column(s).
+
+        Raises
+        ------
+        KeyError
+            If any of the passed column names do not exist.
+
+        Returns
+        -------
+        Table
+            New table without the column(s).
+        
         Warnings
         --------
         This API is depreacted in favor of Table.drop_columns.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'n_legs': [2, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+
+        Drop one column:
+
+        >>> table.drop("animals")
+        pyarrow.Table
+        n_legs: int64
+        ----
+        n_legs: [[2,4,5,100]]
+
+        Drop one or more columns:
+
+        >>> table.drop_columns(["n_legs", "animals"])
+        pyarrow.Table
+        ...
+        ----
         """
         import warnings
         warnings.warn(
             "Table.drop is deprecated, use Table.drop_columns.",
             DeprecationWarning)
 
-        return self.drop_column(columns)
+        return self.drop_columns(columns)
 
     def group_by(self, keys):
         """Declare a grouping over the columns of the table.

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -4729,7 +4729,7 @@ cdef class Table(_PandasConvertible):
         """
         Drop one or more columns and return a new table.
 
-        (Alias of Table.drop_columns for backwards compatibility.)
+        Alias of Table.drop_columns for backwards compatibility.
 
         Parameters
         ----------
@@ -4768,7 +4768,7 @@ cdef class Table(_PandasConvertible):
 
         Drop one or more columns:
 
-        >>> table.drop_columns(["n_legs", "animals"])
+        >>> table.drop(["n_legs", "animals"])
         pyarrow.Table
         ...
         ----

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -4725,10 +4725,9 @@ cdef class Table(_PandasConvertible):
 
         return table
 
-    drop = drop_columns
-    """
-    Alias of Table.drop_columns, kept for backwards compatibility.
-    """
+    def drop(self, columns):
+        """Alias of Table.drop_columns, but kept for backwards compatibility."""
+        return self.drop_columns(columns)
 
     def group_by(self, keys):
         """Declare a grouping over the columns of the table.

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -3906,7 +3906,7 @@ def test_write_dataset_with_scanner(tempdir):
         load_back = ds.dataset(tempdir2, format='ipc', partitioning=["b"])
         load_back_table = load_back.to_table()
         assert dict(load_back_table.to_pydict()
-                    ) == table.drop(["a"]).to_pydict()
+                    ) == table.drop_columns("a").to_pydict()
 
 
 @pytest.mark.parquet

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -1070,6 +1070,26 @@ def test_table_drop_columns():
         table.drop_columns(['d'])
 
 
+def test_table_drop():
+    """ verify the alias of drop_columns is working"""
+    a = pa.array(range(5))
+    b = pa.array([-10, -5, 0, 5, 10])
+    c = pa.array(range(5, 10))
+
+    table = pa.Table.from_arrays([a, b, c], names=('a', 'b', 'c'))
+    t2 = table.drop(['a', 'b'])
+    t3 = table.drop('a')
+
+    exp_t2 = pa.Table.from_arrays([c], names=('c',))
+    assert exp_t2.equals(t2)
+    exp_t3 = pa.Table.from_arrays([b, c], names=('b', 'c',))
+    assert exp_t3.equals(t3)
+
+    # -- raise KeyError if column not in Table
+    with pytest.raises(KeyError, match="Column 'd' not found"):
+        table.drop(['d'])
+
+
 def test_table_remove_column():
     data = [
         pa.array(range(5)),

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -1050,15 +1050,15 @@ def test_table_set_column():
     assert t2.equals(expected)
 
 
-def test_table_drop():
+def test_table_drop_columns():
     """ drop one or more columns given labels"""
     a = pa.array(range(5))
     b = pa.array([-10, -5, 0, 5, 10])
     c = pa.array(range(5, 10))
 
     table = pa.Table.from_arrays([a, b, c], names=('a', 'b', 'c'))
-    t2 = table.drop(['a', 'b'])
-    t3 = table.drop('a')
+    t2 = table.drop_columns(['a', 'b'])
+    t3 = table.drop_columns('a')
 
     exp_t2 = pa.Table.from_arrays([c], names=('c',))
     assert exp_t2.equals(t2)
@@ -1067,21 +1067,7 @@ def test_table_drop():
 
     # -- raise KeyError if column not in Table
     with pytest.raises(KeyError, match="Column 'd' not found"):
-        table.drop(['d'])
-
-
-def test_table_drop_column():
-    data = [
-        pa.array(range(5)),
-        pa.array([-10, -5, 0, 5, 10]),
-        pa.array(range(5, 10))
-    ]
-    table = pa.Table.from_arrays(data, names=('a', 'b', 'c'))
-
-    t2 = table.drop_column('a')
-    t2.validate()
-    expected = pa.Table.from_arrays(data[1:], names=('b', 'c'))
-    assert t2.equals(expected)
+        table.drop_columns(['d'])
 
 
 def test_table_remove_column():

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -1058,13 +1058,30 @@ def test_table_drop():
 
     table = pa.Table.from_arrays([a, b, c], names=('a', 'b', 'c'))
     t2 = table.drop(['a', 'b'])
+    t3 = table.drop('a')
 
-    exp = pa.Table.from_arrays([c], names=('c',))
-    assert exp.equals(t2)
+    exp_t2 = pa.Table.from_arrays([c], names=('c',))
+    assert exp_t2.equals(t2)
+    exp_t3 = pa.Table.from_arrays([b, c], names=('b', 'c',))
+    assert exp_t3.equals(t3)
 
     # -- raise KeyError if column not in Table
-    with pytest.raises(KeyError, match="Column 'd' not found"):
-        table.drop(['d'])
+    with pytest.raises(KeyError, match="Column 'e' not found"):
+        table.drop(['e'])
+
+
+def test_table_drop_column():
+    data = [
+        pa.array(range(5)),
+        pa.array([-10, -5, 0, 5, 10]),
+        pa.array(range(5, 10))
+    ]
+    table = pa.Table.from_arrays(data, names=('a', 'b', 'c'))
+
+    t2 = table.drop_column('a')
+    t2.validate()
+    expected = pa.Table.from_arrays(data[1:], names=('b', 'c'))
+    assert t2.equals(expected)
 
 
 def test_table_remove_column():

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -1066,8 +1066,8 @@ def test_table_drop():
     assert exp_t3.equals(t3)
 
     # -- raise KeyError if column not in Table
-    with pytest.raises(KeyError, match="Column 'e' not found"):
-        table.drop(['e'])
+    with pytest.raises(KeyError, match="Column 'd' not found"):
+        table.drop(['d'])
 
 
 def test_table_drop_column():

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -1070,18 +1070,6 @@ def test_table_drop_columns():
         table.drop_columns(['d'])
 
 
-def test_table_drop():
-    """ test the alias of drop_columns"""
-    a = pa.array(range(5))
-    b = pa.array([-10, -5, 0, 5, 10])
-
-    table = pa.Table.from_arrays([a, b], names=('a', 'b'))
-    t2 = table.drop('b')
-
-    exp = pa.Table.from_arrays([a], names=('a',))
-    assert exp.equals(t2)
-
-
 def test_table_remove_column():
     data = [
         pa.array(range(5)),

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -1070,6 +1070,18 @@ def test_table_drop_columns():
         table.drop_columns(['d'])
 
 
+def test_table_drop():
+    """ test the alias of drop_columns"""
+    a = pa.array(range(5))
+    b = pa.array([-10, -5, 0, 5, 10])
+
+    table = pa.Table.from_arrays([a, b], names=('a', 'b'))
+    t2 = table.drop('b')
+
+    exp = pa.Table.from_arrays([a], names=('a',))
+    assert exp.equals(t2)
+
+
 def test_table_remove_column():
     data = [
         pa.array(range(5)),


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/master/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Provide a better user experience in pyarrow when working with `Table`.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Allow `Table.drop()` to accept a single column name as a `str` argument.
Provide a wrapper `Table.drop_column(str)`, which calls `Table.drop()`, to match similar APIs such as `add_column()`, `append_column()`.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Updated the pytest for `Table.drop()` and added a pytest for `Table.drop_column()`. Verified both test cases ran successfully locally.

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes, a new pyarrow API is added. The existing pyarrow API is backwards compatible, but does support additional types of input now (str). The doc strings are updated so I assume the python API reference will be auto-updated somehow? Let me know if this is not the case.

<!--
If there are any breaking changes to public APIs, please add the `breaking-change` label.
-->
* Closes: #33377