### PR TITLE
GH-33689: [Python][CI] Re-enable fsspec tests on dask nightly tests

### DIFF
--- a/ci/scripts/integration_dask.sh
+++ b/ci/scripts/integration_dask.sh
@@ -33,7 +33,6 @@ python -c "import dask.dataframe"
 
 pytest -v --pyargs dask.dataframe.tests.test_dataframe
 pytest -v --pyargs dask.dataframe.io.tests.test_orc
-# skip test until new fsspec release is out (https://github.com/fsspec/filesystem_spec/pull/1139)
-pytest -v --pyargs dask.dataframe.io.tests.test_parquet -k "not test_pyarrow_filesystem_option"
+pytest -v --pyargs dask.dataframe.io.tests.test_parquet
 # this file contains parquet tests that use S3 filesystem
 pytest -v --pyargs dask.bytes.tests.test_s3


### PR DESCRIPTION
### Rationale for this change

fsspec has had a new release, so this test should now be passing again using the latest versions of fsspec and dask


* Closes: #33689