### PR TITLE
GH-36218:  [CI][Go] Run benchmark steps only on the main branch

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -94,7 +94,8 @@ jobs:
         if: >-
           success() &&
           github.event_name == 'push' &&
-          github.repository == 'apache/arrow'
+          github.repository == 'apache/arrow' &&
+          github.ref_name == 'main'
         env:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -105,7 +106,8 @@ jobs:
           success() &&
           matrix.arch == 'amd64' &&
           github.event_name == 'push' &&
-          github.repository == 'apache/arrow'
+          github.repository == 'apache/arrow' &&
+          github.ref_name == 'main'
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
@@ -131,13 +133,13 @@ jobs:
     name: Go Cross-build for 386
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
-    timeout-minutes: 20    
+    timeout-minutes: 20
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0          
-      - name: Install Go        
+          fetch-depth: 0
+      - name: Install Go
         uses: actions/setup-go@v3
         with:
           go-version: 1.18
@@ -225,7 +227,11 @@ jobs:
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         run: archery docker run debian-go-cgo-python
       - name: Docker Push
-        if: success() && github.event_name == 'push' && github.repository == 'apache/arrow'
+        if: >-
+          success() &&
+          github.event_name == 'push' &&
+          github.repository == 'apache/arrow' &&
+          github.ref_name == 'main'
         env:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -302,12 +308,20 @@ jobs:
         shell: bash
         run: ci/scripts/go_test.sh $(pwd)
       - name: Setup Python
-        if: success() && github.event_name == 'push' && github.repository == 'apache/arrow'
+        if: >-
+          success() &&
+          github.event_name == 'push' &&
+          github.repository == 'apache/arrow' &&
+          github.ref_name == 'main'
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
       - name: Run Benchmarks
-        if: success() && github.event_name == 'push' && github.repository == 'apache/arrow'
+        if: >-
+          success() &&
+          github.event_name == 'push' &&
+          github.repository == 'apache/arrow' &&
+          github.ref_name == 'main'
         shell: bash
         env:
           CONBENCH_URL: 'https://conbench.ursa.dev'


### PR DESCRIPTION
### Rationale for this change

Because our benchmark tool supports only the main branch.

### What changes are included in this PR?

Add branch name check to the existing `if:`s.

### Are these changes tested?

No.

### Are there any user-facing changes?

No.
* Closes: #36218 