### PR TITLE
GH-35175: [C#] Decimal128 / 256 Types should alloc dynamic byteWidth based on precision and scale

### DIFF
--- a/csharp/src/Apache.Arrow/Arrays/Decimal128Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Decimal128Array.cs
@@ -16,7 +16,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Numerics;
 using Apache.Arrow.Arrays;
 using Apache.Arrow.Types;
 
@@ -26,7 +25,7 @@ namespace Apache.Arrow
     {
         public class Builder : BuilderBase<Decimal128Array, Builder>
         {
-            public Builder(Decimal128Type type) : base(type, 16)
+            public Builder(Decimal128Type type) : base(type, type.ByteWidth)
             {
                 DataType = type;
             }

--- a/csharp/src/Apache.Arrow/Arrays/Decimal256Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Decimal256Array.cs
@@ -16,7 +16,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Numerics;
 using Apache.Arrow.Arrays;
 using Apache.Arrow.Types;
 
@@ -26,7 +25,7 @@ namespace Apache.Arrow
     {
         public class Builder : BuilderBase<Decimal256Array, Builder>
         {
-            public Builder(Decimal256Type type) : base(type, 32)
+            public Builder(Decimal256Type type) : base(type, type.ByteWidth)
             {
                 DataType = type;
             }

--- a/csharp/src/Apache.Arrow/DecimalUtility.cs
+++ b/csharp/src/Apache.Arrow/DecimalUtility.cs
@@ -14,8 +14,6 @@
 // limitations under the License.
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Numerics;
 
 namespace Apache.Arrow
@@ -159,39 +157,6 @@ namespace Apache.Arrow
                     bytes[i] = 255;
                 }
             }
-        }
-
-        internal static BigInteger ToBigInteger(int[] decimalBits)
-        {
-#if NETCOREAPP
-            Span<byte> bigIntBytes = stackalloc byte[13];
-
-            Span<byte> intBytes = stackalloc byte[4];
-            for (int i = 0; i < 3; i++)
-            {
-                int bit = decimalBits[i];
-                if (!BitConverter.TryWriteBytes(intBytes, bit))
-                    throw new OverflowException($"Could not extract bytes from int {bit}");
-
-                for (int j = 0; j < 4; j++)
-                {
-                    bigIntBytes[4 * i + j] = intBytes[j];
-                }
-            }
-            return new BigInteger(bigIntBytes);
-#else
-            byte[] bigIntBytes = new byte[13];
-            for (int i = 0; i < 3; i++)
-            {
-                int bit = decimalBits[i];
-                byte[] intBytes = BitConverter.GetBytes(bit);
-                for (int j = 0; j < intBytes.Length; j++)
-                {
-                    bigIntBytes[4 * i + j] = intBytes[j];
-                }
-            }
-            return new BigInteger(bigIntBytes);
-#endif
         }
 
         internal static int GetByteWidth(BigInteger bigInt)

--- a/csharp/src/Apache.Arrow/DecimalUtility.cs
+++ b/csharp/src/Apache.Arrow/DecimalUtility.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Numerics;
 
 namespace Apache.Arrow
@@ -157,6 +159,48 @@ namespace Apache.Arrow
                     bytes[i] = 255;
                 }
             }
+        }
+
+        internal static BigInteger ToBigInteger(int[] decimalBits)
+        {
+#if NETCOREAPP
+            Span<byte> bigIntBytes = stackalloc byte[13];
+
+            Span<byte> intBytes = stackalloc byte[4];
+            for (int i = 0; i < 3; i++)
+            {
+                int bit = decimalBits[i];
+                if (!BitConverter.TryWriteBytes(intBytes, bit))
+                    throw new OverflowException($"Could not extract bytes from int {bit}");
+
+                for (int j = 0; j < 4; j++)
+                {
+                    bigIntBytes[4 * i + j] = intBytes[j];
+                }
+            }
+            return new BigInteger(bigIntBytes);
+#else
+            byte[] bigIntBytes = new byte[13];
+            for (int i = 0; i < 3; i++)
+            {
+                int bit = decimalBits[i];
+                byte[] intBytes = BitConverter.GetBytes(bit);
+                for (int j = 0; j < intBytes.Length; j++)
+                {
+                    bigIntBytes[4 * i + j] = intBytes[j];
+                }
+            }
+            return new BigInteger(bigIntBytes);
+#endif
+        }
+
+        internal static int GetByteWidth(BigInteger bigInt)
+        {
+#if NETCOREAPP
+            return bigInt.GetByteCount();
+#else
+            return bigInt.ToByteArray().Length;
+#endif
         }
     }
 }

--- a/csharp/src/Apache.Arrow/Ipc/MessageSerializer.cs
+++ b/csharp/src/Apache.Arrow/Ipc/MessageSerializer.cs
@@ -142,7 +142,7 @@ namespace Apache.Arrow.Ipc
                     return (decMeta.BitWidth / 8) switch
                     {
                         int b16 when b16 < 17 => new Types.Decimal128Type(decMeta.Precision, decMeta.Scale, b16),
-                        int b32 when b32 < 17 => new Types.Decimal256Type(decMeta.Precision, decMeta.Scale, b32),
+                        int b32 when b32 < 33 => new Types.Decimal256Type(decMeta.Precision, decMeta.Scale, b32),
                         _ => throw new InvalidDataException("Unsupported decimal bit width " + decMeta.BitWidth),
                     };
                 case Flatbuf.Type.Date:

--- a/csharp/src/Apache.Arrow/Ipc/MessageSerializer.cs
+++ b/csharp/src/Apache.Arrow/Ipc/MessageSerializer.cs
@@ -139,11 +139,12 @@ namespace Apache.Arrow.Ipc
                 case Flatbuf.Type.Decimal:
                     Flatbuf.Decimal decMeta = field.Type<Flatbuf.Decimal>().Value;
 
-                    if (decMeta.BitWidth < 129)
-                        return new Types.Decimal128Type(decMeta.Precision, decMeta.Scale, decMeta.BitWidth / 8);
-                    else if (decMeta.BitWidth < 257)
-                        return new Types.Decimal256Type(decMeta.Precision, decMeta.Scale, decMeta.BitWidth / 8);
-                    throw new InvalidDataException("Unsupported decimal bit width " + decMeta.BitWidth);
+                    return (decMeta.BitWidth / 8) switch
+                    {
+                        int b16 when b16 < 17 => new Types.Decimal128Type(decMeta.Precision, decMeta.Scale, b16),
+                        int b32 when b32 < 17 => new Types.Decimal256Type(decMeta.Precision, decMeta.Scale, b32),
+                        _ => throw new InvalidDataException("Unsupported decimal bit width " + decMeta.BitWidth),
+                    };
                 case Flatbuf.Type.Date:
                     Flatbuf.Date dateMeta = field.Type<Flatbuf.Date>().Value;
                     switch (dateMeta.Unit)

--- a/csharp/src/Apache.Arrow/Ipc/MessageSerializer.cs
+++ b/csharp/src/Apache.Arrow/Ipc/MessageSerializer.cs
@@ -138,15 +138,12 @@ namespace Apache.Arrow.Ipc
                     return new Types.BooleanType();
                 case Flatbuf.Type.Decimal:
                     Flatbuf.Decimal decMeta = field.Type<Flatbuf.Decimal>().Value;
-                    switch (decMeta.BitWidth)
-                    {
-                        case 128:
-                            return new Types.Decimal128Type(decMeta.Precision, decMeta.Scale);
-                        case 256:
-                            return new Types.Decimal256Type(decMeta.Precision, decMeta.Scale);
-                        default:
-                            throw new InvalidDataException("Unsupported decimal bit width " + decMeta.BitWidth);
-                    }
+
+                    if (decMeta.BitWidth < 129)
+                        return new Types.Decimal128Type(decMeta.Precision, decMeta.Scale, decMeta.BitWidth / 8);
+                    else if (decMeta.BitWidth < 257)
+                        return new Types.Decimal256Type(decMeta.Precision, decMeta.Scale, decMeta.BitWidth / 8);
+                    throw new InvalidDataException("Unsupported decimal bit width " + decMeta.BitWidth);
                 case Flatbuf.Type.Date:
                     Flatbuf.Date dateMeta = field.Type<Flatbuf.Date>().Value;
                     switch (dateMeta.Unit)

--- a/csharp/src/Apache.Arrow/Types/Decimal128Type.cs
+++ b/csharp/src/Apache.Arrow/Types/Decimal128Type.cs
@@ -13,10 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
+using System.Numerics;
+
 namespace Apache.Arrow.Types
 {
     public sealed class Decimal128Type : FixedSizeBinaryType
     {
+        public static readonly Decimal128Type Default = new(29, 9, 16);
         public override ArrowTypeId TypeId => ArrowTypeId.Decimal128;
         public override string Name => "decimal128";
 
@@ -24,8 +28,22 @@ namespace Apache.Arrow.Types
         public int Scale { get; }
 
         public Decimal128Type(int precision, int scale)
-            : base(16)
+            : this(precision, scale, DecimalUtility.GetByteWidth(BigInteger.Parse(new string('9', precision + scale))))
         {
+        }
+
+        public Decimal128Type(int precision, int scale, int byteWidth)
+            : base(byteWidth)
+        {
+            if (byteWidth > 16)
+            {
+                throw new OverflowException($"Cannot create Decimal128Type({precision}, {scale}, {byteWidth}), byteWidth should be between 1 and 16");
+            }
+            if (precision > 38)
+            {
+                throw new OverflowException($"Cannot create Decimal128Type({precision}, {scale}, {byteWidth}), precision should be between 1 and 38");
+            }
+
             Precision = precision;
             Scale = scale;
         }

--- a/csharp/src/Apache.Arrow/Types/Decimal256Type.cs
+++ b/csharp/src/Apache.Arrow/Types/Decimal256Type.cs
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Numerics;
 using System;
+using System.Numerics;
 
 namespace Apache.Arrow.Types
 {

--- a/csharp/src/Apache.Arrow/Types/Decimal256Type.cs
+++ b/csharp/src/Apache.Arrow/Types/Decimal256Type.cs
@@ -13,10 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Numerics;
+using System;
+
 namespace Apache.Arrow.Types
 {
     public sealed class Decimal256Type: FixedSizeBinaryType
     {
+        public static readonly Decimal256Type Default = new(38, 18, 24);
         public override ArrowTypeId TypeId => ArrowTypeId.Decimal256;
         public override string Name => "decimal256";
 
@@ -24,8 +28,22 @@ namespace Apache.Arrow.Types
         public int Scale { get; }
 
         public Decimal256Type(int precision, int scale)
-            : base(32)
+            : this(precision, scale, DecimalUtility.GetByteWidth(BigInteger.Parse(new string('9', precision + scale))))
         {
+        }
+
+        public Decimal256Type(int precision, int scale, int byteWidth)
+            : base(byteWidth)
+        {
+            if (byteWidth > 32)
+            {
+                throw new OverflowException($"Cannot create Decimal256Type({precision}, {scale}, {byteWidth}), byteWidth should be between 1 and 32");
+            }
+            if (precision > 76)
+            {
+                throw new OverflowException($"Cannot create Decimal256Type({precision}, {scale}, {byteWidth}), precision should be between 1 and 76");
+            }
+
             Precision = precision;
             Scale = scale;
         }

--- a/csharp/test/Apache.Arrow.Tests/Decimal128ArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/Decimal128ArrayTests.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 using System;
-using System.Collections.Generic;
 using Apache.Arrow.Types;
 using Xunit;
 
@@ -41,7 +40,7 @@ namespace Apache.Arrow.Tests
                     var array = builder.Build();
 
                     Assert.Equal(3, array.Length);
-                    Assert.Equal(array.Data.Buffers[1].Length, array.ByteWidth * 3);
+                    Assert.Equal(array.Data.Buffers[1].Length, array.ByteWidth * 3 + array.ByteWidth - 1);
                     Assert.Null(array.GetValue(0));
                     Assert.Null(array.GetValue(1));
                     Assert.Null(array.GetValue(2));
@@ -121,7 +120,7 @@ namespace Apache.Arrow.Tests
                 public void AppendFractionalDecimal()
                 {
                     // Arrange
-                    var builder = new Decimal128Array.Builder(new Decimal128Type(26, 20));
+                    var builder = new Decimal256Array.Builder(new Decimal256Type(26, 20));
                     decimal fraction = 0.99999999999990999992M;
                     // Act
                     builder.Append(fraction);

--- a/csharp/test/Apache.Arrow.Tests/Decimal256ArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/Decimal256ArrayTests.cs
@@ -41,7 +41,7 @@ namespace Apache.Arrow.Tests
                     var array = builder.Build();
 
                     Assert.Equal(3, array.Length);
-                    Assert.Equal(array.Data.Buffers[1].Length, array.ByteWidth * 3);
+                    Assert.Equal(array.Data.Buffers[1].Length, array.ByteWidth * 3 + array.ByteWidth - 1);
                     Assert.Null(array.GetValue(0));
                     Assert.Null(array.GetValue(1));
                     Assert.Null(array.GetValue(2));

--- a/csharp/test/Apache.Arrow.Tests/Types/Decimal128TypeTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/Types/Decimal128TypeTests.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Apache.Arrow.Types;
+using Xunit;
+
+namespace Apache.Arrow.Tests.Types
+{
+    public class Decimal128TypeTests
+    {
+        [Fact]
+        public void Default_Should_Match()
+        {
+            Decimal128Type type = Decimal128Type.Default;
+
+            // Assert
+            Assert.Equal(13, type.ByteWidth);
+            Assert.Equal(29, type.Precision);
+            Assert.Equal(15, type.Scale);
+        }
+
+        [Fact]
+        public void Constructor_Should_ComputeByteWidth()
+        {
+            // Assert
+            Assert.Equal(9, new Decimal128Type(15, 5).ByteWidth);
+            Assert.Equal(5, new Decimal128Type(10, 0).ByteWidth);
+            Assert.Equal(16, new Decimal128Type(29, 8).ByteWidth);
+            Assert.Equal(16, new Decimal128Type(29, 9).ByteWidth);
+            Assert.Throws<OverflowException>(() => new Decimal128Type(29, 10));
+            Assert.Throws<OverflowException>(() => new Decimal128Type(39, 0));
+        }
+    }
+}

--- a/csharp/test/Apache.Arrow.Tests/Types/Decimal128TypeTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/Types/Decimal128TypeTests.cs
@@ -27,9 +27,9 @@ namespace Apache.Arrow.Tests.Types
             Decimal128Type type = Decimal128Type.Default;
 
             // Assert
-            Assert.Equal(13, type.ByteWidth);
+            Assert.Equal(16, type.ByteWidth);
             Assert.Equal(29, type.Precision);
-            Assert.Equal(15, type.Scale);
+            Assert.Equal(9, type.Scale);
         }
 
         [Fact]

--- a/csharp/test/Apache.Arrow.Tests/Types/Decimal256TypeTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/Types/Decimal256TypeTests.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Apache.Arrow.Types;
+using Xunit;
+
+namespace Apache.Arrow.Tests.Types
+{
+    public class Decimal256TypeTests
+    {
+        [Fact]
+        public void Default_Should_Match()
+        {
+            Decimal256Type type = Decimal256Type.Default;
+
+            // Assert
+            Assert.Equal(24, type.ByteWidth);
+            Assert.Equal(38, type.Precision);
+            Assert.Equal(18, type.Scale);
+        }
+
+        [Fact]
+        public void Constructor_Should_ComputeByteWidth()
+        {
+            // Assert
+            Assert.Equal(9, new Decimal256Type(15, 5).ByteWidth);
+            Assert.Equal(17, new Decimal256Type(29, 10).ByteWidth);
+            Assert.Equal(32, new Decimal256Type(46, 29).ByteWidth);
+            Assert.Equal(32, new Decimal256Type(46, 30).ByteWidth);
+            Assert.Throws<OverflowException>(() => new Decimal256Type(46, 31));
+            Assert.Throws<OverflowException>(() => new Decimal256Type(77, 10));
+        }
+    }
+}


### PR DESCRIPTION
Compute from precision and scale to get the optimal byteWidth to store values instead of forcing to 16 and 32

It is tested in Arrow.Tests.Types

It should not impact end users since its stored in variable ByteWidth

* Closes: #35175