### PR TITLE
MINOR: [CI][R] Nightly R upload fails due to wrong branch

### DIFF
--- a/.github/workflows/r_nightly.yml
+++ b/.github/workflows/r_nightly.yml
@@ -58,7 +58,7 @@ jobs:
           fetch-depth: 0
           path: crossbow
           repository: ursacomputing/crossbow
-          ref: master
+          ref: main
       - name: Set up Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
The [R nightly upload](https://github.com/apache/arrow/actions/runs/4915965925/jobs/8779129556) has failed since we renamed the default branch to main in crossbow due to the hardcoded branch name.