### PR TITLE
GH-33963: [C++] add missing arrow/engine headers

### DIFF
--- a/cpp/src/arrow/engine/CMakeLists.txt
+++ b/cpp/src/arrow/engine/CMakeLists.txt
@@ -17,7 +17,7 @@
 
 add_custom_target(arrow_substrait)
 
-arrow_install_all_headers("arrow/engine/substrait")
+arrow_install_all_headers("arrow/engine")
 
 set(ARROW_SUBSTRAIT_SRCS
     substrait/expression_internal.cc

--- a/cpp/src/arrow/engine/api.h
+++ b/cpp/src/arrow/engine/api.h
@@ -19,7 +19,4 @@
 
 #pragma once
 
-#include "arrow/engine/substrait/extension_set.h"
-#include "arrow/engine/substrait/extension_types.h"
-#include "arrow/engine/substrait/relation.h"
-#include "arrow/engine/substrait/serde.h"
+#include "arrow/engine/substrait/api.h"

--- a/cpp/src/arrow/engine/substrait/api.h
+++ b/cpp/src/arrow/engine/substrait/api.h
@@ -21,4 +21,6 @@
 
 #include "arrow/engine/substrait/extension_set.h"
 #include "arrow/engine/substrait/extension_types.h"
+#include "arrow/engine/substrait/options.h"
+#include "arrow/engine/substrait/relation.h"
 #include "arrow/engine/substrait/serde.h"


### PR DESCRIPTION

* Closes: #33963