### PR TITLE
GH-34082: [Packaging][deb] Follow Debian bookworm image change

### DIFF
--- a/dev/release/verify-apt.sh
+++ b/dev/release/verify-apt.sh
@@ -68,6 +68,12 @@ have_plasma=yes
 have_python=yes
 workaround_missing_packages=()
 case "${distribution}-${code_name}" in
+  debian-bookworm)
+    sed \
+      -i"" \
+      -e "s/ main$/ main contrib non-free/g" \
+      /etc/apt/sources.list.d/debian.sources
+    ;;
   debian-*)
     sed \
       -i"" \

--- a/dev/tasks/linux-packages/apache-arrow/apt/debian-bookworm/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/debian-bookworm/Dockerfile
@@ -26,7 +26,11 @@ RUN \
   echo 'APT::Install-Recommends "false";' > \
     /etc/apt/apt.conf.d/disable-install-recommends
 
-RUN sed -i'' -e 's/main$/main contrib non-free/g' /etc/apt/sources.list
+RUN \
+  sed \
+    -i'' \
+    -e 's/main$/main contrib non-free/g' \
+    /etc/apt/sources.list.d/debian.sources
 
 ARG DEBUG
 RUN \


### PR DESCRIPTION
### Rationale for this change

Sources file was moved to /etc/apt/sources.list.d/debian.sources from /etc/apt/sources.list.

### What changes are included in this PR?

Follow the change.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #34082