### PR TITLE
GH-35480: [MATLAB] Add abstract MATLAB base class called `arrow.array.Array`

### DIFF
--- a/matlab/src/cpp/arrow/matlab/array/proxy/array.cc
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/array.cc
@@ -24,7 +24,7 @@ namespace arrow::matlab::array::proxy {
         // Register Proxy methods.
         REGISTER_METHOD(Array, ToString);
         REGISTER_METHOD(Array, ToMatlab);
-
+        REGISTER_METHOD(Array, Length);
     }
 
     void Array::ToString(libmexclass::proxy::method::Context& context) {
@@ -33,5 +33,11 @@ namespace arrow::matlab::array::proxy {
         // TODO: handle non-ascii characters
         auto str_mda = factory.createScalar(array->ToString());
         context.outputs[0] = str_mda;
+    }
+
+    void Array::Length(libmexclass::proxy::method::Context& context) {
+        ::matlab::data::ArrayFactory factory;
+        auto length_mda = factory.createScalar(array->length());
+        context.outputs[0] = length_mda;
     }
 }

--- a/matlab/src/cpp/arrow/matlab/array/proxy/array.h
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/array.h
@@ -33,6 +33,8 @@ class Array : public libmexclass::proxy::Proxy {
 
         void ToString(libmexclass::proxy::method::Context& context);
 
+        void Length(libmexclass::proxy::method::Context& context);
+
         virtual void ToMatlab(libmexclass::proxy::method::Context& context) = 0;
 
         std::shared_ptr<arrow::Array> array;

--- a/matlab/src/matlab/+arrow/+array/Array.m
+++ b/matlab/src/matlab/+arrow/+array/Array.m
@@ -18,7 +18,7 @@ classdef (Abstract) Array < matlab.mixin.CustomDisplay & ...
     % permissions and limitations under the License.
 
     
-    properties (Access = protected)
+    properties (Access=protected)
         Proxy
     end
 

--- a/matlab/src/matlab/+arrow/+array/Array.m
+++ b/matlab/src/matlab/+arrow/+array/Array.m
@@ -1,5 +1,6 @@
-classdef Float64Array < arrow.array.Array
-    % arrow.array.Float64Array
+classdef (Abstract) Array < matlab.mixin.CustomDisplay & ...
+                            matlab.mixin.Scalar
+    % arrow.array.Array
 
     % Licensed to the Apache Software Foundation (ASF) under one or more
     % contributor license agreements.  See the NOTICE file distributed with
@@ -16,26 +17,20 @@ classdef Float64Array < arrow.array.Array
     % implied.  See the License for the specific language governing
     % permissions and limitations under the License.
 
-    properties (Hidden, SetAccess=private)
-        MatlabArray
+    
+    properties (Access = protected)
+        Proxy
+    end
+    
+    methods
+        function obj = Array(varargin)
+            obj.Proxy = libmexclass.proxy.Proxy(varargin{:}); 
+        end
     end
 
-    methods
-        function obj = Float64Array(data, opts)
-            arguments
-                data
-                opts.DeepCopy = false
-            end
-
-            validateattributes(data, "double", ["2d", "nonsparse", "real"]);
-            if ~isempty(data), validateattributes(data, "double", "vector"); end
-            obj@arrow.array.Array("Name", "arrow.array.proxy.Float64Array", "ConstructorArguments", {data, opts.DeepCopy});
-            % Store a reference to the array if not doing a deep copy
-            if (~opts.DeepCopy), obj.MatlabArray = data; end
-        end
-
-        function data = double(obj)
-            data = obj.Proxy.ToMatlab();
+    methods (Access = private)
+        function str = ToString(obj)
+            str = obj.Proxy.ToString();
         end
     end
 
@@ -44,10 +39,5 @@ classdef Float64Array < arrow.array.Array
             disp(obj.ToString());
         end
     end
-
-    methods (Access=private)
-        function str = ToString(obj)
-            str = obj.Proxy.ToString();
-        end
-    end
 end
+

--- a/matlab/src/matlab/+arrow/+array/Array.m
+++ b/matlab/src/matlab/+arrow/+array/Array.m
@@ -21,10 +21,18 @@ classdef (Abstract) Array < matlab.mixin.CustomDisplay & ...
     properties (Access = protected)
         Proxy
     end
+
+    properties (Dependent)
+        Length
+    end
     
     methods
         function obj = Array(varargin)
             obj.Proxy = libmexclass.proxy.Proxy(varargin{:}); 
+        end
+
+        function numElements = get.Length(obj)
+            numElements = obj.Proxy.Length();
         end
     end
 

--- a/matlab/src/matlab/+arrow/+array/Float64Array.m
+++ b/matlab/src/matlab/+arrow/+array/Float64Array.m
@@ -38,16 +38,4 @@ classdef Float64Array < arrow.array.Array
             data = obj.Proxy.ToMatlab();
         end
     end
-
-    methods (Access=protected)
-        function displayScalarObject(obj)
-            disp(obj.ToString());
-        end
-    end
-
-    methods (Access=private)
-        function str = ToString(obj)
-            str = obj.Proxy.ToString();
-        end
-    end
 end

--- a/matlab/test/arrow/array/tFloat64Array.m
+++ b/matlab/test/arrow/array/tFloat64Array.m
@@ -100,5 +100,22 @@ classdef tFloat64Array < matlab.unittest.TestCase
             fcn = @() arrow.array.Float64Array(sparse(ones([10 1])), DeepCopy=MakeDeepCopy);
             testCase.verifyError(fcn, "MATLAB:expectedNonsparse");
         end
+
+        function Length(testCase, MakeDeepCopy)
+            % Zero length array
+            A = arrow.array.Float64Array([], DeepCopy=MakeDeepCopy);
+            expectedLength = int64(0);
+            testCase.verifyEqual(A.Length, expectedLength);
+
+            % Scalar
+            A = arrow.array.Float64Array(1, DeepCopy=MakeDeepCopy);
+            expectedLength = int64(1);
+            testCase.verifyEqual(A.Length, expectedLength);
+
+            % Vector
+            A = arrow.array.Float64Array(1:100, DeepCopy=MakeDeepCopy);
+            expectedLength = int64(100);
+            testCase.verifyEqual(A.Length, expectedLength);
+        end
     end
 end


### PR DESCRIPTION

### Rationale for this change

It will be helpful for sharing the implementation of common functionality if there is an abstract base class from which the MATLAB `arrow.array.[Type]Array` classes can inherit. 

### What changes are included in this PR?

1. Added abstract base class `arrow.array.Array`
2. Changed `arrow.array.Float64Array` to inherit from `arrow.array.Array`
3. Added `Length` property on `arrow.array.Array`

### Are these changes tested?

1. Added a test point for the `Length` property in `tFloat64Array.m`.
2. Qualified locally on macOS and linux.

### Are there any user-facing changes?

Yes, there is now a `Length` property on `arrow.array.Float64Array`

### Future Directions

We will continue to build out the concrete Array subclasses. 
* Closes: #35480