### PR TITLE
GH-34256: [Dev] Update release scripts with main as new default branch

### DIFF
--- a/dev/release/post-04-ruby.sh
+++ b/dev/release/post-04-ruby.sh
@@ -39,7 +39,7 @@ homebrew_version=$(
   curl \
     --fail \
     --no-progress-meter \
-    https://raw.githubusercontent.com/Homebrew/homebrew-core/master/Formula/apache-arrow-glib.rb | \
+    https://raw.githubusercontent.com/Homebrew/homebrew-core/HEAD/Formula/apache-arrow-glib.rb | \
     grep url | \
     grep -o "[0-9]*\.[0-9]*\.[0-9]*" | \
     head -n 1)


### PR DESCRIPTION
### Rationale for this change
This is a follow up task after switching the `apache/arrow` default branch name from `master` to `main`. Usages of `master` were evaluated to determine whether they can be switched over to `main`.

### What changes are included in this PR?
Only once instance of usage of `master` was changed. The other usages depend on `master` being used as the default branch in external repositories.

#### This is a summary of my investigation:

`post-04-ruby.sh`
  - Modified URL to use `HEAD` instead of `master` to refer to the most updated version of the code.


 `post-12-msys2.sh`
  - The usages of `master` is referring to the default branch of `msys2/MINGW-packages`
  - Since the default branch used by the repo is still `master` this will be kept until they swap over.


`post-13-homebrew.sh`
  - The usage of `master` in this file is similar to that of `post-12-msys2.sh`. It is referring to the default branch of the `homebrew/homebrew-core` repository, which is still using `master` as the default branch.


`post-14-vcpkg.sh`
  -  The usage of `master` in this file is similar to that of `post-12-msys2.sh`. It is referring to the default branch of the `microsoft/vcpkg` repository, which is still using `master` as the default branch.


`post-15-conan.sh`
  - The usage of `master` in this file is similar to that of `post-12-msys2.sh`. It is referring to the default branch of the `conan-io/conan-center-index` repository, which is still using `master` as the default branch.

### Are these changes tested?
I verified the change in `post-04-ruby.sh` by navigating to the new URL and confirming the contents are the same as the existing URL. Additionally, existing `release` CI tests will run as part of this pull request.

### Are there any user-facing changes?
No, users nor users of the development tools should see a difference in behavior from this change.
* Closes: #34256