### PR TITLE
GH-35390: [Python] Consolidate some APIs in Table and RecordBatch

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1600,7 +1600,7 @@ cdef class _Tabular(_PandasConvertible):
 
         Returns
         -------
-        columsn : list of Array (for RecordBatch) or list of ChunkedArray (for Table)
+        columns : list of Array (for RecordBatch) or list of ChunkedArray (for Table)
 
         Examples
         --------

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1593,6 +1593,45 @@ cdef class _Tabular(_PandasConvertible):
         """
         return self._column(self._ensure_integer_index(i))
 
+    @property
+    def columns(self):
+        """
+        List of all columns in numerical order.
+
+        Returns
+        -------
+        columsn : list of Array (for RecordBatch) or list of ChunkedArray (for Table)
+
+        Examples
+        --------
+        Table (works similarly for RecordBatch)
+
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'n_legs': [None, 4, 5, None],
+        ...                    'animals': ["Flamingo", "Horse", None, "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> table.columns
+        [<pyarrow.lib.ChunkedArray object at ...>
+        [
+          [
+            null,
+            4,
+            5,
+            null
+          ]
+        ], <pyarrow.lib.ChunkedArray object at ...>
+        [
+          [
+            "Flamingo",
+            "Horse",
+            null,
+            "Centipede"
+          ]
+        ]]
+        """
+        return [self._column(i) for i in range(self.num_columns)]
+
     def drop_null(self):
         """
         Remove rows that contain missing values from a Table or RecordBatch.
@@ -1679,6 +1718,27 @@ cdef class _Tabular(_PandasConvertible):
         -------
         Table or RecordBatch
             A new tabular object sorted according to the sort keys.
+
+        Examples
+        --------
+        Table (works similarly for RecordBatch)
+
+        >>> import pandas as pd
+        >>> import pyarrow as pa
+        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                    "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> table.sort_by('animal')
+        pyarrow.Table
+        year: int64
+        n_legs: int64
+        animal: string
+        ----
+        year: [[2019,2021,2021,2020,2022,2022]]
+        n_legs: [[5,100,4,2,4,2]]
+        animal: [["Brittle stars","Centipede","Dog","Flamingo","Horse","Parrot"]]
         """
         if isinstance(sorting, str):
             sorting = [(sorting, "ascending")]
@@ -2130,43 +2190,6 @@ cdef class RecordBatch(_Tabular):
             self._schema = pyarrow_wrap_schema(self.batch.schema())
 
         return self._schema
-
-    @property
-    def columns(self):
-        """
-        List of all columns in numerical order
-
-        Returns
-        -------
-        list of pyarrow.Array
-
-        Examples
-        --------
-        >>> import pyarrow as pa
-        >>> n_legs = pa.array([2, 2, 4, 4, 5, 100])
-        >>> animals = pa.array(["Flamingo", "Parrot", "Dog", "Horse", "Brittle stars", "Centipede"])
-        >>> batch = pa.RecordBatch.from_arrays([n_legs, animals],
-        ...                                     names=["n_legs", "animals"])
-        >>> batch.columns
-        [<pyarrow.lib.Int64Array object at ...>
-        [
-          2,
-          2,
-          4,
-          4,
-          5,
-          100
-        ], <pyarrow.lib.StringArray object at ...>
-        [
-          "Flamingo",
-          "Parrot",
-          "Dog",
-          "Horse",
-          "Brittle stars",
-          "Centipede"
-        ]]
-        """
-        return [self.column(i) for i in range(self.num_columns)]
 
     def _column(self, int i):
         """
@@ -4197,43 +4220,6 @@ cdef class Table(_Tabular):
         """
         for i in range(self.num_columns):
             yield self._column(i)
-
-    @property
-    def columns(self):
-        """
-        List of all columns in numerical order.
-
-        Returns
-        -------
-        list of ChunkedArray
-
-        Examples
-        --------
-        >>> import pyarrow as pa
-        >>> import pandas as pd
-        >>> df = pd.DataFrame({'n_legs': [None, 4, 5, None],
-        ...                    'animals': ["Flamingo", "Horse", None, "Centipede"]})
-        >>> table = pa.Table.from_pandas(df)
-        >>> table.columns
-        [<pyarrow.lib.ChunkedArray object at ...>
-        [
-          [
-            null,
-            4,
-            5,
-            null
-          ]
-        ], <pyarrow.lib.ChunkedArray object at ...>
-        [
-          [
-            "Flamingo",
-            "Horse",
-            null,
-            "Centipede"
-          ]
-        ]]
-        """
-        return [self._column(i) for i in range(self.num_columns)]
 
     @property
     def num_columns(self):

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1457,14 +1457,141 @@ cdef class _Tabular(_PandasConvertible):
         raise TypeError("This object is not instantiable, "
                         "use a subclass instead.")
 
+    def __dataframe__(self, nan_as_null: bool = False, allow_copy: bool = True):
+        """
+        Return the dataframe interchange object implementing the interchange protocol.
+
+        Parameters
+        ----------
+        nan_as_null : bool, default False
+            Whether to tell the DataFrame to overwrite null values in the data
+            with ``NaN`` (or ``NaT``).
+        allow_copy : bool, default True
+            Whether to allow memory copying when exporting. If set to False
+            it would cause non-zero-copy exports to fail.
+
+        Returns
+        -------
+        DataFrame interchange object
+            The object which consuming library can use to ingress the dataframe.
+
+        Notes
+        -----
+        Details on the interchange protocol:
+        https://data-apis.org/dataframe-protocol/latest/index.html
+        `nan_as_null` currently has no effect; once support for nullable extension
+        dtypes is added, this value should be propagated to columns.
+        """
+
+        from pyarrow.interchange.dataframe import _PyArrowDataFrame
+
+        return _PyArrowDataFrame(self, nan_as_null, allow_copy)
+
+    def __eq__(self, other):
+        try:
+            return self.equals(other)
+        except TypeError:
+            return NotImplemented
+
+    def __getitem__(self, key):
+        """
+        Slice or return column at given index or column name
+
+        Parameters
+        ----------
+        key : integer, str, or slice
+            Slices with step not equal to 1 (or None) will produce a copy
+            rather than a zero-copy view
+
+        Returns
+        -------
+        Array (from RecordBatch) or ChunkedArray (from Table) for column input.
+        RecordBatch or Table for slice input.
+        """
+        if isinstance(key, slice):
+            return _normalize_slice(self, key)
+
+        return self.column(key)
+
     def __repr__(self):
         if not self._is_initialized():
             raise ValueError("This object's internal pointer is NULL, do not "
                              "use any methods or attributes on this object")
         return self.to_string(preview_cols=10)
 
+    def _ensure_integer_index(self, i):
+        """
+        Ensure integer index (convert string column name to integer if needed).
+        """
+        if isinstance(i, (bytes, str)):
+            field_indices = self.schema.get_all_field_indices(i)
+
+            if len(field_indices) == 0:
+                raise KeyError("Field \"{}\" does not exist in schema"
+                               .format(i))
+            elif len(field_indices) > 1:
+                raise KeyError("Field \"{}\" exists {} times in schema"
+                               .format(i, len(field_indices)))
+            else:
+                return field_indices[0]
+        elif isinstance(i, int):
+            return i
+        else:
+            raise TypeError("Index must either be string or integer")
+
     def _is_initialized(self):
         raise NotImplementedError
+
+    def column(self, i):
+        """
+        Select single column from Table or RecordBatch.
+
+        Parameters
+        ----------
+        i : int or string
+            The index or name of the column to retrieve.
+
+        Returns
+        -------
+        column : Array (for RecordBatch) or ChunkedArray (for Table)
+
+        Examples
+        --------
+        Table (works similarly for RecordBatch)
+
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'n_legs': [2, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+
+        Select a column by numeric index:
+
+        >>> table.column(0)
+        <pyarrow.lib.ChunkedArray object at ...>
+        [
+          [
+            2,
+            4,
+            5,
+            100
+          ]
+        ]
+
+        Select a column by its name:
+
+        >>> table.column("animals")
+        <pyarrow.lib.ChunkedArray object at ...>
+        [
+          [
+            "Flamingo",
+            "Horse",
+            "Brittle stars",
+            "Centipede"
+          ]
+        ]
+        """
+        return self._column(self._ensure_integer_index(i))
 
     def drop_null(self):
         """
@@ -1499,6 +1626,68 @@ cdef class _Tabular(_PandasConvertible):
         animals: [["Horse","Centipede"]]
         """
         return _pc().drop_null(self)
+
+    def field(self, i):
+        """
+        Select a schema field by its column name or numeric index.
+
+        Parameters
+        ----------
+        i : int or string
+            The index or name of the field to retrieve.
+
+        Returns
+        -------
+        Field
+
+        Examples
+        --------
+        Table (works similarly for RecordBatch)
+
+        >>> import pyarrow as pa
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({'n_legs': [2, 4, 5, 100],
+        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
+        >>> table = pa.Table.from_pandas(df)
+        >>> table.field(0)
+        pyarrow.Field<n_legs: int64>
+        >>> table.field(1)
+        pyarrow.Field<animals: string>
+        """
+        return self.schema.field(i)
+
+    @property
+    def schema(self):
+        raise NotImplementedError
+
+    def sort_by(self, sorting, **kwargs):
+        """
+        Sort the Table or RecordBatch by one or multiple columns.
+
+        Parameters
+        ----------
+        sorting : str or list[tuple(name, order)]
+            Name of the column to use to sort (ascending), or
+            a list of multiple sorting conditions where
+            each entry is a tuple with column name
+            and sorting order ("ascending" or "descending")
+        **kwargs : dict, optional
+            Additional sorting options.
+            As allowed by :class:`SortOptions`
+
+        Returns
+        -------
+        Table or RecordBatch
+            A new tabular object sorted according to the sort keys.
+        """
+        if isinstance(sorting, str):
+            sorting = [(sorting, "ascending")]
+
+        indices = _pc().sort_indices(
+            self,
+            options=_pc().SortOptions(sort_keys=sorting, **kwargs)
+        )
+        return self.take(indices)
 
     def take(self, object indices):
         """
@@ -1684,39 +1873,6 @@ cdef class RecordBatch(_Tabular):
     def _is_initialized(self):
         return self.batch != NULL
 
-    # ----------------------------------------------------------------------
-    def __dataframe__(self, nan_as_null: bool = False, allow_copy: bool = True):
-        """
-        Return the dataframe interchange object implementing the interchange protocol.
-
-        Parameters
-        ----------
-        nan_as_null : bool, default False
-            Whether to tell the DataFrame to overwrite null values in the data
-            with ``NaN`` (or ``NaT``).
-        allow_copy : bool, default True
-            Whether to allow memory copying when exporting. If set to False
-            it would cause non-zero-copy exports to fail.
-
-        Returns
-        -------
-        DataFrame interchange object
-            The object which consuming library can use to ingress the dataframe.
-
-        Notes
-        -----
-        Details on the interchange protocol:
-        https://data-apis.org/dataframe-protocol/latest/index.html
-        `nan_as_null` currently has no effect; once support for nullable extension
-        dtypes is added, this value should be propagated to columns.
-        """
-
-        from pyarrow.interchange.dataframe import _PyArrowDataFrame
-
-        return _PyArrowDataFrame(self, nan_as_null, allow_copy)
-
-    # ----------------------------------------------------------------------
-
     @staticmethod
     def from_pydict(mapping, schema=None, metadata=None):
         """
@@ -1835,12 +1991,6 @@ cdef class RecordBatch(_Tabular):
 
     def __len__(self):
         return self.batch.num_rows()
-
-    def __eq__(self, other):
-        try:
-            return self.equals(other)
-        except TypeError:
-            return NotImplemented
 
     def validate(self, *, full=False):
         """
@@ -1981,33 +2131,6 @@ cdef class RecordBatch(_Tabular):
 
         return self._schema
 
-    def field(self, i):
-        """
-        Select a schema field by its column name or numeric index
-
-        Parameters
-        ----------
-        i : int or string
-            The index or name of the field to retrieve
-
-        Returns
-        -------
-        pyarrow.Field
-
-        Examples
-        --------
-        >>> import pyarrow as pa
-        >>> n_legs = pa.array([2, 2, 4, 4, 5, 100])
-        >>> animals = pa.array(["Flamingo", "Parrot", "Dog", "Horse", "Brittle stars", "Centipede"])
-        >>> batch = pa.RecordBatch.from_arrays([n_legs, animals],
-        ...                                     names=["n_legs", "animals"])
-        >>> batch.field(0)
-        pyarrow.Field<n_legs: int64>
-        >>> batch.field(1)
-        pyarrow.Field<animals: string>
-        """
-        return self.schema.field(i)
-
     @property
     def columns(self):
         """
@@ -2044,61 +2167,6 @@ cdef class RecordBatch(_Tabular):
         ]]
         """
         return [self.column(i) for i in range(self.num_columns)]
-
-    def _ensure_integer_index(self, i):
-        """
-        Ensure integer index (convert string column name to integer if needed).
-        """
-        if isinstance(i, (bytes, str)):
-            field_indices = self.schema.get_all_field_indices(i)
-
-            if len(field_indices) == 0:
-                raise KeyError(
-                    "Field \"{}\" does not exist in record batch schema"
-                    .format(i))
-            elif len(field_indices) > 1:
-                raise KeyError(
-                    "Field \"{}\" exists {} times in record batch schema"
-                    .format(i, len(field_indices)))
-            else:
-                return field_indices[0]
-        elif isinstance(i, int):
-            return i
-        else:
-            raise TypeError("Index must either be string or integer")
-
-    def column(self, i):
-        """
-        Select single column from record batch
-
-        Parameters
-        ----------
-        i : int or string
-            The index or name of the column to retrieve.
-
-        Returns
-        -------
-        column : pyarrow.Array
-
-        Examples
-        --------
-        >>> import pyarrow as pa
-        >>> n_legs = pa.array([2, 2, 4, 4, 5, 100])
-        >>> animals = pa.array(["Flamingo", "Parrot", "Dog", "Horse", "Brittle stars", "Centipede"])
-        >>> batch = pa.RecordBatch.from_arrays([n_legs, animals],
-        ...                                     names=["n_legs", "animals"])
-        >>> batch.column(1)
-        <pyarrow.lib.StringArray object at ...>
-        [
-          "Flamingo",
-          "Parrot",
-          "Dog",
-          "Horse",
-          "Brittle stars",
-          "Centipede"
-        ]
-        """
-        return self._column(self._ensure_integer_index(i))
 
     def _column(self, int i):
         """
@@ -2180,25 +2248,6 @@ cdef class RecordBatch(_Tabular):
 
     def __sizeof__(self):
         return super(RecordBatch, self).__sizeof__() + self.nbytes
-
-    def __getitem__(self, key):
-        """
-        Slice or return column at given index or column name
-
-        Parameters
-        ----------
-        key : integer, str, or slice
-            Slices with step not equal to 1 (or None) will produce a copy
-            rather than a zero-copy view
-
-        Returns
-        -------
-        value : Array (index/column) or RecordBatch (slice)
-        """
-        if isinstance(key, slice):
-            return _normalize_slice(self, key)
-
-        return self.column(key)
 
     def serialize(self, memory_pool=None):
         """
@@ -2442,35 +2491,6 @@ cdef class RecordBatch(_Tabular):
             c_batch = GetResultValue(self.batch.SelectColumns(move(c_indices)))
 
         return pyarrow_wrap_batch(c_batch)
-
-    def sort_by(self, sorting, **kwargs):
-        """
-        Sort the RecordBatch by one or multiple columns.
-
-        Parameters
-        ----------
-        sorting : str or list[tuple(name, order)]
-            Name of the column to use to sort (ascending), or
-            a list of multiple sorting conditions where
-            each entry is a tuple with column name
-            and sorting order ("ascending" or "descending")
-        **kwargs : dict, optional
-            Additional sorting options.
-            As allowed by :class:`SortOptions`
-
-        Returns
-        -------
-        RecordBatch
-            A new record batch sorted according to the sort keys.
-        """
-        if isinstance(sorting, str):
-            sorting = [(sorting, "ascending")]
-
-        indices = _pc().sort_indices(
-            self,
-            options=_pc().SortOptions(sort_keys=sorting, **kwargs)
-        )
-        return self.take(indices)
 
     def to_pydict(self):
         """
@@ -3023,55 +3043,6 @@ cdef class Table(_Tabular):
         columns = [col for col in self.columns]
         return _reconstruct_table, (columns, self.schema)
 
-    def __getitem__(self, key):
-        """
-        Slice or return column at given index or column name.
-
-        Parameters
-        ----------
-        key : integer, str, or slice
-            Slices with step not equal to 1 (or None) will produce a copy
-            rather than a zero-copy view.
-
-        Returns
-        -------
-        ChunkedArray (index/column) or Table (slice)
-        """
-        if isinstance(key, slice):
-            return _normalize_slice(self, key)
-
-        return self.column(key)
-
-    # ----------------------------------------------------------------------
-    def __dataframe__(self, nan_as_null: bool = False, allow_copy: bool = True):
-        """
-        Return the dataframe interchange object implementing the interchange protocol.
-        Parameters
-        ----------
-        nan_as_null : bool, default False
-            Whether to tell the DataFrame to overwrite null values in the data
-            with ``NaN`` (or ``NaT``).
-        allow_copy : bool, default True
-            Whether to allow memory copying when exporting. If set to False
-            it would cause non-zero-copy exports to fail.
-        Returns
-        -------
-        DataFrame interchange object
-            The object which consuming library can use to ingress the dataframe.
-        Notes
-        -----
-        Details on the interchange protocol:
-        https://data-apis.org/dataframe-protocol/latest/index.html
-        `nan_as_null` currently has no effect; once support for nullable extension
-        dtypes is added, this value should be propagated to columns.
-        """
-
-        from pyarrow.interchange.dataframe import _PyArrowDataFrame
-
-        return _PyArrowDataFrame(self, nan_as_null, allow_copy)
-
-    # ----------------------------------------------------------------------
-
     def slice(self, offset=0, length=None):
         """
         Compute zero-copy slice of this Table.
@@ -3492,12 +3463,6 @@ cdef class Table(_Tabular):
                 deref(self.table), pool))
 
         return pyarrow_wrap_table(c_result)
-
-    def __eq__(self, other):
-        try:
-            return self.equals(other)
-        except TypeError:
-            return NotImplemented
 
     def equals(self, Table other, bint check_metadata=False):
         """
@@ -4190,102 +4155,6 @@ cdef class Table(_Tabular):
         """
         return pyarrow_wrap_schema(self.table.schema())
 
-    def field(self, i):
-        """
-        Select a schema field by its column name or numeric index.
-
-        Parameters
-        ----------
-        i : int or string
-            The index or name of the field to retrieve.
-
-        Returns
-        -------
-        Field
-
-        Examples
-        --------
-        >>> import pyarrow as pa
-        >>> import pandas as pd
-        >>> df = pd.DataFrame({'n_legs': [2, 4, 5, 100],
-        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
-        >>> table = pa.Table.from_pandas(df)
-        >>> table.field(0)
-        pyarrow.Field<n_legs: int64>
-        >>> table.field(1)
-        pyarrow.Field<animals: string>
-        """
-        return self.schema.field(i)
-
-    def _ensure_integer_index(self, i):
-        """
-        Ensure integer index (convert string column name to integer if needed).
-        """
-        if isinstance(i, (bytes, str)):
-            field_indices = self.schema.get_all_field_indices(i)
-
-            if len(field_indices) == 0:
-                raise KeyError("Field \"{}\" does not exist in table schema"
-                               .format(i))
-            elif len(field_indices) > 1:
-                raise KeyError("Field \"{}\" exists {} times in table schema"
-                               .format(i, len(field_indices)))
-            else:
-                return field_indices[0]
-        elif isinstance(i, int):
-            return i
-        else:
-            raise TypeError("Index must either be string or integer")
-
-    def column(self, i):
-        """
-        Select a column by its column name, or numeric index.
-
-        Parameters
-        ----------
-        i : int or string
-            The index or name of the column to retrieve.
-
-        Returns
-        -------
-        ChunkedArray
-
-        Examples
-        --------
-        >>> import pyarrow as pa
-        >>> import pandas as pd
-        >>> df = pd.DataFrame({'n_legs': [2, 4, 5, 100],
-        ...                    'animals': ["Flamingo", "Horse", "Brittle stars", "Centipede"]})
-        >>> table = pa.Table.from_pandas(df)
-
-        Select a column by numeric index:
-
-        >>> table.column(0)
-        <pyarrow.lib.ChunkedArray object at ...>
-        [
-          [
-            2,
-            4,
-            5,
-            100
-          ]
-        ]
-
-        Select a column by its name:
-
-        >>> table.column("animals")
-        <pyarrow.lib.ChunkedArray object at ...>
-        [
-          [
-            "Flamingo",
-            "Horse",
-            "Brittle stars",
-            "Centipede"
-          ]
-        ]
-        """
-        return self._column(self._ensure_integer_index(i))
-
     def _column(self, int i):
         """
         Select a column by its numeric index.
@@ -4885,54 +4754,6 @@ cdef class Table(_Tabular):
         n_legs_sum: [[2,6,104,5]]
         """
         return TableGroupBy(self, keys)
-
-    def sort_by(self, sorting, **kwargs):
-        """
-        Sort the table by one or multiple columns.
-
-        Parameters
-        ----------
-        sorting : str or list[tuple(name, order)]
-            Name of the column to use to sort (ascending), or
-            a list of multiple sorting conditions where
-            each entry is a tuple with column name
-            and sorting order ("ascending" or "descending")
-        **kwargs : dict, optional
-            Additional sorting options.
-            As allowed by :class:`SortOptions`
-
-        Returns
-        -------
-        Table
-            A new table sorted according to the sort keys.
-
-        Examples
-        --------
-        >>> import pandas as pd
-        >>> import pyarrow as pa
-        >>> df = pd.DataFrame({'year': [2020, 2022, 2021, 2022, 2019, 2021],
-        ...                    'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                    'animal': ["Flamingo", "Parrot", "Dog", "Horse",
-        ...                    "Brittle stars", "Centipede"]})
-        >>> table = pa.Table.from_pandas(df)
-        >>> table.sort_by('animal')
-        pyarrow.Table
-        year: int64
-        n_legs: int64
-        animal: string
-        ----
-        year: [[2019,2021,2021,2020,2022,2022]]
-        n_legs: [[5,100,4,2,4,2]]
-        animal: [["Brittle stars","Centipede","Dog","Flamingo","Horse","Parrot"]]
-        """
-        if isinstance(sorting, str):
-            sorting = [(sorting, "ascending")]
-
-        indices = _pc().sort_indices(
-            self,
-            options=_pc().SortOptions(sort_keys=sorting, **kwargs)
-        )
-        return self.take(indices)
 
     def join(self, right_table, keys, right_keys=None, join_type="left outer",
              left_suffix=None, right_suffix=None, coalesce_keys=True,

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -690,7 +690,7 @@ def test_recordbatch_select_column():
     assert batch.column('a').equals(batch.column(0))
 
     with pytest.raises(
-            KeyError, match='Field "d" does not exist in record batch schema'):
+            KeyError, match='Field "d" does not exist in schema'):
         batch.column('d')
 
     with pytest.raises(TypeError):
@@ -1042,7 +1042,7 @@ def test_table_select_column():
     assert table.column('a').equals(table.column(0))
 
     with pytest.raises(KeyError,
-                       match='Field "d" does not exist in table schema'):
+                       match='Field "d" does not exist in schema'):
         table.column('d')
 
     with pytest.raises(TypeError):
@@ -1059,7 +1059,7 @@ def test_table_column_with_duplicates():
                       pa.array([7, 8, 9])], names=['a', 'b', 'a'])
 
     with pytest.raises(KeyError,
-                       match='Field "a" exists 2 times in table schema'):
+                       match='Field "a" exists 2 times in schema'):
         table.column('a')
 
 


### PR DESCRIPTION
### Rationale for this change

Table and RecordBatch share many similar/identical APIs. Let's start consolidating them into the parent class. This diff refactors:

`__dataframe__`
`__eq__`
`__getitem__`
`_ensure_integer_index`
`column`
`columns`
`field`
`sort_by`

### Are these changes tested?

Relying on existing test cases for this refactor.

### Are there any user-facing changes?

No
* Closes: #35390