### PR TITLE
GH-35404: [Docs] Fix logo url and temporarily pin sphinx to 5.x to 

### DIFF
--- a/ci/conda_env_sphinx.txt
+++ b/ci/conda_env_sphinx.txt
@@ -22,7 +22,7 @@ ipython
 numpydoc
 pydata-sphinx-theme==0.8
 sphinx-design
-sphinx>=4.2
+sphinx>=4.2,<6
 sphinx-copybutton
 # Requirement for doctest-cython
 pytest-cython

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,5 +8,5 @@ numpydoc
 pydata-sphinx-theme==0.8
 sphinx-design
 sphinx-copybutton
-sphinx>=4.2
+sphinx>=4.2,<6
 pandas

--- a/docs/source/_templates/docs-sidebar.html
+++ b/docs/source/_templates/docs-sidebar.html
@@ -1,6 +1,6 @@
 
 <a class="navbar-brand" href="{{ pathto(master_doc) }}">
-  <img src="{{ pathto('_static/' + logo_url, 1) }}" class="logo" alt="logo">
+  <img src="{{ logo_url|e }}" class="logo" alt="logo">
 </a>
 
 <div id="version-search-wrapper">


### PR DESCRIPTION
See https://github.com/apache/arrow/issues/35403 about requiring some fixes on our side to support sphinx 6. Until then, let's pin sphinx to <6.

* Closes: #35404
* Closes: #35406