### PR TITLE
GH-33887: [Go] cdata package leaks handles, difficult debugging

### DIFF
--- a/go/arrow/cdata/arrow/c/helpers.h
+++ b/go/arrow/cdata/arrow/c/helpers.h
@@ -27,12 +27,12 @@ extern "C" {
 #endif
 
 /// Query whether the C schema is released
-inline int ArrowSchemaIsReleased(const struct ArrowSchema* schema) {
+static inline int ArrowSchemaIsReleased(const struct ArrowSchema* schema) {
   return schema->release == NULL;
 }
 
 /// Mark the C schema released (for use in release callbacks)
-inline void ArrowSchemaMarkReleased(struct ArrowSchema* schema) {
+static inline void ArrowSchemaMarkReleased(struct ArrowSchema* schema) {
   schema->release = NULL;
 }
 
@@ -40,7 +40,7 @@ inline void ArrowSchemaMarkReleased(struct ArrowSchema* schema) {
 ///
 /// Note `dest` must *not* point to a valid schema already, otherwise there
 /// will be a memory leak.
-inline void ArrowSchemaMove(struct ArrowSchema* src, struct ArrowSchema* dest) {
+static inline void ArrowSchemaMove(struct ArrowSchema* src, struct ArrowSchema* dest) {
   assert(dest != src);
   assert(!ArrowSchemaIsReleased(src));
   memcpy(dest, src, sizeof(struct ArrowSchema));
@@ -48,7 +48,7 @@ inline void ArrowSchemaMove(struct ArrowSchema* src, struct ArrowSchema* dest) {
 }
 
 /// Release the C schema, if necessary, by calling its release callback
-inline void ArrowSchemaRelease(struct ArrowSchema* schema) {
+static inline void ArrowSchemaRelease(struct ArrowSchema* schema) {
   if (!ArrowSchemaIsReleased(schema)) {
     schema->release(schema);
     assert(ArrowSchemaIsReleased(schema));
@@ -56,18 +56,18 @@ inline void ArrowSchemaRelease(struct ArrowSchema* schema) {
 }
 
 /// Query whether the C array is released
-inline int ArrowArrayIsReleased(const struct ArrowArray* array) {
+static inline int ArrowArrayIsReleased(const struct ArrowArray* array) {
   return array->release == NULL;
 }
 
 /// Mark the C array released (for use in release callbacks)
-inline void ArrowArrayMarkReleased(struct ArrowArray* array) { array->release = NULL; }
+static inline void ArrowArrayMarkReleased(struct ArrowArray* array) { array->release = NULL; }
 
 /// Move the C array from `src` to `dest`
 ///
 /// Note `dest` must *not* point to a valid array already, otherwise there
 /// will be a memory leak.
-inline void ArrowArrayMove(struct ArrowArray* src, struct ArrowArray* dest) {
+static inline void ArrowArrayMove(struct ArrowArray* src, struct ArrowArray* dest) {
   assert(dest != src);
   assert(!ArrowArrayIsReleased(src));
   memcpy(dest, src, sizeof(struct ArrowArray));
@@ -75,7 +75,7 @@ inline void ArrowArrayMove(struct ArrowArray* src, struct ArrowArray* dest) {
 }
 
 /// Release the C array, if necessary, by calling its release callback
-inline void ArrowArrayRelease(struct ArrowArray* array) {
+static inline void ArrowArrayRelease(struct ArrowArray* array) {
   if (!ArrowArrayIsReleased(array)) {
     array->release(array);
     assert(ArrowArrayIsReleased(array));
@@ -83,12 +83,12 @@ inline void ArrowArrayRelease(struct ArrowArray* array) {
 }
 
 /// Query whether the C array stream is released
-inline int ArrowArrayStreamIsReleased(const struct ArrowArrayStream* stream) {
+static inline int ArrowArrayStreamIsReleased(const struct ArrowArrayStream* stream) {
   return stream->release == NULL;
 }
 
 /// Mark the C array stream released (for use in release callbacks)
-inline void ArrowArrayStreamMarkReleased(struct ArrowArrayStream* stream) {
+static inline void ArrowArrayStreamMarkReleased(struct ArrowArrayStream* stream) {
   stream->release = NULL;
 }
 
@@ -96,7 +96,7 @@ inline void ArrowArrayStreamMarkReleased(struct ArrowArrayStream* stream) {
 ///
 /// Note `dest` must *not* point to a valid stream already, otherwise there
 /// will be a memory leak.
-inline void ArrowArrayStreamMove(struct ArrowArrayStream* src,
+static inline void ArrowArrayStreamMove(struct ArrowArrayStream* src,
                                  struct ArrowArrayStream* dest) {
   assert(dest != src);
   assert(!ArrowArrayStreamIsReleased(src));
@@ -105,7 +105,7 @@ inline void ArrowArrayStreamMove(struct ArrowArrayStream* src,
 }
 
 /// Release the C array stream, if necessary, by calling its release callback
-inline void ArrowArrayStreamRelease(struct ArrowArrayStream* stream) {
+static inline void ArrowArrayStreamRelease(struct ArrowArrayStream* stream) {
   if (!ArrowArrayStreamIsReleased(stream)) {
     stream->release(stream);
     assert(ArrowArrayStreamIsReleased(stream));

--- a/go/arrow/cdata/exports.go
+++ b/go/arrow/cdata/exports.go
@@ -119,6 +119,7 @@ func releaseExportedArray(arr *CArrowArray) {
 	h := getHandle(arr.private_data)
 	h.Value().(arrow.ArrayData).Release()
 	h.Delete()
+	C.free(unsafe.Pointer(arr.private_data))
 }
 
 //export streamGetSchema
@@ -147,6 +148,7 @@ func streamRelease(handle *CArrowArrayStream) {
 	h := getHandle(handle.private_data)
 	h.Value().(cRecordReader).release()
 	h.Delete()
+	C.free(unsafe.Pointer(handle.private_data))
 	handle.release = nil
 	handle.private_data = nil
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/master/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
Fixing a memory leak of malloc'd `uintptr_t` values used for cgo handles
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
calling `free` on the handles after deleting the Go objects they point at, add `static` keyword to the helper function definitions in `helpers.h` so that compiling without optimizations for debugging doesn't fail.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

* Closes: #33887