### PR TITLE
GH-35141: [C++] Versions of IsNull/IsValid that don't branch on type

### DIFF
--- a/cpp/src/arrow/array/array_base.h
+++ b/cpp/src/arrow/array/array_base.h
@@ -69,11 +69,9 @@ class ARROW_EXPORT Array {
     // a potential inner-branch removal.
     if (type_id() == Type::SPARSE_UNION) {
       return !internal::IsNullSparseUnion(*data_, i);
-    }
-    if (type_id() == Type::DENSE_UNION) {
+    } else if (type_id() == Type::DENSE_UNION) {
       return !internal::IsNullDenseUnion(*data_, i);
-    }
-    if (type_id() == Type::RUN_END_ENCODED) {
+    } else if (type_id() == Type::RUN_END_ENCODED) {
       return !internal::IsNullRunEndEncoded(*data_, i);
     }
     return data_->null_count != data_->length;

--- a/cpp/src/arrow/array/data.h
+++ b/cpp/src/arrow/array/data.h
@@ -180,20 +180,18 @@ struct ARROW_EXPORT ArrayData {
 
   std::shared_ptr<ArrayData> Copy() const { return std::make_shared<ArrayData>(*this); }
 
-  bool IsNull(int64_t i) const { return !IsValid(i); }
+  inline bool IsNull(int64_t i) const { return !IsValid(i); }
 
-  bool IsValid(int64_t i) const {
+  inline bool IsValid(int64_t i) const {
     if (buffers[0] != NULLPTR) {
       return bit_util::GetBit(buffers[0]->data(), i + offset);
     }
     const auto type = this->type->id();
     if (type == Type::SPARSE_UNION) {
       return !internal::IsNullSparseUnion(*this, i);
-    }
-    if (type == Type::DENSE_UNION) {
+    } else if (type == Type::DENSE_UNION) {
       return !internal::IsNullDenseUnion(*this, i);
-    }
-    if (type == Type::RUN_END_ENCODED) {
+    } else if (type == Type::RUN_END_ENCODED) {
       return !internal::IsNullRunEndEncoded(*this, i);
     }
     return null_count.load() != length;
@@ -434,19 +432,16 @@ struct ARROW_EXPORT ArraySpan {
   inline bool IsValid(int64_t i) const {
     if (this->buffers[0].data != NULLPTR) {
       return bit_util::GetBit(this->buffers[0].data, i + this->offset);
-    } else {
-      const auto type = this->type->id();
-      if (type == Type::SPARSE_UNION) {
-        return !IsNullSparseUnion(i);
-      }
-      if (type == Type::DENSE_UNION) {
-        return !IsNullDenseUnion(i);
-      }
-      if (type == Type::RUN_END_ENCODED) {
-        return !IsNullRunEndEncoded(i);
-      }
-      return this->null_count != this->length;
     }
+    const auto type = this->type->id();
+    if (type == Type::SPARSE_UNION) {
+      return !IsNullSparseUnion(i);
+    } else if (type == Type::DENSE_UNION) {
+      return !IsNullDenseUnion(i);
+    } else if (type == Type::RUN_END_ENCODED) {
+      return !IsNullRunEndEncoded(i);
+    }
+    return this->null_count != this->length;
   }
 
   std::shared_ptr<ArrayData> ToArrayData() const;


### PR DESCRIPTION
### Rationale for this change

See #35141.

### What changes are included in this PR?

 - Add missing `ARROW_EXPORT`
 - Make code style consistent in all `IsNull`/`IsValid` member functions
 - Add `IsNullFast<ArrowType>` and `IsValidFast<ArrowType>`
 
### Are these changes tested?

Yes.

### Are there any user-facing changes?

New member functions added to `ArrayData` / `Array` / `ArraySpan`.
* Closes: #35141