### PR TITLE
GH-36050: [Docs][C] Fix memory leak in C export documentation

### DIFF
--- a/docs/source/format/CDataInterface.rst
+++ b/docs/source/format/CDataInterface.rst
@@ -783,6 +783,7 @@ Export the array type as a ``ArrowSchema`` with C-malloc()ed children:
          if (child->release != NULL) {
             child->release(child);
          }
+         free(child);
       }
       free(schema->children);
       // Mark released
@@ -857,6 +858,7 @@ transferring ownership to the consumer:
          if (child->release != NULL) {
             child->release(child);
          }
+         free(child);
       }
       free(array->children);
       // Free buffers


### PR DESCRIPTION
### Rationale for this change
Fix memory leak in C export examples. Fixes #36050.

### What changes are included in this PR?
Change to example in docs

### Are these changes tested?
Docs only change.

### Are there any user-facing changes?
No
* Closes: #36050