### PR TITLE
GH-35007: [C++] Fix reading stdin

### DIFF
--- a/cpp/src/arrow/io/file_test.cc
+++ b/cpp/src/arrow/io/file_test.cc
@@ -35,8 +35,8 @@
 
 #include "arrow/buffer.h"
 #include "arrow/io/file.h"
-#include "arrow/io/stdio.h"
 #include "arrow/io/interfaces.h"
+#include "arrow/io/stdio.h"
 #include "arrow/io/test_common.h"
 #include "arrow/memory_pool.h"
 #include "arrow/status.h"
@@ -1112,7 +1112,7 @@ TEST_F(TestStdio, ReadStdinReadUnalignedBuffer) {
   CreateStdinWithData(data, sizeof(data));
 
   StdinStream input;
-  char buffer[sizeof(data)+16];
+  char buffer[sizeof(data) + 16];
   ASSERT_OK_AND_ASSIGN(auto res, input.Read(sizeof(buffer), buffer));
   ASSERT_EQ(sizeof(data), res);
   ASSERT_EQ(0, std::memcmp(buffer, data, sizeof(data)));

--- a/cpp/src/arrow/io/file_test.cc
+++ b/cpp/src/arrow/io/file_test.cc
@@ -35,6 +35,7 @@
 
 #include "arrow/buffer.h"
 #include "arrow/io/file.h"
+#include "arrow/io/stdio.h"
 #include "arrow/io/interfaces.h"
 #include "arrow/io/test_common.h"
 #include "arrow/memory_pool.h"
@@ -1073,6 +1074,65 @@ TEST_F(TestMemoryMappedFile, ThreadSafety) {
   thread2.join();
 
   ASSERT_EQ(niter * 2, correct_count);
+}
+
+// ----------------------------------------------------------------------
+// Stdio tests
+
+class TestStdio : public FileTestFixture {
+ public:
+  void CreateStdinWithData(const char* data, size_t size) {
+    EnsureFileDeleted();
+
+    ASSERT_OK_AND_ASSIGN(auto file, FileOutputStream::Open(path_, false));
+    ASSERT_OK(file->Write(data, size));
+    ASSERT_OK(file->Close());
+    cin_.reset(new std::ifstream(path_));
+    std::cin.rdbuf(cin_->rdbuf());
+  }
+
+ protected:
+  std::shared_ptr<std::ifstream> cin_;
+};
+
+TEST_F(TestStdio, ReadStdinReadAtOnce) {
+  const char data[] = "testdata";
+  CreateStdinWithData(data, sizeof(data));
+
+  StdinStream input;
+  char buffer[sizeof(data)];
+  ASSERT_OK_AND_ASSIGN(auto res, input.Read(sizeof(buffer), buffer));
+  ASSERT_EQ(sizeof(data), res);
+  ASSERT_EQ(0, std::memcmp(buffer, data, sizeof(data)));
+  ASSERT_EQ(sizeof(data), input.Tell());
+}
+
+TEST_F(TestStdio, ReadStdinReadUnalignedBuffer) {
+  const char data[] = "testdata";
+  CreateStdinWithData(data, sizeof(data));
+
+  StdinStream input;
+  char buffer[sizeof(data)+16];
+  ASSERT_OK_AND_ASSIGN(auto res, input.Read(sizeof(buffer), buffer));
+  ASSERT_EQ(sizeof(data), res);
+  ASSERT_EQ(0, std::memcmp(buffer, data, sizeof(data)));
+  ASSERT_EQ(sizeof(data), input.Tell());
+}
+
+TEST_F(TestStdio, ReadStdinReadAfterClose) {
+  const char data[] = "testdata";
+  CreateStdinWithData(data, sizeof(data));
+
+  StdinStream input;
+  char buffer[4];
+  ASSERT_OK_AND_ASSIGN(auto res, input.Read(sizeof(buffer), buffer));
+  ASSERT_EQ(sizeof(buffer), res);
+  ASSERT_EQ(0, std::memcmp(buffer, data, sizeof(buffer)));
+  ASSERT_EQ(sizeof(buffer), input.Tell());
+  cin_->close();
+  ASSERT_OK_AND_ASSIGN(res, input.Read(sizeof(buffer), buffer));
+  ASSERT_EQ(0, res);
+  ASSERT_EQ(sizeof(buffer), input.Tell());
 }
 
 }  // namespace io

--- a/cpp/src/arrow/io/stdio.cc
+++ b/cpp/src/arrow/io/stdio.cc
@@ -75,12 +75,9 @@ Result<int64_t> StdinStream::Tell() const { return pos_; }
 
 Result<int64_t> StdinStream::Read(int64_t nbytes, void* out) {
   std::cin.read(reinterpret_cast<char*>(out), nbytes);
-  if (std::cin) {
-    pos_ += nbytes;
-    return nbytes;
-  } else {
-    return 0;
-  }
+  nbytes = std::cin.gcount();
+  pos_ += nbytes;
+  return nbytes;
 }
 
 Result<std::shared_ptr<Buffer>> StdinStream::Read(int64_t nbytes) {


### PR DESCRIPTION
lost end of stream when reading in form of
```cpp
    auto input = std::shared_ptr<arrow::io::InputStream>(new arrow::io::StdinStream());
    arrow::Result<int64_t> res;
    char buffer[16];
    while (*(res = input->Read(sizeof(buffer), buffer)) != 0) {
        std::cerr << std::string_view(buffer, *res);
    }
```
the PR fix the issue
* Closes: #35007