### PR TITLE
GH-34539: [C++] Fix throttled scheduler to avoid stack overflow in dataset writer

### DIFF
--- a/cpp/src/arrow/util/async_util_test.cc
+++ b/cpp/src/arrow/util/async_util_test.cc
@@ -598,7 +598,7 @@ TEST(AsyncTaskScheduler, ScanningStress) {
 
 TEST(AsyncTaskScheduler, ThrottleStress) {
   // Queue up a bunch of throttled fast tasks. It shouldn't cause stack overflow
-  constexpr int kNumTasks = 1024 * 1024;
+  constexpr int kNumTasks = 1024 * 10;
   int num_tasks_run = 0;
   Future<> slow_task = Future<>::Make();
   Future<> finished = AsyncTaskScheduler::Make([&](AsyncTaskScheduler* scheduler) {

--- a/cpp/src/arrow/util/async_util_test.cc
+++ b/cpp/src/arrow/util/async_util_test.cc
@@ -595,6 +595,30 @@ TEST(AsyncTaskScheduler, ScanningStress) {
     ASSERT_EQ(kExpectedBatchesScanned, batches_scanned.load());
   }
 }
+
+TEST(AsyncTaskScheduler, ThrottleStress) {
+  // Queue up a bunch of throttled fast tasks. It shouldn't cause stack overflow
+  constexpr int kNumTasks = 1024 * 1024;
+  int num_tasks_run = 0;
+  Future<> slow_task = Future<>::Make();
+  Future<> finished = AsyncTaskScheduler::Make([&](AsyncTaskScheduler* scheduler) {
+    std::shared_ptr<ThrottledAsyncTaskScheduler> throttled =
+        ThrottledAsyncTaskScheduler::Make(scheduler, 1);
+    EXPECT_TRUE(throttled->AddSimpleTask([slow_task] { return slow_task; }, kDummyName));
+    for (int task_idx = 0; task_idx < kNumTasks; task_idx++) {
+      throttled->AddSimpleTask(
+          [&] {
+            num_tasks_run++;
+            return Future<>::MakeFinished();
+          },
+          kDummyName);
+    }
+    return Status::OK();
+  });
+  slow_task.MarkFinished();
+  ASSERT_FINISHES_OK(finished);
+  ASSERT_EQ(kNumTasks, num_tasks_run);
+}
 #endif
 
 class TaskWithPriority : public AsyncTaskScheduler::Task {


### PR DESCRIPTION
### Rationale for this change

Fixes a bug in the throttled scheduler.

### What changes are included in this PR?

The throttled scheduler will no longer recurse in the ContinueTasks loop if the continued task was immediately finished.

### Are these changes tested?

Yes, I added a new stress test that exposed the stack overflow very reliably on a standard Linux system.

### Are there any user-facing changes?

No.
* Closes: #34539