### PR TITLE
GH-35492 [MATLAB]: Add arrow.array.Float32Array MATLAB Class

### DIFF
--- a/matlab/src/cpp/arrow/matlab/proxy/factory.cc
+++ b/matlab/src/cpp/arrow/matlab/proxy/factory.cc
@@ -26,8 +26,8 @@ namespace arrow::matlab::proxy {
 std::shared_ptr<Proxy> Factory::make_proxy(const ClassName& class_name, const FunctionArguments& constructor_arguments) {
 
     // Register MATLAB Proxy classes with corresponding C++ Proxy classes.
+    REGISTER_PROXY(arrow.array.proxy.Float32Array, arrow::matlab::array::proxy::NumericArray<float>);
     REGISTER_PROXY(arrow.array.proxy.Float64Array, arrow::matlab::array::proxy::NumericArray<double>);
-
     // TODO: Decide what to do in the case that there isn't a Proxy match.
     std::cout << "Did not find a matching C++ proxy for: " + class_name << std::endl;
     return nullptr;

--- a/matlab/src/matlab/+arrow/+array/Float32Array.m
+++ b/matlab/src/matlab/+arrow/+array/Float32Array.m
@@ -1,0 +1,40 @@
+classdef Float32Array < arrow.array.Array
+    % arrow.array.Float32Array
+
+    % Licensed to the Apache Software Foundation (ASF) under one or more
+    % contributor license agreements.  See the NOTICE file distributed with
+    % this work for additional information regarding copyright ownership.
+    % The ASF licenses this file to you under the Apache License, Version
+    % 2.0 (the "License"); you may not use this file except in compliance
+    % with the License.  You may obtain a copy of the License at
+    %
+    %   http://www.apache.org/licenses/LICENSE-2.0
+    %
+    % Unless required by applicable law or agreed to in writing, software
+    % distributed under the License is distributed on an "AS IS" BASIS,
+    % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    % implied.  See the License for the specific language governing
+    % permissions and limitations under the License.
+
+    properties (Hidden, SetAccess=private)
+        MatlabArray = single([])
+    end
+
+    methods
+        function obj = Float32Array(data, opts)
+            arguments
+                data
+                opts.DeepCopy = false
+            end
+            validateattributes(data, "single", ["2d", "nonsparse", "real"]);
+            if ~isempty(data), validateattributes(data, "single", "vector"); end
+            obj@arrow.array.Array("Name", "arrow.array.proxy.Float32Array", "ConstructorArguments", {data, opts.DeepCopy});
+            % Store a reference to the array if not doing a deep copy
+            if (~opts.DeepCopy), obj.MatlabArray = data; end
+        end
+
+        function data = single(obj)
+            data = obj.Proxy.ToMatlab();
+        end
+    end
+end

--- a/matlab/test/arrow/array/tFloat32Array.m
+++ b/matlab/test/arrow/array/tFloat32Array.m
@@ -56,7 +56,7 @@ classdef tFloat32Array < matlab.unittest.TestCase
             testCase.verifyEqual(single(A), single([1 2 3]'));
         end
 
-        function Double(testCase, MakeDeepCopy)
+        function Single(testCase, MakeDeepCopy)
             % Create a Float32Array from a scalar double
             A1 = arrow.array.Float32Array(single(100), DeepCopy=MakeDeepCopy);
             data = single(A1);

--- a/matlab/test/arrow/array/tFloat32Array.m
+++ b/matlab/test/arrow/array/tFloat32Array.m
@@ -1,0 +1,99 @@
+classdef tFloat32Array < matlab.unittest.TestCase
+    % Tests for arrow.array.Float32rray
+
+    % Licensed to the Apache Software Foundation (ASF) under one or more
+    % contributor license agreements.  See the NOTICE file distributed with
+    % this work for additional information regarding copyright ownership.
+    % The ASF licenses this file to you under the Apache License, Version
+    % 2.0 (the "License"); you may not use this file except in compliance
+    % with the License.  You may obtain a copy of the License at
+    %
+    %   http://www.apache.org/licenses/LICENSE-2.0
+    %
+    % Unless required by applicable law or agreed to in writing, software
+    % distributed under the License is distributed on an "AS IS" BASIS,
+    % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    % implied.  See the License for the specific language governing
+    % permissions and limitations under the License.
+    
+    properties (TestParameter)
+        MakeDeepCopy = {true false}
+    end
+
+    methods(TestClassSetup)
+        function verifyOnMatlabPath(testCase)
+            % arrow.array.Float32Array must be on the MATLAB path.
+            testCase.assertTrue(~isempty(which('arrow.array.Float32Array')), ...
+                '''arrow.array.Float32Array'' must be on the MATLAB path. Use ''addpath'' to add folders to the MATLAB path.');
+        end
+    end
+    
+    methods(Test)
+        function Basic(testCase, MakeDeepCopy)
+            A = arrow.array.Float32Array(single([1, 2, 3]), DeepCopy=MakeDeepCopy);
+            className = string(class(A));
+            testCase.verifyEqual(className, "arrow.array.Float32Array");
+        end
+
+        function ShallowCopy(testCase)
+        % By default, Float32Array does not create a deep copy on
+        % construction when constructed from a MATLAB array. Instead,
+        % it stores a shallow copy of the array keep the memory alive.
+            A = arrow.array.Float32Array(single([1, 2, 3]));
+            testCase.verifyEqual(A.MatlabArray, single([1 2 3]));
+            testCase.verifyEqual(single(A), single([1 2 3]'));
+
+            A = arrow.array.Float32Array(single([1, 2, 3]), DeepCopy=false);
+            testCase.verifyEqual(A.MatlabArray, single([1 2 3]));
+            testCase.verifyEqual(single(A), single([1 2 3]'));
+        end
+
+        function DeepCopy(testCase)
+        % Verify Float32Array does not store shallow copy of the MATLAB
+        % array if DeepCopy=true was supplied.
+            A = arrow.array.Float32Array(single([1, 2, 3]), DeepCopy=true);
+            testCase.verifyEqual(A.MatlabArray, single([]));
+            testCase.verifyEqual(single(A), single([1 2 3]'));
+        end
+
+        function Double(testCase, MakeDeepCopy)
+            % Create a Float32Array from a scalar double
+            A1 = arrow.array.Float32Array(single(100), DeepCopy=MakeDeepCopy);
+            data = single(A1);
+            testCase.verifyEqual(data, single(100));
+
+            % Create a Float32Array from a double vector 
+            A2 = arrow.array.Float32Array(single([1 2 3]), DeepCopy=MakeDeepCopy);
+            data = single(A2);
+            testCase.verifyEqual(data, single([1 2 3]'));
+        
+            % Create a Float32Array from an empty double vector
+            A3 = arrow.array.Float32Array(single([]), DeepCopy=MakeDeepCopy);
+            data = single(A3);
+            testCase.verifyEqual(data, single.empty(0, 1));
+        end
+
+        function MinValue(testCase, MakeDeepCopy)
+            A1 = arrow.array.Float32Array(realmin("single"), DeepCopy=MakeDeepCopy);
+            data = single(A1);
+            testCase.verifyEqual(data, realmin("single"));
+        end
+
+        function MaxValue(testCase, MakeDeepCopy)
+            A1 = arrow.array.Float32Array(realmax('single'), DeepCopy=MakeDeepCopy);
+            data = single(A1);
+            testCase.verifyEqual(data, realmax('single'));
+        end
+
+        function InfValues(testCase, MakeDeepCopy)
+            A1 = arrow.array.Float32Array(single([Inf -Inf]), DeepCopy=MakeDeepCopy);
+            data = single(A1);
+            testCase.verifyEqual(data, single([Inf -Inf]'));
+        end
+
+        function ErrorIfComplex(testCase, MakeDeepCopy)
+            fcn = @() arrow.array.Float32Array(single([10 + 1i, 4]), DeepCopy=MakeDeepCopy);
+            testCase.verifyError(fcn, "MATLAB:expectedReal");
+        end
+    end
+end

--- a/matlab/test/arrow/array/tFloat32Array.m
+++ b/matlab/test/arrow/array/tFloat32Array.m
@@ -36,9 +36,9 @@ classdef tFloat32Array < matlab.unittest.TestCase
         end
 
         function ShallowCopy(testCase)
-        % By default, Float32Array does not create a deep copy on
-        % construction when constructed from a MATLAB array. Instead,
-        % it stores a shallow copy of the array keep the memory alive.
+            % By default, Float32Array does not create a deep copy on
+            % construction when constructed from a MATLAB array. Instead,
+            % it stores a shallow copy of the array keep the memory alive.
             A = arrow.array.Float32Array(single([1, 2, 3]));
             testCase.verifyEqual(A.MatlabArray, single([1 2 3]));
             testCase.verifyEqual(single(A), single([1 2 3]'));

--- a/matlab/test/arrow/array/tFloat32Array.m
+++ b/matlab/test/arrow/array/tFloat32Array.m
@@ -49,8 +49,8 @@ classdef tFloat32Array < matlab.unittest.TestCase
         end
 
         function DeepCopy(testCase)
-        % Verify Float32Array does not store shallow copy of the MATLAB
-        % array if DeepCopy=true was supplied.
+          % Verify Float32Array does not store shallow copy of the MATLAB
+          % array if DeepCopy=true was supplied.
             A = arrow.array.Float32Array(single([1, 2, 3]), DeepCopy=true);
             testCase.verifyEqual(A.MatlabArray, single([]));
             testCase.verifyEqual(single(A), single([1 2 3]'));


### PR DESCRIPTION
### Rationale for this change
Continuing to build the MATLAB interface to Arrow for numeric types. We're trying to keep the scope of these pull requests small to make them easier to review. 

### What changes are included in this PR?

1. Added `arrow.array.Float32Array` MATLAB class
2. Added new test class `tFloat32Array.m`

### Are these changes tested?

1. Yes, added a new test class called `tFloat32Array.m`. 
2. Qualified locally on macOS.

### Are there any user-facing changes?

Yes, users can now create a array of float32 values.

### Future Directions

1. Continue building out support for numeric arrays.
2. Add shared validation functions.
3. Make a shared test class for Numeric Arrays.
* Closes: #35492