### PR TITLE
GH-35692: [C++][Parquet] Parquet: fixing FixedSizeListReader::AssembleArray when has null FixedSizeList

### DIFF
--- a/cpp/src/arrow/array/validate.cc
+++ b/cpp/src/arrow/array/validate.cc
@@ -265,7 +265,8 @@ struct ValidateArrayImpl {
     }
 
     int64_t expected_values_length = -1;
-    if (MultiplyWithOverflow(data.length, list_size, &expected_values_length) ||
+    if (MultiplyWithOverflow(data.length - data.null_count, list_size,
+                             &expected_values_length) ||
         values.length < expected_values_length) {
       return Status::Invalid("Values length (", values.length,
                              ") is less than the length (", data.length,

--- a/cpp/src/arrow/array/validate.cc
+++ b/cpp/src/arrow/array/validate.cc
@@ -265,8 +265,7 @@ struct ValidateArrayImpl {
     }
 
     int64_t expected_values_length = -1;
-    if (MultiplyWithOverflow(data.length - data.null_count, list_size,
-                             &expected_values_length) ||
+    if (MultiplyWithOverflow(data.length, list_size, &expected_values_length) ||
         values.length < expected_values_length) {
       return Status::Invalid("Values length (", values.length,
                              ") is less than the length (", data.length,

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -3010,6 +3010,27 @@ TEST(ArrowReadWrite, ListOfStructOfList1) {
   CheckSimpleRoundtrip(table, 2);
 }
 
+TEST(ArrowReadWrite, ListOfStructOfList2) {
+  using ::arrow::field;
+  using ::arrow::list;
+  using ::arrow::struct_;
+
+  auto type =
+      list(field("item",
+                 struct_({field("a", ::arrow::int16(), /*nullable=*/false),
+                          field("b", list(::arrow::int64()), /*nullable=*/false)}),
+                 /*nullable=*/false));
+
+  const char* json = R"([
+      [{"a": 123, "b": [1, 2, 3]}],
+      null,
+      [],
+      [{"a": 456, "b": []}, {"a": 789, "b": [null]}, {"a": 876, "b": [4, 5, 6]}]])";
+  auto array = ::arrow::ArrayFromJSON(type, json);
+  auto table = ::arrow::Table::Make(::arrow::schema({field("root", type)}), {array});
+  CheckSimpleRoundtrip(table, 2);
+}
+
 TEST(ArrowReadWrite, ListWithNoValues) {
   using ::arrow::Buffer;
   using ::arrow::field;
@@ -3074,7 +3095,7 @@ TEST(ArrowReadWrite, FixedSizeList) {
   CheckSimpleRoundtrip(table, 2, props_store_schema);
 }
 
-TEST(ArrowReadWrite, NullableFixedSizeList) {
+TEST(ArrowReadWrite, FixedSizeList2) {
   using ::arrow::field;
   using ::arrow::fixed_size_list;
   using ::arrow::struct_;

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -3074,6 +3074,26 @@ TEST(ArrowReadWrite, FixedSizeList) {
   CheckSimpleRoundtrip(table, 2, props_store_schema);
 }
 
+TEST(ArrowReadWrite, NullableFixedSizeList) {
+  using ::arrow::field;
+  using ::arrow::fixed_size_list;
+  using ::arrow::struct_;
+
+  auto type = fixed_size_list(::arrow::int16(), /*size=*/3);
+
+  const char* json = R"([
+      [1, 2, 3],
+      null,
+      [4, 2, 6],
+      null,
+      [7, 8, 3],
+      null])";
+  auto array = ::arrow::ArrayFromJSON(type, json);
+  auto table = ::arrow::Table::Make(::arrow::schema({field("root", type)}), {array});
+  auto props_store_schema = ArrowWriterProperties::Builder().store_schema()->build();
+  CheckSimpleRoundtrip(table, 2, props_store_schema);
+}
+
 TEST(ArrowReadWrite, ListOfStructOfList2) {
   using ::arrow::field;
   using ::arrow::list;

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -3082,37 +3082,40 @@ TEST(ArrowReadWrite, NullableFixedSizeList) {
   auto type = fixed_size_list(::arrow::int16(), /*size=*/3);
 
   const char* json = R"([
-      [null, 2, 3],
       null,
-      [4, null, 6],
+      [null, 1, 2],
+      [null, 3, 4],
       null,
-      [7, 8, null],
-      null])";
+      [5, null, 6],
+      [7, null, 8],
+      null,
+      [9, 10, null],
+      null,
+      null,
+      [11, 12, 13],
+      [14, 15, 16]])";
   auto array = ::arrow::ArrayFromJSON(type, json);
   auto table = ::arrow::Table::Make(::arrow::schema({field("root", type)}), {array});
   auto props_store_schema = ArrowWriterProperties::Builder().store_schema()->build();
   CheckSimpleRoundtrip(table, 2, props_store_schema);
 }
 
-TEST(ArrowReadWrite, ListOfStructOfList2) {
+TEST(ArrowReadWrite, NestedFixedSizeList) {
   using ::arrow::field;
-  using ::arrow::list;
+  using ::arrow::fixed_size_list;
   using ::arrow::struct_;
 
-  auto type =
-      list(field("item",
-                 struct_({field("a", ::arrow::int16(), /*nullable=*/false),
-                          field("b", list(::arrow::int64()), /*nullable=*/false)}),
-                 /*nullable=*/false));
+  auto type = fixed_size_list(fixed_size_list(::arrow::int16(), 2), /*size=*/2);
 
   const char* json = R"([
-      [{"a": 123, "b": [1, 2, 3]}],
+      [[1, 2], [3,4]],
       null,
-      [],
-      [{"a": 456, "b": []}, {"a": 789, "b": [null]}, {"a": 876, "b": [4, 5, 6]}]])";
+      [[5, 6], null],
+      [null, [7, 8]]])";
   auto array = ::arrow::ArrayFromJSON(type, json);
   auto table = ::arrow::Table::Make(::arrow::schema({field("root", type)}), {array});
-  CheckSimpleRoundtrip(table, 2);
+  auto props_store_schema = ArrowWriterProperties::Builder().store_schema()->build();
+  CheckSimpleRoundtrip(table, 2, props_store_schema);
 }
 
 TEST(ArrowReadWrite, StructOfLists) {

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -3110,8 +3110,8 @@ TEST(ArrowReadWrite, NestedFixedSizeList) {
   const char* json = R"([
       [[1, 2], [3,4]],
       null,
-      [[5, 6], null],
-      [null, [7, 8]]])";
+      [[5, 6], [7, 8]],
+      [[9, 10], [11, 12]]])";
   auto array = ::arrow::ArrayFromJSON(type, json);
   auto table = ::arrow::Table::Make(::arrow::schema({field("root", type)}), {array});
   auto props_store_schema = ArrowWriterProperties::Builder().store_schema()->build();

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -3082,11 +3082,11 @@ TEST(ArrowReadWrite, NullableFixedSizeList) {
   auto type = fixed_size_list(::arrow::int16(), /*size=*/3);
 
   const char* json = R"([
-      [1, 2, 3],
+      [null, 2, 3],
       null,
-      [4, 2, 6],
+      [4, null, 6],
       null,
-      [7, 8, 3],
+      [7, 8, null],
       null])";
   auto array = ::arrow::ArrayFromJSON(type, json);
   auto table = ::arrow::Table::Make(::arrow::schema({field("root", type)}), {array});

--- a/cpp/src/parquet/arrow/path_internal.cc
+++ b/cpp/src/parquet/arrow/path_internal.cc
@@ -314,8 +314,8 @@ struct NullableTerminalNode {
 // Type parameters:
 //    |RangeSelector| - A strategy for determine the range of the child node to
 //    process.
-//       this varies depending on the type of list "int32_t* offsets", "int64_t* offsets" or
-//       fixed.
+//       this varies depending on the type of list "int32_t* offsets", "int64_t* offsets"
+//       or fixed.
 template <typename RangeSelector>
 class ListPathNode {
  public:

--- a/cpp/src/parquet/arrow/path_internal.cc
+++ b/cpp/src/parquet/arrow/path_internal.cc
@@ -141,7 +141,7 @@ int64_t LazyNullCount(const Array& array) { return array.data()->null_count.load
 bool LazyNoNulls(const Array& array) {
   int64_t null_count = LazyNullCount(array);
   return null_count == 0 ||
-         // kUnkownNullCount comparison is needed to account
+         // kUnknownNullCount comparison is needed to account
          // for null arrays.
          (null_count == ::arrow::kUnknownNullCount &&
           array.null_bitmap_data() == nullptr);
@@ -312,9 +312,9 @@ struct NullableTerminalNode {
 // at least one other node).
 //
 // Type parameters:
-//    |RangeSelector| - A strategy for determine the the range of the child node to
+//    |RangeSelector| - A strategy for determine the range of the child node to
 //    process.
-//       this varies depending on the type of list (int32_t* offsets, int64_t* offsets of
+//       this varies depending on the type of list "int32_t* offsets", "int64_t* offsets" or
 //       fixed.
 template <typename RangeSelector>
 class ListPathNode {

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -25,6 +25,8 @@
 #include <vector>
 
 #include "arrow/array.h"
+#include "arrow/array/builder_base.h"
+#include "arrow/array/builder_nested.h"
 #include "arrow/buffer.h"
 #include "arrow/extension_type.h"
 #include "arrow/io/memory.h"
@@ -662,16 +664,39 @@ class PARQUET_NO_EXPORT FixedSizeListReader : public ListReader<int32_t> {
     DCHECK_EQ(field()->type()->id(), ::arrow::Type::FIXED_SIZE_LIST);
     const auto& type = checked_cast<::arrow::FixedSizeListType&>(*field()->type());
     const int32_t* offsets = reinterpret_cast<const int32_t*>(data->buffers[1]->data());
+    // Need to reassemble data with correct offsets and paddings.
+    if (field()->nullable() && data->null_count != 0) {
+      std::unique_ptr<::arrow::ArrayBuilder> temp_builder;
+      ARROW_RETURN_NOT_OK(::arrow::MakeBuilder(::arrow::default_memory_pool(),
+                                               field()->type(), &temp_builder));
+      auto fixed_sized_list_builder =
+          checked_cast<::arrow::FixedSizeListBuilder*>(temp_builder.get());
+      for (int x = 1; x <= data->length; x++) {
+        int32_t size = offsets[x] - offsets[x - 1];
+        if (size != type.list_size()) {
+          if (size == 0) {
+            ARROW_RETURN_NOT_OK(fixed_sized_list_builder->AppendNull());
+            continue;
+          }
+          return Status::Invalid("Expected all lists to be of size=", type.list_size(),
+                                 " but index ", x, " had size=", size);
+        }
+        ARROW_RETURN_NOT_OK(fixed_sized_list_builder->AppendValues(1));
+        ARROW_RETURN_NOT_OK(fixed_sized_list_builder->value_builder()->AppendArraySlice(
+            ::arrow::ArraySpan(*data->child_data[0]), offsets[x - 1], size));
+      }
+      ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Array> result,
+                            fixed_sized_list_builder->Finish());
+      return std::make_shared<ChunkedArray>(result);
+    }
     for (int x = 1; x <= data->length; x++) {
       int32_t size = offsets[x] - offsets[x - 1];
       if (size != type.list_size()) {
-        if (field()->nullable() && size == 0) {
-          continue;
-        }
         return Status::Invalid("Expected all lists to be of size=", type.list_size(),
                                " but index ", x, " had size=", size);
       }
     }
+    // remove the offset buffer
     data->buffers.resize(1);
     std::shared_ptr<Array> result = ::arrow::MakeArray(data);
     return std::make_shared<ChunkedArray>(result);

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -644,9 +644,7 @@ class ListReader : public ColumnReaderImpl {
 
   const std::shared_ptr<Field> field() override { return field_; }
 
-  ::arrow::MemoryPool* memory_pool() {
-    return ctx_->pool;
-  }
+  ::arrow::MemoryPool* memory_pool() { return ctx_->pool; }
 
  private:
   std::shared_ptr<ReaderContext> ctx_;
@@ -672,8 +670,8 @@ class PARQUET_NO_EXPORT FixedSizeListReader : public ListReader<int32_t> {
     if (field()->nullable() && data->null_count != 0) {
       const auto& validity_bitmap = data->buffers[0];
       std::unique_ptr<::arrow::ArrayBuilder> temp_builder;
-      ARROW_RETURN_NOT_OK(::arrow::MakeBuilder(memory_pool(),
-                                               field()->type(), &temp_builder));
+      ARROW_RETURN_NOT_OK(
+          ::arrow::MakeBuilder(memory_pool(), field()->type(), &temp_builder));
       auto fixed_sized_list_builder =
           checked_cast<::arrow::FixedSizeListBuilder*>(temp_builder.get());
       std::optional<int> non_null_begin;

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -644,6 +644,10 @@ class ListReader : public ColumnReaderImpl {
 
   const std::shared_ptr<Field> field() override { return field_; }
 
+  ::arrow::MemoryPool* memory_pool() {
+    return ctx_->pool;
+  }
+
  private:
   std::shared_ptr<ReaderContext> ctx_;
   std::shared_ptr<Field> field_;
@@ -668,7 +672,7 @@ class PARQUET_NO_EXPORT FixedSizeListReader : public ListReader<int32_t> {
     if (field()->nullable() && data->null_count != 0) {
       const auto& validity_bitmap = data->buffers[0];
       std::unique_ptr<::arrow::ArrayBuilder> temp_builder;
-      ARROW_RETURN_NOT_OK(::arrow::MakeBuilder(::arrow::default_memory_pool(),
+      ARROW_RETURN_NOT_OK(::arrow::MakeBuilder(memory_pool(),
                                                field()->type(), &temp_builder));
       auto fixed_sized_list_builder =
           checked_cast<::arrow::FixedSizeListBuilder*>(temp_builder.get());

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -665,6 +665,9 @@ class PARQUET_NO_EXPORT FixedSizeListReader : public ListReader<int32_t> {
     for (int x = 1; x <= data->length; x++) {
       int32_t size = offsets[x] - offsets[x - 1];
       if (size != type.list_size()) {
+        if (field()->nullable() && size == 0) {
+          continue;
+        }
         return Status::Invalid("Expected all lists to be of size=", type.list_size(),
                                " but index ", x, " had size=", size);
       }

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -666,24 +666,54 @@ class PARQUET_NO_EXPORT FixedSizeListReader : public ListReader<int32_t> {
     const int32_t* offsets = reinterpret_cast<const int32_t*>(data->buffers[1]->data());
     // Need to reassemble data with correct offsets and paddings.
     if (field()->nullable() && data->null_count != 0) {
+      const auto& validity_bitmap = data->buffers[0];
       std::unique_ptr<::arrow::ArrayBuilder> temp_builder;
       ARROW_RETURN_NOT_OK(::arrow::MakeBuilder(::arrow::default_memory_pool(),
                                                field()->type(), &temp_builder));
       auto fixed_sized_list_builder =
           checked_cast<::arrow::FixedSizeListBuilder*>(temp_builder.get());
+      std::optional<int> non_null_begin;
       for (int x = 1; x <= data->length; x++) {
         int32_t size = offsets[x] - offsets[x - 1];
         if (size != type.list_size()) {
           if (size == 0) {
+            if (ARROW_PREDICT_FALSE(bit_util::GetBit(validity_bitmap->data(), x - 1))) {
+              return Status::Invalid("Expect list to be null at index ", x - 1,
+                                     " but it has non-zero offset");
+            }
+            // Batch flush values within [non_null_begin, x - 1). Member at x - 1 is null.
+            if (non_null_begin.has_value()) {
+              DCHECK_GE(x - 1, *non_null_begin);
+              ARROW_RETURN_NOT_OK(
+                  fixed_sized_list_builder->AppendValues((x - 1) - *non_null_begin));
+              ARROW_RETURN_NOT_OK(
+                  fixed_sized_list_builder->value_builder()->AppendArraySlice(
+                      ::arrow::ArraySpan(*data->child_data[0]), offsets[*non_null_begin],
+                      offsets[x - 1] - offsets[*non_null_begin]));
+              non_null_begin = std::nullopt;
+            }
             ARROW_RETURN_NOT_OK(fixed_sized_list_builder->AppendNull());
             continue;
           }
           return Status::Invalid("Expected all lists to be of size=", type.list_size(),
                                  " but index ", x, " had size=", size);
         }
-        ARROW_RETURN_NOT_OK(fixed_sized_list_builder->AppendValues(1));
+        if (ARROW_PREDICT_FALSE(!bit_util::GetBit(validity_bitmap->data(), x - 1))) {
+          return Status::Invalid("Expect list to be not null at index ", x - 1,
+                                 " but it was null");
+        }
+        if (!non_null_begin.has_value()) {
+          non_null_begin = x - 1;
+        }
+      }
+      // Flush remaining non-null values in [*non_null_begin, data->length).
+      if (non_null_begin.has_value()) {
+        ARROW_RETURN_NOT_OK(
+            fixed_sized_list_builder->AppendValues(data->length - *non_null_begin));
         ARROW_RETURN_NOT_OK(fixed_sized_list_builder->value_builder()->AppendArraySlice(
-            ::arrow::ArraySpan(*data->child_data[0]), offsets[x - 1], size));
+            ::arrow::ArraySpan(*data->child_data[0]), offsets[*non_null_begin],
+            offsets[data->length] - offsets[*non_null_begin]));
+        non_null_begin = std::nullopt;
       }
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Array> result,
                             fixed_sized_list_builder->Finish());


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->


1. Parquet will regard `FixedSizeList` as regular list, and write rep-levels and def-levels if possible
2. When read from Parquet, if no null (or nested null, like `FixedSizeList` doesn't has null but it parent has) is contained, the file can be read correctly
3. However, when read from Parquet with nullable, the `AssembleArray` will not work well. It takes continuous "child array" and child offsets, and need to reserve extra padding space for "null". Previous reader doesn't implement it.

To be more clear:

```
for FixedSizeList(2): [[0, 0], null]

data to be Assemble Array:
null: [0 1]
data: [0 0]
offsets: [0, 2, 2]

required output:
null: [0 1]
data: [0, 0, undefined, undefined]
```

previous reader doesn't implement that required output

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Rebuild the `FixedSizeList` when having null member

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes

### Are there any user-facing changes?

No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #35692