### PR TITLE
GH-35571: [C++][CI][Parquet] Change `EQ` to `FLOAT_EQ` in Decryption tests

### DIFF
--- a/cpp/src/parquet/encryption/read_configurations_test.cc
+++ b/cpp/src/parquet/encryption/read_configurations_test.cc
@@ -236,7 +236,7 @@ TEST_P(TestDecryptionConfiguration, TestDecryption) {
   }
 
   // Iterate over the decryption configurations and use each one to read the encrypted
-  // parqeut file.
+  // parquet file.
   for (unsigned index = 0; index < vector_of_decryption_configurations_.size(); ++index) {
     unsigned decryption_config_num = index + 1;
     CheckResults(file_name, decryption_config_num, encryption_config_num);
@@ -254,7 +254,7 @@ TEST_P(TestDecryptionConfiguration, TestDecryption) {
   }
 
   // Iterate over the decryption configurations and use each one to read the encrypted
-  // parqeut file.
+  // parquet file.
   for (unsigned index = 0; index < vector_of_decryption_configurations_.size(); ++index) {
     unsigned decryption_config_num = index + 1;
     CheckResults(file_name, decryption_config_num, encryption_config_num);

--- a/cpp/src/parquet/encryption/test_encryption_util.cc
+++ b/cpp/src/parquet/encryption/test_encryption_util.cc
@@ -324,6 +324,9 @@ void ReadAndVerifyColumn(RowGroupReader* rg_reader, RowGroupMetadata* rg_md,
   ASSERT_EQ(values_read, rows_should_read);
   // make sure we got the same number of values the metadata says
   ASSERT_EQ(col_md->num_values(), rows_read);
+  // GH-35571: need to use approximate floating-point comparison because of
+  // precision issues on MinGW32 (the values generated in the C++ test code
+  // may not exactly match those from the parquet-testing data files).
   if constexpr (std::is_floating_point_v<typename DType::c_type>) {
     ASSERT_EQ(read_col_data.rows(), expected_column_data.rows());
     for (int i = 0; i < read_col_data.rows(); ++i) {

--- a/cpp/src/parquet/encryption/test_encryption_util.cc
+++ b/cpp/src/parquet/encryption/test_encryption_util.cc
@@ -290,6 +290,15 @@ void FileEncryptor::EncryptFile(
   return;
 }  // namespace test
 
+template <typename T>
+std::string ValueToString(T value) {
+  if constexpr (std::is_same_v<Int96, T>) {
+    return Int96ToString(value);
+  } else {
+    return std::to_string(value);
+  }
+}
+
 template <typename DType, typename RowGroupReader, typename RowGroupMetadata>
 void ReadAndVerifyColumn(RowGroupReader* rg_reader, RowGroupMetadata* rg_md,
                          int column_index, int rows) {
@@ -322,6 +331,20 @@ void ReadAndVerifyColumn(RowGroupReader* rg_reader, RowGroupMetadata* rg_md,
   }
   ASSERT_EQ(rows_read, rows_should_read);
   ASSERT_EQ(values_read, rows_should_read);
+  EXPECT_EQ(read_col_data.rows(), expected_column_data.rows());
+  for (int i = 0; i < read_col_data.rows(); ++i) {
+    if constexpr (std::is_floating_point_v<typename DType::c_type>) {
+      if (std::isnan(expected_column_data.values[i])) {
+        EXPECT_TRUE(std::isnan(read_col_data.values[i]))
+            << "Values at index " << i << " is not nan";
+        continue;
+      }
+    }
+    EXPECT_EQ(expected_column_data.values[i], read_col_data.values[i])
+        << "values at index " << i << " not equal"
+        << " read is " << ValueToString(read_col_data.values[i]) << ", expect "
+        << ValueToString(expected_column_data.values[i]);
+  }
   ASSERT_EQ(read_col_data.values, expected_column_data.values);
   // make sure we got the same number of values the metadata says
   ASSERT_EQ(col_md->num_values(), rows_read);

--- a/cpp/src/parquet/encryption/test_encryption_util.cc
+++ b/cpp/src/parquet/encryption/test_encryption_util.cc
@@ -322,14 +322,11 @@ void ReadAndVerifyColumn(RowGroupReader* rg_reader, RowGroupMetadata* rg_md,
   }
   ASSERT_EQ(rows_read, rows_should_read);
   ASSERT_EQ(values_read, rows_should_read);
+  // make sure we got the same number of values the metadata says
+  ASSERT_EQ(col_md->num_values(), rows_read);
   if constexpr (std::is_floating_point_v<typename DType::c_type>) {
     ASSERT_EQ(read_col_data.rows(), expected_column_data.rows());
     for (int i = 0; i < read_col_data.rows(); ++i) {
-      if (std::isnan(expected_column_data.values[i])) {
-        EXPECT_TRUE(std::isnan(read_col_data.values[i]))
-            << "Values at index " << i << " is not nan";
-        continue;
-      }
       if constexpr (std::is_same_v<float, typename DType::c_type>) {
         EXPECT_FLOAT_EQ(expected_column_data.values[i], read_col_data.values[i]);
       } else {
@@ -337,8 +334,7 @@ void ReadAndVerifyColumn(RowGroupReader* rg_reader, RowGroupMetadata* rg_md,
       }
     }
   } else {
-    // make sure we got the same number of values the metadata says
-    ASSERT_EQ(col_md->num_values(), rows_read);
+    ASSERT_EQ(expected_column_data.values, read_col_data.values);
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

CI would failed in Decrypt test in Windows MinGW. This is because in some MinGW version, it may generate
truncated stream test data in `GenerateSampleData<FloatType>`, as a fixing, here using `EXPECT_FLOAT_EQ`
to handle that problem

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Change comparing float with `_EQ` to `FLOAT_EQ` and `DOUBLE_EQ` in unittest.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

No

### Are there any user-facing changes?

No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #35571