### PR TITLE
GH-35538: [C++] Remove unnecessary status.h include from protobuf

### DIFF
--- a/cpp/src/arrow/engine/substrait/serde.cc
+++ b/cpp/src/arrow/engine/substrait/serde.cc
@@ -24,7 +24,6 @@
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 #include <google/protobuf/message.h>
-#include <google/protobuf/stubs/status.h>
 #include <google/protobuf/util/json_util.h>
 #include <google/protobuf/util/message_differencer.h>
 #include <google/protobuf/util/type_resolver.h>


### PR DESCRIPTION
### Rationale for this change

Newer versions of protobuf use `absl::Status` instead of `google::protobuf::util::Status`. The status variables in this file are type-annotated with `auto` and we can count on the header that declares the status-returning function we are calling to have included the header that defines `Status`.

### What changes are included in this PR?

Removing an include of a protobuf header that don't exist in later versions of the library.

### Are these changes tested?

I haven't tried building with protobuf 23, but I can be sure this specifically fixes the problem reported in #35538.