### PR TITLE
GH-35926: [C++][Parquet] PageIndex allow only building Offset Index

### DIFF
--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -5163,6 +5163,7 @@ TEST(TestArrowReadWrite, FuzzReader) {
 namespace {
 
 struct ColumnIndexObject {
+  bool empty = false;
   std::vector<bool> null_pages;
   std::vector<std::string> min_values;
   std::vector<std::string> max_values;
@@ -5184,6 +5185,7 @@ struct ColumnIndexObject {
 
   explicit ColumnIndexObject(const ColumnIndex* column_index) {
     if (column_index == nullptr) {
+      empty = true;
       return;
     }
     null_pages = column_index->null_pages();
@@ -5331,6 +5333,30 @@ TEST_F(ParquetPageIndexRoundTripTest, SimpleRoundTrip) {
           ColumnIndexObject{/*null_pages=*/{false}, /*min_values=*/{encode_int64(3)},
                             /*max_values=*/{encode_int64(3)}, BoundaryOrder::Ascending,
                             /*null_counts=*/{1}}));
+}
+
+TEST_F(ParquetPageIndexRoundTripTest, SimpleRoundTripWithColumnIndexDisabled) {
+  auto writer_properties = WriterProperties::Builder()
+                               .enable_write_page_index()
+                               ->disable_write_column_index()
+                               ->max_row_group_length(4)
+                               ->build();
+  auto schema = ::arrow::schema({::arrow::field("c0", ::arrow::int64()),
+                                 ::arrow::field("c1", ::arrow::utf8()),
+                                 ::arrow::field("c2", ::arrow::list(::arrow::int64()))});
+  WriteFile(writer_properties, ::arrow::TableFromJSON(schema, {R"([
+      [1,     "a",  [1]      ],
+      [2,     "b",  [1, 2]   ],
+      [3,     "c",  [null]   ],
+      [null,  "d",  []       ],
+      [5,     null, [3, 3, 3]],
+      [6,     "f",  null     ]
+    ])"}));
+
+  ReadPageIndexes(/*expect_num_row_groups=*/2, /*expect_num_pages=*/1);
+  for (auto& column_index : column_indexes_) {
+    EXPECT_TRUE(column_index.empty);
+  }
 }
 
 TEST_F(ParquetPageIndexRoundTripTest, DropLargeStats) {

--- a/cpp/src/parquet/file_writer.cc
+++ b/cpp/src/parquet/file_writer.cc
@@ -146,7 +146,8 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
     auto data_encryptor =
         file_encryptor_ ? file_encryptor_->GetColumnDataEncryptor(path->ToDotString())
                         : nullptr;
-    auto ci_builder = page_index_builder_ && properties_->page_index_enabled(path)
+    auto ci_builder = page_index_builder_ && properties_->page_index_enabled(path) &&
+                              properties_->column_index_enabled(path)
                           ? page_index_builder_->GetColumnIndexBuilder(column_ordinal)
                           : nullptr;
     auto oi_builder = page_index_builder_ && properties_->page_index_enabled(path)

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -139,7 +139,7 @@ static constexpr Encoding::type DEFAULT_ENCODING = Encoding::PLAIN;
 static const char DEFAULT_CREATED_BY[] = CREATED_BY_VERSION;
 static constexpr Compression::type DEFAULT_COMPRESSION_TYPE = Compression::UNCOMPRESSED;
 static constexpr bool DEFAULT_IS_PAGE_INDEX_ENABLED = false;
-static constexpr bool DEFAULT_IS_COLUMN_INDEX_ENABLED = false;
+static constexpr bool DEFAULT_IS_COLUMN_INDEX_ENABLED = true;
 
 class PARQUET_EXPORT ColumnProperties {
  public:

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -139,6 +139,7 @@ static constexpr Encoding::type DEFAULT_ENCODING = Encoding::PLAIN;
 static const char DEFAULT_CREATED_BY[] = CREATED_BY_VERSION;
 static constexpr Compression::type DEFAULT_COMPRESSION_TYPE = Compression::UNCOMPRESSED;
 static constexpr bool DEFAULT_IS_PAGE_INDEX_ENABLED = false;
+static constexpr bool DEFAULT_IS_COLUMN_INDEX_ENABLED = false;
 
 class PARQUET_EXPORT ColumnProperties {
  public:
@@ -147,14 +148,16 @@ class PARQUET_EXPORT ColumnProperties {
                    bool dictionary_enabled = DEFAULT_IS_DICTIONARY_ENABLED,
                    bool statistics_enabled = DEFAULT_ARE_STATISTICS_ENABLED,
                    size_t max_stats_size = DEFAULT_MAX_STATISTICS_SIZE,
-                   bool page_index_enabled = DEFAULT_IS_PAGE_INDEX_ENABLED)
+                   bool page_index_enabled = DEFAULT_IS_PAGE_INDEX_ENABLED,
+                   bool column_index_enabled = DEFAULT_IS_COLUMN_INDEX_ENABLED)
       : encoding_(encoding),
         codec_(codec),
         dictionary_enabled_(dictionary_enabled),
         statistics_enabled_(statistics_enabled),
         max_stats_size_(max_stats_size),
         compression_level_(Codec::UseDefaultCompressionLevel()),
-        page_index_enabled_(DEFAULT_IS_PAGE_INDEX_ENABLED) {}
+        page_index_enabled_(page_index_enabled),
+        column_index_enabled_(column_index_enabled) {}
 
   void set_encoding(Encoding::type encoding) { encoding_ = encoding; }
 
@@ -180,6 +183,10 @@ class PARQUET_EXPORT ColumnProperties {
     page_index_enabled_ = page_index_enabled;
   }
 
+  void set_column_index_enabled(bool column_index_enabled) {
+    column_index_enabled_ = column_index_enabled;
+  }
+
   Encoding::type encoding() const { return encoding_; }
 
   Compression::type compression() const { return codec_; }
@@ -194,6 +201,8 @@ class PARQUET_EXPORT ColumnProperties {
 
   bool page_index_enabled() const { return page_index_enabled_; }
 
+  bool column_index_enabled() const { return column_index_enabled_; }
+
  private:
   Encoding::type encoding_;
   Compression::type codec_;
@@ -202,6 +211,7 @@ class PARQUET_EXPORT ColumnProperties {
   size_t max_stats_size_;
   int compression_level_;
   bool page_index_enabled_;
+  bool column_index_enabled_;
 };
 
 class PARQUET_EXPORT WriterProperties {
@@ -562,6 +572,38 @@ class PARQUET_EXPORT WriterProperties {
       return this->disable_write_page_index(path->ToDotString());
     }
 
+    Builder* enable_write_column_index() {
+      default_column_properties_.set_column_index_enabled(true);
+      return this;
+    }
+
+    /// Disable writing column index in general for all columns.
+    Builder* disable_write_column_index() {
+      default_column_properties_.set_column_index_enabled(false);
+      return this;
+    }
+
+    /// Enable writing page index for column specified by `path`. Default enabled.
+    Builder* enable_write_column_index(const std::string& path) {
+      column_index_enabled_[path] = true;
+      return this;
+    }
+
+    /// Enable writing column index for column specified by `path`. Default enabled.
+    Builder* enable_write_column_index(const std::shared_ptr<schema::ColumnPath>& path) {
+      return this->enable_write_column_index(path->ToDotString());
+    }
+
+    /// Disable writing column index for column specified by `path`.
+    Builder* disable_write_column_index(const std::string& path) {
+      column_index_enabled_[path] = false;
+      return this;
+    }
+
+    Builder* disable_write_column_index(const std::shared_ptr<schema::ColumnPath>& path) {
+      return this->disable_write_column_index(path->ToDotString());
+    }
+
     /// \brief Build the WriterProperties with the builder parameters.
     /// \return The WriterProperties defined by the builder.
     std::shared_ptr<WriterProperties> build() {
@@ -584,6 +626,8 @@ class PARQUET_EXPORT WriterProperties {
         get(item.first).set_statistics_enabled(item.second);
       for (const auto& item : page_index_enabled_)
         get(item.first).set_page_index_enabled(item.second);
+      for (const auto& item : column_index_enabled_)
+        get(item.first).set_column_index_enabled(item.second);
 
       return std::shared_ptr<WriterProperties>(new WriterProperties(
           pool_, dictionary_pagesize_limit_, write_batch_size_, max_row_group_length_,
@@ -618,6 +662,7 @@ class PARQUET_EXPORT WriterProperties {
     std::unordered_map<std::string, bool> dictionary_enabled_;
     std::unordered_map<std::string, bool> statistics_enabled_;
     std::unordered_map<std::string, bool> page_index_enabled_;
+    std::unordered_map<std::string, bool> column_index_enabled_;
   };
 
   inline MemoryPool* memory_pool() const { return pool_; }
@@ -705,6 +750,10 @@ class PARQUET_EXPORT WriterProperties {
       }
     }
     return false;
+  }
+
+  bool column_index_enabled(const std::shared_ptr<schema::ColumnPath>& path) const {
+    return column_properties(path).column_index_enabled();
   }
 
   inline FileEncryptionProperties* file_encryption_properties() const {


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Allow only build Offset Index for some column

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add a property `enable_column_index`.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes

### Are there any user-facing changes?

User can disable column index for some column

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #35926