### PR TITLE
GH-34284: [Java][FlightRPC] Fixed issue with prepared statement getting sent twice

### DIFF
--- a/java/flight/flight-sql-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcFactory.java
+++ b/java/flight/flight-sql-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcFactory.java
@@ -95,7 +95,7 @@ public class ArrowFlightJdbcFactory implements AvaticaFactory {
     final Schema resultSetSchema = preparedStatement.getDataSetSchema();
     signature.columns.addAll(convertArrowFieldsToColumnMetaDataList(resultSetSchema.getFields()));
 
-    return new ArrowFlightPreparedStatement(
+    return ArrowFlightPreparedStatement.newPreparedStatement(
         flightConnection, preparedStatement, statementHandle,
         signature, resultType, resultSetConcurrency, resultSetHoldability);
   }

--- a/java/flight/flight-sql-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcFactory.java
+++ b/java/flight/flight-sql-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcFactory.java
@@ -17,12 +17,16 @@
 
 package org.apache.arrow.driver.jdbc;
 
+import static org.apache.arrow.driver.jdbc.utils.ConvertUtils.convertArrowFieldsToColumnMetaDataList;
+
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.Properties;
 import java.util.TimeZone;
 
+import org.apache.arrow.driver.jdbc.client.ArrowFlightSqlClientHandler;
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.calcite.avatica.AvaticaConnection;
 import org.apache.calcite.avatica.AvaticaFactory;
 import org.apache.calcite.avatica.AvaticaResultSetMetaData;
@@ -81,9 +85,19 @@ public class ArrowFlightJdbcFactory implements AvaticaFactory {
       final int resultType,
       final int resultSetConcurrency,
       final int resultSetHoldability) throws SQLException {
-    return ArrowFlightPreparedStatement.createNewPreparedStatement(
-        (ArrowFlightConnection) connection, statementHandle, signature,
-        resultType, resultSetConcurrency, resultSetHoldability);
+    final ArrowFlightConnection flightConnection = (ArrowFlightConnection) connection;
+    ArrowFlightSqlClientHandler.PreparedStatement preparedStatement =
+        flightConnection.getMeta().getPreparedStatement(statementHandle);
+
+    if (preparedStatement == null) {
+      preparedStatement = flightConnection.getClientHandler().prepare(signature.sql);
+    }
+    final Schema resultSetSchema = preparedStatement.getDataSetSchema();
+    signature.columns.addAll(convertArrowFieldsToColumnMetaDataList(resultSetSchema.getFields()));
+
+    return new ArrowFlightPreparedStatement(
+        flightConnection, preparedStatement, statementHandle,
+        signature, resultType, resultSetConcurrency, resultSetHoldability);
   }
 
   @Override

--- a/java/flight/flight-sql-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightPreparedStatement.java
+++ b/java/flight/flight-sql-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightPreparedStatement.java
@@ -81,12 +81,12 @@ public class ArrowFlightPreparedStatement extends AvaticaPreparedStatement
   }
 
   static ArrowFlightPreparedStatement newPreparedStatement(final ArrowFlightConnection connection,
-                                                           final ArrowFlightSqlClientHandler.PreparedStatement preparedStmt,
-                                                           final StatementHandle statementHandle,
-                                                           final Signature signature,
-                                                           final int resultSetType,
-                                                           final int resultSetConcurrency,
-                                                           final int resultSetHoldability) throws SQLException {
+      final ArrowFlightSqlClientHandler.PreparedStatement preparedStmt,
+      final StatementHandle statementHandle,
+      final Signature signature,
+      final int resultSetType,
+      final int resultSetConcurrency,
+      final int resultSetHoldability) throws SQLException {
     return new ArrowFlightPreparedStatement(
         connection, preparedStmt, statementHandle,
         signature, resultSetType, resultSetConcurrency, resultSetHoldability);

--- a/java/flight/flight-sql-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightPreparedStatement.java
+++ b/java/flight/flight-sql-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightPreparedStatement.java
@@ -39,12 +39,12 @@ public class ArrowFlightPreparedStatement extends AvaticaPreparedStatement
 
   private final ArrowFlightSqlClientHandler.PreparedStatement preparedStatement;
 
-  private ArrowFlightPreparedStatement(final ArrowFlightConnection connection,
-                                       final ArrowFlightSqlClientHandler.PreparedStatement preparedStatement,
-                                       final StatementHandle handle,
-                                       final Signature signature, final int resultSetType,
-                                       final int resultSetConcurrency,
-                                       final int resultSetHoldability)
+  public ArrowFlightPreparedStatement(final ArrowFlightConnection connection,
+                                      final ArrowFlightSqlClientHandler.PreparedStatement preparedStatement,
+                                      final StatementHandle handle,
+                                      final Signature signature, final int resultSetType,
+                                      final int resultSetConcurrency,
+                                      final int resultSetHoldability)
       throws SQLException {
     super(connection, handle, signature, resultSetType, resultSetConcurrency, resultSetHoldability);
     this.preparedStatement = Preconditions.checkNotNull(preparedStatement);

--- a/java/flight/flight-sql-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightPreparedStatement.java
+++ b/java/flight/flight-sql-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightPreparedStatement.java
@@ -39,12 +39,12 @@ public class ArrowFlightPreparedStatement extends AvaticaPreparedStatement
 
   private final ArrowFlightSqlClientHandler.PreparedStatement preparedStatement;
 
-  public ArrowFlightPreparedStatement(final ArrowFlightConnection connection,
-                                      final ArrowFlightSqlClientHandler.PreparedStatement preparedStatement,
-                                      final StatementHandle handle,
-                                      final Signature signature, final int resultSetType,
-                                      final int resultSetConcurrency,
-                                      final int resultSetHoldability)
+  private ArrowFlightPreparedStatement(final ArrowFlightConnection connection,
+                                       final ArrowFlightSqlClientHandler.PreparedStatement preparedStatement,
+                                       final StatementHandle handle,
+                                       final Signature signature, final int resultSetType,
+                                       final int resultSetConcurrency,
+                                       final int resultSetHoldability)
       throws SQLException {
     super(connection, handle, signature, resultSetType, resultSetConcurrency, resultSetHoldability);
     this.preparedStatement = Preconditions.checkNotNull(preparedStatement);
@@ -77,6 +77,18 @@ public class ArrowFlightPreparedStatement extends AvaticaPreparedStatement
 
     return new ArrowFlightPreparedStatement(
         connection, prepare, statementHandle,
+        signature, resultSetType, resultSetConcurrency, resultSetHoldability);
+  }
+
+  static ArrowFlightPreparedStatement newPreparedStatement(final ArrowFlightConnection connection,
+                                                           final ArrowFlightSqlClientHandler.PreparedStatement preparedStmt,
+                                                           final StatementHandle statementHandle,
+                                                           final Signature signature,
+                                                           final int resultSetType,
+                                                           final int resultSetConcurrency,
+                                                           final int resultSetHoldability) throws SQLException {
+    return new ArrowFlightPreparedStatement(
+        connection, preparedStmt, statementHandle,
         signature, resultSetType, resultSetConcurrency, resultSetHoldability);
   }
 

--- a/java/flight/flight-sql-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightPreparedStatementTest.java
+++ b/java/flight/flight-sql-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightPreparedStatementTest.java
@@ -76,9 +76,9 @@ public class ArrowFlightPreparedStatementTest {
   public void testPreparedStatementExecutionOnce() throws SQLException {
     final PreparedStatement statement = connection.prepareStatement(CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD);
     // Expect that there is one entry in the map -- {prepared statement action type, invocation count}.
-    assertEquals(PRODUCER.actionTypeCounter.size(), 1);
+    assertEquals(PRODUCER.getActionTypeCounter().size(), 1);
     // Expect that the prepared statement was executed exactly once.
-    assertEquals(PRODUCER.actionTypeCounter.get(FlightSqlUtils.FLIGHT_SQL_CREATE_PREPARED_STATEMENT.getType()), 1);
+    assertEquals(PRODUCER.getActionTypeCounter().get(FlightSqlUtils.FLIGHT_SQL_CREATE_PREPARED_STATEMENT.getType()), 1);
     statement.close();
   }
 

--- a/java/flight/flight-sql-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightPreparedStatementTest.java
+++ b/java/flight/flight-sql-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightPreparedStatementTest.java
@@ -27,7 +27,9 @@ import java.sql.SQLException;
 
 import org.apache.arrow.driver.jdbc.utils.CoreMockedSqlProducers;
 import org.apache.arrow.driver.jdbc.utils.MockFlightSqlProducer;
+import org.apache.arrow.flight.sql.FlightSqlUtils;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -56,6 +58,11 @@ public class ArrowFlightPreparedStatementTest {
     connection.close();
   }
 
+  @Before
+  public void before() {
+    PRODUCER.clearActionTypeCounter();
+  }
+
   @Test
   public void testSimpleQueryNoParameterBinding() throws SQLException {
     final String query = CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD;
@@ -63,6 +70,16 @@ public class ArrowFlightPreparedStatementTest {
          final ResultSet resultSet = preparedStatement.executeQuery()) {
       CoreMockedSqlProducers.assertLegacyRegularSqlResultSet(resultSet, collector);
     }
+  }
+
+  @Test
+  public void testPreparedStatementExecutionOnce() throws SQLException {
+    final PreparedStatement statement = connection.prepareStatement(CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD);
+    // Expect that there is one entry in the map -- {prepared statement action type, invocation count}.
+    assertEquals(PRODUCER.actionTypeCounter.size(), 1);
+    // Expect that the prepared statement was executed exactly once.
+    assertEquals(PRODUCER.actionTypeCounter.get(FlightSqlUtils.FLIGHT_SQL_CREATE_PREPARED_STATEMENT.getType()), 1);
+    statement.close();
   }
 
   @Test

--- a/java/flight/flight-sql-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/utils/MockFlightSqlProducer.java
+++ b/java/flight/flight-sql-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/utils/MockFlightSqlProducer.java
@@ -75,7 +75,6 @@ import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.util.Preconditions;
-import org.apache.arrow.util.VisibleForTesting;
 import org.apache.arrow.vector.ipc.WriteChannel;
 import org.apache.arrow.vector.ipc.message.MessageSerializer;
 import org.apache.arrow.vector.types.pojo.Schema;
@@ -515,12 +514,10 @@ public final class MockFlightSqlProducer implements FlightSqlProducer {
   /**
    * Clear the `actionTypeCounter` map and restore to its default state. Intended to be used in tests.
    */
-  @VisibleForTesting
   public void clearActionTypeCounter() {
     actionTypeCounter.clear();
   }
 
-  @VisibleForTesting
   public Map<String, Integer> getActionTypeCounter() {
     return actionTypeCounter;
   }

--- a/java/flight/flight-sql-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/utils/MockFlightSqlProducer.java
+++ b/java/flight/flight-sql-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/utils/MockFlightSqlProducer.java
@@ -39,6 +39,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
 
+import org.apache.arrow.flight.Action;
 import org.apache.arrow.flight.CallStatus;
 import org.apache.arrow.flight.Criteria;
 import org.apache.arrow.flight.FlightDescriptor;
@@ -74,6 +75,7 @@ import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.util.Preconditions;
+import org.apache.arrow.util.VisibleForTesting;
 import org.apache.arrow.vector.ipc.WriteChannel;
 import org.apache.arrow.vector.ipc.message.MessageSerializer;
 import org.apache.arrow.vector.types.pojo.Schema;
@@ -97,6 +99,8 @@ public final class MockFlightSqlProducer implements FlightSqlProducer {
       updateResultProviders =
       new HashMap<>();
   private SqlInfoBuilder sqlInfoBuilder = new SqlInfoBuilder();
+
+  private final Map<String, Integer> actionTypeCounter = new HashMap<>();
 
   private static FlightInfo getFightInfoExportedAndImportedKeys(final Message message,
                                                                 final FlightDescriptor descriptor) {
@@ -501,6 +505,26 @@ public final class MockFlightSqlProducer implements FlightSqlProducer {
     // TODO Implement this method.
     throw CallStatus.UNIMPLEMENTED.toRuntimeException();
   }
+
+  @Override
+  public void doAction(CallContext context, Action action, StreamListener<Result> listener) {
+    FlightSqlProducer.super.doAction(context, action, listener);
+    actionTypeCounter.put(action.getType(), actionTypeCounter.getOrDefault(action.getType(), 0) + 1);
+  }
+
+  /**
+   * Clear the `actionTypeCounter` map and restore to its default state. Intended to be used in tests.
+   */
+  @VisibleForTesting
+  public void clearActionTypeCounter() {
+    actionTypeCounter.clear();
+  }
+
+  @VisibleForTesting
+  public Map<String, Integer> getActionTypeCounter() {
+    return actionTypeCounter;
+  }
+
 
   private void getStreamCatalogFunctions(final Message ticket,
                                          final ServerStreamListener serverStreamListener) {

--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightSqlProducer.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightSqlProducer.java
@@ -48,9 +48,7 @@ import static org.apache.arrow.vector.types.Types.MinorType.VARCHAR;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.apache.arrow.flight.Action;
 import org.apache.arrow.flight.ActionType;
@@ -76,7 +74,6 @@ import org.apache.arrow.flight.sql.impl.FlightSql.CommandStatementQuery;
 import org.apache.arrow.flight.sql.impl.FlightSql.CommandStatementUpdate;
 import org.apache.arrow.flight.sql.impl.FlightSql.DoPutUpdateResult;
 import org.apache.arrow.flight.sql.impl.FlightSql.TicketStatementQuery;
-import org.apache.arrow.util.VisibleForTesting;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.UnionMode;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -93,8 +90,6 @@ import com.google.protobuf.InvalidProtocolBufferException;
  * API to Implement an Arrow Flight SQL producer.
  */
 public interface FlightSqlProducer extends FlightProducer, AutoCloseable {
-
-  Map<String, Integer> actionTypeCounter = new HashMap<>();
   /**
    * Depending on the provided command, method either:
    * 1. Return information about a SQL query, or
@@ -314,7 +309,6 @@ public interface FlightSqlProducer extends FlightProducer, AutoCloseable {
   @Override
   default void doAction(CallContext context, Action action, StreamListener<Result> listener) {
     final String actionType = action.getType();
-    actionTypeCounter.put(actionType, actionTypeCounter.getOrDefault(actionType, 0) + 1);
 
     if (actionType.equals(FlightSqlUtils.FLIGHT_SQL_BEGIN_SAVEPOINT.getType())) {
       final ActionBeginSavepointRequest request =
@@ -398,14 +392,6 @@ public interface FlightSqlProducer extends FlightProducer, AutoCloseable {
    */
   default void cancelQuery(FlightInfo info, CallContext context, StreamListener<CancelResult> listener) {
     listener.onError(CallStatus.UNIMPLEMENTED.toRuntimeException());
-  }
-
-  /**
-   * Clear the `actionTypeCounter` map and restore to its default state. Intended to be used in tests.
-   */
-  @VisibleForTesting
-  default void clearActionTypeCounter() {
-    actionTypeCounter.clear();
   }
 
   /**

--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightSqlProducer.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightSqlProducer.java
@@ -48,7 +48,9 @@ import static org.apache.arrow.vector.types.Types.MinorType.VARCHAR;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.arrow.flight.Action;
 import org.apache.arrow.flight.ActionType;
@@ -74,6 +76,7 @@ import org.apache.arrow.flight.sql.impl.FlightSql.CommandStatementQuery;
 import org.apache.arrow.flight.sql.impl.FlightSql.CommandStatementUpdate;
 import org.apache.arrow.flight.sql.impl.FlightSql.DoPutUpdateResult;
 import org.apache.arrow.flight.sql.impl.FlightSql.TicketStatementQuery;
+import org.apache.arrow.util.VisibleForTesting;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.UnionMode;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -90,6 +93,8 @@ import com.google.protobuf.InvalidProtocolBufferException;
  * API to Implement an Arrow Flight SQL producer.
  */
 public interface FlightSqlProducer extends FlightProducer, AutoCloseable {
+
+  Map<String, Integer> actionTypeCounter = new HashMap<>();
   /**
    * Depending on the provided command, method either:
    * 1. Return information about a SQL query, or
@@ -309,6 +314,7 @@ public interface FlightSqlProducer extends FlightProducer, AutoCloseable {
   @Override
   default void doAction(CallContext context, Action action, StreamListener<Result> listener) {
     final String actionType = action.getType();
+    actionTypeCounter.put(actionType, actionTypeCounter.getOrDefault(actionType, 0) + 1);
 
     if (actionType.equals(FlightSqlUtils.FLIGHT_SQL_BEGIN_SAVEPOINT.getType())) {
       final ActionBeginSavepointRequest request =
@@ -392,6 +398,14 @@ public interface FlightSqlProducer extends FlightProducer, AutoCloseable {
    */
   default void cancelQuery(FlightInfo info, CallContext context, StreamListener<CancelResult> listener) {
     listener.onError(CallStatus.UNIMPLEMENTED.toRuntimeException());
+  }
+
+  /**
+   * Clear the `actionTypeCounter` map and restore to its default state. Intended to be used in tests.
+   */
+  @VisibleForTesting
+  default void clearActionTypeCounter() {
+    actionTypeCounter.clear();
   }
 
   /**


### PR DESCRIPTION
### Rationale for this change

The `AvaticaConnection` class within the Calcite library [executes](https://github.com/apache/calcite-avatica/blob/b57eb7cd31a90d3f46b65c13832b398be5b0dad9/core/src/main/java/org/apache/calcite/avatica/AvaticaConnection.java#L357) the `prepareStatement(...)` function on a DB connection in the following order:
1. Calls `prepare()` on the `MetaImpl` class, which in our case is `ArrowFlightMetaImpl`. This function executes a command and returns a prepared statement.
2. Calls `newPreparedStatement` on the JDBC factory class, which in our case is `ArrowFlightJdbcFactory`. This function today creates an entirely new `PreparedStatement` without checking the statement cache, thereby causing 2 executions.

This PR fixes the issue by checking whether or not the `StatementHandle` has been recorded before, and if so, uses the results of the previously executed command. If not, it creates a brand new `PreparedStatement`.

My understanding is that `ConcurrentHashMap` (which is what is being used to keep a mapping of statement handles to prepared statements) is eventually consistent, so there _may_ be cases where the prepared statement execution runs twice.

### What changes are included in this PR?
Check to see if the `PreparedStatement` has run before, and if so, use that instead of executing the command to contact the server again.


### Are these changes tested?

Existing tests should cover this case. Namely, `ArrowFlightPreparedStatementTest` I _think_ should cover all cases.

### Are there any user-facing changes?
There are no user facing changes.
* Closes: #34284