### PR TITLE
MINOR: [Go] Don't panic on unknown SQLite type in example server

### DIFF
--- a/go/arrow/flight/flightsql/example/sql_batch_reader.go
+++ b/go/arrow/flight/flightsql/example/sql_batch_reader.go
@@ -35,6 +35,10 @@ import (
 
 func getArrowTypeFromString(dbtype string) arrow.DataType {
 	dbtype = strings.ToLower(dbtype)
+	if dbtype == "" {
+		// SQLite may not know the type yet.
+		return &arrow.NullType{}
+	}
 	if strings.HasPrefix(dbtype, "varchar") {
 		return arrow.BinaryTypes.String
 	}

--- a/go/arrow/flight/flightsql/sqlite_server_test.go
+++ b/go/arrow/flight/flightsql/sqlite_server_test.go
@@ -180,6 +180,24 @@ func (s *FlightSqliteServerSuite) TestCommandGetTables() {
 	s.Truef(array.RecordEqual(expectedRec, rec), "expected: %s\ngot: %s", expectedRec, rec)
 }
 
+func (s *FlightSqliteServerSuite) TestCommandGetTablesWithIncludedSchemasNoFilter() {
+	ctx := context.Background()
+	info, err := s.cl.GetTables(ctx, &flightsql.GetTablesOpts{
+		IncludeSchema: true,
+	})
+	s.NoError(err)
+	s.NotNil(info)
+
+	rdr, err := s.cl.DoGet(ctx, info.Endpoint[0].Ticket)
+	s.NoError(err)
+	defer rdr.Release()
+
+	// Don't check the actual data since it'll include SQLite internal tables
+	s.True(rdr.Next())
+	s.False(rdr.Next())
+	s.NoError(rdr.Err())
+}
+
 func (s *FlightSqliteServerSuite) TestCommandGetTablesWithTableFilter() {
 	ctx := context.Background()
 	info, err := s.cl.GetTables(ctx, &flightsql.GetTablesOpts{


### PR DESCRIPTION
### Rationale for this change

GetTables just panics right now because SQLite internal tables don't always have a defined type for all columns. 
### What changes are included in this PR?

Just mimic the C++ implementation and assign NullType for such columns.

### Are these changes tested?

Yes

### Are there any user-facing changes?

No, this is an example for internal development.