### PR TITLE
GH-34597: [Packaging][RPM] Don't use glog

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
+++ b/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
@@ -70,7 +70,9 @@
 %define use_gandiva (%{rhel} >= 8 && "%{_arch}" != "aarch64")
 %define use_gcs (%{rhel} >= 8)
 %define use_gflags (!%{is_amazon_linux})
-%define use_glog (%{rhel} <= 8)
+## TODO: Enable this when glob stopped depending on gflags-devel.
+# %%define use_glog (%{rhel} <= 8)
+%define use_glog 0
 %define use_mimalloc (%{rhel} >= 8)
 # TODO: Enable this. This works on local but is fragile on GitHub Actions and
 # Travis CI.

--- a/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
+++ b/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
@@ -70,7 +70,7 @@
 %define use_gandiva (%{rhel} >= 8 && "%{_arch}" != "aarch64")
 %define use_gcs (%{rhel} >= 8)
 %define use_gflags (!%{is_amazon_linux})
-## TODO: Enable this when glob stopped depending on gflags-devel.
+## TODO: Enable this when glog stopped depending on gflags-devel.
 # %%define use_glog (%{rhel} <= 8)
 %define use_glog 0
 %define use_mimalloc (%{rhel} >= 8)


### PR DESCRIPTION
### Rationale for this change

Because glog depends on gflags-devel.

### What changes are included in this PR?

Don't use glog.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #34597