### PR TITLE
GH-32276: [C++][FlightRPC] Align buffers from Flight

### DIFF
--- a/cpp/src/arrow/flight/test_definitions.h
+++ b/cpp/src/arrow/flight/test_definitions.h
@@ -76,6 +76,7 @@ class ARROW_FLIGHT_EXPORT DataTest : public FlightTest {
   void TestDoGetFloats();
   void TestDoGetDicts();
   void TestDoGetLargeBatch();
+  void TestDoGetAlignment();
   void TestFlightDataStreamError();
   void TestOverflowServerBatch();
   void TestOverflowClientBatch();
@@ -108,6 +109,7 @@ class ARROW_FLIGHT_EXPORT DataTest : public FlightTest {
   TEST_F(FIXTURE, TestDoGetFloats) { TestDoGetFloats(); }                             \
   TEST_F(FIXTURE, TestDoGetDicts) { TestDoGetDicts(); }                               \
   TEST_F(FIXTURE, TestDoGetLargeBatch) { TestDoGetLargeBatch(); }                     \
+  TEST_F(FIXTURE, TestDoGetAlignment) { TestDoGetAlignment(); }                       \
   TEST_F(FIXTURE, TestFlightDataStreamError) { TestFlightDataStreamError(); }         \
   TEST_F(FIXTURE, TestOverflowServerBatch) { TestOverflowServerBatch(); }             \
   TEST_F(FIXTURE, TestOverflowClientBatch) { TestOverflowClientBatch(); }             \

--- a/cpp/src/arrow/flight/test_util.h
+++ b/cpp/src/arrow/flight/test_util.h
@@ -180,6 +180,10 @@ Status ExampleNestedBatches(RecordBatchVector* out);
 ARROW_FLIGHT_EXPORT
 Status ExampleLargeBatches(RecordBatchVector* out);
 
+// Batches of data that previously Flight sent unaligned
+ARROW_FLIGHT_EXPORT
+arrow::Result<arrow::RecordBatchVector> ExampleAlignmentBatches();
+
 ARROW_FLIGHT_EXPORT
 arrow::Result<std::shared_ptr<RecordBatch>> VeryLargeBatch();
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Ensure buffers from Flight are at least 8-byte aligned to meet general expectations of downstream users.

### What changes are included in this PR?

Manually align buffers after deserialization.

### Are these changes tested?

Yes

### Are there any user-facing changes?

Flight data will be aligned, at the cost of an additional copy.
* Closes: #32276