### PR TITLE
GH-35331: [Python] Expose Parquet sorting metadata

### DIFF
--- a/docs/source/python/api/formats.rst
+++ b/docs/source/python/api/formats.rst
@@ -97,6 +97,7 @@ Parquet Metadata
 
    FileMetaData
    RowGroupMetaData
+   SortingColumn
    ColumnChunkMetaData
    Statistics
    ParquetSchema

--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -24,7 +24,7 @@ from pyarrow.includes.libarrow cimport (CChunkedArray, CScalar, CSchema, CStatus
                                         CKeyValueMetadata,
                                         CRandomAccessFile, COutputStream,
                                         TimeUnit, CRecordBatchReader)
-from pyarrow.lib cimport _Weakrefable
+from pyarrow.lib cimport (_Weakrefable, pyarrow_unwrap_schema)
 
 
 cdef extern from "parquet/api/schema.h" namespace "parquet::schema" nogil:
@@ -322,11 +322,17 @@ cdef extern from "parquet/api/reader.h" namespace "parquet" nogil:
         int64_t total_uncompressed_size() const
         unique_ptr[CColumnCryptoMetaData] crypto_metadata() const
 
+    struct CSortingColumn" parquet::SortingColumn":
+        int column_idx
+        c_bool descending
+        c_bool nulls_first
+
     cdef cppclass CRowGroupMetaData" parquet::RowGroupMetaData":
         c_bool Equals(const CRowGroupMetaData&) const
-        int num_columns()
-        int64_t num_rows()
-        int64_t total_byte_size()
+        int num_columns() const
+        int64_t num_rows() const
+        int64_t total_byte_size() const
+        vector[CSortingColumn] sorting_columns() const
         unique_ptr[CColumnChunkMetaData] ColumnChunk(int i) const
 
     cdef cppclass CFileMetaData" parquet::FileMetaData":
@@ -410,6 +416,7 @@ cdef extern from "parquet/api/writer.h" namespace "parquet" nogil:
             Builder* disable_dictionary()
             Builder* enable_dictionary()
             Builder* enable_dictionary(const c_string& path)
+            Builder* set_sorting_columns(vector[CSortingColumn] sorting_columns)
             Builder* disable_statistics()
             Builder* enable_statistics()
             Builder* enable_statistics(const c_string& path)
@@ -502,8 +509,8 @@ cdef extern from "parquet/arrow/schema.h" namespace "parquet::arrow" nogil:
 
     CStatus ToParquetSchema(
         const CSchema* arrow_schema,
-        const ArrowReaderProperties& properties,
-        const shared_ptr[const CKeyValueMetadata]& key_value_metadata,
+        const WriterProperties& properties,
+        const ArrowWriterProperties& arrow_properties,
         shared_ptr[SchemaDescriptor]* out)
 
 
@@ -567,7 +574,8 @@ cdef shared_ptr[WriterProperties] _create_writer_properties(
     data_page_version=*,
     FileEncryptionProperties encryption_properties=*,
     write_batch_size=*,
-    dictionary_pagesize_limit=*) except *
+    dictionary_pagesize_limit=*,
+    sorting_columns=*) except *
 
 
 cdef shared_ptr[ArrowWriterProperties] _create_arrow_writer_properties(

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -531,8 +531,7 @@ cdef class SortingColumn:
 
     >>> import pyarrow.parquet as pq
     >>> [pq.SortingColumn(0), pq.SortingColumn(1, descending=True)]
-    [SortingColumn(column_index=0, descending=False, nulls_first=False),
-     SortingColumn(column_index=1, descending=True, nulls_first=False)]
+    [SortingColumn(column_index=0, descending=False, nulls_first=False), SortingColumn(column_index=1, descending=True, nulls_first=False)]
 
     Convert the sort_order into the list of sorting columns with 
     ``from_sort_order`` (note that the schema must be provided as well):
@@ -541,8 +540,7 @@ cdef class SortingColumn:
     >>> schema = pa.schema([('id', pa.int64()), ('timestamp', pa.timestamp('ms'))])
     >>> sorting_columns = pq.SortingColumn.from_sort_order(schema, sort_order)
     >>> sorting_columns
-    (SortingColumn(column_index=0, descending=False, nulls_first=False),
-     SortingColumn(column_index=1, descending=True, nulls_first=False))
+    (SortingColumn(column_index=0, descending=False, nulls_first=False), SortingColumn(column_index=1, descending=True, nulls_first=False))
 
     Convert back to the sort order with ``to_sort_order``:
 

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -505,7 +505,7 @@ cdef class SortingColumn:
     Parameters
     ----------
     column_index : int
-        Index of column data is sorted by.
+        Index of column that data is sorted by.
     descending : bool, default False
         Whether column is sorted in descending order.
     nulls_first : bool, default False
@@ -691,14 +691,6 @@ cdef class SortingColumn:
     def nulls_first(self):
         """Whether null values appear before valid values (bool)."""
         return self.nulls_first
-
-    def to_dict(self):
-        """Convert to dictionary representation."""
-        return {
-            'column_index': self.column_index,
-            'descending': self.descending,
-            'nulls_first': self.nulls_first
-        }
 
 
 cdef class RowGroupMetaData(_Weakrefable):

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -18,6 +18,7 @@
 # cython: profile=False
 # distutils: language = c++
 
+from collections.abc import Sequence
 from textwrap import indent
 import warnings
 
@@ -494,6 +495,122 @@ cdef class ColumnChunkMetaData(_Weakrefable):
         return self.metadata.total_uncompressed_size()
 
 
+cdef class SortingColumn:
+    """Sorting specification for a single column.
+
+    Returned by :meth:`RowGroupMetaData.sorting_columns` and used in :class:`ParquetWriter`
+    to specify the sort order of the data.
+
+    Example
+    -------
+
+    """
+    cdef int column_index
+    cdef c_bool descending
+    cdef c_bool nulls_first
+
+    def __init__(self, int column_index, c_bool descending=False, c_bool nulls_first=False):
+        """
+        Parameters
+        ----------
+        column_index : int
+            Index of column data is sorted by.
+        descending : bool, default False
+            Whether column is sorted in descending order.
+        nulls_first : bool, default False
+            Whether null values appear before valid values.
+        """
+        self.column_index = column_index
+        self.descending = descending
+        self.nulls_first = nulls_first
+
+    @classmethod
+    def from_sort_order(schema, sort_keys, null_placement='at_end'):
+        """
+        Create a tuple of SortingColumn objects from the same arguments as
+        :class:`pyarrow.compute.SortOptions`.
+
+        Parameters
+        ----------
+        schema : Schema
+            Schema of the input data.
+        sort_keys : Sequence of (name, order) tuples
+            Names of field/column keys to sort the input on,
+            along with the order each field/column is sorted in.
+            Accepted values for `order` are "ascending", "descending".
+            The field name can be a string column name or expression.
+        null_placement : {'at_start', 'at_end'}, default 'at_end'
+            Where null values should appear in the sort order.
+
+        Returns
+        -------
+        sorting_columns : tuple of SortingColumn
+        """
+        if null_placement == 'at_start':
+            nulls_first = True
+        elif null_placement == 'at_end':
+            nulls_first = False
+        else:
+            raise ValueError('null_placement must be "at_start" or "at_end"')
+
+        col_map = _name_to_index_map(schema)
+
+        sort_columns = []
+        for name, order in sort_keys:
+            if order == 'ascending':
+                descending = False
+            elif order == 'descending':
+                descending = True
+            else:
+                raise ValueError('order must be "ascending" or "descending"')
+
+            if isinstance(name, str):
+                column_index = col_map[name]
+            elif isinstance(name, int):
+                column_index = name
+            else:
+                raise TypeError('sort key name must be a string or integer')
+
+            sort_columns.append(SortingColumn(column_index, descending, nulls_first))
+
+        return tuple(sort_columns)
+
+    def __repr__(self):
+        return """SortingColumn(column_index={0}, descending={1}, nulls_first={2})""".format(
+            self.column_index, self.descending, self.nulls_first)
+
+    def __eq__(self, SortingColumn other):
+        return (self.column_index == other.column_index and
+                self.descending == other.descending and
+                self.nulls_first == other.nulls_first)
+
+    def __hash__(self):
+        return hash((self.column_index, self.descending, self.nulls_first))
+
+    @property
+    def column_index(self):
+        """"Index of column data is sorted by (int)."""
+        return self.column_index
+
+    @property
+    def descending(self):
+        """Whether column is sorted in descending order (bool)."""
+        return self.descending
+
+    @property
+    def nulls_first(self):
+        """Whether null values appear before valid values (bool)."""
+        return self.nulls_first
+
+    def to_dict(self):
+        """Convert to dictionary representation."""
+        return {
+            'column_index': self.column_index,
+            'descending': self.descending,
+            'nulls_first': self.nulls_first
+        }
+
+
 cdef class RowGroupMetaData(_Weakrefable):
     """Metadata for a single row group."""
 
@@ -553,10 +670,12 @@ cdef class RowGroupMetaData(_Weakrefable):
         return """{0}
   num_columns: {1}
   num_rows: {2}
-  total_byte_size: {3}""".format(object.__repr__(self),
+  total_byte_size: {3}
+  sorting_columns: {4}""".format(object.__repr__(self),
                                  self.num_columns,
                                  self.num_rows,
-                                 self.total_byte_size)
+                                 self.total_byte_size,
+                                 self.sorting_columns)
 
     def to_dict(self):
         """
@@ -573,6 +692,7 @@ cdef class RowGroupMetaData(_Weakrefable):
             num_rows=self.num_rows,
             total_byte_size=self.total_byte_size,
             columns=columns,
+            sorting_columns=[col.to_dict() for col in self.sorting_columns]
         )
         for i in range(self.num_columns):
             columns.append(self.column(i).to_dict())
@@ -592,6 +712,19 @@ cdef class RowGroupMetaData(_Weakrefable):
     def total_byte_size(self):
         """Total byte size of all the uncompressed column data in this row group (int)."""
         return self.metadata.total_byte_size()
+
+    @property
+    def sorting_columns(self):
+        """Columns the row group is sorted by (tuple of :class:`SortingColumn`).)"""
+        out = []
+        cdef vector[CSortingColumn] sorting_columns = self.metadata.sorting_columns()
+        for sorting_col in sorting_columns:
+            out.append(SortingColumn(
+                sorting_col.column_idx,
+                sorting_col.descending,
+                sorting_col.nulls_first
+            ))
+        return tuple(out)
 
 
 def _reconstruct_filemetadata(Buffer serialized):
@@ -1443,6 +1576,31 @@ cdef class ParquetReader(_Weakrefable):
         return closed
 
 
+cdef CSortingColumn _convert_sorting_column(SortingColumn sorting_column):
+    cdef CSortingColumn c_sorting_column
+
+    c_sorting_column.column_idx = sorting_column.column_index
+    c_sorting_column.descending = sorting_column.descending
+    c_sorting_column.nulls_first = sorting_column.nulls_first
+
+    return c_sorting_column
+
+
+cdef vector[CSortingColumn] _convert_sorting_columns(sorting_columns) except *:
+    if not (isinstance(sorting_columns, Sequence)
+            and all(isinstance(col, SortingColumn) for col in sorting_columns)):
+        raise ValueError(
+            "'sorting_columns' must be a list of `SortingColumn`")
+
+    cdef vector[CSortingColumn] c_sorting_columns = [_convert_sorting_column(col)
+                                                     for col in sorting_columns]
+
+    if len(sorting_columns) != len(c_sorting_columns):
+        raise ValueError("something has gone wrong")
+
+    return c_sorting_columns
+
+
 cdef shared_ptr[WriterProperties] _create_writer_properties(
         use_dictionary=None,
         compression=None,
@@ -1455,7 +1613,8 @@ cdef shared_ptr[WriterProperties] _create_writer_properties(
         data_page_version=None,
         FileEncryptionProperties encryption_properties=None,
         write_batch_size=None,
-        dictionary_pagesize_limit=None) except *:
+        dictionary_pagesize_limit=None,
+        sorting_columns=None) except *:
     """General writer properties"""
     cdef:
         shared_ptr[WriterProperties] properties
@@ -1539,6 +1698,11 @@ cdef shared_ptr[WriterProperties] _create_writer_properties(
         props.disable_statistics()
         for column in write_statistics:
             props.enable_statistics(tobytes(column))
+
+    # sorting_columns
+
+    if sorting_columns is not None:
+        props.set_sorting_columns(_convert_sorting_columns(sorting_columns))
 
     # use_byte_stream_split
 
@@ -1665,6 +1829,82 @@ cdef shared_ptr[ArrowWriterProperties] _create_arrow_writer_properties(
 
     return arrow_properties
 
+cdef _name_to_index_map(Schema arrow_schema):
+    cdef:
+        shared_ptr[CSchema] sp_arrow_schema
+        shared_ptr[SchemaDescriptor] sp_parquet_schema
+        shared_ptr[WriterProperties] props = _create_writer_properties()
+        shared_ptr[ArrowWriterProperties] arrow_props = _create_arrow_writer_properties(
+            use_deprecated_int96_timestamps=False,
+            coerce_timestamps=None,
+            allow_truncated_timestamps=False,
+            writer_engine_version="V2"
+        )
+
+    sp_arrow_schema = pyarrow_unwrap_schema(arrow_schema)
+
+    with nogil:
+        check_status(ToParquetSchema(
+            sp_arrow_schema.get(), deref(props.get()), deref(arrow_props.get()), &sp_parquet_schema))
+
+    out = dict()
+
+    cdef SchemaDescriptor* parquet_schema = sp_parquet_schema.get()
+
+    for i in range(parquet_schema.num_columns()):
+        name = frombytes(parquet_schema.Column(i).name())
+        out[name] = i
+
+    return out
+
+
+def _sort_keys_to_sorting_columns(sort_keys, null_placement, Schema schema):
+    """Convert SortOptions to a list of SortingColumn objects"""
+
+    if null_placement is None or null_placement == "at_end":
+        nulls_first = False
+    elif null_placement == "at_start":
+        nulls_first = True
+    else:
+        raise ValueError("Invalid value for null_placement: {0}"
+                         .format(null_placement))
+
+    name_to_index_map = _name_to_index_map(schema)
+
+    sorting_columns = []
+
+    for sort_key in sort_keys:
+        if isinstance(sort_key, str):
+            name = sort_key
+            descending = False
+        elif (isinstance(sort_key, tuple) and len(sort_key) == 2 and
+                isinstance(sort_key[0], str) and
+                isinstance(sort_key[1], str)):
+            name, descending = sort_key
+            if descending == "descending":
+                descending = True
+            elif descending == "ascending":
+                descending = False
+            else:
+                raise ValueError("Invalid sort key direction: {0}"
+                                 .format(descending))
+        else:
+            raise ValueError("Invalid sort key: {0}".format(sort_key))
+
+        try:
+            column_index = name_to_index_map[name]
+        except KeyError:
+            raise ValueError("Sort key name '{0}' not found in schema:\n{1}"
+                             .format(name, schema))
+
+        sorting_column = SortingColumn(
+            column_index,
+            descending,
+            nulls_first)
+        sorting_columns.append(sorting_column)
+
+    return sorting_columns
+
 
 cdef class ParquetWriter(_Weakrefable):
     cdef:
@@ -1710,7 +1950,8 @@ cdef class ParquetWriter(_Weakrefable):
                   encryption_properties=None,
                   write_batch_size=None,
                   dictionary_pagesize_limit=None,
-                  store_schema=True):
+                  store_schema=True,
+                  sorting_columns=None):
         cdef:
             shared_ptr[WriterProperties] properties
             shared_ptr[ArrowWriterProperties] arrow_properties
@@ -1728,6 +1969,29 @@ cdef class ParquetWriter(_Weakrefable):
                 self.sink = GetResultValue(FileOutputStream.Open(c_where))
             self.own_sink = True
 
+        # This needs to be simplified while we still have access to the schema.
+        if sorting_columns is not None:
+            # For [(col1, "descending"), (col2, "ascending"), (col3)]
+            if (isinstance(sorting_columns, Sequence) and
+                    all(isinstance(sort_key, str) or isinstance(sort_key, tuple) for sort_key in sorting_columns)):
+                sorting_columns = _sort_keys_to_sorting_columns(
+                    sorting_columns,
+                    None,
+                    schema
+                )
+            # For ([(col1, "descending"), (col2, "ascending"), (col3)], "at_end")
+            if (isinstance(sorting_columns, tuple)
+                and len(sorting_columns) <= 2
+                    and isinstance(sorting_columns[0], Sequence)):
+                if len(sorting_columns) == 1:
+                    sorting_columns, null_placement = sorting_columns[0], None
+                else:
+                    sorting_columns, null_placement = sorting_columns
+                sorting_columns = _sort_keys_to_sorting_columns(
+                    sorting_columns,
+                    null_placement,
+                    schema)
+
         properties = _create_writer_properties(
             use_dictionary=use_dictionary,
             compression=compression,
@@ -1740,7 +2004,8 @@ cdef class ParquetWriter(_Weakrefable):
             data_page_version=data_page_version,
             encryption_properties=encryption_properties,
             write_batch_size=write_batch_size,
-            dictionary_pagesize_limit=dictionary_pagesize_limit
+            dictionary_pagesize_limit=dictionary_pagesize_limit,
+            sorting_columns=sorting_columns,
         )
         arrow_properties = _create_arrow_writer_properties(
             use_deprecated_int96_timestamps=use_deprecated_int96_timestamps,

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -531,8 +531,14 @@ cdef class SortingColumn:
 
     >>> import pyarrow.parquet as pq
     >>> [pq.SortingColumn(0), pq.SortingColumn(1, descending=True)]
-    [SortingColumn(column_index=0, descending=False, nulls_first=False),
-     SortingColumn(column_index=1, descending=True, nulls_first=False)]
+    [<pyarrow._parquet.SortingColumn object at 0x102c19cd0>
+       column_index: 0
+       descending: False
+       nulls_first: False,
+     <pyarrow._parquet.SortingColumn object at 0x102c191d0>
+       column_index: 1
+       descending: True
+       nulls_first: False]
 
     Convert the sort_order into the list of sorting columns with 
     ``from_sort_order`` (note that the schema must be provided as well):
@@ -541,8 +547,14 @@ cdef class SortingColumn:
     >>> schema = pa.schema([('id', pa.int64()), ('timestamp', pa.timestamp('ms'))])
     >>> sorting_columns = pq.SortingColumn.from_sort_order(schema, sort_order)
     >>> sorting_columns
-    (SortingColumn(column_index=0, descending=False, nulls_first=False),
-     SortingColumn(column_index=1, descending=True, nulls_first=False))
+    (<pyarrow._parquet.SortingColumn object at 0x10598bf70>
+       column_index: 0
+       descending: False
+       nulls_first: False,
+     <pyarrow._parquet.SortingColumn object at 0x102c18cd0>
+       column_index: 1
+       descending: True
+       nulls_first: False)
 
     Convert back to the sort order with ``to_sort_order``:
 

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -525,7 +525,7 @@ cdef class SortingColumn:
         self.nulls_first = nulls_first
 
     @classmethod
-    def from_sort_order(schema, sort_keys, null_placement='at_end'):
+    def from_sort_order(cls, Schema schema, sort_keys, null_placement='at_end'):
         """
         Create a tuple of SortingColumn objects from the same arguments as
         :class:`pyarrow.compute.SortOptions`.
@@ -555,25 +555,79 @@ cdef class SortingColumn:
 
         col_map = _name_to_index_map(schema)
 
-        sort_columns = []
-        for name, order in sort_keys:
-            if order == 'ascending':
+        sorting_columns = []
+
+        for sort_key in sort_keys:
+            if isinstance(sort_key, str):
+                name = sort_key
                 descending = False
-            elif order == 'descending':
-                descending = True
+            elif (isinstance(sort_key, tuple) and len(sort_key) == 2 and
+                    isinstance(sort_key[0], str) and
+                    isinstance(sort_key[1], str)):
+                name, descending = sort_key
+                if descending == "descending":
+                    descending = True
+                elif descending == "ascending":
+                    descending = False
+                else:
+                    raise ValueError("Invalid sort key direction: {0}"
+                                     .format(descending))
             else:
-                raise ValueError('order must be "ascending" or "descending"')
+                raise ValueError("Invalid sort key: {0}".format(sort_key))
 
-            if isinstance(name, str):
+            try:
                 column_index = col_map[name]
-            elif isinstance(name, int):
-                column_index = name
+            except KeyError:
+                raise ValueError("Sort key name '{0}' not found in schema:\n{1}"
+                                 .format(name, schema))
+
+            sorting_columns.append(
+                cls(column_index, descending=descending, nulls_first=nulls_first)
+            )
+
+        return tuple(sorting_columns)
+
+    @staticmethod
+    def as_sort_order(Schema schema, sorting_columns):
+        """
+        Convert a tuple of SortingColumn objects to the same format as
+        :class:`pyarrow.compute.SortOptions`.
+
+        Parameters
+        ----------
+        schema : Schema
+            Schema of the input data.
+        sorting_columns : tuple of SortingColumn
+            Columns to sort the input on.
+
+        Returns
+        -------
+        sort_keys : tuple of (name, order) tuples
+        null_placement : {'at_start', 'at_end'}
+        """
+        col_map = {i: name for i, name in _name_to_index_map(schema).items()}
+
+        sort_keys = []
+        nulls_first = None
+
+        for sorting_column in sorting_columns:
+            name = col_map[sorting_column.column_index]
+            if sorting_column.descending:
+                order = "descending"
             else:
-                raise TypeError('sort key name must be a string or integer')
+                order = "ascending"
+            sort_keys.append((name, order))
+            if nulls_first is None:
+                nulls_first = sorting_column.nulls_first
+            elif nulls_first != sorting_column.nulls_first:
+                raise ValueError("Sorting columns have inconsistent null placement")
 
-            sort_columns.append(SortingColumn(column_index, descending, nulls_first))
+        if nulls_first:
+            null_placement = "at_start"
+        else:
+            null_placement = "at_end"
 
-        return tuple(sort_columns)
+        return tuple(sort_keys), null_placement
 
     def __repr__(self):
         return """SortingColumn(column_index={0}, descending={1}, nulls_first={2})""".format(
@@ -1968,29 +2022,6 @@ cdef class ParquetWriter(_Weakrefable):
             with nogil:
                 self.sink = GetResultValue(FileOutputStream.Open(c_where))
             self.own_sink = True
-
-        # This needs to be simplified while we still have access to the schema.
-        if sorting_columns is not None:
-            # For [(col1, "descending"), (col2, "ascending"), (col3)]
-            if (isinstance(sorting_columns, Sequence) and
-                    all(isinstance(sort_key, str) or isinstance(sort_key, tuple) for sort_key in sorting_columns)):
-                sorting_columns = _sort_keys_to_sorting_columns(
-                    sorting_columns,
-                    None,
-                    schema
-                )
-            # For ([(col1, "descending"), (col2, "ascending"), (col3)], "at_end")
-            if (isinstance(sorting_columns, tuple)
-                and len(sorting_columns) <= 2
-                    and isinstance(sorting_columns[0], Sequence)):
-                if len(sorting_columns) == 1:
-                    sorting_columns, null_placement = sorting_columns[0], None
-                else:
-                    sorting_columns, null_placement = sorting_columns
-                sorting_columns = _sort_keys_to_sorting_columns(
-                    sorting_columns,
-                    null_placement,
-                    schema)
 
         properties = _create_writer_properties(
             use_dictionary=use_dictionary,

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -531,14 +531,8 @@ cdef class SortingColumn:
 
     >>> import pyarrow.parquet as pq
     >>> [pq.SortingColumn(0), pq.SortingColumn(1, descending=True)]
-    [<pyarrow._parquet.SortingColumn object at 0x102c19cd0>
-      column_index: 0
-      descending: False
-      nulls_first: False,
-     <pyarrow._parquet.SortingColumn object at 0x102c191d0>
-      column_index: 1
-      descending: True
-      nulls_first: False]
+    [SortingColumn(column_index=0, descending=False, nulls_first=False),
+     SortingColumn(column_index=1, descending=True, nulls_first=False)]
 
     Convert the sort_order into the list of sorting columns with 
     ``from_sort_order`` (note that the schema must be provided as well):
@@ -547,14 +541,8 @@ cdef class SortingColumn:
     >>> schema = pa.schema([('id', pa.int64()), ('timestamp', pa.timestamp('ms'))])
     >>> sorting_columns = pq.SortingColumn.from_sort_order(schema, sort_order)
     >>> sorting_columns
-    (<pyarrow._parquet.SortingColumn object at 0x10598bf70>
-      column_index: 0
-      descending: False
-      nulls_first: False,
-     <pyarrow._parquet.SortingColumn object at 0x102c18cd0>
-      column_index: 1
-      descending: True
-      nulls_first: False)
+    (SortingColumn(column_index=0, descending=False, nulls_first=False),
+     SortingColumn(column_index=1, descending=True, nulls_first=False))
 
     Convert back to the sort order with ``to_sort_order``:
 
@@ -563,7 +551,7 @@ cdef class SortingColumn:
 
     See Also
     --------
-    RowGroupMetaData.sorting_columns, ParquetFile.sort_order
+    RowGroupMetaData.sorting_columns
     """
     cdef int column_index
     cdef c_bool descending
@@ -679,11 +667,8 @@ cdef class SortingColumn:
         return tuple(sort_keys), null_placement
 
     def __repr__(self):
-        return """{}
-  column_index: {}
-  descending: {}
-  nulls_first: {}""".format(
-            object.__repr__(self),
+        return """{}(column_index={}, descending={}, nulls_first={})""".format(
+            self.__class__.__name__,
             self.column_index, self.descending, self.nulls_first)
 
     def __eq__(self, SortingColumn other):

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -566,10 +566,9 @@ cdef class SortingColumn:
         schema : Schema
             Schema of the input data.
         sort_keys : Sequence of (name, order) tuples
-            Names of field/column keys to sort the input on,
+            Names of field/column keys (str) to sort the input on,
             along with the order each field/column is sorted in.
             Accepted values for `order` are "ascending", "descending".
-            The field name can be a string column name or expression.
         null_placement : {'at_start', 'at_end'}, default 'at_end'
             Where null values should appear in the sort order.
 
@@ -661,7 +660,11 @@ cdef class SortingColumn:
         return tuple(sort_keys), null_placement
 
     def __repr__(self):
-        return """SortingColumn(column_index={0}, descending={1}, nulls_first={2})""".format(
+        return """{}
+  column_index: {}
+  descending: {}
+  nulls_first: {}""".format(
+            object.__repr__(self),
             self.column_index, self.descending, self.nulls_first)
 
     def __eq__(self, SortingColumn other):

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -496,7 +496,8 @@ cdef class ColumnChunkMetaData(_Weakrefable):
 
 
 cdef class SortingColumn:
-    """Sorting specification for a single column.
+    """
+    Sorting specification for a single column.
 
     Returned by :meth:`RowGroupMetaData.sorting_columns` and used in
     :class:`ParquetWriter` to specify the sort order of the data.
@@ -510,12 +511,14 @@ cdef class SortingColumn:
     nulls_first : bool, default False
         Whether null values appear before valid values.
 
-    .. note::
-            Column indices are zero-based, refer only to leaf fields, and are in
-            depth-first order. This may make the column indices for nested schemas
-            different from what you expect. In most cases, it will be easier to
-            specify the sort order using column names instead of column indices
-            and converting using the ``from_sort_order`` method.
+    Notes
+    -----
+
+    Column indices are zero-based, refer only to leaf fields, and are in
+    depth-first order. This may make the column indices for nested schemas
+    different from what you expect. In most cases, it will be easier to
+    specify the sort order using column names instead of column indices
+    and converting using the ``from_sort_order`` method.
 
     Examples
     --------
@@ -545,6 +548,10 @@ cdef class SortingColumn:
 
     >>> pq.SortingColumn.to_sort_order(schema, sorting_columns)
     ((('id', 'ascending'), ('timestamp', 'descending')), 'at_end')
+
+    See Also
+    --------
+    RowGroupMetaData.sorting_columns, ParquetFile.sort_order
     """
     cdef int column_index
     cdef c_bool descending
@@ -803,7 +810,7 @@ cdef class RowGroupMetaData(_Weakrefable):
 
     @property
     def sorting_columns(self):
-        """Columns the row group is sorted by (tuple of :class:`SortingColumn`).)"""
+        """Columns the row group is sorted by (tuple of :class:`SortingColumn`))."""
         out = []
         cdef vector[CSortingColumn] sorting_columns = self.metadata.sorting_columns()
         for sorting_col in sorting_columns:

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -498,28 +498,59 @@ cdef class ColumnChunkMetaData(_Weakrefable):
 cdef class SortingColumn:
     """Sorting specification for a single column.
 
-    Returned by :meth:`RowGroupMetaData.sorting_columns` and used in :class:`ParquetWriter`
-    to specify the sort order of the data.
+    Returned by :meth:`RowGroupMetaData.sorting_columns` and used in
+    :class:`ParquetWriter` to specify the sort order of the data.
 
-    Example
-    -------
+    Parameters
+    ----------
+    column_index : int
+        Index of column data is sorted by.
+    descending : bool, default False
+        Whether column is sorted in descending order.
+    nulls_first : bool, default False
+        Whether null values appear before valid values.
 
+    .. note::
+            Column indices are zero-based, refer only to leaf fields, and are in
+            depth-first order. This may make the column indices for nested schemas
+            different from what you expect. In most cases, it will be easier to
+            specify the sort order using column names instead of column indices
+            and converting using the ``from_sort_order`` method.
+
+    Examples
+    --------
+
+    In other APIs, sort order is specified by names, such as:
+
+    >>> sort_order = [('id', 'ascending'), ('timestamp', 'descending')]
+
+    For Parquet, the column index must be used instead:
+
+    >>> import pyarrow.parquet as pq
+    >>> [pq.SortingColumn(0), pq.SortingColumn(1, descending=True)]
+    [SortingColumn(column_index=0, descending=False, nulls_first=False),
+     SortingColumn(column_index=1, descending=True, nulls_first=False)]
+
+    Convert the sort_order into the list of sorting columns with 
+    ``from_sort_order`` (note that the schema must be provided as well):
+
+    >>> import pyarrow as pa
+    >>> schema = pa.schema([('id', pa.int64()), ('timestamp', pa.timestamp('ms'))])
+    >>> sorting_columns = pq.SortingColumn.from_sort_order(schema, sort_order)
+    >>> sorting_columns
+    (SortingColumn(column_index=0, descending=False, nulls_first=False),
+     SortingColumn(column_index=1, descending=True, nulls_first=False))
+
+    Convert back to the sort order with ``to_sort_order``:
+
+    >>> pq.SortingColumn.to_sort_order(schema, sorting_columns)
+    ((('id', 'ascending'), ('timestamp', 'descending')), 'at_end')
     """
     cdef int column_index
     cdef c_bool descending
     cdef c_bool nulls_first
 
     def __init__(self, int column_index, c_bool descending=False, c_bool nulls_first=False):
-        """
-        Parameters
-        ----------
-        column_index : int
-            Index of column data is sorted by.
-        descending : bool, default False
-            Whether column is sorted in descending order.
-        nulls_first : bool, default False
-            Whether null values appear before valid values.
-        """
         self.column_index = column_index
         self.descending = descending
         self.nulls_first = nulls_first
@@ -588,7 +619,7 @@ cdef class SortingColumn:
         return tuple(sorting_columns)
 
     @staticmethod
-    def as_sort_order(Schema schema, sorting_columns):
+    def to_sort_order(Schema schema, sorting_columns):
         """
         Convert a tuple of SortingColumn objects to the same format as
         :class:`pyarrow.compute.SortOptions`.
@@ -605,7 +636,7 @@ cdef class SortingColumn:
         sort_keys : tuple of (name, order) tuples
         null_placement : {'at_start', 'at_end'}
         """
-        col_map = {i: name for i, name in _name_to_index_map(schema).items()}
+        col_map = {i: name for name, i in _name_to_index_map(schema).items()}
 
         sort_keys = []
         nulls_first = None
@@ -1906,7 +1937,7 @@ cdef _name_to_index_map(Schema arrow_schema):
     cdef SchemaDescriptor* parquet_schema = sp_parquet_schema.get()
 
     for i in range(parquet_schema.num_columns()):
-        name = frombytes(parquet_schema.Column(i).name())
+        name = frombytes(parquet_schema.Column(i).path().get().ToDotString())
         out[name] = i
 
     return out

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -532,13 +532,13 @@ cdef class SortingColumn:
     >>> import pyarrow.parquet as pq
     >>> [pq.SortingColumn(0), pq.SortingColumn(1, descending=True)]
     [<pyarrow._parquet.SortingColumn object at 0x102c19cd0>
-       column_index: 0
-       descending: False
-       nulls_first: False,
+      column_index: 0
+      descending: False
+      nulls_first: False,
      <pyarrow._parquet.SortingColumn object at 0x102c191d0>
-       column_index: 1
-       descending: True
-       nulls_first: False]
+      column_index: 1
+      descending: True
+      nulls_first: False]
 
     Convert the sort_order into the list of sorting columns with 
     ``from_sort_order`` (note that the schema must be provided as well):
@@ -548,13 +548,13 @@ cdef class SortingColumn:
     >>> sorting_columns = pq.SortingColumn.from_sort_order(schema, sort_order)
     >>> sorting_columns
     (<pyarrow._parquet.SortingColumn object at 0x10598bf70>
-       column_index: 0
-       descending: False
-       nulls_first: False,
+      column_index: 0
+      descending: False
+      nulls_first: False,
      <pyarrow._parquet.SortingColumn object at 0x102c18cd0>
-       column_index: 1
-       descending: True
-       nulls_first: False)
+      column_index: 1
+      descending: True
+      nulls_first: False)
 
     Convert back to the sort order with ``to_sort_order``:
 

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -715,11 +715,42 @@ class ParquetFile:
 
         Returns
         -------
-        sort_order : tuple of (sort_keys, null_placement) or None
-            The sort order of the file. sort_keys is a sequence of tuples of
-            (name, order) where name is the column name and order is either
-            "ascending" or "descending". null_placement is either "at_start"
-            or "at_end". If the file is not sorted, None is returned.
+        sort_order : tuple of SortingColumn or None
+            The sort order of the file. If the file is not sorted, None is returned.
+
+        Examples
+        --------
+
+        Parquet files can be written with a sort order. However, you are responsible
+        for ensuring the data provided is sorted; the parquet writer doesn't perform
+        the sorting for you.
+
+        >>> import pyarrow.parquet as pq
+        >>> import pyarrow as pa
+        >>> table = pa.table({'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                   'animal': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                              "Brittle stars", "Centipede"]})
+        >>> sort_keys = (("n_legs", "descending"), ("animal", "ascending"))
+        >>> table = table.sort_by(sort_keys)
+
+        While the sort_by function takes arguments in terms of column names, the
+        Parquet API requires indices. Use the
+        :meth:`pyarrow.parquet.SortingColumn.from_sort_order` method to convert 
+        the sort keys.
+
+        >>> sorting_columns = pq.SortingColumn.from_sort_order(table.schema, sort_keys)
+        >>> sorting_columns
+        (SortingColumn(column_index=0, descending=True, nulls_first=False),
+         SortingColumn(column_index=1, descending=False, nulls_first=False))
+
+        Write the table to a Parquet file with the sort order and read it back:
+
+        >>> pq.write_table(table, 'sorted_animals.parquet',
+        ...                sorting_columns = sorting_columns)
+        >>> parquet_file = pq.ParquetFile('sorted_animals.parquet')
+        >>> parquet_file.sort_order
+        (SortingColumn(column_index=0, descending=True, nulls_first=False),
+         SortingColumn(column_index=1, descending=False, nulls_first=False))
         """
         metadata = self.metadata
         sorting_columns = {
@@ -901,6 +932,7 @@ sorting_columns : Sequence of SortingColumn, default None
     Specify the sort order of the data being written. The writer does not sort
     the data nor does it verify that the data is sorted. The sort order is
     written to the row group metadata, which can then be used by readers.
+    See example at :attr:`ParquetFile.sort_order`.
 """
 
 _parquet_writer_example_doc = """\

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -734,26 +734,8 @@ class ParquetFile:
         if len(sorting_columns) == 0:
             # There are no sorting columns
             return None
-
-        # Need to map the Parquet column indices into field references
-        sort_keys = []
-        for sorting_column in sorting_columns:
-            name = self.schema.column(sorting_column.column_index).name
-            if sorting_column.descending:
-                order = "descending"
-            else:
-                order = "ascending"
-            sort_keys.append((name, order))
-
-        if all(col.nulls_first for col in sorting_columns):
-            null_placement = "at_start"
-        elif all(not col.nulls_first for col in sorting_columns):
-            null_placement = "at_end"
         else:
-            # Mixed null placement is not supported
-            return None
-
-        return (sort_keys, null_placement)
+            return sorting_columns
 
 
 _SPARK_DISALLOWED_CHARS = re.compile('[ ,;{}()\n\t=]')

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -740,8 +740,14 @@ class ParquetFile:
 
         >>> sorting_columns = pq.SortingColumn.from_sort_order(table.schema, sort_keys)
         >>> sorting_columns
-        (SortingColumn(column_index=0, descending=True, nulls_first=False),
-         SortingColumn(column_index=1, descending=False, nulls_first=False))
+        (<pyarrow._parquet.SortingColumn object at 0x1065e4210>
+           column_index: 0
+           descending: True
+           nulls_first: False,
+         <pyarrow._parquet.SortingColumn object at 0x1065e7a90>
+           column_index: 1
+           descending: False
+           nulls_first: False)
 
         Write the table to a Parquet file with the sort order and read it back:
 
@@ -749,8 +755,14 @@ class ParquetFile:
         ...                sorting_columns = sorting_columns)
         >>> parquet_file = pq.ParquetFile('sorted_animals.parquet')
         >>> parquet_file.sort_order
-        (SortingColumn(column_index=0, descending=True, nulls_first=False),
-         SortingColumn(column_index=1, descending=False, nulls_first=False))
+        (<pyarrow._parquet.SortingColumn object at 0x1065e7810>
+           column_index: 0
+           descending: True
+           nulls_first: False,
+         <pyarrow._parquet.SortingColumn object at 0x1065e47d0>
+           column_index: 1
+           descending: False
+           nulls_first: False)
         """
         metadata = self.metadata
         sorting_columns = {

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -735,7 +735,7 @@ class ParquetFile:
 
         While the sort_by function takes arguments in terms of column names, the
         Parquet API requires indices. Use the
-        :meth:`pyarrow.parquet.SortingColumn.from_sort_order` method to convert 
+        :meth:`pyarrow.parquet.SortingColumn.from_sort_order` method to convert
         the sort keys.
 
         >>> sorting_columns = pq.SortingColumn.from_sort_order(table.schema, sort_keys)

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -708,78 +708,6 @@ class ParquetFile:
 
         return indices
 
-    @property
-    def sort_order(self):
-        """
-        Return the sort order of the file, if any.
-
-        Returns
-        -------
-        sort_order : tuple of SortingColumn or None
-            The sort order of the file. If the file is not sorted, None is returned.
-
-        Examples
-        --------
-
-        Parquet files can be written with a sort order. However, you are responsible
-        for ensuring the data provided is sorted; the parquet writer doesn't perform
-        the sorting for you.
-
-        >>> import pyarrow.parquet as pq
-        >>> import pyarrow as pa
-        >>> table = pa.table({'n_legs': [2, 2, 4, 4, 5, 100],
-        ...                   'animal': ["Flamingo", "Parrot", "Dog", "Horse",
-        ...                              "Brittle stars", "Centipede"]})
-        >>> sort_keys = (("n_legs", "descending"), ("animal", "ascending"))
-        >>> table = table.sort_by(sort_keys)
-
-        While the sort_by function takes arguments in terms of column names, the
-        Parquet API requires indices. Use the
-        :meth:`pyarrow.parquet.SortingColumn.from_sort_order` method to convert
-        the sort keys.
-
-        >>> sorting_columns = pq.SortingColumn.from_sort_order(table.schema, sort_keys)
-        >>> sorting_columns
-        (<pyarrow._parquet.SortingColumn object at 0x1065e4210>
-           column_index: 0
-           descending: True
-           nulls_first: False,
-         <pyarrow._parquet.SortingColumn object at 0x1065e7a90>
-           column_index: 1
-           descending: False
-           nulls_first: False)
-
-        Write the table to a Parquet file with the sort order and read it back:
-
-        >>> pq.write_table(table, 'sorted_animals.parquet',
-        ...                sorting_columns = sorting_columns)
-        >>> parquet_file = pq.ParquetFile('sorted_animals.parquet')
-        >>> parquet_file.sort_order
-        (<pyarrow._parquet.SortingColumn object at 0x1065e7810>
-           column_index: 0
-           descending: True
-           nulls_first: False,
-         <pyarrow._parquet.SortingColumn object at 0x1065e47d0>
-           column_index: 1
-           descending: False
-           nulls_first: False)
-        """
-        metadata = self.metadata
-        sorting_columns = {
-            metadata.row_group(i).sorting_columns
-            for i in range(metadata.num_row_groups)
-        }
-
-        if len(sorting_columns) > 1:
-            # There are inconsistent sorting columns, so no global sort order
-            return None
-        sorting_columns = sorting_columns.pop()
-        if len(sorting_columns) == 0:
-            # There are no sorting columns
-            return None
-        else:
-            return sorting_columns
-
 
 _SPARK_DISALLOWED_CHARS = re.compile('[ ,;{}()\n\t=]')
 
@@ -944,7 +872,6 @@ sorting_columns : Sequence of SortingColumn, default None
     Specify the sort order of the data being written. The writer does not sort
     the data nor does it verify that the data is sorted. The sort order is
     written to the row group metadata, which can then be used by readers.
-    See example at :attr:`ParquetFile.sort_order`.
 """
 
 _parquet_writer_example_doc = """\

--- a/python/pyarrow/tests/parquet/test_metadata.py
+++ b/python/pyarrow/tests/parquet/test_metadata.py
@@ -385,10 +385,6 @@ def test_parquet_file_sorting_columns():
                            for i in range(metadata.num_row_groups)}
     assert set_sorting_columns == set([sorting_columns])
 
-    # Can also retrieve from the file reader
-    pq_file = pq.ParquetFile(reader)
-    assert pq_file.sort_order == sorting_columns
-
 
 def test_field_id_metadata():
     # ARROW-7080

--- a/python/pyarrow/tests/parquet/test_metadata.py
+++ b/python/pyarrow/tests/parquet/test_metadata.py
@@ -381,9 +381,8 @@ def test_parquet_file_sorting_columns():
 
     # Can retrieve sorting columns from metadata
     metadata = pq.read_metadata(reader)
-    set_sorting_columns = {metadata.row_group(i).sorting_columns
-                           for i in range(metadata.num_row_groups)}
-    assert set_sorting_columns == set([sorting_columns])
+    assert metadata.num_row_groups == 1
+    assert sorting_columns == metadata.row_group(0).sorting_columns
 
 
 def test_field_id_metadata():

--- a/python/pyarrow/tests/parquet/test_metadata.py
+++ b/python/pyarrow/tests/parquet/test_metadata.py
@@ -301,19 +301,57 @@ def test_parquet_write_disable_statistics(tempdir):
     assert cc_b.statistics is None
 
 
-def test_parquet_sorting_columns():
-    table = pa.table({'a': [1, 2, 3], 'b': ['a', 'b', 'c']})
+def test_parquet_sorting_column():
+    sorting_col = pq.SortingColumn(10)
+    assert sorting_col.column_index == 10
+    assert sorting_col.descending is False
+    assert sorting_col.nulls_first is False
 
-    # Rejects invalid sorting_columns
-    writer = pa.BufferOutputStream()
+    sorting_col = pq.SortingColumn(0, descending=True, nulls_first=True)
+    assert sorting_col.column_index == 0
+    assert sorting_col.descending is True
+    assert sorting_col.nulls_first is True
+
+    schema = pa.schema([('a', pa.int64()), ('b', pa.int64())])
+    sorting_cols = (
+        pq.SortingColumn(1, descending=True),
+        pq.SortingColumn(0, descending=False),
+    )
+    sort_order, null_placement = pq.SortingColumn.as_sort_order(schema, sorting_cols)
+    assert sort_order == (('b', "descending"), ('a', "ascending"))
+    assert null_placement == "at_end"
+
+    sorting_cols_roundtripped = pq.SortingColumn.from_sort_order(
+        schema, sort_order, null_placement)
+    assert sorting_cols_roundtripped == sorting_cols
+
+    sorting_cols = pq.SortingColumn.from_sort_order(
+        schema, ('a', ('b', "descending")), null_placement="at_start")
+    expected = (
+        pq.SortingColumn(0, descending=False, nulls_first=True),
+        pq.SortingColumn(1, descending=True, nulls_first=True),
+    )
+    assert sorting_cols == expected
+
+    # Conversions handle empty tuples
+    empty_sorting_cols = pq.SortingColumn.from_sort_order(schema, ())
+    assert empty_sorting_cols == ()
+
+    assert pq.SortingColumn.as_sort_order(schema, ()) == ((), "at_end")
+
     with pytest.raises(ValueError):
-        _write_table(table, writer, sorting_columns="string")
-    with pytest.raises(ValueError):
-        _write_table(table, writer, sorting_columns=["string"])
-    with pytest.raises(ValueError):
-        _write_table(table, writer, sorting_columns=([("string", None)]))
-    with pytest.raises(ValueError):
-        _write_table(table, writer, sorting_columns=([("string")], None))
+        pq.SortingColumn.from_sort_order(schema, (("a", "not a valid sort order")))
+
+    with pytest.raises(ValueError, match="inconsistent null placement"):
+        sorting_cols = (
+            pq.SortingColumn(1, nulls_first=True),
+            pq.SortingColumn(0, nulls_first=False),
+        )
+        pq.SortingColumn.as_sort_order(schema, sorting_cols)
+
+
+def test_parquet_file_sorting_columns():
+    table = pa.table({'a': [1, 2, 3], 'b': ['a', 'b', 'c']})
 
     sorting_columns = (
         pq.SortingColumn(column_index=0, descending=True, nulls_first=True),
@@ -329,47 +367,9 @@ def test_parquet_sorting_columns():
                            for i in range(metadata.num_row_groups)}
     assert set_sorting_columns == set([sorting_columns])
 
-    # Sort keys are None since nulls_first is inconsistent.
+    # Can also retrieve from the file reader
     pq_file = pq.ParquetFile(reader)
-    assert pq_file.sort_order is None
-
-    expected = (
-        pq.SortingColumn(column_index=0, descending=True),
-        pq.SortingColumn(column_index=1, descending=False),
-    )
-    writer = pa.BufferOutputStream()
-    _write_table(table, writer, sorting_columns=[("a", "descending"), "b"])
-    reader = pa.BufferReader(writer.getvalue())
-
-    # Can retrieve sorting columns from metadata
-    metadata = pq.read_metadata(reader)
-    set_sorting_columns = {metadata.row_group(i).sorting_columns
-                           for i in range(metadata.num_row_groups)}
-    assert set_sorting_columns == set([expected])
-
-    # Sort keys can be retrieved at file level
-    pq_file = pq.ParquetFile(reader)
-    assert pq_file.sort_order == ([("a", "descending"), ("b", "ascending")], "at_end")
-
-    # Now with nulls_first=True
-    expected = (
-        pq.SortingColumn(column_index=0, descending=True, nulls_first=True),
-        pq.SortingColumn(column_index=1, descending=False, nulls_first=True),
-    )
-    writer = pa.BufferOutputStream()
-    _write_table(table, writer, sorting_columns=(
-        [("a", "descending"), "b"], "at_start"))
-    reader = pa.BufferReader(writer.getvalue())
-
-    # Can retrieve sorting columns from metadata
-    metadata = pq.read_metadata(reader)
-    set_sorting_columns = {metadata.row_group(i).sorting_columns
-                           for i in range(metadata.num_row_groups)}
-    assert set_sorting_columns == set([expected])
-
-    # Sort keys can be retrieved at file level
-    pq_file = pq.ParquetFile(reader)
-    assert pq_file.sort_order == ([("a", "descending"), ("b", "ascending")], "at_start")
+    assert pq_file.sort_order == sorting_columns
 
 
 def test_field_id_metadata():


### PR DESCRIPTION
### Rationale for this change

Parquet supports metadata to indicate sort order of the data. This exposes that in a low-level API through row group metadata.

### What changes are included in this PR?

* Adds a new class `pyarrow.parquet.SortingColumn` to represent sorting of a particular column. Since this represents column references in terms of Parquet's standard for column indices, provided method to convert to and from column names.
* Exposes sort order of individual row groups in the metadata.

### Are these changes tested?

Yes, I've added unit tests for all new functionality.

### Are there any user-facing changes?

This adds new APIs and provides documentation for them.

* Closes: #35331