### PR TITLE
GH-35932: [Java][CI] Do not validate ordering on JdbcToArrowCommentMetadataTest

### DIFF
--- a/java/adapter/jdbc/pom.xml
+++ b/java/adapter/jdbc/pom.xml
@@ -86,6 +86,13 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.1</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowCommentMetadataTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowCommentMetadataTest.java
@@ -17,8 +17,6 @@
 
 package org.apache.arrow.adapter.jdbc;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -42,6 +40,8 @@ import org.apache.arrow.vector.util.ObjectMapperFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import com.fasterxml.jackson.databind.ObjectWriter;
 
@@ -78,7 +78,7 @@ public class JdbcToArrowCommentMetadataTest {
     boolean includeMetadata = false;
     String schemaJson = schemaSerializer.writeValueAsString(getSchemaWithCommentFromQuery(includeMetadata));
     String expectedSchema = getExpectedSchema("/h2/expectedSchemaWithComments.json");
-    assertThat(schemaJson).isEqualTo(expectedSchema);
+    JSONAssert.assertEquals(schemaJson, expectedSchema, JSONCompareMode.NON_EXTENSIBLE);
   }
 
   @Test
@@ -92,7 +92,7 @@ public class JdbcToArrowCommentMetadataTest {
         COLUMN1 BOOLEAN,
         COLUMNN INT COMMENT 'Informative description of columnN'
      */
-    assertThat(schemaJson).isEqualTo(expectedSchema);
+    JSONAssert.assertEquals(schemaJson, expectedSchema, JSONCompareMode.NON_EXTENSIBLE);
   }
 
   private Schema getSchemaWithCommentFromQuery(boolean includeMetadata) throws SQLException {


### PR DESCRIPTION
### Rationale for this change

Fix current tests by not checking order on the schema.

### What changes are included in this PR?

Added test dependency to be able to check json without ordering

### Are these changes tested?
Yes and will be tested on CI

### Are there any user-facing changes?

No
* Closes: #35932