### PR TITLE
GH-34540: [C++] Removed set but unused variable

### DIFF
--- a/cpp/tools/parquet/parquet_scan.cc
+++ b/cpp/tools/parquet/parquet_scan.cc
@@ -36,7 +36,6 @@ int main(int argc, char** argv) {
   const std::string COLUMNS_PREFIX = "--columns=";
   const std::string BATCH_SIZE_PREFIX = "--batch-size=";
   std::vector<int> columns;
-  int num_columns = 0;
 
   char *param, *value;
   for (int i = 1; i < argc; i++) {
@@ -45,7 +44,6 @@ int main(int argc, char** argv) {
       while (value) {
         columns.push_back(std::atoi(value));
         value = std::strtok(nullptr, ",");
-        num_columns++;
       }
     } else if ((param = std::strstr(argv[i], BATCH_SIZE_PREFIX.c_str()))) {
       value = std::strtok(param + BATCH_SIZE_PREFIX.length(), " ");


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

The variable has been left from https://github.com/apache/arrow/commit/144699c4210ac0b75d16395a583671b2874acc9e, simply removed this variable from the code.

It breaks builds when `-Werror` option is used.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->


<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

It was successfully built.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

* Closes: #34540