### PR TITLE
MINOR: [CI] Fix minor typo in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,7 @@ x-hierarchy:
   # This section is used by the archery tool to enable building nested images,
   # so it is enough to call:
   #   archery run debian-ruby
-  # instead of a seguence of docker-compose commands:
+  # instead of a sequence of docker-compose commands:
   #   docker-compose build debian-cpp
   #   docker-compose build debian-c-glib
   #   docker-compose build debian-ruby


### PR DESCRIPTION
### Rationale for this change

To fix a minor typographical error in a comment in our `docker-compose.yml`.

### Are these changes tested?

No, though I have a high degree of confidence I'm not breaking anything here.

### Are there any user-facing changes?

No.

