### PR TITLE
GH-36014: [Go] Allow duplicate field names in structs

### DIFF
--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -1722,7 +1722,6 @@ def get_generated_json_files(tempdir=None):
 
         generate_duplicate_fieldnames_case()
         .skip_category('C#')
-        .skip_category('Go')
         .skip_category('JS'),
 
         generate_dictionary_case()

--- a/go/arrow/compare_test.go
+++ b/go/arrow/compare_test.go
@@ -116,13 +116,13 @@ func TestTypeEqual(t *testing.T) {
 				fields: []Field{
 					{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true},
 				},
-				index: map[string]int{"f1": 0},
+				index: map[string][]int{"f1": []int{0}},
 			},
 			&StructType{
 				fields: []Field{
 					{Name: "f1", Type: PrimitiveTypes.Uint32, Nullable: true},
 				},
-				index: map[string]int{"f1": 0},
+				index: map[string][]int{"f1": []int{0}},
 			},
 			false, true,
 		},
@@ -131,13 +131,13 @@ func TestTypeEqual(t *testing.T) {
 				fields: []Field{
 					{Name: "f1", Type: PrimitiveTypes.Uint32, Nullable: false},
 				},
-				index: map[string]int{"f1": 0},
+				index: map[string][]int{"f1": []int{0}},
 			},
 			&StructType{
 				fields: []Field{
 					{Name: "f1", Type: PrimitiveTypes.Uint32, Nullable: true},
 				},
-				index: map[string]int{"f1": 0},
+				index: map[string][]int{"f1": []int{0}},
 			},
 			false, false,
 		},
@@ -146,13 +146,13 @@ func TestTypeEqual(t *testing.T) {
 				fields: []Field{
 					{Name: "f0", Type: PrimitiveTypes.Uint32, Nullable: true},
 				},
-				index: map[string]int{"f0": 0},
+				index: map[string][]int{"f0": []int{0}},
 			},
 			&StructType{
 				fields: []Field{
 					{Name: "f1", Type: PrimitiveTypes.Uint32, Nullable: true},
 				},
-				index: map[string]int{"f1": 0},
+				index: map[string][]int{"f1": []int{0}},
 			},
 			false, false,
 		},
@@ -161,14 +161,14 @@ func TestTypeEqual(t *testing.T) {
 				fields: []Field{
 					{Name: "f1", Type: PrimitiveTypes.Uint32, Nullable: true},
 				},
-				index: map[string]int{"f1": 0},
+				index: map[string][]int{"f1": []int{0}},
 			},
 			&StructType{
 				fields: []Field{
 					{Name: "f1", Type: PrimitiveTypes.Uint32, Nullable: true},
 					{Name: "f2", Type: PrimitiveTypes.Uint32, Nullable: true},
 				},
-				index: map[string]int{"f1": 0, "f2": 1},
+				index: map[string][]int{"f1": []int{0}, "f2": []int{1}},
 			},
 			false, true,
 		},
@@ -177,14 +177,14 @@ func TestTypeEqual(t *testing.T) {
 				fields: []Field{
 					{Name: "f1", Type: PrimitiveTypes.Uint32, Nullable: true},
 				},
-				index: map[string]int{"f1": 0},
+				index: map[string][]int{"f1": []int{0}},
 			},
 			&StructType{
 				fields: []Field{
 					{Name: "f1", Type: PrimitiveTypes.Uint32, Nullable: true},
 					{Name: "f2", Type: PrimitiveTypes.Uint32, Nullable: true},
 				},
-				index: map[string]int{"f1": 0, "f2": 1},
+				index: map[string][]int{"f1": []int{0}, "f2": []int{1}},
 			},
 			false, false,
 		},
@@ -193,13 +193,13 @@ func TestTypeEqual(t *testing.T) {
 				fields: []Field{
 					{Name: "f1", Type: PrimitiveTypes.Uint32, Nullable: true},
 				},
-				index: map[string]int{"f1": 0},
+				index: map[string][]int{"f1": []int{0}},
 			},
 			&StructType{
 				fields: []Field{
 					{Name: "f2", Type: PrimitiveTypes.Uint32, Nullable: true},
 				},
-				index: map[string]int{"f2": 0},
+				index: map[string][]int{"f2": []int{0}},
 			},
 			false, false,
 		},
@@ -209,14 +209,14 @@ func TestTypeEqual(t *testing.T) {
 					{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true},
 					{Name: "f2", Type: PrimitiveTypes.Float32, Nullable: false},
 				},
-				index: map[string]int{"f1": 0, "f2": 1},
+				index: map[string][]int{"f1": []int{0}, "f2": []int{1}},
 			},
 			&StructType{
 				fields: []Field{
 					{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true},
 					{Name: "f2", Type: PrimitiveTypes.Float32, Nullable: false},
 				},
-				index: map[string]int{"f1": 0, "f2": 1},
+				index: map[string][]int{"f1": []int{0}, "f2": []int{1}},
 			},
 			true, false,
 		},
@@ -226,14 +226,14 @@ func TestTypeEqual(t *testing.T) {
 					{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true},
 					{Name: "f2", Type: PrimitiveTypes.Float32, Nullable: false},
 				},
-				index: map[string]int{"f1": 0, "f2": 1},
+				index: map[string][]int{"f1": []int{0}, "f2": []int{1}},
 			},
 			&StructType{
 				fields: []Field{
 					{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true},
 					{Name: "f2", Type: PrimitiveTypes.Float32, Nullable: false},
 				},
-				index: map[string]int{"f1": 0, "f2": 1},
+				index: map[string][]int{"f1": []int{0}, "f2": []int{1}},
 			},
 			true, false,
 		},
@@ -243,7 +243,7 @@ func TestTypeEqual(t *testing.T) {
 					{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true},
 					{Name: "f2", Type: PrimitiveTypes.Float32, Nullable: false},
 				},
-				index: map[string]int{"f1": 0, "f2": 1},
+				index: map[string][]int{"f1": []int{0}, "f2": []int{1}},
 				meta:  MetadataFrom(map[string]string{"k1": "v1", "k2": "v2"}),
 			},
 			&StructType{
@@ -251,7 +251,7 @@ func TestTypeEqual(t *testing.T) {
 					{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true},
 					{Name: "f2", Type: PrimitiveTypes.Float32, Nullable: false},
 				},
-				index: map[string]int{"f1": 0, "f2": 1},
+				index: map[string][]int{"f1": []int{0}, "f2": []int{1}},
 				meta:  MetadataFrom(map[string]string{"k2": "v2", "k1": "v1"}),
 			},
 			true, true,
@@ -261,14 +261,14 @@ func TestTypeEqual(t *testing.T) {
 				fields: []Field{
 					{Name: "f1", Type: PrimitiveTypes.Uint32, Nullable: true},
 				},
-				index: map[string]int{"f1": 0},
+				index: map[string][]int{"f1": []int{0}},
 				meta:  MetadataFrom(map[string]string{"k1": "v1"}),
 			},
 			&StructType{
 				fields: []Field{
 					{Name: "f1", Type: PrimitiveTypes.Uint32, Nullable: true},
 				},
-				index: map[string]int{"f1": 0},
+				index: map[string][]int{"f1": []int{0}},
 				meta:  MetadataFrom(map[string]string{"k1": "v2"}),
 			},
 			true, false,
@@ -279,14 +279,48 @@ func TestTypeEqual(t *testing.T) {
 					{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true, Metadata: MetadataFrom(map[string]string{"k1": "v1"})},
 					{Name: "f2", Type: PrimitiveTypes.Float32, Nullable: false},
 				},
-				index: map[string]int{"f1": 0, "f2": 1},
+				index: map[string][]int{"f1": []int{0}, "f2": []int{1}},
 			},
 			&StructType{
 				fields: []Field{
 					{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true, Metadata: MetadataFrom(map[string]string{"k1": "v2"})},
 					{Name: "f2", Type: PrimitiveTypes.Float32, Nullable: false},
 				},
-				index: map[string]int{"f1": 0, "f2": 1},
+				index: map[string][]int{"f1": []int{0}, "f2": []int{1}},
+			},
+			false, true,
+		},
+		{
+			&StructType{
+				fields: []Field{
+					{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true},
+					{Name: "f1", Type: PrimitiveTypes.Uint32, Nullable: true},
+				},
+				index: map[string][]int{"f1": []int{0, 1}},
+			},
+			&StructType{
+				fields: []Field{
+					{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true},
+					{Name: "f1", Type: PrimitiveTypes.Uint32, Nullable: true},
+				},
+				index: map[string][]int{"f1": []int{0, 1}},
+			},
+			true, true,
+		},
+		{
+			&StructType{
+				fields: []Field{
+					{Name: "f1", Type: PrimitiveTypes.Uint32, Nullable: true},
+					{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true},
+				},
+				index: map[string][]int{"f1": []int{0, 1}},
+			},
+			&StructType{
+				fields: []Field{
+					{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true},
+					{Name: "f1", Type: PrimitiveTypes.Uint32, Nullable: true},
+				},
+				index: map[string][]int{"f1": []int{0, 1}},
 			},
 			false, true,
 		},

--- a/go/arrow/datatype_nested.go
+++ b/go/arrow/datatype_nested.go
@@ -246,13 +246,12 @@ func (*FixedSizeListType) Layout() DataTypeLayout {
 // of relative types, called its fields.
 type StructType struct {
 	fields []Field
-	index  map[string]int
+	index  map[string][]int
 	meta   Metadata
 }
 
 // StructOf returns the struct type with fields fs.
 //
-// StructOf panics if there are duplicated fields.
 // StructOf panics if there is a field with an invalid DataType.
 func StructOf(fs ...Field) *StructType {
 	n := len(fs)
@@ -262,7 +261,7 @@ func StructOf(fs ...Field) *StructType {
 
 	t := &StructType{
 		fields: make([]Field, n),
-		index:  make(map[string]int, n),
+		index:  make(map[string][]int, n),
 	}
 	for i, f := range fs {
 		if f.Type == nil {
@@ -274,10 +273,11 @@ func StructOf(fs ...Field) *StructType {
 			Nullable: f.Nullable,
 			Metadata: f.Metadata.clone(),
 		}
-		if _, dup := t.index[f.Name]; dup {
-			panic(fmt.Errorf("arrow: duplicate field with name %q", f.Name))
+		if indices, exists := t.index[f.Name]; exists {
+			t.index[f.Name] = append(indices, i)
+		} else {
+			t.index[f.Name] = []int{i}
 		}
-		t.index[f.Name] = i
 	}
 
 	return t
@@ -309,17 +309,28 @@ func (t *StructType) Fields() []Field {
 
 func (t *StructType) Field(i int) Field { return t.fields[i] }
 
+// FieldByName gets the field with the given name.
+//
+// If there are multiple fields with the given name, FieldByName
+// returns the first such field.
 func (t *StructType) FieldByName(name string) (Field, bool) {
 	i, ok := t.index[name]
 	if !ok {
 		return Field{}, false
 	}
-	return t.fields[i], true
+	return t.fields[i[0]], true
 }
 
+// FieldIdx gets the index of the field with the given name.
+//
+// If there are multiple fields with the given name, FieldIdx returns
+// the index of the first first such field.
 func (t *StructType) FieldIdx(name string) (int, bool) {
 	i, ok := t.index[name]
-	return i, ok
+	if ok {
+		return i[0], true
+	}
+	return -1, false
 }
 
 func (t *StructType) Fingerprint() string {

--- a/go/arrow/datatype_nested.go
+++ b/go/arrow/datatype_nested.go
@@ -333,6 +333,24 @@ func (t *StructType) FieldIdx(name string) (int, bool) {
 	return -1, false
 }
 
+// FieldsByName returns all fields with the given name.
+func (t *StructType) FieldsByName(n string) ([]Field, bool) {
+	indices, ok := t.index[n]
+	if !ok {
+		return nil, ok
+	}
+	fields := make([]Field, 0, len(indices))
+	for _, v := range indices {
+		fields = append(fields, t.fields[v])
+	}
+	return fields, ok
+}
+
+// FieldIndices returns indices of all fields with the given name, or nil.
+func (t *StructType) FieldIndices(name string) []int {
+	return t.index[name]
+}
+
 func (t *StructType) Fingerprint() string {
 	var b strings.Builder
 	b.WriteString(typeFingerprint(t))

--- a/go/arrow/datatype_nested_test.go
+++ b/go/arrow/datatype_nested_test.go
@@ -272,6 +272,26 @@ func TestStructField(t *testing.T) {
 	_, ok = ty.FieldIdx("f4")
 	assert.False(t, ok)
 
+	flds, ok := ty.FieldsByName("f1")
+	assert.True(t, ok)
+	assert.Equal(t, flds, []Field{fields[0]})
+
+	flds, ok = ty.FieldsByName("f2")
+	assert.True(t, ok)
+	assert.Equal(t, flds, []Field{fields[1]})
+
+	flds, ok = ty.FieldsByName("f3")
+	assert.True(t, ok)
+	assert.Equal(t, flds, []Field{fields[2]})
+
+	flds, ok = ty.FieldsByName("f4")
+	assert.False(t, ok)
+
+	assert.Equal(t, ty.FieldIndices("f1"), []int{0})
+	assert.Equal(t, ty.FieldIndices("f2"), []int{1})
+	assert.Equal(t, ty.FieldIndices("f3"), []int{2})
+	assert.Equal(t, ty.FieldIndices("f4"), []int(nil))
+
 	fields = []Field{
 		{Name: "f1", Type: PrimitiveTypes.Int32},
 		{Name: "f2", Type: PrimitiveTypes.Int64},
@@ -299,6 +319,21 @@ func TestStructField(t *testing.T) {
 
 	_, ok = ty.FieldIdx("f3")
 	assert.False(t, ok)
+
+	flds, ok = ty.FieldsByName("f1")
+	assert.True(t, ok)
+	assert.Equal(t, flds, []Field{fields[0], fields[2]})
+
+	flds, ok = ty.FieldsByName("f2")
+	assert.True(t, ok)
+	assert.Equal(t, flds, []Field{fields[1]})
+
+	flds, ok = ty.FieldsByName("f3")
+	assert.False(t, ok)
+
+	assert.Equal(t, ty.FieldIndices("f1"), []int{0, 2})
+	assert.Equal(t, ty.FieldIndices("f2"), []int{1})
+	assert.Equal(t, ty.FieldIndices("f3"), []int(nil))
 }
 
 func TestFieldEqual(t *testing.T) {

--- a/go/arrow/datatype_nested_test.go
+++ b/go/arrow/datatype_nested_test.go
@@ -94,14 +94,14 @@ func TestStructOf(t *testing.T) {
 			fields: []Field{{Name: "f1", Type: PrimitiveTypes.Int32}},
 			want: &StructType{
 				fields: []Field{{Name: "f1", Type: PrimitiveTypes.Int32}},
-				index:  map[string]int{"f1": 0},
+				index:  map[string][]int{"f1": []int{0}},
 			},
 		},
 		{
 			fields: []Field{{Name: "f1", Type: PrimitiveTypes.Int32, Nullable: true}},
 			want: &StructType{
 				fields: []Field{{Name: "f1", Type: PrimitiveTypes.Int32, Nullable: true}},
-				index:  map[string]int{"f1": 0},
+				index:  map[string][]int{"f1": []int{0}},
 			},
 		},
 		{
@@ -114,7 +114,7 @@ func TestStructOf(t *testing.T) {
 					{Name: "f1", Type: PrimitiveTypes.Int32},
 					{Name: "", Type: PrimitiveTypes.Int64},
 				},
-				index: map[string]int{"f1": 0, "": 1},
+				index: map[string][]int{"f1": []int{0}, "": []int{1}},
 			},
 		},
 		{
@@ -127,7 +127,7 @@ func TestStructOf(t *testing.T) {
 					{Name: "f1", Type: PrimitiveTypes.Int32},
 					{Name: "f2", Type: PrimitiveTypes.Int64},
 				},
-				index: map[string]int{"f1": 0, "f2": 1},
+				index: map[string][]int{"f1": []int{0}, "f2": []int{1}},
 			},
 		},
 		{
@@ -142,7 +142,7 @@ func TestStructOf(t *testing.T) {
 					{Name: "f2", Type: PrimitiveTypes.Int64},
 					{Name: "f3", Type: ListOf(PrimitiveTypes.Float64)},
 				},
-				index: map[string]int{"f1": 0, "f2": 1, "f3": 2},
+				index: map[string][]int{"f1": []int{0}, "f2": []int{1}, "f3": []int{2}},
 			},
 		},
 		{
@@ -157,7 +157,7 @@ func TestStructOf(t *testing.T) {
 					{Name: "f2", Type: PrimitiveTypes.Int64},
 					{Name: "f3", Type: ListOf(ListOf(PrimitiveTypes.Float64))},
 				},
-				index: map[string]int{"f1": 0, "f2": 1, "f3": 2},
+				index: map[string][]int{"f1": []int{0}, "f2": []int{1}, "f3": []int{2}},
 			},
 		},
 		{
@@ -172,7 +172,22 @@ func TestStructOf(t *testing.T) {
 					{Name: "f2", Type: PrimitiveTypes.Int64},
 					{Name: "f3", Type: ListOf(ListOf(StructOf(Field{Name: "f1", Type: PrimitiveTypes.Float64})))},
 				},
-				index: map[string]int{"f1": 0, "f2": 1, "f3": 2},
+				index: map[string][]int{"f1": []int{0}, "f2": []int{1}, "f3": []int{2}},
+			},
+		},
+		{
+			fields: []Field{
+				{Name: "f1", Type: PrimitiveTypes.Int32},
+				{Name: "f2", Type: PrimitiveTypes.Int64},
+				{Name: "f1", Type: PrimitiveTypes.Int64},
+			},
+			want: &StructType{
+				fields: []Field{
+					{Name: "f1", Type: PrimitiveTypes.Int32},
+					{Name: "f2", Type: PrimitiveTypes.Int64},
+					{Name: "f1", Type: PrimitiveTypes.Int64},
+				},
+				index: map[string][]int{"f1": []int{0, 2}, "f2": []int{1}},
 			},
 		},
 	} {
@@ -217,33 +232,73 @@ func TestStructOf(t *testing.T) {
 			}
 		})
 	}
+}
 
-	for _, tc := range []struct {
-		fields []Field
-	}{
-		{
-			fields: []Field{
-				{Name: "", Type: PrimitiveTypes.Int32},
-				{Name: "", Type: PrimitiveTypes.Int32},
-			},
-		},
-		{
-			fields: []Field{
-				{Name: "x", Type: PrimitiveTypes.Int32},
-				{Name: "x", Type: PrimitiveTypes.Int32},
-			},
-		},
-	} {
-		t.Run("", func(t *testing.T) {
-			defer func() {
-				e := recover()
-				if e == nil {
-					t.Fatalf("should have panicked")
-				}
-			}()
-			_ = StructOf(tc.fields...)
-		})
+func TestStructField(t *testing.T) {
+	fields := []Field{
+		{Name: "f1", Type: PrimitiveTypes.Int32},
+		{Name: "f2", Type: PrimitiveTypes.Int64},
+		{Name: "f3", Type: ListOf(ListOf(PrimitiveTypes.Float64))},
 	}
+	ty := StructOf(fields...)
+
+	field, ok := ty.FieldByName("f1")
+	assert.True(t, ok)
+	assert.True(t, field.Equal(fields[0]))
+
+	field, ok = ty.FieldByName("f2")
+	assert.True(t, ok)
+	assert.True(t, field.Equal(fields[1]))
+
+	field, ok = ty.FieldByName("f3")
+	assert.True(t, ok)
+	assert.True(t, field.Equal(fields[2]))
+
+	_, ok = ty.FieldByName("f4")
+	assert.False(t, ok)
+
+	idx, ok := ty.FieldIdx("f1")
+	assert.True(t, ok)
+	assert.Equal(t, idx, 0)
+
+	idx, ok = ty.FieldIdx("f2")
+	assert.True(t, ok)
+	assert.Equal(t, idx, 1)
+
+	idx, ok = ty.FieldIdx("f3")
+	assert.True(t, ok)
+	assert.Equal(t, idx, 2)
+
+	_, ok = ty.FieldIdx("f4")
+	assert.False(t, ok)
+
+	fields = []Field{
+		{Name: "f1", Type: PrimitiveTypes.Int32},
+		{Name: "f2", Type: PrimitiveTypes.Int64},
+		{Name: "f1", Type: PrimitiveTypes.Int64},
+	}
+	ty = StructOf(fields...)
+	field, ok = ty.FieldByName("f1")
+	assert.True(t, ok)
+	assert.True(t, field.Equal(fields[0]))
+
+	field, ok = ty.FieldByName("f2")
+	assert.True(t, ok)
+	assert.True(t, field.Equal(fields[1]))
+
+	_, ok = ty.FieldByName("f3")
+	assert.False(t, ok)
+
+	idx, ok = ty.FieldIdx("f1")
+	assert.True(t, ok)
+	assert.Equal(t, idx, 0)
+
+	idx, ok = ty.FieldIdx("f2")
+	assert.True(t, ok)
+	assert.Equal(t, idx, 1)
+
+	_, ok = ty.FieldIdx("f3")
+	assert.False(t, ok)
 }
 
 func TestFieldEqual(t *testing.T) {

--- a/go/arrow/datatype_nested_test.go
+++ b/go/arrow/datatype_nested_test.go
@@ -284,7 +284,7 @@ func TestStructField(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, flds, []Field{fields[2]})
 
-	flds, ok = ty.FieldsByName("f4")
+	_, ok = ty.FieldsByName("f4")
 	assert.False(t, ok)
 
 	assert.Equal(t, ty.FieldIndices("f1"), []int{0})
@@ -328,7 +328,7 @@ func TestStructField(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, flds, []Field{fields[1]})
 
-	flds, ok = ty.FieldsByName("f3")
+	_, ok = ty.FieldsByName("f3")
 	assert.False(t, ok)
 
 	assert.Equal(t, ty.FieldIndices("f1"), []int{0, 2})


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

The package segfaulted before.

### What changes are included in this PR?

Allow duplicate field names (in general methods will return the first field if there are duplicates)

### Are these changes tested?

Yes

### Are there any user-facing changes?

Yes

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #36014