### PR TITLE
GH-32566: [C++] Connect parquet to the new scan node

### DIFF
--- a/cpp/src/arrow/acero/sink_node_test.cc
+++ b/cpp/src/arrow/acero/sink_node_test.cc
@@ -1,0 +1,77 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+
+#include "arrow/acero/exec_plan.h"
+#include "arrow/acero/options.h"
+#include "arrow/dataset/file_base.h"
+#include "arrow/dataset/file_parquet.h"
+#include "arrow/dataset/partition.h"
+#include "arrow/filesystem/mockfs.h"
+#include "arrow/testing/generator.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/testing/matchers.h"
+
+#include "arrow/table.h"
+#include "arrow/util/key_value_metadata.h"
+
+namespace arrow {
+
+namespace acero {
+
+TEST(SinkNode, CustomFieldMetadata) {
+  // Create an input table with a nullable and a non-nullable type
+  ExecBatch batch = gen::Gen({gen::Step()})->FailOnError()->ExecBatch(/*num_rows=*/1);
+  std::shared_ptr<Schema> test_schema =
+      schema({field("nullable_i32", uint32(), /*nullable=*/true,
+                    key_value_metadata({{"foo", "bar"}})),
+              field("non_nullable_i32", uint32(), /*nullable=*/false)});
+  std::shared_ptr<RecordBatch> record_batch =
+      RecordBatch::Make(test_schema, /*num_rows=*/1,
+                        {batch.values[0].make_array(), batch.values[0].make_array()});
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<Table> table,
+                       Table::FromRecordBatches({std::move(record_batch)}));
+
+  ASSERT_TRUE(table->field(0)->nullable());
+  ASSERT_EQ(1, table->field(0)->metadata()->keys().size());
+  ASSERT_FALSE(table->field(1)->nullable());
+  ASSERT_EQ(0, table->field(1)->metadata()->keys().size());
+
+  Declaration plan = Declaration::Sequence(
+      {{"table_source", TableSourceNodeOptions(std::move(table))},
+       {"project", ProjectNodeOptions({compute::field_ref(0), compute::field_ref(1)})}});
+
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<Table> out_table, DeclarationToTable(plan));
+
+  ASSERT_TRUE(table->field(0)->nullable());
+  ASSERT_EQ(1, table->field(0)->metadata()->keys().size());
+  ASSERT_FALSE(table->field(1)->nullable());
+  ASSERT_EQ(0, table->field(1)->metadata()->keys().size());
+
+  ASSERT_OK_AND_ASSIGN(BatchesWithCommonSchema batches_and_schema,
+                       DeclarationToExecBatches(plan));
+  ASSERT_TRUE(batches_and_schema.schema->field(0)->nullable());
+  ASSERT_FALSE(batches_and_schema.schema->field(1)->nullable());
+}
+
+}  // namespace acero
+}  // namespace arrow

--- a/cpp/src/arrow/compute/key_map_avx2.cc
+++ b/cpp/src/arrow/compute/key_map_avx2.cc
@@ -20,8 +20,6 @@
 #include "arrow/compute/key_map.h"
 #include "arrow/util/logging.h"
 
-#include "arrow/util/logging.h"
-
 namespace arrow {
 namespace compute {
 

--- a/cpp/src/arrow/compute/key_map_avx2.cc
+++ b/cpp/src/arrow/compute/key_map_avx2.cc
@@ -20,6 +20,8 @@
 #include "arrow/compute/key_map.h"
 #include "arrow/util/logging.h"
 
+#include "arrow/util/logging.h"
+
 namespace arrow {
 namespace compute {
 

--- a/cpp/src/arrow/dataset/dataset.cc
+++ b/cpp/src/arrow/dataset/dataset.cc
@@ -193,7 +193,7 @@ class InMemoryFragment::Scanner : public FragmentScanner {
   int NumScanTasks() override { return 1; }
 
   int NumBatchesInScanTask(int task_number) override {
-    DCHECK_LE(batches_.size(), std::numeric_limits<int32_t>::max());
+    DCHECK_LE(batches_.size(), static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
     return static_cast<int>(batches_.size());
   }
 

--- a/cpp/src/arrow/dataset/dataset.cc
+++ b/cpp/src/arrow/dataset/dataset.cc
@@ -68,7 +68,7 @@ Future<std::shared_ptr<InspectedFragment>> Fragment::InspectFragmentImpl(
 }
 
 Future<std::shared_ptr<FragmentScanner>> Fragment::BeginScan(
-    const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
+    const FragmentScanRequest& request, InspectedFragment* inspected_fragment,
     compute::ExecContext* exec_context) {
   return Status::NotImplemented("New scan method");
 }
@@ -202,7 +202,7 @@ class InMemoryFragment::Scanner : public FragmentScanner {
 };
 
 Future<std::shared_ptr<FragmentScanner>> InMemoryFragment::BeginScan(
-    const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
+    const FragmentScanRequest& request, InspectedFragment* inspected_fragment,
     compute::ExecContext* exec_context) {
   return Future<std::shared_ptr<FragmentScanner>>::MakeFinished(
       std::make_shared<InMemoryFragment::Scanner>(record_batches_));

--- a/cpp/src/arrow/dataset/dataset.cc
+++ b/cpp/src/arrow/dataset/dataset.cc
@@ -193,7 +193,8 @@ class InMemoryFragment::Scanner : public FragmentScanner {
   int NumScanTasks() override { return 1; }
 
   int NumBatchesInScanTask(int task_number) override {
-    DCHECK_LE(batches_.size(), static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+    DCHECK_LE(batches_.size(),
+              static_cast<uint64_t>(std::numeric_limits<int32_t>::max()));
     return static_cast<int>(batches_.size());
   }
 

--- a/cpp/src/arrow/dataset/dataset.cc
+++ b/cpp/src/arrow/dataset/dataset.cc
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <limits>
 #include <memory>
 #include <utility>
 
@@ -44,13 +45,31 @@ Fragment::Fragment(compute::Expression partition_expression,
       physical_schema_(std::move(physical_schema)) {}
 
 Future<std::shared_ptr<InspectedFragment>> Fragment::InspectFragment(
+    const FragmentScanOptions* format_options, compute::ExecContext* exec_context,
+    bool should_cache) {
+  util::Mutex::Guard lk = physical_schema_mutex_.Lock();
+  if (cached_inspected_fragment_) {
+    return cached_inspected_fragment_;
+  }
+  lk.Unlock();
+  return InspectFragmentImpl(format_options, exec_context)
+      .Then([this, should_cache](const std::shared_ptr<InspectedFragment>& frag) {
+        if (should_cache) {
+          util::Mutex::Guard lk = physical_schema_mutex_.Lock();
+          cached_inspected_fragment_ = frag;
+        }
+        return frag;
+      });
+}
+
+Future<std::shared_ptr<InspectedFragment>> Fragment::InspectFragmentImpl(
     const FragmentScanOptions* format_options, compute::ExecContext* exec_context) {
   return Status::NotImplemented("Inspect fragment");
 }
 
 Future<std::shared_ptr<FragmentScanner>> Fragment::BeginScan(
     const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
-    const FragmentScanOptions* format_options, compute::ExecContext* exec_context) {
+    compute::ExecContext* exec_context) {
   return Status::NotImplemented("New scan method");
 }
 
@@ -156,42 +175,44 @@ Future<std::optional<int64_t>> InMemoryFragment::CountRows(
   return Future<std::optional<int64_t>>::MakeFinished(total);
 }
 
-Future<std::shared_ptr<InspectedFragment>> InMemoryFragment::InspectFragment(
+Future<std::shared_ptr<InspectedFragment>> InMemoryFragment::InspectFragmentImpl(
     const FragmentScanOptions* format_options, compute::ExecContext* exec_context) {
   return std::make_shared<InspectedFragment>(physical_schema_->field_names());
 }
 
 class InMemoryFragment::Scanner : public FragmentScanner {
  public:
-  explicit Scanner(InMemoryFragment* fragment) : fragment_(fragment) {}
+  explicit Scanner(std::vector<std::shared_ptr<RecordBatch>> batches)
+      : batches_(std::move(batches)) {}
 
-  Future<std::shared_ptr<RecordBatch>> ScanBatch(int batch_number) override {
-    return Future<std::shared_ptr<RecordBatch>>::MakeFinished(
-        fragment_->record_batches_[batch_number]);
+  AsyncGenerator<std::shared_ptr<RecordBatch>> RunScanTask(int batch_number) override {
+    DCHECK_EQ(batch_number, 0);
+    return MakeVectorGenerator(std::move(batches_));
   }
 
-  int64_t EstimatedDataBytes(int batch_number) override {
-    return arrow::util::TotalBufferSize(*fragment_->record_batches_[batch_number]);
-  }
+  int NumScanTasks() override { return 1; }
 
-  int NumBatches() override {
-    return static_cast<int>(fragment_->record_batches_.size());
+  int NumBatchesInScanTask(int task_number) override {
+    DCHECK_LE(batches_.size(), std::numeric_limits<int32_t>::max());
+    return static_cast<int>(batches_.size());
   }
 
  private:
-  InMemoryFragment* fragment_;
+  std::vector<std::shared_ptr<RecordBatch>> batches_;
 };
 
 Future<std::shared_ptr<FragmentScanner>> InMemoryFragment::BeginScan(
     const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
-    const FragmentScanOptions* format_options, compute::ExecContext* exec_context) {
+    compute::ExecContext* exec_context) {
   return Future<std::shared_ptr<FragmentScanner>>::MakeFinished(
-      std::make_shared<InMemoryFragment::Scanner>(this));
+      std::make_shared<InMemoryFragment::Scanner>(record_batches_));
 }
 
-Dataset::Dataset(std::shared_ptr<Schema> schema, compute::Expression partition_expression)
+Dataset::Dataset(std::shared_ptr<Schema> schema, compute::Expression partition_expression,
+                 bool should_cache_metadata)
     : schema_(std::move(schema)),
-      partition_expression_(std::move(partition_expression)) {}
+      partition_expression_(std::move(partition_expression)),
+      should_cache_metadata_(should_cache_metadata) {}
 
 Result<std::shared_ptr<ScannerBuilder>> Dataset::NewScan() {
   return std::make_shared<ScannerBuilder>(this->shared_from_this());
@@ -246,7 +267,7 @@ struct VectorRecordBatchGenerator : InMemoryDataset::RecordBatchGenerator {
 
 InMemoryDataset::InMemoryDataset(std::shared_ptr<Schema> schema,
                                  RecordBatchVector batches)
-    : Dataset(std::move(schema)),
+    : Dataset(std::move(schema), /*should_cache_metadata=*/false),
       get_batches_(new VectorRecordBatchGenerator(std::move(batches))) {}
 
 struct TableRecordBatchGenerator : InMemoryDataset::RecordBatchGenerator {
@@ -263,7 +284,7 @@ struct TableRecordBatchGenerator : InMemoryDataset::RecordBatchGenerator {
 };
 
 InMemoryDataset::InMemoryDataset(std::shared_ptr<Table> table)
-    : Dataset(table->schema()),
+    : Dataset(table->schema(), /*should_cache_metadata=*/false),
       get_batches_(new TableRecordBatchGenerator(std::move(table))) {}
 
 Result<std::shared_ptr<Dataset>> InMemoryDataset::ReplaceSchema(

--- a/cpp/src/arrow/dataset/dataset.h
+++ b/cpp/src/arrow/dataset/dataset.h
@@ -216,7 +216,7 @@ class ARROW_DS_EXPORT Fragment : public std::enable_shared_from_this<Fragment> {
 
   /// \brief Start a scan operation
   virtual Future<std::shared_ptr<FragmentScanner>> BeginScan(
-      const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
+      const FragmentScanRequest& request, InspectedFragment* inspected_fragment,
       compute::ExecContext* exec_context);
 
   /// \brief Count the number of rows in this fragment matching the filter using metadata
@@ -292,7 +292,7 @@ class ARROW_DS_EXPORT InMemoryFragment : public Fragment {
       const FragmentScanOptions* format_options,
       compute::ExecContext* exec_context) override;
   Future<std::shared_ptr<FragmentScanner>> BeginScan(
-      const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
+      const FragmentScanRequest& request, InspectedFragment* inspected_fragment,
       compute::ExecContext* exec_context) override;
 
   std::string type_name() const override { return "in-memory"; }

--- a/cpp/src/arrow/dataset/dataset.h
+++ b/cpp/src/arrow/dataset/dataset.h
@@ -109,25 +109,58 @@ struct ARROW_DS_EXPORT FragmentScanRequest {
   const FragmentScanOptions* format_scan_options;
 };
 
-/// \brief An iterator-like object that can yield batches created from a fragment
+/// \brief An abstraction over (potentially parallel) reading of a fragment
 class ARROW_DS_EXPORT FragmentScanner {
  public:
-  /// This instance will only be destroyed after all ongoing scan futures
+  /// This instance will only be destroyed after all ongoing scan tasks
   /// have been completed.
   ///
   /// This means any callbacks created as part of the scan can safely
   /// capture `this`
   virtual ~FragmentScanner() = default;
-  /// \brief Scan a batch of data from the file
-  /// \param batch_number The index of the batch to read
-  virtual Future<std::shared_ptr<RecordBatch>> ScanBatch(int batch_number) = 0;
-  /// \brief Calculate an estimate of how many data bytes the given batch will represent
+  /// \brief Run a task to scan a batches of data from a file
   ///
-  /// "Data bytes" should be the total size of all the buffers once the data has been
-  /// decoded into the Arrow format.
-  virtual int64_t EstimatedDataBytes(int batch_number) = 0;
-  /// \brief The number of batches in the fragment to scan
-  virtual int NumBatches() = 0;
+  /// Each scan task will generate a sequence of batches.  If a file supports multiple
+  /// scan tasks then the scan tasks should be able to run in parallel.
+  ///
+  /// For example, the CSV scanner currently generates a single stream of batches from
+  /// the start of the file to the end.  It is not capable of reading batches in parallel
+  /// and so there is a single scan task.
+  ///
+  /// The parquet scanner can read from different row groups concurrently.  Each row group
+  /// generates a sequence of batches (row groups can be very large and we may not want
+  /// to read the row group into memory all at once).
+  ///
+  /// Multiple scan tasks will be launched in parallel.  In other words, RunScanTask
+  /// will be called async-reentrantly (it will be called again before the future it
+  /// returns finishes)
+  ///
+  /// However, RunScanTask will not be called sync-reentrantly (it will not be
+  /// called again while a call to this method is in progress) and it will be called
+  /// in order.
+  ///
+  /// For example, RunScanTask(5) will always be called after RunScanTask(4) yet the
+  /// batches from scan task 4 may arrive before the batches from scan task 5 and this is
+  /// ok.  If the user desires ordered execution then batches will be sequenced later.
+  ///
+  /// \param task_number The index of the scan task to execute
+  virtual AsyncGenerator<std::shared_ptr<RecordBatch>> RunScanTask(int task_number) = 0;
+
+  /// \brief The total number of scan tasks that will be run
+  virtual int NumScanTasks() = 0;
+
+  static constexpr int kUnknownNumberOfBatches = -1;
+  /// \brief The total number of batches that will be delivered by a scan task
+  ///
+  /// Ideally, this will be known in advance by inspecting the metadata.  A fragment
+  /// scanner may choose to emit empty batches in order to respect this value.
+  ///
+  /// If it is not possible to know this in advance, then a fragment may return
+  /// FragmentScanner::kUnknownNumberOfBatches.  Note that doing so will have a
+  /// significant negative effect on scan parallelism because a scan task will not start
+  /// until we have determined how many batches precede it.  This means that any scan
+  /// tasks following this one will have to wait until this scan task is fully exhausted.
+  virtual int NumBatchesInScanTask(int task_number) = 0;
 };
 
 /// \brief Information learned about a fragment through inspection
@@ -140,8 +173,11 @@ class ARROW_DS_EXPORT FragmentScanner {
 /// names and use those column names to determine which columns to load
 /// from the CSV file.
 struct ARROW_DS_EXPORT InspectedFragment {
+  virtual ~InspectedFragment() = default;
+
   explicit InspectedFragment(std::vector<std::string> column_names)
       : column_names(std::move(column_names)) {}
+
   std::vector<std::string> column_names;
 };
 
@@ -175,12 +211,13 @@ class ARROW_DS_EXPORT Fragment : public std::enable_shared_from_this<Fragment> {
   /// information will be needed to figure out an evolution strategy.  This information
   /// will then be passed to the call to BeginScan
   virtual Future<std::shared_ptr<InspectedFragment>> InspectFragment(
-      const FragmentScanOptions* format_options, compute::ExecContext* exec_context);
+      const FragmentScanOptions* format_options, compute::ExecContext* exec_context,
+      bool should_cache);
 
   /// \brief Start a scan operation
   virtual Future<std::shared_ptr<FragmentScanner>> BeginScan(
       const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
-      const FragmentScanOptions* format_options, compute::ExecContext* exec_context);
+      compute::ExecContext* exec_context);
 
   /// \brief Count the number of rows in this fragment matching the filter using metadata
   /// only. That is, this method may perform I/O, but will not load data.
@@ -206,11 +243,14 @@ class ARROW_DS_EXPORT Fragment : public std::enable_shared_from_this<Fragment> {
   explicit Fragment(compute::Expression partition_expression,
                     std::shared_ptr<Schema> physical_schema);
 
+  virtual Future<std::shared_ptr<InspectedFragment>> InspectFragmentImpl(
+      const FragmentScanOptions* format_options, compute::ExecContext* exec_context);
   virtual Result<std::shared_ptr<Schema>> ReadPhysicalSchemaImpl() = 0;
 
   util::Mutex physical_schema_mutex_;
   compute::Expression partition_expression_ = compute::literal(true);
   std::shared_ptr<Schema> physical_schema_;
+  std::shared_ptr<InspectedFragment> cached_inspected_fragment_;
 };
 
 /// \brief Per-scan options for fragment(s) in a dataset.
@@ -248,12 +288,11 @@ class ARROW_DS_EXPORT InMemoryFragment : public Fragment {
       compute::Expression predicate,
       const std::shared_ptr<ScanOptions>& options) override;
 
-  Future<std::shared_ptr<InspectedFragment>> InspectFragment(
+  Future<std::shared_ptr<InspectedFragment>> InspectFragmentImpl(
       const FragmentScanOptions* format_options,
       compute::ExecContext* exec_context) override;
   Future<std::shared_ptr<FragmentScanner>> BeginScan(
       const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
-      const FragmentScanOptions* format_options,
       compute::ExecContext* exec_context) override;
 
   std::string type_name() const override { return "in-memory"; }
@@ -348,6 +387,19 @@ MakeBasicDatasetEvolutionStrategy();
 /// A Dataset acts as a union of Fragments, e.g. files deeply nested in a
 /// directory. A Dataset has a schema to which Fragments must align during a
 /// scan operation. This is analogous to Avro's reader and writer schema.
+///
+/// It is assumed that a dataset will always generate fragments in the same
+/// order.  Data in a dataset thus has an "implicit order" which is first
+/// decided by the fragment index and then the row index in a fragment.  For
+/// example, row 1 in fragment 10 comes after the last row in fragment 9.
+///
+/// A dataset will cache metadata by default.  This will enable future scans
+/// to be faster since they can skip some of the initial read steps.  However,
+/// if the dataset has many files, or if the file metadata itself is large, this
+/// cached metadata could occupy a large amount of RAM.
+///
+/// Metadata should not be cached if the contents of the files are expected
+/// to change between scans.
 class ARROW_DS_EXPORT Dataset : public std::enable_shared_from_this<Dataset> {
  public:
   /// \brief Begin to build a new Scan operation against this Dataset
@@ -385,9 +437,15 @@ class ARROW_DS_EXPORT Dataset : public std::enable_shared_from_this<Dataset> {
   virtual ~Dataset() = default;
 
  protected:
-  explicit Dataset(std::shared_ptr<Schema> schema) : schema_(std::move(schema)) {}
+  /// \brief Create a new dataset
+  /// \param schema the dataset schema.  This is the unified schema across all fragments
+  /// \param should_cache_metadata if true then this dataset instance should try and cache
+  ///            metadata information during a scan.
+  explicit Dataset(std::shared_ptr<Schema> schema, bool should_cache_metadata = true)
+      : schema_(std::move(schema)), should_cache_metadata_(should_cache_metadata) {}
 
-  Dataset(std::shared_ptr<Schema> schema, compute::Expression partition_expression);
+  Dataset(std::shared_ptr<Schema> schema, compute::Expression partition_expression,
+          bool should_cache_metadata = true);
 
   virtual Result<FragmentIterator> GetFragmentsImpl(compute::Expression predicate) = 0;
   /// \brief Default non-virtual implementation method for the base
@@ -405,6 +463,8 @@ class ARROW_DS_EXPORT Dataset : public std::enable_shared_from_this<Dataset> {
 
   std::shared_ptr<Schema> schema_;
   compute::Expression partition_expression_ = compute::literal(true);
+  bool should_cache_metadata_;
+
   std::unique_ptr<DatasetEvolutionStrategy> evolution_strategy_ =
       MakeBasicDatasetEvolutionStrategy();
 };
@@ -427,7 +487,8 @@ class ARROW_DS_EXPORT InMemoryDataset : public Dataset {
   /// Construct a dataset from a schema and a factory of record batch iterators.
   InMemoryDataset(std::shared_ptr<Schema> schema,
                   std::shared_ptr<RecordBatchGenerator> get_batches)
-      : Dataset(std::move(schema)), get_batches_(std::move(get_batches)) {}
+      : Dataset(std::move(schema), /*should_cache_metadata=*/false),
+        get_batches_(std::move(get_batches)) {}
 
   /// Convenience constructor taking a fixed list of batches
   InMemoryDataset(std::shared_ptr<Schema> schema, RecordBatchVector batches);

--- a/cpp/src/arrow/dataset/dataset_internal.h
+++ b/cpp/src/arrow/dataset/dataset_internal.h
@@ -89,6 +89,21 @@ arrow::Result<std::shared_ptr<T>> GetFragmentScanOptions(
   return ::arrow::internal::checked_pointer_cast<T>(source);
 }
 
+template <typename T>
+Result<const T*> GetFragmentScanOptions(const FragmentScanOptions* scan_or_format_opts,
+                                        const std::string& type_name) {
+  static T fallback_opts = {};
+  if (scan_or_format_opts == nullptr) {
+    return &fallback_opts;
+  }
+  auto* casted_opts = dynamic_cast<const T*>(scan_or_format_opts);
+  if (!casted_opts) {
+    return Status::Invalid("User provided scan options of type ",
+                           scan_or_format_opts->type_name(), " but expected ", type_name);
+  }
+  return casted_opts;
+}
+
 class FragmentDataset : public Dataset {
  public:
   FragmentDataset(std::shared_ptr<Schema> schema, FragmentVector fragments)

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -134,15 +134,15 @@ Future<std::optional<int64_t>> FileFormat::CountRows(
 }
 
 Future<std::shared_ptr<InspectedFragment>> FileFormat::InspectFragment(
-    const FileSource& source, const FragmentScanOptions* format_options,
-    compute::ExecContext* exec_context) const {
+    const FileFragment& fragment, const FileSource& source,
+    const FragmentScanOptions* format_options, compute::ExecContext* exec_context) const {
   return Status::NotImplemented("This format does not yet support the scan2 node");
 }
 
 Future<std::shared_ptr<FragmentScanner>> FileFormat::BeginScan(
     const FileSource& source, const FragmentScanRequest& request,
-    const InspectedFragment& inspected_fragment,
-    const FragmentScanOptions* format_options, compute::ExecContext* exec_context) const {
+    InspectedFragment* inspected_fragment, const FragmentScanOptions* format_options,
+    compute::ExecContext* exec_context) const {
   return Status::NotImplemented("This format does not yet support the scan2 node");
 }
 
@@ -181,11 +181,11 @@ Future<std::shared_ptr<InspectedFragment>> FileFragment::InspectFragmentImpl(
   if (format_options == nullptr) {
     realized_format_options = format_->default_fragment_scan_options.get();
   }
-  return format_->InspectFragment(source_, realized_format_options, exec_context);
+  return format_->InspectFragment(*this, source_, realized_format_options, exec_context);
 }
 
 Future<std::shared_ptr<FragmentScanner>> FileFragment::BeginScan(
-    const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
+    const FragmentScanRequest& request, InspectedFragment* inspected_fragment,
     compute::ExecContext* exec_context) {
   const FragmentScanOptions* realized_format_options = request.format_scan_options;
   if (realized_format_options == nullptr) {

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -140,7 +140,8 @@ Future<std::shared_ptr<InspectedFragment>> FileFormat::InspectFragment(
 }
 
 Future<std::shared_ptr<FragmentScanner>> FileFormat::BeginScan(
-    const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
+    const FileSource& source, const FragmentScanRequest& request,
+    const InspectedFragment& inspected_fragment,
     const FragmentScanOptions* format_options, compute::ExecContext* exec_context) const {
   return Status::NotImplemented("This format does not yet support the scan2 node");
 }
@@ -174,7 +175,7 @@ Result<RecordBatchGenerator> FileFragment::ScanBatchesAsync(
   return format_->ScanBatchesAsync(options, self);
 }
 
-Future<std::shared_ptr<InspectedFragment>> FileFragment::InspectFragment(
+Future<std::shared_ptr<InspectedFragment>> FileFragment::InspectFragmentImpl(
     const FragmentScanOptions* format_options, compute::ExecContext* exec_context) {
   const FragmentScanOptions* realized_format_options = format_options;
   if (format_options == nullptr) {
@@ -185,12 +186,12 @@ Future<std::shared_ptr<InspectedFragment>> FileFragment::InspectFragment(
 
 Future<std::shared_ptr<FragmentScanner>> FileFragment::BeginScan(
     const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
-    const FragmentScanOptions* format_options, compute::ExecContext* exec_context) {
-  const FragmentScanOptions* realized_format_options = format_options;
-  if (format_options == nullptr) {
+    compute::ExecContext* exec_context) {
+  const FragmentScanOptions* realized_format_options = request.format_scan_options;
+  if (realized_format_options == nullptr) {
     realized_format_options = format_->default_fragment_scan_options.get();
   }
-  return format_->BeginScan(request, inspected_fragment, realized_format_options,
+  return format_->BeginScan(source_, request, inspected_fragment, realized_format_options,
                             exec_context);
 }
 

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -165,7 +165,8 @@ class ARROW_DS_EXPORT FileFormat : public std::enable_shared_from_this<FileForma
 
   /// \brief Learn what we need about the file before we start scanning it
   virtual Future<std::shared_ptr<InspectedFragment>> InspectFragment(
-      const FileSource& source, const FragmentScanOptions* format_options,
+      const FileFragment& fragment, const FileSource& source,
+      const FragmentScanOptions* format_options,
       compute::ExecContext* exec_context) const;
 
   virtual Result<RecordBatchGenerator> ScanBatchesAsync(
@@ -182,8 +183,7 @@ class ARROW_DS_EXPORT FileFormat : public std::enable_shared_from_this<FileForma
   // `format_options` parameter should be preferred over `request.format_scan_options`
   virtual Future<std::shared_ptr<FragmentScanner>> BeginScan(
       const FileSource& source, const FragmentScanRequest& request,
-      const InspectedFragment& inspected_fragment,
-      const FragmentScanOptions* format_options,
+      InspectedFragment* inspected_fragment, const FragmentScanOptions* format_options,
       compute::ExecContext* exec_context) const;
 
   /// \brief Open a fragment
@@ -226,7 +226,7 @@ class ARROW_DS_EXPORT FileFragment : public Fragment,
       compute::Expression predicate,
       const std::shared_ptr<ScanOptions>& options) override;
   Future<std::shared_ptr<FragmentScanner>> BeginScan(
-      const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
+      const FragmentScanRequest& request, InspectedFragment* inspected_fragment,
       compute::ExecContext* exec_context) override;
   Future<std::shared_ptr<InspectedFragment>> InspectFragmentImpl(
       const FragmentScanOptions* format_options,

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -176,8 +176,13 @@ class ARROW_DS_EXPORT FileFormat : public std::enable_shared_from_this<FileForma
       const std::shared_ptr<FileFragment>& file, compute::Expression predicate,
       const std::shared_ptr<ScanOptions>& options);
 
+  // `format_options` may seem redundant (there is a `format_options` in `request`)
+  // however, it will overwrite the scan request's format options with the file format's
+  // default options if the scan request does not specify `format_options`.  So the
+  // `format_options` parameter should be preferred over `request.format_scan_options`
   virtual Future<std::shared_ptr<FragmentScanner>> BeginScan(
-      const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
+      const FileSource& source, const FragmentScanRequest& request,
+      const InspectedFragment& inspected_fragment,
       const FragmentScanOptions* format_options,
       compute::ExecContext* exec_context) const;
 
@@ -222,9 +227,8 @@ class ARROW_DS_EXPORT FileFragment : public Fragment,
       const std::shared_ptr<ScanOptions>& options) override;
   Future<std::shared_ptr<FragmentScanner>> BeginScan(
       const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
-      const FragmentScanOptions* format_options,
       compute::ExecContext* exec_context) override;
-  Future<std::shared_ptr<InspectedFragment>> InspectFragment(
+  Future<std::shared_ptr<InspectedFragment>> InspectFragmentImpl(
       const FragmentScanOptions* format_options,
       compute::ExecContext* exec_context) override;
 

--- a/cpp/src/arrow/dataset/file_csv.cc
+++ b/cpp/src/arrow/dataset/file_csv.cc
@@ -401,11 +401,11 @@ Future<std::optional<int64_t>> CsvFileFormat::CountRows(
 
 Future<std::shared_ptr<FragmentScanner>> CsvFileFormat::BeginScan(
     const FileSource& file_source, const FragmentScanRequest& request,
-    const InspectedFragment& inspected_fragment,
-    const FragmentScanOptions* format_options, compute::ExecContext* exec_context) const {
+    InspectedFragment* inspected_fragment, const FragmentScanOptions* format_options,
+    compute::ExecContext* exec_context) const {
   auto csv_options = static_cast<const CsvFragmentScanOptions*>(format_options);
-  auto csv_fragment = static_cast<const CsvInspectedFragment&>(inspected_fragment);
-  return CsvFileScanner::Make(*csv_options, request, csv_fragment,
+  auto* csv_fragment = static_cast<CsvInspectedFragment*>(inspected_fragment);
+  return CsvFileScanner::Make(*csv_options, request, *csv_fragment,
                               exec_context->executor());
 }
 
@@ -432,8 +432,8 @@ Result<std::shared_ptr<InspectedFragment>> DoInspectFragment(
 }
 
 Future<std::shared_ptr<InspectedFragment>> CsvFileFormat::InspectFragment(
-    const FileSource& source, const FragmentScanOptions* format_options,
-    compute::ExecContext* exec_context) const {
+    const FileFragment& fragment, const FileSource& source,
+    const FragmentScanOptions* format_options, compute::ExecContext* exec_context) const {
   ARROW_ASSIGN_OR_RAISE(
       const auto* csv_options,
       GetFragmentScanOptions<CsvFragmentScanOptions>(format_options, kCsvTypeName));

--- a/cpp/src/arrow/dataset/file_csv.cc
+++ b/cpp/src/arrow/dataset/file_csv.cc
@@ -67,25 +67,19 @@ struct CsvInspectedFragment : public InspectedFragment {
 
 class CsvFileScanner : public FragmentScanner {
  public:
-  CsvFileScanner(std::shared_ptr<csv::StreamingReader> reader, int num_batches,
-                 int64_t best_guess_bytes_per_batch)
-      : reader_(std::move(reader)),
-        num_batches_(num_batches),
-        best_guess_bytes_per_batch_(best_guess_bytes_per_batch) {}
+  explicit CsvFileScanner(std::shared_ptr<csv::StreamingReader> reader, int num_batches)
+      : reader_(std::move(reader)), num_batches_(num_batches) {}
 
-  Future<std::shared_ptr<RecordBatch>> ScanBatch(int batch_number) override {
-    // This should be called in increasing order but let's verify that in case it changes.
-    // It would be easy enough to handle out of order but no need for that complexity at
-    // the moment.
-    DCHECK_EQ(scanned_so_far_++, batch_number);
-    return reader_->ReadNextAsync();
+  AsyncGenerator<std::shared_ptr<RecordBatch>> RunScanTask(int task_number) override {
+    return [this] { return reader_->ReadNextAsync(); };
   }
 
-  int64_t EstimatedDataBytes(int batch_number) override {
-    return best_guess_bytes_per_batch_;
-  }
+  int NumScanTasks() override { return 1; }
 
-  int NumBatches() override { return num_batches_; }
+  int NumBatchesInScanTask(int32_t task_number) override {
+    DCHECK_EQ(task_number, 0);
+    return num_batches_;
+  }
 
   static Result<csv::ConvertOptions> GetConvertOptions(
       const CsvFragmentScanOptions& csv_options, const FragmentScanRequest& scan_request,
@@ -114,11 +108,10 @@ class CsvFileScanner : public FragmentScanner {
       const CsvInspectedFragment& inspected_fragment, Executor* cpu_executor) {
     auto read_options = csv_options.read_options;
 
+    // Right now we disallow values larger than a block.  If we wanted to allow them
+    // however we could just emit an empty batch.  So this should be pretty safe.
     int num_batches = static_cast<int>(bit_util::CeilDiv(
         inspected_fragment.num_bytes, static_cast<int64_t>(read_options.block_size)));
-    // Could be better, but a reasonable starting point.  CSV presumably takes up more
-    // space than an in-memory format so this should be conservative.
-    int64_t best_guess_bytes_per_batch = read_options.block_size;
     ARROW_ASSIGN_OR_RAISE(
         csv::ConvertOptions convert_options,
         GetConvertOptions(csv_options, scan_request, inspected_fragment));
@@ -126,20 +119,15 @@ class CsvFileScanner : public FragmentScanner {
     return csv::StreamingReader::MakeAsync(
                io::default_io_context(), inspected_fragment.input_stream, cpu_executor,
                read_options, csv_options.parse_options, convert_options)
-        .Then([num_batches, best_guess_bytes_per_batch](
-                  const std::shared_ptr<csv::StreamingReader>& reader)
+        .Then([num_batches](const std::shared_ptr<csv::StreamingReader>& reader)
                   -> std::shared_ptr<FragmentScanner> {
-          return std::make_shared<CsvFileScanner>(reader, num_batches,
-                                                  best_guess_bytes_per_batch);
+          return std::make_shared<CsvFileScanner>(reader, num_batches);
         });
   }
 
  private:
   std::shared_ptr<csv::StreamingReader> reader_;
   int num_batches_;
-  int64_t best_guess_bytes_per_batch_;
-
-  int scanned_so_far_ = 0;
 };
 
 using RecordBatchGenerator = std::function<Future<std::shared_ptr<RecordBatch>>()>;
@@ -412,7 +400,8 @@ Future<std::optional<int64_t>> CsvFileFormat::CountRows(
 }
 
 Future<std::shared_ptr<FragmentScanner>> CsvFileFormat::BeginScan(
-    const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
+    const FileSource& file_source, const FragmentScanRequest& request,
+    const InspectedFragment& inspected_fragment,
     const FragmentScanOptions* format_options, compute::ExecContext* exec_context) const {
   auto csv_options = static_cast<const CsvFragmentScanOptions*>(format_options);
   auto csv_fragment = static_cast<const CsvInspectedFragment&>(inspected_fragment);
@@ -445,7 +434,9 @@ Result<std::shared_ptr<InspectedFragment>> DoInspectFragment(
 Future<std::shared_ptr<InspectedFragment>> CsvFileFormat::InspectFragment(
     const FileSource& source, const FragmentScanOptions* format_options,
     compute::ExecContext* exec_context) const {
-  auto csv_options = static_cast<const CsvFragmentScanOptions*>(format_options);
+  ARROW_ASSIGN_OR_RAISE(
+      const auto* csv_options,
+      GetFragmentScanOptions<CsvFragmentScanOptions>(format_options, kCsvTypeName));
   Executor* io_executor;
   if (source.filesystem()) {
     io_executor = source.filesystem()->io_context().executor();

--- a/cpp/src/arrow/dataset/file_csv.h
+++ b/cpp/src/arrow/dataset/file_csv.h
@@ -58,8 +58,7 @@ class ARROW_DS_EXPORT CsvFileFormat : public FileFormat {
 
   Future<std::shared_ptr<FragmentScanner>> BeginScan(
       const FileSource& file_source, const FragmentScanRequest& request,
-      const InspectedFragment& inspected_fragment,
-      const FragmentScanOptions* format_options,
+      InspectedFragment* inspected_fragment, const FragmentScanOptions* format_options,
       compute::ExecContext* exec_context) const override;
 
   Result<RecordBatchGenerator> ScanBatchesAsync(
@@ -67,7 +66,8 @@ class ARROW_DS_EXPORT CsvFileFormat : public FileFormat {
       const std::shared_ptr<FileFragment>& file) const override;
 
   Future<std::shared_ptr<InspectedFragment>> InspectFragment(
-      const FileSource& source, const FragmentScanOptions* format_options,
+      const FileFragment& fragment, const FileSource& source,
+      const FragmentScanOptions* format_options,
       compute::ExecContext* exec_context) const override;
 
   Future<std::optional<int64_t>> CountRows(

--- a/cpp/src/arrow/dataset/file_csv.h
+++ b/cpp/src/arrow/dataset/file_csv.h
@@ -57,7 +57,8 @@ class ARROW_DS_EXPORT CsvFileFormat : public FileFormat {
   Result<std::shared_ptr<Schema>> Inspect(const FileSource& source) const override;
 
   Future<std::shared_ptr<FragmentScanner>> BeginScan(
-      const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
+      const FileSource& file_source, const FragmentScanRequest& request,
+      const InspectedFragment& inspected_fragment,
       const FragmentScanOptions* format_options,
       compute::ExecContext* exec_context) const override;
 

--- a/cpp/src/arrow/dataset/file_csv_test.cc
+++ b/cpp/src/arrow/dataset/file_csv_test.cc
@@ -531,18 +531,13 @@ class TestCsvFileFormatScanNode : public FileFormatScanNodeMixin<CsvFormatHelper
   CsvFragmentScanOptions scan_options_;
 };
 
+TEST_P(TestCsvFileFormatScanNode, Inspect) { TestInspect(); }
 TEST_P(TestCsvFileFormatScanNode, Scan) { TestScan(); }
-TEST_P(TestCsvFileFormatScanNode, ScanProjected) { TestScanProjected(); }
-TEST_P(TestCsvFileFormatScanNode, ScanMissingFilterField) {
-  TestScanMissingFilterField();
-}
+TEST_P(TestCsvFileFormatScanNode, ScanSomeColumns) { TestScanSomeColumns(); }
 // NOTE(ARROW-14658): TestScanProjectedNested is ignored since CSV
 // doesn't have any nested types for us to work with
-TEST_P(TestCsvFileFormatScanNode, ScanProjectedMissingColumns) {
-  TestScanProjectedMissingCols();
-}
-TEST_P(TestCsvFileFormatScanNode, ScanWithDuplicateColumn) {
-  TestScanWithDuplicateColumn();
+TEST_P(TestCsvFileFormatScanNode, ScanWithInvalidOptions) {
+  TestInvalidFormatScanOptions();
 }
 // NOTE: TestScanWithPushdownNulls is ignored since CSV doesn't handle pushdown filtering
 INSTANTIATE_TEST_SUITE_P(TestScanNode, TestCsvFileFormatScanNode,

--- a/cpp/src/arrow/dataset/file_json.cc
+++ b/cpp/src/arrow/dataset/file_json.cc
@@ -401,8 +401,8 @@ Future<std::optional<int64_t>> JsonFileFormat::CountRows(
 }
 
 Future<std::shared_ptr<InspectedFragment>> JsonFileFormat::InspectFragment(
-    const FileSource& source, const FragmentScanOptions* format_options,
-    compute::ExecContext* exec_context) const {
+    const FileFragment& fragment, const FileSource& source,
+    const FragmentScanOptions* format_options, compute::ExecContext* exec_context) const {
   auto json_options = static_cast<const JsonFragmentScanOptions*>(format_options);
   auto* executor = source.filesystem() ? source.filesystem()->io_context().executor()
                                        : exec_context->executor();
@@ -414,11 +414,11 @@ Future<std::shared_ptr<InspectedFragment>> JsonFileFormat::InspectFragment(
 
 Future<std::shared_ptr<FragmentScanner>> JsonFileFormat::BeginScan(
     const FileSource& file_source, const FragmentScanRequest& scan_request,
-    const InspectedFragment& inspected, const FragmentScanOptions* format_options,
+    InspectedFragment* inspected, const FragmentScanOptions* format_options,
     compute::ExecContext* exec_context) const {
   return JsonFragmentScanner::Make(
       scan_request, static_cast<const JsonFragmentScanOptions&>(*format_options),
-      static_cast<const JsonInspectedFragment&>(inspected), exec_context->executor());
+      static_cast<const JsonInspectedFragment&>(*inspected), exec_context->executor());
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/file_json.cc
+++ b/cpp/src/arrow/dataset/file_json.cc
@@ -66,17 +66,20 @@ struct JsonInspectedFragment : public InspectedFragment {
 
 class JsonFragmentScanner : public FragmentScanner {
  public:
-  JsonFragmentScanner(ReaderPtr reader, int num_batches, int64_t block_size)
-      : reader_(std::move(reader)), block_size_(block_size), num_batches_(num_batches) {}
+  JsonFragmentScanner(ReaderPtr reader, int num_batches)
+      : reader_(std::move(reader)), num_batches_(num_batches) {}
 
-  int NumBatches() override { return num_batches_; }
+  int NumScanTasks() override { return 1; }
 
-  Future<std::shared_ptr<RecordBatch>> ScanBatch(int index) override {
-    DCHECK_EQ(num_scanned_++, index);
-    return reader_->ReadNextAsync();
+  int NumBatchesInScanTask(int task_number) override {
+    DCHECK_EQ(task_number, 0);
+    return num_batches_;
   }
 
-  int64_t EstimatedDataBytes(int) override { return block_size_; }
+  AsyncGenerator<std::shared_ptr<RecordBatch>> RunScanTask(int task_number) override {
+    DCHECK_EQ(task_number, 0);
+    return [this] { return reader_->ReadNextAsync(); };
+  }
 
   static Result<std::shared_ptr<Schema>> GetSchema(
       const FragmentScanRequest& scan_request, const JsonInspectedFragment& inspected) {
@@ -114,17 +117,15 @@ class JsonFragmentScanner : public FragmentScanner {
     auto future = json::StreamingReader::MakeAsync(
         inspected.stream, format_options.read_options, parse_options,
         io::default_io_context(), cpu_executor);
-    return future.Then([num_batches, block_size](const ReaderPtr& reader)
+    return future.Then([num_batches](const ReaderPtr& reader)
                            -> Result<std::shared_ptr<FragmentScanner>> {
-      return std::make_shared<JsonFragmentScanner>(reader, num_batches, block_size);
+      return std::make_shared<JsonFragmentScanner>(reader, num_batches);
     });
   }
 
  private:
   ReaderPtr reader_;
-  int64_t block_size_;
   int num_batches_;
-  int num_scanned_ = 0;
 };
 
 // Return the same parse options, but disable any options that could interfere with
@@ -412,8 +413,9 @@ Future<std::shared_ptr<InspectedFragment>> JsonFileFormat::InspectFragment(
 }
 
 Future<std::shared_ptr<FragmentScanner>> JsonFileFormat::BeginScan(
-    const FragmentScanRequest& scan_request, const InspectedFragment& inspected,
-    const FragmentScanOptions* format_options, compute::ExecContext* exec_context) const {
+    const FileSource& file_source, const FragmentScanRequest& scan_request,
+    const InspectedFragment& inspected, const FragmentScanOptions* format_options,
+    compute::ExecContext* exec_context) const {
   return JsonFragmentScanner::Make(
       scan_request, static_cast<const JsonFragmentScanOptions&>(*format_options),
       static_cast<const JsonInspectedFragment&>(inspected), exec_context->executor());

--- a/cpp/src/arrow/dataset/file_json.h
+++ b/cpp/src/arrow/dataset/file_json.h
@@ -54,12 +54,13 @@ class ARROW_DS_EXPORT JsonFileFormat : public FileFormat {
   Result<std::shared_ptr<Schema>> Inspect(const FileSource& source) const override;
 
   Future<std::shared_ptr<InspectedFragment>> InspectFragment(
-      const FileSource& source, const FragmentScanOptions* format_options,
+      const FileFragment& fragment, const FileSource& source,
+      const FragmentScanOptions* format_options,
       compute::ExecContext* exec_context) const override;
 
   Future<std::shared_ptr<FragmentScanner>> BeginScan(
       const FileSource& file_source, const FragmentScanRequest& scan_request,
-      const InspectedFragment& inspected, const FragmentScanOptions* format_options,
+      InspectedFragment* inspected, const FragmentScanOptions* format_options,
       compute::ExecContext* exec_context) const override;
 
   Result<RecordBatchGenerator> ScanBatchesAsync(

--- a/cpp/src/arrow/dataset/file_json.h
+++ b/cpp/src/arrow/dataset/file_json.h
@@ -58,8 +58,8 @@ class ARROW_DS_EXPORT JsonFileFormat : public FileFormat {
       compute::ExecContext* exec_context) const override;
 
   Future<std::shared_ptr<FragmentScanner>> BeginScan(
-      const FragmentScanRequest& scan_request, const InspectedFragment& inspected,
-      const FragmentScanOptions* format_options,
+      const FileSource& file_source, const FragmentScanRequest& scan_request,
+      const InspectedFragment& inspected, const FragmentScanOptions* format_options,
       compute::ExecContext* exec_context) const override;
 
   Result<RecordBatchGenerator> ScanBatchesAsync(

--- a/cpp/src/arrow/dataset/file_json_test.cc
+++ b/cpp/src/arrow/dataset/file_json_test.cc
@@ -327,9 +327,7 @@ INSTANTIATE_TEST_SUITE_P(TestJsonScan, TestJsonScan,
 
 // Common tests for new scanner
 TEST_P(TestJsonScanNode, Scan) { TestScan(); }
-TEST_P(TestJsonScanNode, ScanMissingFilterField) { TestScanMissingFilterField(); }
-TEST_P(TestJsonScanNode, ScanProjected) { TestScanProjected(); }
-TEST_P(TestJsonScanNode, ScanProjectedMissingColumns) { TestScanProjectedMissingCols(); }
+TEST_P(TestJsonScanNode, ScanSomeColumns) { TestScanSomeColumns(); }
 // JSON-specific tests for new scanner
 TEST_P(TestJsonScanNode, ScanWithBOM) { TestScanWithBOM(); }
 TEST_P(TestJsonScanNode, ScanWithCustomParseOptions) { TestScanWithCustomParseOptions(); }

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -50,14 +50,12 @@
 #include "arrow/util/logging.h"
 #include "arrow/util/range.h"
 #include "arrow/util/tracing_internal.h"
-#include "metadata.h"
 #include "parquet/arrow/reader.h"
 #include "parquet/arrow/schema.h"
 #include "parquet/arrow/writer.h"
 #include "parquet/file_reader.h"
 #include "parquet/properties.h"
 #include "parquet/statistics.h"
-#include "schema.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -18,10 +18,12 @@
 #include "arrow/dataset/file_parquet.h"
 
 #include <algorithm>
+#include <cmath>
+#include <functional>
 #include <limits>
 #include <memory>
 #include <mutex>
-#include <stack>
+#include <numeric>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -38,9 +40,10 @@
 #include "arrow/io/caching.h"
 #include "arrow/io/interfaces.h"
 #include "arrow/io/type_fwd.h"
-#include "arrow/memory_pool.h"
+#include "arrow/record_batch.h"
+#include "arrow/scalar.h"
 #include "arrow/table.h"
-#include "arrow/type_fwd.h"
+#include "arrow/type.h"
 #include "arrow/util/async_generator.h"
 #include "arrow/util/async_generator_fwd.h"
 #include "arrow/util/bit_util.h"
@@ -48,13 +51,17 @@
 #include "arrow/util/future.h"
 #include "arrow/util/iterator.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/mutex.h"
 #include "arrow/util/range.h"
+#include "arrow/util/thread_pool.h"
 #include "arrow/util/tracing_internal.h"
 #include "parquet/arrow/reader.h"
 #include "parquet/arrow/schema.h"
 #include "parquet/arrow/writer.h"
 #include "parquet/file_reader.h"
+#include "parquet/metadata.h"
 #include "parquet/properties.h"
+#include "parquet/schema.h"
 #include "parquet/statistics.h"
 
 namespace arrow {

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -476,7 +476,48 @@ class ParquetFragmentScanner : public FragmentScanner {
     return Status::OK();
   }
 
-  Future<> Initialize(std::shared_ptr<io::RandomAccessFile> file) {
+  // We need to convert from a list of paths ([2, 1, 0], [0, 3]) to a list of leaf indices
+  //
+  // First we sort the paths in DFS order(well, get the sorted path indices) so the above
+  // example would change to something like [[0, 3], [2, 1, 0]]
+  //
+  // Then we walk through the schema in DFS fashion, counting leaf nodes, until we
+  // encounter the next item in the sorted list
+  //
+  // 0 - Not leaf
+  // 0 0 - leaf_counter=0
+  // 0 1 - leaf_counter=1
+  // 0 2 - Not leaf
+  // 0 2 0 - leaf_counter=2
+  // 0 2 1 - leaf_counter=3
+  // 0 3 - leaf_counter=4*
+  //
+  // Here we mark down 4 for the [0, 3] element.  Keep in mind that the eventual return
+  // value will have the 4 in position 1 of the returned list (to maintain order)
+  //
+  // If we encounter a non-leaf node then we need to load all leaves under that node
+  void CalculateDesiredColumns(const FragmentScanRequest& request) {
+    std::vector<std::size_t> sorted_path_indices(
+        request.fragment_selection->columns().size());
+    std::iota(sorted_path_indices.begin(), sorted_path_indices.end(), 0);
+    std::sort(sorted_path_indices.begin(), sorted_path_indices.end(),
+              [&](const auto& lhs, const auto& rhs) {
+                return request.fragment_selection->columns()[lhs].path <
+                       request.fragment_selection->columns()[rhs].path;
+              });
+    for (const auto& column : request.fragment_selection->columns()) {
+      sorted_paths.push_back(column.path);
+    }
+    std::vector<int> desired_columns_.reserve(
+        request.fragment_selection->columns().size());
+
+    for (const auto& column : request.fragment_selection->columns()) {
+      desired_columns_.push_back(PathToLeafIndex(column.path));
+    }
+  }
+
+  Future<> Initialize(std::shared_ptr<io::RandomAccessFile> file,
+                      const FragmentScanRequest& request) {
     parquet::ReaderProperties properties = MakeParquetReaderProperties();
     // TODO(ARROW-12259): workaround since we have Future<(move-only type)>
     auto reader_fut = parquet::ParquetFileReader::OpenAsync(
@@ -515,7 +556,7 @@ class ParquetFragmentScanner : public FragmentScanner {
         std::make_shared<ParquetFragmentScanner>(std::move(path),
                                                  inspection.file_metadata, scan_options,
                                                  format_reader_options, exec_context);
-    return parquet_fragment_scanner->Initialize(std::move(file))
+    return parquet_fragment_scanner->Initialize(std::move(file), request)
         .Then([fragment_scanner = std::static_pointer_cast<FragmentScanner>(
                    parquet_fragment_scanner)]() { return fragment_scanner; });
   }
@@ -529,6 +570,7 @@ class ParquetFragmentScanner : public FragmentScanner {
   compute::ExecContext* exec_context_;
 
   // These are set during Initialize
+  std::vector<int> desired_columns_;
   std::unique_ptr<parquet::arrow::FileReader> file_reader_;
   int32_t batch_size_;
 };

--- a/cpp/src/arrow/dataset/file_parquet.h
+++ b/cpp/src/arrow/dataset/file_parquet.h
@@ -96,13 +96,13 @@ class ARROW_DS_EXPORT ParquetFileFormat : public FileFormat {
   Result<std::shared_ptr<Schema>> Inspect(const FileSource& source) const override;
 
   Future<std::shared_ptr<InspectedFragment>> InspectFragment(
-      const FileSource& source, const FragmentScanOptions* format_options,
+      const FileFragment& fragment, const FileSource& source,
+      const FragmentScanOptions* format_options,
       compute::ExecContext* exec_context) const override;
 
   Future<std::shared_ptr<FragmentScanner>> BeginScan(
       const FileSource& source, const FragmentScanRequest& request,
-      const InspectedFragment& inspected_fragment,
-      const FragmentScanOptions* format_options,
+      InspectedFragment* inspected_fragment, const FragmentScanOptions* format_options,
       compute::ExecContext* exec_context) const override;
 
   Result<RecordBatchGenerator> ScanBatchesAsync(
@@ -182,7 +182,8 @@ class ARROW_DS_EXPORT ParquetFileFragment : public FileFragment {
   Result<std::shared_ptr<Fragment>> Subset(std::vector<int> row_group_ids);
 
   static std::optional<compute::Expression> EvaluateStatisticsAsExpression(
-      const Field& field, const parquet::Statistics& statistics);
+      const compute::Expression& field_expr, const std::shared_ptr<DataType>& field_type,
+      const parquet::Statistics& statistics);
 
  private:
   ParquetFileFragment(FileSource source, std::shared_ptr<FileFormat> format,

--- a/cpp/src/arrow/dataset/file_parquet.h
+++ b/cpp/src/arrow/dataset/file_parquet.h
@@ -26,20 +26,20 @@
 #include <utility>
 #include <vector>
 
+#include "arrow/compute/expression.h"
+#include "arrow/dataset/dataset.h"
 #include "arrow/dataset/discovery.h"
 #include "arrow/dataset/file_base.h"
+#include "arrow/dataset/partition.h"
 #include "arrow/dataset/type_fwd.h"
 #include "arrow/dataset/visibility.h"
-#include "arrow/io/caching.h"
+#include "arrow/filesystem/type_fwd.h"
+#include "arrow/type_fwd.h"
+#include "arrow/util/future.h"
 
 namespace parquet {
-class ParquetFileReader;
 class Statistics;
-class ColumnChunkMetaData;
-class RowGroupMetaData;
 class FileMetaData;
-class FileDecryptionProperties;
-class FileEncryptionProperties;
 
 class ReaderProperties;
 class ArrowReaderProperties;

--- a/cpp/src/arrow/dataset/file_parquet.h
+++ b/cpp/src/arrow/dataset/file_parquet.h
@@ -247,7 +247,7 @@ class ARROW_DS_EXPORT ParquetFragmentScanOptions : public FragmentScanOptions {
   ///
   /// kCustom - Pre-buffering, stream buffering, and batch size settings will be
   ///           configured according to reader_properties and arrow_reader_properties.
-  ParquetScanStrategy scan_strategy = ParquetScanStrategy::kMaxSpeed;
+  ParquetScanStrategy scan_strategy = ParquetScanStrategy::kLeastMemory;
 
   /// Reader properties.
   ///

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -721,13 +721,14 @@ INSTANTIATE_TEST_SUITE_P(TestScan, TestParquetFileFormatScan,
 
 TEST(TestParquetStatistics, NullMax) {
   auto field = ::arrow::field("x", float32());
+  auto field_ref = compute::field_ref("x");
   ASSERT_OK_AND_ASSIGN(std::string dir_string,
                        arrow::internal::GetEnvVar("PARQUET_TEST_DATA"));
   auto reader =
       parquet::ParquetFileReader::OpenFile(dir_string + "/nan_in_stats.parquet");
   auto statistics = reader->RowGroup(0)->metadata()->ColumnChunk(0)->statistics();
-  auto stat_expression =
-      ParquetFileFragment::EvaluateStatisticsAsExpression(*field, *statistics);
+  auto stat_expression = ParquetFileFragment::EvaluateStatisticsAsExpression(
+      field_ref, float32(), *statistics);
   EXPECT_EQ(stat_expression->ToString(), "(x >= 1)");
 }
 
@@ -747,6 +748,7 @@ TEST_P(TestParquetFileFormatScanNode, ScanSomeColumns) { TestScanSomeColumns(); 
 TEST_P(TestParquetFileFormatScanNode, ScanSomeNestedColumns) {
   TestScanSomeNestedColumns();
 }
+TEST_P(TestParquetFileFormatScanNode, StatisticsFiltering) { TestStatisticsFiltering(); }
 TEST_P(TestParquetFileFormatScanNode, ScanWithInvalidOptions) {
   TestInvalidFormatScanOptions();
 }

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -743,7 +743,10 @@ class TestParquetFileFormatScanNode
 
 TEST_P(TestParquetFileFormatScanNode, Inspect) { TestInspect(); }
 TEST_P(TestParquetFileFormatScanNode, Scan) { TestScan(); }
-TEST_P(TestParquetFileFormatScanNode, ScanSomeColumn) { TestScanSomeColumns(); }
+TEST_P(TestParquetFileFormatScanNode, ScanSomeColumns) { TestScanSomeColumns(); }
+TEST_P(TestParquetFileFormatScanNode, ScanSomeNestedColumns) {
+  TestScanSomeNestedColumns();
+}
 TEST_P(TestParquetFileFormatScanNode, ScanWithInvalidOptions) {
   TestInvalidFormatScanOptions();
 }

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -23,6 +23,7 @@
 
 #include "arrow/compute/api_scalar.h"
 #include "arrow/dataset/dataset_internal.h"
+#include "arrow/dataset/plan.h"
 #include "arrow/dataset/test_util_internal.h"
 #include "arrow/io/memory.h"
 #include "arrow/io/test_common.h"
@@ -729,6 +730,27 @@ TEST(TestParquetStatistics, NullMax) {
       ParquetFileFragment::EvaluateStatisticsAsExpression(*field, *statistics);
   EXPECT_EQ(stat_expression->ToString(), "(x >= 1)");
 }
+
+class TestParquetFileFormatScanNode
+    : public FileFormatScanNodeMixin<ParquetFormatHelper> {
+  void SetUp() override { internal::Initialize(); }
+
+  const FragmentScanOptions* GetFormatOptions() override { return &scan_options_; }
+
+ protected:
+  ParquetFragmentScanOptions scan_options_;
+};
+
+TEST_P(TestParquetFileFormatScanNode, Inspect) { TestInspect(); }
+TEST_P(TestParquetFileFormatScanNode, Scan) { TestScan(); }
+TEST_P(TestParquetFileFormatScanNode, ScanSomeColumn) { TestScanSomeColumns(); }
+TEST_P(TestParquetFileFormatScanNode, ScanWithInvalidOptions) {
+  TestInvalidFormatScanOptions();
+}
+
+INSTANTIATE_TEST_SUITE_P(TestScanNode, TestParquetFileFormatScanNode,
+                         ::testing::ValuesIn(TestFormatParams::Values()),
+                         TestFormatParams::ToTestNameString);
 
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/scan_node.cc
+++ b/cpp/src/arrow/dataset/scan_node.cc
@@ -605,7 +605,7 @@ class ScanNode : public acero::ExecNode, public acero::TracedNode {
                              filter_minus_part, std::move(extracted.known_values)));
 
       return fragment_
-          ->BeginScan(task_launcher->scan_request(), *inspected_fragment,
+          ->BeginScan(task_launcher->scan_request(), inspected_fragment.get(),
                       node_->plan_->query_context()->exec_context())
           .Then([this, task_launcher = std::move(task_launcher)](
                     const std::shared_ptr<FragmentScanner>& fragment_scanner) mutable {

--- a/cpp/src/arrow/dataset/scan_node.cc
+++ b/cpp/src/arrow/dataset/scan_node.cc
@@ -16,7 +16,6 @@
 // under the License.
 
 #include <functional>
-#include <future>
 #include <list>
 #include <memory>
 #include <mutex>
@@ -43,7 +42,6 @@
 #include "arrow/util/unreachable.h"
 
 using namespace std::string_view_literals;  // NOLINT
-using namespace std::placeholders;          // NOLINT
 
 namespace arrow {
 

--- a/cpp/src/arrow/dataset/scan_node.cc
+++ b/cpp/src/arrow/dataset/scan_node.cc
@@ -452,13 +452,13 @@ class ScanNode : public acero::ExecNode, public acero::TracedNode {
       AsyncGenerator<std::shared_ptr<RecordBatch>> batch_gen =
           scanner->RunScanTask(scan_task_number);
       auto batch_count = std::make_shared<int>(0);
+      int* batch_count_view = batch_count.get();
       node_->plan_->query_context()
           ->async_scheduler()
           ->AddAsyncGenerator<std::shared_ptr<RecordBatch>>(
               std::move(batch_gen),
-              [this, batch_counter =
-                         batch_count.get()](const std::shared_ptr<RecordBatch>& batch) {
-                (*batch_counter)++;
+              [this, batch_count_view](const std::shared_ptr<RecordBatch>& batch) {
+                (*batch_count_view)++;
                 return HandleBatch(batch);
               },
               "ScanNode::ScanBatch::Next",

--- a/cpp/src/arrow/dataset/scan_node.cc
+++ b/cpp/src/arrow/dataset/scan_node.cc
@@ -167,6 +167,8 @@ class ScanTaskStagingArea {
         ScanTaskEntry scan_task;
         scan_task.scan_task_index = i;
         scan_task.num_batches = this->fragment_scanner->NumBatchesInScanTask(i);
+        std::cout << "  Fragment " << fragment_index << " detected "
+                  << scan_task.num_batches << " batches in scan task " << i << std::endl;
         scan_task.launched = false;
         scan_tasks.push_back(scan_task);
       }

--- a/cpp/src/arrow/dataset/scan_node.cc
+++ b/cpp/src/arrow/dataset/scan_node.cc
@@ -16,10 +16,13 @@
 // under the License.
 
 #include <functional>
+#include <future>
+#include <iostream>
 #include <list>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "arrow/acero/exec_plan.h"
@@ -27,11 +30,13 @@
 #include "arrow/acero/util.h"
 #include "arrow/compute/expression.h"
 #include "arrow/compute/expression_internal.h"
+#include "arrow/dataset/dataset.h"
 #include "arrow/dataset/scanner.h"
 #include "arrow/record_batch.h"
 #include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/type.h"
+#include "arrow/util/async_util.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/string.h"
@@ -39,6 +44,7 @@
 #include "arrow/util/unreachable.h"
 
 using namespace std::string_view_literals;  // NOLINT
+using namespace std::placeholders;          // NOLINT
 
 namespace arrow {
 
@@ -47,6 +53,251 @@ using internal::checked_cast;
 namespace dataset {
 
 namespace {
+
+// How many inspection tasks we allow to run at the same time
+constexpr int kNumConcurrentInspections = 4;
+// How many scan tasks we need queued up to pause inspection
+constexpr int kLimitQueuedScanTasks = 4;
+
+// An interface for an object that knows all the details requires to launch a scan task
+class ScanTaskLauncher {
+ public:
+  virtual ~ScanTaskLauncher() = default;
+  virtual void LaunchTask(FragmentScanner* scanner, int scan_task_number,
+                          int first_batch_index,
+                          std::function<void(int num_batches)> task_complete_cb) = 0;
+};
+
+// When we have finished inspecting a fragment we can submit its scan tasks.  However,
+// we only allow certain number of scan tasks at a time.  Ironically, a scan task is not
+// actually a "task".  It's a collection of tasks that will run to scan the stream of
+// batches.
+//
+// This class serves as a synchronous "throttle" which makes sure we aren't running too
+// many scan tasks at once.  It also pauses the inspection process if we have a bunch
+// of scan tasks ready to go.
+//
+// Lastly, it also serves as a sort of sequencing point where we hold off on launching
+// a scan task until we know how many batches precede that scan task.
+//
+// There are two events.
+//
+// First, when a fragment finishes inspection, it is inserted into the queue (we might
+// know how many batches are in the scan tasks)
+//
+//  * An entry is created for each scan task and added to the queue
+//  * We check to see if any entries are free to run
+//  * We may pause or resume the inspection throttle
+//
+// Second, when a scan task finishes it records that it is finished (at this point we
+// definitely know how many batches were in the scan task)
+//
+//  * The task is removed from the queue
+//  * We check to see if any entries are free to run
+//  * We may resume the inspection throttle
+class ScanTaskStagingArea {
+ public:
+  ScanTaskStagingArea(int queue_limit, int run_limit,
+                      util::ThrottledAsyncTaskScheduler* inspection_throttle,
+                      std::function<void()> completion_cb)
+      : queue_limit_(queue_limit),
+        run_limit_(run_limit),
+        inspection_throttle_(inspection_throttle),
+        completion_cb_(std::move(completion_cb)) {}
+
+  void InsertInspectedFragment(std::shared_ptr<FragmentScanner> fragment_scanner,
+                               int fragment_index,
+                               std::unique_ptr<ScanTaskLauncher> task_launcher) {
+    std::cout << "  Inserting fragment into staging area" << std::endl;
+    auto fragment_entry = std::make_unique<FragmentEntry>(
+        std::move(fragment_scanner), fragment_index, std::move(task_launcher));
+
+    std::lock_guard lg(mutex_);
+    num_queued_scan_tasks_ += static_cast<int>(fragment_entry->scan_tasks.size());
+
+    // Ordered insertion into linked list
+    if (!root_) {
+      root_ = std::move(fragment_entry);
+      // fragment_entry.prev will be nullptr, which is correct
+    } else {
+      FragmentEntry* itr = root_.get();
+      while (itr->next != nullptr && itr->next->fragment_index < fragment_index) {
+        itr = itr->next.get();
+      }
+      if (itr->next != nullptr) {
+        fragment_entry->next = std::move(itr->next);
+        fragment_entry->next->prev = fragment_entry.get();
+      }
+      fragment_entry->prev = itr;
+      itr->next = std::move(fragment_entry);
+    }
+
+    // Even if this isn't the first fragment it is still possible that there are tasks we
+    // can now run.  For example, if we are allowed to run 4 scan tasks and the root only
+    // had one.
+    TryAndLaunchTasksUnlocked();
+
+    if (num_queued_scan_tasks_ >= queue_limit_) {
+      inspection_throttle_->Pause();
+    }
+  }
+
+  void FinishedInsertingFragments(int num_fragments) {
+    std::lock_guard lg(mutex_);
+    total_num_fragments_ = num_fragments;
+    if (num_fragments_processed_ == total_num_fragments_) {
+      std::cout << "  Ending on finish" << std::endl;
+      completion_cb_();
+    }
+  }
+
+ private:
+  struct ScanTaskEntry {
+    int scan_task_index;
+    int num_batches;
+    bool launched;
+  };
+  struct FragmentEntry {
+    FragmentEntry(std::shared_ptr<FragmentScanner> fragment_scanner, int fragment_index,
+                  std::unique_ptr<ScanTaskLauncher> task_launcher)
+        : fragment_scanner(std::move(fragment_scanner)),
+          fragment_index(fragment_index),
+          task_launcher(std::move(task_launcher)) {
+      for (int i = 0; i < this->fragment_scanner->NumScanTasks(); i++) {
+        ScanTaskEntry scan_task;
+        scan_task.scan_task_index = i;
+        scan_task.num_batches = this->fragment_scanner->NumBatchesInScanTask(i);
+        scan_task.launched = false;
+        scan_tasks.push_back(scan_task);
+      }
+    }
+
+    std::shared_ptr<FragmentScanner> fragment_scanner;
+    int fragment_index;
+    std::unique_ptr<ScanTaskLauncher> task_launcher;
+
+    std::unique_ptr<FragmentEntry> next;
+    FragmentEntry* prev = nullptr;
+    std::deque<ScanTaskEntry> scan_tasks;
+  };
+
+  void LaunchScanTaskUnlocked(FragmentEntry* entry, int scan_task_number,
+                              int first_batch_index) {
+    entry->task_launcher->LaunchTask(
+        entry->fragment_scanner.get(), scan_task_number, first_batch_index,
+        [this, entry, scan_task_number](int num_batches) {
+          MarkScanTaskFinished(entry, scan_task_number, num_batches);
+        });
+    num_queued_scan_tasks_--;
+    if (num_queued_scan_tasks_ < queue_limit_) {
+      inspection_throttle_->Resume();
+    }
+    num_scan_tasks_running_++;
+  }
+
+  void TryAndLaunchTasksUnlocked() {
+    if (!root_) {
+      std::cout << "  Can't launch tasks because there are none" << std::endl;
+      return;
+    }
+    if (num_scan_tasks_running_ >= run_limit_) {
+      std::cout << "  Can't even start trying to run tasks because we hit the limit"
+                << std::endl;
+      return;
+    }
+    FragmentEntry* itr = root_.get();
+    int num_preceding_batches = batches_completed_;
+    while (itr != nullptr) {
+      for (auto& scan_task : itr->scan_tasks) {
+        if (!scan_task.launched) {
+          std::cout << "  Launching a scan task frag=" << itr->fragment_index
+                    << std::endl;
+          scan_task.launched = true;
+          LaunchScanTaskUnlocked(itr, scan_task.scan_task_index, num_preceding_batches);
+          if (num_scan_tasks_running_ >= run_limit_) {
+            std::cout << "  Can't launch more tasks because we hit the limit"
+                      << std::endl;
+            // We've launched as many as we can
+            return;
+          }
+        }
+        if (scan_task.num_batches >= 0) {
+          num_preceding_batches += scan_task.num_batches;
+        } else {
+          std::cout << "  Can't launch task because waiting for troublemaker"
+                    << std::endl;
+          // A scan task is running that doesn't know how many batches it has.  We can't
+          // proceed
+          return;
+        }
+      }
+      itr = itr->next.get();
+    }
+  }
+
+  void MarkScanTaskFinished(FragmentEntry* fragment_entry, int scan_task_number,
+                            int num_batches) {
+    std::lock_guard lg(mutex_);
+    batches_completed_ += num_batches;
+    num_scan_tasks_running_--;
+    std::cout << "  MarkScanTaskFinished(batches_completed_=" << batches_completed_ << ")"
+              << std::endl;
+    const auto& itr = fragment_entry->scan_tasks.cbegin();
+    std::size_t old_size = fragment_entry->scan_tasks.size();
+    while (itr != fragment_entry->scan_tasks.cend()) {
+      if (itr->scan_task_index == scan_task_number) {
+        fragment_entry->scan_tasks.erase(itr);
+        break;
+      }
+    }
+    DCHECK_LT(fragment_entry->scan_tasks.size(), old_size);
+    if (fragment_entry->scan_tasks.empty()) {
+      std::cout << "Fragment complete: " << fragment_entry->fragment_index << std::endl;
+      FragmentEntry* prev = fragment_entry->prev;
+      if (prev == nullptr) {
+        // The current root has finished
+        std::unique_ptr<FragmentEntry> new_root = std::move(root_->next);
+        if (new_root != nullptr) {
+          new_root->prev = nullptr;
+        }
+        // This next line will cause fragment_entry to be deleted
+        root_ = std::move(new_root);
+      } else {
+        if (fragment_entry->next != nullptr) {
+          // In this case a fragment in the middle finished
+          std::unique_ptr<FragmentEntry> next = std::move(fragment_entry->next);
+          next->prev = prev;
+          // This next line will cause fragment_entry to be deleted
+          prev->next = std::move(next);
+        } else {
+          // In this case a fragment at the end finished
+          // This next line will cause fragment_entry to be deleted
+          prev->next = nullptr;
+        }
+      }
+      num_fragments_processed_++;
+      if (num_fragments_processed_ == total_num_fragments_) {
+        std::cout << "  Completion via fragment end" << std::endl;
+        completion_cb_();
+        return;
+      }
+    }
+    TryAndLaunchTasksUnlocked();
+  }
+
+  int queue_limit_;
+  int run_limit_;
+  util::ThrottledAsyncTaskScheduler* inspection_throttle_;
+  std::function<void()> completion_cb_;
+
+  int num_queued_scan_tasks_ = 0;
+  int num_scan_tasks_running_ = 0;
+  int batches_completed_ = 0;
+  std::unique_ptr<FragmentEntry> root_;
+  std::mutex mutex_;
+  int num_fragments_processed_ = 0;
+  int total_num_fragments_ = -1;
+};
 
 Result<std::shared_ptr<Schema>> OutputSchemaFromOptions(const ScanV2Options& options) {
   return FieldPath::GetAll(*options.dataset->schema(), options.columns);
@@ -80,40 +331,45 @@ Future<AsyncGenerator<std::shared_ptr<Fragment>>> GetFragments(
 
 /// \brief A node that scans a dataset
 ///
-/// The scan node has three groups of io-tasks and one task.
+/// The scan node has three stages.
 ///
-/// The first io-task (listing) fetches the fragments from the dataset.  This may be a
+/// The first stage (listing) fetches the fragments from the dataset.  This may be a
 /// simple iteration of paths or, if the dataset is described with wildcards, this may
-/// involve I/O for listing and walking directory paths.  There is one listing io-task
-/// per dataset.
+/// involve I/O for listing and walking directory paths.  There is only one listing task.
+///
+/// Ths next step is to inspect the fragment.  At a minimum we need to know the names of
+/// the columns in the fragment so that we can perform evolution.  This often involves
+/// reading file metadata or the first block of the file (e.g. CSV / JSON). There is one
+/// inspect task per fragment.
+///
+/// Once the inspect is done we can issue scan tasks.  The number of scan tasks created
+/// will depend on the format and the file structure.  For example, CSV creates 1 scan
+/// task per file.  Parquet creates one scan task per row group.
+///
+/// The creation of scan tasks is a partially sequenced operation.  We can start
+/// inspecting fragments in parallel.  However, we cannot start scanning a fragment until
+/// we know how many batches will come before that fragment.  This allows us to assign a
+/// sequence number to scanned batches.
+///
+/// Each scan task is then broken up into a series of batch scans which scan a single
+/// batch from the disk.  For example, in parquet, we might have a very large row group.
+/// That single row group will have one scan task.  That scan task might generate hundreds
+/// of batch scans.
+///
+/// Finally, when the batch scan is complete, we issue a pipeline task to drive the batch
+/// through the plan.
+///
+/// Most of these tasks are I/O tasks.  They take very few CPU resources and they run on
+/// the I/O thread pool.
+///
+/// In order to manage the disk load and our running memory requirements we limit the
+/// number of scan tasks that run at any one time.
 ///
 /// If a fragment has a guarantee we may use that expression to reduce the columns that
 /// we need to load from disk.  For example, if the guarantee is x==7 then we don't need
 /// to load the column x from disk and can instead populate x with the scalar 7.  If the
 /// fragment on disk actually had a column x, and the value was not 7, then we will prefer
 /// the guarantee in this invalid case.
-///
-/// Ths next step is to fetch the metadata for the fragment.  For some formats (e.g.
-/// CSV) this may be quite simple (get the size of the file).  For other formats (e.g.
-/// parquet) this is more involved and requires reading data.  There is one metadata
-/// io-task per fragment.  The metadata io-task creates an AsyncGenerator<RecordBatch>
-/// from the fragment.
-///
-/// Once the metadata io-task is done we can issue read io-tasks.  Each read io-task
-/// requests a single batch of data from the disk by pulling the next Future from the
-/// generator.
-///
-/// Finally, when the future is fulfilled, we issue a pipeline task to drive the batch
-/// through the pipeline.
-///
-/// Most of these tasks are io-tasks.  They take very few CPU resources and they run on
-/// the I/O thread pool.  These io-tasks are invisible to the exec plan and so we need
-/// to do some custom scheduling.  We limit how many fragments we read from at any one
-/// time. This is referred to as "fragment readahead".
-///
-/// Within a fragment there is usually also some amount of "row readahead".  This row
-/// readahead is handled by the fragment (and not the scanner) because the exact details
-/// of how it is performed depend on the underlying format.
 ///
 /// When a scan node is aborted (StopProducing) we send a cancel signal to any active
 /// fragments.  On destruction we continue consuming the fragments until they complete
@@ -125,7 +381,7 @@ class ScanNode : public acero::ExecNode, public acero::TracedNode {
            std::shared_ptr<Schema> output_schema)
       : acero::ExecNode(plan, {}, {}, std::move(output_schema)),
         acero::TracedNode(this),
-        options_(options) {}
+        options_(std::move(options)) {}
 
   static Result<ScanV2Options> NormalizeAndValidate(const ScanV2Options& options,
                                                     compute::ExecContext* ctx) {
@@ -134,14 +390,9 @@ class ScanNode : public acero::ExecNode, public acero::TracedNode {
       return Status::Invalid("Scan options must include a dataset");
     }
 
-    if (options.fragment_readahead < 0) {
+    if (options.scan_task_readahead < 0) {
       return Status::Invalid(
-          "Fragment readahead may not be less than 0.  Set to 0 to disable readahead");
-    }
-
-    if (options.target_bytes_readahead < 0) {
-      return Status::Invalid(
-          "Batch readahead may not be less than 0.  Set to 0 to disable readahead");
+          "Scan task readahead may not be less than 0.  Set to 0 to disable readahead");
     }
 
     if (!normalized.filter.is_valid()) {
@@ -199,51 +450,67 @@ class ScanNode : public acero::ExecNode, public acero::TracedNode {
     Datum value;
   };
 
-  struct ScanState {
-    std::mutex mutex;
-    std::shared_ptr<FragmentScanner> fragment_scanner;
-    std::unique_ptr<FragmentEvolutionStrategy> fragment_evolution;
-    std::vector<KnownValue> known_values;
-    FragmentScanRequest scan_request;
-  };
+  // The staging area and the fragment scanner don't want to know any details about
+  // evolution Those details are encapsulated here.  The inspection task calculates
+  // exactly how to evolve outgoing batches and creates a template that is used by all
+  // scan tasks in the fragment
+  class ScanTaskLauncherImpl : public ScanTaskLauncher {
+   public:
+    ScanTaskLauncherImpl(ScanNode* node,
+                         std::unique_ptr<FragmentEvolutionStrategy> fragment_evolution,
+                         std::vector<KnownValue> known_values,
+                         FragmentScanRequest scan_request)
+        : node_(node),
+          fragment_evolution_(std::move(fragment_evolution)),
+          known_values_(std::move(known_values)),
+          scan_request_(std::move(scan_request)) {}
 
-  struct ScanBatchTask : public util::AsyncTaskScheduler::Task {
-    ScanBatchTask(ScanNode* node, ScanState* scan_state, int batch_index)
-        : node_(node), scan_(scan_state), batch_index_(batch_index) {
-      int64_t cost = scan_state->fragment_scanner->EstimatedDataBytes(batch_index_);
-      // It's possible, though probably a bad idea, for a single batch of a fragment
-      // to be larger than 2GiB.  In that case, it doesn't matter much if we
-      // underestimate because the largest the throttle can be is 2GiB and thus we will
-      // be in "one batch at a time" mode anyways which is the best we can do in this
-      // case.
-      cost_ = static_cast<int>(
-          std::min(cost, static_cast<int64_t>(std::numeric_limits<int>::max())));
-      name_ = "ScanNode::ScanBatch::" + ::arrow::internal::ToChars(batch_index_);
+    void LaunchTask(FragmentScanner* scanner, int scan_task_number, int first_batch_index,
+                    std::function<void(int num_batches)> task_complete_cb) override {
+      AsyncGenerator<std::shared_ptr<RecordBatch>> batch_gen =
+          scanner->RunScanTask(scan_task_number);
+      auto batch_count = std::make_shared<int>(0);
+      node_->plan_->query_context()
+          ->async_scheduler()
+          ->AddAsyncGenerator<std::shared_ptr<RecordBatch>>(
+              std::move(batch_gen),
+              [this, scan_task_number, batch_counter = batch_count.get()](
+                  const std::shared_ptr<RecordBatch>& batch) {
+                std::cout << "  ScanTask(" << scan_task_number << "," << (*batch_counter)
+                          << ")" << std::endl;
+                (*batch_counter)++;
+                return HandleBatch(batch);
+              },
+              "ScanNode::ScanBatch::Next",
+              [this, scan_task_number, task_complete_cb = std::move(task_complete_cb),
+               batch_count = std::move(batch_count)]() {
+                node_->plan_->query_context()->ScheduleTask(
+                    [scan_task_number, task_complete_cb, batch_count] {
+                      std::cout << "  Scan task complete(" << scan_task_number << ")"
+                                << std::endl;
+                      task_complete_cb(*batch_count);
+                      return Status::OK();
+                    },
+                    "ScanTaskWrapUp");
+                return Status::OK();
+              });
     }
 
-    Result<Future<>> operator()() override {
-      // Prevent concurrent calls to ScanBatch which might not be thread safe
-      std::lock_guard<std::mutex> lk(scan_->mutex);
-      return scan_->fragment_scanner->ScanBatch(batch_index_)
-          .Then([this](const std::shared_ptr<RecordBatch>& batch) {
-            return HandleBatch(batch);
-          });
-    }
+    const FragmentScanRequest& scan_request() const { return scan_request_; }
 
-    std::string_view name() const override { return name_; }
-
+   private:
     compute::ExecBatch AddKnownValues(compute::ExecBatch batch) {
-      if (scan_->known_values.empty()) {
+      if (known_values_.empty()) {
         return batch;
       }
       std::vector<Datum> with_known_values;
       int num_combined_cols =
-          static_cast<int>(batch.values.size() + scan_->known_values.size());
+          static_cast<int>(batch.values.size() + known_values_.size());
       with_known_values.reserve(num_combined_cols);
-      auto known_values_itr = scan_->known_values.cbegin();
+      auto known_values_itr = known_values_.cbegin();
       auto batch_itr = batch.values.begin();
       for (int i = 0; i < num_combined_cols; i++) {
-        if (known_values_itr != scan_->known_values.end() &&
+        if (known_values_itr != known_values_.end() &&
             static_cast<int>(known_values_itr->index) == i) {
           with_known_values.push_back(known_values_itr->value);
           known_values_itr++;
@@ -258,38 +525,39 @@ class ScanNode : public acero::ExecNode, public acero::TracedNode {
     Status HandleBatch(const std::shared_ptr<RecordBatch>& batch) {
       ARROW_ASSIGN_OR_RAISE(
           compute::ExecBatch evolved_batch,
-          scan_->fragment_evolution->EvolveBatch(
-              batch, node_->options_.columns, *scan_->scan_request.fragment_selection));
+          fragment_evolution_->EvolveBatch(batch, node_->options_.columns,
+                                           *scan_request_.fragment_selection));
       compute::ExecBatch with_known_values = AddKnownValues(std::move(evolved_batch));
       node_->plan_->query_context()->ScheduleTask(
           [node = node_, output_batch = std::move(with_known_values)] {
+            node->batch_counter_++;
             return node->output_->InputReceived(node, output_batch);
           },
           "ScanNode::ProcessMorsel");
       return Status::OK();
     }
 
-    int cost() const override { return cost_; }
-
     ScanNode* node_;
-    ScanState* scan_;
-    int batch_index_;
-    int cost_;
-    std::string name_;
+    const std::unique_ptr<FragmentEvolutionStrategy> fragment_evolution_;
+    const std::vector<KnownValue> known_values_;
+    const FragmentScanRequest scan_request_;
   };
 
-  struct ListFragmentTask : util::AsyncTaskScheduler::Task {
-    ListFragmentTask(ScanNode* node, std::shared_ptr<Fragment> fragment)
-        : node(node), fragment(std::move(fragment)) {
-      name_ = "ScanNode::ListFragment::" + this->fragment->ToString();
+  struct InspectFragmentTask : util::AsyncTaskScheduler::Task {
+    InspectFragmentTask(ScanNode* node, std::shared_ptr<Fragment> fragment,
+                        int fragment_index)
+        : node_(node), fragment_(std::move(fragment)), fragment_index_(fragment_index) {
+      name_ = "ScanNode::InspectFragment::" + fragment_->ToString();
     }
 
     Result<Future<>> operator()() override {
-      return fragment
-          ->InspectFragment(node->options_.format_options,
-                            node->plan_->query_context()->exec_context())
+      std::cout << "START: Inspecting fragment: " << fragment_->ToString() << std::endl;
+      return fragment_
+          ->InspectFragment(node_->options_.format_options,
+                            node_->plan_->query_context()->exec_context(),
+                            node_->options_.cache_fragment_inspection)
           .Then([this](const std::shared_ptr<InspectedFragment>& inspected_fragment) {
-            return BeginScan(inspected_fragment);
+            return OnInspectionComplete(inspected_fragment);
           });
     }
 
@@ -306,10 +574,10 @@ class ScanNode : public acero::ExecNode, public acero::TracedNode {
         const compute::Expression& guarantee) {
       ARROW_ASSIGN_OR_RAISE(
           compute::KnownFieldValues part_values,
-          compute::ExtractKnownFieldValues(fragment->partition_expression()));
+          compute::ExtractKnownFieldValues(fragment_->partition_expression()));
       ExtractedKnownValues extracted;
-      for (std::size_t i = 0; i < node->options_.columns.size(); i++) {
-        const auto& field_path = node->options_.columns[i];
+      for (std::size_t i = 0; i < node_->options_.columns.size(); i++) {
+        const auto& field_path = node_->options_.columns[i];
         FieldRef field_ref(field_path);
         auto existing = part_values.map.find(FieldRef(field_path));
         if (existing == part_values.map.end()) {
@@ -317,7 +585,7 @@ class ScanNode : public acero::ExecNode, public acero::TracedNode {
           extracted.remaining_columns.push_back(field_path);
         } else {
           ARROW_ASSIGN_OR_RAISE(const std::shared_ptr<Field>& field,
-                                field_path.Get(*node->options_.dataset->schema()));
+                                field_path.Get(*node_->options_.dataset->schema()));
           Result<Datum> maybe_casted = compute::Cast(existing->second, field->type());
           if (!maybe_casted.ok()) {
             // TODO(weston) In theory this should be preventable.  The dataset and
@@ -336,117 +604,109 @@ class ScanNode : public acero::ExecNode, public acero::TracedNode {
       return std::move(extracted);
     }
 
-    Future<> BeginScan(const std::shared_ptr<InspectedFragment>& inspected_fragment) {
+    Future<> OnInspectionComplete(
+        const std::shared_ptr<InspectedFragment>& inspected_fragment) {
       // Based on the fragment's guarantee we may not need to retrieve all the columns
-      compute::Expression fragment_filter = node->options_.filter;
+      compute::Expression fragment_filter = node_->options_.filter;
       ARROW_ASSIGN_OR_RAISE(
           compute::Expression filter_minus_part,
           compute::SimplifyWithGuarantee(std::move(fragment_filter),
-                                         fragment->partition_expression()));
+                                         fragment_->partition_expression()));
 
       ARROW_ASSIGN_OR_RAISE(
           ExtractedKnownValues extracted,
-          ExtractKnownValuesFromGuarantee(fragment->partition_expression()));
+          ExtractKnownValuesFromGuarantee(fragment_->partition_expression()));
 
       // Now that we have an inspected fragment we need to use the dataset's evolution
       // strategy to figure out how to scan it
-      scan_state->fragment_evolution =
-          node->options_.dataset->evolution_strategy()->GetStrategy(
-              *node->options_.dataset, *fragment, *inspected_fragment);
-      ARROW_RETURN_NOT_OK(InitFragmentScanRequest(extracted.remaining_columns,
-                                                  filter_minus_part,
-                                                  std::move(extracted.known_values)));
-      return fragment
-          ->BeginScan(scan_state->scan_request, *inspected_fragment,
-                      node->options_.format_options,
-                      node->plan_->query_context()->exec_context())
-          .Then([this](const std::shared_ptr<FragmentScanner>& fragment_scanner) {
-            return AddScanTasks(fragment_scanner);
+      std::unique_ptr<FragmentEvolutionStrategy> fragment_evolution =
+          node_->options_.dataset->evolution_strategy()->GetStrategy(
+              *node_->options_.dataset, *fragment_, *inspected_fragment);
+      ARROW_ASSIGN_OR_RAISE(
+          std::unique_ptr<ScanTaskLauncherImpl> task_launcher,
+          CreateTaskLauncher(std::move(fragment_evolution), extracted.remaining_columns,
+                             filter_minus_part, std::move(extracted.known_values)));
+
+      std::cout << "  BeginScan: " << fragment_->ToString() << std::endl;
+      return fragment_
+          ->BeginScan(task_launcher->scan_request(), *inspected_fragment,
+                      node_->plan_->query_context()->exec_context())
+          .Then([this, task_launcher = std::move(task_launcher)](
+                    const std::shared_ptr<FragmentScanner>& fragment_scanner) mutable {
+            node_->staging_area_->InsertInspectedFragment(
+                fragment_scanner, fragment_index_, std::move(task_launcher));
           });
-    }
-
-    Future<> AddScanTasks(const std::shared_ptr<FragmentScanner>& fragment_scanner) {
-      scan_state->fragment_scanner = fragment_scanner;
-      ScanState* state_view = scan_state.get();
-      Future<> list_and_scan_done = Future<>::Make();
-      // Finish callback keeps the scan state alive until all scan tasks done
-      struct StateHolder {
-        Status operator()() {
-          list_and_scan_done.MarkFinished();
-          return Status::OK();
-        }
-        Future<> list_and_scan_done;
-        std::unique_ptr<ScanState> scan_state;
-      };
-
-      std::unique_ptr<util::AsyncTaskGroup> scan_tasks = util::AsyncTaskGroup::Make(
-          node->batches_throttle_.get(),
-          StateHolder{list_and_scan_done, std::move(scan_state)});
-      for (int i = 0; i < fragment_scanner->NumBatches(); i++) {
-        node->num_batches_.fetch_add(1);
-        scan_tasks->AddTask(std::make_unique<ScanBatchTask>(node, state_view, i));
-      }
-      return Status::OK();
-      // The "list fragments" task doesn't actually end until the fragments are
-      // all scanned.  This allows us to enforce fragment readahead.
-      return list_and_scan_done;
     }
 
     // Take the dataset options, and the fragment evolution, and figure out exactly how
     // we should scan the fragment itself.
-    Status InitFragmentScanRequest(const std::vector<FieldPath>& desired_columns,
-                                   const compute::Expression& filter,
-                                   std::vector<KnownValue> known_values) {
-      ARROW_ASSIGN_OR_RAISE(
-          scan_state->scan_request.fragment_selection,
-          scan_state->fragment_evolution->DevolveSelection(desired_columns));
-      ARROW_ASSIGN_OR_RAISE(
-          compute::Expression devolution_guarantee,
-          scan_state->fragment_evolution->GetGuarantee(desired_columns));
+    Result<std::unique_ptr<ScanTaskLauncherImpl>> CreateTaskLauncher(
+        std::unique_ptr<FragmentEvolutionStrategy> fragment_evolution,
+        const std::vector<FieldPath>& desired_columns, const compute::Expression& filter,
+        std::vector<KnownValue> known_values) {
+      FragmentScanRequest scan_request;
+      ARROW_ASSIGN_OR_RAISE(scan_request.fragment_selection,
+                            fragment_evolution->DevolveSelection(desired_columns));
+      ARROW_ASSIGN_OR_RAISE(compute::Expression devolution_guarantee,
+                            fragment_evolution->GetGuarantee(desired_columns));
       ARROW_ASSIGN_OR_RAISE(compute::Expression simplified_filter,
                             compute::SimplifyWithGuarantee(filter, devolution_guarantee));
-      ARROW_ASSIGN_OR_RAISE(
-          scan_state->scan_request.filter,
-          scan_state->fragment_evolution->DevolveFilter(std::move(simplified_filter)));
-      scan_state->scan_request.format_scan_options = node->options_.format_options;
-      scan_state->known_values = std::move(known_values);
-      return Status::OK();
+      ARROW_ASSIGN_OR_RAISE(scan_request.filter, fragment_evolution->DevolveFilter(
+                                                     std::move(simplified_filter)));
+      scan_request.format_scan_options = node_->options_.format_options;
+      auto task_launcher = std::make_unique<ScanTaskLauncherImpl>(
+          node_, std::move(fragment_evolution), std::move(known_values),
+          std::move(scan_request));
+      return task_launcher;
     }
 
-    ScanNode* node;
-    std::shared_ptr<Fragment> fragment;
-    std::unique_ptr<ScanState> scan_state = std::make_unique<ScanState>();
+    ScanNode* node_;
+    std::shared_ptr<Fragment> fragment_;
+    int fragment_index_;
     std::string name_;
   };
 
-  void ScanFragments(const AsyncGenerator<std::shared_ptr<Fragment>>& frag_gen) {
-    std::shared_ptr<util::AsyncTaskScheduler> fragment_tasks =
-        util::MakeThrottledAsyncTaskGroup(
-            plan_->query_context()->async_scheduler(), options_.fragment_readahead + 1,
-            /*queue=*/nullptr,
-            [this]() { return output_->InputFinished(this, num_batches_.load()); });
-    fragment_tasks->AddAsyncGenerator<std::shared_ptr<Fragment>>(
-        std::move(frag_gen),
-        [this, fragment_tasks =
-                   std::move(fragment_tasks)](const std::shared_ptr<Fragment>& fragment) {
-          fragment_tasks->AddTask(std::make_unique<ListFragmentTask>(this, fragment));
-          return Status::OK();
-        },
-        "ScanNode::ListDataset::Next");
+  void InspectFragments(const AsyncGenerator<std::shared_ptr<Fragment>>& frag_gen) {
+    plan_->query_context()
+        ->async_scheduler()
+        ->AddAsyncGenerator<std::shared_ptr<Fragment>>(
+            std::move(frag_gen),
+            [this](const std::shared_ptr<Fragment>& fragment) {
+              std::cout << "  Listed fragment: " << fragment->ToString() << std::endl;
+              inspection_throttle_->AddTask(std::make_unique<InspectFragmentTask>(
+                  this, fragment, fragment_index_++));
+              return Status::OK();
+            },
+            "ScanNode::ListDataset::Next",
+            [this] {
+              staging_area_->FinishedInsertingFragments(fragment_index_);
+              return Status::OK();
+            });
   }
 
   Status StartProducing() override {
     NoteStartProducing(ToStringExtra());
-    batches_throttle_ = util::ThrottledAsyncTaskScheduler::Make(
-        plan_->query_context()->async_scheduler(), options_.target_bytes_readahead + 1);
+    inspection_throttle_ = util::ThrottledAsyncTaskScheduler::Make(
+        plan_->query_context()->async_scheduler(), kNumConcurrentInspections);
+    auto completion = [this] {
+      plan_->query_context()->ScheduleTask(
+          [this] { return output_->InputFinished(this, batch_counter_.load()); },
+          "ScanNode::Finished");
+    };
+    // For ease of use we treat readahead=1 as "only scan one thing at a time"
+    int scan_task_readahead = std::max(options_.scan_task_readahead, 1);
+    staging_area_ = std::make_unique<ScanTaskStagingArea>(
+        kLimitQueuedScanTasks, scan_task_readahead, inspection_throttle_.get(),
+        std::move(completion));
     plan_->query_context()->async_scheduler()->AddSimpleTask(
         [this] {
+          std::cout << "START: ListFragments::GetFragments" << std::endl;
           return GetFragments(options_.dataset.get(), options_.filter)
               .Then([this](const AsyncGenerator<std::shared_ptr<Fragment>>& frag_gen) {
-                ScanFragments(frag_gen);
+                InspectFragments(frag_gen);
               });
         },
-        "ScanNode::ListDataset::GetFragments"sv);
+        "ScanNode::StartListing"sv);
     return Status::OK();
   }
 
@@ -462,8 +722,10 @@ class ScanNode : public acero::ExecNode, public acero::TracedNode {
 
  private:
   ScanV2Options options_;
-  std::atomic<int> num_batches_{0};
-  std::shared_ptr<util::ThrottledAsyncTaskScheduler> batches_throttle_;
+  std::shared_ptr<util::ThrottledAsyncTaskScheduler> inspection_throttle_;
+  std::unique_ptr<ScanTaskStagingArea> staging_area_;
+  int fragment_index_ = 0;
+  std::atomic<int32_t> batch_counter_{0};
 };
 
 }  // namespace

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -54,6 +54,11 @@ constexpr int64_t kDefaultBatchSize = 1 << 17;  // 128Ki rows
 // This will yield 64 batches ~ 8Mi rows
 constexpr int32_t kDefaultBatchReadahead = 16;
 constexpr int32_t kDefaultFragmentReadahead = 4;
+
+// Note, the above properties are specific to the legacy scanner.  These following
+// properties control the new scanner.  This configuration should lead to max of ~512MiB
+// of scanner buffer while still allowing 16 parallel read streams.
+constexpr int32_t kDefaultScanTaskReadahead = 16;
 constexpr int32_t kDefaultBytesReadahead = 1 << 25;  // 32MiB
 
 /// Scan-specific options, which can be changed between scans of the same dataset.
@@ -219,38 +224,58 @@ struct ARROW_DS_EXPORT ScanV2Options : public acero::ExecNodeOptions {
   ///   })
   std::vector<FieldPath> columns;
 
-  /// \brief Target number of bytes to read ahead in a fragment
+  /// \brief How many concurrent streams should the scanner read
   ///
-  /// This limit involves some amount of estimation.  Formats typically only know
-  /// batch boundaries in terms of rows (not decoded bytes) and so an estimation
-  /// must be done to guess the average row size.  Other formats like CSV and JSON
-  /// must make even more generalized guesses.
-  ///
-  /// This is a best-effort guide.  Some formats may need to read ahead further,
-  /// for example, if scanning a parquet file that has batches with 100MiB of data
-  /// then the actual readahead will be at least 100MiB
-  ///
-  /// Set to 0 to disable readhead.  When disabled, the scanner will read the
-  /// dataset one batch at a time
-  ///
-  /// This limit applies across all fragments.  If the limit is 32MiB and the
-  /// fragment readahead allows for 20 fragments to be read at once then the
-  /// total readahead will still be 32MiB and NOT 20 * 32MiB.
-  int32_t target_bytes_readahead = kDefaultBytesReadahead;
-
-  /// \brief Number of fragments to read ahead
-  ///
-  /// Higher readahead will potentially lead to more efficient I/O but will lead
+  /// Higher readahead could potentially lead to more efficient I/O but will lead
   /// to the scan operation using more RAM.  The default is fairly conservative
   /// and designed for fast local disks (or slow local spinning disks which cannot
   /// handle much parallelism anyways).  When using a highly parallel remote filesystem
   /// you will likely want to increase these values.
   ///
-  /// Set to 0 to disable fragment readahead.  When disabled the dataset will be scanned
-  /// one fragment at a time.
-  int32_t fragment_readahead = kDefaultFragmentReadahead;
+  /// Set to 0 to disable readahead.  When disabled the dataset will be scanned
+  /// one stream at a time.
+  ///
+  /// A stream (or scan task) is any independently scannable unit.  For example, an
+  /// entire JSON file is a single stream.  We scan the file from start to finish and
+  /// cannot start scanning in the middle.  A parquet file has one stream per row group.
+  /// This is because we can scan the row groups in parallel.
+  int32_t scan_task_readahead = kDefaultScanTaskReadahead;
   /// \brief Options specific to the file format
   const FragmentScanOptions* format_options = NULLPTR;
+
+  /// \brief How many rows to skip
+  ///
+  /// This skips rows according to the implicit order of the dataset
+  ///
+  /// Not all file formats support skipping.  For example, when scanning CSV we
+  /// do not know ahead of time how many rows are in a batch.  Since we are typically
+  /// scanning in parallel this means we cannot reasonable enforce a skip.
+  ///
+  /// Also note that this skip happens before any filtering of the data.  This means
+  /// that you typically do not want to do skipping if you are also filtering.
+  ///
+  /// If you want to skip after filtering or you want to skip and your file format does
+  /// not support it then you should use a \see arrow::compute::FetchNode
+  int64_t rows_to_skip = 0;
+
+  /// \brief How many rows to read
+  ///
+  /// The default (nullopt) will read all rows
+  ///
+  /// This will read the first `rows_to_read` rows (after any skip) according to
+  /// the implicit order of the dataset.
+  ///
+  /// Similar to `rows_to_skip` this is not supported by all file formats and does
+  /// not typically make sense when you are also using a filter.  In those cases you
+  /// should apply your limit after the scan using \see arrow::compute::FetchNode
+  std::optional<int64_t> rows_to_read = std::nullopt;
+
+  /// \brief Should the scan node cache fragment inspection information
+  ///
+  /// If this is true then future scans of the same fragment instance may start slightly
+  /// faster.  However, this information could take up a large amount of RAM if there are
+  /// many fragments.
+  bool cache_fragment_inspection = false;
 
   /// \brief Utility method to get a selection representing all columns in a dataset
   static std::vector<FieldPath> AllColumns(const Schema& dataset_schema);

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -810,49 +810,6 @@ TEST(TestNewScanner, OutOfOrderFragmentCompletion) {
   ASSERT_EQ(3, batches.size());
 }
 
-// TEST(TestNewScanner, OutOfOrderScanTaskCompletion) {
-//   constexpr int kNumFragments = 1;
-//   constexpr int kNumScanTasksPerFragment = 4;
-//   constexpr int kNumBatchesPerScanTask = 1;
-
-//   internal::Initialize();
-//   std::shared_ptr<MockDataset> test_dataset =
-//       MakeTestDataset(kNumFragments, kNumScanTasksPerFragment, kNumBatchesPerScanTask);
-
-//   ScanV2Options options(test_dataset);
-//   options.columns = ScanV2Options::AllColumns(*test_dataset->schema());
-
-//   // Begin scan
-//   acero::Declaration scan_decl = acero::Declaration("scan2", std::move(options));
-//   Future<RecordBatchVector> batches_fut =
-//       acero::DeclarationToBatchesAsync(std::move(scan_decl));
-
-//   // Start scanning on all fragments
-//   for (int i = 0; i < kNumFragments; i++) {
-//     test_dataset->fragments_[i]->FinishInspection();
-//     test_dataset->fragments_[i]->FinishScanBegin();
-//   }
-
-//   // Let scan tasks get started
-//   SleepABit();
-//   // A fragment in the middle finishes
-//   test_dataset->fragments_[1]->fragment_scanner_->scan_tasks_[0].Finish(0);
-
-//   SleepABit();
-
-//   // A fragment at the end finishes
-//   test_dataset->fragments_[2]->fragment_scanner_->scan_tasks_[0].Finish(0);
-
-//   SleepABit();
-
-//   // Now the first fragment finishes
-//   test_dataset->fragments_[0]->fragment_scanner_->scan_tasks_[0].Finish(0);
-
-//   // The scan should finish cleanly
-//   ASSERT_FINISHES_OK_AND_ASSIGN(RecordBatchVector batches, batches_fut);
-//   ASSERT_EQ(3, batches.size());
-// }
-
 TEST(TestNewScanner, NestedRead) {
   // This tests the case where the file format does not support
   // handling nested reads (e.g. JSON) and so the scanner must

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -686,7 +686,7 @@ void CheckScannerBackpressure(std::shared_ptr<MockDataset> dataset, ScanV2Option
 
   int total_scan_tasks = 0;
   for (const auto& frag : dataset->fragments_) {
-    total_scan_tasks += frag->fragment_scanner_->scan_tasks_.size();
+    total_scan_tasks += static_cast<int>(frag->fragment_scanner_->scan_tasks_.size());
     frag->FinishInspection();
     frag->FinishScanBegin();
   }

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -300,7 +300,7 @@ struct MockFragment : public Fragment {
   }
 
   Future<std::shared_ptr<FragmentScanner>> BeginScan(
-      const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
+      const FragmentScanRequest& request, InspectedFragment* inspected_fragment,
       compute::ExecContext* exec_context) override {
     has_started_ = true;
     seen_request_ = request;

--- a/cpp/src/arrow/dataset/test_util_internal.h
+++ b/cpp/src/arrow/dataset/test_util_internal.h
@@ -61,7 +61,6 @@
 #include "arrow/util/pcg_random.h"
 #include "arrow/util/thread_pool.h"
 #include "arrow/util/vector.h"
-#include "gmock/gmock.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/testing/matchers.h
+++ b/cpp/src/arrow/testing/matchers.h
@@ -264,7 +264,7 @@ class ErrorMatcher {
         } else if (status.ok()) {
           *listener << "whose non-error doesn't match";
         } else {
-          *listener << "whose error (" << status.message() << ") doesn't match";
+          *listener << "whose error doesn't match";
         }
 
         testing::internal::PrintIfNotEmpty(value_listener.str(), listener->stream());

--- a/cpp/src/arrow/testing/matchers.h
+++ b/cpp/src/arrow/testing/matchers.h
@@ -264,7 +264,7 @@ class ErrorMatcher {
         } else if (status.ok()) {
           *listener << "whose non-error doesn't match";
         } else {
-          *listener << "whose error doesn't match";
+          *listener << "whose error (" << status.message() << ") doesn't match";
         }
 
         testing::internal::PrintIfNotEmpty(value_listener.str(), listener->stream());

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -1053,6 +1053,28 @@ size_t FieldPath::hash() const {
   return internal::ComputeStringHash<0>(indices().data(), indices().size() * sizeof(int));
 }
 
+bool FieldPath::operator<(const FieldPath& other) const {
+  std::size_t idx;
+  for (idx = 0; idx < indices().size(); idx++) {
+    if (idx >= other.indices_.size()) {
+      // *this is something like [2, 5, 0] and other is something like [2, 5]
+      return false;
+    }
+    if (indices_[idx] < other.indices_[idx]) {
+      return true;
+    }
+    if (indices_[idx] > other.indices_[idx]) {
+      return false;
+    }
+  }
+  if (idx < other.indices_.size()) {
+    // *this is something like [2, 5] and other is something like [2, 5, 0]
+    return true;
+  }
+  // Equality
+  return false;
+}
+
 std::string FieldPath::ToString() const {
   if (this->indices().empty()) {
     return "FieldPath(empty)";

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1673,6 +1673,10 @@ class ARROW_EXPORT FieldPath {
   bool empty() const { return indices_.empty(); }
   bool operator==(const FieldPath& other) const { return indices() == other.indices(); }
   bool operator!=(const FieldPath& other) const { return indices() != other.indices(); }
+  bool operator<(const FieldPath& other) const;
+  bool operator>(const FieldPath& other) { return other < *this; }
+  bool operator<=(const FieldPath& other) { return !(*this > other); }
+  bool operator>=(const FieldPath& other) { return !(*this < other); }
 
   const std::vector<int>& indices() const { return indices_; }
   int operator[](size_t i) const { return indices_[i]; }

--- a/cpp/src/arrow/util/async_util.cc
+++ b/cpp/src/arrow/util/async_util.cc
@@ -65,6 +65,9 @@ class ThrottleImpl : public ThrottledAsyncTaskScheduler::Throttle {
 
   void Pause() override {
     std::lock_guard lg(mutex_);
+    if (paused_) {
+      return;
+    }
     paused_ = true;
     if (!backoff_.is_valid()) {
       backoff_ = Future<>::Make();
@@ -73,6 +76,9 @@ class ThrottleImpl : public ThrottledAsyncTaskScheduler::Throttle {
 
   void Resume() override {
     std::unique_lock lk(mutex_);
+    if (!paused_) {
+      return;
+    }
     paused_ = false;
     // Might be a useless notification if our current cost is full
     // or no one is waiting but it should be ok.

--- a/cpp/src/arrow/util/async_util.h
+++ b/cpp/src/arrow/util/async_util.h
@@ -131,16 +131,19 @@ class ARROW_EXPORT AsyncTaskScheduler {
   /// This visits the task serially without readahead.  If readahead or parallelism
   /// is desired then it should be added in the generator itself.
   ///
-  /// The generator itself will be kept alive until all tasks have been completed.
-  /// However, if the scheduler is aborted, the generator will be destroyed as soon as the
-  /// next item would be requested.
+  /// The generator itself will be kept alive until all tasks have been completed and the
+  /// on_completion function is run.  However, if the scheduler is aborted, the generator
+  /// will be destroyed as soon as the next item would be requested and the on_completion
+  /// function will not run.
   ///
   /// \param generator the generator to submit to the scheduler
   /// \param visitor a function which visits each generator future as it completes
   /// \param name a name which will be used for each submitted task
+  /// \param on_completion an optional function that will be called after all tasks
   template <typename T>
   bool AddAsyncGenerator(std::function<Future<T>()> generator,
-                         std::function<Status(const T&)> visitor, std::string_view name);
+                         std::function<Status(const T&)> visitor, std::string_view name,
+                         std::function<Status()> on_completion = {});
 
   template <typename Callable>
   struct SimpleTask : public Task {
@@ -270,12 +273,16 @@ class ARROW_EXPORT ThrottledAsyncTaskScheduler : public AsyncTaskScheduler {
   /// Pause the throttle
   ///
   /// Any tasks that have been submitted already will continue.  However, no new tasks
-  /// will be run until the throttle is resumed.
+  /// will be run until the throttle is resumed.\
+  ///
+  /// This method should be idempotent
   virtual void Pause() = 0;
   /// Resume the throttle
   ///
   /// Allows taks to be submitted again.  If there is a max_concurrent_cost limit then
   /// it will still apply.
+  ///
+  /// This method should be idempotent
   virtual void Resume() = 0;
 
   /// Create a throttled view of a scheduler
@@ -377,7 +384,8 @@ ARROW_EXPORT std::unique_ptr<ThrottledAsyncTaskScheduler> MakeThrottledAsyncTask
 template <typename T>
 bool AsyncTaskScheduler::AddAsyncGenerator(std::function<Future<T>()> generator,
                                            std::function<Status(const T&)> visitor,
-                                           std::string_view name) {
+                                           std::string_view name,
+                                           std::function<Status()> on_completion) {
   struct State {
     State(std::function<Future<T>()> generator, std::function<Status(const T&)> visitor,
           std::unique_ptr<AsyncTaskGroup> task_group, std::string_view name)
@@ -412,8 +420,10 @@ bool AsyncTaskScheduler::AddAsyncGenerator(std::function<Future<T>()> generator,
           task_completion.MarkFinished(std::move(visit_st));
           return;
         }
-        state_holder->task_group->AddTask(
-            std::make_unique<SubmitTask>(std::move(state_holder)));
+        State* state_view = state_holder.get();
+        std::unique_ptr<SubmitTask> next_task =
+            std::make_unique<SubmitTask>(std::move(state_holder));
+        state_view->task_group->AddTask(std::move(next_task));
         task_completion.MarkFinished();
       }
       std::unique_ptr<State> state_holder;
@@ -443,8 +453,12 @@ bool AsyncTaskScheduler::AddAsyncGenerator(std::function<Future<T>()> generator,
 
     std::unique_ptr<State> state_holder;
   };
+  std::function<Status()> finish_cb = std::move(on_completion);
+  if (!finish_cb) {
+    finish_cb = [] { return Status::OK(); };
+  }
   std::unique_ptr<AsyncTaskGroup> task_group =
-      AsyncTaskGroup::Make(this, [] { return Status::OK(); });
+      AsyncTaskGroup::Make(this, std::move(finish_cb));
   AsyncTaskGroup* task_group_view = task_group.get();
   std::unique_ptr<State> state_holder = std::make_unique<State>(
       std::move(generator), std::move(visitor), std::move(task_group), name);

--- a/cpp/src/arrow/util/async_util.h
+++ b/cpp/src/arrow/util/async_util.h
@@ -273,7 +273,7 @@ class ARROW_EXPORT ThrottledAsyncTaskScheduler : public AsyncTaskScheduler {
   /// Pause the throttle
   ///
   /// Any tasks that have been submitted already will continue.  However, no new tasks
-  /// will be run until the throttle is resumed.\
+  /// will be run until the throttle is resumed.
   ///
   /// This method should be idempotent
   virtual void Pause() = 0;

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -16,7 +16,6 @@
 // under the License.
 
 #include "parquet/arrow/reader.h"
-#include <sys/types.h>
 
 #include <algorithm>
 #include <cstring>

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -16,10 +16,12 @@
 // under the License.
 
 #include "parquet/arrow/reader.h"
+#include <sys/types.h>
 
 #include <algorithm>
 #include <cstring>
 #include <memory>
+#include <queue>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -58,6 +60,7 @@ using arrow::Future;
 using arrow::Int32Array;
 using arrow::ListArray;
 using arrow::MemoryPool;
+using arrow::RecordBatch;
 using arrow::RecordBatchReader;
 using arrow::ResizableBuffer;
 using arrow::Result;
@@ -326,6 +329,23 @@ class FileReaderImpl : public FileReader {
     return ReadRowGroups(row_groups, Iota(reader_->metadata()->num_columns()), table);
   }
 
+  Result<AsyncBatchGenerator> DoReadRowGroupsAsync(
+      const std::vector<int>& row_groups, const std::vector<int>& indices,
+      ::arrow::internal::Executor* cpu_executor, bool allow_sliced_batches);
+
+  AsyncBatchGenerator ReadRowGroupsAsync(const std::vector<int>& row_groups,
+                                         const std::vector<int>& indices,
+                                         ::arrow::internal::Executor* cpu_executor,
+                                         bool allow_sliced_batches) override {
+    Result<AsyncBatchGenerator> batch_gen =
+        DoReadRowGroupsAsync(row_groups, indices, cpu_executor, allow_sliced_batches);
+    if (batch_gen.ok()) {
+      return batch_gen.MoveValueUnsafe();
+    }
+    return ::arrow::MakeFailingGenerator<std::shared_ptr<RecordBatch>>(
+        batch_gen.status());
+  }
+
   Status ReadRowGroup(int row_group_index, const std::vector<int>& column_indices,
                       std::shared_ptr<Table>* out) override {
     return ReadRowGroups({row_group_index}, column_indices, out);
@@ -333,6 +353,28 @@ class FileReaderImpl : public FileReader {
 
   Status ReadRowGroup(int i, std::shared_ptr<Table>* table) override {
     return ReadRowGroup(i, Iota(reader_->metadata()->num_columns()), table);
+  }
+
+  AsyncBatchGenerator ReadRowGroupAsync(int row_group_index,
+                                        ::arrow::internal::Executor* cpu_executor,
+                                        bool allow_sliced_batches) override {
+    return ReadRowGroupsAsync({row_group_index}, Iota(reader_->metadata()->num_columns()),
+                              cpu_executor, allow_sliced_batches);
+  }
+
+  AsyncBatchGenerator ReadRowGroupAsync(int row_group_index,
+                                        const std::vector<int>& column_indices,
+                                        ::arrow::internal::Executor* cpu_executor,
+                                        bool allow_sliced_batches) override {
+    return ReadRowGroupsAsync({row_group_index}, column_indices, cpu_executor,
+                              allow_sliced_batches);
+  }
+
+  AsyncBatchGenerator ReadRowGroupsAsync(const std::vector<int>& row_groups,
+                                         ::arrow::internal::Executor* cpu_executor,
+                                         bool allow_sliced_batches) override {
+    return ReadRowGroupsAsync(row_groups, Iota(reader_->metadata()->num_columns()),
+                              cpu_executor, allow_sliced_batches);
   }
 
   Status GetRecordBatchReader(const std::vector<int>& row_group_indices,
@@ -1241,6 +1283,124 @@ Status FileReaderImpl::ReadRowGroups(const std::vector<int>& row_groups,
                              /*cpu_executor=*/nullptr);
   ARROW_ASSIGN_OR_RAISE(*out, fut.MoveResult());
   return Status::OK();
+}
+
+struct AsyncBatchGeneratorState {
+  ::arrow::internal::Executor* io_executor;
+  ::arrow::internal::Executor* cpu_executor;
+  std::vector<std::shared_ptr<ColumnReaderImpl>> column_readers;
+  std::queue<std::shared_ptr<RecordBatch>> overflow;
+  std::shared_ptr<::arrow::Schema> schema;
+  int64_t batch_size;
+  int64_t rows_remaining;
+  bool use_threads;
+  bool allow_sliced_batches;
+};
+
+class AsyncBatchGeneratorImpl {
+ public:
+  explicit AsyncBatchGeneratorImpl(std::shared_ptr<AsyncBatchGeneratorState> state)
+      : state_(std::move(state)) {}
+  Future<std::shared_ptr<RecordBatch>> operator()() {
+    if (!state_->overflow.empty()) {
+      std::shared_ptr<RecordBatch> next = std::move(state_->overflow.front());
+      state_->overflow.pop();
+      return next;
+    }
+
+    if (state_->rows_remaining == 0) {
+      // Exhausted
+      return Future<std::shared_ptr<RecordBatch>>::MakeFinished(
+          ::arrow::IterationEnd<std::shared_ptr<RecordBatch>>());
+    }
+
+    int64_t rows_in_batch = std::min(state_->rows_remaining, state_->batch_size);
+    state_->rows_remaining -= rows_in_batch;
+
+    // We read the columns in parallel.  Each reader returns a chunked array.  This is
+    // probably because we might need to chunk a column if that column is too large.  We
+    // do provide a batch size but perhaps that column has massive strings or something
+    // like that.
+    Future<std::vector<std::shared_ptr<ChunkedArray>>> chunked_arrays_fut =
+        ::arrow::internal::OptionalParallelForAsync(
+            state_->use_threads, state_->column_readers,
+            [rows_in_batch](std::size_t, std::shared_ptr<ColumnReaderImpl> column_reader)
+                -> Result<std::shared_ptr<ChunkedArray>> {
+              std::shared_ptr<ChunkedArray> chunked_array;
+              ARROW_RETURN_NOT_OK(
+                  column_reader->NextBatch(rows_in_batch, &chunked_array));
+              return chunked_array;
+            });
+
+    // Grab the first batch of data and return it.  If there is more than one batch then
+    // throw the reamining batches into overflow and they will be fetched on the next call
+    return chunked_arrays_fut.Then(
+        [state = state_,
+         rows_in_batch](const std::vector<std::shared_ptr<ChunkedArray>>& chunks)
+            -> Result<std::shared_ptr<RecordBatch>> {
+          std::shared_ptr<Table> table =
+              Table::Make(state->schema, chunks, rows_in_batch);
+          ::arrow::TableBatchReader batch_reader(*table);
+          std::shared_ptr<RecordBatch> first;
+          while (true) {
+            ARROW_ASSIGN_OR_RAISE(std::shared_ptr<RecordBatch> next_batch,
+                                  batch_reader.Next());
+            if (!next_batch) {
+              break;
+            }
+            if (first) {
+              if (!state->allow_sliced_batches) {
+                return Status::Invalid(
+                    "The setting allow_sliced_batches is set to false and data was "
+                    "encountered that was too large to fit in a single batch.");
+              }
+              state->overflow.push(std::move(next_batch));
+            } else {
+              first = std::move(next_batch);
+            }
+          }
+          if (!first) {
+            // TODO(weston): Test this case
+            return Status::Invalid("Unexpected empty row group");
+          }
+          return first;
+        });
+  }
+
+ private:
+  std::shared_ptr<AsyncBatchGeneratorState> state_;
+};
+
+Result<FileReaderImpl::AsyncBatchGenerator> FileReaderImpl::DoReadRowGroupsAsync(
+    const std::vector<int>& row_groups, const std::vector<int>& column_indices,
+    ::arrow::internal::Executor* cpu_executor, bool allow_sliced_batches) {
+  RETURN_NOT_OK(BoundsCheck(row_groups, column_indices));
+
+  if (reader_properties_.pre_buffer()) {
+    BEGIN_PARQUET_CATCH_EXCEPTIONS
+    parquet_reader()->PreBuffer(row_groups, column_indices,
+                                reader_properties_.io_context(),
+                                reader_properties_.cache_options());
+    END_PARQUET_CATCH_EXCEPTIONS
+  }
+
+  auto generator_state = std::make_shared<AsyncBatchGeneratorState>();
+  generator_state->io_executor = reader_properties_.io_context().executor();
+  generator_state->cpu_executor = cpu_executor;
+  generator_state->use_threads = reader_properties_.use_threads();
+  generator_state->allow_sliced_batches = allow_sliced_batches;
+  RETURN_NOT_OK(GetFieldReaders(column_indices, row_groups,
+                                &generator_state->column_readers,
+                                &generator_state->schema));
+
+  generator_state->batch_size = properties().batch_size();
+  generator_state->rows_remaining = 0;
+  for (int row_group : row_groups) {
+    generator_state->rows_remaining +=
+        parquet_reader()->metadata()->RowGroup(row_group)->num_rows();
+  }
+
+  return AsyncBatchGeneratorImpl(std::move(generator_state));
 }
 
 Future<std::shared_ptr<Table>> FileReaderImpl::DecodeRowGroups(

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -265,6 +265,9 @@ class PARQUET_EXPORT FileReader {
   ///
   /// \param i the index of the row group to read
   /// \param cpu_executor an executor to use to run CPU tasks
+  /// \param allow_sliced_batches if false, an error is raised if a batch has too much
+  ///                             data for the given batch size.  If true, smaller
+  ///                             batches will be returned instead.
   virtual AsyncBatchGenerator ReadRowGroupAsync(int i,
                                                 ::arrow::internal::Executor* cpu_executor,
                                                 bool allow_sliced_batches = false) = 0;
@@ -276,6 +279,9 @@ class PARQUET_EXPORT FileReader {
   /// \param i the index of the row group to read
   /// \param column_indices leaf-indices of the columns to read
   /// \param cpu_executor an executor to use to run CPU tasks
+  /// \param allow_sliced_batches if false, an error is raised if a batch has too much
+  ///                             data for the given batch size.  If true, smaller
+  ///                             batches will be returned instead.
   virtual AsyncBatchGenerator ReadRowGroupAsync(int i,
                                                 const std::vector<int>& column_indices,
                                                 ::arrow::internal::Executor* cpu_executor,
@@ -287,6 +293,9 @@ class PARQUET_EXPORT FileReader {
   ///
   /// \param row_groups indices of the row groups to read
   /// \param cpu_executor an executor to use to run CPU tasks
+  /// \param allow_sliced_batches if false, an error is raised if a batch has too much
+  ///                             data for the given batch size.  If true, smaller
+  ///                             batches will be returned instead.
   virtual AsyncBatchGenerator ReadRowGroupsAsync(
       const std::vector<int>& row_groups, ::arrow::internal::Executor* cpu_executor,
       bool allow_sliced_batches = false) = 0;
@@ -308,15 +317,17 @@ class PARQUET_EXPORT FileReader {
   /// smaller.  This can happen, for example, when there is not enough data or when a
   /// string column is too large to fit into a single batch.  The parameter
   /// `allow_sliced_batches` can be set to false to disallow this later case.  This can be
-  /// useful when you need to know exactly how many batches you will get from a scan
-  /// before you start.
+  /// useful when you need to know exactly how many batches you will get from the
+  /// operation before you start.
   ///
   /// The I/O executor is obtained from the I/O context in the reader properties.
   ///
   /// \param row_groups indices of the row groups to read
   /// \param column_indices indices of the columns to read
   /// \param cpu_executor an executor to use to run CPU tasks
-  /// \param allow_sliced_batches indicates whether or not we can slice large batches
+  /// \param allow_sliced_batches if false, an error is raised if a batch has too much
+  ///                             data for the given batch size.  If false, smaller
+  ///                             batches will be returned instead.
   virtual AsyncBatchGenerator ReadRowGroupsAsync(
       const std::vector<int>& row_groups, const std::vector<int>& column_indices,
       ::arrow::internal::Executor* cpu_executor, bool allow_sliced_batches = false) = 0;

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -256,6 +256,71 @@ class PARQUET_EXPORT FileReader {
   virtual ::arrow::Status ReadRowGroups(const std::vector<int>& row_groups,
                                         std::shared_ptr<::arrow::Table>* out) = 0;
 
+  using AsyncBatchGenerator =
+      std::function<::arrow::Future<std::shared_ptr<::arrow::RecordBatch>>()>;
+
+  /// \brief Read a single row group from the file
+  ///
+  /// \see ReadRowGroupsAsync for operation details
+  ///
+  /// \param i the index of the row group to read
+  /// \param cpu_executor an executor to use to run CPU tasks
+  virtual AsyncBatchGenerator ReadRowGroupAsync(int i,
+                                                ::arrow::internal::Executor* cpu_executor,
+                                                bool allow_sliced_batches = false) = 0;
+  /// \brief Read some columns from a single row group from the file
+  ///
+  /// \see ReadRowGroupsAsync for operation details
+  /// \see ReadTable for details on how column indices are resolved
+  ///
+  /// \param i the index of the row group to read
+  /// \param column_indices leaf-indices of the columns to read
+  /// \param cpu_executor an executor to use to run CPU tasks
+  virtual AsyncBatchGenerator ReadRowGroupAsync(int i,
+                                                const std::vector<int>& column_indices,
+                                                ::arrow::internal::Executor* cpu_executor,
+                                                bool allow_sliced_batches = false) = 0;
+
+  /// \brief Read row groups from the file
+  ///
+  /// \see ReadRowGroupsAsync for operation details
+  ///
+  /// \param row_groups indices of the row groups to read
+  /// \param cpu_executor an executor to use to run CPU tasks
+  virtual AsyncBatchGenerator ReadRowGroupsAsync(
+      const std::vector<int>& row_groups, ::arrow::internal::Executor* cpu_executor,
+      bool allow_sliced_batches = false) = 0;
+
+  /// \brief Read some columns from the given rows groups from the file
+  ///
+  /// If pre-buffering is enabled then all of the data will be read using the pre-buffer
+  /// cache. See ParquetFileReader::PreBuffer for details on how this affects memory and
+  /// performance.
+  ///
+  /// This operation is not perfectly async.  The read from disk will be done on an I/O
+  /// thread, which is correct.  However, compression and  column decoding is also done on
+  /// the I/O thread which may not be ideal.  The stage after that (transferring the
+  /// decoded data into Arrow structures and fulfilling the future) should be done as a
+  /// new task on the cpu_executor.
+  ///
+  /// The returned generator will respect the batch size set in the reader properties.
+  /// Batches will not be larger than the given batch size.  However, batches may be
+  /// smaller.  This can happen, for example, when there is not enough data or when a
+  /// string column is too large to fit into a single batch.  The parameter
+  /// `allow_sliced_batches` can be set to false to disallow this later case.  This can be
+  /// useful when you need to know exactly how many batches you will get from a scan
+  /// before you start.
+  ///
+  /// The I/O executor is obtained from the I/O context in the reader properties.
+  ///
+  /// \param row_groups indices of the row groups to read
+  /// \param column_indices indices of the columns to read
+  /// \param cpu_executor an executor to use to run CPU tasks
+  /// \param allow_sliced_batches indicates whether or not we can slice large batches
+  virtual AsyncBatchGenerator ReadRowGroupsAsync(
+      const std::vector<int>& row_groups, const std::vector<int>& column_indices,
+      ::arrow::internal::Executor* cpu_executor, bool allow_sliced_batches = false) = 0;
+
   /// \brief Scan file contents with one thread, return number of rows
   virtual ::arrow::Status ScanContents(std::vector<int> columns,
                                        const int32_t column_batch_size,


### PR DESCRIPTION
### Rationale for this change

This ended up being considerably more change than just connecting parquet to the new scan node.  In order to do this I had to refactor the scan node itself somewhat.  It introduces the concept of scan tasks (or maybe scan streams would be a better name) to help clarify the concept of a row group (which I didn't have to worry about with CSV).  I also introduced the staging area which is a slightly different approach to sequencing that I think will be much simpler.

### What changes are included in this PR?

The new scan node now supports the parquet format.

### Are these changes tested?

Yes

### Are there any user-facing changes?

There are breaking changes to the scan2 node but this feature hasn't really been released yet.
* Closes: #32566