### PR TITLE
GH-36255: [C++] Add benchmarks for "if_else" kernel on lists

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_if_else_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_benchmark.cc
@@ -58,7 +58,7 @@ struct GetBytesProcessed<Type, enable_if_base_binary<Type>> {
 };
 
 template <typename DataType>
-struct GetBytesProcessed<DataType, enable_if_list_view_like<DataType>> {
+struct GetBytesProcessed<DataType, enable_if_list_like<DataType>> {
   static int64_t Get(const std::shared_ptr<Array>& arr) {
     using OffsetType = typename TypeTraits<DataType>::OffsetType::c_type;
 
@@ -66,10 +66,6 @@ struct GetBytesProcessed<DataType, enable_if_list_view_like<DataType>> {
     if constexpr (DataType::type_id == Type::LIST ||
                   DataType::type_id == Type::LARGE_LIST) {
       total_bytes += (arr->length() + 1) * sizeof(OffsetType);
-    } else if constexpr (DataType::type_id == Type::LIST_VIEW) {
-      // ListView has an extra buffer for the sizes and it uses the same type as the
-      // offsets buffer.
-      total_bytes += 2 * arr->length() * sizeof(OffsetType);
     } else {
       ADD_FAILURE() << "GetBytesProcessed dispatching not implemented for "
                     << arr->type()->ToString();

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_benchmark.cc
@@ -67,21 +67,13 @@ struct GetBytesProcessedVisitor {
   }
 
   template <typename ArrowType>
-  std::enable_if_t<is_list_like_type<ArrowType>::value &&
-                       !is_fixed_size_list_type<ArrowType>::value,
-                   Status>
-  Visit(const ArrowType& type) {
+  enable_if_var_size_list<ArrowType, Status> Visit(const ArrowType& type) {
     using ArrayType = typename TypeTraits<ArrowType>::ArrayType;
     using OffsetType = typename TypeTraits<ArrowType>::OffsetType::c_type;
 
-    if constexpr (ArrowType::type_id == Type::LIST ||
-                  ArrowType::type_id == Type::LARGE_LIST) {
-      total_bytes += (arr->length() + 1) * sizeof(OffsetType);
-      auto child_array = internal::checked_cast<const ArrayType*>(arr)->values();
-      return RecurseInto(child_array.get());
-    } else {
-      return Unimplemented(type);
-    }
+    total_bytes += (arr->length() + 1) * sizeof(OffsetType);
+    auto child_array = internal::checked_cast<const ArrayType*>(arr)->values();
+    return RecurseInto(child_array.get());
   }
 
   Status Visit(const DataType& type) { return Unimplemented(type); }

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_benchmark.cc
@@ -39,7 +39,9 @@ struct GetBytesProcessedVisitor {
   explicit GetBytesProcessedVisitor(const Array* arr) : arr(arr) {}
 
   Status RecurseInto(const Array* child_arr) {
-    // return VisitTypeInline(*child_arr->type(), this);
+    GetBytesProcessedVisitor visitor(child_arr);
+    RETURN_NOT_OK(VisitTypeInline(*child_arr->type(), &visitor));
+    total_bytes += visitor.total_bytes;
     return Status::OK();
   }
 


### PR DESCRIPTION
### Rationale for this change

"if_else" kernels kernels with list input can have their perf improved at the cost of code specialization. I'm working on this problem and would like to introduce benchmarks that measure how it behaves currently.

### What changes are included in this PR?

Only the new benchmarks and addition of `items_per_second` metric on the others.

### Are these changes tested?

By running the benchmarks.

### Are there any user-facing changes?

No.
* Closes: #36255