### PR TITLE
GH-36059: [C++][Compute] Reserve space for hashtable for scalar lookup functions

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
@@ -36,7 +36,7 @@ namespace {
 
 template <typename Type>
 struct SetLookupState : public KernelState {
-  explicit SetLookupState(MemoryPool* pool) : lookup_table(), memory_pool(pool) {}
+  explicit SetLookupState(MemoryPool* pool) : memory_pool(pool) {}
 
   Status Init(const SetLookupOptions& options) {
     if (options.value_set.is_array()) {
@@ -105,7 +105,7 @@ struct SetLookupState : public KernelState {
   }
 
   using MemoTable = typename HashTraits<Type>::MemoTableType;
-  std::optional<MemoTable> lookup_table;
+  std::optional<MemoTable> lookup_table;  // use optional for delayed initialization
   MemoryPool* memory_pool;
   // When there are duplicates in value_set, the MemoTable indices must
   // be mapped back to indices in the value_set.

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
@@ -61,8 +61,8 @@ struct SetLookupState : public KernelState {
     } else {
       return Status::Invalid("value_set should be an array or chunked array");
     }
-    if (!options.skip_nulls && lookup_table.value().GetNull() >= 0) {
-      null_index = memo_index_to_value_index[lookup_table.value().GetNull()];
+    if (!options.skip_nulls && lookup_table->GetNull() >= 0) {
+      null_index = memo_index_to_value_index[lookup_table->GetNull()];
     }
     return Status::OK();
   }
@@ -82,7 +82,7 @@ struct SetLookupState : public KernelState {
         DCHECK_EQ(memo_index, memo_size);
         memo_index_to_value_index.push_back(index);
       };
-      RETURN_NOT_OK(lookup_table.value().GetOrInsert(
+      RETURN_NOT_OK(lookup_table->GetOrInsert(
           v, std::move(on_found), std::move(on_not_found), &unused_memo_index));
       ++index;
       return Status::OK();
@@ -96,7 +96,7 @@ struct SetLookupState : public KernelState {
         DCHECK_EQ(memo_index, memo_size);
         memo_index_to_value_index.push_back(index);
       };
-      lookup_table.value().GetOrInsertNull(std::move(on_found), std::move(on_not_found));
+      lookup_table->GetOrInsertNull(std::move(on_found), std::move(on_not_found));
       ++index;
       return Status::OK();
     };
@@ -272,7 +272,7 @@ struct IndexInVisitor {
     VisitArraySpanInline<Type>(
         data,
         [&](T v) {
-          int32_t index = state.lookup_table.value().Get(v);
+          int32_t index = state.lookup_table->Get(v);
           if (index != -1) {
             bitmap_writer.Set();
 
@@ -366,7 +366,7 @@ struct IsInVisitor {
     VisitArraySpanInline<Type>(
         this->data,
         [&](T v) {
-          if (state.lookup_table.value().Get(v) != -1) {
+          if (state.lookup_table->Get(v) != -1) {
             writer.Set();
           } else {
             writer.Clear();

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
@@ -36,7 +36,7 @@ namespace {
 
 template <typename Type>
 struct SetLookupState : public KernelState {
-  explicit SetLookupState(MemoryPool* pool) : lookup_table(pool, 0), memory_pool(pool) {}
+  explicit SetLookupState(MemoryPool* pool) : lookup_table(), memory_pool(pool) {}
 
   Status Init(const SetLookupOptions& options) {
     if (options.value_set.is_array()) {
@@ -61,8 +61,8 @@ struct SetLookupState : public KernelState {
     } else {
       return Status::Invalid("value_set should be an array or chunked array");
     }
-    if (!options.skip_nulls && lookup_table.GetNull() >= 0) {
-      null_index = memo_index_to_value_index[lookup_table.GetNull()];
+    if (!options.skip_nulls && lookup_table.value().GetNull() >= 0) {
+      null_index = memo_index_to_value_index[lookup_table.value().GetNull()];
     }
     return Status::OK();
   }
@@ -82,7 +82,7 @@ struct SetLookupState : public KernelState {
         DCHECK_EQ(memo_index, memo_size);
         memo_index_to_value_index.push_back(index);
       };
-      RETURN_NOT_OK(lookup_table.GetOrInsert(
+      RETURN_NOT_OK(lookup_table.value().GetOrInsert(
           v, std::move(on_found), std::move(on_not_found), &unused_memo_index));
       ++index;
       return Status::OK();
@@ -96,7 +96,7 @@ struct SetLookupState : public KernelState {
         DCHECK_EQ(memo_index, memo_size);
         memo_index_to_value_index.push_back(index);
       };
-      lookup_table.GetOrInsertNull(std::move(on_found), std::move(on_not_found));
+      lookup_table.value().GetOrInsertNull(std::move(on_found), std::move(on_not_found));
       ++index;
       return Status::OK();
     };
@@ -105,7 +105,7 @@ struct SetLookupState : public KernelState {
   }
 
   using MemoTable = typename HashTraits<Type>::MemoTableType;
-  MemoTable lookup_table;
+  std::optional<MemoTable> lookup_table;
   MemoryPool* memory_pool;
   // When there are duplicates in value_set, the MemoTable indices must
   // be mapped back to indices in the value_set.
@@ -272,7 +272,7 @@ struct IndexInVisitor {
     VisitArraySpanInline<Type>(
         data,
         [&](T v) {
-          int32_t index = state.lookup_table.Get(v);
+          int32_t index = state.lookup_table.value().Get(v);
           if (index != -1) {
             bitmap_writer.Set();
 
@@ -366,7 +366,7 @@ struct IsInVisitor {
     VisitArraySpanInline<Type>(
         this->data,
         [&](T v) {
-          if (state.lookup_table.Get(v) != -1) {
+          if (state.lookup_table.value().Get(v) != -1) {
             writer.Set();
           } else {
             writer.Clear();

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup_benchmark.cc
@@ -111,7 +111,8 @@ static void IndexInInt64SmallSet(benchmark::State& state) {
 }
 
 static void IndexInInt32LargeSet(benchmark::State& state) {
-  SetLookupBenchmarkNumeric<Int32Type>(state, "index_in_meta_binary", state.range(0), 10);
+  SetLookupBenchmarkNumeric<Int32Type>(state, "index_in_meta_binary", state.range(0),
+                                       1000);
 }
 
 static void IsInInt8SmallSet(benchmark::State& state) {
@@ -135,7 +136,7 @@ static void IsInInt64SmallSet(benchmark::State& state) {
 }
 
 static void IsInInt32LargeSet(benchmark::State& state) {
-  SetLookupBenchmarkNumeric<Int32Type>(state, "is_in_meta_binary", state.range(0), 10);
+  SetLookupBenchmarkNumeric<Int32Type>(state, "is_in_meta_binary", state.range(0), 1000);
 }
 
 BENCHMARK(IndexInStringSmallSet)->RangeMultiplier(4)->Range(2, 64);

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup_benchmark.cc
@@ -51,7 +51,7 @@ static void SetLookupBenchmarkString(benchmark::State& state,
   }
   state.SetItemsProcessed(state.iterations() * array_length);
   state.SetBytesProcessed(state.iterations() * values->data()->buffers[2]->size());
-  state.counters["value_set_length"] = value_set_length;
+  state.counters["value_set_length"] = static_cast<double>(value_set_length);
 }
 
 template <typename Type>
@@ -73,7 +73,7 @@ static void SetLookupBenchmarkNumeric(benchmark::State& state,
   }
   state.SetItemsProcessed(state.iterations() * array_length);
   state.SetBytesProcessed(state.iterations() * values->data()->buffers[1]->size());
-  state.counters["value_set_length"] = value_set_length;
+  state.counters["value_set_length"] = static_cast<double>(value_set_length);
 }
 
 static void IndexInStringSmallSet(benchmark::State& state) {

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup_benchmark.cc
@@ -92,8 +92,9 @@ static void IsInStringLargeSet(benchmark::State& state) {
   SetLookupBenchmarkString(state, "is_in_meta_binary", 1 << 10);
 }
 
-constexpr int64_t kArrayLengthWithSmallSet = 1 << 18;
-constexpr int64_t kArrayLengthWithLargeSet = 1000;
+static constexpr int64_t kArrayLengthWithSmallSet = 1 << 18;
+static constexpr int64_t kArrayLengthWithLargeSet = 1000;
+
 static void IndexInInt8SmallSet(benchmark::State& state) {
   SetLookupBenchmarkNumeric<Int8Type>(state, "index_in_meta_binary", state.range(0),
                                       kArrayLengthWithSmallSet);
@@ -156,12 +157,12 @@ BENCHMARK(IndexInInt8SmallSet)->RangeMultiplier(4)->Range(2, 8);
 BENCHMARK(IndexInInt16SmallSet)->RangeMultiplier(4)->Range(2, 64);
 BENCHMARK(IndexInInt32SmallSet)->RangeMultiplier(4)->Range(2, 64);
 BENCHMARK(IndexInInt64SmallSet)->RangeMultiplier(4)->Range(2, 64);
-BENCHMARK(IndexInInt32LargeSet)->RangeMultiplier(100)->Range(100, 1000000);
+BENCHMARK(IndexInInt32LargeSet)->RangeMultiplier(100)->Range(1000, 1000000);
 BENCHMARK(IsInInt8SmallSet)->RangeMultiplier(4)->Range(2, 8);
 BENCHMARK(IsInInt16SmallSet)->RangeMultiplier(4)->Range(2, 64);
 BENCHMARK(IsInInt32SmallSet)->RangeMultiplier(4)->Range(2, 64);
 BENCHMARK(IsInInt64SmallSet)->RangeMultiplier(4)->Range(2, 64);
-BENCHMARK(IsInInt32LargeSet)->RangeMultiplier(100)->Range(100, 1000000);
+BENCHMARK(IsInInt32LargeSet)->RangeMultiplier(100)->Range(1000, 1000000);
 
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup_benchmark.cc
@@ -51,6 +51,7 @@ static void SetLookupBenchmarkString(benchmark::State& state,
   }
   state.SetItemsProcessed(state.iterations() * array_length);
   state.SetBytesProcessed(state.iterations() * values->data()->buffers[2]->size());
+  state.counters["value_set_length"] = value_set_length;
 }
 
 template <typename Type>
@@ -72,6 +73,7 @@ static void SetLookupBenchmarkNumeric(benchmark::State& state,
   }
   state.SetItemsProcessed(state.iterations() * array_length);
   state.SetBytesProcessed(state.iterations() * values->data()->buffers[1]->size());
+  state.counters["value_set_length"] = value_set_length;
 }
 
 static void IndexInStringSmallSet(benchmark::State& state) {
@@ -90,53 +92,56 @@ static void IsInStringLargeSet(benchmark::State& state) {
   SetLookupBenchmarkString(state, "is_in_meta_binary", 1 << 10);
 }
 
+constexpr int64_t kArrayLengthWithSmallSet = 1 << 18;
+constexpr int64_t kArrayLengthWithLargeSet = 1000;
 static void IndexInInt8SmallSet(benchmark::State& state) {
   SetLookupBenchmarkNumeric<Int8Type>(state, "index_in_meta_binary", state.range(0),
-                                      1 << 18);
+                                      kArrayLengthWithSmallSet);
 }
 
 static void IndexInInt16SmallSet(benchmark::State& state) {
   SetLookupBenchmarkNumeric<Int16Type>(state, "index_in_meta_binary", state.range(0),
-                                       1 << 18);
+                                       kArrayLengthWithSmallSet);
 }
 
 static void IndexInInt32SmallSet(benchmark::State& state) {
   SetLookupBenchmarkNumeric<Int32Type>(state, "index_in_meta_binary", state.range(0),
-                                       1 << 18);
+                                       kArrayLengthWithSmallSet);
 }
 
 static void IndexInInt64SmallSet(benchmark::State& state) {
   SetLookupBenchmarkNumeric<Int64Type>(state, "index_in_meta_binary", state.range(0),
-                                       1 << 18);
+                                       kArrayLengthWithSmallSet);
 }
 
 static void IndexInInt32LargeSet(benchmark::State& state) {
   SetLookupBenchmarkNumeric<Int32Type>(state, "index_in_meta_binary", state.range(0),
-                                       1000);
+                                       kArrayLengthWithLargeSet);
 }
 
 static void IsInInt8SmallSet(benchmark::State& state) {
   SetLookupBenchmarkNumeric<Int8Type>(state, "is_in_meta_binary", state.range(0),
-                                      1 << 18);
+                                      kArrayLengthWithSmallSet);
 }
 
 static void IsInInt16SmallSet(benchmark::State& state) {
   SetLookupBenchmarkNumeric<Int16Type>(state, "is_in_meta_binary", state.range(0),
-                                       1 << 18);
+                                       kArrayLengthWithSmallSet);
 }
 
 static void IsInInt32SmallSet(benchmark::State& state) {
   SetLookupBenchmarkNumeric<Int32Type>(state, "is_in_meta_binary", state.range(0),
-                                       1 << 18);
+                                       kArrayLengthWithSmallSet);
 }
 
 static void IsInInt64SmallSet(benchmark::State& state) {
   SetLookupBenchmarkNumeric<Int64Type>(state, "is_in_meta_binary", state.range(0),
-                                       1 << 18);
+                                       kArrayLengthWithSmallSet);
 }
 
 static void IsInInt32LargeSet(benchmark::State& state) {
-  SetLookupBenchmarkNumeric<Int32Type>(state, "is_in_meta_binary", state.range(0), 1000);
+  SetLookupBenchmarkNumeric<Int32Type>(state, "is_in_meta_binary", state.range(0),
+                                       kArrayLengthWithLargeSet);
 }
 
 BENCHMARK(IndexInStringSmallSet)->RangeMultiplier(4)->Range(2, 64);
@@ -151,12 +156,12 @@ BENCHMARK(IndexInInt8SmallSet)->RangeMultiplier(4)->Range(2, 8);
 BENCHMARK(IndexInInt16SmallSet)->RangeMultiplier(4)->Range(2, 64);
 BENCHMARK(IndexInInt32SmallSet)->RangeMultiplier(4)->Range(2, 64);
 BENCHMARK(IndexInInt64SmallSet)->RangeMultiplier(4)->Range(2, 64);
-BENCHMARK(IndexInInt32LargeSet)->RangeMultiplier(10)->Range(100, 10000000);
+BENCHMARK(IndexInInt32LargeSet)->RangeMultiplier(100)->Range(100, 1000000);
 BENCHMARK(IsInInt8SmallSet)->RangeMultiplier(4)->Range(2, 8);
 BENCHMARK(IsInInt16SmallSet)->RangeMultiplier(4)->Range(2, 64);
 BENCHMARK(IsInInt32SmallSet)->RangeMultiplier(4)->Range(2, 64);
 BENCHMARK(IsInInt64SmallSet)->RangeMultiplier(4)->Range(2, 64);
-BENCHMARK(IsInInt32LargeSet)->RangeMultiplier(10)->Range(100, 10000000);
+BENCHMARK(IsInInt32LargeSet)->RangeMultiplier(100)->Range(100, 1000000);
 
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup_benchmark.cc
@@ -106,6 +106,10 @@ static void IndexInInt64SmallSet(benchmark::State& state) {
   SetLookupBenchmarkNumeric<Int64Type>(state, "index_in_meta_binary", state.range(0));
 }
 
+static void IndexInInt32LargeSet(benchmark::State& state) {
+  SetLookupBenchmarkNumeric<Int32Type>(state, "index_in_meta_binary", state.range(0));
+}
+
 static void IsInInt8SmallSet(benchmark::State& state) {
   SetLookupBenchmarkNumeric<Int8Type>(state, "is_in_meta_binary", state.range(0));
 }
@@ -122,6 +126,10 @@ static void IsInInt64SmallSet(benchmark::State& state) {
   SetLookupBenchmarkNumeric<Int64Type>(state, "is_in_meta_binary", state.range(0));
 }
 
+static void IsInInt32LargeSet(benchmark::State& state) {
+  SetLookupBenchmarkNumeric<Int32Type>(state, "is_in_meta_binary", state.range(0));
+}
+
 BENCHMARK(IndexInStringSmallSet)->RangeMultiplier(4)->Range(2, 64);
 BENCHMARK(IsInStringSmallSet)->RangeMultiplier(4)->Range(2, 64);
 
@@ -134,10 +142,12 @@ BENCHMARK(IndexInInt8SmallSet)->RangeMultiplier(4)->Range(2, 8);
 BENCHMARK(IndexInInt16SmallSet)->RangeMultiplier(4)->Range(2, 64);
 BENCHMARK(IndexInInt32SmallSet)->RangeMultiplier(4)->Range(2, 64);
 BENCHMARK(IndexInInt64SmallSet)->RangeMultiplier(4)->Range(2, 64);
+BENCHMARK(IndexInInt32LargeSet)->RangeMultiplier(10)->Range(100, 10000000);
 BENCHMARK(IsInInt8SmallSet)->RangeMultiplier(4)->Range(2, 8);
 BENCHMARK(IsInInt16SmallSet)->RangeMultiplier(4)->Range(2, 64);
 BENCHMARK(IsInInt32SmallSet)->RangeMultiplier(4)->Range(2, 64);
 BENCHMARK(IsInInt64SmallSet)->RangeMultiplier(4)->Range(2, 64);
+BENCHMARK(IsInInt32LargeSet)->RangeMultiplier(10)->Range(100, 10000000);
 
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup_benchmark.cc
@@ -56,8 +56,8 @@ static void SetLookupBenchmarkString(benchmark::State& state,
 template <typename Type>
 static void SetLookupBenchmarkNumeric(benchmark::State& state,
                                       const std::string& func_name,
-                                      const int64_t value_set_length) {
-  const int64_t array_length = 1 << 18;
+                                      const int64_t value_set_length,
+                                      const int64_t array_length) {
   const int64_t value_min = 0;
   const int64_t value_max = std::numeric_limits<typename Type::c_type>::max();
   const double null_probability = 0.1 / value_set_length;
@@ -91,43 +91,51 @@ static void IsInStringLargeSet(benchmark::State& state) {
 }
 
 static void IndexInInt8SmallSet(benchmark::State& state) {
-  SetLookupBenchmarkNumeric<Int8Type>(state, "index_in_meta_binary", state.range(0));
+  SetLookupBenchmarkNumeric<Int8Type>(state, "index_in_meta_binary", state.range(0),
+                                      1 << 18);
 }
 
 static void IndexInInt16SmallSet(benchmark::State& state) {
-  SetLookupBenchmarkNumeric<Int16Type>(state, "index_in_meta_binary", state.range(0));
+  SetLookupBenchmarkNumeric<Int16Type>(state, "index_in_meta_binary", state.range(0),
+                                       1 << 18);
 }
 
 static void IndexInInt32SmallSet(benchmark::State& state) {
-  SetLookupBenchmarkNumeric<Int32Type>(state, "index_in_meta_binary", state.range(0));
+  SetLookupBenchmarkNumeric<Int32Type>(state, "index_in_meta_binary", state.range(0),
+                                       1 << 18);
 }
 
 static void IndexInInt64SmallSet(benchmark::State& state) {
-  SetLookupBenchmarkNumeric<Int64Type>(state, "index_in_meta_binary", state.range(0));
+  SetLookupBenchmarkNumeric<Int64Type>(state, "index_in_meta_binary", state.range(0),
+                                       1 << 18);
 }
 
 static void IndexInInt32LargeSet(benchmark::State& state) {
-  SetLookupBenchmarkNumeric<Int32Type>(state, "index_in_meta_binary", state.range(0));
+  SetLookupBenchmarkNumeric<Int32Type>(state, "index_in_meta_binary", state.range(0), 10);
 }
 
 static void IsInInt8SmallSet(benchmark::State& state) {
-  SetLookupBenchmarkNumeric<Int8Type>(state, "is_in_meta_binary", state.range(0));
+  SetLookupBenchmarkNumeric<Int8Type>(state, "is_in_meta_binary", state.range(0),
+                                      1 << 18);
 }
 
 static void IsInInt16SmallSet(benchmark::State& state) {
-  SetLookupBenchmarkNumeric<Int16Type>(state, "is_in_meta_binary", state.range(0));
+  SetLookupBenchmarkNumeric<Int16Type>(state, "is_in_meta_binary", state.range(0),
+                                       1 << 18);
 }
 
 static void IsInInt32SmallSet(benchmark::State& state) {
-  SetLookupBenchmarkNumeric<Int32Type>(state, "is_in_meta_binary", state.range(0));
+  SetLookupBenchmarkNumeric<Int32Type>(state, "is_in_meta_binary", state.range(0),
+                                       1 << 18);
 }
 
 static void IsInInt64SmallSet(benchmark::State& state) {
-  SetLookupBenchmarkNumeric<Int64Type>(state, "is_in_meta_binary", state.range(0));
+  SetLookupBenchmarkNumeric<Int64Type>(state, "is_in_meta_binary", state.range(0),
+                                       1 << 18);
 }
 
 static void IsInInt32LargeSet(benchmark::State& state) {
-  SetLookupBenchmarkNumeric<Int32Type>(state, "is_in_meta_binary", state.range(0));
+  SetLookupBenchmarkNumeric<Int32Type>(state, "is_in_meta_binary", state.range(0), 10);
 }
 
 BENCHMARK(IndexInStringSmallSet)->RangeMultiplier(4)->Range(2, 64);


### PR DESCRIPTION


<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Performance improvement for scalar lookup functions.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

1. Reserve space for hashtable for scalar lookup functions before the insertion process.
2. A benchmark that demonstrates the improvement. Data is pasted in the comments.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

By existing unit tests.

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
No.
* Closes: #36059