### PR TITLE
GH-36131: [Docs] Use https://arrow.apache.org/julia/ for Julia URL

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -47,7 +47,7 @@ target environment.**
    Go <https://pkg.go.dev/github.com/apache/arrow/go>
    Java <java/index>
    JavaScript <js/index>
-   Julia <https://github.com/apache/arrow-julia/blob/main/README.md>
+   Julia <https://arrow.apache.org/julia/>
    MATLAB <https://github.com/apache/arrow/blob/main/matlab/README.md>
    Python <python/index>
    R <r/index>


### PR DESCRIPTION
### Rationale for this change

The Julia implementation's URL was changed to  https://arrow.apache.org/julia/ .

### What changes are included in this PR?

Use it.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #36131