### PR TITLE
GH-35060: [C#][CI] Update dotnet download link regex

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -366,8 +366,8 @@ install_csharp() {
     local dotnet_download_thank_you_url=https://dotnet.microsoft.com/download/thank-you/dotnet-sdk-${dotnet_version}-${dotnet_platform}-x64-binaries
     local dotnet_download_url=$( \
       curl -sL ${dotnet_download_thank_you_url} | \
-        grep 'window\.open' | \
-        grep -E -o '[^"]+' | \
+        grep 'directLink' | \
+        grep -E -o 'https://download[^"]+' | \
         sed -n 2p)
     mkdir -p ${csharp_bin}
     curl -sL ${dotnet_download_url} | \


### PR DESCRIPTION
The download page changed and the existing regex was not correctly catching the link. This seems overall pretty brittle but it seems there is no better way to download the file directly.
* Closes: #35060