### PR TITLE
GH-18547: [Java] Support re-emitting dictionaries in ArrowStreamWriter

### DIFF
--- a/java/tools/src/main/java/org/apache/arrow/tools/EchoServer.java
+++ b/java/tools/src/main/java/org/apache/arrow/tools/EchoServer.java
@@ -135,6 +135,7 @@ public class EchoServer {
         Preconditions.checkState(reader.bytesRead() == writer.bytesWritten());
         LOGGER.debug(String.format("Echoed %d records", echoed));
         reader.close(false);
+        writer.close();
       }
     }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowStreamWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowStreamWriter.java
@@ -21,11 +21,18 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
+import org.apache.arrow.util.AutoCloseables;
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.compare.VectorEqualsVisitor;
 import org.apache.arrow.vector.compression.CompressionCodec;
 import org.apache.arrow.vector.compression.CompressionUtil;
+import org.apache.arrow.vector.dictionary.Dictionary;
 import org.apache.arrow.vector.dictionary.DictionaryProvider;
 import org.apache.arrow.vector.ipc.message.IpcOption;
 import org.apache.arrow.vector.ipc.message.MessageSerializer;
@@ -34,6 +41,7 @@ import org.apache.arrow.vector.ipc.message.MessageSerializer;
  * Writer for the Arrow stream format to send ArrowRecordBatches over a WriteChannel.
  */
 public class ArrowStreamWriter extends ArrowWriter {
+  private final Map<Long, FieldVector> previousDictionaries = new HashMap<>();
 
   /**
    * Construct an ArrowStreamWriter with an optional DictionaryProvider for the OutputStream.
@@ -120,5 +128,46 @@ public class ArrowStreamWriter extends ArrowWriter {
   @Override
   protected void endInternal(WriteChannel out) throws IOException {
     writeEndOfStream(out, option);
+  }
+
+  @Override
+  protected void ensureDictionariesWritten(DictionaryProvider provider, Set<Long> dictionaryIdsUsed)
+      throws IOException {
+    // write out any dictionaries that have changes
+    for (long id : dictionaryIdsUsed) {
+      Dictionary dictionary = provider.lookup(id);
+      FieldVector vector = dictionary.getVector();
+      if (previousDictionaries.containsKey(id) &&
+          VectorEqualsVisitor.vectorEquals(vector, previousDictionaries.get(id))) {
+        // Dictionary was previously written and hasn't changed
+        continue;
+      }
+      writeDictionaryBatch(dictionary);
+      // Store a copy of the vector in case it is later mutated
+      if (previousDictionaries.containsKey(id)) {
+        previousDictionaries.get(id).close();
+      }
+      previousDictionaries.put(id, copyVector(vector));
+    }
+  }
+
+  @Override
+  public void close() {
+    super.close();
+    try {
+      AutoCloseables.close(previousDictionaries.values());
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static FieldVector copyVector(FieldVector source) {
+    FieldVector copy = source.getField().createVector(source.getAllocator());
+    copy.allocateNew();
+    for (int i = 0; i < source.getValueCount(); i++) {
+      copy.copyFromSafe(i, i, source);
+    }
+    copy.setValueCount(source.getValueCount());
+    return copy;
   }
 }


### PR DESCRIPTION
### Rationale for this change

This allows writing IPC streams where dictionary values change between record batches.

### What changes are included in this PR?

* Add new abstract `void ensureDictionariesWritten(DictionaryProvider provider, Set<Long> dictionaryIdsUsed)` to the base `ArrowWriter` class
* Move existing logic that only writes dictionaries once into the `ArrowFileWriter` class
* Implement replacement dictionary writing in `ArrowStreamWriter` by keeping copies of previously written dictionaries

### Are these changes tested?

Yes, I've added a new unit test for this

### Are there any user-facing changes?

Yes, `ArrowStreamWriter` will now write replacement dictionaries when dictionary values change between batches.

There may also be some performance impact on `ArrowStreamWriter` even when replacement dictionaries are not needed, due to taking an initial copy of dictionaries when writing the first batch and then comparing dictionaries for equality each time a new batch is written.

**This PR includes breaking changes to public APIs.**

`ArrowWriter` has a new abstract `ensureDictionariesWritten` method. This will only affect users directly inheriting from  `ArrowWriter` rather than `ArrowFileWriter` or `ArrowStreamWriter`.

There's also a behaviour change to `ArrowWriter`, where previously dictionaries were read from a `DictionaryProvider` on construction, but this is now delayed until the first batch is written.
* Closes: #18547