### PR TITLE
GH-34605: [C++] Don't use std::move when passing shared_ptr to named table …

### DIFF
--- a/cpp/src/arrow/engine/substrait/options.cc
+++ b/cpp/src/arrow/engine/substrait/options.cc
@@ -161,9 +161,8 @@ class DefaultExtensionProvider : public BaseExtensionProvider {
     ARROW_ASSIGN_OR_RAISE(auto renamed_schema, schema->WithNames(columns));
     auto input_decls = MakeDeclarationInputs(inputs);
     ARROW_ASSIGN_OR_RAISE(
-        auto decl,
-        conv_opts.named_tap_provider(named_tap_rel.kind(), input_decls,
-                                     named_tap_rel.name(), renamed_schema));
+        auto decl, conv_opts.named_tap_provider(named_tap_rel.kind(), input_decls,
+                                                named_tap_rel.name(), renamed_schema));
     return RelationInfo{{std::move(decl), renamed_schema}, std::nullopt};
   }
 };

--- a/cpp/src/arrow/engine/substrait/options.cc
+++ b/cpp/src/arrow/engine/substrait/options.cc
@@ -163,8 +163,8 @@ class DefaultExtensionProvider : public BaseExtensionProvider {
     ARROW_ASSIGN_OR_RAISE(
         auto decl,
         conv_opts.named_tap_provider(named_tap_rel.kind(), input_decls,
-                                     named_tap_rel.name(), std::move(renamed_schema)));
-    return RelationInfo{{std::move(decl), std::move(renamed_schema)}, std::nullopt};
+                                     named_tap_rel.name(), renamed_schema));
+    return RelationInfo{{std::move(decl), renamed_schema}, std::nullopt};
   }
 };
 

--- a/cpp/src/arrow/engine/substrait/options.cc
+++ b/cpp/src/arrow/engine/substrait/options.cc
@@ -163,7 +163,7 @@ class DefaultExtensionProvider : public BaseExtensionProvider {
     ARROW_ASSIGN_OR_RAISE(
         auto decl, conv_opts.named_tap_provider(named_tap_rel.kind(), input_decls,
                                                 named_tap_rel.name(), renamed_schema));
-    return RelationInfo{{std::move(decl), renamed_schema}, std::nullopt};
+    return RelationInfo{{std::move(decl), std::move(renamed_schema)}, std::nullopt};
   }
 };
 


### PR DESCRIPTION
…provider and declaration info


<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

In internal testing, we found a segment fault issue when executing a named tap relation. After debugging, the segfault is caused by accessing the output_schema field of the named tap declaration info, caused by this code:

https://github.com/apache/arrow/blob/main/cpp/src/arrow/engine/substrait/options.cc#L134

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

This PR removes "std::move" when passing shared_ptr of the Schema and thus prevent segfault when accessing this field from named tap provider or DeclarationInfo.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
I verified with internal tests that this PR fixes the issue.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->