### PR TITLE
GH-34296: [C++][CI] Force appveyor builds to use conda-forge and ignore defaults channel

### DIFF
--- a/ci/appveyor-cpp-setup.bat
+++ b/ci/appveyor-cpp-setup.bat
@@ -63,6 +63,9 @@ if "%ARROW_BUILD_GANDIVA%" == "ON" (
 )
 @rem Install pre-built "toolchain" packages for faster builds
 set CONDA_PACKAGES=%CONDA_PACKAGES% --file=ci\conda_env_cpp.txt
+@rem Force conda to use conda-forge
+conda config --add channels conda-forge
+conda config --remove channels defaults
 @rem Arrow conda environment
 mamba create -n arrow -q -y -c conda-forge ^
   --file=ci\conda_env_python.txt ^


### PR DESCRIPTION
For some reason (potentially related to https://github.com/mamba-org/mamba/issues/656 or maybe just the default conda behavior) it appears that specifying `-c conda-forge` is not sufficient as conda will still check the defaults channel.

Lately it seems the defaults channel has introduced some incompatibility that leads to a deadlock or hang during solve.

This PR disables defaults completely which seems to avoid the hang.
* Closes: #34296