### PR TITLE
GH-34117: [C++][Gandiva] Introduce ability to cast from int8 to float32 and int32

### DIFF
--- a/cpp/src/gandiva/function_registry_arithmetic.cc
+++ b/cpp/src/gandiva/function_registry_arithmetic.cc
@@ -65,11 +65,12 @@ std::vector<NativeFunction> GetArithmeticFunctionRegistry() {
       UNARY_SAFE_NULL_IF_NULL(not, {}, boolean, boolean),
       UNARY_SAFE_NULL_IF_NULL(castBIGINT, {}, int32, int64),
       UNARY_SAFE_NULL_IF_NULL(castINT, {}, int64, int32),
+      UNARY_SAFE_NULL_IF_NULL(castINT, {}, int8, int32),
       UNARY_SAFE_NULL_IF_NULL(castBIGINT, {}, decimal128, int64),
 
       // cast to float32
       UNARY_CAST_TO_FLOAT32(int32), UNARY_CAST_TO_FLOAT32(int64),
-      UNARY_CAST_TO_FLOAT32(float64),
+      UNARY_CAST_TO_FLOAT32(float64), UNARY_CAST_TO_FLOAT32(int8),
 
       // cast to int32
       UNARY_CAST_TO_INT32(float32), UNARY_CAST_TO_INT32(float64),

--- a/cpp/src/gandiva/precompiled/arithmetic_ops.cc
+++ b/cpp/src/gandiva/precompiled/arithmetic_ops.cc
@@ -202,6 +202,8 @@ NUMERIC_DATE_TYPES(COMPARE_SIX_VALUES, least, <)
 
 CAST_UNARY(castBIGINT, int32, int64)
 CAST_UNARY(castINT, int64, int32)
+CAST_UNARY(castINT, int8, int32)
+CAST_UNARY(castFLOAT4, int8, float32)
 CAST_UNARY(castFLOAT4, int32, float32)
 CAST_UNARY(castFLOAT4, int64, float32)
 CAST_UNARY(castFLOAT8, int32, float64)


### PR DESCRIPTION
### Rationale for this change

In our analysis, we need to be able to extend data from int8 to float32 and int32.

### What changes are included in this PR?

Ability to cast int8 to float32 and int32 in Gandiva expressions.

### Are these changes tested?

Yes. We run our analysis using them and they produce the expected result.

### Are there any user-facing changes?

Nothing apart the newly introduced capabilities.
* Closes: #34117