### PR TITLE
GH-35321: [Python][CI] Skip extension type test failing with pandas 2.0.1

### DIFF
--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1296,8 +1296,10 @@ def test_extension_to_pandas_storage_type(registered_period_type):
     assert result["ext"].dtype == pandas_dtype
 
     import pandas as pd
-    if Version(pd.__version__) > Version("2.0.0"):
-
+    if (
+        Version(pd.__version__) > Version("2.0.0") and
+        Version(pd.__version__) != Version("2.0.1")
+    ):
         # Check the usage of types_mapper
         result = table.to_pandas(types_mapper=pd.ArrowDtype)
         assert isinstance(result["ext"].dtype, pd.ArrowDtype)


### PR DESCRIPTION
This test fails presumably because of a regression or change in behaviour in pandas 2.0.1, therefore skipping the test for now.
* Closes: #35321