### PR TITLE
GH-35014: [Python] Make sure unit tests can run without acero

### DIFF
--- a/python/pyarrow/acero.py
+++ b/python/pyarrow/acero.py
@@ -41,7 +41,13 @@ try:
     import pyarrow.dataset as ds
     from pyarrow._dataset import ScanNodeOptions
 except ImportError:
-    ds = None
+    class DatasetModuleStub:
+        class Dataset:
+            pass
+
+        class InMemoryDataset:
+            pass
+    ds = DatasetModuleStub
 
 
 def _dataset_to_decl(dataset, use_threads=True):

--- a/python/pyarrow/conftest.py
+++ b/python/pyarrow/conftest.py
@@ -21,6 +21,7 @@ from pyarrow import Codec
 from pyarrow import fs
 
 groups = [
+    'acero',
     'brotli',
     'bz2',
     'cython',
@@ -50,6 +51,7 @@ groups = [
 ]
 
 defaults = {
+    'acero': False,
     'brotli': Codec.is_available('brotli'),
     'bz2': Codec.is_available('bz2'),
     'cython': False,
@@ -93,6 +95,12 @@ except ImportError:
 try:
     import pyarrow.gandiva  # noqa
     defaults['gandiva'] = True
+except ImportError:
+    pass
+
+try:
+    import pyarrow.acero  # noqa
+    defaults['acero'] = True
 except ImportError:
     pass
 

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -1448,7 +1448,6 @@ def test_write_to_dataset_no_partitions_s3fs(
     "ignore:'ParquetDataset:FutureWarning",
     "ignore:'partition_filename_cb':FutureWarning")
 @pytest.mark.pandas
-@pytest.mark.dataset
 @parametrize_legacy_dataset_not_supported
 def test_write_to_dataset_with_partitions_and_custom_filenames(
     tempdir, use_legacy_dataset
@@ -1471,7 +1470,7 @@ def test_write_to_dataset_with_partitions_and_custom_filenames(
                         partition_by, partition_filename_callback,
                         use_legacy_dataset=use_legacy_dataset)
 
-    dataset = pq.ParquetDataset(path)
+    dataset = pq.ParquetDataset(path, use_legacy_dataset=use_legacy_dataset)
 
     # ARROW-3538: Ensure partition filenames match the given pattern
     # defined in the local function partition_filename_callback

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -1448,6 +1448,7 @@ def test_write_to_dataset_no_partitions_s3fs(
     "ignore:'ParquetDataset:FutureWarning",
     "ignore:'partition_filename_cb':FutureWarning")
 @pytest.mark.pandas
+@pytest.mark.dataset
 @parametrize_legacy_dataset_not_supported
 def test_write_to_dataset_with_partitions_and_custom_filenames(
     tempdir, use_legacy_dataset

--- a/python/pyarrow/tests/test_acero.py
+++ b/python/pyarrow/tests/test_acero.py
@@ -40,6 +40,8 @@ try:
 except ImportError:
     ds = None
 
+pytestmark = pytest.mark.acero
+
 
 @pytest.fixture
 def table_source():
@@ -49,7 +51,6 @@ def table_source():
     return table_source
 
 
-@pytest.mark.acero
 def test_declaration():
 
     table = pa.table({'a': [1, 2, 3], 'b': [4, 5, 6]})
@@ -71,14 +72,12 @@ def test_declaration():
     assert result.equals(table.slice(1, 2))
 
 
-@pytest.mark.acero
 def test_declaration_repr(table_source):
 
     assert "TableSourceNode" in str(table_source)
     assert "TableSourceNode" in repr(table_source)
 
 
-@pytest.mark.acero
 def test_declaration_to_reader(table_source):
     with table_source.to_reader() as reader:
         assert reader.schema == pa.schema([("a", pa.int64()), ("b", pa.int64())])
@@ -87,7 +86,6 @@ def test_declaration_to_reader(table_source):
     assert result.equals(expected)
 
 
-@pytest.mark.acero
 def test_table_source():
     with pytest.raises(TypeError):
         TableSourceNodeOptions(pa.record_batch([pa.array([1, 2, 3])], ["a"]))
@@ -100,7 +98,6 @@ def test_table_source():
         _ = decl.to_table()
 
 
-@pytest.mark.acero
 def test_filter(table_source):
     # referencing unknown field
     decl = Declaration.from_sequence([
@@ -117,7 +114,6 @@ def test_filter(table_source):
         FilterNodeOptions(None)
 
 
-@pytest.mark.acero
 def test_project(table_source):
     # default name from expression
     decl = Declaration.from_sequence([
@@ -150,7 +146,6 @@ def test_project(table_source):
         _ = decl.to_table()
 
 
-@pytest.mark.acero
 def test_aggregate_scalar(table_source):
     decl = Declaration.from_sequence([
         table_source,
@@ -202,7 +197,6 @@ def test_aggregate_scalar(table_source):
         _ = decl.to_table()
 
 
-@pytest.mark.acero
 def test_aggregate_hash():
     table = pa.table({'a': [1, 2, None], 'b': ["foo", "bar", "foo"]})
     table_opts = TableSourceNodeOptions(table)
@@ -249,7 +243,6 @@ def test_aggregate_hash():
         _ = decl.to_table()
 
 
-@pytest.mark.acero
 def test_order_by():
     table = pa.table({'a': [1, 2, 3, 4], 'b': [1, 3, None, 2]})
     table_source = Declaration("table_source", TableSourceNodeOptions(table))
@@ -287,7 +280,6 @@ def test_order_by():
         _ = OrderByNodeOptions([("b", "ascending")], null_placement="start")
 
 
-@pytest.mark.acero
 def test_hash_join():
     left = pa.table({'key': [1, 2, 3], 'a': [4, 5, 6]})
     left_source = Declaration("table_source", options=TableSourceNodeOptions(left))

--- a/python/pyarrow/tests/test_acero.py
+++ b/python/pyarrow/tests/test_acero.py
@@ -21,15 +21,18 @@ import pyarrow as pa
 import pyarrow.compute as pc
 from pyarrow.compute import field
 
-from pyarrow.acero import (
-    Declaration,
-    TableSourceNodeOptions,
-    FilterNodeOptions,
-    ProjectNodeOptions,
-    AggregateNodeOptions,
-    OrderByNodeOptions,
-    HashJoinNodeOptions,
-)
+try:
+    from pyarrow.acero import (
+        Declaration,
+        TableSourceNodeOptions,
+        FilterNodeOptions,
+        ProjectNodeOptions,
+        AggregateNodeOptions,
+        OrderByNodeOptions,
+        HashJoinNodeOptions,
+    )
+except ImportError:
+    pass
 
 try:
     import pyarrow.dataset as ds
@@ -46,6 +49,7 @@ def table_source():
     return table_source
 
 
+@pytest.mark.acero
 def test_declaration():
 
     table = pa.table({'a': [1, 2, 3], 'b': [4, 5, 6]})
@@ -67,12 +71,14 @@ def test_declaration():
     assert result.equals(table.slice(1, 2))
 
 
+@pytest.mark.acero
 def test_declaration_repr(table_source):
 
     assert "TableSourceNode" in str(table_source)
     assert "TableSourceNode" in repr(table_source)
 
 
+@pytest.mark.acero
 def test_declaration_to_reader(table_source):
     with table_source.to_reader() as reader:
         assert reader.schema == pa.schema([("a", pa.int64()), ("b", pa.int64())])
@@ -81,6 +87,7 @@ def test_declaration_to_reader(table_source):
     assert result.equals(expected)
 
 
+@pytest.mark.acero
 def test_table_source():
     with pytest.raises(TypeError):
         TableSourceNodeOptions(pa.record_batch([pa.array([1, 2, 3])], ["a"]))
@@ -93,6 +100,7 @@ def test_table_source():
         _ = decl.to_table()
 
 
+@pytest.mark.acero
 def test_filter(table_source):
     # referencing unknown field
     decl = Declaration.from_sequence([
@@ -109,6 +117,7 @@ def test_filter(table_source):
         FilterNodeOptions(None)
 
 
+@pytest.mark.acero
 def test_project(table_source):
     # default name from expression
     decl = Declaration.from_sequence([
@@ -141,6 +150,7 @@ def test_project(table_source):
         _ = decl.to_table()
 
 
+@pytest.mark.acero
 def test_aggregate_scalar(table_source):
     decl = Declaration.from_sequence([
         table_source,
@@ -192,6 +202,7 @@ def test_aggregate_scalar(table_source):
         _ = decl.to_table()
 
 
+@pytest.mark.acero
 def test_aggregate_hash():
     table = pa.table({'a': [1, 2, None], 'b': ["foo", "bar", "foo"]})
     table_opts = TableSourceNodeOptions(table)
@@ -238,6 +249,7 @@ def test_aggregate_hash():
         _ = decl.to_table()
 
 
+@pytest.mark.acero
 def test_order_by():
     table = pa.table({'a': [1, 2, 3, 4], 'b': [1, 3, None, 2]})
     table_source = Declaration("table_source", TableSourceNodeOptions(table))
@@ -275,6 +287,7 @@ def test_order_by():
         _ = OrderByNodeOptions([("b", "ascending")], null_placement="start")
 
 
+@pytest.mark.acero
 def test_hash_join():
     left = pa.table({'key': [1, 2, 3], 'a': [4, 5, 6]})
     left_source = Declaration("table_source", options=TableSourceNodeOptions(left))

--- a/python/pyarrow/tests/test_exec_plan.py
+++ b/python/pyarrow/tests/test_exec_plan.py
@@ -22,11 +22,15 @@ from .test_extension_type import IntegerType
 
 try:
     import pyarrow.dataset as ds
+except ImportError:
+    pass
+
+try:
     from pyarrow.acero import _perform_join, _filter_table
 except ImportError:
     pass
 
-pytestmark = pytest.mark.dataset
+pytestmark = pytest.mark.acero
 
 
 def test_joins_corner_cases():
@@ -89,7 +93,8 @@ def test_joins_corner_cases():
     })
 ])
 @pytest.mark.parametrize("use_threads", [True, False])
-@pytest.mark.parametrize("use_datasets", [False, True])
+@pytest.mark.parametrize("use_datasets",
+                         [False, pytest.param(True, marks=pytest.mark.dataset)])
 def test_joins(jointype, expected, use_threads, use_datasets):
     # Allocate table here instead of using parametrize
     # this prevents having arrow allocated memory forever around.

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -2157,7 +2157,7 @@ def test_table_to_recordbatchreader():
     assert reader.read_next_batch().num_rows == 1
 
 
-@pytest.mark.dataset
+@pytest.mark.acero
 def test_table_join():
     t1 = pa.table({
         "colA": [1, 2, 6],
@@ -2184,7 +2184,7 @@ def test_table_join():
     })
 
 
-@pytest.mark.dataset
+@pytest.mark.acero
 def test_table_join_unique_key():
     t1 = pa.table({
         "colA": [1, 2, 6],
@@ -2211,7 +2211,7 @@ def test_table_join_unique_key():
     })
 
 
-@pytest.mark.dataset
+@pytest.mark.acero
 def test_table_join_collisions():
     t1 = pa.table({
         "colA": [1, 2, 6],
@@ -2235,7 +2235,7 @@ def test_table_join_collisions():
     ], names=["colA", "colB", "colVals", "colB", "colVals"])
 
 
-@pytest.mark.dataset
+@pytest.mark.acero
 def test_table_filter_expression():
     t1 = pa.table({
         "colA": [1, 2, 6],
@@ -2259,7 +2259,7 @@ def test_table_filter_expression():
     })
 
 
-@pytest.mark.dataset
+@pytest.mark.acero
 def test_table_join_many_columns():
     t1 = pa.table({
         "colA": [1, 2, 6],

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -1989,6 +1989,7 @@ def test_table_select():
     assert result.equals(expected)
 
 
+@pytest.mark.acero
 def test_table_group_by():
     def sorted_by_keys(d):
         # Ensure a guaranteed order of keys for aggregation results.


### PR DESCRIPTION
### Rationale for this change

Fixes two failing nightlies:

 * [example-python-minimal-build-fedora-conda](https://github.com/ursacomputing/crossbow/actions/runs/4653275808/jobs/8234009627)
 * [example-python-minimal-build-ubuntu-venv](https://github.com/ursacomputing/crossbow/actions/runs/4653280100/jobs/8234017973)

### What changes are included in this PR?

Adds a pytest mark for Acero, since it is now required.

### Are these changes tested?

Yes, this fixes existing tests. Validated it works locally.

### Are there any user-facing changes?

No.
* Closes: #35014