### PR TITLE
GH-34687: [CI][Python] Create job to remove old nightly wheels from gemfury

### DIFF
--- a/ci/scripts/gemfury_clean.rb
+++ b/ci/scripts/gemfury_clean.rb
@@ -1,0 +1,42 @@
+#!/usr/bin/env ruby
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Clean old releases from Gemfury.
+
+require "gemfury"
+
+client = Gemfury::Client.new(user_api_key: ENV["GEMFURY_API_TOKEN"])
+
+client.list.each do |artifact|
+  puts artifact["name"]
+  versions = client.versions(artifact["name"])
+  versions.sort_by! { |v| v["created_at"] }
+
+  # Keep all versions uploaded within 90 days of the last uploaded version
+  cutoff = DateTime.parse(versions.last['created_at']) - 90.0
+
+  versions.each do |version|
+    time = DateTime.parse(version['created_at'])
+    if time < cutoff
+      client.yank_version(artifact["name"], version["version"])
+      puts "Yanked #{artifact['name']} #{version['version']} (created #{version['created_at']})"
+    else
+      puts "Kept #{artifact['name']} #{version['version']} (created #{version['created_at']})"
+    end
+  end
+end

--- a/dev/tasks/python-wheels/github.clean.yml
+++ b/dev/tasks/python-wheels/github.clean.yml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+{% import 'macros.jinja' as macros with context %}
+
+{{ macros.github_header() }}
+
+jobs:
+  build:
+    name: "Clean old wheels"
+    runs-on: ubuntu-latest
+    steps:
+      {{ macros.github_checkout_arrow()|indent }}
+
+      - name: Clean old wheels
+        shell: bash
+        run: |
+          gem install --user-install gemfury
+          ruby ./ci/scripts/gemfury_clean.rb
+    env:
+      GEMFURY_API_TOKEN: {{ '${{ secrets.CROSSBOW_GEMFURY_TOKEN }}' }}

--- a/dev/tasks/python-wheels/github.clean.yml
+++ b/dev/tasks/python-wheels/github.clean.yml
@@ -27,9 +27,9 @@ jobs:
       {{ macros.github_checkout_arrow()|indent }}
 
       - name: Clean old wheels
+        env:
+          GEMFURY_API_TOKEN: {{ '${{ secrets.CROSSBOW_GEMFURY_API_TOKEN }}' }}
         shell: bash
         run: |
           gem install --user-install gemfury
           ruby ./ci/scripts/gemfury_clean.rb
-    env:
-      GEMFURY_API_TOKEN: {{ '${{ secrets.CROSSBOW_GEMFURY_API_TOKEN }}' }}

--- a/dev/tasks/python-wheels/github.clean.yml
+++ b/dev/tasks/python-wheels/github.clean.yml
@@ -32,4 +32,4 @@ jobs:
           gem install --user-install gemfury
           ruby ./ci/scripts/gemfury_clean.rb
     env:
-      GEMFURY_API_TOKEN: {{ '${{ secrets.CROSSBOW_GEMFURY_TOKEN }}' }}
+      GEMFURY_API_TOKEN: {{ '${{ secrets.CROSSBOW_GEMFURY_API_TOKEN }}' }}

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -444,6 +444,10 @@ tasks:
       - pyarrow-{no_rc_version}-py310(h[a-z0-9]+)_0_cuda.conda
       - pyarrow-{no_rc_version}-py311(h[a-z0-9]+)_0_cuda.conda
 
+  wheel-clean:
+    ci: github
+    template: python-wheels/github.clean.yml
+
 {% for python_version, python_tag, abi_tag in [("3.7", "cp37", "cp37m"),
                                                ("3.8", "cp38", "cp38"),
                                                ("3.9", "cp39", "cp39"),


### PR DESCRIPTION
### Rationale for this change

We haven't been cleaning nightly wheels from gemfury ever.

### What changes are included in this PR?

Add a new job that should clean them. This is mainly reused from the one on arrow-adbc: https://github.com/apache/arrow-adbc/blob/main/ci/scripts/gemfury_clean.rb

### Are these changes tested?

I will trigger via crossbow

### Are there any user-facing changes?

No
* Closes: #34687