### PR TITLE
GH-34590: [C++][ORC] Fix timestamp type mapping between orc and arrow

### DIFF
--- a/cpp/src/arrow/adapters/orc/adapter.cc
+++ b/cpp/src/arrow/adapters/orc/adapter.cc
@@ -173,6 +173,16 @@ class OrcStripeReader : public RecordBatchReader {
   int64_t batch_size_;
 };
 
+liborc::RowReaderOptions default_row_reader_options() {
+  liborc::RowReaderOptions options;
+  // Orc timestamp type is error-prone since it serializes values in the writer timezone
+  // and reads them back in the reader timezone. To avoid this, both the Apache Orc C++
+  // writer and reader set the timezone to GMT by default to avoid any conversion.
+  // We follow the same practice here explicitly to make sure readers are aware of this.
+  options.setTimezoneName("GMT");
+  return options;
+}
+
 }  // namespace
 
 class ORCFileReader::Impl {
@@ -320,25 +330,25 @@ class ORCFileReader::Impl {
   }
 
   Result<std::shared_ptr<Table>> Read() {
-    liborc::RowReaderOptions opts;
+    liborc::RowReaderOptions opts = default_row_reader_options();
     ARROW_ASSIGN_OR_RAISE(auto schema, ReadSchema());
     return ReadTable(opts, schema);
   }
 
   Result<std::shared_ptr<Table>> Read(const std::shared_ptr<Schema>& schema) {
-    liborc::RowReaderOptions opts;
+    liborc::RowReaderOptions opts = default_row_reader_options();
     return ReadTable(opts, schema);
   }
 
   Result<std::shared_ptr<Table>> Read(const std::vector<int>& include_indices) {
-    liborc::RowReaderOptions opts;
+    liborc::RowReaderOptions opts = default_row_reader_options();
     RETURN_NOT_OK(SelectIndices(&opts, include_indices));
     ARROW_ASSIGN_OR_RAISE(auto schema, ReadSchema(opts));
     return ReadTable(opts, schema);
   }
 
   Result<std::shared_ptr<Table>> Read(const std::vector<std::string>& include_names) {
-    liborc::RowReaderOptions opts;
+    liborc::RowReaderOptions opts = default_row_reader_options();
     RETURN_NOT_OK(SelectNames(&opts, include_names));
     ARROW_ASSIGN_OR_RAISE(auto schema, ReadSchema(opts));
     return ReadTable(opts, schema);
@@ -346,13 +356,13 @@ class ORCFileReader::Impl {
 
   Result<std::shared_ptr<Table>> Read(const std::shared_ptr<Schema>& schema,
                                       const std::vector<int>& include_indices) {
-    liborc::RowReaderOptions opts;
+    liborc::RowReaderOptions opts = default_row_reader_options();
     RETURN_NOT_OK(SelectIndices(&opts, include_indices));
     return ReadTable(opts, schema);
   }
 
   Result<std::shared_ptr<RecordBatch>> ReadStripe(int64_t stripe) {
-    liborc::RowReaderOptions opts;
+    liborc::RowReaderOptions opts = default_row_reader_options();
     RETURN_NOT_OK(SelectStripe(&opts, stripe));
     ARROW_ASSIGN_OR_RAISE(auto schema, ReadSchema(opts));
     return ReadBatch(opts, schema, stripes_[stripe].num_rows);
@@ -360,7 +370,7 @@ class ORCFileReader::Impl {
 
   Result<std::shared_ptr<RecordBatch>> ReadStripe(
       int64_t stripe, const std::vector<int>& include_indices) {
-    liborc::RowReaderOptions opts;
+    liborc::RowReaderOptions opts = default_row_reader_options();
     RETURN_NOT_OK(SelectIndices(&opts, include_indices));
     RETURN_NOT_OK(SelectStripe(&opts, stripe));
     ARROW_ASSIGN_OR_RAISE(auto schema, ReadSchema(opts));
@@ -369,7 +379,7 @@ class ORCFileReader::Impl {
 
   Result<std::shared_ptr<RecordBatch>> ReadStripe(
       int64_t stripe, const std::vector<std::string>& include_names) {
-    liborc::RowReaderOptions opts;
+    liborc::RowReaderOptions opts = default_row_reader_options();
     RETURN_NOT_OK(SelectNames(&opts, include_names));
     RETURN_NOT_OK(SelectStripe(&opts, stripe));
     ARROW_ASSIGN_OR_RAISE(auto schema, ReadSchema(opts));
@@ -475,7 +485,7 @@ class ORCFileReader::Impl {
       return nullptr;
     }
 
-    liborc::RowReaderOptions opts;
+    liborc::RowReaderOptions opts = default_row_reader_options();
     if (!include_indices.empty()) {
       RETURN_NOT_OK(SelectIndices(&opts, include_indices));
     }
@@ -496,7 +506,7 @@ class ORCFileReader::Impl {
 
   Result<std::shared_ptr<RecordBatchReader>> GetRecordBatchReader(
       int64_t batch_size, const std::vector<std::string>& include_names) {
-    liborc::RowReaderOptions opts;
+    liborc::RowReaderOptions opts = default_row_reader_options();
     if (!include_names.empty()) {
       RETURN_NOT_OK(SelectNames(&opts, include_names));
     }
@@ -696,6 +706,11 @@ Result<liborc::WriterOptions> MakeOrcWriterOptions(
                 });
   orc_options.setColumnsUseBloomFilter(std::move(orc_bloom_filter_columns));
   orc_options.setBloomFilterFPP(options.bloom_filter_fpp);
+  // Orc timestamp type is error-prone since it serializes values in the writer timezone
+  // and reads them back in the reader timezone. To avoid this, both the Apache Orc C++
+  // writer and reader set the timezone to GMT by default to avoid any conversion.
+  // We follow the same practice here explicitly to make sure readers are aware of this.
+  orc_options.setTimezoneName("GMT");
   switch (options.compression) {
     case Compression::UNCOMPRESSED:
       orc_options.setCompression(liborc::CompressionKind::CompressionKind_NONE);

--- a/cpp/src/arrow/adapters/orc/util.cc
+++ b/cpp/src/arrow/adapters/orc/util.cc
@@ -381,6 +381,7 @@ Status AppendBatch(const liborc::Type* type, liborc::ColumnVectorBatch* batch,
       return AppendNumericBatchCast<Date32Builder, int32_t, liborc::LongVectorBatch,
                                     int64_t>(batch, offset, length, builder);
     case liborc::TIMESTAMP:
+    case liborc::TIMESTAMP_INSTANT:
       return AppendTimestampBatch(batch, offset, length, builder);
     case liborc::DECIMAL:
       return AppendDecimalBatch(type, batch, offset, length, builder);
@@ -995,8 +996,16 @@ Result<std::unique_ptr<liborc::Type>> GetOrcType(const DataType& type) {
     case Type::type::DATE32:
       return liborc::createPrimitiveType(liborc::TypeKind::DATE);
     case Type::type::DATE64:
-    case Type::type::TIMESTAMP:
       return liborc::createPrimitiveType(liborc::TypeKind::TIMESTAMP);
+    case Type::type::TIMESTAMP: {
+      const auto& timestamp_type = checked_cast<const TimestampType&>(type);
+      if (!timestamp_type.timezone().empty()) {
+        // The timestamp values stored in the arrow array are normalized to UTC.
+        return liborc::createPrimitiveType(liborc::TypeKind::TIMESTAMP_INSTANT);
+      }
+      // The timestamp values stored in the arrow array can be in any timezone.
+      return liborc::createPrimitiveType(liborc::TypeKind::TIMESTAMP);
+    }
     case Type::type::DECIMAL128: {
       const uint64_t precision =
           static_cast<uint64_t>(checked_cast<const Decimal128Type&>(type).precision());
@@ -1111,7 +1120,11 @@ Result<std::shared_ptr<DataType>> GetArrowType(const liborc::Type* type) {
     case liborc::CHAR:
       return fixed_size_binary(static_cast<int>(type->getMaximumLength()));
     case liborc::TIMESTAMP:
+      // The timestamp values stored in ORC are in the writer timezone.
       return timestamp(TimeUnit::NANO);
+    case liborc::TIMESTAMP_INSTANT:
+      // The timestamp values stored in ORC are in UTC.
+      return timestamp(TimeUnit::NANO, "UTC");
     case liborc::DATE:
       return date32();
     case liborc::DECIMAL: {

--- a/cpp/src/arrow/adapters/orc/util.cc
+++ b/cpp/src/arrow/adapters/orc/util.cc
@@ -1001,6 +1001,7 @@ Result<std::unique_ptr<liborc::Type>> GetOrcType(const DataType& type) {
       const auto& timestamp_type = checked_cast<const TimestampType&>(type);
       if (!timestamp_type.timezone().empty()) {
         // The timestamp values stored in the arrow array are normalized to UTC.
+        // TIMESTAMP_INSTANT type is always preferred over TIMESTAMP type.
         return liborc::createPrimitiveType(liborc::TypeKind::TIMESTAMP_INSTANT);
       }
       // The timestamp values stored in the arrow array can be in any timezone.
@@ -1120,10 +1121,19 @@ Result<std::shared_ptr<DataType>> GetArrowType(const liborc::Type* type) {
     case liborc::CHAR:
       return fixed_size_binary(static_cast<int>(type->getMaximumLength()));
     case liborc::TIMESTAMP:
-      // The timestamp values stored in ORC are in the writer timezone.
+      // Values of TIMESTAMP type are stored in the writer timezone in the Orc file.
+      // Values are read back in the reader timezone. However, the writer timezone
+      // information in the Orc stripe footer is optional and may be missing. What is
+      // more, stripes in the same Orc file may have different writer timezones (though
+      // unlikely). So we cannot tell the exact timezone of values read back in the
+      // arrow::TimestampArray. In the adapter implementations, we set both writer and
+      // reader timezone to UTC to avoid any conversion so users can get the same values
+      // as written. To get rid of this burden, TIMESTAMP_INSTANT type is always preferred
+      // over TIMESTAMP type.
       return timestamp(TimeUnit::NANO);
     case liborc::TIMESTAMP_INSTANT:
-      // The timestamp values stored in ORC are in UTC.
+      // Values of TIMESTAMP_INSTANT type are stored in the UTC timezone in the ORC file.
+      // Both read and write use the UTC timezone without any conversion.
       return timestamp(TimeUnit::NANO, "UTC");
     case liborc::DATE:
       return date32();


### PR DESCRIPTION
### Rationale for this change

Background: There was an effort to fix inconsistent timestamp types across different SQL-on-Hadoop engines: https://docs.google.com/document/d/1gNRww9mZJcHvUDCXklzjFEQGpefsuR_akCDfWsdE35Q

In the Apache Orc, two timestamp types are provided:

- TIMESTAMP: timestamp type without timezone, timestamp value is stored in the writer timezone .
- TIMESTAMP_INSTANT: timestamp type with local timezone, timestamp value is stored in the UTC timezone.

arrow::TimestampType has an optional timezone field:
- If timezone is provided, values are normalized in UTC.
- If timezone is missing, values can be in any timezone.

### What changes are included in this PR?

The type mapping is fixed as below:
- orc::TIMESTAMP <=> arrow::TimestampType w/o timezone
- orc::TIMESTAMP_INSTANT <=> arrow::TimestampType w/ timezone

### Are these changes tested?

Make sure all tests pass.

### Are there any user-facing changes?

No.
* Closes: #34590