### PR TITLE
MINOR: [Go] Use shared cache in SQLite example.

### DIFF
--- a/go/arrow/flight/flightsql/example/cmd/sqlite_flightsql_server/main.go
+++ b/go/arrow/flight/flightsql/example/cmd/sqlite_flightsql_server/main.go
@@ -40,7 +40,13 @@ func main() {
 
 	flag.Parse()
 
-	srv, err := example.NewSQLiteFlightSQLServer()
+	db, err := example.CreateDB()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	srv, err := example.NewSQLiteFlightSQLServer(db)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/go/arrow/flight/flightsql/example/sqlite_server.go
+++ b/go/arrow/flight/flightsql/example/sqlite_server.go
@@ -140,19 +140,7 @@ func prepareQueryForGetKeys(filter string) string {
 		` ORDER BY pk_catalog_name, pk_schema_name, pk_table_name, pk_key_name, key_sequence`
 }
 
-type Statement struct {
-	stmt   *sql.Stmt
-	params [][]interface{}
-}
-
-type SQLiteFlightSQLServer struct {
-	flightsql.BaseServer
-	db *sql.DB
-
-	prepared sync.Map
-}
-
-func NewSQLiteFlightSQLServer() (*SQLiteFlightSQLServer, error) {
+func CreateDB() (*sql.DB, error) {
 	db, err := sql.Open("sqlite", "file::memory:?cache=shared")
 	if err != nil {
 		return nil, err
@@ -178,20 +166,33 @@ func NewSQLiteFlightSQLServer() (*SQLiteFlightSQLServer, error) {
 	INSERT INTO intTable (keyName, value, foreignId) VALUES ('negative one', -1, 1);
 	INSERT INTO intTable (keyName, value, foreignId) VALUES (NULL, NULL, NULL);
 	`)
-
 	if err != nil {
+		db.Close()
 		return nil, err
 	}
+
+	return db, nil
+}
+
+type Statement struct {
+	stmt   *sql.Stmt
+	params [][]interface{}
+}
+
+type SQLiteFlightSQLServer struct {
+	flightsql.BaseServer
+	db *sql.DB
+
+	prepared sync.Map
+}
+
+func NewSQLiteFlightSQLServer(db *sql.DB) (*SQLiteFlightSQLServer, error) {
 	ret := &SQLiteFlightSQLServer{db: db}
 	ret.Alloc = memory.DefaultAllocator
 	for k, v := range SqlInfoResultMap() {
 		ret.RegisterSqlInfo(flightsql.SqlInfo(k), v)
 	}
 	return ret, nil
-}
-
-func (s *SQLiteFlightSQLServer) Shutdown() error {
-	return s.db.Close()
 }
 
 func (s *SQLiteFlightSQLServer) flightInfoForCommand(desc *flight.FlightDescriptor, schema *arrow.Schema) *flight.FlightInfo {

--- a/go/arrow/flight/flightsql/example/sqlite_server.go
+++ b/go/arrow/flight/flightsql/example/sqlite_server.go
@@ -190,6 +190,10 @@ func NewSQLiteFlightSQLServer() (*SQLiteFlightSQLServer, error) {
 	return ret, nil
 }
 
+func (s *SQLiteFlightSQLServer) Shutdown() error {
+	return s.db.Close()
+}
+
 func (s *SQLiteFlightSQLServer) flightInfoForCommand(desc *flight.FlightDescriptor, schema *arrow.Schema) *flight.FlightInfo {
 	return &flight.FlightInfo{
 		Endpoint:         []*flight.FlightEndpoint{{Ticket: &flight.Ticket{Ticket: desc.Cmd}}},

--- a/go/arrow/flight/flightsql/example/sqlite_server.go
+++ b/go/arrow/flight/flightsql/example/sqlite_server.go
@@ -153,7 +153,7 @@ type SQLiteFlightSQLServer struct {
 }
 
 func NewSQLiteFlightSQLServer() (*SQLiteFlightSQLServer, error) {
-	db, err := sql.Open("sqlite", ":memory:")
+	db, err := sql.Open("sqlite", "file::memory:?cache=shared")
 	if err != nil {
 		return nil, err
 	}

--- a/go/arrow/flight/flightsql/sqlite_server_test.go
+++ b/go/arrow/flight/flightsql/sqlite_server_test.go
@@ -88,6 +88,8 @@ func (s *FlightSqliteServerSuite) SetupTest() {
 func (s *FlightSqliteServerSuite) TearDownTest() {
 	s.Require().NoError(s.cl.Close())
 	s.s.Shutdown()
+	err := s.srv.Shutdown()
+	s.Require().NoError(err)
 	s.srv = nil
 	s.mem.AssertSize(s.T(), 0)
 }

--- a/go/arrow/flight/flightsql/sqlite_server_test.go
+++ b/go/arrow/flight/flightsql/sqlite_server_test.go
@@ -21,6 +21,7 @@ package flightsql_test
 
 import (
 	"context"
+	"database/sql"
 	"os"
 	"strings"
 	"testing"
@@ -42,6 +43,7 @@ import (
 type FlightSqliteServerSuite struct {
 	suite.Suite
 
+	db  *sql.DB
 	srv *example.SQLiteFlightSQLServer
 	s   flight.Server
 	cl  *flightsql.Client
@@ -71,7 +73,9 @@ func (s *FlightSqliteServerSuite) SetupTest() {
 	var err error
 	s.mem = memory.NewCheckedAllocator(memory.DefaultAllocator)
 	s.s = flight.NewServerWithMiddleware(nil)
-	s.srv, err = example.NewSQLiteFlightSQLServer()
+	s.db, err = example.CreateDB()
+	s.Require().NoError(err)
+	s.srv, err = example.NewSQLiteFlightSQLServer(s.db)
 	s.Require().NoError(err)
 	s.srv.Alloc = s.mem
 
@@ -88,9 +92,9 @@ func (s *FlightSqliteServerSuite) SetupTest() {
 func (s *FlightSqliteServerSuite) TearDownTest() {
 	s.Require().NoError(s.cl.Close())
 	s.s.Shutdown()
-	err := s.srv.Shutdown()
-	s.Require().NoError(err)
 	s.srv = nil
+	err := s.db.Close()
+	s.Require().NoError(err)
 	s.mem.AssertSize(s.T(), 0)
 }
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/master/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

When calling this server with a few concurrent requests, you can easily force the Go stdlib to spawn a new connection. Since only the `:memory:` DSN is specified, the stdlib doesn't know any better and effectively creates a new database. The result is a lot of `no such table` errors.

### What changes are included in this PR?

This change adds the `?cache=shared` as specified at:

https://www.sqlite.org/sharedcache.html#enabling_shared_cache_mode

This ensures that these new connections participate in same in-memory database and can see all the tables created at server start.

### Are these changes tested?

I haven't written any additional tests here, because this behavior is difficult to test. Suggestions are welcome on an approach here.

### Are there any user-facing changes?

No.

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #33983