### PR TITLE
GH-34359: [Python] Add select method to pyarrow.RecordBatch

### DIFF
--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -815,6 +815,8 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
 
         const vector[shared_ptr[CArray]]& columns()
 
+        CResult[shared_ptr[CRecordBatch]] SelectColumns(const vector[int]&)
+
         int num_columns()
         int64_t num_rows()
 


### PR DESCRIPTION
### Rationale for this change
There is a `select` method defined for `pa.Table` and we should add the same for `pa.RecordBatch.`

### What changes are included in this PR?
Added method to `RecordBatch` class in `table.pxi`.

### Are these changes tested?
Yes, tests are added to _python/pyarrow/tests/test_table.py_.

### Are there any user-facing changes?
No.
* Closes: #34359