### PR TITLE
GH-36128: [C++][Compute] Allow multiplication between duration and all integer types

### DIFF
--- a/cpp/src/arrow/compute/kernels/codegen_internal.cc
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.cc
@@ -482,6 +482,21 @@ bool HasDecimal(const std::vector<TypeHolder>& types) {
   return false;
 }
 
+void PromoteIntegerForDurationArithmetic(std::vector<TypeHolder>* types) {
+  bool has_duration = std::any_of(types->begin(), types->end(), [](const TypeHolder& t) {
+    return t.id() == Type::DURATION;
+  });
+
+  if (!has_duration) return;
+
+  // Require implicit casts to int64 to match duration's bit width
+  for (auto& type : *types) {
+    if (is_integer(type.id())) {
+      type = int64();
+    }
+  }
+}
+
 }  // namespace internal
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -46,6 +46,7 @@
 #include "arrow/util/decimal.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/macros.h"
+#include "arrow/util/visibility.h"
 #include "arrow/visit_data_inline.h"
 
 namespace arrow {
@@ -1337,7 +1338,7 @@ ArrayKernelExec GenerateDecimal(detail::GetTypeId get_id) {
 
 // END of kernel generator-dispatchers
 // ----------------------------------------------------------------------
-
+// BEGIN of DispatchBest helpers
 ARROW_EXPORT
 void EnsureDictionaryDecoded(std::vector<TypeHolder>* types);
 
@@ -1396,6 +1397,11 @@ Status CastDecimalArgs(TypeHolder* begin, size_t count);
 ARROW_EXPORT
 bool HasDecimal(const std::vector<TypeHolder>& types);
 
+ARROW_EXPORT
+void PromoteIntegerForDurationArithmetic(std::vector<TypeHolder>* types);
+
+// END of DispatchBest helpers
+// ----------------------------------------------------------------------
 }  // namespace internal
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -886,6 +886,10 @@ struct ScalarBinaryNotNull {
   }
 };
 
+// A kernel exec generator for binary kernels where arg orders are reversed
+template <typename OutType, typename Arg0Type, typename Arg1Type, typename Op>
+using ScalarBinaryReverse = ScalarBinary<OutType, Arg1Type, Arg0Type, Op>;
+
 // A kernel exec generator for binary kernels where both input types are the
 // same
 template <typename OutType, typename ArgType, typename Op>

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -886,10 +886,6 @@ struct ScalarBinaryNotNull {
   }
 };
 
-// A kernel exec generator for binary kernels where arg orders are reversed
-template <typename OutType, typename Arg0Type, typename Arg1Type, typename Op>
-using ScalarBinaryReverse = ScalarBinary<OutType, Arg1Type, Arg0Type, Op>;
-
 // A kernel exec generator for binary kernels where both input types are the
 // same
 template <typename OutType, typename ArgType, typename Op>

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -642,6 +642,16 @@ struct ArithmeticFunction : ScalarFunction {
           ReplaceTypes(type, types);
         }
       }
+
+      if (name_ == "multiply_checked") {
+        // Multiply_checked requires the same type for both operands, so we can't easily
+        // make kernels for duration * integers, so we just cast the integers to int64
+        if ((*types)[0].id() == Type::DURATION && is_integer((*types)[1].id())) {
+          ReplaceTypes(int64(), &(*types)[1], 1);
+        } else if ((*types)[1].id() == Type::DURATION && is_integer((*types)[0].id())) {
+          ReplaceTypes(int64(), &(*types)[0], 1);
+        }
+      }
     }
 
     if (auto kernel = DispatchExactImpl(this, *types)) return kernel;

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -644,8 +644,9 @@ struct ArithmeticFunction : ScalarFunction {
       }
 
       if (name_ == "multiply_checked") {
-        // Multiply_checked requires the same type for both operands, so we can't easily
-        // make kernels for duration * integers, so we just cast the integers to int64
+        // MultiplyChecked requires the same type for both operands, therefore we can't
+        // easily make kernels for integers other than int64, so we just cast integers to
+        // int64
         if ((*types)[0].id() == Type::DURATION && is_integer((*types)[1].id())) {
           ReplaceTypes(int64(), &(*types)[1], 1);
         } else if ((*types)[1].id() == Type::DURATION && is_integer((*types)[0].id())) {

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -617,21 +617,6 @@ ArrayKernelExec GenerateArithmeticWithFixedIntOutType(detail::GetTypeId get_id) 
   }
 }
 
-void PromoteIntegerForDurationArithmetic(std::vector<TypeHolder>* types) {
-  bool has_duration = std::any_of(types->begin(), types->end(), [](const TypeHolder& t) {
-    return t.id() == Type::DURATION;
-  });
-
-  if (!has_duration) return;
-
-  // Require implicit casts to int64 to match duration's bit width
-  for (auto& type : *types) {
-    if (is_integer(type.id())) {
-      type = int64();
-    }
-  }
-}
-
 struct ArithmeticFunction : ScalarFunction {
   using ScalarFunction::ScalarFunction;
 

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -51,7 +51,6 @@ using applicator::ScalarBinary;
 using applicator::ScalarBinaryEqualTypes;
 using applicator::ScalarBinaryNotNull;
 using applicator::ScalarBinaryNotNullEqualTypes;
-using applicator::ScalarBinaryReverse;
 using applicator::ScalarUnary;
 using applicator::ScalarUnaryNotNull;
 using applicator::ScalarUnaryNotNullStateful;

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -652,6 +652,12 @@ struct ArithmeticFunction : ScalarFunction {
         } else if ((*types)[1].id() == Type::DURATION && is_integer((*types)[0].id())) {
           ReplaceTypes(int64(), &(*types)[0], 1);
         }
+      } else if (name_ == "divide" || name_ == "divide_checked") {
+        // Similar to MultipyChecked, Divide and DivideChecked require both operands to
+        // have the same type
+        if ((*types)[0].id() == Type::DURATION && is_integer((*types)[1].id())) {
+          ReplaceTypes(int64(), &(*types)[1], 1);
+        }
       }
     }
 

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -1152,6 +1152,23 @@ TEST(TestBinaryArithmetic, AddWithImplicitCastsUint64EdgeCase) {
                                      ArrayFromJSON(uint64(), "[18446744073709551615]")}));
 }
 
+TEST(TestBinaryArithmetic, MultiplyDuration) {
+  // multiplication should work for all duration units and integer types
+  for (auto time_unit : TimeUnit::values()) {
+    for (auto numeric : NumericTypes()) {
+      if (!is_integer(numeric->id())) {
+        continue;
+      }
+      CheckScalarBinary("multiply", ArrayFromJSON(numeric, "[1, 2, 3, null]"),
+                        ArrayFromJSON(duration(time_unit), "[1, 2, 3, 4]"),
+                        ArrayFromJSON(duration(time_unit), "[1, 4, 9, null]"));
+      CheckScalarBinary("multiply", ArrayFromJSON(duration(time_unit), "[1, 2, 3, 4]"),
+                        ArrayFromJSON(numeric, "[1, 2, 3, null]"),
+                        ArrayFromJSON(duration(time_unit), "[1, 4, 9, null]"));
+    }
+  }
+}
+
 TEST(TestUnaryArithmetic, DispatchBest) {
   // All types (with _checked variant)
   for (std::string name : {"abs"}) {

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -1152,53 +1152,6 @@ TEST(TestBinaryArithmetic, AddWithImplicitCastsUint64EdgeCase) {
                                      ArrayFromJSON(uint64(), "[18446744073709551615]")}));
 }
 
-TEST(TestBinaryArithmetic, MultiplyDuration) {
-  // multiplication should work for all duration units and integer types
-  for (auto time_unit : TimeUnit::values()) {
-    for (auto numeric : NumericTypes()) {
-      if (!is_integer(numeric->id())) {
-        continue;
-      }
-      CheckScalarBinary("multiply", ArrayFromJSON(numeric, "[1, 2, 3, null]"),
-                        ArrayFromJSON(duration(time_unit), "[1, 2, 3, 4]"),
-                        ArrayFromJSON(duration(time_unit), "[1, 4, 9, null]"));
-      CheckScalarBinary("multiply", ArrayFromJSON(duration(time_unit), "[1, 2, 3, 4]"),
-                        ArrayFromJSON(numeric, "[1, 2, 3, null]"),
-                        ArrayFromJSON(duration(time_unit), "[1, 4, 9, null]"));
-      CheckScalarBinary("multiply_checked", ArrayFromJSON(numeric, "[1, 2, 3, null]"),
-                        ArrayFromJSON(duration(time_unit), "[1, 2, 3, 4]"),
-                        ArrayFromJSON(duration(time_unit), "[1, 4, 9, null]"));
-      CheckScalarBinary("multiply_checked",
-                        ArrayFromJSON(duration(time_unit), "[1, 2, 3, 4]"),
-                        ArrayFromJSON(numeric, "[1, 2, 3, null]"),
-                        ArrayFromJSON(duration(time_unit), "[1, 4, 9, null]"));
-    }
-  }
-
-  // and overflows are properly handled
-  ASSERT_RAISES(
-      Invalid,
-      CallFunction("multiply_checked",
-                   {ArrayFromJSON(uint8(), "[2]"),
-                    ArrayFromJSON(duration(TimeUnit::SECOND), "[4611686018427387904]")}));
-  ASSERT_RAISES(
-      Invalid, CallFunction("multiply_checked", {ArrayFromJSON(duration(TimeUnit::SECOND),
-                                                               "[4611686018427387904]"),
-                                                 ArrayFromJSON(uint8(), "[2]")}));
-  ASSERT_RAISES(Invalid,
-                CallFunction("multiply_checked",
-                             {ArrayFromJSON(duration(TimeUnit::SECOND), "[1]"),
-                              ArrayFromJSON(uint64(), "[18446744073709551615]")}));
-
-  CheckScalarBinary("multiply",
-                    ArrayFromJSON(duration(TimeUnit::SECOND), "[4611686018427387904]"),
-                    ArrayFromJSON(uint8(), "[2]"),
-                    ArrayFromJSON(duration(TimeUnit::SECOND), "[-9223372036854775808]"));
-  CheckScalarBinary("multiply", ArrayFromJSON(uint8(), "[2]"),
-                    ArrayFromJSON(duration(TimeUnit::SECOND), "[4611686018427387904]"),
-                    ArrayFromJSON(duration(TimeUnit::SECOND), "[-9223372036854775808]"));
-}
-
 TEST(TestUnaryArithmetic, DispatchBest) {
   // All types (with _checked variant)
   for (std::string name : {"abs"}) {

--- a/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
@@ -26,6 +26,7 @@
 #include "arrow/testing/matchers.h"
 #include "arrow/testing/util.h"
 #include "arrow/type.h"
+#include "arrow/type_traits.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/formatting.h"
 #include "arrow/util/logging.h"
@@ -1671,41 +1672,51 @@ TEST_F(ScalarTemporalTest, TestTemporalMultiplyDuration) {
   ArrayFromVector<Int64Type, int64_t>({max, max, max, max, max}, &max_array);
 
   for (auto u : TimeUnit::values()) {
-    auto unit = duration(u);
-    auto durations = ArrayFromJSON(unit, R"([0, -1, 2, 6, null])");
-    auto multipliers = ArrayFromJSON(int64(), R"([0, 3, 2, 7, null])");
-    auto durations_multiplied = ArrayFromJSON(unit, R"([0, -3, 4, 42, null])");
+    for (auto numeric : NumericTypes()) {
+      if (!is_integer(numeric->id())) continue;
+      auto unit = duration(u);
+      auto durations = ArrayFromJSON(unit, R"([0, -1, 2, 6, null])");
+      auto multipliers = ArrayFromJSON(numeric, R"([0, 3, 2, 7, null])");
+      auto durations_multiplied = ArrayFromJSON(unit, R"([0, -3, 4, 42, null])");
 
-    CheckScalarBinaryCommutative("multiply", durations, multipliers,
-                                 durations_multiplied);
-    CheckScalarBinaryCommutative("multiply_checked", durations, multipliers,
-                                 durations_multiplied);
+      CheckScalarBinaryCommutative("multiply", durations, multipliers,
+                                   durations_multiplied);
+      CheckScalarBinaryCommutative("multiply_checked", durations, multipliers,
+                                   durations_multiplied);
 
-    EXPECT_RAISES_WITH_MESSAGE_THAT(
-        Invalid, ::testing::HasSubstr("Invalid: overflow"),
-        CallFunction("multiply_checked", {durations, max_array}));
-    EXPECT_RAISES_WITH_MESSAGE_THAT(
-        Invalid, ::testing::HasSubstr("Invalid: overflow"),
-        CallFunction("multiply_checked", {max_array, durations}));
+      EXPECT_RAISES_WITH_MESSAGE_THAT(
+          Invalid, ::testing::HasSubstr("Invalid: overflow"),
+          CallFunction("multiply_checked", {durations, max_array}));
+      EXPECT_RAISES_WITH_MESSAGE_THAT(
+          Invalid, ::testing::HasSubstr("Invalid: overflow"),
+          CallFunction("multiply_checked", {max_array, durations}));
+    }
   }
 }
 
 TEST_F(ScalarTemporalTest, TestTemporalDivideDuration) {
   for (auto u : TimeUnit::values()) {
-    auto unit = duration(u);
-    auto divided_durations = ArrayFromJSON(unit, R"([0, -1, -2, 6, null])");
-    auto divisors = ArrayFromJSON(int64(), R"([3, 3, -2, 7, null])");
-    auto durations = ArrayFromJSON(unit, R"([1, -3, 4, 42, null])");
-    auto zeros = ArrayFromJSON(int64(), R"([0, 0, 0, 0, null])");
-    CheckScalarBinary("divide", durations, divisors, divided_durations);
-    CheckScalarBinary("divide_checked", durations, divisors, divided_durations);
+    for (auto numeric : NumericTypes()) {
+      if (!is_integer(numeric->id())) continue;
+      auto unit = duration(u);
+      auto divided_durations = is_signed_integer(numeric->id())
+                                   ? ArrayFromJSON(unit, R"([0, -1, -2, 6, null])")
+                                   : ArrayFromJSON(unit, R"([0, -1, 2, 6, null])");
+      auto divisors = is_signed_integer(numeric->id())
+                          ? ArrayFromJSON(numeric, R"([3, 3, -2, 7, null])")
+                          : ArrayFromJSON(numeric, R"([3, 3, 2, 7, null])");
+      auto durations = ArrayFromJSON(unit, R"([1, -3, 4, 42, null])");
+      auto zeros = ArrayFromJSON(numeric, R"([0, 0, 0, 0, null])");
+      CheckScalarBinary("divide", durations, divisors, divided_durations);
+      CheckScalarBinary("divide_checked", durations, divisors, divided_durations);
 
-    EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid,
-                                    ::testing::HasSubstr("Invalid: divide by zero"),
-                                    CallFunction("divide", {durations, zeros}));
-    EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid,
-                                    ::testing::HasSubstr("Invalid: divide by zero"),
-                                    CallFunction("divide_checked", {durations, zeros}));
+      EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid,
+                                      ::testing::HasSubstr("Invalid: divide by zero"),
+                                      CallFunction("divide", {durations, zeros}));
+      EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid,
+                                      ::testing::HasSubstr("Invalid: divide by zero"),
+                                      CallFunction("divide_checked", {durations, zeros}));
+    }
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Currently durations can only be multiplied with int64, but no other integer types.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Allow duration types to be multiplied with any integer type.
1. For `multiply`, new kernels are added to support the new types.
2. For `multiply_checked`, integers will be casted to int64. We can't add new kernels because the MultiplyChecked op class requires both operands to have the same type.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes.

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->

No.
* Closes: #36128