### PR TITLE
GH-34635: [C++][Gandiva] Support functions for average, current timestamp, round with rounding modes

### DIFF
--- a/cpp/src/arrow/array/array_base.cc
+++ b/cpp/src/arrow/array/array_base.cc
@@ -118,7 +118,7 @@ struct ScalarFromArraySlotImpl {
   }
 
   Status Visit(const DenseUnionArray& a) {
-    const auto type_code = a.type_code(index_);
+    const auto type_code = a.type_code(index_) ;
     // child array which stores the actual value
     auto arr = a.field(a.child_id(index_));
     // need to look up the value based on offsets

--- a/cpp/src/gandiva/function_registry_arithmetic.cc
+++ b/cpp/src/gandiva/function_registry_arithmetic.cc
@@ -164,6 +164,10 @@ std::vector<NativeFunction> GetArithmeticFunctionRegistry() {
       NativeFunction("bround", {}, DataTypeVector{float64()}, float64(),
                      kResultNullIfNull, "bround_float64"),
 
+      //round float and double with rounding mode
+      NativeFunction("round", {}, DataTypeVector{float64(), int32(), int32()}, float64(),
+                     kResultNullIfNull, "round_float64_int32_int32"),
+
       // positive and negative functions
       UNARY_SAFE_NULL_IF_NULL(positive, {}, int32, int32),
       UNARY_SAFE_NULL_IF_NULL(positive, {}, int64, int64),

--- a/cpp/src/gandiva/function_registry_datetime.cc
+++ b/cpp/src/gandiva/function_registry_datetime.cc
@@ -171,6 +171,9 @@ std::vector<NativeFunction> GetDateTimeFunctionRegistry() {
                      timestamp(), kResultNullIfNull, "from_utc_timezone_timestamp",
                      NativeFunction::kNeedsContext),
 
+      NativeFunction("current_day", {}, {}, int64(),
+                      kResultNullIfNull, "current_day"),
+
       DATE_TYPES(LAST_DAY_SAFE_NULL_IF_NULL, last_day, {}),
       BASE_NUMERIC_TYPES(TO_TIME_SAFE_NULL_IF_NULL, to_time, {}),
       BASE_NUMERIC_TYPES(TO_TIMESTAMP_SAFE_NULL_IF_NULL, to_timestamp, {})};

--- a/cpp/src/gandiva/precompiled/time.cc
+++ b/cpp/src/gandiva/precompiled/time.cc
@@ -1055,4 +1055,14 @@ gdv_int32 datediff_timestamp_timestamp(gdv_timestamp start_millis,
 CAST_NULLABLE_INTERVAL_YEAR(int32)
 CAST_NULLABLE_INTERVAL_YEAR(int64)
 
+
+gdv_date64 current_day() {
+    using namespace std::chrono;
+    auto now = std::chrono::system_clock::now();
+    auto now_ms = std::chrono::time_point_cast<std::chrono::milliseconds>(now);
+    auto epoch = now_ms.time_since_epoch();
+    auto value = std::chrono::duration_cast<std::chrono::milliseconds>(epoch);
+    return value.count();
+}
+
 }  // extern "C"

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -250,7 +250,9 @@ gdv_int32 round_int32_int32(gdv_int32 number, gdv_int32 precision);
 gdv_int64 round_int64_int32(gdv_int64 number, gdv_int32 precision);
 gdv_int32 round_int32(gdv_int32);
 gdv_int64 round_int64(gdv_int64);
+gdv_float64 round_float64_int32_int32(gdv_float64 number, gdv_int32 out_scale, gdv_int32 rounding_mode);
 gdv_int64 get_power_of_10(gdv_int32);
+gdv_float64 avg_float64_float64(gdv_float64 number1, gdv_float64 number2);
 
 const char* bin_int32(int64_t context, gdv_int32 value, int32_t* out_len);
 const char* bin_int64(int64_t context, gdv_int64 value, int32_t* out_len);
@@ -454,6 +456,7 @@ gdv_date64 last_day_from_timestamp(gdv_date64 millis);
 
 gdv_date64 next_day_from_timestamp(gdv_int64 context, gdv_date64 millis, const char* in,
                                    int32_t in_len);
+gdv_date64 current_day();
 
 gdv_int64 truncate_int64_int32(gdv_int64 in, gdv_int32 out_scale);
 


### PR DESCRIPTION
**This PR includes following changes in [C++][Gandiva]**

    1. Add a no argument function to get current timestamp in Gandiva
    2. Support average (double, double ) method in Gandiva
    3. Enhance round function in Gandiva to accept rounding modes including - up, down, half_up, half_down, half_even_floor , ceiling

* Closes: #34635