### PR TITLE
GH-34405: [C++] Add support for custom names in QueryOptions.  Wire this up to Substrait

### DIFF
--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -951,8 +951,11 @@ struct BatchConverter {
     if (!names.empty()) {
       if (static_cast<int>(names.size()) != schema->num_fields()) {
         return Status::Invalid(
-            "A plan was created with custom field names but the number of names did not "
-            "match the number of output columns");
+            "A plan was created with custom field names but the number of names (",
+            names.size(),
+            ") did not "
+            "match the number of output columns (",
+            schema->num_fields(), ")");
       }
       ARROW_ASSIGN_OR_RAISE(schema, schema->WithNames(names));
     }

--- a/cpp/src/arrow/compute/exec/exec_plan.cc
+++ b/cpp/src/arrow/compute/exec/exec_plan.cc
@@ -624,6 +624,7 @@ Future<std::shared_ptr<Table>> DeclarationToTableImpl(
   ARROW_ASSIGN_OR_RAISE(std::shared_ptr<ExecPlan> exec_plan, ExecPlan::Make(exec_ctx));
   TableSinkNodeOptions sink_options(output_table.get());
   sink_options.sequence_output = query_options.sequence_output;
+  sink_options.names = std::move(query_options.field_names);
   Declaration with_sink =
       Declaration::Sequence({declaration, {"table_sink", sink_options}});
   ARROW_RETURN_NOT_OK(with_sink.AddToPlan(exec_plan.get()));
@@ -652,6 +653,10 @@ Future<BatchesWithCommonSchema> DeclarationToExecBatchesImpl(
   sink_options.sequence_output = options.sequence_output;
   Declaration with_sink = Declaration::Sequence({declaration, {"sink", sink_options}});
   ARROW_RETURN_NOT_OK(with_sink.AddToPlan(exec_plan.get()));
+  if (!options.field_names.empty()) {
+    ARROW_ASSIGN_OR_RAISE(out_schema,
+                          out_schema->WithNames(std::move(options.field_names)));
+  }
   ARROW_RETURN_NOT_OK(exec_plan->Validate());
   exec_plan->StartProducing();
   auto collected_fut = CollectAsyncGenerator(sink_gen);
@@ -800,6 +805,19 @@ Result<std::vector<std::shared_ptr<RecordBatch>>> DeclarationToBatches(
       use_threads);
 }
 
+Result<std::vector<std::shared_ptr<RecordBatch>>> DeclarationToBatches(
+    Declaration declaration, QueryOptions query_options) {
+  if (query_options.custom_cpu_executor != nullptr) {
+    return Status::Invalid("Cannot use synchronous methods with a custom CPU executor");
+  }
+  return ::arrow::internal::RunSynchronously<
+      Future<std::vector<std::shared_ptr<RecordBatch>>>>(
+      [=, declaration = std::move(declaration)](::arrow::internal::Executor* executor) {
+        return DeclarationToBatchesImpl(std::move(declaration), query_options, executor);
+      },
+      query_options.use_threads);
+}
+
 Future<BatchesWithCommonSchema> DeclarationToExecBatchesAsync(Declaration declaration,
                                                               ExecContext exec_context) {
   return DeclarationToExecBatchesImpl(std::move(declaration),
@@ -925,14 +943,32 @@ struct BatchConverter {
         });
   }
 
+  Result<std::shared_ptr<Schema>> InitializeSchema(
+      const std::vector<std::string>& names) {
+    // By this point this->schema will have been set by the SinkNode.  We potentially
+    // rename it with the names provided by the user and then return this in case the user
+    // wants to know the output schema.
+    if (!names.empty()) {
+      if (static_cast<int>(names.size()) != schema->num_fields()) {
+        return Status::Invalid(
+            "A plan was created with custom field names but the number of names did not "
+            "match the number of output columns");
+      }
+      ARROW_ASSIGN_OR_RAISE(schema, schema->WithNames(names));
+    }
+    return schema;
+  }
+
   AsyncGenerator<std::optional<ExecBatch>> exec_batch_gen;
   std::shared_ptr<Schema> schema;
   std::shared_ptr<ExecPlan> exec_plan;
 };
 
 Result<AsyncGenerator<std::shared_ptr<RecordBatch>>> DeclarationToRecordBatchGenerator(
-    Declaration declaration, ExecContext exec_ctx, std::shared_ptr<Schema>* out_schema) {
+    Declaration declaration, QueryOptions options,
+    ::arrow::internal::Executor* cpu_executor, std::shared_ptr<Schema>* out_schema) {
   auto converter = std::make_shared<BatchConverter>();
+  ExecContext exec_ctx(options.memory_pool, cpu_executor, options.function_registry);
   ARROW_ASSIGN_OR_RAISE(std::shared_ptr<ExecPlan> plan, ExecPlan::Make(exec_ctx));
   Declaration with_sink = Declaration::Sequence(
       {declaration,
@@ -941,23 +977,28 @@ Result<AsyncGenerator<std::shared_ptr<RecordBatch>>> DeclarationToRecordBatchGen
   ARROW_RETURN_NOT_OK(plan->Validate());
   plan->StartProducing();
   converter->exec_plan = std::move(plan);
-  *out_schema = converter->schema;
+  ARROW_ASSIGN_OR_RAISE(*out_schema, converter->InitializeSchema(options.field_names));
   return [conv = std::move(converter)] { return (*conv)(); };
 }
+
 }  // namespace
 
-Result<std::unique_ptr<RecordBatchReader>> DeclarationToReader(
-    Declaration declaration, bool use_threads, MemoryPool* memory_pool,
-    FunctionRegistry* function_registry) {
+Result<std::unique_ptr<RecordBatchReader>> DeclarationToReader(Declaration declaration,
+                                                               QueryOptions options) {
+  if (options.custom_cpu_executor != nullptr) {
+    return Status::Invalid("Cannot use synchronous methods with a custom CPU executor");
+  }
   std::shared_ptr<Schema> schema;
   auto batch_iterator = std::make_unique<Iterator<std::shared_ptr<RecordBatch>>>(
       ::arrow::internal::IterateSynchronously<std::shared_ptr<RecordBatch>>(
           [&](::arrow::internal::Executor* executor)
               -> Result<AsyncGenerator<std::shared_ptr<RecordBatch>>> {
-            ExecContext exec_ctx(memory_pool, executor, function_registry);
-            return DeclarationToRecordBatchGenerator(declaration, exec_ctx, &schema);
+            ExecContext exec_ctx(options.memory_pool, executor,
+                                 options.function_registry);
+            return DeclarationToRecordBatchGenerator(declaration, std::move(options),
+                                                     executor, &schema);
           },
-          use_threads));
+          options.use_threads));
 
   struct PlanReader : RecordBatchReader {
     PlanReader(std::shared_ptr<Schema> schema,
@@ -992,6 +1033,16 @@ Result<std::unique_ptr<RecordBatchReader>> DeclarationToReader(
   };
 
   return std::make_unique<PlanReader>(std::move(schema), std::move(batch_iterator));
+}
+
+Result<std::unique_ptr<RecordBatchReader>> DeclarationToReader(
+    Declaration declaration, bool use_threads, MemoryPool* memory_pool,
+    FunctionRegistry* function_registry) {
+  QueryOptions options;
+  options.memory_pool = memory_pool;
+  options.function_registry = function_registry;
+  options.use_threads = use_threads;
+  return DeclarationToReader(std::move(declaration), std::move(options));
 }
 
 namespace internal {

--- a/cpp/src/arrow/compute/exec/exec_plan.h
+++ b/cpp/src/arrow/compute/exec/exec_plan.h
@@ -505,6 +505,12 @@ struct ARROW_EXPORT QueryOptions {
   ///
   /// Must remain valid for the duration of the plan.
   FunctionRegistry* function_registry = GetFunctionRegistry();
+  /// \brief the names of the output columns
+  ///
+  /// If this is empty then names will be generated based on the input columns
+  ///
+  /// If set then the number of names must equal the number of output columns
+  std::vector<std::string> field_names;
 };
 
 /// \brief Calculate the output schema of a declaration
@@ -622,6 +628,9 @@ ARROW_EXPORT Result<std::vector<std::shared_ptr<RecordBatch>>> DeclarationToBatc
     MemoryPool* memory_pool = default_memory_pool(),
     FunctionRegistry* function_registry = NULLPTR);
 
+ARROW_EXPORT Result<std::vector<std::shared_ptr<RecordBatch>>> DeclarationToBatches(
+    Declaration declaration, QueryOptions query_options);
+
 /// \brief Asynchronous version of \see DeclarationToBatches
 ///
 /// \see DeclarationToTableAsync for details on threading & execution
@@ -656,9 +665,8 @@ ARROW_EXPORT Result<std::unique_ptr<RecordBatchReader>> DeclarationToReader(
     MemoryPool* memory_pool = default_memory_pool(),
     FunctionRegistry* function_registry = NULLPTR);
 
-/// \brief Overload of \see DeclarationToReader accepting a custom exec context
 ARROW_EXPORT Result<std::unique_ptr<RecordBatchReader>> DeclarationToReader(
-    Declaration declaration, ExecContext exec_context);
+    Declaration declaration, QueryOptions query_options);
 
 /// \brief Utility method to run a declaration and ignore results
 ///

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -352,7 +352,6 @@ class ARROW_EXPORT SinkNodeConsumer {
   /// This will be run once the schema is finalized as the plan is starting and
   /// before any calls to Consume.  A common use is to save off the schema so that
   /// batches can be interpreted.
-  /// TODO(ARROW-17837) Move ExecPlan* plan to query context
   virtual Status Init(const std::shared_ptr<Schema>& schema,
                       BackpressureControl* backpressure_control, ExecPlan* plan) = 0;
   /// \brief Consume a batch of data
@@ -380,7 +379,7 @@ class ARROW_EXPORT ConsumingSinkNodeOptions : public ExecNodeOptions {
   /// \brief Names to rename the sink's schema fields to
   ///
   /// If specified then names must be provided for all fields. Currently, only a flat
-  /// schema is supported (see ARROW-15901).
+  /// schema is supported (see GH-31875).
   ///
   /// If not specified then names will be generated based on the source data.
   std::vector<std::string> names;
@@ -619,7 +618,7 @@ class ARROW_EXPORT TableSinkNodeOptions : public ExecNodeOptions {
   /// \brief Custom names to use for the columns.
   ///
   /// If specified then names must be provided for all fields. Currently, only a flat
-  /// schema is supported (see ARROW-15901).
+  /// schema is supported (see GH-31875).
   ///
   /// If not specified then names will be generated based on the source data.
   std::vector<std::string> names;

--- a/cpp/src/arrow/compute/exec/options.h
+++ b/cpp/src/arrow/compute/exec/options.h
@@ -381,6 +381,8 @@ class ARROW_EXPORT ConsumingSinkNodeOptions : public ExecNodeOptions {
   ///
   /// If specified then names must be provided for all fields. Currently, only a flat
   /// schema is supported (see ARROW-15901).
+  ///
+  /// If not specified then names will be generated based on the source data.
   std::vector<std::string> names;
   /// \brief Controls whether batches should be emitted immediately or sequenced in order
   ///
@@ -614,6 +616,13 @@ class ARROW_EXPORT TableSinkNodeOptions : public ExecNodeOptions {
   ///
   /// \see QueryOptions for more details
   std::optional<bool> sequence_output;
+  /// \brief Custom names to use for the columns.
+  ///
+  /// If specified then names must be provided for all fields. Currently, only a flat
+  /// schema is supported (see ARROW-15901).
+  ///
+  /// If not specified then names will be generated based on the source data.
+  std::vector<std::string> names;
 };
 
 struct ARROW_EXPORT PivotLongerRowTemplate {

--- a/cpp/src/arrow/engine/substrait/relation.h
+++ b/cpp/src/arrow/engine/substrait/relation.h
@@ -51,7 +51,7 @@ struct ARROW_ENGINE_EXPORT RelationInfo {
 };
 
 /// Information resulting from converting a Substrait plan
-struct PlanInfo {
+struct ARROW_ENGINE_EXPORT PlanInfo {
   /// The root declaration.
   ///
   /// Only plans containing a single top-level relation are supported and so this will

--- a/cpp/src/arrow/engine/substrait/relation.h
+++ b/cpp/src/arrow/engine/substrait/relation.h
@@ -50,5 +50,21 @@ struct ARROW_ENGINE_EXPORT RelationInfo {
   std::optional<std::vector<int>> field_output_indices;
 };
 
+/// Information resulting from converting a Substrait plan
+struct PlanInfo {
+  /// The root declaration.
+  ///
+  /// Only plans containing a single top-level relation are supported and so this will
+  /// represent that relation.
+  ///
+  /// This should technically be a RelRoot but some producers use a simple Rel here and so
+  /// Acero currently supports that case.
+  DeclarationInfo root;
+  /// The names of the output fields
+  ///
+  /// If `root` was created from a simple Rel then this will be empty
+  std::vector<std::string> names;
+};
+
 }  // namespace engine
 }  // namespace arrow

--- a/cpp/src/arrow/engine/substrait/serde.h
+++ b/cpp/src/arrow/engine/substrait/serde.h
@@ -28,6 +28,7 @@
 #include "arrow/compute/type_fwd.h"
 #include "arrow/dataset/type_fwd.h"
 #include "arrow/engine/substrait/options.h"
+#include "arrow/engine/substrait/relation.h"
 #include "arrow/engine/substrait/type_fwd.h"
 #include "arrow/engine/substrait/visibility.h"
 #include "arrow/result.h"
@@ -151,7 +152,7 @@ ARROW_ENGINE_EXPORT Result<std::shared_ptr<compute::ExecPlan>> DeserializePlan(
 /// Plan is returned here.
 /// \param[in] conversion_options options to control how the conversion is to be done.
 /// \return A declaration representing the Substrait plan
-ARROW_ENGINE_EXPORT Result<compute::Declaration> DeserializePlan(
+ARROW_ENGINE_EXPORT Result<PlanInfo> DeserializePlan(
     const Buffer& buf, const ExtensionIdRegistry* registry = NULLPTR,
     ExtensionSet* ext_set_out = NULLPTR,
     const ConversionOptions& conversion_options = {});

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -321,6 +321,7 @@ def test_named_table_empty_names():
     with pytest.raises(ArrowInvalid, match=exec_message):
         substrait.run_query(buf, table_provider=table_provider)
 
+
 @pytest.mark.parametrize("use_threads", [True, False])
 def test_udf_via_substrait(unary_func_fixture, use_threads):
     test_table = pa.Table.from_pydict({"x": [1, 2, 3]})
@@ -562,10 +563,10 @@ def test_udf_via_substrait_wrong_udf_name():
         pa.substrait.run_query(buf, table_provider=table_provider)
     assert "No function registered" in str(excinfo.value)
 
+
 @pytest.mark.parametrize("use_threads", [True, False])
 def test_output_field_names(use_threads):
     in_table = pa.Table.from_pydict({"x": [1, 2, 3]})
-    in_schema = pa.schema([pa.field("x", pa.int64())])
 
     def table_provider(names, schema):
         return in_table

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -442,7 +442,6 @@ def test_udf_via_substrait(unary_func_fixture, use_threads):
     function, name = unary_func_fixture
     expected_tb = test_table.add_column(1, 'y', function(
         mock_scalar_udf_context(10), test_table['x']))
-    res_tb = res_tb.rename_columns(['x', 'y'])
     assert res_tb == expected_tb
 
 
@@ -598,6 +597,10 @@ def test_output_field_names(use_threads):
     """
 
     buf = pa._substrait._parse_json_plan(tobytes(substrait_query))
+    reader = pa.substrait.run_query(
+        buf, table_provider=table_provider, use_threads=use_threads)
+    res_tb = reader.read_all()
+
     expected = pa.Table.from_pydict({"out": [1, 2, 3]})
 
     assert res_tb == expected


### PR DESCRIPTION
### Rationale for this change

Users want to be able to specify custom column names / aliases instead of using the ones generated by Acero

### What changes are included in this PR?

It is now possible to specify custom column names in QueryOptions.  In addition, the python Substrait bindings now use this feature so that the Substrait plan's names will be respsected.

### Are these changes tested?

Yes.  These are tested directly.  In addition, I added a python test for the Substrait bindings as this is actually a regression there and this should close https://github.com/apache/arrow/issues/33434.

### Are there any user-facing changes?

There is new API surface but nothing breaking.
* Closes: #34405
* Closes: gh-33434