### PR TITLE
GH-34027: [C++][Release] Port required patches to build vcpkg

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2652,11 +2652,15 @@ macro(build_utf8proc)
 endmacro()
 
 if(ARROW_WITH_UTF8PROC)
-  resolve_dependency(utf8proc
-                     REQUIRED_VERSION
-                     "2.2.0"
-                     PC_PACKAGE_NAMES
-                     libutf8proc)
+  if(ARROW_PACKAGE_KIND STREQUAL "vcpkg")
+    # We can't specify required version because vcpkg's
+    # unofficial-utf8proc CMake package doesn't provide version
+    # information.
+    set(utf8proc_required_version "")
+  else()
+    set(utf8proc_required_version REQUIRED_VERSION "2.2.0")
+  endif()
+  resolve_dependency(utf8proc ${utf8proc_required_version} PC_PACKAGE_NAMES libutf8proc)
   add_definitions(-DARROW_WITH_UTF8PROC)
 endif()
 


### PR DESCRIPTION
### Rationale for this change

Building vcpkg for Arrow 11.0.0 raised a couple of issues with `utf8_proc` and `thrift`. Required to bring the required changes to the main repo.

### What changes are included in this PR?

CMake changes to be able to build on vcpkg. 

### Are these changes tested?

Yes on vcpkg build
* Closes: #34027