### PR TITLE
GH-33787: [C++] Suppress unused-value warning from LinuxParseCpuFlags() on s390x

### DIFF
--- a/cpp/src/arrow/util/cpu_info.cc
+++ b/cpp/src/arrow/util/cpu_info.cc
@@ -345,6 +345,7 @@ int64_t LinuxGetCacheSize(int level) {
 // care about are present.
 // Returns a bitmap of flags.
 int64_t LinuxParseCpuFlags(const std::string& values) {
+#if defined(CPUINFO_ARCH_X86) || defined(CPUINFO_ARCH_ARM)
   const struct {
     std::string name;
     int64_t flag;
@@ -376,6 +377,9 @@ int64_t LinuxParseCpuFlags(const std::string& values) {
     }
   }
   return flags;
+#else
+  return 0;
+#endif
 }
 
 void OsRetrieveCacheSize(std::array<int64_t, kCacheLevels>* cache_sizes) {


### PR DESCRIPTION
### Rationale for this change

Building at the s390x with the -Werror triggers an error:

    arrow/cpp/src/arrow/util/cpu_info.cc:155:3: error: statement has no effect [-Werror=unused-value].

### What changes are included in this PR?

Just returns `0` in `LinuxParseCpuFlags()` on non-(x86_64|arm64) environment.

### Are these changes tested?

Local test.

### Are there any user-facing changes?

No.

Closes https://github.com/apache/arrow/issues/33787.

Signed-off-by: Aliaksei Makarau <aliaksei.makarau@ibm.com>
