### PR TITLE
GH-35240: [Go][FlightRPC] Fix crash in client middleware

### DIFF
--- a/go/arrow/flight/client.go
+++ b/go/arrow/flight/client.go
@@ -120,10 +120,6 @@ func CreateClientMiddleware(middleware CustomClientMiddleware) ClientMiddleware 
 			}
 
 			if err != nil {
-				if isHdrs {
-					md, _ := cs.Header()
-					hdrs.HeadersReceived(ctx, metadata.Join(md, cs.Trailer()))
-				}
 				if isPostcall {
 					post.CallCompleted(ctx, err)
 				}

--- a/go/arrow/flight/flight_middleware_test.go
+++ b/go/arrow/flight/flight_middleware_test.go
@@ -55,6 +55,17 @@ func (s *ServerMiddlewareAddHeader) CallCompleted(ctx context.Context, err error
 	}
 }
 
+type ServerMiddlewareAddHeaderError struct{}
+
+func (s *ServerMiddlewareAddHeaderError) StartCall(ctx context.Context) context.Context {
+	grpc.SetHeader(ctx, metadata.Pairs("foo", "bar"))
+	return nil
+}
+
+func (s *ServerMiddlewareAddHeaderError) CallCompleted(ctx context.Context, err error) {
+	grpc.SetTrailer(ctx, metadata.Pairs("super", "duper"))
+}
+
 type ServerTraceMiddleware struct{}
 
 type tracetestKey struct{}
@@ -252,6 +263,33 @@ func TestClientStreamMiddleware(t *testing.T) {
 	assert.Equal(t, []string{"duper"}, middleware.md.Get("super"))
 }
 
+func TestClientStreamMiddlewareWithError(t *testing.T) {
+	s := flight.NewServerWithMiddleware([]flight.ServerMiddleware{
+		flight.CreateServerMiddleware(&ServerMiddlewareAddHeaderError{}),
+	})
+	s.Init("localhost:0")
+	f := &flightServer{}
+	s.RegisterFlightService(f)
+
+	go s.Serve()
+	defer s.Shutdown()
+
+	middle := &ClientTestSendHeaderMiddleware{}
+	client, err := flight.NewClientWithMiddleware(s.Addr().String(), nil, []flight.ClientMiddleware{
+		flight.CreateClientMiddleware(middle),
+	}, grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	require.NoError(t, err)
+	defer client.Close()
+
+	// UseCompressor triggers a particular rare failure path.
+	_, err = client.DoGet(context.Background(), &flight.Ticket{Ticket: []byte("this flight does not exist")}, grpc.UseCompressor("foo"))
+	if err == nil {
+		t.Fatal("Expected error but got nothing")
+	}
+	assert.Contains(t, err.Error(), "Compressor is not installed")
+}
+
 func TestClientUnaryMiddleware(t *testing.T) {
 	s := flight.NewServerWithMiddleware([]flight.ServerMiddleware{
 		flight.CreateServerMiddleware(&ServerMiddlewareAddHeader{}),
@@ -294,4 +332,30 @@ func TestClientUnaryMiddleware(t *testing.T) {
 			middle.md = metadata.MD{}
 		})
 	}
+}
+
+func TestClientUnaryMiddlewareWithError(t *testing.T) {
+	s := flight.NewServerWithMiddleware([]flight.ServerMiddleware{
+		flight.CreateServerMiddleware(&ServerMiddlewareAddHeaderError{}),
+	})
+	s.Init("localhost:0")
+	f := &flightServer{}
+	s.RegisterFlightService(f)
+
+	go s.Serve()
+	defer s.Shutdown()
+
+	middle := &ClientTestSendHeaderMiddleware{}
+	client, err := flight.NewClientWithMiddleware(s.Addr().String(), nil, []flight.ClientMiddleware{
+		flight.CreateClientMiddleware(middle),
+	}, grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	require.NoError(t, err)
+	defer client.Close()
+
+	_, err = client.GetSchema(context.Background(), &flight.FlightDescriptor{Path: []string{"this flight does not exist"}}, grpc.UseCompressor("foo"))
+	if err == nil {
+		t.Fatal("Expected error but got nothing")
+	}
+	assert.Contains(t, err.Error(), "Compressor is not installed")
 }

--- a/go/arrow/flight/flight_test.go
+++ b/go/arrow/flight/flight_test.go
@@ -98,7 +98,10 @@ func (f *flightServer) GetSchema(_ context.Context, in *flight.FlightDescriptor)
 }
 
 func (f *flightServer) DoGet(tkt *flight.Ticket, fs flight.FlightService_DoGetServer) error {
-	recs := arrdata.Records[string(tkt.GetTicket())]
+	recs, ok := arrdata.Records[string(tkt.GetTicket())]
+	if !ok {
+		return status.Error(codes.NotFound, "flight not found")
+	}
 
 	w := flight.NewRecordWriter(fs, ipc.WithSchema(recs[0].Schema()))
 	for _, r := range recs {


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

The Go interceptor API includes a provision for errors from trying to start an RPC. The handler for this in the Flight code was trying to use a nil pointer as a result.

### What changes are included in this PR?

Fix a crash when those errors are encountered.

### Are these changes tested?

New tests were added.

### Are there any user-facing changes?

There are no user-facing changes.
* Closes: #35240