### PR TITLE
MINOR: [C++][Parquet] Fix column_reader_test

### DIFF
--- a/cpp/src/parquet/column_reader_test.cc
+++ b/cpp/src/parquet/column_reader_test.cc
@@ -697,7 +697,7 @@ class RecordReaderPrimitiveTypeTest
       }
     }
 
-    if (descr_->schema_node()->is_required()) {
+    if (!descr_->schema_node()->is_required()) {
       std::vector<int16_t> read_defs(
           record_reader_->def_levels(),
           record_reader_->def_levels() + record_reader_->levels_position());


### PR DESCRIPTION
### Rationale for this change

https://github.com/apache/arrow/pull/14142 implemented the logic to skip parquet records and added a lot of test caese. However, there is a minor issue in the test function `RecordReaderPrimitiveTypeTest::CheckReadValues` where `!` is missing.

```c++
    if (descr_->schema_node()->is_required()) {
      std::vector<int16_t> read_defs(
          record_reader_->def_levels(),
          record_reader_->def_levels() + record_reader_->levels_position());
      ASSERT_TRUE(vector_equal(expected_defs, read_defs));
    }

```

### What changes are included in this PR?

Add `!` to `if (descr_->schema_node()->is_required())` as mentioned above.

### Are these changes tested?

This is a fix to the test case.

### Are there any user-facing changes?

NO.