### PR TITLE
GH-34667: [C++][Parquet] Test DeltaLengthByteArrayDecoder with invalid inputs

### DIFF
--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -2708,7 +2708,7 @@ class DeltaLengthByteArrayDecoder : public DecoderImpl,
 
   void SetData(int num_values, const uint8_t* data, int len) override {
     num_values_ = num_values;
-    if (len == 0) {
+    if (ARROW_PREDICT_FALSE(len <= 0)) {
       if (num_values > 0) {
         throw ParquetException(
             "Delta length byte array page was empty, but expected {num_values} values.");

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -2708,7 +2708,14 @@ class DeltaLengthByteArrayDecoder : public DecoderImpl,
 
   void SetData(int num_values, const uint8_t* data, int len) override {
     num_values_ = num_values;
-    if (len == 0) return;
+    if (len == 0) {
+      if (num_values > 0) {
+        throw ParquetException(
+            "Delta length byte array page was empty, but expected {num_values} values.");
+      }
+      num_valid_values_ = 0;
+      return;
+    }
     decoder_ = std::make_shared<::arrow::bit_util::BitReader>(data, len);
     DecodeLengths();
   }
@@ -2723,6 +2730,7 @@ class DeltaLengthByteArrayDecoder : public DecoderImpl,
     // Decode up to `max_values` strings into an internal buffer
     // and reference them into `buffer`.
     max_values = std::min(max_values, num_valid_values_);
+    DCHECK_GE(max_values, 0);
     if (max_values == 0) {
       return 0;
     }

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -2708,10 +2708,6 @@ class DeltaLengthByteArrayDecoder : public DecoderImpl,
 
   void SetData(int num_values, const uint8_t* data, int len) override {
     num_values_ = num_values;
-    if (ARROW_PREDICT_FALSE(len <= 0)) {
-      throw ParquetException(
-          "Delta length byte array page was missing header for lengths.");
-    }
     decoder_ = std::make_shared<::arrow::bit_util::BitReader>(data, len);
     DecodeLengths();
   }

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -2709,12 +2709,8 @@ class DeltaLengthByteArrayDecoder : public DecoderImpl,
   void SetData(int num_values, const uint8_t* data, int len) override {
     num_values_ = num_values;
     if (ARROW_PREDICT_FALSE(len <= 0)) {
-      if (num_values > 0) {
-        throw ParquetException(
-            "Delta length byte array page was empty, but expected {num_values} values.");
-      }
-      num_valid_values_ = 0;
-      return;
+      throw ParquetException(
+          "Delta length byte array page was missing header for lengths.");
     }
     decoder_ = std::make_shared<::arrow::bit_util::BitReader>(data, len);
     DecodeLengths();

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -1639,6 +1639,79 @@ TYPED_TEST(TestDeltaLengthByteArrayEncoding, BasicRoundTrip) {
       /*null_probability*/ 0.1));
 }
 
+std::shared_ptr<Buffer> DeltaEncode(std::vector<int32_t> lengths) {
+  auto encoder = MakeTypedEncoder<Int32Type>(Encoding::DELTA_BINARY_PACKED);
+  encoder->Put(lengths.data(), static_cast<int>(lengths.size()));
+  return encoder->FlushValues();
+}
+
+TEST(TestDeltaLengthByteArrayEncoding, AdHocRoundTrip) {
+  const std::shared_ptr<::arrow::Array> cases[] = {
+      ::arrow::ArrayFromJSON(::arrow::utf8(), R"([])"),
+      ::arrow::ArrayFromJSON(::arrow::utf8(), R"(["abc", "de", ""])"),
+      ::arrow::ArrayFromJSON(::arrow::utf8(), R"(["", "", ""])"),
+      ::arrow::ArrayFromJSON(::arrow::utf8(), R"(["abc", "", "xyz"])")->Slice(1),
+  };
+
+  std::string expected_encoded_vals[] = {
+      DeltaEncode({})->ToString(),
+      DeltaEncode({3, 2, 0})->ToString() + "abcde",
+      DeltaEncode({0, 0, 0})->ToString(),
+      DeltaEncode({0, 3})->ToString() + "xyz",
+  };
+
+  auto encoder = MakeTypedEncoder<ByteArrayType>(Encoding::DELTA_LENGTH_BYTE_ARRAY,
+                                                 /*use_dictionary=*/false);
+  auto decoder = MakeTypedDecoder<ByteArrayType>(Encoding::DELTA_LENGTH_BYTE_ARRAY);
+  for (int i = 0; i < 4; ++i) {
+    auto array = cases[i];
+    auto expected_encoded = expected_encoded_vals[i];
+
+    encoder->Put(*array);
+    std::shared_ptr<Buffer> buffer = encoder->FlushValues();
+
+    ASSERT_EQ(expected_encoded, buffer->ToString());
+
+    int num_values = static_cast<int>(array->length() - array->null_count());
+    decoder->SetData(num_values, buffer->data(), static_cast<int>(buffer->size()));
+
+    typename EncodingTraits<ByteArrayType>::Accumulator acc;
+    acc.builder.reset(new ::arrow::StringBuilder);
+
+    int values_decoded = decoder->DecodeArrow(num_values, 0, nullptr, 0, &acc);
+    ASSERT_EQ(values_decoded, num_values);
+
+    std::shared_ptr<::arrow::Array> roundtripped_array;
+    ASSERT_OK(acc.builder->Finish(&roundtripped_array));
+    ASSERT_ARRAYS_EQUAL(*array, *roundtripped_array);
+  }
+}
+
+TEST(DeltaLengthByteArrayEncoding, RejectBadBuffer) {
+  auto decoder = MakeTypedDecoder<ByteArrayType>(Encoding::DELTA_LENGTH_BYTE_ARRAY);
+
+  Buffer empty_buffer = Buffer("");
+  ASSERT_THROW(decoder->SetData(10, empty_buffer.data(), 0), ParquetException);
+
+  typename EncodingTraits<ByteArrayType>::Accumulator acc;
+  acc.builder.reset(new ::arrow::StringBuilder);
+
+  // buffer only has lengths
+  std::shared_ptr<Buffer> buffer = DeltaEncode({3, 2, 0});
+  decoder->SetData(3, buffer->data(), static_cast<int>(buffer->size()));
+  acc.builder.reset(new ::arrow::StringBuilder);
+  ASSERT_THROW(decoder->DecodeArrow(3, 0, nullptr, 0, &acc), ParquetException);
+
+  // bytes are too short for lengths
+  std::shared_ptr<Buffer> short_buffer =
+      ::arrow::ConcatenateBuffers(
+          {DeltaEncode({2, 4, 6}), std::make_shared<Buffer>("short")})
+          .ValueOrDie();
+  decoder->SetData(3, short_buffer->data(), static_cast<int>(short_buffer->size()));
+  acc.builder.reset(new ::arrow::StringBuilder);
+  ASSERT_THROW(decoder->DecodeArrow(3, 0, nullptr, 0, &acc), ParquetException);
+}
+
 std::shared_ptr<::arrow::Array> CastBinaryTypesHelper(
     std::shared_ptr<::arrow::Array> result, std::shared_ptr<::arrow::DataType> type) {
   if (::arrow::is_large_binary_like(type->id())) {
@@ -1759,12 +1832,10 @@ TEST(DeltaLengthByteArrayEncodingAdHoc, ArrowDirectPut) {
   CheckEncode(::arrow::ArrayFromJSON(::arrow::binary(), values), lengths);
   CheckEncode(::arrow::ArrayFromJSON(::arrow::large_binary(), values), lengths);
 
-  const uint8_t data[] = {
-      0x80, 0x01, 0x04, 0x04, 0x0a, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00,
-      0x00, 0x00, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x57, 0x6f, 0x72, 0x6c, 0x64,
-      0x46, 0x6f, 0x6f, 0x62, 0x61, 0x72, 0x41, 0x44, 0x42, 0x43, 0x45, 0x46,
-  };
-  auto encoded = Buffer::Wrap(data, sizeof(data));
+  auto encoded =
+      ::arrow::ConcatenateBuffers(
+          {DeltaEncode({5, 5, 6, 6}), std::make_shared<Buffer>("HelloWorldFoobarADBCEF")})
+          .ValueOrDie();
 
   CheckDecode(encoded, ::arrow::ArrayFromJSON(::arrow::utf8(), values));
   CheckDecode(encoded, ::arrow::ArrayFromJSON(::arrow::large_utf8(), values));


### PR DESCRIPTION
### Rationale for this change

We should make sure that we are defensive when it comes to invalid inputs. Otherwise malicious actors might send invalid Parquet files as a way to crash a users service.

### What changes are included in this PR?

Makes sure we reject empty pages by deferring to the DeltaBitPackDecoder to error when the lengths header is missing. Also adds a DCHECK that validates `num_valid_values_` was initialized (it wasn't when `len = 0`). Also adds a few more general tests cases for the encoding, covering empty arrays and empty strings.

### Are these changes tested?

Yes, several unit tests have been added.

### Are there any user-facing changes?

**This PR contains a "Critical Fix".**
* Closes: #34667