### PR TITLE
GH-34731: [Python] Release GIL when creating RecordBatchReader

### DIFF
--- a/python/pyarrow/_flight.pyx
+++ b/python/pyarrow/_flight.pyx
@@ -1039,7 +1039,9 @@ cdef class _MetadataRecordBatchReader(_Weakrefable, _ReadPandasMixin):
         """
         cdef RecordBatchReader reader
         reader = RecordBatchReader.__new__(RecordBatchReader)
-        reader.reader = GetResultValue(MakeRecordBatchReader(self.reader))
+        with nogil:
+            reader.reader = GetResultValue(MakeRecordBatchReader(self.reader))
+
         return reader
 
 


### PR DESCRIPTION
### Rationale for this change

See #34731

### What changes are included in this PR?

Wrap existing call that creates RBR in `with nogil:` context

### Are these changes tested?

No new tests. 

### Are there any user-facing changes?

No

* Closes: #34731