### PR TITLE
GH-34092: [R] open_csv_dataset() error if schema supplied and col_names left as TRUE (the default)

### DIFF
--- a/r/R/dataset-format.R
+++ b/r/R/dataset-format.R
@@ -429,7 +429,11 @@ csv_file_format_read_opts <- function(schema = NULL, ...) {
 
   check_ambiguous_options(opt_names, arrow_opts, readr_opts)
 
-  if (!is.null(schema) && is.null(opts[["column_names"]]) && is.null(opts[["col_names"]])) {
+  null_or_true <- function(x) {
+    is.null(x) || isTRUE(x)
+  }
+
+  if (!is.null(schema) && null_or_true(opts[["column_names"]]) && null_or_true(opts[["col_names"]])) {
     if (any(is_readr_opt)) {
       opts[["col_names"]] <- names(schema)
     } else {

--- a/r/tests/testthat/test-dataset-csv.R
+++ b/r/tests/testthat/test-dataset-csv.R
@@ -552,8 +552,11 @@ test_that("open_delim_dataset params passed through to open_dataset", {
   # schema
   ds <- open_csv_dataset(
     csv_dir,
-    schema = schema(int = int64(), dbl = int64(), lgl = bool(), chr = utf8(),
-    fct = utf8(), ts = timestamp(unit = "s"))
+    schema = schema(
+      int = int64(), dbl = int64(), lgl = bool(), chr = utf8(),
+      fct = utf8(), ts = timestamp(unit = "s")
+    ),
+    skip = 1
   ) %>% collect()
 
   expect_named(ds, c("int", "dbl", "lgl", "chr", "fct", "ts"))
@@ -571,4 +574,3 @@ test_that("open_delim_dataset params passed through to open_dataset", {
 
   expect_equal(ds$time, "16-01-2023")
 })
-

--- a/r/tests/testthat/test-dataset-csv.R
+++ b/r/tests/testthat/test-dataset-csv.R
@@ -549,6 +549,15 @@ test_that("open_delim_dataset params passed through to open_dataset", {
 
   expect_named(ds, c("col_1", "col_2", "col_3", "col_4", "col_5", "col_6"))
 
+  # schema
+  ds <- open_csv_dataset(
+    csv_dir,
+    schema = schema(int = int64(), dbl = int64(), lgl = bool(), chr = utf8(),
+    fct = utf8(), ts = timestamp(unit = "s"))
+  ) %>% collect()
+
+  expect_named(ds, c("int", "dbl", "lgl", "chr", "fct", "ts"))
+
   # timestamp_parsers
   skip("GH-33708: timestamp_parsers don't appear to be working properly")
 
@@ -562,3 +571,4 @@ test_that("open_delim_dataset params passed through to open_dataset", {
 
   expect_equal(ds$time, "16-01-2023")
 })
+


### PR DESCRIPTION
Before this PR:

``` r
library(arrow)
tf <- tempfile()
df <- tibble::tibble(x = 1, b = 2)
write_csv_arrow(df, tf)
open_csv_dataset(tf, schema = schema(x = int64(), y = int64()), skip = 1)
#> Error in `check_schema()`:
#> ! Values in `column_names` must match `schema` field names
#> ✖ `x` and `y` not present in `column_names`

#> Backtrace:
#>     ▆
#>  1. └─arrow (local) `<fn>`(...)
#>  2.   └─arrow::open_dataset(...)
#>  3.     └─DatasetFactory$create(...)
#>  4.       └─FileFormat$create(match.arg(format), ...)
#>  5.         └─CsvFileFormat$create(schema = schema, ...)
#>  6.           └─arrow:::check_schema(options[["schema"]], options[["read_options"]]$column_names)
#>  7.             └─rlang::abort(...)
```

After this PR:

``` r
library(arrow)
tf <- tempfile()
df <- tibble::tibble(x = 1, b = 2)
write_csv_arrow(df, tf)
open_csv_dataset(tf, schema = schema(x = int64(), y = int64()), skip = 1)
#> FileSystemDataset with 1 csv file
#> x: int64
#> y: int64
```
* Closes: #34092