### PR TITLE
GH-36074: [C++] Clarify docs for ConcatenateTablesOptions::field_merge_options

### DIFF
--- a/cpp/src/arrow/table.h
+++ b/cpp/src/arrow/table.h
@@ -281,6 +281,9 @@ struct ARROW_EXPORT ConcatenateTablesOptions {
   /// is the result of concatenating the corresponding columns in all input tables.
   bool unify_schemas = false;
 
+  /// options to control how fields are merged when unifying schemas
+  ///
+  /// This field will be ignored if unify_schemas is false
   Field::MergeOptions field_merge_options = Field::MergeOptions::Defaults();
 
   static ConcatenateTablesOptions Defaults() { return {}; }


### PR DESCRIPTION
### Rationale for this change

There was no docstring for this field before

### What changes are included in this PR?

I added a docstring for the field

### Are these changes tested?

No, it's just a comment

### Are there any user-facing changes?

No
* Closes: #36074