### PR TITLE
GH-34388: [C++] Build core compute kernels unconditionally

### DIFF
--- a/cpp/cmake_modules/DefineOptions.cmake
+++ b/cpp/cmake_modules/DefineOptions.cmake
@@ -296,7 +296,7 @@ takes precedence over ccache if a storage backend is configured" ON)
 
   define_option(ARROW_BUILD_UTILITIES "Build Arrow commandline utilities" OFF)
 
-  define_option(ARROW_COMPUTE "Build the Arrow Compute Modules" OFF)
+  define_option(ARROW_COMPUTE "Build all Arrow Compute kernels" OFF)
 
   define_option(ARROW_CSV "Build the Arrow CSV Parser Module" OFF)
 
@@ -361,7 +361,6 @@ takes precedence over ccache if a storage backend is configured" ON)
                 "Build the Parquet libraries"
                 OFF
                 DEPENDS
-                ARROW_COMPUTE
                 ARROW_IPC)
 
   define_option(ARROW_ORC

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -375,10 +375,8 @@ if(ARROW_CSV)
        csv/column_decoder.cc
        csv/options.cc
        csv/parser.cc
-       csv/reader.cc)
-  if(ARROW_COMPUTE)
-    list(APPEND ARROW_SRCS csv/writer.cc)
-  endif()
+       csv/reader.cc
+       csv/writer.cc)
 
   list(APPEND ARROW_TESTING_SRCS csv/test_common.cc)
 endif()
@@ -805,12 +803,7 @@ add_arrow_test(table_test
 add_arrow_test(tensor_test)
 add_arrow_test(sparse_tensor_test)
 
-set(STL_TEST_SRCS stl_iterator_test.cc)
-if(ARROW_COMPUTE)
-  # This unit test uses compute code
-  list(APPEND STL_TEST_SRCS stl_test.cc)
-endif()
-add_arrow_test(stl_test SOURCES ${STL_TEST_SRCS})
+add_arrow_test(stl_test SOURCES stl_iterator_test.cc stl_test.cc)
 
 add_arrow_benchmark(builder_benchmark)
 add_arrow_benchmark(compare_benchmark)

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -383,65 +383,87 @@ if(ARROW_CSV)
   list(APPEND ARROW_TESTING_SRCS csv/test_common.cc)
 endif()
 
+# Baseline Compute functionality + scalar casts and a few select kernels
+list(APPEND
+     ARROW_SRCS
+     compute/api_aggregate.cc
+     compute/api_scalar.cc
+     compute/api_vector.cc
+     compute/cast.cc
+     compute/exec.cc
+     compute/exec/groupby.cc
+     compute/exec/accumulation_queue.cc
+     compute/exec/aggregate_node.cc
+     compute/exec/asof_join_node.cc
+     compute/exec/bloom_filter.cc
+     compute/exec/exec_plan.cc
+     compute/exec/expression.cc
+     compute/exec/fetch_node.cc
+     compute/exec/filter_node.cc
+     compute/exec/hash_join.cc
+     compute/exec/hash_join_dict.cc
+     compute/exec/hash_join_node.cc
+     compute/exec/key_hash.cc
+     compute/exec/key_map.cc
+     compute/exec/map_node.cc
+     compute/exec/options.cc
+     compute/exec/order_by_impl.cc
+     compute/exec/partition_util.cc
+     compute/exec/project_node.cc
+     compute/exec/query_context.cc
+     compute/exec/sink_node.cc
+     compute/exec/source_node.cc
+     compute/exec/swiss_join.cc
+     compute/exec/task_util.cc
+     compute/exec/tpch_node.cc
+     compute/exec/union_node.cc
+     compute/exec/util.cc
+     compute/function.cc
+     compute/function_internal.cc
+     compute/kernel.cc
+     compute/light_array.cc
+     compute/ordering.cc
+     compute/registry.cc
+     compute/kernels/codegen_internal.cc
+     compute/kernels/row_encoder.cc
+     compute/kernels/scalar_cast_boolean.cc
+     compute/kernels/scalar_cast_dictionary.cc
+     compute/kernels/scalar_cast_extension.cc
+     compute/kernels/scalar_cast_internal.cc
+     compute/kernels/scalar_cast_nested.cc
+     compute/kernels/scalar_cast_numeric.cc
+     compute/kernels/scalar_cast_string.cc
+     compute/kernels/scalar_cast_temporal.cc
+     compute/kernels/util_internal.cc
+     compute/kernels/vector_hash.cc
+     compute/kernels/vector_selection.cc
+     compute/row/encode_internal.cc
+     compute/row/compare_internal.cc
+     compute/row/grouper.cc
+     compute/row/row_internal.cc)
+
+append_avx2_src(compute/exec/bloom_filter_avx2.cc)
+append_avx2_src(compute/exec/key_hash_avx2.cc)
+append_avx2_src(compute/exec/key_map_avx2.cc)
+append_avx2_src(compute/exec/swiss_join_avx2.cc)
+append_avx2_src(compute/exec/util_avx2.cc)
+append_avx2_src(compute/row/compare_internal_avx2.cc)
+append_avx2_src(compute/row/encode_internal_avx2.cc)
+
+list(APPEND ARROW_TESTING_SRCS compute/exec/test_util.cc)
+
 if(ARROW_COMPUTE)
+  # Include the remaining kernels
   list(APPEND
        ARROW_SRCS
-       compute/api_aggregate.cc
-       compute/api_scalar.cc
-       compute/api_vector.cc
-       compute/cast.cc
-       compute/exec.cc
-       compute/exec/groupby.cc
-       compute/exec/accumulation_queue.cc
-       compute/exec/aggregate_node.cc
-       compute/exec/asof_join_node.cc
-       compute/exec/bloom_filter.cc
-       compute/exec/exec_plan.cc
-       compute/exec/expression.cc
-       compute/exec/fetch_node.cc
-       compute/exec/filter_node.cc
-       compute/exec/hash_join.cc
-       compute/exec/hash_join_dict.cc
-       compute/exec/hash_join_node.cc
-       compute/exec/key_hash.cc
-       compute/exec/key_map.cc
-       compute/exec/map_node.cc
-       compute/exec/options.cc
-       compute/exec/order_by_impl.cc
-       compute/exec/partition_util.cc
-       compute/exec/project_node.cc
-       compute/exec/query_context.cc
-       compute/exec/sink_node.cc
-       compute/exec/source_node.cc
-       compute/exec/swiss_join.cc
-       compute/exec/task_util.cc
-       compute/exec/tpch_node.cc
-       compute/exec/union_node.cc
-       compute/exec/util.cc
-       compute/function.cc
-       compute/function_internal.cc
-       compute/kernel.cc
-       compute/light_array.cc
-       compute/ordering.cc
-       compute/registry.cc
        compute/kernels/aggregate_basic.cc
        compute/kernels/aggregate_mode.cc
        compute/kernels/aggregate_quantile.cc
        compute/kernels/aggregate_tdigest.cc
        compute/kernels/aggregate_var_std.cc
-       compute/kernels/codegen_internal.cc
        compute/kernels/hash_aggregate.cc
-       compute/kernels/row_encoder.cc
        compute/kernels/scalar_arithmetic.cc
        compute/kernels/scalar_boolean.cc
-       compute/kernels/scalar_cast_boolean.cc
-       compute/kernels/scalar_cast_dictionary.cc
-       compute/kernels/scalar_cast_extension.cc
-       compute/kernels/scalar_cast_internal.cc
-       compute/kernels/scalar_cast_nested.cc
-       compute/kernels/scalar_cast_numeric.cc
-       compute/kernels/scalar_cast_string.cc
-       compute/kernels/scalar_cast_temporal.cc
        compute/kernels/scalar_compare.cc
        compute/kernels/scalar_if_else.cc
        compute/kernels/scalar_nested.cc
@@ -453,33 +475,16 @@ if(ARROW_COMPUTE)
        compute/kernels/scalar_temporal_binary.cc
        compute/kernels/scalar_temporal_unary.cc
        compute/kernels/scalar_validity.cc
-       compute/kernels/util_internal.cc
        compute/kernels/vector_array_sort.cc
        compute/kernels/vector_cumulative_ops.cc
-       compute/kernels/vector_hash.cc
        compute/kernels/vector_nested.cc
        compute/kernels/vector_rank.cc
        compute/kernels/vector_replace.cc
        compute/kernels/vector_select_k.cc
-       compute/kernels/vector_selection.cc
-       compute/kernels/vector_sort.cc
-       compute/row/encode_internal.cc
-       compute/row/compare_internal.cc
-       compute/row/grouper.cc
-       compute/row/row_internal.cc)
+       compute/kernels/vector_sort.cc)
 
   append_avx2_src(compute/kernels/aggregate_basic_avx2.cc)
   append_avx512_src(compute/kernels/aggregate_basic_avx512.cc)
-
-  append_avx2_src(compute/exec/bloom_filter_avx2.cc)
-  append_avx2_src(compute/exec/key_hash_avx2.cc)
-  append_avx2_src(compute/exec/key_map_avx2.cc)
-  append_avx2_src(compute/exec/swiss_join_avx2.cc)
-  append_avx2_src(compute/exec/util_avx2.cc)
-  append_avx2_src(compute/row/compare_internal_avx2.cc)
-  append_avx2_src(compute/row/encode_internal_avx2.cc)
-
-  list(APPEND ARROW_TESTING_SRCS compute/exec/test_util.cc)
 endif()
 
 if(ARROW_FILESYSTEM)
@@ -821,6 +826,7 @@ add_subdirectory(testing)
 
 add_subdirectory(array)
 add_subdirectory(c)
+add_subdirectory(compute)
 add_subdirectory(io)
 add_subdirectory(tensor)
 add_subdirectory(util)
@@ -828,10 +834,6 @@ add_subdirectory(vendored)
 
 if(ARROW_CSV)
   add_subdirectory(csv)
-endif()
-
-if(ARROW_COMPUTE)
-  add_subdirectory(compute)
 endif()
 
 if(ARROW_SUBSTRAIT)

--- a/cpp/src/arrow/array/CMakeLists.txt
+++ b/cpp/src/arrow/array/CMakeLists.txt
@@ -16,11 +16,7 @@
 # under the License.
 
 add_arrow_test(concatenate_test)
-
-if(ARROW_COMPUTE)
-  # This unit test uses compute code
-  add_arrow_test(diff_test)
-endif()
+add_arrow_test(diff_test)
 
 # Headers: top level
 arrow_install_all_headers("arrow/array")

--- a/cpp/src/arrow/compute/CMakeLists.txt
+++ b/cpp/src/arrow/compute/CMakeLists.txt
@@ -26,8 +26,22 @@ arrow_add_pkg_config("arrow-compute")
 # Unit tests
 #
 
+# As of 2023-02-28, the following kernels are always present:
+#  - array_filter
+#  - array_take
+#  - cast
+#  - dictionary_encode
+#  - drop_null
+#  - filter
+#  - indices_nonzero
+#  - take
+#  - unique
+#  - value_counts
+#
+# Tests that use additional kernels should specify REQUIRE_ALL_KERNELS to avoid
+# being included in minimal builds. See: GH-34388
 function(ADD_ARROW_COMPUTE_TEST REL_TEST_NAME)
-  set(options)
+  set(options REQUIRE_ALL_KERNELS)
   set(one_value_args PREFIX)
   set(multi_value_args LABELS)
   cmake_parse_arguments(ARG
@@ -35,6 +49,10 @@ function(ADD_ARROW_COMPUTE_TEST REL_TEST_NAME)
                         "${one_value_args}"
                         "${multi_value_args}"
                         ${ARGN})
+
+  if(ARG_REQUIRE_ALL_KERNELS AND (NOT ARROW_COMPUTE))
+    return()
+  endif()
 
   if(ARG_PREFIX)
     set(PREFIX ${ARG_PREFIX})

--- a/cpp/src/arrow/compute/CMakeLists.txt
+++ b/cpp/src/arrow/compute/CMakeLists.txt
@@ -26,7 +26,7 @@ arrow_add_pkg_config("arrow-compute")
 # Unit tests
 #
 
-# As of 2023-02-28, the following kernels are always present:
+# The following kernels are always present:
 #  - array_filter
 #  - array_take
 #  - cast

--- a/cpp/src/arrow/compute/exec/CMakeLists.txt
+++ b/cpp/src/arrow/compute/exec/CMakeLists.txt
@@ -18,6 +18,7 @@
 arrow_install_all_headers("arrow/compute/exec")
 
 add_arrow_compute_test(expression_test
+                       REQUIRE_ALL_KERNELS
                        PREFIX
                        "arrow-compute"
                        SOURCES
@@ -25,6 +26,7 @@ add_arrow_compute_test(expression_test
                        subtree_test.cc)
 
 add_arrow_compute_test(plan_test
+                       REQUIRE_ALL_KERNELS
                        PREFIX
                        "arrow-compute"
                        SOURCES
@@ -32,12 +34,14 @@ add_arrow_compute_test(plan_test
                        test_nodes_test.cc
                        test_nodes.cc)
 add_arrow_compute_test(fetch_node_test
+                       REQUIRE_ALL_KERNELS
                        PREFIX
                        "arrow-compute"
                        SOURCES
                        fetch_node_test.cc
                        test_nodes.cc)
 add_arrow_compute_test(hash_join_node_test
+                       REQUIRE_ALL_KERNELS
                        PREFIX
                        "arrow-compute"
                        SOURCES
@@ -45,6 +49,7 @@ add_arrow_compute_test(hash_join_node_test
                        bloom_filter_test.cc
                        key_hash_test.cc)
 add_arrow_compute_test(asof_join_node_test
+                       REQUIRE_ALL_KERNELS
                        PREFIX
                        "arrow-compute"
                        SOURCES
@@ -52,7 +57,7 @@ add_arrow_compute_test(asof_join_node_test
                        test_nodes.cc)
 add_arrow_compute_test(tpch_node_test PREFIX "arrow-compute")
 add_arrow_compute_test(union_node_test PREFIX "arrow-compute")
-add_arrow_compute_test(groupby_test PREFIX "arrow-compute")
+add_arrow_compute_test(groupby_test REQUIRE_ALL_KERNELS PREFIX "arrow-compute")
 add_arrow_compute_test(util_test
                        PREFIX
                        "arrow-compute"

--- a/cpp/src/arrow/compute/kernels/CMakeLists.txt
+++ b/cpp/src/arrow/compute/kernels/CMakeLists.txt
@@ -18,10 +18,11 @@
 # ----------------------------------------------------------------------
 # Scalar kernels
 
+add_arrow_compute_test(scalar_cast_test SOURCES scalar_cast_test.cc test_util.cc)
+
 add_arrow_compute_test(scalar_type_test
                        SOURCES
                        scalar_boolean_test.cc
-                       scalar_cast_test.cc
                        scalar_nested_test.cc
                        scalar_string_test.cc
                        test_util.cc)

--- a/cpp/src/arrow/compute/kernels/CMakeLists.txt
+++ b/cpp/src/arrow/compute/kernels/CMakeLists.txt
@@ -21,17 +21,27 @@
 add_arrow_compute_test(scalar_cast_test SOURCES scalar_cast_test.cc test_util.cc)
 
 add_arrow_compute_test(scalar_type_test
+                       REQUIRE_ALL_KERNELS
                        SOURCES
                        scalar_boolean_test.cc
                        scalar_nested_test.cc
                        scalar_string_test.cc
                        test_util.cc)
 
-add_arrow_compute_test(scalar_if_else_test SOURCES scalar_if_else_test.cc test_util.cc)
+add_arrow_compute_test(scalar_if_else_test
+                       REQUIRE_ALL_KERNELS
+                       SOURCES
+                       scalar_if_else_test.cc
+                       test_util.cc)
 
-add_arrow_compute_test(scalar_temporal_test SOURCES scalar_temporal_test.cc test_util.cc)
+add_arrow_compute_test(scalar_temporal_test
+                       REQUIRE_ALL_KERNELS
+                       SOURCES
+                       scalar_temporal_test.cc
+                       test_util.cc)
 
 add_arrow_compute_test(scalar_math_test
+                       REQUIRE_ALL_KERNELS
                        SOURCES
                        scalar_arithmetic_test.cc
                        scalar_compare_test.cc
@@ -39,6 +49,7 @@ add_arrow_compute_test(scalar_math_test
                        test_util.cc)
 
 add_arrow_compute_test(scalar_utility_test
+                       REQUIRE_ALL_KERNELS
                        SOURCES
                        scalar_random_test.cc
                        scalar_set_lookup_test.cc
@@ -60,6 +71,7 @@ add_arrow_benchmark(scalar_temporal_benchmark PREFIX "arrow-compute")
 # Vector kernels
 
 add_arrow_compute_test(vector_test
+                       REQUIRE_ALL_KERNELS
                        SOURCES
                        vector_cumulative_ops_test.cc
                        vector_hash_test.cc
@@ -83,6 +95,7 @@ add_arrow_benchmark(vector_selection_benchmark PREFIX "arrow-compute")
 # Aggregates
 
 add_arrow_compute_test(aggregate_test
+                       REQUIRE_ALL_KERNELS
                        SOURCES
                        aggregate_test.cc
                        hash_aggregate_test.cc

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -761,16 +761,6 @@ struct ArithmeticFloatingPointFunction : public ArithmeticFunction {
   }
 };
 
-// A scalar kernel that ignores (assumed all-null) inputs and returns null.
-Status NullToNullExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
-  return Status::OK();
-}
-
-void AddNullExec(ScalarFunction* func) {
-  std::vector<InputType> input_types(func->arity().num_args, InputType(Type::NA));
-  DCHECK_OK(func->AddKernel(std::move(input_types), OutputType(null()), NullToNullExec));
-}
-
 template <typename Op, typename FunctionImpl = ArithmeticFunction>
 std::shared_ptr<ScalarFunction> MakeArithmeticFunction(std::string name,
                                                        FunctionDoc doc) {

--- a/cpp/src/arrow/compute/kernels/util_internal.cc
+++ b/cpp/src/arrow/compute/kernels/util_internal.cc
@@ -20,6 +20,7 @@
 #include <cstdint>
 
 #include "arrow/array/data.h"
+#include "arrow/compute/function.h"
 #include "arrow/type.h"
 #include "arrow/util/checked_cast.h"
 
@@ -29,6 +30,14 @@ using internal::checked_cast;
 
 namespace compute {
 namespace internal {
+
+namespace {
+
+Status NullToNullExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
+  return Status::OK();
+}
+
+}  // namespace
 
 ExecValue GetExecValue(const Datum& value) {
   ExecValue result;
@@ -47,6 +56,11 @@ int64_t GetTrueCount(const ArraySpan& mask) {
   } else {
     return CountSetBits(mask.buffers[1].data, mask.offset, mask.length);
   }
+}
+
+void AddNullExec(ScalarFunction* func) {
+  std::vector<InputType> input_types(func->arity().num_args, InputType(Type::NA));
+  DCHECK_OK(func->AddKernel(std::move(input_types), OutputType(null()), NullToNullExec));
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/compute/kernels/util_internal.h
+++ b/cpp/src/arrow/compute/kernels/util_internal.h
@@ -35,6 +35,9 @@ using internal::CountAndSetBits;
 using internal::CountSetBits;
 
 namespace compute {
+
+class ScalarFunction;
+
 namespace internal {
 
 template <typename T>
@@ -135,6 +138,22 @@ int64_t CopyNonNullValues(const ChunkedArray& arr, T* out) {
 ExecValue GetExecValue(const Datum& value);
 
 int64_t GetTrueCount(const ArraySpan& mask);
+
+template <template <typename... Args> class KernelGenerator, typename Op>
+ArrayKernelExec GenerateArithmeticFloatingPoint(detail::GetTypeId get_id) {
+  switch (get_id.id) {
+    case Type::FLOAT:
+      return KernelGenerator<FloatType, FloatType, Op>::Exec;
+    case Type::DOUBLE:
+      return KernelGenerator<DoubleType, DoubleType, Op>::Exec;
+    default:
+      DCHECK(false);
+      return nullptr;
+  }
+}
+
+// A scalar kernel that ignores (assumed all-null) inputs and returns null.
+void AddNullExec(ScalarFunction* func);
 
 }  // namespace internal
 }  // namespace compute

--- a/cpp/src/arrow/compute/registry.cc
+++ b/cpp/src/arrow/compute/registry.cc
@@ -27,6 +27,7 @@
 #include "arrow/compute/function_internal.h"
 #include "arrow/compute/registry_internal.h"
 #include "arrow/status.h"
+#include "arrow/util/config.h"  // For ARROW_COMPUTE
 #include "arrow/util/logging.h"
 
 namespace arrow {
@@ -272,10 +273,21 @@ namespace internal {
 static std::unique_ptr<FunctionRegistry> CreateBuiltInRegistry() {
   auto registry = FunctionRegistry::Make();
 
+  // Register core kernels
+  RegisterScalarCast(registry.get());
+  RegisterVectorHash(registry.get());
+  RegisterVectorSelection(registry.get());
+
+  RegisterScalarOptions(registry.get());
+  RegisterVectorOptions(registry.get());
+  RegisterAggregateOptions(registry.get());
+
+#ifdef ARROW_COMPUTE
+  // Register additional kernels
+
   // Scalar functions
   RegisterScalarArithmetic(registry.get());
   RegisterScalarBoolean(registry.get());
-  RegisterScalarCast(registry.get());
   RegisterScalarComparison(registry.get());
   RegisterScalarIfElse(registry.get());
   RegisterScalarNested(registry.get());
@@ -288,20 +300,14 @@ static std::unique_ptr<FunctionRegistry> CreateBuiltInRegistry() {
   RegisterScalarTemporalUnary(registry.get());
   RegisterScalarValidity(registry.get());
 
-  RegisterScalarOptions(registry.get());
-
   // Vector functions
   RegisterVectorArraySort(registry.get());
   RegisterVectorCumulativeSum(registry.get());
-  RegisterVectorHash(registry.get());
   RegisterVectorNested(registry.get());
   RegisterVectorRank(registry.get());
   RegisterVectorReplace(registry.get());
   RegisterVectorSelectK(registry.get());
-  RegisterVectorSelection(registry.get());
   RegisterVectorSort(registry.get());
-
-  RegisterVectorOptions(registry.get());
 
   // Aggregate functions
   RegisterHashAggregateBasic(registry.get());
@@ -310,8 +316,7 @@ static std::unique_ptr<FunctionRegistry> CreateBuiltInRegistry() {
   RegisterScalarAggregateQuantile(registry.get());
   RegisterScalarAggregateTDigest(registry.get());
   RegisterScalarAggregateVariance(registry.get());
-
-  RegisterAggregateOptions(registry.get());
+#endif
 
   return registry;
 }

--- a/cpp/src/arrow/csv/CMakeLists.txt
+++ b/cpp/src/arrow/csv/CMakeLists.txt
@@ -21,12 +21,8 @@ set(CSV_TEST_SRCS
     column_decoder_test.cc
     converter_test.cc
     parser_test.cc
-    reader_test.cc)
-
-# Writer depends on compute's cast functionality
-if(ARROW_COMPUTE)
-  list(APPEND CSV_TEST_SRCS writer_test.cc)
-endif()
+    reader_test.cc
+    writer_test.cc)
 
 add_arrow_test(csv-test SOURCES ${CSV_TEST_SRCS})
 

--- a/cpp/src/arrow/csv/api.h
+++ b/cpp/src/arrow/csv/api.h
@@ -19,9 +19,4 @@
 
 #include "arrow/csv/options.h"
 #include "arrow/csv/reader.h"
-
-// The writer depends on compute module for casting.
-#include "arrow/util/config.h"  // for ARROW_COMPUTE definition
-#ifdef ARROW_COMPUTE
 #include "arrow/csv/writer.h"
-#endif

--- a/cpp/src/arrow/public_api_test.cc
+++ b/cpp/src/arrow/public_api_test.cc
@@ -22,13 +22,10 @@
 
 // Include various "api.h" entrypoints and check they don't leak internal symbols
 
-#include "arrow/api.h"      // IWYU pragma: keep
-#include "arrow/io/api.h"   // IWYU pragma: keep
-#include "arrow/ipc/api.h"  // IWYU pragma: keep
-
-#ifdef ARROW_COMPUTE
+#include "arrow/api.h"          // IWYU pragma: keep
 #include "arrow/compute/api.h"  // IWYU pragma: keep
-#endif
+#include "arrow/io/api.h"       // IWYU pragma: keep
+#include "arrow/ipc/api.h"      // IWYU pragma: keep
 
 #ifdef ARROW_CSV
 #include "arrow/csv/api.h"  // IWYU pragma: keep

--- a/cpp/src/arrow/testing/generator.cc
+++ b/cpp/src/arrow/testing/generator.cc
@@ -289,7 +289,6 @@ class DataGeneratorImpl : public DataGenerator,
     return batches;
   }
 
-#ifdef ARROW_COMPUTE
   Result<::arrow::compute::ExecBatch> ExecBatch(int64_t num_rows) override {
     std::vector<Datum> values;
     values.reserve(generators_.size());
@@ -318,7 +317,6 @@ class DataGeneratorImpl : public DataGenerator,
         "exec_batch_source",
         ::arrow::compute::ExecBatchSourceNodeOptions(schema_, std::move(batches)));
   }
-#endif
 
   Result<std::shared_ptr<::arrow::Table>> Table(int64_t rows_per_chunk,
                                                 int num_chunks = 1) override {
@@ -365,7 +363,7 @@ class GTestDataGeneratorImpl : public GTestDataGenerator {
                          target_->RecordBatches(rows_per_batch, num_batches));
     return batches;
   }
-#ifdef ARROW_COMPUTE
+
   ::arrow::compute::ExecBatch ExecBatch(int64_t num_rows) override {
     EXPECT_OK_AND_ASSIGN(auto batch, target_->ExecBatch(num_rows));
     return batch;
@@ -381,7 +379,7 @@ class GTestDataGeneratorImpl : public GTestDataGenerator {
                          target_->SourceNode(rows_per_batch, num_batches));
     return source_node;
   }
-#endif
+
   std::shared_ptr<::arrow::Table> Table(int64_t rows_per_chunk, int num_chunks) override {
     EXPECT_OK_AND_ASSIGN(auto table, target_->Table(rows_per_chunk, num_chunks));
     return table;

--- a/cpp/src/arrow/testing/generator.h
+++ b/cpp/src/arrow/testing/generator.h
@@ -252,13 +252,13 @@ class ARROW_TESTING_EXPORT GTestDataGenerator {
   virtual std::shared_ptr<::arrow::RecordBatch> RecordBatch(int64_t num_rows) = 0;
   virtual std::vector<std::shared_ptr<::arrow::RecordBatch>> RecordBatches(
       int64_t rows_per_batch, int num_batches) = 0;
-#ifdef ARROW_COMPUTE
+
   virtual ::arrow::compute::ExecBatch ExecBatch(int64_t num_rows) = 0;
   virtual std::vector<::arrow::compute::ExecBatch> ExecBatches(int64_t rows_per_batch,
                                                                int num_batches) = 0;
   virtual ::arrow::compute::Declaration SourceNode(int64_t rows_per_batch,
                                                    int num_batches) = 0;
-#endif
+
   virtual std::shared_ptr<::arrow::Table> Table(int64_t rows_per_chunk,
                                                 int num_chunks = 1) = 0;
   virtual std::shared_ptr<::arrow::Schema> Schema() = 0;
@@ -270,13 +270,13 @@ class ARROW_TESTING_EXPORT DataGenerator {
   virtual Result<std::shared_ptr<::arrow::RecordBatch>> RecordBatch(int64_t num_rows) = 0;
   virtual Result<std::vector<std::shared_ptr<::arrow::RecordBatch>>> RecordBatches(
       int64_t rows_per_batch, int num_batches) = 0;
-#ifdef ARROW_COMPUTE
+
   virtual Result<::arrow::compute::ExecBatch> ExecBatch(int64_t num_rows) = 0;
   virtual Result<std::vector<::arrow::compute::ExecBatch>> ExecBatches(
       int64_t rows_per_batch, int num_batches) = 0;
   virtual Result<::arrow::compute::Declaration> SourceNode(int64_t rows_per_batch,
                                                            int num_batches) = 0;
-#endif
+
   virtual Result<std::shared_ptr<::arrow::Table>> Table(int64_t rows_per_chunk,
                                                         int num_chunks = 1) = 0;
   virtual std::shared_ptr<::arrow::Schema> Schema() = 0;


### PR DESCRIPTION
This includes the core compute machinery in libarrow by default - in addition to all cast kernels and several other kernels that are either dependencies of `cast` (`take`) or utilized in libarrow/libparquet (`unique`, `filter`). The remaining kernels won't be built/registered unless `ARROW_COMPUTE=ON` (note that this would slightly change the option's meaning, as currently, nothing in arrow/compute is built unless it's set).

Initially this was more substantial as the original goal was to build the extra kernels as a shared library (suggested in the orginal issue). After some discussion in the issue thread, I opted not to do that - primarily because I can't personally see the utility of a separate lib here, even ignoring the complexity it introduces. However, there may be a good reason that simply hasn't occured to me.
* Closes: #34388