### PR TITLE
MINOR: [R] Add archery command for revdep checks to packaging checklist

### DIFF
--- a/r/PACKAGING.md
+++ b/r/PACKAGING.md
@@ -37,6 +37,7 @@ Before the release candidate is cut:
 - [ ] Run `urlchecker::url_check()` on the R directory at the release candidate
   commit. Ignore any errors with badges as they will be removed in the CRAN release branch.
 - [ ] [Polish NEWS](https://style.tidyverse.org/news.html#news-release) but do **not** update version numbers (this is done automatically later).
+- [ ] Run preliminary reverse dependency checks using `archery docker run r-revdepcheck`.
 - [ ] For major releases, prepare tweet thread highlighting new features
 
 Wait for the release candidate to be cut:
@@ -76,9 +77,7 @@ Prepare and check the .tar.gz that will be released to CRAN.
   of Arrow C++ available to the configure script is the same as the version
   that is vendored into the R package (e.g., you may need to unset `ARROW_HOME`).
 - [ ] `devtools::check_built("arrow_X.X.X.tar.gz")` locally
-- [ ] Run reverse dependency checks. Currently this is a 
-  [manual process](https://gist.github.com/paleolimbot/630fdab1e204d70fea97633d8fa15ccb);
-  however, in the future it may be a crossbow nightly job.
+- [ ] Run reverse dependency checks using `archery docker run r-revdepcheck`.
 
 Wait for the official release...
   


### PR DESCRIPTION
This PR adds the actual archery command that runs the reverse dependency checks instead of linking to a half-baked gist!