### PR TITLE
GH-35067: [JavaScript] toString for signed `BigNum`s

### DIFF
--- a/js/gulp/test-task.js
+++ b/js/gulp/test-task.js
@@ -41,6 +41,7 @@ const testFiles = [
     `test/unit/`,
     // `test/unit/bit-tests.ts`,
     // `test/unit/int-tests.ts`,
+    // `test/unit/bn-tests.ts`,
     // `test/unit/math-tests.ts`,
     // `test/unit/table-tests.ts`,
     // `test/unit/generated-data-tests.ts`,

--- a/js/src/util/bn.ts
+++ b/js/src/util/bn.ts
@@ -102,7 +102,7 @@ export const bigNumToString: { <T extends BN<BigNumArray>>(a: T): string } = (<T
         return unsignedBigNumToString(a);
     }
 
-    const array = new Uint16Array(a.buffer, a.byteOffset, a.byteLength / 2);
+    let array = new Uint16Array(a.buffer, a.byteOffset, a.byteLength / 2);
 
     // detect positive numbers
     const highOrderWord = new Int16Array([array[array.length - 1]])[0];
@@ -111,6 +111,7 @@ export const bigNumToString: { <T extends BN<BigNumArray>>(a: T): string } = (<T
     }
 
     // flip the negative value
+    array = array.slice();
     let carry = 1;
     for (let i = 0; i < array.length; i++) {
         const elem = array[i];

--- a/js/src/util/bn.ts
+++ b/js/src/util/bn.ts
@@ -97,7 +97,30 @@ export const bigNumToString: { <T extends BN<BigNumArray>>(a: T): string } = (<T
         return `${bigIntArray[0]}`;
     }
 
-    return unsignedBigNumToString(a);
+    // unsigned numbers
+    if (!a.signed) {
+        return unsignedBigNumToString(a);
+    }
+
+    const array = new Uint16Array(a.buffer, a.byteOffset, a.byteLength / 2);
+
+    // detect positive numbers
+    const highOrderWord = new Int16Array([array[array.length - 1]])[0];
+    if (highOrderWord >= 0) {
+        return unsignedBigNumToString(a);
+    }
+
+    // flip the negative value
+    let carry = 1;
+    for (let i = 0; i < array.length; i++) {
+        const elem = array[i];
+        const updated = ~elem + carry;
+        array.set([updated], i);
+        carry &= elem === 0 ? 1 : 0;
+    }
+
+    const negated = unsignedBigNumToString(<any>array);
+    return `-${negated}`;
 });
 
 /** @ignore */

--- a/js/src/util/bn.ts
+++ b/js/src/util/bn.ts
@@ -36,17 +36,17 @@ function BigNum(this: any, x: any, ...xs: any) {
 }
 
 BigNum.prototype[isArrowBigNumSymbol] = true;
-BigNum.prototype.toJSON = function <T extends BN<BigNumArray>>(this: T) { return `"${bignumToString(this)}"`; };
-BigNum.prototype.valueOf = function <T extends BN<BigNumArray>>(this: T) { return bignumToNumber(this); };
-BigNum.prototype.toString = function <T extends BN<BigNumArray>>(this: T) { return bignumToString(this); };
+BigNum.prototype.toJSON = function <T extends BN<BigNumArray>>(this: T) { return `"${bigNumToString(this)}"`; };
+BigNum.prototype.valueOf = function <T extends BN<BigNumArray>>(this: T) { return bigNumToNumber(this); };
+BigNum.prototype.toString = function <T extends BN<BigNumArray>>(this: T) { return bigNumToString(this); };
 BigNum.prototype[Symbol.toPrimitive] = function <T extends BN<BigNumArray>>(this: T, hint: 'string' | 'number' | 'default' = 'default') {
     switch (hint) {
-        case 'number': return bignumToNumber(this);
-        case 'string': return bignumToString(this);
-        case 'default': return bignumToBigInt(this);
+        case 'number': return bigNumToNumber(this);
+        case 'string': return bigNumToString(this);
+        case 'default': return bigNumToBigInt(this);
     }
     // @ts-ignore
-    return bignumToString(this);
+    return bigNumToString(this);
 };
 
 /** @ignore */
@@ -70,7 +70,7 @@ Object.assign(UnsignedBigNum.prototype, BigNum.prototype, { 'constructor': Unsig
 Object.assign(DecimalBigNum.prototype, BigNum.prototype, { 'constructor': DecimalBigNum, 'signed': true, 'TypedArray': Uint32Array, 'BigIntArray': BigUint64Array });
 
 /** @ignore */
-function bignumToNumber<T extends BN<BigNumArray>>(bn: T) {
+function bigNumToNumber<T extends BN<BigNumArray>>(bn: T) {
     const { buffer, byteOffset, length, 'signed': signed } = bn;
     const words = new BigUint64Array(buffer, byteOffset, length);
     const negative = signed && words[words.length - 1] & (BigInt(1) << BigInt(63));
@@ -90,12 +90,28 @@ function bignumToNumber<T extends BN<BigNumArray>>(bn: T) {
 }
 
 /** @ignore */
-export const bignumToString: { <T extends BN<BigNumArray>>(a: T): string } = (<T extends BN<BigNumArray>>(a: T) => a.byteLength === 8 ? `${new a['BigIntArray'](a.buffer, a.byteOffset, 1)[0]}` : decimalToString(a));
-/** @ignore */
-export const bignumToBigInt: { <T extends BN<BigNumArray>>(a: T): bigint } = (<T extends BN<BigNumArray>>(a: T) => a.byteLength === 8 ? new a['BigIntArray'](a.buffer, a.byteOffset, 1)[0] : <any>decimalToString(a));
+export const bigNumToString: { <T extends BN<BigNumArray>>(a: T): string } = (<T extends BN<BigNumArray>>(a: T) => {
+    // use BigInt native implementation
+    if (a.byteLength === 8) {
+        const bigIntArray = new a['BigIntArray'](a.buffer, a.byteOffset, 1);
+        return `${bigIntArray[0]}`;
+    }
+
+    return unsignedBigNumToString(a);
+});
 
 /** @ignore */
-function decimalToString<T extends BN<BigNumArray>>(a: T) {
+export const bigNumToBigInt: { <T extends BN<BigNumArray>>(a: T): bigint } = (<T extends BN<BigNumArray>>(a: T) => {
+    if (a.byteLength === 8) {
+        const bigIntArray = new a['BigIntArray'](a.buffer, a.byteOffset, 1);
+        return bigIntArray[0];
+    } else {
+        return <any>bigNumToString(a);
+    }
+});
+
+/** @ignore */
+function unsignedBigNumToString<T extends BN<BigNumArray>>(a: T) {
     let digits = '';
     const base64 = new Uint32Array(2);
     let base32 = new Uint16Array(a.buffer, a.byteOffset, a.byteLength / 2);

--- a/js/src/util/bn.ts
+++ b/js/src/util/bn.ts
@@ -98,7 +98,7 @@ export const bigNumToString: { <T extends BN<BigNumArray>>(a: T): string } = (<T
     }
 
     // unsigned numbers
-    if (!a.signed) {
+    if (!a['signed']) {
         return unsignedBigNumToString(a);
     }
 

--- a/js/src/util/bn.ts
+++ b/js/src/util/bn.ts
@@ -116,7 +116,7 @@ export const bigNumToString: { <T extends BN<BigNumArray>>(a: T): string } = (<T
     for (let i = 0; i < array.length; i++) {
         const elem = array[i];
         const updated = ~elem + carry;
-        array.set([updated], i);
+        array[i] = updated;
         carry &= elem === 0 ? 1 : 0;
     }
 

--- a/js/test/unit/bn-tests.ts
+++ b/js/test/unit/bn-tests.ts
@@ -42,6 +42,12 @@ describe(`BN`, () => {
 
         const i3 = new BN(new Int32Array([0x11111111, 0x11111111, 0x11111111]), true);
         expect(i3.toString()).toBe('5281877500950955839569596689');
+
+        const i4 = new BN(new Int16Array([0xFFFF, 0xFFFF]), true);
+        expect(i4.toString()).toBe('-1');
+
+        const i5 = new BN(new Int32Array([0xFFFFFFFE, 0xFFFFFFFF, 0xFFFFFFFF]), true);
+        expect(i5.toString()).toBe('-2');
     });
 
     test(`toString for unsigned numbers`, () => {
@@ -51,10 +57,21 @@ describe(`BN`, () => {
         const u2 = new BN(new Uint32Array([0xFFFFFFFF, 0xFFFFFFFF]), false);
         expect(u2.toString()).toBe('18446744073709551615');
 
-        const u3 = new BN(new Uint32Array([0x11111111, 0x11111111, 0x11111111]), true);
+        const u3 = new BN(new Uint32Array([0x11111111, 0x11111111, 0x11111111]), false);
         expect(u3.toString()).toBe('5281877500950955839569596689');
 
         const u4 = new BN(new Uint16Array([0xFFFF, 0xFFFF]), false);
         expect(u4.toString()).toBe('4294967295');
+    });
+
+    test(`toString for decimals`, () => {
+        const d1 = BN.decimal(new Uint16Array([1, 2, 3, 4, 5, 6, 7, 8]));
+        expect(d1.toString()).toBe('41538929472669868031141181829283841');
+
+        const d2 = BN.decimal(new Uint32Array([0xFFFFFFFE, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF]));
+        expect(d2.toString()).toBe('-2');
+
+        const d3 = BN.decimal(new Uint32Array([0x00000000, 0x00000000, 0x00000000, 0x80000000]));
+        expect(d3.toString()).toBe('-170141183460469231731687303715884105728');
     });
 });

--- a/js/test/unit/bn-tests.ts
+++ b/js/test/unit/bn-tests.ts
@@ -73,5 +73,8 @@ describe(`BN`, () => {
 
         const d3 = BN.decimal(new Uint32Array([0x00000000, 0x00000000, 0x00000000, 0x80000000]));
         expect(d3.toString()).toBe('-170141183460469231731687303715884105728');
+
+        const d4 = BN.decimal(new Uint32Array([0x9D91E773, 0x4BB90CED, 0xAB2354CC, 0x54278E9B]));
+        expect(d4.toString()).toBe('111860543658909349380118287427608635251');
     });
 });

--- a/js/test/unit/bn-tests.ts
+++ b/js/test/unit/bn-tests.ts
@@ -65,16 +65,22 @@ describe(`BN`, () => {
     });
 
     test(`toString for decimals`, () => {
-        const d1 = BN.decimal(new Uint16Array([1, 2, 3, 4, 5, 6, 7, 8]));
-        expect(d1.toString()).toBe('41538929472669868031141181829283841');
+        const toDecimal = (val: Uint32Array) => {
+            const builder = Arrow.makeBuilder({
+                type: new Arrow.Decimal(128, 0),
+                nullValues: []
+            });
+            builder.append(val);
+            return <Arrow.Type.Decimal><any>builder.finish().toVector().get(0);
+        };
 
-        const d2 = BN.decimal(new Uint32Array([0xFFFFFFFE, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF]));
+        const d2 = toDecimal(new Uint32Array([0xFFFFFFFE, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF]));
         expect(d2.toString()).toBe('-2');
 
-        const d3 = BN.decimal(new Uint32Array([0x00000000, 0x00000000, 0x00000000, 0x80000000]));
+        const d3 = toDecimal(new Uint32Array([0x00000000, 0x00000000, 0x00000000, 0x80000000]));
         expect(d3.toString()).toBe('-170141183460469231731687303715884105728');
 
-        const d4 = BN.decimal(new Uint32Array([0x9D91E773, 0x4BB90CED, 0xAB2354CC, 0x54278E9B]));
+        const d4 = toDecimal(new Uint32Array([0x9D91E773, 0x4BB90CED, 0xAB2354CC, 0x54278E9B]));
         expect(d4.toString()).toBe('111860543658909349380118287427608635251');
     });
 });

--- a/js/test/unit/bn-tests.ts
+++ b/js/test/unit/bn-tests.ts
@@ -1,0 +1,60 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import * as Arrow from 'apache-arrow';
+const { BN } = Arrow.util;
+
+describe(`BN`, () => {
+    test(`to detect signed numbers, unsigned numbers and decimals`, () => {
+        // SignedBigNum
+        const i = new BN(new Int32Array([5, 0]));
+        expect(i.signed).toBe(true);
+
+        // UnsignedBigNum
+        const u = new BN(new Uint32Array([5, 0]));
+        expect(u.signed).toBe(false);
+
+        // DecimalBigNum
+        const d = new BN(new Uint16Array([1, 2, 3, 4, 5, 6, 7, 8]));
+        expect(d.signed).toBe(true);
+    });
+
+    test(`toString for signed numbers`, () => {
+        const i1 = new BN(new Int32Array([5, 33]), true);
+        expect(i1.toString()).toBe('141733920773');
+
+        const i2 = new BN(new Int32Array([0xFFFFFFFF, 0xFFFFFFFF]), true);
+        expect(i2.toString()).toBe('-1');
+
+        const i3 = new BN(new Int32Array([0x11111111, 0x11111111, 0x11111111]), true);
+        expect(i3.toString()).toBe('5281877500950955839569596689');
+    });
+
+    test(`toString for unsigned numbers`, () => {
+        const u1 = new BN(new Uint32Array([5, 33]), false);
+        expect(u1.toString()).toBe('141733920773');
+
+        const u2 = new BN(new Uint32Array([0xFFFFFFFF, 0xFFFFFFFF]), false);
+        expect(u2.toString()).toBe('18446744073709551615');
+
+        const u3 = new BN(new Uint32Array([0x11111111, 0x11111111, 0x11111111]), true);
+        expect(u3.toString()).toBe('5281877500950955839569596689');
+
+        const u4 = new BN(new Uint16Array([0xFFFF, 0xFFFF]), false);
+        expect(u4.toString()).toBe('4294967295');
+    });
+});


### PR DESCRIPTION
### What changes are included in this PR?

Closes apache/arrow#22932

Basically, signed negative numbers were displayed as very large positive numbers.

### Are these changes tested?

Yes, I've also added tests for `bn.ts` (BigNum) that was not tested before.

### Are there any user-facing changes?

Negative numbers stored in BigNum will now be displayed as negative numbers instead of very large positive numbers.

Note that this change also affects decimals, because they are stored in BigNum as signed numbers. Decimals still don't convert to string correctly, because inserting the decimal dot is not implemented. Ref apache/arrow-js#100.
* Closes: apache/arrow#35067
* GitHub Issue: #35067