### PR TITLE
GH-34861: [C++] Move GTest std version check into SYSTEM if branch

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2229,15 +2229,15 @@ if(ARROW_TESTING)
                      1.10.0
                      USE_CONFIG
                      ${GTEST_USE_CONFIG})
-  get_target_property(gtest_cxx_standard GTest::gtest INTERFACE_COMPILE_FEATURES)
-
-  if((${gtest_cxx_standard} STREQUAL "cxx_std_11") OR (${gtest_cxx_standard} STREQUAL
-                                                       "cxx_std_14"))
-    message(FATAL_ERROR "System GTest is built with a C++ standard lower than 17. Use bundled GTest via passing in CMake flag
--DGTest_SOURCE=\"BUNDLED\"")
-  endif()
 
   if(GTest_SOURCE STREQUAL "SYSTEM")
+    get_target_property(gtest_cxx_standard GTest::gtest INTERFACE_COMPILE_FEATURES)
+    if((${gtest_cxx_standard} STREQUAL "cxx_std_11") OR (${gtest_cxx_standard} STREQUAL
+                                                         "cxx_std_14"))
+      message(FATAL_ERROR "System GTest is built with a C++ standard lower than 17. Use bundled GTest via passing in CMake flag
+-DGTest_SOURCE=\"BUNDLED\"")
+    endif()
+
     find_package(PkgConfig QUIET)
     pkg_check_modules(gtest_PC
                       gtest


### PR DESCRIPTION
### Rationale for this change
Developers have reported that the current GTest std version check will break cpp microbenchmarks in BUNDLE mode.

### What changes are included in this PR?
Move the check into SYSTEM if branch so that it gets triggered in a narrowed scope.

### Are these changes tested?
Tested locally and will be covered by CI.

### Are there any user-facing changes?
No

* Closes: #34861