### PR TITLE
GH-35179: [C++] Set missing IMPORTED_CONFIGURATIONS property for Arrow::bundled_dependencies

### DIFF
--- a/cpp/src/arrow/ArrowConfig.cmake.in
+++ b/cpp/src/arrow/ArrowConfig.cmake.in
@@ -101,7 +101,7 @@ if(TARGET Arrow::arrow_static AND NOT TARGET Arrow::arrow_bundled_dependencies)
   foreach(CONFIGURATION ${arrow_static_configurations})
     string(TOUPPER "${CONFIGURATION}" CONFIGURATION)
     get_target_property(arrow_static_location Arrow::arrow_static
-                        LOCATION_${CONFIGURATION})
+                        IMPORTED_LOCATION_${CONFIGURATION})
     get_filename_component(arrow_lib_dir "${arrow_static_location}" DIRECTORY)
     set_target_properties(Arrow::arrow_bundled_dependencies
                           PROPERTIES IMPORTED_LOCATION_${CONFIGURATION}

--- a/cpp/src/arrow/ArrowConfig.cmake.in
+++ b/cpp/src/arrow/ArrowConfig.cmake.in
@@ -101,7 +101,7 @@ if(TARGET Arrow::arrow_static AND NOT TARGET Arrow::arrow_bundled_dependencies)
   foreach(CONFIGURATION ${arrow_static_configurations})
     string(TOUPPER "${CONFIGURATION}" CONFIGURATION)
     get_target_property(arrow_static_location Arrow::arrow_static
-                        IMPORTED_LOCATION_${CONFIGURATION})
+                        LOCATION_${CONFIGURATION})
     get_filename_component(arrow_lib_dir "${arrow_static_location}" DIRECTORY)
     set_property(TARGET Arrow::arrow_bundled_dependencies
                  APPEND

--- a/cpp/src/arrow/ArrowConfig.cmake.in
+++ b/cpp/src/arrow/ArrowConfig.cmake.in
@@ -103,6 +103,9 @@ if(TARGET Arrow::arrow_static AND NOT TARGET Arrow::arrow_bundled_dependencies)
     get_target_property(arrow_static_location Arrow::arrow_static
                         IMPORTED_LOCATION_${CONFIGURATION})
     get_filename_component(arrow_lib_dir "${arrow_static_location}" DIRECTORY)
+    set_property(TARGET Arrow::arrow_bundled_dependencies
+                 APPEND
+                 PROPERTY IMPORTED_CONFIGURATIONS ${CONFIGURATION})
     set_target_properties(Arrow::arrow_bundled_dependencies
                           PROPERTIES IMPORTED_LOCATION_${CONFIGURATION}
                                      "${arrow_lib_dir}/${CMAKE_STATIC_LIBRARY_PREFIX}arrow_bundled_dependencies${CMAKE_STATIC_LIBRARY_SUFFIX}"


### PR DESCRIPTION
### What changes are included in this PR?

We need to set the `IMPORTED_CONFIGURATIONS` property to use `IMPORTED_LOCATION_<CONFIGURATION>`.

### Are these changes tested?

Crossbow
* Closes: #35179