### PR TITLE
MINOR: [Doc] Update Parquet documentation website links

### DIFF
--- a/docs/source/cpp/parquet.rst
+++ b/docs/source/cpp/parquet.rst
@@ -27,7 +27,7 @@ Reading and writing Parquet files
 .. seealso::
    :ref:`Parquet reader and writer API reference <cpp-api-parquet>`.
 
-The `Parquet format <https://parquet.apache.org/documentation/latest/>`__
+The `Parquet format <https://parquet.apache.org/docs/>`__
 is a space-efficient columnar storage format for complex data.  The Parquet
 C++ implementation is part of the Apache Arrow project and benefits
 from tight integration with the Arrow C++ classes and facilities.

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -1326,4 +1326,4 @@ the Arrow spec.
 .. _Intel performance guide: https://software.intel.com/en-us/articles/practical-intel-avx-optimization-on-2nd-generation-intel-core-processors
 .. _Endianness: https://en.wikipedia.org/wiki/Endianness
 .. _SIMD: https://software.intel.com/en-us/cpp-compiler-developer-guide-and-reference-introduction-to-the-simd-data-layout-templates
-.. _Parquet: https://parquet.apache.org/documentation/latest/
+.. _Parquet: https://parquet.apache.org/docs/


### PR DESCRIPTION
### Rationale for this change

While reviewing the Arrow docs on Parquet, I noticed two links to https://parquet.apache.org/documentation/latest/ which 404 for me. As far as I can tell, the docs site was redone and moved to https://parquet.apache.org/docs some time in 2022.

### Are these changes tested?

I didn't go so far as to find the associated Jira issue for the docs website refactor so I'd appreciate if someone more familiar with the project could double-check if the old URL is indeed permanently dead.