### PR TITLE
GH-35435: [Ruby][Flight] Add ArrowFlight::Client#authenticate_basic

### DIFF
--- a/ruby/red-arrow-flight/lib/arrow-flight/client.rb
+++ b/ruby/red-arrow-flight/lib/arrow-flight/client.rb
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module ArrowFlight
+  class Client
+    # Authenticates by Basic authentication.
+    #
+    # @param user [String] User name to be used.
+    # @param password [String] Password to be used.
+    # @param options [ArrowFlight::CallOptions, Hash, nil] (nil)
+    #   The options to be used.
+    #
+    # @return [ArrowFlight::CallOptions] The options that can be used
+    #   for following calls. It includes Bearer token for @user.
+    #
+    #   If @options is an ArrowFlight::CallOptions, the given @options
+    #   is returned with Bearer token.
+    #
+    #   If @options isn't an ArrowFlight::CallOptions, a new
+    #   ArrowFlight::CallOptions is created and it's returned.
+    #
+    # @since 13.0.0
+    def authenticate_basic(user, password, options=nil)
+      unless options.is_a?(CallOptions)
+        options = CallOptions.try_convert(options)
+      end
+      options ||= CallOptions.new
+      _success, bearer_name, bearer_value =
+        authenticate_basic_token(user, password, options)
+      invalid_bearer = (bearer_name.empty? or bearer_value.empty?)
+      unless invalid_bearer
+        options.add_header(bearer_name, bearer_value)
+      end
+      options
+    end
+  end
+end

--- a/ruby/red-arrow-flight/lib/arrow-flight/loader.rb
+++ b/ruby/red-arrow-flight/lib/arrow-flight/loader.rb
@@ -30,6 +30,7 @@ module ArrowFlight
 
     def require_libraries
       require "arrow-flight/call-options"
+      require "arrow-flight/client"
       require "arrow-flight/client-options"
       require "arrow-flight/location"
       require "arrow-flight/record-batch-reader"


### PR DESCRIPTION
### Rationale for this change

`ArrowFlight::Client#authenticate_basic_token` is inconvenient because users need to set a returned Bearer token manually.

### What changes are included in this PR?

Adds a convenient method for a common Basic authentication use case.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #35435