### PR TITLE
GH-34283 [Python] Add types_mapper support to index for to_pandas

### DIFF
--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -647,23 +647,6 @@ class TestConvertMetadata:
             result = new_table.to_pandas()
             tm.assert_frame_equal(result, expected)
 
-    @pytest.mark.parametrize("index", ["a", ["a", "b"]])
-    def test_to_pandas_types_mapper_index(self, index):
-        if Version(pd.__version__) < Version("1.5.0"):
-            pytest.skip("ArrowDtype missing")
-        df = pd.DataFrame(
-            {
-                "a": [1, 2],
-                "b": [3, 4],
-                "c": [5, 6],
-            },
-            dtype=pd.ArrowDtype(pa.int64()),
-        ).set_index(index)
-        expected = df.copy()
-        table = pa.table(df)
-        result = table.to_pandas(types_mapper=pd.ArrowDtype)
-        tm.assert_frame_equal(result, expected)
-
 
 class TestConvertPrimitiveTypes:
     """
@@ -4174,6 +4157,24 @@ def test_roundtrip_empty_table_with_extension_dtype_index():
                                          {'left': 1, 'right': 2},
                                          {'left': 2, 'right': 3}],
                                         dtype='object')
+
+
+@pytest.mark.parametrize("index", ["a", ["a", "b"]])
+def test_to_pandas_types_mapper_index(index):
+    if Version(pd.__version__) < Version("1.5.0"):
+        pytest.skip("ArrowDtype missing")
+    df = pd.DataFrame(
+        {
+            "a": [1, 2],
+            "b": [3, 4],
+            "c": [5, 6],
+        },
+        dtype=pd.ArrowDtype(pa.int64()),
+    ).set_index(index)
+    expected = df.copy()
+    table = pa.table(df)
+    result = table.to_pandas(types_mapper=pd.ArrowDtype)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_array_to_pandas_types_mapper():

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -649,6 +649,8 @@ class TestConvertMetadata:
 
     @pytest.mark.parametrize("index", ["a", ["a", "b"]])
     def test_to_pandas_types_mapper_index(self, index):
+        if Version(pd.__version__) < Version("1.5.0"):
+            pytest.skip("ArrowDtype missing")
         df = pd.DataFrame(
             {
                 "a": [1, 2],

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -647,6 +647,21 @@ class TestConvertMetadata:
             result = new_table.to_pandas()
             tm.assert_frame_equal(result, expected)
 
+    @pytest.mark.parametrize("index", ["a", ["a", "b"]])
+    def test_to_pandas_types_mapper_index(self, index):
+        df = pd.DataFrame(
+            {
+                "a": [1, 2],
+                "b": [3, 4],
+                "c": [5, 6],
+            },
+            dtype=pd.ArrowDtype(pa.int64()),
+        ).set_index(index)
+        expected = df.copy()
+        table = pa.table(df)
+        result = table.to_pandas(types_mapper=pd.ArrowDtype)
+        tm.assert_frame_equal(result, expected)
+
 
 class TestConvertPrimitiveTypes:
     """


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Only respects types_mapper for indexes as well

### Are these changes tested?

Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

Technically this breaks the API in a way that we would now respect the types_mapper for the index.

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->

- [x] closes #34283

cc @jorisvandenbossche 