### PR TITLE
GH-34068: [C++][Gandiva] Add extra functions

### DIFF
--- a/cpp/src/gandiva/function_registry_arithmetic.cc
+++ b/cpp/src/gandiva/function_registry_arithmetic.cc
@@ -65,11 +65,12 @@ std::vector<NativeFunction> GetArithmeticFunctionRegistry() {
       UNARY_SAFE_NULL_IF_NULL(not, {}, boolean, boolean),
       UNARY_SAFE_NULL_IF_NULL(castBIGINT, {}, int32, int64),
       UNARY_SAFE_NULL_IF_NULL(castINT, {}, int64, int32),
+      UNARY_SAFE_NULL_IF_NULL(castINT, {}, int8, int32),
       UNARY_SAFE_NULL_IF_NULL(castBIGINT, {}, decimal128, int64),
 
       // cast to float32
       UNARY_CAST_TO_FLOAT32(int32), UNARY_CAST_TO_FLOAT32(int64),
-      UNARY_CAST_TO_FLOAT32(float64),
+      UNARY_CAST_TO_FLOAT32(float64), UNARY_CAST_TO_FLOAT32(int8),
 
       // cast to int32
       UNARY_CAST_TO_INT32(float32), UNARY_CAST_TO_INT32(float64),
@@ -125,8 +126,27 @@ std::vector<NativeFunction> GetArithmeticFunctionRegistry() {
       BINARY_SYMMETRIC_SAFE_NULL_IF_NULL(bitwise_or, {}, int64),
       BINARY_SYMMETRIC_SAFE_NULL_IF_NULL(bitwise_xor, {"xor"}, int32),
       BINARY_SYMMETRIC_SAFE_NULL_IF_NULL(bitwise_xor, {"xor"}, int64),
+
+      BINARY_SYMMETRIC_SAFE_NULL_IF_NULL(bitwise_and, {}, uint32),
+      BINARY_SYMMETRIC_SAFE_NULL_IF_NULL(bitwise_and, {}, uint64),
+      BINARY_SYMMETRIC_SAFE_NULL_IF_NULL(bitwise_or, {}, uint32),
+      BINARY_SYMMETRIC_SAFE_NULL_IF_NULL(bitwise_or, {}, uint64),
+      BINARY_SYMMETRIC_SAFE_NULL_IF_NULL(bitwise_xor, {}, uint32),
+      BINARY_SYMMETRIC_SAFE_NULL_IF_NULL(bitwise_xor, {}, uint64),
+
+      BINARY_SYMMETRIC_SAFE_NULL_IF_NULL(bitwise_and, {}, uint8),
+      BINARY_SYMMETRIC_SAFE_NULL_IF_NULL(bitwise_and, {}, uint16),
+      BINARY_SYMMETRIC_SAFE_NULL_IF_NULL(bitwise_or, {}, uint8),
+      BINARY_SYMMETRIC_SAFE_NULL_IF_NULL(bitwise_or, {}, uint16),
+      BINARY_SYMMETRIC_SAFE_NULL_IF_NULL(bitwise_xor, {}, uint8),
+      BINARY_SYMMETRIC_SAFE_NULL_IF_NULL(bitwise_xor, {}, uint16),
+
       UNARY_SAFE_NULL_IF_NULL(bitwise_not, {}, int32, int32),
       UNARY_SAFE_NULL_IF_NULL(bitwise_not, {}, int64, int64),
+      UNARY_SAFE_NULL_IF_NULL(bitwise_not, {}, uint32, uint32),
+      UNARY_SAFE_NULL_IF_NULL(bitwise_not, {}, uint64, uint64),
+      UNARY_SAFE_NULL_IF_NULL(bitwise_not, {}, uint16, uint16),
+      UNARY_SAFE_NULL_IF_NULL(bitwise_not, {}, uint8, uint8),
 
       UNARY_SAFE_NULL_NEVER_BOOL(isnotfalse, ({"is not false"}), boolean),
       UNARY_SAFE_NULL_NEVER_BOOL(isnottrue, ({"is not true"}), boolean),

--- a/cpp/src/gandiva/function_registry_math_ops.cc
+++ b/cpp/src/gandiva/function_registry_math_ops.cc
@@ -79,6 +79,10 @@ std::vector<NativeFunction> GetMathOpsFunctionRegistry() {
       MATH_UNARY_OPS_FLOAT(expf, {}), MATH_UNARY_OPS_FLOAT(logf, {}),
       MATH_UNARY_OPS_FLOAT(log10f, {}),
 
+      MATH_UNARY_OPS_FLOAT(sqrtf, {}), MATH_UNARY_OPS_FLOAT(cbrtf, {}),
+      MATH_UNARY_OPS_FLOAT(expf, {}), MATH_UNARY_OPS_FLOAT(logf, {}),
+      MATH_UNARY_OPS_FLOAT(log10f, {}),
+
       MATH_BINARY_UNSAFE(log, {}),
 
       BINARY_SYMMETRIC_SAFE_NULL_IF_NULL(power, {"pow"}, float64),

--- a/cpp/src/gandiva/function_registry_math_ops.cc
+++ b/cpp/src/gandiva/function_registry_math_ops.cc
@@ -16,7 +16,6 @@
 // under the License.
 
 #include "gandiva/function_registry_math_ops.h"
-
 #include "gandiva/function_registry_common.h"
 
 namespace gandiva {

--- a/cpp/src/gandiva/function_registry_math_ops.cc
+++ b/cpp/src/gandiva/function_registry_math_ops.cc
@@ -16,6 +16,7 @@
 // under the License.
 
 #include "gandiva/function_registry_math_ops.h"
+
 #include "gandiva/function_registry_common.h"
 
 namespace gandiva {
@@ -27,6 +28,11 @@ namespace gandiva {
       UNARY_SAFE_NULL_IF_NULL(name, ALIASES, uint64, float64),  \
       UNARY_SAFE_NULL_IF_NULL(name, ALIASES, float32, float64), \
       UNARY_SAFE_NULL_IF_NULL(name, ALIASES, float64, float64)
+
+#define MATH_UNARY_OPS_FLOAT(name, ALIASES)                    \
+  UNARY_SAFE_NULL_IF_NULL(name, ALIASES, int32, float32),      \
+      UNARY_SAFE_NULL_IF_NULL(name, ALIASES, uint32, float32), \
+      UNARY_SAFE_NULL_IF_NULL(name, ALIASES, float32, float32)
 
 #define MATH_BINARY_UNSAFE(name, ALIASES)                          \
   BINARY_UNSAFE_NULL_IF_NULL(name, ALIASES, int32, float64),       \
@@ -43,6 +49,11 @@ namespace gandiva {
       BINARY_GENERIC_SAFE_NULL_IF_NULL(name, ALIASES, uint64, uint64, float64),   \
       BINARY_GENERIC_SAFE_NULL_IF_NULL(name, ALIASES, float32, float32, float64), \
       BINARY_GENERIC_SAFE_NULL_IF_NULL(name, ALIASES, float64, float64, float64)
+
+#define MATH_BINARY_SAFE_FLOAT(name, ALIASES)                                   \
+  BINARY_GENERIC_SAFE_NULL_IF_NULL(name, ALIASES, int32, int32, float32),       \
+      BINARY_GENERIC_SAFE_NULL_IF_NULL(name, ALIASES, uint32, uint32, float32), \
+      BINARY_GENERIC_SAFE_NULL_IF_NULL(name, ALIASES, float32, float32, float32)
 
 #define UNARY_SAFE_NULL_NEVER_BOOL_FN(name, ALIASES) \
   NUMERIC_BOOL_DATE_TYPES(UNARY_SAFE_NULL_NEVER_BOOL, name, ALIASES)
@@ -62,11 +73,16 @@ namespace gandiva {
 std::vector<NativeFunction> GetMathOpsFunctionRegistry() {
   static std::vector<NativeFunction> math_fn_registry_ = {
       MATH_UNARY_OPS(cbrt, {}), MATH_UNARY_OPS(exp, {}), MATH_UNARY_OPS(log, {}),
-      MATH_UNARY_OPS(log10, {}),
+      MATH_UNARY_OPS(log10, {}), MATH_UNARY_OPS(sqrt, {}),
+
+      MATH_UNARY_OPS_FLOAT(sqrtf, {}), MATH_UNARY_OPS_FLOAT(cbrtf, {}),
+      MATH_UNARY_OPS_FLOAT(expf, {}), MATH_UNARY_OPS_FLOAT(logf, {}),
+      MATH_UNARY_OPS_FLOAT(log10f, {}),
 
       MATH_BINARY_UNSAFE(log, {}),
 
       BINARY_SYMMETRIC_SAFE_NULL_IF_NULL(power, {"pow"}, float64),
+      BINARY_SYMMETRIC_SAFE_NULL_IF_NULL(powerf, {"powf"}, float32),
 
       UNARY_SAFE_NULL_NEVER_BOOL_FN(isnull, {}),
       UNARY_SAFE_NULL_NEVER_BOOL_FN(isnotnull, {}),
@@ -85,9 +101,16 @@ std::vector<NativeFunction> GetMathOpsFunctionRegistry() {
       MATH_UNARY_OPS(sinh, {}), MATH_UNARY_OPS(cosh, {}), MATH_UNARY_OPS(tanh, {}),
       MATH_UNARY_OPS(cot, {}), MATH_UNARY_OPS(radians, {}),
       MATH_UNARY_OPS(degrees, {"udfdegrees"}), MATH_BINARY_SAFE(atan2, {}),
+      MATH_UNARY_OPS_FLOAT(sinf, {}), MATH_UNARY_OPS_FLOAT(cosf, {}),
+      MATH_UNARY_OPS_FLOAT(asinf, {}), MATH_UNARY_OPS_FLOAT(acosf, {}),
+      MATH_UNARY_OPS_FLOAT(tanf, {}), MATH_UNARY_OPS_FLOAT(atanf, {}),
+      MATH_UNARY_OPS_FLOAT(sinhf, {}), MATH_UNARY_OPS_FLOAT(coshf, {}),
+      MATH_UNARY_OPS_FLOAT(tanhf, {}), MATH_UNARY_OPS_FLOAT(cotf, {}),
+      MATH_BINARY_SAFE_FLOAT(atan2f, {}),
 
       // decimal functions
       UNARY_SAFE_NULL_IF_NULL(abs, {}, decimal128, decimal128),
+      UNARY_SAFE_NULL_IF_NULL(absf, {}, float32, float32),
       UNARY_SAFE_NULL_IF_NULL(ceil, {}, decimal128, decimal128),
       UNARY_SAFE_NULL_IF_NULL(floor, {}, decimal128, decimal128),
       UNARY_SAFE_NULL_IF_NULL(round, {}, decimal128, decimal128),
@@ -109,6 +132,8 @@ std::vector<NativeFunction> GetMathOpsFunctionRegistry() {
 }
 
 #undef MATH_UNARY_OPS
+
+#undef MATH_UNARY_OPS_FLOAT
 
 #undef MATH_BINARY_UNSAFE
 

--- a/cpp/src/gandiva/precompiled/arithmetic_ops.cc
+++ b/cpp/src/gandiva/precompiled/arithmetic_ops.cc
@@ -85,6 +85,7 @@ extern "C" {
 NUMERIC_TYPES(BINARY_SYMMETRIC, add, +)
 NUMERIC_TYPES(BINARY_SYMMETRIC, subtract, -)
 NUMERIC_TYPES(BINARY_SYMMETRIC, multiply, *)
+
 BINARY_SYMMETRIC(bitwise_and, int32, &)
 BINARY_SYMMETRIC(bitwise_and, int64, &)
 BINARY_SYMMETRIC(bitwise_or, int32, |)
@@ -92,6 +93,19 @@ BINARY_SYMMETRIC(bitwise_or, int64, |)
 BINARY_SYMMETRIC(bitwise_xor, int32, ^)
 BINARY_SYMMETRIC(bitwise_xor, int64, ^)
 
+BINARY_SYMMETRIC(bitwise_and, uint32, &)
+BINARY_SYMMETRIC(bitwise_and, uint64, &)
+BINARY_SYMMETRIC(bitwise_or, uint32, |)
+BINARY_SYMMETRIC(bitwise_or, uint64, |)
+BINARY_SYMMETRIC(bitwise_xor, uint32, ^)
+BINARY_SYMMETRIC(bitwise_xor, uint64, ^)
+
+BINARY_SYMMETRIC(bitwise_and, uint8, &)
+BINARY_SYMMETRIC(bitwise_and, uint16, &)
+BINARY_SYMMETRIC(bitwise_or, uint8, |)
+BINARY_SYMMETRIC(bitwise_or, uint16, |)
+BINARY_SYMMETRIC(bitwise_xor, uint8, ^)
+BINARY_SYMMETRIC(bitwise_xor, uint16, ^)
 #undef BINARY_SYMMETRIC
 
 MOD_OP(mod, int64, int32, int32)
@@ -202,6 +216,8 @@ NUMERIC_DATE_TYPES(COMPARE_SIX_VALUES, least, <)
 
 CAST_UNARY(castBIGINT, int32, int64)
 CAST_UNARY(castINT, int64, int32)
+CAST_UNARY(castINT, int8, int32)
+CAST_UNARY(castFLOAT4, int8, float32)
 CAST_UNARY(castFLOAT4, int32, float32)
 CAST_UNARY(castFLOAT4, int64, float32)
 CAST_UNARY(castFLOAT8, int32, float64)
@@ -466,6 +482,10 @@ DIV_FLOAT(float64)
 
 BITWISE_NOT(int32)
 BITWISE_NOT(int64)
+BITWISE_NOT(uint64)
+BITWISE_NOT(uint32)
+BITWISE_NOT(uint16)
+BITWISE_NOT(uint8)
 
 #undef BITWISE_NOT
 

--- a/cpp/src/gandiva/precompiled/extended_math_ops.cc
+++ b/cpp/src/gandiva/precompiled/extended_math_ops.cc
@@ -53,11 +53,6 @@ extern "C" {
   gdv_##OUT_TYPE sqrtf_##IN_TYPE(gdv_##IN_TYPE in) {                \
     return static_cast<gdv_float32>(sqrtf(static_cast<float>(in))); \
   }
-#define SQRT(IN_TYPE, OUT_TYPE)                                           \
-  FORCE_INLINE                                                            \
-  gdv_##OUT_TYPE sqrt_##IN_TYPE(gdv_##IN_TYPE in) {                       \
-    return static_cast<gdv_float64>(sqrtl(static_cast<long double>(in))); \
-  }
 
 ENUMERIC_TYPES_UNARY_FLOAT(SQRTF, float32)
 ENUMERIC_TYPES_UNARY(SQRT, float64)

--- a/cpp/src/gandiva/precompiled/extended_math_ops.cc
+++ b/cpp/src/gandiva/precompiled/extended_math_ops.cc
@@ -40,34 +40,79 @@ extern "C" {
   INNER(float32, OUT_TYPE)                    \
   INNER(float64, OUT_TYPE)
 
+#define ENUMERIC_TYPES_UNARY_FLOAT(INNER, OUT_TYPE) \
+  INNER(int32, OUT_TYPE)                            \
+  INNER(uint32, OUT_TYPE)                           \
+  INNER(int64, OUT_TYPE)                            \
+  INNER(uint64, OUT_TYPE)                           \
+  INNER(float32, OUT_TYPE)
+
+// Square root
+#define SQRTF(IN_TYPE, OUT_TYPE)                                    \
+  FORCE_INLINE                                                      \
+  gdv_##OUT_TYPE sqrtf_##IN_TYPE(gdv_##IN_TYPE in) {                \
+    return static_cast<gdv_float32>(sqrtf(static_cast<float>(in))); \
+  }
+#define SQRT(IN_TYPE, OUT_TYPE)                                           \
+  FORCE_INLINE                                                            \
+  gdv_##OUT_TYPE sqrt_##IN_TYPE(gdv_##IN_TYPE in) {                       \
+    return static_cast<gdv_float64>(sqrtl(static_cast<long double>(in))); \
+  }
+
+ENUMERIC_TYPES_UNARY_FLOAT(SQRTF, float32)
+ENUMERIC_TYPES_UNARY(SQRT, float64)
+
 // Cubic root
+#define CBRTF(IN_TYPE, OUT_TYPE)                                    \
+  FORCE_INLINE                                                      \
+  gdv_##OUT_TYPE cbrtf_##IN_TYPE(gdv_##IN_TYPE in) {                \
+    return static_cast<gdv_float32>(cbrtf(static_cast<float>(in))); \
+  }
 #define CBRT(IN_TYPE, OUT_TYPE)                                           \
   FORCE_INLINE                                                            \
   gdv_##OUT_TYPE cbrt_##IN_TYPE(gdv_##IN_TYPE in) {                       \
     return static_cast<gdv_float64>(cbrtl(static_cast<long double>(in))); \
   }
 
+ENUMERIC_TYPES_UNARY_FLOAT(CBRTF, float32)
 ENUMERIC_TYPES_UNARY(CBRT, float64)
 
 // Exponent
+#define EXPF(IN_TYPE, OUT_TYPE)                                    \
+  FORCE_INLINE                                                     \
+  gdv_##OUT_TYPE expf_##IN_TYPE(gdv_##IN_TYPE in) {                \
+    return static_cast<gdv_float32>(expf(static_cast<float>(in))); \
+  }
 #define EXP(IN_TYPE, OUT_TYPE)                                           \
   FORCE_INLINE                                                           \
   gdv_##OUT_TYPE exp_##IN_TYPE(gdv_##IN_TYPE in) {                       \
     return static_cast<gdv_float64>(expl(static_cast<long double>(in))); \
   }
 
+ENUMERIC_TYPES_UNARY_FLOAT(EXPF, float32)
 ENUMERIC_TYPES_UNARY(EXP, float64)
 
 // log
+#define LOGF(IN_TYPE, OUT_TYPE)                                    \
+  FORCE_INLINE                                                     \
+  gdv_##OUT_TYPE logf_##IN_TYPE(gdv_##IN_TYPE in) {                \
+    return static_cast<gdv_float32>(logf(static_cast<float>(in))); \
+  }
 #define LOG(IN_TYPE, OUT_TYPE)                                           \
   FORCE_INLINE                                                           \
   gdv_##OUT_TYPE log_##IN_TYPE(gdv_##IN_TYPE in) {                       \
     return static_cast<gdv_float64>(logl(static_cast<long double>(in))); \
   }
 
+ENUMERIC_TYPES_UNARY_FLOAT(LOGF, float32)
 ENUMERIC_TYPES_UNARY(LOG, float64)
 
 // log base 10
+#define LOG10F(IN_TYPE, OUT_TYPE)                                    \
+  FORCE_INLINE                                                       \
+  gdv_##OUT_TYPE log10f_##IN_TYPE(gdv_##IN_TYPE in) {                \
+    return static_cast<gdv_float32>(log10f(static_cast<float>(in))); \
+  }
 #define LOG10(IN_TYPE, OUT_TYPE)                                           \
   FORCE_INLINE                                                             \
   gdv_##OUT_TYPE log10_##IN_TYPE(gdv_##IN_TYPE in) {                       \
@@ -76,6 +121,7 @@ ENUMERIC_TYPES_UNARY(LOG, float64)
 
 #define LOGL(VALUE) static_cast<gdv_float64>(logl(static_cast<long double>(VALUE)))
 
+ENUMERIC_TYPES_UNARY_FLOAT(LOG10F, float32)
 ENUMERIC_TYPES_UNARY(LOG10, float64)
 
 FORCE_INLINE
@@ -109,93 +155,172 @@ LOG_WITH_BASE(float32, float32, float64)
 LOG_WITH_BASE(float64, float64, float64)
 
 // Sin
-#define SIN(IN_TYPE, OUT_TYPE)                                             \
-  FORCE_INLINE                                                             \
-  gdv_##OUT_TYPE sin_##IN_TYPE(gdv_##IN_TYPE in) {                         \
-    return static_cast<gdv_##OUT_TYPE>(sin(static_cast<long double>(in))); \
+#define SIN(IN_TYPE, OUT_TYPE)                                              \
+  FORCE_INLINE                                                              \
+  gdv_##OUT_TYPE sin_##IN_TYPE(gdv_##IN_TYPE in) {                          \
+    return static_cast<gdv_##OUT_TYPE>(sinl(static_cast<long double>(in))); \
   }
 ENUMERIC_TYPES_UNARY(SIN, float64)
 
+#define SINF(IN_TYPE, OUT_TYPE)                                       \
+  FORCE_INLINE                                                        \
+  gdv_##OUT_TYPE sinf_##IN_TYPE(gdv_##IN_TYPE in) {                   \
+    return static_cast<gdv_##OUT_TYPE>(sinf(static_cast<float>(in))); \
+  }
+
+ENUMERIC_TYPES_UNARY_FLOAT(SINF, float32)
+
 // Asin
-#define ASIN(IN_TYPE, OUT_TYPE)                                             \
-  FORCE_INLINE                                                              \
-  gdv_##OUT_TYPE asin_##IN_TYPE(gdv_##IN_TYPE in) {                         \
-    return static_cast<gdv_##OUT_TYPE>(asin(static_cast<long double>(in))); \
+#define ASIN(IN_TYPE, OUT_TYPE)                                              \
+  FORCE_INLINE                                                               \
+  gdv_##OUT_TYPE asin_##IN_TYPE(gdv_##IN_TYPE in) {                          \
+    return static_cast<gdv_##OUT_TYPE>(asinl(static_cast<long double>(in))); \
   }
 ENUMERIC_TYPES_UNARY(ASIN, float64)
 
+#define ASINF(IN_TYPE, OUT_TYPE)                                       \
+  FORCE_INLINE                                                         \
+  gdv_##OUT_TYPE asinf_##IN_TYPE(gdv_##IN_TYPE in) {                   \
+    return static_cast<gdv_##OUT_TYPE>(asinf(static_cast<float>(in))); \
+  }
+ENUMERIC_TYPES_UNARY_FLOAT(ASINF, float32)
+
 // Cos
-#define COS(IN_TYPE, OUT_TYPE)                                             \
-  FORCE_INLINE                                                             \
-  gdv_##OUT_TYPE cos_##IN_TYPE(gdv_##IN_TYPE in) {                         \
-    return static_cast<gdv_##OUT_TYPE>(cos(static_cast<long double>(in))); \
+#define COS(IN_TYPE, OUT_TYPE)                                              \
+  FORCE_INLINE                                                              \
+  gdv_##OUT_TYPE cos_##IN_TYPE(gdv_##IN_TYPE in) {                          \
+    return static_cast<gdv_##OUT_TYPE>(cosl(static_cast<long double>(in))); \
   }
 ENUMERIC_TYPES_UNARY(COS, float64)
 
+#define COSF(IN_TYPE, OUT_TYPE)                                       \
+  FORCE_INLINE                                                        \
+  gdv_##OUT_TYPE cosf_##IN_TYPE(gdv_##IN_TYPE in) {                   \
+    return static_cast<gdv_##OUT_TYPE>(cosf(static_cast<float>(in))); \
+  }
+ENUMERIC_TYPES_UNARY_FLOAT(COSF, float32)
+
 // Acos
-#define ACOS(IN_TYPE, OUT_TYPE)                                             \
-  FORCE_INLINE                                                              \
-  gdv_##OUT_TYPE acos_##IN_TYPE(gdv_##IN_TYPE in) {                         \
-    return static_cast<gdv_##OUT_TYPE>(acos(static_cast<long double>(in))); \
+#define ACOS(IN_TYPE, OUT_TYPE)                                              \
+  FORCE_INLINE                                                               \
+  gdv_##OUT_TYPE acos_##IN_TYPE(gdv_##IN_TYPE in) {                          \
+    return static_cast<gdv_##OUT_TYPE>(acosl(static_cast<long double>(in))); \
   }
 ENUMERIC_TYPES_UNARY(ACOS, float64)
 
+#define ACOSF(IN_TYPE, OUT_TYPE)                                       \
+  FORCE_INLINE                                                         \
+  gdv_##OUT_TYPE acosf_##IN_TYPE(gdv_##IN_TYPE in) {                   \
+    return static_cast<gdv_##OUT_TYPE>(acosf(static_cast<float>(in))); \
+  }
+ENUMERIC_TYPES_UNARY_FLOAT(ACOSF, float32)
+
 // Tan
-#define TAN(IN_TYPE, OUT_TYPE)                                             \
-  FORCE_INLINE                                                             \
-  gdv_##OUT_TYPE tan_##IN_TYPE(gdv_##IN_TYPE in) {                         \
-    return static_cast<gdv_##OUT_TYPE>(tan(static_cast<long double>(in))); \
+#define TAN(IN_TYPE, OUT_TYPE)                                              \
+  FORCE_INLINE                                                              \
+  gdv_##OUT_TYPE tan_##IN_TYPE(gdv_##IN_TYPE in) {                          \
+    return static_cast<gdv_##OUT_TYPE>(tanl(static_cast<long double>(in))); \
   }
 ENUMERIC_TYPES_UNARY(TAN, float64)
 
+#define TANF(IN_TYPE, OUT_TYPE)                                       \
+  FORCE_INLINE                                                        \
+  gdv_##OUT_TYPE tanf_##IN_TYPE(gdv_##IN_TYPE in) {                   \
+    return static_cast<gdv_##OUT_TYPE>(tanf(static_cast<float>(in))); \
+  }
+ENUMERIC_TYPES_UNARY_FLOAT(TANF, float32)
+
 // Atan
-#define ATAN(IN_TYPE, OUT_TYPE)                                             \
-  FORCE_INLINE                                                              \
-  gdv_##OUT_TYPE atan_##IN_TYPE(gdv_##IN_TYPE in) {                         \
-    return static_cast<gdv_##OUT_TYPE>(atan(static_cast<long double>(in))); \
+#define ATAN(IN_TYPE, OUT_TYPE)                                              \
+  FORCE_INLINE                                                               \
+  gdv_##OUT_TYPE atan_##IN_TYPE(gdv_##IN_TYPE in) {                          \
+    return static_cast<gdv_##OUT_TYPE>(atanl(static_cast<long double>(in))); \
   }
 ENUMERIC_TYPES_UNARY(ATAN, float64)
 
+#define ATANF(IN_TYPE, OUT_TYPE)                                       \
+  FORCE_INLINE                                                         \
+  gdv_##OUT_TYPE atanf_##IN_TYPE(gdv_##IN_TYPE in) {                   \
+    return static_cast<gdv_##OUT_TYPE>(atanf(static_cast<float>(in))); \
+  }
+ENUMERIC_TYPES_UNARY_FLOAT(ATANF, float32)
+
 // Sinh
-#define SINH(IN_TYPE, OUT_TYPE)                                             \
-  FORCE_INLINE                                                              \
-  gdv_##OUT_TYPE sinh_##IN_TYPE(gdv_##IN_TYPE in) {                         \
-    return static_cast<gdv_##OUT_TYPE>(sinh(static_cast<long double>(in))); \
+#define SINH(IN_TYPE, OUT_TYPE)                                              \
+  FORCE_INLINE                                                               \
+  gdv_##OUT_TYPE sinh_##IN_TYPE(gdv_##IN_TYPE in) {                          \
+    return static_cast<gdv_##OUT_TYPE>(sinhl(static_cast<long double>(in))); \
   }
 ENUMERIC_TYPES_UNARY(SINH, float64)
 
+#define SINHF(IN_TYPE, OUT_TYPE)                                       \
+  FORCE_INLINE                                                         \
+  gdv_##OUT_TYPE sinhf_##IN_TYPE(gdv_##IN_TYPE in) {                   \
+    return static_cast<gdv_##OUT_TYPE>(sinhf(static_cast<float>(in))); \
+  }
+ENUMERIC_TYPES_UNARY_FLOAT(SINHF, float32)
+
 // Cosh
-#define COSH(IN_TYPE, OUT_TYPE)                                             \
-  FORCE_INLINE                                                              \
-  gdv_##OUT_TYPE cosh_##IN_TYPE(gdv_##IN_TYPE in) {                         \
-    return static_cast<gdv_##OUT_TYPE>(cosh(static_cast<long double>(in))); \
+#define COSH(IN_TYPE, OUT_TYPE)                                              \
+  FORCE_INLINE                                                               \
+  gdv_##OUT_TYPE cosh_##IN_TYPE(gdv_##IN_TYPE in) {                          \
+    return static_cast<gdv_##OUT_TYPE>(coshl(static_cast<long double>(in))); \
   }
 ENUMERIC_TYPES_UNARY(COSH, float64)
 
+#define COSHF(IN_TYPE, OUT_TYPE)                                       \
+  FORCE_INLINE                                                         \
+  gdv_##OUT_TYPE coshf_##IN_TYPE(gdv_##IN_TYPE in) {                   \
+    return static_cast<gdv_##OUT_TYPE>(coshf(static_cast<float>(in))); \
+  }
+ENUMERIC_TYPES_UNARY_FLOAT(COSHF, float32)
+
 // Tanh
-#define TANH(IN_TYPE, OUT_TYPE)                                             \
-  FORCE_INLINE                                                              \
-  gdv_##OUT_TYPE tanh_##IN_TYPE(gdv_##IN_TYPE in) {                         \
-    return static_cast<gdv_##OUT_TYPE>(tanh(static_cast<long double>(in))); \
+#define TANH(IN_TYPE, OUT_TYPE)                                              \
+  FORCE_INLINE                                                               \
+  gdv_##OUT_TYPE tanh_##IN_TYPE(gdv_##IN_TYPE in) {                          \
+    return static_cast<gdv_##OUT_TYPE>(tanhl(static_cast<long double>(in))); \
   }
 ENUMERIC_TYPES_UNARY(TANH, float64)
+
+#define TANHF(IN_TYPE, OUT_TYPE)                                       \
+  FORCE_INLINE                                                         \
+  gdv_##OUT_TYPE tanhf_##IN_TYPE(gdv_##IN_TYPE in) {                   \
+    return static_cast<gdv_##OUT_TYPE>(tanhf(static_cast<float>(in))); \
+  }
+ENUMERIC_TYPES_UNARY_FLOAT(TANHF, float32)
 
 // Atan2
 #define ATAN2(IN_TYPE, OUT_TYPE)                                                     \
   FORCE_INLINE                                                                       \
   gdv_##OUT_TYPE atan2_##IN_TYPE##_##IN_TYPE(gdv_##IN_TYPE in1, gdv_##IN_TYPE in2) { \
     return static_cast<gdv_##OUT_TYPE>(                                              \
-        atan2(static_cast<long double>(in1), static_cast<long double>(in2)));        \
+        atan2l(static_cast<long double>(in1), static_cast<long double>(in2)));       \
   }
 ENUMERIC_TYPES_UNARY(ATAN2, float64)
 
-// Cot
-#define COT(IN_TYPE, OUT_TYPE)                                                        \
+#define ATAN2F(IN_TYPE, OUT_TYPE)                                                     \
   FORCE_INLINE                                                                        \
-  gdv_##OUT_TYPE cot_##IN_TYPE(gdv_##IN_TYPE in) {                                    \
-    return static_cast<gdv_##OUT_TYPE>(tan(M_PI / 2 - static_cast<long double>(in))); \
+  gdv_##OUT_TYPE atan2f_##IN_TYPE##_##IN_TYPE(gdv_##IN_TYPE in1, gdv_##IN_TYPE in2) { \
+    return static_cast<gdv_##OUT_TYPE>(                                               \
+        atan2f(static_cast<float>(in1), static_cast<float>(in2)));                    \
+  }
+ENUMERIC_TYPES_UNARY_FLOAT(ATAN2F, float32)
+
+// Cot
+#define COT(IN_TYPE, OUT_TYPE)                                                         \
+  FORCE_INLINE                                                                         \
+  gdv_##OUT_TYPE cot_##IN_TYPE(gdv_##IN_TYPE in) {                                     \
+    return static_cast<gdv_##OUT_TYPE>(tanl(M_PI / 2 - static_cast<long double>(in))); \
   }
 ENUMERIC_TYPES_UNARY(COT, float64)
+
+#define COTF(IN_TYPE, OUT_TYPE)                                                  \
+  FORCE_INLINE                                                                   \
+  gdv_##OUT_TYPE cotf_##IN_TYPE(gdv_##IN_TYPE in) {                              \
+    return static_cast<gdv_##OUT_TYPE>(tanf(M_PI / 2 - static_cast<float>(in))); \
+  }
+ENUMERIC_TYPES_UNARY_FLOAT(COTF, float32)
 
 // Radians
 #define RADIANS(IN_TYPE, OUT_TYPE)                                                   \
@@ -214,12 +339,33 @@ ENUMERIC_TYPES_UNARY(RADIANS, float64)
 ENUMERIC_TYPES_UNARY(DEGREES, float64)
 
 // power
+#define POWERF(IN_TYPE1, IN_TYPE2, OUT_TYPE)                          \
+  FORCE_INLINE                                                        \
+  gdv_##OUT_TYPE powerf_##IN_TYPE1##_##IN_TYPE2(gdv_##IN_TYPE1 in1,   \
+                                                gdv_##IN_TYPE2 in2) { \
+    return static_cast<gdv_float32>(powf(in1, in2));                  \
+  }
 #define POWER(IN_TYPE1, IN_TYPE2, OUT_TYPE)                                              \
   FORCE_INLINE                                                                           \
   gdv_##OUT_TYPE power_##IN_TYPE1##_##IN_TYPE2(gdv_##IN_TYPE1 in1, gdv_##IN_TYPE2 in2) { \
     return static_cast<gdv_float64>(powl(in1, in2));                                     \
   }
+
+POWERF(float32, float32, float32)
 POWER(float64, float64, float64)
+
+// ABS
+#define ABSF(IN_TYPE, OUT_TYPE)                     \
+  FORCE_INLINE                                      \
+  gdv_##OUT_TYPE absf_##IN_TYPE(gdv_##IN_TYPE in) { \
+    if (static_cast<gdv_##IN_TYPE>(in) < 0) {       \
+      return static_cast<gdv_##OUT_TYPE>(-in);      \
+    } else {                                        \
+      return static_cast<gdv_##OUT_TYPE>(in);       \
+    }                                               \
+  }
+
+ABSF(float32, float32)
 
 FORCE_INLINE
 gdv_int32 round_int32(gdv_int32 num) { return num; }

--- a/cpp/src/gandiva/precompiled/extended_math_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/extended_math_ops_test.cc
@@ -19,6 +19,7 @@
 #define M_PI 3.14159265358979323846
 #endif
 
+#include <gandiva/precompiled/testing.h>
 #include <gtest/gtest.h>
 
 #include <cmath>
@@ -28,10 +29,14 @@
 
 namespace gandiva {
 
-static const double MAX_ERROR = 0.00005;
+TEST(TestExtendedMathOps, TestSqrt) {
+  VerifyFuzzyEquals(sqrt_int32(9), 3);
+  VerifyFuzzyEquals(sqrt_int64(9), 3);
+  VerifyFuzzyEquals(sqrt_float32(9), 3);
+  VerifyFuzzyEquals(sqrt_float64(9), 3);
 
-void VerifyFuzzyEquals(double actual, double expected, double max_error = MAX_ERROR) {
-  EXPECT_TRUE(fabs(actual - expected) < max_error) << actual << " != " << expected;
+  VerifyFuzzyEquals(sqrt_float32(6.25), 2.5);
+  VerifyFuzzyEquals(sqrt_float64(6.25), 2.5);
 }
 
 TEST(TestExtendedMathOps, TestCbrt) {
@@ -224,6 +229,11 @@ TEST(TestExtendedMathOps, TestTrigonometricFunctions) {
   VerifyFuzzyEquals(sin_float64(-M_PI / 2), sin(-M_PI / 2));
   VerifyFuzzyEquals(sin_int32(0), sin(0));
   VerifyFuzzyEquals(sin_int64(0), sin(0));
+  VerifyFuzzyEquals(sinf_float32(0), sin(0));
+  VerifyFuzzyEquals(sinf_float32(0), sin(0));
+  VerifyFuzzyEquals(sinf_float32(pi_float / 2), sin(M_PI / 2));
+  VerifyFuzzyEquals(sinf_float32(pi_float), sin(M_PI));
+  VerifyFuzzyEquals(sinf_float32(-pi_float / 2), sin(-M_PI / 2));
 
   // Cos functions
   VerifyFuzzyEquals(cos_float32(0), cos(0));
@@ -236,6 +246,10 @@ TEST(TestExtendedMathOps, TestTrigonometricFunctions) {
   VerifyFuzzyEquals(cos_float64(-M_PI / 2), cos(-M_PI / 2));
   VerifyFuzzyEquals(cos_int32(0), cos(0));
   VerifyFuzzyEquals(cos_int64(0), cos(0));
+  VerifyFuzzyEquals(cosf_float32(0), cos(0));
+  VerifyFuzzyEquals(cosf_float32(pi_float / 2), cos(M_PI / 2));
+  VerifyFuzzyEquals(cosf_float32(pi_float), cos(M_PI));
+  VerifyFuzzyEquals(cosf_float32(-pi_float / 2), cos(-M_PI / 2));
 
   // Asin functions
   VerifyFuzzyEquals(asin_float32(-1.0), asin(-1.0));
@@ -244,6 +258,8 @@ TEST(TestExtendedMathOps, TestTrigonometricFunctions) {
   VerifyFuzzyEquals(asin_float64(1.0), asin(1.0));
   VerifyFuzzyEquals(asin_int32(0), asin(0));
   VerifyFuzzyEquals(asin_int64(0), asin(0));
+  VerifyFuzzyEquals(asinf_float32(-1.0), asin(-1.0));
+  VerifyFuzzyEquals(asinf_float32(1.0), asin(1.0));
 
   // Acos functions
   VerifyFuzzyEquals(acos_float32(-1.0), acos(-1.0));
@@ -252,6 +268,8 @@ TEST(TestExtendedMathOps, TestTrigonometricFunctions) {
   VerifyFuzzyEquals(acos_float64(1.0), acos(1.0));
   VerifyFuzzyEquals(acos_int32(0), acos(0));
   VerifyFuzzyEquals(acos_int64(0), acos(0));
+  VerifyFuzzyEquals(acosf_float32(-1.0), acos(-1.0));
+  VerifyFuzzyEquals(acosf_float32(1.0), acos(1.0));
 
   // Tan
   VerifyFuzzyEquals(tan_float32(pi_float), tan(M_PI));
@@ -260,6 +278,8 @@ TEST(TestExtendedMathOps, TestTrigonometricFunctions) {
   VerifyFuzzyEquals(tan_float64(-M_PI), tan(-M_PI));
   VerifyFuzzyEquals(tan_int32(0), tan(0));
   VerifyFuzzyEquals(tan_int64(0), tan(0));
+  VerifyFuzzyEquals(tanf_float32(pi_float), tan(M_PI));
+  VerifyFuzzyEquals(tanf_float32(-pi_float), tan(-M_PI));
 
   // Atan
   VerifyFuzzyEquals(atan_float32(pi_float), atan(M_PI));
@@ -268,6 +288,8 @@ TEST(TestExtendedMathOps, TestTrigonometricFunctions) {
   VerifyFuzzyEquals(atan_float64(-M_PI), atan(-M_PI));
   VerifyFuzzyEquals(atan_int32(0), atan(0));
   VerifyFuzzyEquals(atan_int64(0), atan(0));
+  VerifyFuzzyEquals(atanf_float32(pi_float), atan(M_PI));
+  VerifyFuzzyEquals(atanf_float32(-pi_float), atan(-M_PI));
 
   // Sinh functions
   VerifyFuzzyEquals(sinh_float32(0), sinh(0));
@@ -280,6 +302,10 @@ TEST(TestExtendedMathOps, TestTrigonometricFunctions) {
   VerifyFuzzyEquals(sinh_float64(-M_PI / 2), sinh(-M_PI / 2));
   VerifyFuzzyEquals(sinh_int32(0), sinh(0));
   VerifyFuzzyEquals(sinh_int64(0), sinh(0));
+  VerifyFuzzyEquals(sinhf_float32(0), sinh(0));
+  VerifyFuzzyEquals(sinhf_float32(pi_float / 2), sinh(M_PI / 2));
+  VerifyFuzzyEquals(sinhf_float32(pi_float), sinh(M_PI));
+  VerifyFuzzyEquals(sinhf_float32(-pi_float / 2), sinh(-M_PI / 2));
 
   // Cosh functions
   VerifyFuzzyEquals(cosh_float32(0), cosh(0));
@@ -292,6 +318,10 @@ TEST(TestExtendedMathOps, TestTrigonometricFunctions) {
   VerifyFuzzyEquals(cosh_float64(-M_PI / 2), cosh(-M_PI / 2));
   VerifyFuzzyEquals(cosh_int32(0), cosh(0));
   VerifyFuzzyEquals(cosh_int64(0), cosh(0));
+  VerifyFuzzyEquals(coshf_float32(0), cosh(0));
+  VerifyFuzzyEquals(coshf_float32(pi_float / 2), cosh(M_PI / 2));
+  VerifyFuzzyEquals(coshf_float32(pi_float), cosh(M_PI));
+  VerifyFuzzyEquals(coshf_float32(-pi_float / 2), cosh(-M_PI / 2));
 
   // Tanh
   VerifyFuzzyEquals(tanh_float32(pi_float), tanh(M_PI));
@@ -300,6 +330,8 @@ TEST(TestExtendedMathOps, TestTrigonometricFunctions) {
   VerifyFuzzyEquals(tanh_float64(-M_PI), tanh(-M_PI));
   VerifyFuzzyEquals(tanh_int32(0), tanh(0));
   VerifyFuzzyEquals(tanh_int64(0), tanh(0));
+  VerifyFuzzyEquals(tanhf_float32(pi_float), tanh(M_PI));
+  VerifyFuzzyEquals(tanhf_float32(-pi_float), tanh(-M_PI));
 
   // Atan2
   VerifyFuzzyEquals(atan2_float32_float32(1, 0), atan2(1, 0));
@@ -308,6 +340,8 @@ TEST(TestExtendedMathOps, TestTrigonometricFunctions) {
   VerifyFuzzyEquals(atan2_float64_float64(-1, 0), atan2(-1, 0));
   VerifyFuzzyEquals(atan2_int32_int32(1, 0), atan2(1, 0));
   VerifyFuzzyEquals(atan2_int64_int64(-1, 0), atan2(-1, 0));
+  VerifyFuzzyEquals(atan2f_float32_float32(1, 0), atan2(1, 0));
+  VerifyFuzzyEquals(atan2f_float32_float32(-1.0, 0), atan2(-1, 0));
 
   // Radians
   VerifyFuzzyEquals(radians_float32(0), 0);
@@ -332,6 +366,7 @@ TEST(TestExtendedMathOps, TestTrigonometricFunctions) {
   // Cot
   VerifyFuzzyEquals(cot_float32(pi_float / 2), tan(M_PI / 2 - M_PI / 2));
   VerifyFuzzyEquals(cot_float64(M_PI / 2), tan(M_PI / 2 - M_PI / 2));
+  VerifyFuzzyEquals(cotf_float32(pi_float / 2), tan(M_PI / 2 - M_PI / 2));
 }
 
 TEST(TestExtendedMathOps, TestBinRepresentation) {

--- a/cpp/src/gandiva/precompiled/testing.h
+++ b/cpp/src/gandiva/precompiled/testing.h
@@ -40,4 +40,11 @@ static inline gdv_timestamp StringToTimestamp(const std::string& s) {
   return out * 1000;
 }
 
+static const double MAX_ERROR = 0.00005;
+
+void inline VerifyFuzzyEquals(double actual, double expected,
+                              double max_error = MAX_ERROR) {
+  EXPECT_TRUE(fabs(actual - expected) < max_error) << actual << " != " << expected;
+}
+
 }  // namespace gandiva

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -251,6 +251,10 @@ gdv_int64 round_int64_int32(gdv_int64 number, gdv_int32 precision);
 gdv_int32 round_int32(gdv_int32);
 gdv_int64 round_int64(gdv_int64);
 gdv_int64 get_power_of_10(gdv_int32);
+gdv_float64 sqrt_int32(gdv_int32);
+gdv_float64 sqrt_int64(gdv_int64);
+gdv_float64 sqrt_float32(gdv_float32);
+gdv_float64 sqrt_float64(gdv_float64);
 
 const char* bin_int32(int64_t context, gdv_int32 value, int32_t* out_len);
 const char* bin_int64(int64_t context, gdv_int64 value, int32_t* out_len);
@@ -317,6 +321,29 @@ gdv_float64 atan2_float32_float32(gdv_float32 in1, gdv_float32 in2);
 gdv_float64 atan2_float64_float64(gdv_float64 in1, gdv_float64 in2);
 gdv_float64 cot_float32(gdv_float32);
 gdv_float64 cot_float64(gdv_float64);
+
+gdv_float32 sinf_int32(gdv_int32);
+gdv_float32 sinf_float32(gdv_float32);
+gdv_float32 cosf_int32(gdv_int32);
+gdv_float32 cosf_float32(gdv_float32);
+gdv_float32 asinf_int32(gdv_int32);
+gdv_float32 asinf_float32(gdv_float32);
+gdv_float32 acosf_int32(gdv_int32);
+gdv_float32 acosf_float32(gdv_float32);
+gdv_float32 tanf_int32(gdv_int32);
+gdv_float32 tanf_float32(gdv_float32);
+gdv_float32 atanf_int32(gdv_int32);
+gdv_float32 atanf_float32(gdv_float32);
+gdv_float32 sinhf_int32(gdv_int32);
+gdv_float32 sinhf_float32(gdv_float32);
+gdv_float32 coshf_int32(gdv_int32);
+gdv_float32 coshf_float32(gdv_float32);
+gdv_float32 tanhf_int32(gdv_int32);
+gdv_float32 tanhf_float32(gdv_float32);
+gdv_float32 atan2f_int32_int32(gdv_int32 in1, gdv_int32 in2);
+gdv_float32 atan2f_float32_float32(gdv_float32 in1, gdv_float32 in2);
+gdv_float32 cotf_float32(gdv_float32);
+
 gdv_float64 radians_int32(gdv_int32);
 gdv_float64 radians_int64(gdv_int64);
 gdv_float64 radians_float32(gdv_float32);
@@ -334,6 +361,42 @@ gdv_int32 bitwise_xor_int32_int32(gdv_int32 in1, gdv_int32 in2);
 gdv_int64 bitwise_xor_int64_int64(gdv_int64 in1, gdv_int64 in2);
 gdv_int32 bitwise_not_int32(gdv_int32);
 gdv_int64 bitwise_not_int64(gdv_int64);
+gdv_uint32 bitwise_and_uint32_uint32(gdv_uint32 in1, gdv_uint32 in2);
+gdv_uint64 bitwise_and_uint64_uint64(gdv_uint64 in1, gdv_uint64 in2);
+gdv_uint32 bitwise_or_uint32_uint32(gdv_uint32 in1, gdv_uint32 in2);
+gdv_uint64 bitwise_or_uint64_uint64(gdv_uint64 in1, gdv_uint64 in2);
+gdv_uint32 bitwise_xor_uint32_uint32(gdv_uint32 in1, gdv_uint32 in2);
+gdv_uint64 bitwise_xor_uint64_uint64(gdv_uint64 in1, gdv_uint64 in2);
+gdv_uint16 bitwise_and_uint16_uint16(gdv_uint16 in1, gdv_uint16 in2);
+gdv_uint8 bitwise_and_uint8_uint8(gdv_uint8 in1, gdv_uint8 in2);
+gdv_uint16 bitwise_or_uint16_uint16(gdv_uint16 in1, gdv_uint16 in2);
+gdv_uint8 bitwise_or_uint8_uint8(gdv_uint8 in1, gdv_uint8 in2);
+gdv_uint16 bitwise_xor_uint16_uint16(gdv_uint16 in1, gdv_uint16 in2);
+gdv_uint8 bitwise_xor_uint8_uint8(gdv_uint8 in1, gdv_uint8 in2);
+gdv_uint32 bitwise_not_uint32(gdv_uint32);
+gdv_uint64 bitwise_not_uint64(gdv_uint64);
+gdv_uint16 bitwise_not_uint16(gdv_uint16);
+gdv_uint8 bitwise_not_uint8(gdv_uint8);
+
+gdv_float32 sqrtf_int32(gdv_int32);
+gdv_float32 sqrtf_int64(gdv_int64);
+gdv_float32 sqrtf_float32(gdv_float32);
+
+gdv_float32 cbrtf_int32(gdv_int32);
+gdv_float32 cbrtf_int64(gdv_int64);
+gdv_float32 cbrtf_float32(gdv_float32);
+
+gdv_float32 expf_int32(gdv_int32);
+gdv_float32 expf_int64(gdv_int64);
+gdv_float32 expf_float32(gdv_float32);
+
+gdv_float32 logf_int32(gdv_int32);
+gdv_float32 logf_int64(gdv_int64);
+gdv_float32 logf_float32(gdv_float32);
+
+gdv_float32 log10f_int32(gdv_int32);
+gdv_float32 log10f_int64(gdv_int64);
+gdv_float32 log10f_float32(gdv_float32);
 
 gdv_int32 greatest_int32_int32(gdv_int32 in1, gdv_int32 in2);
 gdv_int64 greatest_int64_int64(gdv_int64 in1, gdv_int64 in2);


### PR DESCRIPTION
### Rationale for this change

A number of trivial functions, or trivial functions acting on different data types (e.g. float rather than double) is currently missing in Gandiva. This PR  introduces a number of them, as requested in [GH-34068](https://github.com/apache/arrow/issues/34068). While the patch is quite straightforward, the goal is to avoid having to maintain them in our own private branch and we are happy to donate it to the community.

### What changes are included in this PR?

* Additional native functions for float32 in Gandiva
* Extend bitwise operations for more int types
* Adapt to upstream trigonometric function definitions
* Prevent clash with c++ variant

### Are these changes tested?

We updated the unit tests for added functions and we (ALICE experiment at the LHC) are currently using them to analyse  terabytes (if not yet petabytes) of data.

### Are there any user-facing changes?

There are not any user facing changes unless you consider the availability of the new Gandiva functions as such. As far as we understand, this PR is not breaking any public APIs.
* Closes: #34068