### PR TITLE
GH-36233: [Packaging][Ubuntu] Add support for Ubuntu 23.04 (lunar)

### DIFF
--- a/dev/release/binary-task.rb
+++ b/dev/release/binary-task.rb
@@ -1087,6 +1087,7 @@ class BinaryTask
       ["debian", "bookworm", "main"],
       ["ubuntu", "focal", "main"],
       ["ubuntu", "jammy", "main"],
+      ["ubuntu", "lunar", "main"],
     ]
   end
 

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -192,7 +192,9 @@ test_apt() {
                 "ubuntu:focal" \
                 "arm64v8/ubuntu:focal" \
                 "ubuntu:jammy" \
-                "arm64v8/ubuntu:jammy"; do \
+                "arm64v8/ubuntu:jammy" \
+                "ubuntu:lunar" \
+                "arm64v8/ubuntu:lunar"; do \
     case "${target}" in
       arm64v8/*)
         if [ "$(arch)" = "aarch64" -o -e /usr/bin/qemu-aarch64-static ]; then

--- a/dev/tasks/linux-packages/apache-arrow-apt-source/apt/ubuntu-lunar/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow-apt-source/apt/ubuntu-lunar/Dockerfile
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM ubuntu:lunar
+
+RUN \
+  echo "debconf debconf/frontend select Noninteractive" | \
+    debconf-set-selections
+
+RUN \
+  echo 'APT::Install-Recommends "false";' > \
+    /etc/apt/apt.conf.d/disable-install-recommends
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
+    build-essential \
+    debhelper \
+    devscripts \
+    fakeroot \
+    gnupg \
+    lsb-release && \
+  apt clean && \
+  rm -rf /var/lib/apt/lists/*

--- a/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-lunar-arm64/from
+++ b/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-lunar-arm64/from
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+arm64v8/ubuntu:kinetic

--- a/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-lunar-arm64/from
+++ b/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-lunar-arm64/from
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-arm64v8/ubuntu:kinetic
+arm64v8/ubuntu:lunar

--- a/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-lunar/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-lunar/Dockerfile
@@ -1,0 +1,85 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ARG FROM=ubuntu:lunar
+FROM ${FROM}
+
+RUN \
+  echo "debconf debconf/frontend select Noninteractive" | \
+    debconf-set-selections
+
+RUN \
+  echo 'APT::Install-Recommends "false";' > \
+    /etc/apt/apt.conf.d/disable-install-recommends
+
+ARG DEBUG
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
+    build-essential \
+    clang \
+    clang-tools \
+    cmake \
+    debhelper \
+    devscripts \
+    git \
+    gtk-doc-tools \
+    libboost-filesystem-dev \
+    libboost-system-dev \
+    libbrotli-dev \
+    libbz2-dev \
+    libc-ares-dev \
+    libcurl4-openssl-dev \
+    libgirepository1.0-dev \
+    libglib2.0-doc \
+    libgmock-dev \
+    libgoogle-glog-dev \
+    libgrpc++-dev \
+    libgtest-dev \
+    liblz4-dev \
+    libmlir-15-dev \
+    libprotobuf-dev \
+    libprotoc-dev \
+    libre2-dev \
+    libsnappy-dev \
+    libssl-dev \
+    libthrift-dev \
+    libutf8proc-dev \
+    libzstd-dev \
+    llvm-dev \
+    lsb-release \
+    meson \
+    mlir-15-tools \
+    ninja-build \
+    nlohmann-json3-dev \
+    pkg-config \
+    protobuf-compiler-grpc \
+    python3-dev \
+    python3-pip \
+    python3-setuptools \
+    rapidjson-dev \
+    tzdata \
+    valac \
+    zlib1g-dev && \
+  if apt list | grep -q '^libcuda1'; then \
+    apt install -y -V ${quiet} nvidia-cuda-toolkit; \
+  else \
+    :; \
+  fi && \
+  apt clean && \
+  rm -rf /var/lib/apt/lists/*

--- a/dev/tasks/linux-packages/package-task.rb
+++ b/dev/tasks/linux-packages/package-task.rb
@@ -275,6 +275,8 @@ class PackageTask
       # "ubuntu-focal-arm64",
       "ubuntu-jammy",
       # "ubuntu-jammy-arm64",
+      "ubuntu-lunar",
+      # "ubuntu-lunar-arm64",
     ]
   end
 

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -502,7 +502,8 @@ tasks:
 {% for target in ["debian-bullseye",
                   "debian-bookworm",
                   "ubuntu-focal",
-                  "ubuntu-jammy"] %}
+                  "ubuntu-jammy",
+                  "ubuntu-lunar"] %}
   {% for architecture in ["amd64", "arm64"] %}
   {{ target }}-{{ architecture }}:
     ci: github


### PR DESCRIPTION
### Rationale for this change

Ubuntu 23.04 (Lunar Lobster) was released on April: https://wiki.ubuntu.com/Releases

> Version | Code name | Docs | Release | End of Standard Support | End of Life
> -- | -- | -- | -- | -- | --
> Ubuntu 23.04 | Lunar Lobster | Release Notes | April 20, 2023 | January 2024 | January 2024

### What changes are included in this PR?

Add support for Ubuntu 23.04

### Are these changes tested?

Yes, crossbow.

### Are there any user-facing changes?

Yes
* Closes: #36233