### PR TITLE
GH-34670: [Packaging][C++] Add support for customizing GDB plugin install directory

### DIFF
--- a/cpp/cmake_modules/DefineOptions.cmake
+++ b/cpp/cmake_modules/DefineOptions.cmake
@@ -615,9 +615,9 @@ that have not been built"
                 OFF)
 
   define_option_string(ARROW_GDB_INSTALL_DIR
-                       "Use a custom install directory for GDB plugin. \
-In general, you don't need to specify this because the default \
-(CMAKE_INSTALL_FULL_BINDIR on Windows, CMAKE_INSTALL_FULL_LIBDIR otherwise) \
+                       "Use a custom install directory for GDB plugin.;\
+In general, you don't need to specify this because the default;\
+(CMAKE_INSTALL_FULL_BINDIR on Windows, CMAKE_INSTALL_FULL_LIBDIR otherwise);\
 is reasonable."
                        "")
 

--- a/cpp/cmake_modules/DefineOptions.cmake
+++ b/cpp/cmake_modules/DefineOptions.cmake
@@ -614,6 +614,13 @@ advised that if this is enabled 'install' will fail silently on components;\
 that have not been built"
                 OFF)
 
+  define_option_string(ARROW_GDB_INSTALL_DIR
+                       "Use a custom install directory for GDB plugin. \
+In general, you don't need to specify this because the default \
+(CMAKE_INSTALL_FULL_BINDIR on Windows, CMAKE_INSTALL_FULL_LIBDIR otherwise) \
+is reasonable."
+                       "")
+
   option(ARROW_BUILD_CONFIG_SUMMARY_JSON "Summarize build configuration in a JSON file"
          ON)
 

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -659,20 +659,27 @@ add_arrow_lib(arrow
 # So it's disabled for now.
 if(ARROW_BUILD_SHARED AND NOT WIN32)
   configure_file(libarrow_gdb.py.in "${CMAKE_CURRENT_BINARY_DIR}/libarrow_gdb.py" @ONLY)
+  if(NOT ARROW_GDB_INSTALL_DIR)
+    if(WIN32)
+      set(ARROW_GDB_INSTALL_DIR ${CMAKE_INSTALL_FULL_BINDIR})
+    else()
+      set(ARROW_GDB_INSTALL_DIR ${CMAKE_INSTALL_FULL_LIBDIR})
+    endif()
+  endif()
   set(ARROW_GDB_AUTO_LOAD_LIBARROW_GDB_INSTALL FALSE)
   if(WIN32)
     find_program(cygpath "cygpath")
     if(cygpath)
-      execute_process(COMMAND cygpath "${CMAKE_INSTALL_FULL_BINDIR}"
-                      OUTPUT_VARIABLE MSYS2_CMAKE_INSTALL_FULL_BINDIR
+      execute_process(COMMAND cygpath "${ARROW_GDB_INSTALL_DIR}"
+                      OUTPUT_VARIABLE MSYS2_ARROW_GDB_INSTALL_DIR
                       OUTPUT_STRIP_TRAILING_WHITESPACE)
       set(ARROW_GDB_AUTO_LOAD_LIBARROW_GDB_DIR
-          "${ARROW_GDB_AUTO_LOAD_DIR}${MSYS2_CMAKE_INSTALL_FULL_BINDIR}")
+          "${ARROW_GDB_AUTO_LOAD_DIR}${MSYS2_ARROW_GDB_INSTALL_DIR}")
       set(ARROW_GDB_AUTO_LOAD_LIBARROW_GDB_INSTALL TRUE)
     endif()
   else()
     set(ARROW_GDB_AUTO_LOAD_LIBARROW_GDB_DIR
-        "${ARROW_GDB_AUTO_LOAD_DIR}/${CMAKE_INSTALL_FULL_LIBDIR}")
+        "${ARROW_GDB_AUTO_LOAD_DIR}/${ARROW_GDB_INSTALL_DIR}")
     set(ARROW_GDB_AUTO_LOAD_LIBARROW_GDB_INSTALL TRUE)
   endif()
   if(ARROW_GDB_AUTO_LOAD_LIBARROW_GDB_INSTALL)


### PR DESCRIPTION
### Rationale for this change

It's for conda package. We can't determine the final GDB plugin path on building. We can adjust the path by replacing a placeholder on installing. 

### What changes are included in this PR?

Conda package can specify a placeholder for GDB plugin path.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #34670