### PR TITLE
GH-34165: [Python] Extension array data type should default to the storage type if to_pandas_dtype is not implemented

### DIFF
--- a/ci/conda_env_gandiva.txt
+++ b/ci/conda_env_gandiva.txt
@@ -16,4 +16,4 @@
 # under the License.
 
 clang>=11
-llvmdev>=11
+llvmdev>=11,<16

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1459,6 +1459,9 @@ cdef class Array(_PandasConvertible):
         supported for primitive arrays with the same memory layout as NumPy
         (i.e. integers, floating point, ..) and without any nulls.
 
+        For the extension arrays, this method simply delegates to the
+        underlying storage array.
+
         Parameters
         ----------
         zero_copy_only : bool, default True

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -3072,23 +3072,6 @@ cdef class ExtensionArray(Array):
         # otherwise convert the storage array with the base implementation
         return Array._to_pandas(self.storage, options, **kwargs)
 
-    def to_numpy(self, **kwargs):
-        """
-        Convert extension array to a numpy ndarray.
-
-        This method simply delegates to the underlying storage array.
-
-        Parameters
-        ----------
-        **kwargs : dict, optional
-            See `Array.to_numpy` for parameter description.
-
-        See Also
-        --------
-        Array.to_numpy
-        """
-        return self.storage.to_numpy(**kwargs)
-
 
 cdef dict _array_classes = {
     _Type_NA: NullArray,

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -480,13 +480,6 @@ cdef class ChunkedArray(_PandasConvertible):
             PandasOptions c_options
             object values
 
-        if self.type.id == _Type_EXTENSION:
-            storage_array = chunked_array(
-                [chunk.storage for chunk in self.iterchunks()],
-                type=self.type.storage_type
-            )
-            return storage_array.to_numpy()
-
         with nogil:
             check_status(
                 ConvertChunkedArrayToPandas(

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -458,6 +458,17 @@ cdef class ChunkedArray(_PandasConvertible):
         return result
 
     def _to_pandas(self, options, types_mapper=None, **kwargs):
+        pandas_dtype = None
+        try:
+            pandas_dtype = self.type.to_pandas_dtype()
+        except NotImplementedError:
+            pass
+
+        # pandas ExtensionDtype that implements conversion from pyarrow
+        if hasattr(pandas_dtype, '__from_arrow__'):
+            arr = pandas_dtype.__from_arrow__(self)
+            return pandas_api.series(arr)
+
         return _array_like_to_pandas(self, options, types_mapper=types_mapper)
 
     def to_numpy(self):

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1127,3 +1127,24 @@ def test_cpp_extension_in_python(tmpdir):
     reconstructed_array = batch.column(0)
     assert reconstructed_array.type == uuid_type
     assert reconstructed_array == array
+
+
+def test_extension_to_pandas_storage_type(registered_period_type):
+    period_type, _ = registered_period_type
+    storage = pa.array([1, 2, 3, 4], pa.int64())
+    arr = pa.ExtensionArray.from_storage(period_type, storage)
+    breakpoint()
+    arr.to_pandas()
+
+    data = [
+        pa.array([1, 2, 3, 4]),
+        pa.array(['foo', 'bar', None, None]),
+        pa.array([True, None, True, False]),
+        arr
+    ]
+    my_schema = pa.schema([('f0', pa.int8()),
+                           ('f1', pa.string()),
+                           ('f2', pa.bool_()),
+                           ('ext', period_type)])
+    table = pa.Table.from_arrays(data, schema=my_schema)
+    table.to_pandas()

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -740,7 +740,21 @@ class PeriodTypeWithClass(PeriodType):
         return PeriodTypeWithClass(freq)
 
 
-@pytest.fixture(params=[PeriodType('D'), PeriodTypeWithClass('D')])
+class PeriodTypeWithToPandasDtype(PeriodType):
+    @classmethod
+    def __arrow_ext_deserialize__(cls, storage_type, serialized):
+        freq = PeriodType.__arrow_ext_deserialize__(
+            storage_type, serialized).freq
+        return PeriodTypeWithToPandasDtype(freq)
+
+    def to_pandas_dtype(self):
+        import pandas as pd
+        return pd.PeriodDtype(freq=self.freq)
+
+
+@pytest.fixture(params=[PeriodType('D'),
+                        PeriodTypeWithClass('D'),
+                        PeriodTypeWithToPandasDtype('D')])
 def registered_period_type(request):
     # setup
     period_type = request.param
@@ -1131,25 +1145,41 @@ def test_cpp_extension_in_python(tmpdir):
 
 def test_extension_to_pandas_storage_type(registered_period_type):
     period_type, _ = registered_period_type
+    np_arr = np.array([1, 2, 3, 4])
     storage = pa.array([1, 2, 3, 4], pa.int64())
     arr = pa.ExtensionArray.from_storage(period_type, storage)
-    arr.to_pandas()
+
+    if isinstance(period_type, PeriodTypeWithToPandasDtype):
+        pandas_dtype = period_type.to_pandas_dtype()
+    else:
+        pandas_dtype = np_arr.dtype
+
+    # Test arrays
+    result = arr.to_pandas()
+    assert result.dtype == pandas_dtype
 
     # Test the change in ConvertChunkedArrayToPandas
     chunked_arr = pa.chunked_array([arr])
-    chunked_arr.to_numpy()
+    result = chunked_arr.to_numpy()
+    assert result.dtype == np_arr.dtype
+
+    result = chunked_arr.to_pandas()
+    # TODO: to_pandas should take use of to_pandas_dtype
+    # if defined!
+    # assert result.dtype == pandas_dtype
+    assert result.dtype == np_arr.dtype
 
     # Test the change in ConvertTableToPandas
-    # data = [
-    #     pa.array([1, 2, 3, 4]),
-    #     pa.array(['foo', 'bar', None, None]),
-    #     pa.array([True, None, True, False]),
-    #     arr
-    # ]
-    # my_schema = pa.schema([('f0', pa.int8()),
-    #                        ('f1', pa.string()),
-    #                        ('f2', pa.bool_()),
-    #                        ('ext', period_type)])
-    # table = pa.Table.from_arrays(data, schema=my_schema)
-
-    # table.to_pandas()
+    data = [
+        pa.array([1, 2, 3, 4]),
+        pa.array(['foo', 'bar', None, None]),
+        pa.array([True, None, True, False]),
+        arr
+    ]
+    my_schema = pa.schema([('f0', pa.int8()),
+                           ('f1', pa.string()),
+                           ('f2', pa.bool_()),
+                           ('ext', period_type)])
+    table = pa.Table.from_arrays(data, schema=my_schema)
+    result = table.to_pandas()
+    assert result["ext"].dtype == pandas_dtype

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -25,6 +25,7 @@ import sys
 
 import numpy as np
 import pyarrow as pa
+from pyarrow.vendored.version import Version
 
 import pytest
 
@@ -1182,7 +1183,10 @@ def test_extension_to_pandas_storage_type(registered_period_type):
     result = table.to_pandas()
     assert result["ext"].dtype == pandas_dtype
 
-    # Check the usage of types_mapper
     import pandas as pd
-    result = table.to_pandas(types_mapper=pd.ArrowDtype)
-    assert isinstance(result["ext"].dtype, pd.ArrowDtype)
+    if Version(pd.__version__) < Version("1.5.0"):
+        pytest.skip("ArrowDtype missing")
+
+        # Check the usage of types_mapper
+        result = table.to_pandas(types_mapper=pd.ArrowDtype)
+        assert isinstance(result["ext"].dtype, pd.ArrowDtype)

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1160,7 +1160,7 @@ def test_extension_to_pandas_storage_type(registered_period_type):
     result = arr.to_pandas()
     assert result.dtype == pandas_dtype
 
-    # Test the change in ConvertChunkedArrayToPandas
+    # Test chunked arrays
     chunked_arr = pa.chunked_array([arr])
     result = chunked_arr.to_numpy()
     assert result.dtype == np_arr.dtype
@@ -1168,7 +1168,7 @@ def test_extension_to_pandas_storage_type(registered_period_type):
     result = chunked_arr.to_pandas()
     assert result.dtype == pandas_dtype
 
-    # Test the change in ConvertTableToPandas
+    # Test Table.to_pandas
     data = [
         pa.array([1, 2, 3, 4]),
         pa.array(['foo', 'bar', None, None]),
@@ -1184,8 +1184,7 @@ def test_extension_to_pandas_storage_type(registered_period_type):
     assert result["ext"].dtype == pandas_dtype
 
     import pandas as pd
-    if Version(pd.__version__) < Version("1.5.0"):
-        pytest.skip("ArrowDtype missing")
+    if Version(pd.__version__) >= Version("2.0.0.dev0"):
 
         # Check the usage of types_mapper
         result = table.to_pandas(types_mapper=pd.ArrowDtype)

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1164,10 +1164,7 @@ def test_extension_to_pandas_storage_type(registered_period_type):
     assert result.dtype == np_arr.dtype
 
     result = chunked_arr.to_pandas()
-    # TODO: to_pandas should take use of to_pandas_dtype
-    # if defined!
-    # assert result.dtype == pandas_dtype
-    assert result.dtype == np_arr.dtype
+    assert result.dtype == pandas_dtype
 
     # Test the change in ConvertTableToPandas
     data = [

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1133,18 +1133,23 @@ def test_extension_to_pandas_storage_type(registered_period_type):
     period_type, _ = registered_period_type
     storage = pa.array([1, 2, 3, 4], pa.int64())
     arr = pa.ExtensionArray.from_storage(period_type, storage)
-    breakpoint()
     arr.to_pandas()
 
-    data = [
-        pa.array([1, 2, 3, 4]),
-        pa.array(['foo', 'bar', None, None]),
-        pa.array([True, None, True, False]),
-        arr
-    ]
-    my_schema = pa.schema([('f0', pa.int8()),
-                           ('f1', pa.string()),
-                           ('f2', pa.bool_()),
-                           ('ext', period_type)])
-    table = pa.Table.from_arrays(data, schema=my_schema)
-    table.to_pandas()
+    # Test the change in ConvertChunkedArrayToPandas
+    chunked_arr = pa.chunked_array([arr])
+    chunked_arr.to_numpy()
+
+    # Test the change in ConvertTableToPandas
+    # data = [
+    #     pa.array([1, 2, 3, 4]),
+    #     pa.array(['foo', 'bar', None, None]),
+    #     pa.array([True, None, True, False]),
+    #     arr
+    # ]
+    # my_schema = pa.schema([('f0', pa.int8()),
+    #                        ('f1', pa.string()),
+    #                        ('f2', pa.bool_()),
+    #                        ('ext', period_type)])
+    # table = pa.Table.from_arrays(data, schema=my_schema)
+
+    # table.to_pandas()

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1147,7 +1147,7 @@ def test_cpp_extension_in_python(tmpdir):
 @pytest.mark.pandas
 def test_extension_to_pandas_storage_type(registered_period_type):
     period_type, _ = registered_period_type
-    np_arr = np.array([1, 2, 3, 4])
+    np_arr = np.array([1, 2, 3, 4], dtype='i8')
     storage = pa.array([1, 2, 3, 4], pa.int64())
     arr = pa.ExtensionArray.from_storage(period_type, storage)
 

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1143,6 +1143,7 @@ def test_cpp_extension_in_python(tmpdir):
     assert reconstructed_array == array
 
 
+@pytest.mark.pandas
 def test_extension_to_pandas_storage_type(registered_period_type):
     period_type, _ = registered_period_type
     np_arr = np.array([1, 2, 3, 4])
@@ -1180,3 +1181,8 @@ def test_extension_to_pandas_storage_type(registered_period_type):
     table = pa.Table.from_arrays(data, schema=my_schema)
     result = table.to_pandas()
     assert result["ext"].dtype == pandas_dtype
+
+    # Check the usage of types_mapper
+    import pandas as pd
+    result = table.to_pandas(types_mapper=pd.ArrowDtype)
+    assert isinstance(result["ext"].dtype, pd.ArrowDtype)

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1184,7 +1184,7 @@ def test_extension_to_pandas_storage_type(registered_period_type):
     assert result["ext"].dtype == pandas_dtype
 
     import pandas as pd
-    if Version(pd.__version__) >= Version("2.0.0.dev0"):
+    if Version(pd.__version__) > Version("2.0.0"):
 
         # Check the usage of types_mapper
         result = table.to_pandas(types_mapper=pd.ArrowDtype)


### PR DESCRIPTION
### Rationale for this change
Method `to_pandas` fails with `KeyError` if a table has an extension array as a column with extension dtype not having `to_pandas_dtype` defined. In this cases we should fall back to storage type of the extension array.

### What changes are included in this PR?
Changes in `arrow_to_pandas.cc` at:
- `GetBlockType` for `ConvertTableToPandas`
- `ConvertChunkedArrayToPandas`
* Closes: #34165