### PR TITLE
GH-35271: [R] `[.ArrowTabular` should return ChunkedArray when num_columns is 1

### DIFF
--- a/r/R/arrow-tabular.R
+++ b/r/R/arrow-tabular.R
@@ -135,6 +135,9 @@ as.data.frame.ArrowTabular <- function(x, row.names = NULL, optional = FALSE, ..
   if (!missing(i)) {
     x <- filter_rows(x, i, ...)
   }
+  if (x$num_columns == 1L) {
+    x <- x$column(0)
+  }
   x
 }
 

--- a/r/tests/testthat/test-Table.R
+++ b/r/tests/testthat/test-Table.R
@@ -111,6 +111,10 @@ test_that("[, [[, $ for Table", {
   expect_error(tab[, c("dbl", "NOTACOLUMN")], 'Column not found: "NOTACOLUMN"')
   expect_error(tab[, c(6, NA)], "Column indices cannot be NA")
 
+  # Return ChunkedArray when number of columns is 1
+  expect_as_vector(tab[, 3], tbl[, 3])
+  expect_as_vector(tab[, "lgl"], tbl[, "lgl"])
+
   skip("Table with 0 cols doesn't know how many rows it should have")
   expect_data_frame(tab[0], tbl[0])
 })


### PR DESCRIPTION
### Rationale for this change

For consistency of behavior with DataFrame, `Table[, "foo"]` is necessary to return a Chunked Array.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.

**This PR includes breaking changes to public APIs.**
* Closes: #35271