### PR TITLE
GH-34074: [GLib][FlightRPC] Add support for authentication

### DIFF
--- a/c_glib/Gemfile
+++ b/c_glib/Gemfile
@@ -20,4 +20,4 @@
 source "https://rubygems.org/"
 
 gem "test-unit"
-gem "gobject-introspection", ">= 3.4.9"
+gem "gobject-introspection", ">= 4.1.1"

--- a/c_glib/arrow-flight-glib/client.h
+++ b/c_glib/arrow-flight-glib/client.h
@@ -105,6 +105,16 @@ gboolean
 gaflight_client_close(GAFlightClient *client,
                       GError **error);
 
+GARROW_AVAILABLE_IN_12_0
+gboolean
+gaflight_client_authenticate_basic_token(GAFlightClient *client,
+                                         const gchar *user,
+                                         const gchar *password,
+                                         GAFlightCallOptions *options,
+                                         gchar **bearer_name,
+                                         gchar **bearer_value,
+                                         GError **error);
+
 GARROW_AVAILABLE_IN_5_0
 GList *
 gaflight_client_list_flights(GAFlightClient *client,

--- a/c_glib/arrow-flight-glib/server.h
+++ b/c_glib/arrow-flight-glib/server.h
@@ -55,6 +55,101 @@ gaflight_record_batch_stream_new(GArrowRecordBatchReader *reader,
                                  GArrowWriteOptions *options);
 
 
+#define GAFLIGHT_TYPE_SERVER_AUTH_SENDER        \
+  (gaflight_server_auth_sender_get_type())
+G_DECLARE_DERIVABLE_TYPE(GAFlightServerAuthSender,
+                         gaflight_server_auth_sender,
+                         GAFLIGHT,
+                         SERVER_AUTH_SENDER,
+                         GObject)
+struct _GAFlightServerAuthSenderClass
+{
+  GObjectClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_12_0
+gboolean
+gaflight_server_auth_sender_write(GAFlightServerAuthSender *sender,
+                                  GBytes *message,
+                                  GError **error);
+
+
+#define GAFLIGHT_TYPE_SERVER_AUTH_READER        \
+  (gaflight_server_auth_reader_get_type())
+G_DECLARE_DERIVABLE_TYPE(GAFlightServerAuthReader,
+                         gaflight_server_auth_reader,
+                         GAFLIGHT,
+                         SERVER_AUTH_READER,
+                         GObject)
+struct _GAFlightServerAuthReaderClass
+{
+  GObjectClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_12_0
+GBytes *
+gaflight_server_auth_reader_read(GAFlightServerAuthReader *reader,
+                                 GError **error);
+
+
+#define GAFLIGHT_TYPE_SERVER_AUTH_HANDLER       \
+  (gaflight_server_auth_handler_get_type())
+G_DECLARE_DERIVABLE_TYPE(GAFlightServerAuthHandler,
+                         gaflight_server_auth_handler,
+                         GAFLIGHT,
+                         SERVER_AUTH_HANDLER,
+                         GObject)
+struct _GAFlightServerAuthHandlerClass
+{
+  GObjectClass parent_class;
+};
+
+#define GAFLIGHT_TYPE_SERVER_CUSTOM_AUTH_HANDLER       \
+  (gaflight_server_custom_auth_handler_get_type())
+G_DECLARE_DERIVABLE_TYPE(GAFlightServerCustomAuthHandler,
+                         gaflight_server_custom_auth_handler,
+                         GAFLIGHT,
+                         SERVER_CUSTOM_AUTH_HANDLER,
+                         GAFlightServerAuthHandler)
+/**
+ * GAFlightServerCustomAuthHandlerClass:
+ * @authenticate: Authenticates the client on initial connection. The server
+ *   can send and read responses from the client at any time.
+ * @is_valid: Validates a per-call client token.
+ *
+ * Since: 12.0.0
+ */
+struct _GAFlightServerCustomAuthHandlerClass
+{
+  GAFlightServerAuthHandlerClass parent_class;
+
+  void (*authenticate)(GAFlightServerCustomAuthHandler *handler,
+                       GAFlightServerAuthSender *sender,
+                       GAFlightServerAuthReader *reader,
+                       GError **error);
+  void (*is_valid)(GAFlightServerCustomAuthHandler *handler,
+                   GBytes *token,
+                   GBytes **peer_identity,
+                   GError **error);
+};
+
+GARROW_AVAILABLE_IN_12_0
+void
+gaflight_server_custom_auth_handler_authenticate(
+  GAFlightServerCustomAuthHandler *handler,
+  GAFlightServerAuthSender *sender,
+  GAFlightServerAuthReader *reader,
+  GError **error);
+
+GARROW_AVAILABLE_IN_12_0
+void
+gaflight_server_custom_auth_handler_is_valid(
+  GAFlightServerCustomAuthHandler *handler,
+  GBytes *token,
+  GBytes **peer_identity,
+  GError **error);
+
+
 #define GAFLIGHT_TYPE_SERVER_OPTIONS (gaflight_server_options_get_type())
 G_DECLARE_DERIVABLE_TYPE(GAFlightServerOptions,
                          gaflight_server_options,

--- a/c_glib/arrow-flight-glib/server.hpp
+++ b/c_glib/arrow-flight-glib/server.hpp
@@ -27,6 +27,21 @@
 arrow::flight::FlightDataStream *
 gaflight_data_stream_get_raw(GAFlightDataStream *stream);
 
+GAFlightServerAuthSender *
+gaflight_server_auth_sender_new_raw(
+  arrow::flight::ServerAuthSender *flight_sender);
+arrow::flight::ServerAuthSender *
+gaflight_server_auth_sender_get_raw(GAFlightServerAuthSender *sender);
+
+GAFlightServerAuthReader *
+gaflight_server_auth_reader_new_raw(
+  arrow::flight::ServerAuthReader *flight_reader);
+arrow::flight::ServerAuthReader *
+gaflight_server_auth_reader_get_raw(GAFlightServerAuthReader *reader);
+
+std::shared_ptr<arrow::flight::ServerAuthHandler>
+gaflight_server_auth_handler_get_raw(GAFlightServerAuthHandler *handler);
+
 arrow::flight::FlightServerOptions *
 gaflight_server_options_get_raw(GAFlightServerOptions *options);
 

--- a/c_glib/arrow-glib/version.h.in
+++ b/c_glib/arrow-glib/version.h.in
@@ -111,6 +111,15 @@
 #endif
 
 /**
+ * GARROW_VERSION_12_0:
+ *
+ * You can use this macro value for compile time API version check.
+ *
+ * Since: 12.0.0
+ */
+#define GARROW_VERSION_12_0 G_ENCODE_VERSION(12, 0)
+
+/**
  * GARROW_VERSION_11_0:
  *
  * You can use this macro value for compile time API version check.
@@ -318,6 +327,20 @@
 
 
 #define GARROW_AVAILABLE_IN_ALL
+
+#if GARROW_VERSION_MIN_REQUIRED >= GARROW_VERSION_12_0
+#  define GARROW_DEPRECATED_IN_12_0                GARROW_DEPRECATED
+#  define GARROW_DEPRECATED_IN_12_0_FOR(function)  GARROW_DEPRECATED_FOR(function)
+#else
+#  define GARROW_DEPRECATED_IN_12_0
+#  define GARROW_DEPRECATED_IN_12_0_FOR(function)
+#endif
+
+#if GARROW_VERSION_MAX_ALLOWED < GARROW_VERSION_12_0
+#  define GARROW_AVAILABLE_IN_12_0 GARROW_UNAVAILABLE(12, 0)
+#else
+#  define GARROW_AVAILABLE_IN_12_0
+#endif
 
 #if GARROW_VERSION_MIN_REQUIRED >= GARROW_VERSION_11_0
 #  define GARROW_DEPRECATED_IN_11_0                GARROW_DEPRECATED

--- a/c_glib/doc/arrow-flight-glib/arrow-flight-glib-docs.xml
+++ b/c_glib/doc/arrow-flight-glib/arrow-flight-glib-docs.xml
@@ -55,6 +55,10 @@
     <title>Index of deprecated API</title>
     <xi:include href="xml/api-index-deprecated.xml"><xi:fallback /></xi:include>
   </index>
+  <index id="api-index-12-0-0" role="12.0.0">
+    <title>Index of new symbols in 12.0.0</title>
+    <xi:include href="xml/api-index-12.0.0.xml"><xi:fallback /></xi:include>
+  </index>
   <index id="api-index-6-0-0" role="6.0.0">
     <title>Index of new symbols in 6.0.0</title>
     <xi:include href="xml/api-index-6.0.0.xml"><xi:fallback /></xi:include>

--- a/c_glib/doc/arrow-glib/arrow-glib-docs.xml
+++ b/c_glib/doc/arrow-glib/arrow-glib-docs.xml
@@ -193,6 +193,10 @@
     <title>Index of deprecated API</title>
     <xi:include href="xml/api-index-deprecated.xml"><xi:fallback /></xi:include>
   </index>
+  <index id="api-index-12-0-0" role="12.0.0">
+    <title>Index of new symbols in 12.0.0</title>
+    <xi:include href="xml/api-index-12.0.0.xml"><xi:fallback /></xi:include>
+  </index>
   <index id="api-index-11-0-0" role="11.0.0">
     <title>Index of new symbols in 11.0.0</title>
     <xi:include href="xml/api-index-11.0.0.xml"><xi:fallback /></xi:include>

--- a/c_glib/test/flight/test-client.rb
+++ b/c_glib/test/flight/test-client.rb
@@ -27,6 +27,7 @@ class TestFlightClient < Test::Unit::TestCase
     host = "127.0.0.1"
     location = ArrowFlight::Location.new("grpc://#{host}:0")
     options = ArrowFlight::ServerOptions.new(location)
+    options.auth_handler = Helper::FlightAuthHandler.new
     @server.listen(options)
     @location = ArrowFlight::Location.new("grpc://#{host}:#{@server.port}")
   end
@@ -41,6 +42,13 @@ class TestFlightClient < Test::Unit::TestCase
     client.close
     # Idempotent
     client.close
+  end
+
+  def test_authenticate_basic_token
+    client = ArrowFlight::Client.new(@location)
+    generator = Helper::FlightInfoGenerator.new
+    assert_equal([true, "", ""],
+                 client.authenticate_basic_token("user", "password"))
   end
 
   def test_list_flights

--- a/c_glib/test/helper/flight-server.rb
+++ b/c_glib/test/helper/flight-server.rb
@@ -27,7 +27,7 @@ module Helper
     end
 
     def virtual_do_is_valid(token)
-      GLib::Bytes.new("identity")
+      "identity"
     end
   end
 

--- a/c_glib/test/helper/flight-server.rb
+++ b/c_glib/test/helper/flight-server.rb
@@ -18,6 +18,19 @@
 require_relative "flight-info-generator"
 
 module Helper
+  class FlightAuthHandler < ArrowFlight::ServerCustomAuthHandler
+    type_register
+
+    private
+    def virtual_do_authenticate(sender, reader)
+      true
+    end
+
+    def virtual_do_is_valid(token)
+      GLib::Bytes.new("identity")
+    end
+  end
+
   class FlightServer < ArrowFlight::Server
     type_register
 


### PR DESCRIPTION
### Rationale for this change

Authentication related features are missing.

### What changes are included in this PR?

New APIs:

* `gaflight_client_authenticate_basic_token()`
* `GAFlightServerAuthSender`
* `GAFlightServerAuthReader`
* `GAFlightServerAuthHandler`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #34074