### PR TITLE
GH-35990: [CI][C++][Windows] Don't use -l for "choco list"

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -267,7 +267,7 @@ jobs:
             /d 1 `
             /f
       - name: Installed Packages
-        run: choco list -l
+        run: choco list
       - name: Install Dependencies
         run: choco install -y --no-progress openssl
       - name: Checkout Arrow


### PR DESCRIPTION
### Rationale for this change

Because it's removed and needless now.

https://docs.chocolatey.org/en-us/guides/upgrading-to-chocolatey-v2-v6#the-list-command-now-lists-local-packages-only-and-the-local-only-and-lo-options-have-been-removed

> The List Command Now Lists Local Packages Only and the --local-only and -lo Options Have Been Removed
>
> In version 1.0.0 of Chocolatey CLI, we added notices that the choco list command will list only local packages, and deprecated the -l and it's alias options. See this [GitHub issue for more information](https://github.com/chocolatey/choco/issues/158). We have also removed the -a and it's alias options from the list command as it no longer made sense to have that option once side-by-side installs were removed.

### What changes are included in this PR?

Just removed "-l".

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #35990