### PR TITLE
GH-35377: [C++][FlightRPC] Add a `ServerCallContext` parameter to `arrow::flight::ServerAuthHandler` methods

### DIFF
--- a/c_glib/arrow-flight-glib/server.h
+++ b/c_glib/arrow-flight-glib/server.h
@@ -55,6 +55,19 @@ gaflight_record_batch_stream_new(GArrowRecordBatchReader *reader,
                                  GArrowWriteOptions *options);
 
 
+#define GAFLIGHT_TYPE_SERVER_CALL_CONTEXT       \
+  (gaflight_server_call_context_get_type())
+G_DECLARE_DERIVABLE_TYPE(GAFlightServerCallContext,
+                         gaflight_server_call_context,
+                         GAFLIGHT,
+                         SERVER_CALL_CONTEXT,
+                         GObject)
+struct _GAFlightServerCallContextClass
+{
+  GObjectClass parent_class;
+};
+
+
 #define GAFLIGHT_TYPE_SERVER_AUTH_SENDER        \
   (gaflight_server_auth_sender_get_type())
 G_DECLARE_DERIVABLE_TYPE(GAFlightServerAuthSender,
@@ -124,10 +137,12 @@ struct _GAFlightServerCustomAuthHandlerClass
   GAFlightServerAuthHandlerClass parent_class;
 
   void (*authenticate)(GAFlightServerCustomAuthHandler *handler,
+                       GAFlightServerCallContext *context,
                        GAFlightServerAuthSender *sender,
                        GAFlightServerAuthReader *reader,
                        GError **error);
   void (*is_valid)(GAFlightServerCustomAuthHandler *handler,
+                   GAFlightServerCallContext *context,
                    GBytes *token,
                    GBytes **peer_identity,
                    GError **error);
@@ -137,6 +152,7 @@ GARROW_AVAILABLE_IN_12_0
 void
 gaflight_server_custom_auth_handler_authenticate(
   GAFlightServerCustomAuthHandler *handler,
+  GAFlightServerCallContext *context,
   GAFlightServerAuthSender *sender,
   GAFlightServerAuthReader *reader,
   GError **error);
@@ -145,6 +161,7 @@ GARROW_AVAILABLE_IN_12_0
 void
 gaflight_server_custom_auth_handler_is_valid(
   GAFlightServerCustomAuthHandler *handler,
+  GAFlightServerCallContext *context,
   GBytes *token,
   GBytes **peer_identity,
   GError **error);
@@ -164,19 +181,6 @@ struct _GAFlightServerOptionsClass
 GARROW_AVAILABLE_IN_5_0
 GAFlightServerOptions *
 gaflight_server_options_new(GAFlightLocation *location);
-
-
-#define GAFLIGHT_TYPE_SERVER_CALL_CONTEXT       \
-  (gaflight_server_call_context_get_type())
-G_DECLARE_DERIVABLE_TYPE(GAFlightServerCallContext,
-                         gaflight_server_call_context,
-                         GAFLIGHT,
-                         SERVER_CALL_CONTEXT,
-                         GObject)
-struct _GAFlightServerCallContextClass
-{
-  GObjectClass parent_class;
-};
 
 
 #define GAFLIGHT_TYPE_SERVABLE (gaflight_servable_get_type())

--- a/c_glib/arrow-flight-glib/server.hpp
+++ b/c_glib/arrow-flight-glib/server.hpp
@@ -27,6 +27,12 @@
 arrow::flight::FlightDataStream *
 gaflight_data_stream_get_raw(GAFlightDataStream *stream);
 
+GAFlightServerCallContext *
+gaflight_server_call_context_new_raw(
+  const arrow::flight::ServerCallContext *flight_call_context);
+const arrow::flight::ServerCallContext *
+gaflight_server_call_context_get_raw(GAFlightServerCallContext *call_context);
+
 GAFlightServerAuthSender *
 gaflight_server_auth_sender_new_raw(
   arrow::flight::ServerAuthSender *flight_sender);
@@ -44,10 +50,6 @@ gaflight_server_auth_handler_get_raw(GAFlightServerAuthHandler *handler);
 
 arrow::flight::FlightServerOptions *
 gaflight_server_options_get_raw(GAFlightServerOptions *options);
-
-GAFlightServerCallContext *
-gaflight_server_call_context_new_raw(
-  const arrow::flight::ServerCallContext *flight_context);
 
 
 struct _GAFlightServableInterface

--- a/c_glib/test/helper/flight-server.rb
+++ b/c_glib/test/helper/flight-server.rb
@@ -22,11 +22,11 @@ module Helper
     type_register
 
     private
-    def virtual_do_authenticate(sender, reader)
+    def virtual_do_authenticate(context, sender, reader)
       true
     end
 
-    def virtual_do_is_valid(token)
+    def virtual_do_is_valid(context, token)
       "identity"
     end
   end

--- a/cpp/src/arrow/flight/server_auth.cc
+++ b/cpp/src/arrow/flight/server_auth.cc
@@ -23,12 +23,14 @@ namespace flight {
 ServerAuthHandler::~ServerAuthHandler() {}
 
 NoOpAuthHandler::~NoOpAuthHandler() {}
-Status NoOpAuthHandler::Authenticate(ServerAuthSender* outgoing,
+Status NoOpAuthHandler::Authenticate(const ServerCallContext& context,
+                                     ServerAuthSender* outgoing,
                                      ServerAuthReader* incoming) {
   return Status::OK();
 }
 
-Status NoOpAuthHandler::IsValid(const std::string& token, std::string* peer_identity) {
+Status NoOpAuthHandler::IsValid(const ServerCallContext& context,
+                                const std::string& token, std::string* peer_identity) {
   *peer_identity = "";
   return Status::OK();
 }

--- a/cpp/src/arrow/flight/server_auth.h
+++ b/cpp/src/arrow/flight/server_auth.h
@@ -57,43 +57,31 @@ class ARROW_FLIGHT_EXPORT ServerAuthHandler {
   virtual ~ServerAuthHandler();
   /// \brief Authenticate the client on initial connection. The server
   /// can send and read responses from the client at any time.
-  ///
-  /// If this version is implemented, the deprecated Authentication()
-  /// without ServerCallContext version isn't used. So we can
-  /// implement the deprecated version like the following:
-  ///
-  ///   Status Authenticate(ServerAuthSender* outgoing,
-  ///                       ServerAuthReader* incoming) override {
-  ///     return Status::NotImplemented("This version is never used");
-  ///   }
-  ///
   /// \param[in] context The call context.
   /// \param[in] outgoing The writer for messages to the client.
   /// \param[in] incoming The reader for messages from the client.
   /// \return Status OK if this authentication is succeeded.
   virtual Status Authenticate(const ServerCallContext& context,
                               ServerAuthSender* outgoing, ServerAuthReader* incoming) {
+    // TODO: We can make this pure virtual function when we remove
+    // the duplicated version.
+    ARROW_SUPPRESS_DEPRECATION_WARNING
     return Authenticate(outgoing, incoming);
+    ARROW_UNSUPPRESS_DEPRECATION_WARNING
   }
   /// \brief Authenticate the client on initial connection. The server
   /// can send and read responses from the client at any time.
   /// \param[in] outgoing The writer for messages to the client.
   /// \param[in] incoming The reader for messages from the client.
   /// \return Status OK if this authentication is succeeded.
-  /// \deprecated Deprecated since 13.0.0. Implement the Authentication()
+  /// \deprecated Deprecated in 13.0.0. Implement the Authentication()
   /// with ServerCallContext version instead.
-  virtual Status Authenticate(ServerAuthSender* outgoing, ServerAuthReader* incoming) = 0;
+  ARROW_DEPRECATED("Deprecated in 13.0.0. Use ServerCallContext overload instead.")
+  virtual Status Authenticate(ServerAuthSender* outgoing, ServerAuthReader* incoming) {
+    return Status::NotImplemented(typeid(this).name(),
+                                  "::Authenticate() isn't implemented");
+  }
   /// \brief Validate a per-call client token.
-  ///
-  /// If this version is implemented, the deprecated IsValid()
-  /// without ServerCallContext version isn't used. So we can
-  /// implement the deprecated version like the following:
-  ///
-  ///   Status IsValid(const std::string& token,
-  ///                  std::string* peer_identity) override {
-  ///     return Status::NotImplemented("This version is never used");
-  ///   }
-  ///
   /// \param[in] token The client token. May be the empty string if
   /// the client does not provide a token.
   /// \param[out] peer_identity The identity of the peer, if this
@@ -102,7 +90,11 @@ class ARROW_FLIGHT_EXPORT ServerAuthHandler {
   /// validation failed
   virtual Status IsValid(const ServerCallContext& context, const std::string& token,
                          std::string* peer_identity) {
+    // TODO: We can make this pure virtual function when we remove
+    // the duplicated version.
+    ARROW_SUPPRESS_DEPRECATION_WARNING
     return IsValid(token, peer_identity);
+    ARROW_UNSUPPRESS_DEPRECATION_WARNING
   }
   /// \brief Validate a per-call client token.
   /// \param[in] token The client token. May be the empty string if
@@ -111,15 +103,22 @@ class ARROW_FLIGHT_EXPORT ServerAuthHandler {
   /// authentication method supports it.
   /// \return Status OK if the token is valid, any other status if
   /// validation failed
-  virtual Status IsValid(const std::string& token, std::string* peer_identity) = 0;
+  /// \deprecated Deprecated in 13.0.0. Implement the IsValid()
+  /// with ServerCallContext version instead.
+  ARROW_DEPRECATED("Deprecated in 13.0.0. Use ServerCallContext overload instead.")
+  virtual Status IsValid(const std::string& token, std::string* peer_identity) {
+    return Status::NotImplemented(typeid(this).name(), "::IsValid() isn't implemented");
+  }
 };
 
 /// \brief An authentication mechanism that does nothing.
 class ARROW_FLIGHT_EXPORT NoOpAuthHandler : public ServerAuthHandler {
  public:
   ~NoOpAuthHandler() override;
-  Status Authenticate(ServerAuthSender* outgoing, ServerAuthReader* incoming) override;
-  Status IsValid(const std::string& token, std::string* peer_identity) override;
+  Status Authenticate(const ServerCallContext& context, ServerAuthSender* outgoing,
+                      ServerAuthReader* incoming) override;
+  Status IsValid(const ServerCallContext& context, const std::string& token,
+                 std::string* peer_identity) override;
 };
 
 }  // namespace flight

--- a/cpp/src/arrow/flight/server_auth.h
+++ b/cpp/src/arrow/flight/server_auth.h
@@ -64,7 +64,7 @@ class ARROW_FLIGHT_EXPORT ServerAuthHandler {
   virtual Status Authenticate(const ServerCallContext& context,
                               ServerAuthSender* outgoing, ServerAuthReader* incoming) {
     // TODO: We can make this pure virtual function when we remove
-    // the duplicated version.
+    // the deprecated version.
     ARROW_SUPPRESS_DEPRECATION_WARNING
     return Authenticate(outgoing, incoming);
     ARROW_UNSUPPRESS_DEPRECATION_WARNING
@@ -82,6 +82,7 @@ class ARROW_FLIGHT_EXPORT ServerAuthHandler {
                                   "::Authenticate() isn't implemented");
   }
   /// \brief Validate a per-call client token.
+  /// \param[in] context The call context.
   /// \param[in] token The client token. May be the empty string if
   /// the client does not provide a token.
   /// \param[out] peer_identity The identity of the peer, if this
@@ -91,7 +92,7 @@ class ARROW_FLIGHT_EXPORT ServerAuthHandler {
   virtual Status IsValid(const ServerCallContext& context, const std::string& token,
                          std::string* peer_identity) {
     // TODO: We can make this pure virtual function when we remove
-    // the duplicated version.
+    // the deprecated version.
     ARROW_SUPPRESS_DEPRECATION_WARNING
     return IsValid(token, peer_identity);
     ARROW_UNSUPPRESS_DEPRECATION_WARNING

--- a/cpp/src/arrow/flight/test_util.cc
+++ b/cpp/src/arrow/flight/test_util.cc
@@ -686,7 +686,8 @@ TestServerAuthHandler::TestServerAuthHandler(const std::string& username,
 
 TestServerAuthHandler::~TestServerAuthHandler() {}
 
-Status TestServerAuthHandler::Authenticate(ServerAuthSender* outgoing,
+Status TestServerAuthHandler::Authenticate(const ServerCallContext& context,
+                                           ServerAuthSender* outgoing,
                                            ServerAuthReader* incoming) {
   std::string token;
   RETURN_NOT_OK(incoming->Read(&token));
@@ -697,7 +698,8 @@ Status TestServerAuthHandler::Authenticate(ServerAuthSender* outgoing,
   return Status::OK();
 }
 
-Status TestServerAuthHandler::IsValid(const std::string& token,
+Status TestServerAuthHandler::IsValid(const ServerCallContext& context,
+                                      const std::string& token,
                                       std::string* peer_identity) {
   if (token != password_) {
     return MakeFlightError(FlightStatusCode::Unauthenticated, "Invalid token");
@@ -714,7 +716,8 @@ TestServerBasicAuthHandler::TestServerBasicAuthHandler(const std::string& userna
 
 TestServerBasicAuthHandler::~TestServerBasicAuthHandler() {}
 
-Status TestServerBasicAuthHandler::Authenticate(ServerAuthSender* outgoing,
+Status TestServerBasicAuthHandler::Authenticate(const ServerCallContext& context,
+                                                ServerAuthSender* outgoing,
                                                 ServerAuthReader* incoming) {
   std::string token;
   RETURN_NOT_OK(incoming->Read(&token));
@@ -727,7 +730,8 @@ Status TestServerBasicAuthHandler::Authenticate(ServerAuthSender* outgoing,
   return Status::OK();
 }
 
-Status TestServerBasicAuthHandler::IsValid(const std::string& token,
+Status TestServerBasicAuthHandler::IsValid(const ServerCallContext& context,
+                                           const std::string& token,
                                            std::string* peer_identity) {
   if (token != basic_auth_.username) {
     return MakeFlightError(FlightStatusCode::Unauthenticated, "Invalid token");

--- a/cpp/src/arrow/flight/test_util.h
+++ b/cpp/src/arrow/flight/test_util.h
@@ -205,14 +205,8 @@ class ARROW_FLIGHT_EXPORT TestServerAuthHandler : public ServerAuthHandler {
   ~TestServerAuthHandler() override;
   Status Authenticate(const ServerCallContext& context, ServerAuthSender* outgoing,
                       ServerAuthReader* incoming) override;
-  Status Authenticate(ServerAuthSender* outgoing, ServerAuthReader* incoming) override {
-    return Status::NotImplemented("This version is never used.");
-  }
   Status IsValid(const ServerCallContext& context, const std::string& token,
                  std::string* peer_identity) override;
-  Status IsValid(const std::string& token, std::string* peer_identity) override {
-    return Status::NotImplemented("This version is never used.");
-  }
 
  private:
   std::string username_;
@@ -226,14 +220,8 @@ class ARROW_FLIGHT_EXPORT TestServerBasicAuthHandler : public ServerAuthHandler 
   ~TestServerBasicAuthHandler() override;
   Status Authenticate(const ServerCallContext& context, ServerAuthSender* outgoing,
                       ServerAuthReader* incoming) override;
-  Status Authenticate(ServerAuthSender* outgoing, ServerAuthReader* incoming) override {
-    return Status::NotImplemented("This version is never used.");
-  }
   Status IsValid(const ServerCallContext& context, const std::string& token,
                  std::string* peer_identity) override;
-  Status IsValid(const std::string& token, std::string* peer_identity) override {
-    return Status::NotImplemented("This version is never used.");
-  }
 
  private:
   BasicAuth basic_auth_;

--- a/cpp/src/arrow/flight/test_util.h
+++ b/cpp/src/arrow/flight/test_util.h
@@ -203,8 +203,16 @@ class ARROW_FLIGHT_EXPORT TestServerAuthHandler : public ServerAuthHandler {
   explicit TestServerAuthHandler(const std::string& username,
                                  const std::string& password);
   ~TestServerAuthHandler() override;
-  Status Authenticate(ServerAuthSender* outgoing, ServerAuthReader* incoming) override;
-  Status IsValid(const std::string& token, std::string* peer_identity) override;
+  Status Authenticate(const ServerCallContext& context, ServerAuthSender* outgoing,
+                      ServerAuthReader* incoming) override;
+  Status Authenticate(ServerAuthSender* outgoing, ServerAuthReader* incoming) override {
+    return Status::NotImplemented("This version is never used.");
+  }
+  Status IsValid(const ServerCallContext& context, const std::string& token,
+                 std::string* peer_identity) override;
+  Status IsValid(const std::string& token, std::string* peer_identity) override {
+    return Status::NotImplemented("This version is never used.");
+  }
 
  private:
   std::string username_;
@@ -216,8 +224,16 @@ class ARROW_FLIGHT_EXPORT TestServerBasicAuthHandler : public ServerAuthHandler 
   explicit TestServerBasicAuthHandler(const std::string& username,
                                       const std::string& password);
   ~TestServerBasicAuthHandler() override;
-  Status Authenticate(ServerAuthSender* outgoing, ServerAuthReader* incoming) override;
-  Status IsValid(const std::string& token, std::string* peer_identity) override;
+  Status Authenticate(const ServerCallContext& context, ServerAuthSender* outgoing,
+                      ServerAuthReader* incoming) override;
+  Status Authenticate(ServerAuthSender* outgoing, ServerAuthReader* incoming) override {
+    return Status::NotImplemented("This version is never used.");
+  }
+  Status IsValid(const ServerCallContext& context, const std::string& token,
+                 std::string* peer_identity) override;
+  Status IsValid(const std::string& token, std::string* peer_identity) override {
+    return Status::NotImplemented("This version is never used.");
+  }
 
  private:
   BasicAuth basic_auth_;

--- a/cpp/src/arrow/flight/transport/grpc/grpc_server.cc
+++ b/cpp/src/arrow/flight/transport/grpc/grpc_server.cc
@@ -299,7 +299,8 @@ class GrpcServiceHandler final : public FlightService::Service {
       } else {
         token = std::string(auth_header->second.data(), auth_header->second.length());
       }
-      GRPC_RETURN_NOT_OK(auth_handler_->IsValid(token, &flight_context.peer_identity_));
+      GRPC_RETURN_NOT_OK(
+          auth_handler_->IsValid(flight_context, token, &flight_context.peer_identity_));
     }
 
     return MakeCallContext(method, context, flight_context);
@@ -352,8 +353,8 @@ class GrpcServiceHandler final : public FlightService::Service {
     }
     GrpcServerAuthSender outgoing{stream};
     GrpcServerAuthReader incoming{stream};
-    RETURN_WITH_MIDDLEWARE(flight_context,
-                           auth_handler_->Authenticate(&outgoing, &incoming));
+    RETURN_WITH_MIDDLEWARE(flight_context, auth_handler_->Authenticate(
+                                               flight_context, &outgoing, &incoming));
   }
 
   ::grpc::Status ListFlights(ServerContext* context, const pb::Criteria* request,


### PR DESCRIPTION
### Rationale for this change

Because they are also RPC calls to like others such as `ListFlights()` and `DoGet()`.

### What changes are included in this PR?

Add with `ServerCallContext` versions.

Old signature versions still exist for keeping backward compatibility.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.

**This PR includes breaking changes to public APIs.**

* C++ API: Don't include any breaking changes.
* C GLib API: Includes a breaking change. `context` argument is added.

* Closes: #35377