### PR TITLE
GH-33993: [Java] Let OS assign port in tests while creating Flight server

### DIFF
--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/FlightTestUtil.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/FlightTestUtil.java
@@ -52,9 +52,12 @@ public class FlightTestUtil {
     IOException lastThrown = null;
     T server = null;
     for (int x = 0; x < 3; x++) {
-      final ServerSocket dynamicPortSocket = new ServerSocket(0);
-      final int port = dynamicPortSocket.getLocalPort();
-      dynamicPortSocket.close();
+      int port;
+      try (final ServerSocket dynamicPortSocket = new ServerSocket(0)) {
+        port = dynamicPortSocket.getLocalPort();
+      } catch (SecurityException | IOException e) {
+        throw new RuntimeException("Unable to create a ServerSocket instance. ", e);
+      }
 
       final Location location = Location.forGrpcInsecure(LOCALHOST, port);
       lastThrown = null;

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/FlightTestUtil.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/FlightTestUtil.java
@@ -20,6 +20,7 @@ package org.apache.arrow.flight;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.net.ServerSocket;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -51,7 +52,10 @@ public class FlightTestUtil {
     IOException lastThrown = null;
     T server = null;
     for (int x = 0; x < 3; x++) {
-      final int port = 49152 + RANDOM.nextInt(5000);
+      final ServerSocket dynamicPortSocket = new ServerSocket(0);
+      final int port = dynamicPortSocket.getLocalPort();
+      dynamicPortSocket.close();
+
       final Location location = Location.forGrpcInsecure(LOCALHOST, port);
       lastThrown = null;
       try {


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/master/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Sometimes tests are flaky because the current port selection algorithm selects a random port between the ranges 49152-54152. This change makes it such that the OS will assign the next free port without us searching for a port in this range.

### What changes are included in this PR?

This PR makes use of  `java.net.ServerSocket`'s ability to assign the next free port if 0 is passed as the port number.

### Are these changes tested?

If existing tests pass, there's confirmation that the Flight server is able to come up successfully, thereby no new tests should be needed.

### Are there any user-facing changes?

No, there are no user facing changes.

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #32954
* Closes: #33993