### PR TITLE
GH-34306: [CI][Packaging][RPM] Don't install utf8proc-devel on CentOS Stream 8

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow/yum/centos-8-stream/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/yum/centos-8-stream/Dockerfile
@@ -59,7 +59,6 @@ RUN \
     snappy-devel \
     tar \
     thrift-devel \
-    utf8proc-devel \
     vala \
     zlib-devel && \
   dnf clean ${quiet} all


### PR DESCRIPTION
### Rationale for this change

It seems that it's removed recently.

### What changes are included in this PR?

This pull request just stops installing it because it's not used.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #34306
* Closes: #34306