### PR TITLE
GH-35059: [C++] Fix "hash_count" for run-end encoded inputs

### DIFF
--- a/cpp/src/arrow/acero/hash_aggregate_test.cc
+++ b/cpp/src/arrow/acero/hash_aggregate_test.cc
@@ -1361,46 +1361,83 @@ void SortBy(std::vector<std::string> names, Datum* aggregated_and_grouped) {
 }  // namespace
 
 TEST_P(GroupBy, CountOnly) {
-  for (bool use_threads : {true, false}) {
-    SCOPED_TRACE(use_threads ? "parallel/merged" : "serial");
+  const std::vector<std::string> json = {
+      // Test inputs ("argument", "key")
+      R"([[1.0,   1],
+          [null,  1]])",
+      R"([[0.0,   2],
+          [null,  3],
+          [4.0,   null],
+          [3.25,  1],
+          [0.125, 2]])",
+      R"([[-0.25, 2],
+          [0.75,  null],
+          [null,  3]])",
+  };
+  const auto skip_nulls = std::make_shared<CountOptions>(CountOptions::ONLY_VALID);
+  const auto only_nulls = std::make_shared<CountOptions>(CountOptions::ONLY_NULL);
+  const auto count_all = std::make_shared<CountOptions>(CountOptions::ALL);
+  const auto possible_count_options = std::vector<std::shared_ptr<CountOptions>>{
+      nullptr,  // default = skip_nulls
+      skip_nulls,
+      only_nulls,
+      count_all,
+  };
+  const auto expected_results = std::vector<std::string>{
+      // Results ("key_0", "hash_count")
+      // nullptr = skip_nulls
+      R"([[1, 2],
+          [2, 3],
+          [3, 0],
+          [null, 2]])",
+      // skip_nulls
+      R"([[1, 2],
+          [2, 3],
+          [3, 0],
+          [null, 2]])",
+      // only_nulls
+      R"([[1, 1],
+          [2, 0],
+          [3, 2],
+          [null, 0]])",
+      // count_all
+      R"([[1, 3],
+          [2, 3],
+          [3, 2],
+          [null, 2]])",
+  };
+  // NOTE: the "key" column (1) does not appear in the possible run-end
+  // encoding transformations because GroupBy kernels do not support run-end
+  // encoded key arrays.
+  for (const auto& re_encode_cols : std::vector<std::vector<int>>{{}}) {
+    for (bool use_threads : {/*true, */ false}) {
+      SCOPED_TRACE(use_threads ? "parallel/merged" : "serial");
+      for (size_t i = 0; i < possible_count_options.size(); i++) {
+        auto table = TableFromJSON(
+            schema({field("argument", float64()), field("key", int64())}), json);
 
-    auto table =
-        TableFromJSON(schema({field("argument", float64()), field("key", int64())}), {R"([
-    [1.0,   1],
-    [null,  1]
-                        ])",
-                                                                                      R"([
-    [0.0,   2],
-    [null,  3],
-    [4.0,   null],
-    [3.25,  1],
-    [0.125, 2]
-                        ])",
-                                                                                      R"([
-    [-0.25, 2],
-    [0.75,  null],
-    [null,  3]
-                        ])"});
+        auto transformed_table = table;
+        if (!re_encode_cols.empty()) {
+          ASSERT_OK_AND_ASSIGN(transformed_table,
+                               RunEndEncodeTableColumns(*table, re_encode_cols));
+        }
 
-    ASSERT_OK_AND_ASSIGN(
-        Datum aggregated_and_grouped,
-        GroupByTest({table->GetColumnByName("argument")}, {table->GetColumnByName("key")},
-                    {
-                        {"hash_count", nullptr},
-                    },
-                    use_threads));
-    SortBy({"key_0"}, &aggregated_and_grouped);
+        ASSERT_OK_AND_ASSIGN(Datum aggregated_and_grouped,
+                             GroupByTest({transformed_table->GetColumnByName("argument")},
+                                         {transformed_table->GetColumnByName("key")},
+                                         {
+                                             {"hash_count", possible_count_options[i]},
+                                         },
+                                         use_threads));
+        SortBy({"key_0"}, &aggregated_and_grouped);
 
-    AssertDatumsEqual(
-        ArrayFromJSON(struct_({field("key_0", int64()), field("hash_count", int64())}),
-                      R"([
-    [1, 2],
-    [2, 3],
-    [3, 0],
-    [null, 2]
-  ])"),
-        aggregated_and_grouped,
-        /*verbose=*/true);
+        AssertDatumsEqual(ArrayFromJSON(struct_({field("key_0", int64()),
+                                                 field("hash_count", int64())}),
+                                        expected_results[i]),
+                          aggregated_and_grouped,
+                          /*verbose=*/true);
+      }
+    }
   }
 }
 

--- a/cpp/src/arrow/acero/hash_aggregate_test.cc
+++ b/cpp/src/arrow/acero/hash_aggregate_test.cc
@@ -1411,7 +1411,7 @@ TEST_P(GroupBy, CountOnly) {
   // NOTE: the "key" column (1) does not appear in the possible run-end
   // encoding transformations because GroupBy kernels do not support run-end
   // encoded key arrays.
-  for (const auto& re_encode_cols : std::vector<std::vector<int>>{{}}) {
+  for (const auto& re_encode_cols : std::vector<std::vector<int>>{{}, {0}}) {
     for (bool use_threads : {/*true, */ false}) {
       SCOPED_TRACE(use_threads ? "parallel/merged" : "serial");
       for (size_t i = 0; i < possible_count_options.size(); i++) {

--- a/cpp/src/arrow/array/data.cc
+++ b/cpp/src/arrow/array/data.cc
@@ -203,7 +203,7 @@ void ArraySpan::SetMembers(const ArrayData& data) {
     type_id = ext_type->storage_type()->id();
   }
 
-  if (data.buffers[0] == nullptr && type_id != Type::NA &&
+  if ((data.buffers.size() == 0 || data.buffers[0] == nullptr) && type_id != Type::NA &&
       type_id != Type::SPARSE_UNION && type_id != Type::DENSE_UNION) {
     // This should already be zero but we make for sure
     this->null_count = 0;

--- a/cpp/src/arrow/compute/kernels/hash_aggregate.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate.cc
@@ -320,22 +320,12 @@ struct GroupedCountImpl : public GroupedAggregator {
       auto end = ree_span.end();
       for (auto it = ree_span.begin(); it != end; ++it) {
         const bool is_valid = bit_util::GetBit(physical_validity, it.index_into_array());
-        if constexpr (count_valid) {
-          if (is_valid) {
-            for (int64_t i = 0; i < it.run_length(); ++i, ++g) {
-              counts[*g] += 1;
-            }
-          } else {
-            g += it.run_length();
+        if (is_valid == count_valid) {
+          for (int64_t i = 0; i < it.run_length(); ++i, ++g) {
+            counts[*g] += 1;
           }
         } else {
-          if (!is_valid) {
-            for (int64_t i = 0; i < it.run_length(); ++i, ++g) {
-              counts[*g] += 1;
-            }
-          } else {
-            g += it.run_length();
-          }
+          g += it.run_length();
         }
       }
     }

--- a/cpp/src/arrow/testing/gtest_util.cc
+++ b/cpp/src/arrow/testing/gtest_util.cc
@@ -436,8 +436,8 @@ Result<std::shared_ptr<Table>> RunEndEncodeTableColumns(
   for (int i = 0; i < num_columns; i++) {
     if (std::find(column_indices.begin(), column_indices.end(), i) !=
         column_indices.end()) {
-      EXPECT_OK_AND_ASSIGN(auto run_end_encoded, compute::RunEndEncode(table.column(i)));
-      EXPECT_EQ(run_end_encoded.kind(), Datum::CHUNKED_ARRAY);
+      ARROW_ASSIGN_OR_RAISE(auto run_end_encoded, compute::RunEndEncode(table.column(i)));
+      DCHECK_EQ(run_end_encoded.kind(), Datum::CHUNKED_ARRAY);
       encoded_columns.push_back(run_end_encoded.chunked_array());
     } else {
       encoded_columns.push_back(table.column(i));

--- a/cpp/src/arrow/testing/gtest_util.cc
+++ b/cpp/src/arrow/testing/gtest_util.cc
@@ -47,6 +47,7 @@
 
 #include "arrow/array.h"
 #include "arrow/buffer.h"
+#include "arrow/compute/api_vector.h"
 #include "arrow/datum.h"
 #include "arrow/ipc/json_simple.h"
 #include "arrow/pretty_print.h"
@@ -425,6 +426,24 @@ std::shared_ptr<Table> TableFromJSON(const std::shared_ptr<Schema>& schema,
     batches.push_back(RecordBatchFromJSON(schema, batch_json));
   }
   return *Table::FromRecordBatches(schema, std::move(batches));
+}
+
+Result<std::shared_ptr<Table>> RunEndEncodeTableColumns(
+    const Table& table, const std::vector<int>& column_indices) {
+  const int num_columns = table.num_columns();
+  std::vector<std::shared_ptr<ChunkedArray>> encoded_columns;
+  encoded_columns.reserve(num_columns);
+  for (int i = 0; i < num_columns; i++) {
+    if (std::find(column_indices.begin(), column_indices.end(), i) !=
+        column_indices.end()) {
+      EXPECT_OK_AND_ASSIGN(auto run_end_encoded, compute::RunEndEncode(table.column(i)));
+      EXPECT_EQ(run_end_encoded.kind(), Datum::CHUNKED_ARRAY);
+      encoded_columns.push_back(run_end_encoded.chunked_array());
+    } else {
+      encoded_columns.push_back(table.column(i));
+    }
+  }
+  return Table::Make(table.schema(), std::move(encoded_columns));
 }
 
 Result<std::optional<std::string>> PrintArrayDiff(const ChunkedArray& expected,

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -341,6 +341,7 @@ ARROW_TESTING_EXPORT
 std::shared_ptr<Table> TableFromJSON(const std::shared_ptr<Schema>&,
                                      const std::vector<std::string>& json);
 
+ARROW_TESTING_EXPORT
 Result<std::shared_ptr<Table>> RunEndEncodeTableColumns(
     const Table& table, const std::vector<int>& column_indices);
 

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -341,6 +341,9 @@ ARROW_TESTING_EXPORT
 std::shared_ptr<Table> TableFromJSON(const std::shared_ptr<Schema>&,
                                      const std::vector<std::string>& json);
 
+Result<std::shared_ptr<Table>> RunEndEncodeTableColumns(
+    const Table& table, const std::vector<int>& column_indices);
+
 // Given an array, return a new identical array except for one validity bit
 // set to a new value.
 // This is useful to force the underlying "value" of null entries to otherwise


### PR DESCRIPTION
### Rationale for this change

Fixing a bug.

### What changes are included in this PR?

Changes to the `"hash_count"` kernel implementation to handle REE and union arrays correctly.

- [x] Generic (potentially slow) implementation
- [x] REE-specialized implementation

### Are these changes tested?

Yes, by modifying the existing unit tests.


* Closes: #35059