### PR TITLE
GH-34768: [C++][Gandiva] Remove LLVM<16 pin

### DIFF
--- a/ci/conda_env_gandiva.txt
+++ b/ci/conda_env_gandiva.txt
@@ -16,4 +16,4 @@
 # under the License.
 
 clang>=11
-llvmdev>=11,<16
+llvmdev>=11


### PR DESCRIPTION
Small follow-up on https://github.com/apache/arrow/pull/34916 to remove this temporary pin now LLVM 16 is accepted
* Closes: #34768