### PR TITLE
GH-34138: [C++][Parquet] Fix parsing stats from min_value/max_value

### DIFF
--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -4083,6 +4083,16 @@ TEST_P(TestArrowWriteDictionary, Statistics) {
   std::vector<std::vector<std::string>> expected_min_max_ = {
       {"a", "b"}, {"b", "c"}, {"a", "d"}, {"", ""}};
 
+  const std::vector<std::vector<std::vector<std::string>>> expected_min_by_page = {
+      {{"b", "a"}, {"b", "a"}}, {{"b", "b"}, {"b", "b"}}, {{"c", "a"}, {"c", "a"}}};
+  const std::vector<std::vector<std::vector<std::string>>> expected_max_by_page = {
+      {{"b", "a"}, {"b", "a"}}, {{"c", "c"}, {"c", "c"}}, {{"d", "a"}, {"d", "a"}}};
+  const std::vector<std::vector<std::vector<bool>>> expected_has_min_max_by_page = {
+      {{true, true}, {true, true}},
+      {{true, true}, {true, true}},
+      {{true, true}, {true, true}},
+      {{false}, {false}}};
+
   for (std::size_t case_index = 0; case_index < test_dictionaries.size(); case_index++) {
     SCOPED_TRACE(test_dictionaries[case_index]->type()->ToString());
     ASSERT_OK_AND_ASSIGN(std::shared_ptr<::arrow::Array> dict_encoded,
@@ -4143,8 +4153,18 @@ TEST_P(TestArrowWriteDictionary, Statistics) {
         DataPage* data_page = (DataPage*)page.get();
         const EncodedStatistics& stats = data_page->statistics();
         EXPECT_EQ(stats.null_count, expected_null_by_page[case_index][page_index]);
-        EXPECT_EQ(stats.has_min, false);
-        EXPECT_EQ(stats.has_max, false);
+
+        auto expect_has_min_max =
+            expected_has_min_max_by_page[case_index][row_group_index][page_index];
+        EXPECT_EQ(stats.has_min, expect_has_min_max);
+        EXPECT_EQ(stats.has_max, expect_has_min_max);
+        if (expect_has_min_max) {
+          EXPECT_EQ(stats.min(),
+                    expected_min_by_page[case_index][row_group_index][page_index]);
+          EXPECT_EQ(stats.max(),
+                    expected_max_by_page[case_index][row_group_index][page_index]);
+        }
+
         EXPECT_EQ(data_page->num_values(),
                   expected_valid_by_page[case_index][page_index] +
                       expected_null_by_page[case_index][page_index]);

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -211,10 +211,15 @@ EncodedStatistics ExtractStatsFromHeader(const H& header) {
     return page_statistics;
   }
   const format::Statistics& stats = header.statistics;
-  if (stats.__isset.max) {
+  // Use the new V2 min-max statistics over the former one if it is filled
+  if (stats.__isset.max_value && stats.__isset.min_value) {
+    // TODO: check if the column_order is TYPE_DEFINED_ORDER.
+    page_statistics.set_max(stats.max_value);
+    page_statistics.set_min(stats.min_value);
+  } else if (stats.__isset.max && stats.__isset.min) {
+    // TODO: check created_by to see if it is corrupted for some types.
+    // TODO: check if the sort_order is SIGNED.
     page_statistics.set_max(stats.max);
-  }
-  if (stats.__isset.min) {
     page_statistics.set_min(stats.min);
   }
   if (stats.__isset.null_count) {

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -212,15 +212,23 @@ EncodedStatistics ExtractStatsFromHeader(const H& header) {
   }
   const format::Statistics& stats = header.statistics;
   // Use the new V2 min-max statistics over the former one if it is filled
-  if (stats.__isset.max_value && stats.__isset.min_value) {
+  if (stats.__isset.max_value || stats.__isset.min_value) {
     // TODO: check if the column_order is TYPE_DEFINED_ORDER.
-    page_statistics.set_max(stats.max_value);
-    page_statistics.set_min(stats.min_value);
-  } else if (stats.__isset.max && stats.__isset.min) {
+    if (stats.__isset.max_value) {
+      page_statistics.set_max(stats.max_value);
+    }
+    if (stats.__isset.min_value) {
+      page_statistics.set_min(stats.min_value);
+    }
+  } else if (stats.__isset.max || stats.__isset.min) {
     // TODO: check created_by to see if it is corrupted for some types.
     // TODO: check if the sort_order is SIGNED.
-    page_statistics.set_max(stats.max);
-    page_statistics.set_min(stats.min);
+    if (stats.__isset.max) {
+      page_statistics.set_max(stats.max);
+    }
+    if (stats.__isset.min) {
+      page_statistics.set_min(stats.min);
+    }
   }
   if (stats.__isset.null_count) {
     page_statistics.set_null_count(stats.null_count);

--- a/cpp/src/parquet/file_deserialize_test.cc
+++ b/cpp/src/parquet/file_deserialize_test.cc
@@ -514,7 +514,11 @@ TEST_F(TestPageSerde, DataPageV2) {
 
 TEST_F(TestPageSerde, TestLargePageHeaders) {
   int stats_size = 256 * 1024;  // 256 KB
-  AddDummyStats(stats_size, data_page_header_);
+  AddDummyStats(stats_size, data_page_header_, /*fill_all_stats=*/false);
+
+  // AddDummyStats() above has only set max which results in an invalid statistics.
+  // Set min explicitly here to make it valid.
+  data_page_header_.statistics.__set_min("");
 
   // Any number to verify metadata roundtrip
   const int32_t num_rows = 4141;

--- a/cpp/src/parquet/file_deserialize_test.cc
+++ b/cpp/src/parquet/file_deserialize_test.cc
@@ -514,11 +514,7 @@ TEST_F(TestPageSerde, DataPageV2) {
 
 TEST_F(TestPageSerde, TestLargePageHeaders) {
   int stats_size = 256 * 1024;  // 256 KB
-  AddDummyStats(stats_size, data_page_header_, /*fill_all_stats=*/false);
-
-  // AddDummyStats() above has only set max which results in an invalid statistics.
-  // Set min explicitly here to make it valid.
-  data_page_header_.statistics.__set_min("");
+  AddDummyStats(stats_size, data_page_header_);
 
   // Any number to verify metadata roundtrip
   const int32_t num_rows = 4141;


### PR DESCRIPTION
### Rationale for this change

The code below does not read from stats.min_value/max_value at all.
```cpp
// Extracts encoded statistics from V1 and V2 data page headers
template <typename H>
EncodedStatistics ExtractStatsFromHeader(const H& header) {
  EncodedStatistics page_statistics;
  if (!header.__isset.statistics) {
    return page_statistics;
  }
  const format::Statistics& stats = header.statistics;
  if (stats.__isset.max) {
    page_statistics.set_max(stats.max);
  }
  if (stats.__isset.min) {
    page_statistics.set_min(stats.min);
  }
  if (stats.__isset.null_count) {
    page_statistics.set_null_count(stats.null_count);
  }
  if (stats.__isset.distinct_count) {
    page_statistics.set_distinct_count(stats.distinct_count);
  }
  return page_statistics;
}
```

### What changes are included in this PR?

Do similar thing from parquet-mr to check and read min_value/max_value from thrift stats.

### Are these changes tested?

Some test cases fail after the fix. Fixed them to make sure it is covered.

### Are there any user-facing changes?
No.

* Closes: #34138