### PR TITLE
GH-36251: [MATLAB] Add `Type` property to `arrow.array.Array`

### DIFF
--- a/matlab/src/matlab/+arrow/+array/Array.m
+++ b/matlab/src/matlab/+arrow/+array/Array.m
@@ -1,21 +1,21 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+    
 classdef (Abstract) Array < matlab.mixin.CustomDisplay & ...
                             matlab.mixin.Scalar
-    % arrow.array.Array
-
-    % Licensed to the Apache Software Foundation (ASF) under one or more
-    % contributor license agreements.  See the NOTICE file distributed with
-    % this work for additional information regarding copyright ownership.
-    % The ASF licenses this file to you under the Apache License, Version
-    % 2.0 (the "License"); you may not use this file except in compliance
-    % with the License.  You may obtain a copy of the License at
-    %
-    %   http://www.apache.org/licenses/LICENSE-2.0
-    %
-    % Unless required by applicable law or agreed to in writing, software
-    % distributed under the License is distributed on an "AS IS" BASIS,
-    % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-    % implied.  See the License for the specific language governing
-    % permissions and limitations under the License.
+% arrow.array.Array
 
     properties (GetAccess=public, SetAccess=private, Hidden)
         Proxy
@@ -24,6 +24,10 @@ classdef (Abstract) Array < matlab.mixin.CustomDisplay & ...
     properties (Dependent)
         Length
         Valid % Validity bitmap
+    end
+
+    properties(Abstract, SetAccess=private, GetAccess=public)
+        Type(1, 1) arrow.type.Type
     end
     
     methods

--- a/matlab/src/matlab/+arrow/+array/BooleanArray.m
+++ b/matlab/src/matlab/+arrow/+array/BooleanArray.m
@@ -20,6 +20,10 @@ classdef BooleanArray < arrow.array.Array
         NullSubstitionValue = false;
     end
 
+    properties(SetAccess=private, GetAccess=public)
+        Type = arrow.type.BooleanType
+    end
+
     methods
         function obj = BooleanArray(data, opts)
             arguments

--- a/matlab/src/matlab/+arrow/+array/Float32Array.m
+++ b/matlab/src/matlab/+arrow/+array/Float32Array.m
@@ -20,6 +20,10 @@ classdef Float32Array < arrow.array.NumericArray
         NullSubstitutionValue = single(NaN);
     end
 
+    properties(SetAccess=private, GetAccess=public)
+        Type = arrow.type.Float32Type
+    end
+
     methods
         function obj = Float32Array(data, varargin)
             obj@arrow.array.NumericArray(data, "single", ...

--- a/matlab/src/matlab/+arrow/+array/Float64Array.m
+++ b/matlab/src/matlab/+arrow/+array/Float64Array.m
@@ -20,6 +20,10 @@ classdef Float64Array < arrow.array.NumericArray
         NullSubstitutionValue = NaN;
     end
 
+    properties(SetAccess=private, GetAccess=public)
+        Type = arrow.type.Float64Type
+    end
+
     methods
         function obj = Float64Array(data, varargin)
             obj@arrow.array.NumericArray(data, "double", ...

--- a/matlab/src/matlab/+arrow/+array/Int16Array.m
+++ b/matlab/src/matlab/+arrow/+array/Int16Array.m
@@ -20,6 +20,10 @@ classdef Int16Array < arrow.array.NumericArray
         NullSubstitutionValue = int16(0)
     end
 
+    properties(SetAccess=private, GetAccess=public)
+        Type = arrow.type.Int16Type
+    end
+
     methods
         function obj = Int16Array(data, varargin)
             obj@arrow.array.NumericArray(data, "int16", ...

--- a/matlab/src/matlab/+arrow/+array/Int32Array.m
+++ b/matlab/src/matlab/+arrow/+array/Int32Array.m
@@ -20,6 +20,10 @@ classdef Int32Array < arrow.array.NumericArray
         NullSubstitutionValue = int32(0)
     end
 
+    properties(SetAccess=private, GetAccess=public)
+        Type = arrow.type.Int32Type
+    end
+
     methods
         function obj = Int32Array(data, varargin)
               obj@arrow.array.NumericArray(data, "int32", ...

--- a/matlab/src/matlab/+arrow/+array/Int64Array.m
+++ b/matlab/src/matlab/+arrow/+array/Int64Array.m
@@ -20,6 +20,10 @@ classdef Int64Array < arrow.array.NumericArray
         NullSubstitutionValue = int64(0);
     end
 
+    properties(SetAccess=private, GetAccess=public)
+        Type = arrow.type.Int64Type
+    end
+
     methods
         function obj = Int64Array(data, varargin)
           obj@arrow.array.NumericArray(data, "int64", ...

--- a/matlab/src/matlab/+arrow/+array/Int8Array.m
+++ b/matlab/src/matlab/+arrow/+array/Int8Array.m
@@ -20,6 +20,10 @@ classdef Int8Array < arrow.array.NumericArray
         NullSubstitutionValue = int8(0);
     end
 
+    properties(SetAccess=private, GetAccess=public)
+        Type = arrow.type.Int8Type
+    end
+
     methods
         function obj = Int8Array(data, varargin)
              obj@arrow.array.NumericArray(data, "int8", ...

--- a/matlab/src/matlab/+arrow/+array/UInt16Array.m
+++ b/matlab/src/matlab/+arrow/+array/UInt16Array.m
@@ -20,6 +20,10 @@ classdef UInt16Array < arrow.array.NumericArray
         NullSubstitutionValue = uint16(0)
     end
 
+    properties(SetAccess=private, GetAccess=public)
+        Type = arrow.type.UInt16Type
+    end
+
     methods
         function obj = UInt16Array(data, varargin)
             obj@arrow.array.NumericArray(data, "uint16", ...

--- a/matlab/src/matlab/+arrow/+array/UInt32Array.m
+++ b/matlab/src/matlab/+arrow/+array/UInt32Array.m
@@ -20,6 +20,10 @@ classdef UInt32Array < arrow.array.NumericArray
         NullSubstitutionValue = uint32(0)
     end
 
+    properties(SetAccess=private, GetAccess=public)
+        Type = arrow.type.UInt32Type
+    end
+
     methods
         function obj = UInt32Array(data, varargin)
             obj@arrow.array.NumericArray(data, "uint32", ...

--- a/matlab/src/matlab/+arrow/+array/UInt64Array.m
+++ b/matlab/src/matlab/+arrow/+array/UInt64Array.m
@@ -20,6 +20,10 @@ classdef UInt64Array < arrow.array.NumericArray
         NullSubstitutionValue = uint64(0)
     end
 
+    properties(SetAccess=private, GetAccess=public)
+        Type = arrow.type.UInt64Type
+    end
+
     methods
         function obj = UInt64Array(data, varargin)
             obj@arrow.array.NumericArray(data, "uint64", ...

--- a/matlab/src/matlab/+arrow/+array/UInt8Array.m
+++ b/matlab/src/matlab/+arrow/+array/UInt8Array.m
@@ -20,6 +20,10 @@ classdef UInt8Array < arrow.array.NumericArray
         NullSubstitutionValue = uint8(0)
     end
 
+    properties(SetAccess=private, GetAccess=public)
+        Type = arrow.type.UInt8Type
+    end
+
     methods
         function obj = UInt8Array(data, varargin)
             obj@arrow.array.NumericArray(data, "uint8", ...

--- a/matlab/test/arrow/array/hNumericArray.m
+++ b/matlab/test/arrow/array/hNumericArray.m
@@ -24,6 +24,7 @@ classdef hNumericArray < matlab.unittest.TestCase
         MaxValue (1, 1)
         MinValue (1, 1)
         NullSubstitutionValue(1, 1)
+        ArrowType(1, 1)
     end
 
     properties (TestParameter)
@@ -156,6 +157,13 @@ classdef hNumericArray < matlab.unittest.TestCase
             tc.verifyEqual(tc.MatlabConversionFcn(arrowArray), expectedData);
             tc.verifyEqual(toMATLAB(arrowArray), expectedData);
             tc.verifyEqual(arrowArray.Valid, [false; true; false; true]);
+        end
+
+        function TestArrowType(tc)
+        % Verify the array has the expected arrow.type.Type object
+            data = tc.MatlabArrayFcn([1 2 3 4]);
+            arrowArray = tc.ArrowArrayConstructor(data);
+            tc.verifyEqual(arrowArray.Type, tc.ArrowType);
         end
     end
 end

--- a/matlab/test/arrow/array/tBooleanArray.m
+++ b/matlab/test/arrow/array/tBooleanArray.m
@@ -21,7 +21,8 @@ classdef tBooleanArray < matlab.unittest.TestCase
         ArrowArrayConstructor = @arrow.array.BooleanArray
         MatlabArrayFcn = @logical
         MatlabConversionFcn = @logical
-        NullSubstitutionValue(1, 1) = false
+        NullSubstitutionValue = false
+        ArrowType = arrow.type.BooleanType
     end
 
     methods(TestClassSetup)
@@ -139,6 +140,13 @@ classdef tBooleanArray < matlab.unittest.TestCase
             data = tc.MatlabArrayFcn(sparse([true false true]));
             fcn = @() tc.ArrowArrayConstructor(data);
             tc.verifyError(fcn, "MATLAB:expectedNonsparse");
+        end
+
+        function TestArrowType(tc)
+        % Verify the array has the expected arrow.type.Type object
+            data = tc.MatlabArrayFcn([true false]);
+            arrowArray = tc.ArrowArrayConstructor(data);
+            tc.verifyEqual(arrowArray.Type, tc.ArrowType);
         end
     end
 end

--- a/matlab/test/arrow/array/tFloat32Array.m
+++ b/matlab/test/arrow/array/tFloat32Array.m
@@ -24,6 +24,7 @@ classdef tFloat32Array < hNumericArray
         MaxValue = realmax("single")
         MinValue = realmin("single")
         NullSubstitutionValue = single(NaN)
+        ArrowType = arrow.type.Float32Type
     end
 
     methods(Test)

--- a/matlab/test/arrow/array/tFloat64Array.m
+++ b/matlab/test/arrow/array/tFloat64Array.m
@@ -24,6 +24,7 @@ classdef tFloat64Array < hNumericArray
         MaxValue = realmax("double")
         MinValue = realmin("double")
         NullSubstitutionValue = NaN
+        ArrowType = arrow.type.Float64Type
     end
 
     methods(Test)

--- a/matlab/test/arrow/array/tInt16Array.m
+++ b/matlab/test/arrow/array/tInt16Array.m
@@ -23,6 +23,8 @@ classdef tInt16Array < hNumericArray
         MatlabArrayFcn = @int16 % int16 function
         MaxValue = intmax("int16")
         MinValue = intmin("int16")
+        NullSubstitutionValue = int16(0)
+        ArrowType = arrow.type.Int16Type
     end
 
 end

--- a/matlab/test/arrow/array/tInt32Array.m
+++ b/matlab/test/arrow/array/tInt32Array.m
@@ -24,5 +24,6 @@ classdef tInt32Array < hNumericArray
         MaxValue = intmax("int32")
         MinValue = intmin("int32")
         NullSubstitutionValue = int32(0)
+        ArrowType = arrow.type.Int32Type
     end
 end

--- a/matlab/test/arrow/array/tInt64Array.m
+++ b/matlab/test/arrow/array/tInt64Array.m
@@ -24,5 +24,6 @@ classdef tInt64Array < hNumericArray
         MaxValue = intmax("int64")
         MinValue = intmin("int64")
         NullSubstitutionValue = int64(0)
+        ArrowType = arrow.type.Int64Type
     end
 end

--- a/matlab/test/arrow/array/tInt8Array.m
+++ b/matlab/test/arrow/array/tInt8Array.m
@@ -24,6 +24,7 @@ classdef tInt8Array < hNumericArray
         MaxValue = intmax("int8")
         MinValue = intmin("int8")
         NullSubstitutionValue = int8(0)
+        ArrowType = arrow.type.Int8Type
     end
 
 end

--- a/matlab/test/arrow/array/tUInt16Array.m
+++ b/matlab/test/arrow/array/tUInt16Array.m
@@ -24,5 +24,6 @@ classdef tUInt16Array < hNumericArray
         MaxValue = intmax("uint16")
         MinValue = intmin("uint16")
         NullSubstitutionValue = uint16(0)
+        ArrowType = arrow.type.UInt16Type
     end
 end

--- a/matlab/test/arrow/array/tUInt32Array.m
+++ b/matlab/test/arrow/array/tUInt32Array.m
@@ -24,5 +24,6 @@ classdef tUInt32Array < hNumericArray
         MaxValue = intmax("uint32")
         MinValue = intmin("uint32")
         NullSubstitutionValue = uint32(0)
+        ArrowType = arrow.type.UInt32Type
     end
 end

--- a/matlab/test/arrow/array/tUInt64Array.m
+++ b/matlab/test/arrow/array/tUInt64Array.m
@@ -24,5 +24,6 @@ classdef tUInt64Array < hNumericArray
         MaxValue = intmax("uint64")
         MinValue = intmin("uint64")
         NullSubstitutionValue = uint64(0)
+        ArrowType = arrow.type.UInt64Type
     end
 end

--- a/matlab/test/arrow/array/tUInt8Array.m
+++ b/matlab/test/arrow/array/tUInt8Array.m
@@ -24,5 +24,6 @@ classdef tUInt8Array < hNumericArray
         MaxValue = intmax("uint8")
         MinValue = intmin("uint8")
         NullSubstitutionValue = uint8(0)
+        ArrowType = arrow.type.UInt8Type
     end
 end


### PR DESCRIPTION
### Rationale for this change

Now that we've added the `arrow.type.Type` class hierarchy to the interface, we should add a property named `Type` to the base `arrow.array.Array` class.

### What changes are included in this PR?

All concrete subclasses of the `arrow.array.Array` define a property named `Type`:

```matlab
>> a = arrow.array.Float64Array([1 2 3 4])

a = 

[
  1,
  2,
  3,
  4
]
>> a.Type

ans = 

  Float64Type with properties:

            ID: Float64
      BitWidth: 64
     NumFields: 0
    NumBuffers: 2
```


### Are these changes tested?
Yes, we added test cases in `hNumeric.m` and `tBooleanArray.m`.

### Are there any user-facing changes?

Yes.

### Note

1. I noticed that the `tInt16Array.m` test class did not define the `NullSubstitutionValue` property. This meant the test class was abstract, so its tests were not running. That was my mistake. We'll think about ways to verify all the appropriate tests are running in CI.
2. As @kou mentioned, we think it may be worth creating "Type" C++ proxy classes, especially when we start implementing nested array types. For now, we'll leave them as MATLAB-only classes, but will probably change their implementation soon. 
3. Thank you to @kevingurney for the help!
* Closes: #36251