### PR TITLE
GH-34960: [C++] test util Fixing arrow Random Generator for lost nullable info

### DIFF
--- a/cpp/src/arrow/testing/random.cc
+++ b/cpp/src/arrow/testing/random.cc
@@ -916,11 +916,11 @@ std::shared_ptr<Array> RandomArrayGenerator::ArrayOf(const Field& field, int64_t
 
     case Type::type::STRUCT: {
       ArrayVector child_arrays(field.type()->num_fields());
-      FieldVector child_fields;
+      FieldVector child_fields(field.type()->num_fields());
       for (int i = 0; i < field.type()->num_fields(); i++) {
         const auto& child_field = field.type()->field(i);
         child_arrays[i] = ArrayOf(*child_field, length, alignment, memory_pool);
-        child_fields.push_back(child_field);
+        child_fields[i] = child_field;
       }
       return *StructArray::Make(
           child_arrays, child_fields,

--- a/cpp/src/arrow/testing/random.cc
+++ b/cpp/src/arrow/testing/random.cc
@@ -793,7 +793,7 @@ std::shared_ptr<Array> RandomArrayGenerator::ArrayOf(const Field& field, int64_t
                 values_length, alignment, memory_pool);                              \
     const auto offsets = OffsetsFromLengthsArray(lengths.get(), force_empty_nulls,   \
                                                  alignment, memory_pool);            \
-    return *ARRAY_TYPE::FromArrays(*offsets, *values);                               \
+    return *ARRAY_TYPE::FromArrays(field.type(), *offsets, *values);                 \
   }
 
   const double null_probability =
@@ -916,14 +916,14 @@ std::shared_ptr<Array> RandomArrayGenerator::ArrayOf(const Field& field, int64_t
 
     case Type::type::STRUCT: {
       ArrayVector child_arrays(field.type()->num_fields());
-      std::vector<std::string> field_names;
+      FieldVector child_fields;
       for (int i = 0; i < field.type()->num_fields(); i++) {
         const auto& child_field = field.type()->field(i);
         child_arrays[i] = ArrayOf(*child_field, length, alignment, memory_pool);
-        field_names.push_back(child_field->name());
+        child_fields.push_back(child_field);
       }
       return *StructArray::Make(
-          child_arrays, field_names,
+          child_arrays, child_fields,
           NullBitmap(length, null_probability, alignment, memory_pool));
     }
 

--- a/cpp/src/arrow/testing/random_test.cc
+++ b/cpp/src/arrow/testing/random_test.cc
@@ -499,43 +499,44 @@ TEST(RandomList, Basics) {
   }
 }
 
-TEST(RandomNestedBatchOf, Basics) {
+TEST(RandomChildFieldNullablity, List) {
   random::RandomArrayGenerator rng(42);
-  {
-    auto item = std::make_shared<arrow::Field>("item", arrow::int8(), true);
-    auto nestListField = std::make_shared<arrow::Field>("list", arrow::list(item), false);
-    auto listField =
-        std::make_shared<arrow::Field>("list", arrow::list(nestListField), true);
-    auto array = rng.ArrayOf(*listField, 428);
-    ARROW_EXPECT_OK(array->ValidateFull());
 
-    auto batch = rng.BatchOf({listField}, 428);
-    ARROW_EXPECT_OK(batch->ValidateFull());
-  }
-  {
-    auto item = std::make_shared<arrow::Field>("item", arrow::int8(), true);
-    auto nestStructField =
-        std::make_shared<arrow::Field>("struct", arrow::struct_({item}), false);
-    auto structField =
-        std::make_shared<arrow::Field>("struct", arrow::struct_({nestStructField}), true);
-    auto array = rng.ArrayOf(*structField, 428);
-    ARROW_EXPECT_OK(array->ValidateFull());
+  auto item = arrow::field("item", arrow::int8(), true);
+  auto nest_list_field = arrow::field("list", arrow::list(item), false);
+  auto list_field = arrow::field("list", arrow::list(nest_list_field), true);
+  auto array = rng.ArrayOf(*list_field, 428);
+  ARROW_EXPECT_OK(array->ValidateFull());
 
-    auto batch = rng.BatchOf({structField}, 428);
-    ARROW_EXPECT_OK(batch->ValidateFull());
-  }
-  {
-    auto item = std::make_shared<arrow::Field>("item", arrow::int8(), true);
-    auto nestMapField = std::make_shared<arrow::Field>(
-        "map", arrow::map(arrow::int8(), item, false), false);
-    auto mapField = std::make_shared<arrow::Field>(
-        "struct", arrow::map(arrow::int8(), nestMapField, false), true);
-    auto array = rng.ArrayOf(*mapField, 428);
-    ARROW_EXPECT_OK(array->ValidateFull());
+  auto batch = rng.BatchOf({list_field}, 428);
+  ARROW_EXPECT_OK(batch->ValidateFull());
+}
 
-    auto batch = rng.BatchOf({mapField}, 428);
-    ARROW_EXPECT_OK(batch->ValidateFull());
-  }
+TEST(RandomChildFieldNullablity, Struct) {
+  random::RandomArrayGenerator rng(42);
+
+  auto item = arrow::field("item", arrow::int8(), true);
+  auto nest_struct_field = arrow::field("struct", arrow::struct_({item}), false);
+  auto struct_field = arrow::field("struct", arrow::struct_({nest_struct_field}), true);
+  auto array = rng.ArrayOf(*struct_field, 428);
+  ARROW_EXPECT_OK(array->ValidateFull());
+
+  auto batch = rng.BatchOf({struct_field}, 428);
+  ARROW_EXPECT_OK(batch->ValidateFull());
+}
+
+TEST(RandomChildFieldNullablity, Map) {
+  random::RandomArrayGenerator rng(42);
+  auto item = arrow::field("item", arrow::int8(), true);
+  auto nest_map_field =
+      arrow::field("map", arrow::map(arrow::int8(), item, false), false);
+  auto map_field =
+      arrow::field("struct", arrow::map(arrow::int8(), nest_map_field, false), true);
+  auto array = rng.ArrayOf(*map_field, 428);
+  ARROW_EXPECT_OK(array->ValidateFull());
+
+  auto batch = rng.BatchOf({map_field}, 428);
+  ARROW_EXPECT_OK(batch->ValidateFull());
 }
 
 TEST(RandomRunEndEncoded, Basics) {

--- a/cpp/src/arrow/testing/random_test.cc
+++ b/cpp/src/arrow/testing/random_test.cc
@@ -499,6 +499,45 @@ TEST(RandomList, Basics) {
   }
 }
 
+TEST(RandomNestedBatchOf, Basics) {
+  random::RandomArrayGenerator rng(42);
+  {
+    auto item = std::make_shared<arrow::Field>("item", arrow::int8(), true);
+    auto nestListField = std::make_shared<arrow::Field>("list", arrow::list(item), false);
+    auto listField =
+        std::make_shared<arrow::Field>("list", arrow::list(nestListField), true);
+    auto array = rng.ArrayOf(*listField, 428);
+    ARROW_EXPECT_OK(array->ValidateFull());
+
+    auto batch = rng.BatchOf({listField}, 428);
+    ARROW_EXPECT_OK(batch->ValidateFull());
+  }
+  {
+    auto item = std::make_shared<arrow::Field>("item", arrow::int8(), true);
+    auto nestStructField =
+        std::make_shared<arrow::Field>("struct", arrow::struct_({item}), false);
+    auto structField =
+        std::make_shared<arrow::Field>("struct", arrow::struct_({nestStructField}), true);
+    auto array = rng.ArrayOf(*structField, 428);
+    ARROW_EXPECT_OK(array->ValidateFull());
+
+    auto batch = rng.BatchOf({structField}, 428);
+    ARROW_EXPECT_OK(batch->ValidateFull());
+  }
+  {
+    auto item = std::make_shared<arrow::Field>("item", arrow::int8(), true);
+    auto nestMapField = std::make_shared<arrow::Field>(
+        "map", arrow::map(arrow::int8(), item, false), false);
+    auto mapField = std::make_shared<arrow::Field>(
+        "struct", arrow::map(arrow::int8(), nestMapField, false), true);
+    auto array = rng.ArrayOf(*mapField, 428);
+    ARROW_EXPECT_OK(array->ValidateFull());
+
+    auto batch = rng.BatchOf({mapField}, 428);
+    ARROW_EXPECT_OK(batch->ValidateFull());
+  }
+}
+
 TEST(RandomRunEndEncoded, Basics) {
   random::RandomArrayGenerator rng(42);
   for (const double null_probability : {0.0, 0.1, 1.0}) {


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Currently, nonnull in nested schema will be losted by random generator. This patch make it not lost.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Using ctor with DataType to deduce the field type.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #34960