### PR TITLE
GH-35868: [C++] Occasional TSAN failure on asof-join-node-test

### DIFF
--- a/cpp/src/arrow/acero/asof_join_node.cc
+++ b/cpp/src/arrow/acero/asof_join_node.cc
@@ -529,7 +529,7 @@ class KeyHasher {
   size_t index_;
   std::vector<col_index_t> indices_;
   std::vector<KeyColumnMetadata> metadata_;
-  const RecordBatch* batch_;
+  std::atomic<const RecordBatch*> batch_;
   std::vector<HashType> hashes_;
   LightContext ctx_;
   std::vector<KeyColumnArray> column_arrays_;


### PR DESCRIPTION
### Rationale for this change

`AsofJoinNode` may run into a data race when invalidating the key hasher.

The key hasher queried from one thread but invalidated from another. This might be simplified so that the key hasher would only be used from one thread, but this is out of scope for this PR.

### What changes are included in this PR?

The invalidated member of the key hasher is made atomic.

### Are these changes tested?

Yes, by existing testing.

### Are there any user-facing changes?

No.
* Closes: #35868