### PR TITLE
GH-32190: [C++][Compute] Implement cumulative prod, max and min functions

### DIFF
--- a/cpp/src/arrow/compute/api_vector.cc
+++ b/cpp/src/arrow/compute/api_vector.cc
@@ -26,6 +26,7 @@
 #include "arrow/array/array_nested.h"
 #include "arrow/array/builder_primitive.h"
 #include "arrow/compute/exec.h"
+#include "arrow/compute/function.h"
 #include "arrow/compute/function_internal.h"
 #include "arrow/compute/kernels/vector_sort_internal.h"
 #include "arrow/compute/registry.h"
@@ -142,9 +143,9 @@ static auto kPartitionNthOptionsType = GetFunctionOptionsType<PartitionNthOption
 static auto kSelectKOptionsType = GetFunctionOptionsType<SelectKOptions>(
     DataMember("k", &SelectKOptions::k),
     DataMember("sort_keys", &SelectKOptions::sort_keys));
-static auto kCumulativeSumOptionsType = GetFunctionOptionsType<CumulativeSumOptions>(
-    DataMember("start", &CumulativeSumOptions::start),
-    DataMember("skip_nulls", &CumulativeSumOptions::skip_nulls));
+static auto kCumulativeOptionsType = GetFunctionOptionsType<CumulativeOptions>(
+    DataMember("start", &CumulativeOptions::start),
+    DataMember("skip_nulls", &CumulativeOptions::skip_nulls));
 static auto kRankOptionsType = GetFunctionOptionsType<RankOptions>(
     DataMember("sort_keys", &RankOptions::sort_keys),
     DataMember("null_placement", &RankOptions::null_placement),
@@ -198,13 +199,15 @@ SelectKOptions::SelectKOptions(int64_t k, std::vector<SortKey> sort_keys)
       sort_keys(std::move(sort_keys)) {}
 constexpr char SelectKOptions::kTypeName[];
 
-CumulativeSumOptions::CumulativeSumOptions(double start, bool skip_nulls)
-    : CumulativeSumOptions(std::make_shared<DoubleScalar>(start), skip_nulls) {}
-CumulativeSumOptions::CumulativeSumOptions(std::shared_ptr<Scalar> start, bool skip_nulls)
-    : FunctionOptions(internal::kCumulativeSumOptionsType),
+CumulativeOptions::CumulativeOptions(bool skip_nulls)
+    : FunctionOptions(internal::kCumulativeOptionsType), skip_nulls(skip_nulls) {}
+CumulativeOptions::CumulativeOptions(double start, bool skip_nulls)
+    : CumulativeOptions(std::make_shared<DoubleScalar>(start), skip_nulls) {}
+CumulativeOptions::CumulativeOptions(std::shared_ptr<Scalar> start, bool skip_nulls)
+    : FunctionOptions(internal::kCumulativeOptionsType),
       start(std::move(start)),
       skip_nulls(skip_nulls) {}
-constexpr char CumulativeSumOptions::kTypeName[];
+constexpr char CumulativeOptions::kTypeName[];
 
 RankOptions::RankOptions(std::vector<SortKey> sort_keys, NullPlacement null_placement,
                          RankOptions::Tiebreaker tiebreaker)
@@ -224,7 +227,7 @@ void RegisterVectorOptions(FunctionRegistry* registry) {
   DCHECK_OK(registry->AddFunctionOptionsType(kSortOptionsType));
   DCHECK_OK(registry->AddFunctionOptionsType(kPartitionNthOptionsType));
   DCHECK_OK(registry->AddFunctionOptionsType(kSelectKOptionsType));
-  DCHECK_OK(registry->AddFunctionOptionsType(kCumulativeSumOptionsType));
+  DCHECK_OK(registry->AddFunctionOptionsType(kCumulativeOptionsType));
   DCHECK_OK(registry->AddFunctionOptionsType(kRankOptionsType));
 }
 }  // namespace internal
@@ -375,10 +378,26 @@ Result<std::shared_ptr<Array>> DropNull(const Array& values, ExecContext* ctx) {
 // ----------------------------------------------------------------------
 // Cumulative functions
 
-Result<Datum> CumulativeSum(const Datum& values, const CumulativeSumOptions& options,
+Result<Datum> CumulativeSum(const Datum& values, const CumulativeOptions& options,
                             bool check_overflow, ExecContext* ctx) {
   auto func_name = check_overflow ? "cumulative_sum_checked" : "cumulative_sum";
   return CallFunction(func_name, {Datum(values)}, &options, ctx);
+}
+
+Result<Datum> CumulativeProd(const Datum& values, const CumulativeOptions& options,
+                             bool check_overflow, ExecContext* ctx) {
+  auto func_name = check_overflow ? "cumulative_prod_checked" : "cumulative_prod";
+  return CallFunction(func_name, {Datum(values)}, &options, ctx);
+}
+
+Result<Datum> CumulativeMax(const Datum& values, const CumulativeOptions& options,
+                            ExecContext* ctx) {
+  return CallFunction("cumulative_max", {Datum(values)}, &options, ctx);
+}
+
+Result<Datum> CumulativeMin(const Datum& values, const CumulativeOptions& options,
+                            ExecContext* ctx) {
+  return CallFunction("cumulative_min", {Datum(values)}, &options, ctx);
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/compute/function_internal.h
+++ b/cpp/src/arrow/compute/function_internal.h
@@ -28,6 +28,7 @@
 #include "arrow/compute/function.h"
 #include "arrow/compute/type_fwd.h"
 #include "arrow/result.h"
+#include "arrow/scalar.h"
 #include "arrow/status.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/key_value_metadata.h"
@@ -283,12 +284,6 @@ static inline Result<decltype(MakeScalar(std::declval<T>()))> GenericToScalar(
   return MakeScalar(value);
 }
 
-template <typename T>
-static inline Result<decltype(MakeScalar(std::declval<T>()))> GenericToScalar(
-    const std::optional<T>& value) {
-  return value.has_value() ? MakeScalar(value.value()) : MakeScalar("");
-}
-
 // For Clang/libc++: when iterating through vector<bool>, we can't
 // pass it by reference so the overload above doesn't apply
 static inline Result<std::shared_ptr<Scalar>> GenericToScalar(bool value) {
@@ -383,6 +378,12 @@ static inline Result<std::shared_ptr<Scalar>> GenericToScalar(const Datum& value
 }
 
 template <typename T>
+static inline Result<decltype(MakeScalar(std::declval<T>()))> GenericToScalar(
+    const std::optional<T>& value) {
+  return value.has_value() ? MakeScalar(value.value()) : std::make_shared<NullScalar>();
+}
+
+template <typename T>
 static inline enable_if_primitive_ctype<typename CTypeTraits<T>::ArrowType, Result<T>>
 GenericFromScalar(const std::shared_ptr<Scalar>& value) {
   using ArrowType = typename CTypeTraits<T>::ArrowType;
@@ -402,26 +403,6 @@ GenericFromScalar(const std::shared_ptr<Scalar>& value) {
   ARROW_ASSIGN_OR_RAISE(auto raw_val,
                         GenericFromScalar<typename EnumTraits<T>::CType>(value));
   return ValidateEnumValue<T>(raw_val);
-}
-
-template <typename>
-constexpr bool is_optional_impl = false;
-template <typename T>
-constexpr bool is_optional_impl<std::optional<T>> = true;
-
-template <typename T>
-using is_optional =
-    std::integral_constant<bool, is_optional_impl<std::decay_t<T>> ||
-                                     std::is_same<T, std::nullopt_t>::value>;
-
-template <typename T, typename R = void>
-using enable_if_optional = enable_if_t<is_optional<T>::value, Result<T>>;
-
-template <typename T>
-static inline enable_if_optional<T> GenericFromScalar(
-    const std::shared_ptr<Scalar>& value) {
-  using value_type = typename T::value_type;
-  return GenericFromScalar<value_type>(value);
 }
 
 template <typename T, typename U>
@@ -508,6 +489,29 @@ static inline enable_if_same_result<T, Datum> GenericFromScalar(
   }
   // TODO(ARROW-9434): handle other possible datum kinds by looking for a union
   return Status::Invalid("Cannot deserialize Datum from ", value->ToString());
+}
+
+template <typename>
+constexpr bool is_optional_impl = false;
+template <typename T>
+constexpr bool is_optional_impl<std::optional<T>> = true;
+
+template <typename T>
+using is_optional =
+    std::integral_constant<bool, is_optional_impl<std::decay_t<T>> ||
+                                     std::is_same<T, std::nullopt_t>::value>;
+
+template <typename T, typename R = void>
+using enable_if_optional = enable_if_t<is_optional<T>::value, Result<T>>;
+
+template <typename T>
+static inline enable_if_optional<T> GenericFromScalar(
+    const std::shared_ptr<Scalar>& value) {
+  using value_type = typename T::value_type;
+  if (value->type->id() == Type::NA) {
+    return std::nullopt;
+  }
+  return GenericFromScalar<value_type>(value);
 }
 
 template <typename T>

--- a/cpp/src/arrow/compute/function_internal.h
+++ b/cpp/src/arrow/compute/function_internal.h
@@ -382,8 +382,8 @@ static inline Result<std::shared_ptr<Scalar>> GenericToScalar(std::nullopt_t) {
 }
 
 template <typename T>
-static inline auto GenericToScalar(
-    const std::optional<T>& value) -> Result<decltype(MakeScalar(value.value()))> {
+static inline auto GenericToScalar(const std::optional<T>& value)
+    -> Result<decltype(MakeScalar(value.value()))> {
   return value.has_value() ? MakeScalar(value.value()) : std::make_shared<NullScalar>();
 }
 
@@ -496,11 +496,11 @@ static inline enable_if_same_result<T, Datum> GenericFromScalar(
 }
 
 template <typename>
-constexpr bool is_optional_v = false;
+constexpr inline bool is_optional_v = false;
 template <typename T>
-constexpr bool is_optional_v<std::optional<T>> = true;
+constexpr inline bool is_optional_v<std::optional<T>> = true;
 template <>
-constexpr bool is_optional_v<std::nullopt_t> = true;
+constexpr inline bool is_optional_v<std::nullopt_t> = true;
 
 template <typename T>
 static inline std::enable_if_t<is_optional_v<T>, Result<T>> GenericFromScalar(

--- a/cpp/src/arrow/compute/kernels/base_arithmetic_internal.h
+++ b/cpp/src/arrow/compute/kernels/base_arithmetic_internal.h
@@ -626,11 +626,6 @@ struct Max {
       return std::max(left, right);
     }
   }
-
-  template <typename T>
-  static constexpr enable_if_decimal_value<T, T> Identity() {
-    return T::GetMinSentinel();
-  }
 };
 
 struct Min {
@@ -652,11 +647,6 @@ struct Min {
     } else {
       return std::min(left, right);
     }
-  }
-
-  template <typename T>
-  static constexpr enable_if_decimal_value<T, T> Identity() {
-    return T::GetMaxSentinel();
   }
 };
 

--- a/cpp/src/arrow/compute/kernels/base_arithmetic_internal.h
+++ b/cpp/src/arrow/compute/kernels/base_arithmetic_internal.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <limits>
 #include "arrow/compute/api_scalar.h"
 #include "arrow/compute/kernels/common_internal.h"
 #include "arrow/compute/kernels/util_internal.h"
@@ -60,11 +61,6 @@ struct Add {
   static enable_if_decimal_value<T> Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
     return left + right;
   }
-
-  template <typename T>
-  static constexpr T Identity() {
-    return static_cast<T>(0);
-  }
 };
 
 struct AddChecked {
@@ -89,11 +85,6 @@ struct AddChecked {
   template <typename T, typename Arg0, typename Arg1>
   static enable_if_decimal_value<T> Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
     return left + right;
-  }
-
-  template <typename T>
-  static constexpr T Identity() {
-    return static_cast<T>(0);
   }
 };
 
@@ -341,11 +332,6 @@ struct Multiply {
   static enable_if_decimal_value<T> Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
     return left * right;
   }
-
-  template <typename T>
-  static constexpr T Identity() {
-    return static_cast<T>(1);
-  }
 };
 
 struct MultiplyChecked {
@@ -370,11 +356,6 @@ struct MultiplyChecked {
   template <typename T, typename Arg0, typename Arg1>
   static enable_if_decimal_value<T> Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
     return left * right;
-  }
-
-  template <typename T>
-  static constexpr T Identity() {
-    return static_cast<T>(1);
   }
 };
 
@@ -650,11 +631,6 @@ struct Max {
   static constexpr enable_if_decimal_value<T, T> Identity() {
     return T::GetMinSentinel();
   }
-
-  template <typename T>
-  static constexpr T Identity() {
-    return std::numeric_limits<T>::min();
-  }
 };
 
 struct Min {
@@ -682,11 +658,42 @@ struct Min {
   static constexpr enable_if_decimal_value<T, T> Identity() {
     return T::GetMaxSentinel();
   }
+};
 
-  template <typename T>
-  static constexpr T Identity() {
-    return std::numeric_limits<T>::max();
-  }
+/// The term identity is from the mathematical notation monoid.
+/// For any associative binary operation, identity is defined as:
+///     Op(identity, x) = x for all x.
+template <typename Op>
+struct Identity;
+
+template <>
+struct Identity<Add> {
+  template <typename Value>
+  static constexpr Value value{0};
+};
+
+template <>
+struct Identity<AddChecked> : Identity<Add> {};
+
+template <>
+struct Identity<Multiply> {
+  template <typename Value>
+  static constexpr Value value{1};
+};
+
+template <>
+struct Identity<MultiplyChecked> : Identity<Multiply> {};
+
+template <>
+struct Identity<Max> {
+  template <typename Value>
+  static constexpr Value value{std::numeric_limits<Value>::min()};
+};
+
+template <>
+struct Identity<Min> {
+  template <typename Value>
+  static constexpr Value value{std::numeric_limits<Value>::max()};
 };
 
 }  // namespace internal

--- a/cpp/src/arrow/compute/kernels/base_arithmetic_internal.h
+++ b/cpp/src/arrow/compute/kernels/base_arithmetic_internal.h
@@ -60,6 +60,11 @@ struct Add {
   static enable_if_decimal_value<T> Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
     return left + right;
   }
+
+  template <typename T>
+  static constexpr T Identity() {
+    return static_cast<T>(0);
+  }
 };
 
 struct AddChecked {
@@ -84,6 +89,11 @@ struct AddChecked {
   template <typename T, typename Arg0, typename Arg1>
   static enable_if_decimal_value<T> Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
     return left + right;
+  }
+
+  template <typename T>
+  static constexpr T Identity() {
+    return static_cast<T>(0);
   }
 };
 
@@ -331,6 +341,11 @@ struct Multiply {
   static enable_if_decimal_value<T> Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
     return left * right;
   }
+
+  template <typename T>
+  static constexpr T Identity() {
+    return static_cast<T>(1);
+  }
 };
 
 struct MultiplyChecked {
@@ -355,6 +370,11 @@ struct MultiplyChecked {
   template <typename T, typename Arg0, typename Arg1>
   static enable_if_decimal_value<T> Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
     return left * right;
+  }
+
+  template <typename T>
+  static constexpr T Identity() {
+    return static_cast<T>(1);
   }
 };
 
@@ -602,6 +622,70 @@ struct Sign {
   static constexpr enable_if_decimal_value<Arg, T> Call(KernelContext*, Arg arg,
                                                         Status*) {
     return (arg == 0) ? 0 : arg.Sign();
+  }
+};
+
+struct Max {
+  template <typename T, typename Arg0, typename Arg1>
+  static constexpr enable_if_not_floating_value<T> Call(KernelContext*, Arg0 arg0,
+                                                        Arg1 arg1, Status*) {
+    static_assert(std::is_same<T, Arg0>::value && std::is_same<Arg0, Arg1>::value);
+    return std::max(arg0, arg1);
+  }
+
+  template <typename T, typename Arg0, typename Arg1>
+  static constexpr enable_if_floating_value<T> Call(KernelContext*, Arg0 left, Arg1 right,
+                                                    Status*) {
+    static_assert(std::is_same<T, Arg0>::value && std::is_same<Arg0, Arg1>::value);
+    if (std::isnan(left)) {
+      return right;
+    } else if (std::isnan(right)) {
+      return left;
+    } else {
+      return std::max(left, right);
+    }
+  }
+
+  template <typename T>
+  static constexpr enable_if_decimal_value<T, T> Identity() {
+    return T::GetMinSentinel();
+  }
+
+  template <typename T>
+  static constexpr T Identity() {
+    return std::numeric_limits<T>::min();
+  }
+};
+
+struct Min {
+  template <typename T, typename Arg0, typename Arg1>
+  static constexpr enable_if_not_floating_value<T> Call(KernelContext*, Arg0 arg0,
+                                                        Arg1 arg1, Status*) {
+    static_assert(std::is_same<T, Arg0>::value && std::is_same<Arg0, Arg1>::value);
+    return std::min(arg0, arg1);
+  }
+
+  template <typename T, typename Arg0, typename Arg1>
+  static constexpr enable_if_floating_value<T> Call(KernelContext*, Arg0 left, Arg1 right,
+                                                    Status*) {
+    static_assert(std::is_same<T, Arg0>::value && std::is_same<Arg0, Arg1>::value);
+    if (std::isnan(left)) {
+      return right;
+    } else if (std::isnan(right)) {
+      return left;
+    } else {
+      return std::min(left, right);
+    }
+  }
+
+  template <typename T>
+  static constexpr enable_if_decimal_value<T, T> Identity() {
+    return T::GetMaxSentinel();
+  }
+
+  template <typename T>
+  static constexpr T Identity() {
+    return std::numeric_limits<T>::max();
   }
 };
 

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -214,6 +214,9 @@ template <typename T, typename R = T>
 using enable_if_floating_value = enable_if_t<std::is_floating_point<T>::value, R>;
 
 template <typename T, typename R = T>
+using enable_if_not_floating_value = enable_if_t<!std::is_floating_point<T>::value, R>;
+
+template <typename T, typename R = T>
 using enable_if_decimal_value =
     enable_if_t<std::is_same<Decimal128, T>::value || std::is_same<Decimal256, T>::value,
                 R>;

--- a/cpp/src/arrow/compute/kernels/vector_cumulative_ops.cc
+++ b/cpp/src/arrow/compute/kernels/vector_cumulative_ops.cc
@@ -204,7 +204,8 @@ const FunctionDoc cumulative_max_doc{
     "Compute the cumulative max over a numeric input",
     ("`values` must be numeric. Return an array/chunked array which is the\n"
      "cumulative max computed over `values`. The default start is the minimum\n"
-     "value of input type."),
+     "value of input type (so that any other value will replace the\n
+     "start as the new maximum)."),
     {"values"},
     "CumulativeOptions"};
 
@@ -212,7 +213,8 @@ const FunctionDoc cumulative_min_doc{
     "Compute the cumulative min over a numeric input",
     ("`values` must be numeric. Return an array/chunked array which is the\n"
      "cumulative min computed over `values`. The default start is the maximum\n"
-     "value of input type."),
+     "value of input type (so that any other value will replace the\n
+	     "start as the new minimum)."),
     {"values"},
     "CumulativeOptions"};
 }  // namespace

--- a/cpp/src/arrow/compute/kernels/vector_cumulative_ops.cc
+++ b/cpp/src/arrow/compute/kernels/vector_cumulative_ops.cc
@@ -51,7 +51,7 @@ struct CumulativeOptionsWrapper : public OptionsWrapper<OptionsType> {
 
     const auto& start = options->start;
 
-    // Ensure `start` option, if given, matches input type,
+    // Ensure `start` option, if given, matches input type
     if (start.has_value() && !start.value()->type->Equals(*args.inputs[0])) {
       ARROW_ASSIGN_OR_RAISE(auto casted_start,
                             Cast(Datum(start.value()), args.inputs[0],

--- a/cpp/src/arrow/compute/kernels/vector_cumulative_ops.cc
+++ b/cpp/src/arrow/compute/kernels/vector_cumulative_ops.cc
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <type_traits>
 #include "arrow/array/array_base.h"
 #include "arrow/array/builder_primitive.h"
 #include "arrow/compute/api_scalar.h"
@@ -49,15 +50,12 @@ struct CumulativeOptionsWrapper : public OptionsWrapper<OptionsType> {
     }
 
     const auto& start = options->start;
-    if (!start || !start->is_valid) {
-      return Status::Invalid("Cumulative `start` option must be non-null and valid");
-    }
 
-    // Ensure `start` option matches input type
-    if (!start->type->Equals(*args.inputs[0])) {
-      ARROW_ASSIGN_OR_RAISE(
-          auto casted_start,
-          Cast(Datum(start), args.inputs[0], CastOptions::Safe(), ctx->exec_context()));
+    // Ensure `start` option, if given, matches input type,
+    if (start.has_value() && !start.value()->type->Equals(*args.inputs[0])) {
+      ARROW_ASSIGN_OR_RAISE(auto casted_start,
+                            Cast(Datum(start.value()), args.inputs[0],
+                                 CastOptions::Safe(), ctx->exec_context()));
       auto new_options = OptionsType(casted_start.scalar(), options->skip_nulls);
       return std::make_unique<State>(new_options);
     }
@@ -66,10 +64,11 @@ struct CumulativeOptionsWrapper : public OptionsWrapper<OptionsType> {
 };
 
 // The driver kernel for all cumulative compute functions. Op is a compute kernel
-// representing any binary associative operation (add, product, min, max, etc.) and
-// OptionsType the options type corresponding to Op. ArgType and OutType are the input
-// and output types, which will normally be the same (e.g. the cumulative sum of an array
-// of Int64Type will result in an array of Int64Type).
+// representing any binary associative operation with an identity element (add, product,
+// min, max, etc.), i.e. ones that form a monoid, and OptionsType the options type
+// corresponding to Op. ArgType and OutType are the input and output types, which will
+// normally be the same (e.g. the cumulative sum of an array of Int64Type will result in
+// an array of Int64Type).
 template <typename OutType, typename ArgType, typename Op, typename OptionsType>
 struct Accumulator {
   using OutValue = typename GetOutputType<OutType>::T;
@@ -118,10 +117,15 @@ struct Accumulator {
 
 template <typename OutType, typename ArgType, typename Op, typename OptionsType>
 struct CumulativeKernel {
+  using OutValue = typename GetOutputType<OutType>::T;
   static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
     const auto& options = CumulativeOptionsWrapper<OptionsType>::Get(ctx);
     Accumulator<OutType, ArgType, Op, OptionsType> accumulator(ctx);
-    accumulator.current_value = UnboxScalar<OutType>::Unbox(*(options.start));
+    if (options.start.has_value()) {
+      accumulator.current_value = UnboxScalar<OutType>::Unbox(*(options.start.value()));
+    } else {
+      accumulator.current_value = Op::template Identity<OutValue>();
+    }
     accumulator.skip_nulls = options.skip_nulls;
 
     RETURN_NOT_OK(accumulator.builder.Reserve(batch.length));
@@ -136,10 +140,15 @@ struct CumulativeKernel {
 
 template <typename OutType, typename ArgType, typename Op, typename OptionsType>
 struct CumulativeKernelChunked {
+  using OutValue = typename GetOutputType<OutType>::T;
   static Status Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
     const auto& options = CumulativeOptionsWrapper<OptionsType>::Get(ctx);
     Accumulator<OutType, ArgType, Op, OptionsType> accumulator(ctx);
-    accumulator.current_value = UnboxScalar<OutType>::Unbox(*(options.start));
+    if (options.start.has_value()) {
+      accumulator.current_value = UnboxScalar<OutType>::Unbox(*(options.start.value()));
+    } else {
+      accumulator.current_value = Op::template Identity<OutValue>();
+    }
     accumulator.skip_nulls = options.skip_nulls;
 
     const ChunkedArray& chunked_input = *batch[0].chunked_array();
@@ -160,18 +169,52 @@ const FunctionDoc cumulative_sum_doc{
     ("`values` must be numeric. Return an array/chunked array which is the\n"
      "cumulative sum computed over `values`. Results will wrap around on\n"
      "integer overflow. Use function \"cumulative_sum_checked\" if you want\n"
-     "overflow to return an error."),
+     "overflow to return an error. The default start is 0."),
     {"values"},
-    "CumulativeSumOptions"};
+    "CumulativeOptions"};
 
 const FunctionDoc cumulative_sum_checked_doc{
     "Compute the cumulative sum over a numeric input",
     ("`values` must be numeric. Return an array/chunked array which is the\n"
      "cumulative sum computed over `values`. This function returns an error\n"
      "on overflow. For a variant that doesn't fail on overflow, use\n"
-     "function \"cumulative_sum\"."),
+     "function \"cumulative_sum\". The default start is 0."),
     {"values"},
-    "CumulativeSumOptions"};
+    "CumulativeOptions"};
+
+const FunctionDoc cumulative_prod_doc{
+    "Compute the cumulative product over a numeric input",
+    ("`values` must be numeric. Return an array/chunked array which is the\n"
+     "cumulative product computed over `values`. Results will wrap around on\n"
+     "integer overflow. Use function \"cumulative_prod_checked\" if you want\n"
+     "overflow to return an error. The default start is 1."),
+    {"values"},
+    "CumulativeOptions"};
+
+const FunctionDoc cumulative_prod_checked_doc{
+    "Compute the cumulative product over a numeric input",
+    ("`values` must be numeric. Return an array/chunked array which is the\n"
+     "cumulative product computed over `values`. This function returns an error\n"
+     "on overflow. For a variant that doesn't fail on overflow, use\n"
+     "function \"cumulative_prod\". The default start is 1."),
+    {"values"},
+    "CumulativeOptions"};
+
+const FunctionDoc cumulative_max_doc{
+    "Compute the cumulative max over a numeric input",
+    ("`values` must be numeric. Return an array/chunked array which is the\n"
+     "cumulative max computed over `values`. The default start is the minimum\n"
+     "value of input type."),
+    {"values"},
+    "CumulativeOptions"};
+
+const FunctionDoc cumulative_min_doc{
+    "Compute the cumulative min over a numeric input",
+    ("`values` must be numeric. Return an array/chunked array which is the\n"
+     "cumulative min computed over `values`. The default start is the maximum\n"
+     "value of input type."),
+    {"values"},
+    "CumulativeOptions"};
 }  // namespace
 
 template <typename Op, typename OptionsType>
@@ -203,10 +246,20 @@ void MakeVectorCumulativeFunction(FunctionRegistry* registry, const std::string 
 }
 
 void RegisterVectorCumulativeSum(FunctionRegistry* registry) {
-  MakeVectorCumulativeFunction<Add, CumulativeSumOptions>(registry, "cumulative_sum",
-                                                          cumulative_sum_doc);
-  MakeVectorCumulativeFunction<AddChecked, CumulativeSumOptions>(
+  MakeVectorCumulativeFunction<Add, CumulativeOptions>(registry, "cumulative_sum",
+                                                       cumulative_sum_doc);
+  MakeVectorCumulativeFunction<AddChecked, CumulativeOptions>(
       registry, "cumulative_sum_checked", cumulative_sum_checked_doc);
+
+  MakeVectorCumulativeFunction<Multiply, CumulativeOptions>(registry, "cumulative_prod",
+                                                            cumulative_prod_doc);
+  MakeVectorCumulativeFunction<MultiplyChecked, CumulativeOptions>(
+      registry, "cumulative_prod_checked", cumulative_prod_checked_doc);
+
+  MakeVectorCumulativeFunction<Min, CumulativeOptions>(registry, "cumulative_min",
+                                                       cumulative_min_doc);
+  MakeVectorCumulativeFunction<Max, CumulativeOptions>(registry, "cumulative_max",
+                                                       cumulative_max_doc);
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/compute/kernels/vector_cumulative_ops.cc
+++ b/cpp/src/arrow/compute/kernels/vector_cumulative_ops.cc
@@ -124,7 +124,7 @@ struct CumulativeKernel {
     if (options.start.has_value()) {
       accumulator.current_value = UnboxScalar<OutType>::Unbox(*(options.start.value()));
     } else {
-      accumulator.current_value = Op::template Identity<OutValue>();
+      accumulator.current_value = Identity<Op>::template value<OutValue>;
     }
     accumulator.skip_nulls = options.skip_nulls;
 
@@ -147,7 +147,7 @@ struct CumulativeKernelChunked {
     if (options.start.has_value()) {
       accumulator.current_value = UnboxScalar<OutType>::Unbox(*(options.start.value()));
     } else {
-      accumulator.current_value = Op::template Identity<OutValue>();
+      accumulator.current_value = Identity<Op>::template value<OutValue>;
     }
     accumulator.skip_nulls = options.skip_nulls;
 
@@ -204,7 +204,7 @@ const FunctionDoc cumulative_max_doc{
     "Compute the cumulative max over a numeric input",
     ("`values` must be numeric. Return an array/chunked array which is the\n"
      "cumulative max computed over `values`. The default start is the minimum\n"
-     "value of input type (so that any other value will replace the\n
+     "value of input type (so that any other value will replace the\n"
      "start as the new maximum)."),
     {"values"},
     "CumulativeOptions"};
@@ -213,8 +213,8 @@ const FunctionDoc cumulative_min_doc{
     "Compute the cumulative min over a numeric input",
     ("`values` must be numeric. Return an array/chunked array which is the\n"
      "cumulative min computed over `values`. The default start is the maximum\n"
-     "value of input type (so that any other value will replace the\n
-	     "start as the new minimum)."),
+     "value of input type (so that any other value will replace the\n"
+     "start as the new minimum)."),
     {"values"},
     "CumulativeOptions"};
 }  // namespace

--- a/cpp/src/arrow/compute/kernels/vector_cumulative_ops_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_cumulative_ops_test.cc
@@ -24,6 +24,7 @@
 #include "arrow/array.h"
 #include "arrow/chunked_array.h"
 #include "arrow/compute/api_vector.h"
+#include "arrow/scalar.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/util.h"
 #include "arrow/type.h"
@@ -36,43 +37,44 @@
 namespace arrow {
 namespace compute {
 
-TEST(TestCumulativeSum, Empty) {
-  CumulativeSumOptions options;
-  for (auto ty : NumericTypes()) {
-    auto empty_arr = ArrayFromJSON(ty, "[]");
-    auto empty_chunked = ChunkedArrayFromJSON(ty, {"[]"});
-    CheckVectorUnary("cumulative_sum", empty_arr, empty_arr, &options);
-    CheckVectorUnary("cumulative_sum_checked", empty_arr, empty_arr, &options);
+constexpr static std::array<const char*, 6> kCumulativeFunctionNames{
+    "cumulative_sum",          "cumulative_sum_checked", "cumulative_prod",
+    "cumulative_prod_checked", "cumulative_min",         "cumulative_max"};
 
-    CheckVectorUnary("cumulative_sum", empty_chunked, empty_chunked, &options);
-    CheckVectorUnary("cumulative_sum_checked", empty_chunked, empty_chunked, &options);
+TEST(TestCumulative, Empty) {
+  for (auto function : kCumulativeFunctionNames) {
+    CumulativeOptions options;
+    for (auto ty : NumericTypes()) {
+      auto empty_arr = ArrayFromJSON(ty, "[]");
+      auto empty_chunked = ChunkedArrayFromJSON(ty, {"[]"});
+      CheckVectorUnary(function, empty_arr, empty_arr, &options);
+
+      CheckVectorUnary(function, empty_chunked, empty_chunked, &options);
+    }
   }
 }
 
-TEST(TestCumulativeSum, AllNulls) {
-  CumulativeSumOptions options;
-  for (auto ty : NumericTypes()) {
-    auto nulls_arr = ArrayFromJSON(ty, "[null, null, null]");
-    auto nulls_one_chunk = ChunkedArrayFromJSON(ty, {"[null, null, null]"});
-    auto nulls_three_chunks = ChunkedArrayFromJSON(ty, {"[null]", "[null]", "[null]"});
-    CheckVectorUnary("cumulative_sum", nulls_arr, nulls_arr, &options);
-    CheckVectorUnary("cumulative_sum_checked", nulls_arr, nulls_arr, &options);
+TEST(TestCumulative, AllNulls) {
+  for (auto function : kCumulativeFunctionNames) {
+    CumulativeOptions options;
+    for (auto ty : NumericTypes()) {
+      auto nulls_arr = ArrayFromJSON(ty, "[null, null, null]");
+      auto nulls_one_chunk = ChunkedArrayFromJSON(ty, {"[null, null, null]"});
+      auto nulls_three_chunks = ChunkedArrayFromJSON(ty, {"[null]", "[null]", "[null]"});
+      CheckVectorUnary(function, nulls_arr, nulls_arr, &options);
 
-    CheckVectorUnary("cumulative_sum", nulls_one_chunk, nulls_one_chunk, &options);
-    CheckVectorUnary("cumulative_sum_checked", nulls_one_chunk, nulls_one_chunk,
-                     &options);
+      CheckVectorUnary(function, nulls_one_chunk, nulls_one_chunk, &options);
 
-    CheckVectorUnary("cumulative_sum", nulls_three_chunks, nulls_one_chunk, &options);
-    CheckVectorUnary("cumulative_sum_checked", nulls_three_chunks, nulls_one_chunk,
-                     &options);
+      CheckVectorUnary(function, nulls_three_chunks, nulls_one_chunk, &options);
+    }
   }
 }
 
 TEST(TestCumulativeSum, ScalarInput) {
-  CumulativeSumOptions no_start_no_skip;
-  CumulativeSumOptions no_start_do_skip(0, true);
-  CumulativeSumOptions has_start_no_skip(10);
-  CumulativeSumOptions has_start_do_skip(10, true);
+  CumulativeOptions no_start_no_skip;
+  CumulativeOptions no_start_do_skip(0, true);
+  CumulativeOptions has_start_no_skip(10.0);
+  CumulativeOptions has_start_do_skip(10, true);
 
   for (auto ty : NumericTypes()) {
     CheckVectorUnary("cumulative_sum", ScalarFromJSON(ty, "10"),
@@ -101,6 +103,43 @@ TEST(TestCumulativeSum, ScalarInput) {
     CheckVectorUnary("cumulative_sum", ScalarFromJSON(ty, "null"),
                      ArrayFromJSON(ty, "[null]"), &has_start_do_skip);
     CheckVectorUnary("cumulative_sum_checked", ScalarFromJSON(ty, "null"),
+                     ArrayFromJSON(ty, "[null]"), &has_start_do_skip);
+  }
+}
+
+TEST(TestCumulativeProd, ScalarInput) {
+  CumulativeOptions no_start_no_skip;
+  CumulativeOptions no_start_do_skip(1, true);
+  CumulativeOptions has_start_no_skip(10.0);
+  CumulativeOptions has_start_do_skip(10, true);
+
+  for (auto ty : NumericTypes()) {
+    CheckVectorUnary("cumulative_prod", ScalarFromJSON(ty, "10"),
+                     ArrayFromJSON(ty, "[10]"), &no_start_no_skip);
+    CheckVectorUnary("cumulative_prod_checked", ScalarFromJSON(ty, "10"),
+                     ArrayFromJSON(ty, "[10]"), &no_start_no_skip);
+
+    CheckVectorUnary("cumulative_prod", ScalarFromJSON(ty, "10"),
+                     ArrayFromJSON(ty, "[100]"), &has_start_no_skip);
+    CheckVectorUnary("cumulative_prod_checked", ScalarFromJSON(ty, "10"),
+                     ArrayFromJSON(ty, "[100]"), &has_start_no_skip);
+
+    CheckVectorUnary("cumulative_prod", ScalarFromJSON(ty, "null"),
+                     ArrayFromJSON(ty, "[null]"), &no_start_no_skip);
+    CheckVectorUnary("cumulative_prod_checked", ScalarFromJSON(ty, "null"),
+                     ArrayFromJSON(ty, "[null]"), &no_start_no_skip);
+    CheckVectorUnary("cumulative_prod", ScalarFromJSON(ty, "null"),
+                     ArrayFromJSON(ty, "[null]"), &has_start_no_skip);
+    CheckVectorUnary("cumulative_prod_checked", ScalarFromJSON(ty, "null"),
+                     ArrayFromJSON(ty, "[null]"), &has_start_no_skip);
+
+    CheckVectorUnary("cumulative_prod", ScalarFromJSON(ty, "null"),
+                     ArrayFromJSON(ty, "[null]"), &no_start_do_skip);
+    CheckVectorUnary("cumulative_prod_checked", ScalarFromJSON(ty, "null"),
+                     ArrayFromJSON(ty, "[null]"), &no_start_do_skip);
+    CheckVectorUnary("cumulative_prod", ScalarFromJSON(ty, "null"),
+                     ArrayFromJSON(ty, "[null]"), &has_start_do_skip);
+    CheckVectorUnary("cumulative_prod_checked", ScalarFromJSON(ty, "null"),
                      ArrayFromJSON(ty, "[null]"), &has_start_do_skip);
   }
 }
@@ -112,7 +151,7 @@ void CheckCumulativeSumUnsignedOverflow() {
   using CType = typename TypeTraits<ArrowType>::CType;
   using BuilderType = typename TypeTraits<ArrowType>::BuilderType;
 
-  CumulativeSumOptions pos_overflow(1);
+  CumulativeOptions pos_overflow(1.0);
   auto max = std::numeric_limits<CType>::max();
   auto min = std::numeric_limits<CType>::lowest();
 
@@ -138,7 +177,7 @@ void CheckCumulativeSumSignedOverflow() {
 
   CheckCumulativeSumUnsignedOverflow<ArrowType>();
 
-  CumulativeSumOptions neg_overflow(-1);
+  CumulativeOptions neg_overflow(-1.0);
   auto max = std::numeric_limits<CType>::max();
   auto min = std::numeric_limits<CType>::lowest();
 
@@ -167,8 +206,64 @@ TEST(TestCumulativeSum, IntegerOverflow) {
   CheckCumulativeSumSignedOverflow<Int64Type>();
 }
 
+template <typename ArrowType>
+void CheckCumulativeProdUnsignedOverflow() {
+  using CType = typename TypeTraits<ArrowType>::CType;
+  using BuilderType = typename TypeTraits<ArrowType>::BuilderType;
+
+  CumulativeOptions pos_overflow(2.0);
+  auto max = std::numeric_limits<CType>::max();
+  auto min = std::numeric_limits<CType>::lowest();
+
+  BuilderType builder;
+  std::shared_ptr<Array> half_max_arr;
+  std::shared_ptr<Array> min_arr;
+  ASSERT_OK(builder.Append(max / 2 + 1));  // 2 * (max / 2 + 1) overflows to min
+  ASSERT_OK(builder.Finish(&half_max_arr));
+  builder.Reset();
+  ASSERT_OK(builder.Append(min));
+  ASSERT_OK(builder.Finish(&min_arr));
+
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      Invalid, HasSubstr("overflow"),
+      CallFunction("cumulative_prod_checked", {half_max_arr}, &pos_overflow));
+  CheckVectorUnary("cumulative_prod", half_max_arr, min_arr, &pos_overflow);
+}
+
+template <typename ArrowType>
+void CheckCumulativeProdSignedOverflow() {
+  using CType = typename TypeTraits<ArrowType>::CType;
+  using BuilderType = typename TypeTraits<ArrowType>::BuilderType;
+
+  CheckCumulativeSumUnsignedOverflow<ArrowType>();
+
+  CumulativeOptions neg_overflow(-1.0);  // min * -1 overflows to min
+  auto min = std::numeric_limits<CType>::lowest();
+
+  BuilderType builder;
+  std::shared_ptr<Array> min_arr;
+  builder.Reset();
+  ASSERT_OK(builder.Append(min));
+  ASSERT_OK(builder.Finish(&min_arr));
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      Invalid, HasSubstr("overflow"),
+      CallFunction("cumulative_prod_checked", {min_arr}, &neg_overflow));
+  CheckVectorUnary("cumulative_prod", min_arr, min_arr, &neg_overflow);
+}
+
+TEST(TestCumulativeProd, IntegerOverflow) {
+  CheckCumulativeProdUnsignedOverflow<UInt8Type>();
+  CheckCumulativeProdUnsignedOverflow<UInt16Type>();
+  CheckCumulativeProdUnsignedOverflow<UInt32Type>();
+  CheckCumulativeProdUnsignedOverflow<UInt64Type>();
+  CheckCumulativeProdSignedOverflow<Int8Type>();
+  CheckCumulativeProdSignedOverflow<Int16Type>();
+  CheckCumulativeProdSignedOverflow<Int32Type>();
+  CheckCumulativeProdSignedOverflow<Int64Type>();
+}
+
 TEST(TestCumulativeSum, NoStartNoSkip) {
-  CumulativeSumOptions options;
+  CumulativeOptions options;
   for (auto ty : NumericTypes()) {
     CheckVectorUnary("cumulative_sum", ArrayFromJSON(ty, "[1, 2, 3, 4, 5, 6]"),
                      ArrayFromJSON(ty, "[1, 3, 6, 10, 15, 21]"), &options);
@@ -212,52 +307,8 @@ TEST(TestCumulativeSum, NoStartNoSkip) {
   }
 }
 
-TEST(TestCumulativeSum, NoStartDoSkip) {
-  CumulativeSumOptions options(0, true);
-  for (auto ty : NumericTypes()) {
-    CheckVectorUnary("cumulative_sum", ArrayFromJSON(ty, "[1, 2, 3, 4, 5, 6]"),
-                     ArrayFromJSON(ty, "[1, 3, 6, 10, 15, 21]"), &options);
-    CheckVectorUnary("cumulative_sum_checked", ArrayFromJSON(ty, "[1, 2, 3, 4, 5, 6]"),
-                     ArrayFromJSON(ty, "[1, 3, 6, 10, 15, 21]"), &options);
-
-    CheckVectorUnary("cumulative_sum", ArrayFromJSON(ty, "[1, 2, null, 4, null, 6]"),
-                     ArrayFromJSON(ty, "[1, 3, null, 7, null, 13]"), &options);
-    CheckVectorUnary("cumulative_sum_checked",
-                     ArrayFromJSON(ty, "[1, 2, null, 4, null, 6]"),
-                     ArrayFromJSON(ty, "[1, 3, null, 7, null, 13]"), &options);
-
-    CheckVectorUnary("cumulative_sum", ArrayFromJSON(ty, "[null, 2, null, 4, null, 6]"),
-                     ArrayFromJSON(ty, "[null, 2, null, 6, null, 12]"), &options);
-    CheckVectorUnary("cumulative_sum_checked",
-                     ArrayFromJSON(ty, "[null, 2, null, 4, null, 6]"),
-                     ArrayFromJSON(ty, "[null, 2, null, 6, null, 12]"), &options);
-
-    CheckVectorUnary("cumulative_sum",
-                     ChunkedArrayFromJSON(ty, {"[1, 2, 3]", "[4, 5, 6]"}),
-                     ChunkedArrayFromJSON(ty, {"[1, 3, 6, 10, 15, 21]"}), &options);
-    CheckVectorUnary("cumulative_sum_checked",
-                     ChunkedArrayFromJSON(ty, {"[1, 2, 3]", "[4, 5, 6]"}),
-                     ChunkedArrayFromJSON(ty, {"[1, 3, 6, 10, 15, 21]"}), &options);
-
-    CheckVectorUnary("cumulative_sum",
-                     ChunkedArrayFromJSON(ty, {"[1, 2, null]", "[4, null, 6]"}),
-                     ChunkedArrayFromJSON(ty, {"[1, 3, null, 7, null, 13]"}), &options);
-    CheckVectorUnary("cumulative_sum_checked",
-                     ChunkedArrayFromJSON(ty, {"[1, 2, null]", "[4, null, 6]"}),
-                     ChunkedArrayFromJSON(ty, {"[1, 3, null, 7, null, 13]"}), &options);
-
-    CheckVectorUnary(
-        "cumulative_sum", ChunkedArrayFromJSON(ty, {"[null, 2, null]", "[4, null, 6]"}),
-        ChunkedArrayFromJSON(ty, {"[null, 2, null, 6, null, 12]"}), &options);
-    CheckVectorUnary("cumulative_sum_checked",
-                     ChunkedArrayFromJSON(ty, {"[null, 2, null]", "[4, null, 6]"}),
-                     ChunkedArrayFromJSON(ty, {"[null, 2, null, 6, null, 12]"}),
-                     &options);
-  }
-}
-
 TEST(TestCumulativeSum, HasStartNoSkip) {
-  CumulativeSumOptions options(10);
+  CumulativeOptions options(10.0);
   for (auto ty : NumericTypes()) {
     CheckVectorUnary("cumulative_sum", ArrayFromJSON(ty, "[1, 2, 3, 4, 5, 6]"),
                      ArrayFromJSON(ty, "[11, 13, 16, 20, 25, 31]"), &options);
@@ -302,7 +353,7 @@ TEST(TestCumulativeSum, HasStartNoSkip) {
 }
 
 TEST(TestCumulativeSum, HasStartDoSkip) {
-  CumulativeSumOptions options(10, true);
+  CumulativeOptions options(10, true);
   for (auto ty : NumericTypes()) {
     CheckVectorUnary("cumulative_sum", ArrayFromJSON(ty, "[1, 2, 3, 4, 5, 6]"),
                      ArrayFromJSON(ty, "[11, 13, 16, 20, 25, 31]"), &options);
@@ -346,15 +397,471 @@ TEST(TestCumulativeSum, HasStartDoSkip) {
   }
 }
 
+TEST(TestCumulativeSum, NoStartDoSkip) {
+  CumulativeOptions options(0, true);
+  for (auto ty : NumericTypes()) {
+    CheckVectorUnary("cumulative_sum", ArrayFromJSON(ty, "[1, 2, 3, 4, 5, 6]"),
+                     ArrayFromJSON(ty, "[1, 3, 6, 10, 15, 21]"), &options);
+    CheckVectorUnary("cumulative_sum_checked", ArrayFromJSON(ty, "[1, 2, 3, 4, 5, 6]"),
+                     ArrayFromJSON(ty, "[1, 3, 6, 10, 15, 21]"), &options);
+
+    CheckVectorUnary("cumulative_sum", ArrayFromJSON(ty, "[1, 2, null, 4, null, 6]"),
+                     ArrayFromJSON(ty, "[1, 3, null, 7, null, 13]"), &options);
+    CheckVectorUnary("cumulative_sum_checked",
+                     ArrayFromJSON(ty, "[1, 2, null, 4, null, 6]"),
+                     ArrayFromJSON(ty, "[1, 3, null, 7, null, 13]"), &options);
+
+    CheckVectorUnary("cumulative_sum", ArrayFromJSON(ty, "[null, 2, null, 4, null, 6]"),
+                     ArrayFromJSON(ty, "[null, 2, null, 6, null, 12]"), &options);
+    CheckVectorUnary("cumulative_sum_checked",
+                     ArrayFromJSON(ty, "[null, 2, null, 4, null, 6]"),
+                     ArrayFromJSON(ty, "[null, 2, null, 6, null, 12]"), &options);
+
+    CheckVectorUnary("cumulative_sum",
+                     ChunkedArrayFromJSON(ty, {"[1, 2, 3]", "[4, 5, 6]"}),
+                     ChunkedArrayFromJSON(ty, {"[1, 3, 6, 10, 15, 21]"}), &options);
+    CheckVectorUnary("cumulative_sum_checked",
+                     ChunkedArrayFromJSON(ty, {"[1, 2, 3]", "[4, 5, 6]"}),
+                     ChunkedArrayFromJSON(ty, {"[1, 3, 6, 10, 15, 21]"}), &options);
+
+    CheckVectorUnary("cumulative_sum",
+                     ChunkedArrayFromJSON(ty, {"[1, 2, null]", "[4, null, 6]"}),
+                     ChunkedArrayFromJSON(ty, {"[1, 3, null, 7, null, 13]"}), &options);
+    CheckVectorUnary("cumulative_sum_checked",
+                     ChunkedArrayFromJSON(ty, {"[1, 2, null]", "[4, null, 6]"}),
+                     ChunkedArrayFromJSON(ty, {"[1, 3, null, 7, null, 13]"}), &options);
+
+    CheckVectorUnary(
+        "cumulative_sum", ChunkedArrayFromJSON(ty, {"[null, 2, null]", "[4, null, 6]"}),
+        ChunkedArrayFromJSON(ty, {"[null, 2, null, 6, null, 12]"}), &options);
+    CheckVectorUnary("cumulative_sum_checked",
+                     ChunkedArrayFromJSON(ty, {"[null, 2, null]", "[4, null, 6]"}),
+                     ChunkedArrayFromJSON(ty, {"[null, 2, null, 6, null, 12]"}),
+                     &options);
+  }
+}
+
+TEST(TestCumulativeProd, NoStartNoSkip) {
+  CumulativeOptions options;
+  for (auto ty : NumericTypes()) {
+    CheckVectorUnary("cumulative_prod", ArrayFromJSON(ty, "[1, 2, 3, 4, 5]"),
+                     ArrayFromJSON(ty, "[1, 2, 6, 24, 120]"), &options);
+    CheckVectorUnary("cumulative_prod_checked", ArrayFromJSON(ty, "[1, 2, 3, 4, 5]"),
+                     ArrayFromJSON(ty, "[1, 2, 6, 24, 120]"), &options);
+
+    CheckVectorUnary("cumulative_prod", ArrayFromJSON(ty, "[1, 2, null, 4, null, 6]"),
+                     ArrayFromJSON(ty, "[1, 2, null, null, null, null]"), &options);
+    CheckVectorUnary("cumulative_prod_checked",
+                     ArrayFromJSON(ty, "[1, 2, null, 4, null, 6]"),
+                     ArrayFromJSON(ty, "[1, 2, null, null, null, null]"), &options);
+
+    CheckVectorUnary("cumulative_prod", ArrayFromJSON(ty, "[null, 2, null, 4, null, 6]"),
+                     ArrayFromJSON(ty, "[null, null, null, null, null, null]"), &options);
+    CheckVectorUnary("cumulative_prod_checked",
+                     ArrayFromJSON(ty, "[null, 2, null, 4, null, 6]"),
+                     ArrayFromJSON(ty, "[null, null, null, null, null, null]"), &options);
+
+    CheckVectorUnary("cumulative_prod", ChunkedArrayFromJSON(ty, {"[1, 2, 3]", "[4, 5]"}),
+                     ChunkedArrayFromJSON(ty, {"[1, 2, 6, 24, 120]"}), &options);
+    CheckVectorUnary("cumulative_prod_checked",
+                     ChunkedArrayFromJSON(ty, {"[1, 2, 3]", "[4, 5]"}),
+                     ChunkedArrayFromJSON(ty, {"[1, 2, 6, 24, 120]"}), &options);
+
+    CheckVectorUnary(
+        "cumulative_prod", ChunkedArrayFromJSON(ty, {"[1, 2, null]", "[4, null, 6]"}),
+        ChunkedArrayFromJSON(ty, {"[1, 2, null, null, null, null]"}), &options);
+    CheckVectorUnary("cumulative_prod_checked",
+                     ChunkedArrayFromJSON(ty, {"[1, 2, null]", "[4, null, 6]"}),
+                     ChunkedArrayFromJSON(ty, {"[1, 2, null, null, null, null]"}),
+                     &options);
+
+    CheckVectorUnary(
+        "cumulative_prod", ChunkedArrayFromJSON(ty, {"[null, 2, null]", "[4, null, 6]"}),
+        ChunkedArrayFromJSON(ty, {"[null, null, null, null, null, null]"}), &options);
+    CheckVectorUnary("cumulative_prod_checked",
+                     ChunkedArrayFromJSON(ty, {"[null, 2, null]", "[4, null, 6]"}),
+                     ChunkedArrayFromJSON(ty, {"[null, null, null, null, null, null]"}),
+                     &options);
+  }
+}
+
+TEST(TestCumulativeProd, HasStartNoSkip) {
+  CumulativeOptions options(2.0);
+  for (auto ty : NumericTypes()) {
+    CheckVectorUnary("cumulative_prod", ArrayFromJSON(ty, "[1, 2, 3, 4]"),
+                     ArrayFromJSON(ty, "[2, 4, 12, 48]"), &options);
+    CheckVectorUnary("cumulative_prod_checked", ArrayFromJSON(ty, "[1, 2, 3, 4]"),
+                     ArrayFromJSON(ty, "[2, 4, 12, 48]"), &options);
+
+    CheckVectorUnary("cumulative_prod", ArrayFromJSON(ty, "[1, 2, null, 4]"),
+                     ArrayFromJSON(ty, "[2, 4, null, null]"), &options);
+    CheckVectorUnary("cumulative_prod_checked", ArrayFromJSON(ty, "[1, 2, null, 4]"),
+                     ArrayFromJSON(ty, "[2, 4, null, null]"), &options);
+
+    CheckVectorUnary("cumulative_prod", ArrayFromJSON(ty, "[null, 2, null, 4]"),
+                     ArrayFromJSON(ty, "[null, null, null, null]"), &options);
+    CheckVectorUnary("cumulative_prod_checked", ArrayFromJSON(ty, "[null, 2, null, 4]"),
+                     ArrayFromJSON(ty, "[null, null, null, null]"), &options);
+
+    CheckVectorUnary("cumulative_prod", ChunkedArrayFromJSON(ty, {"[1, 2]", "[3, 4]"}),
+                     ChunkedArrayFromJSON(ty, {"[2, 4, 12, 48]"}), &options);
+    CheckVectorUnary("cumulative_prod_checked",
+                     ChunkedArrayFromJSON(ty, {"[1, 2]", "[3, 4]"}),
+                     ChunkedArrayFromJSON(ty, {"[2, 4, 12, 48]"}), &options);
+
+    CheckVectorUnary("cumulative_prod", ChunkedArrayFromJSON(ty, {"[1, 2]", "[null, 4]"}),
+                     ChunkedArrayFromJSON(ty, {"[2, 4, null, null]"}), &options);
+    CheckVectorUnary("cumulative_prod_checked",
+                     ChunkedArrayFromJSON(ty, {"[1, 2]", "[null, 4]"}),
+                     ChunkedArrayFromJSON(ty, {"[2, 4, null, null]"}), &options);
+
+    CheckVectorUnary("cumulative_prod",
+                     ChunkedArrayFromJSON(ty, {"[null, 2]", "[null, 4]"}),
+                     ChunkedArrayFromJSON(ty, {"[null, null, null, null]"}), &options);
+    CheckVectorUnary("cumulative_prod_checked",
+                     ChunkedArrayFromJSON(ty, {"[null, 2]", "[null, 4]"}),
+                     ChunkedArrayFromJSON(ty, {"[null, null, null, null]"}), &options);
+  }
+}
+
+TEST(TestCumulativeProd, HasStartDoSkip) {
+  CumulativeOptions options(2.0, true);
+  for (auto ty : NumericTypes()) {
+    CheckVectorUnary("cumulative_prod", ArrayFromJSON(ty, "[1, 2, 3, 4]"),
+                     ArrayFromJSON(ty, "[2, 4, 12, 48]"), &options);
+    CheckVectorUnary("cumulative_prod_checked", ArrayFromJSON(ty, "[1, 2, 3, 4]"),
+                     ArrayFromJSON(ty, "[2, 4, 12, 48]"), &options);
+
+    CheckVectorUnary("cumulative_prod", ArrayFromJSON(ty, "[1, 2, null, 4]"),
+                     ArrayFromJSON(ty, "[2, 4, null, 16]"), &options);
+    CheckVectorUnary("cumulative_prod_checked", ArrayFromJSON(ty, "[1, 2, null, 4]"),
+                     ArrayFromJSON(ty, "[2, 4, null, 16]"), &options);
+
+    CheckVectorUnary("cumulative_prod", ArrayFromJSON(ty, "[null, 2, null, 4]"),
+                     ArrayFromJSON(ty, "[null, 4, null, 16]"), &options);
+    CheckVectorUnary("cumulative_prod_checked", ArrayFromJSON(ty, "[null, 2, null, 4]"),
+                     ArrayFromJSON(ty, "[null, 4, null, 16]"), &options);
+
+    CheckVectorUnary("cumulative_prod", ChunkedArrayFromJSON(ty, {"[1, 2]", "[3, 4]"}),
+                     ChunkedArrayFromJSON(ty, {"[2, 4, 12, 48]"}), &options);
+    CheckVectorUnary("cumulative_prod_checked",
+                     ChunkedArrayFromJSON(ty, {"[1, 2]", "[3, 4]"}),
+                     ChunkedArrayFromJSON(ty, {"[2, 4, 12, 48]"}), &options);
+
+    CheckVectorUnary("cumulative_prod", ChunkedArrayFromJSON(ty, {"[1, 2]", "[null, 4]"}),
+                     ChunkedArrayFromJSON(ty, {"[2, 4, null, 16]"}), &options);
+    CheckVectorUnary("cumulative_prod_checked",
+                     ChunkedArrayFromJSON(ty, {"[1, 2]", "[null, 4]"}),
+                     ChunkedArrayFromJSON(ty, {"[2, 4, null, 16]"}), &options);
+
+    CheckVectorUnary("cumulative_prod",
+                     ChunkedArrayFromJSON(ty, {"[null, 2]", "[null, 4]"}),
+                     ChunkedArrayFromJSON(ty, {"[null, 4, null, 16]"}), &options);
+    CheckVectorUnary("cumulative_prod_checked",
+                     ChunkedArrayFromJSON(ty, {"[null, 2]", "[null, 4]"}),
+                     ChunkedArrayFromJSON(ty, {"[null, 4, null, 16]"}), &options);
+  }
+}
+
+TEST(TestCumulativeProd, NoStartDoSkip) {
+  CumulativeOptions options(true);
+  for (auto ty : NumericTypes()) {
+    CheckVectorUnary("cumulative_prod", ArrayFromJSON(ty, "[1, 2, 3, 4]"),
+                     ArrayFromJSON(ty, "[1, 2, 6, 24]"), &options);
+    CheckVectorUnary("cumulative_prod_checked", ArrayFromJSON(ty, "[1, 2, 3, 4]"),
+                     ArrayFromJSON(ty, "[1, 2, 6, 24]"), &options);
+
+    CheckVectorUnary("cumulative_prod", ArrayFromJSON(ty, "[1, 2, null, 4]"),
+                     ArrayFromJSON(ty, "[1, 2, null, 8]"), &options);
+    CheckVectorUnary("cumulative_prod_checked", ArrayFromJSON(ty, "[1, 2, null, 4]"),
+                     ArrayFromJSON(ty, "[1, 2, null, 8]"), &options);
+
+    CheckVectorUnary("cumulative_prod", ArrayFromJSON(ty, "[null, 2, null, 4]"),
+                     ArrayFromJSON(ty, "[null, 2, null, 8]"), &options);
+    CheckVectorUnary("cumulative_prod_checked", ArrayFromJSON(ty, "[null, 2, null, 4]"),
+                     ArrayFromJSON(ty, "[null, 2, null, 8]"), &options);
+
+    CheckVectorUnary("cumulative_prod", ChunkedArrayFromJSON(ty, {"[1, 2]", "[3, 4]"}),
+                     ChunkedArrayFromJSON(ty, {"[1, 2, 6, 24]"}), &options);
+    CheckVectorUnary("cumulative_prod_checked",
+                     ChunkedArrayFromJSON(ty, {"[1, 2]", "[3, 4]"}),
+                     ChunkedArrayFromJSON(ty, {"[1, 2, 6, 24]"}), &options);
+
+    CheckVectorUnary("cumulative_prod", ChunkedArrayFromJSON(ty, {"[1, 2]", "[null, 4]"}),
+                     ChunkedArrayFromJSON(ty, {"[1, 2, null, 8]"}), &options);
+    CheckVectorUnary("cumulative_prod_checked",
+                     ChunkedArrayFromJSON(ty, {"[1, 2]", "[null, 4]"}),
+                     ChunkedArrayFromJSON(ty, {"[1, 2, null, 8]"}), &options);
+
+    CheckVectorUnary("cumulative_prod",
+                     ChunkedArrayFromJSON(ty, {"[null, 2]", "[null, 4]"}),
+                     ChunkedArrayFromJSON(ty, {"[null, 2, null, 8]"}), &options);
+    CheckVectorUnary("cumulative_prod_checked",
+                     ChunkedArrayFromJSON(ty, {"[null, 2]", "[null, 4]"}),
+                     ChunkedArrayFromJSON(ty, {"[null, 2, null, 8]"}), &options);
+  }
+}
+
+TEST(TestCumulativeMax, NoStartNoSkip) {
+  CumulativeOptions options;
+  for (auto ty : NumericTypes()) {
+    CheckVectorUnary("cumulative_max", ArrayFromJSON(ty, "[2, 1, 3, 5, 4, 6]"),
+                     ArrayFromJSON(ty, "[2, 2, 3, 5, 5, 6]"), &options);
+
+    CheckVectorUnary("cumulative_max", ArrayFromJSON(ty, "[2, 1, null, 5, null, 6]"),
+                     ArrayFromJSON(ty, "[2, 2, null, null, null, null]"), &options);
+
+    CheckVectorUnary("cumulative_max", ArrayFromJSON(ty, "[null, 1, null, 5, null, 6]"),
+                     ArrayFromJSON(ty, "[null, null, null, null, null, null]"), &options);
+
+    CheckVectorUnary("cumulative_max",
+                     ChunkedArrayFromJSON(ty, {"[2, 1, 3]", "[5, 4, 6]"}),
+                     ChunkedArrayFromJSON(ty, {"[2, 2, 3, 5, 5, 6]"}), &options);
+
+    CheckVectorUnary(
+        "cumulative_max", ChunkedArrayFromJSON(ty, {"[2, 1, null]", "[5, null, 6]"}),
+        ChunkedArrayFromJSON(ty, {"[2, 2, null, null, null, null]"}), &options);
+
+    CheckVectorUnary(
+        "cumulative_max", ChunkedArrayFromJSON(ty, {"[null, 1, null]", "[5, null, 6]"}),
+        ChunkedArrayFromJSON(ty, {"[null, null, null, null, null, null]"}), &options);
+  }
+}
+
+TEST(TestCumulativeMax, HasStartNoSkip) {
+  CumulativeOptions options(3.0);
+  for (auto ty : NumericTypes()) {
+    CheckVectorUnary("cumulative_max", ArrayFromJSON(ty, "[2, 1, 3, 5, 4, 6]"),
+                     ArrayFromJSON(ty, "[3, 3, 3, 5, 5, 6]"), &options);
+
+    CheckVectorUnary("cumulative_max", ArrayFromJSON(ty, "[2, 1, null, 5, null, 6]"),
+                     ArrayFromJSON(ty, "[3, 3, null, null, null, null]"), &options);
+
+    CheckVectorUnary("cumulative_max", ArrayFromJSON(ty, "[null, 1, null, 5, null, 6]"),
+                     ArrayFromJSON(ty, "[null, null, null, null, null, null]"), &options);
+
+    CheckVectorUnary("cumulative_max",
+                     ChunkedArrayFromJSON(ty, {"[2, 1, 3]", "[5, 4, 6]"}),
+                     ChunkedArrayFromJSON(ty, {"[3, 3, 3, 5, 5, 6]"}), &options);
+
+    CheckVectorUnary(
+        "cumulative_max", ChunkedArrayFromJSON(ty, {"[2, 1, null]", "[5, null, 6]"}),
+        ChunkedArrayFromJSON(ty, {"[3, 3, null, null, null, null]"}), &options);
+
+    CheckVectorUnary(
+        "cumulative_max", ChunkedArrayFromJSON(ty, {"[null, 1, null]", "[5, null, 6]"}),
+        ChunkedArrayFromJSON(ty, {"[null, null, null, null, null, null]"}), &options);
+  }
+}
+
+TEST(TestCumulativeMax, HasStartDoSkip) {
+  CumulativeOptions options(3.0, true);
+  for (auto ty : NumericTypes()) {
+    CheckVectorUnary("cumulative_max", ArrayFromJSON(ty, "[2, 1, 3, 5, 4, 6]"),
+                     ArrayFromJSON(ty, "[3, 3, 3, 5, 5, 6]"), &options);
+
+    CheckVectorUnary("cumulative_max", ArrayFromJSON(ty, "[2, 1, null, 5, null, 6]"),
+                     ArrayFromJSON(ty, "[3, 3, null, 5, null, 6]"), &options);
+
+    CheckVectorUnary("cumulative_max", ArrayFromJSON(ty, "[null, 1, null, 5, null, 6]"),
+                     ArrayFromJSON(ty, "[null, 3, null, 5, null, 6]"), &options);
+
+    CheckVectorUnary("cumulative_max",
+                     ChunkedArrayFromJSON(ty, {"[2, 1, 3]", "[5, 4, 6]"}),
+                     ChunkedArrayFromJSON(ty, {"[3, 3, 3, 5, 5, 6]"}), &options);
+
+    CheckVectorUnary("cumulative_max",
+                     ChunkedArrayFromJSON(ty, {"[2, 1, null]", "[5, null, 6]"}),
+                     ChunkedArrayFromJSON(ty, {"[3, 3, null, 5, null, 6]"}), &options);
+
+    CheckVectorUnary("cumulative_max",
+                     ChunkedArrayFromJSON(ty, {"[null, 1, null]", "[5, null, 6]"}),
+                     ChunkedArrayFromJSON(ty, {"[null, 3, null, 5, null, 6]"}), &options);
+  }
+}
+
+TEST(TestCumulativeMax, NoStartDoSkip) {
+  CumulativeOptions options(true);
+  for (auto ty : NumericTypes()) {
+    CheckVectorUnary("cumulative_max", ArrayFromJSON(ty, "[2, 1, 3, 5, 4, 6]"),
+                     ArrayFromJSON(ty, "[2, 2, 3, 5, 5, 6]"), &options);
+
+    CheckVectorUnary("cumulative_max", ArrayFromJSON(ty, "[2, 1, null, 5, null, 6]"),
+                     ArrayFromJSON(ty, "[2, 2, null, 5, null, 6]"), &options);
+
+    CheckVectorUnary("cumulative_max", ArrayFromJSON(ty, "[null, 1, null, 5, null, 6]"),
+                     ArrayFromJSON(ty, "[null, 1, null, 5, null, 6]"), &options);
+
+    CheckVectorUnary("cumulative_max",
+                     ChunkedArrayFromJSON(ty, {"[2, 1, 3]", "[5, 4, 6]"}),
+                     ChunkedArrayFromJSON(ty, {"[2, 2, 3, 5, 5, 6]"}), &options);
+
+    CheckVectorUnary("cumulative_max",
+                     ChunkedArrayFromJSON(ty, {"[2, 1, null]", "[5, null, 6]"}),
+                     ChunkedArrayFromJSON(ty, {"[2, 2, null, 5, null, 6]"}), &options);
+
+    CheckVectorUnary("cumulative_max",
+                     ChunkedArrayFromJSON(ty, {"[null, 1, null]", "[5, null, 6]"}),
+                     ChunkedArrayFromJSON(ty, {"[null, 1, null, 5, null, 6]"}), &options);
+  }
+}
+
+TEST(TestCumulativeMin, NoStartNoSkip) {
+  CumulativeOptions options;
+  for (auto ty : NumericTypes()) {
+    CheckVectorUnary("cumulative_min", ArrayFromJSON(ty, "[5, 6, 4, 2, 3, 1]"),
+                     ArrayFromJSON(ty, "[5, 5, 4, 2, 2, 1]"), &options);
+
+    CheckVectorUnary("cumulative_min", ArrayFromJSON(ty, "[5, 6, null, 2, null, 1]"),
+                     ArrayFromJSON(ty, "[5, 5, null, null, null, null]"), &options);
+
+    CheckVectorUnary("cumulative_min", ArrayFromJSON(ty, "[null, 6, null, 2, null, 1]"),
+                     ArrayFromJSON(ty, "[null, null, null, null, null, null]"), &options);
+
+    CheckVectorUnary("cumulative_min",
+                     ChunkedArrayFromJSON(ty, {"[5, 6, 4]", "[2, 3, 1]"}),
+                     ChunkedArrayFromJSON(ty, {"[5, 5, 4, 2, 2, 1]"}), &options);
+
+    CheckVectorUnary(
+        "cumulative_min", ChunkedArrayFromJSON(ty, {"[5, 6, null]", "[2, null, 1]"}),
+        ChunkedArrayFromJSON(ty, {"[5, 5, null, null, null, null]"}), &options);
+
+    CheckVectorUnary(
+        "cumulative_min", ChunkedArrayFromJSON(ty, {"[null, 6, null]", "[2, null, 1]"}),
+        ChunkedArrayFromJSON(ty, {"[null, null, null, null, null, null]"}), &options);
+  }
+}
+
+TEST(TestCumulativeMin, HasStartNoSkip) {
+  CumulativeOptions options(3.0);
+  for (auto ty : NumericTypes()) {
+    CheckVectorUnary("cumulative_min", ArrayFromJSON(ty, "[5, 6, 4, 2, 3, 1]"),
+                     ArrayFromJSON(ty, "[3, 3, 3, 2, 2, 1]"), &options);
+
+    CheckVectorUnary("cumulative_min", ArrayFromJSON(ty, "[5, 6, null, 2, null, 1]"),
+                     ArrayFromJSON(ty, "[3, 3, null, null, null, null]"), &options);
+
+    CheckVectorUnary("cumulative_min", ArrayFromJSON(ty, "[null, 6, null, 2, null, 1]"),
+                     ArrayFromJSON(ty, "[null, null, null, null, null, null]"), &options);
+
+    CheckVectorUnary("cumulative_min",
+                     ChunkedArrayFromJSON(ty, {"[5, 6, 4]", "[2, 3, 1]"}),
+                     ChunkedArrayFromJSON(ty, {"[3, 3, 3, 2, 2, 1]"}), &options);
+
+    CheckVectorUnary(
+        "cumulative_min", ChunkedArrayFromJSON(ty, {"[5, 6, null]", "[2, null, 1]"}),
+        ChunkedArrayFromJSON(ty, {"[3, 3, null, null, null, null]"}), &options);
+
+    CheckVectorUnary(
+        "cumulative_min", ChunkedArrayFromJSON(ty, {"[null, 6, null]", "[2, null, 1]"}),
+        ChunkedArrayFromJSON(ty, {"[null, null, null, null, null, null]"}), &options);
+  }
+}
+
+TEST(TestCumulativeMin, HasStartDoSkip) {
+  CumulativeOptions options(3.0, true);
+  for (auto ty : NumericTypes()) {
+    CheckVectorUnary("cumulative_min", ArrayFromJSON(ty, "[5, 6, 4, 2, 3, 1]"),
+                     ArrayFromJSON(ty, "[3, 3, 3, 2, 2, 1]"), &options);
+
+    CheckVectorUnary("cumulative_min", ArrayFromJSON(ty, "[5, 6, null, 2, null, 1]"),
+                     ArrayFromJSON(ty, "[3, 3, null, 2, null, 1]"), &options);
+
+    CheckVectorUnary("cumulative_min", ArrayFromJSON(ty, "[null, 6, null, 2, null, 1]"),
+                     ArrayFromJSON(ty, "[null, 3, null, 2, null, 1]"), &options);
+
+    CheckVectorUnary("cumulative_min",
+                     ChunkedArrayFromJSON(ty, {"[5, 6, 4]", "[2, 3, 1]"}),
+                     ChunkedArrayFromJSON(ty, {"[3, 3, 3, 2, 2, 1]"}), &options);
+
+    CheckVectorUnary("cumulative_min",
+                     ChunkedArrayFromJSON(ty, {"[5, 6, null]", "[2, null, 1]"}),
+                     ChunkedArrayFromJSON(ty, {"[3, 3, null, 2, null, 1]"}), &options);
+
+    CheckVectorUnary("cumulative_min",
+                     ChunkedArrayFromJSON(ty, {"[null, 6, null]", "[2, null, 1]"}),
+                     ChunkedArrayFromJSON(ty, {"[null, 3, null, 2, null, 1]"}), &options);
+  }
+}
+
+TEST(TestCumulativeMin, NoStartDoSkip) {
+  CumulativeOptions options(true);
+  for (auto ty : NumericTypes()) {
+    CheckVectorUnary("cumulative_min", ArrayFromJSON(ty, "[5, 6, 4, 2, 3, 1]"),
+                     ArrayFromJSON(ty, "[5, 5, 4, 2, 2, 1]"), &options);
+
+    CheckVectorUnary("cumulative_min", ArrayFromJSON(ty, "[5, 6, null, 2, null, 1]"),
+                     ArrayFromJSON(ty, "[5, 5, null, 2, null, 1]"), &options);
+
+    CheckVectorUnary("cumulative_min", ArrayFromJSON(ty, "[null, 6, null, 2, null, 1]"),
+                     ArrayFromJSON(ty, "[null, 6, null, 2, null, 1]"), &options);
+
+    CheckVectorUnary("cumulative_min",
+                     ChunkedArrayFromJSON(ty, {"[5, 6, 4]", "[2, 3, 1]"}),
+                     ChunkedArrayFromJSON(ty, {"[5, 5, 4, 2, 2, 1]"}), &options);
+
+    CheckVectorUnary("cumulative_min",
+                     ChunkedArrayFromJSON(ty, {"[5, 6, null]", "[2, null, 1]"}),
+                     ChunkedArrayFromJSON(ty, {"[5, 5, null, 2, null, 1]"}), &options);
+
+    CheckVectorUnary("cumulative_min",
+                     ChunkedArrayFromJSON(ty, {"[null, 6, null]", "[2, null, 1]"}),
+                     ChunkedArrayFromJSON(ty, {"[null, 6, null, 2, null, 1]"}), &options);
+  }
+}
+
 TEST(TestCumulativeSum, ConvenienceFunctionCheckOverflow) {
   ASSERT_ARRAYS_EQUAL(*CumulativeSum(ArrayFromJSON(int8(), "[127, 1]"),
-                                     CumulativeSumOptions::Defaults(), false)
+                                     CumulativeOptions::Defaults(), false)
                            ->make_array(),
                       *ArrayFromJSON(int8(), "[127, -128]"));
 
   EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, HasSubstr("overflow"),
                                   CumulativeSum(ArrayFromJSON(int8(), "[127, 1]"),
-                                                CumulativeSumOptions::Defaults(), true));
+                                                CumulativeOptions::Defaults(), true));
+}
+
+TEST(TestCumulativeProd, ConvenienceFunctionCheckOverflow) {
+  ASSERT_ARRAYS_EQUAL(*CumulativeProd(ArrayFromJSON(int8(), "[-128, -1]"),
+                                      CumulativeOptions::Defaults(), false)
+                           ->make_array(),
+                      *ArrayFromJSON(int8(), "[-128, -128]"));
+
+  EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, HasSubstr("overflow"),
+                                  CumulativeSum(ArrayFromJSON(int8(), "[-128, -1]"),
+                                                CumulativeOptions::Defaults(), true));
+}
+
+TEST(TestCumulativeMax, ConvenienceFunction) {
+  ASSERT_ARRAYS_EQUAL(
+      *CumulativeMax(ArrayFromJSON(int8(), "[1, 2, 3]"), CumulativeOptions::Defaults())
+           ->make_array(),
+      *ArrayFromJSON(int8(), "[1, 2, 3]"));
+}
+
+TEST(TestCumulativeMin, ConvenienceFunction) {
+  ASSERT_ARRAYS_EQUAL(
+      *CumulativeMin(ArrayFromJSON(int8(), "[-1, -2, -3]"), CumulativeOptions::Defaults())
+           ->make_array(),
+      *ArrayFromJSON(int8(), "[-1, -2, -3]"));
+}
+
+TEST(TestCumulative, NaN) {
+  // addition with NaN is always NaN
+  CheckVectorUnary("cumulative_sum", ArrayFromJSON(float64(), "[1, 2, NaN, 4, 5]"),
+                   ArrayFromJSON(float64(), "[1, 3, NaN, NaN, NaN]"));
+
+  // multiply with Nan is always NaN
+  CheckVectorUnary("cumulative_prod", ArrayFromJSON(float64(), "[1, 2, NaN, 4, 5]"),
+                   ArrayFromJSON(float64(), "[1, 2, NaN, NaN, NaN]"));
+
+  // max with NaN is always ignored because Nan > a always returns false
+  CheckVectorUnary("cumulative_max", ArrayFromJSON(float64(), "[1, 2, NaN, 4, 5]"),
+                   ArrayFromJSON(float64(), "[1, 2, 2, 4, 5]"));
+
+  // min with NaN is always ignored because Nan < a always returns false
+  CheckVectorUnary("cumulative_min", ArrayFromJSON(float64(), "[5, 4, NaN, 2, 1]"),
+                   ArrayFromJSON(float64(), "[5, 4, 4, 2, 1]"));
 }
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -693,6 +693,9 @@ inline std::shared_ptr<Scalar> MakeScalar(std::string value) {
   return std::make_shared<StringScalar>(std::move(value));
 }
 
+inline std::shared_ptr<Scalar> MakeScalar(const std::shared_ptr<Scalar>& scalar) {
+  return scalar;
+}
 /// @}
 
 template <typename ValueRef>

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -1613,28 +1613,39 @@ Array-wise ("vector") functions
 Cumulative Functions
 ~~~~~~~~~~~~~~~~~~~~
 
-Cumulative functions are vector functions that perform a running total on their
-input using a given binary associative operation and output an array containing
-the corresponding intermediate running values. The input is expected to be of
-numeric type. By default these functions do not detect overflow. They are also
-available in an overflow-checking variant, suffixed ``_checked``, which returns
-an ``Invalid`` :class:`Status` when overflow is detected.
+Cumulative functions are vector functions that perform a running accumulation on 
+their input using a given binary associative operation with an identidy element 
+(a monoid) and output an array containing the corresponding intermediate running 
+values. The input is expected to be of numeric type. By default these functions 
+do not detect overflow. They are alsoavailable in an overflow-checking variant, 
+suffixed ``_checked``, which returns an ``Invalid`` :class:`Status` when 
+overflow is detected.
 
 +------------------------+-------+-------------+-------------+--------------------------------+-------+
-| Function name          | Arity | Input types | Output type | Options class                  | Notes |
-+========================+=======+=============+=============+================================+=======+
-| cumulative_sum         | Unary | Numeric     | Numeric     | :struct:`CumulativeSumOptions` | \(1)  |
-+------------------------+-------+-------------+-------------+--------------------------------+-------+
-| cumulative_sum_checked | Unary | Numeric     | Numeric     | :struct:`CumulativeSumOptions` | \(1)  |
-+------------------------+-------+-------------+-------------+--------------------------------+-------+
+| Function name           | Arity | Input types | Output type | Options class                  | Notes |
++=========================+=======+=============+=============+================================+=======+
+| cumulative_sum          | Unary | Numeric     | Numeric     | :struct:`CumulativeOptions`    | \(1)  |
++-------------------------+-------+-------------+-------------+--------------------------------+-------+
+| cumulative_sum_checked  | Unary | Numeric     | Numeric     | :struct:`CumulativeOptions`    | \(1)  |
++-------------------------+-------+-------------+-------------+--------------------------------+-------+
+| cumulative_prod         | Unary | Numeric     | Numeric     | :struct:`CumulativeOptions`    | \(1)  |
++-------------------------+-------+-------------+-------------+--------------------------------+-------+
+| cumulative_prod_checked | Unary | Numeric     | Numeric     | :struct:`CumulativeOptions`    | \(1)  |
++-------------------------+-------+-------------+-------------+--------------------------------+-------+
+| cumulative_max          | Unary | Numeric     | Numeric     | :struct:`CumulativeOptions`    | \(1)  |
++-------------------------+-------+-------------+-------------+--------------------------------+-------+
+| cumulative_min          | Unary | Numeric     | Numeric     | :struct:`CumulativeOptions`    | \(1)  |
++-------------------------+-------+-------------+-------------+--------------------------------+-------+
 
-* \(1) CumulativeSumOptions has two optional parameters. The first parameter
-  :member:`CumulativeSumOptions::start` is a starting value for the running
-  sum. It has a default value of 0. Specified values of ``start`` must have the
-  same type as the input. The second parameter
-  :member:`CumulativeSumOptions::skip_nulls` is a boolean. When set to
+* \(1) CumulativeOptions has two optional parameters. The first parameter
+  :member:`CumulativeOptions::start` is a starting value for the running
+  accumulation. It has a default value of 0 for `sum`, 1 for `prod`, min of 
+  input type for `max`, and max of input type for `min`. Specified values of 
+  ``start`` must be castable to the input type. The second parameter
+  :member:`CumulativeOptions::skip_nulls` is a boolean. When set to
   false (the default), the first encountered null is propagated. When set to
-  true, each null in the input produces a corresponding null in the output.
+  true, each null in the input produces a corresponding null in the output and
+  doesn't affect the accumulation forward.
 
 Associative transforms
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/python/api/compute.rst
+++ b/docs/source/python/api/compute.rst
@@ -52,9 +52,11 @@ Aggregations
 Cumulative Functions
 --------------------
 
-Cumulative functions are vector functions that perform a running total on their
-input and output an array containing the corresponding intermediate running values.
-By default these functions do not detect overflow. They are also
+Cumulative functions are vector functions that perform a running accumulation on 
+their input using a given binary associative operation with an identidy element 
+(a monoid) and output an array containing the corresponding intermediate running 
+values. The input is expected to be of numeric type. By default these functions 
+do not detect overflow. They are also
 available in an overflow-checking variant, suffixed ``_checked``, which
 throws an ``ArrowInvalid`` exception when overflow is detected.
 
@@ -63,6 +65,10 @@ throws an ``ArrowInvalid`` exception when overflow is detected.
 
    cumulative_sum
    cumulative_sum_checked
+   cumulative_prod
+   cumulative_prod_checked
+   cumulative_max
+   cumulative_min
 
 Arithmetic Functions
 --------------------

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -1948,7 +1948,7 @@ cdef class _CumulativeOptions(FunctionOptions):
 class CumulativeOptions(_CumulativeOptions):
     """
     Options for `cumulative_*` functions.
-    
+
     - cumulative_sum
     - cumulative_sum_checked
     ...

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -1947,7 +1947,11 @@ cdef class _CumulativeOptions(FunctionOptions):
 
 class CumulativeOptions(_CumulativeOptions):
     """
-    Options for `cumulative` functions.
+    Options for `cumulative_*` functions.
+    
+    - cumulative_sum
+    - cumulative_sum_checked
+    ...
 
     Parameters
     ----------

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -1951,7 +1951,10 @@ class CumulativeOptions(_CumulativeOptions):
 
     - cumulative_sum
     - cumulative_sum_checked
-    ...
+    - cumulative_prod
+    - cumulative_prod_checked
+    - cumulative_max
+    - cumulative_min
 
     Parameters
     ----------

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -1928,31 +1928,37 @@ class PartitionNthOptions(_PartitionNthOptions):
         self._set_options(pivot, null_placement)
 
 
-cdef class _CumulativeSumOptions(FunctionOptions):
+cdef class _CumulativeOptions(FunctionOptions):
     def _set_options(self, start, skip_nulls):
-        if not isinstance(start, Scalar):
+        if start is None:
+            self.wrapped.reset(new CCumulativeOptions(skip_nulls))
+        elif isinstance(start, Scalar):
+            self.wrapped.reset(new CCumulativeOptions(
+                pyarrow_unwrap_scalar(start), skip_nulls))
+        else:
             try:
                 start = lib.scalar(start)
+                self.wrapped.reset(new CCumulativeOptions(
+                    pyarrow_unwrap_scalar(start), skip_nulls))
             except Exception:
                 _raise_invalid_function_option(
                     start, "`start` type for CumulativeSumOptions", TypeError)
 
-        self.wrapped.reset(new CCumulativeSumOptions((<Scalar> start).unwrap(), skip_nulls))
 
-
-class CumulativeSumOptions(_CumulativeSumOptions):
+class CumulativeOptions(_CumulativeOptions):
     """
-    Options for `cumulative_sum` function.
+    Options for `cumulative` functions.
 
     Parameters
     ----------
-    start : Scalar, default 0.0
-        Starting value for sum computation
+    start : Scalar, default None
+        Starting value for the cumulative operation. If none is given, 
+        a default value depending on the operation and input type is used.
     skip_nulls : bool, default False
         When false, the first encountered null is propagated.
     """
 
-    def __init__(self, start=0.0, *, skip_nulls=False):
+    def __init__(self, start=None, *, skip_nulls=False):
         self._set_options(start, skip_nulls)
 
 

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -34,6 +34,7 @@ from pyarrow._compute import (  # noqa
     CastOptions,
     CountOptions,
     CumulativeOptions,
+    CumulativeOptions as CumulativeSumOptions,
     DayOfWeekOptions,
     DictionaryEncodeOptions,
     RunEndEncodeOptions,

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -35,7 +35,6 @@ from pyarrow._compute import (  # noqa
     CountOptions,
     CumulativeOptions,
     CumulativeOptions as CumulativeSumOptions,
-    CumulativeOptions as CumulativeSumOptions,
     DayOfWeekOptions,
     DictionaryEncodeOptions,
     RunEndEncodeOptions,

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -33,7 +33,7 @@ from pyarrow._compute import (  # noqa
     AssumeTimezoneOptions,
     CastOptions,
     CountOptions,
-    CumulativeSumOptions,
+    CumulativeOptions,
     DayOfWeekOptions,
     DictionaryEncodeOptions,
     RunEndEncodeOptions,

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -35,6 +35,7 @@ from pyarrow._compute import (  # noqa
     CountOptions,
     CumulativeOptions,
     CumulativeOptions as CumulativeSumOptions,
+    CumulativeOptions as CumulativeSumOptions,
     DayOfWeekOptions,
     DictionaryEncodeOptions,
     RunEndEncodeOptions,

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2400,10 +2400,11 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
         int64_t pivot
         CNullPlacement null_placement
 
-    cdef cppclass CCumulativeSumOptions \
-            "arrow::compute::CumulativeSumOptions"(CFunctionOptions):
-        CCumulativeSumOptions(shared_ptr[CScalar] start, c_bool skip_nulls)
-        shared_ptr[CScalar] start
+    cdef cppclass CCumulativeOptions \
+            "arrow::compute::CumulativeOptions"(CFunctionOptions):
+        CCumulativeOptions(c_bool skip_nulls)
+        CCumulativeOptions(shared_ptr[CScalar] start, c_bool skip_nulls)
+        optional[shared_ptr[CScalar]] start
         c_bool skip_nulls
 
     cdef cppclass CArraySortOptions \

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -156,7 +156,7 @@ def test_option_class_equality():
         pc.NullOptions(),
         pc.PadOptions(5),
         pc.PartitionNthOptions(1, null_placement="at_start"),
-        pc.CumulativeSumOptions(start=0, skip_nulls=False),
+        pc.CumulativeOptions(start=None, skip_nulls=False),
         pc.QuantileOptions(),
         pc.RandomOptions(),
         pc.RankOptions(sort_keys="ascending",
@@ -2847,7 +2847,7 @@ def test_min_max_element_wise():
 def test_cumulative_sum(start, skip_nulls):
     # Exact tests (e.g., integral types)
     start_int = int(start)
-    starts = [start_int, pa.scalar(start_int, type=pa.int8()),
+    starts = [None, start_int, pa.scalar(start_int, type=pa.int8()),
               pa.scalar(start_int, type=pa.int64())]
     for strt in starts:
         arrays = [
@@ -2865,10 +2865,10 @@ def test_cumulative_sum(start, skip_nulls):
         for i, arr in enumerate(arrays):
             result = pc.cumulative_sum(arr, start=strt, skip_nulls=skip_nulls)
             # Add `start` offset to expected array before comparing
-            expected = pc.add(expected_arrays[i], strt)
+            expected = pc.add(expected_arrays[i], strt if strt is not None else 0)
             assert result.equals(expected)
 
-    starts = [start, pa.scalar(start, type=pa.float32()),
+    starts = [None, start, pa.scalar(start, type=pa.float32()),
               pa.scalar(start, type=pa.float64())]
     for strt in starts:
         arrays = [
@@ -2885,13 +2885,177 @@ def test_cumulative_sum(start, skip_nulls):
         for i, arr in enumerate(arrays):
             result = pc.cumulative_sum(arr, start=strt, skip_nulls=skip_nulls)
             # Add `start` offset to expected array before comparing
-            expected = pc.add(expected_arrays[i], strt)
+            expected = pc.add(expected_arrays[i], strt if strt is not None else 0)
             np.testing.assert_array_almost_equal(result.to_numpy(
                 zero_copy_only=False), expected.to_numpy(zero_copy_only=False))
 
     for strt in ['a', pa.scalar('arrow'), 1.1]:
         with pytest.raises(pa.ArrowInvalid):
             pc.cumulative_sum([1, 2, 3], start=strt)
+
+
+@pytest.mark.parametrize('start', (1.25, 10.5, -10.5))
+@pytest.mark.parametrize('skip_nulls', (True, False))
+def test_cumulative_prod(start, skip_nulls):
+    # Exact tests (e.g., integral types)
+    start_int = int(start)
+    starts = [None, start_int, pa.scalar(start_int, type=pa.int8()),
+              pa.scalar(start_int, type=pa.int64())]
+    for strt in starts:
+        arrays = [
+            pa.array([1, 2, 3]),
+            pa.array([1, None, 20, 5]),
+            pa.chunked_array([[1, None], [20, 5]])
+        ]
+        expected_arrays = [
+            pa.array([1, 2, 6]),
+            pa.array([1, None, 20, 100])
+            if skip_nulls else pa.array([1, None, None, None]),
+            pa.chunked_array([[1, None, 20, 100]])
+            if skip_nulls else pa.chunked_array([[1, None, None, None]])
+        ]
+        for i, arr in enumerate(arrays):
+            result = pc.cumulative_prod(arr, start=strt, skip_nulls=skip_nulls)
+            # Multiply `start` offset to expected array before comparing
+            expected = pc.multiply(expected_arrays[i], strt if strt is not None else 1)
+            assert result.equals(expected)
+
+    starts = [None, start, pa.scalar(start, type=pa.float32()),
+              pa.scalar(start, type=pa.float64())]
+    for strt in starts:
+        arrays = [
+            pa.array([1.5, 2.5, 3.5]),
+            pa.array([1, np.nan, 2, -3, 4, 5]),
+            pa.array([1, np.nan, None, 3, None, 5])
+        ]
+        expected_arrays = [
+            np.array([1.5, 3.75, 13.125]),
+            np.array([1, np.nan, np.nan, np.nan, np.nan, np.nan]),
+            np.array([1, np.nan, None, np.nan, None, np.nan])
+            if skip_nulls else np.array([1, np.nan, None, None, None, None])
+        ]
+        for i, arr in enumerate(arrays):
+            result = pc.cumulative_prod(arr, start=strt, skip_nulls=skip_nulls)
+            # Multiply `start` offset to expected array before comparing
+            expected = pc.multiply(expected_arrays[i], strt if strt is not None else 1)
+            np.testing.assert_array_almost_equal(result.to_numpy(
+                zero_copy_only=False), expected.to_numpy(zero_copy_only=False))
+
+    for strt in ['a', pa.scalar('arrow'), 1.1]:
+        with pytest.raises(pa.ArrowInvalid):
+            pc.cumulative_prod([1, 2, 3], start=strt)
+
+
+@pytest.mark.parametrize('start', (0.5, 3.5, 6.5))
+@pytest.mark.parametrize('skip_nulls', (True, False))
+def test_cumulative_max(start, skip_nulls):
+    # Exact tests (e.g., integral types)
+    start_int = int(start)
+    starts = [None, start_int, pa.scalar(start_int, type=pa.int8()),
+              pa.scalar(start_int, type=pa.int64())]
+    for strt in starts:
+        arrays = [
+            pa.array([2, 1, 3, 5, 4, 6]),
+            pa.array([2, 1, None, 5, 4, None]),
+            pa.chunked_array([[2, 1, None], [5, 4, None]])
+        ]
+        expected_arrays = [
+            pa.array([2, 2, 3, 5, 5, 6]),
+            pa.array([2, 2, None, 5, 5, None])
+            if skip_nulls else pa.array([2, 2, None, None, None, None]),
+            pa.chunked_array([[2, 2, None, 5, 5, None]])
+            if skip_nulls else
+            pa.chunked_array([[2, 2, None, None, None, None]])
+        ]
+        for i, arr in enumerate(arrays):
+            result = pc.cumulative_max(arr, start=strt, skip_nulls=skip_nulls)
+            # Max `start` offset with expected array before comparing
+            expected = pc.max_element_wise(
+                expected_arrays[i], strt if strt is not None else int(-1e9),
+                skip_nulls=False)
+            assert result.equals(expected)
+
+    starts = [None, start, pa.scalar(start, type=pa.float32()),
+              pa.scalar(start, type=pa.float64())]
+    for strt in starts:
+        arrays = [
+            pa.array([2.5, 1.3, 3.7, 5.1, 4.9, 6.2]),
+            pa.array([2.5, 1.3, 3.7, np.nan, 4.9, 6.2]),
+            pa.array([2.5, 1.3, None, np.nan, 4.9, None])
+        ]
+        expected_arrays = [
+            np.array([2.5, 2.5, 3.7, 5.1, 5.1, 6.2]),
+            np.array([2.5, 2.5, 3.7, 3.7, 4.9, 6.2]),
+            np.array([2.5, 2.5, None, 2.5, 4.9, None])
+            if skip_nulls else np.array([2.5, 2.5, None, None, None, None])
+        ]
+        for i, arr in enumerate(arrays):
+            result = pc.cumulative_max(arr, start=strt, skip_nulls=skip_nulls)
+            # Max `start` offset with expected array before comparing
+            expected = pc.max_element_wise(
+                expected_arrays[i], strt if strt is not None else -1e9, skip_nulls=False)
+            np.testing.assert_array_almost_equal(result.to_numpy(
+                zero_copy_only=False), expected.to_numpy(zero_copy_only=False))
+
+    for strt in ['a', pa.scalar('arrow'), 1.1]:
+        with pytest.raises(pa.ArrowInvalid):
+            pc.cumulative_max([1, 2, 3], start=strt)
+
+
+@pytest.mark.parametrize('start', (0.5, 3.5, 6.5))
+@pytest.mark.parametrize('skip_nulls', (True, False))
+def test_cumulative_min(start, skip_nulls):
+    # Exact tests (e.g., integral types)
+    start_int = int(start)
+    starts = [None, start_int, pa.scalar(start_int, type=pa.int8()),
+              pa.scalar(start_int, type=pa.int64())]
+    for strt in starts:
+        arrays = [
+            pa.array([5, 6, 4, 2, 3, 1]),
+            pa.array([5, 6, None, 2, 3, None]),
+            pa.chunked_array([[5, 6, None], [2, 3, None]])
+        ]
+        expected_arrays = [
+            pa.array([5, 5, 4, 2, 2, 1]),
+            pa.array([5, 5, None, 2, 2, None])
+            if skip_nulls else pa.array([5, 5, None, None, None, None]),
+            pa.chunked_array([[5, 5, None, 2, 2, None]])
+            if skip_nulls else
+            pa.chunked_array([[5, 5, None, None, None, None]])
+        ]
+        for i, arr in enumerate(arrays):
+            result = pc.cumulative_min(arr, start=strt, skip_nulls=skip_nulls)
+            # Min `start` offset with expected array before comparing
+            expected = pc.min_element_wise(
+                expected_arrays[i], strt if strt is not None else int(1e9),
+                skip_nulls=False)
+            assert result.equals(expected)
+
+    starts = [None, start, pa.scalar(start, type=pa.float32()),
+              pa.scalar(start, type=pa.float64())]
+    for strt in starts:
+        arrays = [
+            pa.array([5.5, 6.3, 4.7, 2.1, 3.9, 1.2]),
+            pa.array([5.5, 6.3, 4.7, np.nan, 3.9, 1.2]),
+            pa.array([5.5, 6.3, None, np.nan, 3.9, None])
+        ]
+        expected_arrays = [
+            np.array([5.5, 5.5, 4.7, 2.1, 2.1, 1.2]),
+            np.array([5.5, 5.5, 4.7, 4.7, 3.9, 1.2]),
+            np.array([5.5, 5.5, None, 5.5, 3.9, None])
+            if skip_nulls else np.array([5.5, 5.5, None, None, None, None])
+        ]
+        for i, arr in enumerate(arrays):
+            result = pc.cumulative_min(arr, start=strt, skip_nulls=skip_nulls)
+            # Min `start` offset with expected array before comparing
+            expected = pc.min_element_wise(
+                expected_arrays[i], strt if strt is not None else 1e9, skip_nulls=False)
+            np.testing.assert_array_almost_equal(result.to_numpy(
+                zero_copy_only=False), expected.to_numpy(zero_copy_only=False))
+
+    for strt in ['a', pa.scalar('arrow'), 1.1]:
+        with pytest.raises(pa.ArrowInvalid):
+            pc.cumulative_max([1, 2, 3], start=strt)
 
 
 def test_make_struct():

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -2865,7 +2865,8 @@ def test_cumulative_sum(start, skip_nulls):
         for i, arr in enumerate(arrays):
             result = pc.cumulative_sum(arr, start=strt, skip_nulls=skip_nulls)
             # Add `start` offset to expected array before comparing
-            expected = pc.add(expected_arrays[i], strt if strt is not None else 0)
+            expected = pc.add(expected_arrays[i], strt if strt is not None
+                              else 0)
             assert result.equals(expected)
 
     starts = [None, start, pa.scalar(start, type=pa.float32()),
@@ -2885,7 +2886,8 @@ def test_cumulative_sum(start, skip_nulls):
         for i, arr in enumerate(arrays):
             result = pc.cumulative_sum(arr, start=strt, skip_nulls=skip_nulls)
             # Add `start` offset to expected array before comparing
-            expected = pc.add(expected_arrays[i], strt if strt is not None else 0)
+            expected = pc.add(expected_arrays[i], strt if strt is not None
+                              else 0)
             np.testing.assert_array_almost_equal(result.to_numpy(
                 zero_copy_only=False), expected.to_numpy(zero_copy_only=False))
 
@@ -2917,7 +2919,8 @@ def test_cumulative_prod(start, skip_nulls):
         for i, arr in enumerate(arrays):
             result = pc.cumulative_prod(arr, start=strt, skip_nulls=skip_nulls)
             # Multiply `start` offset to expected array before comparing
-            expected = pc.multiply(expected_arrays[i], strt if strt is not None else 1)
+            expected = pc.multiply(expected_arrays[i], strt if strt is not None
+                                   else 1)
             assert result.equals(expected)
 
     starts = [None, start, pa.scalar(start, type=pa.float32()),
@@ -2937,7 +2940,8 @@ def test_cumulative_prod(start, skip_nulls):
         for i, arr in enumerate(arrays):
             result = pc.cumulative_prod(arr, start=strt, skip_nulls=skip_nulls)
             # Multiply `start` offset to expected array before comparing
-            expected = pc.multiply(expected_arrays[i], strt if strt is not None else 1)
+            expected = pc.multiply(expected_arrays[i], strt if strt is not None
+                                   else 1)
             np.testing.assert_array_almost_equal(result.to_numpy(
                 zero_copy_only=False), expected.to_numpy(zero_copy_only=False))
 
@@ -2993,7 +2997,8 @@ def test_cumulative_max(start, skip_nulls):
             result = pc.cumulative_max(arr, start=strt, skip_nulls=skip_nulls)
             # Max `start` offset with expected array before comparing
             expected = pc.max_element_wise(
-                expected_arrays[i], strt if strt is not None else -1e9, skip_nulls=False)
+                expected_arrays[i], strt if strt is not None else -1e9,
+                skip_nulls=False)
             np.testing.assert_array_almost_equal(result.to_numpy(
                 zero_copy_only=False), expected.to_numpy(zero_copy_only=False))
 
@@ -3049,7 +3054,8 @@ def test_cumulative_min(start, skip_nulls):
             result = pc.cumulative_min(arr, start=strt, skip_nulls=skip_nulls)
             # Min `start` offset with expected array before comparing
             expected = pc.min_element_wise(
-                expected_arrays[i], strt if strt is not None else 1e9, skip_nulls=False)
+                expected_arrays[i], strt if strt is not None else 1e9,
+                skip_nulls=False)
             np.testing.assert_array_almost_equal(result.to_numpy(
                 zero_copy_only=False), expected.to_numpy(zero_copy_only=False))
 


### PR DESCRIPTION

<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Implement cumulative prod, max and min compute functions
### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

1. Add implementations, docs and tests for the three functions.
2. Refactor `CumulativeSumOptions` to `CumulativeOptions` for reusability.
3. Fix a bug where `GenericFromScalar(GenericToScalar(std::nullopt))  != std::nullopt`.
4. Remove an unnecessary Cast with the default start value.
5. Add tests to check behavior with `NaN`.

I'll explain some of the changes in comments.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
6. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, in vector_accumulative_ops_test.cc and test_compute.py

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->

No. The data members of `CumulativeSumOptions` are changed, but the member functions behave as before. And std::optional<T> also can be constructed directly from T. So users should not feel any difference.
* Closes: #32190