### PR TITLE
GH-32512: [Docs][R] Update conda install command

### DIFF
--- a/r/vignettes/install.Rmd
+++ b/r/vignettes/install.Rmd
@@ -105,7 +105,10 @@ Similarly, if you use `conda` to manage your R environment, you can get the
 latest official release of the R package including libarrow via:
 
 ```shell
-conda install -c conda-forge --strict-channel-priority r-arrow
+# Using the --strict-channel-priority flag on `conda install` causes very long
+# solve times, so we add it directly to the config
+conda config --set channel_priority strict
+conda install -c conda-forge r-arrow
 ```
 
 ### R source package with libarrow binary


### PR DESCRIPTION
As shown in #34297 using the cli flag is not enough to avoid influence of the default channel causing extremely long solve times or conflicts.
* Closes: #32512