### PR TITLE
GH-35063: [CI] Fix Python requirement in C# tests

### DIFF
--- a/ci/docker/ubuntu-22.04-csharp.dockerfile
+++ b/ci/docker/ubuntu-22.04-csharp.dockerfile
@@ -21,7 +21,7 @@ ARG platform=jammy
 FROM mcr.microsoft.com/dotnet/sdk:${dotnet}-${platform}-${arch}
 
 RUN apt-get update -y -q && \
-    apt-get install -y --no-install-recommends python3 python3-pip && \
+    apt-get install -y python3 python3-pip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/csharp/test/Apache.Arrow.Tests/CDataInterfacePythonTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/CDataInterfacePythonTests.cs
@@ -30,9 +30,18 @@ namespace Apache.Arrow.Tests
         public CDataSchemaPythonTest()
         {
             bool inCIJob = Environment.GetEnvironmentVariable("GITHUB_ACTIONS") == "true";
+            bool inVerificationJob = Environment.GetEnvironmentVariable("TEST_CSHARP") == "1";
             bool pythonSet = Environment.GetEnvironmentVariable("PYTHONNET_PYDLL") != null;
             // We only skip if this is not in CI
-            Skip.If(!pythonSet && !inCIJob, "PYTHONNET_PYDLL not set; skipping C Data Interface tests.");
+            if (inCIJob && !inVerificationJob && !pythonSet)
+            {
+                throw new Exception("PYTHONNET_PYDLL not set; skipping C Data Interface tests.");
+            }
+            else
+            {
+                Skip.If(!pythonSet, "PYTHONNET_PYDLL not set; skipping C Data Interface tests.");
+            }
+
 
             PythonEngine.Initialize();
 


### PR DESCRIPTION
### Rationale for this change

We need to install Python shared libraries in order to use them in C# tests.

We can also skip the tests in the verification script.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

* [x] Validate in crossbow jobs

### Are there any user-facing changes?

No, these are just for CI.
* Closes: #35063