### PR TITLE
GH-34936: [JavaScript] Added Proxy for Table, RecordBatch, and Vector

### DIFF
--- a/js/perf/index.ts
+++ b/js/perf/index.ts
@@ -133,6 +133,21 @@ b.suite(
     b.cycle(cycle)
 );
 
+b.suite(
+    `[index] Vector`,
+
+    ...Object.entries(vectors).map(([name, vector]) =>
+        b.add(`from: ${name}`, () => {
+            for (let i = -1, n = vector.length; ++i < n;) {
+                vector[i];
+            }
+        })),
+
+    b.cycle(cycle)
+);
+
+
+
 for (const { name, ipc, table } of config) {
     b.suite(
         `Parse`,

--- a/js/src/util/proxyhandler.ts
+++ b/js/src/util/proxyhandler.ts
@@ -1,0 +1,24 @@
+export class IndexAccessProxyHandler<T extends object = any> implements ProxyHandler<T> {
+    get(target: any, key: string, receiver: any) {
+        if (typeof key === "string") { // Need to check because key can be a symbol, such as [Symbol.iterator].
+            const idx = +key; // Convert the key to a number
+            if (idx === idx) { // Basically an inverse NaN check
+                return (receiver || target).get(idx);
+            }
+        }
+
+        return Reflect.get(target, key, receiver);
+    }
+
+    set(target: any, key: string, value: any, receiver: any) {
+        if (typeof key === "string") { // Need to check because key can be a symbol, such as [Symbol.iterator].
+            const idx = +key; // Convert the key to a number
+            if (idx === idx) { // Basically an inverse NaN check
+                (receiver || target).set(idx, value);
+                return true; // Is this correct?
+            }
+        }
+
+        return Reflect.set(target, key, value, receiver);
+    }
+}

--- a/js/test/unit/recordbatch/record-batch-tests.ts
+++ b/js/test/unit/recordbatch/record-batch-tests.ts
@@ -129,4 +129,17 @@ describe(`RecordBatch`, () => {
             expect(f32sBatch.numRows).toBe(45);
         });
     });
+
+    describe(`get()`, () => {
+        test(`can get row with get and []`, () => {
+            const batch = numsRecordBatch(32, 45);
+            const row = batch.get(2)
+            expect(row).not.toBeNull();
+            expect(row!.f32).toEqual(2);
+            expect(row!.i32).toEqual(2);
+
+            const row2 = batch[2];
+            expect(row2).toEqual(row);
+        });
+    });
 });

--- a/js/test/unit/table-tests.ts
+++ b/js/test/unit/table-tests.ts
@@ -291,6 +291,10 @@ describe(`Table`, () => {
                     expect(row.f32).toEqual(expected[F32]);
                     expect(row.i32).toEqual(expected[I32]);
                     expect(row.dictionary).toEqual(expected[DICT]);
+
+                    // Test index access as well
+                    const row2 = table[i];
+                    expect(row2).toEqual(row)
                 }
             });
             test(`iterates expected values`, () => {

--- a/js/test/unit/vector/vector-tests.ts
+++ b/js/test/unit/vector/vector-tests.ts
@@ -73,7 +73,12 @@ describe(`StructVector`, () => {
 
     test(`get value`, () => {
         for (const [i, value] of values.entries()) {
-            expect(vector.get(i)!.toJSON()).toEqual(value);
+            const row = vector.get(i);
+            expect(row).not.toBeNull();
+            expect(row!.toJSON()).toEqual(value);
+
+            const row2 = vector[i];
+            expect(row2).toEqual(row);
         }
     });
 });


### PR DESCRIPTION
**THIS PR IS NOT READY YET**:

- [ ] Potentially add documentation comparing the performance of `.get` vs `[index]`, and maybe even the nuance of how `.get` can use a binary search algorithm when the `Vector` consists of multiple chunks. 
- [ ] Implement other methods such as `filter` on the `Vector` object to ensure 100% compatibility with JavaScript arrays.

### Rationale for this change

Certain codebases that previously uses row-oriented way to access data may wish to migrate to Arrow to save serialization and deserialization cost, and to be able to gain access to fast column-oriented operations. As it stands, Arrow is sort of a drop-in replacement to row-oriented data such as a JavaScript Array of objects. This is great to incrementally migrate legacy codebases to Arrow, as it is frequently infeasible to rewrite the application to use the column-oriented data access patterns. For most data, JavaScript-object-compatible and row-oriented access is already provided via the `StructRowProxy`. However, if the structs themselves include a `Vector`, existing code will break as it assumes the `Vector` object to behave like a JavaScript array, which it does not due to the lack of index access. An example of such a data structure is as follows:

```
[
  {x: 1, y: [1, 2]},
  {x: 2, y: [2, 3]},
]
```

In this case, with the Arrow JS library as it is, the API consumer is unable to get individual element of the `y` array via `table[i].y[j]`. Instead, the API consumer must use the API `table.get(i).y.get(j)`. In the situation where we are migrating a legacy code base to Arrow, this requires a large refactor of the entire codebase, which is infeasible in a short time. This negates the advantage of using Arrow as a drop-in replacement and prevents incremental migration of code to Arrow.

### What changes are included in this PR?

To address this problem, this patch adds a Proxy at the root of the prototype chain for the `Table`, `RecordBatch`, and `Vector` objects and allow index access for these objects for backward compatibility purposes. Basically, objects like `Vector` now supports `vector[i]` in addition to `vector.get(i)`.

However, code should not be using `vector[i]` as it is ~1.5 orders of magnitude slower than `vector.get(i)` as ES6 Proxy objects are quite slow. This should only be used to provide compatibility for legacy codebases. For code that desires high performance, `.get` remains a much better solution. This is also why the Proxy object is added to the root of the prototype chain, as opposed to the usual pattern where a Proxy object is returned from a constructor.

Documentation has been added to compare the performance of the various access.

### Are there any user-facing changes?

`Table`, `RecordBatch`, and `Vector` elements can now be accessed via index operators, albeit much slower than `.get`. All changes should be backward compatible.

### Are these changes tested?

Yes. The performance of the base objects does not seem to be affected. To establish the performance change, we first see how much variability in the `ops/s` there is between two runs of `yarn perf`. The left plot below shows the percent difference between the two runs. This shows a baseline level of "variability" (although may not be statistically significant, but gives an indication) between the runs. We see most benchmarks are within 20% of each other, although a few tests at the bottom show higher variability. The right plot shows the difference in `ops/s` before and after the patch. No benchmark showed significantly higher or lower performance and looks superficially similar to the variability comparison. As such, we can say that the performance of the objects are not impacted by this patch.

![image](https://user-images.githubusercontent.com/338100/230441327-6162a318-362a-4c18-bb81-68bc9a32e987.png)

The following shows the performance of `vector.get(i)` vs `vector[i]`. The raw results shows the index access to have about 50 ops/s while `.get` are around 750 ops/s. This is about 1.5 orders of magnitude difference in performance. Basically, this shouldn't be used unless it is used for backward compatibility with code that expects native JavaScript arrays.

<img src=https://user-images.githubusercontent.com/338100/230442000-0d7bd599-47bc-4268-a8fe-a9f858c2d319.png width=600 />

* Closes: apache/arrow-js#84
* GitHub Issue: #84