### PR TITLE
GH-35359: [C++] FixedSizeListArray.flatten() errors if all elements are null

### DIFF
--- a/cpp/src/arrow/array/array_list_test.cc
+++ b/cpp/src/arrow/array/array_list_test.cc
@@ -1284,6 +1284,7 @@ TEST_F(TestFixedSizeListArray, FlattenZeroLength) {
 TEST_F(TestFixedSizeListArray, FlattenNulls) {
   ASSERT_OK(builder_->AppendNulls(2));
   Done();
+  ASSERT_EQ(result_->data()->GetNullCount(), 2);
   ASSERT_OK_AND_ASSIGN(auto flattened, result_->Flatten());
   ASSERT_OK(flattened->ValidateFull());
   ASSERT_EQ(0, flattened->length());

--- a/cpp/src/arrow/array/array_list_test.cc
+++ b/cpp/src/arrow/array/array_list_test.cc
@@ -436,6 +436,15 @@ class TestListArray : public ::testing::Test {
     EXPECT_TRUE(flattened->Equals(ArrayFromJSON(int32(), "[1, 2, 3, 4, 5, 6]")));
   }
 
+  void TestFlattenNulls() {
+    ASSERT_OK(builder_->AppendNulls(2));
+    Done();
+    ASSERT_OK_AND_ASSIGN(auto flattened, result_->Flatten());
+    ASSERT_OK(flattened->ValidateFull());
+    ASSERT_EQ(0, flattened->length());
+    AssertTypeEqual(*flattened->type(), *value_type_);
+  }
+
   void TestFlattenSliced() {
     auto type = std::make_shared<T>(int32());
     auto list_array = std::dynamic_pointer_cast<ArrayType>(
@@ -594,6 +603,7 @@ TYPED_TEST(TestListArray, BuilderPreserveFieldName) {
 }
 
 TYPED_TEST(TestListArray, FlattenSimple) { this->TestFlattenSimple(); }
+TYPED_TEST(TestListArray, FlattenNulls) { this->TestFlattenNulls(); }
 TYPED_TEST(TestListArray, FlattenZeroLength) { this->TestFlattenZeroLength(); }
 TYPED_TEST(TestListArray, TestFlattenNonEmptyBackingNulls) {
   this->TestFlattenNonEmptyBackingNulls();
@@ -1264,6 +1274,15 @@ TEST_F(TestFixedSizeListArray, NotEnoughValues) {
 }
 
 TEST_F(TestFixedSizeListArray, FlattenZeroLength) {
+  Done();
+  ASSERT_OK_AND_ASSIGN(auto flattened, result_->Flatten());
+  ASSERT_OK(flattened->ValidateFull());
+  ASSERT_EQ(0, flattened->length());
+  AssertTypeEqual(*flattened->type(), *value_type_);
+}
+
+TEST_F(TestFixedSizeListArray, FlattenNulls) {
+  ASSERT_OK(builder_->AppendNulls(2));
   Done();
   ASSERT_OK_AND_ASSIGN(auto flattened, result_->Flatten());
   ASSERT_OK(flattened->ValidateFull());

--- a/cpp/src/arrow/array/array_nested.cc
+++ b/cpp/src/arrow/array/array_nested.cc
@@ -177,6 +177,8 @@ Result<std::shared_ptr<Array>> FlattenListArray(const ListArrayT& list_array,
   // Final attempt to avoid invoking Concatenate().
   if (non_null_fragments.size() == 1) {
     return non_null_fragments[0];
+  } else if (non_null_fragments.size() == 0) {
+    return MakeEmptyArray(value_array->type(), memory_pool);
   }
 
   return Concatenate(non_null_fragments, memory_pool);

--- a/cpp/src/arrow/array/array_nested.cc
+++ b/cpp/src/arrow/array/array_nested.cc
@@ -156,6 +156,12 @@ Result<std::shared_ptr<Array>> FlattenListArray(const ListArrayT& list_array,
                                  list_array.value_offset(list_array_length));
   }
 
+  // Second shortcut: if the list array is *all* nulls, then just return
+  // an empty array.
+  if (list_array.null_count() == list_array.length()) {
+    return MakeEmptyArray(value_array->type(), memory_pool);
+  }
+
   // The ListArray contains nulls: there may be a non-empty sub-list behind
   // a null and it must not be contained in the result.
   std::vector<std::shared_ptr<Array>> non_null_fragments;

--- a/cpp/src/arrow/compute/kernels/vector_nested_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_nested_test.cc
@@ -42,6 +42,13 @@ TEST(TestVectorNested, ListFlatten) {
   }
 }
 
+TEST(TestVectorNested, ListFlattenNulls) {
+  const auto ty = list(int32());
+  auto input = ArrayFromJSON(ty, "[null, null]");
+  auto expected = ArrayFromJSON(int32(), "[]");
+  CheckVectorUnary("list_flatten", input, expected);
+}
+
 TEST(TestVectorNested, ListFlattenChunkedArray) {
   for (auto ty : {list(int16()), large_list(int16())}) {
     auto input = ChunkedArrayFromJSON(ty, {"[[0, null, 1], null]", "[[2, 3], []]"});
@@ -74,6 +81,13 @@ TEST(TestVectorNested, ListFlattenFixedSizeList) {
       CheckVectorUnary("list_flatten", input, expected);
     }
   }
+}
+
+TEST(TestVectorNested, ListFlattenFixedSizeListNulls) {
+  const auto ty = fixed_size_list(int32(), 1);
+  auto input = ArrayFromJSON(ty, "[null, null]");
+  auto expected = ArrayFromJSON(int32(), "[]");
+  CheckVectorUnary("list_flatten", input, expected);
 }
 
 TEST(TestVectorNested, ListParentIndices) {


### PR DESCRIPTION

<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
Added a check inside of `FlattenListArray` before the call to `Concatenate` so that it will return an empty array of the appropriate type if there are no non null fragments to return. This avoids receiving the error from concatenate that you must pass at least one array to it.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
Unit tests are added.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

* Closes: #35359