### PR TITLE
GH-34565: [C++] Teach dataset_writer to accept custom filename functor

### DIFF
--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -404,6 +404,12 @@ struct ARROW_DS_EXPORT FileSystemDatasetWriteOptions {
   /// {i} will be replaced by an auto incremented integer.
   std::string basename_template;
 
+  /// A functor which will be applied on an incremented counter.  The result will be
+  /// inserted into the basename_template in place of {i}.
+  ///
+  /// This can be used, for example, to left-pad the file counter.
+  std::function<std::string(int)> basename_template_functor;
+
   /// If greater than 0 then this will limit the maximum number of files that can be left
   /// open. If an attempt is made to open too many files then the least recently used file
   /// will be closed.  If this setting is set too low you may end up fragmenting your data


### PR DESCRIPTION
### Rationale for this change

Existing basename_template will only use a monotonically increasing int as new filenames. when there is needs for custom filenames(left padding, hash-code), downstream users must rename the files in a post-processing step.

### What changes are included in this PR?

A new functor is added to FileSystemDatasetWriteOptions which allows users to provide a custom name for dataset_writer.

### Are these changes tested?

Yes. Unit tests are added for normal and ill-formed lambdas.

### Are there any user-facing changes?

Yes. It allows users to customize output file names.
* Closes: #34565