### PR TITLE
GH-33882: [C++] Don't find .pc files with ARROW_BUILD_STATIC=OFF

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -287,22 +287,24 @@ macro(resolve_dependency DEPENDENCY_NAME)
   if(${DEPENDENCY_NAME}_SOURCE STREQUAL "SYSTEM" AND ARG_IS_RUNTIME_DEPENDENCY)
     provide_find_module(${PACKAGE_NAME} "Arrow")
     list(APPEND ARROW_SYSTEM_DEPENDENCIES ${PACKAGE_NAME})
-    find_package(PkgConfig QUIET)
-    foreach(ARG_PC_PACKAGE_NAME ${ARG_PC_PACKAGE_NAMES})
-      pkg_check_modules(${ARG_PC_PACKAGE_NAME}_PC
-                        ${ARG_PC_PACKAGE_NAME}
-                        NO_CMAKE_PATH
-                        NO_CMAKE_ENVIRONMENT_PATH
-                        QUIET)
-      if(${${ARG_PC_PACKAGE_NAME}_PC_FOUND})
-        message(STATUS "Using pkg-config package for ${ARG_PC_PACKAGE_NAME} for static link"
-        )
-        string(APPEND ARROW_PC_REQUIRES_PRIVATE " ${ARG_PC_PACKAGE_NAME}")
-      else()
-        message(STATUS "pkg-config package for ${ARG_PC_PACKAGE_NAME} for static link isn't found"
-        )
-      endif()
-    endforeach()
+    if(ARROW_BUILD_STATIC)
+      find_package(PkgConfig QUIET)
+      foreach(ARG_PC_PACKAGE_NAME ${ARG_PC_PACKAGE_NAMES})
+        pkg_check_modules(${ARG_PC_PACKAGE_NAME}_PC
+                          ${ARG_PC_PACKAGE_NAME}
+                          NO_CMAKE_PATH
+                          NO_CMAKE_ENVIRONMENT_PATH
+                          QUIET)
+        if(${${ARG_PC_PACKAGE_NAME}_PC_FOUND})
+          message(STATUS "Using pkg-config package for ${ARG_PC_PACKAGE_NAME} for static link"
+          )
+          string(APPEND ARROW_PC_REQUIRES_PRIVATE " ${ARG_PC_PACKAGE_NAME}")
+        else()
+          message(STATUS "pkg-config package for ${ARG_PC_PACKAGE_NAME} for static link isn't found"
+          )
+        endif()
+      endforeach()
+    endif()
   endif()
 endmacro()
 
@@ -1189,21 +1191,12 @@ if(ARROW_WITH_SNAPPY)
                      TRUE
                      PC_PACKAGE_NAMES
                      snappy)
-  if(${Snappy_SOURCE} STREQUAL "SYSTEM" AND NOT snappy_PC_FOUND)
+  if(${Snappy_SOURCE} STREQUAL "SYSTEM"
+     AND NOT snappy_PC_FOUND
+     AND ARROW_BUILD_STATIC)
     get_target_property(SNAPPY_TYPE ${Snappy_TARGET} TYPE)
     if(NOT SNAPPY_TYPE STREQUAL "INTERFACE_LIBRARY")
-      get_target_property(SNAPPY_LIB ${Snappy_TARGET}
-                          IMPORTED_LOCATION_${UPPERCASE_BUILD_TYPE})
-      if(NOT SNAPPY_LIB)
-        get_target_property(SNAPPY_LIB ${Snappy_TARGET} IMPORTED_LOCATION_RELEASE)
-      endif()
-      if(NOT SNAPPY_LIB)
-        get_target_property(SNAPPY_LIB ${Snappy_TARGET} IMPORTED_LOCATION_NOCONFIG)
-      endif()
-      if(NOT SNAPPY_LIB)
-        get_target_property(SNAPPY_LIB ${Snappy_TARGET} IMPORTED_LOCATION)
-      endif()
-      string(APPEND ARROW_PC_LIBS_PRIVATE " ${SNAPPY_LIB}")
+      string(APPEND ARROW_PC_LIBS_PRIVATE " $<TARGET_FILE:${Snappy_TARGET}>")
     endif()
   endif()
 endif()
@@ -2529,17 +2522,10 @@ if(ARROW_WITH_RE2)
   # include -std=c++11. It's not compatible with C source and C++
   # source not uses C++ 11.
   resolve_dependency(re2 HAVE_ALT TRUE)
-  if(${re2_SOURCE} STREQUAL "SYSTEM")
+  if(${re2_SOURCE} STREQUAL "SYSTEM" AND ARROW_BUILD_STATIC)
     get_target_property(RE2_TYPE re2::re2 TYPE)
     if(NOT RE2_TYPE STREQUAL "INTERFACE_LIBRARY")
-      get_target_property(RE2_LIB re2::re2 IMPORTED_LOCATION_${UPPERCASE_BUILD_TYPE})
-      if(NOT RE2_LIB)
-        get_target_property(RE2_LIB re2::re2 IMPORTED_LOCATION_RELEASE)
-      endif()
-      if(NOT RE2_LIB)
-        get_target_property(RE2_LIB re2::re2 IMPORTED_LOCATION)
-      endif()
-      string(APPEND ARROW_PC_LIBS_PRIVATE " ${RE2_LIB}")
+      string(APPEND ARROW_PC_LIBS_PRIVATE " $<TARGET_FILE:re2::re2>")
     endif()
   endif()
   add_definitions(-DARROW_WITH_RE2)
@@ -2603,7 +2589,9 @@ if(ARROW_WITH_BZ2)
                                      INTERFACE_INCLUDE_DIRECTORIES "${BZIP2_INCLUDE_DIR}")
   endif()
 
-  if(${BZip2_SOURCE} STREQUAL "SYSTEM" AND NOT bzip2_PC_FOUND)
+  if(${BZip2_SOURCE} STREQUAL "SYSTEM"
+     AND NOT bzip2_PC_FOUND
+     AND ARROW_BUILD_STATIC)
     get_target_property(BZIP2_TYPE BZip2::BZip2 TYPE)
     if(BZIP2_TYPE STREQUAL "INTERFACE_LIBRARY")
       # Conan
@@ -4798,15 +4786,17 @@ if(ARROW_S3)
   message(STATUS "Found AWS SDK headers: ${AWSSDK_INCLUDE_DIR}")
   message(STATUS "Found AWS SDK libraries: ${AWSSDK_LINK_LIBRARIES}")
 
-  if(${AWSSDK_SOURCE} STREQUAL "SYSTEM")
-    foreach(AWSSDK_LINK_LIBRARY ${AWSSDK_LINK_LIBRARIES})
-      string(APPEND ARROW_PC_LIBS_PRIVATE " $<TARGET_FILE:${AWSSDK_LINK_LIBRARY}>")
-    endforeach()
+  if(ARROW_BUILD_STATIC)
+    if(${AWSSDK_SOURCE} STREQUAL "SYSTEM")
+      foreach(AWSSDK_LINK_LIBRARY ${AWSSDK_LINK_LIBRARIES})
+        string(APPEND ARROW_PC_LIBS_PRIVATE " $<TARGET_FILE:${AWSSDK_LINK_LIBRARY}>")
+      endforeach()
+    endif()
+    if(UNIX)
+      string(APPEND ARROW_PC_REQUIRES_PRIVATE " libcurl")
+    endif()
+    string(APPEND ARROW_PC_REQUIRES_PRIVATE " openssl")
   endif()
-  if(UNIX)
-    string(APPEND ARROW_PC_REQUIRES_PRIVATE " libcurl")
-  endif()
-  string(APPEND ARROW_PC_REQUIRES_PRIVATE " openssl")
 
   if(APPLE)
     # CoreFoundation's path is hardcoded in the CMake files provided by


### PR DESCRIPTION
### Rationale for this change

Because they are needless and `pkg-config grpc++` is slow.

### What changes are included in this PR?

Don't find .pc files with `ARROW_BUILD_STATIC=OFF`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #33882