### PR TITLE
GH-35433: [CI] Unpin urllib3, upgrade gcs-testbench

### DIFF
--- a/ci/scripts/install_gcs_testbench.sh
+++ b/ci/scripts/install_gcs_testbench.sh
@@ -36,9 +36,8 @@ esac
 
 version=$1
 if [[ "${version}" -eq "default" ]]; then
-  version="v0.32.0"
+  version="v0.36.0"
 fi
 
 ${PYTHON:-python3} -m pip install \
-  "urllib3<2" \
   "https://github.com/googleapis/storage-testbench/archive/${version}.tar.gz"


### PR DESCRIPTION
### Rationale for this change

We only pinned urllib3 as a stop-gap.  Now that a release is out we don't need it.

### What changes are included in this PR?

We unpin urllib3 and upgrade gcs-testbench to the latest version

### Are these changes tested?

Yes, through CI tests that use gcs-testbench

### Are there any user-facing changes?

No
* Closes: #35433