### PR TITLE
GH-35489: [MATLAB] Add CMake `build` directory to MATLAB `.gitignore`

### DIFF
--- a/matlab/.gitignore
+++ b/matlab/.gitignore
@@ -18,6 +18,7 @@
 # CMake files
 CMakeFiles/*
 CMakeCache.txt
+build/
 
 # MEX files
 *.mex*


### PR DESCRIPTION
### Rationale for this change

A typical name that is used for the build folder when building CMake projects is `build`.

The documentation for building the MATLAB interface [mentions using `build` as the build directory name](https://github.com/apache/arrow/tree/main/matlab#build). It would be helpful if `build/` was added to the MATLAB interface `.gitignore` so that the build directory doesn't show up in the list of untracked files with `git`.

### What changes are included in this PR?

Added `build` to the MATLAB `.gitignore`.

### Are these changes tested?

Manually verified on Debian 11 that the `build` folder doesn't show up as untracked with `git`.

### Are there any user-facing changes?

No.
* Closes: #35489