### PR TITLE
GH-33899: [C++] Add NamedTapRel relation as a Substrait extension

### DIFF
--- a/cpp/proto/substrait/extension_rels.proto
+++ b/cpp/proto/substrait/extension_rels.proto
@@ -44,3 +44,9 @@ message AsOfJoinRel {
     repeated .substrait.Expression by = 2;
   }
 }
+
+message NamedTapRel {
+  string kind = 1;
+  string name = 2;
+  repeated string columns = 3;
+}

--- a/cpp/proto/substrait/extension_rels.proto
+++ b/cpp/proto/substrait/extension_rels.proto
@@ -45,8 +45,15 @@ message AsOfJoinRel {
   }
 }
 
+// Named tap relation
+//
+// A tap is a relation having a single input relation that it passes through, while also
+// causing some side-effect, e.g., writing to external storage.
 message NamedTapRel {
+  // The kind of tap
   string kind = 1;
+  // A name used to configure the tap, e.g., a URI defining the destination of writing
   string name = 2;
+  // Column names for the tap's output. Their number must be 0 or equal to the input's.
   repeated string columns = 3;
 }

--- a/cpp/proto/substrait/extension_rels.proto
+++ b/cpp/proto/substrait/extension_rels.proto
@@ -54,6 +54,7 @@ message NamedTapRel {
   string kind = 1;
   // A name used to configure the tap, e.g., a URI defining the destination of writing
   string name = 2;
-  // Column names for the tap's output. Their number must be 0 or equal to the input's.
+  // Column names for the tap's output. If specified there must be one name per field.
+  // If empty, field names will be automatically generated.
   repeated string columns = 3;
 }

--- a/cpp/src/arrow/engine/substrait/options.cc
+++ b/cpp/src/arrow/engine/substrait/options.cc
@@ -30,7 +30,7 @@ namespace engine {
 
 namespace {
 
-std::vector<compute::Declaration::Input> MakeDeclarationInputss(
+std::vector<compute::Declaration::Input> MakeDeclarationInputs(
     const std::vector<DeclarationInfo>& inputs) {
   std::vector<compute::Declaration::Input> input_decls(inputs.size());
   for (size_t i = 0; i < inputs.size(); i++) {
@@ -133,7 +133,7 @@ class DefaultExtensionProvider : public BaseExtensionProvider {
     compute::AsofJoinNodeOptions asofjoin_node_opts{std::move(input_keys), tolerance};
 
     // declaration
-    auto input_decls = MakeDeclarationInputss(inputs);
+    auto input_decls = MakeDeclarationInputs(inputs);
     return RelationInfo{
         {compute::Declaration("asofjoin", input_decls, std::move(asofjoin_node_opts)),
          std::move(schema)},
@@ -146,7 +146,7 @@ class DefaultExtensionProvider : public BaseExtensionProvider {
                                        const ExtensionSet& ext_set) {
     if (inputs.size() != 1) {
       return Status::Invalid(
-          "substrait_ext::NamedTapNode requires a single table but got: ", inputs.size());
+          "substrait_ext::NamedTapRel requires a single input but got: ", inputs.size());
     }
 
     ARROW_ASSIGN_OR_RAISE(auto tap_func_name,
@@ -164,7 +164,7 @@ class DefaultExtensionProvider : public BaseExtensionProvider {
     std::shared_ptr<compute::ExecNodeOptions> named_tap_opts =
         std::make_shared<NamedTapNodeOptions>(named_tap_rel.name(),
                                               std::move(renamed_schema));
-    auto input_decls = MakeDeclarationInputss(inputs);
+    auto input_decls = MakeDeclarationInputs(inputs);
     return RelationInfo{
         {compute::Declaration(tap_func_name, input_decls, std::move(named_tap_opts)),
          std::move(renamed_schema)},

--- a/cpp/src/arrow/engine/substrait/options.cc
+++ b/cpp/src/arrow/engine/substrait/options.cc
@@ -19,6 +19,7 @@
 
 #include <google/protobuf/util/json_util.h>
 #include <mutex>
+
 #include "arrow/compute/exec/asof_join_node.h"
 #include "arrow/compute/exec/options.h"
 #include "arrow/engine/substrait/expression_internal.h"
@@ -174,27 +175,27 @@ std::shared_ptr<ExtensionProvider> default_extension_provider() {
   return ExtensionProvider::kDefaultExtensionProvider;
 }
 
-NamedTapProvider kDefaultNamedTapProvider =
+namespace {
+
+NamedTapProvider g_default_named_tap_provider =
     [](const std::string& tap_kind, std::vector<compute::Declaration::Input> inputs,
        const std::string& tap_name,
        std::shared_ptr<Schema> tap_schema) -> Result<compute::Declaration> {
   return Status::NotImplemented("Named tap provider must be given");
 };
 
-namespace {
-
 std::mutex g_default_named_tap_provider_mutex;
 
-}
+}  // namespace
 
 NamedTapProvider default_named_tap_provider() {
-  std::unique_lock lock(g_default_named_tap_provider_mutex);
-  return kDefaultNamedTapProvider;
+  std::unique_lock<std::mutex> lock(g_default_named_tap_provider_mutex);
+  return g_default_named_tap_provider;
 }
 
 void set_default_named_tap_provider(NamedTapProvider provider) {
-  std::unique_lock lock(g_default_named_tap_provider_mutex);
-  kDefaultNamedTapProvider = provider;
+  std::unique_lock<std::mutex> lock(g_default_named_tap_provider_mutex);
+  g_default_named_tap_provider = provider;
 }
 
 }  // namespace engine

--- a/cpp/src/arrow/engine/substrait/options.cc
+++ b/cpp/src/arrow/engine/substrait/options.cc
@@ -181,7 +181,7 @@ NamedTapProvider g_default_named_tap_provider =
     [](const std::string& tap_kind, std::vector<compute::Declaration::Input> inputs,
        const std::string& tap_name,
        std::shared_ptr<Schema> tap_schema) -> Result<compute::Declaration> {
-  return Status::NotImplemented("Named tap provider must be given");
+  return Status::NotImplemented("Plan contained a NamedTapRel but no provider configured");
 };
 
 std::mutex g_default_named_tap_provider_mutex;

--- a/cpp/src/arrow/engine/substrait/options.cc
+++ b/cpp/src/arrow/engine/substrait/options.cc
@@ -66,7 +66,7 @@ class DefaultExtensionProvider : public BaseExtensionProvider {
     if (rel.Is<substrait_ext::AsOfJoinRel>()) {
       substrait_ext::AsOfJoinRel as_of_join_rel;
       rel.UnpackTo(&as_of_join_rel);
-      return MakeAsOfJoinRel(conv_opts, inputs, as_of_join_rel, ext_set);
+      return MakeAsOfJoinRel(inputs, as_of_join_rel, ext_set);
     }
     if (rel.Is<substrait_ext::NamedTapRel>()) {
       substrait_ext::NamedTapRel named_tap_rel;
@@ -78,8 +78,7 @@ class DefaultExtensionProvider : public BaseExtensionProvider {
   }
 
  private:
-  Result<RelationInfo> MakeAsOfJoinRel(const ConversionOptions& conv_opts,
-                                       const std::vector<DeclarationInfo>& inputs,
+  Result<RelationInfo> MakeAsOfJoinRel(const std::vector<DeclarationInfo>& inputs,
                                        const substrait_ext::AsOfJoinRel& as_of_join_rel,
                                        const ExtensionSet& ext_set) {
     if (inputs.size() < 2) {

--- a/cpp/src/arrow/engine/substrait/options.cc
+++ b/cpp/src/arrow/engine/substrait/options.cc
@@ -181,7 +181,8 @@ NamedTapProvider g_default_named_tap_provider =
     [](const std::string& tap_kind, std::vector<compute::Declaration::Input> inputs,
        const std::string& tap_name,
        std::shared_ptr<Schema> tap_schema) -> Result<compute::Declaration> {
-  return Status::NotImplemented("Plan contained a NamedTapRel but no provider configured");
+  return Status::NotImplemented(
+      "Plan contained a NamedTapRel but no provider configured");
 };
 
 std::mutex g_default_named_tap_provider_mutex;

--- a/cpp/src/arrow/engine/substrait/options.cc
+++ b/cpp/src/arrow/engine/substrait/options.cc
@@ -148,9 +148,6 @@ class DefaultExtensionProvider : public BaseExtensionProvider {
           "substrait_ext::NamedTapRel requires a single input but got: ", inputs.size());
     }
 
-    ARROW_ASSIGN_OR_RAISE(auto tap_func_name,
-                          conv_opts.named_tap_mapper(named_tap_rel.kind()));
-
     auto schema = inputs[0].output_schema;
     int num_fields = schema->num_fields();
     if (named_tap_rel.columns_size() != num_fields) {
@@ -164,10 +161,10 @@ class DefaultExtensionProvider : public BaseExtensionProvider {
         std::make_shared<NamedTapNodeOptions>(named_tap_rel.name(),
                                               std::move(renamed_schema));
     auto input_decls = MakeDeclarationInputs(inputs);
-    return RelationInfo{
-        {compute::Declaration(tap_func_name, input_decls, std::move(named_tap_opts)),
-         std::move(renamed_schema)},
-        std::nullopt};
+    ARROW_ASSIGN_OR_RAISE(auto decl,
+                          conv_opts.named_tap_mapper(named_tap_rel.kind(), input_decls,
+                                                     std::move(named_tap_opts)));
+    return RelationInfo{{std::move(decl), std::move(renamed_schema)}, std::nullopt};
   }
 };
 

--- a/cpp/src/arrow/engine/substrait/options.h
+++ b/cpp/src/arrow/engine/substrait/options.h
@@ -23,6 +23,7 @@
 #include <string>
 #include <vector>
 
+#include "arrow/compute/exec/options.h"
 #include "arrow/compute/type_fwd.h"
 #include "arrow/engine/substrait/type_fwd.h"
 #include "arrow/engine/substrait/visibility.h"
@@ -82,6 +83,14 @@ class ARROW_ENGINE_EXPORT ExtensionProvider {
 };
 
 ARROW_ENGINE_EXPORT std::shared_ptr<ExtensionProvider> default_extension_provider();
+
+struct ARROW_ENGINE_EXPORT NamedTapNodeOptions : public compute::ExecNodeOptions {
+  NamedTapNodeOptions(const std::string& name, std::shared_ptr<Schema> schema)
+      : name(name), schema(std::move(schema)) {}
+
+  std::string name;
+  std::shared_ptr<Schema> schema;
+};
 
 /// Options that control the conversion between Substrait and Acero representations of a
 /// plan.

--- a/cpp/src/arrow/engine/substrait/options.h
+++ b/cpp/src/arrow/engine/substrait/options.h
@@ -68,6 +68,9 @@ using NamedTableProvider =
     std::function<Result<compute::Declaration>(const std::vector<std::string>&)>;
 static NamedTableProvider kDefaultNamedTableProvider;
 
+using NamedTapKindMapper = std::function<Result<std::string>(const std::string&)>;
+static NamedTapKindMapper kDefaultNamedTapKindMapper;
+
 class ARROW_ENGINE_EXPORT ExtensionDetails {
  public:
   virtual ~ExtensionDetails() = default;
@@ -77,7 +80,8 @@ class ARROW_ENGINE_EXPORT ExtensionProvider {
  public:
   static std::shared_ptr<ExtensionProvider> kDefaultExtensionProvider;
   virtual ~ExtensionProvider() = default;
-  virtual Result<RelationInfo> MakeRel(const std::vector<DeclarationInfo>& inputs,
+  virtual Result<RelationInfo> MakeRel(const ConversionOptions& conv_opts,
+                                       const std::vector<DeclarationInfo>& inputs,
                                        const ExtensionDetails& ext_details,
                                        const ExtensionSet& ext_set) = 0;
 };
@@ -102,6 +106,11 @@ struct ARROW_ENGINE_EXPORT ConversionOptions {
   /// The default behavior will return an invalid status if the plan has any
   /// named table relations.
   NamedTableProvider named_table_provider = kDefaultNamedTableProvider;
+  /// \brief A custom strategy to be used for mapping a tap kind to a function name
+  ///
+  /// The default behavior will return an invalid status if the plan has any
+  /// named tap relations.
+  NamedTapKindMapper named_tap_mapper = kDefaultNamedTapKindMapper;
   std::shared_ptr<ExtensionProvider> extension_provider = default_extension_provider();
 };
 

--- a/cpp/src/arrow/engine/substrait/options.h
+++ b/cpp/src/arrow/engine/substrait/options.h
@@ -69,7 +69,8 @@ using NamedTableProvider =
 static NamedTableProvider kDefaultNamedTableProvider;
 
 using NamedTapKindMapper = std::function<Result<std::string>(const std::string&)>;
-static NamedTapKindMapper kDefaultNamedTapKindMapper;
+static NamedTapKindMapper kDefaultNamedTapKindMapper =
+    [](const std::string& kind) -> Result<std::string> { return kind; };
 
 class ARROW_ENGINE_EXPORT ExtensionDetails {
  public:
@@ -108,8 +109,7 @@ struct ARROW_ENGINE_EXPORT ConversionOptions {
   NamedTableProvider named_table_provider = kDefaultNamedTableProvider;
   /// \brief A custom strategy to be used for mapping a tap kind to a function name
   ///
-  /// The default behavior will return an invalid status if the plan has any
-  /// named tap relations.
+  /// The default mapper is the identity mapping.
   NamedTapKindMapper named_tap_mapper = kDefaultNamedTapKindMapper;
   std::shared_ptr<ExtensionProvider> extension_provider = default_extension_provider();
 };

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -206,7 +206,7 @@ Result<RelationInfo> GetExtensionRelationInfo(const substrait::Rel& rel,
     case substrait::Rel::RelTypeCase::kExtensionLeaf: {
       const auto& ext = rel.extension_leaf();
       DefaultExtensionDetails detail{ext.detail()};
-      return conv_opts.extension_provider->MakeRel(inputs, detail, ext_set);
+      return conv_opts.extension_provider->MakeRel(conv_opts, inputs, detail, ext_set);
     }
 
     case substrait::Rel::RelTypeCase::kExtensionSingle: {
@@ -215,7 +215,7 @@ Result<RelationInfo> GetExtensionRelationInfo(const substrait::Rel& rel,
                             FromProto(ext.input(), ext_set, conv_opts));
       inputs.push_back(std::move(input_info));
       DefaultExtensionDetails detail{ext.detail()};
-      return conv_opts.extension_provider->MakeRel(inputs, detail, ext_set);
+      return conv_opts.extension_provider->MakeRel(conv_opts, inputs, detail, ext_set);
     }
 
     case substrait::Rel::RelTypeCase::kExtensionMulti: {
@@ -225,7 +225,7 @@ Result<RelationInfo> GetExtensionRelationInfo(const substrait::Rel& rel,
         inputs.push_back(std::move(input_info));
       }
       DefaultExtensionDetails detail{ext.detail()};
-      return conv_opts.extension_provider->MakeRel(inputs, detail, ext_set);
+      return conv_opts.extension_provider->MakeRel(conv_opts, inputs, detail, ext_set);
     }
 
     default: {

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -5451,8 +5451,6 @@ TEST(Substrait, PlanWithNamedTapExtension) {
       TableFromJSON(input_schema, {"[[2, 1, 1.1], [4, 1, 2.1], [6, 2, 3.1]]"}));
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
-  conversion_options.named_tap_mapper =
-      [](const std::string& tap_kind) -> Result<std::string> { return tap_kind; };
 
   ASSERT_OK_AND_ASSIGN(auto buf, internal::SubstraitFromJSON("Plan", substrait_json));
 

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -5447,17 +5447,8 @@ TEST(Substrait, PlanWithNamedTapExtension) {
 
   std::shared_ptr<Schema> input_schema =
       schema({field("time", int32()), field("key", int32()), field("value", float64())});
-  NamedTableProvider table_provider = ProvideMadeTable(
-      [&input_schema](
-          const std::vector<std::string>& names) -> Result<std::shared_ptr<Table>> {
-        if (names.size() != 1) {
-          return Status::Invalid("Multiple test table names");
-        }
-        if (names[0] == "T") {
-          return TableFromJSON(input_schema, {"[[2, 1, 1.1], [4, 1, 2.1], [6, 2, 3.1]]"});
-        }
-        return Status::Invalid("Unknown test table name ", names[0]);
-      });
+  NamedTableProvider table_provider = AlwaysProvideSameTable(
+      TableFromJSON(input_schema, {"[[2, 1, 1.1], [4, 1, 2.1], [6, 2, 3.1]]"}));
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
   conversion_options.named_tap_mapper =

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -5460,6 +5460,8 @@ TEST(Substrait, PlanWithNamedTapExtension) {
       });
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
+  conversion_options.named_tap_mapper =
+      [](const std::string& tap_kind) -> Result<std::string> { return tap_kind; };
 
   ASSERT_OK_AND_ASSIGN(auto buf, internal::SubstraitFromJSON("Plan", substrait_json));
 

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -5451,6 +5451,12 @@ TEST(Substrait, PlanWithNamedTapExtension) {
       TableFromJSON(input_schema, {"[[2, 1, 1.1], [4, 1, 2.1], [6, 2, 3.1]]"}));
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
+  conversion_options.named_tap_provider =
+      [](const std::string& tap_kind, std::vector<compute::Declaration::Input> inputs,
+         const std::string& tap_name,
+         std::shared_ptr<Schema> tap_schema) -> Result<compute::Declaration> {
+    return compute::Declaration{tap_kind, std::move(inputs), compute::ExecNodeOptions{}};
+  };
 
   ASSERT_OK_AND_ASSIGN(auto buf, internal::SubstraitFromJSON("Plan", substrait_json));
 

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -36,6 +36,7 @@
 #include "arrow/compute/exec/exec_plan.h"
 #include "arrow/compute/exec/expression.h"
 #include "arrow/compute/exec/expression_internal.h"
+#include "arrow/compute/exec/map_node.h"
 #include "arrow/compute/exec/options.h"
 #include "arrow/compute/exec/test_util.h"
 #include "arrow/compute/exec/util.h"
@@ -87,6 +88,30 @@ namespace arrow {
 using internal::checked_cast;
 using internal::hash_combine;
 namespace engine {
+
+Status AddPassFactory(
+    const std::string& factory_name,
+    compute::ExecFactoryRegistry* registry = compute::default_exec_factory_registry()) {
+  using compute::ExecBatch;
+  using compute::ExecNode;
+  using compute::ExecNodeOptions;
+  using compute::ExecPlan;
+  struct PassNode : public compute::MapNode {
+    static Result<ExecNode*> Make(ExecPlan* plan, std::vector<ExecNode*> inputs,
+                                  const compute::ExecNodeOptions& options) {
+      RETURN_NOT_OK(ValidateExecNodeInputs(plan, inputs, 1, "PassNode"));
+      return plan->EmplaceNode<PassNode>(plan, inputs, inputs[0]->output_schema());
+    }
+
+    PassNode(ExecPlan* plan, std::vector<ExecNode*> inputs,
+             std::shared_ptr<Schema> output_schema)
+        : MapNode(plan, inputs, output_schema) {}
+
+    const char* kind_name() const override { return "PassNode"; }
+    Result<ExecBatch> ProcessBatch(ExecBatch batch) override { return batch; }
+  };
+  return registry->AddFactory(factory_name, PassNode::Make);
+}
 
 const auto kNullConsumer = std::make_shared<compute::NullSinkNodeConsumer>();
 
@@ -5352,6 +5377,96 @@ TEST(Substrait, AsOfJoinDefaultEmit) {
   auto expected_table = TableFromJSON(
       out_schema,
       {"[[2, 1, 1.1, 2, 1, 1.2], [4, 1, 2.1, 4, 1, 1.2], [6, 2, 3.1, 6, 2, 3.2]]"});
+  CheckRoundTripResult(std::move(expected_table), buf, {}, conversion_options);
+}
+
+TEST(Substrait, PlanWithNamedTapExtension) {
+  // This demos an extension relation
+  std::string substrait_json = R"({
+    "extensionUris": [],
+    "extensions": [],
+    "relations": [{
+      "root": {
+        "input": {
+          "extension_multi": {
+            "inputs": [
+              {
+                "read": {
+                  "common": {
+                    "direct": {
+                    }
+                  },
+                  "baseSchema": {
+                    "names": ["time", "key", "value"],
+                    "struct": {
+                      "types": [
+                        {
+                          "i32": {
+                            "typeVariationReference": 0,
+                            "nullability": "NULLABILITY_NULLABLE"
+                          }
+                        },
+                        {
+                          "i32": {
+                            "typeVariationReference": 0,
+                            "nullability": "NULLABILITY_NULLABLE"
+                          }
+                        },
+                        {
+                          "fp64": {
+                            "typeVariationReference": 0,
+                            "nullability": "NULLABILITY_NULLABLE"
+                          }
+                        }
+                      ],
+                      "typeVariationReference": 0,
+                      "nullability": "NULLABILITY_REQUIRED"
+                    }
+                  },
+                  "namedTable": {
+                    "names": ["T"]
+                  }
+                }
+              }
+            ],
+            "detail": {
+              "@type": "/arrow.substrait_ext.NamedTapRel",
+              "kind" : "pass_for_named_tap",
+              "name" : "does_not_matter",
+              "columns" : ["pass_time", "pass_key", "pass_value"]
+            }
+          }
+        },
+        "names": ["t", "k", "v"]
+      }
+    }],
+    "expectedTypeUrls": []
+  })";
+
+  ASSERT_OK(AddPassFactory("pass_for_named_tap"));
+
+  std::shared_ptr<Schema> input_schema =
+      schema({field("time", int32()), field("key", int32()), field("value", float64())});
+  NamedTableProvider table_provider = ProvideMadeTable(
+      [&input_schema](
+          const std::vector<std::string>& names) -> Result<std::shared_ptr<Table>> {
+        if (names.size() != 1) {
+          return Status::Invalid("Multiple test table names");
+        }
+        if (names[0] == "T") {
+          return TableFromJSON(input_schema, {"[[2, 1, 1.1], [4, 1, 2.1], [6, 2, 3.1]]"});
+        }
+        return Status::Invalid("Unknown test table name ", names[0]);
+      });
+  ConversionOptions conversion_options;
+  conversion_options.named_table_provider = std::move(table_provider);
+
+  ASSERT_OK_AND_ASSIGN(auto buf, internal::SubstraitFromJSON("Plan", substrait_json));
+
+  std::shared_ptr<Schema> output_schema =
+      schema({field("t", int32()), field("k", int32()), field("v", float64())});
+  auto expected_table =
+      TableFromJSON(output_schema, {"[[2, 1, 1.1], [4, 1, 2.1], [6, 2, 3.1]]"});
   CheckRoundTripResult(std::move(expected_table), buf, {}, conversion_options);
 }
 

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -1714,6 +1714,21 @@ bool Schema::HasDistinctFieldNames() const {
   return names.size() == fields.size();
 }
 
+Result<std::shared_ptr<Schema>> Schema::WithNames(
+    const std::vector<std::string>& names) const {
+  if (names.size() != impl_->fields_.size()) {
+    return Status::Invalid("attempted to rename schema with ", impl_->fields_.size(),
+                           " fields but only ", names.size(), " new names were given");
+  }
+  FieldVector new_fields;
+  new_fields.reserve(names.size());
+  auto names_itr = names.begin();
+  for (const auto& field : impl_->fields_) {
+    new_fields.push_back(field->WithName(*names_itr++));
+  }
+  return schema(std::move(new_fields));
+}
+
 std::shared_ptr<Schema> Schema::WithMetadata(
     const std::shared_ptr<const KeyValueMetadata>& metadata) const {
   return std::make_shared<Schema>(impl_->fields_, metadata);

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1968,6 +1968,8 @@ class ARROW_EXPORT Schema : public detail::Fingerprintable,
   Result<std::shared_ptr<Schema>> SetField(int i,
                                            const std::shared_ptr<Field>& field) const;
 
+  Result<std::shared_ptr<Schema>> WithNames(const std::vector<std::string>& names) const;
+
   /// \brief Replace key-value metadata with new metadata
   ///
   /// \param[in] metadata new KeyValueMetadata

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1968,6 +1968,10 @@ class ARROW_EXPORT Schema : public detail::Fingerprintable,
   Result<std::shared_ptr<Schema>> SetField(int i,
                                            const std::shared_ptr<Field>& field) const;
 
+  /// \brief Replace field names with new names
+  ///
+  /// \param[in] names new names
+  /// \return new Schema
   Result<std::shared_ptr<Schema>> WithNames(const std::vector<std::string>& names) const;
 
   /// \brief Replace key-value metadata with new metadata


### PR DESCRIPTION
See #33899. This PR adds `NamedTapRel` and a simple test case with a no-op tap (i.e., just passing-through).
* Closes: #33899