### PR TITLE
GH-35819: [GLib][Ruby] Refer dependency objects of GArrowExecutePlan

### DIFF
--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -386,6 +386,9 @@ garrow_execute_plan_build_hash_join_node(GArrowExecutePlan *plan,
                                          GArrowExecuteNode *right,
                                          GArrowHashJoinNodeOptions *options,
                                          GError **error);
+GARROW_AVAILABLE_IN_13_0
+GList *
+garrow_execute_plan_get_nodes(GArrowExecutePlan *plan);
 GARROW_AVAILABLE_IN_6_0
 gboolean
 garrow_execute_plan_validate(GArrowExecutePlan *plan,

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -59,7 +59,9 @@ garrow_execute_node_options_get_raw(GArrowExecuteNodeOptions *options);
 
 
 GArrowExecuteNode *
-garrow_execute_node_new_raw(arrow::acero::ExecNode *arrow_node);
+garrow_execute_node_new_raw(
+  arrow::acero::ExecNode* arrow_node,
+  GArrowExecuteNodeOptions *options);
 arrow::acero::ExecNode *
 garrow_execute_node_get_raw(GArrowExecuteNode *node);
 

--- a/c_glib/arrow-glib/reader.cpp
+++ b/c_glib/arrow-glib/reader.cpp
@@ -59,13 +59,14 @@ G_BEGIN_DECLS
  * input.
  */
 
-typedef struct GArrowRecordBatchReaderPrivate_ {
+struct GArrowRecordBatchReaderPrivate {
   std::shared_ptr<arrow::ipc::RecordBatchReader> record_batch_reader;
-} GArrowRecordBatchReaderPrivate;
+  GList *sources;
+};
 
 enum {
-  PROP_0,
-  PROP_RECORD_BATCH_READER
+  PROP_RECORD_BATCH_READER = 1,
+  PROP_SOURCES,
 };
 
 G_DEFINE_TYPE_WITH_PRIVATE(GArrowRecordBatchReader,
@@ -88,6 +89,17 @@ garrow_record_batch_reader_finalize(GObject *object)
 }
 
 static void
+garrow_record_batch_reader_dispose(GObject *object)
+{
+  auto priv = GARROW_RECORD_BATCH_READER_GET_PRIVATE(object);
+
+  g_list_free_full(priv->sources, g_object_unref);
+  priv->sources = nullptr;
+
+  G_OBJECT_CLASS(garrow_record_batch_reader_parent_class)->dispose(object);
+}
+
+static void
 garrow_record_batch_reader_set_property(GObject *object,
                                         guint prop_id,
                                         const GValue *value,
@@ -100,19 +112,11 @@ garrow_record_batch_reader_set_property(GObject *object,
     priv->record_batch_reader =
       *static_cast<std::shared_ptr<arrow::ipc::RecordBatchReader> *>(g_value_get_pointer(value));
     break;
-  default:
-    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+  case PROP_SOURCES:
+    priv->sources = g_list_copy_deep(static_cast<GList *>(g_value_get_pointer(value)),
+                                     reinterpret_cast<GCopyFunc>(g_object_ref),
+                                     nullptr);
     break;
-  }
-}
-
-static void
-garrow_record_batch_reader_get_property(GObject *object,
-                                        guint prop_id,
-                                        GValue *value,
-                                        GParamSpec *pspec)
-{
-  switch (prop_id) {
   default:
     G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
     break;
@@ -129,21 +133,25 @@ garrow_record_batch_reader_init(GArrowRecordBatchReader *object)
 static void
 garrow_record_batch_reader_class_init(GArrowRecordBatchReaderClass *klass)
 {
-  GObjectClass *gobject_class;
-  GParamSpec *spec;
-
-  gobject_class = G_OBJECT_CLASS(klass);
-
+  auto gobject_class = G_OBJECT_CLASS(klass);
   gobject_class->finalize     = garrow_record_batch_reader_finalize;
+  gobject_class->finalize     = garrow_record_batch_reader_dispose;
   gobject_class->set_property = garrow_record_batch_reader_set_property;
-  gobject_class->get_property = garrow_record_batch_reader_get_property;
 
+  GParamSpec *spec;
   spec = g_param_spec_pointer("record-batch-reader",
                               "arrow::ipc::RecordBatchReader",
                               "The raw std::shared<arrow::ipc::RecordBatchRecordBatchReader> *",
                               static_cast<GParamFlags>(G_PARAM_WRITABLE |
                                                        G_PARAM_CONSTRUCT_ONLY));
   g_object_class_install_property(gobject_class, PROP_RECORD_BATCH_READER, spec);
+
+  spec = g_param_spec_pointer("sources",
+                              "Sources",
+                              "The sources of this reader",
+                              static_cast<GParamFlags>(G_PARAM_WRITABLE |
+                                                       G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property(gobject_class, PROP_SOURCES, spec);
 }
 
 /**
@@ -168,7 +176,7 @@ garrow_record_batch_reader_import(gpointer c_abi_array_stream, GError **error)
   if (garrow::check(error,
                     arrow_reader_result,
                     "[record-batch-reader][import]")) {
-    return garrow_record_batch_reader_new_raw(&(*arrow_reader_result));
+    return garrow_record_batch_reader_new_raw(&(*arrow_reader_result), nullptr);
   } else {
     return NULL;
   }
@@ -204,7 +212,8 @@ garrow_record_batch_reader_new(GList *record_batches,
   if (garrow::check(error,
                     arrow_reader_result,
                     "[record-batch-stream-reader][new]")) {
-    return garrow_record_batch_reader_new_raw(&*arrow_reader_result);
+    return garrow_record_batch_reader_new_raw(&*arrow_reader_result,
+                                              record_batches);
   } else {
     return NULL;
   }
@@ -354,6 +363,22 @@ garrow_record_batch_reader_read_all(GArrowRecordBatchReader *reader,
   }
 }
 
+/**
+ * garrow_record_batch_reader_get_sources:
+ * @reader: A #GArrowRecordBatchReader.
+ *
+ * Returns: (transfer none) (element-type GObject): A list of source
+ *   of this reader.
+ *
+ * Since: 13.0.0
+ */
+GList *
+garrow_record_batch_reader_get_sources(GArrowRecordBatchReader *reader)
+{
+  auto priv = GARROW_RECORD_BATCH_READER_GET_PRIVATE(reader);
+  return priv->sources;
+}
+
 
 G_DEFINE_TYPE(GArrowTableBatchReader,
               garrow_table_batch_reader,
@@ -383,7 +408,7 @@ garrow_table_batch_reader_new(GArrowTable *table)
   auto arrow_table = garrow_table_get_raw(table);
   auto arrow_table_batch_reader =
     std::make_shared<arrow::TableBatchReader>(*arrow_table);
-  return garrow_table_batch_reader_new_raw(&arrow_table_batch_reader);
+  return garrow_table_batch_reader_new_raw(&arrow_table_batch_reader, table);
 }
 
 /**
@@ -2233,11 +2258,13 @@ G_END_DECLS
 
 GArrowRecordBatchReader *
 garrow_record_batch_reader_new_raw(
-  std::shared_ptr<arrow::RecordBatchReader> *arrow_reader)
+  std::shared_ptr<arrow::RecordBatchReader> *arrow_reader,
+  GList *sources)
 {
   return GARROW_RECORD_BATCH_READER(
     g_object_new(GARROW_TYPE_RECORD_BATCH_READER,
                  "record-batch-reader", arrow_reader,
+                 "sources", sources,
                  NULL));
 }
 
@@ -2249,12 +2276,17 @@ garrow_record_batch_reader_get_raw(GArrowRecordBatchReader *reader)
 }
 
 GArrowTableBatchReader *
-garrow_table_batch_reader_new_raw(std::shared_ptr<arrow::TableBatchReader> *arrow_reader)
+garrow_table_batch_reader_new_raw(
+  std::shared_ptr<arrow::TableBatchReader> *arrow_reader,
+  GArrowTable *table)
 {
+  auto sources = g_list_prepend(nullptr, table);
   auto reader =
     GARROW_TABLE_BATCH_READER(g_object_new(GARROW_TYPE_TABLE_BATCH_READER,
                                            "record-batch-reader", arrow_reader,
+                                           "sources", sources,
                                            NULL));
+  g_list_free(sources);
   return reader;
 }
 

--- a/c_glib/arrow-glib/reader.h
+++ b/c_glib/arrow-glib/reader.h
@@ -79,6 +79,10 @@ GArrowTable *
 garrow_record_batch_reader_read_all(GArrowRecordBatchReader *reader,
                                     GError **error);
 
+GARROW_AVAILABLE_IN_13_0
+GList *
+garrow_record_batch_reader_get_sources(GArrowRecordBatchReader *reader);
+
 #define GARROW_TYPE_TABLE_BATCH_READER (garrow_table_batch_reader_get_type())
 G_DECLARE_DERIVABLE_TYPE(GArrowTableBatchReader,
                          garrow_table_batch_reader,

--- a/c_glib/arrow-glib/reader.hpp
+++ b/c_glib/arrow-glib/reader.hpp
@@ -27,12 +27,17 @@
 
 #include <arrow-glib/reader.h>
 
-GArrowRecordBatchReader *garrow_record_batch_reader_new_raw(std::shared_ptr<arrow::ipc::RecordBatchReader> *arrow_reader);
-std::shared_ptr<arrow::ipc::RecordBatchReader> garrow_record_batch_reader_get_raw(GArrowRecordBatchReader *reader);
+GArrowRecordBatchReader *
+garrow_record_batch_reader_new_raw(
+  std::shared_ptr<arrow::ipc::RecordBatchReader> *arrow_reader,
+  GList *sources);
+std::shared_ptr<arrow::ipc::RecordBatchReader>
+garrow_record_batch_reader_get_raw(GArrowRecordBatchReader *reader);
 
 GArrowTableBatchReader *
 garrow_table_batch_reader_new_raw(
-  std::shared_ptr<arrow::TableBatchReader> *arrow_reader);
+  std::shared_ptr<arrow::TableBatchReader> *arrow_reader,
+  GArrowTable *table);
 std::shared_ptr<arrow::TableBatchReader>
 garrow_table_batch_reader_get_raw(GArrowTableBatchReader *reader);
 

--- a/c_glib/arrow-glib/version.h.in
+++ b/c_glib/arrow-glib/version.h.in
@@ -111,6 +111,15 @@
 #endif
 
 /**
+ * GARROW_VERSION_13_0:
+ *
+ * You can use this macro value for compile time API version check.
+ *
+ * Since: 13.0.0
+ */
+#define GARROW_VERSION_13_0 G_ENCODE_VERSION(13, 0)
+
+/**
  * GARROW_VERSION_12_0:
  *
  * You can use this macro value for compile time API version check.
@@ -327,6 +336,20 @@
 
 
 #define GARROW_AVAILABLE_IN_ALL
+
+#if GARROW_VERSION_MIN_REQUIRED >= GARROW_VERSION_13_0
+#  define GARROW_DEPRECATED_IN_13_0                GARROW_DEPRECATED
+#  define GARROW_DEPRECATED_IN_13_0_FOR(function)  GARROW_DEPRECATED_FOR(function)
+#else
+#  define GARROW_DEPRECATED_IN_13_0
+#  define GARROW_DEPRECATED_IN_13_0_FOR(function)
+#endif
+
+#if GARROW_VERSION_MAX_ALLOWED < GARROW_VERSION_13_0
+#  define GARROW_AVAILABLE_IN_13_0 GARROW_UNAVAILABLE(13, 0)
+#else
+#  define GARROW_AVAILABLE_IN_13_0
+#endif
 
 #if GARROW_VERSION_MIN_REQUIRED >= GARROW_VERSION_12_0
 #  define GARROW_DEPRECATED_IN_12_0                GARROW_DEPRECATED

--- a/c_glib/doc/arrow-glib/arrow-glib-docs.xml
+++ b/c_glib/doc/arrow-glib/arrow-glib-docs.xml
@@ -193,6 +193,10 @@
     <title>Index of deprecated API</title>
     <xi:include href="xml/api-index-deprecated.xml"><xi:fallback /></xi:include>
   </index>
+  <index id="api-index-13-0-0" role="13.0.0">
+    <title>Index of new symbols in 13.0.0</title>
+    <xi:include href="xml/api-index-13.0.0.xml"><xi:fallback /></xi:include>
+  </index>
   <index id="api-index-12-0-0" role="12.0.0">
     <title>Index of new symbols in 12.0.0</title>
     <xi:include href="xml/api-index-12.0.0.xml"><xi:fallback /></xi:include>

--- a/ruby/red-arrow/ext/arrow/arrow.cpp
+++ b/ruby/red-arrow/ext/arrow/arrow.cpp
@@ -43,6 +43,26 @@ namespace red_arrow {
     VALUE month;
     VALUE nanosecond;
   }
+
+  void
+  record_batch_reader_mark(gpointer object)
+  {
+    auto reader = GARROW_RECORD_BATCH_READER(object);
+    auto sources = garrow_record_batch_reader_get_sources(reader);
+    for (auto source = sources; sources; sources = g_list_next(sources)) {
+      rbgobj_gc_mark_instance(source->data);
+    }
+  }
+
+  void
+  execute_plan_mark(gpointer object)
+  {
+    auto plan = GARROW_EXECUTE_PLAN(object);
+    auto nodes = garrow_execute_plan_get_nodes(plan);
+    for (auto node = nodes; nodes; nodes = g_list_next(nodes)) {
+      rbgobj_gc_mark_instance(node->data);
+    }
+  }
 }
 
 extern "C" void Init_arrow() {
@@ -93,4 +113,9 @@ extern "C" void Init_arrow() {
   red_arrow::symbols::millisecond = ID2SYM(rb_intern("millisecond"));
   red_arrow::symbols::month = ID2SYM(rb_intern("month"));
   red_arrow::symbols::nanosecond = ID2SYM(rb_intern("nanosecond"));
+
+  rbgobj_register_mark_func(GARROW_TYPE_RECORD_BATCH_READER,
+                            red_arrow::record_batch_reader_mark);
+  rbgobj_register_mark_func(GARROW_TYPE_EXECUTE_PLAN,
+                            red_arrow::execute_plan_mark);
 }

--- a/ruby/red-arrow/lib/arrow/slicer.rb
+++ b/ruby/red-arrow/lib/arrow/slicer.rb
@@ -189,7 +189,7 @@ module Arrow
           message =
              "pattern must be either String or Regexp: #{pattern.inspect}"
           raise ArgumentError, message
-        end 
+        end
       end
 
       def start_with?(substring, ignore_case: false)


### PR DESCRIPTION
### Rationale for this change

If we don't refer them, GC may free them unexpectedly.

Relations:

* `GArrowExecutePlan` -> `GArrowExecuteNode`s
* `GArrowExecuteNode` -> `GArrowExecuteOptions`
* `GArrowSourceNodeOptions` -> `GArrowRecordBatchReader` or `GArrowRecordBatch`
* `GArrowRecordBatchReader` -> `GArrowRecordBatch`s or `GArrowTable`

### What changes are included in this PR?

Add missing references in GLib and mark dependency container explicitly in Ruby.
Because we can't mark dependency container automatically in Ruby.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #35819