### PR TITLE
MINOR: [C++][Docs] Remove note about Compute IR in the Acero user guide

### DIFF
--- a/docs/source/cpp/streaming_execution.rst
+++ b/docs/source/cpp/streaming_execution.rst
@@ -405,10 +405,6 @@ their completion::
 Constructing ``ExecPlan`` objects
 =================================
 
-.. warning::
-
-    The following will be superceded by construction from Compute IR, see ARROW-14074.
-
 None of the concrete implementations of :class:`ExecNode` are exposed
 in headers, so they can't be constructed directly outside the
 translation unit where they are defined. Instead, factories to


### PR DESCRIPTION
Compute IR was abandoned in favor of Substrait, and this is already handled above the current section in that doc page.