### PR TITLE
GH-35948: [Go] Only cast `int8` and `unit8` to `float64` when JSON marshaling arrays

### DIFF
--- a/go/arrow/array/numeric.gen.go
+++ b/go/arrow/array/numeric.gen.go
@@ -101,9 +101,7 @@ func (a *Int64) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-
 			vals[i] = a.values[i]
-
 		} else {
 			vals[i] = nil
 		}
@@ -198,9 +196,7 @@ func (a *Uint64) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-
 			vals[i] = a.values[i]
-
 		} else {
 			vals[i] = nil
 		}
@@ -295,9 +291,7 @@ func (a *Float64) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-
 			vals[i] = a.values[i]
-
 		} else {
 			vals[i] = nil
 		}
@@ -392,9 +386,7 @@ func (a *Int32) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-
 			vals[i] = a.values[i]
-
 		} else {
 			vals[i] = nil
 		}
@@ -489,9 +481,7 @@ func (a *Uint32) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-
 			vals[i] = a.values[i]
-
 		} else {
 			vals[i] = nil
 		}
@@ -586,9 +576,7 @@ func (a *Float32) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-
 			vals[i] = a.values[i]
-
 		} else {
 			vals[i] = nil
 		}
@@ -683,9 +671,7 @@ func (a *Int16) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-
 			vals[i] = a.values[i]
-
 		} else {
 			vals[i] = nil
 		}
@@ -780,9 +766,7 @@ func (a *Uint16) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-
 			vals[i] = a.values[i]
-
 		} else {
 			vals[i] = nil
 		}
@@ -877,7 +861,6 @@ func (a *Int8) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-
 			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
 
 		} else {
@@ -974,7 +957,6 @@ func (a *Uint8) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-
 			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
 
 		} else {

--- a/go/arrow/array/numeric.gen.go
+++ b/go/arrow/array/numeric.gen.go
@@ -862,7 +862,6 @@ func (a *Int8) MarshalJSON() ([]byte, error) {
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
 			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
-
 		} else {
 			vals[i] = nil
 		}
@@ -958,7 +957,6 @@ func (a *Uint8) MarshalJSON() ([]byte, error) {
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
 			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
-
 		} else {
 			vals[i] = nil
 		}

--- a/go/arrow/array/numeric.gen.go
+++ b/go/arrow/array/numeric.gen.go
@@ -101,7 +101,9 @@ func (a *Int64) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
+
+			vals[i] = a.values[i]
+
 		} else {
 			vals[i] = nil
 		}
@@ -196,7 +198,9 @@ func (a *Uint64) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
+
+			vals[i] = a.values[i]
+
 		} else {
 			vals[i] = nil
 		}
@@ -291,7 +295,9 @@ func (a *Float64) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
+
+			vals[i] = a.values[i]
+
 		} else {
 			vals[i] = nil
 		}
@@ -386,7 +392,9 @@ func (a *Int32) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
+
+			vals[i] = a.values[i]
+
 		} else {
 			vals[i] = nil
 		}
@@ -481,7 +489,9 @@ func (a *Uint32) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
+
+			vals[i] = a.values[i]
+
 		} else {
 			vals[i] = nil
 		}
@@ -576,7 +586,9 @@ func (a *Float32) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
+
+			vals[i] = a.values[i]
+
 		} else {
 			vals[i] = nil
 		}
@@ -671,7 +683,9 @@ func (a *Int16) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
+
+			vals[i] = a.values[i]
+
 		} else {
 			vals[i] = nil
 		}
@@ -766,7 +780,9 @@ func (a *Uint16) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
+
+			vals[i] = a.values[i]
+
 		} else {
 			vals[i] = nil
 		}
@@ -861,7 +877,9 @@ func (a *Int8) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
+
 			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
+
 		} else {
 			vals[i] = nil
 		}
@@ -956,7 +974,9 @@ func (a *Uint8) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
+
 			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
+
 		} else {
 			vals[i] = nil
 		}

--- a/go/arrow/array/numeric.gen.go.tmpl
+++ b/go/arrow/array/numeric.gen.go.tmpl
@@ -134,7 +134,11 @@ func (a *{{.Name}}) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
+			{{ if (eq .Size "1") }}
 			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
+			{{ else }}
+			vals[i] = a.values[i]
+			{{ end }}
 		} else {
 			vals[i] = nil
 		}

--- a/go/arrow/array/numeric.gen.go.tmpl
+++ b/go/arrow/array/numeric.gen.go.tmpl
@@ -134,11 +134,8 @@ func (a *{{.Name}}) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-			{{ if (eq .Size "1") }}
-			vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
-			{{ else }}
-			vals[i] = a.values[i]
-			{{ end }}
+			{{ if (eq .Size "1") }}vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
+			{{ else }}vals[i] = a.values[i]{{ end }}
 		} else {
 			vals[i] = nil
 		}

--- a/go/arrow/array/numeric.gen.go.tmpl
+++ b/go/arrow/array/numeric.gen.go.tmpl
@@ -134,8 +134,7 @@ func (a *{{.Name}}) MarshalJSON() ([]byte, error) {
 	vals := make([]interface{}, a.Len())
 	for i := 0; i < a.Len(); i++ {
 		if a.IsValid(i) {
-			{{ if (eq .Size "1") }}vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data
-			{{ else }}vals[i] = a.values[i]{{ end }}
+			{{ if (eq .Size "1") }}vals[i] = float64(a.values[i]) // prevent uint8 from being seen as binary data{{ else }}vals[i] = a.values[i]{{ end }}
 		} else {
 			vals[i] = nil
 		}

--- a/go/arrow/array/numeric_test.go
+++ b/go/arrow/array/numeric_test.go
@@ -632,3 +632,61 @@ func TestDate64SliceDataWithNull(t *testing.T) {
 		t.Fatalf("got=%v, want=%v", got, want)
 	}
 }
+
+func TestInt64MarshalJSON(t *testing.T) {
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer pool.AssertSize(t, 0)
+
+	var (
+		vs = []int64{-5474557666971701248}
+	)
+
+	b := array.NewInt64Builder(pool)
+	defer b.Release()
+
+	for _, v := range vs {
+		b.Append(v)
+	}
+
+	arr := b.NewArray().(*array.Int64)
+	defer arr.Release()
+
+	jsonBytes, err := json.Marshal(arr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(jsonBytes)
+	want := `[-5474557666971701248]`
+	if got != want {
+		t.Fatalf("got=%s, want=%s", got, want)
+	}
+}
+
+func TestUInt64MarshalJSON(t *testing.T) {
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer pool.AssertSize(t, 0)
+
+	var (
+		vs = []uint64{14697929703826477056}
+	)
+
+	b := array.NewUint64Builder(pool)
+	defer b.Release()
+
+	for _, v := range vs {
+		b.Append(v)
+	}
+
+	arr := b.NewArray().(*array.Uint64)
+	defer arr.Release()
+
+	jsonBytes, err := json.Marshal(arr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(jsonBytes)
+	want := `[14697929703826477056]`
+	if got != want {
+		t.Fatalf("got=%s, want=%s", got, want)
+	}
+}


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

See [issue](https://github.com/apache/arrow/issues/35948).

Based on https://github.com/apache/arrow/blob/9fb8697dcb442f63317c7d6046393fb74842e0ae/go/arrow/array/numeric.gen.go.tmpl#L120 it seems we should only do the casting for `unit8` and `int8` types.

### What changes are included in this PR?

This PR fixes the numeric template so it only casts `int8` and `unit8` to `float64` when JSON marshaling arrays to avoid losing data for other types.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes

### Are there any user-facing changes?

The user facing change is that if a user was JSON marshaling arrays that has `uint64` or `int64` values they can now get different (more accurate) values than before 

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #35948