### PR TITLE
GH-35988: [C#] The C data interface implementation can leak on import

### DIFF
--- a/csharp/src/Apache.Arrow/C/CArrowArrayExporter.cs
+++ b/csharp/src/Apache.Arrow/C/CArrowArrayExporter.cs
@@ -49,10 +49,6 @@ namespace Apache.Arrow.C
             {
                 throw new ArgumentNullException(nameof(cArray));
             }
-            if (cArray->release != null)
-            {
-                throw new ArgumentException("Cannot export array to a struct that is already initialized.", nameof(cArray));
-            }
 
             ExportedAllocationOwner allocationOwner = new ExportedAllocationOwner();
             try

--- a/csharp/src/Apache.Arrow/C/CArrowArrayImporter.cs
+++ b/csharp/src/Apache.Arrow/C/CArrowArrayImporter.cs
@@ -116,7 +116,7 @@ namespace Apache.Arrow.C
             {
                 if (_cArray.release != null)
                 {
-                    fixed (CArrowArray * cArray =  &_cArray)
+                    fixed (CArrowArray* cArray = &_cArray)
                     {
                         cArray->release(cArray);
                     }

--- a/csharp/src/Apache.Arrow/C/CArrowArrayImporter.cs
+++ b/csharp/src/Apache.Arrow/C/CArrowArrayImporter.cs
@@ -29,8 +29,7 @@ namespace Apache.Arrow.C
         /// </summary>
         /// <remarks>
         /// This will call the release callback once all of the buffers in the returned
-        /// IArrowArray are disposed. If freeOnRelease is set, it will also free the memory
-        /// for the CArrowArray itself on disposal.
+        /// IArrowArray are disposed.
         /// </remarks>
         /// <examples>
         /// Typically, you will allocate an uninitialized CArrowArray pointer,
@@ -43,7 +42,11 @@ namespace Apache.Arrow.C
         /// IArrowArray importedArray = CArrowArrayImporter.ImportArray(importedPtr);
         /// </code>
         /// </examples>
-        public static unsafe IArrowArray ImportArray(CArrowArray* ptr, IArrowType type, bool freeOnRelease)
+        /// <param name="ptr">The pointer to the array being imported</param>
+        /// <param name="type">The type of the array being imported</param>
+        /// <param name="freeOnRelease">If true, frees the memory for the CArrowArray on final release.</param>
+        /// <returns>The imported C# array</returns>
+        public static unsafe IArrowArray ImportArray(CArrowArray* ptr, IArrowType type, bool freeOnRelease = false)
         {
             ImportedArrowArray importedArray = null;
             try
@@ -62,8 +65,7 @@ namespace Apache.Arrow.C
         /// </summary>
         /// <remarks>
         /// This will call the release callback once all of the buffers in the returned
-        /// RecordBatch are disposed. If freeOnRelease is set, it will also free the memory
-        /// for the CArrowArray itself on disposal.
+        /// RecordBatch are disposed.
         /// </remarks>
         /// <examples>
         /// Typically, you will allocate an uninitialized CArrowArray pointer,
@@ -76,7 +78,11 @@ namespace Apache.Arrow.C
         /// RecordBatch batch = CArrowArrayImporter.ImportRecordBatch(importedPtr, schema);
         /// </code>
         /// </examples>
-        public static unsafe RecordBatch ImportRecordBatch(CArrowArray* ptr, Schema schema, bool freeOnRelease)
+        /// <param name="ptr">The pointer to the record batch being imported</param>
+        /// <param name="schema">The schema type of the record batch being imported</param>
+        /// <param name="freeOnRelease">If true, frees the memory for the CArrowArray on final release.</param>
+        /// <returns>The imported C# record batch</returns>
+        public static unsafe RecordBatch ImportRecordBatch(CArrowArray* ptr, Schema schema, bool freeOnRelease = false)
         {
             ImportedArrowArray importedArray = null;
             try

--- a/csharp/src/Apache.Arrow/C/CArrowArrayStreamExporter.cs
+++ b/csharp/src/Apache.Arrow/C/CArrowArrayStreamExporter.cs
@@ -53,10 +53,6 @@ namespace Apache.Arrow.C
             {
                 throw new ArgumentNullException(nameof(arrayStream));
             }
-            if (cArrayStream->release != null)
-            {
-                throw new ArgumentException("Cannot export array to a struct that is already initialized.", nameof(cArrayStream));
-            }
 
             cArrayStream->private_data = ExportedArrayStream.Export(arrayStream);
             cArrayStream->get_schema = (delegate* unmanaged[Stdcall]<CArrowArrayStream*, CArrowSchema*, int>)s_getSchemaArrayStream.Pointer;

--- a/csharp/src/Apache.Arrow/C/CArrowArrayStreamImporter.cs
+++ b/csharp/src/Apache.Arrow/C/CArrowArrayStreamImporter.cs
@@ -30,7 +30,6 @@ namespace Apache.Arrow.C
         /// <remarks>
         /// This will call the release callback on the passed struct if the function fails.
         /// Otherwise, the release callback is called when the IArrowArrayStream is disposed.
-        /// If freeOnRelease is set, it will also free the memory for the CArrowArrayStream itself on disposal.
         /// </remarks>
         /// <examples>
         /// Typically, you will allocate an uninitialized CArrowArrayStream pointer,
@@ -43,7 +42,10 @@ namespace Apache.Arrow.C
         /// IArrowArrayStream importedStream = CArrowArrayStreamImporter.ImportStream(importedPtr);
         /// </code>
         /// </examples>
-        public static unsafe IArrowArrayStream ImportArrayStream(CArrowArrayStream* ptr, bool freeOnRelease)
+        /// <param name="ptr">The pointer to the stream being imported</param>
+        /// <param name="freeOnRelease">If true, frees the memory for the CArrowArrayStream on final release.</param>
+        /// <returns>The imported C# array stream</returns>
+        public static unsafe IArrowArrayStream ImportArrayStream(CArrowArrayStream* ptr, bool freeOnRelease = false)
         {
             return new ImportedArrowArrayStream(ptr, freeOnRelease);
         }

--- a/csharp/src/Apache.Arrow/C/CArrowSchemaExporter.cs
+++ b/csharp/src/Apache.Arrow/C/CArrowSchemaExporter.cs
@@ -50,10 +50,6 @@ namespace Apache.Arrow.C
             {
                 throw new ArgumentNullException(nameof(schema));
             }
-            if (schema->release != null)
-            {
-                throw new ArgumentException("Cannot export schema to a struct that is already initialized.");
-            }
 
             schema->format = StringUtil.ToCStringUtf8(GetFormat(datatype));
             schema->name = null;

--- a/csharp/test/Apache.Arrow.Tests/CDataInterfaceDataTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/CDataInterfaceDataTests.cs
@@ -60,7 +60,7 @@ namespace Apache.Arrow.Tests
             CArrowArray* cArray = CArrowArray.Create();
             CArrowArrayExporter.ExportArray(array, cArray);
             Assert.False(cArray->release == null);
-            CArrowArrayImporter.ImportArray(cArray, array.Data.DataType).Dispose();
+            CArrowArrayImporter.ImportArray(cArray, array.Data.DataType, freeOnRelease: false).Dispose();
             Assert.True(cArray->release == null);
             CArrowArray.Free(cArray);
         }
@@ -82,10 +82,9 @@ namespace Apache.Arrow.Tests
 
             Assert.Throws<InvalidOperationException>(() =>
             {
-                CArrowArrayImporter.ImportArray(cArray, GetTestArray().Data.DataType);
+                CArrowArrayImporter.ImportArray(cArray, GetTestArray().Data.DataType, freeOnRelease: true);
             });
             Assert.True(wasCalled);
-            CArrowArray.Free(cArray);
 
             GC.KeepAlive(releaseCallback);
         }

--- a/csharp/test/Apache.Arrow.Tests/CDataInterfaceDataTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/CDataInterfaceDataTests.cs
@@ -60,7 +60,7 @@ namespace Apache.Arrow.Tests
             CArrowArray* cArray = CArrowArray.Create();
             CArrowArrayExporter.ExportArray(array, cArray);
             Assert.False(cArray->release == null);
-            CArrowArrayImporter.ImportArray(cArray, array.Data.DataType, freeOnRelease: false).Dispose();
+            CArrowArrayImporter.ImportArray(cArray, array.Data.DataType).Dispose();
             Assert.True(cArray->release == null);
             CArrowArray.Free(cArray);
         }
@@ -82,9 +82,11 @@ namespace Apache.Arrow.Tests
 
             Assert.Throws<InvalidOperationException>(() =>
             {
-                CArrowArrayImporter.ImportArray(cArray, GetTestArray().Data.DataType, freeOnRelease: true);
+                CArrowArrayImporter.ImportArray(cArray, GetTestArray().Data.DataType);
             });
             Assert.True(wasCalled);
+
+            CArrowArray.Free(cArray);
 
             GC.KeepAlive(releaseCallback);
         }

--- a/csharp/test/Apache.Arrow.Tests/CDataInterfacePythonTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/CDataInterfacePythonTests.cs
@@ -437,7 +437,7 @@ namespace Apache.Arrow.Tests
             }
 
             ArrowType type = CArrowSchemaImporter.ImportType(cSchema);
-            StringArray importedArray = (StringArray)CArrowArrayImporter.ImportArray(cArray, type);
+            StringArray importedArray = (StringArray)CArrowArrayImporter.ImportArray(cArray, type, freeOnRelease: true);
 
             Assert.Equal(5, importedArray.Length);
             Assert.Equal("hello", importedArray.GetString(0));
@@ -487,7 +487,7 @@ namespace Apache.Arrow.Tests
             }
 
             Schema schema = CArrowSchemaImporter.ImportSchema(cSchema);
-            RecordBatch recordBatch = CArrowArrayImporter.ImportRecordBatch(cArray, schema);
+            RecordBatch recordBatch = CArrowArrayImporter.ImportRecordBatch(cArray, schema, freeOnRelease: true);
 
             Assert.Equal(5, recordBatch.Length);
 
@@ -562,7 +562,7 @@ namespace Apache.Arrow.Tests
                 batchReader._export_to_c(streamPtr);
             }
 
-            IArrowArrayStream stream = CArrowArrayStreamImporter.ImportArrayStream(cArrayStream);
+            IArrowArrayStream stream = CArrowArrayStreamImporter.ImportArrayStream(cArrayStream, freeOnRelease: true);
             var batch1 = stream.ReadNextRecordBatchAsync().Result;
             Assert.Equal(5, batch1.Length);
 
@@ -674,14 +674,13 @@ namespace Apache.Arrow.Tests
             }
 
             Schema schema = CArrowSchemaImporter.ImportSchema(cImportSchema);
-            RecordBatch importedBatch = CArrowArrayImporter.ImportRecordBatch(cImportArray, schema);
+            RecordBatch importedBatch = CArrowArrayImporter.ImportRecordBatch(cImportArray, schema, freeOnRelease: true);
 
             ArrowReaderVerifier.CompareBatches(batch2, importedBatch, strictCompare: false); // Non-strict because span lengths won't match.
 
             // Since we allocated, we are responsible for freeing the pointer.
             CArrowArray.Free(cExportArray);
             CArrowSchema.Free(cExportSchema);
-            CArrowArray.Free(cImportArray);
             CArrowSchema.Free(cImportSchema);
         }
 

--- a/csharp/test/Apache.Arrow.Tests/CDataInterfacePythonTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/CDataInterfacePythonTests.cs
@@ -437,7 +437,7 @@ namespace Apache.Arrow.Tests
             }
 
             ArrowType type = CArrowSchemaImporter.ImportType(cSchema);
-            StringArray importedArray = (StringArray)CArrowArrayImporter.ImportArray(cArray, type, freeOnRelease: true);
+            StringArray importedArray = (StringArray)CArrowArrayImporter.ImportArray(cArray, type);
 
             Assert.Equal(5, importedArray.Length);
             Assert.Equal("hello", importedArray.GetString(0));
@@ -445,6 +445,8 @@ namespace Apache.Arrow.Tests
             Assert.Null(importedArray.GetString(2));
             Assert.Equal("foo", importedArray.GetString(3));
             Assert.Equal("bar", importedArray.GetString(4));
+
+            CArrowArray.Free(cArray);
         }
 
         [SkippableFact]
@@ -487,7 +489,8 @@ namespace Apache.Arrow.Tests
             }
 
             Schema schema = CArrowSchemaImporter.ImportSchema(cSchema);
-            RecordBatch recordBatch = CArrowArrayImporter.ImportRecordBatch(cArray, schema, freeOnRelease: true);
+            RecordBatch recordBatch = CArrowArrayImporter.ImportRecordBatch(cArray, schema);
+            CArrowArray.Free(cArray);
 
             Assert.Equal(5, recordBatch.Length);
 
@@ -562,7 +565,9 @@ namespace Apache.Arrow.Tests
                 batchReader._export_to_c(streamPtr);
             }
 
-            IArrowArrayStream stream = CArrowArrayStreamImporter.ImportArrayStream(cArrayStream, freeOnRelease: true);
+            IArrowArrayStream stream = CArrowArrayStreamImporter.ImportArrayStream(cArrayStream);
+            CArrowArrayStream.Free(cArrayStream);
+
             var batch1 = stream.ReadNextRecordBatchAsync().Result;
             Assert.Equal(5, batch1.Length);
 
@@ -674,13 +679,14 @@ namespace Apache.Arrow.Tests
             }
 
             Schema schema = CArrowSchemaImporter.ImportSchema(cImportSchema);
-            RecordBatch importedBatch = CArrowArrayImporter.ImportRecordBatch(cImportArray, schema, freeOnRelease: true);
+            RecordBatch importedBatch = CArrowArrayImporter.ImportRecordBatch(cImportArray, schema);
 
             ArrowReaderVerifier.CompareBatches(batch2, importedBatch, strictCompare: false); // Non-strict because span lengths won't match.
 
             // Since we allocated, we are responsible for freeing the pointer.
             CArrowArray.Free(cExportArray);
             CArrowSchema.Free(cExportSchema);
+            CArrowArray.Free(cImportArray);
             CArrowSchema.Free(cImportSchema);
         }
 


### PR DESCRIPTION
### What changes are included in this PR?

To ensure proper cleanup, immediately copies the contents of the C structure into the imported class for arrays and streams.
Relaxes the requirement when exporting that the target structure appear uninitialized.

### Are these changes tested?

Existing tests pass. We don't as yet seem to have a good way to test for memory leaks so no new tests have been added.

### Are there any user-facing changes?

No.

* Closes: #35988