### PR TITLE
GH-14917: [C++] Error out when GTest is compiled with a C++ standard lower than 17

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2230,6 +2230,13 @@ if(ARROW_TESTING)
                      1.10.0
                      USE_CONFIG
                      ${GTEST_USE_CONFIG})
+  get_target_property(gtest_cxx_standard GTest::gtest INTERFACE_COMPILE_FEATURES)
+
+  if((${gtest_cxx_standard} STREQUAL "cxx_std_11") OR (${gtest_cxx_standard} STREQUAL
+                                                       "cxx_std_14"))
+    message(FATAL_ERROR "System GTest is built with a C++ standard lower than 17. Use bundled GTest via passing in CMake flag
+-DGTest_SOURCE=\"BUNDLED\"")
+  endif()
 
   if(GTest_SOURCE STREQUAL "SYSTEM")
     find_package(PkgConfig QUIET)


### PR DESCRIPTION
### Rationale for this change
On MacOS, the system GTest from brew uses C++14 while arrow is default to C++17.
The build will fail at the linking stage unless users explicity uses bundled GTest.

Users are often confused by unclear linking errors.

### What changes are included in this PR? 
At CMake configuration time, the CMake code will automatically detect and 
compare the C++ standard used by GTest and arrow. If a mismatch is detected,
CMake will error out and privide meaningful guidance. It will apply both to
linux and MacOS.

### Are these changes tested?
Covered by Arrow github test worker and tested on local host.

### Are there any user-facing changes?
Yes, now users are given better guidance when building Arrow against the system
GTest.

* Closes: #14917
* Closes: #14779
