### PR TITLE
GH-34385: [Go] Read IPC files with compression enabled but uncompressed buffers

### DIFF
--- a/go/arrow/ipc/ipc.go
+++ b/go/arrow/ipc/ipc.go
@@ -182,7 +182,7 @@ func WithDictionaryDeltas(v bool) Option {
 // Values outside of the range [0,1] are handled as errors.
 //
 // Note that enabling this option may result in unreadable data for Arrow
-// C++ versions prior to 12.0.0.
+// Go and C++ versions prior to 12.0.0.
 func WithMinSpaceSavings(savings float64) Option {
 	return func(cfg *config) {
 		cfg.minSpaceSavings = &savings

--- a/go/arrow/ipc/ipc.go
+++ b/go/arrow/ipc/ipc.go
@@ -71,6 +71,7 @@ type config struct {
 	ensureNativeEndian bool
 	noAutoSchema       bool
 	emitDictDeltas     bool
+	minSpaceSavings    *float64
 }
 
 func newConfig(opts ...Option) *config {
@@ -165,6 +166,26 @@ func WithDelayReadSchema(v bool) Option {
 func WithDictionaryDeltas(v bool) Option {
 	return func(cfg *config) {
 		cfg.emitDictDeltas = v
+	}
+}
+
+// WithMinSpaceSavings specifies a percentage of space savings for
+// compression to be applied to buffers.
+//
+// Space savings is calculated as (1.0 - compressedSize / uncompressedSize).
+//
+// For example, if minSpaceSavings = 0.1, a 100-byte body buffer won't
+// undergo compression if its expected compressed size exceeds 90 bytes.
+// If this option is unset, compression will be used indiscriminately. If
+// no codec was supplied, this option is ignored.
+//
+// Values outside of the range [0,1] are handled as errors.
+//
+// Note that enabling this option may result in unreadable data for Arrow
+// C++ versions prior to 12.0.0.
+func WithMinSpaceSavings(savings float64) Option {
+	return func(cfg *config) {
+		cfg.minSpaceSavings = &savings
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
Fixing a bug in compressing buffers by prepending -1 when a buffer is not compressed due to size.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### Are these changes tested?
Unit tests added, and other tests will be enabled via integration tests in #15194
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

* Closes: #34385