### PR TITLE
GH-35375: [C++][FlightRPC] Add `arrow::flight::ServerCallContext::incoming_headers()`

### DIFF
--- a/cpp/src/arrow/flight/client.h
+++ b/cpp/src/arrow/flight/client.h
@@ -223,7 +223,7 @@ class ARROW_FLIGHT_EXPORT FlightClient {
   /// \param[in] username Username to use
   /// \param[in] password Password to use
   /// \return Arrow result with bearer token and status OK if client authenticated
-  /// sucessfully
+  /// successfully
   arrow::Result<std::pair<std::string, std::string>> AuthenticateBasicToken(
       const FlightCallOptions& options, const std::string& username,
       const std::string& password);

--- a/cpp/src/arrow/flight/middleware.h
+++ b/cpp/src/arrow/flight/middleware.h
@@ -20,22 +20,16 @@
 
 #pragma once
 
-#include <map>
 #include <memory>
 #include <string>
 #include <string_view>
 #include <utility>
 
-#include "arrow/flight/visibility.h"  // IWYU pragma: keep
+#include "arrow/flight/types.h"
 #include "arrow/status.h"
 
 namespace arrow {
 namespace flight {
-
-/// \brief Headers sent from the client or server.
-///
-/// Header values are ordered.
-using CallHeaders = std::multimap<std::string_view, std::string_view>;
 
 /// \brief A write-only wrapper around headers for an RPC call.
 class ARROW_FLIGHT_EXPORT AddCallHeaders {

--- a/cpp/src/arrow/flight/server.h
+++ b/cpp/src/arrow/flight/server.h
@@ -137,6 +137,8 @@ class ARROW_FLIGHT_EXPORT ServerCallContext {
   /// \brief Check if the current RPC has been cancelled (by the client, by
   /// a network error, etc.).
   virtual bool is_cancelled() const = 0;
+  /// \brief The headers sent by the client for this call.
+  virtual const CallHeaders& incoming_headers() const = 0;
 };
 
 class ARROW_FLIGHT_EXPORT FlightServerOptions {

--- a/cpp/src/arrow/flight/test_util.cc
+++ b/cpp/src/arrow/flight/test_util.cc
@@ -477,7 +477,7 @@ class FlightTestServer : public FlightServerBase {
   Status ListIncomingHeaders(const ServerCallContext& context, const Action& action,
                              std::unique_ptr<ResultStream>* out) {
     std::vector<Result> results;
-    auto prefix = static_cast<std::string_view>(*(action.body));
+    std::string_view prefix(*action.body);
     for (const auto& header : context.incoming_headers()) {
       if (header.first.substr(0, prefix.size()) != prefix) {
         continue;

--- a/cpp/src/arrow/flight/test_util.cc
+++ b/cpp/src/arrow/flight/test_util.cc
@@ -474,12 +474,31 @@ class FlightTestServer : public FlightServerBase {
     return Status::OK();
   }
 
+  Status ListIncomingHeaders(const ServerCallContext& context, const Action& action,
+                             std::unique_ptr<ResultStream>* out) {
+    std::vector<Result> results;
+    auto prefix = static_cast<std::string_view>(*(action.body));
+    for (const auto& header : context.incoming_headers()) {
+      if (header.first.substr(0, prefix.size()) != prefix) {
+        continue;
+      }
+      Result result;
+      result.body = Buffer::FromString(std::string(header.first) + ": " +
+                                       std::string(header.second));
+      results.push_back(result);
+    }
+    *out = std::make_unique<SimpleResultStream>(std::move(results));
+    return Status::OK();
+  }
+
   Status DoAction(const ServerCallContext& context, const Action& action,
                   std::unique_ptr<ResultStream>* out) override {
     if (action.type == "action1") {
       return RunAction1(action, out);
     } else if (action.type == "action2") {
       return RunAction2(out);
+    } else if (action.type == "list-incoming-headers") {
+      return ListIncomingHeaders(context, action, out);
     } else {
       return Status::NotImplemented(action.type);
     }

--- a/cpp/src/arrow/flight/transport/ucx/ucx_server.cc
+++ b/cpp/src/arrow/flight/transport/ucx/ucx_server.cc
@@ -76,9 +76,11 @@ class UcxServerCallContext : public flight::ServerCallContext {
     return nullptr;
   }
   bool is_cancelled() const override { return false; }
+  const CallHeaders& incoming_headers() const override { return incoming_headers_; }
 
  private:
   std::string peer_;
+  CallHeaders incoming_headers_;
 };
 
 class UcxServerStream : public internal::ServerDataStream {

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -21,6 +21,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -122,6 +123,11 @@ class ARROW_FLIGHT_EXPORT FlightStatusDetail : public arrow::StatusDetail {
 ARROW_FLIGHT_EXPORT
 Status MakeFlightError(FlightStatusCode code, std::string message,
                        std::string extra_info = {});
+
+/// \brief Headers sent from the client or server.
+///
+/// Header values are ordered.
+using CallHeaders = std::multimap<std::string_view, std::string_view>;
 
 /// \brief A TLS certificate plus key.
 struct ARROW_FLIGHT_EXPORT CertKeyPair {


### PR DESCRIPTION
### Rationale for this change

It returns headers sent by a client.

We can get them only in `arrow::flight::ServerMiddlewareCactory::StartCall()` for now. But they're useful for in each RPC call.

### What changes are included in this PR?

Add the method.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #35375