### PR TITLE
MINOR: [Go] Use `arrow.ListLikeType`

### DIFF
--- a/go/arrow/ipc/file_reader.go
+++ b/go/arrow/ipc/file_reader.go
@@ -595,12 +595,7 @@ func (ctx *arrayLoaderContext) loadMap(dt *arrow.MapType) arrow.ArrayData {
 	return array.NewData(dt, int(field.Length()), buffers, []arrow.ArrayData{sub}, int(field.NullCount()), 0)
 }
 
-type listLike interface {
-	arrow.DataType
-	Elem() arrow.DataType
-}
-
-func (ctx *arrayLoaderContext) loadList(dt listLike) arrow.ArrayData {
+func (ctx *arrayLoaderContext) loadList(dt arrow.ListLikeType) arrow.ArrayData {
 	field, buffers := ctx.loadCommon(dt.ID(), 2)
 	buffers = append(buffers, ctx.buffer())
 	defer releaseBuffers(buffers)


### PR DESCRIPTION
### Rationale for this change

Follow-up for #35885

### What changes are included in this PR?

Removed `listLikeType` interface from `ipc.go` & swapped it for `arrow.ListLikeType`.

### Are these changes tested?

It's only a replace of the interface name.

### Are there any user-facing changes?

No.

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->