### PR TITLE
GH-35267: [C#] Serialize TotalBytes and TotalRecords in FlightInfo

### DIFF
--- a/csharp/src/Apache.Arrow.Flight/FlightInfo.cs
+++ b/csharp/src/Apache.Arrow.Flight/FlightInfo.cs
@@ -39,7 +39,7 @@ namespace Apache.Arrow.Flight
             TotalRecords = flightInfo.TotalRecords;
         }
 
-        public FlightInfo(Schema schema, FlightDescriptor descriptor, IReadOnlyList<FlightEndpoint> endpoints, long totalRecords = 0, long totalBytes = 0)
+        public FlightInfo(Schema schema, FlightDescriptor descriptor, IReadOnlyList<FlightEndpoint> endpoints, long totalRecords = -1, long totalBytes = -1)
         {
             Schema = schema;
             Descriptor = descriptor;

--- a/csharp/src/Apache.Arrow.Flight/FlightInfo.cs
+++ b/csharp/src/Apache.Arrow.Flight/FlightInfo.cs
@@ -64,7 +64,9 @@ namespace Apache.Arrow.Flight
             var response = new Protocol.FlightInfo()
             {
                 Schema = serializedSchema,
-                FlightDescriptor = Descriptor.ToProtocol()
+                FlightDescriptor = Descriptor.ToProtocol(),
+                TotalBytes = TotalBytes,
+                TotalRecords = TotalRecords
             };
 
             foreach(var endpoint in Endpoints)

--- a/csharp/test/Apache.Arrow.Flight.TestWeb/FlightHolder.cs
+++ b/csharp/test/Apache.Arrow.Flight.TestWeb/FlightHolder.cs
@@ -56,7 +56,7 @@ namespace Apache.Arrow.Flight.TestWeb
                 new FlightEndpoint(new FlightTicket(_flightDescriptor.Paths.FirstOrDefault()), new List<FlightLocation>(){
                     new FlightLocation(_location)
                 })
-            });
+            }, 2, 4);
         }
     }
 }

--- a/csharp/test/Apache.Arrow.Flight.TestWeb/FlightHolder.cs
+++ b/csharp/test/Apache.Arrow.Flight.TestWeb/FlightHolder.cs
@@ -51,12 +51,14 @@ namespace Apache.Arrow.Flight.TestWeb
 
         public FlightInfo GetFlightInfo()
         {
+            int batchArrayLength = _recordBatches.Sum(rb => rb.RecordBatch.Length);
+            int batchBytes = _recordBatches.Sum(rb => rb.RecordBatch.Arrays.Sum(arr => arr.Data.Buffers.Sum(b=>b.Length)));
             return new FlightInfo(_schema, _flightDescriptor, new List<FlightEndpoint>()
             {
                 new FlightEndpoint(new FlightTicket(_flightDescriptor.Paths.FirstOrDefault()), new List<FlightLocation>(){
                     new FlightLocation(_location)
                 })
-            }, 2, 4);
+            }, batchArrayLength, batchBytes);
         }
     }
 }

--- a/csharp/test/Apache.Arrow.Flight.Tests/FlightTests.cs
+++ b/csharp/test/Apache.Arrow.Flight.Tests/FlightTests.cs
@@ -312,5 +312,26 @@ namespace Apache.Arrow.Flight.Tests
             ArrowReaderVerifier.CompareBatches(expectedBatch1, resultList[0]);
             ArrowReaderVerifier.CompareBatches(expectedBatch2, resultList[1]);
         }
+
+        [Fact]
+        public async Task EnsureTheSerializedBatchContainsTheProperTotalRecordsAndTotalBytesProperties()
+        {
+            var flightDescriptor1 = FlightDescriptor.CreatePathDescriptor("test1");
+            var expectedBatch = CreateTestBatch(0, 100);
+            var expectedTotalBytes = expectedBatch.Arrays.Sum(arr => arr.Data.Buffers.Sum(b => b.Length));
+
+            List<FlightInfo> expectedFlightInfo = new List<FlightInfo>();
+
+            expectedFlightInfo.Add(GivenStoreBatches(flightDescriptor1, new RecordBatchWithMetadata(expectedBatch)));
+
+            var listFlightStream = _flightClient.ListFlights();
+
+            var actualFlights = await listFlightStream.ResponseStream.ToListAsync();
+            var result = actualFlights.First();
+
+            //Expected values can be found in the FlightHolder class
+            Assert.Equal(expectedBatch.Length, result.TotalRecords);
+            Assert.Equal(expectedTotalBytes, result.TotalBytes);
+        }
     }
 }

--- a/csharp/test/Apache.Arrow.Flight.Tests/FlightTests.cs
+++ b/csharp/test/Apache.Arrow.Flight.Tests/FlightTests.cs
@@ -329,7 +329,6 @@ namespace Apache.Arrow.Flight.Tests
             var actualFlights = await listFlightStream.ResponseStream.ToListAsync();
             var result = actualFlights.First();
 
-            //Expected values can be found in the FlightHolder class
             Assert.Equal(expectedBatch.Length, result.TotalRecords);
             Assert.Equal(expectedTotalBytes, result.TotalBytes);
         }


### PR DESCRIPTION
Currently the `TotalBytes` and `TotalRecords` properties are not serialized into the `FlightInfo` ProtoBuf for C#/.NET.  This breaks compatibility with Arrow Flight implementation done in other languages (c++ for example).

This PR adds the `TotalBytes` and `TotalRecords` properties to the protoBuf `FlightInfo` for the C# implementation.
* Closes: #35267