### PR TITLE
GH-34324: [CI][C++] Specify set element type explicitly for old g++

### DIFF
--- a/cpp/src/arrow/util/rows_to_batches_test.cc
+++ b/cpp/src/arrow/util/rows_to_batches_test.cc
@@ -82,7 +82,7 @@ TEST(RowsToBatches, StructAccessor) {
 
   // Test accessor that returns by value instead of using `std::reference_wrapper`
   auto accessor_by_value = [](const TestStruct& s) -> Result<std::set<int>> {
-    return std::set(std::begin(s.values), std::end(s.values));
+    return std::set<int>(std::begin(s.values), std::end(s.values));
   };
   auto batches_by_value =
       RowsToBatches(kTestSchema, data, IntConvertor, accessor_by_value).ValueOrDie();


### PR DESCRIPTION
### Rationale for this change

`std::set(iterator, iterator)` doesn't work with old g++ on Ubuntu 18.04:

    FAILED: src/arrow/util/CMakeFiles/arrow-utility-test.dir/rows_to_batches_test.cc.o
    c++  ... -std=c++1z ... -c /arrow/cpp/src/arrow/util/rows_to_batches_test.cc
    /arrow/cpp/src/arrow/util/rows_to_batches_test.cc: In lambda function:
    /arrow/cpp/src/arrow/util/rows_to_batches_test.cc:85:61: error: class template argument deduction failed:
         return std::set(std::begin(s.values), std::end(s.values));
                                                                 ^
    /arrow/cpp/src/arrow/util/rows_to_batches_test.cc:85:61: error: no matching function for call to 'set(std::vector<int>::const_iterator, std::vector<int>::const_iterator)'
    In file included from /usr/include/c++/7/set:61:0,
                     from googletest_ep-prefix/include/gtest/internal/gtest-internal.h:60,
                     from googletest_ep-prefix/include/gtest/gtest.h:62,
                     from /arrow/cpp/src/arrow/util/rows_to_batches_test.cc:20:
    /usr/include/c++/7/bits/stl_set.h:261:2: note: candidate: template<class _Key, class _Compare, class _Alloc, class _InputIterator> set(_InputIterator, _InputIterator, const _Alloc&)-> std::set<_Key, _Compare, _Alloc>
      set(_InputIterator __first, _InputIterator __last,
      ^~~
    /usr/include/c++/7/bits/stl_set.h:261:2: note:   template argument deduction/substitution failed:
    /arrow/cpp/src/arrow/util/rows_to_batches_test.cc:85:61: note:   candidate expects 3 arguments, 2 provided
         return std::set(std::begin(s.values), std::end(s.values));
                                                                 ^
    In file included from /usr/include/c++/7/set:61:0,
                     from googletest_ep-prefix/include/gtest/internal/gtest-internal.h:60,
                     from googletest_ep-prefix/include/gtest/gtest.h:62,
                     from /arrow/cpp/src/arrow/util/rows_to_batches_test.cc:20:
    /usr/include/c++/7/bits/stl_set.h:255:7: note: candidate: template<class _Key, class _Compare, class _Alloc> set(std::initializer_list<_Tp>, const allocator_type&)-> std::set<_Key, _Compare, _Alloc>
           set(initializer_list<value_type> __l, const allocator_type& __a)
           ^~~
    ...

### What changes are included in this PR?

Specify type explicitly.

### Are these changes tested?

Yes.

### Are there any user-facing changes?
No.
* Closes: #34324