### PR TITLE
GH-34893: [C++] Fix run-end encoded array iterator issues that manifest on backwards iteration

### DIFF
--- a/cpp/src/arrow/array/builder_run_end.cc
+++ b/cpp/src/arrow/array/builder_run_end.cc
@@ -232,8 +232,7 @@ Status RunEndEncodedBuilder::DoAppendArray(const ArraySpan& to_append) {
   RETURN_NOT_OK(ReservePhysical(physical_length));
 
   // Append all the run ends from to_append
-  const auto end = ree_span.end();
-  for (auto it = ree_span.iterator(0, physical_offset); it != end; ++it) {
+  for (auto it = ree_span.iterator(0, physical_offset); !it.is_end(ree_span); ++it) {
     const int64_t run_end = committed_logical_length_ + it.run_length();
     RETURN_NOT_OK(DoAppendRunEnd<RunEndCType>(run_end));
     UpdateDimensions(run_end, 0);

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -486,7 +486,7 @@ class RangeDataEqualsImpl {
     const auto& right_values = *right_.child_data[1];
 
     auto it = ree_util::MergedRunsIterator(left, right);
-    for (; !it.isEnd(); ++it) {
+    for (; !it.is_end(); ++it) {
       RangeDataEqualsImpl impl(options_, floating_approximate_, left_values, right_values,
                                it.index_into_left_array(), it.index_into_right_array(),
                                /*range_length=*/1);

--- a/cpp/src/arrow/compute/kernels/vector_run_end_encode.cc
+++ b/cpp/src/arrow/compute/kernels/vector_run_end_encode.cc
@@ -698,7 +698,7 @@ class RunEndDecodingLoop {
     const ree_util::RunEndEncodedArraySpan<RunEndCType> ree_array_span(input_array_);
     int64_t write_offset = 0;
     int64_t output_valid_count = 0;
-    for (auto it = ree_array_span.begin(); it != ree_array_span.end(); ++it) {
+    for (auto it = ree_array_span.begin(); !it.is_end(ree_array_span); ++it) {
       const int64_t read_offset = values_offset_ + it.index_into_array();
       const int64_t run_length = it.run_length();
       ValueRepr value;

--- a/cpp/src/arrow/util/ree_util.h
+++ b/cpp/src/arrow/util/ree_util.h
@@ -335,15 +335,15 @@ class MergedRunsIterator {
 
   /// \brief Return the initial logical position of the run
   ///
-  /// If isEnd(), this is the same as length().
+  /// If is_end(), this is the same as length().
   int64_t logical_position() const { return logical_pos_; }
 
   /// \brief Whether the iterator has reached the end of both arrays
-  bool isEnd() const { return logical_pos_ == logical_length_; }
+  bool is_end() const { return logical_pos_ == logical_length_; }
 
   /// \brief Return the logical position immediately after the run.
   ///
-  /// Pre-condition: !isEnd()
+  /// Pre-condition: !is_end()
   int64_t run_end() const {
     const auto& left_it = std::get<0>(ree_iterators_);
     const auto& right_it = std::get<1>(ree_iterators_);
@@ -352,7 +352,7 @@ class MergedRunsIterator {
 
   /// \brief returns the logical length of the current run
   ///
-  /// Pre-condition: !isEnd()
+  /// Pre-condition: !is_end()
   int64_t run_length() const { return run_end() - logical_pos_; }
 
   /// \brief Return a physical index into the values array of a given input,

--- a/cpp/src/arrow/util/ree_util_test.cc
+++ b/cpp/src/arrow/util/ree_util_test.cc
@@ -176,10 +176,10 @@ TYPED_TEST_P(ReeUtilTest, MergedRunsInterator) {
     size_t logical_pos = 0;
     auto it = MergedRunsIterator(left_ree_span, right_ree_span);
     ASSERT_EQ(it.logical_position(), 0);
-    ASSERT_TRUE(!it.isEnd());
+    ASSERT_TRUE(!it.is_end());
     ASSERT_EQ(&it.left(), &left_ree_span);
     ASSERT_EQ(&it.right(), &right_ree_span);
-    for (; !it.isEnd(); ++it, ++i) {
+    for (; !it.is_end(); ++it, ++i) {
       ASSERT_EQ(it.run_length(), expected_run_ends[i]);
       ASSERT_EQ(it.index_into_left_array(), expected_left_visits[i]);
       ASSERT_EQ(it.index_into_right_array(), expected_right_visits[i]);
@@ -196,10 +196,10 @@ TYPED_TEST_P(ReeUtilTest, MergedRunsInterator) {
     int64_t logical_pos = 0;
     auto it = MergedRunsIterator(left_ree_span, left_ree_span);
     ASSERT_EQ(it.logical_position(), 0);
-    ASSERT_TRUE(!it.isEnd());
+    ASSERT_TRUE(!it.is_end());
     ASSERT_EQ(&it.left(), &left_ree_span);
     ASSERT_EQ(&it.right(), &left_ree_span);
-    for (; !it.isEnd(); ++it, ++i) {
+    for (; !it.is_end(); ++it, ++i) {
       ASSERT_EQ(it.run_length(), left_only_run_lengths[i]);
       ASSERT_EQ(it.index_into_left_array(), 10 + i);
       ASSERT_EQ(it.index_into_right_array(), 10 + i);
@@ -243,7 +243,7 @@ TYPED_TEST_P(ReeUtilTest, MergedRunsInterator) {
     int64_t i = 0;
     int64_t logical_pos = 0;
     auto it = MergedRunsIterator(right_ree_span, right_ree_span);
-    for (; !it.isEnd(); ++it, ++i) {
+    for (; !it.is_end(); ++it, ++i) {
       ASSERT_EQ(it.run_length(), right_only_run_lengths[i]);
       ASSERT_EQ(it.index_into_left_array(), 5 + i);
       ASSERT_EQ(it.index_into_right_array(), 5 + i);


### PR DESCRIPTION
### Rationale for this change

The value of `RunEndEncodedArraySpan::Iterator::physical_pos_` from the instance returned by `RunEndEncodedArraySpan::end()` is smaller (by 1) than the results of successive applications of `operator++()` until `logical_pos_` reaches the logical length of the run-end encoded array.

To support backwards iteration, the `Iterator` returned by `RunEndEncodedArraySpan::end()` should be well-formed.

There was no `operator--()` in `RunEndEncodedArraySpan::Iterator` before this PR, so one can't go backwards from `end()` and this latent bug doesn't manifest. 

### What changes are included in this PR?

 - Addition of `RunEndEncodedArraySpan::Iterator::operator--()`
 - Addition of `MergedRunsIterator::operator--()`
 - Rename `isEnd()` to `is_end()` (it was a code-style violation)
 - More test cases

### Are these changes tested?

By existing and new unit tests.

### Are there any user-facing changes?

A public function -- `isEnd` -- was renamed, but this code hasn't been released yet, so it's OK.
* Closes: #34893