### PR TITLE
GH-35498: [C++] Fix source node batch realignment

### DIFF
--- a/cpp/src/arrow/acero/source_node.cc
+++ b/cpp/src/arrow/acero/source_node.cc
@@ -105,10 +105,11 @@ struct SourceNode : ExecNode, public TracedNode {
             }
             ExecBatch batch = morsel.Slice(offset, batch_size);
             for (auto& value : batch.values) {
-              if (value.is_array()) {
-                ARROW_ASSIGN_OR_RAISE(value, arrow::util::EnsureAlignment(
-                                                 value.make_array(), ipc::kArrowAlignment,
-                                                 default_memory_pool()));
+              if (value.is_array() && value.type()->byte_width() > 1) {
+                ARROW_ASSIGN_OR_RAISE(
+                    value, arrow::util::EnsureAlignment(value.make_array(),
+                                                        value.type()->byte_width(),
+                                                        default_memory_pool()));
               }
             }
             if (has_ordering) {

--- a/cpp/src/arrow/acero/source_node.cc
+++ b/cpp/src/arrow/acero/source_node.cc
@@ -105,7 +105,7 @@ struct SourceNode : ExecNode, public TracedNode {
             }
             ExecBatch batch = morsel.Slice(offset, batch_size);
             for (auto& value : batch.values) {
-              if (value.is_array() && value.type()->byte_width() > 1) {
+              if (value.is_array() && value.type()->byte_width() > 1) {  // GH-35498
                 ARROW_ASSIGN_OR_RAISE(
                     value, arrow::util::EnsureAlignment(value.make_array(),
                                                         value.type()->byte_width(),


### PR DESCRIPTION
### Rationale for this change

Currently, source node uses too high a value for realignment, which [caused a performance degradation](https://github.com/apache/arrow/issues/35498).

### What changes are included in this PR?

The source node batch realigns an array to its byte width (if it is more than 1).

### Are these changes tested?

The changes are tested for correctness by the existing tests. The performance is checked by regression jobs.

### Are there any user-facing changes?

Only performance.

**This PR contains a "Critical Fix".**
* Closes: #35498