### PR TITLE
GH-35335: [Python][Docs] Fix docstring of `map_`

### DIFF
--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -2918,8 +2918,8 @@ cpdef MapType map_(key_type, item_type, keys_sorted=False):
 
     Parameters
     ----------
-    key_type : DataType
-    item_type : DataType
+    key_type : DataType or Field
+    item_type : DataType or Field
     keys_sorted : bool
 
     Returns


### PR DESCRIPTION
It also accepts fields, but this isn't mentioned in the docstring

* Closes: #35335