### PR TITLE
GH-35066: [CI][Packaging][Linux] Free more disk space

### DIFF
--- a/dev/tasks/linux-packages/github.linux.yml
+++ b/dev/tasks/linux-packages/github.linux.yml
@@ -38,10 +38,15 @@ jobs:
           env.ARCHITECTURE == 'amd64'
         run: |
           df -h
+          df -h /opt/hostedtoolcache || :
           # 5.3GB
           sudo rm -rf /opt/hostedtoolcache/CodeQL || :
           # 1.4GB
           sudo rm -rf /opt/hostedtoolcache/go || :
+          # 489MB
+          sudo rm -rf /opt/hostedtoolcache/PyPy || :
+          # 376MB
+          sudo rm -rf /opt/hostedtoolcache/node || :
           df -h
       - name: Set up Ruby
         run: |

--- a/dev/tasks/linux-packages/github.linux.yml
+++ b/dev/tasks/linux-packages/github.linux.yml
@@ -38,7 +38,7 @@ jobs:
           env.ARCHITECTURE == 'amd64'
         run: |
           df -h
-          df -h /opt/hostedtoolcache || :
+          du -hsc /opt/hostedtoolcache/*
           # 5.3GB
           sudo rm -rf /opt/hostedtoolcache/CodeQL || :
           # 1.4GB


### PR DESCRIPTION
### Rationale for this change

We don't have enough disk space to build ubuntu-jammy-amd64 and ubuntu-kinetic-amd64.

### What changes are included in this PR?

This just removes unused built-in files. This is just a workaround. Reducing build-time disk usage is a real fix. For example, we may be able to reduce binary size of our libraries.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #35066