### PR TITLE
GH-36008: [Ruby][Parquet] Add Parquet::ArrowFileReader#each_row_group

### DIFF
--- a/ruby/red-parquet/lib/parquet/arrow-file-reader.rb
+++ b/ruby/red-parquet/lib/parquet/arrow-file-reader.rb
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module Parquet
+  class ArrowFileReader
+    def each_row_group
+      return to_enum(__method__) {n_row_groups} unless block_given?
+
+      n_row_groups.times do |i|
+        yield(read_row_group(i))
+      end
+    end
+  end
+end

--- a/ruby/red-parquet/lib/parquet/loader.rb
+++ b/ruby/red-parquet/lib/parquet/loader.rb
@@ -29,6 +29,7 @@ module Parquet
     end
 
     def require_libraries
+      require "parquet/arrow-file-reader"
       require "parquet/arrow-table-loadable"
       require "parquet/arrow-table-savable"
       require "parquet/writer-properties"

--- a/ruby/red-parquet/test/test-arrow-file-reader.rb
+++ b/ruby/red-parquet/test/test-arrow-file-reader.rb
@@ -30,6 +30,21 @@ class TestArrowFileReader < Test::Unit::TestCase
   end
 
   sub_test_case("#each_row_group") do
+    test("block") do
+      Arrow::FileInputStream.open(@file.path) do |input|
+        reader = Parquet::ArrowFileReader.new(input)
+        row_groups = []
+        reader.each_row_group do |row_group|
+          row_groups << row_group
+        end
+        assert_equal([
+                       Arrow::Table.new(@schema, [[true]]),
+                       Arrow::Table.new(@schema, [[false]])
+                     ],
+                     row_groups)
+      end
+    end
+
     test("without block") do
       Arrow::FileInputStream.open(@file.path) do |input|
         reader = Parquet::ArrowFileReader.new(input)

--- a/ruby/red-parquet/test/test-arrow-file-reader.rb
+++ b/ruby/red-parquet/test/test-arrow-file-reader.rb
@@ -17,11 +17,8 @@
 
 class TestArrowFileReader < Test::Unit::TestCase
   def setup
-    visible_field = Arrow::Field.new("visible", :boolean)
-    @schema = Arrow::Schema.new([visible_field])
-    visible_arrays = [Arrow::BooleanArray.new([true, false])]
-    visible_array = Arrow::ChunkedArray.new(visible_arrays)
-    table = Arrow::Table.new(@schema, [visible_array])
+    @schema = Arrow::Schema.new(visible: :boolean)
+    table = Arrow::Table.new(@schema, [[true], [false]])
     Tempfile.create(["red-parquet", ".parquet"]) do |file|
       @file = file
       Parquet::ArrowFileWriter.open(table.schema, @file.path) do |writer|
@@ -34,19 +31,14 @@ class TestArrowFileReader < Test::Unit::TestCase
 
   sub_test_case("#each_row_group") do
     test("without block") do
-      first_visible_arrays = [Arrow::BooleanArray.new([true])]
-      first_visible_array = Arrow::ChunkedArray.new(first_visible_arrays)
-      second_visible_arrays = [Arrow::BooleanArray.new([false])]
-      second_visible_array = Arrow::ChunkedArray.new(second_visible_arrays)
-
       Arrow::FileInputStream.open(@file.path) do |input|
         reader = Parquet::ArrowFileReader.new(input)
         each_row_group = reader.each_row_group
         assert_equal({
                        size: 2,
                        to_a: [
-                         Arrow::Table.new(@schema, [first_visible_array]),
-                         Arrow::Table.new(@schema, [second_visible_array])
+                         Arrow::Table.new(@schema, [[true]]),
+                         Arrow::Table.new(@schema, [[false]])
                        ],
                      },
                      {

--- a/ruby/red-parquet/test/test-arrow-file-reader.rb
+++ b/ruby/red-parquet/test/test-arrow-file-reader.rb
@@ -22,11 +22,14 @@ class TestArrowFileReader < Test::Unit::TestCase
     visible_arrays = [Arrow::BooleanArray.new([true, false])]
     visible_array = Arrow::ChunkedArray.new(visible_arrays)
     table = Arrow::Table.new(@schema, [visible_array])
-    @file = Tempfile.open(["red-parquet", ".parquet"])
-    chunk_size = 1
-    writer = Parquet::ArrowFileWriter.new(table.schema, @file.path)
-    writer.write_table(table, chunk_size)
-    writer.close
+    Tempfile.create(["red-parquet", ".parquet"]) do |file|
+      @file = file
+      chunk_size = 1
+      writer = Parquet::ArrowFileWriter.new(table.schema, @file.path)
+      writer.write_table(table, chunk_size)
+      writer.close
+      yield
+    end
   end
 
   sub_test_case("#each_row_group") do

--- a/ruby/red-parquet/test/test-arrow-file-reader.rb
+++ b/ruby/red-parquet/test/test-arrow-file-reader.rb
@@ -24,10 +24,10 @@ class TestArrowFileReader < Test::Unit::TestCase
     table = Arrow::Table.new(@schema, [visible_array])
     Tempfile.create(["red-parquet", ".parquet"]) do |file|
       @file = file
-      chunk_size = 1
-      writer = Parquet::ArrowFileWriter.new(table.schema, @file.path)
-      writer.write_table(table, chunk_size)
-      writer.close
+      Parquet::ArrowFileWriter.open(table.schema, @file.path) do |writer|
+        chunk_size = 1
+        writer.write_table(table, chunk_size)
+      end
       yield
     end
   end

--- a/ruby/red-parquet/test/test-arrow-file-reader.rb
+++ b/ruby/red-parquet/test/test-arrow-file-reader.rb
@@ -1,0 +1,56 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestArrowFileReader < Test::Unit::TestCase
+  def setup
+    visible_field = Arrow::Field.new("visible", :boolean)
+    @schema = Arrow::Schema.new([visible_field])
+    visible_arrays = [Arrow::BooleanArray.new([true, false])]
+    visible_array = Arrow::ChunkedArray.new(visible_arrays)
+    table = Arrow::Table.new(@schema, [visible_array])
+    @file = Tempfile.open(["red-parquet", ".parquet"])
+    chunk_size = 1
+    writer = Parquet::ArrowFileWriter.new(table.schema, @file.path)
+    writer.write_table(table, chunk_size)
+    writer.close
+  end
+
+  sub_test_case("#each_row_group") do
+    test("without block") do
+      first_visible_arrays = [Arrow::BooleanArray.new([true])]
+      first_visible_array = Arrow::ChunkedArray.new(first_visible_arrays)
+      second_visible_arrays = [Arrow::BooleanArray.new([false])]
+      second_visible_array = Arrow::ChunkedArray.new(second_visible_arrays)
+
+      Arrow::FileInputStream.open(@file.path) do |input|
+        reader = Parquet::ArrowFileReader.new(input)
+        each_row_group = reader.each_row_group
+        assert_equal({
+                       size: 2,
+                       to_a: [
+                         Arrow::Table.new(@schema, [first_visible_array]),
+                         Arrow::Table.new(@schema, [second_visible_array])
+                       ],
+                     },
+                     {
+                       size: each_row_group.size,
+                       to_a: each_row_group.to_a,
+                     })
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Rationale for this change
This change allows you to read a large Parquet file per row group.
- ref: https://github.com/apache/arrow/issues/36001

### What changes are included in this PR?
- Add Parquet::ArrowFileReader#each_row_group
- Add the related test about it

### Are these changes tested?
Yes
- I don't have confidence about the test. Could you give me a comment?

### Are there any user-facing changes?
No

Close: https://github.com/apache/arrow/issues/36008
* Closes: #36008