### PR TITLE
MINOR: [Docs] Fix preview docs job to use crossbow main instead of master

### DIFF
--- a/dev/tasks/docs/github.linux.yml
+++ b/dev/tasks/docs/github.linux.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout Crossbow
         uses: actions/checkout@v3
         with:
-          ref: {{ default_branch|default("master") }}
+          ref: {{ default_branch|default("main") }}
           path: crossbow
           fetch-depth: 1
       - name: Prepare docs


### PR DESCRIPTION
### Rationale for this change

The job is failing with:
```
Fetching the repository
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +refs/heads/master*:refs/remotes/origin/master* +refs/tags/master*:refs/tags/master*
  The process '/usr/bin/git' failed with exit code 1
```
See: https://github.com/apache/arrow/pull/35194#issuecomment-1511989544

### What changes are included in this PR?

Change `master` for `main` on the job.

### Are these changes tested?

Archery test