### PR TITLE
added None check in feather.write_feather

### DIFF
--- a/python/pyarrow/feather.py
+++ b/python/pyarrow/feather.py
@@ -182,6 +182,8 @@ def write_feather(df, dest, compression=None, compression_level=None,
             raise ValueError('compression="{}" not supported, must be '
                              'one of {}'.format(compression,
                                                 _FEATHER_SUPPORTED_CODECS))
+    if table is None:
+        raise TypeError("Argument 'table' has incorrect type (expected pyarrow.lib.Table, got None)")
 
     try:
         _feather.write_feather(table, dest, compression=compression,


### PR DESCRIPTION
without this None check the call to _feather.write_feather does crash the python interpreter as it tries to access memory locations it is not allowed to access. This means it does NOT simply raise an exception, but completely crashes the entire Python process immediately. Can be reproduced by passing None as df to write_feather before this patch is activated.