### PR TITLE
GH-32050: [C++] Implement Rank kernel on chunked arrays

### DIFF
--- a/cpp/src/arrow/compute/kernels/vector_array_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_array_sort.cc
@@ -459,7 +459,8 @@ Status ArraySortIndicesChunked(KernelContext* ctx, const ExecBatch& batch, Datum
   std::iota(out_begin, out_end, 0);
   return SortChunkedArray(ctx->exec_context(), out_begin, out_end,
                           *batch[0].chunked_array(), options.order,
-                          options.null_placement);
+                          options.null_placement)
+      .status();
 }
 
 template <template <typename...> class ExecTemplate>

--- a/cpp/src/arrow/compute/kernels/vector_rank.cc
+++ b/cpp/src/arrow/compute/kernels/vector_rank.cc
@@ -195,10 +195,9 @@ class ArrayRanker : public TypeVisitor {
     auto value_selector = [&arr](int64_t index) {
       return GetView::LogicalValue(arr.GetView(index));
     };
-    auto rankings =
-        CreateRankings(ctx_, sorted, null_placement_, tiebreaker_, value_selector);
-    ARROW_ASSIGN_OR_RAISE(auto output, rankings);
-    *output_ = output;
+    ARROW_ASSIGN_OR_RAISE(*output_, CreateRankings(ctx_, sorted, null_placement_,
+                                                   tiebreaker_, value_selector));
+
     return Status::OK();
   }
 
@@ -258,10 +257,9 @@ class ChunkedArrayRanker : public TypeVisitor {
     auto value_selector = [resolver = ChunkedArrayResolver(arrays)](int64_t index) {
       return resolver.Resolve<ArrayType>(index).Value();
     };
-    auto rankings =
-        CreateRankings(ctx_, sorted, null_placement_, tiebreaker_, value_selector);
-    ARROW_ASSIGN_OR_RAISE(auto output, rankings);
-    *output_ = output;
+    ARROW_ASSIGN_OR_RAISE(*output_, CreateRankings(ctx_, sorted, null_placement_,
+                                                   tiebreaker_, value_selector));
+
     return Status::OK();
   }
 

--- a/cpp/src/arrow/compute/kernels/vector_rank.cc
+++ b/cpp/src/arrow/compute/kernels/vector_rank.cc
@@ -219,7 +219,7 @@ template <>
 class Ranker<ChunkedArray> : public RankerMixin<ChunkedArray, Ranker<ChunkedArray>> {
  public:
   template <typename... Args>
-  Ranker(Args&&... args)
+  explicit Ranker(Args&&... args)
       : RankerMixin(std::forward<Args>(args)...),
         physical_chunks_(GetPhysicalChunks(input_, physical_type_)) {}
 

--- a/cpp/src/arrow/compute/kernels/vector_rank.cc
+++ b/cpp/src/arrow/compute/kernels/vector_rank.cc
@@ -25,6 +25,120 @@ namespace {
 // ----------------------------------------------------------------------
 // Rank implementation
 
+template <typename T>
+Result<Datum> CreateRankings(ExecContext* ctx, const NullPartitionResult& sorted,
+                             const NullPlacement null_placement,
+                             const RankOptions::Tiebreaker tiebreaker,
+                             std::function<T(int64_t)> value_selector) {
+  auto length = sorted.overall_end() - sorted.overall_begin();
+  ARROW_ASSIGN_OR_RAISE(auto rankings,
+                        MakeMutableUInt64Array(length, ctx->memory_pool()));
+  auto out_begin = rankings->GetMutableValues<uint64_t>(1);
+  uint64_t rank;
+
+  switch (tiebreaker) {
+    case RankOptions::Dense: {
+      T curr_value, prev_value{};
+      rank = 0;
+
+      if (null_placement == NullPlacement::AtStart && sorted.null_count() > 0) {
+        rank++;
+        for (auto it = sorted.nulls_begin; it < sorted.nulls_end; it++) {
+          out_begin[*it] = rank;
+        }
+      }
+
+      for (auto it = sorted.non_nulls_begin; it < sorted.non_nulls_end; it++) {
+        curr_value = value_selector(*it);
+        if (it == sorted.non_nulls_begin || curr_value != prev_value) {
+          rank++;
+        }
+
+        out_begin[*it] = rank;
+        prev_value = curr_value;
+      }
+
+      if (null_placement == NullPlacement::AtEnd) {
+        rank++;
+        for (auto it = sorted.nulls_begin; it < sorted.nulls_end; it++) {
+          out_begin[*it] = rank;
+        }
+      }
+      break;
+    }
+
+    case RankOptions::First: {
+      rank = 0;
+      for (auto it = sorted.overall_begin(); it < sorted.overall_end(); it++) {
+        out_begin[*it] = ++rank;
+      }
+      break;
+    }
+
+    case RankOptions::Min: {
+      T curr_value, prev_value{};
+      rank = 0;
+
+      if (null_placement == NullPlacement::AtStart) {
+        rank++;
+        for (auto it = sorted.nulls_begin; it < sorted.nulls_end; it++) {
+          out_begin[*it] = rank;
+        }
+      }
+
+      for (auto it = sorted.non_nulls_begin; it < sorted.non_nulls_end; it++) {
+        curr_value = value_selector(*it);
+        if (it == sorted.non_nulls_begin || curr_value != prev_value) {
+          rank = (it - sorted.overall_begin()) + 1;
+        }
+        out_begin[*it] = rank;
+        prev_value = curr_value;
+      }
+
+      if (null_placement == NullPlacement::AtEnd) {
+        rank = sorted.non_null_count() + 1;
+        for (auto it = sorted.nulls_begin; it < sorted.nulls_end; it++) {
+          out_begin[*it] = rank;
+        }
+      }
+      break;
+    }
+
+    case RankOptions::Max: {
+      // The algorithm for Max is just like Min, but in reverse order.
+      T curr_value, prev_value{};
+      rank = length;
+
+      if (null_placement == NullPlacement::AtEnd) {
+        for (auto it = sorted.nulls_begin; it < sorted.nulls_end; it++) {
+          out_begin[*it] = rank;
+        }
+      }
+
+      for (auto it = sorted.non_nulls_end - 1; it >= sorted.non_nulls_begin; it--) {
+        curr_value = value_selector(*it);
+
+        if (it == sorted.non_nulls_end - 1 || curr_value != prev_value) {
+          rank = (it - sorted.overall_begin()) + 1;
+        }
+        out_begin[*it] = rank;
+        prev_value = curr_value;
+      }
+
+      if (null_placement == NullPlacement::AtStart) {
+        rank = sorted.null_count();
+        for (auto it = sorted.nulls_begin; it < sorted.nulls_end; it++) {
+          out_begin[*it] = rank;
+        }
+      }
+
+      break;
+    }
+  }
+
+  return Datum(rankings);
+}
+
 const RankOptions* GetDefaultRankOptions() {
   static const auto kDefaultRankOptions = RankOptions::Defaults();
   return &kDefaultRankOptions;
@@ -77,112 +191,14 @@ class ArrayRanker : public TypeVisitor {
 
     NullPartitionResult sorted =
         array_sorter(sort_begin, sort_end, arr, 0, array_options);
-    uint64_t rank;
 
-    ARROW_ASSIGN_OR_RAISE(auto rankings,
-                          MakeMutableUInt64Array(length, ctx_->memory_pool()));
-    auto out_begin = rankings->GetMutableValues<uint64_t>(1);
-
-    switch (tiebreaker_) {
-      case RankOptions::Dense: {
-        T curr_value, prev_value{};
-        rank = 0;
-
-        if (null_placement_ == NullPlacement::AtStart && sorted.null_count() > 0) {
-          rank++;
-          for (auto it = sorted.nulls_begin; it < sorted.nulls_end; it++) {
-            out_begin[*it] = rank;
-          }
-        }
-
-        for (auto it = sorted.non_nulls_begin; it < sorted.non_nulls_end; it++) {
-          curr_value = GetView::LogicalValue(arr.GetView(*it));
-          if (it == sorted.non_nulls_begin || curr_value != prev_value) {
-            rank++;
-          }
-
-          out_begin[*it] = rank;
-          prev_value = curr_value;
-        }
-
-        if (null_placement_ == NullPlacement::AtEnd) {
-          rank++;
-          for (auto it = sorted.nulls_begin; it < sorted.nulls_end; it++) {
-            out_begin[*it] = rank;
-          }
-        }
-        break;
-      }
-
-      case RankOptions::First: {
-        rank = 0;
-        for (auto it = sorted.overall_begin(); it < sorted.overall_end(); it++) {
-          out_begin[*it] = ++rank;
-        }
-        break;
-      }
-
-      case RankOptions::Min: {
-        T curr_value, prev_value{};
-        rank = 0;
-
-        if (null_placement_ == NullPlacement::AtStart) {
-          rank++;
-          for (auto it = sorted.nulls_begin; it < sorted.nulls_end; it++) {
-            out_begin[*it] = rank;
-          }
-        }
-
-        for (auto it = sorted.non_nulls_begin; it < sorted.non_nulls_end; it++) {
-          curr_value = GetView::LogicalValue(arr.GetView(*it));
-          if (it == sorted.non_nulls_begin || curr_value != prev_value) {
-            rank = (it - sorted.overall_begin()) + 1;
-          }
-          out_begin[*it] = rank;
-          prev_value = curr_value;
-        }
-
-        if (null_placement_ == NullPlacement::AtEnd) {
-          rank = sorted.non_null_count() + 1;
-          for (auto it = sorted.nulls_begin; it < sorted.nulls_end; it++) {
-            out_begin[*it] = rank;
-          }
-        }
-        break;
-      }
-
-      case RankOptions::Max: {
-        // The algorithm for Max is just like Min, but in reverse order.
-        T curr_value, prev_value{};
-        rank = length;
-
-        if (null_placement_ == NullPlacement::AtEnd) {
-          for (auto it = sorted.nulls_begin; it < sorted.nulls_end; it++) {
-            out_begin[*it] = rank;
-          }
-        }
-
-        for (auto it = sorted.non_nulls_end - 1; it >= sorted.non_nulls_begin; it--) {
-          curr_value = GetView::LogicalValue(arr.GetView(*it));
-          if (it == sorted.non_nulls_end - 1 || curr_value != prev_value) {
-            rank = (it - sorted.overall_begin()) + 1;
-          }
-          out_begin[*it] = rank;
-          prev_value = curr_value;
-        }
-
-        if (null_placement_ == NullPlacement::AtStart) {
-          rank = sorted.null_count();
-          for (auto it = sorted.nulls_begin; it < sorted.nulls_end; it++) {
-            out_begin[*it] = rank;
-          }
-        }
-
-        break;
-      }
-    }
-
-    *output_ = Datum(rankings);
+    auto value_selector = [&arr](int64_t index) {
+      return GetView::LogicalValue(arr.GetView(index));
+    };
+    auto rankings =
+        CreateRankings<T>(ctx_, sorted, null_placement_, tiebreaker_, value_selector);
+    ARROW_ASSIGN_OR_RAISE(auto output, rankings);
+    *output_ = output;
     return Status::OK();
   }
 
@@ -192,6 +208,160 @@ class ArrayRanker : public TypeVisitor {
   const NullPlacement null_placement_;
   const RankOptions::Tiebreaker tiebreaker_;
   const std::shared_ptr<DataType> physical_type_;
+  Datum* output_;
+};
+
+class ChunkedArrayRanker : public TypeVisitor {
+ public:
+  // TODO: here we accept order / null_placement / tiebreaker as separate arguments
+  // whereas the ArrayRanker accepts them as the RankOptions struct; this is consistent
+  // with ArraySorter / ChunkedArraySorter, so likely should refactor ArrayRanker
+  ChunkedArrayRanker(ExecContext* ctx, uint64_t* indices_begin, uint64_t* indices_end,
+                     const ChunkedArray& chunked_array, const SortOrder order,
+                     const NullPlacement null_placement,
+                     const RankOptions::Tiebreaker tiebreaker, Datum* output)
+      : TypeVisitor(),
+        ctx_(ctx),
+        indices_begin_(indices_begin),
+        indices_end_(indices_end),
+        chunked_array_(chunked_array),
+        physical_type_(GetPhysicalType(chunked_array.type())),
+        physical_chunks_(GetPhysicalChunks(chunked_array_, physical_type_)),
+        order_(order),
+        null_placement_(null_placement),
+        tiebreaker_(tiebreaker),
+        output_(output) {}
+
+  Status Run() { return physical_type_->Accept(this); }
+
+#define VISIT(TYPE) \
+  Status Visit(const TYPE& type) { return RankInternal<TYPE>(); }
+
+  VISIT_SORTABLE_PHYSICAL_TYPES(VISIT)
+
+#undef VISIT
+
+  template <typename InType>
+  Status RankInternal() {
+    using T = typename GetViewType<InType>::T;
+    using ArrayType = typename TypeTraits<InType>::ArrayType;
+
+    const auto num_chunks = chunked_array_.num_chunks();
+    if (num_chunks == 0) {
+      return Status::OK();
+    }
+    const auto arrays = GetArrayPointers(physical_chunks_);
+
+    ArraySortOptions array_options(order_, null_placement_);
+
+    ARROW_ASSIGN_OR_RAISE(auto array_sorter, GetArraySorter(*physical_type_));
+
+    // See related ChunkedArraySort method for comments
+    std::vector<NullPartitionResult> sorted(num_chunks);
+    int64_t begin_offset = 0;
+    int64_t end_offset = 0;
+    int64_t null_count = 0;
+    for (int i = 0; i < num_chunks; ++i) {
+      const auto array = checked_cast<const ArrayType*>(arrays[i]);
+      end_offset += array->length();
+      null_count += array->null_count();
+      sorted[i] = array_sorter(indices_begin_ + begin_offset, indices_begin_ + end_offset,
+                               *array, begin_offset, array_options);
+      begin_offset = end_offset;
+    }
+    DCHECK_EQ(end_offset, indices_end_ - indices_begin_);
+
+    auto resolver = ChunkedArrayResolver(arrays);
+    if (sorted.size() > 1) {
+      auto merge_nulls = [&](uint64_t* nulls_begin, uint64_t* nulls_middle,
+                             uint64_t* nulls_end, uint64_t* temp_indices,
+                             int64_t null_count) {
+        if (has_null_like_values<typename ArrayType::TypeClass>::value) {
+          PartitionNullsOnly<StablePartitioner>(nulls_begin, nulls_end, resolver,
+                                                null_count, null_placement_);
+        }
+      };
+      auto merge_non_nulls = [&](uint64_t* range_begin, uint64_t* range_middle,
+                                 uint64_t* range_end, uint64_t* temp_indices) {
+        MergeNonNulls<ArrayType>(range_begin, range_middle, range_end, arrays,
+                                 temp_indices);
+      };
+
+      MergeImpl merge_impl{null_placement_, std::move(merge_nulls),
+                           std::move(merge_non_nulls)};
+      // std::merge is only called on non-null values, so size temp indices accordingly
+      RETURN_NOT_OK(merge_impl.Init(ctx_, indices_end_ - indices_begin_ - null_count));
+
+      while (sorted.size() > 1) {
+        auto out_it = sorted.begin();
+        auto it = sorted.begin();
+        while (it < sorted.end() - 1) {
+          const auto& left = *it++;
+          const auto& right = *it++;
+          DCHECK_EQ(left.overall_end(), right.overall_begin());
+          const auto merged = merge_impl.Merge(left, right, null_count);
+          *out_it++ = merged;
+        }
+        if (it < sorted.end()) {
+          *out_it++ = *it++;
+        }
+        sorted.erase(out_it, sorted.end());
+      }
+    }
+
+    DCHECK_EQ(sorted.size(), 1);
+    DCHECK_EQ(sorted[0].overall_begin(), indices_begin_);
+    DCHECK_EQ(sorted[0].overall_end(), indices_end_);
+    // Note that "nulls" can also include NaNs, hence the >= check
+    DCHECK_GE(sorted[0].null_count(), null_count);
+
+    auto value_selector = [resolver](int64_t index) {
+      return resolver.Resolve<ArrayType>(index).Value();
+    };
+    auto rankings =
+        CreateRankings<T>(ctx_, sorted[0], null_placement_, tiebreaker_, value_selector);
+    ARROW_ASSIGN_OR_RAISE(auto output, rankings);
+    *output_ = output;
+    return Status::OK();
+  }
+
+  template <typename ArrayType>
+  void MergeNonNulls(uint64_t* range_begin, uint64_t* range_middle, uint64_t* range_end,
+                     const std::vector<const Array*>& arrays, uint64_t* temp_indices) {
+    const ChunkedArrayResolver left_resolver(arrays);
+    const ChunkedArrayResolver right_resolver(arrays);
+
+    if (order_ == SortOrder::Ascending) {
+      std::merge(range_begin, range_middle, range_middle, range_end, temp_indices,
+                 [&](uint64_t left, uint64_t right) {
+                   const auto chunk_left = left_resolver.Resolve<ArrayType>(left);
+                   const auto chunk_right = right_resolver.Resolve<ArrayType>(right);
+                   return chunk_left.Value() < chunk_right.Value();
+                 });
+    } else {
+      std::merge(range_begin, range_middle, range_middle, range_end, temp_indices,
+                 [&](uint64_t left, uint64_t right) {
+                   const auto chunk_left = left_resolver.Resolve<ArrayType>(left);
+                   const auto chunk_right = right_resolver.Resolve<ArrayType>(right);
+                   // We don't use 'left > right' here to reduce required
+                   // operator. If we use 'right < left' here, '<' is only
+                   // required.
+                   return chunk_right.Value() < chunk_left.Value();
+                 });
+    }
+    // Copy back temp area into main buffer
+    std::copy(temp_indices, temp_indices + (range_end - range_begin), range_begin);
+  }
+
+  ExecContext* ctx_;
+  uint64_t* indices_begin_;
+  uint64_t* indices_end_;
+  const ChunkedArray& chunked_array_;
+  const std::shared_ptr<DataType> physical_type_;
+  const ArrayVector physical_chunks_;
+  const SortOrder order_;
+  const NullPlacement null_placement_;
+  const RankOptions::Tiebreaker tiebreaker_;
   Datum* output_;
 };
 
@@ -220,6 +390,9 @@ class RankMetaFunction : public MetaFunction {
       case Datum::ARRAY: {
         return Rank(*args[0].make_array(), rank_options, ctx);
       } break;
+      case Datum::CHUNKED_ARRAY: {
+        return Rank(*args[0].chunked_array(), rank_options, ctx);
+      } break;
       default:
         break;
     }
@@ -234,6 +407,32 @@ class RankMetaFunction : public MetaFunction {
                      ExecContext* ctx) const {
     Datum output;
     ArrayRanker ranker(ctx, array, options, &output);
+    ARROW_RETURN_NOT_OK(ranker.Run());
+    return output;
+  }
+
+  Result<Datum> Rank(const ChunkedArray& chunked_array, const RankOptions& options,
+                     ExecContext* ctx) const {
+    SortOrder order = SortOrder::Ascending;
+    if (!options.sort_keys.empty()) {
+      order = options.sort_keys[0].order;
+    }
+
+    auto sort_type = uint64();
+    auto length = chunked_array.length();
+    auto buffer_size = bit_util::BytesForBits(
+        length * std::static_pointer_cast<UInt64Type>(sort_type)->bit_width());
+    std::vector<std::shared_ptr<Buffer>> buffers(2);
+    ARROW_ASSIGN_OR_RAISE(buffers[1],
+                          AllocateResizableBuffer(buffer_size, ctx->memory_pool()));
+    auto out = std::make_shared<ArrayData>(sort_type, length, buffers, 0);
+    auto sort_begin = out->GetMutableValues<uint64_t>(1);
+    auto sort_end = sort_begin + length;
+    std::iota(sort_begin, sort_end, 0);
+
+    Datum output;
+    ChunkedArrayRanker ranker(ctx, sort_begin, sort_end, chunked_array, order,
+                              options.null_placement, options.tiebreaker, &output);
     ARROW_RETURN_NOT_OK(ranker.Run());
     return output;
   }

--- a/cpp/src/arrow/compute/kernels/vector_sort_internal.h
+++ b/cpp/src/arrow/compute/kernels/vector_sort_internal.h
@@ -453,9 +453,16 @@ using ArraySortFunc = std::function<NullPartitionResult(
 
 Result<ArraySortFunc> GetArraySorter(const DataType& type);
 
-Status SortChunkedArray(ExecContext* ctx, uint64_t* indices_begin, uint64_t* indices_end,
-                        const ChunkedArray& values, SortOrder sort_order,
-                        NullPlacement null_placement);
+Result<NullPartitionResult> SortChunkedArray(ExecContext* ctx, uint64_t* indices_begin,
+                                             uint64_t* indices_end,
+                                             const ChunkedArray& chunked_array,
+                                             SortOrder sort_order,
+                                             NullPlacement null_placement);
+
+Result<NullPartitionResult> SortChunkedArray(
+    ExecContext* ctx, uint64_t* indices_begin, uint64_t* indices_end,
+    const std::shared_ptr<DataType>& physical_type, const ArrayVector& physical_chunks,
+    SortOrder sort_order, NullPlacement null_placement);
 
 // ----------------------------------------------------------------------
 // Helpers for Sort/SelectK/Rank implementations

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -2147,52 +2147,37 @@ TEST_F(TestRank, Bool) {
   SetInput(ArrayFromJSON(boolean(), "[true, false, true, null, true, null, false]"));
   AssertRank(SortOrder::Ascending, NullPlacement::AtEnd, RankOptions::Min,
              ArrayFromJSON(uint64(), "[3, 1, 3, 6, 3, 6, 1]"));
-  SetInput(ArrayFromJSON(boolean(), "[true, false, true, null, true, null, false]"));
   AssertRank(SortOrder::Ascending, NullPlacement::AtEnd, RankOptions::Max,
              ArrayFromJSON(uint64(), "[5, 2, 5, 7, 5, 7, 2]"));
-  SetInput(ArrayFromJSON(boolean(), "[true, false, true, null, true, null, false]"));
   AssertRank(SortOrder::Ascending, NullPlacement::AtEnd, RankOptions::First,
              ArrayFromJSON(uint64(), "[3, 1, 4, 6, 5, 7, 2]"));
-  SetInput(ArrayFromJSON(boolean(), "[true, false, true, null, true, null, false]"));
   AssertRank(SortOrder::Ascending, NullPlacement::AtEnd, RankOptions::Dense,
              ArrayFromJSON(uint64(), "[2, 1, 2, 3, 2, 3, 1]"));
 
-  SetInput(ArrayFromJSON(boolean(), "[true, false, true, null, true, null, false]"));
   AssertRank(SortOrder::Ascending, NullPlacement::AtStart, RankOptions::Min,
              ArrayFromJSON(uint64(), "[5, 3, 5, 1, 5, 1, 3]"));
-  SetInput(ArrayFromJSON(boolean(), "[true, false, true, null, true, null, false]"));
   AssertRank(SortOrder::Ascending, NullPlacement::AtStart, RankOptions::Max,
              ArrayFromJSON(uint64(), "[7, 4, 7, 2, 7, 2, 4]"));
-  SetInput(ArrayFromJSON(boolean(), "[true, false, true, null, true, null, false]"));
   AssertRank(SortOrder::Ascending, NullPlacement::AtStart, RankOptions::First,
              ArrayFromJSON(uint64(), "[5, 3, 6, 1, 7, 2, 4]"));
-  SetInput(ArrayFromJSON(boolean(), "[true, false, true, null, true, null, false]"));
   AssertRank(SortOrder::Ascending, NullPlacement::AtStart, RankOptions::Dense,
              ArrayFromJSON(uint64(), "[3, 2, 3, 1, 3, 1, 2]"));
 
-  SetInput(ArrayFromJSON(boolean(), "[true, false, true, null, true, null, false]"));
   AssertRank(SortOrder::Descending, NullPlacement::AtEnd, RankOptions::Min,
              ArrayFromJSON(uint64(), "[1, 4, 1, 6, 1, 6, 4]"));
-  SetInput(ArrayFromJSON(boolean(), "[true, false, true, null, true, null, false]"));
   AssertRank(SortOrder::Descending, NullPlacement::AtEnd, RankOptions::Max,
              ArrayFromJSON(uint64(), "[3, 5, 3, 7, 3, 7, 5]"));
-  SetInput(ArrayFromJSON(boolean(), "[true, false, true, null, true, null, false]"));
   AssertRank(SortOrder::Descending, NullPlacement::AtEnd, RankOptions::First,
              ArrayFromJSON(uint64(), "[1, 4, 2, 6, 3, 7, 5]"));
-  SetInput(ArrayFromJSON(boolean(), "[true, false, true, null, true, null, false]"));
   AssertRank(SortOrder::Descending, NullPlacement::AtEnd, RankOptions::Dense,
              ArrayFromJSON(uint64(), "[1, 2, 1, 3, 1, 3, 2]"));
 
-  SetInput(ArrayFromJSON(boolean(), "[true, false, true, null, true, null, false]"));
   AssertRank(SortOrder::Descending, NullPlacement::AtStart, RankOptions::Min,
              ArrayFromJSON(uint64(), "[3, 6, 3, 1, 3, 1, 6]"));
-  SetInput(ArrayFromJSON(boolean(), "[true, false, true, null, true, null, false]"));
   AssertRank(SortOrder::Descending, NullPlacement::AtStart, RankOptions::Max,
              ArrayFromJSON(uint64(), "[5, 7, 5, 2, 5, 2, 7]"));
-  SetInput(ArrayFromJSON(boolean(), "[true, false, true, null, true, null, false]"));
   AssertRank(SortOrder::Descending, NullPlacement::AtStart, RankOptions::First,
              ArrayFromJSON(uint64(), "[3, 6, 4, 1, 5, 2, 7]"));
-  SetInput(ArrayFromJSON(boolean(), "[true, false, true, null, true, null, false]"));
   AssertRank(SortOrder::Descending, NullPlacement::AtStart, RankOptions::Dense,
              ArrayFromJSON(uint64(), "[2, 3, 2, 1, 2, 1, 3]"));
 }


### PR DESCRIPTION
This is a duplicate/continuation of https://github.com/apache/arrow/pull/14505.

William Ayd did the bulk of the work here. There was a somewhat nontrivial rebase that needed to occur (due to one of my recent PRs) so Will's commits have been squashed with the credits intact.

Besides that, I did some refactoring to avoid duplicating `ChunkedArraySorter`'s logic in `ChunkedArrayRanker`. 


* Closes: #32050