### PR TITLE
MINOR: [Python][Docs] Fix typo

### DIFF
--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -110,7 +110,7 @@ cdef class ReadOptions(_Weakrefable):
         block, and empty rows are counted.
         The order of application is as follows:
         - `skip_rows` is applied (if non-zero);
-        - column names aread (unless `column_names` is set);
+        - column names are read (unless `column_names` is set);
         - `skip_rows_after_names` is applied (if non-zero).
     column_names : list, optional
         The column names of the target table.  If empty, fall back on
@@ -251,7 +251,7 @@ cdef class ReadOptions(_Weakrefable):
         block, and empty rows are counted.
         The order of application is as follows:
         - `skip_rows` is applied (if non-zero);
-        - column names aread (unless `column_names` is set);
+        - column names are read (unless `column_names` is set);
         - `skip_rows_after_names` is applied (if non-zero).
         """
         return deref(self.options).skip_rows_after_names


### PR DESCRIPTION
### Rationale for this change

Fix the typo found in #34340 which copied from this file.

### What changes are included in this PR?

Minor typo fixes.

### Are these changes tested?

No. Minor documentation changes only.

### Are there any user-facing changes?

No.