### PR TITLE
GH-34869: [C++] Configure alpine linux nightly job to build gtest from source

### DIFF
--- a/ci/docker/alpine-linux-3.16-cpp.dockerfile
+++ b/ci/docker/alpine-linux-3.16-cpp.dockerfile
@@ -95,6 +95,7 @@ ENV ARROW_ACERO=ON \
     ARROW_WITH_ZSTD=ON \
     AWSSDK_SOURCE=BUNDLED \
     google_cloud_cpp_storage_SOURCE=BUNDLED \
+    GTest_SOURCE=BUNDLED \
     ORC_SOURCE=BUNDLED \
     PATH=/usr/lib/ccache/:$PATH \
     xsimd_SOURCE=BUNDLED

--- a/ci/docker/alpine-linux-3.16-cpp.dockerfile
+++ b/ci/docker/alpine-linux-3.16-cpp.dockerfile
@@ -37,7 +37,6 @@ RUN apk add \
         glog-dev \
         gmock \
         grpc-dev \
-        gtest-dev \
         libxml2-dev \
         llvm13-dev \
         llvm13-static \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -223,8 +223,6 @@ services:
       <<: *ccache
       ARROW_ENABLE_TIMING_TESTS:  # inherit
       ARROW_MIMALLOC: "ON"
-      GTest_SOURCE: "BUNDLED"  # Alpine's GTest is not built against
-                               # C++17 so we build from source
     volumes: &alpine-linux-volumes
       - .:/arrow:delegated
       - ${DOCKER_VOLUME_PREFIX}alpine-linux-ccache:/ccache:delegated

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -223,6 +223,8 @@ services:
       <<: *ccache
       ARROW_ENABLE_TIMING_TESTS:  # inherit
       ARROW_MIMALLOC: "ON"
+      GTest_SOURCE: "BUNDLED"  # Alpine's GTest is not built against
+                               # C++17 so we build from source
     volumes: &alpine-linux-volumes
       - .:/arrow:delegated
       - ${DOCKER_VOLUME_PREFIX}alpine-linux-ccache:/ccache:delegated


### PR DESCRIPTION
### Rationale for this change

The nightly test is currently failing with an error:

```
-- Found GTest: /usr/lib/cmake/GTest/GTestConfig.cmake (found suitable version "1.11.0", minimum required is "1.10.0")  
CMake Error at cmake_modules/ThirdpartyToolchain.cmake:2236 (message):
  System GTest is built with a C++ standard lower than 17.  Use bundled GTest
  via passing in CMake flag

  -DGTest_SOURCE="BUNDLED"
```

### What changes are included in this PR?

Changes the alpine linux nightly test to use `-DGTest_SOURCE="BUNDLED"`

### Are these changes tested?

Yes, by the nightly test itself.

### Are there any user-facing changes?

No
* Closes: #34869