### PR TITLE
MINOR:[CI] Fix automatic issue labeling.

### DIFF
--- a/.github/workflows/issue_bot.yml
+++ b/.github/workflows/issue_bot.yml
@@ -46,6 +46,7 @@ jobs:
             let repo_labels = await github.rest.issues.listLabelsForRepo({
               "owner": context.repo.owner,
               "repo": context.repo.repo,
+              "per_page": 100,
             });
 
             // this removes non-existent labels


### PR DESCRIPTION
### Rationale for this change

The issue labeling was failing because it only got the first 30 label (we have 56) everything on page 2 was regarded as "non-existent' throwing an error.
  
### What changes are included in this PR?

Raise the number of items per page to 100 ensuring that all labels are fetched.
