### PR TITLE
GH-35155: [C#] Improve Array accessor with IEnumerable, C# array like

### DIFF
--- a/csharp/src/Apache.Arrow/Arrays/Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Array.cs
@@ -90,6 +90,8 @@ namespace Apache.Arrow
             }
         }
 
+        public Accessor<TArray, TItem> Items<TArray, TItem>(Func<TArray, int, TItem> getter) where TArray : Array => new(this as TArray, getter);
+
         public class Accessor<TArray, TItem> : IEnumerable<TItem>
             where TArray : IArrowArray
         {

--- a/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
@@ -386,9 +386,8 @@ namespace Apache.Arrow
             //    data[index] = value;
             //}
         }
-
         // Accessors
-        public Accessor<BinaryArray, byte[]> Items() => new(this, (a, i) => a.IsValid(i) ? a.GetValueBytes(i).ToArray() : null);
-        public Accessor<BinaryArray, byte[]> NotNullItems() => new(this, (a, i) => a.GetValueBytes(i).ToArray());
+        public Accessor<BinaryArray, byte[]> Items() => Items<BinaryArray, byte[]>((a, i) => a.IsValid(i) ? a.GetValueBytes(i).ToArray() : null);
+        public Accessor<BinaryArray, byte[]> NotNullItems() => Items<BinaryArray, byte[]>((a, i) => a.GetValueBytes(i).ToArray());
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
@@ -388,7 +388,7 @@ namespace Apache.Arrow
         }
 
         // Accessors
-        public Accessor<BinaryArray, byte[]> Items() => new(this, (a, i) => a.IsValid(i) ? null : a.GetValueBytes(i).ToArray());
+        public Accessor<BinaryArray, byte[]> Items() => new(this, (a, i) => a.IsValid(i) ? a.GetValueBytes(i).ToArray() : null);
         public Accessor<BinaryArray, byte[]> NotNullItems() => new(this, (a, i) => a.GetValueBytes(i).ToArray());
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
@@ -13,13 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Apache.Arrow.Types;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using Apache.Arrow.Memory;
 using System.Runtime.InteropServices;
 using System.Text;
+using Apache.Arrow.Memory;
+using Apache.Arrow.Types;
 
 namespace Apache.Arrow
 {

--- a/csharp/src/Apache.Arrow/Arrays/BooleanArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/BooleanArray.cs
@@ -210,7 +210,7 @@ namespace Apache.Arrow
         }
 
         // Accessors
-        public Accessor<BooleanArray, bool?> Items() => Items<BooleanArray, bool?>((a, i) => a.IsValid(i) ? null : a.GetValueBoolean(i));
+        public Accessor<BooleanArray, bool?> Items() => Items<BooleanArray, bool?>((a, i) => a.IsValid(i) ? a.GetValueBoolean(i) : null);
         public Accessor<BooleanArray, bool> NotNullItems() => Items<BooleanArray, bool>((a, i) => a.GetValueBoolean(i));
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/BooleanArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/BooleanArray.cs
@@ -210,7 +210,7 @@ namespace Apache.Arrow
         }
 
         // Accessors
-        public Accessor<BooleanArray, bool?> Items() => new(this, (a, i) => a.IsValid(i) ? null : a.GetValueBoolean(i));
-        public Accessor<BooleanArray, bool> NotNullItems() => new(this, (a, i) => a.GetValueBoolean(i));
+        public Accessor<BooleanArray, bool?> Items() => Items<BooleanArray, bool?>((a, i) => a.IsValid(i) ? null : a.GetValueBoolean(i));
+        public Accessor<BooleanArray, bool> NotNullItems() => Items<BooleanArray, bool>((a, i) => a.GetValueBoolean(i));
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/BooleanArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/BooleanArray.cs
@@ -13,10 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Apache.Arrow.Memory;
-using Apache.Arrow.Types;
 using System;
 using System.Collections.Generic;
+using Apache.Arrow.Memory;
+using Apache.Arrow.Types;
 
 namespace Apache.Arrow
 {

--- a/csharp/src/Apache.Arrow/Arrays/BooleanArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/BooleanArray.cs
@@ -188,7 +188,29 @@ namespace Apache.Arrow
         {
             return IsNull(index)
                 ? (bool?)null
-                : BitUtility.GetBit(ValueBuffer.Span, index + Offset);
+                : GetValueBoolean(index);
         }
+
+        public bool GetValueBoolean(int index)
+        {
+            return BitUtility.GetBit(ValueBuffer.Span, index + Offset);
+        }
+
+        public bool? this[int index]
+        {
+            get
+            {
+                return index < 0 ? GetValue(Length + index) : GetValue(index);
+            }
+            // TODO: Implement setter
+            //set
+            //{
+            //    data[index] = value;
+            //}
+        }
+
+        // Accessors
+        public Accessor<BooleanArray, bool?> Items() => new(this, (a, i) => a.IsValid(i) ? null : a.GetValueBoolean(i));
+        public Accessor<BooleanArray, bool> NotNullItems() => new(this, (a, i) => a.GetValueBoolean(i));
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/Date32Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Date32Array.cs
@@ -104,8 +104,8 @@ namespace Apache.Arrow
         public new DateTimeOffset? this[int index] => index < 0 ? GetDateTimeOffset(Length + index) : GetDateTimeOffset(index);
 
         // Accessors
-        public new Accessor<Date32Array, DateTimeOffset?> Items() => new(this, (a, i) => IsValid(i) ? a.UnixDaysToDateTimeOffset(i) : null);
-        public new Accessor<Date32Array, DateTimeOffset> NotNullItems() => new(this, (a, i) => a.UnixDaysToDateTimeOffset(i));
+        public new Accessor<Date32Array, DateTimeOffset?> Items() => Items<Date32Array, DateTimeOffset?>((a, i) => IsValid(i) ? a.UnixDaysToDateTimeOffset(i) : null);
+        public new Accessor<Date32Array, DateTimeOffset> NotNullItems() => Items<Date32Array, DateTimeOffset>((a, i) => a.UnixDaysToDateTimeOffset(i));
 
         // Static Methods to Convert ticks to date/time instances
         public DateTime UnixDaysToDateTime(int index) => Types.Convert.UnixDaysToDateTime(Values[index]);

--- a/csharp/src/Apache.Arrow/Arrays/Date64Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Date64Array.cs
@@ -115,8 +115,8 @@ namespace Apache.Arrow
         public new DateTimeOffset? this[int index] => index < 0 ? GetDateTimeOffset(Length + index) : GetDateTimeOffset(index);
 
         // Accessors
-        public new Accessor<Date64Array, DateTimeOffset?> Items() => new(this, (a, i) => a.GetDateTimeOffset(i));
-        public new Accessor<Date64Array, DateTimeOffset> NotNullItems() => new(this, (a, i) => a.UnixMillisecondsToDateTimeOffset(i));
+        public new Accessor<Date64Array, DateTimeOffset?> Items() => Items<Date64Array, DateTimeOffset?>((a, i) => a.GetDateTimeOffset(i));
+        public new Accessor<Date64Array, DateTimeOffset> NotNullItems() => Items<Date64Array, DateTimeOffset>((a, i) => a.UnixMillisecondsToDateTimeOffset(i));
 
         // Static Methods to Convert ticks to date/time instances
         public DateTimeOffset UnixMillisecondsToDateTimeOffset(int index) => Types.Convert.UnixMillisecondsToDateTimeOffset(Values[index]);

--- a/csharp/src/Apache.Arrow/Arrays/Date64Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Date64Array.cs
@@ -94,9 +94,8 @@ namespace Apache.Arrow
         /// </returns>
         public DateTime? GetDateTime(int index)
         {
-            long? value = GetValue(index);
-            return value.HasValue
-                ? DateTimeOffset.FromUnixTimeMilliseconds(value.Value).Date
+            return IsValid(index)
+                ? UnixMillisecondsToDateTimeOffset(index).Date
                 : default(DateTime?);
         }
 
@@ -108,10 +107,18 @@ namespace Apache.Arrow
         /// </returns>
         public DateTimeOffset? GetDateTimeOffset(int index)
         {
-            long? value = GetValue(index);
-            return value.HasValue
-                ? DateTimeOffset.FromUnixTimeMilliseconds(value.Value)
+            return IsValid(index)
+                ? UnixMillisecondsToDateTimeOffset(index)
                 : default(DateTimeOffset?);
         }
+
+        public new DateTimeOffset? this[int index] => index < 0 ? GetDateTimeOffset(Length + index) : GetDateTimeOffset(index);
+
+        // Accessors
+        public new Accessor<Date64Array, DateTimeOffset?> Items() => new(this, (a, i) => a.GetDateTimeOffset(i));
+        public new Accessor<Date64Array, DateTimeOffset> NotNullItems() => new(this, (a, i) => a.UnixMillisecondsToDateTimeOffset(i));
+
+        // Static Methods to Convert ticks to date/time instances
+        public DateTimeOffset UnixMillisecondsToDateTimeOffset(int index) => Types.Convert.UnixMillisecondsToDateTimeOffset(Values[index]);
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/Date64Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Date64Array.cs
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Apache.Arrow.Types;
 using System;
+using Apache.Arrow.Types;
 
 namespace Apache.Arrow
 {

--- a/csharp/src/Apache.Arrow/Arrays/Decimal128Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Decimal128Array.cs
@@ -102,7 +102,7 @@ namespace Apache.Arrow
         {
             get
             {
-                return GetValue(index);
+                return index < 0 ? GetValue(Length + index) : GetValue(index);
             }
             // TODO: Implement setter
             //set
@@ -112,7 +112,7 @@ namespace Apache.Arrow
         }
 
         // Accessors
-        public new Accessor<Decimal128Array, decimal?> Items() => new(this, (a, i) => a[i]);
-        public new Accessor<Decimal128Array, decimal> NotNullItems() => new(this, (a, i) => a.GetDecimal(i));
+        public new Accessor<Decimal128Array, decimal?> Items() => Items<Decimal128Array, decimal?>((a, i) => a.GetValue(i));
+        public new Accessor<Decimal128Array, decimal> NotNullItems() => Items<Decimal128Array, decimal>((a, i) => a.GetDecimal(i));
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/Decimal128Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Decimal128Array.cs
@@ -17,7 +17,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Apache.Arrow.Arrays;
-using Apache.Arrow.Flatbuf;
 using Apache.Arrow.Types;
 
 namespace Apache.Arrow

--- a/csharp/src/Apache.Arrow/Arrays/Decimal128Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Decimal128Array.cs
@@ -16,8 +16,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Numerics;
 using Apache.Arrow.Arrays;
+using Apache.Arrow.Flatbuf;
 using Apache.Arrow.Types;
 
 namespace Apache.Arrow
@@ -26,6 +26,10 @@ namespace Apache.Arrow
     {
         public class Builder : BuilderBase<Decimal128Array, Builder>
         {
+            public Builder(int precision, int scale) : this(new Decimal128Type(precision, scale))
+            {
+            }
+        
             public Builder(Decimal128Type type) : base(type, 16)
             {
                 DataType = type;
@@ -79,9 +83,10 @@ namespace Apache.Arrow
         }
         public override void Accept(IArrowArrayVisitor visitor) => Accept(this, visitor);
 
-        public int Scale => ((Decimal128Type)Data.DataType).Scale;
-        public int Precision => ((Decimal128Type)Data.DataType).Precision;
-        public int ByteWidth => ((Decimal128Type)Data.DataType).ByteWidth;
+        public Decimal128Type DecimalType => ((Decimal128Type)Data.DataType);
+        public int Scale => DecimalType.Scale;
+        public int Precision => DecimalType.Precision;
+        public int ByteWidth => DecimalType.ByteWidth;
 
         public decimal? GetValue(int index)
         {
@@ -89,7 +94,26 @@ namespace Apache.Arrow
             {
                 return null;
             }
-            return DecimalUtility.GetDecimal(ValueBuffer, index, Scale, ByteWidth);
+            return GetDecimal(index);
         }
+
+        public decimal GetDecimal(int index) => DecimalUtility.GetDecimal(ValueBuffer, index, Scale, ByteWidth);
+
+        public new decimal? this[int index]
+        {
+            get
+            {
+                return GetValue(index);
+            }
+            // TODO: Implement setter
+            //set
+            //{
+            //    data[index] = value;
+            //}
+        }
+
+        // Accessors
+        public new Accessor<Decimal128Array, decimal?> Items() => new(this, (a, i) => a[i]);
+        public new Accessor<Decimal128Array, decimal> NotNullItems() => new(this, (a, i) => a.GetDecimal(i));
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/Decimal256Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Decimal256Array.cs
@@ -102,7 +102,7 @@ namespace Apache.Arrow
         {
             get
             {
-                return GetValue(index);
+                return index < 0 ? GetValue(Length + index) : GetValue(index);
             }
             // TODO: Implement setter
             //set
@@ -112,7 +112,7 @@ namespace Apache.Arrow
         }
 
         // Accessors
-        public new Accessor<Decimal256Array, decimal?> Items() => new(this, (a, i) => a[i]);
-        public new Accessor<Decimal256Array, decimal> NotNullItems() => new(this, (a, i) => a.GetDecimal(i));
+        public new Accessor<Decimal256Array, decimal?> Items() => Items<Decimal256Array, decimal?>((a, i) => a.GetValue(i));
+        public new Accessor<Decimal256Array, decimal> NotNullItems() => Items<Decimal256Array, decimal>((a, i) => a.GetDecimal(i));
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/Decimal256Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Decimal256Array.cs
@@ -16,7 +16,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Numerics;
 using Apache.Arrow.Arrays;
 using Apache.Arrow.Types;
 

--- a/csharp/src/Apache.Arrow/Arrays/Decimal256Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Decimal256Array.cs
@@ -26,6 +26,10 @@ namespace Apache.Arrow
     {
         public class Builder : BuilderBase<Decimal256Array, Builder>
         {
+            public Builder(int precision, int scale) : this(new Decimal256Type(precision, scale))
+            {
+            }
+
             public Builder(Decimal256Type type) : base(type, 32)
             {
                 DataType = type;
@@ -79,9 +83,10 @@ namespace Apache.Arrow
         }
         public override void Accept(IArrowArrayVisitor visitor) => Accept(this, visitor);
 
-        public int Scale => ((Decimal256Type)Data.DataType).Scale;
-        public int Precision => ((Decimal256Type)Data.DataType).Precision;
-        public int ByteWidth => ((Decimal256Type)Data.DataType).ByteWidth;
+        public Decimal256Type DecimalType => ((Decimal256Type)Data.DataType);
+        public int Scale => DecimalType.Scale;
+        public int Precision => DecimalType.Precision;
+        public int ByteWidth => DecimalType.ByteWidth;
 
         public decimal? GetValue(int index)
         {
@@ -89,8 +94,26 @@ namespace Apache.Arrow
             {
                 return null;
             }
-
-            return DecimalUtility.GetDecimal(ValueBuffer, index, Scale, ByteWidth);
+            return GetDecimal(index);
         }
+
+        public decimal GetDecimal(int index) => DecimalUtility.GetDecimal(ValueBuffer, index, Scale, ByteWidth);
+
+        public new decimal? this[int index]
+        {
+            get
+            {
+                return GetValue(index);
+            }
+            // TODO: Implement setter
+            //set
+            //{
+            //    data[index] = value;
+            //}
+        }
+
+        // Accessors
+        public new Accessor<Decimal256Array, decimal?> Items() => new(this, (a, i) => a[i]);
+        public new Accessor<Decimal256Array, decimal> NotNullItems() => new(this, (a, i) => a.GetDecimal(i));
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/FixedSizeBinaryArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/FixedSizeBinaryArray.cs
@@ -237,7 +237,7 @@ namespace Apache.Arrow.Arrays
         }
 
         // Accessors
-        public Accessor<FixedSizeBinaryArray, byte[]> Items() => new(this, (a, i) => a.IsValid(i) ? null : a.GetValueBytes(i).ToArray());
+        public Accessor<FixedSizeBinaryArray, byte[]> Items() => new(this, (a, i) => a.IsValid(i) ? a.GetValueBytes(i).ToArray() : null);
         public Accessor<FixedSizeBinaryArray, byte[]> NotNullItems() => new(this, (a, i) => a.GetValueBytes(i).ToArray());
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/FixedSizeBinaryArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/FixedSizeBinaryArray.cs
@@ -237,7 +237,7 @@ namespace Apache.Arrow.Arrays
         }
 
         // Accessors
-        public Accessor<FixedSizeBinaryArray, byte[]> Items() => new(this, (a, i) => a.IsValid(i) ? a.GetValueBytes(i).ToArray() : null);
-        public Accessor<FixedSizeBinaryArray, byte[]> NotNullItems() => new(this, (a, i) => a.GetValueBytes(i).ToArray());
+        public Accessor<FixedSizeBinaryArray, byte[]> Items() => Items<FixedSizeBinaryArray, byte[]>((a, i) => a.IsValid(i) ? a.GetValueBytes(i).ToArray() : null);
+        public Accessor<FixedSizeBinaryArray, byte[]> NotNullItems() => Items<FixedSizeBinaryArray, byte[]>((a, i) => a.GetValueBytes(i).ToArray());
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/Int32Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Int32Array.cs
@@ -41,6 +41,5 @@ namespace Apache.Arrow
         }
 
         public override void Accept(IArrowArrayVisitor visitor) => Accept(this, visitor);
-
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/Int64Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Int64Array.cs
@@ -41,6 +41,5 @@ namespace Apache.Arrow
         }
 
         public override void Accept(IArrowArrayVisitor visitor) => Accept(this, visitor);
-
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/PrimitiveArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/PrimitiveArray.cs
@@ -66,5 +66,22 @@ namespace Apache.Arrow
 
             return list;
         }
+
+        public T? this[int index]
+        {
+            get
+            {
+                return index < 0 ? GetValue(Length + index) : GetValue(index);
+            }
+            // TODO: Implement setter
+            //set
+            //{
+            //    data[index] = value;
+            //}
+        }
+
+        // Accessors
+        public Accessor<PrimitiveArray<T>, T?> Items() => new(this, (a, i) => a[i]);
+        public Accessor<PrimitiveArray<T>, T> NotNullItems() => new(this, (a, i) => a.Values[i]);
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/PrimitiveArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/PrimitiveArray.cs
@@ -81,7 +81,7 @@ namespace Apache.Arrow
         }
 
         // Accessors
-        public Accessor<PrimitiveArray<T>, T?> Items() => new(this, (a, i) => a[i]);
-        public Accessor<PrimitiveArray<T>, T> NotNullItems() => new(this, (a, i) => a.Values[i]);
+        public Accessor<PrimitiveArray<T>, T?> Items() => Items<PrimitiveArray<T>, T?>((a, i) => a.GetValue(i));
+        public Accessor<PrimitiveArray<T>, T> NotNullItems() => Items<PrimitiveArray<T>, T>((a, i) => a.Values[i]);
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/StringArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/StringArray.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Apache.Arrow.Types;
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using System.Text;
+using Apache.Arrow.Types;
 
 namespace Apache.Arrow
 {
@@ -70,26 +69,21 @@ namespace Apache.Arrow
 
         public override void Accept(IArrowArrayVisitor visitor) => Accept(this, visitor);
 
-        public string GetString(int index, Encoding encoding = default)
+        public new string this[int index]
         {
-            encoding = encoding ?? DefaultEncoding;
-
-            ReadOnlySpan<byte> bytes = GetBytes(index);
-
-            if (bytes == default)
+            get
             {
-                return null;
+                return index < 0 ? GetString(Length + index) : GetString(index);
             }
-            if (bytes.Length == 0)
-            {
-                return string.Empty;
-            }
-
-            unsafe
-            {
-                fixed (byte* data = &MemoryMarshal.GetReference(bytes))
-                    return encoding.GetString(data, bytes.Length);
-            }
+            // TODO: Implement setter
+            //set
+            //{
+            //    data[index] = value;
+            //}
         }
+
+        // Accessors
+        public new Accessor<StringArray, string> Items() => new(this, (a, i) => a.GetString(i));
+        public new Accessor<StringArray, string> NotNullItems() => new(this, (a, i) => a.GetString(i));
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/StringArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/StringArray.cs
@@ -83,7 +83,7 @@ namespace Apache.Arrow
         }
 
         // Accessors
-        public new Accessor<StringArray, string> Items() => new(this, (a, i) => a.GetString(i));
-        public new Accessor<StringArray, string> NotNullItems() => new(this, (a, i) => a.GetString(i));
+        public new Accessor<StringArray, string> Items() => Items<StringArray, string>((a, i) => a.GetString(i));
+        public new Accessor<StringArray, string> NotNullItems() => Items<StringArray, string>((a, i) => a.GetString(i));
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/Time32Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Time32Array.cs
@@ -119,6 +119,9 @@ namespace Apache.Arrow
         {
             get
             {
+                if (index < 0)
+                    return this[Length + index];
+
                 if (IsValid(index))
                 {
                     return TimeType.Unit switch

--- a/csharp/src/Apache.Arrow/Arrays/Time32Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Time32Array.cs
@@ -147,10 +147,10 @@ namespace Apache.Arrow
         {
             return TimeType.Unit switch
             {
-                TimeUnit.Second => new(this, (a, i) => a.IsValid(i) ? a.SecondsToTimeSpan(i) : null),
-                TimeUnit.Millisecond => new(this, (a, i) => a.IsValid(i) ? a.MillisecondsToTimeSpan(i) : null),
-                TimeUnit.Microsecond => new(this, (a, i) => a.IsValid(i) ? a.MicrosecondsToTimeSpan(i) : null),
-                TimeUnit.Nanosecond => new(this, (a, i) => a.IsValid(i) ? a.NanosecondsToTimeSpan(i) : null),
+                TimeUnit.Second => Items<Time32Array, TimeSpan?>((a, i) => a.IsValid(i) ? a.SecondsToTimeSpan(i) : null),
+                TimeUnit.Millisecond => Items<Time32Array, TimeSpan?>((a, i) => a.IsValid(i) ? a.MillisecondsToTimeSpan(i) : null),
+                TimeUnit.Microsecond => Items<Time32Array, TimeSpan?>((a, i) => a.IsValid(i) ? a.MicrosecondsToTimeSpan(i) : null),
+                TimeUnit.Nanosecond => Items<Time32Array, TimeSpan?>((a, i) => a.IsValid(i) ? a.NanosecondsToTimeSpan(i) : null),
                 _ => throw new InvalidDataException($"Unsupported time unit for Time32Type: {TimeType.Unit}"),
             };
         }
@@ -158,10 +158,10 @@ namespace Apache.Arrow
         {
             return TimeType.Unit switch
             {
-                TimeUnit.Second => new(this, (a, i) => a.SecondsToTimeSpan(i)),
-                TimeUnit.Millisecond => new(this, (a, i) => a.MillisecondsToTimeSpan(i)),
-                TimeUnit.Microsecond => new(this, (a, i) => a.MicrosecondsToTimeSpan(i)),
-                TimeUnit.Nanosecond => new(this, (a, i) => a.NanosecondsToTimeSpan(i)),
+                TimeUnit.Second => Items<Time32Array, TimeSpan>((a, i) => a.SecondsToTimeSpan(i)),
+                TimeUnit.Millisecond => Items<Time32Array, TimeSpan>((a, i) => a.MillisecondsToTimeSpan(i)),
+                TimeUnit.Microsecond => Items<Time32Array, TimeSpan>((a, i) => a.MicrosecondsToTimeSpan(i)),
+                TimeUnit.Nanosecond => Items<Time32Array, TimeSpan>((a, i) => a.NanosecondsToTimeSpan(i)),
                 _ => throw new InvalidDataException($"Unsupported time unit for Time32Type: {TimeType.Unit}"),
             };
         }

--- a/csharp/src/Apache.Arrow/Arrays/Time32Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Time32Array.cs
@@ -147,10 +147,10 @@ namespace Apache.Arrow
         {
             return TimeType.Unit switch
             {
-                TimeUnit.Second => new(this, (a, i) => a[i]),
-                TimeUnit.Millisecond => new(this, (a, i) => a[i]),
-                TimeUnit.Microsecond => new(this, (a, i) => a[i]),
-                TimeUnit.Nanosecond => new(this, (a, i) => a[i]),
+                TimeUnit.Second => new(this, (a, i) => a.IsValid(i) ? a.SecondsToTimeSpan(i) : null),
+                TimeUnit.Millisecond => new(this, (a, i) => a.IsValid(i) ? a.MillisecondsToTimeSpan(i) : null),
+                TimeUnit.Microsecond => new(this, (a, i) => a.IsValid(i) ? a.MicrosecondsToTimeSpan(i) : null),
+                TimeUnit.Nanosecond => new(this, (a, i) => a.IsValid(i) ? a.NanosecondsToTimeSpan(i) : null),
                 _ => throw new InvalidDataException($"Unsupported time unit for Time32Type: {TimeType.Unit}"),
             };
         }

--- a/csharp/src/Apache.Arrow/Arrays/Time64Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Time64Array.cs
@@ -130,7 +130,7 @@ namespace Apache.Arrow
                         TimeUnit.Millisecond => (TimeSpan?)MillisecondsToTimeSpan(index),
                         TimeUnit.Microsecond => (TimeSpan?)MicrosecondsToTimeSpan(index),
                         TimeUnit.Nanosecond => (TimeSpan?)NanosecondsToTimeSpan(index),
-                        _ => throw new InvalidDataException($"Unsupported time unit for Time32Type: {TimeType.Unit}"),
+                        _ => throw new InvalidDataException($"Unsupported time unit for Time64Type: {TimeType.Unit}"),
                     };
                 }
                 return null;

--- a/csharp/src/Apache.Arrow/Arrays/Time64Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Time64Array.cs
@@ -119,6 +119,9 @@ namespace Apache.Arrow
         {
             get
             {
+                if (index < 0)
+                    return this[Length + index];
+
                 if (IsValid(index))
                 {
                     return TimeType.Unit switch

--- a/csharp/src/Apache.Arrow/Arrays/Time64Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Time64Array.cs
@@ -147,10 +147,10 @@ namespace Apache.Arrow
         {
             return TimeType.Unit switch
             {
-                TimeUnit.Second => new(this, (a, i) => a[i]),
-                TimeUnit.Millisecond => new(this, (a, i) => a[i]),
-                TimeUnit.Microsecond => new(this, (a, i) => a[i]),
-                TimeUnit.Nanosecond => new(this, (a, i) => a[i]),
+                TimeUnit.Second => new(this, (a, i) => a.IsValid(i) ? a.SecondsToTimeSpan(i) : null),
+                TimeUnit.Millisecond => new(this, (a, i) => a.IsValid(i) ? a.MillisecondsToTimeSpan(i) : null),
+                TimeUnit.Microsecond => new(this, (a, i) => a.IsValid(i) ? a.MicrosecondsToTimeSpan(i) : null),
+                TimeUnit.Nanosecond => new(this, (a, i) => a.IsValid(i) ? a.SecondsToTimeSpan(i) : null),
                 _ => throw new InvalidDataException($"Unsupported time unit for Time32Type: {TimeType.Unit}"),
             };
         }

--- a/csharp/src/Apache.Arrow/Arrays/Time64Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Time64Array.cs
@@ -13,9 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Apache.Arrow.Types;
 using System;
 using System.IO;
+using Apache.Arrow.Types;
 
 namespace Apache.Arrow
 {

--- a/csharp/src/Apache.Arrow/Arrays/Time64Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Time64Array.cs
@@ -150,7 +150,7 @@ namespace Apache.Arrow
                 TimeUnit.Second => new(this, (a, i) => a.IsValid(i) ? a.SecondsToTimeSpan(i) : null),
                 TimeUnit.Millisecond => new(this, (a, i) => a.IsValid(i) ? a.MillisecondsToTimeSpan(i) : null),
                 TimeUnit.Microsecond => new(this, (a, i) => a.IsValid(i) ? a.MicrosecondsToTimeSpan(i) : null),
-                TimeUnit.Nanosecond => new(this, (a, i) => a.IsValid(i) ? a.SecondsToTimeSpan(i) : null),
+                TimeUnit.Nanosecond => new(this, (a, i) => a.IsValid(i) ? a.NanosecondsToTimeSpan(i) : null),
                 _ => throw new InvalidDataException($"Unsupported time unit for Time32Type: {TimeType.Unit}"),
             };
         }

--- a/csharp/src/Apache.Arrow/Arrays/Time64Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Time64Array.cs
@@ -151,7 +151,7 @@ namespace Apache.Arrow
                 TimeUnit.Millisecond => Items<Time64Array, TimeSpan?>((a, i) => a.IsValid(i) ? a.MillisecondsToTimeSpan(i) : null),
                 TimeUnit.Microsecond => Items<Time64Array, TimeSpan?>((a, i) => a.IsValid(i) ? a.MicrosecondsToTimeSpan(i) : null),
                 TimeUnit.Nanosecond => Items<Time64Array, TimeSpan?>((a, i) => a.IsValid(i) ? a.NanosecondsToTimeSpan(i) : null),
-                _ => throw new InvalidDataException($"Unsupported time unit for Time32Type: {TimeType.Unit}"),
+                _ => throw new InvalidDataException($"Unsupported time unit for Time64Type: {TimeType.Unit}"),
             };
         }
         public new Accessor<Time64Array, TimeSpan> NotNullItems()
@@ -162,7 +162,7 @@ namespace Apache.Arrow
                 TimeUnit.Millisecond => Items<Time64Array, TimeSpan>((a, i) => a.MillisecondsToTimeSpan(i)),
                 TimeUnit.Microsecond => Items<Time64Array, TimeSpan>((a, i) => a.MicrosecondsToTimeSpan(i)),
                 TimeUnit.Nanosecond => Items<Time64Array, TimeSpan>((a, i) => a.NanosecondsToTimeSpan(i)),
-                _ => throw new InvalidDataException($"Unsupported time unit for Time32Type: {TimeType.Unit}"),
+                _ => throw new InvalidDataException($"Unsupported time unit for Time64Type: {TimeType.Unit}"),
             };
         }
 

--- a/csharp/src/Apache.Arrow/Arrays/Time64Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Time64Array.cs
@@ -147,10 +147,10 @@ namespace Apache.Arrow
         {
             return TimeType.Unit switch
             {
-                TimeUnit.Second => new(this, (a, i) => a.IsValid(i) ? a.SecondsToTimeSpan(i) : null),
-                TimeUnit.Millisecond => new(this, (a, i) => a.IsValid(i) ? a.MillisecondsToTimeSpan(i) : null),
-                TimeUnit.Microsecond => new(this, (a, i) => a.IsValid(i) ? a.MicrosecondsToTimeSpan(i) : null),
-                TimeUnit.Nanosecond => new(this, (a, i) => a.IsValid(i) ? a.NanosecondsToTimeSpan(i) : null),
+                TimeUnit.Second => Items<Time64Array, TimeSpan?>((a, i) => a.IsValid(i) ? a.SecondsToTimeSpan(i) : null),
+                TimeUnit.Millisecond => Items<Time64Array, TimeSpan?>((a, i) => a.IsValid(i) ? a.MillisecondsToTimeSpan(i) : null),
+                TimeUnit.Microsecond => Items<Time64Array, TimeSpan?>((a, i) => a.IsValid(i) ? a.MicrosecondsToTimeSpan(i) : null),
+                TimeUnit.Nanosecond => Items<Time64Array, TimeSpan?>((a, i) => a.IsValid(i) ? a.NanosecondsToTimeSpan(i) : null),
                 _ => throw new InvalidDataException($"Unsupported time unit for Time32Type: {TimeType.Unit}"),
             };
         }
@@ -158,10 +158,10 @@ namespace Apache.Arrow
         {
             return TimeType.Unit switch
             {
-                TimeUnit.Second => new(this, (a, i) => a.SecondsToTimeSpan(i)),
-                TimeUnit.Millisecond => new(this, (a, i) => a.MillisecondsToTimeSpan(i)),
-                TimeUnit.Microsecond => new(this, (a, i) => a.MicrosecondsToTimeSpan(i)),
-                TimeUnit.Nanosecond => new(this, (a, i) => a.NanosecondsToTimeSpan(i)),
+                TimeUnit.Second => Items<Time64Array, TimeSpan>((a, i) => a.SecondsToTimeSpan(i)),
+                TimeUnit.Millisecond => Items<Time64Array, TimeSpan>((a, i) => a.MillisecondsToTimeSpan(i)),
+                TimeUnit.Microsecond => Items<Time64Array, TimeSpan>((a, i) => a.MicrosecondsToTimeSpan(i)),
+                TimeUnit.Nanosecond => Items<Time64Array, TimeSpan>((a, i) => a.NanosecondsToTimeSpan(i)),
                 _ => throw new InvalidDataException($"Unsupported time unit for Time32Type: {TimeType.Unit}"),
             };
         }

--- a/csharp/src/Apache.Arrow/Arrays/Time64Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Time64Array.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 using Apache.Arrow.Types;
+using System;
 using System.IO;
 
 namespace Apache.Arrow
@@ -68,6 +69,8 @@ namespace Apache.Arrow
 
         public override void Accept(IArrowArrayVisitor visitor) => Accept(this, visitor);
 
+        public Time64Type TimeType => (Time64Type)Data.DataType;
+
         /// <summary>
         /// Get the time at the specified index as microseconds
         /// </summary>
@@ -82,12 +85,11 @@ namespace Apache.Arrow
                 return null;
             }
 
-            var unit = ((Time64Type)Data.DataType).Unit;
-            return unit switch
+            return TimeType.Unit switch
             {
                 TimeUnit.Microsecond => value,
                 TimeUnit.Nanosecond => value / 1_000,
-                _ => throw new InvalidDataException($"Unsupported time unit for Time64Type: {unit}")
+                _ => throw new InvalidDataException($"Unsupported time unit for Time64Type: {TimeType.Unit}")
             };
         }
 
@@ -105,13 +107,66 @@ namespace Apache.Arrow
                 return null;
             }
 
-            var unit = ((Time64Type)Data.DataType).Unit;
-            return unit switch
+            return TimeType.Unit switch
             {
                 TimeUnit.Microsecond => value * 1_000,
                 TimeUnit.Nanosecond => value,
-                _ => throw new InvalidDataException($"Unsupported time unit for Time64Type: {unit}")
+                _ => throw new InvalidDataException($"Unsupported time unit for Time64Type: {TimeType.Unit}")
             };
         }
+
+        public new TimeSpan? this[int index]
+        {
+            get
+            {
+                if (IsValid(index))
+                {
+                    return TimeType.Unit switch
+                    {
+                        TimeUnit.Second => (TimeSpan?)SecondsToTimeSpan(index),
+                        TimeUnit.Millisecond => (TimeSpan?)MillisecondsToTimeSpan(index),
+                        TimeUnit.Microsecond => (TimeSpan?)MicrosecondsToTimeSpan(index),
+                        TimeUnit.Nanosecond => (TimeSpan?)NanosecondsToTimeSpan(index),
+                        _ => throw new InvalidDataException($"Unsupported time unit for Time32Type: {TimeType.Unit}"),
+                    };
+                }
+                return null;
+            }
+            // TODO: Implement setter
+            //set
+            //{
+            //    data[index] = value;
+            //}
+        }
+
+        // Accessors
+        public new Accessor<Time64Array, TimeSpan?> Items()
+        {
+            return TimeType.Unit switch
+            {
+                TimeUnit.Second => new(this, (a, i) => a[i]),
+                TimeUnit.Millisecond => new(this, (a, i) => a[i]),
+                TimeUnit.Microsecond => new(this, (a, i) => a[i]),
+                TimeUnit.Nanosecond => new(this, (a, i) => a[i]),
+                _ => throw new InvalidDataException($"Unsupported time unit for Time32Type: {TimeType.Unit}"),
+            };
+        }
+        public new Accessor<Time64Array, TimeSpan> NotNullItems()
+        {
+            return TimeType.Unit switch
+            {
+                TimeUnit.Second => new(this, (a, i) => a.SecondsToTimeSpan(i)),
+                TimeUnit.Millisecond => new(this, (a, i) => a.MillisecondsToTimeSpan(i)),
+                TimeUnit.Microsecond => new(this, (a, i) => a.MicrosecondsToTimeSpan(i)),
+                TimeUnit.Nanosecond => new(this, (a, i) => a.NanosecondsToTimeSpan(i)),
+                _ => throw new InvalidDataException($"Unsupported time unit for Time32Type: {TimeType.Unit}"),
+            };
+        }
+
+        // Static Methods to Convert ticks to date/time instances
+        public TimeSpan SecondsToTimeSpan(int index) => Types.Convert.SecondsToTimeSpan(Values[index]);
+        public TimeSpan MillisecondsToTimeSpan(int index) => Types.Convert.MillisecondsToTimeSpan(Values[index]);
+        public TimeSpan MicrosecondsToTimeSpan(int index) => Types.Convert.MicrosecondsToTimeSpan(Values[index]);
+        public TimeSpan NanosecondsToTimeSpan(int index) => Types.Convert.NanosecondsToTimeSpan(Values[index]);
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/TimestampArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/TimestampArray.cs
@@ -13,10 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Apache.Arrow.Types;
 using System;
 using System.Diagnostics;
 using System.IO;
+using Apache.Arrow.Types;
 
 namespace Apache.Arrow
 {

--- a/csharp/src/Apache.Arrow/Arrays/TimestampArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/TimestampArray.cs
@@ -128,6 +128,8 @@ namespace Apache.Arrow
         {
             get
             {
+                if (index < 0)
+                    return this[Length + index];
                 return GetTimestamp(index);
             }
             // TODO: Implement setter

--- a/csharp/src/Apache.Arrow/Arrays/TimestampArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/TimestampArray.cs
@@ -140,10 +140,10 @@ namespace Apache.Arrow
         {
             return TimeType.Unit switch
             {
-                TimeUnit.Second => new(this, (a, i) => a.IsValid(i) ? a.UnixSecondsToDateTimeOffset(i) : null),
-                TimeUnit.Millisecond => new(this, (a, i) => a.IsValid(i) ? a.UnixMillisecondsToDateTimeOffset(i) : null),
-                TimeUnit.Microsecond => new(this, (a, i) => a.IsValid(i) ? a.UnixMicrosecondsToDateTimeOffset(i) : null),
-                TimeUnit.Nanosecond => new(this, (a, i) => a.IsValid(i) ? a.UnixNanosecondsToDateTimeOffset(i) : null),
+                TimeUnit.Second => Items<TimestampArray, DateTimeOffset?>((a, i) => a.IsValid(i) ? a.UnixSecondsToDateTimeOffset(i) : null),
+                TimeUnit.Millisecond => Items<TimestampArray, DateTimeOffset?>((a, i) => a.IsValid(i) ? a.UnixMillisecondsToDateTimeOffset(i) : null),
+                TimeUnit.Microsecond => Items<TimestampArray, DateTimeOffset?>((a, i) => a.IsValid(i) ? a.UnixMicrosecondsToDateTimeOffset(i) : null),
+                TimeUnit.Nanosecond => Items<TimestampArray, DateTimeOffset?>((a, i) => a.IsValid(i) ? a.UnixNanosecondsToDateTimeOffset(i) : null),
                 _ => throw new InvalidDataException($"Unsupported time unit for Time32Type: {TimeType.Unit}"),
             };
         }
@@ -151,10 +151,10 @@ namespace Apache.Arrow
         {
             return TimeType.Unit switch
             {
-                TimeUnit.Second => new(this, (a, i) => a.UnixSecondsToDateTimeOffset(i)),
-                TimeUnit.Millisecond => new(this, (a, i) => a.UnixMillisecondsToDateTimeOffset(i)),
-                TimeUnit.Microsecond => new(this, (a, i) => a.UnixMicrosecondsToDateTimeOffset(i)),
-                TimeUnit.Nanosecond => new(this, (a, i) => a.UnixNanosecondsToDateTimeOffset(i)),
+                TimeUnit.Second => Items<TimestampArray, DateTimeOffset>((a, i) => a.UnixSecondsToDateTimeOffset(i)),
+                TimeUnit.Millisecond => Items<TimestampArray, DateTimeOffset>((a, i) => a.UnixMillisecondsToDateTimeOffset(i)),
+                TimeUnit.Microsecond => Items<TimestampArray, DateTimeOffset>((a, i) => a.UnixMicrosecondsToDateTimeOffset(i)),
+                TimeUnit.Nanosecond => Items<TimestampArray, DateTimeOffset>((a, i) => a.UnixNanosecondsToDateTimeOffset(i)),
                 _ => throw new InvalidDataException($"Unsupported time unit for Time32Type: {TimeType.Unit}"),
             };
         }

--- a/csharp/src/Apache.Arrow/Arrays/TimestampArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/TimestampArray.cs
@@ -22,8 +22,6 @@ namespace Apache.Arrow
 {
     public class TimestampArray: PrimitiveArray<long>
     {
-        private static readonly DateTimeOffset s_epoch = new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero);
-
         public class Builder: PrimitiveArrayBuilder<DateTimeOffset, long, TimestampArray, Builder>
         {
             internal class TimestampBuilder : PrimitiveArrayBuilder<long, TimestampArray, TimestampBuilder>
@@ -70,7 +68,7 @@ namespace Apache.Arrow
                 // - Compute time span between epoch and specified time
                 // - Compute time divisions per tick
 
-                TimeSpan timeSpan = value - s_epoch;
+                TimeSpan timeSpan = value - Types.Convert.EpochDateTimeOffset;
                 long ticks = timeSpan.Ticks;
 
                 switch (DataType.Unit)
@@ -128,9 +126,7 @@ namespace Apache.Arrow
         {
             get
             {
-                if (index < 0)
-                    return this[Length + index];
-                return GetTimestamp(index);
+                return index < 0 ? this[Length + index] : GetTimestamp(index);
             }
             // TODO: Implement setter
             //set

--- a/csharp/src/Apache.Arrow/Extensions/DateTimeExtensions.cs
+++ b/csharp/src/Apache.Arrow/Extensions/DateTimeExtensions.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Apache.Arrow
+{
+    public static class DetaTimeExtensions
+    {
+        /// <summary>
+        /// Number of days from 1970-01-01
+        /// </summary>
+        /// <param name="dt">DateTime to double</param>
+        /// <returns>number of days</returns>
+        public static double ToUnixDays(this DateTime dt)
+        {
+            return (dt.Date - Types.Convert.EpochDateTime).TotalDays;
+        }
+    }
+}

--- a/csharp/src/Apache.Arrow/Extensions/DateTimeOffsetExtensions.cs
+++ b/csharp/src/Apache.Arrow/Extensions/DateTimeOffsetExtensions.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Apache.Arrow
+{
+    public static class DetaTimeOffsetExtensions
+    {
+        /// <summary>
+        /// Number of days from 1970-01-01
+        /// </summary>
+        /// <param name="dt">DetaTimeOffset to double</param>
+        /// <returns>number of days</returns>
+        public static double ToUnixDays(this DateTimeOffset dt)
+        {
+            return (dt.UtcDateTime.Date - Types.Convert.EpochDateTimeOffset).TotalDays;
+        }
+    }
+}

--- a/csharp/src/Apache.Arrow/Types/TimeType.cs
+++ b/csharp/src/Apache.Arrow/Types/TimeType.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 
 
+using System;
+
 namespace Apache.Arrow.Types
 {
     public enum TimeUnit
@@ -32,5 +34,43 @@ namespace Apache.Arrow.Types
         {
             Unit = unit;
         }
+    }
+
+    public class Convert
+    {
+        public static readonly DateTime EpochDateTime = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
+        public static readonly DateTimeOffset EpochDateTimeOffset = new(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        // Ticks to DateTime
+        public static DateTime UnixDaysToDateTime(int days) => EpochDateTime.AddDays(days);
+        public static DateTime UnixDaysToDateTime(long days) => EpochDateTime.AddDays(days);
+
+        public static DateTimeOffset UnixDaysToDateTimeOffset(int days) => EpochDateTimeOffset.AddDays(days);
+        public static DateTimeOffset UnixDaysToDateTimeOffset(long days) => EpochDateTimeOffset.AddDays(days);
+
+        public static DateTimeOffset UnixSecondsToDateTimeOffset(int seconds) => DateTimeOffset.FromUnixTimeSeconds(seconds);
+        public static DateTimeOffset UnixSecondsToDateTimeOffset(long seconds) => DateTimeOffset.FromUnixTimeSeconds(seconds);
+
+        public static DateTimeOffset UnixMillisecondsToDateTimeOffset(int millis) => DateTimeOffset.FromUnixTimeMilliseconds(millis);
+        public static DateTimeOffset UnixMillisecondsToDateTimeOffset(long millis) => DateTimeOffset.FromUnixTimeMilliseconds(millis);
+
+        public static DateTimeOffset UnixMicrosecondsToDateTimeOffset(int micros) => EpochDateTimeOffset.AddTicks(micros * 10);
+        public static DateTimeOffset UnixMicrosecondsToDateTimeOffset(long micros) => EpochDateTimeOffset.AddTicks(micros * 10);
+
+        public static DateTimeOffset UnixNanosecondsToDateTimeOffset(int nanos) => EpochDateTimeOffset.AddTicks(nanos / 100);
+        public static DateTimeOffset UnixNanosecondsToDateTimeOffset(long nanos) => EpochDateTimeOffset.AddTicks(nanos / 100);
+
+        // Ticks to TimeSpan
+        public static TimeSpan SecondsToTimeSpan(int seconds) => TimeSpan.FromSeconds(seconds);
+        public static TimeSpan SecondsToTimeSpan(long seconds) => TimeSpan.FromSeconds(seconds);
+
+        public static TimeSpan MillisecondsToTimeSpan(int millis) => TimeSpan.FromMilliseconds(millis);
+        public static TimeSpan MillisecondsToTimeSpan(long millis) => TimeSpan.FromMilliseconds(millis);
+
+        public static TimeSpan MicrosecondsToTimeSpan(int micros) => TimeSpan.FromTicks(micros * 10);
+        public static TimeSpan MicrosecondsToTimeSpan(long micros) => TimeSpan.FromTicks(micros * 10);
+
+        public static TimeSpan NanosecondsToTimeSpan(int nanos) => TimeSpan.FromTicks(nanos / 100);
+        public static TimeSpan NanosecondsToTimeSpan(long nanos) => TimeSpan.FromTicks(nanos / 100);
     }
 }

--- a/csharp/test/Apache.Arrow.Tests/BinaryArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/BinaryArrayTests.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Xunit;
+
+namespace Apache.Arrow.Tests
+{
+    public class BinaryArrayTests
+    {
+        public class IEnumerableArray
+        {
+            [Fact]
+            public void BinaryArray_ShouldBe_IEnumerable()
+            {
+                byte[] bvalue = new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05 };
+
+                // Build test array
+                Array.Accessor<BinaryArray, byte[]> array = new BinaryArray.Builder()
+                    .Append(bvalue.AsSpan<byte>()).AppendNull()
+                    .Build()
+                    .Items();
+
+                byte[][] expected = new byte[][] { bvalue, null };
+
+                int i = 0;
+                foreach (byte[] value in array)
+                {
+                    Assert.Equal(expected[i], value);
+                    i++;
+                }
+            }
+        }
+    }
+}

--- a/csharp/test/Apache.Arrow.Tests/Decimal128ArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/Decimal128ArrayTests.cs
@@ -257,5 +257,27 @@ namespace Apache.Arrow.Tests
                 }
             }
         }
+
+        public class IEnumerableArray
+        {
+            [Fact]
+            public void Decimal128Array_ShouldBe_IEnumerable()
+            {
+                // Build test array
+                Array.Accessor<Decimal128Array, decimal?> array = new Decimal128Array.Builder(15, 5)
+                    .Append((decimal)1.12345).AppendNull().Append((decimal)-12.98765)
+                    .Build()
+                    .Items();
+
+                decimal?[] expected = new decimal?[] { (decimal)1.12345, null, (decimal)-12.98765 };
+
+                int i = 0;
+                foreach (decimal? value in array)
+                {
+                    Assert.Equal(expected[i], value);
+                    i++;
+                }
+            }
+        }
     }
 }

--- a/csharp/test/Apache.Arrow.Tests/Decimal256ArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/Decimal256ArrayTests.cs
@@ -257,5 +257,27 @@ namespace Apache.Arrow.Tests
                 }
             }
         }
+
+        public class IEnumerableArray
+        {
+            [Fact]
+            public void Decimal256Array_ShouldBe_IEnumerable()
+            {
+                // Build test array
+                Array.Accessor<Decimal256Array, decimal?> array = new Decimal256Array.Builder(42, 9)
+                    .Append((decimal)1.123456).AppendNull().Append((decimal)-12.987654321)
+                    .Build()
+                    .Items();
+
+                decimal?[] expected = new decimal?[] { (decimal?)1.123456, null, (decimal?)-12.987654321 };
+
+                int i = 0;
+                foreach (decimal? value in array)
+                {
+                    Assert.Equal(expected[i], value);
+                    i++;
+                }
+            }
+        }
     }
 }

--- a/csharp/test/Apache.Arrow.Tests/ListArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ListArrayTests.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Linq;
+using Apache.Arrow.Types;
+using Xunit;
+
+namespace Apache.Arrow.Tests
+{
+    public class ListArrayTests
+    {
+        public class IEnumerableArray
+        {
+            [Fact]
+            public void ListArray_ShouldBe_IEnumerable()
+            {
+                // Build test array
+                var builder = new ListArray.Builder(new StringType());
+                var valueBuilder = (StringArray.Builder)builder.ValueBuilder;
+
+                // Populate
+                builder.Append();
+                valueBuilder.Append("john").AppendNull().Append("doe");
+                builder.Append();
+                valueBuilder.AppendNull().AppendNull().AppendNull();
+                builder.Append();
+                valueBuilder.AppendNull().Append("elon").Append("musk");
+
+                Array.Accessor<ListArray, StringArray> array = builder.Build().Items<StringArray>();
+
+                string[][] expected = new string[][]
+                {
+                    new string[] { "john", null, "doe" },
+                    new string[] { null, null, null },
+                    new string[] { null, "elon", "musk" }
+                };
+
+                // Assert
+                Assert.Equal(expected.Length, array.Length);
+
+                int i = 0;
+                foreach (StringArray value in array)
+                {
+                    Assert.Equal(expected[i], value.Items().ToArray());
+                    i++;
+                }
+            }
+        }
+    }
+}

--- a/csharp/test/Apache.Arrow.Tests/PrimitiveArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/PrimitiveArrayTests.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Linq;
+using Xunit;
+
+namespace Apache.Arrow.Tests
+{
+    public class PrimitiveArrayTests
+    {
+        public class Accessor
+        {
+            [Fact]
+            public void PrimitiveArray_ShouldBe_IEnumerable()
+            {
+                // Build test array
+                Array.Accessor<PrimitiveArray<int>, int?> array = new Int32Array.Builder()
+                    .Append(1).AppendNull().Append(-12)
+                    .Build()
+                    .Items();
+
+                int?[] expected = new int?[] { 1, null, -12 };
+
+                int i = 0;
+                foreach (int? value in array)
+                {
+                    Assert.Equal(expected[i], value);
+                    i++;
+                }
+            }
+
+            [Fact]
+            public void PrimitiveArray_Should_Use_System_Linq()
+            {
+                // Build test array
+                Array.Accessor<PrimitiveArray<int>, int?> array = new Int32Array.Builder()
+                    .Append(1).AppendNull().Append(-12)
+                    .Build()
+                    .Items();
+
+                Assert.Equal(new int?[] { 2 }, array.Select(i => i * 2).Where(i => i == 2).ToArray());
+                Assert.Equal(array.Sum(), -11);
+            }
+
+            [Fact]
+            public void PrimitiveArray_Should_GetFromIndex()
+            {
+                // Build test array
+                PrimitiveArray<long> array = new Int64Array.Builder()
+                    .Append(1).AppendNull().Append(-12)
+                    .Build();
+
+                Assert.Equal(1, array[0]);
+                Assert.Null(array[1]);
+                Assert.Equal(-12, array[2]);
+                Assert.Equal(array[-1], array[2]);
+                Assert.Equal(array[-2], array[1]);
+                Assert.Equal(array[-3], array[0]);
+            }
+        }
+    }
+}

--- a/csharp/test/Apache.Arrow.Tests/StringArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/StringArrayTests.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+namespace Apache.Arrow.Tests
+{
+    public class StringArrayTests
+    {
+        public class IEnumerableArray
+        {
+            [Fact]
+            public void StringArray_ShouldBe_IEnumerable()
+            {
+                // Build test array
+                Array.Accessor<StringArray, string> array = new StringArray.Builder()
+                    .Append("john").AppendNull().Append("doe")
+                    .Build()
+                    .Items();
+
+                string[] expected = new string[] { "john", null, "doe" };
+
+                int i = 0;
+                foreach (string value in array)
+                {
+                    Assert.Equal(expected[i], value);
+                    i++;
+                }
+            }
+        }
+    }
+}

--- a/csharp/test/Apache.Arrow.Tests/Time32ArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/Time32ArrayTests.cs
@@ -1,0 +1,65 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Apache.Arrow.Types;
+using Xunit;
+
+namespace Apache.Arrow.Tests
+{
+    public class Time32ArrayTests
+    {
+        public class IEnumerableArray
+        {
+            [Fact]
+            public void Time32Array_Seconds_ShouldBe_IEnumerable()
+            {
+                // Build test array
+                Array.Accessor<Time32Array, TimeSpan?> array = new Time32Array.Builder(TimeUnit.Second)
+                    .Append(1).AppendNull().Append(-1)
+                    .Build()
+                    .Items();
+
+                TimeSpan?[] expected = new TimeSpan?[] { TimeSpan.FromSeconds(1), null, TimeSpan.FromSeconds(-1) };
+
+                int i = 0;
+                foreach (TimeSpan? value in array)
+                {
+                    Assert.Equal(expected[i], value);
+                    i++;
+                }
+            }
+
+            [Fact]
+            public void Time32Array_MilliSeconds_ShouldBe_IEnumerable()
+            {
+                // Build test array
+                Array.Accessor<Time32Array, TimeSpan?> array = new Time32Array.Builder(TimeUnit.Millisecond)
+                    .Append(1).AppendNull().Append(-1)
+                    .Build()
+                    .Items();
+
+                TimeSpan?[] expected = new TimeSpan?[] { TimeSpan.FromMilliseconds(1), null, TimeSpan.FromMilliseconds(-1) };
+
+                int i = 0;
+                foreach (TimeSpan? value in array)
+                {
+                    Assert.Equal(expected[i], value);
+                    i++;
+                }
+            }
+        }
+    }
+}

--- a/csharp/test/Apache.Arrow.Tests/Time64ArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/Time64ArrayTests.cs
@@ -1,0 +1,65 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Apache.Arrow.Types;
+using Xunit;
+
+namespace Apache.Arrow.Tests
+{
+    public class Time64ArrayTests
+    {
+        public class IEnumerableArray
+        {
+            [Fact]
+            public void Time64Array_MicroSeconds_ShouldBe_IEnumerable()
+            {
+                // Build test array
+                Array.Accessor<Time64Array, TimeSpan?> array = new Time64Array.Builder(TimeUnit.Microsecond)
+                    .Append(1).AppendNull().Append(-1)
+                    .Build()
+                    .Items();
+
+                TimeSpan?[] expected = new TimeSpan?[] { TimeSpan.FromMicroseconds(1), null, TimeSpan.FromMicroseconds(-1) };
+
+                int i = 0;
+                foreach (TimeSpan? value in array)
+                {
+                    Assert.Equal(expected[i], value);
+                    i++;
+                }
+            }
+
+            [Fact]
+            public void Time64Array_NanoSeconds_ShouldBe_IEnumerable()
+            {
+                // Build test array
+                Array.Accessor<Time64Array, TimeSpan?> array = new Time64Array.Builder(TimeUnit.Nanosecond)
+                    .Append(123).AppendNull().Append(-987)
+                    .Build()
+                    .Items();
+
+                TimeSpan?[] expected = new TimeSpan?[] { TimeSpan.FromTicks(1), null, TimeSpan.FromTicks(-9) };
+
+                int i = 0;
+                foreach (TimeSpan? value in array)
+                {
+                    Assert.Equal(expected[i], value);
+                    i++;
+                }
+            }
+        }
+    }
+}

--- a/csharp/test/Apache.Arrow.Tests/TimestampArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/TimestampArrayTests.cs
@@ -1,0 +1,103 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Apache.Arrow.Types;
+using Xunit;
+
+namespace Apache.Arrow.Tests
+{
+    public class TimestampArrayTests
+    {
+        public class IEnumerableArray
+        {
+            [Fact]
+            public void TimestampArray_Seconds_ShouldBe_IEnumerable()
+            {
+                // Build test array
+                Array.Accessor<TimestampArray, DateTimeOffset?> array = new TimestampArray.Builder(TimeUnit.Second)
+                    .Append(DateTimeOffset.FromUnixTimeMilliseconds(1)).AppendNull().Append(DateTimeOffset.FromUnixTimeSeconds(-1))
+                    .Build()
+                    .Items();
+
+                DateTimeOffset?[] expected = new DateTimeOffset?[] { DateTimeOffset.FromUnixTimeMilliseconds(0), null, DateTimeOffset.FromUnixTimeSeconds(-1) };
+
+                int i = 0;
+                foreach (DateTimeOffset? value in array)
+                {
+                    Assert.Equal(expected[i], value);
+                    i++;
+                }
+            }
+
+            [Fact]
+            public void TimestampArray_Milliseconds_ShouldBe_IEnumerable()
+            {
+                // Build test array
+                Array.Accessor<TimestampArray, DateTimeOffset?> array = new TimestampArray.Builder(TimeUnit.Millisecond)
+                    .Append(DateTimeOffset.FromUnixTimeMilliseconds(1)).AppendNull().Append(DateTimeOffset.FromUnixTimeSeconds(-1))
+                    .Build()
+                    .Items();
+
+                DateTimeOffset?[] expected = new DateTimeOffset?[] { DateTimeOffset.FromUnixTimeMilliseconds(1), null, DateTimeOffset.FromUnixTimeSeconds(-1) };
+
+                int i = 0;
+                foreach (DateTimeOffset? value in array)
+                {
+                    Assert.Equal(expected[i], value);
+                    i++;
+                }
+            }
+
+            [Fact]
+            public void TimestampArray_Microseconds_ShouldBe_IEnumerable()
+            {
+                // Build test array
+                Array.Accessor<TimestampArray, DateTimeOffset?> array = new TimestampArray.Builder(TimeUnit.Microsecond)
+                    .Append(DateTimeOffset.FromUnixTimeMilliseconds(1)).AppendNull().Append(DateTimeOffset.FromUnixTimeSeconds(-1))
+                    .Build()
+                    .Items();
+
+                DateTimeOffset?[] expected = new DateTimeOffset?[] { DateTimeOffset.FromUnixTimeMilliseconds(1), null, DateTimeOffset.FromUnixTimeSeconds(-1) };
+
+                int i = 0;
+                foreach (DateTimeOffset? value in array)
+                {
+                    Assert.Equal(expected[i], value);
+                    i++;
+                }
+            }
+
+            [Fact]
+            public void TimestampArray_Nanoseconds_ShouldBe_IEnumerable()
+            {
+                // Build test array
+                Array.Accessor<TimestampArray, DateTimeOffset?> array = new TimestampArray.Builder(TimeUnit.Nanosecond)
+                    .Append(DateTimeOffset.FromUnixTimeMilliseconds(1)).AppendNull().Append(DateTimeOffset.FromUnixTimeSeconds(-1))
+                    .Build()
+                    .Items();
+
+                DateTimeOffset?[] expected = new DateTimeOffset?[] { DateTimeOffset.FromUnixTimeMilliseconds(1), null, DateTimeOffset.FromUnixTimeSeconds(-1) };
+
+                int i = 0;
+                foreach (DateTimeOffset? value in array)
+                {
+                    Assert.Equal(expected[i], value);
+                    i++;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Rationale for this change

Make Arrow array closer to C# native implementations with IEnumerable, [index] getter

### What changes are included in this PR?

Add Array.Items() Accessor to iterate / use System.Linq with a default C# type based on arrow array

### Are these changes tested?

Yes

### Are there any user-facing changes?

No, only new features
* Closes: #35155