### PR TITLE
GH-36109: [MATLAB] Store a nullptr as the validity bitmap if all array elements are valid

### DIFF
--- a/matlab/src/cpp/arrow/matlab/array/proxy/array.cc
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/array.cc
@@ -17,7 +17,7 @@
 
 #include "arrow/matlab/array/proxy/array.h"
 
-#include "arrow/matlab/bit/bit_unpack_arrow_buffer.h"
+#include "arrow/matlab/bit/unpack.h"
 
 namespace arrow::matlab::array::proxy {
 
@@ -50,7 +50,7 @@ namespace arrow::matlab::array::proxy {
 
     void Array::valid(libmexclass::proxy::method::Context& context) {
         auto array_length = static_cast<size_t>(array->length());
-        
+
         // If the Arrow array has no null values, then return a MATLAB
         // logical array that is all "true" for the validity bitmap.
         if (array->null_count() == 0) {
@@ -64,8 +64,7 @@ namespace arrow::matlab::array::proxy {
         }
 
         auto validity_bitmap = array->null_bitmap();
-        auto valid_elements_mda = arrow::matlab::bit::bitUnpackArrowBuffer(validity_bitmap, array_length);
+        auto valid_elements_mda = bit::unpack(validity_bitmap, array_length);
         context.outputs[0] = valid_elements_mda;
     }
-
 }

--- a/matlab/src/cpp/arrow/matlab/array/proxy/boolean_array.cc
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/boolean_array.cc
@@ -18,8 +18,8 @@
 #include "arrow/matlab/array/proxy/boolean_array.h"
 
 #include "arrow/matlab/error/error.h"
-#include "arrow/matlab/bit/bit_pack_matlab_logical_array.h"
-#include "arrow/matlab/bit/bit_unpack_arrow_buffer.h"
+#include "arrow/matlab/bit/pack.h"
+#include "arrow/matlab/bit/unpack.h"
 
 namespace arrow::matlab::array::proxy {
 
@@ -31,11 +31,11 @@ namespace arrow::matlab::array::proxy {
             const ::matlab::data::TypedArray<bool> validity_bitmap_mda = opts[0]["Valid"];
 
             // Pack the logical data values.
-            auto maybe_packed_logical_buffer = arrow::matlab::bit::bitPackMatlabLogicalArray(logical_mda);
+            auto maybe_packed_logical_buffer = arrow::matlab::bit::pack(logical_mda);
             MATLAB_ERROR_IF_NOT_OK(maybe_packed_logical_buffer.status(), error::BITPACK_VALIDITY_BITMAP_ERROR_ID);
 
             // Pack the validity bitmap values.
-            auto maybe_validity_bitmap_buffer = arrow::matlab::bit::bitPackMatlabLogicalArray(validity_bitmap_mda);
+            auto maybe_validity_bitmap_buffer = bit::packValid(validity_bitmap_mda);
             MATLAB_ERROR_IF_NOT_OK(maybe_validity_bitmap_buffer.status(), error::BITPACK_VALIDITY_BITMAP_ERROR_ID);
 
             const auto data_type = arrow::boolean();
@@ -50,7 +50,7 @@ namespace arrow::matlab::array::proxy {
         void BooleanArray::toMATLAB(libmexclass::proxy::method::Context& context) {
             auto array_length = array->length();
             auto packed_logical_data_buffer = std::static_pointer_cast<arrow::BooleanArray>(array)->values();
-            auto logical_array_mda = arrow::matlab::bit::bitUnpackArrowBuffer(packed_logical_data_buffer, array_length);
+            auto logical_array_mda = bit::unpack(packed_logical_data_buffer, array_length);
             context.outputs[0] = logical_array_mda;
         }
 

--- a/matlab/src/cpp/arrow/matlab/array/proxy/numeric_array.h
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/numeric_array.h
@@ -94,7 +94,6 @@ class NumericArray : public arrow::matlab::array::proxy::Array {
                 auto maybe_buffer = bit::packValid(valid_mda);
                 MATLAB_ERROR_IF_NOT_OK(maybe_buffer.status(), error::BITPACK_VALIDITY_BITMAP_ERROR_ID);
                 auto packed_validity_bitmap = *maybe_buffer;
-       
                 auto array_data = arrow::ArrayData::Make(data_type, length, {packed_validity_bitmap, data_buffer});
                 return std::make_shared<arrow::matlab::array::proxy::NumericArray<CType>>(arrow::MakeArray(array_data));
             }

--- a/matlab/src/cpp/arrow/matlab/array/proxy/numeric_array.h
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/numeric_array.h
@@ -26,7 +26,7 @@
 
 #include "arrow/matlab/array/proxy/array.h"
 #include "arrow/matlab/error/error.h"
-#include "arrow/matlab/bit/bit_pack_matlab_logical_array.h"
+#include "arrow/matlab/bit/pack.h"
 
 #include "libmexclass/proxy/Proxy.h"
 
@@ -34,8 +34,12 @@ namespace arrow::matlab::array::proxy {
 
 namespace {
 const uint8_t* getUnpackedValidityBitmap(const ::matlab::data::TypedArray<bool>& valid_elements) {
-    const auto valid_elements_iterator(valid_elements.cbegin());
-    return reinterpret_cast<const uint8_t*>(valid_elements_iterator.operator->());
+    if (valid_elements.getNumberOfElements() > 0) {
+        const auto valid_elements_iterator(valid_elements.cbegin());
+        return reinterpret_cast<const uint8_t*>(valid_elements_iterator.operator->());
+    } else {
+        return nullptr;
+    }
 }
 } // anonymous namespace
 
@@ -85,12 +89,12 @@ class NumericArray : public arrow::matlab::array::proxy::Array {
                 // Do not make a copy when creating arrow::Buffer
                 auto data_buffer = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(dt),
                                                               sizeof(CType) * numeric_mda.getNumberOfElements());
-
                 // Pack the validity bitmap values.
-                auto maybe_buffer = arrow::matlab::bit::bitPackMatlabLogicalArray(valid_mda);
+
+                auto maybe_buffer = bit::packValid(valid_mda);
                 MATLAB_ERROR_IF_NOT_OK(maybe_buffer.status(), error::BITPACK_VALIDITY_BITMAP_ERROR_ID);
                 auto packed_validity_bitmap = *maybe_buffer;
-
+       
                 auto array_data = arrow::ArrayData::Make(data_type, length, {packed_validity_bitmap, data_buffer});
                 return std::make_shared<arrow::matlab::array::proxy::NumericArray<CType>>(arrow::MakeArray(array_data));
             }

--- a/matlab/src/cpp/arrow/matlab/bit/pack.h
+++ b/matlab/src/cpp/arrow/matlab/bit/pack.h
@@ -17,10 +17,18 @@
 
 #pragma once
 
-#include "arrow/buffer.h"
+#include <arrow/buffer.h>
+#include <arrow/result.h>
 
 #include "MatlabDataArray.hpp"
 
 namespace arrow::matlab::bit {
-    ::matlab::data::TypedArray<bool> bitUnpackArrowBuffer(const std::shared_ptr<arrow::Buffer>& packed_buffer, int64_t length);
+    // Calculate the number of bytes required in the bit-packed validity buffer.
+    int64_t packedLength(int64_t num_elements);
+
+    // Pack an unpacked MATLAB logical array into a bit-packed arrow::Buffer representing the validity bitmap.
+    arrow::Result<std::shared_ptr<arrow::Buffer>> packValid(const ::matlab::data::TypedArray<bool> matlab_logical_array);
+
+    // Pack an unpacked MATLAB logical array into a bit-packed arrow::Buffer.
+    arrow::Result<std::shared_ptr<arrow::Buffer>> pack(const ::matlab::data::TypedArray<bool> matlab_logical_array);
 }

--- a/matlab/src/cpp/arrow/matlab/bit/unpack.cc
+++ b/matlab/src/cpp/arrow/matlab/bit/unpack.cc
@@ -15,12 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "arrow/matlab/bit/bit_unpack_arrow_buffer.h"
+#include "arrow/matlab/bit/unpack.h"
 
 #include "arrow/util/bitmap_visit.h"
 
 namespace arrow::matlab::bit {
-    ::matlab::data::TypedArray<bool> bitUnpackArrowBuffer(const std::shared_ptr<arrow::Buffer>& packed_buffer, int64_t length) {
+    ::matlab::data::TypedArray<bool> unpack(const std::shared_ptr<arrow::Buffer>& packed_buffer, int64_t length) {
         const auto packed_buffer_ptr = packed_buffer->data();
 
         ::matlab::data::ArrayFactory factory;

--- a/matlab/src/cpp/arrow/matlab/bit/unpack.h
+++ b/matlab/src/cpp/arrow/matlab/bit/unpack.h
@@ -17,14 +17,10 @@
 
 #pragma once
 
-#include <arrow/buffer.h>
-#include <arrow/result.h>
+#include "arrow/buffer.h"
 
 #include "MatlabDataArray.hpp"
 
 namespace arrow::matlab::bit {
-    // Calculate the number of bytes required in the bit-packed validity buffer.
-    int64_t bitPackedLength(int64_t num_elements);
-    // Pack an unpacked MATLAB logical array into into a bit-packed arrow::Buffer.
-    arrow::Result<std::shared_ptr<arrow::Buffer>> bitPackMatlabLogicalArray(const ::matlab::data::TypedArray<bool> matlab_logical_array);
+    ::matlab::data::TypedArray<bool> unpack(const std::shared_ptr<arrow::Buffer>& packed_buffer, int64_t length);
 }

--- a/matlab/src/matlab/+arrow/+args/parseValidElements.m
+++ b/matlab/src/matlab/+arrow/+args/parseValidElements.m
@@ -25,6 +25,12 @@ function validElements = parseValidElements(data, opts)
     else
         validElements = parseInferNulls(data, opts.InferNulls);
     end
+    
+    if ~isempty(validElements) && all(validElements)
+        % Check if validElements contains only true values. 
+        % If so, return an empty logical array.
+        validElements = logical.empty(0, 1);
+    end
 end
 
 function validElements = parseValid(numElements, valid)
@@ -33,12 +39,11 @@ function validElements = parseValid(numElements, valid)
         if ~isscalar(validElements)
             % Verify the logical vector has the correct number of elements
             validateattributes(validElements, "logical", {'numel', numElements});
-        else
-            % TODO: consider making validElements empty if every 
-            % element is Valid.
-
-            % Expand scalar logical inputs to the correct dimensions
-            validElements = repmat(validElements, numElements, 1);
+        elseif validElements == false
+            validElements = false(numElements, 1);
+        else % validElements == true
+            % Return an empty logical to represent all elements are valid. 
+            validElements = logical.empty(0, 1);
         end
     else
         % valid is a list of indices. Verify the indices are numeric, 
@@ -52,12 +57,13 @@ function validElements = parseValid(numElements, valid)
 end
 
 function validElements = parseInferNulls(data, inferNulls)
-    if inferNulls
-        % TODO: consider making validElements empty if everything is valid.
+    if inferNulls && ~(isinteger(data) || islogical(data))
+        % Only call ismissing on data types that have a "missing" value,
+        % i.e. double, single, string, datetime, duration.
         validElements = ~ismissing(data);
         validElements = reshape(validElements, [], 1);
     else
-        % TODO: consider making this an empty array if everything is valid
-        validElements = true([numel(data) 1]);
+        % Return an empty logical to represent all elements are valid. 
+        validElements = logical.empty(0, 1);
     end
 end

--- a/matlab/test/arrow/args/tParseValidElements.m
+++ b/matlab/test/arrow/args/tParseValidElements.m
@@ -25,11 +25,6 @@ classdef tParseValidElements < matlab.unittest.TestCase
             validElements = parseValidElements(data, InferNulls=true);
             expectedValidElements = [true; false; true; false; true];
             testCase.verifyEqual(validElements, expectedValidElements);
-
-            data = [1 2 3];
-            validElements = parseValidElements(data, InferNulls=true);
-            expectedValidElements = [true; true; true];
-            testCase.verifyEqual(validElements, expectedValidElements);
         end
 
         function InferNullsFalse(testCase)
@@ -37,16 +32,17 @@ classdef tParseValidElements < matlab.unittest.TestCase
             % provided - including values for which that ismissing returns true.
             data = [1 NaN 3 NaN 5];
             validElements = parseValidElements(data, InferNulls=false);
-            expectedValidElements = [true; true; true; true; true];
+            expectedValidElements = logical.empty(0, 1);
             testCase.verifyEqual(validElements, expectedValidElements);
         end
 
         function LogicalValid(testCase)
             data = [1 2 3]; 
 
-            % Supply a scalar true value for Valid 
+            % Verify an empty logical array is returned when a scalar true
+            % value is supplied for Valid.
             validElements = parseValidElements(data, Valid=true);
-            expectedValidElements = [true; true; true];
+            expectedValidElements = logical.empty(0, 1);
             testCase.verifyEqual(validElements, expectedValidElements);
 
             % Supply a scalar false value for Valid
@@ -135,7 +131,7 @@ classdef tParseValidElements < matlab.unittest.TestCase
 
             data = [1 NaN 3];
             validElements = parseValidElements(data, InferNulls=true, Valid=true);
-            expectedValidElements = [true; true; true];
+            expectedValidElements = logical.empty(0, 1);
             testCase.verifyEqual(validElements, expectedValidElements);
 
             validElements = parseValidElements(data, InferNulls=false, Valid=[true; false; false]);
@@ -148,6 +144,37 @@ classdef tParseValidElements < matlab.unittest.TestCase
 
             validElements = parseValidElements(data, InferNulls=false, Valid=1);
             expectedValidElements = [true; false; false];
+            testCase.verifyEqual(validElements, expectedValidElements);
+        end
+
+        function AllElementsAreValid(testCase)
+        % Verify parseValidElements returns a 0x1 logical array when all
+        % elements in the array are Valid.
+
+            expectedValidElements = logical.empty(0, 1);
+            validElements = parseValidElements([1 2 3], InferNulls=true);
+            testCase.verifyEqual(validElements, expectedValidElements);
+
+            validElements = parseValidElements([1 NaN 3], InferNulls=false);
+            testCase.verifyEqual(validElements, expectedValidElements);
+
+            validElements = parseValidElements([1 NaN 3], Valid=[1 2 3]);
+            testCase.verifyEqual(validElements, expectedValidElements);
+
+            validElements = parseValidElements([1 NaN 3], Valid=true);
+            testCase.verifyEqual(validElements, expectedValidElements);
+
+            validElements = parseValidElements([1 NaN 3], Valid=[true; true; true]);
+            testCase.verifyEqual(validElements, expectedValidElements);
+
+            % Pass a logical data array to parseValidElements and
+            % InferNulls=true
+            validElements = parseValidElements([true false true], InferNulls=true);
+            testCase.verifyEqual(validElements, expectedValidElements);
+
+            % Pass an integer data array to parseValidElements and
+            % InferNulls=true
+            validElements = parseValidElements(uint8([0 1 2 3]), InferNulls=true);
             testCase.verifyEqual(validElements, expectedValidElements);
         end
     end

--- a/matlab/test/arrow/array/hNumericArray.m
+++ b/matlab/test/arrow/array/hNumericArray.m
@@ -156,6 +156,14 @@ classdef hNumericArray < matlab.unittest.TestCase
             tc.verifyEqual(tc.MatlabConversionFcn(arrowArray), expectedData);
             tc.verifyEqual(toMATLAB(arrowArray), expectedData);
             tc.verifyEqual(arrowArray.Valid, [false; true; false; true]);
+
+            % Make sure the optimization where the valid-bitmap is stored
+            % as a nullptr works as expected.
+            expectedData = data';
+            arrowArray = tc.ArrowArrayConstructor(data, Valid=[1, 2, 3, 4]);
+            tc.verifyEqual(tc.MatlabConversionFcn(arrowArray), expectedData);
+            tc.verifyEqual(toMATLAB(arrowArray), expectedData);
+            tc.verifyEqual(arrowArray.Valid, [true; true; true; true]);
         end
     end
 end

--- a/matlab/test/arrow/array/tBooleanArray.m
+++ b/matlab/test/arrow/array/tBooleanArray.m
@@ -120,6 +120,15 @@ classdef tBooleanArray < matlab.unittest.TestCase
             tc.verifyEqual(tc.MatlabConversionFcn(arrowArray), expectedData);
             tc.verifyEqual(toMATLAB(arrowArray), expectedData);
             tc.verifyEqual(arrowArray.Valid, [true; true; false]);
+
+
+            % Make sure the optimization where the valid-bitmap is stored as
+            % a nullptr works as expected.
+            expectedData = data;
+            arrowArray = tc.ArrowArrayConstructor(data, Valid=[1, 2, 3]);
+            tc.verifyEqual(tc.MatlabConversionFcn(arrowArray), expectedData);
+            tc.verifyEqual(toMATLAB(arrowArray), expectedData);
+            tc.verifyEqual(arrowArray.Valid, [true; true; true]);
         end
 
         function ErrorIfNonVector(tc)

--- a/matlab/tools/cmake/BuildMatlabArrowInterface.cmake
+++ b/matlab/tools/cmake/BuildMatlabArrowInterface.cmake
@@ -40,9 +40,8 @@ set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/src/c
 set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_SOURCES "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/array/proxy/array.cc"
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/array/proxy/boolean_array.cc"
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/tabular/proxy/record_batch.cc"
-                                                  "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/bit/bit_pack_matlab_logical_array.cc"
-                                                  "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/bit/bit_unpack_arrow_buffer.cc")
-
+                                                  "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/bit/pack.cc"
+                                                  "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/bit/unpack.cc")
 set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_FACTORY_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/proxy")
 set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_FACTORY_SOURCES "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/proxy/factory.cc")
 set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_LIBRARY_INCLUDE_DIRS ${MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_LIBRARY_ROOT_INCLUDE_DIR}


### PR DESCRIPTION
### Rationale for this change

We want to take advantage of the validity bitmap optimization in which it's stored a nullptr if everything in the array is valid. When making large arrow arrays with only valid elements, this speeds up construction because we don't have to bit-pack the the validity array. 

### What changes are included in this PR?

1. Renamed `bit_pack_matlab_logical_array` to `pack`. This function lives in the `arrow::matlab::bit` namespace.
2. Renamed `bit_unpack_arrow_buffer` to `unpack`. This function lives in the `arrow::matlab::bit` namespace.
3. Added a new function called `packValid`, which returns a `nullptr` if the input MATLAB logical array that represents the valid elements is empty. 
4. Modified `arrow.args.parseValidElements` to return a 0x1 logical array if all the elements in the MATLAB array are valid.


### Are these changes tested?
Yes. 

1. Added tests to `tParseValidElements.m`, `tBooleanArray.m`, and `hNumericArray.m` that verify the optimization works as expected.

### Are there any user-facing changes?
They are not user-facing. 

### Notes

Thanks to @kevingurney for the help!



* Closes: #36109