### PR TITLE
GH-35025: [Python] Remove use of deprecated pandas.Categorical fastpath keyword

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1685,10 +1685,9 @@ cdef wrap_array_output(PyObject* output):
     cdef object obj = PyObject_to_object(output)
 
     if isinstance(obj, dict):
-        return pandas_api.categorical_type(obj['indices'],
-                                           categories=obj['dictionary'],
-                                           ordered=obj['ordered'],
-                                           fastpath=True)
+        return _pandas_api.categorical_type.from_codes(
+            obj['indices'], categories=obj['dictionary'], ordered=obj['ordered']
+        )
     else:
         return obj
 


### PR DESCRIPTION
### Rationale for this change
We are using `pd.Categorical(codes, categories, fastpath=True)`. This keyword is deprecated in pandas 2.1 and this should be changed to `pd.Categorical.from_codes(codes, categories)`.

### Are there any user-facing changes?
No
* Closes: #35025