### PR TITLE
GH-14790: [Dev] Avoid extra comment with Closes issue id on PRs

### DIFF
--- a/.github/workflows/dev_pr/link.js
+++ b/.github/workflows/dev_pr/link.js
@@ -83,21 +83,15 @@ async function commentGitHubURL(github, context, pullRequestNumber, issueID) {
   // Make the call to ensure issue exists before adding comment
   const issueInfo = await helpers.getGitHubInfo(github, context, issueID, pullRequestNumber);
   const message = "* Closes: #" + issueInfo.number
-  if (await haveComment(github, context, pullRequestNumber, message)) {
-    return;
-  }
   if (issueInfo){
+    if (context.payload.pull_request.body.includes(message)){
+      return;
+    }
     await github.pulls.update({
       owner: context.repo.owner,
       repo: context.repo.repo,
       pull_number: pullRequestNumber,
       body: (context.payload.pull_request.body || "") + "\n" + message
-    });
-    await github.issues.createComment({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      issue_number: pullRequestNumber,
-      body: message
     });
   }
 }

--- a/.github/workflows/dev_pr/link.js
+++ b/.github/workflows/dev_pr/link.js
@@ -83,8 +83,8 @@ async function commentGitHubURL(github, context, pullRequestNumber, issueID) {
   // Make the call to ensure issue exists before adding comment
   const issueInfo = await helpers.getGitHubInfo(github, context, issueID, pullRequestNumber);
   const message = "* Closes: #" + issueInfo.number
-  if (issueInfo){
-    if (context.payload.pull_request.body.includes(message)){
+  if (issueInfo) {
+    if (context.payload.pull_request.body.includes(message)) {
       return;
     }
     await github.pulls.update({


### PR DESCRIPTION
### Rationale for this change

We are duplicating the Closes issue_id comment on PRs adding it to both the PR body and a comment. There was some discussion to remove it from the comment.

### What changes are included in this PR?

Remove adding extra comment to PR and check whether `Closes XXX` was already added on the body instead of checking comment.

### Are these changes tested?

Yes, I have tested on my fork, see this PR: https://github.com/raulcd/arrow/pull/79

### Are there any user-facing changes?

No
* Closes: #14790