### PR TITLE
GH-35078: [Python][CI] Tests on windows are running very slow

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -173,6 +173,8 @@ jobs:
           python -m pip install \
             -r python/requirements-build.txt \
             -r python/requirements-test.txt
+          python -m pip uninstall pytest
+          python -m pip install pytest==7.2
       - name: Build
         shell: bash
         run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -173,7 +173,7 @@ jobs:
           python -m pip install \
             -r python/requirements-build.txt \
             -r python/requirements-test.txt
-          python -m pip uninstall pytest
+          python -m pip uninstall pytest --yes
           python -m pip install pytest==7.2
       - name: Build
         shell: bash

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -173,8 +173,6 @@ jobs:
           python -m pip install \
             -r python/requirements-build.txt \
             -r python/requirements-test.txt
-          python -m pip uninstall pytest --yes
-          python -m pip install pytest==7.2
       - name: Build
         shell: bash
         run: |

--- a/ci/scripts/python_test.sh
+++ b/ci/scripts/python_test.sh
@@ -35,6 +35,9 @@ export PYTHONDEVMODE=1
 # Enable memory debug checks.
 export ARROW_DEBUG_MEMORY_POOL=trap
 
+# Retain directories only for tests with outcome error or failed
+export PYTEST_ADDOPTS="-o tmp_path_retention_policy=failed"
+
 # By default, force-test all optional components
 : ${PYARROW_TEST_ACERO:=${ARROW_ACERO:-ON}}
 : ${PYARROW_TEST_CUDA:=${ARROW_CUDA:-ON}}

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -30,6 +30,7 @@ filterwarnings =
     error:The SparseDataFrame:FutureWarning
 # Get a debug traceback when a test takes a really long time
 faulthandler_timeout = 300
+tmp_path_retention_policy = failed
 
 [pep8]
 ignore = E211,E225,E226,E227,E402,W503,W504


### PR DESCRIPTION
With [new release of pytest 7.3.0](https://docs.pytest.org/en/latest/changelog.html) the default value of `tmp_path_retention_policy` was changed from `failed` to `all`. With this PR we are testing if this change is the reason the tests on Windows are timing out.
* Closes: #35078