### PR TITLE
GH-33813: [CI][GLib] Use Ruby 3.2 to update bundled MSYS2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -196,7 +196,7 @@ jobs:
         mingw-n-bits:
           - 64
         ruby-version:
-          - "3.1"
+          - ruby
     env:
       ARROW_BUILD_STATIC: OFF
       ARROW_BUILD_TESTS: OFF


### PR DESCRIPTION
### What changes are included in this PR?

Use Ruby 3.2 to update bundled MSYS2.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #33813