### PR TITLE
MINOR: [C++][R] Declare FieldRef(std::vector<FieldRef>) constructor explicit

### DIFF
--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1692,9 +1692,7 @@ class ARROW_EXPORT FieldRef : public util::EqualityComparable<FieldRef> {
   FieldRef(int index) : impl_(FieldPath({index})) {}  // NOLINT runtime/explicit
 
   /// Construct a nested FieldRef.
-  FieldRef(std::vector<FieldRef> refs) {  // NOLINT runtime/explicit
-    Flatten(std::move(refs));
-  }
+  explicit FieldRef(std::vector<FieldRef> refs) { Flatten(std::move(refs)); }
 
   /// Convenience constructor for nested FieldRefs: each argument will be used to
   /// construct a FieldRef

--- a/r/src/expression.cpp
+++ b/r/src/expression.cpp
@@ -101,7 +101,8 @@ std::shared_ptr<compute::Expression> compute___expr__nested_field_ref(
     }
     // Add the new ref
     ref_vec.push_back(arrow::FieldRef(std::move(name)));
-    return std::make_shared<compute::Expression>(compute::field_ref(std::move(ref_vec)));
+    return std::make_shared<compute::Expression>(
+        compute::field_ref(arrow::FieldRef{std::move(ref_vec)}));
   } else {
     cpp11::stop("'x' must be a FieldRef Expression");
   }


### PR DESCRIPTION
This implicit constructor can make passing `std::vector<FieldRef>`s around very confusing. You might think you are passing a vector, but it's implicitly being converted into a single `FieldRef`.