### PR TITLE
MINOR: [Go][CI] Increase Go benchmark timeout

### DIFF
--- a/ci/scripts/go_bench.sh
+++ b/ci/scripts/go_bench.sh
@@ -41,7 +41,7 @@ pushd ${source_dir}
 # lots of benchmarks, they can take a while
 # the timeout is for *ALL* benchmarks together,
 # not per benchmark
-go test -bench=. -benchmem -timeout 20m -run=^$ ./... | tee bench_stat.dat
+go test -bench=. -benchmem -timeout 40m -run=^$ ./... | tee bench_stat.dat
 
 popd
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
The addition of more Go benchmarks for the RunEndEncoding/Decoding pushed the time taken for the `compute` module's benchmarks over the 20m timeout that we were using for the script, but only on one of the runs (other runs finished just fine but very close to the timeout). So I'm increasing the timeout passed to the `go test -bench` command to avoid it failing.
