### PR TITLE
GH-34037: [Python][Docs] Fix Table.drop docstring

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -4736,19 +4736,11 @@ cdef class Table(_PandasConvertible):
         columns : str or list[str]
             Field name(s) referencing existing column(s).
 
-        Raises
-        ------
-        KeyError
-            If any of the passed column names do not exist.
-
         Returns
         -------
         Table
             New table without the column(s).
         """
-        import warnings
-        warnings.warn(
-            'Table.drop is deprecated, use Table.drop_columns', FutureWarning)
         return self.drop_columns(columns)
 
     def group_by(self, keys):

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -4726,7 +4726,29 @@ cdef class Table(_PandasConvertible):
         return table
 
     def drop(self, columns):
-        """Alias of Table.drop_columns, but kept for backwards compatibility."""
+        """
+        Drop one or more columns and return a new table.
+
+        Alias of Table.drop_columns, but kept for backwards compatibility.
+
+        Parameters
+        ----------
+        columns : str or list[str]
+            Field name(s) referencing existing column(s).
+
+        Raises
+        ------
+        KeyError
+            If any of the passed column names do not exist.
+
+        Returns
+        -------
+        Table
+            New table without the column(s).
+        """
+        import warnings
+        warnings.warn(
+            'Table.drop is deprecated, use Table.drop_columns', FutureWarning)
         return self.drop_columns(columns)
 
     def group_by(self, keys):

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -2297,9 +2297,3 @@ def test_record_batch_sort():
     assert sorted_rb_dict["a"] == [5, 7, 7, 35]
     assert sorted_rb_dict["b"] == [2, 3, 4, 1]
     assert sorted_rb_dict["c"] == ["foobar", "bar", "foo", "car"]
-
-
-def test_drop_deprecated():
-    table = pa.table([pa.array([1, 2, 3, 4])], names=['a'])
-    with pytest.warns(FutureWarning):
-        table.drop(['a'])

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -2297,3 +2297,9 @@ def test_record_batch_sort():
     assert sorted_rb_dict["a"] == [5, 7, 7, 35]
     assert sorted_rb_dict["b"] == [2, 3, 4, 1]
     assert sorted_rb_dict["c"] == ["foobar", "bar", "foo", "car"]
+
+
+def test_drop_deprecated():
+    table = pa.table([pa.array([1, 2, 3, 4])], names=['a'])
+    with pytest.warns(FutureWarning):
+        table.drop(['a'])


### PR DESCRIPTION
It throws errors in the CI, while I was working on other docstrings:

```
pyarrow.lib.Table.drop
-> pyarrow.lib.Table.drop(self, columns)
PR01: Parameters {'columns'} not documented

pyarrow.lib.Table.drop
-> pyarrow.lib.Table.drop(self, columns)
PR01: Parameters {'columns'} not documented

pyarrow.lib.Table.drop
-> pyarrow.lib.Table.drop(self, columns)
PR01: Parameters {'columns'} not documented

Total number of docstring violations: 3
```


<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/master/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #34037