### PR TITLE
GH-34906: [C++] Return invalid status instead of segfault if reading from a closed ArrayStreamBatchReader

### DIFF
--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -1784,6 +1784,10 @@ class ArrayStreamBatchReader : public RecordBatchReader {
 
   Status ReadNext(std::shared_ptr<RecordBatch>* batch) override {
     struct ArrowArray c_array;
+    if (ArrowArrayStreamIsReleased(&stream_)) {
+      return Status::Invalid(
+          "Attempt to read from a reader that has already been closed");
+    }
     RETURN_NOT_OK(StatusFromCError(stream_.get_next(&stream_, &c_array)));
     if (ArrowArrayIsReleased(&c_array)) {
       // End of stream

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -35,6 +35,7 @@
 #include "arrow/memory_pool.h"
 #include "arrow/testing/extension_type.h"
 #include "arrow/testing/gtest_util.h"
+#include "arrow/testing/matchers.h"
 #include "arrow/testing/util.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/endian.h"
@@ -3349,6 +3350,16 @@ class TestArrayStreamRoundtrip : public BaseArrayStreamTest {
     ASSERT_OK_AND_ASSIGN(auto batch, reader->Next());
     ASSERT_EQ(batch, nullptr);
   }
+
+  void AssertReaderClosed(const std::shared_ptr<RecordBatchReader>& reader) {
+    ASSERT_THAT(reader->Next(),
+                Raises(StatusCode::Invalid, ::testing::HasSubstr("already been closed")));
+  }
+
+  void AssertReaderClose(const std::shared_ptr<RecordBatchReader>& reader) {
+    ASSERT_OK(reader->Close());
+    AssertReaderClosed(reader);
+  }
 };
 
 TEST_F(TestArrayStreamRoundtrip, Simple) {
@@ -3364,6 +3375,20 @@ TEST_F(TestArrayStreamRoundtrip, Simple) {
     AssertReaderNext(reader, *batches[1]);
     AssertReaderEnd(reader);
     AssertReaderEnd(reader);
+    AssertReaderClose(reader);
+  });
+}
+
+TEST_F(TestArrayStreamRoundtrip, CloseEarly) {
+  auto orig_schema = arrow::schema({field("ints", int32())});
+  auto batches = MakeBatches(orig_schema, {ArrayFromJSON(int32(), "[1, 2]"),
+                                           ArrayFromJSON(int32(), "[4, 5, null]")});
+
+  ASSERT_OK_AND_ASSIGN(auto reader, RecordBatchReader::Make(batches, orig_schema));
+
+  Roundtrip(std::move(reader), [&](const std::shared_ptr<RecordBatchReader>& reader) {
+    AssertReaderNext(reader, *batches[0]);
+    AssertReaderClose(reader);
   });
 }
 


### PR DESCRIPTION
### Rationale for this change

Segfaults should be avoided, even on improper calling patterns.

### What changes are included in this PR?

Attempting to use a record batch reader, sourced from a C API stream, after it had been closed, will now return an invalid status instead of a segmentation fault.

### Are these changes tested?

Yes, new unit tests were added to regress this usage.

### Are there any user-facing changes?

No
* Closes: #34906