### PR TITLE
GH-15285: [GLib] Add GArrowMatchSubstringOptions

### DIFF
--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -718,6 +718,23 @@ GArrowRoundToMultipleOptions *
 garrow_round_to_multiple_options_new(void);
 
 
+#define GARROW_TYPE_MATCH_SUBSTRING_OPTIONS     \
+  (garrow_match_substring_options_get_type())
+G_DECLARE_DERIVABLE_TYPE(GArrowMatchSubstringOptions,
+                         garrow_match_substring_options,
+                         GARROW,
+                         MATCH_SUBSTRING_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowMatchSubstringOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_12_0
+GArrowMatchSubstringOptions *
+garrow_match_substring_options_new(void);
+
+
 /**
  * GArrowUTF8NormalizeForm:
  * @GARROW_UTF8_NORMALIZE_FORM_NFC: Normalization Form Canonical Composition.
@@ -819,7 +836,7 @@ struct _GArrowIndexOptionsClass
 
 GARROW_AVAILABLE_IN_12_0
 GArrowIndexOptions *
-garrow_index_options_new(GArrowScalar *value);
+garrow_index_options_new(void);
 
 
 /**

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -151,6 +151,13 @@ arrow::compute::RoundToMultipleOptions *
 garrow_round_to_multiple_options_get_raw(GArrowRoundToMultipleOptions *options);
 
 
+GArrowMatchSubstringOptions *
+garrow_match_substring_options_new_raw(
+  const arrow::compute::MatchSubstringOptions *arrow_options);
+arrow::compute::MatchSubstringOptions *
+garrow_match_substring_options_get_raw(GArrowMatchSubstringOptions *options);
+
+
 GArrowUTF8NormalizeOptions *
 garrow_utf8_normalize_options_new_raw(
   const arrow::compute::Utf8NormalizeOptions *arrow_options);

--- a/c_glib/test/test-index-options.rb
+++ b/c_glib/test/test-index-options.rb
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestIndexOptions < Test::Unit::TestCase
+  def setup
+    @value = Arrow::Int32Scalar.new(29)
+    @options = Arrow::IndexOptions.new
+    @options.value = @value
+  end
+
+  def test_value
+    assert_equal(@value, @options.value)
+    new_value = Arrow::UInt8Scalar.new(1)
+    @options.value = new_value
+    assert_equal(new_value, @options.value)
+  end
+end

--- a/c_glib/test/test-match-substring-options.rb
+++ b/c_glib/test/test-match-substring-options.rb
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestMatchSubstringOptions < Test::Unit::TestCase
+  def setup
+    @options = Arrow::MatchSubstringOptions.new
+  end
+
+  def test_pattern
+    assert_equal("", @options.pattern)
+    @options.pattern = "substring"
+    assert_equal("substring", @options.pattern)
+  end
+
+  def test_ignore_case
+    assert do
+      not @options.ignore_case?
+    end
+    @options.ignore_case = true
+    assert do
+      @options.ignore_case?
+    end
+  end
+end


### PR DESCRIPTION
### Rationale for this change

It's needed for match substring related kernels.

### What changes are included in this PR?

These changes add `GArrowMatchSubstringOptions`.

These changes also includes bug fixes of `GArrowIndexOptions`. Sorry.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #15285