### PR TITLE
GH-35909: [Go] Deprecate `arrow.MapType.ValueField` & `arrow.MapType.ValueType` methods

### DIFF
--- a/go/arrow/array/map.go
+++ b/go/arrow/array/map.go
@@ -150,7 +150,7 @@ type MapBuilder struct {
 func NewMapBuilder(mem memory.Allocator, keytype, itemtype arrow.DataType, keysSorted bool) *MapBuilder {
 	etype := arrow.MapOf(keytype, itemtype)
 	etype.KeysSorted = keysSorted
-	listBldr := NewListBuilder(mem, etype.ValueType())
+	listBldr := NewListBuilder(mem, etype.Elem())
 	keyBldr := listBldr.ValueBuilder().(*StructBuilder).FieldBuilder(0)
 	keyBldr.Retain()
 	itemBldr := listBldr.ValueBuilder().(*StructBuilder).FieldBuilder(1)
@@ -167,7 +167,7 @@ func NewMapBuilder(mem memory.Allocator, keytype, itemtype arrow.DataType, keysS
 }
 
 func NewMapBuilderWithType(mem memory.Allocator, dt *arrow.MapType) *MapBuilder {
-	listBldr := NewListBuilder(mem, dt.ValueType())
+	listBldr := NewListBuilder(mem, dt.Elem())
 	keyBldr := listBldr.ValueBuilder().(*StructBuilder).FieldBuilder(0)
 	keyBldr.Retain()
 	itemBldr := listBldr.ValueBuilder().(*StructBuilder).FieldBuilder(1)
@@ -178,7 +178,7 @@ func NewMapBuilderWithType(mem memory.Allocator, dt *arrow.MapType) *MapBuilder 
 		itemBuilder: itemBldr,
 		etype:       dt,
 		keytype:     dt.KeyType(),
-		itemtype:    dt.ValueType(),
+		itemtype:    dt.ItemType(),
 		keysSorted:  dt.KeysSorted,
 	}
 }

--- a/go/arrow/cdata/cdata.go
+++ b/go/arrow/cdata/cdata.go
@@ -359,7 +359,7 @@ func (imp *cimporter) doImportChildren() error {
 			imp.children[i].importChild(imp, c)
 		}
 	case arrow.MAP: // only one child to import, it's a struct array
-		imp.children[0].dt = imp.dt.(*arrow.MapType).ValueType()
+		imp.children[0].dt = imp.dt.(*arrow.MapType).Elem()
 		if err := imp.children[0].importChild(imp, children[0]); err != nil {
 			return err
 		}

--- a/go/arrow/datatype_nested.go
+++ b/go/arrow/datatype_nested.go
@@ -37,6 +37,7 @@ type (
 	ListLikeType interface {
 		DataType
 		Elem() DataType
+		ElemField() Field
 	}
 )
 
@@ -400,6 +401,9 @@ func (t *MapType) ValueField() Field      { return Field{Name: "entries", Type: 
 
 // Elem returns the MapType's element type (if treating MapType as ListLikeType)
 func (t *MapType) Elem() DataType { return t.ValueType() }
+
+// ElemField returns the MapType's element field (if treating MapType as ListLikeType)
+func (t *MapType) ElemField() Field { return t.ValueField() }
 
 func (t *MapType) SetItemNullable(nullable bool) {
 	t.value.Elem().(*StructType).fields[1].Nullable = nullable

--- a/go/arrow/datatype_nested.go
+++ b/go/arrow/datatype_nested.go
@@ -392,18 +392,22 @@ func (t *MapType) String() string {
 	return o.String()
 }
 
-func (t *MapType) KeyField() Field        { return t.value.Elem().(*StructType).Field(0) }
-func (t *MapType) KeyType() DataType      { return t.KeyField().Type }
-func (t *MapType) ItemField() Field       { return t.value.Elem().(*StructType).Field(1) }
-func (t *MapType) ItemType() DataType     { return t.ItemField().Type }
-func (t *MapType) ValueType() *StructType { return t.value.Elem().(*StructType) }
-func (t *MapType) ValueField() Field      { return Field{Name: "entries", Type: t.ValueType()} }
+func (t *MapType) KeyField() Field    { return t.value.Elem().(*StructType).Field(0) }
+func (t *MapType) KeyType() DataType  { return t.KeyField().Type }
+func (t *MapType) ItemField() Field   { return t.value.Elem().(*StructType).Field(1) }
+func (t *MapType) ItemType() DataType { return t.ItemField().Type }
+
+// Deprecated: use MapType.Elem().(*StructType) instead
+func (t *MapType) ValueType() *StructType { return t.Elem().(*StructType) }
+
+// Deprecated: use MapType.ElemField() instead
+func (t *MapType) ValueField() Field { return t.ElemField() }
 
 // Elem returns the MapType's element type (if treating MapType as ListLikeType)
-func (t *MapType) Elem() DataType { return t.ValueType() }
+func (t *MapType) Elem() DataType { return t.value.Elem() }
 
 // ElemField returns the MapType's element field (if treating MapType as ListLikeType)
-func (t *MapType) ElemField() Field { return t.ValueField() }
+func (t *MapType) ElemField() Field { return Field{Name: "entries", Type: t.Elem()} }
 
 func (t *MapType) SetItemNullable(nullable bool) {
 	t.value.Elem().(*StructType).fields[1].Nullable = nullable
@@ -423,7 +427,7 @@ func (t *MapType) Fingerprint() string {
 	return fingerprint + "{" + keyFingerprint + itemFingerprint + "}"
 }
 
-func (t *MapType) Fields() []Field { return []Field{t.ValueField()} }
+func (t *MapType) Fields() []Field { return []Field{t.ElemField()} }
 
 func (t *MapType) Layout() DataTypeLayout {
 	return t.value.Layout()

--- a/go/arrow/datatype_nested_test.go
+++ b/go/arrow/datatype_nested_test.go
@@ -417,7 +417,7 @@ func TestMapOf(t *testing.T) {
 				t.Fatalf("invalid item type. got=%q, want=%q", got, want)
 			}
 
-			if got, want := got.ValueType(), StructOf(got.KeyField(), got.ItemField()); !TypeEqual(got, want) {
+			if got, want := got.Elem(), StructOf(got.KeyField(), got.ItemField()); !TypeEqual(got, want) {
 				t.Fatalf("invalid value type. got=%q, want=%q", got, want)
 			}
 
@@ -477,7 +477,7 @@ func TestMapOfWithMetadata(t *testing.T) {
 				t.Fatalf("invalid item type. got=%q, want=%q", got, want)
 			}
 
-			if got, want := got.ValueType(), StructOf(got.KeyField(), got.ItemField()); !TypeEqual(got, want) {
+			if got, want := got.Elem(), StructOf(got.KeyField(), got.ItemField()); !TypeEqual(got, want) {
 				t.Fatalf("invalid value type. got=%q, want=%q", got, want)
 			}
 
@@ -485,11 +485,11 @@ func TestMapOfWithMetadata(t *testing.T) {
 				t.Fatalf("invalid String() result. got=%q, want=%q", got, want)
 			}
 
-			if !reflect.DeepEqual(got.ValueType().fields[0].Metadata, tc.keyMetadata) {
-				t.Fatalf("invalid key metadata. got=%v, want=%v", got.ValueType().fields[0].Metadata, tc.keyMetadata)
+			if !reflect.DeepEqual(got.Elem().(*StructType).fields[0].Metadata, tc.keyMetadata) {
+				t.Fatalf("invalid key metadata. got=%v, want=%v", got.Elem().(*StructType).fields[0].Metadata, tc.keyMetadata)
 			}
-			if !reflect.DeepEqual(got.ValueType().fields[1].Metadata, tc.itemMetadata) {
-				t.Fatalf("invalid item metadata. got=%v, want=%v", got.ValueType().fields[1].Metadata, tc.itemMetadata)
+			if !reflect.DeepEqual(got.Elem().(*StructType).fields[1].Metadata, tc.itemMetadata) {
+				t.Fatalf("invalid item metadata. got=%v, want=%v", got.Elem().(*StructType).fields[1].Metadata, tc.itemMetadata)
 			}
 		})
 	}

--- a/go/arrow/internal/arrdata/arrdata.go
+++ b/go/arrow/internal/arrdata/arrdata.go
@@ -745,7 +745,7 @@ func makeMapsRecords() []arrow.Record {
 	chunks := [][]arrow.Array{
 		{
 			mapOf(mem, dtype.KeysSorted, []arrow.Array{
-				structOf(mem, dtype.ValueType(), [][]arrow.Array{
+				structOf(mem, dtype.Elem().(*arrow.StructType), [][]arrow.Array{
 					{
 						arrayOf(mem, []int32{-1, -2, -3, -4, -5}, nil),
 						arrayOf(mem, []string{"111", "222", "333", "444", "555"}, mask[:5]),
@@ -767,7 +767,7 @@ func makeMapsRecords() []arrow.Record {
 						arrayOf(mem, []string{"4111", "4222", "4333", "4444", "4555"}, mask[:5]),
 					},
 				}, nil),
-				structOf(mem, dtype.ValueType(), [][]arrow.Array{
+				structOf(mem, dtype.Elem().(*arrow.StructType), [][]arrow.Array{
 					{
 						arrayOf(mem, []int32{1, 2, 3, 4, 5}, nil),
 						arrayOf(mem, []string{"-111", "-222", "-333", "-444", "-555"}, mask[:5]),
@@ -793,7 +793,7 @@ func makeMapsRecords() []arrow.Record {
 		},
 		{
 			mapOf(mem, dtype.KeysSorted, []arrow.Array{
-				structOf(mem, dtype.ValueType(), [][]arrow.Array{
+				structOf(mem, dtype.Elem().(*arrow.StructType), [][]arrow.Array{
 					{
 						arrayOf(mem, []int32{1, 2, 3, 4, 5}, nil),
 						arrayOf(mem, []string{"-111", "-222", "-333", "-444", "-555"}, mask[:5]),
@@ -815,7 +815,7 @@ func makeMapsRecords() []arrow.Record {
 						arrayOf(mem, []string{"-4111", "-4222", "-4333", "-4444", "-4555"}, mask[:5]),
 					},
 				}, nil),
-				structOf(mem, dtype.ValueType(), [][]arrow.Array{
+				structOf(mem, dtype.Elem().(*arrow.StructType), [][]arrow.Array{
 					{
 						arrayOf(mem, []int32{-1, -2, -3, -4, -5}, nil),
 						arrayOf(mem, []string{"111", "222", "333", "444", "555"}, mask[:5]),

--- a/go/arrow/internal/arrjson/arrjson.go
+++ b/go/arrow/internal/arrjson/arrjson.go
@@ -1098,7 +1098,7 @@ func arrayFromJSON(mem memory.Allocator, dt arrow.DataType, arr Array) arrow.Arr
 
 	case *arrow.MapType:
 		valids := validsFromJSON(arr.Valids)
-		elems := arrayFromJSON(mem, dt.ValueType(), arr.Children[0])
+		elems := arrayFromJSON(mem, dt.Elem(), arr.Children[0])
 		defer elems.Release()
 
 		bitmap := validsToBitmap(valids, mem)
@@ -1429,7 +1429,7 @@ func arrayToJSON(field arrow.Field, arr arrow.Array) Array {
 			Valids: validsToJSON(arr),
 			Offset: arr.Offsets(),
 			Children: []Array{
-				arrayToJSON(arrow.Field{Name: "entries", Type: arr.DataType().(*arrow.MapType).ValueType()}, arr.ListValues()),
+				arrayToJSON(arrow.Field{Name: "entries", Type: arr.DataType().(*arrow.MapType).Elem()}, arr.ListValues()),
 			},
 		}
 		return o

--- a/go/arrow/ipc/file_reader.go
+++ b/go/arrow/ipc/file_reader.go
@@ -589,7 +589,7 @@ func (ctx *arrayLoaderContext) loadMap(dt *arrow.MapType) arrow.ArrayData {
 	buffers = append(buffers, ctx.buffer())
 	defer releaseBuffers(buffers)
 
-	sub := ctx.loadChild(dt.ValueType())
+	sub := ctx.loadChild(dt.Elem())
 	defer sub.Release()
 
 	return array.NewData(dt, int(field.Length()), buffers, []arrow.ArrayData{sub}, int(field.NullCount()), 0)

--- a/go/arrow/ipc/metadata.go
+++ b/go/arrow/ipc/metadata.go
@@ -420,7 +420,7 @@ func (fv *fieldVisitor) visit(field arrow.Field) {
 
 	case *arrow.MapType:
 		fv.dtype = flatbuf.TypeMap
-		fv.kids = append(fv.kids, fieldToFB(fv.b, fv.pos.Child(0), dt.ValueField(), fv.memo))
+		fv.kids = append(fv.kids, fieldToFB(fv.b, fv.pos.Child(0), dt.ElemField(), fv.memo))
 		flatbuf.MapStart(fv.b)
 		flatbuf.MapAddKeysSorted(fv.b, dt.KeysSorted)
 		fv.offset = flatbuf.MapEnd(fv.b)

--- a/go/arrow/scalar/nested.go
+++ b/go/arrow/scalar/nested.go
@@ -69,20 +69,7 @@ func (l *List) Validate() (err error) {
 		return
 	}
 
-	var (
-		valueType arrow.DataType
-	)
-
-	switch dt := l.Type.(type) {
-	case *arrow.ListType:
-		valueType = dt.Elem()
-	case *arrow.LargeListType:
-		valueType = dt.Elem()
-	case *arrow.FixedSizeListType:
-		valueType = dt.Elem()
-	case *arrow.MapType:
-		valueType = dt.ValueType()
-	}
+	valueType := l.Type.(arrow.ListLikeType).Elem()
 	listType := l.Type
 
 	if !arrow.TypeEqual(l.Value.DataType(), valueType) {

--- a/go/arrow/scalar/parse.go
+++ b/go/arrow/scalar/parse.go
@@ -512,7 +512,7 @@ func MakeScalarParam(val interface{}, dt arrow.DataType) (Scalar, error) {
 			}
 			return NewFixedSizeListScalarWithType(v, dt), nil
 		case arrow.MAP:
-			if !arrow.TypeEqual(dt.(*arrow.MapType).ValueType(), v.DataType()) {
+			if !arrow.TypeEqual(dt.(*arrow.MapType).Elem(), v.DataType()) {
 				return nil, fmt.Errorf("inconsistent type for map scalar type")
 			}
 			return NewMapScalar(v), nil

--- a/go/parquet/pqarrow/encode_arrow.go
+++ b/go/parquet/pqarrow/encode_arrow.go
@@ -36,6 +36,10 @@ import (
 
 // get the count of the number of leaf arrays for the type
 func calcLeafCount(dt arrow.DataType) int {
+	if dt, ok := dt.(arrow.ListLikeType); ok {
+		return calcLeafCount(dt.Elem())
+	}
+
 	switch dt.ID() {
 	case arrow.EXTENSION:
 		return calcLeafCount(dt.(arrow.ExtensionType).StorageType())
@@ -43,12 +47,6 @@ func calcLeafCount(dt arrow.DataType) int {
 		panic("arrow type not implemented")
 	case arrow.DICTIONARY:
 		return calcLeafCount(dt.(*arrow.DictionaryType).ValueType)
-	case arrow.LIST:
-		return calcLeafCount(dt.(*arrow.ListType).Elem())
-	case arrow.FIXED_SIZE_LIST:
-		return calcLeafCount(dt.(*arrow.FixedSizeListType).Elem())
-	case arrow.MAP:
-		return calcLeafCount(dt.(*arrow.MapType).ValueType())
 	case arrow.STRUCT:
 		nleaves := 0
 		for _, f := range dt.(*arrow.StructType).Fields() {

--- a/go/parquet/pqarrow/schema.go
+++ b/go/parquet/pqarrow/schema.go
@@ -1002,7 +1002,7 @@ func applyOriginalStorageMetadata(origin arrow.Field, inferred *SchemaField) (mo
 			}
 			inferred.Field.Type = factory(modifiedChildren)
 		}
-	case arrow.FIXED_SIZE_LIST, arrow.LIST, arrow.MAP:
+	case arrow.FIXED_SIZE_LIST, arrow.LIST, arrow.LARGE_LIST, arrow.MAP: // arrow.ListLike
 		if nchildren != 1 {
 			return
 		}
@@ -1012,17 +1012,9 @@ func applyOriginalStorageMetadata(origin arrow.Field, inferred *SchemaField) (mo
 		}
 
 		modified = origin.Type.ID() != inferred.Field.Type.ID()
-		var childModified bool
-		switch typ := origin.Type.(type) {
-		case *arrow.FixedSizeListType:
-			childModified, err = applyOriginalMetadata(arrow.Field{Type: typ.Elem()}, &inferred.Children[0])
-		case *arrow.ListType:
-			childModified, err = applyOriginalMetadata(arrow.Field{Type: typ.Elem()}, &inferred.Children[0])
-		case *arrow.MapType:
-			childModified, err = applyOriginalMetadata(arrow.Field{Type: typ.ValueType()}, &inferred.Children[0])
-		}
+		childModified, err := applyOriginalMetadata(arrow.Field{Type: origin.Type.(arrow.ListLikeType).Elem()}, &inferred.Children[0])
 		if err != nil {
-			return
+			return modified, err
 		}
 		modified = modified || childModified
 		if modified {


### PR DESCRIPTION
### Rationale for this change

Follow-up for #35885 

### What changes are included in this PR?

* Added `ElemField() Field` to `arrow.ListLikeType` interface
* Added `ElemField() Field` to `arrow.MapType` implementation
* Added deprecation notice to `arrow.MapType.ValueField` & `arrow.MapType.ValueType`
* Fixed a bug in `go/arrow/array/map.go` (`NewMapBuilderWithType` used `ValueType` instead of `ItemType`)

### Are these changes tested?

Compile-time assertion for corresponding types.

### Are there any user-facing changes?

* Added `ElemField() Field` to `arrow.ListLikeType` interface
* Added `ElemField() Field` to `arrow.MapType` implementation
* Added deprecation notice to `arrow.MapType.ValueField` & `arrow.MapType.ValueType`

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #35909