### PR TITLE
GH-34968: [C++] Add Equal Options to RecordBatch

### DIFF
--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -232,7 +232,8 @@ const std::string& RecordBatch::column_name(int i) const {
   return schema_->field(i)->name();
 }
 
-bool RecordBatch::Equals(const RecordBatch& other, bool check_metadata) const {
+bool RecordBatch::Equals(const RecordBatch& other, bool check_metadata,
+                         const EqualOptions& opts) const {
   if (num_columns() != other.num_columns() || num_rows_ != other.num_rows()) {
     return false;
   }
@@ -242,7 +243,7 @@ bool RecordBatch::Equals(const RecordBatch& other, bool check_metadata) const {
   }
 
   for (int i = 0; i < num_columns(); ++i) {
-    if (!column(i)->Equals(other.column(i))) {
+    if (!column(i)->Equals(other.column(i), opts)) {
       return false;
     }
   }
@@ -250,13 +251,13 @@ bool RecordBatch::Equals(const RecordBatch& other, bool check_metadata) const {
   return true;
 }
 
-bool RecordBatch::ApproxEquals(const RecordBatch& other) const {
+bool RecordBatch::ApproxEquals(const RecordBatch& other, const EqualOptions& opts) const {
   if (num_columns() != other.num_columns() || num_rows_ != other.num_rows()) {
     return false;
   }
 
   for (int i = 0; i < num_columns(); ++i) {
-    if (!column(i)->ApproxEquals(other.column(i))) {
+    if (!column(i)->ApproxEquals(other.column(i), opts)) {
       return false;
     }
   }

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -104,6 +104,8 @@ class ARROW_EXPORT RecordBatch {
               const EqualOptions& opts = EqualOptions::Defaults()) const;
 
   /// \brief Determine if two record batches are approximately equal
+  ///
+  /// \param[in] other the RecordBatch to compare with
   /// \param[in] opts the options for equality comparisons
   bool ApproxEquals(const RecordBatch& other,
                     const EqualOptions& opts = EqualOptions::Defaults()) const;

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -107,6 +107,7 @@ class ARROW_EXPORT RecordBatch {
   ///
   /// \param[in] other the RecordBatch to compare with
   /// \param[in] opts the options for equality comparisons
+  /// \return true if batches are equal
   bool ApproxEquals(const RecordBatch& other,
                     const EqualOptions& opts = EqualOptions::Defaults()) const;
 

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <vector>
 
+#include "arrow/compare.h"
 #include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/type_fwd.h"
@@ -97,11 +98,15 @@ class ARROW_EXPORT RecordBatch {
   ///
   /// \param[in] other the RecordBatch to compare with
   /// \param[in] check_metadata if true, check that Schema metadata is the same
+  /// \param[in] opts the options for equality comparisons
   /// \return true if batches are equal
-  bool Equals(const RecordBatch& other, bool check_metadata = false) const;
+  bool Equals(const RecordBatch& other, bool check_metadata = false,
+              const EqualOptions& opts = EqualOptions::Defaults()) const;
 
   /// \brief Determine if two record batches are approximately equal
-  bool ApproxEquals(const RecordBatch& other) const;
+  /// \param[in] opts the options for equality comparisons
+  bool ApproxEquals(const RecordBatch& other,
+                    const EqualOptions& opts = EqualOptions::Defaults()) const;
 
   /// \return the record batch's schema
   const std::shared_ptr<Schema>& schema() const { return schema_; }

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -107,7 +107,7 @@ class ARROW_EXPORT RecordBatch {
   ///
   /// \param[in] other the RecordBatch to compare with
   /// \param[in] opts the options for equality comparisons
-  /// \return true if batches are equal
+  /// \return true if batches are approximately equal
   bool ApproxEquals(const RecordBatch& other,
                     const EqualOptions& opts = EqualOptions::Defaults()) const;
 

--- a/cpp/src/arrow/record_batch_test.cc
+++ b/cpp/src/arrow/record_batch_test.cc
@@ -82,11 +82,9 @@ TEST_F(TestRecordBatch, Equals) {
   ASSERT_FALSE(b1->Equals(*b2, /*check_metadata=*/true));
 }
 
-TEST_F(TestRecordBatch, EqualsOptions) {
+TEST_F(TestRecordBatch, EqualOptions) {
   int length = 2;
   auto f = field("f", float64());
-
-  auto metadata = key_value_metadata({"foo"}, {"bar"});
 
   std::vector<std::shared_ptr<Field>> fields = {f};
   auto schema = ::arrow::schema(fields);
@@ -97,15 +95,15 @@ TEST_F(TestRecordBatch, EqualsOptions) {
   auto b1 = RecordBatch::Make(schema, length, {array1});
   auto b2 = RecordBatch::Make(schema, length, {array2});
 
-  EXPECT_FALSE(b1->Equals(*b2, false, EqualOptions::Defaults().nans_equal(false)));
-  EXPECT_TRUE(b1->Equals(*b2, false, EqualOptions::Defaults().nans_equal(true)));
+  EXPECT_FALSE(b1->Equals(*b2, /*check_metadata=*/false,
+                          EqualOptions::Defaults().nans_equal(false)));
+  EXPECT_TRUE(b1->Equals(*b2, /*check_metadata=*/false,
+                         EqualOptions::Defaults().nans_equal(true)));
 }
 
-TEST_F(TestRecordBatch, ApproxEqualsOptions) {
+TEST_F(TestRecordBatch, ApproxEqualOptions) {
   int length = 2;
   auto f = field("f", float64());
-
-  auto metadata = key_value_metadata({"foo"}, {"bar"});
 
   std::vector<std::shared_ptr<Field>> fields = {f};
   auto schema = ::arrow::schema(fields);

--- a/cpp/src/arrow/record_batch_test.cc
+++ b/cpp/src/arrow/record_batch_test.cc
@@ -90,30 +90,36 @@ TEST_F(TestRecordBatch, EqualsOptions) {
 
   std::vector<std::shared_ptr<Field>> fields = {f};
   auto schema = ::arrow::schema(fields);
-  {
-    std::shared_ptr<Array> array1, array2;
-    ArrayFromVector<FloatType>(float32(), {true, true}, {0.5, NAN}, &array1);
-    ArrayFromVector<FloatType>(float32(), {true, true}, {0.5, NAN}, &array2);
-    auto b1 = RecordBatch::Make(schema, length, {array1});
-    auto b2 = RecordBatch::Make(schema, length, {array2});
 
-    EXPECT_FALSE(b1->Equals(*b2, false, EqualOptions::Defaults().nans_equal(false)));
-    EXPECT_TRUE(b1->Equals(*b2, false, EqualOptions::Defaults().nans_equal(true)));
-  }
-  {
-    std::shared_ptr<Array> array1, array2;
-    ArrayFromVector<FloatType>(float32(), {true, true}, {0.5, NAN}, &array1);
-    ArrayFromVector<FloatType>(float32(), {true, true}, {0.501, NAN}, &array2);
+  std::shared_ptr<Array> array1, array2;
+  ArrayFromVector<FloatType>(float32(), {true, true}, {0.5, NAN}, &array1);
+  ArrayFromVector<FloatType>(float32(), {true, true}, {0.5, NAN}, &array2);
+  auto b1 = RecordBatch::Make(schema, length, {array1});
+  auto b2 = RecordBatch::Make(schema, length, {array2});
 
-    auto b1 = RecordBatch::Make(schema, length, {array1});
-    auto b2 = RecordBatch::Make(schema, length, {array2});
+  EXPECT_FALSE(b1->Equals(*b2, false, EqualOptions::Defaults().nans_equal(false)));
+  EXPECT_TRUE(b1->Equals(*b2, false, EqualOptions::Defaults().nans_equal(true)));
+}
 
-    EXPECT_FALSE(b1->ApproxEquals(*b2, EqualOptions::Defaults().nans_equal(false)));
-    EXPECT_FALSE(b1->ApproxEquals(*b2, EqualOptions::Defaults().nans_equal(true)));
+TEST_F(TestRecordBatch, ApproxEqualsOptions) {
+  int length = 2;
+  auto f = field("f", float32());
 
-    EXPECT_TRUE(
-        b1->ApproxEquals(*b2, EqualOptions::Defaults().nans_equal(true).atol(0.1)));
-  }
+  auto metadata = key_value_metadata({"foo"}, {"bar"});
+
+  std::vector<std::shared_ptr<Field>> fields = {f};
+  auto schema = ::arrow::schema(fields);
+  std::shared_ptr<Array> array1, array2;
+  ArrayFromVector<FloatType>(float32(), {true, true}, {0.5, NAN}, &array1);
+  ArrayFromVector<FloatType>(float32(), {true, true}, {0.501, NAN}, &array2);
+
+  auto b1 = RecordBatch::Make(schema, length, {array1});
+  auto b2 = RecordBatch::Make(schema, length, {array2});
+
+  EXPECT_FALSE(b1->ApproxEquals(*b2, EqualOptions::Defaults().nans_equal(false)));
+  EXPECT_FALSE(b1->ApproxEquals(*b2, EqualOptions::Defaults().nans_equal(true)));
+
+  EXPECT_TRUE(b1->ApproxEquals(*b2, EqualOptions::Defaults().nans_equal(true).atol(0.1)));
 }
 
 TEST_F(TestRecordBatch, Validate) {

--- a/cpp/src/arrow/record_batch_test.cc
+++ b/cpp/src/arrow/record_batch_test.cc
@@ -84,7 +84,7 @@ TEST_F(TestRecordBatch, Equals) {
 
 TEST_F(TestRecordBatch, EqualsOptions) {
   int length = 2;
-  auto f = field("f", float32());
+  auto f = field("f", float64());
 
   auto metadata = key_value_metadata({"foo"}, {"bar"});
 
@@ -92,8 +92,8 @@ TEST_F(TestRecordBatch, EqualsOptions) {
   auto schema = ::arrow::schema(fields);
 
   std::shared_ptr<Array> array1, array2;
-  ArrayFromVector<FloatType>(float32(), {true, true}, {0.5, NAN}, &array1);
-  ArrayFromVector<FloatType>(float32(), {true, true}, {0.5, NAN}, &array2);
+  ArrayFromVector<DoubleType>(float64(), {true, true}, {0.5, NAN}, &array1);
+  ArrayFromVector<DoubleType>(float64(), {true, true}, {0.5, NAN}, &array2);
   auto b1 = RecordBatch::Make(schema, length, {array1});
   auto b2 = RecordBatch::Make(schema, length, {array2});
 
@@ -103,15 +103,15 @@ TEST_F(TestRecordBatch, EqualsOptions) {
 
 TEST_F(TestRecordBatch, ApproxEqualsOptions) {
   int length = 2;
-  auto f = field("f", float32());
+  auto f = field("f", float64());
 
   auto metadata = key_value_metadata({"foo"}, {"bar"});
 
   std::vector<std::shared_ptr<Field>> fields = {f};
   auto schema = ::arrow::schema(fields);
   std::shared_ptr<Array> array1, array2;
-  ArrayFromVector<FloatType>(float32(), {true, true}, {0.5, NAN}, &array1);
-  ArrayFromVector<FloatType>(float32(), {true, true}, {0.501, NAN}, &array2);
+  ArrayFromVector<DoubleType>(float64(), {true, true}, {0.5, NAN}, &array1);
+  ArrayFromVector<DoubleType>(float64(), {true, true}, {0.501, NAN}, &array2);
 
   auto b1 = RecordBatch::Make(schema, length, {array1});
   auto b2 = RecordBatch::Make(schema, length, {array2});


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Currently, directly comparing Array supports EqualOptions, which support nan comparing mode and others. However, array doesn't support passing argument like that. So, it can only use default EqualOptions

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add EqualOptions 

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

currently not

### Are there any user-facing changes?

User can call EqualOptions in RecordBatch

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #34968