### PR TITLE
GH-33926: [Python] DataFrame Interchange Protocol for pyarrow.RecordBatch

### DIFF
--- a/python/pyarrow/interchange/dataframe.py
+++ b/python/pyarrow/interchange/dataframe.py
@@ -130,10 +130,7 @@ class _PyArrowDataFrame:
         """
         Return an iterator yielding the column names.
         """
-        if isinstance(self._df, pa.RecordBatch):
-            return self._df.schema.names
-        else:
-            return self._df.column_names
+        return self._df.schema.names
 
     def get_column(self, i: int) -> _PyArrowColumn:
         """

--- a/python/pyarrow/interchange/dataframe.py
+++ b/python/pyarrow/interchange/dataframe.py
@@ -219,7 +219,7 @@ class _PyArrowDataFrame:
             if isinstance(self._df, pa.Table):
                 batches = self._df.to_batches()
             else:
-                batches = self._df
+                batches = [self._df]
 
         # Create an iterator of RecordBatches
         iterator = [_PyArrowDataFrame(batch,

--- a/python/pyarrow/interchange/dataframe.py
+++ b/python/pyarrow/interchange/dataframe.py
@@ -159,14 +159,9 @@ class _PyArrowDataFrame:
         """
         Create a new DataFrame by selecting a subset of columns by index.
         """
-        if isinstance(self._df, pa.RecordBatch):
-            columns = [self._df.column(i) for i in indices]
-            names = [self._df.schema.names[i] for i in indices]
-            return _PyArrowDataFrame(pa.record_batch(columns, names=names))
-        else:
-            return _PyArrowDataFrame(
-                self._df.select(list(indices)), self._nan_as_null, self._allow_copy
-            )
+        return _PyArrowDataFrame(
+            self._df.select(list(indices)), self._nan_as_null, self._allow_copy
+        )
 
     def select_columns_by_name(
         self, names: Sequence[str]
@@ -174,13 +169,9 @@ class _PyArrowDataFrame:
         """
         Create a new DataFrame by selecting a subset of columns by name.
         """
-        if isinstance(self._df, pa.RecordBatch):
-            columns = [self._df[i] for i in names]
-            return _PyArrowDataFrame(pa.record_batch(columns, names=names))
-        else:
-            return _PyArrowDataFrame(
-                self._df.select(list(names)), self._nan_as_null, self._allow_copy
-            )
+        return _PyArrowDataFrame(
+            self._df.select(list(names)), self._nan_as_null, self._allow_copy
+        )
 
     def get_chunks(
         self, n_chunks: Optional[int] = None

--- a/python/pyarrow/interchange/dataframe.py
+++ b/python/pyarrow/interchange/dataframe.py
@@ -44,11 +44,13 @@ class _PyArrowDataFrame:
     """
 
     def __init__(
-        self, df: pa.Table, nan_as_null: bool = False, allow_copy: bool = True
+        self, df: pa.Table | pa.RecordBatch,
+        nan_as_null: bool = False,
+        allow_copy: bool = True
     ) -> None:
         """
         Constructor - an instance of this (private) class is returned from
-        `pa.Table.__dataframe__`.
+        `pa.Table.__dataframe__` or `pa.RecordBatch.__dataframe__`.
         """
         self._df = df
         # ``nan_as_null`` is a keyword intended for the consumer to tell the
@@ -114,18 +116,24 @@ class _PyArrowDataFrame:
         """
         Return the number of chunks the DataFrame consists of.
         """
-        # pyarrow.Table can have columns with different number
-        # of chunks so we take the number of chunks that
-        # .to_batches() returns as it takes the min chunk size
-        # of all the columns (to_batches is a zero copy method)
-        batches = self._df.to_batches()
-        return len(batches)
+        if isinstance(self._df, pa.RecordBatch):
+            return 1
+        else:
+            # pyarrow.Table can have columns with different number
+            # of chunks so we take the number of chunks that
+            # .to_batches() returns as it takes the min chunk size
+            # of all the columns (to_batches is a zero copy method)
+            batches = self._df.to_batches()
+            return len(batches)
 
     def column_names(self) -> Iterable[str]:
         """
         Return an iterator yielding the column names.
         """
-        return self._df.column_names
+        if isinstance(self._df, pa.RecordBatch):
+            return self._df.schema.names
+        else:
+            return self._df.column_names
 
     def get_column(self, i: int) -> _PyArrowColumn:
         """
@@ -182,21 +190,31 @@ class _PyArrowDataFrame:
         Note that the producer must ensure that all columns are chunked the
         same way.
         """
+        # Subdivide chunks
         if n_chunks and n_chunks > 1:
             chunk_size = self.num_rows() // n_chunks
             if self.num_rows() % n_chunks != 0:
                 chunk_size += 1
-            batches = self._df.to_batches(max_chunksize=chunk_size)
+            if isinstance(self._df, pa.Table):
+                batches = self._df.to_batches(max_chunksize=chunk_size)
+            else:
+                batches = []
+                for start in range(0, chunk_size * n_chunks, chunk_size):
+                    batches.append(self.slice(start, chunk_size))
             # In case when the size of the chunk is such that the resulting
             # list is one less chunk then n_chunks -> append an empty chunk
             if len(batches) == n_chunks - 1:
                 batches.append(pa.record_batch([[]], schema=self._df.schema))
+        # yields the chunks that the data is stored as
         else:
-            batches = self._df.to_batches()
+            if isinstance(self._df, pa.Table):
+                batches = self._df.to_batches()
+            else:
+                batches = self._df
 
-        iterator_tables = [_PyArrowDataFrame(
-            pa.Table.from_batches([batch]), self._nan_as_null, self._allow_copy
-        )
-            for batch in batches
-        ]
-        return iterator_tables
+        # Create an iterator of RecordBatches
+        iterator = [_PyArrowDataFrame(batch,
+                                      self._nan_as_null,
+                                      self._allow_copy)
+                    for batch in batches]
+        return iterator

--- a/python/pyarrow/interchange/from_dataframe.py
+++ b/python/pyarrow/interchange/from_dataframe.py
@@ -58,10 +58,9 @@ _PYARROW_DTYPES: dict[DtypeKind, dict[int, Any]] = {
 }
 
 
-def from_dataframe(df: DataFrameObject, allow_copy=True) -> pa.Table | pa.RecordBatch:
+def from_dataframe(df: DataFrameObject, allow_copy=True) -> pa.Table:
     """
-    Build a ``pa.Table`` or a ``pa.RecordBatch`` from any DataFrame supporting
-    the interchange protocol.
+    Build a ``pa.Table`` from any DataFrame supporting the interchange protocol.
 
     Parameters
     ----------
@@ -74,10 +73,12 @@ def from_dataframe(df: DataFrameObject, allow_copy=True) -> pa.Table | pa.Record
 
     Returns
     -------
-    pa.Table or pa.RecordBatch
+    pa.Table
     """
-    if isinstance(df, (pa.Table, pa.RecordBatch)):
+    if isinstance(df, pa.Table):
         return df
+    elif isinstance(df, pa.RecordBatch):
+        return pa.Table.from_batches([df])
 
     if not hasattr(df, "__dataframe__"):
         raise ValueError("`df` does not support __dataframe__")

--- a/python/pyarrow/interchange/from_dataframe.py
+++ b/python/pyarrow/interchange/from_dataframe.py
@@ -108,10 +108,7 @@ def _from_dataframe(df: DataFrameObject, allow_copy=True):
         batch = protocol_df_chunk_to_pyarrow(chunk, allow_copy)
         batches.append(batch)
 
-    if len(batches) == 1:
-        return batches[0]
-    else:
-        return pa.Table.from_batches(batches)
+    return pa.Table.from_batches(batches)
 
 
 def protocol_df_chunk_to_pyarrow(

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1517,6 +1517,36 @@ cdef class RecordBatch(_PandasConvertible):
         self.sp_batch = batch
         self.batch = batch.get()
 
+    # ----------------------------------------------------------------------
+    def __dataframe__(self, nan_as_null: bool = False, allow_copy: bool = True):
+        """
+        Return the dataframe interchange object implementing the interchange protocol.
+        Parameters
+        ----------
+        nan_as_null : bool, default False
+            Whether to tell the DataFrame to overwrite null values in the data
+            with ``NaN`` (or ``NaT``).
+        allow_copy : bool, default True
+            Whether to allow memory copying when exporting. If set to False
+            it would cause non-zero-copy exports to fail.
+        Returns
+        -------
+        DataFrame interchange object
+            The object which consuming library can use to ingress the dataframe.
+        Notes
+        -----
+        Details on the interchange protocol:
+        https://data-apis.org/dataframe-protocol/latest/index.html
+        `nan_as_null` currently has no effect; once support for nullable extension
+        dtypes is added, this value should be propagated to columns.
+        """
+
+        from pyarrow.interchange.dataframe import _PyArrowDataFrame
+
+        return _PyArrowDataFrame(self, nan_as_null, allow_copy)
+
+    # ----------------------------------------------------------------------
+
     @staticmethod
     def from_pydict(mapping, schema=None, metadata=None):
         """

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1521,6 +1521,7 @@ cdef class RecordBatch(_PandasConvertible):
     def __dataframe__(self, nan_as_null: bool = False, allow_copy: bool = True):
         """
         Return the dataframe interchange object implementing the interchange protocol.
+
         Parameters
         ----------
         nan_as_null : bool, default False
@@ -1529,10 +1530,12 @@ cdef class RecordBatch(_PandasConvertible):
         allow_copy : bool, default True
             Whether to allow memory copying when exporting. If set to False
             it would cause non-zero-copy exports to fail.
+
         Returns
         -------
         DataFrame interchange object
             The object which consuming library can use to ingress the dataframe.
+
         Notes
         -----
         Details on the interchange protocol:

--- a/python/pyarrow/tests/interchange/test_conversion.py
+++ b/python/pyarrow/tests/interchange/test_conversion.py
@@ -85,7 +85,6 @@ def test_offset_of_sliced_array():
     assert col.offset == 2
 
     result = _from_dataframe(table_sliced.__dataframe__())
-    result = pa.Table.from_batches([result])
     assert table_sliced.equals(result)
     assert not table.equals(result)
 
@@ -177,7 +176,6 @@ def test_pandas_roundtrip(uint, int, float, np_float):
     )
     pandas_df = pandas_from_dataframe(table)
     result = pi.from_dataframe(pandas_df)
-    result = pa.Table.from_batches([result])
     assert table.equals(result)
 
     table_protocol = table.__dataframe__()
@@ -203,7 +201,6 @@ def test_roundtrip_pandas_string():
     )
     pandas_df = pandas_from_dataframe(table)
     result = pi.from_dataframe(pandas_df)
-    result = pa.Table.from_batches([result])
 
     assert result[0].to_pylist() == table[0].to_pylist()
     assert pa.types.is_string(table[0].type)
@@ -230,7 +227,6 @@ def test_roundtrip_pandas_boolean():
     )
     pandas_df = pandas_from_dataframe(table)
     result = pi.from_dataframe(pandas_df)
-    result = pa.Table.from_batches([result])
 
     assert table.equals(result)
 
@@ -267,7 +263,6 @@ def test_roundtrip_pandas_datetime(unit):
     )
     pandas_df = pandas_from_dataframe(table)
     result = pi.from_dataframe(pandas_df)
-    result = pa.Table.from_batches([result])
 
     assert expected.equals(result)
 
@@ -318,7 +313,6 @@ def test_pandas_to_pyarrow_with_missing(np_float):
         "dt": pa.array(datetime_array, type=pa.timestamp("ns"))
     })
     result = pi.from_dataframe(df)
-    result = pa.Table.from_batches([result])
 
     assert result.equals(expected)
 
@@ -373,8 +367,8 @@ def test_pandas_to_pyarrow_categorical_with_missing():
     expected_indices = pa.array([1, 4, 1, 5, 1, 3, 0, 2, None], type=pa.int8())
 
     assert result[0].to_pylist() == arr
-    assert result[0].dictionary.to_pylist() == expected_dictionary
-    assert result[0].indices.equals(expected_indices)
+    assert result[0].chunk(0).dictionary.to_pylist() == expected_dictionary
+    assert result[0].chunk(0).indices.equals(expected_indices)
 
 
 @pytest.mark.parametrize(
@@ -414,7 +408,6 @@ def test_pyarrow_roundtrip(uint, int, float, np_float,
     )
     table = table.slice(offset, length)
     result = _from_dataframe(table.__dataframe__())
-    result = pa.Table.from_batches([result])
 
     assert table.equals(result)
 
@@ -435,7 +428,6 @@ def test_pyarrow_roundtrip_categorical(offset, length):
     )
     table = table.slice(offset, length)
     result = _from_dataframe(table.__dataframe__())
-    result = pa.Table.from_batches([result])
 
     assert table.equals(result)
 

--- a/python/pyarrow/tests/interchange/test_conversion.py
+++ b/python/pyarrow/tests/interchange/test_conversion.py
@@ -49,6 +49,15 @@ def test_datetime(unit, tz):
     assert col.dtype[0] == DtypeKind.DATETIME
     assert col.describe_null == (ColumnNullType.USE_BITMASK, 0)
 
+    batch = table.to_batches()[0]
+    col = batch.__dataframe__().get_column_by_name("A")
+
+    assert col.size() == 3
+    assert col.offset == 0
+    assert col.null_count == 1
+    assert col.dtype[0] == DtypeKind.DATETIME
+    assert col.describe_null == (ColumnNullType.USE_BITMASK, 0)
+
 
 @pytest.mark.parametrize(
     ["test_data", "kind"],
@@ -98,6 +107,15 @@ def test_offset_of_sliced_array():
     # tm.assert_series_equal(df["arr"][2:4], df_sliced["arr_sliced"],
     #                        check_index=False, check_names=False)
 
+    batch_sliced = pa.record_batch([arr_sliced], names=["arr_sliced"])
+
+    col = batch_sliced.__dataframe__().get_column(0)
+    assert col.offset == 2
+
+    result = _from_dataframe(batch_sliced.__dataframe__())
+    assert table_sliced.equals(result)
+    assert not table.equals(result)
+
 
 # Currently errors due to string conversion
 # as col.size is called as a property not method in pandas
@@ -108,6 +126,7 @@ def test_categorical_roundtrip():
 
     if Version(pd.__version__) < Version("1.5.0"):
         pytest.skip("__dataframe__ added to pandas in 1.5.0")
+
     arr = ["Mon", "Tue", "Mon", "Wed", "Mon", "Thu", "Fri", "Sat", "Sun"]
     table = pa.table(
         {"weekday": pa.array(arr).dictionary_encode()}
@@ -130,6 +149,38 @@ def test_categorical_roundtrip():
     assert table_protocol.column_names() == result_protocol.column_names()
 
     col_table = table_protocol.get_column(0)
+    col_result = result_protocol.get_column(0)
+
+    assert col_result.dtype[0] == DtypeKind.CATEGORICAL
+    assert col_result.dtype[0] == col_table.dtype[0]
+    assert col_result.size == col_table.size
+    assert col_result.offset == col_table.offset
+
+    desc_cat_table = col_result.describe_categorical
+    desc_cat_result = col_result.describe_categorical
+
+    assert desc_cat_table["is_ordered"] == desc_cat_result["is_ordered"]
+    assert desc_cat_table["is_dictionary"] == desc_cat_result["is_dictionary"]
+    assert isinstance(desc_cat_result["categories"]._col, pa.Array)
+
+    batch = table.to_batches()[0]
+    pandas_df = batch.to_pandas()
+    result = pi.from_dataframe(pandas_df)
+
+    # Checking equality for the values
+    # As the dtype of the indices is changed from int32 in pa.Table
+    # to int64 in pandas interchange protocol implementation
+    assert result[0].chunk(0).dictionary == table[0].chunk(0).dictionary
+
+    batch_protocol = batch.__dataframe__()
+    result_protocol = result.__dataframe__()
+
+    assert batch_protocol.num_columns() == result_protocol.num_columns()
+    assert batch_protocol.num_rows() == result_protocol.num_rows()
+    assert batch_protocol.num_chunks() == result_protocol.num_chunks()
+    assert batch_protocol.column_names() == result_protocol.column_names()
+
+    col_table = batch_protocol.get_column(0)
     col_result = result_protocol.get_column(0)
 
     assert col_result.dtype[0] == DtypeKind.CATEGORICAL
@@ -186,6 +237,19 @@ def test_pandas_roundtrip(uint, int, float, np_float):
     assert table_protocol.num_chunks() == result_protocol.num_chunks()
     assert table_protocol.column_names() == result_protocol.column_names()
 
+    batch = table.to_batches()[0]
+    pandas_df = pandas_from_dataframe(batch)
+    result = pi.from_dataframe(pandas_df)
+    assert table.equals(result)
+
+    batch_protocol = batch.__dataframe__()
+    result_protocol = result.__dataframe__()
+
+    assert batch_protocol.num_columns() == result_protocol.num_columns()
+    assert batch_protocol.num_rows() == result_protocol.num_rows()
+    assert batch_protocol.num_chunks() == result_protocol.num_chunks()
+    assert batch_protocol.column_names() == result_protocol.column_names()
+
 
 @pytest.mark.pandas
 def test_roundtrip_pandas_string():
@@ -214,6 +278,22 @@ def test_roundtrip_pandas_string():
     assert table_protocol.num_chunks() == result_protocol.num_chunks()
     assert table_protocol.column_names() == result_protocol.column_names()
 
+    batch = table.to_batches()[0]
+    pandas_df = pandas_from_dataframe(batch)
+    result = pi.from_dataframe(pandas_df)
+
+    assert result[0].to_pylist() == batch[0].to_pylist()
+    assert pa.types.is_string(table[0].type)
+    assert pa.types.is_large_string(result[0].type)
+
+    batch_protocol = batch.__dataframe__()
+    result_protocol = result.__dataframe__()
+
+    assert batch_protocol.num_columns() == result_protocol.num_columns()
+    assert batch_protocol.num_rows() == result_protocol.num_rows()
+    assert batch_protocol.num_chunks() == result_protocol.num_chunks()
+    assert batch_protocol.column_names() == result_protocol.column_names()
+
 
 @pytest.mark.pandas
 def test_roundtrip_pandas_boolean():
@@ -237,6 +317,20 @@ def test_roundtrip_pandas_boolean():
     assert table_protocol.num_rows() == result_protocol.num_rows()
     assert table_protocol.num_chunks() == result_protocol.num_chunks()
     assert table_protocol.column_names() == result_protocol.column_names()
+
+    batch = table.to_batches()[0]
+    pandas_df = pandas_from_dataframe(batch)
+    result = pi.from_dataframe(pandas_df)
+
+    assert table.equals(result)
+
+    batch_protocol = batch.__dataframe__()
+    result_protocol = result.__dataframe__()
+
+    assert batch_protocol.num_columns() == result_protocol.num_columns()
+    assert batch_protocol.num_rows() == result_protocol.num_rows()
+    assert batch_protocol.num_chunks() == result_protocol.num_chunks()
+    assert batch_protocol.column_names() == result_protocol.column_names()
 
 
 @pytest.mark.pandas
@@ -274,6 +368,21 @@ def test_roundtrip_pandas_datetime(unit):
     assert expected_protocol.num_chunks() == result_protocol.num_chunks()
     assert expected_protocol.column_names() == result_protocol.column_names()
 
+    batch = table.to_batches()[0]
+    pandas_df = pandas_from_dataframe(batch)
+    result = pi.from_dataframe(pandas_df)
+
+    assert expected.equals(result)
+
+    expected_batch = expected.to_batches()[0]
+    expected_protocol = expected_batch.__dataframe__()
+    result_protocol = result.__dataframe__()
+
+    assert expected_protocol.num_columns() == result_protocol.num_columns()
+    assert expected_protocol.num_rows() == result_protocol.num_rows()
+    assert expected_protocol.num_chunks() == result_protocol.num_chunks()
+    assert expected_protocol.column_names() == result_protocol.column_names()
+
 
 @pytest.mark.large_memory
 @pytest.mark.pandas
@@ -292,6 +401,10 @@ def test_pandas_assertion_error_large_string():
 
     with pytest.raises(AssertionError):
         pandas_from_dataframe(table)
+
+    batch = table.to_batches()[0]
+    with pytest.raises(AssertionError):
+        pandas_from_dataframe(batch)
 
 
 @pytest.mark.pandas
@@ -419,6 +532,19 @@ def test_pyarrow_roundtrip(uint, int, float, np_float,
     assert table_protocol.num_chunks() == result_protocol.num_chunks()
     assert table_protocol.column_names() == result_protocol.column_names()
 
+    batch = table.to_batches()[0]
+    result = _from_dataframe(batch.__dataframe__())
+
+    assert table.equals(result)
+
+    batch_protocol = batch.__dataframe__()
+    result_protocol = result.__dataframe__()
+
+    assert batch_protocol.num_columns() == result_protocol.num_columns()
+    assert batch_protocol.num_rows() == result_protocol.num_rows()
+    assert batch_protocol.num_chunks() == result_protocol.num_chunks()
+    assert batch_protocol.column_names() == result_protocol.column_names()
+
 
 @pytest.mark.parametrize("offset, length", [(0, 10), (0, 2), (7, 3), (2, 1)])
 def test_pyarrow_roundtrip_categorical(offset, length):
@@ -447,11 +573,39 @@ def test_pyarrow_roundtrip_categorical(offset, length):
     assert col_result.size() == col_table.size()
     assert col_result.offset == col_table.offset
 
-    desc_cat_table = col_result.describe_categorical
+    desc_cat_table = col_table.describe_categorical
     desc_cat_result = col_result.describe_categorical
 
     assert desc_cat_table["is_ordered"] == desc_cat_result["is_ordered"]
     assert desc_cat_table["is_dictionary"] == desc_cat_result["is_dictionary"]
+    assert isinstance(desc_cat_result["categories"]._col, pa.Array)
+
+    batch = table.to_batches()[0]
+    result = _from_dataframe(batch.__dataframe__())
+
+    assert table.equals(result)
+
+    batch_protocol = batch.__dataframe__()
+    result_protocol = result.__dataframe__()
+
+    assert batch_protocol.num_columns() == result_protocol.num_columns()
+    assert batch_protocol.num_rows() == result_protocol.num_rows()
+    assert batch_protocol.num_chunks() == result_protocol.num_chunks()
+    assert batch_protocol.column_names() == result_protocol.column_names()
+
+    col_batch = batch_protocol.get_column(0)
+    col_result = result_protocol.get_column(0)
+
+    assert col_result.dtype[0] == DtypeKind.CATEGORICAL
+    assert col_result.dtype[0] == col_batch.dtype[0]
+    assert col_result.size() == col_batch.size()
+    assert col_result.offset == col_batch.offset
+
+    desc_col_batch = col_batch.describe_categorical
+    desc_cat_result = col_result.describe_categorical
+
+    assert desc_col_batch["is_ordered"] == desc_cat_result["is_ordered"]
+    assert desc_col_batch["is_dictionary"] == desc_cat_result["is_dictionary"]
     assert isinstance(desc_cat_result["categories"]._col, pa.Array)
 
 
@@ -471,11 +625,24 @@ def test_pyarrow_roundtrip_large_string():
 
     assert table.equals(result)
 
+    batch = table.to_batches()[0]
+    result = _from_dataframe(batch.__dataframe__())
+    col = result.__dataframe__().get_column(0)
+
+    assert col.size() == 3*1024**2
+    assert pa.types.is_large_string(table[0].type)
+    assert pa.types.is_large_string(result[0].type)
+
+    assert table.equals(result)
+
 
 def test_nan_as_null():
     table = pa.table({"a": [1, 2, 3, 4]})
     with pytest.raises(RuntimeError):
         table.__dataframe__(nan_as_null=True)
+    batch = table.to_batches()[0]
+    with pytest.raises(RuntimeError):
+        batch.__dataframe__(nan_as_null=True)
 
 
 @pytest.mark.pandas

--- a/python/pyarrow/tests/interchange/test_conversion.py
+++ b/python/pyarrow/tests/interchange/test_conversion.py
@@ -85,6 +85,7 @@ def test_offset_of_sliced_array():
     assert col.offset == 2
 
     result = _from_dataframe(table_sliced.__dataframe__())
+    result = pa.Table.from_batches([result])
     assert table_sliced.equals(result)
     assert not table.equals(result)
 
@@ -176,6 +177,7 @@ def test_pandas_roundtrip(uint, int, float, np_float):
     )
     pandas_df = pandas_from_dataframe(table)
     result = pi.from_dataframe(pandas_df)
+    result = pa.Table.from_batches([result])
     assert table.equals(result)
 
     table_protocol = table.__dataframe__()
@@ -201,6 +203,7 @@ def test_roundtrip_pandas_string():
     )
     pandas_df = pandas_from_dataframe(table)
     result = pi.from_dataframe(pandas_df)
+    result = pa.Table.from_batches([result])
 
     assert result[0].to_pylist() == table[0].to_pylist()
     assert pa.types.is_string(table[0].type)
@@ -227,6 +230,7 @@ def test_roundtrip_pandas_boolean():
     )
     pandas_df = pandas_from_dataframe(table)
     result = pi.from_dataframe(pandas_df)
+    result = pa.Table.from_batches([result])
 
     assert table.equals(result)
 
@@ -263,6 +267,7 @@ def test_roundtrip_pandas_datetime(unit):
     )
     pandas_df = pandas_from_dataframe(table)
     result = pi.from_dataframe(pandas_df)
+    result = pa.Table.from_batches([result])
 
     assert expected.equals(result)
 
@@ -313,6 +318,7 @@ def test_pandas_to_pyarrow_with_missing(np_float):
         "dt": pa.array(datetime_array, type=pa.timestamp("ns"))
     })
     result = pi.from_dataframe(df)
+    result = pa.Table.from_batches([result])
 
     assert result.equals(expected)
 
@@ -367,8 +373,8 @@ def test_pandas_to_pyarrow_categorical_with_missing():
     expected_indices = pa.array([1, 4, 1, 5, 1, 3, 0, 2, None], type=pa.int8())
 
     assert result[0].to_pylist() == arr
-    assert result[0].chunk(0).dictionary.to_pylist() == expected_dictionary
-    assert result[0].chunk(0).indices.equals(expected_indices)
+    assert result[0].dictionary.to_pylist() == expected_dictionary
+    assert result[0].indices.equals(expected_indices)
 
 
 @pytest.mark.parametrize(
@@ -408,6 +414,7 @@ def test_pyarrow_roundtrip(uint, int, float, np_float,
     )
     table = table.slice(offset, length)
     result = _from_dataframe(table.__dataframe__())
+    result = pa.Table.from_batches([result])
 
     assert table.equals(result)
 
@@ -428,6 +435,7 @@ def test_pyarrow_roundtrip_categorical(offset, length):
     )
     table = table.slice(offset, length)
     result = _from_dataframe(table.__dataframe__())
+    result = pa.Table.from_batches([result])
 
     assert table.equals(result)
 

--- a/python/pyarrow/tests/interchange/test_interchange_spec.py
+++ b/python/pyarrow/tests/interchange/test_interchange_spec.py
@@ -266,4 +266,3 @@ def test_buffer(int, use_batch):
         for idx, truth in enumerate(arr):
             val = ctype.from_address(dataBuf.ptr + idx * (bitwidth // 8)).value
             assert val == truth, f"Buffer at index {idx} mismatch"
-


### PR DESCRIPTION
### Rationale for this change
Add the implementation of the Dataframe Interchange Protocol for `pyarrow.RecordBatch`. The protocol is already implemented for pyarrow.Table, see https://github.com/apache/arrow/pull/14804.

### Are these changes tested?
Yes, tests are added to:

- python/pyarrow/tests/interchange/test_interchange_spec.py
- python/pyarrow/tests/interchange/test_conversion.py
* Closes: #33926