### PR TITLE
GH-34280: [C++][Python] Clarify meaning of row_group_size and change default to 1Mi

### DIFF
--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -265,7 +265,7 @@ class PARQUET_EXPORT WriterProperties {
     }
 
     /// Specify the max number of rows to put in a single row group.
-    /// Default 64Mi rows.
+    /// Default 1Mi rows.
     Builder* max_row_group_length(int64_t max_row_group_length) {
       max_row_group_length_ = max_row_group_length;
       return this;

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -132,7 +132,7 @@ static constexpr int64_t kDefaultDataPageSize = 1024 * 1024;
 static constexpr bool DEFAULT_IS_DICTIONARY_ENABLED = true;
 static constexpr int64_t DEFAULT_DICTIONARY_PAGE_SIZE_LIMIT = kDefaultDataPageSize;
 static constexpr int64_t DEFAULT_WRITE_BATCH_SIZE = 1024;
-static constexpr int64_t DEFAULT_MAX_ROW_GROUP_LENGTH = 64 * 1024 * 1024;
+static constexpr int64_t DEFAULT_MAX_ROW_GROUP_LENGTH = 1024 * 1024;
 static constexpr bool DEFAULT_ARE_STATISTICS_ENABLED = true;
 static constexpr int64_t DEFAULT_MAX_STATISTICS_SIZE = 4096;
 static constexpr Encoding::type DEFAULT_ENCODING = Encoding::PLAIN;
@@ -264,8 +264,8 @@ class PARQUET_EXPORT WriterProperties {
       return this;
     }
 
-    /// Specify the max row group length.
-    /// Default 64M.
+    /// Specify the max number of rows to put in a single row group.
+    /// Default 64Mi rows.
     Builder* max_row_group_length(int64_t max_row_group_length) {
       max_row_group_length_ = max_row_group_length;
       return this;

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -1038,7 +1038,7 @@ Examples
         ----------
         table_or_batch : {RecordBatch, Table}
         row_group_size : int, default None
-            Maximum # of rows in each written row group. If None,
+            Maximum number of rows in each written row group. If None,
             the row group size will be the minimum of the input
             table or batch length and 1024 * 1024.
         """
@@ -1057,7 +1057,7 @@ Examples
         ----------
         batch : RecordBatch
         row_group_size : int, default None
-            Maximum # of rows in written row group. If None, the
+            Maximum number of rows in written row group. If None, the
             row group size will be the minimum of the RecordBatch
             size and 1024 * 1024.
         """
@@ -1072,8 +1072,8 @@ Examples
         ----------
         table : Table
         row_group_size : int, default None
-            Maximum # of rows in each written row group. If None, the
-            row group size will be the minimum of the Table size
+            Maximum number of rows in each written row group. If None,
+            the row group size will be the minimum of the Table size
             and 1024 * 1024.
 
         """
@@ -3153,9 +3153,9 @@ Parameters
 table : pyarrow.Table
 where : string or pyarrow.NativeFile
 row_group_size : int
-    Maximum # of rows in each written row group. If None, the
-    row group size will be the minimum of the Table size
-    and 1024 * 1024.
+    Maximum number of rows in each written row group. If None, the
+    row group size will be the minimum of the Table size and
+    1024 * 1024.
 {}
 **kwargs : optional
     Additional options for ParquetWriter

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -1038,9 +1038,9 @@ Examples
         ----------
         table_or_batch : {RecordBatch, Table}
         row_group_size : int, default None
-            Maximum size of each written row group. If None, the
-            row group size will be the minimum of the input
-            table or batch length and 64 * 1024 * 1024.
+            Maximum # of rows in each written row group. If None,
+            the row group size will be the minimum of the input
+            table or batch length and 1024 * 1024.
         """
         if isinstance(table_or_batch, pa.RecordBatch):
             self.write_batch(table_or_batch, row_group_size)
@@ -1057,9 +1057,9 @@ Examples
         ----------
         batch : RecordBatch
         row_group_size : int, default None
-            Maximum size of each written row group. If None, the
+            Maximum # of rows in written row group. If None, the
             row group size will be the minimum of the RecordBatch
-            size and 64 * 1024 * 1024.
+            size and 1024 * 1024.
         """
         table = pa.Table.from_batches([batch], batch.schema)
         self.write_table(table, row_group_size)
@@ -1072,9 +1072,9 @@ Examples
         ----------
         table : Table
         row_group_size : int, default None
-            Maximum size of each written row group. If None, the
+            Maximum # of rows in each written row group. If None, the
             row group size will be the minimum of the Table size
-            and 64 * 1024 * 1024.
+            and 1024 * 1024.
 
         """
         if self.schema_changed:
@@ -3153,9 +3153,9 @@ Parameters
 table : pyarrow.Table
 where : string or pyarrow.NativeFile
 row_group_size : int
-    Maximum size of each written row group. If None, the
+    Maximum # of rows in each written row group. If None, the
     row group size will be the minimum of the Table size
-    and 64 * 1024 * 1024.
+    and 1024 * 1024.
 {}
 **kwargs : optional
     Additional options for ParquetWriter


### PR DESCRIPTION
BREAKING CHANGE: Changes the default row group size when writing parquet files.
* Closes: #34280