### PR TITLE
GH-33709: [R] Remove suffix argument from semi_join and anti_join

### DIFF
--- a/r/R/dplyr-join.R
+++ b/r/R/dplyr-join.R
@@ -116,9 +116,8 @@ semi_join.arrow_dplyr_query <- function(x,
                                         y,
                                         by = NULL,
                                         copy = FALSE,
-                                        suffix = c(".x", ".y"),
                                         ...) {
-  do_join(x, y, by, copy, suffix, ..., join_type = "LEFT_SEMI")
+  do_join(x, y, by, copy, suffix = c(".x", ".y"), ..., join_type = "LEFT_SEMI")
 }
 semi_join.Dataset <- semi_join.ArrowTabular <- semi_join.RecordBatchReader <- semi_join.arrow_dplyr_query
 
@@ -126,9 +125,8 @@ anti_join.arrow_dplyr_query <- function(x,
                                         y,
                                         by = NULL,
                                         copy = FALSE,
-                                        suffix = c(".x", ".y"),
                                         ...) {
-  do_join(x, y, by, copy, suffix, ..., join_type = "LEFT_ANTI")
+  do_join(x, y, by, copy, suffix = c(".x", ".y"), ..., join_type = "LEFT_ANTI")
 }
 anti_join.Dataset <- anti_join.ArrowTabular <- anti_join.RecordBatchReader <- anti_join.arrow_dplyr_query
 

--- a/r/man/arrow-package.Rd
+++ b/r/man/arrow-package.Rd
@@ -13,7 +13,7 @@ Useful links:
 \itemize{
   \item \url{https://github.com/apache/arrow/}
   \item \url{https://arrow.apache.org/docs/r/}
-  \item Report bugs at \url{https://issues.apache.org/jira/projects/ARROW/issues}
+  \item Report bugs at \url{https://github.com/apache/arrow/issues}
 }
 
 }


### PR DESCRIPTION
The function signatures for `semi_join()` and `anti_join()` don't match those of dplyr.  This PR removes the argument `suffix` from `anti_join()` and `semi_join()`. Is this change necessary/useful or just pedantic? Unsure.

* Closes: #33709