### PR TITLE
GH-34937: [R] Minimal build failing due to new test which relies on snappy being installed 

### DIFF
--- a/r/tests/testthat/test-parquet.R
+++ b/r/tests/testthat/test-parquet.R
@@ -478,6 +478,7 @@ test_that("Can read parquet with nested lists and maps", {
 test_that("Can read Parquet files from a URL", {
   skip_if_offline()
   skip_on_cran()
+  skip_if_not_available("snappy")
   parquet_url <- "https://github.com/apache/arrow/blob/64f2cc7986ce672dd1a8cb268d193617a80a1653/r/inst/v0.7.1.parquet?raw=true" # nolint
   pu <- read_parquet(parquet_url)
   expect_true(tibble::is_tibble(pu))


### PR DESCRIPTION

* Closes: #34937