### PR TITLE
GH-21761: [Python] accept pyarrow scalars in array constructor

### DIFF
--- a/python/pyarrow/src/arrow/python/inference.cc
+++ b/python/pyarrow/src/arrow/python/inference.cc
@@ -29,7 +29,6 @@
 
 #include "arrow/scalar.h"
 #include "arrow/status.h"
-#include "arrow/type.h"
 #include "arrow/util/decimal.h"
 #include "arrow/util/logging.h"
 

--- a/python/pyarrow/src/arrow/python/inference.cc
+++ b/python/pyarrow/src/arrow/python/inference.cc
@@ -79,7 +79,7 @@ Status ImportPresentIntervalTypes(OwnedRefNoGIL* interval_types_tuple) {
 
 }  // namespace
 
-int import_pyarrow();
+import_pyarrow();
 
 #define _NUMPY_UNIFY_NOOP(DTYPE) \
   case NPY_##DTYPE:              \

--- a/python/pyarrow/src/arrow/python/inference.cc
+++ b/python/pyarrow/src/arrow/python/inference.cc
@@ -27,7 +27,9 @@
 #include <utility>
 #include <vector>
 
+#include "arrow/scalar.h"
 #include "arrow/status.h"
+#include "arrow/type.h"
 #include "arrow/util/decimal.h"
 #include "arrow/util/logging.h"
 
@@ -76,6 +78,8 @@ Status ImportPresentIntervalTypes(OwnedRefNoGIL* interval_types_tuple) {
 }
 
 }  // namespace
+
+int import_pyarrow();
 
 #define _NUMPY_UNIFY_NOOP(DTYPE) \
   case NPY_##DTYPE:              \
@@ -340,6 +344,7 @@ class TypeInferrer {
         decimal_count_(0),
         list_count_(0),
         struct_count_(0),
+        arrow_scalar_count_(0),
         numpy_dtype_count_(0),
         interval_count_(0),
         max_decimal_metadata_(std::numeric_limits<int32_t>::min(),
@@ -391,6 +396,8 @@ class TypeInferrer {
     } else if (PyUnicode_Check(obj)) {
       ++unicode_count_;
       *keep_going = make_unions_;
+    } else if(arrow::py::is_scalar(obj)) {
+      RETURN_NOT_OK(VisitArrowScalar(obj, keep_going));
     } else if (PyArray_CheckAnyScalarExact(obj)) {
       RETURN_NOT_OK(VisitDType(PyArray_DescrFromScalar(obj), keep_going));
     } else if (PySet_Check(obj) || (Py_TYPE(obj) == &PyDictValues_Type)) {
@@ -496,6 +503,12 @@ class TypeInferrer {
       }
     }
 
+    if (arrow_scalar_count_ > 0 and arrow_scalar_count_ + none_count_ != total_count_){
+      return Status::Invalid(
+              "pyarrow scalars cannot be mixed "
+              "with other Python scalar values currently");
+    }
+
     if (list_count_) {
       std::shared_ptr<DataType> value_type;
       RETURN_NOT_OK(list_inferrer_->GetType(&value_type));
@@ -534,6 +547,8 @@ class TypeInferrer {
       *out = utf8();
     } else if (interval_count_) {
       *out = month_day_nano_interval();
+    } else if (arrow_scalar_count_) {
+      *out = scalar_type_;
     } else {
       *out = null();
     }
@@ -557,6 +572,24 @@ class TypeInferrer {
         RETURN_NOT_OK(it.second.Validate());
       }
     }
+    return Status::OK();
+  }
+
+  Status VisitArrowScalar(PyObject* obj, bool* keep_going) {
+    Result<std::shared_ptr<Scalar>> result = arrow::py::unwrap_scalar(obj);
+    if (!result.ok()){
+      return internal::InvalidValue(obj, "Oh, what?");
+    }
+    std::shared_ptr<Scalar> scalar = result.ValueOrDie();
+
+    // Check that all the scalar types for the sequence are the same
+    std::shared_ptr<DataType> type = (*scalar->type).GetSharedPtr();
+    if (arrow_scalar_count_ > 0 and type != scalar_type_) {
+      return internal::InvalidValue(obj,
+                                    "cannot mix scalars with different types");
+    }
+    scalar_type_ = type;
+    ++arrow_scalar_count_;
     return Status::OK();
   }
 
@@ -675,10 +708,12 @@ class TypeInferrer {
   int64_t decimal_count_;
   int64_t list_count_;
   int64_t struct_count_;
+  int64_t arrow_scalar_count_;
   int64_t numpy_dtype_count_;
   int64_t interval_count_;
   std::unique_ptr<TypeInferrer> list_inferrer_;
   std::map<std::string, TypeInferrer> struct_inferrers_;
+  std::shared_ptr<DataType> scalar_type_;
 
   // If we observe a strongly-typed value in e.g. a NumPy array, we can store
   // it here to skip the type counting logic above

--- a/python/pyarrow/src/arrow/python/inference.cc
+++ b/python/pyarrow/src/arrow/python/inference.cc
@@ -576,7 +576,7 @@ class TypeInferrer {
   Status VisitArrowScalar(PyObject* obj, bool* keep_going) {
     ARROW_ASSIGN_OR_RAISE(auto scalar, arrow::py::unwrap_scalar(obj));
     // Check that all the scalar types for the sequence are the same
-    if (arrow_scalar_count_ > 0 and *scalar->type != *scalar_type_) {
+    if (arrow_scalar_count_ > 0 && *scalar->type != *scalar_type_) {
       return internal::InvalidValue(obj, "cannot mix scalars with different types");
     }
     scalar_type_ = scalar->type;

--- a/python/pyarrow/src/arrow/python/inference.cc
+++ b/python/pyarrow/src/arrow/python/inference.cc
@@ -79,8 +79,6 @@ Status ImportPresentIntervalTypes(OwnedRefNoGIL* interval_types_tuple) {
 
 }  // namespace
 
-import_pyarrow();
-
 #define _NUMPY_UNIFY_NOOP(DTYPE) \
   case NPY_##DTYPE:              \
     return OK;

--- a/python/pyarrow/src/arrow/python/inference.cc
+++ b/python/pyarrow/src/arrow/python/inference.cc
@@ -396,7 +396,7 @@ class TypeInferrer {
     } else if (PyUnicode_Check(obj)) {
       ++unicode_count_;
       *keep_going = make_unions_;
-    } else if(arrow::py::is_scalar(obj)) {
+    } else if (arrow::py::is_scalar(obj)) {
       RETURN_NOT_OK(VisitArrowScalar(obj, keep_going));
     } else if (PyArray_CheckAnyScalarExact(obj)) {
       RETURN_NOT_OK(VisitDType(PyArray_DescrFromScalar(obj), keep_going));
@@ -462,10 +462,10 @@ class TypeInferrer {
 
     RETURN_NOT_OK(Validate());
 
-    if (arrow_scalar_count_ > 0 and arrow_scalar_count_ + none_count_ != total_count_){
+    if (arrow_scalar_count_ > 0 and arrow_scalar_count_ + none_count_ != total_count_) {
       return Status::Invalid(
-              "pyarrow scalars cannot be mixed "
-              "with other Python scalar values currently");
+          "pyarrow scalars cannot be mixed "
+          "with other Python scalar values currently");
     }
 
     if (numpy_dtype_count_ > 0) {
@@ -579,8 +579,7 @@ class TypeInferrer {
     ARROW_ASSIGN_OR_RAISE(auto scalar, arrow::py::unwrap_scalar(obj));
     // Check that all the scalar types for the sequence are the same
     if (arrow_scalar_count_ > 0 and *scalar->type != *scalar_type_) {
-      return internal::InvalidValue(obj,
-                                    "cannot mix scalars with different types");
+      return internal::InvalidValue(obj, "cannot mix scalars with different types");
     }
     scalar_type_ = scalar->type;
     ++arrow_scalar_count_;

--- a/python/pyarrow/src/arrow/python/inference.cc
+++ b/python/pyarrow/src/arrow/python/inference.cc
@@ -460,7 +460,7 @@ class TypeInferrer {
 
     RETURN_NOT_OK(Validate());
 
-    if (arrow_scalar_count_ > 0 and arrow_scalar_count_ + none_count_ != total_count_) {
+    if (arrow_scalar_count_ > 0 && arrow_scalar_count_ + none_count_ != total_count_) {
       return Status::Invalid(
           "pyarrow scalars cannot be mixed "
           "with other Python scalar values currently");

--- a/python/pyarrow/src/arrow/python/inference.cc
+++ b/python/pyarrow/src/arrow/python/inference.cc
@@ -573,7 +573,7 @@ class TypeInferrer {
     return Status::OK();
   }
 
-  Status VisitArrowScalar(PyObject* obj, bool* keep_going) {
+  Status VisitArrowScalar(PyObject* obj, bool* keep_going /* unused */) {
     ARROW_ASSIGN_OR_RAISE(auto scalar, arrow::py::unwrap_scalar(obj));
     // Check that all the scalar types for the sequence are the same
     if (arrow_scalar_count_ > 0 && *scalar->type != *scalar_type_) {

--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -83,8 +83,6 @@ struct MonthDayNanoAttrData {
   const int64_t multiplier;
 };
 
-int import_pyarrow();
-
 template <>
 struct MonthDayNanoTraits<MonthDayNanoField::kMonths> {
   using c_type = int32_t;
@@ -914,7 +912,7 @@ class PyStructConverter : public StructConverter<PyConverter, PyConverterTrait> 
   Status Append(PyObject* value) override {
     if (PyValue::IsNull(this->options_, value)) {
       return this->struct_builder_->AppendNull();
-    } else if (arrow::py::is_scalar(value)){
+    } else if (arrow::py::is_scalar(value)) {
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
                             arrow::py::unwrap_scalar(value));
       return this->struct_builder_->AppendScalar(*scalar);

--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -627,7 +627,8 @@ class PyPrimitiveConverter<
     if (PyValue::IsNull(this->options_, value)) {
       this->primitive_builder_->UnsafeAppendNull();
     } else if (arrow::py::is_scalar(value)){
-      ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar, arrow::py::unwrap_scalar(value));
+      ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
+                            arrow::py::unwrap_scalar(value));
       ARROW_RETURN_NOT_OK(this->primitive_builder_->AppendScalar(*scalar));
     } else {
       ARROW_ASSIGN_OR_RAISE(
@@ -647,7 +648,8 @@ class PyPrimitiveConverter<
     if (PyValue::IsNull(this->options_, value)) {
       this->primitive_builder_->UnsafeAppendNull();
     } else if (arrow::py::is_scalar(value)){
-      ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar, arrow::py::unwrap_scalar(value));
+      ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
+                            arrow::py::unwrap_scalar(value));
       ARROW_RETURN_NOT_OK(this->primitive_builder_->AppendScalar(*scalar));
     } else {
       ARROW_ASSIGN_OR_RAISE(
@@ -672,7 +674,8 @@ class PyPrimitiveConverter<T, enable_if_t<std::is_same<T, FixedSizeBinaryType>::
     if (PyValue::IsNull(this->options_, value)) {
       this->primitive_builder_->UnsafeAppendNull();
     } else if (arrow::py::is_scalar(value)){
-      ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar, arrow::py::unwrap_scalar(value));
+      ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
+                            arrow::py::unwrap_scalar(value));
       ARROW_RETURN_NOT_OK(this->primitive_builder_->AppendScalar(*scalar));
     } else {
       ARROW_RETURN_NOT_OK(
@@ -697,7 +700,8 @@ class PyPrimitiveConverter<T, enable_if_base_binary<T>>
     if (PyValue::IsNull(this->options_, value)) {
       this->primitive_builder_->UnsafeAppendNull();
     } else if (arrow::py::is_scalar(value)){
-      ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar, arrow::py::unwrap_scalar(value));
+      ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
+                            arrow::py::unwrap_scalar(value));
       ARROW_RETURN_NOT_OK(this->primitive_builder_->AppendScalar(*scalar));
     } else {
       ARROW_RETURN_NOT_OK(
@@ -740,7 +744,8 @@ class PyDictionaryConverter<U, enable_if_has_c_type<U>>
     if (PyValue::IsNull(this->options_, value)) {
       return this->value_builder_->AppendNull();
     } else if (arrow::py::is_scalar(value)){
-      ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar, arrow::py::unwrap_scalar(value));
+      ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
+                            arrow::py::unwrap_scalar(value));
       return this->value_builder_->AppendScalar(*scalar, 1);
     } else {
       ARROW_ASSIGN_OR_RAISE(auto converted,
@@ -758,7 +763,8 @@ class PyDictionaryConverter<U, enable_if_has_string_view<U>>
     if (PyValue::IsNull(this->options_, value)) {
       return this->value_builder_->AppendNull();
     } else if (arrow::py::is_scalar(value)){
-      ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar, arrow::py::unwrap_scalar(value));
+      ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
+                            arrow::py::unwrap_scalar(value));
       return this->value_builder_->AppendScalar(*scalar, 1);
     } else {
       ARROW_RETURN_NOT_OK(
@@ -910,7 +916,8 @@ class PyStructConverter : public StructConverter<PyConverter, PyConverterTrait> 
       return this->struct_builder_->AppendNull();
     }
     else if (arrow::py::is_scalar(value)){
-      ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar, arrow::py::unwrap_scalar(value));
+      ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
+                            arrow::py::unwrap_scalar(value));
       return this->struct_builder_->AppendScalar(*scalar);
     }
     switch (input_kind_) {

--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -603,7 +603,7 @@ class PyPrimitiveConverter<T, enable_if_null<T>>
   Status Append(PyObject* value) override {
     if (PyValue::IsNull(this->options_, value)) {
       return this->primitive_builder_->AppendNull();
-    } else if (arrow::py::is_scalar(value)){
+    } else if (arrow::py::is_scalar(value)) {
       return this->primitive_builder_->AppendNull();
     } else {
       ARROW_ASSIGN_OR_RAISE(
@@ -626,7 +626,7 @@ class PyPrimitiveConverter<
     // rely on the Unsafe builder API which improves the performance.
     if (PyValue::IsNull(this->options_, value)) {
       this->primitive_builder_->UnsafeAppendNull();
-    } else if (arrow::py::is_scalar(value)){
+    } else if (arrow::py::is_scalar(value)) {
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
                             arrow::py::unwrap_scalar(value));
       ARROW_RETURN_NOT_OK(this->primitive_builder_->AppendScalar(*scalar));
@@ -647,7 +647,7 @@ class PyPrimitiveConverter<
   Status Append(PyObject* value) override {
     if (PyValue::IsNull(this->options_, value)) {
       this->primitive_builder_->UnsafeAppendNull();
-    } else if (arrow::py::is_scalar(value)){
+    } else if (arrow::py::is_scalar(value)) {
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
                             arrow::py::unwrap_scalar(value));
       ARROW_RETURN_NOT_OK(this->primitive_builder_->AppendScalar(*scalar));
@@ -673,7 +673,7 @@ class PyPrimitiveConverter<T, enable_if_t<std::is_same<T, FixedSizeBinaryType>::
   Status Append(PyObject* value) override {
     if (PyValue::IsNull(this->options_, value)) {
       this->primitive_builder_->UnsafeAppendNull();
-    } else if (arrow::py::is_scalar(value)){
+    } else if (arrow::py::is_scalar(value)) {
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
                             arrow::py::unwrap_scalar(value));
       ARROW_RETURN_NOT_OK(this->primitive_builder_->AppendScalar(*scalar));
@@ -699,7 +699,7 @@ class PyPrimitiveConverter<T, enable_if_base_binary<T>>
   Status Append(PyObject* value) override {
     if (PyValue::IsNull(this->options_, value)) {
       this->primitive_builder_->UnsafeAppendNull();
-    } else if (arrow::py::is_scalar(value)){
+    } else if (arrow::py::is_scalar(value)) {
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
                             arrow::py::unwrap_scalar(value));
       ARROW_RETURN_NOT_OK(this->primitive_builder_->AppendScalar(*scalar));
@@ -743,7 +743,7 @@ class PyDictionaryConverter<U, enable_if_has_c_type<U>>
   Status Append(PyObject* value) override {
     if (PyValue::IsNull(this->options_, value)) {
       return this->value_builder_->AppendNull();
-    } else if (arrow::py::is_scalar(value)){
+    } else if (arrow::py::is_scalar(value)) {
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
                             arrow::py::unwrap_scalar(value));
       return this->value_builder_->AppendScalar(*scalar, 1);
@@ -762,7 +762,7 @@ class PyDictionaryConverter<U, enable_if_has_string_view<U>>
   Status Append(PyObject* value) override {
     if (PyValue::IsNull(this->options_, value)) {
       return this->value_builder_->AppendNull();
-    } else if (arrow::py::is_scalar(value)){
+    } else if (arrow::py::is_scalar(value)) {
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
                             arrow::py::unwrap_scalar(value));
       return this->value_builder_->AppendScalar(*scalar, 1);
@@ -914,8 +914,7 @@ class PyStructConverter : public StructConverter<PyConverter, PyConverterTrait> 
   Status Append(PyObject* value) override {
     if (PyValue::IsNull(this->options_, value)) {
       return this->struct_builder_->AppendNull();
-    }
-    else if (arrow::py::is_scalar(value)){
+    } else if (arrow::py::is_scalar(value)){
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
                             arrow::py::unwrap_scalar(value));
       return this->struct_builder_->AppendScalar(*scalar);

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -2457,29 +2457,14 @@ def test_array_from_pylist_offset_overflow():
     )
 ])
 def test_array_accepts_pyarrow_scalar(seq, data, scalar_data, value_type):
+    if type(seq(scalar_data)) == set:
+        pytest.skip("The elements in the set get reordered.")
     expect = pa.array(data, type=value_type)
     result = pa.array(seq(scalar_data))
-
-    if type(seq(scalar_data)) == set:
-        try:
-            import pyarrow.compute as pc
-            expect = [expect[a] for a in pc.array_sort_indices(expect).to_pylist()]
-            result = [result[a] for a in pc.array_sort_indices(result).to_pylist()]
-            expect == result
-        except pa.lib.ArrowNotImplementedError:
-            set(expect) == set(result)
-    else:
-        assert expect.equals(result)
+    assert expect.equals(result)
 
     result = pa.array(seq(scalar_data), type=value_type)
-    if type(seq(scalar_data)) == set:
-        try:
-            result = [result[a] for a in pc.array_sort_indices(result).to_pylist()]
-            expect == result
-        except pa.lib.ArrowNotImplementedError:
-            set(expect) == set(result)
-    else:
-        assert expect.equals(result)
+    assert expect.equals(result)
 
 
 @parametrize_with_collections_types

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -2368,7 +2368,11 @@ def test_array_from_pylist_offset_overflow():
 @parametrize_with_collections_types
 @pytest.mark.parametrize(('data', 'scalar_data', 'value_type'), [
     ([True, False, None], [pa.scalar(True), pa.scalar(False), None], pa.bool_()),
-    ([1, 2, None], [pa.scalar(1), pa.scalar(2), pa.scalar(None, pa.int64())], pa.int64()),
+    (
+        [1, 2, None],
+        [pa.scalar(1), pa.scalar(2), pa.scalar(None, pa.int64())],
+        pa.int64()
+    ),
     ([1, None, None], [pa.scalar(1), None, pa.scalar(None, pa.int64())], pa.int64()),
     ([None, None], [pa.scalar(None), pa.scalar(None)], pa.null()),
     ([1., 2., None], [pa.scalar(1.), pa.scalar(2.), None], pa.float64()),

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -2380,8 +2380,8 @@ def test_array_from_pylist_offset_overflow():
     ([pa.MonthDayNano([1, -1, -10100])], [pa.scalar(pa.MonthDayNano([1, -1, -10100]))]),
     (["a", "b"], [pa.scalar("a"), pa.scalar("b")]),
     ([b"a", b"b"], [pa.scalar(b"a"), pa.scalar(b"b")]),
-    ([1, 2, 3], pa.scalar([1, 2, 3])),
-    (["a", "b"], pa.scalar(["a", "b"])),
+    ([[1, 2, 3]], [pa.scalar([1, 2, 3])]),
+    ([["a", "b"]], [pa.scalar(["a", "b"])]),
 ])
 def test_array_accepts_pyarrow_scalar(seq, data, scalar_data):
     if type(seq(scalar_data)) == set:

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -2363,3 +2363,27 @@ def test_array_from_pylist_offset_overflow():
     assert isinstance(arr, pa.ChunkedArray)
     assert len(arr) == 2**31
     assert len(arr.chunks) > 1
+
+
+@parametrize_with_collections_types
+def test_array_accepts_pyarrow_scalar(seq):
+    sequence = seq([pa.scalar(1), pa.scalar("a"), pa.scalar(3.0)])
+    with pytest.raises(pa.ArrowInvalid,
+                       match="cannot mix scalars with different types"):
+        pa.array(sequence)
+
+    sequence = seq([1, pa.scalar("a"), None])
+    with pytest.raises(pa.ArrowInvalid,
+                       match="pyarrow scalars cannot be mixed with other "
+                             "Python scalar values currently"):
+        pa.array(sequence)
+
+    # arr = pa.array([1, 2, 3])
+    # result = pa.array([arr.sum()])
+    # expect = pa.array([6])
+    # assert expect == result
+
+    # sequence = seq([pa.scalar(1), pa.scalar(2), pa.scalar(3)])
+    # result = pa.array(sequence)
+    # expect = pa.array([1, 2, 3])
+    # assert expect == result

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -2437,7 +2437,7 @@ def test_array_accepts_pyarrow_scalar_with_type(seq, data, scalar_data, value_ty
     assert expect.equals(result)
 
 
-def test_array_accepts_pyarrow_scalar_something():
+def test_array_accepts_pyarrow_scalar_from_compute():
     arr = pa.array([1, 2, 3])
     result = pa.array([arr.sum()])
     expect = pa.array([6])
@@ -2473,3 +2473,8 @@ def test_array_accepts_pyarrow_scalar_errors(seq):
                        match="Cannot append scalar of type string "
                              "to builder for type int32"):
         pa.array([pa.scalar("a")], type=pa.int32())
+
+    with pytest.raises(pa.ArrowInvalid,
+                       match="Cannot append scalar of type int64 "
+                             "to builder for type null"):
+        pa.array([pa.scalar(1)], type=pa.null())

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -2364,6 +2364,7 @@ def test_array_from_pylist_offset_overflow():
     assert len(arr) == 2**31
     assert len(arr.chunks) > 1
 
+
 @parametrize_with_collections_types
 @pytest.mark.parametrize(('data', 'scalar_data'), [
     ([True, False, None], [pa.scalar(True), pa.scalar(False), None]),
@@ -2373,8 +2374,9 @@ def test_array_from_pylist_offset_overflow():
     ([1., 2., None], [pa.scalar(1.), pa.scalar(2.), None]),
     ([None, datetime.date.today()], [None, pa.scalar(datetime.date.today())]),
     ([datetime.time(1, 1, 1), None], [pa.scalar(datetime.time(1, 1, 1)), None]),
-    ([datetime.timedelta(seconds=10)],[pa.scalar(datetime.timedelta(seconds=10))]),
-    ([None, datetime.datetime(2014,1,1)], [None, pa.scalar(datetime.datetime(2014,1,1))]),
+    ([datetime.timedelta(seconds=10)], [pa.scalar(datetime.timedelta(seconds=10))]),
+    ([None, datetime.datetime(2014, 1, 1)], [
+     None, pa.scalar(datetime.datetime(2014, 1, 1))]),
     ([pa.MonthDayNano([1, -1, -10100])], [pa.scalar(pa.MonthDayNano([1, -1, -10100]))]),
     (["a", "b"], [pa.scalar("a"), pa.scalar("b")]),
     ([b"a", b"b"], [pa.scalar(b"a"), pa.scalar(b"b")]),
@@ -2391,9 +2393,11 @@ def test_array_accepts_pyarrow_scalar(seq, data, scalar_data):
 
 @parametrize_with_collections_types
 @pytest.mark.parametrize(('data', 'scalar_data', 'value_type'), [
-    ([1, 2, None], [pa.scalar(1, type=pa.int8()), pa.scalar(2, type=pa.int8()), None], pa.int8()),
+    ([1, 2, None], [pa.scalar(1, type=pa.int8()),
+     pa.scalar(2, type=pa.int8()), None], pa.int8()),
     ([1, None], [pa.scalar(1.0, type=pa.int32()), None], pa.int32()),
-    (["aaa", "bbb"], [pa.scalar("aaa", type=pa.binary(3)), pa.scalar("bbb", type=pa.binary(3))], pa.binary(3)),
+    (["aaa", "bbb"], [pa.scalar("aaa", type=pa.binary(3)),
+     pa.scalar("bbb", type=pa.binary(3))], pa.binary(3)),
     ([b"a"], [pa.scalar("a", type=pa.large_binary())], pa.large_binary()),
     (["a"], [pa.scalar("a", type=pa.large_string())], pa.large_string()),
     (
@@ -2403,7 +2407,8 @@ def test_array_accepts_pyarrow_scalar(seq, data, scalar_data):
     ),
     (
         ["a", "b"],
-        [pa.scalar("a", pa.dictionary(pa.int64(), pa.string())), pa.scalar("b", pa.dictionary(pa.int64(), pa.string()))],
+        [pa.scalar("a", pa.dictionary(pa.int64(), pa.string())),
+         pa.scalar("b", pa.dictionary(pa.int64(), pa.string()))],
         pa.dictionary(pa.int64(), pa.string())
     ),
     (
@@ -2413,12 +2418,14 @@ def test_array_accepts_pyarrow_scalar(seq, data, scalar_data):
     ),
     (
         [(1, 2)],
-        [pa.scalar([('a', 1), ('b', 2)], type=pa.struct([('a', pa.int8()), ('b', pa.int8())]))],
+        [pa.scalar([('a', 1), ('b', 2)], type=pa.struct(
+            [('a', pa.int8()), ('b', pa.int8())]))],
         pa.struct([('a', pa.int8()), ('b', pa.int8())])
     ),
     (
         [(1, 'bar')],
-        [pa.scalar([('a', 1), ('b', 'bar')], type=pa.struct([('a', pa.int8()), ('b', pa.string())]))],
+        [pa.scalar([('a', 1), ('b', 'bar')], type=pa.struct(
+            [('a', pa.int8()), ('b', pa.string())]))],
         pa.struct([('a', pa.int8()), ('b', pa.string())])
     )
 ])
@@ -2443,19 +2450,19 @@ def test_array_accepts_pyarrow_scalar_errors(seq):
     with pytest.raises(pa.ArrowInvalid,
                        match="cannot mix scalars with different types"):
         pa.array(sequence)
-    
+
     sequence = seq([1, pa.scalar("a"), None])
     with pytest.raises(pa.ArrowInvalid,
                        match="pyarrow scalars cannot be mixed with other "
                              "Python scalar values currently"):
         pa.array(sequence)
-    
+
     sequence = seq([np.float16("0.1"), pa.scalar("a"), None])
     with pytest.raises(pa.ArrowInvalid,
                        match="pyarrow scalars cannot be mixed with other "
                              "Python scalar values currently"):
         pa.array(sequence)
-    
+
     sequence = seq([pa.scalar("a"), np.float16("0.1"), None])
     with pytest.raises(pa.ArrowInvalid,
                        match="pyarrow scalars cannot be mixed with other "

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -2457,14 +2457,29 @@ def test_array_from_pylist_offset_overflow():
     )
 ])
 def test_array_accepts_pyarrow_scalar(seq, data, scalar_data, value_type):
-    if type(seq(scalar_data)) == set:
-        pytest.skip("TODO: The elements in the set get reordered.")
     expect = pa.array(data, type=value_type)
     result = pa.array(seq(scalar_data))
-    assert expect.equals(result)
+
+    if type(seq(scalar_data)) == set:
+        try:
+            import pyarrow.compute as pc
+            expect = [expect[a] for a in pc.array_sort_indices(expect).to_pylist()]
+            result = [result[a] for a in pc.array_sort_indices(result).to_pylist()]
+            expect == result
+        except pa.lib.ArrowNotImplementedError:
+            set(expect) == set(result)
+    else:
+        assert expect.equals(result)
 
     result = pa.array(seq(scalar_data), type=value_type)
-    assert expect.equals(result)
+    if type(seq(scalar_data)) == set:
+        try:
+            result = [result[a] for a in pc.array_sort_indices(result).to_pylist()]
+            expect == result
+        except pa.lib.ArrowNotImplementedError:
+            set(expect) == set(result)
+    else:
+        assert expect.equals(result)
 
 
 @parametrize_with_collections_types

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -2364,26 +2364,105 @@ def test_array_from_pylist_offset_overflow():
     assert len(arr) == 2**31
     assert len(arr.chunks) > 1
 
+@parametrize_with_collections_types
+@pytest.mark.parametrize(('data', 'scalar_data'), [
+    ([True, False, None], [pa.scalar(True), pa.scalar(False), None]),
+    ([1, 2, None], [pa.scalar(1), pa.scalar(2), None]),
+    ([1, None, None], [pa.scalar(1), None, pa.scalar(None, type=pa.int64())]),
+    ([None, None], [pa.scalar(None), pa.scalar(None)]),
+    ([1., 2., None], [pa.scalar(1.), pa.scalar(2.), None]),
+    ([None, datetime.date.today()], [None, pa.scalar(datetime.date.today())]),
+    ([datetime.time(1, 1, 1), None], [pa.scalar(datetime.time(1, 1, 1)), None]),
+    ([datetime.timedelta(seconds=10)],[pa.scalar(datetime.timedelta(seconds=10))]),
+    ([None, datetime.datetime(2014,1,1)], [None, pa.scalar(datetime.datetime(2014,1,1))]),
+    ([pa.MonthDayNano([1, -1, -10100])], [pa.scalar(pa.MonthDayNano([1, -1, -10100]))]),
+    (["a", "b"], [pa.scalar("a"), pa.scalar("b")]),
+    ([b"a", b"b"], [pa.scalar(b"a"), pa.scalar(b"b")]),
+    ([1, 2, 3], pa.scalar([1, 2, 3])),
+    (["a", "b"], pa.scalar(["a", "b"])),
+])
+def test_array_accepts_pyarrow_scalar(seq, data, scalar_data):
+    if type(seq(scalar_data)) == set:
+        pytest.skip("TODO: look at the reordering of the elements in the set")
+    expect = pa.array(data)
+    result = pa.array(seq(scalar_data))
+    assert expect.equals(result)
+
 
 @parametrize_with_collections_types
-def test_array_accepts_pyarrow_scalar(seq):
+@pytest.mark.parametrize(('data', 'scalar_data', 'value_type'), [
+    ([1, 2, None], [pa.scalar(1, type=pa.int8()), pa.scalar(2, type=pa.int8()), None], pa.int8()),
+    ([1, None], [pa.scalar(1.0, type=pa.int32()), None], pa.int32()),
+    (["aaa", "bbb"], [pa.scalar("aaa", type=pa.binary(3)), pa.scalar("bbb", type=pa.binary(3))], pa.binary(3)),
+    ([b"a"], [pa.scalar("a", type=pa.large_binary())], pa.large_binary()),
+    (["a"], [pa.scalar("a", type=pa.large_string())], pa.large_string()),
+    (
+        ["a"],
+        [pa.scalar("a", type=pa.dictionary(pa.int64(), pa.string()))],
+        pa.dictionary(pa.int64(), pa.string())
+    ),
+    (
+        ["a", "b"],
+        [pa.scalar("a", pa.dictionary(pa.int64(), pa.string())), pa.scalar("b", pa.dictionary(pa.int64(), pa.string()))],
+        pa.dictionary(pa.int64(), pa.string())
+    ),
+    (
+        [1],
+        [pa.scalar(1, type=pa.dictionary(pa.int64(), pa.int32()))],
+        pa.dictionary(pa.int64(), pa.int32())
+    ),
+    (
+        [(1, 2)],
+        [pa.scalar([('a', 1), ('b', 2)], type=pa.struct([('a', pa.int8()), ('b', pa.int8())]))],
+        pa.struct([('a', pa.int8()), ('b', pa.int8())])
+    ),
+    (
+        [(1, 'bar')],
+        [pa.scalar([('a', 1), ('b', 'bar')], type=pa.struct([('a', pa.int8()), ('b', pa.string())]))],
+        pa.struct([('a', pa.int8()), ('b', pa.string())])
+    )
+])
+def test_array_accepts_pyarrow_scalar_with_type(seq, data, scalar_data, value_type):
+    if type(seq(scalar_data)) == set:
+        pytest.skip("TODO: look at the reordering of the elements in the set")
+    expect = pa.array(data, type=value_type)
+    result = pa.array(seq(scalar_data), type=value_type)
+    assert expect.equals(result)
+
+
+def test_array_accepts_pyarrow_scalar_something():
+    arr = pa.array([1, 2, 3])
+    result = pa.array([arr.sum()])
+    expect = pa.array([6])
+    assert expect.equals(result)
+
+
+@parametrize_with_collections_types
+def test_array_accepts_pyarrow_scalar_errors(seq):
     sequence = seq([pa.scalar(1), pa.scalar("a"), pa.scalar(3.0)])
     with pytest.raises(pa.ArrowInvalid,
                        match="cannot mix scalars with different types"):
         pa.array(sequence)
-
+    
     sequence = seq([1, pa.scalar("a"), None])
     with pytest.raises(pa.ArrowInvalid,
                        match="pyarrow scalars cannot be mixed with other "
                              "Python scalar values currently"):
         pa.array(sequence)
+    
+    sequence = seq([np.float16("0.1"), pa.scalar("a"), None])
+    with pytest.raises(pa.ArrowInvalid,
+                       match="pyarrow scalars cannot be mixed with other "
+                             "Python scalar values currently"):
+        pa.array(sequence)
+    
+    sequence = seq([pa.scalar("a"), np.float16("0.1"), None])
+    with pytest.raises(pa.ArrowInvalid,
+                       match="pyarrow scalars cannot be mixed with other "
+                             "Python scalar values currently"):
+        pa.array(sequence)
 
-    # arr = pa.array([1, 2, 3])
-    # result = pa.array([arr.sum()])
-    # expect = pa.array([6])
-    # assert expect == result
-
-    # sequence = seq([pa.scalar(1), pa.scalar(2), pa.scalar(3)])
-    # result = pa.array(sequence)
-    # expect = pa.array([1, 2, 3])
-    # assert expect == result
+    with pytest.raises(pa.ArrowInvalid,
+                       match="Cannot append scalar of type string "
+                             "to builder for type int32"):
+        pa.array([pa.scalar("a")], type=pa.int32())

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -2366,38 +2366,53 @@ def test_array_from_pylist_offset_overflow():
 
 
 @parametrize_with_collections_types
-@pytest.mark.parametrize(('data', 'scalar_data'), [
-    ([True, False, None], [pa.scalar(True), pa.scalar(False), None]),
-    ([1, 2, None], [pa.scalar(1), pa.scalar(2), None]),
-    ([1, None, None], [pa.scalar(1), None, pa.scalar(None, type=pa.int64())]),
-    ([None, None], [pa.scalar(None), pa.scalar(None)]),
-    ([1., 2., None], [pa.scalar(1.), pa.scalar(2.), None]),
-    ([None, datetime.date.today()], [None, pa.scalar(datetime.date.today())]),
-    ([datetime.time(1, 1, 1), None], [pa.scalar(datetime.time(1, 1, 1)), None]),
-    ([datetime.timedelta(seconds=10)], [pa.scalar(datetime.timedelta(seconds=10))]),
-    ([None, datetime.datetime(2014, 1, 1)], [
-     None, pa.scalar(datetime.datetime(2014, 1, 1))]),
-    ([pa.MonthDayNano([1, -1, -10100])], [pa.scalar(pa.MonthDayNano([1, -1, -10100]))]),
-    (["a", "b"], [pa.scalar("a"), pa.scalar("b")]),
-    ([b"a", b"b"], [pa.scalar(b"a"), pa.scalar(b"b")]),
-    ([[1, 2, 3]], [pa.scalar([1, 2, 3])]),
-    ([["a", "b"]], [pa.scalar(["a", "b"])]),
-])
-def test_array_accepts_pyarrow_scalar(seq, data, scalar_data):
-    if type(seq(scalar_data)) == set:
-        pytest.skip("TODO: look at the reordering of the elements in the set")
-    expect = pa.array(data)
-    result = pa.array(seq(scalar_data))
-    assert expect.equals(result)
-
-
-@parametrize_with_collections_types
 @pytest.mark.parametrize(('data', 'scalar_data', 'value_type'), [
-    ([1, 2, None], [pa.scalar(1, type=pa.int8()),
-     pa.scalar(2, type=pa.int8()), None], pa.int8()),
+    ([True, False, None], [pa.scalar(True), pa.scalar(False), None], pa.bool_()),
+    ([1, 2, None], [pa.scalar(1), pa.scalar(2), None], pa.int64()),
+    ([1, None, None], [pa.scalar(1), None, pa.scalar(None, pa.int64())], pa.int64()),
+    ([None, None], [pa.scalar(None), pa.scalar(None)], pa.null()),
+    ([1., 2., None], [pa.scalar(1.), pa.scalar(2.), None], pa.float64()),
+    (
+        [None, datetime.date.today()],
+        [None, pa.scalar(datetime.date.today())],
+        pa.date32()),
+    (
+        [datetime.time(1, 1, 1), None],
+        [pa.scalar(datetime.time(1, 1, 1)), None],
+        pa.time64('us')),
+    (
+        [datetime.timedelta(seconds=10)],
+        [pa.scalar(datetime.timedelta(seconds=10))],
+        pa.duration('us')),
+    (
+        [None, datetime.datetime(2014, 1, 1)],
+        [None, pa.scalar(datetime.datetime(2014, 1, 1))],
+        pa.timestamp('us')
+    ),
+    (
+        [pa.MonthDayNano([1, -1, -10100])],
+        [pa.scalar(pa.MonthDayNano([1, -1, -10100]))],
+        pa.month_day_nano_interval()
+    ),
+    (["a", "b"], [pa.scalar("a"), pa.scalar("b")], pa.string()),
+    ([b"a", b"b"], [pa.scalar(b"a"), pa.scalar(b"b")], pa.binary()),
+    (
+        [b"a", b"b"],
+        [pa.scalar(b"a", pa.binary(1)), pa.scalar(b"b", pa.binary(1))],
+        pa.binary(1)
+    ),
+    ([[1, 2, 3]], [pa.scalar([1, 2, 3])], pa.list_(pa.int64())),
+    ([["a", "b"]], [pa.scalar(["a", "b"])], pa.list_(pa.string())),
+    (
+        [1, 2, None],
+        [pa.scalar(1, type=pa.int8()), pa.scalar(2, type=pa.int8()), None],
+        pa.int8()
+    ),
     ([1, None], [pa.scalar(1.0, type=pa.int32()), None], pa.int32()),
-    (["aaa", "bbb"], [pa.scalar("aaa", type=pa.binary(3)),
-     pa.scalar("bbb", type=pa.binary(3))], pa.binary(3)),
+    (
+        ["aaa", "bbb"],
+        [pa.scalar("aaa", type=pa.binary(3)), pa.scalar("bbb", type=pa.binary(3))],
+        pa.binary(3)),
     ([b"a"], [pa.scalar("a", type=pa.large_binary())], pa.large_binary()),
     (["a"], [pa.scalar("a", type=pa.large_string())], pa.large_string()),
     (
@@ -2429,10 +2444,13 @@ def test_array_accepts_pyarrow_scalar(seq, data, scalar_data):
         pa.struct([('a', pa.int8()), ('b', pa.string())])
     )
 ])
-def test_array_accepts_pyarrow_scalar_with_type(seq, data, scalar_data, value_type):
+def test_array_accepts_pyarrow_scalar(seq, data, scalar_data, value_type):
     if type(seq(scalar_data)) == set:
-        pytest.skip("TODO: look at the reordering of the elements in the set")
+        pytest.skip("TODO: The elements in the set get reordered.")
     expect = pa.array(data, type=value_type)
+    result = pa.array(seq(scalar_data))
+    assert expect.equals(result)
+
     result = pa.array(seq(scalar_data), type=value_type)
     assert expect.equals(result)
 

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -2368,7 +2368,7 @@ def test_array_from_pylist_offset_overflow():
 @parametrize_with_collections_types
 @pytest.mark.parametrize(('data', 'scalar_data', 'value_type'), [
     ([True, False, None], [pa.scalar(True), pa.scalar(False), None], pa.bool_()),
-    ([1, 2, None], [pa.scalar(1), pa.scalar(2), None], pa.int64()),
+    ([1, 2, None], [pa.scalar(1), pa.scalar(2), pa.scalar(None, pa.int64())], pa.int64()),
     ([1, None, None], [pa.scalar(1), None, pa.scalar(None, pa.int64())], pa.int64()),
     ([None, None], [pa.scalar(None), pa.scalar(None)], pa.null()),
     ([1., 2., None], [pa.scalar(1.), pa.scalar(2.), None], pa.float64()),

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -2463,13 +2463,6 @@ def test_array_accepts_pyarrow_scalar(seq, data, scalar_data, value_type):
     assert expect.equals(result)
 
 
-def test_array_accepts_pyarrow_scalar_from_compute():
-    arr = pa.array([1, 2, 3])
-    result = pa.array([arr.sum()])
-    expect = pa.array([6])
-    assert expect.equals(result)
-
-
 @parametrize_with_collections_types
 def test_array_accepts_pyarrow_scalar_errors(seq):
     sequence = seq([pa.scalar(1), pa.scalar("a"), pa.scalar(3.0)])

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -2375,15 +2375,23 @@ def test_array_from_pylist_offset_overflow():
     (
         [None, datetime.date.today()],
         [None, pa.scalar(datetime.date.today())],
-        pa.date32()),
+        pa.date32()
+    ),
+    (
+        [None, datetime.date.today()],
+        [None, pa.scalar(datetime.date.today(), pa.date64())],
+        pa.date64()
+    ),
     (
         [datetime.time(1, 1, 1), None],
         [pa.scalar(datetime.time(1, 1, 1)), None],
-        pa.time64('us')),
+        pa.time64('us')
+    ),
     (
         [datetime.timedelta(seconds=10)],
         [pa.scalar(datetime.timedelta(seconds=10))],
-        pa.duration('us')),
+        pa.duration('us')
+    ),
     (
         [None, datetime.datetime(2014, 1, 1)],
         [None, pa.scalar(datetime.datetime(2014, 1, 1))],


### PR DESCRIPTION
### Rationale for this change

Currently, `pyarrow.array `doesn't accept list of pyarrow Scalars and this PR adds a check to allow that.

* Closes: #21761