### PR TITLE
GH-35069: [Archery][Release] Remove retrieving ARROW issue from migration comment on Archery release

### DIFF
--- a/dev/archery/archery/release/core.py
+++ b/dev/archery/archery/release/core.py
@@ -67,12 +67,6 @@ class Version(SemVer):
         )
 
 
-ORIGINAL_ARROW_REGEX = re.compile(
-    r"\*This issue was originally created as " +
-    r"\[(?P<issue>ARROW\-(?P<issue_id>(\d+)))\]"
-)
-
-
 class Issue:
 
     def __init__(self, key, type, summary, github_issue=None):
@@ -92,10 +86,8 @@ class Issue:
 
     @classmethod
     def from_github(cls, github_issue):
-        original_jira = cls.original_jira_id(github_issue)
-        key = original_jira or github_issue.number
         return cls(
-            key=key,
+            key=github_issue.number,
             type=next(
                 iter(
                     [
@@ -123,16 +115,6 @@ class Issue:
     @cached_property
     def is_pr(self):
         return bool(self._github_issue and self._github_issue.pull_request)
-
-    @classmethod
-    def original_jira_id(cls, github_issue):
-        # All migrated issues contain body
-        if not github_issue.body:
-            return None
-        matches = ORIGINAL_ARROW_REGEX.search(github_issue.body)
-        if matches:
-            values = matches.groupdict()
-            return values['issue']
 
 
 class Jira(JIRA):


### PR DESCRIPTION
### Rationale for this change
This is not required anymore because even when the issue was originally created on JIRA the PR has been merged referring to GH.

### What changes are included in this PR?

Remove retrieving for release curate and release notes the original `ARROW-` prefix issue id for JIRA and use the new `GH-` issue id.

### Are these changes tested?

I have tested it locally.

### Are there any user-facing changes?
No
* Closes: #35069