### PR TITLE
GH-35180: [R] Implement bindings for cumsum function

### DIFF
--- a/r/R/arrow-datum.R
+++ b/r/R/arrow-datum.R
@@ -151,7 +151,7 @@ Math.ArrowDatum <- function(x, ..., base = exp(1), digits = 0) {
     gamma = ,
     digamma = ,
     trigamma = ,
-    cumsum = ,
+    cumsum = eval_array_expression("cumulative_sum_checked", x),
     cumprod = ,
     cummax = ,
     cummin = ,

--- a/r/tests/testthat/test-compute-arith.R
+++ b/r/tests/testthat/test-compute-arith.R
@@ -175,12 +175,12 @@ test_that("Math group generics work on Array objects", {
     round(exp(Array$create(c(2L, 1L))), digits = 10),
     Array$create(round(exp(c(2L, 1L)), 10))
   )
-  expect_equal(round(cumsum(Array$create(c(2.3, -1.0, 7.9, NA_real_,1.0))), digits = 10),
+  expect_equal(round(cumsum(Array$create(c(2.3, -1.0, 7.9, NA_real_, 1.0))), digits = 10),
                Array$create(c(2.3, 1.3, 9.2, NA, NA)))
   expect_equal(cumsum(Array$create(-10L)), Array$create(-10L))
   expect_equal(cumsum(Array$create(NA_integer_)), Array$create(NA_integer_))
   expect_equal(
-    cumsum(ChunkedArray$create(c(2L, 7L, 8L), c(-1L, 2L, 17L, NA_integer_,3L), 18L))$as_vector(),
+    cumsum(ChunkedArray$create(c(2L, 7L, 8L), c(-1L, 2L, 17L, NA_integer_, 3L), 18L))$as_vector(),
     c(2L, 9L, 17L, 16L, 18L, 35L, NA_integer_, NA_integer_, NA_integer_)
   )
 

--- a/r/tests/testthat/test-compute-arith.R
+++ b/r/tests/testthat/test-compute-arith.R
@@ -175,12 +175,15 @@ test_that("Math group generics work on Array objects", {
     round(exp(Array$create(c(2L, 1L))), digits = 10),
     Array$create(round(exp(c(2L, 1L)), 10))
   )
-  expect_equal(round(cumsum(Array$create(c(2.3, -1.0, 7.9, NA_real_, 1.0))), digits = 10),
+  expect_equal(round(cumsum(Array$create(c(2.3, -1.0, 7.9, NA_real_, 1.0))),
+                     digits = 10),
                Array$create(c(2.3, 1.3, 9.2, NA, NA)))
   expect_equal(cumsum(Array$create(-10L)), Array$create(-10L))
   expect_equal(cumsum(Array$create(NA_integer_)), Array$create(NA_integer_))
   expect_equal(
-    cumsum(ChunkedArray$create(c(2L, 7L, 8L), c(-1L, 2L, 17L, NA_integer_, 3L), 18L))$as_vector(),
+    cumsum(
+      ChunkedArray$create(c(2L, 7L, 8L), c(-1L, 2L, 17L, NA_integer_, 3L), 18L)
+    )$as_vector(),
     c(2L, 9L, 17L, 16L, 18L, 35L, NA_integer_, NA_integer_, NA_integer_)
   )
 

--- a/r/tests/testthat/test-compute-arith.R
+++ b/r/tests/testthat/test-compute-arith.R
@@ -175,9 +175,17 @@ test_that("Math group generics work on Array objects", {
     round(exp(Array$create(c(2L, 1L))), digits = 10),
     Array$create(round(exp(c(2L, 1L)), 10))
   )
+  expect_equal(round(cumsum(Array$create(c(2.3, -1.0, 7.9, NA_real_,1.0))), digits = 10),
+               Array$create(c(2.3, 1.3, 9.2, NA, NA)))
+  expect_equal(cumsum(Array$create(-10L)), Array$create(-10L))
+  expect_equal(cumsum(Array$create(NA_integer_)), Array$create(NA_integer_))
+  expect_equal(
+    cumsum(ChunkedArray$create(c(2L, 7L, 8L), c(-1L, 2L, 17L, NA_integer_,3L), 18L))$as_vector(),
+    c(2L, 9L, 17L, 16L, 18L, 35L, NA_integer_, NA_integer_, NA_integer_)
+  )
 
   expect_error(
-    cumsum(Array$create(c(4L, 1L))),
+    cumprod(Array$create(c(4L, 1L))),
     "Unsupported operation on `Array`"
   )
 })

--- a/r/tests/testthat/test-compute-arith.R
+++ b/r/tests/testthat/test-compute-arith.R
@@ -175,15 +175,14 @@ test_that("Math group generics work on Array objects", {
     round(exp(Array$create(c(2L, 1L))), digits = 10),
     Array$create(round(exp(c(2L, 1L)), 10))
   )
-  expect_equal(round(cumsum(Array$create(c(2.3, -1.0, 7.9, NA_real_, 1.0))),
-                     digits = 10),
-               Array$create(c(2.3, 1.3, 9.2, NA, NA)))
+  expect_as_vector(
+    cumsum(Array$create(c(2.3, -1.0, 7.9, NA_real_, 1.0))),
+    c(2.3, 1.3, 9.2, NA_real_, NA_real_)
+  )
   expect_equal(cumsum(Array$create(-10L)), Array$create(-10L))
   expect_equal(cumsum(Array$create(NA_integer_)), Array$create(NA_integer_))
-  expect_equal(
-    cumsum(
-      ChunkedArray$create(c(2L, 7L, 8L), c(-1L, 2L, 17L, NA_integer_, 3L), 18L)
-    )$as_vector(),
+  expect_as_vector(
+    cumsum(ChunkedArray$create(c(2L, 7L, 8L), c(-1L, 2L, 17L, NA_integer_, 3L), 18L)),
     c(2L, 9L, 17L, 16L, 18L, 35L, NA_integer_, NA_integer_, NA_integer_)
   )
 


### PR DESCRIPTION
Fixes #35180 
Can't do the binding to dplyr, as dplyr takes Scalar Expressions and cumsum ( #12460 ) isn't a scalar expression.
* Closes: #35180