### PR TITLE
GH-33721: [CI][R] Disable sccache on test-r-install-local macOS

### DIFF
--- a/dev/tasks/r/github.macos-linux.local.yml
+++ b/dev/tasks/r/github.macos-linux.local.yml
@@ -41,7 +41,9 @@ jobs:
         if: contains(matrix.os, 'macOS')
         run: |
           brew install openssl
-          brew install sccache
+          # disable sccache on macos as it timesout for unknown reasons
+          # see GH-33721
+          # brew install sccache
       - name: Configure non-autobrew dependencies (linux)
         if: contains(matrix.os, 'ubuntu')
         run: |
@@ -71,7 +73,7 @@ jobs:
           ARROW_R_DEV: TRUE
         {{ macros.github_set_sccache_envvars()|indent(8)}}
         run: |
-          sccache --start-server
+          sccache --start-server || echo 'sccache not found'
           cd arrow/r
           R CMD INSTALL . --install-tests
       - name: Run the tests


### PR DESCRIPTION
I was unable to diagnose the reason why sccache times out only in the mac build of this job but all attemots to avoid it (like explicitly starting the server) have failed. So for now the best option is to disable it to not hinder the job further.
* Closes: #33721