### PR TITLE
GH-33911: [C++] Add missing std::forward to Result::ValueOrElse

### DIFF
--- a/cpp/src/arrow/result.h
+++ b/cpp/src/arrow/result.h
@@ -371,7 +371,7 @@ class [[nodiscard]] Result : public util::EqualityComparable<Result<T>> {
     if (ok()) {
       return MoveValueUnsafe();
     }
-    return generate_alternative();
+    return std::forward<G>(generate_alternative)();
   }
 
   /// Apply a function to the internally stored value to produce a new result or propagate

--- a/cpp/src/arrow/result_test.cc
+++ b/cpp/src/arrow/result_test.cc
@@ -28,6 +28,7 @@
 #include "arrow/testing/gtest_compat.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/matchers.h"
+#include "arrow/util/functional.h"
 
 namespace arrow {
 
@@ -793,6 +794,15 @@ TEST(ResultTest, MatcherExplanations) {
     EXPECT_THAT(listener.str(),
                 testing::StrEq("whose error \"Type error: XXX\" doesn't match"));
   }
+}
+
+TEST(ResultTest, ValueOrGeneratedMoveOnlyGenerator) {
+  Result<MoveOnlyDataType> result = Status::Invalid("");
+  internal::FnOnce<MoveOnlyDataType()> alternative_generator = [] {
+    return MoveOnlyDataType{kIntElement};
+  };
+  auto out = std::move(result).ValueOrElse(std::move(alternative_generator));
+  EXPECT_EQ(*out.data, kIntElement);
 }
 
 }  // namespace


### PR DESCRIPTION
It fixes #33911.

------

From #33911:

> https://github.com/apache/arrow/blob/4f1d255f3dc57457e5c78d98c4b76fc523cf9961/cpp/src/arrow/result.h#L369-L375
>
> The parameter `generate_alternative` is passed by univeral forwarding, but `std::forward` is missing to use it.
>
> This may result in incorrect overloading selection or compilation errors, such as a class type with the method `operator()() &&`.
* Closes: #33911