### PR TITLE
GH-35681: [Ruby] Add support for #select_columns with empty table

### DIFF
--- a/ruby/red-arrow/lib/arrow/chunked-array.rb
+++ b/ruby/red-arrow/lib/arrow/chunked-array.rb
@@ -29,7 +29,11 @@ module Arrow
     end
 
     def to_arrow_array
-      combine
+      if n_chunks.zero?
+        value_data_type.build_array([])
+      else
+        combine
+      end
     end
 
     def to_arrow_chunked_array

--- a/ruby/red-arrow/test/test-table.rb
+++ b/ruby/red-arrow/test/test-table.rb
@@ -589,6 +589,13 @@ class TableTest < Test::Unit::TestCase
 0	1
       TABLE
     end
+
+    test("empty result") do
+      selected_table = @table.filter([false] * @table.size).select_columns(:a)
+      assert_equal(<<-TABLE, selected_table.to_s)
+	a
+      TABLE
+    end
   end
 
   sub_test_case("#column_names") do


### PR DESCRIPTION
### Rationale for this change

We can't use `garrow_chunked_array_combine()` with an empty `GArrowChunkedArray`.

### What changes are included in this PR?

Create an empty array instead of combining with an empty `GArrowChunkedArray`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #35681