### PR TITLE
GH-35266: [GLib][Parquet] Fix a GC bug that parent metadata reference is missing in sub metadata

### DIFF
--- a/c_glib/parquet-glib/metadata.hpp
+++ b/c_glib/parquet-glib/metadata.hpp
@@ -25,12 +25,15 @@
 
 GParquetColumnChunkMetadata *
 gparquet_column_chunk_metadata_new_raw(
-  parquet::ColumnChunkMetaData *parquet_metadata);
+  parquet::ColumnChunkMetaData *parquet_metadata,
+  GParquetRowGroupMetadata *owner);
 parquet::ColumnChunkMetaData *
 gparquet_column_chunk_metadata_get_raw(GParquetColumnChunkMetadata *metadata);
 
 GParquetRowGroupMetadata *
-gparquet_row_group_metadata_new_raw(parquet::RowGroupMetaData *parquet_metadata);
+gparquet_row_group_metadata_new_raw(
+  parquet::RowGroupMetaData *parquet_metadata,
+  GParquetFileMetadata *owner);
 parquet::RowGroupMetaData *
 gparquet_row_group_metadata_get_raw(GParquetRowGroupMetadata *metadata);
 

--- a/c_glib/test/parquet/test-column-chunk-metadata.rb
+++ b/c_glib/test/parquet/test-column-chunk-metadata.rb
@@ -45,7 +45,6 @@ class TestParquetColumnChunkMetadata < Test::Unit::TestCase
   end
 
   test("#==") do
-    omit("parquet::ColumnChunkMetaData::Equals() isn't stable.")
     reader = Parquet::ArrowFileReader.new(@file.path)
     other_metadata = reader.metadata.get_row_group(0).get_column_chunk(0)
     assert do

--- a/c_glib/test/parquet/test-row-group-metadata.rb
+++ b/c_glib/test/parquet/test-row-group-metadata.rb
@@ -45,7 +45,6 @@ class TestParquetRowGroupMetadata < Test::Unit::TestCase
   end
 
   test("#==") do
-    omit("parquet::RowGroupMetaData::Equals() isn't stable.")
     reader = Parquet::ArrowFileReader.new(@file.path)
     other_metadata = reader.metadata.get_row_group(0)
     assert do


### PR DESCRIPTION
### Rationale for this change

`GParquetColumnChunkMetadata` must not be GC-ed while the parent `GParquetRowGroupMetadata` is alive.

`GParquetRowGroupMetadata` must not be GC-ed while the parent `GParquetFileMetadata` is alive.

### What changes are included in this PR?

Add missing parent metadata references to sub metadata.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #35266