### PR TITLE
GH-15202: [R] Function create_package_with_all_dependencies fails

### DIFF
--- a/r/tools/download_dependencies_R.sh
+++ b/r/tools/download_dependencies_R.sh
@@ -45,7 +45,7 @@ download_dependency() {
   local url=$1
   local out=$2
 
-  echo 'download.file("'${url}'", "'${out}'")'
+  echo 'download.file("'${url}'", "'${out}'", quiet = !identical(tolower(Sys.getenv("ARROW_R_DEV")), "true"))'
 }
 
 print_tar_name() {

--- a/r/tools/download_dependencies_R.sh
+++ b/r/tools/download_dependencies_R.sh
@@ -45,7 +45,7 @@ download_dependency() {
   local url=$1
   local out=$2
 
-  echo 'download.file("'${url}'", "'${out}'", quiet = TRUE)'
+  echo 'download.file("'${url}'", "'${out}'")'
 }
 
 print_tar_name() {


### PR DESCRIPTION
The linked user issue shows a failure of `create_package_with_all_dependencies()` due to a problem downloading a dependency, the nature of which is unclear from the output. If we allow output shown when downloading these dependencies, it'll make it easier for users to diagnose issues when things go wrong.

(We might also not want to merge this as this was an unusual situation, and we might not want that much output to be displayed?)
* Closes: #15202