### PR TITLE
GH-35858: [Python] disallow none schema parquet writer

### DIFF
--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -1691,7 +1691,7 @@ cdef class ParquetWriter(_Weakrefable):
         int64_t dictionary_pagesize_limit
         object store_schema
 
-    def __cinit__(self, where, Schema schema, use_dictionary=None,
+    def __cinit__(self, where, Schema schema not None, use_dictionary=None,
                   compression=None, version=None,
                   write_statistics=None,
                   MemoryPool memory_pool=None,

--- a/python/pyarrow/tests/parquet/test_parquet_writer.py
+++ b/python/pyarrow/tests/parquet/test_parquet_writer.py
@@ -93,6 +93,14 @@ def test_validate_schema_write_table(tempdir):
         with pytest.raises(ValueError):
             w.write_table(simple_table)
 
+def test_parquet_invalid_writer():
+
+    with pytest.raises(TypeError):
+        some_schema = pa.schema([pa.field("x", pa.int32())])
+        pq.ParquetWriter(None, some_schema)
+
+    with pytest.raises(TypeError):
+        pq.ParquetWriter("some_path", None)
 
 @pytest.mark.pandas
 @parametrize_legacy_dataset


### PR DESCRIPTION
### Rationale for this change

Previously, passing in None for the schema would cause a segmentation fault.

### What changes are included in this PR?

Now a TypeError is raised instead

### Are these changes tested?

Yes, a new unit test is created

### Are there any user-facing changes?

No
* Closes: #35858