### PR TITLE
GH-34839: [Go] Build compute without noasm for non-amd64 GOARCH

### DIFF
--- a/go/arrow/compute/internal/kernels/basic_arithmetic_noasm.go
+++ b/go/arrow/compute/internal/kernels/basic_arithmetic_noasm.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build go1.18 && noasm
+//go:build go1.18 && (noasm || !amd64)
 
 package kernels
 

--- a/go/arrow/compute/internal/kernels/scalar_comparison_noasm.go
+++ b/go/arrow/compute/internal/kernels/scalar_comparison_noasm.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build go1.18 && noasm
+//go:build go1.18 && (noasm || !amd64)
 
 package kernels
 


### PR DESCRIPTION
Building github.com/apache/arrow/go/v12/arrow/compute for a non-amd64 GOARCH requires -tag=noasm.  Adjust some build constraints so -tag=noasm isn't required.
* Closes: #34839