### PR TITLE
GH-34621: [GLib] Don't use "g_strdup(XXX->ToString().c_str())"

### DIFF
--- a/c_glib/arrow-dataset-glib/partitioning.cpp
+++ b/c_glib/arrow-dataset-glib/partitioning.cpp
@@ -757,10 +757,11 @@ gchar *
 gadataset_hive_partitioning_get_null_fallback(
   GADatasetHivePartitioning *partitioning)
 {
-  auto arrow_partitioning =
+  const auto arrow_partitioning =
     std::static_pointer_cast<arrow::dataset::HivePartitioning>(
       gadataset_partitioning_get_raw(GADATASET_PARTITIONING(partitioning)));
-  return g_strdup(arrow_partitioning->null_fallback().c_str());
+  const auto null_fallback = arrow_partitioning->null_fallback();
+  return g_strdup(null_fallback.c_str());
 }
 
 

--- a/c_glib/arrow-flight-glib/common.cpp
+++ b/c_glib/arrow-flight-glib/common.cpp
@@ -284,7 +284,8 @@ gchar *
 gaflight_location_to_string(GAFlightLocation *location)
 {
   const auto flight_location = gaflight_location_get_raw(location);
-  return g_strdup(flight_location->ToString().c_str());
+  const auto string = flight_location->ToString();
+  return g_strdup(string.c_str());
 }
 
 /**
@@ -301,7 +302,8 @@ gchar *
 gaflight_location_get_scheme(GAFlightLocation *location)
 {
   const auto flight_location = gaflight_location_get_raw(location);
-  return g_strdup(flight_location->scheme().c_str());
+  const auto scheme = flight_location->scheme();
+  return g_strdup(scheme.c_str());
 }
 
 /**
@@ -406,8 +408,9 @@ gaflight_descriptor_class_init(GAFlightDescriptorClass *klass)
 gchar *
 gaflight_descriptor_to_string(GAFlightDescriptor *descriptor)
 {
-  auto flight_descriptor = gaflight_descriptor_get_raw(descriptor);
-  return g_strdup(flight_descriptor->ToString().c_str());
+  const auto flight_descriptor = gaflight_descriptor_get_raw(descriptor);
+  const auto string = flight_descriptor->ToString();
+  return g_strdup(string.c_str());
 }
 
 /**

--- a/c_glib/arrow-glib/basic-array.cpp
+++ b/c_glib/arrow-glib/basic-array.cpp
@@ -929,7 +929,8 @@ gchar *
 garrow_array_to_string(GArrowArray *array, GError **error)
 {
   const auto arrow_array = garrow_array_get_raw(array);
-  return g_strdup(arrow_array->ToString().c_str());
+  const auto string = arrow_array->ToString();
+  return g_strdup(string.c_str());
 }
 
 /**

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -297,7 +297,8 @@ gchar *
 garrow_data_type_to_string(GArrowDataType *data_type)
 {
   const auto arrow_data_type = garrow_data_type_get_raw(data_type);
-  return g_strdup(arrow_data_type->ToString().c_str());
+  const auto string = arrow_data_type->ToString();
+  return g_strdup(string.c_str());
 }
 
 /**
@@ -327,7 +328,8 @@ gchar *
 garrow_data_type_get_name(GArrowDataType *data_type)
 {
   const auto arrow_data_type = garrow_data_type_get_raw(data_type);
-  return g_strdup(arrow_data_type->name().c_str());
+  const auto name = arrow_data_type->name();
+  return g_strdup(name.c_str());
 }
 
 
@@ -1770,7 +1772,8 @@ garrow_extension_data_type_get_extension_name(GArrowExtensionDataType *data_type
   auto arrow_data_type =
     std::static_pointer_cast<arrow::ExtensionType>(
       garrow_data_type_get_raw(GARROW_DATA_TYPE(data_type)));
-  return g_strdup(arrow_data_type->extension_name().c_str());
+  const auto name = arrow_data_type->extension_name();
+  return g_strdup(name.c_str());
 }
 
 /**

--- a/c_glib/arrow-glib/chunked-array.cpp
+++ b/c_glib/arrow-glib/chunked-array.cpp
@@ -384,7 +384,8 @@ gchar *
 garrow_chunked_array_to_string(GArrowChunkedArray *chunked_array, GError **error)
 {
   const auto arrow_chunked_array = garrow_chunked_array_get_raw(chunked_array);
-  return g_strdup(arrow_chunked_array->ToString().c_str());
+  const auto string = arrow_chunked_array->ToString();
+  return g_strdup(string.c_str());
 }
 
 /**

--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -799,7 +799,8 @@ garrow_function_to_string(GArrowFunction *function)
     if (i > 0) {
       g_string_append(string, ", ");
     }
-    g_string_append(string, arrow_default_options->ToString().c_str());
+    const auto options_string = arrow_default_options->ToString();
+    g_string_append(string, options_string.c_str());
   }
   g_string_append_printf(string, "): %s", arrow_doc.summary.c_str());
   return g_string_free(string, FALSE);

--- a/c_glib/arrow-glib/datum.cpp
+++ b/c_glib/arrow-glib/datum.cpp
@@ -207,7 +207,8 @@ gchar *
 garrow_datum_to_string(GArrowDatum *datum)
 {
   const auto &arrow_datum = garrow_datum_get_raw(datum);
-  return g_strdup(arrow_datum.ToString().c_str());
+  const auto string = arrow_datum.ToString();
+  return g_strdup(string.c_str());
 }
 
 

--- a/c_glib/arrow-glib/decimal.cpp
+++ b/c_glib/arrow-glib/decimal.cpp
@@ -166,7 +166,8 @@ garrow_decimal_to_string_scale(typename DecimalConverter<Decimal>::GArrowType *d
 {
   DecimalConverter<Decimal> converter;
   const auto arrow_decimal = converter.get_raw(decimal);
-  return g_strdup(arrow_decimal->ToString(scale).c_str());
+  const auto string = arrow_decimal->ToString(scale);
+  return g_strdup(string.c_str());
 }
 
 template <typename Decimal>
@@ -175,7 +176,8 @@ garrow_decimal_to_string(typename DecimalConverter<Decimal>::GArrowType *decimal
 {
   DecimalConverter<Decimal> converter;
   const auto arrow_decimal = converter.get_raw(decimal);
-  return g_strdup(arrow_decimal->ToIntegerString().c_str());
+  const auto string = arrow_decimal->ToIntegerString();
+  return g_strdup(string.c_str());
 }
 
 template <typename Decimal>

--- a/c_glib/arrow-glib/field.cpp
+++ b/c_glib/arrow-glib/field.cpp
@@ -286,7 +286,8 @@ gchar *
 garrow_field_to_string(GArrowField *field)
 {
   const auto arrow_field = garrow_field_get_raw(field);
-  return g_strdup(arrow_field->ToString().c_str());
+  const auto string = arrow_field->ToString();
+  return g_strdup(string.c_str());
 }
 
 /**
@@ -304,7 +305,8 @@ gchar *
 garrow_field_to_string_metadata(GArrowField *field, gboolean show_metadata)
 {
   const auto arrow_field = garrow_field_get_raw(field);
-  return g_strdup(arrow_field->ToString(show_metadata).c_str());
+  const auto string = arrow_field->ToString(show_metadata);
+  return g_strdup(string.c_str());
 }
 
 /**

--- a/c_glib/arrow-glib/file-system.cpp
+++ b/c_glib/arrow-glib/file-system.cpp
@@ -378,7 +378,8 @@ gchar *
 garrow_file_info_to_string(GArrowFileInfo *file_info)
 {
   const auto arrow_file_info = garrow_file_info_get_raw(file_info);
-  return g_strdup(arrow_file_info->ToString().c_str());
+  const auto string = arrow_file_info->ToString();
+  return g_strdup(string.c_str());
 }
 
 /* arrow::fs::FileSelector */

--- a/c_glib/arrow-glib/memory-pool.cpp
+++ b/c_glib/arrow-glib/memory-pool.cpp
@@ -149,7 +149,8 @@ gchar *
 garrow_memory_pool_get_backend_name(GArrowMemoryPool *memory_pool)
 {
   auto arrow_memory_pool = garrow_memory_pool_get_raw(memory_pool);
-  return g_strdup(arrow_memory_pool->backend_name().c_str());
+  const auto name = arrow_memory_pool->backend_name();
+  return g_strdup(name.c_str());
 }
 
 G_END_DECLS

--- a/c_glib/arrow-glib/record-batch.cpp
+++ b/c_glib/arrow-glib/record-batch.cpp
@@ -418,7 +418,8 @@ gchar *
 garrow_record_batch_to_string(GArrowRecordBatch *record_batch, GError **error)
 {
   const auto arrow_record_batch = garrow_record_batch_get_raw(record_batch);
-  return g_strdup(arrow_record_batch->ToString().c_str());
+  const auto string = arrow_record_batch->ToString();
+  return g_strdup(string.c_str());
 }
 
 /**

--- a/c_glib/arrow-glib/scalar.cpp
+++ b/c_glib/arrow-glib/scalar.cpp
@@ -361,7 +361,8 @@ gchar *
 garrow_scalar_to_string(GArrowScalar *scalar)
 {
   const auto arrow_scalar = garrow_scalar_get_raw(scalar);
-  return g_strdup(arrow_scalar->ToString().c_str());
+  const auto string = arrow_scalar->ToString();
+  return g_strdup(string.c_str());
 }
 
 /**

--- a/c_glib/arrow-glib/schema.cpp
+++ b/c_glib/arrow-glib/schema.cpp
@@ -308,7 +308,8 @@ gchar *
 garrow_schema_to_string(GArrowSchema *schema)
 {
   const auto arrow_schema = garrow_schema_get_raw(schema);
-  return g_strdup(arrow_schema->ToString().c_str());
+  const auto string = arrow_schema->ToString();
+  return g_strdup(string.c_str());
 }
 
 /**
@@ -326,7 +327,8 @@ gchar *
 garrow_schema_to_string_metadata(GArrowSchema *schema, gboolean show_metadata)
 {
   const auto arrow_schema = garrow_schema_get_raw(schema);
-  return g_strdup(arrow_schema->ToString(show_metadata).c_str());
+  const auto string = arrow_schema->ToString(show_metadata);
+  return g_strdup(string.c_str());
 }
 
 /**

--- a/c_glib/arrow-glib/table.cpp
+++ b/c_glib/arrow-glib/table.cpp
@@ -684,7 +684,8 @@ gchar *
 garrow_table_to_string(GArrowTable *table, GError **error)
 {
   const auto arrow_table = garrow_table_get_raw(table);
-  return g_strdup(arrow_table->ToString().c_str());
+  const auto string = arrow_table->ToString();
+  return g_strdup(string.c_str());
 }
 
 /**

--- a/c_glib/gandiva-glib/function-signature.cpp
+++ b/c_glib/gandiva-glib/function-signature.cpp
@@ -156,7 +156,8 @@ ggandiva_function_signature_to_string(GGandivaFunctionSignature *function_signat
 {
   auto gandiva_function_signature =
     ggandiva_function_signature_get_raw(function_signature);
-  return g_strdup(gandiva_function_signature->ToString().c_str());
+  const auto string = gandiva_function_signature->ToString();
+  return g_strdup(string.c_str());
 }
 
 /**
@@ -193,7 +194,8 @@ ggandiva_function_signature_get_base_name(GGandivaFunctionSignature *function_si
 {
   auto gandiva_function_signature =
     ggandiva_function_signature_get_raw(function_signature);
-  return g_strdup(gandiva_function_signature->base_name().c_str());
+  const auto base_name = gandiva_function_signature->base_name();
+  return g_strdup(base_name.c_str());
 }
 
 /**

--- a/c_glib/plasma-glib/object.cpp
+++ b/c_glib/plasma-glib/object.cpp
@@ -140,7 +140,8 @@ gchar *
 gplasma_object_id_to_hex(GPlasmaObjectID *id)
 {
   auto priv = GPLASMA_OBJECT_ID_GET_PRIVATE(id);
-  return g_strdup(priv->id.hex().c_str());
+  const auto hex = priv->id.hex();
+  return g_strdup(hex.c_str());
 }
 
 typedef struct GPlasmaObjectPrivate_ {


### PR DESCRIPTION
### Rationale for this change

Because it reports "object backing the pointer will be destroyed at the end of the full-expression" [-Wdangling-gsl] warning.

### What changes are included in this PR?

Create a variable for temporary `std::string`. 

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #34621