### PR TITLE
GH-34386: [C++] Add a PathFromUriOrPath method

### DIFF
--- a/cpp/src/arrow/filesystem/filesystem.cc
+++ b/cpp/src/arrow/filesystem/filesystem.cc
@@ -759,7 +759,7 @@ Result<std::shared_ptr<FileSystem>> FileSystemFromUriOrPath(
   if (internal::DetectAbsolutePath(uri_string)) {
     // Normalize path separators
     if (out_path != nullptr) {
-      *out_path = ToSlashes(uri_string);
+      *out_path = std::string(RemoveTrailingSlash(ToSlashes(uri_string)));
     }
     return std::make_shared<LocalFileSystem>();
   }

--- a/cpp/src/arrow/filesystem/filesystem.cc
+++ b/cpp/src/arrow/filesystem/filesystem.cc
@@ -759,7 +759,8 @@ Result<std::shared_ptr<FileSystem>> FileSystemFromUriOrPath(
   if (internal::DetectAbsolutePath(uri_string)) {
     // Normalize path separators
     if (out_path != nullptr) {
-      *out_path = std::string(RemoveTrailingSlash(ToSlashes(uri_string)));
+      *out_path =
+          std::string(RemoveTrailingSlash(ToSlashes(uri_string), /*preserve_root=*/true));
     }
     return std::make_shared<LocalFileSystem>();
   }

--- a/cpp/src/arrow/filesystem/filesystem.h
+++ b/cpp/src/arrow/filesystem/filesystem.h
@@ -491,6 +491,7 @@ Result<std::shared_ptr<FileSystem>> FileSystemFromUri(const std::string& uri,
 /// file separators.
 ///
 /// \return The path inside the filesystem that is indicated by the URI.
+ARROW_EXPORT
 Result<std::string> PathFromUriOrPath(const FileSystem* filesystem,
                                       const std::string& uri);
 

--- a/cpp/src/arrow/filesystem/filesystem.h
+++ b/cpp/src/arrow/filesystem/filesystem.h
@@ -181,9 +181,12 @@ class ARROW_EXPORT FileSystem : public std::enable_shared_from_this<FileSystem> 
   /// when a user provides multiple URIs that should be compatible with the same
   /// filesystem.
   ///
-  /// uri can be an absolute path instead of a URI.  In that case it will ensure the
-  /// filesystem (if supplied) is the local filesystem (or some custom filesystem that
+  /// uri_string can be an absolute path instead of a URI.  In that case it will ensure
+  /// the filesystem (if supplied) is the local filesystem (or some custom filesystem that
   /// is capable of reading local paths) and will normalize the path's file separators.
+  ///
+  /// Note, this method only checks to ensure the URI scheme is valid.  It will not detect
+  /// inconsistencies like a mismatching region or endpoint override.
   ///
   /// \return The path inside the filesystem that is indicated by the URI.
   virtual Result<std::string> PathFromUri(const std::string& uri_string) const;

--- a/cpp/src/arrow/filesystem/filesystem.h
+++ b/cpp/src/arrow/filesystem/filesystem.h
@@ -476,6 +476,24 @@ Result<std::shared_ptr<FileSystem>> FileSystemFromUri(const std::string& uri,
                                                       const io::IOContext& io_context,
                                                       std::string* out_path = NULLPTR);
 
+/// \brief Ensure a URI (or path) is compatible with the given filesystem and return the
+///        path
+///
+/// \param filesystem A filesystem that should be capable of fetching the URI
+/// \param uri A URI representing a resource in the given filesystem.
+///
+/// This method will check to ensure the given filesystem is compatible with the
+/// URI.  If that behavior is not desired then NULLPTR can be specified for the
+/// filesystem and that check will be skipped.
+///
+/// uri can be an absolute path instead of a URI.  In that case it will ensure the
+/// filesystem (if supplied) is the local filesystem and will normalize the path's
+/// file separators.
+///
+/// \return The path inside the filesystem that is indicated by the URI.
+Result<std::string> PathFromUriOrPath(const FileSystem* filesystem,
+                                      const std::string& uri);
+
 /// \brief Create a new FileSystem by URI
 ///
 /// Same as FileSystemFromUri, but in addition also recognize non-URIs

--- a/cpp/src/arrow/filesystem/gcsfs.cc
+++ b/cpp/src/arrow/filesystem/gcsfs.cc
@@ -874,28 +874,9 @@ bool GcsFileSystem::Equals(const FileSystem& other) const {
 }
 
 Result<std::string> GcsFileSystem::PathFromUri(const std::string& uri_string) const {
-  if (internal::DetectAbsolutePath(uri_string)) {
-    return Status::Invalid(
-        "The GCS filesystem is not capable of loading local paths.  URIs must start "
-        "with gs:// or gcs://");
-  }
-  Uri uri;
-  ARROW_RETURN_NOT_OK(uri.Parse(uri_string));
-  const auto scheme = uri.scheme();
-  if (uri.scheme() != "gs" && uri.scheme() != "gcs") {
-    return Status::Invalid("GCS URIs must start with gs:// or gcs:// but received ",
-                           uri_string);
-  }
-  std::string path;
-  ARROW_ASSIGN_OR_RAISE(GcsOptions parsed_options, GcsOptions::FromUri(uri, &path));
-  const GcsOptions& existing_options = impl_->options();
-  if (parsed_options.endpoint_override != existing_options.endpoint_override) {
-    return Status::Invalid("Provided URI specified endpoint '",
-                           parsed_options.endpoint_override,
-                           "' but existing filesystem is configured for endpoint '",
-                           existing_options.endpoint_override, "'");
-  }
-  return path;
+  return internal::PathFromUriHelper(uri_string, {"gs", "gcs"},
+                                     /*accept_local_paths=*/false,
+                                     internal::AuthorityHandlingBehavior::kPrepend);
 }
 
 Result<FileInfo> GcsFileSystem::GetFileInfo(const std::string& path) {

--- a/cpp/src/arrow/filesystem/gcsfs.h
+++ b/cpp/src/arrow/filesystem/gcsfs.h
@@ -178,6 +178,7 @@ class ARROW_EXPORT GcsFileSystem : public FileSystem {
   const GcsOptions& options() const;
 
   bool Equals(const FileSystem& other) const override;
+  Result<std::string> PathFromUri(const std::string& uri_string) const override;
 
   Result<FileInfo> GetFileInfo(const std::string& path) override;
   Result<FileInfoVector> GetFileInfo(const FileSelector& select) override;

--- a/cpp/src/arrow/filesystem/gcsfs_test.cc
+++ b/cpp/src/arrow/filesystem/gcsfs_test.cc
@@ -1397,15 +1397,11 @@ TEST_F(GcsIntegrationTest, TestFileSystemFromUri) {
                                                    PreexistingBucketPath()));
   EXPECT_EQ(fs2->type_name(), "gcs");
   ASSERT_THAT(fs->PathFromUri("/foo/bar"),
-              Raises(StatusCode::Invalid, testing::HasSubstr("URIs must start with")));
+              Raises(StatusCode::Invalid, testing::HasSubstr("Expected a URI")));
   ASSERT_THAT(
       fs->PathFromUri("s3:///foo/bar"),
-      Raises(StatusCode::Invalid, testing::HasSubstr("GCS URIs must start with")));
-  ASSERT_THAT(
-      fs->PathFromUri(std::string("gs://anonymous@") + PreexistingBucketPath() +
-                      "?endpoint_override=foo"),
       Raises(StatusCode::Invalid,
-             testing::HasSubstr("but existing filesystem is configured for endpoint")));
+             testing::HasSubstr("expected a URI with one of the schemes (gs, gcs)")));
 }
 
 }  // namespace

--- a/cpp/src/arrow/filesystem/gcsfs_test.cc
+++ b/cpp/src/arrow/filesystem/gcsfs_test.cc
@@ -1383,9 +1383,15 @@ TEST_F(GcsIntegrationTest, OpenInputFileClosed) {
 
 TEST_F(GcsIntegrationTest, TestFileSystemFromUri) {
   // Smoke test for FileSystemFromUri
-  ASSERT_OK_AND_ASSIGN(auto fs, FileSystemFromUri(std::string("gs://anonymous@") +
-                                                  PreexistingBucketPath()));
+  std::string path;
+  ASSERT_OK_AND_ASSIGN(
+      auto fs,
+      FileSystemFromUri(std::string("gs://anonymous@") + PreexistingBucketPath(), &path));
   EXPECT_EQ(fs->type_name(), "gcs");
+  EXPECT_EQ(path, PreexistingBucketName());
+  ASSERT_OK_AND_ASSIGN(path, PathFromUriOrPath(fs.get(), std::string("gs://anonymous@") +
+                                                             PreexistingBucketPath()));
+  EXPECT_EQ(path, PreexistingBucketName());
   ASSERT_OK_AND_ASSIGN(auto fs2, FileSystemFromUri(std::string("gcs://anonymous@") +
                                                    PreexistingBucketPath()));
   EXPECT_EQ(fs2->type_name(), "gcs");

--- a/cpp/src/arrow/filesystem/hdfs.cc
+++ b/cpp/src/arrow/filesystem/hdfs.cc
@@ -474,19 +474,9 @@ bool HadoopFileSystem::Equals(const FileSystem& other) const {
 }
 
 Result<std::string> HadoopFileSystem::PathFromUri(const std::string& uri_string) const {
-  if (internal::DetectAbsolutePath(uri_string)) {
-    return Status::Invalid(
-        "The HDFS filesystem is not capable of loading local paths.  URIs must start "
-        "with hdfs:// or viewfs://");
-  }
-  Uri uri;
-  ARROW_RETURN_NOT_OK(uri.Parse(uri_string));
-  const auto scheme = uri.scheme();
-  if (uri.scheme() != "hdfs" && uri.scheme() != "viewfs") {
-    return Status::Invalid("HDFS URIs must start with hdfs:// or viewfs:// but received ",
-                           uri_string);
-  }
-  return uri.path();
+  return internal::PathFromUriHelper(uri_string, {"hdfs", "viewfs"},
+                                     /*accept_local_paths=*/false,
+                                     internal::AuthorityHandlingBehavior::kIgnore);
 }
 
 Result<std::vector<FileInfo>> HadoopFileSystem::GetFileInfo(const FileSelector& select) {

--- a/cpp/src/arrow/filesystem/hdfs.cc
+++ b/cpp/src/arrow/filesystem/hdfs.cc
@@ -473,6 +473,22 @@ bool HadoopFileSystem::Equals(const FileSystem& other) const {
   return options().Equals(hdfs.options());
 }
 
+Result<std::string> HadoopFileSystem::PathFromUri(const std::string& uri_string) const {
+  if (internal::DetectAbsolutePath(uri_string)) {
+    return Status::Invalid(
+        "The HDFS filesystem is not capable of loading local paths.  URIs must start "
+        "with hdfs:// or viewfs://");
+  }
+  Uri uri;
+  ARROW_RETURN_NOT_OK(uri.Parse(uri_string));
+  const auto scheme = uri.scheme();
+  if (uri.scheme() != "hdfs" && uri.scheme() != "viewfs") {
+    return Status::Invalid("HDFS URIs must start with hdfs:// or viewfs:// but received ",
+                           uri_string);
+  }
+  return uri.path();
+}
+
 Result<std::vector<FileInfo>> HadoopFileSystem::GetFileInfo(const FileSelector& select) {
   return impl_->GetFileInfo(select);
 }

--- a/cpp/src/arrow/filesystem/hdfs.h
+++ b/cpp/src/arrow/filesystem/hdfs.h
@@ -66,6 +66,7 @@ class ARROW_EXPORT HadoopFileSystem : public FileSystem {
   std::string type_name() const override { return "hdfs"; }
   HdfsOptions options() const;
   bool Equals(const FileSystem& other) const override;
+  Result<std::string> PathFromUri(const std::string& uri_string) const override;
 
   /// \cond FALSE
   using FileSystem::GetFileInfo;

--- a/cpp/src/arrow/filesystem/hdfs_test.cc
+++ b/cpp/src/arrow/filesystem/hdfs_test.cc
@@ -119,6 +119,8 @@ class TestHadoopFileSystem : public ::testing::Test, public HadoopFileSystemTest
     ARROW_LOG(INFO) << "!!! uri = " << ss.str();
     ASSERT_OK_AND_ASSIGN(uri_fs, FileSystemFromUri(ss.str(), &path));
     ASSERT_EQ(path, "/");
+    ASSERT_OK_AND_ASSIGN(path, PathFromUriOrPath(uri_fs.get(), ss.str()));
+    ASSERT_EQ(path, "/");
 
     // Sanity check
     ASSERT_OK(uri_fs->CreateDir("AB"));

--- a/cpp/src/arrow/filesystem/hdfs_test.cc
+++ b/cpp/src/arrow/filesystem/hdfs_test.cc
@@ -119,7 +119,7 @@ class TestHadoopFileSystem : public ::testing::Test, public HadoopFileSystemTest
     ARROW_LOG(INFO) << "!!! uri = " << ss.str();
     ASSERT_OK_AND_ASSIGN(uri_fs, FileSystemFromUri(ss.str(), &path));
     ASSERT_EQ(path, "/");
-    ASSERT_OK_AND_ASSIGN(path, PathFromUriOrPath(uri_fs.get(), ss.str()));
+    ASSERT_OK_AND_ASSIGN(path, uri_fs->PathFromUri(ss.str()));
     ASSERT_EQ(path, "/");
 
     // Sanity check

--- a/cpp/src/arrow/filesystem/localfs.cc
+++ b/cpp/src/arrow/filesystem/localfs.cc
@@ -238,13 +238,15 @@ Result<LocalFileSystemOptions> LocalFileSystemOptions::FromUri(
 #ifdef _WIN32
     std::stringstream ss;
     ss << "//" << host << "/" << internal::RemoveLeadingSlash(uri.path());
-    *out_path = std::string(internal::RemoveTrailingSlash(ss.str()));
+    *out_path =
+        std::string(internal::RemoveTrailingSlash(ss.str(), /*preserve_root=*/true));
 #else
     return Status::Invalid("Unsupported hostname in non-Windows local URI: '",
                            uri.ToString(), "'");
 #endif
   } else {
-    *out_path = std::string(internal::RemoveTrailingSlash(uri.path()));
+    *out_path =
+        std::string(internal::RemoveTrailingSlash(uri.path(), /*preserve_root=*/true));
   }
 
   // TODO handle use_mmap option

--- a/cpp/src/arrow/filesystem/localfs.cc
+++ b/cpp/src/arrow/filesystem/localfs.cc
@@ -238,13 +238,13 @@ Result<LocalFileSystemOptions> LocalFileSystemOptions::FromUri(
 #ifdef _WIN32
     std::stringstream ss;
     ss << "//" << host << "/" << internal::RemoveLeadingSlash(uri.path());
-    *out_path = ss.str();
+    *out_path = std::string(internal::RemoveTrailingSlash(ss.str()));
 #else
     return Status::Invalid("Unsupported hostname in non-Windows local URI: '",
                            uri.ToString(), "'");
 #endif
   } else {
-    *out_path = uri.path();
+    *out_path = std::string(internal::RemoveTrailingSlash(uri.path()));
   }
 
   // TODO handle use_mmap option

--- a/cpp/src/arrow/filesystem/localfs.h
+++ b/cpp/src/arrow/filesystem/localfs.h
@@ -82,6 +82,7 @@ class ARROW_EXPORT LocalFileSystem : public FileSystem {
   std::string type_name() const override { return "local"; }
 
   Result<std::string> NormalizePath(std::string path) override;
+  Result<std::string> PathFromUri(const std::string& uri_string) const override;
 
   bool Equals(const FileSystem& other) const override;
 
@@ -120,14 +121,6 @@ class ARROW_EXPORT LocalFileSystem : public FileSystem {
  protected:
   LocalFileSystemOptions options_;
 };
-
-namespace internal {
-
-// Return whether the string is detected as a local absolute path.
-ARROW_EXPORT
-bool DetectAbsolutePath(const std::string& s);
-
-}  // namespace internal
 
 }  // namespace fs
 }  // namespace arrow

--- a/cpp/src/arrow/filesystem/localfs_test.cc
+++ b/cpp/src/arrow/filesystem/localfs_test.cc
@@ -184,7 +184,7 @@ class TestLocalFS : public LocalFSTestMixin {
     }
     std::string path;
     ASSERT_OK_AND_ASSIGN(fs_, fs_from_uri(uri, &path));
-    ASSERT_EQ(path, local_path_);
+    ASSERT_EQ(path, std::string(RemoveTrailingSlash(local_path_)));
 
     // Test that the right location on disk is accessed
     CreateFile(fs_.get(), local_path_ + "abc", "some data");
@@ -352,7 +352,7 @@ TYPED_TEST(TestLocalFS, FileSystemFromUriNoScheme) {
   this->TestLocalUriOrPath(this->path_formatter_("/foo/bar"), "/foo/bar");
 
 #ifdef _WIN32
-  this->TestLocalUriOrPath(this->path_formatter_("C:/foo/bar/"), "C:/foo/bar/");
+  this->TestLocalUriOrPath(this->path_formatter_("C:/foo/bar/"), "C:/foo/bar");
 #endif
 
   // Relative paths

--- a/cpp/src/arrow/filesystem/localfs_test.cc
+++ b/cpp/src/arrow/filesystem/localfs_test.cc
@@ -202,6 +202,7 @@ class TestLocalFS : public LocalFSTestMixin {
   template <typename FileSystemFromUriFunc>
   void CheckLocalUri(const std::string& uri, const std::string& expected_path,
                      FileSystemFromUriFunc&& fs_from_uri) {
+    ARROW_SCOPED_TRACE("uri = ", uri);
     if (!path_formatter_.supports_uri()) {
       return;  // skip
     }

--- a/cpp/src/arrow/filesystem/localfs_test.cc
+++ b/cpp/src/arrow/filesystem/localfs_test.cc
@@ -350,6 +350,7 @@ TYPED_TEST(TestLocalFS, FileSystemFromUriNoScheme) {
 
   // Variations
   this->TestLocalUriOrPath(this->path_formatter_("/foo/bar"), "/foo/bar");
+  this->TestLocalUriOrPath(this->path_formatter_("/"), "/");
 
 #ifdef _WIN32
   this->TestLocalUriOrPath(this->path_formatter_("C:/foo/bar/"), "C:/foo/bar");

--- a/cpp/src/arrow/filesystem/mockfs.cc
+++ b/cpp/src/arrow/filesystem/mockfs.cc
@@ -436,6 +436,19 @@ MockFileSystem::MockFileSystem(TimePoint current_time, const io::IOContext& io_c
 
 bool MockFileSystem::Equals(const FileSystem& other) const { return this == &other; }
 
+Result<std::string> MockFileSystem::PathFromUri(const std::string& uri_string) const {
+  if (internal::DetectAbsolutePath(uri_string)) {
+    return std::string(RemoveLeadingSlash(uri_string));
+  }
+  Uri uri;
+  ARROW_RETURN_NOT_OK(uri.Parse(uri_string));
+  const auto scheme = uri.scheme();
+  if (uri.scheme() != "mock") {
+    return Status::Invalid("Mock URIs must start with mock:// but received ", uri_string);
+  }
+  return std::string(RemoveLeadingSlash(uri.path()));
+}
+
 Status MockFileSystem::CreateDir(const std::string& path, bool recursive) {
   RETURN_NOT_OK(ValidatePath(path));
   auto parts = SplitAbstractPath(path);

--- a/cpp/src/arrow/filesystem/mockfs.cc
+++ b/cpp/src/arrow/filesystem/mockfs.cc
@@ -437,16 +437,11 @@ MockFileSystem::MockFileSystem(TimePoint current_time, const io::IOContext& io_c
 bool MockFileSystem::Equals(const FileSystem& other) const { return this == &other; }
 
 Result<std::string> MockFileSystem::PathFromUri(const std::string& uri_string) const {
-  if (internal::DetectAbsolutePath(uri_string)) {
-    return std::string(RemoveLeadingSlash(uri_string));
-  }
-  Uri uri;
-  ARROW_RETURN_NOT_OK(uri.Parse(uri_string));
-  const auto scheme = uri.scheme();
-  if (uri.scheme() != "mock") {
-    return Status::Invalid("Mock URIs must start with mock:// but received ", uri_string);
-  }
-  return std::string(RemoveLeadingSlash(uri.path()));
+  ARROW_ASSIGN_OR_RAISE(
+      std::string parsed_path,
+      internal::PathFromUriHelper(uri_string, {"mock"}, /*accept_local_paths=*/true,
+                                  internal::AuthorityHandlingBehavior::kDisallow));
+  return std::string(internal::RemoveLeadingSlash(parsed_path));
 }
 
 Status MockFileSystem::CreateDir(const std::string& path, bool recursive) {

--- a/cpp/src/arrow/filesystem/mockfs.h
+++ b/cpp/src/arrow/filesystem/mockfs.h
@@ -66,6 +66,7 @@ class ARROW_EXPORT MockFileSystem : public FileSystem {
   std::string type_name() const override { return "mock"; }
 
   bool Equals(const FileSystem& other) const override;
+  Result<std::string> PathFromUri(const std::string& uri_string) const override;
 
   // XXX It's not very practical to have to explicitly declare inheritance
   // of default overrides.

--- a/cpp/src/arrow/filesystem/path_util.cc
+++ b/cpp/src/arrow/filesystem/path_util.cc
@@ -129,7 +129,11 @@ std::string EnsureLeadingSlash(std::string_view v) {
     return std::string(v);
   }
 }
-std::string_view RemoveTrailingSlash(std::string_view key) {
+std::string_view RemoveTrailingSlash(std::string_view key, bool preserve_root) {
+  if (preserve_root && key.size() == 1) {
+    // If the user gives us "/" then don't return ""
+    return key;
+  }
   while (!key.empty() && key.back() == kSep) {
     key.remove_suffix(1);
   }

--- a/cpp/src/arrow/filesystem/path_util.cc
+++ b/cpp/src/arrow/filesystem/path_util.cc
@@ -134,6 +134,12 @@ std::string_view RemoveTrailingSlash(std::string_view key, bool preserve_root) {
     // If the user gives us "/" then don't return ""
     return key;
   }
+#ifdef _WIN32
+  if (preserve_root && key.size() == 3 && key[1] == ':' && key[0] != '/') {
+    // If the user gives us C:/ then don't return C:
+    return key;
+  }
+#endif
   while (!key.empty() && key.back() == kSep) {
     key.remove_suffix(1);
   }

--- a/cpp/src/arrow/filesystem/path_util.h
+++ b/cpp/src/arrow/filesystem/path_util.h
@@ -69,8 +69,11 @@ std::string_view RemoveLeadingSlash(std::string_view s);
 ARROW_EXPORT
 std::string EnsureTrailingSlash(std::string_view s);
 
+/// \brief remove the forward slash (if any) from the given path
+/// \param s the input path
+/// \param preserve_root if true, allow a path of just "/" to remain unchanged
 ARROW_EXPORT
-std::string_view RemoveTrailingSlash(std::string_view s);
+std::string_view RemoveTrailingSlash(std::string_view s, bool preserve_root = false);
 
 ARROW_EXPORT
 Status AssertNoTrailingSlash(std::string_view s);

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -2236,32 +2236,8 @@ bool S3FileSystem::Equals(const FileSystem& other) const {
 }
 
 Result<std::string> S3FileSystem::PathFromUri(const std::string& uri_string) const {
-  if (internal::DetectAbsolutePath(uri_string)) {
-    return Status::Invalid(
-        "The S3 filesystem is not capable of loading local paths.  URIs must start "
-        "with s3://");
-  }
-  Uri uri;
-  ARROW_RETURN_NOT_OK(uri.Parse(uri_string));
-  const auto scheme = uri.scheme();
-  if (uri.scheme() != "s3") {
-    return Status::Invalid("S3 URIs must start with s3:// but received ", uri_string);
-  }
-  std::string path;
-  ARROW_ASSIGN_OR_RAISE(S3Options parsed_options, S3Options::FromUri(uri, &path));
-  const S3Options& existing_options = impl_->options();
-  if (parsed_options.endpoint_override != existing_options.endpoint_override) {
-    return Status::Invalid("Provided URI specified endpoint '",
-                           parsed_options.endpoint_override,
-                           "' but existing filesystem is configured for endpoint '",
-                           existing_options.endpoint_override, "'");
-  }
-  if (parsed_options.region != existing_options.region) {
-    return Status::Invalid("Provided URI specified region '", parsed_options.region,
-                           "' but existing filesystem is configured for region '",
-                           existing_options.region, "'");
-  }
-  return path;
+  return internal::PathFromUriHelper(uri_string, {"s3"}, /*accept_local_paths=*/false,
+                                     internal::AuthorityHandlingBehavior::kPrepend);
 }
 
 S3Options S3FileSystem::options() const { return impl_->options(); }

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -247,6 +247,7 @@ class ARROW_EXPORT S3FileSystem : public FileSystem {
   std::string region() const;
 
   bool Equals(const FileSystem& other) const override;
+  Result<std::string> PathFromUri(const std::string& uri_string) const override;
 
   /// \cond FALSE
   using FileSystem::GetFileInfo;

--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -1149,24 +1149,12 @@ TEST_F(TestS3FS, FileSystemFromUri) {
 
   // Incorrect scheme
   ASSERT_THAT(fs->PathFromUri("file:///@bucket/somedir/subdir/subfile"),
-              Raises(StatusCode::Invalid, testing::HasSubstr("must start with s3://")));
+              Raises(StatusCode::Invalid,
+                     testing::HasSubstr("expected a URI with one of the schemes (s3)")));
 
   // Not a URI
   ASSERT_THAT(fs->PathFromUri("/@bucket/somedir/subdir/subfile"),
-              Raises(StatusCode::Invalid, testing::HasSubstr("must start with s3://")));
-
-  // Correct scheme, wrong endpoint
-  ASSERT_THAT(
-      fs->PathFromUri("s3://@bucket/somedir/subdir/subfile"),
-      Raises(StatusCode::Invalid,
-             testing::HasSubstr("but existing filesystem is configured for endpoint")));
-
-  // Correct scheme & endpoint, wrong region
-  ss << "&region=us-west-2";
-  ASSERT_THAT(
-      fs->PathFromUri(ss.str()),
-      Raises(StatusCode::Invalid,
-             testing::HasSubstr("but existing filesystem is configured for region")));
+              Raises(StatusCode::Invalid, testing::HasSubstr("Expected a URI")));
 
   // Check the filesystem has the right connection parameters
   AssertFileInfo(fs.get(), path, FileType::File, 8);

--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -1143,6 +1143,9 @@ TEST_F(TestS3FS, FileSystemFromUri) {
   ASSERT_OK_AND_ASSIGN(auto fs, FileSystemFromUri(ss.str(), &path));
   ASSERT_EQ(path, "bucket/somedir/subdir/subfile");
 
+  ASSERT_OK_AND_ASSIGN(path, PathFromUriOrPath(fs.get(), ss.str()));
+  ASSERT_EQ(path, "bucket/somedir/subdir/subfile");
+
   // Check the filesystem has the right connection parameters
   AssertFileInfo(fs.get(), path, FileType::File, 8);
 }

--- a/cpp/src/arrow/filesystem/util_internal.cc
+++ b/cpp/src/arrow/filesystem/util_internal.cc
@@ -128,7 +128,8 @@ Result<std::string> PathFromUriHelper(const std::string& uri_string,
                                       AuthorityHandlingBehavior authority_handling) {
   if (internal::DetectAbsolutePath(uri_string)) {
     if (accept_local_paths) {
-      return uri_string;
+      // Normalize the path and remove any trailing slash
+      return std::string(internal::RemoveTrailingSlash(ToSlashes(uri_string)));
     }
     return Status::Invalid(
         "The filesystem is not capable of loading local paths.  Expected a URI but "

--- a/cpp/src/arrow/filesystem/util_internal.cc
+++ b/cpp/src/arrow/filesystem/util_internal.cc
@@ -129,7 +129,8 @@ Result<std::string> PathFromUriHelper(const std::string& uri_string,
   if (internal::DetectAbsolutePath(uri_string)) {
     if (accept_local_paths) {
       // Normalize the path and remove any trailing slash
-      return std::string(internal::RemoveTrailingSlash(ToSlashes(uri_string)));
+      return std::string(
+          internal::RemoveTrailingSlash(ToSlashes(uri_string), /*preserve_root=*/true));
     }
     return Status::Invalid(
         "The filesystem is not capable of loading local paths.  Expected a URI but "

--- a/cpp/src/arrow/filesystem/util_internal.h
+++ b/cpp/src/arrow/filesystem/util_internal.h
@@ -63,6 +63,29 @@ Result<Uri> ParseFileSystemUri(const std::string& uri_string);
 ARROW_EXPORT
 bool DetectAbsolutePath(const std::string& s);
 
+/// \brief describes how to handle the authority (host) component of the URI
+enum class AuthorityHandlingBehavior {
+  // Return an invalid status if the authority is non-empty
+  kDisallow = 0,
+  // Prepend the authority to the path (e.g. authority/some/path)
+  kPrepend = 1,
+  // Convert to a Windows style network path (e.g. //authority/some/path)
+  kWindows = 2,
+  // Ignore the authority and just use the path
+  kIgnore = 3
+};
+
+/// \brief check to see if uri_string matches one of the supported schemes and return the
+/// path component
+/// \param uri_string a uri or local path to test and convert
+/// \param supported_schemes the set of URI schemes that should be accepted
+/// \param accept_local_paths if true, allow an absolute path
+/// \return the path portion of the URI
+Result<std::string> PathFromUriHelper(const std::string& uri_string,
+                                      std::vector<std::string> supported_schemes,
+                                      bool accept_local_paths,
+                                      AuthorityHandlingBehavior authority_handling);
+
 /// \brief Return files matching the glob pattern on the filesystem
 ///
 /// Globbing starts from the root of the filesystem.

--- a/cpp/src/arrow/filesystem/util_internal.h
+++ b/cpp/src/arrow/filesystem/util_internal.h
@@ -24,9 +24,11 @@
 #include "arrow/filesystem/filesystem.h"
 #include "arrow/io/interfaces.h"
 #include "arrow/status.h"
+#include "arrow/util/uri.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
+using internal::Uri;
 namespace fs {
 namespace internal {
 
@@ -49,6 +51,17 @@ Status NotAFile(std::string_view path);
 
 ARROW_EXPORT
 Status InvalidDeleteDirContents(std::string_view path);
+
+/// \brief Parse the string as a URI
+/// \param uri_string the string to parse
+///
+/// This is the same as Uri::Parse except it tolerates Windows
+/// file URIs that contain backslash instead of /
+Result<Uri> ParseFileSystemUri(const std::string& uri_string);
+
+/// \brief check if the string is a local absolute path
+ARROW_EXPORT
+bool DetectAbsolutePath(const std::string& s);
 
 /// \brief Return files matching the glob pattern on the filesystem
 ///


### PR DESCRIPTION
### Rationale for this change

We have some URI parsing indirectly exposed through FilesystemFromUri.  However, this isn't very useful if the user has multiple URIs or if they already have a filesystem.  This method allows that same URI handling to be used even if the user already has a filesystem.

### What changes are included in this PR?

Adds a new arrow::fs::PathFromUriOrPath method

### Are these changes tested?

Yes, via unit tests

### Are there any user-facing changes?

There is a new API method but no changes to any existing APIs
* Closes: #34386