### PR TITLE
GH-35138: [Java] Fix ArrowFlightJdbcTimeStampVectorAccessor to deal with calendar

### DIFF
--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessor.java
@@ -96,7 +96,7 @@ public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAcces
       TimeZone timeZone = calendar.getTimeZone();
       long millis = this.timeUnit.toMillis(value);
       localDateTime = localDateTime
-          .minus(timeZone.getOffset(millis) - this.timeZone.getOffset(millis), ChronoUnit.MILLIS);
+          .plus(timeZone.getOffset(millis) - this.timeZone.getOffset(millis), ChronoUnit.MILLIS);
     }
     return localDateTime;
   }

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/DateTimeUtils.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/DateTimeUtils.java
@@ -36,7 +36,7 @@ public class DateTimeUtils {
   }
 
   /**
-   * Subtracts given Calendar's TimeZone offset from epoch milliseconds.
+   * Adds given Calendar's TimeZone offset from epoch milliseconds.
    */
   public static long applyCalendarOffset(long milliseconds, Calendar calendar) {
     if (calendar == null) {
@@ -47,7 +47,7 @@ public class DateTimeUtils {
     final TimeZone defaultTz = TimeZone.getDefault();
 
     if (tz != defaultTz) {
-      milliseconds -= tz.getOffset(milliseconds) - defaultTz.getOffset(milliseconds);
+      milliseconds += tz.getOffset(milliseconds) - defaultTz.getOffset(milliseconds);
     }
 
     return milliseconds;

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcDateVectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcDateVectorAccessorTest.java
@@ -130,7 +130,7 @@ public class ArrowFlightJdbcDateVectorAccessorTest {
 
       long offset = timeZone.getOffset(resultWithoutCalendar.getTime());
 
-      collector.checkThat(resultWithoutCalendar.getTime() - result.getTime(), is(offset));
+      collector.checkThat(result.getTime() - resultWithoutCalendar.getTime(), is(offset));
       collector.checkThat(accessor.wasNull(), is(false));
     });
   }
@@ -160,7 +160,7 @@ public class ArrowFlightJdbcDateVectorAccessorTest {
 
       long offset = timeZone.getOffset(resultWithoutCalendar.getTime());
 
-      collector.checkThat(resultWithoutCalendar.getTime() - result.getTime(), is(offset));
+      collector.checkThat(result.getTime() - resultWithoutCalendar.getTime(), is(offset));
       collector.checkThat(accessor.wasNull(), is(false));
     });
   }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
@@ -182,7 +182,7 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
       long offset = timeZone.getOffset(resultWithoutCalendar.getTime()) -
           timeZoneForVector.getOffset(resultWithoutCalendar.getTime());
 
-      collector.checkThat(resultWithoutCalendar.getTime() - result.getTime(), is(offset));
+      collector.checkThat(result.getTime() - resultWithoutCalendar.getTime(), is(offset));
       collector.checkThat(accessor.wasNull(), is(false));
     });
   }
@@ -215,7 +215,7 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
       long offset = timeZone.getOffset(resultWithoutCalendar.getTime()) -
           timeZoneForVector.getOffset(resultWithoutCalendar.getTime());
 
-      collector.checkThat(resultWithoutCalendar.getTime() - result.getTime(), is(offset));
+      collector.checkThat(result.getTime() - resultWithoutCalendar.getTime(), is(offset));
       collector.checkThat(accessor.wasNull(), is(false));
     });
   }
@@ -248,7 +248,7 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
       long offset = timeZone.getOffset(resultWithoutCalendar.getTime()) -
           timeZoneForVector.getOffset(resultWithoutCalendar.getTime());
 
-      collector.checkThat(resultWithoutCalendar.getTime() - result.getTime(), is(offset));
+      collector.checkThat(result.getTime() - resultWithoutCalendar.getTime(), is(offset));
       collector.checkThat(accessor.wasNull(), is(false));
     });
   }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeVectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeVectorAccessorTest.java
@@ -137,7 +137,7 @@ public class ArrowFlightJdbcTimeVectorAccessorTest {
 
       long offset = timeZone.getOffset(resultWithoutCalendar.getTime());
 
-      collector.checkThat(resultWithoutCalendar.getTime() - result.getTime(), is(offset));
+      collector.checkThat(result.getTime() - resultWithoutCalendar.getTime(), is(offset));
       collector.checkThat(accessor.wasNull(), is(false));
     });
   }
@@ -170,7 +170,7 @@ public class ArrowFlightJdbcTimeVectorAccessorTest {
 
       long offset = timeZone.getOffset(resultWithoutCalendar.getTime());
 
-      collector.checkThat(resultWithoutCalendar.getTime() - result.getTime(), is(offset));
+      collector.checkThat(result.getTime() - resultWithoutCalendar.getTime(), is(offset));
       collector.checkThat(accessor.wasNull(), is(false));
     });
   }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/text/ArrowFlightJdbcVarCharVectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/text/ArrowFlightJdbcVarCharVectorAccessorTest.java
@@ -510,14 +510,23 @@ public class ArrowFlightJdbcVarCharVectorAccessorTest {
     Text value = new Text("2021-07-02");
     when(getter.get(0)).thenReturn(value.copyBytes());
 
-    Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("America/Sao_Paulo"));
-    Date result = accessor.getDate(calendar);
+    {
+      Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("America/Sao_Paulo"));
+      Date result = accessor.getDate(calendar);
+      calendar.setTime(result);
 
-    calendar = Calendar.getInstance(TimeZone.getTimeZone("Etc/UTC"));
-    calendar.setTime(result);
+      collector.checkThat(dateTimeFormat.format(calendar.getTime()),
+          equalTo("2021-07-01T21:00:00.000Z"));
+    }
 
-    collector.checkThat(dateTimeFormat.format(calendar.getTime()),
-        equalTo("2021-07-02T03:00:00.000Z"));
+    {
+      Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("Etc/UTC"));
+      Date result = accessor.getDate(calendar);
+      calendar.setTime(result);
+
+      collector.checkThat(dateTimeFormat.format(calendar.getTime()),
+          equalTo("2021-07-02T00:00:00.000Z"));
+    }
   }
 
   @Test
@@ -547,13 +556,21 @@ public class ArrowFlightJdbcVarCharVectorAccessorTest {
     Text value = new Text("02:30:00");
     when(getter.get(0)).thenReturn(value.copyBytes());
 
-    Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("America/Sao_Paulo"));
-    Time result = accessor.getTime(calendar);
+    {
+      Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("America/Sao_Paulo"));
+      Time result = accessor.getTime(calendar);
+      calendar.setTime(result);
 
-    calendar = Calendar.getInstance(TimeZone.getTimeZone("Etc/UTC"));
-    calendar.setTime(result);
+      collector.checkThat(timeFormat.format(calendar.getTime()), equalTo("23:30:00.000Z"));
+    }
 
-    collector.checkThat(timeFormat.format(calendar.getTime()), equalTo("05:30:00.000Z"));
+    {
+      Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("Etc/UTC"));
+      Time result = accessor.getTime(calendar);
+      calendar.setTime(result);
+
+      collector.checkThat(timeFormat.format(calendar.getTime()), equalTo("02:30:00.000Z"));
+    }
   }
 
   @Test
@@ -584,14 +601,23 @@ public class ArrowFlightJdbcVarCharVectorAccessorTest {
     Text value = new Text("2021-07-02 02:30:00.000");
     when(getter.get(0)).thenReturn(value.copyBytes());
 
-    Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("America/Sao_Paulo"));
-    Timestamp result = accessor.getTimestamp(calendar);
+    {
+      Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("America/Sao_Paulo"));
+      Timestamp result = accessor.getTimestamp(calendar);
+      calendar.setTime(result);
 
-    calendar = Calendar.getInstance(TimeZone.getTimeZone("Etc/UTC"));
-    calendar.setTime(result);
+      collector.checkThat(dateTimeFormat.format(calendar.getTime()),
+          equalTo("2021-07-01T23:30:00.000Z"));
+    }
 
-    collector.checkThat(dateTimeFormat.format(calendar.getTime()),
-        equalTo("2021-07-02T05:30:00.000Z"));
+    {
+      Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("Etc/UTC"));
+      Timestamp result = accessor.getTimestamp(calendar);
+      calendar.setTime(result);
+
+      collector.checkThat(dateTimeFormat.format(calendar.getTime()),
+          equalTo("2021-07-02T02:30:00.000Z"));
+    }
   }
 
   private void assertGetBoolean(Text value, boolean expectedResult) throws SQLException {

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/DateTimeUtilsTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/DateTimeUtilsTest.java
@@ -67,7 +67,7 @@ public class DateTimeUtilsTest {
     TimeZone.setDefault(alternateTimezone);
 
     try { // Trying to guarantee timezone returns to its original value
-      final long expectedEpochMillis = epochMillis + offset;
+      final long expectedEpochMillis = epochMillis - offset;
       final long actualEpochMillis = DateTimeUtils.applyCalendarOffset(epochMillis, Calendar.getInstance(
           defaultTimezone));
 


### PR DESCRIPTION
### Rationale for this change

The piece of code below in the `class ArrowFlightJdbcTimeStampVectorAccessor` does not deal with timezone correctly.

```java
  private LocalDateTime getLocalDateTime(Calendar calendar) {
    getter.get(getCurrentRow(), holder);
    this.wasNull = holder.isSet == 0;
    this.wasNullConsumer.setWasNull(this.wasNull);
    if (this.wasNull) {
      return null;
    }

    long value = holder.value;

    LocalDateTime localDateTime = this.longToLocalDateTime.fromLong(value);

    if (calendar != null) {
      TimeZone timeZone = calendar.getTimeZone();
      long millis = this.timeUnit.toMillis(value);
      localDateTime = localDateTime
          .minus(timeZone.getOffset(millis) - this.timeZone.getOffset(millis), ChronoUnit.MILLIS);
    }
    return localDateTime;
  }
```

I hit this issue when integrating this into our own JDBC implementation and found that the timestamp string in the `ResultSet` is wrong when converting between timezones.

### What changes are included in this PR?

It should call `localDateTime.plus` instead of `localDateTime.minus`.

### Are these changes tested?

Actually these conversions are covered by plenty of tests but unfortunately they share the same issues. This commit fixes them all.

### Are there any user-facing changes?

No.
* Closes: #35138