### PR TITLE
GH-36207: [MATLAB] Add MATLAB autosave files (`.asv`) to the `.gitignore`

### DIFF
--- a/matlab/.gitignore
+++ b/matlab/.gitignore
@@ -22,3 +22,5 @@ build/
 
 # MEX files
 *.mex*
+# MATLAB autosave files
+*.asv


### PR DESCRIPTION
### Rationale for this change

By default, MATLAB will [periodically create backup files](https://www.mathworks.com/company/newsletters/articles/automatically-save-backup-m-files-with-the-matlab-editor.html) for files that are currently open in the MATLAB Editor. These files have a default file extension of `.asv`. To prevent these backup files from accidentally being committed to version control, it would be helpful to add `.asv` files to the `.gitignore` for the MATLAB interface.

### What changes are included in this PR?

1. MATLAB autosave files (`.asv`) have been added to the `.gitignore` for the MATLAB interface

### Are these changes tested?

1. Yes. Manually verified that files with filenames of the form `<filename.asv>` under the `matlab` folder are not tracked by Git. 

### Are there any user-facing changes?

No.
* Closes: #36207