### PR TITLE
GH-34995: [C++] Improve available GTest check for SYSTEM case

### DIFF
--- a/cpp/cmake_modules/FindGTestAlt.cmake
+++ b/cpp/cmake_modules/FindGTestAlt.cmake
@@ -55,7 +55,9 @@ TEST(CXX_STANDARD, MatcherStringView) {
               LINK_LIBRARIES GTest::gtest_main)
   set(CMAKE_TRY_COMPILE_TARGET_TYPE ${KEEP_CMAKE_TRY_COMPILE_TARGET_TYPE})
   if(NOT GTestAlt_CXX_STANDARD_AVAILABLE)
-    message(STATUS "GTest can't be used with ${CMAKE_CXX_STANDARD}")
-    set(GTestAlt_FOUND FALSE)
+    message(STATUS "GTest can't be used with C++${CMAKE_CXX_STANDARD}. Use -DGTest_SOURCE=BUNDLED."
+    )
+    find_package_handle_standard_args(GTestAlt
+                                      REQUIRED_VARS GTestAlt_CXX_STANDARD_AVAILABLE)
   endif()
 endif()

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -118,6 +118,11 @@ if(ARROW_DEPENDENCY_SOURCE STREQUAL "CONDA")
     set(ARROW_PACKAGE_PREFIX $ENV{CONDA_PREFIX})
   endif()
   set(ARROW_ACTUAL_DEPENDENCY_SOURCE "SYSTEM")
+  # GoogleTest provided by conda can't be used on macOS because it's
+  # built with C++14. So we accept auto fallback only for GoogleTest.
+  if(GTest_SOURCE STREQUAL "")
+    set(GTest_SOURCE "AUTO")
+  endif()
   message(STATUS "Using CONDA_PREFIX for ARROW_PACKAGE_PREFIX: ${ARROW_PACKAGE_PREFIX}")
 else()
   set(ARROW_ACTUAL_DEPENDENCY_SOURCE "${ARROW_DEPENDENCY_SOURCE}")

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -120,7 +120,7 @@ if(ARROW_DEPENDENCY_SOURCE STREQUAL "CONDA")
   set(ARROW_ACTUAL_DEPENDENCY_SOURCE "SYSTEM")
   # GoogleTest provided by conda can't be used on macOS because it's
   # built with C++14. So we accept auto fallback only for GoogleTest.
-  if(GTest_SOURCE STREQUAL "")
+  if("${GTest_SOURCE}" STREQUAL "")
     set(GTest_SOURCE "AUTO")
   endif()
   message(STATUS "Using CONDA_PREFIX for ARROW_PACKAGE_PREFIX: ${ARROW_PACKAGE_PREFIX}")


### PR DESCRIPTION
### Rationale for this change

The `GTest_SOURCE=AUTO` case worked without this but the `GTest_SOURCE=SYSTEM` case didn't. On conda environment, `SYSTEM` is used. So this is needed for conda environment.

### What changes are included in this PR?

Raises an error in the `GTest_SOURCE=SYSTEM` case.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #34995