### PR TITLE
GH-34743: [Python] Relax condition in flaky Flight test

### DIFF
--- a/python/pyarrow/tests/test_flight.py
+++ b/python/pyarrow/tests/test_flight.py
@@ -2045,7 +2045,7 @@ def test_generic_options():
         client = flight.connect(('localhost', s.port),
                                 tls_root_certs=certs["root_cert"],
                                 generic_options=options)
-        with pytest.raises(pa.ArrowInvalid):
+        with pytest.raises((pa.ArrowInvalid, flight.FlightCancelledError)):
             client.do_get(flight.Ticket(b'ints'))
         client.close()
 


### PR DESCRIPTION
### Rationale for this change
This test is consistently flaky on AMD64 macOS.

### What changes are included in this PR?

Relax the test condition a bit.
### Are these changes tested?

This is a change to a test.

### Are there any user-facing changes?

No.
* Closes: #34743