### PR TITLE
GH-33944: [C++] Allow FnOnce to be used in ThreadPool::Submit

### DIFF
--- a/cpp/src/arrow/util/thread_pool_test.cc
+++ b/cpp/src/arrow/util/thread_pool_test.cc
@@ -751,6 +751,20 @@ TEST_F(TestThreadPool, Submit) {
   }
 }
 
+TEST_F(TestThreadPool, SubmitFnOnce) {
+  auto pool = this->MakeThreadPool(3);
+  FnOnce<int()> move_only_fn = [] { return 0; };
+  ASSERT_OK_AND_ASSIGN(
+      Future<int> fut,
+      pool->SubmitOnce(TaskHints{}, StopToken::Unstoppable(), std::move(move_only_fn)));
+  ASSERT_OK_AND_EQ(9, fut.result());
+
+  FnOnce<int(int)> move_only_fn_args = [](int x) { return x; };
+  ASSERT_OK_AND_ASSIGN(fut, pool->SubmitOnce(TaskHints{}, StopToken::Unstoppable(),
+                                             std::move(move_only_fn_args), 5));
+  ASSERT_OK_AND_EQ(9, fut.result());
+}
+
 TEST_F(TestThreadPool, SubmitWithStopToken) {
   auto pool = this->MakeThreadPool(3);
   {

--- a/cpp/src/arrow/util/thread_pool_test.cc
+++ b/cpp/src/arrow/util/thread_pool_test.cc
@@ -757,12 +757,12 @@ TEST_F(TestThreadPool, SubmitFnOnce) {
   ASSERT_OK_AND_ASSIGN(
       Future<int> fut,
       pool->SubmitOnce(TaskHints{}, StopToken::Unstoppable(), std::move(move_only_fn)));
-  ASSERT_OK_AND_EQ(9, fut.result());
+  ASSERT_OK_AND_EQ(0, fut.result());
 
   FnOnce<int(int)> move_only_fn_args = [](int x) { return x; };
   ASSERT_OK_AND_ASSIGN(fut, pool->SubmitOnce(TaskHints{}, StopToken::Unstoppable(),
                                              std::move(move_only_fn_args), 5));
-  ASSERT_OK_AND_EQ(9, fut.result());
+  ASSERT_OK_AND_EQ(5, fut.result());
 }
 
 TEST_F(TestThreadPool, SubmitWithStopToken) {


### PR DESCRIPTION

* Closes: #33944