### PR TITLE
GH-35181: [R] Bump R package version number in versions.json

### DIFF
--- a/dev/release/01-prepare-test.rb
+++ b/dev/release/01-prepare-test.rb
@@ -243,10 +243,10 @@ class PrepareTest < Test::Unit::TestCase
             [
               "-        \"name\": \"#{@previous_version}.9000 (dev)\",",
               "+        \"name\": \"#{@release_version}.9000 (dev)\",",
-              "-        \"name\": \"#{@previous_version} (release)\",",
+              "-        \"name\": \"#{@previous_r_version} (release)\",",
               "+        \"name\": \"#{@release_version} (release)\",",
               "+    {",
-              "+        \"name\": \"#{@previous_version}\",",
+              "+        \"name\": \"#{@previous_r_version}\",",
               "+        \"version\": \"#{@previous_compatible_version}/\"",
               "+    },",
             ]
@@ -261,7 +261,7 @@ class PrepareTest < Test::Unit::TestCase
             [
               "-        \"name\": \"#{@previous_version}.9000 (dev)\",",
               "+        \"name\": \"#{@release_version}.9000 (dev)\",",
-              "-        \"name\": \"#{@previous_version} (release)\",",
+              "-        \"name\": \"#{@previous_r_version} (release)\",",
               "+        \"name\": \"#{@release_version} (release)\",",
             ]
           ],

--- a/dev/release/post-11-bump-versions-test.rb
+++ b/dev/release/post-11-bump-versions-test.rb
@@ -190,10 +190,10 @@ class PostBumpVersionsTest < Test::Unit::TestCase
             [
               "-        \"name\": \"#{@previous_version}.9000 (dev)\",",
               "+        \"name\": \"#{@release_version}.9000 (dev)\",",
-              "-        \"name\": \"#{@previous_version} (release)\",",
+              "-        \"name\": \"#{@previous_r_version} (release)\",",
               "+        \"name\": \"#{@release_version} (release)\",",
               "+    {",
-              "+        \"name\": \"#{@previous_version}\",",
+              "+        \"name\": \"#{@previous_r_version}\",",
               "+        \"version\": \"#{@previous_compatible_version}/\"",
               "+    },",
             ],
@@ -208,7 +208,7 @@ class PostBumpVersionsTest < Test::Unit::TestCase
             [
               "-        \"name\": \"#{@previous_version}.9000 (dev)\",",
               "+        \"name\": \"#{@release_version}.9000 (dev)\",",
-              "-        \"name\": \"#{@previous_version} (release)\",",
+              "-        \"name\": \"#{@previous_r_version} (release)\",",
               "+        \"name\": \"#{@release_version} (release)\",",
             ],
           ],

--- a/dev/release/test-helper.rb
+++ b/dev/release/test-helper.rb
@@ -130,6 +130,8 @@ module VersionDetectable
     else
       @previous_compatible_version = nil
     end
+    r_versions = top_dir + "r" + "pkgdown" + "assets" + "versions.json"
+    @previous_r_version = r_versions.read[/"name": "(.+?) \(release\)"/, 1]
   end
 
   def compute_so_version(version)

--- a/r/pkgdown/assets/versions.json
+++ b/r/pkgdown/assets/versions.json
@@ -4,7 +4,7 @@
         "version": "dev/"
     },
     {
-        "name": "11.0.0 (release)",
+        "name": "11.0.0.3 (release)",
         "version": ""
     },
     {


### PR DESCRIPTION
This PR corrects a missed R package version number increase
* Closes: #35181