### PR TITLE
GH-35275: [Java] Ensure VectorSchemaRoot slice returns a new root

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorSchemaRoot.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorSchemaRoot.java
@@ -327,10 +327,6 @@ public class VectorSchemaRoot implements AutoCloseable {
     Preconditions.checkArgument(index + length <= rowCount,
         "index + length should <= rowCount");
 
-    if (index == 0 && length == rowCount) {
-      return this;
-    }
-
     List<FieldVector> sliceVectors = fieldVectors.stream().map(v -> {
       TransferPair transferPair = v.getTransferPair(v.getAllocator());
       transferPair.splitAndTransfer(index, length);


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
The optimization in the `slice` function for VectorSchemaRoot that returns the reference to the original root when the slice covers the entire root should be removed because this is an inconsistent interface (sometimes you get a totally new autocloseable and sometimes you get the original one). 

Also - in the [this documentation page](https://arrow.apache.org/docs/java/vector_schema_root.html#vectorschemaroot) it explicitly says that "A **NEW** VectorSchemaRoot can be sliced from an existing root without copying data:" so any time you call `slice`, the slice root should be a new one (even if it's the entire root). 

The test for slice has also been changed to have more coverage of the slice function (not just slicing from the start index).  


<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
Remove self reference return in `VectorSchemaRoot#split` and expand test coverage for the function.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
Yes

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
Yes 

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
**This PR includes breaking changes to public APIs.** 

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: apache/arrow#35275
* GitHub Issue: apache/arrow#35275
* GitHub Issue: #35275