### PR TITLE
GH-33920: [C++][CI] Disable Flight SQL in sanitizer job

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -3997,6 +3997,13 @@ if(ARROW_WITH_GRPC)
     else()
       message(FATAL_ERROR "Cannot find grpc++ headers in ${GRPC_INCLUDE_DIR}")
     endif()
+    if(ARROW_USE_ASAN)
+      # Disable ASAN in system gRPC.
+      add_library(gRPC::grpc_asan_suppressed INTERFACE IMPORTED)
+      target_compile_definitions(gRPC::grpc_asan_suppressed
+                                 INTERFACE "GRPC_ASAN_SUPPRESSED")
+      target_link_libraries(gRPC::grpc++ INTERFACE gRPC::grpc_asan_suppressed)
+    endif()
   endif()
 endif()
 

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -1649,8 +1649,8 @@ macro(build_protobuf)
 endmacro()
 
 if(ARROW_WITH_PROTOBUF)
-  if(ARROW_WITH_GRPC)
-    # FlightSQL uses proto3 optionals, which require 3.15 or later.
+  if(ARROW_FLIGHT_SQL)
+    # Flight SQL uses proto3 optionals, which require 3.15 or later.
     set(ARROW_PROTOBUF_REQUIRED_VERSION "3.15.0")
   elseif(ARROW_SUBSTRAIT)
     # Substrait protobuf files use proto3 syntax

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -521,7 +521,7 @@ services:
     #   docker-compose run --rm ubuntu-cpp-sanitizer
     # Parameters:
     #   ARCH: amd64, arm64v8, ...
-    #   UBUNTU: 18.04, 20.04, 22.04
+    #   UBUNTU: 22.04, ...
     image: ${REPO}:${ARCH}-ubuntu-${UBUNTU}-cpp
     cap_add:
       # For LeakSanitizer
@@ -542,14 +542,18 @@ services:
       CC: clang-${CLANG_TOOLS}
       CXX: clang++-${CLANG_TOOLS}
       ARROW_ENABLE_TIMING_TESTS:  # inherit
+      # GH-33920: Disable Flight SQL to reduce build time.
+      # We'll be able to re-enable this with Ubuntu 24.04 because
+      # Ubuntu 24.04 will ship ProtoBuf 3.15.0 or later that is required
+      # by Flight SQL.
+      ARROW_FLIGHT_SQL: "OFF"
       ARROW_FUZZING: "ON"  # Check fuzz regressions
       ARROW_JEMALLOC: "OFF"
       ARROW_ORC: "OFF"
       ARROW_S3: "OFF"
       ARROW_USE_ASAN: "ON"
       ARROW_USE_UBSAN: "ON"
-      # utf8proc 2.1.0 in Ubuntu Bionic has test failures
-      utf8proc_SOURCE: "BUNDLED"
+      Protobuf_SOURCE: "AUTO"
     command: *cpp-command
 
   ubuntu-cpp-thread-sanitizer:


### PR DESCRIPTION
### Rationale for this change

We want to reduce CI time.

### What changes are included in this PR?

This disables Flight SQL to use system gRPC and ProtoBuf.
We can reduce build time by avoiding bundled gRPC and ProtoBuf.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #33920