### PR TITLE
MINOR: [Java] Fix dependencies scope in flight-sql module

### DIFF
--- a/java/flight/flight-sql/pom.xml
+++ b/java/flight/flight-sql/pom.xml
@@ -102,11 +102,13 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
       <version>1.4</version>
+      <optional>true</optional>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
### Rationale for this change
flight-sql module advertises dependencies which are not actually used by the published code, causing those dependencies to show up in downstream projects.

### What changes are included in this PR?
Fix dependencies scope in flight-sql module:
* move hamcrest to test scope as it is only used during unit tests
* add optional flag for commons-cli as it is only used in the example class

### Are these changes tested?
No new test. Confirming that there's no build issue

### Are there any user-facing changes?
No