### PR TITLE
GH-33867: [Go][FlightSQL] Allow passing grpc call options to PreparedStatement methods

### DIFF
--- a/go/arrow/flight/flightsql/client.go
+++ b/go/arrow/flight/flightsql/client.go
@@ -355,7 +355,6 @@ func (c *Client) Prepare(ctx context.Context, mem memory.Allocator, query string
 
 	prep = &PreparedStatement{
 		client:        c,
-		opts:          opts,
 		handle:        result.PreparedStatementHandle,
 		datasetSchema: dsSchema,
 		paramSchema:   paramSchema,
@@ -383,7 +382,6 @@ func (c *Client) Close() error { return c.Client.Close() }
 // should be called when no longer needed.
 type PreparedStatement struct {
 	client        *Client
-	opts          []grpc.CallOption
 	handle        []byte
 	datasetSchema *arrow.Schema
 	paramSchema   *arrow.Schema
@@ -397,7 +395,7 @@ type PreparedStatement struct {
 // then the parameter bindings will be sent before execution.
 //
 // Will error if already closed.
-func (p *PreparedStatement) Execute(ctx context.Context) (*flight.FlightInfo, error) {
+func (p *PreparedStatement) Execute(ctx context.Context, opts ...grpc.CallOption) (*flight.FlightInfo, error) {
 	if p.closed {
 		return nil, errors.New("arrow/flightsql: prepared statement already closed")
 	}
@@ -410,7 +408,7 @@ func (p *PreparedStatement) Execute(ctx context.Context) (*flight.FlightInfo, er
 	}
 
 	if p.hasBindParameters() {
-		pstream, err := p.client.Client.DoPut(ctx, p.opts...)
+		pstream, err := p.client.Client.DoPut(ctx, opts...)
 		if err != nil {
 			return nil, err
 		}
@@ -430,13 +428,13 @@ func (p *PreparedStatement) Execute(ctx context.Context) (*flight.FlightInfo, er
 		}
 	}
 
-	return p.client.getFlightInfo(ctx, desc, p.opts...)
+	return p.client.getFlightInfo(ctx, desc, opts...)
 }
 
 // ExecuteUpdate executes the prepared statement update query on the server
 // and returns the number of rows affected. If SetParameters was called,
 // the parameter bindings will be sent with the request to execute.
-func (p *PreparedStatement) ExecuteUpdate(ctx context.Context) (nrecords int64, err error) {
+func (p *PreparedStatement) ExecuteUpdate(ctx context.Context, opts ...grpc.CallOption) (nrecords int64, err error) {
 	if p.closed {
 		return 0, errors.New("arrow/flightsql: prepared statement already closed")
 	}
@@ -455,7 +453,7 @@ func (p *PreparedStatement) ExecuteUpdate(ctx context.Context) (nrecords int64, 
 		return
 	}
 
-	if pstream, err = p.client.Client.DoPut(ctx, p.opts...); err != nil {
+	if pstream, err = p.client.Client.DoPut(ctx, opts...); err != nil {
 		return
 	}
 	if p.hasBindParameters() {
@@ -529,7 +527,7 @@ func (p *PreparedStatement) ParameterSchema() *arrow.Schema { return p.paramSche
 // statement from the server. It should otherwise be identical to DatasetSchema.
 //
 // Will error if already closed.
-func (p *PreparedStatement) GetSchema(ctx context.Context) (*flight.SchemaResult, error) {
+func (p *PreparedStatement) GetSchema(ctx context.Context, opts ...grpc.CallOption) (*flight.SchemaResult, error) {
 	if p.closed {
 		return nil, errors.New("arrow/flightsql: prepared statement already closed")
 	}
@@ -541,7 +539,7 @@ func (p *PreparedStatement) GetSchema(ctx context.Context) (*flight.SchemaResult
 		return nil, err
 	}
 
-	return p.client.getSchema(ctx, desc, p.opts...)
+	return p.client.getSchema(ctx, desc, opts...)
 }
 
 func (p *PreparedStatement) clearParameters() {
@@ -585,7 +583,7 @@ func (p *PreparedStatement) SetRecordReader(binding array.RecordReader) {
 // Close calls release on any parameter binding record and sends
 // a ClosePreparedStatement action to the server. After calling
 // Close, the PreparedStatement should not be used again.
-func (p *PreparedStatement) Close(ctx context.Context) error {
+func (p *PreparedStatement) Close(ctx context.Context, opts ...grpc.CallOption) error {
 	if p.closed {
 		return errors.New("arrow/flightsql: already closed")
 	}
@@ -609,7 +607,7 @@ func (p *PreparedStatement) Close(ctx context.Context) error {
 	}
 
 	action := &flight.Action{Type: actionType, Body: body}
-	_, err = p.client.Client.DoAction(ctx, action, p.opts...)
+	_, err = p.client.Client.DoAction(ctx, action, opts...)
 	if err != nil {
 		return err
 	}

--- a/go/arrow/flight/flightsql/client_test.go
+++ b/go/arrow/flight/flightsql/client_test.go
@@ -132,6 +132,7 @@ func getAction(cmd proto.Message) *flight.Action {
 func (s *FlightSqlClientSuite) SetupTest() {
 	s.mockClient = FlightServiceClientMock{}
 	s.sqlClient.Client = &s.mockClient
+	s.callOpts = []grpc.CallOption{grpc.EmptyCallOption{}}
 }
 
 func (s *FlightSqlClientSuite) TearDownTest() {
@@ -358,9 +359,9 @@ func (s *FlightSqlClientSuite) TestPreparedStatementExecute() {
 
 	prepared, err := s.sqlClient.Prepare(context.TODO(), memory.DefaultAllocator, query, s.callOpts...)
 	s.NoError(err)
-	defer prepared.Close(context.TODO())
+	defer prepared.Close(context.TODO(), s.callOpts...)
 
-	info, err := prepared.Execute(context.TODO())
+	info, err := prepared.Execute(context.TODO(), s.callOpts...)
 	s.NoError(err)
 	s.Equal(&emptyFlightInfo, info)
 }
@@ -411,7 +412,7 @@ func (s *FlightSqlClientSuite) TestPreparedStatementExecuteParamBinding() {
 
 	prepared, err := s.sqlClient.Prepare(context.TODO(), memory.DefaultAllocator, query, s.callOpts...)
 	s.NoError(err)
-	defer prepared.Close(context.TODO())
+	defer prepared.Close(context.TODO(), s.callOpts...)
 
 	paramSchema := prepared.ParameterSchema()
 	rec, _, err := array.RecordFromJSON(memory.DefaultAllocator, paramSchema, strings.NewReader(`[{"id": 1}]`))
@@ -419,7 +420,7 @@ func (s *FlightSqlClientSuite) TestPreparedStatementExecuteParamBinding() {
 	defer rec.Release()
 
 	prepared.SetParameters(rec)
-	info, err := prepared.Execute(context.TODO())
+	info, err := prepared.Execute(context.TODO(), s.callOpts...)
 	s.NoError(err)
 	s.Equal(&emptyFlightInfo, info)
 }
@@ -475,7 +476,7 @@ func (s *FlightSqlClientSuite) TestPreparedStatementExecuteReaderBinding() {
 
 	prepared, err := s.sqlClient.Prepare(context.TODO(), memory.DefaultAllocator, query, s.callOpts...)
 	s.NoError(err)
-	defer prepared.Close(context.TODO())
+	defer prepared.Close(context.TODO(), s.callOpts...)
 
 	paramSchema := prepared.ParameterSchema()
 	rec, _, err := array.RecordFromJSON(memory.DefaultAllocator, paramSchema, strings.NewReader(`[{"id": 1}]`))
@@ -486,7 +487,7 @@ func (s *FlightSqlClientSuite) TestPreparedStatementExecuteReaderBinding() {
 	s.NoError(err)
 	prepared.SetRecordReader(rdr)
 
-	info, err := prepared.Execute(context.TODO())
+	info, err := prepared.Execute(context.TODO(), s.callOpts...)
 	s.NoError(err)
 	s.Equal(&emptyFlightInfo, info)
 }


### PR DESCRIPTION


<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/master/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
To allow propagating timeouts among other call options when using PreparedStatements with FlightSQL we need to update the function signatures to allow passing the call options to them.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### Are there any user-facing changes?
The signatures for the methods on PreparedStatement objects have been updated to accept `opts... grpc.CallOption` as their last parameter. This shouldn't break any existing usage of the methods (since they are optional) but would cause a problem if consumers set up interfaces based on them.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #33867