### PR TITLE
GH-35144: [C++] Fix a unit test broken when the output order of the aggregate node changed

### DIFF
--- a/cpp/src/arrow/acero/hash_aggregate_test.cc
+++ b/cpp/src/arrow/acero/hash_aggregate_test.cc
@@ -155,7 +155,7 @@ TEST(AggregateSchema, SingleKeyAndSegmentKey) {
       aggregate::MakeOutputSchema(input_schema, {FieldRef("y")}, {FieldRef("z")},
                                   {{"hash_count", nullptr, "x", "hash_count"}}));
   AssertSchemaEqual(
-      schema({field("y", int32()), field("z", int32()), field("hash_count", int64())}),
+      schema({field("z", int32()), field("y", int32()), field("hash_count", int64())}),
       output_schema);
 }
 


### PR DESCRIPTION
### Rationale for this change

The unit test was broken by a recent change and needed to be updated.

### What changes are included in this PR?

The unit test has been updated to expect the correct order.

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* Closes: #35144