### PR TITLE
GH-34547: [C++][ORC] Remove deprecated ORC_UNIQUE_PTR

### DIFF
--- a/cpp/src/arrow/adapters/orc/adapter.cc
+++ b/cpp/src/arrow/adapters/orc/adapter.cc
@@ -781,7 +781,7 @@ class ORCFileWriter::Impl {
   std::unique_ptr<liborc::OutputStream> out_stream_;
   std::shared_ptr<Schema> arrow_schema_;
   WriteOptions write_options_;
-  ORC_UNIQUE_PTR<liborc::Type> orc_schema_;
+  std::unique_ptr<liborc::Type> orc_schema_;
 };
 
 ORCFileWriter::~ORCFileWriter() {}

--- a/cpp/src/arrow/adapters/orc/adapter_test.cc
+++ b/cpp/src/arrow/adapters/orc/adapter_test.cc
@@ -341,7 +341,7 @@ std::unique_ptr<liborc::Writer> CreateWriter(uint64_t stripe_size,
 
 TEST(TestAdapterRead, ReadIntAndStringFileMultipleStripes) {
   MemoryOutputStream mem_stream(kDefaultMemStreamSize);
-  ORC_UNIQUE_PTR<liborc::Type> type(
+  std::unique_ptr<liborc::Type> type(
       liborc::Type::buildTypeFromString("struct<col1:int,col2:string>"));
 
   constexpr uint64_t stripe_size = 1024;  // 1K

--- a/cpp/src/arrow/adapters/orc/util.cc
+++ b/cpp/src/arrow/adapters/orc/util.cc
@@ -34,7 +34,6 @@
 #include "arrow/util/string.h"
 #include "arrow/visit_data_inline.h"
 
-#include "orc/Exceptions.hh"
 #include "orc/MemoryPool.hh"
 #include "orc/OrcFile.hh"
 
@@ -966,10 +965,9 @@ Status WriteBatch(const Array& array, int64_t orc_offset,
                                     array.type()->ToString());
     }
   }
-  return Status::OK();
 }
 
-Result<ORC_UNIQUE_PTR<liborc::Type>> GetOrcType(const DataType& type) {
+Result<std::unique_ptr<liborc::Type>> GetOrcType(const DataType& type) {
   Type::type kind = type.id();
   switch (kind) {
     case Type::type::BOOL:
@@ -1015,7 +1013,7 @@ Result<ORC_UNIQUE_PTR<liborc::Type>> GetOrcType(const DataType& type) {
       return liborc::createListType(std::move(orc_subtype));
     }
     case Type::type::STRUCT: {
-      ORC_UNIQUE_PTR<liborc::Type> out_type = liborc::createStructType();
+      std::unique_ptr<liborc::Type> out_type = liborc::createStructType();
       std::vector<std::shared_ptr<Field>> arrow_fields =
           checked_cast<const StructType&>(type).fields();
       for (auto it = arrow_fields.begin(); it != arrow_fields.end(); ++it) {
@@ -1037,7 +1035,7 @@ Result<ORC_UNIQUE_PTR<liborc::Type>> GetOrcType(const DataType& type) {
     }
     case Type::type::DENSE_UNION:
     case Type::type::SPARSE_UNION: {
-      ORC_UNIQUE_PTR<liborc::Type> out_type = liborc::createUnionType();
+      std::unique_ptr<liborc::Type> out_type = liborc::createUnionType();
       std::vector<std::shared_ptr<Field>> arrow_fields =
           checked_cast<const UnionType&>(type).fields();
       for (const auto& arrow_field : arrow_fields) {
@@ -1167,9 +1165,9 @@ Result<std::shared_ptr<DataType>> GetArrowType(const liborc::Type* type) {
   }
 }
 
-Result<ORC_UNIQUE_PTR<liborc::Type>> GetOrcType(const Schema& schema) {
+Result<std::unique_ptr<liborc::Type>> GetOrcType(const Schema& schema) {
   int numFields = schema.num_fields();
-  ORC_UNIQUE_PTR<liborc::Type> out_type = liborc::createStructType();
+  std::unique_ptr<liborc::Type> out_type = liborc::createStructType();
   for (int i = 0; i < numFields; i++) {
     const auto& field = schema.field(i);
     ARROW_ASSIGN_OR_RAISE(auto orc_subtype, GetOrcType(*field->type()));

--- a/cpp/src/arrow/adapters/orc/util.h
+++ b/cpp/src/arrow/adapters/orc/util.h
@@ -33,7 +33,7 @@ namespace orc {
 
 Result<std::shared_ptr<DataType>> GetArrowType(const liborc::Type* type);
 
-Result<ORC_UNIQUE_PTR<liborc::Type>> GetOrcType(const Schema& schema);
+Result<std::unique_ptr<liborc::Type>> GetOrcType(const Schema& schema);
 
 ARROW_EXPORT Status AppendBatch(const liborc::Type* type,
                                 liborc::ColumnVectorBatch* batch, int64_t offset,


### PR DESCRIPTION
### Rationale for this change

`ORC_UNIQUE_PTR` is used to wrap `std::auto_ptr` and `std::unique_ptr` before wide adoption of C++11 in the Apache ORC C++ library. Now the library has adopted C++17 already and this macro has been deprecated.

### What changes are included in this PR?

Replace `ORC_UNIQUE_PTR` with `std::unique_ptr`.

### Are these changes tested?

Make sure all tests pass.

### Are there any user-facing changes?

No.
* Closes: #34547