### PR TITLE
GH-35754: [CI][GLib] Don't build static C++ libraries

### DIFF
--- a/ci/docker/linux-apt-c-glib.dockerfile
+++ b/ci/docker/linux-apt-c-glib.dockerfile
@@ -58,6 +58,7 @@ RUN (python3 -m pip install meson || \
 COPY c_glib/Gemfile /arrow/c_glib/
 RUN bundle install --gemfile /arrow/c_glib/Gemfile
 
-ENV ARROW_BUILD_TESTS=OFF \
+ENV ARROW_BUILD_STATIC=OFF \
+    ARROW_BUILD_TESTS=OFF \
     ARROW_BUILD_UTILITIES=OFF \
     ARROW_INSTALL_NAME_RPATH=OFF


### PR DESCRIPTION
### Rationale for this change

GLib doesn't use static C++ libraries. 

### What changes are included in this PR?

Disable building static C++ libraries.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #35754