### PR TITLE
GH-35442: [C++][FlightRPC] Pass ServerCallContext instead of CallHeaders to ServerMiddlewareFactory::StartCall()

### DIFF
--- a/cpp/src/arrow/flight/CMakeLists.txt
+++ b/cpp/src/arrow/flight/CMakeLists.txt
@@ -199,6 +199,7 @@ set(ARROW_FLIGHT_SRCS
     serialization_internal.cc
     server.cc
     server_auth.cc
+    server_middleware.cc
     server_tracing_middleware.cc
     transport.cc
     transport_server.cc

--- a/cpp/src/arrow/flight/integration_tests/test_integration.cc
+++ b/cpp/src/arrow/flight/integration_tests/test_integration.cc
@@ -143,10 +143,10 @@ class TestServerMiddleware : public ServerMiddleware {
 
 class TestServerMiddlewareFactory : public ServerMiddlewareFactory {
  public:
-  Status StartCall(const CallInfo& info, const CallHeaders& incoming_headers,
+  Status StartCall(const CallInfo& info, const ServerCallContext& context,
                    std::shared_ptr<ServerMiddleware>* middleware) override {
     const std::pair<CallHeaders::const_iterator, CallHeaders::const_iterator>& iter_pair =
-        incoming_headers.equal_range("x-middleware");
+        context.incoming_headers().equal_range("x-middleware");
     std::string received = "";
     if (iter_pair.first != iter_pair.second) {
       const std::string_view& value = (*iter_pair.first).second;

--- a/cpp/src/arrow/flight/server_auth.h
+++ b/cpp/src/arrow/flight/server_auth.h
@@ -21,14 +21,13 @@
 
 #include <string>
 
+#include "arrow/flight/type_fwd.h"
 #include "arrow/flight/visibility.h"
 #include "arrow/status.h"
 
 namespace arrow {
 
 namespace flight {
-
-class ServerCallContext;
 
 /// \brief A reader for messages from the client during an
 /// authentication handshake.

--- a/cpp/src/arrow/flight/server_middleware.cc
+++ b/cpp/src/arrow/flight/server_middleware.cc
@@ -1,0 +1,35 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/flight/server_middleware.h"
+#include "arrow/flight/server.h"
+
+namespace arrow {
+namespace flight {
+
+Status ServerMiddlewareFactory::StartCall(const CallInfo& info,
+                                          const ServerCallContext& context,
+                                          std::shared_ptr<ServerMiddleware>* middleware) {
+  // TODO: We can make this pure virtual function when we remove
+  // the deprecated version.
+  ARROW_SUPPRESS_DEPRECATION_WARNING
+  return StartCall(info, context.incoming_headers(), middleware);
+  ARROW_UNSUPPRESS_DEPRECATION_WARNING
+}
+
+}  // namespace flight
+}  // namespace arrow

--- a/cpp/src/arrow/flight/server_middleware.h
+++ b/cpp/src/arrow/flight/server_middleware.h
@@ -24,6 +24,7 @@
 #include <string>
 
 #include "arrow/flight/middleware.h"
+#include "arrow/flight/type_fwd.h"
 #include "arrow/flight/visibility.h"  // IWYU pragma: keep
 #include "arrow/status.h"
 
@@ -65,6 +66,22 @@ class ARROW_FLIGHT_EXPORT ServerMiddlewareFactory {
   ///
   /// Return a non-OK status to reject the call with the given status.
   ///
+  /// \param[in] info Information about the call.
+  /// \param[in] context The call context.
+  /// \param[out] middleware The middleware instance for this call. If
+  ///     null, no middleware will be added to this call instance from
+  ///     this factory.
+  /// \return Status A non-OK status will reject the call with the
+  ///     given status. Middleware previously in the chain will have
+  ///     their CallCompleted callback called. Other middleware
+  ///     factories will not be called.
+  virtual Status StartCall(const CallInfo& info, const ServerCallContext& context,
+                           std::shared_ptr<ServerMiddleware>* middleware);
+
+  /// \brief A callback for the start of a new call.
+  ///
+  /// Return a non-OK status to reject the call with the given status.
+  ///
   /// \param info Information about the call.
   /// \param incoming_headers Headers sent by the client for this call.
   ///     Do not retain a reference to this object.
@@ -75,8 +92,13 @@ class ARROW_FLIGHT_EXPORT ServerMiddlewareFactory {
   ///     given status. Middleware previously in the chain will have
   ///     their CallCompleted callback called. Other middleware
   ///     factories will not be called.
+  /// \deprecated Deprecated in 13.0.0. Implement the StartCall()
+  /// with ServerCallContext version instead.
+  ARROW_DEPRECATED("Deprecated in 13.0.0. Use ServerCallContext overload instead.")
   virtual Status StartCall(const CallInfo& info, const CallHeaders& incoming_headers,
-                           std::shared_ptr<ServerMiddleware>* middleware) = 0;
+                           std::shared_ptr<ServerMiddleware>* middleware) {
+    return Status::NotImplemented(typeid(this).name(), "::StartCall() isn't implemented");
+  }
 };
 
 }  // namespace flight

--- a/cpp/src/arrow/flight/server_tracing_middleware.cc
+++ b/cpp/src/arrow/flight/server_tracing_middleware.cc
@@ -122,11 +122,11 @@ class TracingServerMiddleware::Impl {
 class TracingServerMiddlewareFactory : public ServerMiddlewareFactory {
  public:
   virtual ~TracingServerMiddlewareFactory() = default;
-  Status StartCall(const CallInfo& info, const CallHeaders& incoming_headers,
+  Status StartCall(const CallInfo& info, const ServerCallContext& context,
                    std::shared_ptr<ServerMiddleware>* middleware) override {
     constexpr char kServiceName[] = "arrow.flight.protocol.FlightService";
 
-    FlightServerCarrier carrier(incoming_headers);
+    FlightServerCarrier carrier(context.incoming_headers());
     auto context = otel::context::RuntimeContext::GetCurrent();
     auto propagator =
         otel::context::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
@@ -167,7 +167,7 @@ class TracingServerMiddleware::Impl {
 class TracingServerMiddlewareFactory : public ServerMiddlewareFactory {
  public:
   virtual ~TracingServerMiddlewareFactory() = default;
-  Status StartCall(const CallInfo&, const CallHeaders&,
+  Status StartCall(const CallInfo&, const ServerCallContext&,
                    std::shared_ptr<ServerMiddleware>* middleware) override {
     std::unique_ptr<TracingServerMiddleware::Impl> impl(
         new TracingServerMiddleware::Impl());

--- a/cpp/src/arrow/flight/server_tracing_middleware.cc
+++ b/cpp/src/arrow/flight/server_tracing_middleware.cc
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include "arrow/flight/server.h"
 #include "arrow/flight/server_tracing_middleware.h"
 
 #include <string>

--- a/cpp/src/arrow/flight/server_tracing_middleware.cc
+++ b/cpp/src/arrow/flight/server_tracing_middleware.cc
@@ -15,8 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "arrow/flight/server.h"
 #include "arrow/flight/server_tracing_middleware.h"
+#include "arrow/flight/server.h"
 
 #include <string>
 #include <string_view>

--- a/cpp/src/arrow/flight/server_tracing_middleware.cc
+++ b/cpp/src/arrow/flight/server_tracing_middleware.cc
@@ -127,14 +127,14 @@ class TracingServerMiddlewareFactory : public ServerMiddlewareFactory {
     constexpr char kServiceName[] = "arrow.flight.protocol.FlightService";
 
     FlightServerCarrier carrier(context.incoming_headers());
-    auto context = otel::context::RuntimeContext::GetCurrent();
+    auto otel_context = otel::context::RuntimeContext::GetCurrent();
     auto propagator =
         otel::context::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
-    auto new_context = propagator->Extract(carrier, context);
+    auto new_otel_context = propagator->Extract(carrier, otel_context);
 
     otel::trace::StartSpanOptions options;
     options.kind = otel::trace::SpanKind::kServer;
-    options.parent = otel::trace::GetSpan(new_context)->GetContext();
+    options.parent = otel::trace::GetSpan(new_otel_context)->GetContext();
 
     auto* tracer = arrow::internal::tracing::GetTracer();
     auto method_name = ToString(info.method);

--- a/cpp/src/arrow/flight/transport/grpc/grpc_server.cc
+++ b/cpp/src/arrow/flight/transport/grpc/grpc_server.cc
@@ -323,8 +323,7 @@ class GrpcServiceHandler final : public FlightService::Service {
     GrpcAddServerHeaders outgoing_headers(context);
     for (const auto& factory : middleware_) {
       std::shared_ptr<ServerMiddleware> instance;
-      Status result =
-          factory.second->StartCall(info, flight_context.incoming_headers(), &instance);
+      Status result = factory.second->StartCall(info, flight_context, &instance);
       if (!result.ok()) {
         // Interceptor rejected call, end the request on all existing
         // interceptors


### PR DESCRIPTION
### Rationale for this change

Because it's also a RPC call like others such as `ListFlights()` and `DoGet()`.

If we pass `ServerCallContext` instead of `CallHeaders`, implementers can also get other information such as client address. For example, https://github.com/apache/arrow-flight-sql-postgresql will use it by `ServerCallContext::peer()`.

### What changes are included in this PR?

Passes `ServerCallContext` instead of `CallHeaders` but keeps a backward compatibility.
Implementers can still use the old signature.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes. But this is still backward compatible.
* Closes: #35442