### PR TITLE
GH-35410: [CI] Pin urllib3 for gcs testbench

### DIFF
--- a/ci/scripts/install_gcs_testbench.sh
+++ b/ci/scripts/install_gcs_testbench.sh
@@ -40,5 +40,5 @@ if [[ "${version}" -eq "default" ]]; then
 fi
 
 ${PYTHON:-python3} -m pip install \
-  "urllib3<2" \
+  "requests-toolbelt>=1" \
   "https://github.com/googleapis/storage-testbench/archive/${version}.tar.gz"

--- a/ci/scripts/install_gcs_testbench.sh
+++ b/ci/scripts/install_gcs_testbench.sh
@@ -40,5 +40,5 @@ if [[ "${version}" -eq "default" ]]; then
 fi
 
 ${PYTHON:-python3} -m pip install \
-  "requests-toolbelt>=1" \
+  "urllib3<2" \
   "https://github.com/googleapis/storage-testbench/archive/${version}.tar.gz"

--- a/ci/scripts/install_gcs_testbench.sh
+++ b/ci/scripts/install_gcs_testbench.sh
@@ -40,5 +40,5 @@ if [[ "${version}" -eq "default" ]]; then
 fi
 
 ${PYTHON:-python3} -m pip install \
-  "urllib3<2"
+  "urllib3<2" \
   "https://github.com/googleapis/storage-testbench/archive/${version}.tar.gz"

--- a/ci/scripts/install_gcs_testbench.sh
+++ b/ci/scripts/install_gcs_testbench.sh
@@ -40,4 +40,5 @@ if [[ "${version}" -eq "default" ]]; then
 fi
 
 ${PYTHON:-python3} -m pip install \
+  "urllib<2"
   "https://github.com/googleapis/storage-testbench/archive/${version}.tar.gz"

--- a/ci/scripts/install_gcs_testbench.sh
+++ b/ci/scripts/install_gcs_testbench.sh
@@ -40,5 +40,5 @@ if [[ "${version}" -eq "default" ]]; then
 fi
 
 ${PYTHON:-python3} -m pip install \
-  "urllib<2"
+  "urllib3<2"
   "https://github.com/googleapis/storage-testbench/archive/${version}.tar.gz"


### PR DESCRIPTION
### Rationale for this change

gcs-toolbench's latest release currently pins requests-toolbelt to 0.10.0 which is not compatible with urllib >= 2.0.  Until there is a new release of gcs-toolbench I think we need to pin urllib to be < 2.0.

### What changes are included in this PR?

A change to the install_gcs_toolbench.sh script that pins urllib to < 2.

### Are these changes tested?

Yes, CI uses this script today.

### Are there any user-facing changes?

No
* Closes: #35410