### PR TITLE
GH-34629: [Go] Fix transpose_ints to work on riscv64-freebsd

### DIFF
--- a/go/internal/utils/endians_default.go
+++ b/go/internal/utils/endians_default.go
@@ -15,7 +15,6 @@
 // limitations under the License.
 
 //go:build !s390x
-// +build !s390x
 
 package utils
 

--- a/go/internal/utils/min_max_amd64.go
+++ b/go/internal/utils/min_max_amd64.go
@@ -15,7 +15,6 @@
 // limitations under the License.
 
 //go:build !noasm
-// +build !noasm
 
 package utils
 

--- a/go/internal/utils/min_max_arm64.go
+++ b/go/internal/utils/min_max_arm64.go
@@ -15,7 +15,6 @@
 // limitations under the License.
 
 //go:build !noasm
-// +build !noasm
 
 package utils
 

--- a/go/internal/utils/min_max_avx2_amd64.go
+++ b/go/internal/utils/min_max_avx2_amd64.go
@@ -15,7 +15,6 @@
 // limitations under the License.
 
 //go:build !noasm
-// +build !noasm
 
 package utils
 

--- a/go/internal/utils/min_max_neon_arm64.go
+++ b/go/internal/utils/min_max_neon_arm64.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !noasm
+//go:build !noasm
 
 package utils
 

--- a/go/internal/utils/min_max_noasm.go
+++ b/go/internal/utils/min_max_noasm.go
@@ -15,7 +15,6 @@
 // limitations under the License.
 
 //go:build noasm
-// +build noasm
 
 package utils
 

--- a/go/internal/utils/min_max_ppc64le.go
+++ b/go/internal/utils/min_max_ppc64le.go
@@ -15,7 +15,6 @@
 // limitations under the License.
 
 //go:build !noasm
-// +build !noasm
 
 package utils
 

--- a/go/internal/utils/min_max_s390x.go
+++ b/go/internal/utils/min_max_s390x.go
@@ -15,7 +15,6 @@
 // limitations under the License.
 
 //go:build !noasm
-// +build !noasm
 
 package utils
 

--- a/go/internal/utils/min_max_sse4_amd64.go
+++ b/go/internal/utils/min_max_sse4_amd64.go
@@ -15,7 +15,6 @@
 // limitations under the License.
 
 //go:build !noasm
-// +build !noasm
 
 package utils
 

--- a/go/internal/utils/transpose_ints_amd64.go
+++ b/go/internal/utils/transpose_ints_amd64.go
@@ -17,7 +17,6 @@
 // limitations under the License.
 
 //go:build !noasm
-// +build !noasm
 
 package utils
 

--- a/go/internal/utils/transpose_ints_arm64.go
+++ b/go/internal/utils/transpose_ints_arm64.go
@@ -17,7 +17,6 @@
 // limitations under the License.
 
 //go:build !noasm
-// +build !noasm
 
 package utils
 

--- a/go/internal/utils/transpose_ints_avx2_amd64.go
+++ b/go/internal/utils/transpose_ints_avx2_amd64.go
@@ -17,7 +17,6 @@
 // limitations under the License.
 
 //go:build !noasm
-// +build !noasm
 
 package utils
 

--- a/go/internal/utils/transpose_ints_noasm.go
+++ b/go/internal/utils/transpose_ints_noasm.go
@@ -16,8 +16,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build noasm
-// +build noasm
+//go:build noasm || (!amd64 && !arm64 && !s390x && !ppc64le)
+// +build noasm || (!amd64 && !arm64 && !s390x && !ppc64le)
 
 package utils
 

--- a/go/internal/utils/transpose_ints_noasm.go
+++ b/go/internal/utils/transpose_ints_noasm.go
@@ -17,7 +17,6 @@
 // limitations under the License.
 
 //go:build noasm || (!amd64 && !arm64 && !s390x && !ppc64le)
-// +build noasm || (!amd64 && !arm64 && !s390x && !ppc64le)
 
 package utils
 

--- a/go/internal/utils/transpose_ints_ppc64le.go
+++ b/go/internal/utils/transpose_ints_ppc64le.go
@@ -17,7 +17,6 @@
 // limitations under the License.
 
 //go:build !noasm
-// +build !noasm
 
 package utils
 

--- a/go/internal/utils/transpose_ints_s390x.go
+++ b/go/internal/utils/transpose_ints_s390x.go
@@ -17,7 +17,6 @@
 // limitations under the License.
 
 //go:build !noasm
-// +build !noasm
 
 package utils
 

--- a/go/internal/utils/transpose_ints_sse4_amd64.go
+++ b/go/internal/utils/transpose_ints_sse4_amd64.go
@@ -17,7 +17,6 @@
 // limitations under the License.
 
 //go:build !noasm
-// +build !noasm
 
 package utils
 

--- a/go/internal/utils/transpose_ints_test.go
+++ b/go/internal/utils/transpose_ints_test.go
@@ -15,7 +15,6 @@
 // limitations under the License.
 
 //go:build !noasm
-// +build !noasm
 
 package utils_test
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
Protecting the Go arrow packages from failing on new architectures by ensuring the pure go implementation gets loaded for any architecture that isn't one of the explicit ones we have assembly for.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
changing the go build constraint

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->


* Closes: #34629