### PR TITLE
GH-34440: [Ruby] Add support for `RecordBatch{File,Stream}Reader#each` without block

### DIFF
--- a/ruby/red-arrow/lib/arrow/record-batch-file-reader.rb
+++ b/ruby/red-arrow/lib/arrow/record-batch-file-reader.rb
@@ -20,6 +20,8 @@ module Arrow
     include Enumerable
 
     def each
+      return to_enum(__method__) unless block_given?
+
       n_record_batches.times do |i|
         yield(get_record_batch(i))
       end

--- a/ruby/red-arrow/lib/arrow/record-batch-file-reader.rb
+++ b/ruby/red-arrow/lib/arrow/record-batch-file-reader.rb
@@ -20,7 +20,7 @@ module Arrow
     include Enumerable
 
     def each
-      return to_enum(__method__) unless block_given?
+      return to_enum(__method__) {n_record_batches} unless block_given?
 
       n_record_batches.times do |i|
         yield(get_record_batch(i))

--- a/ruby/red-arrow/lib/arrow/record-batch-stream-reader.rb
+++ b/ruby/red-arrow/lib/arrow/record-batch-stream-reader.rb
@@ -20,6 +20,8 @@ module Arrow
     include Enumerable
 
     def each
+      return to_enum(__method__) unless block_given?
+
       loop do
         record_batch = next_record_batch
         break if record_batch.nil?

--- a/ruby/red-arrow/test/test-record-batch-file-reader.rb
+++ b/ruby/red-arrow/test/test-record-batch-file-reader.rb
@@ -119,10 +119,17 @@ class RecordBatchFileReaderTest < Test::Unit::TestCase
       Arrow::Table.new(number: [1, 2, 3]).save(buffer)
       Arrow::BufferInputStream.open(buffer) do |input|
         reader = Arrow::RecordBatchFileReader.new(input)
-        assert_equal([
-                       Arrow::RecordBatch.new(number: [1, 2, 3]),
-                     ],
-                     reader.each.to_a)
+        each = reader.each
+        assert_equal({
+                       size: 1,
+                       to_a: [
+                         Arrow::RecordBatch.new(number: [1, 2, 3]),
+                       ],
+                     }.
+                     {
+                       size: each.size,
+                       to_a: each.to_a,
+                     })
       end
     end
   end

--- a/ruby/red-arrow/test/test-record-batch-file-reader.rb
+++ b/ruby/red-arrow/test/test-record-batch-file-reader.rb
@@ -125,7 +125,7 @@ class RecordBatchFileReaderTest < Test::Unit::TestCase
                        to_a: [
                          Arrow::RecordBatch.new(number: [1, 2, 3]),
                        ],
-                     }.
+                     },
                      {
                        size: each.size,
                        to_a: each.to_a,

--- a/ruby/red-arrow/test/test-record-batch-stream-reader.rb
+++ b/ruby/red-arrow/test/test-record-batch-stream-reader.rb
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class RecordBatchFileReaderTest < Test::Unit::TestCase
+class RecordBatchStreamReaderTest < Test::Unit::TestCase
   test("write/read") do
     fields = [
       Arrow::Field.new("uint8",  :uint8),
@@ -31,9 +31,9 @@ class RecordBatchFileReaderTest < Test::Unit::TestCase
     ]
     schema = Arrow::Schema.new(fields)
 
-    tempfile = Tempfile.new(["batch", ".arrow"])
+    tempfile = Tempfile.new(["batch", ".arrows"])
     Arrow::FileOutputStream.open(tempfile.path, false) do |output|
-      Arrow::RecordBatchFileWriter.open(output, schema) do |writer|
+      Arrow::RecordBatchStreamWriter.open(output, schema) do |writer|
         uints = [1, 2, 4, 8]
         ints = [1, -2, 4, -8]
         floats = [1.1, -2.2, 4.4, -8.8]
@@ -56,7 +56,7 @@ class RecordBatchFileReaderTest < Test::Unit::TestCase
     end
 
     Arrow::MemoryMappedInputStream.open(tempfile.path) do |input|
-      reader = Arrow::RecordBatchFileReader.new(input)
+      reader = Arrow::RecordBatchStreamReader.new(input)
       reader.each do |record_batch|
         assert_equal([
                        {
@@ -116,9 +116,9 @@ class RecordBatchFileReaderTest < Test::Unit::TestCase
   sub_test_case("#each") do
     test("without block") do
       buffer = Arrow::ResizableBuffer.new(1024)
-      Arrow::Table.new(number: [1, 2, 3]).save(buffer)
+      Arrow::Table.new(number: [1, 2, 3]).save(buffer, format: :arrows)
       Arrow::BufferInputStream.open(buffer) do |input|
-        reader = Arrow::RecordBatchFileReader.new(input)
+        reader = Arrow::RecordBatchStreamReader.new(input)
         assert_equal([
                        Arrow::RecordBatch.new(number: [1, 2, 3]),
                      ],


### PR DESCRIPTION
### Rationale for this change

`#each` must support this.

### What changes are included in this PR?

`to_enum` and tests for this.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #34440