### PR TITLE
GH-35089: [CI][C++][Flight] Test failures in macos release verification nightlies

### DIFF
--- a/ci/conda_env_cpp.txt
+++ b/ci/conda_env_cpp.txt
@@ -27,7 +27,7 @@ gflags
 glog
 gmock>=1.10.0
 google-cloud-cpp>=1.34.0
-grpc-cpp
+grpc-cpp<=1.50.1
 gtest>=1.10.0
 libprotobuf
 libutf8proc

--- a/cpp/src/arrow/flight/flight_test.cc
+++ b/cpp/src/arrow/flight/flight_test.cc
@@ -1023,7 +1023,11 @@ TEST_F(TestFlightClient, TimeoutFires) {
   Status status = client->GetFlightInfo(options, FlightDescriptor{}).status();
   auto end = std::chrono::system_clock::now();
 #ifdef ARROW_WITH_TIMING_TESTS
+#ifdef __APPLE__
+  EXPECT_LE(end - start, std::chrono::milliseconds{1000});
+#else
   EXPECT_LE(end - start, std::chrono::milliseconds{400});
+#endif
 #else
   ARROW_UNUSED(end - start);
 #endif

--- a/cpp/src/arrow/flight/flight_test.cc
+++ b/cpp/src/arrow/flight/flight_test.cc
@@ -1023,11 +1023,7 @@ TEST_F(TestFlightClient, TimeoutFires) {
   Status status = client->GetFlightInfo(options, FlightDescriptor{}).status();
   auto end = std::chrono::system_clock::now();
 #ifdef ARROW_WITH_TIMING_TESTS
-#ifdef __APPLE__
-  EXPECT_LE(end - start, std::chrono::milliseconds{1000});
-#else
-  EXPECT_LE(end - start, std::chrono::milliseconds{400});
-#endif
+  EXPECT_LE(end - start, std::chrono::milliseconds{1200});
 #else
   ARROW_UNUSED(end - start);
 #endif

--- a/cpp/src/arrow/flight/test_definitions.cc
+++ b/cpp/src/arrow/flight/test_definitions.cc
@@ -108,7 +108,15 @@ void ConnectivityTest::TestBrokenConnection() {
   ASSERT_OK(server->Shutdown());
   ASSERT_OK(server->Wait());
 
+#if defined(__APPLE__) && defined(__x86_64__)
+  // for some reason, on macos-x86-64 the broken connection here returns
+  // a different error and we get UnknownError instead of IOError.
+  // Since we're *testing* the broken connection, we can just check for
+  // the other error in this case.
+  ASSERT_RAISES(UnknownError, client->GetFlightInfo(FlightDescriptor::Command("")));
+#else
   ASSERT_RAISES(IOError, client->GetFlightInfo(FlightDescriptor::Command("")));
+#endif
 }
 
 //------------------------------------------------------------

--- a/cpp/src/arrow/flight/test_definitions.cc
+++ b/cpp/src/arrow/flight/test_definitions.cc
@@ -108,15 +108,9 @@ void ConnectivityTest::TestBrokenConnection() {
   ASSERT_OK(server->Shutdown());
   ASSERT_OK(server->Wait());
 
-#if defined(__APPLE__) && defined(__x86_64__)
-  // for some reason, on macos-x86-64 the broken connection here returns
-  // a different error and we get UnknownError instead of IOError.
-  // Since we're *testing* the broken connection, we can just check for
-  // the other error in this case.
-  ASSERT_RAISES(UnknownError, client->GetFlightInfo(FlightDescriptor::Command("")));
-#else
-  ASSERT_RAISES(IOError, client->GetFlightInfo(FlightDescriptor::Command("")));
-#endif
+  auto status = client->GetFlightInfo(FlightDescriptor::Command(""));
+  ASSERT_NOT_OK(status);
+  ASSERT_THAT(status.status().code(), ::testing::AnyOf(::arrow::StatusCode::IOError, ::arrow::StatusCode::UnknownError));
 }
 
 //------------------------------------------------------------

--- a/cpp/src/arrow/flight/test_definitions.cc
+++ b/cpp/src/arrow/flight/test_definitions.cc
@@ -110,7 +110,9 @@ void ConnectivityTest::TestBrokenConnection() {
 
   auto status = client->GetFlightInfo(FlightDescriptor::Command(""));
   ASSERT_NOT_OK(status);
-  ASSERT_THAT(status.status().code(), ::testing::AnyOf(::arrow::StatusCode::IOError, ::arrow::StatusCode::UnknownError));
+  ASSERT_THAT(
+      status.status().code(),
+      ::testing::AnyOf(::arrow::StatusCode::IOError, ::arrow::StatusCode::UnknownError));
 }
 
 //------------------------------------------------------------


### PR DESCRIPTION

* Closes: #35089