### PR TITLE
GH-35027: [Go]: Use base64.StdEncoding in FixedSizeBinaryBuilder Unmarshal

### DIFF
--- a/go/arrow/array/fixedsize_binary_test.go
+++ b/go/arrow/array/fixedsize_binary_test.go
@@ -109,3 +109,43 @@ func TestFixedSizeBinarySlice(t *testing.T) {
 		t.Fatalf("got=%q, want=%q", got, want)
 	}
 }
+
+func TestFixedSizeBinary_MarshalUnmarshalJSON(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	dtype := &arrow.FixedSizeBinaryType{ByteWidth: 4}
+	b := array.NewFixedSizeBinaryBuilder(mem, dtype)
+	defer b.Release()
+
+	var data = [][]byte{
+		[]byte("ABCD"),
+		[]byte("1234"),
+		nil,
+		[]byte("AZER"),
+	}
+	b.AppendValues(data[:2], nil)
+	b.AppendNull()
+	b.Append(data[3])
+
+	arr := b.NewFixedSizeBinaryArray()
+	defer arr.Release()
+
+	jsonBytes, err := arr.MarshalJSON()
+	if err != nil {
+		t.Fatalf("failed to marshal json: %v", err)
+	}
+
+	err = b.UnmarshalJSON(jsonBytes)
+	if err != nil {
+		t.Fatalf("failed to unmarshal json: %v", err)
+	}
+	gotArr := b.NewFixedSizeBinaryArray()
+	defer gotArr.Release()
+
+	gotString := gotArr.String()
+	wantString := arr.String()
+	if gotString != wantString {
+		t.Fatalf("got=%q, want=%q", gotString, wantString)
+	}
+}

--- a/go/arrow/array/fixedsize_binarybuilder.go
+++ b/go/arrow/array/fixedsize_binarybuilder.go
@@ -175,7 +175,7 @@ func (b *FixedSizeBinaryBuilder) UnmarshalOne(dec *json.Decoder) error {
 	var val []byte
 	switch v := t.(type) {
 	case string:
-		data, err := base64.RawStdEncoding.DecodeString(v)
+		data, err := base64.StdEncoding.DecodeString(v)
 		if err != nil {
 			return err
 		}

--- a/go/arrow/compute/scalar_compare_test.go
+++ b/go/arrow/compute/scalar_compare_test.go
@@ -873,9 +873,9 @@ func (c *CompareFixedSizeBinary) TestArrayScalar() {
 		valAba = `YWJh`
 		valAbc = `YWJj`
 		valAbd = `YWJk`
-		valA   = `YQ`
-		valB   = `Yg`
-		valC   = `Yw`
+		valA   = `YQ==`
+		valB   = `Yg==`
+		valC   = `Yw==`
 	)
 
 	const (
@@ -883,7 +883,6 @@ func (c *CompareFixedSizeBinary) TestArrayScalar() {
 		lhs1    = `["aba", "abc", "abd", null]`
 		rhs1    = "abc"
 		lhs2bin = `["` + valA + `","` + valB + `","` + valC + `", null]`
-		lhs2    = `["a", "b", "c", null]`
 		rhs2    = "b"
 	)
 
@@ -968,9 +967,9 @@ func (c *CompareFixedSizeBinary) TestScalarArray() {
 		valAba = `YWJh`
 		valAbc = `YWJj`
 		valAbd = `YWJk`
-		valA   = `YQ`
-		valB   = `Yg`
-		valC   = `Yw`
+		valA   = `YQ==`
+		valB   = `Yg==`
+		valC   = `Yw==`
 	)
 
 	const (
@@ -1078,13 +1077,11 @@ func (c *CompareFixedSizeBinary) TestArrayArray() {
 
 	// base64 encoding
 	const (
-		valAba = `YWJh`
 		valAbc = `YWJj`
 		valAbd = `YWJk`
-		valA   = `YQ`
-		valB   = `Yg`
-		valC   = `Yw`
-		valD   = `ZA`
+		valA   = `YQ==`
+		valC   = `Yw==`
+		valD   = `ZA==`
 	)
 
 	const (
@@ -1092,8 +1089,6 @@ func (c *CompareFixedSizeBinary) TestArrayArray() {
 		rhs1bin = `["` + valAbc + `","` + valAbd + `","` + valAbc + `","` + valAbc + `", null]`
 		lhs1    = `["abc", "abc", "abd", null, "abc"]`
 		rhs1    = `["abc", "abd", "abc", "abc", null]`
-		lhs2    = `["a", "a", "d", null, "a"]`
-		rhs2    = `["a", "d", "c", "a", null]`
 		lhs2bin = `["` + valA + `","` + valA + `","` + valD + `", null, "` + valA + `"]`
 		rhs2bin = `["` + valA + `","` + valD + `","` + valC + `","` + valA + `", null]`
 	)


### PR DESCRIPTION
This changes `FixedSizeBinaryBuilder`'s Unmarshal to use `base64.StdEncoding` instead of `base64.RawStdEncoding`. The previous implementation caused an error when unmarshaling from JSON previously produced by a `FixedSizeBinary` array instance.

I also added a test for Marshal/Unmarshal to set the expectation that these operations should mirror one another.
* Closes: #35027