### PR TITLE
GH-34790: [Go]: Add array.Diff()

### DIFF
--- a/go/arrow/array/diff.go
+++ b/go/arrow/array/diff.go
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package array
 
 import (

--- a/go/arrow/array/diff.go
+++ b/go/arrow/array/diff.go
@@ -47,7 +47,7 @@ import (
 // target: an array of identical type to base whose elements differ from base's
 // mem: memory to store the result will be allocated from this memory pool
 func Diff(mem memory.Allocator, base, target arrow.Array) (*Struct, error) {
-	if arrow.TypeEqual(base.DataType(), target.DataType()) {
+	if !arrow.TypeEqual(base.DataType(), target.DataType()) {
 		return nil, fmt.Errorf("%w: only taking the diff of like-typed arrays is supported", arrow.ErrNotImplemented)
 	}
 	switch base.DataType().ID() {

--- a/go/arrow/array/diff.go
+++ b/go/arrow/array/diff.go
@@ -51,9 +51,9 @@ func Diff(base, target arrow.Array) (inserts []bool, runLengths []int64, err err
 	case arrow.EXTENSION:
 		return Diff(base.(ExtensionArray).Storage(), target.(ExtensionArray).Storage())
 	case arrow.DICTIONARY:
-		return nil, nil, fmt.Errorf("%w: diffing arrays of type %s is not implemented", arrow.ErrNotImplemented, base.DataType().String())
+		return nil, nil, fmt.Errorf("%w: diffing arrays of type %s is not implemented", arrow.ErrNotImplemented, base.DataType())
 	case arrow.RUN_END_ENCODED:
-		return nil, nil, fmt.Errorf("%w: diffing arrays of type %s is not implemented", arrow.ErrNotImplemented, base.DataType().String())
+		return nil, nil, fmt.Errorf("%w: diffing arrays of type %s is not implemented", arrow.ErrNotImplemented, base.DataType())
 	}
 	d := newQuadraticSpaceMyersDiff(base, target)
 	return d.Diff()
@@ -63,10 +63,6 @@ func Diff(base, target arrow.Array) (inserts []bool, runLengths []int64, err err
 type editPoint struct {
 	base   int
 	target int
-}
-
-func (e editPoint) Equals(other editPoint) bool {
-	return e.base == other.base && e.target == other.target
 }
 
 type quadraticSpaceMyersDiff struct {

--- a/go/arrow/array/diff.go
+++ b/go/arrow/array/diff.go
@@ -171,7 +171,7 @@ func (d *quadraticSpaceMyersDiff) Next() {
 
 	// check if inserting from target could do better
 	for i, iOut := 0, 1; i < d.editCount; i, iOut = i+1, iOut+1 {
-		// retrieve the previously computed best endpoint for (edit_count_, i_out)
+		// retrieve the previously computed best endpoint for (editCount, iOut)
 		// for comparison with the best endpoint achievable with an insertion
 		endpointAfterDeletion := d.getEditPoint(d.editCount, iOut+currentOffset)
 
@@ -179,7 +179,7 @@ func (d *quadraticSpaceMyersDiff) Next() {
 		endpointAfterInsertion := d.insertOne(previousEndpoint)
 
 		if endpointAfterInsertion.base-endpointAfterDeletion.base >= 0 {
-			// insertion was more efficient; keep it and mark the insertion in insert_
+			// insertion was more efficient; keep it and mark the insertion in insert
 			d.insert[iOut+currentOffset] = true
 			d.endpointBase[iOut+currentOffset] = endpointAfterInsertion.base
 		}

--- a/go/arrow/array/diff.go
+++ b/go/arrow/array/diff.go
@@ -1,0 +1,260 @@
+package array
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/apache/arrow/go/v12/arrow"
+	"github.com/apache/arrow/go/v12/arrow/memory"
+)
+
+// Diff compares two arrays, returning an edit script which expresses the difference
+// between them. The edit script can be applied to the base array to produce the target.
+//
+// An edit script is an array of struct(insert bool, run_length int64).
+// Each element of "insert" determines whether an element was inserted into (true)
+// or deleted from (false) base. Each insertion or deletion is followed by a run of
+// elements which are unchanged from base to target; the length of this run is stored
+// in "run_length". (Note that the edit script begins and ends with a run of shared
+// elements but both fields of the struct must have the same length. To accommodate this
+// the first element of "insert" should be ignored.)
+//
+// For example for base "hlloo" and target "hello", the edit script would be
+// [
+//
+//	{"insert": false, "run_length": 1}, // leading run of length 1 ("h")
+//	{"insert": true, "run_length": 3}, // insert("e") then a run of length 3 ("llo")
+//	{"insert": false, "run_length": 0} // delete("o") then an empty run
+//
+// ]
+//
+// base: baseline for comparison
+// target: an array of identical type to base whose elements differ from base's
+// mem: memory to store the result will be allocated from this memory pool
+func Diff(base, target arrow.Array, mem memory.Allocator) (*Struct, error) {
+	if base.DataType() != target.DataType() {
+		return nil, errors.New("only taking the diff of like-typed arrays is supported")
+	}
+	switch base.DataType().ID() {
+	case arrow.EXTENSION:
+		return Diff(base.(ExtensionArray).Storage(), target.(ExtensionArray).Storage(), mem)
+	case arrow.DICTIONARY:
+		return nil, fmt.Errorf("diffing arrays of type %s is not implemented", base.DataType().String())
+	case arrow.RUN_END_ENCODED:
+		return nil, fmt.Errorf("diffing arrays of type %s is not implemented", base.DataType().String())
+	}
+	d := newQuadraticSpaceMyersDiff(base, target)
+	r, err := d.Diff(mem)
+	if err != nil {
+		if r != nil {
+			r.Release()
+		}
+		return nil, err
+	}
+	return r, nil
+}
+
+// editPoint represents an intermediate state in the comparison of two arrays
+type editPoint struct {
+	base   int
+	target int
+}
+
+func (e editPoint) Equals(other editPoint) bool {
+	return e.base == other.base && e.target == other.target
+}
+
+type quadraticSpaceMyersDiff struct {
+	base         arrow.Array
+	target       arrow.Array
+	finishIndex  int
+	editCount    int
+	endpointBase []int
+	insert       []bool
+	baseBegin    int
+	targetBegin  int
+	baseEnd      int
+	targetEnd    int
+}
+
+func newQuadraticSpaceMyersDiff(base, target arrow.Array) *quadraticSpaceMyersDiff {
+	d := &quadraticSpaceMyersDiff{
+		base:         base,
+		target:       target,
+		finishIndex:  -1,
+		editCount:    0,
+		endpointBase: []int{},
+		insert:       []bool{},
+		baseBegin:    0,
+		targetBegin:  0,
+		baseEnd:      base.Len(),
+		targetEnd:    target.Len(),
+	}
+	d.endpointBase = []int{d.extendFrom(editPoint{d.baseBegin, d.targetBegin}).base}
+	if d.baseEnd-d.baseBegin == d.targetEnd-d.targetBegin && d.endpointBase[0] == d.baseEnd {
+		// trivial case: base == target
+		d.finishIndex = 0
+	}
+	return d
+}
+
+func (d *quadraticSpaceMyersDiff) valuesEqual(baseIndex, targetIndex int) bool {
+	baseNull := d.base.IsNull(baseIndex)
+	targetNull := d.target.IsNull(targetIndex)
+	if baseNull || targetNull {
+		return baseNull && targetNull
+	}
+	return SliceEqual(d.base, int64(baseIndex), int64(baseIndex+1), d.target, int64(targetIndex), int64(targetIndex+1))
+}
+
+// increment the position within base and target (the elements skipped in this way were
+// present in both sequences)
+func (d *quadraticSpaceMyersDiff) extendFrom(p editPoint) editPoint {
+	for p.base != d.baseEnd && p.target != d.targetEnd {
+		if !d.valuesEqual(p.base, p.target) {
+			break
+		}
+		p.base++
+		p.target++
+	}
+	return p
+}
+
+// increment the position within base (the element pointed to was deleted)
+// then extend maximally
+func (d *quadraticSpaceMyersDiff) deleteOne(p editPoint) editPoint {
+	if p.base != d.baseEnd {
+		p.base++
+	}
+	return d.extendFrom(p)
+}
+
+// increment the position within target (the element pointed to was inserted)
+// then extend maximally
+func (d *quadraticSpaceMyersDiff) insertOne(p editPoint) editPoint {
+	if p.target != d.targetEnd {
+		p.target++
+	}
+	return d.extendFrom(p)
+}
+
+// beginning of a range for storing per-edit state in endpointBase and insert
+func storageOffset(editCount int) int {
+	return editCount * (editCount + 1) / 2
+}
+
+// given edit_count and index, augment endpointBase[index] with the corresponding
+// position in target (which is only implicitly represented in editCount, index)
+func (d *quadraticSpaceMyersDiff) getEditPoint(editCount, index int) editPoint {
+	insertionsMinusDeletions := 2*(index-storageOffset(editCount)) - editCount
+	maximalBase := d.endpointBase[index]
+	maximalTarget := min(d.targetBegin+((maximalBase-d.baseBegin)+insertionsMinusDeletions), d.targetEnd)
+	return editPoint{maximalBase, maximalTarget}
+}
+
+func (d *quadraticSpaceMyersDiff) Next() {
+	d.editCount++
+	if len(d.endpointBase) < storageOffset(d.editCount+1) {
+		d.endpointBase = append(d.endpointBase, make([]int, storageOffset(d.editCount+1)-len(d.endpointBase))...)
+	}
+	if len(d.insert) < storageOffset(d.editCount+1) {
+		d.insert = append(d.insert, make([]bool, storageOffset(d.editCount+1)-len(d.insert))...)
+	}
+	previousOffset := storageOffset(d.editCount - 1)
+	currentOffset := storageOffset(d.editCount)
+
+	// try deleting from base first
+	for i, iOut := 0, 0; i < d.editCount; i, iOut = i+1, iOut+1 {
+		previousEndpoint := d.getEditPoint(d.editCount-1, i+previousOffset)
+		d.endpointBase[iOut+currentOffset] = d.deleteOne(previousEndpoint).base
+	}
+
+	// check if inserting from target could do better
+	for i, iOut := 0, 1; i < d.editCount; i, iOut = i+1, iOut+1 {
+		// retrieve the previously computed best endpoint for (edit_count_, i_out)
+		// for comparison with the best endpoint achievable with an insertion
+		endpointAfterDeletion := d.getEditPoint(d.editCount, iOut+currentOffset)
+
+		previousEndpoint := d.getEditPoint(d.editCount-1, i+previousOffset)
+		endpointAfterInsertion := d.insertOne(previousEndpoint)
+
+		if endpointAfterInsertion.base-endpointAfterDeletion.base >= 0 {
+			// insertion was more efficient; keep it and mark the insertion in insert_
+			d.insert[iOut+currentOffset] = true
+			d.endpointBase[iOut+currentOffset] = endpointAfterInsertion.base
+		}
+	}
+
+	finish := editPoint{d.baseEnd, d.targetEnd}
+	for iOut := 0; iOut < d.editCount+1; iOut++ {
+		if d.getEditPoint(d.editCount, iOut+currentOffset) == finish {
+			d.finishIndex = iOut + currentOffset
+			return
+		}
+	}
+}
+
+func (d *quadraticSpaceMyersDiff) Done() bool {
+	return d.finishIndex != -1
+}
+
+func (d *quadraticSpaceMyersDiff) GetEdits(mem memory.Allocator) (*Struct, error) {
+	if !d.Done() {
+		panic("GetEdits called but Done() = false")
+	}
+
+	length := d.editCount + 1
+	insertBuf := make([]bool, length)
+	runLength := make([]int64, length)
+	index := d.finishIndex
+	endpoint := d.getEditPoint(d.editCount, d.finishIndex)
+
+	for i := d.editCount; i > 0; i-- {
+		insert := d.insert[index]
+		insertBuf[i] = insert
+		insertionsMinusDeletions := (endpoint.base - d.baseBegin) - (endpoint.target - d.targetBegin)
+		if insert {
+			insertionsMinusDeletions++
+		} else {
+			insertionsMinusDeletions--
+		}
+		index = (i-1-insertionsMinusDeletions)/2 + storageOffset(i-1)
+
+		// endpoint of previous edit
+		previous := d.getEditPoint(i-1, index)
+		in := 0
+		if insert {
+			in = 1
+		}
+		runLength[i] = int64(endpoint.base - previous.base - (1 - in))
+		endpoint = previous
+	}
+	insertBuf[0] = false
+	runLength[0] = int64(endpoint.base - d.baseBegin)
+
+	inserts := NewBooleanBuilder(mem)
+	defer inserts.Release()
+	inserts.AppendValues(insertBuf, nil)
+
+	run := NewInt64Builder(mem)
+	defer run.Release()
+	run.AppendValues(runLength, nil)
+
+	insArr := inserts.NewArray()
+	defer insArr.Release()
+
+	runArr := run.NewArray()
+	defer runArr.Release()
+
+	return NewStructArray([]arrow.Array{
+		insArr,
+		runArr,
+	}, []string{"insert", "run_length"})
+}
+
+func (d *quadraticSpaceMyersDiff) Diff(mem memory.Allocator) (*Struct, error) {
+	for !d.Done() {
+		d.Next()
+	}
+	return d.GetEdits(mem)
+}

--- a/go/arrow/array/diff.go
+++ b/go/arrow/array/diff.go
@@ -32,7 +32,7 @@ import (
 // target: an array of identical type to base whose elements differ from base's
 // mem: memory to store the result will be allocated from this memory pool
 func Diff(base, target arrow.Array, mem memory.Allocator) (*Struct, error) {
-	if base.DataType() != target.DataType() {
+	if base.DataType().Fingerprint() != target.DataType().Fingerprint() {
 		return nil, errors.New("only taking the diff of like-typed arrays is supported")
 	}
 	switch base.DataType().ID() {

--- a/go/arrow/array/diff_test.go
+++ b/go/arrow/array/diff_test.go
@@ -54,7 +54,7 @@ func (s *diffTestCase) check(t *testing.T) {
 	}
 	defer target.Release()
 
-	got, err := array.Diff(base, target, mem)
+	got, err := array.Diff(mem, base, target)
 	if err != nil {
 		t.Fatalf("got unexpected error %v", err)
 	}
@@ -431,7 +431,7 @@ func testRandomCase(t *testing.T, rng *rand.Rand) {
 	}
 	defer target.Release()
 
-	got, err := array.Diff(base, target, mem)
+	got, err := array.Diff(mem, base, target)
 	if err != nil {
 		t.Fatalf("got unexpected error %v", err)
 	}

--- a/go/arrow/array/diff_test.go
+++ b/go/arrow/array/diff_test.go
@@ -1,0 +1,140 @@
+package array_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/apache/arrow/go/v12/arrow"
+	"github.com/apache/arrow/go/v12/arrow/array"
+	"github.com/apache/arrow/go/v12/arrow/memory"
+)
+
+func TestDiff(t *testing.T) {
+	cases := []struct {
+		name          string
+		base          string
+		target        string
+		dataType      arrow.DataType
+		wantInsert    []bool
+		wantRunLength []int64
+	}{
+		{
+			name:          "trivial: empty",
+			base:          `[]`,
+			target:        `[]`,
+			dataType:      arrow.PrimitiveTypes.Int32,
+			wantInsert:    []bool{false},
+			wantRunLength: []int64{0},
+		},
+		{
+			name:          "trivial: nulls",
+			base:          `[null, null]`,
+			target:        `[null, null, null, null]`,
+			dataType:      arrow.PrimitiveTypes.Int32,
+			wantInsert:    []bool{false, true, true},
+			wantRunLength: []int64{2, 0, 0},
+		},
+		{
+			name:          "trivial: equal",
+			base:          `[1, 2, 3]`,
+			target:        `[1, 2, 3]`,
+			dataType:      arrow.PrimitiveTypes.Int32,
+			wantInsert:    []bool{false},
+			wantRunLength: []int64{3},
+		},
+		{
+			name:          "basics: insert one",
+			base:          `[1, 2, null, 5]`,
+			target:        `[1, 2, 3, null, 5]`,
+			dataType:      arrow.PrimitiveTypes.Int32,
+			wantInsert:    []bool{false, true},
+			wantRunLength: []int64{2, 2},
+		},
+		{
+			name:          "basics: delete one",
+			base:          `[1, 2, 3, null, 5]`,
+			target:        `[1, 2, null, 5]`,
+			dataType:      arrow.PrimitiveTypes.Int32,
+			wantInsert:    []bool{false, false},
+			wantRunLength: []int64{2, 2},
+		},
+		{
+			name:          "basics: change one",
+			base:          `[1, 2, 3, null, 5]`,
+			target:        `[1, 2, 23, null, 5]`,
+			dataType:      arrow.PrimitiveTypes.Int32,
+			wantInsert:    []bool{false, false, true},
+			wantRunLength: []int64{2, 0, 2},
+		},
+		{
+			name:          "basics: null out one",
+			base:          `[1, 2, 3, null, 5]`,
+			target:        `[1, 2, null, null, 5]`,
+			dataType:      arrow.PrimitiveTypes.Int32,
+			wantInsert:    []bool{false, false, true},
+			wantRunLength: []int64{2, 1, 1},
+		},
+		{
+			name:          "basics: append some",
+			base:          `[1, 2, 3, null, 5]`,
+			target:        `[1, 2, 3, null, 5, 6, 7, 8, 9]`,
+			dataType:      arrow.PrimitiveTypes.Int32,
+			wantInsert:    []bool{false, true, true, true, true},
+			wantRunLength: []int64{5, 0, 0, 0, 0},
+		},
+		{
+			name:          "basics: prepend some",
+			base:          `[1, 2, 3, null, 5]`,
+			target:        `[6, 4, 2, 0, 1, 2, 3, null, 5]`,
+			dataType:      arrow.PrimitiveTypes.Int32,
+			wantInsert:    []bool{false, true, true, true, true},
+			wantRunLength: []int64{0, 0, 0, 0, 5},
+		},
+	}
+	for _, tc := range cases {
+		if tc.dataType == nil {
+			t.Fatalf("test case %q has nil dataType", tc.name)
+		}
+
+		t.Run(tc.name, func(t *testing.T) {
+			mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+			defer mem.AssertSize(t, 0)
+
+			base, _, err := array.FromJSON(mem, tc.dataType, strings.NewReader(tc.base))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer base.Release()
+
+			target, _, err := array.FromJSON(mem, tc.dataType, strings.NewReader(tc.target))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer target.Release()
+
+			got, err := array.Diff(base, target, mem)
+			if err != nil {
+				t.Fatalf("got unexpected error %v", err)
+			}
+			defer got.Release()
+
+			gotInsert := boolValues(got.Field(0).(*array.Boolean))
+			gotRunLength := got.Field(1).(*array.Int64).Int64Values()
+			if !reflect.DeepEqual(gotInsert, tc.wantInsert) {
+				t.Errorf("Diff(\n  base=%v, \ntarget=%v\n) got insert %v, want %v", base, target, gotInsert, tc.wantInsert)
+			}
+			if !reflect.DeepEqual(gotRunLength, tc.wantRunLength) {
+				t.Errorf("Diff(\n  base=%v, \ntarget=%v\n) got run length %v, want %v", base, target, gotRunLength, tc.wantRunLength)
+			}
+		})
+	}
+}
+
+func boolValues(b *array.Boolean) []bool {
+	ret := make([]bool, b.Len())
+	for i := range ret {
+		ret[i] = b.Value(i)
+	}
+	return ret
+}

--- a/go/arrow/array/diff_test.go
+++ b/go/arrow/array/diff_test.go
@@ -1,6 +1,9 @@
 package array_test
 
 import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
 	"reflect"
 	"strings"
 	"testing"
@@ -10,124 +13,46 @@ import (
 	"github.com/apache/arrow/go/v12/arrow/memory"
 )
 
-func TestDiff(t *testing.T) {
-	cases := []struct {
-		name          string
-		base          string
-		target        string
-		dataType      arrow.DataType
-		wantInsert    []bool
-		wantRunLength []int64
-	}{
-		{
-			name:          "trivial: empty",
-			base:          `[]`,
-			target:        `[]`,
-			dataType:      arrow.PrimitiveTypes.Int32,
-			wantInsert:    []bool{false},
-			wantRunLength: []int64{0},
-		},
-		{
-			name:          "trivial: nulls",
-			base:          `[null, null]`,
-			target:        `[null, null, null, null]`,
-			dataType:      arrow.PrimitiveTypes.Int32,
-			wantInsert:    []bool{false, true, true},
-			wantRunLength: []int64{2, 0, 0},
-		},
-		{
-			name:          "trivial: equal",
-			base:          `[1, 2, 3]`,
-			target:        `[1, 2, 3]`,
-			dataType:      arrow.PrimitiveTypes.Int32,
-			wantInsert:    []bool{false},
-			wantRunLength: []int64{3},
-		},
-		{
-			name:          "basics: insert one",
-			base:          `[1, 2, null, 5]`,
-			target:        `[1, 2, 3, null, 5]`,
-			dataType:      arrow.PrimitiveTypes.Int32,
-			wantInsert:    []bool{false, true},
-			wantRunLength: []int64{2, 2},
-		},
-		{
-			name:          "basics: delete one",
-			base:          `[1, 2, 3, null, 5]`,
-			target:        `[1, 2, null, 5]`,
-			dataType:      arrow.PrimitiveTypes.Int32,
-			wantInsert:    []bool{false, false},
-			wantRunLength: []int64{2, 2},
-		},
-		{
-			name:          "basics: change one",
-			base:          `[1, 2, 3, null, 5]`,
-			target:        `[1, 2, 23, null, 5]`,
-			dataType:      arrow.PrimitiveTypes.Int32,
-			wantInsert:    []bool{false, false, true},
-			wantRunLength: []int64{2, 0, 2},
-		},
-		{
-			name:          "basics: null out one",
-			base:          `[1, 2, 3, null, 5]`,
-			target:        `[1, 2, null, null, 5]`,
-			dataType:      arrow.PrimitiveTypes.Int32,
-			wantInsert:    []bool{false, false, true},
-			wantRunLength: []int64{2, 1, 1},
-		},
-		{
-			name:          "basics: append some",
-			base:          `[1, 2, 3, null, 5]`,
-			target:        `[1, 2, 3, null, 5, 6, 7, 8, 9]`,
-			dataType:      arrow.PrimitiveTypes.Int32,
-			wantInsert:    []bool{false, true, true, true, true},
-			wantRunLength: []int64{5, 0, 0, 0, 0},
-		},
-		{
-			name:          "basics: prepend some",
-			base:          `[1, 2, 3, null, 5]`,
-			target:        `[6, 4, 2, 0, 1, 2, 3, null, 5]`,
-			dataType:      arrow.PrimitiveTypes.Int32,
-			wantInsert:    []bool{false, true, true, true, true},
-			wantRunLength: []int64{0, 0, 0, 0, 5},
-		},
+type diffTestCase struct {
+	dataType arrow.DataType
+
+	baseJSON      string
+	targetJSON    string
+	wantInsert    []bool
+	wantRunLength []int64
+}
+
+func (s *diffTestCase) check(t *testing.T) {
+	t.Helper()
+
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	base, _, err := array.FromJSON(mem, s.dataType, strings.NewReader(s.baseJSON))
+	if err != nil {
+		t.Fatal(err)
 	}
-	for _, tc := range cases {
-		if tc.dataType == nil {
-			t.Fatalf("test case %q has nil dataType", tc.name)
-		}
+	defer base.Release()
 
-		t.Run(tc.name, func(t *testing.T) {
-			mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
-			defer mem.AssertSize(t, 0)
+	target, _, err := array.FromJSON(mem, s.dataType, strings.NewReader(s.targetJSON))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer target.Release()
 
-			base, _, err := array.FromJSON(mem, tc.dataType, strings.NewReader(tc.base))
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer base.Release()
+	got, err := array.Diff(base, target, mem)
+	if err != nil {
+		t.Fatalf("got unexpected error %v", err)
+	}
+	defer got.Release()
 
-			target, _, err := array.FromJSON(mem, tc.dataType, strings.NewReader(tc.target))
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer target.Release()
-
-			got, err := array.Diff(base, target, mem)
-			if err != nil {
-				t.Fatalf("got unexpected error %v", err)
-			}
-			defer got.Release()
-
-			gotInsert := boolValues(got.Field(0).(*array.Boolean))
-			gotRunLength := got.Field(1).(*array.Int64).Int64Values()
-			if !reflect.DeepEqual(gotInsert, tc.wantInsert) {
-				t.Errorf("Diff(\n  base=%v, \ntarget=%v\n) got insert %v, want %v", base, target, gotInsert, tc.wantInsert)
-			}
-			if !reflect.DeepEqual(gotRunLength, tc.wantRunLength) {
-				t.Errorf("Diff(\n  base=%v, \ntarget=%v\n) got run length %v, want %v", base, target, gotRunLength, tc.wantRunLength)
-			}
-		})
+	gotInsert := boolValues(got.Field(0).(*array.Boolean))
+	gotRunLength := got.Field(1).(*array.Int64).Int64Values()
+	if !reflect.DeepEqual(gotInsert, s.wantInsert) {
+		t.Errorf("Diff(\n  base=%v, \ntarget=%v\n) got insert %v, want %v", base, target, gotInsert, s.wantInsert)
+	}
+	if !reflect.DeepEqual(gotRunLength, s.wantRunLength) {
+		t.Errorf("Diff(\n  base=%v, \ntarget=%v\n) got run length %v, want %v", base, target, gotRunLength, s.wantRunLength)
 	}
 }
 
@@ -137,4 +62,403 @@ func boolValues(b *array.Boolean) []bool {
 		ret[i] = b.Value(i)
 	}
 	return ret
+}
+
+func TestDiff_Trivial(t *testing.T) {
+	cases := []struct {
+		name          string
+		base          string
+		target        string
+		wantInsert    []bool
+		wantRunLength []int64
+	}{
+		{
+			name:          "empty",
+			base:          `[]`,
+			target:        `[]`,
+			wantInsert:    []bool{false},
+			wantRunLength: []int64{0},
+		},
+		{
+			name:          "nulls",
+			base:          `[null, null]`,
+			target:        `[null, null, null, null]`,
+			wantInsert:    []bool{false, true, true},
+			wantRunLength: []int64{2, 0, 0},
+		},
+		{
+			name:          "equal",
+			base:          `[1, 2, 3]`,
+			target:        `[1, 2, 3]`,
+			wantInsert:    []bool{false},
+			wantRunLength: []int64{3},
+		},
+	}
+	for _, tc := range cases {
+		d := diffTestCase{
+			dataType:      arrow.PrimitiveTypes.Int32,
+			baseJSON:      tc.base,
+			targetJSON:    tc.target,
+			wantInsert:    tc.wantInsert,
+			wantRunLength: tc.wantRunLength,
+		}
+		t.Run(tc.name, d.check)
+	}
+}
+
+func TestDiff_Basics(t *testing.T) {
+	cases := []struct {
+		name          string
+		base          string
+		target        string
+		wantInsert    []bool
+		wantRunLength []int64
+	}{
+		{
+			name:          "insert one",
+			base:          `[1, 2, null, 5]`,
+			target:        `[1, 2, 3, null, 5]`,
+			wantInsert:    []bool{false, true},
+			wantRunLength: []int64{2, 2},
+		},
+		{
+			name:          "delete one",
+			base:          `[1, 2, 3, null, 5]`,
+			target:        `[1, 2, null, 5]`,
+			wantInsert:    []bool{false, false},
+			wantRunLength: []int64{2, 2},
+		},
+		{
+			name:          "change one",
+			base:          `[1, 2, 3, null, 5]`,
+			target:        `[1, 2, 23, null, 5]`,
+			wantInsert:    []bool{false, false, true},
+			wantRunLength: []int64{2, 0, 2},
+		},
+		{
+			name:          "null out one",
+			base:          `[1, 2, 3, null, 5]`,
+			target:        `[1, 2, null, null, 5]`,
+			wantInsert:    []bool{false, false, true},
+			wantRunLength: []int64{2, 1, 1},
+		},
+		{
+			name:          "append some",
+			base:          `[1, 2, 3, null, 5]`,
+			target:        `[1, 2, 3, null, 5, 6, 7, 8, 9]`,
+			wantInsert:    []bool{false, true, true, true, true},
+			wantRunLength: []int64{5, 0, 0, 0, 0},
+		},
+		{
+			name:          "prepend some",
+			base:          `[1, 2, 3, null, 5]`,
+			target:        `[6, 4, 2, 0, 1, 2, 3, null, 5]`,
+			wantInsert:    []bool{false, true, true, true, true},
+			wantRunLength: []int64{0, 0, 0, 0, 5},
+		},
+	}
+	for _, tc := range cases {
+		d := diffTestCase{
+			dataType:      arrow.PrimitiveTypes.Int32,
+			baseJSON:      tc.base,
+			targetJSON:    tc.target,
+			wantInsert:    tc.wantInsert,
+			wantRunLength: tc.wantRunLength,
+		}
+		t.Run(tc.name, d.check)
+	}
+}
+
+func TestDiff_BasicsWithBooleans(t *testing.T) {
+	cases := []struct {
+		name          string
+		base          string
+		target        string
+		wantInsert    []bool
+		wantRunLength []int64
+	}{
+		{
+			name:          "insert one",
+			base:          `[true, true, true]`,
+			target:        `[true, false, true, true]`,
+			wantInsert:    []bool{false, true},
+			wantRunLength: []int64{1, 2},
+		},
+		{
+			name:          "delete one",
+			base:          `[true, false, true, true]`,
+			target:        `[true, true, true]`,
+			wantInsert:    []bool{false, false},
+			wantRunLength: []int64{1, 2},
+		},
+		{
+			name:          "change one",
+			base:          `[false, false, true]`,
+			target:        `[true, false, true]`,
+			wantInsert:    []bool{false, false, true},
+			wantRunLength: []int64{0, 0, 2},
+		},
+		{
+			name:          "null out one",
+			base:          `[true, false, true]`,
+			target:        `[true, false, null]`,
+			wantInsert:    []bool{false, false, true},
+			wantRunLength: []int64{2, 0, 0},
+		},
+	}
+	for _, tc := range cases {
+		d := diffTestCase{
+			dataType:      &arrow.BooleanType{},
+			baseJSON:      tc.base,
+			targetJSON:    tc.target,
+			wantInsert:    tc.wantInsert,
+			wantRunLength: tc.wantRunLength,
+		}
+		t.Run(tc.name, d.check)
+	}
+}
+
+func TestDiff_BasicsWithStrings(t *testing.T) {
+	cases := []struct {
+		name          string
+		base          string
+		target        string
+		wantInsert    []bool
+		wantRunLength []int64
+	}{
+		{
+			name:          "insert one",
+			base:          `["give", "a", "break"]`,
+			target:        `["give", "me", "a", "break"]`,
+			wantInsert:    []bool{false, true},
+			wantRunLength: []int64{1, 2},
+		},
+		{
+			name:          "delete one",
+			base:          `["give", "me", "a", "break"]`,
+			target:        `["give", "a", "break"]`,
+			wantInsert:    []bool{false, false},
+			wantRunLength: []int64{1, 2},
+		},
+		{
+			name:          "change one",
+			base:          `["give", "a", "break"]`,
+			target:        `["gimme", "a", "break"]`,
+			wantInsert:    []bool{false, false, true},
+			wantRunLength: []int64{0, 0, 2},
+		},
+		{
+			name:          "null out one",
+			base:          `["give", "a", "break"]`,
+			target:        `["give", "a", null]`,
+			wantInsert:    []bool{false, false, true},
+			wantRunLength: []int64{2, 0, 0},
+		},
+	}
+	for _, tc := range cases {
+		d := diffTestCase{
+			dataType:      &arrow.StringType{},
+			baseJSON:      tc.base,
+			targetJSON:    tc.target,
+			wantInsert:    tc.wantInsert,
+			wantRunLength: tc.wantRunLength,
+		}
+		t.Run(tc.name, d.check)
+	}
+}
+
+func TestDiff_BasicsWithLists(t *testing.T) {
+	cases := []struct {
+		name          string
+		base          string
+		target        string
+		wantInsert    []bool
+		wantRunLength []int64
+	}{
+		{
+			name:          "insert one",
+			base:          `[[2, 3, 1], [], [13]]`,
+			target:        `[[2, 3, 1], [5, 9], [], [13]]`,
+			wantInsert:    []bool{false, true},
+			wantRunLength: []int64{1, 2},
+		},
+		{
+			name:          "delete one",
+			base:          `[[2, 3, 1], [5, 9], [], [13]]`,
+			target:        `[[2, 3, 1], [], [13]]`,
+			wantInsert:    []bool{false, false},
+			wantRunLength: []int64{1, 2},
+		},
+		{
+			name:          "change one",
+			base:          `[[2, 3, 1], [], [13]]`,
+			target:        `[[3, 3, 3], [], [13]]`,
+			wantInsert:    []bool{false, false, true},
+			wantRunLength: []int64{0, 0, 2},
+		},
+		{
+			name:          "null out one",
+			base:          `[[2, 3, 1], [], [13]]`,
+			target:        `[[2, 3, 1], [], null]`,
+			wantInsert:    []bool{false, false, true},
+			wantRunLength: []int64{2, 0, 0},
+		},
+	}
+	for _, tc := range cases {
+		d := diffTestCase{
+			dataType:      arrow.ListOf(arrow.PrimitiveTypes.Int32),
+			baseJSON:      tc.base,
+			targetJSON:    tc.target,
+			wantInsert:    tc.wantInsert,
+			wantRunLength: tc.wantRunLength,
+		}
+		t.Run(tc.name, d.check)
+	}
+}
+
+func TestDiff_BasicsWithStructs(t *testing.T) {
+	cases := []struct {
+		name          string
+		base          string
+		target        string
+		wantInsert    []bool
+		wantRunLength []int64
+	}{
+		{
+			name:          "insert one",
+			base:          `[{"foo": "!", "bar": 3}, {}, {"bar": 13}]`,
+			target:        `[{"foo": "!", "bar": 3}, {"foo": "?"}, {}, {"bar": 13}]`,
+			wantInsert:    []bool{false, true},
+			wantRunLength: []int64{1, 2},
+		},
+		{
+			name:          "delete one",
+			base:          `[{"foo": "!", "bar": 3}, {"foo": "?"}, {}, {"bar": 13}]`,
+			target:        `[{"foo": "!", "bar": 3}, {}, {"bar": 13}]`,
+			wantInsert:    []bool{false, false},
+			wantRunLength: []int64{1, 2},
+		},
+		{
+			name:          "change one",
+			base:          `[{"foo": "!", "bar": 3}, {}, {"bar": 13}]`,
+			target:        `[{"foo": "!", "bar": 2}, {}, {"bar": 13}]`,
+			wantInsert:    []bool{false, false, true},
+			wantRunLength: []int64{0, 0, 2},
+		},
+		{
+			name:          "null out one",
+			base:          `[{"foo": "!", "bar": 3}, {}, {"bar": 13}]`,
+			target:        `[{"foo": "!", "bar": 3}, {}, null]`,
+			wantInsert:    []bool{false, false, true},
+			wantRunLength: []int64{2, 0, 0},
+		},
+	}
+	for _, tc := range cases {
+		f1 := arrow.Field{Name: "foo", Type: arrow.BinaryTypes.String, Nullable: true}
+		f2 := arrow.Field{Name: "bar", Type: arrow.PrimitiveTypes.Int32, Nullable: true}
+		d := diffTestCase{
+			dataType:      arrow.StructOf(f1, f2),
+			baseJSON:      tc.base,
+			targetJSON:    tc.target,
+			wantInsert:    tc.wantInsert,
+			wantRunLength: tc.wantRunLength,
+		}
+		t.Run(tc.name, d.check)
+	}
+}
+
+func TestDiff_Random(t *testing.T) {
+	rng := rand.New(rand.NewSource(0xdeadbeef))
+	for i := 0; i < 100; i++ {
+		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
+			testRandomCase(t, rng)
+		})
+	}
+}
+
+func testRandomCase(t *testing.T, rng *rand.Rand) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	dataType := arrow.PrimitiveTypes.Int32
+
+	baseValues := make([]int32, rng.Intn(10))
+	for i := range baseValues {
+		baseValues[i] = rng.Int31()
+	}
+	baseJSON, err := json.Marshal(baseValues)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	targetValues := make([]int32, rng.Intn(10))
+	for i := range targetValues {
+		// create runs with some probability
+		if rng.Intn(2) == 0 && len(baseValues) > 0 {
+			targetValues[i] = baseValues[rng.Intn(len(baseValues))]
+		} else {
+			targetValues[i] = rng.Int31()
+		}
+	}
+	targetJSON, err := json.Marshal(targetValues)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	base, _, err := array.FromJSON(mem, dataType, strings.NewReader(string(baseJSON)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer base.Release()
+
+	target, _, err := array.FromJSON(mem, dataType, strings.NewReader(string(targetJSON)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer target.Release()
+
+	got, err := array.Diff(base, target, mem)
+	if err != nil {
+		t.Fatalf("got unexpected error %v", err)
+	}
+	defer got.Release()
+
+	validateEditScript(t, got, base, target)
+}
+
+// validateEditScript checks that the edit script produces target when applied to base.
+func validateEditScript(t *testing.T, edits *array.Struct, base, target arrow.Array) {
+	t.Helper()
+
+	inserts := boolValues(edits.Field(0).(*array.Boolean))
+	runLengths := edits.Field(1).(*array.Int64).Int64Values()
+
+	if len(runLengths) == 0 {
+		t.Fatalf("edit script has run length of zero")
+	}
+	if len(runLengths) != len(inserts) {
+		t.Fatalf("edit script has %d run lengths but %d insert flags", len(runLengths), len(inserts))
+	}
+
+	baseIndex := int64(0)
+	targetIndex := int64(0)
+	for i := 0; i < len(runLengths); i++ {
+		if i > 0 {
+			if inserts[i] {
+				targetIndex++
+			} else {
+				baseIndex++
+			}
+		}
+		for j := int64(0); j < runLengths[i]; j++ {
+			if !array.SliceEqual(base, baseIndex, baseIndex+1, target, targetIndex, targetIndex+1) {
+				t.Fatalf("edit script (inserts=%v, runLengths=%v) when applied to base %v does not produce target %v", inserts, runLengths, base, target)
+			}
+			baseIndex += 1
+			targetIndex += 1
+		}
+	}
+	if baseIndex != int64(base.Len()) || targetIndex != int64(target.Len()) {
+		t.Fatalf("edit script (inserts=%v, runLengths=%v) when applied to base %v does not produce target %v", inserts, runLengths, base, target)
+	}
 }

--- a/go/arrow/array/diff_test.go
+++ b/go/arrow/array/diff_test.go
@@ -39,8 +39,6 @@ type diffTestCase struct {
 }
 
 func (s *diffTestCase) check(t *testing.T) {
-	t.Helper()
-
 	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
 	defer mem.AssertSize(t, 0)
 
@@ -444,8 +442,6 @@ func testRandomCase(t *testing.T, rng *rand.Rand) {
 
 // validateEditScript checks that the edit script produces target when applied to base.
 func validateEditScript(t *testing.T, edits *array.Struct, base, target arrow.Array) {
-	t.Helper()
-
 	inserts := boolValues(edits.Field(0).(*array.Boolean))
 	runLengths := edits.Field(1).(*array.Int64).Int64Values()
 

--- a/go/arrow/array/diff_test.go
+++ b/go/arrow/array/diff_test.go
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package array_test
 
 import (


### PR DESCRIPTION
This adds an `array.Diff` function that returns an edit script that, when applied to `base`, produces `target`. This mirrors the C++ implementation. 

It does not yet include a string diff formatter.  This can be done in a follow-up.

* Closes: #34790