### PR TITLE
GH-35786: [C++] Add pairwise_diff function

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -456,6 +456,7 @@ if(ARROW_COMPUTE)
        compute/kernels/scalar_validity.cc
        compute/kernels/vector_array_sort.cc
        compute/kernels/vector_cumulative_ops.cc
+       compute/kernels/vector_pairwise.cc
        compute/kernels/vector_nested.cc
        compute/kernels/vector_rank.cc
        compute/kernels/vector_replace.cc

--- a/cpp/src/arrow/compute/api_vector.cc
+++ b/cpp/src/arrow/compute/api_vector.cc
@@ -221,7 +221,7 @@ RankOptions::RankOptions(std::vector<SortKey> sort_keys, NullPlacement null_plac
       tiebreaker(tiebreaker) {}
 constexpr char RankOptions::kTypeName[];
 
-PairwiseDiffOptions::PairwiseDiffOptions(double periods, bool check_overflow)
+PairwiseDiffOptions::PairwiseDiffOptions(int64_t periods, bool check_overflow)
     : FunctionOptions(internal::kPairwiseDiffOptionsType),
       periods(periods),
       check_overflow(check_overflow) {}

--- a/cpp/src/arrow/compute/api_vector.h
+++ b/cpp/src/arrow/compute/api_vector.h
@@ -670,6 +670,7 @@ Result<Datum> CumulativeMin(
 ///
 /// \param[in] array array input
 /// \param[in] options options, specifying overflow behavior and period
+/// \param[in] check_overflow whether to return error on overflow
 /// \param[in] ctx the function execution context, optional
 /// \return result as array
 ARROW_EXPORT

--- a/cpp/src/arrow/compute/api_vector.h
+++ b/cpp/src/arrow/compute/api_vector.h
@@ -670,7 +670,8 @@ Result<Datum> CumulativeMin(
 ///   Diff([1, 4, 9, 10, 15]) = [null, 3, 5, 1, 5].
 /// With p = 2,
 ///   Diff([1, 4, 9, 10, 15]) = [null, null, 8, 6, 6]
-///
+/// p can also be negative, in which case the diff is computed in
+/// the opposite direction.
 /// \param[in] array array input
 /// \param[in] options options, specifying overflow behavior and period
 /// \param[in] check_overflow whether to return error on overflow

--- a/cpp/src/arrow/compute/api_vector.h
+++ b/cpp/src/arrow/compute/api_vector.h
@@ -234,6 +234,21 @@ class ARROW_EXPORT CumulativeOptions : public FunctionOptions {
 };
 using CumulativeSumOptions = CumulativeOptions;  // For backward compatibility
 
+/// \brief Options for pairwise functions
+class ARROW_EXPORT PairwiseDiffOptions : public FunctionOptions {
+ public:
+  explicit PairwiseDiffOptions(double periods = 1, bool check_overflow = false);
+  static constexpr char const kTypeName[] = "PairwiseDiffOptions";
+  static PairwiseDiffOptions Defaults() { return PairwiseDiffOptions(); }
+
+  /// Periods to shift for applying the binary operation, accepts negative values.
+  int64_t periods = 1;
+
+  /// When true, returns an Invalid Status when overflow is detected, otherwise result is
+  /// wrapped around.
+  bool check_overflow = false;
+};
+
 /// @}
 
 /// \brief Filter with a boolean selection filter
@@ -649,6 +664,22 @@ ARROW_EXPORT
 Result<Datum> CumulativeMin(
     const Datum& values, const CumulativeOptions& options = CumulativeOptions::Defaults(),
     ExecContext* ctx = NULLPTR);
+
+/// \brief Return the first order difference of an array.
+///
+/// Computes the first order difference of an array, i.e. output[i] = input[i] - input[i -
+/// p] if i >= p, otherwise output[i] = null, where p is the period. For example, with p =
+/// 1, Diff([1, 4, 9, 10, 15]) = [null, 3, 5, 1, 5]. With p = 2, Diff([1, 4, 9, 10, 15]) =
+/// [null, null, 8, 6, 6]
+///
+/// \param[in] datum array input
+/// \param[in] options options, specifying overflow behavior and period
+/// \param[in] ctx the function execution context, optional
+/// \return result as array
+ARROW_EXPORT
+Result<std::shared_ptr<Array>> PairwiseDiff(const Array& array,
+                                            const PairwiseDiffOptions& options,
+                                            ExecContext* ctx = NULLPTR);
 
 // ----------------------------------------------------------------------
 // Deprecated functions

--- a/cpp/src/arrow/compute/api_vector.h
+++ b/cpp/src/arrow/compute/api_vector.h
@@ -237,7 +237,7 @@ using CumulativeSumOptions = CumulativeOptions;  // For backward compatibility
 /// \brief Options for pairwise functions
 class ARROW_EXPORT PairwiseDiffOptions : public FunctionOptions {
  public:
-  explicit PairwiseDiffOptions(double periods = 1, bool check_overflow = false);
+  explicit PairwiseDiffOptions(int64_t periods = 1, bool check_overflow = false);
   static constexpr char const kTypeName[] = "PairwiseDiffOptions";
   static PairwiseDiffOptions Defaults() { return PairwiseDiffOptions(); }
 

--- a/cpp/src/arrow/compute/api_vector.h
+++ b/cpp/src/arrow/compute/api_vector.h
@@ -672,7 +672,7 @@ Result<Datum> CumulativeMin(
 /// 1, Diff([1, 4, 9, 10, 15]) = [null, 3, 5, 1, 5]. With p = 2, Diff([1, 4, 9, 10, 15]) =
 /// [null, null, 8, 6, 6]
 ///
-/// \param[in] datum array input
+/// \param[in] array array input
 /// \param[in] options options, specifying overflow behavior and period
 /// \param[in] ctx the function execution context, optional
 /// \return result as array

--- a/cpp/src/arrow/compute/api_vector.h
+++ b/cpp/src/arrow/compute/api_vector.h
@@ -235,18 +235,14 @@ class ARROW_EXPORT CumulativeOptions : public FunctionOptions {
 using CumulativeSumOptions = CumulativeOptions;  // For backward compatibility
 
 /// \brief Options for pairwise functions
-class ARROW_EXPORT PairwiseDiffOptions : public FunctionOptions {
+class ARROW_EXPORT PairwiseOptions : public FunctionOptions {
  public:
-  explicit PairwiseDiffOptions(int64_t periods = 1, bool check_overflow = false);
-  static constexpr char const kTypeName[] = "PairwiseDiffOptions";
-  static PairwiseDiffOptions Defaults() { return PairwiseDiffOptions(); }
+  explicit PairwiseOptions(int64_t periods = 1);
+  static constexpr char const kTypeName[] = "PairwiseOptions";
+  static PairwiseOptions Defaults() { return PairwiseOptions(); }
 
   /// Periods to shift for applying the binary operation, accepts negative values.
   int64_t periods = 1;
-
-  /// When true, returns an Invalid Status when overflow is detected, otherwise result is
-  /// wrapped around.
-  bool check_overflow = false;
 };
 
 /// @}
@@ -678,7 +674,8 @@ Result<Datum> CumulativeMin(
 /// \return result as array
 ARROW_EXPORT
 Result<std::shared_ptr<Array>> PairwiseDiff(const Array& array,
-                                            const PairwiseDiffOptions& options,
+                                            const PairwiseOptions& options,
+                                            bool check_overflow = false,
                                             ExecContext* ctx = NULLPTR);
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/compute/api_vector.h
+++ b/cpp/src/arrow/compute/api_vector.h
@@ -663,10 +663,13 @@ Result<Datum> CumulativeMin(
 
 /// \brief Return the first order difference of an array.
 ///
-/// Computes the first order difference of an array, i.e. output[i] = input[i] - input[i -
-/// p] if i >= p, otherwise output[i] = null, where p is the period. For example, with p =
-/// 1, Diff([1, 4, 9, 10, 15]) = [null, 3, 5, 1, 5]. With p = 2, Diff([1, 4, 9, 10, 15]) =
-/// [null, null, 8, 6, 6]
+/// Computes the first order difference of an array, i.e.
+///   output[i] = input[i] - input[i - p]  if i >= p
+///   output[i] = null                     otherwise
+/// where p is the period. For example, with p = 1,
+///   Diff([1, 4, 9, 10, 15]) = [null, 3, 5, 1, 5].
+/// With p = 2,
+///   Diff([1, 4, 9, 10, 15]) = [null, null, 8, 6, 6]
 ///
 /// \param[in] array array input
 /// \param[in] options options, specifying overflow behavior and period

--- a/cpp/src/arrow/compute/exec.h
+++ b/cpp/src/arrow/compute/exec.h
@@ -356,6 +356,9 @@ struct ARROW_EXPORT ExecResult {
   const std::shared_ptr<ArrayData>& array_data() const {
     return std::get<std::shared_ptr<ArrayData>>(this->value);
   }
+  ArrayData* array_data_mutable() {
+    return std::get<std::shared_ptr<ArrayData>>(this->value).get();
+  }
 
   bool is_array_data() const { return this->value.index() == 1; }
 };

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -283,7 +283,12 @@ class ARROW_EXPORT OutputType {
   ///
   /// This function SHOULD _not_ be used to check for arity, that is to be
   /// performed one or more layers above.
-  using Resolver = Result<TypeHolder> (*)(KernelContext*, const std::vector<TypeHolder>&);
+  using Resolver =
+      std::function<Result<TypeHolder>(KernelContext*, const std::vector<TypeHolder>&)>;
+
+  // For backward compatibility
+  using ResolverFuncPtr = Result<TypeHolder> (*)(KernelContext*,
+                                                 const std::vector<TypeHolder>&);
 
   /// \brief Output an exact type
   OutputType(std::shared_ptr<DataType> type)  // NOLINT implicit construction
@@ -291,6 +296,10 @@ class ARROW_EXPORT OutputType {
 
   /// \brief Output a computed type depending on actual input types
   OutputType(Resolver resolver)  // NOLINT implicit construction
+      : kind_(COMPUTED), resolver_(std::move(resolver)) {}
+
+  /// \brief For backward compatibility
+  OutputType(ResolverFuncPtr resolver)  // NOLINT implicit construction
       : kind_(COMPUTED), resolver_(std::move(resolver)) {}
 
   OutputType(const OutputType& other) {

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -286,20 +286,13 @@ class ARROW_EXPORT OutputType {
   using Resolver =
       std::function<Result<TypeHolder>(KernelContext*, const std::vector<TypeHolder>&)>;
 
-  // For backward compatibility
-  using ResolverFuncPtr = Result<TypeHolder> (*)(KernelContext*,
-                                                 const std::vector<TypeHolder>&);
-
   /// \brief Output an exact type
   OutputType(std::shared_ptr<DataType> type)  // NOLINT implicit construction
       : kind_(FIXED), type_(std::move(type)) {}
 
   /// \brief Output a computed type depending on actual input types
-  OutputType(Resolver resolver)  // NOLINT implicit construction
-      : kind_(COMPUTED), resolver_(std::move(resolver)) {}
-
-  /// \brief For backward compatibility
-  OutputType(ResolverFuncPtr resolver)  // NOLINT implicit construction
+  template <typename Fn>
+  OutputType(Fn resolver)  // NOLINT implicit construction
       : kind_(COMPUTED), resolver_(std::move(resolver)) {}
 
   OutputType(const OutputType& other) {

--- a/cpp/src/arrow/compute/kernels/CMakeLists.txt
+++ b/cpp/src/arrow/compute/kernels/CMakeLists.txt
@@ -69,6 +69,7 @@ add_arrow_benchmark(scalar_temporal_benchmark PREFIX "arrow-compute")
 add_arrow_compute_test(vector_test
                        SOURCES
                        vector_cumulative_ops_test.cc
+                       vector_pairwise_test.cc
                        vector_hash_test.cc
                        vector_nested_test.cc
                        vector_replace_test.cc

--- a/cpp/src/arrow/compute/kernels/vector_pairwise.cc
+++ b/cpp/src/arrow/compute/kernels/vector_pairwise.cc
@@ -1,3 +1,22 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Vector kernels for pairwise computation
+
 #include <memory>
 #include "arrow/builder.h"
 #include "arrow/compute/api_vector.h"
@@ -152,7 +171,6 @@ void RegisterPairwiseDiffKernels(FunctionRegistry* registry) {
        PairwiseDiffKernel<FloatType, FloatType, Subtract, SubtractChecked>},
       {float64(), float64(),
        PairwiseDiffKernel<DoubleType, DoubleType, Subtract, SubtractChecked>},
-
   };
 
   auto decimal_resolver = [](KernelContext*,

--- a/cpp/src/arrow/compute/kernels/vector_pairwise.cc
+++ b/cpp/src/arrow/compute/kernels/vector_pairwise.cc
@@ -42,11 +42,11 @@ namespace arrow::compute::internal {
 // We reuse the kernel exec function of a scalar binary function to compute pairwise
 // results. For example, for pairwise_diff, we reuse subtract's kernel exec.
 struct PairwiseState : KernelState {
-  PairwiseState(const PairwiseOptions& options, const ArrayKernelExec& scalar_exec)
+  PairwiseState(const PairwiseOptions& options, ArrayKernelExec scalar_exec)
       : periods(options.periods), scalar_exec(scalar_exec) {}
 
   int64_t periods;
-  const ArrayKernelExec& scalar_exec;
+  ArrayKernelExec scalar_exec;
 };
 
 /// A generic pairwise implementation that can be reused by different ops.

--- a/cpp/src/arrow/compute/kernels/vector_pairwise.cc
+++ b/cpp/src/arrow/compute/kernels/vector_pairwise.cc
@@ -146,7 +146,7 @@ void RegisterPairwiseDiffKernels(std::string_view func_name,
   auto base_func_result = registry->GetFunction(std::string(base_func_name));
   DCHECK_OK(base_func_result.status());
   const auto& base_func = checked_cast<const ScalarFunction&>(**base_func_result);
-  DCHECK(base_func.arity().num_args == 2);
+  DCHECK_EQ(base_func.arity().num_args, 2);
 
   for (const auto& base_func_kernel : base_func.kernels()) {
     const auto& base_func_kernel_sig = base_func_kernel->signature;

--- a/cpp/src/arrow/compute/kernels/vector_pairwise.cc
+++ b/cpp/src/arrow/compute/kernels/vector_pairwise.cc
@@ -1,0 +1,256 @@
+#include <memory>
+#include "arrow/builder.h"
+#include "arrow/compute/api_vector.h"
+#include "arrow/compute/exec.h"
+#include "arrow/compute/function.h"
+#include "arrow/compute/kernel.h"
+#include "arrow/compute/kernels/base_arithmetic_internal.h"
+#include "arrow/compute/kernels/codegen_internal.h"
+#include "arrow/compute/registry.h"
+#include "arrow/status.h"
+#include "arrow/type.h"
+#include "arrow/type_fwd.h"
+#include "arrow/type_traits.h"
+#include "arrow/util/checked_cast.h"
+#include "arrow/util/logging.h"
+#include "arrow/visit_type_inline.h"
+
+namespace arrow::compute::internal {
+
+template <typename InputType>
+Result<std::shared_ptr<DataType>> GetDiffOutputType(
+    const std::shared_ptr<arrow::DataType>& type) {
+  std::shared_ptr<DataType> output_type;
+  if constexpr (is_timestamp_type<InputType>::value) {  // timestamp -> duration with same
+                                                        // time unit
+    const auto* real_type = checked_cast<const TimestampType*>(type.get());
+    return std::make_shared<DurationType>(real_type->unit());
+  } else if constexpr (is_time_type<InputType>::value) {  // time -> duration with same
+                                                          // time unit
+    const auto* real_type = checked_cast<const InputType*>(type.get());
+    return std::make_shared<DurationType>(real_type->unit());
+  } else if constexpr (is_date_type<InputType>::value) {  // date -> duration
+    if constexpr (InputType::type_id == Type::DATE32) {   // date32 -> second
+      return duration(TimeUnit::SECOND);
+    } else {  // date64 -> millisecond
+      return duration(TimeUnit::MILLI);
+    }
+  } else if constexpr (is_decimal_type<InputType>::value) {  // decimal -> decimal with
+                                                             // precision + 1
+    const auto* real_type = checked_cast<const InputType*>(type.get());
+    if constexpr (InputType::type_id == Type::DECIMAL128) {
+      return Decimal128Type::Make(real_type->precision() + 1, real_type->scale());
+    } else {
+      return Decimal256Type::Make(real_type->precision() + 1, real_type->scale());
+    }
+  } else {
+    return type;
+  }
+}
+
+/// A generic pairwise implementation that can be reused by different Ops.
+template <typename InputType, typename OutputType, typename Op>
+Status PairwiseKernelImpl(const ArraySpan& input, int64_t periods,
+                          const std::shared_ptr<DataType>& output_type,
+                          std::shared_ptr<ArrayData>* result) {
+  typename TypeTraits<OutputType>::BuilderType builder(output_type,
+                                                       default_memory_pool());
+  RETURN_NOT_OK(builder.Reserve(input.length));
+
+  Status status;
+  auto valid_func = [&](typename GetViewType<InputType>::T left,
+                        typename GetViewType<InputType>::T right) {
+    auto result = Op::template Call<typename GetOutputType<OutputType>::T>(
+        nullptr, left, right, &status);
+    builder.UnsafeAppend(result);
+  };
+  auto null_func = [&]() { builder.UnsafeAppendNull(); };
+
+  if (periods > 0) {
+    periods = std::min(periods, input.length);
+    RETURN_NOT_OK(builder.AppendNulls(periods));
+    ArraySpan left(input);
+    left.SetSlice(periods, input.length - periods);
+    ArraySpan right(input);
+    right.SetSlice(0, input.length - periods);
+    VisitTwoArrayValuesInline<InputType, InputType>(left, right, valid_func, null_func);
+    RETURN_NOT_OK(status);
+  } else {
+    periods = std::max(periods, -input.length);
+    ArraySpan left(input);
+    left.SetSlice(0, input.length + periods);
+    ArraySpan right(input);
+    right.SetSlice(-periods, input.length + periods);
+    VisitTwoArrayValuesInline<InputType, InputType>(left, right, valid_func, null_func);
+    RETURN_NOT_OK(status);
+    RETURN_NOT_OK(builder.AppendNulls(-periods));
+  }
+  RETURN_NOT_OK(builder.FinishInternal(result));
+  return Status::OK();
+}
+
+template <typename InputType, typename OutputType, typename Subtract,
+          typename SubtractChecked>
+Status PairwiseDiffKernel(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
+  const PairwiseDiffOptions& options = OptionsWrapper<PairwiseDiffOptions>::Get(ctx);
+  std::shared_ptr<ArrayData> result;
+  auto input = batch[0].array;
+  ARROW_ASSIGN_OR_RAISE(auto output_type,
+                        GetDiffOutputType<InputType>(input.type->GetSharedPtr()));
+  if (options.check_overflow) {
+    RETURN_NOT_OK((PairwiseKernelImpl<InputType, OutputType, SubtractChecked>(
+        batch[0].array, options.periods, output_type, &result)));
+  } else {
+    RETURN_NOT_OK((PairwiseKernelImpl<InputType, OutputType, Subtract>(
+        batch[0].array, options.periods, output_type, &result)));
+  }
+
+  out->value = std::move(result);
+  return Status::OK();
+}
+
+const FunctionDoc pairwise_diff_doc(
+    "Compute first order difference of an array",
+    ("This function computes the first order difference of an array, i.e. output[i]\n"
+     "= input[i] - input[i - p] if i >= p, otherwise output[i] = null, where p is \n"
+     "the period. The period can also be negative. It internally calls the scalar \n"
+     "function Subtract to compute the differences, so its behavior and supported \n"
+     "types are the same as Subtract.\n"
+     "\n"
+     "The period and handling of overflow can be specified in PairwiseDiffOptions."),
+    {"input"}, "PairwiseDiffOptions");
+
+const PairwiseDiffOptions* GetDefaultPairwiseDiffOptions() {
+  static const auto kDefaultPairwiseDiffOptions = PairwiseDiffOptions::Defaults();
+  return &kDefaultPairwiseDiffOptions;
+}
+
+struct PairwiseKernelData {
+  InputType input;
+  OutputType output;
+  ArrayKernelExec exec;
+};
+
+void RegisterPairwiseDiffKernels(FunctionRegistry* registry) {
+  std::vector<PairwiseKernelData> pairwise_diff_kernels = {
+      {int8(), int8(), PairwiseDiffKernel<Int8Type, Int8Type, Subtract, SubtractChecked>},
+      {uint8(), uint8(),
+       PairwiseDiffKernel<UInt8Type, UInt8Type, Subtract, SubtractChecked>},
+      {int16(), int16(),
+       PairwiseDiffKernel<Int16Type, Int16Type, Subtract, SubtractChecked>},
+      {uint16(), uint16(),
+       PairwiseDiffKernel<UInt16Type, UInt16Type, Subtract, SubtractChecked>},
+      {int32(), int32(),
+       PairwiseDiffKernel<Int32Type, Int32Type, Subtract, SubtractChecked>},
+      {uint32(), uint32(),
+       PairwiseDiffKernel<UInt32Type, UInt32Type, Subtract, SubtractChecked>},
+      {int64(), int64(),
+       PairwiseDiffKernel<Int64Type, Int64Type, Subtract, SubtractChecked>},
+      {uint64(), uint64(),
+       PairwiseDiffKernel<UInt64Type, UInt64Type, Subtract, SubtractChecked>},
+      {float32(), float32(),
+       PairwiseDiffKernel<FloatType, FloatType, Subtract, SubtractChecked>},
+      {float64(), float64(),
+       PairwiseDiffKernel<DoubleType, DoubleType, Subtract, SubtractChecked>},
+
+  };
+
+  auto decimal_resolver = [](KernelContext*,
+                             const std::vector<TypeHolder>& types) -> Result<TypeHolder> {
+    // Subtract increase decimal precision by one
+    DCHECK(is_decimal(types[0].id()));
+    auto decimal_type = checked_cast<const DecimalType*>(types[0].type);
+    return decimal(decimal_type->precision() + 1, decimal_type->scale());
+  };
+
+  pairwise_diff_kernels.emplace_back(PairwiseKernelData{
+      Type::DECIMAL128, OutputType(decimal_resolver),
+      PairwiseDiffKernel<Decimal128Type, Decimal128Type, Subtract, SubtractChecked>});
+  pairwise_diff_kernels.emplace_back(PairwiseKernelData{
+      Type::DECIMAL256, OutputType(decimal_resolver),
+      PairwiseDiffKernel<Decimal256Type, Decimal256Type, Subtract, SubtractChecked>});
+
+  auto identity_resolver =
+      [](KernelContext*, const std::vector<TypeHolder>& types) -> Result<TypeHolder> {
+    return types[0];
+  };
+
+  // timestamp -> duration
+  for (auto unit : TimeUnit::values()) {
+    InputType in_type(match::TimestampTypeUnit(unit));
+    OutputType out_type(duration(unit));
+    auto exec =
+        PairwiseDiffKernel<TimestampType, DurationType, Subtract, SubtractChecked>;
+    pairwise_diff_kernels.emplace_back(PairwiseKernelData{in_type, out_type, exec});
+  }
+
+  // duration -> duration
+  for (auto unit : TimeUnit::values()) {
+    InputType in_type(match::DurationTypeUnit(unit));
+    OutputType out_type(identity_resolver);
+    auto exec = PairwiseDiffKernel<DurationType, DurationType, Subtract, SubtractChecked>;
+    pairwise_diff_kernels.emplace_back(
+        PairwiseKernelData{in_type, out_type, std::move(exec)});
+  }
+
+  // time32 -> duration
+  for (auto unit : {TimeUnit::SECOND, TimeUnit::MILLI}) {
+    InputType in_type(match::Time32TypeUnit(unit));
+    OutputType out_type(duration(unit));
+    auto exec = PairwiseDiffKernel<Time32Type, DurationType, Subtract, SubtractChecked>;
+    pairwise_diff_kernels.emplace_back(
+        PairwiseKernelData{in_type, out_type, std::move(exec)});
+  }
+
+  // time64 -> duration
+  for (auto unit : {TimeUnit::MICRO, TimeUnit::NANO}) {
+    InputType in_type(match::Time64TypeUnit(unit));
+    OutputType out_type(duration(unit));
+    auto exec = PairwiseDiffKernel<Time64Type, DurationType, Subtract, SubtractChecked>;
+    pairwise_diff_kernels.emplace_back(
+        PairwiseKernelData{in_type, out_type, std::move(exec)});
+  }
+
+  // date32 -> duration(TimeUnit::SECOND)
+  {
+    InputType in_type(date32());
+    OutputType out_type(duration(TimeUnit::SECOND));
+    auto exec = PairwiseDiffKernel<Date32Type, DurationType, SubtractDate32,
+                                   SubtractCheckedDate32>;
+    pairwise_diff_kernels.emplace_back(
+        PairwiseKernelData{in_type, out_type, std::move(exec)});
+  }
+
+  // date64 -> duration(TimeUnit::MILLI)
+  {
+    InputType in_type(date64());
+    OutputType out_type(duration(TimeUnit::MILLI));
+    auto exec = PairwiseDiffKernel<Date64Type, DurationType, Subtract, SubtractChecked>;
+    pairwise_diff_kernels.emplace_back(
+        PairwiseKernelData{in_type, out_type, std::move(exec)});
+  }
+
+  VectorKernel base_kernel;
+  base_kernel.can_execute_chunkwise = false;
+  base_kernel.null_handling = NullHandling::COMPUTED_NO_PREALLOCATE;
+  base_kernel.mem_allocation = MemAllocation::NO_PREALLOCATE;
+  base_kernel.init = OptionsWrapper<PairwiseDiffOptions>::Init;
+  auto func =
+      std::make_shared<VectorFunction>("pairwise_diff", Arity::Unary(), pairwise_diff_doc,
+                                       GetDefaultPairwiseDiffOptions());
+
+  for (const auto& kernel_data : pairwise_diff_kernels) {
+    base_kernel.signature =
+        KernelSignature::Make({kernel_data.input}, kernel_data.output);
+    base_kernel.exec = kernel_data.exec;
+    DCHECK_OK(func->AddKernel(base_kernel));
+  }
+
+  DCHECK_OK(registry->AddFunction(std::move(func)));
+}
+
+void RegisterVectorPairwise(FunctionRegistry* registry) {
+  RegisterPairwiseDiffKernels(registry);
+}
+
+}  // namespace arrow::compute::internal

--- a/cpp/src/arrow/compute/kernels/vector_pairwise.cc
+++ b/cpp/src/arrow/compute/kernels/vector_pairwise.cc
@@ -59,8 +59,8 @@ Status PairwiseExecImpl(KernelContext* ctx, const ArraySpan& input,
   auto computed_length = input.length - margin_length;
   auto margin_start = periods > 0 ? 0 : computed_length;
   auto computed_start = periods > 0 ? margin_length : 0;
-  auto left_start = periods > 0 ? margin_length : 0;
-  auto right_start = periods > 0 ? 0 : margin_length;
+  auto left_start = computed_start;
+  auto right_start = margin_length - computed_start;
   // prepare bitmap
   bit_util::ClearBitmap(result->buffers[0]->mutable_data(), margin_start, margin_length);
   for (int64_t i = computed_start; i < computed_start + computed_length; i++) {

--- a/cpp/src/arrow/compute/kernels/vector_pairwise.cc
+++ b/cpp/src/arrow/compute/kernels/vector_pairwise.cc
@@ -17,6 +17,7 @@
 
 // Vector kernels for pairwise computation
 
+#include <iostream>
 #include <memory>
 #include "arrow/builder.h"
 #include "arrow/compute/api_vector.h"
@@ -26,99 +27,75 @@
 #include "arrow/compute/kernels/base_arithmetic_internal.h"
 #include "arrow/compute/kernels/codegen_internal.h"
 #include "arrow/compute/registry.h"
+#include "arrow/compute/util.h"
 #include "arrow/status.h"
 #include "arrow/type.h"
 #include "arrow/type_fwd.h"
 #include "arrow/type_traits.h"
+#include "arrow/util/bit_util.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/logging.h"
 #include "arrow/visit_type_inline.h"
 
 namespace arrow::compute::internal {
 
-template <typename InputType>
-Result<std::shared_ptr<DataType>> GetDiffOutputType(
-    const std::shared_ptr<arrow::DataType>& type) {
-  std::shared_ptr<DataType> output_type;
-  if constexpr (is_timestamp_type<InputType>::value) {  // timestamp -> duration with same
-                                                        // time unit
-    const auto* real_type = checked_cast<const TimestampType*>(type.get());
-    return std::make_shared<DurationType>(real_type->unit());
-  } else if constexpr (is_time_type<InputType>::value) {  // time -> duration with same
-                                                          // time unit
-    const auto* real_type = checked_cast<const InputType*>(type.get());
-    return std::make_shared<DurationType>(real_type->unit());
-  } else if constexpr (is_date_type<InputType>::value) {  // date -> duration
-    if constexpr (InputType::type_id == Type::DATE32) {   // date32 -> second
-      return duration(TimeUnit::SECOND);
-    } else {  // date64 -> millisecond
-      return duration(TimeUnit::MILLI);
-    }
-  } else if constexpr (is_decimal_type<InputType>::value) {  // decimal -> decimal with
-                                                             // precision + 1
-    const auto* real_type = checked_cast<const InputType*>(type.get());
-    if constexpr (InputType::type_id == Type::DECIMAL128) {
-      return Decimal128Type::Make(real_type->precision() + 1, real_type->scale());
-    } else {
-      return Decimal256Type::Make(real_type->precision() + 1, real_type->scale());
-    }
-  } else {
-    return type;
-  }
+// We reuse the kernel exec function of a scalar binary function to compute pairwise
+// results. For example, for pairwise_diff, we reuse subtract's kernel exec.
+struct PairwiseState : KernelState {
+  PairwiseState(const PairwiseOptions& options, const ArrayKernelExec& scalar_exec)
+      : periods(options.periods), scalar_exec(scalar_exec) {}
+
+  int64_t periods;
+  const ArrayKernelExec& scalar_exec;
+};
+
+KernelInit GeneratePairwiseInit(const ArrayKernelExec& scalar_exec) {
+  return [&scalar_exec](KernelContext* ctx, const KernelInitArgs& args) {
+    return std::make_unique<PairwiseState>(
+        checked_cast<const PairwiseOptions&>(*args.options), scalar_exec);
+  };
 }
 
-/// A generic pairwise implementation that can be reused by different Ops.
-template <typename InputType, typename OutputType, typename Op>
-Status PairwiseKernelImpl(const ArraySpan& input, int64_t periods,
-                          const std::shared_ptr<DataType>& output_type,
-                          std::shared_ptr<ArrayData>* result) {
-  typename TypeTraits<OutputType>::BuilderType builder(output_type,
-                                                       default_memory_pool());
-  RETURN_NOT_OK(builder.Reserve(input.length));
-
-  Status status;
-  auto valid_func = [&](typename GetViewType<InputType>::T left,
-                        typename GetViewType<InputType>::T right) {
-    auto result = Op::template Call<typename GetOutputType<OutputType>::T>(
-        nullptr, left, right, &status);
-    builder.UnsafeAppend(result);
-  };
-  auto null_func = [&]() { builder.UnsafeAppendNull(); };
-
-  if (periods > 0) {
-    periods = std::min(periods, input.length);
-    RETURN_NOT_OK(builder.AppendNulls(periods));
-    ArraySpan left(input);
-    left.SetSlice(periods, input.length - periods);
-    ArraySpan right(input);
-    right.SetSlice(0, input.length - periods);
-    VisitTwoArrayValuesInline<InputType, InputType>(left, right, valid_func, null_func);
-    RETURN_NOT_OK(status);
-  } else {
-    periods = std::max(periods, -input.length);
-    ArraySpan left(input);
-    left.SetSlice(0, input.length + periods);
-    ArraySpan right(input);
-    right.SetSlice(-periods, input.length + periods);
-    VisitTwoArrayValuesInline<InputType, InputType>(left, right, valid_func, null_func);
-    RETURN_NOT_OK(status);
-    RETURN_NOT_OK(builder.AppendNulls(-periods));
+/// A generic pairwise implementation that can be reused by different ops.
+Status PairwiseExecImpl(KernelContext* ctx, const ArraySpan& input,
+                        const ArrayKernelExec& scalar_exec, int64_t periods,
+                        ArrayData* result) {
+  auto offset = abs(periods);
+  offset = std::min(offset, input.length);
+  auto exec_length = input.length - offset;
+  // prepare bitmap
+  auto null_start = periods > 0 ? 0 : exec_length;
+  auto non_null_start = periods > 0 ? offset : 0;
+  bit_util::ClearBitmap(result->buffers[0]->mutable_data(), null_start, offset);
+  for (int64_t i = non_null_start; i < non_null_start + exec_length; i++) {
+    if (input.IsValid(i) && input.IsValid(i - periods)) {
+      bit_util::SetBit(result->buffers[0]->mutable_data(), i);
+    } else {
+      bit_util::ClearBit(result->buffers[0]->mutable_data(), i);
+    }
   }
-  RETURN_NOT_OK(builder.FinishInternal(result));
+  // prepare input span
+  ArraySpan left(input);
+  left.SetSlice(periods > 0 ? offset : 0, exec_length);
+  ArraySpan right(input);
+  right.SetSlice(periods > 0 ? 0 : offset, exec_length);
+  // prepare output span
+  ArraySpan output_span;
+  output_span.SetMembers(*result);
+  output_span.offset = periods > 0 ? offset : 0;
+  output_span.length = exec_length;
+  ExecResult output{output_span};
+  // execute scalar function
+  RETURN_NOT_OK(scalar_exec(ctx, ExecSpan({left, right}, exec_length), &output));
+
   return Status::OK();
 }
 
-template <typename InputType, typename OutputType, typename Op>
-Status PairwiseDiffKernel(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
-  const PairwiseOptions& options = OptionsWrapper<PairwiseOptions>::Get(ctx);
-  std::shared_ptr<ArrayData> result;
+Status PairwiseExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
+  const auto& state = checked_cast<const PairwiseState&>(*ctx->state());
   auto input = batch[0].array;
-  ARROW_ASSIGN_OR_RAISE(auto output_type,
-                        GetDiffOutputType<InputType>(input.type->GetSharedPtr()));
-  RETURN_NOT_OK((PairwiseKernelImpl<InputType, OutputType, Op>(
-      batch[0].array, options.periods, output_type, &result)));
-
-  out->value = std::move(result);
+  RETURN_NOT_OK(PairwiseExecImpl(ctx, batch[0].array, state.scalar_exec, state.periods,
+                                 out->array_data_mutable()));
   return Status::OK();
 }
 
@@ -155,118 +132,51 @@ struct PairwiseKernelData {
   ArrayKernelExec exec;
 };
 
-template <typename Op, typename OpDate32>
-void RegisterPairwiseDiffKernels(std::string_view func_name, const FunctionDoc& doc,
+void RegisterPairwiseDiffKernels(std::string_view func_name,
+                                 std::string_view base_func_name, const FunctionDoc& doc,
                                  FunctionRegistry* registry) {
-  std::vector<PairwiseKernelData> pairwise_diff_kernels = {
-      {int8(), int8(), PairwiseDiffKernel<Int8Type, Int8Type, Op>},
-      {uint8(), uint8(), PairwiseDiffKernel<UInt8Type, UInt8Type, Op>},
-      {int16(), int16(), PairwiseDiffKernel<Int16Type, Int16Type, Op>},
-      {uint16(), uint16(), PairwiseDiffKernel<UInt16Type, UInt16Type, Op>},
-      {int32(), int32(), PairwiseDiffKernel<Int32Type, Int32Type, Op>},
-      {uint32(), uint32(), PairwiseDiffKernel<UInt32Type, UInt32Type, Op>},
-      {int64(), int64(), PairwiseDiffKernel<Int64Type, Int64Type, Op>},
-      {uint64(), uint64(), PairwiseDiffKernel<UInt64Type, UInt64Type, Op>},
-      {float32(), float32(), PairwiseDiffKernel<FloatType, FloatType, Op>},
-      {float64(), float64(), PairwiseDiffKernel<DoubleType, DoubleType, Op>},
-  };
-
-  auto decimal_resolver = [](KernelContext*,
-                             const std::vector<TypeHolder>& types) -> Result<TypeHolder> {
-    // Subtract increase decimal precision by one
-    DCHECK(is_decimal(types[0].id()));
-    auto decimal_type = checked_cast<const DecimalType*>(types[0].type);
-    return decimal(decimal_type->precision() + 1, decimal_type->scale());
-  };
-
-  pairwise_diff_kernels.emplace_back(
-      PairwiseKernelData{Type::DECIMAL128, OutputType(decimal_resolver),
-                         PairwiseDiffKernel<Decimal128Type, Decimal128Type, Op>});
-  pairwise_diff_kernels.emplace_back(
-      PairwiseKernelData{Type::DECIMAL256, OutputType(decimal_resolver),
-                         PairwiseDiffKernel<Decimal256Type, Decimal256Type, Op>});
-
-  auto identity_resolver =
-      [](KernelContext*, const std::vector<TypeHolder>& types) -> Result<TypeHolder> {
-    return types[0];
-  };
-
-  // timestamp -> duration
-  for (auto unit : TimeUnit::values()) {
-    InputType in_type(match::TimestampTypeUnit(unit));
-    OutputType out_type(duration(unit));
-    auto exec = PairwiseDiffKernel<TimestampType, DurationType, Op>;
-    pairwise_diff_kernels.emplace_back(PairwiseKernelData{in_type, out_type, exec});
-  }
-
-  // duration -> duration
-  for (auto unit : TimeUnit::values()) {
-    InputType in_type(match::DurationTypeUnit(unit));
-    OutputType out_type(identity_resolver);
-    auto exec = PairwiseDiffKernel<DurationType, DurationType, Op>;
-    pairwise_diff_kernels.emplace_back(
-        PairwiseKernelData{in_type, out_type, std::move(exec)});
-  }
-
-  // time32 -> duration
-  for (auto unit : {TimeUnit::SECOND, TimeUnit::MILLI}) {
-    InputType in_type(match::Time32TypeUnit(unit));
-    OutputType out_type(duration(unit));
-    auto exec = PairwiseDiffKernel<Time32Type, DurationType, Op>;
-    pairwise_diff_kernels.emplace_back(
-        PairwiseKernelData{in_type, out_type, std::move(exec)});
-  }
-
-  // time64 -> duration
-  for (auto unit : {TimeUnit::MICRO, TimeUnit::NANO}) {
-    InputType in_type(match::Time64TypeUnit(unit));
-    OutputType out_type(duration(unit));
-    auto exec = PairwiseDiffKernel<Time64Type, DurationType, Op>;
-    pairwise_diff_kernels.emplace_back(
-        PairwiseKernelData{in_type, out_type, std::move(exec)});
-  }
-
-  // date32 -> duration(TimeUnit::SECOND)
-  {
-    InputType in_type(date32());
-    OutputType out_type(duration(TimeUnit::SECOND));
-    auto exec = PairwiseDiffKernel<Date32Type, DurationType, OpDate32>;
-    pairwise_diff_kernels.emplace_back(
-        PairwiseKernelData{in_type, out_type, std::move(exec)});
-  }
-
-  // date64 -> duration(TimeUnit::MILLI)
-  {
-    InputType in_type(date64());
-    OutputType out_type(duration(TimeUnit::MILLI));
-    auto exec = PairwiseDiffKernel<Date64Type, DurationType, Op>;
-    pairwise_diff_kernels.emplace_back(
-        PairwiseKernelData{in_type, out_type, std::move(exec)});
-  }
-
   VectorKernel base_kernel;
   base_kernel.can_execute_chunkwise = false;
-  base_kernel.null_handling = NullHandling::COMPUTED_NO_PREALLOCATE;
-  base_kernel.mem_allocation = MemAllocation::NO_PREALLOCATE;
+  base_kernel.null_handling = NullHandling::COMPUTED_PREALLOCATE;
+  base_kernel.mem_allocation = MemAllocation::PREALLOCATE;
   base_kernel.init = OptionsWrapper<PairwiseOptions>::Init;
   auto func = std::make_shared<VectorFunction>(std::string(func_name), Arity::Unary(),
                                                doc, GetDefaultPairwiseOptions());
 
-  for (const auto& kernel_data : pairwise_diff_kernels) {
-    base_kernel.signature =
-        KernelSignature::Make({kernel_data.input}, kernel_data.output);
-    base_kernel.exec = kernel_data.exec;
-    DCHECK_OK(func->AddKernel(base_kernel));
+  auto base_func_result = registry->GetFunction(std::string(base_func_name));
+  DCHECK_OK(base_func_result.status());
+  const auto& base_func = checked_cast<const ScalarFunction&>(**base_func_result);
+  DCHECK(base_func.arity().num_args == 2);
+
+  for (const auto& base_func_kernel : base_func.kernels()) {
+    const auto& base_func_kernel_sig = base_func_kernel->signature;
+    if (base_func_kernel_sig->in_types()[0].Equals(base_func_kernel_sig->in_types()[1])) {
+      OutputType out_type(base_func_kernel_sig->out_type());
+      // Need to wrap base output resolver
+      if (out_type.kind() == OutputType::COMPUTED) {
+        const auto& base_resolver = base_func_kernel_sig->out_type().resolver();
+        auto resolver = [&base_resolver](KernelContext* ctx,
+                                         const std::vector<TypeHolder>& input_types) {
+          return base_resolver(ctx, {input_types[0], input_types[0]});
+        };
+        out_type = OutputType(resolver);
+      }
+
+      base_kernel.signature =
+          KernelSignature::Make({base_func_kernel_sig->in_types()[0]}, out_type);
+      base_kernel.exec = PairwiseExec;
+      base_kernel.init = GeneratePairwiseInit(base_func_kernel->exec);
+      DCHECK_OK(func->AddKernel(base_kernel));
+    }
   }
 
   DCHECK_OK(registry->AddFunction(std::move(func)));
 }
 
 void RegisterVectorPairwise(FunctionRegistry* registry) {
-  RegisterPairwiseDiffKernels<Subtract, SubtractDate32>("pairwise_diff",
-                                                        pairwise_diff_doc, registry);
-  RegisterPairwiseDiffKernels<SubtractChecked, SubtractCheckedDate32>(
-      "pairwise_diff_checked", pairwise_diff_checked_doc, registry);
+  RegisterPairwiseDiffKernels("pairwise_diff", "subtract", pairwise_diff_doc, registry);
+  RegisterPairwiseDiffKernels("pairwise_diff_checked", "subtract_checked",
+                              pairwise_diff_checked_doc, registry);
 }
 
 }  // namespace arrow::compute::internal

--- a/cpp/src/arrow/compute/kernels/vector_pairwise.cc
+++ b/cpp/src/arrow/compute/kernels/vector_pairwise.cc
@@ -168,7 +168,6 @@ void RegisterPairwiseDiffKernels(std::string_view func_name,
       return std::make_unique<PairwiseState>(
           checked_cast<const PairwiseOptions&>(*args.options), scalar_exec);
     };
-    ;
     DCHECK_OK(func->AddKernel(kernel));
   }
 

--- a/cpp/src/arrow/compute/kernels/vector_pairwise_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_pairwise_test.cc
@@ -63,7 +63,7 @@ Result<std::shared_ptr<DataType>> GetOutputType(
   }
 }
 
-class TestDiffKernel : public ::testing::Test {
+class TestPairwiseDiff : public ::testing::Test {
  public:
   void SetUp() override {
     test_numerical_types_ = NumericTypes();
@@ -85,7 +85,7 @@ class TestDiffKernel : public ::testing::Test {
   std::vector<std::shared_ptr<DataType>> test_input_types_;
 };
 
-TEST_F(TestDiffKernel, Empty) {
+TEST_F(TestPairwiseDiff, Empty) {
   for (int64_t period = -2; period <= 2; ++period) {
     PairwiseOptions options(period);
     for (auto input_type : test_input_types_) {
@@ -97,7 +97,7 @@ TEST_F(TestDiffKernel, Empty) {
   }
 }
 
-TEST_F(TestDiffKernel, AllNull) {
+TEST_F(TestPairwiseDiff, AllNull) {
   for (int64_t period = -2; period <= 2; ++period) {
     PairwiseOptions options(period);
     for (auto input_type : test_input_types_) {
@@ -109,7 +109,7 @@ TEST_F(TestDiffKernel, AllNull) {
   }
 }
 
-TEST_F(TestDiffKernel, Numeric) {
+TEST_F(TestPairwiseDiff, Numeric) {
   {
     PairwiseOptions options(1);
     for (auto input_type : test_numerical_types_) {
@@ -151,7 +151,7 @@ TEST_F(TestDiffKernel, Numeric) {
   }
 }
 
-TEST_F(TestDiffKernel, Overflow) {
+TEST_F(TestPairwiseDiff, Overflow) {
   {
     PairwiseOptions options(1);
     auto input = ArrayFromJSON(uint8(), "[3, 2, 1]");
@@ -169,7 +169,7 @@ TEST_F(TestDiffKernel, Overflow) {
   }
 }
 
-TEST_F(TestDiffKernel, Temporal) {
+TEST_F(TestPairwiseDiff, Temporal) {
   {
     PairwiseOptions options(1);
     for (auto input_type : test_temporal_types_) {
@@ -185,7 +185,7 @@ TEST_F(TestDiffKernel, Temporal) {
   }
 }
 
-TEST_F(TestDiffKernel, Decimal) {
+TEST_F(TestPairwiseDiff, Decimal) {
   {
     PairwiseOptions options(1);
     auto input = ArrayFromJSON(decimal(4, 2), R"(["11.00", "22.11", "-10.25", "33.45"])");

--- a/cpp/src/arrow/compute/kernels/vector_pairwise_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_pairwise_test.cc
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 #include <gtest/gtest.h>
 #include <memory>
 #include <string>

--- a/cpp/src/arrow/compute/kernels/vector_pairwise_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_pairwise_test.cc
@@ -1,0 +1,197 @@
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include "arrow/compute/api_vector.h"
+#include "arrow/compute/kernels/test_util.h"
+#include "arrow/compute/registry.h"
+#include "arrow/compute/type_fwd.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/testing/random.h"
+#include "arrow/testing/util.h"
+#include "arrow/type.h"
+#include "arrow/type_fwd.h"
+#include "gmock/gmock.h"
+
+namespace arrow::compute {
+
+Result<std::shared_ptr<DataType>> GetOutputType(
+    const std::shared_ptr<DataType> input_type) {
+  switch (input_type->id()) {
+    case Type::TIMESTAMP: {
+      return duration(checked_cast<const TimestampType&>(*input_type).unit());
+    }
+    case Type::TIME32: {
+      return duration(checked_cast<const Time32Type&>(*input_type).unit());
+    }
+    case Type::TIME64: {
+      return duration(checked_cast<const Time64Type&>(*input_type).unit());
+    }
+    case Type::DATE32: {
+      return duration(TimeUnit::SECOND);
+    }
+    case Type::DATE64: {
+      return duration(TimeUnit::MILLI);
+    }
+    case Type::DECIMAL128: {
+      const auto& real_type = checked_cast<const Decimal128Type&>(*input_type);
+      return Decimal128Type::Make(real_type.precision() + 1, real_type.scale());
+    }
+    case Type::DECIMAL256: {
+      const auto& real_type = checked_cast<const Decimal256Type&>(*input_type);
+      return Decimal256Type::Make(real_type.precision() + 1, real_type.scale());
+    }
+    default: {
+      return input_type;
+    }
+  }
+}
+
+class TestDiffKernel : public ::testing::Test {
+ public:
+  void SetUp() override {
+    test_numerical_types_ = NumericTypes();
+    test_temporal_types_ = TemporalTypes();
+    test_decimal_types_ = {decimal(4, 2), decimal(70, 10)};
+
+    test_input_types_.insert(test_input_types_.end(), test_numerical_types_.begin(),
+                             test_numerical_types_.end());
+    test_input_types_.insert(test_input_types_.end(), test_temporal_types_.begin(),
+                             test_temporal_types_.end());
+    test_input_types_.insert(test_input_types_.end(), test_decimal_types_.begin(),
+                             test_decimal_types_.end());
+  }
+
+ protected:
+  std::vector<std::shared_ptr<DataType>> test_numerical_types_;
+  std::vector<std::shared_ptr<DataType>> test_temporal_types_;
+  std::vector<std::shared_ptr<DataType>> test_decimal_types_;
+  std::vector<std::shared_ptr<DataType>> test_input_types_;
+};
+
+TEST_F(TestDiffKernel, Empty) {
+  for (int64_t period = -2; period <= 2; ++period) {
+    PairwiseDiffOptions options(period);
+    for (auto input_type : test_input_types_) {
+      ASSERT_OK_AND_ASSIGN(auto output_type, GetOutputType(input_type));
+      auto input = ArrayFromJSON(input_type, "[]");
+      auto output = ArrayFromJSON(output_type, "[]");
+      CheckVectorUnary("pairwise_diff", input, output, &options);
+    }
+  }
+}
+
+TEST_F(TestDiffKernel, AllNull) {
+  for (int64_t period = -2; period <= 2; ++period) {
+    PairwiseDiffOptions options(period);
+    for (auto input_type : test_input_types_) {
+      ASSERT_OK_AND_ASSIGN(auto output_type, GetOutputType(input_type));
+      auto input = ArrayFromJSON(input_type, "[null, null, null]");
+      auto output = ArrayFromJSON(output_type, "[null, null, null]");
+      CheckVectorUnary("pairwise_diff", input, output, &options);
+    }
+  }
+}
+
+TEST_F(TestDiffKernel, Numeric) {
+  {
+    PairwiseDiffOptions options(1);
+    for (auto input_type : test_numerical_types_) {
+      ASSERT_OK_AND_ASSIGN(auto output_type, GetOutputType(input_type));
+      auto input = ArrayFromJSON(input_type, "[null, 1, 2, null, 4, 5, 6]");
+      auto output = ArrayFromJSON(output_type, "[null, null, 1, null, null, 1, 1]");
+      CheckVectorUnary("pairwise_diff", input, output, &options);
+    }
+  }
+
+  {
+    PairwiseDiffOptions options(2);
+    for (auto input_type : test_numerical_types_) {
+      ASSERT_OK_AND_ASSIGN(auto output_type, GetOutputType(input_type));
+      auto input = ArrayFromJSON(input_type, "[null, 1, 2, null, 4, 5, 6]");
+      auto output = ArrayFromJSON(output_type, "[null, null, null, null, 2, null, 2]");
+      CheckVectorUnary("pairwise_diff", input, output, &options);
+    }
+  }
+
+  {
+    PairwiseDiffOptions options(-1);
+    for (auto input_type : test_numerical_types_) {
+      ASSERT_OK_AND_ASSIGN(auto output_type, GetOutputType(input_type));
+      auto input = ArrayFromJSON(input_type, "[6, 5, 4, null, 2, 1, null]");
+      auto output = ArrayFromJSON(output_type, "[1, 1, null, null, 1, null, null]");
+      CheckVectorUnary("pairwise_diff", input, output, &options);
+    }
+  }
+
+  {
+    PairwiseDiffOptions options(-2);
+    for (auto input_type : test_numerical_types_) {
+      ASSERT_OK_AND_ASSIGN(auto output_type, GetOutputType(input_type));
+      auto input = ArrayFromJSON(input_type, "[6, 5, 4, null, 2, 1, null]");
+      auto output = ArrayFromJSON(output_type, "[2, null, 2, null, null, null, null]");
+      CheckVectorUnary("pairwise_diff", input, output, &options);
+    }
+  }
+}
+
+TEST_F(TestDiffKernel, Overflow) {
+  {
+    PairwiseDiffOptions options(1);
+    auto input = ArrayFromJSON(uint8(), "[3, 2, 1]");
+    auto output = ArrayFromJSON(uint8(), "[null, 255, 255]");
+    CheckVectorUnary("pairwise_diff", input, output, &options);
+  }
+
+  {
+    PairwiseDiffOptions options(1, /*check_overflow=*/true);
+    auto input = ArrayFromJSON(uint8(), "[3, 2, 1]");
+    auto output = ArrayFromJSON(uint8(), "[null, 255, 255]");
+    EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, testing::HasSubstr("overflow"),
+                                    CallFunction("pairwise_diff", {input}, &options));
+  }
+}
+
+TEST_F(TestDiffKernel, Temporal) {
+  {
+    PairwiseDiffOptions options(1);
+    for (auto input_type : test_temporal_types_) {
+      ASSERT_OK_AND_ASSIGN(auto output_type, GetOutputType(input_type));
+      auto input = ArrayFromJSON(input_type, "[null, 5, 1, null, 9, 6, 37]");
+      auto output = ArrayFromJSON(
+          output_type,
+          input_type->id() != Type::DATE32  // Subtract date32 results in seconds
+              ? "[null, null, -4, null, null, -3, 31]"
+              : "[null, null, -345600, null, null, -259200, 2678400]");
+      CheckVectorUnary("pairwise_diff", input, output, &options);
+    }
+  }
+}
+
+TEST_F(TestDiffKernel, Decimal) {
+  {
+    PairwiseDiffOptions options(1);
+    auto input = ArrayFromJSON(decimal(4, 2), R"(["11.00", "22.11", "-10.25", "33.45"])");
+    auto output = ArrayFromJSON(decimal(5, 2), R"([null, "11.11", "-32.36", "43.70"])");
+    CheckVectorUnary("pairwise_diff", input, output, &options);
+  }
+
+  {
+    PairwiseDiffOptions options(-1);
+    auto input = ArrayFromJSON(
+        decimal(40, 30),
+        R"(["1111111111.222222222222222222222222222222", "2222222222.333333333333333333333333333333"])");
+    auto output = ArrayFromJSON(
+        decimal(41, 30), R"(["-1111111111.111111111111111111111111111111", null])");
+    CheckVectorUnary("pairwise_diff", input, output, &options);
+  }
+
+  {  /// Out of range decimal precision
+    PairwiseDiffOptions options(1);
+    auto input = ArrayFromJSON(decimal(38, 0), R"(["1e38"])");
+
+    EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid,
+                                    testing::HasSubstr("Decimal precision out of range"),
+                                    CallFunction("pairwise_diff", {input}, &options));
+  }
+}
+}  // namespace arrow::compute

--- a/cpp/src/arrow/compute/registry.cc
+++ b/cpp/src/arrow/compute/registry.cc
@@ -310,6 +310,7 @@ static std::unique_ptr<FunctionRegistry> CreateBuiltInRegistry() {
   RegisterVectorSort(registry.get());
   RegisterVectorRunEndEncode(registry.get());
   RegisterVectorRunEndDecode(registry.get());
+  RegisterVectorPairwise(registry.get());
 
   // Aggregate functions
   RegisterHashAggregateBasic(registry.get());

--- a/cpp/src/arrow/compute/registry_internal.h
+++ b/cpp/src/arrow/compute/registry_internal.h
@@ -54,7 +54,7 @@ void RegisterVectorSelection(FunctionRegistry* registry);
 void RegisterVectorSort(FunctionRegistry* registry);
 void RegisterVectorRunEndEncode(FunctionRegistry* registry);
 void RegisterVectorRunEndDecode(FunctionRegistry* registry);
-
+void RegisterVectorPairwise(FunctionRegistry* registry);
 void RegisterVectorOptions(FunctionRegistry* registry);
 
 // Aggregate functions

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -1850,7 +1850,7 @@ replaced, based on the remaining inputs.
 
 Pairwise functions
 ~~~~~~~~~~~~~~~~~~~~
-Pairwise functions are unary vector functions that performs a binary operation on 
+Pairwise functions are unary vector functions that perform a binary operation on 
 a pair of elements in the input array, typically on adjacent elements. The n-th
 output is computed by applying the binary operation on the n-th and (n-p)-th, 
 where p is the period. The default period is 1. The period can also be negative.

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -1851,16 +1851,21 @@ replaced, based on the remaining inputs.
 Pairwise functions
 ~~~~~~~~~~~~~~~~~~~~
 Pairwise functions are unary vector functions that performs a binary operation on 
-a pair of elements in the input array, typically on adjacent elements.
+a pair of elements in the input array, typically on adjacent elements. The n-th
+output is computed by applying the binary operation on the n-th and (n-p)-th, 
+where p is the period. The default period is 1. The period can also be negative.
 
-+------------------------+-------+----------------------+----------------------+--------------------------------+-------+
-| Function name          | Arity | Input types          | Output type          | Options class                  | Notes |
-+========================+=======+======================+======================+================================+=======+
-| pairwise_diff          | Unary | Numeric/Temporal     | Numeric/Temporal     | :struct:`PairwiseDiffOptions`  | \(1)  |
-+------------------------+-------+----------------------+----------------------+--------------------------------+-------+
-* \(1) Computes the first order difference of an array, i.e. output[i] =  
-  input[i] - input[i-period]. The default period is 1. The period can also 
-  be negative. It internally calls the scalar function ``Subtract`` to compute 
-  the differences, so its behavior and supported types are the same as 
-  ``Subtract``. The period and handling of overflow can be specified in
-  :struct:`PairwiseDiffOptions`. 
++------------------------+-------+----------------------+----------------------+--------------------------------+----------+
+| Function name          | Arity | Input types          | Output type          | Options class                  | Notes    |
++========================+=======+======================+======================+================================+==========+
+| pairwise_diff          | Unary | Numeric/Temporal     | Numeric/Temporal     | :struct:`PairwiseOptions`      | \(1)(2)  |
++------------------------+-------+----------------------+----------------------+--------------------------------+----------+
+| pairwise_diff_checked  | Unary | Numeric/Temporal     | Numeric/Temporal     | :struct:`PairwiseOptions`      | \(1)(3)  |
++------------------------+-------+----------------------+----------------------+--------------------------------+----------+
+
+* \(1) Computes the first order difference of an array, It internally calls 
+  the scalar function ``Subtract`` (or the checked variant) to compute 
+  differences, so its behavior and supported types are the same as 
+  ``Subtract``. The period can be specified in :struct:`PairwiseOptions`. 
+* \(2) Wraps around the result when overflow is detected.
+* \(3) Returns an ``Invalid`` :class:`Status` when overflow is detected.

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -1852,8 +1852,11 @@ Pairwise functions
 ~~~~~~~~~~~~~~~~~~~~
 Pairwise functions are unary vector functions that perform a binary operation on 
 a pair of elements in the input array, typically on adjacent elements. The n-th
-output is computed by applying the binary operation on the n-th and (n-p)-th, 
-where p is the period. The default period is 1. The period can also be negative.
+output is computed by applying the binary operation to the n-th and (n-p)-th inputs, 
+where p is the period. The default period is 1, in which case the binary
+operation is applied to adjacent pairs of inputs. The period can also be
+negative, in which case the n-th output is computed by applying the binary
+operation to the n-th and (n+abs(p))-th inputs.
 
 +------------------------+-------+----------------------+----------------------+--------------------------------+----------+
 | Function name          | Arity | Input types          | Output type          | Options class                  | Notes    |

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -1847,3 +1847,20 @@ replaced, based on the remaining inputs.
   results in a corresponding null in the output.
 
   Also see: :ref:`if_else <cpp-compute-scalar-selections>`.
+
+Pairwise functions
+~~~~~~~~~~~~~~~~~~~~
+Pairwise functions are unary vector functions that performs a binary operation on 
+a pair of elements in the input array, typically on adjacent elements.
+
++------------------------+-------+----------------------+----------------------+--------------------------------+-------+
+| Function name          | Arity | Input types          | Output type          | Options class                  | Notes |
++========================+=======+======================+======================+================================+=======+
+| pairwise_diff          | Unary | Numeric/Temporal     | Numeric/Temporal     | :struct:`PairwiseDiffOptions`  | \(1)  |
++------------------------+-------+----------------------+----------------------+--------------------------------+-------+
+* \(1) Computes the first order difference of an array, i.e. output[i] =  
+  input[i] - input[i-period]. The default period is 1. The period can also 
+  be negative. It internally calls the scalar function ``Subtract`` to compute 
+  the differences, so its behavior and supported types are the same as 
+  ``Subtract``. The period and handling of overflow can be specified in
+  :struct:`PairwiseDiffOptions`. 

--- a/docs/source/python/api/compute.rst
+++ b/docs/source/python/api/compute.rst
@@ -555,7 +555,7 @@ Compute Options
    ModeOptions
    NullOptions
    PadOptions
-   PairwiseDiffOptions
+   PairwiseOptions
    PartitionNthOptions
    QuantileOptions
    ReplaceSliceOptions

--- a/docs/source/python/api/compute.rst
+++ b/docs/source/python/api/compute.rst
@@ -521,6 +521,14 @@ Structural Transforms
    replace_with_mask
    struct_field
 
+Pairwise Functions
+------------------
+
+.. autosummary::
+   :toctree: ../generated/
+
+   pairwise_diff
+
 Compute Options
 ---------------
 
@@ -547,6 +555,7 @@ Compute Options
    ModeOptions
    NullOptions
    PadOptions
+   PairwiseDiffOptions
    PartitionNthOptions
    QuantileOptions
    ReplaceSliceOptions

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -1968,6 +1968,7 @@ class CumulativeOptions(_CumulativeOptions):
     def __init__(self, start=None, *, skip_nulls=False):
         self._set_options(start, skip_nulls)
 
+
 cdef class _PairwiseDiffOptions(FunctionOptions):
     def _set_options(self, period, check_overflow):
         self.wrapped.reset(new CPairwiseDiffOptions(period, check_overflow))
@@ -1987,6 +1988,7 @@ class PairwiseDiffOptions(_PairwiseDiffOptions):
 
     def __init__(self, period=1, check_overflow=False):
         self._set_options(period, check_overflow)
+
 
 cdef class _ArraySortOptions(FunctionOptions):
     def _set_options(self, order, null_placement):

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -1968,6 +1968,25 @@ class CumulativeOptions(_CumulativeOptions):
     def __init__(self, start=None, *, skip_nulls=False):
         self._set_options(start, skip_nulls)
 
+cdef class _PairwiseDiffOptions(FunctionOptions):
+    def _set_options(self, period, check_overflow):
+        self.wrapped.reset(new CPairwiseDiffOptions(period, check_overflow))
+
+
+class PairwiseDiffOptions(_PairwiseDiffOptions):
+    """
+    Options for `pairwise_diff` function.
+
+    Parameters
+    ----------
+    period : int, default 1
+        Period for computing difference.
+    check_overflow : bool, default False
+        When true, return error on overflow. When false, wrap around on overflow.
+    """
+
+    def __init__(self, period=1, check_overflow=False):
+        self._set_options(period, check_overflow)
 
 cdef class _ArraySortOptions(FunctionOptions):
     def _set_options(self, order, null_placement):

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -1969,25 +1969,23 @@ class CumulativeOptions(_CumulativeOptions):
         self._set_options(start, skip_nulls)
 
 
-cdef class _PairwiseDiffOptions(FunctionOptions):
-    def _set_options(self, period, check_overflow):
-        self.wrapped.reset(new CPairwiseDiffOptions(period, check_overflow))
+cdef class _PairwiseOptions(FunctionOptions):
+    def _set_options(self, period):
+        self.wrapped.reset(new CPairwiseOptions(period))
 
 
-class PairwiseDiffOptions(_PairwiseDiffOptions):
+class PairwiseOptions(_PairwiseOptions):
     """
-    Options for `pairwise_diff` function.
+    Options for `pairwise` functions.
 
     Parameters
     ----------
     period : int, default 1
-        Period for computing difference.
-    check_overflow : bool, default False
-        When true, return error on overflow. When false, wrap around on overflow.
+        Period for applying the period function.
     """
 
-    def __init__(self, period=1, check_overflow=False):
-        self._set_options(period, check_overflow)
+    def __init__(self, period=1):
+        self._set_options(period)
 
 
 cdef class _ArraySortOptions(FunctionOptions):

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -50,6 +50,7 @@ from pyarrow._compute import (  # noqa
     ModeOptions,
     NullOptions,
     PadOptions,
+    PairwiseDiffOptions,
     PartitionNthOptions,
     QuantileOptions,
     RandomOptions,

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -50,7 +50,7 @@ from pyarrow._compute import (  # noqa
     ModeOptions,
     NullOptions,
     PadOptions,
-    PairwiseDiffOptions,
+    PairwiseOptions,
     PartitionNthOptions,
     QuantileOptions,
     RandomOptions,

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2407,11 +2407,10 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
         optional[shared_ptr[CScalar]] start
         c_bool skip_nulls
 
-    cdef cppclass CPairwiseDiffOptions \
-            "arrow::compute::PairwiseDiffOptions"(CFunctionOptions):
-        CPairwiseDiffOptions(int64_t period, c_bool skip_nulls)
+    cdef cppclass CPairwiseOptions \
+            "arrow::compute::PairwiseOptions"(CFunctionOptions):
+        CPairwiseOptions(int64_t period)
         int64_t period
-        c_bool skip_nulls
 
     cdef cppclass CArraySortOptions \
             "arrow::compute::ArraySortOptions"(CFunctionOptions):

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2407,6 +2407,12 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
         optional[shared_ptr[CScalar]] start
         c_bool skip_nulls
 
+    cdef cppclass CPairwiseDiffOptions \
+            "arrow::compute::PairwiseDiffOptions"(CFunctionOptions):
+        CPairwiseDiffOptions(int64_t period, c_bool skip_nulls)
+        int64_t period
+        c_bool skip_nulls
+
     cdef cppclass CArraySortOptions \
             "arrow::compute::ArraySortOptions"(CFunctionOptions):
         CArraySortOptions(CSortOrder, CNullPlacement)

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -155,7 +155,7 @@ def test_option_class_equality():
         pc.ModeOptions(),
         pc.NullOptions(),
         pc.PadOptions(5),
-        pc.PairwiseDiffOptions(period=1, check_overflow=False),
+        pc.PairwiseOptions(period=1),
         pc.PartitionNthOptions(1, null_placement="at_start"),
         pc.CumulativeOptions(start=None, skip_nulls=False),
         pc.QuantileOptions(),
@@ -3511,4 +3511,4 @@ def test_pairwise_diff():
     arr = pa.array([1, 2, 3, None, 4, 5], type=pa.uint8())
     with pytest.raises(pa.ArrowInvalid,
                        match="overflow"):
-        pa.compute.pairwise_diff(arr, period=-1, check_overflow=True)
+        pa.compute.pairwise_diff_checked(arr, period=-1)

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -155,6 +155,7 @@ def test_option_class_equality():
         pc.ModeOptions(),
         pc.NullOptions(),
         pc.PadOptions(5),
+        pc.PairwiseDiffOptions(period=1, check_overflow=False),
         pc.PartitionNthOptions(1, null_placement="at_start"),
         pc.CumulativeOptions(start=None, skip_nulls=False),
         pc.QuantileOptions(),
@@ -3481,3 +3482,33 @@ def test_run_end_encode():
     check_run_end_encode_decode(pc.RunEndEncodeOptions(pa.int16()))
     check_run_end_encode_decode(pc.RunEndEncodeOptions('int32'))
     check_run_end_encode_decode(pc.RunEndEncodeOptions(pa.int64()))
+
+
+def test_pairwise_diff():
+    arr = pa.array([1, 2, 3, None, 4, 5])
+    expected = pa.array([None, 1, 1, None, None, 1])
+    result = pa.compute.pairwise_diff(arr, period=1)
+    assert result.equals(expected)
+
+    arr = pa.array([1, 2, 3, None, 4, 5])
+    expected = pa.array([None, None, 2, None, 1, None])
+    result = pa.compute.pairwise_diff(arr, period=2)
+    assert result.equals(expected)
+
+    # negative period
+    arr = pa.array([1, 2, 3, None, 4, 5], type=pa.int8())
+    expected = pa.array([-1, -1, None, None, -1, None], type=pa.int8())
+    result = pa.compute.pairwise_diff(arr, period=-1)
+    assert result.equals(expected)
+
+    # wrap around overflow
+    arr = pa.array([1, 2, 3, None, 4, 5], type=pa.uint8())
+    expected = pa.array([255, 255, None, None, 255, None], type=pa.uint8())
+    result = pa.compute.pairwise_diff(arr, period=-1)
+    assert result.equals(expected)
+
+    # fail on overflow
+    arr = pa.array([1, 2, 3, None, 4, 5], type=pa.uint8())
+    with pytest.raises(pa.ArrowInvalid,
+                       match="overflow"):
+        pa.compute.pairwise_diff(arr, period=-1, check_overflow=True)


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Add a `pairwise_diff` function similar to pandas' [Series.Diff](https://pandas.pydata.org/docs/reference/api/pandas.Series.diff.html), the function computes the first order difference of an array.
### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

I followed [these instructions](https://github.com/apache/arrow/pull/12460#issuecomment-1057520554). The function is implemented for numerical, temporal and decimal types. Chuck arrays are not yet supported.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes. They are tested in vector_pairwise_test.cc and in python/pyarrow/tests/compute.py.

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes, and docs are also updated in this PR.

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #35786