### PR TITLE
GH-35101: [C++] Update deprecated LOCATION target property in ArrowConfig.cmake.in

### DIFF
--- a/cpp/src/arrow/ArrowConfig.cmake.in
+++ b/cpp/src/arrow/ArrowConfig.cmake.in
@@ -96,21 +96,18 @@ include("${CMAKE_CURRENT_LIST_DIR}/ArrowTargets.cmake")
 
 if(TARGET Arrow::arrow_static AND NOT TARGET Arrow::arrow_bundled_dependencies)
   add_library(Arrow::arrow_bundled_dependencies STATIC IMPORTED)
-  get_target_property(arrow_static_debug_location Arrow::arrow_static
-                      IMPORTED_LOCATION_DEBUG)
-  get_filename_component(arrow_debug_lib_dir "${arrow_static_debug_location}" DIRECTORY)
-  set_target_properties(Arrow::arrow_bundled_dependencies
-                        PROPERTIES IMPORTED_LOCATION
-                                   "${arrow_debug_lib_dir}/${CMAKE_STATIC_LIBRARY_PREFIX}arrow_bundled_dependencies${CMAKE_STATIC_LIBRARY_SUFFIX}"
-  )
-  get_target_property(arrow_static_release_location Arrow::arrow_static
-                      IMPORTED_LOCATION_RELEASE)
-  get_filename_component(arrow_release_lib_dir "${arrow_static_release_location}"
-                         DIRECTORY)
-  set_target_properties(Arrow::arrow_bundled_dependencies
-                        PROPERTIES IMPORTED_LOCATION_RELEASE
-                                   "${arrow_release_lib_dir}/${CMAKE_STATIC_LIBRARY_PREFIX}arrow_bundled_dependencies${CMAKE_STATIC_LIBRARY_SUFFIX}"
-  )
+  get_target_property(arrow_static_configurations Arrow::arrow_static
+                      IMPORTED_CONFIGURATIONS)
+  foreach(CONFIGURATION ${arrow_static_configurations})
+    string(TOUPPER "${CONFIGURATION}" CONFIGURATION)
+    get_target_property(arrow_static_location Arrow::arrow_static
+                        LOCATION_${CONFIGURATION})
+    get_filename_component(arrow_lib_dir "${arrow_static_location}" DIRECTORY)
+    set_target_properties(Arrow::arrow_bundled_dependencies
+                          PROPERTIES IMPORTED_LOCATION_${CONFIGURATION}
+                                     "${arrow_lib_dir}/${CMAKE_STATIC_LIBRARY_PREFIX}arrow_bundled_dependencies${CMAKE_STATIC_LIBRARY_SUFFIX}"
+    )
+  endforeach()
 
   # CMP0057: Support new if() IN_LIST operator.
   # https://cmake.org/cmake/help/latest/policy/CMP0057.html

--- a/cpp/src/arrow/ArrowConfig.cmake.in
+++ b/cpp/src/arrow/ArrowConfig.cmake.in
@@ -96,14 +96,17 @@ include("${CMAKE_CURRENT_LIST_DIR}/ArrowTargets.cmake")
 
 if(TARGET Arrow::arrow_static AND NOT TARGET Arrow::arrow_bundled_dependencies)
   add_library(Arrow::arrow_bundled_dependencies STATIC IMPORTED)
-  get_target_property(arrow_static_debug_location Arrow::arrow_static IMPORTED_LOCATION_DEBUG)
+  get_target_property(arrow_static_debug_location Arrow::arrow_static
+                      IMPORTED_LOCATION_DEBUG)
   get_filename_component(arrow_debug_lib_dir "${arrow_static_debug_location}" DIRECTORY)
   set_target_properties(Arrow::arrow_bundled_dependencies
                         PROPERTIES IMPORTED_LOCATION
                                    "${arrow_debug_lib_dir}/${CMAKE_STATIC_LIBRARY_PREFIX}arrow_bundled_dependencies${CMAKE_STATIC_LIBRARY_SUFFIX}"
   )
-  get_target_property(arrow_static_release_location Arrow::arrow_static IMPORTED_LOCATION_RELEASE)
-  get_filename_component(arrow_release_lib_dir "${arrow_static_release_location}" DIRECTORY)
+  get_target_property(arrow_static_release_location Arrow::arrow_static
+                      IMPORTED_LOCATION_RELEASE)
+  get_filename_component(arrow_release_lib_dir "${arrow_static_release_location}"
+                         DIRECTORY)
   set_target_properties(Arrow::arrow_bundled_dependencies
                         PROPERTIES IMPORTED_LOCATION_RELEASE
                                    "${arrow_release_lib_dir}/${CMAKE_STATIC_LIBRARY_PREFIX}arrow_bundled_dependencies${CMAKE_STATIC_LIBRARY_SUFFIX}"

--- a/cpp/src/arrow/ArrowConfig.cmake.in
+++ b/cpp/src/arrow/ArrowConfig.cmake.in
@@ -96,11 +96,17 @@ include("${CMAKE_CURRENT_LIST_DIR}/ArrowTargets.cmake")
 
 if(TARGET Arrow::arrow_static AND NOT TARGET Arrow::arrow_bundled_dependencies)
   add_library(Arrow::arrow_bundled_dependencies STATIC IMPORTED)
-  get_target_property(arrow_static_location Arrow::arrow_static LOCATION)
-  get_filename_component(arrow_lib_dir "${arrow_static_location}" DIRECTORY)
+  get_target_property(arrow_static_debug_location Arrow::arrow_static IMPORTED_LOCATION_DEBUG)
+  get_filename_component(arrow_debug_lib_dir "${arrow_static_debug_location}" DIRECTORY)
   set_target_properties(Arrow::arrow_bundled_dependencies
                         PROPERTIES IMPORTED_LOCATION
-                                   "${arrow_lib_dir}/${CMAKE_STATIC_LIBRARY_PREFIX}arrow_bundled_dependencies${CMAKE_STATIC_LIBRARY_SUFFIX}"
+                                   "${arrow_debug_lib_dir}/${CMAKE_STATIC_LIBRARY_PREFIX}arrow_bundled_dependencies${CMAKE_STATIC_LIBRARY_SUFFIX}"
+  )
+  get_target_property(arrow_static_release_location Arrow::arrow_static IMPORTED_LOCATION_RELEASE)
+  get_filename_component(arrow_release_lib_dir "${arrow_static_release_location}" DIRECTORY)
+  set_target_properties(Arrow::arrow_bundled_dependencies
+                        PROPERTIES IMPORTED_LOCATION_RELEASE
+                                   "${arrow_release_lib_dir}/${CMAKE_STATIC_LIBRARY_PREFIX}arrow_bundled_dependencies${CMAKE_STATIC_LIBRARY_SUFFIX}"
   )
 
   # CMP0057: Support new if() IN_LIST operator.


### PR DESCRIPTION
### Rationale for this change

Issue: https://github.com/apache/arrow/issues/35101
Application in release mode is linked to the debug version `libarrow_bundled_dependencies.a` if Arrow is installed by vcpkg. As the deprecated `LOCATION` property in `ArrowConfig.cmake.in` always returns the debug lib's path. (https://cmake.org/cmake/help/latest/policy/CMP0026.html)

### What changes are included in this PR?

Use `IMPORTED_LOCATION_DEBUG` and `IMPORTED_LOCATION_DEBUG` to replace the deprecated `LOCATION` property in `ArrowConfig.cmake.in`.

### Are these changes tested?

It's a fix of vcpkg build.

### Are there any user-facing changes?
No
* Closes: #35101