### PR TITLE
MINOR: [C++] Name RunEnd[C]Type consistently

### DIFF
--- a/cpp/src/arrow/array/builder_run_end.h
+++ b/cpp/src/arrow/array/builder_run_end.h
@@ -262,10 +262,10 @@ class ARROW_EXPORT RunEndEncodedBuilder : public ArrayBuilder {
   }
 
   // Pre-condition: !value_run_builder_.has_open_run()
-  template <typename RunEndsType>
+  template <typename RunEndCType>
   Status DoAppendArray(const ArraySpan& to_append);
 
-  template <typename RunEndsType>
+  template <typename RunEndCType>
   Status DoAppendRunEnd(int64_t run_end);
 
   /// \brief Cast run_end to the appropriate type and appends it to the run_ends

--- a/cpp/src/arrow/array/validate.cc
+++ b/cpp/src/arrow/array/validate.cc
@@ -637,15 +637,15 @@ struct ValidateArrayImpl {
     return Status::OK();
   }
 
-  template <typename RunEndsType>
+  template <typename RunEndCType>
   Status ValidateRunEndEncoded(const RunEndEncodedType& type) {
     // Overflow was already checked at this point
-    if (data.offset + data.length > std::numeric_limits<RunEndsType>::max()) {
+    if (data.offset + data.length > std::numeric_limits<RunEndCType>::max()) {
       return Status::Invalid(
           "Offset + length of a run-end encoded array must fit in a value"
           " of the run end type ",
           *type.run_end_type(), ", but offset + length is ", data.offset + data.length,
-          " while the allowed maximum is ", std::numeric_limits<RunEndsType>::max());
+          " while the allowed maximum is ", std::numeric_limits<RunEndCType>::max());
     }
     if (!data.child_data[0]) {
       return Status::Invalid("Run ends array is null pointer");
@@ -695,7 +695,7 @@ struct ValidateArrayImpl {
       return Status::OK();
     }
     ArraySpan span(data);
-    const auto* run_ends = ree_util::RunEnds<RunEndsType>(span);
+    const auto* run_ends = ree_util::RunEnds<RunEndCType>(span);
     // The last run-end is the logical offset + the logical length.
     if (run_ends[run_ends_data.length - 1] < data.offset + data.length) {
       return Status::Invalid("Last run end is ", run_ends[run_ends_data.length - 1],

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -473,14 +473,14 @@ class RangeDataEqualsImpl {
     return Status::OK();
   }
 
-  template <typename RunEndsType>
+  template <typename RunEndCType>
   Status CompareRunEndEncoded() {
     auto left_span = ArraySpan(left_);
     auto right_span = ArraySpan(right_);
     left_span.SetSlice(left_.offset + left_start_idx_, range_length_);
     right_span.SetSlice(right_.offset + right_start_idx_, range_length_);
-    const ree_util::RunEndEncodedArraySpan<RunEndsType> left(left_span);
-    const ree_util::RunEndEncodedArraySpan<RunEndsType> right(right_span);
+    const ree_util::RunEndEncodedArraySpan<RunEndCType> left(left_span);
+    const ree_util::RunEndEncodedArraySpan<RunEndCType> right(right_span);
 
     const auto& left_values = *left_.child_data[1];
     const auto& right_values = *right_.child_data[1];

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -1625,10 +1625,10 @@ TEST_F(TestDenseUnionScalar, GetScalar) {
 template <typename RunEndType>
 class TestRunEndEncodedScalar : public ::testing::Test {
  public:
-  using RunEndArrowType = typename CTypeTraits<RunEndType>::ArrowType;
+  using RunEndCType = typename RunEndType::c_type;
 
   void SetUp() override {
-    run_end_type_ = std::make_shared<RunEndArrowType>();
+    run_end_type_ = std::make_shared<RunEndType>();
     value_type_ = utf8();
     type_.reset(new RunEndEncodedType(run_end_type_, value_type_));
 
@@ -1726,7 +1726,7 @@ class TestRunEndEncodedScalar : public ::testing::Test {
   std::shared_ptr<Scalar> beta_;
 };
 
-using RunEndTestTypes = ::testing::Types<int16_t, int32_t, int64_t>;
+using RunEndTestTypes = ::testing::Types<Int16Type, Int32Type, Int64Type>;
 TYPED_TEST_SUITE(TestRunEndEncodedScalar, RunEndTestTypes);
 
 TYPED_TEST(TestRunEndEncodedScalar, Basics) { this->TestBasics(); }

--- a/cpp/src/arrow/util/ree_util_test.cc
+++ b/cpp/src/arrow/util/ree_util_test.cc
@@ -28,11 +28,11 @@
 namespace arrow {
 namespace ree_util {
 
-template <typename RunEndsType>
+template <typename RunEndCType>
 struct ReeUtilTest : public ::testing::Test {
   // Re-implementation of FindPhysicalIndex that uses trivial linear-search
   // instead of the more efficient implementation.
-  int64_t FindPhysicalIndexTestImpl(const RunEndsType* run_ends, int64_t run_ends_size,
+  int64_t FindPhysicalIndexTestImpl(const RunEndCType* run_ends, int64_t run_ends_size,
                                     int64_t i, int64_t absolute_offset = 0) {
     for (int64_t j = 0; j < run_ends_size; j++) {
       if (absolute_offset + i < run_ends[j]) {


### PR DESCRIPTION
Minor change: renaming template parameters so it's clear whether arrow or C types are expected as argument.