### PR TITLE
GH-35244: [C#] DataType should compare values

### DIFF
--- a/csharp/src/Apache.Arrow/Field.cs
+++ b/csharp/src/Apache.Arrow/Field.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Apache.Arrow.Types;
+using Apache.Arrow.Util;
 
 namespace Apache.Arrow
 {
@@ -60,6 +61,25 @@ namespace Apache.Arrow
             Name = name;
             DataType = dataType ?? NullType.Default;
             IsNullable = nullable;
+        }
+
+        // C# object methods
+        public override bool Equals(object obj)
+        {
+            if (obj == null || obj is not Field other)
+            {
+                return false;
+            }
+
+            return IsNullable == other.IsNullable && Name == other.Name && DataType.Equals(other.DataType);
+        }
+
+        public override int GetHashCode()
+        {
+            checked
+            {
+                return HashUtil.CombineHash32(IsNullable.GetHashCode(), HashUtil.Hash32(Name), DataType.GetHashCode());
+            }
         }
     }
 }

--- a/csharp/src/Apache.Arrow/Field.cs
+++ b/csharp/src/Apache.Arrow/Field.cs
@@ -74,12 +74,6 @@ namespace Apache.Arrow
             return IsNullable == other.IsNullable && Name == other.Name && DataType.Equals(other.DataType);
         }
 
-        public override int GetHashCode()
-        {
-            checked
-            {
-                return HashUtil.CombineHash32(IsNullable.GetHashCode(), HashUtil.Hash32(Name), DataType.GetHashCode());
-            }
-        }
+        public override int GetHashCode() => HashUtil.Hash32(IsNullable, Name, DataType.GetHashCode());
     }
 }

--- a/csharp/src/Apache.Arrow/Types/ArrowType.cs
+++ b/csharp/src/Apache.Arrow/Types/ArrowType.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 
 
+using Apache.Arrow.Util;
+
 namespace Apache.Arrow.Types
 {
     public abstract class ArrowType: IArrowType
@@ -24,6 +26,33 @@ namespace Apache.Arrow.Types
 
         public virtual bool IsFixedWidth => false;
 
+        // C# object methods
+        public override bool Equals(object obj)
+        {
+            if (obj == null || obj is not ArrowType other)
+            {
+                return false;
+            }
+
+            return Equals(other);
+        }
+
+        public bool Equals(IArrowType other)
+        {
+            return TypeId == other.TypeId
+                && IsFixedWidth == other.IsFixedWidth
+                && Name == other.Name;
+        }
+
+        public override int GetHashCode()
+        {
+            checked
+            {
+                return HashUtil.CombineHash32(TypeId.GetHashCode(), IsFixedWidth.GetHashCode(), HashUtil.Hash32(Name));
+            }
+        }
+
+        // Instance methods
         public abstract void Accept(IArrowTypeVisitor visitor);
 
         internal static void Accept<T>(T type, IArrowTypeVisitor visitor)

--- a/csharp/src/Apache.Arrow/Types/ArrowType.cs
+++ b/csharp/src/Apache.Arrow/Types/ArrowType.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 
+using System;
 using Apache.Arrow.Util;
 
 namespace Apache.Arrow.Types
@@ -44,13 +45,7 @@ namespace Apache.Arrow.Types
                 && Name == other.Name;
         }
 
-        public override int GetHashCode()
-        {
-            checked
-            {
-                return HashUtil.CombineHash32(TypeId.GetHashCode(), IsFixedWidth.GetHashCode(), HashUtil.Hash32(Name));
-            }
-        }
+        public override int GetHashCode() => HashUtil.Hash32(TypeId, IsFixedWidth, Name);
 
         // Instance methods
         public abstract void Accept(IArrowTypeVisitor visitor);

--- a/csharp/src/Apache.Arrow/Types/DateType.cs
+++ b/csharp/src/Apache.Arrow/Types/DateType.cs
@@ -47,12 +47,6 @@ namespace Apache.Arrow.Types
             return base.Equals(_other) && Unit == _other.Unit;
         }
 
-        public override int GetHashCode()
-        {
-            checked
-            {
-                return HashUtil.CombineHash32(base.GetHashCode(), Unit.GetHashCode());
-            }
-        }
+        public override int GetHashCode() => HashUtil.Hash32(base.GetHashCode(), Unit);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/DateType.cs
+++ b/csharp/src/Apache.Arrow/Types/DateType.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 
 
+using Apache.Arrow.Util;
+
 namespace Apache.Arrow.Types
 {
     public enum DateUnit
@@ -25,5 +27,32 @@ namespace Apache.Arrow.Types
     public abstract class DateType: FixedWidthType
     {
         public abstract DateUnit Unit { get; }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null || obj is not ArrowType other)
+            {
+                return false;
+            }
+
+            return Equals(other);
+        }
+
+        public new bool Equals(IArrowType other)
+        {
+            if (other is not DateType _other)
+            {
+                return false;
+            }
+            return base.Equals(_other) && Unit == _other.Unit;
+        }
+
+        public override int GetHashCode()
+        {
+            checked
+            {
+                return HashUtil.CombineHash32(base.GetHashCode(), Unit.GetHashCode());
+            }
+        }
     }
 }

--- a/csharp/src/Apache.Arrow/Types/Decimal128Type.cs
+++ b/csharp/src/Apache.Arrow/Types/Decimal128Type.cs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Apache.Arrow.Util;
+
 namespace Apache.Arrow.Types
 {
     public sealed class Decimal128Type : FixedSizeBinaryType
@@ -28,6 +30,33 @@ namespace Apache.Arrow.Types
         {
             Precision = precision;
             Scale = scale;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null || obj is not ArrowType other)
+            {
+                return false;
+            }
+
+            return Equals(other);
+        }
+
+        public new bool Equals(IArrowType other)
+        {
+            if (other is not Decimal128Type _other)
+            {
+                return false;
+            }
+            return base.Equals(_other) && Precision == _other.Precision && Scale == _other.Scale;
+        }
+
+        public override int GetHashCode()
+        {
+            checked
+            {
+                return HashUtil.CombineHash32(base.GetHashCode(), Precision.GetHashCode(), Scale.GetHashCode());
+            }
         }
 
         public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);

--- a/csharp/src/Apache.Arrow/Types/Decimal128Type.cs
+++ b/csharp/src/Apache.Arrow/Types/Decimal128Type.cs
@@ -51,13 +51,7 @@ namespace Apache.Arrow.Types
             return base.Equals(_other) && Precision == _other.Precision && Scale == _other.Scale;
         }
 
-        public override int GetHashCode()
-        {
-            checked
-            {
-                return HashUtil.CombineHash32(base.GetHashCode(), Precision.GetHashCode(), Scale.GetHashCode());
-            }
-        }
+        public override int GetHashCode() => HashUtil.Hash32(base.GetHashCode(), Precision, Scale);
 
         public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }

--- a/csharp/src/Apache.Arrow/Types/Decimal256Type.cs
+++ b/csharp/src/Apache.Arrow/Types/Decimal256Type.cs
@@ -51,13 +51,8 @@ namespace Apache.Arrow.Types
             return base.Equals(_other) && Precision == _other.Precision && Scale == _other.Scale;
         }
 
-        public override int GetHashCode()
-        {
-            checked
-            {
-                return HashUtil.CombineHash32(base.GetHashCode(), Precision.GetHashCode(), Scale.GetHashCode());
-            }
-        }
+        public override int GetHashCode() => HashUtil.Hash32(base.GetHashCode(), Precision, Scale);
+
         public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/Decimal256Type.cs
+++ b/csharp/src/Apache.Arrow/Types/Decimal256Type.cs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Apache.Arrow.Util;
+
 namespace Apache.Arrow.Types
 {
     public sealed class Decimal256Type: FixedSizeBinaryType
@@ -30,6 +32,32 @@ namespace Apache.Arrow.Types
             Scale = scale;
         }
 
+        public override bool Equals(object obj)
+        {
+            if (obj == null || obj is not ArrowType other)
+            {
+                return false;
+            }
+
+            return Equals(other);
+        }
+
+        public new bool Equals(IArrowType other)
+        {
+            if (other is not Decimal256Type _other)
+            {
+                return false;
+            }
+            return base.Equals(_other) && Precision == _other.Precision && Scale == _other.Scale;
+        }
+
+        public override int GetHashCode()
+        {
+            checked
+            {
+                return HashUtil.CombineHash32(base.GetHashCode(), Precision.GetHashCode(), Scale.GetHashCode());
+            }
+        }
         public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/DictionaryType.cs
+++ b/csharp/src/Apache.Arrow/Types/DictionaryType.cs
@@ -15,6 +15,8 @@
 
 
 using System;
+using Apache.Arrow.Util;
+using System.Runtime.CompilerServices;
 
 namespace Apache.Arrow.Types
 {
@@ -42,5 +44,32 @@ namespace Apache.Arrow.Types
         public IArrowType IndexType { get; private set; }
         public IArrowType ValueType { get; private set; }
         public bool Ordered { get; private set; }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null || obj is not ArrowType other)
+            {
+                return false;
+            }
+
+            return Equals(other);
+        }
+
+        public new bool Equals(IArrowType other)
+        {
+            if (other is not DictionaryType _other)
+            {
+                return false;
+            }
+            return base.Equals(_other) && Ordered == _other.Ordered;
+        }
+
+        public override int GetHashCode()
+        {
+            checked
+            {
+                return HashUtil.CombineHash32(base.GetHashCode(), Ordered.GetHashCode());
+            }
+        }
     }
 }

--- a/csharp/src/Apache.Arrow/Types/DictionaryType.cs
+++ b/csharp/src/Apache.Arrow/Types/DictionaryType.cs
@@ -16,7 +16,6 @@
 
 using System;
 using Apache.Arrow.Util;
-using System.Runtime.CompilerServices;
 
 namespace Apache.Arrow.Types
 {
@@ -64,12 +63,6 @@ namespace Apache.Arrow.Types
             return base.Equals(_other) && Ordered == _other.Ordered;
         }
 
-        public override int GetHashCode()
-        {
-            checked
-            {
-                return HashUtil.CombineHash32(base.GetHashCode(), Ordered.GetHashCode());
-            }
-        }
+        public override int GetHashCode() => HashUtil.Hash32(base.GetHashCode(), Ordered);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/FixedWidthType.cs
+++ b/csharp/src/Apache.Arrow/Types/FixedWidthType.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 
 
+using Apache.Arrow.Util;
+
 namespace Apache.Arrow.Types
 {
     public abstract class FixedWidthType: ArrowType
@@ -21,5 +23,32 @@ namespace Apache.Arrow.Types
         public override bool IsFixedWidth => true;
 
         public abstract int BitWidth { get; }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null || obj is not ArrowType other)
+            {
+                return false;
+            }
+
+            return Equals(other);
+        }
+
+        public new bool Equals(IArrowType other)
+        {
+            if (other is not FixedWidthType _other)
+            {
+                return false;
+            }
+            return base.Equals(_other) && BitWidth == _other.BitWidth;
+        }
+
+        public override int GetHashCode()
+        {
+            checked
+            {
+                return HashUtil.CombineHash32(base.GetHashCode(), BitWidth.GetHashCode());
+            }
+        }
     }
 }

--- a/csharp/src/Apache.Arrow/Types/FixedWidthType.cs
+++ b/csharp/src/Apache.Arrow/Types/FixedWidthType.cs
@@ -43,12 +43,6 @@ namespace Apache.Arrow.Types
             return base.Equals(_other) && BitWidth == _other.BitWidth;
         }
 
-        public override int GetHashCode()
-        {
-            checked
-            {
-                return HashUtil.CombineHash32(base.GetHashCode(), BitWidth.GetHashCode());
-            }
-        }
+        public override int GetHashCode() => HashUtil.Hash32(base.GetHashCode(), BitWidth);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/FloatingPointType.cs
+++ b/csharp/src/Apache.Arrow/Types/FloatingPointType.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 
 
+using Apache.Arrow.Util;
+
 namespace Apache.Arrow.Types
 {
     public abstract class FloatingPointType: NumberType
@@ -26,5 +28,32 @@ namespace Apache.Arrow.Types
         }
 
         public abstract PrecisionKind Precision { get; }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null || obj is not ArrowType other)
+            {
+                return false;
+            }
+
+            return Equals(other);
+        }
+
+        public new bool Equals(IArrowType other)
+        {
+            if (other is not FloatingPointType _other)
+            {
+                return false;
+            }
+            return base.Equals(_other) && Precision == _other.Precision;
+        }
+
+        public override int GetHashCode()
+        {
+            checked
+            {
+                return HashUtil.CombineHash32(base.GetHashCode(), Precision.GetHashCode());
+            }
+        }
     }
 }

--- a/csharp/src/Apache.Arrow/Types/FloatingPointType.cs
+++ b/csharp/src/Apache.Arrow/Types/FloatingPointType.cs
@@ -48,12 +48,6 @@ namespace Apache.Arrow.Types
             return base.Equals(_other) && Precision == _other.Precision;
         }
 
-        public override int GetHashCode()
-        {
-            checked
-            {
-                return HashUtil.CombineHash32(base.GetHashCode(), Precision.GetHashCode());
-            }
-        }
+        public override int GetHashCode() => HashUtil.Hash32(base.GetHashCode(), Precision);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/IArrowType.cs
+++ b/csharp/src/Apache.Arrow/Types/IArrowType.cs
@@ -58,6 +58,7 @@ namespace Apache.Arrow.Types
         void Accept(IArrowTypeVisitor visitor);
 
         bool IsFixedWidth { get; }
-    
+
+        bool Equals(IArrowType other);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/IntervalUnit.cs
+++ b/csharp/src/Apache.Arrow/Types/IntervalUnit.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 
 
+using Apache.Arrow.Util;
+
 namespace Apache.Arrow.Types
 {
     public enum IntervalUnit
@@ -33,6 +35,33 @@ namespace Apache.Arrow.Types
         public IntervalType(IntervalUnit unit = IntervalUnit.YearMonth)
         {
             Unit = unit;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null || obj is not ArrowType other)
+            {
+                return false;
+            }
+
+            return Equals(other);
+        }
+
+        public new bool Equals(IArrowType other)
+        {
+            if (other is not IntervalType _other)
+            {
+                return false;
+            }
+            return base.Equals(_other) && Unit == _other.Unit;
+        }
+
+        public override int GetHashCode()
+        {
+            checked
+            {
+                return HashUtil.CombineHash32(base.GetHashCode(), Unit.GetHashCode());
+            }
         }
 
         public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);

--- a/csharp/src/Apache.Arrow/Types/IntervalUnit.cs
+++ b/csharp/src/Apache.Arrow/Types/IntervalUnit.cs
@@ -56,13 +56,7 @@ namespace Apache.Arrow.Types
             return base.Equals(_other) && Unit == _other.Unit;
         }
 
-        public override int GetHashCode()
-        {
-            checked
-            {
-                return HashUtil.CombineHash32(base.GetHashCode(), Unit.GetHashCode());
-            }
-        }
+        public override int GetHashCode() => HashUtil.Hash32(base.GetHashCode(), Unit);
 
         public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }

--- a/csharp/src/Apache.Arrow/Types/NestedType.cs
+++ b/csharp/src/Apache.Arrow/Types/NestedType.cs
@@ -65,14 +65,6 @@ namespace Apache.Arrow.Types
             return base.Equals(other) && Fields.SequenceEqual(_other.Fields);
         }
 
-        public override int GetHashCode()
-        {
-            checked
-            {
-                int fieldsHash = HashUtil.CombineHash32(Fields.Select(field => field.GetHashCode()).ToArray());
-
-                return HashUtil.CombineHash32(base.GetHashCode(), fieldsHash);
-            }
-        }
+        public override int GetHashCode() => HashUtil.Hash32(TypeId, IsFixedWidth, Name, HashUtil.Hash32Array(Fields.Select(field => field.GetHashCode()).ToArray()));
     }
 }

--- a/csharp/src/Apache.Arrow/Types/NestedType.cs
+++ b/csharp/src/Apache.Arrow/Types/NestedType.cs
@@ -15,6 +15,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using Apache.Arrow.Util;
 
 namespace Apache.Arrow.Types
 {
@@ -41,6 +43,36 @@ namespace Apache.Arrow.Types
                 throw new ArgumentNullException(nameof(field));
             }
             Fields = new Field[] { field };
+        }
+
+        // C# object methods
+        public override bool Equals(object obj)
+        {
+            if (obj == null || obj is not ArrowType other)
+            {
+                return false;
+            }
+
+            return Equals(other);
+        }
+
+        public new bool Equals(IArrowType other)
+        {
+            if (other is not NestedType _other)
+            {
+                return false;
+            }
+            return base.Equals(other) && Fields.SequenceEqual(_other.Fields);
+        }
+
+        public override int GetHashCode()
+        {
+            checked
+            {
+                int fieldsHash = HashUtil.CombineHash32(Fields.Select(field => field.GetHashCode()).ToArray());
+
+                return HashUtil.CombineHash32(base.GetHashCode(), fieldsHash);
+            }
         }
     }
 }

--- a/csharp/src/Apache.Arrow/Types/NumberType.cs
+++ b/csharp/src/Apache.Arrow/Types/NumberType.cs
@@ -41,12 +41,6 @@ namespace Apache.Arrow.Types
             return base.Equals(_other) && IsSigned == _other.IsSigned;
         }
 
-        public override int GetHashCode()
-        {
-            checked
-            {
-                return HashUtil.CombineHash32(base.GetHashCode(), IsSigned.GetHashCode());
-            }
-        }
+        public override int GetHashCode() => HashUtil.Hash32(base.GetHashCode(), IsSigned);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/NumberType.cs
+++ b/csharp/src/Apache.Arrow/Types/NumberType.cs
@@ -14,10 +14,39 @@
 // limitations under the License.
 
 
+using Apache.Arrow.Util;
+
 namespace Apache.Arrow.Types
 {
     public abstract class NumberType: FixedWidthType
     {
         public abstract bool IsSigned { get; }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null || obj is not ArrowType other)
+            {
+                return false;
+            }
+
+            return Equals(other);
+        }
+
+        public new bool Equals(IArrowType other)
+        {
+            if (other is not NumberType _other)
+            {
+                return false;
+            }
+            return base.Equals(_other) && IsSigned == _other.IsSigned;
+        }
+
+        public override int GetHashCode()
+        {
+            checked
+            {
+                return HashUtil.CombineHash32(base.GetHashCode(), IsSigned.GetHashCode());
+            }
+        }
     }
 }

--- a/csharp/src/Apache.Arrow/Types/TimeType.cs
+++ b/csharp/src/Apache.Arrow/Types/TimeType.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 
 
+using Apache.Arrow.Util;
+
 namespace Apache.Arrow.Types
 {
     public enum TimeUnit
@@ -31,6 +33,33 @@ namespace Apache.Arrow.Types
         protected TimeType(TimeUnit unit)
         {
             Unit = unit;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null || obj is not ArrowType other)
+            {
+                return false;
+            }
+
+            return Equals(other);
+        }
+
+        public new bool Equals(IArrowType other)
+        {
+            if (other is not TimeType _other)
+            {
+                return false;
+            }
+            return base.Equals(_other) && Unit == _other.Unit;
+        }
+
+        public override int GetHashCode()
+        {
+            checked
+            {
+                return HashUtil.CombineHash32(base.GetHashCode(), Unit.GetHashCode());
+            }
         }
     }
 }

--- a/csharp/src/Apache.Arrow/Types/TimeType.cs
+++ b/csharp/src/Apache.Arrow/Types/TimeType.cs
@@ -54,12 +54,6 @@ namespace Apache.Arrow.Types
             return base.Equals(_other) && Unit == _other.Unit;
         }
 
-        public override int GetHashCode()
-        {
-            checked
-            {
-                return HashUtil.CombineHash32(base.GetHashCode(), Unit.GetHashCode());
-            }
-        }
+        public override int GetHashCode() => HashUtil.Hash32(base.GetHashCode(), Unit);
     }
 }

--- a/csharp/src/Apache.Arrow/Types/TimestampType.cs
+++ b/csharp/src/Apache.Arrow/Types/TimestampType.cs
@@ -71,7 +71,7 @@ namespace Apache.Arrow.Types
         {
             checked
             {
-                return HashUtil.CombineHash32(base.GetHashCode(), Unit.GetHashCode(), Timezone.GetHashCode());
+                return HashUtil.CombineHash32(base.GetHashCode(), Unit.GetHashCode(), HashUtil.Hash32(Timezone));
             }
         }
 

--- a/csharp/src/Apache.Arrow/Types/TimestampType.cs
+++ b/csharp/src/Apache.Arrow/Types/TimestampType.cs
@@ -67,13 +67,7 @@ namespace Apache.Arrow.Types
             return base.Equals(_other) && Unit == _other.Unit && Timezone == _other.Timezone;
         }
 
-        public override int GetHashCode()
-        {
-            checked
-            {
-                return HashUtil.CombineHash32(base.GetHashCode(), Unit.GetHashCode(), HashUtil.Hash32(Timezone));
-            }
-        }
+        public override int GetHashCode() => HashUtil.Hash32(base.GetHashCode(), Unit);
 
         public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }

--- a/csharp/src/Apache.Arrow/Types/TimestampType.cs
+++ b/csharp/src/Apache.Arrow/Types/TimestampType.cs
@@ -15,6 +15,7 @@
 
 
 using System;
+using Apache.Arrow.Util;
 
 namespace Apache.Arrow.Types
 {
@@ -45,6 +46,33 @@ namespace Apache.Arrow.Types
         {
             Unit = unit;
             Timezone = timezone?.BaseUtcOffset.ToTimeZoneOffsetString();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null || obj is not ArrowType other)
+            {
+                return false;
+            }
+
+            return Equals(other);
+        }
+
+        public new bool Equals(IArrowType other)
+        {
+            if (other is not TimestampType _other)
+            {
+                return false;
+            }
+            return base.Equals(_other) && Unit == _other.Unit && Timezone == _other.Timezone;
+        }
+
+        public override int GetHashCode()
+        {
+            checked
+            {
+                return HashUtil.CombineHash32(base.GetHashCode(), Unit.GetHashCode(), Timezone.GetHashCode());
+            }
         }
 
         public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);

--- a/csharp/src/Apache.Arrow/Types/UnionType.cs
+++ b/csharp/src/Apache.Arrow/Types/UnionType.cs
@@ -61,13 +61,7 @@ namespace Apache.Arrow.Types
             return base.Equals(_other) && Mode == _other.Mode && TypeCodes.SequenceEqual(_other.TypeCodes);
         }
 
-        public override int GetHashCode()
-        {
-            checked
-            {
-                return HashUtil.CombineHash32(base.GetHashCode(), Mode.GetHashCode(), TypeCodes.GetHashCode());
-            }
-        }
+        public override int GetHashCode() => HashUtil.Hash32(base.GetHashCode(), Mode, TypeCodes);
 
         public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }

--- a/csharp/src/Apache.Arrow/Types/UnionType.cs
+++ b/csharp/src/Apache.Arrow/Types/UnionType.cs
@@ -15,6 +15,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Apache.Arrow.Util;
 
 namespace Apache.Arrow.Types
 {
@@ -39,6 +40,33 @@ namespace Apache.Arrow.Types
         {
             TypeCodes = typeCodes.ToList();
             Mode = mode;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null || obj is not ArrowType other)
+            {
+                return false;
+            }
+
+            return Equals(other);
+        }
+
+        public new bool Equals(IArrowType other)
+        {
+            if (other is not UnionType _other)
+            {
+                return false;
+            }
+            return base.Equals(_other) && Mode == _other.Mode && TypeCodes.SequenceEqual(_other.TypeCodes);
+        }
+
+        public override int GetHashCode()
+        {
+            checked
+            {
+                return HashUtil.CombineHash32(base.GetHashCode(), Mode.GetHashCode(), TypeCodes.GetHashCode());
+            }
         }
 
         public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);

--- a/csharp/src/Apache.Arrow/Util/HashUtil.cs
+++ b/csharp/src/Apache.Arrow/Util/HashUtil.cs
@@ -99,6 +99,7 @@ namespace Apache.Arrow.Util
             }
         }
         internal static int CombineHash32(int h1, int h2) => Tuple.Create(h1, h2).GetHashCode();
+        internal static int CombineHash32(int h1, int h2, int h3) => Tuple.Create(h1, h2, h3).GetHashCode();
 
         internal static int CombineHash32(params int[] hashCodes)
         {

--- a/csharp/src/Apache.Arrow/Util/HashUtil.cs
+++ b/csharp/src/Apache.Arrow/Util/HashUtil.cs
@@ -13,8 +13,10 @@ namespace Apache.Arrow.Util
         }
 
 #if NETCOREAPP2_0_OR_GREATER
-        internal static int Hash32(string str, Encoding encoding = null)
+        public static int Hash32(string str, Encoding encoding = null)
         {
+            if (string.IsNullOrEmpty(str))
+                return 0;
             encoding = encoding ?? Encoding.UTF8;
             byte[] compressed = str.Length > 128 ? Compress(encoding.GetBytes(str)) : encoding.GetBytes(str);
             ReadOnlySpan<byte> span = compressed.AsSpan();
@@ -23,6 +25,8 @@ namespace Apache.Arrow.Util
 
         internal static int Hash32(ReadOnlySpan<byte> data, Seed seed)
         {
+            if (data == null || data.Length == 0)
+                return 0;
             const uint c1 = 0xcc9e2d51;
             const uint c2 = 0x1b873593;
             const int r1 = 15;
@@ -70,7 +74,7 @@ namespace Apache.Arrow.Util
             return (int)hash;
         }
 #else
-        internal static int Hash32(string str)
+        public static int Hash32(string str)
         {
             const uint FNV_prime = 16777619;
             const uint FNV_offset_basis = 2166136261;

--- a/csharp/src/Apache.Arrow/Util/HashUtil.cs
+++ b/csharp/src/Apache.Arrow/Util/HashUtil.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+
+namespace Apache.Arrow.Util
+{
+    internal class HashUtil
+    {
+        internal enum Seed : uint
+        {
+            String
+        }
+
+#if NETCOREAPP2_0_OR_GREATER
+        internal static int Hash32(string str, Encoding encoding = null)
+        {
+            encoding = encoding ?? Encoding.UTF8;
+            byte[] compressed = str.Length > 128 ? Compress(encoding.GetBytes(str)) : encoding.GetBytes(str);
+            ReadOnlySpan<byte> span = compressed.AsSpan();
+            return Hash32(span, Seed.String);
+        }
+
+        internal static int Hash32(ReadOnlySpan<byte> data, Seed seed)
+        {
+            const uint c1 = 0xcc9e2d51;
+            const uint c2 = 0x1b873593;
+            const int r1 = 15;
+            const int r2 = 13;
+            const uint m = 5;
+            const uint n = 0xe6546b64;
+
+            uint hash = (uint)seed;
+            int remainingBytes = data.Length & 3;
+            int byteCount = data.Length - remainingBytes;
+
+            for (int i = 0; i < byteCount; i += 4)
+            {
+                uint k = BitConverter.ToUInt32(data.Slice(i, 4));
+                k *= c1;
+                k = (k << r1) | (k >> (32 - r1));
+                k *= c2;
+
+                hash ^= k;
+                hash = ((hash << r2) | (hash >> (32 - r2))) * m + n;
+            }
+
+            if (remainingBytes > 0)
+            {
+                uint k = 0;
+                for (int i = byteCount; i < data.Length; i++)
+                {
+                    k |= (uint)data[i] << ((i - byteCount) * 8);
+                }
+
+                k *= c1;
+                k = (k << r1) | (k >> (32 - r1));
+                k *= c2;
+
+                hash ^= k;
+            }
+
+            hash ^= (uint)data.Length;
+            hash ^= hash >> 16;
+            hash *= 0x85ebca6b;
+            hash ^= hash >> 13;
+            hash *= 0xc2b2ae35;
+            hash ^= hash >> 16;
+
+            return (int)hash;
+        }
+#else
+        internal static int Hash32(string str)
+        {
+            const uint FNV_prime = 16777619;
+            const uint FNV_offset_basis = 2166136261;
+
+            uint hash = FNV_offset_basis;
+            ReadOnlySpan<char> span = str.AsSpan();
+
+            for (int i = 0; i < span.Length; i++)
+            {
+                hash ^= span[i];
+                hash *= FNV_prime;
+            }
+
+            return (int)hash;
+        }
+#endif
+        internal static byte[] Compress(byte[] data)
+        {
+            using (MemoryStream compressedStream = new MemoryStream())
+            {
+                using (DeflateStream compressionStream = new DeflateStream(compressedStream, CompressionMode.Compress))
+                {
+                    compressionStream.Write(data, 0, data.Length);
+                }
+                return compressedStream.ToArray();
+            }
+        }
+        internal static int CombineHash32(int h1, int h2) => Tuple.Create(h1, h2).GetHashCode();
+
+        internal static int CombineHash32(params int[] hashCodes)
+        {
+            int hash = 0;
+
+            foreach (int hashCode in hashCodes)
+            {
+                hash = CombineHash32(hash, hashCode);
+            }
+
+            return hash;
+        }        
+    }
+}

--- a/csharp/src/Apache.Arrow/Util/HashUtil.cs
+++ b/csharp/src/Apache.Arrow/Util/HashUtil.cs
@@ -16,7 +16,7 @@ namespace Apache.Arrow.Util
         public static int Hash32(string str, Encoding encoding = null)
         {
             if (string.IsNullOrEmpty(str))
-                return 0;
+                return (int)Seed.String;
             encoding = encoding ?? Encoding.UTF8;
             byte[] compressed = str.Length > 128 ? Compress(encoding.GetBytes(str)) : encoding.GetBytes(str);
             ReadOnlySpan<byte> span = compressed.AsSpan();
@@ -25,8 +25,10 @@ namespace Apache.Arrow.Util
 
         internal static int Hash32(ReadOnlySpan<byte> data, Seed seed)
         {
+            uint hash = (uint)seed;
             if (data == null || data.Length == 0)
-                return 0;
+                return (int)hash;
+
             const uint c1 = 0xcc9e2d51;
             const uint c2 = 0x1b873593;
             const int r1 = 15;
@@ -34,7 +36,7 @@ namespace Apache.Arrow.Util
             const uint m = 5;
             const uint n = 0xe6546b64;
 
-            uint hash = (uint)seed;
+            
             int remainingBytes = data.Length & 3;
             int byteCount = data.Length - remainingBytes;
 
@@ -76,6 +78,8 @@ namespace Apache.Arrow.Util
 #else
         public static int Hash32(string str)
         {
+            if (string.IsNullOrEmpty(str))
+                return (int)Seed.String;
             const uint FNV_prime = 16777619;
             const uint FNV_offset_basis = 2166136261;
 

--- a/csharp/src/Apache.Arrow/Util/HashUtil.cs
+++ b/csharp/src/Apache.Arrow/Util/HashUtil.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace Apache.Arrow.Util
 {
-    internal class HashUtil
+    public class HashUtil
     {
         internal enum Seed : uint
         {
@@ -98,10 +98,10 @@ namespace Apache.Arrow.Util
                 return compressedStream.ToArray();
             }
         }
-        internal static int CombineHash32(int h1, int h2) => Tuple.Create(h1, h2).GetHashCode();
-        internal static int CombineHash32(int h1, int h2, int h3) => Tuple.Create(h1, h2, h3).GetHashCode();
+        public static int CombineHash32(int h1, int h2) => Tuple.Create(h1, h2).GetHashCode();
+        public static int CombineHash32(int h1, int h2, int h3) => Tuple.Create(h1, h2, h3).GetHashCode();
 
-        internal static int CombineHash32(params int[] hashCodes)
+        public static int CombineHash32(params int[] hashCodes)
         {
             int hash = 0;
 

--- a/csharp/test/Apache.Arrow.Tests/Types/ArrowTypeTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/Types/ArrowTypeTests.cs
@@ -20,20 +20,19 @@ namespace Apache.Arrow.Tests
 {
     public class ArrowTypeTests
     {
-#if NETCOREAPP2_0_OR_GREATER
         // Hash32 of string only implemented for .net >= 2.0
         [Fact]
         public void ArrowType_Should_GetHashCode()
         {
-            Assert.Equal(-950003445, new BooleanType().GetHashCode());
+            Assert.Equal(new BooleanType().GetHashCode(), new BooleanType().GetHashCode());
         }
 
         [Fact]
         public void NestedType_Should_GetHashCode()
         {
-            Assert.Equal(2016456901, new ListType(new Int32Type()).GetHashCode());
+            Assert.Equal(new ListType(new Int32Type()).GetHashCode(), new ListType(new Int32Type()).GetHashCode());
         }
-#endif
+
         [Fact]
         public void ArrowType_Should_ComparePrimitiveTypes()
         {

--- a/csharp/test/Apache.Arrow.Tests/Types/ArrowTypeTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/Types/ArrowTypeTests.cs
@@ -20,7 +20,6 @@ namespace Apache.Arrow.Tests
 {
     public class ArrowTypeTests
     {
-        // Hash32 of string only implemented for .net >= 2.0
         [Fact]
         public void ArrowType_Should_GetHashCode()
         {

--- a/csharp/test/Apache.Arrow.Tests/Types/ArrowTypeTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/Types/ArrowTypeTests.cs
@@ -1,0 +1,124 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Apache.Arrow.Types;
+using Xunit;
+
+namespace Apache.Arrow.Tests
+{
+    public class ArrowTypeTests
+    {
+#if NETCOREAPP2_0_OR_GREATER
+        // Hash32 of string only implemented for .net >= 2.0
+        [Fact]
+        public void ArrowType_Should_GetHashCode()
+        {
+            Assert.Equal(-950003445, new BooleanType().GetHashCode());
+        }
+
+        [Fact]
+        public void NestedType_Should_GetHashCode()
+        {
+            Assert.Equal(2016456901, new ListType(new Int32Type()).GetHashCode());
+        }
+#endif
+        [Fact]
+        public void ArrowType_Should_ComparePrimitiveTypes()
+        {
+            Assert.Equal(new BooleanType(), new BooleanType());
+            Assert.NotEqual(new BooleanType() as IArrowType, new BinaryType() as IArrowType);
+            Assert.NotEqual(new BooleanType() as IArrowType, new ListType(new BooleanType()) as IArrowType);
+        }
+
+        [Fact]
+        public void ArrowType_Should_CompareNestedTypes()
+        {
+            Assert.Equal((NestedType)new ListType(new BooleanType()), (NestedType)new ListType(new BooleanType()));
+            Assert.NotEqual((NestedType)new ListType(new BooleanType()), (NestedType)new ListType(new BinaryType()));
+        }
+
+        [Fact]
+        public void ArrowType_Should_CompareListTypes()
+        {
+            Assert.Equal(new ListType(new Int32Type()), new ListType(new Int32Type()));
+            Assert.NotEqual(new ListType(new Int32Type()), new ListType(new FloatType()));
+        }
+
+        [Fact]
+        public void ArrowType_Should_CompareStructTypes()
+        {
+            Assert.Equal(
+                new StructType(new Field[] { new Field("test", new Int32Type(), false) }),
+                new StructType(new Field[] { new Field("test", new Int32Type(), false) })
+            );
+            Assert.NotEqual(
+                new StructType(new Field[] { new Field("test", new Int32Type(), false) }),
+                new StructType(new Field[] { new Field("test", new Int8Type(), false) })
+            );
+            Assert.NotEqual(
+                new StructType(new Field[] { new Field("_", new Int32Type(), false) }),
+                new StructType(new Field[] { new Field("test", new Int32Type(), false) })
+            );
+            Assert.NotEqual(
+                new StructType(new Field[] { new Field("test", new Int32Type(), true) }),
+                new StructType(new Field[] { new Field("test", new Int32Type(), false) })
+            );
+        }
+
+        [Fact]
+        public void TimeType_Should_Compare()
+        {
+            Assert.Equal(new Time32Type(TimeUnit.Microsecond), new Time32Type(TimeUnit.Microsecond));
+            Assert.NotEqual(new Time32Type(TimeUnit.Microsecond), new Time32Type(TimeUnit.Second));
+        }
+
+        [Fact]
+        public void Decimal128Type_Should_Compare()
+        {
+            Assert.Equal(new Decimal128Type(15, 2), new Decimal128Type(15, 2));
+            Assert.NotEqual(new Decimal128Type(15, 2), new Decimal128Type(15, 3));
+            Assert.NotEqual(new Decimal128Type(15, 2), new Decimal128Type(1, 2));
+        }
+
+        [Fact]
+        public void Decimal256Type_Should_Compare()
+        {
+            Assert.Equal(new Decimal256Type(15, 2), new Decimal256Type(15, 2));
+            Assert.NotEqual(new Decimal256Type(15, 2), new Decimal256Type(15, 3));
+        }
+
+        [Fact]
+        public void TimestampType_Should_Compare()
+        {
+            Assert.Equal(new TimestampType(TimeUnit.Second, "+00:00"), new TimestampType(TimeUnit.Second, "+00:00"));
+            Assert.NotEqual(new TimestampType(TimeUnit.Second, "+00:00"), new TimestampType(TimeUnit.Second, "+00:01"));
+            Assert.NotEqual(new TimestampType(TimeUnit.Second, "+00:00"), new TimestampType(TimeUnit.Millisecond, "+00:00"));
+            Assert.NotEqual(new TimestampType(TimeUnit.Second, "+00:00"), new TimestampType(TimeUnit.Millisecond, "+00:12"));
+        }
+
+        [Fact]
+        public void FloatingType_Should_Compare()
+        {
+            Assert.Equal(new FloatType(), new FloatType());
+            Assert.NotEqual(new FloatType(), new DoubleType() as IArrowType);
+        }
+
+        [Fact]
+        public void NumericType_Should_Compare()
+        {
+            Assert.NotEqual(new FloatType(), new Decimal128Type(15, 2) as IArrowType);
+        }
+    }
+}

--- a/csharp/test/Apache.Arrow.Tests/Util/HashUtilTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/Util/HashUtilTests.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Linq;
+using Apache.Arrow.Util;
+using Xunit;
+
+namespace Apache.Arrow.Tests
+{
+    public class HashUtilTests
+    {
+        [Fact]
+        public void CombineHash32_Should_NotOverflow()
+        {
+            Assert.Equal(0, HashUtil.CombineHash32(Enumerable.Range(0, 512).Select(i => int.MinValue).ToArray()));
+            Assert.Equal(968630272, HashUtil.CombineHash32(Enumerable.Range(0, 512).Select(i => int.MaxValue).ToArray()));
+        }
+    }
+}

--- a/csharp/test/Apache.Arrow.Tests/Util/HashUtilTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/Util/HashUtilTests.cs
@@ -27,5 +27,13 @@ namespace Apache.Arrow.Tests
             Assert.Equal(0, HashUtil.CombineHash32(Enumerable.Range(0, 512).Select(i => int.MinValue).ToArray()));
             Assert.Equal(968630272, HashUtil.CombineHash32(Enumerable.Range(0, 512).Select(i => int.MaxValue).ToArray()));
         }
+
+        [Fact]
+        public void Hash32_Should_HashString()
+        {
+            Assert.Equal(0, HashUtil.Hash32(null));
+            Assert.Equal(0, HashUtil.Hash32(""));
+            Assert.Equal(-1277324294, HashUtil.Hash32("abc"));
+        }
     }
 }

--- a/csharp/test/Apache.Arrow.Tests/Util/HashUtilTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/Util/HashUtilTests.cs
@@ -22,18 +22,24 @@ namespace Apache.Arrow.Tests
     public class HashUtilTests
     {
         [Fact]
-        public void CombineHash32_Should_NotOverflow()
+        public void Hash32_ShouldNot_OverFlow()
         {
-            Assert.Equal(0, HashUtil.CombineHash32(Enumerable.Range(0, 512).Select(i => int.MinValue).ToArray()));
-            Assert.Equal(968630272, HashUtil.CombineHash32(Enumerable.Range(0, 512).Select(i => int.MaxValue).ToArray()));
+            Assert.InRange(HashUtil.Hash32Array(new int[] { 1 }), int.MinValue, int.MaxValue);
+            Assert.InRange(HashUtil.Hash32(""), int.MinValue, int.MaxValue);
+            Assert.InRange(HashUtil.Hash32("abc", 1), int.MinValue, int.MaxValue);
         }
 
         [Fact]
-        public void Hash32_Should_HashString()
+        public void Hash32_Should_HashObjects()
         {
-            Assert.Equal(0, HashUtil.Hash32(null));
-            Assert.Equal(0, HashUtil.Hash32(""));
-            Assert.Equal(-1277324294, HashUtil.Hash32("abc"));
+            Assert.Equal(HashUtil.Hash32("abc", 1), HashUtil.Hash32("abc", 1));
+            Assert.NotEqual(HashUtil.Hash32("abc", 1), HashUtil.Hash32(1, "abc"));
+        }
+
+        [Fact]
+        public void Hash32_Should_HashObjectsOver8()
+        {
+            Assert.InRange(HashUtil.Hash32(Enumerable.Range(0, 20).ToArray()), int.MinValue, int.MaxValue);
         }
     }
 }


### PR DESCRIPTION
### Rationale for this change

Compare DataTypes easier

### What changes are included in this PR?

Hashcode + Equals on all Types

### Are these changes tested?

yes

### Are there any user-facing changes?

Unless they compare types by reference, no impacts
* Closes: #35244