### PR TITLE
MINOR: [CI] Display detailed ccache counters

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,4 +58,4 @@ build_script:
 test: off
 
 after_build:
-  - ccache -s
+  - ccache -sv

--- a/ci/scripts/cpp_build.sh
+++ b/ci/scripts/cpp_build.sh
@@ -42,7 +42,7 @@ fi
 
 if [ "${ARROW_USE_CCACHE}" == "ON" ]; then
     echo -e "===\n=== ccache statistics before build\n==="
-    ccache -sv
+    ccache -sv 2>/dev/null || ccache -s
 fi
 
 if [ "${ARROW_USE_TSAN}" == "ON" ] && [ ! -x "${ASAN_SYMBOLIZER_PATH}" ]; then
@@ -175,7 +175,7 @@ fi
 
 if [ "${ARROW_USE_CCACHE}" == "ON" ]; then
     echo -e "===\n=== ccache statistics after build\n==="
-    ccache -sv
+    ccache -sv 2>/dev/null || ccache -s
 fi
 
 if command -v sccache &> /dev/null; then

--- a/ci/scripts/cpp_build.sh
+++ b/ci/scripts/cpp_build.sh
@@ -42,7 +42,7 @@ fi
 
 if [ "${ARROW_USE_CCACHE}" == "ON" ]; then
     echo -e "===\n=== ccache statistics before build\n==="
-    ccache -s
+    ccache -sv
 fi
 
 if [ "${ARROW_USE_TSAN}" == "ON" ] && [ ! -x "${ASAN_SYMBOLIZER_PATH}" ]; then
@@ -175,7 +175,7 @@ fi
 
 if [ "${ARROW_USE_CCACHE}" == "ON" ]; then
     echo -e "===\n=== ccache statistics after build\n==="
-    ccache -s
+    ccache -sv
 fi
 
 if command -v sccache &> /dev/null; then

--- a/ci/scripts/java_jni_macos_build.sh
+++ b/ci/scripts/java_jni_macos_build.sh
@@ -56,7 +56,7 @@ export ARROW_ORC
 
 if [ "${ARROW_USE_CCACHE}" == "ON" ]; then
   echo "=== ccache statistics before build ==="
-  ccache -sv
+  ccache -sv 2>/dev/null || ccache -s
 fi
 
 export ARROW_TEST_DATA="${arrow_dir}/testing/data"
@@ -117,7 +117,7 @@ ${arrow_dir}/ci/scripts/java_jni_build.sh \
 
 if [ "${ARROW_USE_CCACHE}" == "ON" ]; then
   echo "=== ccache statistics after build ==="
-  ccache -sv
+  ccache -sv 2>/dev/null || ccache -s
 fi
 
 

--- a/ci/scripts/java_jni_macos_build.sh
+++ b/ci/scripts/java_jni_macos_build.sh
@@ -56,7 +56,7 @@ export ARROW_ORC
 
 if [ "${ARROW_USE_CCACHE}" == "ON" ]; then
   echo "=== ccache statistics before build ==="
-  ccache -s
+  ccache -sv
 fi
 
 export ARROW_TEST_DATA="${arrow_dir}/testing/data"
@@ -117,7 +117,7 @@ ${arrow_dir}/ci/scripts/java_jni_build.sh \
 
 if [ "${ARROW_USE_CCACHE}" == "ON" ]; then
   echo "=== ccache statistics after build ==="
-  ccache -s
+  ccache -sv
 fi
 
 

--- a/ci/scripts/java_jni_manylinux_build.sh
+++ b/ci/scripts/java_jni_manylinux_build.sh
@@ -56,7 +56,7 @@ export ARROW_ORC
 
 if [ "${ARROW_USE_CCACHE}" == "ON" ]; then
   echo "=== ccache statistics before build ==="
-  ccache -s
+  ccache -sv
 fi
 
 export ARROW_TEST_DATA="${arrow_dir}/testing/data"
@@ -130,7 +130,7 @@ ${arrow_dir}/ci/scripts/java_jni_build.sh \
 
 if [ "${ARROW_USE_CCACHE}" == "ON" ]; then
   echo "=== ccache statistics after build ==="
-  ccache -s
+  ccache -sv
 fi
 
 

--- a/ci/scripts/java_jni_manylinux_build.sh
+++ b/ci/scripts/java_jni_manylinux_build.sh
@@ -56,7 +56,7 @@ export ARROW_ORC
 
 if [ "${ARROW_USE_CCACHE}" == "ON" ]; then
   echo "=== ccache statistics before build ==="
-  ccache -sv
+  ccache -sv 2>/dev/null || ccache -s
 fi
 
 export ARROW_TEST_DATA="${arrow_dir}/testing/data"
@@ -130,7 +130,7 @@ ${arrow_dir}/ci/scripts/java_jni_build.sh \
 
 if [ "${ARROW_USE_CCACHE}" == "ON" ]; then
   echo "=== ccache statistics after build ==="
-  ccache -sv
+  ccache -sv 2>/dev/null || ccache -s
 fi
 
 

--- a/ci/scripts/java_jni_windows_build.sh
+++ b/ci/scripts/java_jni_windows_build.sh
@@ -45,7 +45,7 @@ export ARROW_ORC
 
 if [ "${ARROW_USE_CCACHE}" == "ON" ]; then
   echo "=== ccache statistics before build ==="
-  ccache -sv
+  ccache -sv 2>/dev/null || ccache -s
 fi
 
 export ARROW_TEST_DATA="${arrow_dir}/testing/data"
@@ -105,7 +105,7 @@ ${arrow_dir}/ci/scripts/java_jni_build.sh \
 
 if [ "${ARROW_USE_CCACHE}" == "ON" ]; then
   echo "=== ccache statistics after build ==="
-  ccache -sv
+  ccache -sv 2>/dev/null || ccache -s
 fi
 
 

--- a/ci/scripts/java_jni_windows_build.sh
+++ b/ci/scripts/java_jni_windows_build.sh
@@ -45,7 +45,7 @@ export ARROW_ORC
 
 if [ "${ARROW_USE_CCACHE}" == "ON" ]; then
   echo "=== ccache statistics before build ==="
-  ccache -s
+  ccache -sv
 fi
 
 export ARROW_TEST_DATA="${arrow_dir}/testing/data"
@@ -105,7 +105,7 @@ ${arrow_dir}/ci/scripts/java_jni_build.sh \
 
 if [ "${ARROW_USE_CCACHE}" == "ON" ]; then
   echo "=== ccache statistics after build ==="
-  ccache -s
+  ccache -sv
 fi
 
 


### PR DESCRIPTION
This will display more detailed counters and reasons for uncacheable files.

Example before:
```
# ccache -s
Cacheable calls:   284 / 894 (31.77%)
  Hits:              5 / 284 ( 1.76%)
    Direct:          5 /   5 (100.0%)
    Preprocessed:    0 /   5 ( 0.00%)
  Misses:          279 / 284 (98.24%)
Uncacheable calls: 610 / 894 (68.23%)
Local storage:
  Cache size (GB): 1.0 / 1.0 (100.3%)
  Cleanups:          6
  Hits:              5 / 284 ( 1.76%)
  Misses:          279 / 284 (98.24%)
```

Same example after:
```
# ccache -sv
Cache directory:                    /ccache
Config file:                        /ccache/ccache.conf
System config file:                 /opt/conda/envs/arrow/etc/ccache.conf
Stats updated:                      Wed May 17 17:06:44 2023
Cacheable calls:                     284 / 894 (31.77%)
  Hits:                                5 / 284 ( 1.76%)
    Direct:                            5 /   5 (100.0%)
    Preprocessed:                      0 /   5 ( 0.00%)
  Misses:                            279 / 284 (98.24%)
Uncacheable calls:                   610 / 894 (68.23%)
  Could not use precompiled header:  610 / 610 (100.0%)
Successful lookups:
  Direct:                              5 / 284 ( 1.76%)
  Preprocessed:                        0 / 279 ( 0.00%)
Local storage:
  Cache size (GB):                   1.0 / 1.0 (100.3%)
  Files:                            3998
  Cleanups:                            6
  Hits:                                5 / 284 ( 1.76%)
  Misses:                            279 / 284 (98.24%)
  Reads:                             568
  Writes:                            558
```