### PR TITLE
GH-44855: [Python][Packaging] Use delvewheel to repair Windows wheels

### DIFF
--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -126,6 +126,8 @@ python setup.py bdist_wheel || exit /B 1
 
 @REM Repair the wheel with delvewheel
 pip install delvewheel || exit /B 1
-delvewheel repair dist\pyarrow-*.whl -w repaired_wheels || exit /B 1
-delvewheel show dist\pyarrow-*.whl || exit /B 1
+for /f %%i in ('dir dist\pyarrow-*.whl /B') do set WHEEL_NAME=dist\%%i || exit /B 1
+echo "Wheel name: %WHEEL_NAME%"
+delvewheel repair %WHEEL_NAME% -w repaired_wheels || exit /B 1
+delvewheel show %WHEEL_NAME% || exit /B 1
 popd

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -126,6 +126,6 @@ python setup.py bdist_wheel || exit /B 1
 
 @REM Repair the wheel with delvewheel
 pip install delvewheel || exit /B 1
-delvewheel repair -L . dist\pyarrow-*.whl -w repaired_wheels || exit /B 1
+delvewheel repair dist\pyarrow-*.whl -w repaired_wheels || exit /B 1
 delvewheel show dist\pyarrow-*.whl || exit /B 1
 popd

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -126,6 +126,6 @@ python setup.py bdist_wheel || exit /B 1
 
 @REM Repair the wheel with delvewheel
 pip install delvewheel || exit /B 1
-delvewheel show || exit /B 1
 delvewheel repair -L . dist\pyarrow-*.whl -w repaired_wheels || exit /B 1
+delvewheel show dist\pyarrow-*.whl || exit /B 1
 popd

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -128,6 +128,6 @@ python setup.py bdist_wheel || exit /B 1
 pip install delvewheel || exit /B 1
 for /f %%i in ('dir dist\pyarrow-*.whl /B') do set WHEEL_NAME=dist\%%i || exit /B 1
 echo "Wheel name: %WHEEL_NAME%"
-delvewheel repair %WHEEL_NAME% -w repaired_wheels || exit /B 1
+delvewheel repair %WHEEL_NAME% --add-path C:\arrow\python\build\bdist.win-amd64\wheel\pyarrow -w repaired_wheels || exit /B 1
 delvewheel show %WHEEL_NAME% || exit /B 1
 popd

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -121,6 +121,7 @@ set ARROW_HOME=C:\arrow-dist
 set CMAKE_PREFIX_PATH=C:\arrow-dist
 
 pushd C:\arrow\python
+
 @REM build wheel
 python setup.py bdist_wheel || exit /B 1
 
@@ -129,8 +130,7 @@ pip install delvewheel || exit /B 1
 for /f %%i in ('dir dist\pyarrow-*.whl /B') do set WHEEL_NAME=dist\%%i || exit /B 1
 echo "Wheel name: %WHEEL_NAME%"
 
-delvewheel show -v --analyze-existing %WHEEL_NAME% || exit /B 1
-
-delvewheel repair -v %WHEEL_NAME% --add-path C:\arrow\python\build\bdist.win-amd64\wheel\pyarrow -w repaired_wheels || exit /B 1
+delvewheel show -v --ignore-existing --include msvcp140.dll %WHEEL_NAME% || exit /B 1
+delvewheel repair -v --ignore-existing --include msvcp140.dll %WHEEL_NAME% -w repaired_wheels || exit /B 1
 
 popd

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -134,10 +134,12 @@ python setup.py bdist_wheel || exit /B 1
 
 @REM Repair the wheel with delvewheel
 pip install delvewheel || exit /B 1
-for /f %%i in ('dir dist\pyarrow-*.whl /B') do set WHEEL_NAME="%cd%\dist\%%i" || exit /B 1
+for /f %%i in ('dir dist\pyarrow-*.whl /B') do (set WHEEL_NAME=%cd%\dist\%%i) || exit /B 1
 echo "Wheel name: %WHEEL_NAME%"
-for /f %%i in ('dir build\lib* /B') do set WHEEL_BUILD_DIR="%cd%\build\%%i" || exit /B 1
+for /f %%i in ('dir build\lib* /B') do (set WHEEL_BUILD_DIR=%cd%\build\%%i) || exit /B 1
 echo "Wheel build dir: %WHEEL_BUILD_DIR%"
+
+dir "%WHEEL_BUILD_DIR%\pyarrow"
 
 delvewheel show -vv --add-path "%WHEEL_BUILD_DIR%\pyarrow";C:\Windows\System32 %WHEEL_NAME% || exit /B 1
 delvewheel repair -vv --add-path "%WHEEL_BUILD_DIR%\pyarrow";C:\Windows\System32 %WHEEL_NAME% -w repaired_wheels || exit /B 1

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -128,6 +128,9 @@ python setup.py bdist_wheel || exit /B 1
 pip install delvewheel || exit /B 1
 for /f %%i in ('dir dist\pyarrow-*.whl /B') do set WHEEL_NAME=dist\%%i || exit /B 1
 echo "Wheel name: %WHEEL_NAME%"
-delvewheel repair %WHEEL_NAME% --add-path C:\arrow\python\build\bdist.win-amd64\wheel\pyarrow -w repaired_wheels || exit /B 1
-delvewheel show %WHEEL_NAME% || exit /B 1
+
+delvewheel show -v --analyze-existing %WHEEL_NAME% || exit /B 1
+
+delvewheel repair -v %WHEEL_NAME% --add-path C:\arrow\python\build\bdist.win-amd64\wheel\pyarrow -w repaired_wheels || exit /B 1
+
 popd

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -104,7 +104,7 @@ popd
 
 echo "=== (%PYTHON_VERSION%) Building wheel ==="
 set PYARROW_BUILD_TYPE=%CMAKE_BUILD_TYPE%
-set PYARROW_BUNDLE_ARROW_CPP=ON
+set PYARROW_BUNDLE_ARROW_CPP=OFF
 set PYARROW_CMAKE_GENERATOR=%CMAKE_GENERATOR%
 set PYARROW_WITH_ACERO=%ARROW_ACERO%
 set PYARROW_WITH_DATASET=%ARROW_DATASET%
@@ -129,7 +129,7 @@ python setup.py bdist_wheel || exit /B 1
 pip install delvewheel || exit /B 1
 for /f %%i in ('dir dist\pyarrow-*.whl /B') do set WHEEL_NAME=dist\%%i || exit /B 1
 echo "Wheel name: %WHEEL_NAME%"
-for /f %%i in ('dir dist\lib* /B') do set WHEEL_BUILD_DIR=dist\%%i || exit /B 1
+for /f %%i in ('dir build\lib* /B') do set WHEEL_BUILD_DIR=build\%%i || exit /B 1
 echo "Wheel build dir: %WHEEL_BUILD_DIR%"
 dir %WHEEL_BUILD_DIR% || exit /B 1
 

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -144,6 +144,7 @@ pip install https://github.com/pitrou/delvewheel/archive/refs/heads/fixes-for-ar
 for /f %%i in ('dir dist\pyarrow-*.whl /B') do (set WHEEL_NAME=%cd%\dist\%%i) || exit /B 1
 echo "Wheel name: %WHEEL_NAME%"
 
-delvewheel repair -vv --mangle-only=msvcp140.dll %WHEEL_NAME% -w repaired_wheels || exit /B 1
+delvewheel repair -vv --mangle-only=msvcp140.dll --no-patch ^
+    -w repaired_wheels %WHEEL_NAME% || exit /B 1
 
 popd

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -20,9 +20,10 @@
 echo "Building windows wheel..."
 
 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
+@echo on
 
 @REM Install a more recent msvcp140.dll in C:\Windows\System
-RUN choco install -r -y --no-progress vcredist140
+choco install -r -y --no-progress vcredist140
 
 echo "=== (%PYTHON_VERSION%) Clear output directories and leftovers ==="
 del /s /q C:\arrow-build
@@ -130,9 +131,9 @@ python setup.py bdist_wheel || exit /B 1
 
 @REM Repair the wheel with delvewheel
 pip install delvewheel || exit /B 1
-for /f %%i in ('dir dist\pyarrow-*.whl /B') do set WHEEL_NAME="%%~fi" || exit /B 1
+for /f %%i in ('dir dist\pyarrow-*.whl /B') do set WHEEL_NAME="%cd%\dist\%%i" || exit /B 1
 echo "Wheel name: %WHEEL_NAME%"
-for /f %%i in ('dir build\lib* /B') do set WHEEL_BUILD_DIR="%%~fi" || exit /B 1
+for /f %%i in ('dir build\lib* /B') do set WHEEL_BUILD_DIR="%cd%\build\%%i" || exit /B 1
 echo "Wheel build dir: %WHEEL_BUILD_DIR%"
 
 delvewheel show -vv --add-path "%WHEEL_BUILD_DIR%\pyarrow" %WHEEL_NAME% || exit /B 1

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -128,7 +128,10 @@ set CMAKE_PREFIX_PATH=C:\arrow-dist
 
 pushd C:\arrow\python
 
-@REM build wheel
+@REM Bundle the C++ runtime
+cp C:\Windows\System32\msvcp140.dll pyarrow\
+
+@REM Build wheel
 python setup.py bdist_wheel || exit /B 1
 
 @REM Repair the wheel with delvewheel

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -127,11 +127,10 @@ python setup.py bdist_wheel || exit /B 1
 
 @REM Repair the wheel with delvewheel
 pip install delvewheel || exit /B 1
-for /f %%i in ('dir dist\pyarrow-*.whl /B') do set WHEEL_NAME=dist\%%i || exit /B 1
+for /f %%i in ('dir dist\pyarrow-*.whl /B') do set WHEEL_NAME=dist\%%~fi || exit /B 1
 echo "Wheel name: %WHEEL_NAME%"
-for /f %%i in ('dir build\lib* /B') do set WHEEL_BUILD_DIR=build\%%i || exit /B 1
+for /f %%i in ('dir build\lib* /B') do set WHEEL_BUILD_DIR=build\%%~fi || exit /B 1
 echo "Wheel build dir: %WHEEL_BUILD_DIR%"
-dir %WHEEL_BUILD_DIR% || exit /B 1
 
 delvewheel show -vv --add-path %WHEEL_BUILD_DIR%\pyarrow %WHEEL_NAME% || exit /B 1
 delvewheel repair -vv --add-path %WHEEL_BUILD_DIR%\pyarrow %WHEEL_NAME% -w repaired_wheels || exit /B 1

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -121,7 +121,11 @@ set ARROW_HOME=C:\arrow-dist
 set CMAKE_PREFIX_PATH=C:\arrow-dist
 
 pushd C:\arrow\python
-@REM bundle the msvc runtime
-cp "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Redist\MSVC\14.28.29325\x64\Microsoft.VC142.CRT\msvcp140.dll" pyarrow\
+@REM build wheel
 python setup.py bdist_wheel || exit /B 1
+
+@REM Repair the wheel with delvewheel
+pip install delvewheel || exit /B 1
+delvewheel show || exit /B 1
+delvewheel repair -L . dist\pyarrow-*.whl -w repaired_wheels || exit /B 1
 popd

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -130,7 +130,7 @@ pip install delvewheel || exit /B 1
 for /f %%i in ('dir dist\pyarrow-*.whl /B') do set WHEEL_NAME=dist\%%i || exit /B 1
 echo "Wheel name: %WHEEL_NAME%"
 
-delvewheel show -vv --ignore-existing --include msvcp140.dll %WHEEL_NAME% || exit /B 1
-delvewheel repair -vv --ignore-existing --include msvcp140.dll %WHEEL_NAME% -w repaired_wheels || exit /B 1
+delvewheel show -vv %WHEEL_NAME% || exit /B 1
+delvewheel repair -vv %WHEEL_NAME% -w repaired_wheels || exit /B 1
 
 popd

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -139,6 +139,9 @@ python setup.py bdist_wheel || exit /B 1
 @REM Since we bundled the Arrow C++ libraries ourselves, we only need to
 @REM mangle msvcp140.dll so as to avoid ABI issues when msvcp140.dll is
 @REM required by multiple Python libraries in the same process.
+@REM
+@REM For now this requires a custom version of delvewheel:
+@REM https://github.com/adang1345/delvewheel/pull/59
 pip install https://github.com/pitrou/delvewheel/archive/refs/heads/fixes-for-arrow.zip || exit /B 1
 
 for /f %%i in ('dir dist\pyarrow-*.whl /B') do (set WHEEL_NAME=%cd%\dist\%%i) || exit /B 1

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -21,6 +21,9 @@ echo "Building windows wheel..."
 
 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
 
+@REM Install a more recent msvcp140.dll in C:\Windows\System
+RUN choco install -r -y --no-progress vcredist140
+
 echo "=== (%PYTHON_VERSION%) Clear output directories and leftovers ==="
 del /s /q C:\arrow-build
 del /s /q C:\arrow-dist
@@ -127,12 +130,12 @@ python setup.py bdist_wheel || exit /B 1
 
 @REM Repair the wheel with delvewheel
 pip install delvewheel || exit /B 1
-for /f %%i in ('dir dist\pyarrow-*.whl /B') do set WHEEL_NAME=dist\%%~fi || exit /B 1
+for /f %%i in ('dir dist\pyarrow-*.whl /B') do set WHEEL_NAME="%%~fi" || exit /B 1
 echo "Wheel name: %WHEEL_NAME%"
-for /f %%i in ('dir build\lib* /B') do set WHEEL_BUILD_DIR=build\%%~fi || exit /B 1
+for /f %%i in ('dir build\lib* /B') do set WHEEL_BUILD_DIR="%%~fi" || exit /B 1
 echo "Wheel build dir: %WHEEL_BUILD_DIR%"
 
-delvewheel show -vv --add-path %WHEEL_BUILD_DIR%\pyarrow %WHEEL_NAME% || exit /B 1
-delvewheel repair -vv --add-path %WHEEL_BUILD_DIR%\pyarrow %WHEEL_NAME% -w repaired_wheels || exit /B 1
+delvewheel show -vv --add-path "%WHEEL_BUILD_DIR%\pyarrow" %WHEEL_NAME% || exit /B 1
+delvewheel repair -vv --add-path "%WHEEL_BUILD_DIR%\pyarrow" %WHEEL_NAME% -w repaired_wheels || exit /B 1
 
 popd

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -24,6 +24,9 @@ call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary
 
 @REM Install a more recent msvcp140.dll in C:\Windows\System
 choco install -r -y --no-progress vcredist140
+choco upgrade -r -y --no-progress vcredist140
+
+dir C:\Windows\System32\msvcp140.dll
 
 echo "=== (%PYTHON_VERSION%) Clear output directories and leftovers ==="
 del /s /q C:\arrow-build
@@ -136,7 +139,7 @@ echo "Wheel name: %WHEEL_NAME%"
 for /f %%i in ('dir build\lib* /B') do set WHEEL_BUILD_DIR="%cd%\build\%%i" || exit /B 1
 echo "Wheel build dir: %WHEEL_BUILD_DIR%"
 
-delvewheel show -vv --add-path "%WHEEL_BUILD_DIR%\pyarrow" %WHEEL_NAME% || exit /B 1
-delvewheel repair -vv --add-path "%WHEEL_BUILD_DIR%\pyarrow" %WHEEL_NAME% -w repaired_wheels || exit /B 1
+delvewheel show -vv --add-path "%WHEEL_BUILD_DIR%\pyarrow";C:\Windows\System32 %WHEEL_NAME% || exit /B 1
+delvewheel repair -vv --add-path "%WHEEL_BUILD_DIR%\pyarrow";C:\Windows\System32 %WHEEL_NAME% -w repaired_wheels || exit /B 1
 
 popd

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -129,8 +129,11 @@ python setup.py bdist_wheel || exit /B 1
 pip install delvewheel || exit /B 1
 for /f %%i in ('dir dist\pyarrow-*.whl /B') do set WHEEL_NAME=dist\%%i || exit /B 1
 echo "Wheel name: %WHEEL_NAME%"
+for /f %%i in ('dir dist\lib* /B') do set WHEEL_BUILD_DIR=dist\%%i || exit /B 1
+echo "Wheel build dir: %WHEEL_BUILD_DIR%"
+dir %WHEEL_BUILD_DIR% || exit /B 1
 
-delvewheel show -vv %WHEEL_NAME% || exit /B 1
-delvewheel repair -vv %WHEEL_NAME% -w repaired_wheels || exit /B 1
+delvewheel show -vv --add-path %WHEEL_BUILD_DIR%\pyarrow %WHEEL_NAME% || exit /B 1
+delvewheel repair -vv --add-path %WHEEL_BUILD_DIR%\pyarrow %WHEEL_NAME% -w repaired_wheels || exit /B 1
 
 popd

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -139,9 +139,15 @@ echo "Wheel name: %WHEEL_NAME%"
 for /f %%i in ('dir build\lib* /B') do (set WHEEL_BUILD_DIR=%cd%\build\%%i) || exit /B 1
 echo "Wheel build dir: %WHEEL_BUILD_DIR%"
 
-dir "%WHEEL_BUILD_DIR%\pyarrow"
+dir "%WHEEL_BUILD_DIR%\pyarrow" || exit /B 1
 
-delvewheel show -vv --add-path "%WHEEL_BUILD_DIR%\pyarrow";C:\Windows\System32 %WHEEL_NAME% || exit /B 1
-delvewheel repair -vv --add-path "%WHEEL_BUILD_DIR%\pyarrow";C:\Windows\System32 %WHEEL_NAME% -w repaired_wheels || exit /B 1
+delvewheel show -vv ^
+    --add-path "%WHEEL_BUILD_DIR%\pyarrow";C:\Windows\System32 ^
+    --add-path "%ARROW_HOME%\lib" ^
+    %WHEEL_NAME% || exit /B 1
+delvewheel repair -vv ^
+    --add-path "%WHEEL_BUILD_DIR%\pyarrow";C:\Windows\System32 ^
+    --add-path "%ARROW_HOME%\lib" ^
+    %WHEEL_NAME% -w repaired_wheels || exit /B 1
 
 popd

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -143,11 +143,11 @@ dir "%WHEEL_BUILD_DIR%\pyarrow" || exit /B 1
 
 delvewheel show -vv ^
     --add-path "%WHEEL_BUILD_DIR%\pyarrow";C:\Windows\System32 ^
-    --add-path "%ARROW_HOME%\lib" ^
+    --add-path "%ARROW_HOME%\bin" ^
     %WHEEL_NAME% || exit /B 1
 delvewheel repair -vv ^
     --add-path "%WHEEL_BUILD_DIR%\pyarrow";C:\Windows\System32 ^
-    --add-path "%ARROW_HOME%\lib" ^
+    --add-path "%ARROW_HOME%\bin" ^
     %WHEEL_NAME% -w repaired_wheels || exit /B 1
 
 popd

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -130,7 +130,7 @@ pip install delvewheel || exit /B 1
 for /f %%i in ('dir dist\pyarrow-*.whl /B') do set WHEEL_NAME=dist\%%i || exit /B 1
 echo "Wheel name: %WHEEL_NAME%"
 
-delvewheel show -v --ignore-existing --include msvcp140.dll %WHEEL_NAME% || exit /B 1
-delvewheel repair -v --ignore-existing --include msvcp140.dll %WHEEL_NAME% -w repaired_wheels || exit /B 1
+delvewheel show -vv --ignore-existing --include msvcp140.dll %WHEEL_NAME% || exit /B 1
+delvewheel repair -vv --ignore-existing --include msvcp140.dll %WHEEL_NAME% -w repaired_wheels || exit /B 1
 
 popd

--- a/ci/scripts/python_wheel_windows_test.bat
+++ b/ci/scripts/python_wheel_windows_test.bat
@@ -65,7 +65,7 @@ set PYTHON_CMD=py -%PYTHON%
 %PYTHON_CMD% -c "import pyarrow.substrait" || exit /B 1
 
 @REM Validate wheel contents
-%PYTHON_CMD% C:\arrow\ci\scripts\python_wheel_validate_contents.py --path C:\arrow\python\dist || exit /B 1
+%PYTHON_CMD% C:\arrow\ci\scripts\python_wheel_validate_contents.py --path C:\arrow\python\repaired_wheels || exit /B 1
 
 @rem Download IANA Timezone Database for ORC C++
 curl https://cygwin.osuosl.org/noarch/release/tzdata/tzdata-2024a-1.tar.xz --output tzdata.tar.xz || exit /B

--- a/ci/scripts/python_wheel_windows_test.bat
+++ b/ci/scripts/python_wheel_windows_test.bat
@@ -65,7 +65,7 @@ set PYTHON_CMD=py -%PYTHON%
 %PYTHON_CMD% -c "import pyarrow.substrait" || exit /B 1
 
 @REM Validate wheel contents
-@rem %PYTHON_CMD% C:\arrow\ci\scripts\python_wheel_validate_contents.py --path C:\arrow\python\repaired_wheels || exit /B 1
+%PYTHON_CMD% C:\arrow\ci\scripts\python_wheel_validate_contents.py --path C:\arrow\python\repaired_wheels || exit /B 1
 
 @rem Download IANA Timezone Database for ORC C++
 curl https://cygwin.osuosl.org/noarch/release/tzdata/tzdata-2024a-1.tar.xz --output tzdata.tar.xz || exit /B

--- a/ci/scripts/python_wheel_windows_test.bat
+++ b/ci/scripts/python_wheel_windows_test.bat
@@ -48,7 +48,7 @@ set PYTHON_CMD=py -%PYTHON%
 %PYTHON_CMD% -m pip install -r C:\arrow\python\requirements-wheel-test.txt || exit /B 1
 
 @REM Install the built wheels
-%PYTHON_CMD% -m pip install --no-index --find-links=C:\arrow\python\dist\ pyarrow || exit /B 1
+%PYTHON_CMD% -m pip install --no-index --find-links=C:\arrow\python\repaired_wheels pyarrow || exit /B 1
 
 @REM Test that the modules are importable
 %PYTHON_CMD% -c "import pyarrow" || exit /B 1

--- a/ci/scripts/python_wheel_windows_test.bat
+++ b/ci/scripts/python_wheel_windows_test.bat
@@ -65,7 +65,7 @@ set PYTHON_CMD=py -%PYTHON%
 %PYTHON_CMD% -c "import pyarrow.substrait" || exit /B 1
 
 @REM Validate wheel contents
-%PYTHON_CMD% C:\arrow\ci\scripts\python_wheel_validate_contents.py --path C:\arrow\python\repaired_wheels || exit /B 1
+@rem %PYTHON_CMD% C:\arrow\ci\scripts\python_wheel_validate_contents.py --path C:\arrow\python\repaired_wheels || exit /B 1
 
 @rem Download IANA Timezone Database for ORC C++
 curl https://cygwin.osuosl.org/noarch/release/tzdata/tzdata-2024a-1.tar.xz --output tzdata.tar.xz || exit /B

--- a/dev/tasks/python-wheels/github.windows.yml
+++ b/dev/tasks/python-wheels/github.windows.yml
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: wheel
-          path: arrow/python/dist/*.whl
+          path: arrow/python/repaired_wheels/*.whl
 
       - name: Test wheel
         shell: cmd
@@ -73,7 +73,7 @@ jobs:
 
       {{ macros.github_upload_releases("arrow/python/repaired_wheels/*.whl")|indent }}
       {{ macros.github_upload_gemfury("arrow/python/repaired_wheels/*.whl")|indent }}
-      {{ macros.github_upload_wheel_scientific_python("arrow/repaired_wheels/dist/*.whl")|indent }}
+      {{ macros.github_upload_wheel_scientific_python("arrow/repaired_wheels/repaired_wheels/*.whl")|indent }}
 
       {% if arrow.is_default_branch() %}
       - name: Push Docker Image

--- a/dev/tasks/python-wheels/github.windows.yml
+++ b/dev/tasks/python-wheels/github.windows.yml
@@ -71,9 +71,9 @@ jobs:
           cd arrow
           archery docker run python-wheel-windows-test
 
-      {{ macros.github_upload_releases("arrow/python/dist/*.whl")|indent }}
-      {{ macros.github_upload_gemfury("arrow/python/dist/*.whl")|indent }}
-      {{ macros.github_upload_wheel_scientific_python("arrow/python/dist/*.whl")|indent }}
+      {{ macros.github_upload_releases("arrow/python/repaired_wheels/*.whl")|indent }}
+      {{ macros.github_upload_gemfury("arrow/python/repaired_wheels/*.whl")|indent }}
+      {{ macros.github_upload_wheel_scientific_python("arrow/repaired_wheels/dist/*.whl")|indent }}
 
       {% if arrow.is_default_branch() %}
       - name: Push Docker Image


### PR DESCRIPTION
### Rationale for this change

We need to ship the C++ standard library with our Windows wheels, as it is not guaranteed that a recent enough version is present on the system. However, some other Python libraries may require an even more recent version than the one we ship. This may incur crashes when PyArrow is imported before such other Python library, as the older version of the C++ standard library would be used by both.

### What changes are included in this PR?

Use a [fixed-up version](https://github.com/adang1345/delvewheel/pull/59) of delvewheel that allows us to name-mangle an individual DLL, and name-mangle `msvcp140.dll` to ensure that other Python libraries do not reuse the version we ship.

### Are these changes tested?

By regular wheel build tests.

* Closes: #44855
* GitHub Issue: #33981
* GitHub Issue: #44855