### PR TITLE
MINOR: [C++] Add mising pragma-once

### DIFF
--- a/cpp/src/arrow/compute/kernels/ree_util_internal.h
+++ b/cpp/src/arrow/compute/kernels/ree_util_internal.h
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#pragma once
+
 // Useful operations to implement kernels handling run-end encoded arrays
 
 #include <algorithm>


### PR DESCRIPTION
### Rationale for this change

The C compilation model.

### What changes are included in this PR?

Adding a `#pragma once` that I forgot to add when I created this header.

### Are these changes tested?

N/A.
