### PR TITLE
GH-35021: [Python][CI] Use conda's gdb in test-conda-python

### DIFF
--- a/ci/conda_env_python.txt
+++ b/ci/conda_env_python.txt
@@ -21,6 +21,7 @@ cffi
 cython
 cloudpickle
 fsspec
+gdb
 hypothesis
 numpy>=1.16.6
 pytest


### PR DESCRIPTION
### Rationale for this change

If we use system gdb, we can't import build-in libraries such as math:

    (gdb) source /arrow/cpp/gdb_arrow.py
    Traceback (most recent call last):
      File "/arrow/cpp/gdb_arrow.py", line 20, in <module>
        import datetime
      File "/usr/lib/python3.10/datetime.py", line 12, in <module>
        import math as _math
    ModuleNotFoundError: No module named 'math'

Because system gdb is built with system Python not conda's Python.

### What changes are included in this PR?

Use conda's gdb instead of system gdb.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #35021