### PR TITLE
GH-35250: [Python] Add test for datetime column conversion to pandas

### DIFF
--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -4822,16 +4822,10 @@ def test_column_conversion_for_datetime():
     # GH-35235
     # pandas implemented __from_arrow__ for DatetimeTZDtype
     # https://github.com/pandas-dev/pandas/pull/52201
-    if Version(pd.__version__) <= Version("2.0.1"):
-        pytest.skip("__from_arrow__ added to DatetimeTZDtype in pandas version 2.1.0")
-
     arr = pd.Series(pd.date_range("2012", periods=2, tz="Europe/Brussels"),
                     name="datetime_column")
     table = pa.table({"datetime_column": pa.array(arr)})
     table_col = table.column("datetime_column")
-
-    pandas_dtype = table_col.type.to_pandas_dtype()
-    assert hasattr(pandas_dtype, '__from_arrow__')
 
     result = table_col.to_pandas()
     assert result.name == "datetime_column"


### PR DESCRIPTION
### Rationale for this change
In pandas version 2.1.0 `__from_arrow__` method has been implemented for `DatetimeTZDtype` extension type. See https://github.com/pandas-dev/pandas/pull/52201.

Due to this change, the conversion from pyarrow table column with datetime uses the newly implemented `__from_arrow__` method for the pandas dtype and `pandas_api.series` to construct the pandas series. We had to pass the name in the `pandas_api.series` also, to fix failing tests in https://github.com/apache/arrow/pull/35248.

This PR adds explicit test for this change.
* Closes: #35250