### PR TITLE
GH-34644: [C++] Prefer unsafe casting by default in Substrait 

### DIFF
--- a/cpp/src/arrow/engine/substrait/expression_internal.cc
+++ b/cpp/src/arrow/engine/substrait/expression_internal.cc
@@ -336,8 +336,9 @@ Result<compute::Expression> FromProto(const substrait::Expression& expr,
       if (cast_exp.failure_behavior() ==
           substrait::Expression::Cast::FailureBehavior::
               Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_THROW_EXCEPTION) {
-        return compute::call("cast", {std::move(input)},
-                             compute::CastOptions::Safe(std::move(type_nullable.first)));
+        return compute::call(
+            "cast", {std::move(input)},
+            compute::CastOptions::Unsafe(std::move(type_nullable.first)));
       } else if (cast_exp.failure_behavior() ==
                  substrait::Expression::Cast::FailureBehavior::
                      Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_RETURN_NULL) {

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -814,6 +814,19 @@ TEST(Substrait, Cast) {
   ASSERT_TRUE(expr.call());
 
   ASSERT_THAT(expr.call()->arguments[0].call()->function_name, "cast");
+
+  std::shared_ptr<compute::FunctionOptions> call_opts =
+      expr.call()->arguments[0].call()->options;
+
+  ASSERT_TRUE(!!call_opts);
+  std::shared_ptr<compute::CastOptions> cast_opts =
+      std::dynamic_pointer_cast<compute::CastOptions>(call_opts);
+  ASSERT_TRUE(!!cast_opts);
+  // It is unclear whether a Substrait cast should be safe or not.  In the meantime we are
+  // assuming it is unsafe based on the behavior of many SQL engines.
+  ASSERT_TRUE(cast_opts->allow_int_overflow);
+  ASSERT_TRUE(cast_opts->allow_float_truncate);
+  ASSERT_TRUE(cast_opts->allow_decimal_truncate);
 }
 
 TEST(Substrait, CastRequiresFailureBehavior) {


### PR DESCRIPTION
### Rationale for this change

See issue

### What changes are included in this PR?

Changes the default cast in Substrait to an unsafe cast.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes

BREAKING CHANGE: The default Substrait behavior has changed slightly.  However, we believe this to be more in line with user expectation.
* Closes: #34644