### PR TITLE
GH-34933: [Python] Raise minimum cython version

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -17,7 +17,7 @@
 
 [build-system]
 requires = [
-    "cython >= 0.29.22",
+    "cython >= 0.29.31",
     "oldest-supported-numpy>=0.14",
     "setuptools_scm",
     "setuptools >= 40.1.0",

--- a/python/requirements-build.txt
+++ b/python/requirements-build.txt
@@ -1,4 +1,4 @@
-cython>=0.29
+cython>=0.29.34
 oldest-supported-numpy>=0.14
 setuptools_scm
 setuptools>=38.6.0

--- a/python/requirements-build.txt
+++ b/python/requirements-build.txt
@@ -1,4 +1,4 @@
-cython>=0.29.34
+cython>=0.29.31
 oldest-supported-numpy>=0.14
 setuptools_scm
 setuptools>=38.6.0

--- a/python/requirements-wheel-build.txt
+++ b/python/requirements-wheel-build.txt
@@ -1,4 +1,4 @@
-cython>=0.29.11
+cython>=0.29.34
 oldest-supported-numpy>=0.14
 setuptools_scm
 setuptools>=58

--- a/python/requirements-wheel-build.txt
+++ b/python/requirements-wheel-build.txt
@@ -1,4 +1,4 @@
-cython>=0.29.34
+cython>=0.29.31
 oldest-supported-numpy>=0.14
 setuptools_scm
 setuptools>=58

--- a/python/setup.py
+++ b/python/setup.py
@@ -491,7 +491,7 @@ setup(
                                  'pyarrow/_generated_version.py'),
         'version_scheme': guess_next_dev_version
     },
-    setup_requires=['setuptools_scm', 'cython >= 0.29.34'] + setup_requires,
+    setup_requires=['setuptools_scm', 'cython >= 0.29.31'] + setup_requires,
     install_requires=install_requires,
     tests_require=['pytest', 'pandas', 'hypothesis'],
     python_requires='>=3.7',

--- a/python/setup.py
+++ b/python/setup.py
@@ -40,8 +40,8 @@ import Cython
 # Check if we're running 64-bit Python
 is_64_bit = sys.maxsize > 2**32
 
-if Cython.__version__ < '0.29.34':
-    raise Exception('Please upgrade to Cython 0.29.34 or newer')
+if Cython.__version__ < '0.29.31':
+    raise Exception('Please upgrade to Cython 0.29.31 or newer')
 
 setup_dir = os.path.abspath(os.path.dirname(__file__))
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -40,8 +40,8 @@ import Cython
 # Check if we're running 64-bit Python
 is_64_bit = sys.maxsize > 2**32
 
-if Cython.__version__ < '0.29.22':
-    raise Exception('Please upgrade to Cython 0.29.22 or newer')
+if Cython.__version__ < '0.29.34':
+    raise Exception('Please upgrade to Cython 0.29.34 or newer')
 
 setup_dir = os.path.abspath(os.path.dirname(__file__))
 
@@ -491,7 +491,7 @@ setup(
                                  'pyarrow/_generated_version.py'),
         'version_scheme': guess_next_dev_version
     },
-    setup_requires=['setuptools_scm', 'cython >= 0.29'] + setup_requires,
+    setup_requires=['setuptools_scm', 'cython >= 0.29.34'] + setup_requires,
     install_requires=install_requires,
     tests_require=['pytest', 'pandas', 'hypothesis'],
     python_requires='>=3.7',


### PR DESCRIPTION
Building with cython 0.29.11 fails but works with latest 0.29.34.
* Closes: #34933