### PR TITLE
MINOR: [Archery] Fixed ArrowSources.__str__() not returning string

### DIFF
--- a/dev/archery/archery/utils/source.py
+++ b/dev/archery/archery/utils/source.py
@@ -221,4 +221,4 @@ class ArrowSources:
         )
 
     def __repr__(self):
-        return self.path
+        return os.fspath(self.path)


### PR DESCRIPTION
<!--


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

When no git repository is initialised in the `arrow/` directory, archery is supposed to raise an error when executing for example `archery benchmark list`. This error raises another error because the class ArrowSources does not have a proper `__repr__()` method. Below an example traceback:
```sh
Traceback (most recent call last):
  File "/opt/homebrew/bin/archery", line 33, in <module>
    sys.exit(load_entry_point('archery', 'console_scripts', 'archery')())
  File "/opt/homebrew/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/opt/homebrew/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/opt/homebrew/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/homebrew/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/homebrew/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/homebrew/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/opt/homebrew/lib/python3.10/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/philipgroet/projects/afstuderen/arrow/dev/archery/archery/cli.py", line 419, in benchmark_list
    runner_base = CppBenchmarkRunner.from_rev_or_path(
  File "/Users/philipgroet/projects/afstuderen/arrow/dev/archery/archery/benchmark/runner.py", line 222, in from_rev_or_path
    src_rev, _ = src.at_revision(rev_or_path, clone_dir)
  File "/Users/philipgroet/projects/afstuderen/arrow/dev/archery/archery/utils/source.py", line 151, in at_revision
    raise ValueError("{} is not backed by git".format(self))
TypeError: __str__ returned non-string (type PosixPath)
```

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
The `self.path` attribute of ArrowSources is of type Path, we stringify it.


### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes, now prints: `ValueError: /Users/philipgroet/projects/afstuderen/arrow is not backed by git`

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No, bugfix

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->