### PR TITLE
GH-36023: [CI][Ruby][Release] Suppress meaningless progress log from verify-rc-ruby

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1891,6 +1891,7 @@ services:
       CMAKE_GENERATOR: Ninja
       DEBIAN_FRONTEND: "noninteractive"
       DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: 1
+      GITHUB_ACTIONS:
       TEST_APT: 0  # would require docker-in-docker
       TEST_YUM: 0
       USE_CONDA: 1
@@ -1922,6 +1923,7 @@ services:
     environment:
       <<: *ccache
       CMAKE_GENERATOR: Ninja
+      GITHUB_ACTIONS:
       TEST_APT: 0  # would require docker-in-docker
       TEST_YUM: 0
     command: >
@@ -1950,6 +1952,7 @@ services:
     environment:
       <<: *ccache
       CMAKE_GENERATOR: Ninja
+      GITHUB_ACTIONS:
       TEST_APT: 0  # would require docker-in-docker
       TEST_YUM: 0
     command: >


### PR DESCRIPTION
### Rationale for this change

GLib/Ruby tests show progress log by default:

https://github.com/ursacomputing/crossbow/actions/runs/5230026234/jobs/9443353956#step:6:10172

```text
|
/
-
\
|
/
-
\
|
```

It's useful on local run but meaningless on CI.

### What changes are included in this PR?

Pass through `GITHUB_ACTIONS` environment variable because the testing frame that is used by GLib/Ruby tests suppress the progress log with `GITHUB_ACTIONS=true` automatically.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #36023