### PR TITLE
GH-33801: [Python] Further expose C++ Extension Types in Python

### DIFF
--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2693,6 +2693,12 @@ cdef extern from "arrow/extension_type.h" namespace "arrow":
         c_string extension_name()
         shared_ptr[CDataType] storage_type()
 
+        c_string Serialize()
+        CResult[shared_ptr[CDataType]] Deserialize(shared_ptr[CDataType] storage_type,
+                                                   const c_string & serialized_data)
+
+        bint ExtensionEquals(CExtensionType other)
+
         @staticmethod
         shared_ptr[CArray] WrapArray(shared_ptr[CDataType] ext_type,
                                      shared_ptr[CArray] storage)


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Explained in greater detail in https://github.com/apache/arrow/issues/33997, but my summary follows:

* C++ Extension Types currently are not well-exposed in the Python Layer
* In particular, generic `ExtensionArray` and `ExtensionScalar` types are associated with C++ Extensions exposed through `BaseExtensionType`, rather than hand-coded Python types (which would be laborious to generate).

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

* When `BaseExtensionType.__arrow_ext_class__()` and `BaseExtensionType.__arrow_ext_scalar_class__()` are called, associated Python classes are created on the fly and cached for future calls.
* `BaseExtensionType.__arrow_ext_serialize__()` and `BaseExtensionType.__arrow_ext_deserialize__()` defer to `CExtensionType.Serialize()` and `CExtensionType.Deserialize()` respectively.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

* `__arrow_ext_class__()` and `__arrow_ext_scalar_class__()` are tested
* `__arrow_ext_serialize__()` and `__arrow_ext_deserialize__()` are not tested yet. I'd appreciate feedback on whether the general approach is useful going forward before adding tests.

### Are there any user-facing changes?

* I don't believe so.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #33997 