### PR TITLE
GH-34119: [C#] Add [] operator to Schema

### DIFF
--- a/csharp/src/Apache.Arrow/Schema.cs
+++ b/csharp/src/Apache.Arrow/Schema.cs
@@ -36,6 +36,10 @@ namespace Apache.Arrow
 
         private readonly IList<Field> _fields;
 
+        public Field this[int index] => GetFieldByIndex(index);
+
+        public Field this[string name] => GetFieldByName(name);
+
         public Schema(
             IEnumerable<Field> fields,
             IEnumerable<KeyValuePair<string, string>> metadata)

--- a/csharp/test/Apache.Arrow.Tests/SchemaBuilderTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/SchemaBuilderTests.cs
@@ -118,7 +118,7 @@ namespace Apache.Arrow.Tests
             }
 
             [Fact]
-            public void SquareBracketOperatorWithIndexReturnsGetFieldByName()
+            public void SquareBracketOperatorWithStringReturnsGetFieldByName()
             {
                 Field f0 = new Field.Builder().Name("f0").DataType(Int32Type.Default).Build();
                 Field f1 = new Field.Builder().Name("f1").DataType(Int8Type.Default).Build();

--- a/csharp/test/Apache.Arrow.Tests/SchemaBuilderTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/SchemaBuilderTests.cs
@@ -30,7 +30,7 @@ namespace Apache.Arrow.Tests
             public void FieldsAreNullableByDefault()
             {
                 var b = new Schema.Builder();
-                
+
                 var schema = new Schema.Builder()
                     .Field(f => f.Name("f0").DataType(Int32Type.Default))
                     .Build();
@@ -115,6 +115,36 @@ namespace Apache.Arrow.Tests
                     .Field(f0Uppercase)
                     .Build();
                 Assert.True(schema.GetFieldByName("f0") == f0 && schema.GetFieldByName("F0") == f0Uppercase);
+            }
+
+            [Fact]
+            public void SquareBracketOperatorWithIndexReturnsGetFieldByName()
+            {
+                Field f0 = new Field.Builder().Name("f0").DataType(Int32Type.Default).Build();
+                Field f1 = new Field.Builder().Name("f1").DataType(Int8Type.Default).Build();
+
+                var schema = new Schema.Builder()
+                    .Field(f0)
+                    .Field(f1)
+                    .Build();
+
+                Assert.Equal(schema.GetFieldByName("f0"), schema["f0"]);
+                Assert.Equal(schema.GetFieldByName("f1"), schema["f1"]);
+            }
+
+            [Fact]
+            public void SquareBracketOperatorWithIntReturnsGetFieldByIndex()
+            {
+                Field f0 = new Field.Builder().Name("f0").DataType(Int32Type.Default).Build();
+                Field f1 = new Field.Builder().Name("f1").DataType(Int8Type.Default).Build();
+
+                var schema = new Schema.Builder()
+                    .Field(f0)
+                    .Field(f1)
+                    .Build();
+
+                Assert.Equal(schema.GetFieldByIndex(0), schema[0]);
+                Assert.Equal(schema.GetFieldByIndex(1), schema[1]);
             }
 
             [Fact]


### PR DESCRIPTION
Add the `[]` operator to Schema that retrieves a field by index if an int is passed, or retrieved a field by name if a string is passed.
* Closes: #34119