### PR TITLE
GH-20351: [C++] Kernel input type matcher for run-end encoded types

### DIFF
--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -141,6 +141,25 @@ ARROW_EXPORT std::shared_ptr<TypeMatcher> FixedSizeBinaryLike();
 // Type)
 ARROW_EXPORT std::shared_ptr<TypeMatcher> Primitive();
 
+// \brief Match any integer type that can be used as run-end in run-end encoded
+// arrays
+ARROW_EXPORT std::shared_ptr<TypeMatcher> RunEndInteger();
+
+/// \brief Match run-end encoded types that use any valid run-end type and
+/// encode specific value types
+///
+/// @param[in] value_type_matcher a matcher that is applied to the values field
+ARROW_EXPORT std::shared_ptr<TypeMatcher> RunEndEncoded(
+    std::shared_ptr<TypeMatcher> value_type_matcher);
+
+/// \brief Match run-end encoded types that encode specific run-end and value types
+///
+/// @param[in] run_end_type_matcher a matcher that is applied to the run_ends field
+/// @param[in] value_type_matcher a matcher that is applied to the values field
+ARROW_EXPORT std::shared_ptr<TypeMatcher> RunEndEncoded(
+    std::shared_ptr<TypeMatcher> run_end_type_matcher,
+    std::shared_ptr<TypeMatcher> value_type_matcher);
+
 }  // namespace match
 
 /// \brief An object used for type-checking arguments to be passed to a kernel

--- a/cpp/src/arrow/compute/kernel_test.cc
+++ b/cpp/src/arrow/compute/kernel_test.cc
@@ -69,6 +69,35 @@ TEST(TypeMatcher, TimestampTypeUnit) {
   ASSERT_FALSE(matcher->Equals(*match::Time32TypeUnit(TimeUnit::MILLI)));
 }
 
+TEST(TypeMatcher, RunEndInteger) {
+  auto matcher = match::RunEndInteger();
+  ASSERT_FALSE(matcher->Matches(*int8()));
+  ASSERT_FALSE(matcher->Matches(*uint8()));
+  ASSERT_FALSE(matcher->Matches(*uint16()));
+  ASSERT_FALSE(matcher->Matches(*uint32()));
+  ASSERT_FALSE(matcher->Matches(*uint64()));
+
+  ASSERT_TRUE(matcher->Matches(*int16()));
+  ASSERT_TRUE(matcher->Matches(*int32()));
+  ASSERT_TRUE(matcher->Matches(*int64()));
+}
+
+TEST(TypeMatcher, RunEndEncoded) {
+  auto string_ree_matcher = match::RunEndEncoded(match::SameTypeId(Type::STRING));
+  auto int32_ree_matcher = match::RunEndEncoded(match::SameTypeId(Type::INT32));
+  auto empty_ree_matcher =
+      match::RunEndEncoded(match::SameTypeId(Type::INT8), match::SameTypeId(Type::INT32));
+  for (auto run_end_type : {int16(), int32(), int64()}) {
+    ASSERT_TRUE(string_ree_matcher->Matches(*run_end_encoded(run_end_type, utf8())));
+    ASSERT_FALSE(string_ree_matcher->Matches(*run_end_encoded(run_end_type, int32())));
+
+    ASSERT_FALSE(int32_ree_matcher->Matches(*run_end_encoded(run_end_type, utf8())));
+    ASSERT_TRUE(int32_ree_matcher->Matches(*run_end_encoded(run_end_type, int32())));
+
+    ASSERT_FALSE(empty_ree_matcher->Matches(*run_end_encoded(run_end_type, int32())));
+  }
+}
+
 // ----------------------------------------------------------------------
 // InputType
 

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -806,8 +806,7 @@ std::string RunEndEncodedType::ToString() const {
 }
 
 bool RunEndEncodedType::RunEndTypeValid(const DataType& run_end_type) {
-  return run_end_type.id() == Type::INT16 || run_end_type.id() == Type::INT32 ||
-         run_end_type.id() == Type::INT64;
+  return is_run_end_type(run_end_type.id());
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -981,6 +981,23 @@ constexpr bool is_decimal(Type::type type_id) {
   return false;
 }
 
+/// \brief Check for a type that can be used as a run-end in Run-End Encoded
+/// arrays
+///
+/// \param[in] type_id the type-id to check
+/// \return whether type-id can represent a run-end value
+constexpr bool is_run_end_type(Type::type type_id) {
+  switch (type_id) {
+    case Type::INT16:
+    case Type::INT32:
+    case Type::INT64:
+      return true;
+    default:
+      break;
+  }
+  return false;
+}
+
 /// \brief Check for a primitive type
 ///
 /// This predicate doesn't match null, decimals and binary-like types.

--- a/cpp/src/arrow/util/ree_util.h
+++ b/cpp/src/arrow/util/ree_util.h
@@ -209,7 +209,7 @@ class RunEndEncodedArraySpan {
   /// \brief Create an iterator from a logical position and its
   /// pre-computed physical offset into the run ends array
   ///
-  /// \param logical_pos is an index in the [0, length()) range
+  /// \param logical_pos is an index in the [0, length()] range
   /// \param physical_offset the pre-calculated PhysicalIndex(logical_pos)
   Iterator iterator(int64_t logical_pos, int64_t physical_offset) const {
     return Iterator{PrivateTag{}, *this, logical_pos, physical_offset};
@@ -217,10 +217,11 @@ class RunEndEncodedArraySpan {
 
   /// \brief Create an iterator from a logical position
   ///
-  /// \param logical_pos is an index in the [0, length()) range
+  /// \param logical_pos is an index in the [0, length()] range
   Iterator iterator(int64_t logical_pos) const {
-    assert(logical_pos < length());
-    return iterator(logical_pos, PhysicalIndex(logical_pos));
+    return iterator(logical_pos, logical_pos < length()
+                                     ? PhysicalIndex(logical_pos)
+                                     : RunEndsArray(array_span).length);
   }
 
   /// \brief Create an iterator representing the logical begin of the run-end


### PR DESCRIPTION
### Rationale for this change

This is necessary to be able to specify dispatching of filters based on run-end encoded array (upcoming PR).

### Are these changes tested?

Yes. By unit tests.

* Closes #13971
* Closes: #20351