### PR TITLE
GH-34381: [Dev] Retrieve committers from arrow-site committers.yml instead of relying on author_association

### DIFF
--- a/.github/workflows/pr_bot.yml
+++ b/.github/workflows/pr_bot.yml
@@ -66,6 +66,12 @@ jobs:
         run: |
           unzip pr_review.zip
           echo "pr_review_path=$(pwd)/event.json" >> $GITHUB_OUTPUT
+      - name: Download committers file
+        id: committers
+        run: |
+          url="https://raw.githubusercontent.com/apache/arrow-site/main/_data/committers.yml"
+          curl -sL -o committers.yml $url
+          echo "committers_path=$(pwd)/committers.yml" >> $GITHUB_OUTPUT
       - name: Checkout Arrow
         uses: actions/checkout@v3
         with:
@@ -90,8 +96,10 @@ jobs:
             archery trigger-bot \
               --event-name "pull_request_review" \
               --event-payload "${{ steps.extract.outputs.pr_review_path }}"
+              --committers "${{ steps.committers.outputs.committers_path }}"
           else
             archery trigger-bot \
               --event-name "${{ github.event_name }}" \
               --event-payload "${{ github.event_path }}"
+              --committers "${{ steps.committers.outputs.committers_path }}"
           fi

--- a/.github/workflows/pr_bot.yml
+++ b/.github/workflows/pr_bot.yml
@@ -95,11 +95,11 @@ jobs:
             # workflow_run is executed on PR review. Update to original event.
             archery trigger-bot \
               --event-name "pull_request_review" \
-              --event-payload "${{ steps.extract.outputs.pr_review_path }}"
+              --event-payload "${{ steps.extract.outputs.pr_review_path }}" \
               --committers "${{ steps.committers.outputs.committers_path }}"
           else
             archery trigger-bot \
               --event-name "${{ github.event_name }}" \
-              --event-payload "${{ github.event_path }}"
+              --event-payload "${{ github.event_path }}" \
               --committers "${{ steps.committers.outputs.committers_path }}"
           fi

--- a/.github/workflows/pr_bot.yml
+++ b/.github/workflows/pr_bot.yml
@@ -96,10 +96,10 @@ jobs:
             archery trigger-bot \
               --event-name "pull_request_review" \
               --event-payload "${{ steps.extract.outputs.pr_review_path }}" \
-              --committers "${{ steps.committers.outputs.committers_path }}"
+              --committers-file "${{ steps.committers.outputs.committers_path }}"
           else
             archery trigger-bot \
               --event-name "${{ github.event_name }}" \
               --event-payload "${{ github.event_path }}" \
-              --committers "${{ steps.committers.outputs.committers_path }}"
+              --committers-file "${{ steps.committers.outputs.committers_path }}"
           fi

--- a/dev/archery/archery/bot.py
+++ b/dev/archery/archery/bot.py
@@ -106,10 +106,11 @@ COMMITTER_ROLES = {'OWNER', 'MEMBER'}
 
 class PullRequestWorkflowBot:
 
-    def __init__(self, event_name, event_payload, token=None):
+    def __init__(self, event_name, event_payload, token=None, committers=None):
         self.github = github.Github(token)
         self.event_name = event_name
         self.event_payload = event_payload
+        self.committers = committers
 
     @cached_property
     def pull(self):
@@ -121,6 +122,18 @@ class PullRequestWorkflowBot:
     @cached_property
     def repo(self):
         return self.github.get_repo(self.event_payload['repository']['id'], lazy=True)
+
+    def is_committer(self, action):
+        """
+        Returns whether the author of the action is a committer or not.
+        If the list of committer usernames is not available it will use the
+        author_association as a fallback mechanism.
+        """
+        if self.committers:
+            return (self.event_payload[action]['user']['login'] in
+                    self.committers)
+        return (self.event_payload[action]['author_association'] in
+                COMMITTER_ROLES)
 
     def handle(self):
         current_state = None
@@ -165,17 +178,14 @@ class PullRequestWorkflowBot:
         """
         if (self.event_name == "pull_request_target" and
                 self.event_payload['action'] == 'opened'):
-            if (self.event_payload['pull_request']['author_association'] in
-                    COMMITTER_ROLES):
+            if self.is_committer('pull_request'):
                 return PullRequestState.committer_review
             else:
                 return PullRequestState.review
         elif (self.event_name == "pull_request_review" and
                 self.event_payload["action"] == "submitted"):
             review_state = self.event_payload["review"]["state"].lower()
-            is_committer_review = (self.event_payload['review']['author_association']
-                                   in COMMITTER_ROLES)
-            if not is_committer_review:
+            if not self.is_committer('review'):
                 # Non-committer reviews cannot change state once committer has already
                 # reviewed, requested changes or approved
                 if current_state in (

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -777,11 +777,11 @@ def integration(with_all=False, random_seed=12345, **args):
 @archery.command()
 @click.option('--arrow-token', envvar='ARROW_GITHUB_TOKEN',
               help='OAuth token for responding comment in the arrow repo')
-@click.option('--committers', '-c', type=click.File('r', encoding='utf8'))
+@click.option('--committers-file', '-c', type=click.File('r', encoding='utf8'))
 @click.option('--event-name', '-n', required=True)
 @click.option('--event-payload', '-p', type=click.File('r', encoding='utf8'),
               default='-', required=True)
-def trigger_bot(arrow_token, committers_path, event_name, event_payload):
+def trigger_bot(arrow_token, committers_file, event_name, event_payload):
     from .bot import CommentBot, PullRequestWorkflowBot, actions
     from ruamel.yaml import YAML
 
@@ -791,9 +791,9 @@ def trigger_bot(arrow_token, committers_path, event_name, event_payload):
         bot.handle(event_name, event_payload)
     else:
         committers = None
-        if committers_path:
-            with pathlib.Path(committers_path).open() as fp:
-                committers = [committer['alias'] for committer in YAML().load(fp)]
+        if committers_file:
+            committers = [committer['alias']
+                          for committer in YAML().load(committers_file)]
         bot = PullRequestWorkflowBot(event_name, event_payload, token=arrow_token,
                                      committers=committers)
         bot.handle()

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -24,6 +24,8 @@ import os
 import pathlib
 import sys
 
+from ruamel.yaml import YAML
+
 from .benchmark.codec import JsonEncoder
 from .benchmark.compare import RunnerComparator, DEFAULT_THRESHOLD
 from .benchmark.runner import CppBenchmarkRunner, JavaBenchmarkRunner
@@ -775,12 +777,13 @@ def integration(with_all=False, random_seed=12345, **args):
 
 
 @archery.command()
+@click.option('--arrow-token', envvar='ARROW_GITHUB_TOKEN',
+              help='OAuth token for responding comment in the arrow repo')
+@click.option('--committers', '-c', type=click.File('r', encoding='utf8'))
 @click.option('--event-name', '-n', required=True)
 @click.option('--event-payload', '-p', type=click.File('r', encoding='utf8'),
               default='-', required=True)
-@click.option('--arrow-token', envvar='ARROW_GITHUB_TOKEN',
-              help='OAuth token for responding comment in the arrow repo')
-def trigger_bot(event_name, event_payload, arrow_token):
+def trigger_bot(arrow_token, committers_path, event_name, event_payload):
     from .bot import CommentBot, PullRequestWorkflowBot, actions
 
     event_payload = json.loads(event_payload.read())
@@ -788,7 +791,12 @@ def trigger_bot(event_name, event_payload, arrow_token):
         bot = CommentBot(name='github-actions', handler=actions, token=arrow_token)
         bot.handle(event_name, event_payload)
     else:
-        bot = PullRequestWorkflowBot(event_name, event_payload, token=arrow_token)
+        committers = None
+        if committers_path:
+            with pathlib.Path(committers_path).open() as fp:
+                committers = [committer['alias'] for committer in YAML().load(fp)]
+        bot = PullRequestWorkflowBot(event_name, event_payload, token=arrow_token,
+                                     committers=committers)
         bot.handle()
 
 

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -24,8 +24,6 @@ import os
 import pathlib
 import sys
 
-from ruamel.yaml import YAML
-
 from .benchmark.codec import JsonEncoder
 from .benchmark.compare import RunnerComparator, DEFAULT_THRESHOLD
 from .benchmark.runner import CppBenchmarkRunner, JavaBenchmarkRunner
@@ -785,6 +783,7 @@ def integration(with_all=False, random_seed=12345, **args):
               default='-', required=True)
 def trigger_bot(arrow_token, committers_path, event_name, event_payload):
     from .bot import CommentBot, PullRequestWorkflowBot, actions
+    from ruamel.yaml import YAML
 
     event_payload = json.loads(event_payload.read())
     if 'comment' in event_name:


### PR DESCRIPTION
### Rationale for this change

If a committer has their ASF role on GitHub as private the GitHub PR bot author_association is not correctly assigned.

### What changes are included in this PR?

 This change uses the committers list on the arrow_site repository to retrieve the list of committers.

### Are these changes tested?

There is a unit test and have tested the different steps of the workflow individually but haven't tested the full workflow.

### Are there any user-facing changes?

No
* Closes: #34381