### PR TITLE
GH-35635: [C++][CI] Preserve root when ignoring host on PathFromUriHelper to fix HDFS tests

### DIFF
--- a/cpp/src/arrow/filesystem/util_internal.cc
+++ b/cpp/src/arrow/filesystem/util_internal.cc
@@ -180,7 +180,7 @@ Result<std::string> PathFromUriHelper(const std::string& uri_string,
     case AuthorityHandlingBehavior::kWindows:
       return std::string(internal::RemoveTrailingSlash("//" + host + path));
     case AuthorityHandlingBehavior::kIgnore:
-      return std::string(internal::RemoveTrailingSlash(path));
+      return std::string(internal::RemoveTrailingSlash(path, /*preserve_root=*/true));
     default:
       return Status::Invalid("Unrecognized authority_handling value");
   }


### PR DESCRIPTION
### Rationale for this change

As discussed on the issue the HDFS filesystem should be returning `/` if the entire path is `/`

### What changes are included in this PR?

Change behavior of helper `PathFromUriHelper` when ignoring host to preserve `/`

### Are these changes tested?

On CI and archery.

### Are there any user-facing changes?

No
* Closes: #35635