### PR TITLE
GH-34142: [C++][Parquet] Fix record not to span multiple pages

### DIFF
--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -1015,11 +1015,33 @@ template <typename Action>
 inline void DoInBatches(int64_t total, int64_t batch_size, Action&& action) {
   int64_t num_batches = static_cast<int>(total / batch_size);
   for (int round = 0; round < num_batches; round++) {
-    action(round * batch_size, batch_size);
+    action(round * batch_size, batch_size, /*check_page=*/true);
   }
   // Write the remaining values
   if (total % batch_size > 0) {
-    action(num_batches * batch_size, total % batch_size);
+    action(num_batches * batch_size, total % batch_size, /*check_page=*/true);
+  }
+}
+
+template <typename Action>
+inline void DoInBatches(const int16_t* def_levels, const int16_t* rep_levels,
+                        int64_t num_levels, int64_t batch_size, Action&& action,
+                        bool pages_change_on_record_boundaries) {
+  if (!pages_change_on_record_boundaries || !rep_levels) {
+    // If rep_levels is null, then we are writing a non-repeated column.
+    // In this case, every record contains only one level.
+    return DoInBatches(num_levels, batch_size, std::forward<Action>(action));
+  }
+
+  int64_t offset = 0;
+  while (offset < num_levels) {
+    int64_t end_offset = std::min(offset + batch_size, num_levels);
+    // Find next record boundary (i.e. ref_level = 0)
+    while (end_offset < num_levels && rep_levels[end_offset] != 0) {
+      end_offset++;
+    }
+    action(offset, end_offset - offset, /*check_page=*/end_offset < num_levels);
+    offset = end_offset;
   }
 }
 
@@ -1083,7 +1105,7 @@ class TypedColumnWriterImpl : public ColumnWriterImpl, public TypedColumnWriter<
     // pagesize limit
     int64_t value_offset = 0;
 
-    auto WriteChunk = [&](int64_t offset, int64_t batch_size) {
+    auto WriteChunk = [&](int64_t offset, int64_t batch_size, bool check_page) {
       int64_t values_to_write = WriteLevels(batch_size, AddIfNotNull(def_levels, offset),
                                             AddIfNotNull(rep_levels, offset));
 
@@ -1093,14 +1115,15 @@ class TypedColumnWriterImpl : public ColumnWriterImpl, public TypedColumnWriter<
       }
       WriteValues(AddIfNotNull(values, value_offset), values_to_write,
                   batch_size - values_to_write);
-      CommitWriteAndCheckPageLimit(batch_size, values_to_write);
+      CommitWriteAndCheckPageLimit(batch_size, values_to_write, check_page);
       value_offset += values_to_write;
 
       // Dictionary size checked separately from data page size since we
       // circumvent this check when writing ::arrow::DictionaryArray directly
       CheckDictionarySizeLimit();
     };
-    DoInBatches(num_values, properties_->write_batch_size(), WriteChunk);
+    DoInBatches(def_levels, rep_levels, num_values, properties_->write_batch_size(),
+                WriteChunk, pages_change_on_record_boundaries());
     return value_offset;
   }
 
@@ -1109,7 +1132,7 @@ class TypedColumnWriterImpl : public ColumnWriterImpl, public TypedColumnWriter<
                         int64_t valid_bits_offset, const T* values) override {
     // Like WriteBatch, but for spaced values
     int64_t value_offset = 0;
-    auto WriteChunk = [&](int64_t offset, int64_t batch_size) {
+    auto WriteChunk = [&](int64_t offset, int64_t batch_size, bool check_page) {
       int64_t batch_num_values = 0;
       int64_t batch_num_spaced_values = 0;
       int64_t null_count;
@@ -1128,14 +1151,15 @@ class TypedColumnWriterImpl : public ColumnWriterImpl, public TypedColumnWriter<
                           batch_num_spaced_values, valid_bits,
                           valid_bits_offset + value_offset, /*num_levels=*/batch_size);
       }
-      CommitWriteAndCheckPageLimit(batch_size, batch_num_spaced_values);
+      CommitWriteAndCheckPageLimit(batch_size, batch_num_spaced_values, check_page);
       value_offset += batch_num_spaced_values;
 
       // Dictionary size checked separately from data page size since we
       // circumvent this check when writing ::arrow::DictionaryArray directly
       CheckDictionarySizeLimit();
     };
-    DoInBatches(num_values, properties_->write_batch_size(), WriteChunk);
+    DoInBatches(def_levels, rep_levels, num_values, properties_->write_batch_size(),
+                WriteChunk, pages_change_on_record_boundaries());
   }
 
   Status WriteArrow(const int16_t* def_levels, const int16_t* rep_levels,
@@ -1227,6 +1251,10 @@ class TypedColumnWriterImpl : public ColumnWriterImpl, public TypedColumnWriter<
   int64_t total_bytes_written() const override { return total_bytes_written_; }
 
   const WriterProperties* properties() override { return properties_; }
+
+  bool pages_change_on_record_boundaries() const {
+    return properties_->data_page_version() == ParquetDataPageVersion::V2;
+  }
 
  private:
   using ValueEncoderType = typename EncodingTraits<DType>::Encoder;
@@ -1374,11 +1402,13 @@ class TypedColumnWriterImpl : public ColumnWriterImpl, public TypedColumnWriter<
     }
   }
 
-  void CommitWriteAndCheckPageLimit(int64_t num_levels, int64_t num_values) {
+  void CommitWriteAndCheckPageLimit(int64_t num_levels, int64_t num_values,
+                                    bool check_page) {
     num_buffered_values_ += num_levels;
     num_buffered_encoded_values_ += num_values;
 
-    if (current_encoder_->EstimatedDataEncodedSize() >= properties_->data_pagesize()) {
+    if (check_page &&
+        current_encoder_->EstimatedDataEncodedSize() >= properties_->data_pagesize()) {
       AddDataPage();
     }
   }
@@ -1518,7 +1548,7 @@ Status TypedColumnWriterImpl<DType>::WriteArrowDictionary(
   };
 
   int64_t value_offset = 0;
-  auto WriteIndicesChunk = [&](int64_t offset, int64_t batch_size) {
+  auto WriteIndicesChunk = [&](int64_t offset, int64_t batch_size, bool check_page) {
     int64_t batch_num_values = 0;
     int64_t batch_num_spaced_values = 0;
     int64_t null_count = ::arrow::kUnknownNullCount;
@@ -1538,7 +1568,7 @@ Status TypedColumnWriterImpl<DType>::WriteArrowDictionary(
         writeable_indices,
         MaybeReplaceValidity(writeable_indices, null_count, ctx->memory_pool));
     dict_encoder->PutIndices(*writeable_indices);
-    CommitWriteAndCheckPageLimit(batch_size, batch_num_values);
+    CommitWriteAndCheckPageLimit(batch_size, batch_num_values, check_page);
     value_offset += batch_num_spaced_values;
   };
 
@@ -1562,8 +1592,9 @@ Status TypedColumnWriterImpl<DType>::WriteArrowDictionary(
     return WriteDense();
   }
 
-  PARQUET_CATCH_NOT_OK(
-      DoInBatches(num_levels, properties_->write_batch_size(), WriteIndicesChunk));
+  PARQUET_CATCH_NOT_OK(DoInBatches(def_levels, rep_levels, num_levels,
+                                   properties_->write_batch_size(), WriteIndicesChunk,
+                                   pages_change_on_record_boundaries()));
   return Status::OK();
 }
 
@@ -1995,7 +2026,7 @@ Status TypedColumnWriterImpl<ByteArrayType>::WriteArrowDense(
   }
 
   int64_t value_offset = 0;
-  auto WriteChunk = [&](int64_t offset, int64_t batch_size) {
+  auto WriteChunk = [&](int64_t offset, int64_t batch_size, bool check_page) {
     int64_t batch_num_values = 0;
     int64_t batch_num_spaced_values = 0;
     int64_t null_count = 0;
@@ -2017,13 +2048,14 @@ Status TypedColumnWriterImpl<ByteArrayType>::WriteArrowDense(
       page_statistics_->IncrementNullCount(batch_size - non_null);
       page_statistics_->IncrementNumValues(non_null);
     }
-    CommitWriteAndCheckPageLimit(batch_size, batch_num_values);
+    CommitWriteAndCheckPageLimit(batch_size, batch_num_values, check_page);
     CheckDictionarySizeLimit();
     value_offset += batch_num_spaced_values;
   };
 
-  PARQUET_CATCH_NOT_OK(
-      DoInBatches(num_levels, properties_->write_batch_size(), WriteChunk));
+  PARQUET_CATCH_NOT_OK(DoInBatches(def_levels, rep_levels, num_levels,
+                                   properties_->write_batch_size(), WriteChunk,
+                                   pages_change_on_record_boundaries()));
   return Status::OK();
 }
 

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -1196,7 +1196,7 @@ TEST(TestColumnWriter, WriteDataPagesChangeOnRecordBoundaries) {
 
   // Check if pages are changed on record boundaries.
   constexpr int num_columns = 3;
-  const std::array<int64_t, num_columns> expected_num_pages = {10, 10, 17};
+  const std::array<int64_t, num_columns> expected_num_pages = {10, 10, 19};
   for (int i = 0; i < num_columns; ++i) {
     auto page_reader = row_group_reader->GetColumnPageReader(i);
     int64_t num_rows = 0;
@@ -1216,6 +1216,66 @@ TEST(TestColumnWriter, WriteDataPagesChangeOnRecordBoundaries) {
     EXPECT_EQ(num_levels, num_rows);
     EXPECT_EQ(expected_num_pages[i], num_pages);
   }
+}
+
+TEST(TestColumnWriter, WriteDataPagesChangeOnRecordBoundariesLargeBatchSize) {
+  auto sink = CreateOutputStream();
+  auto schema = std::static_pointer_cast<GroupNode>(GroupNode::Make(
+      "schema", Repetition::REQUIRED, {schema::Int32("col", Repetition::REPEATED)}));
+
+  constexpr int64_t num_rows = 400;
+  constexpr int64_t num_levels = 100;
+  constexpr int64_t batch_size = 1024;
+
+  auto properties = WriterProperties::Builder()
+                        .disable_dictionary()
+                        ->data_page_version(ParquetDataPageVersion::V2)
+                        ->write_batch_size(batch_size)
+                        ->data_pagesize(1)
+                        ->build();
+  auto file_writer = ParquetFileWriter::Open(sink, schema, properties);
+  auto rg_writer = file_writer->AppendRowGroup();
+  auto repeated_writer = static_cast<parquet::Int32Writer*>(rg_writer->NextColumn());
+
+  // Each row has repeated twice.
+  const std::vector<int32_t> values(num_levels, 123);
+  std::array<int16_t, num_levels> def_levels;
+  std::array<int16_t, num_levels> rep_levels;
+  for (int32_t i = 0; i < num_levels; i++) {
+    def_levels[i] = i % 2 == 0 ? 1 : 0;
+    rep_levels[i] = i % 2 == 0 ? 0 : 1;
+  }
+  constexpr int32_t num_write_batches = num_rows * 2 / num_levels;
+  for (int32_t i = 0; i < num_write_batches; i++) {
+    repeated_writer->WriteBatch(num_levels, def_levels.data(), rep_levels.data(),
+                                values.data());
+  }
+
+  ASSERT_NO_THROW(file_writer->Close());
+  ASSERT_OK_AND_ASSIGN(auto buffer, sink->Finish());
+  auto file_reader = ParquetFileReader::Open(
+      std::make_shared<::arrow::io::BufferReader>(buffer), default_reader_properties());
+  auto metadata = file_reader->metadata();
+  ASSERT_EQ(1, metadata->num_row_groups());
+  auto row_group_reader = file_reader->RowGroup(0);
+
+  // Check if pages are changed on record boundaries and more than one page is written.
+  constexpr int64_t expect_num_pages = num_write_batches + 1;
+  constexpr std::array<int64_t, expect_num_pages> expected_num_rows = {49, 50, 50, 50, 50,
+                                                                       50, 50, 50, 1};
+  auto page_reader = row_group_reader->GetColumnPageReader(0);
+  int64_t num_rows_read = 0;
+  int64_t num_pages_read = 0;
+  std::shared_ptr<Page> page;
+  while ((page = page_reader->NextPage()) != nullptr) {
+    auto data_page = std::static_pointer_cast<DataPageV2>(page);
+    // Make sure repeated column has 2 values per row and not span multiple pages.
+    EXPECT_EQ(data_page->num_values(), 2 * data_page->num_rows());
+    EXPECT_EQ(expected_num_rows[num_pages_read++], data_page->num_rows());
+    num_rows_read += data_page->num_rows();
+  }
+  EXPECT_EQ(num_rows, num_rows_read);
+  EXPECT_EQ(expect_num_pages, num_pages_read);
 }
 
 }  // namespace test


### PR DESCRIPTION
### Rationale for this change

Parquet data page v2 requires pages change on record boundaries. Currently the parquet-cpp writer does not enforce this.

### What changes are included in this PR?

Change `ColumnWriter` to split data page on record boundaries when data page v2 is applied.

### Are these changes tested?

Add test `TEST(TestColumnWriter, WriteDataPagesChangeOnRecordBoundaries)`

### Are there any user-facing changes?

No.
* Closes: #34142