### PR TITLE
GH-34258: [C++]  Add suppport for building with system flatbuffers

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -541,7 +541,20 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}/src)
 include_directories(src)
 
 # Compiled flatbuffers files
-include_directories(src/generated)
+if("${flatbuffers_SOURCE}" STREQUAL "SYSTEM")
+  file(GLOB _flatbuffers_files "${CMAKE_CURRENT_SOURCE_DIR}/../format/*.fbs")
+  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/src/generated
+                     COMMAND "${BUILD_SUPPORT_DIR}/update-flatbuffers.sh"
+                             "${CMAKE_CURRENT_BINARY_DIR}/src/generated"
+                     DEPENDS ${_flatbuffers_files}
+                     VERBATIM)
+  unset(_flatbuffers_files)
+  add_custom_target(generate-flatbuffers
+                    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/src/generated)
+  include_directories(${CMAKE_CURRENT_BINARY_DIR}/src/generated)
+else()
+  include_directories(src/generated)
+endif()
 
 #
 # Visibility
@@ -652,9 +665,9 @@ endif()
 # Note that arrow::hadoop is a header only target that refers
 # cpp/thirdparty/hadoop/include/. See
 # cpp/cmake_modules/ThirdpartyToolchain.cmake for details.
-set(ARROW_SHARED_LINK_LIBS arrow::flatbuffers arrow::hadoop)
+set(ARROW_SHARED_LINK_LIBS flatbuffers::flatbuffers arrow::hadoop)
 set(ARROW_SHARED_INSTALL_INTERFACE_LIBS)
-set(ARROW_STATIC_LINK_LIBS arrow::flatbuffers arrow::hadoop)
+set(ARROW_STATIC_LINK_LIBS flatbuffers::flatbuffers arrow::hadoop)
 set(ARROW_STATIC_INSTALL_INTERFACE_LIBS)
 
 if(ARROW_USE_BOOST)
@@ -818,6 +831,10 @@ add_custom_target(arrow_test_dependencies)
 add_dependencies(arrow_dependencies toolchain)
 add_dependencies(arrow_test_dependencies toolchain-tests)
 
+if(TARGET generate-flatbuffers)
+  add_dependencies(arrow_dependencies generate-flatbuffers)
+endif()
+
 if(ARROW_STATIC_LINK_LIBS)
   add_dependencies(arrow_dependencies ${ARROW_STATIC_LINK_LIBS})
   if(ARROW_HDFS OR ARROW_ORC)
@@ -837,7 +854,7 @@ if(NOT MSVC_TOOLCHAIN)
   list(APPEND ARROW_SHARED_LINK_LIBS ${CMAKE_DL_LIBS})
 endif()
 
-set(ARROW_TEST_LINK_TOOLCHAIN arrow::flatbuffers GTest::gtest_main GTest::gtest
+set(ARROW_TEST_LINK_TOOLCHAIN flatbuffers::flatbuffers GTest::gtest_main GTest::gtest
                               GTest::gmock)
 
 if(ARROW_BUILD_TESTS)

--- a/cpp/build-support/update-flatbuffers.sh
+++ b/cpp/build-support/update-flatbuffers.sh
@@ -37,11 +37,3 @@ $FLATC --cpp --cpp-std c++11 \
   --scoped-enums \
   -o "$OUT_DIR" \
   "${FILES[@]}"
-
-PLASMA_FBS=("$SOURCE_DIR"/plasma/{plasma,common}.fbs)
-
-$FLATC --cpp --cpp-std c++11 \
-  -o "$SOURCE_DIR/plasma" \
-  --gen-object-api \
-  --scoped-enums \
-  "${PLASMA_FBS[@]}"

--- a/cpp/build-support/update-flatbuffers.sh
+++ b/cpp/build-support/update-flatbuffers.sh
@@ -18,19 +18,19 @@
 # under the License.
 #
 
-# Run this from cpp/ directory. flatc is expected to be in your path
+# Run this from cpp/ directory. flatc is expected to be in your path.
+# The output directory can be passed as a positional argumenet,
+# it defaults to /cpp/src/generated.
 
 set -euo pipefail
 
 CWD="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 SOURCE_DIR="$CWD/../src"
-PYTHON_SOURCE_DIR="$CWD/../../python"
 FORMAT_DIR="$CWD/../../format"
-TOP="$FORMAT_DIR/.."
 FLATC="flatc"
 
-OUT_DIR="$SOURCE_DIR/generated"
-FILES=($(find $FORMAT_DIR -name '*.fbs'))
+OUT_DIR="${1:-$SOURCE_DIR/generated}"
+FILES=($(find "$FORMAT_DIR" -name '*.fbs'))
 FILES+=("$SOURCE_DIR/arrow/ipc/feather.fbs")
 
 $FLATC --cpp --cpp-std c++11 \

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -74,6 +74,11 @@ set(ARROW_THIRDPARTY_DEPENDENCIES
     ZLIB
     zstd)
 
+# For backward compatibility. We use bundled flatbuffers by default.
+if("${flatbuffers_SOURCE}" STREQUAL "")
+  set(flatbuffers_SOURCE "BUNDLED")
+endif()
+
 # For backward compatibility. We use "BOOST_SOURCE" if "Boost_SOURCE"
 # isn't specified and "BOOST_SOURCE" is specified.
 # We renamed "BOOST" dependency name to "Boost" in 3.0.0 because
@@ -161,6 +166,8 @@ macro(build_dependency DEPENDENCY_NAME)
     build_bzip2()
   elseif("${DEPENDENCY_NAME}" STREQUAL "c-ares")
     build_cares()
+  elseif("${DEPENDENCY_NAME}" STREQUAL "flatbuffers")
+    build_flatbuffers()
   elseif("${DEPENDENCY_NAME}" STREQUAL "gflags")
     build_gflags()
   elseif("${DEPENDENCY_NAME}" STREQUAL "GLOG")
@@ -313,15 +320,23 @@ endmacro()
 
 set(THIRDPARTY_DIR "${arrow_SOURCE_DIR}/thirdparty")
 
-add_library(arrow::flatbuffers INTERFACE IMPORTED)
-if(CMAKE_VERSION VERSION_LESS 3.11)
-  set_target_properties(arrow::flatbuffers
-                        PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
-                                   "${THIRDPARTY_DIR}/flatbuffers/include")
-else()
-  target_include_directories(arrow::flatbuffers
-                             INTERFACE "${THIRDPARTY_DIR}/flatbuffers/include")
-endif()
+macro(build_flatbuffers)
+  add_library(flatbuffers::flatbuffers INTERFACE IMPORTED)
+  if(CMAKE_VERSION VERSION_LESS 3.11)
+    set_target_properties(flatbuffers::flatbuffers
+                          PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                                     "${THIRDPARTY_DIR}/flatbuffers/include")
+  else()
+    target_include_directories(flatbuffers::flatbuffers
+                               INTERFACE "${THIRDPARTY_DIR}/flatbuffers/include")
+  endif()
+endmacro()
+
+resolve_dependency(flatbuffers
+                   IS_RUNTIME_DEPENDENCY
+                   FALSE
+                   USE_CONFIG
+                   TRUE)
 
 # ----------------------------------------------------------------------
 # Some EP's require other EP's

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -702,7 +702,7 @@ if(ARROW_TESTING)
                 DEPENDENCIES
                 arrow_test_dependencies
                 SHARED_LINK_LIBS
-                arrow::flatbuffers
+                flatbuffers::flatbuffers
                 rapidjson::rapidjson
                 arrow_shared
                 GTest::gtest
@@ -710,7 +710,7 @@ if(ARROW_TESTING)
                 Arrow::arrow_shared
                 GTest::gtest
                 STATIC_LINK_LIBS
-                arrow::flatbuffers
+                flatbuffers::flatbuffers
                 rapidjson::rapidjson
                 arrow_static
                 GTest::gtest

--- a/cpp/src/arrow/gpu/CMakeLists.txt
+++ b/cpp/src/arrow/gpu/CMakeLists.txt
@@ -29,7 +29,7 @@ if(DEFINED ENV{CUDA_HOME})
   set(CUDA_TOOLKIT_ROOT_DIR "$ENV{CUDA_HOME}")
 endif()
 
-set(ARROW_CUDA_LINK_LIBS arrow::flatbuffers)
+set(ARROW_CUDA_LINK_LIBS flatbuffers::flatbuffers)
 if(CMAKE_VERSION VERSION_LESS 3.17)
   find_package(CUDA REQUIRED)
   set(ARROW_CUDA_SHARED_LINK_LIBS ${CUDA_CUDA_LIBRARY})

--- a/cpp/src/plasma/CMakeLists.txt
+++ b/cpp/src/plasma/CMakeLists.txt
@@ -52,8 +52,8 @@ set(PLASMA_STORE_SRCS
     store.cc
     thirdparty/ae/ae.c)
 
-set(PLASMA_SHARED_LINK_LIBS arrow::flatbuffers)
-set(PLASMA_STATIC_LINK_LIBS arrow::flatbuffers)
+set(PLASMA_SHARED_LINK_LIBS flatbuffers::flatbuffers)
+set(PLASMA_STATIC_LINK_LIBS flatbuffers::flatbuffers)
 set(PLASMA_SHARED_INSTALL_INTERFACE_LIBS)
 set(PLASMA_STATIC_INSTALL_INTERFACE_LIBS)
 


### PR DESCRIPTION
### What changes are included in this PR?

* Make it possible to use `-Dflatbuffers_SOURCE=SYSTEM`. 
* Change `update-flatbuffers.sh` so that the output directory can optionally be passed in.
* Generate flatbuffers headers with `update-flatbuffers.sh` when flatbuffers is provided by the system.
* Remove plasma file generation from `update-flatbuffers.sh`.

### Are these changes tested?

This change is opt-in, so I'm not sure if it makes sense to extend the build matrix for it.
* Closes: #34258