### PR TITLE
increase required cmake version in C++ build docs

### DIFF
--- a/docs/source/developers/cpp/building.rst
+++ b/docs/source/developers/cpp/building.rst
@@ -41,7 +41,7 @@ Building requires:
 
 * A C++17-enabled compiler. On Linux, gcc 7.1 and higher should be
   sufficient. For Windows, at least Visual Studio VS2017 is required.
-* CMake 3.5 or higher
+* CMake 3.22.1 or higher
 * On Linux and macOS, either ``make`` or ``ninja`` build utilities
 * At least 1GB of RAM for a minimal build, 4GB for a minimal  
   debug build with tests and 8GB for a full build using


### PR DESCRIPTION
Current docs say that cmake >=3.5 is required to build C++ libraries, but that is not consistent with what I observe, build commands fail (do not report output similar to docs) using cmake 3.10.2 on my system, see below. Not sure what the minimal cmake version would be, but I installed cmake 3.22.1 from conda and that seems to work (gives output similar to docs).
```
(arrow) tdhock@maude-MacBookPro:~/arrow-git/cpp/build(main)$ /usr/bin/cmake --version
cmake version 3.10.2

CMake suite maintained and supported by Kitware (kitware.com/cmake).
(arrow) tdhock@maude-MacBookPro:~/arrow-git/cpp/build(main)$ cd ..
(arrow) tdhock@maude-MacBookPro:~/arrow-git/cpp(main)$ /usr/bin/cmake --list-presets
CMake Error: The source directory "/home/tdhock/arrow-git/cpp/--list-presets" does not exist.
Specify --help for usage, or press the help button on the CMake GUI.
(arrow) tdhock@maude-MacBookPro:~/arrow-git/cpp(main)$ /usr/bin/cmake --preset -N ninja-debug-minimal
(arrow) tdhock@maude-MacBookPro:~/arrow-git/cpp(main)$ cd build
(arrow) tdhock@maude-MacBookPro:~/arrow-git/cpp/build(main)$ /usr/bin/cmake .. --preset ninja-debug-minimal
CMake Error: The source directory "/home/tdhock/arrow-git/cpp/build/ninja-debug-minimal" does not exist.
Specify --help for usage, or press the help button on the CMake GUI.
```