### PR TITLE
GH-33904: [R] improve behavior of s3_bucket - work-around

### DIFF
--- a/r/R/filesystem.R
+++ b/r/R/filesystem.R
@@ -462,8 +462,8 @@ s3_bucket <- function(bucket, ...) {
   if (!is_url(bucket)) {
     bucket <- paste0("s3://", bucket)
   }
-  
-  if (!length(args)) {  
+
+  if (!length(args)) {
     fs_and_path <- FileSystem$from_uri(bucket)
     fs <- fs_and_path$fs
   } else {

--- a/r/R/filesystem.R
+++ b/r/R/filesystem.R
@@ -458,19 +458,20 @@ s3_bucket <- function(bucket, ...) {
   assert_that(is.string(bucket))
   args <- list2(...)
 
-  # Use FileSystemFromUri to detect the bucket's region
-  if (!is_url(bucket)) {
-    bucket <- paste0("s3://", bucket)
-  }
+  # If user specifies args, they must specify region as arg, env var, or config
+  if (length(args) == 0) {
+    # Use FileSystemFromUri to detect the bucket's region
+    if (!is_url(bucket)) {
+      bucket <- paste0("s3://", bucket)
+    }
 
-  if (!length(args)) {
     fs_and_path <- FileSystem$from_uri(bucket)
     fs <- fs_and_path$fs
   } else {
-  # If there are no additional S3Options, we can use that filesystem
-  # If user specifies args, they must specify region as arg, env var, or config
+    # If there are no additional S3Options, we can use that filesystem
     fs <- exec(S3FileSystem$create, !!!args)
   }
+
   # Return a subtree pointing at that bucket path
   SubTreeFileSystem$create(bucket, fs)
 }

--- a/r/R/filesystem.R
+++ b/r/R/filesystem.R
@@ -462,12 +462,13 @@ s3_bucket <- function(bucket, ...) {
   if (!is_url(bucket)) {
     bucket <- paste0("s3://", bucket)
   }
-  fs_and_path <- FileSystem$from_uri(bucket)
-  fs <- fs_and_path$fs
+  
+  if (!length(args)) {  
+    fs_and_path <- FileSystem$from_uri(bucket)
+    fs <- fs_and_path$fs
+  } else {
   # If there are no additional S3Options, we can use that filesystem
-  # Otherwise, take the region that was detected and make a new fs with the args
-  if (length(args)) {
-    args$region <- fs$region
+  # If user specifies args, they must specify region as arg, env var, or config
     fs <- exec(S3FileSystem$create, !!!args)
   }
   # Return a subtree pointing at that bucket path

--- a/r/R/filesystem.R
+++ b/r/R/filesystem.R
@@ -472,7 +472,7 @@ s3_bucket <- function(bucket, ...) {
     fs <- exec(S3FileSystem$create, !!!args)
   }
   # Return a subtree pointing at that bucket path
-  SubTreeFileSystem$create(fs_and_path$path, fs)
+  SubTreeFileSystem$create(bucket, fs)
 }
 
 #' Connect to a Google Cloud Storage (GCS) bucket

--- a/r/tests/testthat/test-s3-minio.R
+++ b/r/tests/testthat/test-s3-minio.R
@@ -62,7 +62,9 @@ fs$CreateDir(now)
 withr::defer(fs$DeleteDir(now))
 
 test_that("Confirm s3_bucket works with endpoint_override", {
-  bucket <- s3_bucket(now, endpoint_override = paste0("localhost:", minio_port))
+  
+  
+  bucket <- s3_bucket("test", endpoint_override = "https://play.min.io")
   expect_r6_class(bucket, "SubTreeFileSystem")
 })
 

--- a/r/tests/testthat/test-s3-minio.R
+++ b/r/tests/testthat/test-s3-minio.R
@@ -61,6 +61,11 @@ fs$CreateDir(now)
 # Clean up when we're all done
 withr::defer(fs$DeleteDir(now))
 
+test_that("Confirm s3_bucket works with endpoint_override", {
+  bucket <- s3_bucket(now, endpoint_override = paste0("localhost:", minio_port))
+  expect_r6_class(bucket, "SubTreeFileSystem")
+})
+
 test_filesystem("s3", fs, minio_path, minio_uri)
 
 test_that("CreateDir fails on bucket if allow_bucket_creation=False", {


### PR DESCRIPTION
I think this is another option to address #33918.

This retains the existing behavior when no additional arguments (region, endpoint, etc) are supplied.  

If any optional arguments are supplied, this approach will by-pass the `$from_uri` call.  I think this is reasonable, given that the `from_uri()` call is implicitly ignoring optional arguments already, which is giving rise to the current bugs.  


* Closes: #33904