### PR TITLE
GH-36151: [Java] Add `volatile` declaration to `keyPosition` in `ParallelSearcher`

### DIFF
--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/search/ParallelSearcher.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/search/ParallelSearcher.java
@@ -52,7 +52,7 @@ public class ParallelSearcher<V extends ValueVector> {
   /**
    * The position of the key in the target vector, if any.
    */
-  private int keyPosition = -1;
+  private volatile int keyPosition = -1;
 
   /**
    * Constructs a parallel searcher.


### PR DESCRIPTION
### Rationale for this change

Multiple threads can read/write to the `keyPosition` variable. Thus, it should be declared `volatile` so that all threads have a consistent view of the value of this variable.

### What changes are included in this PR?

This PR just marks an instance member `volatile`.

### Are these changes tested?

Existing tests should suffice as no functionality is being changed.

### Are there any user-facing changes?

No, there are no user facing changes. There are no changes to the public API either.
* Closes: #36151