### PR TITLE
GH-34492: [Go] Fix missing boolean plain encoder state update

### DIFF
--- a/go/parquet/file/column_writer_test.go
+++ b/go/parquet/file/column_writer_test.go
@@ -256,10 +256,8 @@ func (p *PrimitiveWriterTestSuite) buildReader(nrows int64, compression compress
 	return file.NewColumnReader(p.descr, pagereader, mem, &p.bufferPool)
 }
 
-func (p *PrimitiveWriterTestSuite) buildWriter(_ int64, columnProps parquet.ColumnProperties, version parquet.Version) file.ColumnChunkWriter {
+func (p *PrimitiveWriterTestSuite) buildWriter(_ int64, columnProps parquet.ColumnProperties, opts ...parquet.WriterProperty) file.ColumnChunkWriter {
 	p.sink = encoding.NewBufferWriter(0, mem)
-	opts := make([]parquet.WriterProperty, 0)
-	opts = append(opts, parquet.WithVersion(version))
 	if columnProps.Encoding == parquet.Encodings.PlainDict || columnProps.Encoding == parquet.Encodings.RLEDict {
 		opts = append(opts, parquet.WithDictionaryDefault(true), parquet.WithDictionaryPageSizeLimit(DictionaryPageSize))
 	} else {
@@ -304,7 +302,7 @@ func (p *PrimitiveWriterTestSuite) writeRequiredWithSettings(encoding parquet.En
 		StatsEnabled:      stats,
 		CompressionLevel:  compressLvl,
 	}
-	writer := p.buildWriter(nrows, columnProperties, parquet.V1_0)
+	writer := p.buildWriter(nrows, columnProperties, parquet.WithVersion(parquet.V1_0))
 	p.WriteBatchValues(writer, nil, nil)
 	// behavior should be independant of the number of calls to Close
 	writer.Close()
@@ -321,7 +319,7 @@ func (p *PrimitiveWriterTestSuite) writeRequiredWithSettingsSpaced(encoding parq
 		StatsEnabled:      stats,
 		CompressionLevel:  compressionLvl,
 	}
-	writer := p.buildWriter(nrows, columnProperties, parquet.V1_0)
+	writer := p.buildWriter(nrows, columnProperties, parquet.WithVersion(parquet.V1_0))
 	p.WriteBatchValuesSpaced(writer, nil, nil, validBits, 0)
 	// behavior should be independant from the number of close calls
 	writer.Close()
@@ -382,7 +380,7 @@ func (p *PrimitiveWriterTestSuite) testDictionaryFallbackEncoding(version parque
 		props.Encoding = parquet.Encodings.RLEDict
 	}
 
-	writer := p.buildWriter(VeryLargeSize, props, version)
+	writer := p.buildWriter(VeryLargeSize, props, parquet.WithVersion(version))
 	p.WriteBatchValues(writer, nil, nil)
 	writer.Close()
 
@@ -491,7 +489,7 @@ func (p *PrimitiveWriterTestSuite) TestOptionalNonRepeated() {
 	p.GenerateData(SmallSize)
 	p.DefLevels[1] = 0
 
-	writer := p.buildWriter(SmallSize, parquet.DefaultColumnProperties(), parquet.V1_0)
+	writer := p.buildWriter(SmallSize, parquet.DefaultColumnProperties(), parquet.WithVersion(parquet.V1_0))
 	p.WriteBatchValues(writer, p.DefLevels, nil)
 	writer.Close()
 
@@ -514,7 +512,7 @@ func (p *PrimitiveWriterTestSuite) TestOptionalSpaced() {
 	p.DefLevels[1] = 0
 	bitutil.ClearBit(validBits, 1)
 
-	writer := p.buildWriter(SmallSize, parquet.DefaultColumnProperties(), parquet.V1_0)
+	writer := p.buildWriter(SmallSize, parquet.DefaultColumnProperties(), parquet.WithVersion(parquet.V1_0))
 	p.WriteBatchValuesSpaced(writer, p.DefLevels, nil, validBits, 0)
 	writer.Close()
 
@@ -544,7 +542,7 @@ func (p *PrimitiveWriterTestSuite) TestWriteRepeated() {
 		p.RepLevels[idx] = 0
 	}
 
-	writer := p.buildWriter(SmallSize, parquet.DefaultColumnProperties(), parquet.V1_0)
+	writer := p.buildWriter(SmallSize, parquet.DefaultColumnProperties(), parquet.WithVersion(parquet.V1_0))
 	p.WriteBatchValues(writer, p.DefLevels, p.RepLevels)
 	writer.Close()
 
@@ -559,7 +557,7 @@ func (p *PrimitiveWriterTestSuite) TestRequiredLargeChunk() {
 	p.GenerateData(LargeSize)
 
 	// Test 1: required and non-repeated, so no def or rep levels
-	writer := p.buildWriter(LargeSize, parquet.DefaultColumnProperties(), parquet.V1_0)
+	writer := p.buildWriter(LargeSize, parquet.DefaultColumnProperties(), parquet.WithVersion(parquet.V1_0))
 	p.WriteBatchValues(writer, nil, nil)
 	writer.Close()
 
@@ -588,7 +586,7 @@ func (p *PrimitiveWriterTestSuite) TestOptionalNullValueChunk() {
 		p.RepLevels[idx] = 0
 	}
 
-	writer := p.buildWriter(LargeSize, parquet.DefaultColumnProperties(), parquet.V1_0)
+	writer := p.buildWriter(LargeSize, parquet.DefaultColumnProperties(), parquet.WithVersion(parquet.V1_0))
 	p.WriteBatchValues(writer, p.DefLevels, p.RepLevels)
 	writer.Close()
 
@@ -639,7 +637,7 @@ func (b *ByteArrayWriterSuite) TestOmitStats() {
 	maxLen := 1024 * 8
 	b.SetupSchema(parquet.Repetitions.Required, 1)
 	b.Values = make([]parquet.ByteArray, SmallSize)
-	writer := b.buildWriter(SmallSize, parquet.DefaultColumnProperties(), parquet.V1_0)
+	writer := b.buildWriter(SmallSize, parquet.DefaultColumnProperties(), parquet.WithVersion(parquet.V1_0))
 	testutils.RandomByteArray(0, b.Values.([]parquet.ByteArray), b.Buffer, minLen, maxLen)
 	writer.(*file.ByteArrayColumnChunkWriter).WriteBatch(b.Values.([]parquet.ByteArray), nil, nil)
 	writer.Close()
@@ -657,7 +655,7 @@ func (b *ByteArrayWriterSuite) TestOmitDataPageStats() {
 	colprops := parquet.DefaultColumnProperties()
 	colprops.StatsEnabled = false
 
-	writer := b.buildWriter(SmallSize, colprops, parquet.V1_0)
+	writer := b.buildWriter(SmallSize, colprops, parquet.WithVersion(parquet.V1_0))
 	b.Values = make([]parquet.ByteArray, 1)
 	testutils.RandomByteArray(0, b.Values.([]parquet.ByteArray), b.Buffer, int(minLen), int(maxLen))
 	writer.(*file.ByteArrayColumnChunkWriter).WriteBatch(b.Values.([]parquet.ByteArray), nil, nil)
@@ -673,7 +671,7 @@ func (b *ByteArrayWriterSuite) TestLimitStats() {
 	colprops := parquet.DefaultColumnProperties()
 	colprops.MaxStatsSize = int64(maxLen)
 
-	writer := b.buildWriter(SmallSize, colprops, parquet.V1_0).(*file.ByteArrayColumnChunkWriter)
+	writer := b.buildWriter(SmallSize, colprops, parquet.WithVersion(parquet.V1_0)).(*file.ByteArrayColumnChunkWriter)
 	b.Values = make([]parquet.ByteArray, SmallSize)
 	testutils.RandomByteArray(0, b.Values.([]parquet.ByteArray), b.Buffer, minLen, maxLen)
 	writer.WriteBatch(b.Values.([]parquet.ByteArray), nil, nil)
@@ -684,7 +682,7 @@ func (b *ByteArrayWriterSuite) TestLimitStats() {
 
 func (b *ByteArrayWriterSuite) TestCheckDefaultStats() {
 	b.SetupSchema(parquet.Repetitions.Required, 1)
-	writer := b.buildWriter(SmallSize, parquet.DefaultColumnProperties(), parquet.V1_0)
+	writer := b.buildWriter(SmallSize, parquet.DefaultColumnProperties(), parquet.WithVersion(parquet.V1_0))
 	b.GenerateData(SmallSize)
 	b.WriteBatchValues(writer, nil, nil)
 	writer.Close()
@@ -698,7 +696,8 @@ type BooleanValueWriterSuite struct {
 
 func (b *BooleanValueWriterSuite) TestAlternateBooleanValues() {
 	b.SetupSchema(parquet.Repetitions.Required, 1)
-	writer := b.buildWriter(SmallSize, parquet.DefaultColumnProperties(), parquet.V1_0).(*file.BooleanColumnChunkWriter)
+	// We use an unusual data-page size to try to flush out Boolean encoder issues in usage of the BitMapWriter
+	writer := b.buildWriter(SmallSize, parquet.DefaultColumnProperties(), parquet.WithVersion(parquet.V1_0), parquet.WithDataPageSize(7)).(*file.BooleanColumnChunkWriter)
 	for i := 0; i < SmallSize; i++ {
 		val := i%2 == 0
 		writer.WriteBatch([]bool{val}, nil, nil)

--- a/go/parquet/internal/encoding/boolean_encoder.go
+++ b/go/parquet/internal/encoding/boolean_encoder.go
@@ -83,5 +83,7 @@ func (enc *PlainBooleanEncoder) FlushValues() (Buffer, error) {
 		enc.append(enc.bitsBuffer[:bitutil.BytesForBits(int64(toFlush))])
 	}
 
+	enc.wr.Reset(0, boolsInBuf)
+
 	return enc.sink.Finish(), nil
 }

--- a/go/parquet/metadata/statistics_test.go
+++ b/go/parquet/metadata/statistics_test.go
@@ -188,3 +188,15 @@ func TestCheckNegativeZeroStats(t *testing.T) {
 		assertMinMaxZeroesSign(dstats, []float64{f64zero, f64zero})
 	}
 }
+
+func TestBooleanStatisticsEncoding(t *testing.T) {
+	n := schema.NewBooleanNode("boolean", parquet.Repetitions.Required, -1)
+	descr := schema.NewColumn(n, 0, 0)
+	s := metadata.NewStatistics(descr, nil)
+	bs := s.(*metadata.BooleanStatistics)
+	bs.SetMinMax(false, true)
+	maxEnc := bs.EncodeMax()
+	minEnc := bs.EncodeMin()
+	assert.Equal(t, []byte{1}, maxEnc)
+	assert.Equal(t, []byte{0}, minEnc)
+}


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

This is a bugfix in the go `PlainBooleanEncoder`. Statistics of boolean columns, as well as data in rare cases, can be malformed. This is a data-correctness bugfix.

### What changes are included in this PR?

`FlushValue` does not reset the intermediary BitMapWriter position. In this way previously-encoded values might "leak" into subsequent `FlushValue` calls. Page emission and statistics emission (for examples) manifest this issue.

### Are these changes tested?

Yes. The most direct test is the new `TestBooleanPlainDecoderAfterFlushing` in internal\encoding\encoding_test.go, but I also added `TestBooleanStatisticsEncoding` as a "consumer" of that encoder.

Question: should I add more testing? I experimentally harnessed a fuzz test targeted towards the Boolean encoder, and that manifested the issue, but that's a fuzz test and also targeted towards Bools alone. I also provisionally implemented a (hacky) extension to the roundtrip tests to have an intermediate flush, but that didn't seem enough to manifest the (somewhat value-count-sensitive) issue.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
This is a correctness fix, so other than that, no.

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
**This PR contains a "Critical Fix".**
* Closes: #34492