### PR TITLE
GH-34003: [C++] AddWithOverflow and friends should be [[nodiscard]]

### DIFF
--- a/cpp/src/arrow/util/int_util_overflow.h
+++ b/cpp/src/arrow/util/int_util_overflow.h
@@ -40,9 +40,9 @@ namespace internal {
 // On overflow, these functions return true.  Otherwise, false is returned
 // and `out` is updated with the result of the operation.
 
-#define OP_WITH_OVERFLOW(_func_name, _psnip_op, _type, _psnip_type) \
-  static inline bool _func_name(_type u, _type v, _type* out) {     \
-    return !psnip_safe_##_psnip_type##_##_psnip_op(out, u, v);      \
+#define OP_WITH_OVERFLOW(_func_name, _psnip_op, _type, _psnip_type)           \
+  [[nodiscard]] static inline bool _func_name(_type u, _type v, _type* out) { \
+    return !psnip_safe_##_psnip_type##_##_psnip_op(out, u, v);                \
   }
 
 #define OPS_WITH_OVERFLOW(_func_name, _psnip_op)            \
@@ -69,7 +69,7 @@ OPS_WITH_OVERFLOW(DivideWithOverflow, div)
 // operation.
 
 #define UNARY_OP_WITH_OVERFLOW(_func_name, _psnip_op, _type, _psnip_type) \
-  static inline bool _func_name(_type u, _type* out) {                    \
+  [[nodiscard]] static inline bool _func_name(_type u, _type* out) {      \
     return !psnip_safe_##_psnip_type##_##_psnip_op(out, u);               \
   }
 


### PR DESCRIPTION
### Rationale for this change

Enforce checking return values of the arithmetic operations in case of overflow.

### What changes are included in this PR?

Add `[[nodiscard]]` attribute to those functions.

### Are these changes tested?

Make sure all tests pass.

### Are there any user-facing changes?

No.
* Closes: #34003