### PR TITLE
GH-34823: [C++][ORC] Fix ORC CHAR type mapping

### DIFF
--- a/cpp/src/arrow/adapters/orc/adapter_test.cc
+++ b/cpp/src/arrow/adapters/orc/adapter_test.cc
@@ -502,7 +502,7 @@ TEST(TestAdapterRead, ReadCharAndVarcharType) {
       EXPECT_EQ(expected_data[col][row], str_array->GetString(row));
     }
   }
-  ASSERT_TRUE(stripe_reader->ReadNext(&record_batch).ok());
+  ASSERT_OK(stripe_reader->ReadNext(&record_batch));
   ASSERT_EQ(record_batch, nullptr);
 }
 

--- a/cpp/src/arrow/adapters/orc/adapter_test.cc
+++ b/cpp/src/arrow/adapters/orc/adapter_test.cc
@@ -503,7 +503,7 @@ TEST(TestAdapterRead, ReadCharAndVarcharType) {
     }
   }
   ASSERT_OK(stripe_reader->ReadNext(&record_batch));
-  ASSERT_EQ(record_batch, nullptr);
+  ASSERT_EQ(nullptr, record_batch);
 }
 
 // Trivial

--- a/cpp/src/arrow/adapters/orc/adapter_test.cc
+++ b/cpp/src/arrow/adapters/orc/adapter_test.cc
@@ -468,14 +468,14 @@ TEST(TestAdapterRead, ReadCharAndVarcharType) {
   const std::vector<std::vector<std::string>> expected_data = {{"abcd  ", "ABCDEF"},
                                                                {"abcd", "ABCDEF"}};
 
-  for (uint64_t col = 0; col < orc_type->getSubtypeCount(); col++) {
+  for (uint64_t col = 0; col < orc_type->getSubtypeCount(); ++col) {
     auto str_batch =
         internal::checked_cast<liborc::StringVectorBatch*>(struct_batch->fields[col]);
     str_batch->hasNulls = false;
     str_batch->numElements = row_count;
-    for (int64_t i = 0; i < row_count; ++i) {
-      str_batch->data[i] = const_cast<char*>(data[i].c_str());
-      str_batch->length[i] = static_cast<int64_t>(data[i].size());
+    for (int64_t row = 0; row < row_count; ++row) {
+      str_batch->data[row] = const_cast<char*>(data[row].c_str());
+      str_batch->length[row] = static_cast<int64_t>(data[row].size());
     }
   }
   batch->numElements = row_count;
@@ -492,8 +492,8 @@ TEST(TestAdapterRead, ReadCharAndVarcharType) {
 
   EXPECT_OK_AND_ASSIGN(auto stripe_reader, reader->NextStripeReader(row_count));
   std::shared_ptr<RecordBatch> record_batch;
-  ASSERT_TRUE(stripe_reader->ReadNext(&record_batch).ok());
-  ASSERT_NE(record_batch, nullptr);
+  ASSERT_OK(stripe_reader->ReadNext(&record_batch));
+  ASSERT_NE(nullptr, record_batch);
   ASSERT_EQ(row_count, record_batch->num_rows());
 
   for (int col = 0; col < record_batch->num_columns(); col++) {

--- a/cpp/src/arrow/adapters/orc/adapter_test.cc
+++ b/cpp/src/arrow/adapters/orc/adapter_test.cc
@@ -496,7 +496,7 @@ TEST(TestAdapterRead, ReadCharAndVarcharType) {
   ASSERT_NE(nullptr, record_batch);
   ASSERT_EQ(row_count, record_batch->num_rows());
 
-  for (int col = 0; col < record_batch->num_columns(); col++) {
+  for (int col = 0; col < record_batch->num_columns(); ++col) {
     auto str_array = checked_pointer_cast<StringArray>(record_batch->column(col));
     for (int row = 0; row < row_count; row++) {
       EXPECT_EQ(expected_data[col][row], str_array->GetString(row));

--- a/cpp/src/arrow/adapters/orc/adapter_test.cc
+++ b/cpp/src/arrow/adapters/orc/adapter_test.cc
@@ -498,7 +498,7 @@ TEST(TestAdapterRead, ReadCharAndVarcharType) {
 
   for (int col = 0; col < record_batch->num_columns(); ++col) {
     auto str_array = checked_pointer_cast<StringArray>(record_batch->column(col));
-    for (int row = 0; row < row_count; row++) {
+    for (int row = 0; row < row_count; ++row) {
       EXPECT_EQ(expected_data[col][row], str_array->GetString(row));
     }
   }

--- a/cpp/src/arrow/adapters/orc/adapter_test.cc
+++ b/cpp/src/arrow/adapters/orc/adapter_test.cc
@@ -453,6 +453,59 @@ TEST(TestAdapterRead, ReadIntAndStringFileMultipleStripes) {
   EXPECT_EQ(num_rows / reader_batch_size, batches);
 }
 
+TEST(TestAdapterRead, ReadCharAndVarcharType) {
+  MemoryOutputStream mem_stream(kDefaultMemStreamSize);
+  auto orc_type = liborc::Type::buildTypeFromString("struct<c1:char(6),c2:varchar(6)>");
+  auto writer = CreateWriter(/*stripe_size=*/1024, *orc_type, &mem_stream);
+
+  constexpr int64_t row_count = 2;
+  auto batch = writer->createRowBatch(row_count);
+  auto struct_batch = internal::checked_cast<liborc::StructVectorBatch*>(batch.get());
+
+  // Verify that longer data will be truncated by ORC char and varchar types.
+  // In addition, ORC char type will pad the data with spaces if the data is shorter.
+  const std::vector<std::string> data = {"abcd", "ABCDEFGH"};
+  const std::vector<std::vector<std::string>> expected_data = {{"abcd  ", "ABCDEF"},
+                                                               {"abcd", "ABCDEF"}};
+
+  for (uint64_t col = 0; col < orc_type->getSubtypeCount(); col++) {
+    auto str_batch =
+        internal::checked_cast<liborc::StringVectorBatch*>(struct_batch->fields[col]);
+    str_batch->hasNulls = false;
+    str_batch->numElements = row_count;
+    for (int64_t i = 0; i < row_count; ++i) {
+      str_batch->data[i] = const_cast<char*>(data[i].c_str());
+      str_batch->length[i] = static_cast<int64_t>(data[i].size());
+    }
+  }
+  batch->numElements = row_count;
+  writer->add(*batch);
+  writer->close();
+
+  std::shared_ptr<io::RandomAccessFile> in_stream(std::make_shared<io::BufferReader>(
+      reinterpret_cast<const uint8_t*>(mem_stream.getData()),
+      static_cast<int64_t>(mem_stream.getLength())));
+  ASSERT_OK_AND_ASSIGN(
+      auto reader, adapters::orc::ORCFileReader::Open(in_stream, default_memory_pool()));
+  ASSERT_EQ(row_count, reader->NumberOfRows());
+  ASSERT_EQ(1, reader->NumberOfStripes());
+
+  EXPECT_OK_AND_ASSIGN(auto stripe_reader, reader->NextStripeReader(row_count));
+  std::shared_ptr<RecordBatch> record_batch;
+  ASSERT_TRUE(stripe_reader->ReadNext(&record_batch).ok());
+  ASSERT_NE(record_batch, nullptr);
+  ASSERT_EQ(row_count, record_batch->num_rows());
+
+  for (int col = 0; col < record_batch->num_columns(); col++) {
+    auto str_array = checked_pointer_cast<StringArray>(record_batch->column(col));
+    for (int row = 0; row < row_count; row++) {
+      EXPECT_EQ(expected_data[col][row], str_array->GetString(row));
+    }
+  }
+  ASSERT_TRUE(stripe_reader->ReadNext(&record_batch).ok());
+  ASSERT_EQ(record_batch, nullptr);
+}
+
 // Trivial
 
 class TestORCWriterTrivialNoWrite : public ::testing::Test {};

--- a/docs/source/cpp/orc.rst
+++ b/docs/source/cpp/orc.rst
@@ -85,10 +85,10 @@ Here are a list of ORC types and mapped Arrow types.
 +-------------------+-----------------------------------+-----------+
 | DATE              | Date32                            |           |
 +-------------------+-----------------------------------+-----------+
-| VARCHAR           | String                            |           |
+| VARCHAR           | String                            | \(3)      |
 +-------------------+-----------------------------------+-----------+
-
-*Unsupported ORC types:* CHAR.
+| CHAR              | String                            | \(3)      |
++-------------------+-----------------------------------+-----------+
 
 * \(1) On the read side the ORC type is read as the first corresponding Arrow type in the table.
 
@@ -96,6 +96,9 @@ Here are a list of ORC types and mapped Arrow types.
   ORC TIMESTAMP is used. On the read side both ORC TIMESTAMP and TIMESTAMP_INSTANT types are read
   as the Arrow Timestamp type with :cpp:enumerator:`arrow::TimeUnit::NANO` and timezone is set to
   UTC for ORC TIMESTAMP_INSTANT type only.
+
+* \(3) On the read side both ORC CHAR and VARCHAR types are read as the Arrow String type. ORC CHAR
+  and VARCHAR types are not supported on the write side.
 
 Compression
 -----------


### PR DESCRIPTION
### Rationale for this change

Currently the ORC CHAR type is mapped to Arrow FIXED_SIZE_BINARY type. However, the meaning of length differs between these types. The length of ORC CHAR type means number of UTF8 characters while that of Arrow FIXED_SIZE_BINARY means number of bytes.

### What changes are included in this PR?

Use Arrow String type to read from ORC CHAR type.

### Are these changes tested?

Make sure all tests pass.

### Are there any user-facing changes?

Yes, the doc has been updated as well.
* Closes: #34823