### PR TITLE
GH-36218: [CI][Go] Run benchmark steps only on the main branch

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -118,7 +118,8 @@ jobs:
           success() &&
           matrix.arch == 'amd64' &&
           github.event_name == 'push' &&
-          github.repository == 'apache/arrow'
+          github.repository == 'apache/arrow' &&
+          github.ref_name == 'main'
         env:
           CONBENCH_URL: https://conbench.ursa.dev
           CONBENCH_EMAIL: ${{ secrets.CONBENCH_EMAIL }}


### PR DESCRIPTION
### Rationale for this change

Sorry. This is a follow-up of GH-36219. We need one more change for this.

### What changes are included in this PR?

Add one more branch name check.

### Are these changes tested?

No.

### Are there any user-facing changes?

No.
* Closes: #36218