### PR TITLE
GH-34241: [C++] Fix ExecSpanIterator to properly initialize empty dictionary arrays

### DIFF
--- a/cpp/src/arrow/array/data.cc
+++ b/cpp/src/arrow/array/data.cc
@@ -233,10 +233,17 @@ void FillZeroLengthArray(const DataType* type, ArraySpan* span) {
     span->buffers[i] = {};
   }
 
-  // Fill children
-  span->child_data.resize(type->num_fields());
-  for (int i = 0; i < type->num_fields(); ++i) {
-    FillZeroLengthArray(type->field(i)->type().get(), &span->child_data[i]);
+  if (type->id() == Type::DICTIONARY) {
+    span->child_data.resize(1);
+    const std::shared_ptr<DataType>& values_type =
+        checked_cast<const DictionaryType*>(type)->value_type();
+    FillZeroLengthArray(values_type.get(), &span->child_data[0]);
+  } else {
+    // Fill children
+    span->child_data.resize(type->num_fields());
+    for (int i = 0; i < type->num_fields(); ++i) {
+      FillZeroLengthArray(type->field(i)->type().get(), &span->child_data[i]);
+    }
   }
 }
 

--- a/cpp/src/arrow/array/data.cc
+++ b/cpp/src/arrow/array/data.cc
@@ -235,9 +235,9 @@ void FillZeroLengthArray(const DataType* type, ArraySpan* span) {
 
   if (type->id() == Type::DICTIONARY) {
     span->child_data.resize(1);
-    const std::shared_ptr<DataType>& values_type =
+    const std::shared_ptr<DataType>& value_type =
         checked_cast<const DictionaryType*>(type)->value_type();
-    FillZeroLengthArray(values_type.get(), &span->child_data[0]);
+    FillZeroLengthArray(value_type.get(), &span->child_data[0]);
   } else {
     // Fill children
     span->child_data.resize(type->num_fields());


### PR DESCRIPTION

* Closes: #34241