### PR TITLE
GH-34729: [C++][Python] Enhanced Arrow<->Pandas map/pydict support

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -875,7 +875,7 @@ cdef PandasOptions _convert_pandas_options(dict options):
     elif maps_as_pydicts == "lossy":
         result.maps_as_pydicts = MapConversionType.LOSSY
     elif maps_as_pydicts == "strict":
-        result.maps_as_pydicts = MapConversionType.STRICT
+        result.maps_as_pydicts = MapConversionType.STRICT_
     else:
         raise ValueError(
             "Invalid value for 'maps_as_pydicts': "

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -699,6 +699,7 @@ cdef class _PandasConvertible(_Weakrefable):
             bint safe=True,
             bint split_blocks=False,
             bint self_destruct=False,
+            bint maps_as_pydicts=False,
             types_mapper=None
     ):
         """
@@ -753,6 +754,13 @@ cdef class _PandasConvertible(_Weakrefable):
             Note that you may not see always memory usage improvements. For
             example, if multiple columns share an underlying allocation,
             memory can't be freed until all columns are converted.
+        maps_as_pydicts : bool, default False
+            If true, convert Arrow Map arrays to native Python dicts.
+            This can change the ordering of (key, value) pairs, and will
+            deduplicate multiple keys, resulting in a possible loss of data.
+            The default behavior (false), is to convert Arrow Map arrays to
+            Python list-of-tuples in the same order as the Arrow Map, as in
+            [(key1, value1), (key2, value2), ...]
         types_mapper : function, default None
             A function mapping a pyarrow DataType to a pandas ExtensionDtype.
             This can be used to override the default pandas type for conversion
@@ -832,7 +840,8 @@ cdef class _PandasConvertible(_Weakrefable):
             deduplicate_objects=deduplicate_objects,
             safe=safe,
             split_blocks=split_blocks,
-            self_destruct=self_destruct
+            self_destruct=self_destruct,
+            maps_as_pydicts=maps_as_pydicts
         )
         return self._to_pandas(options, categories=categories,
                                ignore_metadata=ignore_metadata,
@@ -853,6 +862,7 @@ cdef PandasOptions _convert_pandas_options(dict options):
     result.split_blocks = options['split_blocks']
     result.self_destruct = options['self_destruct']
     result.ignore_timezone = os.environ.get('PYARROW_IGNORE_TIMEZONE', False)
+    result.maps_as_pydicts = options['maps_as_pydicts']
     return result
 
 

--- a/python/pyarrow/includes/libarrow_python.pxd
+++ b/python/pyarrow/includes/libarrow_python.pxd
@@ -45,6 +45,13 @@ cdef extern from "arrow/python/api.h" namespace "arrow::py::internal":
         const CMonthDayNanoIntervalScalar& scalar)
 
 
+cdef extern from "arrow/python/arrow_to_pandas.h" namespace "arrow::py::MapConversionType":
+    cdef enum MapConversionType "arrow::py::MapConversionType":
+        DEFAULT,
+        LOSSY,
+        STRICT
+
+
 cdef extern from "arrow/python/api.h" namespace "arrow::py" nogil:
     shared_ptr[CDataType] GetPrimitiveType(Type type)
 
@@ -186,7 +193,7 @@ cdef extern from "arrow/python/api.h" namespace "arrow::py" nogil:
         c_bool safe_cast
         c_bool split_blocks
         c_bool self_destruct
-        c_bool maps_as_pydicts
+        MapConversionType maps_as_pydicts
         c_bool decode_dictionaries
         unordered_set[c_string] categorical_columns
         unordered_set[c_string] extension_columns

--- a/python/pyarrow/includes/libarrow_python.pxd
+++ b/python/pyarrow/includes/libarrow_python.pxd
@@ -49,7 +49,7 @@ cdef extern from "arrow/python/arrow_to_pandas.h" namespace "arrow::py::MapConve
     cdef enum MapConversionType "arrow::py::MapConversionType":
         DEFAULT,
         LOSSY,
-        STRICT
+        STRICT_
 
 
 cdef extern from "arrow/python/api.h" namespace "arrow::py" nogil:

--- a/python/pyarrow/includes/libarrow_python.pxd
+++ b/python/pyarrow/includes/libarrow_python.pxd
@@ -186,6 +186,7 @@ cdef extern from "arrow/python/api.h" namespace "arrow::py" nogil:
         c_bool safe_cast
         c_bool split_blocks
         c_bool self_destruct
+        c_bool maps_as_pydicts
         c_bool decode_dictionaries
         unordered_set[c_string] categorical_columns
         unordered_set[c_string] extension_columns

--- a/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
+++ b/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
@@ -894,7 +894,8 @@ Status CheckMapAsPydictsError() {
     PyErr_Fetch(&type, &value, &traceback);
     std::string message;
     RETURN_NOT_OK(internal::PyObject_StdStringStr(value, &message));
-    message += ". If keys are not hashable, then you must use `maps_as_pydicts=False`";
+    message += ". If keys are not hashable, then you must use the option "
+        "[maps_as_pydicts=False (default)]";
 
     // resets the error
     PyErr_SetString(PyExc_TypeError, message.c_str());
@@ -984,7 +985,7 @@ Status ConvertMap(PandasOptions options, const ChunkedArray& data,
           // returns -1 if there are internal errors around hashing/resizing
           return setitem_result == 0 ?
             Status::OK() :
-            Status::UnknownError(
+            Status::UnknownError("[maps_as_pydicts=True] "
                 "Unexpected failure inserting Arrow (key, value) pair into Python dict"
             );
         },
@@ -999,9 +1000,10 @@ Status ConvertMap(PandasOptions options, const ChunkedArray& data,
         out_values);
 
     if (status.ok() && (total_dict_len < total_raw_len)) {
-      const char* message = "After conversion of Arrow map to pydict, "
-          "detected possible data loss due to duplicate keys. "
-          "Input length is [%lld], total pydict length is [%lld].";
+      const char* message = "[maps_as_pydicts=True] "
+          "After conversion of Arrow maps to pydicts, "
+          "detected data loss due to duplicate keys. "
+          "Original input length is [%lld], total converted pydict length is [%lld].";
       std::array<char, 256> buf;
       std::snprintf(buf.data(), buf.size(), message, total_raw_len, total_dict_len);
       ARROW_LOG(WARNING) << buf.data();

--- a/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
+++ b/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
@@ -994,7 +994,7 @@ Status ConvertMap(PandasOptions options, const ChunkedArray& data,
     bool error_on_duplicate_keys;
     if (options.maps_as_pydicts == MapConversionType::LOSSY) {
       error_on_duplicate_keys = false;
-    } else if (options.maps_as_pydicts == MapConversionType::STRICT) {
+    } else if (options.maps_as_pydicts == MapConversionType::STRICT_) {
       error_on_duplicate_keys = true;
     } else {
       auto val = std::underlying_type_t<MapConversionType>(options.maps_as_pydicts);

--- a/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
+++ b/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
@@ -1030,9 +1030,10 @@ Status ConvertMap(PandasOptions options, const ChunkedArray& data,
         item_arrays,
         out_values);
 
+    ARROW_RETURN_NOT_OK(status);
     // If there were no errors generating the pydicts,
     // then check if we detected any data loss from duplicate keys.
-    return !status.ok() ? status : CheckForDuplicateKeys(error_on_duplicate_keys, total_dict_len, total_raw_len);
+    return CheckForDuplicateKeys(error_on_duplicate_keys, total_dict_len, total_raw_len);
   }
 }
 

--- a/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
+++ b/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
@@ -176,6 +176,7 @@ static inline bool ListTypeSupported(const DataType& type) {
     case Type::DATE32:
     case Type::DATE64:
     case Type::STRUCT:
+    case Type::MAP:
     case Type::TIME32:
     case Type::TIME64:
     case Type::TIMESTAMP:

--- a/python/pyarrow/src/arrow/python/arrow_to_pandas.h
+++ b/python/pyarrow/src/arrow/python/arrow_to_pandas.h
@@ -41,6 +41,12 @@ class Table;
 
 namespace py {
 
+enum class MapConversionType {
+  DEFAULT, // convert arrow maps to assoc lists (list of kev-value tuples) in Pandas
+  LOSSY, // report warnings when lossiness is encountered due to duplicate keys
+  STRICT, // raise a Python exception when lossiness is encountered due to duplicate keys
+};
+
 struct PandasOptions {
   /// arrow::MemoryPool to use for memory allocations
   MemoryPool* pool = default_memory_pool();
@@ -90,13 +96,16 @@ struct PandasOptions {
   /// conversions
   bool self_destruct = false;
 
-  /// \brief If true, convert Arrow Map arrays to native Python dicts.
+  /// \brief The default behavior (DEFAULT), is to convert Arrow Map arrays to
+  /// Python association lists (list-of-tuples) in the same order as the Arrow
+  /// Map, as in [(key1, value1), (key2, value2), ...]
+  /// If LOSSY or STRICT, convert Arrow Map arrays to native Python dicts.
   /// This can change the ordering of (key, value) pairs, and will deduplicate
   /// multiple keys, resulting in a possible loss of data.
-  /// The default behavior (false), is to convert Arrow Map arrays to Python
-  /// list-of-tuples in the same order as the Arrow Map,
-  /// as in [(key1, value1), (key2, value2), ...]
-  bool maps_as_pydicts = false;
+  /// If 'lossy', this key deduplication results in a warning printed
+  /// when detected. If 'strict', this instead results in an exception
+  /// being raised when detected.
+  MapConversionType maps_as_pydicts = MapConversionType::DEFAULT;
 
   // Used internally for nested arrays.
   bool decode_dictionaries = false;

--- a/python/pyarrow/src/arrow/python/arrow_to_pandas.h
+++ b/python/pyarrow/src/arrow/python/arrow_to_pandas.h
@@ -44,7 +44,7 @@ namespace py {
 enum class MapConversionType {
   DEFAULT, // convert arrow maps to assoc lists (list of kev-value tuples) in Pandas
   LOSSY, // report warnings when lossiness is encountered due to duplicate keys
-  STRICT, // raise a Python exception when lossiness is encountered due to duplicate keys
+  STRICT_, // raise a Python exception when lossiness is encountered due to duplicate keys
 };
 
 struct PandasOptions {

--- a/python/pyarrow/src/arrow/python/arrow_to_pandas.h
+++ b/python/pyarrow/src/arrow/python/arrow_to_pandas.h
@@ -90,6 +90,14 @@ struct PandasOptions {
   /// conversions
   bool self_destruct = false;
 
+  /// \brief If true, convert Arrow Map arrays to native Python dicts.
+  /// This can change the ordering of (key, value) pairs, and will deduplicate
+  /// multiple keys, resulting in a possible loss of data.
+  /// The default behavior (false), is to convert Arrow Map arrays to Python
+  /// list-of-tuples in the same order as the Arrow Map,
+  /// as in [(key1, value1), (key2, value2), ...]
+  bool maps_as_pydicts = false;
+
   // Used internally for nested arrays.
   bool decode_dictionaries = false;
 

--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -762,7 +762,7 @@ class PyListConverter : public ListConverter<T, PyConverter, PyConverterTrait> {
       RETURN_NOT_OK(AppendSequence(value));
     } else if (PySet_Check(value) || (Py_TYPE(value) == &PyDictValues_Type)) {
       RETURN_NOT_OK(AppendIterable(value));
-    } else if (PyDict_Check(value) && this->options_.type->id() == Type::MAP) {
+    } else if (PyDict_Check(value) && this->type()->id() == Type::MAP) {
       // Branch to support Python Dict with `map` DataType.
       auto items = PyDict_Items(value);
       OwnedRef item_ref(items);

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -4579,8 +4579,14 @@ def test_does_not_mutate_timedelta_nested():
 
 
 def test_roundtrip_nested_map_table_with_pydicts():
-    schema = pa.schema(
-        [pa.field("a", pa.list_(pa.map_(pa.int8(), pa.struct([pa.field("b", pa.binary())]))))])
+    schema = pa.schema([
+        pa.field(
+            "a",
+            pa.list_(
+                pa.map_(pa.int8(), pa.struct([pa.field("b", pa.binary())]))
+            )
+        )
+    ])
     table = pa.table([[
         [[(1, None)]],
         None,
@@ -4597,7 +4603,11 @@ def test_roundtrip_nested_map_table_with_pydicts():
                                      [(3, {"b": None}), (4, {"b": b"def"})]]]}
     )
     expected_as_pydicts_df = pd.DataFrame(
-        {"a": [[{1: None}], None, [{2: {"b": b"abc"}}, {3: {"b": None}, 4: {"b": b"def"}}]]}
+        {"a": [
+            [{1: None}],
+            None,
+            [{2: {"b": b"abc"}}, {3: {"b": None}, 4: {"b": b"def"}}],
+        ]}
     )
 
     default_df = table.to_pandas()

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -4775,7 +4775,6 @@ def test_roundtrip_map_array_with_pydicts_duplicate_keys():
     expected_series_pydicts = pd.Series([
         {'foo': ['1', '2'], 'bar': ['c', 'd']},
     ])
-    tm.assert_series_equal(series_pydicts, expected_series_pydicts)
     # roundtrip is not possible because of data loss
     assert not maps.equals(pa.Array.from_pandas(series_pydicts, type=ty))
 
@@ -4785,8 +4784,27 @@ def test_roundtrip_map_array_with_pydicts_duplicate_keys():
     expected_series_default = pd.Series([
         [('foo', ['a', 'b']), ('bar', ['c', 'd']), ('foo', ['1', '2'])],
     ])
-    tm.assert_series_equal(series_default, expected_series_default)
     assert maps.equals(pa.Array.from_pandas(series_default, type=ty))
+
+    # custom comparison for compatibility w/ Pandas 1.0.0
+    # would otherwise run:
+    #   tm.assert_series_equal(series_pydicts, expected_series_pydicts)
+    assert len(series_pydicts) == len(expected_series_pydicts)
+    for row1, row2 in zip(series_pydicts, expected_series_pydicts):
+        assert len(row1) == len(row2)
+        for tup1, tup2 in zip(row1.items(), row2.items()):
+            assert tup1[0] == tup2[0]
+            assert np.array_equal(tup1[1], tup2[1])
+
+    # custom comparison for compatibility w/ Pandas 1.0.0
+    # would otherwise run:
+    #   tm.assert_series_equal(series_default, expected_series_default)
+    assert len(series_default) == len(expected_series_default)
+    for row1, row2 in zip(series_default, expected_series_default):
+        assert len(row1) == len(row2)
+        for tup1, tup2 in zip(row1, row2):
+            assert tup1[0] == tup2[0]
+            assert np.array_equal(tup1[1], tup2[1])
 
 
 def test_unhashable_map_keys_with_pydicts():
@@ -4810,4 +4828,13 @@ def test_unhashable_map_keys_with_pydicts():
         [(['a', 'b'], 'foo'), (['c', 'd'], 'bar')],
         [([], 'baz'), (['e'], 'qux'), ([None, 'f'], 'quux'), (['g', 'h'], 'quz')],
     ])
-    tm.assert_series_equal(series, expected_series_default)
+
+    # custom comparison for compatibility w/ Pandas 1.0.0
+    # would otherwise run:
+    #   tm.assert_series_equal(series, expected_series_default)
+    assert len(series) == len(expected_series_default)
+    for row1, row2 in zip(series, expected_series_default):
+        assert len(row1) == len(row2)
+        for tup1, tup2 in zip(row1, row2):
+            assert np.array_equal(tup1[0], tup2[0])
+            assert tup1[1] == tup2[1]

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -2144,7 +2144,7 @@ class TestConvertListTypes:
         offsets = pa.array([0, 2, 5, 6], pa.int32())
         keys = pa.array(['foo', 'bar', 'baz', 'qux', 'quux', 'quz'])
         items = pa.array([['a', 'b'], ['c', 'd'], [], None, [None, 'e'], ['f', 'g']],
-                           pa.list_(pa.string()))
+                         pa.list_(pa.string()))
         maps = pa.MapArray.from_arrays(offsets, keys, items)
         data = pa.ListArray.from_arrays([0, 1, 3], maps)
 
@@ -4579,20 +4579,22 @@ def test_does_not_mutate_timedelta_nested():
 
 
 def test_roundtrip_nested_map_table_with_pydicts():
-    schema = pa.schema([pa.field("a", pa.list_(pa.map_(pa.int8(), pa.struct([pa.field("b", pa.binary())]))))])
+    schema = pa.schema(
+        [pa.field("a", pa.list_(pa.map_(pa.int8(), pa.struct([pa.field("b", pa.binary())]))))])
     table = pa.table([[
-            [[(1, None)]],
-            None,
-            [
-                [(2, {"b": b"abc"})],
-                [(3, {"b": None}), (4, {"b": b"def"})],
-            ]
-        ]],
+        [[(1, None)]],
+        None,
+        [
+            [(2, {"b": b"abc"})],
+            [(3, {"b": None}), (4, {"b": b"def"})],
+        ]
+    ]],
         schema=schema,
     )
 
     expected_default_df = pd.DataFrame(
-        {"a": [[[(1, None)]], None, [[(2, {"b": b"abc"})], [(3, {"b": None}), (4, {"b": b"def"})]]]}
+        {"a": [[[(1, None)]], None, [[(2, {"b": b"abc"})],
+                                     [(3, {"b": None}), (4, {"b": b"def"})]]]}
     )
     expected_as_pydicts_df = pd.DataFrame(
         {"a": [[{1: None}], None, [{2: {"b": b"abc"}}, {3: {"b": None}, 4: {"b": b"def"}}]]}
@@ -4607,5 +4609,5 @@ def test_roundtrip_nested_map_table_with_pydicts():
     table_default_roundtrip = pa.Table.from_pandas(default_df, schema=schema)
     assert table.equals(table_default_roundtrip)
 
-    with pytest.raises(pa.ArrowTypeError):
-        table_as_pydicts_roundtrip = pa.Table.from_pandas(as_pydicts_df, schema=schema)
+    table_as_pydicts_roundtrip = pa.Table.from_pandas(as_pydicts_df, schema=schema)
+    assert table.equals(table_as_pydicts_roundtrip)

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -4669,7 +4669,7 @@ def test_roundtrip_nested_map_table_with_pydicts():
     )
 
     default_df = table.to_pandas()
-    as_pydicts_df = table.to_pandas(maps_as_pydicts=True)
+    as_pydicts_df = table.to_pandas(maps_as_pydicts="strict")
 
     tm.assert_frame_equal(default_df, expected_default_df)
     tm.assert_frame_equal(as_pydicts_df, expected_as_pydicts_df)
@@ -4718,7 +4718,7 @@ def test_roundtrip_nested_map_array_with_pydicts_sliced():
         [],
     ])
 
-    series_pydicts = chunked_array.to_pandas(maps_as_pydicts=True)
+    series_pydicts = chunked_array.to_pandas(maps_as_pydicts="strict")
     expected_series_pydicts = pd.Series([
         [{'foo': ['a', 'b'], 'bar': ['c', 'd']}],
         [{'quz': ['f', 'g']}],
@@ -4732,7 +4732,7 @@ def test_roundtrip_nested_map_array_with_pydicts_sliced():
         [],
     ])
 
-    series_pydicts_sliced = sliced.to_pandas(maps_as_pydicts=True)
+    series_pydicts_sliced = sliced.to_pandas(maps_as_pydicts="strict")
     expected_series_pydicts_sliced = pd.Series([
         [{'quz': ['f', 'g']}],
         [],
@@ -4770,7 +4770,10 @@ def test_roundtrip_map_array_with_pydicts_duplicate_keys():
 
     # ------------------------
     # With maps as pydicts
-    series_pydicts = maps.to_pandas(maps_as_pydicts=True)
+    with pytest.raises(pa.lib.ArrowException):
+        # raises because of duplicate keys
+        maps.to_pandas(maps_as_pydicts="strict")
+    series_pydicts = maps.to_pandas(maps_as_pydicts="lossy")
     # some data loss occurs for duplicate keys
     expected_series_pydicts = pd.Series([
         {'foo': ['1', '2'], 'bar': ['c', 'd']},
@@ -4819,7 +4822,7 @@ def test_unhashable_map_keys_with_pydicts():
     # ------------------------
     # With maps as pydicts
     with pytest.raises(TypeError):
-        maps.to_pandas(maps_as_pydicts=True)
+        maps.to_pandas(maps_as_pydicts="lossy")
 
     # ------------------------
     # With default assoc list of tuples


### PR DESCRIPTION
### Rationale for this change

Explained in issue #34729 

### What changes are included in this PR?

- Add support for list of maps when converting Arrow to Pandas. There doesn't seem to be a strong reason to omit this. Previously it was a hard error as unsupported, due to a bool check.
- Refactor Arrow Map -> Pandas to support two paths: (1) list of tuples, or (2) pydicts
- Add another option in PandasOptions to enable (2), above
- Bugfix in nested pydicts -> Arrow maps. 
- Unit tests

### Are these changes tested?

Unit tests are added in `test_pandas.py`

### Are there any user-facing changes?

- An additional option flag in PandasOptions
- Enable list of maps to Pandas, which was previously disabled
* Closes: #34729