### PR TITLE
GH-34944: [Python] Fix crash when converting non-sequence object with getitem in pa.array()

### DIFF
--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -1099,6 +1099,7 @@ Status ConvertToSequenceAndInferSize(PyObject* obj, PyObject** seq, int64_t* siz
   if (PySequence_Check(obj)) {
     // obj is already a sequence
     int64_t real_size = static_cast<int64_t>(PySequence_Size(obj));
+    RETURN_IF_PYERROR();
     if (*size < 0) {
       *size = real_size;
     } else {

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -133,6 +133,18 @@ def test_failing_iterator():
         pa.array((1 // 0 for x in range(10)), size=10)
 
 
+class ObjectWithOnlyGetitem:
+    def __getitem__(self, key):
+        return 3
+
+
+def test_object_with_getitem():
+    # https://github.com/apache/arrow/issues/34944
+    # considered as sequence because of __getitem__, but has no length
+    with pytest.raises(TypeError, match="has no len()"):
+        pa.array(ObjectWithOnlyGetitem())
+
+
 def _as_list(xs):
     return xs
 


### PR DESCRIPTION
### What changes are included in this PR?

Some python objects can pass the `PySequence_Check` without being "proper" sequences with a length, resulting in a subsequent `PySequence_Size` to fail, but we didn't check for python errors there, and so failed to properly raise this as a python exception.
* Closes: #34944