### PR TITLE
GH-34807: [Go] Handle `io.EOF` when reading parquet footer size and magic bytes

### DIFF
--- a/go/parquet/file/file_reader.go
+++ b/go/parquet/file/file_reader.go
@@ -163,7 +163,7 @@ func (f *Reader) parseMetaData() error {
 	buf := make([]byte, footerSize)
 	// backup 8 bytes to read the footer size (first four bytes) and the magic bytes (last 4 bytes)
 	n, err := f.r.ReadAt(buf, f.footerOffset-int64(footerSize))
-	if err != nil {
+	if err != nil && err != io.EOF {
 		return fmt.Errorf("parquet: could not read footer: %w", err)
 	}
 	if n != len(buf) {

--- a/go/parquet/file/file_reader_test.go
+++ b/go/parquet/file/file_reader_test.go
@@ -19,12 +19,13 @@ package file_test
 import (
 	"bytes"
 	"encoding/binary"
-	"github.com/apache/arrow/go/v12/parquet"
-	"github.com/apache/arrow/go/v12/parquet/schema"
-	"github.com/stretchr/testify/require"
 	"io"
 	"math/rand"
 	"testing"
+
+	"github.com/apache/arrow/go/v12/parquet"
+	"github.com/apache/arrow/go/v12/parquet/schema"
+	"github.com/stretchr/testify/require"
 
 	"github.com/apache/arrow/go/v12/arrow/memory"
 	"github.com/apache/arrow/go/v12/internal/utils"

--- a/go/parquet/file/file_reader_test.go
+++ b/go/parquet/file/file_reader_test.go
@@ -23,20 +23,19 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/apache/arrow/go/v12/parquet"
-	"github.com/apache/arrow/go/v12/parquet/schema"
-	"github.com/stretchr/testify/require"
-
 	"github.com/apache/arrow/go/v12/arrow/memory"
 	"github.com/apache/arrow/go/v12/internal/utils"
+	"github.com/apache/arrow/go/v12/parquet"
 	"github.com/apache/arrow/go/v12/parquet/compress"
 	"github.com/apache/arrow/go/v12/parquet/file"
 	"github.com/apache/arrow/go/v12/parquet/internal/encoding"
 	format "github.com/apache/arrow/go/v12/parquet/internal/gen-go/parquet"
 	"github.com/apache/arrow/go/v12/parquet/internal/thrift"
 	"github.com/apache/arrow/go/v12/parquet/metadata"
+	"github.com/apache/arrow/go/v12/parquet/schema"
 	libthrift "github.com/apache/thrift/lib/go/thrift"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 


### PR DESCRIPTION
* Closes: #34807