### PR TITLE
GH-34911: [C++] Add first and last aggregator

### DIFF
--- a/cpp/src/arrow/acero/aggregate_node.cc
+++ b/cpp/src/arrow/acero/aggregate_node.cc
@@ -616,7 +616,7 @@ class GroupByNode : public ExecNode, public TracedNode {
   static Result<AggregateNodeArgs<HashAggregateKernel>> MakeAggregateNodeArgs(
       const std::shared_ptr<Schema>& input_schema, const std::vector<FieldRef>& keys,
       const std::vector<FieldRef>& segment_keys, const std::vector<Aggregate>& aggs,
-      ExecContext* ctx) {
+      ExecContext* ctx, const int concurrency) {
     // Find input field indices for key fields
     std::vector<int> key_field_ids(keys.size());
     for (size_t i = 0; i < keys.size(); ++i) {
@@ -673,6 +673,20 @@ class GroupByNode : public ExecNode, public TracedNode {
     // Construct aggregates
     ARROW_ASSIGN_OR_RAISE(auto agg_kernels, GetKernels(ctx, aggs, agg_src_types));
 
+    if (concurrency > 1) {
+      if (segment_keys.size() > 0) {
+        return Status::NotImplemented(
+            "Segmented aggregation in a multi-threaded execution context");
+      }
+
+      for (auto kernel : agg_kernels) {
+        if (kernel->ordered) {
+          return Status::NotImplemented(
+              "Using ordered aggregator in multiple threaded execution is not supported");
+        }
+      }
+    }
+
     ARROW_ASSIGN_OR_RAISE(auto agg_states,
                           InitKernels(agg_kernels, ctx, aggs, agg_src_types));
 
@@ -720,27 +734,13 @@ class GroupByNode : public ExecNode, public TracedNode {
     const auto& keys = aggregate_options.keys;
     const auto& segment_keys = aggregate_options.segment_keys;
     auto aggs = aggregate_options.aggregates;
-    auto concurreny = plan->query_context()->exec_context()->executor()->GetCapacity();
-
-    if (concurreny > 1 && segment_keys.size() > 0) {
-      return Status::NotImplemented(
-          "Segmented aggregation in a multi-threaded execution context");
-    }
+    auto concurrency = plan->query_context()->exec_context()->executor()->GetCapacity();
 
     const auto& input_schema = input->output_schema();
     auto exec_ctx = plan->query_context()->exec_context();
-
-    ARROW_ASSIGN_OR_RAISE(auto args, MakeAggregateNodeArgs(input_schema, keys,
-                                                           segment_keys, aggs, exec_ctx));
-
-    if (concurreny > 1) {
-      for (auto kernel : args.kernels) {
-        if (kernel->ordered) {
-          return Status::NotImplemented(
-              "Using ordered aggregator in multiple threaded execution is not supported");
-        }
-      }
-    }
+    ARROW_ASSIGN_OR_RAISE(
+        auto args, MakeAggregateNodeArgs(input_schema, keys, segment_keys, aggs, exec_ctx,
+                                         concurrency));
 
     return input->plan()->EmplaceNode<GroupByNode>(
         input, std::move(args.output_schema), std::move(args.grouping_key_field_ids),
@@ -1068,9 +1068,9 @@ Result<std::shared_ptr<Schema>> MakeOutputSchema(
                                          exec_ctx, /*concurrency=*/1));
     return std::move(args.output_schema);
   } else {
-    ARROW_ASSIGN_OR_RAISE(
-        auto args, GroupByNode::MakeAggregateNodeArgs(input_schema, keys, segment_keys,
-                                                      aggregates, exec_ctx));
+    ARROW_ASSIGN_OR_RAISE(auto args, GroupByNode::MakeAggregateNodeArgs(
+                                         input_schema, keys, segment_keys, aggregates,
+                                         exec_ctx, /*concurrency=*/1));
     return std::move(args.output_schema);
   }
 }

--- a/cpp/src/arrow/acero/aggregate_node.cc
+++ b/cpp/src/arrow/acero/aggregate_node.cc
@@ -294,7 +294,6 @@ class ScalarAggregateNode : public ExecNode, public TracedNode {
       ExecContext* exec_ctx, size_t concurrency) {
     // Copy (need to modify options pointer below)
     std::vector<Aggregate> aggregates(aggs);
-
     std::vector<int> segment_field_ids(segment_keys.size());
     std::vector<TypeHolder> segment_key_types(segment_keys.size());
     for (size_t i = 0; i < segment_keys.size(); i++) {

--- a/cpp/src/arrow/acero/hash_aggregate_test.cc
+++ b/cpp/src/arrow/acero/hash_aggregate_test.cc
@@ -402,7 +402,7 @@ Result<Datum> RunGroupBy(const BatchesWithSchema& input,
                          const std::vector<std::string>& segment_key_names,
                          const std::vector<Aggregate>& aggregates, bool use_threads,
                          bool segmented = false, bool naive = false) {
-  if (segment_key_names.size() > 0) {
+  if (!use_threads) {
     ARROW_ASSIGN_OR_RAISE(auto thread_pool, arrow::internal::ThreadPool::Make(1));
     ExecContext seq_ctx(default_memory_pool(), thread_pool.get());
     return RunGroupBy(input, key_names, segment_key_names, aggregates, &seq_ctx,

--- a/cpp/src/arrow/acero/plan_test.cc
+++ b/cpp/src/arrow/acero/plan_test.cc
@@ -1611,7 +1611,7 @@ TEST(ExecPlanExecution, SegmentedAggregationWithMultiThreading) {
        {"aggregate", AggregateNodeOptions{/*aggregates=*/{
                                               {"count", nullptr, "i32", "count(i32)"},
                                           },
-                                          /*keys=*/{"i32"}, /*segment_leys=*/{"i32"}}}});
+                                          /*keys=*/{}, /*segment_keys=*/{"i32"}}}});
   EXPECT_RAISES_WITH_MESSAGE_THAT(NotImplemented, HasSubstr("multi-threaded"),
                                   DeclarationToExecBatches(std::move(plan)));
 }

--- a/cpp/src/arrow/compute/api_aggregate.cc
+++ b/cpp/src/arrow/compute/api_aggregate.cc
@@ -203,6 +203,16 @@ Result<Datum> Sum(const Datum& value, const ScalarAggregateOptions& options,
   return CallFunction("sum", {value}, &options, ctx);
 }
 
+Result<Datum> First(const Datum& value, const ScalarAggregateOptions& options,
+                    ExecContext* ctx) {
+  return CallFunction("first", {value}, &options, ctx);
+}
+
+Result<Datum> Last(const Datum& value, const ScalarAggregateOptions& options,
+                   ExecContext* ctx) {
+  return CallFunction("last", {value}, &options, ctx);
+}
+
 Result<Datum> FirstLast(const Datum& value, const ScalarAggregateOptions& options,
                         ExecContext* ctx) {
   return CallFunction("first_last", {value}, &options, ctx);

--- a/cpp/src/arrow/compute/api_aggregate.cc
+++ b/cpp/src/arrow/compute/api_aggregate.cc
@@ -213,11 +213,6 @@ Result<Datum> Last(const Datum& value, const ScalarAggregateOptions& options,
   return CallFunction("last", {value}, &options, ctx);
 }
 
-Result<Datum> FirstLast(const Datum& value, const ScalarAggregateOptions& options,
-                        ExecContext* ctx) {
-  return CallFunction("first_last", {value}, &options, ctx);
-}
-
 Result<Datum> MinMax(const Datum& value, const ScalarAggregateOptions& options,
                      ExecContext* ctx) {
   return CallFunction("min_max", {value}, &options, ctx);

--- a/cpp/src/arrow/compute/api_aggregate.cc
+++ b/cpp/src/arrow/compute/api_aggregate.cc
@@ -203,6 +203,11 @@ Result<Datum> Sum(const Datum& value, const ScalarAggregateOptions& options,
   return CallFunction("sum", {value}, &options, ctx);
 }
 
+Result<Datum> FirstLast(const Datum& value, const ScalarAggregateOptions& options,
+                        ExecContext* ctx) {
+  return CallFunction("first_last", {value}, &options, ctx);
+}
+
 Result<Datum> MinMax(const Datum& value, const ScalarAggregateOptions& options,
                      ExecContext* ctx) {
   return CallFunction("min_max", {value}, &options, ctx);

--- a/cpp/src/arrow/compute/api_aggregate.h
+++ b/cpp/src/arrow/compute/api_aggregate.h
@@ -284,18 +284,36 @@ Result<Datum> Sum(
     const ScalarAggregateOptions& options = ScalarAggregateOptions::Defaults(),
     ExecContext* ctx = NULLPTR);
 
-/// \brief Calculate the first / last of an array
-///
-/// This function returns both the first and last as a struct scalar, with type
-/// struct<first: T, last: T>, where T is the input type
+/// \brief Calculate the first value of an array
 ///
 /// \param[in] value input datum, expecting Array or ChunkedArray
 /// \param[in] options see ScalarAggregateOptions for more information
 /// \param[in] ctx the function execution context, optional
-/// \return resulting datum as a struct<first: T, last: T> scalar
+/// \return datum of the computed first as Scalar
 ///
-/// \since 12.0.0
+/// \since 13.0.0
 /// \note API not yet finalized
+ARROW_EXPORT
+Result<Datum> First(
+    const Datum& value,
+    const ScalarAggregateOptions& options = ScalarAggregateOptions::Defaults(),
+    ExecContext* ctx = NULLPTR);
+
+/// \brief Calculate the last value of an array
+///
+/// \param[in] value input datum, expecting Array or ChunkedArray
+/// \param[in] options see ScalarAggregateOptions for more information
+/// \param[in] ctx the function execution context, optional
+/// \return datum of the computed last as a Scalar
+///
+/// \since 13.0.0
+/// \note API not yet finalized
+ARROW_EXPORT
+Result<Datum> Last(
+    const Datum& value,
+    const ScalarAggregateOptions& options = ScalarAggregateOptions::Defaults(),
+    ExecContext* ctx = NULLPTR);
+
 ARROW_EXPORT
 Result<Datum> FirstLast(
     const Datum& value,

--- a/cpp/src/arrow/compute/api_aggregate.h
+++ b/cpp/src/arrow/compute/api_aggregate.h
@@ -284,6 +284,24 @@ Result<Datum> Sum(
     const ScalarAggregateOptions& options = ScalarAggregateOptions::Defaults(),
     ExecContext* ctx = NULLPTR);
 
+/// \brief Calculate the first / last of an array
+///
+/// This function returns both the first and last as a struct scalar, with type
+/// struct<first: T, last: T>, where T is the input type
+///
+/// \param[in] value input datum, expecting Array or ChunkedArray
+/// \param[in] options see ScalarAggregateOptions for more information
+/// \param[in] ctx the function execution context, optional
+/// \return resulting datum as a struct<first: T, last: T> scalar
+///
+/// \since 12.0.0
+/// \note API not yet finalized
+ARROW_EXPORT
+Result<Datum> FirstLast(
+    const Datum& value,
+    const ScalarAggregateOptions& options = ScalarAggregateOptions::Defaults(),
+    ExecContext* ctx = NULLPTR);
+
 /// \brief Calculate the min / max of a numeric array
 ///
 /// This function returns both the min and max as a struct scalar, with type

--- a/cpp/src/arrow/compute/api_aggregate.h
+++ b/cpp/src/arrow/compute/api_aggregate.h
@@ -314,12 +314,6 @@ Result<Datum> Last(
     const ScalarAggregateOptions& options = ScalarAggregateOptions::Defaults(),
     ExecContext* ctx = NULLPTR);
 
-ARROW_EXPORT
-Result<Datum> FirstLast(
-    const Datum& value,
-    const ScalarAggregateOptions& options = ScalarAggregateOptions::Defaults(),
-    ExecContext* ctx = NULLPTR);
-
 /// \brief Calculate the min / max of a numeric array
 ///
 /// This function returns both the min and max as a struct scalar, with type

--- a/cpp/src/arrow/compute/function_test.cc
+++ b/cpp/src/arrow/compute/function_test.cc
@@ -323,7 +323,7 @@ TEST(ScalarAggregateFunction, DispatchExact) {
 
   std::vector<InputType> in_args = {int8()};
   ScalarAggregateKernel kernel(std::move(in_args), int64(), NoopInit, NoopConsume,
-                               NoopMerge, NoopFinalize);
+                               NoopMerge, NoopFinalize, /*ordered*/ false);
   ASSERT_OK(func.AddKernel(kernel));
 
   in_args = {float64()};

--- a/cpp/src/arrow/compute/function_test.cc
+++ b/cpp/src/arrow/compute/function_test.cc
@@ -323,7 +323,7 @@ TEST(ScalarAggregateFunction, DispatchExact) {
 
   std::vector<InputType> in_args = {int8()};
   ScalarAggregateKernel kernel(std::move(in_args), int64(), NoopInit, NoopConsume,
-                               NoopMerge, NoopFinalize, /*ordered*/ false);
+                               NoopMerge, NoopFinalize, /*ordered=*/false);
   ASSERT_OK(func.AddKernel(kernel));
 
   in_args = {float64()};

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -677,7 +677,7 @@ struct ARROW_EXPORT ScalarAggregateKernel : public Kernel {
   /// The caller of the aggregate kernel is responsible for passing data in some
   /// defined order to the kernel. The flag here is a way for the kernel to tell
   /// the caller that data passed to the kernel must be defined in some order.
-  bool ordered;
+  bool ordered = false;
 };
 
 // ----------------------------------------------------------------------
@@ -731,7 +731,7 @@ struct ARROW_EXPORT HashAggregateKernel : public Kernel {
   /// @brief whether the summarizer requires ordering
   /// This is similar to ScalarAggregateKernel. See ScalarAggregateKernel
   /// for detailed doc of this variable.
-  bool ordered;
+  bool ordered = false;
 };
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -648,18 +648,20 @@ struct ARROW_EXPORT ScalarAggregateKernel : public Kernel {
 
   ScalarAggregateKernel(std::shared_ptr<KernelSignature> sig, KernelInit init,
                         ScalarAggregateConsume consume, ScalarAggregateMerge merge,
-                        ScalarAggregateFinalize finalize)
+                        ScalarAggregateFinalize finalize, const bool ordered)
       : Kernel(std::move(sig), std::move(init)),
         consume(consume),
         merge(merge),
-        finalize(finalize) {}
+        finalize(finalize),
+        ordered(ordered) {}
 
   ScalarAggregateKernel(std::vector<InputType> in_types, OutputType out_type,
                         KernelInit init, ScalarAggregateConsume consume,
-                        ScalarAggregateMerge merge, ScalarAggregateFinalize finalize)
+                        ScalarAggregateMerge merge, ScalarAggregateFinalize finalize,
+                        const bool ordered)
       : ScalarAggregateKernel(
             KernelSignature::Make(std::move(in_types), std::move(out_type)),
-            std::move(init), consume, merge, finalize) {}
+            std::move(init), consume, merge, finalize, ordered) {}
 
   /// \brief Merge a vector of KernelStates into a single KernelState.
   /// The merged state will be returned and will be set on the KernelContext.
@@ -670,6 +672,14 @@ struct ARROW_EXPORT ScalarAggregateKernel : public Kernel {
   ScalarAggregateConsume consume;
   ScalarAggregateMerge merge;
   ScalarAggregateFinalize finalize;
+  /// \brief Whether this kernel requires ordering
+  /// Some aggregations, such as, "first", requires some kind of input order. The
+  /// order can be implicit, e.g., the order of the input data, or explicit, e.g.
+  /// the ordering specified with a window aggregation.
+  /// The caller of the aggregate kernel is responsible for passing data in some
+  /// defined order to the kernel. The flag here is a way for the kernel to tell
+  /// the caller that data passed to the kernel must be defined in some order.
+  const bool ordered;
 };
 
 // ----------------------------------------------------------------------
@@ -699,25 +709,31 @@ struct ARROW_EXPORT HashAggregateKernel : public Kernel {
 
   HashAggregateKernel(std::shared_ptr<KernelSignature> sig, KernelInit init,
                       HashAggregateResize resize, HashAggregateConsume consume,
-                      HashAggregateMerge merge, HashAggregateFinalize finalize)
+                      HashAggregateMerge merge, HashAggregateFinalize finalize,
+                      const bool ordered)
       : Kernel(std::move(sig), std::move(init)),
         resize(resize),
         consume(consume),
         merge(merge),
-        finalize(finalize) {}
+        finalize(finalize),
+        ordered(ordered) {}
 
   HashAggregateKernel(std::vector<InputType> in_types, OutputType out_type,
                       KernelInit init, HashAggregateConsume consume,
                       HashAggregateResize resize, HashAggregateMerge merge,
-                      HashAggregateFinalize finalize)
+                      HashAggregateFinalize finalize, const bool ordered)
       : HashAggregateKernel(
             KernelSignature::Make(std::move(in_types), std::move(out_type)),
-            std::move(init), resize, consume, merge, finalize) {}
+            std::move(init), resize, consume, merge, finalize, ordered) {}
 
   HashAggregateResize resize;
   HashAggregateConsume consume;
   HashAggregateMerge merge;
   HashAggregateFinalize finalize;
+  /// @brief whether the summarizer requires ordering
+  /// This is similar to ScalarAggregateKernel. See ScalarAggregateKernel
+  /// for detailed doc of this variable.
+  bool ordered{false};
 };
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -677,7 +677,7 @@ struct ARROW_EXPORT ScalarAggregateKernel : public Kernel {
   /// The caller of the aggregate kernel is responsible for passing data in some
   /// defined order to the kernel. The flag here is a way for the kernel to tell
   /// the caller that data passed to the kernel must be defined in some order.
-  const bool ordered;
+  bool ordered;
 };
 
 // ----------------------------------------------------------------------
@@ -731,7 +731,7 @@ struct ARROW_EXPORT HashAggregateKernel : public Kernel {
   /// @brief whether the summarizer requires ordering
   /// This is similar to ScalarAggregateKernel. See ScalarAggregateKernel
   /// for detailed doc of this variable.
-  bool ordered{false};
+  bool ordered;
 };
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -644,8 +644,6 @@ using ScalarAggregateFinalize = Status (*)(KernelContext*, Datum*);
 /// * finalize: produces the end result of the aggregation using the
 ///   KernelState in the KernelContext.
 struct ARROW_EXPORT ScalarAggregateKernel : public Kernel {
-  ScalarAggregateKernel() = default;
-
   ScalarAggregateKernel(std::shared_ptr<KernelSignature> sig, KernelInit init,
                         ScalarAggregateConsume consume, ScalarAggregateMerge merge,
                         ScalarAggregateFinalize finalize, const bool ordered)

--- a/cpp/src/arrow/compute/kernels/aggregate_basic.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic.cc
@@ -1081,8 +1081,11 @@ void RegisterScalarAggregateBasic(FunctionRegistry* registry) {
       "first_last", Arity::Unary(), first_last_doc, &default_scalar_aggregate_options);
   auto first_last_func = func.get();
 
-  AddFirstLastKernels(FirstLastInit, {boolean(), fixed_size_binary(1)}, func.get());
-  AddFirstLastKernels(FirstLastInit, PrimitiveTypes(), func.get());
+  AddFirstLastKernels(FirstLastInit, {boolean()}, func.get());
+  AddFirstLastKernels(FirstLastInit, NumericTypes(), func.get());
+  AddFirstLastKernels(FirstLastInit, BaseBinaryTypes(), func.get());
+  AddFirstLastKernels(FirstLastInit, TemporalTypes(), func.get());
+  AddFirstLastKernel(FirstLastInit, Type::FIXED_SIZE_BINARY, func.get(), SimdLevel::NONE);
   DCHECK_OK(registry->AddFunction(std::move(func)));
 
   // Add first/last as convience functions

--- a/cpp/src/arrow/compute/kernels/aggregate_basic.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic.cc
@@ -953,25 +953,27 @@ const FunctionDoc mean_doc{
     {"array"},
     "ScalarAggregateOptions"};
 
-const FunctionDoc first_last_doc{"Compute the first and last values of an array",
-                                 ("Do not use this directly. This is internal and might"
-                                  "be removed in the future."),
-                                 {"array"},
-                                 "ScalarAggregateOptions"};
+const FunctionDoc first_last_doc{
+    "Compute the first and last values of an array",
+    ("Null values are ignored by default.\n"
+     "If skip_nulls = false, then this will return the first and last values\n"
+     "regardless if it is null"),
+    {"array"},
+    "ScalarAggregateOptions"};
 
 const FunctionDoc first_doc{
     "Compute the first value in each group",
     ("Null values are ignored by default.\n"
-     "Currently this should only be used with serial execution because\n"
-     "ordering is otherwise undefined."),
+     "If skip_nulls = false, then this will return the first and last values\n"
+     "regardless if it is null"),
     {"array"},
     "ScalarAggregateOptions"};
 
 const FunctionDoc last_doc{
     "Compute the first value in each group",
     ("Null values are ignored by default.\n"
-     "Currently this should only be used with serial execution because\n"
-     "ordering is otherwise undefined."),
+     "If skip_nulls = false, then this will return the first and last values\n"
+     "regardless if it is null"),
     {"array"},
     "ScalarAggregateOptions"};
 

--- a/cpp/src/arrow/compute/kernels/aggregate_basic.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic.cc
@@ -1081,7 +1081,7 @@ void RegisterScalarAggregateBasic(FunctionRegistry* registry) {
       "first_last", Arity::Unary(), first_last_doc, &default_scalar_aggregate_options);
   auto first_last_func = func.get();
 
-  AddFirstLastKernels(FirstLastInit, {boolean()}, func.get());
+  AddFirstLastKernels(FirstLastInit, {boolean(), fixed_size_binary(1)}, func.get());
   AddFirstLastKernels(FirstLastInit, PrimitiveTypes(), func.get());
   DCHECK_OK(registry->AddFunction(std::move(func)));
 

--- a/cpp/src/arrow/compute/kernels/aggregate_basic.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic.cc
@@ -448,13 +448,12 @@ Result<std::unique_ptr<KernelState>> FirstLastInit(KernelContext* ctx,
   ARROW_ASSIGN_OR_RAISE(TypeHolder out_type,
                         args.kernel->signature->out_type().Resolve(ctx, args.inputs));
 
-  FirstLastInitState<SimdLevel::NONE> visitor(
-      ctx, *args.inputs[0], out_type.GetSharedPtr(),
-      static_cast<const ScalarAggregateOptions&>(*args.options));
+  FirstLastInitState visitor(ctx, *args.inputs[0], out_type.GetSharedPtr(),
+                             static_cast<const ScalarAggregateOptions&>(*args.options));
   return visitor.Create();
 }
 
-// For "first" and "last" functions: override finanlize and return the actual value
+// For "first" and "last" functions: override finalize and return the actual value
 template <FirstOrLast first_or_last>
 void AddFirstOrLastAggKernel(ScalarAggregateFunction* func,
                              ScalarAggregateFunction* first_last_func) {
@@ -477,7 +476,7 @@ void AddFirstOrLastAggKernel(ScalarAggregateFunction* func,
   };
 
   AddAggKernel(std::move(sig), std::move(init), std::move(finalize), func,
-               SimdLevel::NONE, /*ordered*/ true);
+               SimdLevel::NONE, /*ordered=*/true);
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/compute/kernels/aggregate_basic_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic_internal.h
@@ -522,6 +522,8 @@ struct FirstLastImpl : public ScalarAggregator {
           values = {first_scalar, last_scalar};
         }
       } else {
+        // If there is no non-null values, we always output null regardless of
+        // skip_null
         values = {null_scalar, null_scalar};
       }
     }

--- a/cpp/src/arrow/compute/kernels/aggregate_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_internal.h
@@ -100,6 +100,10 @@ struct ScalarAggregator : public KernelState {
 // kernel implementations together
 enum class VarOrStd : bool { Var, Std };
 
+// Helper to differentiate between first/last calculation so we can fold
+// kernel implementations together
+enum class FirstOrLast : bool { First, Last };
+
 // Helper to differentiate between min/max calculation so we can fold
 // kernel implementations together
 enum class MinOrMax : uint8_t { Min = 0, Max };

--- a/cpp/src/arrow/compute/kernels/aggregate_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_internal.h
@@ -110,11 +110,11 @@ enum class MinOrMax : uint8_t { Min = 0, Max };
 
 void AddAggKernel(std::shared_ptr<KernelSignature> sig, KernelInit init,
                   ScalarAggregateFunction* func,
-                  SimdLevel::type simd_level = SimdLevel::NONE);
+                  SimdLevel::type simd_level = SimdLevel::NONE, bool ordered = false);
 
 void AddAggKernel(std::shared_ptr<KernelSignature> sig, KernelInit init,
                   ScalarAggregateFinalize finalize, ScalarAggregateFunction* func,
-                  SimdLevel::type simd_level = SimdLevel::NONE);
+                  SimdLevel::type simd_level = SimdLevel::NONE, bool ordered = false);
 
 using arrow::internal::VisitSetBitRunsVoid;
 

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -1573,8 +1573,8 @@ TYPED_TEST_SUITE(TestPrimitiveFirstLastKernel, PrimitiveArrowTypes);
 TYPED_TEST(TestPrimitiveFirstLastKernel, Basics) {
   ScalarAggregateOptions options;
   std::vector<std::string> chunked_input1 = {"[5, 1, 2, 3, 4]", "[9, 8, null, 3, 4]"};
-  std::vector<std::string> chunked_input2 = {"[null, null, null, null]",
-                                             "[null, 8, null, 3 ,4]"};
+  std::vector<std::string> chunked_input2 = {"[null, null, null, 7]",
+                                             "[null, 8, null, 3, 4, null]"};
   std::vector<std::string> chunked_input3 = {"[null, null, null]", "[null, null]"};
   auto item_ty = default_type_instance<TypeParam>();
 
@@ -1582,12 +1582,13 @@ TYPED_TEST(TestPrimitiveFirstLastKernel, Basics) {
   this->AssertFirstLastIs("[5, null, 2, 3, null]", 5, 3, options);
   this->AssertFirstLastIs(chunked_input1, 5, 4, options);
   this->AssertFirstLastIs(chunked_input1[1], 9, 4, options);
-  this->AssertFirstLastIs(chunked_input2, 8, 4, options);
-  this->AssertFirstLastIsNull(chunked_input2[0], options);
+  this->AssertFirstLastIs(chunked_input2, 7, 4, options);
+  this->AssertFirstLastIsNull(chunked_input3[0], options);
   this->AssertFirstLastIsNull(chunked_input3, options);
 
   options.skip_nulls = false;
-  this->AssertFirstLastIsNull(chunked_input1, options);
+  this->AssertFirstLastIsNull(chunked_input2[1], options);
+  this->AssertFirstLastIsNull(chunked_input2, options);
 }
 
 TYPED_TEST_SUITE(TestTemporalFirstLastKernel, TemporalArrowTypes);
@@ -1595,12 +1596,16 @@ TYPED_TEST(TestTemporalFirstLastKernel, Basics) {
   ScalarAggregateOptions options;
   std::vector<std::string> chunked_input1 = {"[5, 1, 2, 3, 4]", "[9, 8, null, 3, 4]"};
   std::vector<std::string> chunked_input2 = {"[null, null, null, null]",
-                                             "[null, 8, null, 3 ,4]"};
+                                             "[null, 8, null, 3 ,4, null]"};
   auto item_ty = default_type_instance<TypeParam>();
 
   this->AssertFirstLastIs("[5, 1, 2, 3, 4]", 5, 4, options);
   this->AssertFirstLastIs("[5, null, 2, 3, null]", 5, 3, options);
   this->AssertFirstLastIs(chunked_input1, 5, 4, options);
+  this->AssertFirstLastIs(chunked_input2, 8, 4, options);
+
+  options.skip_nulls = false;
+  this->AssertFirstLastIsNull(chunked_input2, options);
 }
 
 template <typename ArrowType>

--- a/cpp/src/arrow/compute/kernels/hash_aggregate.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate.cc
@@ -1802,7 +1802,9 @@ struct GroupedFirstLastImpl final : public GroupedAggregator {
     ARROW_ASSIGN_OR_RAISE(auto null_bitmap, has_values_.Finish());
 
     if (!options_.skip_nulls) {
-      return Status::NotImplemented("Don't support first/last with skip nulls = False");
+      ARROW_ASSIGN_OR_RAISE(auto has_nulls, has_nulls_.Finish());
+      arrow::internal::BitmapAndNot(null_bitmap->data(), 0, has_nulls->data(), 0,
+                                    num_groups_, 0, null_bitmap->mutable_data());
     }
 
     auto firsts = ArrayData::Make(type_, num_groups_, {null_bitmap, nullptr});

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -212,7 +212,13 @@ the input to a single output value.
 +--------------------+---------+------------------+------------------------+----------------------------------+-------+
 | count_distinct     | Unary   | Non-nested types | Scalar Int64           | :struct:`CountOptions`           | \(2)  |
 +--------------------+---------+------------------+------------------------+----------------------------------+-------+
+| first              | Unary   | Numeric, Binary  | Scalar Input type      | :struct:`ScalarAggregateOptions` | \(11) |
++--------------------+---------+------------------+------------------------+----------------------------------+-------+
+| first_last         | Unary   | Numeric, Binary  | Scalar Struct          | :struct:`ScalarAggregateOptions` | \(11) |
++--------------------+---------+------------------+------------------------+----------------------------------+-------+
 | index              | Unary   | Any              | Scalar Int64           | :struct:`IndexOptions`           | \(3)  |
++--------------------+---------+------------------+------------------------+----------------------------------+-------+
+| last               | Unary   | Numeric, Binary  | Scalar Input type      | :struct:`ScalarAggregateOptions` | \(11) |
 +--------------------+---------+------------------+------------------------+----------------------------------+-------+
 | max                | Unary   | Non-nested types | Scalar Input type      | :struct:`ScalarAggregateOptions` |       |
 +--------------------+---------+------------------+------------------------+----------------------------------+-------+
@@ -272,6 +278,8 @@ the input to a single output value.
 * \(10) tdigest/t-digest computes approximate quantiles, and so only needs a
   fixed amount of memory. See the `reference implementation
   <https://github.com/tdunning/t-digest>`_ for details.
+
+* \(11) Result is based on the ordering of input data
 
   Decimal arguments are cast to Float64 first.
 
@@ -340,6 +348,12 @@ equivalents above and reflects how they are implemented internally.
 +-------------------------+---------+------------------------------------+------------------------+----------------------------------+-----------+
 | hash_distinct           | Unary   | Any                                | List of input type     | :struct:`CountOptions`           | \(2) \(3) |
 +-------------------------+---------+------------------------------------+------------------------+----------------------------------+-----------+
+| hash_first              | Unary   | Numeric, Binary                    | Input type             | :struct:`ScalarAggregateOptions` | \(10)     |
++-------------------------+---------+------------------------------------+------------------------+----------------------------------+-----------+
+| hash_first_last         | Unary   | Numeric, Binary                    | Struct                 | :struct:`ScalarAggregateOptions` | \(10)     |
++-------------------------+---------+------------------------------------+------------------------+----------------------------------+-----------+
+| hash_last               | Unary   | Numeric, Binary                    | Input type             | :struct:`ScalarAggregateOptions` | \(10)     |
++-------------------------+---------+------------------------------------+------------------------+----------------------------------+-----------+
 | hash_list               | Unary   | Any                                | List of input type     |                                  | \(3)      |
 +-------------------------+---------+------------------------------------+------------------------+----------------------------------+-----------+
 | hash_max                | Unary   | Non-nested, non-binary/string-like | Input type             | :struct:`ScalarAggregateOptions` |           |
@@ -397,6 +411,8 @@ equivalents above and reflects how they are implemented internally.
 * \(9) T-digest computes approximate quantiles, and so only needs a
   fixed amount of memory. See the `reference implementation
   <https://github.com/tdunning/t-digest>`_ for details.
+
+* \(10) Result is based on ordering of the input data.
 
   Decimal arguments are cast to Float64 first.
 
@@ -1412,7 +1428,7 @@ null input value is converted into a null output value.
 
 * \(4) Offsets are unchanged, the keys and values are cast from respective input
   to output types (if a conversion is available). If output type is a list of
-  struct, the key field is output as the first field and the value field the 
+  struct, the key field is output as the first field and the value field the
   second field, regardless of field names chosen.
 
 * \(5) Any input type that can be cast to the resulting extension's storage type.
@@ -1614,7 +1630,7 @@ an ``Invalid`` :class:`Status` when overflow is detected.
 * \(1) CumulativeSumOptions has two optional parameters. The first parameter
   :member:`CumulativeSumOptions::start` is a starting value for the running
   sum. It has a default value of 0. Specified values of ``start`` must have the
-  same type as the input. The second parameter 
+  same type as the input. The second parameter
   :member:`CumulativeSumOptions::skip_nulls` is a boolean. When set to
   false (the default), the first encountered null is propagated. When set to
   true, each null in the input produces a corresponding null in the output.


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
This PR adds "first" and "last" aggregator and support using those with Acero's segmented aggregation.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
- [x] Numeric Scalar Aggregator (bool, int types, floating types)
- [x] Numeric Hash Aggregator (bool, int types, floating types)
- [x] Docstring
- [x] Non-Numeric Scalar Aggregator (string, binary, fixed binary, temporal)
- [x] Non-Numeric Hash Aggregator (string, binary, fixed binary, temporal)
- [x] Add `ordered` flag in aggregate kernels
- [x] Implement and test skip null
- [x] Update compute.rst

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
- [x] Compute Kernel Test (Scalar Kernels, all supported datatypes)
- [x] Hash Aggregate Test (Hash Kernels, all supported datatypes)
- [x] Segmented Aggregation Test (Both Scalar and Hash Kernels)
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
Yes. Added First and Last aggregator.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->