### PR TITLE
GH-34303: [CI][Packaging][deb] Use system Meson on Debian GNU/Linux bookworm

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow/apt/debian-bookworm/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/debian-bookworm/Dockerfile
@@ -68,6 +68,7 @@ RUN \
     libzstd-dev \
     llvm-dev \
     lsb-release \
+    meson \
     ninja-build \
     nlohmann-json3-dev \
     pkg-config \
@@ -81,6 +82,4 @@ RUN \
   if apt list | grep '^nvidia-cuda-toolkit/'; then \
     apt install -y -V ${quiet} nvidia-cuda-toolkit; \
   fi && \
-  pip3 install --upgrade meson && \
-  ln -s /usr/local/bin/meson /usr/bin/ && \
   apt clean


### PR DESCRIPTION
### Rationale for this change

"pip3 install meson" isn't accepted on Debian GNU/Linux bookworm.

### What changes are included in this PR?

System Meson is recent engouh.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #34303