### PR TITLE
MINOR: [Docs][C++] Improve Input Shapes section of Compute doc

### DIFF
--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -49,8 +49,9 @@ Computation inputs are represented as a general :class:`Datum` class,
 which is a tagged union of several shapes of data such as :class:`Scalar`,
 :class:`Array` and :class:`ChunkedArray`.  Many compute functions support
 both array (chunked or not) and scalar inputs, however some will mandate
-either.  For example, while ``sort_indices`` requires its first and only
-input to be an array.
+particular input types. For example, while ``array_sort_indices`` requires its 
+first and only input to be an array, the generalized ``sort_indices`` 
+function accepts an array, chunked array, record batch or table.
 
 .. _invoking-compute-functions:
 


### PR DESCRIPTION
1.  The function that only takes arrays should be `array_sort_indices`, not `sort_indices`.
2. IMO The word `either` implies that `array_sort_indices` also accepts chunked arrays but in fact it doesn't. So I changed `either` to `particular input types`.
3. There are no mention of two dimensional data types, i.e. RecordBatch and Table, throughout the Input Shapes section, which I feel like is a miss. So I added `sort_indices` as an example for them.