### PR TITLE
MINOR: [C++] Add missing RunEndEncodedType dtor

### DIFF
--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -799,6 +799,8 @@ RunEndEncodedType::RunEndEncodedType(std::shared_ptr<DataType> run_end_type,
                std::make_shared<Field>("values", std::move(value_type), true)};
 }
 
+RunEndEncodedType::~RunEndEncodedType() = default;
+
 std::string RunEndEncodedType::ToString() const {
   std::stringstream s;
   s << name() << "<run_ends: " << run_end_type()->ToString()

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1232,6 +1232,7 @@ class ARROW_EXPORT RunEndEncodedType : public NestedType {
 
   explicit RunEndEncodedType(std::shared_ptr<DataType> run_end_type,
                              std::shared_ptr<DataType> value_type);
+  ~RunEndEncodedType() override;
 
   DataTypeLayout layout() const override {
     // A lot of existing code expects at least one buffer


### PR DESCRIPTION
### Rationale for this change

Avoid problems with LTO compilation (see commit 24da3be9560c5)

### What changes are included in this PR?

Definition of a virtual dtor for RunEndEncodedType.

### Are these changes tested?

N/A.