### PR TITLE
GH-35515: [C++][Python] Add non decomposable aggregation UDF

### DIFF
--- a/cpp/src/arrow/engine/substrait/extension_set.cc
+++ b/cpp/src/arrow/engine/substrait/extension_set.cc
@@ -981,12 +981,12 @@ ExtensionIdRegistry::SubstraitAggregateToArrow DecodeBasicAggregate(
             options = std::make_shared<compute::VarianceOptions>(ddof);
           }
         }
-
         fixed_arrow_func += arrow_function_name;
+
         std::vector<FieldRef> target;
         for (int i = 0; i < call.size(); i++) {
           ARROW_ASSIGN_OR_RAISE(compute::Expression arg, call.GetValueArg(i));
-          const FieldRef* arg_ref = arg.field_ref();
+          FieldRef* arg_ref = arg.field_ref();
           if (!arg_ref) {
             return Status::Invalid("Expected an aggregate call ", call.id().uri, "#",
                                    call.id().name, " to have a direct reference");
@@ -994,7 +994,7 @@ ExtensionIdRegistry::SubstraitAggregateToArrow DecodeBasicAggregate(
           target.emplace_back(std::move(*arg_ref));
         }
         return compute::Aggregate{std::move(fixed_arrow_func),
-                                  options ? std::move(options) : nullptr, target, ""};
+                                  options ? std::move(options) : nullptr, std::move(target), ""};
       }
     }
   };

--- a/cpp/src/arrow/engine/substrait/extension_set.cc
+++ b/cpp/src/arrow/engine/substrait/extension_set.cc
@@ -986,15 +986,17 @@ ExtensionIdRegistry::SubstraitAggregateToArrow DecodeBasicAggregate(
         std::vector<FieldRef> target;
         for (int i = 0; i < call.size(); i++) {
           ARROW_ASSIGN_OR_RAISE(compute::Expression arg, call.GetValueArg(i));
-          FieldRef* arg_ref = arg.field_ref();
+          const FieldRef* arg_ref = arg.field_ref();
           if (!arg_ref) {
             return Status::Invalid("Expected an aggregate call ", call.id().uri, "#",
                                    call.id().name, " to have a direct reference");
           }
-          target.emplace_back(std::move(*arg_ref));
+          // Copy arg_ref here because field_ref() return const FieldRef*
+          target.emplace_back(*arg_ref);
         }
         return compute::Aggregate{std::move(fixed_arrow_func),
-                                  options ? std::move(options) : nullptr, std::move(target), ""};
+                                  options ? std::move(options) : nullptr,
+                                  std::move(target), ""};
       }
     }
   };

--- a/cpp/src/arrow/engine/substrait/extension_set.cc
+++ b/cpp/src/arrow/engine/substrait/extension_set.cc
@@ -363,81 +363,6 @@ ExtensionIdRegistry::SubstraitAggregateToArrow kSimpleSubstraitAggregateToArrow 
   return DecodeBasicAggregate(std::string(call.id().name))(call);
 };
 
-ExtensionIdRegistry::SubstraitAggregateToArrow DecodeBasicAggregate(
-    const std::string& arrow_function_name) {
-  return [arrow_function_name](const SubstraitCall& call) -> Result<compute::Aggregate> {
-    std::string fixed_arrow_func;
-    if (call.is_hash()) {
-      fixed_arrow_func = "hash_";
-    }
-
-    switch (call.size()) {
-      case 0: {
-        if (call.id().name == "count") {
-          fixed_arrow_func += "count_all";
-          return compute::Aggregate{std::move(fixed_arrow_func), ""};
-        }
-        return Status::Invalid("Expected aggregate call ", call.id().uri, "#",
-                               call.id().name, " to have at least one argument");
-      }
-      case 1: {
-        std::shared_ptr<compute::FunctionOptions> options = nullptr;
-        if (arrow_function_name == "stddev" || arrow_function_name == "variance") {
-          // See the following URL for the spec of stddev and variance:
-          // https://github.com/substrait-io/substrait/blob/
-          // 73228b4112d79eb1011af0ebb41753ce23ca180c/
-          // extensions/functions_arithmetic.yaml#L1240
-          auto maybe_dist = call.GetOption("distribution");
-          if (maybe_dist) {
-            auto& prefs = **maybe_dist;
-            if (prefs.size() != 1) {
-              return Status::Invalid("expected a single preference for ",
-                                     arrow_function_name, " but got ", prefs.size());
-            }
-            int ddof;
-            if (prefs[0] == "POPULATION") {
-              ddof = 1;
-            } else if (prefs[0] == "SAMPLE") {
-              ddof = 0;
-            } else {
-              return Status::Invalid("unknown distribution preference ", prefs[0]);
-            }
-            options = std::make_shared<compute::VarianceOptions>(ddof);
-          }
-        }
-        fixed_arrow_func += arrow_function_name;
-
-        ARROW_ASSIGN_OR_RAISE(compute::Expression arg, call.GetValueArg(0));
-        const FieldRef* arg_ref = arg.field_ref();
-        if (!arg_ref) {
-          return Status::Invalid("Expected an aggregate call ", call.id().uri, "#",
-                                 call.id().name, " to have a direct reference");
-        }
-
-        return compute::Aggregate{std::move(fixed_arrow_func),
-                                  options ? std::move(options) : nullptr, *arg_ref, ""};
-      }
-      default: {
-
-        fixed_arrow_func += arrow_function_name;
-        std::vector<FieldRef> target;
-        for (int i = 0; i < call.size(); i++) {
-          ARROW_ASSIGN_OR_RAISE(compute::Expression arg, call.GetValueArg(i));
-          const FieldRef* arg_ref = arg.field_ref();
-          if (!arg_ref) {
-          return Status::Invalid("Expected an aggregate call ", call.id().uri, "#",
-                                 call.id().name, " to have a direct reference");
-          }
-          target.emplace_back(*arg_ref);
-        }
-        return compute::Aggregate{std::move(fixed_arrow_func), nullptr, target, ""};
-      }
-    }
-    return Status::NotImplemented(
-        "Only nullary and unary aggregate functions are currently supported");
-  };
-}
-
 struct ExtensionIdRegistryImpl : ExtensionIdRegistry {
   ExtensionIdRegistryImpl() : parent_(nullptr) {}
   explicit ExtensionIdRegistryImpl(const ExtensionIdRegistry* parent) : parent_(parent) {}
@@ -1009,6 +934,68 @@ ExtensionIdRegistry::SubstraitCallToArrow DecodeConcatMapping() {
                           GetValueArgs(call, 0));
     value_args.push_back(compute::literal(""));
     return compute::call("binary_join_element_wise", std::move(value_args));
+  };
+}
+
+ExtensionIdRegistry::SubstraitAggregateToArrow DecodeBasicAggregate(
+    const std::string& arrow_function_name) {
+  return [arrow_function_name](const SubstraitCall& call) -> Result<compute::Aggregate> {
+    std::string fixed_arrow_func;
+    if (call.is_hash()) {
+      fixed_arrow_func = "hash_";
+    }
+
+    switch (call.size()) {
+      case 0: {
+        if (call.id().name == "count") {
+          fixed_arrow_func += "count_all";
+          return compute::Aggregate{std::move(fixed_arrow_func), ""};
+        }
+        return Status::Invalid("Expected aggregate call ", call.id().uri, "#",
+                               call.id().name, " to have at least one argument");
+      }
+      default: {
+        // Handles all arity > 0
+
+        std::shared_ptr<compute::FunctionOptions> options = nullptr;
+        if (arrow_function_name == "stddev" || arrow_function_name == "variance") {
+          // See the following URL for the spec of stddev and variance:
+          // https://github.com/substrait-io/substrait/blob/
+          // 73228b4112d79eb1011af0ebb41753ce23ca180c/
+          // extensions/functions_arithmetic.yaml#L1240
+          auto maybe_dist = call.GetOption("distribution");
+          if (maybe_dist) {
+            auto& prefs = **maybe_dist;
+            if (prefs.size() != 1) {
+              return Status::Invalid("expected a single preference for ",
+                                     arrow_function_name, " but got ", prefs.size());
+            }
+            int ddof;
+            if (prefs[0] == "POPULATION") {
+              ddof = 1;
+            } else if (prefs[0] == "SAMPLE") {
+              ddof = 0;
+            } else {
+              return Status::Invalid("unknown distribution preference ", prefs[0]);
+            }
+            options = std::make_shared<compute::VarianceOptions>(ddof);
+          }
+        }
+
+        fixed_arrow_func += arrow_function_name;
+        std::vector<FieldRef> target;
+        for (int i = 0; i < call.size(); i++) {
+          ARROW_ASSIGN_OR_RAISE(compute::Expression arg, call.GetValueArg(i));
+          const FieldRef* arg_ref = arg.field_ref();
+          if (!arg_ref) {
+            return Status::Invalid("Expected an aggregate call ", call.id().uri, "#",
+                                   call.id().name, " to have a direct reference");
+          }
+          target.emplace_back(*arg_ref);
+        }
+        return compute::Aggregate{std::move(fixed_arrow_func), nullptr, target, ""};
+      }
+    }
   };
 }
 

--- a/cpp/src/arrow/engine/substrait/extension_set.cc
+++ b/cpp/src/arrow/engine/substrait/extension_set.cc
@@ -991,9 +991,10 @@ ExtensionIdRegistry::SubstraitAggregateToArrow DecodeBasicAggregate(
             return Status::Invalid("Expected an aggregate call ", call.id().uri, "#",
                                    call.id().name, " to have a direct reference");
           }
-          target.emplace_back(*arg_ref);
+          target.emplace_back(std::move(*arg_ref));
         }
-        return compute::Aggregate{std::move(fixed_arrow_func), nullptr, target, ""};
+        return compute::Aggregate{std::move(fixed_arrow_func),
+                                  options ? std::move(options) : nullptr, target, ""};
       }
     }
   };

--- a/python/pyarrow/_compute.pxd
+++ b/python/pyarrow/_compute.pxd
@@ -21,11 +21,11 @@ from pyarrow.lib cimport *
 from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport *
 
-cdef class ScalarUdfContext(_Weakrefable):
+cdef class UdfContext(_Weakrefable):
     cdef:
-        CScalarUdfContext c_context
+        CUdfContext c_context
 
-    cdef void init(self, const CScalarUdfContext& c_context)
+    cdef void init(self, const CUdfContext& c_context)
 
 
 cdef class FunctionOptions(_Weakrefable):

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2676,6 +2676,8 @@ def register_scalar_function(func, function_name, function_doc, in_types, out_ty
     """
     Register a user-defined scalar function.
 
+    This API is EXPERIMENTAL.
+
     A scalar function is a function that executes elementwise
     operations on arrays or scalars, i.e. a scalar function must
     be computed row-by-row with no state where each output row
@@ -2752,8 +2754,9 @@ def register_scalar_function(func, function_name, function_doc, in_types, out_ty
 
 def register_aggregate_function(func, function_name, function_doc, in_types, out_type,
                                 func_registry=None):
-    """
-    Register a user-defined non-decomposable aggregate function.
+    """Register a user-defined non-decomposable aggregate function.
+
+    This API is EXPERIMENTAL.
 
     A non-decomposable aggregation function is a function that executes
     aggregate operations on the whole data that it is aggregating.
@@ -2828,8 +2831,9 @@ def register_aggregate_function(func, function_name, function_doc, in_types, out
 
 def register_tabular_function(func, function_name, function_doc, in_types, out_type,
                               func_registry=None):
-    """
-    Register a user-defined tabular function.
+    """Register a user-defined tabular function.
+
+    This API is EXPERIMENTAL.
 
     A tabular function is one accepting a context argument of type
     UdfContext and returning a generator of struct arrays.

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2771,10 +2771,10 @@ def register_aggregate_function(func, function_name, function_doc, in_types, out
         Then, it must take arguments equal to the number of
         in_types defined. It must return Scalar matching the
         out_type.
-
         To define a varargs function, pass a callable that takes
-        varargs. The last in_type will be the type of all varargs
-        arguments.
+        varargs. The in_type needs to match in type of inputs when
+        the function gets called.
+
     function_name : str
         Name of the function. This name must be globally unique.
     function_doc : dict

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2754,7 +2754,8 @@ def register_scalar_function(func, function_name, function_doc, in_types, out_ty
 
 def register_aggregate_function(func, function_name, function_doc, in_types, out_type,
                                 func_registry=None):
-    """Register a user-defined non-decomposable aggregate function.
+    """
+    Register a user-defined non-decomposable aggregate function.
 
     This API is EXPERIMENTAL.
 
@@ -2778,7 +2779,6 @@ def register_aggregate_function(func, function_name, function_doc, in_types, out
         To define a varargs function, pass a callable that takes
         *args. The in_type needs to match in type of inputs when
         the function gets called.
-
     function_name : str
         Name of the function. This name must be unique, i.e.,
         there should only be one function registered with
@@ -2831,7 +2831,8 @@ def register_aggregate_function(func, function_name, function_doc, in_types, out
 
 def register_tabular_function(func, function_name, function_doc, in_types, out_type,
                               func_registry=None):
-    """Register a user-defined tabular function.
+    """
+    Register a user-defined tabular function.
 
     This API is EXPERIMENTAL.
 

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2559,7 +2559,7 @@ cdef CExpression _bind(Expression filter, Schema schema) except *:
         deref(pyarrow_unwrap_schema(schema).get())))
 
 
-cdef class ScalarUdfContext:
+cdef class UdfContext:
     """
     Per-invocation function context/state.
 
@@ -2571,7 +2571,7 @@ cdef class ScalarUdfContext:
         raise TypeError("Do not call {}'s constructor directly"
                         .format(self.__class__.__name__))
 
-    cdef void init(self, const CScalarUdfContext &c_context):
+    cdef void init(self, const CUdfContext &c_context):
         self.c_context = c_context
 
     @property
@@ -2620,26 +2620,26 @@ cdef inline CFunctionDoc _make_function_doc(dict func_doc) except *:
     return f_doc
 
 
-cdef object box_scalar_udf_context(const CScalarUdfContext& c_context):
-    cdef ScalarUdfContext context = ScalarUdfContext.__new__(ScalarUdfContext)
+cdef object box_udf_context(const CUdfContext& c_context):
+    cdef UdfContext context = UdfContext.__new__(UdfContext)
     context.init(c_context)
     return context
 
 
-cdef _udf_callback(user_function, const CScalarUdfContext& c_context, inputs):
+cdef _udf_callback(user_function, const CUdfContext& c_context, inputs):
     """
-    Helper callback function used to wrap the ScalarUdfContext from Python to C++
+    Helper callback function used to wrap the UdfContext from Python to C++
     execution.
     """
-    context = box_scalar_udf_context(c_context)
+    context = box_udf_context(c_context)
     return user_function(context, *inputs)
 
 
-def _get_scalar_udf_context(memory_pool, batch_length):
-    cdef CScalarUdfContext c_context
+def _get_udf_context(memory_pool, batch_length):
+    cdef CUdfContext c_context
     c_context.pool = maybe_unbox_memory_pool(memory_pool)
     c_context.batch_length = batch_length
-    context = box_scalar_udf_context(c_context)
+    context = box_udf_context(c_context)
     return context
 
 
@@ -2690,7 +2690,7 @@ def register_scalar_function(func, function_name, function_doc, in_types, out_ty
     func : callable
         A callable implementing the user-defined function.
         The first argument is the context argument of type
-        ScalarUdfContext.
+        UdfContext.
         Then, it must take arguments equal to the number of
         in_types defined. It must return an Array or Scalar
         matching the out_type. It must return a Scalar if
@@ -2744,35 +2744,33 @@ def register_scalar_function(func, function_name, function_doc, in_types, out_ty
       21
     ]
     """
-    return _register_scalar_like_function(get_register_scalar_function(),
-                                          func, function_name, function_doc, in_types,
-                                          out_type, func_registry)
+    return _register_user_defined_function(get_register_scalar_function(),
+                                           func, function_name, function_doc, in_types,
+                                           out_type, func_registry)
 
 
 def register_aggregate_function(func, function_name, function_doc, in_types, out_type,
                                 func_registry=None):
     """
-    Register a user-defined scalar function.
+    Register a user-defined non-decomposable aggregate function.
 
-    A scalar function is a function that executes elementwise
-    operations on arrays or scalars, i.e. a scalar function must
-    be computed row-by-row with no state where each output row
-    is computed only from its corresponding input row.
-    In other words, all argument arrays have the same length,
-    and the output array is of the same length as the arguments.
-    Scalar functions are the only functions allowed in query engine
-    expressions.
+    A non-decomposable aggregation function is a function that executes
+    aggregate operations on the whole data that it is aggregating.
+    In other words, non-decomposable aggregate function cannot be
+    split into consume/merge/finalize steps.
+
+    This is mostly useful with segemented aggregation, where the data
+    to be aggregated is continuous.
 
     Parameters
     ----------
     func : callable
         A callable implementing the user-defined function.
         The first argument is the context argument of type
-        ScalarUdfContext.
+        UdfContext.
         Then, it must take arguments equal to the number of
-        in_types defined. It must return an Array or Scalar
-        matching the out_type. It must return a Scalar if
-        all arguments are scalar, else it must return an Array.
+        in_types defined. It must return Scalar matching the
+        out_type.
 
         To define a varargs function, pass a callable that takes
         varargs. The last in_type will be the type of all varargs
@@ -2796,35 +2794,33 @@ def register_aggregate_function(func, function_name, function_doc, in_types, out
 
     Examples
     --------
+    >>> import numpy as np
     >>> import pyarrow as pa
     >>> import pyarrow.compute as pc
     >>>
     >>> func_doc = {}
-    >>> func_doc["summary"] = "simple udf"
-    >>> func_doc["description"] = "add a constant to a scalar"
+    >>> func_doc["summary"] = "simple mean udf"
+    >>> func_doc["description"] = "compute mean"
     >>>
-    >>> def add_constant(ctx, array):
-    ...     return pc.add(array, 1, memory_pool=ctx.memory_pool)
+    >>> def compute_mean(ctx, array):
+    ...     return pa.scalar(np.nanmean(array))
     >>>
-    >>> func_name = "py_add_func"
+    >>> func_name = "py_compute_mean"
     >>> in_types = {"array": pa.int64()}
-    >>> out_type = pa.int64()
-    >>> pc.register_scalar_function(add_constant, func_name, func_doc,
+    >>> out_type = pa.float64()
+    >>> pc.register_aggregate_function(compute_mean, func_name, func_doc,
     ...                   in_types, out_type)
     >>>
     >>> func = pc.get_function(func_name)
     >>> func.name
-    'py_add_func'
-    >>> answer = pc.call_function(func_name, [pa.array([20])])
+    'py_compute_mean'
+    >>> answer = pc.call_function(func_name, [pa.array([20, 40])])
     >>> answer
-    <pyarrow.lib.Int64Array object at ...>
-    [
-      21
-    ]
+    <pyarrow.DoubleScalar: 30.0>
     """
-    return _register_scalar_like_function(get_register_aggregate_function(),
-                                          func, function_name, function_doc, in_types,
-                                          out_type, func_registry)
+    return _register_user_defined_function(get_register_aggregate_function(),
+                                           func, function_name, function_doc, in_types,
+                                           out_type, func_registry)
 
 
 def register_tabular_function(func, function_name, function_doc, in_types, out_type,
@@ -2833,7 +2829,7 @@ def register_tabular_function(func, function_name, function_doc, in_types, out_t
     Register a user-defined tabular function.
 
     A tabular function is one accepting a context argument of type
-    ScalarUdfContext and returning a generator of struct arrays.
+    UdfContext and returning a generator of struct arrays.
     The in_types argument must be empty and the out_type argument
     specifies a schema. Each struct array must have field types
     correspoding to the schema.
@@ -2843,7 +2839,7 @@ def register_tabular_function(func, function_name, function_doc, in_types, out_t
     func : callable
         A callable implementing the user-defined function.
         The only argument is the context argument of type
-        ScalarUdfContext. It must return a callable that
+        UdfContext. It must return a callable that
         returns on each invocation a StructArray matching
         the out_type, where an empty array indicates end.
     function_name : str
@@ -2867,36 +2863,25 @@ def register_tabular_function(func, function_name, function_doc, in_types, out_t
         with nogil:
             c_type = <shared_ptr[CDataType]>make_shared[CStructType](deref(c_schema).fields())
         out_type = pyarrow_wrap_data_type(c_type)
-    return _register_scalar_like_function(get_register_tabular_function(),
-                                          func, function_name, function_doc, in_types,
-                                          out_type, func_registry)
+    return _register_user_defined_function(get_register_tabular_function(),
+                                           func, function_name, function_doc, in_types,
+                                           out_type, func_registry)
 
 
-def _register_scalar_like_function(register_func, func, function_name, function_doc, in_types,
-                                   out_type, func_registry=None):
+def _register_user_defined_function(register_func, func, function_name, function_doc, in_types,
+                                    out_type, func_registry=None):
     """
-    Register a user-defined scalar-like function.
+    Register a user-defined function.
 
-    A scalar-like function is a callable accepting a first
-    context argument of type ScalarUdfContext as well as
-    possibly additional Arrow arguments, and returning a
-    an Arrow result appropriate for the kind of function.
-    A scalar function and a tabular function are examples
-    for scalar-like functions.
-    This function is normally not called directly but via
-    register_scalar_function or register_tabular_function.
+    This method itself doesn't care what the type of the UDF
+    (i.e., scalar vs tabular vs aggregate)
 
     Parameters
     ----------
     register_func: object
-        An object holding a CRegisterUdf in a "register_func" attribute. Use
-        get_register_scalar_function() for a scalar function and
-        get_register_tabular_function() for a tabular function.
+        An object holding a CRegisterUdf in a "register_func" attribute.
     func : callable
         A callable implementing the user-defined function.
-        See register_scalar_function and
-        register_tabular_function for details.
-
     function_name : str
         Name of the function. This name must be globally unique.
     function_doc : dict
@@ -2905,8 +2890,6 @@ def _register_scalar_like_function(register_func, func, function_name, function_
     in_types : Dict[str, DataType]
         A dictionary mapping function argument names to
         their respective DataType.
-        See register_scalar_function and
-        register_tabular_function for details.
     out_type : DataType
         Output type of the function.
     func_registry : FunctionRegistry

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2769,7 +2769,7 @@ def register_aggregate_function(func, function_name, function_doc, in_types, out
         The first argument is the context argument of type
         UdfContext.
         Then, it must take arguments equal to the number of
-        in_types defined. It must return Scalar matching the
+        in_types defined. It must return a Scalar matching the
         out_type.
         To define a varargs function, pass a callable that takes
         varargs. The in_type needs to match in type of inputs when

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2697,10 +2697,11 @@ def register_scalar_function(func, function_name, function_doc, in_types, out_ty
         all arguments are scalar, else it must return an Array.
 
         To define a varargs function, pass a callable that takes
-        varargs. The last in_type will be the type of all varargs
+        *args. The last in_type will be the type of all varargs
         arguments.
     function_name : str
-        Name of the function. This name must be globally unique.
+        Name of the function. There should only be one function
+        registered with this name in the function registry.
     function_doc : dict
         A dictionary object with keys "summary" (str),
         and "description" (str).
@@ -2759,8 +2760,8 @@ def register_aggregate_function(func, function_name, function_doc, in_types, out
     In other words, non-decomposable aggregate function cannot be
     split into consume/merge/finalize steps.
 
-    This is mostly useful with segemented aggregation, where the data
-    to be aggregated is continuous.
+    This is often used with ordered or segmented aggregation where groups
+    can be emit before accumulating all of the input data.
 
     Parameters
     ----------
@@ -2772,11 +2773,13 @@ def register_aggregate_function(func, function_name, function_doc, in_types, out
         in_types defined. It must return a Scalar matching the
         out_type.
         To define a varargs function, pass a callable that takes
-        varargs. The in_type needs to match in type of inputs when
+        *args. The in_type needs to match in type of inputs when
         the function gets called.
 
     function_name : str
-        Name of the function. This name must be globally unique.
+        Name of the function. This name must be unique, i.e.,
+        there should only be one function registered with
+        this name in the function registry.
     function_doc : dict
         A dictionary object with keys "summary" (str),
         and "description" (str).
@@ -2799,21 +2802,21 @@ def register_aggregate_function(func, function_name, function_doc, in_types, out
     >>> import pyarrow.compute as pc
     >>>
     >>> func_doc = {}
-    >>> func_doc["summary"] = "simple mean udf"
-    >>> func_doc["description"] = "compute mean"
+    >>> func_doc["summary"] = "simple median udf"
+    >>> func_doc["description"] = "compute median"
     >>>
-    >>> def compute_mean(ctx, array):
-    ...     return pa.scalar(np.nanmean(array))
+    >>> def compute_median(ctx, array):
+    ...     return pa.scalar(np.median(array))
     >>>
-    >>> func_name = "py_compute_mean"
+    >>> func_name = "py_compute_median"
     >>> in_types = {"array": pa.int64()}
     >>> out_type = pa.float64()
-    >>> pc.register_aggregate_function(compute_mean, func_name, func_doc,
+    >>> pc.register_aggregate_function(compute_median, func_name, func_doc,
     ...                   in_types, out_type)
     >>>
     >>> func = pc.get_function(func_name)
     >>> func.name
-    'py_compute_mean'
+    'py_compute_median'
     >>> answer = pc.call_function(func_name, [pa.array([20, 40])])
     >>> answer
     <pyarrow.DoubleScalar: 30.0>
@@ -2843,7 +2846,8 @@ def register_tabular_function(func, function_name, function_doc, in_types, out_t
         returns on each invocation a StructArray matching
         the out_type, where an empty array indicates end.
     function_name : str
-        Name of the function. This name must be globally unique.
+        Name of the function. There should only be one function
+        registered with this name in the function registry.
     function_doc : dict
         A dictionary object with keys "summary" (str),
         and "description" (str).
@@ -2873,7 +2877,7 @@ def _register_user_defined_function(register_func, func, function_name, function
     """
     Register a user-defined function.
 
-    This method itself doesn't care what the type of the UDF
+    This method itself doesn't care about the type of the UDF
     (i.e., scalar vs tabular vs aggregate)
 
     Parameters
@@ -2883,7 +2887,8 @@ def _register_user_defined_function(register_func, func, function_name, function
     func : callable
         A callable implementing the user-defined function.
     function_name : str
-        Name of the function. This name must be globally unique.
+        Name of the function. There should only be one function
+        registered with this name in the function registry.
     function_doc : dict
         A dictionary object with keys "summary" (str),
         and "description" (str).

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -85,7 +85,7 @@ from pyarrow._compute import (  # noqa
     register_scalar_function,
     register_tabular_function,
     register_aggregate_function,
-    ScalarUdfContext,
+    UdfContext,
     # Expressions
     Expression,
 )

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -84,6 +84,7 @@ from pyarrow._compute import (  # noqa
     call_tabular_function,
     register_scalar_function,
     register_tabular_function,
+    register_aggregate_function,
     ScalarUdfContext,
     # Expressions
     Expression,

--- a/python/pyarrow/conftest.py
+++ b/python/pyarrow/conftest.py
@@ -278,3 +278,29 @@ def unary_func_fixture():
                                 {"array": pa.int64()},
                                 pa.int64())
     return unary_function, func_name
+
+
+@pytest.fixture(scope="session")
+def unary_agg_func_fixture():
+    """
+    Register a unary aggregate function
+    """
+    from pyarrow import compute as pc
+    import numpy as np
+
+    def func(ctx, x):
+        return pa.array([np.nanmean(x)])
+
+    func_name = "y=avg(x)"
+    func_doc = {"summary": "y=avg(x)",
+                "description": "find mean of x"}
+
+    pc.register_aggregate_function(func,
+                                   func_name,
+                                   func_doc,
+                                   {
+                                       "x": pa.float64(),
+                                   },
+                                   pa.float64()
+                                   )
+    return func, func_name

--- a/python/pyarrow/conftest.py
+++ b/python/pyarrow/conftest.py
@@ -305,6 +305,7 @@ def unary_agg_func_fixture():
                                    )
     return func, func_name
 
+
 @pytest.fixture(scope="session")
 def varargs_agg_func_fixture():
     """

--- a/python/pyarrow/conftest.py
+++ b/python/pyarrow/conftest.py
@@ -289,7 +289,7 @@ def unary_agg_func_fixture():
     import numpy as np
 
     def func(ctx, x):
-        return pa.array([np.nanmean(x)])
+        return pa.scalar(np.nanmean(x))
 
     func_name = "y=avg(x)"
     func_doc = {"summary": "y=avg(x)",

--- a/python/pyarrow/conftest.py
+++ b/python/pyarrow/conftest.py
@@ -304,3 +304,32 @@ def unary_agg_func_fixture():
                                    pa.float64()
                                    )
     return func, func_name
+
+@pytest.fixture(scope="session")
+def varargs_agg_func_fixture():
+    """
+    Register a unary aggregate function
+    """
+    from pyarrow import compute as pc
+    import numpy as np
+
+    def func(ctx, *args):
+        sum = 0.0
+        for arg in args:
+            sum += np.nanmean(arg)
+        return pa.scalar(sum)
+
+    func_name = "y=sum_mean(x...)"
+    func_doc = {"summary": "Varargs aggregate",
+                "description": "Varargs aggregate"}
+
+    pc.register_aggregate_function(func,
+                                   func_name,
+                                   func_doc,
+                                   {
+                                       "x": pa.float64(),
+                                       "y": pa.float64()
+                                   },
+                                   pa.float64()
+                                   )
+    return func, func_name

--- a/python/pyarrow/conftest.py
+++ b/python/pyarrow/conftest.py
@@ -328,7 +328,7 @@ def varargs_agg_func_fixture():
                                    func_name,
                                    func_doc,
                                    {
-                                       "x": pa.float64(),
+                                       "x": pa.int64(),
                                        "y": pa.float64()
                                    },
                                    pa.float64()

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2805,5 +2805,9 @@ cdef extern from "arrow/python/udf.h" namespace "arrow::py" nogil:
                                     function[CallbackUdf] wrapper, const CUdfOptions& options,
                                     CFunctionRegistry* registry)
 
+    CStatus RegisterAggregateFunction(PyObject* function,
+                                      function[CallbackUdf] wrapper, const CUdfOptions& options,
+                                      CFunctionRegistry* registry)
+
     CResult[shared_ptr[CRecordBatchReader]] CallTabularFunction(
         const c_string& func_name, const vector[CDatum]& args, CFunctionRegistry* registry)

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2775,7 +2775,7 @@ cdef extern from "arrow/util/byte_size.h" namespace "arrow::util" nogil:
     int64_t TotalBufferSize(const CRecordBatch& record_batch)
     int64_t TotalBufferSize(const CTable& table)
 
-ctypedef PyObject* CallbackUdf(object user_function, const CScalarUdfContext& context, object inputs)
+ctypedef PyObject* CallbackUdf(object user_function, const CUdfContext& context, object inputs)
 
 
 cdef extern from "arrow/api.h" namespace "arrow" nogil:
@@ -2786,7 +2786,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
 
 
 cdef extern from "arrow/python/udf.h" namespace "arrow::py" nogil:
-    cdef cppclass CScalarUdfContext" arrow::py::ScalarUdfContext":
+    cdef cppclass CUdfContext" arrow::py::UdfContext":
         CMemoryPool *pool
         int64_t batch_length
 

--- a/python/pyarrow/src/arrow/python/udf.cc
+++ b/python/pyarrow/src/arrow/python/udf.cc
@@ -199,11 +199,13 @@ struct PythonTableUdfKernelInit {
                                    ", but function returned datatype ",
                                    val->type()->ToString());
         }
-        out->value = std::move(val->data());
+        ARROW_ASSIGN_OR_RAISE(auto scalar_val , val->GetScalar(0));
+        *out = Datum(scalar_val);
+        // out->value = std::move(val->data());
         return Status::OK();
       } else {
         return Status::TypeError("Unexpected output type: ", Py_TYPE(result.obj())->tp_name,
-                               " (expected Array)");
+                                 " (expected Array)");
       }
       // *out = Datum((int32_t)table->num_rows());
       return Status::OK();

--- a/python/pyarrow/src/arrow/python/udf.cc
+++ b/python/pyarrow/src/arrow/python/udf.cc
@@ -377,6 +377,8 @@ Status RegisterAggregateFunction(PyObject* agg_function, UdfWrapperCallback agg_
     registry = compute::GetFunctionRegistry();
   }
 
+  Py_INCREF(agg_function);
+
   static auto default_scalar_aggregate_options = compute::ScalarAggregateOptions::Defaults();
   auto aggregate_func = std::make_shared<compute::ScalarAggregateFunction>(
       options.func_name, options.arity, options.func_doc, &default_scalar_aggregate_options);

--- a/python/pyarrow/src/arrow/python/udf.cc
+++ b/python/pyarrow/src/arrow/python/udf.cc
@@ -381,16 +381,16 @@ Status RegisterAggregateFunction(PyObject* agg_function, UdfWrapperCallback agg_
   auto aggregate_func = std::make_shared<compute::ScalarAggregateFunction>(
       options.func_name, options.arity, options.func_doc, &default_scalar_aggregate_options);
 
-  Py_INCREF(agg_function);
   std::vector<compute::InputType> input_types;
   for (const auto& in_dtype : options.input_types) {
     input_types.emplace_back(in_dtype);
   }
   compute::OutputType output_type(options.output_type);
 
-  auto init = [agg_wrapper, agg_function, options](
+  compute::KernelInit init = [agg_wrapper, agg_function, options](
                   compute::KernelContext* ctx,
                   const compute::KernelInitArgs& args) -> Result<std::unique_ptr<compute::KernelState>> {
+    // Py_INCREF because OwnedRefNoGIL will call Py_XDECREF in destructor
     Py_INCREF(agg_function);
     return std::make_unique<PythonUdfScalarAggregatorImpl>(
       agg_wrapper,

--- a/python/pyarrow/src/arrow/python/udf.cc
+++ b/python/pyarrow/src/arrow/python/udf.cc
@@ -169,7 +169,6 @@ struct PythonTableUdfKernelInit {
       // Ignore batch length here
       ScalarUdfContext udf_context{ctx->memory_pool(), 0};
 
-
       OwnedRef arg_tuple(PyTuple_New(num_args));
       RETURN_NOT_OK(CheckPyError());
 

--- a/python/pyarrow/src/arrow/python/udf.cc
+++ b/python/pyarrow/src/arrow/python/udf.cc
@@ -131,6 +131,7 @@ struct PythonUdfScalarAggregatorImpl : public ScalarUdfAggregator {
                                 std::vector<std::shared_ptr<DataType>> input_types,
                                 std::shared_ptr<DataType> output_type)
       : agg_cb(agg_cb), agg_function(agg_function), output_type(output_type) {
+    Py_INCREF(agg_function->obj());
     std::vector<std::shared_ptr<Field>> fields;
     for (size_t i = 0; i < input_types.size(); i++) {
       fields.push_back(std::move(field("", input_types[i])));
@@ -183,8 +184,8 @@ struct PythonUdfScalarAggregatorImpl : public ScalarUdfAggregator {
       return Status::Invalid("Finalized is called with empty inputs");
     }
 
-    std::unique_ptr<OwnedRef> result;
     RETURN_NOT_OK(SafeCallIntoPython([&] {
+      std::unique_ptr<OwnedRef> result;
       OwnedRef arg_tuple(PyTuple_New(num_args));
       RETURN_NOT_OK(CheckPyError());
 
@@ -197,21 +198,21 @@ struct PythonUdfScalarAggregatorImpl : public ScalarUdfAggregator {
       result = std::make_unique<OwnedRef>(
           agg_cb(function->obj(), udf_context, arg_tuple.obj()));
       RETURN_NOT_OK(CheckPyError());
-      return Status::OK();
-    }));
-    // unwrapping the output for expected output type
-    if (is_scalar(result->obj())) {
-      ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> val, unwrap_scalar(result->obj()));
-      if (*output_type != *val->type) {
-        return Status::TypeError("Expected output datatype ", output_type->ToString(),
-                                 ", but function returned datatype ",
-                                 val->type->ToString());
+      // unwrapping the output for expected output type
+      if (is_scalar(result->obj())) {
+        ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> val, unwrap_scalar(result->obj()));
+        if (*output_type != *val->type) {
+          return Status::TypeError("Expected output datatype ", output_type->ToString(),
+                                   ", but function returned datatype ",
+                                   val->type->ToString());
+        }
+        out->value = std::move(val);
+        return Status::OK();
       }
-      out->value = std::move(val);
-      return Status::OK();
-    }
-    return Status::TypeError("Unexpected output type: ", Py_TYPE(result->obj())->tp_name,
-                             " (expected Scalar)");
+      return Status::TypeError("Unexpected output type: ", Py_TYPE(result->obj())->tp_name,
+                               " (expected Scalar)");
+    }));
+    return Status::OK();
   }
 
   UdfWrapperCallback agg_cb;
@@ -374,6 +375,9 @@ Status RegisterAggregateFunction(PyObject* agg_function, UdfWrapperCallback agg_
     registry = compute::GetFunctionRegistry();
   }
 
+  // Py_INCREF here so that once a function is registered
+  // its refcount gets increased by 1 and doesn't get gced
+  // if all existing refs are gone
   Py_INCREF(agg_function);
 
   static auto default_scalar_aggregate_options =
@@ -392,8 +396,6 @@ Status RegisterAggregateFunction(PyObject* agg_function, UdfWrapperCallback agg_
                                  compute::KernelContext* ctx,
                                  const compute::KernelInitArgs& args)
       -> Result<std::unique_ptr<compute::KernelState>> {
-    // Py_INCREF because OwnedRefNoGIL will call Py_XDECREF in destructor
-    Py_INCREF(agg_function);
     return std::make_unique<PythonUdfScalarAggregatorImpl>(
         agg_wrapper, std::make_shared<OwnedRefNoGIL>(agg_function), options.input_types,
         options.output_type);

--- a/python/pyarrow/src/arrow/python/udf.cc
+++ b/python/pyarrow/src/arrow/python/udf.cc
@@ -383,6 +383,7 @@ Status RegisterAggregateFunction(PyObject* agg_function, UdfWrapperCallback agg_
   auto init = [agg_wrapper, agg_function, options](
                   compute::KernelContext* ctx,
                   const compute::KernelInitArgs& args) -> Result<std::unique_ptr<compute::KernelState>> {
+    Py_INCREF(agg_function);
     return std::make_unique<PythonUdfScalarAggregatorImpl>(
       agg_wrapper,
       std::make_shared<OwnedRefNoGIL>(agg_function),

--- a/python/pyarrow/src/arrow/python/udf.cc
+++ b/python/pyarrow/src/arrow/python/udf.cc
@@ -393,7 +393,8 @@ Status RegisterAggregateFunction(PyObject* agg_function, UdfWrapperCallback agg_
   };
 
   RETURN_NOT_OK(
-      AddAggKernel(compute::KernelSignature::Make(input_types, output_type),
+      AddAggKernel(compute::KernelSignature::Make(
+        std::move(input_types), std::move(output_type), options.arity.is_varargs),
                    init, aggregate_func.get()));
 
   RETURN_NOT_OK(registry->AddFunction(std::move(aggregate_func)));

--- a/python/pyarrow/src/arrow/python/udf.cc
+++ b/python/pyarrow/src/arrow/python/udf.cc
@@ -209,8 +209,8 @@ struct PythonUdfScalarAggregatorImpl : public ScalarUdfAggregator {
         out->value = std::move(val);
         return Status::OK();
       }
-      return Status::TypeError("Unexpected output type: ", Py_TYPE(result->obj())->tp_name,
-                               " (expected Scalar)");
+      return Status::TypeError("Unexpected output type: ",
+                               Py_TYPE(result->obj())->tp_name, " (expected Scalar)");
     }));
     return Status::OK();
   }

--- a/python/pyarrow/src/arrow/python/udf.cc
+++ b/python/pyarrow/src/arrow/python/udf.cc
@@ -15,12 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-
+#include "arrow/python/udf.h"
 #include "arrow/compute/api_aggregate.h"
 #include "arrow/compute/function.h"
 #include "arrow/compute/kernel.h"
 #include "arrow/python/common.h"
-#include "arrow/python/udf.h"
 #include "arrow/table.h"
 #include "arrow/util/checked_cast.h"
 
@@ -129,7 +128,9 @@ struct PythonUdfScalarAggregatorImpl : public ScalarUdfAggregator {
                                 std::shared_ptr<OwnedRefNoGIL> agg_function,
                                 std::vector<std::shared_ptr<DataType>> input_types,
                                 std::shared_ptr<DataType> output_type)
-      : agg_cb(std::move(agg_cb)), agg_function(agg_function), output_type(std::move(output_type)) {
+      : agg_cb(std::move(agg_cb)),
+        agg_function(agg_function),
+        output_type(std::move(output_type)) {
     Py_INCREF(agg_function->obj());
     std::vector<std::shared_ptr<Field>> fields;
     for (size_t i = 0; i < input_types.size(); i++) {

--- a/python/pyarrow/src/arrow/python/udf.h
+++ b/python/pyarrow/src/arrow/python/udf.h
@@ -67,10 +67,6 @@ Status ARROW_PYTHON_EXPORT RegisterAggregateFunction(
     PyObject* user_function, UdfWrapperCallback wrapper,
     const UdfOptions& options, compute::FunctionRegistry* registry = NULLPTR);
 
-Result<std::shared_ptr<RecordBatchReader>> ARROW_PYTHON_EXPORT CallTabularFunction(
-    const std::string& func_name, const std::vector<Datum>& args,
-    compute::FunctionRegistry* registry = NULLPTR);
-
 Result<std::shared_ptr<RecordBatchReader>> ARROW_PYTHON_EXPORT
 CallTabularFunction(const std::string& func_name, const std::vector<Datum>& args,
                     compute::FunctionRegistry* registry = NULLPTR);

--- a/python/pyarrow/src/arrow/python/udf.h
+++ b/python/pyarrow/src/arrow/python/udf.h
@@ -59,7 +59,16 @@ Status ARROW_PYTHON_EXPORT RegisterScalarFunction(
 
 /// \brief register a Table user-defined-function from Python
 Status ARROW_PYTHON_EXPORT RegisterTabularFunction(
-    PyObject* user_function, UdfWrapperCallback wrapper, const UdfOptions& options,
+    PyObject* user_function, UdfWrapperCallback wrapper,
+    const UdfOptions& options, compute::FunctionRegistry* registry = NULLPTR);
+
+/// \brief register a Aggregate user-defined-function from Python
+Status ARROW_PYTHON_EXPORT RegisterAggregateFunction(
+    PyObject* user_function, UdfWrapperCallback wrapper,
+    const UdfOptions& options, compute::FunctionRegistry* registry = NULLPTR);
+
+Result<std::shared_ptr<RecordBatchReader>> ARROW_PYTHON_EXPORT CallTabularFunction(
+    const std::string& func_name, const std::vector<Datum>& args,
     compute::FunctionRegistry* registry = NULLPTR);
 
 Result<std::shared_ptr<RecordBatchReader>> ARROW_PYTHON_EXPORT

--- a/python/pyarrow/src/arrow/python/udf.h
+++ b/python/pyarrow/src/arrow/python/udf.h
@@ -43,19 +43,19 @@ struct ARROW_PYTHON_EXPORT UdfOptions {
   std::shared_ptr<DataType> output_type;
 };
 
-/// \brief A context passed as the first argument of scalar UDF functions.
-struct ARROW_PYTHON_EXPORT ScalarUdfContext {
+/// \brief A context passed as the first argument of UDF functions.
+struct ARROW_PYTHON_EXPORT UdfContext {
   MemoryPool* pool;
   int64_t batch_length;
 };
 
 using UdfWrapperCallback = std::function<PyObject*(
-    PyObject* user_function, const ScalarUdfContext& context, PyObject* inputs)>;
+    PyObject* user_function, const UdfContext& context, PyObject* inputs)>;
 
 /// \brief register a Scalar user-defined-function from Python
 Status ARROW_PYTHON_EXPORT RegisterScalarFunction(
-    PyObject* user_function, UdfWrapperCallback wrapper, const UdfOptions& options,
-    compute::FunctionRegistry* registry = NULLPTR);
+    PyObject* user_function, UdfWrapperCallback wrapper,
+    const UdfOptions& options, compute::FunctionRegistry* registry = NULLPTR);
 
 /// \brief register a Table user-defined-function from Python
 Status ARROW_PYTHON_EXPORT RegisterTabularFunction(

--- a/python/pyarrow/src/arrow/python/udf.h
+++ b/python/pyarrow/src/arrow/python/udf.h
@@ -54,18 +54,18 @@ using UdfWrapperCallback = std::function<PyObject*(
 
 /// \brief register a Scalar user-defined-function from Python
 Status ARROW_PYTHON_EXPORT RegisterScalarFunction(
-    PyObject* user_function, UdfWrapperCallback wrapper,
-    const UdfOptions& options, compute::FunctionRegistry* registry = NULLPTR);
+    PyObject* user_function, UdfWrapperCallback wrapper, const UdfOptions& options,
+    compute::FunctionRegistry* registry = NULLPTR);
 
 /// \brief register a Table user-defined-function from Python
 Status ARROW_PYTHON_EXPORT RegisterTabularFunction(
-    PyObject* user_function, UdfWrapperCallback wrapper,
-    const UdfOptions& options, compute::FunctionRegistry* registry = NULLPTR);
+    PyObject* user_function, UdfWrapperCallback wrapper, const UdfOptions& options,
+    compute::FunctionRegistry* registry = NULLPTR);
 
 /// \brief register a Aggregate user-defined-function from Python
 Status ARROW_PYTHON_EXPORT RegisterAggregateFunction(
-    PyObject* user_function, UdfWrapperCallback wrapper,
-    const UdfOptions& options, compute::FunctionRegistry* registry = NULLPTR);
+    PyObject* user_function, UdfWrapperCallback wrapper, const UdfOptions& options,
+    compute::FunctionRegistry* registry = NULLPTR);
 
 Result<std::shared_ptr<RecordBatchReader>> ARROW_PYTHON_EXPORT
 CallTabularFunction(const std::string& func_name, const std::vector<Datum>& args,

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -607,10 +607,11 @@ def test_output_field_names(use_threads):
     assert res_tb == expected
 
 
-def test_aggregate_udf_basic(unary_agg_func_fixture):
+def test_aggregate_udf_basic(varargs_agg_func_fixture):
 
     test_table = pa.Table.from_pydict(
-        {"k": [1, 1, 2, 2], "v": [1.0, 2.0, 3.0, 4.0]}
+        {"k": [1, 1, 2, 2], "v1": [1.0, 2.0, 3.0, 4.0],
+         "v2": [1.0, 1.0, 1.0, 1.0]}
     )
 
     def table_provider(names, _):
@@ -629,7 +630,7 @@ def test_aggregate_udf_basic(unary_agg_func_fixture):
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 1,
-        "name": "y=avg(x)"
+        "name": "y=sum_mean(x...)"
       }
     }
   ],
@@ -650,14 +651,20 @@ def test_aggregate_udf_basic(unary_agg_func_fixture):
               "read": {
                 "baseSchema": {
                   "names": [
-                    "time",
-                    "price"
+                    "k",
+                    "v1",
+                    "v2",
                   ],
                   "struct": {
                     "types": [
                       {
                         "i64": {
                           "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "fp64": {
+                          "nullability": "NULLABILITY_NULLABLE"
                         }
                       },
                       {
@@ -706,6 +713,18 @@ def test_aggregate_udf_basic(unary_agg_func_fixture):
                             "rootReference": {}
                           }
                         }
+                      },
+                      {
+                        "value": {
+                          "selection": {
+                            "directReference": {
+                              "structField": {
+                                "field": 2
+                              }
+                            },
+                            "rootReference": {}
+                          }
+                        }
                       }
                     ]
                   }
@@ -730,7 +749,7 @@ def test_aggregate_udf_basic(unary_agg_func_fixture):
 
     expected_tb = pa.Table.from_pydict({
         'k': [1, 2],
-        'v_avg': [1.5, 3.5]
+        'v_avg': [2.5, 4.5]
     })
 
     assert res_tb == expected_tb

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -34,9 +34,9 @@ except ImportError:
 pytestmark = [pytest.mark.dataset, pytest.mark.substrait]
 
 
-def mock_scalar_udf_context(batch_length=10):
-    from pyarrow._compute import _get_scalar_udf_context
-    return _get_scalar_udf_context(pa.default_memory_pool(), batch_length)
+def mock_udf_context(batch_length=10):
+    from pyarrow._compute import _get_udf_context
+    return _get_udf_context(pa.default_memory_pool(), batch_length)
 
 
 def _write_dummy_data_to_disk(tmpdir, file_name, table):
@@ -436,14 +436,13 @@ def test_udf_via_substrait(unary_func_fixture, use_threads):
     """
 
     buf = pa._substrait._parse_json_plan(substrait_query)
-    breakpoint()
     reader = pa.substrait.run_query(
         buf, table_provider=table_provider, use_threads=use_threads)
     res_tb = reader.read_all()
 
     function, name = unary_func_fixture
     expected_tb = test_table.add_column(1, 'y', function(
-        mock_scalar_udf_context(10), test_table['x']))
+        mock_udf_context(10), test_table['x']))
     assert res_tb == expected_tb
 
 
@@ -608,7 +607,7 @@ def test_output_field_names(use_threads):
     assert res_tb == expected
 
 
-def test_agg_udf(unary_agg_func_fixture):
+def test_aggregate_udf_basic(unary_agg_func_fixture):
 
     test_table = pa.Table.from_pydict(
         {"k": [1, 1, 2, 2], "v": [1.0, 2.0, 3.0, 4.0]}

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -610,7 +610,7 @@ def test_output_field_names(use_threads):
 def test_aggregate_udf_basic(varargs_agg_func_fixture):
 
     test_table = pa.Table.from_pydict(
-        {"k": [1, 1, 2, 2], "v1": [1.0, 2.0, 3.0, 4.0],
+        {"k": [1, 1, 2, 2], "v1": [1, 2, 3, 4],
          "v2": [1.0, 1.0, 1.0, 1.0]}
     )
 
@@ -663,7 +663,7 @@ def test_aggregate_udf_basic(varargs_agg_func_fixture):
                         }
                       },
                       {
-                        "fp64": {
+                        "i64": {
                           "nullability": "NULLABILITY_NULLABLE"
                         }
                       },

--- a/python/pyarrow/tests/test_udf.py
+++ b/python/pyarrow/tests/test_udf.py
@@ -40,30 +40,6 @@ class MyError(RuntimeError):
 
 
 @pytest.fixture(scope="session")
-def unary_agg_func_fixture():
-    """
-    Register a unary aggregate function
-    """
-
-    def func(ctx, x):
-        return pa.array([len(x)])
-
-    func_name = "y=len(x)"
-    func_doc = {"summary": "y=len(x)",
-                "description": "find length of x"}
-
-    pc.register_aggregate_function(func,
-                                   func_name,
-                                   func_doc,
-                                   {
-                                       "x": pa.int64(),
-                                   },
-                                   pa.int64()
-                                   )
-    return func, func_name
-
-
-@pytest.fixture(scope="session")
 def bad_unary_agg_func_fixture():
     """
     Register a unary aggregate function
@@ -645,9 +621,9 @@ def test_udt_datasource1_exception():
 
 
 def test_aggregate_basic(unary_agg_func_fixture):
-    arr = pa.array([10, 20, 30, 40, 50, 60], pa.int64())
-    result = pc.call_function("y=len(x)", [arr])
-    expected = pa.array([6])
+    arr = pa.array([10.0, 20.0, 30.0, 40.0, 50.0, 60.0], pa.float64())
+    result = pc.call_function("y=avg(x)", [arr])
+    expected = pa.scalar(35.0)
     assert result == expected
 
 

--- a/python/pyarrow/tests/test_udf.py
+++ b/python/pyarrow/tests/test_udf.py
@@ -658,16 +658,3 @@ def test_aggregate_exception(bad_unary_agg_func_fixture):
             pc.call_function("y=bad_len(x)", [arr])
         except Exception as e:
             raise e
-
-
-def test_aggregate_segfault(bad_unary_agg_func_fixture):
-    # This test will segfault the python process.
-    arr = pa.array([10, 20, 30, 40, 50, 60], pa.int64())
-    try:
-        result = pc.call_function("y=bad_len(x)", [arr])
-    except Exception as e:
-        print("Before segfault")
-        raise e
-
-    expected = pa.array([6])
-    assert result == expected

--- a/python/pyarrow/tests/test_udf.py
+++ b/python/pyarrow/tests/test_udf.py
@@ -40,6 +40,30 @@ class MyError(RuntimeError):
 
 
 @pytest.fixture(scope="session")
+def unary_agg_func_fixture():
+    """
+    Register a unary aggregate function
+    """
+
+    def func(ctx, x):
+        return pa.array([len(x)])
+
+    func_name = "y=len(x)"
+    func_doc = {"summary": "y=len(x)",
+                "description": "find length of x"}
+
+    pc.register_aggregate_function(func,
+                                   func_name,
+                                   func_doc,
+                                   {
+                                       "x": pa.int64(),
+                                   },
+                                   pa.int64()
+                                   )
+    return func, func_name
+
+
+@pytest.fixture(scope="session")
 def binary_func_fixture():
     """
     Register a binary scalar function.
@@ -593,3 +617,10 @@ def test_udt_datasource1_generator():
 def test_udt_datasource1_exception():
     with pytest.raises(RuntimeError, match='datasource1_exception'):
         _test_datasource1_udt(datasource1_exception)
+
+
+def test_aggregate_udf_basic(unary_agg_func_fixture):
+    arr = pa.array([10, 20, 30, 40, 50, 60], pa.int64())
+    result = pc.call_function("y=len(x)", [arr])
+    expected = pa.array([6])
+    assert result == expected

--- a/python/pyarrow/tests/test_udf.py
+++ b/python/pyarrow/tests/test_udf.py
@@ -63,7 +63,6 @@ def bad_unary_agg_func_fixture():
                                    )
     return func, func_name
 
-
 @pytest.fixture(scope="session")
 def binary_func_fixture():
     """
@@ -621,14 +620,26 @@ def test_udt_datasource1_exception():
 
 
 def test_aggregate_basic(unary_agg_func_fixture):
-    arr = pa.array([10.0, 20.0, 30.0, 40.0, 50.0, 60.0], pa.float64())
+    arr = pa.array([10.0, 20.0, 30.0, 40.0, 50.0], pa.float64())
     result = pc.call_function("y=avg(x)", [arr])
-    expected = pa.scalar(35.0)
+    expected = pa.scalar(30.0)
+    assert result == expected
+
+
+def test_aggregate_varargs(varargs_agg_func_fixture):
+    arr1 = pa.array([10.0, 20.0, 30.0, 40.0, 50.0], pa.float64())
+    arr2 = pa.array([1.0, 2.0, 3.0, 4.0, 5.0], pa.float64())
+
+    result = pc.call_function(
+        "y=sum_mean(x...)", [arr1, arr2]
+    )
+    expected = pa.scalar(33.0)
     assert result == expected
 
 
 def test_aggregate_exception(bad_unary_agg_func_fixture):
     arr = pa.array([10, 20, 30, 40, 50, 60], pa.int64())
+
     with pytest.raises(RuntimeError, match='Oops'):
         try:
             pc.call_function("y=bad_len(x)", [arr])

--- a/python/pyarrow/tests/test_udf.py
+++ b/python/pyarrow/tests/test_udf.py
@@ -63,6 +63,7 @@ def bad_unary_agg_func_fixture():
                                    )
     return func, func_name
 
+
 @pytest.fixture(scope="session")
 def binary_func_fixture():
     """

--- a/python/pyarrow/tests/test_udf.py
+++ b/python/pyarrow/tests/test_udf.py
@@ -628,7 +628,7 @@ def test_aggregate_basic(unary_agg_func_fixture):
 
 
 def test_aggregate_varargs(varargs_agg_func_fixture):
-    arr1 = pa.array([10.0, 20.0, 30.0, 40.0, 50.0], pa.float64())
+    arr1 = pa.array([10, 20, 30, 40, 50], pa.int64())
     arr2 = pa.array([1.0, 2.0, 3.0, 4.0, 5.0], pa.float64())
 
     result = pc.call_function(

--- a/python/pyarrow/tests/test_udf.py
+++ b/python/pyarrow/tests/test_udf.py
@@ -30,9 +30,9 @@ except ImportError:
     ds = None
 
 
-def mock_scalar_udf_context(batch_length=10):
-    from pyarrow._compute import _get_scalar_udf_context
-    return _get_scalar_udf_context(pa.default_memory_pool(), batch_length)
+def mock_udf_context(batch_length=10):
+    from pyarrow._compute import _get_udf_context
+    return _get_udf_context(pa.default_memory_pool(), batch_length)
 
 
 class MyError(RuntimeError):
@@ -47,7 +47,7 @@ def bad_unary_agg_func_fixture():
 
     def func(ctx, x):
         raise RuntimeError("Oops")
-        return pa.array([len(x)])
+        return pa.scalar(len(x))
 
     func_name = "y=bad_len(x)"
     func_doc = {"summary": "y=bad_len(x)",
@@ -257,7 +257,7 @@ def check_scalar_function(func_fixture,
     assert func.name == name
 
     result = pc.call_function(name, inputs, length=batch_length)
-    expected_output = function(mock_scalar_udf_context(batch_length), *inputs)
+    expected_output = function(mock_udf_context(batch_length), *inputs)
     assert result == expected_output
     # At the moment there is an issue when handling nullary functions.
     # See: ARROW-15286 and ARROW-16290.

--- a/python/pyarrow/tests/test_udf.py
+++ b/python/pyarrow/tests/test_udf.py
@@ -626,6 +626,11 @@ def test_aggregate_basic(unary_agg_func_fixture):
     expected = pa.scalar(30.0)
     assert result == expected
 
+def test_aggregate_empty(unary_agg_func_fixture):
+    arr = pa.array([], pa.float64())
+
+    with pytest.raises(RuntimeError, match='.*empty inputs.*'):
+        pc.call_function("y=avg(x)", [arr])
 
 def test_aggregate_varargs(varargs_agg_func_fixture):
     arr1 = pa.array([10, 20, 30, 40, 50], pa.int64())
@@ -642,7 +647,4 @@ def test_aggregate_exception(bad_unary_agg_func_fixture):
     arr = pa.array([10, 20, 30, 40, 50, 60], pa.int64())
 
     with pytest.raises(RuntimeError, match='Oops'):
-        try:
-            pc.call_function("y=bad_len(x)", [arr])
-        except Exception as e:
-            raise e
+        pc.call_function("y=bad_len(x)", [arr])


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
Non decomposable aggregation is aggregation that cannot be split into consume/merge/finalize. This is often when the logic rewritten with external python libraries (numpy, pandas, statmodels, etc) and those either cannot be decomposed or not worthy the effect (these are often one-off function instead of reusable one). This PR implements the support for non decomposable aggregation UDFs.

The major issue with non decomposable UDF is that the UDF needs to see all data at once, unlike scalar UDF where UDF only needs to see a batch at a time. This makes non decomposable not so useful as it is same as collect all the data to a pd.DataFrame and apply the UDF on it. However, one very application of non decomposable UDF is with segmented aggregation. To refresh, segmented aggregation works on ordered data and passed one logic chunk at a time (e.g., all data with the same date). With segmented aggregation and non decomposable aggregation UDF, the user can apply any custom aggregation logic over large stream of ordered data, with the memory overhead of a single segment.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
### What changes are included in this PR?
This PR is currently WIP and not ready for review.

So far I have implemented the minimal amount of code to make a basic test working but needs clean up, error handling etc.

* [x] First round of self review
* [x] Second round of self review
* [x] Implement and test unary
* [x] Implement and test varargs
* [x] Implement and test Acero support with segmented aggregation
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
Added new test calling with compute and acero.

The compute tests calls the aggregation on the full array. The acero test callings the aggregation with segmented aggregation.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #35515