### PR TITLE
GH-35209: [Python] Add a type alias for pa.dictionary(pa.int32(), pa.string())

### DIFF
--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -952,6 +952,23 @@ class BaseCSVTableRead(BaseTestCSV):
             'b': [2.5, -3.0, None],
         }
 
+    def test_dictionary(self):
+        # Infer floats with a custom decimal point
+        parse_options = ParseOptions(delimiter=';')
+        rows = b"a;b\nx;x\ny;y\nx;x"
+
+        schema = pa.schema([('a', pa.dictionary(pa.int32(), pa.string())),
+                            ('b', "dictionary[int32,string]")])
+        convert_options = ConvertOptions(column_types=schema)
+        table = self.read_bytes(rows, parse_options=parse_options,
+                                convert_options=convert_options)
+
+        assert table.schema == schema
+        assert table.to_pydict() == {
+            'a': ["x", "y", "x"],
+            'b': ["x", "y", "x"],
+        }
+
     def test_simple_timestamps(self):
         # Infer a timestamp column
         rows = (b"a,b,c\n"

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -4790,7 +4790,7 @@ cdef dict _type_aliases = {
     'duration[us]': duration('us'),
     'duration[ns]': duration('ns'),
     'month_day_nano_interval': month_day_nano_interval(),
-    'dictionary[int32,string]' : dictionary(int32, string),
+    'dictionary[int32,string]' : dictionary(int32(), utf8()),
 }
 
 

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -4790,6 +4790,7 @@ cdef dict _type_aliases = {
     'duration[us]': duration('us'),
     'duration[ns]': duration('ns'),
     'month_day_nano_interval': month_day_nano_interval(),
+    'dictionary[int32,string]' : dictionary(int32, string),
 }
 
 

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -4790,6 +4790,8 @@ cdef dict _type_aliases = {
     'duration[us]': duration('us'),
     'duration[ns]': duration('ns'),
     'month_day_nano_interval': month_day_nano_interval(),
+
+    # Composite types
     'dictionary[int32,string]': dictionary(int32(), utf8()),
 }
 

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -4790,7 +4790,7 @@ cdef dict _type_aliases = {
     'duration[us]': duration('us'),
     'duration[ns]': duration('ns'),
     'month_day_nano_interval': month_day_nano_interval(),
-    'dictionary[int32,string]' : dictionary(int32(), utf8()),
+    'dictionary[int32,string]': dictionary(int32(), utf8()),
 }
 
 


### PR DESCRIPTION
Fixes #35209
* Closes: #35209