### PR TITLE
GH-34983: [C++] Preserve map values nullability on C Data Interface import

### DIFF
--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -1102,7 +1102,13 @@ struct SchemaImporter {
     }
 
     bool keys_sorted = (c_struct_->flags & ARROW_FLAG_MAP_KEYS_SORTED);
-    type_ = map(value_type->field(0)->type(), value_type->field(1)->type(), keys_sorted);
+    bool values_nullable = value_type->field(1)->nullable();
+    // Some implementations of Arrow (such as Rust) use a non-standard field name
+    // for key ("keys") and value ("values") fields. For simplicity, we override
+    // them on import.
+    auto values_field =
+        ::arrow::field("value", value_type->field(1)->type(), values_nullable);
+    type_ = map(value_type->field(0)->type(), values_field, keys_sorted);
     return Status::OK();
   }
 


### PR DESCRIPTION
### Rationale for this change

Map types with non-nullable values don't roundtrip right now through C Data interface, when they arguably should.

I also found that field names don't roundtrip, but I think that might be a feature, not a bug. Therefore I added unit tests enforcing it for now.
 
### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes, added various unit tests for export and roundtrip.

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #34983