### PR TITLE
GH-35379: [C++][FlightRPC] Add teardown needed checks to avoid crash on error

### DIFF
--- a/cpp/src/arrow/flight/flight_test.cc
+++ b/cpp/src/arrow/flight/flight_test.cc
@@ -395,14 +395,19 @@ class TestTls : public ::testing::Test {
     ASSERT_RAISES(UnknownError, server_->Init(options));
     ASSERT_OK(ExampleTlsCertificates(&options.tls_certificates));
     ASSERT_OK(server_->Init(options));
+    server_is_initialized_ = true;
 
     ASSERT_OK_AND_ASSIGN(location_, Location::ForGrpcTls("localhost", server_->port()));
     ASSERT_OK(ConnectClient());
   }
 
   void TearDown() {
-    ASSERT_OK(client_->Close());
-    ASSERT_OK(server_->Shutdown());
+    if (client_) {
+      ASSERT_OK(client_->Close());
+    }
+    if (server_is_initialized_) {
+      ASSERT_OK(server_->Shutdown());
+    }
     grpc_shutdown();
   }
 
@@ -418,6 +423,7 @@ class TestTls : public ::testing::Test {
   Location location_;
   std::unique_ptr<FlightClient> client_;
   std::unique_ptr<FlightServerBase> server_;
+  bool server_is_initialized_;
 };
 
 // A server middleware that rejects all calls.


### PR DESCRIPTION
### Rationale for this change

If `ARROW_TEST_DATA` isn't set, `arrow-flight-test` is crashed:

```console
$ LD_LIBRARY_PATH=$PWD/debug debug/arrow-flight-test
...
[----------] 4 tests from TestTls
[ RUN      ] TestTls.DoAction
E0501 16:24:25.455014704  800882 ssl_security_connector.cc:270]        Handshaker factory creation failed with TSI_INVALID_ARGUMENT.
E0501 16:24:25.455054228  800882 chttp2_server.cc:1045]                UNKNOWN:Unable to create secure server with credentials of type Ssl {file:"./src/core/ext/transport/chttp2/server/chttp2_server.cc", file_line:1032, created_time:"2023-05-01T16:24:25.455046974+09:00"}
/home/kou/work/cpp/arrow.kou/cpp/src/arrow/flight/flight_test.cc:396: Failure
Failed
'ExampleTlsCertificates(&options.tls_certificates)' failed with IOError: Test resources not found, set ARROW_TEST_DATA to <repo root>/testing/data
../cpp/src/arrow/flight/test_util.cc:784  GetTestResourceRoot(&root)
```

Because `client_` isn't created and `server_->Init()` isn't called when this error is occurred and `TearDown()` is executed.

### What changes are included in this PR?

Executes each teardown process only when they are needed.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #35379