### PR TITLE
GH-34211: [R] Make sure Arrow arrays are unmaterialized before attempting to access the underlying ChunkedArray

### DIFF
--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -1052,8 +1052,12 @@ bool is_arrow_altrep(SEXP x) {
   return false;
 }
 
+bool is_unmaterialized_arrow_altrep(SEXP x) {
+  return is_arrow_altrep(x) && R_altrep_data1(x) != R_NilValue;
+}
+
 std::shared_ptr<ChunkedArray> vec_to_arrow_altrep_bypass(SEXP x) {
-  if (is_arrow_altrep(x) && R_altrep_data1(x) != R_NilValue) {
+  if (is_unmaterialized_arrow_altrep(x)) {
     return GetChunkedArray(x);
   }
 
@@ -1078,6 +1082,8 @@ SEXP MakeAltrepVector(const std::shared_ptr<ChunkedArray>& chunked_array) {
 bool is_arrow_altrep(SEXP) { return false; }
 
 std::shared_ptr<ChunkedArray> vec_to_arrow_altrep_bypass(SEXP x) { return nullptr; }
+
+bool is_unmaterialized_arrow_altrep(SEXP) { return false; }
 
 }  // namespace altrep
 }  // namespace r

--- a/r/src/array_to_vector.cpp
+++ b/r/src/array_to_vector.cpp
@@ -761,7 +761,7 @@ class Converter_Struct : public Converter {
       SEXP data_i = VECTOR_ELT(data, i);
 
       // only ingest if the column is not altrep
-      if (!altrep::is_arrow_altrep(data_i)) {
+      if (!altrep::is_unmaterialized_arrow_altrep(data_i)) {
         StopIfNotOk(converters[i]->Ingest_all_nulls(data_i, start, n));
       }
     }
@@ -778,7 +778,7 @@ class Converter_Struct : public Converter {
       SEXP data_i = VECTOR_ELT(data, i);
 
       // only ingest if the column is not altrep
-      if (!altrep::is_arrow_altrep(data_i)) {
+      if (!altrep::is_unmaterialized_arrow_altrep(data_i)) {
         StopIfNotOk(converters[i]->Ingest_some_nulls(VECTOR_ELT(data, i), arrays[i],
                                                      start, n, chunk_index));
       }

--- a/r/src/arrow_types.h
+++ b/r/src/arrow_types.h
@@ -239,6 +239,7 @@ void Init_Altrep_classes(DllInfo* dll);
 
 SEXP MakeAltrepVector(const std::shared_ptr<ChunkedArray>& chunked_array);
 bool is_arrow_altrep(SEXP x);
+bool is_unmaterialized_arrow_altrep(SEXP x);
 std::shared_ptr<ChunkedArray> vec_to_arrow_altrep_bypass(SEXP);
 
 }  // namespace altrep

--- a/r/src/r_to_arrow.cpp
+++ b/r/src/r_to_arrow.cpp
@@ -1498,7 +1498,7 @@ std::shared_ptr<arrow::Table> Table__from_dots(SEXP lst, SEXP schema_sxp,
     } else if (Rf_inherits(x, "Array")) {
       columns[j] = std::make_shared<arrow::ChunkedArray>(
           cpp11::as_cpp<std::shared_ptr<arrow::Array>>(x));
-    } else if (arrow::r::altrep::is_arrow_altrep(x)) {
+    } else if (arrow::r::altrep::is_unmaterialized_arrow_altrep(x)) {
       columns[j] = arrow::r::altrep::vec_to_arrow_altrep_bypass(x);
     } else {
       arrow::r::RConversionOptions options;

--- a/r/src/type_infer.cpp
+++ b/r/src/type_infer.cpp
@@ -185,7 +185,7 @@ std::shared_ptr<arrow::DataType> InferArrowTypeFromVector<VECSXP>(SEXP x) {
 }
 
 std::shared_ptr<arrow::DataType> InferArrowType(SEXP x) {
-  if (arrow::r::altrep::is_arrow_altrep(x)) {
+  if (arrow::r::altrep::is_unmaterialized_arrow_altrep(x)) {
     return arrow::r::altrep::vec_to_arrow_altrep_bypass(x)->type();
   }
 


### PR DESCRIPTION
### Rationale for this change

When we attempt to re-use an object that Arrow itself created previously by wrapping a chunked array, we will get a crash if this object has been materialized (i.e., R values have been accessed and the ChunkedArray reference deleted). This behaviour changed between 10.0.0 and 11.0.0 because I redid the ALTREP implementation just after the 10.0.0 release.

The following test crashes R on main and 11.0.0 but passes after this PR:

``` r
library(arrow, warn.conflicts = FALSE)
#> Some features are not enabled in this build of Arrow. Run `arrow_info()` for more information.
library(testthat, warn.conflicts = FALSE)
withr::local_namespace("arrow")

test_that("Materialized ALTREP arrays don't cause arrow to crash when attempting to bypass", {
  a_int <- Array$create(c(1L, 2L, 3L))
  b_int <- a_int$as_vector()
  expect_true(is_arrow_altrep(b_int))
  expect_false(test_arrow_altrep_is_materialized(b_int))
  
  # Some operations that use altrep bypass
  expect_equal(infer_type(b_int), int32())
  expect_equal(as_arrow_array(b_int), a_int)
  
  # Still shouldn't have materialized yet
  expect_false(test_arrow_altrep_is_materialized(b_int))
  
  # Force it to materialize and check again
  test_arrow_altrep_force_materialize(b_int)
  expect_true(test_arrow_altrep_is_materialized(b_int))
  expect_equal(infer_type(b_int), int32())
  expect_equal(as_arrow_array(b_int), a_int)
})
#> Test passed 🎉
```

### What changes are included in this PR?

We used a function called `is_arrow_altrep()` to check if we could safely access the ChunkedArray reference; however, *materialized* ALTREP arrays still cause this return `true`. I added a new function `is_unmaterialized_arrow_altrep()` and replaced usage that depended on the ChunkedArray actually existing to use it.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #34211