### PR TITLE
GH-34301: [CI][Packaging][RPM][arm64] Use closer.lua to download KEYS

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow-apt-source/Rakefile
+++ b/dev/tasks/linux-packages/apache-arrow-apt-source/Rakefile
@@ -36,7 +36,7 @@ class ApacheArrowAptSourcePackageTask < PackageTask
     file @archive_name do
       rm_rf(@archive_base_name)
       mkdir(@archive_base_name)
-      download("https://downloads.apache.org/arrow/KEYS",
+      download("https://www.apache.org/dyn/closer.lua?action=download&filename=arrow/KEYS",
                "#{@archive_base_name}/KEYS")
       sh("tar", "czf", @archive_name, @archive_base_name)
       rm_rf(@archive_base_name)

--- a/dev/tasks/linux-packages/apache-arrow-release/Rakefile
+++ b/dev/tasks/linux-packages/apache-arrow-release/Rakefile
@@ -41,7 +41,7 @@ class ApacheArrowReleasePackageTask < PackageTask
       rm_rf(@archive_base_name)
       mkdir(@archive_base_name)
       keys_path = "#{@archive_base_name}/KEYS"
-      download("https://downloads.apache.org/arrow/KEYS",
+      download("https://www.apache.org/dyn/closer.lua?action=download&filename=arrow/KEYS",
                keys_path)
       keys = File.read(keys_path)
       File.open(keys_path, "w") do |keys_file|


### PR DESCRIPTION
### Rationale for this change

https://downloads.apache.org/ may not be stable on Travis CI.

### What changes are included in this PR?

Use https://www.apache.org/dyn/closer.lua to use suitable mirror.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #34301