### PR TITLE
GH-34753: [C++] Nightly builds failing with EnsureAlignment

### DIFF
--- a/cpp/src/arrow/util/align_util.cc
+++ b/cpp/src/arrow/util/align_util.cc
@@ -101,7 +101,7 @@ Result<std::shared_ptr<Buffer>> EnsureAlignment(std::shared_ptr<Buffer> buffer,
     ARROW_ASSIGN_OR_RAISE(auto new_buffer,
                           AllocateBuffer(buffer->size(), alignment, memory_pool));
     std::memcpy(new_buffer->mutable_data(), buffer->data(), buffer->size());
-    return new_buffer;
+    return std::move(new_buffer);
   } else {
     return std::move(buffer);
   }


### PR DESCRIPTION
This PR should fix the nightly builds CI error which occurred after merging #14758. In the EnsureAlignment utility for a Buffer, the modified buffer should be returned by `std::move`.
* Closes: #34753