### PR TITLE
GH-34421: [R] Let GcsFileSystem take a path for json_credentials

### DIFF
--- a/r/R/filesystem.R
+++ b/r/R/filesystem.R
@@ -574,7 +574,7 @@ GcsFileSystem$create <- function(anonymous = FALSE, retry_limit_seconds = 15, ..
 
   # Handle reading json_credentials from the filesystem
   if ("json_credentials" %in% names(options) && file.exists(options[["json_credentials"]])) {
-    options[["json_credentials"]] <- paste(readLines(options[["json_credentials"]]), collapse = "")
+    options[["json_credentials"]] <- paste(readLines(options[["json_credentials"]]), collapse = "\n")
   }
 
   fs___GcsFileSystem__Make(anonymous, options)

--- a/r/R/filesystem.R
+++ b/r/R/filesystem.R
@@ -169,6 +169,7 @@ FileSelector$create <- function(base_dir, allow_not_found = FALSE, recursive = F
 #'   `access_token` will expire.
 #' - `json_credentials`: optional string for authentication. Either a string
 #'   containing JSON credentials or a path to their location on the filesystem.
+#'   If a path to credentials is given, the file should be UTF-8 encoded.
 #' - `endpoint_override`: if non-empty, will connect to provided host name / port,
 #'   such as "localhost:9001", instead of default GCS ones. This is primarily useful
 #'   for testing purposes.
@@ -574,7 +575,7 @@ GcsFileSystem$create <- function(anonymous = FALSE, retry_limit_seconds = 15, ..
 
   # Handle reading json_credentials from the filesystem
   if ("json_credentials" %in% names(options) && file.exists(options[["json_credentials"]])) {
-    options[["json_credentials"]] <- paste(readLines(options[["json_credentials"]]), collapse = "\n")
+    options[["json_credentials"]] <- paste(readLines(options[["json_credentials"]], encoding = "UTF-8"), collapse = "\n")
   }
 
   fs___GcsFileSystem__Make(anonymous, options)

--- a/r/R/filesystem.R
+++ b/r/R/filesystem.R
@@ -575,7 +575,7 @@ GcsFileSystem$create <- function(anonymous = FALSE, retry_limit_seconds = 15, ..
 
   # Handle reading json_credentials from the filesystem
   if ("json_credentials" %in% names(options) && file.exists(options[["json_credentials"]])) {
-    options[["json_credentials"]] <- paste(readLines(options[["json_credentials"]], encoding = "UTF-8"), collapse = "\n")
+    options[["json_credentials"]] <- paste(read_file_utf8(options[["json_credentials"]]), collapse = "\n")
   }
 
   fs___GcsFileSystem__Make(anonymous, options)
@@ -662,4 +662,11 @@ clean_path_rel <- function(path) {
   # Make sure all path separators are "/", not "\" as on Windows
   path_sep <- ifelse(tolower(Sys.info()[["sysname"]]) == "windows", "\\\\", "/")
   gsub(path_sep, "/", path)
+}
+
+read_file_utf8 <- function(file) {
+  res <- readBin(file, "raw", n = file.size(file))
+  res <- rawToChar(res)
+  Encoding(res) <- "UTF-8"
+  res
 }

--- a/r/R/filesystem.R
+++ b/r/R/filesystem.R
@@ -167,8 +167,8 @@ FileSelector$create <- function(base_dir, allow_not_found = FALSE, recursive = F
 #'   with `expiration`
 #' - `expiration`: `POSIXct`. optional datetime representing point at which
 #'   `access_token` will expire.
-#' - `json_credentials`: optional string for authentication. Point to a JSON
-#'   credentials file downloaded from GCS.
+#' - `json_credentials`: optional string for authentication. Either a string
+#'   containing JSON credentials or a path to their location on the filesystem.
 #' - `endpoint_override`: if non-empty, will connect to provided host name / port,
 #'   such as "localhost:9001", instead of default GCS ones. This is primarily useful
 #'   for testing purposes.
@@ -571,6 +571,11 @@ GcsFileSystem$create <- function(anonymous = FALSE, retry_limit_seconds = 15, ..
   }
 
   options$retry_limit_seconds <- retry_limit_seconds
+
+  # Handle reading json_credentials from the filesystem
+  if ("json_credentials" %in% names(options) && file.exists(options[["json_credentials"]])) {
+    options[["json_credentials"]] <- paste(readLines(options[["json_credentials"]]), collapse = "")
+  }
 
   fs___GcsFileSystem__Make(anonymous, options)
 }

--- a/r/man/FileSystem.Rd
+++ b/r/man/FileSystem.Rd
@@ -71,6 +71,7 @@ with \code{expiration}
 \code{access_token} will expire.
 \item \code{json_credentials}: optional string for authentication. Either a string
 containing JSON credentials or a path to their location on the filesystem.
+If a path to credentials is given, the file should be UTF-8 encoded.
 \item \code{endpoint_override}: if non-empty, will connect to provided host name / port,
 such as "localhost:9001", instead of default GCS ones. This is primarily useful
 for testing purposes.

--- a/r/man/FileSystem.Rd
+++ b/r/man/FileSystem.Rd
@@ -69,8 +69,8 @@ credentials using standard GCS configuration methods.
 with \code{expiration}
 \item \code{expiration}: \code{POSIXct}. optional datetime representing point at which
 \code{access_token} will expire.
-\item \code{json_credentials}: optional string for authentication. Point to a JSON
-credentials file downloaded from GCS.
+\item \code{json_credentials}: optional string for authentication. Either a string
+containing JSON credentials or a path to their location on the filesystem.
 \item \code{endpoint_override}: if non-empty, will connect to provided host name / port,
 such as "localhost:9001", instead of default GCS ones. This is primarily useful
 for testing purposes.

--- a/r/tests/testthat/test-gcs.R
+++ b/r/tests/testthat/test-gcs.R
@@ -103,6 +103,16 @@ test_that("GcsFileSystem$create() can read json_credentials", {
   writeBin(iconv('{"key" : "valu\u00e9"}\n', toRaw = TRUE)[[1]], con)
   close(con)
 
+  # WIP: Debugging https://github.com/apache/arrow/pull/34524 via CI
+  cred_path <- tempfile()
+  on.exit(unlink(cred_path))
+  con <- file(cred_path, open = "wb")
+  input <- '{"key" : "valu\u00e9"}\n'
+  print(Encoding(input))
+  writeBin(iconv(input, from = Encoding(input), out = "UTF-8", toRaw = TRUE)[[1]], con)
+  close(con) # Close now, Windows file handles are special
+  print(readBin(cred_path, "raw", file.size(cred_path)))
+
   fs <- GcsFileSystem$create(json_credentials = cred_path)
   expect_equal(fs$options$json_credentials, "{\"key\" : \"valué\"}")
 })

--- a/r/tests/testthat/test-gcs.R
+++ b/r/tests/testthat/test-gcs.R
@@ -100,14 +100,10 @@ test_that("GcsFileSystem$create() can read json_credentials", {
   cred_path <- tempfile()
   on.exit(unlink(cred_path))
   con <- file(cred_path, open = "wb")
-  writeBin('{"key" : "valu\u00e9"}', con)
+  writeBin(iconv('{"key" : "valu\u00e9"}\n', toRaw = TRUE)[[1]], con)
   close(con)
 
-  # This calls readLines which complains about embedded nuls and missing a
-  # final newline (See ?readLines)
-  suppressWarnings({
-    fs <- GcsFileSystem$create(json_credentials = cred_path)
-  })
+  fs <- GcsFileSystem$create(json_credentials = cred_path)
   expect_equal(fs$options$json_credentials, "{\"key\" : \"valué\"}")
 })
 

--- a/r/tests/testthat/test-gcs.R
+++ b/r/tests/testthat/test-gcs.R
@@ -91,6 +91,18 @@ test_that("GcsFileSystem$create() input validation", {
   )
 })
 
+test_that("GcsFileSystem$create() can read json_credentials", {
+  # From string
+  fs <- GcsFileSystem$create(json_credentials = "fromstring")
+  expect_equal(fs$options$json_credentials, "fromstring")
+
+  # From disk
+  cred_path <- tempfile()
+  writeLines("fromdisk", cred_path)
+  fs <- GcsFileSystem$create(json_credentials = cred_path)
+  expect_equal(fs$options$json_credentials, "fromdisk")
+})
+
 skip_on_cran()
 skip_if_not(system('python -c "import testbench"') == 0, message = "googleapis-storage-testbench is not installed.")
 library(dplyr)

--- a/r/tests/testthat/test-gcs.R
+++ b/r/tests/testthat/test-gcs.R
@@ -99,10 +99,16 @@ test_that("GcsFileSystem$create() can read json_credentials", {
   # From disk
   cred_path <- tempfile()
   on.exit(unlink(cred_path))
+  con <- file(cred_path, open = "wb")
+  writeBin('{"key" : "valu\u00e9"}', con)
+  close(con)
 
-  writeLines("fromdisk", cred_path)
-  fs <- GcsFileSystem$create(json_credentials = cred_path)
-  expect_equal(fs$options$json_credentials, "fromdisk")
+  # This calls readLines which complains about embedded nuls and missing a
+  # final newline (See ?readLines)
+  suppressWarnings({
+    fs <- GcsFileSystem$create(json_credentials = cred_path)
+  })
+  expect_equal(fs$options$json_credentials, "{\"key\" : \"valué\"}")
 })
 
 skip_on_cran()

--- a/r/tests/testthat/test-gcs.R
+++ b/r/tests/testthat/test-gcs.R
@@ -100,18 +100,8 @@ test_that("GcsFileSystem$create() can read json_credentials", {
   cred_path <- tempfile()
   on.exit(unlink(cred_path))
   con <- file(cred_path, open = "wb")
-  writeBin(iconv('{"key" : "valu\u00e9"}\n', toRaw = TRUE)[[1]], con)
+  writeBin(iconv('{"key" : "valu\u00e9"}\n', to = "UTF-8", toRaw = TRUE)[[1]], con)
   close(con)
-
-  # WIP: Debugging https://github.com/apache/arrow/pull/34524 via CI
-  cred_path <- tempfile()
-  on.exit(unlink(cred_path))
-  con <- file(cred_path, open = "wb")
-  input <- '{"key" : "valu\u00e9"}\n'
-  print(Encoding(input))
-  writeBin(iconv(input, from = Encoding(input), to = "UTF-8", toRaw = TRUE)[[1]], con)
-  close(con) # Close now, Windows file handles are special
-  print(readBin(cred_path, "raw", file.size(cred_path)))
 
   fs <- GcsFileSystem$create(json_credentials = cred_path)
   expect_equal(fs$options$json_credentials, "{\"key\" : \"valué\"}")

--- a/r/tests/testthat/test-gcs.R
+++ b/r/tests/testthat/test-gcs.R
@@ -98,6 +98,8 @@ test_that("GcsFileSystem$create() can read json_credentials", {
 
   # From disk
   cred_path <- tempfile()
+  on.exit(unlink(cred_path))
+
   writeLines("fromdisk", cred_path)
   fs <- GcsFileSystem$create(json_credentials = cred_path)
   expect_equal(fs$options$json_credentials, "fromdisk")

--- a/r/tests/testthat/test-gcs.R
+++ b/r/tests/testthat/test-gcs.R
@@ -100,7 +100,7 @@ test_that("GcsFileSystem$create() can read json_credentials", {
   cred_path <- tempfile()
   on.exit(unlink(cred_path))
   con <- file(cred_path, open = "wb")
-  writeBin(iconv('{"key" : "valu\u00e9"}\n', to = "UTF-8", toRaw = TRUE)[[1]], con)
+  writeBin(iconv('{"key" : "valu\u00e9"}', to = "UTF-8", toRaw = TRUE)[[1]], con)
   close(con)
 
   fs <- GcsFileSystem$create(json_credentials = cred_path)

--- a/r/tests/testthat/test-gcs.R
+++ b/r/tests/testthat/test-gcs.R
@@ -97,10 +97,18 @@ test_that("GcsFileSystem$create() can read json_credentials", {
   expect_equal(fs$options$json_credentials, "fromstring")
 
   # From disk
+  cred_string <- '{"key" : "valu\u00e9"}'
+  cred_string_bytes_utf8 <- iconv(
+    cred_string,
+    from = Encoding(cred_string),
+    to = "UTF-8",
+    toRaw = TRUE
+  )[[1]]
+
   cred_path <- tempfile()
   on.exit(unlink(cred_path))
   con <- file(cred_path, open = "wb")
-  writeBin(iconv('{"key" : "valu\u00e9"}', to = "UTF-8", toRaw = TRUE)[[1]], con)
+  writeBin(cred_string_bytes_utf8, con)
   close(con)
 
   fs <- GcsFileSystem$create(json_credentials = cred_path)

--- a/r/tests/testthat/test-gcs.R
+++ b/r/tests/testthat/test-gcs.R
@@ -109,7 +109,7 @@ test_that("GcsFileSystem$create() can read json_credentials", {
   con <- file(cred_path, open = "wb")
   input <- '{"key" : "valu\u00e9"}\n'
   print(Encoding(input))
-  writeBin(iconv(input, from = Encoding(input), out = "UTF-8", toRaw = TRUE)[[1]], con)
+  writeBin(iconv(input, from = Encoding(input), to = "UTF-8", toRaw = TRUE)[[1]], con)
   close(con) # Close now, Windows file handles are special
   print(readBin(cred_path, "raw", file.size(cred_path)))
 


### PR DESCRIPTION
### Rationale for this change

Existing documentation for this argument was misleading.

### What changes are included in this PR?

A change in functionality, matching tests, and updated documentation are included. `json_credentials` can now either be a literal string containing credentials or a string containing a path to credentials. In the latter case, credentials will be automatically read in from the fileystem.

### Are these changes tested?

Yes

### Are there any user-facing changes?

Yes, though not breaking. This affects user-facing APIs and documentation and is both a bug fix and new functionality.

Closes https://github.com/apache/arrow/issues/34421
Closes https://github.com/apache/arrow/issues/33106
* Closes: #34421