### PR TITLE
MINOR: [Go] Add IsNull method to dictionary builder

### DIFF
--- a/go/arrow/array/builder.go
+++ b/go/arrow/array/builder.go
@@ -77,6 +77,9 @@ type Builder interface {
 	// a new array.
 	NewArray() arrow.Array
 
+	// IsNull returns if a previously appended value at a given index is null or not.
+	IsNull(i int) bool
+
 	UnsafeAppendBoolToBitmap(bool)
 
 	init(capacity int)
@@ -112,6 +115,10 @@ func (b *builder) Cap() int { return b.capacity }
 
 // NullN returns the number of null values in the array builder.
 func (b *builder) NullN() int { return b.nulls }
+
+func (b *builder) IsNull(i int) bool {
+	return b.nullBitmap.Len() != 0 && bitutil.BitIsNotSet(b.nullBitmap.Bytes(), i)
+}
 
 func (b *builder) init(capacity int) {
 	toAlloc := bitutil.CeilByte(capacity) / 8

--- a/go/arrow/array/builder_test.go
+++ b/go/arrow/array/builder_test.go
@@ -81,3 +81,19 @@ func TestBuilder_resize(t *testing.T) {
 	assert.Equal(t, n, b.Len())
 	assert.Equal(t, n-1, b.NullN())
 }
+
+func TestBuilder_IsNull(t *testing.T) {
+	b := &builder{mem: memory.NewGoAllocator()}
+	n := 32
+	b.init(n)
+
+	assert.True(t, b.IsNull(0))
+	assert.True(t, b.IsNull(1))
+
+	for i := 0; i < n; i++ {
+		b.UnsafeAppendBoolToBitmap(i%2 == 0)
+	}
+	for i := 0; i < n; i++ {
+		assert.Equal(t, i%2 != 0, b.IsNull(i))
+	}
+}

--- a/go/arrow/array/dictionary.go
+++ b/go/arrow/array/dictionary.go
@@ -45,12 +45,12 @@ import (
 //
 // For example, the array:
 //
-//      ["foo", "bar", "foo", "bar", "foo", "bar"]
+//	["foo", "bar", "foo", "bar", "foo", "bar"]
 //
 // with dictionary ["bar", "foo"], would have the representation of:
 //
-//      indices: [1, 0, 1, 0, 1, 0]
-//      dictionary: ["bar", "foo"]
+//	indices: [1, 0, 1, 0, 1, 0]
+//	dictionary: ["bar", "foo"]
 //
 // The indices in principle may be any integer type.
 type Dictionary struct {

--- a/go/arrow/array/map.go
+++ b/go/arrow/array/map.go
@@ -210,6 +210,11 @@ func (b *MapBuilder) Cap() int { return b.listBuilder.Cap() }
 // NullN returns the number of null values in the array builder.
 func (b *MapBuilder) NullN() int { return b.listBuilder.NullN() }
 
+// IsNull returns if a previously appended value at a given index is null or not.
+func (b *MapBuilder) IsNull(i int) bool {
+	return b.listBuilder.IsNull(i)
+}
+
 // Append adds a new Map element to the array, calling Append(false) is
 // equivalent to calling AppendNull.
 func (b *MapBuilder) Append(v bool) {


### PR DESCRIPTION
Given that this function is super similar to the previously added `GetValueIndex` I've decided to not open an Issue first.

### Rationale for this change

This is helpful to check if previously appended rows have been null or not.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

The changes have been tested in our unit tests building on top of this. I'm happy to follow up with a unit test if deemed necessary. 
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

The addition of `IsNull(i int) bool` to the `BinaryDictionaryBuilder`. 
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->