### PR TITLE
MINOR: [R] Update phrasing of match_arrow docs to match base R 

### DIFF
--- a/r/R/compute.R
+++ b/r/R/compute.R
@@ -216,10 +216,10 @@ all.ArrowDatum <- function(..., na.rm = FALSE) {
   scalar_aggregate("all", ..., na.rm = na.rm)
 }
 
-#' `match` and `%in%` for Arrow objects
+#' Value matching for Arrow objects
 #'
-#' `base::match()` is not a generic, so we can't just define Arrow methods for
-#' it. This function exposes the analogous functions in the Arrow C++ library.
+#' `base::match()` and `base::%in%` are not generics, so we can't just define Arrow methods for
+#' them. These functions expose the analogous functions in the Arrow C++ library.
 #'
 #' @param x `Scalar`, `Array` or `ChunkedArray`
 #' @param table `Scalar`, Array`, `ChunkedArray`, or R vector lookup table.

--- a/r/man/match_arrow.Rd
+++ b/r/man/match_arrow.Rd
@@ -3,7 +3,7 @@
 \name{match_arrow}
 \alias{match_arrow}
 \alias{is_in}
-\title{\code{match} and \code{\%in\%} for Arrow objects}
+\title{Value matching for Arrow objects}
 \usage{
 match_arrow(x, table, ...)
 
@@ -23,8 +23,8 @@ and type as \code{x} with the (0-based) indexes into \code{table}. \code{is_in()
 per element of \code{x} it it is present in \code{table}.
 }
 \description{
-\code{base::match()} is not a generic, so we can't just define Arrow methods for
-it. This function exposes the analogous functions in the Arrow C++ library.
+\code{base::match()} and \verb{base::\%in\%} are not generics, so we can't just define Arrow methods for
+them. These functions expose the analogous functions in the Arrow C++ library.
 }
 \examples{
 # note that the returned value is 0-indexed


### PR DESCRIPTION
Make the phrasing more clear when skimming the reference page on pkgdown