### PR TITLE
GH-33923: [Docs] Tensor canonical extension type specification

### DIFF
--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -94,4 +94,4 @@ Fixed size tensor
   * boolean indicating the order of elements in memory with key
     "is_row_major".
 
-  For example: `{ "shape": [2, 5], "is_row_major": True }`
+  For example: `{ "shape": [2, 5], "is_row_major": true }`

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -90,6 +90,6 @@ Fixed size tensor
   The metadata must be a valid JSON object including:
 
   * shape of the contained tensors as an array with key “shape”,
-  * string defining the order of elements in memory with key “order”.
+  * boolean indicating the order of elements in memory with key “order”.
 
   For example: `{ "shape": [2, 5], "is_row_major": True }`

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -84,7 +84,7 @@ Fixed shape tensor
 
 * Extension type parameters:
 
-  * **value_type** = Arrow DataType or Field of the tensor elements.
+  * **value_type** = the Arrow data type of individual tensor elements.
   * **shape** = the physical shape of the contained tensors
     as an array.
 

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -83,13 +83,15 @@ Fixed size tensor
 
   * **value_type** = Arrow DataType of the tensor elements
   * **shape** = shape of the contained tensors as a tuple
-  * **is_row_major** = boolean indicating the order of elements in memory
+  * **is_row_major** = boolean indicating the order of elements
+    in memory
 
 * Description of the serialization:
 
   The metadata must be a valid JSON object including:
 
-  * shape of the contained tensors as an array with key “shape”,
-  * boolean indicating the order of elements in memory with key “order”.
+  * shape of the contained tensors as an array with key "shape",
+  * boolean indicating the order of elements in memory with key
+    "is_row_major".
 
   For example: `{ "shape": [2, 5], "is_row_major": True }`

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -77,11 +77,11 @@ Fixed size tensor
 
 * Extension name: `arrow.fixed_size_tensor`.
 
-* The storage type of the extension: ``List``.
+* The storage type of the extension: ``FixedSizeList``.
 
 * Extension type parameters:
 
-  * **value_type** = pyarrow DataType of the tensor elements
+  * **value_type** = Arrow DataType of the tensor elements
   * **shape** = shape of the contained tensors as a tuple
   * **order** = string indicating the order of elements in memory;
     ‘C’ for row major order and ‘F’ for column major order
@@ -90,10 +90,10 @@ Fixed size tensor
 
   The metadata MUST be a valid JSON object including:
 
-  * shape of the contained tensors as a tuple with key “shape”,
+  * shape of the contained tensors as an array with key “shape”,
   * string defining the order of elements in memory with key “order”.
 
-  For example: `{ “shape”: (2, 5), “order”: ‘C’}`
+  For example: `{ "shape": [2, 5], "order": "C" }`
 
   Implementations MAY include implementation-specific metadata by using a
   namespaced key. For example `{"package.name": {"my": "metadata"}}`

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -79,8 +79,7 @@ Fixed shape tensor
 
 * The storage type of the extension: ``FixedSizeList`` where:
 
-  * **value_type** is the data type of individual tensor elements
-    and is an instance of Arrow ``DataType`` or ``Field``.
+  * **value_type** is the data type of individual tensor elements.
   * **list_size** is the product of all the elements in tensor shape.
 
 * Extension type parameters:

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -95,22 +95,22 @@ Fixed shape tensor
     length and equal to the number of dimensions.
 
     ``dim_names`` are used if the dimensions have well-known
-    names and they map to the physical order (row-major).
+    names and they map to the physical layout (row-major).
 
   * **permutation**  = indices of the desired ordering of the
     original dimensions, defined as an array.
 
     The indices contain a permutation of the values [0, 1, .., N-1] where
     N is the number of dimensions. The permutation indicates which
-    dimension of the logical order corresponds to which dimension of the
+    dimension of the logical layout corresponds to which dimension of the
     physical tensor (the i-th dimension of the logical view corresponds
     to the dimension with number permutations[i] of the physical tensor).
 
     **Permutation is only needed in case the logical order of
     the tensor is a permutation of the physical order (row-major).**
 
-    When logical and physical order are equal, the permutation will
-    always equal to the original order of dimensions ([0, 1, .., N-1])
+    When logical and physical layout are equal, the permutation will
+    always equal to the original layout of dimensions ([0, 1, .., N-1])
     and therefore doesn't need to be defined.
 
 * Description of the serialization:

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -109,9 +109,10 @@ Fixed shape tensor
     **Permutation is only needed in case the logical order of
     the tensor is a permutation of the physical order (row-major).**
 
-    When logical and physical layout are equal, the permutation will
-    always equal to the original layout of dimensions ([0, 1, .., N-1])
-    and therefore doesn't need to be defined.
+    When logical and physical layout are equal, the permutation will always
+    be ([0, 1, .., N-1]) and is therefore absent. Same holds the other way
+    round: if permutation parameter is absent, it is assumed that logical
+    layout matches the physical one.
 
 * Description of the serialization:
 

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -110,9 +110,7 @@ Fixed shape tensor
     the tensor is a permutation of the physical order (row-major).
 
     When logical and physical layout are equal, the permutation will always
-    be ([0, 1, .., N-1]) and can therefore be left out. Same holds the other way
-    round: if permutation parameter is absent, it is assumed that logical
-    layout matches the physical one.
+    be ([0, 1, .., N-1]) and can therefore be left out.
 
 * Description of the serialization:
 

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -79,8 +79,8 @@ Fixed shape tensor
 
 * The storage type of the extension: ``FixedSizeList`` where:
 
-  * **value_type** is the data type of individual tensors and
-    is an instance of ``pyarrow.DataType`` or ``pyarrow.Field``.
+  * **value_type** is the data type of individual tensor elements
+    and is an instance of Arrow ``DataType`` or ``Field``.
   * **list_size** is the product of all the elements in tensor shape.
 
 * Extension type parameters:

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -88,12 +88,9 @@ Fixed size tensor
 
 * Description of the serialization:
 
-  The metadata MUST be a valid JSON object including:
+  The metadata must be a valid JSON object including:
 
   * shape of the contained tensors as an array with key “shape”,
   * string defining the order of elements in memory with key “order”.
 
   For example: `{ "shape": [2, 5], "order": "C" }`
-
-  Implementations MAY include implementation-specific metadata by using a
-  namespaced key. For example `{"package.name": {"my": "metadata"}}`

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -94,7 +94,7 @@ Fixed shape tensor
     as an array. The length of it should be equal to the shape
     length and equal to the number of dimensions.
 
-    ``dim_names`` are used if the dimensions have well-known
+    ``dim_names`` can be used if the dimensions have well-known
     names and they map to the physical layout (row-major).
 
   * **permutation**  = indices of the desired ordering of the
@@ -104,13 +104,13 @@ Fixed shape tensor
     N is the number of dimensions. The permutation indicates which
     dimension of the logical layout corresponds to which dimension of the
     physical tensor (the i-th dimension of the logical view corresponds
-    to the dimension with number permutations[i] of the physical tensor).
+    to the dimension with number ``permutations[i]`` of the physical tensor).
 
-    **Permutation is only needed in case the logical order of
-    the tensor is a permutation of the physical order (row-major).**
+    Permutation can be useful in case the logical order of
+    the tensor is a permutation of the physical order (row-major).
 
     When logical and physical layout are equal, the permutation will always
-    be ([0, 1, .., N-1]) and is therefore absent. Same holds the other way
+    be ([0, 1, .., N-1]) and can therefore be left out. Same holds the other way
     round: if permutation parameter is absent, it is assumed that logical
     layout matches the physical one.
 
@@ -132,5 +132,5 @@ Fixed shape tensor
 
 .. note::
 
-  Elements in an fixed shape tensor extension array are stored
+  Elements in a fixed shape tensor extension array are stored
   in row-major/C-contiguous order.

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -79,9 +79,9 @@ Fixed shape tensor
 
 * The storage type of the extension: ``FixedSizeList`` where:
 
-  * **value_type** is the data type of the child array (individual tensor) and
+  * **value_type** is the data type of individual tensors and
     is an instance of ``pyarrow.DataType`` or ``pyarrow.Field``.
-  * **list_size** is the size of the child array (individual tensor).
+  * **list_size** is the product of all the elements in tensor shape.
 
 * Extension type parameters:
 

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -83,8 +83,7 @@ Fixed size tensor
 
   * **value_type** = Arrow DataType of the tensor elements
   * **shape** = shape of the contained tensors as a tuple
-  * **order** = string indicating the order of elements in memory;
-    ‘C’ for row major order and ‘F’ for column major order
+  * **is_row_major** = boolean indicating the order of elements in memory
 
 * Description of the serialization:
 
@@ -93,4 +92,4 @@ Fixed size tensor
   * shape of the contained tensors as an array with key “shape”,
   * string defining the order of elements in memory with key “order”.
 
-  For example: `{ "shape": [2, 5], "order": "C" }`
+  For example: `{ "shape": [2, 5], "is_row_major": True }`

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -72,4 +72,28 @@ same rules as laid out above, and provide backwards compatibility guarantees.
 Official List
 =============
 
-No canonical extension types have been standardized yet.
+Fixed size tensor
+=================
+
+* Extension name: `arrow.fixed_size_tensor`.
+
+* The storage type of the extension: ``List``.
+
+* Extension type parameters:
+
+  * **value_type** = pyarrow DataType of the tensor elements
+  * **shape** = shape of the contained tensors as a tuple
+  * **order** = string indicating the order of elements in memory;
+    ‘C’ for row major order and ‘F’ for column major order
+
+* Description of the serialization:
+
+  The metadata MUST be a valid JSON object including:
+
+  * shape of the contained tensors as a tuple with key “shape”,
+  * string defining the order of elements in memory with key “order”.
+
+  For example: `{ “shape”: (2, 5), “order”: ‘C’}`
+
+  Implementations MAY include implementation-specific metadata by using a
+  namespaced key. For example `{"package.name": {"my": "metadata"}}`

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -87,15 +87,15 @@ Fixed shape tensor
 
   * **value_type** = Arrow DataType of the tensor elements
   * **shape** = shape of the contained tensors as a tuple
-  * **is_row_major** = boolean indicating the order of elements
-    in memory
 
 * Description of the serialization:
 
-  The metadata must be a valid JSON object including:
+  The metadata must be a valid JSON object including shape of
+  the contained tensors as an array with key "shape".
 
-  * shape of the contained tensors as an array with key "shape",
-  * boolean indicating the order of elements in memory with key
-    "is_row_major".
+  For example: `{ "shape": [2, 5]}`
 
-  For example: `{ "shape": [2, 5], "is_row_major": true }`
+.. note::
+
+  Elements in an fixed shape tensor extension array are stored
+  in row-major/C-contiguous order.

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -105,12 +105,22 @@ Fixed shape tensor
 
     ``{ "shape": [100, 200, 500], "dim_names": ["C", "H", "W"]}``
 
+    The ``dim_names`` metadata can be added if the dimensions have
+    well-known names that can map to the physical order (row-major).
+
   - **"permutation"** holds indexes of the desired ordering of the
     original dimensions. Also defined as an array.
 
     Example of permuted 3-dimensional tensor:
 
     ``{ "shape": [100, 200, 500], "permutation": [2, 0, 1]}``
+
+    **Permutation key in the metadata is needed only in case the logical
+    order of the tensor doesn't equal the physical order (row-major).**
+
+    When logical and physical order are equal, the permutation metadata
+    is not added as it will always equal the original order of dimensions
+    (example ``[0, 1, 2]``).
 
 .. note::
 

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -135,3 +135,13 @@ Fixed shape tensor
 
   Elements in a fixed shape tensor extension array are stored
   in row-major/C-contiguous order.
+
+.. note::
+
+  Other Data Structures in Arrow include a
+  `Tensor (Multi-dimensional Array) <https://arrow.apache.org/docs/format/Other.html>`_
+  to be used as a message in the interprocess communication machinery (IPC).
+
+  This structure has no relationship with the Fixed shape tensor extension type defined
+  by this specification. With defining an extension type one can use fixed shape tensors
+  as elements in a field of a RecordBatch or a Table.

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -91,9 +91,26 @@ Fixed shape tensor
 * Description of the serialization:
 
   The metadata must be a valid JSON object including shape of
-  the contained tensors as an array with key "shape".
+  the contained tensors as an array with key **"shape"**
 
-  For example: `{ "shape": [2, 5]}`
+  - example: ``{ "shape": [2, 5]}``
+
+  and optional:
+
+  - **"dim_names"** holds explicit names to tensor dimensions
+    as an array. The length of it should be equal to the shape
+    length and equal to the number of dimensions.
+
+    Example of dim_names metadata for NCHW ordered data:
+
+    ``{ "shape": [100, 200, 500], "dim_names": ["C", "H", "W"]}``
+
+  - **"permutation"** holds indexes of the desired ordering of the
+    original dimensions. Also defined as an array.
+
+    Example of permuted 3-dimensional tensor:
+
+    ``{ "shape": [100, 200, 500], "permutation": [2, 0, 1]}``
 
 .. note::
 

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -95,17 +95,23 @@ Fixed shape tensor
     length and equal to the number of dimensions.
 
     ``dim_names`` are used if the dimensions have well-known
-    names and map to the physical order (row-major).
+    names and they map to the physical order (row-major).
 
-  * **permutation**  = indexes of the desired ordering of the
-    original dimensions. Also defined as an array.
+  * **permutation**  = indices of the desired ordering of the
+    original dimensions, defined as an array.
 
-    **Permutation key in the metadata is needed only in case the logical
-    order of the tensor doesn't equal the physical order (row-major).**
+    The indices contain a permutation of the values [0, 1, .., N-1] where
+    N is the number of dimensions. The permutation indicates which
+    dimension of the logical order corresponds to which dimension of the
+    physical tensor (the i-th dimension of the logical view corresponds
+    to the dimension with number permutations[i] of the physical tensor).
 
-    When logical and physical order are equal, the permutation metadata
-    is not added as it will always equal the original order of dimensions
-    (example ``[0, 1, 2]``).
+    **Permutation is only needed in case the logical order of
+    the tensor is a permutation of the physical order (row-major).**
+
+    When logical and physical order are equal, the permutation will
+    always equal to the original order of dimensions ([0, 1, .., N-1])
+    and therefore doesn't need to be defined.
 
 * Description of the serialization:
 

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -106,7 +106,7 @@ Fixed shape tensor
     ``{ "shape": [100, 200, 500], "dim_names": ["C", "H", "W"]}``
 
     The ``dim_names`` metadata can be added if the dimensions have
-    well-known names that can map to the physical order (row-major).
+    well-known names and map to the physical order (row-major).
 
   - **"permutation"** holds indexes of the desired ordering of the
     original dimensions. Also defined as an array.

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -86,34 +86,19 @@ Fixed shape tensor
 * Extension type parameters:
 
   * **value_type** = Arrow DataType of the tensor elements
-  * **shape** = shape of the contained tensors as a tuple
+  * **shape** = shape of the contained tensors as an array
 
-* Description of the serialization:
+  Optional parameters:
 
-  The metadata must be a valid JSON object including shape of
-  the contained tensors as an array with key **"shape"**
-
-  - example: ``{ "shape": [2, 5]}``
-
-  and optional:
-
-  - **"dim_names"** holds explicit names to tensor dimensions
+  * **dim_names** = explicit names to tensor dimensions
     as an array. The length of it should be equal to the shape
     length and equal to the number of dimensions.
 
-    Example of dim_names metadata for NCHW ordered data:
+    ``dim_names`` are used if the dimensions have well-known
+    names and map to the physical order (row-major).
 
-    ``{ "shape": [100, 200, 500], "dim_names": ["C", "H", "W"]}``
-
-    The ``dim_names`` metadata can be added if the dimensions have
-    well-known names and map to the physical order (row-major).
-
-  - **"permutation"** holds indexes of the desired ordering of the
+  * **permutation**  = indexes of the desired ordering of the
     original dimensions. Also defined as an array.
-
-    Example of permuted 3-dimensional tensor:
-
-    ``{ "shape": [100, 200, 500], "permutation": [2, 0, 1]}``
 
     **Permutation key in the metadata is needed only in case the logical
     order of the tensor doesn't equal the physical order (row-major).**
@@ -121,6 +106,22 @@ Fixed shape tensor
     When logical and physical order are equal, the permutation metadata
     is not added as it will always equal the original order of dimensions
     (example ``[0, 1, 2]``).
+
+* Description of the serialization:
+
+  The metadata must be a valid JSON object including shape of
+  the contained tensors as an array with key **"shape"** plus optional
+  dimension names with keys **"dim_names"** and ordering of the
+  dimensions with key **"permutation"**.
+
+  - Example: ``{ "shape": [2, 5]}``
+  - Example with ``dim_names`` metadata for NCHW ordered data:
+
+    ``{ "shape": [100, 200, 500], "dim_names": ["C", "H", "W"]}``
+
+  - Example of permuted 3-dimensional tensor:
+
+    ``{ "shape": [100, 200, 500], "permutation": [2, 0, 1]}``
 
 .. note::
 

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -85,10 +85,11 @@ Fixed shape tensor
 
 * Extension type parameters:
 
-  * **value_type** = Arrow DataType of the tensor elements
-  * **shape** = shape of the contained tensors as an array
+  * **value_type** = Arrow DataType or Field of the tensor elements.
+  * **shape** = the physical shape of the contained tensors
+    as an array.
 
-  Optional parameters:
+  Optional parameters describing the logical layout:
 
   * **dim_names** = explicit names to tensor dimensions
     as an array. The length of it should be equal to the shape

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -72,10 +72,10 @@ same rules as laid out above, and provide backwards compatibility guarantees.
 Official List
 =============
 
-Fixed size tensor
-=================
+Fixed shape tensor
+==================
 
-* Extension name: `arrow.fixed_size_tensor`.
+* Extension name: `arrow.fixed_shape_tensor`.
 
 * The storage type of the extension: ``FixedSizeList``.
 

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -129,6 +129,9 @@ Fixed shape tensor
 
     ``{ "shape": [100, 200, 500], "permutation": [2, 0, 1]}``
 
+    This is the physical layout shape and the the shape of the logical
+    layout would in this case be ``[500, 100, 200]``.
+
 .. note::
 
   Elements in a fixed shape tensor extension array are stored

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -77,7 +77,11 @@ Fixed shape tensor
 
 * Extension name: `arrow.fixed_shape_tensor`.
 
-* The storage type of the extension: ``FixedSizeList``.
+* The storage type of the extension: ``FixedSizeList`` where:
+
+  * **value_type** is the data type of the child array (individual tensor) and
+    is an instance of ``pyarrow.DataType`` or ``pyarrow.Field``.
+  * **list_size** is the size of the child array (individual tensor).
 
 * Extension type parameters:
 

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -143,5 +143,5 @@ Fixed shape tensor
   to be used as a message in the interprocess communication machinery (IPC).
 
   This structure has no relationship with the Fixed shape tensor extension type defined
-  by this specification. With defining an extension type one can use fixed shape tensors
+  by this specification. Instead, this extension type lets one use fixed shape tensors
   as elements in a field of a RecordBatch or a Table.


### PR DESCRIPTION
### Rationale for this change

There have been quite a lot of discussions connected to the tensor support in Arrow Tables/RecorBatches. This PR is a specification proposal to add tensors as a canonical type extensions and is meant to be sent to the Mailing list for discussion and vote.

### What changes are included in this PR?
Specification for canonical extension type for fixed sized tensors.

**Open question**

Should metadata include the `"dim_names"` key to (optionally) specify dimension names when creating the Arrow FixedShapeTensorArray? 


* Closes: #33923