### PR TITLE
GH-32240: [C#] Support decompression when reading an IPC stream from ReadOnlyMemory

### DIFF
--- a/csharp/src/Apache.Arrow/Ipc/ArrowMemoryReaderImplementation.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowMemoryReaderImplementation.cs
@@ -28,7 +28,7 @@ namespace Apache.Arrow.Ipc
         private readonly ReadOnlyMemory<byte> _buffer;
         private int _bufferPosition;
 
-        public ArrowMemoryReaderImplementation(ReadOnlyMemory<byte> buffer) : base()
+        public ArrowMemoryReaderImplementation(ReadOnlyMemory<byte> buffer, ICompressionCodecFactory compressionCodecFactory) : base(null, compressionCodecFactory)
         {
             _buffer = buffer;
         }

--- a/csharp/src/Apache.Arrow/Ipc/ArrowStreamReader.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowStreamReader.cs
@@ -70,7 +70,12 @@ namespace Apache.Arrow.Ipc
 
         public ArrowStreamReader(ReadOnlyMemory<byte> buffer)
         {
-            _implementation = new ArrowMemoryReaderImplementation(buffer);
+            _implementation = new ArrowMemoryReaderImplementation(buffer, compressionCodecFactory: null);
+        }
+
+        public ArrowStreamReader(ReadOnlyMemory<byte> buffer, ICompressionCodecFactory compressionCodecFactory)
+        {
+            _implementation = new ArrowMemoryReaderImplementation(buffer, compressionCodecFactory);
         }
 
         private protected ArrowStreamReader(ArrowReaderImplementation implementation)

--- a/csharp/test/Apache.Arrow.Tests/ArrowStreamReaderTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowStreamReaderTests.cs
@@ -205,8 +205,26 @@ namespace Apache.Arrow.Tests
             var codecFactory = new Compression.CompressionCodecFactory();
             using var reader = new ArrowStreamReader(stream, codecFactory);
 
-            var batch = reader.ReadNextRecordBatch();
+            VerifyCompressedIpcFileBatch(reader.ReadNextRecordBatch());
+        }
 
+        [Theory]
+        [InlineData("ipc_lz4_compression.arrow_stream")]
+        [InlineData("ipc_zstd_compression.arrow_stream")]
+        public void CanReadCompressedIpcStreamFromMemoryBuffer(string fileName)
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            using var stream = assembly.GetManifestResourceStream($"Apache.Arrow.Tests.Resources.{fileName}");
+            var buffer = new byte[stream.Length];
+            stream.ReadExactly(buffer);
+            var codecFactory = new Compression.CompressionCodecFactory();
+            using var reader = new ArrowStreamReader(buffer, codecFactory);
+
+            VerifyCompressedIpcFileBatch(reader.ReadNextRecordBatch());
+        }
+
+        private static void VerifyCompressedIpcFileBatch(RecordBatch batch)
+        {
             var intArray = (Int32Array) batch.Column("integers");
             var floatArray = (FloatArray) batch.Column("floats");
 


### PR DESCRIPTION
This is a small follow-up to #33603 to support reading a compressed IPC stream from a `ReadOnlyMemory<byte>`, as I missed that this has a separate reader implementation.
* Closes: #32240