### PR TITLE
GH-35891: [Doc][Python] Update link to Parquet C++ repository

### DIFF
--- a/docs/source/python/parquet.rst
+++ b/docs/source/python/parquet.rst
@@ -32,7 +32,8 @@ performance data IO.
 
 Apache Arrow is an ideal in-memory transport layer for data that is being read
 or written with Parquet files. We have been concurrently developing the `C++
-implementation of Apache Parquet <http://github.com/apache/parquet-cpp>`_,
+implementation of 
+Apache Parquet <https://github.com/apache/arrow/tree/main/cpp/tools/parquet>`_,
 which includes a native, multithreaded C++ adapter to and from in-memory Arrow
 data. PyArrow includes Python bindings to this code, which thus enables reading
 and writing Parquet files with pandas as well.


### PR DESCRIPTION
Remove old link to repository that is not updated



* Closes: #35891