### PR TITLE
GH-32950: [Go] REE Benchmarks

### DIFF
--- a/go/arrow/compute/internal/kernels/vector_run_end_encode.go
+++ b/go/arrow/compute/internal/kernels/vector_run_end_encode.go
@@ -92,8 +92,8 @@ func (re *runEndEncodeLoopFixedWidth[R, V]) WriteEncodedRuns(out *exec.ExecResul
 	readOffset++
 
 	var writeOffset int64
+	var value V
 	for readOffset < re.inputOffset+re.inputLen {
-		var value V
 		valid := re.readValue(re.inputValidity, re.inputValues, readOffset, &value)
 		if valid != curRunValid || value != currentRun {
 			// close the current run by writing it out
@@ -122,8 +122,8 @@ func (re *runEndEncodeLoopFixedWidth[R, V]) CountNumberOfRuns() (numValid, numOu
 	}
 	numOutput = 1
 
+	var value V
 	for offset < re.inputOffset+re.inputLen {
-		var value V
 		valid := re.readValue(re.inputValidity, re.inputValues, offset, &value)
 		offset++
 		// new run

--- a/go/arrow/compute/vector_run_end_test.go
+++ b/go/arrow/compute/vector_run_end_test.go
@@ -20,6 +20,8 @@ package compute_test
 
 import (
 	"context"
+	"fmt"
+	"math"
 	"strings"
 	"testing"
 
@@ -27,6 +29,8 @@ import (
 	"github.com/apache/arrow/go/v12/arrow/array"
 	"github.com/apache/arrow/go/v12/arrow/bitutil"
 	"github.com/apache/arrow/go/v12/arrow/compute"
+	"github.com/apache/arrow/go/v12/arrow/compute/internal/exec"
+	"github.com/apache/arrow/go/v12/arrow/internal/testing/gen"
 	"github.com/apache/arrow/go/v12/arrow/memory"
 	"github.com/stretchr/testify/suite"
 )
@@ -290,6 +294,128 @@ func TestRunEndFunctions(t *testing.T) {
 						valueType:  tt.valueType,
 						jsonData:   tt.data,
 					})
+				})
+			}
+		})
+	}
+}
+
+func benchRunEndEncode(b *testing.B, sz int, nullProb float64, runEndType, valueType arrow.DataType) {
+	b.Run("encode", func(b *testing.B) {
+		var (
+			mem = memory.NewCheckedAllocator(memory.DefaultAllocator)
+			rng = gen.NewRandomArrayGenerator(seed, mem)
+		)
+
+		values := rng.ArrayOf(valueType.ID(), int64(sz), nullProb)
+		b.Cleanup(func() {
+			values.Release()
+		})
+
+		var (
+			res   compute.Datum
+			err   error
+			ctx   = compute.WithAllocator(context.Background(), mem)
+			input = &compute.ArrayDatum{Value: values.Data()}
+			opts  = compute.RunEndEncodeOptions{RunEndType: runEndType}
+
+			byts int64
+		)
+
+		for _, buf := range values.Data().Buffers() {
+			if buf != nil {
+				byts += int64(buf.Len())
+			}
+		}
+
+		b.SetBytes(byts)
+		b.ResetTimer()
+		for n := 0; n < b.N; n++ {
+			res, err = compute.RunEndEncode(ctx, opts, input)
+			b.StopTimer()
+			if err != nil {
+				b.Fatal(err)
+			}
+			res.Release()
+			b.StartTimer()
+		}
+	})
+}
+
+func benchRunEndDecode(b *testing.B, sz int, nullProb float64, runEndType, valueType arrow.DataType) {
+	b.Run("decode", func(b *testing.B) {
+		var (
+			mem = memory.NewCheckedAllocator(memory.DefaultAllocator)
+			rng = gen.NewRandomArrayGenerator(seed, mem)
+		)
+
+		values := rng.ArrayOf(valueType.ID(), int64(sz), nullProb)
+		b.Cleanup(func() {
+			values.Release()
+		})
+
+		var (
+			res        compute.Datum
+			ctx        = compute.WithAllocator(context.Background(), mem)
+			opts       = compute.RunEndEncodeOptions{RunEndType: runEndType}
+			input, err = compute.RunEndEncode(ctx, opts, &compute.ArrayDatum{Value: values.Data()})
+			byts       int64
+		)
+
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		for _, buf := range values.Data().Buffers() {
+			if buf != nil {
+				byts += int64(buf.Len())
+			}
+		}
+
+		b.SetBytes(byts)
+		b.ResetTimer()
+		for n := 0; n < b.N; n++ {
+			res, err = compute.RunEndDecode(ctx, input)
+			b.StopTimer()
+			if err != nil {
+				b.Fatal(err)
+			}
+			res.Release()
+			b.StartTimer()
+		}
+	})
+}
+
+func BenchmarkRunEndKernels(b *testing.B) {
+	args := []struct {
+		sz       int
+		nullProb float64
+	}{
+		{CpuCacheSizes[2], 0},
+		{CpuCacheSizes[2], 0.5},
+		{CpuCacheSizes[2], 1},
+	}
+
+	runEnds := []struct {
+		dt     arrow.DataType
+		maxLen int
+	}{
+		{arrow.PrimitiveTypes.Int16, math.MaxInt16},
+		{arrow.PrimitiveTypes.Int32, math.MaxInt32},
+		{arrow.PrimitiveTypes.Int64, math.MaxInt64},
+	}
+
+	for _, a := range args {
+		b.Run(fmt.Sprintf("nullprob=%.1f", a.nullProb), func(b *testing.B) {
+			for _, runEndType := range runEnds {
+				sz := exec.Min(a.sz, runEndType.maxLen)
+				b.Run("run_ends_type="+runEndType.dt.String(), func(b *testing.B) {
+					for _, valType := range append(numericTypes, arrow.BinaryTypes.String, arrow.FixedWidthTypes.Boolean) {
+						b.Run("value_type="+valType.String(), func(b *testing.B) {
+							benchRunEndEncode(b, sz, a.nullProb, runEndType.dt, valType)
+							benchRunEndDecode(b, sz, a.nullProb, runEndType.dt, valType)
+						})
+					}
 				})
 			}
 		})

--- a/go/arrow/internal/testing/gen/random_array_gen.go
+++ b/go/arrow/internal/testing/gen/random_array_gen.go
@@ -126,7 +126,7 @@ func (r *RandomArrayGenerator) Uint8(size int64, min, max uint8, prob float64) a
 	dist := rand.New(rand.NewSource(r.seed + r.extra))
 	out := arrow.Uint8Traits.CastFromBytes(buffers[1].Bytes())
 	for i := int64(0); i < size; i++ {
-		out[i] = uint8(dist.Intn(int(max-min+1))) + min
+		out[i] = uint8(dist.Intn(int(max)-int(min)+1)) + min
 	}
 
 	data := array.NewData(arrow.PrimitiveTypes.Uint8, int(size), buffers, nil, int(nullcount), 0)
@@ -144,7 +144,7 @@ func (r *RandomArrayGenerator) Int16(size int64, min, max int16, prob float64) a
 	dist := rand.New(rand.NewSource(r.seed + r.extra))
 	out := arrow.Int16Traits.CastFromBytes(buffers[1].Bytes())
 	for i := int64(0); i < size; i++ {
-		out[i] = int16(dist.Intn(int(max-min+1))) + min
+		out[i] = int16(dist.Intn(int(max)-int(min)+1)) + min
 	}
 
 	data := array.NewData(arrow.PrimitiveTypes.Int16, int(size), buffers, nil, int(nullcount), 0)
@@ -162,7 +162,7 @@ func (r *RandomArrayGenerator) Uint16(size int64, min, max uint16, prob float64)
 	dist := rand.New(rand.NewSource(r.seed + r.extra))
 	out := arrow.Uint16Traits.CastFromBytes(buffers[1].Bytes())
 	for i := int64(0); i < size; i++ {
-		out[i] = uint16(dist.Intn(int(max-min+1))) + min
+		out[i] = uint16(dist.Intn(int(max)-int(min)+1)) + min
 	}
 
 	data := array.NewData(arrow.PrimitiveTypes.Uint16, int(size), buffers, nil, int(nullcount), 0)
@@ -180,7 +180,7 @@ func (r *RandomArrayGenerator) Int32(size int64, min, max int32, prob float64) a
 	dist := rand.New(rand.NewSource(r.seed + r.extra))
 	out := arrow.Int32Traits.CastFromBytes(buffers[1].Bytes())
 	for i := int64(0); i < size; i++ {
-		out[i] = dist.Int31n(max-min+1) + min
+		out[i] = int32(dist.Intn(int(max)-int(min)+1)) + min
 	}
 
 	data := array.NewData(arrow.PrimitiveTypes.Int32, int(size), buffers, nil, int(nullcount), 0)
@@ -198,7 +198,7 @@ func (r *RandomArrayGenerator) Uint32(size int64, min, max uint32, prob float64)
 	dist := rand.New(rand.NewSource(r.seed + r.extra))
 	out := arrow.Uint32Traits.CastFromBytes(buffers[1].Bytes())
 	for i := int64(0); i < size; i++ {
-		out[i] = uint32(dist.Uint64n(uint64(max-min+1))) + min
+		out[i] = uint32(dist.Uint64n(uint64(max)-uint64(min)+1)) + min
 	}
 
 	data := array.NewData(arrow.PrimitiveTypes.Uint32, int(size), buffers, nil, int(nullcount), 0)
@@ -239,8 +239,14 @@ func (r *RandomArrayGenerator) Uint64(size int64, min, max uint64, prob float64)
 	r.extra++
 	dist := rand.New(rand.NewSource(r.seed + r.extra))
 	out := arrow.Uint64Traits.CastFromBytes(buffers[1].Bytes())
-	for i := int64(0); i < size; i++ {
-		out[i] = dist.Uint64n(max-min+1) + min
+	if max == math.MaxUint64 {
+		for i := int64(0); i < size; i++ {
+			out[i] = dist.Uint64() + min
+		}
+	} else {
+		for i := int64(0); i < size; i++ {
+			out[i] = dist.Uint64n(max-min+1) + min
+		}
 	}
 
 	data := array.NewData(arrow.PrimitiveTypes.Uint64, int(size), buffers, nil, int(nullcount), 0)
@@ -372,6 +378,8 @@ func (r *RandomArrayGenerator) Numeric(dt arrow.Type, size int64, min, max int64
 
 func (r *RandomArrayGenerator) ArrayOf(dt arrow.Type, size int64, nullprob float64) arrow.Array {
 	switch dt {
+	case arrow.BOOL:
+		return r.Boolean(size, 0.50, nullprob)
 	case arrow.STRING:
 		return r.String(size, 0, 20, nullprob)
 	case arrow.LARGE_STRING:


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
Adding benchmarks for `run_end_encode` and `run_end_decode` to track and hopefully improve the performance of these kernels.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

* Closes: #32950