### PR TITLE
GH-35662: [CI][C++][MinGW] Avoid crash in FormatTwoDigits() with release build

### DIFF
--- a/cpp/src/arrow/util/formatting.h
+++ b/cpp/src/arrow/util/formatting.h
@@ -129,35 +129,23 @@ ARROW_EXPORT extern const char digit_pairs[];
 // Write digits from right to left into a stack allocated buffer
 inline void FormatOneChar(char c, char** cursor) { *--*cursor = c; }
 
-#ifdef __MINGW32__
-// GH-35662: I don't know why but the template implementations + MinGW
-// + release build cause SEGV.
-inline void FormatOneDigit(int value, char** cursor) {
-  assert(value >= 0 && value <= 9);
-  FormatOneChar(static_cast<char>('0' + value), cursor);
-}
-
-inline void FormatTwoDigits(int value, char** cursor) {
-  assert(value >= 0 && value <= 99);
-  auto digit_pair = &digit_pairs[value * 2];
-  FormatOneChar(digit_pair[1], cursor);
-  FormatOneChar(digit_pair[0], cursor);
-}
-#else
 template <typename Int>
 void FormatOneDigit(Int value, char** cursor) {
   assert(value >= 0 && value <= 9);
   FormatOneChar(static_cast<char>('0' + value), cursor);
 }
 
+// GH-35662: I don't know why but the following combination causes SEGV:
+// * template implementation without inline
+// * MinGW
+// * Release build
 template <typename Int>
-void FormatTwoDigits(Int value, char** cursor) {
+inline void FormatTwoDigits(Int value, char** cursor) {
   assert(value >= 0 && value <= 99);
   auto digit_pair = &digit_pairs[value * 2];
   FormatOneChar(digit_pair[1], cursor);
   FormatOneChar(digit_pair[0], cursor);
 }
-#endif
 
 template <typename Int>
 void FormatAllDigits(Int value, char** cursor) {

--- a/cpp/src/arrow/util/formatting.h
+++ b/cpp/src/arrow/util/formatting.h
@@ -129,6 +129,21 @@ ARROW_EXPORT extern const char digit_pairs[];
 // Write digits from right to left into a stack allocated buffer
 inline void FormatOneChar(char c, char** cursor) { *--*cursor = c; }
 
+#ifdef __MINGW32__
+// GH-35662: I don't know why but the template implementations + MinGW
+// + release build cause SEGV.
+inline void FormatOneDigit(int value, char** cursor) {
+  assert(value >= 0 && value <= 9);
+  FormatOneChar(static_cast<char>('0' + value), cursor);
+}
+
+inline void FormatTwoDigits(int value, char** cursor) {
+  assert(value >= 0 && value <= 99);
+  auto digit_pair = &digit_pairs[value * 2];
+  FormatOneChar(digit_pair[1], cursor);
+  FormatOneChar(digit_pair[0], cursor);
+}
+#else
 template <typename Int>
 void FormatOneDigit(Int value, char** cursor) {
   assert(value >= 0 && value <= 9);
@@ -142,6 +157,7 @@ void FormatTwoDigits(Int value, char** cursor) {
   FormatOneChar(digit_pair[1], cursor);
   FormatOneChar(digit_pair[0], cursor);
 }
+#endif
 
 template <typename Int>
 void FormatAllDigits(Int value, char** cursor) {


### PR DESCRIPTION
### Rationale for this change

I don't know why but the following combination is crashed:

* Template `FormatTwoDigits()` implementation without explicit `inline`
* MinGW
* Release build

### What changes are included in this PR?

This breaks the "template `FormatTwoDigits()` implementation without explicit `inline`" by specifying `inline` explicitly.

But I don't know why we can avoid this crash by specifying `inline` explicitly...

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #35662