### PR TITLE
GH-34638: [C++][Docs] Add documentation for minimal build flags

### DIFF
--- a/docs/source/developers/cpp/building.rst
+++ b/docs/source/developers/cpp/building.rst
@@ -317,7 +317,7 @@ several optional system components which you can opt into building by passing
 boolean flags to ``cmake``.
 
 * ``-DARROW_BUILD_UTILITIES=ON`` : Build Arrow commandline utilities
-* ``-DARROW_COMPUTE=ON``: Computational kernel functions and other support
+* ``-DARROW_COMPUTE=ON``: Build all computational kernel functions
 * ``-DARROW_CSV=ON``: CSV reader module
 * ``-DARROW_CUDA=ON``: CUDA integration for GPU development. Depends on NVIDIA
   CUDA toolkit. The CUDA toolchain used to build the library can be customized
@@ -368,6 +368,19 @@ Some features of the core Arrow shared library can be switched off for improved
 build times if they are not required for your application:
 
 * ``-DARROW_IPC=ON``: build the IPC extensions
+
+.. note::
+   If your use-case is limited to reading/writing Arrow data then the default
+   options should be sufficient. However, if you wish to build any tests/benchmarks
+   then ``ARROW_JSON`` is also required (it will be enabled automatically).
+   If extended format support is desired then adding ``ARROW_PARQUET``, ``ARROW_CSV``,
+    ``ARROW_JSON``, or ``ARROW_ORC`` shouldn't enable any additional components.
+
+.. note::
+   In general, it's a good idea to enable ``ARROW_COMPUTE`` if you anticipate using
+   any compute kernels beyond ``cast``. While there are (as of 12.0.0) a handful of
+   additional kernels built in by default, this list may change in the future as it's
+   partly based on kernel usage in the current format implementations.
 
 .. warning::
    Plasma is deprecated as of Arrow 10.0.0, and will be removed in 12.0.0 or so.


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

There's an ongoing effort to support smaller builds of Arrow C++ for simple format integration so explicitly documenting the necessary flags would be useful. Also, some recent changes to the build system may require disclosure.

### What changes are included in this PR?

Adds documentation to `cpp/building.rst` regarding:
- Minimal cmake flags for basic format support
- Recent changes to `ARROW_COMPUTE` and how compute kernels are included in builds.

### Are these changes tested?

N/A

### Are there any user-facing changes?

N/A
* Closes: #34638