### PR TITLE
GH-33618: [C++] add option needs_extended_file_info and implement localFS

### DIFF
--- a/cpp/src/arrow/filesystem/filesystem.h
+++ b/cpp/src/arrow/filesystem/filesystem.h
@@ -132,7 +132,10 @@ struct ARROW_EXPORT FileSelector {
   bool recursive;
   /// The maximum number of subdirectories to recurse into.
   int32_t max_recursion;
-  /// If true, use stat() to obtain extended file metadata.
+  /// If false, may skip retrieving size and modification time metadata.
+  ///
+  /// On local filesystem, setting to false avoids an additional system call.
+  /// On other filesystems, this may have no effect.
   bool needs_extended_file_info;
 
   FileSelector()

--- a/cpp/src/arrow/filesystem/filesystem.h
+++ b/cpp/src/arrow/filesystem/filesystem.h
@@ -132,8 +132,14 @@ struct ARROW_EXPORT FileSelector {
   bool recursive;
   /// The maximum number of subdirectories to recurse into.
   int32_t max_recursion;
+  /// If true, use stat() to obtain extended file metadata.
+  bool needs_extended_file_info;
 
-  FileSelector() : allow_not_found(false), recursive(false), max_recursion(INT32_MAX) {}
+  FileSelector()
+      : allow_not_found(false),
+        recursive(false),
+        max_recursion(INT32_MAX),
+        needs_extended_file_info(true) {}
 };
 
 /// \brief FileSystem, path pair

--- a/cpp/src/arrow/filesystem/localfs.cc
+++ b/cpp/src/arrow/filesystem/localfs.cc
@@ -211,6 +211,8 @@ Result<FileInfo> StatFile(const std::string& path) {
   return info;
 }
 
+#endif
+
 Result<FileInfo> IdentifyFile(const std::string& path) {
   FileInfo info;
 
@@ -226,8 +228,6 @@ Result<FileInfo> IdentifyFile(const std::string& path) {
 
   return info;
 }
-
-#endif
 
 Status StatSelector(const PlatformFilename& dir_fn, const FileSelector& select,
                     int32_t nesting_depth, std::vector<FileInfo>* out) {

--- a/cpp/src/arrow/filesystem/localfs.cc
+++ b/cpp/src/arrow/filesystem/localfs.cc
@@ -233,14 +233,15 @@ Result<FileInfo> IdentifyFile(const std::filesystem::path path) {
   return info;
 }
 
-Status SelectorFileExists(const PlatformFilename& dir_fn, bool allow_not_found, auto status) {
-    if (allow_not_found && status.IsIOError()) {
-      ARROW_ASSIGN_OR_RAISE(bool exists, FileExists(dir_fn));
-      if (!exists) {
-        return Status::OK();
-      }
+Status SelectorFileExists(const PlatformFilename& dir_fn, bool allow_not_found,
+                          Status status) {
+  if (allow_not_found && status.IsIOError()) {
+    ARROW_ASSIGN_OR_RAISE(bool exists, FileExists(dir_fn));
+    if (!exists) {
+      return Status::OK();
     }
-    return status;
+  }
+  return status;
 }
 
 Status StatSelector(const PlatformFilename& dir_fn, const FileSelector& select,
@@ -266,7 +267,6 @@ Status StatSelector(const PlatformFilename& dir_fn, const FileSelector& select,
 
 Status IdentifyFileSelector(const PlatformFilename& dir_fn, const FileSelector& select,
                             int32_t nesting_depth, std::vector<FileInfo>* out) {
-
   auto result = ListDir(dir_fn);
   if (!result.ok()) {
     return SelectorFileExists(dir_fn, select.allow_not_found, result.status());

--- a/cpp/src/arrow/filesystem/localfs.cc
+++ b/cpp/src/arrow/filesystem/localfs.cc
@@ -218,8 +218,10 @@ Result<FileInfo> IdentifyFile(const std::string& path) {
 
   if (std::filesystem::is_directory(path)) {
     info.set_type(FileType::Directory);
-  } else if (std::filesystem::is_regular_file(path)) {
+  } else if (std::filesystem::is_regular_file(path) || std::filesystem::is_symlink(path)) {
     info.set_type(FileType::File);
+  } else {
+    info.set_type(FileType::Unknown);
   }
 
   info.set_mtime(kNoTime);

--- a/cpp/src/arrow/filesystem/localfs.cc
+++ b/cpp/src/arrow/filesystem/localfs.cc
@@ -361,7 +361,7 @@ Result<std::vector<FileInfo>> LocalFileSystem::GetFileInfo(const FileSelector& s
   RETURN_NOT_OK(ValidatePath(select.base_dir));
   ARROW_ASSIGN_OR_RAISE(auto fn, PlatformFilename::FromString(select.base_dir));
   std::vector<FileInfo> results;
-  if (select.needs_extended_file_info == true) {
+  if (select.needs_extended_file_info) {
     RETURN_NOT_OK(StatSelector(fn, select, 0, &results));
   } else {
     RETURN_NOT_OK(IdentifyFileSelector(fn, select, 0, &results));

--- a/cpp/src/arrow/filesystem/localfs_test.cc
+++ b/cpp/src/arrow/filesystem/localfs_test.cc
@@ -474,7 +474,7 @@ TYPED_TEST(TestLocalFS, StressGetFileInfoGenerator) {
 
 TYPED_TEST(TestLocalFS, NeedsExtendedFileInfo) {
   ASSERT_OK(this->fs_->CreateDir("AB/CD"));
-  CreateFile(this->fs_.get(), "ab", "data");
+  CreateFile(this->fs_.get(), "AB/ab", "data");
 
   FileSelector selector;
   selector.base_dir = "";
@@ -482,13 +482,11 @@ TYPED_TEST(TestLocalFS, NeedsExtendedFileInfo) {
   std::vector<FileInfo> infos;
 
   ASSERT_OK_AND_ASSIGN(infos, this->fs_->GetFileInfo(selector));
-  ASSERT_EQ(infos.size(), 2);
+  ASSERT_EQ(infos.size(), 1);
 
   for (FileInfo info : infos) {
     if (info.path() == "AB") {
       AssertFileInfo(info, "AB", FileType::Directory);
-    } else if (info.path() == "ab") {
-      AssertFileInfo(info, "ab", FileType::File);
     } else {
       // TODO how would I raise an error in a test?
       ASSERT_TRUE(false);
@@ -507,8 +505,8 @@ TYPED_TEST(TestLocalFS, NeedsExtendedFileInfo) {
       AssertFileInfo(info, "AB", FileType::Directory);
     } else if (info.path() == "AB/CD") {
       AssertFileInfo(info, "AB/CD", FileType::Directory);
-    } else if (info.path() == "ab") {
-      AssertFileInfo(info, "ab", FileType::File);
+    } else if (info.path() == "AB/ab") {
+      AssertFileInfo(info, "AB/ab", FileType::File);
     } else {
       // TODO how would I raise an error in a test?
       ASSERT_TRUE(false);

--- a/cpp/src/arrow/filesystem/localfs_test.cc
+++ b/cpp/src/arrow/filesystem/localfs_test.cc
@@ -484,34 +484,21 @@ TYPED_TEST(TestLocalFS, NeedsExtendedFileInfo) {
   ASSERT_OK_AND_ASSIGN(infos, this->fs_->GetFileInfo(selector));
   ASSERT_EQ(infos.size(), 1);
 
-  for (FileInfo info : infos) {
-    if (info.path() == "AB") {
-      AssertFileInfo(info, "AB", FileType::Directory);
-    } else {
-      // TODO how would I raise an error in a test?
-      ASSERT_TRUE(false);
-    }
+  AssertFileInfo(infos[0], "AB", FileType::Directory);
 
-    ASSERT_EQ(info.size(), kNoSize);
-    ASSERT_EQ(info.mtime(), kNoTime);
-  }
+  ASSERT_EQ(infos[0].size(), kNoSize);
+  ASSERT_EQ(infos[0].mtime(), kNoTime);
 
   selector.recursive = true;
   ASSERT_OK_AND_ASSIGN(infos, this->fs_->GetFileInfo(selector));
   ASSERT_EQ(infos.size(), 3);
 
-  for (FileInfo info : infos) {
-    if (info.path() == "AB") {
-      AssertFileInfo(info, "AB", FileType::Directory);
-    } else if (info.path() == "AB/CD") {
-      AssertFileInfo(info, "AB/CD", FileType::Directory);
-    } else if (info.path() == "AB/ab") {
-      AssertFileInfo(info, "AB/ab", FileType::File);
-    } else {
-      // TODO how would I raise an error in a test?
-      ASSERT_TRUE(false);
-    }
+  SortInfos(&infos);
+  AssertFileInfo(infos[0], "AB", FileType::Directory);
+  AssertFileInfo(infos[1], "AB/CD", FileType::Directory);
+  AssertFileInfo(infos[2], "AB/ab", FileType::File);
 
+  for (FileInfo info : infos) {
     ASSERT_EQ(info.size(), kNoSize);
     ASSERT_EQ(info.mtime(), kNoTime);
   }

--- a/cpp/src/arrow/filesystem/localfs_test.cc
+++ b/cpp/src/arrow/filesystem/localfs_test.cc
@@ -472,6 +472,24 @@ TYPED_TEST(TestLocalFS, StressGetFileInfoGenerator) {
   }
 }
 
+TYPED_TEST(TestLocalFS, NeedsExtendedFileInfo) {
+  // Test setting needs_extended_file_info to true and false
+  ASSERT_OK(this->fs_->CreateDir("AB/CD"));
+  CreateFile(this->fs_.get(), "AB/cd", "data");
+
+  std::vector<FileInfo> infos;
+  FileSelector selector;
+  selector.base_dir = "AB";
+  selector.needs_extended_file_info = false;
+
+  ASSERT_OK_AND_ASSIGN(infos, this->fs_->GetFileInfo(selector));
+  AssertFileInfo(infos[0], "AB/cd", FileType::File);
+  AssertFileInfo(infos[1], "AB/CD", FileType::Directory);
+
+  ASSERT_EQ(infos[0].size(), -1);
+  ASSERT_EQ(infos[1].size(), -1);
+}
+
 // TODO Should we test backslash paths on Windows?
 // SubTreeFileSystem isn't compatible with them.
 

--- a/cpp/src/arrow/filesystem/localfs_test.cc
+++ b/cpp/src/arrow/filesystem/localfs_test.cc
@@ -495,8 +495,13 @@ TYPED_TEST(TestLocalFS, NeedsExtendedFileInfo) {
 
   SortInfos(&infos);
   AssertFileInfo(infos[0], "AB", FileType::Directory);
+#ifdef _WIN32
+  AssertFileInfo(infos[1], "AB\\CD", FileType::Directory);
+  AssertFileInfo(infos[2], "AB\\ab", FileType::File);
+#else
   AssertFileInfo(infos[1], "AB/CD", FileType::Directory);
   AssertFileInfo(infos[2], "AB/ab", FileType::File);
+#endif
 
   for (FileInfo info : infos) {
     ASSERT_EQ(info.size(), kNoSize);

--- a/cpp/src/arrow/filesystem/localfs_test.cc
+++ b/cpp/src/arrow/filesystem/localfs_test.cc
@@ -486,11 +486,11 @@ TYPED_TEST(TestLocalFS, NeedsExtendedFileInfo) {
   AssertFileInfo(infos[0], "AB/cd", FileType::File);
   AssertFileInfo(infos[1], "AB/CD", FileType::Directory);
 
-  ASSERT_EQ(infos[0].size(), -1);
-  ASSERT_EQ(infos[1].size(), -1);
+  ASSERT_EQ(infos[0].size(), kNoSize);
+  ASSERT_EQ(infos[1].size(), kNoSize);
 
-  ASSERT_EQ(infos[0].mtime(), -1);
-  ASSERT_EQ(infos[1].mtime(), -1);
+  ASSERT_EQ(infos[0].mtime(), kNoTime);
+  ASSERT_EQ(infos[1].mtime(), kNoTime);
 }
 
 // TODO Should we test backslash paths on Windows?

--- a/cpp/src/arrow/filesystem/localfs_test.cc
+++ b/cpp/src/arrow/filesystem/localfs_test.cc
@@ -514,7 +514,7 @@ TYPED_TEST(TestLocalFS, NeedsExtendedFileInfo) {
 #else
   selector.base_dir = "//foo//bar//baz//";
 #endif
-  ASSERT_RAISES(Invalid, this->fs_->GetFileInfo(selector));
+  ASSERT_RAISES(IOError, this->fs_->GetFileInfo(selector));
 }
 
 // TODO Should we test backslash paths on Windows?

--- a/cpp/src/arrow/filesystem/localfs_test.cc
+++ b/cpp/src/arrow/filesystem/localfs_test.cc
@@ -473,7 +473,7 @@ TYPED_TEST(TestLocalFS, StressGetFileInfoGenerator) {
 }
 
 TYPED_TEST(TestLocalFS, NeedsExtendedFileInfo) {
-  // Test setting needs_extended_file_info to true and false
+  // Test setting needs_extended_file_info to false
   ASSERT_OK(this->fs_->CreateDir("AB/CD"));
   CreateFile(this->fs_.get(), "AB/cd", "data");
 
@@ -488,6 +488,9 @@ TYPED_TEST(TestLocalFS, NeedsExtendedFileInfo) {
 
   ASSERT_EQ(infos[0].size(), -1);
   ASSERT_EQ(infos[1].size(), -1);
+
+  ASSERT_EQ(infos[0].mtime(), -1);
+  ASSERT_EQ(infos[1].mtime(), -1);
 }
 
 // TODO Should we test backslash paths on Windows?

--- a/cpp/src/arrow/filesystem/localfs_test.cc
+++ b/cpp/src/arrow/filesystem/localfs_test.cc
@@ -473,8 +473,13 @@ TYPED_TEST(TestLocalFS, StressGetFileInfoGenerator) {
 }
 
 TYPED_TEST(TestLocalFS, NeedsExtendedFileInfo) {
+#ifdef _WIN32
+  ASSERT_OK(this->fs_->CreateDir("AB\\CD"));
+  CreateFile(this->fs_.get(), "AB\\ab", "data");
+#else
   ASSERT_OK(this->fs_->CreateDir("AB/CD"));
   CreateFile(this->fs_.get(), "AB/ab", "data");
+#endif
 
   FileSelector selector;
   selector.base_dir = "";

--- a/cpp/src/arrow/filesystem/localfs_test.cc
+++ b/cpp/src/arrow/filesystem/localfs_test.cc
@@ -518,10 +518,9 @@ TYPED_TEST(TestLocalFS, NeedsExtendedFileInfo) {
     ASSERT_EQ(info.mtime(), kNoTime);
   }
 
-
   // Invalid path
-  //selector.base_dir = "//foo//bar//baz//";
-  //ASSERT_RAISES(Invalid, this->fs_->GetFileInfo(selector));
+  selector.base_dir = "//foo//bar//baz//";
+  ASSERT_RAISES(Invalid, this->fs_->GetFileInfo(selector));
 }
 
 // TODO Should we test backslash paths on Windows?

--- a/cpp/src/arrow/filesystem/localfs_test.cc
+++ b/cpp/src/arrow/filesystem/localfs_test.cc
@@ -509,7 +509,11 @@ TYPED_TEST(TestLocalFS, NeedsExtendedFileInfo) {
   }
 
   // Invalid path
+#ifdef _WIN32
+  selector.base_dir = "\\foo\\bar\\baz\\";
+#else
   selector.base_dir = "//foo//bar//baz//";
+#endif
   ASSERT_RAISES(Invalid, this->fs_->GetFileInfo(selector));
 }
 


### PR DESCRIPTION
### Rationale for this change

When set to false on localFS, use `std::filesystem` to set FileType instead of `stat()`. Does nothing for the other filesystems.

Improves performance 10x on checks whether entities are directories or files on localFS. file size and mtime are not set.


### What changes are included in this PR?

Added variable `needs_extended_file_info` (default `true`) to struct `FileSelector`.

When `false`, `StatSelector` (called by `GetFileInfo (FileSelector)`) will call `IdentifyFile` instead of `StatFile`. `IdentifyFile` will then use `std::filesystem` to set the `.type`, instead of using `stat()`.

### Are these changes tested?

A basic test was added.

### Are there any user-facing changes?

Yes, an optional variable was added to the `FileSelector` struct. Would a cookbook example or docstring update be appropriate?
* Closes: #33618