### PR TITLE
GH-34453: [Go] Support Builders for user defined extensions

### DIFF
--- a/go/arrow/array/array.go
+++ b/go/arrow/array/array.go
@@ -27,7 +27,7 @@ import (
 type arraymarshal interface {
 	arrow.Array
 
-	getOneForMarshal(i int) interface{}
+	GetOneForMarshal(i int) interface{}
 }
 
 const (

--- a/go/arrow/array/binary.go
+++ b/go/arrow/array/binary.go
@@ -141,7 +141,7 @@ func (a *Binary) setData(data *Data) {
 	}
 }
 
-func (a *Binary) getOneForMarshal(i int) interface{} {
+func (a *Binary) GetOneForMarshal(i int) interface{} {
 	if a.IsNull(i) {
 		return nil
 	}
@@ -151,7 +151,7 @@ func (a *Binary) getOneForMarshal(i int) interface{} {
 func (a *Binary) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
-		vals[i] = a.getOneForMarshal(i)
+		vals[i] = a.GetOneForMarshal(i)
 	}
 	// golang marshal standard says that []byte will be marshalled
 	// as a base64-encoded string
@@ -274,7 +274,7 @@ func (a *LargeBinary) setData(data *Data) {
 	}
 }
 
-func (a *LargeBinary) getOneForMarshal(i int) interface{} {
+func (a *LargeBinary) GetOneForMarshal(i int) interface{} {
 	if a.IsNull(i) {
 		return nil
 	}
@@ -284,7 +284,7 @@ func (a *LargeBinary) getOneForMarshal(i int) interface{} {
 func (a *LargeBinary) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
-		vals[i] = a.getOneForMarshal(i)
+		vals[i] = a.GetOneForMarshal(i)
 	}
 	// golang marshal standard says that []byte will be marshalled
 	// as a base64-encoded string

--- a/go/arrow/array/binarybuilder.go
+++ b/go/arrow/array/binarybuilder.go
@@ -289,7 +289,7 @@ func (b *BinaryBuilder) appendNextOffset() {
 	b.appendOffsetVal(numBytes)
 }
 
-func (b *BinaryBuilder) unmarshalOne(dec *json.Decoder) error {
+func (b *BinaryBuilder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -316,9 +316,9 @@ func (b *BinaryBuilder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *BinaryBuilder) unmarshal(dec *json.Decoder) error {
+func (b *BinaryBuilder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -336,7 +336,7 @@ func (b *BinaryBuilder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("binary builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 var (

--- a/go/arrow/array/boolean.go
+++ b/go/arrow/array/boolean.go
@@ -81,7 +81,7 @@ func (a *Boolean) setData(data *Data) {
 	}
 }
 
-func (a *Boolean) getOneForMarshal(i int) interface{} {
+func (a *Boolean) GetOneForMarshal(i int) interface{} {
 	if a.IsValid(i) {
 		return a.Value(i)
 	}

--- a/go/arrow/array/booleanbuilder.go
+++ b/go/arrow/array/booleanbuilder.go
@@ -172,7 +172,7 @@ func (b *BooleanBuilder) newData() *Data {
 	return res
 }
 
-func (b *BooleanBuilder) unmarshalOne(dec *json.Decoder) error {
+func (b *BooleanBuilder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -205,9 +205,9 @@ func (b *BooleanBuilder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *BooleanBuilder) unmarshal(dec *json.Decoder) error {
+func (b *BooleanBuilder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -226,7 +226,7 @@ func (b *BooleanBuilder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("boolean builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 var (

--- a/go/arrow/array/builder.go
+++ b/go/arrow/array/builder.go
@@ -79,8 +79,8 @@ type Builder interface {
 	init(capacity int)
 	resize(newBits int, init func(int))
 
-	unmarshalOne(*json.Decoder) error
-	unmarshal(*json.Decoder) error
+	UnmarshalOne(*json.Decoder) error
+	Unmarshal(*json.Decoder) error
 
 	newData() *Data
 }
@@ -318,6 +318,10 @@ func NewBuilder(mem memory.Allocator, dtype arrow.DataType) Builder {
 		return NewMapBuilderWithType(mem, typ)
 	case arrow.EXTENSION:
 		typ := dtype.(arrow.ExtensionType)
+		bldr := typ.NewBuilder(mem, typ)
+		if bldr != nil {
+			return bldr.(Builder)
+		}
 		return NewExtensionBuilder(mem, typ)
 	case arrow.FIXED_SIZE_LIST:
 		typ := dtype.(*arrow.FixedSizeListType)

--- a/go/arrow/array/builder.go
+++ b/go/arrow/array/builder.go
@@ -318,11 +318,11 @@ func NewBuilder(mem memory.Allocator, dtype arrow.DataType) Builder {
 		return NewMapBuilderWithType(mem, typ)
 	case arrow.EXTENSION:
 		typ := dtype.(arrow.ExtensionType)
-		bldr := typ.NewBuilder(mem, typ)
-		if bldr != nil {
-			return bldr.(Builder)
+		bldr := NewExtensionBuilder(mem, typ)
+		if custom, ok := typ.(ExtensionBuilderWrapper); ok {
+			return custom.NewBuilder(bldr)
 		}
-		return NewExtensionBuilder(mem, typ)
+		return bldr
 	case arrow.FIXED_SIZE_LIST:
 		typ := dtype.(*arrow.FixedSizeListType)
 		return NewFixedSizeListBuilder(mem, typ.Len(), typ.Elem())

--- a/go/arrow/array/decimal128.go
+++ b/go/arrow/array/decimal128.go
@@ -80,7 +80,7 @@ func (a *Decimal128) setData(data *Data) {
 	}
 }
 
-func (a *Decimal128) getOneForMarshal(i int) interface{} {
+func (a *Decimal128) GetOneForMarshal(i int) interface{} {
 	if a.IsNull(i) {
 		return nil
 	}
@@ -94,7 +94,7 @@ func (a *Decimal128) getOneForMarshal(i int) interface{} {
 func (a *Decimal128) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
-		vals[i] = a.getOneForMarshal(i)
+		vals[i] = a.GetOneForMarshal(i)
 	}
 	return json.Marshal(vals)
 }
@@ -259,7 +259,7 @@ func (b *Decimal128Builder) newData() (data *Data) {
 	return
 }
 
-func (b *Decimal128Builder) unmarshalOne(dec *json.Decoder) error {
+func (b *Decimal128Builder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -298,9 +298,9 @@ func (b *Decimal128Builder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *Decimal128Builder) unmarshal(dec *json.Decoder) error {
+func (b *Decimal128Builder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -322,7 +322,7 @@ func (b *Decimal128Builder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("decimal128 builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 var (

--- a/go/arrow/array/decimal256.go
+++ b/go/arrow/array/decimal256.go
@@ -80,7 +80,7 @@ func (a *Decimal256) setData(data *Data) {
 	}
 }
 
-func (a *Decimal256) getOneForMarshal(i int) interface{} {
+func (a *Decimal256) GetOneForMarshal(i int) interface{} {
 	if a.IsNull(i) {
 		return nil
 	}
@@ -94,7 +94,7 @@ func (a *Decimal256) getOneForMarshal(i int) interface{} {
 func (a *Decimal256) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
-		vals[i] = a.getOneForMarshal(i)
+		vals[i] = a.GetOneForMarshal(i)
 	}
 	return json.Marshal(vals)
 }
@@ -259,7 +259,7 @@ func (b *Decimal256Builder) newData() (data *Data) {
 	return
 }
 
-func (b *Decimal256Builder) unmarshalOne(dec *json.Decoder) error {
+func (b *Decimal256Builder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -298,9 +298,9 @@ func (b *Decimal256Builder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *Decimal256Builder) unmarshal(dec *json.Decoder) error {
+func (b *Decimal256Builder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -322,7 +322,7 @@ func (b *Decimal256Builder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("arrow/array: decimal256 builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 var (

--- a/go/arrow/array/dictionary.go
+++ b/go/arrow/array/dictionary.go
@@ -281,18 +281,18 @@ func (d *Dictionary) GetValueIndex(i int) int {
 	return -1
 }
 
-func (d *Dictionary) getOneForMarshal(i int) interface{} {
+func (d *Dictionary) GetOneForMarshal(i int) interface{} {
 	if d.IsNull(i) {
 		return nil
 	}
 	vidx := d.GetValueIndex(i)
-	return d.Dictionary().(arraymarshal).getOneForMarshal(vidx)
+	return d.Dictionary().(arraymarshal).GetOneForMarshal(vidx)
 }
 
 func (d *Dictionary) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, d.Len())
 	for i := 0; i < d.Len(); i++ {
-		vals[i] = d.getOneForMarshal(i)
+		vals[i] = d.GetOneForMarshal(i)
 	}
 	return json.Marshal(vals)
 }
@@ -721,14 +721,14 @@ func (b *dictionaryBuilder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("dictionary builder must upack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
-func (b *dictionaryBuilder) unmarshal(dec *json.Decoder) error {
+func (b *dictionaryBuilder) Unmarshal(dec *json.Decoder) error {
 	bldr := NewBuilder(b.mem, b.dt.ValueType)
 	defer bldr.Release()
 
-	if err := bldr.unmarshal(dec); err != nil {
+	if err := bldr.Unmarshal(dec); err != nil {
 		return err
 	}
 
@@ -737,7 +737,7 @@ func (b *dictionaryBuilder) unmarshal(dec *json.Decoder) error {
 	return b.AppendArray(arr)
 }
 
-func (b *dictionaryBuilder) unmarshalOne(dec *json.Decoder) error {
+func (b *dictionaryBuilder) UnmarshalOne(dec *json.Decoder) error {
 	return errors.New("unmarshal json to dictionary not yet implemented")
 }
 

--- a/go/arrow/array/encoded.go
+++ b/go/arrow/array/encoded.go
@@ -200,12 +200,12 @@ func (r *RunEndEncoded) String() string {
 			buf.WriteByte(',')
 		}
 
-		value := r.values.(arraymarshal).getOneForMarshal(i)
+		value := r.values.(arraymarshal).GetOneForMarshal(i)
 		if byts, ok := value.(json.RawMessage); ok {
 			value = string(byts)
 		}
 		fmt.Fprintf(&buf, "{%d -> %v}",
-			r.ends.(arraymarshal).getOneForMarshal(i),
+			r.ends.(arraymarshal).GetOneForMarshal(i),
 			value)
 	}
 
@@ -213,9 +213,9 @@ func (r *RunEndEncoded) String() string {
 	return buf.String()
 }
 
-func (r *RunEndEncoded) getOneForMarshal(i int) interface{} {
+func (r *RunEndEncoded) GetOneForMarshal(i int) interface{} {
 	physIndex := encoded.FindPhysicalIndex(r.data, i+r.data.offset)
-	return r.values.(arraymarshal).getOneForMarshal(physIndex)
+	return r.values.(arraymarshal).GetOneForMarshal(physIndex)
 }
 
 func (r *RunEndEncoded) MarshalJSON() ([]byte, error) {
@@ -226,7 +226,7 @@ func (r *RunEndEncoded) MarshalJSON() ([]byte, error) {
 		if i != 0 {
 			buf.WriteByte(',')
 		}
-		if err := enc.Encode(r.getOneForMarshal(i)); err != nil {
+		if err := enc.Encode(r.GetOneForMarshal(i)); err != nil {
 			return nil, err
 		}
 	}
@@ -397,7 +397,7 @@ func (b *RunEndEncodedBuilder) newData() (data *Data) {
 	return
 }
 
-func (b *RunEndEncodedBuilder) unmarshalOne(dec *json.Decoder) error {
+func (b *RunEndEncodedBuilder) UnmarshalOne(dec *json.Decoder) error {
 	var value interface{}
 	if err := dec.Decode(&value); err != nil {
 		return err
@@ -422,13 +422,13 @@ func (b *RunEndEncodedBuilder) unmarshalOne(dec *json.Decoder) error {
 
 	b.Append(1)
 	b.lastUnmarshalled = value
-	return b.ValueBuilder().unmarshalOne(json.NewDecoder(bytes.NewReader(data)))
+	return b.ValueBuilder().UnmarshalOne(json.NewDecoder(bytes.NewReader(data)))
 }
 
-func (b *RunEndEncodedBuilder) unmarshal(dec *json.Decoder) error {
+func (b *RunEndEncodedBuilder) Unmarshal(dec *json.Decoder) error {
 	b.finishRun()
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -446,7 +446,7 @@ func (b *RunEndEncodedBuilder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("list builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 var (

--- a/go/arrow/array/extension.go
+++ b/go/arrow/array/extension.go
@@ -134,8 +134,8 @@ func (e *ExtensionArrayBase) String() string {
 	return fmt.Sprintf("(%s)%s", e.data.dtype, e.storage)
 }
 
-func (e *ExtensionArrayBase) getOneForMarshal(i int) interface{} {
-	return e.storage.getOneForMarshal(i)
+func (e *ExtensionArrayBase) GetOneForMarshal(i int) interface{} {
+	return e.storage.GetOneForMarshal(i)
 }
 
 func (e *ExtensionArrayBase) MarshalJSON() ([]byte, error) {

--- a/go/arrow/array/extension_builder.go
+++ b/go/arrow/array/extension_builder.go
@@ -16,6 +16,8 @@
 
 package array
 
+// ExtensionBuilderWrapper is an interface that you need to implement in your custom extension type if you want to provide a customer builder as well.
+// See example in ./arrow/internal/testing/types/extension_types.go
 type ExtensionBuilderWrapper interface {
 	NewBuilder(bldr *ExtensionBuilder) Builder
 }

--- a/go/arrow/array/extension_builder.go
+++ b/go/arrow/array/extension_builder.go
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package array
 
 type ExtensionBuilderWrapper interface {

--- a/go/arrow/array/extension_builder.go
+++ b/go/arrow/array/extension_builder.go
@@ -1,0 +1,5 @@
+package array
+
+type ExtensionBuilderWrapper interface {
+	NewBuilder(bldr *ExtensionBuilder) Builder
+}

--- a/go/arrow/array/fixed_size_list.go
+++ b/go/arrow/array/fixed_size_list.go
@@ -112,7 +112,7 @@ func (a *FixedSizeList) Release() {
 	a.values.Release()
 }
 
-func (a *FixedSizeList) getOneForMarshal(i int) interface{} {
+func (a *FixedSizeList) GetOneForMarshal(i int) interface{} {
 	if a.IsNull(i) {
 		return nil
 	}
@@ -278,7 +278,7 @@ func (b *FixedSizeListBuilder) newData() (data *Data) {
 	return
 }
 
-func (b *FixedSizeListBuilder) unmarshalOne(dec *json.Decoder) error {
+func (b *FixedSizeListBuilder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -287,7 +287,7 @@ func (b *FixedSizeListBuilder) unmarshalOne(dec *json.Decoder) error {
 	switch t {
 	case json.Delim('['):
 		b.Append(true)
-		if err := b.values.unmarshal(dec); err != nil {
+		if err := b.values.Unmarshal(dec); err != nil {
 			return err
 		}
 		// consume ']'
@@ -308,9 +308,9 @@ func (b *FixedSizeListBuilder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *FixedSizeListBuilder) unmarshal(dec *json.Decoder) error {
+func (b *FixedSizeListBuilder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -328,7 +328,7 @@ func (b *FixedSizeListBuilder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("fixed size list builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 var (

--- a/go/arrow/array/fixedsize_binary.go
+++ b/go/arrow/array/fixedsize_binary.go
@@ -79,7 +79,7 @@ func (a *FixedSizeBinary) setData(data *Data) {
 
 }
 
-func (a *FixedSizeBinary) getOneForMarshal(i int) interface{} {
+func (a *FixedSizeBinary) GetOneForMarshal(i int) interface{} {
 	if a.IsNull(i) {
 		return nil
 	}

--- a/go/arrow/array/fixedsize_binarybuilder.go
+++ b/go/arrow/array/fixedsize_binarybuilder.go
@@ -166,7 +166,7 @@ func (b *FixedSizeBinaryBuilder) newData() (data *Data) {
 	return
 }
 
-func (b *FixedSizeBinaryBuilder) unmarshalOne(dec *json.Decoder) error {
+func (b *FixedSizeBinaryBuilder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -206,9 +206,9 @@ func (b *FixedSizeBinaryBuilder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *FixedSizeBinaryBuilder) unmarshal(dec *json.Decoder) error {
+func (b *FixedSizeBinaryBuilder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -226,7 +226,7 @@ func (b *FixedSizeBinaryBuilder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("fixed size binary builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 var (

--- a/go/arrow/array/float16.go
+++ b/go/arrow/array/float16.go
@@ -71,7 +71,7 @@ func (a *Float16) setData(data *Data) {
 	}
 }
 
-func (a *Float16) getOneForMarshal(i int) interface{} {
+func (a *Float16) GetOneForMarshal(i int) interface{} {
 	if a.IsValid(i) {
 		return a.values[i].Float32()
 	}

--- a/go/arrow/array/float16_builder.go
+++ b/go/arrow/array/float16_builder.go
@@ -176,7 +176,7 @@ func (b *Float16Builder) newData() (data *Data) {
 	return
 }
 
-func (b *Float16Builder) unmarshalOne(dec *json.Decoder) error {
+func (b *Float16Builder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -210,9 +210,9 @@ func (b *Float16Builder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *Float16Builder) unmarshal(dec *json.Decoder) error {
+func (b *Float16Builder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -233,5 +233,5 @@ func (b *Float16Builder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("float16 builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }

--- a/go/arrow/array/interval.go
+++ b/go/arrow/array/interval.go
@@ -87,7 +87,7 @@ func (a *MonthInterval) setData(data *Data) {
 	}
 }
 
-func (a *MonthInterval) getOneForMarshal(i int) interface{} {
+func (a *MonthInterval) GetOneForMarshal(i int) interface{} {
 	if a.IsValid(i) {
 		return a.values[i]
 	}
@@ -267,7 +267,7 @@ func (b *MonthIntervalBuilder) newData() (data *Data) {
 	return
 }
 
-func (b *MonthIntervalBuilder) unmarshalOne(dec *json.Decoder) error {
+func (b *MonthIntervalBuilder) UnmarshalOne(dec *json.Decoder) error {
 	var v *arrow.MonthInterval
 	if err := dec.Decode(&v); err != nil {
 		return err
@@ -281,9 +281,9 @@ func (b *MonthIntervalBuilder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *MonthIntervalBuilder) unmarshal(dec *json.Decoder) error {
+func (b *MonthIntervalBuilder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -304,7 +304,7 @@ func (b *MonthIntervalBuilder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("month interval builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 // A type which represents an immutable sequence of arrow.DayTimeInterval values.
@@ -352,7 +352,7 @@ func (a *DayTimeInterval) setData(data *Data) {
 	}
 }
 
-func (a *DayTimeInterval) getOneForMarshal(i int) interface{} {
+func (a *DayTimeInterval) GetOneForMarshal(i int) interface{} {
 	if a.IsValid(i) {
 		return a.values[i]
 	}
@@ -530,7 +530,7 @@ func (b *DayTimeIntervalBuilder) newData() (data *Data) {
 	return
 }
 
-func (b *DayTimeIntervalBuilder) unmarshalOne(dec *json.Decoder) error {
+func (b *DayTimeIntervalBuilder) UnmarshalOne(dec *json.Decoder) error {
 	var v *arrow.DayTimeInterval
 	if err := dec.Decode(&v); err != nil {
 		return err
@@ -544,9 +544,9 @@ func (b *DayTimeIntervalBuilder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *DayTimeIntervalBuilder) unmarshal(dec *json.Decoder) error {
+func (b *DayTimeIntervalBuilder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -566,7 +566,7 @@ func (b *DayTimeIntervalBuilder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("day_time interval builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 // A type which represents an immutable sequence of arrow.DayTimeInterval values.
@@ -616,7 +616,7 @@ func (a *MonthDayNanoInterval) setData(data *Data) {
 	}
 }
 
-func (a *MonthDayNanoInterval) getOneForMarshal(i int) interface{} {
+func (a *MonthDayNanoInterval) GetOneForMarshal(i int) interface{} {
 	if a.IsValid(i) {
 		return a.values[i]
 	}
@@ -796,7 +796,7 @@ func (b *MonthDayNanoIntervalBuilder) newData() (data *Data) {
 	return
 }
 
-func (b *MonthDayNanoIntervalBuilder) unmarshalOne(dec *json.Decoder) error {
+func (b *MonthDayNanoIntervalBuilder) UnmarshalOne(dec *json.Decoder) error {
 	var v *arrow.MonthDayNanoInterval
 	if err := dec.Decode(&v); err != nil {
 		return err
@@ -810,9 +810,9 @@ func (b *MonthDayNanoIntervalBuilder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *MonthDayNanoIntervalBuilder) unmarshal(dec *json.Decoder) error {
+func (b *MonthDayNanoIntervalBuilder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -833,7 +833,7 @@ func (b *MonthDayNanoIntervalBuilder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("month_day_nano interval builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 var (

--- a/go/arrow/array/list.go
+++ b/go/arrow/array/list.go
@@ -87,7 +87,7 @@ func (a *List) setData(data *Data) {
 	a.values = MakeFromData(data.childData[0])
 }
 
-func (a *List) getOneForMarshal(i int) interface{} {
+func (a *List) GetOneForMarshal(i int) interface{} {
 	if a.IsNull(i) {
 		return nil
 	}
@@ -110,7 +110,7 @@ func (a *List) MarshalJSON() ([]byte, error) {
 		if i != 0 {
 			buf.WriteByte(',')
 		}
-		if err := enc.Encode(a.getOneForMarshal(i)); err != nil {
+		if err := enc.Encode(a.GetOneForMarshal(i)); err != nil {
 			return nil, err
 		}
 	}
@@ -210,7 +210,7 @@ func (a *LargeList) setData(data *Data) {
 	a.values = MakeFromData(data.childData[0])
 }
 
-func (a *LargeList) getOneForMarshal(i int) interface{} {
+func (a *LargeList) GetOneForMarshal(i int) interface{} {
 	if a.IsNull(i) {
 		return nil
 	}
@@ -233,7 +233,7 @@ func (a *LargeList) MarshalJSON() ([]byte, error) {
 		if i != 0 {
 			buf.WriteByte(',')
 		}
-		if err := enc.Encode(a.getOneForMarshal(i)); err != nil {
+		if err := enc.Encode(a.GetOneForMarshal(i)); err != nil {
 			return nil, err
 		}
 	}
@@ -531,7 +531,7 @@ func (b *baseListBuilder) newData() (data *Data) {
 	return
 }
 
-func (b *baseListBuilder) unmarshalOne(dec *json.Decoder) error {
+func (b *baseListBuilder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -540,7 +540,7 @@ func (b *baseListBuilder) unmarshalOne(dec *json.Decoder) error {
 	switch t {
 	case json.Delim('['):
 		b.Append(true)
-		if err := b.values.unmarshal(dec); err != nil {
+		if err := b.values.Unmarshal(dec); err != nil {
 			return err
 		}
 		// consume ']'
@@ -558,9 +558,9 @@ func (b *baseListBuilder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *baseListBuilder) unmarshal(dec *json.Decoder) error {
+func (b *baseListBuilder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -578,7 +578,7 @@ func (b *baseListBuilder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("list builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 var (

--- a/go/arrow/array/map.go
+++ b/go/arrow/array/map.go
@@ -300,12 +300,12 @@ func (b *MapBuilder) ValueBuilder() Builder {
 	return b.listBuilder.ValueBuilder()
 }
 
-func (b *MapBuilder) unmarshalOne(dec *json.Decoder) error {
-	return b.listBuilder.unmarshalOne(dec)
+func (b *MapBuilder) UnmarshalOne(dec *json.Decoder) error {
+	return b.listBuilder.UnmarshalOne(dec)
 }
 
-func (b *MapBuilder) unmarshal(dec *json.Decoder) error {
-	return b.listBuilder.unmarshal(dec)
+func (b *MapBuilder) Unmarshal(dec *json.Decoder) error {
+	return b.listBuilder.Unmarshal(dec)
 }
 
 func (b *MapBuilder) UnmarshalJSON(data []byte) error {
@@ -319,7 +319,7 @@ func (b *MapBuilder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("map builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 var (

--- a/go/arrow/array/null.go
+++ b/go/arrow/array/null.go
@@ -77,7 +77,7 @@ func (a *Null) setData(data *Data) {
 	a.array.data.nulls = a.array.data.length
 }
 
-func (a *Null) getOneForMarshal(i int) interface{} {
+func (a *Null) GetOneForMarshal(i int) interface{} {
 	return nil
 }
 
@@ -150,7 +150,7 @@ func (b *NullBuilder) newData() (data *Data) {
 	return
 }
 
-func (b *NullBuilder) unmarshalOne(dec *json.Decoder) error {
+func (b *NullBuilder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -169,9 +169,9 @@ func (b *NullBuilder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *NullBuilder) unmarshal(dec *json.Decoder) error {
+func (b *NullBuilder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -189,7 +189,7 @@ func (b *NullBuilder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("null builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 var (

--- a/go/arrow/array/numeric.gen.go
+++ b/go/arrow/array/numeric.gen.go
@@ -81,7 +81,7 @@ func (a *Int64) setData(data *Data) {
 	}
 }
 
-func (a *Int64) getOneForMarshal(i int) interface{} {
+func (a *Int64) GetOneForMarshal(i int) interface{} {
 	if a.IsNull(i) {
 		return nil
 	}
@@ -169,7 +169,7 @@ func (a *Uint64) setData(data *Data) {
 	}
 }
 
-func (a *Uint64) getOneForMarshal(i int) interface{} {
+func (a *Uint64) GetOneForMarshal(i int) interface{} {
 	if a.IsNull(i) {
 		return nil
 	}
@@ -257,7 +257,7 @@ func (a *Float64) setData(data *Data) {
 	}
 }
 
-func (a *Float64) getOneForMarshal(i int) interface{} {
+func (a *Float64) GetOneForMarshal(i int) interface{} {
 	if a.IsNull(i) {
 		return nil
 	}
@@ -345,7 +345,7 @@ func (a *Int32) setData(data *Data) {
 	}
 }
 
-func (a *Int32) getOneForMarshal(i int) interface{} {
+func (a *Int32) GetOneForMarshal(i int) interface{} {
 	if a.IsNull(i) {
 		return nil
 	}
@@ -433,7 +433,7 @@ func (a *Uint32) setData(data *Data) {
 	}
 }
 
-func (a *Uint32) getOneForMarshal(i int) interface{} {
+func (a *Uint32) GetOneForMarshal(i int) interface{} {
 	if a.IsNull(i) {
 		return nil
 	}
@@ -521,7 +521,7 @@ func (a *Float32) setData(data *Data) {
 	}
 }
 
-func (a *Float32) getOneForMarshal(i int) interface{} {
+func (a *Float32) GetOneForMarshal(i int) interface{} {
 	if a.IsNull(i) {
 		return nil
 	}
@@ -609,7 +609,7 @@ func (a *Int16) setData(data *Data) {
 	}
 }
 
-func (a *Int16) getOneForMarshal(i int) interface{} {
+func (a *Int16) GetOneForMarshal(i int) interface{} {
 	if a.IsNull(i) {
 		return nil
 	}
@@ -697,7 +697,7 @@ func (a *Uint16) setData(data *Data) {
 	}
 }
 
-func (a *Uint16) getOneForMarshal(i int) interface{} {
+func (a *Uint16) GetOneForMarshal(i int) interface{} {
 	if a.IsNull(i) {
 		return nil
 	}
@@ -785,7 +785,7 @@ func (a *Int8) setData(data *Data) {
 	}
 }
 
-func (a *Int8) getOneForMarshal(i int) interface{} {
+func (a *Int8) GetOneForMarshal(i int) interface{} {
 	if a.IsNull(i) {
 		return nil
 	}
@@ -873,7 +873,7 @@ func (a *Uint8) setData(data *Data) {
 	}
 }
 
-func (a *Uint8) getOneForMarshal(i int) interface{} {
+func (a *Uint8) GetOneForMarshal(i int) interface{} {
 	if a.IsNull(i) {
 		return nil
 	}
@@ -961,7 +961,7 @@ func (a *Timestamp) setData(data *Data) {
 	}
 }
 
-func (a *Timestamp) getOneForMarshal(i int) interface{} {
+func (a *Timestamp) GetOneForMarshal(i int) interface{} {
 	if a.IsNull(i) {
 		return nil
 	}
@@ -971,7 +971,7 @@ func (a *Timestamp) getOneForMarshal(i int) interface{} {
 func (a *Timestamp) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := range a.values {
-		vals[i] = a.getOneForMarshal(i)
+		vals[i] = a.GetOneForMarshal(i)
 	}
 
 	return json.Marshal(vals)
@@ -1044,7 +1044,7 @@ func (a *Time32) setData(data *Data) {
 	}
 }
 
-func (a *Time32) getOneForMarshal(i int) interface{} {
+func (a *Time32) GetOneForMarshal(i int) interface{} {
 	if a.IsNull(i) {
 		return nil
 	}
@@ -1054,7 +1054,7 @@ func (a *Time32) getOneForMarshal(i int) interface{} {
 func (a *Time32) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := range a.values {
-		vals[i] = a.getOneForMarshal(i)
+		vals[i] = a.GetOneForMarshal(i)
 	}
 
 	return json.Marshal(vals)
@@ -1127,7 +1127,7 @@ func (a *Time64) setData(data *Data) {
 	}
 }
 
-func (a *Time64) getOneForMarshal(i int) interface{} {
+func (a *Time64) GetOneForMarshal(i int) interface{} {
 	if a.IsNull(i) {
 		return nil
 	}
@@ -1137,7 +1137,7 @@ func (a *Time64) getOneForMarshal(i int) interface{} {
 func (a *Time64) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := range a.values {
-		vals[i] = a.getOneForMarshal(i)
+		vals[i] = a.GetOneForMarshal(i)
 	}
 
 	return json.Marshal(vals)
@@ -1210,7 +1210,7 @@ func (a *Date32) setData(data *Data) {
 	}
 }
 
-func (a *Date32) getOneForMarshal(i int) interface{} {
+func (a *Date32) GetOneForMarshal(i int) interface{} {
 	if a.IsNull(i) {
 		return nil
 	}
@@ -1220,7 +1220,7 @@ func (a *Date32) getOneForMarshal(i int) interface{} {
 func (a *Date32) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := range a.values {
-		vals[i] = a.getOneForMarshal(i)
+		vals[i] = a.GetOneForMarshal(i)
 	}
 
 	return json.Marshal(vals)
@@ -1293,7 +1293,7 @@ func (a *Date64) setData(data *Data) {
 	}
 }
 
-func (a *Date64) getOneForMarshal(i int) interface{} {
+func (a *Date64) GetOneForMarshal(i int) interface{} {
 	if a.IsNull(i) {
 		return nil
 	}
@@ -1303,7 +1303,7 @@ func (a *Date64) getOneForMarshal(i int) interface{} {
 func (a *Date64) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := range a.values {
-		vals[i] = a.getOneForMarshal(i)
+		vals[i] = a.GetOneForMarshal(i)
 	}
 
 	return json.Marshal(vals)
@@ -1376,7 +1376,7 @@ func (a *Duration) setData(data *Data) {
 	}
 }
 
-func (a *Duration) getOneForMarshal(i int) interface{} {
+func (a *Duration) GetOneForMarshal(i int) interface{} {
 	if a.IsNull(i) {
 		return nil
 	}
@@ -1387,7 +1387,7 @@ func (a *Duration) getOneForMarshal(i int) interface{} {
 func (a *Duration) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := range a.values {
-		vals[i] = a.getOneForMarshal(i)
+		vals[i] = a.GetOneForMarshal(i)
 	}
 
 	return json.Marshal(vals)

--- a/go/arrow/array/numeric.gen.go.tmpl
+++ b/go/arrow/array/numeric.gen.go.tmpl
@@ -82,7 +82,7 @@ func (a *{{.Name}}) setData(data *Data) {
 	}
 }
 
-func (a *{{.Name}}) getOneForMarshal(i int) interface{} {
+func (a *{{.Name}}) GetOneForMarshal(i int) interface{} {
 	if a.IsNull(i) {
 		return nil
 	}

--- a/go/arrow/array/numericbuilder.gen.go
+++ b/go/arrow/array/numericbuilder.gen.go
@@ -176,7 +176,7 @@ func (b *Int64Builder) newData() (data *Data) {
 	return
 }
 
-func (b *Int64Builder) unmarshalOne(dec *json.Decoder) error {
+func (b *Int64Builder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -220,9 +220,9 @@ func (b *Int64Builder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *Int64Builder) unmarshal(dec *json.Decoder) error {
+func (b *Int64Builder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -240,7 +240,7 @@ func (b *Int64Builder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("binary builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 type Uint64Builder struct {
@@ -385,7 +385,7 @@ func (b *Uint64Builder) newData() (data *Data) {
 	return
 }
 
-func (b *Uint64Builder) unmarshalOne(dec *json.Decoder) error {
+func (b *Uint64Builder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -429,9 +429,9 @@ func (b *Uint64Builder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *Uint64Builder) unmarshal(dec *json.Decoder) error {
+func (b *Uint64Builder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -449,7 +449,7 @@ func (b *Uint64Builder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("binary builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 type Float64Builder struct {
@@ -594,7 +594,7 @@ func (b *Float64Builder) newData() (data *Data) {
 	return
 }
 
-func (b *Float64Builder) unmarshalOne(dec *json.Decoder) error {
+func (b *Float64Builder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -638,9 +638,9 @@ func (b *Float64Builder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *Float64Builder) unmarshal(dec *json.Decoder) error {
+func (b *Float64Builder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -658,7 +658,7 @@ func (b *Float64Builder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("binary builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 type Int32Builder struct {
@@ -803,7 +803,7 @@ func (b *Int32Builder) newData() (data *Data) {
 	return
 }
 
-func (b *Int32Builder) unmarshalOne(dec *json.Decoder) error {
+func (b *Int32Builder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -847,9 +847,9 @@ func (b *Int32Builder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *Int32Builder) unmarshal(dec *json.Decoder) error {
+func (b *Int32Builder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -867,7 +867,7 @@ func (b *Int32Builder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("binary builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 type Uint32Builder struct {
@@ -1012,7 +1012,7 @@ func (b *Uint32Builder) newData() (data *Data) {
 	return
 }
 
-func (b *Uint32Builder) unmarshalOne(dec *json.Decoder) error {
+func (b *Uint32Builder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -1056,9 +1056,9 @@ func (b *Uint32Builder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *Uint32Builder) unmarshal(dec *json.Decoder) error {
+func (b *Uint32Builder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -1076,7 +1076,7 @@ func (b *Uint32Builder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("binary builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 type Float32Builder struct {
@@ -1221,7 +1221,7 @@ func (b *Float32Builder) newData() (data *Data) {
 	return
 }
 
-func (b *Float32Builder) unmarshalOne(dec *json.Decoder) error {
+func (b *Float32Builder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -1265,9 +1265,9 @@ func (b *Float32Builder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *Float32Builder) unmarshal(dec *json.Decoder) error {
+func (b *Float32Builder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -1285,7 +1285,7 @@ func (b *Float32Builder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("binary builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 type Int16Builder struct {
@@ -1430,7 +1430,7 @@ func (b *Int16Builder) newData() (data *Data) {
 	return
 }
 
-func (b *Int16Builder) unmarshalOne(dec *json.Decoder) error {
+func (b *Int16Builder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -1474,9 +1474,9 @@ func (b *Int16Builder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *Int16Builder) unmarshal(dec *json.Decoder) error {
+func (b *Int16Builder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -1494,7 +1494,7 @@ func (b *Int16Builder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("binary builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 type Uint16Builder struct {
@@ -1639,7 +1639,7 @@ func (b *Uint16Builder) newData() (data *Data) {
 	return
 }
 
-func (b *Uint16Builder) unmarshalOne(dec *json.Decoder) error {
+func (b *Uint16Builder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -1683,9 +1683,9 @@ func (b *Uint16Builder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *Uint16Builder) unmarshal(dec *json.Decoder) error {
+func (b *Uint16Builder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -1703,7 +1703,7 @@ func (b *Uint16Builder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("binary builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 type Int8Builder struct {
@@ -1848,7 +1848,7 @@ func (b *Int8Builder) newData() (data *Data) {
 	return
 }
 
-func (b *Int8Builder) unmarshalOne(dec *json.Decoder) error {
+func (b *Int8Builder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -1892,9 +1892,9 @@ func (b *Int8Builder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *Int8Builder) unmarshal(dec *json.Decoder) error {
+func (b *Int8Builder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -1912,7 +1912,7 @@ func (b *Int8Builder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("binary builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 type Uint8Builder struct {
@@ -2057,7 +2057,7 @@ func (b *Uint8Builder) newData() (data *Data) {
 	return
 }
 
-func (b *Uint8Builder) unmarshalOne(dec *json.Decoder) error {
+func (b *Uint8Builder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -2101,9 +2101,9 @@ func (b *Uint8Builder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *Uint8Builder) unmarshal(dec *json.Decoder) error {
+func (b *Uint8Builder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -2121,7 +2121,7 @@ func (b *Uint8Builder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("binary builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 type TimestampBuilder struct {
@@ -2267,7 +2267,7 @@ func (b *TimestampBuilder) newData() (data *Data) {
 	return
 }
 
-func (b *TimestampBuilder) unmarshalOne(dec *json.Decoder) error {
+func (b *TimestampBuilder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -2313,9 +2313,9 @@ func (b *TimestampBuilder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *TimestampBuilder) unmarshal(dec *json.Decoder) error {
+func (b *TimestampBuilder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -2333,7 +2333,7 @@ func (b *TimestampBuilder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("binary builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 type Time32Builder struct {
@@ -2479,7 +2479,7 @@ func (b *Time32Builder) newData() (data *Data) {
 	return
 }
 
-func (b *Time32Builder) unmarshalOne(dec *json.Decoder) error {
+func (b *Time32Builder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -2524,9 +2524,9 @@ func (b *Time32Builder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *Time32Builder) unmarshal(dec *json.Decoder) error {
+func (b *Time32Builder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -2544,7 +2544,7 @@ func (b *Time32Builder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("binary builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 type Time64Builder struct {
@@ -2690,7 +2690,7 @@ func (b *Time64Builder) newData() (data *Data) {
 	return
 }
 
-func (b *Time64Builder) unmarshalOne(dec *json.Decoder) error {
+func (b *Time64Builder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -2735,9 +2735,9 @@ func (b *Time64Builder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *Time64Builder) unmarshal(dec *json.Decoder) error {
+func (b *Time64Builder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -2755,7 +2755,7 @@ func (b *Time64Builder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("binary builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 type Date32Builder struct {
@@ -2900,7 +2900,7 @@ func (b *Date32Builder) newData() (data *Data) {
 	return
 }
 
-func (b *Date32Builder) unmarshalOne(dec *json.Decoder) error {
+func (b *Date32Builder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -2944,9 +2944,9 @@ func (b *Date32Builder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *Date32Builder) unmarshal(dec *json.Decoder) error {
+func (b *Date32Builder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -2964,7 +2964,7 @@ func (b *Date32Builder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("binary builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 type Date64Builder struct {
@@ -3109,7 +3109,7 @@ func (b *Date64Builder) newData() (data *Data) {
 	return
 }
 
-func (b *Date64Builder) unmarshalOne(dec *json.Decoder) error {
+func (b *Date64Builder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -3153,9 +3153,9 @@ func (b *Date64Builder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *Date64Builder) unmarshal(dec *json.Decoder) error {
+func (b *Date64Builder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -3173,7 +3173,7 @@ func (b *Date64Builder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("binary builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 type DurationBuilder struct {
@@ -3319,7 +3319,7 @@ func (b *DurationBuilder) newData() (data *Data) {
 	return
 }
 
-func (b *DurationBuilder) unmarshalOne(dec *json.Decoder) error {
+func (b *DurationBuilder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -3386,9 +3386,9 @@ func (b *DurationBuilder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *DurationBuilder) unmarshal(dec *json.Decoder) error {
+func (b *DurationBuilder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -3406,7 +3406,7 @@ func (b *DurationBuilder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("binary builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 var (

--- a/go/arrow/array/numericbuilder.gen.go.tmpl
+++ b/go/arrow/array/numericbuilder.gen.go.tmpl
@@ -184,7 +184,7 @@ func (b *{{.Name}}Builder) newData() (data *Data) {
 	return
 }
 
-func (b *{{.Name}}Builder) unmarshalOne(dec *json.Decoder) error {
+func (b *{{.Name}}Builder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -340,7 +340,7 @@ func (b *{{.Name}}Builder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *{{.Name}}Builder) unmarshal(dec *json.Decoder) error {
+func (b *{{.Name}}Builder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
 		if err := b.unmarshalOne(dec); err != nil {
 			return err

--- a/go/arrow/array/record.go
+++ b/go/arrow/array/record.go
@@ -366,7 +366,7 @@ func (b *RecordBuilder) UnmarshalJSON(data []byte) error {
 			continue
 		}
 
-		if err := b.fields[indices[0]].unmarshalOne(dec); err != nil {
+		if err := b.fields[indices[0]].UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}

--- a/go/arrow/array/string.go
+++ b/go/arrow/array/string.go
@@ -132,7 +132,7 @@ func (a *String) setData(data *Data) {
 	}
 }
 
-func (a *String) getOneForMarshal(i int) interface{} {
+func (a *String) GetOneForMarshal(i int) interface{} {
 	if a.IsValid(i) {
 		return a.Value(i)
 	}
@@ -267,7 +267,7 @@ func (a *LargeString) setData(data *Data) {
 	}
 }
 
-func (a *LargeString) getOneForMarshal(i int) interface{} {
+func (a *LargeString) GetOneForMarshal(i int) interface{} {
 	if a.IsValid(i) {
 		return a.Value(i)
 	}
@@ -349,7 +349,7 @@ func (b *StringBuilder) NewStringArray() (a *String) {
 	return
 }
 
-func (b *StringBuilder) unmarshalOne(dec *json.Decoder) error {
+func (b *StringBuilder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -370,9 +370,9 @@ func (b *StringBuilder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *StringBuilder) unmarshal(dec *json.Decoder) error {
+func (b *StringBuilder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -390,7 +390,7 @@ func (b *StringBuilder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("string builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 // A LargeStringBuilder is used to build a LargeString array using the Append methods.
@@ -446,7 +446,7 @@ func (b *LargeStringBuilder) NewLargeStringArray() (a *LargeString) {
 	return
 }
 
-func (b *LargeStringBuilder) unmarshalOne(dec *json.Decoder) error {
+func (b *LargeStringBuilder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -467,9 +467,9 @@ func (b *LargeStringBuilder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *LargeStringBuilder) unmarshal(dec *json.Decoder) error {
+func (b *LargeStringBuilder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -487,7 +487,7 @@ func (b *LargeStringBuilder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("string builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 type StringLikeBuilder interface {

--- a/go/arrow/array/struct.go
+++ b/go/arrow/array/struct.go
@@ -144,7 +144,7 @@ func (a *Struct) setData(data *Data) {
 	}
 }
 
-func (a *Struct) getOneForMarshal(i int) interface{} {
+func (a *Struct) GetOneForMarshal(i int) interface{} {
 	if a.IsNull(i) {
 		return nil
 	}
@@ -152,7 +152,7 @@ func (a *Struct) getOneForMarshal(i int) interface{} {
 	tmp := make(map[string]interface{})
 	fieldList := a.data.dtype.(*arrow.StructType).Fields()
 	for j, d := range a.fields {
-		tmp[fieldList[j].Name] = d.(arraymarshal).getOneForMarshal(i)
+		tmp[fieldList[j].Name] = d.(arraymarshal).GetOneForMarshal(i)
 	}
 	return tmp
 }
@@ -166,7 +166,7 @@ func (a *Struct) MarshalJSON() ([]byte, error) {
 		if i != 0 {
 			buf.WriteByte(',')
 		}
-		if err := enc.Encode(a.getOneForMarshal(i)); err != nil {
+		if err := enc.Encode(a.GetOneForMarshal(i)); err != nil {
 			return nil, err
 		}
 	}
@@ -351,7 +351,7 @@ func (b *StructBuilder) newData() (data *Data) {
 	return
 }
 
-func (b *StructBuilder) unmarshalOne(dec *json.Decoder) error {
+func (b *StructBuilder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -385,7 +385,7 @@ func (b *StructBuilder) unmarshalOne(dec *json.Decoder) error {
 				continue
 			}
 
-			if err := b.fields[idx].unmarshalOne(dec); err != nil {
+			if err := b.fields[idx].UnmarshalOne(dec); err != nil {
 				return err
 			}
 		}
@@ -415,9 +415,9 @@ func (b *StructBuilder) unmarshalOne(dec *json.Decoder) error {
 	return nil
 }
 
-func (b *StructBuilder) unmarshal(dec *json.Decoder) error {
+func (b *StructBuilder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
@@ -435,7 +435,7 @@ func (b *StructBuilder) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("struct builder must unpack from json array, found %s", delim)
 	}
 
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
 var (

--- a/go/arrow/array/union.go
+++ b/go/arrow/array/union.go
@@ -313,7 +313,7 @@ func (a *SparseUnion) setData(data *Data) {
 	debug.Assert(a.data.buffers[0] == nil, "arrow/array: validity bitmap for sparse unions should be nil")
 }
 
-func (a *SparseUnion) getOneForMarshal(i int) interface{} {
+func (a *SparseUnion) GetOneForMarshal(i int) interface{} {
 	typeID := a.RawTypeCodes()[i]
 
 	childID := a.ChildID(i)
@@ -323,7 +323,7 @@ func (a *SparseUnion) getOneForMarshal(i int) interface{} {
 		return nil
 	}
 
-	return []interface{}{typeID, data.(arraymarshal).getOneForMarshal(i)}
+	return []interface{}{typeID, data.(arraymarshal).GetOneForMarshal(i)}
 }
 
 func (a *SparseUnion) MarshalJSON() ([]byte, error) {
@@ -335,7 +335,7 @@ func (a *SparseUnion) MarshalJSON() ([]byte, error) {
 		if i != 0 {
 			buf.WriteByte(',')
 		}
-		if err := enc.Encode(a.getOneForMarshal(i)); err != nil {
+		if err := enc.Encode(a.GetOneForMarshal(i)); err != nil {
 			return nil, err
 		}
 	}
@@ -355,7 +355,7 @@ func (a *SparseUnion) String() string {
 
 		field := fieldList[a.ChildID(i)]
 		f := a.Field(a.ChildID(i))
-		fmt.Fprintf(&b, "{%s=%v}", field.Name, f.(arraymarshal).getOneForMarshal(i))
+		fmt.Fprintf(&b, "{%s=%v}", field.Name, f.(arraymarshal).GetOneForMarshal(i))
 	}
 	b.WriteByte(']')
 	return b.String()
@@ -570,7 +570,7 @@ func (a *DenseUnion) setData(data *Data) {
 	}
 }
 
-func (a *DenseUnion) getOneForMarshal(i int) interface{} {
+func (a *DenseUnion) GetOneForMarshal(i int) interface{} {
 	typeID := a.RawTypeCodes()[i]
 
 	childID := a.ChildID(i)
@@ -581,7 +581,7 @@ func (a *DenseUnion) getOneForMarshal(i int) interface{} {
 		return nil
 	}
 
-	return []interface{}{typeID, data.(arraymarshal).getOneForMarshal(int(offsets[i]))}
+	return []interface{}{typeID, data.(arraymarshal).GetOneForMarshal(int(offsets[i]))}
 }
 
 func (a *DenseUnion) MarshalJSON() ([]byte, error) {
@@ -593,7 +593,7 @@ func (a *DenseUnion) MarshalJSON() ([]byte, error) {
 		if i != 0 {
 			buf.WriteByte(',')
 		}
-		if err := enc.Encode(a.getOneForMarshal(i)); err != nil {
+		if err := enc.Encode(a.GetOneForMarshal(i)); err != nil {
 			return nil, err
 		}
 	}
@@ -615,7 +615,7 @@ func (a *DenseUnion) String() string {
 
 		field := fieldList[a.ChildID(i)]
 		f := a.Field(a.ChildID(i))
-		fmt.Fprintf(&b, "{%s=%v}", field.Name, f.(arraymarshal).getOneForMarshal(int(offsets[i])))
+		fmt.Fprintf(&b, "{%s=%v}", field.Name, f.(arraymarshal).GetOneForMarshal(int(offsets[i])))
 	}
 	b.WriteByte(']')
 	return b.String()
@@ -975,19 +975,19 @@ func (b *SparseUnionBuilder) UnmarshalJSON(data []byte) (err error) {
 	if delim, ok := t.(json.Delim); !ok || delim != '[' {
 		return fmt.Errorf("sparse union builder must unpack from json array, found %s", t)
 	}
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
-func (b *SparseUnionBuilder) unmarshal(dec *json.Decoder) error {
+func (b *SparseUnionBuilder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (b *SparseUnionBuilder) unmarshalOne(dec *json.Decoder) error {
+func (b *SparseUnionBuilder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -1037,7 +1037,7 @@ func (b *SparseUnionBuilder) unmarshalOne(dec *json.Decoder) error {
 		}
 
 		b.Append(typeCode)
-		if err := b.children[childNum].unmarshalOne(dec); err != nil {
+		if err := b.children[childNum].UnmarshalOne(dec); err != nil {
 			return err
 		}
 
@@ -1220,19 +1220,19 @@ func (b *DenseUnionBuilder) UnmarshalJSON(data []byte) (err error) {
 	if delim, ok := t.(json.Delim); !ok || delim != '[' {
 		return fmt.Errorf("dense union builder must unpack from json array, found %s", t)
 	}
-	return b.unmarshal(dec)
+	return b.Unmarshal(dec)
 }
 
-func (b *DenseUnionBuilder) unmarshal(dec *json.Decoder) error {
+func (b *DenseUnionBuilder) Unmarshal(dec *json.Decoder) error {
 	for dec.More() {
-		if err := b.unmarshalOne(dec); err != nil {
+		if err := b.UnmarshalOne(dec); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (b *DenseUnionBuilder) unmarshalOne(dec *json.Decoder) error {
+func (b *DenseUnionBuilder) UnmarshalOne(dec *json.Decoder) error {
 	t, err := dec.Token()
 	if err != nil {
 		return err
@@ -1276,7 +1276,7 @@ func (b *DenseUnionBuilder) unmarshalOne(dec *json.Decoder) error {
 		}
 
 		b.Append(typeCode)
-		if err := b.children[childNum].unmarshalOne(dec); err != nil {
+		if err := b.children[childNum].UnmarshalOne(dec); err != nil {
 			return err
 		}
 

--- a/go/arrow/array/util.go
+++ b/go/arrow/array/util.go
@@ -161,7 +161,7 @@ func FromJSON(mem memory.Allocator, dt arrow.DataType, r io.Reader, opts ...From
 		}
 	}
 
-	if err = bldr.unmarshal(dec); err != nil {
+	if err = bldr.Unmarshal(dec); err != nil {
 		return nil, dec.InputOffset(), err
 	}
 
@@ -228,7 +228,7 @@ func RecordToJSON(rec arrow.Record, w io.Writer) error {
 	cols := make(map[string]interface{})
 	for i := 0; int64(i) < rec.NumRows(); i++ {
 		for j, c := range rec.Columns() {
-			cols[fields[j].Name] = c.(arraymarshal).getOneForMarshal(i)
+			cols[fields[j].Name] = c.(arraymarshal).GetOneForMarshal(i)
 		}
 		if err := enc.Encode(cols); err != nil {
 			return err

--- a/go/arrow/datatype_extension.go
+++ b/go/arrow/datatype_extension.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
-
-	"github.com/apache/arrow/go/v12/arrow/memory"
 )
 
 var (
@@ -124,20 +122,16 @@ type ExtensionType interface {
 	// If the storage type is incorrect or something else is invalid with the data this should
 	// return nil and an appropriate error.
 	Deserialize(storageType DataType, data string) (ExtensionType, error)
-	// this should return array.Builder interface but we cannot import due to cycle import, so we use 
-	// interface{} instead. At least for 
-	NewBuilder(mem memory.Allocator, dt ExtensionType) interface{}
 	mustEmbedExtensionBase()
 }
 
 // ExtensionBase is the base struct for user-defined Extension Types which must be
 // embedded in any user-defined types like so:
 //
-//     type UserDefinedType struct {
-//         arrow.ExtensionBase
-//         // any other data
-//     }
-//
+//	type UserDefinedType struct {
+//	    arrow.ExtensionBase
+//	    // any other data
+//	}
 type ExtensionBase struct {
 	// Storage is the underlying storage type
 	Storage DataType
@@ -166,13 +160,10 @@ func (e *ExtensionBase) Fields() []Field {
 	return nil
 }
 
-func (e *ExtensionBase) NewBuilder(mem memory.Allocator, dt ExtensionType) interface{} {
-	return nil
-}
-
 func (e *ExtensionBase) Layout() DataTypeLayout { return e.Storage.Layout() }
 
 // this no-op exists to ensure that this type must be embedded in any user-defined extension type.
+//
 //lint:ignore U1000 this function is intentionally unused as it only exists to ensure embedding happens
 func (ExtensionBase) mustEmbedExtensionBase() {}
 

--- a/go/arrow/datatype_extension.go
+++ b/go/arrow/datatype_extension.go
@@ -122,7 +122,7 @@ type ExtensionType interface {
 	// If the storage type is incorrect or something else is invalid with the data this should
 	// return nil and an appropriate error.
 	Deserialize(storageType DataType, data string) (ExtensionType, error)
-	
+
 	mustEmbedExtensionBase()
 }
 

--- a/go/arrow/datatype_extension.go
+++ b/go/arrow/datatype_extension.go
@@ -122,6 +122,7 @@ type ExtensionType interface {
 	// If the storage type is incorrect or something else is invalid with the data this should
 	// return nil and an appropriate error.
 	Deserialize(storageType DataType, data string) (ExtensionType, error)
+	
 	mustEmbedExtensionBase()
 }
 

--- a/go/arrow/datatype_extension.go
+++ b/go/arrow/datatype_extension.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
+
+	"github.com/apache/arrow/go/v12/arrow/memory"
 )
 
 var (
@@ -122,7 +124,9 @@ type ExtensionType interface {
 	// If the storage type is incorrect or something else is invalid with the data this should
 	// return nil and an appropriate error.
 	Deserialize(storageType DataType, data string) (ExtensionType, error)
-
+	// this should return array.Builder interface but we cannot import due to cycle import, so we use 
+	// interface{} instead. At least for 
+	NewBuilder(mem memory.Allocator, dt ExtensionType) interface{}
 	mustEmbedExtensionBase()
 }
 
@@ -159,6 +163,10 @@ func (e *ExtensionBase) Fields() []Field {
 	if nested, ok := e.Storage.(NestedType); ok {
 		return nested.Fields()
 	}
+	return nil
+}
+
+func (e *ExtensionBase) NewBuilder(mem memory.Allocator, dt ExtensionType) interface{} {
 	return nil
 }
 

--- a/go/arrow/internal/testing/types/extension_test.go
+++ b/go/arrow/internal/testing/types/extension_test.go
@@ -33,7 +33,8 @@ import (
 var testUUID = uuid.New()
 
 func TestExtensionBuilder(t *testing.T) {
-	builder := types.NewUUIDBuilder(memory.DefaultAllocator, types.NewUUIDType())
+	extBuilder := array.NewExtensionBuilder(memory.DefaultAllocator, types.NewUUIDType())
+	builder := types.NewUUIDBuilder(extBuilder)
 	builder.Append(testUUID)
 	arr := builder.NewArray()
 	arrStr := arr.String()
@@ -41,7 +42,7 @@ func TestExtensionBuilder(t *testing.T) {
 	jsonStr, err := json.Marshal(arr)
 	assert.NoError(t, err)
 
-	arr1, _ , err := array.FromJSON(memory.DefaultAllocator, types.NewUUIDType(), bytes.NewReader(jsonStr))	
+	arr1, _, err := array.FromJSON(memory.DefaultAllocator, types.NewUUIDType(), bytes.NewReader(jsonStr))
 	assert.NoError(t, err)
 	assert.Equal(t, arr, arr1)
 }

--- a/go/arrow/internal/testing/types/extension_test.go
+++ b/go/arrow/internal/testing/types/extension_test.go
@@ -1,0 +1,62 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/apache/arrow/go/v12/arrow"
+	"github.com/apache/arrow/go/v12/arrow/array"
+	"github.com/apache/arrow/go/v12/arrow/internal/testing/types"
+	"github.com/apache/arrow/go/v12/arrow/memory"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var testUUID = uuid.New()
+
+func TestExtensionBuilder(t *testing.T) {
+	builder := types.NewUUIDBuilder(memory.DefaultAllocator, types.NewUUIDType())
+	builder.Append(testUUID)
+	arr := builder.NewArray()
+	arrStr := arr.String()
+	assert.Equal(t, "[\""+testUUID.String()+"\"]", arrStr)
+	jsonStr, err := json.Marshal(arr)
+	assert.NoError(t, err)
+
+	arr1, _ , err := array.FromJSON(memory.DefaultAllocator, types.NewUUIDType(), bytes.NewReader(jsonStr))	
+	assert.NoError(t, err)
+	assert.Equal(t, arr, arr1)
+}
+
+func TestExtensionRecordBuilder(t *testing.T) {
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "uuid", Type: types.NewUUIDType()},
+	}, nil)
+	builder := array.NewRecordBuilder(memory.DefaultAllocator, schema)
+	builder.Field(0).(*types.UUIDBuilder).Append(testUUID)
+	record := builder.NewRecord()
+	b, err := record.MarshalJSON()
+	require.NoError(t, err)
+	require.Equal(t, "[{\"uuid\":\""+testUUID.String()+"\"}\n]", string(b))
+	record1, _, err := array.RecordFromJSON(memory.DefaultAllocator, schema, bytes.NewReader(b))
+	require.NoError(t, err)
+	require.Equal(t, record, record1)
+}

--- a/go/arrow/internal/testing/types/extension_types.go
+++ b/go/arrow/internal/testing/types/extension_types.go
@@ -34,7 +34,6 @@ import (
 
 type UUIDBuilder struct {
 	*array.ExtensionBuilder
-	dtype *UUIDType
 }
 
 func NewUUIDBuilder(bldr *array.ExtensionBuilder) *UUIDBuilder {

--- a/go/arrow/internal/testing/types/extension_types.go
+++ b/go/arrow/internal/testing/types/extension_types.go
@@ -47,10 +47,6 @@ func (b *UUIDBuilder) Append(v uuid.UUID) {
 	b.ExtensionBuilder.Builder.(*array.FixedSizeBinaryBuilder).Append(v[:])
 }
 
-func (b *UUIDBuilder) UnsafeAppend(v uuid.UUID) {
-	b.ExtensionBuilder.Builder.(*array.FixedSizeBinaryBuilder).UnsafeAppend(v[:])
-}
-
 func (b *UUIDBuilder) AppendValues(v []uuid.UUID, valid []bool) {
 	data := make([][]byte, len(v))
 	for i, v := range v {
@@ -69,12 +65,6 @@ func (b *UUIDBuilder) UnmarshalOne(dec *json.Decoder) error {
 	switch v := t.(type) {
 	case string:
 		data, err := uuid.Parse(v)
-		if err != nil {
-			return err
-		}
-		val = data
-	case []byte:
-		data, err := uuid.ParseBytes(v)
 		if err != nil {
 			return err
 		}

--- a/go/arrow/internal/testing/types/extension_types.go
+++ b/go/arrow/internal/testing/types/extension_types.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/apache/arrow/go/v12/arrow"
 	"github.com/apache/arrow/go/v12/arrow/array"
-	"github.com/apache/arrow/go/v12/arrow/memory"
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 )
@@ -38,10 +37,9 @@ type UUIDBuilder struct {
 	dtype *UUIDType
 }
 
-func NewUUIDBuilder(mem memory.Allocator, dtype arrow.ExtensionType) *UUIDBuilder {
+func NewUUIDBuilder(bldr *array.ExtensionBuilder) *UUIDBuilder {
 	b := &UUIDBuilder{
-		ExtensionBuilder: array.NewExtensionBuilder(mem, dtype),
-		dtype:            dtype.(*UUIDType),
+		ExtensionBuilder: bldr,
 	}
 	return b
 }
@@ -192,7 +190,6 @@ type UUIDType struct {
 	arrow.ExtensionBase
 }
 
-
 // NewUUIDType is a convenience function to create an instance of UuidType
 // with the correct storage type
 func NewUUIDType() *UUIDType {
@@ -226,10 +223,9 @@ func (u UUIDType) ExtensionEquals(other arrow.ExtensionType) bool {
 	return u.ExtensionName() == other.ExtensionName()
 }
 
-func (u UUIDType) NewBuilder(mem memory.Allocator, dt arrow.ExtensionType) interface{} {
-	return NewUUIDBuilder(mem, dt)
+func (u UUIDType) NewBuilder(bldr *array.ExtensionBuilder) array.Builder {
+	return NewUUIDBuilder(bldr)
 }
-
 
 // Parametric1Array is a simple int32 array for use with the Parametric1Type
 // in testing a parameterized user-defined extension type.

--- a/go/arrow/internal/testing/types/extension_types.go
+++ b/go/arrow/internal/testing/types/extension_types.go
@@ -18,18 +18,172 @@
 package types
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"reflect"
+	"strings"
+
+	"github.com/goccy/go-json"
 
 	"github.com/apache/arrow/go/v12/arrow"
 	"github.com/apache/arrow/go/v12/arrow/array"
+	"github.com/apache/arrow/go/v12/arrow/memory"
+	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 )
+
+type UUIDBuilder struct {
+	*array.ExtensionBuilder
+	dtype *UUIDType
+}
+
+func NewUUIDBuilder(mem memory.Allocator, dtype arrow.ExtensionType) *UUIDBuilder {
+	b := &UUIDBuilder{
+		ExtensionBuilder: array.NewExtensionBuilder(mem, dtype),
+		dtype:            dtype.(*UUIDType),
+	}
+	return b
+}
+
+func (b *UUIDBuilder) Append(v uuid.UUID) {
+	b.ExtensionBuilder.Builder.(*array.FixedSizeBinaryBuilder).Append(v[:])
+}
+
+func (b *UUIDBuilder) UnsafeAppend(v uuid.UUID) {
+	b.ExtensionBuilder.Builder.(*array.FixedSizeBinaryBuilder).UnsafeAppend(v[:])
+}
+
+func (b *UUIDBuilder) AppendValues(v []uuid.UUID, valid []bool) {
+	data := make([][]byte, len(v))
+	for i, v := range v {
+		data[i] = v[:]
+	}
+	b.ExtensionBuilder.Builder.(*array.FixedSizeBinaryBuilder).AppendValues(data, valid)
+}
+
+func (b *UUIDBuilder) UnmarshalOne(dec *json.Decoder) error {
+	t, err := dec.Token()
+	if err != nil {
+		return err
+	}
+
+	var val uuid.UUID
+	switch v := t.(type) {
+	case string:
+		data, err := uuid.Parse(v)
+		if err != nil {
+			return err
+		}
+		val = data
+	case []byte:
+		data, err := uuid.ParseBytes(v)
+		if err != nil {
+			return err
+		}
+		val = data
+	case nil:
+		b.AppendNull()
+		return nil
+	default:
+		return &json.UnmarshalTypeError{
+			Value:  fmt.Sprint(t),
+			Type:   reflect.TypeOf([]byte{}),
+			Offset: dec.InputOffset(),
+			Struct: fmt.Sprintf("FixedSizeBinary[%d]", 16),
+		}
+	}
+
+	if len(val) != 16 {
+		return &json.UnmarshalTypeError{
+			Value:  fmt.Sprint(val),
+			Type:   reflect.TypeOf([]byte{}),
+			Offset: dec.InputOffset(),
+			Struct: fmt.Sprintf("FixedSizeBinary[%d]", 16),
+		}
+	}
+	b.Append(val)
+	return nil
+}
+
+func (b *UUIDBuilder) Unmarshal(dec *json.Decoder) error {
+	for dec.More() {
+		if err := b.UnmarshalOne(dec); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (b *UUIDBuilder) UnmarshalJSON(data []byte) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	t, err := dec.Token()
+	if err != nil {
+		return err
+	}
+
+	if delim, ok := t.(json.Delim); !ok || delim != '[' {
+		return fmt.Errorf("fixed size binary builder must unpack from json array, found %s", delim)
+	}
+
+	return b.Unmarshal(dec)
+}
 
 // UUIDArray is a simple array which is a FixedSizeBinary(16)
 type UUIDArray struct {
 	array.ExtensionArrayBase
+}
+
+func (a UUIDArray) String() string {
+	arr := a.Storage().(*array.FixedSizeBinary)
+	o := new(strings.Builder)
+	o.WriteString("[")
+	for i := 0; i < arr.Len(); i++ {
+		if i > 0 {
+			o.WriteString(" ")
+		}
+		switch {
+		case a.IsNull(i):
+			o.WriteString("(null)")
+		default:
+			uuidStr, err := uuid.FromBytes(arr.Value(i))
+			if err != nil {
+				panic(fmt.Errorf("invalid uuid: %w", err))
+			}
+			fmt.Fprintf(o, "%q", uuidStr)
+		}
+	}
+	o.WriteString("]")
+	return o.String()
+}
+
+func (a *UUIDArray) MarshalJSON() ([]byte, error) {
+	arr := a.Storage().(*array.FixedSizeBinary)
+	vals := make([]interface{}, a.Len())
+	for i := 0; i < a.Len(); i++ {
+		if a.IsValid(i) {
+			uuidStr, err := uuid.FromBytes(arr.Value(i))
+			if err != nil {
+				panic(fmt.Errorf("invalid uuid: %w", err))
+			}
+			vals[i] = uuidStr
+		} else {
+			vals[i] = nil
+		}
+	}
+	return json.Marshal(vals)
+}
+
+func (a *UUIDArray) GetOneForMarshal(i int) interface{} {
+	arr := a.Storage().(*array.FixedSizeBinary)
+	if a.IsValid(i) {
+		uuidObj, err := uuid.FromBytes(arr.Value(i))
+		if err != nil {
+			panic(fmt.Errorf("invalid uuid: %w", err))
+		}
+		return uuidObj
+	}
+	return nil
 }
 
 // UUIDType is a simple extension type that represents a FixedSizeBinary(16)
@@ -37,6 +191,7 @@ type UUIDArray struct {
 type UUIDType struct {
 	arrow.ExtensionBase
 }
+
 
 // NewUUIDType is a convenience function to create an instance of UuidType
 // with the correct storage type
@@ -70,6 +225,11 @@ func (UUIDType) Deserialize(storageType arrow.DataType, data string) (arrow.Exte
 func (u UUIDType) ExtensionEquals(other arrow.ExtensionType) bool {
 	return u.ExtensionName() == other.ExtensionName()
 }
+
+func (u UUIDType) NewBuilder(mem memory.Allocator, dt arrow.ExtensionType) interface{} {
+	return NewUUIDBuilder(mem, dt)
+}
+
 
 // Parametric1Array is a simple int32 array for use with the Parametric1Type
 // in testing a parameterized user-defined extension type.

--- a/go/go.mod
+++ b/go/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/golang/snappy v0.0.4
 	github.com/google/flatbuffers v2.0.8+incompatible
 	github.com/google/go-cmp v0.5.9
+	github.com/google/uuid v1.3.0
 	github.com/klauspost/asmfmt v1.3.2
 	github.com/klauspost/compress v1.15.9
 	github.com/klauspost/cpuid/v2 v2.0.9
@@ -50,7 +51,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect

--- a/go/go.mod
+++ b/go/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/goccy/go-json v0.9.11
 	github.com/golang/snappy v0.0.4
 	github.com/google/flatbuffers v2.0.8+incompatible
-	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	github.com/klauspost/asmfmt v1.3.2
 	github.com/klauspost/compress v1.15.9

--- a/go/go.sum
+++ b/go/go.sum
@@ -44,7 +44,6 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=


### PR DESCRIPTION
This should serve as discussion as it's a medium change but this should Close https://github.com/apache/arrow/issues/34453 and give users the ability to define custom Builder for their extensions just like they define ExtensionTypes and ExtensionArrays
* Closes: #34453