### PR TITLE
GH-15054: [C++] Change s3 finalization to happen after arrow threads finished, add pyarrow exit hook

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -2576,7 +2576,7 @@ Aws::SDKOptions aws_options;
 bool aws_initialized = false;
 
 struct AwsInstance : public ::arrow::internal::Executor::Resource {
-  AwsInstance(const S3GlobalOptions& options) {
+  explicit AwsInstance(const S3GlobalOptions& options) {
     Aws::Utils::Logging::LogLevel aws_log_level;
 
 #define LOG_LEVEL_CASE(level_name)                             \

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -335,6 +335,9 @@ struct ARROW_EXPORT S3GlobalOptions {
 
 /// Initialize the S3 APIs.  It is required to call this function at least once
 /// before using S3FileSystem.
+///
+/// Once this function is called you MUST call FinalizeS3 before the end of the
+/// application in order to avoid a segmentation fault at shutdown.
 ARROW_EXPORT
 Status InitializeS3(const S3GlobalOptions& options);
 

--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -185,7 +185,7 @@ class S3TestMixin : public AwsTestMixin {
     Status connect_status;
     int retries = kNumServerRetries;
     do {
-      InitServerAndClient();
+      ASSERT_OK(InitServerAndClient());
       connect_status = OutcomeToStatus("ListBuckets", client_->ListBuckets());
     } while (!connect_status.ok() && --retries > 0);
     ASSERT_OK(connect_status);
@@ -198,8 +198,8 @@ class S3TestMixin : public AwsTestMixin {
   }
 
  protected:
-  void InitServerAndClient() {
-    ASSERT_OK_AND_ASSIGN(minio_, GetMinioEnv()->GetOneServer());
+  Status InitServerAndClient() {
+    ARROW_ASSIGN_OR_RAISE(minio_, GetMinioEnv()->GetOneServer());
     client_config_.reset(new Aws::Client::ClientConfiguration());
     client_config_->endpointOverride = ToAwsString(minio_->connect_string());
     client_config_->scheme = Aws::Http::Scheme::HTTP;
@@ -211,6 +211,7 @@ class S3TestMixin : public AwsTestMixin {
         new Aws::S3::S3Client(credentials_, *client_config_,
                               Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,
                               use_virtual_addressing));
+    return Status::OK();
   }
 
   // How many times to try launching a server in a row before decreeing failure

--- a/python/pyarrow/fs.py
+++ b/python/pyarrow/fs.py
@@ -59,6 +59,8 @@ except ImportError:
     _not_imported.append("S3FileSystem")
 else:
     ensure_s3_initialized()
+    import atexit
+    atexit.register(finalize_s3)
 
 
 def __getattr__(name):

--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -157,6 +157,8 @@ s3_finalizer <- new.env(parent = emptyenv())
   reregister_extension_type(vctrs_extension_type(vctrs::unspecified()))
 
   # Registers a callback to run at session exit
+  # This can't be done in .onUnload or .onDetach because those hooks are
+  # not guaranteed to run (e.g. they only run if the user unloads arrow)
   reg.finalizer(s3_finalizer, finalize_s3, onexit=TRUE)
 
   invisible()

--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -112,6 +112,9 @@ finalize_s3 <- function(env) {
   FinalizeS3()
 }
 
+# Helper environment to register the exit hook
+s3_finalizer <- new.env(parent = emptyenv())
+
 #' @importFrom vctrs s3_register vec_size vec_cast vec_unique
 .onLoad <- function(...) {
   # Make sure C++ knows on which thread it is safe to call the R API
@@ -154,10 +157,7 @@ finalize_s3 <- function(env) {
   reregister_extension_type(vctrs_extension_type(vctrs::unspecified()))
 
   # Registers a callback to run at session exit
-  .onLoad <- function(libname, pkgname) {
-    print(parent.env(environment()))
-    reg.finalizer(parent.env(environment()), finalize_s3, onexit=TRUE)
-  }
+  reg.finalizer(s3_finalizer, finalize_s3, onexit=TRUE)
 
   invisible()
 }

--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -106,6 +106,12 @@ supported_dplyr_methods <- list(
   explain = NULL
 )
 
+# This should be run at session exit and must be called
+# to avoid a segmentation fault at shutdown
+finalize_s3 <- function(env) {
+  FinalizeS3()
+}
+
 #' @importFrom vctrs s3_register vec_size vec_cast vec_unique
 .onLoad <- function(...) {
   # Make sure C++ knows on which thread it is safe to call the R API
@@ -146,6 +152,12 @@ supported_dplyr_methods <- list(
 
   # Register extension types that we use internally
   reregister_extension_type(vctrs_extension_type(vctrs::unspecified()))
+
+  # Registers a callback to run at session exit
+  .onLoad <- function(libname, pkgname) {
+    print(parent.env(environment()))
+    reg.finalizer(parent.env(environment()), finalize_s3, onexit=TRUE)
+  }
 
   invisible()
 }

--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -159,7 +159,7 @@ s3_finalizer <- new.env(parent = emptyenv())
   # Registers a callback to run at session exit
   # This can't be done in .onUnload or .onDetach because those hooks are
   # not guaranteed to run (e.g. they only run if the user unloads arrow)
-  reg.finalizer(s3_finalizer, finalize_s3, onexit=TRUE)
+  reg.finalizer(s3_finalizer, finalize_s3, onexit = TRUE)
 
   invisible()
 }

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -1352,6 +1352,10 @@ fs___S3FileSystem__region <- function(fs) {
   .Call(`_arrow_fs___S3FileSystem__region`, fs)
 }
 
+FinalizeS3 <- function() {
+  invisible(.Call(`_arrow_FinalizeS3`))
+}
+
 fs___GcsFileSystem__Make <- function(anonymous, options) {
   .Call(`_arrow_fs___GcsFileSystem__Make`, anonymous, options)
 }

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -3490,6 +3490,14 @@ extern "C" SEXP _arrow_fs___S3FileSystem__region(SEXP fs_sexp){
 #endif
 
 // filesystem.cpp
+void FinalizeS3();
+extern "C" SEXP _arrow_FinalizeS3(){
+BEGIN_CPP11
+	FinalizeS3();
+	return R_NilValue;
+END_CPP11
+}
+// filesystem.cpp
 #if defined(ARROW_R_WITH_GCS)
 std::shared_ptr<fs::GcsFileSystem> fs___GcsFileSystem__Make(bool anonymous, cpp11::list options);
 extern "C" SEXP _arrow_fs___GcsFileSystem__Make(SEXP anonymous_sexp, SEXP options_sexp){
@@ -5828,6 +5836,7 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_fs___CopyFiles", (DL_FUNC) &_arrow_fs___CopyFiles, 6}, 
 		{ "_arrow_fs___S3FileSystem__create", (DL_FUNC) &_arrow_fs___S3FileSystem__create, 17}, 
 		{ "_arrow_fs___S3FileSystem__region", (DL_FUNC) &_arrow_fs___S3FileSystem__region, 1}, 
+		{ "_arrow_FinalizeS3", (DL_FUNC) &_arrow_FinalizeS3, 0}, 
 		{ "_arrow_fs___GcsFileSystem__Make", (DL_FUNC) &_arrow_fs___GcsFileSystem__Make, 2}, 
 		{ "_arrow_fs___GcsFileSystem__options", (DL_FUNC) &_arrow_fs___GcsFileSystem__options, 1}, 
 		{ "_arrow_io___Readable__Read", (DL_FUNC) &_arrow_io___Readable__Read, 2}, 

--- a/r/src/filesystem.cpp
+++ b/r/src/filesystem.cpp
@@ -351,6 +351,13 @@ std::string fs___S3FileSystem__region(const std::shared_ptr<fs::S3FileSystem>& f
 
 #endif
 
+// [[arrow::export]]
+void FinalizeS3() {
+#if defined(ARROW_R_WITH_S3)
+  StopIfNotOk(fs::FinalizeS3());
+#endif
+}
+
 #if defined(ARROW_R_WITH_GCS)
 
 #include <arrow/filesystem/gcsfs.h>


### PR DESCRIPTION
CRITICAL FIX: When statically linking error with AWS it was possible to have a crash on shutdown/exit.  Now that should no longer be possible.

BREAKING CHANGE: S3 can only be initialized and finalized once.

BREAKING CHANGE: S3 (the AWS SDK) will not be finalized until after all CPU & I/O threads are finished.
* Closes: #15054