### PR TITLE
GH-34519: [C++][R] Fix dataset scans that project the same name as a field

### DIFF
--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -141,19 +141,17 @@ Result<std::shared_ptr<Schema>> GetProjectedSchemaFromExpression(
     if (call->function_name != "make_struct") {
       return Status::Invalid("Top level projection expression call must be make_struct");
     }
-    for (const compute::Expression& arg : call->arguments) {
-      if (auto field_ref = arg.field_ref()) {
-        if (field_ref->IsName()) {
-          field_names.emplace(*field_ref->name());
-        } else if (field_ref->IsNested()) {
-          // We keep the top-level field name.
-          auto nested_field_refs = *field_ref->nested_refs();
-          field_names.emplace(*nested_field_refs[0].name());
-        } else {
-          return Status::Invalid(
-              "No projected schema was supplied and we could not infer the projected "
-              "schema from the projection expression.");
-        }
+    for (auto field_ref : compute::FieldsInExpression(projection)) {
+      if (field_ref.IsName()) {
+        field_names.emplace(*field_ref.name());
+      } else if (field_ref.IsNested()) {
+        // We keep the top-level field name.
+        auto nested_field_refs = *field_ref.nested_refs();
+        field_names.emplace(*nested_field_refs[0].name());
+      } else {
+        return Status::Invalid(
+            "No projected schema was supplied and we could not infer the projected "
+            "schema from the projection expression.");
       }
     }
   }


### PR DESCRIPTION
### Rationale for this change

Fixes #34519. #33770 introduced the bug; I had [asked](https://github.com/apache/arrow/pull/33770/files#r1081612013) in the review why the C++ function wasn't using `FieldsInExpression`. I swapped that in, and the test I added to reproduce the bug now passes.

### What changes are included in this PR?

Fix for the C++ function, test in R. 

### Are these changes tested?

Yes

### Are there any user-facing changes?

The behavior observed in the report no longer happens.
* Closes: #34519