### PR TITLE
MINOR: [Go][CI][Benchmarking] Fix 'Run Benchmarks' steps of 'Go' CI check (broken on `main`, fails with `TypeError`)

### DIFF
--- a/ci/scripts/go_bench_adapt.py
+++ b/ci/scripts/go_bench_adapt.py
@@ -38,11 +38,8 @@ SCRIPTS_PATH = ARROW_ROOT / "ci" / "scripts"
 github_commit_info: Optional[Dict] = None
 
 if os.environ.get("CONBENCH_REF") == "main":
-    # Assume GitHub Actions CI. The environment
-    # variable lookups below are expected to fail when
-    # not running in GitHub Actions. See
-    # https://github.com/conbench/conbench/blob/7c4968e631ecdc064559c86a1174a1353713b700/benchadapt/python/benchadapt/result.py#L66
-    # for a specification of this `github` argument.
+    # Assume GitHub Actions CI. The environment variable lookups below are
+    # expected to fail when not running in GitHub Actions.
     github_commit_info = {
         "repository": os.environ["GITHUB_REPOSITORY"],
         "commit": os.environ["GITHUB_SHA"],
@@ -50,23 +47,23 @@ if os.environ.get("CONBENCH_REF") == "main":
     }
     run_reason = "commit"
 else:
-    # Assume that the environment is not GitHub Actions CI.
-    # Error out if that assumption seems to be wrong.
+    # Assume that the environment is not GitHub Actions CI. Error out if that
+    # assumption seems to be wrong.
     assert os.getenv("GITHUB_ACTIONS") is None
 
-    # This is probably a local dev environment, for testing.
-    # In this case, it does usually not make sense to provide
-    # commit information (not a controlled CI environment).
-    # Explicitly set `github=None` to reflect that (to _not_
-    # send commit information).
+    # This is probably a local dev environment, for testing. In this case, it
+    # does usually not make sense to provide commit information (not a
+    # controlled CI environment). Explicitly keep `github_commit_info=None` to
+    # reflect that (to not send commit information).
 
-    # Reflect 'local dev' scenario in run_reason. Allow user
-    # to (optionally) inject a custom piece of information
-    #into the run reason here, from environment.
+    # Reflect 'local dev' scenario in run_reason. Allow user to (optionally)
+    # inject a custom piece of information into the run reason here, from
+    # environment.
     run_reason = "localdev"
-    custom_reason_suffix = os.getenv('CONBENCH_CUSTOM_RUN_REASON')
+    custom_reason_suffix = os.getenv("CONBENCH_CUSTOM_RUN_REASON")
     if custom_reason_suffix is not None:
         run_reason += f" {custom_reason_suffix.strip()}"
+
 
 class GoAdapter(BenchmarkAdapter):
     result_file = "bench_stats.json"

--- a/ci/scripts/go_bench_adapt.py
+++ b/ci/scripts/go_bench_adapt.py
@@ -89,9 +89,9 @@ class GoAdapter(BenchmarkAdapter):
                 data = benchmark["Mem"]["MBPerSec"] * 1e6
                 time = 1 / benchmark["NsPerOp"] * 1e9
 
-                name = benchmark["Name"].removeprefix('Benchmark')
-                ncpu = name[name.rfind('-')+1:]
-                pieces = name[:-(len(ncpu)+1)].split('/')
+                name = benchmark["Name"].removeprefix("Benchmark")
+                ncpu = name[name.rfind("-") + 1 :]
+                pieces = name[: -(len(ncpu) + 1)].split("/")
 
                 parsed = BenchmarkResult(
                     run_id=run_id,
@@ -112,7 +112,7 @@ class GoAdapter(BenchmarkAdapter):
                         "pkg": pkg,
                         "num_cpu": ncpu,
                         "name": pieces[0],
-                        "params": '/'.join(pieces[1:]),
+                        "params": "/".join(pieces[1:]),
                     },
                     run_reason=run_reason,
                     github=github_commit_info,
@@ -125,5 +125,5 @@ class GoAdapter(BenchmarkAdapter):
 
 
 if __name__ == "__main__":
-    go_adapter = GoAdapter(result_fields_override={"info":{}})
+    go_adapter = GoAdapter(result_fields_override={"info": {}})
     go_adapter()

--- a/ci/scripts/go_bench_adapt.py
+++ b/ci/scripts/go_bench_adapt.py
@@ -66,7 +66,7 @@ else:
     run_reason = "localdev"
     custom_reason_suffix = os.getenv('CONBENCH_CUSTOM_RUN_REASON')
     if custom_reason_suffix is not None:
-        run_reason += f" {custom_run_reason.strip()}" 
+        run_reason += f" {custom_reason_suffix.strip()}"
 
 class GoAdapter(BenchmarkAdapter):
     result_file = "bench_stats.json"

--- a/ci/scripts/go_bench_adapt.py
+++ b/ci/scripts/go_bench_adapt.py
@@ -115,7 +115,9 @@ class GoAdapter(BenchmarkAdapter):
                     github=github_commit_info,
                 )
                 if github_commit_info is not None:
-                    parsed.run_name = f"{parsed.run_reason}: {parsed.github['commit']}"
+                    parsed.run_name = (
+                        f"{parsed.run_reason}: {github_commit_info['commit']}"
+                    )
                 parsed_results.append(parsed)
 
         return parsed_results

--- a/ci/scripts/go_bench_adapt.py
+++ b/ci/scripts/go_bench_adapt.py
@@ -20,7 +20,7 @@ import os
 import uuid
 import logging
 from pathlib import Path
-from typing import List
+from typing import List, Optional, Dict
 
 from benchadapt import BenchmarkResult
 from benchadapt.adapters import BenchmarkAdapter
@@ -30,6 +30,12 @@ log.setLevel(logging.DEBUG)
 
 ARROW_ROOT = Path(__file__).parent.parent.parent.resolve()
 SCRIPTS_PATH = ARROW_ROOT / "ci" / "scripts"
+
+# `github_commit_info` is meant to communicate GitHub-flavored commit
+# information to Conbench. See
+# https://github.com/conbench/conbench/blob/7c4968e631ecdc064559c86a1174a1353713b700/benchadapt/python/benchadapt/result.py#L66
+# for a specification.
+github_commit_info: Optional[Dict] = None
 
 if os.environ.get("CONBENCH_REF") == "main":
     # Assume GitHub Actions CI. The environment
@@ -53,7 +59,6 @@ else:
     # commit information (not a controlled CI environment).
     # Explicitly set `github=None` to reflect that (to _not_
     # send commit information).
-    github_commit_info = None
 
     # Reflect 'local dev' scenario in run_reason. Allow user
     # to (optionally) inject a custom piece of information


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

As part of https://github.com/apache/arrow/issues/31142 we did not rename `master` to `main` in [`ci/scripts/go_bench_adapt.py`](https://github.com/apache/arrow/blob/b43f4cd4ce28e2ddb7bad89081e141f381b09d5e/ci/scripts/go_bench_adapt.py#L34).

This was not immediately noticed in CI because we accidentally switched to a code branch intended for local dev (cf. the `else:` block [here](https://github.com/apache/arrow/blob/b43f4cd4ce28e2ddb7bad89081e141f381b09d5e/ci/scripts/go_bench_adapt.py#L41)), also see [this commit message](https://github.com/apache/arrow/commit/885e050b6b2c367d266793cba8d601c805a4e17d).

Since then we were unintentionally using a feature in conbench/benchadapt to read commit information from the local file system, instead of reading it from CI-focused environment variables.

That even worked for a while.

However, last week, that feature was [removed from benchadapt](https://github.com/conbench/conbench/pull/1135#issuecomment-1537110851) (certainly assuming that this is _not_ used in CI anywhere).

That is also when `BenchmarkResult.github` started to potentially become `None`. Which `mypy` knows about, see:
![image](https://user-images.githubusercontent.com/265630/236622341-0dee8385-d58b-4784-ab1e-233f4d471352.png)

Well, but further down in code, `parsed.github['commit']` was used w/o protection against this `None` case, and that is how we started to see CI run failures with
```
Traceback (most recent call last):
...
  File "/home/runner/work/arrow/arrow/ci/scripts/go_bench_adapt.py", line 94, in _transform_results
    parsed.run_name = f"{parsed.run_reason}: {parsed.github['commit']}"
TypeError: 'NoneType' object is not subscriptable
```
See e.g.  https://github.com/apache/arrow/actions/runs/4859969743/jobs/8742255231 -- thank you @zeroshade for reporting this.


### What changes are included in this PR?

- Clarification in code via comments
- More expressive variable naming, type hints
- Additional assert statement guarding against running 'local dev' code in CI
- Minor formatting changes via black in VSCode (that's OK I hope?)

A tiny feature/convenience for local dev: the env var `CONBENCH_CUSTOM_RUN_REASON` can be used to inject custom info.
```python
    # Reflect 'local dev' scenario in run_reason. Allow user to (optionally)
    # inject a custom piece of information into the run reason here, from
    # environment.
    run_reason = "localdev"
    custom_reason_suffix = os.getenv("CONBENCH_CUSTOM_RUN_REASON")
    if custom_reason_suffix is not None:
        run_reason += f" {custom_reason_suffix.strip()}"
```

### Are these changes tested?

No. Relied on mypy/pylint here.
