### PR TITLE
GH-34603: [Go][Parquet] Problem writing dictionary with empty strings

### DIFF
--- a/go/internal/hashing/xxh3_memo_table.go
+++ b/go/internal/hashing/xxh3_memo_table.go
@@ -342,6 +342,11 @@ func (b *BinaryMemoTable) GetOrInsertNull() (idx int, found bool) {
 // helper function to get the offset into the builder data for a given
 // index value.
 func (b *BinaryMemoTable) findOffset(idx int) uintptr {
+	if b.builder.DataLen() == 0 {
+		// only empty strings, short circuit
+		return 0
+	}
+
 	val := b.builder.Value(idx)
 	for len(val) == 0 {
 		idx++

--- a/go/parquet/internal/encoding/byte_array_encoder.go
+++ b/go/parquet/internal/encoding/byte_array_encoder.go
@@ -95,9 +95,6 @@ func (enc *DictByteArrayEncoder) WriteDict(out []byte) {
 // PutByteArray adds a single byte array to buffer, updating the dictionary
 // and encoded size if it's a new value
 func (enc *DictByteArrayEncoder) PutByteArray(in parquet.ByteArray) {
-	if in == nil {
-		in = empty[:]
-	}
 	memoIdx, found, err := enc.memo.GetOrInsert(in)
 	if err != nil {
 		panic(err)

--- a/go/parquet/internal/encoding/decoder.go
+++ b/go/parquet/internal/encoding/decoder.go
@@ -198,8 +198,6 @@ func (d *dictDecoder) DecodeIndicesSpaced(numValues, nullCount int, validBits []
 	return n, nil
 }
 
-var empty = [1]byte{0}
-
 // spacedExpand is used to take a slice of data and utilize the bitmap provided to fill in nulls into the
 // correct slots according to the bitmap in order to produce a fully expanded result slice with nulls
 // in the correct slots.

--- a/go/parquet/internal/encoding/fixed_len_byte_array_encoder.go
+++ b/go/parquet/internal/encoding/fixed_len_byte_array_encoder.go
@@ -84,9 +84,6 @@ func (enc *DictFixedLenByteArrayEncoder) WriteDict(out []byte) {
 // Put writes fixed length values to a dictionary encoded column
 func (enc *DictFixedLenByteArrayEncoder) Put(in []parquet.FixedLenByteArray) {
 	for _, v := range in {
-		if v == nil {
-			v = empty[:]
-		}
 		memoIdx, found, err := enc.memo.GetOrInsert(v)
 		if err != nil {
 			panic(err)

--- a/go/parquet/pqarrow/encode_dictionary_test.go
+++ b/go/parquet/pqarrow/encode_dictionary_test.go
@@ -103,7 +103,7 @@ func (ad *ArrowWriteDictionarySuite) TestStatisticsWithFallback() {
 	}
 
 	testIndices := []arrow.Array{
-        // ["b", null, "a", "b", null, "a"]
+		// ["b", null, "a", "b", null, "a"]
 		ad.fromJSON(mem, arrow.PrimitiveTypes.Int32, `[0, null, 3, 0, null, 3]`),
 		// ["b", "c", null, "b", "c", null]
 		ad.fromJSON(mem, arrow.PrimitiveTypes.Int32, `[0, 1, null, 0, 1, null]`),
@@ -703,4 +703,45 @@ func TestArrowWriteNestedSubfieldDictionary(t *testing.T) {
 	defer actual.Release()
 
 	assert.Truef(t, array.TableEqual(tbl, actual), "expected: %s\ngot: %s", tbl, actual)
+}
+
+func TestDictOfEmptyStringsRoundtrip(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "reserved1", Type: arrow.BinaryTypes.String, Nullable: true},
+	}, nil)
+
+	bldr := array.NewStringBuilder(mem)
+	defer bldr.Release()
+
+	for i := 0; i < 6; i++ {
+		bldr.AppendEmptyValue()
+	}
+
+	arr := bldr.NewArray()
+	defer arr.Release()
+	col1 := arrow.NewColumnFromArr(schema.Field(0), arr)
+	defer col1.Release()
+	tbl := array.NewTable(schema, []arrow.Column{col1}, 6)
+	defer tbl.Release()
+
+	var buf bytes.Buffer
+	require.NoError(t, pqarrow.WriteTable(tbl, &buf, 6,
+		parquet.NewWriterProperties(parquet.WithDictionaryDefault(true)),
+		pqarrow.NewArrowWriterProperties()))
+
+	result, err := pqarrow.ReadTable(context.Background(), bytes.NewReader(buf.Bytes()), nil, pqarrow.ArrowReadProperties{}, mem)
+	require.NoError(t, err)
+	defer result.Release()
+
+	assert.EqualValues(t, 6, result.NumRows())
+	assert.EqualValues(t, 1, result.NumCols())
+	col := result.Column(0).Data().Chunk(0)
+	assert.Equal(t, arrow.STRING, col.DataType().ID())
+
+	for i := 0; i < 6; i++ {
+		assert.Zero(t, col.(*array.String).Value(i))
+	}
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
Writing a dictionary encoded column consisting of empty strings ended up writing values that consisted of a string with a NUL character in them rather than actually writing an empty string. This fixes that issue and also cleans the code up a little bit in doing so.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### Are these changes tested?
A unit test is added to test for the behavior.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
Users who wrote dictionary ByteArray or FixedLenByteArray columns that contained empty strings will see this fixed when it comes to handling those empty strings rather than having written strings containing a single NUL character (`\x00`). 

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #34603