### PR TITLE
GH-35676: [MATLAB] Add an `InferNulls` name-value pair for controlling null value inference during construction of `arrow.array.Array`

### DIFF
--- a/matlab/src/matlab/+arrow/+args/parseValidElements.m
+++ b/matlab/src/matlab/+arrow/+args/parseValidElements.m
@@ -1,24 +1,24 @@
-function validElements = parseValidElements(data, detectNulls, nullDetectionFcn)
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+function validElements = parseValidElements(data, inferNulls)
     % Returns a logical vector of the validElements in data. If inferNulls
     % is true, calls ismissing on data to determine which elements are 
     % null.
 
-    % Licensed to the Apache Software Foundation (ASF) under one or more
-    % contributor license agreements.  See the NOTICE file distributed with
-    % this work for additional information regarding copyright ownership.
-    % The ASF licenses this file to you under the Apache License, Version
-    % 2.0 (the "License"); you may not use this file except in compliance
-    % with the License.  You may obtain a copy of the License at
-    %
-    %   http://www.apache.org/licenses/LICENSE-2.0
-    %
-    % Unless required by applicable law or agreed to in writing, software
-    % distributed under the License is distributed on an "AS IS" BASIS,
-    % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-    % implied.  See the License for the specific language governing
-    % permissions and limitations under the License.
-
-    if detectNulls
+    if inferNulls
         % TODO: consider making validElements empty if everything is valid.
         validElements = ~ismissing(data);
     else

--- a/matlab/src/matlab/+arrow/+args/parseValidElements.m
+++ b/matlab/src/matlab/+arrow/+args/parseValidElements.m
@@ -1,7 +1,7 @@
 function validElements = parseValidElements(data, detectNulls, nullDetectionFcn)
-    % Creates the validElements logical vector based on data if
-    % detectNulls is true. If so, data is based to the NullDetectionFcn.
-    % Otherwise, all elements in data are valid.
+    % Returns a logical vector of the validElements in data. If inferNulls
+    % is true, calls ismissing on data to determine which elements are 
+    % null.
 
     % Licensed to the Apache Software Foundation (ASF) under one or more
     % contributor license agreements.  See the NOTICE file distributed with
@@ -20,15 +20,7 @@ function validElements = parseValidElements(data, detectNulls, nullDetectionFcn)
 
     if detectNulls
         % TODO: consider making validElements empty if everything is valid.
-        validElements = ~nullDetectionFcn(data);
-    
-        % If data was empty, it's ok for validElements to be a 0x0 
-        % logical array. 
-        expectedShape = 'vector';
-        if isempty(validElements)
-            expectedShape = '2d';
-        end
-        validateattributes(validElements, "logical", {expectedShape, 'numel', numel(data)});
+        validElements = ~ismissing(data);
     else
         % TODO: consider making this an empty array if everything is valid
         validElements = true([numel(data) 1]);

--- a/matlab/src/matlab/+arrow/+args/parseValidElements.m
+++ b/matlab/src/matlab/+arrow/+args/parseValidElements.m
@@ -1,5 +1,7 @@
-classdef Int8Array < arrow.array.Array
-    % arrow.array.Int8Array
+function validElements = parseValidElements(data, detectNulls, nullDetectionFcn)
+    % Creates the validElements logical vector based on data if
+    % detectNulls is true. If so, data is based to the NullDetectionFcn.
+    % Otherwise, all elements in data are valid.
 
     % Licensed to the Apache Software Foundation (ASF) under one or more
     % contributor license agreements.  See the NOTICE file distributed with
@@ -16,25 +18,19 @@ classdef Int8Array < arrow.array.Array
     % implied.  See the License for the specific language governing
     % permissions and limitations under the License.
 
-    properties (Hidden, SetAccess=private)
-        MatlabArray = int8([])
-    end
-
-    methods
-        function obj = Int8Array(data, opts)
-            arguments
-                data
-                opts.DeepCopy = false
-            end
-            
-            arrow.args.validateTypeAndShape(data, "int8");
-            obj@arrow.array.Array("Name", "arrow.array.proxy.Int8Array", "ConstructorArguments", {data, opts.DeepCopy});
-            % Store a reference to the array if not doing a deep copy
-            if (~opts.DeepCopy), obj.MatlabArray = data; end
+    if detectNulls
+        % TODO: consider making validElements empty if everything is valid.
+        validElements = ~nullDetectionFcn(data);
+    
+        % If data was empty, it's ok for validElements to be a 0x0 
+        % logical array. 
+        expectedShape = 'vector';
+        if isempty(validElements)
+            expectedShape = '2d';
         end
-
-        function data = int8(obj)
-            data = obj.Proxy.toMATLAB();
-        end
+        validateattributes(validElements, "logical", {expectedShape, 'numel', numel(data)});
+    else
+        % TODO: consider making this an empty array if everything is valid
+        validElements = true([numel(data) 1]);
     end
 end

--- a/matlab/src/matlab/+arrow/+args/validateTypeAndShape.m
+++ b/matlab/src/matlab/+arrow/+args/validateTypeAndShape.m
@@ -1,5 +1,6 @@
-classdef Int8Array < arrow.array.Array
-    % arrow.array.Int8Array
+function validateTypeAndShape(data, type)
+    % Validates data has the expected type and is a vector or empty 2D
+    % matrix. If data is numeric, validates is real and nonsparse.
 
     % Licensed to the Apache Software Foundation (ASF) under one or more
     % contributor license agreements.  See the NOTICE file distributed with
@@ -16,25 +17,20 @@ classdef Int8Array < arrow.array.Array
     % implied.  See the License for the specific language governing
     % permissions and limitations under the License.
 
-    properties (Hidden, SetAccess=private)
-        MatlabArray = int8([])
+    arguments
+        data
+        type(1, 1) string
     end
 
-    methods
-        function obj = Int8Array(data, opts)
-            arguments
-                data
-                opts.DeepCopy = false
-            end
-            
-            arrow.args.validateTypeAndShape(data, "int8");
-            obj@arrow.array.Array("Name", "arrow.array.proxy.Int8Array", "ConstructorArguments", {data, opts.DeepCopy});
-            % Store a reference to the array if not doing a deep copy
-            if (~opts.DeepCopy), obj.MatlabArray = data; end
-        end
-
-        function data = int8(obj)
-            data = obj.Proxy.toMATLAB();
-        end
+    % If data is empty, only require it's shape to be 2D to support 0x0 
+    % arrays. Otherwise, require data to be a vector.
+    %
+    % TODO: Consider supporting nonvector 2D arrays. We chould reshape them
+    % to column vectors if needed.
+    
+    expectedShape = "vector";
+    if isempty(data)
+        expectedShape = "2d";
     end
+    validateattributes(data, type, [expectedShape, "nonsparse", "real"]);
 end

--- a/matlab/src/matlab/+arrow/+args/validateTypeAndShape.m
+++ b/matlab/src/matlab/+arrow/+args/validateTypeAndShape.m
@@ -1,21 +1,21 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
 function validateTypeAndShape(data, type)
     % Validates data has the expected type and is a vector or empty 2D
     % matrix. If data is numeric, validates is real and nonsparse.
-
-    % Licensed to the Apache Software Foundation (ASF) under one or more
-    % contributor license agreements.  See the NOTICE file distributed with
-    % this work for additional information regarding copyright ownership.
-    % The ASF licenses this file to you under the Apache License, Version
-    % 2.0 (the "License"); you may not use this file except in compliance
-    % with the License.  You may obtain a copy of the License at
-    %
-    %   http://www.apache.org/licenses/LICENSE-2.0
-    %
-    % Unless required by applicable law or agreed to in writing, software
-    % distributed under the License is distributed on an "AS IS" BASIS,
-    % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-    % implied.  See the License for the specific language governing
-    % permissions and limitations under the License.
 
     arguments
         data

--- a/matlab/src/matlab/+arrow/+array/Float32Array.m
+++ b/matlab/src/matlab/+arrow/+array/Float32Array.m
@@ -26,8 +26,7 @@ classdef Float32Array < arrow.array.Array
                 data
                 opts.DeepCopy = false
             end
-            validateattributes(data, "single", ["2d", "nonsparse", "real"]);
-            if ~isempty(data), validateattributes(data, "single", "vector"); end
+            arrow.args.validateTypeAndShape(data, "single");
             obj@arrow.array.Array("Name", "arrow.array.proxy.Float32Array", "ConstructorArguments", {data, opts.DeepCopy});
             % Store a reference to the array if not doing a deep copy
             if (~opts.DeepCopy), obj.MatlabArray = data; end

--- a/matlab/src/matlab/+arrow/+array/Float64Array.m
+++ b/matlab/src/matlab/+arrow/+array/Float64Array.m
@@ -29,19 +29,8 @@ classdef Float64Array < arrow.array.Array
                 opts.DetectNulls(1, 1) logical = true
                 opts.NullDetectionFcn(1, 1) function_handle = @isnan
             end
-
-            validateattributes(data, "double", ["2d", "nonsparse", "real"]);
-            if ~isempty(data), validateattributes(data, "double", "vector"); end
-
-            if opts.DetectNulls
-                % TODO: consider making validElements empty if everything is valid.
-                validElements = ~opts.NullDetectionFcn(data);
-                validateattributes(validElements, "logical", {'vector', 'numel', numel(data)});
-            else
-                % TODO: consider making this an empty array if everything is valid
-                validElements = true([numel(data) 1]);
-            end
-
+            arrow.args.validateTypeAndShape(data, "double");
+            validElements = arrow.args.parseValidElements(data, opts.DetectNulls, opts.NullDetectionFcn);
             obj@arrow.array.Array("Name", "arrow.array.proxy.Float64Array", "ConstructorArguments", {data, opts.DeepCopy, validElements});
             % Store a reference to the array if not doing a deep copy
             if (~opts.DeepCopy), obj.MatlabArray = data; end
@@ -57,3 +46,4 @@ classdef Float64Array < arrow.array.Array
         end
     end
 end
+

--- a/matlab/src/matlab/+arrow/+array/Float64Array.m
+++ b/matlab/src/matlab/+arrow/+array/Float64Array.m
@@ -26,11 +26,10 @@ classdef Float64Array < arrow.array.Array
             arguments
                 data
                 opts.DeepCopy(1, 1) logical = false
-                opts.DetectNulls(1, 1) logical = true
-                opts.NullDetectionFcn(1, 1) function_handle = @isnan
+                opts.InferNulls(1, 1) logical = true
             end
             arrow.args.validateTypeAndShape(data, "double");
-            validElements = arrow.args.parseValidElements(data, opts.DetectNulls, opts.NullDetectionFcn);
+            validElements = arrow.args.parseValidElements(data, opts.InferNulls);
             obj@arrow.array.Array("Name", "arrow.array.proxy.Float64Array", "ConstructorArguments", {data, opts.DeepCopy, validElements});
             % Store a reference to the array if not doing a deep copy
             if (~opts.DeepCopy), obj.MatlabArray = data; end

--- a/matlab/src/matlab/+arrow/+array/Int16Array.m
+++ b/matlab/src/matlab/+arrow/+array/Int16Array.m
@@ -26,8 +26,8 @@ classdef Int16Array < arrow.array.Array
                 data
                 opts.DeepCopy = false
             end
-            validateattributes(data, "int16", ["2d", "nonsparse", "real"]);
-            if ~isempty(data), validateattributes(data, "int16", "vector"); end
+
+            arrow.args.validateTypeAndShape(data, "int16");
             obj@arrow.array.Array("Name", "arrow.array.proxy.Int16Array", "ConstructorArguments", {data, opts.DeepCopy});
             % Store a reference to the array if not doing a deep copy
             if (~opts.DeepCopy), obj.MatlabArray = data; end

--- a/matlab/src/matlab/+arrow/+array/Int32Array.m
+++ b/matlab/src/matlab/+arrow/+array/Int32Array.m
@@ -26,8 +26,7 @@ classdef Int32Array < arrow.array.Array
                 data
                 opts.DeepCopy = false
             end
-            validateattributes(data, "int32", ["2d", "nonsparse", "real"]);
-            if ~isempty(data), validateattributes(data, "int32", "vector"); end
+            arrow.args.validateTypeAndShape(data, "int32");
             obj@arrow.array.Array("Name", "arrow.array.proxy.Int32Array", "ConstructorArguments", {data, opts.DeepCopy});
             % Store a reference to the array if not doing a deep copy
             if (~opts.DeepCopy), obj.MatlabArray = data; end

--- a/matlab/src/matlab/+arrow/+array/Int64Array.m
+++ b/matlab/src/matlab/+arrow/+array/Int64Array.m
@@ -26,8 +26,7 @@ classdef Int64Array < arrow.array.Array
                 data
                 opts.DeepCopy = false
             end
-            validateattributes(data, "int64", ["2d", "nonsparse", "real"]);
-            if ~isempty(data), validateattributes(data, "int64", "vector"); end
+            arrow.args.validateTypeAndShape(data, "int64");
             obj@arrow.array.Array("Name", "arrow.array.proxy.Int64Array", "ConstructorArguments", {data, opts.DeepCopy});
             % Store a reference to the array if not doing a deep copy
             if (~opts.DeepCopy), obj.MatlabArray = data; end

--- a/matlab/src/matlab/+arrow/+array/UInt16Array.m
+++ b/matlab/src/matlab/+arrow/+array/UInt16Array.m
@@ -26,8 +26,7 @@ classdef UInt16Array < arrow.array.Array
                 data
                 opts.DeepCopy = false
             end
-            validateattributes(data, "uint16", ["2d", "nonsparse", "real"]);
-            if ~isempty(data), validateattributes(data, "uint16", "vector"); end
+            arrow.args.validateTypeAndShape(data, "uint16");
             obj@arrow.array.Array("Name", "arrow.array.proxy.UInt16Array", "ConstructorArguments", {data, opts.DeepCopy});
             % Store a reference to the array if not doing a deep copy
             if (~opts.DeepCopy), obj.MatlabArray = data; end

--- a/matlab/src/matlab/+arrow/+array/UInt32Array.m
+++ b/matlab/src/matlab/+arrow/+array/UInt32Array.m
@@ -26,8 +26,7 @@ classdef UInt32Array < arrow.array.Array
                 data
                 opts.DeepCopy = false
             end
-            validateattributes(data, "uint32", ["2d", "nonsparse", "real"]);
-            if ~isempty(data), validateattributes(data, "uint32", "vector"); end
+            arrow.args.validateTypeAndShape(data, "uint32");
             obj@arrow.array.Array("Name", "arrow.array.proxy.UInt32Array", "ConstructorArguments", {data, opts.DeepCopy});
             % Store a reference to the array if not doing a deep copy
             if (~opts.DeepCopy), obj.MatlabArray = data; end

--- a/matlab/src/matlab/+arrow/+array/UInt64Array.m
+++ b/matlab/src/matlab/+arrow/+array/UInt64Array.m
@@ -26,8 +26,7 @@ classdef UInt64Array < arrow.array.Array
                 data
                 opts.DeepCopy = false
             end
-            validateattributes(data, "uint64", ["2d", "nonsparse", "real"]);
-            if ~isempty(data), validateattributes(data, "uint64", "vector"); end
+            arrow.args.validateTypeAndShape(data, "uint64");
             obj@arrow.array.Array("Name", "arrow.array.proxy.UInt64Array", "ConstructorArguments", {data, opts.DeepCopy});
             % Store a reference to the array if not doing a deep copy
             if (~opts.DeepCopy), obj.MatlabArray = data; end

--- a/matlab/src/matlab/+arrow/+array/UInt8Array.m
+++ b/matlab/src/matlab/+arrow/+array/UInt8Array.m
@@ -26,8 +26,7 @@ classdef UInt8Array < arrow.array.Array
                 data
                 opts.DeepCopy = false
             end
-            validateattributes(data, "uint8", ["2d", "nonsparse", "real"]);
-            if ~isempty(data), validateattributes(data, "uint8", "vector"); end
+            arrow.args.validateTypeAndShape(data, "uint8");
             obj@arrow.array.Array("Name", "arrow.array.proxy.UInt8Array", "ConstructorArguments", {data, opts.DeepCopy});
             % Store a reference to the array if not doing a deep copy
             if (~opts.DeepCopy), obj.MatlabArray = data; end

--- a/matlab/test/arrow/array/hNumericArray.m
+++ b/matlab/test/arrow/array/hNumericArray.m
@@ -117,17 +117,17 @@ classdef hNumericArray < matlab.unittest.TestCase
             tc.verifyError(fcn, "MATLAB:expectedReal");
         end
 
-        function ErrorIfNotTwoDimensional(tc, MakeDeepCopy)
+        function ErrorIfNonVector(tc, MakeDeepCopy)
             data = tc.MatlabArrayFcn([1 2 3 4 5 6 7 8 9]);
             data = reshape(data, 3, 1, 3);
             fcn = @() tc.ArrowArrayConstructor(tc.MatlabArrayFcn(data), DeepCopy=MakeDeepCopy);
-            tc.verifyError(fcn, "MATLAB:expected2D");
+            tc.verifyError(fcn, "MATLAB:expectedVector");
         end
 
-        function ErrorIfNonVector(tc, MakeDeepCopy)
-            data = tc.MatlabArrayFcn([1 2; 3 4]);
+        function ErrorIfEmptyArrayIsNotTwoDimensional(tc, MakeDeepCopy)
+            data = tc.MatlabArrayFcn(reshape([], [1 0 0]));
             fcn = @() tc.ArrowArrayConstructor(data, DeepCopy=MakeDeepCopy);
-            tc.verifyError(fcn, "MATLAB:expectedVector");
+            tc.verifyError(fcn, "MATLAB:expected2D");
         end
     end
 end

--- a/matlab/test/arrow/array/tFloat64Array.m
+++ b/matlab/test/arrow/array/tFloat64Array.m
@@ -40,10 +40,27 @@ classdef tFloat64Array < hNumericArray
 
         function ValidBasic(testCase, MakeDeepCopy)
             % Create a MATLAB array with one null value (i.e. one NaN).
+            % Verify NaN is considered a null value by default.
             matlabArray = [1, NaN, 3]';
             arrowArray = arrow.array.Float64Array(matlabArray, DeepCopy=MakeDeepCopy);
             expectedValid = [true, false, true]';
             testCase.verifyEqual(arrowArray.Valid, expectedValid);
+        end
+
+        function InferNulls(testCase, MakeDeepCopy)
+            matlabArray = [1, NaN, 3];
+
+            % Verify NaN is treated as a null value when InferNulls=true.
+            arrowArray1 = arrow.array.Float64Array(matlabArray, InferNulls=true, DeepCopy=MakeDeepCopy);
+            expectedValid1 = [true false true]';
+            testCase.verifyEqual(arrowArray1.Valid, expectedValid1);
+            testCase.verifyEqual(toMATLAB(arrowArray1), matlabArray');
+
+            % Verify NaN is not treated as a null value when InferNulls=false.
+            arrowArray2 = arrow.array.Float64Array(matlabArray, InferNulls=false, DeepCopy=MakeDeepCopy);
+            expectedValid2 = [true true true]';
+            testCase.verifyEqual(arrowArray2.Valid, expectedValid2);
+            testCase.verifyEqual(toMATLAB(arrowArray2), matlabArray');
         end
 
         function ValidNoNulls(testCase, MakeDeepCopy)
@@ -79,6 +96,5 @@ classdef tFloat64Array < hNumericArray
             arrowArray = arrow.array.Float64Array(matlabArray, DeepCopy=MakeDeepCopy);
             testCase.verifyEqual(arrowArray.Valid, expectedValid);
         end
-        
     end
 end


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
This change lets users control toggle the automatic null-value detection behavior. By default, values MATLAB considers to be missing  (e.g. `NaN` for `double`, `<missing>` for `string`, and `NaT` for `datetime`) will be treated as `null` values. Users can toggle this behavior on and off using the `InferNulls` name-value pair. 

**Example**
```matlab
>> matlabArray = [1 NaN 3]'

matlabArray =

     1
     NaN
     3
      
% Treat NaN as a null value
 >> arrowArray1 = arrow.array.Float64Array(maltabArray, InferNulls=true)

arrowArray1 = 

[
  1,
  null,
  3
]

% Don't treat NaN as a null value 
 >> arrowArray2 = arrow.array.Float64Array(maltabArray, InferNulls=false)
   
arrowArray2 = 

[
  1,
  nan,
  3
]

```
We've only added this nv-pair to `arrow.array.Float64Array` for now. We'll add this nv-pair to the other types in a followup changelist.

### What changes are included in this PR?

1. Added `InferNulls` name-value pair to `arrow.array.Float64Array`.
2. Added common validation function `arrow.args.validateTypeAndShape` to remove duplicate validation code among the numeric classes.
3. Added a function called `arrow.args.parseValidElements` that the `arrow.array.<Type>Array` classes will be able to share for generating the logical mask of valid elements.

### Are these changes tested?

Yes, we added a test pointed called `InferNulls` to  the test class`tFloat64Array.m`.

### Are there any user-facing changes?

Yes, users can now control how `NaN` values are treated when creating an `arrow.array.Float64Array`.

### Future Directions

1. Add a name-value pair to allow users to specify the valid elements themselves.
2. Extend null support to other numeric types.
3. We've been working on adding error-handling support to `mathworks/libmexclass`. We have a prototype to do this using status-like and result-like objects already pushed to a [branch](https://github.com/mathworks/libmexclass/tree/33). Once this branch is merged with the `main` branch of `mathworks/libmexclass`, we'll port it over.


### Notes

Thank you @kevingurney for all the help with this PR! 
* Closes: #35676