### PR TITLE
GH-34556: [C++] Add prefix 'ACT_' for 'arrow::Compression::type' to avoid naming conflicts

### DIFF
--- a/c_glib/arrow-glib/codec.cpp
+++ b/c_glib/arrow-glib/codec.cpp
@@ -200,21 +200,21 @@ GArrowCompressionType
 garrow_compression_type_from_raw(arrow::Compression::type arrow_type)
 {
   switch (arrow_type) {
-  case arrow::Compression::type::UNCOMPRESSED:
+  case arrow::Compression::type::ACT_UNCOMPRESSED:
     return GARROW_COMPRESSION_TYPE_UNCOMPRESSED;
-  case arrow::Compression::type::SNAPPY:
+  case arrow::Compression::type::ACT_SNAPPY:
     return GARROW_COMPRESSION_TYPE_SNAPPY;
-  case arrow::Compression::type::GZIP:
+  case arrow::Compression::type::ACT_GZIP:
     return GARROW_COMPRESSION_TYPE_GZIP;
-  case arrow::Compression::type::BROTLI:
+  case arrow::Compression::type::ACT_BROTLI:
     return GARROW_COMPRESSION_TYPE_BROTLI;
-  case arrow::Compression::type::ZSTD:
+  case arrow::Compression::type::ACT_ZSTD:
     return GARROW_COMPRESSION_TYPE_ZSTD;
-  case arrow::Compression::type::LZ4:
+  case arrow::Compression::type::ACT_LZ4:
     return GARROW_COMPRESSION_TYPE_LZ4;
-  case arrow::Compression::type::LZO:
+  case arrow::Compression::type::ACT_LZO:
     return GARROW_COMPRESSION_TYPE_LZO;
-  case arrow::Compression::type::BZ2:
+  case arrow::Compression::type::ACT_BZ2:
     return GARROW_COMPRESSION_TYPE_BZ2;
   default:
     return GARROW_COMPRESSION_TYPE_UNCOMPRESSED;
@@ -226,23 +226,23 @@ garrow_compression_type_to_raw(GArrowCompressionType type)
 {
   switch (type) {
   case GARROW_COMPRESSION_TYPE_UNCOMPRESSED:
-    return arrow::Compression::type::UNCOMPRESSED;
+    return arrow::Compression::type::ACT_UNCOMPRESSED;
   case GARROW_COMPRESSION_TYPE_SNAPPY:
-    return arrow::Compression::type::SNAPPY;
+    return arrow::Compression::type::ACT_SNAPPY;
   case GARROW_COMPRESSION_TYPE_GZIP:
-    return arrow::Compression::type::GZIP;
+    return arrow::Compression::type::ACT_GZIP;
   case GARROW_COMPRESSION_TYPE_BROTLI:
-    return arrow::Compression::type::BROTLI;
+    return arrow::Compression::type::ACT_BROTLI;
   case GARROW_COMPRESSION_TYPE_ZSTD:
-    return arrow::Compression::type::ZSTD;
+    return arrow::Compression::type::ACT_ZSTD;
   case GARROW_COMPRESSION_TYPE_LZ4:
-    return arrow::Compression::type::LZ4;
+    return arrow::Compression::type::ACT_LZ4;
   case GARROW_COMPRESSION_TYPE_LZO:
-    return arrow::Compression::type::LZO;
+    return arrow::Compression::type::ACT_LZO;
   case GARROW_COMPRESSION_TYPE_BZ2:
-    return arrow::Compression::type::BZ2;
+    return arrow::Compression::type::ACT_BZ2;
   default:
-    return arrow::Compression::type::UNCOMPRESSED;
+    return arrow::Compression::type::ACT_UNCOMPRESSED;
   }
 }
 

--- a/cpp/src/arrow/ipc/feather.cc
+++ b/cpp/src/arrow/ipc/feather.cc
@@ -798,9 +798,9 @@ Result<std::shared_ptr<Reader>> Reader::Open(
 WriteProperties WriteProperties::Defaults() {
   WriteProperties result;
 #ifdef ARROW_WITH_LZ4
-  result.compression = Compression::LZ4_FRAME;
+  result.compression = Compression::ACT_LZ4_FRAME;
 #else
-  result.compression = Compression::UNCOMPRESSED;
+  result.compression = Compression::ACT_UNCOMPRESSED;
 #endif
   return result;
 }

--- a/cpp/src/arrow/ipc/feather.h
+++ b/cpp/src/arrow/ipc/feather.h
@@ -135,7 +135,7 @@ struct ARROW_EXPORT WriteProperties {
   /// WriteProperties::Defaults() is not used, the default constructor for
   /// WriteProperties will work regardless of the options used to build the C++
   /// project.
-  Compression::type compression = Compression::UNCOMPRESSED;
+  Compression::type compression = Compression::ACT_UNCOMPRESSED;
 
   /// Compressor-specific compression level
   int compression_level = ::arrow::util::kUseDefaultCompressionLevel;

--- a/cpp/src/arrow/ipc/metadata_internal.cc
+++ b/cpp/src/arrow/ipc/metadata_internal.cc
@@ -936,9 +936,9 @@ static Status GetBodyCompression(FBB& fbb, const IpcWriteOptions& options,
                                  BodyCompressionOffset* out) {
   if (options.codec != nullptr) {
     flatbuf::CompressionType codec;
-    if (options.codec->compression_type() == Compression::LZ4_FRAME) {
+    if (options.codec->compression_type() == Compression::ACT_LZ4_FRAME) {
       codec = flatbuf::CompressionType::LZ4_FRAME;
-    } else if (options.codec->compression_type() == Compression::ZSTD) {
+    } else if (options.codec->compression_type() == Compression::ACT_ZSTD) {
       codec = flatbuf::CompressionType::ZSTD;
     } else {
       return Status::Invalid("Unsupported IPC compression codec: ",

--- a/cpp/src/arrow/ipc/options.cc
+++ b/cpp/src/arrow/ipc/options.cc
@@ -29,7 +29,7 @@ IpcReadOptions IpcReadOptions::Defaults() { return IpcReadOptions(); }
 namespace internal {
 
 Status CheckCompressionSupported(Compression::type codec) {
-  if (!(codec == Compression::LZ4_FRAME || codec == Compression::ZSTD)) {
+  if (!(codec == Compression::ACT_LZ4_FRAME || codec == Compression::ACT_ZSTD)) {
     return Status::Invalid("Only LZ4_FRAME and ZSTD compression allowed");
   }
   return Status::OK();

--- a/cpp/src/arrow/util/compression.cc
+++ b/cpp/src/arrow/util/compression.cc
@@ -52,25 +52,25 @@ const std::string& Codec::GetCodecAsString(Compression::type t) {
                            zstd = "zstd", bz2 = "bz2", unknown = "unknown";
 
   switch (t) {
-    case Compression::UNCOMPRESSED:
+    case Compression::ACT_UNCOMPRESSED:
       return uncompressed;
-    case Compression::SNAPPY:
+    case Compression::ACT_SNAPPY:
       return snappy;
-    case Compression::GZIP:
+    case Compression::ACT_GZIP:
       return gzip;
-    case Compression::LZO:
+    case Compression::ACT_LZO:
       return lzo;
-    case Compression::BROTLI:
+    case Compression::ACT_BROTLI:
       return brotli;
-    case Compression::LZ4:
+    case Compression::ACT_LZ4:
       return lz4_raw;
-    case Compression::LZ4_FRAME:
+    case Compression::ACT_LZ4_FRAME:
       return lz4;
-    case Compression::LZ4_HADOOP:
+    case Compression::ACT_LZ4_HADOOP:
       return lz4_hadoop;
-    case Compression::ZSTD:
+    case Compression::ACT_ZSTD:
       return zstd;
-    case Compression::BZ2:
+    case Compression::ACT_BZ2:
       return bz2;
     default:
       return unknown;
@@ -79,25 +79,25 @@ const std::string& Codec::GetCodecAsString(Compression::type t) {
 
 Result<Compression::type> Codec::GetCompressionType(const std::string& name) {
   if (name == "uncompressed") {
-    return Compression::UNCOMPRESSED;
+    return Compression::ACT_UNCOMPRESSED;
   } else if (name == "gzip") {
-    return Compression::GZIP;
+    return Compression::ACT_GZIP;
   } else if (name == "snappy") {
-    return Compression::SNAPPY;
+    return Compression::ACT_SNAPPY;
   } else if (name == "lzo") {
-    return Compression::LZO;
+    return Compression::ACT_LZO;
   } else if (name == "brotli") {
-    return Compression::BROTLI;
+    return Compression::ACT_BROTLI;
   } else if (name == "lz4_raw") {
-    return Compression::LZ4;
+    return Compression::ACT_LZ4;
   } else if (name == "lz4") {
-    return Compression::LZ4_FRAME;
+    return Compression::ACT_LZ4_FRAME;
   } else if (name == "lz4_hadoop") {
-    return Compression::LZ4_HADOOP;
+    return Compression::ACT_LZ4_HADOOP;
   } else if (name == "zstd") {
-    return Compression::ZSTD;
+    return Compression::ACT_ZSTD;
   } else if (name == "bz2") {
-    return Compression::BZ2;
+    return Compression::ACT_BZ2;
   } else {
     return Status::Invalid("Unrecognized compression type: ", name);
   }
@@ -105,12 +105,12 @@ Result<Compression::type> Codec::GetCompressionType(const std::string& name) {
 
 bool Codec::SupportsCompressionLevel(Compression::type codec) {
   switch (codec) {
-    case Compression::GZIP:
-    case Compression::BROTLI:
-    case Compression::ZSTD:
-    case Compression::BZ2:
-    case Compression::LZ4_FRAME:
-    case Compression::LZ4:
+    case Compression::ACT_GZIP:
+    case Compression::ACT_BROTLI:
+    case Compression::ACT_ZSTD:
+    case Compression::ACT_BZ2:
+    case Compression::ACT_LZ4_FRAME:
+    case Compression::ACT_LZ4:
       return true;
     default:
       return false;
@@ -138,7 +138,7 @@ Result<int> Codec::DefaultCompressionLevel(Compression::type codec_type) {
 Result<std::unique_ptr<Codec>> Codec::Create(Compression::type codec_type,
                                              int compression_level) {
   if (!IsAvailable(codec_type)) {
-    if (codec_type == Compression::LZO) {
+    if (codec_type == Compression::ACT_LZO) {
       return Status::NotImplemented("LZO codec not implemented");
     }
 
@@ -159,44 +159,44 @@ Result<std::unique_ptr<Codec>> Codec::Create(Compression::type codec_type,
 
   std::unique_ptr<Codec> codec;
   switch (codec_type) {
-    case Compression::UNCOMPRESSED:
+    case Compression::ACT_UNCOMPRESSED:
       return nullptr;
-    case Compression::SNAPPY:
+    case Compression::ACT_SNAPPY:
 #ifdef ARROW_WITH_SNAPPY
       codec = internal::MakeSnappyCodec();
 #endif
       break;
-    case Compression::GZIP:
+    case Compression::ACT_GZIP:
 #ifdef ARROW_WITH_ZLIB
       codec = internal::MakeGZipCodec(compression_level);
 #endif
       break;
-    case Compression::BROTLI:
+    case Compression::ACT_BROTLI:
 #ifdef ARROW_WITH_BROTLI
       codec = internal::MakeBrotliCodec(compression_level);
 #endif
       break;
-    case Compression::LZ4:
+    case Compression::ACT_LZ4:
 #ifdef ARROW_WITH_LZ4
       codec = internal::MakeLz4RawCodec(compression_level);
 #endif
       break;
-    case Compression::LZ4_FRAME:
+    case Compression::ACT_LZ4_FRAME:
 #ifdef ARROW_WITH_LZ4
       codec = internal::MakeLz4FrameCodec(compression_level);
 #endif
       break;
-    case Compression::LZ4_HADOOP:
+    case Compression::ACT_LZ4_HADOOP:
 #ifdef ARROW_WITH_LZ4
       codec = internal::MakeLz4HadoopRawCodec();
 #endif
       break;
-    case Compression::ZSTD:
+    case Compression::ACT_ZSTD:
 #ifdef ARROW_WITH_ZSTD
       codec = internal::MakeZSTDCodec(compression_level);
 #endif
       break;
-    case Compression::BZ2:
+    case Compression::ACT_BZ2:
 #ifdef ARROW_WITH_BZ2
       codec = internal::MakeBZ2Codec(compression_level);
 #endif
@@ -212,43 +212,43 @@ Result<std::unique_ptr<Codec>> Codec::Create(Compression::type codec_type,
 
 bool Codec::IsAvailable(Compression::type codec_type) {
   switch (codec_type) {
-    case Compression::UNCOMPRESSED:
+    case Compression::ACT_UNCOMPRESSED:
       return true;
-    case Compression::SNAPPY:
+    case Compression::ACT_SNAPPY:
 #ifdef ARROW_WITH_SNAPPY
       return true;
 #else
       return false;
 #endif
-    case Compression::GZIP:
+    case Compression::ACT_GZIP:
 #ifdef ARROW_WITH_ZLIB
       return true;
 #else
       return false;
 #endif
-    case Compression::LZO:
+    case Compression::ACT_LZO:
       return false;
-    case Compression::BROTLI:
+    case Compression::ACT_BROTLI:
 #ifdef ARROW_WITH_BROTLI
       return true;
 #else
       return false;
 #endif
-    case Compression::LZ4:
-    case Compression::LZ4_FRAME:
-    case Compression::LZ4_HADOOP:
+    case Compression::ACT_LZ4:
+    case Compression::ACT_LZ4_FRAME:
+    case Compression::ACT_LZ4_HADOOP:
 #ifdef ARROW_WITH_LZ4
       return true;
 #else
       return false;
 #endif
-    case Compression::ZSTD:
+    case Compression::ACT_ZSTD:
 #ifdef ARROW_WITH_ZSTD
       return true;
 #else
       return false;
 #endif
-    case Compression::BZ2:
+    case Compression::ACT_BZ2:
 #ifdef ARROW_WITH_BZ2
       return true;
 #else

--- a/cpp/src/arrow/util/compression_snappy.cc
+++ b/cpp/src/arrow/util/compression_snappy.cc
@@ -85,7 +85,7 @@ class SnappyCodec : public Codec {
     return Status::NotImplemented("Streaming decompression unsupported with Snappy");
   }
 
-  Compression::type compression_type() const override { return Compression::SNAPPY; }
+  Compression::type compression_type() const override { return Compression::ACT_SNAPPY; }
   int minimum_compression_level() const override { return kUseDefaultCompressionLevel; }
   int maximum_compression_level() const override { return kUseDefaultCompressionLevel; }
   int default_compression_level() const override { return kUseDefaultCompressionLevel; }

--- a/cpp/src/arrow/util/compression_zlib.cc
+++ b/cpp/src/arrow/util/compression_zlib.cc
@@ -468,7 +468,7 @@ class GZipCodec : public Codec {
     return InitDecompressor();
   }
 
-  Compression::type compression_type() const override { return Compression::GZIP; }
+  Compression::type compression_type() const override { return Compression::ACT_GZIP; }
 
   int compression_level() const override { return compression_level_; }
   int minimum_compression_level() const override { return kGZipMinCompressionLevel; }

--- a/cpp/src/arrow/util/type_fwd.h
+++ b/cpp/src/arrow/util/type_fwd.h
@@ -45,17 +45,18 @@ struct Scope;
 
 struct Compression {
   /// \brief Compression algorithm
+  //   prefix 'ACT'(arrow compression type) to avoid nameing conflicts.
   enum type {
-    UNCOMPRESSED,
-    SNAPPY,
-    GZIP,
-    BROTLI,
-    ZSTD,
-    LZ4,
-    LZ4_FRAME,
-    LZO,
-    BZ2,
-    LZ4_HADOOP
+    ACT_UNCOMPRESSED,
+    ACT_SNAPPY,
+    ACT_GZIP,
+    ACT_BROTLI,
+    ACT_ZSTD,
+    ACT_LZ4,
+    ACT_LZ4_FRAME,
+    ACT_LZO,
+    ACT_BZ2,
+    ACT_LZ4_HADOOP
   };
 };
 

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -137,7 +137,7 @@ static constexpr bool DEFAULT_ARE_STATISTICS_ENABLED = true;
 static constexpr int64_t DEFAULT_MAX_STATISTICS_SIZE = 4096;
 static constexpr Encoding::type DEFAULT_ENCODING = Encoding::PLAIN;
 static const char DEFAULT_CREATED_BY[] = CREATED_BY_VERSION;
-static constexpr Compression::type DEFAULT_COMPRESSION_TYPE = Compression::UNCOMPRESSED;
+static constexpr Compression::type DEFAULT_COMPRESSION_TYPE = Compression::ACT_UNCOMPRESSED;
 
 class PARQUET_EXPORT ColumnProperties {
  public:

--- a/cpp/src/parquet/thrift_internal.h
+++ b/cpp/src/parquet/thrift_internal.h
@@ -79,24 +79,24 @@ static inline PageType::type FromThriftUnsafe(format::PageType::type type) {
 static inline Compression::type FromThriftUnsafe(format::CompressionCodec::type type) {
   switch (type) {
     case format::CompressionCodec::UNCOMPRESSED:
-      return Compression::UNCOMPRESSED;
+      return Compression::ACT_UNCOMPRESSED;
     case format::CompressionCodec::SNAPPY:
-      return Compression::SNAPPY;
+      return Compression::ACT_SNAPPY;
     case format::CompressionCodec::GZIP:
-      return Compression::GZIP;
+      return Compression::ACT_GZIP;
     case format::CompressionCodec::LZO:
-      return Compression::LZO;
+      return Compression::ACT_LZO;
     case format::CompressionCodec::BROTLI:
-      return Compression::BROTLI;
+      return Compression::ACT_BROTLI;
     case format::CompressionCodec::LZ4:
-      return Compression::LZ4_HADOOP;
+      return Compression::ACT_LZ4_HADOOP;
     case format::CompressionCodec::LZ4_RAW:
-      return Compression::LZ4;
+      return Compression::ACT_LZ4;
     case format::CompressionCodec::ZSTD:
-      return Compression::ZSTD;
+      return Compression::ACT_ZSTD;
     default:
       DCHECK(false) << "Cannot reach here";
-      return Compression::UNCOMPRESSED;
+      return Compression::ACT_UNCOMPRESSED;
   }
 }
 
@@ -214,7 +214,7 @@ inline typename Compression::type LoadEnumSafe(const format::CompressionCodec::t
   const auto max_value =
       static_cast<decltype(raw_value)>(format::CompressionCodec::LZ4_RAW);
   if (raw_value < min_value || raw_value > max_value) {
-    return Compression::UNCOMPRESSED;
+    return Compression::ACT_UNCOMPRESSED;
   }
   return FromThriftUnsafe(*in);
 }
@@ -272,22 +272,22 @@ static inline format::Encoding::type ToThrift(Encoding::type type) {
 
 static inline format::CompressionCodec::type ToThrift(Compression::type type) {
   switch (type) {
-    case Compression::UNCOMPRESSED:
+    case Compression::ACT_UNCOMPRESSED:
       return format::CompressionCodec::UNCOMPRESSED;
-    case Compression::SNAPPY:
+    case Compression::ACT_SNAPPY:
       return format::CompressionCodec::SNAPPY;
-    case Compression::GZIP:
+    case Compression::ACT_GZIP:
       return format::CompressionCodec::GZIP;
-    case Compression::LZO:
+    case Compression::ACT_LZO:
       return format::CompressionCodec::LZO;
-    case Compression::BROTLI:
+    case Compression::ACT_BROTLI:
       return format::CompressionCodec::BROTLI;
-    case Compression::LZ4:
+    case Compression::ACT_LZ4:
       return format::CompressionCodec::LZ4_RAW;
-    case Compression::LZ4_HADOOP:
+    case Compression::ACT_LZ4_HADOOP:
       // Deprecated "LZ4" Parquet compression has Hadoop-specific framing
       return format::CompressionCodec::LZ4;
-    case Compression::ZSTD:
+    case Compression::ACT_ZSTD:
       return format::CompressionCodec::ZSTD;
     default:
       DCHECK(false) << "Cannot reach here";

--- a/cpp/src/parquet/types.cc
+++ b/cpp/src/parquet/types.cc
@@ -37,13 +37,13 @@ namespace parquet {
 
 bool IsCodecSupported(Compression::type codec) {
   switch (codec) {
-    case Compression::UNCOMPRESSED:
-    case Compression::SNAPPY:
-    case Compression::GZIP:
-    case Compression::BROTLI:
-    case Compression::ZSTD:
-    case Compression::LZ4:
-    case Compression::LZ4_HADOOP:
+    case Compression::ACT_UNCOMPRESSED:
+    case Compression::ACT_SNAPPY:
+    case Compression::ACT_GZIP:
+    case Compression::ACT_BROTLI:
+    case Compression::ACT_ZSTD:
+    case Compression::ACT_LZ4:
+    case Compression::ACT_LZ4_HADOOP:
       return true;
     default:
       return false;
@@ -56,7 +56,7 @@ std::unique_ptr<Codec> GetCodec(Compression::type codec) {
 
 std::unique_ptr<Codec> GetCodec(Compression::type codec, int compression_level) {
   std::unique_ptr<Codec> result;
-  if (codec == Compression::LZO) {
+  if (codec == Compression::ACT_LZO) {
     throw ParquetException(
         "While LZO compression is supported by the Parquet format in "
         "general, it is currently not supported by the C++ implementation.");


### PR DESCRIPTION
Because compression name is very easy to conflicts when using arrow library in others project.
* Closes: #34556