### PR TITLE
MINOR: [Docs][C++] Explain "Illegal Instruction" on legacy CPU

### DIFF
--- a/docs/source/cpp/env_vars.rst
+++ b/docs/source/cpp/env_vars.rst
@@ -106,6 +106,14 @@ that changing their value later will have an effect.
       Unlike runtime dispatch, compile-time SIMD optimizations cannot be
       changed at runtime (for example, if you compile Arrow C++ with AVX512
       enabled, the resulting binary will only run on AVX512-enabled CPUs).
+      Setting ``ARROW_USER_SIMD_LEVEL=NONE`` prevents the execution of
+      explicit SIMD optimization code, but it does not rule out the execution
+      of compiler generated SIMD instructions.  E.g., on x86_64 platform,
+      Arrow is built with ``ARROW_SIMD_LEVEL=SSE4_2`` by default.  Compiler
+      may generate SSE4.2 instructions from any C/C++ source code.  On legacy
+      x86_64 platforms do not support SSE4.2, Arrow binary may fail with
+      SIGILL (Illegal Instruction).  User must rebuild Arrow and PyArrow from
+      scratch by setting cmake option ``ARROW_SIMD_LEVEL=NONE``.
 
 .. envvar:: GANDIVA_CACHE_SIZE
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
We saw "Illegal Instruction" bug repots from time to time. It happens on legacy x86_64 CPUs don't support SSE4.2.
User may misunderstand current document and think that setting `ARROW_USER_SIMD_LEVEL=NONE` will disable SSE instruction at runtime and fix the issue. Clearer explaination is necessary.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
Update cpp document to explain "Illegal Instruction" issue and how to fix it.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
No.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->