### PR TITLE
GH-35906: [Docs] Enable building the documentation without having pyarrow installed

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,6 +49,7 @@ sys.path.extend([
 try:
     import pyarrow
     exclude_patterns = []
+    pyarrow_version =  pyarrow.__version
 
     # Conditional API doc generation
 
@@ -92,6 +93,7 @@ try:
         pyarrow.parquet.encryption = sys.modules['pyarrow.parquet.encryption'] = mock.Mock()
 except (ImportError, LookupError):
     exclude_patterns = ['python']
+    pyarrow_version =  ""
     cuda_enabled = False
     flight_enabled = False
 
@@ -206,10 +208,10 @@ author = u'Apache Software Foundation'
 # built documents.
 #
 # The short X.Y version.
-version = os.environ.get('ARROW_DOCS_VERSION',"")
+version = os.environ.get('ARROW_DOCS_VERSION', pyarrow_version)
 
 # The full version, including alpha/beta/rc tags.
-release = os.environ.get('ARROW_DOCS_VERSION',"")
+release = os.environ.get('ARROW_DOCS_VERSION', pyarrow_version)
 
 if "+" in release:
     release = release.split(".dev")[0] + " (dev)"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -90,7 +90,7 @@ try:
     except ImportError:
         parquet_encryption_enabled = False
         pyarrow.parquet.encryption = sys.modules['pyarrow.parquet.encryption'] = mock.Mock()
-except:
+except (ImportError, LookupError):
     exclude_patterns = ['python']
     cuda_enabled = False
     flight_enabled = False

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,7 +49,7 @@ sys.path.extend([
 try:
     import pyarrow
     exclude_patterns = []
-    pyarrow_version =  pyarrow.__version
+    pyarrow_version =  pyarrow.__version__
 
     # Conditional API doc generation
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,14 +38,62 @@ import warnings
 from unittest import mock
 from docutils.parsers.rst import Directive, directives
 
-import pyarrow
-
-
 sys.path.extend([
     os.path.join(os.path.dirname(__file__),
                  '..', '../..')
 
 ])
+
+# -- Customization --------------------------------------------------------
+
+try:
+    import pyarrow
+    exclude_patterns = []
+
+    # Conditional API doc generation
+
+    # Sphinx has two features for conditional inclusion:
+    # - The "only" directive
+    #   https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#including-content-based-on-tags
+    # - The "ifconfig" extension
+    #   https://www.sphinx-doc.org/en/master/usage/extensions/ifconfig.html
+    #
+    # Both have issues, but "ifconfig" seems to work in this setting.
+
+    try:
+        import pyarrow.cuda
+        cuda_enabled = True
+    except ImportError:
+        cuda_enabled = False
+        # Mock pyarrow.cuda to avoid autodoc warnings.
+        # XXX I can't get autodoc_mock_imports to work, so mock manually instead
+        # (https://github.com/sphinx-doc/sphinx/issues/2174#issuecomment-453177550)
+        pyarrow.cuda = sys.modules['pyarrow.cuda'] = mock.Mock()
+
+    try:
+        import pyarrow.flight
+        flight_enabled = True
+    except ImportError:
+        flight_enabled = False
+        pyarrow.flight = sys.modules['pyarrow.flight'] = mock.Mock()
+
+    try:
+        import pyarrow.orc
+        orc_enabled = True
+    except ImportError:
+        orc_enabled = False
+        pyarrow.orc = sys.modules['pyarrow.orc'] = mock.Mock()
+
+    try:
+        import pyarrow.parquet.encryption
+        parquet_encryption_enabled = True
+    except ImportError:
+        parquet_encryption_enabled = False
+        pyarrow.parquet.encryption = sys.modules['pyarrow.parquet.encryption'] = mock.Mock()
+except:
+    exclude_patterns = ['python']
+    cuda_enabled = False
+    flight_enabled = False
 
 # Suppresses all warnings printed when sphinx is traversing the code (e.g.
 # deprecation warnings)
@@ -158,11 +206,18 @@ author = u'Apache Software Foundation'
 # built documents.
 #
 # The short X.Y version.
-version = os.environ.get('ARROW_DOCS_VERSION',
-                         pyarrow.__version__)
+try:
+    version = os.environ.get('ARROW_DOCS_VERSION',
+                             pyarrow.__version__)
+except:
+    version = '0.0.0-local-docs-build'
+
 # The full version, including alpha/beta/rc tags.
-release = os.environ.get('ARROW_DOCS_VERSION',
-                         pyarrow.__version__)
+try:
+    release = os.environ.get('ARROW_DOCS_VERSION',
+                             pyarrow.__version__)
+except:
+    release = '0.0.0-local-docs-build'
 
 if "+" in release:
     release = release.split(".dev")[0] + " (dev)"
@@ -186,7 +241,7 @@ language = "en"
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = exclude_patterns + ['_build', 'Thumbs.db', '.DS_Store']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
@@ -472,50 +527,6 @@ texinfo_documents = [
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #
 # texinfo_no_detailmenu = False
-
-
-# -- Customization --------------------------------------------------------
-
-# Conditional API doc generation
-
-# Sphinx has two features for conditional inclusion:
-# - The "only" directive
-#   https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#including-content-based-on-tags
-# - The "ifconfig" extension
-#   https://www.sphinx-doc.org/en/master/usage/extensions/ifconfig.html
-#
-# Both have issues, but "ifconfig" seems to work in this setting.
-
-try:
-    import pyarrow.cuda
-    cuda_enabled = True
-except ImportError:
-    cuda_enabled = False
-    # Mock pyarrow.cuda to avoid autodoc warnings.
-    # XXX I can't get autodoc_mock_imports to work, so mock manually instead
-    # (https://github.com/sphinx-doc/sphinx/issues/2174#issuecomment-453177550)
-    pyarrow.cuda = sys.modules['pyarrow.cuda'] = mock.Mock()
-
-try:
-    import pyarrow.flight
-    flight_enabled = True
-except ImportError:
-    flight_enabled = False
-    pyarrow.flight = sys.modules['pyarrow.flight'] = mock.Mock()
-
-try:
-    import pyarrow.orc
-    orc_enabled = True
-except ImportError:
-    orc_enabled = False
-    pyarrow.orc = sys.modules['pyarrow.orc'] = mock.Mock()
-
-try:
-    import pyarrow.parquet.encryption
-    parquet_encryption_enabled = True
-except ImportError:
-    parquet_encryption_enabled = False
-    pyarrow.parquet.encryption = sys.modules['pyarrow.parquet.encryption'] = mock.Mock()
 
 
 def setup(app):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -206,18 +206,10 @@ author = u'Apache Software Foundation'
 # built documents.
 #
 # The short X.Y version.
-try:
-    version = os.environ.get('ARROW_DOCS_VERSION',
-                             pyarrow.__version__)
-except:
-    version = '0.0.0-local-docs-build'
+version = os.environ.get('ARROW_DOCS_VERSION',"")
 
 # The full version, including alpha/beta/rc tags.
-try:
-    release = os.environ.get('ARROW_DOCS_VERSION',
-                             pyarrow.__version__)
-except:
-    release = '0.0.0-local-docs-build'
+release = os.environ.get('ARROW_DOCS_VERSION',"")
 
 if "+" in release:
     release = release.split(".dev")[0] + " (dev)"

--- a/docs/source/developers/documentation.rst
+++ b/docs/source/developers/documentation.rst
@@ -63,11 +63,17 @@ These two steps are mandatory and must be executed in order.
 
    .. note::
 
-      This step requires the pyarrow library is installed
+      If you are working on the Python bindings documentation then
+      this step requires that ``pyarrow`` library is installed
       in your python environment.  One way to accomplish
       this is to follow the build instructions at :ref:`python-development`
       and then run ``python setup.py install`` in arrow/python
       (it is best to do this in a dedicated conda/virtual environment).
+
+      You can still build the documentation without ``pyarrow``
+      library installed but note that Python part of the documentation
+      will be missing from the ``_build/html`` file structure and the
+      links to the Python documentation will get broken.
 
    .. code-block:: shell
 


### PR DESCRIPTION
### Rationale for this change

Ease the process of building the documentation for dev purposes.

### What changes are included in this PR?

`conf.py` is updated in a way to permit having pyarrow not installed (from source or as a binary).
In case pyarrow is not available:
- `docs/source/python` folder will be excluded from the build of the documentation
-  version of the documentation will be set to `'0.0.0-local-docs-build'`

I have tested the changes for cases when:
- pyarrow was built from source
- without pyarrow
- pyarrow was installed from PyPI, version 12.0.0

with building all of the docs and only format/developers sections.
* Closes: #35906