### PR TITLE
GH-34523: [C++] Avoid mixing bundled Abseil and system Abseil

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -659,6 +659,23 @@ set(ARROW_SHARED_INSTALL_INTERFACE_LIBS)
 set(ARROW_STATIC_LINK_LIBS arrow::flatbuffers arrow::hadoop)
 set(ARROW_STATIC_INSTALL_INTERFACE_LIBS)
 
+# We must use google-cloud-cpp::storage first. If
+# google-cloud-cpp::storage depends on bundled Abseil, bundled Abseil
+# and system Abseil may be mixed.
+#
+# For example, if Boost::headers is used before
+# google-cloud-cpp::storage AND Boost::headers has
+# -I/opt/homebrew/include AND /opt/homebrew/include/absl/ exists,
+# /opt/homebrew/include/absl/**/*.h are used instead of .h provided by
+# bundled Abseil.
+if(ARROW_GCS)
+  list(APPEND ARROW_SHARED_LINK_LIBS google-cloud-cpp::storage)
+  list(APPEND ARROW_STATIC_LINK_LIBS google-cloud-cpp::storage)
+  if(google_cloud_cpp_storage_SOURCE STREQUAL "SYSTEM")
+    list(APPEND ARROW_STATIC_INSTALL_INTERFACE_LIBS google-cloud-cpp::storage)
+  endif()
+endif()
+
 if(ARROW_USE_BOOST)
   list(APPEND ARROW_SHARED_LINK_LIBS Boost::headers)
   list(APPEND ARROW_STATIC_LINK_LIBS Boost::headers)
@@ -722,14 +739,6 @@ if(ARROW_ORC)
   if(ORC_SOURCE STREQUAL "SYSTEM")
     list(APPEND ARROW_STATIC_INSTALL_INTERFACE_LIBS orc::liborc
          ${ARROW_PROTOBUF_LIBPROTOBUF})
-  endif()
-endif()
-
-if(ARROW_GCS)
-  list(APPEND ARROW_SHARED_LINK_LIBS google-cloud-cpp::storage)
-  list(APPEND ARROW_STATIC_LINK_LIBS google-cloud-cpp::storage)
-  if(google_cloud_cpp_storage_SOURCE STREQUAL "SYSTEM")
-    list(APPEND ARROW_STATIC_INSTALL_INTERFACE_LIBS google-cloud-cpp::storage)
   endif()
 endif()
 

--- a/cpp/src/arrow/flight/CMakeLists.txt
+++ b/cpp/src/arrow/flight/CMakeLists.txt
@@ -238,13 +238,19 @@ add_arrow_lib(arrow_flight
               SHARED_LINK_FLAGS
               ${ARROW_VERSION_SCRIPT_FLAGS} # Defined in cpp/arrow/CMakeLists.txt
               SHARED_LINK_LIBS
-              arrow_shared
+              # We must use gPRC::grpc++ first. If gRPC::grpc++
+              # depends on bundled Abseil, bundled Abseil and system
+              # Abseil may be mixed.
+              #
+              # See also a comment for "if(ARROW_GCS)" in
+              # cpp/CMakeLists.txt.
               ${ARROW_FLIGHT_LINK_LIBS}
+              arrow_shared
               SHARED_INSTALL_INTERFACE_LIBS
               Arrow::arrow_shared
               STATIC_LINK_LIBS
-              arrow_static
               ${ARROW_FLIGHT_LINK_LIBS}
+              arrow_static
               STATIC_INSTALL_INTERFACE_LIBS
               Arrow::arrow_static)
 

--- a/cpp/src/arrow/flight/CMakeLists.txt
+++ b/cpp/src/arrow/flight/CMakeLists.txt
@@ -238,7 +238,7 @@ add_arrow_lib(arrow_flight
               SHARED_LINK_FLAGS
               ${ARROW_VERSION_SCRIPT_FLAGS} # Defined in cpp/arrow/CMakeLists.txt
               SHARED_LINK_LIBS
-              # We must use gPRC::grpc++ first. If gRPC::grpc++
+              # We must use gRPC::grpc++ first. If gRPC::grpc++
               # depends on bundled Abseil, bundled Abseil and system
               # Abseil may be mixed.
               #


### PR DESCRIPTION
### Rationale for this change

If we use a CMake target that provides the same include path for system Abseil in advance of a CMake target for bundled Abseil, header files for system Abseil are used.

It causes a link error when system Abseil and bundled Abseil are incompatible.  

### What changes are included in this PR?

Use a CMake target for bundled Abseil as early as possible.
 
### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #34523