### PR TITLE
GH-35099: [CI][Packaging] Upgrade vcpkg to 2023.04.15 Release

### DIFF
--- a/.env
+++ b/.env
@@ -96,8 +96,7 @@ DEVTOOLSET_VERSION=
 # Please also update the crossbow configuration in order to keep the github
 # actions cache up to date for the macOS wheels:
 #   https://github.com/ursacomputing/crossbow/blob/master/.github/workflows/cache_vcpkg.yml
-# TODO: Update to an official release tag https://github.com/apache/arrow/issues/35099
-VCPKG="b619a233fbf7b2c9765fb4458f3ecb05bd3166e3"    # 2023.04.03
+VCPKG="501db0f17ef6df184fcdbfbe0f87cde2313b6ab1"    # 2023.04.15 Release
 
 # This must be updated when we update
 # ci/docker/python-wheel-windows-vs2017.dockerfile.

--- a/.env
+++ b/.env
@@ -92,10 +92,6 @@ DEVTOOLSET_VERSION=
 # Used through docker-compose.yml and serves as the default version for the
 # ci/scripts/install_vcpkg.sh script. Prefer to use short SHAs to keep the
 # docker tags more readable.
-#
-# Please also update the crossbow configuration in order to keep the github
-# actions cache up to date for the macOS wheels:
-#   https://github.com/ursacomputing/crossbow/blob/master/.github/workflows/cache_vcpkg.yml
 VCPKG="501db0f17ef6df184fcdbfbe0f87cde2313b6ab1"    # 2023.04.15 Release
 
 # This must be updated when we update

--- a/ci/vcpkg/ports.patch
+++ b/ci/vcpkg/ports.patch
@@ -49,18 +49,5 @@ index 0000000000..a57ce0c22f
 +   return v & ~(mask << (8 * n));
 +-#endif
 + }
-+ 
++
 + static inline bool LeftShiftOverflows(uint8_t value, uint32_t shift) {
-diff --git a/scripts/cmake/vcpkg_find_acquire_program.cmake b/scripts/cmake/vcpkg_find_acquire_program.cmake
-index 4611af6..d11936f 100644
---- a/scripts/cmake/vcpkg_find_acquire_program.cmake
-+++ b/scripts/cmake/vcpkg_find_acquire_program.cmake
-@@ -239,7 +239,7 @@ function(vcpkg_find_acquire_program program)
-             set(paths_to_search "${DOWNLOADS}/tools/python/${tool_subdirectory}")
-             vcpkg_list(SET post_install_command "${CMAKE_COMMAND}" -E rm python310._pth)
-         else()
--            set(program_name python3)
-+            set(program_name python)
-             set(brew_package_name "python")
-             set(apt_package_name "python3")
-         endif()


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

- https://github.com/apache/arrow/pull/34818 pinned vcpkg to a non-release master branch commit.
- This was to include unreleased changes, specifically https://github.com/microsoft/vcpkg/issues/29674.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This pins vcpkg to the official 2023.04.15 release (commit https://github.com/microsoft/vcpkg/commit/501db0f17ef6df184fcdbfbe0f87cde2313b6ab1)

### Are these changes tested?

I've successfully test that the following local wheel builds succeed:

```bash
$ ARCH=amd64 PYTHON=3.10 archery docker run python-wheel-manylinux-2014
$ ARCH=amd64 PYTHON=3.10 archery docker run python-wheel-manylinux-2-28
```

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

I don't believe so

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #35099