### PR TITLE
GH-35352: [Java] Fix issues with "semi complex" types.

### DIFF
--- a/java/vector/src/main/codegen/templates/ComplexWriters.java
+++ b/java/vector/src/main/codegen/templates/ComplexWriters.java
@@ -32,6 +32,10 @@ package org.apache.arrow.vector.complex.impl;
 
 <#include "/@includes/vv_imports.ftl" />
 
+<#function is_timestamp_tz type>
+  <#return type?starts_with("TimeStamp") && type?ends_with("TZ")>
+</#function>
+
 /*
  * This class is generated using FreeMarker on the ${.template_name} template.
  */
@@ -191,7 +195,15 @@ package org.apache.arrow.vector.complex.writer;
 public interface ${eName}Writer extends BaseWriter {
   public void write(${minor.class}Holder h);
 
-  <#if minor.class?starts_with("Decimal")>@Deprecated</#if>
+<#if minor.class?starts_with("Decimal") || is_timestamp_tz(minor.class) || minor.class == "Duration" || minor.class == "FixedSizeBinary">
+  /**
+   * @deprecated
+   * The holder version should be used instead because the plain value version does not contain enough information
+   * to fully specify this field type.
+   * @see #write(${minor.class}Holder)
+   */
+  @Deprecated
+</#if>
   public void write${minor.class}(<#list fields as field>${field.type} ${field.name}<#if field_has_next>, </#if></#list>);
 <#if minor.class?starts_with("Decimal")>
 
@@ -201,6 +213,13 @@ public interface ${eName}Writer extends BaseWriter {
 
   public void writeBigEndianBytesTo${minor.class}(byte[] value, ArrowType arrowType);
 
+  /**
+   * @deprecated
+   * Use either the version that additionally takes in an ArrowType or use the holder version.
+   * This version does not contain enough information to fully specify this field type.
+   * @see #writeBigEndianBytesTo${minor.class}(byte[], ArrowType)
+   * @see #write(${minor.class}Holder)
+   */
   @Deprecated
   public void writeBigEndianBytesTo${minor.class}(byte[] value);
 </#if>

--- a/java/vector/src/main/codegen/templates/UnionReader.java
+++ b/java/vector/src/main/codegen/templates/UnionReader.java
@@ -28,6 +28,11 @@ import org.apache.arrow.vector.types.pojo.Field;
 package org.apache.arrow.vector.complex.impl;
 
 <#include "/@includes/vv_imports.ftl" />
+
+<#function is_timestamp_tz type>
+  <#return type?starts_with("TimeStamp") && type?ends_with("TZ")>
+</#function>
+
 /**
  * Source code generated using FreeMarker template ${.template_name}
  */
@@ -90,7 +95,7 @@ public class UnionReader extends AbstractFieldReader {
       <#list type.minor as minor>
         <#assign name = minor.class?cap_first />
         <#assign uncappedName = name?uncap_first/>
-        <#if !minor.typeParams?? || minor.class?starts_with("Decimal")>
+        <#if !minor.typeParams?? || minor.class?starts_with("Decimal") || is_timestamp_tz(minor.class) || minor.class == "Duration" || minor.class == "FixedSizeBinary">
     case ${name?upper_case}:
       return (FieldReader) get${name}();
         </#if>
@@ -170,7 +175,7 @@ public class UnionReader extends AbstractFieldReader {
       <#assign friendlyType = (minor.friendlyType!minor.boxedType!type.boxedType) />
       <#assign safeType=friendlyType />
       <#if safeType=="byte[]"><#assign safeType="ByteArray" /></#if>
-      <#if !minor.typeParams?? || minor.class?starts_with("Decimal") >
+      <#if !minor.typeParams?? || minor.class?starts_with("Decimal") || is_timestamp_tz(minor.class) || minor.class == "Duration" || minor.class == "FixedSizeBinary">
 
   private ${name}ReaderImpl ${uncappedName}Reader;
 

--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -67,7 +67,9 @@ import static org.apache.arrow.vector.types.UnionMode.Sparse;
 import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
 import static org.apache.arrow.memory.util.LargeMemoryUtil.capAtMaxInt;
 
-
+<#function is_timestamp_tz type>
+  <#return type?starts_with("TimeStamp") && type?ends_with("TZ")>
+</#function>
 
 /*
  * This class is generated using freemarker and the ${.template_name} template.
@@ -269,18 +271,24 @@ public class UnionVector extends AbstractContainerVector implements FieldVector 
       <#assign fields = minor.fields!type.fields />
       <#assign uncappedName = name?uncap_first/>
       <#assign lowerCaseName = name?lower_case/>
-      <#if !minor.typeParams?? || minor.class?starts_with("Decimal") >
+      <#if !minor.typeParams?? || minor.class?starts_with("Decimal") || is_timestamp_tz(minor.class) || minor.class == "Duration" || minor.class == "FixedSizeBinary">
 
   private ${name}Vector ${uncappedName}Vector;
 
-  public ${name}Vector get${name}Vector(<#if minor.class?starts_with("Decimal")> ArrowType arrowType</#if>) {
-    return get${name}Vector(null<#if minor.class?starts_with("Decimal")>, arrowType</#if>);
+  <#if minor.class?starts_with("Decimal") || is_timestamp_tz(minor.class) || minor.class == "Duration" || minor.class == "FixedSizeBinary">
+  public ${name}Vector get${name}Vector() {
+    if (${uncappedName}Vector == null) {
+      throw new IllegalArgumentException("No ${name} present. Provide ArrowType argument to create a new vector");
+    }
+    return ${uncappedName}Vector;
   }
-
-  public ${name}Vector get${name}Vector(String name<#if minor.class?starts_with("Decimal")>, ArrowType arrowType</#if>) {
+  public ${name}Vector get${name}Vector(ArrowType arrowType) {
+    return get${name}Vector(null, arrowType);
+  }
+  public ${name}Vector get${name}Vector(String name, ArrowType arrowType) {
     if (${uncappedName}Vector == null) {
       int vectorCount = internalStruct.size();
-      ${uncappedName}Vector = addOrGet(name, MinorType.${name?upper_case},<#if minor.class?starts_with("Decimal")> arrowType,</#if> ${name}Vector.class);
+      ${uncappedName}Vector = addOrGet(name, MinorType.${name?upper_case}, arrowType, ${name}Vector.class);
       if (internalStruct.size() > vectorCount) {
         ${uncappedName}Vector.allocateNew();
         if (callBack != null) {
@@ -290,10 +298,21 @@ public class UnionVector extends AbstractContainerVector implements FieldVector 
     }
     return ${uncappedName}Vector;
   }
-  <#if minor.class?starts_with("Decimal")>
+  <#else>
   public ${name}Vector get${name}Vector() {
+    return get${name}Vector(null);
+  }
+
+  public ${name}Vector get${name}Vector(String name) {
     if (${uncappedName}Vector == null) {
-      throw new IllegalArgumentException("No ${uncappedName} present. Provide ArrowType argument to create a new vector");
+      int vectorCount = internalStruct.size();
+      ${uncappedName}Vector = addOrGet(name, MinorType.${name?upper_case}, ${name}Vector.class);
+      if (internalStruct.size() > vectorCount) {
+        ${uncappedName}Vector.allocateNew();
+        if (callBack != null) {
+          callBack.doWork();
+        }
+      }
     }
     return ${uncappedName}Vector;
   }
@@ -658,9 +677,9 @@ public class UnionVector extends AbstractContainerVector implements FieldVector 
           <#assign name = minor.class?cap_first />
           <#assign fields = minor.fields!type.fields />
           <#assign uncappedName = name?uncap_first/>
-          <#if !minor.typeParams?? || minor.class?starts_with("Decimal") >
+          <#if !minor.typeParams?? || minor.class?starts_with("Decimal") || is_timestamp_tz(minor.class) || minor.class == "Duration" || minor.class == "FixedSizeBinary">
         case ${name?upper_case}:
-        return get${name}Vector(name<#if minor.class?starts_with("Decimal")>, arrowType</#if>);
+        return get${name}Vector(name<#if minor.class?starts_with("Decimal") || is_timestamp_tz(minor.class) || minor.class == "Duration" || minor.class == "FixedSizeBinary">, arrowType</#if>);
           </#if>
         </#list>
       </#list>
@@ -745,11 +764,15 @@ public class UnionVector extends AbstractContainerVector implements FieldVector 
           <#assign name = minor.class?cap_first />
           <#assign fields = minor.fields!type.fields />
           <#assign uncappedName = name?uncap_first/>
-          <#if !minor.typeParams?? || minor.class?starts_with("Decimal") >
+          <#if !minor.typeParams?? || minor.class?starts_with("Decimal") || is_timestamp_tz(minor.class) || minor.class == "Duration" || minor.class == "FixedSizeBinary">
       case ${name?upper_case}:
         Nullable${name}Holder ${uncappedName}Holder = new Nullable${name}Holder();
         reader.read(${uncappedName}Holder);
-        setSafe(index, ${uncappedName}Holder<#if minor.class?starts_with("Decimal")>, arrowType</#if>);
+        <#if minor.class?starts_with("Decimal") || is_timestamp_tz(minor.class) || minor.class == "Duration" || minor.class == "FixedSizeBinary">
+        setSafe(index, ${uncappedName}Holder, arrowType);
+        <#else>
+        setSafe(index, ${uncappedName}Holder);
+        </#if>
         break;
           </#if>
         </#list>
@@ -766,17 +789,24 @@ public class UnionVector extends AbstractContainerVector implements FieldVector 
         throw new UnsupportedOperationException();
       }
     }
+
     <#list vv.types as type>
       <#list type.minor as minor>
         <#assign name = minor.class?cap_first />
         <#assign fields = minor.fields!type.fields />
         <#assign uncappedName = name?uncap_first/>
-        <#if !minor.typeParams?? || minor.class?starts_with("Decimal") >
-    public void setSafe(int index, Nullable${name}Holder holder<#if minor.class?starts_with("Decimal")>, ArrowType arrowType</#if>) {
+        <#if !minor.typeParams?? || minor.class?starts_with("Decimal") || is_timestamp_tz(minor.class) || minor.class == "Duration" || minor.class == "FixedSizeBinary">
+    <#if minor.class?starts_with("Decimal") || is_timestamp_tz(minor.class) || minor.class == "Duration" || minor.class == "FixedSizeBinary">
+    public void setSafe(int index, Nullable${name}Holder holder, ArrowType arrowType) {
       setType(index, MinorType.${name?upper_case});
-      get${name}Vector(null<#if minor.class?starts_with("Decimal")>, arrowType</#if>).setSafe(index, holder);
+      get${name}Vector(null, arrowType).setSafe(index, holder);
     }
-
+    <#else>
+    public void setSafe(int index, Nullable${name}Holder holder) {
+      setType(index, MinorType.${name?upper_case});
+      get${name}Vector(null).setSafe(index, holder);
+    }
+    </#if>
         </#if>
       </#list>
     </#list>

--- a/java/vector/src/main/java/org/apache/arrow/vector/DurationVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/DurationVector.java
@@ -141,6 +141,7 @@ public final class DurationVector extends BaseFixedWidthVector {
     }
     holder.isSet = 1;
     holder.value = get(valueBuffer, index);
+    holder.unit = this.unit;
   }
 
   /**
@@ -241,6 +242,9 @@ public final class DurationVector extends BaseFixedWidthVector {
   public void set(int index, NullableDurationHolder holder) throws IllegalArgumentException {
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
+    } else if (!this.unit.equals(holder.unit)) {
+      throw new IllegalArgumentException(
+          String.format("holder.unit: %s not equal to vector unit: %s", holder.unit, this.unit));
     } else if (holder.isSet > 0) {
       set(index, holder.value);
     } else {
@@ -255,6 +259,10 @@ public final class DurationVector extends BaseFixedWidthVector {
    * @param holder  data holder for value of element
    */
   public void set(int index, DurationHolder holder) {
+    if (!this.unit.equals(holder.unit)) {
+      throw new IllegalArgumentException(
+          String.format("holder.unit: %s not equal to vector unit: %s", holder.unit, this.unit));
+    }
     set(index, holder.value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/FixedSizeBinaryVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/FixedSizeBinaryVector.java
@@ -138,6 +138,7 @@ public class FixedSizeBinaryVector extends BaseFixedWidthVector {
     }
     holder.isSet = 1;
     holder.buffer = valueBuffer.slice((long) index * byteWidth, byteWidth);
+    holder.byteWidth = byteWidth;
   }
 
   /**
@@ -257,7 +258,10 @@ public class FixedSizeBinaryVector extends BaseFixedWidthVector {
    * @param holder  holder that carries data buffer.
    */
   public void set(int index, FixedSizeBinaryHolder holder) {
-    assert holder.byteWidth == byteWidth;
+    if (this.byteWidth != holder.byteWidth) {
+      throw new IllegalArgumentException(
+          String.format("holder.byteWidth: %d not equal to vector byteWidth: %d", holder.byteWidth, this.byteWidth));
+    }
     set(index, holder.buffer);
   }
 
@@ -282,9 +286,11 @@ public class FixedSizeBinaryVector extends BaseFixedWidthVector {
    * @param holder  holder that carries data buffer.
    */
   public void set(int index, NullableFixedSizeBinaryHolder holder) {
-    assert holder.byteWidth == byteWidth;
     if (holder.isSet < 0) {
       throw new IllegalArgumentException("holder has a negative isSet value");
+    } else if (this.byteWidth != holder.byteWidth) {
+      throw new IllegalArgumentException(
+          String.format("holder.byteWidth: %d not equal to vector byteWidth: %d", holder.byteWidth, this.byteWidth));
     } else if (holder.isSet > 0) {
       set(index, holder.buffer);
     } else {

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMicroTZVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMicroTZVector.java
@@ -132,6 +132,7 @@ public final class TimeStampMicroTZVector extends TimeStampVector {
     }
     holder.isSet = 1;
     holder.value = valueBuffer.getLong((long) index * TYPE_WIDTH);
+    holder.timezone = timeZone;
   }
 
   /**
@@ -167,6 +168,9 @@ public final class TimeStampMicroTZVector extends TimeStampVector {
   public void set(int index, NullableTimeStampMicroTZHolder holder) throws IllegalArgumentException {
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
+    } else if (!this.timeZone.equals(holder.timezone)) {
+      throw new IllegalArgumentException(
+          String.format("holder.timezone: %s not equal to vector timezone: %s", holder.timezone, this.timeZone));
     } else if (holder.isSet > 0) {
       BitVectorHelper.setBit(validityBuffer, index);
       setValue(index, holder.value);
@@ -182,6 +186,10 @@ public final class TimeStampMicroTZVector extends TimeStampVector {
    * @param holder  data holder for value of element
    */
   public void set(int index, TimeStampMicroTZHolder holder) {
+    if (!this.timeZone.equals(holder.timezone)) {
+      throw new IllegalArgumentException(
+          String.format("holder.timezone: %s not equal to vector timezone: %s", holder.timezone, this.timeZone));
+    }
     BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, holder.value);
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMilliTZVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMilliTZVector.java
@@ -132,6 +132,7 @@ public final class TimeStampMilliTZVector extends TimeStampVector {
     }
     holder.isSet = 1;
     holder.value = valueBuffer.getLong((long) index * TYPE_WIDTH);
+    holder.timezone = timeZone;
   }
 
   /**
@@ -167,6 +168,9 @@ public final class TimeStampMilliTZVector extends TimeStampVector {
   public void set(int index, NullableTimeStampMilliTZHolder holder) throws IllegalArgumentException {
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
+    } else if (!this.timeZone.equals(holder.timezone)) {
+      throw new IllegalArgumentException(
+          String.format("holder.timezone: %s not equal to vector timezone: %s", holder.timezone, this.timeZone));
     } else if (holder.isSet > 0) {
       BitVectorHelper.setBit(validityBuffer, index);
       setValue(index, holder.value);
@@ -182,6 +186,10 @@ public final class TimeStampMilliTZVector extends TimeStampVector {
    * @param holder  data holder for value of element
    */
   public void set(int index, TimeStampMilliTZHolder holder) {
+    if (!this.timeZone.equals(holder.timezone)) {
+      throw new IllegalArgumentException(
+          String.format("holder.timezone: %s not equal to vector timezone: %s", holder.timezone, this.timeZone));
+    }
     BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, holder.value);
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampNanoTZVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampNanoTZVector.java
@@ -132,6 +132,7 @@ public final class TimeStampNanoTZVector extends TimeStampVector {
     }
     holder.isSet = 1;
     holder.value = valueBuffer.getLong((long) index * TYPE_WIDTH);
+    holder.timezone = timeZone;
   }
 
   /**
@@ -167,6 +168,9 @@ public final class TimeStampNanoTZVector extends TimeStampVector {
   public void set(int index, NullableTimeStampNanoTZHolder holder) throws IllegalArgumentException {
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
+    } else if (!this.timeZone.equals(holder.timezone)) {
+      throw new IllegalArgumentException(
+          String.format("holder.timezone: %s not equal to vector timezone: %s", holder.timezone, this.timeZone));
     } else if (holder.isSet > 0) {
       BitVectorHelper.setBit(validityBuffer, index);
       setValue(index, holder.value);
@@ -182,6 +186,10 @@ public final class TimeStampNanoTZVector extends TimeStampVector {
    * @param holder  data holder for value of element
    */
   public void set(int index, TimeStampNanoTZHolder holder) {
+    if (!this.timeZone.equals(holder.timezone)) {
+      throw new IllegalArgumentException(
+          String.format("holder.timezone: %s not equal to vector timezone: %s", holder.timezone, this.timeZone));
+    }
     BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, holder.value);
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampSecTZVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampSecTZVector.java
@@ -132,6 +132,7 @@ public final class TimeStampSecTZVector extends TimeStampVector {
     }
     holder.isSet = 1;
     holder.value = valueBuffer.getLong((long) index * TYPE_WIDTH);
+    holder.timezone = timeZone;
   }
 
   /**
@@ -167,6 +168,9 @@ public final class TimeStampSecTZVector extends TimeStampVector {
   public void set(int index, NullableTimeStampSecTZHolder holder) throws IllegalArgumentException {
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
+    } else if (!this.timeZone.equals(holder.timezone)) {
+      throw new IllegalArgumentException(
+          String.format("holder.timezone: %s not equal to vector timezone: %s", holder.timezone, this.timeZone));
     } else if (holder.isSet > 0) {
       BitVectorHelper.setBit(validityBuffer, index);
       setValue(index, holder.value);
@@ -182,6 +186,10 @@ public final class TimeStampSecTZVector extends TimeStampVector {
    * @param holder  data holder for value of element
    */
   public void set(int index, TimeStampSecTZHolder holder) {
+    if (!this.timeZone.equals(holder.timezone)) {
+      throw new IllegalArgumentException(
+          String.format("holder.timezone: %s not equal to vector timezone: %s", holder.timezone, this.timeZone));
+    }
     BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, holder.value);
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/PromotableWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/PromotableWriter.java
@@ -247,10 +247,18 @@ public class PromotableWriter extends AbstractPromotableFieldWriter {
     }
   }
 
+  private boolean requiresArrowType(MinorType type) {
+    return type == MinorType.DECIMAL ||
+        type == MinorType.MAP ||
+        type == MinorType.DURATION ||
+        type == MinorType.FIXEDSIZEBINARY ||
+        (type.name().startsWith("TIMESTAMP") && type.name().endsWith("TZ"));
+  }
+
   @Override
   protected FieldWriter getWriter(MinorType type, ArrowType arrowType) {
     if (state == State.UNION) {
-      if (type == MinorType.DECIMAL || type == MinorType.MAP) {
+      if (requiresArrowType(type)) {
         ((UnionWriter) writer).getWriter(type, arrowType);
       } else {
         ((UnionWriter) writer).getWriter(type);
@@ -277,7 +285,7 @@ public class PromotableWriter extends AbstractPromotableFieldWriter {
       writer.setPosition(position);
     } else if (type != this.type) {
       promoteToUnion();
-      if (type == MinorType.DECIMAL || type == MinorType.MAP) {
+      if (requiresArrowType(type)) {
         ((UnionWriter) writer).getWriter(type, arrowType);
       } else {
         ((UnionWriter) writer).getWriter(type);

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestFixedSizeBinaryVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestFixedSizeBinaryVector.java
@@ -207,25 +207,25 @@ public class TestFixedSizeBinaryVector {
     try {
       vector.set(0, smallValue);
       failWithException(errorMsg);
-    } catch (AssertionError ignore) {
+    } catch (AssertionError | IllegalArgumentException ignore) {
     }
 
     try {
       vector.set(0, smallHolder);
       failWithException(errorMsg);
-    } catch (AssertionError ignore) {
+    } catch (AssertionError | IllegalArgumentException ignore) {
     }
 
     try {
       vector.set(0, smallNullableHolder);
       failWithException(errorMsg);
-    } catch (AssertionError ignore) {
+    } catch (AssertionError | IllegalArgumentException ignore) {
     }
 
     try {
       vector.set(0, smallBuf);
       failWithException(errorMsg);
-    } catch (AssertionError ignore) {
+    } catch (AssertionError | IllegalArgumentException ignore) {
     }
 
     // test large inputs, byteWidth matches but value or buffer is bigger than byteWidth
@@ -243,25 +243,25 @@ public class TestFixedSizeBinaryVector {
     try {
       vector.setSafe(0, smallValue);
       failWithException(errorMsg);
-    } catch (AssertionError ignore) {
+    } catch (AssertionError | IllegalArgumentException ignore) {
     }
 
     try {
       vector.setSafe(0, smallHolder);
       failWithException(errorMsg);
-    } catch (AssertionError ignore) {
+    } catch (AssertionError | IllegalArgumentException ignore) {
     }
 
     try {
       vector.setSafe(0, smallNullableHolder);
       failWithException(errorMsg);
-    } catch (AssertionError ignore) {
+    } catch (AssertionError | IllegalArgumentException ignore) {
     }
 
     try {
       vector.setSafe(0, smallBuf);
       failWithException(errorMsg);
-    } catch (AssertionError ignore) {
+    } catch (AssertionError | IllegalArgumentException ignore) {
     }
 
     // test large inputs, byteWidth matches but value or buffer is bigger than byteWidth

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestUnionVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestUnionVector.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -494,6 +495,28 @@ public class TestUnionVector {
       srcVector.setSafe(0, holder);
 
       assertNull(srcVector.getObject(0));
+    }
+  }
+
+  @Test
+  public void testCreateNewVectorWithoutTypeExceptionThrown() {
+    try (UnionVector vector =
+        new UnionVector(EMPTY_SCHEMA_PATH, allocator, /* field type */ null, /* call-back */ null)) {
+      IllegalArgumentException e1 = assertThrows(IllegalArgumentException.class,
+          () -> vector.getTimeStampMilliTZVector());
+      assertEquals("No TimeStampMilliTZ present. Provide ArrowType argument to create a new vector", e1.getMessage());
+
+      IllegalArgumentException e2 = assertThrows(IllegalArgumentException.class,
+          () -> vector.getDurationVector());
+      assertEquals("No Duration present. Provide ArrowType argument to create a new vector", e2.getMessage());
+
+      IllegalArgumentException e3 = assertThrows(IllegalArgumentException.class,
+          () -> vector.getFixedSizeBinaryVector());
+      assertEquals("No FixedSizeBinary present. Provide ArrowType argument to create a new vector", e3.getMessage());
+
+      IllegalArgumentException e4 = assertThrows(IllegalArgumentException.class,
+          () -> vector.getDecimalVector());
+      assertEquals("No Decimal present. Provide ArrowType argument to create a new vector", e4.getMessage());
     }
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/complex/writer/TestComplexWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/complex/writer/TestComplexWriter.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -61,8 +62,15 @@ import org.apache.arrow.vector.complex.writer.BaseWriter.ListWriter;
 import org.apache.arrow.vector.complex.writer.BaseWriter.MapWriter;
 import org.apache.arrow.vector.complex.writer.BaseWriter.StructWriter;
 import org.apache.arrow.vector.holders.DecimalHolder;
+import org.apache.arrow.vector.holders.DurationHolder;
+import org.apache.arrow.vector.holders.FixedSizeBinaryHolder;
 import org.apache.arrow.vector.holders.IntHolder;
+import org.apache.arrow.vector.holders.NullableDurationHolder;
+import org.apache.arrow.vector.holders.NullableFixedSizeBinaryHolder;
+import org.apache.arrow.vector.holders.NullableTimeStampMilliTZHolder;
 import org.apache.arrow.vector.holders.NullableTimeStampNanoTZHolder;
+import org.apache.arrow.vector.holders.TimeStampMilliTZHolder;
+import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.ArrowType.ArrowTypeID;
 import org.apache.arrow.vector.types.pojo.ArrowType.Int;
@@ -355,6 +363,125 @@ public class TestComplexWriter {
   }
 
   @Test
+  public void listTimeStampMilliTZType() {
+    try (ListVector listVector = ListVector.empty("list", allocator)) {
+      listVector.allocateNew();
+      UnionListWriter listWriter = new UnionListWriter(listVector);
+      for (int i = 0; i < COUNT; i++) {
+        listWriter.startList();
+        for (int j = 0; j < i % 7; j++) {
+          if (j % 2 == 0) {
+            listWriter.writeNull();
+          } else {
+            TimeStampMilliTZHolder holder = new TimeStampMilliTZHolder();
+            holder.timezone = "FakeTimeZone";
+            holder.value = j;
+            listWriter.timeStampMilliTZ().write(holder);
+          }
+        }
+        listWriter.endList();
+      }
+      listWriter.setValueCount(COUNT);
+      UnionListReader listReader = new UnionListReader(listVector);
+      for (int i = 0; i < COUNT; i++) {
+        listReader.setPosition(i);
+        for (int j = 0; j < i % 7; j++) {
+          listReader.next();
+          if (j % 2 == 0) {
+            assertFalse("index is set: " + j, listReader.reader().isSet());
+          } else {
+            NullableTimeStampMilliTZHolder actual = new NullableTimeStampMilliTZHolder();
+            listReader.reader().read(actual);
+            assertEquals(j, actual.value);
+            assertEquals("FakeTimeZone", actual.timezone);
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  public void listDurationType() {
+    try (ListVector listVector = ListVector.empty("list", allocator)) {
+      listVector.allocateNew();
+      UnionListWriter listWriter = new UnionListWriter(listVector);
+      for (int i = 0; i < COUNT; i++) {
+        listWriter.startList();
+        for (int j = 0; j < i % 7; j++) {
+          if (j % 2 == 0) {
+            listWriter.writeNull();
+          } else {
+            DurationHolder holder = new DurationHolder();
+            holder.unit = TimeUnit.MICROSECOND;
+            holder.value = j;
+            listWriter.duration().write(holder);
+          }
+        }
+        listWriter.endList();
+      }
+      listWriter.setValueCount(COUNT);
+      UnionListReader listReader = new UnionListReader(listVector);
+      for (int i = 0; i < COUNT; i++) {
+        listReader.setPosition(i);
+        for (int j = 0; j < i % 7; j++) {
+          listReader.next();
+          if (j % 2 == 0) {
+            assertFalse("index is set: " + j, listReader.reader().isSet());
+          } else {
+            NullableDurationHolder actual = new NullableDurationHolder();
+            listReader.reader().read(actual);
+            assertEquals(TimeUnit.MICROSECOND, actual.unit);
+            assertEquals(j, actual.value);
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  public void listFixedSizeBinaryType() throws Exception {
+    List<ArrowBuf> bufs = new ArrayList<ArrowBuf>();
+    try (ListVector listVector = ListVector.empty("list", allocator)) {
+      listVector.allocateNew();
+      UnionListWriter listWriter = new UnionListWriter(listVector);
+      for (int i = 0; i < COUNT; i++) {
+        listWriter.startList();
+        for (int j = 0; j < i % 7; j++) {
+          if (j % 2 == 0) {
+            listWriter.writeNull();
+          } else {
+            ArrowBuf buf = allocator.buffer(4);
+            buf.setInt(0, j);
+            FixedSizeBinaryHolder holder = new FixedSizeBinaryHolder();
+            holder.byteWidth = 4;
+            holder.buffer = buf;
+            listWriter.fixedSizeBinary().write(holder);
+            bufs.add(buf);
+          }
+        }
+        listWriter.endList();
+      }
+      listWriter.setValueCount(COUNT);
+      UnionListReader listReader = new UnionListReader(listVector);
+      for (int i = 0; i < COUNT; i++) {
+        listReader.setPosition(i);
+        for (int j = 0; j < i % 7; j++) {
+          listReader.next();
+          if (j % 2 == 0) {
+            assertFalse("index is set: " + j, listReader.reader().isSet());
+          } else {
+            NullableFixedSizeBinaryHolder actual = new NullableFixedSizeBinaryHolder();
+            listReader.reader().read(actual);
+            assertEquals(j, actual.buffer.getInt(0));
+            assertEquals(4, actual.byteWidth);
+          }
+        }
+      }
+    }
+    AutoCloseables.close(bufs);
+  }
+
+  @Test
   public void listScalarTypeNullable() {
     try (ListVector listVector = ListVector.empty("list", allocator)) {
       listVector.allocateNew();
@@ -605,14 +732,33 @@ public class TestComplexWriter {
   }
 
   @Test
-  public void simpleUnion() {
+  public void simpleUnion() throws Exception {
+    List<ArrowBuf> bufs = new ArrayList<ArrowBuf>();
     UnionVector vector = new UnionVector("union", allocator, /* field type */ null, /* call-back */ null);
     UnionWriter unionWriter = new UnionWriter(vector);
     unionWriter.allocate();
     for (int i = 0; i < COUNT; i++) {
       unionWriter.setPosition(i);
-      if (i % 2 == 0) {
+      if (i % 5 == 0) {
         unionWriter.writeInt(i);
+      } else if (i % 5 == 1) {
+        TimeStampMilliTZHolder holder = new TimeStampMilliTZHolder();
+        holder.value = (long) i;
+        holder.timezone = "AsdfTimeZone";
+        unionWriter.write(holder);
+      } else if (i % 5 == 2) {
+        DurationHolder holder = new DurationHolder();
+        holder.value = (long) i;
+        holder.unit = TimeUnit.NANOSECOND;
+        unionWriter.write(holder);
+      } else if (i % 5 == 3) {
+        FixedSizeBinaryHolder holder = new FixedSizeBinaryHolder();
+        ArrowBuf buf = allocator.buffer(4);
+        buf.setInt(0, i);
+        holder.byteWidth = 4;
+        holder.buffer = buf;
+        unionWriter.write(holder);
+        bufs.add(buf);
       } else {
         unionWriter.writeFloat4((float) i);
       }
@@ -621,13 +767,29 @@ public class TestComplexWriter {
     UnionReader unionReader = new UnionReader(vector);
     for (int i = 0; i < COUNT; i++) {
       unionReader.setPosition(i);
-      if (i % 2 == 0) {
+      if (i % 5 == 0) {
         Assert.assertEquals(i, i, unionReader.readInteger());
+      } else if (i % 5 == 1) {
+        NullableTimeStampMilliTZHolder holder = new NullableTimeStampMilliTZHolder();
+        unionReader.read(holder);
+        Assert.assertEquals(i, holder.value);
+        Assert.assertEquals("AsdfTimeZone", holder.timezone);
+      } else if (i % 5 == 2) {
+        NullableDurationHolder holder = new NullableDurationHolder();
+        unionReader.read(holder);
+        Assert.assertEquals(i, holder.value);
+        Assert.assertEquals(TimeUnit.NANOSECOND, holder.unit);
+      } else if (i % 5 == 3) {
+        NullableFixedSizeBinaryHolder holder = new NullableFixedSizeBinaryHolder();
+        unionReader.read(holder);
+        assertEquals(i, holder.buffer.getInt(0));
+        assertEquals(4, holder.byteWidth);
       } else {
         Assert.assertEquals((float) i, unionReader.readFloat(), 1e-12);
       }
     }
     vector.close();
+    AutoCloseables.close(bufs);
   }
 
   @Test


### PR DESCRIPTION
### Rationale for this change

"semi complex" types like `TimeStamp*TZ`, `Duration`, and `FixedSizeBinary`
were missing implementations in `UnionListWriter`, `UnionVector`,
`UnionReader` and other associated classes.

This patch adds these missing methods so that these types can now be
written to things like `ListVector`s, whereas before it would throw an
exception because the methods were just not implemented.

For example, without this patch, one of the new tests added would fail:
```
    TestListVector.testWriterGetTimestampMilliTZField:913 ? IllegalArgument You tried to write a TimeStampMilliTZ type when you are using a ValueWriter of type UnionListWriter.
```

There are also fixes for get and set methods for holders for the respective
`*Vector`s classes for these types:
  - The get methods did not set fields like `TimeStampMilliTZHolder.timezone`,
    `DurationHolder.unit`, `FixedSizeBinaryHolder.byteWidth`.

  - The set methods did not all validate that those fields matched what
    the vector's `ArrowType` was set to. For example `TimeStampMilliTZHolder.timezone` should
    match `ArrowType.Timestamp.timezone` on the vector and should throw if it doesn't.
    Otherwise users would never get a signal that there is anything wrong with their code writing
    these holders with mismatching values.

This patch additionally marks some of the existing interfaces for writing these
"semi complex" types as deprecated, because they do not actually provide enough
context to properly write these parameterized `ArrowTypes`. Instead, users should
use the write methods that take `*Holders` that do provide enough context for the
writers to properly write these types. Also note that the equivalent write
methods for `Decimal` have already also been marked as deprecated, for the same
reasoning.

### What changes are included in this PR?

- Various template changes. See this gist for a diff of the generated files: https://gist.github.com/henrymai/03b0f5a4165cd9822aa797c89bbd74e9
   - Note that the diff for the ComplexWriter.java generated ones is not included since that change is easy to see from just the template.

- Additional tests to verify that this is fixed.

### Are these changes tested?

Yes, added unit tests and they pass.

### Are there any user-facing changes?

Yes, users will now be able to write to types like TimeStamp*TZ, Duration, and FixedSizeBinary on ListVector, MapVector, StructVector due to added implementations for these types on UnionListVector, UnionWriter.

This also marks the non-holder write interfaces for these types as `@Deprecated`.
The interfaces themselves have not been removed, so this part is not a breaking change.
Also as mentioned above, this follows in the footsteps of what `Decimal*` has already done, where they marked the non holder write interfaces as `@Deprecated`.

Additionally another user visible change is that when reading these types into a holder all of the fields are now populated. For example `TimeStamp*TZHolder.timezone` is now populated when it was not before.

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
**This PR includes breaking changes to public APIs.**

We now throw an exception when some of the holder fields that correspond to the Vector's ArrowType parameters do not match.
This is a breaking change because previously this would silently accept the writes but was actually incorrect, since the element written does not correspond to the right ArrowType variant due to mismatching parameters (like ArrowType.Timestamp.unit, ArrowType.Duration.unit, and ArrowType.FixedSizeBinary.byteWidth).

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #35352