### PR TITLE
GH-35974: [Go] Don't panic if importing C Array Stream fails

### DIFF
--- a/go/arrow/cdata/cdata.go
+++ b/go/arrow/cdata/cdata.go
@@ -717,7 +717,7 @@ func importCArrayAsType(arr *CArrowArray, dt arrow.DataType) (imp *cimporter, er
 	return
 }
 
-func initReader(rdr *nativeCRecordBatchReader, stream *CArrowArrayStream) {
+func initReader(rdr *nativeCRecordBatchReader, stream *CArrowArrayStream) error {
 	rdr.stream = C.get_stream()
 	C.ArrowArrayStreamMove(stream, rdr.stream)
 	rdr.arr = C.get_arr()
@@ -730,6 +730,20 @@ func initReader(rdr *nativeCRecordBatchReader, stream *CArrowArrayStream) {
 		C.free(unsafe.Pointer(r.stream))
 		C.free(unsafe.Pointer(r.arr))
 	})
+
+	var sc CArrowSchema
+	errno := C.stream_get_schema(rdr.stream, &sc)
+	if errno != 0 {
+		return rdr.getError(int(errno))
+	}
+	defer C.ArrowSchemaRelease(&sc)
+	s, err := ImportCArrowSchema((*CArrowSchema)(&sc))
+	if err != nil {
+		return err
+	}
+	rdr.schema = s
+
+	return nil
 }
 
 // Record Batch reader that conforms to arrio.Reader for the ArrowArrayStream interface
@@ -802,20 +816,6 @@ func (n *nativeCRecordBatchReader) next() error {
 }
 
 func (n *nativeCRecordBatchReader) Schema() *arrow.Schema {
-	if n.schema == nil {
-		var sc CArrowSchema
-		errno := C.stream_get_schema(n.stream, &sc)
-		if errno != 0 {
-			panic(n.getError(int(errno)))
-		}
-		defer C.ArrowSchemaRelease(&sc)
-		s, err := ImportCArrowSchema((*CArrowSchema)(&sc))
-		if err != nil {
-			panic(err)
-		}
-
-		n.schema = s
-	}
 	return n.schema
 }
 

--- a/go/arrow/cdata/cdata_test.go
+++ b/go/arrow/cdata/cdata_test.go
@@ -898,3 +898,19 @@ func TestRecordReaderError(t *testing.T) {
 	}
 	assert.Contains(t, err.Error(), "Expected error message")
 }
+
+func TestRecordReaderImportError(t *testing.T) {
+	// Regression test for apache/arrow#35974
+
+	err := fallibleSchemaTestDeprecated()
+	if err == nil {
+		t.Fatalf("Expected error but got nil")
+	}
+	assert.Contains(t, err.Error(), "Expected error message")
+
+	err = fallibleSchemaTest()
+	if err == nil {
+		t.Fatalf("Expected error but got nil")
+	}
+	assert.Contains(t, err.Error(), "Expected error message")
+}

--- a/go/arrow/cdata/cdata_test_framework.go
+++ b/go/arrow/cdata/cdata_test_framework.go
@@ -55,6 +55,7 @@ package cdata
 // struct ArrowSchema** test_schema(const char** fmts, const char** names, int64_t* flags, const int n);
 // struct ArrowSchema** test_union(const char** fmts, const char** names, int64_t* flags, const int n);
 // int test_exported_stream(struct ArrowArrayStream* stream);
+// void test_stream_schema_fallible(struct ArrowArrayStream* stream);
 import "C"
 import (
 	"errors"
@@ -309,15 +310,43 @@ func exportedStreamTest(reader array.RecordReader) error {
 func roundTripStreamTest(reader array.RecordReader) error {
 	out := C.get_test_stream()
 	ExportRecordReader(reader, out)
-	rdr := ImportCArrayStream(out, nil)
+	rdr, err := ImportCRecordReader(out, nil)
+
+	if err != nil {
+		return err
+	}
 
 	for {
-		_, err := rdr.Read()
+		_, err = rdr.Read()
 		if errors.Is(err, io.EOF) {
 			break
 		} else if err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func fallibleSchemaTestDeprecated() (err error) {
+	stream := CArrowArrayStream{}
+	C.test_stream_schema_fallible(&stream)
+
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("Panicked: %#v", r)
+		}
+	}()
+	_ = ImportCArrayStream(&stream, nil)
+	return nil
+}
+
+func fallibleSchemaTest() error {
+	stream := CArrowArrayStream{}
+	C.test_stream_schema_fallible(&stream)
+
+	_, err := ImportCRecordReader(&stream, nil)
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/go/arrow/cdata/interface.go
+++ b/go/arrow/cdata/interface.go
@@ -164,10 +164,32 @@ func ImportCRecordBatch(arr *CArrowArray, sc *CArrowSchema) (arrow.Record, error
 //
 // NOTE: The reader takes ownership of the underlying memory buffers via ArrowArrayStreamMove,
 // it does not take ownership of the actual stream object itself.
+//
+// Deprecated: This will panic if importing the schema fails (which is possible).
+// Prefer ImportCRecordReader instead.
 func ImportCArrayStream(stream *CArrowArrayStream, schema *arrow.Schema) arrio.Reader {
+	reader, err := ImportCRecordReader(stream, schema)
+	if err != nil {
+		panic(err)
+	}
+	return reader
+}
+
+// ImportCStreamReader creates an arrio.Reader from an ArrowArrayStream taking ownership
+// of the underlying stream object via ArrowArrayStreamMove.
+//
+// The records returned by this reader must be released manually after they are returned.
+// The reader itself will release the stream via SetFinalizer when it is garbage collected.
+// It will return (nil, io.EOF) from the Read function when there are no more records to return.
+//
+// NOTE: The reader takes ownership of the underlying memory buffers via ArrowArrayStreamMove,
+// it does not take ownership of the actual stream object itself.
+func ImportCRecordReader(stream *CArrowArrayStream, schema *arrow.Schema) (arrio.Reader, error) {
 	out := &nativeCRecordBatchReader{schema: schema}
-	initReader(out, stream)
-	return out
+	if err := initReader(out, stream); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // ExportArrowSchema populates the passed in CArrowSchema with the schema passed in so


### PR DESCRIPTION
### Rationale for this change
Panicking is rude.

### What changes are included in this PR?

Import C Array Stream schemas up front and report the error.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

`ImportCArrayStream` (which cannot fail, only panic) is deprecated in favor of `ImportCRecordReader` (which can return an error).
* Closes: #35974