### PR TITLE
GH-36177: [MATLAB] Add the Type object hierarchy to the MATLAB interface

### DIFF
--- a/matlab/src/matlab/+arrow/+type/BooleanType.m
+++ b/matlab/src/matlab/+arrow/+type/BooleanType.m
@@ -1,0 +1,22 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef BooleanType < arrow.type.PrimitiveType
+%BOOLEANTYPE Type class for boolean data.
+    
+    properties(SetAccess = protected)
+        ID = arrow.type.ID.Boolean
+    end
+end

--- a/matlab/src/matlab/+arrow/+type/Float32Type.m
+++ b/matlab/src/matlab/+arrow/+type/Float32Type.m
@@ -1,0 +1,22 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef Float32Type < arrow.type.PrimitiveType
+%FLOAT32TYPE Type class for float32 data.
+    
+    properties(SetAccess = protected)
+        ID = arrow.type.ID.Float32
+    end
+end

--- a/matlab/src/matlab/+arrow/+type/Float64Type.m
+++ b/matlab/src/matlab/+arrow/+type/Float64Type.m
@@ -1,0 +1,22 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef Float64Type < arrow.type.PrimitiveType
+%FLOAT64Type Type class for float64 data. 
+    
+    properties(SetAccess = protected)
+        ID = arrow.type.ID.Float64
+    end
+end

--- a/matlab/src/matlab/+arrow/+type/ID.m
+++ b/matlab/src/matlab/+arrow/+type/ID.m
@@ -1,0 +1,52 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef ID < uint64
+%ID Data type enumeration
+    enumeration
+        Boolean (1)
+        UInt8   (2)
+        Int8    (3)
+        UInt16  (4)
+        Int16   (5)
+        UInt32  (6)
+        Int32   (7)
+        UInt64  (8)
+        Int64   (9)
+        % Float16 (10) not yet supported
+        Float32 (11)
+        Float64 (12)
+    end
+
+    methods
+        function bitWidth = bitWidth(obj)
+            import arrow.type.ID
+            switch obj
+                case ID.Boolean
+                    bitWidth = 1;
+                case {ID.UInt8, ID.Int8}
+                    bitWidth = 8;
+                case {ID.UInt16, ID.Int16}
+                    bitWidth = 16;
+                case {ID.UInt32, ID.Int32, ID.Float32}
+                    bitWidth = 32;
+                case {ID.UInt64, ID.Int64, ID.Float64}
+                    bitWidth = 64;
+                otherwise
+                    bitWidth = NaN;
+            end
+        end
+    end
+end

--- a/matlab/src/matlab/+arrow/+type/Int16Type.m
+++ b/matlab/src/matlab/+arrow/+type/Int16Type.m
@@ -1,0 +1,23 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef Int16Type < arrow.type.PrimitiveType
+%INT16TYPE Type class for int8 data. 
+    
+    properties(SetAccess = protected)
+        ID = arrow.type.ID.Int16
+    end
+end
+

--- a/matlab/src/matlab/+arrow/+type/Int32Type.m
+++ b/matlab/src/matlab/+arrow/+type/Int32Type.m
@@ -1,0 +1,23 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef Int32Type < arrow.type.PrimitiveType
+%INT32TYPE Type class for int32 data.
+
+    properties(SetAccess = protected)
+        ID = arrow.type.ID.Int32
+    end
+end
+

--- a/matlab/src/matlab/+arrow/+type/Int64Type.m
+++ b/matlab/src/matlab/+arrow/+type/Int64Type.m
@@ -1,0 +1,22 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef Int64Type < arrow.type.PrimitiveType
+%INT64TYPE Type class for int64 data.
+
+    properties(SetAccess = protected)
+        ID = arrow.type.ID.Int64
+    end
+end

--- a/matlab/src/matlab/+arrow/+type/Int8Type.m
+++ b/matlab/src/matlab/+arrow/+type/Int8Type.m
@@ -1,0 +1,23 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef Int8Type < arrow.type.PrimitiveType
+%INT8TYPE Type class for int8 data. 
+    
+    properties(SetAccess = protected)
+        ID = arrow.type.ID.Int8
+    end
+end
+

--- a/matlab/src/matlab/+arrow/+type/PrimitiveType.m
+++ b/matlab/src/matlab/+arrow/+type/PrimitiveType.m
@@ -1,0 +1,33 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef PrimitiveType < arrow.type.Type
+%PRIMITIVETYPE Abstract type class representing primtive data types. 
+    
+    properties(Dependent, SetAccess=protected, GetAccess=public)
+        BitWidth
+    end
+
+    properties(Constant)
+        NumFields = 0
+        NumBuffers = 2
+    end
+
+    methods
+        function width = get.BitWidth(obj)
+            width = bitWidth(obj.ID);
+        end
+    end
+end

--- a/matlab/src/matlab/+arrow/+type/Type.m
+++ b/matlab/src/matlab/+arrow/+type/Type.m
@@ -1,0 +1,23 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef Type
+%TYPE Abstract type class. 
+
+    properties (Abstract, SetAccess=protected)
+        ID(1, 1) arrow.type.ID
+    end
+end
+

--- a/matlab/src/matlab/+arrow/+type/UInt16Type.m
+++ b/matlab/src/matlab/+arrow/+type/UInt16Type.m
@@ -1,0 +1,22 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef UInt16Type < arrow.type.PrimitiveType
+%UINT16TYPE Type class for uint16 data.
+    
+    properties(SetAccess = protected)
+        ID = arrow.type.ID.UInt16
+    end
+end

--- a/matlab/src/matlab/+arrow/+type/UInt32Type.m
+++ b/matlab/src/matlab/+arrow/+type/UInt32Type.m
@@ -1,0 +1,22 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef UInt32Type < arrow.type.PrimitiveType
+%UINT32TYPE Type class for uint32 data.
+    
+    properties(SetAccess = protected)
+        ID = arrow.type.ID.UInt32
+    end
+end

--- a/matlab/src/matlab/+arrow/+type/UInt64Type.m
+++ b/matlab/src/matlab/+arrow/+type/UInt64Type.m
@@ -1,0 +1,22 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef UInt64Type < arrow.type.PrimitiveType
+%UINT64TYPE Type class for uint64 data.
+    
+    properties(SetAccess = protected)
+        ID = arrow.type.ID.UInt64
+    end
+end

--- a/matlab/src/matlab/+arrow/+type/UInt8Type.m
+++ b/matlab/src/matlab/+arrow/+type/UInt8Type.m
@@ -1,0 +1,22 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef UInt8Type < arrow.type.PrimitiveType
+%UINT8TYPE Type class for uint8 data.
+    
+    properties(SetAccess = protected)
+        ID = arrow.type.ID.UInt8
+    end
+end

--- a/matlab/test/arrow/type/hPrimitiveType.m
+++ b/matlab/test/arrow/type/hPrimitiveType.m
@@ -1,0 +1,51 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef hPrimitiveType < matlab.unittest.TestCase
+% Test class that defines shared unit tests for classes that inherit from
+% arrow.type.PrimitiveType
+
+    properties(Abstract)
+        ArrowType
+        TypeID
+        BitWidth
+    end
+
+    methods(Test)
+        function TestTypeID(testCase)
+        % Verify ID is set to the appropriate arrow.type.ID value.
+            arrowType = testCase.ArrowType;
+            testCase.verifyEqual(arrowType.ID, testCase.TypeID);
+        end
+
+        function TestBitWidth(testCase)
+        % Verify the BitWidth value.
+            arrowType = testCase.ArrowType;
+            testCase.verifyEqual(arrowType.BitWidth, testCase.BitWidth);
+        end
+
+        function TestNumFields(testCase)
+        % Verify NumFields is set to 0 for primitive types.
+            arrowType = testCase.ArrowType;
+            testCase.verifyEqual(arrowType.NumFields, 0);
+        end
+
+        function TestNumBuffers(testCase)
+        % Verify NumBuffers is set to 2 for primitive types.
+            arrowType = testCase.ArrowType;
+            testCase.verifyEqual(arrowType.NumBuffers, 2);
+        end
+    end
+end

--- a/matlab/test/arrow/type/tBooleanType.m
+++ b/matlab/test/arrow/type/tBooleanType.m
@@ -17,7 +17,6 @@ classdef tBooleanType < hPrimitiveType
 % Test class for arrow.type.BooleanType
 
     properties
-        ArrowTypeClassName = "arrow.type.BooleanType"
         ArrowType = arrow.type.BooleanType
         TypeID = arrow.type.ID.Boolean
         BitWidth = 1;

--- a/matlab/test/arrow/type/tBooleanType.m
+++ b/matlab/test/arrow/type/tBooleanType.m
@@ -1,0 +1,25 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef tBooleanType < hPrimitiveType
+% Test class for arrow.type.BooleanType
+
+    properties
+        ArrowTypeClassName = "arrow.type.BooleanType"
+        ArrowType = arrow.type.BooleanType
+        TypeID = arrow.type.ID.Boolean
+        BitWidth = 1;
+    end
+end

--- a/matlab/test/arrow/type/tFloat32Type.m
+++ b/matlab/test/arrow/type/tFloat32Type.m
@@ -17,7 +17,6 @@ classdef tFloat32Type < hPrimitiveType
 % Test class for arrow.type.Float32Type
 
     properties
-        ArrowTypeClassName = "arrow.type.Float32Type"
         ArrowType = arrow.type.Float32Type
         TypeID = arrow.type.ID.Float32
         BitWidth = 32;

--- a/matlab/test/arrow/type/tFloat32Type.m
+++ b/matlab/test/arrow/type/tFloat32Type.m
@@ -1,0 +1,25 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef tFloat32Type < hPrimitiveType
+% Test class for arrow.type.Float32Type
+
+    properties
+        ArrowTypeClassName = "arrow.type.Float32Type"
+        ArrowType = arrow.type.Float32Type
+        TypeID = arrow.type.ID.Float32
+        BitWidth = 32;
+    end
+end

--- a/matlab/test/arrow/type/tFloat64Type.m
+++ b/matlab/test/arrow/type/tFloat64Type.m
@@ -17,7 +17,6 @@ classdef tFloat64Type < hPrimitiveType
 % Test class for arrow.type.Float64Type
 
     properties
-        ArrowTypeClassName = "arrow.type.Float64Type"
         ArrowType = arrow.type.Float64Type
         TypeID = arrow.type.ID.Float64
         BitWidth = 64;

--- a/matlab/test/arrow/type/tFloat64Type.m
+++ b/matlab/test/arrow/type/tFloat64Type.m
@@ -1,0 +1,25 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef tFloat64Type < hPrimitiveType
+% Test class for arrow.type.Float64Type
+
+    properties
+        ArrowTypeClassName = "arrow.type.Float64Type"
+        ArrowType = arrow.type.Float64Type
+        TypeID = arrow.type.ID.Float64
+        BitWidth = 64;
+    end
+end

--- a/matlab/test/arrow/type/tID.m
+++ b/matlab/test/arrow/type/tID.m
@@ -1,0 +1,60 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef tID < matlab.unittest.TestCase
+% Test class for arrow.type.ID
+
+    methods(TestClassSetup)
+        function verifyOnMatlabPath(tc)
+        % Verify the arrow array class is on the MATLAB Search Path.
+            tc.assertTrue(~isempty(which("arrow.type.ID")), ...
+                """arrow.type.ID"" must be on the MATLAB path. " + ...
+                "Use ""addpath"" to add folders to the MATLAB path.");
+        end
+    end
+
+    methods (Test)
+        function bitWidth(testCase)
+            import arrow.type.ID
+
+            typeIDs = [ID.Boolean, ID.UInt8, ID.Int8, ID.UInt16, ...
+                       ID.Int16, ID.UInt32, ID.Int32, ID.UInt64, ...
+                       ID.Int64, ID.Float32, ID.Float64];
+
+            expectedWidths = [1, 8, 8, 16, 16, 32, 32, 64, 64, 32, 64];
+
+            for ii = 1:numel(typeIDs)
+                actualWidth = bitWidth(typeIDs(ii)); 
+                expectedWidth = expectedWidths(ii);
+                testCase.verifyEqual(actualWidth, expectedWidth);
+            end
+        end
+
+        function CastToUInt64(testCase)
+            import arrow.type.ID
+
+            typeIDs = [ID.Boolean, ID.UInt8, ID.Int8, ID.UInt16, ...
+                       ID.Int16, ID.UInt32, ID.Int32, ID.UInt64, ...
+                       ID.Int64, ID.Float32, ID.Float64];
+
+            expectedValues = uint64([1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12]); 
+            for ii = 1:numel(typeIDs)
+                actualValue = uint64(typeIDs(ii)); 
+                expectedValue = expectedValues(ii);
+                testCase.verifyEqual(actualValue, expectedValue);
+            end
+        end
+    end
+end

--- a/matlab/test/arrow/type/tInt16Type.m
+++ b/matlab/test/arrow/type/tInt16Type.m
@@ -1,0 +1,25 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef tInt16Type < hPrimitiveType
+% Test class for arrow.type.Int16Type
+
+    properties
+        ArrowTypeClassName = "arrow.type.Int16Type"
+        ArrowType = arrow.type.Int16Type
+        TypeID = arrow.type.ID.Int16
+        BitWidth = 16;
+    end
+end

--- a/matlab/test/arrow/type/tInt16Type.m
+++ b/matlab/test/arrow/type/tInt16Type.m
@@ -17,7 +17,6 @@ classdef tInt16Type < hPrimitiveType
 % Test class for arrow.type.Int16Type
 
     properties
-        ArrowTypeClassName = "arrow.type.Int16Type"
         ArrowType = arrow.type.Int16Type
         TypeID = arrow.type.ID.Int16
         BitWidth = 16;

--- a/matlab/test/arrow/type/tInt32Type.m
+++ b/matlab/test/arrow/type/tInt32Type.m
@@ -17,7 +17,6 @@ classdef tInt32Type < hPrimitiveType
 % Test class for arrow.type.Int32Type
 
     properties
-        ArrowTypeClassName = "arrow.type.Int32Type"
         ArrowType = arrow.type.Int32Type
         TypeID = arrow.type.ID.Int32
         BitWidth = 32;

--- a/matlab/test/arrow/type/tInt32Type.m
+++ b/matlab/test/arrow/type/tInt32Type.m
@@ -1,0 +1,25 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef tInt32Type < hPrimitiveType
+% Test class for arrow.type.Int32Type
+
+    properties
+        ArrowTypeClassName = "arrow.type.Int32Type"
+        ArrowType = arrow.type.Int32Type
+        TypeID = arrow.type.ID.Int32
+        BitWidth = 32;
+    end
+end

--- a/matlab/test/arrow/type/tInt64Type.m
+++ b/matlab/test/arrow/type/tInt64Type.m
@@ -17,7 +17,6 @@ classdef tInt64Type < hPrimitiveType
 % Test class for arrow.type.Int64Type
 
     properties
-        ArrowTypeClassName = "arrow.type.Int64Type"
         ArrowType = arrow.type.Int64Type
         TypeID = arrow.type.ID.Int64
         BitWidth = 64;

--- a/matlab/test/arrow/type/tInt64Type.m
+++ b/matlab/test/arrow/type/tInt64Type.m
@@ -1,0 +1,25 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef tInt64Type < hPrimitiveType
+% Test class for arrow.type.Int64Type
+
+    properties
+        ArrowTypeClassName = "arrow.type.Int64Type"
+        ArrowType = arrow.type.Int64Type
+        TypeID = arrow.type.ID.Int64
+        BitWidth = 64;
+    end
+end

--- a/matlab/test/arrow/type/tInt8Type.m
+++ b/matlab/test/arrow/type/tInt8Type.m
@@ -17,7 +17,6 @@ classdef tInt8Type < hPrimitiveType
 % Test class for arrow.type.Int8Type
 
     properties
-        ArrowTypeClassName = "arrow.type.Int8Type"
         ArrowType = arrow.type.Int8Type
         TypeID = arrow.type.ID.Int8
         BitWidth = 8;

--- a/matlab/test/arrow/type/tInt8Type.m
+++ b/matlab/test/arrow/type/tInt8Type.m
@@ -1,0 +1,25 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef tInt8Type < hPrimitiveType
+% Test class for arrow.type.Int8Type
+
+    properties
+        ArrowTypeClassName = "arrow.type.Int8Type"
+        ArrowType = arrow.type.Int8Type
+        TypeID = arrow.type.ID.Int8
+        BitWidth = 8;
+    end
+end

--- a/matlab/test/arrow/type/tUInt16Type.m
+++ b/matlab/test/arrow/type/tUInt16Type.m
@@ -1,0 +1,25 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef tUInt16Type < hPrimitiveType
+% Test class for arrow.type.UInt16Type
+
+    properties
+        ArrowTypeClassName = "arrow.type.Int64Type"
+        ArrowType = arrow.type.UInt16Type
+        TypeID = arrow.type.ID.UInt16
+        BitWidth = 16;
+    end
+end

--- a/matlab/test/arrow/type/tUInt16Type.m
+++ b/matlab/test/arrow/type/tUInt16Type.m
@@ -17,7 +17,6 @@ classdef tUInt16Type < hPrimitiveType
 % Test class for arrow.type.UInt16Type
 
     properties
-        ArrowTypeClassName = "arrow.type.Int64Type"
         ArrowType = arrow.type.UInt16Type
         TypeID = arrow.type.ID.UInt16
         BitWidth = 16;

--- a/matlab/test/arrow/type/tUInt32Type.m
+++ b/matlab/test/arrow/type/tUInt32Type.m
@@ -1,0 +1,25 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef tUInt32Type < hPrimitiveType
+% Test class for arrow.type.UInt32Type
+
+    properties
+        ArrowTypeClassName = "arrow.type.Int64Type"
+        ArrowType = arrow.type.UInt32Type
+        TypeID = arrow.type.ID.UInt32
+        BitWidth = 32;
+    end
+end

--- a/matlab/test/arrow/type/tUInt32Type.m
+++ b/matlab/test/arrow/type/tUInt32Type.m
@@ -17,7 +17,6 @@ classdef tUInt32Type < hPrimitiveType
 % Test class for arrow.type.UInt32Type
 
     properties
-        ArrowTypeClassName = "arrow.type.Int64Type"
         ArrowType = arrow.type.UInt32Type
         TypeID = arrow.type.ID.UInt32
         BitWidth = 32;

--- a/matlab/test/arrow/type/tUInt64Type.m
+++ b/matlab/test/arrow/type/tUInt64Type.m
@@ -1,0 +1,25 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef tUInt64Type < hPrimitiveType
+% Test class for arrow.type.UInt64Type
+
+    properties
+        ArrowTypeClassName = "arrow.type.Int64Type"
+        ArrowType = arrow.type.UInt64Type
+        TypeID = arrow.type.ID.UInt64
+        BitWidth = 64;
+    end
+end

--- a/matlab/test/arrow/type/tUInt64Type.m
+++ b/matlab/test/arrow/type/tUInt64Type.m
@@ -17,7 +17,6 @@ classdef tUInt64Type < hPrimitiveType
 % Test class for arrow.type.UInt64Type
 
     properties
-        ArrowTypeClassName = "arrow.type.Int64Type"
         ArrowType = arrow.type.UInt64Type
         TypeID = arrow.type.ID.UInt64
         BitWidth = 64;

--- a/matlab/test/arrow/type/tUInt8Type.m
+++ b/matlab/test/arrow/type/tUInt8Type.m
@@ -1,0 +1,25 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef tUInt8Type < hPrimitiveType
+% Test class for arrow.type.UInt64Type
+
+    properties
+        ArrowTypeClassName = "arrow.type.Int64Type"
+        ArrowType = arrow.type.UInt8Type
+        TypeID = arrow.type.ID.UInt8
+        BitWidth = 8;
+    end
+end

--- a/matlab/test/arrow/type/tUInt8Type.m
+++ b/matlab/test/arrow/type/tUInt8Type.m
@@ -17,7 +17,6 @@ classdef tUInt8Type < hPrimitiveType
 % Test class for arrow.type.UInt64Type
 
     properties
-        ArrowTypeClassName = "arrow.type.Int64Type"
         ArrowType = arrow.type.UInt8Type
         TypeID = arrow.type.ID.UInt8
         BitWidth = 8;


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

As we continue to build up the MATLAB Interface, we need to add the `Type` class hierarchy to the interface to support objects with schemas.


### What changes are included in this PR?

1. Added an enum class called `arrow.type.ID` with the following values:
```matlab
>> enumeration(arrow.type.ID.Boolean)

Enumeration members for class 'arrow.type.ID':

    Boolean
    UInt8
    Int8
    UInt16
    Int16
    UInt32
    Int32
    UInt64
    Int64
    Float32
    Float64
```

2. Added an abstract class representing a type called `arrow.type.Type`. It defines one property named `ID` that all concrete subclasses must define. `ID` must be an `arrow.type.ID`.

3. Defined an abstract class called `arrow.type.PrimitiveType` that inherits from `arrow.type.Type`. All primitive type classes inherit from this class.

4. Defined the following concrete type classes: 
    - `arrow.type.BooleanType`
    - `arrow.type.Float32Type`
    - `arrow.type.Float64Type`
    - `arrow.type.Int8Type`
    - `arrow.type.UInt8Type`
    - `arrow.type.Int16Type`
    - `arrow.type.UInt16Type`
    - `arrow.type.Int32Type`
    - `arrow.type.UInt32Type`
    - `arrow.type.Int64Type`
    - `arrow.type.UInt64Type`

### Are these changes tested?

Yes, added the following test classes: 
    - `tID.m`
    - `tBooleanType.m`
    - `tFloat32Type.m`
    - `tFloat64Type.m`
    - `tInt8Type.m`
    - `tUInt8Type.m`
    - `tInt16Type.m`
    - `tUInt16Type.m`
    - `tInt32Type.m`
    - `tUInt32Type.m`
    - `tInt64Type.m`
    - `tUInt64Type.m`

### Future Directions

1. Add a new property to `arrow.array.Array` called `Type`.
2. Add a `arrow.type.Field` class.
3. Add a `arrow.tabular.Schema` class.
4. As we add more array types, we will extend `arrow.type.ID` and add the appropriate type class. 

* Closes: #36177 
