### PR TITLE
GH-35118: [FlightSQL] Use `int32` to refer to 32-bit integers rather than `int`

### DIFF
--- a/format/FlightSql.proto
+++ b/format/FlightSql.proto
@@ -1271,7 +1271,7 @@ message CommandGetTableTypes {
  *  table_name: utf8 not null,
  *  column_name: utf8 not null,
  *  key_name: utf8,
- *  key_sequence: int not null
+ *  key_sequence: int32 not null
  * >
  * The returned data should be ordered by catalog_name, db_schema_name, table_name, key_name, then key_sequence.
  */
@@ -1321,7 +1321,7 @@ enum UpdateDeleteRules {
  *  fk_db_schema_name: utf8,
  *  fk_table_name: utf8 not null,
  *  fk_column_name: utf8 not null,
- *  key_sequence: int not null,
+ *  key_sequence: int32 not null,
  *  fk_key_name: utf8,
  *  pk_key_name: utf8,
  *  update_rule: uint1 not null,
@@ -1367,7 +1367,7 @@ message CommandGetExportedKeys {
  *  fk_db_schema_name: utf8,
  *  fk_table_name: utf8 not null,
  *  fk_column_name: utf8 not null,
- *  key_sequence: int not null,
+ *  key_sequence: int32 not null,
  *  fk_key_name: utf8,
  *  pk_key_name: utf8,
  *  update_rule: uint1 not null,
@@ -1420,7 +1420,7 @@ message CommandGetImportedKeys {
  *  fk_db_schema_name: utf8,
  *  fk_table_name: utf8 not null,
  *  fk_column_name: utf8 not null,
- *  key_sequence: int not null,
+ *  key_sequence: int32 not null,
  *  fk_key_name: utf8,
  *  pk_key_name: utf8,
  *  update_rule: uint1 not null,


### PR DESCRIPTION



<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

The spec is inconsistent -- see details on #35118 

### What changes are included in this PR?

Use `int32` to refer to 32-bit integers rather than `int`

### Are these changes tested?

No, only comments are changed

### Are there any user-facing changes?

This clarifies a small corner case in the document

* Closes: https://github.com/apache/arrow/issues/35118
* Closes: #35118