### PR TITLE
GH-35029: [CI][C#] Install python on ubuntu-csharp image to fix nuget CI build

### DIFF
--- a/ci/docker/ubuntu-22.04-csharp.dockerfile
+++ b/ci/docker/ubuntu-22.04-csharp.dockerfile
@@ -20,4 +20,9 @@ ARG dotnet=7.0
 ARG platform=jammy
 FROM mcr.microsoft.com/dotnet/sdk:${dotnet}-${platform}-${arch}
 
+RUN apt-get update -y -q && \
+    apt-get install -y --no-install-recommends python3 python3-pip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN dotnet tool install --tool-path /usr/local/bin sourcelink

--- a/ci/scripts/csharp_test.sh
+++ b/ci/scripts/csharp_test.sh
@@ -21,6 +21,17 @@ set -ex
 
 source_dir=${1}/csharp
 
+# Python and PyArrow are required for C Data Interface tests.
+if [ -z "${PYTHON}" ]; then
+  if type python3 > /dev/null 2>&1; then
+    export PYTHON=python3
+  else
+    export PYTHON=python
+  fi
+fi
+${PYTHON} -m pip install pyarrow find-libpython
+export PYTHONNET_PYDLL=$(${PYTHON} -m find_libpython)
+
 pushd ${source_dir}
 dotnet test
 for pdb in artifacts/Apache.Arrow/*/*/Apache.Arrow.pdb; do

--- a/ci/scripts/csharp_test.sh
+++ b/ci/scripts/csharp_test.sh
@@ -21,17 +21,6 @@ set -ex
 
 source_dir=${1}/csharp
 
-# Python and PyArrow are required for C Data Interface tests.
-if [ -z "${PYTHON}" ]; then
-  if type python3 > /dev/null 2>&1; then
-    export PYTHON=python3
-  else
-    export PYTHON=python
-  fi 
-fi
-${PYTHON} -m pip install pyarrow find-libpython
-export PYTHONNET_PYDLL=$(${PYTHON} -m find_libpython)
-
 pushd ${source_dir}
 dotnet test
 for pdb in artifacts/Apache.Arrow/*/*/Apache.Arrow.pdb; do


### PR DESCRIPTION
### Rationale for this change

Fix the nuget CI nightly packaging failure.

### What changes are included in this PR?

Install python on ubuntu-csharp docker image

### Are these changes tested?

Tested on CI via archery

### Are there any user-facing changes?

No
* Closes: #35029