### PR TITLE
GH-35788: [Swift] bug fixes and change reader/writer to user Result type

### DIFF
--- a/swift/Arrow/Sources/Arrow/ArrowArrayBuilder.swift
+++ b/swift/Arrow/Sources/Arrow/ArrowArrayBuilder.swift
@@ -107,7 +107,7 @@ public class ArrowArrayBuilders {
         } else if t == Double.self {
             return try NumberArrayBuilder<T>()
         } else {
-            throw ValidationError.unknownType
+            throw ArrowError.unknownType
         }
     }
 

--- a/swift/Arrow/Sources/Arrow/ArrowBufferBuilder.swift
+++ b/swift/Arrow/Sources/Arrow/ArrowBufferBuilder.swift
@@ -39,7 +39,7 @@ public class BaseBufferBuilder<T> {
     public var length: UInt = 0
     public var nullCount : UInt  = 0
 
-    init(values: ArrowBuffer, nulls: ArrowBuffer, stride: Int = MemoryLayout<T>.stride) throws {
+    init(values: ArrowBuffer, nulls: ArrowBuffer, stride: Int = MemoryLayout<T>.stride) {
         self.stride = stride
         self.values = values
         self.nulls = nulls
@@ -68,7 +68,7 @@ public class FixedBufferBuilder<T>: BaseBufferBuilder<T>, ArrowBufferBuilder {
         self.defaultVal = try FixedBufferBuilder<T>.defaultValueForType()
         let values = ArrowBuffer.createBuffer(0, size: UInt(MemoryLayout<T>.stride))
         let nulls = ArrowBuffer.createBuffer(0, size: UInt(MemoryLayout<UInt8>.stride))
-        try super.init(values: values, nulls: nulls)
+        super.init(values: values, nulls: nulls)
     }
 
     public func append(_ newValue: ItemType?) {
@@ -134,7 +134,7 @@ public class FixedBufferBuilder<T>: BaseBufferBuilder<T>, ArrowBufferBuilder {
             return Double(0) as! T
         }
         
-        throw ValidationError.unknownType
+        throw ArrowError.unknownType
     }
 }
 
@@ -143,7 +143,7 @@ public class BoolBufferBuilder: BaseBufferBuilder<Bool>, ArrowBufferBuilder {
     public required init() throws {
         let values = ArrowBuffer.createBuffer(0, size: UInt(MemoryLayout<UInt8>.stride))
         let nulls = ArrowBuffer.createBuffer(0, size: UInt(MemoryLayout<UInt8>.stride))
-        try super.init(values: values, nulls: nulls)
+        super.init(values: values, nulls: nulls)
     }
 
     public func append(_ newValue: ItemType?) {
@@ -198,7 +198,7 @@ public class VariableBufferBuilder<T>: BaseBufferBuilder<T>, ArrowBufferBuilder 
         let values = ArrowBuffer.createBuffer(0, size: UInt(binaryStride))
         let nulls = ArrowBuffer.createBuffer(0, size: UInt(binaryStride))
         self.offsets = ArrowBuffer.createBuffer(0, size: UInt(MemoryLayout<Int32>.stride))
-        try super.init(values: values, nulls: nulls, stride: binaryStride)
+        super.init(values: values, nulls: nulls, stride: binaryStride)
     }
 
     public func append(_ newValue: ItemType?) {

--- a/swift/Arrow/Sources/Arrow/ArrowData.swift
+++ b/swift/Arrow/Sources/Arrow/ArrowData.swift
@@ -28,11 +28,11 @@ public class ArrowData {
         switch(type) {
             case let .PrimitiveInfo(typeId):
                 if typeId == ArrowTypeId.Unknown {
-                    throw ValidationError.unknownType
+                    throw ArrowError.unknownType
                 }
             case let .VariableInfo(typeId):
                 if typeId == ArrowTypeId.Unknown {
-                    throw ValidationError.unknownType
+                    throw ArrowError.unknownType
                 }
         }
 

--- a/swift/Arrow/Sources/Arrow/ArrowReader.swift
+++ b/swift/Arrow/Sources/Arrow/ArrowReader.swift
@@ -18,10 +18,6 @@
 import FlatBuffers
 import Foundation
 
-public enum ArrowError: Error {
-    case runtimeError(String)
-}
-
 let FILEMARKER = "ARROW1"
 let CONTINUATIONMARKER = -1
 
@@ -35,77 +31,101 @@ public class ArrowReader {
         let messageOffset: Int64
     }
 
-    private func loadSchema(_ schema: org_apache_arrow_flatbuf_Schema) throws -> ArrowSchema {
+    private func loadSchema(_ schema: org_apache_arrow_flatbuf_Schema) -> Result<ArrowSchema, ArrowError> {
         let builder = ArrowSchema.Builder()
         for index in 0 ..< schema.fieldsCount {
             let field = schema.fields(at: index)!
             let arrowField = ArrowField(field.name!, type: findArrowType(field), isNullable: field.nullable)
-            let _ = builder.addField(arrowField)
+            builder.addField(arrowField)
             if field.typeType == .struct_ {
-                throw ValidationError.unknownType
+                return .failure(.unknownType)
             }
         }
 
-        return builder.finish()
+        return .success(builder.finish())
     }
 
-    private func loadPrimitiveData(_ loadInfo: DataLoadInfo) throws -> ChunkedArrayHolder {
-        let node = loadInfo.recordBatch.nodes(at: loadInfo.nodeIndex)!
-        try validateBufferIndex(loadInfo.recordBatch, index: loadInfo.bufferIndex)
-        let nullBuffer = loadInfo.recordBatch.buffers(at: loadInfo.bufferIndex)!
-        let arrowNullBuffer = makeBuffer(nullBuffer, fileData: loadInfo.fileData,
-                                         length: UInt(node.nullCount), messageOffset: loadInfo.messageOffset)
-        try validateBufferIndex(loadInfo.recordBatch, index: loadInfo.bufferIndex + 1)
-        let valueBuffer = loadInfo.recordBatch.buffers(at: loadInfo.bufferIndex + 1)!
-        let arrowValueBuffer = makeBuffer(valueBuffer, fileData: loadInfo.fileData,
-                                          length: UInt(node.length), messageOffset: loadInfo.messageOffset)
-        return try makeArrayHolder(loadInfo.field, buffers: [arrowNullBuffer, arrowValueBuffer])
+    private func loadPrimitiveData(_ loadInfo: DataLoadInfo) -> Result<ArrowArrayHolder, ArrowError> {
+        do {
+            let node = loadInfo.recordBatch.nodes(at: loadInfo.nodeIndex)!
+            try validateBufferIndex(loadInfo.recordBatch, index: loadInfo.bufferIndex)
+            let nullBuffer = loadInfo.recordBatch.buffers(at: loadInfo.bufferIndex)!
+            let arrowNullBuffer = makeBuffer(nullBuffer, fileData: loadInfo.fileData,
+                                             length: UInt(node.nullCount), messageOffset: loadInfo.messageOffset)
+            try validateBufferIndex(loadInfo.recordBatch, index: loadInfo.bufferIndex + 1)
+            let valueBuffer = loadInfo.recordBatch.buffers(at: loadInfo.bufferIndex + 1)!
+            let arrowValueBuffer = makeBuffer(valueBuffer, fileData: loadInfo.fileData,
+                                              length: UInt(node.length), messageOffset: loadInfo.messageOffset)
+            return makeArrayHolder(loadInfo.field, buffers: [arrowNullBuffer, arrowValueBuffer])
+        } catch let error as ArrowError {
+            return .failure(error)
+        } catch {
+            return .failure(.unknownError("\(error)"))
+        }
     }
 
-    private func loadVariableData(_ loadInfo: DataLoadInfo) throws -> ChunkedArrayHolder {
+    private func loadVariableData(_ loadInfo: DataLoadInfo) -> Result<ArrowArrayHolder, ArrowError> {
         let node = loadInfo.recordBatch.nodes(at: loadInfo.nodeIndex)!
-        try validateBufferIndex(loadInfo.recordBatch, index: loadInfo.bufferIndex)
-        let nullBuffer = loadInfo.recordBatch.buffers(at: loadInfo.bufferIndex)!
-        let arrowNullBuffer = makeBuffer(nullBuffer, fileData: loadInfo.fileData,
-                                         length: UInt(node.nullCount), messageOffset: loadInfo.messageOffset)
-        try validateBufferIndex(loadInfo.recordBatch, index: loadInfo.bufferIndex + 1)
-        let offsetBuffer = loadInfo.recordBatch.buffers(at: loadInfo.bufferIndex + 1)!
-        let arrowOffsetBuffer = makeBuffer(offsetBuffer, fileData: loadInfo.fileData,
-                                           length: UInt(node.length), messageOffset: loadInfo.messageOffset)
-        try validateBufferIndex(loadInfo.recordBatch, index: loadInfo.bufferIndex + 2)
-        let valueBuffer = loadInfo.recordBatch.buffers(at: loadInfo.bufferIndex + 2)!
-        let arrowValueBuffer = makeBuffer(valueBuffer, fileData: loadInfo.fileData,
-                                          length: UInt(node.length), messageOffset: loadInfo.messageOffset)
-        return try makeArrayHolder(loadInfo.field, buffers: [arrowNullBuffer, arrowOffsetBuffer, arrowValueBuffer])
+        do {
+            try validateBufferIndex(loadInfo.recordBatch, index: loadInfo.bufferIndex)
+            let nullBuffer = loadInfo.recordBatch.buffers(at: loadInfo.bufferIndex)!
+            let arrowNullBuffer = makeBuffer(nullBuffer, fileData: loadInfo.fileData,
+                                             length: UInt(node.nullCount), messageOffset: loadInfo.messageOffset)
+            try validateBufferIndex(loadInfo.recordBatch, index: loadInfo.bufferIndex + 1)
+            let offsetBuffer = loadInfo.recordBatch.buffers(at: loadInfo.bufferIndex + 1)!
+            let arrowOffsetBuffer = makeBuffer(offsetBuffer, fileData: loadInfo.fileData,
+                                               length: UInt(node.length), messageOffset: loadInfo.messageOffset)
+            try validateBufferIndex(loadInfo.recordBatch, index: loadInfo.bufferIndex + 2)
+            let valueBuffer = loadInfo.recordBatch.buffers(at: loadInfo.bufferIndex + 2)!
+            let arrowValueBuffer = makeBuffer(valueBuffer, fileData: loadInfo.fileData,
+                                              length: UInt(node.length), messageOffset: loadInfo.messageOffset)
+            return makeArrayHolder(loadInfo.field, buffers: [arrowNullBuffer, arrowOffsetBuffer, arrowValueBuffer])
+        } catch let error as ArrowError {
+            return .failure(error)
+        } catch {
+            return .failure(.unknownError("\(error)"))
+        }
     }
 
     private func loadRecordBatch(_ message: org_apache_arrow_flatbuf_Message, schema: org_apache_arrow_flatbuf_Schema,
-                                 data: Data, messageEndOffset: Int64) throws -> RecordBatch {
+                                 data: Data, messageEndOffset: Int64) -> Result<RecordBatch, ArrowError> {
         let recordBatch = message.header(type: org_apache_arrow_flatbuf_RecordBatch.self)
         let nodesCount = recordBatch?.nodesCount ?? 0
         var bufferIndex: Int32 = 0
-        var columns: [ChunkedArrayHolder] = []
-        let arrowSchema = try loadSchema(schema)
+        var columns: [ArrowArrayHolder] = []
         for nodeIndex in 0 ..< nodesCount {
             let field = schema.fields(at: nodeIndex)!
             let loadInfo = DataLoadInfo(recordBatch: recordBatch!, field: field,
                                         nodeIndex: nodeIndex, bufferIndex: bufferIndex,
                                         fileData: data, messageOffset: messageEndOffset)
+            var result: Result<ArrowArrayHolder, ArrowError>
             if isFixedPrimitive(field.typeType) {
-                let holder = try loadPrimitiveData(loadInfo)
-                columns.append(holder)
+                result = loadPrimitiveData(loadInfo)
                 bufferIndex += 2
             } else {
-                let holder = try loadVariableData(loadInfo)
-                columns.append(holder)
+                result = loadVariableData(loadInfo)
                 bufferIndex += 3
             }
+            
+            switch result {
+            case .success(let holder):
+                columns.append(holder)
+            case .failure(let error):
+                return .failure(error)
+            }
+            
         }
-
-        return RecordBatch(arrowSchema, columns: columns)
+        
+        let schemaResult = loadSchema(schema)
+        switch schemaResult {
+        case .success(let arrowSchema):
+            return .success(RecordBatch(arrowSchema, columns: columns))
+        case .failure(let error):
+            return .failure(error)
+        }
     }
 
-    public func fromStream(_ fileData: Data) throws -> [RecordBatch] {
+    public func fromStream(_ fileData: Data) -> Result<[RecordBatch], ArrowError> {
         let footerLength = fileData.withUnsafeBytes { rawBuffer in
             rawBuffer.loadUnaligned(fromByteOffset: fileData.count - 4, as: Int32.self)
         }
@@ -138,26 +158,36 @@ public class ArrowReader {
             let message = org_apache_arrow_flatbuf_Message.getRootAsMessage(bb: mbb)
             switch message.headerType {
             case .recordbatch:
-                let recordBatch = try loadRecordBatch(message, schema: footer.schema!,
-                                                      data: fileData, messageEndOffset: messageEndOffset)
-                recordBatchs.append(recordBatch)
+                do {
+                    let recordBatch = try loadRecordBatch(message, schema: footer.schema!,
+                                                          data: fileData, messageEndOffset: messageEndOffset).get()
+                    recordBatchs.append(recordBatch)
+                } catch let error as ArrowError {
+                    return .failure(error)
+                } catch {
+                    return .failure(.unknownError("Unexpected error: \(error)"))
+                }
             default:
-                print("Unhandled header type: \(message.headerType)")
+                return .failure(.unknownError("Unhandled header type: \(message.headerType)"))
             }
         }
 
-        return recordBatchs
+        return .success(recordBatchs)
     }
 
-    public func fromFile(_ fileURL: URL) throws -> [RecordBatch] {
-        let fileData = try Data(contentsOf: fileURL)
-        if !validateFileData(fileData) {
-            throw ArrowError.runtimeError("Not a valid arrow file.")
-        }
+    public func fromFile(_ fileURL: URL) -> Result<[RecordBatch], ArrowError> {
+        do {
+            let fileData = try Data(contentsOf: fileURL)
+            if !validateFileData(fileData) {
+                return .failure(.ioError("Not a valid arrow file."))
+            }
 
-        let markerLength = FILEMARKER.utf8.count
-        let footerLengthEnd = Int(fileData.count - markerLength)
-        let data = fileData[..<(footerLengthEnd)]
-        return try fromStream(data)
+            let markerLength = FILEMARKER.utf8.count
+            let footerLengthEnd = Int(fileData.count - markerLength)
+            let data = fileData[..<(footerLengthEnd)]
+            return fromStream(data)
+        } catch {
+            return .failure(.unknownError("Error loading file: \(error)"))
+        }
     }
 }

--- a/swift/Arrow/Sources/Arrow/ArrowSchema.swift
+++ b/swift/Arrow/Sources/Arrow/ArrowSchema.swift
@@ -52,11 +52,13 @@ public class ArrowSchema {
     public class Builder {
         private var fields: [ArrowField] = []
         
+        @discardableResult
         public func addField(_ field: ArrowField) -> Builder {
             fields.append(field)
             return self
         }
 
+        @discardableResult
         public func addField(_ name: String, type: ArrowType.Info, isNullable: Bool) -> Builder {
             fields.append(ArrowField(name, type: type, isNullable: isNullable))
             return self

--- a/swift/Arrow/Sources/Arrow/ArrowTable.swift
+++ b/swift/Arrow/Sources/Arrow/ArrowTable.swift
@@ -17,60 +17,6 @@
 
 import Foundation
 
-public class ChunkedArrayHolder {
-    public let type: ArrowType.Info
-    public let length: UInt
-    public let nullCount: UInt
-    public let holder: Any
-    public let getBufferData: () throws -> [Data]
-    public let getBufferDataSizes: () throws -> [Int]
-    public init<T>(_ chunked: ChunkedArray<T>) {
-        self.holder = chunked
-        self.length = chunked.length
-        self.type = chunked.type
-        self.nullCount = chunked.nullCount
-        self.getBufferData = {() throws -> [Data] in 
-            var bufferData = [Data]()
-            var numBuffers = 2;
-            if !isFixedPrimitive(try toFBTypeEnum(chunked.type)) {
-                numBuffers = 3
-            }
-
-            for _ in 0 ..< numBuffers {
-                bufferData.append(Data())
-            }
-
-            for arrow_data in chunked.arrays {
-                for index in 0 ..< numBuffers {
-                    arrow_data.arrowData.buffers[index].append(to: &bufferData[index])
-                }
-            }
-
-            return bufferData;
-        }
-        
-        self.getBufferDataSizes = {() throws -> [Int] in
-            var bufferDataSizes = [Int]()
-            var numBuffers = 2;
-            if !isFixedPrimitive(try toFBTypeEnum(chunked.type)) {
-                numBuffers = 3
-            }
-            for _ in 0 ..< numBuffers {
-                bufferDataSizes.append(Int(0))
-            }
-            
-            for arrow_data in chunked.arrays {
-                for index in 0 ..< numBuffers {
-                    bufferDataSizes[index] += Int(arrow_data.arrowData.buffers[index].capacity);
-                }
-            }
-
-            return bufferDataSizes;
-        }
-
-    }
-}
-
 public class ArrowColumn {
     public let field: ArrowField
     fileprivate let dataHolder: ChunkedArrayHolder
@@ -83,9 +29,9 @@ public class ArrowColumn {
     }
 
     public var name: String {get{return field.name}}
-    public init<T>(_ field: ArrowField, chunked: ChunkedArray<T>) {
+    public init(_ field: ArrowField, chunked: ChunkedArrayHolder) {
         self.field = field
-        self.dataHolder = ChunkedArrayHolder(chunked)
+        self.dataHolder = chunked
     }
 }
 
@@ -100,43 +46,70 @@ public class ArrowTable {
         self.rowCount = columns[0].length
     }
     
-    public func toRecordBatch() -> RecordBatch {
-        var rbColumns = [ChunkedArrayHolder]()
-        for column in self.columns {
-            rbColumns.append(column.dataHolder)
+    public static func from(recordBatches: [RecordBatch]) -> Result<ArrowTable, ArrowError> {
+        if(recordBatches.isEmpty) {
+            return .failure(.arrayHasNoElements)
         }
         
-        return RecordBatch(schema, columns: rbColumns)
+        var holders = [[ArrowArrayHolder]]()
+        let schema = recordBatches[0].schema;
+        for recordBatch in recordBatches {
+            for index in 0..<schema.fields.count {
+                if holders.count <= index {
+                    holders.append([ArrowArrayHolder]())
+                }
+                holders[index].append(recordBatch.columns[index])
+            }
+        }
+        
+        let builder = ArrowTable.Builder()
+        for index in 0..<schema.fields.count {
+            switch ArrowArrayHolder.makeArrowColumn(schema.fields[index], holders: holders[index]) {
+            case .success(let column):
+                builder.addColumn(column)
+            case .failure(let error):
+                return .failure(error)
+            }
+        }
+        
+        return .success(builder.finish())
     }
     
     public class Builder {
         let schemaBuilder = ArrowSchema.Builder()
         var columns = [ArrowColumn]()
         
+        @discardableResult
         public func addColumn<T>(_ fieldName: String, arrowArray: ArrowArray<T>) throws -> Builder {
             return self.addColumn(fieldName, chunked: try ChunkedArray([arrowArray]))
         }
 
+        @discardableResult
         public func addColumn<T>(_ fieldName: String, chunked: ChunkedArray<T>) -> Builder {
             let field = ArrowField(fieldName, type: chunked.type, isNullable: chunked.nullCount != 0)
-            let _ = self.schemaBuilder.addField(field)
-            self.columns.append(ArrowColumn(field, chunked: chunked))
+            self.schemaBuilder.addField(field)
+            self.columns.append(ArrowColumn(field, chunked: ChunkedArrayHolder(chunked)))
             return self
         }
 
+        @discardableResult
         public func addColumn<T>(_ field: ArrowField, arrowArray: ArrowArray<T>) throws -> Builder {
-            let _ = self.schemaBuilder.addField(field)
-            self.columns.append(ArrowColumn(field, chunked: try ChunkedArray([arrowArray])))
+            self.schemaBuilder.addField(field)
+            let holder = ChunkedArrayHolder(try ChunkedArray([arrowArray]))
+            self.columns.append(ArrowColumn(field, chunked: holder))
             return self
         }
 
+        @discardableResult
         public func addColumn<T>(_ field: ArrowField, chunked: ChunkedArray<T>) -> Builder {
-            let _ = self.schemaBuilder.addField(field)
-            self.columns.append(ArrowColumn(field, chunked: chunked))
+            self.schemaBuilder.addField(field)
+            self.columns.append(ArrowColumn(field, chunked: ChunkedArrayHolder(chunked)))
             return self
         }
 
+        @discardableResult
         public func addColumn(_ column: ArrowColumn) -> Builder {
+            self.schemaBuilder.addField(column.field)
             self.columns.append(column)
             return self
         }
@@ -150,9 +123,9 @@ public class ArrowTable {
 public class RecordBatch {
     let schema: ArrowSchema
     var columnCount: UInt {get{return UInt(self.columns.count)}}
-    let columns: [ChunkedArrayHolder]
+    let columns: [ArrowArrayHolder]
     let length: UInt
-    public init(_ schema: ArrowSchema, columns: [ChunkedArrayHolder]) {
+    public init(_ schema: ArrowSchema, columns: [ArrowArrayHolder]) {
         self.schema = schema
         self.columns = columns
         self.length = columns[0].length
@@ -160,36 +133,46 @@ public class RecordBatch {
     
     public class Builder {
         let schemaBuilder = ArrowSchema.Builder()
-        var columns = [ChunkedArrayHolder]()
+        var columns = [ArrowArrayHolder]()
         
-        public func addColumn(_ fieldName: String, chunked: ChunkedArrayHolder) -> Builder {
-            let field = ArrowField(fieldName, type: chunked.type, isNullable: chunked.nullCount != 0)
-            let _ = self.schemaBuilder.addField(field)
-            self.columns.append(chunked)
+        @discardableResult
+        public func addColumn(_ fieldName: String, arrowArray: ArrowArrayHolder) -> Builder {
+            let field = ArrowField(fieldName, type: arrowArray.type, isNullable: arrowArray.nullCount != 0)
+            self.schemaBuilder.addField(field)
+            self.columns.append(arrowArray)
             return self
         }
 
-        public func addColumn(_ field: ArrowField, chunked: ChunkedArrayHolder) -> Builder {
-            let _ = self.schemaBuilder.addField(field)
-            self.columns.append(chunked)
+        @discardableResult
+        public func addColumn(_ field: ArrowField, arrowArray: ArrowArrayHolder) -> Builder {
+            self.schemaBuilder.addField(field)
+            self.columns.append(arrowArray)
             return self
         }
 
-        public func finish() -> RecordBatch {
-            return RecordBatch(self.schemaBuilder.finish(), columns: self.columns)
+        public func finish() -> Result<RecordBatch, ArrowError> {
+            if columns.count > 0 {
+                let columnLength = columns[0].length
+                for column in columns {
+                    if column.length != columnLength {
+                        return .failure(.runtimeError("Columns have different sizes"))
+                    }
+                }
+            }
+            return .success(RecordBatch(self.schemaBuilder.finish(), columns: self.columns))
         }
     }
     
-    public func data<T>(for columnIndex: Int) -> ChunkedArray<T> {
+    public func data<T>(for columnIndex: Int) -> ArrowArray<T> {
         let arrayHolder = column(columnIndex)
-        return (arrayHolder.holder as! ChunkedArray<T>)
+        return (arrayHolder.array as! ArrowArray<T>)
     }
     
-    public func column(_ index: Int) -> ChunkedArrayHolder {
+    public func column(_ index: Int) -> ArrowArrayHolder {
         return self.columns[index]
     }
 
-    public func column(_ name: String) -> ChunkedArrayHolder? {
+    public func column(_ name: String) -> ArrowArrayHolder? {
         if let index = self.schema.fieldIndex(name) {
             return self.columns[index]
         }

--- a/swift/Arrow/Sources/Arrow/ArrowType.swift
+++ b/swift/Arrow/Sources/Arrow/ArrowType.swift
@@ -19,11 +19,17 @@ import Foundation
 
 func FlatBuffersVersion_23_1_4() {
 }
-
-public enum ValidationError: Error {
+                                                                                                                
+public enum ArrowError: Error {
+    case none
     case unknownType
-    case outOfBounds(index: UInt)
+    case runtimeError(String)
+    case outOfBounds(index: Int64)
     case arrayHasNoElements
+    case unknownError(String)
+    case notImplemented
+    case ioError(String)
+    case invalid(String)
 }
 
 public enum ArrowTypeId {

--- a/swift/Arrow/Sources/Arrow/ArrowWriterHelper.swift
+++ b/swift/Arrow/Sources/Arrow/ArrowWriterHelper.swift
@@ -24,53 +24,53 @@ extension Data {
     }
 }
 
-func toFBTypeEnum(_ infoType: ArrowType.Info) throws -> org_apache_arrow_flatbuf_Type_ {
+func toFBTypeEnum(_ infoType: ArrowType.Info) -> Result<org_apache_arrow_flatbuf_Type_, ArrowError> {
     if infoType == ArrowType.ArrowInt8 || infoType == ArrowType.ArrowInt16 ||
         infoType == ArrowType.ArrowInt64 || infoType == ArrowType.ArrowUInt8 ||
         infoType == ArrowType.ArrowUInt16 || infoType == ArrowType.ArrowUInt32 ||
         infoType == ArrowType.ArrowUInt64 || infoType == ArrowType.ArrowInt32 {
-        return org_apache_arrow_flatbuf_Type_.int
+        return .success(org_apache_arrow_flatbuf_Type_.int)
     } else if infoType == ArrowType.ArrowFloat || infoType == ArrowType.ArrowDouble {
-        return org_apache_arrow_flatbuf_Type_.floatingpoint
+        return .success(org_apache_arrow_flatbuf_Type_.floatingpoint)
     } else if infoType == ArrowType.ArrowString {
-        return org_apache_arrow_flatbuf_Type_.utf8
+        return .success(org_apache_arrow_flatbuf_Type_.utf8)
     } else if infoType == ArrowType.ArrowBool {
-        return org_apache_arrow_flatbuf_Type_.bool
+        return .success(org_apache_arrow_flatbuf_Type_.bool)
     } else if infoType == ArrowType.ArrowDate32 || infoType == ArrowType.ArrowDate64 {
-        return org_apache_arrow_flatbuf_Type_.date
+        return .success(org_apache_arrow_flatbuf_Type_.date)
     }
 
-    throw ValidationError.unknownType
+    return .failure(.unknownType)
 }
 
-func toFBType(_ fbb: inout FlatBufferBuilder, infoType: ArrowType.Info) throws -> Offset {
+func toFBType(_ fbb: inout FlatBufferBuilder, infoType: ArrowType.Info) -> Result<Offset, ArrowError> {
     if infoType == ArrowType.ArrowInt8 || infoType == ArrowType.ArrowUInt8 {
-        return org_apache_arrow_flatbuf_Int.createInt(&fbb, bitWidth: 8, isSigned: infoType == ArrowType.ArrowInt8);
+        return .success(org_apache_arrow_flatbuf_Int.createInt(&fbb, bitWidth: 8, isSigned: infoType == ArrowType.ArrowInt8))
     } else if infoType == ArrowType.ArrowInt16 || infoType == ArrowType.ArrowUInt16 {
-        return org_apache_arrow_flatbuf_Int.createInt(&fbb, bitWidth: 16, isSigned: infoType == ArrowType.ArrowInt16);
+        return .success(org_apache_arrow_flatbuf_Int.createInt(&fbb, bitWidth: 16, isSigned: infoType == ArrowType.ArrowInt16))
     } else if infoType == ArrowType.ArrowInt32 || infoType == ArrowType.ArrowUInt32 {
-        return org_apache_arrow_flatbuf_Int.createInt(&fbb, bitWidth: 32, isSigned: infoType == ArrowType.ArrowInt32);
+        return .success(org_apache_arrow_flatbuf_Int.createInt(&fbb, bitWidth: 32, isSigned: infoType == ArrowType.ArrowInt32))
     } else if infoType == ArrowType.ArrowInt64 || infoType == ArrowType.ArrowUInt64 {
-        return org_apache_arrow_flatbuf_Int.createInt(&fbb, bitWidth: 64, isSigned: infoType == ArrowType.ArrowInt64);
+        return .success(org_apache_arrow_flatbuf_Int.createInt(&fbb, bitWidth: 64, isSigned: infoType == ArrowType.ArrowInt64))
     } else if infoType == ArrowType.ArrowFloat {
-        return org_apache_arrow_flatbuf_FloatingPoint.createFloatingPoint(&fbb, precision: .single)
+        return .success(org_apache_arrow_flatbuf_FloatingPoint.createFloatingPoint(&fbb, precision: .single))
     } else if infoType == ArrowType.ArrowDouble {
-        return org_apache_arrow_flatbuf_FloatingPoint.createFloatingPoint(&fbb, precision: .double)
+        return .success(org_apache_arrow_flatbuf_FloatingPoint.createFloatingPoint(&fbb, precision: .double))
     } else if infoType == ArrowType.ArrowString {
-        return org_apache_arrow_flatbuf_Utf8.endUtf8(&fbb, start: org_apache_arrow_flatbuf_Utf8.startUtf8(&fbb))
+        return .success(org_apache_arrow_flatbuf_Utf8.endUtf8(&fbb, start: org_apache_arrow_flatbuf_Utf8.startUtf8(&fbb)))
     } else if infoType == ArrowType.ArrowBool {
-        return org_apache_arrow_flatbuf_Bool.endBool(&fbb, start: org_apache_arrow_flatbuf_Bool.startBool(&fbb))
+        return .success(org_apache_arrow_flatbuf_Bool.endBool(&fbb, start: org_apache_arrow_flatbuf_Bool.startBool(&fbb)))
     } else if infoType == ArrowType.ArrowDate32 {
         let startOffset = org_apache_arrow_flatbuf_Date.startDate(&fbb)
         org_apache_arrow_flatbuf_Date.add(unit: .day, &fbb)
-        return org_apache_arrow_flatbuf_Date.endDate(&fbb, start: startOffset)
+        return .success(org_apache_arrow_flatbuf_Date.endDate(&fbb, start: startOffset))
     } else if infoType == ArrowType.ArrowDate64 {
         let startOffset = org_apache_arrow_flatbuf_Date.startDate(&fbb)
         org_apache_arrow_flatbuf_Date.add(unit: .millisecond, &fbb)
-        return org_apache_arrow_flatbuf_Date.endDate(&fbb, start: startOffset)
+        return .success(org_apache_arrow_flatbuf_Date.endDate(&fbb, start: startOffset))
     }
-
-    throw ValidationError.unknownType
+    
+    return .failure(.unknownType)
 }
 
 func addPadForAlignment(_ data: inout Data, alignment: Int = 8) {

--- a/swift/Arrow/Sources/Arrow/ChunkedArray.swift
+++ b/swift/Arrow/Sources/Arrow/ChunkedArray.swift
@@ -20,6 +20,73 @@ import Foundation
 public protocol AsString {
     func asString(_ index: UInt) -> String
 }
+
+public class ChunkedArrayHolder {
+    public let type: ArrowType.Info
+    public let length: UInt
+    public let nullCount: UInt
+    public let holder: Any
+    public let getBufferData: () -> Result<[Data], ArrowError>
+    public let getBufferDataSizes: () -> Result<[Int], ArrowError>
+    public init<T>(_ chunked: ChunkedArray<T>) {
+        self.holder = chunked
+        self.length = chunked.length
+        self.type = chunked.type
+        self.nullCount = chunked.nullCount
+        self.getBufferData = {() -> Result<[Data], ArrowError> in
+            var bufferData = [Data]()
+            var numBuffers = 2;
+            switch toFBTypeEnum(chunked.type) {
+            case .success(let fbType):
+                if !isFixedPrimitive(fbType) {
+                    numBuffers = 3
+                }
+            case .failure(let error):
+                return .failure(error)
+            }
+
+            for _ in 0 ..< numBuffers {
+                bufferData.append(Data())
+            }
+
+            for arrow_data in chunked.arrays {
+                for index in 0 ..< numBuffers {
+                    arrow_data.arrowData.buffers[index].append(to: &bufferData[index])
+                }
+            }
+
+            return .success(bufferData);
+        }
+        
+        self.getBufferDataSizes = {() -> Result<[Int], ArrowError> in
+            var bufferDataSizes = [Int]()
+            var numBuffers = 2;
+            
+            switch toFBTypeEnum(chunked.type) {
+            case .success(let fbType):
+                if !isFixedPrimitive(fbType) {
+                    numBuffers = 3
+                }
+            case .failure(let error):
+                return .failure(error)
+            }
+            
+            for _ in 0 ..< numBuffers {
+                bufferDataSizes.append(Int(0))
+            }
+            
+            for arrow_data in chunked.arrays {
+                for index in 0 ..< numBuffers {
+                    bufferDataSizes[index] += Int(arrow_data.arrowData.buffers[index].capacity)
+                }
+            }
+
+            return .success(bufferDataSizes)
+        }
+
+    }
+}
+
 public class ChunkedArray<T> : AsString {
     public let arrays: [ArrowArray<T>]
     public let type: ArrowType.Info
@@ -29,7 +96,7 @@ public class ChunkedArray<T> : AsString {
     
     public init(_ arrays: [ArrowArray<T>]) throws {
         if arrays.count == 0 {
-            throw ValidationError.arrayHasNoElements
+            throw ArrowError.arrayHasNoElements
         }
         
         self.type = arrays[0].arrowData.type
@@ -53,7 +120,7 @@ public class ChunkedArray<T> : AsString {
         var localIndex = index
         var arrayIndex = 0;
         var len: UInt = arrays[arrayIndex].length
-        while localIndex > len {
+        while localIndex > (len - 1) {
             arrayIndex += 1
             if arrayIndex > arrays.count {
                 return nil

--- a/swift/Arrow/Tests/ArrowTests/RecordBatchTests.swift
+++ b/swift/Arrow/Tests/ArrowTests/RecordBatchTests.swift
@@ -27,25 +27,29 @@ final class RecordBatchTests: XCTestCase {
         stringBuilder.append("test10")
         stringBuilder.append("test22")
         
-        let intHolder = ChunkedArrayHolder(try ChunkedArray([uint8Builder.finish()]))
-        let stringHolder = ChunkedArrayHolder(try ChunkedArray([stringBuilder.finish()]))
-        let recordBatch = RecordBatch.Builder()
-            .addColumn("col1", chunked: intHolder)
-            .addColumn("col2", chunked: stringHolder)
+        let intHolder = ArrowArrayHolder(try uint8Builder.finish())
+        let stringHolder = ArrowArrayHolder(try stringBuilder.finish())
+        let result = RecordBatch.Builder()
+            .addColumn("col1", arrowArray: intHolder)
+            .addColumn("col2", arrowArray: stringHolder)
             .finish()
-
-        let schema = recordBatch.schema
-        XCTAssertEqual(schema.fields.count, 2)
-        XCTAssertEqual(schema.fields[0].name, "col1")
-        XCTAssertEqual(schema.fields[0].type, ArrowType.ArrowUInt8)
-        XCTAssertEqual(schema.fields[0].isNullable, false)
-        XCTAssertEqual(schema.fields[1].name, "col2")
-        XCTAssertEqual(schema.fields[1].type, ArrowType.ArrowString)
-        XCTAssertEqual(schema.fields[1].isNullable, false)
-        XCTAssertEqual(recordBatch.columns.count, 2)
-        let col1: ChunkedArray<UInt8> = recordBatch.data(for: 0);
-        let col2: ChunkedArray<String> = recordBatch.data(for: 1);
-        XCTAssertEqual(col1.length, 2)
-        XCTAssertEqual(col2.length, 2)
+        switch result {
+        case .success(let recordBatch):
+            let schema = recordBatch.schema
+            XCTAssertEqual(schema.fields.count, 2)
+            XCTAssertEqual(schema.fields[0].name, "col1")
+            XCTAssertEqual(schema.fields[0].type, ArrowType.ArrowUInt8)
+            XCTAssertEqual(schema.fields[0].isNullable, false)
+            XCTAssertEqual(schema.fields[1].name, "col2")
+            XCTAssertEqual(schema.fields[1].type, ArrowType.ArrowString)
+            XCTAssertEqual(schema.fields[1].isNullable, false)
+            XCTAssertEqual(recordBatch.columns.count, 2)
+            let col1: ArrowArray<UInt8> = recordBatch.data(for: 0);
+            let col2: ArrowArray<String> = recordBatch.data(for: 1);
+            XCTAssertEqual(col1.length, 2)
+            XCTAssertEqual(col2.length, 2)
+        case .failure(let error):
+            throw error
+        }
     }
 }

--- a/swift/Arrow/Tests/ArrowTests/TableTests.swift
+++ b/swift/Arrow/Tests/ArrowTests/TableTests.swift
@@ -71,7 +71,63 @@ final class TableTests: XCTestCase {
         XCTAssertEqual(col2.length, 2)
         XCTAssertEqual(col3.length, 2)
     }
-    
+
+    func testTableWithChunkedData() throws {
+        let uint8Builder: NumberArrayBuilder<UInt8> = try ArrowArrayBuilders.loadNumberArrayBuilder();
+        uint8Builder.append(10)
+        uint8Builder.append(22)
+        let uint8Builder2: NumberArrayBuilder<UInt8> = try ArrowArrayBuilders.loadNumberArrayBuilder();
+        uint8Builder2.append(33)
+        let uint8Builder3: NumberArrayBuilder<UInt8> = try ArrowArrayBuilders.loadNumberArrayBuilder();
+        uint8Builder3.append(44)
+        let stringBuilder = try ArrowArrayBuilders.loadStringArrayBuilder();
+        stringBuilder.append("test10")
+        stringBuilder.append("test22")
+        let stringBuilder2 = try ArrowArrayBuilders.loadStringArrayBuilder();
+        stringBuilder.append("test33")
+        stringBuilder.append("test44")
+        
+        let date32Builder: Date32ArrayBuilder = try ArrowArrayBuilders.loadDate32ArrayBuilder();
+        let date2 = Date(timeIntervalSinceReferenceDate: 86400 * 1)
+        let date1 = Date(timeIntervalSinceReferenceDate: 86400 * 5000 + 352)
+        date32Builder.append(date1)
+        date32Builder.append(date2)
+        date32Builder.append(date1)
+        date32Builder.append(date2)
+
+        let intArray = try ChunkedArray([uint8Builder.finish(), uint8Builder2.finish(), uint8Builder3.finish()])
+        let stringArray = try ChunkedArray([stringBuilder.finish(), stringBuilder2.finish()])
+        let dateArray = try ChunkedArray([date32Builder.finish()])
+        let table = ArrowTable.Builder()
+            .addColumn("col1", chunked: intArray)
+            .addColumn("col2", chunked: stringArray)
+            .addColumn("col3", chunked: dateArray)
+            .finish();
+        
+        let schema = table.schema
+        XCTAssertEqual(schema.fields.count, 3)
+        XCTAssertEqual(schema.fields[0].name, "col1")
+        XCTAssertEqual(schema.fields[0].type, ArrowType.ArrowUInt8)
+        XCTAssertEqual(schema.fields[0].isNullable, false)
+        XCTAssertEqual(schema.fields[1].name, "col2")
+        XCTAssertEqual(schema.fields[1].type, ArrowType.ArrowString)
+        XCTAssertEqual(schema.fields[1].isNullable, false)
+        XCTAssertEqual(schema.fields[1].name, "col2")
+        XCTAssertEqual(schema.fields[1].type, ArrowType.ArrowString)
+        XCTAssertEqual(schema.fields[1].isNullable, false)
+        XCTAssertEqual(table.columns.count, 3)
+        let col1: ChunkedArray<UInt8> = table.columns[0].data();
+        let col2: ChunkedArray<String> = table.columns[1].data();
+        let col3: ChunkedArray<Date> = table.columns[2].data();
+        XCTAssertEqual(col1.length, 4)
+        XCTAssertEqual(col2.length, 4)
+        XCTAssertEqual(col3.length, 4)
+        XCTAssertEqual(col1.asString(0), "10")
+        XCTAssertEqual(col1.asString(3), "44")
+        XCTAssertEqual(col2.asString(0), "test10")
+        XCTAssertEqual(col2.asString(2), "test33")
+    }
+
     func testTableToRecordBatch() throws {
         let uint8Builder: NumberArrayBuilder<UInt8> = try ArrowArrayBuilders.loadNumberArrayBuilder();
         uint8Builder.append(10)
@@ -80,24 +136,31 @@ final class TableTests: XCTestCase {
         stringBuilder.append("test10")
         stringBuilder.append("test22")
         
-        let table = try ArrowTable.Builder()
-            .addColumn("col1", arrowArray: uint8Builder.finish())
-            .addColumn("col2", arrowArray: stringBuilder.finish())
-            .finish();
-
-        let recordBatch = table.toRecordBatch()
-        let schema = recordBatch.schema
-        XCTAssertEqual(schema.fields.count, 2)
-        XCTAssertEqual(schema.fields[0].name, "col1")
-        XCTAssertEqual(schema.fields[0].type, ArrowType.ArrowUInt8)
-        XCTAssertEqual(schema.fields[0].isNullable, false)
-        XCTAssertEqual(schema.fields[1].name, "col2")
-        XCTAssertEqual(schema.fields[1].type, ArrowType.ArrowString)
-        XCTAssertEqual(schema.fields[1].isNullable, false)
-        XCTAssertEqual(recordBatch.columns.count, 2)
-        let col1: ChunkedArray<UInt8> = recordBatch.data(for: 0);
-        let col2: ChunkedArray<String> = recordBatch.data(for: 1);
-        XCTAssertEqual(col1.length, 2)
-        XCTAssertEqual(col2.length, 2)
+        let intHolder = ArrowArrayHolder(try uint8Builder.finish())
+        let stringHolder = ArrowArrayHolder(try stringBuilder.finish())
+        let result = RecordBatch.Builder()
+            .addColumn("col1", arrowArray: intHolder)
+            .addColumn("col2", arrowArray: stringHolder)
+            .finish().flatMap({ rb in
+                return ArrowTable.from(recordBatches: [rb])
+            })
+        switch result {
+        case .success(let table):
+            let schema = table.schema
+            XCTAssertEqual(schema.fields.count, 2)
+            XCTAssertEqual(schema.fields[0].name, "col1")
+            XCTAssertEqual(schema.fields[0].type, ArrowType.ArrowUInt8)
+            XCTAssertEqual(schema.fields[0].isNullable, false)
+            XCTAssertEqual(schema.fields[1].name, "col2")
+            XCTAssertEqual(schema.fields[1].type, ArrowType.ArrowString)
+            XCTAssertEqual(schema.fields[1].isNullable, false)
+            XCTAssertEqual(table.columns.count, 2)
+            let col1: ChunkedArray<UInt8> = table.columns[0].data();
+            let col2: ChunkedArray<String> = table.columns[1].data();
+            XCTAssertEqual(col1.length, 2)
+            XCTAssertEqual(col2.length, 2)
+        case .failure(let error):
+            throw error
+        }
     }
 }


### PR DESCRIPTION
Changes:
- Changed Reader and Writer to use Result<T, Error> instead of throwing.  Since the Error is an enum the handling of the error is enforced.
- Update RecordBatch to accept only a single array per column instead of chunked arrays (which could cause problems when writing out)
- Added ability for Table to be created from RecordBatches
- Fixed a bug with indexing in Chunked array with many arrays 
- Added tests for the above changes.
- Switched ValidationErrors to ArrowError and added additional ArrowError values.

* Closes: #35788