### PR TITLE
GH-34564: [Python][C++] Update code to compile with cython 3

### DIFF
--- a/python/pyarrow/_flight.pyx
+++ b/python/pyarrow/_flight.pyx
@@ -40,7 +40,7 @@ import pyarrow.lib as lib
 cdef CFlightCallOptions DEFAULT_CALL_OPTIONS
 
 
-cdef int check_flight_status(const CStatus& status) nogil except -1:
+cdef int check_flight_status(const CStatus& status) except -1 nogil:
     cdef shared_ptr[FlightStatusDetail] detail
 
     if status.ok():

--- a/python/pyarrow/_plasma.pyx
+++ b/python/pyarrow/_plasma.pyx
@@ -282,7 +282,7 @@ class PlasmaObjectExists(ArrowException):
     pass
 
 
-cdef int plasma_check_status(const CStatus& status) nogil except -1:
+cdef int plasma_check_status(const CStatus& status) except -1 nogil:
     if status.ok():
         return 0
 

--- a/python/pyarrow/error.pxi
+++ b/python/pyarrow/error.pxi
@@ -79,7 +79,7 @@ ArrowIOError = IOError
 
 # This function could be written directly in C++ if we didn't
 # define Arrow-specific subclasses (ArrowInvalid etc.)
-cdef int check_status(const CStatus& status) nogil except -1:
+cdef int check_status(const CStatus& status) except -1 nogil:
     if status.ok():
         return 0
 
@@ -140,7 +140,7 @@ cdef int check_status(const CStatus& status) nogil except -1:
 
 # This is an API function for C++ PyArrow
 cdef api int pyarrow_internal_check_status(const CStatus& status) \
-        nogil except -1:
+        except -1 nogil:
     return check_status(status)
 
 

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1571,7 +1571,7 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
         c_bool unify_dictionaries
 
         CIpcWriteOptions()
-        CIpcWriteOptions(CIpcWriteOptions&&)
+        CIpcWriteOptions(CIpcWriteOptions)
 
         @staticmethod
         CIpcWriteOptions Defaults()
@@ -1777,7 +1777,7 @@ cdef extern from "arrow/csv/api.h" namespace "arrow::csv" nogil:
         function[CInvalidRowHandler] invalid_row_handler
 
         CCSVParseOptions()
-        CCSVParseOptions(CCSVParseOptions&&)
+        CCSVParseOptions(CCSVParseOptions)
 
         @staticmethod
         CCSVParseOptions Defaults()
@@ -1802,7 +1802,7 @@ cdef extern from "arrow/csv/api.h" namespace "arrow::csv" nogil:
         c_bool include_missing_columns
 
         CCSVConvertOptions()
-        CCSVConvertOptions(CCSVConvertOptions&&)
+        CCSVConvertOptions(CCSVConvertOptions)
 
         @staticmethod
         CCSVConvertOptions Defaults()
@@ -1818,7 +1818,7 @@ cdef extern from "arrow/csv/api.h" namespace "arrow::csv" nogil:
         c_bool autogenerate_column_names
 
         CCSVReadOptions()
-        CCSVReadOptions(CCSVReadOptions&&)
+        CCSVReadOptions(CCSVReadOptions)
 
         @staticmethod
         CCSVReadOptions Defaults()
@@ -1833,7 +1833,7 @@ cdef extern from "arrow/csv/api.h" namespace "arrow::csv" nogil:
         CIOContext io_context
 
         CCSVWriteOptions()
-        CCSVWriteOptions(CCSVWriteOptions&&)
+        CCSVWriteOptions(CCSVWriteOptions)
 
         @staticmethod
         CCSVWriteOptions Defaults()
@@ -2193,7 +2193,7 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
     cdef cppclass CCastOptions" arrow::compute::CastOptions"(CFunctionOptions):
         CCastOptions()
         CCastOptions(c_bool safe)
-        CCastOptions(CCastOptions&& options)
+        CCastOptions(CCastOptions options)
 
         @staticmethod
         CCastOptions Safe()

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -31,8 +31,8 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
 
     cdef cppclass CFileInfo "arrow::fs::FileInfo":
         CFileInfo()
-        CFileInfo(CFileInfo&&)
-        CFileInfo& operator=(CFileInfo&&)
+        CFileInfo(CFileInfo)
+        CFileInfo& operator=(CFileInfo)
         CFileInfo(const CFileInfo&)
         CFileInfo& operator=(const CFileInfo&)
 

--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -64,7 +64,7 @@ cdef extern from "Python.h":
     int PySlice_Check(object)
 
 
-cdef int check_status(const CStatus& status) nogil except -1
+cdef int check_status(const CStatus& status) except -1 nogil
 
 
 cdef class _Weakrefable:

--- a/python/pyarrow/tensor.pxi
+++ b/python/pyarrow/tensor.pxi
@@ -553,7 +553,8 @@ shape: {0.shape}""".format(self)
 
     @property
     def dim_names(self):
-        return tuple(frombytes(x) for x in tuple(self.stp.dim_names()))
+        names_tuple = tuple(self.stp.dim_names())
+        return tuple(frombytes(x) for x in names_tuple)
 
     @property
     def non_zero_length(self):
@@ -784,7 +785,8 @@ shape: {0.shape}""".format(self)
 
     @property
     def dim_names(self):
-        return tuple(frombytes(x) for x in tuple(self.stp.dim_names()))
+        names_tuple = tuple(self.stp.dim_names())
+        return tuple(frombytes(x) for x in names_tuple)
 
     @property
     def non_zero_length(self):
@@ -999,7 +1001,8 @@ shape: {0.shape}""".format(self)
 
     @property
     def dim_names(self):
-        return tuple(frombytes(x) for x in tuple(self.stp.dim_names()))
+        names_tuple = tuple(self.stp.dim_names())
+        return tuple(frombytes(x) for x in names_tuple)
 
     @property
     def non_zero_length(self):
@@ -1191,7 +1194,8 @@ shape: {0.shape}""".format(self)
 
     @property
     def dim_names(self):
-        return tuple(frombytes(x) for x in tuple(self.stp.dim_names()))
+        names_tuple = tuple(self.stp.dim_names())
+        return tuple(frombytes(x) for x in names_tuple)
 
     @property
     def non_zero_length(self):


### PR DESCRIPTION
### Rationale for this change

Cython 3 has some breaking changes:

 * `&&` is no longer supported
 * `nogil` must appear at the end of the line

In addition we had to work around a bug: https://github.com/cython/cython/issues/5333

### What changes are included in this PR?

Minor changes to the cython code.

### Are these changes tested?

No, and they probably should be at some point.  However, Cython 3 has not yet released and so it would be impractical to update our CI to run Cython 3 until that happens.

### Are there any user-facing changes?

No
* Closes: #34564