### PR TITLE
GH-35086: [Java][CI] Upgrade CycloneDX Maven plugin version

### DIFF
--- a/ci/scripts/java_jni_macos_build.sh
+++ b/ci/scripts/java_jni_macos_build.sh
@@ -97,7 +97,7 @@ if [ "${ARROW_BUILD_TESTS}" == "ON" ]; then
   # MinIO is required
   exclude_tests="arrow-s3fs-test"
   # unstable
-  exclude_tests="${exclude_tests}|arrow-compute-hash-join-node-test"
+  exclude_tests="${exclude_tests}|arrow-acero-hash-join-node-test"
   ctest \
     --exclude-regex "${exclude_tests}" \
     --label-regex unittest \

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -358,7 +358,7 @@
       <plugin>
         <groupId>org.cyclonedx</groupId>
         <artifactId>cyclonedx-maven-plugin</artifactId>
-        <version>2.7.3</version>
+        <version>2.7.6</version>
         <executions>
           <execution>
             <phase>package</phase>


### PR DESCRIPTION
### Rationale for this change

CyctloneDX Maven plugin 2.7.3 doesn't work with recent Apache Maven.

### What changes are included in this PR?

It may fix the "UTF-8 BOM plus xml decl of ISO-8859-1 is incompatible" error.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #35086