### PR TITLE
GH-33864: [Go] Don't directly coerce cgo.Handle to unsafe.Pointer

### DIFF
--- a/go/arrow/cdata/cdata_exports.go
+++ b/go/arrow/cdata/cdata_exports.go
@@ -396,7 +396,7 @@ func exportArray(arr arrow.Array, out *CArrowArray, outSchema *CArrowSchema) {
 
 	arr.Data().Retain()
 	h := cgo.NewHandle(arr.Data())
-	out.private_data = unsafe.Pointer(&h)
+	out.private_data = createHandle(h)
 	out.release = (*[0]byte)(C.goReleaseArray)
 	switch arr := arr.(type) {
 	case array.ListLike:

--- a/go/go.mod
+++ b/go/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/google/flatbuffers v2.0.8+incompatible
 	github.com/klauspost/asmfmt v1.3.2
 	github.com/klauspost/compress v1.15.9
+	github.com/klauspost/cpuid/v2 v2.0.9
 	github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8
 	github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3
 	github.com/pierrec/lz4/v4 v4.1.15
@@ -49,7 +50,6 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
-	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect


### PR DESCRIPTION
### Rationale for this change

Converting cgo.Handle to unsafe.Pointer is not allowed as per the docs. Doing so appears to cause occasional panics at runtime, possibly because something corrupts or collects the handle unexpectedly.

### What changes are included in this PR?

Heap-allocate the Handle to preserve it.

### Are these changes tested?

We were unable to reproduce this outside of an integration test.

### Are there any user-facing changes?

No user-facing changes.
* Closes: #33864