### PR TITLE
MINOR: [R] Fix repository URL configurations for pkgdown website

### DIFF
--- a/r/_pkgdown.yml
+++ b/r/_pkgdown.yml
@@ -279,3 +279,4 @@ repo:
   url:
     source: https://github.com/apache/arrow/blob/main/r/
     issue: https://github.com/apache/arrow/issues/
+    user: https://github.com/

--- a/r/_pkgdown.yml
+++ b/r/_pkgdown.yml
@@ -277,6 +277,7 @@ reference:
 
 repo:
   url:
+    home: https://github.com/apache/arrow/
     source: https://github.com/apache/arrow/blob/main/r/
     issue: https://github.com/apache/arrow/issues/
     user: https://github.com/


### PR DESCRIPTION
### Rationale for this change

When manually setting repository URLs for pkgdown, four different URLs could be set (home, source, issue, user).
https://pkgdown.r-lib.org/reference/build_site.html#source-repository

Because two of these (home, user) are not configured, the link to the repository home (the GitHub icon in the upper right corner of the menu bar) and the links to the users (the links from the account names on Changelog to the GitHub account) are currently not enabled on the `arrow` package website.

### What changes are included in this PR?

Set up a link to the repository home and links to the users so that pkgdown's ability to link to the repository is fully functional.

### Are these changes tested?

I built the website locally by using the `pkgdown::build_site_github_pages()` and verified that the link works.

### Are there any user-facing changes?

No.