### PR TITLE
GH-34703: [Python] Set copy=False explicitly when creating a pandas Series

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1664,7 +1664,7 @@ cdef _array_like_to_pandas(obj, options, types_mapper):
     else:
         dtype = None
 
-    result = pandas_api.series(arr, dtype=dtype, name=name)
+    result = pandas_api.series(arr, dtype=dtype, name=name, copy=False)
 
     if (isinstance(original_type, TimestampType) and
             original_type.tz is not None and
@@ -2901,7 +2901,7 @@ cdef class ExtensionArray(Array):
         # pandas ExtensionDtype that implements conversion from pyarrow
         if hasattr(pandas_dtype, '__from_arrow__'):
             arr = pandas_dtype.__from_arrow__(self)
-            return pandas_api.series(arr)
+            return pandas_api.series(arr, copy=False)
 
         # otherwise convert the storage array with the base implementation
         return Array._to_pandas(self.storage, options, **kwargs)
@@ -3004,7 +3004,7 @@ cdef object get_values(object obj, bint* is_series):
         result = obj
         is_series[0] = False
     else:
-        result = pandas_api.series(obj).values
+        result = pandas_api.series(obj, copy=False).values
         is_series[0] = False
 
     return result

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -1015,9 +1015,9 @@ def _extract_index_level(table, result_table, field_name,
         values = values.copy()
 
     if isinstance(col.type, pa.lib.TimestampType) and col.type.tz is not None:
-        index_level = make_tz_aware(pd.Series(values), col.type.tz)
+        index_level = make_tz_aware(pd.Series(values, copy=False), col.type.tz)
     else:
-        index_level = pd.Series(values, dtype=values.dtype)
+        index_level = pd.Series(values, dtype=values.dtype, copy=False)
     result_table = result_table.remove_column(
         result_table.schema.get_field_index(field_name)
     )


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

pandas will change the default for creating a Series from an array (numpy, arrow, ...) to copy=True when Copy-on-Write is enabled. To avoid this when using it internally, we have to specify copy=False explicitly.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Setting copy=False when creating a Series

### Are these changes tested?

This is equivalent to the current default behavior, so no reason to add any additional tests. 
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

no

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->

cc @jorisvandenbossche 
* Closes: #34703