### PR TITLE
GH-34692: [Java] Expose Location.toSocketAddress

### DIFF
--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/Location.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/Location.java
@@ -60,7 +60,7 @@ public class Location {
    *
    * @return null if could not be converted
    */
-  SocketAddress toSocketAddress() {
+  public SocketAddress toSocketAddress() {
     switch (uri.getScheme()) {
       case LocationSchemes.GRPC:
       case LocationSchemes.GRPC_TLS:

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestBasicOperation.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestBasicOperation.java
@@ -24,6 +24,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
@@ -411,6 +412,24 @@ public class TestBasicOperation {
         parsedMessage.asSchema();
       }
     }
+  }
+
+  @Test
+  public void testGrpcInsecureLocation() throws Exception {
+    Location location = Location.forGrpcInsecure(LOCALHOST, 9000);
+    Assertions.assertEquals(
+        new URI(LocationSchemes.GRPC_INSECURE, null, LOCALHOST, 9000, null, null, null),
+        location.getUri());
+    Assertions.assertEquals(new InetSocketAddress(LOCALHOST, 9000), location.toSocketAddress());
+  }
+
+  @Test
+  public void testGrpcTlsLocation() throws Exception {
+    Location location = Location.forGrpcTls(LOCALHOST, 9000);
+    Assertions.assertEquals(
+            new URI(LocationSchemes.GRPC_TLS, null, LOCALHOST, 9000, null, null, null),
+            location.getUri());
+    Assertions.assertEquals(new InetSocketAddress(LOCALHOST, 9000), location.toSocketAddress());
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Change `Location.toSocketAddress()` to a public method. This is useful for creating a `FlightClient` via `FlightGrpcUtils.createFlightClient`:

https://github.com/apache/arrow/blob/08fb86107b001e2e1903ae0e416ff51386d4239e/java/flight/flight-grpc/src/main/java/org/apache/arrow/flight/FlightGrpcUtils.java#L148

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: apache/arrow#34692
* GitHub Issue: #34692