### PR TITLE
GH-34951: [Ruby] Add methods using MatchSubStringFamilyCondition

### DIFF
--- a/ruby/red-arrow/lib/arrow/slicer.rb
+++ b/ruby/red-arrow/lib/arrow/slicer.rb
@@ -192,15 +192,6 @@ module Arrow
         end 
       end
 
-      def match_substring_regexp?(pattern, ignore_case: false)
-        if pattern.is_a?(Regexp)
-          ignore_case = pattern.casefold?
-          pattern = pattern.source
-        end
-        MatchSubstringFamilyCondition.new("match_substring_regex",
-                                          @column, pattern, ignore_case)
-      end
-
       def start_with?(substring, ignore_case: false)
         MatchSubstringFamilyCondition.new("starts_with",
                                           @column, substring, ignore_case)

--- a/ruby/red-arrow/lib/arrow/slicer.rb
+++ b/ruby/red-arrow/lib/arrow/slicer.rb
@@ -168,7 +168,7 @@ module Arrow
                                           @column, substring, ignore_case)
       end
 
-      def match_like(pattern, ignore_case: false)
+      def match_like?(pattern, ignore_case: false)
         MatchSubstringFamilyCondition.new("match_like",
                                           @column, pattern, ignore_case)
       end

--- a/ruby/red-arrow/lib/arrow/slicer.rb
+++ b/ruby/red-arrow/lib/arrow/slicer.rb
@@ -173,9 +173,21 @@ module Arrow
                                           @column, pattern, ignore_case)
       end
 
-      def match_substring?(substring, ignore_case: false)
-        MatchSubstringFamilyCondition.new("match_substring",
-                                          @column, substring, ignore_case)
+      def match_substring?(pattern, ignore_case: false)
+        case pattern
+        when String
+          MatchSubstringFamilyCondition.new("match_substring",
+                                            @column, pattern, ignore_case)
+        when Regexp
+          MatchSubstringFamilyCondition.new("match_substring_regex",
+                                            @column,
+                                            pattern.source,
+                                            ignore_case)
+        else
+          message =
+             "pattern must be either String or Regexp not #{pattern}.class"
+          raise ArgumentError, message
+        end 
       end
 
       def match_substring_regex?(pattern, ignore_case: false)

--- a/ruby/red-arrow/lib/arrow/slicer.rb
+++ b/ruby/red-arrow/lib/arrow/slicer.rb
@@ -191,6 +191,7 @@ module Arrow
       end
 
       def match_substring_regex?(pattern, ignore_case: false)
+        pattern = pattern.source if pattern.is_a?(Regexp)
         MatchSubstringFamilyCondition.new("match_substring_regex",
                                           @column, pattern, ignore_case)
       end

--- a/ruby/red-arrow/lib/arrow/slicer.rb
+++ b/ruby/red-arrow/lib/arrow/slicer.rb
@@ -173,16 +173,18 @@ module Arrow
                                           @column, pattern, ignore_case)
       end
 
-      def match_substring?(pattern, ignore_case: false)
+      def match_substring?(pattern, ignore_case: nil)
         case pattern
         when String
+          ignore_case = false if ignore_case.nil?
           MatchSubstringFamilyCondition.new("match_substring",
                                             @column, pattern, ignore_case)
         when Regexp
+          ignore_case = pattern.casefold? if ignore_case.nil?
           MatchSubstringFamilyCondition.new("match_substring_regex",
                                             @column,
                                             pattern.source,
-                                            pattern.casefold?)
+                                            ignore_case)
         else
           message =
              "pattern must be either String or Regexp: #{pattern.inspect}"

--- a/ruby/red-arrow/lib/arrow/slicer.rb
+++ b/ruby/red-arrow/lib/arrow/slicer.rb
@@ -163,7 +163,7 @@ module Arrow
         RejectCondition.new(@column, block)
       end
 
-      def ends_with(substring, ignore_case: false)
+      def end_with?(substring, ignore_case: false)
         MatchSubstringFamilyCondition.new("ends_with",
                                           @column, substring, ignore_case)
       end

--- a/ruby/red-arrow/lib/arrow/slicer.rb
+++ b/ruby/red-arrow/lib/arrow/slicer.rb
@@ -173,7 +173,7 @@ module Arrow
                                           @column, pattern, ignore_case)
       end
 
-      def match_substring(substring, ignore_case: false)
+      def match_substring?(substring, ignore_case: false)
         MatchSubstringFamilyCondition.new("match_substring",
                                           @column, substring, ignore_case)
       end

--- a/ruby/red-arrow/lib/arrow/slicer.rb
+++ b/ruby/red-arrow/lib/arrow/slicer.rb
@@ -178,7 +178,7 @@ module Arrow
                                           @column, substring, ignore_case)
       end
 
-      def match_substring_regex(pattern, ignore_case: false)
+      def match_substring_regex?(pattern, ignore_case: false)
         MatchSubstringFamilyCondition.new("match_substring_regex",
                                           @column, pattern, ignore_case)
       end

--- a/ruby/red-arrow/lib/arrow/slicer.rb
+++ b/ruby/red-arrow/lib/arrow/slicer.rb
@@ -163,8 +163,18 @@ module Arrow
         RejectCondition.new(@column, block)
       end
 
+      def ends_with(substring, ignore_case: false)
+        MatchSubstringFamilyCondition.new("ends_with",
+                                          @column, substring, ignore_case)
+      end
+
       def match_substring(substring, ignore_case: false)
         MatchSubstringFamilyCondition.new("match_substring",
+                                          @column, substring, ignore_case)
+      end
+
+      def starts_with(substring, ignore_case: false)
+        MatchSubstringFamilyCondition.new("starts_with",
                                           @column, substring, ignore_case)
       end
     end

--- a/ruby/red-arrow/lib/arrow/slicer.rb
+++ b/ruby/red-arrow/lib/arrow/slicer.rb
@@ -178,6 +178,11 @@ module Arrow
                                           @column, substring, ignore_case)
       end
 
+      def match_substring_regex(pattern, ignore_case: false)
+        MatchSubstringFamilyCondition.new("match_substring_regex",
+                                          @column, pattern, ignore_case)
+      end
+
       def starts_with(substring, ignore_case: false)
         MatchSubstringFamilyCondition.new("starts_with",
                                           @column, substring, ignore_case)

--- a/ruby/red-arrow/lib/arrow/slicer.rb
+++ b/ruby/red-arrow/lib/arrow/slicer.rb
@@ -185,7 +185,7 @@ module Arrow
                                             ignore_case)
         else
           message =
-             "pattern must be either String or Regexp not #{pattern}.class"
+             "pattern must be either String or Regexp: #{pattern.inspect}"
           raise ArgumentError, message
         end 
       end

--- a/ruby/red-arrow/lib/arrow/slicer.rb
+++ b/ruby/red-arrow/lib/arrow/slicer.rb
@@ -190,7 +190,7 @@ module Arrow
         end 
       end
 
-      def match_substring_regex?(pattern, ignore_case: false)
+      def match_substring_regexp?(pattern, ignore_case: false)
         pattern = pattern.source if pattern.is_a?(Regexp)
         MatchSubstringFamilyCondition.new("match_substring_regex",
                                           @column, pattern, ignore_case)

--- a/ruby/red-arrow/lib/arrow/slicer.rb
+++ b/ruby/red-arrow/lib/arrow/slicer.rb
@@ -182,7 +182,7 @@ module Arrow
           MatchSubstringFamilyCondition.new("match_substring_regex",
                                             @column,
                                             pattern.source,
-                                            ignore_case)
+                                            pattern.casefold?)
         else
           message =
              "pattern must be either String or Regexp: #{pattern.inspect}"
@@ -191,7 +191,10 @@ module Arrow
       end
 
       def match_substring_regexp?(pattern, ignore_case: false)
-        pattern = pattern.source if pattern.is_a?(Regexp)
+        if pattern.is_a?(Regexp)
+          ignore_case = pattern.casefold?
+          pattern = pattern.source
+        end
         MatchSubstringFamilyCondition.new("match_substring_regex",
                                           @column, pattern, ignore_case)
       end

--- a/ruby/red-arrow/lib/arrow/slicer.rb
+++ b/ruby/red-arrow/lib/arrow/slicer.rb
@@ -183,7 +183,7 @@ module Arrow
                                           @column, pattern, ignore_case)
       end
 
-      def starts_with(substring, ignore_case: false)
+      def start_with?(substring, ignore_case: false)
         MatchSubstringFamilyCondition.new("starts_with",
                                           @column, substring, ignore_case)
       end

--- a/ruby/red-arrow/lib/arrow/slicer.rb
+++ b/ruby/red-arrow/lib/arrow/slicer.rb
@@ -168,6 +168,11 @@ module Arrow
                                           @column, substring, ignore_case)
       end
 
+      def match_like(pattern, ignore_case: false)
+        MatchSubstringFamilyCondition.new("match_like",
+                                          @column, pattern, ignore_case)
+      end
+
       def match_substring(substring, ignore_case: false)
         MatchSubstringFamilyCondition.new("match_substring",
                                           @column, substring, ignore_case)

--- a/ruby/red-arrow/test/test-slicer.rb
+++ b/ruby/red-arrow/test/test-slicer.rb
@@ -573,9 +573,9 @@ class SlicerTest < Test::Unit::TestCase
       end
     end  
 
-    test("match_substring_regex?(string)") do
+    test("match_substring_regexp?(string)") do
       sliced_table = @table.slice do |slicer|
-        slicer.string.match_substring_regex?("[dr]ow")
+        slicer.string.match_substring_regexp?("[dr]ow")
       end
       assert_equal(<<~TABLE, sliced_table.to_s)
 	string
@@ -585,9 +585,9 @@ class SlicerTest < Test::Unit::TestCase
       TABLE
     end
 
-    test("match_substring_regex?(regexp)") do
+    test("match_substring_regexp?(regexp)") do
       sliced_table = @table.slice do |slicer|
-        slicer.string.match_substring_regex?(/[dr]ow/)
+        slicer.string.match_substring_regexp?(/[dr]ow/)
       end
       assert_equal(<<~TABLE, sliced_table.to_s)
 	string

--- a/ruby/red-arrow/test/test-slicer.rb
+++ b/ruby/red-arrow/test/test-slicer.rb
@@ -541,6 +541,18 @@ class SlicerTest < Test::Unit::TestCase
       TABLE
     end
 
+    test("match_like") do
+      sliced_table = @table.slice do |slicer|
+        slicer.string.match_like("_rr%")
+      end
+      assert_equal(<<~TABLE, sliced_table.to_s)
+	string
+0	array 
+1	Arrow 
+2	(null)
+      TABLE
+    end
+
     test("starts_with") do
       sliced_table = @table.slice do |slicer|
         slicer.string.starts_with("ca")

--- a/ruby/red-arrow/test/test-slicer.rb
+++ b/ruby/red-arrow/test/test-slicer.rb
@@ -492,9 +492,9 @@ class SlicerTest < Test::Unit::TestCase
       )
     end
 
-    test("ends_with") do
+    test("end_with?") do
       sliced_table = @table.slice do |slicer|
-        slicer.string.ends_with("ow")
+        slicer.string.end_with?("ow")
       end
       assert_equal(<<~TABLE, sliced_table.to_s)
 	string
@@ -565,9 +565,9 @@ class SlicerTest < Test::Unit::TestCase
       TABLE
     end
 
-    test("starts_with") do
+    test("start_with?") do
       sliced_table = @table.slice do |slicer|
-        slicer.string.starts_with("ca")
+        slicer.string.start_with?("ca")
       end
       assert_equal(<<~TABLE, sliced_table.to_s)
 	string

--- a/ruby/red-arrow/test/test-slicer.rb
+++ b/ruby/red-arrow/test/test-slicer.rb
@@ -588,30 +588,6 @@ class SlicerTest < Test::Unit::TestCase
       end
     end  
 
-    test("match_substring_regexp?(string)") do
-      sliced_table = @table.slice do |slicer|
-        slicer.string.match_substring_regexp?("[dr]ow")
-      end
-      assert_equal(<<~TABLE, sliced_table.to_s)
-	string
-0	Arrow 
-1	(null)
-2	window
-      TABLE
-    end
-
-    test("match_substring_regexp?(regexp)") do
-      sliced_table = @table.slice do |slicer|
-        slicer.string.match_substring_regexp?(/[dr]ow/)
-      end
-      assert_equal(<<~TABLE, sliced_table.to_s)
-	string
-0	Arrow 
-1	(null)
-2	window
-      TABLE
-    end
-
     test("start_with?") do
       sliced_table = @table.slice do |slicer|
         slicer.string.start_with?("ca")

--- a/ruby/red-arrow/test/test-slicer.rb
+++ b/ruby/red-arrow/test/test-slicer.rb
@@ -573,9 +573,21 @@ class SlicerTest < Test::Unit::TestCase
       end
     end  
 
-    test("match_substring_regex?") do
+    test("match_substring_regex?(string)") do
       sliced_table = @table.slice do |slicer|
         slicer.string.match_substring_regex?("[dr]ow")
+      end
+      assert_equal(<<~TABLE, sliced_table.to_s)
+	string
+0	Arrow 
+1	(null)
+2	window
+      TABLE
+    end
+
+    test("match_substring_regex?(regexp)") do
+      sliced_table = @table.slice do |slicer|
+        slicer.string.match_substring_regex?(/[dr]ow/)
       end
       assert_equal(<<~TABLE, sliced_table.to_s)
 	string

--- a/ruby/red-arrow/test/test-slicer.rb
+++ b/ruby/red-arrow/test/test-slicer.rb
@@ -553,7 +553,7 @@ class SlicerTest < Test::Unit::TestCase
       TABLE
     end
 
-    test("match_substring?(regexp)") do
+    test("match_substring?(Regexp)") do
       sliced_table = @table.slice do |slicer|
         slicer.string.match_substring?(/[dr]ow/)
       end

--- a/ruby/red-arrow/test/test-slicer.rb
+++ b/ruby/red-arrow/test/test-slicer.rb
@@ -504,9 +504,21 @@ class SlicerTest < Test::Unit::TestCase
       TABLE
     end
 
-    test("match_substring") do
+    test("match_like?") do
       sliced_table = @table.slice do |slicer|
-        slicer.string.match_substring("arr")
+        slicer.string.match_like?("_rr%")
+      end
+      assert_equal(<<~TABLE, sliced_table.to_s)
+	string
+0	array 
+1	Arrow 
+2	(null)
+      TABLE
+    end
+
+    test("match_substring?") do
+      sliced_table = @table.slice do |slicer|
+        slicer.string.match_substring?("arr")
       end
       assert_equal(<<~TABLE, sliced_table.to_s)
 	string
@@ -516,9 +528,9 @@ class SlicerTest < Test::Unit::TestCase
       TABLE
     end
 
-    test("match_substring(ignore_case:)") do
+    test("match_substring?(ignore_case:)") do
       sliced_table = @table.slice do |slicer|
-        slicer.string.match_substring("arr", ignore_case: true)
+        slicer.string.match_substring?("arr", ignore_case: true)
       end
       assert_equal(<<~TABLE, sliced_table.to_s)
 	string
@@ -529,9 +541,9 @@ class SlicerTest < Test::Unit::TestCase
       TABLE
     end
 
-    test("!match_substring") do
+    test("!match_substring?") do
       sliced_table = @table.slice do |slicer|
-        !slicer.string.match_substring("arr")
+        !slicer.string.match_substring?("arr")
       end
       assert_equal(<<~TABLE, sliced_table.to_s)
 	string
@@ -541,21 +553,9 @@ class SlicerTest < Test::Unit::TestCase
       TABLE
     end
 
-    test("match_like") do
+    test("match_substring_regex?") do
       sliced_table = @table.slice do |slicer|
-        slicer.string.match_like("_rr%")
-      end
-      assert_equal(<<~TABLE, sliced_table.to_s)
-	string
-0	array 
-1	Arrow 
-2	(null)
-      TABLE
-    end
-
-    test("match_substring_regex") do
-      sliced_table = @table.slice do |slicer|
-        slicer.string.match_substring_regex("[dr]ow")
+        slicer.string.match_substring_regex?("[dr]ow")
       end
       assert_equal(<<~TABLE, sliced_table.to_s)
 	string

--- a/ruby/red-arrow/test/test-slicer.rb
+++ b/ruby/red-arrow/test/test-slicer.rb
@@ -567,7 +567,7 @@ class SlicerTest < Test::Unit::TestCase
 
     test("match_substring?(invalid_pattern)") do
       assert_raise(ArgumentError) do
-        sliced_table = @table.slice do |slicer|
+        @table.slice do |slicer|
           slicer.string.match_substring?(["arr"])
         end
       end

--- a/ruby/red-arrow/test/test-slicer.rb
+++ b/ruby/red-arrow/test/test-slicer.rb
@@ -565,7 +565,7 @@ class SlicerTest < Test::Unit::TestCase
       TABLE
     end
 
-    test("match_substring?(/String/i") do
+    test("match_substring?(/String/i)") do
       sliced_table = @table.slice do |slicer|
         slicer.string.match_substring?(/arr/i)
       end

--- a/ruby/red-arrow/test/test-slicer.rb
+++ b/ruby/red-arrow/test/test-slicer.rb
@@ -578,7 +578,7 @@ class SlicerTest < Test::Unit::TestCase
       TABLE
     end
 
-    test("match_substring?(invalid_pattern)") do
+    test("match_substring? - invalid") do
       message =
         'pattern must be either String or Regexp: ["arr"]'
       assert_raise(ArgumentError.new(message)) do

--- a/ruby/red-arrow/test/test-slicer.rb
+++ b/ruby/red-arrow/test/test-slicer.rb
@@ -492,6 +492,18 @@ class SlicerTest < Test::Unit::TestCase
       )
     end
 
+    test("ends_with") do
+      sliced_table = @table.slice do |slicer|
+        slicer.string.ends_with("ow")
+      end
+      assert_equal(<<~TABLE, sliced_table.to_s)
+	string
+0	Arrow 
+1	(null)
+2	window
+      TABLE
+    end
+
     test("match_substring") do
       sliced_table = @table.slice do |slicer|
         slicer.string.match_substring("arr")
@@ -526,6 +538,17 @@ class SlicerTest < Test::Unit::TestCase
 0	Arrow 
 1	(null)
 2	window
+      TABLE
+    end
+
+    test("starts_with") do
+      sliced_table = @table.slice do |slicer|
+        slicer.string.starts_with("ca")
+      end
+      assert_equal(<<~TABLE, sliced_table.to_s)
+	string
+0	carrot
+1	(null)
       TABLE
     end
   end

--- a/ruby/red-arrow/test/test-slicer.rb
+++ b/ruby/red-arrow/test/test-slicer.rb
@@ -553,6 +553,18 @@ class SlicerTest < Test::Unit::TestCase
       TABLE
     end
 
+    test("match_substring_regex") do
+      sliced_table = @table.slice do |slicer|
+        slicer.string.match_substring_regex("[dr]ow")
+      end
+      assert_equal(<<~TABLE, sliced_table.to_s)
+	string
+0	Arrow 
+1	(null)
+2	window
+      TABLE
+    end
+
     test("starts_with") do
       sliced_table = @table.slice do |slicer|
         slicer.string.starts_with("ca")

--- a/ruby/red-arrow/test/test-slicer.rb
+++ b/ruby/red-arrow/test/test-slicer.rb
@@ -553,6 +553,26 @@ class SlicerTest < Test::Unit::TestCase
       TABLE
     end
 
+    test("match_substring?(regexp)") do
+      sliced_table = @table.slice do |slicer|
+        slicer.string.match_substring?(/[dr]ow/)
+      end
+      assert_equal(<<~TABLE, sliced_table.to_s)
+	string
+0	Arrow 
+1	(null)
+2	window
+      TABLE
+    end
+
+    test("match_substring?(invalid_pattern)") do
+      assert_raise(ArgumentError) do
+        sliced_table = @table.slice do |slicer|
+          slicer.string.match_substring?(["arr"])
+        end
+      end
+    end  
+
     test("match_substring_regex?") do
       sliced_table = @table.slice do |slicer|
         slicer.string.match_substring_regex?("[dr]ow")

--- a/ruby/red-arrow/test/test-slicer.rb
+++ b/ruby/red-arrow/test/test-slicer.rb
@@ -565,6 +565,19 @@ class SlicerTest < Test::Unit::TestCase
       TABLE
     end
 
+    test("match_substring?(/String/i") do
+      sliced_table = @table.slice do |slicer|
+        slicer.string.match_substring?(/arr/i)
+      end
+      assert_equal(<<~TABLE, sliced_table.to_s)
+	string
+0	array 
+1	Arrow 
+2	carrot
+3	(null)
+      TABLE
+    end
+
     test("match_substring?(invalid_pattern)") do
       message =
         'pattern must be either String or Regexp: ["arr"]'

--- a/ruby/red-arrow/test/test-slicer.rb
+++ b/ruby/red-arrow/test/test-slicer.rb
@@ -566,7 +566,9 @@ class SlicerTest < Test::Unit::TestCase
     end
 
     test("match_substring?(invalid_pattern)") do
-      assert_raise(ArgumentError) do
+      message =
+        'pattern must be either String or Regexp: ["arr"]'
+      assert_raise(ArgumentError.new(message)) do
         @table.slice do |slicer|
           slicer.string.match_substring?(["arr"])
         end


### PR DESCRIPTION
### Rationale for this change

Ruby binding supported `Arrow::Slicer::ColumnCondition#match_substring` in #34902.
This PR will use same strategy as this to its family methods.

### What changes are included in this PR?

- [x] Add `Arrow::Slicer::ColumnCondition#end_with?`
  - Accepts substring as a `String`
- [x] Add `Arrow::Slicer::ColumnCondition#match_like?`
  - Accepts SQL like substring as a `String`
- [x] Renamed and updated `Arrow::Slicer::ColumnCondition#match_substring?`
  - Accepts substring as a `String`
  - Also accepts `Regexp` falling back to `#match_substring_regex?`
- [x] Add `Arrow::Slicer::ColumnCondition#start_with?`
  - Accepts substring as a `String`
### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
It will add new methods for `Arrow::Slicer`.

* Closes: #34951