### PR TITLE
GH-34210: [C++] Make casting timestamp and duration zero-copy when TimeUnit matches

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_cast_temporal.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_temporal.cc
@@ -147,20 +147,24 @@ struct CastFunctor<
     enable_if_t<(is_timestamp_type<O>::value && is_timestamp_type<I>::value) ||
                 (is_duration_type<O>::value && is_duration_type<I>::value)>> {
   static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
-    const ArraySpan& input = batch[0].array;
-    ArraySpan* output = out->array_span_mutable();
-
     const auto& in_type = checked_cast<const I&>(*batch[0].type());
-    const auto& out_type = checked_cast<const O&>(*output->type);
+    const auto& out_type = checked_cast<const O&>(*out->type());
 
-    if (I::type_id == Type::TIMESTAMP && in_type.unit() == out_type.unit()) {
-      std::shared_ptr<const ArrayData> array_data = input.ToArrayData();
-      output->SetMembers(*array_data);
-      return Status::OK();
+    if (in_type.unit() == out_type.unit()) {
+      return ZeroCopyCastExec(ctx, batch, out);
     }
+
+    ArrayData* out_arr = out->array_data().get();
+    DCHECK_EQ(0, out_arr->offset);
+    int value_size = batch[0].type()->byte_width();
+    DCHECK_OK(ctx->Allocate(out_arr->length * value_size).Value(&out_arr->buffers[1]));
+
+    ArraySpan output_span;
+    output_span.SetMembers(*out_arr);
+    const ArraySpan& input = batch[0].array;
     auto conversion = util::GetTimestampConversion(in_type.unit(), out_type.unit());
     return ShiftTime<int64_t, int64_t>(ctx, conversion.first, conversion.second, input,
-                                       output);
+                                       &output_span);
   }
 };
 
@@ -455,6 +459,16 @@ void AddCrossUnitCast(CastFunction* func) {
   DCHECK_OK(func->AddKernel(Type::type_id, std::move(kernel)));
 }
 
+template <typename Type>
+void AddCrossUnitCastNoPreallocate(CastFunction* func) {
+  ScalarKernel kernel;
+  kernel.exec = CastFunctor<Type, Type>::Exec;
+  kernel.null_handling = NullHandling::INTERSECTION;
+  kernel.mem_allocation = MemAllocation::NO_PREALLOCATE;
+  kernel.signature = KernelSignature::Make({InputType(Type::type_id)}, kOutputTargetType);
+  DCHECK_OK(func->AddKernel(Type::type_id, std::move(kernel)));
+}
+
 std::shared_ptr<CastFunction> GetDate32Cast() {
   auto func = std::make_shared<CastFunction>("cast_date32", Type::DATE32);
   auto out_ty = date32();
@@ -502,7 +516,7 @@ std::shared_ptr<CastFunction> GetDurationCast() {
   AddZeroCopyCast(Type::INT64, /*in_type=*/int64(), kOutputTargetType, func.get());
 
   // Between durations
-  AddCrossUnitCast<DurationType>(func.get());
+  AddCrossUnitCastNoPreallocate<DurationType>(func.get());
 
   return func;
 }
@@ -577,7 +591,7 @@ std::shared_ptr<CastFunction> GetTimestampCast() {
                                                 func.get());
 
   // From one timestamp to another
-  AddCrossUnitCast<TimestampType>(func.get());
+  AddCrossUnitCastNoPreallocate<TimestampType>(func.get());
 
   return func;
 }

--- a/cpp/src/arrow/compute/kernels/scalar_cast_temporal.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_temporal.cc
@@ -20,8 +20,6 @@
 #include <limits>
 
 #include "arrow/array/builder_time.h"
-#include "arrow/compute/exec.h"
-#include "arrow/compute/exec_internal.h"
 #include "arrow/compute/kernels/common_internal.h"
 #include "arrow/compute/kernels/scalar_cast_internal.h"
 #include "arrow/compute/kernels/temporal_internal.h"
@@ -158,7 +156,6 @@ struct CastFunctor<
     if (I::type_id == Type::TIMESTAMP && in_type.unit() == out_type.unit()) {
       std::shared_ptr<const ArrayData> array_data = input.ToArrayData();
       output->SetMembers(*array_data);
-      arrow::compute::detail::PropagateNullsSpans(batch, output);
       return Status::OK();
     }
     auto conversion = util::GetTimestampConversion(in_type.unit(), out_type.unit());

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -1067,6 +1067,10 @@ TEST(Cast, TimestampToTimestamp) {
     CheckCast(will_be_truncated, coarse, options);
   }
 
+  options.to_type = timestamp(TimeUnit::SECOND);
+  CheckCast(ArrayFromJSON(timestamp(TimeUnit::SECOND, "UTC"), "[0, null, 200, 1, 2]"),
+            ArrayFromJSON(timestamp(TimeUnit::SECOND), "[0, null, 200, 1, 2]"), options);
+
   for (auto types : {
            TimestampTypePair{timestamp(TimeUnit::SECOND), timestamp(TimeUnit::MICRO)},
            TimestampTypePair{timestamp(TimeUnit::MILLI), timestamp(TimeUnit::NANO)},
@@ -1125,6 +1129,10 @@ TEST(Cast, TimestampZeroCopy) {
   }
   CheckCastZeroCopy(ArrayFromJSON(int64(), "[0, null, 2000, 1000, 0]"),
                     timestamp(TimeUnit::SECOND));
+
+  CheckCastZeroCopy(
+      ArrayFromJSON(timestamp(TimeUnit::SECOND, "UTC"), "[0, null, 2000, 1000, 0]"),
+      timestamp(TimeUnit::SECOND));
 }
 
 TEST(Cast, TimestampToTimestampMultiplyOverflow) {


### PR DESCRIPTION
### Rationale for this change

Casting from e.g. `timestamp(s, "UTC")` to `timestamp(s)` could be a metadata only change, but is currently a multiplication operation.

### What changes are included in this PR?

This change adds a zero-copy casting path for durations that have equal units and timestamps that have equal units and potentially different timezones.

### Are these changes tested?

We test for correctness and zero-copy.

### Are there any user-facing changes?

No.
* Closes: #34210