### PR TITLE
GH-34001: [C++] Add more rvalue overload for Status::operator&

### DIFF
--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -157,8 +157,10 @@ class ARROW_EXPORT [[nodiscard]] Status : public util::EqualityComparable<Status
   inline bool Equals(const Status& s) const;
 
   // AND the statuses.
-  inline Status operator&(const Status& s) const noexcept;
-  inline Status operator&(Status&& s) const noexcept;
+  inline Status operator&(const Status& s) const& noexcept;
+  inline Status operator&(const Status& s) && noexcept;
+  inline Status operator&(Status&& s) const& noexcept;
+  inline Status operator&(Status&& s) && noexcept;
   inline Status& operator&=(const Status& s) noexcept;
   inline Status& operator&=(Status&& s) noexcept;
 
@@ -422,7 +424,7 @@ bool Status::Equals(const Status& s) const {
 /// \cond FALSE
 // (note: emits warnings on Doxygen < 1.8.15,
 //  see https://github.com/doxygen/doxygen/issues/6295)
-Status Status::operator&(const Status& s) const noexcept {
+Status Status::operator&(const Status& s) const& noexcept {
   if (ok()) {
     return s;
   } else {
@@ -430,11 +432,27 @@ Status Status::operator&(const Status& s) const noexcept {
   }
 }
 
-Status Status::operator&(Status&& s) const noexcept {
+Status Status::operator&(const Status& s) && noexcept {
+  if (ok()) {
+    return s;
+  } else {
+    return std::move(*this);
+  }
+}
+
+Status Status::operator&(Status&& s) const& noexcept {
   if (ok()) {
     return std::move(s);
   } else {
     return *this;
+  }
+}
+
+Status Status::operator&(Status&& s) && noexcept {
+  if (ok()) {
+    return std::move(s);
+  } else {
+    return std::move(*this);
   }
 }
 

--- a/cpp/src/arrow/status_test.cc
+++ b/cpp/src/arrow/status_test.cc
@@ -104,6 +104,21 @@ TEST(StatusTest, AndStatus) {
   res = Status::Invalid("foo") & Status::IOError("bar");
   ASSERT_TRUE(res.IsInvalid());
 
+  ASSERT_TRUE((a & Status::OK()).ok());
+  ASSERT_TRUE((c & Status::OK()).IsInvalid());
+  ASSERT_TRUE((a & Status::IOError("")).IsIOError());
+  ASSERT_TRUE((c & Status::IOError("")).IsInvalid());
+
+  ASSERT_TRUE((Status::OK() & a).ok());
+  ASSERT_TRUE((Status::OK() & c).IsInvalid());
+  ASSERT_TRUE((Status::IOError("") & a).IsIOError());
+  ASSERT_TRUE((Status::IOError("") & c).IsIOError());
+
+  ASSERT_TRUE((Status::OK() & Status::OK()).ok());
+  ASSERT_TRUE((Status::Invalid("") & Status::OK()).IsInvalid());
+  ASSERT_TRUE((Status::OK() & Status::IOError("")).IsIOError());
+  ASSERT_TRUE((Status::IOError("") & Status::Invalid("")).IsIOError());
+
   res = Status::OK();
   res &= Status::OK();
   ASSERT_TRUE(res.ok());


### PR DESCRIPTION
It fixes #34001

-----

From #34001:

> https://github.com/apache/arrow/blob/a0d0ecee71b99b45f2c1b269c70033d39b982d00/cpp/src/arrow/status.h#L160-L161
>
> Currently there are two overloads for `Status::operator&` to achieve "reference forwarding", but only for the rhs (i.e. `const > Status& s` or `Status&& s`), the reference type of lhs value (i.e. `*this`) cannot be forwarded. e.g.
> ```c++
> Status v = ...;
> Status f(/* some parameters */);
> Status g(/* some parameters */);
>
> auto v1 = v & f(); // OK! the rhs rvalue can be moved into result
> auto v2 = f() & v; // Ooops, the lhs rvalue cannot be moved into result
> auto v3 = f() & g(); // Ooops, same as above
> ```
>
> We can add more overloads to forward reference of lhs for better performance.
* Closes: #34001