### PR TITLE
GH-35579: [C++] Support non-named FieldRefs in Parquet scanner

### DIFF
--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -224,23 +224,11 @@ Status ResolveOneFieldRef(
   return Status::OK();
 }
 
-bool IsNamedFieldRef(const FieldRef& ref) {
-  if (ref.IsName()) return true;
-  if (const auto* nested_refs = ref.nested_refs()) {
-    for (const auto& nested_ref : *nested_refs) {
-      if (!nested_ref.IsName()) return false;
-    }
-    return true;
-  }
-  return false;
-}
-
 // Converts a field ref into a position-independent ref (containing only a sequence of
 // names) based on the dataset schema. Returns `false` if no conversion was needed.
-Status MaybeConvertFieldRef(const FieldRef& ref, const Schema& dataset_schema,
-                            FieldRef* out) {
-  if (ARROW_PREDICT_TRUE(IsNamedFieldRef(ref))) {
-    return Status::OK();
+Result<FieldRef> MaybeConvertFieldRef(FieldRef ref, const Schema& dataset_schema) {
+  if (ARROW_PREDICT_TRUE(ref.IsNameSequence())) {
+    return std::move(ref);
   }
 
   ARROW_ASSIGN_OR_RAISE(auto path, ref.FindOne(dataset_schema));
@@ -254,9 +242,8 @@ Status MaybeConvertFieldRef(const FieldRef& ref, const Schema& dataset_schema,
     child_fields = &child_field.type()->fields();
   }
 
-  *out =
-      named_refs.size() == 1 ? std::move(named_refs[0]) : FieldRef(std::move(named_refs));
-  return Status::OK();
+  return named_refs.size() == 1 ? std::move(named_refs[0])
+                                : FieldRef(std::move(named_refs));
 }
 
 // Compute the column projection based on the scan options
@@ -287,7 +274,8 @@ Result<std::vector<int>> InferColumnProjection(const parquet::arrow::FileReader&
     // In the (unlikely) absence of a known dataset schema, we require that all
     // materialized refs are named.
     if (options.dataset_schema) {
-      ARROW_RETURN_NOT_OK(MaybeConvertFieldRef(ref, *options.dataset_schema, &ref));
+      ARROW_ASSIGN_OR_RAISE(
+          ref, MaybeConvertFieldRef(std::move(ref), *options.dataset_schema));
     }
     RETURN_NOT_OK(ResolveOneFieldRef(manifest, ref, field_lookup, duplicate_fields,
                                      &columns_selection));

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -678,6 +678,42 @@ TEST_P(TestParquetFileFormatScan, PredicatePushdownRowGroupFragmentsUsingStringC
   CountRowGroupsInFragment(fragment, {0, 3}, equal(field_ref("x"), literal("a")));
 }
 
+// Tests projection with nested/indexed FieldRefs.
+// https://github.com/apache/arrow/issues/35579
+TEST_P(TestParquetFileFormatScan, ProjectWithNonNamedFieldRefs) {
+  auto table_schema = schema(
+      {field("info", struct_({field("name", utf8()),
+                              field("data", struct_({field("amount", float64()),
+                                                     field("percent", float32())}))}))});
+  auto table = TableFromJSON(table_schema, {R"([
+    {"info": {"name": "a", "data": {"amount": 10.3, "percent": 0.1}}},
+    {"info": {"name": "b", "data": {"amount": 11.6, "percent": 0.2}}},
+    {"info": {"name": "c", "data": {"amount": 12.9, "percent": 0.3}}},
+    {"info": {"name": "d", "data": {"amount": 14.2, "percent": 0.4}}},
+    {"info": {"name": "e", "data": {"amount": 15.5, "percent": 0.5}}},
+    {"info": {"name": "f", "data": {"amount": 16.8, "percent": 0.6}}}])"});
+  ASSERT_OK_AND_ASSIGN(auto expected_batch, table->CombineChunksToBatch());
+
+  TableBatchReader reader(*table);
+  SetSchema(reader.schema()->fields());
+
+  auto source = GetFileSource(&reader);
+  ASSERT_OK_AND_ASSIGN(auto fragment, format_->MakeFragment(*source));
+
+  std::vector<FieldRef> equivalent_refs = {
+      FieldRef("info", "data", "percent"), FieldRef("info", 1, 1),
+      FieldRef(0, 1, "percent"),           FieldRef(0, 1, 1),
+      FieldRef(0, FieldRef("data", 1)),    FieldRef(FieldRef(0), FieldRef(1, 1)),
+  };
+  for (const auto& ref : equivalent_refs) {
+    ARROW_SCOPED_TRACE("ref = ", ref.ToString());
+
+    Project({field_ref(ref)}, {"value"});
+    auto batch = SingleBatch(fragment);
+    AssertBatchesEqual(*expected_batch, *batch);
+  }
+}
+
 INSTANTIATE_TEST_SUITE_P(TestScan, TestParquetFileFormatScan,
                          ::testing::ValuesIn(TestFormatParams::Values()),
                          TestFormatParams::ToTestNameString);
@@ -692,56 +728,6 @@ TEST(TestParquetStatistics, NullMax) {
   auto stat_expression =
       ParquetFileFragment::EvaluateStatisticsAsExpression(*field, *statistics);
   EXPECT_EQ(stat_expression->ToString(), "(x >= 1)");
-}
-
-// Tests round-trip projection with nested/indexed FieldRefs
-// https://github.com/apache/arrow/issues/35579
-TEST(TestRoundTrip, ProjectedFieldRefs) {
-  auto test_schema = schema(
-      {field("id", uint32()),
-       field("info", struct_({field("name", utf8()),
-                              field("data", struct_({field("amount", float64()),
-                                                     field("percent", float32())}))}))});
-  auto test_table = TableFromJSON(test_schema, {R"([
-    {"id": 1, "info": {"name": "a", "data": {"amount": 10.3, "percent": 0.1}}},
-    {"id": 2, "info": {"name": "b", "data": {"amount": 11.6, "percent": 0.2}}},
-    {"id": 3, "info": {"name": "c", "data": {"amount": 12.9, "percent": 0.3}}},
-    {"id": 4, "info": {"name": "d", "data": {"amount": 14.2, "percent": 0.4}}},
-    {"id": 5, "info": {"name": "e", "data": {"amount": 15.5, "percent": 0.5}}},
-    {"id": 6, "info": {"name": "f", "data": {"amount": 16.8, "percent": 0.6}}}])"});
-  ASSERT_OK(test_table->ValidateFull());
-
-  ASSERT_OK_AND_ASSIGN(auto fs, fs::internal::MockFileSystem::Make(fs::kNoTime, {}));
-  ASSERT_OK_AND_ASSIGN(auto sink, fs->OpenOutputStream("test.parquet"));
-  ASSERT_OK(parquet::arrow::WriteTable(*test_table, arrow::default_memory_pool(), sink));
-  ASSERT_OK(sink->Close());
-  auto format = std::make_shared<ParquetFileFormat>();
-  ASSERT_OK_AND_ASSIGN(auto factory,
-                       FileSystemDatasetFactory::Make(fs, fs::FileSelector(), format,
-                                                      FileSystemFactoryOptions{}));
-  ASSERT_OK_AND_ASSIGN(auto dataset, factory->Finish());
-  AssertSchemaEqual(test_schema, dataset->schema());
-
-  auto expected_schema = schema({field("value", float32())});
-  auto expected_table = TableFromJSON(expected_schema, {R"([
-    {"value": 0.1},{"value": 0.2},{"value": 0.3},
-    {"value": 0.4},{"value": 0.5},{"value": 0.6}])"});
-
-  std::vector<FieldRef> equivalent_refs = {
-      FieldRef("info", "data", "percent"), FieldRef("info", 1, 1),
-      FieldRef(1, 1, "percent"),           FieldRef(1, 1, 1),
-      FieldRef(1, FieldRef("data", 1)),    FieldRef(FieldRef(1), FieldRef(1, 1)),
-  };
-  for (const auto& ref : equivalent_refs) {
-    ARROW_SCOPED_TRACE("ref = ", ref.ToString());
-
-    ScannerBuilder builder(dataset);
-    ASSERT_OK(builder.Project({field_ref(ref)}, {"value"}));
-    ASSERT_OK_AND_ASSIGN(auto scanner, builder.Finish());
-    ASSERT_OK_AND_ASSIGN(auto actual_table, scanner->ToTable());
-
-    AssertTablesEqual(*expected_table, *actual_table);
-  }
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -694,5 +694,55 @@ TEST(TestParquetStatistics, NullMax) {
   EXPECT_EQ(stat_expression->ToString(), "(x >= 1)");
 }
 
+// Tests round-trip projection with nested/indexed FieldRefs
+// https://github.com/apache/arrow/issues/35579
+TEST(TestRoundTrip, ProjectedFieldRefs) {
+  auto test_schema = schema(
+      {field("id", uint32()),
+       field("info", struct_({field("name", utf8()),
+                              field("data", struct_({field("amount", float64()),
+                                                     field("percent", float32())}))}))});
+  auto test_table = TableFromJSON(test_schema, {R"([
+    {"id": 1, "info": {"name": "a", "data": {"amount": 10.3, "percent": 0.1}}},
+    {"id": 2, "info": {"name": "b", "data": {"amount": 11.6, "percent": 0.2}}},
+    {"id": 3, "info": {"name": "c", "data": {"amount": 12.9, "percent": 0.3}}},
+    {"id": 4, "info": {"name": "d", "data": {"amount": 14.2, "percent": 0.4}}},
+    {"id": 5, "info": {"name": "e", "data": {"amount": 15.5, "percent": 0.5}}},
+    {"id": 6, "info": {"name": "f", "data": {"amount": 16.8, "percent": 0.6}}}])"});
+  ASSERT_OK(test_table->ValidateFull());
+
+  ASSERT_OK_AND_ASSIGN(auto fs, fs::internal::MockFileSystem::Make(fs::kNoTime, {}));
+  ASSERT_OK_AND_ASSIGN(auto sink, fs->OpenOutputStream("test.parquet"));
+  ASSERT_OK(parquet::arrow::WriteTable(*test_table, arrow::default_memory_pool(), sink));
+  ASSERT_OK(sink->Close());
+  auto format = std::make_shared<ParquetFileFormat>();
+  ASSERT_OK_AND_ASSIGN(auto factory,
+                       FileSystemDatasetFactory::Make(fs, fs::FileSelector(), format,
+                                                      FileSystemFactoryOptions{}));
+  ASSERT_OK_AND_ASSIGN(auto dataset, factory->Finish());
+  AssertSchemaEqual(test_schema, dataset->schema());
+
+  auto expected_schema = schema({field("value", float32())});
+  auto expected_table = TableFromJSON(expected_schema, {R"([
+    {"value": 0.1},{"value": 0.2},{"value": 0.3},
+    {"value": 0.4},{"value": 0.5},{"value": 0.6}])"});
+
+  std::vector<FieldRef> equivalent_refs = {
+      FieldRef("info", "data", "percent"), FieldRef("info", 1, 1),
+      FieldRef(1, 1, "percent"),           FieldRef(1, 1, 1),
+      FieldRef(1, FieldRef("data", 1)),    FieldRef(FieldRef(1), FieldRef(1, 1)),
+  };
+  for (const auto& ref : equivalent_refs) {
+    ARROW_SCOPED_TRACE("ref = ", ref.ToString());
+
+    ScannerBuilder builder(dataset);
+    ASSERT_OK(builder.Project({field_ref(ref)}, {"value"}));
+    ASSERT_OK_AND_ASSIGN(auto scanner, builder.Finish());
+    ASSERT_OK_AND_ASSIGN(auto actual_table, scanner->ToTable());
+
+    AssertTablesEqual(*expected_table, *actual_table);
+  }
+}
+
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/test_util_internal.h
+++ b/cpp/src/arrow/dataset/test_util_internal.h
@@ -516,16 +516,20 @@ class FileFormatFixtureMixin : public ::testing::Test {
     SetProjection(opts_.get(), std::move(projection));
   }
 
+  void Project(std::vector<compute::Expression> exprs, std::vector<std::string> names) {
+    ASSERT_OK_AND_ASSIGN(auto projection,
+                         ProjectionDescr::FromExpressions(
+                             std::move(exprs), std::move(names), *opts_->dataset_schema));
+    SetProjection(opts_.get(), std::move(projection));
+  }
+
   void ProjectNested(std::vector<std::string> names) {
     std::vector<compute::Expression> exprs;
     for (const auto& name : names) {
       ASSERT_OK_AND_ASSIGN(auto ref, FieldRef::FromDotPath(name));
       exprs.push_back(field_ref(ref));
     }
-    ASSERT_OK_AND_ASSIGN(
-        auto descr, ProjectionDescr::FromExpressions(std::move(exprs), std::move(names),
-                                                     *opts_->dataset_schema));
-    SetProjection(opts_.get(), std::move(descr));
+    Project(std::move(exprs), std::move(names));
   }
 
   // Shared test cases

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1823,6 +1823,20 @@ class ARROW_EXPORT FieldRef : public util::EqualityComparable<FieldRef> {
     return true;
   }
 
+  /// \brief Return true if this ref is a name or a nested sequence of only names
+  ///
+  /// Useful for determining if iteration is possible without recursion or inner loops
+  bool IsNameSequence() const {
+    if (IsName()) return true;
+    if (const auto* nested = nested_refs()) {
+      for (const auto& ref : *nested) {
+        if (!ref.IsName()) return false;
+      }
+      return !nested->empty();
+    }
+    return false;
+  }
+
   const FieldPath* field_path() const {
     return IsFieldPath() ? &std::get<FieldPath>(impl_) : NULLPTR;
   }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

When setting projections/filters for the file system scanner, the Parquet implementation requires that all materialized `FieldRef`s be position-independent (containing only names). However, it may be useful to support index-based field lookups as well - assuming the dataset schema is known.

### What changes are included in this PR?

Adds a translation step for field refs prior to looking them up in the fragment schema. A known dataset schema is required to do this reliably, however (since the fragment schema may be a sub/superset of the dataset schema) - so in the absence of one, we fall back to the existing behavior.

### Are these changes tested?

Yes (tests are included)

### Are there any user-facing changes?

Yes

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #35579