### PR TITLE
GH-36198: [Go] Remove deprecated equality checks

### DIFF
--- a/go/arrow/array/compare.go
+++ b/go/arrow/array/compare.go
@@ -37,7 +37,7 @@ func RecordEqual(left, right arrow.Record) bool {
 	for i := range left.Columns() {
 		lc := left.Column(i)
 		rc := right.Column(i)
-		if !ArrayEqual(lc, rc) {
+		if !Equal(lc, rc) {
 			return false
 		}
 	}
@@ -196,15 +196,6 @@ func TableApproxEqual(left, right arrow.Table, opts ...EqualOption) bool {
 	return true
 }
 
-// ArrayEqual reports whether the two provided arrays are equal.
-//
-// Deprecated: This currently just delegates to calling Equal. This will be
-// removed in v9 so please update any calling code to just call array.Equal
-// directly instead.
-func ArrayEqual(left, right arrow.Array) bool {
-	return Equal(left, right)
-}
-
 // Equal reports whether the two provided arrays are equal.
 func Equal(left, right arrow.Array) bool {
 	switch {
@@ -342,14 +333,6 @@ func Equal(left, right arrow.Array) bool {
 	}
 }
 
-// ArraySliceEqual reports whether slices left[lbeg:lend] and right[rbeg:rend] are equal.
-//
-// Deprecated: Renamed to just array.SliceEqual, this currently will just delegate to the renamed
-// function and will be removed in v9. Please update any calling code.
-func ArraySliceEqual(left arrow.Array, lbeg, lend int64, right arrow.Array, rbeg, rend int64) bool {
-	return SliceEqual(left, lbeg, lend, right, rbeg, rend)
-}
-
 // SliceEqual reports whether slices left[lbeg:lend] and right[rbeg:rend] are equal.
 func SliceEqual(left arrow.Array, lbeg, lend int64, right arrow.Array, rbeg, rend int64) bool {
 	l := NewSlice(left, lbeg, lend)
@@ -358,14 +341,6 @@ func SliceEqual(left arrow.Array, lbeg, lend int64, right arrow.Array, rbeg, ren
 	defer r.Release()
 
 	return Equal(l, r)
-}
-
-// ArraySliceApproxEqual reports whether slices left[lbeg:lend] and right[rbeg:rend] are approximately equal.
-//
-// Deprecated: renamed to just SliceApproxEqual and will be removed in v9. Please update
-// calling code to just call array.SliceApproxEqual.
-func ArraySliceApproxEqual(left arrow.Array, lbeg, lend int64, right arrow.Array, rbeg, rend int64, opts ...EqualOption) bool {
-	return SliceApproxEqual(left, lbeg, lend, right, rbeg, rend, opts...)
 }
 
 // SliceApproxEqual reports whether slices left[lbeg:lend] and right[rbeg:rend] are approximately equal.
@@ -459,17 +434,8 @@ func WithUnorderedMapKeys(v bool) EqualOption {
 	}
 }
 
-// ArrayApproxEqual reports whether the two provided arrays are approximately equal.
-// For non-floating point arrays, it is equivalent to ArrayEqual.
-//
-// Deprecated: renamed to just ApproxEqual, this alias will be removed in v9. Please update
-// calling code to just call array.ApproxEqual
-func ArrayApproxEqual(left, right arrow.Array, opts ...EqualOption) bool {
-	return ApproxEqual(left, right, opts...)
-}
-
 // ApproxEqual reports whether the two provided arrays are approximately equal.
-// For non-floating point arrays, it is equivalent to ArrayEqual.
+// For non-floating point arrays, it is equivalent to Equal.
 func ApproxEqual(left, right arrow.Array, opts ...EqualOption) bool {
 	opt := newEqualOption(opts...)
 	return arrayApproxEqual(left, right, opt)

--- a/go/arrow/array/compare_test.go
+++ b/go/arrow/array/compare_test.go
@@ -38,7 +38,7 @@ func TestArrayEqual(t *testing.T) {
 			for i, col := range rec.Columns() {
 				t.Run(schema.Field(i).Name, func(t *testing.T) {
 					arr := col
-					if !array.ArrayEqual(arr, arr) {
+					if !array.Equal(arr, arr) {
 						t.Fatalf("identical arrays should compare equal:\narray=%v", arr)
 					}
 					sub1 := array.NewSlice(arr, 1, int64(arr.Len()))
@@ -47,7 +47,7 @@ func TestArrayEqual(t *testing.T) {
 					sub2 := array.NewSlice(arr, 0, int64(arr.Len()-1))
 					defer sub2.Release()
 
-					if array.ArrayEqual(sub1, sub2) && name != "nulls" {
+					if array.Equal(sub1, sub2) && name != "nulls" {
 						t.Fatalf("non-identical arrays should not compare equal:\nsub1=%v\nsub2=%v\narrf=%v\n", sub1, sub2, arr)
 					}
 				})
@@ -465,7 +465,7 @@ func TestArrayEqualBaseArray(t *testing.T) {
 	a2 := b2.NewBooleanArray()
 	defer a2.Release()
 
-	if array.ArrayEqual(a1, a2) {
+	if array.Equal(a1, a2) {
 		t.Errorf("two arrays with different lengths must not be equal")
 	}
 
@@ -475,7 +475,7 @@ func TestArrayEqualBaseArray(t *testing.T) {
 	a3 := b3.NewBooleanArray()
 	defer a3.Release()
 
-	if array.ArrayEqual(a1, a3) {
+	if array.Equal(a1, a3) {
 		t.Errorf("two arrays with different number of null values must not be equal")
 	}
 
@@ -485,7 +485,7 @@ func TestArrayEqualBaseArray(t *testing.T) {
 	a4 := b4.NewInt32Array()
 	defer a4.Release()
 
-	if array.ArrayEqual(a1, a4) {
+	if array.Equal(a1, a4) {
 		t.Errorf("two arrays with different types must not be equal")
 	}
 
@@ -497,7 +497,7 @@ func TestArrayEqualBaseArray(t *testing.T) {
 	defer a5.Release()
 	b1.AppendNull()
 
-	if array.ArrayEqual(a1, a5) {
+	if array.Equal(a1, a5) {
 		t.Errorf("two arrays with different validity bitmaps must not be equal")
 	}
 }
@@ -509,7 +509,7 @@ func TestArrayEqualNull(t *testing.T) {
 	null := array.NewNull(0)
 	defer null.Release()
 
-	if !array.ArrayEqual(null, null) {
+	if !array.Equal(null, null) {
 		t.Fatalf("identical arrays should compare equal")
 	}
 
@@ -519,13 +519,13 @@ func TestArrayEqualNull(t *testing.T) {
 	n1 := array.NewNull(10)
 	defer n1.Release()
 
-	if !array.ArrayEqual(n0, n0) {
+	if !array.Equal(n0, n0) {
 		t.Fatalf("identical arrays should compare equal")
 	}
-	if !array.ArrayEqual(n1, n1) {
+	if !array.Equal(n1, n1) {
 		t.Fatalf("identical arrays should compare equal")
 	}
-	if !array.ArrayEqual(n0, n1) || !array.ArrayEqual(n1, n0) {
+	if !array.Equal(n0, n1) || !array.Equal(n1, n0) {
 		t.Fatalf("n0 and n1 should compare equal")
 	}
 
@@ -536,11 +536,11 @@ func TestArrayEqualNull(t *testing.T) {
 	sub19 := array.NewSlice(n0, 1, 9)
 	defer sub19.Release()
 
-	if !array.ArrayEqual(sub08, sub19) {
+	if !array.Equal(sub08, sub19) {
 		t.Fatalf("sub08 and sub19 should compare equal")
 	}
 
-	if array.ArrayEqual(sub08, sub07) {
+	if array.Equal(sub08, sub07) {
 		t.Fatalf("sub08 and sub07 should not compare equal")
 	}
 }
@@ -562,11 +562,11 @@ func TestArrayEqualMaskedArray(t *testing.T) {
 	a2 := ab.NewInt32Array()
 	defer a2.Release()
 
-	if !array.ArrayEqual(a1, a1) || !array.ArrayEqual(a2, a2) {
+	if !array.Equal(a1, a1) || !array.Equal(a2, a2) {
 		t.Errorf("an array must be equal to itself")
 	}
 
-	if !array.ArrayEqual(a1, a2) {
+	if !array.Equal(a1, a2) {
 		t.Errorf("%v must be equal to %v", a1, a2)
 	}
 }
@@ -589,11 +589,11 @@ func TestArrayEqualDifferentMaskedValues(t *testing.T) {
 	a2 := ab.NewInt32Array()
 	defer a2.Release()
 
-	if !array.ArrayEqual(a1, a1) || !array.ArrayEqual(a2, a2) {
+	if !array.Equal(a1, a1) || !array.Equal(a2, a2) {
 		t.Errorf("an array must be equal to itself")
 	}
 
-	if !array.ArrayEqual(a1, a2) {
+	if !array.Equal(a1, a2) {
 		t.Errorf("%v must be equal to %v", a1, a2)
 	}
 }

--- a/go/arrow/array/concat_test.go
+++ b/go/arrow/array/concat_test.go
@@ -56,7 +56,7 @@ func TestConcatenateValueBuffersNull(t *testing.T) {
 	assert.NoError(t, err)
 	defer actual.Release()
 
-	assert.True(t, array.ArrayEqual(actual, inputs[1]))
+	assert.True(t, array.Equal(actual, inputs[1]))
 }
 
 func TestConcatenate(t *testing.T) {
@@ -324,7 +324,7 @@ func (cts *ConcatTestSuite) TestCheckConcat() {
 					cts.NoError(err)
 					defer actual.Release()
 
-					cts.Truef(array.ArrayEqual(expected, actual), "expected: %s\ngot: %s\n", expected, actual)
+					cts.Truef(array.Equal(expected, actual), "expected: %s\ngot: %s\n", expected, actual)
 					if len(actual.Data().Buffers()) > 0 {
 						if actual.Data().Buffers()[0] != nil {
 							cts.checkTrailingBitsZeroed(actual.Data().Buffers()[0], int64(actual.Len()))

--- a/go/arrow/array/dictionary.go
+++ b/go/arrow/array/dictionary.go
@@ -251,7 +251,7 @@ func (d *Dictionary) CanCompareIndices(other *Dictionary) bool {
 	}
 
 	minlen := int64(min(d.data.dictionary.length, other.data.dictionary.length))
-	return ArraySliceEqual(d.Dictionary(), 0, minlen, other.Dictionary(), 0, minlen)
+	return SliceEqual(d.Dictionary(), 0, minlen, other.Dictionary(), 0, minlen)
 }
 
 func (d *Dictionary) ValueStr(i int) string {
@@ -306,7 +306,7 @@ func (d *Dictionary) MarshalJSON() ([]byte, error) {
 }
 
 func arrayEqualDict(l, r *Dictionary) bool {
-	return ArrayEqual(l.Dictionary(), r.Dictionary()) && ArrayEqual(l.indices, r.indices)
+	return Equal(l.Dictionary(), r.Dictionary()) && Equal(l.indices, r.indices)
 }
 
 func arrayApproxEqualDict(l, r *Dictionary, opt equalOption) bool {

--- a/go/arrow/array/dictionary_test.go
+++ b/go/arrow/array/dictionary_test.go
@@ -106,7 +106,7 @@ func (p *PrimitiveDictionaryTestSuite) TestDictionaryBuilderBasic() {
 	expected := array.NewDictionaryArray(expectedType, expectedIndices, expectedDict)
 	defer expected.Release()
 
-	p.True(array.ArrayEqual(expected, arr))
+	p.True(array.Equal(expected, arr))
 }
 
 func (p *PrimitiveDictionaryTestSuite) TestDictionaryBuilderInit() {
@@ -139,7 +139,7 @@ func (p *PrimitiveDictionaryTestSuite) TestDictionaryBuilderInit() {
 	expected := array.NewDictionaryArray(dictType, expectedIndices, dictArr)
 	defer expected.Release()
 
-	p.True(array.ArrayEqual(expected, arr))
+	p.True(array.Equal(expected, arr))
 }
 
 func (p *PrimitiveDictionaryTestSuite) TestDictionaryNewBuilder() {
@@ -172,7 +172,7 @@ func (p *PrimitiveDictionaryTestSuite) TestDictionaryNewBuilder() {
 	expected := array.NewDictionaryArray(dictType, expectedIndices, dictArr)
 	defer expected.Release()
 
-	p.True(array.ArrayEqual(expected, arr))
+	p.True(array.Equal(expected, arr))
 }
 
 func (p *PrimitiveDictionaryTestSuite) TestDictionaryBuilderAppendArr() {
@@ -200,7 +200,7 @@ func (p *PrimitiveDictionaryTestSuite) TestDictionaryBuilderAppendArr() {
 	expected := array.NewDictionaryArray(expectedType, expectedIndices, expectedDict)
 	defer expected.Release()
 
-	p.True(array.ArrayEqual(expected, result))
+	p.True(array.Equal(expected, result))
 }
 
 func (p *PrimitiveDictionaryTestSuite) TestDictionaryBuilderDeltaDictionary() {
@@ -226,7 +226,7 @@ func (p *PrimitiveDictionaryTestSuite) TestDictionaryBuilderDeltaDictionary() {
 	defer exindices.Release()
 	expected := array.NewDictionaryArray(result.DataType().(*arrow.DictionaryType), exindices, exdict)
 	defer expected.Release()
-	p.True(array.ArrayEqual(expected, result))
+	p.True(array.Equal(expected, result))
 
 	p.Nil(appfn.Call([]reflect.Value{reflect.ValueOf(2).Convert(p.reftyp)})[0].Interface())
 	p.Nil(appfn.Call([]reflect.Value{reflect.ValueOf(3).Convert(p.reftyp)})[0].Interface())
@@ -244,8 +244,8 @@ func (p *PrimitiveDictionaryTestSuite) TestDictionaryBuilderDeltaDictionary() {
 	exdelta, _, _ := array.FromJSON(p.mem, p.typ, strings.NewReader("[3]"))
 	defer exdelta.Release()
 
-	p.True(array.ArrayEqual(exindices, indices))
-	p.True(array.ArrayEqual(exdelta, delta))
+	p.True(array.Equal(exindices, indices))
+	p.True(array.Equal(exdelta, delta))
 }
 
 func (p *PrimitiveDictionaryTestSuite) TestDictionaryBuilderDoubleDeltaDictionary() {
@@ -271,7 +271,7 @@ func (p *PrimitiveDictionaryTestSuite) TestDictionaryBuilderDoubleDeltaDictionar
 	defer exindices.Release()
 	expected := array.NewDictionaryArray(result.DataType().(*arrow.DictionaryType), exindices, exdict)
 	defer expected.Release()
-	p.True(array.ArrayEqual(expected, result))
+	p.True(array.Equal(expected, result))
 
 	p.Nil(appfn.Call([]reflect.Value{reflect.ValueOf(2).Convert(p.reftyp)})[0].Interface())
 	p.Nil(appfn.Call([]reflect.Value{reflect.ValueOf(3).Convert(p.reftyp)})[0].Interface())
@@ -289,8 +289,8 @@ func (p *PrimitiveDictionaryTestSuite) TestDictionaryBuilderDoubleDeltaDictionar
 	exdelta, _, _ := array.FromJSON(p.mem, p.typ, strings.NewReader("[3]"))
 	defer exdelta.Release()
 
-	p.True(array.ArrayEqual(exindices, indices))
-	p.True(array.ArrayEqual(exdelta, delta))
+	p.True(array.Equal(exindices, indices))
+	p.True(array.Equal(exdelta, delta))
 
 	p.Nil(appfn.Call([]reflect.Value{reflect.ValueOf(1).Convert(p.reftyp)})[0].Interface())
 	p.Nil(appfn.Call([]reflect.Value{reflect.ValueOf(2).Convert(p.reftyp)})[0].Interface())
@@ -308,8 +308,8 @@ func (p *PrimitiveDictionaryTestSuite) TestDictionaryBuilderDoubleDeltaDictionar
 	exdelta, _, _ = array.FromJSON(p.mem, p.typ, strings.NewReader("[4, 5]"))
 	defer exdelta.Release()
 
-	p.True(array.ArrayEqual(exindices, indices))
-	p.True(array.ArrayEqual(exdelta, delta))
+	p.True(array.Equal(exindices, indices))
+	p.True(array.Equal(exdelta, delta))
 }
 
 func (p *PrimitiveDictionaryTestSuite) TestNewResetBehavior() {
@@ -369,8 +369,8 @@ func (p *PrimitiveDictionaryTestSuite) TestResetFull() {
 	defer exindices.Release()
 	defer exdict.Release()
 
-	p.True(array.ArrayEqual(exindices, result.Indices()))
-	p.True(array.ArrayEqual(exdict, result.Dictionary()))
+	p.True(array.Equal(exindices, result.Indices()))
+	p.True(array.Equal(exdict, result.Dictionary()))
 
 	bldr.ResetFull()
 	p.Nil(appfn.Call([]reflect.Value{reflect.ValueOf(4).Convert(p.reftyp)})[0].Interface())
@@ -382,8 +382,8 @@ func (p *PrimitiveDictionaryTestSuite) TestResetFull() {
 	defer exindices.Release()
 	defer exdict.Release()
 
-	p.True(array.ArrayEqual(exindices, result.Indices()))
-	p.True(array.ArrayEqual(exdict, result.Dictionary()))
+	p.True(array.Equal(exindices, result.Indices()))
+	p.True(array.Equal(exdict, result.Dictionary()))
 }
 
 func (p *PrimitiveDictionaryTestSuite) TestStringRoundTrip() {
@@ -448,7 +448,7 @@ func TestBasicStringDictionaryBuilder(t *testing.T) {
 	expected := array.NewDictionaryArray(dictType, exint, exdict)
 	defer expected.Release()
 
-	assert.True(t, array.ArrayEqual(expected, result))
+	assert.True(t, array.Equal(expected, result))
 }
 
 func TestStringDictionaryInsertValues(t *testing.T) {
@@ -490,7 +490,7 @@ func TestStringDictionaryInsertValues(t *testing.T) {
 	defer exindices.Release()
 	expected := array.NewDictionaryArray(dictType, exindices, exdict)
 	defer expected.Release()
-	assert.True(t, array.ArrayEqual(expected, result))
+	assert.True(t, array.Equal(expected, result))
 }
 
 func TestStringDictionaryBuilderInit(t *testing.T) {
@@ -517,7 +517,7 @@ func TestStringDictionaryBuilderInit(t *testing.T) {
 	expected := array.NewDictionaryArray(dictType, intarr, dictArr)
 	defer expected.Release()
 
-	assert.True(t, array.ArrayEqual(expected, result))
+	assert.True(t, array.Equal(expected, result))
 }
 
 func TestStringDictionaryBuilderOnlyNull(t *testing.T) {
@@ -540,7 +540,7 @@ func TestStringDictionaryBuilderOnlyNull(t *testing.T) {
 	expected := array.NewDictionaryArray(dictType, intarr, dict)
 	defer expected.Release()
 
-	assert.True(t, array.ArrayEqual(expected, result))
+	assert.True(t, array.Equal(expected, result))
 }
 
 func TestStringDictionaryBuilderDelta(t *testing.T) {
@@ -568,7 +568,7 @@ func TestStringDictionaryBuilderDelta(t *testing.T) {
 	expected := array.NewDictionaryArray(dictType, exint, exdict)
 	defer expected.Release()
 
-	assert.True(t, array.ArrayEqual(expected, result))
+	assert.True(t, array.Equal(expected, result))
 
 	assert.NoError(t, builder.AppendString("test2"))
 	assert.NoError(t, builder.AppendString("test3"))
@@ -584,8 +584,8 @@ func TestStringDictionaryBuilderDelta(t *testing.T) {
 	exint, _, _ = array.FromJSON(mem, arrow.PrimitiveTypes.Int8, strings.NewReader("[1, 2, 1]"))
 	defer exint.Release()
 
-	assert.True(t, array.ArrayEqual(exdelta, delta))
-	assert.True(t, array.ArrayEqual(exint, indices))
+	assert.True(t, array.Equal(exdelta, delta))
+	assert.True(t, array.Equal(exint, indices))
 }
 
 func TestStringDictionaryBuilderBigDelta(t *testing.T) {
@@ -626,7 +626,7 @@ func TestStringDictionaryBuilderBigDelta(t *testing.T) {
 	expected := array.NewDictionaryArray(dictType, intarr, strarr)
 	defer expected.Release()
 
-	assert.True(t, array.ArrayEqual(expected, result))
+	assert.True(t, array.Equal(expected, result))
 
 	strbldr2 := array.NewStringBuilder(mem)
 	defer strbldr2.Release()
@@ -652,8 +652,8 @@ func TestStringDictionaryBuilderBigDelta(t *testing.T) {
 	intarr2 := intbldr2.NewInt16Array()
 	defer intarr2.Release()
 
-	assert.True(t, array.ArrayEqual(intarr2, indices2))
-	assert.True(t, array.ArrayEqual(strarr2, delta2))
+	assert.True(t, array.Equal(intarr2, indices2))
+	assert.True(t, array.Equal(strarr2, delta2))
 
 	strbldr3 := array.NewStringBuilder(mem)
 	defer strbldr3.Release()
@@ -679,8 +679,8 @@ func TestStringDictionaryBuilderBigDelta(t *testing.T) {
 	intarr3 := intbldr3.NewInt16Array()
 	defer intarr3.Release()
 
-	assert.True(t, array.ArrayEqual(intarr3, indices3))
-	assert.True(t, array.ArrayEqual(strarr3, delta3))
+	assert.True(t, array.Equal(intarr3, indices3))
+	assert.True(t, array.Equal(strarr3, delta3))
 }
 
 func TestFixedSizeBinaryDictionaryBuilder(t *testing.T) {
@@ -719,7 +719,7 @@ func TestFixedSizeBinaryDictionaryBuilder(t *testing.T) {
 	expected := array.NewDictionaryArray(dictType, intArr, fsbArr)
 	defer expected.Release()
 
-	assert.True(t, array.ArrayEqual(expected, result))
+	assert.True(t, array.Equal(expected, result))
 }
 
 func TestFixedSizeBinaryDictionaryBuilderInit(t *testing.T) {
@@ -752,7 +752,7 @@ func TestFixedSizeBinaryDictionaryBuilderInit(t *testing.T) {
 	expected := array.NewDictionaryArray(dictType, indices, dictArr)
 	defer expected.Release()
 
-	assert.True(t, array.ArrayEqual(expected, result))
+	assert.True(t, array.Equal(expected, result))
 }
 
 func TestFixedSizeBinaryDictionaryBuilderMakeBuilder(t *testing.T) {
@@ -785,7 +785,7 @@ func TestFixedSizeBinaryDictionaryBuilderMakeBuilder(t *testing.T) {
 	expected := array.NewDictionaryArray(dictType, indices, dictArr)
 	defer expected.Release()
 
-	assert.True(t, array.ArrayEqual(expected, result))
+	assert.True(t, array.Equal(expected, result))
 }
 
 func TestFixedSizeBinaryDictionaryBuilderDeltaDictionary(t *testing.T) {
@@ -823,7 +823,7 @@ func TestFixedSizeBinaryDictionaryBuilderDeltaDictionary(t *testing.T) {
 
 	expected := array.NewDictionaryArray(dictType, intArr1, fsbArr1)
 	defer expected.Release()
-	assert.True(t, array.ArrayEqual(expected, result1))
+	assert.True(t, array.Equal(expected, result1))
 
 	assert.NoError(t, builder.Append(test))
 	assert.NoError(t, builder.Append(test2))
@@ -842,8 +842,8 @@ func TestFixedSizeBinaryDictionaryBuilderDeltaDictionary(t *testing.T) {
 	intArr2 := intBuilder.NewInt8Array()
 	defer intArr2.Release()
 
-	assert.True(t, array.ArrayEqual(intArr2, indices2))
-	assert.True(t, array.ArrayEqual(fsbArr2, delta2))
+	assert.True(t, array.Equal(intArr2, indices2))
+	assert.True(t, array.Equal(fsbArr2, delta2))
 }
 
 func TestFixedSizeBinaryDictionaryStringRoundTrip(t *testing.T) {
@@ -904,7 +904,7 @@ func TestDecimal128DictionaryBuilderBasic(t *testing.T) {
 	expected := array.NewDictionaryArray(dictType, indices, dict)
 	defer expected.Release()
 
-	assert.True(t, array.ArrayApproxEqual(expected, result))
+	assert.True(t, array.ApproxEqual(expected, result))
 }
 
 func TestDecimal256DictionaryBuilderBasic(t *testing.T) {
@@ -932,7 +932,7 @@ func TestDecimal256DictionaryBuilderBasic(t *testing.T) {
 	expected := array.NewDictionaryArray(dictType, indices, dict)
 	defer expected.Release()
 
-	assert.True(t, array.ArrayApproxEqual(expected, result))
+	assert.True(t, array.ApproxEqual(expected, result))
 }
 
 func TestNullDictionaryBuilderBasic(t *testing.T) {
@@ -1009,15 +1009,15 @@ func TestDictionaryEquals(t *testing.T) {
 		arr4.Release()
 	}()
 
-	assert.True(t, array.ArrayEqual(arr, arr))
+	assert.True(t, array.Equal(arr, arr))
 	// equal because the unequal index is masked by null
-	assert.True(t, array.ArrayEqual(arr, arr2))
+	assert.True(t, array.Equal(arr, arr2))
 	// unequal dictionaries
-	assert.False(t, array.ArrayEqual(arr, arr3))
+	assert.False(t, array.Equal(arr, arr3))
 	// unequal indices
-	assert.False(t, array.ArrayEqual(arr, arr4))
-	assert.True(t, array.ArraySliceEqual(arr, 3, 6, arr4, 3, 6))
-	assert.False(t, array.ArraySliceEqual(arr, 1, 3, arr4, 1, 3))
+	assert.False(t, array.Equal(arr, arr4))
+	assert.True(t, array.SliceEqual(arr, 3, 6, arr4, 3, 6))
+	assert.False(t, array.SliceEqual(arr, 1, 3, arr4, 1, 3))
 
 	sz := arr.Len()
 	slice := array.NewSlice(arr, 2, int64(sz))
@@ -1026,8 +1026,8 @@ func TestDictionaryEquals(t *testing.T) {
 	defer slice2.Release()
 
 	assert.Equal(t, sz-2, slice.Len())
-	assert.True(t, array.ArrayEqual(slice, slice2))
-	assert.True(t, array.ArraySliceEqual(arr, 2, int64(arr.Len()), slice, 0, int64(slice.Len())))
+	assert.True(t, array.Equal(slice, slice2))
+	assert.True(t, array.SliceEqual(arr, 2, int64(arr.Len()), slice, 0, int64(slice.Len())))
 
 	// chained slice
 	slice2 = array.NewSlice(arr, 1, int64(arr.Len()))
@@ -1035,15 +1035,15 @@ func TestDictionaryEquals(t *testing.T) {
 	slice2 = array.NewSlice(slice2, 1, int64(slice2.Len()))
 	defer slice2.Release()
 
-	assert.True(t, array.ArrayEqual(slice, slice2))
+	assert.True(t, array.Equal(slice, slice2))
 	slice = array.NewSlice(arr, 1, 4)
 	defer slice.Release()
 	slice2 = array.NewSlice(arr, 1, 4)
 	defer slice2.Release()
 
 	assert.Equal(t, 3, slice.Len())
-	assert.True(t, array.ArrayEqual(slice, slice2))
-	assert.True(t, array.ArraySliceEqual(arr, 1, 4, slice, 0, int64(slice.Len())))
+	assert.True(t, array.Equal(slice, slice2))
+	assert.True(t, array.SliceEqual(arr, 1, 4, slice, 0, int64(slice.Len())))
 }
 
 func TestDictionaryIndexTypes(t *testing.T) {
@@ -1082,7 +1082,7 @@ func TestDictionaryIndexTypes(t *testing.T) {
 			expectedIndices, _, _ := array.FromJSON(mem, indextyp, strings.NewReader("[0, 1, 0, 2, null]"))
 			defer expectedIndices.Release()
 
-			assert.True(t, array.ArrayEqual(expectedIndices, result.Indices()))
+			assert.True(t, array.Equal(expectedIndices, result.Indices()))
 		})
 	}
 }
@@ -1188,7 +1188,7 @@ func TestListOfDictionary(t *testing.T) {
 	defer arr.Release()
 
 	actualDict := arr.(*array.List).ListValues().(*array.Dictionary)
-	assert.True(t, array.ArrayEqual(expectedDict, actualDict.Dictionary()))
+	assert.True(t, array.Equal(expectedDict, actualDict.Dictionary()))
 }
 
 func TestDictionaryCanCompareIndices(t *testing.T) {

--- a/go/arrow/array/util_test.go
+++ b/go/arrow/array/util_test.go
@@ -133,7 +133,7 @@ func TestStringsJSON(t *testing.T) {
 			assert.NoError(t, err)
 			defer arr.Release()
 
-			assert.Truef(t, array.ArrayEqual(expected, arr), "expected: %s\ngot: %s\n", expected, arr)
+			assert.Truef(t, array.Equal(expected, arr), "expected: %s\ngot: %s\n", expected, arr)
 
 			data, err := json.Marshal(arr)
 			assert.NoError(t, err)
@@ -154,7 +154,7 @@ func TestStringsJSON(t *testing.T) {
 			assert.NoError(t, err)
 			defer arr.Release()
 
-			assert.Truef(t, array.ArrayEqual(expected, arr), "expected: %s\ngot: %s\n", expected, arr)
+			assert.Truef(t, array.Equal(expected, arr), "expected: %s\ngot: %s\n", expected, arr)
 
 			data, err := json.Marshal(arr)
 			assert.NoError(t, err)
@@ -276,7 +276,7 @@ func TestDurationsJSON(t *testing.T) {
 		assert.NoError(t, err)
 		defer arr.Release()
 
-		assert.Truef(t, array.ArrayEqual(expected, arr), "expected: %s\ngot: %s\n", expected, arr)
+		assert.Truef(t, array.Equal(expected, arr), "expected: %s\ngot: %s\n", expected, arr)
 	}
 }
 
@@ -303,7 +303,7 @@ func TestTimestampsJSON(t *testing.T) {
 		assert.NoError(t, err)
 		defer arr.Release()
 
-		assert.Truef(t, array.ArrayEqual(expected, arr), "expected: %s\ngot: %s\n", expected, arr)
+		assert.Truef(t, array.Equal(expected, arr), "expected: %s\ngot: %s\n", expected, arr)
 	}
 }
 
@@ -323,7 +323,7 @@ func TestDateJSON(t *testing.T) {
 		assert.NoError(t, err)
 		defer arr.Release()
 
-		assert.Truef(t, array.ArrayEqual(expected, arr), "expected: %s\ngot: %s\n", expected, arr)
+		assert.Truef(t, array.Equal(expected, arr), "expected: %s\ngot: %s\n", expected, arr)
 
 		data, err := json.Marshal(arr)
 		assert.NoError(t, err)
@@ -344,7 +344,7 @@ func TestDateJSON(t *testing.T) {
 		assert.NoError(t, err)
 		defer arr.Release()
 
-		assert.Truef(t, array.ArrayEqual(expected, arr), "expected: %s\ngot: %s\n", expected, arr)
+		assert.Truef(t, array.Equal(expected, arr), "expected: %s\ngot: %s\n", expected, arr)
 
 		data, err := json.Marshal(arr)
 		assert.NoError(t, err)
@@ -389,7 +389,7 @@ func TestTimeJSON(t *testing.T) {
 			assert.NoError(t, err)
 			defer arr.Release()
 
-			assert.Truef(t, array.ArrayEqual(expected, arr), "expected: %s\ngot: %s\n", expected, arr)
+			assert.Truef(t, array.Equal(expected, arr), "expected: %s\ngot: %s\n", expected, arr)
 
 			data, err := json.Marshal(arr)
 			assert.NoError(t, err)
@@ -411,7 +411,7 @@ func TestDecimal128JSON(t *testing.T) {
 	assert.NoError(t, err)
 	defer arr.Release()
 
-	assert.Truef(t, array.ArrayEqual(expected, arr), "expected: %s\ngot: %s\n", expected, arr)
+	assert.Truef(t, array.Equal(expected, arr), "expected: %s\ngot: %s\n", expected, arr)
 
 	data, err := json.Marshal(arr)
 	assert.NoError(t, err)
@@ -431,7 +431,7 @@ func TestDecimal256JSON(t *testing.T) {
 	assert.NoError(t, err)
 	defer arr.Release()
 
-	assert.Truef(t, array.ArrayEqual(expected, arr), "expected: %s\ngot: %s\n", expected, arr)
+	assert.Truef(t, array.Equal(expected, arr), "expected: %s\ngot: %s\n", expected, arr)
 
 	data, err := json.Marshal(arr)
 	assert.NoError(t, err)

--- a/go/arrow/cdata/cdata_test.go
+++ b/go/arrow/cdata/cdata_test.go
@@ -487,7 +487,7 @@ func TestPrimitiveArrs(t *testing.T) {
 
 			imported, err := ImportCArrayWithType(carr, arr.DataType())
 			assert.NoError(t, err)
-			assert.True(t, array.ArrayEqual(arr, imported))
+			assert.True(t, array.Equal(arr, imported))
 			assert.True(t, isReleased(carr))
 
 			imported.Release()
@@ -507,7 +507,7 @@ func TestPrimitiveSliced(t *testing.T) {
 
 	imported, err := ImportCArrayWithType(carr, arr.DataType())
 	assert.NoError(t, err)
-	assert.True(t, array.ArrayEqual(sl, imported))
+	assert.True(t, array.Equal(sl, imported))
 	assert.True(t, array.SliceEqual(arr, 1, 2, imported, 0, int64(imported.Len())))
 	assert.True(t, isReleased(carr))
 
@@ -673,7 +673,7 @@ func TestNestedArrays(t *testing.T) {
 
 			imported, err := ImportCArrayWithType(carr, arr.DataType())
 			assert.NoError(t, err)
-			assert.True(t, array.ArrayEqual(arr, imported))
+			assert.True(t, array.Equal(arr, imported))
 			assert.True(t, isReleased(carr))
 
 			imported.Release()


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

There are several deprecated comparison functions that have long been deprecated.
This PR unblocks the removal of those functions as nothing depends on them anymore.

Given the functions have been deprecated for a long time and might have been removed in v9, I removed them in this PR already, given this is for v13. 

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Unit tests are passing locally. 

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

Removal of old deprecated functions for comparing arrays. 

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #36198