### PR TITLE
GH-36133: [C#] Support Set on the `BinaryArray` Builder

### DIFF
--- a/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
@@ -319,8 +319,8 @@ namespace Apache.Arrow
 
                 return Instance;
 #else
-                //There is not a clean way to shift the bytes with Span.CopyTo which was added in .NetStandard 2.1/.NET5
-                //Given .NetStandard past EOL, keep existing functionality the same for those users.
+                //There is not a clean way to shift the bytes without Span.CopyTo which was added in .NetStandard 2.1/.NET5
+                //For that reason this feature is only avaiable when running versions of .NetStandard 2.1/.NET5 and higher
                 throw new NotImplementedException();
 #endif
             }

--- a/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
@@ -263,7 +263,7 @@ namespace Apache.Arrow
                 return Instance;
             }
 
-            public TBuilder Set(int offset, IEnumerable<byte> values)
+            public TBuilder Set(int offset, ReadOnlySpan<byte> values)
             {
 #if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
                 byte[] newValues = values.ToArray();

--- a/csharp/src/Apache.Arrow/Arrays/StringArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/StringArray.cs
@@ -40,8 +40,8 @@ namespace Apache.Arrow
                 {
                     return AppendNull();
                 }
-                encoding = encoding ?? DefaultEncoding;
-                byte[] span = encoding.GetBytes(value);
+
+                byte[] span = GetBytes(value, encoding);
                 return Append(span.AsSpan());
             }
 
@@ -53,6 +53,17 @@ namespace Apache.Arrow
                 }
 
                 return this;
+            }
+
+            public Builder Set(int index, string value, Encoding encoding = null)
+            {
+                return base.Set(index, GetBytes(value, encoding));
+            }
+
+            private byte[] GetBytes(string value, Encoding encoding)
+            {
+                encoding ??= DefaultEncoding;
+                return encoding.GetBytes(value);
             }
         }
 

--- a/csharp/test/Apache.Arrow.Tests/BinaryArrayBuilderTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/BinaryArrayBuilderTests.cs
@@ -474,6 +474,42 @@ namespace Apache.Arrow.Tests
             }
         }
 
+        public class Set
+        {
+            [Theory]
+            [InlineData(1, "Test5")]
+            [InlineData(0, "T5")]
+            [InlineData(1, "T5")]
+            [InlineData(2, "T5")]
+            [InlineData(2, "Test3")]
+            [InlineData(1, "NewTest")]
+            [InlineData(2, "NewTest")]
+            [InlineData(0, "NewTest")]
+            public void EnsureSetsUpdatesTheCorrectBytes(int offset, string newValue)
+            {
+                // Arrange
+                var builder = new BinaryArray.Builder();
+                var defaultValues = new[] { "Test",  "Test1", "Test2"};
+                var expectedValues = (string[])defaultValues.Clone();
+                expectedValues[offset] = newValue;
+                foreach (string defaultValue in defaultValues)
+                {
+                    builder.Append(StringArray.DefaultEncoding.GetBytes(defaultValue).AsSpan());
+                }
+
+                // Act
+                builder.Set(offset, StringArray.DefaultEncoding.GetBytes(newValue));
+                var array = builder.Build();
+
+                // Assert
+                for (int i = 0; i <expectedValues.Length; i++)
+                {
+                    string actual = StringArray.DefaultEncoding.GetString(array.GetBytes(i));
+                    Assert.Equal(expectedValues[i], actual);
+                }
+            }
+        }
+
         private static void AssertArrayContents(IEnumerable<byte[]> expectedContents, BinaryArray array)
         {
             var expectedContentsArr = expectedContents.ToArray();

--- a/csharp/test/Apache.Arrow.Tests/BinaryArrayBuilderTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/BinaryArrayBuilderTests.cs
@@ -508,6 +508,35 @@ namespace Apache.Arrow.Tests
                     Assert.Equal(expectedValues[i], actual);
                 }
             }
+
+            [Theory]
+            [InlineData(0)]
+            [InlineData(1)]
+            [InlineData(2)]
+            public void EnsureSetNullUpdatesTheCorrectBytes(int offset)
+            {
+                // Arrange
+                var builder = new BinaryArray.Builder();
+                var defaultValues = new[] { "Test",  "Test1", "Test2"};
+                var expectedValues = (string[])defaultValues.Clone();
+                expectedValues[offset] = null;
+                foreach (string defaultValue in defaultValues)
+                {
+                    builder.Append(StringArray.DefaultEncoding.GetBytes(defaultValue).AsSpan());
+                }
+
+                // Act
+                builder.SetNull(offset);
+                var array = builder.Build();
+
+                // Assert
+                for (int i = 0; i <expectedValues.Length; i++)
+                {
+                    ReadOnlySpan<byte> byteValue = array.GetBytes(i);
+                    string actual = byteValue == null ? null : StringArray.DefaultEncoding.GetString(byteValue);
+                    Assert.Equal(expectedValues[i], actual);
+                }
+            }
         }
 
         private static void AssertArrayContents(IEnumerable<byte[]> expectedContents, BinaryArray array)

--- a/csharp/test/Apache.Arrow.Tests/StringArrayBuilderTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/StringArrayBuilderTests.cs
@@ -53,5 +53,33 @@ public class StringArrayBuilderTests
                 Assert.Equal(expectedValues[i], actual);
             }
         }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void EnsureSetNullUpdatesTheCorrectStrings(int offset)
+        {
+            // Arrange
+            var builder = new StringArray.Builder();
+            var defaultValues = new[] { "Test",  "Test1", "Test2"};
+            var expectedValues = (string[])defaultValues.Clone();
+            expectedValues[offset] = null;
+            foreach (string defaultValue in defaultValues)
+            {
+                builder.Append(defaultValue);
+            }
+
+            // Act
+            builder.SetNull(offset);
+            var array = builder.Build();
+
+            // Assert
+            for (int i = 0; i <expectedValues.Length; i++)
+            {
+                string actual = array.GetString(i);
+                Assert.Equal(expectedValues[i], actual);
+            }
+        }
     }
 }

--- a/csharp/test/Apache.Arrow.Tests/StringArrayBuilderTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/StringArrayBuilderTests.cs
@@ -1,0 +1,42 @@
+using Xunit;
+
+namespace Apache.Arrow.Tests;
+
+public class StringArrayBuilderTests
+{
+    public class Set
+    {
+        [Theory]
+        [InlineData(1, "Test5")]
+        [InlineData(0, "T5")]
+        [InlineData(1, "T5")]
+        [InlineData(2, "T5")]
+        [InlineData(2, "Test3")]
+        [InlineData(1, "NewTest")]
+        [InlineData(2, "NewTest")]
+        [InlineData(0, "NewTest")]
+        public void EnsureSetsUpdatesTheCorrectStrings(int offset, string newValue)
+        {
+            // Arrange
+            var builder = new StringArray.Builder();
+            var defaultValues = new[] { "Test",  "Test1", "Test2"};
+            var expectedValues = (string[])defaultValues.Clone();
+            expectedValues[offset] = newValue;
+            foreach (string defaultValue in defaultValues)
+            {
+                builder.Append(defaultValue);
+            }
+
+            // Act
+            builder.Set(offset, newValue);
+            var array = builder.Build();
+
+            // Assert
+            for (int i = 0; i <expectedValues.Length; i++)
+            {
+                string actual = array.GetString(i);
+                Assert.Equal(expectedValues[i], actual);
+            }
+        }
+    }
+}

--- a/csharp/test/Apache.Arrow.Tests/StringArrayBuilderTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/StringArrayBuilderTests.cs
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using Xunit;
 
 namespace Apache.Arrow.Tests;


### PR DESCRIPTION
### What changes are included in this PR?

Implemented the Set method on both the `BinaryArray` and `StringArray` builders to match functionality of other Builders (`PrimitiveArray.Builder` for example).

Closes #36133
* Closes: #36133