### PR TITLE
GH-35799: [CI] Set s3 region for sccache

### DIFF
--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -354,6 +354,7 @@ on:
             "AWS_ACCESS_KEY_ID": '${{ secrets.AWS_ACCESS_KEY_ID }}',
             "AWS_SECRET_ACCESS_KEY": '${{ secrets.AWS_SECRET_ACCESS_KEY }}',
             "SCCACHE_BUCKET": '${{ secrets.SCCACHE_BUCKET }}',
+            "SCCACHE_REGION": '${{ secrets.SCCACHE_REGION }}',
             "SCCACHE_S3_KEY_PREFIX": sccache_key_prefix 
           }
  %}
@@ -367,6 +368,7 @@ on:
             "AWS_ACCESS_KEY_ID": '$(AWS_ACCESS_KEY_ID)',
             "AWS_SECRET_ACCESS_KEY": '$(AWS_SECRET_ACCESS_KEY)',
             "SCCACHE_BUCKET": '$(SCCACHE_BUCKET)',
+            "SCCACHE_REGION": '$(SCCACHE_REGION)',
             "SCCACHE_S3_KEY_PREFIX": sccache_key_prefix 
           }
   %}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,7 @@ x-sccache: &sccache
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:
   SCCACHE_BUCKET:
+  SCCACHE_REGION:
   SCCACHE_S3_KEY_PREFIX: ${SCCACHE_S3_KEY_PREFIX:-sccache}
 
 # CPU/memory limit presets to pass to Docker.


### PR DESCRIPTION
Recent versions of sccache require the region to be set explicitly.
* Closes: #35799