### PR TITLE
GH-34785: [C++][Parquet] Skeleton for Parquet bloom filter writer

### DIFF
--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -156,6 +156,7 @@ set(PARQUET_SRCS
     arrow/writer.cc
     bloom_filter.cc
     bloom_filter_reader.cc
+    bloom_filter_writer.cc
     column_reader.cc
     column_scanner.cc
     column_writer.cc

--- a/cpp/src/parquet/bloom_filter.h
+++ b/cpp/src/parquet/bloom_filter.h
@@ -101,6 +101,12 @@ class PARQUET_EXPORT BloomFilter {
   /// @return hash result.
   virtual uint64_t Hash(const FLBA* value, uint32_t len) const = 0;
 
+  // Variant of const pointer argument to facilitate template
+  uint64_t Hash(const int32_t* value) const { return Hash(*value); }
+  uint64_t Hash(const int64_t* value) const { return Hash(*value); }
+  uint64_t Hash(const float* value) const { return Hash(*value); }
+  uint64_t Hash(const double* value) const { return Hash(*value); }
+
   virtual ~BloomFilter() {}
 
  protected:

--- a/cpp/src/parquet/bloom_filter_writer.cc
+++ b/cpp/src/parquet/bloom_filter_writer.cc
@@ -27,13 +27,6 @@ bool RowGroupBloomFilterReference::GetBloomFilterOffsets(
   return false;
 }
 
-void BloomFilterWriter::DropRowGroupBloomFilter(
-    const std::shared_ptr<schema::ColumnPath>& col_path) {
-  if (properties_.bloom_filter_enabled(col_path)) {
-    row_group_bloom_filters_.back().erase(col_path->ToDotString());
-  }
-}
-
 void BloomFilterWriter::AppendRowGroup() { row_group_bloom_filters_.emplace_back(); }
 
 void BloomFilterWriter::WriteTo(::arrow::io::OutputStream* sink,
@@ -44,7 +37,6 @@ void BloomFilterWriter::WriteTo(::arrow::io::OutputStream* sink,
     return;
   }
 
-  size_t total_serialized_count = 0;
   for (const auto& row_group_bloom_filters : row_group_bloom_filters_) {
     reference_.AppendRowGroup();
 
@@ -70,7 +62,6 @@ void BloomFilterWriter::WriteTo(::arrow::io::OutputStream* sink,
         iter->second->WriteTo(sink);
         PARQUET_ASSIGN_OR_THROW(int64_t pos, sink->Tell());
         reference_.AddBloomFilter(column_id, offset, static_cast<int32_t>(pos - offset));
-        total_serialized_count++;
       }
     }
   }

--- a/cpp/src/parquet/bloom_filter_writer.cc
+++ b/cpp/src/parquet/bloom_filter_writer.cc
@@ -1,0 +1,98 @@
+#include "bloom_filter_writer.h"
+
+#include "arrow/io/interfaces.h"
+
+#include "parquet/encryption/encryption.h"
+#include "parquet/encryption/internal_file_encryptor.h"
+#include "parquet/exception.h"
+#include "parquet/properties.h"
+
+namespace parquet {
+
+void RowGroupBloomFilterReference::AppendRowGroup() { references_.emplace_back(); }
+
+void RowGroupBloomFilterReference::AddBloomFilter(int32_t column_id, int64_t offset,
+                                                  int32_t length) {
+  DCHECK(!references_.empty());
+  references_.back().emplace(column_id, Reference{offset, length});
+}
+
+bool RowGroupBloomFilterReference::GetBloomFilterOffsets(
+    size_t row_group_ordinal, const std::map<int32_t, Reference>** out) const {
+  if (row_group_ordinal < references_.size()) {
+    *out = &references_.at(row_group_ordinal);
+    return true;
+  }
+  *out = nullptr;
+  return false;
+}
+
+void BloomFilterWriter::DropRowGroupBloomFilter(
+    const std::shared_ptr<schema::ColumnPath>& col_path) {
+  if (properties_.bloom_filter_enabled(col_path)) {
+    row_group_bloom_filters_.back().erase(col_path->ToDotString());
+  }
+}
+
+void BloomFilterWriter::AppendRowGroup() { row_group_bloom_filters_.emplace_back(); }
+
+void BloomFilterWriter::WriteTo(::arrow::io::OutputStream* sink,
+                                const SchemaDescriptor* schema,
+                                InternalFileEncryptor* encryptor) {
+  if (row_group_bloom_filters_.empty()) {
+    // Return quickly if there is no bloom filter
+    return;
+  }
+
+  size_t total_serialized_count = 0;
+  for (const auto& row_group_bloom_filters : row_group_bloom_filters_) {
+    reference_.AppendRowGroup();
+
+    // the whole row group has no bloom filter
+    if (row_group_bloom_filters.empty()) {
+      continue;
+    }
+
+    // serialize bloom filter by ascending order of column id
+    for (int32_t column_id = 0; column_id < schema->num_columns(); ++column_id) {
+      const auto column_path = schema->Column(column_id)->path()->ToDotString();
+      auto meta_encryptor =
+          encryptor ? encryptor->GetColumnMetaEncryptor(column_path) : nullptr;
+      auto data_encryptor =
+          encryptor ? encryptor->GetColumnDataEncryptor(column_path) : nullptr;
+      if (meta_encryptor || data_encryptor) {
+        ParquetException::NYI("Bloom filter encryption is not implemented");
+      }
+
+      auto iter = row_group_bloom_filters.find(column_path);
+      if (iter != row_group_bloom_filters.cend()) {
+        PARQUET_ASSIGN_OR_THROW(int64_t offset, sink->Tell());
+        iter->second->WriteTo(sink);
+        PARQUET_ASSIGN_OR_THROW(int64_t pos, sink->Tell());
+        reference_.AddBloomFilter(column_id, offset, static_cast<int32_t>(pos - offset));
+        total_serialized_count++;
+      }
+    }
+  }
+
+  // release memory actively
+  row_group_bloom_filters_.clear();
+}
+
+const RowGroupBloomFilterReference& BloomFilterWriter::reference() const {
+  return reference_;
+}
+
+BloomFilter* BloomFilterWriter::GetOrCreateBloomFilter(
+    const std::shared_ptr<schema::ColumnPath>& col_path,
+    const std::function<std::unique_ptr<BloomFilter>()>& bf_creator) {
+  if (properties_.bloom_filter_enabled(col_path)) {
+    DCHECK(!row_group_bloom_filters_.empty());
+    auto it =
+        row_group_bloom_filters_.back().emplace(col_path->ToDotString(), bf_creator());
+    return it.first->second.get();
+  }
+  return nullptr;
+}
+
+}  // namespace parquet

--- a/cpp/src/parquet/bloom_filter_writer.h
+++ b/cpp/src/parquet/bloom_filter_writer.h
@@ -43,9 +43,6 @@ class PARQUET_EXPORT BloomFilterWriter {
   /// Append a new row group to host all incoming bloom filters.
   void AppendRowGroup();
 
-  /// Drop the bloom filter if possible.
-  void DropRowGroupBloomFilter(const std::shared_ptr<schema::ColumnPath>& col_path);
-
   /// Return a BloomFilter defined by `col_path`.
   ///
   /// * If the col_path has a bloom filter, create a BloomFilter in

--- a/cpp/src/parquet/bloom_filter_writer.h
+++ b/cpp/src/parquet/bloom_filter_writer.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "bloom_filter.h"
+
+#include <map>
+#include <vector>
+
+namespace parquet {
+
+class PARQUET_EXPORT RowGroupBloomFilterReference {
+ public:
+  struct Reference {
+    int64_t offset;
+    int32_t length;
+  };
+
+  /// Append a new row group to host all incoming bloom filters.
+  void AppendRowGroup();
+
+  /// Add reference to the serialized bloom filter.
+  void AddBloomFilter(int32_t column_id, int64_t offset, int32_t length);
+
+  /// Get bloom filter offsets of a specific row group.
+  bool GetBloomFilterOffsets(size_t row_group_ordinal,
+                             const std::map<int32_t, Reference>** out) const;
+
+  bool empty() const { return references_.empty(); }
+
+ private:
+  std::vector<std::map<int32_t, Reference>> references_;
+};
+
+class InternalFileEncryptor;
+
+namespace schema {
+class ColumnPath;
+}
+
+class PARQUET_EXPORT BloomFilterWriter {
+ public:
+  explicit BloomFilterWriter(const WriterProperties& properties)
+      : properties_(properties) {}
+  /// Append a new row group to host all incoming bloom filters.
+  void AppendRowGroup();
+
+  /// Drop the bloom filter if possible.
+  void DropRowGroupBloomFilter(const std::shared_ptr<schema::ColumnPath>& col_path);
+
+  /// Return a BloomFilter defined by `col_path`.
+  ///
+  /// * If the col_path has a bloom filter, create a BloomFilter in
+  ///  `row_group_bloom_filters_` and return.
+  /// * Otherwise, return nullptr.
+  BloomFilter* GetOrCreateBloomFilter(
+      const std::shared_ptr<schema::ColumnPath>& col_path,
+      const std::function<std::unique_ptr<BloomFilter>()>& bf_creator);
+
+  /// Serialize all bloom filters with header and bitset in the order of row group and
+  /// column id. Column encryption is not implemented yet. The side effect is that it
+  /// deletes all bloom filters after they have been flushed.
+  void WriteTo(::arrow::io::OutputStream* sink, const SchemaDescriptor* schema,
+               InternalFileEncryptor* encryptor = nullptr);
+
+  /// Return reference to serialized bloom filters. It is undefined behavior until
+  /// WriteTo() has been called.
+  const RowGroupBloomFilterReference& reference() const;
+
+ private:
+  const WriterProperties& properties_;
+
+  std::vector<std::map<std::string, std::unique_ptr<BloomFilter>>>
+      row_group_bloom_filters_;
+
+  RowGroupBloomFilterReference reference_;
+};
+
+}  // namespace parquet

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -43,6 +43,9 @@
 #include "arrow/util/rle_encoding.h"
 #include "arrow/util/type_traits.h"
 #include "arrow/visit_array_inline.h"
+#include "arrow/visit_data_inline.h"
+#include "parquet/bloom_filter.h"
+#include "parquet/bloom_filter_writer.h"
 #include "parquet/column_page.h"
 #include "parquet/encoding.h"
 #include "parquet/encryption/encryption_internal.h"
@@ -715,7 +718,8 @@ class ColumnWriterImpl {
  public:
   ColumnWriterImpl(ColumnChunkMetaDataBuilder* metadata,
                    std::unique_ptr<PageWriter> pager, const bool use_dictionary,
-                   Encoding::type encoding, const WriterProperties* properties)
+                   Encoding::type encoding, const WriterProperties* properties,
+                   BloomFilter* bloom_filter)
       : metadata_(metadata),
         descr_(metadata->descr()),
         level_info_(ComputeLevelInfo(metadata->descr())),
@@ -734,7 +738,8 @@ class ColumnWriterImpl {
         closed_(false),
         fallback_(false),
         definition_levels_sink_(allocator_),
-        repetition_levels_sink_(allocator_) {
+        repetition_levels_sink_(allocator_),
+        bloom_filter_(bloom_filter) {
     definition_levels_rle_ =
         std::static_pointer_cast<ResizableBuffer>(AllocateBuffer(allocator_, 0));
     repetition_levels_rle_ =
@@ -856,6 +861,8 @@ class ColumnWriterImpl {
 
   ::arrow::BufferBuilder definition_levels_sink_;
   ::arrow::BufferBuilder repetition_levels_sink_;
+
+  BloomFilter* bloom_filter_;
 
   std::shared_ptr<ResizableBuffer> definition_levels_rle_;
   std::shared_ptr<ResizableBuffer> repetition_levels_rle_;
@@ -1183,9 +1190,10 @@ class TypedColumnWriterImpl : public ColumnWriterImpl, public TypedColumnWriter<
 
   TypedColumnWriterImpl(ColumnChunkMetaDataBuilder* metadata,
                         std::unique_ptr<PageWriter> pager, const bool use_dictionary,
-                        Encoding::type encoding, const WriterProperties* properties)
-      : ColumnWriterImpl(metadata, std::move(pager), use_dictionary, encoding,
-                         properties) {
+                        Encoding::type encoding, const WriterProperties* properties,
+                        BloomFilter* bloom_filter)
+      : ColumnWriterImpl(metadata, std::move(pager), use_dictionary, encoding, properties,
+                         bloom_filter) {
     current_encoder_ = MakeEncoder(DType::type_num, encoding, use_dictionary, descr_,
                                    properties->memory_pool());
     // We have to dynamic_cast as some compilers don't want to static_cast
@@ -1567,6 +1575,7 @@ class TypedColumnWriterImpl : public ColumnWriterImpl, public TypedColumnWriter<
     if (page_statistics_ != nullptr) {
       page_statistics_->Update(values, num_values, num_nulls);
     }
+    UpdateBloomFilter(values, num_values);
   }
 
   /// \brief Write values with spaces and update page statistics accordingly.
@@ -1588,14 +1597,21 @@ class TypedColumnWriterImpl : public ColumnWriterImpl, public TypedColumnWriter<
     if (num_values != num_spaced_values) {
       current_value_encoder_->PutSpaced(values, static_cast<int>(num_spaced_values),
                                         valid_bits, valid_bits_offset);
+      UpdateBloomFilterSpaced(values, num_spaced_values, valid_bits, valid_bits_offset);
     } else {
       current_value_encoder_->Put(values, static_cast<int>(num_values));
+      UpdateBloomFilter(values, num_values);
     }
     if (page_statistics_ != nullptr) {
       page_statistics_->UpdateSpaced(values, valid_bits, valid_bits_offset,
                                      num_spaced_values, num_values, num_nulls);
     }
   }
+
+  void UpdateBloomFilter(const T* values, int64_t num_values);
+  void UpdateBloomFilterSpaced(const T* values, int64_t num_values,
+                               const uint8_t* valid_bits, int64_t valid_bits_offset);
+  void UpdateBloomFilter(const ::arrow::Array& values);
 };
 
 template <typename DType>
@@ -2143,6 +2159,9 @@ Status TypedColumnWriterImpl<DoubleType>::WriteArrowDense(
 
 // ----------------------------------------------------------------------
 // Write Arrow to BYTE_ARRAY
+template <>
+void TypedColumnWriterImpl<ByteArrayType>::UpdateBloomFilter(
+    const ::arrow::Array& values);
 
 template <>
 Status TypedColumnWriterImpl<ByteArrayType>::WriteArrowDense(
@@ -2175,6 +2194,7 @@ Status TypedColumnWriterImpl<ByteArrayType>::WriteArrowDense(
       page_statistics_->IncrementNullCount(batch_size - non_null);
       page_statistics_->IncrementNumValues(non_null);
     }
+    UpdateBloomFilter(*data_slice);
     CommitWriteAndCheckPageLimit(batch_size, batch_num_values, batch_size - non_null,
                                  check_page);
     CheckDictionarySizeLimit();
@@ -2299,12 +2319,112 @@ Status TypedColumnWriterImpl<FLBAType>::WriteArrowDense(
   return Status::OK();
 }
 
+template <typename DType>
+void TypedColumnWriterImpl<DType>::UpdateBloomFilter(const T* values,
+                                                     int64_t num_values) {
+  if (bloom_filter_) {
+    for (int64_t i = 0; i < num_values; ++i) {
+      bloom_filter_->InsertHash(bloom_filter_->Hash(values + i));
+    }
+  }
+}
+
+template <typename DType>
+void TypedColumnWriterImpl<DType>::UpdateBloomFilterSpaced(const T* values,
+                                                           int64_t num_values,
+                                                           const uint8_t* valid_bits,
+                                                           int64_t valid_bits_offset) {
+  if (bloom_filter_) {
+    ::arrow::internal::VisitSetBitRunsVoid(
+        valid_bits, valid_bits_offset, num_values, [&](int64_t position, int64_t length) {
+          for (int64_t i = 0; i < length; i++) {
+            bloom_filter_->InsertHash(bloom_filter_->Hash(values + i + position));
+          }
+        });
+  }
+}
+
+template <>
+void TypedColumnWriterImpl<FLBAType>::UpdateBloomFilter(const FLBA* values,
+                                                        int64_t num_values) {
+  if (bloom_filter_) {
+    for (int64_t i = 0; i < num_values; ++i) {
+      bloom_filter_->InsertHash(bloom_filter_->Hash(values + i, descr_->type_length()));
+    }
+  }
+}
+
+template <>
+void TypedColumnWriterImpl<FLBAType>::UpdateBloomFilterSpaced(const FLBA* values,
+                                                              int64_t num_values,
+                                                              const uint8_t* valid_bits,
+                                                              int64_t valid_bits_offset) {
+  if (bloom_filter_) {
+    ::arrow::internal::VisitSetBitRunsVoid(
+        valid_bits, valid_bits_offset, num_values, [&](int64_t position, int64_t length) {
+          for (int64_t i = 0; i < length; i++) {
+            bloom_filter_->InsertHash(
+                bloom_filter_->Hash(values + i + position, descr_->type_length()));
+          }
+        });
+  }
+}
+
+template <>
+void TypedColumnWriterImpl<BooleanType>::UpdateBloomFilter(const bool*, int64_t) {
+  DCHECK(bloom_filter_ == nullptr);
+}
+
+template <>
+void TypedColumnWriterImpl<BooleanType>::UpdateBloomFilterSpaced(const bool*, int64_t,
+                                                                 const uint8_t*,
+                                                                 int64_t) {
+  DCHECK(bloom_filter_ == nullptr);
+}
+
+template <typename DType>
+void TypedColumnWriterImpl<DType>::UpdateBloomFilter(const ::arrow::Array& values) {
+  ParquetException::NYI("UpdateBloomFilter via arrow::Array only supports BYTE_ARRAY");
+}
+
+template <typename ArrayType>
+void UpdateBinaryBloomFilter(BloomFilter* bloom_filter, const ArrayType& array) {
+  PARQUET_THROW_NOT_OK(::arrow::VisitArraySpanInline<typename ArrayType::TypeClass>(
+      *array.data(),
+      [&](const std::string_view& view) {
+        const ByteArray value{view};
+        bloom_filter->InsertHash(bloom_filter->Hash(&value));
+        return Status::OK();
+      },
+      []() { return Status::OK(); }));
+}
+
+template <>
+void TypedColumnWriterImpl<ByteArrayType>::UpdateBloomFilter(
+    const ::arrow::Array& values) {
+  if (bloom_filter_) {
+    if (!::arrow::is_base_binary_like(values.type_id())) {
+      throw ParquetException("Only BaseBinaryArray and subclasses supported");
+    }
+
+    if (::arrow::is_binary_like(values.type_id())) {
+      UpdateBinaryBloomFilter(bloom_filter_,
+                              checked_cast<const ::arrow::BinaryArray&>(values));
+    } else {
+      DCHECK(::arrow::is_large_binary_like(values.type_id()));
+      UpdateBinaryBloomFilter(bloom_filter_,
+                              checked_cast<const ::arrow::LargeBinaryArray&>(values));
+    }
+  }
+}
+
 // ----------------------------------------------------------------------
 // Dynamic column writer constructor
 
 std::shared_ptr<ColumnWriter> ColumnWriter::Make(ColumnChunkMetaDataBuilder* metadata,
                                                  std::unique_ptr<PageWriter> pager,
-                                                 const WriterProperties* properties) {
+                                                 const WriterProperties* properties,
+                                                 BloomFilter* bloom_filter) {
   const ColumnDescriptor* descr = metadata->descr();
   const bool use_dictionary = properties->dictionary_enabled(descr->path()) &&
                               descr->physical_type() != Type::BOOLEAN;
@@ -2315,28 +2435,28 @@ std::shared_ptr<ColumnWriter> ColumnWriter::Make(ColumnChunkMetaDataBuilder* met
   switch (descr->physical_type()) {
     case Type::BOOLEAN:
       return std::make_shared<TypedColumnWriterImpl<BooleanType>>(
-          metadata, std::move(pager), use_dictionary, encoding, properties);
+          metadata, std::move(pager), use_dictionary, encoding, properties, bloom_filter);
     case Type::INT32:
       return std::make_shared<TypedColumnWriterImpl<Int32Type>>(
-          metadata, std::move(pager), use_dictionary, encoding, properties);
+          metadata, std::move(pager), use_dictionary, encoding, properties, bloom_filter);
     case Type::INT64:
       return std::make_shared<TypedColumnWriterImpl<Int64Type>>(
-          metadata, std::move(pager), use_dictionary, encoding, properties);
+          metadata, std::move(pager), use_dictionary, encoding, properties, bloom_filter);
     case Type::INT96:
       return std::make_shared<TypedColumnWriterImpl<Int96Type>>(
-          metadata, std::move(pager), use_dictionary, encoding, properties);
+          metadata, std::move(pager), use_dictionary, encoding, properties, bloom_filter);
     case Type::FLOAT:
       return std::make_shared<TypedColumnWriterImpl<FloatType>>(
-          metadata, std::move(pager), use_dictionary, encoding, properties);
+          metadata, std::move(pager), use_dictionary, encoding, properties, bloom_filter);
     case Type::DOUBLE:
       return std::make_shared<TypedColumnWriterImpl<DoubleType>>(
-          metadata, std::move(pager), use_dictionary, encoding, properties);
+          metadata, std::move(pager), use_dictionary, encoding, properties, bloom_filter);
     case Type::BYTE_ARRAY:
       return std::make_shared<TypedColumnWriterImpl<ByteArrayType>>(
-          metadata, std::move(pager), use_dictionary, encoding, properties);
+          metadata, std::move(pager), use_dictionary, encoding, properties, bloom_filter);
     case Type::FIXED_LEN_BYTE_ARRAY:
       return std::make_shared<TypedColumnWriterImpl<FLBAType>>(
-          metadata, std::move(pager), use_dictionary, encoding, properties);
+          metadata, std::move(pager), use_dictionary, encoding, properties, bloom_filter);
     default:
       ParquetException::NYI("type reader not implemented");
   }

--- a/cpp/src/parquet/column_writer.h
+++ b/cpp/src/parquet/column_writer.h
@@ -42,6 +42,7 @@ class RleEncoder;
 namespace parquet {
 
 struct ArrowWriteContext;
+class BloomFilter;
 class ColumnChunkMetaDataBuilder;
 class ColumnDescriptor;
 class ColumnIndexBuilder;
@@ -125,7 +126,8 @@ class PARQUET_EXPORT ColumnWriter {
 
   static std::shared_ptr<ColumnWriter> Make(ColumnChunkMetaDataBuilder*,
                                             std::unique_ptr<PageWriter>,
-                                            const WriterProperties* properties);
+                                            const WriterProperties* properties,
+                                            BloomFilter* bloom_filter = nullptr);
 
   /// \brief Closes the ColumnWriter, commits any buffered values to pages.
   /// \return Total size of the column in bytes

--- a/cpp/src/parquet/file_writer.cc
+++ b/cpp/src/parquet/file_writer.cc
@@ -546,7 +546,7 @@ class FileSerializer : public ParquetFileWriter::Contents {
       page_index_builder_ = PageIndexBuilder::Make(&schema_);
     }
     if (properties_->bloom_filter_enabled()) {
-      bloom_filter_writer_ = std::make_unique<BloomFilterWriter>();
+      bloom_filter_writer_ = std::make_unique<BloomFilterWriter>(*properties_);
     }
   }
 };

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -34,6 +34,7 @@ namespace parquet {
 
 class ColumnDescriptor;
 class EncodedStatistics;
+class RowGroupBloomFilterReference;
 class Statistics;
 class SchemaDescriptor;
 
@@ -541,6 +542,9 @@ class PARQUET_EXPORT FileMetaDataBuilder {
 
   // Update location to all page indexes in the parquet file
   void SetPageIndexLocation(const PageIndexLocation& location);
+
+  // Set reference to serialized bloom filter
+  void SetBloomFilterReference(const RowGroupBloomFilterReference& reference);
 
   // Complete the Thrift structure
   std::unique_ptr<FileMetaData> Finish(


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Currently we allow reading bloom filter for specific column and rowgroup, now this patch allow it writing BF.

This patch is just a skeleton. If reviewer thinks interface would be OK, I'll go on and add testing.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Allow writing bf:

* [x] Add WriterProperties config for writing bloom filter, including bf and (per-rowgroup) ndv estimation.
* [x] Add BloomFilterWriter for parquet
* [x] From FileSerializer to ColumnWriter, adding bloomfilter
* [x] Ensure Bloom Filter info is written to the file
* [ ] Testing logic above

### Are these changes tested?

Currently not, after reviewers think it's ok, I'll continue testing it.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

User can create Bloom Filter in parquet with C++ api

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #34785