### PR TITLE
GH-34784: [Go] Fix 32-bit build

### DIFF
--- a/go/arrow/cdata/cdata.go
+++ b/go/arrow/cdata/cdata.go
@@ -100,12 +100,12 @@ var formatToSimpleType = map[string]arrow.DataType{
 
 // decode metadata from C which is encoded as
 //
-//  [int32] -> number of metadata pairs
-//	for 0..n
-//		[int32] -> number of bytes in key
-//		[n bytes] -> key value
-//		[int32] -> number of bytes in value
-//		[n bytes] -> value
+//	 [int32] -> number of metadata pairs
+//		for 0..n
+//			[int32] -> number of bytes in key
+//			[n bytes] -> key value
+//			[int32] -> number of bytes in value
+//			[n bytes] -> value
 func decodeCMetadata(md *C.char) arrow.Metadata {
 	if md == nil {
 		return arrow.Metadata{}
@@ -413,8 +413,7 @@ func (imp *cimporter) doImport(src *CArrowArray) error {
 
 	if imp.arr.n_buffers > 0 {
 		// get a view of the buffers, zero-copy. we're just looking at the pointers
-		const maxlen = 0x7fffffff
-		imp.cbuffers = (*[maxlen]*C.void)(unsafe.Pointer(imp.arr.buffers))[:imp.arr.n_buffers:imp.arr.n_buffers]
+		imp.cbuffers = unsafe.Slice((**C.void)(unsafe.Pointer(imp.arr.buffers)), imp.arr.n_buffers)
 	}
 
 	// handle each of our type cases

--- a/go/arrow/compute/internal/exec/utils.go
+++ b/go/arrow/compute/internal/exec/utils.go
@@ -239,21 +239,21 @@ func RechunkArraysConsistently(groups [][]arrow.Array) [][]arrow.Array {
 	}
 
 	rechunked := make([][]arrow.Array, len(groups))
-	offsets := make([]int, len(groups))
+	offsets := make([]int64, len(groups))
 	// scan all array vectors at once, rechunking along the way
 	var start int64
 	for start < int64(totalLen) {
 		// first compute max possible length for next chunk
-		chunkLength := math.MaxInt64
+		var chunkLength int64 = math.MaxInt64
 		for i, g := range groups {
 			offset := offsets[i]
 			// skip any done arrays including 0-length
-			for offset == g[0].Len() {
+			for offset == int64(g[0].Len()) {
 				g = g[1:]
 				offset = 0
 			}
 			arr := g[0]
-			chunkLength = Min(chunkLength, arr.Len()-offset)
+			chunkLength = Min(chunkLength, int64(arr.Len())-offset)
 
 			offsets[i] = offset
 			groups[i] = g
@@ -263,7 +263,7 @@ func RechunkArraysConsistently(groups [][]arrow.Array) [][]arrow.Array {
 		for i, g := range groups {
 			offset := offsets[i]
 			arr := g[0]
-			if offset == 0 && arr.Len() == chunkLength {
+			if offset == 0 && int64(arr.Len()) == chunkLength {
 				// slice spans entire array
 				arr.Retain()
 				rechunked[i] = append(rechunked[i], arr)


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
Two locations in the code cause issues when building with `GOARCH=386` (e.g. 32-bit systems).

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
In the `compute` package we assume a 64-bit system when using an untyped `int` to hold `math.MaxInt64` which overflows on a 32-bit system. So we just explicitly identify it as an `int64`

In the `cdata` package we use the older `*(*[maxlen]*C.void)(unsafe.Pointer(.....))[:]` syntax to retrieve the `void**` for the buffers, with maxlen set to a very large constant. Unfortunately on a 32-bit system this is larger than the address space. Instead we switch to using the `unsafe.Slice` method that was added in go1.17.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->


* Closes: #34784