### PR TITLE
GH-34262: [C++][ORC] Support union type

### DIFF
--- a/cpp/src/arrow/adapters/orc/adapter_test.cc
+++ b/cpp/src/arrow/adapters/orc/adapter_test.cc
@@ -22,6 +22,7 @@
 #include <string>
 
 #include "arrow/adapters/orc/adapter.h"
+#include "arrow/adapters/orc/util.h"
 #include "arrow/array.h"
 #include "arrow/buffer.h"
 #include "arrow/buffer_builder.h"
@@ -34,7 +35,6 @@
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/random.h"
 #include "arrow/type.h"
-#include "arrow/util/decimal.h"
 #include "arrow/util/key_value_metadata.h"
 
 namespace liborc = orc;
@@ -840,21 +840,72 @@ TEST_F(TestORCWriterSingleArray, WriteListOfMap) {
   AssertArrayWriteReadEqual(array, array, kDefaultSmallMemStreamSize * 10);
 }
 
-TEST_F(TestORCWriterSingleArray, WriteSparseUnion) {
-  const int64_t num_rows = 1024;
-  auto type =
-      sparse_union({field("_union_0", utf8()), field("_union_1", int32())}, {0, 1});
-  auto array = checked_pointer_cast<SparseUnionArray>(rand.ArrayOf(type, num_rows, 0.4));
+namespace {
+
+// The random array generator fills random unselected values in the child arrays
+// of SparseUnionArray. However, orc file only contains dense union type meaning
+// that these unselected values will not be written to the file (so we can never
+// read them back and compare equality in the unit test). Because the orc reader
+// fills unselected values to nulls when reading from the file. So flattening
+// the SparseUnionArray before writing makes it easy for the array equality check.
+std::shared_ptr<Array> FlattenSparseUnionArray(std::shared_ptr<Array> array) {
+  auto union_array = checked_pointer_cast<SparseUnionArray>(array);
   ArrayVector children;
   for (int i = 0; i < array->num_fields(); ++i) {
-    ASSERT_OK_AND_ASSIGN(auto flattened_child, array->GetFlattenedField(i));
+    ASSIGN_OR_ABORT(auto flattened_child, union_array->GetFlattenedField(i));
     children.emplace_back(std::move(flattened_child));
   }
-  auto flattened_array = std::make_shared<SparseUnionArray>(
-      array->type(), array->length(), std::move(children), array->type_codes(),
-      array->offset());
-  AssertArrayWriteReadEqual(flattened_array, flattened_array,
-                            kDefaultSmallMemStreamSize * 10);
+  return std::make_shared<SparseUnionArray>(array->type(), array->length(),
+                                            std::move(children),
+                                            union_array->type_codes(), array->offset());
+}
+
+void TestUnionConversion(std::shared_ptr<Array> array) {
+  auto length = array->length();
+  auto orc_type = liborc::Type::buildTypeFromString("uniontype<string,int>");
+  auto orc_batch = orc_type->createRowBatch(array->length(), *liborc::getDefaultPool());
+
+  // Convert from arrow to orc
+  int arrow_chunk_offset = 0;
+  int64_t arrow_index_offset = 0;
+  ASSERT_OK(adapters::orc::WriteBatch(ChunkedArray{array}, length, &arrow_chunk_offset,
+                                      &arrow_index_offset, orc_batch.get()));
+
+  // Convert from orc to arrow
+  ASSIGN_OR_ABORT(auto array_builder, MakeBuilder(array->type()));
+  ASSERT_OK(adapters::orc::AppendBatch(orc_type.get(), orc_batch.get(), 0, length,
+                                       array_builder.get()));
+  std::shared_ptr<Array> result;
+  ASSERT_OK(array_builder->Finish(&result));
+
+  // Compare the result
+  AssertArraysEqual(*array, *result);
+}
+
+}  // namespace
+
+TEST_F(TestORCWriterSingleArray, WriteSparseUnion) {
+  constexpr int64_t num_rows = 1024;
+  auto type =
+      sparse_union({field("_union_0", utf8()), field("_union_1", int32())}, {0, 1});
+  auto array =
+      FlattenSparseUnionArray(rand.ArrayOf(type, num_rows, /*null_probability=*/0.4));
+  AssertArrayWriteReadEqual(array, array, kDefaultSmallMemStreamSize * 10);
+}
+
+TEST(TestWriteReadORCBatch, SparseUnionConversion) {
+  random::RandomArrayGenerator rand(kRandomSeed);
+  auto type = sparse_union({field("a", utf8()), field("b", int32())}, {0, 1});
+  auto array = FlattenSparseUnionArray(
+      rand.ArrayOf(type, /*size=*/1024, /*null_probability=*/0.4));
+  TestUnionConversion(std::move(array));
+}
+
+TEST(TestWriteReadORCBatch, DenseUnionConversion) {
+  random::RandomArrayGenerator rand(kRandomSeed);
+  auto type = dense_union({field("a", utf8()), field("b", int32())}, {0, 1});
+  auto array = rand.ArrayOf(type, /*size=*/1024, /*null_probability=*/0.4);
+  TestUnionConversion(std::move(array));
 }
 
 class TestORCWriterMultipleWrite : public ::testing::Test {

--- a/cpp/src/arrow/adapters/orc/util.cc
+++ b/cpp/src/arrow/adapters/orc/util.cc
@@ -44,6 +44,7 @@ namespace liborc = orc;
 namespace arrow {
 
 using internal::checked_cast;
+using internal::checked_pointer_cast;
 using internal::ToChars;
 
 namespace adapters {
@@ -283,6 +284,58 @@ Status AppendDecimalBatch(const liborc::Type* type,
   return Status::OK();
 }
 
+template <typename UnionBuilderType>
+Status AppendUnionBatchInternal(const liborc::Type* type,
+                                liborc::ColumnVectorBatch* column_vector_batch,
+                                int64_t offset, int64_t length, ArrayBuilder* abuilder) {
+  auto builder = checked_cast<UnionBuilderType*>(abuilder);
+  auto batch = checked_cast<liborc::UnionVectorBatch*>(column_vector_batch);
+
+  auto union_type = checked_pointer_cast<UnionType>(abuilder->type());
+  const std::vector<int8_t>& type_codes = union_type->type_codes();
+  const unsigned char* tags = batch->tags.data();
+
+  for (int64_t i = offset; i < length + offset; i++) {
+    if (!batch->hasNulls || batch->notNull[i]) {
+      auto child_id = tags[i];
+      auto type_code = type_codes[child_id];
+      RETURN_NOT_OK(builder->Append(type_code));
+
+      auto child_type = type->getSubtype(child_id);
+      auto child_batch = batch->children[child_id];
+      auto start = static_cast<int64_t>(batch->offsets[i]);
+      RETURN_NOT_OK(AppendBatch(child_type, child_batch, start, /*length=*/1,
+                                builder->child_builder(child_id).get()));
+
+      if constexpr (std::is_same_v<UnionBuilderType, SparseUnionBuilder>) {
+        // Append null value to other child builders for sparse union type.
+        for (int8_t field_id = 0; field_id < union_type->num_fields(); field_id++) {
+          if (field_id != child_id) {
+            RETURN_NOT_OK(builder->child_builder(field_id)->AppendNull());
+          }
+        }
+      }
+    } else {
+      RETURN_NOT_OK(builder->AppendNull());
+    }
+  }
+  return Status::OK();
+}
+
+Status AppendUnionBatch(const liborc::Type* type,
+                        liborc::ColumnVectorBatch* column_vector_batch, int64_t offset,
+                        int64_t length, ArrayBuilder* abuilder) {
+  if (abuilder->type()->id() == Type::SPARSE_UNION) {
+    return AppendUnionBatchInternal<SparseUnionBuilder>(type, column_vector_batch, offset,
+                                                        length, abuilder);
+  }
+  if (abuilder->type()->id() == Type::DENSE_UNION) {
+    return AppendUnionBatchInternal<DenseUnionBuilder>(type, column_vector_batch, offset,
+                                                       length, abuilder);
+  }
+  return Status::Invalid("Invalid union type");
+}
+
 }  // namespace
 
 Status AppendBatch(const liborc::Type* type, liborc::ColumnVectorBatch* batch,
@@ -332,6 +385,8 @@ Status AppendBatch(const liborc::Type* type, liborc::ColumnVectorBatch* batch,
       return AppendTimestampBatch(batch, offset, length, builder);
     case liborc::DECIMAL:
       return AppendDecimalBatch(type, batch, offset, length, builder);
+    case liborc::UNION:
+      return AppendUnionBatch(type, batch, offset, length, builder);
     default:
       return Status::NotImplemented("Not implemented type kind: ", kind);
   }
@@ -414,6 +469,32 @@ Result<std::shared_ptr<Array>> NormalizeArray(const std::shared_ptr<Array>& arra
                                         map_array->value_offsets(), key_array, item_array,
                                         map_array->null_bitmap(), map_array->null_count(),
                                         map_array->offset());
+    }
+    case Type::type::DENSE_UNION: {
+      auto dense_union_array = checked_pointer_cast<DenseUnionArray>(array);
+      ArrayVector children;
+      for (int i = 0; i < dense_union_array->num_fields(); ++i) {
+        ARROW_ASSIGN_OR_RAISE(auto child_array,
+                              NormalizeArray(dense_union_array->field(i)));
+        children.emplace_back(std::move(child_array));
+      }
+      return std::make_shared<DenseUnionArray>(
+          dense_union_array->type(), dense_union_array->length(), children,
+          dense_union_array->type_codes(), dense_union_array->value_offsets(),
+          dense_union_array->offset());
+    }
+    case Type::type::SPARSE_UNION: {
+      auto sparse_union_array = checked_pointer_cast<SparseUnionArray>(array);
+      ArrayVector children;
+      for (int i = 0; i < sparse_union_array->num_fields(); ++i) {
+        ARROW_ASSIGN_OR_RAISE(auto flattened_child,
+                              sparse_union_array->GetFlattenedField(i));
+        ARROW_ASSIGN_OR_RAISE(auto child_array, NormalizeArray(flattened_child));
+        children.emplace_back(std::move(child_array));
+      }
+      return std::make_shared<SparseUnionArray>(
+          sparse_union_array->type(), sparse_union_array->length(), children,
+          sparse_union_array->type_codes(), sparse_union_array->offset());
     }
     default: {
       return array;
@@ -578,7 +659,7 @@ struct FixedSizeBinaryAppender {
 };
 
 // static_cast from int64_t or double to itself shouldn't introduce overhead
-// Pleae see
+// Please see
 // https://stackoverflow.com/questions/19106826/
 // can-static-cast-to-same-type-introduce-runtime-overhead
 template <class DataType, class BatchType>
@@ -742,6 +823,55 @@ Status WriteMapBatch(const Array& array, int64_t orc_offset,
   return Status::OK();
 }
 
+template <typename UnionArrayType>
+Status WriteUnionBatch(const Array& array, int64_t orc_offset,
+                       liborc::ColumnVectorBatch* column_vector_batch) {
+  auto union_array = checked_cast<const UnionArrayType*>(&array);
+  auto batch = checked_cast<liborc::UnionVectorBatch*>(column_vector_batch);
+
+  // Union array itself does not have nulls.
+  batch->hasNulls = false;
+
+  int64_t arrow_length = array.length();
+  int64_t running_arrow_offset = 0, running_orc_offset = orc_offset;
+
+  for (; running_arrow_offset < arrow_length;
+       running_orc_offset++, running_arrow_offset++) {
+    auto child_id = union_array->child_id(running_arrow_offset);
+    batch->tags[running_orc_offset] = static_cast<unsigned char>(child_id);
+    batch->notNull[running_orc_offset] = true;
+
+    // Orc union batch is dense, so we need to find the previous row that has the same
+    // type code (or child_id) to calculate the offset.
+    batch->offsets[running_orc_offset] = 0;
+    for (int64_t row = running_orc_offset - 1; row >= 0; row--) {
+      if (batch->tags[row] == child_id) {
+        batch->offsets[running_orc_offset] = batch->offsets[row] + 1;
+        break;
+      }
+    }
+
+    // Fill child batch.
+    liborc::ColumnVectorBatch* child_batch = batch->children[child_id];
+    int64_t child_array_orc_offset = batch->offsets[running_orc_offset];
+    int64_t child_array_arrow_offset;
+
+    if constexpr (std::is_same_v<UnionArrayType, DenseUnionArray>) {
+      child_array_arrow_offset = union_array->value_offset(running_arrow_offset);
+    } else {
+      static_assert(std::is_same_v<UnionArrayType, SparseUnionArray>);
+      child_array_arrow_offset = running_arrow_offset;
+    }
+    child_batch->resize(child_array_orc_offset + 1);
+
+    std::shared_ptr<Array> child_array = union_array->field(child_id);
+    RETURN_NOT_OK(WriteBatch(*(child_array->Slice(child_array_arrow_offset, 1)),
+                             child_array_orc_offset, child_batch));
+  }
+
+  return Status::OK();
+}
+
 Status WriteBatch(const Array& array, int64_t orc_offset,
                   liborc::ColumnVectorBatch* column_vector_batch) {
   Type::type kind = array.type_id();
@@ -827,6 +957,10 @@ Status WriteBatch(const Array& array, int64_t orc_offset,
       return WriteListBatch<FixedSizeListArray>(array, orc_offset, column_vector_batch);
     case Type::type::MAP:
       return WriteMapBatch(array, orc_offset, column_vector_batch);
+    case Type::type::SPARSE_UNION:
+      return WriteUnionBatch<SparseUnionArray>(array, orc_offset, column_vector_batch);
+    case Type::type::DENSE_UNION:
+      return WriteUnionBatch<DenseUnionArray>(array, orc_offset, column_vector_batch);
     default: {
       return Status::NotImplemented("Unknown or unsupported Arrow type: ",
                                     array.type()->ToString());
@@ -884,8 +1018,7 @@ Result<ORC_UNIQUE_PTR<liborc::Type>> GetOrcType(const DataType& type) {
       ORC_UNIQUE_PTR<liborc::Type> out_type = liborc::createStructType();
       std::vector<std::shared_ptr<Field>> arrow_fields =
           checked_cast<const StructType&>(type).fields();
-      for (std::vector<std::shared_ptr<Field>>::iterator it = arrow_fields.begin();
-           it != arrow_fields.end(); ++it) {
+      for (auto it = arrow_fields.begin(); it != arrow_fields.end(); ++it) {
         std::string field_name = (*it)->name();
         std::shared_ptr<DataType> arrow_child_type = (*it)->type();
         ARROW_ASSIGN_OR_RAISE(auto orc_subtype, GetOrcType(*arrow_child_type));
@@ -907,10 +1040,8 @@ Result<ORC_UNIQUE_PTR<liborc::Type>> GetOrcType(const DataType& type) {
       ORC_UNIQUE_PTR<liborc::Type> out_type = liborc::createUnionType();
       std::vector<std::shared_ptr<Field>> arrow_fields =
           checked_cast<const UnionType&>(type).fields();
-      for (std::vector<std::shared_ptr<Field>>::iterator it = arrow_fields.begin();
-           it != arrow_fields.end(); ++it) {
-        std::string field_name = (*it)->name();
-        std::shared_ptr<DataType> arrow_child_type = (*it)->type();
+      for (const auto& arrow_field : arrow_fields) {
+        std::shared_ptr<DataType> arrow_child_type = arrow_field->type();
         ARROW_ASSIGN_OR_RAISE(auto orc_subtype, GetOrcType(*arrow_child_type));
         out_type->addUnionChild(std::move(orc_subtype));
       }
@@ -994,7 +1125,6 @@ Result<std::shared_ptr<DataType>> GetArrowType(const liborc::Type* type) {
       } else {
         return decimal128(precision, scale);
       }
-      break;
     }
     case liborc::LIST: {
       if (subtype_count != 1) {
@@ -1021,6 +1151,9 @@ Result<std::shared_ptr<DataType>> GetArrowType(const liborc::Type* type) {
       return struct_(std::move(fields));
     }
     case liborc::UNION: {
+      if (subtype_count > UnionType::kMaxTypeCode + 1) {
+        return Status::TypeError("ORC union subtype count exceeds Arrow union limit");
+      }
       FieldVector fields(subtype_count);
       std::vector<int8_t> type_codes(subtype_count);
       for (int child = 0; child < subtype_count; ++child) {

--- a/cpp/src/arrow/adapters/orc/util.cc
+++ b/cpp/src/arrow/adapters/orc/util.cc
@@ -1122,9 +1122,8 @@ Result<std::shared_ptr<DataType>> GetArrowType(const liborc::Type* type) {
       if (precision == 0) {
         // In HIVE 0.11/0.12 precision is set as 0, but means max precision
         return decimal128(38, 6);
-      } else {
-        return decimal128(precision, scale);
       }
+      return decimal128(precision, scale);
     }
     case liborc::LIST: {
       if (subtype_count != 1) {

--- a/cpp/src/arrow/adapters/orc/util.h
+++ b/cpp/src/arrow/adapters/orc/util.h
@@ -35,8 +35,9 @@ Result<std::shared_ptr<DataType>> GetArrowType(const liborc::Type* type);
 
 Result<ORC_UNIQUE_PTR<liborc::Type>> GetOrcType(const Schema& schema);
 
-Status AppendBatch(const liborc::Type* type, liborc::ColumnVectorBatch* batch,
-                   int64_t offset, int64_t length, arrow::ArrayBuilder* builder);
+ARROW_EXPORT Status AppendBatch(const liborc::Type* type,
+                                liborc::ColumnVectorBatch* batch, int64_t offset,
+                                int64_t length, arrow::ArrayBuilder* builder);
 
 /// \brief Write a chunked array to an orc::ColumnVectorBatch
 ///
@@ -47,9 +48,9 @@ Status AppendBatch(const liborc::Type* type, liborc::ColumnVectorBatch* batch,
 /// before or after a process
 /// \param[in,out] column_vector_batch the orc::ColumnVectorBatch to be filled
 /// \return Status
-Status WriteBatch(const ChunkedArray& chunked_array, int64_t length,
-                  int* arrow_chunk_offset, int64_t* arrow_index_offset,
-                  liborc::ColumnVectorBatch* column_vector_batch);
+ARROW_EXPORT Status WriteBatch(const ChunkedArray& chunked_array, int64_t length,
+                               int* arrow_chunk_offset, int64_t* arrow_index_offset,
+                               liborc::ColumnVectorBatch* column_vector_batch);
 
 }  // namespace orc
 }  // namespace adapters


### PR DESCRIPTION
### Rationale for this change

The ORC adapter does not support union type yet.

### What changes are included in this PR?

Support union type to both ORC reader and writer.

### Are these changes tested?

To be added.

### Are there any user-facing changes?

No.
* Closes: #34262