### PR TITLE
GH-35952: [R] Ensure that schema metadata can actually be set as a named character vector

### DIFF
--- a/r/R/schema.R
+++ b/r/R/schema.R
@@ -229,9 +229,13 @@ prepare_key_value_metadata <- function(metadata) {
       call. = FALSE
     )
   }
+
+  metadata <- as.list(metadata)
+
   if (!is_empty(metadata) && is.list(metadata[["r"]])) {
     metadata[["r"]] <- .serialize_arrow_r_metadata(metadata[["r"]])
   }
+
   map_chr(metadata, as.character)
 }
 

--- a/r/tests/testthat/test-schema.R
+++ b/r/tests/testthat/test-schema.R
@@ -140,6 +140,22 @@ test_that("Schema modification", {
   expect_error(schm[[c(2, 4)]] <- int32(), "length(i) not equal to 1", fixed = TRUE)
 })
 
+test_that("Metadata can be reassigned as a whole", {
+  schm <- schema(b = double(), c = string(), d = int8())
+
+  # Check named character vector
+  schm$metadata <- c("foo" = "bar")
+  expect_identical(schm$metadata, list(foo = "bar"))
+
+  # Check list()
+  schm$metadata <- list("foo" = "bar")
+  expect_identical(schm$metadata, list(foo = "bar"))
+
+  # Check NULL for removal
+  schm$metadata <- NULL
+  expect_identical(schm$metadata, set_names(list(), character()))
+})
+
 test_that("Metadata is preserved when modifying Schema", {
   schm <- schema(b = double(), c = string(), d = int8())
   schm$metadata$foo <- "bar"


### PR DESCRIPTION
This wasn't necessarily a regression (reprex fails in 12.0.0 as well), although the comments suggest that assigning a named character vector will work when assigning schema metadata and this feature appears to be used by at least one of our dependencies (sfarrow). Given that the sfarrow check passes on 12.0.0, there is possibly also a place in our code that returns a named character vector rather than a list. I've confirmed that this fix solves the reverse dependency failure building the sfarrow example vignette.

``` r
library(arrow, warn.conflicts = FALSE)

schema <- schema(x = int32())
schema$metadata <- c("name" = "value")
schema$metadata
#> $name
#> [1] "value"
```

<sup>Created on 2023-06-06 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
* Closes: #35952