### PR TITLE
GH-29105: [C++][Parquet] Relax schema checking when writing using StreamWriter

### DIFF
--- a/cpp/src/parquet/schema.h
+++ b/cpp/src/parquet/schema.h
@@ -222,6 +222,9 @@ class PARQUET_EXPORT PrimitiveNode : public Node {
 
   bool Equals(const Node* other) const override;
 
+  // Check if a value of converted_type can be read or written to this Parquet node.
+  bool CompatibleType(ConvertedType::type converted_type) const;
+
   Type::type physical_type() const { return physical_type_; }
 
   ColumnOrder column_order() const { return column_order_; }

--- a/cpp/src/parquet/stream_writer.cc
+++ b/cpp/src/parquet/stream_writer.cc
@@ -197,7 +197,7 @@ void StreamWriter::CheckColumn(Type::type physical_type,
                            "' has physical type '" + TypeToString(node->physical_type()) +
                            "' not '" + TypeToString(physical_type) + "'");
   }
-  if (converted_type != node->converted_type()) {
+  if (!node->CompatibleType(converted_type)) {
     throw ParquetException("Column converted type mismatch.  Column '" + node->name() +
                            "' has converted type[" +
                            ConvertedTypeToString(node->converted_type()) + "] not '" +


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The converted type expected by StreamWriter when writing int and string values did not match the converted type typically set in the Parquet schema. When writing INT_32 and INT_64, a converted type NONE is typically set in the Parquet schema, but this caused a ParquetException to be raised. This error was encountered when using StreamWriter after converting an Arrow schema to Parquet schema via ToParquetSchema().



Closes #29105.


### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Relax the schema checking in StreamWriter. The fix was already present for StreamReader since 4d82549, and is now ported to StreamWriter as well, with the shared logic moved to PrimitiveNode.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes. A test was added to verify that StreamWriter is able to write `INT_32`, `INT_64` and `UTF8` types when the `ConvertedType` in the Parquet schema is set to `NONE`.

### Are there any user-facing changes?

No.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #29105