### PR TITLE
GH-35136: [Go][FlightSQL] Support backends without `CreatePreparedStatement` implemented

### DIFF
--- a/go/arrow/flight/flightsql/driver/driver.go
+++ b/go/arrow/flight/flightsql/driver/driver.go
@@ -490,7 +490,6 @@ func readEndpoint(ctx context.Context, client *flightsql.Client, endpoint *fligh
 		record := reader.Record()
 		record.Retain()
 		records = append(records, record)
-
 	}
 
 	if err := reader.Err(); err != nil && !errors.Is(err, io.EOF) {

--- a/go/arrow/flight/flightsql/driver/driver.go
+++ b/go/arrow/flight/flightsql/driver/driver.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"errors"
 	"fmt"
 	"io"
 	"sort"
@@ -491,7 +492,12 @@ func readEndpoint(ctx context.Context, client *flightsql.Client, endpoint *fligh
 		records = append(records, record)
 
 	}
-	return schema, records, reader.Err()
+
+	if err := reader.Err(); err != nil && !errors.Is(err, io.EOF) {
+		return nil, nil, err
+	}
+
+	return schema, records, nil
 }
 
 // Close invalidates and potentially stops any current


### PR DESCRIPTION
Without this PR all backends that do not implement `CreatePreparedStatement` will error out as the `database/sql` framework tries to prepare/execute all queries if the `QueryerContext` is missing. See linked issue.
* Closes: #35136