### PR TITLE
GH-34053: [C++][Parquet] Write parquet page index

### DIFF
--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -5202,7 +5202,7 @@ TEST(TestArrowReadWrite, WriteReadPageIndexRoundTrip) {
   auto page_index_reader = reader->GetPageIndexReader();
   ASSERT_NE(page_index_reader, nullptr);
 
-  auto encode_int64 = [=](int64_t value) {
+  auto encode_int64 = [](int64_t value) {
     return std::string(reinterpret_cast<const char*>(&value), sizeof(int64_t));
   };
 
@@ -5379,7 +5379,7 @@ TEST(TestArrowReadWrite, WriteReadPageIndexRoundTripWithMultiplePages) {
   ASSERT_NE(row_group_index_reader, nullptr);
 
   // Setup expected data.
-  auto encode_int64 = [=](int64_t value) {
+  auto encode_int64 = [](int64_t value) {
     return std::string(reinterpret_cast<const char*>(&value), sizeof(int64_t));
   };
   const std::vector<std::string> c0_min_values = {encode_int64(1), encode_int64(3),
@@ -5476,7 +5476,7 @@ TEST(TestArrowReadWrite, WriteReadPageIndexRoundTripWithNaNs) {
   ASSERT_NE(page_index_reader, nullptr);
 
   // Set up expected values.
-  auto encode = [=](double value) {
+  auto encode = [](double value) {
     return std::string(reinterpret_cast<const char*>(&value), sizeof(double));
   };
   const std::vector<std::string> min_values = {encode(0.1), encode(-0.0), encode(-0.0)};

--- a/cpp/src/parquet/column_page.h
+++ b/cpp/src/parquet/column_page.h
@@ -23,6 +23,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "parquet/statistics.h"
@@ -64,23 +65,28 @@ class DataPage : public Page {
   Encoding::type encoding() const { return encoding_; }
   int64_t uncompressed_size() const { return uncompressed_size_; }
   const EncodedStatistics& statistics() const { return statistics_; }
+  std::optional<int64_t> first_row_index() const { return first_row_index_; }
 
   virtual ~DataPage() = default;
 
  protected:
   DataPage(PageType::type type, const std::shared_ptr<Buffer>& buffer, int32_t num_values,
            Encoding::type encoding, int64_t uncompressed_size,
-           const EncodedStatistics& statistics = EncodedStatistics())
+           const EncodedStatistics& statistics = EncodedStatistics(),
+           std::optional<int64_t> first_row_index = std::nullopt)
       : Page(buffer, type),
         num_values_(num_values),
         encoding_(encoding),
         uncompressed_size_(uncompressed_size),
-        statistics_(statistics) {}
+        statistics_(statistics),
+        first_row_index_(std::move(first_row_index)) {}
 
   int32_t num_values_;
   Encoding::type encoding_;
   int64_t uncompressed_size_;
   EncodedStatistics statistics_;
+  /// Row ordinal within the row group to the first row in the data page.
+  std::optional<int64_t> first_row_index_;
 };
 
 class DataPageV1 : public DataPage {
@@ -88,9 +94,10 @@ class DataPageV1 : public DataPage {
   DataPageV1(const std::shared_ptr<Buffer>& buffer, int32_t num_values,
              Encoding::type encoding, Encoding::type definition_level_encoding,
              Encoding::type repetition_level_encoding, int64_t uncompressed_size,
-             const EncodedStatistics& statistics = EncodedStatistics())
+             const EncodedStatistics& statistics = EncodedStatistics(),
+             std::optional<int64_t> first_row_index = std::nullopt)
       : DataPage(PageType::DATA_PAGE, buffer, num_values, encoding, uncompressed_size,
-                 statistics),
+                 statistics, std::move(first_row_index)),
         definition_level_encoding_(definition_level_encoding),
         repetition_level_encoding_(repetition_level_encoding) {}
 
@@ -109,9 +116,10 @@ class DataPageV2 : public DataPage {
              int32_t num_rows, Encoding::type encoding,
              int32_t definition_levels_byte_length, int32_t repetition_levels_byte_length,
              int64_t uncompressed_size, bool is_compressed = false,
-             const EncodedStatistics& statistics = EncodedStatistics())
+             const EncodedStatistics& statistics = EncodedStatistics(),
+             std::optional<int64_t> first_row_index = std::nullopt)
       : DataPage(PageType::DATA_PAGE_V2, buffer, num_values, encoding, uncompressed_size,
-                 statistics),
+                 statistics, std::move(first_row_index)),
         num_nulls_(num_nulls),
         num_rows_(num_rows),
         definition_levels_byte_length_(definition_levels_byte_length),

--- a/cpp/src/parquet/column_page.h
+++ b/cpp/src/parquet/column_page.h
@@ -65,6 +65,9 @@ class DataPage : public Page {
   Encoding::type encoding() const { return encoding_; }
   int64_t uncompressed_size() const { return uncompressed_size_; }
   const EncodedStatistics& statistics() const { return statistics_; }
+  /// Return the row ordinal within the row group to the first row in the data page.
+  /// Currently it is only present from data pages created by ColumnWriter in order
+  /// to collect page index.
   std::optional<int64_t> first_row_index() const { return first_row_index_; }
 
   virtual ~DataPage() = default;

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -346,7 +346,7 @@ class SerializedPageWriter : public PageWriter {
     }
 
     // Serialized page writer does not need to adjust page offsets.
-    FinishPageIndex(/*final_position=*/0);
+    FinishPageIndexes(/*final_position=*/0);
 
     // index_page_offset = -1 since they are not supported
     metadata_->Finish(num_values_, dictionary_page_offset_, -1, data_page_offset_,
@@ -488,7 +488,7 @@ class SerializedPageWriter : public PageWriter {
 
   /// \brief Finish page index builders and update the stream offset to adjust
   /// page offsets.
-  void FinishPageIndex(int64_t final_position) {
+  void FinishPageIndexes(int64_t final_position) {
     if (column_index_builder_ != nullptr) {
       column_index_builder_->Finish();
     }
@@ -652,7 +652,7 @@ class BufferedPageWriter : public PageWriter {
     metadata_->WriteTo(in_memory_sink_.get());
 
     // Buffered page writer needs to adjust page offsets.
-    pager_->FinishPageIndex(final_position);
+    pager_->FinishPageIndexes(final_position);
 
     // flush everything to the serialized sink
     PARQUET_ASSIGN_OR_THROW(auto buffer, in_memory_sink_->Finish());

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -49,6 +49,7 @@
 #include "parquet/encryption/internal_file_encryptor.h"
 #include "parquet/level_conversion.h"
 #include "parquet/metadata.h"
+#include "parquet/page_index.h"
 #include "parquet/platform.h"
 #include "parquet/properties.h"
 #include "parquet/schema.h"
@@ -253,7 +254,9 @@ class SerializedPageWriter : public PageWriter {
                        bool use_page_checksum_verification,
                        MemoryPool* pool = ::arrow::default_memory_pool(),
                        std::shared_ptr<Encryptor> meta_encryptor = nullptr,
-                       std::shared_ptr<Encryptor> data_encryptor = nullptr)
+                       std::shared_ptr<Encryptor> data_encryptor = nullptr,
+                       ColumnIndexBuilder* column_index_builder = nullptr,
+                       OffsetIndexBuilder* offset_index_builder = nullptr)
       : sink_(std::move(sink)),
         metadata_(metadata),
         pool_(pool),
@@ -268,7 +271,9 @@ class SerializedPageWriter : public PageWriter {
         page_checksum_verification_(use_page_checksum_verification),
         meta_encryptor_(std::move(meta_encryptor)),
         data_encryptor_(std::move(data_encryptor)),
-        encryption_buffer_(AllocateBuffer(pool, 0)) {
+        encryption_buffer_(AllocateBuffer(pool, 0)),
+        column_index_builder_(column_index_builder),
+        offset_index_builder_(offset_index_builder) {
     if (data_encryptor_ != nullptr || meta_encryptor_ != nullptr) {
       InitEncryption();
     }
@@ -339,6 +344,10 @@ class SerializedPageWriter : public PageWriter {
     if (meta_encryptor_ != nullptr) {
       UpdateEncryption(encryption::kColumnMetaData);
     }
+
+    // Serialized page writer does not need to adjust page offsets.
+    FinishPageIndex(/*final_position=*/0);
+
     // index_page_offset = -1 since they are not supported
     metadata_->Finish(num_values_, dictionary_page_offset_, -1, data_page_offset_,
                       total_compressed_size_, total_uncompressed_size_, has_dictionary,
@@ -417,6 +426,25 @@ class SerializedPageWriter : public PageWriter {
         thrift_serializer_->Serialize(&page_header, sink_.get(), meta_encryptor_);
     PARQUET_THROW_NOT_OK(sink_->Write(output_data_buffer, output_data_len));
 
+    /// Collect page index
+    if (column_index_builder_ != nullptr) {
+      column_index_builder_->AddPage(page.statistics());
+    }
+    if (offset_index_builder_ != nullptr) {
+      const int64_t compressed_size = output_data_len + header_size;
+      if (compressed_size > std::numeric_limits<int32_t>::max()) {
+        throw ParquetException("Compressed page size overflows to INT32_MAX.");
+      }
+      if (!page.first_row_index().has_value()) {
+        throw ParquetException("First row index is not set in data page.");
+      }
+      /// start_pos is a relative offset in the buffered mode. It should be
+      /// adjusted via OffsetIndexBuilder::Finish() after BufferedPageWriter
+      /// has flushed all data pages.
+      offset_index_builder_->AddPage(start_pos, static_cast<int32_t>(compressed_size),
+                                     *page.first_row_index());
+    }
+
     total_uncompressed_size_ += uncompressed_size + header_size;
     total_compressed_size_ += output_data_len + header_size;
     num_values_ += page.num_values();
@@ -456,6 +484,17 @@ class SerializedPageWriter : public PageWriter {
 
     page_header.__set_type(format::PageType::DATA_PAGE_V2);
     page_header.__set_data_page_header_v2(data_page_header);
+  }
+
+  /// \brief Finish page index builders and update the stream offset to adjust
+  /// page offsets.
+  void FinishPageIndex(int64_t final_position) {
+    if (column_index_builder_ != nullptr) {
+      column_index_builder_->Finish();
+    }
+    if (offset_index_builder_ != nullptr) {
+      offset_index_builder_->Finish(final_position);
+    }
   }
 
   bool has_compressor() override { return (compressor_ != nullptr); }
@@ -563,6 +602,9 @@ class SerializedPageWriter : public PageWriter {
 
   std::map<Encoding::type, int32_t> dict_encoding_stats_;
   std::map<Encoding::type, int32_t> data_encoding_stats_;
+
+  ColumnIndexBuilder* column_index_builder_;
+  OffsetIndexBuilder* offset_index_builder_;
 };
 
 // This implementation of the PageWriter writes to the final sink on Close .
@@ -574,13 +616,16 @@ class BufferedPageWriter : public PageWriter {
                      bool use_page_checksum_verification,
                      MemoryPool* pool = ::arrow::default_memory_pool(),
                      std::shared_ptr<Encryptor> meta_encryptor = nullptr,
-                     std::shared_ptr<Encryptor> data_encryptor = nullptr)
+                     std::shared_ptr<Encryptor> data_encryptor = nullptr,
+                     ColumnIndexBuilder* column_index_builder = nullptr,
+                     OffsetIndexBuilder* offset_index_builder = nullptr)
       : final_sink_(std::move(sink)), metadata_(metadata), has_dictionary_pages_(false) {
     in_memory_sink_ = CreateOutputStream(pool);
     pager_ = std::make_unique<SerializedPageWriter>(
         in_memory_sink_, codec, compression_level, metadata, row_group_ordinal,
         current_column_ordinal, use_page_checksum_verification, pool,
-        std::move(meta_encryptor), std::move(data_encryptor));
+        std::move(meta_encryptor), std::move(data_encryptor), column_index_builder,
+        offset_index_builder);
   }
 
   int64_t WriteDictionaryPage(const DictionaryPage& page) override {
@@ -605,6 +650,9 @@ class BufferedPageWriter : public PageWriter {
 
     // Write metadata at end of column chunk
     metadata_->WriteTo(in_memory_sink_.get());
+
+    // Buffered page writer needs to adjust page offsets.
+    pager_->FinishPageIndex(final_position);
 
     // flush everything to the serialized sink
     PARQUET_ASSIGN_OR_THROW(auto buffer, in_memory_sink_->Finish());
@@ -638,17 +686,20 @@ std::unique_ptr<PageWriter> PageWriter::Open(
     int compression_level, ColumnChunkMetaDataBuilder* metadata,
     int16_t row_group_ordinal, int16_t column_chunk_ordinal, MemoryPool* pool,
     bool buffered_row_group, std::shared_ptr<Encryptor> meta_encryptor,
-    std::shared_ptr<Encryptor> data_encryptor, bool page_write_checksum_enabled) {
+    std::shared_ptr<Encryptor> data_encryptor, bool page_write_checksum_enabled,
+    ColumnIndexBuilder* column_index_builder, OffsetIndexBuilder* offset_index_builder) {
   if (buffered_row_group) {
     return std::unique_ptr<PageWriter>(new BufferedPageWriter(
         std::move(sink), codec, compression_level, metadata, row_group_ordinal,
         column_chunk_ordinal, page_write_checksum_enabled, pool,
-        std::move(meta_encryptor), std::move(data_encryptor)));
+        std::move(meta_encryptor), std::move(data_encryptor), column_index_builder,
+        offset_index_builder));
   } else {
     return std::unique_ptr<PageWriter>(new SerializedPageWriter(
         std::move(sink), codec, compression_level, metadata, row_group_ordinal,
         column_chunk_ordinal, page_write_checksum_enabled, pool,
-        std::move(meta_encryptor), std::move(data_encryptor)));
+        std::move(meta_encryptor), std::move(data_encryptor), column_index_builder,
+        offset_index_builder));
   }
 }
 
@@ -925,6 +976,7 @@ void ColumnWriterImpl::BuildDataPageV1(int64_t definition_levels_rle_size,
   }
 
   int32_t num_values = static_cast<int32_t>(num_buffered_values_);
+  int64_t first_row_index = rows_written_ - num_buffered_rows_;
 
   // Write the page to OutputStream eagerly if there is no dictionary or
   // if dictionary encoding has fallen back to PLAIN
@@ -934,13 +986,13 @@ void ColumnWriterImpl::BuildDataPageV1(int64_t definition_levels_rle_size,
         compressed_data->CopySlice(0, compressed_data->size(), allocator_));
     std::unique_ptr<DataPage> page_ptr = std::make_unique<DataPageV1>(
         compressed_data_copy, num_values, encoding_, Encoding::RLE, Encoding::RLE,
-        uncompressed_size, page_stats);
+        uncompressed_size, page_stats, first_row_index);
     total_compressed_bytes_ += page_ptr->size() + sizeof(format::PageHeader);
 
     data_pages_.push_back(std::move(page_ptr));
   } else {  // Eagerly write pages
     DataPageV1 page(compressed_data, num_values, encoding_, Encoding::RLE, Encoding::RLE,
-                    uncompressed_size, page_stats);
+                    uncompressed_size, page_stats, first_row_index);
     WriteDataPage(page);
   }
 }
@@ -977,6 +1029,7 @@ void ColumnWriterImpl::BuildDataPageV2(int64_t definition_levels_rle_size,
   int32_t num_rows = static_cast<int32_t>(num_buffered_rows_);
   int32_t def_levels_byte_length = static_cast<int32_t>(definition_levels_rle_size);
   int32_t rep_levels_byte_length = static_cast<int32_t>(repetition_levels_rle_size);
+  int64_t first_row_index = rows_written_ - num_buffered_rows_;
 
   // page_stats.null_count is not set when page_statistics_ is nullptr. It is only used
   // here for safety check.
@@ -989,13 +1042,14 @@ void ColumnWriterImpl::BuildDataPageV2(int64_t definition_levels_rle_size,
                             combined->CopySlice(0, combined->size(), allocator_));
     std::unique_ptr<DataPage> page_ptr = std::make_unique<DataPageV2>(
         combined, num_values, null_count, num_rows, encoding_, def_levels_byte_length,
-        rep_levels_byte_length, uncompressed_size, pager_->has_compressor(), page_stats);
+        rep_levels_byte_length, uncompressed_size, pager_->has_compressor(), page_stats,
+        first_row_index);
     total_compressed_bytes_ += page_ptr->size() + sizeof(format::PageHeader);
     data_pages_.push_back(std::move(page_ptr));
   } else {
     DataPageV2 page(combined, num_values, null_count, num_rows, encoding_,
                     def_levels_byte_length, rep_levels_byte_length, uncompressed_size,
-                    pager_->has_compressor(), page_stats);
+                    pager_->has_compressor(), page_stats, first_row_index);
     WriteDataPage(page);
   }
 }
@@ -1313,7 +1367,8 @@ class TypedColumnWriterImpl : public ColumnWriterImpl, public TypedColumnWriter<
   const WriterProperties* properties() override { return properties_; }
 
   bool pages_change_on_record_boundaries() const {
-    return properties_->data_page_version() == ParquetDataPageVersion::V2;
+    return properties_->data_page_version() == ParquetDataPageVersion::V2 ||
+           properties_->write_page_index();
   }
 
  private:
@@ -1515,6 +1570,19 @@ class TypedColumnWriterImpl : public ColumnWriterImpl, public TypedColumnWriter<
     }
   }
 
+  /// \brief Write values with spaces and update page statistics accordingly.
+  ///
+  /// \param values input buffer of values to write, including spaces.
+  /// \param num_values number of non-null values in the values buffer.
+  /// \param num_spaced_values length of values buffer, including spaces and does not
+  ///   count some nulls from ancestor (e.g. empty lists).
+  /// \param valid_bits validity bitmap of values buffer, which does not include some
+  ///   nulls from ancestor (e.g. empty lists).
+  /// \param valid_bits_offset offset to valid_bits bitmap.
+  /// \param num_levels number of levels to write, including nulls from values buffer
+  ///   and nulls from ancestor (e.g. empty lists).
+  /// \param num_nulls number of nulls in the values buffer as well as nulls from the
+  ///   ancestor (e.g. empty lists).
   void WriteValuesSpaced(const T* values, int64_t num_values, int64_t num_spaced_values,
                          const uint8_t* valid_bits, int64_t valid_bits_offset,
                          int64_t num_levels, int64_t num_nulls) {

--- a/cpp/src/parquet/column_writer.h
+++ b/cpp/src/parquet/column_writer.h
@@ -94,7 +94,9 @@ class PARQUET_EXPORT PageWriter {
       std::shared_ptr<Encryptor> header_encryptor = NULLPTR,
       std::shared_ptr<Encryptor> data_encryptor = NULLPTR,
       bool page_write_checksum_enabled = false,
+      // column_index_builder MUST outlive the PageWriter
       ColumnIndexBuilder* column_index_builder = NULLPTR,
+      // offset_index_builder MUST outlive the PageWriter
       OffsetIndexBuilder* offset_index_builder = NULLPTR);
 
   // The Column Writer decides if dictionary encoding is used if set and

--- a/cpp/src/parquet/column_writer.h
+++ b/cpp/src/parquet/column_writer.h
@@ -42,11 +42,13 @@ class RleEncoder;
 namespace parquet {
 
 struct ArrowWriteContext;
+class ColumnChunkMetaDataBuilder;
 class ColumnDescriptor;
+class ColumnIndexBuilder;
 class DataPage;
 class DictionaryPage;
-class ColumnChunkMetaDataBuilder;
 class Encryptor;
+class OffsetIndexBuilder;
 class WriterProperties;
 
 class PARQUET_EXPORT LevelEncoder {
@@ -91,7 +93,9 @@ class PARQUET_EXPORT PageWriter {
       bool buffered_row_group = false,
       std::shared_ptr<Encryptor> header_encryptor = NULLPTR,
       std::shared_ptr<Encryptor> data_encryptor = NULLPTR,
-      bool page_write_checksum_enabled = false);
+      bool page_write_checksum_enabled = false,
+      ColumnIndexBuilder* column_index_builder = NULLPTR,
+      OffsetIndexBuilder* offset_index_builder = NULLPTR);
 
   // The Column Writer decides if dictionary encoding is used if set and
   // if the dictionary encoding has fallen back to default encoding on reaching dictionary

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -506,6 +506,21 @@ class PARQUET_EXPORT RowGroupMetaDataBuilder {
   std::unique_ptr<RowGroupMetaDataBuilderImpl> impl_;
 };
 
+/// \brief Public struct for location to all page indexes in a parquet file.
+struct PageIndexLocation {
+  /// Alias type of page index location of a row group. The index location
+  /// is located by column ordinal. If the column does not have the page index,
+  /// its value is set to std::nullopt.
+  using RowGroupIndexLocation = std::vector<std::optional<IndexLocation>>;
+  /// Alis type of page index location of a parquet file. The index location
+  /// is located by the row group ordinal.
+  using FileIndexLocation = std::map<size_t, RowGroupIndexLocation>;
+  /// Row group column index locations which uses row group ordinal as the key.
+  FileIndexLocation column_index_location;
+  /// Row group offset index locations which uses row group ordinal as the key.
+  FileIndexLocation offset_index_location;
+};
+
 class PARQUET_EXPORT FileMetaDataBuilder {
  public:
   // API convenience to get a MetaData reader
@@ -517,6 +532,9 @@ class PARQUET_EXPORT FileMetaDataBuilder {
 
   // The prior RowGroupMetaDataBuilder (if any) is destroyed
   RowGroupMetaDataBuilder* AppendRowGroup();
+
+  // Update location to all page indexes in the parquet file
+  void SetPageIndexLocation(const PageIndexLocation& location);
 
   // Complete the Thrift structure
   std::unique_ptr<FileMetaData> Finish();

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -512,7 +512,7 @@ struct PageIndexLocation {
   /// is located by column ordinal. If the column does not have the page index,
   /// its value is set to std::nullopt.
   using RowGroupIndexLocation = std::vector<std::optional<IndexLocation>>;
-  /// Alis type of page index location of a parquet file. The index location
+  /// Alias type of page index location of a parquet file. The index location
   /// is located by the row group ordinal.
   using FileIndexLocation = std::map<size_t, RowGroupIndexLocation>;
   /// Row group column index locations which uses row group ordinal as the key.

--- a/cpp/src/parquet/page_index.cc
+++ b/cpp/src/parquet/page_index.cc
@@ -426,6 +426,354 @@ class PageIndexReaderImpl : public PageIndexReader {
   std::unordered_map<int32_t, RowGroupIndexReadRange> index_read_ranges_;
 };
 
+/// \brief Internal state of page index builder.
+enum class BuilderState {
+  /// Created but not yet write any data.
+  kCreated,
+  /// Some data are written but not yet finished.
+  kStarted,
+  /// All data are written and no more write is allowed.
+  kFinished,
+  /// The builder has corrupted data or empty data and therefore discarded.
+  kDiscarded
+};
+
+template <typename DType>
+class ColumnIndexBuilderImpl final : public ColumnIndexBuilder {
+ public:
+  using T = typename DType::c_type;
+
+  explicit ColumnIndexBuilderImpl(const ColumnDescriptor* descr) : descr_(descr) {
+    /// Initialize the null_counts vector as set. Invalid null_counts vector from
+    /// any page will invalidate the null_counts vector of the column index.
+    column_index_.__isset.null_counts = true;
+    column_index_.boundary_order = format::BoundaryOrder::UNORDERED;
+  }
+
+  void AddPage(const EncodedStatistics& stats) override {
+    if (state_ == BuilderState::kFinished) {
+      throw ParquetException("Cannot add page to finished ColumnIndexBuilder.");
+    } else if (state_ == BuilderState::kDiscarded) {
+      /// The offset index is discarded. Do nothing.
+      return;
+    }
+
+    state_ = BuilderState::kStarted;
+
+    if (stats.all_null_value) {
+      column_index_.null_pages.emplace_back(true);
+      column_index_.min_values.emplace_back("");
+      column_index_.max_values.emplace_back("");
+    } else if (stats.has_min && stats.has_max) {
+      const size_t page_ordinal = column_index_.null_pages.size();
+      non_null_page_indices_.emplace_back(page_ordinal);
+      column_index_.min_values.emplace_back(stats.min());
+      column_index_.max_values.emplace_back(stats.max());
+      column_index_.null_pages.emplace_back(false);
+    } else {
+      /// This is a non-null page but it lacks of meaningful min/max values.
+      /// Discard the column index.
+      state_ = BuilderState::kDiscarded;
+      return;
+    }
+
+    if (column_index_.__isset.null_counts && stats.has_null_count) {
+      column_index_.null_counts.emplace_back(stats.null_count);
+    } else {
+      column_index_.__isset.null_counts = false;
+    }
+  }
+
+  void Finish() override {
+    switch (state_) {
+      case BuilderState::kCreated: {
+        /// No page is added. Discard the column index.
+        state_ = BuilderState::kDiscarded;
+        return;
+      }
+      case BuilderState::kFinished:
+        throw ParquetException("ColumnIndexBuilder is already finished.");
+      case BuilderState::kDiscarded:
+        // The column index is discarded. Do nothing.
+        return;
+      case BuilderState::kStarted:
+        break;
+    }
+
+    state_ = BuilderState::kFinished;
+
+    /// Clear null_counts vector because at least one page does not provide it.
+    if (!column_index_.__isset.null_counts) {
+      column_index_.null_counts.clear();
+    }
+
+    /// Decode min/max values according to the data type.
+    const size_t non_null_page_count = non_null_page_indices_.size();
+    std::vector<T> min_values, max_values;
+    min_values.resize(non_null_page_count);
+    max_values.resize(non_null_page_count);
+    auto decoder = MakeTypedDecoder<DType>(Encoding::PLAIN, descr_);
+    for (size_t i = 0; i < non_null_page_count; ++i) {
+      auto page_ordinal = non_null_page_indices_.at(i);
+      Decode<DType>(decoder, column_index_.min_values.at(page_ordinal), &min_values, i);
+      Decode<DType>(decoder, column_index_.max_values.at(page_ordinal), &max_values, i);
+    }
+
+    /// Decide the boundary order from decoded min/max values.
+    auto boundary_order = DetermineBoundaryOrder(min_values, max_values);
+    column_index_.__set_boundary_order(ToThrift(boundary_order));
+  }
+
+  void WriteTo(::arrow::io::OutputStream* sink) const override {
+    if (state_ == BuilderState::kFinished) {
+      ThriftSerializer{}.Serialize(&column_index_, sink);
+    }
+  }
+
+  std::unique_ptr<ColumnIndex> Build() const override {
+    if (state_ == BuilderState::kFinished) {
+      return std::make_unique<TypedColumnIndexImpl<DType>>(*descr_, column_index_);
+    }
+    return nullptr;
+  }
+
+ private:
+  BoundaryOrder::type DetermineBoundaryOrder(const std::vector<T>& min_values,
+                                             const std::vector<T>& max_values) const {
+    DCHECK_EQ(min_values.size(), max_values.size());
+    if (min_values.empty()) {
+      return BoundaryOrder::Unordered;
+    }
+
+    std::shared_ptr<TypedComparator<DType>> comparator;
+    try {
+      comparator = MakeComparator<DType>(descr_);
+    } catch (const ParquetException&) {
+      /// Simply return unordered for unsupported comparator.
+      return BoundaryOrder::Unordered;
+    }
+
+    /// Check if both min_values and max_values are in ascending order.
+    bool is_ascending = true;
+    for (size_t i = 1; i < min_values.size(); ++i) {
+      if (comparator->Compare(min_values[i], min_values[i - 1]) ||
+          comparator->Compare(max_values[i], max_values[i - 1])) {
+        is_ascending = false;
+        break;
+      }
+    }
+    if (is_ascending) {
+      return BoundaryOrder::Ascending;
+    }
+
+    /// Check if both min_values and max_values are in descending order.
+    bool is_descending = true;
+    for (size_t i = 1; i < min_values.size(); ++i) {
+      if (comparator->Compare(min_values[i - 1], min_values[i]) ||
+          comparator->Compare(max_values[i - 1], max_values[i])) {
+        is_descending = false;
+        break;
+      }
+    }
+    if (is_descending) {
+      return BoundaryOrder::Descending;
+    }
+
+    /// Neither ascending nor descending is detected.
+    return BoundaryOrder::Unordered;
+  }
+
+  const ColumnDescriptor* descr_;
+  format::ColumnIndex column_index_;
+  std::vector<size_t> non_null_page_indices_;
+  BuilderState state_ = BuilderState::kCreated;
+};
+
+class OffsetIndexBuilderImpl final : public OffsetIndexBuilder {
+ public:
+  OffsetIndexBuilderImpl() = default;
+
+  void AddPage(int64_t offset, int32_t compressed_page_size,
+               int64_t first_row_index) override {
+    if (state_ == BuilderState::kFinished) {
+      throw ParquetException("Cannot add page to finished OffsetIndexBuilder.");
+    } else if (state_ == BuilderState::kDiscarded) {
+      /// The offset index is discarded. Do nothing.
+      return;
+    }
+
+    state_ = BuilderState::kStarted;
+
+    format::PageLocation page_location;
+    page_location.__set_offset(offset);
+    page_location.__set_compressed_page_size(compressed_page_size);
+    page_location.__set_first_row_index(first_row_index);
+    offset_index_.page_locations.emplace_back(std::move(page_location));
+  }
+
+  void Finish(int64_t final_position) override {
+    switch (state_) {
+      case BuilderState::kCreated: {
+        /// No pages are added. Simply discard the offset index.
+        state_ = BuilderState::kDiscarded;
+        break;
+      }
+      case BuilderState::kStarted: {
+        /// Adjust page offsets according the final position.
+        if (final_position > 0) {
+          for (auto& page_location : offset_index_.page_locations) {
+            page_location.__set_offset(page_location.offset + final_position);
+          }
+        }
+        state_ = BuilderState::kFinished;
+        break;
+      }
+      case BuilderState::kFinished:
+      case BuilderState::kDiscarded:
+        throw ParquetException("OffsetIndexBuilder is already finished");
+    }
+  }
+
+  void WriteTo(::arrow::io::OutputStream* sink) const override {
+    if (state_ == BuilderState::kFinished) {
+      ThriftSerializer{}.Serialize(&offset_index_, sink);
+    }
+  }
+
+  std::unique_ptr<OffsetIndex> Build() const override {
+    if (state_ == BuilderState::kFinished) {
+      return std::make_unique<OffsetIndexImpl>(offset_index_);
+    }
+    return nullptr;
+  }
+
+ private:
+  format::OffsetIndex offset_index_;
+  BuilderState state_ = BuilderState::kCreated;
+};
+
+class PageIndexBuilderImpl final : public PageIndexBuilder {
+ public:
+  explicit PageIndexBuilderImpl(const SchemaDescriptor* schema) : schema_(schema) {}
+
+  void AppendRowGroup() override {
+    if (finished_) {
+      throw ParquetException(
+          "Cannot call AppendRowGroup() to finished PageIndexBuilder.");
+    }
+
+    // Append new builders of next row group.
+    const auto num_columns = static_cast<size_t>(schema_->num_columns());
+    column_index_builders_.emplace_back();
+    offset_index_builders_.emplace_back();
+    column_index_builders_.back().resize(num_columns);
+    offset_index_builders_.back().resize(num_columns);
+
+    DCHECK_EQ(column_index_builders_.size(), offset_index_builders_.size());
+    DCHECK_EQ(column_index_builders_.back().size(), num_columns);
+    DCHECK_EQ(offset_index_builders_.back().size(), num_columns);
+  }
+
+  ColumnIndexBuilder* GetColumnIndexBuilder(int32_t i) override {
+    CheckState(i);
+    std::unique_ptr<ColumnIndexBuilder>& builder = column_index_builders_.back()[i];
+    if (builder == nullptr) {
+      builder = ColumnIndexBuilder::Make(schema_->Column(i));
+    }
+    return builder.get();
+  }
+
+  OffsetIndexBuilder* GetOffsetIndexBuilder(int32_t i) override {
+    CheckState(i);
+    std::unique_ptr<OffsetIndexBuilder>& builder = offset_index_builders_.back()[i];
+    if (builder == nullptr) {
+      builder = OffsetIndexBuilder::Make();
+    }
+    return builder.get();
+  }
+
+  void Finish() override { finished_ = true; }
+
+  void WriteTo(::arrow::io::OutputStream* sink,
+               PageIndexLocation* location) const override {
+    if (!finished_) {
+      throw ParquetException("Cannot call WriteTo() to unfinished PageIndexBuilder.");
+    }
+
+    location->column_index_location.clear();
+    location->offset_index_location.clear();
+
+    /// Serialize column index ordered by row group ordinal and then column ordinal.
+    SerializeIndex(column_index_builders_, sink, &location->column_index_location);
+
+    /// Serialize offset index ordered by row group ordinal and then column ordinal.
+    SerializeIndex(offset_index_builders_, sink, &location->offset_index_location);
+  }
+
+ private:
+  /// Make sure column ordinal is not out of bound and the builder is in good state.
+  void CheckState(int32_t column_ordinal) const {
+    if (finished_) {
+      throw ParquetException("PageIndexBuilder is already finished.");
+    }
+    if (column_ordinal < 0 || column_ordinal >= schema_->num_columns()) {
+      throw ParquetException("Invalid column ordinal: ", column_ordinal);
+    }
+    if (offset_index_builders_.empty() || column_index_builders_.empty()) {
+      throw ParquetException("No row group appended to PageIndexBuilder.");
+    }
+  }
+
+  template <typename Builder>
+  void SerializeIndex(
+      const std::vector<std::vector<std::unique_ptr<Builder>>>& page_index_builders,
+      ::arrow::io::OutputStream* sink,
+      std::map<size_t, std::vector<std::optional<IndexLocation>>>* location) const {
+    const auto num_columns = static_cast<size_t>(schema_->num_columns());
+
+    /// Serialize the same kind of page index row group by row group.
+    for (size_t row_group = 0; row_group < page_index_builders.size(); ++row_group) {
+      const auto& row_group_page_index_builders = page_index_builders[row_group];
+      DCHECK_EQ(row_group_page_index_builders.size(), num_columns);
+
+      bool has_valid_index = false;
+      std::vector<std::optional<IndexLocation>> locations(num_columns, std::nullopt);
+
+      /// In the same row group, serialize the same kind of page index column by column.
+      for (size_t column = 0; column < num_columns; ++column) {
+        const auto& column_page_index_builder = row_group_page_index_builders[column];
+        if (column_page_index_builder != nullptr) {
+          /// Try serializing the page index.
+          PARQUET_ASSIGN_OR_THROW(int64_t pos_before_write, sink->Tell());
+          column_page_index_builder->WriteTo(sink);
+          PARQUET_ASSIGN_OR_THROW(int64_t pos_after_write, sink->Tell());
+          int64_t len = pos_after_write - pos_before_write;
+
+          /// The page index is not serialized and skip reporting its location
+          if (len == 0) {
+            continue;
+          }
+
+          if (len > std::numeric_limits<int32_t>::max()) {
+            throw ParquetException("Page index size overflows to INT32_MAX");
+          }
+          locations[column] = {pos_before_write, static_cast<int32_t>(len)};
+          has_valid_index = true;
+        }
+      }
+
+      if (has_valid_index) {
+        location->emplace(row_group, std::move(locations));
+      }
+    }
+  }
+
+  const SchemaDescriptor* schema_;
+  std::vector<std::vector<std::unique_ptr<ColumnIndexBuilder>>> column_index_builders_;
+  std::vector<std::vector<std::unique_ptr<OffsetIndexBuilder>>> offset_index_builders_;
+  bool finished_ = false;
+};
+
 }  // namespace
 
 RowGroupIndexReadRange PageIndexReader::DeterminePageIndexRangesInRowGroup(
@@ -529,6 +877,40 @@ std::shared_ptr<PageIndexReader> PageIndexReader::Make(
     std::shared_ptr<InternalFileDecryptor> file_decryptor) {
   return std::make_shared<PageIndexReaderImpl>(input, file_metadata, properties,
                                                std::move(file_decryptor));
+}
+
+std::unique_ptr<ColumnIndexBuilder> ColumnIndexBuilder::Make(
+    const ColumnDescriptor* descr) {
+  switch (descr->physical_type()) {
+    case Type::BOOLEAN:
+      return std::make_unique<ColumnIndexBuilderImpl<BooleanType>>(descr);
+    case Type::INT32:
+      return std::make_unique<ColumnIndexBuilderImpl<Int32Type>>(descr);
+    case Type::INT64:
+      return std::make_unique<ColumnIndexBuilderImpl<Int64Type>>(descr);
+    case Type::INT96:
+      return std::make_unique<ColumnIndexBuilderImpl<Int96Type>>(descr);
+    case Type::FLOAT:
+      return std::make_unique<ColumnIndexBuilderImpl<FloatType>>(descr);
+    case Type::DOUBLE:
+      return std::make_unique<ColumnIndexBuilderImpl<DoubleType>>(descr);
+    case Type::BYTE_ARRAY:
+      return std::make_unique<ColumnIndexBuilderImpl<ByteArrayType>>(descr);
+    case Type::FIXED_LEN_BYTE_ARRAY:
+      return std::make_unique<ColumnIndexBuilderImpl<FLBAType>>(descr);
+    case Type::UNDEFINED:
+      return nullptr;
+  }
+  ::arrow::Unreachable("Cannot make ColumnIndexBuilder of an unknown type");
+  return nullptr;
+}
+
+std::unique_ptr<OffsetIndexBuilder> OffsetIndexBuilder::Make() {
+  return std::make_unique<OffsetIndexBuilderImpl>();
+}
+
+std::unique_ptr<PageIndexBuilder> PageIndexBuilder::Make(const SchemaDescriptor* schema) {
+  return std::make_unique<PageIndexBuilderImpl>(schema);
 }
 
 }  // namespace parquet

--- a/cpp/src/parquet/page_index.cc
+++ b/cpp/src/parquet/page_index.cc
@@ -481,6 +481,7 @@ class ColumnIndexBuilderImpl final : public ColumnIndexBuilder {
       column_index_.null_counts.emplace_back(stats.null_count);
     } else {
       column_index_.__isset.null_counts = false;
+      column_index_.null_counts.clear();
     }
   }
 

--- a/cpp/src/parquet/page_index.h
+++ b/cpp/src/parquet/page_index.h
@@ -26,8 +26,10 @@
 namespace parquet {
 
 class ColumnDescriptor;
+class EncodedStatistics;
 class FileMetaData;
 class InternalFileDecryptor;
+struct PageIndexLocation;
 class ReaderProperties;
 class RowGroupMetaData;
 class RowGroupPageIndexReader;
@@ -248,6 +250,118 @@ class PARQUET_EXPORT PageIndexReader {
   ///          is corrupted.
   static RowGroupIndexReadRange DeterminePageIndexRangesInRowGroup(
       const RowGroupMetaData& row_group_metadata, const std::vector<int32_t>& columns);
+};
+
+/// \brief Interface for collecting column index of data pages in a column chunk.
+class PARQUET_EXPORT ColumnIndexBuilder {
+ public:
+  /// \brief API convenience to create a ColumnIndexBuilder.
+  static std::unique_ptr<ColumnIndexBuilder> Make(const ColumnDescriptor* descr);
+
+  virtual ~ColumnIndexBuilder() = default;
+
+  /// \brief Add statistics of a data page.
+  ///
+  /// If the ColumnIndexBuilder has seen any corrupted statistics, it will
+  /// not update statistics any more.
+  ///
+  /// \param stats Page statistics in the encoded form.
+  virtual void AddPage(const EncodedStatistics& stats) = 0;
+
+  /// \brief Complete the column index.
+  ///
+  /// Once called, AddPage() can no longer be called.
+  /// WriteTo() and Build() can only called after Finish() has been called.
+  virtual void Finish() = 0;
+
+  /// \brief Serialize the column index thrift message.
+  ///
+  /// If the ColumnIndexBuilder has seen any corrupted statistics, it will
+  /// not write any data to the sink.
+  ///
+  /// \param[out] sink output stream to write the serialized message.
+  virtual void WriteTo(::arrow::io::OutputStream* sink) const = 0;
+
+  /// \brief Create a ColumnIndex directly.
+  ///
+  /// \return If the ColumnIndexBuilder has seen any corrupted statistics, it simply
+  /// returns nullptr. Otherwise the column index is built and returned.
+  virtual std::unique_ptr<ColumnIndex> Build() const = 0;
+};
+
+/// \brief Interface for collecting offset index of data pages in a column chunk.
+class PARQUET_EXPORT OffsetIndexBuilder {
+ public:
+  /// \brief API convenience to create a OffsetIndexBuilder.
+  static std::unique_ptr<OffsetIndexBuilder> Make();
+
+  virtual ~OffsetIndexBuilder() = default;
+
+  /// \brief Add page location of a data page.
+  virtual void AddPage(int64_t offset, int32_t compressed_page_size,
+                       int64_t first_row_index) = 0;
+
+  /// \brief Add page location of a data page.
+  void AddPage(const PageLocation& page_location) {
+    AddPage(page_location.offset, page_location.compressed_page_size,
+            page_location.first_row_index);
+  }
+
+  /// \brief Complete the offset index.
+  ///
+  /// In the buffered row group mode, data pages are flushed into memory
+  /// sink and the OffsetIndexBuilder has only collected the relative offset
+  /// which requires adjustment once they are flushed to the file.
+  ///
+  /// \param final_position Final stream offset to add for page offset adjustment.
+  virtual void Finish(int64_t final_position) = 0;
+
+  /// \brief Serialize the offset index thrift message.
+  ///
+  /// \param[out] sink output stream to write the serialized message.
+  virtual void WriteTo(::arrow::io::OutputStream* sink) const = 0;
+
+  /// \brief Create an OffsetIndex directly.
+  virtual std::unique_ptr<OffsetIndex> Build() const = 0;
+};
+
+/// \brief Interface for collecting page index of a parquet file.
+class PARQUET_EXPORT PageIndexBuilder {
+ public:
+  /// \brief API convenience to create a PageIndexBuilder.
+  static std::unique_ptr<PageIndexBuilder> Make(const SchemaDescriptor* schema);
+
+  virtual ~PageIndexBuilder() = default;
+
+  /// \brief Start a new row group.
+  virtual void AppendRowGroup() = 0;
+
+  /// \brief Get the ColumnIndexBuilder from column ordinal.
+  ///
+  /// \param i Column ordinal.
+  /// \return ColumnIndexBuilder for the column and its memory ownership belongs to
+  /// the PageIndexBuilder.
+  virtual ColumnIndexBuilder* GetColumnIndexBuilder(int32_t i) = 0;
+
+  /// \brief Get the OffsetIndexBuilder from column ordinal.
+  ///
+  /// \param i Column ordinal.
+  /// \return OffsetIndexBuilder for the column and its memory ownership belongs to
+  /// the PageIndexBuilder.
+  virtual OffsetIndexBuilder* GetOffsetIndexBuilder(int32_t i) = 0;
+
+  /// \brief Complete the page index builder and no more write is allowed.
+  virtual void Finish() = 0;
+
+  /// \brief Serialize the page index thrift message.
+  ///
+  /// Only valid column indexes and offset indexes are serialized and their locations
+  /// are set.
+  ///
+  /// \param[out] sink The output stream to write the page index.
+  /// \param[out] location The location of all page index to the start of sink.
+  virtual void WriteTo(::arrow::io::OutputStream* sink,
+                       PageIndexLocation* location) const = 0;
 };
 
 }  // namespace parquet

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -208,7 +208,8 @@ class PARQUET_EXPORT WriterProperties {
           data_page_version_(ParquetDataPageVersion::V1),
           created_by_(DEFAULT_CREATED_BY),
           store_decimal_as_integer_(false),
-          page_checksum_enabled_(false) {}
+          page_checksum_enabled_(false),
+          write_page_index_(false) {}
     virtual ~Builder() {}
 
     /// Specify the memory pool for the writer. Default default_memory_pool.
@@ -501,6 +502,28 @@ class PARQUET_EXPORT WriterProperties {
       return this;
     }
 
+    /// Enable writing page index.
+    ///
+    /// Page index contains statistics for data pages and can be used to skip pages
+    /// when scanning data in ordered and unordered columns.
+    ///
+    /// Please check the link below for more details:
+    /// https://github.com/apache/parquet-format/blob/master/PageIndex.md
+    ///
+    /// Default disabled.
+    Builder* enable_write_page_index() {
+      write_page_index_ = true;
+      return this;
+    }
+
+    /// Disable writing page index.
+    ///
+    /// Default disabled.
+    Builder* disable_write_page_index() {
+      write_page_index_ = false;
+      return this;
+    }
+
     /// \brief Build the WriterProperties with the builder parameters.
     /// \return The WriterProperties defined by the builder.
     std::shared_ptr<WriterProperties> build() {
@@ -526,7 +549,8 @@ class PARQUET_EXPORT WriterProperties {
           pool_, dictionary_pagesize_limit_, write_batch_size_, max_row_group_length_,
           pagesize_, version_, created_by_, page_checksum_enabled_,
           std::move(file_encryption_properties_), default_column_properties_,
-          column_properties, data_page_version_, store_decimal_as_integer_));
+          column_properties, data_page_version_, store_decimal_as_integer_,
+          write_page_index_));
     }
 
    private:
@@ -540,6 +564,7 @@ class PARQUET_EXPORT WriterProperties {
     std::string created_by_;
     bool store_decimal_as_integer_;
     bool page_checksum_enabled_;
+    bool write_page_index_;
 
     std::shared_ptr<FileEncryptionProperties> file_encryption_properties_;
 
@@ -573,6 +598,8 @@ class PARQUET_EXPORT WriterProperties {
   inline bool store_decimal_as_integer() const { return store_decimal_as_integer_; }
 
   inline bool page_checksum_enabled() const { return page_checksum_enabled_; }
+
+  inline bool write_page_index() const { return write_page_index_; }
 
   inline Encoding::type dictionary_index_encoding() const {
     if (parquet_version_ == ParquetVersion::PARQUET_1_0) {
@@ -642,7 +669,8 @@ class PARQUET_EXPORT WriterProperties {
       std::shared_ptr<FileEncryptionProperties> file_encryption_properties,
       const ColumnProperties& default_column_properties,
       const std::unordered_map<std::string, ColumnProperties>& column_properties,
-      ParquetDataPageVersion data_page_version, bool store_short_decimal_as_integer)
+      ParquetDataPageVersion data_page_version, bool store_short_decimal_as_integer,
+      bool write_page_index)
       : pool_(pool),
         dictionary_pagesize_limit_(dictionary_pagesize_limit),
         write_batch_size_(write_batch_size),
@@ -653,6 +681,7 @@ class PARQUET_EXPORT WriterProperties {
         parquet_created_by_(created_by),
         store_decimal_as_integer_(store_short_decimal_as_integer),
         page_checksum_enabled_(page_write_checksum_enabled),
+        write_page_index_(write_page_index),
         file_encryption_properties_(file_encryption_properties),
         default_column_properties_(default_column_properties),
         column_properties_(column_properties) {}
@@ -667,6 +696,7 @@ class PARQUET_EXPORT WriterProperties {
   std::string parquet_created_by_;
   bool store_decimal_as_integer_;
   bool page_checksum_enabled_;
+  bool write_page_index_;
 
   std::shared_ptr<FileEncryptionProperties> file_encryption_properties_;
 

--- a/cpp/src/parquet/statistics.cc
+++ b/cpp/src/parquet/statistics.cc
@@ -610,6 +610,8 @@ class TypedStatisticsImpl : public TypedStatistics<DType> {
     if (HasNullCount()) {
       s.set_null_count(this->null_count());
     }
+    // num_values_ is reliable and it means number of non-null values.
+    s.all_null_value = num_values_ == 0;
     return s;
   }
 
@@ -625,7 +627,7 @@ class TypedStatisticsImpl : public TypedStatistics<DType> {
   T min_;
   T max_;
   ::arrow::MemoryPool* pool_;
-  int64_t num_values_ = 0;
+  int64_t num_values_ = 0;  // # of non-null values.
   EncodedStatistics statistics_;
   std::shared_ptr<TypedComparator<DType>> comparator_;
   std::shared_ptr<ResizableBuffer> min_buffer_, max_buffer_;

--- a/cpp/src/parquet/statistics.h
+++ b/cpp/src/parquet/statistics.h
@@ -137,6 +137,12 @@ class PARQUET_EXPORT EncodedStatistics {
   bool has_null_count = false;
   bool has_distinct_count = false;
 
+  // When all values in the statistics are null, it is set to true.
+  // Otherwise, at least one value is not null, or we are not sure at all.
+  // Page index requires this information to decide whether a data page
+  // is a null page or not.
+  bool all_null_value = false;
+
   // From parquet-mr
   // Don't write stats larger than the max size rather than truncating. The
   // rationale is that some engines may use the minimum value in the page as

--- a/cpp/src/parquet/thrift_internal.h
+++ b/cpp/src/parquet/thrift_internal.h
@@ -295,6 +295,18 @@ static inline format::CompressionCodec::type ToThrift(Compression::type type) {
   }
 }
 
+static inline format::BoundaryOrder::type ToThrift(BoundaryOrder::type type) {
+  switch (type) {
+    case BoundaryOrder::Unordered:
+    case BoundaryOrder::Ascending:
+    case BoundaryOrder::Descending:
+      return static_cast<format::BoundaryOrder::type>(type);
+    default:
+      DCHECK(false) << "Cannot reach here";
+      return format::BoundaryOrder::UNORDERED;
+  }
+}
+
 static inline format::Statistics ToThrift(const EncodedStatistics& stats) {
   format::Statistics statistics;
   if (stats.has_min) {


### PR DESCRIPTION
### Rationale for this change

Parquet C++ reader supports reading page index from file, but the writer does not yet support writing it.

### What changes are included in this PR?

Parquet file writer collects page index from all data pages and serializes page index into the file.

### Are these changes tested?

Not yet, will be added later.

### Are there any user-facing changes?

`WriterProperties::enable_write_page_index()` and `WriterProperties::disable_write_page_index()` have been added to toggle it on and off.
* Closes: #34053