### PR TITLE
Fix underlying type for DATE64

### DIFF
--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -372,7 +372,7 @@ Status FieldToNode(const std::string& name, const std::shared_ptr<Field>& field,
       logical_type = LogicalType::Date();
       break;
     case ArrowTypeId::DATE64:
-      type = ParquetType::INT32;
+      type = ParquetType::INT64;
       logical_type = LogicalType::Date();
       break;
     case ArrowTypeId::TIMESTAMP:


### PR DESCRIPTION
When converting a column of type DATE64 to parquet, the underlying type is INT32 instead of INT64. This updates the type to be the correct width.