### PR TITLE
GH-35915: [Ruby] Add support for converting function options from Hash automatically

### DIFF
--- a/c_glib/arrow-glib/expression.cpp
+++ b/c_glib/arrow-glib/expression.cpp
@@ -223,7 +223,7 @@ garrow_call_expression_new(const gchar *function,
   }
   std::shared_ptr<arrow::compute::FunctionOptions> arrow_options;
   if (options) {
-    arrow_options.reset(garrow_function_options_get_raw(options));
+    arrow_options.reset(garrow_function_options_get_raw(options)->Copy().release());
   }
   auto arrow_expression = arrow::compute::call(function,
                                                arrow_arguments,

--- a/ruby/red-arrow/lib/arrow/expression.rb
+++ b/ruby/red-arrow/lib/arrow/expression.rb
@@ -31,10 +31,14 @@ module Arrow
           else
             return nil
           end
+          options = nil
           if arguments.last.is_a?(FunctionOptions)
             options = arguments.pop
-          else
-            options = nil
+          elsif arguments.last.is_a?(Hash)
+            function = Function.find(function_name)
+            if function
+              options = function.resolve_options(arguments.pop)
+            end
           end
           CallExpression.new(function_name, arguments, options)
         else

--- a/ruby/red-arrow/lib/arrow/function.rb
+++ b/ruby/red-arrow/lib/arrow/function.rb
@@ -24,7 +24,6 @@ module Arrow
     end
     alias_method :call, :execute
 
-    private
     def resolve_options(options)
       return nil if options.nil?
       return options if options.is_a?(FunctionOptions)

--- a/ruby/red-arrow/test/test-expression.rb
+++ b/ruby/red-arrow/test/test-expression.rb
@@ -36,5 +36,16 @@ class TestExpression < Test::Unit::TestCase
       assert_equal(Arrow::CallExpression.new("func", ["argument1"]),
                    Arrow::Expression.try_convert(["func", "argument1"]))
     end
+
+    test("[Symbol, String, Hash]") do
+      options = Arrow::MatchSubstringOptions.new
+      options.pattern = "hello"
+      assert_equal(Arrow::CallExpression.new("match_substring",
+                                             ["content"],
+                                             options),
+                   Arrow::Expression.try_convert([:match_substring,
+                                                  "content",
+                                                  {pattern: "hello"}]))
+    end
   end
 end


### PR DESCRIPTION
### Rationale for this change

It's convenient.

### What changes are included in this PR?

This also fixes a crash bug with `CallExpression.new(name, args, Arrow::MatchSubstringOptions.new)`. `Arrow::MatchSubstringOptions.new` is freed multiple times.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #35915