### PR TITLE
GH-35982: [Go] Fix go1.18 broken builds

### DIFF
--- a/go/arrow/compute/exprs/exec.go
+++ b/go/arrow/compute/exprs/exec.go
@@ -285,7 +285,7 @@ func literalToDatum(mem memory.Allocator, lit expr.Literal, ext ExtensionIDSet) 
 				return nil, fmt.Errorf("%w: key type mismatch for %s, got key with type %s",
 					arrow.ErrInvalid, mapType, scalarKey.DataType())
 			}
-			if !arrow.TypeEqual(mapType.ValueType(), scalarValue.DataType()) {
+			if !arrow.TypeEqual(mapType.ItemType(), scalarValue.DataType()) {
 				return nil, fmt.Errorf("%w: value type mismatch for %s, got key with type %s",
 					arrow.ErrInvalid, mapType, scalarValue.DataType())
 			}
@@ -293,7 +293,7 @@ func literalToDatum(mem memory.Allocator, lit expr.Literal, ext ExtensionIDSet) 
 			keys[i], values[i] = scalarKey, scalarValue
 		}
 
-		keyBldr, valBldr := array.NewBuilder(mem, mapType.KeyType()), array.NewBuilder(mem, mapType.ValueType())
+		keyBldr, valBldr := array.NewBuilder(mem, mapType.KeyType()), array.NewBuilder(mem, mapType.ItemType())
 		defer keyBldr.Release()
 		defer valBldr.Release()
 

--- a/go/arrow/compute/exprs/types.go
+++ b/go/arrow/compute/exprs/types.go
@@ -623,7 +623,7 @@ func ToSubstraitType(dt arrow.DataType, nullable bool, ext ExtensionIDSet) (type
 		if err != nil {
 			return nil, err
 		}
-		valueType, err := ToSubstraitType(dt.ValueType(), dt.ValueField().Nullable, ext)
+		valueType, err := ToSubstraitType(dt.Elem(), dt.ElemField().Nullable, ext)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION

### Rationale for this change
Fix usage of deprecated functions to fix the Go 1.18 builds.

* Closes: #35982