### PR TITLE
MINOR: [C++][Benchmark][Acero] Fix a typo

### DIFF
--- a/cpp/src/arrow/acero/hash_join_benchmark.cc
+++ b/cpp/src/arrow/acero/hash_join_benchmark.cc
@@ -34,7 +34,7 @@
 #include <omp.h>
 
 namespace arrow {
-namespace aceroacero {
+namespace acero {
 struct BenchmarkSettings {
   int num_threads = 1;
   JoinType join_type = JoinType::INNER;
@@ -453,5 +453,5 @@ BENCHMARK(BM_HashJoinBasic_ProbeParallelism)
 
 #endif  // ARROW_BUILD_DETAILED_BENCHMARKS
 
-}  // namespace aceroacero
+}  // namespace acero
 }  // namespace arrow


### PR DESCRIPTION
### Rationale for this change

It causes a build error:

```text
cpp/src/arrow/acero/hash_join_benchmark.cc:40:3: error: ‘JoinType’ does not name a type; did you mean ‘UnionType’?
   40 |   JoinType join_type = JoinType::INNER;
      |   ^~~~~~~~
      |   UnionType
...
```

### What changes are included in this PR?

Fix a typo.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.