### PR TITLE
GH-35853: [Python] Fix deprecation warnings from NumPy NEP50

### DIFF
--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1414,16 +1414,19 @@ def test_chunked_array_data_warns():
 
 
 def test_cast_integers_unsafe():
-    # We let NumPy do the unsafe casting
+    # We let NumPy do the unsafe casting.
+    # Note that NEP50 in the NumPy spec no longer allows
+    # the np.array() constructor to pass the dtype directly
+    # if it results in an unsafe cast.
     unsafe_cases = [
         (np.array([50000], dtype='i4'), 'int32',
-         np.array([50000], dtype='i2'), pa.int16()),
+         np.array([50000]).astype(dtype='i2'), pa.int16()),
         (np.array([70000], dtype='i4'), 'int32',
-         np.array([70000], dtype='u2'), pa.uint16()),
+         np.array([70000]).astype(dtype='u2'), pa.uint16()),
         (np.array([-1], dtype='i4'), 'int32',
-         np.array([-1], dtype='u2'), pa.uint16()),
+         np.array([-1]).astype(dtype='u2'), pa.uint16()),
         (np.array([50000], dtype='u2'), pa.uint16(),
-         np.array([50000], dtype='i2'), pa.int16())
+         np.array([50000]).astype(dtype='i2'), pa.int16())
     ]
 
     for case in unsafe_cases:


### PR DESCRIPTION
### Rationale for this change

Remove warnings from the pyarrow test suite (preventing them from eventually becoming errors).

### Are these changes tested?

Yes, verified no warnings are displayed.


```
$ python -m pytest pyarrow/tests/test_array.py -k test_cast_integers_unsafe
=================================================================== test session starts ===================================================================
platform darwin -- Python 3.11.2, pytest-7.2.2, pluggy-1.0.0
rootdir: /Users/dane/code/arrow/python, configfile: setup.cfg
plugins: hypothesis-6.70.1, cython-0.2.1, lazy-fixture-0.6.3
collected 237 items / 236 deselected / 1 selected

pyarrow/tests/test_array.py .                                                                                                                       [100%]

============================================================ 1 passed, 236 deselected in 0.24s ============================================================
```

### Are there any user-facing changes?

No.

* Closes: #35853