### PR TITLE
GH-34044: [Go] Fix build with noasm tag

### DIFF
--- a/go/arrow/compute/internal/kernels/basic_arithmetic_noasm.go
+++ b/go/arrow/compute/internal/kernels/basic_arithmetic_noasm.go
@@ -24,13 +24,9 @@ import (
 )
 
 func getArithmeticOpFloating[InT, OutT constraints.Float](op ArithmeticOp) exec.ArrayKernelExec {
-	return getGoArithmeticOpFloatingSameType[InT, OutT](op)
+	return getGoArithmeticOpFloating[InT, OutT](op)
 }
 
 func getArithmeticOpIntegral[InT, OutT exec.UintTypes | exec.IntTypes](op ArithmeticOp) exec.ArrayKernelExec {
 	return getGoArithmeticOpIntegral[InT, OutT](op)
-}
-
-func getArithmeticUnaryFixedIntOut[InT exec.NumericTypes, OutT exec.IntTypes](op ArithmeticOp) exec.ArrayKernelExec {
-	return getGoArithmeticFixedIntOut[InT, OutT](op)
 }


### PR DESCRIPTION
Fix the following build failure.

    $ go build -tags noasm ./...
    # github.com/apache/arrow/go/v12/arrow/compute/internal/kernels
    arrow/compute/internal/kernels/basic_arithmetic_noasm.go:27:9: undefined: getGoArithmeticOpFloatingSameType
    arrow/compute/internal/kernels/basic_arithmetic_noasm.go:35:9: undefined: getGoArithmeticFixedIntOut

Closes #34044.