### PR TITLE
GH-35736: [C++] Fix compile key_map_avx2.cc

### DIFF
--- a/cpp/src/arrow/compute/key_map_avx2.cc
+++ b/cpp/src/arrow/compute/key_map_avx2.cc
@@ -18,6 +18,7 @@
 #include <immintrin.h>
 
 #include "arrow/compute/key_map.h"
+#include "arrow/util/logging.h"
 
 namespace arrow {
 namespace compute {


### PR DESCRIPTION
Add missing include for `ARROW_DCHECK`.

* Closes: #35736