### PR TITLE
MINOR: [C++] Fix build issue where wrong variable checked for re2 prefix dir

### DIFF
--- a/cpp/cmake_modules/Findre2Alt.cmake
+++ b/cpp/cmake_modules/Findre2Alt.cmake
@@ -43,7 +43,7 @@ if(re2_ROOT)
                NO_DEFAULT_PATH)
   find_path(RE2_INCLUDE_DIR
             NAMES re2/re2.h
-            PATHS ${RE2_ROOT}
+            PATHS ${re2_ROOT}
             NO_DEFAULT_PATH
             PATH_SUFFIXES ${ARROW_INCLUDE_PATH_SUFFIXES})
 else()


### PR DESCRIPTION
### Rationale for this change

CMake variables are case sensitive.

When providing a manual prefix dir for re2 (`re2_ROOT`), the wrong variable (`RE2_ROOT`) would be checked, causing build issues.

### What changes are included in this PR?

typo fix

### Are these changes tested?

Built on my end by providing `-Dre2_ROOT=...`

### Are there any user-facing changes?

Possibly if a user decided to set `RE2_ROOT` to something different. Unlikely, though.