### PR TITLE
GH-35817: [Docs][C++] Fix value_counts/unique doc about null handling

### DIFF
--- a/cpp/src/arrow/compute/kernels/vector_hash.cc
+++ b/cpp/src/arrow/compute/kernels/vector_hash.cc
@@ -740,11 +740,10 @@ void AddHashKernels(VectorFunction* func, VectorKernel base, OutputType out_ty) 
   }
 }
 
-const FunctionDoc unique_doc(
-    "Compute unique elements",
-    ("Return an array with distinct values.\n"
-     "Nulls are considered as a distinct value as well."),
-    {"array"});
+const FunctionDoc unique_doc("Compute unique elements",
+                             ("Return an array with distinct values.\n"
+                              "Nulls are considered as a distinct value as well."),
+                             {"array"});
 
 const FunctionDoc value_counts_doc(
     "Compute counts of unique elements",

--- a/cpp/src/arrow/compute/kernels/vector_hash.cc
+++ b/cpp/src/arrow/compute/kernels/vector_hash.cc
@@ -742,14 +742,15 @@ void AddHashKernels(VectorFunction* func, VectorKernel base, OutputType out_ty) 
 
 const FunctionDoc unique_doc(
     "Compute unique elements",
-    ("Return an array with distinct values.  Nulls in the input are ignored."),
+    ("Return an array with distinct values.\n"
+     "Nulls are considered as a distinct value as well."),
     {"array"});
 
 const FunctionDoc value_counts_doc(
     "Compute counts of unique elements",
     ("For each distinct value, compute the number of times it occurs in the array.\n"
      "The result is returned as an array of `struct<input type, int64>`.\n"
-     "Nulls in the input are ignored."),
+     "Nulls in the input are counted and included in the output as well."),
     {"array"});
 
 const DictionaryEncodeOptions* GetDefaultDictionaryEncodeOptions() {


### PR DESCRIPTION
### Rationale for this change

The documentation of "unique" and "value_counts" kernels indicate that nulls in the input are ignored, but this is not the case: they are considered as distinct values that are counted.

* Closes: #35817