### PR TITLE
GH-34188: [C++][Benchmark] Add missing BENCHMARK_STATIC_DEFINE for bundled gbenchmark

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2289,6 +2289,7 @@ macro(build_benchmark)
                         PROPERTIES IMPORTED_LOCATION "${GBENCHMARK_STATIC_LIB}"
                                    INTERFACE_INCLUDE_DIRECTORIES
                                    "${GBENCHMARK_INCLUDE_DIR}")
+  target_compile_definitions(benchmark::benchmark INTERFACE "BENCHMARK_STATIC_DEFINE")
 
   add_library(benchmark::benchmark_main STATIC IMPORTED)
   set_target_properties(benchmark::benchmark_main


### PR DESCRIPTION
### Rationale for this change

We need to specify `-DBENCHMARK_STATIC_DEFINE` to use gbenchmark as a static library since gbenchmark 1.6.2.

### What changes are included in this PR?

This change specifies `BENCHMARK_STATIC_DEFINE` for bundled gbenchmark explicitly.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #34188