### PR TITLE
MINOR: [Docs][Python] Remove note about pyarrow.dataset being experimental

### DIFF
--- a/docs/source/python/api/dataset.rst
+++ b/docs/source/python/api/dataset.rst
@@ -22,11 +22,6 @@
 Dataset
 =======
 
-.. warning::
-
-    The ``pyarrow.dataset`` module is experimental (specifically the classes),
-    and a stable API is not yet guaranteed.
-
 Factory functions
 -----------------
 

--- a/docs/source/python/dataset.rst
+++ b/docs/source/python/dataset.rst
@@ -33,11 +33,6 @@
 Tabular Datasets
 ================
 
-.. warning::
-
-    The ``pyarrow.dataset`` module is experimental (specifically the classes),
-    and a stable API is not yet guaranteed.
-
 The ``pyarrow.dataset`` module provides functionality to efficiently work with
 tabular, potentially larger than memory, and multi-file datasets. This includes:
 


### PR DESCRIPTION
### Rationale for this change

In practice pyarrow.dataset is quite stable and we have not been treating it as experimental. So after several years of existence, high time to remove the (misleading) "experimental" label