### PR TITLE
GH-35202: [Go][Parquet] Fix panic reading nested empty list

### DIFF
--- a/go/arrow/memory/internal/cgoalloc/allocator.go
+++ b/go/arrow/memory/internal/cgoalloc/allocator.go
@@ -14,12 +14,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build ccalloc
 // +build ccalloc
 
 package cgoalloc
 
 // #cgo !windows pkg-config: arrow
-// #cgo CXXFLAGS: -std=c++14
+// #cgo CXXFLAGS: -std=c++17
 // #cgo windows LDFLAGS:  -larrow
 // #include "allocator.h"
 import "C"

--- a/go/parquet/file/level_conversion.go
+++ b/go/parquet/file/level_conversion.go
@@ -170,7 +170,7 @@ func defLevelsBatchToBitmap(defLevels []int16, remainingUpperBound int64, info L
 
 // create a bitmap out of the definition Levels
 func defLevelsToBitmapInternal(defLevels []int16, info LevelInfo, out *ValidityBitmapInputOutput, hasRepeatedParent bool) {
-	wr := utils.NewFirstTimeBitmapWriter(out.ValidBits, out.ValidBitsOffset, int64(len(defLevels)))
+	wr := utils.NewFirstTimeBitmapWriter(out.ValidBits, out.ValidBitsOffset, int64(out.ReadUpperBound))
 	defer wr.Finish()
 	setCount := defLevelsBatchToBitmap(defLevels, out.ReadUpperBound, info, wr, hasRepeatedParent)
 	out.Read = int64(wr.Pos())

--- a/go/parquet/pqarrow/column_readers.go
+++ b/go/parquet/pqarrow/column_readers.go
@@ -250,33 +250,35 @@ func (sr *structReader) BuildArray(lenBound int64) (*arrow.Chunked, error) {
 
 	var nullBitmap *memory.Buffer
 
-	if sr.hasRepeatedChild {
-		nullBitmap = memory.NewResizableBuffer(sr.rctx.mem)
-		nullBitmap.Resize(int(bitutil.BytesForBits(lenBound)))
-		validityIO.ValidBits = nullBitmap.Bytes()
-		defLevels, err := sr.GetDefLevels()
-		if err != nil {
-			return nil, err
-		}
-		repLevels, err := sr.GetRepLevels()
-		if err != nil {
-			return nil, err
-		}
+	if lenBound > 0 {
+		if sr.hasRepeatedChild {
+			nullBitmap = memory.NewResizableBuffer(sr.rctx.mem)
+			nullBitmap.Resize(int(bitutil.BytesForBits(lenBound)))
+			validityIO.ValidBits = nullBitmap.Bytes()
+			defLevels, err := sr.GetDefLevels()
+			if err != nil {
+				return nil, err
+			}
+			repLevels, err := sr.GetRepLevels()
+			if err != nil {
+				return nil, err
+			}
 
-		if err := file.DefRepLevelsToBitmap(defLevels, repLevels, sr.levelInfo, &validityIO); err != nil {
-			return nil, err
-		}
+			if err := file.DefRepLevelsToBitmap(defLevels, repLevels, sr.levelInfo, &validityIO); err != nil {
+				return nil, err
+			}
 
-	} else if sr.filtered.Nullable {
-		nullBitmap = memory.NewResizableBuffer(sr.rctx.mem)
-		nullBitmap.Resize(int(bitutil.BytesForBits(lenBound)))
-		validityIO.ValidBits = nullBitmap.Bytes()
-		defLevels, err := sr.GetDefLevels()
-		if err != nil {
-			return nil, err
-		}
+		} else if sr.filtered.Nullable {
+			nullBitmap = memory.NewResizableBuffer(sr.rctx.mem)
+			nullBitmap.Resize(int(bitutil.BytesForBits(lenBound)))
+			validityIO.ValidBits = nullBitmap.Bytes()
+			defLevels, err := sr.GetDefLevels()
+			if err != nil {
+				return nil, err
+			}
 
-		file.DefLevelsToBitmap(defLevels, sr.levelInfo, &validityIO)
+			file.DefLevelsToBitmap(defLevels, sr.levelInfo, &validityIO)
+		}
 	}
 
 	if nullBitmap != nil {

--- a/go/parquet/pqarrow/encode_arrow_test.go
+++ b/go/parquet/pqarrow/encode_arrow_test.go
@@ -1366,12 +1366,32 @@ func (ps *ParquetIOTestSuite) TestNestedEmptyList() {
 	child1Bldr := rootBldr.FieldBuilder(0).(*array.ListBuilder)
 	child1ElBldr := child1Bldr.ValueBuilder().(*array.StructBuilder)
 	child2Bldr := child1ElBldr.FieldBuilder(0).(*array.ListBuilder)
+	leafBldr := child2Bldr.ValueBuilder().(*array.StructBuilder)
+	nameBldr := leafBldr.FieldBuilder(0).(*array.StringBuilder)
 
-	bldr.Append(true)
-	rootBldr.Append(true)
-	child1Bldr.Append(true)
-	child1ElBldr.Append(true)
-	child2Bldr.AppendEmptyValue()
+	// target structure 8 times
+	// {
+	//   "root": {
+	//     "child1": [
+	//       { "child2": [{ "name": "foo" }] },
+	//       { "child2": [] }
+	//     ]
+	//   }
+	// }
+
+	for i := 0; i < 8; i++ {
+		bldr.Append(true)
+		rootBldr.Append(true)
+		child1Bldr.Append(true)
+
+		child1ElBldr.Append(true)
+		child2Bldr.Append(true)
+		leafBldr.Append(true)
+		nameBldr.Append("foo")
+
+		child1ElBldr.Append(true)
+		child2Bldr.Append(true)
+	}
 
 	arr := bldr.NewArray()
 	defer arr.Release()

--- a/go/parquet/pqarrow/encode_arrow_test.go
+++ b/go/parquet/pqarrow/encode_arrow_test.go
@@ -1335,6 +1335,54 @@ func (ps *ParquetIOTestSuite) TestNestedNullableField() {
 	ps.roundTripTable(mem, tbl, false)
 }
 
+func (ps *ParquetIOTestSuite) TestNestedEmptyList() {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(ps.T(), 0)
+
+	bldr := array.NewStructBuilder(mem, arrow.StructOf(
+		arrow.Field{
+			Name: "root",
+			Type: arrow.StructOf(
+				arrow.Field{
+					Name: "child1",
+					Type: arrow.ListOf(arrow.StructOf(
+						arrow.Field{
+							Name: "child2",
+							Type: arrow.ListOf(arrow.StructOf(
+								arrow.Field{
+									Name: "name",
+									Type: arrow.BinaryTypes.String,
+								},
+							)),
+						},
+					)),
+				},
+			),
+		},
+	))
+	defer bldr.Release()
+
+	rootBldr := bldr.FieldBuilder(0).(*array.StructBuilder)
+	child1Bldr := rootBldr.FieldBuilder(0).(*array.ListBuilder)
+	child1ElBldr := child1Bldr.ValueBuilder().(*array.StructBuilder)
+	child2Bldr := child1ElBldr.FieldBuilder(0).(*array.ListBuilder)
+
+	bldr.Append(true)
+	rootBldr.Append(true)
+	child1Bldr.Append(true)
+	child1ElBldr.Append(true)
+	child2Bldr.AppendEmptyValue()
+
+	arr := bldr.NewArray()
+	defer arr.Release()
+
+	field := arrow.Field{Name: "x", Type: arr.DataType(), Nullable: true}
+	expected := array.NewTableFromSlice(arrow.NewSchema([]arrow.Field{field}, nil), [][]arrow.Array{{arr}})
+	defer expected.Release()
+
+	ps.roundTripTable(mem, expected, false)
+}
+
 func (ps *ParquetIOTestSuite) TestCanonicalNestedRoundTrip() {
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(ps.T(), 0)


### PR DESCRIPTION

### What changes are included in this PR?
A simple check in the struct reader to validate that we're trying to read something with at least one child before we start trying to build a nullbitmap that wouldn't exist if there are 0 elements in the actual array.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
Yes a unit test is included in this change.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

* Closes: #35202