### PR TITLE
GH-35607: [C++] Support simple Substrait aggregate extensions

### DIFF
--- a/cpp/src/arrow/engine/substrait/extension_set.cc
+++ b/cpp/src/arrow/engine/substrait/extension_set.cc
@@ -339,6 +339,9 @@ const int* GetIndex(const KeyToIndex& key_to_index, const Key& key) {
 
 namespace {
 
+ExtensionIdRegistry::SubstraitAggregateToArrow DecodeBasicAggregate(
+    const std::string& arrow_function_name);
+
 ExtensionIdRegistry::SubstraitCallToArrow kSimpleSubstraitToArrow =
     [](const SubstraitCall& call) -> Result<::arrow::compute::Expression> {
   std::vector<::arrow::compute::Expression> args;
@@ -353,6 +356,11 @@ ExtensionIdRegistry::SubstraitCallToArrow kSimpleSubstraitToArrow =
     args.push_back(std::move(arg));
   }
   return ::arrow::compute::call(std::string(call.id().name), std::move(args));
+};
+
+ExtensionIdRegistry::SubstraitAggregateToArrow kSimpleSubstraitAggregateToArrow =
+    [](const SubstraitCall& call) -> Result<::arrow::compute::Aggregate> {
+  return DecodeBasicAggregate(std::string(call.id().name))(call);
 };
 
 struct ExtensionIdRegistryImpl : ExtensionIdRegistry {
@@ -592,6 +600,9 @@ struct ExtensionIdRegistryImpl : ExtensionIdRegistry {
 
   Result<SubstraitAggregateToArrow> GetSubstraitAggregateToArrow(
       Id substrait_function_id) const override {
+    if (substrait_function_id.uri == kArrowSimpleExtensionFunctionsUri) {
+      return kSimpleSubstraitAggregateToArrow;
+    }
     auto maybe_converter = substrait_to_arrow_agg_.find(substrait_function_id);
     if (maybe_converter == substrait_to_arrow_agg_.end()) {
       if (parent_) {


### PR DESCRIPTION
### Rationale for this change

See #35607.

### What changes are included in this PR?

A simple `SubstraitAggregateToArrow` converter for `urn:arrow:substrait_simple_extension_function` is added.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #35607