### PR TITLE
GH-34569: [C++] Diffing of Run-End Encoded arrays

### DIFF
--- a/cpp/src/arrow/array/diff.cc
+++ b/cpp/src/arrow/array/diff.cc
@@ -151,24 +151,13 @@ struct DefaultValueComparator : public ValueComparator {
 
   ~DefaultValueComparator() override = default;
 
-  /// \brief Compare validity bits of base[base_index] and target[target_index]
-  ///
-  /// \return std::nullopt if the validity bits differ, otherwise a bool
-  /// containing the validity bit found in both arrays.
-  static std::optional<bool> ValidityIfEquals(const ArrayType& base, int64_t base_index,
-                                              const ArrayType& target,
-                                              int64_t target_index) {
+  bool Equals(int64_t base_index, int64_t target_index) override {
     const bool base_valid = base.IsValid(base_index);
     const bool target_valid = target.IsValid(target_index);
-    return base_valid ^ target_valid ? std::nullopt : std::optional<bool>{base_valid};
-  }
-
-  bool Equals(int64_t base_index, int64_t target_index) override {
-    const auto valid = ValidityIfEquals(base, base_index, target, target_index);
-    if (valid.has_value()) {
-      return *valid ? GetView(base, base_index) == GetView(target, target_index) : true;
+    if (base_valid && target_valid) {
+      return GetView(base, base_index) == GetView(target, target_index);
     }
-    return false;
+    return base_valid == target_valid;
   }
 };
 

--- a/cpp/src/arrow/array/diff.cc
+++ b/cpp/src/arrow/array/diff.cc
@@ -241,19 +241,11 @@ class REEValueComparator : public ValueComparator {
       DCHECK_GT(base_run, 0);
       DCHECK_GT(target_run, 0);
 
-      int64_t increment = 0;
-      if (base_run < target_run) {
-        increment = base_run;
-        physical_base_index += 1;  // skip to next run on base
-      } else if (base_run > target_run) {
-        increment = target_run;
-        physical_target_index += 1;  // skip to next run on target
-      } else {
-        increment = base_run;
-        // skip to next run on both base and target
-        physical_base_index += 1;
-        physical_target_index += 1;
-      }
+      // Skip the smallest run (or both runs if they are equal)
+      const int64_t increment = std::min(base_run, target_run);
+      physical_base_index += increment == base_run;
+      physical_target_index += increment == target_run;
+
       // Since both base_run and target_run are greater than zero,
       // increment is also greater than zero...
       DCHECK_GT(increment, 0);

--- a/cpp/src/arrow/array/diff.cc
+++ b/cpp/src/arrow/array/diff.cc
@@ -524,8 +524,9 @@ class QuadraticSpaceMyersDiff {
 
  public:
   Result<std::shared_ptr<StructArray>> Diff() {
+    CreateValueComparator create_value_comparator;
     ARROW_ASSIGN_OR_RAISE(auto comparator,
-                          CreateValueComparator{}(*base_.type(), base_, target_));
+                          create_value_comparator(*base_.type(), base_, target_));
     DCHECK_GE(base_end_, 0);
     DCHECK_GE(target_end_, 0);
     endpoint_base_ = {ExtendFrom(*comparator, {base_begin_, target_begin_}).base};

--- a/cpp/src/arrow/array/diff_test.cc
+++ b/cpp/src/arrow/array/diff_test.cc
@@ -163,6 +163,100 @@ class DiffTest : public ::testing::Test {
     AssertRunLengthIs("[2, 0, 0]");
   }
 
+  std::shared_ptr<RunEndEncodedArray> RunEndEncodedArrayFromJSON(
+      int64_t logical_length, const std::shared_ptr<DataType>& ree_type,
+      std::string_view run_ends_json, std::string_view values_json,
+      int64_t logical_offset = 0) {
+    auto& ree_type_ref = checked_cast<const RunEndEncodedType&>(*ree_type);
+    auto run_ends = ArrayFromJSON(ree_type_ref.run_end_type(), run_ends_json);
+    auto values = ArrayFromJSON(ree_type_ref.value_type(), values_json);
+    return RunEndEncodedArray::Make(logical_length, std::move(run_ends),
+                                    std::move(values), logical_offset)
+        .ValueOrDie();
+  }
+
+  template <typename RunEndType>
+  void TestBasicsWithREEs() {
+    auto run_end_type = std::make_shared<RunEndType>();
+    auto value_type = utf8();
+    auto ree_type = run_end_encoded(run_end_type, value_type);
+
+    // empty REEs
+    base_ = RunEndEncodedArrayFromJSON(0, ree_type, "[]", "[]");
+    target_ = RunEndEncodedArrayFromJSON(0, ree_type, "[]", "[]");
+    DoDiff();
+    AssertInsertIs("[false]");
+    AssertRunLengthIs("[0]");
+
+    // null REE arrays of different lengths
+    base_ = RunEndEncodedArrayFromJSON(2, ree_type, "[2]", "[null]");
+    target_ = RunEndEncodedArrayFromJSON(4, ree_type, "[4]", "[null]");
+    DoDiff();
+    AssertInsertIs("[false, true, true]");
+    AssertRunLengthIs("[2, 0, 0]");
+
+    // identical REE arrays w/ offsets
+    base_ =
+        RunEndEncodedArrayFromJSON(110, ree_type, R"([20, 120])", R"(["a", "b"])", 10);
+    target_ =
+        RunEndEncodedArrayFromJSON(110, ree_type, R"([20, 120])", R"(["a", "b"])", 10);
+    DoDiff();
+    AssertInsertIs("[false]");
+    AssertRunLengthIs("[110]");
+
+    // equivalent REE arrays
+    base_ = RunEndEncodedArrayFromJSON(120, ree_type, R"([10, 20, 120])",
+                                       R"(["a", "a", "b"])");
+    target_ = RunEndEncodedArrayFromJSON(120, ree_type, R"([20, 30, 120])",
+                                         R"(["a", "b", "b"])");
+    DoDiff();
+    AssertInsertIs("[false]");
+    AssertRunLengthIs("[120]");
+
+    // insert one
+    base_ = RunEndEncodedArrayFromJSON(12, ree_type, R"([2, 12])", R"(["a", "b"])");
+    target_ = RunEndEncodedArrayFromJSON(13, ree_type, R"([3, 13])", R"(["a", "b"])");
+    DoDiff();
+    AssertInsertIs("[false, true]");
+    AssertRunLengthIs("[2, 10]");
+
+    // delete one
+    base_ =
+        RunEndEncodedArrayFromJSON(13, ree_type, R"([2, 5, 13])", R"(["a", "b", "c"])");
+    target_ =
+        RunEndEncodedArrayFromJSON(12, ree_type, R"([2, 4, 12])", R"(["a", "b", "c"])");
+    DoDiff();
+    AssertInsertIs("[false, false]");
+    AssertRunLengthIs("[4, 8]");
+
+    // null out one
+    base_ =
+        RunEndEncodedArrayFromJSON(12, ree_type, R"([2, 5, 12])", R"(["a", "b", "c"])");
+    target_ = RunEndEncodedArrayFromJSON(12, ree_type, R"([2, 4, 5, 12])",
+                                         R"(["a", "b", null, "c"])");
+    DoDiff();
+    AssertInsertIs("[false, false, true]");
+    AssertRunLengthIs("[4, 0, 7]");
+
+    // append some
+    base_ = RunEndEncodedArrayFromJSON(12, ree_type, R"([2, 4, 8, 12])",
+                                       R"(["a", "b", "c", "d"])");
+    target_ = RunEndEncodedArrayFromJSON(15, ree_type, R"([2, 4, 8, 13, 15])",
+                                         R"(["a", "b", "c", "d", "e"])");
+    DoDiff();
+    AssertInsertIs("[false, true, true, true]");
+    AssertRunLengthIs("[12, 0, 0, 0]");
+
+    // prepend some
+    base_ = RunEndEncodedArrayFromJSON(12, ree_type, R"([2, 4, 8, 12])",
+                                       R"(["c", "d", "e", "f"])");
+    target_ = RunEndEncodedArrayFromJSON(15, ree_type, R"([1, 3, 5, 7, 11, 15])",
+                                         R"(["a", "b", "c", "d", "e", "f"])");
+    DoDiff();
+    AssertInsertIs("[false, true, true, true]");
+    AssertRunLengthIs("[0, 0, 0, 12]");
+  }
+
   random::RandomArrayGenerator rng_;
   std::shared_ptr<StructArray> edits_;
   std::shared_ptr<Array> base_, target_;
@@ -414,6 +508,12 @@ TEST_F(DiffTest, BasicsWithStructs) {
 TEST_F(DiffTest, BasicsWithSparseUnions) { TestBasicsWithUnions(UnionMode::SPARSE); }
 
 TEST_F(DiffTest, BasicsWithDenseUnions) { TestBasicsWithUnions(UnionMode::DENSE); }
+
+TEST_F(DiffTest, BasicsWithREEs) {
+  TestBasicsWithREEs<Int16Type>();
+  TestBasicsWithREEs<Int32Type>();
+  TestBasicsWithREEs<Int64Type>();
+}
 
 TEST_F(DiffTest, UnifiedDiffFormatter) {
   // no changes

--- a/cpp/src/arrow/array/diff_test.cc
+++ b/cpp/src/arrow/array/diff_test.cc
@@ -213,6 +213,13 @@ class DiffTest : public ::testing::Test {
     AssertInsertIs("[false]");
     AssertRunLengthIs("[120]");
 
+    // slice so last run-end goes beyond length
+    base_ = base_->Slice(5, 105);
+    target_ = target_->Slice(5, 105);
+    DoDiff();
+    AssertInsertIs("[false]");
+    AssertRunLengthIs("[105]");
+
     // insert one
     base_ = RunEndEncodedArrayFromJSON(12, ree_type, R"([2, 12])", R"(["a", "b"])");
     target_ = RunEndEncodedArrayFromJSON(13, ree_type, R"([3, 13])", R"(["a", "b"])");

--- a/cpp/src/arrow/util/ree_util.cc
+++ b/cpp/src/arrow/util/ree_util.cc
@@ -61,6 +61,62 @@ int64_t LogicalNullCount(const ArraySpan& span) {
   return LogicalNullCount<int64_t>(span);
 }
 
+namespace internal {
+
+/// \pre 0 <= i < array_span_.length()
+template <typename RunEndCType>
+int64_t FindPhysicalIndexImpl(PhysicalIndexFinder<RunEndCType>& self, int64_t i) {
+  DCHECK_LT(i, self.array_span.length);
+  const int64_t run_ends_size = ree_util::RunEndsArray(self.array_span).length;
+  DCHECK_LT(self.last_physical_index, run_ends_size);
+  // This access to self.run_ends_[last_physical_index_] is always safe because:
+  // 1. 0 <= i < array_span_.length() implies there is at least one run and the initial
+  //    value 0 will be safe to index with.
+  // 2. last_physical_index_ > 0 is always the result of a valid call to
+  //    internal::FindPhysicalIndex.
+  if (ARROW_PREDICT_TRUE(self.array_span.offset + i <
+                         self.run_ends[self.last_physical_index])) {
+    // The cached value is an upper-bound, but is it the least upper-bound?
+    if (self.last_physical_index == 0 ||
+        self.array_span.offset + i >= self.run_ends[self.last_physical_index - 1]) {
+      return self.last_physical_index;
+    }
+    // last_physical_index_ - 1 is a candidate for the least upper-bound,
+    // so search for the least upper-bound in the range that includes it.
+    const int64_t j = ree_util::internal::FindPhysicalIndex<RunEndCType>(
+        self.run_ends, /*run_ends_size=*/self.last_physical_index, i,
+        self.array_span.offset);
+    DCHECK_LT(j, self.last_physical_index);
+    return self.last_physical_index = j;
+  }
+
+  // last_physical_index_ is not an upper-bound, and the logical index i MUST be
+  // in the runs that follow it. Since i is a valid logical index, we know that at least
+  // one extra run is present.
+  DCHECK_LT(self.last_physical_index + 1, run_ends_size);
+  const int64_t lower_physical_index = self.last_physical_index + 1;
+
+  const int64_t j = ree_util::internal::FindPhysicalIndex<RunEndCType>(
+      /*run_ends=*/self.run_ends + lower_physical_index,
+      /*run_ends_size=*/run_ends_size - lower_physical_index, i, self.array_span.offset);
+  DCHECK_LT(lower_physical_index + j, run_ends_size);
+  return self.last_physical_index = lower_physical_index + j;
+}
+
+int64_t FindPhysicalIndexImpl16(PhysicalIndexFinder<int16_t>& self, int64_t i) {
+  return FindPhysicalIndexImpl(self, i);
+}
+
+int64_t FindPhysicalIndexImpl32(PhysicalIndexFinder<int32_t>& self, int64_t i) {
+  return FindPhysicalIndexImpl(self, i);
+}
+
+int64_t FindPhysicalIndexImpl64(PhysicalIndexFinder<int64_t>& self, int64_t i) {
+  return FindPhysicalIndexImpl(self, i);
+}
+
+}  // namespace internal
+
 int64_t FindPhysicalIndex(const ArraySpan& span, int64_t i, int64_t absolute_offset) {
   const auto type_id = RunEndsArray(span).type->id();
   if (type_id == Type::INT16) {

--- a/cpp/src/arrow/util/ree_util.cc
+++ b/cpp/src/arrow/util/ree_util.cc
@@ -63,16 +63,16 @@ int64_t LogicalNullCount(const ArraySpan& span) {
 
 namespace internal {
 
-/// \pre 0 <= i < array_span_.length()
+/// \pre 0 <= i < array_span.length()
 template <typename RunEndCType>
 int64_t FindPhysicalIndexImpl(PhysicalIndexFinder<RunEndCType>& self, int64_t i) {
   DCHECK_LT(i, self.array_span.length);
   const int64_t run_ends_size = ree_util::RunEndsArray(self.array_span).length;
   DCHECK_LT(self.last_physical_index, run_ends_size);
-  // This access to self.run_ends_[last_physical_index_] is always safe because:
-  // 1. 0 <= i < array_span_.length() implies there is at least one run and the initial
+  // This access to self.run_ends[last_physical_index] is alwas safe because:
+  // 1. 0 <= i < array_span.length() implies there is at least one run and the initial
   //    value 0 will be safe to index with.
-  // 2. last_physical_index_ > 0 is always the result of a valid call to
+  // 2. last_physical_index > 0 is always the result of a valid call to
   //    internal::FindPhysicalIndex.
   if (ARROW_PREDICT_TRUE(self.array_span.offset + i <
                          self.run_ends[self.last_physical_index])) {
@@ -81,7 +81,7 @@ int64_t FindPhysicalIndexImpl(PhysicalIndexFinder<RunEndCType>& self, int64_t i)
         self.array_span.offset + i >= self.run_ends[self.last_physical_index - 1]) {
       return self.last_physical_index;
     }
-    // last_physical_index_ - 1 is a candidate for the least upper-bound,
+    // last_physical_index - 1 is a candidate for the least upper-bound,
     // so search for the least upper-bound in the range that includes it.
     const int64_t j = ree_util::internal::FindPhysicalIndex<RunEndCType>(
         self.run_ends, /*run_ends_size=*/self.last_physical_index, i,
@@ -90,17 +90,17 @@ int64_t FindPhysicalIndexImpl(PhysicalIndexFinder<RunEndCType>& self, int64_t i)
     return self.last_physical_index = j;
   }
 
-  // last_physical_index_ is not an upper-bound, and the logical index i MUST be
+  // last_physical_index is not an upper-bound, and the logical index i MUST be
   // in the runs that follow it. Since i is a valid logical index, we know that at least
   // one extra run is present.
   DCHECK_LT(self.last_physical_index + 1, run_ends_size);
-  const int64_t lower_physical_index = self.last_physical_index + 1;
+  const int64_t min_physical_index = self.last_physical_index + 1;
 
   const int64_t j = ree_util::internal::FindPhysicalIndex<RunEndCType>(
-      /*run_ends=*/self.run_ends + lower_physical_index,
-      /*run_ends_size=*/run_ends_size - lower_physical_index, i, self.array_span.offset);
-  DCHECK_LT(lower_physical_index + j, run_ends_size);
-  return self.last_physical_index = lower_physical_index + j;
+      /*run_ends=*/self.run_ends + min_physical_index,
+      /*run_ends_size=*/run_ends_size - min_physical_index, i, self.array_span.offset);
+  DCHECK_LT(min_physical_index + j, run_ends_size);
+  return self.last_physical_index = min_physical_index + j;
 }
 
 int64_t FindPhysicalIndexImpl16(PhysicalIndexFinder<int16_t>& self, int64_t i) {

--- a/cpp/src/arrow/util/ree_util.h
+++ b/cpp/src/arrow/util/ree_util.h
@@ -188,7 +188,7 @@ struct PhysicalIndexFinder {
 
   /// \brief Find the physical index into the values array of the REE array.
   ///
-  /// \pre 0 <= i < array_span_.length()
+  /// \pre 0 <= i < array_span.length()
   /// \param i the logical index into the REE array
   /// \return the physical index into the values array
   int64_t FindPhysicalIndex(int64_t i) {

--- a/cpp/src/arrow/util/ree_util.h
+++ b/cpp/src/arrow/util/ree_util.h
@@ -23,6 +23,7 @@
 
 #include "arrow/array/data.h"
 #include "arrow/type_traits.h"
+#include "arrow/util/checked_cast.h"
 #include "arrow/util/macros.h"
 
 namespace arrow {
@@ -139,6 +140,69 @@ int64_t FindPhysicalLength(const ArraySpan& span) {
       /*offset=*/span.offset);
 }
 
+template <typename RunEndCType>
+struct PhysicalIndexFinder;
+
+// non-inline implementations for each run-end type
+ARROW_EXPORT int64_t FindPhysicalIndexImpl16(PhysicalIndexFinder<int16_t>& self,
+                                             int64_t i);
+ARROW_EXPORT int64_t FindPhysicalIndexImpl32(PhysicalIndexFinder<int32_t>& self,
+                                             int64_t i);
+ARROW_EXPORT int64_t FindPhysicalIndexImpl64(PhysicalIndexFinder<int64_t>& self,
+                                             int64_t i);
+
+/// \brief Stateful version of FindPhysicalIndex() that caches the result of
+/// the previous search and uses it to optimize the next search.
+///
+/// When new queries for the physical index of a logical index come in,
+/// binary search is performed again but the first candidate checked is the
+/// result of the previous search (cached physical index) instead of the
+/// midpoint of the run-ends array.
+///
+/// If that test fails, internal::FindPhysicalIndex() is called with one of the
+/// partitions defined by the cached index. If the queried logical indices
+/// follow an increasing or decreasing pattern, this first test is much more
+/// effective in (1) finding the answer right away (close logical indices belong
+/// to the same runs) or (2) discarding many more candidates than probing
+/// the midpoint would.
+///
+/// The most adversarial case (i.e. alternating between 0 and length-1 queries)
+/// only adds one extra binary search probe when compared to always starting
+/// binary search from the midpoint without any of these optimizations.
+///
+/// \tparam RunEndCType The numeric type of the run-ends array.
+template <typename RunEndCType>
+struct PhysicalIndexFinder {
+  const ArraySpan array_span;
+  const RunEndCType* run_ends;
+  int64_t last_physical_index = 0;
+
+  explicit PhysicalIndexFinder(const ArrayData& data)
+      : array_span(data),
+        run_ends(RunEndsArray(array_span).template GetValues<RunEndCType>(1)) {
+    assert(CTypeTraits<RunEndCType>::ArrowType::type_id ==
+           ::arrow::internal::checked_cast<const RunEndEncodedType&>(*data.type)
+               .run_end_type()
+               ->id());
+  }
+
+  /// \brief Find the physical index into the values array of the REE array.
+  ///
+  /// \pre 0 <= i < array_span_.length()
+  /// \param i the logical index into the REE array
+  /// \return the physical index into the values array
+  int64_t FindPhysicalIndex(int64_t i) {
+    if constexpr (std::is_same_v<RunEndCType, int16_t>) {
+      return FindPhysicalIndexImpl16(*this, i);
+    } else if constexpr (std::is_same_v<RunEndCType, int32_t>) {
+      return FindPhysicalIndexImpl32(*this, i);
+    } else {
+      static_assert(std::is_same_v<RunEndCType, int64_t>, "Unsupported RunEndCType.");
+      return FindPhysicalIndexImpl64(*this, i);
+    }
+  }
+};
+
 }  // namespace internal
 
 /// \brief Find the physical index into the values array of the REE ArraySpan
@@ -165,6 +229,10 @@ ARROW_EXPORT int64_t FindPhysicalLength(const ArraySpan& span);
 ARROW_EXPORT std::pair<int64_t, int64_t> FindPhysicalRange(const ArraySpan& span,
                                                            int64_t offset,
                                                            int64_t length);
+
+// Publish PhysicalIndexFinder outside of the internal namespace.
+template <typename RunEndCType>
+using PhysicalIndexFinder = internal::PhysicalIndexFinder<RunEndCType>;
 
 template <typename RunEndCType>
 class RunEndEncodedArraySpan {


### PR DESCRIPTION
### What changes are included in this PR?

Ability to diff run-end encoded arrays without expanding them first. This is useful for debugging and understanding of unit test failures.

Many successive random accesses to REE arrays by logical indices incur many successive binary searches on the run-ends array to find the physical index of the values array, so this PR implements a few interesting optimizations -- the most complicated one is encapsulated in a new utility available via `ree_util.h` as there are many potential uses for it other than diffing.

    +-------------+---------------------------+----------------------------------------------------+
    |             |                                  Optimizations                                 |
    +-------------+---------------------------+-----------------------+----------------------------+
    | # bsearches | Null checks on Comparator | RunLengthOfEqualsFrom | Cached FindPhysicalIndex() |
    +-------------+---------------------------+----------------------+-----------------------------+
    |    3798     |                           |                      |                             |
    +-------------+---------------------------+----------------------+-----------------------------+
    |    1914     |           X               |                      |                             |
    +-------------+---------------------------+----------------------+-----------------------------+
    |     180     |           X               |        X             |                             |
    +-------------+---------------------------+----------------------+-----------------------------+
    |     153     |           X               |                      |           X                 |
    +-------------+---------------------------+----------------------+-----------------------------+
    |      75     |           X               |        X             |           X                 |
    +-------------+---------------------------+----------------------+-----------------------------+
    
### Are these changes tested?

Yes. By existing and newly added REE-specific tests.

### Are there any user-facing changes?

No.

* Closes: #34569