### PR TITLE
GH-35143: [R][C++] Fixed shape tensor causes broken build on OSX

### DIFF
--- a/cpp/src/arrow/extension/fixed_shape_tensor.cc
+++ b/cpp/src/arrow/extension/fixed_shape_tensor.cc
@@ -268,14 +268,14 @@ Result<std::shared_ptr<FixedShapeTensorArray>> FixedShapeTensorArray::FromTensor
   ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Array> arr,
                         FixedSizeListArray::FromArrays(value_array, cell_size));
   std::shared_ptr<Array> ext_arr = ExtensionType::WrapArray(ext_type, arr);
-  return std::reinterpret_pointer_cast<FixedShapeTensorArray>(ext_arr);
+  return std::static_pointer_cast<FixedShapeTensorArray>(ext_arr);
 }
 
 const Result<std::shared_ptr<Tensor>> FixedShapeTensorArray::ToTensor() const {
   // To convert an array of n dimensional tensors to a n+1 dimensional tensor we
   // interpret the array's length as the first dimension the new tensor.
 
-  auto ext_arr = internal::checked_pointer_cast<FixedSizeListArray>(this->storage());
+  auto ext_arr = std::static_pointer_cast<FixedSizeListArray>(this->storage());
   auto ext_type = internal::checked_pointer_cast<FixedShapeTensorType>(this->type());
   ARROW_RETURN_IF(!is_fixed_width(*ext_arr->value_type()),
                   Status::Invalid(ext_arr->value_type()->ToString(),

--- a/cpp/src/arrow/extension/fixed_shape_tensor_test.cc
+++ b/cpp/src/arrow/extension/fixed_shape_tensor_test.cc
@@ -101,7 +101,7 @@ TEST_F(TestExtensionType, CreateExtensionType) {
   ASSERT_EQ(ext_type_->Serialize(), serialized_);
   ASSERT_OK_AND_ASSIGN(auto ds,
                        ext_type_->Deserialize(ext_type_->storage_type(), serialized_));
-  auto deserialized = std::reinterpret_pointer_cast<ExtensionType>(ds);
+  auto deserialized = internal::checked_pointer_cast<ExtensionType>(ds);
   ASSERT_TRUE(deserialized->Equals(*ext_type_));
 
   // Test FixedShapeTensorType methods
@@ -267,7 +267,7 @@ TEST_F(TestExtensionType, CreateFromTensor) {
 
   ASSERT_OK_AND_ASSIGN(auto fsla_arr,
                        FixedSizeListArray::FromArrays(arr, fixed_size_list(binary(), 2)));
-  auto ext_arr_5 = std::reinterpret_pointer_cast<FixedShapeTensorArray>(
+  auto ext_arr_5 = std::static_pointer_cast<FixedShapeTensorArray>(
       ExtensionType::WrapArray(ext_type_5, fsla_arr));
   EXPECT_RAISES_WITH_MESSAGE_THAT(
       Invalid, testing::HasSubstr("binary is not valid data type for a tensor"),


### PR DESCRIPTION
### Rationale for this change

`std::reinterpret_pointer_cast` was introduced with FixedShapeTensor PR (#34797) but is not available on OSX (see #35143).

### What changes are included in this PR?

This change switches to using `internal::checked_pointer_cast`.

### Are these changes tested?

Change is tested in CI, but should also be verified on crossbow.

### Are there any user-facing changes?

No.
* Closes: #35143