### PR TITLE
GH-33699: [C++] Increase timeout of c++ tests when running under valgrind and shorten long tests

### DIFF
--- a/cpp/src/arrow/compute/exec/bloom_filter_test.cc
+++ b/cpp/src/arrow/compute/exec/bloom_filter_test.cc
@@ -439,7 +439,6 @@ TEST(BloomFilter, Basic) {
   constexpr int log_min = 8;
   constexpr int log_max = 16;
 #endif
-  constexpr int log_large = 22;
   for (int log_num_build = log_min; log_num_build < log_max; ++log_num_build) {
     constexpr int num_intermediate_points = 2;
     for (int i = 0; i < num_intermediate_points; ++i) {
@@ -449,8 +448,11 @@ TEST(BloomFilter, Basic) {
                           num_intermediate_points);
     }
   }
+#ifndef ARROW_VALGRIND
   num_build.push_back(1LL << log_max);
+  constexpr int log_large = 22;
   num_build.push_back(1LL << log_large);
+#endif
 
   constexpr int num_param_sets = 3;
   struct {
@@ -466,7 +468,9 @@ TEST(BloomFilter, Basic) {
 
   std::vector<BloomFilterBuildStrategy> strategy;
   strategy.push_back(BloomFilterBuildStrategy::SINGLE_THREADED);
+#ifndef ARROW_VALGRIND
   strategy.push_back(BloomFilterBuildStrategy::PARALLEL);
+#endif
 
   static constexpr int64_t min_rows_for_large = 2 * 1024 * 1024;
 
@@ -492,6 +496,7 @@ TEST(BloomFilter, Basic) {
   }
 }
 
+#ifndef ARROW_VALGRIND
 TEST(BloomFilter, Scaling) {
   std::vector<int64_t> num_build;
   num_build.push_back(1000000);
@@ -515,6 +520,7 @@ TEST(BloomFilter, Scaling) {
     }
   }
 }
+#endif
 
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/exec/hash_join_node_test.cc
+++ b/cpp/src/arrow/compute/exec/hash_join_node_test.cc
@@ -2103,8 +2103,12 @@ void TestSingleChainOfHashJoins(Random64Bit& rng) {
 
 TEST(HashJoin, ChainedIntegerHashJoins) {
   Random64Bit rng(42);
-  int num_tests = 30;
-  for (int i = 0; i < num_tests; i++) {
+#ifdef ARROW_VALGRIND
+  constexpr int kNumTests = 3;
+#else
+  constexpr int kNumTests = 30;
+#endif
+  for (int i = 0; i < kNumTests; i++) {
     ARROW_SCOPED_TRACE("Test ", std::to_string(i));
     TestSingleChainOfHashJoins(rng);
   }

--- a/cpp/src/arrow/compute/exec/key_hash_test.cc
+++ b/cpp/src/arrow/compute/exec/key_hash_test.cc
@@ -223,14 +223,18 @@ template <typename Type>
 void RunTestVectorHash() {
   random::pcg32_fast gen(/*seed=*/0);
 
-  int numtest = 40;
+#ifdef ARROW_VALGRIND
+  constexpr int kNumTests = 5;
+#else
+  constexpr int kNumTests = 40;
+#endif
 
   constexpr int min_length = 0;
   constexpr int max_length = 50;
 
   for (bool use_32bit_hash : {true, false}) {
     for (bool use_varlen_input : {false, true}) {
-      for (int itest = 0; itest < numtest; ++itest) {
+      for (int itest = 0; itest < kNumTests; ++itest) {
         TestVectorHash::RunSingle<Type>(&gen, use_32bit_hash, use_varlen_input,
                                         min_length, max_length);
       }

--- a/cpp/src/arrow/compute/kernels/CMakeLists.txt
+++ b/cpp/src/arrow/compute/kernels/CMakeLists.txt
@@ -18,19 +18,36 @@
 # ----------------------------------------------------------------------
 # Scalar kernels
 
-add_arrow_compute_test(scalar_test
+add_arrow_compute_test(scalar_type_test
                        SOURCES
-                       scalar_arithmetic_test.cc
                        scalar_boolean_test.cc
                        scalar_cast_test.cc
-                       scalar_compare_test.cc
-                       scalar_if_else_test.cc
                        scalar_nested_test.cc
-                       scalar_random_test.cc
-                       scalar_round_arithmetic_test.cc
-                       scalar_set_lookup_test.cc
                        scalar_string_test.cc
+                       test_util.cc
+                       )
+
+add_arrow_compute_test(scalar_if_else_test
+                       SOURCES
+                       scalar_if_else_test.cc
+                       test_util.cc)
+
+add_arrow_compute_test(scalar_temporal_test
+                       SOURCES
                        scalar_temporal_test.cc
+                       test_util.cc)
+
+add_arrow_compute_test(scalar_math_test
+                       SOURCES
+                       scalar_arithmetic_test.cc
+                       scalar_compare_test.cc
+                       scalar_round_arithmetic_test.cc
+                       test_util.cc)
+
+add_arrow_compute_test(scalar_utility_test
+                       SOURCES
+                       scalar_random_test.cc
+                       scalar_set_lookup_test.cc
                        scalar_validity_test.cc
                        test_util.cc)
 

--- a/cpp/src/arrow/compute/kernels/CMakeLists.txt
+++ b/cpp/src/arrow/compute/kernels/CMakeLists.txt
@@ -24,18 +24,11 @@ add_arrow_compute_test(scalar_type_test
                        scalar_cast_test.cc
                        scalar_nested_test.cc
                        scalar_string_test.cc
-                       test_util.cc
-                       )
-
-add_arrow_compute_test(scalar_if_else_test
-                       SOURCES
-                       scalar_if_else_test.cc
                        test_util.cc)
 
-add_arrow_compute_test(scalar_temporal_test
-                       SOURCES
-                       scalar_temporal_test.cc
-                       test_util.cc)
+add_arrow_compute_test(scalar_if_else_test SOURCES scalar_if_else_test.cc test_util.cc)
+
+add_arrow_compute_test(scalar_temporal_test SOURCES scalar_temporal_test.cc test_util.cc)
 
 add_arrow_compute_test(scalar_math_test
                        SOURCES

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -27,6 +27,7 @@
 #include "arrow/buffer.h"
 #include "arrow/compute/api.h"
 #include "arrow/compute/kernels/test_util.h"
+#include "arrow/datum.h"
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/bit_util.h"

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -387,7 +387,7 @@ class TestBinaryArithmetic : public ::testing::Test {
 
   void ValidateAndAssertApproxEqual(const std::shared_ptr<Array>& actual,
                                     const std::shared_ptr<Array>& expected) {
-    ValidateOutput(Datum(*actual));
+    ::arrow::compute::ValidateOutput(*actual);
     AssertArraysApproxEqual(*expected, *actual, /*verbose=*/true, equal_options_);
   }
 

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -387,7 +387,7 @@ class TestBinaryArithmetic : public ::testing::Test {
 
   void ValidateAndAssertApproxEqual(const std::shared_ptr<Array>& actual,
                                     const std::shared_ptr<Array>& expected) {
-    ValidateOutput(*actual);
+    ValidateOutput(Datum(*actual));
     AssertArraysApproxEqual(*expected, *actual, /*verbose=*/true, equal_options_);
   }
 

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -387,7 +387,7 @@ class TestBinaryArithmetic : public ::testing::Test {
 
   void ValidateAndAssertApproxEqual(const std::shared_ptr<Array>& actual,
                                     const std::shared_ptr<Array>& expected) {
-    ::arrow::compute::ValidateOutput(*actual);
+    ValidateOutput(*actual);
     AssertArraysApproxEqual(*expected, *actual, /*verbose=*/true, equal_options_);
   }
 

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
@@ -68,10 +68,21 @@ class TestIfElseKernel : public ::testing::Test {};
 template <typename Type>
 class TestIfElsePrimitive : public ::testing::Test {};
 
+// There are a lot of tests here if we cover all the types and it gets slow on valgrind
+// so we overrdie the standard type sets with a smaller range
+#ifdef ARROW_VALGRIND
+using IfElseNumericBasedTypes =
+    ::testing::Types<UInt32Type, FloatType, Date32Type, Time32Type, TimestampType,
+                     MonthIntervalType>;
+using BaseBinaryArrowTypes = ::testing::Types<BinaryType>;
+using ListArrowTypes = ::testing::Types<ListType>;
+using IntegralArrowTypes = ::testing::Types<Int32Type>;
+#else
 using IfElseNumericBasedTypes =
     ::testing::Types<UInt8Type, UInt16Type, UInt32Type, UInt64Type, Int8Type, Int16Type,
                      Int32Type, Int64Type, FloatType, DoubleType, Date32Type, Date64Type,
                      Time32Type, Time64Type, TimestampType, MonthIntervalType>;
+#endif
 
 TYPED_TEST_SUITE(TestIfElsePrimitive, IfElseNumericBasedTypes);
 

--- a/cpp/src/arrow/compute/kernels/test_util.cc
+++ b/cpp/src/arrow/compute/kernels/test_util.cc
@@ -282,26 +282,26 @@ void CheckScalarBinaryCommutative(std::string func_name, Datum left_input,
 
 namespace {
 
-void ValidateOutput(const ArrayData& output) {
+void ValidateOutputImpl(const ArrayData& output) {
   ASSERT_OK(::arrow::internal::ValidateArrayFull(output));
   TestInitialized(output);
 }
 
-void ValidateOutput(const ChunkedArray& output) {
+void ValidateOutputImpl(const ChunkedArray& output) {
   ASSERT_OK(output.ValidateFull());
   for (const auto& chunk : output.chunks()) {
     TestInitialized(*chunk);
   }
 }
 
-void ValidateOutput(const RecordBatch& output) {
+void ValidateOutputImpl(const RecordBatch& output) {
   ASSERT_OK(output.ValidateFull());
   for (const auto& column : output.column_data()) {
     TestInitialized(*column);
   }
 }
 
-void ValidateOutput(const Table& output) {
+void ValidateOutputImpl(const Table& output) {
   ASSERT_OK(output.ValidateFull());
   for (const auto& column : output.columns()) {
     for (const auto& chunk : column->chunks()) {
@@ -310,26 +310,26 @@ void ValidateOutput(const Table& output) {
   }
 }
 
-void ValidateOutput(const Scalar& output) { ASSERT_OK(output.ValidateFull()); }
+void ValidateOutputImpl(const Scalar& output) { ASSERT_OK(output.ValidateFull()); }
 
 }  // namespace
 
 void ValidateOutput(const Datum& output) {
   switch (output.kind()) {
     case Datum::ARRAY:
-      ValidateOutput(*output.array());
+      ValidateOutputImpl(*output.array());
       break;
     case Datum::CHUNKED_ARRAY:
-      ValidateOutput(*output.chunked_array());
+      ValidateOutputImpl(*output.chunked_array());
       break;
     case Datum::RECORD_BATCH:
-      ValidateOutput(*output.record_batch());
+      ValidateOutputImpl(*output.record_batch());
       break;
     case Datum::TABLE:
-      ValidateOutput(*output.table());
+      ValidateOutputImpl(*output.table());
       break;
     case Datum::SCALAR:
-      ValidateOutput(*output.scalar());
+      ValidateOutputImpl(*output.scalar());
       break;
     default:
       break;

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -45,6 +45,15 @@ using internal::checked_pointer_cast;
 
 namespace compute {
 
+#ifdef ARROW_VALGRIND
+using RealArrowTypes = ::testing::Types<FloatType>;
+
+using IntegralArrowTypes = ::testing::Types<UInt32Type>;
+using TemporalArrowTypes = ::testing::Types<Date32Type, TimestampType, Time32Type>;
+
+using DecimalArrowTypes = ::testing::Types<Decimal128Type>;
+#endif
+
 std::vector<SortOrder> AllOrders() {
   return {SortOrder::Ascending, SortOrder::Descending};
 }
@@ -320,10 +329,15 @@ class TestNthToIndicesRandom : public TestNthToIndicesBase<ArrowType> {
   }
 };
 
+#ifdef ARROW_VALGRIND
+using NthToIndicesableTypes =
+    ::testing::Types<Int16Type, FloatType, Decimal128Type, StringType>;
+#else
 using NthToIndicesableTypes =
     ::testing::Types<UInt8Type, UInt16Type, UInt32Type, UInt64Type, Int8Type, Int16Type,
                      Int32Type, Int64Type, FloatType, DoubleType, Decimal128Type,
                      StringType>;
+#endif
 
 TYPED_TEST_SUITE(TestNthToIndicesRandom, NthToIndicesableTypes);
 
@@ -779,10 +793,15 @@ class TestArraySortIndicesRandomCount : public ::testing::Test {};
 template <typename ArrowType>
 class TestArraySortIndicesRandomCompare : public ::testing::Test {};
 
+#ifdef ARROW_VALGRIND
+using SortIndicesableTypes = ::testing::Types<UInt32Type, FloatType, DoubleType,
+                                              StringType, Decimal128Type, BooleanType>;
+#else
 using SortIndicesableTypes =
     ::testing::Types<UInt8Type, UInt16Type, UInt32Type, UInt64Type, Int8Type, Int16Type,
                      Int32Type, Int64Type, FloatType, DoubleType, StringType,
                      Decimal128Type, BooleanType>;
+#endif
 
 template <typename ArrayType>
 void ValidateSorted(const ArrayType& array, UInt64Array& offsets, SortOrder order,
@@ -1940,12 +1959,17 @@ TEST_P(TestTableSortIndicesRandom, Sort) {
   }
 }
 
+#ifdef ARROW_VALGRIND
+static const auto first_sort_keys = testing::Values("uint64");
+static const auto num_sort_keys = testing::Values(3);
+#else
 // Some first keys will have duplicates, others not
 static const auto first_sort_keys = testing::Values("uint8", "int16", "uint64", "float",
                                                     "boolean", "string", "decimal128");
 
 // Different numbers of sort keys may trigger different algorithms
 static const auto num_sort_keys = testing::Values(1, 3, 7, 9);
+#endif
 
 INSTANTIATE_TEST_SUITE_P(NoNull, TestTableSortIndicesRandom,
                          testing::Combine(first_sort_keys, num_sort_keys,

--- a/cpp/src/arrow/dataset/file_csv_test.cc
+++ b/cpp/src/arrow/dataset/file_csv_test.cc
@@ -457,6 +457,11 @@ INSTANTIATE_TEST_SUITE_P(TestUncompressedCsv, TestCsvFileFormat,
 INSTANTIATE_TEST_SUITE_P(TestUncompressedCsvV2, TestCsvFileFormat,
                          ::testing::Values(CsvFileFormatParams{Compression::UNCOMPRESSED,
                                                                true}));
+
+// Writing even small CSV files takes a lot of time in valgrind.  The various compression
+// codecs should be independently tested and so we do not need to cover those with
+// valgrind here.
+#ifndef ARROW_VALGRIND
 #ifdef ARROW_WITH_BZ2
 INSTANTIATE_TEST_SUITE_P(TestBZ2Csv, TestCsvFileFormat,
                          ::testing::Values(CsvFileFormatParams{Compression::BZ2, false}));
@@ -486,6 +491,7 @@ INSTANTIATE_TEST_SUITE_P(TestZSTDCsv, TestCsvFileFormat,
 INSTANTIATE_TEST_SUITE_P(TestZSTDCsvV2, TestCsvFileFormat,
                          ::testing::Values(CsvFileFormatParams{Compression::ZSTD, true}));
 #endif
+#endif  // ARROW_VALGRIND
 
 class TestCsvFileFormatScan : public FileFormatScanMixin<CsvFormatHelper> {};
 

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -460,7 +460,7 @@ std::ostream& operator<<(std::ostream& out, const ScannerTestParams& params) {
   return out;
 }
 
-constexpr int kRowsPerTestBatch = 1024;
+constexpr int kRowsPerTestBatch = 16;
 
 std::shared_ptr<Schema> ScannerTestSchema() {
   return schema({field("row_num", int32()), field("filterable", int16()),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -315,6 +315,7 @@ services:
       ARROW_TEST_MEMCHECK: "ON"
       ARROW_USE_LD_GOLD: "ON"
       BUILD_WARNING_LEVEL: "PRODUCTION"
+      ARROW_CTEST_TIMEOUT: 500
     volumes: *conda-volumes
     command: *conda-cpp-command
 


### PR DESCRIPTION
This partially addresses #33699.  Once these tests are passing we can analyze the runtime and try and scope our valgrind coverage to something appropriate.
* Closes: #33699