### PR TITLE
GH-35729: [C++][Parquet] Implement batch interface for BloomFilter in Parquet

### DIFF
--- a/cpp/src/arrow/util/bitmap_writer.h
+++ b/cpp/src/arrow/util/bitmap_writer.h
@@ -124,7 +124,7 @@ class FirstTimeBitmapWriter {
       // unset so no additional accounting is needed for when number_of_bits <
       // bits_to_carry.
       current_byte_ |= (word & bit_util::kPrecedingBitmask[bits_to_carry]) << bit_offset;
-      // Check if everything is transfered into current_byte_.
+      // Check if everything is transferred into current_byte_.
       if (ARROW_PREDICT_FALSE(number_of_bits < bits_to_carry)) {
         return;
       }

--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -401,6 +401,7 @@ endif()
 add_parquet_test(file_deserialize_test SOURCES file_deserialize_test.cc test_util.cc)
 add_parquet_test(schema_test)
 
+add_parquet_benchmark(bloom_filter_benchmark)
 add_parquet_benchmark(column_reader_benchmark)
 add_parquet_benchmark(column_io_benchmark)
 add_parquet_benchmark(encoding_benchmark)

--- a/cpp/src/parquet/bloom_filter.cc
+++ b/cpp/src/parquet/bloom_filter.cc
@@ -227,4 +227,11 @@ void BlockSplitBloomFilter::InsertHash(uint64_t hash) {
   }
 }
 
+void BlockSplitBloomFilter::InsertHashes(const uint64_t* hashes, int num_values) {
+  for (int i = 0; i < num_values; ++i) {
+    // BlockSplitBloomFilter is marked by final, so InsertHash would be de-virtualized.
+    InsertHash(hashes[i]);
+  }
+}
+
 }  // namespace parquet

--- a/cpp/src/parquet/bloom_filter.cc
+++ b/cpp/src/parquet/bloom_filter.cc
@@ -21,7 +21,10 @@
 
 #include "arrow/result.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/macros.h"
+
 #include "generated/parquet_types.h"
+
 #include "parquet/bloom_filter.h"
 #include "parquet/exception.h"
 #include "parquet/thrift_internal.h"
@@ -180,32 +183,17 @@ void BlockSplitBloomFilter::WriteTo(ArrowOutputStream* sink) const {
   PARQUET_THROW_NOT_OK(sink->Write(data_->data(), num_bytes_));
 }
 
-void BlockSplitBloomFilter::SetMask(uint32_t key, BlockMask& block_mask) const {
-  for (int i = 0; i < kBitsSetPerBlock; ++i) {
-    block_mask.item[i] = key * SALT[i];
-  }
-
-  for (int i = 0; i < kBitsSetPerBlock; ++i) {
-    block_mask.item[i] = block_mask.item[i] >> 27;
-  }
-
-  for (int i = 0; i < kBitsSetPerBlock; ++i) {
-    block_mask.item[i] = UINT32_C(0x1) << block_mask.item[i];
-  }
-}
-
 bool BlockSplitBloomFilter::FindHash(uint64_t hash) const {
   const uint32_t bucket_index =
       static_cast<uint32_t>(((hash >> 32) * (num_bytes_ / kBytesPerFilterBlock)) >> 32);
   const uint32_t key = static_cast<uint32_t>(hash);
   const uint32_t* bitset32 = reinterpret_cast<const uint32_t*>(data_->data());
 
-  // Calculate mask for bucket.
-  BlockMask block_mask;
-  SetMask(key, block_mask);
-
   for (int i = 0; i < kBitsSetPerBlock; ++i) {
-    if (0 == (bitset32[kBitsSetPerBlock * bucket_index + i] & block_mask.item[i])) {
+    // Calculate mask for key in the given bitset.
+    const uint32_t mask = UINT32_C(0x1) << ((key * SALT[i]) >> 27);
+    if (ARROW_PREDICT_FALSE(0 ==
+                            (bitset32[kBitsSetPerBlock * bucket_index + i] & mask))) {
       return false;
     }
   }
@@ -218,12 +206,10 @@ void BlockSplitBloomFilter::InsertHashImpl(uint64_t hash) {
   const uint32_t key = static_cast<uint32_t>(hash);
   uint32_t* bitset32 = reinterpret_cast<uint32_t*>(data_->mutable_data());
 
-  // Calculate mask for bucket.
-  BlockMask block_mask;
-  SetMask(key, block_mask);
-
   for (int i = 0; i < kBitsSetPerBlock; i++) {
-    bitset32[bucket_index * kBitsSetPerBlock + i] |= block_mask.item[i];
+    // Calculate mask for key in the given bitset.
+    const uint32_t mask = UINT32_C(0x1) << ((key * SALT[i]) >> 27);
+    bitset32[bucket_index * kBitsSetPerBlock + i] |= mask;
   }
 }
 

--- a/cpp/src/parquet/bloom_filter.cc
+++ b/cpp/src/parquet/bloom_filter.cc
@@ -212,7 +212,7 @@ bool BlockSplitBloomFilter::FindHash(uint64_t hash) const {
   return true;
 }
 
-void BlockSplitBloomFilter::InsertHash(uint64_t hash) {
+void BlockSplitBloomFilter::InsertHashImpl(uint64_t hash) {
   const uint32_t bucket_index =
       static_cast<uint32_t>(((hash >> 32) * (num_bytes_ / kBytesPerFilterBlock)) >> 32);
   const uint32_t key = static_cast<uint32_t>(hash);
@@ -227,10 +227,11 @@ void BlockSplitBloomFilter::InsertHash(uint64_t hash) {
   }
 }
 
+void BlockSplitBloomFilter::InsertHash(uint64_t hash) { InsertHashImpl(hash); }
+
 void BlockSplitBloomFilter::InsertHashes(const uint64_t* hashes, int num_values) {
   for (int i = 0; i < num_values; ++i) {
-    // BlockSplitBloomFilter is marked by final, so InsertHash would be de-virtualized.
-    InsertHash(hashes[i]);
+    InsertHashImpl(hashes[i]);
   }
 }
 

--- a/cpp/src/parquet/bloom_filter.h
+++ b/cpp/src/parquet/bloom_filter.h
@@ -108,57 +108,64 @@ class PARQUET_EXPORT BloomFilter {
 
   /// Batch compute hashes for 32 bits values by using its plain encoding result.
   ///
-  /// @param values the value to hash.
+  /// @param values values a pointer to the values to hash.
   /// @param num_values the number of values to hash.
-  /// @param hashes the output hash value, it length should be equal to num_values.
+  /// @param hashes a pointer to the output hash values, its length should be equal to
+  /// num_values.
   virtual void Hashes(const int32_t* values, int num_values, uint64_t* hashes) const = 0;
 
   /// Batch compute hashes for 64 bits values by using its plain encoding result.
   ///
-  /// @param values the value to hash.
+  /// @param values values a pointer to the values to hash.
   /// @param num_values the number of values to hash.
-  /// @param hashes the output hash value, it length should be equal to num_values.
+  /// @param hashes a pointer to the output hash values, its length should be equal to
+  /// num_values.
   virtual void Hashes(const int64_t* values, int num_values, uint64_t* hashes) const = 0;
 
   /// Batch compute hashes for float values by using its plain encoding result.
   ///
-  /// @param values the value to hash.
+  /// @param values values a pointer to the values to hash.
   /// @param num_values the number of values to hash.
-  /// @param hashes the output hash value, it length should be equal to num_values.
+  /// @param hashes a pointer to the output hash values, its length should be equal to
+  /// num_values.
   virtual void Hashes(const float* values, int num_values, uint64_t* hashes) const = 0;
 
   /// Batch compute hashes for double values by using its plain encoding result.
   ///
-  /// @param values the value to hash.
+  /// @param values values a pointer to the values to hash.
   /// @param num_values the number of values to hash.
-  /// @param hashes the output hash value, it length should be equal to num_values.
+  /// @param hashes a pointer to the output hash values, its length should be equal to
+  /// num_values.
   virtual void Hashes(const double* values, int num_values, uint64_t* hashes) const = 0;
 
   /// Batch compute hashes for Int96 values by using its plain encoding result.
   ///
-  /// @param values the value to hash.
+  /// @param values values a pointer to the values to hash.
   /// @param num_values the number of values to hash.
-  /// @param hashes the output hash value, it length should be equal to num_values.
+  /// @param hashes a pointer to the output hash values, its length should be equal to
+  /// num_values.
   virtual void Hashes(const Int96* values, int num_values, uint64_t* hashes) const = 0;
 
   /// Batch compute hashes for ByteArray values by using its plain encoding result.
   ///
-  /// @param values the value to hash.
+  /// @param values values a pointer to the values to hash.
   /// @param num_values the number of values to hash.
-  /// @param hashes the output hash value, it length should be equal to num_values.
+  /// @param hashes a pointer to the output hash values, its length should be equal to
+  /// num_values.
   virtual void Hashes(const ByteArray* values, int num_values,
                       uint64_t* hashes) const = 0;
 
   /// Batch compute hashes for fixed byte array values by using its plain encoding result.
   ///
-  /// @param values the value address.
+  /// @param values values a pointer to the values to hash.
   /// @param type_len the value length.
   /// @param num_values the number of values to hash.
-  /// @param hashes the output hash value, it length should be equal to num_values.
+  /// @param hashes a pointer to the output hash values, its length should be equal to
+  /// num_values.
   virtual void Hashes(const FLBA* values, uint32_t type_len, int num_values,
                       uint64_t* hashes) const = 0;
 
-  virtual ~BloomFilter() {}
+  virtual ~BloomFilter() = default;
 
  protected:
   // Hash strategy available for Bloom filter.
@@ -257,11 +264,7 @@ class PARQUET_EXPORT BlockSplitBloomFilter final : public BloomFilter {
 
   bool FindHash(uint64_t hash) const override;
   void InsertHash(uint64_t hash) override;
-  void InsertHashes(const uint64_t* hashes, int num_values) override {
-    for (int i = 0; i < num_values; ++i) {
-      InsertHash(hashes[i]);
-    }
-  }
+  void InsertHashes(const uint64_t* hashes, int num_values) override;
   void WriteTo(ArrowOutputStream* sink) const override;
   uint32_t GetBitsetSize() const override { return num_bytes_; }
 
@@ -298,10 +301,10 @@ class PARQUET_EXPORT BlockSplitBloomFilter final : public BloomFilter {
     hasher_->Hashes(values, type_len, num_values, hashes);
   }
 
-  uint64_t Hash(int32_t* value) const { return hasher_->Hash(*value); }
-  uint64_t Hash(int64_t* value) const { return hasher_->Hash(*value); }
-  uint64_t Hash(float* value) const { return hasher_->Hash(*value); }
-  uint64_t Hash(double* value) const { return hasher_->Hash(*value); }
+  uint64_t Hash(const int32_t* value) const { return hasher_->Hash(*value); }
+  uint64_t Hash(const int64_t* value) const { return hasher_->Hash(*value); }
+  uint64_t Hash(const float* value) const { return hasher_->Hash(*value); }
+  uint64_t Hash(const double* value) const { return hasher_->Hash(*value); }
 
   /// Deserialize the Bloom filter from an input stream. It is used when reconstructing
   /// a Bloom filter from a parquet filter.

--- a/cpp/src/parquet/bloom_filter.h
+++ b/cpp/src/parquet/bloom_filter.h
@@ -49,8 +49,8 @@ class PARQUET_EXPORT BloomFilter {
   /// @param hash the hash of value to insert into Bloom filter.
   virtual void InsertHash(uint64_t hash) = 0;
 
-  /// Insert element to set represented by Bloom filter bitset.
-  /// @param hashes the hash of value to insert into Bloom filter.
+  /// Insert elements to set represented by Bloom filter bitset.
+  /// @param hashes the hash values to insert into Bloom filter.
   /// @param num_values the length of hash to insert.
   virtual void InsertHashes(const uint64_t* hashes, int num_values) = 0;
 

--- a/cpp/src/parquet/bloom_filter.h
+++ b/cpp/src/parquet/bloom_filter.h
@@ -183,7 +183,7 @@ class PARQUET_EXPORT BloomFilter {
 ///
 /// This implementation sets 8 bits in each tiny Bloom filter. Each tiny Bloom
 /// filter is 32 bytes to take advantage of 32-byte SIMD instructions.
-class PARQUET_EXPORT BlockSplitBloomFilter final : public BloomFilter {
+class PARQUET_EXPORT BlockSplitBloomFilter : public BloomFilter {
  public:
   /// The constructor of BlockSplitBloomFilter. It uses XXH64 as hash function.
   ///
@@ -314,6 +314,9 @@ class PARQUET_EXPORT BlockSplitBloomFilter final : public BloomFilter {
   /// @return The BlockSplitBloomFilter.
   static BlockSplitBloomFilter Deserialize(const ReaderProperties& properties,
                                            ArrowInputStream* input_stream);
+
+ private:
+  void InsertHashImpl(uint64_t hash);
 
  private:
   // Bytes in a tiny Bloom filter block.

--- a/cpp/src/parquet/bloom_filter.h
+++ b/cpp/src/parquet/bloom_filter.h
@@ -51,7 +51,7 @@ class PARQUET_EXPORT BloomFilter {
 
   /// Insert elements to set represented by Bloom filter bitset.
   /// @param hashes the hash values to insert into Bloom filter.
-  /// @param num_values the length of hash to insert.
+  /// @param num_values the number of hash values to insert.
   virtual void InsertHashes(const uint64_t* hashes, int num_values) = 0;
 
   /// Write this Bloom filter to an output stream. A Bloom filter structure should
@@ -316,9 +316,8 @@ class PARQUET_EXPORT BlockSplitBloomFilter : public BloomFilter {
                                            ArrowInputStream* input_stream);
 
  private:
-  void InsertHashImpl(uint64_t hash);
+  inline void InsertHashImpl(uint64_t hash);
 
- private:
   // Bytes in a tiny Bloom filter block.
   static constexpr int kBytesPerFilterBlock = 32;
 
@@ -335,11 +334,6 @@ class PARQUET_EXPORT BlockSplitBloomFilter : public BloomFilter {
   static constexpr uint32_t SALT[kBitsSetPerBlock] = {
       0x47b6137bU, 0x44974d91U, 0x8824ad5bU, 0xa2b7289dU,
       0x705495c7U, 0x2df1424bU, 0x9efc4947U, 0x5c6bfb31U};
-
-  /// Set bits in mask array according to input key.
-  /// @param key the value to calculate mask values.
-  /// @param mask the mask array is used to set inside a block
-  void SetMask(uint32_t key, BlockMask& mask) const;
 
   // Memory pool to allocate aligned buffer for bitset
   ::arrow::MemoryPool* pool_;

--- a/cpp/src/parquet/bloom_filter.h
+++ b/cpp/src/parquet/bloom_filter.h
@@ -176,7 +176,7 @@ class PARQUET_EXPORT BloomFilter {
 ///
 /// This implementation sets 8 bits in each tiny Bloom filter. Each tiny Bloom
 /// filter is 32 bytes to take advantage of 32-byte SIMD instructions.
-class PARQUET_EXPORT BlockSplitBloomFilter : public BloomFilter {
+class PARQUET_EXPORT BlockSplitBloomFilter final : public BloomFilter {
  public:
   /// The constructor of BlockSplitBloomFilter. It uses XXH64 as hash function.
   ///
@@ -265,12 +265,12 @@ class PARQUET_EXPORT BlockSplitBloomFilter : public BloomFilter {
   void WriteTo(ArrowOutputStream* sink) const override;
   uint32_t GetBitsetSize() const override { return num_bytes_; }
 
+  uint64_t Hash(int32_t value) const override { return hasher_->Hash(value); }
   uint64_t Hash(int64_t value) const override { return hasher_->Hash(value); }
   uint64_t Hash(float value) const override { return hasher_->Hash(value); }
   uint64_t Hash(double value) const override { return hasher_->Hash(value); }
   uint64_t Hash(const Int96* value) const override { return hasher_->Hash(value); }
   uint64_t Hash(const ByteArray* value) const override { return hasher_->Hash(value); }
-  uint64_t Hash(int32_t value) const override { return hasher_->Hash(value); }
   uint64_t Hash(const FLBA* value, uint32_t len) const override {
     return hasher_->Hash(value, len);
   }
@@ -297,6 +297,11 @@ class PARQUET_EXPORT BlockSplitBloomFilter : public BloomFilter {
               uint64_t* hashes) const override {
     hasher_->Hashes(values, type_len, num_values, hashes);
   }
+
+  uint64_t Hash(int32_t* value) const { return hasher_->Hash(*value); }
+  uint64_t Hash(int64_t* value) const { return hasher_->Hash(*value); }
+  uint64_t Hash(float* value) const { return hasher_->Hash(*value); }
+  uint64_t Hash(double* value) const { return hasher_->Hash(*value); }
 
   /// Deserialize the Bloom filter from an input stream. It is used when reconstructing
   /// a Bloom filter from a parquet filter.

--- a/cpp/src/parquet/bloom_filter_benchmark.cc
+++ b/cpp/src/parquet/bloom_filter_benchmark.cc
@@ -155,7 +155,7 @@ static void BM_InsertHash(::benchmark::State& state) {
   for (auto _ : state) {
     state.PauseTiming();
     auto filter = CreateBloomFilter(kNumBloomFilterInserts);
-    state.KeepRunning();
+    state.ResumeTiming();
     for (auto hash : hashes) {
       filter->InsertHash(hash);
     }
@@ -169,7 +169,7 @@ static void BM_BatchInsertHash(::benchmark::State& state) {
   for (auto _ : state) {
     state.PauseTiming();
     auto filter = CreateBloomFilter(kNumBloomFilterInserts);
-    state.KeepRunning();
+    state.ResumeTiming();
     filter->InsertHashes(hashes.data(), static_cast<int>(hashes.size()));
     ::benchmark::ClobberMemory();
   }

--- a/cpp/src/parquet/bloom_filter_benchmark.cc
+++ b/cpp/src/parquet/bloom_filter_benchmark.cc
@@ -58,24 +58,24 @@ void GenerateBenchmarkData(uint32_t size, T* data,
     std::default_random_engine gen(/*seed*/ 0);
     std::uniform_int_distribution<T> d(std::numeric_limits<T>::min(),
                                        std::numeric_limits<T>::max());
-    for (int i = 0; i < size; ++i) {
+    for (uint32_t i = 0; i < size; ++i) {
       data[i] = d(gen);
     }
   } else if constexpr (std::is_floating_point_v<T>) {
     std::default_random_engine gen(/*seed*/ 0);
     std::uniform_real_distribution<T> d(std::numeric_limits<T>::lowest(),
                                         std::numeric_limits<T>::max());
-    for (int i = 0; i < size; ++i) {
+    for (uint32_t i = 0; i < size; ++i) {
       data[i] = d(gen);
     }
   } else if constexpr (std::is_same_v<FLBA, T>) {
     GenerateRandomString(kGenerateBenchmarkDataStringLength * size, heap);
-    for (int i = 0; i < size; ++i) {
+    for (uint32_t i = 0; i < size; ++i) {
       data[i].ptr = heap->data() + i * kGenerateBenchmarkDataStringLength;
     }
   } else if constexpr (std::is_same_v<ByteArray, T>) {
     GenerateRandomString(kGenerateBenchmarkDataStringLength * size, heap);
-    for (int i = 0; i < size; ++i) {
+    for (uint32_t i = 0; i < size; ++i) {
       data[i].ptr = heap->data() + i * kGenerateBenchmarkDataStringLength;
       data[i].len = kGenerateBenchmarkDataStringLength;
     }
@@ -83,7 +83,7 @@ void GenerateBenchmarkData(uint32_t size, T* data,
     std::default_random_engine gen(/*seed*/ 0);
     std::uniform_int_distribution<int> d(std::numeric_limits<int>::min(),
                                          std::numeric_limits<int>::max());
-    for (int i = 0; i < size; ++i) {
+    for (uint32_t i = 0; i < size; ++i) {
       data[i].value[0] = d(gen);
       data[i].value[1] = d(gen);
       data[i].value[2] = d(gen);
@@ -103,8 +103,9 @@ static void BM_ComputeHash(::benchmark::State& state) {
       uint64_t hash = 0;
       if constexpr (std::is_same_v<DType, FLBAType>) {
         hash = filter->Hash(&value, kGenerateBenchmarkDataStringLength);
-      } else if constexpr (std::is_same_v<DType, Int96Type> ||
-                           std::is_same_v<DType, ByteArrayType>) {
+      } else if constexpr (std::is_same_v<DType, Int96Type>) {
+        hash = filter->Hash(&value);
+      } else if constexpr (std::is_same_v<DType, ByteArrayType>) {
         hash = filter->Hash(&value);
       } else {
         hash = filter->Hash(value);

--- a/cpp/src/parquet/bloom_filter_benchmark.cc
+++ b/cpp/src/parquet/bloom_filter_benchmark.cc
@@ -44,11 +44,13 @@ static void BM_ComputeHash(::benchmark::State& state) {
   auto filter = createBloomFilter(kBloomFilterElementSize);
   for (auto _ : state) {
     for (const auto& value : values) {
+      uint64_t hash = 0;
       if constexpr (std::is_same_v<DType, FLBAType>) {
-        filter->Hash(&value, test::kGenerateDataFLBALength);
+        hash = filter->Hash(&value, test::kGenerateDataFLBALength);
       } else {
-        filter->Hash(value);
+        hash = filter->Hash(value);
       }
+      ::benchmark::DoNotOptimize(hash);
       ::benchmark::ClobberMemory();
     }
   }
@@ -70,6 +72,7 @@ static void BM_BatchComputeHash(::benchmark::State& state) {
     } else {
       filter->Hashes(values.data(), static_cast<int>(values.size()), hashes.data());
     }
+    ::benchmark::DoNotOptimize(hashes);
     ::benchmark::ClobberMemory();
   }
   state.SetItemsProcessed(state.iterations() * values.size());

--- a/cpp/src/parquet/bloom_filter_benchmark.cc
+++ b/cpp/src/parquet/bloom_filter_benchmark.cc
@@ -29,14 +29,17 @@ static void BM_CountHash(::benchmark::State& state) {
   std::vector<T> values(1024);
   std::vector<uint8_t> heap;
   test::GenerateData(1024, values.data(), &heap);
-  BlockSplitBloomFilter filter;
-  filter.Init(BlockSplitBloomFilter::OptimalNumOfBytes(1024, /*fpp=*/0.05));
+  BlockSplitBloomFilter block_split_bloom_filter;
+  block_split_bloom_filter.Init(
+      BlockSplitBloomFilter::OptimalNumOfBytes(1024, /*fpp=*/0.05));
+  BloomFilter* filter = &block_split_bloom_filter;
+  ::benchmark::DoNotOptimize(filter);
   for (auto _ : state) {
     for (int i = 0; i < 1024; ++i) {
       if constexpr (std::is_same_v<DType, FLBAType>) {
-        filter.Hash(&values[i], test::kGenerateDataFLBALength);
+        filter->Hash(&values[i], test::kGenerateDataFLBALength);
       } else {
-        filter.Hash(&values[i]);
+        filter->Hash(values[i]);
       }
     }
   }
@@ -49,15 +52,18 @@ static void BM_BatchCountHash(::benchmark::State& state) {
   std::vector<T> values(1024);
   std::vector<uint8_t> heap;
   test::GenerateData(1024, values.data(), &heap);
-  BlockSplitBloomFilter filter;
-  filter.Init(BlockSplitBloomFilter::OptimalNumOfBytes(1024, /*fpp=*/0.05));
+  BlockSplitBloomFilter block_split_bloom_filter;
+  block_split_bloom_filter.Init(
+      BlockSplitBloomFilter::OptimalNumOfBytes(1024, /*fpp=*/0.05));
+  BloomFilter* filter = &block_split_bloom_filter;
+  ::benchmark::DoNotOptimize(filter);
   std::vector<uint64_t> hashes(1024);
   for (auto _ : state) {
     if constexpr (std::is_same_v<DType, FLBAType>) {
-      filter.Hashes(values.data(), test::kGenerateDataFLBALength,
-                    static_cast<int>(values.size()), hashes.data());
+      filter->Hashes(values.data(), test::kGenerateDataFLBALength,
+                     static_cast<int>(values.size()), hashes.data());
     } else {
-      filter.Hashes(values.data(), static_cast<int>(values.size()), hashes.data());
+      filter->Hashes(values.data(), static_cast<int>(values.size()), hashes.data());
     }
   }
   state.SetItemsProcessed(state.iterations() * values.size());
@@ -68,13 +74,16 @@ static void BM_InsertHash(::benchmark::State& state) {
   std::vector<T> values(1024);
   std::vector<uint8_t> heap;
   test::GenerateData(1024, values.data(), &heap);
-  BlockSplitBloomFilter filter;
-  filter.Init(BlockSplitBloomFilter::OptimalNumOfBytes(1024, /*fpp=*/0.05));
+  BlockSplitBloomFilter block_split_bloom_filter;
+  block_split_bloom_filter.Init(
+      BlockSplitBloomFilter::OptimalNumOfBytes(1024, /*fpp=*/0.05));
+  BloomFilter* filter = &block_split_bloom_filter;
+  ::benchmark::DoNotOptimize(filter);
   std::vector<uint64_t> hashes(1024);
-  filter.Hashes(values.data(), static_cast<int>(values.size()), hashes.data());
+  filter->Hashes(values.data(), static_cast<int>(values.size()), hashes.data());
   for (auto _ : state) {
     for (auto hash : hashes) {
-      filter.InsertHash(hash);
+      filter->InsertHash(hash);
     }
   }
   state.SetItemsProcessed(state.iterations() * values.size());
@@ -85,12 +94,15 @@ static void BM_BatchInsertHash(::benchmark::State& state) {
   std::vector<T> values(1024);
   std::vector<uint8_t> heap;
   test::GenerateData(1024, values.data(), &heap);
-  BlockSplitBloomFilter filter;
-  filter.Init(BlockSplitBloomFilter::OptimalNumOfBytes(1024, /*fpp=*/0.05));
+  BlockSplitBloomFilter block_split_bloom_filter;
+  block_split_bloom_filter.Init(
+      BlockSplitBloomFilter::OptimalNumOfBytes(1024, /*fpp=*/0.05));
+  BloomFilter* filter = &block_split_bloom_filter;
+  ::benchmark::DoNotOptimize(filter);
   std::vector<uint64_t> hashes(1024);
-  filter.Hashes(values.data(), static_cast<int>(values.size()), hashes.data());
+  filter->Hashes(values.data(), static_cast<int>(values.size()), hashes.data());
   for (auto _ : state) {
-    filter.InsertHashes(hashes.data(), static_cast<int>(hashes.size()));
+    filter->InsertHashes(hashes.data(), static_cast<int>(hashes.size()));
   }
   state.SetItemsProcessed(state.iterations() * values.size());
 }
@@ -100,14 +112,17 @@ static void BM_FindHash(::benchmark::State& state) {
   std::vector<T> values(1024);
   std::vector<uint8_t> heap;
   test::GenerateData(1024, values.data(), &heap);
-  BlockSplitBloomFilter filter;
-  filter.Init(BlockSplitBloomFilter::OptimalNumOfBytes(1024, /*fpp=*/0.05));
+  BlockSplitBloomFilter block_split_bloom_filter;
+  block_split_bloom_filter.Init(
+      BlockSplitBloomFilter::OptimalNumOfBytes(1024, /*fpp=*/0.05));
+  BloomFilter* filter = &block_split_bloom_filter;
+  ::benchmark::DoNotOptimize(filter);
   std::vector<uint64_t> hashes(1024);
-  filter.Hashes(values.data(), static_cast<int>(values.size()), hashes.data());
-  filter.InsertHashes(hashes.data(), static_cast<int>(hashes.size()));
+  filter->Hashes(values.data(), static_cast<int>(values.size()), hashes.data());
+  filter->InsertHashes(hashes.data(), static_cast<int>(hashes.size()));
   for (auto _ : state) {
     for (auto hash : hashes) {
-      ::benchmark::DoNotOptimize(filter.FindHash(hash));
+      ::benchmark::DoNotOptimize(filter->FindHash(hash));
     }
   }
   state.SetItemsProcessed(state.iterations() * values.size());

--- a/cpp/src/parquet/bloom_filter_benchmark.cc
+++ b/cpp/src/parquet/bloom_filter_benchmark.cc
@@ -1,0 +1,133 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "benchmark/benchmark.h"
+
+#include "parquet/bloom_filter.h"
+#include "parquet/test_util.h"
+
+namespace parquet {
+namespace benchmark {
+
+template <typename DType>
+static void BM_CountHash(::benchmark::State& state) {
+  using T = typename DType::c_type;
+  std::vector<T> values(1024);
+  std::vector<uint8_t> heap;
+  test::GenerateData(1024, values.data(), &heap);
+  BlockSplitBloomFilter filter;
+  filter.Init(BlockSplitBloomFilter::OptimalNumOfBytes(1024, /*fpp=*/0.05));
+  for (auto _ : state) {
+    for (int i = 0; i < 1024; ++i) {
+      if constexpr (std::is_same_v<DType, FLBAType>) {
+        filter.Hash(&values[i], test::kGenerateDataFLBALength);
+      } else {
+        filter.Hash(&values[i]);
+      }
+    }
+  }
+  state.SetItemsProcessed(state.iterations() * values.size());
+}
+
+template <typename DType>
+static void BM_BatchCountHash(::benchmark::State& state) {
+  using T = typename DType::c_type;
+  std::vector<T> values(1024);
+  std::vector<uint8_t> heap;
+  test::GenerateData(1024, values.data(), &heap);
+  BlockSplitBloomFilter filter;
+  filter.Init(BlockSplitBloomFilter::OptimalNumOfBytes(1024, /*fpp=*/0.05));
+  std::vector<uint64_t> hashes(1024);
+  for (auto _ : state) {
+    if constexpr (std::is_same_v<DType, FLBAType>) {
+      filter.Hashes(values.data(), test::kGenerateDataFLBALength,
+                    static_cast<int>(values.size()), hashes.data());
+    } else {
+      filter.Hashes(values.data(), static_cast<int>(values.size()), hashes.data());
+    }
+  }
+  state.SetItemsProcessed(state.iterations() * values.size());
+}
+
+static void BM_InsertHash(::benchmark::State& state) {
+  using T = int32_t;
+  std::vector<T> values(1024);
+  std::vector<uint8_t> heap;
+  test::GenerateData(1024, values.data(), &heap);
+  BlockSplitBloomFilter filter;
+  filter.Init(BlockSplitBloomFilter::OptimalNumOfBytes(1024, /*fpp=*/0.05));
+  std::vector<uint64_t> hashes(1024);
+  filter.Hashes(values.data(), static_cast<int>(values.size()), hashes.data());
+  for (auto _ : state) {
+    for (auto hash : hashes) {
+      filter.InsertHash(hash);
+    }
+  }
+  state.SetItemsProcessed(state.iterations() * values.size());
+}
+
+static void BM_BatchInsertHash(::benchmark::State& state) {
+  using T = int32_t;
+  std::vector<T> values(1024);
+  std::vector<uint8_t> heap;
+  test::GenerateData(1024, values.data(), &heap);
+  BlockSplitBloomFilter filter;
+  filter.Init(BlockSplitBloomFilter::OptimalNumOfBytes(1024, /*fpp=*/0.05));
+  std::vector<uint64_t> hashes(1024);
+  filter.Hashes(values.data(), static_cast<int>(values.size()), hashes.data());
+  for (auto _ : state) {
+    filter.InsertHashes(hashes.data(), static_cast<int>(hashes.size()));
+  }
+  state.SetItemsProcessed(state.iterations() * values.size());
+}
+
+static void BM_FindHash(::benchmark::State& state) {
+  using T = int32_t;
+  std::vector<T> values(1024);
+  std::vector<uint8_t> heap;
+  test::GenerateData(1024, values.data(), &heap);
+  BlockSplitBloomFilter filter;
+  filter.Init(BlockSplitBloomFilter::OptimalNumOfBytes(1024, /*fpp=*/0.05));
+  std::vector<uint64_t> hashes(1024);
+  filter.Hashes(values.data(), static_cast<int>(values.size()), hashes.data());
+  filter.InsertHashes(hashes.data(), static_cast<int>(hashes.size()));
+  for (auto _ : state) {
+    for (auto hash : hashes) {
+      ::benchmark::DoNotOptimize(filter.FindHash(hash));
+    }
+  }
+  state.SetItemsProcessed(state.iterations() * values.size());
+}
+
+BENCHMARK_TEMPLATE(BM_CountHash, Int32Type);
+BENCHMARK_TEMPLATE(BM_CountHash, Int64Type);
+BENCHMARK_TEMPLATE(BM_CountHash, FloatType);
+BENCHMARK_TEMPLATE(BM_CountHash, DoubleType);
+BENCHMARK_TEMPLATE(BM_BatchCountHash, Int32Type);
+BENCHMARK_TEMPLATE(BM_BatchCountHash, Int64Type);
+BENCHMARK_TEMPLATE(BM_BatchCountHash, FloatType);
+BENCHMARK_TEMPLATE(BM_BatchCountHash, DoubleType);
+
+BENCHMARK(BM_InsertHash);
+BENCHMARK(BM_InsertHash);
+BENCHMARK(BM_BatchInsertHash);
+BENCHMARK(BM_BatchInsertHash);
+BENCHMARK(BM_FindHash);
+BENCHMARK(BM_FindHash);
+
+}  // namespace benchmark
+}  // namespace parquet

--- a/cpp/src/parquet/bloom_filter_benchmark.cc
+++ b/cpp/src/parquet/bloom_filter_benchmark.cc
@@ -122,7 +122,7 @@ static void BM_FindHash(::benchmark::State& state) {
   filter->InsertHashes(hashes.data(), static_cast<int>(hashes.size()));
   for (auto _ : state) {
     for (auto hash : hashes) {
-      ::benchmark::DoNotOptimize(filter->FindHash(hash));
+      filter->FindHash(hash);
     }
   }
   state.SetItemsProcessed(state.iterations() * values.size());

--- a/cpp/src/parquet/bloom_filter_test.cc
+++ b/cpp/src/parquet/bloom_filter_test.cc
@@ -396,12 +396,12 @@ TYPED_TEST(TestBatchBloomFilter, Basic) {
       BlockSplitBloomFilter::OptimalNumOfBytes(TestFixture::kTestDataSize, fpp));
 
   std::vector<uint64_t> hashes;
-  for (int i = 0; i < static_cast<int>(test_data.size()); ++i) {
+  for (const Type& value : test_data) {
     uint64_t hash = 0;
     if constexpr (std::is_same_v<Type, FLBA>) {
-      hash = filter.Hash(&test_data[i], kGenerateDataFLBALength);
+      hash = filter.Hash(&value, kGenerateDataFLBALength);
     } else {
-      hash = filter.Hash(&test_data[i]);
+      hash = filter.Hash(&value);
     }
     hashes.push_back(hash);
   }

--- a/cpp/src/parquet/bloom_filter_test.cc
+++ b/cpp/src/parquet/bloom_filter_test.cc
@@ -324,9 +324,10 @@ const int64_t HASHES_OF_LOOPING_BYTES_WITH_SEED_0[32] = {
  * }
  */
 TEST(XxHashTest, TestBloomFilter) {
-  uint8_t bytes[32] = {};
+  constexpr int kNumValues = 32;
+  uint8_t bytes[kNumValues] = {};
 
-  for (int i = 0; i < 32; i++) {
+  for (int i = 0; i < kNumValues; i++) {
     ByteArray byte_array(i, bytes);
     bytes[i] = i;
 
@@ -338,19 +339,20 @@ TEST(XxHashTest, TestBloomFilter) {
 
 // Same as TestBloomFilter but using Batch interface
 TEST(XxHashTest, TestBloomFilterHashes) {
-  uint8_t bytes[32] = {};
+  constexpr int kNumValues = 32;
+  uint8_t bytes[kNumValues] = {};
 
   std::vector<ByteArray> byte_array_vector;
-  for (int i = 0; i < 32; i++) {
+  for (int i = 0; i < kNumValues; i++) {
     bytes[i] = i;
     byte_array_vector.emplace_back(i, bytes);
   }
   auto hasher_seed_0 = std::make_unique<XxHasher>();
   std::vector<uint64_t> hashes;
-  hashes.resize(32);
+  hashes.resize(kNumValues);
   hasher_seed_0->Hashes(byte_array_vector.data(),
                         static_cast<int>(byte_array_vector.size()), hashes.data());
-  for (int i = 0; i < 32; i++) {
+  for (int i = 0; i < kNumValues; i++) {
     EXPECT_EQ(HASHES_OF_LOOPING_BYTES_WITH_SEED_0[i], hashes[i])
         << "Hash with seed 0 Error: " << i;
   }
@@ -359,12 +361,6 @@ TEST(XxHashTest, TestBloomFilterHashes) {
 template <typename DType>
 class TestBatchBloomFilter : public testing::Test {
  public:
-  using T = typename DType::c_type;
-
-  void SetUp() {}
-
-  void TearDown() {}
-
   constexpr static int kStringLength = 8;
   constexpr static int kTestDataSize = 64;
 
@@ -372,7 +368,7 @@ class TestBatchBloomFilter : public testing::Test {
   constexpr static int kTypeLength = 8;
 
   // GenerateTestData with size 64.
-  std::vector<T> GenerateTestData();
+  std::vector<typename DType::c_type> GenerateTestData();
 
   // The Lifetime owner for Test data
   std::vector<std::string> members;
@@ -411,7 +407,7 @@ using BloomFilterTestTypes = ::testing::Types<Int32Type, Int64Type, FloatType, D
 TYPED_TEST_SUITE(TestBatchBloomFilter, BloomFilterTestTypes);
 
 TYPED_TEST(TestBatchBloomFilter, Basic) {
-  using Type = typename TestFixture::T;
+  using Type = typename TypeParam::c_type;
   std::vector<Type> test_data = TestFixture::GenerateTestData();
   BlockSplitBloomFilter batch_insert_filter;
   BlockSplitBloomFilter filter;

--- a/cpp/src/parquet/bloom_filter_test.cc
+++ b/cpp/src/parquet/bloom_filter_test.cc
@@ -361,16 +361,18 @@ class TestBatchBloomFilter : public testing::Test {
  public:
   using T = typename DType::c_type;
 
-  // FLBA Type length
-  constexpr static int kTypeLength = 8;
+  void SetUp() {}
+
+  void TearDown() {}
+
   constexpr static int kStringLength = 8;
   constexpr static int kTestDataSize = 64;
 
+  // FLBA Type length
+  constexpr static int kTypeLength = 8;
+
   // GenerateTestData with size 64.
   std::vector<T> GenerateTestData();
-
-  // Underlying data
-  std::unique_ptr<XxHasher> bloom_filter_hasher;
 
   // The Lifetime owner for Test data
   std::vector<std::string> members;
@@ -403,10 +405,10 @@ std::vector<typename DType::c_type> TestBatchBloomFilter<DType>::GenerateTestDat
   return values;
 }
 
-using TestTypes = ::testing::Types<Int32Type, Int64Type, FloatType, DoubleType, FLBAType,
-                                   ByteArrayType>;
+using BloomFilterTestTypes = ::testing::Types<Int32Type, Int64Type, FloatType, DoubleType,
+                                              FLBAType, ByteArrayType>;
 
-TYPED_TEST_SUITE(TestBatchBloomFilter, TestTypes);
+TYPED_TEST_SUITE(TestBatchBloomFilter, BloomFilterTestTypes);
 
 TYPED_TEST(TestBatchBloomFilter, Basic) {
   using Type = typename TestFixture::T;

--- a/cpp/src/parquet/bloom_filter_test.cc
+++ b/cpp/src/parquet/bloom_filter_test.cc
@@ -429,7 +429,7 @@ TYPED_TEST(TestBatchBloomFilter, Basic) {
     batch_insert_filter.WriteTo(sink.get());
     ASSERT_OK_AND_ASSIGN(batch_insert_buffer, sink->Finish());
   }
-  EXPECT_TRUE(buffer->Equals(*batch_insert_buffer));
+  AssertBufferEqual(*buffer, *batch_insert_buffer);
 }
 
 }  // namespace test

--- a/cpp/src/parquet/bloom_filter_test.cc
+++ b/cpp/src/parquet/bloom_filter_test.cc
@@ -97,7 +97,7 @@ TEST(BasicTest, TestBloomFilter) {
     for (const auto v : kNegativeIntLookups) {
       false_positives += bloom_filter.FindHash(bloom_filter.Hash(v));
     }
-    // (this is a crude check, see FPPTest below for a more rigourous formula)
+    // (this is a crude check, see FPPTest below for a more rigorous formula)
     EXPECT_LE(false_positives, 2);
 
     // Serialize Bloom filter to memory output stream
@@ -326,11 +326,31 @@ TEST(XxHashTest, TestBloomFilter) {
   uint8_t bytes[32] = {};
 
   for (int i = 0; i < 32; i++) {
-    ByteArray byteArray(i, bytes);
+    ByteArray byte_array(i, bytes);
     bytes[i] = i;
 
     auto hasher_seed_0 = std::make_unique<XxHasher>();
-    EXPECT_EQ(HASHES_OF_LOOPING_BYTES_WITH_SEED_0[i], hasher_seed_0->Hash(&byteArray))
+    EXPECT_EQ(HASHES_OF_LOOPING_BYTES_WITH_SEED_0[i], hasher_seed_0->Hash(&byte_array))
+        << "Hash with seed 0 Error: " << i;
+  }
+}
+
+// Same as TestBloomFilter but using Batch interface
+TEST(XxHashTest, TestBloomFilterHashes) {
+  uint8_t bytes[32] = {};
+
+  std::vector<ByteArray> byte_array_vector;
+  for (int i = 0; i < 32; i++) {
+    bytes[i] = i;
+    byte_array_vector.emplace_back(i, bytes);
+  }
+  auto hasher_seed_0 = std::make_unique<XxHasher>();
+  std::vector<uint64_t> hashes;
+  hashes.resize(32);
+  hasher_seed_0->Hashes(byte_array_vector.data(),
+                        static_cast<int>(byte_array_vector.size()), hashes.data());
+  for (int i = 0; i < 32; i++) {
+    EXPECT_EQ(HASHES_OF_LOOPING_BYTES_WITH_SEED_0[i], hashes[i])
         << "Hash with seed 0 Error: " << i;
   }
 }

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -114,52 +114,6 @@ TEST(VectorBooleanTest, TestEncodeIntDecode) {
   }
 }
 
-// ----------------------------------------------------------------------
-// test data generation
-
-template <typename T>
-void GenerateData(int num_values, T* out, std::vector<uint8_t>* heap) {
-  // seed the prng so failure is deterministic
-  random_numbers(num_values, 0, std::numeric_limits<T>::min(),
-                 std::numeric_limits<T>::max(), out);
-}
-
-template <typename T>
-void GenerateBoundData(int num_values, T* out, T min, T max, std::vector<uint8_t>* heap) {
-  // seed the prng so failure is deterministic
-  random_numbers(num_values, 0, min, max, out);
-}
-
-template <>
-void GenerateData<bool>(int num_values, bool* out, std::vector<uint8_t>* heap) {
-  // seed the prng so failure is deterministic
-  random_bools(num_values, 0.5, 0, out);
-}
-
-template <>
-void GenerateData<Int96>(int num_values, Int96* out, std::vector<uint8_t>* heap) {
-  // seed the prng so failure is deterministic
-  random_Int96_numbers(num_values, 0, std::numeric_limits<int32_t>::min(),
-                       std::numeric_limits<int32_t>::max(), out);
-}
-
-template <>
-void GenerateData<ByteArray>(int num_values, ByteArray* out, std::vector<uint8_t>* heap) {
-  // seed the prng so failure is deterministic
-  int max_byte_array_len = 12;
-  heap->resize(num_values * max_byte_array_len);
-  random_byte_array(num_values, 0, heap->data(), out, 2, max_byte_array_len);
-}
-
-static int flba_length = 8;
-
-template <>
-void GenerateData<FLBA>(int num_values, FLBA* out, std::vector<uint8_t>* heap) {
-  // seed the prng so failure is deterministic
-  heap->resize(num_values * flba_length);
-  random_fixed_byte_array(num_values, 0, heap->data(), flba_length, out);
-}
-
 template <typename T>
 void VerifyResults(T* result, T* expected, int num_values) {
   for (int i = 0; i < num_values; ++i) {
@@ -180,7 +134,7 @@ void VerifyResultsSpaced(T* result, T* expected, int num_values,
 template <>
 void VerifyResults<FLBA>(FLBA* result, FLBA* expected, int num_values) {
   for (int i = 0; i < num_values; ++i) {
-    ASSERT_EQ(0, memcmp(expected[i].ptr, result[i].ptr, flba_length)) << i;
+    ASSERT_EQ(0, memcmp(expected[i].ptr, result[i].ptr, kGenerateDataFLBALength)) << i;
   }
 }
 
@@ -189,7 +143,7 @@ void VerifyResultsSpaced<FLBA>(FLBA* result, FLBA* expected, int num_values,
                                const uint8_t* valid_bits, int64_t valid_bits_offset) {
   for (auto i = 0; i < num_values; ++i) {
     if (bit_util::GetBit(valid_bits, valid_bits_offset + i)) {
-      ASSERT_EQ(0, memcmp(expected[i].ptr, result[i].ptr, flba_length)) << i;
+      ASSERT_EQ(0, memcmp(expected[i].ptr, result[i].ptr, kGenerateDataFLBALength)) << i;
     }
   }
 }
@@ -207,7 +161,7 @@ template <>
 std::shared_ptr<ColumnDescriptor> ExampleDescr<FLBAType>() {
   auto node = schema::PrimitiveNode::Make("name", Repetition::OPTIONAL,
                                           Type::FIXED_LEN_BYTE_ARRAY,
-                                          ConvertedType::DECIMAL, flba_length, 10, 2);
+                                          ConvertedType::DECIMAL, kGenerateDataFLBALength, 10, 2);
   return std::make_shared<ColumnDescriptor>(node, 0, 0);
 }
 

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -159,9 +159,9 @@ std::shared_ptr<ColumnDescriptor> ExampleDescr() {
 
 template <>
 std::shared_ptr<ColumnDescriptor> ExampleDescr<FLBAType>() {
-  auto node = schema::PrimitiveNode::Make("name", Repetition::OPTIONAL,
-                                          Type::FIXED_LEN_BYTE_ARRAY,
-                                          ConvertedType::DECIMAL, kGenerateDataFLBALength, 10, 2);
+  auto node = schema::PrimitiveNode::Make(
+      "name", Repetition::OPTIONAL, Type::FIXED_LEN_BYTE_ARRAY, ConvertedType::DECIMAL,
+      kGenerateDataFLBALength, 10, 2);
   return std::make_shared<ColumnDescriptor>(node, 0, 0);
 }
 

--- a/cpp/src/parquet/hasher.h
+++ b/cpp/src/parquet/hasher.h
@@ -66,6 +66,58 @@ class Hasher {
   /// @param len the value length.
   virtual uint64_t Hash(const FLBA* value, uint32_t len) const = 0;
 
+  /// Batch compute hashes for 32 bits values by using its plain encoding result.
+  ///
+  /// @param values the value to hash.
+  /// @param num_values the number of values to hash.
+  /// @param hashes the output hash value, it length should be equal to num_values.
+  virtual void Hashes(const int32_t* values, int num_values, uint64_t* hashes) const = 0;
+
+  /// Batch compute hashes for 64 bits values by using its plain encoding result.
+  ///
+  /// @param values the value to hash.
+  /// @param num_values the number of values to hash.
+  /// @param hashes the output hash value, it length should be equal to num_values.
+  virtual void Hashes(const int64_t* values, int num_values, uint64_t* hashes) const = 0;
+
+  /// Batch compute hashes for float values by using its plain encoding result.
+  ///
+  /// @param values the value to hash.
+  /// @param num_values the number of values to hash.
+  /// @param hashes the output hash value, it length should be equal to num_values.
+  virtual void Hashes(const float* values, int num_values, uint64_t* hashes) const = 0;
+
+  /// Batch compute hashes for double values by using its plain encoding result.
+  ///
+  /// @param values the value to hash.
+  /// @param num_values the number of values to hash.
+  /// @param hashes the output hash value, it length should be equal to num_values.
+  virtual void Hashes(const double* values, int num_values, uint64_t* hashes) const = 0;
+
+  /// Batch compute hashes for Int96 values by using its plain encoding result.
+  ///
+  /// @param values the value to hash.
+  /// @param num_values the number of values to hash.
+  /// @param hashes the output hash value, it length should be equal to num_values.
+  virtual void Hashes(const Int96* values, int num_values, uint64_t* hashes) const = 0;
+
+  /// Batch compute hashes for ByteArray values by using its plain encoding result.
+  ///
+  /// @param values the value to hash.
+  /// @param num_values the number of values to hash.
+  /// @param hashes the output hash value, it length should be equal to num_values.
+  virtual void Hashes(const ByteArray* values, int num_values,
+                      uint64_t* hashes) const = 0;
+
+  /// Batch compute hashes for fixed byte array values by using its plain encoding result.
+  ///
+  /// @param values the value address.
+  /// @param type_len the value length.
+  /// @param num_values the number of values to hash.
+  /// @param hashes the output hash value, it length should be equal to num_values.
+  virtual void Hashes(const FLBA* values, uint32_t type_len, int num_values,
+                      uint64_t* hashes) const = 0;
+
   virtual ~Hasher() = default;
 };
 

--- a/cpp/src/parquet/hasher.h
+++ b/cpp/src/parquet/hasher.h
@@ -68,44 +68,44 @@ class Hasher {
 
   /// Batch compute hashes for 32 bits values by using its plain encoding result.
   ///
-  /// @param values the value to hash.
+  /// @param values a pointer to the values to hash.
   /// @param num_values the number of values to hash.
-  /// @param hashes the output hash value, it length should be equal to num_values.
+  /// @param hashes a pointer to the output hash values, its length should be equal to num_values.
   virtual void Hashes(const int32_t* values, int num_values, uint64_t* hashes) const = 0;
 
   /// Batch compute hashes for 64 bits values by using its plain encoding result.
   ///
-  /// @param values the value to hash.
+  /// @param values a pointer to the values to hash.
   /// @param num_values the number of values to hash.
-  /// @param hashes the output hash value, it length should be equal to num_values.
+  /// @param hashes a pointer to the output hash values, its length should be equal to num_values.
   virtual void Hashes(const int64_t* values, int num_values, uint64_t* hashes) const = 0;
 
   /// Batch compute hashes for float values by using its plain encoding result.
   ///
-  /// @param values the value to hash.
+  /// @param values a pointer to the values to hash.
   /// @param num_values the number of values to hash.
-  /// @param hashes the output hash value, it length should be equal to num_values.
+  /// @param hashes a pointer to the output hash values, its length should be equal to num_values.
   virtual void Hashes(const float* values, int num_values, uint64_t* hashes) const = 0;
 
   /// Batch compute hashes for double values by using its plain encoding result.
   ///
-  /// @param values the value to hash.
+  /// @param values a pointer to the values to hash.
   /// @param num_values the number of values to hash.
-  /// @param hashes the output hash value, it length should be equal to num_values.
+  /// @param hashes a pointer to the output hash values, its length should be equal to num_values.
   virtual void Hashes(const double* values, int num_values, uint64_t* hashes) const = 0;
 
   /// Batch compute hashes for Int96 values by using its plain encoding result.
   ///
-  /// @param values the value to hash.
+  /// @param values a pointer to the values to hash.
   /// @param num_values the number of values to hash.
-  /// @param hashes the output hash value, it length should be equal to num_values.
+  /// @param hashes a pointer to the output hash values, its length should be equal to num_values.
   virtual void Hashes(const Int96* values, int num_values, uint64_t* hashes) const = 0;
 
   /// Batch compute hashes for ByteArray values by using its plain encoding result.
   ///
-  /// @param values the value to hash.
+  /// @param values a pointer to the values to hash.
   /// @param num_values the number of values to hash.
-  /// @param hashes the output hash value, it length should be equal to num_values.
+  /// @param hashes a pointer to the output hash values, its length should be equal to num_values.
   virtual void Hashes(const ByteArray* values, int num_values,
                       uint64_t* hashes) const = 0;
 
@@ -114,7 +114,7 @@ class Hasher {
   /// @param values the value address.
   /// @param type_len the value length.
   /// @param num_values the number of values to hash.
-  /// @param hashes the output hash value, it length should be equal to num_values.
+  /// @param hashes a pointer to the output hash values, its length should be equal to num_values.
   virtual void Hashes(const FLBA* values, uint32_t type_len, int num_values,
                       uint64_t* hashes) const = 0;
 

--- a/cpp/src/parquet/hasher.h
+++ b/cpp/src/parquet/hasher.h
@@ -70,42 +70,48 @@ class Hasher {
   ///
   /// @param values a pointer to the values to hash.
   /// @param num_values the number of values to hash.
-  /// @param hashes a pointer to the output hash values, its length should be equal to num_values.
+  /// @param hashes a pointer to the output hash values, its length should be equal to
+  /// num_values.
   virtual void Hashes(const int32_t* values, int num_values, uint64_t* hashes) const = 0;
 
   /// Batch compute hashes for 64 bits values by using its plain encoding result.
   ///
   /// @param values a pointer to the values to hash.
   /// @param num_values the number of values to hash.
-  /// @param hashes a pointer to the output hash values, its length should be equal to num_values.
+  /// @param hashes a pointer to the output hash values, its length should be equal to
+  /// num_values.
   virtual void Hashes(const int64_t* values, int num_values, uint64_t* hashes) const = 0;
 
   /// Batch compute hashes for float values by using its plain encoding result.
   ///
   /// @param values a pointer to the values to hash.
   /// @param num_values the number of values to hash.
-  /// @param hashes a pointer to the output hash values, its length should be equal to num_values.
+  /// @param hashes a pointer to the output hash values, its length should be equal to
+  /// num_values.
   virtual void Hashes(const float* values, int num_values, uint64_t* hashes) const = 0;
 
   /// Batch compute hashes for double values by using its plain encoding result.
   ///
   /// @param values a pointer to the values to hash.
   /// @param num_values the number of values to hash.
-  /// @param hashes a pointer to the output hash values, its length should be equal to num_values.
+  /// @param hashes a pointer to the output hash values, its length should be equal to
+  /// num_values.
   virtual void Hashes(const double* values, int num_values, uint64_t* hashes) const = 0;
 
   /// Batch compute hashes for Int96 values by using its plain encoding result.
   ///
   /// @param values a pointer to the values to hash.
   /// @param num_values the number of values to hash.
-  /// @param hashes a pointer to the output hash values, its length should be equal to num_values.
+  /// @param hashes a pointer to the output hash values, its length should be equal to
+  /// num_values.
   virtual void Hashes(const Int96* values, int num_values, uint64_t* hashes) const = 0;
 
   /// Batch compute hashes for ByteArray values by using its plain encoding result.
   ///
   /// @param values a pointer to the values to hash.
   /// @param num_values the number of values to hash.
-  /// @param hashes a pointer to the output hash values, its length should be equal to num_values.
+  /// @param hashes a pointer to the output hash values, its length should be equal to
+  /// num_values.
   virtual void Hashes(const ByteArray* values, int num_values,
                       uint64_t* hashes) const = 0;
 
@@ -114,7 +120,8 @@ class Hasher {
   /// @param values the value address.
   /// @param type_len the value length.
   /// @param num_values the number of values to hash.
-  /// @param hashes a pointer to the output hash values, its length should be equal to num_values.
+  /// @param hashes a pointer to the output hash values, its length should be equal to
+  /// num_values.
   virtual void Hashes(const FLBA* values, uint32_t type_len, int num_values,
                       uint64_t* hashes) const = 0;
 

--- a/cpp/src/parquet/level_conversion.cc
+++ b/cpp/src/parquet/level_conversion.cc
@@ -82,7 +82,7 @@ void DefRepLevelsToListInfo(const int16_t* def_levels, const int16_t* rep_levels
       // offsets until we get to the children).
       if (offsets != nullptr) {
         ++offsets;
-        // Use cumulative offsets because variable size lists are more common then
+        // Use cumulative offsets because variable size lists are more common than
         // fixed size lists so it should be cheaper to make these cumulative and
         // subtract when validating fixed size lists.
         *offsets = *(offsets - 1);

--- a/cpp/src/parquet/level_conversion.h
+++ b/cpp/src/parquet/level_conversion.h
@@ -151,7 +151,7 @@ struct PARQUET_EXPORT ValidityBitmapInputOutput {
   int64_t values_read = 0;
   // Input/Output. The number of nulls encountered.
   int64_t null_count = 0;
-  // Output only. The validity bitmap to populate. May be be null only
+  // Output only. The validity bitmap to populate. Maybe be null only
   // for DefRepLevelsToListInfo (if all that is needed is list offsets).
   uint8_t* valid_bits = NULLPTR;
   // Input only, offset into valid_bits to start at.

--- a/cpp/src/parquet/test_util.h
+++ b/cpp/src/parquet/test_util.h
@@ -744,5 +744,52 @@ inline void PrimitiveTypedTest<BooleanType>::GenerateData(int64_t num_values,
   std::fill(def_levels_.begin(), def_levels_.end(), 1);
 }
 
+// ----------------------------------------------------------------------
+// test data generation
+
+template <typename T>
+inline void GenerateData(int num_values, T* out, std::vector<uint8_t>* heap) {
+  // seed the prng so failure is deterministic
+  random_numbers(num_values, 0, std::numeric_limits<T>::min(),
+                 std::numeric_limits<T>::max(), out);
+}
+
+template <typename T>
+inline void GenerateBoundData(int num_values, T* out, T min, T max, std::vector<uint8_t>* heap) {
+  // seed the prng so failure is deterministic
+  random_numbers(num_values, 0, min, max, out);
+}
+
+template <>
+inline void GenerateData<bool>(int num_values, bool* out, std::vector<uint8_t>* heap) {
+  // seed the prng so failure is deterministic
+  random_bools(num_values, 0.5, 0, out);
+}
+
+template <>
+inline void GenerateData<Int96>(int num_values, Int96* out, std::vector<uint8_t>* heap) {
+  // seed the prng so failure is deterministic
+  random_Int96_numbers(num_values, 0, std::numeric_limits<int32_t>::min(),
+                       std::numeric_limits<int32_t>::max(), out);
+}
+
+template <>
+inline void GenerateData<ByteArray>(int num_values, ByteArray* out, std::vector<uint8_t>* heap) {
+  // seed the prng so failure is deterministic
+  int max_byte_array_len = 12;
+  heap->resize(num_values * max_byte_array_len);
+  random_byte_array(num_values, 0, heap->data(), out, 2, max_byte_array_len);
+}
+
+static constexpr int kGenerateDataFLBALength = 8;
+
+template <>
+inline void GenerateData<FLBA>(int num_values, FLBA* out, std::vector<uint8_t>* heap) {
+  // seed the prng so failure is deterministic
+  heap->resize(num_values * kGenerateDataFLBALength);
+  random_fixed_byte_array(num_values, 0, heap->data(), kGenerateDataFLBALength, out);
+}
+
+
 }  // namespace test
 }  // namespace parquet

--- a/cpp/src/parquet/test_util.h
+++ b/cpp/src/parquet/test_util.h
@@ -755,7 +755,8 @@ inline void GenerateData(int num_values, T* out, std::vector<uint8_t>* heap) {
 }
 
 template <typename T>
-inline void GenerateBoundData(int num_values, T* out, T min, T max, std::vector<uint8_t>* heap) {
+inline void GenerateBoundData(int num_values, T* out, T min, T max,
+                              std::vector<uint8_t>* heap) {
   // seed the prng so failure is deterministic
   random_numbers(num_values, 0, min, max, out);
 }
@@ -774,7 +775,8 @@ inline void GenerateData<Int96>(int num_values, Int96* out, std::vector<uint8_t>
 }
 
 template <>
-inline void GenerateData<ByteArray>(int num_values, ByteArray* out, std::vector<uint8_t>* heap) {
+inline void GenerateData<ByteArray>(int num_values, ByteArray* out,
+                                    std::vector<uint8_t>* heap) {
   // seed the prng so failure is deterministic
   int max_byte_array_len = 12;
   heap->resize(num_values * max_byte_array_len);
@@ -789,7 +791,6 @@ inline void GenerateData<FLBA>(int num_values, FLBA* out, std::vector<uint8_t>* 
   heap->resize(num_values * kGenerateDataFLBALength);
   random_fixed_byte_array(num_values, 0, heap->data(), kGenerateDataFLBALength, out);
 }
-
 
 }  // namespace test
 }  // namespace parquet

--- a/cpp/src/parquet/xxhasher.cc
+++ b/cpp/src/parquet/xxhasher.cc
@@ -29,9 +29,9 @@ uint64_t XxHashHelper(T value, uint32_t seed) {
 }
 
 template <typename T>
-void XxHashesHelper(const T* value, uint32_t seed, int num_values, uint64_t* results) {
+void XxHashesHelper(const T* values, uint32_t seed, int num_values, uint64_t* results) {
   for (int i = 0; i < num_values; ++i) {
-    results[i] = XxHashHelper(value[i], seed);
+    results[i] = XxHashHelper(values[i], seed);
   }
 }
 

--- a/cpp/src/parquet/xxhasher.cc
+++ b/cpp/src/parquet/xxhasher.cc
@@ -27,6 +27,14 @@ template <typename T>
 uint64_t XxHashHelper(T value, uint32_t seed) {
   return XXH64(reinterpret_cast<const void*>(&value), sizeof(T), seed);
 }
+
+template <typename T>
+void XxHashesHelper(const T* value, uint32_t seed, int num_values, uint64_t* results) {
+  for (int i = 0; i < num_values; ++i) {
+    results[i] = XxHashHelper(value[i], seed);
+  }
+}
+
 }  // namespace
 
 uint64_t XxHasher::Hash(int32_t value) const {
@@ -57,6 +65,35 @@ uint64_t XxHasher::Hash(const Int96* value) const {
 uint64_t XxHasher::Hash(const ByteArray* value) const {
   return XXH64(reinterpret_cast<const void*>(value->ptr), value->len,
                kParquetBloomXxHashSeed);
+}
+
+void XxHasher::Hashes(const int32_t* values, int num_values, uint64_t* hashes) const {
+  XxHashesHelper(values, kParquetBloomXxHashSeed, num_values, hashes);
+}
+void XxHasher::Hashes(const int64_t* values, int num_values, uint64_t* hashes) const {
+  XxHashesHelper(values, kParquetBloomXxHashSeed, num_values, hashes);
+}
+void XxHasher::Hashes(const float* values, int num_values, uint64_t* hashes) const {
+  XxHashesHelper(values, kParquetBloomXxHashSeed, num_values, hashes);
+}
+void XxHasher::Hashes(const double* values, int num_values, uint64_t* hashes) const {
+  XxHashesHelper(values, kParquetBloomXxHashSeed, num_values, hashes);
+}
+void XxHasher::Hashes(const Int96* values, int num_values, uint64_t* hashes) const {
+  for (int i = 0; i < num_values; ++i) {
+    hashes[i] = XXH64(reinterpret_cast<const void*>(values[i].value),
+                      sizeof(values[i].value), kParquetBloomXxHashSeed);
+  }
+}
+void XxHasher::Hashes(const ByteArray* values, int num_values, uint64_t* hashes) const {
+  XxHashesHelper(values, kParquetBloomXxHashSeed, num_values, hashes);
+}
+void XxHasher::Hashes(const FLBA* values, uint32_t type_len, int num_values,
+                      uint64_t* hashes) const {
+  for (int i = 0; i < num_values; ++i) {
+    hashes[i] = XXH64(reinterpret_cast<const void*>(values[i].ptr), type_len,
+                      kParquetBloomXxHashSeed);
+  }
 }
 
 }  // namespace parquet

--- a/cpp/src/parquet/xxhasher.cc
+++ b/cpp/src/parquet/xxhasher.cc
@@ -70,24 +70,33 @@ uint64_t XxHasher::Hash(const ByteArray* value) const {
 void XxHasher::Hashes(const int32_t* values, int num_values, uint64_t* hashes) const {
   XxHashesHelper(values, kParquetBloomXxHashSeed, num_values, hashes);
 }
+
 void XxHasher::Hashes(const int64_t* values, int num_values, uint64_t* hashes) const {
   XxHashesHelper(values, kParquetBloomXxHashSeed, num_values, hashes);
 }
+
 void XxHasher::Hashes(const float* values, int num_values, uint64_t* hashes) const {
   XxHashesHelper(values, kParquetBloomXxHashSeed, num_values, hashes);
 }
+
 void XxHasher::Hashes(const double* values, int num_values, uint64_t* hashes) const {
   XxHashesHelper(values, kParquetBloomXxHashSeed, num_values, hashes);
 }
+
 void XxHasher::Hashes(const Int96* values, int num_values, uint64_t* hashes) const {
   for (int i = 0; i < num_values; ++i) {
     hashes[i] = XXH64(reinterpret_cast<const void*>(values[i].value),
                       sizeof(values[i].value), kParquetBloomXxHashSeed);
   }
 }
+
 void XxHasher::Hashes(const ByteArray* values, int num_values, uint64_t* hashes) const {
-  XxHashesHelper(values, kParquetBloomXxHashSeed, num_values, hashes);
+  for (int i = 0; i < num_values; ++i) {
+    hashes[i] = XXH64(reinterpret_cast<const void*>(values[i].ptr), values[i].len,
+                      kParquetBloomXxHashSeed);
+  }
 }
+
 void XxHasher::Hashes(const FLBA* values, uint32_t type_len, int num_values,
                       uint64_t* hashes) const {
   for (int i = 0; i < num_values; ++i) {

--- a/cpp/src/parquet/xxhasher.h
+++ b/cpp/src/parquet/xxhasher.h
@@ -35,6 +35,15 @@ class PARQUET_EXPORT XxHasher : public Hasher {
   uint64_t Hash(const ByteArray* value) const override;
   uint64_t Hash(const FLBA* val, uint32_t len) const override;
 
+  void Hashes(const int32_t* values, int num_values, uint64_t* hashes) const override;
+  void Hashes(const int64_t* values, int num_values, uint64_t* hashes) const override;
+  void Hashes(const float* values, int num_values, uint64_t* hashes) const override;
+  void Hashes(const double* values, int num_values, uint64_t* hashes) const override;
+  void Hashes(const Int96* values, int num_values, uint64_t* hashes) const override;
+  void Hashes(const ByteArray* values, int num_values, uint64_t* hashes) const override;
+  void Hashes(const FLBA* values, uint32_t type_len, int num_values,
+              uint64_t* hashes) const override;
+
   static constexpr int kParquetBloomXxHashSeed = 0;
 };
 


### PR DESCRIPTION
### Rationale for this change

For optimizing https://github.com/apache/arrow/pull/35691 . We need batch execution for BloomFilter

### What changes are included in this PR?

* Add `InsertHashes` and `Hashes` for BloomFilter
* Make `BloomFilter::Find` faster by inlining the bitmask computation inside the loop

* Closes: #35729