### PR TITLE
GH-35733: [Java] Fix minor type in IntervalMonthDayNanoVector ctor

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/IntervalMonthDayNanoVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/IntervalMonthDayNanoVector.java
@@ -57,7 +57,7 @@ public final class IntervalMonthDayNanoVector extends BaseFixedWidthVector {
    * @param allocator allocator for memory management.
    */
   public IntervalMonthDayNanoVector(String name, BufferAllocator allocator) {
-    this(name, FieldType.nullable(MinorType.INTERVALDAY.getType()), allocator);
+    this(name, FieldType.nullable(MinorType.INTERVALMONTHDAYNANO.getType()), allocator);
   }
 
   /**

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestIntervalMonthDayNanoVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestIntervalMonthDayNanoVector.java
@@ -26,6 +26,9 @@ import java.time.Period;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.holders.IntervalMonthDayNanoHolder;
 import org.apache.arrow.vector.holders.NullableIntervalMonthDayNanoHolder;
+import org.apache.arrow.vector.types.IntervalUnit;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -94,6 +97,12 @@ public class TestIntervalMonthDayNanoVector {
 
       assertEquals(0, vector.isSet(1));
       assertEquals(1, vector.isSet(2));
+
+      assertEquals(Types.MinorType.INTERVALMONTHDAYNANO, vector.getMinorType());
+      ArrowType fieldType = vector.getField().getType();
+      assertEquals(ArrowType.ArrowTypeID.Interval, fieldType.getTypeID());
+      ArrowType.Interval intervalType = (ArrowType.Interval) fieldType;
+      assertEquals(IntervalUnit.MONTH_DAY_NANO, intervalType.getUnit());
     }
   }
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestIntervalYearVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestIntervalYearVector.java
@@ -20,6 +20,9 @@ package org.apache.arrow.vector;
 import static org.junit.Assert.assertEquals;
 
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.types.IntervalUnit;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -53,6 +56,11 @@ public class TestIntervalYearVector {
       assertEquals("1 year 8 months ", vector.getAsStringBuilder(20).toString());
       assertEquals("2 years 6 months ", vector.getAsStringBuilder(30).toString());
 
+      assertEquals(Types.MinorType.INTERVALYEAR, vector.getMinorType());
+      ArrowType fieldType = vector.getField().getType();
+      assertEquals(ArrowType.ArrowTypeID.Interval, fieldType.getTypeID());
+      ArrowType.Interval intervalType = (ArrowType.Interval) fieldType;
+      assertEquals(IntervalUnit.YEAR_MONTH, intervalType.getUnit());
     }
   }
 }


### PR DESCRIPTION
### Rationale for this change

The constructor of IntervalMonthDayNanoVector does not set minor type correctly.

```java
  public IntervalMonthDayNanoVector(String name, BufferAllocator allocator) {
    this(name, FieldType.nullable(MinorType.INTERVALDAY.getType()), allocator);
  }
```

It should be `MinorType.INTERVALMONTHDAYNANO`.

### What changes are included in this PR?

Change it to set `MinorType.INTERVALMONTHDAYNANO`.

### Are these changes tested?

Added test to verify vector type.

### Are there any user-facing changes?

No.
* Closes: #35733