### PR TITLE
GH-34956: [Docs][Python] Add to docs the usage of the FixedShapeTensorType

### DIFF
--- a/docs/source/python/extending_types.rst
+++ b/docs/source/python/extending_types.rst
@@ -428,7 +428,7 @@ Extension arrays can be used as columns in  ``pyarrow.Table`` or
    tensors_int: [[[1,2,3,4],[10,20,30,40],[100,200,300,400]]]
    tensors_float: [[[1,2,3,4],[10,20,30,40],[100,200,300,400]]]
 
-We can also convert a tensor array to a numpy ndarray:
+We can also convert a tensor array to a single multi-dimensional numpy ndarray:
 
 .. code-block:: python
 
@@ -449,8 +449,7 @@ We can also convert a tensor array to a numpy ndarray:
    The conversion to numpy ndarray is only possible for trivial permutations (``None`` or
    ``[0, 1, ... N-1]`` where ``N`` is the number of tensor dimensions).
 
-And also the other way around, we can convert a list of numpy ndarrays to a fixed shape tensor
-array:
+And also the other way around, we can convert a numpy ndarray to a fixed shape tensor array:
 
 .. code-block:: python
 

--- a/docs/source/python/extending_types.rst
+++ b/docs/source/python/extending_types.rst
@@ -435,11 +435,11 @@ We can also convert a tensor array to a numpy ndarray:
    >>> numpy_tensor = tensor_array_2.to_numpy_ndarray()
    >>> numpy_tensor
    array([[[  1.,   2.],
-         [  3.,   4.]],
-         [[ 10.,  20.],
-         [ 30.,  40.]],
-         [[100., 200.],
-         [300., 400.]]])
+           [  3.,   4.]],
+          [[ 10.,  20.],
+           [ 30.,  40.]],
+          [[100., 200.],
+           [300., 400.]]])
 
 .. note::
 
@@ -476,6 +476,23 @@ array:
        400
      ]
    ]
+
+With the conversion the first dimension of the ndarray becomes the length of the pyarrow extension
+array. We can see in the example that ndarray of shape ``(3, 2, 2)`` becomes an arrow array of
+length 3 with tensor elements of shape ``(2, 2)``.
+
+.. code-block:: python
+
+   # ndarray of shape (3, 2, 2)
+   >>> numpy_tensor.shape
+   (3, 2, 2)
+
+   # arrow array of length 3 with tensor elements of shape (2, 2)
+   >>> pyarrow_tensor_array = pa.FixedShapeTensorArray.from_numpy_ndarray(numpy_tensor)
+   >>> len(pyarrow_tensor_array)
+   3
+   >>> pyarrow_tensor_array.type.shape
+   [2, 2]
 
 The extension type can also have ``permutation`` and ``dim_names`` defined. For
 example

--- a/docs/source/python/extending_types.rst
+++ b/docs/source/python/extending_types.rst
@@ -388,9 +388,9 @@ Create another array of tensors with different value type:
 
 .. code-block:: python
 
-   >>> tensor_type2 = pa.fixed_shape_tensor(pa.float32(), (2, 2))
+   >>> tensor_type_2 = pa.fixed_shape_tensor(pa.float32(), (2, 2))
    >>> storage2 = pa.array(arr, pa.list_(pa.float32(), 4))
-   >>> tensor2 = pa.ExtensionArray.from_storage(tensor_type2, storage2)
+   >>> tensor_array_2 = pa.ExtensionArray.from_storage(tensor_type_2, storage2)
 
 Create a ``pyarrow.Table`` with random data and two tensor arrays:
 
@@ -400,14 +400,14 @@ Create a ``pyarrow.Table`` with random data and two tensor arrays:
    ...     pa.array([1, 2, 3]),
    ...     pa.array(['foo', 'bar', None]),
    ...     pa.array([True, None, True]),
-   ...     tensor,
-   ...     tensor2
+   ...     tensor_array,
+   ...     tensor_array_2
    ... ]
    >>> my_schema = pa.schema([('f0', pa.int8()),
    ...                        ('f1', pa.string()),
    ...                        ('f2', pa.bool_()),
    ...                        ('tensors_int', tensor_type),
-   ...                        ('tensors_float', tensor_type2)])
+   ...                        ('tensors_float', tensor_type_2)])
    >>> table = pa.Table.from_arrays(data, schema=my_schema)
    >>> table
    pyarrow.Table
@@ -427,7 +427,7 @@ Convert a tensor array to numpy ndarray (tensor):
 
 .. code-block:: python
 
-   >>> numpy_tensor = tensor2.to_numpy_ndarray()
+   >>> numpy_tensor = tensor_array_2.to_numpy_ndarray()
    >>> numpy_tensor
    array([[[  1.,   2.],
          [  3.,   4.]],

--- a/docs/source/python/extending_types.rst
+++ b/docs/source/python/extending_types.rst
@@ -463,76 +463,10 @@ Convert a list of numpy ndarrays (tensors) to a tensor array:
      ]
    ]
 
-Both optional parameters, ``permutation`` and ``dim_names`` are meant to provide the user
-with the information about the logical layout of the data compared to the physical layout
-and are **not used** when converting fixed shape tensor extension array to numpy ndarray.
-
-If the user needs to use the information of the optional parameters on numpy ndarrays,
-for example to revert the logical view to be equal to the physical view, one could do
-the following:
-
-.. code-block:: python
-
-   >>> tensor_type = pa.fixed_shape_tensor(pa.int32(), (2, 2), permutation=[1,0])
-   >>> arr = [[1, 2, 3, 4], [10, 20, 30, 40], [100, 200, 300, 400]]
-   >>> storage = pa.array(arr, pa.list_(pa.int32(), 4))
-   >>> tensor = pa.ExtensionArray.from_storage(tensor_type, storage)
-
-First you convert the tensor array to ndarray (``permutation`` is not used
-in the conversion):
-
-.. code-block:: python
-
-   >>> tensor.to_numpy_ndarray()
-   array([[[  1,   2],
-         [  3,   4]],
-         [[ 10,  20],
-         [ 30,  40]],
-         [[100, 200],
-         [300, 400]]], dtype=int32)
-
-Before using the permutation parameter to transpose the numpy ndarray we received,
-we first need to do some small recalculation.
-
-The dimension of the ndarray is one dimension higher as the first dimension is
-always the array of tensors. For that we need to increment the values of the
-permutation parameter and add the first dimension (dimension of the array of tensors):
-
 .. note::
 
-    The first dimension we are adding should always equal ``0`` due to the design of
-    the storage type of the extension, which is ``FixedSizeList`` and where the first
-    dimension is the array of individual tensors with given shape.
+   Both optional parameters, ``permutation`` and ``dim_names``, are meant to provide the user
+   with the information about the logical layout of the data compared to the physical layout.
 
-.. code-block:: python
-
-   >>> permutation = [x+1 for x in tensor.type.permutation]
-   >>> permutation
-   [2, 1]
-   >>> permutation.insert(0,0)
-   >>> permutation
-   [0, 2, 1]
-   >>> tensor.to_numpy_ndarray().transpose(permutation)
-   array([[[  1,   3],
-         [  2,   4]],
-         [[ 10,  30],
-         [ 20,  40]],
-         [[100, 300],
-         [200, 400]]], dtype=int32)
-
-In case we have a tensor array with ``dim_names`` parameter defined we can use
-permutation to change the logical layout. For example, if we have a tensor array
-with ``dim_names=['C', 'H', 'W']`` which is ``NCHW`` format where:
-
-* N: number of images which is in our case the length of an array
-* H: height of the image
-* W: width of the image
-* C: number of channels of the image
-
-and we want to transpose the numpy ndarray to use ``NHWC``format, we could use
-permutations as we have above. The permutation array would in this case be
-``[0, 2, 3, 1]`` where the first dimension will stay same, the second dimension
-will be the third dimension of the original layout (which is the second element in
-``dim_names``), the third dimension will be the forth dimension of the original
-layout (which is the third element in ``dim_names``) and the last dimension will
-be the second dimension of the original layout (first element of ``dim_names``).
+   The conversion to numpy ndarray is only possible for trivial permutations (``None`` or
+   ``[0, 1, ... N-1]`` where ``N`` is the number of tensor dimensions).

--- a/docs/source/python/extending_types.rst
+++ b/docs/source/python/extending_types.rst
@@ -428,7 +428,9 @@ Extension arrays can be used as columns in  ``pyarrow.Table`` or
    tensors_int: [[[1,2,3,4],[10,20,30,40],[100,200,300,400]]]
    tensors_float: [[[1,2,3,4],[10,20,30,40],[100,200,300,400]]]
 
-We can also convert a tensor array to a single multi-dimensional numpy ndarray:
+We can also convert a tensor array to a single multi-dimensional numpy ndarray.
+With the conversion the length of the arrow array becomes the first dimension
+in the numpy ndarray:
 
 .. code-block:: python
 
@@ -440,6 +442,8 @@ We can also convert a tensor array to a single multi-dimensional numpy ndarray:
            [ 30.,  40.]],
           [[100., 200.],
            [300., 400.]]])
+    >>> numpy_tensor.shape
+   (3, 2, 2)
 
 .. note::
 

--- a/docs/source/python/extending_types.rst
+++ b/docs/source/python/extending_types.rst
@@ -363,8 +363,8 @@ Canonical extension types
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In the :ref:`format_canonical_extensions` under the section **Official List**
-there is a list of canonical extension types. Here you can find an example of how
-to implement and how to use the listed canonical extension types.
+there is a list of canonical extension types. Here we list examples of how to
+use the listed canonical extension types.
 
 Fixed size tensor
 """""""""""""""""
@@ -382,7 +382,7 @@ extension type:
 
    >>> arr = [[1, 2, 3, 4], [10, 20, 30, 40], [100, 200, 300, 400]]
    >>> storage = pa.array(arr, pa.list_(pa.int32(), 4))
-   >>> tensor = pa.ExtensionArray.from_storage(tensor_type, storage)
+   >>> tensor_array = pa.ExtensionArray.from_storage(tensor_type, storage)
 
 Create another array of tensors with different value type:
 


### PR DESCRIPTION
### Rationale for this change

This PR adds examples of the use of `FixedShapeTensorType`to the PyArrow user guide. Should be reviewed and merged after https://github.com/apache/arrow/pull/34883 is done.
* Closes: #34956