### PR TITLE
GH-34309: [C++] Disable LTO for aws_lc and s2n-tls

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -4871,11 +4871,18 @@ macro(build_awssdk)
                         BUILD_BYPRODUCTS ${AWS_LC_STATIC_LIBRARY})
     add_dependencies(AWS::crypto aws_lc_ep)
 
+    set(S2N_TLS_C_FLAGS ${EP_C_FLAGS})
+    string(APPEND S2N_TLS_C_FLAGS " -Wno-error=overlength-strings -Wno-error=pedantic")
+    # Link time optimization is causing trouble like #34349
+    string(REPLACE "-flto=auto" "" S2N_TLS_C_FLAGS "${S2N_TLS_C_FLAGS}")
+    string(REPLACE "-ffat-lto-objects" "" S2N_TLS_C_FLAGS "${S2N_TLS_C_FLAGS}")
+
     set(S2N_TLS_CMAKE_ARGS ${AWSSDK_COMMON_CMAKE_ARGS})
     list(APPEND
          S2N_TLS_CMAKE_ARGS
          -DS2N_INTERN_LIBCRYPTO=ON # internalize libcrypto to avoid name conflict with openssl
-         -DCMAKE_PREFIX_PATH=${AWS_LC_PREFIX}) # path to find crypto provided by aws-lc
+         -DCMAKE_PREFIX_PATH=${AWS_LC_PREFIX} # path to find crypto provided by aws-lc
+         -DCMAKE_C_FLAGS=${S2N_TLS_C_FLAGS}) 
 
     externalproject_add(s2n_tls_ep
                         ${EP_COMMON_OPTIONS}
@@ -4885,9 +4892,6 @@ macro(build_awssdk)
                         BUILD_BYPRODUCTS ${S2N_TLS_STATIC_LIBRARY}
                         DEPENDS aws_lc_ep)
     add_dependencies(AWS::s2n-tls s2n_tls_ep)
-    set_property(TARGET AWS::s2n-tls
-                 APPEND
-                 PROPERTY INTERFACE_LINK_LIBRARIES OpenSSL::Crypto OpenSSL::SSL)
   endif()
 
   externalproject_add(aws_c_cal_ep

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -4882,7 +4882,7 @@ macro(build_awssdk)
          S2N_TLS_CMAKE_ARGS
          -DS2N_INTERN_LIBCRYPTO=ON # internalize libcrypto to avoid name conflict with openssl
          -DCMAKE_PREFIX_PATH=${AWS_LC_PREFIX} # path to find crypto provided by aws-lc
-         -DCMAKE_C_FLAGS=${S2N_TLS_C_FLAGS}) 
+         -DCMAKE_C_FLAGS=${S2N_TLS_C_FLAGS})
 
     externalproject_add(s2n_tls_ep
                         ${EP_COMMON_OPTIONS}

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -4872,7 +4872,6 @@ macro(build_awssdk)
     add_dependencies(AWS::crypto aws_lc_ep)
 
     set(S2N_TLS_C_FLAGS ${EP_C_FLAGS})
-    string(APPEND S2N_TLS_C_FLAGS " -Wno-error=overlength-strings -Wno-error=pedantic")
     # Link time optimization is causing trouble like #34349
     string(REPLACE "-flto=auto" "" S2N_TLS_C_FLAGS "${S2N_TLS_C_FLAGS}")
     string(REPLACE "-ffat-lto-objects" "" S2N_TLS_C_FLAGS "${S2N_TLS_C_FLAGS}")

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -4886,8 +4886,8 @@ macro(build_awssdk)
                         DEPENDS aws_lc_ep)
     add_dependencies(AWS::s2n-tls s2n_tls_ep)
     set_property(TARGET AWS::s2n-tls
-                  APPEND
-                  PROPERTY INTERFACE_LINK_LIBRARIES OpenSSL::Crypto)
+                 APPEND
+                 PROPERTY INTERFACE_LINK_LIBRARIES OpenSSL::Crypto)
   endif()
 
   externalproject_add(aws_c_cal_ep

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -4885,6 +4885,9 @@ macro(build_awssdk)
                         BUILD_BYPRODUCTS ${S2N_TLS_STATIC_LIBRARY}
                         DEPENDS aws_lc_ep)
     add_dependencies(AWS::s2n-tls s2n_tls_ep)
+    set_property(TARGET AWS::s2n-tls
+                  APPEND
+                  PROPERTY INTERFACE_LINK_LIBRARIES OpenSSL::Crypto)
   endif()
 
   externalproject_add(aws_c_cal_ep

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -4887,7 +4887,7 @@ macro(build_awssdk)
     add_dependencies(AWS::s2n-tls s2n_tls_ep)
     set_property(TARGET AWS::s2n-tls
                  APPEND
-                 PROPERTY INTERFACE_LINK_LIBRARIES OpenSSL::Crypto)
+                 PROPERTY INTERFACE_LINK_LIBRARIES OpenSSL::Crypto OpenSSL::SSL)
   endif()
 
   externalproject_add(aws_c_cal_ep

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -4855,6 +4855,9 @@ macro(build_awssdk)
   if("s2n-tls" IN_LIST _AWSSDK_LIBS)
     set(AWS_LC_C_FLAGS ${EP_C_FLAGS})
     string(APPEND AWS_LC_C_FLAGS " -Wno-error=overlength-strings -Wno-error=pedantic")
+    # Link time optimization is causing trouble like #34349
+    string(REPLACE "-flto=auto" "" AWS_LC_C_FLAGS "${AWS_LC_C_FLAGS}")
+    string(REPLACE "-ffat-lto-objects" "" AWS_LC_C_FLAGS "${AWS_LC_C_FLAGS}")
 
     set(AWS_LC_CMAKE_ARGS ${AWSSDK_COMMON_CMAKE_ARGS})
     list(APPEND AWS_LC_CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${AWS_LC_PREFIX}

--- a/dev/tasks/linux-packages/apache-arrow/apt/debian-bookworm/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/debian-bookworm/Dockerfile
@@ -38,7 +38,6 @@ RUN \
   apt update ${quiet} && \
   apt install -y -V ${quiet} \
     build-essential \
-    ccache \
     clang \
     cmake \
     debhelper \

--- a/dev/tasks/linux-packages/apache-arrow/apt/debian-bullseye/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/debian-bullseye/Dockerfile
@@ -34,7 +34,6 @@ RUN \
   apt update ${quiet} && \
   apt install -y -V ${quiet} \
     build-essential \
-    ccache \
     clang \
     cmake \
     debhelper \

--- a/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-bionic/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-bionic/Dockerfile
@@ -32,7 +32,6 @@ RUN \
   apt update ${quiet} && \
   apt install -y -V ${quiet} \
     build-essential \
-    ccache \
     clang-10 \
     cmake \
     devscripts \

--- a/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-focal/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-focal/Dockerfile
@@ -32,7 +32,6 @@ RUN \
   apt update ${quiet} && \
   apt install -y -V ${quiet} \
     build-essential \
-    ccache \
     clang \
     cmake \
     debhelper \

--- a/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-jammy/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-jammy/Dockerfile
@@ -32,7 +32,6 @@ RUN \
   apt update ${quiet} && \
   apt install -y -V ${quiet} \
     build-essential \
-    ccache \
     clang \
     cmake \
     debhelper \

--- a/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-kinetic/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-kinetic/Dockerfile
@@ -32,7 +32,6 @@ RUN \
   apt update ${quiet} && \
   apt install -y -V ${quiet} \
     build-essential \
-    ccache \
     clang \
     clang-tools \
     cmake \

--- a/dev/tasks/linux-packages/apache-arrow/debian/rules
+++ b/dev/tasks/linux-packages/apache-arrow/debian/rules
@@ -96,7 +96,7 @@ override_dh_auto_install:
 
 	df -h
 	du -hsc cpp_build/release/* || :
-	dh_auto_install				\
+	: dh_auto_install				\
 	  --sourcedirectory=cpp			\
 	  --builddirectory=cpp_build
 	# Remove built files to reduce disk usage

--- a/dev/tasks/linux-packages/apache-arrow/debian/rules
+++ b/dev/tasks/linux-packages/apache-arrow/debian/rules
@@ -96,6 +96,7 @@ override_dh_auto_install:
 
 	df -h
 	du -hsc cpp_build/release/* || :
+	du -hsc cpp_build/src/arrow/CMakeFiles/arrow_objlib.dir/**/*.o || :
 	rm -rf cpp_build/*_ep-prefix/src/*.tar.gz
 	rm -rf cpp_build/*_ep-prefix/src/*_ep-build/
 	df -h

--- a/dev/tasks/linux-packages/apache-arrow/debian/rules
+++ b/dev/tasks/linux-packages/apache-arrow/debian/rules
@@ -94,6 +94,8 @@ override_dh_auto_install:
 	  --builddirectory=c_glib_build		\
 	  --buildsystem=meson+ninja
 
+	df -h
+	du -hsc cpp_build/release/* || :
 	dh_auto_install				\
 	  --sourcedirectory=cpp			\
 	  --builddirectory=cpp_build

--- a/dev/tasks/linux-packages/apache-arrow/debian/rules
+++ b/dev/tasks/linux-packages/apache-arrow/debian/rules
@@ -21,7 +21,7 @@ override_dh_auto_configure:
 	  ARROW_CUDA=OFF;					\
 	  ARROW_PLASMA=OFF;					\
 	fi;							\
-	if [ $$(arch) = "x86_64" ]; then				\
+	if [ $$(arch) = "x86_64" ]; then			\
 	  ARROW_FLIGHT=ON;					\
 	  ARROW_FLIGHT_SQL=ON;					\
 	else							\
@@ -96,7 +96,10 @@ override_dh_auto_install:
 
 	df -h
 	du -hsc cpp_build/release/* || :
-	: dh_auto_install				\
+	rm -rf cpp_build/*_ep-prefix/src/*.tar.gz
+	rm -rf cpp_build/*_ep-prefix/src/*_ep-build/
+	df -h
+	: dh_auto_install			\
 	  --sourcedirectory=cpp			\
 	  --builddirectory=cpp_build
 	# Remove built files to reduce disk usage

--- a/dev/tasks/linux-packages/apache-arrow/debian/rules
+++ b/dev/tasks/linux-packages/apache-arrow/debian/rules
@@ -94,11 +94,6 @@ override_dh_auto_install:
 	  --builddirectory=c_glib_build		\
 	  --buildsystem=meson+ninja
 
-	df -h
-	du -hsc cpp_build/release/* || :
-	du -hsc cpp_build/src/arrow/CMakeFiles/arrow_objlib.dir/**/*.o || :
-	rm -rf cpp_build/*_ep-prefix/src/*.tar.gz
-	df -h
 	dh_auto_install				\
 	  --sourcedirectory=cpp			\
 	  --builddirectory=cpp_build

--- a/dev/tasks/linux-packages/apache-arrow/debian/rules
+++ b/dev/tasks/linux-packages/apache-arrow/debian/rules
@@ -98,7 +98,6 @@ override_dh_auto_install:
 	du -hsc cpp_build/release/* || :
 	du -hsc cpp_build/src/arrow/CMakeFiles/arrow_objlib.dir/**/*.o || :
 	rm -rf cpp_build/*_ep-prefix/src/*.tar.gz
-	rm -rf cpp_build/*_ep-prefix/src/*_ep-build/
 	df -h
 	dh_auto_install				\
 	  --sourcedirectory=cpp			\

--- a/dev/tasks/linux-packages/apache-arrow/debian/rules
+++ b/dev/tasks/linux-packages/apache-arrow/debian/rules
@@ -100,7 +100,7 @@ override_dh_auto_install:
 	rm -rf cpp_build/*_ep-prefix/src/*.tar.gz
 	rm -rf cpp_build/*_ep-prefix/src/*_ep-build/
 	df -h
-	: dh_auto_install			\
+	dh_auto_install				\
 	  --sourcedirectory=cpp			\
 	  --builddirectory=cpp_build
 	# Remove built files to reduce disk usage

--- a/dev/tasks/linux-packages/apt/build.sh
+++ b/dev/tasks/linux-packages/apt/build.sh
@@ -92,11 +92,13 @@ fi
 : ${DEB_BUILD_OPTIONS:="parallel=$(nproc)"}
 # DEB_BUILD_OPTIONS="${DEB_BUILD_OPTIONS} noopt"
 export DEB_BUILD_OPTIONS
+df -h
 if [ "${DEBUG:-no}" = "yes" ]; then
   run debuild "${debuild_options[@]}" "${dpkg_buildpackage_options[@]}"
 else
   run debuild "${debuild_options[@]}" "${dpkg_buildpackage_options[@]}" > /dev/null
 fi
+df -h
 if which ccache > /dev/null 2>&1; then
   ccache --show-stats --verbose || :
 fi

--- a/dev/tasks/linux-packages/github.linux.amd64.yml
+++ b/dev/tasks/linux-packages/github.linux.amd64.yml
@@ -30,12 +30,8 @@ jobs:
       - name: Free up disk space
         run: |
           df -h
-          sudo du -hsc /* || :
-          sudo du -hsc /usr/* || :
-          sudo du -hsc /usr/local/* || :
-          sudo du -hsc /opt/* || :
-          sudo du -hsc /opt/hostedtoolcache/* || :
-          sudo du -hsc /mnt/* || :
+          # 5.3GB
+          sudo rm -rf /opt/hostedtoolcache/CodeQL || :
           df -h
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/dev/tasks/linux-packages/github.linux.amd64.yml
+++ b/dev/tasks/linux-packages/github.linux.amd64.yml
@@ -30,19 +30,16 @@ jobs:
       - name: Free up disk space
         run: |
           df -h
+          sudo du -hsc /*
+          sudo du -hsc /usr/local/*
           sudo du -hsc /opt/*
-          sudo rm -rf /opt/ghc
+          sudo du -hsc /opt/hostedtoolcache/*
+          sudo du -hsc /mnt/*
           df -h
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1'
-      - name: Cache ccache
-        uses: actions/cache@v2
-        with:
-          path: arrow/dev/tasks/linux-packages/apache-arrow/{{ task_namespace }}/build/{{ target }}/ccache
-          key: linux-{{ task_namespace }}-ccache-{{ target }}-{{ "${{ hashFiles('arrow/cpp/**') }}" }}
-          restore-keys: linux-{{ task_namespace }}-ccache-{{ target }}-
       - name: Build
         run: |
           set -e

--- a/dev/tasks/linux-packages/github.linux.amd64.yml
+++ b/dev/tasks/linux-packages/github.linux.amd64.yml
@@ -32,6 +32,8 @@ jobs:
           df -h
           # 5.3GB
           sudo rm -rf /opt/hostedtoolcache/CodeQL || :
+          # 1.4GB
+          sudo rm -rf /opt/hostedtoolcache/go || :
           df -h
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/dev/tasks/linux-packages/github.linux.amd64.yml
+++ b/dev/tasks/linux-packages/github.linux.amd64.yml
@@ -27,6 +27,12 @@ jobs:
       {{ macros.github_checkout_arrow()|indent }}
       {{ macros.github_login_dockerhub()|indent }}
 
+      - name: Free up disk space
+        run: |
+          df -h
+          sudo du -hsc /opt/*
+          sudo rm -rf /opt/ghc
+          df -h
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/dev/tasks/linux-packages/github.linux.amd64.yml
+++ b/dev/tasks/linux-packages/github.linux.amd64.yml
@@ -30,11 +30,12 @@ jobs:
       - name: Free up disk space
         run: |
           df -h
-          sudo du -hsc /*
-          sudo du -hsc /usr/local/*
-          sudo du -hsc /opt/*
-          sudo du -hsc /opt/hostedtoolcache/*
-          sudo du -hsc /mnt/*
+          sudo du -hsc /* || :
+          sudo du -hsc /usr/* || :
+          sudo du -hsc /usr/local/* || :
+          sudo du -hsc /opt/* || :
+          sudo du -hsc /opt/hostedtoolcache/* || :
+          sudo du -hsc /mnt/* || :
           df -h
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/dev/tasks/linux-packages/yum/build.sh
+++ b/dev/tasks/linux-packages/yum/build.sh
@@ -129,6 +129,8 @@ run cp \
     /host/tmp/${PACKAGE}.spec \
     rpmbuild/SPECS/
 
+df -h
+
 run cat <<BUILD > build.sh
 #!/usr/bin/env bash
 
@@ -157,6 +159,8 @@ else
     run ./build.sh > /dev/null
   fi
 fi
+
+df -h
 
 if which ccache > /dev/null 2>&1; then
   ccache --show-stats --verbose || :


### PR DESCRIPTION
When built with LTO, s2n-tls can't properly intern aws_lc symbols, which may cause undefined references.


* Closes: #34309