### PR TITLE
GH-35573: [Python] pa.FixedShapeTensorArray.to_numpy_ndarray fails on sliced arrays

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -3153,7 +3153,7 @@ class FixedShapeTensorArray(ExtensionArray):
         Note: ``permutation`` should be trivial (``None`` or ``[0, 1, ..., len(shape)-1]``).
         """
         if self.type.permutation is None or self.type.permutation == list(range(len(self.type.shape))):
-            np_flat = np.asarray(self.storage.values)
+            np_flat = np.asarray(self.storage.flatten())
             numpy_tensor = np_flat.reshape((len(self),) + tuple(self.type.shape))
             return numpy_tensor
         else:

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1198,6 +1198,10 @@ def test_tensor_class_methods():
     result = arr.to_numpy_ndarray()
     np.testing.assert_array_equal(result, expected)
 
+    expected = np.array([[[1, 2, 3], [4, 5, 6]]], dtype=np.float32)
+    result = arr[:1].to_numpy_ndarray()
+    np.testing.assert_array_equal(result, expected)
+
     arr = np.array(
         [[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]],
         dtype=np.float32, order="C")


### PR DESCRIPTION
### Rationale for this change
`pa.FixedShapeTensorArray.to_numpy_ndarray` fails if called on a sliced `FixedShapeTensorArray`.

### What changes are included in this PR?
The use of `pyarrow.FixedSizeListArray.values` is replaced with `pyarrow.FixedSizeListArray.flatten()` in `FixedShapeTensorArray.to_numpy_ndarray`.

### Are these changes tested?
Yes, test is added to _python/pyarrow/tests/test_extension_type.py_

### Are there any user-facing changes?
No.
* Closes: #35573