### PR TITLE
GH-34257:[Docs] Update git links/branches from master to main for external projects

### DIFF
--- a/cpp/cmake_modules/DefineOptions.cmake
+++ b/cpp/cmake_modules/DefineOptions.cmake
@@ -552,7 +552,7 @@ takes precedence over ccache if a storage backend is configured" ON)
 
     if(DEFINED ENV{CONDA_PREFIX})
       # Conda package changes the output name.
-      # https://github.com/conda-forge/snappy-feedstock/blob/master/recipe/windows-static-lib-name.patch
+      # https://github.com/conda-forge/snappy-feedstock/blob/main/recipe/windows-static-lib-name.patch
       set(SNAPPY_MSVC_STATIC_LIB_SUFFIX_DEFAULT "_static")
     else()
       set(SNAPPY_MSVC_STATIC_LIB_SUFFIX_DEFAULT "")

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -4182,7 +4182,7 @@ macro(build_google_cloud_cpp_storage)
   message(STATUS "Building google-cloud-cpp from source")
   message(STATUS "Only building the google-cloud-cpp::storage component")
 
-  # List of dependencies taken from https://github.com/googleapis/google-cloud-cpp/blob/master/doc/packaging.md
+  # List of dependencies taken from https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging.md
   ensure_absl()
   build_crc32c_once()
 

--- a/cpp/src/arrow/vendored/xxhash/xxhash.h
+++ b/cpp/src/arrow/vendored/xxhash/xxhash.h
@@ -2474,7 +2474,7 @@ XXH_FORCE_INLINE xxh_u64x2 XXH_vec_loadu(const void *ptr)
 #  define XXH_vec_mule __builtin_altivec_vmuleuw
 # else
 /* gcc needs inline assembly */
-/* Adapted from https://github.com/google/highwayhash/blob/master/highwayhash/hh_vsx.h. */
+/* Adapted from https://github.com/google/highwayhash/blob/main/highwayhash/hh_vsx.h. */
 XXH_FORCE_INLINE xxh_u64x2 XXH_vec_mulo(xxh_u32x4 a, xxh_u32x4 b)
 {
     xxh_u64x2 result;

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -156,7 +156,7 @@ When building the officially released version run: (see Note below about current
 
 Which will build the final/stable package.
 
-NOTE: When building the officially released version, ensure that your `git` repository has the `origin` remote set to `https://github.com/apache/arrow.git`, which will ensure Source Link is set correctly. See https://github.com/dotnet/sourcelink/blob/master/docs/README.md for more information.
+NOTE: When building the officially released version, ensure that your `git` repository has the `origin` remote set to `https://github.com/apache/arrow.git`, which will ensure Source Link is set correctly. See https://github.com/dotnet/sourcelink/blob/main/docs/README.md for more information.
 
 There are two output artifacts:
 1. `Apache.Arrow.<version>.nupkg` - this contains the executable assemblies
@@ -178,7 +178,7 @@ All build artifacts are placed in the **artifacts** folder in the project root.
 
 # Coding Style
 
-This project follows the coding style specified in [Coding Style](https://github.com/dotnet/runtime/blob/master/docs/coding-guidelines/coding-style.md).
+This project follows the coding style specified in [Coding Style](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/coding-style.md).
 
 # Updating FlatBuffers code
 

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -81,7 +81,7 @@ jobs:
           # doesn't provides static z3 because z3's CMake doesn't accept
           # building both shared and static libraries at once.
           # See also: Z3_BUILD_LIBZ3_SHARED in
-          # https://github.com/Z3Prover/z3/blob/master/README-CMake.md
+          # https://github.com/Z3Prover/z3/blob/main/README-CMake.md
           #
           # If llvm is installed, Apache Arrow C++ uses llvm rather than
           # llvm@14 because llvm is newer than llvm@14.

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -81,7 +81,7 @@ jobs:
           # doesn't provides static z3 because z3's CMake doesn't accept
           # building both shared and static libraries at once.
           # See also: Z3_BUILD_LIBZ3_SHARED in
-          # https://github.com/Z3Prover/z3/blob/main/README-CMake.md
+          # https://github.com/Z3Prover/z3/blob/master/README-CMake.md
           #
           # If llvm is installed, Apache Arrow C++ uses llvm rather than
           # llvm@14 because llvm is newer than llvm@14.

--- a/python/pyarrow/serialization.py
+++ b/python/pyarrow/serialization.py
@@ -31,7 +31,7 @@ except ImportError:
 
 try:
     # This function is available after numpy-0.16.0.
-    # See also: https://github.com/numpy/numpy/blob/master/numpy/lib/format.py
+    # See also: https://github.com/numpy/numpy/blob/main/numpy/lib/format.py
     from numpy.lib.format import descr_to_dtype
 except ImportError:
     def descr_to_dtype(descr):

--- a/python/pyarrow/src/arrow/python/datetime.cc
+++ b/python/pyarrow/src/arrow/python/datetime.cc
@@ -88,7 +88,7 @@ void InitDatetime() {
 #endif
 
 // The following code is adapted from
-// https://github.com/numpy/numpy/blob/master/numpy/core/src/multiarray/datetime.c
+// https://github.com/numpy/numpy/blob/main/numpy/core/src/multiarray/datetime.c
 
 // Days per month, regular year and leap year
 static int64_t _days_per_month_table[2][12] = {

--- a/python/pyarrow/tests/data/orc/README.md
+++ b/python/pyarrow/tests/data/orc/README.md
@@ -19,4 +19,4 @@
 
 The ORC and JSON files come from the `examples` directory in the Apache ORC
 source tree:
-https://github.com/apache/orc/tree/master/examples
+https://github.com/apache/orc/tree/main/examples

--- a/r/R/dplyr-mutate.R
+++ b/r/R/dplyr-mutate.R
@@ -134,7 +134,7 @@ transmute.arrow_dplyr_query <- function(.data, ...) {
 transmute.Dataset <- transmute.ArrowTabular <- transmute.RecordBatchReader <- transmute.arrow_dplyr_query
 
 # This function is a copy of dplyr:::check_transmute_args at
-# https://github.com/tidyverse/dplyr/blob/master/R/mutate.R
+# https://github.com/tidyverse/dplyr/blob/main/R/mutate.R
 check_transmute_args <- function(..., .keep, .before, .after) {
   if (!missing(.keep)) {
     abort("`transmute()` does not support the `.keep` argument")

--- a/r/R/dplyr-select.R
+++ b/r/R/dplyr-select.R
@@ -39,7 +39,7 @@ rename_with.Dataset <- rename_with.ArrowTabular <- rename_with.RecordBatchReader
 
 relocate.arrow_dplyr_query <- function(.data, ..., .before = NULL, .after = NULL) {
   # The code in this function is adapted from the code in dplyr::relocate.data.frame
-  # at https://github.com/tidyverse/dplyr/blob/master/R/relocate.R
+  # at https://github.com/tidyverse/dplyr/blob/main/R/relocate.R
   # TODO: revisit this after https://github.com/tidyverse/dplyr/issues/5829
 
   .data <- as_adq(.data)


### PR DESCRIPTION
As shown in [#34257](https://github.com/apache/arrow/issues/34257), this pull request update the branch in our doc from **master**  to **main** for the external dependencies who have changed their default branch to main.

**What changes are included in this PR?**
9 files.
changed link's git repos:
https://github.com/conda-forge/snappy-feedstock
https://github.com/googleapis/google-cloud-cpp
https://github.com/google/highwayhash
https://github.com/dotnet/sourcelink
https://github.com/dotnet/runtime
https://github.com/numpy/numpy
https://github.com/tidyverse/dplyr
https://github.com/apache/orc

**Are these changes tested?**
no
* Closes: #34257