### PR TITLE
GH-35651: [C++] Don't use self-move with MinGW

### DIFF
--- a/cpp/src/arrow/util/small_vector_test.cc
+++ b/cpp/src/arrow/util/small_vector_test.cc
@@ -413,10 +413,12 @@ class TestSmallStaticVector : public ::testing::Test {
     ASSERT_EQ(moved_moved_ints.size(), 5);
     EXPECT_THAT(moved_moved_ints, ElementsAre(4, 5, 6, 7, 8));
 
+#ifndef __MINGW32__
     // Move into itself
     moved_moved_ints = std::move(moved_moved_ints);
     ASSERT_EQ(moved_moved_ints.size(), 5);
     EXPECT_THAT(moved_moved_ints, ElementsAre(4, 5, 6, 7, 8));
+#endif
   }
 
   void TestMove() {


### PR DESCRIPTION
### Rationale for this change

Because MinGW g++ reports a warning:

```text
D:/a/arrow/arrow/cpp/src/arrow/util/small_vector_test.cc:417:22:
warning: moving 'moved_moved_ints' of type
'arrow::internal::TestSmallStaticVector<
  arrow::internal::VectorIntLikeParam<
    arrow::internal::StaticVectorTraits, arrow::MoveOnlyDataType> >::IntVectorType<5>'
{aka 'arrow::internal::StaticVectorImpl<
        arrow::MoveOnlyDataType, 5, arrow::internal::StaticVectorStorage<arrow::MoveOnlyDataType, 5, true> >'}
to itself [-Wself-move]
  417 |     moved_moved_ints = std::move(moved_moved_ints);
      |     ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
D:/a/arrow/arrow/cpp/src/arrow/util/small_vector_test.cc:417:22: note: remove 'std::move' call
```

### What changes are included in this PR?

Disable self-move code only for MinGW.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #35651