### PR TITLE
GH-35485: [CI][Python] Archery formats Python C++ codebase

### DIFF
--- a/dev/archery/archery/lang/python.py
+++ b/dev/archery/archery/lang/python.py
@@ -31,6 +31,11 @@ from ..utils.logger import logger
 from ..utils.command import Command, capture_stdout, default_bin
 
 
+class PythonCommand(Command):
+    def __init__(self, python_bin=None):
+        self.bin = default_bin(python_bin, "python")
+
+
 class Flake8(Command):
     def __init__(self, flake8_bin=None):
         self.bin = default_bin(flake8_bin, "flake8")

--- a/dev/archery/archery/utils/lint.py
+++ b/dev/archery/archery/utils/lint.py
@@ -28,7 +28,7 @@ from .cmake import CMake
 from .git import git
 from .logger import logger
 from ..lang.cpp import CppCMakeDefinition, CppConfiguration
-from ..lang.python import Autopep8, Flake8, CythonLint, NumpyDoc
+from ..lang.python import Autopep8, Flake8, CythonLint, NumpyDoc, PythonCommand
 from .rat import Rat, exclusion_from_globs
 from .tmpdir import tmpdir
 
@@ -259,6 +259,26 @@ def python_linter(src, fix=False):
     yield LintResult.from_cmd(cython_lint(*args))
 
 
+def python_cpp_linter(src, clang_format=True, fix=False):
+    """Run C++ linters on python/pyarrow/src/arrow/python."""
+    cpp_src = os.path.join(src.python, "pyarrow", "src", "arrow", "python")
+
+    python = PythonCommand()
+
+    if clang_format:
+        logger.info("Running clang-format for python/pyarrow/src/arrow/python")
+        if "CLANG_TOOLS_PATH" in os.environ:
+            clang_format_binary = os.path.join(
+                os.environ["CLANG_TOOLS_PATH"], "clang-format")
+        else:
+            clang_format_binary = "clang-format"
+        args = ["cpp/build-support/run_clang_format.py", "--source_dir", cpp_src,
+                "--clang_format_binary", clang_format_binary]
+        if fix:
+            args += ["--fix"]
+        yield LintResult.from_cmd(python.run(*args))
+
+
 def python_numpydoc(symbols=None, allow_rules=None, disallow_rules=None):
     """Run numpydoc linter on python.
 
@@ -433,6 +453,11 @@ def linter(src, fix=False, *, clang_format=False, cpplint=False,
 
         if python:
             results.extend(python_linter(src, fix=fix))
+
+        if python and clang_format:
+            results.extend(python_cpp_linter(src,
+                                             clang_format=clang_format,
+                                             fix=fix))
 
         if numpydoc:
             results.extend(python_numpydoc())

--- a/dev/archery/archery/utils/lint.py
+++ b/dev/archery/archery/utils/lint.py
@@ -272,7 +272,7 @@ def python_cpp_linter(src, clang_format=True, fix=False):
             clang_format_binary = os.path.join(
                 os.environ["CLANG_TOOLS_PATH"], "clang-format")
         else:
-            clang_format_binary = "clang-format"
+            clang_format_binary = "clang-format-14"
 
         run_clang_format = os.path.join(src.cpp, "build-support",
                                         "run_clang_format.py")

--- a/dev/archery/archery/utils/lint.py
+++ b/dev/archery/archery/utils/lint.py
@@ -267,15 +267,20 @@ def python_cpp_linter(src, clang_format=True, fix=False):
 
     if clang_format:
         logger.info("Running clang-format for python/pyarrow/src/arrow/python")
+
         if "CLANG_TOOLS_PATH" in os.environ:
             clang_format_binary = os.path.join(
                 os.environ["CLANG_TOOLS_PATH"], "clang-format")
         else:
             clang_format_binary = "clang-format"
-        args = ["cpp/build-support/run_clang_format.py", "--source_dir", cpp_src,
+
+        run_clang_format = os.path.join(src.cpp, "build-support",
+                                        "run_clang_format.py")
+        args = [run_clang_format, "--source_dir", cpp_src,
                 "--clang_format_binary", clang_format_binary]
         if fix:
             args += ["--fix"]
+
         yield LintResult.from_cmd(python.run(*args))
 
 

--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -47,6 +47,13 @@ Some of the issues can be automatically fixed by passing the ``--fix`` option:
 
    $ archery lint --python --fix
 
+The Python code base also includes some C++ files. To fix formatting in those
+files, add the ``--clang-format`` option:
+
+.. code-block::
+
+   $ archery lint --python --clang-format --fix
+
 .. _python-unit-testing:
 
 Unit Testing

--- a/python/pyarrow/src/arrow/python/arrow_to_pandas.h
+++ b/python/pyarrow/src/arrow/python/arrow_to_pandas.h
@@ -42,9 +42,10 @@ class Table;
 namespace py {
 
 enum class MapConversionType {
-  DEFAULT, // convert arrow maps to assoc lists (list of kev-value tuples) in Pandas
-  LOSSY, // report warnings when lossiness is encountered due to duplicate keys
-  STRICT_, // raise a Python exception when lossiness is encountered due to duplicate keys
+  DEFAULT,  // convert arrow maps to assoc lists (list of kev-value tuples) in Pandas
+  LOSSY,    // report warnings when lossiness is encountered due to duplicate keys
+  STRICT_,  // raise a Python exception when lossiness is encountered due to duplicate
+            // keys
 };
 
 struct PandasOptions {

--- a/python/pyarrow/src/arrow/python/csv.h
+++ b/python/pyarrow/src/arrow/python/csv.h
@@ -23,8 +23,8 @@
 #include <vector>
 
 #include "arrow/csv/options.h"
-#include "arrow/util/macros.h"
 #include "arrow/python/common.h"
+#include "arrow/util/macros.h"
 
 namespace arrow {
 namespace py {

--- a/python/pyarrow/src/arrow/python/datetime.cc
+++ b/python/pyarrow/src/arrow/python/datetime.cc
@@ -23,16 +23,16 @@
 #include <string_view>
 
 #include "arrow/array.h"
+#include "arrow/python/arrow_to_python_internal.h"
+#include "arrow/python/common.h"
+#include "arrow/python/helpers.h"
+#include "arrow/python/platform.h"
 #include "arrow/scalar.h"
 #include "arrow/status.h"
 #include "arrow/type.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/regex.h"
 #include "arrow/util/value_parsing.h"
-#include "arrow/python/arrow_to_python_internal.h"
-#include "arrow/python/common.h"
-#include "arrow/python/helpers.h"
-#include "arrow/python/platform.h"
 
 namespace arrow {
 

--- a/python/pyarrow/src/arrow/python/datetime.h
+++ b/python/pyarrow/src/arrow/python/datetime.h
@@ -20,14 +20,14 @@
 #include <algorithm>
 #include <chrono>
 
+#include "arrow/python/platform.h"
+#include "arrow/python/visibility.h"
 #include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/type.h"
 #include "arrow/type_fwd.h"
 #include "arrow/util/int_util_overflow.h"
 #include "arrow/util/logging.h"
-#include "arrow/python/platform.h"
-#include "arrow/python/visibility.h"
 
 // By default, PyDateTimeAPI is a *static* variable.  This forces
 // PyDateTime_IMPORT to be called in every C/C++ module using the

--- a/python/pyarrow/src/arrow/python/decimal.cc
+++ b/python/pyarrow/src/arrow/python/decimal.cc
@@ -18,12 +18,12 @@
 #include <algorithm>
 #include <limits>
 
-#include "arrow/type_fwd.h"
-#include "arrow/util/decimal.h"
-#include "arrow/util/logging.h"
 #include "arrow/python/common.h"
 #include "arrow/python/decimal.h"
 #include "arrow/python/helpers.h"
+#include "arrow/type_fwd.h"
+#include "arrow/util/decimal.h"
+#include "arrow/util/logging.h"
 
 namespace arrow {
 namespace py {

--- a/python/pyarrow/src/arrow/python/deserialize.h
+++ b/python/pyarrow/src/arrow/python/deserialize.h
@@ -21,9 +21,9 @@
 #include <memory>
 #include <vector>
 
-#include "arrow/status.h"
 #include "arrow/python/serialize.h"
 #include "arrow/python/visibility.h"
+#include "arrow/status.h"
 
 namespace arrow {
 

--- a/python/pyarrow/src/arrow/python/extension_type.cc
+++ b/python/pyarrow/src/arrow/python/extension_type.cc
@@ -19,11 +19,11 @@
 #include <sstream>
 #include <utility>
 
-#include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
 #include "arrow/python/extension_type.h"
 #include "arrow/python/helpers.h"
 #include "arrow/python/pyarrow.h"
+#include "arrow/util/checked_cast.h"
+#include "arrow/util/logging.h"
 
 namespace arrow {
 

--- a/python/pyarrow/src/arrow/python/extension_type.h
+++ b/python/pyarrow/src/arrow/python/extension_type.h
@@ -21,9 +21,9 @@
 #include <string>
 
 #include "arrow/extension_type.h"
-#include "arrow/util/macros.h"
 #include "arrow/python/common.h"
 #include "arrow/python/visibility.h"
+#include "arrow/util/macros.h"
 
 namespace arrow {
 namespace py {

--- a/python/pyarrow/src/arrow/python/filesystem.cc
+++ b/python/pyarrow/src/arrow/python/filesystem.cc
@@ -15,8 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "arrow/util/logging.h"
 #include "arrow/python/filesystem.h"
+#include "arrow/util/logging.h"
 
 namespace arrow {
 

--- a/python/pyarrow/src/arrow/python/filesystem.h
+++ b/python/pyarrow/src/arrow/python/filesystem.h
@@ -22,9 +22,9 @@
 #include <vector>
 
 #include "arrow/filesystem/filesystem.h"
-#include "arrow/util/macros.h"
 #include "arrow/python/common.h"
 #include "arrow/python/visibility.h"
+#include "arrow/util/macros.h"
 
 namespace arrow {
 namespace py {

--- a/python/pyarrow/src/arrow/python/flight.cc
+++ b/python/pyarrow/src/arrow/python/flight.cc
@@ -18,9 +18,9 @@
 #include <signal.h>
 #include <utility>
 
+#include "arrow/python/flight.h"
 #include "arrow/util/io_util.h"
 #include "arrow/util/logging.h"
-#include "arrow/python/flight.h"
 
 using arrow::flight::FlightPayload;
 

--- a/python/pyarrow/src/arrow/python/gdb.cc
+++ b/python/pyarrow/src/arrow/python/gdb.cc
@@ -24,6 +24,7 @@
 #include "arrow/datum.h"
 #include "arrow/extension_type.h"
 #include "arrow/ipc/json_simple.h"
+#include "arrow/python/gdb.h"
 #include "arrow/record_batch.h"
 #include "arrow/scalar.h"
 #include "arrow/table.h"
@@ -33,7 +34,6 @@
 #include "arrow/util/key_value_metadata.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/macros.h"
-#include "arrow/python/gdb.h"
 
 namespace arrow {
 

--- a/python/pyarrow/src/arrow/python/helpers.cc
+++ b/python/pyarrow/src/arrow/python/helpers.cc
@@ -25,11 +25,11 @@
 #include <sstream>
 #include <type_traits>
 
+#include "arrow/python/common.h"
+#include "arrow/python/decimal.h"
 #include "arrow/type_fwd.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/logging.h"
-#include "arrow/python/common.h"
-#include "arrow/python/decimal.h"
 
 namespace arrow {
 

--- a/python/pyarrow/src/arrow/python/helpers.h
+++ b/python/pyarrow/src/arrow/python/helpers.h
@@ -28,9 +28,9 @@
 
 #include <numpy/halffloat.h>
 
+#include "arrow/python/visibility.h"
 #include "arrow/type.h"
 #include "arrow/util/macros.h"
-#include "arrow/python/visibility.h"
 
 namespace arrow {
 

--- a/python/pyarrow/src/arrow/python/inference.h
+++ b/python/pyarrow/src/arrow/python/inference.h
@@ -24,9 +24,9 @@
 
 #include <memory>
 
+#include "arrow/python/visibility.h"
 #include "arrow/type.h"
 #include "arrow/util/macros.h"
-#include "arrow/python/visibility.h"
 
 #include "common.h"
 

--- a/python/pyarrow/src/arrow/python/ipc.h
+++ b/python/pyarrow/src/arrow/python/ipc.h
@@ -19,11 +19,11 @@
 
 #include <memory>
 
+#include "arrow/python/common.h"
+#include "arrow/python/visibility.h"
 #include "arrow/record_batch.h"
 #include "arrow/result.h"
 #include "arrow/util/macros.h"
-#include "arrow/python/common.h"
-#include "arrow/python/visibility.h"
 
 namespace arrow {
 namespace py {

--- a/python/pyarrow/src/arrow/python/numpy_convert.h
+++ b/python/pyarrow/src/arrow/python/numpy_convert.h
@@ -27,8 +27,8 @@
 #include <vector>
 
 #include "arrow/buffer.h"
-#include "arrow/sparse_tensor.h"
 #include "arrow/python/visibility.h"
+#include "arrow/sparse_tensor.h"
 
 namespace arrow {
 

--- a/python/pyarrow/src/arrow/python/platform.h
+++ b/python/pyarrow/src/arrow/python/platform.h
@@ -24,7 +24,7 @@
 // to mean Py_ssize_t (defining this to suppress deprecation warning)
 #define PY_SSIZE_T_CLEAN
 
-#include <Python.h> // IWYU pragma: export
+#include <Python.h>  // IWYU pragma: export
 #include <datetime.h>
 
 // Work around C2528 error
@@ -33,4 +33,3 @@
 #undef timezone
 #endif
 #endif
-

--- a/python/pyarrow/src/arrow/python/python_test.cc
+++ b/python/pyarrow/src/arrow/python/python_test.cc
@@ -36,69 +36,77 @@
 #include "arrow/python/python_test.h"
 #include "arrow/python/python_to_arrow.h"
 
-#define ASSERT_EQ(x, y) { \
-  auto&& _left = (x); \
-  auto&& _right = (y); \
-  if (_left != _right) { \
-    return Status::Invalid("Expected equality between `", #x, "` and `", #y, \
-                           "`, but ", arrow::py::testing::ToString(_left), \
-                           " != ", arrow::py::testing::ToString(_right)); \
-  } \
-}
+#define ASSERT_EQ(x, y)                                                        \
+  {                                                                            \
+    auto&& _left = (x);                                                        \
+    auto&& _right = (y);                                                       \
+    if (_left != _right) {                                                     \
+      return Status::Invalid("Expected equality between `", #x, "` and `", #y, \
+                             "`, but ", arrow::py::testing::ToString(_left),   \
+                             " != ", arrow::py::testing::ToString(_right));    \
+    }                                                                          \
+  }
 
-#define ASSERT_NE(x, y) { \
-  auto&& _left = (x); \
-  auto&& _right = (y); \
-  if (_left == _right) { \
-    return Status::Invalid("Expected inequality between `", #x, "` and `", #y, \
-                           "`, but ", arrow::py::testing::ToString(_left), \
-                           " == ", arrow::py::testing::ToString(_right)); \
-  } \
-}
+#define ASSERT_NE(x, y)                                                          \
+  {                                                                              \
+    auto&& _left = (x);                                                          \
+    auto&& _right = (y);                                                         \
+    if (_left == _right) {                                                       \
+      return Status::Invalid("Expected inequality between `", #x, "` and `", #y, \
+                             "`, but ", arrow::py::testing::ToString(_left),     \
+                             " == ", arrow::py::testing::ToString(_right));      \
+    }                                                                            \
+  }
 
-#define ASSERT_FALSE(v) { \
-  auto&& _v = (v); \
-  if (!!_v) { \
-    return Status::Invalid("Expected `", #v, "` to evaluate to false, but got ", \
-                           arrow::py::testing::ToString(_v)); \
-  } \
-}
+#define ASSERT_FALSE(v)                                                            \
+  {                                                                                \
+    auto&& _v = (v);                                                               \
+    if (!!_v) {                                                                    \
+      return Status::Invalid("Expected `", #v, "` to evaluate to false, but got ", \
+                             arrow::py::testing::ToString(_v));                    \
+    }                                                                              \
+  }
 
-#define ASSERT_TRUE(v){ \
-  auto&& _v = (v); \
-  if (!_v) { \
-    return Status::Invalid("Expected `", #v, "` to evaluate to true, but got ", \
-                           arrow::py::testing::ToString(_v)); \
-  } \
-}
+#define ASSERT_TRUE(v)                                                            \
+  {                                                                               \
+    auto&& _v = (v);                                                              \
+    if (!_v) {                                                                    \
+      return Status::Invalid("Expected `", #v, "` to evaluate to true, but got ", \
+                             arrow::py::testing::ToString(_v));                   \
+    }                                                                             \
+  }
 
-#define ASSERT_FALSE_MSG(v, msg) { \
-  auto&& _v = (v); \
-  if (!!_v) { \
-    return Status::Invalid("Expected `", #v, "` to evaluate to false, but got ", \
-                           arrow::py::testing::ToString(_v), ": ", msg); \
-  } \
-}
+#define ASSERT_FALSE_MSG(v, msg)                                                   \
+  {                                                                                \
+    auto&& _v = (v);                                                               \
+    if (!!_v) {                                                                    \
+      return Status::Invalid("Expected `", #v, "` to evaluate to false, but got ", \
+                             arrow::py::testing::ToString(_v), ": ", msg);         \
+    }                                                                              \
+  }
 
-#define ASSERT_TRUE_MSG(v, msg) { \
-  auto&& _v = (v); \
-  if (!_v) { \
-    return Status::Invalid("Expected `", #v, "` to evaluate to true, but got ", \
-                           arrow::py::testing::ToString(_v), ": ", msg); \
-  } \
-}
+#define ASSERT_TRUE_MSG(v, msg)                                                   \
+  {                                                                               \
+    auto&& _v = (v);                                                              \
+    if (!_v) {                                                                    \
+      return Status::Invalid("Expected `", #v, "` to evaluate to true, but got ", \
+                             arrow::py::testing::ToString(_v), ": ", msg);        \
+    }                                                                             \
+  }
 
-#define ASSERT_OK(expr) { \
-  for (::arrow::Status _st = ::arrow::internal::GenericToStatus((expr)); !_st.ok();) \
-  return Status::Invalid("`", #expr, "` failed with ", _st.ToString()); \
-}
+#define ASSERT_OK(expr)                                                                \
+  {                                                                                    \
+    for (::arrow::Status _st = ::arrow::internal::GenericToStatus((expr)); !_st.ok();) \
+      return Status::Invalid("`", #expr, "` failed with ", _st.ToString());            \
+  }
 
-#define ASSERT_RAISES(code, expr) { \
-  for (::arrow::Status _st_expr = ::arrow::internal::GenericToStatus((expr)); \
-       !_st_expr.Is##code();) \
-  return Status::Invalid("Expected `", #expr, "` to fail with ", \
-                         #code, ", but got ", _st_expr.ToString()); \
-}
+#define ASSERT_RAISES(code, expr)                                               \
+  {                                                                             \
+    for (::arrow::Status _st_expr = ::arrow::internal::GenericToStatus((expr)); \
+         !_st_expr.Is##code();)                                                 \
+      return Status::Invalid("Expected `", #expr, "` to fail with ", #code,     \
+                             ", but got ", _st_expr.ToString());                \
+  }
 
 namespace arrow {
 
@@ -343,17 +351,17 @@ Status TestNumPyBufferNumpyArray() {
 }
 #endif
 
-Status TestPythonDecimalToString(){
+Status TestPythonDecimalToString() {
   OwnedRef decimal_constructor_;
   OwnedRef decimal_module;
 
   RETURN_NOT_OK(internal::ImportModule("decimal", &decimal_module));
-  RETURN_NOT_OK(internal::ImportFromModule(decimal_module.obj(), "Decimal",
-                                           &decimal_constructor_));
+  RETURN_NOT_OK(
+      internal::ImportFromModule(decimal_module.obj(), "Decimal", &decimal_constructor_));
 
   std::string decimal_string("-39402950693754869342983");
-  PyObject* python_object = internal::DecimalFromString(decimal_constructor_.obj(),
-                                                        decimal_string);
+  PyObject* python_object =
+      internal::DecimalFromString(decimal_constructor_.obj(), decimal_string);
   ASSERT_NE(python_object, nullptr);
 
   std::string string_result;
@@ -362,17 +370,17 @@ Status TestPythonDecimalToString(){
   return Status::OK();
 }
 
-Status TestInferPrecisionAndScale(){
+Status TestInferPrecisionAndScale() {
   OwnedRef decimal_constructor_;
   OwnedRef decimal_module;
 
   RETURN_NOT_OK(internal::ImportModule("decimal", &decimal_module));
-  RETURN_NOT_OK(internal::ImportFromModule(decimal_module.obj(), "Decimal",
-                                           &decimal_constructor_));
+  RETURN_NOT_OK(
+      internal::ImportFromModule(decimal_module.obj(), "Decimal", &decimal_constructor_));
 
   std::string decimal_string("-394029506937548693.42983");
-  PyObject* python_decimal = internal::DecimalFromString(decimal_constructor_.obj(),
-                                                        decimal_string);
+  PyObject* python_decimal =
+      internal::DecimalFromString(decimal_constructor_.obj(), decimal_string);
 
   internal::DecimalMetadata metadata;
   ASSERT_OK(metadata.Update(python_decimal));
@@ -387,17 +395,17 @@ Status TestInferPrecisionAndScale(){
   return Status::OK();
 }
 
-Status TestInferPrecisionAndNegativeScale(){
+Status TestInferPrecisionAndNegativeScale() {
   OwnedRef decimal_constructor_;
   OwnedRef decimal_module;
 
   RETURN_NOT_OK(internal::ImportModule("decimal", &decimal_module));
-  RETURN_NOT_OK(internal::ImportFromModule(decimal_module.obj(), "Decimal",
-                                           &decimal_constructor_));
+  RETURN_NOT_OK(
+      internal::ImportFromModule(decimal_module.obj(), "Decimal", &decimal_constructor_));
 
   std::string decimal_string("-3.94042983E+10");
-  PyObject* python_decimal = internal::DecimalFromString(decimal_constructor_.obj(),
-                                                        decimal_string);
+  PyObject* python_decimal =
+      internal::DecimalFromString(decimal_constructor_.obj(), decimal_string);
 
   internal::DecimalMetadata metadata;
   ASSERT_OK(metadata.Update(python_decimal));
@@ -411,17 +419,17 @@ Status TestInferPrecisionAndNegativeScale(){
   return Status::OK();
 }
 
-Status TestInferAllLeadingZeros(){
+Status TestInferAllLeadingZeros() {
   OwnedRef decimal_constructor_;
   OwnedRef decimal_module;
 
   RETURN_NOT_OK(internal::ImportModule("decimal", &decimal_module));
-  RETURN_NOT_OK(internal::ImportFromModule(decimal_module.obj(), "Decimal",
-                                           &decimal_constructor_));
+  RETURN_NOT_OK(
+      internal::ImportFromModule(decimal_module.obj(), "Decimal", &decimal_constructor_));
 
   std::string decimal_string("0.001");
-  PyObject* python_decimal = internal::DecimalFromString(decimal_constructor_.obj(),
-                                                        decimal_string);
+  PyObject* python_decimal =
+      internal::DecimalFromString(decimal_constructor_.obj(), decimal_string);
 
   internal::DecimalMetadata metadata;
   ASSERT_OK(metadata.Update(python_decimal));
@@ -431,17 +439,17 @@ Status TestInferAllLeadingZeros(){
   return Status::OK();
 }
 
-Status TestInferAllLeadingZerosExponentialNotationPositive(){
+Status TestInferAllLeadingZerosExponentialNotationPositive() {
   OwnedRef decimal_constructor_;
   OwnedRef decimal_module;
 
   RETURN_NOT_OK(internal::ImportModule("decimal", &decimal_module));
-  RETURN_NOT_OK(internal::ImportFromModule(decimal_module.obj(), "Decimal",
-                                           &decimal_constructor_));
+  RETURN_NOT_OK(
+      internal::ImportFromModule(decimal_module.obj(), "Decimal", &decimal_constructor_));
 
   std::string decimal_string("0.01E5");
-  PyObject* python_decimal = internal::DecimalFromString(decimal_constructor_.obj(),
-                                                        decimal_string);
+  PyObject* python_decimal =
+      internal::DecimalFromString(decimal_constructor_.obj(), decimal_string);
 
   internal::DecimalMetadata metadata;
   ASSERT_OK(metadata.Update(python_decimal));
@@ -451,17 +459,17 @@ Status TestInferAllLeadingZerosExponentialNotationPositive(){
   return Status::OK();
 }
 
-Status TestInferAllLeadingZerosExponentialNotationNegative(){
+Status TestInferAllLeadingZerosExponentialNotationNegative() {
   OwnedRef decimal_constructor_;
   OwnedRef decimal_module;
 
   RETURN_NOT_OK(internal::ImportModule("decimal", &decimal_module));
-  RETURN_NOT_OK(internal::ImportFromModule(decimal_module.obj(), "Decimal",
-                                           &decimal_constructor_));
+  RETURN_NOT_OK(
+      internal::ImportFromModule(decimal_module.obj(), "Decimal", &decimal_constructor_));
 
   std::string decimal_string("0.01E3");
-  PyObject* python_decimal = internal::DecimalFromString(decimal_constructor_.obj(),
-                                                        decimal_string);
+  PyObject* python_decimal =
+      internal::DecimalFromString(decimal_constructor_.obj(), decimal_string);
   internal::DecimalMetadata metadata;
   ASSERT_OK(metadata.Update(python_decimal));
   ASSERT_EQ(2, metadata.precision());
@@ -470,7 +478,7 @@ Status TestInferAllLeadingZerosExponentialNotationNegative(){
   return Status::OK();
 }
 
-Status TestObjectBlockWriteFails(){
+Status TestObjectBlockWriteFails() {
   StringBuilder builder;
   const char value[] = {'\xf1', '\0'};
 
@@ -502,7 +510,7 @@ Status TestObjectBlockWriteFails(){
   return Status::OK();
 }
 
-Status TestMixedTypeFails(){
+Status TestMixedTypeFails() {
   OwnedRef list_ref(PyList_New(3));
   PyObject* list = list_ref.obj();
 
@@ -530,40 +538,37 @@ Status TestMixedTypeFails(){
 
 template <typename DecimalValue>
 Status DecimalTestFromPythonDecimalRescale(std::shared_ptr<DataType> type,
-                                         PyObject* python_decimal,
-                                         std::optional<int> expected) {
+                                           PyObject* python_decimal,
+                                           std::optional<int> expected) {
   DecimalValue value;
   const auto& decimal_type = checked_cast<const DecimalType&>(*type);
 
   if (expected.has_value()) {
-    ASSERT_OK(
-        internal::DecimalFromPythonDecimal(python_decimal, decimal_type, &value));
+    ASSERT_OK(internal::DecimalFromPythonDecimal(python_decimal, decimal_type, &value));
     ASSERT_EQ(expected.value(), value);
 
     ASSERT_OK(internal::DecimalFromPyObject(python_decimal, decimal_type, &value));
     ASSERT_EQ(expected.value(), value);
   } else {
+    ASSERT_RAISES(Invalid, internal::DecimalFromPythonDecimal(python_decimal,
+                                                              decimal_type, &value));
     ASSERT_RAISES(Invalid,
-                  internal::DecimalFromPythonDecimal(python_decimal,
-                                                     decimal_type, &value));
-    ASSERT_RAISES(Invalid,
-                  internal::DecimalFromPyObject(python_decimal,
-                                                decimal_type, &value));
+                  internal::DecimalFromPyObject(python_decimal, decimal_type, &value));
   }
   return Status::OK();
 }
 
-Status TestFromPythonDecimalRescaleNotTruncateable(){
+Status TestFromPythonDecimalRescaleNotTruncateable() {
   OwnedRef decimal_constructor_;
   OwnedRef decimal_module;
 
   RETURN_NOT_OK(internal::ImportModule("decimal", &decimal_module));
-  RETURN_NOT_OK(internal::ImportFromModule(decimal_module.obj(), "Decimal",
-                                           &decimal_constructor_));
+  RETURN_NOT_OK(
+      internal::ImportFromModule(decimal_module.obj(), "Decimal", &decimal_constructor_));
 
   std::string decimal_string("1.001");
-  PyObject* python_decimal = internal::DecimalFromString(decimal_constructor_.obj(),
-                                                        decimal_string);
+  PyObject* python_decimal =
+      internal::DecimalFromString(decimal_constructor_.obj(), decimal_string);
   // We fail when truncating values that would lose data if cast to a decimal type with
   // lower scale
   ASSERT_OK(DecimalTestFromPythonDecimalRescale<Decimal128>(::arrow::decimal128(10, 2),
@@ -574,47 +579,47 @@ Status TestFromPythonDecimalRescaleNotTruncateable(){
   return Status::OK();
 }
 
-Status TestFromPythonDecimalRescaleTruncateable(){
+Status TestFromPythonDecimalRescaleTruncateable() {
   OwnedRef decimal_constructor_;
   OwnedRef decimal_module;
 
   RETURN_NOT_OK(internal::ImportModule("decimal", &decimal_module));
-  RETURN_NOT_OK(internal::ImportFromModule(decimal_module.obj(), "Decimal",
-                                           &decimal_constructor_));
+  RETURN_NOT_OK(
+      internal::ImportFromModule(decimal_module.obj(), "Decimal", &decimal_constructor_));
 
   std::string decimal_string("1.000");
-  PyObject* python_decimal = internal::DecimalFromString(decimal_constructor_.obj(),
-                                                        decimal_string);
+  PyObject* python_decimal =
+      internal::DecimalFromString(decimal_constructor_.obj(), decimal_string);
   // We allow truncation of values that do not lose precision when dividing by 10 * the
   // difference between the scales, e.g., 1.000 -> 1.00
-  ASSERT_OK(DecimalTestFromPythonDecimalRescale<Decimal128>(
-      ::arrow::decimal128(10, 2), python_decimal, 100));
-  ASSERT_OK(DecimalTestFromPythonDecimalRescale<Decimal256>(
-      ::arrow::decimal256(10, 2), python_decimal, 100));
+  ASSERT_OK(DecimalTestFromPythonDecimalRescale<Decimal128>(::arrow::decimal128(10, 2),
+                                                            python_decimal, 100));
+  ASSERT_OK(DecimalTestFromPythonDecimalRescale<Decimal256>(::arrow::decimal256(10, 2),
+                                                            python_decimal, 100));
 
   return Status::OK();
 }
 
-Status TestFromPythonNegativeDecimalRescale(){
+Status TestFromPythonNegativeDecimalRescale() {
   OwnedRef decimal_constructor_;
   OwnedRef decimal_module;
 
   RETURN_NOT_OK(internal::ImportModule("decimal", &decimal_module));
-  RETURN_NOT_OK(internal::ImportFromModule(decimal_module.obj(), "Decimal",
-                                           &decimal_constructor_));
+  RETURN_NOT_OK(
+      internal::ImportFromModule(decimal_module.obj(), "Decimal", &decimal_constructor_));
 
   std::string decimal_string("-1.000");
-  PyObject* python_decimal = internal::DecimalFromString(decimal_constructor_.obj(),
-                                                        decimal_string);
-  ASSERT_OK(DecimalTestFromPythonDecimalRescale<Decimal128>(
-      ::arrow::decimal128(10, 9), python_decimal, -1000000000));
-  ASSERT_OK(DecimalTestFromPythonDecimalRescale<Decimal256>(
-      ::arrow::decimal256(10, 9), python_decimal, -1000000000));
+  PyObject* python_decimal =
+      internal::DecimalFromString(decimal_constructor_.obj(), decimal_string);
+  ASSERT_OK(DecimalTestFromPythonDecimalRescale<Decimal128>(::arrow::decimal128(10, 9),
+                                                            python_decimal, -1000000000));
+  ASSERT_OK(DecimalTestFromPythonDecimalRescale<Decimal256>(::arrow::decimal256(10, 9),
+                                                            python_decimal, -1000000000));
 
   return Status::OK();
 }
 
-Status TestDecimal128FromPythonInteger(){
+Status TestDecimal128FromPythonInteger() {
   Decimal128 value;
   OwnedRef python_long(PyLong_FromLong(42));
   auto type = ::arrow::decimal128(10, 2);
@@ -624,7 +629,7 @@ Status TestDecimal128FromPythonInteger(){
   return Status::OK();
 }
 
-Status TestDecimal256FromPythonInteger(){
+Status TestDecimal256FromPythonInteger() {
   Decimal256 value;
   OwnedRef python_long(PyLong_FromLong(42));
   auto type = ::arrow::decimal256(10, 2);
@@ -634,18 +639,18 @@ Status TestDecimal256FromPythonInteger(){
   return Status::OK();
 }
 
-Status TestDecimal128OverflowFails(){
+Status TestDecimal128OverflowFails() {
   Decimal128 value;
   OwnedRef decimal_constructor_;
   OwnedRef decimal_module;
 
   RETURN_NOT_OK(internal::ImportModule("decimal", &decimal_module));
-  RETURN_NOT_OK(internal::ImportFromModule(decimal_module.obj(), "Decimal",
-                                           &decimal_constructor_));
+  RETURN_NOT_OK(
+      internal::ImportFromModule(decimal_module.obj(), "Decimal", &decimal_constructor_));
 
   std::string decimal_string("9999999999999999999999999999999999999.9");
-  PyObject* python_decimal = internal::DecimalFromString(decimal_constructor_.obj(),
-                                                        decimal_string);
+  PyObject* python_decimal =
+      internal::DecimalFromString(decimal_constructor_.obj(), decimal_string);
   internal::DecimalMetadata metadata;
   ASSERT_OK(metadata.Update(python_decimal));
   ASSERT_EQ(38, metadata.precision());
@@ -654,23 +659,23 @@ Status TestDecimal128OverflowFails(){
   auto type = ::arrow::decimal(38, 38);
   const auto& decimal_type = checked_cast<const DecimalType&>(*type);
   ASSERT_RAISES(Invalid,
-                internal::DecimalFromPythonDecimal(python_decimal,
-                                                   decimal_type, &value));
+                internal::DecimalFromPythonDecimal(python_decimal, decimal_type, &value));
   return Status::OK();
 }
 
-Status TestDecimal256OverflowFails(){
+Status TestDecimal256OverflowFails() {
   Decimal256 value;
   OwnedRef decimal_constructor_;
   OwnedRef decimal_module;
 
   RETURN_NOT_OK(internal::ImportModule("decimal", &decimal_module));
-  RETURN_NOT_OK(internal::ImportFromModule(decimal_module.obj(), "Decimal",
-                                           &decimal_constructor_));
+  RETURN_NOT_OK(
+      internal::ImportFromModule(decimal_module.obj(), "Decimal", &decimal_constructor_));
 
-  std::string decimal_string("999999999999999999999999999999999999999999999999999999999999999999999999999.9");
-  PyObject* python_decimal = internal::DecimalFromString(decimal_constructor_.obj(),
-                                                        decimal_string);
+  std::string decimal_string(
+      "999999999999999999999999999999999999999999999999999999999999999999999999999.9");
+  PyObject* python_decimal =
+      internal::DecimalFromString(decimal_constructor_.obj(), decimal_string);
 
   internal::DecimalMetadata metadata;
   ASSERT_OK(metadata.Update(python_decimal));
@@ -680,12 +685,11 @@ Status TestDecimal256OverflowFails(){
   auto type = ::arrow::decimal(76, 76);
   const auto& decimal_type = checked_cast<const DecimalType&>(*type);
   ASSERT_RAISES(Invalid,
-                internal::DecimalFromPythonDecimal(python_decimal,
-                                                   decimal_type, &value));
+                internal::DecimalFromPythonDecimal(python_decimal, decimal_type, &value));
   return Status::OK();
 }
 
-Status TestNoneAndNaN(){
+Status TestNoneAndNaN() {
   OwnedRef list_ref(PyList_New(4));
   PyObject* list = list_ref.obj();
 
@@ -694,8 +698,8 @@ Status TestNoneAndNaN(){
   OwnedRef decimal_constructor_;
   OwnedRef decimal_module;
   RETURN_NOT_OK(internal::ImportModule("decimal", &decimal_module));
-  RETURN_NOT_OK(internal::ImportFromModule(decimal_module.obj(), "Decimal",
-                                           &decimal_constructor_));
+  RETURN_NOT_OK(
+      internal::ImportFromModule(decimal_module.obj(), "Decimal", &decimal_constructor_));
   PyObject* constructor = decimal_constructor_.obj();
   PyObject* decimal_value = internal::DecimalFromString(constructor, "1.234");
   ASSERT_NE(decimal_value, nullptr);
@@ -718,8 +722,7 @@ Status TestNoneAndNaN(){
   ASSERT_EQ(0, PyList_SetItem(list, 3, missing_value3));
 
   PyConversionOptions options;
-  ASSERT_RAISES(TypeError,
-                ConvertPySequence(list, nullptr, options));
+  ASSERT_RAISES(TypeError, ConvertPySequence(list, nullptr, options));
 
   options.from_pandas = true;
   auto chunked = std::move(ConvertPySequence(list, nullptr, options)).ValueOrDie();
@@ -734,7 +737,7 @@ Status TestNoneAndNaN(){
   return Status::OK();
 }
 
-Status TestMixedPrecisionAndScale(){
+Status TestMixedPrecisionAndScale() {
   std::vector<std::string> strings{{"0.001", "1.01E5", "1.01E5"}};
 
   OwnedRef list_ref(PyList_New(static_cast<Py_ssize_t>(strings.size())));
@@ -745,8 +748,8 @@ Status TestMixedPrecisionAndScale(){
   OwnedRef decimal_constructor_;
   OwnedRef decimal_module;
   RETURN_NOT_OK(internal::ImportModule("decimal", &decimal_module));
-  RETURN_NOT_OK(internal::ImportFromModule(decimal_module.obj(), "Decimal",
-                                           &decimal_constructor_));
+  RETURN_NOT_OK(
+      internal::ImportFromModule(decimal_module.obj(), "Decimal", &decimal_constructor_));
   // PyList_SetItem steals a reference to the item so we don't decref it later
   PyObject* decimal_constructor = decimal_constructor_.obj();
   for (Py_ssize_t i = 0; i < static_cast<Py_ssize_t>(strings.size()); ++i) {
@@ -766,22 +769,22 @@ Status TestMixedPrecisionAndScale(){
   return Status::OK();
 }
 
-Status TestMixedPrecisionAndScaleSequenceConvert(){
+Status TestMixedPrecisionAndScaleSequenceConvert() {
   OwnedRef decimal_constructor_;
   OwnedRef decimal_module;
 
   RETURN_NOT_OK(internal::ImportModule("decimal", &decimal_module));
-  RETURN_NOT_OK(internal::ImportFromModule(decimal_module.obj(), "Decimal",
-                                           &decimal_constructor_));
+  RETURN_NOT_OK(
+      internal::ImportFromModule(decimal_module.obj(), "Decimal", &decimal_constructor_));
 
   std::string decimal_string_1("0.01");
-  PyObject* value1 = internal::DecimalFromString(decimal_constructor_.obj(),
-                                                        decimal_string_1);
+  PyObject* value1 =
+      internal::DecimalFromString(decimal_constructor_.obj(), decimal_string_1);
   ASSERT_NE(value1, nullptr);
 
   std::string decimal_string_2("0.001");
-  PyObject* value2 = internal::DecimalFromString(decimal_constructor_.obj(),
-                                                        decimal_string_2);
+  PyObject* value2 =
+      internal::DecimalFromString(decimal_constructor_.obj(), decimal_string_2);
   ASSERT_NE(value2, nullptr);
 
   OwnedRef list_ref(PyList_New(2));
@@ -800,17 +803,17 @@ Status TestMixedPrecisionAndScaleSequenceConvert(){
   return Status::OK();
 }
 
-Status TestSimpleInference(){
+Status TestSimpleInference() {
   OwnedRef decimal_constructor_;
   OwnedRef decimal_module;
 
   RETURN_NOT_OK(internal::ImportModule("decimal", &decimal_module));
-  RETURN_NOT_OK(internal::ImportFromModule(decimal_module.obj(), "Decimal",
-                                           &decimal_constructor_));
+  RETURN_NOT_OK(
+      internal::ImportFromModule(decimal_module.obj(), "Decimal", &decimal_constructor_));
 
   std::string decimal_string("0.01");
-  PyObject* value = internal::DecimalFromString(decimal_constructor_.obj(),
-                                                        decimal_string);
+  PyObject* value =
+      internal::DecimalFromString(decimal_constructor_.obj(), decimal_string);
   ASSERT_NE(value, nullptr);
   internal::DecimalMetadata metadata;
   ASSERT_OK(metadata.Update(value));
@@ -820,16 +823,16 @@ Status TestSimpleInference(){
   return Status::OK();
 }
 
-Status TestUpdateWithNaN(){
+Status TestUpdateWithNaN() {
   internal::DecimalMetadata metadata;
   OwnedRef decimal_constructor_;
   OwnedRef decimal_module;
   RETURN_NOT_OK(internal::ImportModule("decimal", &decimal_module));
-  RETURN_NOT_OK(internal::ImportFromModule(decimal_module.obj(), "Decimal",
-                                           &decimal_constructor_));
+  RETURN_NOT_OK(
+      internal::ImportFromModule(decimal_module.obj(), "Decimal", &decimal_constructor_));
   std::string decimal_string("nan");
-  PyObject* nan_value = internal::DecimalFromString(decimal_constructor_.obj(),
-                                                        decimal_string);
+  PyObject* nan_value =
+      internal::DecimalFromString(decimal_constructor_.obj(), decimal_string);
 
   ASSERT_OK(metadata.Update(nan_value));
   ASSERT_EQ(std::numeric_limits<int32_t>::min(), metadata.precision());
@@ -842,41 +845,41 @@ Status TestUpdateWithNaN(){
 
 std::vector<TestCase> GetCppTestCases() {
   return {
-    {"test_owned_ref_moves", TestOwnedRefMoves},
-    {"test_owned_ref_nogil_moves", TestOwnedRefNoGILMoves},
-    {"test_check_pyerror_status", TestCheckPyErrorStatus},
-    {"test_check_pyerror_status_nogil", TestCheckPyErrorStatusNoGIL},
-    {"test_restore_pyerror_basics", TestRestorePyErrorBasics},
-    {"test_pybuffer_invalid_input_object", TestPyBufferInvalidInputObject},
+      {"test_owned_ref_moves", TestOwnedRefMoves},
+      {"test_owned_ref_nogil_moves", TestOwnedRefNoGILMoves},
+      {"test_check_pyerror_status", TestCheckPyErrorStatus},
+      {"test_check_pyerror_status_nogil", TestCheckPyErrorStatusNoGIL},
+      {"test_restore_pyerror_basics", TestRestorePyErrorBasics},
+      {"test_pybuffer_invalid_input_object", TestPyBufferInvalidInputObject},
 #ifndef _WIN32
-    {"test_pybuffer_numpy_array", TestPyBufferNumpyArray},
-    {"test_numpybuffer_numpy_array", TestNumPyBufferNumpyArray},
+      {"test_pybuffer_numpy_array", TestPyBufferNumpyArray},
+      {"test_numpybuffer_numpy_array", TestNumPyBufferNumpyArray},
 #endif
-    {"test_python_decimal_to_string", TestPythonDecimalToString},
-    {"test_infer_precision_and_scale", TestInferPrecisionAndScale},
-    {"test_infer_precision_and_negative_scale", TestInferPrecisionAndNegativeScale},
-    {"test_infer_all_leading_zeros", TestInferAllLeadingZeros},
-    {"test_infer_all_leading_zeros_exponential_notation_positive",
-     TestInferAllLeadingZerosExponentialNotationPositive},
-    {"test_infer_all_leading_zeros_exponential_notation_negative",
-     TestInferAllLeadingZerosExponentialNotationNegative},
-    {"test_object_block_write_fails", TestObjectBlockWriteFails},
-    {"test_mixed_type_fails", TestMixedTypeFails},
-    {"test_from_python_decimal_rescale_not_truncateable",
-     TestFromPythonDecimalRescaleNotTruncateable},
-    {"test_from_python_decimal_rescale_truncateable",
-     TestFromPythonDecimalRescaleTruncateable},
-    {"test_from_python_negative_decimal_rescale", TestFromPythonNegativeDecimalRescale},
-    {"test_decimal128_from_python_integer", TestDecimal128FromPythonInteger},
-    {"test_decimal256_from_python_integer", TestDecimal256FromPythonInteger},
-    {"test_decimal128_overflow_fails", TestDecimal128OverflowFails},
-    {"test_decimal256_overflow_fails", TestDecimal256OverflowFails},
-    {"test_none_and_nan", TestNoneAndNaN},
-    {"test_mixed_precision_and_scale", TestMixedPrecisionAndScale},
-    {"test_mixed_precision_and_scale_sequence_convert",
-     TestMixedPrecisionAndScaleSequenceConvert},
-    {"test_simple_inference", TestSimpleInference},
-    {"test_update_with_nan", TestUpdateWithNaN},
+      {"test_python_decimal_to_string", TestPythonDecimalToString},
+      {"test_infer_precision_and_scale", TestInferPrecisionAndScale},
+      {"test_infer_precision_and_negative_scale", TestInferPrecisionAndNegativeScale},
+      {"test_infer_all_leading_zeros", TestInferAllLeadingZeros},
+      {"test_infer_all_leading_zeros_exponential_notation_positive",
+       TestInferAllLeadingZerosExponentialNotationPositive},
+      {"test_infer_all_leading_zeros_exponential_notation_negative",
+       TestInferAllLeadingZerosExponentialNotationNegative},
+      {"test_object_block_write_fails", TestObjectBlockWriteFails},
+      {"test_mixed_type_fails", TestMixedTypeFails},
+      {"test_from_python_decimal_rescale_not_truncateable",
+       TestFromPythonDecimalRescaleNotTruncateable},
+      {"test_from_python_decimal_rescale_truncateable",
+       TestFromPythonDecimalRescaleTruncateable},
+      {"test_from_python_negative_decimal_rescale", TestFromPythonNegativeDecimalRescale},
+      {"test_decimal128_from_python_integer", TestDecimal128FromPythonInteger},
+      {"test_decimal256_from_python_integer", TestDecimal256FromPythonInteger},
+      {"test_decimal128_overflow_fails", TestDecimal128OverflowFails},
+      {"test_decimal256_overflow_fails", TestDecimal256OverflowFails},
+      {"test_none_and_nan", TestNoneAndNaN},
+      {"test_mixed_precision_and_scale", TestMixedPrecisionAndScale},
+      {"test_mixed_precision_and_scale_sequence_convert",
+       TestMixedPrecisionAndScaleSequenceConvert},
+      {"test_simple_inference", TestSimpleInference},
+      {"test_update_with_nan", TestUpdateWithNaN},
   };
 }
 

--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -45,7 +45,6 @@
 #include "arrow/util/int_util_overflow.h"
 #include "arrow/util/logging.h"
 
-#include "arrow/visit_type_inline.h"
 #include "arrow/python/datetime.h"
 #include "arrow/python/decimal.h"
 #include "arrow/python/helpers.h"
@@ -53,6 +52,7 @@
 #include "arrow/python/iterators.h"
 #include "arrow/python/numpy_convert.h"
 #include "arrow/python/type_traits.h"
+#include "arrow/visit_type_inline.h"
 
 namespace arrow {
 

--- a/python/pyarrow/src/arrow/python/python_to_arrow.h
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.h
@@ -25,9 +25,9 @@
 #include <cstdint>
 #include <memory>
 
+#include "arrow/python/visibility.h"
 #include "arrow/type.h"
 #include "arrow/util/macros.h"
-#include "arrow/python/visibility.h"
 
 #include "arrow/python/common.h"
 

--- a/python/pyarrow/src/arrow/python/serialize.h
+++ b/python/pyarrow/src/arrow/python/serialize.h
@@ -21,9 +21,9 @@
 #include <vector>
 
 #include "arrow/ipc/options.h"
+#include "arrow/python/visibility.h"
 #include "arrow/sparse_tensor.h"
 #include "arrow/status.h"
-#include "arrow/python/visibility.h"
 
 // Forward declaring PyObject, see
 // https://mail.python.org/pipermail/python-dev/2003-August/037601.html

--- a/python/pyarrow/src/arrow/python/udf.cc
+++ b/python/pyarrow/src/arrow/python/udf.cc
@@ -94,8 +94,7 @@ struct PythonTableUdfKernelInit {
     if (!PyCallable_Check(function->obj())) {
       return Status::TypeError("Expected a callable Python object.");
     }
-    return std::make_unique<PythonUdfKernelState>(
-        std::move(function));
+    return std::make_unique<PythonUdfKernelState>(std::move(function));
   }
 
   std::shared_ptr<OwnedRefNoGIL> function_maker;
@@ -215,10 +214,9 @@ Status RegisterUdf(PyObject* user_function, compute::KernelInit kernel_init,
 Status RegisterScalarFunction(PyObject* user_function, UdfWrapperCallback wrapper,
                               const UdfOptions& options,
                               compute::FunctionRegistry* registry) {
-  return RegisterUdf(
-      user_function,
-      PythonUdfKernelInit{std::make_shared<OwnedRefNoGIL>(user_function)}, wrapper,
-      options, registry);
+  return RegisterUdf(user_function,
+                     PythonUdfKernelInit{std::make_shared<OwnedRefNoGIL>(user_function)},
+                     wrapper, options, registry);
 }
 
 Status RegisterTabularFunction(PyObject* user_function, UdfWrapperCallback wrapper,
@@ -272,9 +270,8 @@ Result<std::shared_ptr<RecordBatchReader>> CallTabularFunction(
   std::vector<TypeHolder> in_types;
   ARROW_ASSIGN_OR_RAISE(auto func_exec,
                         GetFunctionExecutor(func_name, in_types, NULLPTR, registry));
-  auto next_func =
-      [schema,
-       func_exec = std::move(func_exec)]() -> Result<std::shared_ptr<RecordBatch>> {
+  auto next_func = [schema, func_exec = std::move(
+                                func_exec)]() -> Result<std::shared_ptr<RecordBatch>> {
     std::vector<Datum> args;
     // passed_length of -1 or 0 with args.size() of 0 leads to an empty ExecSpanIterator
     // in exec.cc and to never invoking the source function, so 1 is passed instead

--- a/python/pyarrow/src/arrow/python/udf.h
+++ b/python/pyarrow/src/arrow/python/udf.h
@@ -54,17 +54,17 @@ using UdfWrapperCallback = std::function<PyObject*(
 
 /// \brief register a Scalar user-defined-function from Python
 Status ARROW_PYTHON_EXPORT RegisterScalarFunction(
-    PyObject* user_function, UdfWrapperCallback wrapper,
-    const UdfOptions& options, compute::FunctionRegistry* registry = NULLPTR);
+    PyObject* user_function, UdfWrapperCallback wrapper, const UdfOptions& options,
+    compute::FunctionRegistry* registry = NULLPTR);
 
 /// \brief register a Table user-defined-function from Python
 Status ARROW_PYTHON_EXPORT RegisterTabularFunction(
-    PyObject* user_function, UdfWrapperCallback wrapper,
-    const UdfOptions& options, compute::FunctionRegistry* registry = NULLPTR);
-
-Result<std::shared_ptr<RecordBatchReader>> ARROW_PYTHON_EXPORT CallTabularFunction(
-    const std::string& func_name, const std::vector<Datum>& args,
+    PyObject* user_function, UdfWrapperCallback wrapper, const UdfOptions& options,
     compute::FunctionRegistry* registry = NULLPTR);
+
+Result<std::shared_ptr<RecordBatchReader>> ARROW_PYTHON_EXPORT
+CallTabularFunction(const std::string& func_name, const std::vector<Datum>& args,
+                    compute::FunctionRegistry* registry = NULLPTR);
 
 }  // namespace py
 


### PR DESCRIPTION
### Rationale for this change

Python C++ files weren't being formatted. 

### What changes are included in this PR?

This adds a new format to Archery and formats all the files. The last commit contains just the formatting. The first two contain the substantive changes.

Adds a new linter step that activates when both `--python` and `--clang-format` are passed. This was easy to implement and works fine, but does have a disadvantage: You can't run `clang-format` on _just_ the Python C++ codebase. It also runs it on the C++ and that requires a CMake build to be setup. I think this is fine for now.

### Are these changes tested?

Tested in CI and locally. I'd recommend pulling this branch down and verifying you can run this locally as well. We want contributors to be able to run this as well.

### Are there any user-facing changes?

This adds a new linting step. Instructions in the developer documentation are updated to reflect these changes.

* Closes: #35485