### PR TITLE
GH-36129: [Python] Consolidate common APIs in Table and RecordBatch

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1457,12 +1457,6 @@ cdef class _Tabular(_PandasConvertible):
         raise TypeError(f"Do not call {self.__class__.__name__}'s constructor directly, use "
                         f"one of the `{self.__class__.__name__}.from_*` functions instead.")
 
-    def _is_initialized(self):
-        raise NotImplementedError
-
-    def _column(self, int i):
-        raise NotImplementedError
-
     def __dataframe__(self, nan_as_null: bool = False, allow_copy: bool = True):
         """
         Return the dataframe interchange object implementing the interchange protocol.
@@ -1528,6 +1522,9 @@ cdef class _Tabular(_PandasConvertible):
                              "use any methods or attributes on this object")
         return self.to_string(preview_cols=10)
 
+    def _column(self, int i):
+        raise NotImplementedError
+
     def _ensure_integer_index(self, i):
         """
         Ensure integer index (convert string column name to integer if needed).
@@ -1547,6 +1544,9 @@ cdef class _Tabular(_PandasConvertible):
             return i
         else:
             raise TypeError("Index must either be string or integer")
+
+    def _is_initialized(self):
+        raise NotImplementedError
 
     def column(self, i):
         """

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -548,6 +548,9 @@ foo: 'bar'"""
     del batch
     assert wr() is None
 
+def test_recordbatch_dunder_init():
+    with pytest.raises(TypeError, match='RecordBatch'):
+        pa.RecordBatch()
 
 def test_recordbatch_equals():
     data1 = [
@@ -951,6 +954,9 @@ def test_table_basics():
     del table
     assert wr() is None
 
+def test_table_dunder_init():
+    with pytest.raises(TypeError, match='Table'):
+        pa.Table()
 
 def test_table_from_arrays_preserves_column_metadata():
     # Added to test https://issues.apache.org/jira/browse/ARROW-3866

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -548,9 +548,11 @@ foo: 'bar'"""
     del batch
     assert wr() is None
 
+
 def test_recordbatch_dunder_init():
     with pytest.raises(TypeError, match='RecordBatch'):
         pa.RecordBatch()
+
 
 def test_recordbatch_equals():
     data1 = [
@@ -954,9 +956,11 @@ def test_table_basics():
     del table
     assert wr() is None
 
+
 def test_table_dunder_init():
     with pytest.raises(TypeError, match='Table'):
         pa.Table()
+
 
 def test_table_from_arrays_preserves_column_metadata():
     # Added to test https://issues.apache.org/jira/browse/ARROW-3866

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -554,6 +554,23 @@ def test_recordbatch_dunder_init():
         pa.RecordBatch()
 
 
+def test_recordbatch_itercolumns():
+    data = [
+        pa.array(range(5), type='int16'),
+        pa.array([-10, -5, 0, None, 10], type='int32')
+    ]
+    batch = pa.record_batch(data, ['c0', 'c1'])
+
+    columns = []
+    for col in batch.itercolumns():
+        columns.append(col)
+
+    assert batch.columns == columns
+    assert batch == pa.record_batch(columns, names=batch.column_names)
+    assert batch != pa.record_batch(columns[1:], names=batch.column_names[1:])
+    assert batch != columns
+
+
 def test_recordbatch_equals():
     data1 = [
         pa.array(range(5), type='int16'),


### PR DESCRIPTION
### Rationale for this change

Deduplicate python code in subclasses. The following functions are moved to the shared parent class:
```
__init__
__len__
column_names
from_pylist
from_pydict
itercolumns
to_pylist
to_pydict
```
### What changes are included in this PR?

Refactoring and minor test updates.

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* Closes: #36129