### PR TITLE
GH-35360: [C++] Take offset into account in ScalarHashImpl::ArrayHash()

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -216,6 +216,7 @@ set(ARROW_SRCS
     util/delimiting.cc
     util/formatting.cc
     util/future.cc
+    util/hashing.cc
     util/int_util.cc
     util/io_util.cc
     util/logging.cc

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -155,7 +155,6 @@ struct ScalarHashImpl {
   Status ArrayHash(const ArraySpan& a, int64_t offset, int64_t length) {
     // Calculate null count within the range
     const auto* validity = a.buffers[0].data;
-    const int64_t validity_size = a.buffers[0].size;
     int64_t null_count = 0;
     if (validity != NULLPTR) {
       if (offset == a.offset && length == a.length) {
@@ -170,7 +169,7 @@ struct ScalarHashImpl {
       // We can't visit values without unboxing the whole array, so only hash
       // the null bitmap for now. Only hash the null bitmap if the null count
       // is not 0 to ensure hash consistency.
-      hash_ = internal::ComputeBitmapHash(validity, validity_size, /*seed=*/hash_,
+      hash_ = internal::ComputeBitmapHash(validity, /*seed=*/hash_,
                                           /*bits_offset=*/offset, /*num_bits=*/length);
     }
 

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -29,6 +29,7 @@
 #include "arrow/compare.h"
 #include "arrow/pretty_print.h"
 #include "arrow/type.h"
+#include "arrow/util/bitmap_ops.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/decimal.h"
 #include "arrow/util/formatting.h"
@@ -151,19 +152,52 @@ struct ScalarHashImpl {
 
   Status ArrayHash(const Array& a) { return ArrayHash(*a.data()); }
 
-  Status ArrayHash(const ArrayData& a) {
-    RETURN_NOT_OK(StdHash(a.length) & StdHash(a.GetNullCount()));
-    if (a.GetNullCount() != 0 && a.buffers[0] != nullptr) {
+  Status ArrayHash(const ArraySpan& a, int64_t offset, int64_t length) {
+    // Calculate null count within the range
+    const auto* validity = a.buffers[0].data;
+    const int64_t validity_size = a.buffers[0].size;
+    int64_t null_count = 0;
+    if (validity != NULLPTR) {
+      if (offset == a.offset && length == a.length) {
+        null_count = a.GetNullCount();
+      } else {
+        null_count = length - internal::CountSetBits(validity, offset, length);
+      }
+    }
+
+    RETURN_NOT_OK(StdHash(length) & StdHash(null_count));
+    if (null_count != 0) {
       // We can't visit values without unboxing the whole array, so only hash
       // the null bitmap for now. Only hash the null bitmap if the null count
       // is not 0 to ensure hash consistency.
-      RETURN_NOT_OK(BufferHash(*a.buffers[0]));
+      hash_ = internal::ComputeBitmapHash(validity, validity_size, /*seed=*/hash_,
+                                          /*bits_offset=*/offset, /*num_bits=*/length);
     }
-    for (const auto& child : a.child_data) {
-      RETURN_NOT_OK(ArrayHash(*child));
+
+    // Hash the relevant child arrays for each type taking offset and length
+    // from the parent array into account if necessary.
+    switch (a.type->id()) {
+      case Type::RUN_END_ENCODED:
+        // Hash only the values, not the run lengths.
+        RETURN_NOT_OK(ArrayHash(a.child_data[1], offset, length));
+        break;
+      case Type::STRUCT:
+        for (const auto& child : a.child_data) {
+          RETURN_NOT_OK(ArrayHash(child, offset, length));
+        }
+        break;
+      default:
+        // By default, just hash the arrays without considering
+        // the offset and length of the parent.
+        for (const auto& child : a.child_data) {
+          RETURN_NOT_OK(ArrayHash(child));
+        }
+        break;
     }
     return Status::OK();
   }
+
+  Status ArrayHash(const ArraySpan& a) { return ArrayHash(a, a.offset, a.length); }
 
   explicit ScalarHashImpl(const Scalar& scalar) : hash_(scalar.type->Hash()) {
     AccumulateHashFrom(scalar);

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -177,15 +177,13 @@ struct ScalarHashImpl {
     // Hash the relevant child arrays for each type taking offset and length
     // from the parent array into account if necessary.
     switch (a.type->id()) {
-      case Type::RUN_END_ENCODED:
-        // Hash only the values, not the run lengths.
-        RETURN_NOT_OK(ArrayHash(a.child_data[1], offset, length));
-        break;
       case Type::STRUCT:
         for (const auto& child : a.child_data) {
           RETURN_NOT_OK(ArrayHash(child, offset, length));
         }
         break;
+        // TODO(GH-35830): Investigate what should be the correct behavior for
+        // each nested type.
       default:
         // By default, just hash the arrays without considering
         // the offset and length of the parent.

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -1121,6 +1121,16 @@ class TestListScalar : public ::testing::Test {
     ASSERT_NE(set_bitmap_scalar->value->data()->buffers[0], nullptr);
     // ... yet it's hashing equal to the other scalar
     ASSERT_EQ(empty_bitmap_scalar.hash(), set_bitmap_scalar->hash());
+
+    // GH-35360: the hash value of a scalar from a list of structs should
+    // pay attention to the offset so it hashes the equivalent validity bitmap
+    auto list_struct_type = list(struct_({field("a", int64())}));
+    auto a =
+        ArrayFromJSON(list_struct_type, R"([[{"a": 5}, {"a": 6}], [{"a": 7}, null]])");
+    auto b = ArrayFromJSON(list_struct_type, R"([[{"a": 7}, null]])");
+    EXPECT_OK_AND_ASSIGN(auto a1, a->GetScalar(1));
+    EXPECT_OK_AND_ASSIGN(auto b0, b->GetScalar(0));
+    ASSERT_EQ(a1->hash(), b0->hash());
   }
 
  protected:

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -1128,7 +1128,7 @@ class TestListScalar : public ::testing::Test {
     auto a =
         ArrayFromJSON(list_struct_type, R"([[{"a": 5}, {"a": 6}], [{"a": 7}, null]])");
     auto b = ArrayFromJSON(list_struct_type, R"([[{"a": 7}, null]])");
-    EXPECT_OK_AND_ASSIGN(auto a0, a->GetScalar(1));
+    EXPECT_OK_AND_ASSIGN(auto a0, a->GetScalar(0));
     EXPECT_OK_AND_ASSIGN(auto a1, a->GetScalar(1));
     EXPECT_OK_AND_ASSIGN(auto b0, b->GetScalar(0));
     ASSERT_EQ(a1->hash(), b0->hash());

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -1128,9 +1128,11 @@ class TestListScalar : public ::testing::Test {
     auto a =
         ArrayFromJSON(list_struct_type, R"([[{"a": 5}, {"a": 6}], [{"a": 7}, null]])");
     auto b = ArrayFromJSON(list_struct_type, R"([[{"a": 7}, null]])");
+    EXPECT_OK_AND_ASSIGN(auto a0, a->GetScalar(1));
     EXPECT_OK_AND_ASSIGN(auto a1, a->GetScalar(1));
     EXPECT_OK_AND_ASSIGN(auto b0, b->GetScalar(0));
     ASSERT_EQ(a1->hash(), b0->hash());
+    ASSERT_NE(a0->hash(), b0->hash());
   }
 
  protected:

--- a/cpp/src/arrow/util/hashing.cc
+++ b/cpp/src/arrow/util/hashing.cc
@@ -1,0 +1,83 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/util/hashing.h"
+
+namespace arrow {
+namespace internal {
+
+namespace {
+
+// MurmurHash2, 64-bit versions, by Austin Appleby
+
+uint64_t MurmurHash64A(const void* buffer, int len, uint64_t seed) {
+  const uint64_t m = 0xc6a4a7935bd1e995LLU;
+  const int r = 47;
+
+  uint64_t h = seed ^ (len * m);
+
+  const auto* data = static_cast<const uint64_t*>(buffer);
+  const uint64_t* end = data + (len / 8);
+
+  while (data != end) {
+    uint64_t k = *data++;
+
+    k *= m;
+    k ^= k >> r;
+    k *= m;
+
+    h ^= k;
+    h *= m;
+  }
+
+  const auto* data2 = reinterpret_cast<const uint8_t*>(data);
+
+  switch (len & 7) {
+    case 7:
+      h ^= static_cast<uint64_t>(data2[6]) << 48;
+    case 6:
+      h ^= static_cast<uint64_t>(data2[5]) << 40;
+    case 5:
+      h ^= static_cast<uint64_t>(data2[4]) << 32;
+    case 4:
+      h ^= static_cast<uint64_t>(data2[3]) << 24;
+    case 3:
+      h ^= static_cast<uint64_t>(data2[2]) << 16;
+    case 2:
+      h ^= static_cast<uint64_t>(data2[1]) << 8;
+    case 1:
+      h ^= static_cast<uint64_t>(data2[0]);
+      h *= m;
+  };
+
+  h ^= h >> r;
+  h *= m;
+  h ^= h >> r;
+
+  return h;
+}
+
+}  // namespace
+
+hash_t ComputeBitmapHash(const uint8_t* bitmap, int64_t length, int64_t bit_offset,
+                         int64_t num_bits) {
+  hash_t seed = 0;  // XXX: add seed parameter
+  return 0;
+}
+
+}  // namespace internal
+}  // namespace arrow

--- a/cpp/src/arrow/util/hashing.cc
+++ b/cpp/src/arrow/util/hashing.cc
@@ -25,13 +25,6 @@ namespace internal {
 
 namespace {
 
-/// \brief Rotate-right, 64-bit.
-///
-/// This compiles to a single instruction on CPUs that have rotation instructions.
-///
-/// \pre n must be in the range [1, 64].
-#define ROTR64(v, n) (((v) >> (n)) | ((v) << (64 - (n))))
-
 /// \brief A hash function for bitmaps that can handle offsets and lengths in
 /// terms of number of bits. The hash only depends on the bits actually hashed.
 ///

--- a/cpp/src/arrow/util/hashing.cc
+++ b/cpp/src/arrow/util/hashing.cc
@@ -82,11 +82,10 @@ uint64_t MurmurHashBitmap64(const uint8_t* key, uint64_t seed, uint64_t bits_off
 
 }  // namespace
 
-hash_t ComputeBitmapHash(const uint8_t* bitmap, int64_t length, hash_t seed,
-                         int64_t bits_offset, int64_t num_bits) {
+hash_t ComputeBitmapHash(const uint8_t* bitmap, hash_t seed, int64_t bits_offset,
+                         int64_t num_bits) {
   DCHECK_GE(bits_offset, 0);
   DCHECK_GE(num_bits, 0);
-  DCHECK_LE(bit_util::BytesForBits(bits_offset + num_bits), length);
   return MurmurHashBitmap64(bitmap, seed, bits_offset, num_bits);
 }
 

--- a/cpp/src/arrow/util/hashing.cc
+++ b/cpp/src/arrow/util/hashing.cc
@@ -97,7 +97,7 @@ uint64_t MurmurHashBitmap64A(const uint8_t* key, uint64_t seed, uint64_t bits_of
     if (ARROW_PREDICT_TRUE(shift == 0)) {
       // Fast case: no shift.
       do {
-        uint64_t k1 = *data;
+        uint64_t k1 = bit_util::ToLittleEndian(*data);
         ++data;
         HASHING_ROUND(k1);
       } while (data != end);
@@ -106,11 +106,12 @@ uint64_t MurmurHashBitmap64A(const uint8_t* key, uint64_t seed, uint64_t bits_of
       k0 = *data & msb_mask;
       ++data;
       while (data != end) {
-        uint64_t k1 = k0 | (*data & lsb_mask);
+        auto data0_le = bit_util::ToLittleEndian(*data);
+        uint64_t k1 = k0 | (data0_le & lsb_mask);
         if (shift > 0) {
           k1 = ROTR64(k1, shift);
         }
-        k0 = *data & msb_mask;
+        k0 = data0_le & msb_mask;
         ++data;
         HASHING_ROUND(k1);
       }

--- a/cpp/src/arrow/util/hashing.cc
+++ b/cpp/src/arrow/util/hashing.cc
@@ -16,6 +16,8 @@
 // under the License.
 
 #include "arrow/util/hashing.h"
+#include "arrow/util/bit_util.h"
+#include "arrow/util/bitmap_reader.h"
 #include "arrow/util/macros.h"
 
 namespace arrow {
@@ -35,9 +37,6 @@ namespace {
 ///
 /// This implementation is based on 64-bit versions of MurmurHash2 by Austin Appleby.
 ///
-/// The key (a bitmap) is read as a sequence of 64-bit words before the trailing
-/// bytes. So if the input is 64-bit aligned, all memory accesses are aligned.
-///
 /// It's the caller's responsibility to ensure that bits_offset + num_bits are
 /// readable from the bitmap.
 ///
@@ -45,8 +44,8 @@ namespace {
 /// \param seed The seed for the hash function (useful when chaining hash functions).
 /// \param bits_offset The offset in bits relative to the start of the bitmap.
 /// \param num_bits The number of bits after the offset to be hashed.
-uint64_t MurmurHashBitmap64A(const uint8_t* key, uint64_t seed, uint64_t bits_offset,
-                             uint64_t num_bits) {
+uint64_t MurmurHashBitmap64(const uint8_t* key, uint64_t seed, uint64_t bits_offset,
+                            uint64_t num_bits) {
   const uint64_t m = 0xc6a4a7935bd1e995LLU;
   const int r = 47;
 
@@ -60,91 +59,21 @@ uint64_t MurmurHashBitmap64A(const uint8_t* key, uint64_t seed, uint64_t bits_of
   h ^= (k);              \
   h *= m
 
-  // Shift key pointer by as many words as possible.
-  key += (bits_offset / 64) * 8;
-  // The shift within each word.
-  const uint64_t shift = bits_offset % 64;
-  const uint64_t readable_bits = shift + num_bits;
-
-  const auto* data = reinterpret_cast<const uint64_t*>(key);
-  const auto* end = data + (readable_bits / 64);
-  if (data == end) {
-    // The bitmap is entirely contained in a single word, but not all bytes of
-    // the word are necessarily accessible, so access is performed byte-by-byte.
-    // ROTR644 is not necessary and shift-right is safe because readable_bits < 64
-    // when data == end.
-    if (num_bits > 0) {
-      // clang-format off
-      switch (uint64_t k0 = 0; (readable_bits + 7) / 8) {
-        case 8: k0 |= static_cast<uint64_t>(key[7]) << 56;
-        case 7: k0 |= static_cast<uint64_t>(key[6]) << 48;
-        case 6: k0 |= static_cast<uint64_t>(key[5]) << 40;
-        case 5: k0 |= static_cast<uint64_t>(key[4]) << 32;
-        case 4: k0 |= static_cast<uint64_t>(key[3]) << 24;
-        case 3: k0 |= static_cast<uint64_t>(key[2]) << 16;
-        case 2: k0 |= static_cast<uint64_t>(key[1]) << 8;
-        case 1: k0 |= static_cast<uint64_t>(key[0]);
-                k0 &= (0x1LLU << readable_bits) - 1;
-                k0 >>= shift;
-                HASHING_ROUND(k0);
-      }
-      // clang-format on
-    }
-  } else {
-    const uint64_t lsb_mask = shift ? (0x1LLU << shift) - 1 : -1;
-    const uint64_t msb_mask = ~lsb_mask;
-    uint64_t k0 = 0;
-    if (ARROW_PREDICT_TRUE(shift == 0)) {
-      // Fast case: no shift.
-      do {
-        uint64_t k1 = bit_util::ToLittleEndian(*data);
-        ++data;
-        HASHING_ROUND(k1);
-      } while (data != end);
-    } else {
-      // General case: shift.
-      k0 = *data & msb_mask;
-      ++data;
-      while (data != end) {
-        auto data0_le = bit_util::ToLittleEndian(*data);
-        uint64_t k1 = k0 | (data0_le & lsb_mask);
-        if (shift > 0) {
-          k1 = ROTR64(k1, shift);
-        }
-        k0 = data0_le & msb_mask;
-        ++data;
-        HASHING_ROUND(k1);
-      }
-    }
-
-    const auto* trailing = reinterpret_cast<const uint8_t*>(data);
-    const auto trailing_bits = readable_bits % 64;
-    uint64_t k1 = k0;
-    // clang-format off
-    switch (uint64_t final_blk = 0; (trailing_bits + 7) / 8) {
-      case 8: final_blk |= static_cast<uint64_t>(trailing[7]) << 56;
-      case 7: final_blk |= static_cast<uint64_t>(trailing[6]) << 48;
-      case 6: final_blk |= static_cast<uint64_t>(trailing[5]) << 40;
-      case 5: final_blk |= static_cast<uint64_t>(trailing[4]) << 32;
-      case 4: final_blk |= static_cast<uint64_t>(trailing[3]) << 24;
-      case 3: final_blk |= static_cast<uint64_t>(trailing[2]) << 16;
-      case 2: final_blk |= static_cast<uint64_t>(trailing[1]) << 8;
-      case 1: final_blk |= static_cast<uint64_t>(trailing[0]);
-              final_blk &= (0x1LLU << trailing_bits) - 1;
-              // Combine with the last key block (k0).
-              k1 |= final_blk & lsb_mask;
-              if (shift > 0) {
-                k1 = ROTR64(k1, shift);
-              }
-              k0 = final_blk & msb_mask;
-              HASHING_ROUND(k1);
-    }
-    // clang-format on
-    // Perform a final round with bits from k0 if it still contains relevant bits.
-    if (shift > 0 && (trailing_bits == 0 || trailing_bits > shift)) {
-      k1 = ROTR64(k0, shift);
-      HASHING_ROUND(k1);
-    }
+  BitmapWordReader<uint64_t> reader(key, bits_offset, num_bits);
+  auto nwords = reader.words();
+  while (nwords--) {
+    auto k = reader.NextWord();
+    HASHING_ROUND(k);
+  }
+  auto nbytes = reader.trailing_bytes();
+  if (nbytes) {
+    uint64_t k = 0;
+    do {
+      int valid_bits;
+      auto byte = reader.NextTrailingByte(valid_bits);
+      k = (k << 8) | static_cast<uint64_t>(byte);
+    } while (--nbytes);
+    HASHING_ROUND(k);
   }
 
   // Finalize.
@@ -160,8 +89,8 @@ hash_t ComputeBitmapHash(const uint8_t* bitmap, int64_t length, hash_t seed,
                          int64_t bits_offset, int64_t num_bits) {
   DCHECK_GE(bits_offset, 0);
   DCHECK_GE(num_bits, 0);
-  DCHECK_LE((bits_offset + num_bits + 7) / 8, length);
-  return MurmurHashBitmap64A(bitmap, seed, bits_offset, num_bits);
+  DCHECK_LE(bit_util::BytesForBits(bits_offset + num_bits), length);
+  return MurmurHashBitmap64(bitmap, seed, bits_offset, num_bits);
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/util/hashing.cc
+++ b/cpp/src/arrow/util/hashing.cc
@@ -16,67 +16,151 @@
 // under the License.
 
 #include "arrow/util/hashing.h"
+#include "arrow/util/macros.h"
 
 namespace arrow {
 namespace internal {
 
 namespace {
 
-// MurmurHash2, 64-bit versions, by Austin Appleby
+/// \brief Rotate-right, 64-bit.
+///
+/// This compiles to a single instruction on CPUs that have rotation instructions.
+///
+/// \pre n must be in the range [1, 64].
+#define ROTR64(v, n) (((v) >> (n)) | ((v) << (64 - (n))))
 
-uint64_t MurmurHash64A(const void* buffer, int len, uint64_t seed) {
+/// \brief A hash function for bitmaps that can handle offsets and lengths in
+/// terms of number of bits. The hash only depends on the bits actually hashed.
+///
+/// This implementation is based on 64-bit versions of MurmurHash2 by Austin Appleby.
+///
+/// The key (a bitmap) is read as a sequence of 64-bit words before the trailing
+/// bytes. So if the input is 64-bit aligned, all memory accesses are aligned.
+///
+/// It's the caller's responsibility to ensure that bits_offset + num_bits are
+/// readable from the bitmap.
+///
+/// \param key The pointer to the bitmap.
+/// \param seed The seed for the hash function (useful when chaining hash functions).
+/// \param bits_offset The offset in bits relative to the start of the bitmap.
+/// \param num_bits The number of bits after the offset to be hashed.
+uint64_t MurmurHashBitmap64A(const uint8_t* key, uint64_t seed, uint64_t bits_offset,
+                             uint64_t num_bits) {
   const uint64_t m = 0xc6a4a7935bd1e995LLU;
   const int r = 47;
 
-  uint64_t h = seed ^ (len * m);
+  uint64_t h = seed ^ (num_bits * m);
 
-  const auto* data = static_cast<const uint64_t*>(buffer);
-  const uint64_t* end = data + (len / 8);
+#define HASHING_ROUND(k) \
+  (k) *= m;              \
+  (k) ^= (k) >> r;       \
+  (k) *= m;              \
+                         \
+  h ^= (k);              \
+  h *= m
 
-  while (data != end) {
-    uint64_t k = *data++;
+  // Shift key pointer by as many words as possible.
+  key += (bits_offset / 64) * 8;
+  // The shift within each word.
+  const uint64_t shift = bits_offset % 64;
+  const uint64_t readable_bits = shift + num_bits;
 
-    k *= m;
-    k ^= k >> r;
-    k *= m;
+  const auto* data = reinterpret_cast<const uint64_t*>(key);
+  const auto* end = data + (readable_bits / 64);
+  if (data == end) {
+    // The bitmap is entirely contained in a single word, but not all bytes of
+    // the word are necessarily accessible, so access is performed byte-by-byte.
+    // ROTR644 is not necessary and shift-right is safe because readable_bits < 64
+    // when data == end.
+    if (num_bits > 0) {
+      // clang-format off
+      switch (uint64_t k0 = 0; (readable_bits + 7) / 8) {
+        case 8: k0 |= static_cast<uint64_t>(key[7]) << 56;
+        case 7: k0 |= static_cast<uint64_t>(key[6]) << 48;
+        case 6: k0 |= static_cast<uint64_t>(key[5]) << 40;
+        case 5: k0 |= static_cast<uint64_t>(key[4]) << 32;
+        case 4: k0 |= static_cast<uint64_t>(key[3]) << 24;
+        case 3: k0 |= static_cast<uint64_t>(key[2]) << 16;
+        case 2: k0 |= static_cast<uint64_t>(key[1]) << 8;
+        case 1: k0 |= static_cast<uint64_t>(key[0]);
+                k0 &= (0x1LLU << readable_bits) - 1;
+                k0 >>= shift;
+                HASHING_ROUND(k0);
+      }
+      // clang-format on
+    }
+  } else {
+    const uint64_t lsb_mask = shift ? (0x1LLU << shift) - 1 : -1;
+    const uint64_t msb_mask = ~lsb_mask;
+    uint64_t k0 = 0;
+    if (ARROW_PREDICT_TRUE(shift == 0)) {
+      // Fast case: no shift.
+      do {
+        uint64_t k1 = *data;
+        ++data;
+        HASHING_ROUND(k1);
+      } while (data != end);
+    } else {
+      // General case: shift.
+      k0 = *data & msb_mask;
+      ++data;
+      while (data != end) {
+        uint64_t k1 = k0 | (*data & lsb_mask);
+        if (shift > 0) {
+          k1 = ROTR64(k1, shift);
+        }
+        k0 = *data & msb_mask;
+        ++data;
+        HASHING_ROUND(k1);
+      }
+    }
 
-    h ^= k;
-    h *= m;
+    const auto* trailing = reinterpret_cast<const uint8_t*>(data);
+    const auto trailing_bits = readable_bits % 64;
+    uint64_t k1 = k0;
+    // clang-format off
+    switch (uint64_t final_blk = 0; (trailing_bits + 7) / 8) {
+      case 8: final_blk |= static_cast<uint64_t>(trailing[7]) << 56;
+      case 7: final_blk |= static_cast<uint64_t>(trailing[6]) << 48;
+      case 6: final_blk |= static_cast<uint64_t>(trailing[5]) << 40;
+      case 5: final_blk |= static_cast<uint64_t>(trailing[4]) << 32;
+      case 4: final_blk |= static_cast<uint64_t>(trailing[3]) << 24;
+      case 3: final_blk |= static_cast<uint64_t>(trailing[2]) << 16;
+      case 2: final_blk |= static_cast<uint64_t>(trailing[1]) << 8;
+      case 1: final_blk |= static_cast<uint64_t>(trailing[0]);
+              final_blk &= (0x1LLU << trailing_bits) - 1;
+              // Combine with the last key block (k0).
+              k1 |= final_blk & lsb_mask;
+              if (shift > 0) {
+                k1 = ROTR64(k1, shift);
+              }
+              k0 = final_blk & msb_mask;
+              HASHING_ROUND(k1);
+    }
+    // clang-format on
+    // Perform a final round with bits from k0 if it still contains relevant bits.
+    if (shift > 0 && (trailing_bits == 0 || trailing_bits > shift)) {
+      k1 = ROTR64(k0, shift);
+      HASHING_ROUND(k1);
+    }
   }
 
-  const auto* data2 = reinterpret_cast<const uint8_t*>(data);
-
-  switch (len & 7) {
-    case 7:
-      h ^= static_cast<uint64_t>(data2[6]) << 48;
-    case 6:
-      h ^= static_cast<uint64_t>(data2[5]) << 40;
-    case 5:
-      h ^= static_cast<uint64_t>(data2[4]) << 32;
-    case 4:
-      h ^= static_cast<uint64_t>(data2[3]) << 24;
-    case 3:
-      h ^= static_cast<uint64_t>(data2[2]) << 16;
-    case 2:
-      h ^= static_cast<uint64_t>(data2[1]) << 8;
-    case 1:
-      h ^= static_cast<uint64_t>(data2[0]);
-      h *= m;
-  };
-
+  // Finalize.
   h ^= h >> r;
   h *= m;
   h ^= h >> r;
-
   return h;
 }
 
 }  // namespace
 
-hash_t ComputeBitmapHash(const uint8_t* bitmap, int64_t length, int64_t bit_offset,
-                         int64_t num_bits) {
-  hash_t seed = 0;  // XXX: add seed parameter
-  return 0;
+hash_t ComputeBitmapHash(const uint8_t* bitmap, int64_t length, hash_t seed,
+                         int64_t bits_offset, int64_t num_bits) {
+  DCHECK_GE(bits_offset, 0);
+  DCHECK_GE(num_bits, 0);
+  DCHECK_LE((bits_offset + num_bits + 7) / 8, length);
+  return MurmurHashBitmap64A(bitmap, seed, bits_offset, num_bits);
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -71,14 +71,13 @@ inline hash_t ComputeStringHash(const void* data, int64_t length);
 ///
 /// \pre bits_offset >= 0
 /// \pre num_bits >= 0
-/// \pre (bits_offset + num_bits + 7) / 8 <= length
+/// \pre (bits_offset + num_bits + 7) / 8 <= readable length in bytes from bitmap
 ///
 /// \param bitmap The pointer to the bitmap.
-/// \param length The length of the bitmap in bytes.
 /// \param seed The seed for the hash function (useful when chaining hash functions).
 /// \param bits_offset The offset in bits relative to the start of the bitmap.
 /// \param num_bits The number of bits after the offset to be hashed.
-ARROW_EXPORT hash_t ComputeBitmapHash(const uint8_t* bitmap, int64_t length, hash_t seed,
+ARROW_EXPORT hash_t ComputeBitmapHash(const uint8_t* bitmap, hash_t seed,
                                       int64_t bits_offset, int64_t num_bits);
 
 template <typename Scalar, uint64_t AlgNum>

--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -63,8 +63,26 @@ typedef uint64_t hash_t;
 template <uint64_t AlgNum>
 inline hash_t ComputeStringHash(const void* data, int64_t length);
 
-hash_t ComputeBitmapHash(const uint8_t* bitmap, int64_t length, int64_t bit_offset,
-                         int64_t num_bits);
+/// \brief A hash function for bitmaps that can handle offsets and lengths in
+/// terms of number of bits. The hash only depends on the bits actually hashed.
+///
+/// The key (a bitmap) is read as a sequence of 64-bit words before the trailing
+/// bytes. So if the input is 64-bit aligned, all memory accesses are aligned.
+///
+/// It's the caller's responsibility to ensure that bits_offset + num_bits are
+/// readable from the bitmap.
+///
+/// \pre bits_offset >= 0
+/// \pre num_bits >= 0
+/// \pre (bits_offset + num_bits + 7) / 8 <= length
+///
+/// \param bitmap The pointer to the bitmap.
+/// \param length The length of the bitmap in bytes.
+/// \param seed The seed for the hash function (useful when chaining hash functions).
+/// \param bits_offset The offset in bits relative to the start of the bitmap.
+/// \param num_bits The number of bits after the offset to be hashed.
+hash_t ComputeBitmapHash(const uint8_t* bitmap, int64_t length, hash_t seed,
+                         int64_t bits_offset, int64_t num_bits);
 
 template <typename Scalar, uint64_t AlgNum>
 struct ScalarHelperBase {

--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -81,8 +81,8 @@ inline hash_t ComputeStringHash(const void* data, int64_t length);
 /// \param seed The seed for the hash function (useful when chaining hash functions).
 /// \param bits_offset The offset in bits relative to the start of the bitmap.
 /// \param num_bits The number of bits after the offset to be hashed.
-hash_t ComputeBitmapHash(const uint8_t* bitmap, int64_t length, hash_t seed,
-                         int64_t bits_offset, int64_t num_bits);
+ARROW_EXPORT hash_t ComputeBitmapHash(const uint8_t* bitmap, int64_t length, hash_t seed,
+                                      int64_t bits_offset, int64_t num_bits);
 
 template <typename Scalar, uint64_t AlgNum>
 struct ScalarHelperBase {

--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -63,6 +63,9 @@ typedef uint64_t hash_t;
 template <uint64_t AlgNum>
 inline hash_t ComputeStringHash(const void* data, int64_t length);
 
+hash_t ComputeBitmapHash(const uint8_t* bitmap, int64_t length, int64_t bit_offset,
+                         int64_t num_bits);
+
 template <typename Scalar, uint64_t AlgNum>
 struct ScalarHelperBase {
   static bool CompareScalars(Scalar u, Scalar v) { return u == v; }

--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -66,9 +66,6 @@ inline hash_t ComputeStringHash(const void* data, int64_t length);
 /// \brief A hash function for bitmaps that can handle offsets and lengths in
 /// terms of number of bits. The hash only depends on the bits actually hashed.
 ///
-/// The key (a bitmap) is read as a sequence of 64-bit words before the trailing
-/// bytes. So if the input is 64-bit aligned, all memory accesses are aligned.
-///
 /// It's the caller's responsibility to ensure that bits_offset + num_bits are
 /// readable from the bitmap.
 ///

--- a/cpp/src/arrow/util/hashing_test.cc
+++ b/cpp/src/arrow/util/hashing_test.cc
@@ -491,7 +491,7 @@ TEST(BinaryMemoTable, Empty) {
 hash_t HashDataBitmap(const ArraySpan& array) {
   EXPECT_EQ(array.type->id(), Type::BOOL);
   const auto& bitmap = array.buffers[1];
-  return ComputeBitmapHash(bitmap.data, bitmap.size,
+  return ComputeBitmapHash(bitmap.data,
                            /*seed=*/0,
                            /*bit_offset=*/array.offset,
                            /*num_bits=*/array.length);

--- a/cpp/src/arrow/util/hashing_test.cc
+++ b/cpp/src/arrow/util/hashing_test.cc
@@ -560,7 +560,7 @@ TEST(BitmapHashTest, LongerInputs) {
   }
   const auto hash_of_block = HashDataBitmap(*block_of_bools->data());
 
-  const auto kStep = 9;
+  const auto kStep = 13;
   constexpr auto kMaxPadding = 64 + 32 + kStep;
 
   for (int prefix_pad_len = 0; prefix_pad_len < kMaxPadding; prefix_pad_len += kStep) {

--- a/cpp/src/arrow/util/hashing_test.cc
+++ b/cpp/src/arrow/util/hashing_test.cc
@@ -576,7 +576,7 @@ TEST(TestBitmapHash, Empty) {
   }
   const auto hash_of_negated_block = HashDataBitmap(*negated_block_of_bools->data());
 
-  constexpr bool kSlowTests = true;
+  constexpr bool kSlowTests = false;
   constexpr auto kMaxPadding = 64 + 32 + 1;
   auto step = [&](int& i) {
     const auto kStep = kSlowTests ? 1 : 8;

--- a/cpp/src/arrow/util/hashing_test.cc
+++ b/cpp/src/arrow/util/hashing_test.cc
@@ -28,6 +28,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "arrow/array/builder_primitive.h"
+#include "arrow/array/concatenate.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/hashing.h"
@@ -484,6 +486,171 @@ TEST(BinaryMemoTable, Empty) {
   BinaryMemoTable<BinaryBuilder>::builder_offset_type offsets[1];
   table.CopyOffsets(0, offsets);
   EXPECT_EQ(offsets[0], 0);
+}
+
+hash_t HashDataBitmap(const ArraySpan& array) {
+  EXPECT_EQ(array.type->id(), Type::BOOL);
+  const auto& bitmap = array.buffers[1];
+  return ComputeBitmapHash(bitmap.data, bitmap.size,
+                           /*seed=*/0,
+                           /*bit_offset=*/array.offset,
+                           /*num_bits=*/array.length);
+}
+
+std::shared_ptr<BooleanArray> BuildBooleanArray(int len, bool start) {
+  // This could be memoized in the future to speed up tests.
+  BooleanBuilder builder;
+  for (int i = 0; i < len; ++i) {
+    EXPECT_TRUE(builder.Append(((i % 2) ^ start) == 1).ok());
+  }
+  std::shared_ptr<BooleanArray> array;
+  EXPECT_TRUE(builder.Finish(&array).ok());
+  return array;
+}
+
+hash_t HashConcatenation(const ArrayVector& arrays, int64_t bits_offset = -1,
+                         int64_t num_bits = -1) {
+  EXPECT_OK_AND_ASSIGN(auto concat, Concatenate(arrays));
+  EXPECT_EQ(concat->type()->id(), Type::BOOL);
+  if (bits_offset == -1 || num_bits == -1) {
+    return HashDataBitmap(*concat->data());
+  }
+  auto slice = concat->Slice(bits_offset, num_bits);
+  return HashDataBitmap(*slice->data());
+}
+
+TEST(SmallBitmapHash, Empty) {
+  for (bool start : {false, true}) {
+    auto block = BuildBooleanArray(64, start);
+    for (int len = 0; len < 64; len++) {
+      auto prefix = BuildBooleanArray(len, start);
+      auto expected_hash = HashDataBitmap(*prefix->data());
+
+      auto slice = block->Slice(0, len);
+      auto slice_hash = HashDataBitmap(*slice->data());
+      ASSERT_EQ(expected_hash, slice_hash);
+
+      for (int j = 1; j < len; j++) {
+        auto fragment = BuildBooleanArray(len - j, start ^ (j % 2));
+        expected_hash = HashDataBitmap(*fragment->data());
+
+        slice = block->Slice(j, len - j);
+        slice_hash = HashDataBitmap(*slice->data());
+        ASSERT_EQ(expected_hash, slice_hash);
+      }
+    }
+  }
+}
+
+TEST(TestBitmapHash, Empty) {
+  BooleanBuilder builder;
+  std::shared_ptr<BooleanArray> block_of_bools;
+  {
+    ASSERT_OK(builder.AppendValues(2, true));
+    ASSERT_OK(builder.AppendValues(3, false));
+    ASSERT_OK(builder.AppendValues(5, true));
+    ASSERT_OK(builder.AppendValues(7, false));
+    ASSERT_OK(builder.AppendValues(11, true));
+    ASSERT_OK(builder.AppendValues(13, false));
+    ASSERT_OK(builder.AppendValues(17, true));
+    ASSERT_OK(builder.AppendValues(5, false));
+    ASSERT_OK(builder.AppendValues(1, true));
+    ASSERT_OK(builder.Finish(&block_of_bools));
+    ASSERT_EQ(block_of_bools->length(), 64);
+  }
+  const auto hash_of_block = HashDataBitmap(*block_of_bools->data());
+
+  std::shared_ptr<BooleanArray> negated_block_of_bools;
+  {
+    ASSERT_OK(builder.AppendValues(2, false));
+    ASSERT_OK(builder.AppendValues(3, true));
+    ASSERT_OK(builder.AppendValues(5, false));
+    ASSERT_OK(builder.AppendValues(7, true));
+    ASSERT_OK(builder.AppendValues(11, false));
+    ASSERT_OK(builder.AppendValues(13, true));
+    ASSERT_OK(builder.AppendValues(17, false));
+    ASSERT_OK(builder.AppendValues(5, true));
+    ASSERT_OK(builder.AppendValues(1, false));
+    ASSERT_OK(builder.Finish(&negated_block_of_bools));
+    ASSERT_EQ(negated_block_of_bools->length(), 64);
+  }
+  const auto hash_of_negated_block = HashDataBitmap(*negated_block_of_bools->data());
+
+  constexpr bool kSlowTests = true;
+  constexpr auto kMaxPadding = 64 + 32 + 1;
+  auto step = [&](int& i) {
+    const auto kStep = kSlowTests ? 1 : 8;
+    if (i + kStep >= kMaxPadding && i != kMaxPadding - 1) {
+      i = kMaxPadding - 1;
+    } else {
+      i += kStep;
+    }
+  };
+
+  for (int start_bits = 0; start_bits < 8; ++start_bits) {
+    for (int prefix_pad_len = 0; prefix_pad_len < kMaxPadding; step(prefix_pad_len)) {
+      auto prefix_pad = BuildBooleanArray(prefix_pad_len, start_bits & 0x1);
+      for (int suffix_pad_len = 0; suffix_pad_len < kMaxPadding; step(suffix_pad_len)) {
+        auto suffix_pad = BuildBooleanArray(suffix_pad_len, (start_bits >> 1) & 0x1);
+
+        // A block of 64 bools in the middle
+        auto hash = HashConcatenation({prefix_pad, block_of_bools, suffix_pad},
+                                      prefix_pad_len, 64);
+        ASSERT_EQ(hash, hash_of_block);
+        // Negated
+        hash = HashConcatenation({prefix_pad, negated_block_of_bools, suffix_pad},
+                                 prefix_pad_len, 64);
+        ASSERT_EQ(hash, hash_of_negated_block);
+
+        std::shared_ptr<BooleanArray> bools;
+        // Trailing bits and leading bits around a block
+        for (int trailing_len = 1; trailing_len < kMaxPadding; step(trailing_len)) {
+          auto trailing = BuildBooleanArray(trailing_len, (start_bits >> 1) & 0x1);
+          auto expected_hash = HashConcatenation({block_of_bools, trailing});
+          auto hash =
+              HashConcatenation({prefix_pad, block_of_bools, trailing, suffix_pad},
+                                prefix_pad_len, 64 + trailing_len);
+          ASSERT_EQ(hash, expected_hash);
+          // Negated
+          expected_hash = HashConcatenation({negated_block_of_bools, trailing});
+          hash = HashConcatenation(
+              {prefix_pad, negated_block_of_bools, trailing, suffix_pad}, prefix_pad_len,
+              64 + trailing_len);
+          ASSERT_EQ(hash, expected_hash);
+
+          // Use the trailing bits as leading bits now
+          auto leading = trailing;
+          auto leading_len = trailing_len;
+          expected_hash = HashConcatenation({leading, block_of_bools});
+          hash = HashConcatenation({prefix_pad, leading, block_of_bools, suffix_pad},
+                                   prefix_pad_len, leading_len + 64);
+          ASSERT_EQ(hash, expected_hash);
+          // Negated
+          expected_hash = HashConcatenation({leading, negated_block_of_bools});
+          hash =
+              HashConcatenation({prefix_pad, leading, negated_block_of_bools, suffix_pad},
+                                prefix_pad_len, leading_len + 64);
+          ASSERT_EQ(hash, expected_hash);
+
+          // leading and trailing at the same time
+          expected_hash = HashConcatenation({leading, block_of_bools, trailing});
+          hash = HashConcatenation(
+              {prefix_pad, leading, block_of_bools, trailing, suffix_pad}, prefix_pad_len,
+              leading_len + 64 + trailing_len);
+          ASSERT_EQ(hash, expected_hash);
+          // Negated
+          expected_hash = HashConcatenation({leading, negated_block_of_bools, trailing});
+          hash = HashConcatenation(
+              {prefix_pad, leading, negated_block_of_bools, trailing, suffix_pad},
+              prefix_pad_len, leading_len + 64 + trailing_len);
+          ASSERT_EQ(hash, expected_hash);
+        }
+      }
+    }
+    if (!kSlowTests) {
+      break;
+    }
+  }
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/util/hashing_test.cc
+++ b/cpp/src/arrow/util/hashing_test.cc
@@ -519,7 +519,7 @@ hash_t HashConcatenation(const ArrayVector& arrays, int64_t bits_offset = -1,
   return HashDataBitmap(*slice->data());
 }
 
-TEST(SmallBitmapHash, Empty) {
+TEST(BitmapHashTest, SmallInputs) {
   for (bool start : {false, true}) {
     auto block = BuildBooleanArray(64, start);
     for (int len = 0; len < 64; len++) {
@@ -542,7 +542,7 @@ TEST(SmallBitmapHash, Empty) {
   }
 }
 
-TEST(TestBitmapHash, Empty) {
+TEST(BitmapHashTest, LongerInputs) {
   BooleanBuilder builder;
   std::shared_ptr<BooleanArray> block_of_bools;
   {

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -143,6 +143,15 @@ def test_hashing():
     assert len(set_from_array) == 500
 
 
+def test_hashing_struct_scalar():
+    # GH-35360
+    a = pa.array([[{'a': 5}, {'a': 6}], [{'a': 7}, None]])
+    b = pa.array([[{'a': 7}, None]])
+    hash1 = hash(a[1])
+    hash2 = hash(b[0])
+    assert hash1 == hash2
+
+
 def test_bool():
     false = pa.scalar(False)
     true = pa.scalar(True)


### PR DESCRIPTION
### Rationale for this change

A fix for #35360.

### What changes are included in this PR?

 - [x] A hash function that can hash bitmaps
 - [x] The fix for hashes of equal scalars sometimes not being equal because of offsets

### Are these changes tested?

Yes. By unit tests.

### Are there any user-facing changes?

No.
* Closes: #35360