### PR TITLE
GH-35346: [CI][Python] Move gdb from env-file to dockerfile

### DIFF
--- a/ci/conda_env_unix.txt
+++ b/ci/conda_env_unix.txt
@@ -19,6 +19,5 @@
 
 autoconf
 ccache
-gdb
 orc
 pkg-config

--- a/ci/docker/conda-python.dockerfile
+++ b/ci/docker/conda-python.dockerfile
@@ -27,6 +27,7 @@ COPY ci/conda_env_python.txt \
 RUN mamba install -q -y \
         --file arrow/ci/conda_env_python.txt \
         --file arrow/ci/conda_env_sphinx.txt \
+        gdb \
         $([ "$python" == "3.7" ] && echo "pickle5") \
         python=${python} \
         nomkl && \


### PR DESCRIPTION
### Rationale for this change
Similar to the issue with windows in https://github.com/apache/arrow/pull/35057 gdb is also not available for arm64, causing benchmarks to fail.

This moves gdb into the dockerfile that actually needs it to prevent further changes. An alternative would be to use multi-arch-gdb but that is only available in `-c memfault` and adding on an entire new channel will only increase solve times and potentially cause problems.

* Closes: #35346