### PR TITLE
GH-35192: [Docs] Switch from `logo` to `logo_url` to support sphinx >= 6

### DIFF
--- a/docs/source/_templates/docs-sidebar.html
+++ b/docs/source/_templates/docs-sidebar.html
@@ -1,6 +1,6 @@
 
 <a class="navbar-brand" href="{{ pathto(master_doc) }}">
-  <img src="{{ pathto('_static/' + logo, 1) }}" class="logo" alt="logo">
+  <img src="{{ pathto('_static/' + logo_url, 1) }}" class="logo" alt="logo">
 </a>
 
 <div id="version-search-wrapper">


### PR DESCRIPTION
### Rationale for this change

Sphinx dropped support for the `logo` property in release 6.  See https://github.com/sphinx-doc/sphinx/issues/11062  Instead we are supposed to use `logo_url` which has been available since release 4.

### What changes are included in this PR?

Change from `logo` to `logo_url`

### Are these changes tested?

There was a CI test that was failing so yes.

### Are there any user-facing changes?

No.  We already required `sphinx >= 4` and since `logo_url` is available in 4 we should not need to update the minimum sphinx version.
* Closes: #35192