### PR TITLE
GH-35521: [C++] Hash null bitmap only if null count is 0

### DIFF
--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -153,10 +153,10 @@ struct ScalarHashImpl {
 
   Status ArrayHash(const ArrayData& a) {
     RETURN_NOT_OK(StdHash(a.length) & StdHash(a.GetNullCount()));
-    if (a.GetNullCount() != 0) {
+    if (a.GetNullCount() != 0 && a.buffers[0] != nullptr) {
       // We can't visit values without unboxing the whole array, so only hash
       // the null bitmap for now. Only hash the null bitmap if the null count
-      // is 0 to ensure hash consistency.
+      // is not 0 to ensure hash consistency.
       RETURN_NOT_OK(BufferHash(*a.buffers[0]));
     }
     for (const auto& child : a.child_data) {

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -153,9 +153,10 @@ struct ScalarHashImpl {
 
   Status ArrayHash(const ArrayData& a) {
     RETURN_NOT_OK(StdHash(a.length) & StdHash(a.GetNullCount()));
-    if (a.buffers[0] != nullptr) {
+    if (a.GetNullCount() != 0) {
       // We can't visit values without unboxing the whole array, so only hash
-      // the null bitmap for now.
+      // the null bitmap for now. Only hash the null bitmap if the null count
+      // is 0 to ensure hash consistency.
       RETURN_NOT_OK(BufferHash(*a.buffers[0]));
     }
     for (const auto& child : a.child_data) {


### PR DESCRIPTION
### Are these changes tested?

I am new to contributing and am having a hard time creating a good test for this. The steps to reproduce this bug originally are too complicated for a simple test. I included my attempt at making a good test in the PR, but some help would be nice.
-->

### Are there any user-facing changes?
No.

**This PR contains a "Critical Fix".**
* Closes: #35521