### PR TITLE
GH-33668: [Python] Reading flat dataset with partitioning="hive" results in partition schema equal to dataset schema

### DIFF
--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -827,7 +827,7 @@ class HivePartitioningFactory : public KeyValuePartitioningFactory {
   Result<std::shared_ptr<Partitioning>> Finish(
       const std::shared_ptr<Schema>& schema) const override {
     if (dictionaries_.empty()) {
-      return std::make_shared<HivePartitioning>(schema, dictionaries_);
+      return std::make_shared<HivePartitioning>(arrow::schema({}), dictionaries_);
     } else {
       for (FieldRef ref : field_names_) {
         // ensure all of field_names_ are present in schema

--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -825,17 +825,17 @@ class HivePartitioningFactory : public KeyValuePartitioningFactory {
   }
 
   Result<std::shared_ptr<Partitioning>> Finish(
-      const std::shared_ptr<Schema>& schema) const override {
+      const std::shared_ptr<Schema>& dataset_schema) const override {
     if (dictionaries_.empty()) {
-      return std::make_shared<HivePartitioning>(arrow::schema({}), dictionaries_);
+      return std::make_shared<HivePartitioning>(schema({}), dictionaries_);
     } else {
       for (FieldRef ref : field_names_) {
         // ensure all of field_names_ are present in schema
-        RETURN_NOT_OK(ref.FindOne(*schema));
+        RETURN_NOT_OK(ref.FindOne(*dataset_schema));
       }
 
       // drop fields which aren't in field_names_
-      auto out_schema = SchemaFromColumnNames(schema, field_names_);
+      auto out_schema = SchemaFromColumnNames(dataset_schema, field_names_);
 
       return std::make_shared<HivePartitioning>(std::move(out_schema), dictionaries_,
                                                 options_.AsHivePartitioningOptions());

--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -827,7 +827,7 @@ class HivePartitioningFactory : public KeyValuePartitioningFactory {
   Result<std::shared_ptr<Partitioning>> Finish(
       const std::shared_ptr<Schema>& dataset_schema) const override {
     if (dictionaries_.empty()) {
-      return std::make_shared<HivePartitioning>(schema({}), dictionaries_);
+      return std::make_shared<HivePartitioning>(dataset_schema, dictionaries_);
     } else {
       for (FieldRef ref : field_names_) {
         // ensure all of field_names_ are present in schema

--- a/cpp/src/arrow/dataset/partition_test.cc
+++ b/cpp/src/arrow/dataset/partition_test.cc
@@ -84,8 +84,16 @@ class TestPartitioning : public ::testing::Test {
   void AssertInspect(const std::vector<std::string>& paths,
                      const std::vector<std::shared_ptr<Field>>& expected) {
     ASSERT_OK_AND_ASSIGN(auto actual, factory_->Inspect(paths));
-    ASSERT_EQ(*actual, Schema(expected));
-    ASSERT_OK_AND_ASSIGN(partitioning_, factory_->Finish(actual));
+    // ASSERT_EQ(*actual, Schema(expected));
+    // ASSERT_OK_AND_ASSIGN(partitioning_, factory_->Finish(actual));
+    Schema expected_schema(expected);
+    ASSERT_EQ(*actual, expected_schema);
+    // The dataset will usually have more than just partition fields.  The partitioning
+    // schema should ignore these.
+    std::vector<std::shared_ptr<Field>> all_fields(expected);
+    all_fields.push_back(field("field_unrelated_to_partitioning", int8()));
+    ASSERT_OK_AND_ASSIGN(partitioning_, factory_->Finish(schema(std::move(all_fields))));
+    AssertSchemaEqual(expected_schema, *partitioning_->schema());
   }
 
   void AssertPartition(const std::shared_ptr<Partitioning> partitioning,
@@ -572,6 +580,11 @@ TEST_F(TestPartitioning, DiscoverHiveSchema) {
   // missing path segments will not cause an error
   AssertInspect({"/alpha=0/beta=1", "/beta=2/alpha=3", "/gamma=what"},
                 {Int("alpha"), Int("beta"), Str("gamma")});
+
+  // No partitioning information should yield an empty partitioning even if
+  // there are fields in the dataset schema
+  AssertInspect({"/foo/chunk.parquet", "/bar/chunk.parquet", "/baz"}, {});
+  AssertInspect({"chunk.parquet"}, {});
 }
 
 TEST_F(TestPartitioning, HiveDictionaryInference) {
@@ -1106,89 +1119,6 @@ TEST(TestStripPrefixAndFilename, Basic) {
   auto paths = StripPrefixAndFilename(input, "/data");
   EXPECT_THAT(paths, testing::ElementsAre("year=2019", "year=2019/month=12",
                                           "year=2019/month=12/day=01"));
-}
-
-TEST_F(TestPartitioning, HivePartitionReadEvaluation) {
-  // Test non-partitioned data
-  auto filesystem = std::make_shared<fs::LocalFileSystem>();
-  const std::string file_name = "data.arrow";
-  ASSERT_OK_AND_ASSIGN(auto tempdir,
-                       arrow::internal::TemporaryDir::Make("non-hive-tempdir-"));
-  ASSERT_OK_AND_ASSIGN(auto file_path, tempdir->path().Join(file_name));
-  std::string file_path_str = file_path.ToString();
-  auto schema = arrow::schema(
-      {arrow::field("a", arrow::int64()), arrow::field("part", arrow::utf8())});
-
-  auto table = TableFromJSON(schema, {
-                                         R"([
-    [10, "a2"],
-    [11, "a1"],
-    [12, "a2"],
-    [20, "a1"],
-    [14, "a2"]
-  ])",
-                                     });
-  // Write data with no-partitioning
-  ASSERT_OK_AND_ASSIGN(auto output, filesystem->OpenOutputStream(file_path_str));
-  ASSERT_OK_AND_ASSIGN(auto writer, ipc::MakeFileWriter(output.get(), schema));
-  ASSERT_OK(writer->WriteTable(*table));
-  ASSERT_OK(writer->Close());
-
-  FileSystemFactoryOptions options;
-  options.partitioning = HivePartitioning::MakeFactory();
-
-  std::vector<fs::FileInfo> files;
-  const std::vector<std::string> f_paths = {file_path_str};
-
-  for (const auto& f_path : f_paths) {
-    ASSERT_OK_AND_ASSIGN(auto f_file, filesystem->GetFileInfo(f_path));
-    files.push_back(std::move(f_file));
-  }
-  auto format = std::make_shared<dataset::IpcFileFormat>();
-  ASSERT_OK_AND_ASSIGN(auto ds_factory,
-                       dataset::FileSystemDatasetFactory::Make(
-                           filesystem, std::move(files), format, options));
-  ASSERT_OK_AND_ASSIGN(auto ds, ds_factory->Finish());
-
-  auto file_system_dataset = std::dynamic_pointer_cast<FileSystemDataset>(ds);
-  // When non-partitioned data is even read with `HivePartitioning` options, the
-  // schema of the partiion should be an empty schema.
-  EXPECT_TRUE(file_system_dataset->partitioning()->schema()->Equals(arrow::schema({})));
-
-  // Test Hive-based partitioning with `partition_schema`.
-
-  auto partition_schema = arrow::schema({arrow::field("part", arrow::utf8())});
-  auto partitioning = std::make_shared<dataset::HivePartitioning>(partition_schema);
-  ASSERT_OK_AND_ASSIGN(auto hive_tempdir,
-                       arrow::internal::TemporaryDir::Make("hive-tempdir-"));
-  dataset::FileSystemDatasetWriteOptions write_options;
-  write_options.file_write_options = format->DefaultWriteOptions();
-  write_options.filesystem = filesystem;
-  write_options.base_dir = hive_tempdir->path().ToString();
-  write_options.partitioning = partitioning;  // partiion with `HivePartitioning`
-  write_options.basename_template = "part{i}.arrow";
-
-  // Write it using Datasets
-  auto dataset = std::make_shared<dataset::InMemoryDataset>(table);
-  ASSERT_OK_AND_ASSIGN(auto scanner_builder, dataset->NewScan());
-  ASSERT_OK_AND_ASSIGN(auto scanner, scanner_builder->Finish());
-
-  ASSERT_OK(dataset::FileSystemDataset::Write(write_options, scanner));
-
-  fs::FileSelector selector;
-  selector.base_dir = hive_tempdir->path().ToString();
-  selector.recursive = true;  // Make sure to search subdirectories
-  FileSystemFactoryOptions hive_options;
-  hive_options.partitioning = HivePartitioning::MakeFactory();
-  ASSERT_OK_AND_ASSIGN(auto factory, FileSystemDatasetFactory::Make(
-                                         filesystem, selector, format, hive_options));
-  ASSERT_OK_AND_ASSIGN(auto hive_ds, factory->Finish());
-
-  auto hive_file_system_dataset = std::dynamic_pointer_cast<FileSystemDataset>(hive_ds);
-  // When `HivePartitioning` is used in writing and reading, the partitioning schema
-  // should equal to the `partition_schema`.
-  EXPECT_TRUE(
-      hive_file_system_dataset->partitioning()->schema()->Equals(partition_schema));
 }
 
 }  // namespace dataset

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -259,7 +259,7 @@ def partitioning(schema=None, field_names=None, flavor=None,
         raise ValueError("Unsupported flavor")
 
 
-def _ensure_partitioning(scheme, schema):
+def _ensure_partitioning(scheme):
     """
     Validate input and return a Partitioning(Factory).
 
@@ -268,7 +268,7 @@ def _ensure_partitioning(scheme, schema):
     if scheme is None:
         pass
     elif isinstance(scheme, str):
-        scheme = partitioning(schema=schema, flavor=scheme)
+        scheme = partitioning(flavor=scheme)
     elif isinstance(scheme, list):
         scheme = partitioning(field_names=scheme)
     elif isinstance(scheme, (Partitioning, PartitioningFactory)):
@@ -437,7 +437,7 @@ def _filesystem_dataset(source, schema=None, filesystem=None,
     FileSystemDataset
     """
     format = _ensure_format(format or 'parquet')
-    partitioning = _ensure_partitioning(partitioning, schema)
+    partitioning = _ensure_partitioning(partitioning)
 
     if isinstance(source, (list, tuple)):
         fs, paths_or_selector = _ensure_multiple_sources(source, filesystem)
@@ -542,7 +542,7 @@ def parquet_dataset(metadata_path, schema=None, filesystem=None, format=None,
     metadata_path = filesystem.normalize_path(_stringify_path(metadata_path))
     options = ParquetFactoryOptions(
         partition_base_dir=partition_base_dir,
-        partitioning=_ensure_partitioning(partitioning, schema)
+        partitioning=_ensure_partitioning(partitioning)
     )
 
     factory = ParquetDatasetFactory(

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -259,7 +259,7 @@ def partitioning(schema=None, field_names=None, flavor=None,
         raise ValueError("Unsupported flavor")
 
 
-def _ensure_partitioning(scheme):
+def _ensure_partitioning(scheme, schema):
     """
     Validate input and return a Partitioning(Factory).
 
@@ -268,7 +268,7 @@ def _ensure_partitioning(scheme):
     if scheme is None:
         pass
     elif isinstance(scheme, str):
-        scheme = partitioning(flavor=scheme)
+        scheme = partitioning(schema=schema, flavor=scheme)
     elif isinstance(scheme, list):
         scheme = partitioning(field_names=scheme)
     elif isinstance(scheme, (Partitioning, PartitioningFactory)):
@@ -437,7 +437,7 @@ def _filesystem_dataset(source, schema=None, filesystem=None,
     FileSystemDataset
     """
     format = _ensure_format(format or 'parquet')
-    partitioning = _ensure_partitioning(partitioning)
+    partitioning = _ensure_partitioning(partitioning, schema)
 
     if isinstance(source, (list, tuple)):
         fs, paths_or_selector = _ensure_multiple_sources(source, filesystem)
@@ -542,7 +542,7 @@ def parquet_dataset(metadata_path, schema=None, filesystem=None, format=None,
     metadata_path = filesystem.normalize_path(_stringify_path(metadata_path))
     options = ParquetFactoryOptions(
         partition_base_dir=partition_base_dir,
-        partitioning=_ensure_partitioning(partitioning)
+        partitioning=_ensure_partitioning(partitioning, schema)
     )
 
     factory = ParquetDatasetFactory(

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -1926,10 +1926,11 @@ def test_write_to_dataset_kwargs_passed(tempdir, write_dataset_kwarg):
         _name, _args, kwargs = mock_write_dataset.mock_calls[0]
         assert kwargs[key] == arg
 
+
 def test_partition_schema_validity(tempdir):
     data = {
-    "a": [1, 2, 1, 2, 3, 4],
-    "b": [10, 20, 30, 40, 50, 60]
+        "a": [1, 2, 1, 2, 3, 4],
+        "b": [10, 20, 30, 40, 50, 60]
     }
 
     table = pa.Table.from_pydict(data)
@@ -1941,4 +1942,3 @@ def test_partition_schema_validity(tempdir):
 
     flat_ds = pa.dataset.dataset(tempdir, format="parquet")
     assert hive_ds.schema == flat_ds.schema
-    assert flat_ds.partitioning == None

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -1925,3 +1925,20 @@ def test_write_to_dataset_kwargs_passed(tempdir, write_dataset_kwarg):
         pq.write_to_dataset(table, path, **{key: arg})
         _name, _args, kwargs = mock_write_dataset.mock_calls[0]
         assert kwargs[key] == arg
+
+def test_partition_schema_validity(tempdir):
+    data = {
+    "a": [1, 2, 1, 2, 3, 4],
+    "b": [10, 20, 30, 40, 50, 60]
+    }
+
+    table = pa.Table.from_pydict(data)
+    pq.write_table(table, tempdir / "table.parquet")
+
+    hive_ds = pa.dataset.dataset(tempdir, partitioning="hive", format="parquet")
+
+    assert hive_ds.partitioning.schema == pa.schema([])
+
+    flat_ds = pa.dataset.dataset(tempdir, format="parquet")
+    assert hive_ds.schema == flat_ds.schema
+    assert flat_ds.partitioning == None

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -5058,10 +5058,8 @@ def test_dataset_partition_with_slash(tmpdir):
     read_table = ds.dataset(
         source=path,
         format='ipc',
-        partitioning='hive',
-        schema=pa.schema([pa.field("exp_id", pa.int32()),
-                          pa.field("exp_meta", pa.utf8())])
-    ).to_table().combine_chunks()
+        schema=dt_table.schema,
+        partitioning='hive').to_table().combine_chunks()
 
     assert dt_table == read_table.sort_by("exp_id")
 


### PR DESCRIPTION
This PR includes a minor modification to `HivePartitioningFactory` to fix an error caused when reading non-partitioned data in hive format. And test cases for Python and C++ has been added to evaluate the update.