### PR TITLE
GH-35062: [Go][CI] Fix verification failures

### DIFF
--- a/go/arrow/datatype_fixedwidth_test.go
+++ b/go/arrow/datatype_fixedwidth_test.go
@@ -262,7 +262,7 @@ func TestTime64Type(t *testing.T) {
 		{arrow.Microsecond, "22:10:15.123456", arrow.Time64((22*h + 10*m + 15*s + 123456*us).Microseconds()), false},
 		{arrow.Microsecond, "12:34:56.78901234", arrow.Time64(0), true},
 		{arrow.Nanosecond, "12:34:56.78901234", arrow.Time64(12*h + 34*m + 56*s + 789012340), false},
-		{arrow.Nanosecond, "12:34:56.1234567890", arrow.Time64(0), true},
+		{arrow.Nanosecond, "12:34:56.1234567899", arrow.Time64(0), true},
 	} {
 		t.Run("FromString", func(t *testing.T) {
 			v, e := arrow.Time64FromString(tc.str, tc.unit)

--- a/go/arrow/datatype_fixedwidth_test.go
+++ b/go/arrow/datatype_fixedwidth_test.go
@@ -262,7 +262,7 @@ func TestTime64Type(t *testing.T) {
 		{arrow.Microsecond, "22:10:15.123456", arrow.Time64((22*h + 10*m + 15*s + 123456*us).Microseconds()), false},
 		{arrow.Microsecond, "12:34:56.78901234", arrow.Time64(0), true},
 		{arrow.Nanosecond, "12:34:56.78901234", arrow.Time64(12*h + 34*m + 56*s + 789012340), false},
-		{arrow.Nanosecond, "12:34:56.1234567899", arrow.Time64(0), true},
+		{arrow.Nanosecond, "12:34:56.123456789 9", arrow.Time64(0), true},
 	} {
 		t.Run("FromString", func(t *testing.T) {
 			v, e := arrow.Time64FromString(tc.str, tc.unit)

--- a/go/arrow/flight/flightsql/driver/driver.go
+++ b/go/arrow/flight/flightsql/driver/driver.go
@@ -246,6 +246,9 @@ func (s *Stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driv
 
 		}
 		if err := reader.Err(); err != nil {
+			if err == io.EOF {
+				break
+			}
 			return &rows, err
 		}
 	}

--- a/go/arrow/memory/default_allocator.go
+++ b/go/arrow/memory/default_allocator.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !mallocator
+//go:build !mallocator || !cgo
 
 package memory
 

--- a/go/arrow/memory/default_mallocator.go
+++ b/go/arrow/memory/default_mallocator.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build mallocator
+//go:build mallocator && cgo
 
 package memory
 

--- a/go/arrow/memory/default_mallocator_test.go
+++ b/go/arrow/memory/default_mallocator_test.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build mallocator
+//go:build mallocator && cgo
 
 package memory_test
 

--- a/go/arrow/memory/mallocator/doc.go
+++ b/go/arrow/memory/mallocator/doc.go
@@ -1,0 +1,21 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package mallocator defines an allocator implementation for
+// memory.Allocator which defers to libc malloc. It requires
+// usage of CGO.
+package mallocator

--- a/go/arrow/memory/mallocator/mallocator_test.go
+++ b/go/arrow/memory/mallocator/mallocator_test.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build cgo
+
 package mallocator_test
 
 import (


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
In the conda release verification we saw an error failure due to "build constraints exclude all files" in the `memory/mallocator` directory. This is easily fixed by adding a `doc.go` file with a package documentation and no build constraint on it to the directory. While here, to ensure everything is handled correctly, the `cgo` constraint was added to the default `mallocator` tagged files (and `!cgo` to the defaults) so that it's explicit rather than implicit (by virtue of importing mallocator which requires cgo).

This should, hopefully, also fix the other macos verification failure by ensuring the Time64 nanosecond parsing test doesn't just drop the extraneous 0.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are there any user-facing changes?
There shouldn't be.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #35062