### PR TITLE
MINOR: [Docs] Add note about service specific parameters to JDBC driver docs

### DIFF
--- a/docs/source/java/flight_sql_jdbc_driver.rst
+++ b/docs/source/java/flight_sql_jdbc_driver.rst
@@ -126,3 +126,12 @@ parameters are:
    * - useSystemTrustStore
      - true
      - When TLS is enabled, whether to use the system certificate store
+
+Any URI parameters that are not handled by the driver are passed to
+the Flight SQL service as gRPC headers. For example, the following URI ::
+
+  jdbc:arrow-flight-sql://localhost:12345/?useEncryption=0&database=mydb
+
+This will connect without authentication or encryption, to a Flight
+SQL service running on ``localhost`` on port 12345. Each request will
+also include a `database=mydb` gRPC header.


### PR DESCRIPTION

### Rationale for this change

While implementing Flight SQL for https://github.com/influxdata/influxdb_iox, it took me a while to realize we could pass the equivalent of our "catalog name" via a JDBC URL parameter. It turns out it works great!

This was also not clear to me when contributing to the mailing list discussion on catalog support either https://lists.apache.org/thread/fd6r1n7vt91sg2c7fr35wcrsqz6x4645

### What changes are included in this PR?

1. Add a paragraph and example adding custom parameters to the JDBC docs at https://arrow.apache.org/docs/java/flight_sql_jdbc_driver.html
 
### Are these changes tested?
Doc changes only

### Are there any user-facing changes?
Doc changes
