### PR TITLE
MINOR: [Ruby][Docs] Add a short example of Arrow::Table#join to README

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -152,4 +152,19 @@ table.group('name').sum('amount')
 ```
 
 ### Joining
-Work in progress, see https://issues.apache.org/jira/browse/ARROW-14531
+```ruby
+amounts = Arrow::Table.new(
+  'name' => ['Tom', 'Max', 'Kate'],
+  'amount' => [10, 2, 3]
+)
+levels = Arrow::Table.new(
+  'name' => ['Max', 'Kate', 'Tom'],
+  'level' => [1, 9, 5]
+)
+amounts.join(levels, [:name])
+# => #<Arrow::Table:0x55d512ceb1b0 ptr=0x55d51262aa70>
+# 	name	amount	name	level
+# 0	Tom 	    10	Tom 	    5
+# 1	Max 	     2	Max 	    1
+# 2	Kate	     3	Kate	    9
+```


### PR DESCRIPTION
### Rationale for this change

The code for `Apache::Table` `join` has recently been merged (#12108, #30086) into the Ruby gem, but the current documentation for `join` suggests referring to Jira, which then links into GitHub, where the commit can be found.

This change instead provides a short example of a join.

### What changes are included in this PR?

I have added an example to the README and removed the link to the now-completed bug report.

### Are these changes tested?

No, but is documentation only.

### Are there any user-facing changes?

Yes - this PR is documentation.