### PR TITLE
GH-33876: [C++][Windows] Use different .pc path for each config

### DIFF
--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -947,9 +947,9 @@ function(ARROW_ADD_PKG_CONFIG MODULE)
   configure_file(${MODULE}.pc.in "${CMAKE_CURRENT_BINARY_DIR}/${MODULE}.pc.generate.in"
                  @ONLY)
   file(GENERATE
-       OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${MODULE}.pc"
+       OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${MODULE}.pc"
        INPUT "${CMAKE_CURRENT_BINARY_DIR}/${MODULE}.pc.generate.in")
-  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${MODULE}.pc"
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${MODULE}.pc"
           DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
 endfunction()
 


### PR DESCRIPTION
### What changes are included in this PR?

Use different .pc path for each CMake configuration because .pc content may be different with different CMake configuration.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #33876