### PR TITLE
GH-34011: [Doc] Ensure substrait is enabled on complete doc build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1643,6 +1643,7 @@ services:
       <<: *ccache
       ARROW_JAVA_SKIP_GIT_PLUGIN:
       ARROW_CUDA: "ON"
+      ARROW_SUBSTRAIT: "ON"
       BUILD_DOCS_C_GLIB: "ON"
       BUILD_DOCS_CPP: "ON"
       BUILD_DOCS_JAVA: "ON"


### PR DESCRIPTION
Follow-up on https://github.com/apache/arrow/pull/34012#issuecomment-1415572411 to ensure that the substrait module is also built on the "Complete Documentation" CI build, and not only on the Python docs build.
* Closes: #34011