### PR TITLE
GH-33976: [Python] Add scan ExecNode options

### DIFF
--- a/python/pyarrow/tests/test_acero.py
+++ b/python/pyarrow/tests/test_acero.py
@@ -20,6 +20,7 @@ import pytest
 import pyarrow as pa
 import pyarrow.compute as pc
 from pyarrow.compute import field
+import pyarrow.dataset as ds
 
 from pyarrow._acero import (
     TableSourceNodeOptions,
@@ -29,6 +30,7 @@ from pyarrow._acero import (
     HashJoinNodeOptions,
     Declaration,
 )
+from pyarrow._dataset import ScanNodeOptions
 
 
 @pytest.fixture
@@ -291,3 +293,38 @@ def test_hash_join():
         names=["key", "a", "b"]
     )
     assert result.sort_by("a").equals(expected)
+
+
+def test_scan(tempdir):
+    table = pa.table({'a': [1, 2, 3], 'b': [4, 5, 6]})
+    ds.write_dataset(table, tempdir / "dataset", format="parquet")
+    dataset = ds.dataset(tempdir / "dataset", format="parquet")
+    decl = Declaration("scan", ScanNodeOptions(dataset))
+    result = decl.to_table()
+    assert result.schema.names == [
+        "a", "b", "__fragment_index", "__batch_index",
+        "__last_in_fragment", "__filename"
+    ]
+    assert result.select(["a", "b"]).equals(table)
+
+    # using a filter only does pushdown (depending on file format), not actual filter
+
+    scan_opts = ScanNodeOptions(dataset, filter=field('a') > 1)
+    decl = Declaration("scan", scan_opts)
+    # fragment not filtered based on min/max statistics
+    assert decl.to_table().num_rows == 3
+
+    scan_opts = ScanNodeOptions(dataset, filter=field('a') > 4)
+    decl = Declaration("scan", scan_opts)
+    # full fragment filtered based on min/max statistics
+    assert decl.to_table().num_rows == 0
+
+    # projection scan option
+
+    scan_opts = ScanNodeOptions(dataset, columns={"a2": pc.multiply(field("a"), 2)})
+    decl = Declaration("scan", scan_opts)
+    result = decl.to_table()
+    # "a" is included in the result (needed later on for the actual projection)
+    assert result["a"].to_pylist() == [1, 2, 3]
+    # "b" is still included, but without data as it will be removed by the projection
+    assert pc.all(result["b"].is_null()).as_py()


### PR DESCRIPTION
Continuing GH-34102, this adds the exec node options classes defined in the dataset module (scan, not yet write).

* Issue: #33976