### PR TITLE
GH-33971: [C++] Fix AdaptiveIntBuilder to always populate data buffer

### DIFF
--- a/cpp/src/arrow/array/array_dict_test.cc
+++ b/cpp/src/arrow/array/array_dict_test.cc
@@ -157,6 +157,18 @@ TYPED_TEST(TestDictionaryBuilder, MakeBuilder) {
   AssertArraysEqual(expected, *result);
 }
 
+TYPED_TEST(TestDictionaryBuilder, Empty) {
+  DictionaryBuilder<TypeParam> dictionary_builder;
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<Array> empty_arr, dictionary_builder.Finish());
+  std::shared_ptr<DictionaryArray> empty_dict_arr =
+      std::static_pointer_cast<DictionaryArray>(empty_arr);
+  // Ensure that the indices value buffer is initialized
+  ASSERT_NE(nullptr, empty_dict_arr->data()->buffers[1]);
+  // Ensure that the dictionary's value buffer is initialized
+  ASSERT_NE(nullptr, empty_dict_arr->dictionary());
+  ASSERT_NE(nullptr, empty_dict_arr->dictionary()->data()->buffers[1]);
+}
+
 TYPED_TEST(TestDictionaryBuilder, ArrayConversion) {
   auto type = std::make_shared<TypeParam>();
 

--- a/cpp/src/arrow/array/array_dict_test.cc
+++ b/cpp/src/arrow/array/array_dict_test.cc
@@ -161,7 +161,7 @@ TYPED_TEST(TestDictionaryBuilder, Empty) {
   DictionaryBuilder<TypeParam> dictionary_builder;
   ASSERT_OK_AND_ASSIGN(std::shared_ptr<Array> empty_arr, dictionary_builder.Finish());
   std::shared_ptr<DictionaryArray> empty_dict_arr =
-      std::static_pointer_cast<DictionaryArray>(empty_arr);
+      checked_pointer_cast<DictionaryArray>(empty_arr);
   // Ensure that the indices value buffer is initialized
   ASSERT_NE(nullptr, empty_dict_arr->data()->buffers[1]);
   // Ensure that the dictionary's value buffer is initialized

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -2320,7 +2320,17 @@ class TestAdaptiveIntBuilder : public TestBuilder {
     builder_ = std::make_shared<AdaptiveIntBuilder>(pool_);
   }
 
-  void Done() { FinishAndCheckPadding(builder_.get(), &result_); }
+  void EnsureValuesBufferNotNull(const ArrayData& data) {
+    // The values buffer should be initialized
+    ASSERT_EQ(2, data.buffers.size());
+    ASSERT_NE(nullptr, data.buffers[1]);
+    ASSERT_NE(nullptr, data.buffers[1]->data());
+  }
+
+  void Done() {
+    FinishAndCheckPadding(builder_.get(), &result_);
+    EnsureValuesBufferNotNull(*result_->data());
+  }
 
   template <typename ExpectedType>
   void TestAppendValues() {
@@ -2570,6 +2580,8 @@ TEST_F(TestAdaptiveIntBuilder, TestAppendEmptyValue) {
   // NOTE: The fact that we get 0 is really an implementation detail
   AssertArraysEqual(*result_, *ArrayFromJSON(int8(), "[null, null, 0, 42, 0, 0]"));
 }
+
+TEST_F(TestAdaptiveIntBuilder, Empty) { Done(); }
 
 TEST(TestAdaptiveIntBuilderWithStartIntSize, TestReset) {
   auto builder = std::make_shared<AdaptiveIntBuilder>(


### PR DESCRIPTION
If the AdaptiveIntBuilder was empty it would yield a null for the values buffer.  The byte_size.h utilities were not expecting this which led to the error reported in the issue.

Example:

```
>>> pa.array([], type=pa.dictionary(pa.int32(), pa.string())).buffers()
[None, None]
```
* Closes: #33971