### PR TITLE
GH-33206: [C++] Add support for StructArray sorting and nested sort keys

### DIFF
--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -892,6 +892,10 @@ class SortIndicesMetaFunction : public MetaFunction {
     }
     // We avoid using `Table::FromChunkedStructArray` here since it doesn't take top-level
     // validity into account for the columns.
+    //
+    // TODO: We could instead use the provided sort keys to only flatten the selected
+    // columns (via `GetFlattenedField`). Same for the Array -> RecordBatch conversion,
+    // since `RecordBatch::FromStructArray` flattens all columns as well.
     ARROW_ASSIGN_OR_RAISE(auto columns, chunked_array->Flatten());
     return Table::Make(schema(chunked_array->type()->fields()), std::move(columns),
                        chunked_array->length());

--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -1044,7 +1044,7 @@ void AddLeafFields(const FieldVector& fields, SortOrder order,
     if (type.id() == Type::STRUCT) {
       AddLeafFields(type.fields(), order, out, tmp_indices);
     } else {
-      out->emplace_back(FieldPath(*tmp_indices), order);
+      out->emplace_back(FieldPath(*tmp_indices), order, &type);
     }
     ++tmp_indices->back();
   }
@@ -1057,7 +1057,7 @@ void AddField(const DataType& type, const FieldPath& path, SortOrder order,
     *tmp_indices = path.indices();
     AddLeafFields(type.fields(), order, out, tmp_indices);
   } else {
-    out->emplace_back(path, order);
+    out->emplace_back(path, order, &type);
   }
 }
 

--- a/cpp/src/arrow/compute/kernels/vector_sort_internal.h
+++ b/cpp/src/arrow/compute/kernels/vector_sort_internal.h
@@ -464,6 +464,12 @@ Result<NullPartitionResult> SortChunkedArray(
     const std::shared_ptr<DataType>& physical_type, const ArrayVector& physical_chunks,
     SortOrder sort_order, NullPlacement null_placement);
 
+Result<NullPartitionResult> SortStructArray(ExecContext* ctx, uint64_t* indices_begin,
+                                            uint64_t* indices_end,
+                                            const StructArray& array,
+                                            SortOrder sort_order,
+                                            NullPlacement null_placement);
+
 // ----------------------------------------------------------------------
 // Helpers for Sort/SelectK/Rank implementations
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

We don't currently support sorting `StructArray`s despite already having the high-level facilities to do so. For instance, we allow passing multiple sort keys (based on `FieldRef`s) to sort record batches and tables - but the current implementations are fairly limited since nested refs aren't allowed (due to the burden of null flattening). Since https://github.com/apache/arrow/pull/35197, we now have an easier way to do this.

### What changes are included in this PR?

- Adds support for `StructArray` in `sort_indices`
- Adds support for nested sort keys in `sort_indices` for `RecordBatch`, `ChunkedArray`, and `Table`

### Are these changes tested?

Yes (tests are included)

### Are there any user-facing changes?

Yes
* Closes: #33206