### PR TITLE
GH-35097: [C++] ArrayData support for child_data slice.

### DIFF
--- a/cpp/src/arrow/array/array_struct_test.cc
+++ b/cpp/src/arrow/array/array_struct_test.cc
@@ -303,6 +303,17 @@ TEST(StructArray, FlattenOfSlice) {
   ASSERT_OK(arr->ValidateFull());
 }
 
+TEST(StructArray, ChildSlice) {
+  auto a = ArrayFromJSON(int32(), "[4, 5, 6, 7]");
+  auto type = struct_({field("a", int32())});
+  auto children = std::vector<std::shared_ptr<Array>>{a};
+  auto arr = std::make_shared<StructArray>(type, 4, children)->data();
+  auto slice_arr = arr->Slice(1, 2);
+  auto actual = MakeArray(slice_arr->child_data[0]);
+  AssertArraysEqual(*ArrayFromJSON(int32(), "[5, 6]"), *actual,
+                    /*verbose=*/true);
+}
+
 // ----------------------------------------------------------------------------------
 // Struct test
 class TestStructBuilder : public ::testing::Test {

--- a/cpp/src/arrow/array/data.cc
+++ b/cpp/src/arrow/array/data.cc
@@ -144,6 +144,8 @@ std::shared_ptr<ArrayData> ArrayData::Slice(int64_t off, int64_t len) const {
   } else {
     copy->null_count = null_count != 0 ? kUnknownNullCount : 0;
   }
+  for (auto& child : copy->child_data) 
+    child = child->Slice(copy->offset, copy->length);
   return copy;
 }
 


### PR DESCRIPTION
### Rationale for this change

issue: [35097](https://github.com/apache/arrow/issues/35097)

### What changes are included in this PR?

change data.cc, for ArrayData::Slice, add child_data logic.
change  array_struct_test.cc, add ChildSlice test.

### Are these changes tested?

yes! see array_struct_test.cc.


* Closes: #35097