### PR TITLE
GH-33850: [C++] Allow Substrait's default extension provider to be configured (fix)

### DIFF
--- a/cpp/src/arrow/engine/substrait/options.cc
+++ b/cpp/src/arrow/engine/substrait/options.cc
@@ -18,6 +18,8 @@
 #include "arrow/engine/substrait/options.h"
 
 #include <google/protobuf/util/json_util.h>
+#include <mutex>
+
 #include "arrow/compute/exec/asof_join_node.h"
 #include "arrow/compute/exec/options.h"
 #include "arrow/engine/substrait/expression_internal.h"


### PR DESCRIPTION
See [this post](https://github.com/apache/arrow/pull/34042#issuecomment-1422191511) for background.
* Closes: #33850