### PR TITLE
GH-35205: [C++][Gandiva] Don't find system Zstandard when we use bundled one

### DIFF
--- a/cpp/src/gandiva/CMakeLists.txt
+++ b/cpp/src/gandiva/CMakeLists.txt
@@ -27,7 +27,7 @@ add_dependencies(gandiva-all gandiva gandiva-tests gandiva-benchmarks)
 
 find_package(LLVMAlt REQUIRED)
 provide_find_module(LLVMAlt "Gandiva")
-if(ARROW_WITH_ZSTD)
+if(ARROW_WITH_ZSTD AND "${zstd_SOURCE}" STREQUAL "SYSTEM")
   provide_find_module(zstdAlt "Gandiva")
 endif()
 

--- a/cpp/src/gandiva/GandivaConfig.cmake.in
+++ b/cpp/src/gandiva/GandivaConfig.cmake.in
@@ -27,6 +27,7 @@
 @PACKAGE_INIT@
 
 set(ARROW_LLVM_VERSIONS "@ARROW_LLVM_VERSIONS@")
+set(ARROW_ZSTD_SOURCE "@zstd_SOURCE@")
 
 include(CMakeFindDependencyMacro)
 find_dependency(Arrow)
@@ -36,7 +37,7 @@ else()
   unset(GANDIVA_CMAKE_MODULE_PATH_OLD)
 endif()
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
-if(ARROW_WITH_ZSTD)
+if(ARROW_WITH_ZSTD AND "${ARROW_ZSTD_SOURCE}" STREQUAL "SYSTEM")
   find_dependency(zstdAlt)
 endif()
 find_dependency(LLVMAlt)


### PR DESCRIPTION
### Rationale for this change

If we use bundled Zstandared, we should not find system Zstandard for Gandiva.
Because it's always failed.

### What changes are included in this PR?

Add a missing check whether we're using system Zstandard or bundled Zstandard.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #35205