### PR TITLE
GH-33750: [GLib] Add garrow_table_batch_reader_set_max_chunk_size()

### DIFF
--- a/c_glib/arrow-glib/reader.cpp
+++ b/c_glib/arrow-glib/reader.cpp
@@ -386,6 +386,26 @@ garrow_table_batch_reader_new(GArrowTable *table)
   return garrow_table_batch_reader_new_raw(&arrow_table_batch_reader);
 }
 
+/**
+ * garrow_table_batch_reader_set_max_chunk_size:
+ * @reader: A #GArrowTableBatchReader.
+ * @max_chunk_size: The maximum chunk size of record batches.
+ *
+ * Set the desired maximum chunk size of record batches.
+ *
+ * The actual chunk size of each record batch may be smaller,
+ * depending on actual chunking characteristics of each table column.
+ *
+ * Since: 12.0.0
+ */
+void
+garrow_table_batch_reader_set_max_chunk_size(GArrowTableBatchReader *reader,
+                                             gint64 max_chunk_size)
+{
+  auto arrow_reader = garrow_table_batch_reader_get_raw(reader);
+  arrow_reader->set_chunksize(max_chunk_size);
+}
+
 
 G_DEFINE_TYPE(GArrowRecordBatchStreamReader,
               garrow_record_batch_stream_reader,
@@ -2236,6 +2256,13 @@ garrow_table_batch_reader_new_raw(std::shared_ptr<arrow::TableBatchReader> *arro
                                            "record-batch-reader", arrow_reader,
                                            NULL));
   return reader;
+}
+
+std::shared_ptr<arrow::TableBatchReader>
+garrow_table_batch_reader_get_raw(GArrowTableBatchReader *reader)
+{
+  return std::static_pointer_cast<arrow::TableBatchReader>(
+    garrow_record_batch_reader_get_raw(GARROW_RECORD_BATCH_READER(reader)));
 }
 
 GArrowRecordBatchStreamReader *

--- a/c_glib/arrow-glib/reader.h
+++ b/c_glib/arrow-glib/reader.h
@@ -92,6 +92,11 @@ struct _GArrowTableBatchReaderClass
 
 GArrowTableBatchReader *garrow_table_batch_reader_new(GArrowTable *table);
 
+GARROW_AVAILABLE_IN_12_0
+void
+garrow_table_batch_reader_set_max_chunk_size(GArrowTableBatchReader *reader,
+                                             gint64 max_chunk_size);
+
 
 #define GARROW_TYPE_RECORD_BATCH_STREAM_READER          \
   (garrow_record_batch_stream_reader_get_type())

--- a/c_glib/arrow-glib/reader.hpp
+++ b/c_glib/arrow-glib/reader.hpp
@@ -30,7 +30,11 @@
 GArrowRecordBatchReader *garrow_record_batch_reader_new_raw(std::shared_ptr<arrow::ipc::RecordBatchReader> *arrow_reader);
 std::shared_ptr<arrow::ipc::RecordBatchReader> garrow_record_batch_reader_get_raw(GArrowRecordBatchReader *reader);
 
-GArrowTableBatchReader *garrow_table_batch_reader_new_raw(std::shared_ptr<arrow::TableBatchReader> *arrow_reader);
+GArrowTableBatchReader *
+garrow_table_batch_reader_new_raw(
+  std::shared_ptr<arrow::TableBatchReader> *arrow_reader);
+std::shared_ptr<arrow::TableBatchReader>
+garrow_table_batch_reader_get_raw(GArrowTableBatchReader *reader);
 
 GArrowRecordBatchStreamReader *garrow_record_batch_stream_reader_new_raw(std::shared_ptr<arrow::ipc::RecordBatchStreamReader> *arrow_reader);
 

--- a/c_glib/test/test-table-batch-reader.rb
+++ b/c_glib/test/test-table-batch-reader.rb
@@ -39,4 +39,16 @@ class TestTableBatchReader < Test::Unit::TestCase
     reader = Arrow::TableBatchReader.new(table)
     assert_equal(table.schema, reader.schema)
   end
+
+  def test_max_chunk_size
+    array = build_int32_array([1, 2, 3])
+    table = build_table("number" => array)
+    reader = Arrow::TableBatchReader.new(table)
+    reader.max_chunk_size = 2
+    assert_equal(build_record_batch("number" => build_int32_array([1, 2])),
+                 reader.read_next)
+    assert_equal(build_record_batch("number" => build_int32_array([3])),
+                 reader.read_next)
+    assert_nil(reader.read_next)
+  end
 end


### PR DESCRIPTION
### Rationale for this change

This is a missing feature.

### What changes are included in this PR?

This adds a binding.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #33750