### PR TITLE
GH-36252: [Python] Add non decomposable hash aggregate UDF 

### DIFF
--- a/cpp/src/arrow/compute/row/grouper.h
+++ b/cpp/src/arrow/compute/row/grouper.h
@@ -149,7 +149,7 @@ class ARROW_EXPORT Grouper {
   ///       []
   ///   ]
   static Result<std::shared_ptr<ListArray>> MakeGroupings(
-      const UInt32Array& ids, uint32_t num_groups,
+      const UInt32Array& ids, uint32_t  ,
       ExecContext* ctx = default_exec_context());
 
   /// \brief Produce a ListArray whose slots are selections of `array` which correspond to

--- a/cpp/src/arrow/compute/row/grouper.h
+++ b/cpp/src/arrow/compute/row/grouper.h
@@ -149,8 +149,7 @@ class ARROW_EXPORT Grouper {
   ///       []
   ///   ]
   static Result<std::shared_ptr<ListArray>> MakeGroupings(
-      const UInt32Array& ids, uint32_t  ,
-      ExecContext* ctx = default_exec_context());
+      const UInt32Array& ids, uint32_t, ExecContext* ctx = default_exec_context());
 
   /// \brief Produce a ListArray whose slots are selections of `array` which correspond to
   /// the provided groupings.

--- a/cpp/src/arrow/compute/row/grouper.h
+++ b/cpp/src/arrow/compute/row/grouper.h
@@ -149,7 +149,8 @@ class ARROW_EXPORT Grouper {
   ///       []
   ///   ]
   static Result<std::shared_ptr<ListArray>> MakeGroupings(
-      const UInt32Array& ids, uint32_t, ExecContext* ctx = default_exec_context());
+      const UInt32Array& ids, uint32_t num_groups,
+      ExecContext* ctx = default_exec_context());
 
   /// \brief Produce a ListArray whose slots are selections of `array` which correspond to
   /// the provided groupings.

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2824,7 +2824,7 @@ def register_aggregate_function(func, function_name, function_doc, in_types, out
     >>> answer
     <pyarrow.DoubleScalar: 30.0>
     >>> table = pa.table([pa.array([1, 1, 2, 2]), pa.array([10, 20, 30, 40])], names=['k', 'v'])
-    >>> result = table.group_by('k').aggregate(['v', 'py_compute_median'])
+    >>> result = table.group_by('k').aggregate([('v', 'py_compute_median')])
     >>> result
     pyarrow.Table
     k: int64

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2767,6 +2767,9 @@ def register_aggregate_function(func, function_name, function_doc, in_types, out
     This is often used with ordered or segmented aggregation where groups
     can be emit before accumulating all of the input data.
 
+    Note that currently size of any input column can not exceed 2 GB limit
+    (all groups combined).
+
     Parameters
     ----------
     func : callable

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2767,8 +2767,8 @@ def register_aggregate_function(func, function_name, function_doc, in_types, out
     This is often used with ordered or segmented aggregation where groups
     can be emit before accumulating all of the input data.
 
-    Note that currently size of any input column can not exceed 2 GB limit
-    (all groups combined).
+    Note that currently the size of any input column can not exceed 2 GB
+    for a single segment (all groups combined).
 
     Parameters
     ----------

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2823,6 +2823,15 @@ def register_aggregate_function(func, function_name, function_doc, in_types, out
     >>> answer = pc.call_function(func_name, [pa.array([20, 40])])
     >>> answer
     <pyarrow.DoubleScalar: 30.0>
+    >>> table = pa.table([pa.array([1, 1, 2, 2]), pa.array([10, 20, 30, 40])], names=['k', 'v'])
+    >>> result = table.group_by('k').aggregate(['v', 'py_compute_median'])
+    >>> result
+    pyarrow.Table
+    k: int64
+    v_py_compute_median: double
+    ----
+    k: [[1,2]]
+    v_py_compute_median: [[15,35]]
     """
     return _register_user_defined_function(get_register_aggregate_function(),
                                            func, function_name, function_doc, in_types,

--- a/python/pyarrow/conftest.py
+++ b/python/pyarrow/conftest.py
@@ -289,7 +289,7 @@ def unary_agg_func_fixture():
     """
     from pyarrow import compute as pc
 
-    def func(ctx, x, *args):
+    def func(ctx, x):
         return pa.scalar(np.nanmean(x))
 
     func_name = "mean_udf"

--- a/python/pyarrow/conftest.py
+++ b/python/pyarrow/conftest.py
@@ -20,6 +20,8 @@ import pyarrow as pa
 from pyarrow import Codec
 from pyarrow import fs
 
+import numpy as np
+
 groups = [
     'acero',
     'brotli',
@@ -283,10 +285,9 @@ def unary_func_fixture():
 @pytest.fixture(scope="session")
 def unary_agg_func_fixture():
     """
-    Register a unary aggregate function
+    Register a unary aggregate function (mean)
     """
     from pyarrow import compute as pc
-    import numpy as np
 
     def func(ctx, x, *args):
         return pa.scalar(np.nanmean(x))
@@ -312,7 +313,6 @@ def varargs_agg_func_fixture():
     Register a unary aggregate function
     """
     from pyarrow import compute as pc
-    import numpy as np
 
     def func(ctx, *args):
         sum = 0.0
@@ -320,7 +320,7 @@ def varargs_agg_func_fixture():
             sum += np.nanmean(arg)
         return pa.scalar(sum)
 
-    func_name = "y=sum_mean(x...)"
+    func_name = "sum_mean"
     func_doc = {"summary": "Varargs aggregate",
                 "description": "Varargs aggregate"}
 

--- a/python/pyarrow/conftest.py
+++ b/python/pyarrow/conftest.py
@@ -288,13 +288,14 @@ def unary_agg_func_fixture():
     from pyarrow import compute as pc
     import numpy as np
 
-    def func(ctx, x):
+    def func(ctx, x, *args):
         return pa.scalar(np.nanmean(x))
 
-    func_name = "y=avg(x)"
+    func_name = "mean_udf"
     func_doc = {"summary": "y=avg(x)",
                 "description": "find mean of x"}
 
+    breakpoint()
     pc.register_aggregate_function(func,
                                    func_name,
                                    func_doc,

--- a/python/pyarrow/conftest.py
+++ b/python/pyarrow/conftest.py
@@ -295,7 +295,6 @@ def unary_agg_func_fixture():
     func_doc = {"summary": "y=avg(x)",
                 "description": "find mean of x"}
 
-    breakpoint()
     pc.register_aggregate_function(func,
                                    func_name,
                                    func_doc,

--- a/python/pyarrow/src/arrow/python/udf.cc
+++ b/python/pyarrow/src/arrow/python/udf.cc
@@ -329,7 +329,8 @@ struct PythonUdfHashAggregatorImpl : public HashUdfAggregator {
   }
 
   Status Finalize(KernelContext* ctx, Datum* out) {
-      const int num_args = input_schema->num_fields();
+      // Exclude the last column which is the group id
+      const int num_args = input_schema->num_fields() - 1;
 
       ARROW_ASSIGN_OR_RAISE(auto groups_buffer, groups.Finish());
       ARROW_ASSIGN_OR_RAISE(
@@ -355,7 +356,6 @@ struct PythonUdfHashAggregatorImpl : public HashUdfAggregator {
           OwnedRef arg_tuple(PyTuple_New(num_args));
           RETURN_NOT_OK(CheckPyError());
 
-          // Exclude the last column which is the group id
           for (int arg_id = 0; arg_id < num_args; arg_id++) {
             // Since we combined chunks there is only one chunk
             std::shared_ptr<Array> c_data = group_rb->column(arg_id);

--- a/python/pyarrow/src/arrow/python/udf.cc
+++ b/python/pyarrow/src/arrow/python/udf.cc
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-
+#include "arrow/python/udf.h"
 #include "arrow/array/builder_base.h"
 #include "arrow/buffer_builder.h"
 #include "arrow/compute/api_aggregate.h"
@@ -24,7 +24,6 @@
 #include "arrow/compute/kernel.h"
 #include "arrow/compute/row/grouper.h"
 #include "arrow/python/common.h"
-#include "arrow/python/udf.h"
 #include "arrow/table.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/logging.h"
@@ -310,7 +309,7 @@ struct PythonUdfHashAggregatorImpl : public HashUdfAggregator {
     const ArraySpan& groups_array_data = batch[batch.num_values() - 1].array;
     DCHECK_EQ(groups_array_data.offset, 0);
     int64_t batch_num_values = groups_array_data.length;
-    const auto* batch_groups = groups_array_data.GetValues<uint32_t>(1, 0);
+    const auto* batch_groups = groups_array_data.GetValues<uint32_t>(1);
     RETURN_NOT_OK(groups.Append(batch_groups, batch_num_values));
     values.push_back(std::move(rb));
     num_values += batch_num_values;
@@ -352,7 +351,8 @@ struct PythonUdfHashAggregatorImpl : public HashUdfAggregator {
     UdfContext udf_context{ctx->memory_pool(), table->num_rows()};
 
     if (rb->num_rows() == 0) {
-      return Status::Invalid("Finalized is called with empty inputs");
+      *out = Datum();
+      return Status::OK();
     }
 
     ARROW_ASSIGN_OR_RAISE(RecordBatchVector rbs, ApplyGroupings(*groupings, rb));

--- a/python/pyarrow/src/arrow/python/udf.cc
+++ b/python/pyarrow/src/arrow/python/udf.cc
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <iostream>
 
 #include "arrow/array/builder_base.h"
 #include "arrow/buffer_builder.h"
@@ -264,6 +263,7 @@ struct PythonUdfHashAggregatorImpl : public HashUdfAggregator {
       : function(function), cb(std::move(cb)), output_type(std::move(output_type)) {
     Py_INCREF(function->obj());
     std::vector<std::shared_ptr<Field>> fields;
+    fields.reserve(input_types.size());
     for (size_t i = 0; i < input_types.size(); i++) {
       fields.push_back(field("", input_types[i]));
     }
@@ -276,8 +276,8 @@ struct PythonUdfHashAggregatorImpl : public HashUdfAggregator {
     }
   }
 
-  /// @brief Same as ApplyGrouping in parition.cc
-  /// Replicated the code here to avoid complicating the dependencies
+  // same as ApplyGrouping in parition.cc
+  // replicated the code here to avoid complicating the dependencies
   static Result<RecordBatchVector> ApplyGroupings(
       const ListArray& groupings, const std::shared_ptr<RecordBatch>& batch) {
     ARROW_ASSIGN_OR_RAISE(Datum sorted,
@@ -587,8 +587,8 @@ Status RegisterScalarAggregateFunction(PyObject* function, UdfWrapperCallback cb
   return Status::OK();
 }
 
-/// @brief Create a new UdfOptions with adjustment for hash kernel
-/// @param options User provided udf options
+/// \brief Create a new UdfOptions with adjustment for hash kernel
+/// \param options User provided udf options
 UdfOptions AdjustForHashAggregate(const UdfOptions& options) {
   UdfOptions hash_options;
   // Append hash_ before the function name to seperate from the scalar

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -754,6 +754,7 @@ def test_scalar_aggregate_udf_basic(varargs_agg_func_fixture):
 
     assert res_tb == expected_tb
 
+
 def test_hash_aggregate_udf_basic(varargs_agg_func_fixture):
 
     test_table = pa.Table.from_pydict(

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -607,7 +607,7 @@ def test_output_field_names(use_threads):
     assert res_tb == expected
 
 
-def test_aggregate_udf_basic(varargs_agg_func_fixture):
+def test_scalar_aggregate_udf_basic(varargs_agg_func_fixture):
 
     test_table = pa.Table.from_pydict(
         {"k": [1, 1, 2, 2], "v1": [1, 2, 3, 4],
@@ -630,7 +630,7 @@ def test_aggregate_udf_basic(varargs_agg_func_fixture):
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 1,
-        "name": "y=sum_mean(x...)"
+        "name": "sum_mean"
       }
     }
   ],
@@ -752,4 +752,173 @@ def test_aggregate_udf_basic(varargs_agg_func_fixture):
         'v_avg': [2.5, 4.5]
     })
 
+    assert res_tb == expected_tb
+
+def test_hash_aggregate_udf_basic(varargs_agg_func_fixture):
+
+    test_table = pa.Table.from_pydict(
+        {"t": [1, 1, 1, 1, 2, 2, 2, 2],
+         "k": [1, 0, 0, 1, 0, 1, 0, 1],
+         "v1": [1, 2, 3, 4, 5, 6, 7, 8],
+         "v2": [1.0, 1.0, 1.0, 1.0, 2.0, 3.0, 4.0, 5.0]}
+    )
+
+    def table_provider(names, _):
+        return test_table
+
+    substrait_query = b"""
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 1,
+      "uri": "urn:arrow:substrait_simple_extension_function"
+    },
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 1,
+        "name": "sum_mean"
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "extensionSingle": {
+            "common": {
+              "emit": {
+                "outputMapping": [
+                  0,
+                  1,
+                  2
+                ]
+              }
+            },
+            "input": {
+              "read": {
+                "baseSchema": {
+                  "names": [
+                    "t",
+                    "k",
+                    "v1",
+                    "v2",
+                  ],
+                  "struct": {
+                    "types": [
+                      {
+                        "i64": {
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "i64": {
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "i64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      {
+                        "fp64": {
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      }
+                    ],
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                },
+                "namedTable": {
+                  "names": ["t1"]
+                }
+              }
+            },
+            "detail": {
+              "@type": "/arrow.substrait_ext.SegmentedAggregateRel",
+              "groupingKeys": [
+                {
+                  "directReference": {
+                    "structField": {
+                      "field": 1
+                    }
+                  },
+                  "rootReference": {}
+                }
+              ],
+              "segmentKeys": [
+                {
+                  "directReference": {
+                    "structField": {}
+                  },
+                  "rootReference": {}
+                }
+              ],
+              "measures": [
+                {
+                  "measure": {
+                    "functionReference": 1,
+                    "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                    "outputType": {
+                      "fp64": {
+                        "nullability": "NULLABILITY_NULLABLE"
+                      }
+                    },
+                    "arguments": [
+                      {
+                        "value": {
+                          "selection": {
+                            "directReference": {
+                              "structField": {
+                                "field": 2
+                              }
+                            },
+                            "rootReference": {}
+                          }
+                        }
+                      },
+                      {
+                        "value": {
+                          "selection": {
+                            "directReference": {
+                              "structField": {
+                                "field": 3
+                              }
+                            },
+                            "rootReference": {}
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        },
+        "names": [
+          "t",
+          "k",
+          "v_avg"
+        ]
+      }
+    }
+  ],
+}
+"""
+    buf = pa._substrait._parse_json_plan(substrait_query)
+    reader = pa.substrait.run_query(
+        buf, table_provider=table_provider, use_threads=False)
+    res_tb = reader.read_all()
+
+    expected_tb = pa.Table.from_pydict({
+        't': [1, 1, 2, 2],
+        'k': [1, 0, 0, 1],
+        'v_avg': [3.5, 3.5, 9.0, 11.0]
+    })
+
+    # Ordering of k is deterministic because this is running with serial execution
     assert res_tb == expected_tb

--- a/python/pyarrow/tests/test_udf.py
+++ b/python/pyarrow/tests/test_udf.py
@@ -747,8 +747,11 @@ def test_hash_agg_empty(unary_agg_func_fixture):
     arr2 = pa.array([], pa.int32())
     table = pa.table([arr2, arr1], names=["id", "value"])
 
-    with pytest.raises(pa.ArrowInvalid, match='empty inputs'):
-        table.group_by("id").aggregate([("value", "mean_udf")])
+    result = table.group_by("id").aggregate([("value", "mean_udf")])
+    expected = pa.table([pa.array([], pa.int32()), pa.array(
+        [], pa.float64())], names=['id', 'value_mean_udf'])
+
+    assert result == expected
 
 
 def test_hash_agg_wrong_output_dtype(wrong_output_dtype_agg_func_fixture):

--- a/python/pyarrow/tests/test_udf.py
+++ b/python/pyarrow/tests/test_udf.py
@@ -674,7 +674,6 @@ def test_hash_agg_basic(unary_agg_func_fixture):
     table2 = pa.table([arr4, arr3], names=["id", "value"])
     table = pa.concat_tables([table1, table2])
 
-    breakpoint()
     result = table.group_by("id").aggregate([("value", "mean_udf")])
     expected = table.group_by("id").aggregate([("value", "mean")]).rename_columns(['id', 'value_mean_udf'])
 

--- a/python/pyarrow/tests/test_udf.py
+++ b/python/pyarrow/tests/test_udf.py
@@ -65,6 +65,7 @@ def sum_agg_func_fixture():
                                    )
     return func, func_name
 
+
 @pytest.fixture(scope="session")
 def exception_agg_func_fixture():
     def func(ctx, x):
@@ -698,9 +699,11 @@ def test_hash_agg_basic(unary_agg_func_fixture):
     table = pa.concat_tables([table1, table2])
 
     result = table.group_by("id").aggregate([("value", "mean_udf")])
-    expected = table.group_by("id").aggregate([("value", "mean")]).rename_columns(['id', 'value_mean_udf'])
+    expected = table.group_by("id").aggregate(
+        [("value", "mean")]).rename_columns(['id', 'value_mean_udf'])
 
     assert result.sort_by('id') == expected.sort_by('id')
+
 
 def test_hash_agg_random(sum_agg_func_fixture):
     """Test hash aggregate udf with randomly sampled data"""
@@ -717,7 +720,8 @@ def test_hash_agg_random(sum_agg_func_fixture):
     table = pa.table([arr2, arr1], names=['id', 'value'])
 
     result = table.group_by("id").aggregate([("value", "sum_udf")])
-    expected = table.group_by("id").aggregate([("value", "sum")]).rename_columns(['id', 'value_sum_udf'])
+    expected = table.group_by("id").aggregate(
+        [("value", "sum")]).rename_columns(['id', 'value_sum_udf'])
 
     assert result.sort_by('id') == expected.sort_by('id')
 
@@ -757,4 +761,3 @@ def test_agg_exception(exception_agg_func_fixture):
 
     with pytest.raises(RuntimeError, match='Oops'):
         pc.call_function("y=exception_len(x)", [arr])
-

--- a/python/pyarrow/tests/test_udf.py
+++ b/python/pyarrow/tests/test_udf.py
@@ -748,7 +748,7 @@ def test_hash_agg_empty(unary_agg_func_fixture):
     table = pa.table([arr2, arr1], names=["id", "value"])
 
     with pytest.raises(pa.ArrowInvalid, match='empty inputs'):
-        result = table.group_by("id").aggregate([("value", "mean_udf")])
+        table.group_by("id").aggregate([("value", "mean_udf")])
 
 
 def test_hash_agg_wrong_output_dtype(wrong_output_dtype_agg_func_fixture):
@@ -757,7 +757,7 @@ def test_hash_agg_wrong_output_dtype(wrong_output_dtype_agg_func_fixture):
 
     table = pa.table([arr2, arr1], names=["id", "value"])
     with pytest.raises(pa.ArrowTypeError, match="output datatype"):
-        result = table.group_by("id").aggregate([("value", "y=wrong_output_dtype(x)")])
+        table.group_by("id").aggregate([("value", "y=wrong_output_dtype(x)")])
 
 
 def test_hash_agg_wrong_output_type(wrong_output_type_agg_func_fixture):
@@ -766,7 +766,7 @@ def test_hash_agg_wrong_output_type(wrong_output_type_agg_func_fixture):
     table = pa.table([arr2, arr1], names=["id", "value"])
 
     with pytest.raises(pa.ArrowTypeError, match="output type"):
-        result = table.group_by("id").aggregate([("value", "y=wrong_output_type(x)")])
+        table.group_by("id").aggregate([("value", "y=wrong_output_type(x)")])
 
 
 def test_hash_agg_exception(exception_agg_func_fixture):
@@ -775,7 +775,7 @@ def test_hash_agg_exception(exception_agg_func_fixture):
     table = pa.table([arr2, arr1], names=["id", "value"])
 
     with pytest.raises(RuntimeError, match='Oops'):
-        result = table.group_by("id").aggregate([("value", "y=exception_len(x)")])
+        table.group_by("id").aggregate([("value", "y=exception_len(x)")])
 
 
 def test_hash_agg_random(sum_agg_func_fixture):


### PR DESCRIPTION
### Rationale for this change

In https://github.com/apache/arrow/issues/35515,

I have implemented a Scalar version of the non decomposable UDF (Scalar as in SCALAR_AGGREGATE). I would like to support the Hash version of it (Hash as in HASH_AGGREGATE)

With this PR, user can register an aggregate UDF once with `pc.register_aggregate_function` and it can be used as both scalar aggregate function and hash aggregate function.

Example:

```
def median(x):
    return pa.scalar(np.nanmedian(x))

pc.register_aggregate_function(func=median, func_name='median_udf', ...)

table = ...
table.groupby("id").aggregate([("v", 'median_udf')])
```

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

The main changes are:
* In ResigterAggregateFunction (udf.cc), we now register the function both as a scalar aggregate function and a hash aggregate function (with signature adjustment for hash aggregate kernel because we need to append the grouping key)
* Implemented PythonUdfHashAggregateImpl, similar to the PythonUdfScalarAggregateImpl. In Consume, it will accumulate both the input batches and the group id array. In Merge, it will merge the input batches and group id array (with the group_id_mapping). In Finalize, it will apply groupings to the accumulated batches to create one record batch per group, then apply the UDF over each group.
* Some code clean up - `UdfWrapperCallback` objects are named `cb` (previously, `agg_cb` or `wrapper`) now and the user defined python function is now just called `function` (previously `agg_function`) 

For table.groupby().aggregate(...), the space complexity is O(n) where n is the size of the table (and therefore, is not very useful). However, this is more useful in the segmented aggregation case, where the space complexity of O(s), where s the size of the segments.

### Are these changes tested?
Added new test in test_udf.py (with table.group_by().aggregate() and test_substrait.py (with segmented aggregation)


<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
Yes with this change, user can call use registered aggregate UDF with `table.group_by().aggregate() ` or Acero's segmented aggregation.

### Checklist

- [x] Self Review
- [x] API Documentation

* Closes: #36252