### PR TITLE
GH-34973: [CI][Packaging] Fix script path in wheel-clean

### DIFF
--- a/dev/tasks/python-wheels/github.clean.yml
+++ b/dev/tasks/python-wheels/github.clean.yml
@@ -32,4 +32,4 @@ jobs:
         shell: bash
         run: |
           gem install --user-install gemfury
-          ruby ./ci/scripts/gemfury_clean.rb
+          ruby arrow/ci/scripts/gemfury_clean.rb


### PR DESCRIPTION
### Rationale for this change

> https://github.com/ursacomputing/crossbow/actions/runs/4587784310/jobs/8101540480
>
> ```text
> ruby: No such file or directory -- ./ci/scripts/gemfury_clean.rb (LoadError)
> ```

### What changes are included in this PR?

Fix the path.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #34973