### PR TITLE
GH-34622: [CI][GLib] Use "meson setup ..."

### DIFF
--- a/ci/scripts/c_glib_build.sh
+++ b/ci/scripts/c_glib_build.sh
@@ -36,7 +36,8 @@ export CXXFLAGS="-DARROW_NO_DEPRECATED_API"
 mkdir -p ${build_dir}
 
 # Build with Meson
-meson --prefix=$ARROW_HOME \
+meson setup \
+      --prefix=$ARROW_HOME \
       --libdir=lib \
       -Dgtk_doc=${with_gtk_doc} \
       -Dvapi=${ARROW_GLIB_VAPI} \


### PR DESCRIPTION
### Rationale for this change

Because "meson ..." is deprecated.


### What changes are included in this PR?

Use "meson setup ..." instead.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #34622