### PR TITLE
GH-34657: [Go] Move Scalar interface to arrow

### DIFF
--- a/go/arrow/array.go
+++ b/go/arrow/array.go
@@ -23,6 +23,31 @@ import (
 	"github.com/apache/arrow/go/v12/arrow/memory"
 )
 
+// Scalar represents a single value of a specific DataType as opposed to
+// an array.
+//
+// Scalars are useful for passing single value inputs to compute functions
+// (not yet implemented) or for representing individual array elements,
+// (with a non-trivial cost though).
+type Scalar interface {
+	fmt.Stringer
+	// IsValid returns true if the value is non-null, otherwise false.
+	IsValid() bool
+	// The datatype of the value in this scalar
+	DataType() DataType
+	// Performs cheap validation checks, returns nil if successful
+	Validate() error
+	// Perform more expensive validation checks, returns nil if successful
+	ValidateFull() error
+	// Cast the value to the desired DataType (returns an error if unable to do so)
+	// should take semantics into account and modify the value accordingly.
+	CastTo(DataType) (Scalar, error)
+
+	// internal only functions for delegation
+	ValueInterface() interface{}
+	Equals(Scalar) bool
+}
+
 // ArrayData is the underlying memory and metadata of an Arrow array, corresponding
 // to the same-named object in the C++ implementation.
 //
@@ -105,6 +130,9 @@ type Array interface {
 	// IsValid returns true if value at index is not null.
 	// NOTE: IsValid will panic if NullBitmapBytes is not empty and 0 > i ≥ Len.
 	IsValid(i int) bool
+	
+	// GetScalar returns the scalar value at index i.
+	// GetScalar(i int) Scalar
 
 	Data() ArrayData
 

--- a/go/arrow/compute/arithmetic_test.go
+++ b/go/arrow/compute/arithmetic_test.go
@@ -108,7 +108,7 @@ type binaryArithmeticFunc = func(context.Context, compute.ArithmeticOptions, com
 
 type binaryFunc = func(left, right compute.Datum) (compute.Datum, error)
 
-func assertScalarEquals(t *testing.T, expected, actual scalar.Scalar, opt ...scalar.EqualOption) {
+func assertScalarEquals(t *testing.T, expected, actual arrow.Scalar, opt ...scalar.EqualOption) {
 	assert.Truef(t, scalar.ApproxEquals(expected, actual, opt...), "expected: %s\ngot: %s", expected, actual)
 }
 
@@ -218,11 +218,11 @@ func (b *BinaryArithmeticSuite[T]) SetupTest() {
 	b.opts.NoCheckOverflow = false
 }
 
-func (b *BinaryArithmeticSuite[T]) makeNullScalar() scalar.Scalar {
+func (b *BinaryArithmeticSuite[T]) makeNullScalar() arrow.Scalar {
 	return scalar.MakeNullScalar(b.DataType())
 }
 
-func (b *BinaryArithmeticSuite[T]) makeScalar(val T) scalar.Scalar {
+func (b *BinaryArithmeticSuite[T]) makeScalar(val T) arrow.Scalar {
 	return scalar.MakeScalar(val)
 }
 
@@ -242,7 +242,7 @@ func (b *BinaryArithmeticSuite[T]) assertBinopScalarValArr(fn binaryArithmeticFu
 	b.assertBinopScalarArr(fn, left, rhs, expected)
 }
 
-func (b *BinaryArithmeticSuite[T]) assertBinopScalarArr(fn binaryArithmeticFunc, lhs scalar.Scalar, rhs, expected string) {
+func (b *BinaryArithmeticSuite[T]) assertBinopScalarArr(fn binaryArithmeticFunc, lhs arrow.Scalar, rhs, expected string) {
 	right, _, _ := array.FromJSON(b.mem, b.DataType(), strings.NewReader(rhs))
 	defer right.Release()
 	exp, _, _ := array.FromJSON(b.mem, b.DataType(), strings.NewReader(expected))
@@ -254,7 +254,7 @@ func (b *BinaryArithmeticSuite[T]) assertBinopScalarArr(fn binaryArithmeticFunc,
 	assertDatumsEqual(b.T(), &compute.ArrayDatum{Value: exp.Data()}, actual, b.equalOpts, b.scalarEqualOpts)
 }
 
-func (b *BinaryArithmeticSuite[T]) assertBinopArrScalarExpArr(fn binaryArithmeticFunc, lhs string, rhs scalar.Scalar, exp arrow.Array) {
+func (b *BinaryArithmeticSuite[T]) assertBinopArrScalarExpArr(fn binaryArithmeticFunc, lhs string, rhs arrow.Scalar, exp arrow.Array) {
 	left, _, _ := array.FromJSON(b.mem, b.DataType(), strings.NewReader(lhs))
 	defer left.Release()
 
@@ -269,7 +269,7 @@ func (b *BinaryArithmeticSuite[T]) assertBinopArrScalarVal(fn binaryArithmeticFu
 	b.assertBinopArrScalar(fn, lhs, right, expected)
 }
 
-func (b *BinaryArithmeticSuite[T]) assertBinopArrScalar(fn binaryArithmeticFunc, lhs string, rhs scalar.Scalar, expected string) {
+func (b *BinaryArithmeticSuite[T]) assertBinopArrScalar(fn binaryArithmeticFunc, lhs string, rhs arrow.Scalar, expected string) {
 	left, _, _ := array.FromJSON(b.mem, b.DataType(), strings.NewReader(lhs))
 	defer left.Release()
 	exp, _, _ := array.FromJSON(b.mem, b.DataType(), strings.NewReader(expected))
@@ -2436,11 +2436,11 @@ func (*UnaryArithmeticSuite[T, O]) datatype() arrow.DataType {
 	return exec.GetDataType[T]()
 }
 
-func (us *UnaryArithmeticSuite[T, O]) makeNullScalar() scalar.Scalar {
+func (us *UnaryArithmeticSuite[T, O]) makeNullScalar() arrow.Scalar {
 	return scalar.MakeNullScalar(us.datatype())
 }
 
-func (us *UnaryArithmeticSuite[T, O]) makeScalar(v T) scalar.Scalar {
+func (us *UnaryArithmeticSuite[T, O]) makeScalar(v T) arrow.Scalar {
 	return scalar.MakeScalar(v)
 }
 
@@ -2477,7 +2477,7 @@ func (us *UnaryArithmeticSuite[T, O]) assertUnaryOpVals(fn unaryArithmeticFunc[O
 	assertScalarEquals(us.T(), exp, actual.(*compute.ScalarDatum).Value, scalar.WithNaNsEqual(true))
 }
 
-func (us *UnaryArithmeticSuite[T, O]) assertUnaryOpScalars(fn unaryArithmeticFunc[O], arg, exp scalar.Scalar) {
+func (us *UnaryArithmeticSuite[T, O]) assertUnaryOpScalars(fn unaryArithmeticFunc[O], arg, exp arrow.Scalar) {
 	actual, err := fn(us.ctx, us.opts, compute.NewDatum(arg))
 	us.Require().NoError(err)
 	assertScalarEquals(us.T(), exp, actual.(*compute.ScalarDatum).Value, scalar.WithNaNsEqual(true))

--- a/go/arrow/compute/cast_test.go
+++ b/go/arrow/compute/cast_test.go
@@ -41,8 +41,8 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func getScalars(inputs []compute.Datum, idx int) []scalar.Scalar {
-	out := make([]scalar.Scalar, len(inputs))
+func getScalars(inputs []compute.Datum, idx int) []arrow.Scalar {
+	out := make([]arrow.Scalar, len(inputs))
 	for i, in := range inputs {
 		if in.Kind() == compute.KindArray {
 			arr := in.(*compute.ArrayDatum).MakeArray()
@@ -97,7 +97,7 @@ func checkScalarNonRecursive(t *testing.T, funcName string, inputs []compute.Dat
 	assertDatumsEqual(t, expected, out, nil, nil)
 }
 
-func checkScalarWithScalars(t *testing.T, funcName string, inputs []scalar.Scalar, expected scalar.Scalar, opts compute.FunctionOptions) {
+func checkScalarWithScalars(t *testing.T, funcName string, inputs []arrow.Scalar, expected arrow.Scalar, opts compute.FunctionOptions) {
 	datums := getDatums(inputs)
 	defer func() {
 		for _, s := range inputs {

--- a/go/arrow/compute/datum.go
+++ b/go/arrow/compute/datum.go
@@ -100,7 +100,7 @@ func (EmptyDatum) data() any { return nil }
 
 // ScalarDatum contains a scalar value
 type ScalarDatum struct {
-	Value scalar.Scalar
+	Value arrow.Scalar
 }
 
 func (ScalarDatum) Kind() DatumKind         { return KindScalar }
@@ -108,7 +108,7 @@ func (ScalarDatum) Len() int64              { return 1 }
 func (ScalarDatum) Chunks() []arrow.Array   { return nil }
 func (d *ScalarDatum) Type() arrow.DataType { return d.Value.DataType() }
 func (d *ScalarDatum) String() string       { return d.Value.String() }
-func (d *ScalarDatum) ToScalar() (scalar.Scalar, error) {
+func (d *ScalarDatum) ToScalar() (arrow.Scalar, error) {
 	return d.Value, nil
 }
 func (d *ScalarDatum) data() any { return d.Value }
@@ -149,7 +149,7 @@ func (d *ArrayDatum) NullN() int64           { return int64(d.Value.NullN()) }
 func (d *ArrayDatum) String() string         { return fmt.Sprintf("Array:{%s}", d.Value.DataType()) }
 func (d *ArrayDatum) MakeArray() arrow.Array { return array.MakeFromData(d.Value) }
 func (d *ArrayDatum) Chunks() []arrow.Array  { return []arrow.Array{d.MakeArray()} }
-func (d *ArrayDatum) ToScalar() (scalar.Scalar, error) {
+func (d *ArrayDatum) ToScalar() (arrow.Scalar, error) {
 	return scalar.NewListScalarData(d.Value), nil
 }
 func (d *ArrayDatum) Release() {
@@ -248,7 +248,7 @@ func (d *TableDatum) Equals(other Datum) bool {
 // An array.Chunked gets a ChunkedDatum
 // An array.Record gets a RecordDatum
 // an array.Table gets a TableDatum
-// a scalar.Scalar gets a ScalarDatum
+// a arrow.Scalar gets a ScalarDatum
 //
 // Anything else is passed to scalar.MakeScalar and recieves a scalar
 // datum of that appropriate type.
@@ -262,7 +262,7 @@ func NewDatum(value interface{}) Datum {
 	case scalar.Releasable:
 		v.Retain()
 		return NewDatumWithoutOwning(v)
-	case scalar.Scalar:
+	case arrow.Scalar:
 		return &ScalarDatum{v}
 	default:
 		return &ScalarDatum{scalar.MakeScalar(value)}
@@ -289,7 +289,7 @@ func NewDatumWithoutOwning(value interface{}) Datum {
 		return &RecordDatum{v}
 	case arrow.Table:
 		return &TableDatum{v}
-	case scalar.Scalar:
+	case arrow.Scalar:
 		return &ScalarDatum{v}
 	default:
 		return &ScalarDatum{scalar.MakeScalar(value)}

--- a/go/arrow/compute/exec_test.go
+++ b/go/arrow/compute/exec_test.go
@@ -78,13 +78,13 @@ func ExecNoPreallocatedAnything(ctx *exec.KernelCtx, batch *exec.ExecSpan, out *
 }
 
 type ExampleOptions struct {
-	Value scalar.Scalar
+	Value arrow.Scalar
 }
 
 func (e *ExampleOptions) TypeName() string { return "example" }
 
 type ExampleState struct {
-	Value scalar.Scalar
+	Value arrow.Scalar
 }
 
 func InitStateful(_ *exec.KernelCtx, args exec.KernelInitArgs) (exec.KernelState, error) {

--- a/go/arrow/compute/expression.go
+++ b/go/arrow/compute/expression.go
@@ -702,7 +702,7 @@ func SerializeExpr(expr Expression, mem memory.Allocator) (*memory.Buffer, error
 		visit     func(Expression) error
 	)
 
-	addScalar := func(s scalar.Scalar) (string, error) {
+	addScalar := func(s arrow.Scalar) (string, error) {
 		ret := len(cols)
 		arr, err := scalar.MakeArrayFromScalar(s, 1, mem)
 		if err != nil {
@@ -816,7 +816,7 @@ func DeserializeExpr(mem memory.Allocator, buf *memory.Buffer) (Expression, erro
 		metadata     = batch.Schema().Metadata()
 	)
 
-	getscalar := func(i string) (scalar.Scalar, error) {
+	getscalar := func(i string) (arrow.Scalar, error) {
 		colIndex, err := strconv.ParseInt(i, 10, 32)
 		if err != nil {
 			return nil, err

--- a/go/arrow/compute/internal/exec/span.go
+++ b/go/arrow/compute/internal/exec/span.go
@@ -268,7 +268,7 @@ func setOffsetsForScalar[T int32 | int64](span *ArraySpan, buf []T, valueSize in
 
 // FillFromScalar populates this ArraySpan as if it were a 1 length array
 // with the single value equal to the passed in Scalar.
-func (a *ArraySpan) FillFromScalar(val scalar.Scalar) {
+func (a *ArraySpan) FillFromScalar(val arrow.Scalar) {
 	var (
 		trueBit  byte = 0x01
 		falseBit byte = 0x00
@@ -560,7 +560,7 @@ func (a *ArraySpan) SetMembers(data arrow.ArrayData) {
 // be either an Array (ArraySpan) or a Scalar value
 type ExecValue struct {
 	Array  ArraySpan
-	Scalar scalar.Scalar
+	Scalar arrow.Scalar
 }
 
 func (e *ExecValue) IsArray() bool  { return e.Scalar == nil }

--- a/go/arrow/compute/internal/exec/span_test.go
+++ b/go/arrow/compute/internal/exec/span_test.go
@@ -497,7 +497,7 @@ func TestArraySpan_FillFromScalar(t *testing.T) {
 
 	tests := []struct {
 		name string
-		args scalar.Scalar
+		args arrow.Scalar
 		exp  exec.ArraySpan
 	}{
 		{"null-type",
@@ -691,8 +691,8 @@ func TestArraySpan_FillFromScalar(t *testing.T) {
 			},
 		},
 		{"struct scalar",
-			func() scalar.Scalar {
-				s, _ := scalar.NewStructScalarWithNames([]scalar.Scalar{
+			func() arrow.Scalar {
+				s, _ := scalar.NewStructScalarWithNames([]arrow.Scalar{
 					scalar.MakeScalar(int32(5)), scalar.MakeScalar(uint8(10)),
 				}, []string{"int32", "uint8"})
 				return s
@@ -728,7 +728,7 @@ func TestArraySpan_FillFromScalar(t *testing.T) {
 			},
 		},
 		{"dense union scalar",
-			func() scalar.Scalar {
+			func() arrow.Scalar {
 				dt := arrow.UnionOf(arrow.DenseMode, []arrow.Field{
 					{Name: "string", Type: arrow.BinaryTypes.String, Nullable: true},
 					{Name: "number", Type: arrow.PrimitiveTypes.Uint64, Nullable: true},
@@ -773,7 +773,7 @@ func TestArraySpan_FillFromScalar(t *testing.T) {
 			},
 		},
 		{"sparse union",
-			func() scalar.Scalar {
+			func() arrow.Scalar {
 				dt := arrow.UnionOf(arrow.SparseMode, []arrow.Field{
 					{Name: "string", Type: arrow.BinaryTypes.String, Nullable: true},
 					{Name: "number", Type: arrow.PrimitiveTypes.Uint64, Nullable: true},

--- a/go/arrow/compute/internal/kernels/helpers.go
+++ b/go/arrow/compute/internal/kernels/helpers.go
@@ -200,7 +200,7 @@ func ScalarBinary[OutT, Arg0T, Arg1T exec.FixedWidthTypes](ops binaryOps[OutT, A
 		return ops.arrArr(ctx, a0, a1, outData)
 	}
 
-	arrayScalar := func(ctx *exec.KernelCtx, arg0 *exec.ArraySpan, arg1 scalar.Scalar, out *exec.ExecResult) error {
+	arrayScalar := func(ctx *exec.KernelCtx, arg0 *exec.ArraySpan, arg1 arrow.Scalar, out *exec.ExecResult) error {
 		var (
 			a0      = exec.GetSpanValues[Arg0T](arg0, 1)
 			a1      = UnboxScalar[Arg1T](arg1.(scalar.PrimitiveScalar))
@@ -209,7 +209,7 @@ func ScalarBinary[OutT, Arg0T, Arg1T exec.FixedWidthTypes](ops binaryOps[OutT, A
 		return ops.arrScalar(ctx, a0, a1, outData)
 	}
 
-	scalarArray := func(ctx *exec.KernelCtx, arg0 scalar.Scalar, arg1 *exec.ArraySpan, out *exec.ExecResult) error {
+	scalarArray := func(ctx *exec.KernelCtx, arg0 arrow.Scalar, arg1 *exec.ArraySpan, out *exec.ExecResult) error {
 		var (
 			a0      = UnboxScalar[Arg0T](arg0.(scalar.PrimitiveScalar))
 			a1      = exec.GetSpanValues[Arg1T](arg1, 1)
@@ -246,7 +246,7 @@ func ScalarBinaryBools(ops *binaryBoolOps) exec.ArrayKernelExec {
 		return ops.arrArr(ctx, a0Bm, a1Bm, outBm)
 	}
 
-	arrayScalar := func(ctx *exec.KernelCtx, arg0 *exec.ArraySpan, arg1 scalar.Scalar, out *exec.ExecResult) error {
+	arrayScalar := func(ctx *exec.KernelCtx, arg0 *exec.ArraySpan, arg1 arrow.Scalar, out *exec.ExecResult) error {
 		var (
 			a0Bm  = bitutil.Bitmap{Data: arg0.Buffers[1].Buf, Offset: arg0.Offset, Len: arg0.Len}
 			a1    = arg1.(*scalar.Boolean).Value
@@ -255,7 +255,7 @@ func ScalarBinaryBools(ops *binaryBoolOps) exec.ArrayKernelExec {
 		return ops.arrScalar(ctx, a0Bm, a1, outBm)
 	}
 
-	scalarArray := func(ctx *exec.KernelCtx, arg0 scalar.Scalar, arg1 *exec.ArraySpan, out *exec.ExecResult) error {
+	scalarArray := func(ctx *exec.KernelCtx, arg0 arrow.Scalar, arg1 *exec.ArraySpan, out *exec.ExecResult) error {
 		var (
 			a0    = arg0.(*scalar.Boolean).Value
 			a1Bm  = bitutil.Bitmap{Data: arg1.Buffers[1].Buf, Offset: arg1.Offset, Len: arg1.Len}
@@ -306,7 +306,7 @@ func ScalarBinaryNotNull[OutT, Arg0T, Arg1T exec.FixedWidthTypes](op func(*exec.
 		return
 	}
 
-	arrayScalar := func(ctx *exec.KernelCtx, arg0 *exec.ArraySpan, arg1 scalar.Scalar, out *exec.ExecResult) (err error) {
+	arrayScalar := func(ctx *exec.KernelCtx, arg0 *exec.ArraySpan, arg1 arrow.Scalar, out *exec.ExecResult) (err error) {
 		// fast path if one side is entirely null
 		if arg0.UpdateNullCount() == arg0.Len || !arg1.IsValid() {
 			return nil
@@ -334,7 +334,7 @@ func ScalarBinaryNotNull[OutT, Arg0T, Arg1T exec.FixedWidthTypes](op func(*exec.
 		return
 	}
 
-	scalarArray := func(ctx *exec.KernelCtx, arg0 scalar.Scalar, arg1 *exec.ArraySpan, out *exec.ExecResult) (err error) {
+	scalarArray := func(ctx *exec.KernelCtx, arg0 arrow.Scalar, arg1 *exec.ArraySpan, out *exec.ExecResult) (err error) {
 		// fast path if one side is entirely null
 		if arg1.UpdateNullCount() == arg1.Len || !arg0.IsValid() {
 			return nil
@@ -394,7 +394,7 @@ func ScalarBinaryBinaryArgsBoolOut(itrFn func(*exec.ArraySpan) exec.ArrayIter[[]
 		return nil
 	}
 
-	arrScalar := func(ctx *exec.KernelCtx, arg0 *exec.ArraySpan, arg1 scalar.Scalar, out *exec.ExecResult) error {
+	arrScalar := func(ctx *exec.KernelCtx, arg0 *exec.ArraySpan, arg1 arrow.Scalar, out *exec.ExecResult) error {
 		var (
 			arg0It = itrFn(arg0)
 			a1     = UnboxBinaryScalar(arg1.(scalar.BinaryScalar))
@@ -406,7 +406,7 @@ func ScalarBinaryBinaryArgsBoolOut(itrFn func(*exec.ArraySpan) exec.ArrayIter[[]
 		return nil
 	}
 
-	scalarArr := func(ctx *exec.KernelCtx, arg0 scalar.Scalar, arg1 *exec.ArraySpan, out *exec.ExecResult) error {
+	scalarArr := func(ctx *exec.KernelCtx, arg0 arrow.Scalar, arg1 *exec.ArraySpan, out *exec.ExecResult) error {
 		var (
 			arg1It = itrFn(arg1)
 			a0     = UnboxBinaryScalar(arg0.(scalar.BinaryScalar))

--- a/go/arrow/compute/internal/kernels/rounding.go
+++ b/go/arrow/compute/internal/kernels/rounding.go
@@ -96,7 +96,7 @@ type RoundToMultipleOptions struct {
 	// Should be a positive numeric scalar of a type compatible
 	// with the argument to be rounded. The cast kernel is used
 	// to convert the rounding multiple to match the result type.
-	Multiple scalar.Scalar
+	Multiple arrow.Scalar
 	// Mode is the rounding and tie-breaking mode
 	Mode RoundMode
 }
@@ -105,7 +105,7 @@ func (RoundToMultipleOptions) TypeName() string { return "RoundToMultipleOptions
 
 type RoundToMultipleState = RoundToMultipleOptions
 
-func isPositive(s scalar.Scalar) bool {
+func isPositive(s arrow.Scalar) bool {
 	switch s := s.(type) {
 	case *scalar.Decimal128:
 		return s.Value.Greater(decimal128.Num{})

--- a/go/arrow/compute/internal/kernels/scalar_arithmetic.go
+++ b/go/arrow/compute/internal/kernels/scalar_arithmetic.go
@@ -207,7 +207,7 @@ func bitwiseKernelOp(op BitwiseOp) exec.ArrayKernelExec {
 		return nil
 	}
 
-	arrayScalar := func(arr *exec.ArraySpan, sc scalar.Scalar, out *exec.ExecResult) error {
+	arrayScalar := func(arr *exec.ArraySpan, sc arrow.Scalar, out *exec.ExecResult) error {
 		if !sc.IsValid() {
 			// no work to be done, everything is null
 			return nil

--- a/go/arrow/compute/internal/kernels/scalar_boolean.go
+++ b/go/arrow/compute/internal/kernels/scalar_boolean.go
@@ -19,6 +19,7 @@
 package kernels
 
 import (
+	"github.com/apache/arrow/go/v12/arrow"
 	"github.com/apache/arrow/go/v12/arrow/bitutil"
 	"github.com/apache/arrow/go/v12/arrow/compute/internal/exec"
 	"github.com/apache/arrow/go/v12/arrow/scalar"
@@ -74,7 +75,7 @@ func (AndOpKernel) Call(ctx *exec.KernelCtx, left, right *exec.ArraySpan, out *e
 	return nil
 }
 
-func (AndOpKernel) CallScalarLeft(ctx *exec.KernelCtx, left scalar.Scalar, right *exec.ArraySpan, out *exec.ExecResult) error {
+func (AndOpKernel) CallScalarLeft(ctx *exec.KernelCtx, left arrow.Scalar, right *exec.ArraySpan, out *exec.ExecResult) error {
 	if !left.IsValid() {
 		return nil
 	}
@@ -106,7 +107,7 @@ func (KleeneAndOpKernel) Call(ctx *exec.KernelCtx, left, right *exec.ArraySpan, 
 	return computeKleene(computeWord, ctx, left, right, out)
 }
 
-func (KleeneAndOpKernel) CallScalarLeft(ctx *exec.KernelCtx, left scalar.Scalar, right *exec.ArraySpan, out *exec.ExecResult) error {
+func (KleeneAndOpKernel) CallScalarLeft(ctx *exec.KernelCtx, left arrow.Scalar, right *exec.ArraySpan, out *exec.ExecResult) error {
 	var (
 		leftTrue  = left.IsValid() && left.(*scalar.Boolean).Value
 		leftFalse = left.IsValid() && !left.(*scalar.Boolean).Value
@@ -151,7 +152,7 @@ func (OrOpKernel) Call(ctx *exec.KernelCtx, left, right *exec.ArraySpan, out *ex
 	return nil
 }
 
-func (OrOpKernel) CallScalarLeft(ctx *exec.KernelCtx, left scalar.Scalar, right *exec.ArraySpan, out *exec.ExecResult) error {
+func (OrOpKernel) CallScalarLeft(ctx *exec.KernelCtx, left arrow.Scalar, right *exec.ArraySpan, out *exec.ExecResult) error {
 	if !left.IsValid() {
 		return nil
 	}
@@ -183,7 +184,7 @@ func (KleeneOrOpKernel) Call(ctx *exec.KernelCtx, left, right *exec.ArraySpan, o
 	return computeKleene(computeWord, ctx, left, right, out)
 }
 
-func (KleeneOrOpKernel) CallScalarLeft(ctx *exec.KernelCtx, left scalar.Scalar, right *exec.ArraySpan, out *exec.ExecResult) error {
+func (KleeneOrOpKernel) CallScalarLeft(ctx *exec.KernelCtx, left arrow.Scalar, right *exec.ArraySpan, out *exec.ExecResult) error {
 	var (
 		leftTrue  = left.IsValid() && left.(*scalar.Boolean).Value
 		leftFalse = left.IsValid() && !left.(*scalar.Boolean).Value
@@ -228,7 +229,7 @@ func (XorOpKernel) Call(ctx *exec.KernelCtx, left, right *exec.ArraySpan, out *e
 	return nil
 }
 
-func (XorOpKernel) CallScalarLeft(ctx *exec.KernelCtx, left scalar.Scalar, right *exec.ArraySpan, out *exec.ExecResult) error {
+func (XorOpKernel) CallScalarLeft(ctx *exec.KernelCtx, left arrow.Scalar, right *exec.ArraySpan, out *exec.ExecResult) error {
 	if !left.IsValid() {
 		return nil
 	}
@@ -244,7 +245,7 @@ func (XorOpKernel) CallScalarLeft(ctx *exec.KernelCtx, left scalar.Scalar, right
 	return nil
 }
 
-func invertScalar(in scalar.Scalar) *scalar.Boolean {
+func invertScalar(in arrow.Scalar) *scalar.Boolean {
 	if in.IsValid() {
 		return scalar.NewBooleanScalar(!in.(*scalar.Boolean).Value)
 	}
@@ -259,7 +260,7 @@ func (AndNotOpKernel) Call(ctx *exec.KernelCtx, left, right *exec.ArraySpan, out
 	return nil
 }
 
-func (AndNotOpKernel) CallScalarLeft(ctx *exec.KernelCtx, left scalar.Scalar, right *exec.ArraySpan, out *exec.ExecResult) error {
+func (AndNotOpKernel) CallScalarLeft(ctx *exec.KernelCtx, left arrow.Scalar, right *exec.ArraySpan, out *exec.ExecResult) error {
 	if !left.IsValid() {
 		return nil
 	}
@@ -274,7 +275,7 @@ func (AndNotOpKernel) CallScalarLeft(ctx *exec.KernelCtx, left scalar.Scalar, ri
 	return nil
 }
 
-func (AndNotOpKernel) CallScalarRight(ctx *exec.KernelCtx, left *exec.ArraySpan, right scalar.Scalar, out *exec.ExecResult) error {
+func (AndNotOpKernel) CallScalarRight(ctx *exec.KernelCtx, left *exec.ArraySpan, right arrow.Scalar, out *exec.ExecResult) error {
 	return (AndOpKernel{}).CallScalarRight(ctx, left, invertScalar(right), out)
 }
 
@@ -294,7 +295,7 @@ func (KleeneAndNotOpKernel) Call(ctx *exec.KernelCtx, left, right *exec.ArraySpa
 	return computeKleene(computeWord, ctx, left, right, out)
 }
 
-func (KleeneAndNotOpKernel) CallScalarLeft(ctx *exec.KernelCtx, left scalar.Scalar, right *exec.ArraySpan, out *exec.ExecResult) error {
+func (KleeneAndNotOpKernel) CallScalarLeft(ctx *exec.KernelCtx, left arrow.Scalar, right *exec.ArraySpan, out *exec.ExecResult) error {
 	var (
 		leftTrue  = left.IsValid() && left.(*scalar.Boolean).Value
 		leftFalse = left.IsValid() && !left.(*scalar.Boolean).Value
@@ -329,6 +330,6 @@ func (KleeneAndNotOpKernel) CallScalarLeft(ctx *exec.KernelCtx, left scalar.Scal
 	return nil
 }
 
-func (KleeneAndNotOpKernel) CallScalarRight(ctx *exec.KernelCtx, left *exec.ArraySpan, right scalar.Scalar, out *exec.ExecResult) error {
+func (KleeneAndNotOpKernel) CallScalarRight(ctx *exec.KernelCtx, left *exec.ArraySpan, right arrow.Scalar, out *exec.ExecResult) error {
 	return (KleeneAndOpKernel{}).CallScalarRight(ctx, left, invertScalar(right), out)
 }

--- a/go/arrow/compute/internal/kernels/types.go
+++ b/go/arrow/compute/internal/kernels/types.go
@@ -24,7 +24,6 @@ import (
 	"github.com/apache/arrow/go/v12/arrow"
 	"github.com/apache/arrow/go/v12/arrow/compute/internal/exec"
 	"github.com/apache/arrow/go/v12/arrow/internal/debug"
-	"github.com/apache/arrow/go/v12/arrow/scalar"
 )
 
 var (
@@ -72,19 +71,19 @@ const (
 
 type simpleBinaryKernel interface {
 	Call(*exec.KernelCtx, *exec.ArraySpan, *exec.ArraySpan, *exec.ExecResult) error
-	CallScalarLeft(*exec.KernelCtx, scalar.Scalar, *exec.ArraySpan, *exec.ExecResult) error
+	CallScalarLeft(*exec.KernelCtx, arrow.Scalar, *exec.ArraySpan, *exec.ExecResult) error
 }
 
 type commutativeBinaryKernel[T simpleBinaryKernel] struct{}
 
-func (commutativeBinaryKernel[T]) CallScalarRight(ctx *exec.KernelCtx, left *exec.ArraySpan, right scalar.Scalar, out *exec.ExecResult) error {
+func (commutativeBinaryKernel[T]) CallScalarRight(ctx *exec.KernelCtx, left *exec.ArraySpan, right arrow.Scalar, out *exec.ExecResult) error {
 	var t T
 	return t.CallScalarLeft(ctx, right, left, out)
 }
 
 type SimpleBinaryKernel interface {
 	simpleBinaryKernel
-	CallScalarRight(*exec.KernelCtx, *exec.ArraySpan, scalar.Scalar, *exec.ExecResult) error
+	CallScalarRight(*exec.KernelCtx, *exec.ArraySpan, arrow.Scalar, *exec.ExecResult) error
 }
 
 func SimpleBinary[K SimpleBinaryKernel](ctx *exec.KernelCtx, batch *exec.ExecSpan, out *exec.ExecResult) error {

--- a/go/arrow/compute/scalar_bool_test.go
+++ b/go/arrow/compute/scalar_bool_test.go
@@ -37,7 +37,7 @@ func checkScalarBinary(t *testing.T, fn string, left, right, expected compute.Da
 
 func checkBooleanScalarArrayBinary(t *testing.T, ctx context.Context, funcName string, array compute.Datum) {
 	mem := compute.GetAllocator(ctx)
-	for _, sc := range []scalar.Scalar{scalar.MakeNullScalar(arrow.FixedWidthTypes.Boolean), scalar.NewBooleanScalar(true), scalar.NewBooleanScalar(false)} {
+	for _, sc := range []arrow.Scalar{scalar.MakeNullScalar(arrow.FixedWidthTypes.Boolean), scalar.NewBooleanScalar(true), scalar.NewBooleanScalar(false)} {
 		constantArr, err := scalar.MakeArrayFromScalar(sc, int(array.Len()), mem)
 		defer constantArr.Release()
 

--- a/go/arrow/flight/flightsql/example/sqlite_server.go
+++ b/go/arrow/flight/flightsql/example/sqlite_server.go
@@ -546,7 +546,7 @@ func (s *SQLiteFlightSQLServer) DoGetPreparedStatement(ctx context.Context, cmd 
 	return
 }
 
-func scalarToIFace(s scalar.Scalar) (interface{}, error) {
+func scalarToIFace(s arrow.Scalar) (interface{}, error) {
 	if !s.IsValid() {
 		return nil, nil
 	}

--- a/go/arrow/flight/flightsql/sqlite_server_test.go
+++ b/go/arrow/flight/flightsql/sqlite_server_test.go
@@ -748,7 +748,7 @@ func (s *FlightSqliteServerSuite) TestCommandGetCrossRef() {
 	s.False(rdr.Next())
 }
 
-func validateSqlInfo(t *testing.T, expected interface{}, sc scalar.Scalar) bool {
+func validateSqlInfo(t *testing.T, expected interface{}, sc arrow.Scalar) bool {
 	switch ex := expected.(type) {
 	case string:
 		return assert.Equal(t, ex, sc.String())

--- a/go/arrow/scalar/append.go
+++ b/go/arrow/scalar/append.go
@@ -46,17 +46,17 @@ type binaryBuilder interface {
 	ReserveData(int)
 }
 
-func appendPrimitive[T primitives, B builder[T]](bldr B, scalars []Scalar) {
+func appendPrimitive[T primitives, B builder[T]](bldr B, scalars []arrow.Scalar) {
 	for _, sc := range scalars {
 		if sc.IsValid() {
-			bldr.UnsafeAppend(sc.value().(T))
+			bldr.UnsafeAppend(sc.ValueInterface().(T))
 		} else {
 			bldr.UnsafeAppendBoolToBitmap(false)
 		}
 	}
 }
 
-func appendBinary(bldr binaryBuilder, scalars []Scalar) {
+func appendBinary(bldr binaryBuilder, scalars []arrow.Scalar) {
 	var dataSize int
 	for _, s := range scalars {
 		s := s.(BinaryScalar)
@@ -81,8 +81,8 @@ func appendBinary(bldr binaryBuilder, scalars []Scalar) {
 // the type hasn't been implemented for this.
 //
 // NOTE only available in go1.18+
-func Append(bldr array.Builder, s Scalar) error {
-	return AppendSlice(bldr, []Scalar{s})
+func Append(bldr array.Builder, s arrow.Scalar) error {
+	return AppendSlice(bldr, []arrow.Scalar{s})
 }
 
 // AppendSlice requires the passed in builder and all scalars in the slice
@@ -90,7 +90,7 @@ func Append(bldr array.Builder, s Scalar) error {
 // arrow.ErrNotImplemented if the type hasn't been implemented for this.
 //
 // NOTE only available in go1.18+
-func AppendSlice(bldr array.Builder, scalars []Scalar) error {
+func AppendSlice(bldr array.Builder, scalars []arrow.Scalar) error {
 	if len(scalars) == 0 {
 		return nil
 	}

--- a/go/arrow/scalar/append_test.go
+++ b/go/arrow/scalar/append_test.go
@@ -110,7 +110,7 @@ type PrimitiveAppendTestSuite[T primitiveTypes | string | []byte] struct {
 	dt      arrow.DataType
 	bldr    builder[T]
 	bldrNN  builder[T]
-	scalars []scalar.Scalar
+	scalars []arrow.Scalar
 
 	getRand func(n int64) []T
 
@@ -143,7 +143,7 @@ func (pt *PrimitiveAppendTestSuite[T]) TestAppendScalar() {
 	pt.randomData(int64(size), 0.1)
 
 	pt.bldr.Reserve(size)
-	pt.scalars = make([]scalar.Scalar, size)
+	pt.scalars = make([]arrow.Scalar, size)
 
 	var nullCount int
 	for i := 0; i < 1000; i++ {

--- a/go/arrow/scalar/binary.go
+++ b/go/arrow/scalar/binary.go
@@ -26,7 +26,7 @@ import (
 )
 
 type BinaryScalar interface {
-	Scalar
+	arrow.Scalar
 
 	Retain()
 	Release()
@@ -52,9 +52,9 @@ func (b *Binary) Release() {
 	}
 }
 
-func (b *Binary) value() interface{} { return b.Value }
+func (b *Binary) ValueInterface() interface{} { return b.Value }
 func (b *Binary) Data() []byte       { return b.Value.Bytes() }
-func (b *Binary) equals(rhs Scalar) bool {
+func (b *Binary) Equals(rhs arrow.Scalar) bool {
 	return bytes.Equal(b.Value.Bytes(), rhs.(BinaryScalar).Data())
 }
 func (b *Binary) Buffer() *memory.Buffer { return b.Value }
@@ -66,7 +66,7 @@ func (b *Binary) String() string {
 	return string(b.Value.Bytes())
 }
 
-func (b *Binary) CastTo(to arrow.DataType) (Scalar, error) {
+func (b *Binary) CastTo(to arrow.DataType) (arrow.Scalar, error) {
 	if !b.Valid {
 		return MakeNullScalar(to), nil
 	}
@@ -132,7 +132,7 @@ func (s *String) ValidateFull() (err error) {
 	return
 }
 
-func (s *String) CastTo(to arrow.DataType) (Scalar, error) {
+func (s *String) CastTo(to arrow.DataType) (arrow.Scalar, error) {
 	if !s.Valid {
 		return MakeNullScalar(to), nil
 	}

--- a/go/arrow/scalar/compare.go
+++ b/go/arrow/scalar/compare.go
@@ -20,7 +20,7 @@ import "github.com/apache/arrow/go/v12/arrow"
 
 // Equals returns true if two scalars are equal, which means they have the same
 // datatype, validity and value.
-func Equals(left, right Scalar) bool {
+func Equals(left, right arrow.Scalar) bool {
 	if left == right {
 		return true
 	}
@@ -37,7 +37,7 @@ func Equals(left, right Scalar) bool {
 		return true
 	}
 
-	return left.equals(right)
+	return left.Equals(right)
 }
 
 type equalOption struct {
@@ -66,10 +66,10 @@ func WithAbsTolerance(atol float64) EqualOption {
 const defaultAbsoluteTolerance = 1e-5
 
 type approxEqualScalar interface {
-	approxEquals(Scalar, equalOption) bool
+	approxEquals(arrow.Scalar, equalOption) bool
 }
 
-func ApproxEquals(left, right Scalar, opts ...EqualOption) bool {
+func ApproxEquals(left, right arrow.Scalar, opts ...EqualOption) bool {
 	eq := equalOption{
 		atol:   defaultAbsoluteTolerance,
 		nansEq: false,
@@ -93,5 +93,5 @@ func ApproxEquals(left, right Scalar, opts ...EqualOption) bool {
 		return approx.approxEquals(right, eq)
 	}
 
-	return left.equals(right)
+	return left.Equals(right)
 }

--- a/go/arrow/scalar/numeric.gen.go
+++ b/go/arrow/scalar/numeric.gen.go
@@ -38,11 +38,11 @@ func (s *Int8) Data() []byte {
 	return (*[arrow.Int8SizeBytes]byte)(unsafe.Pointer(&s.Value))[:]
 }
 
-func (s *Int8) equals(rhs Scalar) bool {
+func (s *Int8) Equals(rhs arrow.Scalar) bool {
 	return s.Value == rhs.(*Int8).Value
 }
 
-func (s *Int8) value() interface{} {
+func (s *Int8) ValueInterface() interface{} {
 	return s.Value
 }
 
@@ -57,7 +57,7 @@ func (s *Int8) String() string {
 	return string(val.(*String).Value.Bytes())
 }
 
-func (s *Int8) CastTo(dt arrow.DataType) (Scalar, error) {
+func (s *Int8) CastTo(dt arrow.DataType) (arrow.Scalar, error) {
 	if !s.Valid {
 		return MakeNullScalar(dt), nil
 	}
@@ -108,11 +108,11 @@ func (s *Int16) Data() []byte {
 	return (*[arrow.Int16SizeBytes]byte)(unsafe.Pointer(&s.Value))[:]
 }
 
-func (s *Int16) equals(rhs Scalar) bool {
+func (s *Int16) Equals(rhs arrow.Scalar) bool {
 	return s.Value == rhs.(*Int16).Value
 }
 
-func (s *Int16) value() interface{} {
+func (s *Int16) ValueInterface() interface{} {
 	return s.Value
 }
 
@@ -127,7 +127,7 @@ func (s *Int16) String() string {
 	return string(val.(*String).Value.Bytes())
 }
 
-func (s *Int16) CastTo(dt arrow.DataType) (Scalar, error) {
+func (s *Int16) CastTo(dt arrow.DataType) (arrow.Scalar, error) {
 	if !s.Valid {
 		return MakeNullScalar(dt), nil
 	}
@@ -178,11 +178,11 @@ func (s *Int32) Data() []byte {
 	return (*[arrow.Int32SizeBytes]byte)(unsafe.Pointer(&s.Value))[:]
 }
 
-func (s *Int32) equals(rhs Scalar) bool {
+func (s *Int32) Equals(rhs arrow.Scalar) bool {
 	return s.Value == rhs.(*Int32).Value
 }
 
-func (s *Int32) value() interface{} {
+func (s *Int32) ValueInterface() interface{} {
 	return s.Value
 }
 
@@ -197,7 +197,7 @@ func (s *Int32) String() string {
 	return string(val.(*String).Value.Bytes())
 }
 
-func (s *Int32) CastTo(dt arrow.DataType) (Scalar, error) {
+func (s *Int32) CastTo(dt arrow.DataType) (arrow.Scalar, error) {
 	if !s.Valid {
 		return MakeNullScalar(dt), nil
 	}
@@ -248,11 +248,11 @@ func (s *Int64) Data() []byte {
 	return (*[arrow.Int64SizeBytes]byte)(unsafe.Pointer(&s.Value))[:]
 }
 
-func (s *Int64) equals(rhs Scalar) bool {
+func (s *Int64) Equals(rhs arrow.Scalar) bool {
 	return s.Value == rhs.(*Int64).Value
 }
 
-func (s *Int64) value() interface{} {
+func (s *Int64) ValueInterface() interface{} {
 	return s.Value
 }
 
@@ -267,7 +267,7 @@ func (s *Int64) String() string {
 	return string(val.(*String).Value.Bytes())
 }
 
-func (s *Int64) CastTo(dt arrow.DataType) (Scalar, error) {
+func (s *Int64) CastTo(dt arrow.DataType) (arrow.Scalar, error) {
 	if !s.Valid {
 		return MakeNullScalar(dt), nil
 	}
@@ -318,11 +318,11 @@ func (s *Uint8) Data() []byte {
 	return (*[arrow.Uint8SizeBytes]byte)(unsafe.Pointer(&s.Value))[:]
 }
 
-func (s *Uint8) equals(rhs Scalar) bool {
+func (s *Uint8) Equals(rhs arrow.Scalar) bool {
 	return s.Value == rhs.(*Uint8).Value
 }
 
-func (s *Uint8) value() interface{} {
+func (s *Uint8) ValueInterface() interface{} {
 	return s.Value
 }
 
@@ -337,7 +337,7 @@ func (s *Uint8) String() string {
 	return string(val.(*String).Value.Bytes())
 }
 
-func (s *Uint8) CastTo(dt arrow.DataType) (Scalar, error) {
+func (s *Uint8) CastTo(dt arrow.DataType) (arrow.Scalar, error) {
 	if !s.Valid {
 		return MakeNullScalar(dt), nil
 	}
@@ -388,11 +388,11 @@ func (s *Uint16) Data() []byte {
 	return (*[arrow.Uint16SizeBytes]byte)(unsafe.Pointer(&s.Value))[:]
 }
 
-func (s *Uint16) equals(rhs Scalar) bool {
+func (s *Uint16) Equals(rhs arrow.Scalar) bool {
 	return s.Value == rhs.(*Uint16).Value
 }
 
-func (s *Uint16) value() interface{} {
+func (s *Uint16) ValueInterface() interface{} {
 	return s.Value
 }
 
@@ -407,7 +407,7 @@ func (s *Uint16) String() string {
 	return string(val.(*String).Value.Bytes())
 }
 
-func (s *Uint16) CastTo(dt arrow.DataType) (Scalar, error) {
+func (s *Uint16) CastTo(dt arrow.DataType) (arrow.Scalar, error) {
 	if !s.Valid {
 		return MakeNullScalar(dt), nil
 	}
@@ -458,11 +458,11 @@ func (s *Uint32) Data() []byte {
 	return (*[arrow.Uint32SizeBytes]byte)(unsafe.Pointer(&s.Value))[:]
 }
 
-func (s *Uint32) equals(rhs Scalar) bool {
+func (s *Uint32) Equals(rhs arrow.Scalar) bool {
 	return s.Value == rhs.(*Uint32).Value
 }
 
-func (s *Uint32) value() interface{} {
+func (s *Uint32) ValueInterface() interface{} {
 	return s.Value
 }
 
@@ -477,7 +477,7 @@ func (s *Uint32) String() string {
 	return string(val.(*String).Value.Bytes())
 }
 
-func (s *Uint32) CastTo(dt arrow.DataType) (Scalar, error) {
+func (s *Uint32) CastTo(dt arrow.DataType) (arrow.Scalar, error) {
 	if !s.Valid {
 		return MakeNullScalar(dt), nil
 	}
@@ -528,11 +528,11 @@ func (s *Uint64) Data() []byte {
 	return (*[arrow.Uint64SizeBytes]byte)(unsafe.Pointer(&s.Value))[:]
 }
 
-func (s *Uint64) equals(rhs Scalar) bool {
+func (s *Uint64) Equals(rhs arrow.Scalar) bool {
 	return s.Value == rhs.(*Uint64).Value
 }
 
-func (s *Uint64) value() interface{} {
+func (s *Uint64) ValueInterface() interface{} {
 	return s.Value
 }
 
@@ -547,7 +547,7 @@ func (s *Uint64) String() string {
 	return string(val.(*String).Value.Bytes())
 }
 
-func (s *Uint64) CastTo(dt arrow.DataType) (Scalar, error) {
+func (s *Uint64) CastTo(dt arrow.DataType) (arrow.Scalar, error) {
 	if !s.Valid {
 		return MakeNullScalar(dt), nil
 	}
@@ -598,11 +598,11 @@ func (s *Float32) Data() []byte {
 	return (*[arrow.Float32SizeBytes]byte)(unsafe.Pointer(&s.Value))[:]
 }
 
-func (s *Float32) equals(rhs Scalar) bool {
+func (s *Float32) Equals(rhs arrow.Scalar) bool {
 	return s.Value == rhs.(*Float32).Value
 }
 
-func (s *Float32) approxEquals(rhs Scalar, eq equalOption) bool {
+func (s *Float32) approxEquals(rhs arrow.Scalar, eq equalOption) bool {
 	v1 := float64(s.Value)
 	v2 := float64(rhs.(*Float32).Value)
 	switch {
@@ -613,7 +613,7 @@ func (s *Float32) approxEquals(rhs Scalar, eq equalOption) bool {
 	}
 }
 
-func (s *Float32) value() interface{} {
+func (s *Float32) ValueInterface() interface{} {
 	return s.Value
 }
 
@@ -628,7 +628,7 @@ func (s *Float32) String() string {
 	return string(val.(*String).Value.Bytes())
 }
 
-func (s *Float32) CastTo(dt arrow.DataType) (Scalar, error) {
+func (s *Float32) CastTo(dt arrow.DataType) (arrow.Scalar, error) {
 	if !s.Valid {
 		return MakeNullScalar(dt), nil
 	}
@@ -687,11 +687,11 @@ func (s *Float64) Data() []byte {
 	return (*[arrow.Float64SizeBytes]byte)(unsafe.Pointer(&s.Value))[:]
 }
 
-func (s *Float64) equals(rhs Scalar) bool {
+func (s *Float64) Equals(rhs arrow.Scalar) bool {
 	return s.Value == rhs.(*Float64).Value
 }
 
-func (s *Float64) approxEquals(rhs Scalar, eq equalOption) bool {
+func (s *Float64) approxEquals(rhs arrow.Scalar, eq equalOption) bool {
 	v1 := float64(s.Value)
 	v2 := float64(rhs.(*Float64).Value)
 	switch {
@@ -702,7 +702,7 @@ func (s *Float64) approxEquals(rhs Scalar, eq equalOption) bool {
 	}
 }
 
-func (s *Float64) value() interface{} {
+func (s *Float64) ValueInterface() interface{} {
 	return s.Value
 }
 
@@ -717,7 +717,7 @@ func (s *Float64) String() string {
 	return string(val.(*String).Value.Bytes())
 }
 
-func (s *Float64) CastTo(dt arrow.DataType) (Scalar, error) {
+func (s *Float64) CastTo(dt arrow.DataType) (arrow.Scalar, error) {
 	if !s.Valid {
 		return MakeNullScalar(dt), nil
 	}
@@ -784,14 +784,14 @@ var numericMap = map[arrow.Type]struct {
 }
 
 var (
-	_ Scalar = (*Int8)(nil)
-	_ Scalar = (*Int16)(nil)
-	_ Scalar = (*Int32)(nil)
-	_ Scalar = (*Int64)(nil)
-	_ Scalar = (*Uint8)(nil)
-	_ Scalar = (*Uint16)(nil)
-	_ Scalar = (*Uint32)(nil)
-	_ Scalar = (*Uint64)(nil)
-	_ Scalar = (*Float32)(nil)
-	_ Scalar = (*Float64)(nil)
+	_ arrow.Scalar = (*Int8)(nil)
+	_ arrow.Scalar = (*Int16)(nil)
+	_ arrow.Scalar = (*Int32)(nil)
+	_ arrow.Scalar = (*Int64)(nil)
+	_ arrow.Scalar = (*Uint8)(nil)
+	_ arrow.Scalar = (*Uint16)(nil)
+	_ arrow.Scalar = (*Uint32)(nil)
+	_ arrow.Scalar = (*Uint64)(nil)
+	_ arrow.Scalar = (*Float32)(nil)
+	_ arrow.Scalar = (*Float64)(nil)
 )

--- a/go/arrow/scalar/numeric.gen.go.tmpl
+++ b/go/arrow/scalar/numeric.gen.go.tmpl
@@ -26,12 +26,12 @@ func (s *{{.Name}}) Data() []byte {
     return (*[arrow.{{.Name}}SizeBytes]byte)(unsafe.Pointer(&s.Value))[:]
 }
 
-func (s *{{.Name}}) equals(rhs Scalar) bool {
+func (s *{{.Name}}) Equals(rhs arrow.Scalar) bool {
     return s.Value == rhs.(*{{.Name}}).Value
 }
 
 {{if or (eq .Name "Float32") (eq .Name "Float64") }}
-func (s *{{.Name}}) approxEquals(rhs Scalar, eq equalOption) bool {
+func (s *{{.Name}}) approxEquals(rhs arrow.Scalar, eq equalOption) bool {
     v1 := float64(s.Value)
     v2 := float64(rhs.(*{{.Name}}).Value)
     switch {
@@ -43,7 +43,7 @@ func (s *{{.Name}}) approxEquals(rhs Scalar, eq equalOption) bool {
 }
 {{end}}
 
-func (s *{{.Name}}) value() interface{} {
+func (s *{{.Name}}) ValueInterface() interface{} {
     return s.Value
 }
 
@@ -58,7 +58,7 @@ func (s *{{.Name}}) String() string {
 	return string(val.(*String).Value.Bytes())
 }
 
-func (s *{{.Name}}) CastTo(dt arrow.DataType) (Scalar, error) {
+func (s *{{.Name}}) CastTo(dt arrow.DataType) (arrow.Scalar, error) {
     if !s.Valid {
         return MakeNullScalar(dt), nil
     }


### PR DESCRIPTION
This is a pre-requirement for https://github.com/apache/arrow/issues/34657 as array interface needs access to the Scalar interface and without it, it will cause cyclic loop.

cc @zeroshade 
* Closes: #34657