### PR TITLE
GH-34907: [Docs][R] Version selector reports that release version is dev

### DIFF
--- a/r/pkgdown/assets/versions.json
+++ b/r/pkgdown/assets/versions.json
@@ -5,7 +5,7 @@
     },
     {
         "name": "11.0.0.3 (release)",
-        "version": "/"
+        "version": ""
     },
     {
         "name": "10.0.1",

--- a/r/pkgdown/assets/versions.json
+++ b/r/pkgdown/assets/versions.json
@@ -4,8 +4,8 @@
         "version": "dev/"
     },
     {
-        "name": "11.0.0 (release)",
-        "version": ""
+        "name": "11.0.0.3 (release)",
+        "version": "11.0/"
     },
     {
         "name": "10.0.1",

--- a/r/pkgdown/assets/versions.json
+++ b/r/pkgdown/assets/versions.json
@@ -5,7 +5,7 @@
     },
     {
         "name": "11.0.0.3 (release)",
-        "version": "11.0/"
+        "version": "/"
     },
     {
         "name": "10.0.1",

--- a/r/pkgdown/extra.js
+++ b/r/pkgdown/extra.js
@@ -118,7 +118,7 @@ $(window).bind("pageshow", function(event) {
         // Load JSON file mapping between docs version and R package version
         $.getJSON("https://arrow.apache.org/docs/r/versions.json", function( data ) {
           // get the current page's version number:
-    		  var displayed_version = $('.version').text();
+    		  var displayed_version = $('.version').innerText;
     		  // Create a dropdown selector and add the appropriate attributes
           const sel = document.createElement("select");
           sel.name = "version-selector";


### PR DESCRIPTION
This PR updates the version number, which was missed in the CRAN release.
* Closes: #34907