### PR TITLE
GH-34094: [C++] Increase Boost minimum version for clang >= 16

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -1057,8 +1057,8 @@ macro(build_boost)
   set(BOOST_VENDORED TRUE)
 endmacro()
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION
-                                              VERSION_GREATER 15)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER
+                                              15)
   # GH-34094 Older versions of Boost use the deprecated std::unary_function in
   # boost/container_hash/hash.hpp and support for that was removed in clang 16
   set(ARROW_BOOST_REQUIRED_VERSION "1.81")

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -1057,7 +1057,11 @@ macro(build_boost)
   set(BOOST_VENDORED TRUE)
 endmacro()
 
-if(ARROW_BUILD_TESTS)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION
+                                              VERSION_GREATER_EQUAL 16)
+  # GH-34094 we require newer Boost versions for Clang 16 or newer 
+  set(ARROW_BOOST_REQUIRED_VERSION "1.81.0")
+elseif(ARROW_BUILD_TESTS)
   set(ARROW_BOOST_REQUIRED_VERSION "1.64")
 else()
   set(ARROW_BOOST_REQUIRED_VERSION "1.58")

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -1060,7 +1060,7 @@ endmacro()
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION
                                               VERSION_GREATER_EQUAL 16)
   # GH-34094 we require newer Boost versions for Clang 16 or newer 
-  set(ARROW_BOOST_REQUIRED_VERSION "1.81.0")
+  set(ARROW_BOOST_REQUIRED_VERSION "1.81")
 elseif(ARROW_BUILD_TESTS)
   set(ARROW_BOOST_REQUIRED_VERSION "1.64")
 else()

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -1059,7 +1059,8 @@ endmacro()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION
                                               VERSION_GREATER_EQUAL 16)
-  # GH-34094 we require newer Boost versions for Clang 16 or newer
+  # GH-34094 Older versions of Boost use the deprecated std::unary_function in
+  # boost/container_hash/hash.hpp and support for that was removed in clang 16
   set(ARROW_BOOST_REQUIRED_VERSION "1.81")
 elseif(ARROW_BUILD_TESTS)
   set(ARROW_BOOST_REQUIRED_VERSION "1.64")

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -1058,7 +1058,7 @@ macro(build_boost)
 endmacro()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION
-                                              VERSION_GREATER_EQUAL 16)
+                                              VERSION_GREATER 15)
   # GH-34094 Older versions of Boost use the deprecated std::unary_function in
   # boost/container_hash/hash.hpp and support for that was removed in clang 16
   set(ARROW_BOOST_REQUIRED_VERSION "1.81")

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -1059,7 +1059,7 @@ endmacro()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION
                                               VERSION_GREATER_EQUAL 16)
-  # GH-34094 we require newer Boost versions for Clang 16 or newer 
+  # GH-34094 we require newer Boost versions for Clang 16 or newer
   set(ARROW_BOOST_REQUIRED_VERSION "1.81")
 elseif(ARROW_BUILD_TESTS)
   set(ARROW_BOOST_REQUIRED_VERSION "1.64")


### PR DESCRIPTION
### Rationale for this change

Build fails with older Boost on Clang >= 16

### Are there any user-facing changes?
No our dependency management will download the required Boost version if it is not installed on the system.
* Closes: #34094