### PR TITLE
GH-34641: [CI][Python] Mark test_scan on test_acero.py to require dataset

### DIFF
--- a/python/pyarrow/tests/test_acero.py
+++ b/python/pyarrow/tests/test_acero.py
@@ -20,7 +20,6 @@ import pytest
 import pyarrow as pa
 import pyarrow.compute as pc
 from pyarrow.compute import field
-import pyarrow.dataset as ds
 
 from pyarrow._acero import (
     TableSourceNodeOptions,
@@ -30,7 +29,12 @@ from pyarrow._acero import (
     HashJoinNodeOptions,
     Declaration,
 )
-from pyarrow._dataset import ScanNodeOptions
+
+try:
+    import pyarrow.dataset as ds
+    from pyarrow._dataset import ScanNodeOptions
+except ImportError:
+    ds = None
 
 
 @pytest.fixture
@@ -295,6 +299,7 @@ def test_hash_join():
     assert result.sort_by("a").equals(expected)
 
 
+@pytest.mark.dataset
 def test_scan(tempdir):
     table = pa.table({'a': [1, 2, 3], 'b': [4, 5, 6]})
     ds.write_dataset(table, tempdir / "dataset", format="parquet")


### PR DESCRIPTION
### Rationale for this change

Some nightly builds were failing.

### What changes are included in this PR?

Correctly skip test if no dataset.

### Are these changes tested?

Yes, locally and will test the CI jobs

### Are there any user-facing changes?

No
* Closes: #34641