### PR TITLE
MINOR: [Python] Respect BUILD_SHARED_LIBS cmake options

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -358,7 +358,7 @@ if(NOT PYARROW_CPP_LINK_LIBS)
   endif()
 endif()
 
-add_library(arrow_python SHARED ${PYARROW_CPP_SRCS})
+add_library(arrow_python ${PYARROW_CPP_SRCS})
 target_include_directories(arrow_python PUBLIC ${PYARROW_CPP_ROOT_DIR}
                                                ${CMAKE_CURRENT_BINARY_DIR}/pyarrow/src)
 if(NOT CMAKE_VERSION VERSION_LESS 3.16)


### PR DESCRIPTION
### Rationale for this change

Prior to 240ebb75b57bb05551c9103ec3dee11c23fd0aca , both dynamic and static libraries would be built.

After, only dynamic shared libraries were being built.

This change at least gives the user the option to build dynamic or static libs with the `BUILD_SHARED_LIBS` cmake variable

See: https://cmake.org/cmake/help/latest/command/add_library.html

### What changes are included in this PR?

CMake build change

### Are these changes tested?

Yes, build with default value, and `-DBUILD_SHARED_LIBS=OFF`

For the former, got dynamic libarrow_python libs, for the latter got static libarrow_python archive

### Are there any user-facing changes?

No, default stays the same