### PR TITLE
GH-32763: [C++] Add FromProto for fetch & sort

### DIFF
--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -788,6 +788,7 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel, const ExtensionSet&
           null_placement = IsSortNullsFirst(sort.direction())
                                ? compute::NullPlacement::AtStart
                                : compute::NullPlacement::AtEnd;
+          first = false;
         } else {
           if ((null_placement == compute::NullPlacement::AtStart &&
                !IsSortNullsFirst(sort.direction())) ||

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -367,7 +367,6 @@ struct SortBehavior {
       default:
         return Status::NotImplemented(
             "Acero does not support the specified sort direction: ", dir);
-        break;
     }
     return sort_behavior;
   }

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -5366,15 +5366,9 @@ TEST(Substrait, SortAndFetch) {
     [null, null]
   ])"});
 
-  NamedTableProvider table_provider = [&](const std::vector<std::string>& names,
-                                          const Schema&) {
-    std::shared_ptr<acero::ExecNodeOptions> options =
-        std::make_shared<acero::TableSourceNodeOptions>(input_table);
-    return acero::Declaration("table_source", {}, options, "mock_source");
-  };
-
   ConversionOptions conversion_options;
-  conversion_options.named_table_provider = std::move(table_provider);
+  conversion_options.named_table_provider =
+      AlwaysProvideSameTable(std::move(input_table));
 
   CheckRoundTripResult(std::move(output_table), buf, {}, conversion_options);
 }

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -5257,6 +5257,128 @@ TEST(Substrait, CompoundEmitWithFilter) {
   CheckRoundTripResult(std::move(expected_table), buf, {}, conversion_options);
 }
 
+TEST(Substrait, SortAndFetch) {
+  // Sort by A, ascending, take items [2, 5), then sort by B descending
+  std::string substrait_json = R"({
+    "version": {
+        "major_number": 9999,
+        "minor_number": 9999,
+        "patch_number": 9999
+    },
+    "relations": [
+        {
+            "rel": {
+                "sort": {
+                    "input": {
+                        "fetch": {
+                            "input": {
+                                "sort": {
+                                    "input": {
+                                        "read": {
+                                            "base_schema": {
+                                                "names": [
+                                                    "A",
+                                                    "B"
+                                                ],
+                                                "struct": {
+                                                    "types": [
+                                                        {
+                                                            "i32": {}
+                                                        },
+                                                        {
+                                                            "i32": {}
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "namedTable": {
+                                                "names": [
+                                                    "table"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "sorts": [
+                                        {
+                                            "expr": {
+                                                "selection": {
+                                                    "directReference": {
+                                                        "structField": {
+                                                            "field": 0
+                                                        }
+                                                    },
+                                                    "rootReference": {}
+                                                }
+                                            },
+                                            "direction": "SORT_DIRECTION_ASC_NULLS_FIRST"
+                                        }
+                                    ]
+                                }
+                            },
+                            "offset": 2,
+                            "count": 3
+                        }
+                    },
+                    "sorts": [
+                        {
+                            "expr": {
+                                "selection": {
+                                    "directReference": {
+                                        "structField": {
+                                            "field": 1
+                                        }
+                                    },
+                                    "rootReference": {}
+                                }
+                            },
+                            "direction": "SORT_DIRECTION_DESC_NULLS_LAST"
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "extension_uris": [],
+    "extensions": []
+})";
+
+  ASSERT_OK_AND_ASSIGN(auto buf, internal::SubstraitFromJSON("Plan", substrait_json));
+  auto test_schema = schema({field("A", int32()), field("B", int32())});
+
+  auto input_table = TableFromJSON(test_schema, {R"([
+      [null, null],
+      [5, 8],
+      [null, null],
+      [null, null],
+      [3, 4],
+      [9, 6],
+      [4, 5]
+  ])"});
+
+  // First sort by A, ascending, nulls first to yield rows:
+  // 0, 2, 3, 4, 6, 1, 5
+  // Apply fetch to grab rows 3, 4, 6
+  // Then sort by B, descending, to yield rows 6, 4, 3
+
+  auto output_table = TableFromJSON(test_schema, {R"([
+    [4, 5],
+    [3, 4],
+    [null, null]
+  ])"});
+
+  NamedTableProvider table_provider = [&](const std::vector<std::string>& names,
+                                          const Schema&) {
+    std::shared_ptr<acero::ExecNodeOptions> options =
+        std::make_shared<acero::TableSourceNodeOptions>(input_table);
+    return acero::Declaration("table_source", {}, options, "mock_source");
+  };
+
+  ConversionOptions conversion_options;
+  conversion_options.named_table_provider = std::move(table_provider);
+
+  CheckRoundTripResult(std::move(output_table), buf, {}, conversion_options);
+}
+
 TEST(Substrait, PlanWithExtension) {
   // This demos an extension relation
   std::string substrait_json = R"({


### PR DESCRIPTION
This does not support the clustered sort direction, custom sort functions, or complex (non-reference) expressions as sort keys.
* Closes: #32763