### PR TITLE
GH-36214: [C++] Specify `FieldPath::Hash` as template parameter where possible

### DIFF
--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -20,9 +20,6 @@
 #include "arrow/compute/kernels/vector_sort_internal.h"
 #include "arrow/compute/registry.h"
 
-template <>
-struct std::hash<arrow::FieldPath> : public arrow::FieldPath::Hash {};
-
 namespace arrow {
 
 using internal::checked_cast;
@@ -1095,7 +1092,7 @@ struct SortFieldPopulator {
   }
 
   std::vector<SortField> sort_fields_;
-  std::unordered_set<FieldPath> seen_;
+  std::unordered_set<FieldPath, FieldPath::Hash> seen_;
   std::vector<int> tmp_indices_;
 };
 

--- a/cpp/src/arrow/ipc/dictionary.cc
+++ b/cpp/src/arrow/ipc/dictionary.cc
@@ -35,13 +35,6 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/logging.h"
 
-namespace std {
-template <>
-struct hash<arrow::FieldPath> {
-  size_t operator()(const arrow::FieldPath& path) const { return path.hash(); }
-};
-}  // namespace std
-
 namespace arrow {
 
 using internal::checked_cast;
@@ -54,7 +47,7 @@ using internal::FieldPosition;
 // DictionaryFieldMapper implementation
 
 struct DictionaryFieldMapper::Impl {
-  using FieldPathMap = std::unordered_map<FieldPath, int64_t>;
+  using FieldPathMap = std::unordered_map<FieldPath, int64_t, FieldPath::Hash>;
 
   FieldPathMap field_path_to_id;
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Internal specializations of `std::hash<FieldPath>` have caused multiple-definition errors with unity builds.

### What changes are included in this PR?

To avoid exposing a global specialization of `std::hash` (which must be declared in the `std` namespace), this specifies the `FieldPath::Hash` helper as a template parameter to hashable containers instead.

### Are these changes tested?

Yes (covered by existing tests)

### Are there any user-facing changes?

No

* Closes: #36214