### PR TITLE
GH-35911: [Go] Fix method CastToBytes of decimal256Traits

### DIFF
--- a/go/arrow/type_traits_decimal256.go
+++ b/go/arrow/type_traits_decimal256.go
@@ -59,7 +59,7 @@ func (decimal256Traits) CastToBytes(b []decimal256.Num) []byte {
 	h := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 
 	var res []byte
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
 	s.Data = h.Data
 	s.Len = h.Len * Decimal256SizeBytes
 	s.Cap = h.Cap * Decimal256SizeBytes

--- a/go/arrow/type_traits_test.go
+++ b/go/arrow/type_traits_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/apache/arrow/go/v13/arrow"
 	"github.com/apache/arrow/go/v13/arrow/decimal128"
+	"github.com/apache/arrow/go/v13/arrow/decimal256"
 	"github.com/apache/arrow/go/v13/arrow/float16"
 )
 
@@ -127,6 +128,50 @@ func TestDecimal128Traits(t *testing.T) {
 
 	v2 := make([]decimal128.Num, N)
 	arrow.Decimal128Traits.Copy(v2, v1)
+
+	if !reflect.DeepEqual(v1, v2) {
+		t.Fatalf("invalid values:\nv1=%v\nv2=%v\n", v1, v2)
+	}
+}
+
+func TestDecimal256Traits(t *testing.T) {
+	const N = 10
+	nbytes := arrow.Decimal256Traits.BytesRequired(N)
+	b1 := arrow.Decimal256Traits.CastToBytes([]decimal256.Num{
+		decimal256.New(0, 0, 0, 10),
+		decimal256.New(1, 1, 1, 10),
+		decimal256.New(2, 2, 2, 10),
+		decimal256.New(3, 3, 3, 10),
+		decimal256.New(4, 4, 4, 10),
+		decimal256.New(5, 5, 5, 10),
+		decimal256.New(6, 6, 6, 10),
+		decimal256.New(7, 7, 7, 10),
+		decimal256.New(8, 8, 8, 10),
+		decimal256.New(9, 9, 9, 10),
+	})
+
+	b2 := make([]byte, nbytes)
+	for i := 0; i < N; i++ {
+		beg := i * arrow.Decimal256SizeBytes
+		end := (i + 1) * arrow.Decimal256SizeBytes
+		arrow.Decimal256Traits.PutValue(b2[beg:end], decimal256.New(uint64(i), uint64(i), uint64(i), 10))
+	}
+
+	if !reflect.DeepEqual(b1, b2) {
+		v1 := arrow.Decimal256Traits.CastFromBytes(b1)
+		v2 := arrow.Decimal256Traits.CastFromBytes(b2)
+		t.Fatalf("invalid values:\nb1=%v\nb2=%v\nv1=%v\nv2=%v\n", b1, b2, v1, v2)
+	}
+
+	v1 := arrow.Decimal256Traits.CastFromBytes(b1)
+	for i, v := range v1 {
+		if got, want := v, decimal256.New(uint64(i), uint64(i), uint64(i), 10); got != want {
+			t.Fatalf("invalid value[%d]. got=%v, want=%v", i, got, want)
+		}
+	}
+
+	v2 := make([]decimal256.Num, N)
+	arrow.Decimal256Traits.Copy(v2, v1)
 
 	if !reflect.DeepEqual(v1, v2) {
 		t.Fatalf("invalid values:\nv1=%v\nv2=%v\n", v1, v2)


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
Yes
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #35911