### PR TITLE
GH-34778: [Java] Only apply ServerInterceptorAdapter logic to Flight service requests

### DIFF
--- a/docs/source/java/flight.rst
+++ b/docs/source/java/flight.rst
@@ -204,8 +204,7 @@ authentication methods.
 Adding Services
 ===============
 
-Servers can add other gRPC services. For example, to add the `Health Check service
-<https://github.com/grpc/grpc/blob/master/doc/health-checking.md>`:
+Servers can add other gRPC services. For example, to add the `Health Check service <https://github.com/grpc/grpc/blob/master/doc/health-checking.md>`:
 
 .. code-block:: Java
 

--- a/docs/source/java/flight.rst
+++ b/docs/source/java/flight.rst
@@ -201,6 +201,34 @@ request/response. On the server, they can inspect incoming headers and
 fail the request; hence, they can be used to implement custom
 authentication methods.
 
+Adding Services
+===============
+
+Servers can add other gRPC services. For example, to add the `Health Check service
+<https://github.com/grpc/grpc/blob/master/doc/health-checking.md>`:
+
+.. code-block:: Java
+
+    final HealthStatusManager statusManager = new HealthStatusManager();
+    final Consumer<NettyServerBuilder> consumer = (builder) -> {
+      builder.addService(statusManager.getHealthService());
+    };
+    final Location location = forGrpcInsecure(LOCALHOST, 5555);
+    try (
+        BufferAllocator a = new RootAllocator(Long.MAX_VALUE);
+        Producer producer = new Producer(a);
+        FlightServer s = FlightServer.builder(a, location, producer)
+            .transportHint("grpc.builderConsumer", consumer).build().start();
+    ) {
+      Channel channel = NettyChannelBuilder.forAddress(location.toSocketAddress()).usePlaintext().build();
+      HealthCheckResponse response = HealthGrpc
+              .newBlockingStub(channel)
+              .check(HealthCheckRequest.getDefaultInstance());
+
+      System.out.println(response.getStatus());
+    }
+
+
 :ref:`Flight best practices <flight-best-practices>`
 ====================================================
 

--- a/docs/source/java/flight.rst
+++ b/docs/source/java/flight.rst
@@ -204,7 +204,7 @@ authentication methods.
 Adding Services
 ===============
 
-Servers can add other gRPC services. For example, to add the `Health Check service <https://github.com/grpc/grpc/blob/master/doc/health-checking.md>`:
+Servers can add other gRPC services. For example, to add the `Health Check service <https://github.com/grpc/grpc/blob/master/doc/health-checking.md>`_:
 
 .. code-block:: Java
 

--- a/java/flight/flight-core/pom.xml
+++ b/java/flight/flight-core/pom.xml
@@ -98,6 +98,11 @@
       <groupId>io.grpc</groupId>
       <artifactId>grpc-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-services</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightServer.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightServer.java
@@ -47,6 +47,7 @@ import org.apache.arrow.util.VisibleForTesting;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
+import io.grpc.BindableService;
 import io.grpc.Server;
 import io.grpc.ServerInterceptors;
 import io.grpc.netty.NettyServerBuilder;
@@ -175,11 +176,13 @@ public class FlightServer implements AutoCloseable {
     private final List<KeyFactory<?>> interceptors;
     // Keep track of inserted interceptors
     private final Set<String> interceptorKeys;
+    private final List<BindableService> extraServices;
 
     Builder() {
       builderOptions = new HashMap<>();
       interceptors = new ArrayList<>();
       interceptorKeys = new HashSet<>();
+      extraServices = new ArrayList<>();
     }
 
     Builder(BufferAllocator allocator, Location location, FlightProducer producer) {
@@ -293,6 +296,8 @@ public class FlightServer implements AutoCloseable {
         return null;
       });
 
+      extraServices.forEach(builder::addService);
+
       builder.intercept(new ServerInterceptorAdapter(interceptors));
       return new FlightServer(location, builder.build(), grpcExecutor);
     }
@@ -393,6 +398,11 @@ public class FlightServer implements AutoCloseable {
 
     public Builder producer(FlightProducer producer) {
       this.producer = Preconditions.checkNotNull(producer);
+      return this;
+    }
+
+    public Builder addService(BindableService service) {
+      this.extraServices.add(service);
       return this;
     }
   }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightServer.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightServer.java
@@ -48,7 +48,6 @@ import org.apache.arrow.util.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import io.grpc.Server;
-import io.grpc.ServerBuilder;
 import io.grpc.ServerInterceptors;
 import io.grpc.netty.NettyServerBuilder;
 import io.netty.channel.EventLoopGroup;
@@ -176,7 +175,6 @@ public class FlightServer implements AutoCloseable {
     private final List<KeyFactory<?>> interceptors;
     // Keep track of inserted interceptors
     private final Set<String> interceptorKeys;
-    private Consumer<ServerBuilder<?>> transportHook = null;
 
     Builder() {
       builderOptions = new HashMap<>();
@@ -297,11 +295,6 @@ public class FlightServer implements AutoCloseable {
       });
 
       builder.intercept(new ServerInterceptorAdapter(interceptors));
-
-      if (transportHook != null) {
-        transportHook.accept(builder);
-      }
-      
       return new FlightServer(location, builder.build(), grpcExecutor);
     }
 
@@ -401,11 +394,6 @@ public class FlightServer implements AutoCloseable {
 
     public Builder producer(FlightProducer producer) {
       this.producer = Preconditions.checkNotNull(producer);
-      return this;
-    }
-
-    public Builder withTransportHook(Consumer<ServerBuilder<?>> hook) {
-      this.transportHook = hook;
       return this;
     }
   }


### PR DESCRIPTION
### Rationale for this change

The interceptor applies to all methods. When receiving a method for a different service, we don't want to throw an error because the method doesn't exist.

### What changes are included in this PR?

- Ensure added services work correctly
- Add test to make sure registered services work correctly
- Add documentation explaining how to add services

### Are these changes tested?

Yes

### Are there any user-facing changes?

Yes, documentation now explains how to add services

* Closes: #34778