### PR TITLE
GH-33830: Clarify handling of Null values in REE encoding

### DIFF
--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -824,7 +824,7 @@ In Run-end-encoded form, this could appear as:
 
 ::
 
-    * Length: 7, Null count: 2
+    * Length: 7, Null count: 0
     * Child Arrays:
 
       * run_ends (Int32):

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -816,7 +816,7 @@ run ends array all are positive and in strictly ascending order. A run end canno
 null.
 
 The REE parent has no validity bitmap, and it's null count field should always be 0.
-validity bitmap. Null values are encoded as runs with the value null.
+Null values are encoded as runs with the value null.
 
 As an example, you could have the following data: ::
 

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -815,6 +815,9 @@ A run must have have a length of at least 1. This means the values in the
 run ends array all are positive and in strictly ascending order. A run end cannot be
 null.
 
+The REE parent has no validity bitmap, and it's null count field should always be 0.
+validity bitmap. Null values are encoded as runs with the value null.
+
 As an example, you could have the following data: ::
 
     type: Float32


### PR DESCRIPTION

* Closes: #33830