### PR TITLE
GH-36006: [Packaging][RPM] Add support for Amazon Linux 2023

### DIFF
--- a/dev/release/binary-task.rb
+++ b/dev/release/binary-task.rb
@@ -1460,6 +1460,7 @@ APT::FTPArchive::Release::Description "#{apt_repository_description}";
     [
       ["almalinux", "9"],
       ["almalinux", "8"],
+      ["amazon-linux", "2023"],
       ["amazon-linux", "2"],
       ["centos", "9-stream"],
       ["centos", "8-stream"],

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -232,6 +232,7 @@ test_yum() {
                 "arm64v8/almalinux:9" \
                 "almalinux:8" \
                 "arm64v8/almalinux:8" \
+                "amazonlinux:2023" \
                 "amazonlinux:2" \
                 "quay.io/centos/centos:stream9" \
                 "quay.io/centos/centos:stream8" \

--- a/dev/release/verify-yum.sh
+++ b/dev/release/verify-yum.sh
@@ -58,10 +58,10 @@ have_parquet=yes
 have_ruby=yes
 have_vala=yes
 ruby_devel_packages=(ruby-devel)
-install_command="dnf install -y --enablerepo=crb"
+install_command="dnf install -y --enablerepo=crb --enablerepo=epel"
 uninstall_command="dnf remove -y"
 clean_command="dnf clean"
-info_command="dnf info --enablerepo=crb"
+info_command="dnf info --enablerepo=crb --enablerepo=epel"
 
 echo "::group::Prepare repository"
 
@@ -70,8 +70,8 @@ case "${distribution}-${distribution_version}" in
     distribution_prefix="almalinux"
     have_arrow_libs=yes
     ruby_devel_packages+=(redhat-rpm-config)
-    install_command="dnf install -y --enablerepo=powertools"
-    info_command="dnf info --enablerepo=powertools"
+    install_command="dnf install -y --enablerepo=powertools --enablerepo=epel"
+    info_command="dnf info --enablerepo=powertools --enablerepo=epel"
     ;;
   almalinux-*)
     distribution_prefix="almalinux"
@@ -87,10 +87,10 @@ case "${distribution}-${distribution_version}" in
     have_flight=no
     have_gandiva=no
     have_ruby=no
-    install_command="yum install -y"
+    install_command="yum install -y --enablerepo=epel"
     uninstall_command="yum remove -y"
     clean_command="yum clean"
-    info_command="yum info"
+    info_command="yum info --enablerepo=epel"
     amazon-linux-extras install epel -y
     ;;
   amzn-2023)
@@ -109,17 +109,17 @@ case "${distribution}-${distribution_version}" in
     have_gandiva=no
     have_ruby=no
     have_vala=no
-    install_command="yum install -y"
+    install_command="yum install -y --enablerepo=epel"
     uninstall_command="yum remove -y"
     clean_command="yum clean"
-    info_command="yum info"
+    info_command="yum info --enablerepo=epel"
     ;;
   centos-8)
     distribution_prefix="centos"
     repository_version+="-stream"
     ruby_devel_packages+=(redhat-rpm-config)
-    install_command="dnf install -y --enablerepo=powertools"
-    info_command="dnf info --enablerepo=powertools"
+    install_command="dnf install -y --enablerepo=powertools --enablerepo=epel"
+    info_command="dnf info --enablerepo=powertools --enablerepo=epel"
     ;;
   centos-*)
     distribution_prefix="centos"
@@ -200,7 +200,7 @@ echo "::endgroup::"
 
 
 echo "::group::Test Apache Arrow C++"
-${install_command} --enablerepo=epel arrow-devel-${package_version}
+${install_command} arrow-devel-${package_version}
 if [ -n "${devtoolset}" ]; then
   ${install_command} ${scl_package}
 fi
@@ -234,8 +234,8 @@ if [ "${have_glib}" = "yes" ]; then
   echo "::group::Test Apache Arrow GLib"
   export G_DEBUG=fatal-warnings
 
-  ${install_command} --enablerepo=epel arrow-glib-devel-${package_version}
-  ${install_command} --enablerepo=epel arrow-glib-doc-${package_version}
+  ${install_command} arrow-glib-devel-${package_version}
+  ${install_command} arrow-glib-doc-${package_version}
 
   if [ "${have_vala}" = "yes" ]; then
     ${install_command} vala
@@ -256,16 +256,16 @@ fi
 
 if [ "${have_flight}" = "yes" ]; then
   echo "::group::Test Apache Arrow Flight"
-  ${install_command} --enablerepo=epel arrow-flight-glib-devel-${package_version}
-  ${install_command} --enablerepo=epel arrow-flight-glib-doc-${package_version}
+  ${install_command} arrow-flight-glib-devel-${package_version}
+  ${install_command} arrow-flight-glib-doc-${package_version}
   if [ "${have_ruby}" = "yes" ]; then
     ruby -r gi -e "p GI.load('ArrowFlight')"
   fi
   echo "::endgroup::"
 
   echo "::group::Test Apache Arrow Flight SQL"
-  ${install_command} --enablerepo=epel arrow-flight-sql-glib-devel-${package_version}
-  ${install_command} --enablerepo=epel arrow-flight-sql-glib-doc-${package_version}
+  ${install_command} arrow-flight-sql-glib-devel-${package_version}
+  ${install_command} arrow-flight-sql-glib-doc-${package_version}
   if [ "${have_ruby}" = "yes" ]; then
     ruby -r gi -e "p GI.load('ArrowFlightSQL')"
   fi
@@ -275,13 +275,13 @@ fi
 if [ "${have_gandiva}" = "yes" ]; then
   echo "::group::Test Gandiva"
   if [ "${have_glib}" = "yes" ]; then
-    ${install_command} --enablerepo=epel gandiva-glib-devel-${package_version}
-    ${install_command} --enablerepo=epel gandiva-glib-doc-${package_version}
+    ${install_command} gandiva-glib-devel-${package_version}
+    ${install_command} gandiva-glib-doc-${package_version}
     if [ "${have_ruby}" = "yes" ]; then
       ruby -r gi -e "p GI.load('Gandiva')"
     fi
   else
-    ${install_command} --enablerepo=epel gandiva-devel-${package_version}
+    ${install_command} gandiva-devel-${package_version}
   fi
   echo "::endgroup::"
 fi
@@ -289,13 +289,13 @@ fi
 if [ "${have_parquet}" = "yes" ]; then
   echo "::group::Test Apache Parquet"
   if [ "${have_glib}" = "yes" ]; then
-    ${install_command} --enablerepo=epel parquet-glib-devel-${package_version}
-    ${install_command} --enablerepo=epel parquet-glib-doc-${package_version}
+    ${install_command} parquet-glib-devel-${package_version}
+    ${install_command} parquet-glib-doc-${package_version}
     if [ "${have_ruby}" = "yes" ]; then
       ruby -r gi -e "p GI.load('Parquet')"
     fi
   else
-    ${install_command} --enablerepo=epel parquet-devel-${package_version}
+    ${install_command} parquet-devel-${package_version}
   fi
   echo "::endgroup::"
 fi

--- a/dev/release/verify-yum.sh
+++ b/dev/release/verify-yum.sh
@@ -55,7 +55,6 @@ have_flight=yes
 have_gandiva=yes
 have_glib=yes
 have_parquet=yes
-have_python=yes
 have_ruby=yes
 have_vala=yes
 ruby_devel_packages=(ruby-devel)
@@ -87,13 +86,15 @@ case "${distribution}-${distribution_version}" in
     fi
     have_flight=no
     have_gandiva=no
-    have_python=no
     have_ruby=no
     install_command="yum install -y"
     uninstall_command="yum remove -y"
     clean_command="yum clean"
     info_command="yum info"
     amazon-linux-extras install epel -y
+    ;;
+  amzn-2023)
+    distribution_prefix="amazon-linux"
     ;;
   centos-7)
     distribution_prefix="centos"
@@ -104,7 +105,6 @@ case "${distribution}-${distribution_version}" in
     have_arrow_libs=yes
     have_flight=no
     have_gandiva=no
-    have_python=no
     have_ruby=no
     have_vala=no
     install_command="yum install -y"

--- a/dev/release/verify-yum.sh
+++ b/dev/release/verify-yum.sh
@@ -150,7 +150,6 @@ if [ "${TYPE}" = "local" ]; then
     amzn)
       package_version+=".${distribution}${distribution_version}"
       release_path+="/amazon-linux"
-      amazon-linux-extras install -y epel
       ;;
     centos)
       package_version+=".el${distribution_version}"

--- a/dev/release/verify-yum.sh
+++ b/dev/release/verify-yum.sh
@@ -95,6 +95,8 @@ case "${distribution}-${distribution_version}" in
     ;;
   amzn-2023)
     distribution_prefix="amazon-linux"
+    install_command="dnf install -y"
+    info_command="dnf info"
     ;;
   centos-7)
     distribution_prefix="centos"

--- a/dev/release/verify-yum.sh
+++ b/dev/release/verify-yum.sh
@@ -58,10 +58,11 @@ have_parquet=yes
 have_ruby=yes
 have_vala=yes
 ruby_devel_packages=(ruby-devel)
-install_command="dnf install -y --enablerepo=crb --enablerepo=epel"
+enablerepo_epel="--enablerepo=epel"
+install_command="dnf install -y --enablerepo=crb"
 uninstall_command="dnf remove -y"
 clean_command="dnf clean"
-info_command="dnf info --enablerepo=crb --enablerepo=epel"
+info_command="dnf info --enablerepo=crb"
 
 echo "::group::Prepare repository"
 
@@ -70,8 +71,8 @@ case "${distribution}-${distribution_version}" in
     distribution_prefix="almalinux"
     have_arrow_libs=yes
     ruby_devel_packages+=(redhat-rpm-config)
-    install_command="dnf install -y --enablerepo=powertools --enablerepo=epel"
-    info_command="dnf info --enablerepo=powertools --enablerepo=epel"
+    install_command="dnf install -y --enablerepo=powertools"
+    info_command="dnf info --enablerepo=powertools"
     ;;
   almalinux-*)
     distribution_prefix="almalinux"
@@ -87,14 +88,15 @@ case "${distribution}-${distribution_version}" in
     have_flight=no
     have_gandiva=no
     have_ruby=no
-    install_command="yum install -y --enablerepo=epel"
+    install_command="yum install -y"
     uninstall_command="yum remove -y"
     clean_command="yum clean"
-    info_command="yum info --enablerepo=epel"
+    info_command="yum info"
     amazon-linux-extras install epel -y
     ;;
   amzn-2023)
     distribution_prefix="amazon-linux"
+    enablerepo_epel=""
     install_command="dnf install -y"
     info_command="dnf info"
     ;;
@@ -109,17 +111,17 @@ case "${distribution}-${distribution_version}" in
     have_gandiva=no
     have_ruby=no
     have_vala=no
-    install_command="yum install -y --enablerepo=epel"
+    install_command="yum install -y"
     uninstall_command="yum remove -y"
     clean_command="yum clean"
-    info_command="yum info --enablerepo=epel"
+    info_command="yum info"
     ;;
   centos-8)
     distribution_prefix="centos"
     repository_version+="-stream"
     ruby_devel_packages+=(redhat-rpm-config)
-    install_command="dnf install -y --enablerepo=powertools --enablerepo=epel"
-    info_command="dnf info --enablerepo=powertools --enablerepo=epel"
+    install_command="dnf install -y --enablerepo=powertools"
+    info_command="dnf info --enablerepo=powertools"
     ;;
   centos-*)
     distribution_prefix="centos"
@@ -200,7 +202,7 @@ echo "::endgroup::"
 
 
 echo "::group::Test Apache Arrow C++"
-${install_command} arrow-devel-${package_version}
+${install_command} ${enablerepo_epel} arrow-devel-${package_version}
 if [ -n "${devtoolset}" ]; then
   ${install_command} ${scl_package}
 fi
@@ -234,8 +236,8 @@ if [ "${have_glib}" = "yes" ]; then
   echo "::group::Test Apache Arrow GLib"
   export G_DEBUG=fatal-warnings
 
-  ${install_command} arrow-glib-devel-${package_version}
-  ${install_command} arrow-glib-doc-${package_version}
+  ${install_command} ${enablerepo_epel} arrow-glib-devel-${package_version}
+  ${install_command} ${enablerepo_epel} arrow-glib-doc-${package_version}
 
   if [ "${have_vala}" = "yes" ]; then
     ${install_command} vala
@@ -256,16 +258,16 @@ fi
 
 if [ "${have_flight}" = "yes" ]; then
   echo "::group::Test Apache Arrow Flight"
-  ${install_command} arrow-flight-glib-devel-${package_version}
-  ${install_command} arrow-flight-glib-doc-${package_version}
+  ${install_command} ${enablerepo_epel} arrow-flight-glib-devel-${package_version}
+  ${install_command} ${enablerepo_epel} arrow-flight-glib-doc-${package_version}
   if [ "${have_ruby}" = "yes" ]; then
     ruby -r gi -e "p GI.load('ArrowFlight')"
   fi
   echo "::endgroup::"
 
   echo "::group::Test Apache Arrow Flight SQL"
-  ${install_command} arrow-flight-sql-glib-devel-${package_version}
-  ${install_command} arrow-flight-sql-glib-doc-${package_version}
+  ${install_command} ${enablerepo_epel} arrow-flight-sql-glib-devel-${package_version}
+  ${install_command} ${enablerepo_epel} arrow-flight-sql-glib-doc-${package_version}
   if [ "${have_ruby}" = "yes" ]; then
     ruby -r gi -e "p GI.load('ArrowFlightSQL')"
   fi
@@ -275,13 +277,13 @@ fi
 if [ "${have_gandiva}" = "yes" ]; then
   echo "::group::Test Gandiva"
   if [ "${have_glib}" = "yes" ]; then
-    ${install_command} gandiva-glib-devel-${package_version}
-    ${install_command} gandiva-glib-doc-${package_version}
+    ${install_command} ${enablerepo_epel} gandiva-glib-devel-${package_version}
+    ${install_command} ${enablerepo_epel} gandiva-glib-doc-${package_version}
     if [ "${have_ruby}" = "yes" ]; then
       ruby -r gi -e "p GI.load('Gandiva')"
     fi
   else
-    ${install_command} gandiva-devel-${package_version}
+    ${install_command} ${enablerepo_epel} gandiva-devel-${package_version}
   fi
   echo "::endgroup::"
 fi
@@ -289,13 +291,13 @@ fi
 if [ "${have_parquet}" = "yes" ]; then
   echo "::group::Test Apache Parquet"
   if [ "${have_glib}" = "yes" ]; then
-    ${install_command} parquet-glib-devel-${package_version}
-    ${install_command} parquet-glib-doc-${package_version}
+    ${install_command} ${enablerepo_epel} parquet-glib-devel-${package_version}
+    ${install_command} ${enablerepo_epel} parquet-glib-doc-${package_version}
     if [ "${have_ruby}" = "yes" ]; then
       ruby -r gi -e "p GI.load('Parquet')"
     fi
   else
-    ${install_command} parquet-devel-${package_version}
+    ${install_command} ${enablerepo_epel} parquet-devel-${package_version}
   fi
   echo "::endgroup::"
 fi
@@ -306,12 +308,12 @@ if ${install_command} \
      https://apache.jfrog.io/artifactory/arrow/${distribution_prefix}/${repository_version}/apache-arrow-release-latest.rpm; then
   ${clean_command} all
   if [ "${have_arrow_libs}" = "yes" ]; then
-    ${install_command} arrow-libs
+    ${install_command} ${enablerepo_epel} arrow-libs
   else
     major_version=$(echo ${VERSION} | grep -E -o '^[0-9]+')
     previous_major_version="$((${major_version} - 1))"
-    if ${info_command} arrow${previous_major_version}-libs; then
-      ${install_command} arrow${previous_major_version}-libs
+    if ${info_command} ${enablerepo_epel} arrow${previous_major_version}-libs; then
+      ${install_command} ${enablerepo_epel} arrow${previous_major_version}-libs
     fi
   fi
 fi

--- a/dev/tasks/linux-packages/apache-arrow-release/yum/Apache-Arrow.repo
+++ b/dev/tasks/linux-packages/apache-arrow-release/yum/Apache-Arrow.repo
@@ -29,6 +29,13 @@ gpgcheck=1
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Apache-Arrow
 
+[apache-arrow-amazon-linux-2023]
+name=Apache Arrow for Amazon Linux 2023 - $basearch
+baseurl=https://apache.jfrog.io/artifactory/arrow/amazon-linux/2023/$basearch/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Apache-Arrow
+
 [apache-arrow-centos-stream]
 name=Apache Arrow for CentOS Stream $releasever - $basearch
 baseurl=https://apache.jfrog.io/artifactory/arrow/centos/$stream/$basearch/

--- a/dev/tasks/linux-packages/apache-arrow-release/yum/amazon-linux-2023/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow-release/yum/amazon-linux-2023/Dockerfile
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM amazonlinux:2023
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
+  dnf install -y ${quiet} \
+    rpmdevtools && \
+  dnf clean ${quiet} all

--- a/dev/tasks/linux-packages/apache-arrow-release/yum/apache-arrow-release.spec.in
+++ b/dev/tasks/linux-packages/apache-arrow-release/yum/apache-arrow-release.spec.in
@@ -87,7 +87,9 @@ rm -rf $RPM_BUILD_ROOT
 %config(noreplace) %{_sysconfdir}/yum.repos.d/Apache-Arrow.repo
 
 %post
-if grep -q 'Amazon Linux' /etc/system-release 2>/dev/null; then
+if grep -q 'Amazon Linux release 2023' /etc/system-release 2>/dev/null; then
+  %{yum_repository_enable apache-arrow-amazon-linux-2023}
+elif grep -q 'Amazon Linux release 2' /etc/system-release 2>/dev/null; then
   %{yum_repository_enable apache-arrow-amazon-linux}
 elif grep -q 'Red Hat Enterprise Linux Server release 7' /etc/system-release 2>/dev/null; then
   %{yum_repository_enable apache-arrow-rhel7}

--- a/dev/tasks/linux-packages/apache-arrow-release/yum/apache-arrow-release.spec.in
+++ b/dev/tasks/linux-packages/apache-arrow-release/yum/apache-arrow-release.spec.in
@@ -21,6 +21,8 @@
 %define _rhel %{?rhel:%{rhel}}%{!?rhel:0}
 
 %define use_dnf (%{_rhel} >= 8 || %{_amzn} >= 2023)
+%define use_epel (%{_amzn} < 2023)
+
 %if %{use_dnf}
 %define yum_repository_enable() (dnf config-manager --set-enabled %1)
 %define yum_repository_disable() (dnf config-manager --set-disabled %1)
@@ -40,7 +42,9 @@ Source0:	@PACKAGE@-%{version}.tar.gz
 
 BuildArch:	noarch
 
+%if %{use_epel}
 Requires:	epel-release
+%endif
 %if %{use_dnf}
 Requires:	dnf-command(config-manager)
 %else

--- a/dev/tasks/linux-packages/apache-arrow-release/yum/apache-arrow-release.spec.in
+++ b/dev/tasks/linux-packages/apache-arrow-release/yum/apache-arrow-release.spec.in
@@ -17,7 +17,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-%define use_dnf (%{rhel} >= 8)
+%define _amzn %{?amzn:%{amzn}}%{!?amzn:0}
+%define _rhel %{?rhel:%{rhel}}%{!?rhel:0}
+
+%define use_dnf (%{_rhel} >= 8 || %{_amzn} >= 2023)
 %if %{use_dnf}
 %define yum_repository_enable() (dnf config-manager --set-enabled %1)
 %define yum_repository_disable() (dnf config-manager --set-disabled %1)
@@ -80,7 +83,7 @@ rm -rf $RPM_BUILD_ROOT
 %config(noreplace) %{_sysconfdir}/yum.repos.d/Apache-Arrow.repo
 
 %post
-if grep -q 'Amazon Linux release 2' /etc/system-release 2>/dev/null; then
+if grep -q 'Amazon Linux' /etc/system-release 2>/dev/null; then
   %{yum_repository_enable apache-arrow-amazon-linux}
 elif grep -q 'Red Hat Enterprise Linux Server release 7' /etc/system-release 2>/dev/null; then
   %{yum_repository_enable apache-arrow-rhel7}

--- a/dev/tasks/linux-packages/apache-arrow/yum/amazon-linux-2023-aarch64/from
+++ b/dev/tasks/linux-packages/apache-arrow/yum/amazon-linux-2023-aarch64/from
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+arm64v8/amazonlinux:2

--- a/dev/tasks/linux-packages/apache-arrow/yum/amazon-linux-2023-aarch64/from
+++ b/dev/tasks/linux-packages/apache-arrow/yum/amazon-linux-2023-aarch64/from
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-arm64v8/amazonlinux:2
+arm64v8/amazonlinux:2023

--- a/dev/tasks/linux-packages/apache-arrow/yum/amazon-linux-2023/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/yum/amazon-linux-2023/Dockerfile
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ARG FROM=amazonlinux:2023
+FROM ${FROM}
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
+  dnf update -y ${quiet} && \
+  dnf install -y ${quiet} \
+    bison \
+    boost-devel \
+    brotli-devel \
+    bzip2-devel \
+    c-ares-devel \
+    clang \
+    cmake \
+    curl-devel \
+    flex \
+    gcc-c++ \
+    git \
+    gobject-introspection-devel \
+    grpc-devel \
+    grpc-plugins \
+    gtk-doc \
+    libzstd-devel \
+    llvm-devel \
+    lz4-devel \
+    ninja-build \
+    make \
+    meson \
+    openssl-devel \
+    pkg-config \
+    protobuf-compiler \
+    protobuf-devel \
+    rapidjson-devel \
+    re2-devel \
+    rpmdevtools \
+    snappy-devel \
+    tar \
+    utf8proc-devel \
+    vala \
+    zlib-devel && \
+  dnf clean ${quiet} all

--- a/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
+++ b/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
@@ -78,7 +78,7 @@
 
 %define have_lz4_libs (%{_rhel} >= 8 || %{is_amazon_linux})
 %define have_rapidjson (%{_rhel} != 8)
-%define have_re2 (%{_rhel} >= 8 || %{is_amazon_linux})
+%define have_re2 (%{_rhel} >= 8 || %{_amzn} >= 2023)
 %define have_thrift (%{_rhel} >= 8)
 %define have_utf8proc (%{_rhel} >= 9 || %{_amzn} >= 2023)
 %define have_zstd (%{_amzn} != 2)

--- a/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
+++ b/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
@@ -76,7 +76,7 @@
 %define use_s3 0
 %define use_vala (%{_rhel} >= 8 || %{is_amazon_linux})
 
-%define have_lz4_libs (%{_rhel} >= 8 || %{is_amazon_linux})
+%define have_lz4_libs (%{_rhel} >= 8 || %{_amzn} >= 2023)
 %define have_rapidjson (%{_rhel} != 8)
 %define have_re2 (%{_rhel} >= 8 || %{_amzn} >= 2023)
 %define have_thrift (%{_rhel} >= 8)

--- a/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
+++ b/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
@@ -76,6 +76,7 @@
 %define use_s3 0
 %define use_vala (%{_rhel} >= 8 || %{is_amazon_linux})
 
+%define have_grpc (%{_amzn} >= 2023)
 %define have_lz4_libs (%{_rhel} >= 8 || %{_amzn} >= 2023)
 %define have_rapidjson (%{_rhel} != 8)
 %define have_re2 (%{_rhel} >= 8 || %{_amzn} >= 2023)
@@ -111,6 +112,10 @@ BuildRequires:	gflags-devel
 BuildRequires:	git
 %if %{use_glog}
 BuildRequires:	glog-devel
+%endif
+%if %{have_grpc}
+BuildRequires:	grpc-devel
+BuildRequires:	grpc-plugins
 %endif
 %if %{use_gcs}
 BuildRequires:	json-devel
@@ -296,6 +301,10 @@ Requires:	bzip2-devel
 Requires:	c-ares-devel
 %endif
 Requires:	curl-devel
+%if %{have_grpc}
+Requires:	grpc-devel
+Requires:	grpc-plugins
+%endif
 %if %{use_gcs}
 Requires:	json-devel
 %endif

--- a/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
+++ b/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
@@ -22,22 +22,19 @@
 %define _amzn %{?amzn:%{amzn}}%{!?amzn:0}
 %define is_amazon_linux (%{_amzn} != 0)
 
-%define is_centos_7 (%{rhel} == 7 && !%{is_amazon_linux})
+%define _rhel %{?rhel:%{rhel}}%{!?rhel:0}
+%define is_rhel (%{_rhel} != 0)
+
+%define is_centos_7 (%{_rhel} == 7 && !%{is_amazon_linux})
 
 %define major_version %(echo @VERSION@ | grep -o '^[0-9]*')
 
 %define boost_version %( \
-  if [ %{rhel} -eq 7 ]; then \
+  if [ %{_rhel} -eq 7 ]; then \
     echo 169; \
   fi)
 %define cmake_version %( \
-  if [ %{rhel} -lt 8 ]; then \
-    echo 3; \
-  fi)
-%define python_version %( \
-  if [ %{rhel} -lt 9 ]; then \
-    echo 39; \
-  else \
+  if [ %{_rhel} -eq 7 ]; then \
     echo 3; \
   fi)
 
@@ -46,7 +43,7 @@
     echo ">= 1.8.0"; \
   fi)
 
-%if %{rhel} >= 9
+%if %{_rhel} >= 9 || %{_amzn} >= 2023
 %define arrow_cmake_builddir %{__cmake_builddir}
 %define arrow_cmake %cmake
 %define arrow_cmake_build make -C %{arrow_cmake_builddir} %{?_smp_mflags}
@@ -64,27 +61,27 @@
 %define gcc_package gcc
 %endif
 
-%define use_boost (!%{is_amazon_linux})
-%define use_flight (%{rhel} >= 8)
-%define use_gandiva (%{rhel} >= 8)
-%define use_gcs (%{rhel} >= 8)
+%define use_boost (%{_amzn} != 2)
+%define use_flight (%{_rhel} >= 8 || %{_amzn} >= 2023)
+%define use_gandiva (%{_rhel} >= 8 || %{_amzn} >= 2023)
+%define use_gcs (%{_rhel} >= 8)
 %define use_gflags (!%{is_amazon_linux})
 ## TODO: Enable this when glog stopped depending on gflags-devel.
-# %%define use_glog (%{rhel} <= 8)
+# %%define use_glog (%%{_rhel} <= 8)
 %define use_glog 0
-%define use_mimalloc (%{rhel} >= 8)
+%define use_mimalloc (%{_rhel} >= 8)
 # TODO: Enable this. This works on local but is fragile on GitHub Actions and
 # Travis CI.
-# %%define use_s3 (%%{rhel} >= 8)
+# %%define use_s3 (%%{_rhel} >= 8)
 %define use_s3 0
-%define use_vala (%{rhel} >= 8 || %{is_amazon_linux})
+%define use_vala (%{_rhel} >= 8 || %{is_amazon_linux})
 
-%define have_lz4_libs (%{rhel} >= 8)
-%define have_rapidjson (%{rhel} != 8)
-%define have_re2 (%{rhel} >= 8)
-%define have_thrift (%{rhel} >= 8)
-%define have_utf8proc (%{rhel} >= 9)
-%define have_zstd (!%{is_amazon_linux})
+%define have_lz4_libs (%{_rhel} >= 8 || %{is_amazon_linux})
+%define have_rapidjson (%{_rhel} != 8)
+%define have_re2 (%{_rhel} >= 8 || %{is_amazon_linux})
+%define have_thrift (%{_rhel} >= 8)
+%define have_utf8proc (%{_rhel} >= 9 || %{_amzn} >= 2023)
+%define have_zstd (%{_amzn} != 2)
 
 Name:		@PACKAGE@
 Version:	@VERSION@
@@ -200,13 +197,17 @@ cd cpp
 cd -
 
 cd c_glib
-%if (%{rhel} >= 8 || "%{_arch}" != "aarch64")
-  pip3 install meson
+%if %{_amzn} >= 2023
+  # Do nothing
 %else
-  # Meson 0.57.0 or later requires Ninja 1.8.2 or later but EPEL for
-  # Amazon Linux 2 aarch64 provides Ninja 1.7.2. We can remove
-  # '<0.57.0' once we drop support for Amazon Linux 2.
-  pip3 install 'meson<0.57.0'
+  %if (%{_rhel} >= 8 || "%{_arch}" != "aarch64")
+    pip3 install meson
+  %else
+    # Meson 0.57.0 or later requires Ninja 1.8.2 or later but EPEL for
+    # Amazon Linux 2 aarch64 provides Ninja 1.7.2. We can remove
+    # '<0.57.0' once we drop support for Amazon Linux 2.
+    pip3 install 'meson<0.57.0'
+  %endif
 %endif
 meson setup build \
   --default-library=both \
@@ -330,7 +331,6 @@ Libraries and header files for Apache Arrow C++.
 %if %{use_flight}
 %exclude %{_includedir}/arrow/flight/
 %endif
-%exclude %{_includedir}/arrow/python/
 %{_libdir}/cmake/Arrow/
 %{_libdir}/libarrow.a
 %{_libdir}/libarrow.so

--- a/dev/tasks/linux-packages/package-task.rb
+++ b/dev/tasks/linux-packages/package-task.rb
@@ -415,6 +415,8 @@ VERSION=#{@deb_upstream_version}
       # "almalinux-9-arch64",
       "almalinux-8",
       # "almalinux-8-arch64",
+      "amazon-linux-2023",
+      # "amazon-linux-2023-arch64",
       "amazon-linux-2",
       # "amazon-linux-2-arch64",
       "centos-9-stream",

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -600,6 +600,7 @@ tasks:
 
 {% for target in ["almalinux-9",
                   "almalinux-8",
+                  "amazon-linux-2023",
                   "amazon-linux-2",
                   "centos-9-stream",
                   "centos-8-stream",


### PR DESCRIPTION
### Rationale for this change

Amazon Linux 2023 was released on 2023-02-22.

### What changes are included in this PR?

Add Dockerfile for Amazon Linux 2023 to build packages for it.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #36006