### PR TITLE
GH-34460: [C++][Parquet] Split arrow::FileReader::ReadRowGroups() for flexible async IO

### DIFF
--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -312,7 +312,7 @@ class FileReaderImpl : public FileReader {
   }
 
   Status WillNeedRowGroups(const std::vector<int>& row_groups,
-                          const std::vector<int>& column_indices) override;
+                           const std::vector<int>& column_indices) override;
 
   Status DecodeRowGroups(const std::vector<int>& row_groups,
                          const std::vector<int>& column_indices,
@@ -1239,8 +1239,8 @@ Status FileReaderImpl::WillNeedRowGroups(const std::vector<int>& row_groups,
 }
 
 Status FileReaderImpl::DecodeRowGroups(const std::vector<int>& row_groups,
-                       const std::vector<int>& column_indices,
-                       std::shared_ptr<::arrow::Table>* out) {
+                                       const std::vector<int>& column_indices,
+                                       std::shared_ptr<::arrow::Table>* out) {
   RETURN_NOT_OK(BoundsCheck(row_groups, column_indices));
 
   auto fut = DecodeRowGroups(/*self=*/nullptr, row_groups, column_indices,

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -250,7 +250,7 @@ class PARQUET_EXPORT FileReader {
   virtual ::arrow::Status ReadRowGroup(int i, std::shared_ptr<::arrow::Table>* out) = 0;
 
   virtual ::arrow::Status WillNeedRowGroups(const std::vector<int>& row_groups,
-                                           const std::vector<int>& column_indices) = 0;
+                                            const std::vector<int>& column_indices) = 0;
 
   virtual ::arrow::Status DecodeRowGroups(const std::vector<int>& row_groups,
                                           const std::vector<int>& column_indices,

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -249,6 +249,13 @@ class PARQUET_EXPORT FileReader {
 
   virtual ::arrow::Status ReadRowGroup(int i, std::shared_ptr<::arrow::Table>* out) = 0;
 
+  virtual ::arrow::Status WillNeedRowGroups(const std::vector<int>& row_groups,
+                                           const std::vector<int>& column_indices) = 0;
+
+  virtual ::arrow::Status DecodeRowGroups(const std::vector<int>& row_groups,
+                                          const std::vector<int>& column_indices,
+                                          std::shared_ptr<::arrow::Table>* out) = 0;
+
   virtual ::arrow::Status ReadRowGroups(const std::vector<int>& row_groups,
                                         const std::vector<int>& column_indices,
                                         std::shared_ptr<::arrow::Table>* out) = 0;


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Current implementation of arrow::FileReader::ReadRowGroups() has sync interface. It complicates use in environments where additional threads are undesirable. Splitting this method into 2 parts will fix it. Details and usage examples are inside issue description.

### What changes are included in this PR?

Two new methods in arrow::FileReader class

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Changes were tested actively in our private repository.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

No changes to the current functionality. PR is simple enough and expects no regression.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #34460