### PR TITLE
GH-36189: [C++][Parquet] StreamReader::SkipRows() skips to incorrect place in multi-row-group files

### DIFF
--- a/cpp/src/parquet/stream_reader.cc
+++ b/cpp/src/parquet/stream_reader.cc
@@ -441,7 +441,7 @@ int64_t StreamReader::SkipRows(int64_t num_rows_to_skip) {
   while (!eof_ && (num_rows_remaining_to_skip > 0)) {
     int64_t num_rows_in_row_group = row_group_reader_->metadata()->num_rows();
     int64_t num_rows_remaining_in_row_group =
-        num_rows_in_row_group - current_row_ - row_group_row_offset_;
+        num_rows_in_row_group - (current_row_ - row_group_row_offset_);
 
     if (num_rows_remaining_in_row_group > num_rows_remaining_to_skip) {
       for (auto reader : column_readers_) {

--- a/cpp/src/parquet/stream_reader_test.cc
+++ b/cpp/src/parquet/stream_reader_test.cc
@@ -996,7 +996,7 @@ class TestMultiRowGroupStreamReader : public ::testing::Test {
   }
 
   void ReadRowAndAssertPosition(uint64_t expected_row_num) {
-    const uint16_t expected_group_num = expected_row_num / kNumRowsPerGroup;
+    const uint16_t expected_group_num = ((uint16_t)expected_row_num) / kNumRowsPerGroup;
     ASSERT_FALSE(reader_.eof());
     uint16_t group_num = 0;
     uint64_t row_num = 0;

--- a/cpp/src/parquet/stream_reader_test.cc
+++ b/cpp/src/parquet/stream_reader_test.cc
@@ -984,13 +984,13 @@ class TestMultiRowGroupStreamReader : public ::testing::Test {
 
     int nrows = 0;
     for (auto group = 0; group < num_row_groups; ++group) {
-        for (auto i = 0; i < num_rows_per_group; ++i) {
-          os << static_cast<uint16_t>(group);
-          os << static_cast<uint64_t>(nrows);
-          os << EndRow;
-          nrows++;
-        }
-        os.EndRowGroup();
+      for (auto i = 0; i < num_rows_per_group; ++i) {
+        os << static_cast<uint16_t>(group);
+        os << static_cast<uint64_t>(nrows);
+        os << EndRow;
+        nrows++;
+      }
+      os.EndRowGroup();
     }
   }
 
@@ -1013,7 +1013,7 @@ TEST_F(TestMultiRowGroupStreamReader, SkipRows) {
   uint16_t current_row_group = 0;
   uint64_t current_global_row = 0;
   reader_ >> current_row_group;
-  EXPECT_EQ(current_row_group, current_row/10);
+  EXPECT_EQ(current_row_group, current_row / 10);
 
   reader_ >> current_global_row;
   EXPECT_EQ(current_global_row, current_row);
@@ -1026,7 +1026,7 @@ TEST_F(TestMultiRowGroupStreamReader, SkipRows) {
   // we read row 33 (were at 34, then skipped 4 => 38)
   current_row = 38;
   reader_ >> current_row_group;
-  EXPECT_EQ(current_row_group, current_row/10);
+  EXPECT_EQ(current_row_group, current_row / 10);
 
   reader_ >> current_global_row;
   EXPECT_EQ(current_global_row, current_row);
@@ -1050,7 +1050,6 @@ TEST_F(TestMultiRowGroupStreamReader, SkipRows) {
   ASSERT_GE(retval, 0);
 
   EXPECT_TRUE(reader_.eof());
-
 }
 
 }  // namespace test

--- a/cpp/src/parquet/stream_reader_test.cc
+++ b/cpp/src/parquet/stream_reader_test.cc
@@ -974,7 +974,7 @@ class TestMultiRowGroupStreamReader : public ::testing::Test {
         schema::GroupNode::Make("schema", Repetition::REQUIRED, fields));
   }
 
-  void createTestFile() {
+  void CreateTestFile() {
     PARQUET_ASSIGN_OR_THROW(auto outfile,
                             ::arrow::io::FileOutputStream::Open(GetDataFile()));
 
@@ -995,8 +995,8 @@ class TestMultiRowGroupStreamReader : public ::testing::Test {
   }
 
   StreamReader reader_;
-  static constexpr int num_row_groups = 5;
-  static constexpr int num_rows_per_group = 10;
+  static constexpr int kNumGroups = 5;
+  static constexpr int kNumRowsPerGroup = 10;
 };
 
 TEST_F(TestMultiRowGroupStreamReader, SkipRows) {
@@ -1004,7 +1004,7 @@ TEST_F(TestMultiRowGroupStreamReader, SkipRows) {
   auto current_row = 33;
 
   auto retval = reader_.SkipRows(current_row);
-  ASSERT_GE(retval, 0);
+  ASSERT_EQ(retval, current_row);
 
   // there are 50 total rows, so definitely not EOF
   ASSERT_FALSE(reader_.eof());
@@ -1013,7 +1013,7 @@ TEST_F(TestMultiRowGroupStreamReader, SkipRows) {
   uint16_t current_row_group = 0;
   uint64_t current_global_row = 0;
   reader_ >> current_row_group;
-  EXPECT_EQ(current_row_group, current_row / 10);
+  EXPECT_EQ(current_row_group, current_row / kNumRowsPerGroup);
 
   reader_ >> current_global_row;
   EXPECT_EQ(current_global_row, current_row);
@@ -1023,10 +1023,10 @@ TEST_F(TestMultiRowGroupStreamReader, SkipRows) {
   retval = reader_.SkipRows(4);
   ASSERT_GE(retval, 0);
 
-  // we read row 33 (were at 34, then skipped 4 => 38)
+  // we read row 38 (were at 34, then skipped 4 => 38)
   current_row = 38;
   reader_ >> current_row_group;
-  EXPECT_EQ(current_row_group, current_row / 10);
+  EXPECT_EQ(current_row_group, current_row / kNumRowsPerGroup);
 
   reader_ >> current_global_row;
   EXPECT_EQ(current_global_row, current_row);

--- a/cpp/src/parquet/stream_reader_test.cc
+++ b/cpp/src/parquet/stream_reader_test.cc
@@ -17,13 +17,11 @@
 
 #include "parquet/stream_reader.h"
 
-#include <fcntl.h>
 #include <gtest/gtest.h>
 
 #include <chrono>
 #include <ctime>
 #include <memory>
-#include <utility>
 
 #include "arrow/io/file.h"
 #include "arrow/util/decimal.h"
@@ -38,7 +36,7 @@ using optional = StreamReader::optional<T>;
 using ::std::nullopt;
 
 struct TestData {
-  static void init() { std::time(&ts_offset_); }
+  static void Init() { std::time(&ts_offset_); }
 
   static constexpr int num_rows = 2000;
 
@@ -145,18 +143,18 @@ constexpr int TestData::num_rows;
 
 class TestStreamReader : public ::testing::Test {
  public:
-  TestStreamReader() { createTestFile(); }
+  TestStreamReader() { CreateTestFile(); }
 
  protected:
   const char* GetDataFile() const { return "stream_reader_test.parquet"; }
 
-  void SetUp() {
+  void SetUp() override {
     PARQUET_ASSIGN_OR_THROW(auto infile, ::arrow::io::ReadableFile::Open(GetDataFile()));
     auto file_reader = parquet::ParquetFileReader::Open(infile);
     reader_ = StreamReader{std::move(file_reader)};
   }
 
-  void TearDown() { reader_ = StreamReader{}; }
+  void TearDown() override { reader_ = StreamReader{}; }
 
   std::shared_ptr<schema::GroupNode> GetSchema() {
     schema::NodeVector fields;
@@ -201,7 +199,7 @@ class TestStreamReader : public ::testing::Test {
         schema::GroupNode::Make("schema", Repetition::REQUIRED, fields));
   }
 
-  void createTestFile() {
+  void CreateTestFile() {
     PARQUET_ASSIGN_OR_THROW(auto outfile,
                             ::arrow::io::FileOutputStream::Open(GetDataFile()));
 
@@ -209,7 +207,7 @@ class TestStreamReader : public ::testing::Test {
 
     StreamWriter os{std::move(file_writer)};
 
-    TestData::init();
+    TestData::Init();
 
     for (auto i = 0; i < TestData::num_rows; ++i) {
       os << TestData::GetBool(i);
@@ -586,7 +584,7 @@ TEST_F(TestStreamReader, SkipColumns) {
 
 class TestOptionalFields : public ::testing::Test {
  public:
-  TestOptionalFields() { createTestFile(); }
+  TestOptionalFields() { CreateTestFile(); }
 
  protected:
   const char* GetDataFile() const { return "stream_reader_test_optional_fields.parquet"; }
@@ -644,13 +642,13 @@ class TestOptionalFields : public ::testing::Test {
         schema::GroupNode::Make("schema", Repetition::REQUIRED, fields));
   }
 
-  void createTestFile() {
+  void CreateTestFile() {
     PARQUET_ASSIGN_OR_THROW(auto outfile,
                             ::arrow::io::FileOutputStream::Open(GetDataFile()));
 
     StreamWriter os{ParquetFileWriter::Open(outfile, GetSchema())};
 
-    TestData::init();
+    TestData::Init();
 
     for (auto i = 0; i < TestData::num_rows; ++i) {
       os << TestData::GetOptBool(i);
@@ -732,7 +730,7 @@ TEST_F(TestOptionalFields, ReadOptionalFieldAsRequiredField) {
     _provided_ that the optional value is available.
 
     This can be useful if a schema is changed such that a required
-    field beomes optional.  Applications can continue reading the
+    field becomes optional.  Applications can continue reading the
     field as if it were mandatory and do not need to be changed if the
     field value is always provided.
 
@@ -948,20 +946,17 @@ TEST_F(TestReadingDataFiles, ByteArrayDecimal) {
 }
 
 class TestMultiRowGroupStreamReader : public ::testing::Test {
- public:
-  TestMultiRowGroupStreamReader() {}
-
  protected:
   const char* GetDataFile() const { return "stream_reader_multirowgroup_test.parquet"; }
 
-  void SetUp() {
+  void SetUp() override {
     CreateTestFile();
     PARQUET_ASSIGN_OR_THROW(auto infile, ::arrow::io::ReadableFile::Open(GetDataFile()));
     auto file_reader = parquet::ParquetFileReader::Open(infile);
     reader_ = StreamReader{std::move(file_reader)};
   }
 
-  void TearDown() { reader_ = StreamReader{}; }
+  void TearDown() override { reader_ = StreamReader{}; }
 
   std::shared_ptr<schema::GroupNode> GetSchema() {
     schema::NodeVector fields;
@@ -996,7 +991,8 @@ class TestMultiRowGroupStreamReader : public ::testing::Test {
   }
 
   void ReadRowAndAssertPosition(uint64_t expected_row_num) {
-    const uint16_t expected_group_num = ((uint16_t)expected_row_num) / kNumRowsPerGroup;
+    const auto expected_group_num =
+        static_cast<uint16_t>(expected_row_num / kNumRowsPerGroup);
     ASSERT_FALSE(reader_.eof());
     uint16_t group_num = 0;
     uint64_t row_num = 0;
@@ -1032,7 +1028,6 @@ TEST_F(TestMultiRowGroupStreamReader, SkipRows) {
   current_row += 1;  // row=40
   ASSERT_EQ(retval, 1);
   ReadRowAndAssertPosition(current_row);
-  current_row += 1;  // row=41
 
   // finally, skip off the end of the file
   retval = reader_.SkipRows(10);


### PR DESCRIPTION
### Rationale for this change

The behavior of Parquet `StreamReader::SkipRows()` is wrong due to an error in calculating the row offset from the current row group. 

### What changes are included in this PR?

A unit test case demonstrating the failure and a trivial fix. 

### Are these changes tested?

Yes 

### Are there any user-facing changes?

No


I am not sure if this bug is critical given how long it has existed in the code and no one has seemed to notice. There are two manifestations of this bug that might give the user the wrong impression about what is in their data: 

* sometimes a negative return value is returned, which is unexpected given the nature of the API, so the user should know something is up (this is how I discovered the bug)
* the `SkipRows()` call leads to setting of the `eof` flag prematurely, which might lead the user to think there is less data in the file than there is. 
* Closes: #36189