### PR TITLE
GH-35201: [C++][Gandiva] Add a Secondary Cache to cache gandiva object code

### DIFF
--- a/cpp/src/gandiva/cache.h
+++ b/cpp/src/gandiva/cache.h
@@ -50,6 +50,11 @@ class Cache {
     cache_.insert(cache_key, module);
   }
 
+  void Clear() {
+    std::lock_guard<std::mutex> lock(mtx_);
+    cache_.clear();
+  }
+
  private:
   LruCache<KeyType, ValueType> cache_;
   std::mutex mtx_;

--- a/cpp/src/gandiva/engine.cc
+++ b/cpp/src/gandiva/engine.cc
@@ -88,6 +88,7 @@ std::once_flag llvm_init_once_flag;
 static bool llvm_init = false;
 static llvm::StringRef cpu_name;
 static llvm::SmallVector<std::string, 10> cpu_attrs;
+static char* cpu_details_;
 
 void Engine::InitOnce() {
   DCHECK_EQ(llvm_init, false);
@@ -111,7 +112,18 @@ void Engine::InitOnce() {
   }
   ARROW_LOG(INFO) << "Detected CPU Name : " << cpu_name.str();
   ARROW_LOG(INFO) << "Detected CPU Features:" << cpu_attrs_str;
+
+  std::string cpu_details = cpu_name.str();
+  cpu_details += cpu_attrs_str;
+  cpu_details_ = strdup(cpu_details.c_str());
+
   llvm_init = true;
+}
+
+char* Engine::GetCpuIdentifier() {
+  DCHECK_EQ(llvm_init, true);
+
+  return cpu_details_;
 }
 
 Engine::Engine(const std::shared_ptr<Configuration>& conf,

--- a/cpp/src/gandiva/engine.h
+++ b/cpp/src/gandiva/engine.h
@@ -76,6 +76,8 @@ class GANDIVA_EXPORT Engine {
   /// Load the function IRs that can be accessed in the module.
   Status LoadFunctionIRs();
 
+  static char* GetCpuIdentifier();
+
  private:
   Engine(const std::shared_ptr<Configuration>& conf,
          std::unique_ptr<llvm::LLVMContext> ctx,

--- a/cpp/src/gandiva/expression_cache_key.h
+++ b/cpp/src/gandiva/expression_cache_key.h
@@ -19,6 +19,7 @@
 
 #include <stddef.h>
 
+#include <sstream>
 #include <thread>
 
 #include "arrow/util/hash_util.h"
@@ -108,6 +109,18 @@ class ExpressionCacheKey {
   }
 
   bool operator!=(const ExpressionCacheKey& other) const { return !(*this == other); }
+
+  std::string ToString() {
+      std::stringstream s;
+
+      s << schema_->ToString() << "\n";
+      s << mode_ << configuration_->Hash() << uniqifier_ << "\n";
+      for (std::string expr : expressions_as_strings_) {
+        s << expr << "\n";
+      }
+
+      return s.str();
+    }
 
  private:
   size_t hash_code_;

--- a/cpp/src/gandiva/filter.h
+++ b/cpp/src/gandiva/filter.h
@@ -27,6 +27,7 @@
 #include "gandiva/arrow.h"
 #include "gandiva/condition.h"
 #include "gandiva/configuration.h"
+#include "gandiva/secondary_cache.h"
 #include "gandiva/selection_vector.h"
 #include "gandiva/visibility.h"
 
@@ -68,6 +69,19 @@ class GANDIVA_EXPORT Filter {
                      std::shared_ptr<Configuration> config,
                      std::shared_ptr<Filter>* filter);
 
+  /// \brief Build a filter for the given schema and condition.
+  /// Customize the filter with runtime configuration.
+  ///
+  /// \param[in] schema schema for the record batches, and the condition.
+  /// \param[in] condition filter conditions.
+  /// \param[in] config run time configuration.
+  /// \param[in] sec_cache object to enable jni upcalls.
+  /// \param[out] filter the returned filter object
+  static Status Make(SchemaPtr schema, ConditionPtr condition,
+                     std::shared_ptr<Configuration> config,
+                     std::shared_ptr<SecondaryCacheInterface> sec_cache,
+                     std::shared_ptr<Filter>* filter);
+
   /// Evaluate the specified record batch, and populate output selection vector.
   ///
   /// \param[in] batch the record batch. schema should be the same as the one in 'Make'
@@ -82,7 +96,12 @@ class GANDIVA_EXPORT Filter {
 
   bool GetBuiltFromCache();
 
+  void Clear();
+
  private:
+   // Create an arrow buffer with the key for the secondary cache.
+   static std::shared_ptr<arrow::Buffer> GetSecondaryCacheKey(std::string primaryKey);
+
   std::unique_ptr<LLVMGenerator> llvm_generator_;
   SchemaPtr schema_;
   std::shared_ptr<Configuration> configuration_;

--- a/cpp/src/gandiva/projector.cc
+++ b/cpp/src/gandiva/projector.cc
@@ -56,6 +56,23 @@ Status Projector::Make(SchemaPtr schema, const ExpressionVector& exprs,
                        SelectionVector::Mode selection_vector_mode,
                        std::shared_ptr<Configuration> configuration,
                        std::shared_ptr<Projector>* projector) {
+  return Projector::Make(schema, exprs, selection_vector_mode, configuration, nullptr,
+                         projector);
+}
+
+Status Projector::Make(SchemaPtr schema, const ExpressionVector& exprs,
+                       std::shared_ptr<Configuration> configuration,
+                       std::shared_ptr<SecondaryCacheInterface> sec_cache,
+                       std::shared_ptr<Projector>* projector) {
+  return Projector::Make(schema, exprs, SelectionVector::Mode::MODE_NONE, configuration,
+                         sec_cache, projector);
+}
+
+Status Projector::Make(SchemaPtr schema, const ExpressionVector& exprs,
+                       SelectionVector::Mode selection_vector_mode,
+                       std::shared_ptr<Configuration> configuration,
+                       std::shared_ptr<SecondaryCacheInterface> sec_cache,
+                       std::shared_ptr<Projector>* projector) {
   ARROW_RETURN_IF(schema == nullptr, Status::Invalid("Schema cannot be null"));
   ARROW_RETURN_IF(exprs.empty(), Status::Invalid("Expressions cannot be empty"));
   ARROW_RETURN_IF(configuration == nullptr,
@@ -83,6 +100,20 @@ Status Projector::Make(SchemaPtr schema, const ExpressionVector& exprs,
   std::unique_ptr<LLVMGenerator> llvm_gen;
   ARROW_RETURN_NOT_OK(LLVMGenerator::Make(configuration, is_cached, &llvm_gen));
 
+  if (!is_cached && sec_cache != nullptr) {
+    std::shared_ptr<arrow::Buffer> arrow_buffer =
+        sec_cache->Get(GetSecondaryCacheKey(cache_key.ToString()));
+    if (arrow_buffer != nullptr) {
+      is_cached = true;
+      llvm::StringRef string_buffer(reinterpret_cast<char*>(arrow_buffer->address()),
+                                    arrow_buffer->size());
+      std::unique_ptr<llvm::MemoryBuffer> obj_buffer =
+          llvm::MemoryBuffer::getMemBufferCopy(string_buffer);
+      std::shared_ptr<llvm::MemoryBuffer> sec_cached_obj = std::move(obj_buffer);
+      cache->PutObjectCode(cache_key, sec_cached_obj);
+    }
+  }
+
   // Run the validation on the expressions.
   // Return if any of the expression is invalid since
   // we will not be able to process further.
@@ -109,6 +140,13 @@ Status Projector::Make(SchemaPtr schema, const ExpressionVector& exprs,
   *projector = std::shared_ptr<Projector>(
       new Projector(std::move(llvm_gen), schema, output_fields, configuration));
   projector->get()->SetBuiltFromCache(is_cached);
+
+  if (sec_cache != nullptr && is_cached == false) {
+    std::shared_ptr<llvm::MemoryBuffer> sec_cached_obj = cache->GetObjectCode(cache_key);
+    llvm::StringRef string_buffer = sec_cached_obj->getBuffer();
+    std::shared_ptr<arrow::Buffer> arrow_buffer =
+        arrow::Buffer::FromString(string_buffer.str());
+    sec_cache->Set(GetSecondaryCacheKey(cache_key.ToString()), arrow_buffer);
 
   return Status::OK();
 }
@@ -285,5 +323,19 @@ std::string Projector::DumpIR() { return llvm_generator_->DumpIR(); }
 void Projector::SetBuiltFromCache(bool flag) { built_from_cache_ = flag; }
 
 bool Projector::GetBuiltFromCache() { return built_from_cache_; }
+
+// added method for testing the secondary cache
+void Projector::Clear() {
+  std::shared_ptr<Cache<ExpressionCacheKey, std::shared_ptr<llvm::MemoryBuffer>>> cache =
+      LLVMGenerator::GetCache();
+  cache->Clear();
+}
+
+std::shared_ptr<arrow::Buffer> Projector::GetSecondaryCacheKey(std::string primaryKey) {
+  // compute key from primary key and cpu attributes
+  // cpu attributes are required as the compiled code depends on the cpu type and features
+  std::string key = std::string(Engine::GetCpuIdentifier()) + " | " + primaryKey;
+  return arrow::Buffer::FromString(key);
+}
 
 }  // namespace gandiva

--- a/cpp/src/gandiva/secondary_cache.h
+++ b/cpp/src/gandiva/secondary_cache.h
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "arrow/buffer.h"
+
+namespace gandiva {
+
+// secondary cache c++ interface
+class GANDIVA_EXPORT SecondaryCacheInterface {
+ public:
+  virtual std::shared_ptr<arrow::Buffer> Get(
+      std::shared_ptr<arrow::Buffer> serialized_expr) = 0;
+
+  virtual void Set(std::shared_ptr<arrow::Buffer> serialized_expr,
+                   std::shared_ptr<arrow::Buffer> value) = 0;
+
+  virtual ~SecondaryCacheInterface() {}
+};
+
+}  // namespace gandiva

--- a/cpp/src/gandiva/tests/CMakeLists.txt
+++ b/cpp/src/gandiva/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ add_gandiva_test(null_validity_test)
 add_gandiva_test(decimal_test)
 add_gandiva_test(decimal_single_test)
 add_gandiva_test(filter_project_test)
+add_gandiva_test(secondary_cache_test)
 
 if(ARROW_BUILD_STATIC)
   add_gandiva_test(projector_test_static SOURCES projector_test.cc USE_STATIC_LINKING)

--- a/cpp/src/gandiva/tests/secondary_cache_test.cc
+++ b/cpp/src/gandiva/tests/secondary_cache_test.cc
@@ -1,0 +1,222 @@
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#include "gandiva/filter.h"
+#include "gandiva/projector.h"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include "arrow/memory_pool.h"
+#include "gandiva/literal_holder.h"
+#include "gandiva/node.h"
+#include "gandiva/tests/test_util.h"
+#include "gandiva/tree_expr_builder.h"
+
+namespace gandiva {
+
+using arrow::boolean;
+using arrow::float32;
+using arrow::int32;
+using arrow::int64;
+using arrow::utf8;
+
+// compare the string representation of the arrow buffers
+struct compare {
+  bool operator()(const std::shared_ptr<arrow::Buffer>& lhs,
+                  const std::shared_ptr<arrow::Buffer>& rhs) const {
+    return lhs->ToString().compare(rhs->ToString()) < 0;
+  }
+};
+
+class SecondaryCache : public SecondaryCacheInterface {
+ public:
+  std::shared_ptr<arrow::Buffer> Get(std::shared_ptr<arrow::Buffer> key) {
+    auto it = cache.find(key);
+    if (it != cache.end()) {
+      return it->second;
+    }
+    return nullptr;
+  }
+
+  void Set(std::shared_ptr<arrow::Buffer> key, std::shared_ptr<arrow::Buffer> value) {
+    cache[key] = value;
+  }
+
+ private:
+  std::map<std::shared_ptr<arrow::Buffer>, std::shared_ptr<arrow::Buffer>, compare> cache;
+};
+
+class TestSecondaryCache : public ::testing::Test {
+ public:
+  void SetUp() {
+    pool_ = arrow::default_memory_pool();
+    sec_cache_ = std::make_shared<SecondaryCache>();
+    // Setup arrow log severity threshold to debug level.
+    arrow::util::ArrowLog::StartArrowLog("", arrow::util::ArrowLogLevel::ARROW_DEBUG);
+  }
+
+ protected:
+  arrow::MemoryPool* pool_;
+  std::shared_ptr<SecondaryCache> sec_cache_;
+};
+
+TEST_F(TestSecondaryCache, TestProjectSecCache) {
+  // schema for input fields
+  auto field0 = field("f0", int32());
+  auto field1 = field("f2", int32());
+  auto schema = arrow::schema({field0, field1});
+
+  // output fields
+  auto field_sum = field("add", int32());
+  auto field_sub = field("subtract", int32());
+
+  // Build expression
+  auto sum_expr = TreeExprBuilder::MakeExpression("add", {field0, field1}, field_sum);
+  auto sub_expr =
+      TreeExprBuilder::MakeExpression("subtract", {field0, field1}, field_sub);
+
+  auto configuration = TestConfiguration();
+
+  std::shared_ptr<Projector> projector;
+  auto status = Projector::Make(schema, {sum_expr, sub_expr}, configuration, sec_cache_,
+                                &projector);
+  ASSERT_OK(status);
+  EXPECT_FALSE(projector->GetBuiltFromCache());
+  projector->Clear();
+
+  // everything is same, should return the same projector.
+  auto schema_same = arrow::schema({field0, field1});
+  std::shared_ptr<Projector> cached_projector;
+  status = Projector::Make(schema_same, {sum_expr, sub_expr}, configuration, sec_cache_,
+                           &cached_projector);
+  ASSERT_OK(status);
+  EXPECT_TRUE(cached_projector->GetBuiltFromCache());
+  cached_projector->Clear();
+
+  // schema is different should return a new projector.
+  auto field2 = field("f2", int32());
+  auto different_schema = arrow::schema({field0, field1, field2});
+  std::shared_ptr<Projector> should_be_new_projector;
+  status = Projector::Make(different_schema, {sum_expr, sub_expr}, configuration,
+                           sec_cache_, &should_be_new_projector);
+  ASSERT_OK(status);
+  EXPECT_FALSE(should_be_new_projector->GetBuiltFromCache());
+  should_be_new_projector->Clear();
+
+  // expression list is different should return a new projector.
+  std::shared_ptr<Projector> should_be_new_projector1;
+  status = Projector::Make(schema, {sum_expr}, configuration, sec_cache_,
+                           &should_be_new_projector1);
+  ASSERT_OK(status);
+  EXPECT_FALSE(should_be_new_projector1->GetBuiltFromCache());
+  should_be_new_projector1->Clear();
+
+  // another instance of the same configuration, should return the same projector.
+  status = Projector::Make(schema, {sum_expr, sub_expr}, TestConfiguration(), sec_cache_,
+                           &cached_projector);
+  ASSERT_OK(status);
+  EXPECT_TRUE(cached_projector->GetBuiltFromCache());
+}
+
+TEST_F(TestSecondaryCache, TestProjectCacheDecimalCast) {
+  auto field_float64 = field("float64", arrow::float64());
+  auto schema = arrow::schema({field_float64});
+
+  auto res_31_13 = field("result", arrow::decimal(31, 13));
+  auto expr0 = TreeExprBuilder::MakeExpression("castDECIMAL", {field_float64}, res_31_13);
+  std::shared_ptr<Projector> projector0;
+  ASSERT_OK(
+      Projector::Make(schema, {expr0}, TestConfiguration(), sec_cache_, &projector0));
+  EXPECT_FALSE(projector0->GetBuiltFromCache());
+  projector0->Clear();
+
+  // if the output scale is different, the cache can't be used.
+  auto res_31_14 = field("result", arrow::decimal(31, 14));
+  auto expr1 = TreeExprBuilder::MakeExpression("castDECIMAL", {field_float64}, res_31_14);
+  std::shared_ptr<Projector> projector1;
+  ASSERT_OK(
+      Projector::Make(schema, {expr1}, TestConfiguration(), sec_cache_, &projector1));
+  EXPECT_FALSE(projector1->GetBuiltFromCache());
+  projector1->Clear();
+
+  // if the output scale/precision are same, should get a cache hit.
+  auto res_31_13_alt = field("result", arrow::decimal(31, 13));
+  auto expr2 =
+      TreeExprBuilder::MakeExpression("castDECIMAL", {field_float64}, res_31_13_alt);
+  std::shared_ptr<Projector> projector2;
+  ASSERT_OK(
+      Projector::Make(schema, {expr2}, TestConfiguration(), sec_cache_, &projector2));
+  EXPECT_TRUE(projector2->GetBuiltFromCache());
+}
+
+TEST_F(TestSecondaryCache, TestFilterCache) {
+  // schema for input fields
+  auto field0 = field("f0", int32());
+  auto field1 = field("f1", int32());
+  auto schema = arrow::schema({field0, field1});
+
+  // Build condition f0 + f1 < 10
+  auto node_f0 = TreeExprBuilder::MakeField(field0);
+  auto node_f1 = TreeExprBuilder::MakeField(field1);
+  auto sum_func =
+      TreeExprBuilder::MakeFunction("add", {node_f0, node_f1}, arrow::int32());
+  auto literal_10 = TreeExprBuilder::MakeLiteral((int32_t)10);
+  auto less_than_10 = TreeExprBuilder::MakeFunction("less_than", {sum_func, literal_10},
+                                                    arrow::boolean());
+  auto condition = TreeExprBuilder::MakeCondition(less_than_10);
+  auto configuration = TestConfiguration();
+
+  std::shared_ptr<Filter> filter;
+  auto status = Filter::Make(schema, condition, configuration, sec_cache_, &filter);
+  EXPECT_TRUE(status.ok());
+  EXPECT_FALSE(filter->GetBuiltFromCache());
+  filter->Clear();
+
+  // same schema and condition, should return the same filter as above.
+  std::shared_ptr<Filter> cached_filter;
+  status = Filter::Make(schema, condition, configuration, sec_cache_, &cached_filter);
+  EXPECT_TRUE(status.ok());
+  EXPECT_TRUE(cached_filter->GetBuiltFromCache());
+  cached_filter->Clear();
+
+  // schema is different should return a new filter.
+  auto field2 = field("f2", int32());
+  auto different_schema = arrow::schema({field0, field1, field2});
+  std::shared_ptr<Filter> should_be_new_filter;
+  status = Filter::Make(different_schema, condition, configuration, sec_cache_,
+                        &should_be_new_filter);
+  EXPECT_TRUE(status.ok());
+  EXPECT_FALSE(should_be_new_filter->GetBuiltFromCache());
+
+  // condition is different, should return a new filter.
+  auto greater_than_10 = TreeExprBuilder::MakeFunction(
+      "greater_than", {sum_func, literal_10}, arrow::boolean());
+  auto new_condition = TreeExprBuilder::MakeCondition(greater_than_10);
+  std::shared_ptr<Filter> should_be_new_filter1;
+  status = Filter::Make(schema, new_condition, configuration, sec_cache_,
+                        &should_be_new_filter1);
+  EXPECT_TRUE(status.ok());
+  EXPECT_FALSE(should_be_new_filter->GetBuiltFromCache());
+}
+}  // namespace gandiva

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/Filter.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/Filter.java
@@ -82,6 +82,23 @@ public class Filter {
     return make(schema, condition, JniLoader.getConfiguration(configOptions));
   }
 
+
+  /**
+   * Invoke this function to generate LLVM code to evaluate the condition expression. Invoke
+   * Filter::Evaluate() against a RecordBatch to evaluate the filter on this record batch
+   *
+   * @param schema Table schema. The field names in the schema should match the fields used to
+   *               create the TreeNodes
+   * @param condition condition to be evaluated against data
+   * @param configOptions ConfigOptions parameter
+   * @param secondaryCache  SecondaryCache cache for gandiva object code.
+   * @return A native filter object that can be used to invoke on a RecordBatch
+   */
+  public static Filter make(Schema schema, Condition condition, ConfigurationBuilder.ConfigOptions configOptions,
+                            JavaSecondaryCacheInterface secondaryCache) throws GandivaException {
+    return make(schema, condition, JniLoader.getConfiguration(configOptions), secondaryCache);
+  }
+
   /**
    * Invoke this function to generate LLVM code to evaluate the condition expression. Invoke
    * Filter::Evaluate() against a RecordBatch to evaluate the filter on this record batch
@@ -110,11 +127,31 @@ public class Filter {
    */
   public static Filter make(Schema schema, Condition condition, long configurationId)
       throws GandivaException {
+    return make(schema, condition, configurationId, null);
+  }
+
+  /**
+   * Invoke this function to generate LLVM code to evaluate the condition
+   * expression. Invoke
+   * Filter::Evaluate() against a RecordBatch to evaluate the filter on this
+   * record batch
+   *
+   * @param schema          Table schema. The field names in the schema should
+   *                        match the fields used to
+   *                        create the TreeNodes
+   * @param condition       condition to be evaluated against data
+   * @param configurationId Custom configuration created through config builder.
+   * @param secondaryCache  SecondaryCache cache for gandiva object code.
+   * @return A native evaluator object that can be used to invoke these
+   *         projections on a RecordBatch
+   */
+  public static Filter make(Schema schema, Condition condition, long configurationId,
+                            JavaSecondaryCacheInterface secondaryCache) throws GandivaException {
     // Invoke the JNI layer to create the LLVM module representing the filter.
     GandivaTypes.Condition conditionBuf = condition.toProtobuf();
     GandivaTypes.Schema schemaBuf = ArrowTypeHelper.arrowSchemaToProtobuf(schema);
     JniWrapper wrapper = JniLoader.getInstance().getWrapper();
-    long moduleId = wrapper.buildFilter(schemaBuf.toByteArray(),
+    long moduleId = wrapper.buildFilter(secondaryCache, schemaBuf.toByteArray(),
         conditionBuf.toByteArray(), configurationId);
     logger.debug("Created module for the filter with id {}", moduleId);
     return new Filter(wrapper, moduleId, schema);

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/JavaSecondaryCacheInterface.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/JavaSecondaryCacheInterface.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.gandiva.evaluator;
+
+/**
+ * Acts as an interface to the secondary cache class that uses a callback
+ * mechanism from gandiva.
+ */
+public interface JavaSecondaryCacheInterface {
+    /**
+     * Resultant buffer of the get call to the secondary cache.
+     */
+    class BufferResult {
+        public long address;
+        public long size;
+
+        public BufferResult(long address, long size) {
+            this.address = address;
+            this.size = size;
+        }
+
+    }
+
+    /**
+     * Get from the secondary cache using the key buffer.
+     * @param keyBufAddr address of the key buffer
+     * @param keyBufSize size of the key buffer
+     * @return
+     */
+    BufferResult get(long keyBufAddr, long keyBufSize);
+
+    /**
+     * Set the secondary cache with the value in the buffer.
+     * @param keyBufAddr address of the key buffer
+     * @param keyBufSize size of the key buffer
+     * @param valueBufAddr address of the value buffer
+     * @param valueBufSize size of the value buffer
+     */
+    void set(long keyBufAddr, long keyBufSize, long valueBufAddr, long valueBufSize);
+
+    /**
+     * release the buffer associated with the given address.
+     */
+    void releaseBufferResult(long address);
+
+}

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/JniWrapper.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/JniWrapper.java
@@ -31,6 +31,7 @@ public class JniWrapper {
    * Generates the projector module to evaluate the expressions with
    * custom configuration.
    *
+   * @param cache SecondaryCacheInterface object. Used for callbacks from cpp.
    * @param schemaBuf   The schema serialized as a protobuf. See Types.proto
    *                    to see the protobuf specification
    * @param exprListBuf The serialized protobuf of the expression vector. Each
@@ -40,7 +41,7 @@ public class JniWrapper {
    * @return A moduleId that is passed to the evaluateProjector() and closeProjector() methods
    *
    */
-  native long buildProjector(byte[] schemaBuf, byte[] exprListBuf,
+  native long buildProjector(Object cache, byte[] schemaBuf, byte[] exprListBuf,
                              int selectionVectorType,
                              long configId) throws GandivaException;
 
@@ -87,13 +88,14 @@ public class JniWrapper {
    * @return A moduleId that is passed to the evaluateFilter() and closeFilter() methods
    *
    */
-  native long buildFilter(byte[] schemaBuf, byte[] conditionBuf,
+  native long buildFilter(Object cache, byte[] schemaBuf, byte[] conditionBuf,
                           long configId) throws GandivaException;
 
   /**
    * Evaluate the filter represented by the moduleId on a record batch
    * and store the output in buffer 'outAddr'. Throws an exception in case of errors
    *
+   * @param cache SecondaryCacheInterface object. Used for callbacks from cpp.
    * @param moduleId moduleId representing expressions. Created using a call to
    *                 buildNativeCode
    * @param numRows Number of rows in the record batch

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/Projector.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/Projector.java
@@ -187,6 +187,45 @@ public class Projector {
   public static Projector make(Schema schema, List<ExpressionTree> exprs,
       SelectionVectorType selectionVectorType,
       long configurationId) throws GandivaException {
+    return make(schema, exprs, selectionVectorType, configurationId, null);
+  }
+
+  /**
+   * Invoke this function to generate LLVM code to evaluate the list of project expressions.
+   * Invoke Projector::Evaluate() against a RecordBatch to evaluate the record batch
+   * against these projections.
+   *
+   * @param schema         Table schema. The field names in the schema should match the fields used
+   *                       to create the TreeNodes
+   * @param exprs          List of expressions to be evaluated against data
+   * @param configOptions  ConfigOptions parameter
+   * @param secondaryCache SecondaryCache cache for gandiva object code.
+   *
+   * @return A native evaluator object that can be used to invoke these projections on a RecordBatch
+   */
+  public static Projector make(Schema schema, List<ExpressionTree> exprs,
+                               ConfigurationBuilder.ConfigOptions configOptions,
+                               JavaSecondaryCacheInterface secondaryCache) throws GandivaException {
+    return make(schema, exprs, SelectionVectorType.SV_NONE, JniLoader.getConfiguration(configOptions), secondaryCache);
+  }
+
+  /**
+   * Invoke this function to generate LLVM code to evaluate the list of project expressions.
+   * Invoke Projector::Evaluate() against a RecordBatch to evaluate the record batch
+   * against these projections.
+   *
+   * @param schema              Table schema. The field names in the schema should match the fields used
+   *                            to create the TreeNodes
+   * @param exprs               List of expressions to be evaluated against data
+   * @param selectionVectorType type of selection vector
+   * @param configurationId     Custom configuration created through config builder.
+   * @param secondaryCache      SecondaryCache cache for gandiva object code.
+   *
+   * @return A native evaluator object that can be used to invoke these projections on a RecordBatch
+   */
+  public static Projector make(Schema schema, List<ExpressionTree> exprs,
+                               SelectionVectorType selectionVectorType,
+                               long configurationId, JavaSecondaryCacheInterface secondaryCache) throws GandivaException {
     // serialize the schema and the list of expressions as a protobuf
     GandivaTypes.ExpressionList.Builder builder = GandivaTypes.ExpressionList.newBuilder();
     for (ExpressionTree expr : exprs) {
@@ -196,7 +235,7 @@ public class Projector {
     // Invoke the JNI layer to create the LLVM module representing the expressions
     GandivaTypes.Schema schemaBuf = ArrowTypeHelper.arrowSchemaToProtobuf(schema);
     JniWrapper wrapper = JniLoader.getInstance().getWrapper();
-    long moduleId = wrapper.buildProjector(schemaBuf.toByteArray(),
+    long moduleId = wrapper.buildProjector(secondaryCache, schemaBuf.toByteArray(),
         builder.build().toByteArray(), selectionVectorType.getNumber(), configurationId);
     logger.debug("Created module for the projector with id {}", moduleId);
     return new Projector(wrapper, moduleId, schema, exprs.size());

--- a/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorTest.java
+++ b/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorTest.java
@@ -2599,4 +2599,85 @@ public class ProjectorTest extends BaseEvaluatorTest {
     releaseRecordBatch(batch);
     releaseValueVectors(output);
   }
+
+
+  public class DummySecondaryCache implements JavaSecondaryCacheInterface {
+    public DummySecondaryCache() {
+      gotFromCache = false;
+      setToCache = false;
+    }
+
+    public BufferResult get(long addrKey, long sizeKey) {
+      gotFromCache = true;
+      return null;
+    }
+
+    public void set(long addrKey, long sizeKey, long addrValue, long sizeValue) {
+      setToCache = true;
+    }
+
+    public void releaseBufferResult(long address) {}
+
+    public boolean gotFromCache;
+    public boolean setToCache;
+  }
+
+  @Test
+  public void testSecondaryCache() throws GandivaException {
+    Field a = Field.nullable("field0", int32);
+    Field b = Field.nullable("field1", int32);
+    List<Field> args = Lists.newArrayList(a, b);
+
+    Field retType = Field.nullable("c", int32);
+    ExpressionTree root = TreeBuilder.makeExpression("add", args, retType);
+
+    List<ExpressionTree> exprs = Lists.newArrayList(root);
+
+    Schema schema = new Schema(args);
+
+    DummySecondaryCache secondaryCache = new DummySecondaryCache();
+
+    Projector eval = Projector.make(schema, exprs,
+            new ConfigurationBuilder.ConfigOptions().getDefault(), secondaryCache);
+
+    // assert the jni calls were successful
+    assertTrue(secondaryCache.gotFromCache);
+    assertTrue(secondaryCache.setToCache);
+
+    int numRows = 16;
+    byte[] validity = new byte[]{(byte) 255, 0};
+    // second half is "undefined"
+    int[] aValues = new int[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+    int[] bValues = new int[]{16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
+
+    ArrowBuf validitya = buf(validity);
+    ArrowBuf valuesa = intBuf(aValues);
+    ArrowBuf validityb = buf(validity);
+    ArrowBuf valuesb = intBuf(bValues);
+    ArrowRecordBatch batch =
+            new ArrowRecordBatch(
+                    numRows,
+                    Lists.newArrayList(new ArrowFieldNode(numRows, 8), new ArrowFieldNode(numRows, 8)),
+                    Lists.newArrayList(validitya, valuesa, validityb, valuesb));
+
+    IntVector intVector = new IntVector(EMPTY_SCHEMA_PATH, allocator);
+    intVector.allocateNew(numRows);
+
+    List<ValueVector> output = new ArrayList<ValueVector>();
+    output.add(intVector);
+    eval.evaluate(batch, output);
+
+    for (int i = 0; i < 8; i++) {
+      assertFalse(intVector.isNull(i));
+      assertEquals(17, intVector.get(i));
+    }
+    for (int i = 8; i < 16; i++) {
+      assertTrue(intVector.isNull(i));
+    }
+
+    // free buffers
+    releaseRecordBatch(batch);
+    releaseValueVectors(output);
+    eval.close();
+  }
 }


### PR DESCRIPTION
 

<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Arrow gandiva has a primary cache but this cache doesn't persist across restarts.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
Integrate a new API in project and filter and make calls that allow the user to specify the implementation of the secondary cache by providing a c++ and java interface to this persistent cache.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
Yes.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
No.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: apache/arrow-java#203