### PR TITLE
GH-35833: [C++] Add support for Abseil 20230125

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2823,7 +2823,7 @@ macro(ensure_absl)
       # 20211102 or later. We need to update
       # ARROW_ABSL_REQUIRED_LTS_VERSIONS list when new Abseil LTS is
       # released.
-      set(ARROW_ABSL_REQUIRED_LTS_VERSIONS 20211102 20220623)
+      set(ARROW_ABSL_REQUIRED_LTS_VERSIONS 20230125 20220623 20211102)
       foreach(_VERSION ${ARROW_ABSL_REQUIRED_LTS_VERSIONS})
         find_package(absl ${_VERSION})
         if(absl_FOUND)


### PR DESCRIPTION
### Rationale for this change

The latest Abseil LTS is 20230125.

### What changes are included in this PR?

Accept 20230125 too.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #35833