### PR TITLE
GH-33742: [Python] Address docstrings in Data Types classes 

### DIFF
--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -1315,6 +1315,58 @@ cdef class ExtensionType(BaseExtensionType):
     ----------
     storage_type : DataType
     extension_name : str
+
+    Examples
+    --------
+    Define a UuidType extension type subclassing ExtensionType:
+
+    >>> import pyarrow as pa
+    >>> class UuidType(pa.ExtensionType):
+    ...    def __init__(self):
+    ...       pa.ExtensionType.__init__(self, pa.binary(16), "my_package.uuid")
+    ...    def __arrow_ext_serialize__(self):
+    ...       # since we don't have a parameterized type, we don't need extra
+    ...       # metadata to be deserialized
+    ...       return b''
+    ...    @classmethod
+    ...    def __arrow_ext_deserialize__(self, storage_type, serialized):
+    ...       # return an instance of this subclass given the serialized
+    ...       # metadata.
+    ...       return UuidType()
+    ...
+
+    Register the extension type:
+
+    >>> pa.register_extension_type(UuidType())
+
+    Create an instance of UuidType extension type:
+
+    >>> uuid_type = UuidType()
+
+    Inspect the extension type:
+
+    >>> uuid_type.extension_name
+    'my_package.uuid'
+    >>> uuid_type.storage_type
+    FixedSizeBinaryType(fixed_size_binary[16])
+
+    Wrap an array as an extension array:
+
+    >>> import uuid
+    >>> storage_array = pa.array([uuid.uuid4().bytes for _ in range(4)], pa.binary(16))
+    >>> uuid_type.wrap_array(storage_array)
+    <pyarrow.lib.ExtensionArray object at ...>
+    [
+      ...
+    ]
+
+    Or do the same with creating an ExtensionArray:
+
+    >>> pa.ExtensionArray.from_storage(uuid_type, storage_array)
+    <pyarrow.lib.ExtensionArray object at ...>
+    [
+      ...
+    ]
     """
 
     def __cinit__(self):
@@ -1414,6 +1466,47 @@ cdef class PyExtensionType(ExtensionType):
     ----------
     storage_type : DataType
         The storage type for which the extension is built.
+
+    Examples
+    --------
+    Define a UuidType extension type subclassing PyExtensionType:
+
+    >>> import pyarrow as pa
+    >>> class UuidType(pa.PyExtensionType):
+    ...     def __init__(self):
+    ...         pa.PyExtensionType.__init__(self, pa.binary(16))
+    ...     def __reduce__(self):
+    ...         return UuidType, ()
+    ...
+
+    Create an instance of UuidType extension type:
+
+    >>> uuid_type = UuidType()
+
+    Inspect the extension type:
+
+    >>> uuid_type.extension_name
+    'arrow.py_extension_type'
+    >>> uuid_type.storage_type
+    FixedSizeBinaryType(fixed_size_binary[16])
+
+    Wrap an array as an extension array:
+
+    >>> import uuid
+    >>> storage_array = pa.array([uuid.uuid4().bytes for _ in range(4)], pa.binary(16))
+    >>> uuid_type.wrap_array(storage_array)
+    <pyarrow.lib.ExtensionArray object at ...>
+    [
+      ...
+    ]
+
+    Or do the same with creating an ExtensionArray:
+
+    >>> pa.ExtensionArray.from_storage(uuid_type, storage_array)
+    <pyarrow.lib.ExtensionArray object at ...>
+    [
+      ...
+    ]
     """
 
     def __cinit__(self):
@@ -1490,6 +1583,28 @@ def register_extension_type(ext_type):
     ext_type : BaseExtensionType instance
         The ExtensionType subclass to register.
 
+    Examples
+    --------
+    Define a UuidType extension type subclassing ExtensionType:
+
+    >>> import pyarrow as pa
+    >>> class UuidType(pa.ExtensionType):
+    ...    def __init__(self):
+    ...       pa.ExtensionType.__init__(self, pa.binary(16), "my_package.uuid")
+    ...    def __arrow_ext_serialize__(self):
+    ...       # since we don't have a parameterized type, we don't need extra
+    ...       # metadata to be deserialized
+    ...       return b''
+    ...    @classmethod
+    ...    def __arrow_ext_deserialize__(self, storage_type, serialized):
+    ...       # return an instance of this subclass given the serialized
+    ...       # metadata.
+    ...       return UuidType()
+    ...
+
+    Register the extension type:
+
+    >>> pa.register_extension_type(UuidType())
     """
     cdef:
         DataType _type = ensure_type(ext_type, allow_none=False)
@@ -1514,6 +1629,32 @@ def unregister_extension_type(type_name):
     type_name : str
         The name of the ExtensionType subclass to unregister.
 
+    Examples
+    --------
+    Define a UuidType extension type subclassing ExtensionType:
+
+    >>> import pyarrow as pa
+    >>> class UuidType(pa.ExtensionType):
+    ...    def __init__(self):
+    ...       pa.ExtensionType.__init__(self, pa.binary(16), "my_package.uuid")
+    ...    def __arrow_ext_serialize__(self):
+    ...       # since we don't have a parameterized type, we don't need extra
+    ...       # metadata to be deserialized
+    ...       return b''
+    ...    @classmethod
+    ...    def __arrow_ext_deserialize__(self, storage_type, serialized):
+    ...       # return an instance of this subclass given the serialized
+    ...       # metadata.
+    ...       return UuidType()
+    ...
+
+    Register the extension type:
+
+    >>> pa.register_extension_type(UuidType())
+
+    Unregister the extension type:
+
+    >>> pa.unregister_extension_type(UuidType())
     """
     cdef:
         c_string c_type_name = tobytes(type_name)

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -376,6 +376,16 @@ cdef class DictionaryType(DataType):
 cdef class ListType(DataType):
     """
     Concrete class for list data types.
+
+    Examples
+    --------
+    Create an instance of ListType:
+
+    >>> import pyarrow as pa
+    >>> pa.list_(pa.string())
+    ListType(list<item: string>)
+    >>> pa.list_(pa.int32(), 2)
+    FixedSizeListType(fixed_size_list<item: int32>[2])
     """
 
     cdef void init(self, const shared_ptr[CDataType]& type) except *:
@@ -387,12 +397,27 @@ cdef class ListType(DataType):
 
     @property
     def value_field(self):
+        """
+        A field of list values.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> pa.list_(pa.string()).value_field
+        pyarrow.Field<item: string>
+        """
         return pyarrow_wrap_field(self.list_type.value_field())
 
     @property
     def value_type(self):
         """
         The data type of list values.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> pa.list_(pa.string()).value_type
+        DataType(string)
         """
         return pyarrow_wrap_data_type(self.list_type.value_type())
 

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -194,6 +194,9 @@ cdef class DataType(_Weakrefable):
         ListType(list<item: string>)
         >>> pa.list_(pa.string()).num_fields
         1
+        >>> struct = pa.struct({'x': pa.int32(), 'y': pa.string()})
+        >>> struct.num_fields
+        2
         """
         return self.type.num_fields()
 

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -125,6 +125,14 @@ cdef class DataType(_Weakrefable):
     Base class of all Arrow data types.
 
     Each data type is an *instance* of this class.
+
+    Examples
+    --------
+    Instance of int64 type:
+
+    >>> import pyarrow as pa
+    >>> pa.int64()
+    DataType(int64)
     """
 
     def __cinit__(self):
@@ -153,6 +161,17 @@ cdef class DataType(_Weakrefable):
 
     @property
     def bit_width(self):
+        """
+        Bit width for fixed width type.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> pa.int64()
+        DataType(int64)
+        >>> pa.int64().bit_width
+        64
+        """
         cdef _CFixedWidthTypePtr ty
         ty = dynamic_cast[_CFixedWidthTypePtr](self.type)
         if ty == nullptr:
@@ -163,6 +182,18 @@ cdef class DataType(_Weakrefable):
     def num_fields(self):
         """
         The number of child fields.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> pa.int64()
+        DataType(int64)
+        >>> pa.int64().num_fields
+        0
+        >>> pa.list_(pa.string())
+        ListType(list<item: string>)
+        >>> pa.list_(pa.string()).num_fields
+        1
         """
         return self.type.num_fields()
 
@@ -171,6 +202,14 @@ cdef class DataType(_Weakrefable):
         """
         Number of data buffers required to construct Array type
         excluding children.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> pa.int64().num_buffers
+        2
+        >>> pa.string().num_buffers
+        3
         """
         return self.type.layout().buffers.size()
 
@@ -205,6 +244,14 @@ cdef class DataType(_Weakrefable):
         Returns
         -------
         is_equal : bool
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> pa.int64().equals(pa.string())
+        False
+        >>> pa.int64().equals(pa.int64())
+        True
         """
         cdef:
             DataType other_type
@@ -217,6 +264,12 @@ cdef class DataType(_Weakrefable):
     def to_pandas_dtype(self):
         """
         Return the equivalent NumPy / Pandas dtype.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> pa.int64().to_pandas_dtype()
+        <class 'numpy.int64'>
         """
         cdef Type type_id = self.type.id()
         if type_id in _pandas_type_map:

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -1137,6 +1137,14 @@ cdef class FixedSizeBinaryType(DataType):
 cdef class Decimal128Type(FixedSizeBinaryType):
     """
     Concrete class for decimal128 data types.
+
+    Examples
+    --------
+    Create an instance of decimal128 type:
+
+    >>> import pyarrow as pa
+    >>> pa.decimal128(5, 2)
+    Decimal128Type(decimal128(5, 2))
     """
 
     cdef void init(self, const shared_ptr[CDataType]& type) except *:
@@ -1150,6 +1158,13 @@ cdef class Decimal128Type(FixedSizeBinaryType):
     def precision(self):
         """
         The decimal precision, in number of decimal digits (an integer).
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> t = pa.decimal128(5, 2)
+        >>> t.precision
+        5
         """
         return self.decimal128_type.precision()
 
@@ -1157,13 +1172,28 @@ cdef class Decimal128Type(FixedSizeBinaryType):
     def scale(self):
         """
         The decimal scale (an integer).
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> t = pa.decimal128(5, 2)
+        >>> t.scale
+        2
         """
         return self.decimal128_type.scale()
 
 
 cdef class Decimal256Type(FixedSizeBinaryType):
     """
-    Concrete class for Decimal256 data types.
+    Concrete class for decimal256 data types.
+
+    Examples
+    --------
+    Create an instance of decimal256 type:
+
+    >>> import pyarrow as pa
+    >>> pa.decimal256(76, 38)
+    Decimal256Type(decimal256(76, 38))
     """
 
     cdef void init(self, const shared_ptr[CDataType]& type) except *:
@@ -1177,6 +1207,13 @@ cdef class Decimal256Type(FixedSizeBinaryType):
     def precision(self):
         """
         The decimal precision, in number of decimal digits (an integer).
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> t = pa.decimal256(76, 38)
+        >>> t.precision
+        76
         """
         return self.decimal256_type.precision()
 
@@ -1184,6 +1221,13 @@ cdef class Decimal256Type(FixedSizeBinaryType):
     def scale(self):
         """
         The decimal scale (an integer).
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> t = pa.decimal256(76, 38)
+        >>> t.scale
+        38
         """
         return self.decimal256_type.scale()
 

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -426,6 +426,14 @@ cdef class LargeListType(DataType):
     """
     Concrete class for large list data types
     (like ListType, but with 64-bit offsets).
+
+    Examples
+    --------
+    Create an instance of LargeListType:
+
+    >>> import pyarrow as pa
+    >>> pa.large_list(pa.string())
+    LargeListType(large_list<item: string>)
     """
 
     cdef void init(self, const shared_ptr[CDataType]& type) except *:
@@ -443,6 +451,12 @@ cdef class LargeListType(DataType):
     def value_type(self):
         """
         The data type of large list values.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> pa.large_list(pa.string()).value_type
+        DataType(string)
         """
         return pyarrow_wrap_data_type(self.list_type.value_type())
 

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -313,6 +313,14 @@ cdef class DictionaryMemo(_Weakrefable):
 cdef class DictionaryType(DataType):
     """
     Concrete class for dictionary data types.
+
+    Examples
+    --------
+    Create an instance of dictionary type:
+
+    >>> import pyarrow as pa
+    >>> pa.dictionary(pa.int64(), pa.utf8())
+    DictionaryType(dictionary<values=string, indices=int64, ordered=0>)
     """
 
     cdef void init(self, const shared_ptr[CDataType]& type) except *:
@@ -327,6 +335,12 @@ cdef class DictionaryType(DataType):
         """
         Whether the dictionary is ordered, i.e. whether the ordering of values
         in the dictionary is important.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> pa.dictionary(pa.int64(), pa.utf8()).ordered
+        False
         """
         return self.dict_type.ordered()
 
@@ -334,6 +348,12 @@ cdef class DictionaryType(DataType):
     def index_type(self):
         """
         The data type of dictionary indices (a signed integer type).
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> pa.dictionary(pa.int16(), pa.utf8()).index_type
+        DataType(int16)
         """
         return pyarrow_wrap_data_type(self.dict_type.index_type())
 
@@ -343,6 +363,12 @@ cdef class DictionaryType(DataType):
         The dictionary value type.
 
         The dictionary values are found in an instance of DictionaryArray.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> pa.dictionary(pa.int16(), pa.utf8()).value_type
+        DataType(string)
         """
         return pyarrow_wrap_data_type(self.dict_type.value_type())
 

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -384,8 +384,6 @@ cdef class ListType(DataType):
     >>> import pyarrow as pa
     >>> pa.list_(pa.string())
     ListType(list<item: string>)
-    >>> pa.list_(pa.int32(), 2)
-    FixedSizeListType(fixed_size_list<item: int32>[2])
     """
 
     cdef void init(self, const shared_ptr[CDataType]& type) except *:
@@ -539,6 +537,14 @@ cdef class MapType(DataType):
 cdef class FixedSizeListType(DataType):
     """
     Concrete class for fixed size list data types.
+
+    Examples
+    --------
+    Create an instance of FixedSizeListType:
+
+    >>> import pyarrow as pa
+    >>> pa.list_(pa.int32(), 2)
+    FixedSizeListType(fixed_size_list<item: int32>[2])
     """
 
     cdef void init(self, const shared_ptr[CDataType]& type) except *:
@@ -550,12 +556,27 @@ cdef class FixedSizeListType(DataType):
 
     @property
     def value_field(self):
+        """
+        The field for list values.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> pa.list_(pa.int32(), 2).value_field
+        pyarrow.Field<item: int32>
+        """
         return pyarrow_wrap_field(self.list_type.value_field())
 
     @property
     def value_type(self):
         """
         The data type of large list values.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> pa.list_(pa.int32(), 2).value_type
+        DataType(int32)
         """
         return pyarrow_wrap_data_type(self.list_type.value_type())
 
@@ -563,6 +584,12 @@ cdef class FixedSizeListType(DataType):
     def list_size(self):
         """
         The size of the fixed size lists.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> pa.list_(pa.int32(), 2).list_size
+        2
         """
         return self.list_type.list_size()
 

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -1101,6 +1101,14 @@ cdef class DurationType(DataType):
 cdef class FixedSizeBinaryType(DataType):
     """
     Concrete class for fixed-size binary data types.
+
+    Examples
+    --------
+    Create an instance of fixed-size binary type:
+
+    >>> import pyarrow as pa
+    >>> pa.binary(3)
+    FixedSizeBinaryType(fixed_size_binary[3])
     """
 
     cdef void init(self, const shared_ptr[CDataType]& type) except *:
@@ -1115,6 +1123,13 @@ cdef class FixedSizeBinaryType(DataType):
     def byte_width(self):
         """
         The binary size in bytes.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> t = pa.binary(3)
+        >>> t.byte_width
+        3
         """
         return self.fixed_size_binary_type.byte_width()
 

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -398,7 +398,7 @@ cdef class ListType(DataType):
     @property
     def value_field(self):
         """
-        A field of list values.
+        The field for list values.
 
         Examples
         --------
@@ -464,6 +464,16 @@ cdef class LargeListType(DataType):
 cdef class MapType(DataType):
     """
     Concrete class for map data types.
+
+    Examples
+    --------
+    Create an instance of MapType:
+
+    >>> import pyarrow as pa
+    >>> pa.map_(pa.string(), pa.int32())
+    MapType(map<string, int32>)
+    >>> pa.map_(pa.string(), pa.int32(), keys_sorted=True)
+    MapType(map<string, int32, keys_sorted>)
     """
 
     cdef void init(self, const shared_ptr[CDataType]& type) except *:
@@ -477,6 +487,12 @@ cdef class MapType(DataType):
     def key_field(self):
         """
         The field for keys in the map entries.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> pa.map_(pa.string(), pa.int32()).key_field
+        pyarrow.Field<key: string not null>
         """
         return pyarrow_wrap_field(self.map_type.key_field())
 
@@ -484,6 +500,12 @@ cdef class MapType(DataType):
     def key_type(self):
         """
         The data type of keys in the map entries.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> pa.map_(pa.string(), pa.int32()).key_type
+        DataType(string)
         """
         return pyarrow_wrap_data_type(self.map_type.key_type())
 
@@ -491,6 +513,12 @@ cdef class MapType(DataType):
     def item_field(self):
         """
         The field for items in the map entries.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> pa.map_(pa.string(), pa.int32()).item_field
+        pyarrow.Field<value: int32>
         """
         return pyarrow_wrap_field(self.map_type.item_field())
 
@@ -498,6 +526,12 @@ cdef class MapType(DataType):
     def item_type(self):
         """
         The data type of items in the map entries.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> pa.map_(pa.string(), pa.int32()).item_type
+        DataType(int32)
         """
         return pyarrow_wrap_data_type(self.map_type.item_type())
 

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -1483,6 +1483,39 @@ cdef class PyExtensionType(ExtensionType):
     ...     def __reduce__(self):
     ...         return UuidType, ()
     ...
+
+    Create an instance of UuidType extension type:
+
+    >>> uuid_type = UuidType() # doctest: +SKIP
+    >>> uuid_type # doctest: +SKIP
+    UuidType(FixedSizeBinaryType(fixed_size_binary[16]))
+
+    Inspect the extension type:
+
+    >>> uuid_type.extension_name # doctest: +SKIP
+    'arrow.py_extension_type'
+    >>> uuid_type.storage_type # doctest: +SKIP
+    FixedSizeBinaryType(fixed_size_binary[16])
+
+    Wrap an array as an extension array:
+
+    >>> import uuid
+    >>> storage_array = pa.array([uuid.uuid4().bytes for _ in range(4)],
+    ...                          pa.binary(16)) # doctest: +SKIP
+    >>> uuid_type.wrap_array(storage_array) # doctest: +SKIP
+    <pyarrow.lib.ExtensionArray object at ...>
+    [
+      ...
+    ]
+
+    Or do the same with creating an ExtensionArray:
+
+    >>> pa.ExtensionArray.from_storage(uuid_type,
+    ...                                storage_array) # doctest: +SKIP
+    <pyarrow.lib.ExtensionArray object at ...>
+    [
+      ...
+    ]
     """
 
     def __cinit__(self):

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -773,6 +773,31 @@ cdef class StructType(DataType):
 cdef class UnionType(DataType):
     """
     Base class for union data types.
+
+    Examples
+    --------
+    Create an instance of a dense UnionType using ``pa.union``:
+
+    >>> import pyarrow as pa
+    >>> pa.union([pa.field('a', pa.binary(10)), pa.field('b', pa.string())],
+    ...          mode=pa.lib.UnionMode_DENSE),
+    (DenseUnionType(dense_union<a: fixed_size_binary[10]=0, b: string=1>),)
+
+    Create an instance of a dense UnionType using ``pa.dense_union``:
+
+    >>> pa.dense_union([pa.field('a', pa.binary(10)), pa.field('b', pa.string())])
+    DenseUnionType(dense_union<a: fixed_size_binary[10]=0, b: string=1>)
+
+    Create an instance of a sparse UnionType using ``pa.union``:
+
+    >>> pa.union([pa.field('a', pa.binary(10)), pa.field('b', pa.string())],
+    ...          mode=pa.lib.UnionMode_SPARSE),
+    (SparseUnionType(sparse_union<a: fixed_size_binary[10]=0, b: string=1>),)
+
+    Create an instance of a sparse UnionType using ``pa.sparse_union``:
+
+    >>> pa.sparse_union([pa.field('a', pa.binary(10)), pa.field('b', pa.string())])
+    SparseUnionType(sparse_union<a: fixed_size_binary[10]=0, b: string=1>)
     """
 
     cdef void init(self, const shared_ptr[CDataType]& type) except *:
@@ -782,6 +807,13 @@ cdef class UnionType(DataType):
     def mode(self):
         """
         The mode of the union ("dense" or "sparse").
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> union = pa.sparse_union([pa.field('a', pa.binary(10)), pa.field('b', pa.string())])
+        >>> union.mode
+        'sparse'
         """
         cdef CUnionType* type = <CUnionType*> self.sp_type.get()
         cdef int mode = type.mode()
@@ -795,6 +827,13 @@ cdef class UnionType(DataType):
     def type_codes(self):
         """
         The type code to indicate each data type in this union.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> union = pa.sparse_union([pa.field('a', pa.binary(10)), pa.field('b', pa.string())])
+        >>> union.type_codes
+        [0, 1]
         """
         cdef CUnionType* type = <CUnionType*> self.sp_type.get()
         return type.type_codes()
@@ -823,6 +862,13 @@ cdef class UnionType(DataType):
         Returns
         -------
         pyarrow.Field
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> union = pa.sparse_union([pa.field('a', pa.binary(10)), pa.field('b', pa.string())])
+        >>> union[0]
+        pyarrow.Field<a: fixed_size_binary[10]>
         """
         if isinstance(i, int):
             return DataType.field(self, i)
@@ -844,12 +890,39 @@ cdef class UnionType(DataType):
 cdef class SparseUnionType(UnionType):
     """
     Concrete class for sparse union types.
+
+    Examples
+    --------
+    Create an instance of a sparse UnionType using ``pa.union``:
+
+    >>> pa.union([pa.field('a', pa.binary(10)), pa.field('b', pa.string())],
+    ...          mode=pa.lib.UnionMode_SPARSE),
+    (SparseUnionType(sparse_union<a: fixed_size_binary[10]=0, b: string=1>),)
+
+    Create an instance of a sparse UnionType using ``pa.sparse_union``:
+
+    >>> pa.sparse_union([pa.field('a', pa.binary(10)), pa.field('b', pa.string())])
+    SparseUnionType(sparse_union<a: fixed_size_binary[10]=0, b: string=1>)
     """
 
 
 cdef class DenseUnionType(UnionType):
     """
     Concrete class for dense union types.
+
+    Examples
+    --------
+    Create an instance of a dense UnionType using ``pa.union``:
+
+    >>> import pyarrow as pa
+    >>> pa.union([pa.field('a', pa.binary(10)), pa.field('b', pa.string())],
+    ...          mode=pa.lib.UnionMode_DENSE),
+    (DenseUnionType(dense_union<a: fixed_size_binary[10]=0, b: string=1>),)
+
+    Create an instance of a dense UnionType using ``pa.dense_union``:
+
+    >>> pa.dense_union([pa.field('a', pa.binary(10)), pa.field('b', pa.string())])
+    DenseUnionType(dense_union<a: fixed_size_binary[10]=0, b: string=1>)
     """
 
 

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -929,6 +929,20 @@ cdef class DenseUnionType(UnionType):
 cdef class TimestampType(DataType):
     """
     Concrete class for timestamp data types.
+
+    Examples
+    --------
+    >>> import pyarrow as pa
+
+    Create an instance of timestamp type:
+
+    >>> pa.timestamp('us')
+    TimestampType(timestamp[us])
+
+    Create an instance of timestamp type with timezone:
+
+    >>> pa.timestamp('s', tz='UTC')
+    TimestampType(timestamp[s, tz=UTC])
     """
 
     cdef void init(self, const shared_ptr[CDataType]& type) except *:
@@ -939,6 +953,13 @@ cdef class TimestampType(DataType):
     def unit(self):
         """
         The timestamp unit ('s', 'ms', 'us' or 'ns').
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> t = pa.timestamp('us')
+        >>> t.unit
+        'us'
         """
         return timeunit_to_string(self.ts_type.unit())
 
@@ -946,6 +967,13 @@ cdef class TimestampType(DataType):
     def tz(self):
         """
         The timestamp time zone, if any, or None.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> t = pa.timestamp('s', tz='UTC')
+        >>> t.tz
+        'UTC'
         """
         if self.ts_type.timezone().size() > 0:
             return frombytes(self.ts_type.timezone())
@@ -955,6 +983,13 @@ cdef class TimestampType(DataType):
     def to_pandas_dtype(self):
         """
         Return the equivalent NumPy / Pandas dtype.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> t = pa.timestamp('s', tz='UTC')
+        >>> t.to_pandas_dtype()
+        datetime64[ns, UTC]
         """
         if self.tz is None:
             return _pandas_type_map[_Type_TIMESTAMP]
@@ -970,6 +1005,14 @@ cdef class TimestampType(DataType):
 cdef class Time32Type(DataType):
     """
     Concrete class for time32 data types.
+
+    Examples
+    --------
+    Create an instance of time32 type:
+
+    >>> import pyarrow as pa
+    >>> pa.time32('ms')
+    Time32Type(time32[ms])
     """
 
     cdef void init(self, const shared_ptr[CDataType]& type) except *:
@@ -980,6 +1023,13 @@ cdef class Time32Type(DataType):
     def unit(self):
         """
         The time unit ('s', 'ms', 'us' or 'ns').
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> t = pa.time32('ms')
+        >>> t.unit
+        'ms'
         """
         return timeunit_to_string(self.time_type.unit())
 
@@ -987,6 +1037,14 @@ cdef class Time32Type(DataType):
 cdef class Time64Type(DataType):
     """
     Concrete class for time64 data types.
+
+    Examples
+    --------
+    Create an instance of time64 type:
+
+    >>> import pyarrow as pa
+    >>> pa.time64('us')
+    Time64Type(time64[us])
     """
 
     cdef void init(self, const shared_ptr[CDataType]& type) except *:
@@ -997,6 +1055,13 @@ cdef class Time64Type(DataType):
     def unit(self):
         """
         The time unit ('s', 'ms', 'us' or 'ns').
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> t = pa.time64('us')
+        >>> t.unit
+        'us'
         """
         return timeunit_to_string(self.time_type.unit())
 
@@ -1004,6 +1069,14 @@ cdef class Time64Type(DataType):
 cdef class DurationType(DataType):
     """
     Concrete class for duration data types.
+
+    Examples
+    --------
+    Create an instance of duration type:
+
+    >>> import pyarrow as pa
+    >>> pa.duration('s')
+    DurationType(duration[s])
     """
 
     cdef void init(self, const shared_ptr[CDataType]& type) except *:
@@ -1014,6 +1087,13 @@ cdef class DurationType(DataType):
     def unit(self):
         """
         The duration unit ('s', 'ms', 'us' or 'ns').
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> t = pa.duration('s')
+        >>> t.unit
+        's'
         """
         return timeunit_to_string(self.duration_type.unit())
 

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -895,6 +895,7 @@ cdef class SparseUnionType(UnionType):
     --------
     Create an instance of a sparse UnionType using ``pa.union``:
 
+    >>> import pyarrow as pa
     >>> pa.union([pa.field('a', pa.binary(10)), pa.field('b', pa.string())],
     ...          mode=pa.lib.UnionMode_SPARSE),
     (SparseUnionType(sparse_union<a: fixed_size_binary[10]=0, b: string=1>),)
@@ -1367,6 +1368,10 @@ cdef class ExtensionType(BaseExtensionType):
     [
       ...
     ]
+
+    Unregister the extension type:
+
+    >>> pa.unregister_extension_type("my_package.uuid")
     """
 
     def __cinit__(self):
@@ -1478,35 +1483,6 @@ cdef class PyExtensionType(ExtensionType):
     ...     def __reduce__(self):
     ...         return UuidType, ()
     ...
-
-    Create an instance of UuidType extension type:
-
-    >>> uuid_type = UuidType()
-
-    Inspect the extension type:
-
-    >>> uuid_type.extension_name
-    'arrow.py_extension_type'
-    >>> uuid_type.storage_type
-    FixedSizeBinaryType(fixed_size_binary[16])
-
-    Wrap an array as an extension array:
-
-    >>> import uuid
-    >>> storage_array = pa.array([uuid.uuid4().bytes for _ in range(4)], pa.binary(16))
-    >>> uuid_type.wrap_array(storage_array)
-    <pyarrow.lib.ExtensionArray object at ...>
-    [
-      ...
-    ]
-
-    Or do the same with creating an ExtensionArray:
-
-    >>> pa.ExtensionArray.from_storage(uuid_type, storage_array)
-    <pyarrow.lib.ExtensionArray object at ...>
-    [
-      ...
-    ]
     """
 
     def __cinit__(self):
@@ -1605,6 +1581,10 @@ def register_extension_type(ext_type):
     Register the extension type:
 
     >>> pa.register_extension_type(UuidType())
+
+    Unregister the extension type:
+
+    >>> pa.unregister_extension_type("my_package.uuid")
     """
     cdef:
         DataType _type = ensure_type(ext_type, allow_none=False)
@@ -1654,7 +1634,7 @@ def unregister_extension_type(type_name):
 
     Unregister the extension type:
 
-    >>> pa.unregister_extension_type(UuidType())
+    >>> pa.unregister_extension_type("my_package.uuid")
     """
     cdef:
         c_string c_type_name = tobytes(type_name)
@@ -2114,14 +2094,14 @@ cdef class Field(_Weakrefable):
         >>> import pyarrow as pa
         >>> f1 = pa.field('bar', pa.float64(), nullable=False)
         >>> f2 = pa.field('foo', pa.int32()).with_metadata({"key": "Something important"})
-        >>> ff = pa.field('ff', pa.struct([f0, f1]), nullable=False)
+        >>> ff = pa.field('ff', pa.struct([f1, f2]), nullable=False)
 
         Flatten a struct field:
 
         >>> ff
-        pyarrow.Field<ff: struct<foo: int32, bar: double not null> not null>
+        pyarrow.Field<ff: struct<bar: double not null, foo: int32> not null>
         >>> ff.flatten()
-        [pyarrow.Field<ff.foo: int32>, pyarrow.Field<ff.bar: double not null>]
+        [pyarrow.Field<ff.bar: double not null>, pyarrow.Field<ff.foo: int32>]
         """
         cdef vector[shared_ptr[CField]] flattened
         with nogil:

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -683,8 +683,16 @@ cdef class StructType(DataType):
         --------
         >>> import pyarrow as pa
         >>> struct_type = pa.struct({'x': pa.int32(), 'y': pa.string()})
+
+        Index of the field with a name 'y':
+
         >>> struct_type.get_field_index('y')
         1
+
+        Index of the field that does not exist:
+
+        >>> struct_type.get_field_index('z')
+        -1
         """
         return self.struct_type.GetFieldIndex(tobytes(name))
 

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -678,6 +678,13 @@ cdef class StructType(DataType):
             The index of the field with the given name; -1 if the
             name isn't found or there are several fields with the given
             name.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> struct_type = pa.struct({'x': pa.int32(), 'y': pa.string()})
+        >>> struct_type.get_field_index('y')
+        1
         """
         return self.struct_type.GetFieldIndex(tobytes(name))
 
@@ -728,6 +735,13 @@ cdef class StructType(DataType):
         Returns
         -------
         indices : List[int]
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> struct_type = pa.struct({'x': pa.int32(), 'y': pa.string()})
+        >>> struct_type.get_all_field_indices('x')
+        [0]
         """
         return self.struct_type.GetAllFieldIndices(tobytes(name))
 


### PR DESCRIPTION
### Rationale for this change

Ensure docstrings for [Data Types Classes](https://arrow.apache.org/docs/python/api/datatypes.html#type-classes) have an Examples section.

### What changes are included in this PR?

Docstrings examples are added.

### Are these changes tested?

Yes, with `python -m pytest --doctest-cython python/pyarrow `
* Closes: #33742