### PR TITLE
GH-34232: [R] Fix AMD64 Ubuntu 20.04 R 4.2 CI

### DIFF
--- a/r/tests/testthat/test-io.R
+++ b/r/tests/testthat/test-io.R
@@ -71,7 +71,7 @@ test_that("make_readable_file() works for non-filesystem URLs", {
   skip_if_offline()
 
   readable_file <- make_readable_file(
-    "https://github.com/apache/arrow/raw/master/r/inst/v0.7.1.parquet"
+    "https://github.com/apache/arrow/raw/main/r/inst/v0.7.1.parquet"
   )
   expect_r6_class(readable_file, "InputStream")
   expect_identical(rawToChar(as.raw(readable_file$Read(3))), "PAR")


### PR DESCRIPTION
### Rationale for this change

The CI build is breaking because of a recent branch rename from `master` to `main`.

### What changes are included in this PR?

Rename the URL of test file to use `main`.

### Are these changes tested?

Make sure the CI build passes.

### Are there any user-facing changes?

No.
* Closes: #34232