### PR TITLE
GH-34819: [Ruby] Add Slicer::ColumnCondition#match_substring

### DIFF
--- a/ruby/red-arrow/lib/arrow/slicer.rb
+++ b/ruby/red-arrow/lib/arrow/slicer.rb
@@ -162,6 +162,10 @@ module Arrow
       def reject(&block)
         RejectCondition.new(@column, block)
       end
+
+      def match_substring(value, ignore_case: false)
+        MatchSubstringCondition.new(@column, value, ignore_case)
+      end
     end
 
     class NotColumnCondition < Condition
@@ -349,6 +353,19 @@ module Arrow
           end
         end
         BooleanArray.new(raw_array)
+      end
+    end
+
+    class MatchSubstringCondition < Condition
+      def initialize(column, value, ignore_case)
+        @column = column
+        @options = MatchSubstringOptions.new
+        @options.pattern = value
+        @options.ignore_case = true if ignore_case
+      end
+
+      def evaluate
+        Function.find("match_substring").execute([@column.data], @options).value
       end
     end
   end

--- a/ruby/red-arrow/lib/arrow/slicer.rb
+++ b/ruby/red-arrow/lib/arrow/slicer.rb
@@ -378,10 +378,9 @@ module Arrow
       def evaluate
         datum = Function.find(@function).execute([@column.data], @options)
         if @invert
-          Function.find("invert").execute([datum]).value
-        else
-          datum.value
+          datum = Function.find("invert").execute([datum])
         end
+        datum.value
       end
     end
   end

--- a/ruby/red-arrow/lib/arrow/slicer.rb
+++ b/ruby/red-arrow/lib/arrow/slicer.rb
@@ -164,7 +164,7 @@ module Arrow
       end
 
       def match_substring(substring, ignore_case: false)
-        MatchSubstringCondition.new("match_substring",
+        MatchSubstringFamilyCondition.new("match_substring",
                                     @column, substring, ignore_case)
       end
     end
@@ -357,7 +357,7 @@ module Arrow
       end
     end
 
-    class MatchSubstringCondition < Condition
+    class MatchSubstringFamilyCondition < Condition
       def initialize(function, column, pattern, ignore_case, invert: false)
         @function = function
         @column = column
@@ -368,7 +368,7 @@ module Arrow
       end
 
       def !@
-        MatchSubstringCondition.new(@function,
+        MatchSubstringFamilyCondition.new(@function,
                                     @column,
                                     @options.pattern,
                                     @options.ignore_case?,

--- a/ruby/red-arrow/lib/arrow/slicer.rb
+++ b/ruby/red-arrow/lib/arrow/slicer.rb
@@ -361,7 +361,7 @@ module Arrow
         @column = column
         @options = MatchSubstringOptions.new
         @options.pattern = substring
-        @options.ignore_case = true if ignore_case
+        @options.ignore_case = ignore_case
       end
 
       def evaluate

--- a/ruby/red-arrow/lib/arrow/slicer.rb
+++ b/ruby/red-arrow/lib/arrow/slicer.rb
@@ -165,7 +165,7 @@ module Arrow
 
       def match_substring(substring, ignore_case: false)
         MatchSubstringFamilyCondition.new("match_substring",
-                                    @column, substring, ignore_case)
+                                          @column, substring, ignore_case)
       end
     end
 
@@ -369,10 +369,10 @@ module Arrow
 
       def !@
         MatchSubstringFamilyCondition.new(@function,
-                                    @column,
-                                    @options.pattern,
-                                    @options.ignore_case?,
-                                    invert: !@invert)
+                                          @column,
+                                          @options.pattern,
+                                          @options.ignore_case?,
+                                          invert: !@invert)
       end
 
       def evaluate

--- a/ruby/red-arrow/lib/arrow/slicer.rb
+++ b/ruby/red-arrow/lib/arrow/slicer.rb
@@ -164,7 +164,8 @@ module Arrow
       end
 
       def match_substring(substring, ignore_case: false)
-        MatchSubstringCondition.new(@column, substring, ignore_case)
+        MatchSubstringFamilyCondition.new("match_substring",
+                                          @column, substring, ignore_case)
       end
     end
 
@@ -356,8 +357,9 @@ module Arrow
       end
     end
 
-    class MatchSubstringCondition < Condition
-      def initialize(column, substring, ignore_case)
+    class MatchSubstringFamilyCondition < Condition
+      def initialize(function, column, substring, ignore_case)
+        @function = function
         @column = column
         @options = MatchSubstringOptions.new
         @options.pattern = substring
@@ -365,7 +367,10 @@ module Arrow
       end
 
       def evaluate
-        Function.find("match_substring").execute([@column.data], @options).value
+        case @function
+        when "match_substring"
+          Function.find("match_substring").execute([@column.data], @options).value
+        end
       end
     end
   end

--- a/ruby/red-arrow/lib/arrow/slicer.rb
+++ b/ruby/red-arrow/lib/arrow/slicer.rb
@@ -163,8 +163,8 @@ module Arrow
         RejectCondition.new(@column, block)
       end
 
-      def match_substring(value, ignore_case: false)
-        MatchSubstringCondition.new(@column, value, ignore_case)
+      def match_substring(substring, ignore_case: false)
+        MatchSubstringCondition.new(@column, substring, ignore_case)
       end
     end
 
@@ -357,10 +357,10 @@ module Arrow
     end
 
     class MatchSubstringCondition < Condition
-      def initialize(column, value, ignore_case)
+      def initialize(column, substring, ignore_case)
         @column = column
         @options = MatchSubstringOptions.new
-        @options.pattern = value
+        @options.pattern = substring
         @options.ignore_case = true if ignore_case
       end
 

--- a/ruby/red-arrow/test/test-slicer.rb
+++ b/ruby/red-arrow/test/test-slicer.rb
@@ -487,34 +487,45 @@ class SlicerTest < Test::Unit::TestCase
 
   sub_test_case "MatchSubstringOptions family" do
     def setup
-      @string_table = Arrow::Table.new(
-        index: [*1..5],
+      @table = Arrow::Table.new(
         string: ["array", "Arrow", "carrot", nil, "window"]
       )
     end
 
     test("match_substring") do
-      sliced_table = @string_table.slice do |slicer|
+      sliced_table = @table.slice do |slicer|
         slicer.string.match_substring("arr")
       end
       assert_equal(<<~TABLE, sliced_table.to_s)
-	 index	string
-0	     1	array 
-1	     3	carrot
-2	(null)	(null)
+	string
+0	array 
+1	carrot
+2	(null)
       TABLE
     end
 
     test("match_substring(ignore_case:)") do
-      sliced_table = @string_table.slice do |slicer|
+      sliced_table = @table.slice do |slicer|
         slicer.string.match_substring("arr", ignore_case: true)
       end
       assert_equal(<<~TABLE, sliced_table.to_s)
-	 index	string
-0	     1	array 
-1	     2	Arrow 
-2	     3	carrot
-3	(null)	(null)
+	string
+0	array 
+1	Arrow 
+2	carrot
+3	(null)
+      TABLE
+    end
+
+    test("!match_substring") do
+      sliced_table = @table.slice do |slicer|
+        !slicer.string.match_substring("arr")
+      end
+      assert_equal(<<~TABLE, sliced_table.to_s)
+	string
+0	Arrow 
+1	(null)
+2	window
       TABLE
     end
   end

--- a/ruby/red-arrow/test/test-slicer.rb
+++ b/ruby/red-arrow/test/test-slicer.rb
@@ -37,6 +37,10 @@ class SlicerTest < Test::Unit::TestCase
     @count_array = Arrow::ChunkedArray.new(count_arrays)
     @visible_array = Arrow::ChunkedArray.new(visible_arrays)
     @table = Arrow::Table.new(schema, [@count_array, @visible_array])
+
+    # Test data for the sub string slicers
+    @string_table = Arrow::Table.new(index: [*1..5],
+                                     string: ["array", "Arrow", "carrot", nil, "window"])
   end
 
   sub_test_case("column") do
@@ -482,6 +486,31 @@ class SlicerTest < Test::Unit::TestCase
 5	    64	 (null)
 6	(null)	 (null)
 7	   256	true   
+    TABLE
+  end
+
+  test("match_substring") do
+    sliced_table = @string_table.slice do |slicer|
+      slicer.string.match_substring("arr")
+    end
+    assert_equal(<<~TABLE, sliced_table.to_s)
+	 index	string
+0	     1	array 
+1	     3	carrot
+2	(null)	(null)
+    TABLE
+  end
+
+  test("match_substring with ignore_case option") do
+    sliced_table = @string_table.slice do |slicer|
+      slicer.string.match_substring("arr", ignore_case: true)
+    end
+    assert_equal(<<~TABLE, sliced_table.to_s)
+	 index	string
+0	     1	array 
+1	     2	Arrow 
+2	     3	carrot
+3	(null)	(null)
     TABLE
   end
 end

--- a/ruby/red-arrow/test/test-slicer.rb
+++ b/ruby/red-arrow/test/test-slicer.rb
@@ -37,10 +37,6 @@ class SlicerTest < Test::Unit::TestCase
     @count_array = Arrow::ChunkedArray.new(count_arrays)
     @visible_array = Arrow::ChunkedArray.new(visible_arrays)
     @table = Arrow::Table.new(schema, [@count_array, @visible_array])
-
-    # Test data for the sub string slicers
-    @string_table = Arrow::Table.new(index: [*1..5],
-                                     string: ["array", "Arrow", "carrot", nil, "window"])
   end
 
   sub_test_case("column") do
@@ -489,28 +485,37 @@ class SlicerTest < Test::Unit::TestCase
     TABLE
   end
 
-  test("match_substring") do
-    sliced_table = @string_table.slice do |slicer|
-      slicer.string.match_substring("arr")
+  sub_test_case "MatchSubstringOptions family" do
+    def setup
+      @string_table = Arrow::Table.new(
+        index: [*1..5],
+        string: ["array", "Arrow", "carrot", nil, "window"]
+      )
     end
-    assert_equal(<<~TABLE, sliced_table.to_s)
+
+    test("match_substring") do
+      sliced_table = @string_table.slice do |slicer|
+        slicer.string.match_substring("arr")
+      end
+      assert_equal(<<~TABLE, sliced_table.to_s)
 	 index	string
 0	     1	array 
 1	     3	carrot
 2	(null)	(null)
-    TABLE
-  end
-
-  test("match_substring with ignore_case option") do
-    sliced_table = @string_table.slice do |slicer|
-      slicer.string.match_substring("arr", ignore_case: true)
+      TABLE
     end
-    assert_equal(<<~TABLE, sliced_table.to_s)
+
+    test("match_substring with ignore_case option") do
+      sliced_table = @string_table.slice do |slicer|
+        slicer.string.match_substring("arr", ignore_case: true)
+      end
+      assert_equal(<<~TABLE, sliced_table.to_s)
 	 index	string
 0	     1	array 
 1	     2	Arrow 
 2	     3	carrot
 3	(null)	(null)
-    TABLE
+      TABLE
+    end
   end
 end

--- a/ruby/red-arrow/test/test-slicer.rb
+++ b/ruby/red-arrow/test/test-slicer.rb
@@ -505,7 +505,7 @@ class SlicerTest < Test::Unit::TestCase
       TABLE
     end
 
-    test("match_substring with ignore_case option") do
+    test("match_substring(ignore_case:)") do
       sliced_table = @string_table.slice do |slicer|
         slicer.string.match_substring("arr", ignore_case: true)
       end


### PR DESCRIPTION
### Rationale for this change

C GLib supported `MatchSubstringOptions` in #34725. This PR will use this and will supply an easy to use API in Ruby binding.

### What changes are included in this PR?

- Add a class `Arrow::Slicer::MatchSubstringCondition`
- Add a method `#match_substring` in `Arrow::Slicer::ColumnCondition`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.

* Closes: #34819