### PR TITLE
GH-35266: [CI][GLib][Parquet] Omit gparquet_column_chunk_metadata_equal() test

### DIFF
--- a/c_glib/test/parquet/test-column-chunk-metadata.rb
+++ b/c_glib/test/parquet/test-column-chunk-metadata.rb
@@ -45,6 +45,7 @@ class TestParquetColumnChunkMetadata < Test::Unit::TestCase
   end
 
   test("#==") do
+    omit("parquet::ColumnChunkMetaData::Equals() isn't stable.")
     reader = Parquet::ArrowFileReader.new(@file.path)
     other_metadata = reader.metadata.get_row_group(0).get_column_chunk(0)
     assert do


### PR DESCRIPTION
### Rationale for this change

Because it's not stable on macOS.

### What changes are included in this PR?

We omit the test for now like GH-20207.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #35266