### PR TITLE
GH-34446: [C++][Parquet] Fix RecordReaderPrimitveTypeTests test

### DIFF
--- a/cpp/src/parquet/column_reader_test.cc
+++ b/cpp/src/parquet/column_reader_test.cc
@@ -936,7 +936,7 @@ TEST_P(RecordReaderPrimitiveTypeTest, ReadNullableRepeated) {
   ASSERT_EQ(records_read, 0);
 
   // Test the descr() accessor.
-  ASSERT_EQ(record_reader_->descr()->max_definition_level(), 1);
+  ASSERT_EQ(record_reader_->descr()->max_definition_level(), 3);
 
   // Read [10], null
   // We do not read this null for both reading dense and spaced.


### PR DESCRIPTION
### Rationale for this change

The test data was updated in https://github.com/apache/arrow/pull/17877 to have a depth of 3.

An assertion was added concurrently to assert the max depth in https://github.com/apache/arrow/pull/34318.

This PR fixes the test so the changes are compatible.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #34446