### PR TITLE
GH-36025: [JS] Allow Node.js 18.14 or later in `verify-release-candidate.sh`

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -323,7 +323,7 @@ install_nodejs() {
   else
     export NVM_DIR="`pwd`/.nvm"
     mkdir -p $NVM_DIR
-    curl -sL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | \
+    curl -sL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | \
       PROFILE=/dev/null bash
     [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -321,7 +321,7 @@ install_nodejs() {
   if [ -n "${node_major_version}" ] && [ "${node_major_version}" -ge ${required_node_major_version} ]; then
     show_info "Found NodeJS installation with major version ${node_major_version}"
   else
-    export NVM_DIR="`pwd`/.nvm"
+    export NVM_DIR="$(pwd)/.nvm"
     mkdir -p $NVM_DIR
     curl -sL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | \
       PROFILE=/dev/null bash

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -315,11 +315,13 @@ install_nodejs() {
     return 0
   fi
 
-  required_node_major_version=16
   node_major_version=$(node --version 2>&1 | grep -o '^v[0-9]*' | sed -e 's/^v//g' || :)
-
-  if [ -n "${node_major_version}" ] && [ "${node_major_version}" -ge ${required_node_major_version} ]; then
-    show_info "Found NodeJS installation with major version ${node_major_version}"
+  node_minor_version=$(node --version 2>&1 | grep -o '^v[0-9]*\.[0-9]*' | sed -e 's/^v[0-9]*\.//g' || :)
+  if [[ -n "${node_major_version}" && -n "${node_minor_version}" &&
+      ("${node_major_version}" -eq 16 ||
+        ("${node_major_version}" -eq 18 && "${node_minor_version}" -ge 14) ||
+        "${node_major_version}" -ge 20) ]]; then
+    show_info "Found NodeJS installation with version v${node_major_version}.${node_minor_version}.x"
   else
     export NVM_DIR="$(pwd)/.nvm"
     mkdir -p $NVM_DIR
@@ -327,9 +329,7 @@ install_nodejs() {
       PROFILE=/dev/null bash
     [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 
-    # ARROW-18335: "gulp bundle" failed with Node.js 18.
-    # nvm install --lts
-    nvm install 16
+    nvm install --lts
     show_info "Installed NodeJS $(node --version)"
   fi
 
@@ -837,7 +837,7 @@ test_js() {
   show_header "Build and test JavaScript libraries"
 
   maybe_setup_nodejs || exit 1
-  maybe_setup_conda nodejs=16 || exit 1
+  maybe_setup_conda nodejs=18 || exit 1
 
   if ! command -v yarn &> /dev/null; then
     npm install yarn


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

In Node.js 18.14 or later, `gulp bundle:webpack` succeeds.
So we support running `verify-release-candidate.sh` with Node.js 18.14 or later.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Node.js version check allows 16, 18.14 or later.
Install Node.js LTS with `nvm`.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

I have tested that `TEST_DEFAULT=0 TEST_JS=1 dev/release/verify-release-candidate.sh` succeeds in several environments.

* Node.js is not installed
    * v18.16.0 installed with `nvm` and `verify-release-candidate.sh` succeeded.
* Node.js 16.x installed
    *  Node.js 16.x is used and `verify-release-candidate.sh` succeeded.
* Node.js 18.13.0 installed
    * v18.16.0 installed  with `nvm` and `verify-release-candidate.sh` succeeded.
* Node.js 18.14.0 installed
    *  Node.js 18.14.0 is used and `verify-release-candidate.sh` succeeded.
* Node.js 20.x installed
    *  Node.js 20.x is used and `verify-release-candidate.sh` succeeded.

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #36025