### PR TITLE
GH-35297: [C++][IPC] Fix schema deserialization of map field

### DIFF
--- a/cpp/src/arrow/ipc/metadata_internal.cc
+++ b/cpp/src/arrow/ipc/metadata_internal.cc
@@ -367,9 +367,9 @@ Status ConcreteTypeFromFlatbuffer(flatbuf::Type type, const void* type_data,
         return Status::Invalid("Map's keys must be non-nullable");
       } else {
         auto map = static_cast<const flatbuf::Map*>(type_data);
-        *out = std::make_shared<MapType>(children[0]->type()->field(0)->type(),
-                                         children[0]->type()->field(1)->type(),
-                                         map->keysSorted());
+        *out =
+            std::make_shared<MapType>(children[0]->type()->field(0),
+                                      children[0]->type()->field(1), map->keysSorted());
       }
       return Status::OK();
     case flatbuf::Type::FixedSizeList:

--- a/cpp/src/arrow/ipc/metadata_internal.cc
+++ b/cpp/src/arrow/ipc/metadata_internal.cc
@@ -367,9 +367,9 @@ Status ConcreteTypeFromFlatbuffer(flatbuf::Type type, const void* type_data,
         return Status::Invalid("Map's keys must be non-nullable");
       } else {
         auto map = static_cast<const flatbuf::Map*>(type_data);
-        *out =
-            std::make_shared<MapType>(children[0]->type()->field(0),
-                                      children[0]->type()->field(1), map->keysSorted());
+        *out = std::make_shared<MapType>(children[0]->type()->field(0)->WithName("key"),
+                                         children[0]->type()->field(1)->WithName("value"),
+                                         map->keysSorted());
       }
       return Status::OK();
     case flatbuf::Type::FixedSizeList:

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -283,7 +283,7 @@ TEST_F(TestSchemaMetadata, NestedFields) {
 // Verify that nullable=false is well-preserved for child fields of map type.
 TEST_F(TestSchemaMetadata, MapField) {
   auto key = field("key", int32(), false);
-  auto item = field("item", int32(), false);
+  auto item = field("value", int32(), false);
   auto f0 = field("f0", std::make_shared<MapType>(key, item));
   Schema schema({f0});
   CheckSchemaRoundtrip(schema);
@@ -291,14 +291,14 @@ TEST_F(TestSchemaMetadata, MapField) {
 
 // Verify that key value metadata is well-preserved for child fields of nested type.
 TEST_F(TestSchemaMetadata, NestedFieldsWithKeyValueMetadata) {
-  auto inner = field("inner", std::make_shared<Int64Type>(), false,
-                     key_value_metadata({"foo"}, {"bar"}));
-
-  auto f0 = field("f0", list(inner), false, key_value_metadata({"k1"}, {"v1"}));
-  auto f1 = field("f1", struct_({inner}), false, key_value_metadata({"k2"}, {"v2"}));
-  auto f2 = field("f3", std::make_shared<MapType>(inner, inner), false,
-                  key_value_metadata({"k3"}, {"v3"}));
-
+  auto metadata = key_value_metadata({"foo"}, {"bar"});
+  auto inner_field = field("inner", int32(), false, metadata);
+  auto f0 = field("f0", list(inner_field), false, metadata);
+  auto f1 = field("f1", struct_({inner_field}), false, metadata);
+  auto f2 = field("f2",
+                  std::make_shared<MapType>(field("key", int32(), false, metadata),
+                                            field("value", int32(), false, metadata)),
+                  false, metadata);
   Schema schema({f0, f1, f2});
   CheckSchemaRoundtrip(schema);
 }


### PR DESCRIPTION
### Rationale for this change

The arrow schema deserialization from flatbuffer does not preserve nullable and metadata of sub-fields in the map type.

### What changes are included in this PR?

Fix map type deserialization by creating map type using field objects instead of type objects for sub-types.

### Are these changes tested?

Add several new test cases in the arrow/ipc/read_write_test.cc.

### Are there any user-facing changes?

No.
* Closes: #35297