### PR TITLE
GH-35606: [CI][C++][MinGW32] Use more accurate float inputs for decimal test

### DIFF
--- a/cpp/src/arrow/util/decimal_test.cc
+++ b/cpp/src/arrow/util/decimal_test.cc
@@ -822,31 +822,19 @@ class TestDecimalFromReal : public ::testing::Test {
         {123.6f, 19, 0, "124"},
         {-123.6f, 19, 0, "-124"},
         // 2**62
-        {4.611686e+18f, 19, 0, "4611686018427387904"},
-        {-4.611686e+18f, 19, 0, "-4611686018427387904"},
+        {4.6116860184273879e+18, 19, 0, "4611686018427387904"},
+        {-4.6116860184273879e+18, 19, 0, "-4611686018427387904"},
         // 2**63
-        {9.223372e+18f, 19, 0, "9223372036854775808"},
-        {-9.223372e+18f, 19, 0, "-9223372036854775808"},
+        {9.2233720368547758e+18, 19, 0, "9223372036854775808"},
+        {-9.2233720368547758e+18, 19, 0, "-9223372036854775808"},
         // 2**64
-        {1.8446744e+19f, 20, 0, "18446744073709551616"},
-        {-1.8446744e+19f, 20, 0, "-18446744073709551616"}
+        {1.8446744073709552e+19, 20, 0, "18446744073709551616"},
+        {-1.8446744073709552e+19, 20, 0, "-18446744073709551616"}
         // clang-format on
     };
     for (const ParamType& param : params) {
-      auto expected = param.expected;
-#if defined(__MINGW32__) && !defined(__MINGW64__)
-      // Large/small double values are truncated with MinGW 32bit
-      if (sizeof(Real) == 8 &&
-          // param.real <= 2**62 || 2**62 <= param.real
-          (param.real <= -4.611686e+18f || 4.611686e+18f <= param.real)) {
-        const char* truncated = "000000000000";
-        // "4611686018427387904" ->
-        // "4611686000000000000"
-        expected.replace(expected.size() - strlen(truncated), strlen(truncated),
-                         truncated);
-      }
-#endif
-      CheckDecimalFromReal<Decimal>(param.real, param.precision, param.scale, expected);
+      CheckDecimalFromReal<Decimal>(param.real, param.precision, param.scale,
+                                    param.expected);
     }
   }
 


### PR DESCRIPTION
### Rationale for this change

If we use `4.611686e+18f` for `2**62` value, MinGW 32bit can't generate enough precious double value.
See the following errors for this:

```text
[----------] 2 tests from TestDecimalFromReal/1, where TypeParam = std::pair<arrow::Decimal128, double>
[ RUN      ] TestDecimalFromReal/1.TestSuccess
D:/a/arrow/arrow/cpp/src/arrow/util/decimal_test.cc:766: Failure
Expected equality of these values:
  dec.ToString(scale)
    Which is: "4611686000000000000"
  expected
    Which is: "4611686018427387904"
D:/a/arrow/arrow/cpp/src/arrow/util/decimal_test.cc:766: Failure
Expected equality of these values:
  dec.ToString(scale)
    Which is: "-4611686000000000000"
  expected
    Which is: "-4611686018427387904"
D:/a/arrow/arrow/cpp/src/arrow/util/decimal_test.cc:766: Failure
Expected equality of these values:
  dec.ToString(scale)
    Which is: "9223372000000000000"
  expected
    Which is: "9223372036854775808"
D:/a/arrow/arrow/cpp/src/arrow/util/decimal_test.cc:766: Failure
Expected equality of these values:
  dec.ToString(scale)
    Which is: "-9223372000000000000"
  expected
    Which is: "-9223372036854775808"
D:/a/arrow/arrow/cpp/src/arrow/util/decimal_test.cc:766: Failure
Expected equality of these values:
  dec.ToString(scale)
    Which is: "18446744000000000000"
  expected
    Which is: "18446744073709551616"
D:/a/arrow/arrow/cpp/src/arrow/util/decimal_test.cc:766: Failure
Expected equality of these values:
  dec.ToString(scale)
    Which is: "-18446744000000000000"
  expected
    Which is: "-18446744073709551616"
[  FAILED  ] TestDecimalFromReal/1.TestSuccess, where TypeParam = std::pair<arrow::Decimal128, double> (0 ms)
[ RUN      ] TestDecimalFromReal/1.TestErrors
[       OK ] TestDecimalFromReal/1.TestErrors (0 ms)
[----------] 2 tests from TestDecimalFromReal/1 (0 ms total)

[----------] 2 tests from TestDecimalFromReal/2, where TypeParam = std::pair<arrow::Decimal256, float>
[ RUN      ] TestDecimalFromReal/2.TestSuccess
[       OK ] TestDecimalFromReal/2.TestSuccess (0 ms)
[ RUN      ] TestDecimalFromReal/2.TestErrors
[       OK ] TestDecimalFromReal/2.TestErrors (0 ms)
[----------] 2 tests from TestDecimalFromReal/2 (0 ms total)

[----------] 2 tests from TestDecimalFromReal/3, where TypeParam = std::pair<arrow::Decimal256, double>
[ RUN      ] TestDecimalFromReal/3.TestSuccess
D:/a/arrow/arrow/cpp/src/arrow/util/decimal_test.cc:766: Failure
Expected equality of these values:
  dec.ToString(scale)
    Which is: "4611686000000000000"
  expected
    Which is: "4611686018427387904"
D:/a/arrow/arrow/cpp/src/arrow/util/decimal_test.cc:766: Failure
Expected equality of these values:
  dec.ToString(scale)
    Which is: "-4611686000000000000"
  expected
    Which is: "-4611686018427387904"
D:/a/arrow/arrow/cpp/src/arrow/util/decimal_test.cc:766: Failure
Expected equality of these values:
  dec.ToString(scale)
    Which is: "9223372000000000000"
  expected
    Which is: "9223372036854775808"
D:/a/arrow/arrow/cpp/src/arrow/util/decimal_test.cc:766: Failure
Expected equality of these values:
  dec.ToString(scale)
    Which is: "-9223372000000000000"
  expected
    Which is: "-9223372036854775808"
D:/a/arrow/arrow/cpp/src/arrow/util/decimal_test.cc:766: Failure
Expected equality of these values:
  dec.ToString(scale)
    Which is: "18446744000000000000"
  expected
    Which is: "18446744073709551616"
D:/a/arrow/arrow/cpp/src/arrow/util/decimal_test.cc:766: Failure
Expected equality of these values:
  dec.ToString(scale)
    Which is: "-18446744000000000000"
  expected
    Which is: "-18446744073709551616"
[  FAILED  ] TestDecimalFromReal/3.TestSuccess, where TypeParam = std::pair<arrow::Decimal256, double> (0 ms)
[ RUN      ] TestDecimalFromReal/3.TestErrors
```

### What changes are included in this PR?

This changes use `4.6116860184273879e+18` for `2**62` value. It works with MinGW 32bit too.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #35606