### PR TITLE
GH-35550: [MATLAB] Add public `toMATLAB` method to `arrow.array.Array` for converting to MATLAB types

### DIFF
--- a/matlab/src/cpp/arrow/matlab/array/proxy/array.cc
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/array.cc
@@ -23,7 +23,7 @@ namespace arrow::matlab::array::proxy {
 
         // Register Proxy methods.
         REGISTER_METHOD(Array, ToString);
-        REGISTER_METHOD(Array, ToMatlab);
+        REGISTER_METHOD(Array, toMATLAB);
         REGISTER_METHOD(Array, Length);
     }
 

--- a/matlab/src/cpp/arrow/matlab/array/proxy/array.cc
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/array.cc
@@ -22,12 +22,12 @@ namespace arrow::matlab::array::proxy {
     Array::Array(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
 
         // Register Proxy methods.
-        REGISTER_METHOD(Array, ToString);
+        REGISTER_METHOD(Array, toString);
         REGISTER_METHOD(Array, toMATLAB);
-        REGISTER_METHOD(Array, Length);
+        REGISTER_METHOD(Array, length);
     }
 
-    void Array::ToString(libmexclass::proxy::method::Context& context) {
+    void Array::toString(libmexclass::proxy::method::Context& context) {
         ::matlab::data::ArrayFactory factory;
 
         // TODO: handle non-ascii characters
@@ -35,7 +35,7 @@ namespace arrow::matlab::array::proxy {
         context.outputs[0] = str_mda;
     }
 
-    void Array::Length(libmexclass::proxy::method::Context& context) {
+    void Array::length(libmexclass::proxy::method::Context& context) {
         ::matlab::data::ArrayFactory factory;
         auto length_mda = factory.createScalar(array->length());
         context.outputs[0] = length_mda;

--- a/matlab/src/cpp/arrow/matlab/array/proxy/array.h
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/array.h
@@ -31,9 +31,9 @@ class Array : public libmexclass::proxy::Proxy {
 
     protected:
 
-        void ToString(libmexclass::proxy::method::Context& context);
+        void toString(libmexclass::proxy::method::Context& context);
 
-        void Length(libmexclass::proxy::method::Context& context);
+        void length(libmexclass::proxy::method::Context& context);
 
         virtual void toMATLAB(libmexclass::proxy::method::Context& context) = 0;
 

--- a/matlab/src/cpp/arrow/matlab/array/proxy/array.h
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/array.h
@@ -35,7 +35,7 @@ class Array : public libmexclass::proxy::Proxy {
 
         void Length(libmexclass::proxy::method::Context& context);
 
-        virtual void ToMatlab(libmexclass::proxy::method::Context& context) = 0;
+        virtual void toMATLAB(libmexclass::proxy::method::Context& context) = 0;
 
         std::shared_ptr<arrow::Array> array;
 };

--- a/matlab/src/cpp/arrow/matlab/array/proxy/numeric_array.h
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/numeric_array.h
@@ -78,7 +78,7 @@ class NumericArray : public arrow::matlab::array::proxy::Array {
         }
 
     protected:
-        void ToMatlab(libmexclass::proxy::method::Context& context) override {
+        void toMATLAB(libmexclass::proxy::method::Context& context) override {
             using ArrowArrayType = typename arrow::CTypeTraits<CType>::ArrayType;
 
             const auto num_elements = static_cast<size_t>(array->length());

--- a/matlab/src/matlab/+arrow/+array/Array.m
+++ b/matlab/src/matlab/+arrow/+array/Array.m
@@ -32,7 +32,7 @@ classdef (Abstract) Array < matlab.mixin.CustomDisplay & ...
         end
 
         function numElements = get.Length(obj)
-            numElements = obj.Proxy.Length();
+            numElements = obj.Proxy.length();
         end
 
         function matlabArray = toMATLAB(obj)
@@ -41,14 +41,14 @@ classdef (Abstract) Array < matlab.mixin.CustomDisplay & ...
     end
 
     methods (Access = private)
-        function str = ToString(obj)
-            str = obj.Proxy.ToString();
+        function str = toString(obj)
+            str = obj.Proxy.toString();
         end
     end
 
     methods (Access=protected)
         function displayScalarObject(obj)
-            disp(obj.ToString());
+            disp(obj.toString());
         end
     end
 end

--- a/matlab/src/matlab/+arrow/+array/Array.m
+++ b/matlab/src/matlab/+arrow/+array/Array.m
@@ -34,6 +34,10 @@ classdef (Abstract) Array < matlab.mixin.CustomDisplay & ...
         function numElements = get.Length(obj)
             numElements = obj.Proxy.Length();
         end
+
+        function matlabArray = toMATLAB(obj)
+            matlabArray = obj.Proxy.toMATLAB();
+        end
     end
 
     methods (Access = private)

--- a/matlab/src/matlab/+arrow/+array/Float32Array.m
+++ b/matlab/src/matlab/+arrow/+array/Float32Array.m
@@ -34,7 +34,7 @@ classdef Float32Array < arrow.array.Array
         end
 
         function data = single(obj)
-            data = obj.Proxy.ToMatlab();
+            data = obj.Proxy.toMATLAB();
         end
     end
 end

--- a/matlab/src/matlab/+arrow/+array/Float64Array.m
+++ b/matlab/src/matlab/+arrow/+array/Float64Array.m
@@ -35,7 +35,7 @@ classdef Float64Array < arrow.array.Array
         end
 
         function data = double(obj)
-            data = obj.Proxy.ToMatlab();
+            data = obj.Proxy.toMATLAB();
         end
     end
 end

--- a/matlab/test/arrow/array/tFloat32Array.m
+++ b/matlab/test/arrow/array/tFloat32Array.m
@@ -96,7 +96,7 @@ classdef tFloat32Array < matlab.unittest.TestCase
             testCase.verifyError(fcn, "MATLAB:expectedReal");
         end
 
-        function ToMATLAB(testCase, MakeDeepCopy)
+        function toMATLAB(testCase, MakeDeepCopy)
             A1 = arrow.array.Float32Array(single(100), DeepCopy=MakeDeepCopy);
             data = toMATLAB(A1);
             testCase.verifyEqual(data, single(100));

--- a/matlab/test/arrow/array/tFloat32Array.m
+++ b/matlab/test/arrow/array/tFloat32Array.m
@@ -95,5 +95,11 @@ classdef tFloat32Array < matlab.unittest.TestCase
             fcn = @() arrow.array.Float32Array(single([10 + 1i, 4]), DeepCopy=MakeDeepCopy);
             testCase.verifyError(fcn, "MATLAB:expectedReal");
         end
+
+        function ToMATLAB(testCase, MakeDeepCopy)
+            A1 = arrow.array.Float32Array(single(100), DeepCopy=MakeDeepCopy);
+            data = toMATLAB(A1);
+            testCase.verifyEqual(data, single(100));
+        end
     end
 end

--- a/matlab/test/arrow/array/tFloat64Array.m
+++ b/matlab/test/arrow/array/tFloat64Array.m
@@ -116,6 +116,12 @@ classdef tFloat64Array < matlab.unittest.TestCase
             A = arrow.array.Float64Array(1:100, DeepCopy=MakeDeepCopy);
             expectedLength = int64(100);
             testCase.verifyEqual(A.Length, expectedLength);
+         end
+
+         function toMATLAB(testCase, MakeDeepCopy)
+            A1 = arrow.array.Float64Array(100, DeepCopy=MakeDeepCopy);
+            data = toMATLAB(A1);
+            testCase.verifyEqual(data, 100);
         end
     end
 end


### PR DESCRIPTION
### Rationale for this change

In order to allow clients to write generic code for different concrete `arrow.array.Array` subclasses in MATLAB, it would be helpful to have one generic `toMATLAB` method. `toMATLAB` would convert the `arrow.array.Array` into a corresponding MATLAB type.

For example, `arrow.array.Float64Array` would be converted to a MATLAB `double` array.

```matlab
>> doubleMatlabArray = toMATLAB(float64ArrowArray) % Convert the arrow.array.Float64Array to a MATLAB double array
```
### What changes are included in this PR?

1. Added a public `toMATLAB` method to the `arrow.array.Array` superclass.

Example of using `toMATLAB` on an `arrow.array.Float64Array`:

```matlab
>> arrowArray = arrow.array.Float64Array(1:10)

arrowArray = 

[
  1,
  2,
  3,
  4,
  5,
  6,
  7,
  8,
  9,
  10
]
>> matlabArray = toMATLAB(arrowArray)

matlabArray =

     1
     2
     3
     4
     5
     6
     7
     8
     9
    10

>> class(matlabArray)

ans =

    'double'

```

### Are these changes tested?

1. Yes, we added tests for `toMATLAB` to `tFloat32Array.m` and `tFloat64Array.m`.
2. This was qualified on a Debian 11 machine.

### Future Directions

1. Move the `toMATLAB` tests to the shared test utility class (i.e. #35537).

### Notes

1. Thanks to @sgilmore10 for her help with this pull request!
* Closes: #35550