### PR TITLE
GH-35684: [Go][Parquet] Fix nil dereference with nil list array

### DIFF
--- a/go/parquet/pqarrow/encode_arrow.go
+++ b/go/parquet/pqarrow/encode_arrow.go
@@ -246,10 +246,6 @@ type binary64arr interface {
 }
 
 func writeDenseArrow(ctx *arrowWriteContext, cw file.ColumnChunkWriter, leafArr arrow.Array, defLevels, repLevels []int16, maybeParentNulls bool) (err error) {
-	if leafArr.Len() == 0 {
-		return
-	}
-
 	if leafArr.DataType().ID() == arrow.EXTENSION {
 		extensionArray := leafArr.(array.ExtensionArray)
 		// Replace leafArr with its underlying storage array
@@ -291,12 +287,16 @@ func writeDenseArrow(ctx *arrowWriteContext, cw file.ColumnChunkWriter, leafArr 
 		case arrow.INT32:
 			data = leafArr.(*array.Int32).Int32Values()
 		case arrow.DATE32, arrow.UINT32:
-			data = arrow.Int32Traits.CastFromBytes(leafArr.Data().Buffers()[1].Bytes())
-			data = data[leafArr.Data().Offset() : leafArr.Data().Offset()+leafArr.Len()]
-		case arrow.TIME32:
-			if leafArr.DataType().(*arrow.Time32Type).Unit != arrow.Second {
+			if leafArr.Data().Buffers()[1] != nil {
 				data = arrow.Int32Traits.CastFromBytes(leafArr.Data().Buffers()[1].Bytes())
 				data = data[leafArr.Data().Offset() : leafArr.Data().Offset()+leafArr.Len()]
+			}
+		case arrow.TIME32:
+			if leafArr.DataType().(*arrow.Time32Type).Unit != arrow.Second {
+				if leafArr.Data().Buffers()[1] != nil {
+					data = arrow.Int32Traits.CastFromBytes(leafArr.Data().Buffers()[1].Bytes())
+					data = data[leafArr.Data().Offset() : leafArr.Data().Offset()+leafArr.Len()]
+				}
 			} else { // coerce time32 if necessary by multiplying by 1000
 				ctx.dataBuffer.ResizeNoShrink(arrow.Int32Traits.BytesRequired(leafArr.Len()))
 				data = arrow.Int32Traits.CastFromBytes(ctx.dataBuffer.Bytes())
@@ -355,8 +355,10 @@ func writeDenseArrow(ctx *arrowWriteContext, cw file.ColumnChunkWriter, leafArr 
 				// user explicitly requested coercion to specific unit
 				if tstype.Unit == ctx.props.coerceTimestampUnit {
 					// no conversion necessary
-					data = arrow.Int64Traits.CastFromBytes(leafArr.Data().Buffers()[1].Bytes())
-					data = data[leafArr.Data().Offset() : leafArr.Data().Offset()+leafArr.Len()]
+					if leafArr.Data().Buffers()[1] != nil {
+						data = arrow.Int64Traits.CastFromBytes(leafArr.Data().Buffers()[1].Bytes())
+						data = data[leafArr.Data().Offset() : leafArr.Data().Offset()+leafArr.Len()]
+					}
 				} else {
 					ctx.dataBuffer.ResizeNoShrink(arrow.Int64Traits.BytesRequired(leafArr.Len()))
 					data = arrow.Int64Traits.CastFromBytes(ctx.dataBuffer.Bytes())
@@ -384,8 +386,10 @@ func writeDenseArrow(ctx *arrowWriteContext, cw file.ColumnChunkWriter, leafArr 
 				}
 			} else {
 				// no data conversion neccessary
-				data = arrow.Int64Traits.CastFromBytes(leafArr.Data().Buffers()[1].Bytes())
-				data = data[leafArr.Data().Offset() : leafArr.Data().Offset()+leafArr.Len()]
+				if leafArr.Data().Buffers()[1] != nil {
+					data = arrow.Int64Traits.CastFromBytes(leafArr.Data().Buffers()[1].Bytes())
+					data = data[leafArr.Data().Offset() : leafArr.Data().Offset()+leafArr.Len()]
+				}
 			}
 		case arrow.UINT32:
 			ctx.dataBuffer.ResizeNoShrink(arrow.Int64Traits.BytesRequired(leafArr.Len()))
@@ -396,8 +400,10 @@ func writeDenseArrow(ctx *arrowWriteContext, cw file.ColumnChunkWriter, leafArr 
 		case arrow.INT64:
 			data = leafArr.(*array.Int64).Int64Values()
 		case arrow.UINT64, arrow.TIME64, arrow.DATE64:
-			data = arrow.Int64Traits.CastFromBytes(leafArr.Data().Buffers()[1].Bytes())
-			data = data[leafArr.Data().Offset() : leafArr.Data().Offset()+leafArr.Len()]
+			if leafArr.Data().Buffers()[1] != nil {
+				data = arrow.Int64Traits.CastFromBytes(leafArr.Data().Buffers()[1].Bytes())
+				data = data[leafArr.Data().Offset() : leafArr.Data().Offset()+leafArr.Len()]
+			}
 		default:
 			return fmt.Errorf("unimplemented arrow type to write to int64 column: %s", leafArr.DataType().Name())
 		}

--- a/go/parquet/pqarrow/encode_arrow.go
+++ b/go/parquet/pqarrow/encode_arrow.go
@@ -246,6 +246,10 @@ type binary64arr interface {
 }
 
 func writeDenseArrow(ctx *arrowWriteContext, cw file.ColumnChunkWriter, leafArr arrow.Array, defLevels, repLevels []int16, maybeParentNulls bool) (err error) {
+	if leafArr.Len() == 0 {
+		return
+	}
+
 	if leafArr.DataType().ID() == arrow.EXTENSION {
 		extensionArray := leafArr.(array.ExtensionArray)
 		// Replace leafArr with its underlying storage array

--- a/go/parquet/pqarrow/encode_arrow_test.go
+++ b/go/parquet/pqarrow/encode_arrow_test.go
@@ -359,7 +359,7 @@ func simpleRoundTrip(t *testing.T, tbl arrow.Table, rowGroupSize int64) {
 	}
 }
 
-func TestArrowBug(t *testing.T) {
+func TestWriteEmptyLists(t *testing.T) {
 	sc := arrow.NewSchema([]arrow.Field{
 		{Name: "f1", Type: arrow.ListOf(arrow.FixedWidthTypes.Date32)},
 		{Name: "f2", Type: arrow.ListOf(arrow.FixedWidthTypes.Date64)},

--- a/go/parquet/pqarrow/encode_arrow_test.go
+++ b/go/parquet/pqarrow/encode_arrow_test.go
@@ -359,6 +359,38 @@ func simpleRoundTrip(t *testing.T, tbl arrow.Table, rowGroupSize int64) {
 	}
 }
 
+func TestArrowBug(t *testing.T) {
+	sc := arrow.NewSchema([]arrow.Field{
+		{Name: "f1", Type: arrow.ListOf(arrow.FixedWidthTypes.Date32)},
+		{Name: "f2", Type: arrow.ListOf(arrow.FixedWidthTypes.Date64)},
+		{Name: "f3", Type: arrow.ListOf(arrow.FixedWidthTypes.Timestamp_us)},
+		{Name: "f4", Type: arrow.ListOf(arrow.FixedWidthTypes.Timestamp_ms)},
+		{Name: "f5", Type: arrow.ListOf(arrow.FixedWidthTypes.Time32ms)},
+		{Name: "f6", Type: arrow.ListOf(arrow.FixedWidthTypes.Time64ns)},
+		{Name: "f7", Type: arrow.ListOf(arrow.FixedWidthTypes.Time64us)},
+	}, nil)
+	bldr := array.NewRecordBuilder(memory.DefaultAllocator, sc)
+	defer bldr.Release()
+	for _, b := range bldr.Fields() {
+		b.AppendNull()
+	}
+
+	rec := bldr.NewRecord()
+	defer rec.Release()
+
+	props := parquet.NewWriterProperties(
+		parquet.WithVersion(parquet.V1_0),
+	)
+	arrprops := pqarrow.DefaultWriterProps()
+	var buf bytes.Buffer
+	fw, err := pqarrow.NewFileWriter(sc, &buf, props, arrprops)
+	require.NoError(t, err)
+	err = fw.Write(rec)
+	require.NoError(t, err)
+	err = fw.Close()
+	require.NoError(t, err)
+}
+
 func TestArrowReadWriteTableChunkedCols(t *testing.T) {
 	chunkSizes := []int{2, 4, 10, 2}
 	const totalLen = int64(18)


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
If a column to be written to parquet is a list array with only nulls in it, then the child will be empty and potentially have nil buffers. This case isn't checked in the `writeDenseArrow` function, so we blindly attempt to grab the bytes from the buffers which might be nil. 
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
Adding a check of `leafArr.Len()` at the top of `writeDenseArrow`. If the leaf array's length is > 0 we can be sure that the data buffer is non-nil. So we can just bail if the leaf array is empty, nothing to write.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
Unit test is added.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

* Closes: #35684