### PR TITLE
GH-15145: [C++][Parquet] Specify Dict Encoding Type

### DIFF
--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -1043,7 +1043,7 @@ Status ConvertDictionaryToDense(const ::arrow::Array& array, MemoryPool* pool,
 }
 
 static inline bool IsDictionaryEncoding(Encoding::type encoding) {
-  return encoding == Encoding::PLAIN_DICTIONARY;
+  return encoding == Encoding::PLAIN_DICTIONARY || encoding == Encoding::RLE_DICTIONARY;
 }
 
 template <typename DType>

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -380,7 +380,8 @@ class TestDictionaryEncoding : public TestEncodingBase<Type> {
     std::vector<uint8_t> valid_bits(::arrow::bit_util::BytesForBits(num_values_) + 1,
                                     255);
 
-    auto base_encoder = MakeEncoder(Type::type_num, Encoding::PLAIN, true, descr_.get());
+    auto base_encoder =
+        MakeEncoder(Type::type_num, Encoding::PLAIN_DICTIONARY, true, descr_.get());
     auto encoder =
         dynamic_cast<typename EncodingTraits<Type>::Encoder*>(base_encoder.get());
     auto dict_traits = dynamic_cast<DictEncoder<Type>*>(base_encoder.get());
@@ -392,7 +393,7 @@ class TestDictionaryEncoding : public TestEncodingBase<Type> {
     std::shared_ptr<Buffer> indices = encoder->FlushValues();
 
     auto base_spaced_encoder =
-        MakeEncoder(Type::type_num, Encoding::PLAIN, true, descr_.get());
+        MakeEncoder(Type::type_num, Encoding::PLAIN_DICTIONARY, true, descr_.get());
     auto spaced_encoder =
         dynamic_cast<typename EncodingTraits<Type>::Encoder*>(base_spaced_encoder.get());
 
@@ -749,7 +750,7 @@ class EncodingAdHocTyped : public ::testing::Test {
     auto values = GetValues(seed);
 
     auto owned_encoder =
-        MakeTypedEncoder<ParquetType>(Encoding::PLAIN,
+        MakeTypedEncoder<ParquetType>(Encoding::PLAIN_DICTIONARY,
                                       /*use_dictionary=*/true, column_descr());
     auto encoder = dynamic_cast<DictEncoder<ParquetType>*>(owned_encoder.get());
 
@@ -793,7 +794,7 @@ class EncodingAdHocTyped : public ::testing::Test {
                             "120, -37, null, 47]");
 
     auto owned_encoder =
-        MakeTypedEncoder<ParquetType>(Encoding::PLAIN,
+        MakeTypedEncoder<ParquetType>(Encoding::PLAIN_DICTIONARY,
                                       /*use_dictionary=*/true, column_descr());
     auto owned_decoder = MakeDictDecoder<ParquetType>();
 
@@ -888,7 +889,7 @@ TEST(DictEncodingAdHoc, ArrowBinaryDirectPut) {
   ::arrow::random::RandomArrayGenerator rag(0);
   auto values = rag.String(size, min_length, max_length, null_probability);
 
-  auto owned_encoder = MakeTypedEncoder<ByteArrayType>(Encoding::PLAIN,
+  auto owned_encoder = MakeTypedEncoder<ByteArrayType>(Encoding::PLAIN_DICTIONARY,
                                                        /*use_dictionary=*/true);
 
   auto encoder = dynamic_cast<DictEncoder<ByteArrayType>*>(owned_encoder.get());
@@ -927,7 +928,7 @@ TEST(DictEncodingAdHoc, PutDictionaryPutIndices) {
                                            "[\"foo\", \"bar\", \"baz\", null, "
                                            "\"foo\", \"bar\", null, \"baz\"]");
 
-    auto owned_encoder = MakeTypedEncoder<ByteArrayType>(Encoding::PLAIN,
+    auto owned_encoder = MakeTypedEncoder<ByteArrayType>(Encoding::PLAIN_DICTIONARY,
                                                          /*use_dictionary=*/true);
     auto owned_decoder = MakeDictDecoder<ByteArrayType>();
 
@@ -970,8 +971,8 @@ class DictEncoding : public TestArrowBuilderDecoding {
   void SetupEncoderDecoder() override {
     auto node = schema::ByteArray("name");
     descr_ = std::make_unique<ColumnDescriptor>(node, 0, 0);
-    encoder_ = MakeTypedEncoder<ByteArrayType>(Encoding::PLAIN, /*use_dictionary=*/true,
-                                               descr_.get());
+    encoder_ = MakeTypedEncoder<ByteArrayType>(Encoding::PLAIN_DICTIONARY,
+                                               /*use_dictionary=*/true, descr_.get());
     if (null_count_ == 0) {
       ASSERT_NO_THROW(encoder_->Put(input_data_.data(), num_values_));
     } else {

--- a/cpp/src/parquet/test_util.h
+++ b/cpp/src/parquet/test_util.h
@@ -375,9 +375,10 @@ class DictionaryPageBuilder {
   using SpecializedEncoder = typename EncodingTraits<TYPE>::Encoder;
 
   // This class writes data and metadata to the passed inputs
-  explicit DictionaryPageBuilder(const ColumnDescriptor* d)
+  explicit DictionaryPageBuilder(const ColumnDescriptor* d,
+                                 Encoding::type dict_index_encoding)
       : num_dict_values_(0), have_values_(false) {
-    auto encoder = MakeTypedEncoder<TYPE>(Encoding::PLAIN, true, d);
+    auto encoder = MakeTypedEncoder<TYPE>(dict_index_encoding, true, d);
     dict_traits_ = dynamic_cast<DictEncoder<TYPE>*>(encoder.get());
     encoder_.reset(dynamic_cast<SpecializedEncoder*>(encoder.release()));
   }
@@ -411,7 +412,7 @@ class DictionaryPageBuilder {
 
 template <>
 inline DictionaryPageBuilder<BooleanType>::DictionaryPageBuilder(
-    const ColumnDescriptor* d) {
+    const ColumnDescriptor* d, Encoding::type dict_encoding) {
   ParquetException::NYI("only plain encoding currently implemented for boolean");
 }
 
@@ -433,7 +434,7 @@ inline static std::shared_ptr<DictionaryPage> MakeDictPage(
     const ColumnDescriptor* d, const std::vector<typename Type::c_type>& values,
     const std::vector<int>& values_per_page, Encoding::type encoding,
     std::vector<std::shared_ptr<Buffer>>& rle_indices) {
-  test::DictionaryPageBuilder<Type> page_builder(d);
+  test::DictionaryPageBuilder<Type> page_builder(d, encoding);
   int num_pages = static_cast<int>(values_per_page.size());
   int value_start = 0;
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/master/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

In parquet, for v1 writer, it will use `PLAIN_DICTIONARY` for dict index page. In parquet v2, `RLE_DICTIONARY` and `PLAIN` is used. However, the encoder will always be `PLAIN_DICTIONARY`, which is really confusing.

This patch is a draft. In `parquet::WriterProperties`, we're able to get `dictionary_index_encoding()`, and `ColumnWriter` would use it. However, testing usally uses `MakeEncoder(Encoding::PLAIN, /* use_dict */ true)`. So I wonder if it's ok.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Change Dict Encoding using specified encoding.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Currently not.

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Users using parquet internal `MakeEncoder` would failed.

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #15145