### PR TITLE
GH-34953: [Ruby] Change null selection behavior in `Table.slice` to `:drop`

### DIFF
--- a/ruby/red-arrow/lib/arrow/table.rb
+++ b/ruby/red-arrow/lib/arrow/table.rb
@@ -316,8 +316,6 @@ module Arrow
         end
       end
 
-      filter_options = Arrow::FilterOptions.new
-      filter_options.null_selection_behavior = :emit_null
       sliced_tables = []
       slicers.each do |slicer|
         slicer = slicer.evaluate if slicer.respond_to?(:evaluate)
@@ -339,7 +337,7 @@ module Arrow
           to += n_rows if to < 0
           sliced_tables << slice_by_range(from, to)
         when ::Array, BooleanArray, ChunkedArray
-          sliced_tables << filter(slicer, filter_options)
+          sliced_tables << filter(slicer)
         else
           message = "slicer must be Integer, Range, (from, to), " +
             "Arrow::ChunkedArray of Arrow::BooleanArray, " +

--- a/ruby/red-arrow/test/test-slicer.rb
+++ b/ruby/red-arrow/test/test-slicer.rb
@@ -45,15 +45,11 @@ class SlicerTest < Test::Unit::TestCase
         slicer.visible
       end
       assert_equal(<<-TABLE, sliced_table.to_s)
-	 count	visible
-0	(null)	 (null)
-1	     1	true   
-2	(null)	 (null)
-3	     8	true   
-4	    16	true   
-5	(null)	 (null)
-6	(null)	 (null)
-7	   256	true   
+	count	visible
+0	    1	true   
+1	    8	true   
+2	   16	true   
+3	  256	true   
       TABLE
     end
 
@@ -62,16 +58,15 @@ class SlicerTest < Test::Unit::TestCase
         slicer.count
       end
       assert_equal(<<-TABLE, sliced_table.to_s)
-	 count	visible
-0	     1	true   
-1	     2	false  
-2	     4	 (null)
-3	     8	true   
-4	    16	true   
-5	    32	false  
-6	    64	 (null)
-7	(null)	 (null)
-8	   256	true   
+	count	visible
+0	    1	true   
+1	    2	false  
+2	    4	 (null)
+3	    8	true   
+4	   16	true   
+5	   32	false  
+6	   64	 (null)
+7	  256	true   
       TABLE
     end
   end
@@ -82,13 +77,9 @@ class SlicerTest < Test::Unit::TestCase
         !slicer.visible
       end
       assert_equal(<<-TABLE, sliced_table.to_s)
-	 count	visible
-0	(null)	 (null)
-1	     2	false  
-2	(null)	 (null)
-3	    32	false  
-4	(null)	 (null)
-5	(null)	 (null)
+	count	visible
+0	    2	false  
+1	   32	false  
       TABLE
     end
 
@@ -97,9 +88,8 @@ class SlicerTest < Test::Unit::TestCase
         !slicer.count
       end
       assert_equal(<<-TABLE, sliced_table.to_s)
-	 count	visible
-0	     0	 (null)
-1	(null)	 (null)
+	count	visible
+0	    0	 (null)
       TABLE
     end
   end
@@ -151,15 +141,11 @@ class SlicerTest < Test::Unit::TestCase
         slicer.visible == true
       end
       assert_equal(<<-TABLE, sliced_table.to_s)
-	 count	visible
-0	(null)	 (null)
-1	     1	true   
-2	(null)	 (null)
-3	     8	true   
-4	    16	true   
-5	(null)	 (null)
-6	(null)	 (null)
-7	   256	true   
+	count	visible
+0	    1	true   
+1	    8	true   
+2	   16	true   
+3	  256	true   
       TABLE
     end
   end
@@ -185,13 +171,9 @@ class SlicerTest < Test::Unit::TestCase
         !(slicer.visible == true)
       end
       assert_equal(<<-TABLE, sliced_table.to_s)
-	 count	visible
-0	(null)	 (null)
-1	     2	false  
-2	(null)	 (null)
-3	    32	false  
-4	(null)	 (null)
-5	(null)	 (null)
+	count	visible
+0	    2	false  
+1	   32	false  
       TABLE
     end
   end
@@ -217,13 +199,9 @@ class SlicerTest < Test::Unit::TestCase
         slicer.visible != true
       end
       assert_equal(<<-TABLE, sliced_table.to_s)
-	 count	visible
-0	(null)	 (null)
-1	     2	false  
-2	(null)	 (null)
-3	    32	false  
-4	(null)	 (null)
-5	(null)	 (null)
+	count	visible
+0	    2	false  
+1	   32	false  
       TABLE
     end
   end
@@ -233,13 +211,12 @@ class SlicerTest < Test::Unit::TestCase
       slicer.count < 16
     end
     assert_equal(<<-TABLE, sliced_table.to_s)
-	 count	visible
-0	     0	 (null)
-1	     1	true   
-2	     2	false  
-3	     4	 (null)
-4	     8	true   
-5	(null)	 (null)
+	count	visible
+0	    0	 (null)
+1	    1	true   
+2	    2	false  
+3	    4	 (null)
+4	    8	true   
     TABLE
   end
 
@@ -248,12 +225,11 @@ class SlicerTest < Test::Unit::TestCase
       !(slicer.count < 16)
     end
     assert_equal(<<-TABLE, sliced_table.to_s)
-	 count	visible
-0	    16	true   
-1	    32	false  
-2	    64	 (null)
-3	(null)	 (null)
-4	   256	true   
+	count	visible
+0	   16	true   
+1	   32	false  
+2	   64	 (null)
+3	  256	true   
     TABLE
   end
 
@@ -262,14 +238,13 @@ class SlicerTest < Test::Unit::TestCase
       slicer.count <= 16
     end
     assert_equal(<<-TABLE, sliced_table.to_s)
-	 count	visible
-0	     0	 (null)
-1	     1	true   
-2	     2	false  
-3	     4	 (null)
-4	     8	true   
-5	    16	true   
-6	(null)	 (null)
+	count	visible
+0	    0	 (null)
+1	    1	true   
+2	    2	false  
+3	    4	 (null)
+4	    8	true   
+5	   16	true   
     TABLE
   end
 
@@ -278,11 +253,10 @@ class SlicerTest < Test::Unit::TestCase
       !(slicer.count <= 16)
     end
     assert_equal(<<-TABLE, sliced_table.to_s)
-	 count	visible
-0	    32	false  
-1	    64	 (null)
-2	(null)	 (null)
-3	   256	true   
+	count	visible
+0	   32	false  
+1	   64	 (null)
+2	  256	true   
     TABLE
   end
 
@@ -291,11 +265,10 @@ class SlicerTest < Test::Unit::TestCase
       slicer.count > 16
     end
     assert_equal(<<-TABLE, sliced_table.to_s)
-	 count	visible
-0	    32	false  
-1	    64	 (null)
-2	(null)	 (null)
-3	   256	true   
+	count	visible
+0	   32	false  
+1	   64	 (null)
+2	  256	true   
     TABLE
   end
 
@@ -304,14 +277,13 @@ class SlicerTest < Test::Unit::TestCase
       !(slicer.count > 16)
     end
     assert_equal(<<-TABLE, sliced_table.to_s)
-	 count	visible
-0	     0	 (null)
-1	     1	true   
-2	     2	false  
-3	     4	 (null)
-4	     8	true   
-5	    16	true   
-6	(null)	 (null)
+	count	visible
+0	    0	 (null)
+1	    1	true   
+2	    2	false  
+3	    4	 (null)
+4	    8	true   
+5	   16	true   
     TABLE
   end
 
@@ -320,12 +292,11 @@ class SlicerTest < Test::Unit::TestCase
       slicer.count >= 16
     end
     assert_equal(<<-TABLE, sliced_table.to_s)
-	 count	visible
-0	    16	true   
-1	    32	false  
-2	    64	 (null)
-3	(null)	 (null)
-4	   256	true   
+	count	visible
+0	   16	true   
+1	   32	false  
+2	   64	 (null)
+3	  256	true   
     TABLE
   end
 
@@ -334,13 +305,12 @@ class SlicerTest < Test::Unit::TestCase
       !(slicer.count >= 16)
     end
     assert_equal(<<-TABLE, sliced_table.to_s)
-	 count	visible
-0	     0	 (null)
-1	     1	true   
-2	     2	false  
-3	     4	 (null)
-4	     8	true   
-5	(null)	 (null)
+	count	visible
+0	    0	 (null)
+1	    1	true   
+2	    2	false  
+3	    4	 (null)
+4	    8	true   
     TABLE
   end
 
@@ -377,13 +347,9 @@ class SlicerTest < Test::Unit::TestCase
       slicer.visible & (slicer.count >= 16)
     end
     assert_equal(<<-TABLE, sliced_table.to_s)
-	 count	visible
-0	(null)	 (null)
-1	(null)	 (null)
-2	    16	true   
-3	(null)	 (null)
-4	(null)	 (null)
-5	   256	true   
+	count	visible
+0	   16	true   
+1	  256	true   
     TABLE
   end
 
@@ -392,16 +358,12 @@ class SlicerTest < Test::Unit::TestCase
       slicer.visible | (slicer.count >= 16)
     end
     assert_equal(<<-TABLE, sliced_table.to_s)
-	 count	visible
-0	(null)	 (null)
-1	     1	true   
-2	(null)	 (null)
-3	     8	true   
-4	    16	true   
-5	    32	false  
-6	(null)	 (null)
-7	(null)	 (null)
-8	   256	true   
+	count	visible
+0	    1	true   
+1	    8	true   
+2	   16	true   
+3	   32	false  
+4	  256	true   
     TABLE
   end
 
@@ -410,14 +372,10 @@ class SlicerTest < Test::Unit::TestCase
       slicer.visible ^ (slicer.count >= 16)
     end
     assert_equal(<<-TABLE, sliced_table.to_s)
-	 count	visible
-0	(null)	 (null)
-1	     1	true   
-2	(null)	 (null)
-3	     8	true   
-4	    32	false  
-5	(null)	 (null)
-6	(null)	 (null)
+	count	visible
+0	    1	true   
+1	    8	true   
+2	   32	false  
     TABLE
   end
 
@@ -524,7 +482,6 @@ class SlicerTest < Test::Unit::TestCase
 	string
 0	array 
 1	carrot
-2	(null)
       TABLE
     end
 
@@ -537,7 +494,6 @@ class SlicerTest < Test::Unit::TestCase
 0	array 
 1	Arrow 
 2	carrot
-3	(null)
       TABLE
     end
 
@@ -548,8 +504,7 @@ class SlicerTest < Test::Unit::TestCase
       assert_equal(<<~TABLE, sliced_table.to_s)
 	string
 0	Arrow 
-1	(null)
-2	window
+1	window
       TABLE
     end
 

--- a/ruby/red-arrow/test/test-slicer.rb
+++ b/ruby/red-arrow/test/test-slicer.rb
@@ -457,8 +457,7 @@ class SlicerTest < Test::Unit::TestCase
       assert_equal(<<~TABLE, sliced_table.to_s)
 	string
 0	Arrow 
-1	(null)
-2	window
+1	window
       TABLE
     end
 
@@ -470,7 +469,6 @@ class SlicerTest < Test::Unit::TestCase
 	string
 0	array 
 1	Arrow 
-2	(null)
       TABLE
     end
 
@@ -515,8 +513,7 @@ class SlicerTest < Test::Unit::TestCase
       assert_equal(<<~TABLE, sliced_table.to_s)
 	string
 0	Arrow 
-1	(null)
-2	window
+1	window
       TABLE
     end
 
@@ -529,7 +526,6 @@ class SlicerTest < Test::Unit::TestCase
 0	array 
 1	Arrow 
 2	carrot
-3	(null)
       TABLE
     end
 
@@ -550,7 +546,6 @@ class SlicerTest < Test::Unit::TestCase
       assert_equal(<<~TABLE, sliced_table.to_s)
 	string
 0	carrot
-1	(null)
       TABLE
     end
   end

--- a/ruby/red-arrow/test/test-table.rb
+++ b/ruby/red-arrow/test/test-table.rb
@@ -87,26 +87,24 @@ class TableTest < Test::Unit::TestCase
       target_rows_raw = [nil, true, true, false, true, false, true, true]
       target_rows = Arrow::BooleanArray.new(target_rows_raw)
       assert_equal(<<-TABLE, @table.slice(target_rows).to_s)
-	 count	visible
-0	(null)	 (null)
-1	     2	false  
-2	     4	 (null)
-3	    16	true   
-4	    64	 (null)
-5	   128	 (null)
+	count	visible
+0	    2	false  
+1	    4	 (null)
+2	   16	true   
+3	   64	 (null)
+4	  128	 (null)
       TABLE
     end
 
     test("Array: boolean") do
       target_rows_raw = [nil, true, true, false, true, false, true, true]
       assert_equal(<<-TABLE, @table.slice(target_rows_raw).to_s)
-	 count	visible
-0	(null)	 (null)
-1	     2	false  
-2	     4	 (null)
-3	    16	true   
-4	    64	 (null)
-5	   128	 (null)
+	count	visible
+0	    2	false  
+1	    4	 (null)
+2	   16	true   
+3	   64	 (null)
+4	  128	 (null)
       TABLE
     end
 
@@ -198,24 +196,18 @@ class TableTest < Test::Unit::TestCase
 
     test("{key: true}") do
       assert_equal(<<-TABLE, @table.slice(visible: true).to_s)
-	 count	visible
-0	     1	true   
-1	(null)	 (null)
-2	     8	true   
-3	    16	true   
-4	(null)	 (null)
-5	(null)	 (null)
+	count	visible
+0	    1	true   
+1	    8	true   
+2	   16	true   
       TABLE
     end
 
     test("{key: false}") do
       assert_equal(<<-TABLE, @table.slice(visible: false).to_s)
-	 count	visible
-0	     2	false  
-1	(null)	 (null)
-2	    32	false  
-3	(null)	 (null)
-4	(null)	 (null)
+	count	visible
+0	    2	false  
+1	   32	false  
       TABLE
     end
 
@@ -286,11 +278,8 @@ class TableTest < Test::Unit::TestCase
 
     test("{key1: Range, key2: true}") do
       assert_equal(<<-TABLE, @table.slice(count: 0..8, visible: false).to_s)
-	 count	visible
-0	     2	false  
-1	(null)	 (null)
-2	(null)	 (null)
-3	(null)	 (null)
+	count	visible
+0	    2	false  
       TABLE
     end
 


### PR DESCRIPTION
### Rationale for this change

`Table.slice` behaves as `FilterOptions.null_selection_behavior = :emit_null` for backward compatibility.
But this is a differnt behavior from `Table#filter` and `Slicer::ColumnCondition#select` 
which use default option `:drop`.

This request will change the behavior of `Table#slice` to align with the default of `FilterOptions`.

### What changes are included in this PR?

Set `FilterOptions.null_selection_behavior` to the default value `:drop` from `:emit_null` .

### Are these changes tested?

Yes. Rebased after #34952.

### Are there any user-facing changes?

Yes.

**This PR includes breaking changes to public APIs.**

* Closes: #34953