### PR TITLE
GH-36038: [Python] Implement __reduce__ on ExtensionType class

### DIFF
--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -867,11 +867,29 @@ def test_generic_ext_type_equality():
     assert not period_type == period_type3
 
 
-def test_generic_ext_type_pickling():
+def test_generic_ext_type_pickling(registered_period_type):
     # GH-36038
-    period_type = PeriodType('D')
-    period_type_pickled = pickle.loads(pickle.dumps(period_type))
-    assert period_type == period_type_pickled
+    for proto in range(0, pickle.HIGHEST_PROTOCOL + 1):
+        period_type, _ = registered_period_type
+        ser = pickle.dumps(period_type, protocol=proto)
+        period_type_pickled = pickle.loads(ser)
+        assert period_type == period_type_pickled
+
+
+def test_generic_ext_array_pickling(registered_period_type):
+    for proto in range(0, pickle.HIGHEST_PROTOCOL + 1):
+        period_type, _ = registered_period_type
+        storage = pa.array([1, 2, 3, 4], pa.int64())
+        arr = pa.ExtensionArray.from_storage(period_type, storage)
+        ser = pickle.dumps(arr, protocol=proto)
+        del storage, arr
+        arr = pickle.loads(ser)
+        arr.validate()
+        assert isinstance(arr, pa.ExtensionArray)
+        assert arr.type == period_type
+        assert arr.type.storage_type == pa.int64()
+        assert arr.storage.type == pa.int64()
+        assert arr.storage.to_pylist() == [1, 2, 3, 4]
 
 
 def test_generic_ext_type_register(registered_period_type):

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -867,6 +867,13 @@ def test_generic_ext_type_equality():
     assert not period_type == period_type3
 
 
+def test_generic_ext_type_pickling():
+    # GH-36038
+    period_type = PeriodType('D')
+    period_type_pickled = pickle.loads(pickle.dumps(period_type))
+    assert period_type == period_type_pickled
+
+
 def test_generic_ext_type_register(registered_period_type):
     # test that trying to register other type does not segfault
     with pytest.raises(TypeError):

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -1487,6 +1487,9 @@ cdef class ExtensionType(BaseExtensionType):
         """
         return NotImplementedError
 
+    def __reduce__(self):
+        return self.__arrow_ext_deserialize__, (self.storage_type, self.__arrow_ext_serialize__())
+
     def __arrow_ext_class__(self):
         """Return an extension array class to be used for building or
         deserializing arrays with this extension type.


### PR DESCRIPTION
### Rationale for this change
`ExtensionType` subclasses can't be pickled if `__reduce__` method isn't implemented separately.

### What changes are included in this PR?
Add `__reduce__` method to `ExtensionType` class.

### Are these changes tested?
Yes, test is added to python/pyarrow/tests/test_extension_type.py.

### Are there any user-facing changes?
No.
* Closes: #36038