### PR TITLE
GH-34579: [Python][Docs] TableGroupBy.aggregate options

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -5516,7 +5516,7 @@ list[tuple(str, str, FunctionOptions)]
             respectively.
 
             For the list of function names and respective aggregation
-            function options see: :ref:`py-grouped-aggrs`.
+            function options see :ref:`py-grouped-aggrs`.
 
         Returns
         -------
@@ -5571,7 +5571,7 @@ list[tuple(str, str, FunctionOptions)]
 
         >>> import pyarrow.compute as pc
         >>> t.group_by(["keys"]).aggregate([
-        ...    ("values", "count", pc.CountOptions(mode="all"))
+        ...    ("values", "count", pc.CountOptions(mode="only_valid"))
         ... ])
         pyarrow.Table
         values_count: int64

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -5515,6 +5515,9 @@ list[tuple(str, str, FunctionOptions)]
             column names, for unary, nullary and n-ary aggregation functions
             respectively.
 
+            For the list of function names and respective aggregation
+            function options see: :ref:`py-grouped-aggrs`.
+
         Returns
         -------
         Table
@@ -5527,6 +5530,9 @@ list[tuple(str, str, FunctionOptions)]
         ...       pa.array(["a", "a", "b", "b", "c"]),
         ...       pa.array([1, 2, 3, 4, 5]),
         ... ], names=["keys", "values"])
+
+        Sum the column "values" over the grouped column "keys":
+
         >>> t.group_by("keys").aggregate([("values", "sum")])
         pyarrow.Table
         values_sum: int64
@@ -5534,6 +5540,9 @@ list[tuple(str, str, FunctionOptions)]
         ----
         values_sum: [[3,7,5]]
         keys: [["a","b","c"]]
+
+        Count the rows over the grouped column "keys":
+
         >>> t.group_by("keys").aggregate([([], "count_all")])
         pyarrow.Table
         count_all: int64
@@ -5541,6 +5550,38 @@ list[tuple(str, str, FunctionOptions)]
         ----
         count_all: [[2,2,1]]
         keys: [["a","b","c"]]
+
+        Do multiple aggregations:
+
+        >>> t.group_by("keys").aggregate([
+        ...    ("values", "sum"),
+        ...    ("keys", "count")
+        ... ])
+        pyarrow.Table
+        values_sum: int64
+        keys_count: int64
+        keys: string
+        ----
+        values_sum: [[3,7,5]]
+        keys_count: [[2,2,1]]
+        keys: [["a","b","c"]]
+
+        Count the number of non-null values for column "values"
+        over the grouped column "keys":
+
+        >>> import pyarrow.compute as pc
+        >>> t.group_by(["keys"]).aggregate([
+        ...    ("values", "count", pc.CountOptions(mode="all"))
+        ... ])
+        pyarrow.Table
+        values_count: int64
+        keys: string
+        ----
+        values_count: [[2,2,1]]
+        keys: [["a","b","c"]]
+
+        Get a single row for each group in column "keys":
+
         >>> t.group_by("keys").aggregate([])
         pyarrow.Table
         keys: string


### PR DESCRIPTION
### Rationale for this change

Add more information and examples to `pa.TableGroupBy.aggregate` method to make it clearer to use.

### What changes are included in this PR?

Changes in the `pa.TableGroupBy.aggregate` docstrings include:
- link to https://arrow.apache.org/docs/python/compute.html#grouped-aggregations
- extra examples
* Closes: #34579