### PR TITLE
GH-36178: [C++]support prefetching for ReadRangeCache lazy mode

### DIFF
--- a/cpp/src/arrow/io/caching.cc
+++ b/cpp/src/arrow/io/caching.cc
@@ -35,13 +35,15 @@ namespace io {
 CacheOptions CacheOptions::Defaults() {
   return CacheOptions{internal::ReadRangeCache::kDefaultHoleSizeLimit,
                       internal::ReadRangeCache::kDefaultRangeSizeLimit,
-                      /*lazy=*/false};
+                      /*lazy=*/false,
+                      /*prefetch_limit=*/0};
 }
 
 CacheOptions CacheOptions::LazyDefaults() {
   return CacheOptions{internal::ReadRangeCache::kDefaultHoleSizeLimit,
                       internal::ReadRangeCache::kDefaultRangeSizeLimit,
-                      /*lazy=*/true};
+                      /*lazy=*/true,
+                      /*prefetch_limit=*/0};
 }
 
 CacheOptions CacheOptions::MakeFromNetworkMetrics(int64_t time_to_first_byte_millis,
@@ -125,7 +127,7 @@ CacheOptions CacheOptions::MakeFromNetworkMetrics(int64_t time_to_first_byte_mil
                                       (1 - ideal_bandwidth_utilization_frac))));
   DCHECK_GT(range_size_limit, 0) << "Computed range_size_limit must be > 0";
 
-  return {hole_size_limit, range_size_limit, false};
+  return {hole_size_limit, range_size_limit, /*lazy=*/false, /*prefetch_limit=*/0};
 }
 
 namespace internal {
@@ -204,6 +206,18 @@ struct ReadRangeCache::Impl {
     if (it != entries.end() && it->range.Contains(range)) {
       auto fut = MaybeRead(&*it);
       ARROW_ASSIGN_OR_RAISE(auto buf, fut.result());
+      if (options.lazy && options.prefetch_limit > 0) {
+        int64_t num_prefetched = 0;
+        for (auto next_it = it + 1;
+             next_it != entries.end() && num_prefetched < options.prefetch_limit;
+             ++next_it) {
+          if (!next_it->future.is_valid()) {
+            next_it->future =
+                file->ReadAsync(ctx, next_it->range.offset, next_it->range.length);
+          }
+          ++num_prefetched;
+        }
+      }
       return SliceBuffer(std::move(buf), range.offset - it->range.offset, range.length);
     }
     return Status::Invalid("ReadRangeCache did not find matching cache entry");

--- a/cpp/src/arrow/io/caching.h
+++ b/cpp/src/arrow/io/caching.h
@@ -43,10 +43,14 @@ struct ARROW_EXPORT CacheOptions {
   int64_t range_size_limit;
   /// \brief A lazy cache does not perform any I/O until requested.
   bool lazy;
+  /// \brief The maximum number of ranges to be prefetched. This is only used
+  ///   for lazy cache to asynchronously read some ranges after reading the target range.
+  int64_t prefetch_limit = 0;
 
   bool operator==(const CacheOptions& other) const {
     return hole_size_limit == other.hole_size_limit &&
-           range_size_limit == other.range_size_limit && lazy == other.lazy;
+           range_size_limit == other.range_size_limit && lazy == other.lazy &&
+           prefetch_limit == other.prefetch_limit;
   }
 
   /// \brief Construct CacheOptions from network storage metrics (e.g. S3).


### PR DESCRIPTION
### Rationale for this change

The current [ReadRangeCache](https://github.com/apache/arrow/blob/main/cpp/src/arrow/io/caching.h#L100) support a laze mode where each range is read upon an [explicit request](https://github.com/apache/arrow/blob/main/cpp/src/arrow/io/caching.cc#L255), and a non-lazy mode where all ranges are read concurrently [at once](https://github.com/apache/arrow/blob/main/cpp/src/arrow/io/caching.cc#L168). In some scenarios, it would help to support a prefetch mode (which naturally is bound to the lazy mode) such that  explicitly reading one range will prefetching one or more following ranges . 

### What changes are included in this PR?

Add a new cache option `prefetch_limit` to define the maximum number of ranges to be prefetched when reading one range in lazy mode.


### Are these changes tested?

Yes. A new unit test is included

### Are there any user-facing changes?

No.
* Closes: #36178