### PR TITLE
GH-33820: [CI][Release] Don't libxsimd-dev on Ubuntu 20.04

### DIFF
--- a/dev/release/setup-ubuntu.sh
+++ b/dev/release/setup-ubuntu.sh
@@ -47,8 +47,17 @@ case ${codename} in
     python=3
     apt-get update -y -q
     apt-get install -y -q --no-install-recommends \
-      libxsimd-dev \
       llvm-dev
+    ;;
+esac
+
+case ${codename} in
+  bionic|focal)
+    ;;
+  *)
+    apt-get update -y -q
+    apt-get install -y -q --no-install-recommends \
+      libxsimd-dev
     ;;
 esac
 


### PR DESCRIPTION
### Rationale for this change

Ubuntu 20.04 doesn't ship `libxsimd-dev`.

### What changes are included in this PR?

Install `libxsimd-dev` only on Ubuntu 22.04 or later.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #33820