### PR TITLE
GH-33824: [C++] Improve error message on discovery failure

### DIFF
--- a/cpp/src/arrow/dataset/discovery.cc
+++ b/cpp/src/arrow/dataset/discovery.cc
@@ -244,8 +244,7 @@ Result<std::vector<std::shared_ptr<Schema>>> FileSystemDatasetFactory::InspectSc
     if (ARROW_PREDICT_FALSE(!result.ok())) {
       return result.status().WithMessage(
           "Error creating dataset. Could not read schema from '", info.path(),
-          "' Is this a '", format_->type_name(), "' file?: ", result.status().message()
-          );
+          "' Is this a '", format_->type_name(), "' file?: ", result.status().message());
     }
     schemas.push_back(result.MoveValueUnsafe());
   }

--- a/cpp/src/arrow/dataset/discovery.cc
+++ b/cpp/src/arrow/dataset/discovery.cc
@@ -244,7 +244,7 @@ Result<std::vector<std::shared_ptr<Schema>>> FileSystemDatasetFactory::InspectSc
     if (ARROW_PREDICT_FALSE(!result.ok())) {
       return result.status().WithMessage(
           "Error creating dataset. Could not read schema from '", info.path(),
-          "' Is this a '", format_->type_name(), "' file?: ", result.status().message());
+          "'. Is this a '", format_->type_name(), "' file?: ", result.status().message());
     }
     schemas.push_back(result.MoveValueUnsafe());
   }

--- a/cpp/src/arrow/dataset/discovery.cc
+++ b/cpp/src/arrow/dataset/discovery.cc
@@ -244,7 +244,7 @@ Result<std::vector<std::shared_ptr<Schema>>> FileSystemDatasetFactory::InspectSc
     if (ARROW_PREDICT_FALSE(!result.ok())) {
       return result.status().WithMessage(
           "Error creating dataset. Could not read schema from '", info.path(),
-          "': ", result.status().message(), ". Is this a '", format_->type_name(),
+          "': ", result.status().message(), " Is this a '", format_->type_name(),
           "' file?");
     }
     schemas.push_back(result.MoveValueUnsafe());

--- a/cpp/src/arrow/dataset/discovery.cc
+++ b/cpp/src/arrow/dataset/discovery.cc
@@ -244,8 +244,8 @@ Result<std::vector<std::shared_ptr<Schema>>> FileSystemDatasetFactory::InspectSc
     if (ARROW_PREDICT_FALSE(!result.ok())) {
       return result.status().WithMessage(
           "Error creating dataset. Could not read schema from '", info.path(),
-          "': ", result.status().message(), " Is this a '", format_->type_name(),
-          "' file?");
+          "' Is this a '", format_->type_name(), "' file?: ", result.status().message()
+          );
     }
     schemas.push_back(result.MoveValueUnsafe());
   }

--- a/cpp/src/arrow/dataset/test_util_internal.h
+++ b/cpp/src/arrow/dataset/test_util_internal.h
@@ -482,7 +482,7 @@ class FileFormatFixtureMixin : public ::testing::Test {
         ::testing::AllOf(
             ::testing::HasSubstr(make_error_message("/herp/derp")),
             ::testing::HasSubstr(
-                "Error creating dataset. Could not read schema from '/herp/derp':"),
+                "Error creating dataset. Could not read schema from '/herp/derp'."),
             ::testing::HasSubstr("Is this a '" + format_->type_name() + "' file?")));
   }
 


### PR DESCRIPTION
### Rationale for this change

Grammatical correctness of message on an exception from pyarrow.lib.ArrowInvalid

### What changes are included in this PR?

Removed a redundant period in the exception message

### Are these changes tested?

No, this is a more of a string amendment and should cause any failures or issues.
I can test it out if this deems to be mandatory.

### Are there any user-facing changes?

User will be greeted with a correct(grammatically) exception message in case of an error.
* Closes: #33824