### PR TITLE
GH-36166: [C++][MATLAB] Add utility to convert UTF-8 strings to UTF-16 and UTF-16 strings to UTF-8

### DIFF
--- a/cpp/src/arrow/util/utf8.cc
+++ b/cpp/src/arrow/util/utf8.cc
@@ -146,14 +146,14 @@ std::string WideStringToUTF8Internal(const std::wstring& source) {
   return s;
 }
 
-std::string UTF16StringToUTF8Internal(const std::basic_string<char16_t>& source) {
+std::string UTF16StringToUTF8Internal(const std::u16string& source) {
   std::string s;
   ::utf8::utf16to8(source.begin(), source.end(), std::back_inserter(s));
   return s;
 }
 
-std::basic_string<char16_t> UTF8StringToUTF16Internal(const std::string& source) {
-  std::basic_string<char16_t> s;
+std::u16string UTF8StringToUTF16Internal(const std::string& source) {
+  std::u16string s;
   ::utf8::utf8to16(source.begin(), source.end(), std::back_inserter(s));
   return s;
 }
@@ -176,7 +176,7 @@ ARROW_EXPORT Result<std::string> WideStringToUTF8(const std::wstring& source) {
   }
 }
 
-ARROW_EXPORT Result<std::string> UTF16StringToUTF8(const std::basic_string<char16_t>& source) {
+ARROW_EXPORT Result<std::string> UTF16StringToUTF8(const std::u16string& source) {
   try {
     return UTF16StringToUTF8Internal(source);
   } catch (std::exception& e) {
@@ -184,7 +184,7 @@ ARROW_EXPORT Result<std::string> UTF16StringToUTF8(const std::basic_string<char1
   }
 }
 
-ARROW_EXPORT Result<std::basic_string<char16_t>> UTF8StringToUTF16(const std::string& source) {
+ARROW_EXPORT Result<std::u16string> UTF8StringToUTF16(const std::string& source) {
   try {
     return UTF8StringToUTF16Internal(source);
   } catch (std::exception& e) {

--- a/cpp/src/arrow/util/utf8.cc
+++ b/cpp/src/arrow/util/utf8.cc
@@ -146,6 +146,18 @@ std::string WideStringToUTF8Internal(const std::wstring& source) {
   return s;
 }
 
+std::string UTF16StringToUTF8Internal(const std::basic_string<char16_t>& source) {
+  std::string s;
+  ::utf8::utf16to8(source.begin(), source.end(), std::back_inserter(s));
+  return s;
+}
+
+std::basic_string<char16_t> UTF8StringToUTF16Internal(const std::string& source) {
+  std::basic_string<char16_t> s;
+  ::utf8::utf8to16(source.begin(), source.end(), std::back_inserter(s));
+  return s;
+}
+
 }  // namespace
 
 Result<std::wstring> UTF8ToWideString(std::string_view source) {
@@ -159,6 +171,22 @@ Result<std::wstring> UTF8ToWideString(std::string_view source) {
 ARROW_EXPORT Result<std::string> WideStringToUTF8(const std::wstring& source) {
   try {
     return WideStringToUTF8Internal(source);
+  } catch (std::exception& e) {
+    return Status::Invalid(e.what());
+  }
+}
+
+ARROW_EXPORT Result<std::string> UTF16StringToUTF8(const std::basic_string<char16_t>& source) {
+  try {
+    return UTF16StringToUTF8Internal(source);
+  } catch (std::exception& e) {
+    return Status::Invalid(e.what());
+  }
+}
+
+ARROW_EXPORT Result<std::basic_string<char16_t>> UTF8StringToUTF16(const std::string& source) {
+  try {
+    return UTF8StringToUTF16Internal(source);
   } catch (std::exception& e) {
     return Status::Invalid(e.what());
   }

--- a/cpp/src/arrow/util/utf8.h
+++ b/cpp/src/arrow/util/utf8.h
@@ -36,6 +36,12 @@ ARROW_EXPORT Result<std::wstring> UTF8ToWideString(std::string_view source);
 // Similarly, convert a wstring to a UTF8 string.
 ARROW_EXPORT Result<std::string> WideStringToUTF8(const std::wstring& source);
 
+// Convert UTF8 string to a UTF16 string.
+ARROW_EXPORT Result<std::basic_string<char16_t>> UTF8StringToUTF16(const std::string& source);
+
+// Convert UTF16 string to a UTF8 string.
+ARROW_EXPORT Result<std::string> UTF16StringToUTF8(const std::basic_string<char16_t>& source);
+
 // This function needs to be called before doing UTF8 validation.
 ARROW_EXPORT void InitializeUTF8();
 

--- a/cpp/src/arrow/util/utf8.h
+++ b/cpp/src/arrow/util/utf8.h
@@ -37,10 +37,10 @@ ARROW_EXPORT Result<std::wstring> UTF8ToWideString(std::string_view source);
 ARROW_EXPORT Result<std::string> WideStringToUTF8(const std::wstring& source);
 
 // Convert UTF8 string to a UTF16 string.
-ARROW_EXPORT Result<std::basic_string<char16_t>> UTF8StringToUTF16(const std::string& source);
+ARROW_EXPORT Result<std::u16string> UTF8StringToUTF16(const std::string& source);
 
 // Convert UTF16 string to a UTF8 string.
-ARROW_EXPORT Result<std::string> UTF16StringToUTF8(const std::basic_string<char16_t>& source);
+ARROW_EXPORT Result<std::string> UTF16StringToUTF8(const std::u16string& source);
 
 // This function needs to be called before doing UTF8 validation.
 ARROW_EXPORT void InitializeUTF8();

--- a/cpp/src/arrow/util/utf8_util_test.cc
+++ b/cpp/src/arrow/util/utf8_util_test.cc
@@ -398,9 +398,9 @@ TEST(WideStringToUTF8, Basics) {
 }
 
 TEST(UTF8StringToUTF16, Basics) {
-  auto CheckOk = [](const std::string& s, const std::basic_string<char16_t>& expected) -> void {
-    ASSERT_OK_AND_ASSIGN(std::basic_string<char16_t> utf16String, UTF8StringToUTF16(s));
-    ASSERT_EQ(utf16String, expected);
+  auto CheckOk = [](const std::string& s, const std::u16string& expected) -> void {
+    ASSERT_OK_AND_ASSIGN(std::u16string u16s, UTF8StringToUTF16(s));
+    ASSERT_EQ(u16s, expected);
   };
 
   auto CheckInvalid = [](const std::string& s) -> void {
@@ -419,13 +419,13 @@ TEST(UTF8StringToUTF16, Basics) {
 }
 
 TEST(UTF16StringToUTF8, Basics) {
-  auto CheckOk = [](const std::basic_string<char16_t>& utf16String, const std::string& expected) -> void {
-    ASSERT_OK_AND_ASSIGN(std::string s, UTF16StringToUTF8(utf16String));
+  auto CheckOk = [](const std::u16string& u16s, const std::string& expected) -> void {
+    ASSERT_OK_AND_ASSIGN(std::string s, UTF16StringToUTF8(u16s));
     ASSERT_EQ(s, expected);
   };
 
-  auto CheckInvalid = [](const std::basic_string<char16_t>& utf16String) -> void {
-    ASSERT_RAISES(Invalid, UTF16StringToUTF8(utf16String));
+  auto CheckInvalid = [](const std::u16string& u16s) -> void {
+    ASSERT_RAISES(Invalid, UTF16StringToUTF8(u16s));
   };
 
   CheckOk(u"", "");


### PR DESCRIPTION
### Rationale for this change

MATLAB uses UTF-16 encoded strings, but arrow uses UTF-8.  We need a way to convert between the two encodings. 

### What changes are included in this PR?

Added two new utility functions:

1. `std::string UTF16StringToUTF8(const std::basic_string<char16_t>& source)`
2. `std::basic_string<char16_t> UTF8StringToUTF16(const std::string& source)` 

### Are these changes tested?

Added two test cases to `utf8_util_test.cc`:

1. `UTF16StringToUTF8`
2. `UTF8StringToUTF16`


### Are there any user-facing changes?
No, these APIs are intended for developers.

### Future Directions

In a followup PR, we will update the MATLAB Interface source code to use these utilities when converting between UTF16 and UTF8 encoded strings.
* Closes: #36166