### PR TITLE
GH-34203: [C++] Ensure benchmark does not declspec(dllexport) symbols from the static…

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2292,6 +2292,7 @@ macro(build_benchmark)
   file(MAKE_DIRECTORY "${GBENCHMARK_INCLUDE_DIR}")
 
   add_library(benchmark::benchmark STATIC IMPORTED)
+  target_compile_definitions(benchmark::benchmark INTERFACE BENCHMARK_STATIC_DEFINE)
   set_target_properties(benchmark::benchmark
                         PROPERTIES IMPORTED_LOCATION "${GBENCHMARK_STATIC_LIB}"
                                    INTERFACE_INCLUDE_DIRECTORIES


### PR DESCRIPTION

* Closes: #34203