### PR TITLE
GH-34023: [Docs] Version warning about viewing old docs doesn't work for versions >= 10

### DIFF
--- a/docs/source/_static/versionwarning.js
+++ b/docs/source/_static/versionwarning.js
@@ -30,7 +30,7 @@
             // Path of the page
             var location_array = location.pathname.split('/');
             var versionPath = location_array[2];
-            var versionNumber = Number(versionPath.match(/^\d+/))
+            var majorVersionNumber = Number(versionPath.match(/^\d+/))
             var subPath = location_array[3];
             var filePath = location_array.slice(3).join('/');
             // Links to stable or dev versions
@@ -55,7 +55,7 @@
                         $('.container-fluid').prepend(`${showWarning}`)
                     }
                 });
-            } else if (versionNumber < 4) {
+            } else if (majorVersionNumber < 4) {
                 // old versions 1.0, 2.0 or 3.0
                 $.ajax({
                     type: 'HEAD',
@@ -86,7 +86,7 @@
                         });
                     }
                 });
-            } else if (versionNumber && subPath == 'developers') {
+            } else if (majorVersionNumber && subPath == 'developers') {
                 // older versions of developers section (with numbered version in the URL)
                 $.ajax({
                     type: 'HEAD',
@@ -102,7 +102,7 @@
                         $('.container-fluid').prepend(`${showWarning}`)
                     }
                 });
-            } else if (versionNumber) {
+            } else if (majorVersionNumber) {
                 // older versions (with numbered version in the URL)
                 $.ajax({
                     type: 'HEAD',

--- a/docs/source/_static/versionwarning.js
+++ b/docs/source/_static/versionwarning.js
@@ -30,6 +30,7 @@
             // Path of the page
             var location_array = location.pathname.split('/');
             var versionPath = location_array[2];
+            var versionNumber = Number(versionPath.match(/^\d+/))
             var subPath = location_array[3];
             var filePath = location_array.slice(3).join('/');
             // Links to stable or dev versions
@@ -54,8 +55,8 @@
                         $('.container-fluid').prepend(`${showWarning}`)
                     }
                 });
-            } else if (versionPath.match(/^\d/) < "4") {
-                // old versions 1.0,. 2.0 or 3.0
+            } else if (versionNumber < 4) {
+                // old versions 1.0, 2.0 or 3.0
                 $.ajax({
                     type: 'HEAD',
                     url: `${uri_stable}`,
@@ -85,7 +86,7 @@
                         });
                     }
                 });
-            } else if (versionPath.match(/^\d/) && subPath == 'developers') {
+            } else if (versionNumber && subPath == 'developers') {
                 // older versions of developers section (with numbered version in the URL)
                 $.ajax({
                     type: 'HEAD',
@@ -101,7 +102,7 @@
                         $('.container-fluid').prepend(`${showWarning}`)
                     }
                 });
-            } else if (versionPath.match(/^\d/)) {
+            } else if (versionNumber) {
                 // older versions (with numbered version in the URL)
                 $.ajax({
                     type: 'HEAD',


### PR DESCRIPTION
### Rationale for this change
Due to a bump in number of characters in the major version number (7, 8, 9 etc -> 10) the check for versions in `versionwarning.js` no longer works as expected.

### What changes are included in this PR?
Update of the checks in `versionwarning.js` file.

### Are these changes tested?
Yes, on the apache/arrow-site PR:

- https://github.com/apache/arrow-site/pull/312
- https://arrow.apache.org/docs/10.0/index.html

### Are there any user-facing changes?
No.
* Closes: #34023