### PR TITLE
GH-36157: [C++][Dev] Add support for using python3 to run IWYU

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -344,8 +344,19 @@ if(${CLANG_TIDY_FOUND})
 endif()
 
 if(UNIX)
-  add_custom_target(iwyu ${BUILD_SUPPORT_DIR}/iwyu/iwyu.sh)
-  add_custom_target(iwyu-all ${BUILD_SUPPORT_DIR}/iwyu/iwyu.sh all)
+  add_custom_target(iwyu
+                    ${CMAKE_COMMAND}
+                    -E
+                    env
+                    "PYTHON=${PYTHON_EXECUTABLE}"
+                    ${BUILD_SUPPORT_DIR}/iwyu/iwyu.sh)
+  add_custom_target(iwyu-all
+                    ${CMAKE_COMMAND}
+                    -E
+                    env
+                    "PYTHON=${PYTHON_EXECUTABLE}"
+                    ${BUILD_SUPPORT_DIR}/iwyu/iwyu.sh
+                    all)
 endif(UNIX)
 
 # datetime code used by iOS requires zlib support

--- a/cpp/build-support/iwyu/iwyu.sh
+++ b/cpp/build-support/iwyu/iwyu.sh
@@ -49,8 +49,8 @@ affected_files() {
 include-what-you-use --version
 
 if [[ "${1:-}" == "all" ]]; then
-    python $ROOT/cpp/build-support/iwyu/iwyu_tool.py -p ${IWYU_COMPILATION_DATABASE_PATH:-.} \
-        -- $IWYU_ARGS | awk -f $ROOT/cpp/build-support/iwyu/iwyu-filter.awk
+  ${PYTHON:-python3} $ROOT/cpp/build-support/iwyu/iwyu_tool.py -p ${IWYU_COMPILATION_DATABASE_PATH:-.} \
+      -- $IWYU_ARGS | awk -f $ROOT/cpp/build-support/iwyu/iwyu-filter.awk
 elif [[ "${1:-}" == "match" ]]; then
   ALL_FILES=
   IWYU_FILE_LIST=
@@ -61,7 +61,7 @@ elif [[ "${1:-}" == "match" ]]; then
   done
 
   echo "Running IWYU on $IWYU_FILE_LIST"
-  python $ROOT/cpp/build-support/iwyu/iwyu_tool.py \
+  ${PYTHON:-python3} $ROOT/cpp/build-support/iwyu/iwyu_tool.py \
       -p ${IWYU_COMPILATION_DATABASE_PATH:-.} $IWYU_FILE_LIST  -- \
        $IWYU_ARGS | awk -f $ROOT/cpp/build-support/iwyu/iwyu-filter.awk
 else
@@ -78,7 +78,7 @@ else
     IWYU_FILE_LIST="$IWYU_FILE_LIST $ROOT/$p"
   done
 
-  python $ROOT/cpp/build-support/iwyu/iwyu_tool.py \
+  ${PYTHON:-python3} $ROOT/cpp/build-support/iwyu/iwyu_tool.py \
       -p ${IWYU_COMPILATION_DATABASE_PATH:-.} $IWYU_FILE_LIST  -- \
        $IWYU_ARGS | awk -f $ROOT/cpp/build-support/iwyu/iwyu-filter.awk > $IWYU_LOG
 fi


### PR DESCRIPTION
### Rationale for this change

Python executable name is hard-corded in `cpp/build-support/iwyu/iwyu.sh`. If a developer uses `python3` for Python executable, the developer can't use the script.

### What changes are included in this PR?

Add support for customizing Python executable name (and path) by `PYTHON` environment variable like other scripts.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #36157