### PR TITLE
GH-36243: [Dev] Remove PR workflow label as part of merge

### DIFF
--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -418,11 +418,11 @@ class GitHubAPI(object):
         }
         response = requests.put(url, headers=self.headers, json=payload)
         result = response.json()
-        if response.status_code != 200 and 'merged' not in result:
-            result['merged'] = False
-            result['message'] += f': {url}'
-        else:
+        if response.status_code == 200 and 'merged' in result:
             self.clear_pr_state_labels(number)
+        else:
+            result['merged'] = False
+            result['message'] += f': {url}'            
         return result
 
     def clear_pr_state_labels(self, number):
@@ -430,9 +430,10 @@ class GitHubAPI(object):
         response = requests.get(url, headers=self.headers)
         labels = response.json()
         for label in labels:
+            # All PR workflow state labes starts with "awaiting"
             if label['name'].startswith('awaiting'):
                 label_url = f"{url}/{label['name']}"
-                response = requests.delete(label_url, headers=self.headers)
+                requests.delete(label_url, headers=self.headers)
 
 
 class CommandInput(object):

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -421,7 +421,18 @@ class GitHubAPI(object):
         if response.status_code != 200 and 'merged' not in result:
             result['merged'] = False
             result['message'] += f': {url}'
+        else:
+            self.clear_pr_state_labels(number)
         return result
+
+    def clear_pr_state_labels(self, number):
+        url = f'{self.github_api}/issues/{number}/labels'
+        response = requests.get(url, headers=self.headers)
+        labels = response.json()
+        for label in labels:
+            if label['name'].startswith('awaiting'):
+                label_url = f"{url}/{label['name']}"
+                response = requests.delete(label_url, headers=self.headers)
 
 
 class CommandInput(object):

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -422,7 +422,7 @@ class GitHubAPI(object):
             self.clear_pr_state_labels(number)
         else:
             result['merged'] = False
-            result['message'] += f': {url}'            
+            result['message'] += f': {url}'
         return result
 
     def clear_pr_state_labels(self, number):


### PR DESCRIPTION
### Rationale for this change

Those labels are unnecessary once they are merged. There was a conversation on Zulip about removing them in the past.

### What changes are included in this PR?

Once we merge a PR we remove labels that starts with the PR workflow prefix `awaiting`.

### Are these changes tested?

I have tested the code against an old testing PR I have here: https://github.com/apache/arrow/pull/35323
The label was removed successfully.

### Are there any user-facing changes?

No
* Closes: #36243