### PR TITLE
GH-34832: [Go] Add Record SetColumn method 

### DIFF
--- a/go/arrow/array/record_test.go
+++ b/go/arrow/array/record_test.go
@@ -91,13 +91,15 @@ func TestRecord(t *testing.T) {
 	if got, want := rec.ColumnName(0), schema.Field(0).Name; got != want {
 		t.Fatalf("invalid column name: got=%q, want=%q", got, want)
 	}
-	if err := rec.SetColumn(0, col2_1); err == nil {
+	if _, err := rec.SetColumn(0, col2_1); err == nil {
 		t.Fatalf("expected an error")
 	}
-	if err := rec.SetColumn(1, col2_1); err != nil {
+	newRec, err := rec.SetColumn(1, col2_1);
+	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !reflect.DeepEqual(rec.Column(1), col2_1) {
+	defer newRec.Release()
+	if !reflect.DeepEqual(newRec.Column(1), col2_1) {
 		t.Fatalf("invalid column: got=%q, want=%q", rec.Column(1), col2_1)
 	}
 

--- a/go/arrow/array/record_test.go
+++ b/go/arrow/array/record_test.go
@@ -56,6 +56,15 @@ func TestRecord(t *testing.T) {
 	}()
 	defer col2.Release()
 
+	col2_1 := func() arrow.Array {
+		b := array.NewFloat64Builder(mem)
+		defer b.Release()
+
+		b.AppendValues([]float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, nil)
+		return b.NewFloat64Array()
+	}()
+	defer col2_1.Release()
+
 	cols := []arrow.Array{col1, col2}
 	rec := array.NewRecord(schema, cols, -1)
 	defer rec.Release()
@@ -81,6 +90,15 @@ func TestRecord(t *testing.T) {
 	}
 	if got, want := rec.ColumnName(0), schema.Field(0).Name; got != want {
 		t.Fatalf("invalid column name: got=%q, want=%q", got, want)
+	}
+	if err := rec.SetColumn(0, col2_1); err == nil {
+		t.Fatalf("expected an error")
+	}
+	if err := rec.SetColumn(1, col2_1); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(rec.Column(1), col2_1) {
+		t.Fatalf("invalid column: got=%q, want=%q", rec.Column(1), col2_1)
 	}
 
 	for _, tc := range []struct {

--- a/go/arrow/record.go
+++ b/go/arrow/record.go
@@ -37,6 +37,7 @@ type Record interface {
 	Columns() []Array
 	Column(i int) Array
 	ColumnName(i int) string
+	SetColumn(i int, col Array) error
 
 	// NewSlice constructs a zero-copy slice of the record with the indicated
 	// indices i and j, corresponding to array[i:j].

--- a/go/arrow/record.go
+++ b/go/arrow/record.go
@@ -37,7 +37,7 @@ type Record interface {
 	Columns() []Array
 	Column(i int) Array
 	ColumnName(i int) string
-	SetColumn(i int, col Array) error
+	SetColumn(i int, col Array) (Record, error)
 
 	// NewSlice constructs a zero-copy slice of the record with the indicated
 	// indices i and j, corresponding to array[i:j].


### PR DESCRIPTION
Small [method](https://arrow.apache.org/docs/cpp/api/table.html#_CPPv4NK5arrow11RecordBatch9SetColumnEiRKNSt10shared_ptrI5FieldEERKNSt10shared_ptrI5ArrayEE) similar to the c/c++ implementation.

* Closes: #34832