### PR TITLE
GH-35482: [Go] Append nulls to values in `array.FixedSizeListBuilder.AppendNull`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ java-native-cpp/
 dev/archery/build
 
 swift/Arrow/.build
+
+# Go dependencies
+go/vendor

--- a/go/arrow/array/fixed_size_list.go
+++ b/go/arrow/array/fixed_size_list.go
@@ -207,6 +207,9 @@ func (b *FixedSizeListBuilder) Append(v bool) {
 func (b *FixedSizeListBuilder) AppendNull() {
 	b.Reserve(1)
 	b.unsafeAppendBoolToBitmap(false)
+	for i := int32(0); i < b.n; i++ {
+		b.values.AppendNull()
+	}
 }
 
 func (b *FixedSizeListBuilder) AppendEmptyValue() {
@@ -311,9 +314,6 @@ func (b *FixedSizeListBuilder) UnmarshalOne(dec *json.Decoder) error {
 		return err
 	case nil:
 		b.AppendNull()
-		for i := int32(0); i < b.n; i++ {
-			b.values.AppendNull()
-		}
 	default:
 		return &json.UnmarshalTypeError{
 			Value:  fmt.Sprint(t),

--- a/go/arrow/array/fixed_size_list.go
+++ b/go/arrow/array/fixed_size_list.go
@@ -204,6 +204,7 @@ func (b *FixedSizeListBuilder) Append(v bool) {
 	b.unsafeAppendBoolToBitmap(v)
 }
 
+// AppendNull will append null values to the underlying values by itself
 func (b *FixedSizeListBuilder) AppendNull() {
 	b.Reserve(1)
 	b.unsafeAppendBoolToBitmap(false)

--- a/go/arrow/example_test.go
+++ b/go/arrow/example_test.go
@@ -225,7 +225,6 @@ func Example_fixedSizeListArray() {
 	vb.Append(2)
 
 	lb.AppendNull()
-	vb.AppendValues([]int64{-1, -1, -1}, nil)
 
 	lb.Append(true)
 	vb.Append(3)


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Currently there's a gotcha to use `array.FixedSizeListBuilder.AppendNull`: you have to manually append null values to the underlying list.

This changes this behavior to match the one of `array.FixedSizeListBuilder.AppendEmptyValue` that handles it by itself.

### What changes are included in this PR?

Add `AppendNull` call to the values builder in `array.FixedSizeListBuilder.AppendNull`.

### Are these changes tested?

Yes, the `Example_fixedSizeListArray` was modified to express the changed behavior.

### Are there any user-facing changes?

**This PR includes breaking changes to public APIs.**

Added `AppendNull` call to the values builder in `array.FixedSizeListBuilder.AppendNull`.
Previously, manually adding these calls was required.
After this change a simple `array.FixedSizeListBuilder.AppendNull` is enough to maintain the correct indices.

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #35482