### PR TITLE
GH-34513: [CI][Python] Remove unused imports from _acero.pyx to fix linting failures

### DIFF
--- a/python/pyarrow/_acero.pyx
+++ b/python/pyarrow/_acero.pyx
@@ -25,11 +25,10 @@
 from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport *
 from pyarrow.includes.libarrow_dataset cimport *
-from pyarrow.lib cimport (Table, check_status, pyarrow_unwrap_table, pyarrow_wrap_table,
+from pyarrow.lib cimport (Table, pyarrow_unwrap_table, pyarrow_wrap_table,
                           RecordBatchReader)
 from pyarrow.lib import frombytes, tobytes
 from pyarrow._compute cimport Expression, FunctionOptions, _ensure_field_ref, _true
-from pyarrow.compute import field
 
 
 cdef class ExecNodeOptions(_Weakrefable):


### PR DESCRIPTION
### Rationale for this change

PR linting jobs are failing

### What changes are included in this PR?

Lint fixes :)

### Are these changes tested?

On CI

### Are there any user-facing changes?

No
* Closes: #34513