### PR TITLE
MINOR: [R] Make description of to_arrow function more specific

### DIFF
--- a/r/R/duckdb.R
+++ b/r/R/duckdb.R
@@ -116,10 +116,9 @@ duckdb_disconnector <- function(con, tbl_name) {
   environment()
 }
 
-#' Create an Arrow object from others
+#' Create an Arrow object from a DuckDB connection
 #'
-#' This can be used in pipelines that pass data back and forth between Arrow and
-#' other processes (like DuckDB).
+#' This can be used in pipelines that pass data back and forth between Arrow and DuckDB
 #'
 #' @param .data the object to be converted
 #' @return A `RecordBatchReader`.

--- a/r/man/to_arrow.Rd
+++ b/r/man/to_arrow.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/duckdb.R
 \name{to_arrow}
 \alias{to_arrow}
-\title{Create an Arrow object from others}
+\title{Create an Arrow object from a DuckDB connection}
 \usage{
 to_arrow(.data)
 }
@@ -13,8 +13,7 @@ to_arrow(.data)
 A \code{RecordBatchReader}.
 }
 \description{
-This can be used in pipelines that pass data back and forth between Arrow and
-other processes (like DuckDB).
+This can be used in pipelines that pass data back and forth between Arrow and DuckDB
 }
 \examples{
 \dontshow{if (getFromNamespace("run_duckdb_examples", "arrow")()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}


### PR DESCRIPTION
The purpose of this function is for working with DuckDB connection objects, and while the comments allude to possible future adaptations to work with other objects, we should document the current purpose now and update the docs if we do support alternatives in future.