### PR TITLE
GH-21430: [GLib] GArrowSparseUnionArrayBuilder

### DIFF
--- a/c_glib/arrow-glib/array-builder.h
+++ b/c_glib/arrow-glib/array-builder.h
@@ -1581,7 +1581,26 @@ struct _GArrowDenseUnionArrayBuilderClass
 
 GARROW_AVAILABLE_IN_12_0
 GArrowDenseUnionArrayBuilder *
-garrow_dense_union_array_builder_new(void);
+garrow_dense_union_array_builder_new(GArrowDenseUnionDataType *data_type,
+                                     GError **error);
+
+
+#define GARROW_TYPE_SPARSE_UNION_ARRAY_BUILDER   \
+  (garrow_sparse_union_array_builder_get_type())
+G_DECLARE_DERIVABLE_TYPE(GArrowSparseUnionArrayBuilder,
+                         garrow_sparse_union_array_builder,
+                         GARROW,
+                         SPARSE_UNION_ARRAY_BUILDER,
+                         GArrowUnionArrayBuilder)
+struct _GArrowSparseUnionArrayBuilderClass
+{
+  GArrowUnionArrayBuilderClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_12_0
+GArrowSparseUnionArrayBuilder *
+garrow_sparse_union_array_builder_new(GArrowSparseUnionDataType *data_type,
+                                      GError **error);
 
 
 G_END_DECLS

--- a/c_glib/test/test-dense-union-array-builder.rb
+++ b/c_glib/test/test-dense-union-array-builder.rb
@@ -22,10 +22,68 @@ class TestDenseUnionArrayBuilder < Test::Unit::TestCase
     @builder = Arrow::DenseUnionArrayBuilder.new
   end
 
-  def create_dense_union_array(type_ids, value_offsets, fields)
-    Arrow::DenseUnionArray.new(build_int8_array(type_ids),
-                               build_int32_array(value_offsets),
-                               fields)
+  def create_dense_union_array(type_ids,
+                               value_offsets,
+                               fields,
+                               data_type: nil)
+    args = [
+      build_int8_array(type_ids),
+      build_int32_array(value_offsets),
+      fields,
+    ]
+    args.unshift(data_type) if data_type
+    Arrow::DenseUnionArray.new(*args)
+  end
+
+  def test_new_data_type
+    number_field_data_type = Arrow::Int32DataType.new
+    text_field_data_type = Arrow::StringDataType.new
+    number_field = Arrow::Field.new("number", number_field_data_type)
+    text_field = Arrow::Field.new("text", text_field_data_type)
+    fields = [
+      number_field,
+      text_field,
+    ]
+    number_field_type_id = 2
+    text_field_type_id = 9
+    type_ids = [
+      number_field_type_id,
+      text_field_type_id,
+    ]
+    data_type = Arrow::DenseUnionDataType.new(fields, type_ids)
+
+    builder = Arrow::DenseUnionArrayBuilder.new(data_type)
+    number_builder = builder.get_child(0)
+    text_builder = builder.get_child(1)
+
+    expected_type_ids = []
+    expected_value_offsets = []
+    expected_number_values = []
+    expected_text_values = []
+
+    builder.append_value(2)
+    number_builder.append_value(1)
+    # expected
+    expected_type_ids << number_field_type_id
+    expected_value_offsets << expected_number_values.size
+    expected_number_values << 1
+
+    builder.append_value(text_field_type_id)
+    text_builder.append_value("a")
+    # expected
+    expected_type_ids << text_field_type_id
+    expected_value_offsets << expected_text_values.size
+    expected_text_values << "a"
+
+    expected_fields = [
+      build_int32_array(expected_number_values),
+      build_string_array(expected_text_values),
+    ]
+    assert_equal(create_dense_union_array(expected_type_ids,
+                                          expected_value_offsets,
+                                          expected_fields,
+                                          data_type: data_type),
+                 builder.finish)
   end
 
   def test_append_null

--- a/ruby/red-arrow/lib/arrow/loader.rb
+++ b/ruby/red-arrow/lib/arrow/loader.rb
@@ -112,6 +112,7 @@ module Arrow
       require "arrow/sort-options"
       require "arrow/source-node-options"
       require "arrow/sparse-union-array"
+      require "arrow/sparse-union-array-builder"
       require "arrow/sparse-union-data-type"
       require "arrow/string-dictionary-array-builder"
       require "arrow/string-array-builder"
@@ -137,6 +138,7 @@ module Arrow
       require "arrow/timestamp-array"
       require "arrow/timestamp-array-builder"
       require "arrow/timestamp-data-type"
+      require "arrow/union-array-builder"
       require "arrow/writable"
     end
 

--- a/ruby/red-arrow/lib/arrow/sparse-union-array-builder.rb
+++ b/ruby/red-arrow/lib/arrow/sparse-union-array-builder.rb
@@ -16,7 +16,7 @@
 # under the License.
 
 module Arrow
-  class DenseUnionArrayBuilder
+  class SparseUnionArrayBuilder
     alias_method :append_value_raw, :append_value
 
     # @overload append_value
@@ -42,7 +42,14 @@ module Arrow
         key = value.keys[0]
         child_info = child_infos[key]
         append_value_raw(child_info[:id])
-        child_info[:builder].append(value.values[0])
+        child_infos.each do |child_key, child_info|
+          builder = child_info[:builder]
+          if child_key == key
+            builder.append(value.values[0])
+          else
+            builder.append_null
+          end
+        end
       end
     end
   end

--- a/ruby/red-arrow/lib/arrow/union-array-builder.rb
+++ b/ruby/red-arrow/lib/arrow/union-array-builder.rb
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module Arrow
+  class UnionArrayBuilder
+    def append_values(values, is_valids=nil)
+      if is_valids
+        is_valids.each_with_index do |is_valid, i|
+          if is_valid
+            append_value(values[i])
+          else
+            append_null
+          end
+        end
+      else
+        values.each do |value|
+          append_value(value)
+        end
+      end
+    end
+
+    alias_method :append_child_raw, :append_child
+    def append_child(builder, filed_name=nil)
+      @child_infos = nil
+      append_child_raw(builder, field_name)
+    end
+
+    private
+    def child_infos
+      @child_infos ||= create_child_infos
+    end
+
+    def create_child_infos
+      infos = {}
+      type = value_data_type
+      type.fields.zip(children, type.type_codes).each do |field, child, id|
+        infos[field.name] = {
+          builder: child,
+          id: id,
+        }
+      end
+      infos
+    end
+  end
+end

--- a/ruby/red-arrow/test/raw-records/test-dense-union-array.rb
+++ b/ruby/red-arrow/test/raw-records/test-dense-union-array.rb
@@ -480,10 +480,10 @@ module RawRecordsDenseUnionArrayTests
   end
 
   def test_sparse_union
-    omit("Need to add support for SparseUnionArrayBuilder")
     records = [
       [{"0" => {"field1" => true}}],
       [{"1" => nil}],
+      [{"0" => {"field2" => 29}}],
       [{"0" => {"field2" => nil}}],
     ]
     target = build({
@@ -509,6 +509,7 @@ module RawRecordsDenseUnionArrayTests
     records = [
       [{"0" => {"field1" => true}}],
       [{"1" => nil}],
+      [{"0" => {"field2" => 29}}],
       [{"0" => {"field2" => nil}}],
     ]
     target = build({

--- a/ruby/red-arrow/test/raw-records/test-list-array.rb
+++ b/ruby/red-arrow/test/raw-records/test-list-array.rb
@@ -528,7 +528,6 @@ module RawRecordsListArrayTests
   end
 
   def test_sparse_union
-    omit("Need to add support for SparseUnionArrayBuilder")
     records = [
       [
         [

--- a/ruby/red-arrow/test/raw-records/test-map-array.rb
+++ b/ruby/red-arrow/test/raw-records/test-map-array.rb
@@ -413,7 +413,6 @@ module RawRecordsMapArrayTests
   end
 
   def test_sparse_union
-    omit("Need to add support for SparseUnionArrayBuilder")
     records = [
       [
         {

--- a/ruby/red-arrow/test/raw-records/test-sparse-union-array.rb
+++ b/ruby/red-arrow/test/raw-records/test-sparse-union-array.rb
@@ -470,10 +470,10 @@ module RawRecordsSparseUnionArrayTests
   end
 
   def test_sparse_union
-    omit("Need to add support for SparseUnionArrayBuilder")
     records = [
       [{"0" => {"field1" => true}}],
       [{"1" => nil}],
+      [{"0" => {"field2" => 29}}],
       [{"0" => {"field2" => nil}}],
     ]
     target = build({
@@ -499,6 +499,7 @@ module RawRecordsSparseUnionArrayTests
     records = [
       [{"0" => {"field1" => true}}],
       [{"1" => nil}],
+      [{"0" => {"field2" => 29}}],
       [{"0" => {"field2" => nil}}],
     ]
     target = build({

--- a/ruby/red-arrow/test/raw-records/test-struct-array.rb
+++ b/ruby/red-arrow/test/raw-records/test-struct-array.rb
@@ -441,7 +441,6 @@ module RawRecordsStructArrayTests
   end
 
   def test_sparse_union
-    omit("Need to add support for SparseUnionArrayBuilder")
     records = [
       [{"field" => {"field1" => true}}],
       [nil],
@@ -464,7 +463,7 @@ module RawRecordsStructArrayTests
                      type_codes: [0, 1],
                    },
                    records)
-    assert_equal(remove_union_fields(records),
+    assert_equal(remove_union_field_names(records),
                  target.raw_records)
   end
 

--- a/ruby/red-arrow/test/values/test-dense-union-array.rb
+++ b/ruby/red-arrow/test/values/test-dense-union-array.rb
@@ -466,7 +466,6 @@ module ValuesDenseUnionArrayTests
   end
 
   def test_sparse_union
-    omit("Need to add support for SparseUnionArrayBuilder")
     values = [
       {"0" => {"field1" => true}},
       {"1" => nil},

--- a/ruby/red-arrow/test/values/test-list-array.rb
+++ b/ruby/red-arrow/test/values/test-list-array.rb
@@ -493,7 +493,6 @@ module ValuesListArrayTests
   end
 
   def test_sparse_union
-    omit("Need to add support for SparseUnionArrayBuilder")
     values = [
       [
         {"field1" => true},

--- a/ruby/red-arrow/test/values/test-map-array.rb
+++ b/ruby/red-arrow/test/values/test-map-array.rb
@@ -399,7 +399,6 @@ module ValuesMapArrayTests
   end
 
   def test_sparse_union
-    omit("Need to add support for SparseUnionArrayBuilder")
     values = [
       {
         "key1" => {"field1" => true},

--- a/ruby/red-arrow/test/values/test-sparse-union-array.rb
+++ b/ruby/red-arrow/test/values/test-sparse-union-array.rb
@@ -457,7 +457,6 @@ module ValuesSparseUnionArrayTests
   end
 
   def test_sparse_union
-    omit("Need to add support for SparseUnionArrayBuilder")
     values = [
       {"0" => {"field1" => true}},
       {"1" => nil},

--- a/ruby/red-arrow/test/values/test-struct-array.rb
+++ b/ruby/red-arrow/test/values/test-struct-array.rb
@@ -436,7 +436,6 @@ module ValuesStructArrayTests
   end
 
   def test_sparse_union
-    omit("Need to add support for SparseUnionArrayBuilder")
     values = [
       {"field" => {"field1" => true}},
       nil,


### PR DESCRIPTION
### Rationale for this change

It's a missing binding.

### What changes are included in this PR?

Add `arrow::SparseUnionBuilder` binding and related features.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #21430