### PR TITLE
GH-34417: [C++][Flight] Upgrade OpenTelemetry SemanticConventions header

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -4705,17 +4705,7 @@ if(ARROW_WITH_OPENTELEMETRY)
   # (OTel's cmake files do not call find_curl for you)
   find_curl()
   set(opentelemetry-cpp_SOURCE "AUTO")
-
-  if(ARROW_FLIGHT)
-    # In 1.5.0 they introduced the stable semantic convention header that we require
-    # in Flight.
-    set(OPENTELEMETRY_REQUIRED_VERSION 1.5.0)
-  else()
-    set(OPENTELEMETRY_REQUIRED_VERSION 1.0.0)
-  endif()
-
-  resolve_dependency(opentelemetry-cpp
-                     REQUIRED_VERSION ${OPENTELEMETRY_REQUIRED_VERSION})
+  resolve_dependency(opentelemetry-cpp)
   get_target_property(OPENTELEMETRY_INCLUDE_DIR opentelemetry-cpp::api
                       INTERFACE_INCLUDE_DIRECTORIES)
   message(STATUS "Found OpenTelemetry headers: ${OPENTELEMETRY_INCLUDE_DIR}")

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -4705,7 +4705,17 @@ if(ARROW_WITH_OPENTELEMETRY)
   # (OTel's cmake files do not call find_curl for you)
   find_curl()
   set(opentelemetry-cpp_SOURCE "AUTO")
-  resolve_dependency(opentelemetry-cpp)
+
+  if(ARROW_FLIGHT)
+    # In 1.5.0 they introduced the stable semantic convention header that we require
+    # in Flight.
+    set(OPENTELEMETRY_REQUIRED_VERSION 1.5.0)
+  else()
+    set(OPENTELEMETRY_REQUIRED_VERSION 1.0.0)
+  endif()
+
+  resolve_dependency(opentelemetry-cpp
+                     REQUIRED_VERSION ${OPENTELEMETRY_REQUIRED_VERSION})
   get_target_property(OPENTELEMETRY_INCLUDE_DIR opentelemetry-cpp::api
                       INTERFACE_INCLUDE_DIRECTORIES)
   message(STATUS "Found OpenTelemetry headers: ${OPENTELEMETRY_INCLUDE_DIR}")

--- a/cpp/src/arrow/flight/server_tracing_middleware.cc
+++ b/cpp/src/arrow/flight/server_tracing_middleware.cc
@@ -31,7 +31,7 @@
 #include <opentelemetry/trace/context.h>
 #include <opentelemetry/trace/propagation/http_trace_context.h>
 #include <opentelemetry/trace/semantic_conventions.h>
-#endif  // ARROW_WITH_OPENTELEMETRY
+#endif
 
 namespace arrow {
 namespace flight {

--- a/cpp/src/arrow/flight/server_tracing_middleware.cc
+++ b/cpp/src/arrow/flight/server_tracing_middleware.cc
@@ -31,14 +31,28 @@
 #include <opentelemetry/trace/context.h>
 #include <opentelemetry/trace/propagation/http_trace_context.h>
 #include <opentelemetry/trace/semantic_conventions.h>
-#endif
+#endif  // ARROW_WITH_OPENTELEMETRY
 
 namespace arrow {
 namespace flight {
 
 #ifdef ARROW_WITH_OPENTELEMETRY
 namespace otel = opentelemetry;
-namespace SemanticConventions = otel::trace::SemanticConventions;
+
+// TODO: Update this once opentelemetry-cpp exposes minor version as a macro
+// https://github.com/open-telemetry/opentelemetry-cpp/issues/2012
+// TODO: Remove once we drop support for opentelemetry-cpp < 1.8.0
+// They switched from ALL_CAPS to kConstantFormat in 1.8.0. But we can't check
+// the minor version until they expose that. So, for now, we vendor these constants.
+namespace SemanticConventions {
+static constexpr const char* kRpcGrpcStatusCode = "rpc.grpc.status_code";
+static constexpr const char* kRpcSystem = "rpc.system";
+static constexpr const char* kRpcService = "rpc.service";
+static constexpr const char* kRpcMethod = "rpc.method";
+namespace RpcSystemValues {
+static constexpr const char* kGrpc = "grpc";
+}
+}  // namespace SemanticConventions
 
 namespace {
 class FlightServerCarrier : public otel::context::propagation::TextMapCarrier {


### PR DESCRIPTION
### Rationale for this change

This is required for compatibility with opentelemtry-cpp 1.8.2 (released 2023-01-31) and beyond.

### What changes are included in this PR?

Replaced experimental header with stable one. Added a version guard to our CMake build to enforce minimum version of opentelemtry-cpp that has this header.

### Are these changes tested?

* [x] Built locally with minimum version of opentelemtry-cpp.

### Are there any user-facing changes?

Yes, this increases the minimum version of opentelemtry-cpp.

* Closes: #34417