### PR TITLE
MINOR: [C++] Remove std::move when calling ProcessEmit and ProcessExtensionEmit

### DIFF
--- a/cpp/src/arrow/engine/substrait/expression_internal.h
+++ b/cpp/src/arrow/engine/substrait/expression_internal.h
@@ -40,11 +40,6 @@ Result<FieldRef> DirectReferenceFromProto(const substrait::Expression::FieldRefe
                                           const ExtensionSet&, const ConversionOptions&);
 
 ARROW_ENGINE_EXPORT
-Result<compute::Expression> FromProto(const substrait::Expression::FieldReference*,
-                                      const ExtensionSet&, const ConversionOptions&,
-                                      std::optional<compute::Expression>);
-
-ARROW_ENGINE_EXPORT
 Result<compute::Expression> FromProto(const substrait::Expression&, const ExtensionSet&,
                                       const ConversionOptions&);
 

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -89,7 +89,7 @@ Result<EmitInfo> GetEmitInfo(const RelMessage& rel,
   }
   emit_info.expressions = std::move(proj_field_refs);
   emit_info.schema = schema(std::move(emit_fields));
-  return emit_info;
+  return std::move(emit_info);
 }
 
 Result<DeclarationInfo> ProcessEmitProject(
@@ -964,7 +964,7 @@ Result<std::unique_ptr<substrait::ReadRel>> NamedTableRelationConverter(
   }
   read_rel->set_allocated_named_table(read_rel_tn.release());
 
-  return read_rel;
+  return std::move(read_rel);
 }
 
 Result<std::unique_ptr<substrait::ReadRel>> ScanRelationConverter(
@@ -1008,7 +1008,7 @@ Result<std::unique_ptr<substrait::ReadRel>> ScanRelationConverter(
     read_rel_lfs->mutable_items()->AddAllocated(read_rel_lfs_ffs.release());
   }
   read_rel->set_allocated_local_files(read_rel_lfs.release());
-  return read_rel;
+  return std::move(read_rel);
 }
 
 Result<std::unique_ptr<substrait::FilterRel>> FilterRelationConverter(
@@ -1038,7 +1038,7 @@ Result<std::unique_ptr<substrait::FilterRel>> FilterRelationConverter(
   ARROW_ASSIGN_OR_RAISE(auto subs_expr,
                         ToProto(bound_expression, ext_set, conversion_options));
   filter_rel->set_allocated_condition(subs_expr.release());
-  return filter_rel;
+  return std::move(filter_rel);
 }
 
 }  // namespace
@@ -1087,7 +1087,7 @@ Result<std::unique_ptr<substrait::Rel>> ToProto(
     const ConversionOptions& conversion_options) {
   auto rel = std::make_unique<substrait::Rel>();
   RETURN_NOT_OK(SerializeAndCombineRelations(declr, ext_set, &rel, conversion_options));
-  return rel;
+  return std::move(rel);
 }
 
 }  // namespace engine

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -819,7 +819,8 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel, const ExtensionSet&
               std::move(aggregates), std::move(agg_src_fieldsets), std::move(keys),
               std::move(key_field_ids), {}, {}, ext_set, conversion_options));
 
-      return ProcessEmit(aggregate, aggregate_declaration, aggregate_declaration.output_schema);
+      return ProcessEmit(aggregate, aggregate_declaration,
+                         aggregate_declaration.output_schema);
     }
 
     case substrait::Rel::RelTypeCase::kExtensionLeaf:


### PR DESCRIPTION
### Rationale for this change
I noticed a few places in relation_internal.cc that std::move is used incorrectly. 

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
* Currently, `std::move` is used when passing arguments to `ProcessEmit` and `ProcessExtensionEmit`, however these two methods takes in const reference and therefore the `std::move` is not needed.
* (orthogonal) Removed unneeded `FromProto` from header
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
With existing tests
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->