### PR TITLE
GH-34411: [Python] Change array constructor to accept pyarrow array

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -232,6 +232,11 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
     else:
         c_from_pandas = from_pandas
 
+    if isinstance(obj, Array):
+        if type is not None and not obj.type.equals(type):
+            obj = obj.cast(type)
+        return obj
+
     if hasattr(obj, '__arrow_array__'):
         return _handle_arrow_array_protocol(obj, type, mask, size)
     elif _is_array_like(obj):

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -234,7 +234,7 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
 
     if isinstance(obj, Array):
         if type is not None and not obj.type.equals(type):
-            obj = obj.cast(type, safe=safe)
+            obj = obj.cast(type, safe=safe, memory_pool=memory_pool)
         return obj
 
     if hasattr(obj, '__arrow_array__'):
@@ -909,7 +909,7 @@ cdef class Array(_PandasConvertible):
             result = self.ap.Diff(deref(other.ap))
         return frombytes(result, safe=True)
 
-    def cast(self, object target_type=None, safe=None, options=None):
+    def cast(self, object target_type=None, safe=None, options=None, memory_pool=None):
         """
         Cast array values to another data type
 
@@ -923,12 +923,15 @@ cdef class Array(_PandasConvertible):
             Whether to check for conversion errors such as overflow.
         options : CastOptions, default None
             Additional checks pass by CastOptions
+        memory_pool : MemoryPool, optional
+            memory pool to use for allocations during function execution.
 
         Returns
         -------
         cast : Array
         """
-        return _pc().cast(self, target_type, safe=safe, options=options)
+        return _pc().cast(self, target_type, safe=safe,
+                          options=options, memory_pool=memory_pool)
 
     def view(self, object target_type):
         """

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -234,7 +234,7 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
 
     if isinstance(obj, Array):
         if type is not None and not obj.type.equals(type):
-            obj = obj.cast(type)
+            obj = obj.cast(type, safe=safe)
         return obj
 
     if hasattr(obj, '__arrow_array__'):

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -331,7 +331,7 @@ def _make_global_functions():
 _make_global_functions()
 
 
-def cast(arr, target_type=None, safe=None, options=None):
+def cast(arr, target_type=None, safe=None, options=None, memory_pool=None):
     """
     Cast array values to another data type. Can also be invoked as an array
     instance method.
@@ -345,6 +345,8 @@ def cast(arr, target_type=None, safe=None, options=None):
         Check for overflows or other unsafe conversions
     options : CastOptions, default None
         Additional checks pass by CastOptions
+    memory_pool : MemoryPool, optional
+        memory pool to use for allocations during function execution.
 
     Examples
     --------
@@ -395,7 +397,7 @@ def cast(arr, target_type=None, safe=None, options=None):
             options = CastOptions.unsafe(target_type)
         else:
             options = CastOptions.safe(target_type)
-    return call_function("cast", [arr], options)
+    return call_function("cast", [arr], options, memory_pool)
 
 
 def index(data, value, start=None, end=None, *, memory_pool=None):

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -3389,7 +3389,18 @@ def test_array_accepts_pyarrow_array():
 
     assert arr == result
 
+    # Test casting to a different type
     result = pa.array(arr, type=pa.uint8())
     expected = pa.array([1, 2, 3], type=pa.uint8())
-
     assert expected == result
+    assert expected.type == pa.uint8()
+
+    # Test casting with safe keyward
+    arr = pa.array([2 ** 63 - 1], type=pa.int64())
+
+    with pytest.raises(pa.ArrowInvalid):
+        pa.array(arr, type=pa.int32())
+
+    expected = pa.array([-1], type=pa.int32())
+    result = pa.array(arr, type=pa.int32(), safe=False)
+    assert result == expected

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -3389,7 +3389,7 @@ def test_array_accepts_pyarrow_array():
 
     assert arr == result
 
-    arr_uint = pa.array([1, 2, 3], type=pa.uint8())
     result = pa.array(arr, type=pa.uint8())
+    expected = pa.array([1, 2, 3], type=pa.uint8())
 
-    assert arr_uint == result
+    assert expected == result

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -3386,7 +3386,6 @@ def test_struct_array_sort():
 def test_array_accepts_pyarrow_array():
     arr = pa.array([1, 2, 3])
     result = pa.array(arr)
-
     assert arr == result
 
     # Test casting to a different type
@@ -3395,7 +3394,7 @@ def test_array_accepts_pyarrow_array():
     assert expected == result
     assert expected.type == pa.uint8()
 
-    # Test casting with safe keyward
+    # Test casting with safe keyword
     arr = pa.array([2 ** 63 - 1], type=pa.int64())
 
     with pytest.raises(pa.ArrowInvalid):
@@ -3404,3 +3403,7 @@ def test_array_accepts_pyarrow_array():
     expected = pa.array([-1], type=pa.int32())
     result = pa.array(arr, type=pa.int32(), safe=False)
     assert result == expected
+
+    # Test memory_pool keyword is accepted
+    result = pa.array(arr, memory_pool=pa.default_memory_pool())
+    assert arr == result

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -3381,3 +3381,15 @@ def test_struct_array_sort():
         {"a": 5, "b": "foo"},
         None
     ]
+
+
+def test_array_accepts_pyarrow_array():
+    arr = pa.array([1, 2, 3])
+    result = pa.array(arr)
+
+    assert arr == result
+
+    arr_uint = pa.array([1, 2, 3], type=pa.uint8())
+    result = pa.array(arr, type=pa.uint8())
+
+    assert arr_uint == result


### PR DESCRIPTION
### Rationale for this change

Currently, `pyarrow.array` doesn't accept pyarrow Arrays and this PR adds a check to allow that.

* Closes: #34411