### PR TITLE
MINOR: [C++][clang-tidy] Disable modernize-use-nodiscard check 

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -22,6 +22,7 @@ Checks: |
   google-*,
   modernize-*,
   -modernize-use-trailing-return-type,
+  -modernize-use-nodiscard,
 # produce HeaderFilterRegex from cpp/build-support/lint_exclusions.txt with:
 # echo -n '^('; sed -e 's/*/\.*/g' cpp/build-support/lint_exclusions.txt | tr '\n' '|'; echo ')$'
 HeaderFilterRegex: '^(.*codegen.*|.*_generated.*|.*windows_compatibility.h|.*pyarrow_api.h|.*pyarrow_lib.h|.*python/config.h|.*python/platform.h|.*thirdparty/ae/.*|.*vendored/.*|.*RcppExports.cpp.*|)$'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,7 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-Checks: 'clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-alpha*,google-*,modernize-*,-modernize-use-trailing-return-type'
+Checks: |
+  clang-diagnostic-*,
+  clang-analyzer-*,
+  -clang-analyzer-alpha*,
+  google-*,
+  modernize-*,
+  -modernize-use-trailing-return-type,
 # produce HeaderFilterRegex from cpp/build-support/lint_exclusions.txt with:
 # echo -n '^('; sed -e 's/*/\.*/g' cpp/build-support/lint_exclusions.txt | tr '\n' '|'; echo ')$'
 HeaderFilterRegex: '^(.*codegen.*|.*_generated.*|.*windows_compatibility.h|.*pyarrow_api.h|.*pyarrow_lib.h|.*python/config.h|.*python/platform.h|.*thirdparty/ae/.*|.*vendored/.*|.*RcppExports.cpp.*|)$'


### PR DESCRIPTION
Not all functions that return a value should have a `[[nodiscard]]`.

`[[nodiscard]]` adds noise and is better used for functions that:
 1. Return a `Status` or some kind of error code
 2. Have a confusing name like the STL container's `empty()`. The STL uses  `[[nodiscard]]` for `empty()` so people are less likely to call it believing it has the same effect of `clear()`.