### PR TITLE
MINOR: [Release] Fix website date locale using LC_TIME

### DIFF
--- a/dev/release/post-03-website.sh
+++ b/dev/release/post-03-website.sh
@@ -57,7 +57,7 @@ else
 fi
 
 export TZ=UTC
-release_date=$(LANG=C LC_TIME=C date "+%-d %B %Y")
+release_date=$(LC_TIME=C date "+%-d %B %Y")
 previous_tag_date=$(git log -n 1 --pretty=%aI apache-arrow-${previous_version})
 rough_previous_release_date=$(date --date "${previous_tag_date}" +%s)
 rough_release_date=$(date +%s)

--- a/dev/release/post-03-website.sh
+++ b/dev/release/post-03-website.sh
@@ -57,7 +57,7 @@ else
 fi
 
 export TZ=UTC
-release_date=$(LANG=C date "+%-d %B %Y")
+release_date=$(LANG=C LC_TIME=C date "+%-d %B %Y")
 previous_tag_date=$(git log -n 1 --pretty=%aI apache-arrow-${previous_version})
 rough_previous_release_date=$(date --date "${previous_tag_date}" +%s)
 rough_release_date=$(date +%s)


### PR DESCRIPTION
### Rationale for this change

When executing the post website update `$ dev/release/post-03-website.sh 10.0.0 11.0.0` the locale on the site was wrong:

```
$ LANG=C date "+%-d %B %Y"
26 enero 2023
```

### What changes are included in this PR?

The following fixed it:
```
$ LANG=C LC_TIME=C date "+%-d %B %Y"
26 January 2023
```

### Are these changes tested?

Locally

### Are there any user-facing changes?

No