### PR TITLE
GH-32954: [Java][FlightRPC] Remove FlightTestUtil#getStartedServer and bind to port 0 directly

### DIFF
--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/FlightTestUtil.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/FlightTestUtil.java
@@ -18,18 +18,14 @@
 package org.apache.arrow.flight;
 
 import java.io.File;
-import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.net.ServerSocket;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Random;
-import java.util.function.Function;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.function.Executable;
 
@@ -43,45 +39,6 @@ public class FlightTestUtil {
   public static final String LOCALHOST = "localhost";
   public static final String TEST_DATA_ENV_VAR = "ARROW_TEST_DATA";
   public static final String TEST_DATA_PROPERTY = "arrow.test.dataRoot";
-
-  /**
-   * Returns a a FlightServer (actually anything that is startable)
-   * that has been started bound to a random port.
-   */
-  public static <T> T getStartedServer(Function<Location, T> newServerFromLocation) throws IOException {
-    IOException lastThrown = null;
-    T server = null;
-    for (int x = 0; x < 3; x++) {
-      int port;
-      try (final ServerSocket dynamicPortSocket = new ServerSocket(0)) {
-        port = dynamicPortSocket.getLocalPort();
-      } catch (SecurityException | IOException e) {
-        throw new RuntimeException("Unable to create a ServerSocket instance. ", e);
-      }
-
-      final Location location = Location.forGrpcInsecure(LOCALHOST, port);
-      lastThrown = null;
-      try {
-        server = newServerFromLocation.apply(location);
-        try {
-          server.getClass().getMethod("start").invoke(server);
-        } catch (NoSuchMethodException | IllegalAccessException e) {
-          throw new IllegalArgumentException("Couldn't call start method on object.", e);
-        }
-        break;
-      } catch (InvocationTargetException e) {
-        if (e.getTargetException() instanceof IOException) {
-          lastThrown = (IOException) e.getTargetException();
-        } else {
-          throw (RuntimeException) e.getTargetException();
-        }
-      }
-    }
-    if (lastThrown != null) {
-      throw lastThrown;
-    }
-    return server;
-  }
 
   static Path getTestDataRoot() {
     String path = System.getenv(TEST_DATA_ENV_VAR);

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestAuth.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestAuth.java
@@ -17,6 +17,9 @@
 
 package org.apache.arrow.flight;
 
+import static org.apache.arrow.flight.FlightTestUtil.LOCALHOST;
+import static org.apache.arrow.flight.Location.forGrpcInsecure;
+
 import java.util.Iterator;
 import java.util.Optional;
 
@@ -34,10 +37,9 @@ public class TestAuth {
   public void noMessages() throws Exception {
     Assertions.assertThrows(RuntimeException.class, () -> {
       try (final BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE);
-           final FlightServer s = FlightTestUtil
-               .getStartedServer(
-                   location -> FlightServer.builder(allocator, location, new NoOpFlightProducer()).authHandler(
-                       new OneshotAuthHandler()).build());
+           final FlightServer s = FlightServer.builder(allocator, forGrpcInsecure(LOCALHOST, 0),
+               new NoOpFlightProducer()).authHandler(
+               new OneshotAuthHandler()).build().start();
            final FlightClient client = FlightClient.builder(allocator, s.getLocation()).build()) {
         client.authenticate(new ClientAuthHandler() {
           @Override
@@ -58,10 +60,9 @@ public class TestAuth {
   public void clientError() throws Exception {
     Assertions.assertThrows(RuntimeException.class, () -> {
       try (final BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE);
-           final FlightServer s = FlightTestUtil
-               .getStartedServer(
-                   location -> FlightServer.builder(allocator, location, new NoOpFlightProducer()).authHandler(
-                       new OneshotAuthHandler()).build());
+           final FlightServer s = FlightServer.builder(allocator, forGrpcInsecure(LOCALHOST, 0),
+               new NoOpFlightProducer()).authHandler(
+               new OneshotAuthHandler()).build().start();
            final FlightClient client = FlightClient.builder(allocator, s.getLocation()).build()) {
         client.authenticate(new ClientAuthHandler() {
           @Override

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestBackPressure.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestBackPressure.java
@@ -88,13 +88,12 @@ public class TestBackPressure {
                                                   serverConstructor) throws Exception {
     try (
         final BufferAllocator a = new RootAllocator(Long.MAX_VALUE);
-        final PerformanceTestServer server = serverConstructor.apply(a).apply(forGrpcInsecure(LOCALHOST, 0))
+        final PerformanceTestServer server = serverConstructor.apply(a).apply(forGrpcInsecure(LOCALHOST, 0)).start();
+        final FlightClient client = FlightClient.builder(a, server.getLocation()).build()
     ) {
-      server.start();
-      try (final FlightClient client = FlightClient.builder(a, server.getLocation()).build();
-           FlightStream fs1 = client.getStream(client.getInfo(
-                   TestPerf.getPerfFlightDescriptor(110L * BATCH_SIZE, BATCH_SIZE, 1))
-               .getEndpoints().get(0).getTicket())) {
+      try (FlightStream fs1 = client.getStream(client.getInfo(
+          TestPerf.getPerfFlightDescriptor(110L * BATCH_SIZE, BATCH_SIZE, 1))
+          .getEndpoints().get(0).getTicket())) {
         consume(fs1, 10);
 
         // stop consuming fs1 but make sure we can consume a large amount of fs2.

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestBasicOperation.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestBasicOperation.java
@@ -17,6 +17,9 @@
 
 package org.apache.arrow.flight;
 
+import static org.apache.arrow.flight.FlightTestUtil.LOCALHOST;
+import static org.apache.arrow.flight.Location.forGrpcInsecure;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -113,7 +116,7 @@ public class TestBasicOperation {
                 new Ticket(new byte[10]), Location.forGrpcDomainSocket("/tmp/test.sock")),
             new FlightEndpoint(
                 new Ticket(new byte[10]), Location.forGrpcDomainSocket("/tmp/test.sock"),
-                Location.forGrpcInsecure("localhost", 50051))
+                forGrpcInsecure("localhost", 50051))
         ), 200, 500);
 
     Assertions.assertEquals(info1, FlightInfo.deserialize(info1.serialize()));
@@ -318,10 +321,7 @@ public class TestBasicOperation {
     try (
         BufferAllocator a = new RootAllocator(Long.MAX_VALUE);
         Producer producer = new Producer(a);
-        FlightServer s =
-            FlightTestUtil.getStartedServer(
-                (location) -> FlightServer.builder(a, location, producer).build()
-            )) {
+        FlightServer s = FlightServer.builder(a, forGrpcInsecure(LOCALHOST, 0), producer).build().start()) {
 
       try (
           FlightClient c = FlightClient.builder(a, s.getLocation()).build()

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestCallOptions.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestCallOptions.java
@@ -17,6 +17,9 @@
 
 package org.apache.arrow.flight;
 
+import static org.apache.arrow.flight.FlightTestUtil.LOCALHOST;
+import static org.apache.arrow.flight.Location.forGrpcInsecure;
+
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
@@ -101,8 +104,7 @@ public class TestCallOptions {
     try (
         BufferAllocator a = new RootAllocator(Long.MAX_VALUE);
         HeaderProducer producer = new HeaderProducer();
-        FlightServer s =
-            FlightTestUtil.getStartedServer((location) -> FlightServer.builder(a, location, producer).build());
+        FlightServer s = FlightServer.builder(a, forGrpcInsecure(LOCALHOST, 0), producer).build().start();
         FlightClient client = FlightClient.builder(a, s.getLocation()).build()) {
       Assertions.assertFalse(client.doAction(new Action(""), new HeaderCallOption(headers)).hasNext());
       final CallHeaders incomingHeaders = producer.headers();
@@ -122,8 +124,7 @@ public class TestCallOptions {
     try (
         BufferAllocator a = new RootAllocator(Long.MAX_VALUE);
         Producer producer = new Producer();
-        FlightServer s =
-            FlightTestUtil.getStartedServer((location) -> FlightServer.builder(a, location, producer).build());
+        FlightServer s = FlightServer.builder(a, forGrpcInsecure(LOCALHOST, 0), producer).build().start();
         FlightClient client = FlightClient.builder(a, s.getLocation()).build()) {
       testFn.accept(client);
     } catch (InterruptedException | IOException e) {

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestLargeMessage.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestLargeMessage.java
@@ -17,6 +17,9 @@
 
 package org.apache.arrow.flight;
 
+import static org.apache.arrow.flight.FlightTestUtil.LOCALHOST;
+import static org.apache.arrow.flight.Location.forGrpcInsecure;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
@@ -40,8 +43,7 @@ public class TestLargeMessage {
   public void getLargeMessage() throws Exception {
     try (final BufferAllocator a = new RootAllocator(Long.MAX_VALUE);
          final Producer producer = new Producer(a);
-         final FlightServer s =
-             FlightTestUtil.getStartedServer((location) -> FlightServer.builder(a, location, producer).build())) {
+         final FlightServer s = FlightServer.builder(a, forGrpcInsecure(LOCALHOST, 0), producer).build().start()) {
 
       try (FlightClient client = FlightClient.builder(a, s.getLocation()).build()) {
         try (FlightStream stream = client.getStream(new Ticket(new byte[]{}));
@@ -68,10 +70,7 @@ public class TestLargeMessage {
   public void putLargeMessage() throws Exception {
     try (final BufferAllocator a = new RootAllocator(Long.MAX_VALUE);
          final Producer producer = new Producer(a);
-         final FlightServer s =
-             FlightTestUtil.getStartedServer((location) -> FlightServer.builder(a, location, producer).build()
-             )) {
-
+         final FlightServer s = FlightServer.builder(a, forGrpcInsecure(LOCALHOST, 0), producer).build().start()) {
       try (FlightClient client = FlightClient.builder(a, s.getLocation()).build();
            BufferAllocator testAllocator = a.newChildAllocator("testcase", 0, Long.MAX_VALUE);
            VectorSchemaRoot root = generateData(testAllocator)) {

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestTls.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestTls.java
@@ -17,6 +17,9 @@
 
 package org.apache.arrow.flight;
 
+import static org.apache.arrow.flight.FlightTestUtil.LOCALHOST;
+import static org.apache.arrow.flight.Location.forGrpcInsecure;
+
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -107,17 +110,9 @@ public class TestTls {
     try (
         BufferAllocator a = new RootAllocator(Long.MAX_VALUE);
         Producer producer = new Producer();
-        FlightServer s =
-            FlightTestUtil.getStartedServer(
-                (location) -> {
-                  try {
-                    return FlightServer.builder(a, location, producer)
-                        .useTls(certKey.cert, certKey.key)
-                        .build();
-                  } catch (IOException e) {
-                    throw new RuntimeException(e);
-                  }
-                })) {
+        FlightServer s = FlightServer.builder(a, forGrpcInsecure(LOCALHOST, 0), producer)
+            .useTls(certKey.cert, certKey.key)
+            .build().start()) {
       final Builder builder = FlightClient.builder(a, Location.forGrpcTls(FlightTestUtil.LOCALHOST, s.getPort()));
       testFn.accept(builder);
     } catch (InterruptedException | IOException e) {

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/auth/TestBasicAuth.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/auth/TestBasicAuth.java
@@ -17,6 +17,9 @@
 
 package org.apache.arrow.flight.auth;
 
+import static org.apache.arrow.flight.FlightTestUtil.LOCALHOST;
+import static org.apache.arrow.flight.Location.forGrpcInsecure;
+
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -116,9 +119,8 @@ public class TestBasicAuth {
       }
     };
 
-    server = FlightTestUtil.getStartedServer((location) -> FlightServer.builder(
-        allocator,
-        location,
+    server = FlightServer.builder(
+        allocator, forGrpcInsecure(LOCALHOST, 0),
         new NoOpFlightProducer() {
           @Override
           public void listFlights(CallContext context, Criteria criteria,
@@ -146,7 +148,7 @@ public class TestBasicAuth {
               listener.completed();
             }
           }
-        }).authHandler(new BasicServerAuthHandler(validator)).build());
+        }).authHandler(new BasicServerAuthHandler(validator)).build().start();
     client = FlightClient.builder(allocator, server.getLocation()).build();
   }
 

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/auth2/TestBasicAuth2.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/auth2/TestBasicAuth2.java
@@ -17,6 +17,9 @@
 
 package org.apache.arrow.flight.auth2;
 
+import static org.apache.arrow.flight.FlightTestUtil.LOCALHOST;
+import static org.apache.arrow.flight.Location.forGrpcInsecure;
+
 import java.io.IOException;
 
 import org.apache.arrow.flight.CallStatus;
@@ -98,12 +101,11 @@ public class TestBasicAuth2 {
 
   private void startServerAndClient() throws IOException {
     final FlightProducer flightProducer = getFlightProducer();
-    this.server = FlightTestUtil.getStartedServer((location) -> FlightServer
-        .builder(allocator, location, flightProducer)
+    this.server = FlightServer
+        .builder(allocator, forGrpcInsecure(LOCALHOST, 0), flightProducer)
         .headerAuthenticator(new GeneratedBearerTokenAuthenticator(
             new BasicCallHeaderAuthenticator(this::validate)))
-        .build());
-
+        .build().start();
     this.client = FlightClient.builder(allocator, server.getLocation())
         .build();
   }

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/client/TestCookieHandling.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/client/TestCookieHandling.java
@@ -17,6 +17,9 @@
 
 package org.apache.arrow.flight.client;
 
+import static org.apache.arrow.flight.FlightTestUtil.LOCALHOST;
+import static org.apache.arrow.flight.Location.forGrpcInsecure;
+
 import java.io.IOException;
 
 import org.apache.arrow.flight.CallHeaders;
@@ -30,7 +33,6 @@ import org.apache.arrow.flight.FlightMethod;
 import org.apache.arrow.flight.FlightProducer;
 import org.apache.arrow.flight.FlightServer;
 import org.apache.arrow.flight.FlightServerMiddleware;
-import org.apache.arrow.flight.FlightTestUtil;
 import org.apache.arrow.flight.NoOpFlightProducer;
 import org.apache.arrow.flight.RequestContext;
 import org.apache.arrow.memory.BufferAllocator;
@@ -255,10 +257,10 @@ public class TestCookieHandling {
       }
     };
 
-    this.server = FlightTestUtil.getStartedServer((location) -> FlightServer
-            .builder(allocator, location, flightProducer)
-            .middleware(FlightServerMiddleware.Key.of("test"), new SetCookieHeaderInjector.Factory())
-            .build());
+    this.server = FlightServer
+        .builder(allocator, forGrpcInsecure(LOCALHOST, 0), flightProducer)
+        .middleware(FlightServerMiddleware.Key.of("test"), new SetCookieHeaderInjector.Factory())
+        .build().start();
 
     this.client = FlightClient.builder(allocator, server.getLocation())
             .intercept(testFactory)

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/perf/PerformanceTestServer.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/perf/PerformanceTestServer.java
@@ -86,7 +86,7 @@ public class PerformanceTestServer implements AutoCloseable {
   }
 
   public Location getLocation() {
-    return location;
+    return flightServer.getLocation();
   }
 
   public void start() throws IOException {

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/perf/PerformanceTestServer.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/perf/PerformanceTestServer.java
@@ -89,8 +89,9 @@ public class PerformanceTestServer implements AutoCloseable {
     return flightServer.getLocation();
   }
 
-  public void start() throws IOException {
+  public PerformanceTestServer start() throws IOException {
     flightServer.start();
+    return this;
   }
 
   @Override

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/perf/TestPerf.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/perf/TestPerf.java
@@ -31,6 +31,7 @@ import org.apache.arrow.flight.FlightClient;
 import org.apache.arrow.flight.FlightDescriptor;
 import org.apache.arrow.flight.FlightInfo;
 import org.apache.arrow.flight.FlightStream;
+import org.apache.arrow.flight.FlightTestUtil;
 import org.apache.arrow.flight.Ticket;
 import org.apache.arrow.flight.perf.impl.PerfOuterClass.Perf;
 import org.apache.arrow.memory.BufferAllocator;
@@ -89,36 +90,34 @@ public class TestPerf {
     for (int i = 0; i < numRuns; i++) {
       try (
           final BufferAllocator a = new RootAllocator(Long.MAX_VALUE);
-          final PerformanceTestServer server = new PerformanceTestServer(a, forGrpcInsecure(LOCALHOST, 0));
+          final PerformanceTestServer server = new PerformanceTestServer(a, forGrpcInsecure(LOCALHOST, 0)).start();
+          final FlightClient client = FlightClient.builder(a, server.getLocation()).build();
       ) {
-        server.start();
-        try (final FlightClient client = FlightClient.builder(a, server.getLocation()).build()) {
-          final FlightInfo info = client.getInfo(getPerfFlightDescriptor(50_000_000L, 4095, 2));
-          List<ListenableFuture<Result>> results = info.getEndpoints()
-              .stream()
-              .map(t -> new Consumer(client, t.getTicket()))
-              .map(t -> pool.submit(t))
-              .collect(Collectors.toList());
+        final FlightInfo info = client.getInfo(getPerfFlightDescriptor(50_000_000L, 4095, 2));
+        List<ListenableFuture<Result>> results = info.getEndpoints()
+            .stream()
+            .map(t -> new Consumer(client, t.getTicket()))
+            .map(t -> pool.submit(t))
+            .collect(Collectors.toList());
 
-          final Result r = Futures.whenAllSucceed(results).call(() -> {
-            Result res = new Result();
-            for (ListenableFuture<Result> f : results) {
-              res.add(f.get());
-            }
-            return res;
-          }, pool).get();
+        final Result r = Futures.whenAllSucceed(results).call(() -> {
+          Result res = new Result();
+          for (ListenableFuture<Result> f : results) {
+            res.add(f.get());
+          }
+          return res;
+        }, pool).get();
 
-          double seconds = r.nanos * 1.0d / 1000 / 1000 / 1000;
-          throughPuts[i] = (r.bytes * 1.0d / 1024 / 1024) / seconds;
-          System.out.println(String.format(
-              "Transferred %d records totaling %s bytes at %f MiB/s. %f record/s. %f batch/s.",
-              r.rows,
-              r.bytes,
-              throughPuts[i],
-              (r.rows * 1.0d) / seconds,
-              (r.batches * 1.0d) / seconds
-          ));
-        }
+        double seconds = r.nanos * 1.0d / 1000 / 1000 / 1000;
+        throughPuts[i] = (r.bytes * 1.0d / 1024 / 1024) / seconds;
+        System.out.println(String.format(
+            "Transferred %d records totaling %s bytes at %f MiB/s. %f record/s. %f batch/s.",
+            r.rows,
+            r.bytes,
+            throughPuts[i],
+            (r.rows * 1.0d) / seconds,
+            (r.batches * 1.0d) / seconds
+        ));
       }
     }
     pool.shutdown();

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/perf/TestPerf.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/perf/TestPerf.java
@@ -31,7 +31,6 @@ import org.apache.arrow.flight.FlightClient;
 import org.apache.arrow.flight.FlightDescriptor;
 import org.apache.arrow.flight.FlightInfo;
 import org.apache.arrow.flight.FlightStream;
-import org.apache.arrow.flight.FlightTestUtil;
 import org.apache.arrow.flight.Ticket;
 import org.apache.arrow.flight.perf.impl.PerfOuterClass.Perf;
 import org.apache.arrow.memory.BufferAllocator;


### PR DESCRIPTION
### Rationale for this change

Today, the `FlightServer` is created in `FlightTestUtil#getStartedServer`. All tests that need a server go through this function, but this is unnecessary since the server could directly be started on port 0 (the OS will assign a random port later).

### What changes are included in this PR?

All invocations of `FlightTestUtil#getStartedServer` have been removed, and the burden of generating a `Location` object for the server has been placed on the caller.

### Are these changes tested?

Existing tests impacted were run locally to make sure that there no regressions.

### Are there any user-facing changes?

There are no user facing changes. There are no breaking changes to the public API as well.

@lidavidm
* Closes: #32954