### PR TITLE
MINOR: [R][Docs] Minor documentation fixes

### DIFF
--- a/r/R/dataset-factory.R
+++ b/r/R/dataset-factory.R
@@ -205,7 +205,7 @@ handle_partitioning <- function(partitioning, path_and_fs, hive_style) {
 #'     (but if you're providing the file list, you can filter invalid files
 #'     yourself).
 #' @param ... Additional format-specific options, passed to
-#' `FileFormat$create()`. For CSV options, note that you can specify them either
+#' [`FileFormat$create()`][FileFormat]. For CSV options, note that you can specify them either
 #' with the Arrow C++ library naming ("delimiter", "quoting", etc.) or the
 #' `readr`-style naming used in [read_csv_arrow()] ("delim", "quote", etc.).
 #' Not all `readr` options are currently supported; please file an issue if you

--- a/r/R/dataset-format.R
+++ b/r/R/dataset-format.R
@@ -33,7 +33,7 @@
 #'   * "tsv", equivalent to passing `format = "text", delimiter = "\t"`
 #' * `...`: Additional format-specific options
 #'
-#'   `format = "parquet"``:
+#'   `format = "parquet"`:
 #'   * `dict_columns`: Names of columns which should be read as dictionaries.
 #'   * Any Parquet options from [FragmentScanOptions].
 #'
@@ -470,7 +470,7 @@ csv_file_format_read_opts <- function(schema = NULL, ...) {
 #'   * "csv"/"text", aliases for the same format.
 #' * `...`: Additional format-specific options
 #'
-#'   `format = "parquet"``:
+#'   `format = "parquet"`:
 #'   * `use_buffered_stream`: Read files through buffered input streams rather than
 #'                            loading entire row groups at once. This may be enabled
 #'                            to reduce memory overhead. Disabled by default.

--- a/r/man/FileFormat.Rd
+++ b/r/man/FileFormat.Rd
@@ -25,7 +25,7 @@ delimiter for text files
 }
 \item \code{...}: Additional format-specific options
 
-`format = "parquet"``:
+\code{format = "parquet"}:
 \itemize{
 \item \code{dict_columns}: Names of columns which should be read as dictionaries.
 \item Any Parquet options from \link{FragmentScanOptions}.

--- a/r/man/FragmentScanOptions.Rd
+++ b/r/man/FragmentScanOptions.Rd
@@ -20,7 +20,7 @@ operation.
 }
 \item \code{...}: Additional format-specific options
 
-`format = "parquet"``:
+\code{format = "parquet"}:
 \itemize{
 \item \code{use_buffered_stream}: Read files through buffered input streams rather than
 loading entire row groups at once. This may be enabled

--- a/r/man/dataset_factory.Rd
+++ b/r/man/dataset_factory.Rd
@@ -80,7 +80,7 @@ yourself).
 }}
 
 \item{...}{Additional format-specific options, passed to
-\code{FileFormat$create()}. For CSV options, note that you can specify them either
+\code{\link[=FileFormat]{FileFormat$create()}}. For CSV options, note that you can specify them either
 with the Arrow C++ library naming ("delimiter", "quoting", etc.) or the
 \code{readr}-style naming used in \code{\link[=read_csv_arrow]{read_csv_arrow()}} ("delim", "quote", etc.).
 Not all \code{readr} options are currently supported; please file an issue if you

--- a/r/man/read_json_arrow.Rd
+++ b/r/man/read_json_arrow.Rd
@@ -63,16 +63,15 @@ When \code{as_data_frame = TRUE}, Arrow types are further converted to R types.
 \dontshow{if (arrow_with_json()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 tf <- tempfile()
 on.exit(unlink(tf))
-json <- '
-  { "hello": 3.5, "world": false, "yo": "thing" }
-  { "hello": 3.25, "world": null }
-  { "hello": 0.0, "world": true, "yo": null }
-'
-writeLines(json, tf, useBytes = TRUE)
+writeLines('
+    { "hello": 3.5, "world": false, "yo": "thing" }
+    { "hello": 3.25, "world": null }
+    { "hello": 0.0, "world": true, "yo": null }
+  ', tf, useBytes = TRUE)
 
 read_json_arrow(tf)
 
 # Read directly from strings with `I()`
-read_json_arrow(I(json))
+read_json_arrow(I(c('{"x": 1, "y": 2}', '{"x": 3, "y": 4}')))
 \dontshow{\}) # examplesIf}
 }


### PR DESCRIPTION
### Rationale for this change

Make small improvements that I noticed while reading the documentation.

### What changes are included in this PR?

- Fix typo of inline code (``` `format = "parquet"`` ``` to `` `format = "parquet"` ``)
- Link `FileFormat$create()` to `FileFormat`
- Updating Rd file I forgot to update in #33968

### Are these changes tested?

Only the documentation is changed, and the generated Rd files are included in this PR.

### Are there any user-facing changes?

No.