### PR TITLE
GH-34610: [Java] Fix valueCount when loading NullVector

### DIFF
--- a/java/c/src/test/java/org/apache/arrow/c/RoundtripTest.java
+++ b/java/c/src/test/java/org/apache/arrow/c/RoundtripTest.java
@@ -463,6 +463,13 @@ public class RoundtripTest {
   }
 
   @Test
+  public void testNullVector() {
+    try (final NullVector vector = new NullVector("v", 1024)) {
+      assertTrue(roundtrip(vector, NullVector.class));
+    }
+  }
+
+  @Test
   public void testVarBinaryVector() {
     try (final VarBinaryVector vector = new VarBinaryVector("v", allocator)) {
       setVector(vector, "abc".getBytes(), "def".getBytes(), null);

--- a/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
@@ -58,6 +58,16 @@ public class NullVector implements FieldVector {
   }
 
   /**
+   * Instantiate a NullVector with the given number of values
+   *
+   * @param name name of the vector
+   * @param valueCount number of values (i.e., nulls) in this vector
+   */
+  public NullVector(String name, int valueCount) {
+    this(new Field(name, FieldType.nullable(Types.MinorType.NULL.getType()), null), valueCount);
+  }
+
+  /**
    * Instantiate a NullVector.
    *
    * @param name      name of the vector
@@ -73,8 +83,18 @@ public class NullVector implements FieldVector {
    * @param field field materialized by this vector.
    */
   public NullVector(Field field) {
-    this.valueCount = 0;
+    this(field, 0);
+  }
+
+  /**
+   * Instantiate a NullVector with the given number of values
+   *
+   * @param field field materialized by this vector.
+   * @param valueCount number of values (i.e., nulls) in this vector
+   */
+  public NullVector(Field field, int valueCount) {
     this.field = field;
+    this.valueCount = valueCount;
   }
 
   @Deprecated
@@ -192,6 +212,7 @@ public class NullVector implements FieldVector {
   @Override
   public void loadFieldBuffers(ArrowFieldNode fieldNode, List<ArrowBuf> ownBuffers) {
     Preconditions.checkArgument(ownBuffers.isEmpty(), "Null vector has no buffers");
+    this.valueCount = fieldNode.getLength();
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
@@ -58,10 +58,10 @@ public class NullVector implements FieldVector {
   }
 
   /**
-   * Instantiate a NullVector with the given number of values
+   * Instantiate a NullVector with the given number of values.
    *
    * @param name name of the vector
-   * @param valueCount number of values (i.e., nulls) in this vector
+   * @param valueCount number of values (i.e., nulls) in this vector.
    */
   public NullVector(String name, int valueCount) {
     this(new Field(name, FieldType.nullable(Types.MinorType.NULL.getType()), null), valueCount);
@@ -87,10 +87,10 @@ public class NullVector implements FieldVector {
   }
 
   /**
-   * Instantiate a NullVector with the given number of values
+   * Instantiate a NullVector with the given number of values.
    *
    * @param field field materialized by this vector.
-   * @param valueCount number of values (i.e., nulls) in this vector
+   * @param valueCount number of values (i.e., nulls) in this vector.
    */
   public NullVector(Field field, int valueCount) {
     this.field = field;


### PR DESCRIPTION
We should set `valueCount` and `nullCount` when loading `NullVector`.


<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

When importing a `NullVector`, for example, via Arrow C interface, the `valueCount` and `nullCount` is currently not set properly, which will result both values to be 0.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Set `valueCount` when loading the vector.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Added a test. Also had to add extra constructor to facilitate the test.

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No.

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #34610