### PR TITLE
GH-34004: [C++] Add a benchmarks-maximal CMake preset

### DIFF
--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -120,7 +120,7 @@
     {
       "name": "features-python-minimal",
       "inherits": [
-	  "features-minimal"
+        "features-minimal"
       ],
       "hidden": true,
       "cacheVariables": {
@@ -133,7 +133,7 @@
     {
       "name": "features-python",
       "inherits": [
-	  "features-main"
+        "features-main"
       ],
       "hidden": true,
       "cacheVariables": {
@@ -148,12 +148,12 @@
     {
       "name": "features-python-maximal",
       "inherits": [
-	  "features-cuda",
-	  "features-filesystems",
-	  "features-flight",
-	  "features-gandiva",
-	  "features-main",
-	  "features-python-minimal"
+        "features-cuda",
+        "features-filesystems",
+        "features-flight",
+        "features-gandiva",
+        "features-main",
+        "features-python-minimal"
       ],
       "hidden": true,
       "cacheVariables": {
@@ -183,10 +183,12 @@
         "PARQUET_REQUIRE_ENCRYPTION": "ON"
       }
     },
-
     {
       "name": "ninja-debug-minimal",
-      "inherits": ["base-debug", "features-minimal"],
+      "inherits": [
+        "base-debug",
+        "features-minimal"
+      ],
       "displayName": "Debug build without anything enabled",
       "cacheVariables": {
         "ARROW_BUILD_INTEGRATION": "OFF",
@@ -195,136 +197,209 @@
     },
     {
       "name": "ninja-debug-basic",
-      "inherits": ["base-debug", "features-basic"],
+      "inherits": [
+        "base-debug",
+        "features-basic"
+      ],
       "displayName": "Debug build with tests and reduced dependencies",
       "cacheVariables": {}
     },
     {
       "name": "ninja-debug",
-      "inherits": ["base-debug", "features-main"],
+      "inherits": [
+        "base-debug",
+        "features-main"
+      ],
       "displayName": "Debug build with tests and more optional components",
       "cacheVariables": {}
     },
     {
       "name": "ninja-debug-cuda",
-      "inherits": ["base-debug", "features-cuda"],
+      "inherits": [
+        "base-debug",
+        "features-cuda"
+      ],
       "displayName": "Debug build with tests and CUDA integration",
       "cacheVariables": {}
     },
     {
       "name": "ninja-debug-filesystems",
-      "inherits": ["base-debug", "features-filesystems"],
+      "inherits": [
+        "base-debug",
+        "features-filesystems"
+      ],
       "displayName": "Debug build with tests and filesystems",
       "cacheVariables": {}
     },
     {
       "name": "ninja-debug-flight",
-      "inherits": ["base-debug", "features-flight"],
+      "inherits": [
+        "base-debug",
+        "features-flight"
+      ],
       "displayName": "Debug build with tests and Flight",
       "cacheVariables": {}
     },
     {
       "name": "ninja-debug-gandiva",
-      "inherits": ["base-debug", "features-gandiva"],
+      "inherits": [
+        "base-debug",
+        "features-gandiva"
+      ],
       "displayName": "Debug build with tests and Gandiva",
       "cacheVariables": {}
     },
     {
       "name": "ninja-debug-python-minimal",
-      "inherits": ["base-debug", "features-python-minimal"],
+      "inherits": [
+        "base-debug",
+        "features-python-minimal"
+      ],
       "displayName": "Debug build for PyArrow with minimal features",
       "cacheVariables": {}
     },
     {
       "name": "ninja-debug-python",
-      "inherits": ["base-debug", "features-python"],
+      "inherits": [
+        "base-debug",
+        "features-python"
+      ],
       "displayName": "Debug build for PyArrow with common features (for backward compatibility)",
       "cacheVariables": {}
     },
     {
       "name": "ninja-debug-python-maximal",
-      "inherits": ["base-debug", "features-python-maximal"],
-      "displayName": "Debug build for PyArrow with everything enabled (except CUDA)",
+      "inherits": [
+        "base-debug",
+        "features-python-maximal"
+      ],
+      "displayName": "Debug build for PyArrow with everything enabled",
       "cacheVariables": {}
     },
     {
       "name": "ninja-debug-maximal",
-      "inherits": ["base-debug", "features-maximal"],
-      "displayName": "Debug build with everything enabled (except benchmarks and CUDA)",
+      "inherits": [
+        "base-debug",
+        "features-maximal"
+      ],
+      "displayName": "Debug build with everything enabled (except benchmarks)",
       "cacheVariables": {}
     },
-
     {
       "name": "ninja-release-minimal",
-      "inherits": ["base-release", "features-minimal"],
+      "inherits": [
+        "base-release",
+        "features-minimal"
+      ],
       "displayName": "Release build without anything enabled",
       "cacheVariables": {}
     },
     {
       "name": "ninja-release-basic",
-      "inherits": ["base-release", "features-basic"],
+      "inherits": [
+        "base-release",
+        "features-basic"
+      ],
       "displayName": "Release build with reduced dependencies",
       "cacheVariables": {}
     },
     {
       "name": "ninja-release",
-      "inherits": ["base-release", "features-main"],
+      "inherits": [
+        "base-release",
+        "features-main"
+      ],
       "displayName": "Release build with more optional components",
       "cacheVariables": {}
     },
     {
       "name": "ninja-release-cuda",
-      "inherits": ["base-release", "features-cuda"],
+      "inherits": [
+        "base-release",
+        "features-cuda"
+      ],
       "displayName": "Release build with CUDA integration",
       "cacheVariables": {}
     },
     {
       "name": "ninja-release-flight",
-      "inherits": ["base-release", "features-flight"],
+      "inherits": [
+        "base-release",
+        "features-flight"
+      ],
       "displayName": "Release build with Flight",
       "cacheVariables": {}
     },
     {
       "name": "ninja-release-gandiva",
-      "inherits": ["base-release", "features-gandiva"],
+      "inherits": [
+        "base-release",
+        "features-gandiva"
+      ],
       "displayName": "Release build with Gandiva",
       "cacheVariables": {}
     },
     {
       "name": "ninja-release-python-minimal",
-      "inherits": ["base-release", "features-python-minimal"],
+      "inherits": [
+        "base-release",
+        "features-python-minimal"
+      ],
       "displayName": "Release build for PyArrow with minimal features",
       "cacheVariables": {}
     },
     {
       "name": "ninja-release-python",
-      "inherits": ["base-release", "features-python"],
+      "inherits": [
+        "base-release",
+        "features-python"
+      ],
       "displayName": "Release build for PyArrow with common features (for backward compatibility)",
       "cacheVariables": {}
     },
     {
       "name": "ninja-release-python-maximal",
-      "inherits": ["base-release", "features-python-maximal"],
-      "displayName": "Release build for PyArrow with everything enabled (except CUDA)",
+      "inherits": [
+        "base-release",
+        "features-python-maximal"
+      ],
+      "displayName": "Release build for PyArrow with everything enabled",
       "cacheVariables": {}
     },
     {
       "name": "ninja-release-maximal",
-      "inherits": ["base-release", "features-maximal"],
-      "displayName": "Release build with everything enabled (except benchmarks and CUDA)",
+      "inherits": [
+        "base-release",
+        "features-maximal"
+      ],
+      "displayName": "Release build with everything enabled (except benchmarks)",
       "cacheVariables": {}
     },
-
     {
       "name": "ninja-benchmarks-basic",
-      "inherits": ["base-benchmarks", "features-basic"],
+      "inherits": [
+        "base-benchmarks",
+        "features-basic"
+      ],
       "displayName": "Benchmarking build with reduced dependencies",
       "cacheVariables": {}
     },
     {
       "name": "ninja-benchmarks",
-      "inherits": ["base-benchmarks", "features-main"],
+      "inherits": [
+        "base-benchmarks",
+        "features-main"
+      ],
       "displayName": "Benchmarking build with more optional components",
+      "cacheVariables": {}
+    },
+    {
+      "name": "ninja-benchmarks-maximal",
+      "inherits": [
+        "base-benchmarks",
+        "features-maximal"
+      ],
+      "displayName": "Benchmarking build with with everything enabled",
       "cacheVariables": {}
     }
   ]

--- a/cpp/src/arrow/compute/exec/hash_join_benchmark.cc
+++ b/cpp/src/arrow/compute/exec/hash_join_benchmark.cc
@@ -160,7 +160,8 @@ class JoinBenchmark {
         &ctx_, settings.join_type, settings.num_threads, &(schema_mgr_->proj_maps[0]),
         &(schema_mgr_->proj_maps[1]), std::move(key_cmp), std::move(filter),
         std::move(register_task_group_callback), std::move(start_task_group_callback),
-        [](int64_t, ExecBatch) {}, [](int64_t x) {}));
+        [](int64_t, ExecBatch) { return Status::OK(); },
+        [](int64_t) { return Status::OK(); }));
 
     task_group_probe_ = scheduler_->RegisterTaskGroup(
         [this](size_t thread_index, int64_t task_id) -> Status {

--- a/cpp/src/arrow/compute/exec/hash_join_benchmark.cc
+++ b/cpp/src/arrow/compute/exec/hash_join_benchmark.cc
@@ -160,8 +160,7 @@ class JoinBenchmark {
         &ctx_, settings.join_type, settings.num_threads, &(schema_mgr_->proj_maps[0]),
         &(schema_mgr_->proj_maps[1]), std::move(key_cmp), std::move(filter),
         std::move(register_task_group_callback), std::move(start_task_group_callback),
-        [](int64_t, ExecBatch) { return Status::OK(); },
-        [](int64_t) { return Status::OK(); }));
+        [](int64_t, ExecBatch) {}, [](int64_t x) {}));
 
     task_group_probe_ = scheduler_->RegisterTaskGroup(
         [this](size_t thread_index, int64_t task_id) -> Status {


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/master/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Add a benchmarks-maximal CMake preset to benchmark all components or to test the compilation of all benchmark files.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Along with the new preset, also

1. Fixed indentation of the json file.
2. The "maximal" presets actually include CUDA, so I fixed their display names.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

The preset works locally on my machine.

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->

No.
* Closes: #34004