### PR TITLE
GH-36224: [CI] Update rest api invocations in GitHub scripts

### DIFF
--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -186,7 +186,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            github.issues.addAssignees({
+            github.rest.issues.addAssignees({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.payload.issue.number,

--- a/.github/workflows/dev_pr/helpers.js
+++ b/.github/workflows/dev_pr/helpers.js
@@ -75,7 +75,7 @@ async function getJiraInfo(jiraID) {
  */
  async function getGitHubInfo(github, context, issueID, pullRequestNumber) {
     try {
-        const response = await github.issues.get({
+        const response = await github.rest.issues.get({
             issue_number: issueID,
             owner: context.repo.owner,
             repo: context.repo.repo,

--- a/.github/workflows/dev_pr/issue_check.js
+++ b/.github/workflows/dev_pr/issue_check.js
@@ -48,7 +48,7 @@ async function verifyJIRAIssue(github, context, pullRequestNumber, jiraID) {
  * @param {String} pullRequestNumber
  */
 async function commentMissingComponents(github, context, pullRequestNumber) {
-    const {data: comments} = await github.issues.listComments({
+    const {data: comments} = await github.rest.issues.listComments({
         owner: context.repo.owner,
         repo: context.repo.repo,
         issue_number: pullRequestNumber,
@@ -62,7 +62,7 @@ async function commentMissingComponents(github, context, pullRequestNumber) {
         } 
     }
     if (!found) {
-        await github.issues.createComment({
+        await github.rest.issues.createComment({
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: pullRequestNumber,
@@ -79,7 +79,7 @@ async function commentMissingComponents(github, context, pullRequestNumber) {
  * @param {String} pullRequestNumber
  */
 async function commentNotStartedTicket(github, context, pullRequestNumber) {
-    const {data: comments} = await github.issues.listComments({
+    const {data: comments} = await github.rest.issues.listComments({
         owner: context.repo.owner,
         repo: context.repo.repo,
         issue_number: pullRequestNumber,
@@ -93,7 +93,7 @@ async function commentNotStartedTicket(github, context, pullRequestNumber) {
         } 
     }
     if (!found) {
-        await github.issues.createComment({
+        await github.rest.issues.createComment({
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: pullRequestNumber,
@@ -111,13 +111,13 @@ async function commentNotStartedTicket(github, context, pullRequestNumber) {
  * @param {Object} issueInfo
  */
 async function assignGitHubIssue(github, context, pullRequestNumber, issueInfo) {
-    await github.issues.addAssignees({
+    await github.rest.issues.addAssignees({
         owner: context.repo.owner,
         repo: context.repo.repo,
         issue_number: issueInfo.number,
         assignees: context.payload.pull_request.user.login
     });
-    await github.issues.createComment({
+    await github.rest.issues.createComment({
         owner: context.repo.owner,
         repo: context.repo.repo,
         issue_number: pullRequestNumber,
@@ -139,7 +139,7 @@ async function assignGitHubIssue(github, context, pullRequestNumber, issueInfo) 
 async function verifyGitHubIssue(github, context, pullRequestNumber, issueID) {
     const issueInfo = await helpers.getGitHubInfo(github, context, issueID, pullRequestNumber);
     if (!issueInfo) {
-        await github.issues.createComment({
+        await github.rest.issues.createComment({
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: pullRequestNumber,
@@ -150,7 +150,7 @@ async function verifyGitHubIssue(github, context, pullRequestNumber, issueID) {
         await assignGitHubIssue(github, context, pullRequestNumber, issueInfo);
     }
     if(!issueInfo.labels.filter((label) => label.name.startsWith("Component:")).length) {
-        await github.issues.createComment({
+        await github.rest.issues.createComment({
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: pullRequestNumber,

--- a/.github/workflows/dev_pr/link.js
+++ b/.github/workflows/dev_pr/link.js
@@ -35,7 +35,7 @@ async function haveComment(github, context, pullRequestNumber, message) {
     page: 1
   };
   while (true) {
-    const response = await github.issues.listComments(options);
+    const response = await github.rest.issues.listComments(options);
     if (response.data.some(comment => comment.body === message)) {
       return true;
     }
@@ -62,7 +62,7 @@ async function commentJIRAURL(github, context, pullRequestNumber, jiraID) {
     return;
   }
   if (issueInfo){
-    await github.issues.createComment({
+    await github.rest.issues.createComment({
       owner: context.repo.owner,
       repo: context.repo.repo,
       issue_number: pullRequestNumber,
@@ -87,7 +87,7 @@ async function commentGitHubURL(github, context, pullRequestNumber, issueID) {
     if (context.payload.pull_request.body.includes(message)) {
       return;
     }
-    await github.pulls.update({
+    await github.rest.pulls.update({
       owner: context.repo.owner,
       repo: context.repo.repo,
       pull_number: pullRequestNumber,

--- a/.github/workflows/dev_pr/title_check.js
+++ b/.github/workflows/dev_pr/title_check.js
@@ -19,7 +19,7 @@ const fs = require("fs");
 const helpers = require("./helpers.js");
 
 async function commentOpenGitHubIssue(github, context, pullRequestNumber) {
-  const {data: comments} = await github.issues.listComments({
+  const {data: comments} = await github.rest.issues.listComments({
     owner: context.repo.owner,
     repo: context.repo.repo,
     issue_number: pullRequestNumber,
@@ -30,7 +30,7 @@ async function commentOpenGitHubIssue(github, context, pullRequestNumber) {
   }
   const commentPath = ".github/workflows/dev_pr/title_check.md";
   const comment = fs.readFileSync(commentPath).toString();
-  await github.issues.createComment({
+  await github.rest.issues.createComment({
     owner: context.repo.owner,
     repo: context.repo.repo,
     issue_number: pullRequestNumber,


### PR DESCRIPTION
The rest api calls were moved into from `github.` to `github.rest.` so the workflows are failing after the update to gh script v6.

### Are these changes tested?

As these changes are in priviliged workflows testing is only possible after merge.

Closes #36224 