### PR TITLE
GH-34136: [C++] Add a concept of ordering to ExecPlan

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -406,9 +406,9 @@ if(ARROW_COMPUTE)
        compute/exec/key_hash.cc
        compute/exec/key_map.cc
        compute/exec/map_node.cc
+       compute/exec/options.cc
        compute/exec/order_by_impl.cc
        compute/exec/partition_util.cc
-       compute/exec/options.cc
        compute/exec/project_node.cc
        compute/exec/query_context.cc
        compute/exec/sink_node.cc
@@ -422,6 +422,7 @@ if(ARROW_COMPUTE)
        compute/function_internal.cc
        compute/kernel.cc
        compute/light_array.cc
+       compute/ordering.cc
        compute/registry.cc
        compute/kernels/aggregate_basic.cc
        compute/kernels/aggregate_mode.cc

--- a/cpp/src/arrow/compute/api_vector.cc
+++ b/cpp/src/arrow/compute/api_vector.cc
@@ -118,23 +118,6 @@ namespace compute {
 // ----------------------------------------------------------------------
 // Function options
 
-bool SortKey::Equals(const SortKey& other) const {
-  return target == other.target && order == other.order;
-}
-std::string SortKey::ToString() const {
-  std::stringstream ss;
-  ss << target.ToString() << ' ';
-  switch (order) {
-    case SortOrder::Ascending:
-      ss << "ASC";
-      break;
-    case SortOrder::Descending:
-      ss << "DESC";
-      break;
-  }
-  return ss.str();
-}
-
 namespace internal {
 namespace {
 using ::arrow::internal::DataMember;

--- a/cpp/src/arrow/compute/api_vector.h
+++ b/cpp/src/arrow/compute/api_vector.h
@@ -21,6 +21,7 @@
 #include <utility>
 
 #include "arrow/compute/function.h"
+#include "arrow/compute/ordering.h"
 #include "arrow/datum.h"
 #include "arrow/result.h"
 #include "arrow/type_fwd.h"
@@ -77,37 +78,6 @@ class ARROW_EXPORT DictionaryEncodeOptions : public FunctionOptions {
   static DictionaryEncodeOptions Defaults() { return DictionaryEncodeOptions(); }
 
   NullEncodingBehavior null_encoding_behavior = MASK;
-};
-
-enum class SortOrder {
-  /// Arrange values in increasing order
-  Ascending,
-  /// Arrange values in decreasing order
-  Descending,
-};
-
-enum class NullPlacement {
-  /// Place nulls and NaNs before any non-null values.
-  /// NaNs will come after nulls.
-  AtStart,
-  /// Place nulls and NaNs after any non-null values.
-  /// NaNs will come before nulls.
-  AtEnd,
-};
-
-/// \brief One sort key for PartitionNthIndices (TODO) and SortIndices
-class ARROW_EXPORT SortKey : public util::EqualityComparable<SortKey> {
- public:
-  explicit SortKey(FieldRef target, SortOrder order = SortOrder::Ascending)
-      : target(std::move(target)), order(order) {}
-
-  bool Equals(const SortKey& other) const;
-  std::string ToString() const;
-
-  /// A FieldRef targetting the sort column.
-  FieldRef target;
-  /// How to order by this sort key.
-  SortOrder order;
 };
 
 class ARROW_EXPORT ArraySortOptions : public FunctionOptions {

--- a/cpp/src/arrow/compute/exec/accumulation_queue.cc
+++ b/cpp/src/arrow/compute/exec/accumulation_queue.cc
@@ -22,6 +22,7 @@
 #include <queue>
 #include <vector>
 
+#include "arrow/compute/exec.h"
 #include "arrow/util/logging.h"
 
 namespace arrow {
@@ -73,6 +74,7 @@ class SequencingQueueImpl : public SequencingQueue {
   explicit SequencingQueueImpl(Processor* processor) : processor_(processor) {}
 
   Status InsertBatch(ExecBatch batch) override {
+    DCHECK_NE(::arrow::compute::kUnsequencedIndex, batch.index);
     std::unique_lock lk(mutex_);
     if (batch.index == next_index_) {
       return DeliverNextUnlocked(std::move(batch), std::move(lk));
@@ -122,6 +124,7 @@ class SerialSequencingQueueImpl : public SerialSequencingQueue {
   explicit SerialSequencingQueueImpl(Processor* processor) : processor_(processor) {}
 
   Status InsertBatch(ExecBatch batch) override {
+    DCHECK_NE(::arrow::compute::kUnsequencedIndex, batch.index);
     std::unique_lock lk(mutex_);
     queue_.push(std::move(batch));
     if (queue_.top().index == next_index_ && !is_processing_) {

--- a/cpp/src/arrow/compute/exec/asof_join_node.cc
+++ b/cpp/src/arrow/compute/exec/asof_join_node.cc
@@ -1491,9 +1491,7 @@ class AsofJoinNode : public ExecNode {
   }
 
   const char* kind_name() const override { return "AsofJoinNode"; }
-  const std::optional<std::vector<SortKey>>& ordering() const override {
-    return ordering_;
-  }
+  const Ordering& ordering() const override { return ordering_; }
 
   Status InputReceived(ExecNode* input, ExecBatch batch) override {
     // Get the input
@@ -1544,7 +1542,7 @@ class AsofJoinNode : public ExecNode {
 
  private:
   // Outputs from this node are always in ascending order according to the on key
-  const std::optional<std::vector<SortKey>> ordering_;
+  const Ordering ordering_;
   std::vector<col_index_t> indices_of_on_key_;
   std::vector<std::vector<col_index_t>> indices_of_by_key_;
   std::vector<std::unique_ptr<KeyHasher>> key_hashers_;

--- a/cpp/src/arrow/compute/exec/asof_join_node.cc
+++ b/cpp/src/arrow/compute/exec/asof_join_node.cc
@@ -1150,8 +1150,8 @@ class AsofJoinNode : public ExecNode {
       if (result.ok()) {
         auto out_rb = *result;
         if (!out_rb) break;
-        ++batches_produced_;
         ExecBatch out_b(*out_rb);
+        out_b.index = batches_produced_++;
         Status st = output_->InputReceived(this, std::move(out_b));
         if (!st.ok()) {
           EndFromProcessThread(std::move(st));
@@ -1491,6 +1491,9 @@ class AsofJoinNode : public ExecNode {
   }
 
   const char* kind_name() const override { return "AsofJoinNode"; }
+  const std::optional<std::vector<SortKey>>& ordering() const override {
+    return ordering_;
+  }
 
   Status InputReceived(ExecNode* input, ExecBatch batch) override {
     // Get the input
@@ -1540,6 +1543,8 @@ class AsofJoinNode : public ExecNode {
   }
 
  private:
+  // Outputs from this node are always in ascending order according to the on key
+  const std::optional<std::vector<SortKey>> ordering_;
   std::vector<col_index_t> indices_of_on_key_;
   std::vector<std::vector<col_index_t>> indices_of_by_key_;
   std::vector<std::unique_ptr<KeyHasher>> key_hashers_;
@@ -1573,6 +1578,7 @@ AsofJoinNode::AsofJoinNode(ExecPlan* plan, NodeVector inputs,
                            bool must_hash, bool may_rehash)
     : ExecNode(plan, inputs, input_labels,
                /*output_schema=*/std::move(output_schema)),
+      ordering_({SortKey(indices_of_on_key[0])}),
       indices_of_on_key_(std::move(indices_of_on_key)),
       indices_of_by_key_(std::move(indices_of_by_key)),
       key_hashers_(std::move(key_hashers)),

--- a/cpp/src/arrow/compute/exec/asof_join_node_test.cc
+++ b/cpp/src/arrow/compute/exec/asof_join_node_test.cc
@@ -1314,6 +1314,44 @@ TEST(AsofJoinTest, BackpressureWithBatches) {
                           /*fast_delay=*/0.01, /*slow_delay=*/0.1, /*noisy=*/false);
 }
 
+template <typename BatchesMaker>
+void TestSequencing(BatchesMaker maker, int num_batches, int batch_size) {
+  auto l_schema =
+      schema({field("time", int32()), field("key", int32()), field("l_value", int32())});
+  auto r_schema =
+      schema({field("time", int32()), field("key", int32()), field("r0_value", int32())});
+
+  auto make_shift = [&maker, num_batches, batch_size](
+                        const std::shared_ptr<Schema>& schema, int shift) {
+    return maker({[](int row) -> int64_t { return row; },
+                  [num_batches](int row) -> int64_t { return row / num_batches; },
+                  [shift](int row) -> int64_t { return row * 10 + shift; }},
+                 schema, num_batches, batch_size);
+  };
+  ASSERT_OK_AND_ASSIGN(auto l_batches, make_shift(l_schema, 0));
+  ASSERT_OK_AND_ASSIGN(auto r_batches, make_shift(r_schema, 1));
+
+  compute::Declaration l_src = {"source",
+                                SourceNodeOptions(l_schema, l_batches.gen(false, false))};
+  compute::Declaration r_src = {"source",
+                                SourceNodeOptions(r_schema, r_batches.gen(false, false))};
+
+  compute::Declaration asofjoin = {
+      "asofjoin", {l_src, r_src}, GetRepeatedOptions(2, "time", {"key"}, 1000)};
+
+  QueryOptions query_options;
+  query_options.sequence_output = true;
+  query_options.use_threads = false;
+  ASSERT_OK_AND_ASSIGN(BatchesWithCommonSchema batches,
+                       DeclarationToExecBatches(asofjoin, query_options));
+
+  AssertExecBatchesSequenced(batches.batches);
+}
+
+TEST(AsofJoinTest, BatchSequencing) {
+  return TestSequencing(MakeIntegerBatches, /*num_batches=*/32, /*batch_size=*/1);
+}
+
 namespace {
 
 Result<AsyncGenerator<std::optional<ExecBatch>>> MakeIntegerBatchGenForTest(

--- a/cpp/src/arrow/compute/exec/asof_join_node_test.cc
+++ b/cpp/src/arrow/compute/exec/asof_join_node_test.cc
@@ -1340,7 +1340,6 @@ void TestSequencing(BatchesMaker maker, int num_batches, int batch_size) {
       "asofjoin", {l_src, r_src}, GetRepeatedOptions(2, "time", {"key"}, 1000)};
 
   QueryOptions query_options;
-  query_options.sequence_output = true;
   query_options.use_threads = false;
   ASSERT_OK_AND_ASSIGN(BatchesWithCommonSchema batches,
                        DeclarationToExecBatches(asofjoin, query_options));

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -437,6 +437,11 @@ ExecNode::ExecNode(ExecPlan* plan, NodeVector inputs,
   }
 }
 
+const std::optional<std::vector<SortKey>>& ExecNode::ordering() const {
+  // The safest default is to assume a node destroys ordering
+  return kUnordered;
+}
+
 Status ExecNode::Init() { return Status::OK(); }
 
 Status ExecNode::Validate() const {
@@ -650,9 +655,13 @@ Future<BatchesWithCommonSchema> DeclarationToExecBatchesImpl(
   ARROW_RETURN_NOT_OK(exec_plan->Validate());
   exec_plan->StartProducing();
   auto collected_fut = CollectAsyncGenerator(sink_gen);
-  return AllFinished({exec_plan->finished(), Future<>(collected_fut)})
-      .Then([collected_fut, exec_plan,
-             schema = std::move(out_schema)]() -> Result<BatchesWithCommonSchema> {
+  return exec_plan->finished().Then(
+      [collected_fut, exec_plan,
+       schema = std::move(out_schema)]() -> Result<BatchesWithCommonSchema> {
+        if (!collected_fut.is_finished()) {
+          return Status::Invalid(
+              "Plan finished but it did not emit the expected number of batches.");
+        }
         ARROW_ASSIGN_OR_RAISE(auto collected, collected_fut.result());
         std::vector<ExecBatch> exec_batches = ::arrow::internal::MapVector(
             [](std::optional<ExecBatch> batch) { return batch.value_or(ExecBatch()); },
@@ -667,9 +676,9 @@ Future<> DeclarationToStatusImpl(Declaration declaration, QueryOptions options,
   ARROW_ASSIGN_OR_RAISE(std::shared_ptr<ExecPlan> exec_plan, ExecPlan::Make(exec_ctx));
   ARROW_ASSIGN_OR_RAISE(ExecNode * last_node, declaration.AddToPlan(exec_plan.get()));
   if (!last_node->is_sink()) {
-    Declaration null_sink =
-        Declaration("consuming_sink", {last_node},
-                    ConsumingSinkNodeOptions(NullSinkNodeConsumer::Make()));
+    ConsumingSinkNodeOptions sink_options(NullSinkNodeConsumer::Make());
+    sink_options.sequence_output = options.sequence_output;
+    Declaration null_sink = Declaration("consuming_sink", {last_node}, sink_options);
     ARROW_RETURN_NOT_OK(null_sink.AddToPlan(exec_plan.get()));
   }
   ARROW_RETURN_NOT_OK(exec_plan->Validate());
@@ -826,6 +835,20 @@ Result<BatchesWithCommonSchema> DeclarationToExecBatches(
       use_threads);
 }
 
+Result<BatchesWithCommonSchema> DeclarationToExecBatches(Declaration declaration,
+                                                         QueryOptions query_options) {
+  if (query_options.custom_cpu_executor != nullptr) {
+    return Status::Invalid("Cannot use synchronous methods with a custom CPU executor");
+  }
+  return ::arrow::internal::RunSynchronously<Future<BatchesWithCommonSchema>>(
+      [=, declaration =
+              std::move(declaration)](::arrow::internal::Executor* executor) mutable {
+        return DeclarationToExecBatchesImpl(std::move(declaration), query_options,
+                                            executor);
+      },
+      query_options.use_threads);
+}
+
 Future<> DeclarationToStatusAsync(Declaration declaration, ExecContext exec_context) {
   return DeclarationToStatusImpl(std::move(declaration),
                                  QueryOptionsFromCustomExecContext(exec_context),
@@ -856,6 +879,17 @@ Status DeclarationToStatus(Declaration declaration, bool use_threads,
             executor);
       },
       use_threads);
+}
+
+Status DeclarationToStatus(Declaration declaration, QueryOptions query_options) {
+  if (query_options.custom_cpu_executor != nullptr) {
+    return Status::Invalid("Cannot use synchronous methods with a custom CPU executor");
+  }
+  return ::arrow::internal::RunSynchronously<Future<>>(
+      [=, declaration = std::move(declaration)](::arrow::internal::Executor* executor) {
+        return DeclarationToStatusImpl(std::move(declaration), query_options, executor);
+      },
+      query_options.use_threads);
 }
 
 namespace {

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -649,7 +649,7 @@ Future<BatchesWithCommonSchema> DeclarationToExecBatchesImpl(
   ExecContext exec_ctx(options.memory_pool, cpu_executor, options.function_registry);
   ARROW_ASSIGN_OR_RAISE(std::shared_ptr<ExecPlan> exec_plan, ExecPlan::Make(exec_ctx));
   SinkNodeOptions sink_options(&sink_gen, &out_schema);
-  sink_options.sequence_delivery = options.sequence_output;
+  sink_options.sequence_output = options.sequence_output;
   Declaration with_sink = Declaration::Sequence({declaration, {"sink", sink_options}});
   ARROW_RETURN_NOT_OK(with_sink.AddToPlan(exec_plan.get()));
   ARROW_RETURN_NOT_OK(exec_plan->Validate());

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -437,9 +437,9 @@ ExecNode::ExecNode(ExecPlan* plan, NodeVector inputs,
   }
 }
 
-const std::optional<std::vector<SortKey>>& ExecNode::ordering() const {
+const Ordering& ExecNode::ordering() const {
   // The safest default is to assume a node destroys ordering
-  return kUnordered;
+  return Ordering::Unordered();
 }
 
 Status ExecNode::Init() { return Status::OK(); }

--- a/cpp/src/arrow/compute/exec/fetch_node.cc
+++ b/cpp/src/arrow/compute/exec/fetch_node.cc
@@ -106,6 +106,10 @@ class FetchNode : public ExecNode, public TracedNode, util::SequencingQueue::Pro
 
   const char* kind_name() const override { return "FetchNode"; }
 
+  const std::optional<std::vector<SortKey>>& ordering() const override {
+    return inputs_[0]->ordering();
+  }
+
   Status InputFinished(ExecNode* input, int total_batches) override {
     DCHECK_EQ(input, inputs_[0]);
     EVENT_ON_CURRENT_SPAN("InputFinished", {{"batches.length", total_batches}});
@@ -118,6 +122,17 @@ class FetchNode : public ExecNode, public TracedNode, util::SequencingQueue::Pro
         ARROW_RETURN_NOT_OK(inputs_[0]->StopProducing());
         ARROW_RETURN_NOT_OK(output_->InputFinished(this, out_batch_count_));
       }
+    }
+    return Status::OK();
+  }
+
+  Status Validate() const override {
+    ARROW_RETURN_NOT_OK(ExecNode::Validate());
+    if (!inputs_[0]->ordering().has_value()) {
+      return Status::Invalid(
+          "Fetch node's input has no meaningful ordering and so limit/offset will be "
+          "non-deterministic.  Please establish order in some way (e.g. by inserting an "
+          "order_by node)");
     }
     return Status::OK();
   }

--- a/cpp/src/arrow/compute/exec/fetch_node.cc
+++ b/cpp/src/arrow/compute/exec/fetch_node.cc
@@ -106,9 +106,7 @@ class FetchNode : public ExecNode, public TracedNode, util::SequencingQueue::Pro
 
   const char* kind_name() const override { return "FetchNode"; }
 
-  const std::optional<std::vector<SortKey>>& ordering() const override {
-    return inputs_[0]->ordering();
-  }
+  const Ordering& ordering() const override { return inputs_[0]->ordering(); }
 
   Status InputFinished(ExecNode* input, int total_batches) override {
     DCHECK_EQ(input, inputs_[0]);
@@ -128,7 +126,7 @@ class FetchNode : public ExecNode, public TracedNode, util::SequencingQueue::Pro
 
   Status Validate() const override {
     ARROW_RETURN_NOT_OK(ExecNode::Validate());
-    if (!inputs_[0]->ordering().has_value()) {
+    if (inputs_[0]->ordering().is_unordered()) {
       return Status::Invalid(
           "Fetch node's input has no meaningful ordering and so limit/offset will be "
           "non-deterministic.  Please establish order in some way (e.g. by inserting an "

--- a/cpp/src/arrow/compute/exec/fetch_node_test.cc
+++ b/cpp/src/arrow/compute/exec/fetch_node_test.cc
@@ -48,7 +48,6 @@ void CheckFetch(FetchNodeOptions options) {
                              {"fetch", options}});
   for (bool use_threads : {false, true}) {
     QueryOptions query_options;
-    query_options.sequence_output = true;
     query_options.use_threads = use_threads;
     ASSERT_OK_AND_ASSIGN(std::shared_ptr<Table> actual,
                          DeclarationToTable(plan, query_options));

--- a/cpp/src/arrow/compute/exec/map_node.cc
+++ b/cpp/src/arrow/compute/exec/map_node.cc
@@ -49,6 +49,12 @@ Status MapNode::InputFinished(ExecNode* input, int total_batches) {
   return Status::OK();
 }
 
+// Right now this assumes the map operation will always maintain ordering.  This
+// may change in the future but is true for the current map nodes (filter/project)
+const std::optional<std::vector<SortKey>>& MapNode::ordering() const {
+  return inputs_[0]->ordering();
+}
+
 Status MapNode::StartProducing() {
   NoteStartProducing(ToStringExtra());
   return Status::OK();
@@ -68,8 +74,10 @@ Status MapNode::InputReceived(ExecNode* input, ExecBatch batch) {
   auto scope = TraceInputReceived(batch);
   DCHECK_EQ(input, inputs_[0]);
   compute::Expression guarantee = batch.guarantee;
+  int64_t index = batch.index;
   ARROW_ASSIGN_OR_RAISE(auto output_batch, ProcessBatch(std::move(batch)));
   output_batch.guarantee = guarantee;
+  output_batch.index = index;
   ARROW_RETURN_NOT_OK(output_->InputReceived(this, std::move(output_batch)));
   if (input_counter_.Increment()) {
     this->Finish();

--- a/cpp/src/arrow/compute/exec/map_node.cc
+++ b/cpp/src/arrow/compute/exec/map_node.cc
@@ -51,9 +51,7 @@ Status MapNode::InputFinished(ExecNode* input, int total_batches) {
 
 // Right now this assumes the map operation will always maintain ordering.  This
 // may change in the future but is true for the current map nodes (filter/project)
-const std::optional<std::vector<SortKey>>& MapNode::ordering() const {
-  return inputs_[0]->ordering();
-}
+const Ordering& MapNode::ordering() const { return inputs_[0]->ordering(); }
 
 Status MapNode::StartProducing() {
   NoteStartProducing(ToStringExtra());

--- a/cpp/src/arrow/compute/exec/map_node.h
+++ b/cpp/src/arrow/compute/exec/map_node.h
@@ -56,6 +56,8 @@ class ARROW_EXPORT MapNode : public ExecNode, public TracedNode {
 
   Status InputReceived(ExecNode* input, ExecBatch batch) override;
 
+  const std::optional<std::vector<SortKey>>& ordering() const override;
+
  protected:
   Status StopProducingImpl() override;
 

--- a/cpp/src/arrow/compute/exec/map_node.h
+++ b/cpp/src/arrow/compute/exec/map_node.h
@@ -56,7 +56,7 @@ class ARROW_EXPORT MapNode : public ExecNode, public TracedNode {
 
   Status InputReceived(ExecNode* input, ExecBatch batch) override;
 
-  const std::optional<std::vector<SortKey>>& ordering() const override;
+  const Ordering& ordering() const override;
 
  protected:
   Status StopProducingImpl() override;

--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -24,12 +24,14 @@
 #include "arrow/compute/exec/exec_plan.h"
 #include "arrow/compute/exec/expression.h"
 #include "arrow/compute/exec/options.h"
+#include "arrow/compute/exec/test_nodes.h"
 #include "arrow/compute/exec/test_util.h"
 #include "arrow/compute/exec/util.h"
 #include "arrow/io/util_internal.h"
 #include "arrow/record_batch.h"
 #include "arrow/table.h"
 #include "arrow/testing/future_util.h"
+#include "arrow/testing/generator.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/matchers.h"
 #include "arrow/testing/random.h"
@@ -277,6 +279,12 @@ void TestSourceSinkError(
   auto null_schema_options = OptionsType{no_schema, element_it_maker};
   ASSERT_THAT(MakeExecNode(source_factory_name, plan.get(), {}, null_schema_options),
               Raises(StatusCode::Invalid, HasSubstr("not null")));
+
+  auto no_io_but_executor = OptionsType{exp_batches.schema, element_it_maker,
+                                        io::default_io_context().executor()};
+  no_io_but_executor.requires_io = false;
+  ASSERT_THAT(MakeExecNode(source_factory_name, plan.get(), {}, no_io_but_executor),
+              Raises(StatusCode::Invalid, HasSubstr("io_executor was not nullptr")));
 }
 
 template <typename ElementType, typename OptionsType>
@@ -289,11 +297,20 @@ void TestSourceSink(
   auto element_it_maker = [&elements]() {
     return MakeVectorIterator<ElementType>(elements);
   };
-  Declaration plan(source_factory_name,
-                   OptionsType{exp_batches.schema, element_it_maker});
-  ASSERT_OK_AND_ASSIGN(auto result,
-                       DeclarationToExecBatches(std::move(plan), /*use_threads=*/false));
-  AssertExecBatchesEqualIgnoringOrder(result.schema, result.batches, exp_batches.batches);
+  for (bool requires_io : {false, true}) {
+    for (bool use_threads : {false, true}) {
+      Declaration plan(source_factory_name,
+                       OptionsType{exp_batches.schema, element_it_maker, requires_io});
+      QueryOptions query_options;
+      query_options.sequence_output = true;
+      query_options.use_threads = use_threads;
+      ASSERT_OK_AND_ASSIGN(auto result,
+                           DeclarationToExecBatches(std::move(plan), query_options));
+      // Should not need to ignore order since sink should sequence by implicit order
+      AssertExecBatchesEqual(result.schema, result.batches, exp_batches.batches);
+      AssertExecBatchesSequenced(result.batches);
+    }
+  }
 }
 
 void TestRecordBatchReaderSourceSink(
@@ -586,6 +603,19 @@ TEST(ExecPlanExecution, SourceSinkError) {
 
   ASSERT_THAT(StartAndCollect(plan.get(), sink_gen),
               Finishes(Raises(StatusCode::Invalid, HasSubstr("Artificial"))));
+}
+
+TEST(ExecPlanExecution, InvalidSequencing) {
+  auto basic_data = MakeBasicBatches();
+  Declaration plan = Declaration::Sequence(
+      {{"source", SourceNodeOptions{basic_data.schema, basic_data.gen(false, false)}},
+       {"aggregate", AggregateNodeOptions({}, {"i32"})}});
+
+  QueryOptions query_options;
+  ASSERT_OK(DeclarationToStatus(plan, query_options));
+  query_options.sequence_output = true;
+  ASSERT_THAT(DeclarationToStatus(plan, query_options),
+              Raises(StatusCode::Invalid, HasSubstr("no meaningful ordering")));
 }
 
 TEST(ExecPlanExecution, SourceConsumingSink) {
@@ -950,6 +980,53 @@ TEST(ExecPlanExecution, SourceProjectSink) {
       ExecBatchFromJSON({boolean(), int32()}, "[[null, 6], [true, 7], [true, 8]]")};
   ASSERT_OK_AND_ASSIGN(auto result, DeclarationToExecBatches(std::move(plan)));
   AssertExecBatchesEqualIgnoringOrder(result.schema, result.batches, exp_batches);
+}
+
+TEST(ExecPlanExecution, ProjectMaintainsOrder) {
+  RegisterTestNodes();
+  constexpr int kRandomSeed = 42;
+  constexpr int64_t kRowsPerBatch = 1;
+  constexpr int kNumBatches = 16;
+  auto source_node = gen::Gen({{"x", gen::Step()}})
+                         ->FailOnError()
+                         ->SourceNode(kRowsPerBatch, kNumBatches);
+  Declaration plan =
+      Declaration::Sequence({source_node,
+                             {"jitter", JitterNodeOptions(kRandomSeed)},
+                             {"project", ProjectNodeOptions({field_ref("x")})}});
+
+  QueryOptions query_options;
+  query_options.sequence_output = true;
+  ASSERT_OK_AND_ASSIGN(BatchesWithCommonSchema batches,
+                       DeclarationToExecBatches(std::move(plan), query_options));
+
+  AssertExecBatchesSequenced(batches.batches);
+}
+
+TEST(ExecPlanExecution, FilterMaintainsOrder) {
+  RegisterTestNodes();
+  constexpr int kRandomSeed = 42;
+  constexpr int64_t kRowsPerBatch = 1;
+  constexpr int kNumBatches = 16;
+  auto source_node = gen::Gen({{"x", gen::Step()}})
+                         ->FailOnError()
+                         ->SourceNode(kRowsPerBatch, kNumBatches);
+  Declaration plan = Declaration::Sequence(
+      {source_node,
+       {"jitter", JitterNodeOptions(kRandomSeed)},
+       {"filter",
+        // The filter x > 50 should result in a few empty batches
+        FilterNodeOptions({call("greater", {field_ref("x"), literal(50)})})}});
+
+  QueryOptions query_options;
+  query_options.sequence_output = true;
+  ASSERT_OK_AND_ASSIGN(BatchesWithCommonSchema batches,
+                       DeclarationToExecBatches(std::move(plan), query_options));
+
+  // Sanity check that some filtering took place
+  ASSERT_EQ(0, batches.batches[0].length);
+
+  AssertExecBatchesSequenced(batches.batches);
 }
 
 namespace {

--- a/cpp/src/arrow/compute/exec/plan_test.cc
+++ b/cpp/src/arrow/compute/exec/plan_test.cc
@@ -302,7 +302,6 @@ void TestSourceSink(
       Declaration plan(source_factory_name,
                        OptionsType{exp_batches.schema, element_it_maker, requires_io});
       QueryOptions query_options;
-      query_options.sequence_output = true;
       query_options.use_threads = use_threads;
       ASSERT_OK_AND_ASSIGN(auto result,
                            DeclarationToExecBatches(std::move(plan), query_options));
@@ -995,10 +994,8 @@ TEST(ExecPlanExecution, ProjectMaintainsOrder) {
                              {"jitter", JitterNodeOptions(kRandomSeed)},
                              {"project", ProjectNodeOptions({field_ref("x")})}});
 
-  QueryOptions query_options;
-  query_options.sequence_output = true;
   ASSERT_OK_AND_ASSIGN(BatchesWithCommonSchema batches,
-                       DeclarationToExecBatches(std::move(plan), query_options));
+                       DeclarationToExecBatches(std::move(plan)));
 
   AssertExecBatchesSequenced(batches.batches);
 }
@@ -1018,10 +1015,8 @@ TEST(ExecPlanExecution, FilterMaintainsOrder) {
         // The filter x > 50 should result in a few empty batches
         FilterNodeOptions({call("greater", {field_ref("x"), literal(50)})})}});
 
-  QueryOptions query_options;
-  query_options.sequence_output = true;
   ASSERT_OK_AND_ASSIGN(BatchesWithCommonSchema batches,
-                       DeclarationToExecBatches(std::move(plan), query_options));
+                       DeclarationToExecBatches(std::move(plan)));
 
   // Sanity check that some filtering took place
   ASSERT_EQ(0, batches.batches[0].length);

--- a/cpp/src/arrow/compute/exec/sink_node.cc
+++ b/cpp/src/arrow/compute/exec/sink_node.cc
@@ -105,7 +105,8 @@ class SinkNode : public ExecNode,
   SinkNode(ExecPlan* plan, std::vector<ExecNode*> inputs,
            AsyncGenerator<std::optional<ExecBatch>>* generator,
            std::shared_ptr<Schema>* schema, BackpressureOptions backpressure,
-           BackpressureMonitor** backpressure_monitor_out, bool sequence_delivery)
+           BackpressureMonitor** backpressure_monitor_out,
+           std::optional<bool> sequence_output)
       : ExecNode(plan, std::move(inputs), {"collected"}, {}),
         TracedNode(this),
         backpressure_queue_(backpressure.resume_if_below, backpressure.pause_if_above),
@@ -131,7 +132,11 @@ class SinkNode : public ExecNode,
         return batch;
       });
     };
-    if (sequence_delivery) {
+
+    bool explicit_sequencing = sequence_output.has_value() && *sequence_output;
+    bool sequencing_disabled = sequence_output.has_value() && !*sequence_output;
+    if (explicit_sequencing ||
+        (!sequencing_disabled && !inputs_[0]->ordering().is_unordered())) {
       sequencer_ = util::SerialSequencingQueue::Make(this);
     }
   }
@@ -147,7 +152,7 @@ class SinkNode : public ExecNode,
     return plan->EmplaceNode<SinkNode>(plan, std::move(inputs), sink_options.generator,
                                        sink_options.schema, sink_options.backpressure,
                                        sink_options.backpressure_monitor,
-                                       sink_options.sequence_delivery);
+                                       sink_options.sequence_output);
   }
 
   const char* kind_name() const override { return "SinkNode"; }
@@ -290,12 +295,18 @@ class ConsumingSinkNode : public ExecNode,
  public:
   ConsumingSinkNode(ExecPlan* plan, std::vector<ExecNode*> inputs,
                     std::shared_ptr<SinkNodeConsumer> consumer,
-                    std::vector<std::string> names, bool sequence_delivery)
+                    std::vector<std::string> names, std::optional<bool> sequence_output)
       : ExecNode(plan, std::move(inputs), {"to_consume"}, {}),
         TracedNode(this),
         consumer_(std::move(consumer)),
         names_(std::move(names)) {
-    if (sequence_delivery) {
+    bool explicit_sequencing = sequence_output.has_value() && *sequence_output;
+    bool sequencing_disabled = sequence_output.has_value() && !*sequence_output;
+    // If the user explicitly requests sequencing then we configure a sequencer_ even
+    // if the input isn't ordered.  This will later lead to a validation failure (which is
+    // what the user is asking for in this case)
+    if (explicit_sequencing ||
+        (!sequencing_disabled && !inputs_[0]->ordering().is_unordered())) {
       sequencer_ = util::SerialSequencingQueue::Make(this);
     }
   }
@@ -436,7 +447,7 @@ struct OrderBySinkNode final : public SinkNode {
                   AsyncGenerator<std::optional<ExecBatch>>* generator)
       : SinkNode(plan, std::move(inputs), generator, /*schema=*/nullptr,
                  /*backpressure=*/{},
-                 /*backpressure_monitor_out=*/nullptr, /*sequence_delivery=*/false),
+                 /*backpressure_monitor_out=*/nullptr, /*sequence_output=*/false),
         impl_(std::move(impl)) {}
 
   const char* kind_name() const override { return "OrderBySinkNode"; }

--- a/cpp/src/arrow/compute/exec/sink_node.cc
+++ b/cpp/src/arrow/compute/exec/sink_node.cc
@@ -181,7 +181,7 @@ class SinkNode : public ExecNode,
     if (output_ != nullptr) {
       return Status::Invalid("Sink node '", label(), "' has an output");
     }
-    if (!inputs_[0]->ordering().has_value() && !!sequencer_) {
+    if (inputs_[0]->ordering().is_unordered() && !!sequencer_) {
       return Status::Invalid("Sink node '", label(),
                              "' is configured to sequence output but there is no "
                              "meaningful ordering in the input");
@@ -342,7 +342,7 @@ class ConsumingSinkNode : public ExecNode,
     if (output_ != nullptr) {
       return Status::Invalid("Consuming sink node '", label(), "' has an output");
     }
-    if (!inputs_[0]->ordering().has_value() && !!sequencer_) {
+    if (inputs_[0]->ordering().is_unordered() && !!sequencer_) {
       return Status::Invalid("Consuming sink node '", label(),
                              "' is configured to sequence output but there is no "
                              "meaningful ordering in the input");

--- a/cpp/src/arrow/compute/exec/source_node.cc
+++ b/cpp/src/arrow/compute/exec/source_node.cc
@@ -236,7 +236,7 @@ struct SourceNode : ExecNode, public TracedNode {
 struct TableSourceNode : public SourceNode {
   TableSourceNode(ExecPlan* plan, std::shared_ptr<Table> table, int64_t batch_size)
       : SourceNode(plan, table->schema(), TableGenerator(*table, batch_size),
-                   Ordering::Imiplicit()) {}
+                   Ordering::Implicit()) {}
 
   static Result<ExecNode*> Make(ExecPlan* plan, std::vector<ExecNode*> inputs,
                                 const ExecNodeOptions& options) {
@@ -305,7 +305,7 @@ template <typename This, typename Options>
 struct SchemaSourceNode : public SourceNode {
   SchemaSourceNode(ExecPlan* plan, std::shared_ptr<Schema> schema,
                    arrow::AsyncGenerator<std::optional<ExecBatch>> generator)
-      : SourceNode(plan, schema, generator, Ordering::Imiplicit()) {}
+      : SourceNode(plan, schema, generator, Ordering::Implicit()) {}
 
   static Result<ExecNode*> Make(ExecPlan* plan, std::vector<ExecNode*> inputs,
                                 const ExecNodeOptions& options) {

--- a/cpp/src/arrow/compute/exec/source_node.cc
+++ b/cpp/src/arrow/compute/exec/source_node.cc
@@ -52,10 +52,12 @@ namespace {
 
 struct SourceNode : ExecNode, public TracedNode {
   SourceNode(ExecPlan* plan, std::shared_ptr<Schema> output_schema,
-             AsyncGenerator<std::optional<ExecBatch>> generator)
+             AsyncGenerator<std::optional<ExecBatch>> generator,
+             std::optional<std::vector<SortKey>> ordering = kUnordered)
       : ExecNode(plan, {}, {}, std::move(output_schema)),
         TracedNode(this),
-        generator_(std::move(generator)) {}
+        generator_(std::move(generator)),
+        ordering_(ordering) {}
 
   static Result<ExecNode*> Make(ExecPlan* plan, std::vector<ExecNode*> inputs,
                                 const ExecNodeOptions& options) {
@@ -76,6 +78,7 @@ struct SourceNode : ExecNode, public TracedNode {
   void SliceAndDeliverMorsel(const ExecBatch& morsel) {
     bool use_legacy_batching = plan_->query_context()->options().use_legacy_batching;
     int64_t morsel_length = static_cast<int64_t>(morsel.length);
+    int initial_batch_index = batch_count_;
     if (use_legacy_batching || morsel_length == 0) {
       // For various reasons (e.g. ARROW-13982) we pass empty batches
       // through
@@ -86,8 +89,10 @@ struct SourceNode : ExecNode, public TracedNode {
       batch_count_ += num_batches;
     }
     plan_->query_context()->ScheduleTask(
-        [this, morsel_length, use_legacy_batching, morsel]() {
+        [this, morsel_length, use_legacy_batching, initial_batch_index, morsel,
+         has_ordering = ordering_.has_value()]() {
           int64_t offset = 0;
+          int batch_index = initial_batch_index;
           do {
             int64_t batch_size =
                 std::min<int64_t>(morsel_length - offset, ExecPlan::kMaxBatchSize);
@@ -97,7 +102,11 @@ struct SourceNode : ExecNode, public TracedNode {
               batch_size = morsel_length;
             }
             ExecBatch batch = morsel.Slice(offset, batch_size);
+            if (has_ordering) {
+              batch.index = batch_index;
+            }
             offset += batch_size;
+            batch_index++;
             ARROW_RETURN_NOT_OK(output_->InputReceived(this, std::move(batch)));
           } while (offset < morsel.length);
           return Status::OK();
@@ -176,6 +185,10 @@ struct SourceNode : ExecNode, public TracedNode {
     return Status::OK();
   }
 
+  const std::optional<std::vector<SortKey>>& ordering() const override {
+    return ordering_;
+  }
+
   void PauseProducing(ExecNode* output, int32_t counter) override {
     std::lock_guard<std::mutex> lg(mutex_);
     if (counter <= backpressure_counter_) {
@@ -218,12 +231,14 @@ struct SourceNode : ExecNode, public TracedNode {
   bool stop_requested_{false};
   bool started_ = false;
   int batch_count_{0};
-  AsyncGenerator<std::optional<ExecBatch>> generator_;
+  const AsyncGenerator<std::optional<ExecBatch>> generator_;
+  const std::optional<std::vector<SortKey>> ordering_;
 };
 
 struct TableSourceNode : public SourceNode {
   TableSourceNode(ExecPlan* plan, std::shared_ptr<Table> table, int64_t batch_size)
-      : SourceNode(plan, table->schema(), TableGenerator(*table, batch_size)) {}
+      : SourceNode(plan, table->schema(), TableGenerator(*table, batch_size),
+                   kImplicitOrdering) {}
 
   static Result<ExecNode*> Make(ExecPlan* plan, std::vector<ExecNode*> inputs,
                                 const ExecNodeOptions& options) {
@@ -274,7 +289,6 @@ struct TableSourceNode : public SourceNode {
 
     std::shared_ptr<RecordBatch> batch;
     std::vector<ExecBatch> exec_batches;
-    int index = 0;
     while (true) {
       auto batch_res = reader->Next();
       if (batch_res.ok()) {
@@ -284,7 +298,6 @@ struct TableSourceNode : public SourceNode {
         break;
       }
       exec_batches.emplace_back(*batch);
-      exec_batches[exec_batches.size() - 1].index = index++;
     }
     return exec_batches;
   }
@@ -294,7 +307,7 @@ template <typename This, typename Options>
 struct SchemaSourceNode : public SourceNode {
   SchemaSourceNode(ExecPlan* plan, std::shared_ptr<Schema> schema,
                    arrow::AsyncGenerator<std::optional<ExecBatch>> generator)
-      : SourceNode(plan, schema, generator) {}
+      : SourceNode(plan, schema, generator, kImplicitOrdering) {}
 
   static Result<ExecNode*> Make(ExecPlan* plan, std::vector<ExecNode*> inputs,
                                 const ExecNodeOptions& options) {
@@ -306,11 +319,20 @@ struct SchemaSourceNode : public SourceNode {
 
     auto it = it_maker();
 
-    if (schema == NULLPTR) {
+    if (schema == nullptr) {
       return Status::Invalid(This::kKindName, " requires schema which is not null");
     }
-    if (io_executor == NULLPTR) {
-      io_executor = io::internal::GetIOThreadPool();
+
+    if (cast_options.requires_io) {
+      if (io_executor == nullptr) {
+        io_executor = io::internal::GetIOThreadPool();
+      }
+    } else {
+      if (io_executor != nullptr) {
+        return Status::Invalid(
+            This::kKindName,
+            " specified with requires_io=false but io_executor was not nullptr");
+      }
     }
 
     ARROW_ASSIGN_OR_RAISE(auto generator, This::MakeGenerator(it, io_executor, schema));
@@ -356,6 +378,9 @@ struct RecordBatchReaderSourceNode : public SourceNode {
     };
     Iterator<std::shared_ptr<RecordBatch>> batch_it = MakeIteratorFromReader(reader);
     auto exec_batch_it = MakeMapIterator(to_exec_batch, std::move(batch_it));
+    if (io_executor == nullptr) {
+      return MakeBlockingGenerator(std::move(exec_batch_it));
+    }
     return MakeBackgroundGenerator(std::move(exec_batch_it), io_executor);
   }
 
@@ -389,6 +414,9 @@ struct RecordBatchSourceNode
       return std::optional<ExecBatch>(ExecBatch(*batch));
     };
     auto exec_batch_it = MakeMapIterator(to_exec_batch, std::move(batch_it));
+    if (io_executor == nullptr) {
+      return MakeBlockingGenerator(std::move(exec_batch_it));
+    }
     return MakeBackgroundGenerator(std::move(exec_batch_it), io_executor);
   }
 
@@ -419,6 +447,9 @@ struct ExecBatchSourceNode
       return batch == NULLPTR ? std::nullopt : std::optional<ExecBatch>(*batch);
     };
     auto exec_batch_it = MakeMapIterator(to_exec_batch, std::move(batch_it));
+    if (io_executor == nullptr) {
+      return MakeBlockingGenerator(std::move(exec_batch_it));
+    }
     return MakeBackgroundGenerator(std::move(exec_batch_it), io_executor);
   }
 
@@ -457,6 +488,9 @@ struct ArrayVectorSourceNode
           ExecBatch(std::move(datumvec), (*arrayvec)[0]->length()));
     };
     auto exec_batch_it = MakeMapIterator(to_exec_batch, std::move(arrayvec_it));
+    if (io_executor == nullptr) {
+      return MakeBlockingGenerator(std::move(exec_batch_it));
+    }
     return MakeBackgroundGenerator(std::move(exec_batch_it), io_executor);
   }
 

--- a/cpp/src/arrow/compute/exec/test_nodes.cc
+++ b/cpp/src/arrow/compute/exec/test_nodes.cc
@@ -121,9 +121,7 @@ class JitterNode : public ExecNode {
 
   const char* kind_name() const override { return "JitterNode"; }
 
-  const std::optional<std::vector<SortKey>>& ordering() const override {
-    return inputs_[0]->ordering();
-  }
+  const Ordering& ordering() const override { return inputs_[0]->ordering(); }
 
   Status StartProducing() override { return Status::OK(); }
 

--- a/cpp/src/arrow/compute/exec/test_nodes.cc
+++ b/cpp/src/arrow/compute/exec/test_nodes.cc
@@ -121,6 +121,10 @@ class JitterNode : public ExecNode {
 
   const char* kind_name() const override { return "JitterNode"; }
 
+  const std::optional<std::vector<SortKey>>& ordering() const override {
+    return inputs_[0]->ordering();
+  }
+
   Status StartProducing() override { return Status::OK(); }
 
   void PauseProducing(ExecNode* output, int32_t counter) override {

--- a/cpp/src/arrow/compute/exec/test_nodes.h
+++ b/cpp/src/arrow/compute/exec/test_nodes.h
@@ -48,7 +48,7 @@ struct JitterNodeOptions : public ExecNodeOptions {
   /// The max amount to add to a node's "cost".
   int max_jitter_modifier;
 
-  JitterNodeOptions(random::SeedType seed, int max_jitter_modifier)
+  explicit JitterNodeOptions(random::SeedType seed, int max_jitter_modifier = 5)
       : seed(seed), max_jitter_modifier(max_jitter_modifier) {}
   static constexpr std::string_view kName = "jitter";
 };

--- a/cpp/src/arrow/compute/exec/test_nodes_test.cc
+++ b/cpp/src/arrow/compute/exec/test_nodes_test.cc
@@ -39,8 +39,10 @@ TEST(JitterNode, Basic) {
   Declaration plan =
       Declaration::Sequence({{"table_source", TableSourceNodeOptions(input)},
                              {"jitter", JitterNodeOptions(kTestSeed, kMaxJitterMod)}});
+  QueryOptions query_options;
+  query_options.sequence_output = false;
   ASSERT_OK_AND_ASSIGN(BatchesWithCommonSchema batches_and_schema,
-                       DeclarationToExecBatches(std::move(plan)));
+                       DeclarationToExecBatches(std::move(plan), query_options));
 
   ASSERT_EQ(kNumBatches, static_cast<int>(batches_and_schema.batches.size()));
   int numOutOfPlace = 0;

--- a/cpp/src/arrow/compute/exec/test_util.cc
+++ b/cpp/src/arrow/compute/exec/test_util.cc
@@ -420,6 +420,21 @@ void AssertExecBatchesEqualIgnoringOrder(const std::shared_ptr<Schema>& schema,
   AssertTablesEqualIgnoringOrder(exp_tab, act_tab);
 }
 
+void AssertExecBatchesEqual(const std::shared_ptr<Schema>& schema,
+                            const std::vector<ExecBatch>& exp,
+                            const std::vector<ExecBatch>& act) {
+  ASSERT_OK_AND_ASSIGN(auto exp_tab, TableFromExecBatches(schema, exp));
+  ASSERT_OK_AND_ASSIGN(auto act_tab, TableFromExecBatches(schema, act));
+  AssertTablesEqual(*exp_tab, *act_tab);
+}
+
+void AssertExecBatchesSequenced(const std::vector<ExecBatch>& batches) {
+  int expected_index = 0;
+  for (const auto& batch : batches) {
+    ASSERT_EQ(expected_index++, batch.index);
+  }
+}
+
 template <typename T>
 static const T& OptionsAs(const ExecNodeOptions& opts) {
   const auto& ptr = checked_cast<const T&>(opts);

--- a/cpp/src/arrow/compute/exec/test_util.h
+++ b/cpp/src/arrow/compute/exec/test_util.h
@@ -167,6 +167,14 @@ void AssertExecBatchesEqualIgnoringOrder(const std::shared_ptr<Schema>& schema,
                                          const std::vector<ExecBatch>& act);
 
 ARROW_TESTING_EXPORT
+void AssertExecBatchesEqual(const std::shared_ptr<Schema>& schema,
+                            const std::vector<ExecBatch>& exp,
+                            const std::vector<ExecBatch>& act);
+
+ARROW_TESTING_EXPORT void AssertExecBatchesSequenced(
+    const std::vector<ExecBatch>& batches);
+
+ARROW_TESTING_EXPORT
 bool operator==(const Declaration&, const Declaration&);
 
 ARROW_TESTING_EXPORT

--- a/cpp/src/arrow/compute/exec_test.cc
+++ b/cpp/src/arrow/compute/exec_test.cc
@@ -33,6 +33,7 @@
 #include "arrow/compute/function.h"
 #include "arrow/compute/function_internal.h"
 #include "arrow/compute/kernel.h"
+#include "arrow/compute/ordering.h"
 #include "arrow/compute/registry.h"
 #include "arrow/memory_pool.h"
 #include "arrow/record_batch.h"
@@ -1393,6 +1394,35 @@ TEST_F(TestCallScalarFunctionScalarFunction, SimpleCall) {
 
 TEST_F(TestCallScalarFunctionScalarFunction, ExecCall) {
   TestCallScalarFunctionScalarFunction::DoTest(ExecFunctionCaller::Maker);
+}
+
+TEST(Ordering, IsSuborderOf) {
+  Ordering a{{SortKey{3}, SortKey{1}, SortKey{7}}};
+  Ordering b{{SortKey{3}, SortKey{1}}};
+  Ordering c{{SortKey{1}, SortKey{7}}};
+  Ordering d{{SortKey{1}, SortKey{7}}, NullPlacement::AtEnd};
+  Ordering imp = Ordering::Imiplicit();
+  Ordering unordered = Ordering::Unordered();
+
+  std::vector<Ordering> orderings = {a, b, c, d, imp, unordered};
+
+  auto CheckOrdering = [&](const Ordering& ordering, std::vector<bool> expected) {
+    for (std::size_t other_idx = 0; other_idx < orderings.size(); other_idx++) {
+      const auto& other = orderings[other_idx];
+      if (expected[other_idx]) {
+        ASSERT_TRUE(ordering.IsSuborderOf(other));
+      } else {
+        ASSERT_FALSE(ordering.IsSuborderOf(other));
+      }
+    }
+  };
+
+  CheckOrdering(a, {true, false, false, false, false, false});
+  CheckOrdering(b, {true, true, false, false, false, false});
+  CheckOrdering(c, {false, false, true, false, false, false});
+  CheckOrdering(d, {false, false, false, true, false, false});
+  CheckOrdering(imp, {false, false, false, false, false, false});
+  CheckOrdering(unordered, {true, true, true, true, true, true});
 }
 
 }  // namespace detail

--- a/cpp/src/arrow/compute/exec_test.cc
+++ b/cpp/src/arrow/compute/exec_test.cc
@@ -1401,7 +1401,7 @@ TEST(Ordering, IsSuborderOf) {
   Ordering b{{SortKey{3}, SortKey{1}}};
   Ordering c{{SortKey{1}, SortKey{7}}};
   Ordering d{{SortKey{1}, SortKey{7}}, NullPlacement::AtEnd};
-  Ordering imp = Ordering::Imiplicit();
+  Ordering imp = Ordering::Implicit();
   Ordering unordered = Ordering::Unordered();
 
   std::vector<Ordering> orderings = {a, b, c, d, imp, unordered};

--- a/cpp/src/arrow/compute/ordering.cc
+++ b/cpp/src/arrow/compute/ordering.cc
@@ -1,0 +1,95 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <sstream>
+
+#include "arrow/compute/ordering.h"
+#include "arrow/util/unreachable.h"
+
+namespace arrow {
+namespace compute {
+
+bool SortKey::Equals(const SortKey& other) const {
+  return target == other.target && order == other.order;
+}
+
+std::string SortKey::ToString() const {
+  std::stringstream ss;
+  ss << target.ToString() << ' ';
+  switch (order) {
+    case SortOrder::Ascending:
+      ss << "ASC";
+      break;
+    case SortOrder::Descending:
+      ss << "DESC";
+      break;
+  }
+  return ss.str();
+}
+
+bool Ordering::IsSuborderOf(const Ordering& other) const {
+  if (sort_keys_.empty()) {
+    // The implicit ordering is a subordering of nothing.  The unordered ordering
+    // is a subordering of everything
+    return !is_implicit_;
+  }
+  if (null_placement_ != other.null_placement_) {
+    return false;
+  }
+  if (sort_keys_.size() > other.sort_keys_.size()) {
+    return false;
+  }
+  for (std::size_t key_idx = 0; key_idx < sort_keys_.size(); key_idx++) {
+    if (sort_keys_[key_idx] != other.sort_keys_[key_idx]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool Ordering::Equals(const Ordering& other) const {
+  return null_placement_ == other.null_placement_ && sort_keys_ == other.sort_keys_;
+}
+
+std::string Ordering::ToString() const {
+  std::stringstream ss;
+  ss << "[";
+  bool first = true;
+  for (const auto& key : sort_keys_) {
+    if (first) {
+      first = false;
+    } else {
+      ss << ", ";
+    }
+    ss << key.ToString();
+  }
+  ss << "]";
+  switch (null_placement_) {
+    case NullPlacement::AtEnd:
+      ss << " nulls last";
+      break;
+    case NullPlacement::AtStart:
+      ss << " nulls first";
+      break;
+    default:
+      Unreachable();
+  }
+  return ss.str();
+}
+
+}  // namespace compute
+}  // namespace arrow

--- a/cpp/src/arrow/compute/ordering.h
+++ b/cpp/src/arrow/compute/ordering.h
@@ -1,0 +1,120 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "arrow/type.h"
+#include "arrow/util/compare.h"
+#include "arrow/util/visibility.h"
+
+namespace arrow {
+namespace compute {
+
+enum class SortOrder {
+  /// Arrange values in increasing order
+  Ascending,
+  /// Arrange values in decreasing order
+  Descending,
+};
+
+enum class NullPlacement {
+  /// Place nulls and NaNs before any non-null values.
+  /// NaNs will come after nulls.
+  AtStart,
+  /// Place nulls and NaNs after any non-null values.
+  /// NaNs will come before nulls.
+  AtEnd,
+};
+
+/// \brief One sort key for PartitionNthIndices (TODO) and SortIndices
+class ARROW_EXPORT SortKey : public util::EqualityComparable<SortKey> {
+ public:
+  explicit SortKey(FieldRef target, SortOrder order = SortOrder::Ascending)
+      : target(std::move(target)), order(order) {}
+
+  bool Equals(const SortKey& other) const;
+  std::string ToString() const;
+
+  /// A FieldRef targetting the sort column.
+  FieldRef target;
+  /// How to order by this sort key.
+  SortOrder order;
+};
+
+class ARROW_EXPORT Ordering : public util::EqualityComparable<Ordering> {
+ public:
+  Ordering(std::vector<SortKey> sort_keys,
+           NullPlacement null_placement = NullPlacement::AtStart)
+      : sort_keys_(std::move(sort_keys)), null_placement_(null_placement) {}
+  /// true if data ordered by other is also ordered by this
+  ///
+  /// For example, if data is ordered by [a, b, c] then it is also ordered
+  /// by [a, b] but not by [b, c] or [a, b, c, d].
+  ///
+  /// [a, b].IsSuborderOf([a, b, c]) - true
+  /// [a, b, c].IsSuborderOf([a, b, c]) - true
+  /// [b, c].IsSuborderOf([a, b, c]) - false
+  /// [a, b, c, d].IsSuborderOf([a, b, c]) - false
+  ///
+  /// The implicit ordering is not a suborder of any other ordering and
+  /// no other ordering is a suborder of it.  The implicit ordering is not a
+  /// suborder of itself.
+  ///
+  /// The unordered ordering is a suborder of all other orderings but no
+  /// other ordering is a suborder of it.  The unordered ordering is a suborder
+  /// of itself.
+  ///
+  /// The unordered ordering is a suborder of the implicit ordering.
+  bool IsSuborderOf(const Ordering& other) const;
+
+  bool Equals(const Ordering& other) const;
+  std::string ToString() const;
+
+  bool is_implicit() const { return is_implicit_; }
+  bool is_unordered() const { return !is_implicit_ && sort_keys_.empty(); }
+
+  std::vector<SortKey> sort_keys() { return sort_keys_; }
+  NullPlacement null_placement() { return null_placement_; }
+
+  static const Ordering& Imiplicit() {
+    static const Ordering kImplicit(true);
+    return kImplicit;
+  }
+
+  static const Ordering& Unordered() {
+    static const Ordering kUnordered(false);
+    // It is also possible to get an unordered ordering by passing in an empty vector
+    // using the normal constructor.  This is ok and useful when ordering comes from user
+    // input.
+    return kUnordered;
+  }
+
+ private:
+  Ordering(bool is_implicit)
+      : null_placement_(NullPlacement::AtStart), is_implicit_(is_implicit) {}
+  /// Column key(s) to order by and how to order by these sort keys.
+  std::vector<SortKey> sort_keys_;
+  /// Whether nulls and NaNs are placed at the start or at the end
+  NullPlacement null_placement_;
+  bool is_implicit_ = false;
+};
+
+}  // namespace compute
+}  // namespace arrow

--- a/cpp/src/arrow/compute/ordering.h
+++ b/cpp/src/arrow/compute/ordering.h
@@ -93,7 +93,7 @@ class ARROW_EXPORT Ordering : public util::EqualityComparable<Ordering> {
   std::vector<SortKey> sort_keys() { return sort_keys_; }
   NullPlacement null_placement() { return null_placement_; }
 
-  static const Ordering& Imiplicit() {
+  static const Ordering& Implicit() {
     static const Ordering kImplicit(true);
     return kImplicit;
   }

--- a/cpp/src/arrow/compute/ordering.h
+++ b/cpp/src/arrow/compute/ordering.h
@@ -107,7 +107,7 @@ class ARROW_EXPORT Ordering : public util::EqualityComparable<Ordering> {
   }
 
  private:
-  Ordering(bool is_implicit)
+  explicit Ordering(bool is_implicit)
       : null_placement_(NullPlacement::AtStart), is_implicit_(is_implicit) {}
   /// Column key(s) to order by and how to order by these sort keys.
   std::vector<SortKey> sort_keys_;

--- a/cpp/src/arrow/compute/registry.h
+++ b/cpp/src/arrow/compute/registry.h
@@ -117,8 +117,5 @@ class ARROW_EXPORT FunctionRegistry {
   explicit FunctionRegistry(FunctionRegistryImpl* impl);
 };
 
-/// \brief Return the process-global function registry.
-ARROW_EXPORT FunctionRegistry* GetFunctionRegistry();
-
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/type_fwd.h
+++ b/cpp/src/arrow/compute/type_fwd.h
@@ -33,7 +33,7 @@ class FunctionRegistry;
 
 /// \brief Return the process-global function registry.
 // Defined in registry.cc
-FunctionRegistry* GetFunctionRegistry();
+ARROW_EXPORT FunctionRegistry* GetFunctionRegistry();
 
 class CastOptions;
 

--- a/cpp/src/arrow/compute/type_fwd.h
+++ b/cpp/src/arrow/compute/type_fwd.h
@@ -31,6 +31,8 @@ class FunctionExecutor;
 class FunctionOptions;
 class FunctionRegistry;
 
+/// \brief Return the process-global function registry.
+// Defined in registry.cc
 FunctionRegistry* GetFunctionRegistry();
 
 class CastOptions;

--- a/cpp/src/arrow/compute/type_fwd.h
+++ b/cpp/src/arrow/compute/type_fwd.h
@@ -31,6 +31,8 @@ class FunctionExecutor;
 class FunctionOptions;
 class FunctionRegistry;
 
+FunctionRegistry* GetFunctionRegistry();
+
 class CastOptions;
 
 struct ExecBatch;

--- a/cpp/src/arrow/testing/generator.h
+++ b/cpp/src/arrow/testing/generator.h
@@ -256,6 +256,8 @@ class ARROW_TESTING_EXPORT GTestDataGenerator {
   virtual ::arrow::compute::ExecBatch ExecBatch(int64_t num_rows) = 0;
   virtual std::vector<::arrow::compute::ExecBatch> ExecBatches(int64_t rows_per_batch,
                                                                int num_batches) = 0;
+  virtual ::arrow::compute::Declaration SourceNode(int64_t rows_per_batch,
+                                                   int num_batches) = 0;
 #endif
   virtual std::shared_ptr<::arrow::Table> Table(int64_t rows_per_chunk,
                                                 int num_chunks = 1) = 0;
@@ -272,6 +274,8 @@ class ARROW_TESTING_EXPORT DataGenerator {
   virtual Result<::arrow::compute::ExecBatch> ExecBatch(int64_t num_rows) = 0;
   virtual Result<std::vector<::arrow::compute::ExecBatch>> ExecBatches(
       int64_t rows_per_batch, int num_batches) = 0;
+  virtual Result<::arrow::compute::Declaration> SourceNode(int64_t rows_per_batch,
+                                                           int num_batches) = 0;
 #endif
   virtual Result<std::shared_ptr<::arrow::Table>> Table(int64_t rows_per_chunk,
                                                         int num_chunks = 1) = 0;


### PR DESCRIPTION
In addition, it is now possible to bypass the I/O executor on the `record_batch_source`, `exec_batch_source`, and `array_vector_source`.

It is now possible to create a source node from a `gen::Gen` generator.

BREAKING CHANGE: The default executor for `record_batch_source`, `exec_batch_source`, and `array_vector_source` was (erroneously) the plan's CPU executor.  It now defaults properly to the I/O executor.
* Closes: #34136