### PR TITLE
GH-35633: [R] R builds failing with error 'Invalid: Timestamps already have a timezone: 'UTC'. Cannot localize to 'UTC''

### DIFF
--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -61,12 +61,14 @@ register_bindings_datetime_utility <- function() {
         tz <- Sys.timezone()
       }
 
-      # if a timestamp does not contain timezone information (i.e. it is
+      # If a timestamp does not contain timezone information (i.e. it is
       # "timezone-naive") we can attach timezone information (i.e. convert it into
       # a "timezone-aware" timestamp) with `assume_timezone`
       # if we want to cast to a different timezone, we can only do it for
-      # timezone-aware timestamps, not for timezone-naive ones
-      if (!is.null(tz)) {
+      # timezone-aware timestamps, not for timezone-naive ones.
+      # strptime in Acero will return a timezone-aware timestamp if %z is
+      # part of the format string.
+      if (!is.null(tz) && !grepl("%z", format, fixed = TRUE)) {
         output <- Expression$create(
           "assume_timezone",
           output,


### PR DESCRIPTION
Alternative approach to #35634.
* Closes: #35633