### PR TITLE
GH-35107: [FlightSQL]: Use `uint8` to refer to 8 bit unsigned integers rather than `uint1`

### DIFF
--- a/format/FlightSql.proto
+++ b/format/FlightSql.proto
@@ -1324,8 +1324,8 @@ enum UpdateDeleteRules {
  *  key_sequence: int not null,
  *  fk_key_name: utf8,
  *  pk_key_name: utf8,
- *  update_rule: uint1 not null,
- *  delete_rule: uint1 not null
+ *  update_rule: uint8 not null,
+ *  delete_rule: uint8 not null
  * >
  * The returned data should be ordered by fk_catalog_name, fk_db_schema_name, fk_table_name, fk_key_name, then key_sequence.
  * update_rule and delete_rule returns a byte that is equivalent to actions declared on UpdateDeleteRules enum.
@@ -1370,8 +1370,8 @@ message CommandGetExportedKeys {
  *  key_sequence: int not null,
  *  fk_key_name: utf8,
  *  pk_key_name: utf8,
- *  update_rule: uint1 not null,
- *  delete_rule: uint1 not null
+ *  update_rule: uint8 not null,
+ *  delete_rule: uint8 not null
  * >
  * The returned data should be ordered by pk_catalog_name, pk_db_schema_name, pk_table_name, pk_key_name, then key_sequence.
  * update_rule and delete_rule returns a byte that is equivalent to actions:
@@ -1423,8 +1423,8 @@ message CommandGetImportedKeys {
  *  key_sequence: int not null,
  *  fk_key_name: utf8,
  *  pk_key_name: utf8,
- *  update_rule: uint1 not null,
- *  delete_rule: uint1 not null
+ *  update_rule: uint8 not null,
+ *  delete_rule: uint8 not null
  * >
  * The returned data should be ordered by pk_catalog_name, pk_db_schema_name, pk_table_name, pk_key_name, then key_sequence.
  * update_rule and delete_rule returns a byte that is equivalent to actions:


### PR DESCRIPTION



<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

The spec is inconsistent -- see details on https://github.com/apache/arrow/issues/35107

### What changes are included in this PR?

Use `uint8` to refer to 8 bit unsigned integers rather than `uint1`

### Are these changes tested?
No, they are comment only changed

### Are there any user-facing changes?

This clarifies a small corner case in the document
* Closes: #35107