### PR TITLE
MINOR: [C++] Make clang-tidy stop complaining about C arrays

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,6 +21,7 @@ Checks: |
   -clang-analyzer-alpha*,
   google-*,
   modernize-*,
+  -modernize-avoid-c-arrays,
   -modernize-use-trailing-return-type,
   -modernize-use-nodiscard,
 # produce HeaderFilterRegex from cpp/build-support/lint_exclusions.txt with:


### PR DESCRIPTION
### Rationale for this change

`std::array` is rarely a good fit for the kind of low-level array and buffer manipulation that Arrow does, so having `clang-tidy` complaining about C-style arrays confuses more than it helps.

### What changes are included in this PR?

Change in `.clang-tidy`.

### Are these changes tested?

I checked on my editor. Warnings not shown anymore.