### PR TITLE
MINOR: [C++] io_util.cc: fix for macOS without MACH_TASK_BASIC_INFO

### DIFF
--- a/cpp/src/arrow/util/io_util.cc
+++ b/cpp/src/arrow/util/io_util.cc
@@ -2139,6 +2139,7 @@ int64_t GetCurrentRSS() {
 
 #elif defined(__APPLE__)
   // OSX ------------------------------------------------------
+  #ifdef MACH_TASK_BASIC_INFO
   struct mach_task_basic_info info;
   mach_msg_type_number_t infoCount = MACH_TASK_BASIC_INFO_COUNT;
   if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO, (task_info_t)&info, &infoCount) !=
@@ -2146,6 +2147,14 @@ int64_t GetCurrentRSS() {
     ARROW_LOG(WARNING) << "Can't resolve RSS value";
     return 0;
   }
+  #else
+  struct task_basic_info info;
+  mach_msg_type_number_t infoCount = TASK_BASIC_INFO_COUNT;
+  if (task_info(mach_task_self(), TASK_BASIC_INFO, (task_info_t)&info, &infoCount) != KERN_SUCCESS) {
+    ARROW_LOG(WARNING) << "Can't resolve RSS value";
+    return 0;
+  }
+  #endif
   return static_cast<int64_t>(info.resident_size);
 
 #elif defined(__linux__)

--- a/cpp/src/arrow/util/io_util.cc
+++ b/cpp/src/arrow/util/io_util.cc
@@ -2138,8 +2138,8 @@ int64_t GetCurrentRSS() {
   return static_cast<int64_t>(info.WorkingSetSize);
 
 #elif defined(__APPLE__)
-  // OSX ------------------------------------------------------
-  #ifdef MACH_TASK_BASIC_INFO
+// OSX ------------------------------------------------------
+#ifdef MACH_TASK_BASIC_INFO
   struct mach_task_basic_info info;
   mach_msg_type_number_t infoCount = MACH_TASK_BASIC_INFO_COUNT;
   if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO, (task_info_t)&info, &infoCount) !=
@@ -2147,14 +2147,15 @@ int64_t GetCurrentRSS() {
     ARROW_LOG(WARNING) << "Can't resolve RSS value";
     return 0;
   }
-  #else
+#else
   struct task_basic_info info;
   mach_msg_type_number_t infoCount = TASK_BASIC_INFO_COUNT;
-  if (task_info(mach_task_self(), TASK_BASIC_INFO, (task_info_t)&info, &infoCount) != KERN_SUCCESS) {
+  if (task_info(mach_task_self(), TASK_BASIC_INFO, (task_info_t)&info, &infoCount) !=
+      KERN_SUCCESS) {
     ARROW_LOG(WARNING) << "Can't resolve RSS value";
     return 0;
   }
-  #endif
+#endif
   return static_cast<int64_t>(info.resident_size);
 
 #elif defined(__linux__)


### PR DESCRIPTION
Earlier macOS have no `MACH_TASK_BASIC_INFO`, but they have an equivalent `TASK_BASIC_INFO`. Use the latter as a fall back on Apple when the former is undefined. Fixes the build on earlier systems. Tested on macOS 10.6 (fixes the build), tested on the latest macOS (i.e. the patch does not break anything and works as supposed to).

We use a similar patch for `folly` and elsewhere: https://github.com/macports/macports-ports/blob/eaa29a4816054657e65d001562d7f77ba5157e40/devel/folly/files/patch-older-systems.diff#L232-L251