### PR TITLE
GH-33892: [R] Map `dplyr::n()` to `count_all` kernel

### DIFF
--- a/r/R/dplyr-collect.R
+++ b/r/R/dplyr-collect.R
@@ -188,7 +188,7 @@ implicit_schema <- function(.data) {
     group_fields <- new_fields[.data$group_by_vars]
     hash <- length(.data$group_by_vars) > 0
     agg_fields <- new_fields[setdiff(names(new_fields), .data$group_by_vars)]
-    agg_fields <- fix_aggregated_types(.data$aggregations, agg_fields, hash)
+    agg_fields <- fix_aggregated_types(agg_fields, .data$aggregations, hash)
     new_fields <- c(group_fields, agg_fields)
   }
   schema(!!!new_fields)

--- a/r/R/dplyr-collect.R
+++ b/r/R/dplyr-collect.R
@@ -179,16 +179,18 @@ implicit_schema <- function(.data) {
       new_fields <- c(left_fields, right_fields)
     }
   } else {
+    hash <- length(.data$group_by_vars) > 0
     # The output schema is based on the aggregations and any group_by vars
-    new_fields <- map(summarize_fields(.data), ~ .$type(old_schm))
+    new_fields <- c(
+      aggregate_types(.data, hash, old_schm),
+      group_types(.data, old_schm)
+    )
     # * Put group_by_vars first (this can't be done by summarize,
     #   they have to be last per the aggregate node signature,
     #   and they get projected to this order after aggregation)
     # * Determine the output types of the aggregations
     group_fields <- new_fields[.data$group_by_vars]
-    hash <- length(.data$group_by_vars) > 0
     agg_fields <- new_fields[setdiff(names(new_fields), .data$group_by_vars)]
-    agg_fields <- fix_aggregated_types(agg_fields, .data$aggregations, hash)
     new_fields <- c(group_fields, agg_fields)
   }
   schema(!!!new_fields)

--- a/r/R/dplyr-collect.R
+++ b/r/R/dplyr-collect.R
@@ -180,17 +180,13 @@ implicit_schema <- function(.data) {
     }
   } else {
     # The output schema is based on the aggregations and any group_by vars
-    new_fields <- map(summarize_projection(.data), ~ .$type(old_schm))
+    new_fields <- map(summarize_fields(.data), ~ .$type(old_schm))
     # * Put group_by_vars first (this can't be done by summarize,
     #   they have to be last per the aggregate node signature,
     #   and they get projected to this order after aggregation)
-    # * Infer the output types from the aggregations
+    # * Determine the output types of the aggregations
     group_fields <- new_fields[.data$group_by_vars]
-    hash <- length(.data$group_by_vars) > 0
-    agg_fields <- imap(
-      new_fields[setdiff(names(new_fields), .data$group_by_vars)],
-      ~ agg_fun_output_type(.data$aggregations[[.y]][["fun"]], .x, hash)
-    )
+    agg_fields <- new_fields[setdiff(names(new_fields), .data$group_by_vars)]
     new_fields <- c(group_fields, agg_fields)
   }
   schema(!!!new_fields)

--- a/r/R/dplyr-collect.R
+++ b/r/R/dplyr-collect.R
@@ -184,7 +184,10 @@ implicit_schema <- function(.data) {
     # The group_by vars come first (this can't be done by summarize; they have
     # to be last per the aggregate node signature, and they get projected to
     # this order after aggregation)
-    new_fields <- c(group_types(.data), aggregate_types(.data, hash))
+    new_fields <- c(
+      group_types(.data, old_schm),
+      aggregate_types(.data, hash, old_schm)
+    )
   }
   schema(!!!new_fields)
 }

--- a/r/R/dplyr-collect.R
+++ b/r/R/dplyr-collect.R
@@ -180,18 +180,14 @@ implicit_schema <- function(.data) {
     }
   } else {
     hash <- length(.data$group_by_vars) > 0
-    # The output schema is based on the aggregations and any group_by vars
+    # The output schema is based on the aggregations and any group_by vars.
+    # The group_by vars come first (this can't be done by summarize; they have
+    # to be last per the aggregate node signature, and they get projected to
+    # this order after aggregation)
     new_fields <- c(
-      aggregate_types(.data, hash, old_schm),
-      group_types(.data, old_schm)
+      group_types(.data, old_schm),
+      aggregate_types(.data, hash, old_schm)
     )
-    # * Put group_by_vars first (this can't be done by summarize,
-    #   they have to be last per the aggregate node signature,
-    #   and they get projected to this order after aggregation)
-    # * Determine the output types of the aggregations
-    group_fields <- new_fields[.data$group_by_vars]
-    agg_fields <- new_fields[setdiff(names(new_fields), .data$group_by_vars)]
-    new_fields <- c(group_fields, agg_fields)
   }
   schema(!!!new_fields)
 }

--- a/r/R/dplyr-collect.R
+++ b/r/R/dplyr-collect.R
@@ -186,7 +186,9 @@ implicit_schema <- function(.data) {
     #   and they get projected to this order after aggregation)
     # * Determine the output types of the aggregations
     group_fields <- new_fields[.data$group_by_vars]
+    hash <- length(.data$group_by_vars) > 0
     agg_fields <- new_fields[setdiff(names(new_fields), .data$group_by_vars)]
+    agg_fields <- fix_aggregated_types(.data$aggregations, agg_fields, hash)
     new_fields <- c(group_fields, agg_fields)
   }
   schema(!!!new_fields)

--- a/r/R/dplyr-collect.R
+++ b/r/R/dplyr-collect.R
@@ -184,10 +184,7 @@ implicit_schema <- function(.data) {
     # The group_by vars come first (this can't be done by summarize; they have
     # to be last per the aggregate node signature, and they get projected to
     # this order after aggregation)
-    new_fields <- c(
-      group_types(.data, old_schm),
-      aggregate_types(.data, hash, old_schm)
-    )
+    new_fields <- c(group_types(.data), aggregate_types(.data, hash))
   }
   schema(!!!new_fields)
 }

--- a/r/R/dplyr-funcs.R
+++ b/r/R/dplyr-funcs.R
@@ -49,7 +49,7 @@ NULL
 #'   aggregate function. This function must accept `Expression` objects as
 #'   arguments and return a `list()` with components:
 #'   - `fun`: string function name
-#'   - `data`: `Expression` (all currently a single field, except `dplyr::n`)
+#'   - `data`: list of 0 or more `Expression`s
 #'   - `options`: list of function options, as passed to call_function
 #' @param update_cache Update .cache$functions at the time of registration.
 #'   the default is FALSE because the majority of usage is to register

--- a/r/R/dplyr-funcs.R
+++ b/r/R/dplyr-funcs.R
@@ -49,7 +49,7 @@ NULL
 #'   aggregate function. This function must accept `Expression` objects as
 #'   arguments and return a `list()` with components:
 #'   - `fun`: string function name
-#'   - `data`: `Expression` (these are all currently a single field)
+#'   - `data`: `Expression` (all currently a single field, except `dplyr::n`)
 #'   - `options`: list of function options, as passed to call_function
 #' @param update_cache Update .cache$functions at the time of registration.
 #'   the default is FALSE because the majority of usage is to register

--- a/r/R/dplyr-summarize.R
+++ b/r/R/dplyr-summarize.R
@@ -310,10 +310,19 @@ summarize_projection <- function(.data) {
   c(
     unlist(unname(imap(
       .data$aggregations,
-      ~setNames(
-        .x$data,
-        paste(.y[length(.x$data) > 0], seq_along(.x$data), sep = "..")
-      )
+      ~if (length(.x$data) > 1) {
+          setNames(
+            .x$data,
+            paste(.y, seq_along(.x$data), sep = "..")
+          )
+        } else if (length(.x$data) > 0) {
+          setNames(
+            .x$data,
+            .y
+          )
+        } else {
+          character(0)
+        }
     ))),
     .data$selected_columns[.data$group_by_vars]
   )

--- a/r/R/dplyr-summarize.R
+++ b/r/R/dplyr-summarize.R
@@ -31,28 +31,28 @@ ensure_one_arg <- function(args, fun) {
   } else if (length(args) > 1) {
     arrow_not_supported(paste0("Multiple arguments to ", fun, "()"))
   }
-  args[[1]]
+  args
 }
 
 register_bindings_aggregate <- function() {
   register_binding_agg("base::sum", function(..., na.rm = FALSE) {
     list(
       fun = "sum",
-      data = list(ensure_one_arg(list2(...), "sum")),
+      data = ensure_one_arg(list2(...), "sum"),
       options = list(skip_nulls = na.rm, min_count = 0L)
     )
   })
   register_binding_agg("base::any", function(..., na.rm = FALSE) {
     list(
       fun = "any",
-      data = list(ensure_one_arg(list2(...), "any")),
+      data = ensure_one_arg(list2(...), "any"),
       options = list(skip_nulls = na.rm, min_count = 0L)
     )
   })
   register_binding_agg("base::all", function(..., na.rm = FALSE) {
     list(
       fun = "all",
-      data = list(ensure_one_arg(list2(...), "all")),
+      data = ensure_one_arg(list2(...), "all"),
       options = list(skip_nulls = na.rm, min_count = 0L)
     )
   })
@@ -124,7 +124,7 @@ register_bindings_aggregate <- function() {
   register_binding_agg("dplyr::n_distinct", function(..., na.rm = FALSE) {
     list(
       fun = "count_distinct",
-      data = list(ensure_one_arg(list2(...), "n_distinct")),
+      data = ensure_one_arg(list2(...), "n_distinct"),
       options = list(na.rm = na.rm)
     )
   })
@@ -138,14 +138,14 @@ register_bindings_aggregate <- function() {
   register_binding_agg("base::min", function(..., na.rm = FALSE) {
     list(
       fun = "min",
-      data = list(ensure_one_arg(list2(...), "min")),
+      data = ensure_one_arg(list2(...), "min"),
       options = list(skip_nulls = na.rm, min_count = 0L)
     )
   })
   register_binding_agg("base::max", function(..., na.rm = FALSE) {
     list(
       fun = "max",
-      data = list(ensure_one_arg(list2(...), "max")),
+      data = ensure_one_arg(list2(...), "max"),
       options = list(skip_nulls = na.rm, min_count = 0L)
     )
   })

--- a/r/R/dplyr-summarize.R
+++ b/r/R/dplyr-summarize.R
@@ -319,15 +319,6 @@ summarize_projection <- function(.data) {
   )
 }
 
-# This function determines whether we need to project before aggregating. If
-# all the aggregation targets are column references, then this function returns
-# TRUE, indicating that we do not need to project before aggregating. If any of
-# the targets are literals or expressions, then this function returns FALSE,
-# indicating that we do need to project aggregating.
-all_targets_are_field_refs <- function(aggs) {
-  all(map_lgl(aggs, ~all(map_lgl(.$data, ~.$is_field_ref()))))
-}
-
 # This function returns a list of expressions representing the aggregated fields
 # that will be returned by an aggregation
 aggregated_fields <- function(aggs) {

--- a/r/R/dplyr-summarize.R
+++ b/r/R/dplyr-summarize.R
@@ -325,7 +325,7 @@ aggregated_fields <- function(aggs) {
 # `FixedSizeList[Float64]`. The system that the R bindings use to infer the
 # output types of expressions does not account for this. It infers the output
 # type of `hash_tdigest` as `Float64`. This function is used to correct this.
-fix_aggregated_types <- function(aggs, fields, hash) {
+fix_aggregated_types <- function(fields, aggs, hash) {
   imap(
     fields,
     ~if(hash && aggs[[.y]]$fun == "tdigest") {

--- a/r/R/dplyr-summarize.R
+++ b/r/R/dplyr-summarize.R
@@ -305,6 +305,7 @@ arrow_eval_or_stop <- function(expr, mask) {
 # data before an aggregation to only the fields required for the aggregation
 summarize_projection <- function(.data) {
   c(
+    # TODO: support 2+ targets
     unlist(map(.data$aggregations, ~ .$data)),
     .data$selected_columns[.data$group_by_vars]
   )

--- a/r/R/dplyr-summarize.R
+++ b/r/R/dplyr-summarize.R
@@ -336,7 +336,7 @@ aggregate_target_names <- function(data, name) {
 
 # This function returns a named list of the data types of the aggregate columns
 # returned by an aggregation
-aggregate_types <- function(.data, hash) {
+aggregate_types <- function(.data, hash, schema = NULL) {
   if (hash) dummy_groups <- Scalar$create(1L, uint32())
   map(
     .data$aggregations,
@@ -348,21 +348,21 @@ aggregate_types <- function(.data, hash) {
         # groups will not affect the type that an aggregation returns
         args = c(.$data, dummy_groups),
         options = .$options
-      )$type(schema)
+      )$type()
     } else {
       Expression$create(
         .$fun,
         args = .$data,
         options = .$options
-      )$type(schema)
+      )$type()
     }
   )
 }
 
 # This function returns a named list of the data types of the group columns
 # returned by an aggregation
-group_types <- function(.data, schema = NULL) {
-  map(.data$selected_columns[.data$group_by_vars], ~.$type(schema))
+group_types <- function(.data) {
+  map(.data$selected_columns[.data$group_by_vars], ~.$type())
 }
 
 format_aggregation <- function(x) {

--- a/r/R/dplyr-summarize.R
+++ b/r/R/dplyr-summarize.R
@@ -302,11 +302,19 @@ arrow_eval_or_stop <- function(expr, mask) {
 }
 
 # This function returns a list of expressions that can be used to project the
-# data before an aggregation to only the fields required for the aggregation
+# data before an aggregation to only the fields required for the aggregation,
+# including the fields used in the aggregations (the "targets") and the group
+# fields. It gives unique names to the targets used in an aggregation,  to
+# support aggregation functions with 2+ arguments.
 summarize_projection <- function(.data) {
   c(
-    # TODO: support 2+ targets
-    unlist(map(.data$aggregations, ~ .$data)),
+    unlist(unname(imap(
+      .data$aggregations,
+      ~setNames(
+        .x$data,
+        paste(.y[length(.x$data) > 0], seq_along(.x$data), sep = "..")
+      )
+    ))),
     .data$selected_columns[.data$group_by_vars]
   )
 }

--- a/r/R/dplyr-summarize.R
+++ b/r/R/dplyr-summarize.R
@@ -18,7 +18,7 @@
 # Aggregation functions
 # These all return a list of:
 # @param fun string function name
-# @param data Expression (these are all currently a single field)
+# @param data Expression (all currently a single field, except for dplyr::n)
 # @param options list of function options, as passed to call_function
 # For group-by aggregation, `hash_` gets prepended to the function name.
 # So to see a list of available hash aggregation functions,

--- a/r/R/dplyr-summarize.R
+++ b/r/R/dplyr-summarize.R
@@ -348,21 +348,21 @@ aggregate_types <- function(.data, hash, schema = NULL) {
         # groups will not affect the type that an aggregation returns
         args = c(.$data, dummy_groups),
         options = .$options
-      )$type()
+      )$type(schema)
     } else {
       Expression$create(
         .$fun,
         args = .$data,
         options = .$options
-      )$type()
+      )$type(schema)
     }
   )
 }
 
 # This function returns a named list of the data types of the group columns
 # returned by an aggregation
-group_types <- function(.data) {
-  map(.data$selected_columns[.data$group_by_vars], ~.$type())
+group_types <- function(.data, schema = NULL) {
+  map(.data$selected_columns[.data$group_by_vars], ~.$type(schema))
 }
 
 format_aggregation <- function(x) {

--- a/r/R/dplyr-summarize.R
+++ b/r/R/dplyr-summarize.R
@@ -328,7 +328,7 @@ aggregated_fields <- function(aggs) {
 fix_aggregated_types <- function(fields, aggs, hash) {
   imap(
     fields,
-    ~if(hash && aggs[[.y]]$fun == "tdigest") {
+    ~if (hash && aggs[[.y]]$fun == "tdigest") {
         fixed_size_list_of(float64(), 1L)
       } else {
         .x

--- a/r/R/dplyr-summarize.R
+++ b/r/R/dplyr-summarize.R
@@ -34,27 +34,6 @@ ensure_one_arg <- function(args, fun) {
   args[[1]]
 }
 
-agg_fun_output_type <- function(fun, input_type, hash) {
-  # These are quick and dirty heuristics.
-  if (fun %in% c("any", "all")) {
-    bool()
-  } else if (fun %in% "sum") {
-    # It may upcast to a bigger type but this is close enough
-    input_type
-  } else if (fun %in% c("mean", "stddev", "variance", "approximate_median")) {
-    float64()
-  } else if (fun %in% "tdigest") {
-    if (hash) {
-      fixed_size_list_of(float64(), 1L)
-    } else {
-      float64()
-    }
-  } else {
-    # Just so things don't error, assume the resulting type is the same
-    input_type
-  }
-}
-
 register_bindings_aggregate <- function() {
   register_binding_agg("base::sum", function(..., na.rm = FALSE) {
     list(

--- a/r/R/dplyr-summarize.R
+++ b/r/R/dplyr-summarize.R
@@ -18,7 +18,7 @@
 # Aggregation functions
 # These all return a list of:
 # @param fun string function name
-# @param data Expression (all currently a single field, except for dplyr::n)
+# @param data list of 0 or more Expressions
 # @param options list of function options, as passed to call_function
 # For group-by aggregation, `hash_` gets prepended to the function name.
 # So to see a list of available hash aggregation functions,
@@ -301,8 +301,8 @@ arrow_eval_or_stop <- function(expr, mask) {
   out
 }
 
-# This function returns a list of expressions that can be used to project the
-# data before an aggregation to only the fields required for the aggregation,
+# This function returns a list of expressions that is used to project the data
+# before an aggregation to only the fields required for the aggregation,
 # including the fields used in the aggregations (the "targets") and the group
 # fields. The names of the returned list are used to ensure that the projection
 # node is wired up correctly to the aggregation node.

--- a/r/R/dplyr-summarize.R
+++ b/r/R/dplyr-summarize.R
@@ -319,6 +319,15 @@ summarize_projection <- function(.data) {
   )
 }
 
+# This function determines whether we need to project before aggregating. If
+# all the aggregation targets are column references, then this function returns
+# TRUE, indicating that we do not need to project before aggregating. If any of
+# the targets are literals or expressions, then this function returns FALSE,
+# indicating that we do need to project aggregating.
+all_targets_are_field_refs <- function(aggs) {
+  all(map_lgl(aggs, ~all(map_lgl(.$data, ~.$is_field_ref()))))
+}
+
 # This function returns a list of expressions representing the aggregated fields
 # that will be returned by an aggregation
 aggregated_fields <- function(aggs) {

--- a/r/R/dplyr-summarize.R
+++ b/r/R/dplyr-summarize.R
@@ -334,14 +334,10 @@ aggregate_target_names <- function(data, name) {
   }
 }
 
-# .dummy_groups is used inside the aggregate_types() function, but there is
-# a compute cost in creating it, so for efficiency, we create it just once
-# here outside of the function
-.dummy_groups <- Scalar$create(1L, uint32())
-
 # This function returns a named list of the data types of the aggregate columns
 # returned by an aggregation
-aggregate_types <- function(.data, hash, schema = NULL) {
+aggregate_types <- function(.data, hash) {
+  if (hash) dummy_groups <- Scalar$create(1L, uint32())
   map(
     .data$aggregations,
     ~if (hash) {
@@ -350,7 +346,7 @@ aggregate_types <- function(.data, hash, schema = NULL) {
         # hash aggregate kernels must be passed an additional argument
         # representing the groups, so we pass in a dummy scalar, since the
         # groups will not affect the type that an aggregation returns
-        args = c(.$data, .dummy_groups),
+        args = c(.$data, dummy_groups),
         options = .$options
       )$type(schema)
     } else {

--- a/r/R/dplyr-summarize.R
+++ b/r/R/dplyr-summarize.R
@@ -304,8 +304,10 @@ arrow_eval_or_stop <- function(expr, mask) {
 # This function returns a list of expressions that can be used to project the
 # data before an aggregation to only the fields required for the aggregation,
 # including the fields used in the aggregations (the "targets") and the group
-# fields. It gives unique names to the targets used in an aggregation,  to
-# support aggregation functions with 2+ arguments.
+# fields. The names of the returned list are used to ensure that the projection
+# node is wired up correctly to the aggregation node. When an aggregation
+# function takes 2 or more fields as targets, this function gives the fields
+# unique names by appending `..1`, `..2`, ...
 summarize_projection <- function(.data) {
   c(
     unlist(unname(imap(

--- a/r/R/dplyr-summarize.R
+++ b/r/R/dplyr-summarize.R
@@ -130,8 +130,8 @@ register_bindings_aggregate <- function() {
   })
   register_binding_agg("dplyr::n", function() {
     list(
-      fun = "sum",
-      data = list(Expression$scalar(1L)),
+      fun = "count_all",
+      data = list(),
       options = list()
     )
   })

--- a/r/R/dplyr-summarize.R
+++ b/r/R/dplyr-summarize.R
@@ -334,6 +334,11 @@ aggregate_target_names <- function(data, name) {
   }
 }
 
+# .dummy_groups is used inside the aggregate_types() function, but there is
+# a compute cost in creating it, so for efficiency, we create it just once
+# here outside of the function
+.dummy_groups <- Scalar$create(1L, uint32())
+
 # This function returns a named list of the data types of the aggregate columns
 # returned by an aggregation
 aggregate_types <- function(.data, hash, schema = NULL) {
@@ -342,10 +347,10 @@ aggregate_types <- function(.data, hash, schema = NULL) {
     ~if (hash) {
       Expression$create(
         paste0("hash_", .$fun),
-        # hash aggregate kernels must be passed another argument representing
-        # the groups, so we pass in a dummy scalar, since the groups will not
-        # affect the type that an aggregation returns
-        args = c(.$data, Scalar$create(1L, uint32())),
+        # hash aggregate kernels must be passed an additional argument
+        # representing the groups, so we pass in a dummy scalar, since the
+        # groups will not affect the type that an aggregation returns
+        args = c(.$data, .dummy_groups),
         options = .$options
       )$type(schema)
     } else {

--- a/r/R/query-engine.R
+++ b/r/R/query-engine.R
@@ -116,16 +116,9 @@ ExecPlan <- R6Class("ExecPlan",
         }
 
         .data$aggregations <- imap(.data$aggregations, function(x, name) {
-          # Embed `name` and `targets` inside the aggregation objects,
-          # matching how summarize_projection() named `targets`
+          # Embed `name` and `targets` inside the aggregation objects
           x[["name"]] <- name
-          if (length(x$data) > 1) {
-            x[["targets"]] <- paste0(name, "..", seq_along(x$data))
-          } else if (length(x$data) > 0) {
-            x[["targets"]] <- name
-          } else {
-            x[["targets"]] <- character(0)
-          }
+          x[["targets"]] <- aggregate_target_names(x$data, name)
           x
         })
 

--- a/r/R/query-engine.R
+++ b/r/R/query-engine.R
@@ -115,11 +115,13 @@ ExecPlan <- R6Class("ExecPlan",
         }
 
         .data$aggregations <- imap(.data$aggregations, function(x, name) {
-          # Embed `name` and `targets` inside the aggregation objects
+          # Embed `name` and `targets` inside the aggregation objects,
+          # matching how summarize_projection() named `targets`
           x[["name"]] <- name
-          if (length(x$data)) {
-            # name the targets to match how summarize_projection() named them
+          if (length(x$data) > 1) {
             x[["targets"]] <- paste0(name, "..", seq_along(x$data))
+          } else if (length(x$data) > 0) {
+            x[["targets"]] <- name
           } else {
             x[["targets"]] <- character(0)
           }

--- a/r/R/query-engine.R
+++ b/r/R/query-engine.R
@@ -102,6 +102,7 @@ ExecPlan <- R6Class("ExecPlan",
         # TODO: validate that none of names(aggregations) are the same as names(group_by_vars)
         # dplyr does not error on this but the result it gives isn't great
         projection <- summarize_projection(.data)
+        # skip projection if no grouping and all aggregate functions are nullary
         if (length(projection)) {
           node <- node$Project(projection)
         }

--- a/r/R/query-engine.R
+++ b/r/R/query-engine.R
@@ -118,14 +118,13 @@ ExecPlan <- R6Class("ExecPlan",
         }
 
         .data$aggregations <- imap(.data$aggregations, function(x, name) {
-          # Embed the name inside the aggregation objects. `target` and `name`
-          # are the same because we just Project()ed the data that way above
+          # Embed `name` and `targets` inside the aggregation objects
           x[["name"]] <- name
-          # TODO: support 2+ targets
           if (length(x$data)) {
-            x[["target"]] <- name
+            # name the targets to match how summarize_projection() named them
+            x[["targets"]] <- paste0(name, "..", seq_along(x$data))
           } else {
-            x[["target"]] <- character(0)
+            x[["targets"]] <- character(0)
           }
           x
         })

--- a/r/R/query-engine.R
+++ b/r/R/query-engine.R
@@ -97,14 +97,12 @@ ExecPlan <- R6Class("ExecPlan",
       }
 
       if (!is.null(.data$aggregations)) {
-        # When necessary, project to include the data required for each
-        # aggregation, plus group_by_vars (last)
+        # Project to include just the data required for each aggregation,
+        # plus group_by_vars (last)
         # TODO: validate that none of names(aggregations) are the same as names(group_by_vars)
         # dplyr does not error on this but the result it gives isn't great
         projection <- summarize_projection(.data)
-        projection_required <- length(projection) &&
-          !all_targets_are_field_refs(.data$aggregations)
-        if (projection_required) {
+        if (length(projection)) {
           node <- node$Project(projection)
         }
 
@@ -120,13 +118,8 @@ ExecPlan <- R6Class("ExecPlan",
           # Embed `name` and `targets` inside the aggregation objects
           x[["name"]] <- name
           if (length(x$data)) {
-            if (projection_required) {
-              # name the targets to match how summarize_projection() named them
-              x[["targets"]] <- paste0(name, "..", seq_along(x$data))
-            } else {
-              # name the targets to match the field names they refer to
-              x[["targets"]] <- map(x$data, ~.$field_name)
-            }
+            # name the targets to match how summarize_projection() named them
+            x[["targets"]] <- paste0(name, "..", seq_along(x$data))
           } else {
             x[["targets"]] <- character(0)
           }

--- a/r/R/query-engine.R
+++ b/r/R/query-engine.R
@@ -97,15 +97,14 @@ ExecPlan <- R6Class("ExecPlan",
       }
 
       if (!is.null(.data$aggregations)) {
-        # Project to include just the data required for each aggregation,
-        # plus group_by_vars (last)
+        # When necessary, project to include the data required for each
+        # aggregation, plus group_by_vars (last)
         # TODO: validate that none of names(aggregations) are the same as names(group_by_vars)
         # dplyr does not error on this but the result it gives isn't great
-        # TODO: detect whether we actually need to project before aggregating
-        # by checking whether the targets contain literals or expressions. If
-        # they are all just column references, then we don't need to project.
         projection <- summarize_projection(.data)
-        if (length(projection)) {
+        projection_required <- length(projection) &&
+          !all_targets_are_field_refs(.data$aggregations)
+        if (projection_required) {
           node <- node$Project(projection)
         }
 
@@ -121,8 +120,13 @@ ExecPlan <- R6Class("ExecPlan",
           # Embed `name` and `targets` inside the aggregation objects
           x[["name"]] <- name
           if (length(x$data)) {
-            # name the targets to match how summarize_projection() named them
-            x[["targets"]] <- paste0(name, "..", seq_along(x$data))
+            if (projection_required) {
+              # name the targets to match how summarize_projection() named them
+              x[["targets"]] <- paste0(name, "..", seq_along(x$data))
+            } else {
+              # name the targets to match the field names they refer to
+              x[["targets"]] <- map(x$data, ~.$field_name)
+            }
           } else {
             x[["targets"]] <- character(0)
           }

--- a/r/man/register_binding.Rd
+++ b/r/man/register_binding.Rd
@@ -40,7 +40,7 @@ aggregate function. This function must accept \code{Expression} objects as
 arguments and return a \code{list()} with components:
 \itemize{
 \item \code{fun}: string function name
-\item \code{data}: \code{Expression} (these are all currently a single field)
+\item \code{data}: \code{Expression} (all currently a single field, except \code{dplyr::n})
 \item \code{options}: list of function options, as passed to call_function
 }}
 }

--- a/r/man/register_binding.Rd
+++ b/r/man/register_binding.Rd
@@ -40,7 +40,7 @@ aggregate function. This function must accept \code{Expression} objects as
 arguments and return a \code{list()} with components:
 \itemize{
 \item \code{fun}: string function name
-\item \code{data}: \code{Expression} (all currently a single field, except \code{dplyr::n})
+\item \code{data}: list of 0 or more \code{Expression}s
 \item \code{options}: list of function options, as passed to call_function
 }}
 }

--- a/r/src/compute-exec.cpp
+++ b/r/src/compute-exec.cpp
@@ -396,8 +396,13 @@ std::shared_ptr<compute::ExecNode> ExecNode_Aggregate(
     auto target = cpp11::as_cpp<std::string>(name_opts["target"]);
     auto name = cpp11::as_cpp<std::string>(name_opts["name"]);
 
-    aggregates.push_back(arrow::compute::Aggregate{std::move(function), opts,
-                                                   std::move(target), std::move(name)});
+    if (target.size() > 0) {
+      aggregates.push_back(arrow::compute::Aggregate{std::move(function), opts,
+                                                     std::move(target), std::move(name)});
+    } else {
+      aggregates.push_back(
+          arrow::compute::Aggregate{std::move(function), std::move(name)});
+    }
   }
 
   std::vector<arrow::FieldRef> keys;

--- a/r/src/compute-exec.cpp
+++ b/r/src/compute-exec.cpp
@@ -393,7 +393,7 @@ std::shared_ptr<compute::ExecNode> ExecNode_Aggregate(
   for (cpp11::list name_opts : options) {
     auto function = cpp11::as_cpp<std::string>(name_opts["fun"]);
     auto opts = make_compute_options(function, name_opts["options"]);
-    auto target_names = cpp11::as_cpp<std::vector<std::string>>(name_opts["target"]);
+    auto target_names = cpp11::as_cpp<std::vector<std::string>>(name_opts["targets"]);
     auto name = cpp11::as_cpp<std::string>(name_opts["name"]);
 
     std::vector<arrow::FieldRef> targets;

--- a/r/src/compute-exec.cpp
+++ b/r/src/compute-exec.cpp
@@ -393,16 +393,15 @@ std::shared_ptr<compute::ExecNode> ExecNode_Aggregate(
   for (cpp11::list name_opts : options) {
     auto function = cpp11::as_cpp<std::string>(name_opts["fun"]);
     auto opts = make_compute_options(function, name_opts["options"]);
-    auto target = cpp11::as_cpp<std::string>(name_opts["target"]);
+    auto target_names = cpp11::as_cpp<std::vector<std::string>>(name_opts["target"]);
     auto name = cpp11::as_cpp<std::string>(name_opts["name"]);
 
-    if (target.size() > 0) {
-      aggregates.push_back(arrow::compute::Aggregate{std::move(function), opts,
-                                                     std::move(target), std::move(name)});
-    } else {
-      aggregates.push_back(
-          arrow::compute::Aggregate{std::move(function), std::move(name)});
+    std::vector<arrow::FieldRef> targets;
+    for (auto&& target : target_names) {
+      targets.emplace_back(std::move(target));
     }
+    aggregates.push_back(arrow::compute::Aggregate{std::move(function), opts,
+                                                   std::move(targets), std::move(name)});
   }
 
   std::vector<arrow::FieldRef> keys;

--- a/r/tests/testthat/test-dplyr-collapse.R
+++ b/r/tests/testthat/test-dplyr-collapse.R
@@ -162,8 +162,8 @@ test_that("Properties of collapsed query", {
     print(q),
     "Table (query)
 lgl: bool
-total: int32
-extra: int32 (multiply_checked(total, 5))
+total: int64
+extra: int64 (multiply_checked(total, 5))
 
 See $.data for the source Arrow object",
     fixed = TRUE

--- a/r/tests/testthat/test-dplyr-summarize.R
+++ b/r/tests/testthat/test-dplyr-summarize.R
@@ -1129,8 +1129,8 @@ test_that("We don't add unnecessary ProjectNodes when aggregating", {
   )
 
   # 0 Projections if
-  # (a) the aggregate function is nullary, and
-  # (b) no groping
+  # (a) only nullary functions in summarize()
+  # (b) no grouping
   expect_project_nodes(
     tab[, "int"] %>% summarize(n()),
     0

--- a/r/tests/testthat/test-dplyr-summarize.R
+++ b/r/tests/testthat/test-dplyr-summarize.R
@@ -1119,12 +1119,20 @@ test_that("We don't add unnecessary ProjectNodes when aggregating", {
     1
   )
 
-  # 0 Projections only if
+  # 0 Projections if
   # (a) input only contains the col you're aggregating, and
   # (b) the output col name is the same as the input name, and
   # (c) no grouping
   expect_project_nodes(
     tab[, "int"] %>% summarize(int = mean(int, na.rm = TRUE)),
+    0
+  )
+
+  # 0 Projections if
+  # (a) the aggregate function is nullary, and
+  # (b) no groping
+  expect_project_nodes(
+    tab[, "int"] %>% summarize(n()),
     0
   )
 


### PR DESCRIPTION
### Rationale for this change

This PR is a follow-up to #15083. It allows the R package to register bindings to nullary aggregation functions, and it remaps `dplyr::n()` to the nullary aggregation function `count_all`.

This PR also:
- Prepares the R bindings to support aggregation functions with 2+ arguments, although none yet exist in the C++ library
- Removes the heuristics that were used to infer the data types of aggregates, replacing that with actual type determination

### Are these changes tested?

Yes, through existing tests.

### Are there any user-facing changes?

No.
* Closes: #33892
* Closes: #33960 