### PR TITLE
MINOR: Ignore direnv file .envrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ swift/Arrow/.build
 
 # Go dependencies
 go/vendor
+
+# direnv
+.envrc


### PR DESCRIPTION
Ignore .envrc files associated with the direnv[1] utility.

### Rationale for this change

There is no conflicting usage of .envrc in the arrow repo. 

### Are these changes tested?

Yes

### Are there any user-facing changes?

No


[1] https://direnv.net/