### PR TITLE
GH-34484: [C++] Substrait join results in all zeroes on the righthand side of the join

### DIFF
--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -490,7 +490,7 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel, const ExtensionSet&
       ARROW_ASSIGN_OR_RAISE(auto ds, ds_factory->Finish(base_schema));
 
       // GH-34484: Based on the proposed fixed, adding a project node to eliminate
-      // unnecessary columns
+      // augmented columns from `scan`.
       std::vector<compute::Expression> project_exprs;
       project_exprs.reserve(base_schema->num_fields());
       for (const auto& field_name : base_schema->field_names()) {


### PR DESCRIPTION
This PR includes a modification to the `ReadRel` in Substrait consumer with Acero. Earlier it was allowed to include the augmented fields, but with this change, the augmented fields are ignored. This only affects when the data source is file/s. The change made in this PR follows the suggestion in the corresponding issue. Test cases were updated to reflect the change and also included a new test case to validate the idea. 

This could be a breaking change for some of the existing users who allow augmented fields to be used.
* Closes: #34484