### PR TITLE
GH-33901: [Go] Add a malloc-based allocator

### DIFF
--- a/go/arrow/memory/default_allocator.go
+++ b/go/arrow/memory/default_allocator.go
@@ -14,14 +14,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !mallocator
+
 package memory
 
-const (
-	alignment = 64
-)
-
-type Allocator interface {
-	Allocate(size int) []byte
-	Reallocate(size int, b []byte) []byte
-	Free(b []byte)
-}
+// DefaultAllocator is a default implementation of Allocator and can be used anywhere
+// an Allocator is required.
+//
+// DefaultAllocator is safe to use from multiple goroutines.
+var DefaultAllocator Allocator = NewGoAllocator()

--- a/go/arrow/memory/default_mallocator.go
+++ b/go/arrow/memory/default_mallocator.go
@@ -14,14 +14,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build mallocator
+
 package memory
 
-const (
-	alignment = 64
+import (
+	"github.com/apache/arrow/go/v12/arrow/memory/mallocator"
 )
 
-type Allocator interface {
-	Allocate(size int) []byte
-	Reallocate(size int, b []byte) []byte
-	Free(b []byte)
-}
+// DefaultAllocator is a default implementation of Allocator and can be used anywhere
+// an Allocator is required.
+//
+// DefaultAllocator is safe to use from multiple goroutines.
+var DefaultAllocator Allocator = mallocator.NewMallocator()

--- a/go/arrow/memory/default_mallocator_test.go
+++ b/go/arrow/memory/default_mallocator_test.go
@@ -14,14 +14,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package memory
+//go:build mallocator
 
-const (
-	alignment = 64
+package memory_test
+
+import (
+	"testing"
+
+	"github.com/apache/arrow/go/v12/arrow/memory"
+	"github.com/apache/arrow/go/v12/arrow/memory/mallocator"
+	"github.com/stretchr/testify/assert"
 )
 
-type Allocator interface {
-	Allocate(size int) []byte
-	Reallocate(size int, b []byte) []byte
-	Free(b []byte)
+func TestDefaultAllocator(t *testing.T) {
+	assert.IsType(t, &mallocator.Mallocator{}, memory.DefaultAllocator)
 }

--- a/go/arrow/memory/doc.go
+++ b/go/arrow/memory/doc.go
@@ -16,5 +16,7 @@
 
 /*
 Package memory provides support for allocating and manipulating memory at a low level.
+
+The build tag 'mallocator' will switch the default allocator to one backed by libc malloc. This also requires CGO.
 */
 package memory

--- a/go/arrow/memory/mallocator/mallocator.go
+++ b/go/arrow/memory/mallocator/mallocator.go
@@ -1,0 +1,102 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mallocator
+
+// #include <stdlib.h>
+// #include <string.h>
+//
+// void* realloc_and_initialize(void* ptr, size_t old_len, size_t new_len) {
+//   void* new_ptr = realloc(ptr, new_len);
+//   if (new_ptr && new_len > old_len) {
+//     memset(new_ptr + old_len, 0, new_len - old_len);
+//   }
+//   return new_ptr;
+// }
+import "C"
+
+import (
+	"reflect"
+	"sync/atomic"
+	"unsafe"
+
+	"github.com/apache/arrow/go/v12/arrow/memory"
+)
+
+type Mallocator struct {
+	allocatedBytes uint64
+}
+
+func NewMallocator() *Mallocator { return &Mallocator{} }
+
+func (alloc *Mallocator) Allocate(size int) []byte {
+	// Use calloc to zero-initialize memory.
+	// > ...the current implementation may sometimes cause a runtime error if the
+	// > contents of the C memory appear to be a Go pointer. Therefore, avoid
+	// > passing uninitialized C memory to Go code if the Go code is going to store
+	// > pointer values in it. Zero out the memory in C before passing it to Go.
+	if size < 0 {
+		panic("mallocator: negative size")
+	}
+	ptr, err := C.calloc(C.size_t(size), 1)
+	if err != nil {
+		panic(err)
+	} else if ptr == nil {
+		panic("mallocator: out of memory")
+	}
+	atomic.AddUint64(&alloc.allocatedBytes, uint64(size))
+	return unsafe.Slice((*byte)(ptr), size)
+}
+
+func (alloc *Mallocator) Free(b []byte) {
+	sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	C.free(unsafe.Pointer(sh.Data))
+	// Subtract sh.Len via two's complement (since atomic doesn't offer subtract)
+	atomic.AddUint64(&alloc.allocatedBytes, ^(uint64(sh.Len) - 1))
+}
+
+func (alloc *Mallocator) Reallocate(size int, b []byte) []byte {
+	if size < 0 {
+		panic("mallocator: negative size")
+	}
+	sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	ptr, err := C.realloc_and_initialize(unsafe.Pointer(sh.Data), C.size_t(sh.Cap), C.size_t(size))
+	if err != nil {
+		panic(err)
+	} else if ptr == nil && size != 0 {
+		panic("mallocator: out of memory")
+	}
+	delta := size - len(b)
+	if delta >= 0 {
+		atomic.AddUint64(&alloc.allocatedBytes, uint64(delta))
+	} else {
+		atomic.AddUint64(&alloc.allocatedBytes, ^(uint64(-delta) - 1))
+	}
+	return unsafe.Slice((*byte)(ptr), size)
+}
+
+func (alloc *Mallocator) AllocatedBytes() int64 {
+	return int64(alloc.allocatedBytes)
+}
+
+func (alloc *Mallocator) AssertSize(t memory.TestingT, sz int) {
+	cur := alloc.AllocatedBytes()
+	if int64(sz) != cur {
+		t.Helper()
+		t.Errorf("invalid memory size exp=%d, got=%d", sz, cur)
+	}
+}

--- a/go/arrow/memory/mallocator/mallocator_test.go
+++ b/go/arrow/memory/mallocator/mallocator_test.go
@@ -1,0 +1,125 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mallocator_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apache/arrow/go/v12/arrow/memory/mallocator"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMallocatorAllocate(t *testing.T) {
+	sizes := []int{0, 1, 4, 33, 65, 4095, 4096, 8193}
+	for _, size := range sizes {
+		t.Run(fmt.Sprint(size), func(t *testing.T) {
+			a := mallocator.NewMallocator()
+			buf := a.Allocate(size)
+			defer a.Free(buf)
+
+			assert.Equal(t, size, len(buf))
+			assert.LessOrEqual(t, size, cap(buf))
+			// check 0-initialized
+			for idx, c := range buf {
+				assert.Equal(t, uint8(0), c, fmt.Sprintf("Buf not zero-initialized at %d", idx))
+			}
+		})
+	}
+}
+
+func TestMallocatorReallocate(t *testing.T) {
+	sizes := []struct {
+		before, after int
+	}{
+		{0, 1},
+		{1, 0},
+		{1, 2},
+		{1, 33},
+		{4, 4},
+		{32, 16},
+		{32, 1},
+	}
+	for _, test := range sizes {
+		t.Run(fmt.Sprintf("%dTo%d", test.before, test.after), func(t *testing.T) {
+			a := mallocator.NewMallocator()
+			buf := a.Allocate(test.before)
+
+			assert.Equal(t, test.before, len(buf))
+			assert.LessOrEqual(t, test.before, cap(buf))
+			// check 0-initialized
+			for idx, c := range buf {
+				assert.Equal(t, uint8(0), c, fmt.Sprintf("Buf not zero-initialized at %d", idx))
+			}
+
+			buf = a.Reallocate(test.after, buf)
+			defer a.Free(buf)
+			assert.Equal(t, test.after, len(buf))
+			assert.LessOrEqual(t, test.after, cap(buf))
+			// check 0-initialized
+			for idx, c := range buf {
+				assert.Equal(t, uint8(0), c, fmt.Sprintf("Buf not zero-initialized at %d", idx))
+			}
+		})
+	}
+}
+
+func TestMallocatorAssertSize(t *testing.T) {
+	a := mallocator.NewMallocator()
+	assert.Equal(t, int64(0), a.AllocatedBytes())
+
+	buf1 := a.Allocate(64)
+	a.AssertSize(t, 64)
+
+	buf2 := a.Allocate(128)
+	a.AssertSize(t, 192)
+	assert.Equal(t, int64(192), a.AllocatedBytes())
+
+	a.Free(buf1)
+	a.AssertSize(t, 128)
+	assert.Equal(t, int64(128), a.AllocatedBytes())
+
+	buf2 = a.Reallocate(256, buf2)
+	a.AssertSize(t, 256)
+	assert.Equal(t, int64(256), a.AllocatedBytes())
+
+	buf2 = a.Reallocate(64, buf2)
+	a.AssertSize(t, 64)
+	assert.Equal(t, int64(64), a.AllocatedBytes())
+
+	a.Free(buf2)
+	a.AssertSize(t, 0)
+	assert.Equal(t, int64(0), a.AllocatedBytes())
+}
+
+func TestMallocatorAllocateNegative(t *testing.T) {
+	a := mallocator.NewMallocator()
+	assert.PanicsWithValue(t, "mallocator: negative size", func() {
+		a.Allocate(-1)
+	})
+}
+
+func TestMallocatorReallocateNegative(t *testing.T) {
+	a := mallocator.NewMallocator()
+	buf := a.Allocate(1)
+	defer a.Free(buf)
+
+	assert.PanicsWithValue(t, "mallocator: negative size", func() {
+		a.Reallocate(-1, buf)
+	})
+}


### PR DESCRIPTION
### Rationale for this change

Add a cgo-based allocator for use with the C Data Interface. (See apache/arrow-go#70.)

### What changes are included in this PR?

Add a new allocator implementation, `Mallocator`.

### Are these changes tested?

A new test suite was added.

### Are there any user-facing changes?

Adds a new public implementation of an API.
* Closes: apache/arrow#33901