### PR TITLE
GH-35617: [Docs] Current n_buffers use in C API example

### DIFF
--- a/docs/source/format/CDataInterface.rst
+++ b/docs/source/format/CDataInterface.rst
@@ -907,7 +907,7 @@ transferring ownership to the consumer:
          // Bookkeeping
          .release = &release_malloced_array
       };
-      child->buffers = malloc(sizeof(void*) * array->n_buffers);
+      child->buffers = malloc(sizeof(void*) * child->n_buffers);
       child->buffers[0] = float32_nulls;
       child->buffers[1] = float32_data;
 
@@ -927,7 +927,7 @@ transferring ownership to the consumer:
          // Bookkeeping
          .release = &release_malloced_array
       };
-      child->buffers = malloc(sizeof(void*) * array->n_buffers);
+      child->buffers = malloc(sizeof(void*) * child->n_buffers);
       child->buffers[0] = utf8_nulls;
       child->buffers[1] = utf8_offsets;
       child->buffers[2] = utf8_data;


### PR DESCRIPTION
### Rationale for this change

As described in #35617 the example in docs suffers from a likely copy-and-paste error as the `n_buffers` value references the _parent_ rather that the two children where this is used. `g++-12` spots this and bemoans that assigning to, respectively, `buffers[1]` and then `buffers[1]` and `buffers[2]` is out of bounds.

### What changes are included in this PR?

The example is corrected.

### Are these changes tested?

Yes, locally.  The warnings under `g++-12` go away.

### Are there any user-facing changes?

Not in behavior but the documentation is improved.

* Closes: #35617