### PR TITLE
MINOR: [Python][CI] Fix harmless user warning in test_list_of_datetime_time_roundtrip

### DIFF
--- a/python/pyarrow/tests/parquet/test_datetime.py
+++ b/python/pyarrow/tests/parquet/test_datetime.py
@@ -359,7 +359,7 @@ def test_timestamp_restore_timezone_nanosecond():
 def test_list_of_datetime_time_roundtrip():
     # ARROW-4135
     times = pd.to_datetime(['09:00', '09:30', '10:00', '10:30', '11:00',
-                            '11:30', '12:00'])
+                            '11:30', '12:00'], format="%H:%M")
     df = pd.DataFrame({'time': [times.time]})
     _roundtrip_pandas_dataframe(df, write_kwargs={})
 


### PR DESCRIPTION
### Rationale for this change

With recent pandas, this usage of `to_datetime` gives a warning about each element getting parsed individually, and that you can avoid the warning by passing a format:

```
>>> pd.to_datetime(['09:00', '09:30', '10:00', '10:30', '11:00', '11:30', '12:00'])
UserWarning: Could not infer format, so each element will be parsed individually, falling back to `dateutil`. To ensure parsing is consistent and as-expected, please specify a format.
```

This doesn't change any behaviour in the test, but just ensures running our tests don't print this warning.
