### PR TITLE
GH-35693: [MATLAB] Add `Valid` as a name-value pair on the `arrow.array.Float64Array` constructor

### DIFF
--- a/matlab/src/matlab/+arrow/+args/parseValidElements.m
+++ b/matlab/src/matlab/+arrow/+args/parseValidElements.m
@@ -55,6 +55,7 @@ function validElements = parseInferNulls(data, inferNulls)
     if inferNulls
         % TODO: consider making validElements empty if everything is valid.
         validElements = ~ismissing(data);
+        validElements = reshape(validElements, [], 1);
     else
         % TODO: consider making this an empty array if everything is valid
         validElements = true([numel(data) 1]);

--- a/matlab/src/matlab/+arrow/+args/parseValidElements.m
+++ b/matlab/src/matlab/+arrow/+args/parseValidElements.m
@@ -14,11 +14,11 @@
 % permissions and limitations under the License.
 
 function validElements = parseValidElements(data, opts)
-    % Returns a logical vector of the validElements in data. 
-
-    % opts is a scalar struct that is required to have a field called
-    % InferNulls. opts may have a field named Valid. If so, it takes 
-    % precedence over InferNulls.
+% Returns a logical vector of the validElements in data. 
+%
+% opts is a scalar struct that is required to have a field called
+% InferNulls. opts may have a field named Valid. If so, it takes 
+% precedence over InferNulls.
 
     if isfield(opts, "Valid")
         validElements = parseValid(numel(data), opts.Valid);

--- a/matlab/src/matlab/+arrow/+args/parseValidElements.m
+++ b/matlab/src/matlab/+arrow/+args/parseValidElements.m
@@ -13,11 +13,45 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-function validElements = parseValidElements(data, inferNulls)
-    % Returns a logical vector of the validElements in data. If inferNulls
-    % is true, calls ismissing on data to determine which elements are 
-    % null.
+function validElements = parseValidElements(data, opts)
+    % Returns a logical vector of the validElements in data. 
 
+    % opts is a scalar struct that is required to have a field called
+    % InferNulls. opts may have a field named Valid. If so, it takes 
+    % precedence over InferNulls.
+
+    if isfield(opts, "Valid")
+        validElements = parseValid(numel(data), opts.Valid);
+    else
+        validElements = parseInferNulls(data, opts.InferNulls);
+    end
+end
+
+function validElements = parseValid(numElements, valid)
+    if islogical(valid)
+        validElements = reshape(valid, [], 1);
+        if ~isscalar(validElements)
+            % Verify the logical vector has the correct number of elements
+            validateattributes(validElements, "logical", {'numel', numElements});
+        else
+            % TODO: consider making validElements empty if every 
+            % element is Valid.
+
+            % Expand scalar logical inputs to the correct dimensions
+            validElements = repmat(validElements, numElements, 1);
+        end
+    else
+        % valid is a list of indices. Verify the indices are numeric, 
+        % integers, and within the range 1 < indices < numElements.
+        validateattributes(valid, "numeric", {'integer', '>', 0, '<=', numElements});
+        % Create a logical vector that contains true values at the indices
+        % specified by opts.Valid.
+        validElements = false([numElements 1]);
+        validElements(valid) = true;
+    end
+end
+
+function validElements = parseInferNulls(data, inferNulls)
     if inferNulls
         % TODO: consider making validElements empty if everything is valid.
         validElements = ~ismissing(data);

--- a/matlab/src/matlab/+arrow/+args/validateTypeAndShape.m
+++ b/matlab/src/matlab/+arrow/+args/validateTypeAndShape.m
@@ -14,8 +14,8 @@
 % permissions and limitations under the License.
 
 function validateTypeAndShape(data, type)
-    % Validates data has the expected type and is a vector or empty 2D
-    % matrix. If data is numeric, validates is real and nonsparse.
+% Validates data has the expected type and is a vector or empty 2D
+% matrix. If data is numeric, validates is real and nonsparse.
 
     arguments
         data

--- a/matlab/src/matlab/+arrow/+array/Float32Array.m
+++ b/matlab/src/matlab/+arrow/+array/Float32Array.m
@@ -1,20 +1,19 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
 classdef Float32Array < arrow.array.Array
-    % arrow.array.Float32Array
-
-    % Licensed to the Apache Software Foundation (ASF) under one or more
-    % contributor license agreements.  See the NOTICE file distributed with
-    % this work for additional information regarding copyright ownership.
-    % The ASF licenses this file to you under the Apache License, Version
-    % 2.0 (the "License"); you may not use this file except in compliance
-    % with the License.  You may obtain a copy of the License at
-    %
-    %   http://www.apache.org/licenses/LICENSE-2.0
-    %
-    % Unless required by applicable law or agreed to in writing, software
-    % distributed under the License is distributed on an "AS IS" BASIS,
-    % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-    % implied.  See the License for the specific language governing
-    % permissions and limitations under the License.
+% arrow.array.Float32Array
 
     properties (Hidden, SetAccess=private)
         MatlabArray = single([])

--- a/matlab/src/matlab/+arrow/+array/Float64Array.m
+++ b/matlab/src/matlab/+arrow/+array/Float64Array.m
@@ -39,7 +39,7 @@ classdef Float64Array < arrow.array.Array
         function data = double(obj)
             data = obj.toMATLAB();
         end
-        
+
         function matlabArray = toMATLAB(obj)
             matlabArray = obj.Proxy.toMATLAB();
             matlabArray(~obj.Valid) = obj.NullSubstitionValue;

--- a/matlab/src/matlab/+arrow/+array/Float64Array.m
+++ b/matlab/src/matlab/+arrow/+array/Float64Array.m
@@ -22,14 +22,15 @@ classdef Float64Array < arrow.array.Array
     end
 
     methods
-        function obj = Float64Array(data, opts)
+        function obj = Float64Array(data, opts, nullOpts)
             arguments
                 data
                 opts.DeepCopy(1, 1) logical = false
-                opts.InferNulls(1, 1) logical = true
+                nullOpts.InferNulls(1, 1) logical = true
+                nullOpts.Valid
             end
             arrow.args.validateTypeAndShape(data, "double");
-            validElements = arrow.args.parseValidElements(data, opts.InferNulls);
+            validElements = arrow.args.parseValidElements(data, nullOpts);
             obj@arrow.array.Array("Name", "arrow.array.proxy.Float64Array", "ConstructorArguments", {data, opts.DeepCopy, validElements});
             % Store a reference to the array if not doing a deep copy
             if (~opts.DeepCopy), obj.MatlabArray = data; end

--- a/matlab/src/matlab/+arrow/+array/Float64Array.m
+++ b/matlab/src/matlab/+arrow/+array/Float64Array.m
@@ -1,20 +1,19 @@
+ % Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
 classdef Float64Array < arrow.array.Array
-    % arrow.array.Float64Array
-
-    % Licensed to the Apache Software Foundation (ASF) under one or more
-    % contributor license agreements.  See the NOTICE file distributed with
-    % this work for additional information regarding copyright ownership.
-    % The ASF licenses this file to you under the Apache License, Version
-    % 2.0 (the "License"); you may not use this file except in compliance
-    % with the License.  You may obtain a copy of the License at
-    %
-    %   http://www.apache.org/licenses/LICENSE-2.0
-    %
-    % Unless required by applicable law or agreed to in writing, software
-    % distributed under the License is distributed on an "AS IS" BASIS,
-    % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-    % implied.  See the License for the specific language governing
-    % permissions and limitations under the License.
+% arrow.array.Float64Array
 
     properties (Hidden, SetAccess=private)
         MatlabArray

--- a/matlab/src/matlab/+arrow/+array/Int16Array.m
+++ b/matlab/src/matlab/+arrow/+array/Int16Array.m
@@ -1,20 +1,20 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+    
 classdef Int16Array < arrow.array.Array
-    % arrow.array.Int16Array
-
-    % Licensed to the Apache Software Foundation (ASF) under one or more
-    % contributor license agreements.  See the NOTICE file distributed with
-    % this work for additional information regarding copyright ownership.
-    % The ASF licenses this file to you under the Apache License, Version
-    % 2.0 (the "License"); you may not use this file except in compliance
-    % with the License.  You may obtain a copy of the License at
-    %
-    %   http://www.apache.org/licenses/LICENSE-2.0
-    %
-    % Unless required by applicable law or agreed to in writing, software
-    % distributed under the License is distributed on an "AS IS" BASIS,
-    % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-    % implied.  See the License for the specific language governing
-    % permissions and limitations under the License.
+% arrow.array.Int16Array
 
     properties (Hidden, SetAccess=private)
         MatlabArray = int16([])

--- a/matlab/src/matlab/+arrow/+array/Int32Array.m
+++ b/matlab/src/matlab/+arrow/+array/Int32Array.m
@@ -1,20 +1,20 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
 classdef Int32Array < arrow.array.Array
     % arrow.array.Int32Array
-
-    % Licensed to the Apache Software Foundation (ASF) under one or more
-    % contributor license agreements.  See the NOTICE file distributed with
-    % this work for additional information regarding copyright ownership.
-    % The ASF licenses this file to you under the Apache License, Version
-    % 2.0 (the "License"); you may not use this file except in compliance
-    % with the License.  You may obtain a copy of the License at
-    %
-    %   http://www.apache.org/licenses/LICENSE-2.0
-    %
-    % Unless required by applicable law or agreed to in writing, software
-    % distributed under the License is distributed on an "AS IS" BASIS,
-    % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-    % implied.  See the License for the specific language governing
-    % permissions and limitations under the License.
 
     properties (Hidden, SetAccess=private)
         MatlabArray = int32([])

--- a/matlab/src/matlab/+arrow/+array/Int64Array.m
+++ b/matlab/src/matlab/+arrow/+array/Int64Array.m
@@ -1,20 +1,20 @@
-classdef Int64Array < arrow.array.Array
-    % arrow.array.Int64Array
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
 
-    % Licensed to the Apache Software Foundation (ASF) under one or more
-    % contributor license agreements.  See the NOTICE file distributed with
-    % this work for additional information regarding copyright ownership.
-    % The ASF licenses this file to you under the Apache License, Version
-    % 2.0 (the "License"); you may not use this file except in compliance
-    % with the License.  You may obtain a copy of the License at
-    %
-    %   http://www.apache.org/licenses/LICENSE-2.0
-    %
-    % Unless required by applicable law or agreed to in writing, software
-    % distributed under the License is distributed on an "AS IS" BASIS,
-    % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-    % implied.  See the License for the specific language governing
-    % permissions and limitations under the License.
+classdef Int64Array < arrow.array.Array
+% arrow.array.Int64Array
 
     properties (Hidden, SetAccess=private)
         MatlabArray = int64([])

--- a/matlab/src/matlab/+arrow/+array/Int8Array.m
+++ b/matlab/src/matlab/+arrow/+array/Int8Array.m
@@ -1,20 +1,20 @@
-classdef Int8Array < arrow.array.Array
-    % arrow.array.Int8Array
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
 
-    % Licensed to the Apache Software Foundation (ASF) under one or more
-    % contributor license agreements.  See the NOTICE file distributed with
-    % this work for additional information regarding copyright ownership.
-    % The ASF licenses this file to you under the Apache License, Version
-    % 2.0 (the "License"); you may not use this file except in compliance
-    % with the License.  You may obtain a copy of the License at
-    %
-    %   http://www.apache.org/licenses/LICENSE-2.0
-    %
-    % Unless required by applicable law or agreed to in writing, software
-    % distributed under the License is distributed on an "AS IS" BASIS,
-    % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-    % implied.  See the License for the specific language governing
-    % permissions and limitations under the License.
+classdef Int8Array < arrow.array.Array
+% arrow.array.Int8Array
 
     properties (Hidden, SetAccess=private)
         MatlabArray = int8([])

--- a/matlab/src/matlab/+arrow/+array/UInt16Array.m
+++ b/matlab/src/matlab/+arrow/+array/UInt16Array.m
@@ -1,20 +1,20 @@
-classdef UInt16Array < arrow.array.Array
-    % arrow.array.UInt16Array
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
 
-    % Licensed to the Apache Software Foundation (ASF) under one or more
-    % contributor license agreements.  See the NOTICE file distributed with
-    % this work for additional information regarding copyright ownership.
-    % The ASF licenses this file to you under the Apache License, Version
-    % 2.0 (the "License"); you may not use this file except in compliance
-    % with the License.  You may obtain a copy of the License at
-    %
-    %   http://www.apache.org/licenses/LICENSE-2.0
-    %
-    % Unless required by applicable law or agreed to in writing, software
-    % distributed under the License is distributed on an "AS IS" BASIS,
-    % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-    % implied.  See the License for the specific language governing
-    % permissions and limitations under the License.
+classdef UInt16Array < arrow.array.Array
+% arrow.array.UInt16Array
 
     properties (Hidden, SetAccess=private)
         MatlabArray = uint16([])

--- a/matlab/src/matlab/+arrow/+array/UInt32Array.m
+++ b/matlab/src/matlab/+arrow/+array/UInt32Array.m
@@ -1,20 +1,20 @@
-classdef UInt32Array < arrow.array.Array
-    % arrow.array.UInt32Array
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
 
-    % Licensed to the Apache Software Foundation (ASF) under one or more
-    % contributor license agreements.  See the NOTICE file distributed with
-    % this work for additional information regarding copyright ownership.
-    % The ASF licenses this file to you under the Apache License, Version
-    % 2.0 (the "License"); you may not use this file except in compliance
-    % with the License.  You may obtain a copy of the License at
-    %
-    %   http://www.apache.org/licenses/LICENSE-2.0
-    %
-    % Unless required by applicable law or agreed to in writing, software
-    % distributed under the License is distributed on an "AS IS" BASIS,
-    % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-    % implied.  See the License for the specific language governing
-    % permissions and limitations under the License.
+classdef UInt32Array < arrow.array.Array
+% arrow.array.UInt32Array
 
     properties (Hidden, SetAccess=private)
         MatlabArray = uint32([])

--- a/matlab/src/matlab/+arrow/+array/UInt64Array.m
+++ b/matlab/src/matlab/+arrow/+array/UInt64Array.m
@@ -1,20 +1,20 @@
-classdef UInt64Array < arrow.array.Array
-    % arrow.array.UInt64Array
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
 
-    % Licensed to the Apache Software Foundation (ASF) under one or more
-    % contributor license agreements.  See the NOTICE file distributed with
-    % this work for additional information regarding copyright ownership.
-    % The ASF licenses this file to you under the Apache License, Version
-    % 2.0 (the "License"); you may not use this file except in compliance
-    % with the License.  You may obtain a copy of the License at
-    %
-    %   http://www.apache.org/licenses/LICENSE-2.0
-    %
-    % Unless required by applicable law or agreed to in writing, software
-    % distributed under the License is distributed on an "AS IS" BASIS,
-    % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-    % implied.  See the License for the specific language governing
-    % permissions and limitations under the License.
+classdef UInt64Array < arrow.array.Array
+% arrow.array.UInt64Array
 
     properties (Hidden, SetAccess=private)
         MatlabArray = uint64([])

--- a/matlab/src/matlab/+arrow/+array/UInt8Array.m
+++ b/matlab/src/matlab/+arrow/+array/UInt8Array.m
@@ -1,20 +1,20 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+    
 classdef UInt8Array < arrow.array.Array
-    % arrow.array.UInt8Array
-
-    % Licensed to the Apache Software Foundation (ASF) under one or more
-    % contributor license agreements.  See the NOTICE file distributed with
-    % this work for additional information regarding copyright ownership.
-    % The ASF licenses this file to you under the Apache License, Version
-    % 2.0 (the "License"); you may not use this file except in compliance
-    % with the License.  You may obtain a copy of the License at
-    %
-    %   http://www.apache.org/licenses/LICENSE-2.0
-    %
-    % Unless required by applicable law or agreed to in writing, software
-    % distributed under the License is distributed on an "AS IS" BASIS,
-    % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-    % implied.  See the License for the specific language governing
-    % permissions and limitations under the License.
+% arrow.array.UInt8Array
 
     properties (Hidden, SetAccess=private)
         MatlabArray = uint8([])

--- a/matlab/test/arrow/args/tParseValidElements.m
+++ b/matlab/test/arrow/args/tParseValidElements.m
@@ -1,0 +1,163 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef tParseValidElements < matlab.unittest.TestCase
+    % Tests for arrow.args.parseValidElements
+    
+    methods(Test)
+        % Test methods
+        function InferNullsTrue(testCase)
+        % Verify values for which ismissing returns true for are not
+        % considered valid.
+            data = [1 NaN 3 NaN 5];
+            validElements = parseValidElements(data, InferNulls=true);
+            expectedValidElements = [true; false; true; false; true];
+            testCase.verifyEqual(validElements, expectedValidElements);
+
+            data = [1 2 3];
+            validElements = parseValidElements(data, InferNulls=true);
+            expectedValidElements = [true; true; true];
+            testCase.verifyEqual(validElements, expectedValidElements);
+        end
+
+        function InferNullsFalse(testCase)
+        % Verify all elements are treated as Valid wen InferNulls=false is
+        % provided - including values for which that ismissing returns true.
+            data = [1 NaN 3 NaN 5];
+            validElements = parseValidElements(data, InferNulls=false);
+            expectedValidElements = [true; true; true; true; true];
+            testCase.verifyEqual(validElements, expectedValidElements);
+        end
+
+        function LogicalValid(testCase)
+            data = [1 2 3]; 
+
+            % Supply a scalar true value for Valid 
+            validElements = parseValidElements(data, Valid=true);
+            expectedValidElements = [true; true; true];
+            testCase.verifyEqual(validElements, expectedValidElements);
+
+            % Supply a scalar false value for Valid
+            validElements = parseValidElements(data, Valid=false);
+            expectedValidElements = [false; false; false];
+            testCase.verifyEqual(validElements, expectedValidElements);
+
+            % Supply a logical vector for Valid
+            validElements = parseValidElements(data, Valid=[false; true; true]);
+            expectedValidElements = [false; true; true];
+            testCase.verifyEqual(validElements, expectedValidElements);
+        end
+
+        function NumericValid(testCase)
+            data = [1 2 3]; 
+
+            % Supply 1 valid index for Valid
+            validElements = parseValidElements(data, Valid=2);
+            expectedValidElements = [false; true; false];
+            testCase.verifyEqual(validElements, expectedValidElements);
+
+            % Supply a numeric vector for Valid 
+            validElements = parseValidElements(data, Valid=[1 3]);
+            expectedValidElements = [true; false; true];
+            testCase.verifyEqual(validElements, expectedValidElements);
+        end
+
+        function ComplexValidIndicesError(testCase)
+        % Verify parseValidElements errors if Valid is a numeric array
+        % containing complex numbers.
+            data = [1 2 3];
+            fcn = @() parseValidElements(data, Valid=[1i 2]);
+            testCase.verifyError(fcn, "MATLAB:expectedInteger");
+        end
+
+        function FloatingPointValidIndicesError(testCase)
+        % Verify parseValidElements errors if Valid is a numeric array
+        % containing floating point values.
+            data = [1 2 3];
+            fcn = @() parseValidElements(data, Valid=[1.1 2.1]);
+            testCase.verifyError(fcn, "MATLAB:expectedInteger");
+        end
+
+        function NegativeValidIndicesError(testCase)
+        % Verify parseValidElements errors if Valid is a numeric array
+        % containing negative numbers.
+            data = [1 2 3];
+            fcn = @() parseValidElements(data, Valid=-1);
+            testCase.verifyError(fcn, "MATLAB:notGreater");
+        end
+
+        function ValidIndicesNotInRangeError(testCase)
+        % Verify parseValidElements errors if Valid is a numeric array
+        % whose values are not between 1 and the number of  elements in 
+        % the data array.
+            data = [1 2 3];
+            fcn = @() parseValidElements(data, Valid=0);
+            testCase.verifyError(fcn, "MATLAB:notGreater");
+
+            fcn = @() parseValidElements(data, Valid=4);
+            testCase.verifyError(fcn, "MATLAB:notLessEqual");
+        end
+
+        function LogicalValidTooManyError(testCase)
+        % Verify parseValidElements errors if Valid is a logical array
+        % with more elements than data.
+            data = [1 2 3];
+            fcn = @() parseValidElements(data, Valid=[true false false true]);
+            testCase.verifyError(fcn, "MATLAB:incorrectNumel");
+        end
+
+        function LogicalValidTooFewError(testCase)
+        % Verify parseValidElements errors if Valid is a non-scalar logical
+        % array containing less elements than the data array.
+            data = [1 2 3];
+            fcn = @() parseValidElements(data, Valid=[true false]);
+            testCase.verifyError(fcn, "MATLAB:incorrectNumel");
+
+            fcn = @() parseValidElements(data, Valid=logical.empty(0, 1));
+            testCase.verifyError(fcn, "MATLAB:incorrectNumel");
+        end
+
+        function ValidPrecedenceOverInferNulls(testCase)
+        % Verify that if both InferNulls and Valid are supplied, Valid
+        % takes precedence over InferNulls.
+
+            data = [1 NaN 3];
+            validElements = parseValidElements(data, InferNulls=true, Valid=true);
+            expectedValidElements = [true; true; true];
+            testCase.verifyEqual(validElements, expectedValidElements);
+
+            validElements = parseValidElements(data, InferNulls=false, Valid=[true; false; false]);
+            expectedValidElements = [true; false; false];
+            testCase.verifyEqual(validElements, expectedValidElements);
+
+            validElements = parseValidElements(data, InferNulls=true, Valid=[1 2]);
+            expectedValidElements = [true; true; false];
+            testCase.verifyEqual(validElements, expectedValidElements);
+
+            validElements = parseValidElements(data, InferNulls=false, Valid=1);
+            expectedValidElements = [true; false; false];
+            testCase.verifyEqual(validElements, expectedValidElements);
+        end
+    end
+end
+
+function validElements = parseValidElements(data, opts)
+    arguments
+        data
+        opts.InferNulls = true;
+        opts.Valid
+    end
+    validElements = arrow.args.parseValidElements(data, opts);
+end

--- a/matlab/test/arrow/args/tParseValidElements.m
+++ b/matlab/test/arrow/args/tParseValidElements.m
@@ -19,8 +19,8 @@ classdef tParseValidElements < matlab.unittest.TestCase
     methods(Test)
         % Test methods
         function InferNullsTrue(testCase)
-        % Verify values for which ismissing returns true for are not
-        % considered valid.
+            % Verify values for which ismissing returns true for are not
+            % considered valid.
             data = [1 NaN 3 NaN 5];
             validElements = parseValidElements(data, InferNulls=true);
             expectedValidElements = [true; false; true; false; true];

--- a/matlab/test/arrow/args/tParseValidElements.m
+++ b/matlab/test/arrow/args/tParseValidElements.m
@@ -14,7 +14,7 @@
 % permissions and limitations under the License.
 
 classdef tParseValidElements < matlab.unittest.TestCase
-    % Tests for arrow.args.parseValidElements
+% Tests for arrow.args.parseValidElements
     
     methods(Test)
         % Test methods

--- a/matlab/test/arrow/args/tParseValidElements.m
+++ b/matlab/test/arrow/args/tParseValidElements.m
@@ -33,8 +33,8 @@ classdef tParseValidElements < matlab.unittest.TestCase
         end
 
         function InferNullsFalse(testCase)
-        % Verify all elements are treated as Valid wen InferNulls=false is
-        % provided - including values for which that ismissing returns true.
+            % Verify all elements are treated as Valid wen InferNulls=false is
+            % provided - including values for which that ismissing returns true.
             data = [1 NaN 3 NaN 5];
             validElements = parseValidElements(data, InferNulls=false);
             expectedValidElements = [true; true; true; true; true];

--- a/matlab/test/arrow/args/tParseValidElements.m
+++ b/matlab/test/arrow/args/tParseValidElements.m
@@ -75,8 +75,8 @@ classdef tParseValidElements < matlab.unittest.TestCase
         end
 
         function ComplexValidIndicesError(testCase)
-        % Verify parseValidElements errors if Valid is a numeric array
-        % containing complex numbers.
+            % Verify parseValidElements errors if Valid is a numeric array
+            % containing complex numbers.
             data = [1 2 3];
             fcn = @() parseValidElements(data, Valid=[1i 2]);
             testCase.verifyError(fcn, "MATLAB:expectedInteger");

--- a/matlab/test/arrow/array/hNumericArray.m
+++ b/matlab/test/arrow/array/hNumericArray.m
@@ -1,21 +1,22 @@
-classdef hNumericArray < matlab.unittest.TestCase
-    % Test class containing shared tests for numeric arrays.
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
 
-    % Licensed to the Apache Software Foundation (ASF) under one or more
-    % contributor license agreements.  See the NOTICE file distributed with
-    % this work for additional information regarding copyright ownership.
-    % The ASF licenses this file to you under the Apache License, Version
-    % 2.0 (the "License"); you may not use this file except in compliance
-    % with the License.  You may obtain a copy of the License at
-    %
-    %   http://www.apache.org/licenses/LICENSE-2.0
-    %
-    % Unless required by applicable law or agreed to in writing, software
-    % distributed under the License is distributed on an "AS IS" BASIS,
-    % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-    % implied.  See the License for the specific language governing
-    % permissions and limitations under the License.
-    properties (Abstract)
+classdef hNumericArray < matlab.unittest.TestCase
+% Test class containing shared tests for numeric arrays.
+
+      properties (Abstract)
         ArrowArrayClassName(1, 1) string
         ArrowArrayConstructor
         MatlabArrayFcn
@@ -30,7 +31,7 @@ classdef hNumericArray < matlab.unittest.TestCase
 
     methods(TestClassSetup)
         function verifyOnMatlabPath(tc)
-            % Verify the arrow array class is on the MATLAB Search Path.
+        % Verify the arrow array class is on the MATLAB Search Path.
             tc.assertTrue(~isempty(which(tc.ArrowArrayClassName)), ...
                 """" + tc.ArrowArrayClassName + """must be on the MATLAB path. " + ...
                 "Use ""addpath"" to add folders to the MATLAB path.");
@@ -45,9 +46,9 @@ classdef hNumericArray < matlab.unittest.TestCase
         end
 
         function ShallowCopyTest(tc)
-            % By default, NumericArrays do not create a deep copy on
-            % construction when constructed from a MATLAB array. Instead,
-            % it stores a shallow copy of the array keep the memory alive.
+        % By default, NumericArrays do not create a deep copy on
+        % construction when constructed from a MATLAB array. Instead,
+        % it stores a shallow copy of the array keep the memory alive.
             A = tc.ArrowArrayConstructor(tc.MatlabArrayFcn([1, 2, 3]));
             tc.verifyEqual(A.MatlabArray, tc.MatlabArrayFcn([1, 2, 3]));
             tc.verifyEqual(toMATLAB(A), tc.MatlabArrayFcn([1 2 3]'));
@@ -58,8 +59,8 @@ classdef hNumericArray < matlab.unittest.TestCase
         end
 
         function DeepCopyTest(tc)
-            % Verify NumericArrays does not store shallow copy of the 
-            % MATLAB array if DeepCopy=true was supplied.
+        % Verify NumericArrays does not store shallow copy of the 
+        % MATLAB array if DeepCopy=true was supplied.
             A = tc.ArrowArrayConstructor(tc.MatlabArrayFcn([1, 2, 3]), DeepCopy=true);
             tc.verifyEqual(A.MatlabArray, tc.MatlabArrayFcn([]));
             tc.verifyEqual(toMATLAB(A), tc.MatlabArrayFcn([1 2 3]'));
@@ -83,8 +84,8 @@ classdef hNumericArray < matlab.unittest.TestCase
         end
 
         function MatlabConversion(tc, MakeDeepCopy)
-            % Tests the type-specific conversion methods, e.g. single for
-            % arrow.array.Float32Array, double for array.array.Float64Array
+        % Tests the type-specific conversion methods, e.g. single for
+        % arrow.array.Float32Array, double for array.array.Float64Array
 
             % Create array from a scalar
             A1 = tc.ArrowArrayConstructor(tc.MatlabArrayFcn(100), DeepCopy=MakeDeepCopy);

--- a/matlab/test/arrow/array/tFloat32Array.m
+++ b/matlab/test/arrow/array/tFloat32Array.m
@@ -1,21 +1,21 @@
-classdef tFloat32Array < hNumericArray
-    % Tests for arrow.array.Float32rray
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
 
-    % Licensed to the Apache Software Foundation (ASF) under one or more
-    % contributor license agreements.  See the NOTICE file distributed with
-    % this work for additional information regarding copyright ownership.
-    % The ASF licenses this file to you under the Apache License, Version
-    % 2.0 (the "License"); you may not use this file except in compliance
-    % with the License.  You may obtain a copy of the License at
-    %
-    %   http://www.apache.org/licenses/LICENSE-2.0
-    %
-    % Unless required by applicable law or agreed to in writing, software
-    % distributed under the License is distributed on an "AS IS" BASIS,
-    % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-    % implied.  See the License for the specific language governing
-    % permissions and limitations under the License.
-    
+classdef tFloat32Array < hNumericArray
+% Tests for arrow.array.Float32rray
+
     properties
         ArrowArrayClassName = "arrow.array.Float32Array"
         ArrowArrayConstructor = @arrow.array.Float32Array

--- a/matlab/test/arrow/array/tFloat64Array.m
+++ b/matlab/test/arrow/array/tFloat64Array.m
@@ -99,16 +99,6 @@ classdef tFloat64Array < hNumericArray
         function LogicalValidNVPair(testCase)
             matlabArray = [1 2 3]; 
 
-            % Supply a scalar true value for Valid 
-            arrowArray = arrow.array.Float64Array(matlabArray, Valid=true);
-            testCase.verifyEqual(arrowArray.Valid, [true; true; true]);
-            testCase.verifyEqual(toMATLAB(arrowArray), [1; 2; 3]);
-
-            % Supply a scalar false value for Valid
-            arrowArray = arrow.array.Float64Array(matlabArray, Valid=false);
-            testCase.verifyEqual(arrowArray.Valid, [false; false; false]);
-            testCase.verifyEqual(toMATLAB(arrowArray), [NaN; NaN; NaN]);
-
             % Supply a logical vector for Valid
             arrowArray = arrow.array.Float64Array(matlabArray, Valid=[false; true; true]);
             testCase.verifyEqual(arrowArray.Valid, [false; true; true]);
@@ -118,55 +108,10 @@ classdef tFloat64Array < hNumericArray
         function NumericlValidNVPair(testCase)
             matlabArray = [1 2 3]; 
 
-            % Supply 1 valid index for Valid
-            arrowArray = arrow.array.Float64Array(matlabArray, Valid=2);
-            testCase.verifyEqual(arrowArray.Valid, [false; true; false]);
-            testCase.verifyEqual(toMATLAB(arrowArray), [NaN; 2; NaN]);
-
             % Supply a numeric vector for Valid 
             arrowArray = arrow.array.Float64Array(matlabArray, Valid=[1 3]);
             testCase.verifyEqual(arrowArray.Valid, [true; false; true]);
             testCase.verifyEqual(toMATLAB(arrowArray), [1; NaN; 3]);
-        end
-
-        function InvalidNumericValidNVPair(testCase)
-            matlabArray = [1 2 3]; 
-
-            % Valid contains complex numbers
-            fcn = @() arrow.array.Float64Array(matlabArray, Valid=[1i 2]);
-            testCase.verifyError(fcn, "MATLAB:expectedInteger");
-
-            % Valid contains floating point numbers
-            fcn = @() arrow.array.Float64Array(matlabArray, Valid=[1.1 3]);
-            testCase.verifyError(fcn, "MATLAB:expectedInteger");
-
-            % Valid contains negative numbers
-            fcn = @() arrow.array.Float64Array(matlabArray, Valid=-1);
-            testCase.verifyError(fcn, "MATLAB:notGreater");
-
-            % Valid contains 0
-            fcn = @() arrow.array.Float64Array(matlabArray, Valid=[0 1]);
-            testCase.verifyError(fcn, "MATLAB:notGreater");
-
-            % Valid contains values greater than num elements
-            fcn = @() arrow.array.Float64Array(matlabArray, Valid=4);
-            testCase.verifyError(fcn, "MATLAB:notLessEqual");
-        end
-
-        function InvalidLogicalValidNVPair(testCase)
-            matlabArray = [1 2 3]; 
-
-            % Valid has more elements than the array
-            fcn = @() arrow.array.Float64Array(matlabArray, Valid=[true false false true]);
-            testCase.verifyError(fcn, "MATLAB:incorrectNumel");
-
-            % Valid has less elements than the array
-            fcn = @() arrow.array.Float64Array(matlabArray, Valid=[true false]);
-            testCase.verifyError(fcn, "MATLAB:incorrectNumel");
-
-            % Valid is empty 
-            fcn = @() arrow.array.Float64Array(matlabArray, Valid=logical.empty(0, 1));
-            testCase.verifyError(fcn, "MATLAB:incorrectNumel");
         end
     end
 end

--- a/matlab/test/arrow/array/tFloat64Array.m
+++ b/matlab/test/arrow/array/tFloat64Array.m
@@ -14,7 +14,7 @@
 % permissions and limitations under the License.
     
 classdef tFloat64Array < hNumericArray
-    % Tests for arrow.array.Float64Array
+% Tests for arrow.array.Float64Array
 
     properties
         ArrowArrayClassName = "arrow.array.Float64Array"

--- a/matlab/test/arrow/array/tInt16Array.m
+++ b/matlab/test/arrow/array/tInt16Array.m
@@ -1,20 +1,20 @@
-classdef tInt16Array < hNumericArray
-    % Tests for arrow.array.Int16Array
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
 
-    % Licensed to the Apache Software Foundation (ASF) under one or more
-    % contributor license agreements.  See the NOTICE file distributed with
-    % this work for additional information regarding copyright ownership.
-    % The ASF licenses this file to you under the Apache License, Version
-    % 2.0 (the "License"); you may not use this file except in compliance
-    % with the License.  You may obtain a copy of the License at
-    %
-    %   http://www.apache.org/licenses/LICENSE-2.0
-    %
-    % Unless required by applicable law or agreed to in writing, software
-    % distributed under the License is distributed on an "AS IS" BASIS,
-    % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-    % implied.  See the License for the specific language governing
-    % permissions and limitations under the License.
+classdef tInt16Array < hNumericArray
+% Tests for arrow.array.Int16Array
     
     properties
         ArrowArrayClassName = "arrow.array.Int16Array"

--- a/matlab/test/arrow/array/tInt32Array.m
+++ b/matlab/test/arrow/array/tInt32Array.m
@@ -1,20 +1,20 @@
-classdef tInt32Array < hNumericArray
-    % Tests for arrow.array.Int32Array
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
 
-    % Licensed to the Apache Software Foundation (ASF) under one or more
-    % contributor license agreements.  See the NOTICE file distributed with
-    % this work for additional information regarding copyright ownership.
-    % The ASF licenses this file to you under the Apache License, Version
-    % 2.0 (the "License"); you may not use this file except in compliance
-    % with the License.  You may obtain a copy of the License at
-    %
-    %   http://www.apache.org/licenses/LICENSE-2.0
-    %
-    % Unless required by applicable law or agreed to in writing, software
-    % distributed under the License is distributed on an "AS IS" BASIS,
-    % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-    % implied.  See the License for the specific language governing
-    % permissions and limitations under the License.
+classdef tInt32Array < hNumericArray
+% Tests for arrow.array.Int32Array
     
     properties
         ArrowArrayClassName = "arrow.array.Int32Array"

--- a/matlab/test/arrow/array/tInt64Array.m
+++ b/matlab/test/arrow/array/tInt64Array.m
@@ -1,21 +1,21 @@
-classdef tInt64Array < hNumericArray
-    % Tests for arrow.array.Int64Array
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
 
-    % Licensed to the Apache Software Foundation (ASF) under one or more
-    % contributor license agreements.  See the NOTICE file distributed with
-    % this work for additional information regarding copyright ownership.
-    % The ASF licenses this file to you under the Apache License, Version
-    % 2.0 (the "License"); you may not use this file except in compliance
-    % with the License.  You may obtain a copy of the License at
-    %
-    %   http://www.apache.org/licenses/LICENSE-2.0
-    %
-    % Unless required by applicable law or agreed to in writing, software
-    % distributed under the License is distributed on an "AS IS" BASIS,
-    % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-    % implied.  See the License for the specific language governing
-    % permissions and limitations under the License.
-    
+classdef tInt64Array < hNumericArray
+% Tests for arrow.array.Int64Array
+
     properties
         ArrowArrayClassName = "arrow.array.Int64Array"
         ArrowArrayConstructor = @arrow.array.Int64Array

--- a/matlab/test/arrow/array/tInt8Array.m
+++ b/matlab/test/arrow/array/tInt8Array.m
@@ -1,20 +1,20 @@
-classdef tInt8Array < hNumericArray
-    % Tests for arrow.array.Int8Array
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
 
-    % Licensed to the Apache Software Foundation (ASF) under one or more
-    % contributor license agreements.  See the NOTICE file distributed with
-    % this work for additional information regarding copyright ownership.
-    % The ASF licenses this file to you under the Apache License, Version
-    % 2.0 (the "License"); you may not use this file except in compliance
-    % with the License.  You may obtain a copy of the License at
-    %
-    %   http://www.apache.org/licenses/LICENSE-2.0
-    %
-    % Unless required by applicable law or agreed to in writing, software
-    % distributed under the License is distributed on an "AS IS" BASIS,
-    % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-    % implied.  See the License for the specific language governing
-    % permissions and limitations under the License.
+classdef tInt8Array < hNumericArray
+% Tests for arrow.array.Int8Array
     
     properties
         ArrowArrayClassName = "arrow.array.Int8Array"

--- a/matlab/test/arrow/array/tUInt16Array.m
+++ b/matlab/test/arrow/array/tUInt16Array.m
@@ -1,20 +1,20 @@
-classdef tUInt16Array < hNumericArray
-    % Tests for arrow.array.UInt16Array
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
 
-    % Licensed to the Apache Software Foundation (ASF) under one or more
-    % contributor license agreements.  See the NOTICE file distributed with
-    % this work for additional information regarding copyright ownership.
-    % The ASF licenses this file to you under the Apache License, Version
-    % 2.0 (the "License"); you may not use this file except in compliance
-    % with the License.  You may obtain a copy of the License at
-    %
-    %   http://www.apache.org/licenses/LICENSE-2.0
-    %
-    % Unless required by applicable law or agreed to in writing, software
-    % distributed under the License is distributed on an "AS IS" BASIS,
-    % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-    % implied.  See the License for the specific language governing
-    % permissions and limitations under the License.
+classdef tUInt16Array < hNumericArray
+% Tests for arrow.array.UInt16Array
     
     properties
         ArrowArrayClassName = "arrow.array.UInt16Array"

--- a/matlab/test/arrow/array/tUInt32Array.m
+++ b/matlab/test/arrow/array/tUInt32Array.m
@@ -1,20 +1,20 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
 classdef tUInt32Array < hNumericArray
     % Tests for arrow.array.UInt32Array
-
-    % Licensed to the Apache Software Foundation (ASF) under one or more
-    % contributor license agreements.  See the NOTICE file distributed with
-    % this work for additional information regarding copyright ownership.
-    % The ASF licenses this file to you under the Apache License, Version
-    % 2.0 (the "License"); you may not use this file except in compliance
-    % with the License.  You may obtain a copy of the License at
-    %
-    %   http://www.apache.org/licenses/LICENSE-2.0
-    %
-    % Unless required by applicable law or agreed to in writing, software
-    % distributed under the License is distributed on an "AS IS" BASIS,
-    % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-    % implied.  See the License for the specific language governing
-    % permissions and limitations under the License.
     
     properties
         ArrowArrayClassName = "arrow.array.UInt32Array"

--- a/matlab/test/arrow/array/tUInt64Array.m
+++ b/matlab/test/arrow/array/tUInt64Array.m
@@ -1,21 +1,21 @@
-classdef tUInt64Array < hNumericArray
-    % Tests for arrow.array.UInt64Array
-
-    % Licensed to the Apache Software Foundation (ASF) under one or more
-    % contributor license agreements.  See the NOTICE file distributed with
-    % this work for additional information regarding copyright ownership.
-    % The ASF licenses this file to you under the Apache License, Version
-    % 2.0 (the "License"); you may not use this file except in compliance
-    % with the License.  You may obtain a copy of the License at
-    %
-    %   http://www.apache.org/licenses/LICENSE-2.0
-    %
-    % Unless required by applicable law or agreed to in writing, software
-    % distributed under the License is distributed on an "AS IS" BASIS,
-    % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-    % implied.  See the License for the specific language governing
-    % permissions and limitations under the License.
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
     
+classdef tUInt64Array < hNumericArray
+% Tests for arrow.array.UInt64Array
+
     properties
         ArrowArrayClassName = "arrow.array.UInt64Array"
         ArrowArrayConstructor = @arrow.array.UInt64Array

--- a/matlab/test/arrow/array/tUInt8Array.m
+++ b/matlab/test/arrow/array/tUInt8Array.m
@@ -1,20 +1,20 @@
-classdef tUInt8Array < hNumericArray
-    % Tests for arrow.array.UInt8Array
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
 
-    % Licensed to the Apache Software Foundation (ASF) under one or more
-    % contributor license agreements.  See the NOTICE file distributed with
-    % this work for additional information regarding copyright ownership.
-    % The ASF licenses this file to you under the Apache License, Version
-    % 2.0 (the "License"); you may not use this file except in compliance
-    % with the License.  You may obtain a copy of the License at
-    %
-    %   http://www.apache.org/licenses/LICENSE-2.0
-    %
-    % Unless required by applicable law or agreed to in writing, software
-    % distributed under the License is distributed on an "AS IS" BASIS,
-    % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-    % implied.  See the License for the specific language governing
-    % permissions and limitations under the License.
+classdef tUInt8Array < hNumericArray
+% Tests for arrow.array.UInt8Array
     
     properties
         ArrowArrayClassName = "arrow.array.UInt8Array"


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
Users should be able to specify exactly which elements in a MATLAB array should be treated as `null` values. In a previous PR, we added the name-value pair `InferNulls` which users can use to turn off the automatic "null detection" of values for which the MATLAB `ismissing` function returns true:

```MATLAB
>> matlabArray = [1 NaN 3];

% NaN is treated as null by default
>> arrowArray = arrow.array.Float64Array(matlabArray);

arrowArray = 

[
  1,
  null,
  3
]

% Don't treat NaN as a null value
>> arrowArray = arrow.array.Float64Array(matlabArray, InferNulls=false);

arrowArray = 

[
  1,
  nan,
  3
]
``` 

To provide more control, this PR adds a new name-value pair named `Valid`. This name-value pair will take precedence over `InferNulls` and allows users to specify which elements are valid using either a logical array or a list of indices:

```MATLAB
>> matlabArray = [1 NaN 3];

>> arrowArray = arrow.array.Float64Array(matlabArray, Valid=[true true false]);

arrowArray = 

[
  1,
  nan,
  null
]

>> arrowArray = arrow.array.Float64Array(matlabArray, Valid=[2 3]);

arrowArray = 

[
  null,
  nan,
  3
]

``` 

### What changes are included in this PR?

1. Added the `Valid` name-value pair to `arrow.array.Float64Array`.

### Are these changes tested?

1. Added a new test file called `tParseValidElements.m` to independently test the helper function `arrow.args.parseValidElements` used by `arrow.array.Float64Array`.
2. Added two integration tests in `tFloat64Array.m`.

### Are there any user-facing changes?
Yes, users can now pass the `Valid` name-value pair to `arrow.array.Float64Array`.

### Future Directions

1. Currently, only `arrow.array.Float64Array` supports the `InferNulls` and `Valid` name-value pairs. In a followup PR, we will add support for these name-value pairs to the rest of the numeric array classes. 

* Closes: #35693