### PR TITLE
GH-33936: [Go] C Data Interface: export dummy buffer for nil buffers

### DIFF
--- a/go/arrow/cdata/cdata_exports.go
+++ b/go/arrow/cdata/cdata_exports.go
@@ -381,7 +381,7 @@ func exportArray(arr arrow.Array, out *CArrowArray, outSchema *CArrowSchema) {
 		// unions don't have validity bitmaps, but we keep them shifted
 		// to make processing easier in other contexts. This means that
 		// we have to adjust for union arrays
-		if !internal.HasValidityBitmap(arr.DataType().ID(), flatbuf.MetadataVersionV5) {
+		if !internal.DefaultHasValidityBitmap(arr.DataType().ID()) {
 			out.n_buffers--
 			nbuffers--
 			bufs = bufs[1:]
@@ -390,7 +390,7 @@ func exportArray(arr arrow.Array, out *CArrowArray, outSchema *CArrowSchema) {
 		for i := range bufs {
 			buf := bufs[i]
 			if buf == nil || buf.Len() == 0 {
-				if i > 0 || !internal.HasValidityBitmap(arr.DataType().ID(), flatbuf.MetadataVersionV5) {
+				if i > 0 || !internal.DefaultHasValidityBitmap(arr.DataType().ID()) {
 					// apache/arrow#33936: export a dummy buffer to be friendly to
 					// implementations that don't import NULL properly
 					buffers[i] = (*C.void)(unsafe.Pointer(&C.kGoCdataZeroRegion))

--- a/go/arrow/cdata/cdata_exports.go
+++ b/go/arrow/cdata/cdata_exports.go
@@ -49,7 +49,6 @@ import (
 	"github.com/apache/arrow/go/v12/arrow/array"
 	"github.com/apache/arrow/go/v12/arrow/endian"
 	"github.com/apache/arrow/go/v12/arrow/internal"
-	"github.com/apache/arrow/go/v12/arrow/internal/flatbuf"
 	"github.com/apache/arrow/go/v12/arrow/ipc"
 )
 

--- a/go/arrow/cdata/cdata_test.go
+++ b/go/arrow/cdata/cdata_test.go
@@ -795,6 +795,29 @@ func TestEmptyDictExport(t *testing.T) {
 	assert.Nil(t, out.dictionary.dictionary)
 }
 
+func TestEmptyStringExport(t *testing.T) {
+	// apache/arrow#33936: regression test
+	bldr := array.NewBuilder(memory.DefaultAllocator, &arrow.StringType{})
+	defer bldr.Release()
+
+	arr := bldr.NewArray()
+	defer arr.Release()
+
+	var out CArrowArray
+	var sc CArrowSchema
+	ExportArrowArray(arr, &out, &sc)
+
+	assert.EqualValues(t, 'u', *sc.format)
+	assert.Zero(t, sc.n_children)
+	assert.Nil(t, sc.dictionary)
+
+	assert.EqualValues(t, 3, out.n_buffers)
+	buffers := (*[3]unsafe.Pointer)(unsafe.Pointer(out.buffers))
+	assert.EqualValues(t, unsafe.Pointer(nil), buffers[0])
+	assert.NotEqualValues(t, unsafe.Pointer(nil), buffers[1])
+	assert.NotEqualValues(t, unsafe.Pointer(nil), buffers[2])
+}
+
 func TestRecordReaderExport(t *testing.T) {
 	// Regression test for apache/arrow#33767
 	reclist := arrdata.Records["primitives"]

--- a/go/arrow/cdata/cdata_test.go
+++ b/go/arrow/cdata/cdata_test.go
@@ -818,6 +818,28 @@ func TestEmptyStringExport(t *testing.T) {
 	assert.NotEqualValues(t, unsafe.Pointer(nil), buffers[2])
 }
 
+func TestEmptyUnionExport(t *testing.T) {
+	// apache/arrow#33936: regression test
+	bldr := array.NewBuilder(memory.DefaultAllocator, arrow.SparseUnionOf([]arrow.Field{
+		{Name: "child", Type: &arrow.Int64Type{}},
+	}, []arrow.UnionTypeCode{0}))
+	defer bldr.Release()
+
+	arr := bldr.NewArray()
+	defer arr.Release()
+
+	var out CArrowArray
+	var sc CArrowSchema
+	ExportArrowArray(arr, &out, &sc)
+
+	assert.EqualValues(t, 1, sc.n_children)
+	assert.Nil(t, sc.dictionary)
+
+	assert.EqualValues(t, 1, out.n_buffers)
+	buffers := (*[1]unsafe.Pointer)(unsafe.Pointer(out.buffers))
+	assert.NotEqualValues(t, unsafe.Pointer(nil), buffers[0])
+}
+
 func TestRecordReaderExport(t *testing.T) {
 	// Regression test for apache/arrow#33767
 	reclist := arrdata.Records["primitives"]


### PR DESCRIPTION
### Rationale for this change

While #14805 clarified that NULL buffers are valid in the C Data Interface, not all implementations handle this correctly (or were fixed, but earlier versions still exist).

### What changes are included in this PR?

Export a non-NULL dummy buffer for nil/empty buffers to ensure compatibility.

### Are these changes tested?

A regression test is included.
* Closes: #33936