### PR TITLE
GH-35752: [CI][GLib][Ruby] Pass GITHUB_ACTIONS environment variable to Docker containers

### DIFF
--- a/c_glib/README.md
+++ b/c_glib/README.md
@@ -67,9 +67,9 @@ GLib (replace the version number in the following commands with the
 one you use):
 
 ```console
-% wget https://downloads.apache.org/arrow/arrow-3.0.0/apache-arrow-3.0.0.tar.gz
-% tar xf apache-arrow-3.0.0.tar.gz
-% cd apache-arrow-3.0.0
+$ wget 'https://www.apache.org/dyn/closer.lua?action=download&filename=arrow/arrow-12.0.0/apache-arrow-12.0.0.tar.gz'
+$ tar xf apache-arrow-12.0.0.tar.gz
+$ cd apache-arrow-12.0.0
 ```
 
 You need to build and install Arrow C++ before you build and install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -712,6 +712,7 @@ services:
     environment:
       <<: *ccache
       BUILD_DOCS_C_GLIB: "ON"
+      GITHUB_ACTIONS:
     volumes: *debian-volumes
     command: &c-glib-command >
       /bin/bash -c "
@@ -739,6 +740,7 @@ services:
     ulimits: *ulimits
     environment:
       <<: *ccache
+      GITHUB_ACTIONS:
     volumes: *ubuntu-volumes
     command: *c-glib-command
 
@@ -770,6 +772,7 @@ services:
     environment:
       <<: *ccache
       BUILD_DOCS_C_GLIB: "ON"
+      GITHUB_ACTIONS:
     volumes: *debian-volumes
     command: &ruby-command >
       /bin/bash -c "
@@ -799,6 +802,7 @@ services:
     ulimits: *ulimits
     environment:
       <<: *ccache
+      GITHUB_ACTIONS:
     volumes: *ubuntu-volumes
     command: *ruby-command
 


### PR DESCRIPTION
### Rationale for this change

It's for choosing GitHub Actions suitable output automatically.

test-unit gem checks `GITHUB_ACTIONS=true` and the environment variable is set by GitHub Actions automatically.

### What changes are included in this PR?

Add `GITHUB_ACTIONS:` to `environment:`.

`c_glib/README.md` is updated to run CI jobs.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #35752