### PR TITLE
GH-34467: [R] Disable DuckDB tests on R versions < 4.0.0  

### DIFF
--- a/r/R/duckdb.R
+++ b/r/R/duckdb.R
@@ -94,7 +94,8 @@ run_duckdb_examples <- function() {
     requireNamespace("duckdb", quietly = TRUE) &&
     packageVersion("duckdb") > "0.2.7" &&
     requireNamespace("dplyr", quietly = TRUE) &&
-    requireNamespace("dbplyr", quietly = TRUE)
+    requireNamespace("dbplyr", quietly = TRUE) &&
+    R.Version()$major >= 4
 }
 
 # Adapted from dbplyr

--- a/r/R/duckdb.R
+++ b/r/R/duckdb.R
@@ -95,7 +95,7 @@ run_duckdb_examples <- function() {
     packageVersion("duckdb") > "0.2.7" &&
     requireNamespace("dplyr", quietly = TRUE) &&
     requireNamespace("dbplyr", quietly = TRUE) &&
-    R.Version()$major >= 4
+    getRversion() >= 4
 }
 
 # Adapted from dbplyr

--- a/r/tests/testthat/test-duckdb.R
+++ b/r/tests/testthat/test-duckdb.R
@@ -17,6 +17,8 @@
 
 skip_if_not_available("dataset")
 skip_on_cran()
+# DuckDB 0.7.1-1 may have errors with R<4.0
+skip_on_r_older_than("4.0")
 
 # this test needs to be the first one since all other test blocks are skipped
 # if duckdb is not installed


### PR DESCRIPTION
This PR skips DuckDB tests on older versions of R.
* Closes: #34467