### PR TITLE
GH-35315: [C++][CMake] Add presets for Flight SQL

### DIFF
--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -111,6 +111,14 @@
       }
     },
     {
+      "name": "features-flight-sql",
+      "inherits": "features-flight",
+      "hidden": true,
+      "cacheVariables": {
+        "ARROW_FLIGHT_SQL": "ON"
+      }
+    },
+    {
       "name": "features-gandiva",
       "inherits": "features-basic",
       "hidden": true,
@@ -151,7 +159,7 @@
       "inherits": [
         "features-cuda",
         "features-filesystems",
-        "features-flight",
+        "features-flight-sql",
         "features-gandiva",
         "features-main",
         "features-python-minimal"
@@ -168,7 +176,7 @@
         "features-main",
         "features-cuda",
         "features-filesystems",
-        "features-flight",
+        "features-flight-sql",
         "features-gandiva",
         "features-python-maximal"
       ],
@@ -239,6 +247,15 @@
         "features-flight"
       ],
       "displayName": "Debug build with tests and Flight",
+      "cacheVariables": {}
+    },
+    {
+      "name": "ninja-debug-flight-sql",
+      "inherits": [
+        "base-debug",
+        "features-flight-sql"
+      ],
+      "displayName": "Debug build with tests and Flight SQL",
       "cacheVariables": {}
     },
     {
@@ -329,6 +346,15 @@
         "features-flight"
       ],
       "displayName": "Release build with Flight",
+      "cacheVariables": {}
+    },
+    {
+      "name": "ninja-release-flight-sql",
+      "inherits": [
+        "base-release",
+        "features-flight-sql"
+      ],
+      "displayName": "Release build with Flight SQL",
       "cacheVariables": {}
     },
     {


### PR DESCRIPTION
### Rationale for this change

The `ninja-release-maximal` preset doesn't enable Flight SQL.

### What changes are included in this PR?

Add Flight SQL related presets.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.

* Closes: #35315