### PR TITLE
MINOR: [Go] Tweak Flight SQL demo server for ADBC Java Flight SQL

### DIFF
--- a/go/arrow/flight/flightsql/example/sql_batch_reader.go
+++ b/go/arrow/flight/flightsql/example/sql_batch_reader.go
@@ -56,7 +56,7 @@ func getArrowTypeFromString(dbtype string) arrow.DataType {
 		return arrow.PrimitiveTypes.Float64
 	case "blob":
 		return arrow.BinaryTypes.Binary
-	case "text", "date", "char":
+	case "text", "date", "char", "clob":
 		return arrow.BinaryTypes.String
 	default:
 		panic("invalid sqlite type: " + dbtype)

--- a/go/arrow/flight/flightsql/example/sqlite_server.go
+++ b/go/arrow/flight/flightsql/example/sqlite_server.go
@@ -643,6 +643,9 @@ func (s *SQLiteFlightSQLServer) DoPutPreparedStatementUpdate(ctx context.Context
 	if len(args) == 0 {
 		result, err := stmt.stmt.ExecContext(ctx)
 		if err != nil {
+			if strings.Contains(err.Error(), "no such table") {
+				return 0, status.Error(codes.NotFound, err.Error())
+			}
 			return 0, err
 		}
 
@@ -653,6 +656,9 @@ func (s *SQLiteFlightSQLServer) DoPutPreparedStatementUpdate(ctx context.Context
 	for _, p := range args {
 		result, err := stmt.stmt.ExecContext(ctx, p...)
 		if err != nil {
+			if strings.Contains(err.Error(), "no such table") {
+				return totalAffected, status.Error(codes.NotFound, err.Error())
+			}
 			return totalAffected, err
 		}
 

--- a/go/arrow/flight/flightsql/sqlite_server_test.go
+++ b/go/arrow/flight/flightsql/sqlite_server_test.go
@@ -566,6 +566,18 @@ func (s *FlightSqliteServerSuite) TestCommandPreparedStatementQueryWithParams() 
 	s.False(rdr.Next())
 }
 
+func (s *FlightSqliteServerSuite) TestCommandPreparedStatementUpdateNoTable() {
+	ctx := context.Background()
+	stmt, err := s.cl.Prepare(ctx, "INSERT INTO thisTableDoesNotExist (keyName, value) VALUES ('new_value', 2)")
+	s.NoError(err)
+	defer stmt.Close(ctx)
+
+	_, err = stmt.ExecuteUpdate(context.Background())
+	s.Error(err)
+	s.Equal(codes.NotFound, status.Code(err), "%#v", err.Error())
+	s.Contains(err.Error(), "no such table")
+}
+
 func (s *FlightSqliteServerSuite) TestCommandPreparedStatementUpdateWithParams() {
 	ctx := context.Background()
 	stmt, err := s.cl.Prepare(ctx, "INSERT INTO intTable (keyName, value) VALUES ('new_value', ?)")


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

The ADBC Flight SQL driver/test suite depends on semantic error codes from the server.

### What changes are included in this PR?

Return a more specific error in the SQLite Flight SQL example server.

### Are these changes tested?

Yes

### Are there any user-facing changes?

No