### PR TITLE
GH-34086: [C++][Parquet] Fix writing num_rows to data page v2

### DIFF
--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -642,6 +642,7 @@ class ColumnWriterImpl {
         allocator_(properties->memory_pool()),
         num_buffered_values_(0),
         num_buffered_encoded_values_(0),
+        num_buffered_rows_(0),
         rows_written_(0),
         total_bytes_written_(0),
         total_compressed_bytes_(0),
@@ -742,9 +743,12 @@ class ColumnWriterImpl {
   // case.
   int64_t num_buffered_values_;
 
-  // The total number of stored values. For repeated or optional values, this
-  // number may be lower than num_buffered_values_.
+  // The total number of stored values in the data page. For repeated or optional
+  // values, this number may be lower than num_buffered_values_.
   int64_t num_buffered_encoded_values_;
+
+  // Total number of rows buffered in the data page.
+  int64_t num_buffered_rows_;
 
   // Total number of rows written with this ColumnWriter
   int64_t rows_written_;
@@ -854,7 +858,20 @@ void ColumnWriterImpl::AddDataPage() {
   InitSinks();
   num_buffered_values_ = 0;
   num_buffered_encoded_values_ = 0;
+  num_buffered_rows_ = 0;
 }
+
+namespace {
+
+int32_t safe_cast_64_to_32(int64_t value) {
+  if (value > std::numeric_limits<int32_t>::max() ||
+      value < std::numeric_limits<int32_t>::min()) {
+    throw ParquetException("Cannot cast ", value, " to int32_t");
+  }
+  return static_cast<int32_t>(value);
+}
+
+}  // namespace
 
 void ColumnWriterImpl::BuildDataPageV1(int64_t definition_levels_rle_size,
                                        int64_t repetition_levels_rle_size,
@@ -879,6 +896,8 @@ void ColumnWriterImpl::BuildDataPageV1(int64_t definition_levels_rle_size,
     compressed_data = uncompressed_data_;
   }
 
+  const int32_t num_values = safe_cast_64_to_32(num_buffered_values_);
+
   // Write the page to OutputStream eagerly if there is no dictionary or
   // if dictionary encoding has fallen back to PLAIN
   if (has_dictionary_ && !fallback_) {  // Save pages until end of dictionary encoding
@@ -886,15 +905,14 @@ void ColumnWriterImpl::BuildDataPageV1(int64_t definition_levels_rle_size,
         auto compressed_data_copy,
         compressed_data->CopySlice(0, compressed_data->size(), allocator_));
     std::unique_ptr<DataPage> page_ptr = std::make_unique<DataPageV1>(
-        compressed_data_copy, static_cast<int32_t>(num_buffered_values_), encoding_,
-        Encoding::RLE, Encoding::RLE, uncompressed_size, page_stats);
+        compressed_data_copy, num_values, encoding_, Encoding::RLE, Encoding::RLE,
+        uncompressed_size, page_stats);
     total_compressed_bytes_ += page_ptr->size() + sizeof(format::PageHeader);
 
     data_pages_.push_back(std::move(page_ptr));
   } else {  // Eagerly write pages
-    DataPageV1 page(compressed_data, static_cast<int32_t>(num_buffered_values_),
-                    encoding_, Encoding::RLE, Encoding::RLE, uncompressed_size,
-                    page_stats);
+    DataPageV1 page(compressed_data, num_values, encoding_, Encoding::RLE, Encoding::RLE,
+                    uncompressed_size, page_stats);
     WriteDataPage(page);
   }
 }
@@ -926,10 +944,11 @@ void ColumnWriterImpl::BuildDataPageV2(int64_t definition_levels_rle_size,
   page_stats.set_is_signed(SortOrder::SIGNED == descr_->sort_order());
   ResetPageStatistics();
 
-  int32_t num_values = static_cast<int32_t>(num_buffered_values_);
-  int32_t null_count = static_cast<int32_t>(page_stats.null_count);
-  int32_t def_levels_byte_length = static_cast<int32_t>(definition_levels_rle_size);
-  int32_t rep_levels_byte_length = static_cast<int32_t>(repetition_levels_rle_size);
+  const int32_t num_values = safe_cast_64_to_32(num_buffered_values_);
+  const int32_t null_count = safe_cast_64_to_32(page_stats.null_count);
+  const int32_t num_rows = safe_cast_64_to_32(num_buffered_rows_);
+  const int32_t def_levels_byte_length = safe_cast_64_to_32(definition_levels_rle_size);
+  const int32_t rep_levels_byte_length = safe_cast_64_to_32(repetition_levels_rle_size);
 
   // Write the page to OutputStream eagerly if there is no dictionary or
   // if dictionary encoding has fallen back to PLAIN
@@ -937,12 +956,12 @@ void ColumnWriterImpl::BuildDataPageV2(int64_t definition_levels_rle_size,
     PARQUET_ASSIGN_OR_THROW(auto data_copy,
                             combined->CopySlice(0, combined->size(), allocator_));
     std::unique_ptr<DataPage> page_ptr = std::make_unique<DataPageV2>(
-        combined, num_values, null_count, num_values, encoding_, def_levels_byte_length,
+        combined, num_values, null_count, num_rows, encoding_, def_levels_byte_length,
         rep_levels_byte_length, uncompressed_size, pager_->has_compressor(), page_stats);
     total_compressed_bytes_ += page_ptr->size() + sizeof(format::PageHeader);
     data_pages_.push_back(std::move(page_ptr));
   } else {
-    DataPageV2 page(combined, num_values, null_count, num_values, encoding_,
+    DataPageV2 page(combined, num_values, null_count, num_rows, encoding_,
                     def_levels_byte_length, rep_levels_byte_length, uncompressed_size,
                     pager_->has_compressor(), page_stats);
     WriteDataPage(page);
@@ -1248,6 +1267,7 @@ class TypedColumnWriterImpl : public ColumnWriterImpl, public TypedColumnWriter<
       for (int64_t i = 0; i < num_values; ++i) {
         if (rep_levels[i] == 0) {
           rows_written_++;
+          num_buffered_rows_++;
         }
       }
 
@@ -1255,6 +1275,7 @@ class TypedColumnWriterImpl : public ColumnWriterImpl, public TypedColumnWriter<
     } else {
       // Each value is exactly one row
       rows_written_ += num_values;
+      num_buffered_rows_ += num_values;
     }
     return values_to_write;
   }
@@ -1338,12 +1359,14 @@ class TypedColumnWriterImpl : public ColumnWriterImpl, public TypedColumnWriter<
       for (int64_t i = 0; i < num_levels; ++i) {
         if (rep_levels[i] == 0) {
           rows_written_++;
+          num_buffered_rows_++;
         }
       }
       WriteRepetitionLevels(num_levels, rep_levels);
     } else {
       // Each value is exactly one row
       rows_written_ += num_levels;
+      num_buffered_rows_ += num_levels;
     }
   }
 
@@ -1462,9 +1485,9 @@ Status TypedColumnWriterImpl<DType>::WriteArrowDictionary(
     int64_t batch_num_values = 0;
     int64_t batch_num_spaced_values = 0;
     int64_t null_count = ::arrow::kUnknownNullCount;
-    // Bits is not null for nullable values.  At this point in the code we can't determine
-    // if the leaf array has the same null values as any parents it might have had so we
-    // need to recompute it from def levels.
+    // Bits is not null for nullable values.  At this point in the code we can't
+    // determine if the leaf array has the same null values as any parents it might have
+    // had so we need to recompute it from def levels.
     MaybeCalculateValidityBits(AddIfNotNull(def_levels, offset), batch_size,
                                &batch_num_values, &batch_num_spaced_values, &null_count);
     WriteLevelsSpaced(batch_size, AddIfNotNull(def_levels, offset),

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -861,18 +861,6 @@ void ColumnWriterImpl::AddDataPage() {
   num_buffered_rows_ = 0;
 }
 
-namespace {
-
-int32_t safe_cast_64_to_32(int64_t value) {
-  if (value > std::numeric_limits<int32_t>::max() ||
-      value < std::numeric_limits<int32_t>::min()) {
-    throw ParquetException("Cannot cast ", value, " to int32_t");
-  }
-  return static_cast<int32_t>(value);
-}
-
-}  // namespace
-
 void ColumnWriterImpl::BuildDataPageV1(int64_t definition_levels_rle_size,
                                        int64_t repetition_levels_rle_size,
                                        int64_t uncompressed_size,
@@ -896,7 +884,7 @@ void ColumnWriterImpl::BuildDataPageV1(int64_t definition_levels_rle_size,
     compressed_data = uncompressed_data_;
   }
 
-  const int32_t num_values = safe_cast_64_to_32(num_buffered_values_);
+  int32_t num_values = static_cast<int32_t>(num_buffered_values_);
 
   // Write the page to OutputStream eagerly if there is no dictionary or
   // if dictionary encoding has fallen back to PLAIN
@@ -944,11 +932,11 @@ void ColumnWriterImpl::BuildDataPageV2(int64_t definition_levels_rle_size,
   page_stats.set_is_signed(SortOrder::SIGNED == descr_->sort_order());
   ResetPageStatistics();
 
-  const int32_t num_values = safe_cast_64_to_32(num_buffered_values_);
-  const int32_t null_count = safe_cast_64_to_32(page_stats.null_count);
-  const int32_t num_rows = safe_cast_64_to_32(num_buffered_rows_);
-  const int32_t def_levels_byte_length = safe_cast_64_to_32(definition_levels_rle_size);
-  const int32_t rep_levels_byte_length = safe_cast_64_to_32(repetition_levels_rle_size);
+  int32_t num_values = static_cast<int32_t>(num_buffered_values_);
+  int32_t null_count = static_cast<int32_t>(page_stats.null_count);
+  int32_t num_rows = static_cast<int32_t>(num_buffered_rows_);
+  int32_t def_levels_byte_length = static_cast<int32_t>(definition_levels_rle_size);
+  int32_t rep_levels_byte_length = static_cast<int32_t>(repetition_levels_rle_size);
 
   // Write the page to OutputStream eagerly if there is no dictionary or
   // if dictionary encoding has fallen back to PLAIN

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -27,6 +27,7 @@
 
 #include "parquet/column_reader.h"
 #include "parquet/column_writer.h"
+#include "parquet/file_reader.h"
 #include "parquet/file_writer.h"
 #include "parquet/metadata.h"
 #include "parquet/platform.h"
@@ -1019,6 +1020,90 @@ TEST(TestLevelEncoder, MinimumBufferSize2) {
     int encode_count = encoder.Encode(kNumToEncode, levels.data());
 
     ASSERT_EQ(kNumToEncode, encode_count);
+  }
+}
+
+TEST(TestColumnWriter, WriteDataPageV2Header) {
+  auto sink = CreateOutputStream();
+  auto schema = std::static_pointer_cast<GroupNode>(
+      GroupNode::Make("schema", Repetition::REQUIRED,
+                      {
+                          schema::Int32("required", Repetition::REQUIRED),
+                          schema::Int32("optional", Repetition::OPTIONAL),
+                          schema::Int32("repeated", Repetition::REPEATED),
+                      }));
+  auto properties = WriterProperties::Builder()
+                        .disable_dictionary()
+                        ->data_page_version(ParquetDataPageVersion::V2)
+                        ->build();
+  auto file_writer = ParquetFileWriter::Open(sink, schema, properties);
+  auto rg_writer = file_writer->AppendRowGroup();
+
+  constexpr int32_t num_rows = 100;
+
+  auto required_writer = static_cast<parquet::Int32Writer*>(rg_writer->NextColumn());
+  for (int32_t i = 0; i < num_rows; i++) {
+    required_writer->WriteBatch(1, nullptr, nullptr, &i);
+  }
+
+  // Write a null value at every other row.
+  auto optional_writer = static_cast<parquet::Int32Writer*>(rg_writer->NextColumn());
+  for (int32_t i = 0; i < num_rows; i++) {
+    int16_t definition_level = i % 2 == 0 ? 1 : 0;
+    optional_writer->WriteBatch(1, &definition_level, nullptr, &i);
+  }
+
+  // Each row has repeated twice.
+  auto repeated_writer = static_cast<parquet::Int32Writer*>(rg_writer->NextColumn());
+  for (int i = 0; i < 2 * num_rows; i++) {
+    int32_t value = i * 1000;
+    int16_t definition_level = 1;
+    int16_t repetition_level = i % 2 == 0 ? 1 : 0;
+    repeated_writer->WriteBatch(1, &definition_level, &repetition_level, &value);
+  }
+
+  ASSERT_NO_THROW(file_writer->Close());
+  ASSERT_OK_AND_ASSIGN(auto buffer, sink->Finish());
+  auto file_reader = ParquetFileReader::Open(
+      std::make_shared<::arrow::io::BufferReader>(buffer), default_reader_properties());
+  auto metadata = file_reader->metadata();
+  ASSERT_EQ(1, metadata->num_row_groups());
+  auto row_group_reader = file_reader->RowGroup(0);
+
+  // Verify required column.
+  {
+    auto page_reader = row_group_reader->GetColumnPageReader(0);
+    auto page = page_reader->NextPage();
+    ASSERT_NE(page, nullptr);
+    auto data_page = std::static_pointer_cast<DataPageV2>(page);
+    EXPECT_EQ(num_rows, data_page->num_rows());
+    EXPECT_EQ(num_rows, data_page->num_values());
+    EXPECT_EQ(0, data_page->num_nulls());
+    EXPECT_EQ(page_reader->NextPage(), nullptr);
+  }
+
+  // Verify optional column.
+  {
+    auto page_reader = row_group_reader->GetColumnPageReader(1);
+    auto page = page_reader->NextPage();
+    ASSERT_NE(page, nullptr);
+    auto data_page = std::static_pointer_cast<DataPageV2>(page);
+    EXPECT_EQ(num_rows, data_page->num_rows());
+    EXPECT_EQ(num_rows, data_page->num_values());
+    EXPECT_EQ(num_rows / 2, data_page->num_nulls());
+    EXPECT_EQ(page_reader->NextPage(), nullptr);
+  }
+
+  // Verify repeated column.
+  {
+    auto page_reader = row_group_reader->GetColumnPageReader(2);
+    auto page = page_reader->NextPage();
+    ASSERT_NE(page, nullptr);
+    auto data_page = std::static_pointer_cast<DataPageV2>(page);
+    EXPECT_EQ(num_rows, data_page->num_rows());
+    EXPECT_EQ(num_rows * 2, data_page->num_values());
+    EXPECT_EQ(0, data_page->num_nulls());
+    EXPECT_EQ(page_reader->NextPage(), nullptr);
   }
 }
 


### PR DESCRIPTION
### Rationale for this change

The C++ parquet writer does not correctly fill num_rows field to DataPageV2 header.

### What changes are included in this PR?

ColumnWriter keeps track of number of rows buffered in the current data page and then fills it into header of data page v2.

### Are these changes tested?

A test case has been added to make sure the data page header has been set correctly for required, optional and repeated columns.

### Are there any user-facing changes?

No.
* Closes: #34086