### PR TITLE
GH-34308: [CI][C++] Use str("") to reset std::stringstream for old g++

### DIFF
--- a/cpp/src/arrow/array/array_run_end_test.cc
+++ b/cpp/src/arrow/array/array_run_end_test.cc
@@ -577,7 +577,7 @@ TEST_P(TestRunEndEncodedArray, Printing) {
 
   ASSERT_OK_AND_ASSIGN(auto string_array,
                        RunEndEncodedArray::Make(30, run_end_values, string_values));
-  ss = {};
+  ss.str("");
   ASSERT_OK(PrettyPrint(*string_array, {}, &ss));
   ASSERT_EQ(ss.str(),
             "\n"
@@ -595,7 +595,7 @@ TEST_P(TestRunEndEncodedArray, Printing) {
             "  ]");
 
   auto sliced_array = string_array->Slice(15, 6);
-  ss = {};
+  ss.str("");
   ASSERT_OK(PrettyPrint(*sliced_array, {}, &ss));
   ASSERT_EQ(ss.str(),
             "\n"
@@ -616,7 +616,7 @@ TEST_P(TestRunEndEncodedArray, Printing) {
                        RunEndEncodedArray::Make(0, ArrayFromJSON(run_end_type, "[]"),
                                                 ArrayFromJSON(binary(), "[]")));
 
-  ss = {};
+  ss.str("");
   ASSERT_OK(PrettyPrint(*empty_array, {}, &ss));
   ASSERT_EQ(ss.str(),
             "\n"


### PR DESCRIPTION
### Rationale for this change

Error log:

    FAILED: src/arrow/CMakeFiles/arrow-array-test.dir/array/array_run_end_test.cc.o
    g++ ... -std=c++17 -c /arrow/cpp/src/arrow/array/array_run_end_test.cc
    /arrow/cpp/src/arrow/array/array_run_end_test.cc: In member
    function 'virtual void
    arrow::{anonymous}::TestRunEndEncodedArray_Printing_Test::TestBody()':
    /arrow/cpp/src/arrow/array/array_run_end_test.cc:580:9: error:
    converting to 'std::__cxx11::basic_stringstream<char>' from
    initializer list would use explicit constructor
    'std::__cxx11::basic_stringstream<
       _CharT,
       _Traits,
       _Alloc
     >::basic_stringstream(std::ios_base::openmode)
     [with _CharT = char;
           _Traits = std::char_traits<char>;
           _Alloc = std::allocator<char>;
            std::ios_base::openmode = std::_Ios_Openmode]' [-Werror]
       ss = {};
             ^
    ...
    cc1plus: all warnings being treated as errors

### What changes are included in this PR?

This pull request uses `str("")` instead of `= {}` like other tests.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #34308