### PR TITLE
GH-35278: [C++][Parquet] Tools: Add debug string for ColumnChunkMetadata

### DIFF
--- a/c_glib/parquet-glib/metadata.cpp
+++ b/c_glib/parquet-glib/metadata.cpp
@@ -211,7 +211,7 @@ gparquet_column_chunk_metadata_get_statistics(
 }
 
 /**
- * gparquet_column_chunk_metadata_get_statistics:
+ * gparquet_column_chunk_metadata_to_string:
  * @metadata: A #GParquetColumnChunkMetadata.
  *
  * Returns: The debug string.

--- a/c_glib/parquet-glib/metadata.cpp
+++ b/c_glib/parquet-glib/metadata.cpp
@@ -210,6 +210,24 @@ gparquet_column_chunk_metadata_get_statistics(
   }
 }
 
+/**
+ * gparquet_column_chunk_metadata_get_statistics:
+ * @metadata: A #GParquetColumnChunkMetadata.
+ *
+ * Returns: The debug string.
+ *
+ *   It should be freed with g_free() when no longer needed.
+ *
+ * Since: 8.0.0
+ */
+gchar *
+gparquet_column_chunk_metadata_to_string(GParquetColumnChunkMetadata *metadata)
+{
+  auto parquet_metadata = gparquet_column_chunk_metadata_get_raw(metadata);
+  const auto string = parquet_metadata->ToDebugString();
+  return g_strdup(string.c_str());
+}
+
 
 struct GParquetRowGroupMetadataPrivate {
   parquet::RowGroupMetaData *metadata;

--- a/c_glib/parquet-glib/metadata.h
+++ b/c_glib/parquet-glib/metadata.h
@@ -60,6 +60,9 @@ GARROW_AVAILABLE_IN_8_0
 GParquetStatistics *
 gparquet_column_chunk_metadata_get_statistics(
   GParquetColumnChunkMetadata *metadata);
+gchar *
+gparquet_column_chunk_metadata_to_string(
+  GParquetColumnChunkMetadata *metadata);
 
 
 #define GPARQUET_TYPE_ROW_GROUP_METADATA (gparquet_row_group_metadata_get_type())

--- a/c_glib/test/parquet/test-column-chunk-metadata.rb
+++ b/c_glib/test/parquet/test-column-chunk-metadata.rb
@@ -45,7 +45,6 @@ class TestParquetColumnChunkMetadata < Test::Unit::TestCase
   end
 
   test("#==") do
-    omit("parquet::ColumnChunkMetaData::Equals() isn't stable.")
     reader = Parquet::ArrowFileReader.new(@file.path)
     other_metadata = reader.metadata.get_row_group(0).get_column_chunk(0)
     assert do

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -332,6 +332,12 @@ class ColumnChunkMetaData::ColumnChunkMetaDataImpl {
     return std::nullopt;
   }
 
+  std::string ToDebugString() const {
+    std::stringstream ss;
+    column_->printTo(ss);
+    return ss.str();
+  }
+
  private:
   mutable std::shared_ptr<Statistics> possible_stats_;
   std::vector<Encoding::type> encodings_;
@@ -455,6 +461,8 @@ std::optional<IndexLocation> ColumnChunkMetaData::GetOffsetIndexLocation() const
 bool ColumnChunkMetaData::Equals(const ColumnChunkMetaData& other) const {
   return impl_->Equals(*other.impl_);
 }
+
+std::string ColumnChunkMetaData::ToDebugString() const { return impl_->ToDebugString(); }
 
 // row-group metadata
 class RowGroupMetaData::RowGroupMetaDataImpl {

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -183,6 +183,8 @@ class PARQUET_EXPORT ColumnChunkMetaData {
   std::optional<IndexLocation> GetColumnIndexLocation() const;
   std::optional<IndexLocation> GetOffsetIndexLocation() const;
 
+  std::string ToDebugString() const;
+
  private:
   explicit ColumnChunkMetaData(
       const void* metadata, const ColumnDescriptor* descr, int16_t row_group_ordinal,


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Add debugString to ColumnChunkMetadata

### What changes are included in this PR?

A debug string directly using thrift internal methods.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

No

### Are there any user-facing changes?

User can use it to debug

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #35278