### PR TITLE
GH-33875: [Go] Handle writing LargeString and LargeBinary types

### DIFF
--- a/go/parquet/file/record_reader.go
+++ b/go/parquet/file/record_reader.go
@@ -756,10 +756,16 @@ func newByteArrayRecordReader(descr *schema.Column, info LevelInfo, dtype arrow.
 		mem = memory.DefaultAllocator
 	}
 
+	dt, ok := dtype.(arrow.BinaryDataType)
+	// arrow.DecimalType will also come through here, which we want to treat as binary
+	if !ok {
+		dt = arrow.BinaryTypes.Binary
+	}
+
 	return &binaryRecordReader{&recordReader{
 		recordReaderImpl: &byteArrayRecordReader{
 			createPrimitiveRecordReader(descr, mem, bufferPool),
-			array.NewBinaryBuilder(mem, dtype.(arrow.BinaryDataType)),
+			array.NewBinaryBuilder(mem, dt),
 			nil,
 		},
 		leafInfo:  info,

--- a/go/parquet/file/record_reader.go
+++ b/go/parquet/file/record_reader.go
@@ -751,20 +751,15 @@ type byteArrayRecordReader struct {
 	valueBuf []parquet.ByteArray
 }
 
-func newByteArrayRecordReader(descr *schema.Column, info LevelInfo, mem memory.Allocator, bufferPool *sync.Pool) RecordReader {
+func newByteArrayRecordReader(descr *schema.Column, info LevelInfo, dtype arrow.DataType, mem memory.Allocator, bufferPool *sync.Pool) RecordReader {
 	if mem == nil {
 		mem = memory.DefaultAllocator
-	}
-
-	dt := arrow.BinaryTypes.Binary
-	if descr.LogicalType().Equals(schema.StringLogicalType{}) {
-		dt = arrow.BinaryTypes.String
 	}
 
 	return &binaryRecordReader{&recordReader{
 		recordReaderImpl: &byteArrayRecordReader{
 			createPrimitiveRecordReader(descr, mem, bufferPool),
-			array.NewBinaryBuilder(mem, dt),
+			array.NewBinaryBuilder(mem, dtype.(arrow.BinaryDataType)),
 			nil,
 		},
 		leafInfo:  info,
@@ -841,10 +836,10 @@ func (br *byteArrayRecordReader) GetBuilderChunks() []arrow.Array {
 
 // TODO(mtopol): create optimized readers for dictionary types after ARROW-7286 is done
 
-func NewRecordReader(descr *schema.Column, info LevelInfo, readDict bool, mem memory.Allocator, bufferPool *sync.Pool) RecordReader {
+func NewRecordReader(descr *schema.Column, info LevelInfo, dtype arrow.DataType, mem memory.Allocator, bufferPool *sync.Pool) RecordReader {
 	switch descr.PhysicalType() {
 	case parquet.Types.ByteArray:
-		return newByteArrayRecordReader(descr, info, mem, bufferPool)
+		return newByteArrayRecordReader(descr, info, dtype, mem, bufferPool)
 	case parquet.Types.FixedLenByteArray:
 		return newFLBARecordReader(descr, info, mem, bufferPool)
 	default:

--- a/go/parquet/internal/testutils/random_arrow.go
+++ b/go/parquet/internal/testutils/random_arrow.go
@@ -136,8 +136,15 @@ func RandomNonNull(dt arrow.DataType, size int) arrow.Array {
 			bldr.Append("test-string")
 		}
 		return bldr.NewArray()
-	case arrow.BINARY:
-		bldr := array.NewBinaryBuilder(memory.DefaultAllocator, arrow.BinaryTypes.Binary)
+	case arrow.LARGE_STRING:
+		bldr := array.NewLargeStringBuilder(memory.DefaultAllocator)
+		defer bldr.Release()
+		for i := 0; i < size; i++ {
+			bldr.Append("test-large-string")
+		}
+		return bldr.NewArray()
+	case arrow.BINARY, arrow.LARGE_BINARY:
+		bldr := array.NewBinaryBuilder(memory.DefaultAllocator, dt.(arrow.BinaryDataType))
 		defer bldr.Release()
 
 		buf := make([]byte, 12)

--- a/go/parquet/pqarrow/column_readers.go
+++ b/go/parquet/pqarrow/column_readers.go
@@ -57,7 +57,7 @@ func newLeafReader(rctx *readerCtx, field *arrow.Field, input *columnIterator, l
 		field:     field,
 		input:     input,
 		descr:     input.Descr(),
-		recordRdr: file.NewRecordReader(input.Descr(), leafInfo, field.Type.ID() == arrow.DICTIONARY, rctx.mem, bufferPool),
+		recordRdr: file.NewRecordReader(input.Descr(), leafInfo, field.Type, rctx.mem, bufferPool),
 		props:     props,
 		refCount:  1,
 	}
@@ -480,7 +480,7 @@ func transferColumnData(rdr file.RecordReader, valueType arrow.DataType, descr *
 		data = transferInt(rdr, valueType)
 	case arrow.DATE64:
 		data = transferDate64(rdr, valueType)
-	case arrow.FIXED_SIZE_BINARY, arrow.BINARY, arrow.STRING:
+	case arrow.FIXED_SIZE_BINARY, arrow.BINARY, arrow.STRING, arrow.LARGE_BINARY, arrow.LARGE_STRING:
 		return transferBinary(rdr, valueType), nil
 	case arrow.DECIMAL:
 		switch descr.PhysicalType() {
@@ -534,7 +534,7 @@ func transferZeroCopy(rdr file.RecordReader, dt arrow.DataType) arrow.ArrayData 
 func transferBinary(rdr file.RecordReader, dt arrow.DataType) *arrow.Chunked {
 	brdr := rdr.(file.BinaryRecordReader)
 	chunks := brdr.GetBuilderChunks()
-	if dt == arrow.BinaryTypes.String {
+	if dt == arrow.BinaryTypes.String || dt == arrow.BinaryTypes.LargeString {
 		// convert chunks from binary to string without copying data,
 		// just changing the interpretation of the metadata
 		for idx := range chunks {

--- a/go/parquet/pqarrow/encode_arrow_test.go
+++ b/go/parquet/pqarrow/encode_arrow_test.go
@@ -391,7 +391,7 @@ func getLogicalType(typ arrow.DataType) schema.LogicalType {
 		return schema.NewIntLogicalType(64, true)
 	case arrow.UINT64:
 		return schema.NewIntLogicalType(64, false)
-	case arrow.STRING:
+	case arrow.STRING, arrow.LARGE_STRING:
 		return schema.StringLogicalType{}
 	case arrow.DATE32:
 		return schema.DateLogicalType{}
@@ -441,7 +441,7 @@ func getPhysicalType(typ arrow.DataType) parquet.Type {
 		return parquet.Types.Float
 	case arrow.FLOAT64:
 		return parquet.Types.Double
-	case arrow.BINARY, arrow.STRING:
+	case arrow.BINARY, arrow.LARGE_BINARY, arrow.STRING, arrow.LARGE_STRING:
 		return parquet.Types.ByteArray
 	case arrow.FIXED_SIZE_BINARY, arrow.DECIMAL:
 		return parquet.Types.FixedLenByteArray
@@ -708,6 +708,64 @@ func (ps *ParquetIOTestSuite) TestDateTimeTypesWithInt96ReadWriteTable() {
 		ps.Equal(len(exChunk.Chunks()), len(tblChunk.Chunks()))
 		ps.Truef(array.Equal(exChunk.Chunk(0), tblChunk.Chunk(0)), "expected %s\ngot %s", exChunk.Chunk(0), tblChunk.Chunk(0))
 	}
+}
+
+func (ps *ParquetIOTestSuite) TestLargeBinaryReadWriteTable() {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(ps.T(), 0)
+
+	// While we may write using LargeString, when we read, we get an array.String back out.
+	// So we're building a normal array.String to use with array.Equal
+	lsBldr := array.NewLargeStringBuilder(memory.DefaultAllocator)
+	defer lsBldr.Release()
+	sBldr := array.NewStringBuilder(memory.DefaultAllocator)
+	defer sBldr.Release()
+	lbBldr := array.NewBinaryBuilder(memory.DefaultAllocator, arrow.BinaryTypes.LargeBinary)
+	defer lbBldr.Release()
+	bBldr := array.NewBinaryBuilder(memory.DefaultAllocator, arrow.BinaryTypes.Binary)
+	defer bBldr.Release()
+
+	for i := 0; i < smallSize; i++ {
+		s := strconv.FormatInt(int64(i), 10)
+		lsBldr.Append(s)
+		sBldr.Append(s)
+		lbBldr.Append([]byte(s))
+		bBldr.Append([]byte(s))
+	}
+
+	lsValues := lsBldr.NewArray()
+	defer lsValues.Release()
+	sExpected := sBldr.NewArray()
+	defer sExpected.Release()
+	lbValues := lbBldr.NewArray()
+	defer lbValues.Release()
+	bExpected := bBldr.NewArray()
+	defer bExpected.Release()
+
+	lsField := arrow.Field{Name: "large_string", Type: arrow.BinaryTypes.LargeString, Nullable: true}
+	lbField := arrow.Field{Name: "large_binary", Type: arrow.BinaryTypes.LargeBinary, Nullable: true}
+	tbl := array.NewTable(
+		arrow.NewSchema([]arrow.Field{lsField, lbField}, nil),
+		[]arrow.Column{
+			*arrow.NewColumn(lsField, arrow.NewChunked(lsField.Type, []arrow.Array{lsValues})),
+			*arrow.NewColumn(lbField, arrow.NewChunked(lbField.Type, []arrow.Array{lbValues})),
+		},
+		-1,
+	)
+	defer tbl.Release()
+
+	var buf bytes.Buffer
+	ps.Require().NoError(pqarrow.WriteTable(tbl, &buf, tbl.NumRows(), nil, pqarrow.DefaultWriterProps()))
+
+	reader := ps.createReader(buf.Bytes())
+	actual := ps.readTable(reader)
+	defer actual.Release()
+
+	ps.Equal(tbl.NumCols(), actual.NumCols())
+	ps.Equal(tbl.NumRows(), actual.NumRows())
+
+	ps.True(array.Equal(sExpected, actual.Column(0).Data().Chunk(0)))
+	ps.True(array.Equal(bExpected, actual.Column(1).Data().Chunk(0)))
 }
 
 func (ps *ParquetIOTestSuite) TestReadSingleColumnFile() {

--- a/go/parquet/pqarrow/schema.go
+++ b/go/parquet/pqarrow/schema.go
@@ -1001,6 +1001,9 @@ func applyOriginalStorageMetadata(origin arrow.Field, inferred *SchemaField) (mo
 			inferred.Field.Type = origin.Type
 		}
 		modified = true
+	case arrow.LARGE_STRING, arrow.LARGE_BINARY:
+		inferred.Field.Type = origin.Type
+		modified = true
 	}
 
 	if origin.HasMetadata() {

--- a/go/parquet/pqarrow/schema.go
+++ b/go/parquet/pqarrow/schema.go
@@ -292,10 +292,10 @@ func fieldToNode(name string, field arrow.Field, props *parquet.WriterProperties
 		typ = parquet.Types.Float
 	case arrow.FLOAT64:
 		typ = parquet.Types.Double
-	case arrow.STRING:
+	case arrow.STRING, arrow.LARGE_STRING:
 		logicalType = schema.StringLogicalType{}
 		fallthrough
-	case arrow.BINARY:
+	case arrow.BINARY, arrow.LARGE_BINARY:
 		typ = parquet.Types.ByteArray
 	case arrow.FIXED_SIZE_BINARY:
 		typ = parquet.Types.FixedLenByteArray


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/master/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Handle writing `array.LargeString` and `array.LargeBinary` data types. This allows parquet files to contain more than 2G worth of binary data in a single column chunk.

### Are these changes tested?

Unit tests included

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

* Closes: #33875