### PR TITLE
MINOR: [C++] Use [] instead of exception-throwing at(i) in concatenate.cc

### DIFF
--- a/cpp/src/arrow/array/concatenate.cc
+++ b/cpp/src/arrow/array/concatenate.cc
@@ -125,9 +125,9 @@ Status ConcatenateOffsets(const BufferVector& buffers, MemoryPool* pool,
     // the first offset from buffers[i] will be adjusted to values_length
     // (the cumulative length of values spanned by offsets in previous buffers)
     RETURN_NOT_OK(PutOffsets<Offset>(buffers[i], values_length, &dst[elements_length],
-                                     &values_ranges->at(i)));
+                                     &(*values_ranges)[i]));
     elements_length += buffers[i]->size() / sizeof(Offset);
-    values_length += static_cast<Offset>(values_ranges->at(i).length);
+    values_length += static_cast<Offset>((*values_ranges)[i].length);
   }
 
   // the final element in dst is the length of all values spanned by the offsets


### PR DESCRIPTION
### Rationale for this change

`vector::at` performs bounds checking and can throw an exception [1]. Its use is discouraged and in this specific case, the access is provably safe because array is previously resized to `buffers.size()`.

[1] https://en.cppreference.com/w/cpp/container/vector/at

### What changes are included in this PR?

Use of `operator[]` instead of `at()`.

### Are these changes tested?

By the existing concatenation tests.