### PR TITLE
MINOR: [Docs] Fix typo in docs for dense union data type

### DIFF
--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -622,7 +622,7 @@ will have the following layout: ::
 
     * Children arrays:
       * Field-0 array (f: Float32):
-        * Length: 2, Null count: 1
+        * Length: 3, Null count: 1
         * Validity bitmap buffer: 00000101
 
         * Value Buffer:


### PR DESCRIPTION
## Rationale for this change / What changes are included in this PR?

Fixed typo in `Columnar.rst`. 

I think this typo may have crept in from an [older](https://wesm.github.io/arrow-site-test/format/Layout.html#example-layout-dense-union) version of the docs when validity bitmaps were allowed for Union types.

## Are these changes tested?

N/A

## Are there any user-facing changes?

Only in the docs.
