### PR TITLE
GH-35828: [Go] Add `array.WithUnorderedMapKeys` option for `array.ApproxEqual`

### DIFF
--- a/go/arrow/array/compare.go
+++ b/go/arrow/array/compare.go
@@ -752,7 +752,8 @@ func arrayApproxEqualMap(left, right *Map, opt equalOption) bool {
 func arrayApproxEqualSingleMapEntry(left, right *Struct, opt equalOption) bool {
 	defer left.Release()
 	defer right.Release()
-	// we get here only if the left & right lengths are 1, and the values are valid
+
+	// Every element here is a key-value pair
 	lElems := make([]arrow.Array, left.Len())
 	rElems := make([]arrow.Array, right.Len())
 	for i := 0; i < left.Len(); i++ {

--- a/go/arrow/array/compare.go
+++ b/go/arrow/array/compare.go
@@ -385,8 +385,9 @@ func sliceApproxEqual(left arrow.Array, lbeg, lend int64, right arrow.Array, rbe
 const defaultAbsoluteTolerance = 1e-5
 
 type equalOption struct {
-	atol   float64 // absolute tolerance
-	nansEq bool    // whether NaNs are considered equal.
+	atol             float64 // absolute tolerance
+	nansEq           bool    // whether NaNs are considered equal.
+	unorderedMapKeys bool    // whether maps are allowed to have different entries order
 }
 
 func (eq equalOption) f16(f1, f2 float16.Num) bool {
@@ -447,6 +448,13 @@ func WithNaNsEqual(v bool) EqualOption {
 func WithAbsTolerance(atol float64) EqualOption {
 	return func(o *equalOption) {
 		o.atol = atol
+	}
+}
+
+// WithUnorderedMapKeys configures the comparison functions so that Map with different entries order are considered equal.
+func WithUnorderedMapKeys(v bool) EqualOption {
+	return func(o *equalOption) {
+		o.unorderedMapKeys = v
 	}
 }
 
@@ -581,7 +589,10 @@ func arrayApproxEqual(left, right arrow.Array, opt equalOption) bool {
 		return arrayEqualDuration(l, r)
 	case *Map:
 		r := right.(*Map)
-		return arrayApproxEqualMap(l, r, opt)
+		if opt.unorderedMapKeys {
+			return arrayApproxEqualMap(l, r, opt)
+		}
+		return arrayApproxEqualList(l.List, r.List, opt)
 	case *Dictionary:
 		r := right.(*Dictionary)
 		return arrayApproxEqualDict(l, r, opt)
@@ -753,30 +764,46 @@ func arrayApproxEqualSingleMapEntry(left, right *Struct, opt equalOption) bool {
 	defer left.Release()
 	defer right.Release()
 
-	// Every element here is a key-value pair
-	lElems := make([]arrow.Array, left.Len())
-	rElems := make([]arrow.Array, right.Len())
-	for i := 0; i < left.Len(); i++ {
-		lElems[i] = NewSlice(left, int64(i), int64(i+1))
-		rElems[i] = NewSlice(right, int64(i), int64(i+1))
+	// we don't compare the validity bitmap, but we want other checks from baseArrayEqual
+	switch {
+	case left.Len() != right.Len():
+		return false
+	case left.NullN() != right.NullN():
+		return false
+	case !arrow.TypeEqual(left.DataType(), right.DataType()): // We do not check for metadata as in the C++ implementation.
+		return false
+	case left.NullN() == left.Len():
+		return true
 	}
-	defer func() {
-		for i := range lElems {
-			lElems[i].Release()
-			rElems[i].Release()
-		}
-	}()
 
 	used := make(map[int]bool, right.Len())
-	for _, ll := range lElems {
+	for i := 0; i < left.Len(); i++ {
+		if left.IsNull(i) {
+			continue
+		}
+
 		found := false
-		for i, rr := range rElems {
-			if used[i] {
+		lBeg, lEnd := int64(i), int64(i+1)
+		for j := 0; j < right.Len(); j++ {
+			if used[j] {
 				continue
 			}
-			if arrayApproxEqual(ll, rr, opt) {
+			if right.IsNull(j) {
+				used[j] = true
+				continue
+			}
+
+			rBeg, rEnd := int64(j), int64(j+1)
+
+			// check keys (field 0)
+			if !sliceApproxEqual(left.Field(0), lBeg, lEnd, right.Field(0), rBeg, rEnd, opt) {
+				continue
+			}
+
+			// only now check the values
+			if sliceApproxEqual(left.Field(1), lBeg, lEnd, right.Field(1), rBeg, rEnd, opt) {
 				found = true
-				used[i] = true
+				used[j] = true
 				break
 			}
 		}
@@ -784,5 +811,6 @@ func arrayApproxEqualSingleMapEntry(left, right *Struct, opt equalOption) bool {
 			return false
 		}
 	}
-	return true
+
+	return len(used) == right.Len()
 }

--- a/go/arrow/array/compare.go
+++ b/go/arrow/array/compare.go
@@ -739,11 +739,7 @@ func arrayApproxEqualMap(left, right *Map, opt equalOption) bool {
 		if left.IsNull(i) {
 			continue
 		}
-		l, r := left.newListValue(i).(*Struct), right.newListValue(i).(*Struct)
-		eq := arrayApproxEqualSingleMapEntry(l, r, opt)
-		l.Release()
-		r.Release()
-		if !eq {
+		if !arrayApproxEqualSingleMapEntry(left.newListValue(i).(*Struct), right.newListValue(i).(*Struct), opt) {
 			return false
 		}
 	}
@@ -751,8 +747,11 @@ func arrayApproxEqualMap(left, right *Map, opt equalOption) bool {
 }
 
 // arrayApproxEqualSingleMapEntry is a helper function that checks if a single entry pair is approx equal.
-// Basically, it doesn't care about key order
+// Basically, it doesn't care about key order.
+// structs passed will be released
 func arrayApproxEqualSingleMapEntry(left, right *Struct, opt equalOption) bool {
+	defer left.Release()
+	defer right.Release()
 	// we get here only if the left & right lengths are 1, and the values are valid
 	lElems := make([]arrow.Array, left.Len())
 	rElems := make([]arrow.Array, right.Len())

--- a/go/arrow/array/compare_test.go
+++ b/go/arrow/array/compare_test.go
@@ -303,43 +303,103 @@ func TestArrayApproxEqualFloats(t *testing.T) {
 	}
 }
 
+func testStringMap(mem memory.Allocator, m map[string]string, keys []string) *array.Map {
+	dt := arrow.MapOf(arrow.BinaryTypes.String, arrow.BinaryTypes.String)
+	builder := array.NewMapBuilderWithType(mem, dt)
+	defer builder.Release()
+	key, item := builder.KeyBuilder().(*array.StringBuilder), builder.ItemBuilder().(*array.StringBuilder)
+
+	builder.AppendNull()
+	builder.Append(true)
+
+	for _, k := range keys {
+		key.Append(k)
+
+		v, ok := m[k]
+		if !ok {
+			item.AppendNull()
+			continue
+		}
+
+		item.Append(v)
+	}
+
+	return builder.NewMapArray()
+}
+
 func TestArrayApproxEqualMaps(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
 	defer mem.AssertSize(t, 0)
 
-	getArr := func(values []string) *array.Map {
-		dt := arrow.MapOf(arrow.BinaryTypes.String, arrow.BinaryTypes.String)
-		builder := array.NewMapBuilderWithType(mem, dt)
-		defer builder.Release()
-		key, item := builder.KeyBuilder().(*array.StringBuilder), builder.ItemBuilder().(*array.StringBuilder)
+	t.Run("different order", func(t *testing.T) {
+		m := map[string]string{"x": "x", "y": "y", "z": "z"}
 
-		builder.AppendNull()
-		builder.Append(true)
-		for _, k := range values {
-			key.Append(k)
-			item.Append(k)
+		keys := []string{"z", "y", "x", "null"}
+		a := testStringMap(mem, m, keys)
+		defer a.Release()
 
-			key.Append("null_" + k)
-			item.AppendNull()
-		}
+		asc := make([]string, len(keys))
+		copy(asc, keys)
+		sort.Strings(asc)
+		assert.NotEqual(t, keys, asc)
 
-		return builder.NewMapArray()
-	}
+		b := testStringMap(mem, m, asc)
+		defer b.Release()
 
-	descKeys := []string{"z", "y", "x"}
-	desc := getArr(descKeys)
-	defer desc.Release()
+		assert.False(t, array.ApproxEqual(a, b))
+		assert.True(t, array.ApproxEqual(a, b, array.WithUnorderedMapKeys(true)))
+	})
 
-	askKeys := make([]string, len(descKeys))
-	copy(askKeys, descKeys)
-	sort.Strings(askKeys)
-	assert.NotEqual(t, descKeys, askKeys)
+	t.Run("extra left value", func(t *testing.T) {
+		m := map[string]string{"x": "x", "y": "y", "z": "z", "extra": "extra"}
 
-	asc := getArr(askKeys)
-	defer asc.Release()
+		aKeys := []string{"z", "y", "x", "extra"}
+		a := testStringMap(mem, m, aKeys)
+		defer a.Release()
 
-	assert.False(t, array.ApproxEqual(desc, asc))
-	assert.True(t, array.ApproxEqual(desc, asc, array.WithUnorderedMapKeys(true)))
+		bKeys := []string{"z", "y", "x"}
+		b := testStringMap(mem, m, bKeys)
+		defer b.Release()
+
+		assert.NotEqual(t, aKeys, bKeys)
+		assert.Equal(t, a.NullN(), b.NullN())
+		assert.False(t, array.ApproxEqual(a, b))
+		assert.False(t, array.ApproxEqual(a, b, array.WithUnorderedMapKeys(true)))
+	})
+
+	t.Run("extra right value", func(t *testing.T) {
+		m := map[string]string{"x": "x", "y": "y", "z": "z", "extra": "extra"}
+
+		aKeys := []string{"z", "y", "x"}
+		a := testStringMap(mem, m, aKeys)
+		defer a.Release()
+
+		bKeys := []string{"z", "y", "x", "extra"}
+		b := testStringMap(mem, m, bKeys)
+		defer b.Release()
+
+		assert.NotEqual(t, aKeys, bKeys)
+		assert.Equal(t, a.NullN(), b.NullN())
+		assert.False(t, array.ApproxEqual(a, b))
+		assert.False(t, array.ApproxEqual(a, b, array.WithUnorderedMapKeys(true)))
+	})
+
+	t.Run("unmatched value", func(t *testing.T) {
+		m := map[string]string{"x": "x", "y": "y", "z": "z", "extra": "extra", "extra2": "extra"}
+
+		aKeys := []string{"z", "y", "x", "extra"}
+		a := testStringMap(mem, m, aKeys)
+		defer a.Release()
+
+		bKeys := []string{"z", "y", "x", "extra2"}
+		b := testStringMap(mem, m, bKeys)
+		defer b.Release()
+
+		assert.NotEqual(t, aKeys, bKeys)
+		assert.Equal(t, a.NullN(), b.NullN())
+		assert.False(t, array.ApproxEqual(a, b))
+		assert.False(t, array.ApproxEqual(a, b, array.WithUnorderedMapKeys(true)))
+	})
 }
 
 func arrayOf(mem memory.Allocator, a interface{}, valids []bool) arrow.Array {

--- a/go/arrow/array/compare_test.go
+++ b/go/arrow/array/compare_test.go
@@ -338,7 +338,8 @@ func TestArrayApproxEqualMaps(t *testing.T) {
 	asc := getArr(askKeys)
 	defer asc.Release()
 
-	assert.True(t, array.ApproxEqual(desc, asc))
+	assert.False(t, array.ApproxEqual(desc, asc))
+	assert.True(t, array.ApproxEqual(desc, asc, array.WithUnorderedMapKeys(true)))
 }
 
 func arrayOf(mem memory.Allocator, a interface{}, valids []bool) arrow.Array {

--- a/go/arrow/array/compare_test.go
+++ b/go/arrow/array/compare_test.go
@@ -400,6 +400,22 @@ func TestArrayApproxEqualMaps(t *testing.T) {
 		assert.False(t, array.ApproxEqual(a, b))
 		assert.False(t, array.ApproxEqual(a, b, array.WithUnorderedMapKeys(true)))
 	})
+
+	t.Run("different value", func(t *testing.T) {
+		m := map[string]string{"x": "x", "y": "y", "z": "z", "extra": "extra"}
+
+		keys := []string{"z", "y", "x", "extra"}
+		a := testStringMap(mem, m, keys)
+		defer a.Release()
+
+		m["extra"] = "different"
+		b := testStringMap(mem, m, keys)
+		defer b.Release()
+
+		assert.Equal(t, a.NullN(), b.NullN())
+		assert.False(t, array.ApproxEqual(a, b))
+		assert.False(t, array.ApproxEqual(a, b, array.WithUnorderedMapKeys(true)))
+	})
 }
 
 func arrayOf(mem memory.Allocator, a interface{}, valids []bool) arrow.Array {

--- a/go/arrow/array/compare_test.go
+++ b/go/arrow/array/compare_test.go
@@ -19,6 +19,7 @@ package array_test
 import (
 	"fmt"
 	"math"
+	"sort"
 	"testing"
 
 	"github.com/apache/arrow/go/v13/arrow"
@@ -27,7 +28,6 @@ import (
 	"github.com/apache/arrow/go/v13/arrow/internal/arrdata"
 	"github.com/apache/arrow/go/v13/arrow/memory"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/exp/slices"
 )
 
 func TestArrayEqual(t *testing.T) {
@@ -332,7 +332,7 @@ func TestArrayApproxEqualMaps(t *testing.T) {
 
 	askKeys := make([]string, len(descKeys))
 	copy(askKeys, descKeys)
-	slices.Sort(askKeys)
+	sort.Strings(askKeys)
 	assert.NotEqual(t, descKeys, askKeys)
 
 	asc := getArr(askKeys)


### PR DESCRIPTION
### Rationale for this change

If we store the value of the `*array.Map` into Go map we can't expect to put the values back in the same order, as the map traversal order in Go is undefined.
This PR extends `array.ApproxEqual` by allowing map keys to be in different order.

### What changes are included in this PR?

New helper functions:
* `array.arrayApproxEqualMap` that is now used instead of `array.arrayApproxEqualList` for map comparison
* `array.arrayApproxEqualSingleMapEntry` that checks if the single map entry we have matches to the other one without having keys sorted the same way

### Are these changes tested?

1. Newly added test `array.TestArrayApproxEqualMaps`
2. https://github.com/cloudquery/cloudquery/pull/11078

### Are there any user-facing changes?

New `array.WithUnorderedMapKeys` option for `array.ApproxEqual` that allows users to control if the entries order is important or not.

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #35828