### PR TITLE
MINOR: [CI][C++] Make ASan job faster

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -49,7 +49,7 @@ permissions:
   contents: read
 
 env:
-  ARROW_ENABLE_TIMING_TESTS: "OFF"
+  ARROW_ENABLE_TIMING_TESTS: OFF
   DOCKER_VOLUME_PREFIX: ".docker/"
 
 jobs:

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -49,7 +49,7 @@ permissions:
   contents: read
 
 env:
-  ARROW_ENABLE_TIMING_TESTS: OFF
+  ARROW_ENABLE_TIMING_TESTS: "OFF"
   DOCKER_VOLUME_PREFIX: ".docker/"
 
 jobs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -586,6 +586,8 @@ services:
       <<: *ccache
       CC: clang-${CLANG_TOOLS}
       CXX: clang++-${CLANG_TOOLS}
+      # Avoid creating huge static libraries
+      ARROW_BUILD_STATIC: "OFF"
       ARROW_ENABLE_TIMING_TESTS:  # inherit
       # GH-33920: Disable Flight SQL to reduce build time.
       # We'll be able to re-enable this with Ubuntu 24.04 because
@@ -598,6 +600,8 @@ services:
       ARROW_S3: "OFF"
       ARROW_USE_ASAN: "ON"
       ARROW_USE_UBSAN: "ON"
+      # 1 GB isn't enough for a single sanitizer build
+      CCACHE_MAXSIZE: 2G
       Protobuf_SOURCE: "AUTO"
     command: *cpp-command
 


### PR DESCRIPTION
ASAN + UBSAN massively increase the generated code size.

The default compile cache size (1 GB) wasn't sufficient to hold all generated outputs, therefore the cache hit rate would be close to 0% (a cached object would be evicted before the first time it could be requested again).

Also, save 5GB in the build directory by disabling static libraries.
