### PR TITLE
MINOR: [Go][FlightSQL] Fix Sqlite example Nullable in schema

### DIFF
--- a/go/arrow/flight/flightsql/example/sqlite_server.go
+++ b/go/arrow/flight/flightsql/example/sqlite_server.go
@@ -149,12 +149,12 @@ func CreateDB() (*sql.DB, error) {
 
 	_, err = db.Exec(`
 	CREATE TABLE foreignTable (
-		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
 		foreignName varchar(100),
 		value int);
 
 	CREATE TABLE intTable (
-		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
 		keyName varchar(100),
 		value int,
 		foreignId int references foreignTable(id));

--- a/go/arrow/flight/flightsql/example/sqlite_tables_schema_batch_reader.go
+++ b/go/arrow/flight/flightsql/example/sqlite_tables_schema_batch_reader.go
@@ -179,7 +179,7 @@ func (s *SqliteTablesSchemaBatchReader) Next() bool {
 			columnFields = append(columnFields, arrow.Field{
 				Name:     name,
 				Type:     getArrowTypeFromString(typ),
-				Nullable: nn == 1,
+				Nullable: nn == 0,
 				Metadata: getColumnMetadata(bldr, getSqlTypeFromTypeName(typ), tableName),
 			})
 		}

--- a/go/arrow/flight/flightsql/sqlite_server_test.go
+++ b/go/arrow/flight/flightsql/sqlite_server_test.go
@@ -316,11 +316,11 @@ func (s *FlightSqliteServerSuite) TestCommandGetTablesWithIncludedSchemas() {
 	tableSchema := arrow.NewSchema([]arrow.Field{
 		{Name: "id", Type: arrow.PrimitiveTypes.Int64,
 			Metadata: s.getColMetadata(sqlite3.SQLITE_INTEGER, dbTableName)},
-		{Name: "keyName", Type: arrow.BinaryTypes.String,
+		{Name: "keyName", Type: arrow.BinaryTypes.String, Nullable: true,
 			Metadata: s.getColMetadata(sqlite3.SQLITE_TEXT, dbTableName)},
-		{Name: "value", Type: arrow.PrimitiveTypes.Int64,
+		{Name: "value", Type: arrow.PrimitiveTypes.Int64, Nullable: true,
 			Metadata: s.getColMetadata(sqlite3.SQLITE_INTEGER, dbTableName)},
-		{Name: "foreignId", Type: arrow.PrimitiveTypes.Int64,
+		{Name: "foreignId", Type: arrow.PrimitiveTypes.Int64, Nullable: true,
 			Metadata: s.getColMetadata(sqlite3.SQLITE_INTEGER, dbTableName)},
 	}, nil)
 	schemaBuf := flight.SerializeSchema(tableSchema, s.mem)


### PR DESCRIPTION
Fix SQLite FlightSQL GetTableSchema example to *properly* return the nullable flag