### PR TITLE
GH-35763: [Go] Fix TypeEqual for lists

### DIFF
--- a/go/arrow/compare.go
+++ b/go/arrow/compare.go
@@ -58,16 +58,16 @@ func TypeEqual(left, right DataType, opts ...TypeEqualOption) bool {
 		if !TypeEqual(l.Elem(), right.(*ListType).Elem(), opts...) {
 			return false
 		}
-		if cfg.metadata {
-			return l.elem.Metadata.Equal(right.(*ListType).elem.Metadata)
+		if cfg.metadata && !l.elem.Metadata.Equal(right.(*ListType).elem.Metadata) {
+			return false
 		}
 		return l.elem.Nullable == right.(*ListType).elem.Nullable
 	case *FixedSizeListType:
 		if !TypeEqual(l.Elem(), right.(*FixedSizeListType).Elem(), opts...) {
 			return false
 		}
-		if cfg.metadata {
-			return l.elem.Metadata.Equal(right.(*FixedSizeListType).elem.Metadata)
+		if cfg.metadata && !l.elem.Metadata.Equal(right.(*FixedSizeListType).elem.Metadata) {
+			return false
 		}
 		return l.n == right.(*FixedSizeListType).n && l.elem.Nullable == right.(*FixedSizeListType).elem.Nullable
 	case *StructType:

--- a/go/arrow/compare_test.go
+++ b/go/arrow/compare_test.go
@@ -99,6 +99,18 @@ func TestTypeEqual(t *testing.T) {
 			&ListType{elem: Field{Type: &ListType{elem: Field{Type: &ListType{elem: Field{Type: PrimitiveTypes.Uint16}}}}}}, &ListType{elem: Field{Type: &ListType{elem: Field{Type: PrimitiveTypes.Uint8}}}}, false, false,
 		},
 		{
+			&ListType{elem: Field{Type: PrimitiveTypes.Uint64, Nullable: true}}, &ListType{elem: Field{Type: PrimitiveTypes.Uint64, Nullable: false}}, false, true,
+		},
+		{
+			&FixedSizeListType{n: 2, elem: Field{Type: PrimitiveTypes.Uint64, Nullable: false}}, &FixedSizeListType{n: 3, elem: Field{Type: PrimitiveTypes.Uint64, Nullable: false}}, false, true,
+		},
+		{
+			&FixedSizeListType{n: 2, elem: Field{Type: PrimitiveTypes.Uint64, Nullable: false}}, &FixedSizeListType{n: 2, elem: Field{Type: PrimitiveTypes.Uint64, Nullable: false}}, true, true,
+		},
+		{
+			&FixedSizeListType{n: 2, elem: Field{Type: PrimitiveTypes.Uint64, Nullable: false}}, &FixedSizeListType{n: 2, elem: Field{Type: PrimitiveTypes.Uint64, Nullable: true}}, false, true,
+		},
+		{
 			&StructType{
 				fields: []Field{
 					{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true},


### PR DESCRIPTION
This fixes an edge case for list comparisons where TypeEqual would return true even when the nullability of the lists differed.
* Closes: #35763