### PR TITLE
GH-35273: [C++] Add integer round kernels

### DIFF
--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -198,6 +198,11 @@ template <typename T>
 using is_signed_integer_value =
     std::integral_constant<bool, std::is_integral<T>::value && std::is_signed<T>::value>;
 
+template <typename T>
+using is_integer_value =
+    std::integral_constant<bool, is_signed_integer_value<T>::value ||
+                                     is_unsigned_integer_value<T>::value>;
+
 template <typename T, typename R = T>
 using enable_if_signed_integer_value = enable_if_t<is_signed_integer_value<T>::value, R>;
 

--- a/cpp/src/arrow/compute/kernels/scalar_round.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_round.cc
@@ -397,7 +397,7 @@ struct RoundImpl<Type, RoundMode::HALF_TO_ODD> {
   template <typename T = Type>
   static constexpr enable_if_integer_value<T> Round(const T val, const T floor,
                                                     const T multiple, Status* st) {
-    if ((floor / multiple) % 2 == 1) {
+    if ((floor / multiple) % 2 != 0) {
       return floor;
     }
     return RoundImpl<T, RoundMode::TOWARDS_INFINITY>::Round(val, floor, multiple, st);

--- a/cpp/src/arrow/compute/kernels/scalar_round.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_round.cc
@@ -132,7 +132,7 @@ struct RoundUtil {
         Pow10Struct<18>::value, Pow10Struct<19>::value};
 
     auto digits10 = std::numeric_limits<T>::digits10;
-    return lut[std::min(power, static_cast<int64_t>(digits10))];
+    return static_cast<T>(lut[std::min(power, static_cast<int64_t>(digits10))]);
   }
 };
 

--- a/cpp/src/arrow/compute/kernels/scalar_round.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_round.cc
@@ -125,7 +125,7 @@ struct RoundUtil {
         10000000000000000ULL,
         100000000000000000ULL,
         1000000000000000000ULL
-        // clang-format on 
+        // clang-format on
     };
 
     return static_cast<T>(lut[power]);

--- a/cpp/src/arrow/compute/kernels/scalar_round.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_round.cc
@@ -84,25 +84,6 @@ bool IsPositive(const Scalar& scalar) {
   return visitor.result;
 }
 
-// N.B. take care not to conflict with type_traits.h as that can cause surprises in a
-// unity build
-
-// A constexpr helper struct to compute powers of 10 at compile time
-// Can use a consteval function once we force C++20
-template <int Exp>
-struct Pow10Struct {
- private:
-  static constexpr uint64_t half_pow = Pow10Struct<Exp / 2>::value;
-
- public:
-  static constexpr uint64_t value = half_pow * half_pow * (Exp % 2 ? 10 : 1);
-};
-
-template <>
-struct Pow10Struct<0> {
-  static constexpr uint64_t value = 1;
-};
-
 struct RoundUtil {
   // Calculate powers of ten with arbitrary integer exponent
   template <typename T>
@@ -124,13 +105,28 @@ struct RoundUtil {
     DCHECK_GE(power, 0);
     DCHECK_LE(power, std::numeric_limits<T>::digits10);
     static constexpr uint64_t lut[] = {
-        Pow10Struct<0>::value,  Pow10Struct<1>::value,  Pow10Struct<2>::value,
-        Pow10Struct<3>::value,  Pow10Struct<4>::value,  Pow10Struct<5>::value,
-        Pow10Struct<6>::value,  Pow10Struct<7>::value,  Pow10Struct<8>::value,
-        Pow10Struct<9>::value,  Pow10Struct<10>::value, Pow10Struct<11>::value,
-        Pow10Struct<12>::value, Pow10Struct<13>::value, Pow10Struct<14>::value,
-        Pow10Struct<15>::value, Pow10Struct<16>::value, Pow10Struct<17>::value,
-        Pow10Struct<18>::value, Pow10Struct<19>::value};
+        // clang-format off
+        1ULL,
+        10ULL,
+        100ULL,
+        1000ULL,
+        10000ULL,
+        100000ULL,
+        1000000ULL,
+        10000000ULL,
+        100000000ULL,
+        1000000000ULL,
+        10000000000ULL,
+        100000000000ULL,
+        1000000000000ULL,
+        10000000000000ULL,
+        100000000000000ULL,
+        1000000000000000ULL,
+        10000000000000000ULL,
+        100000000000000000ULL,
+        1000000000000000000ULL
+        // clang-format on 
+    };
 
     return static_cast<T>(lut[power]);
   }

--- a/cpp/src/arrow/compute/kernels/scalar_round.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_round.cc
@@ -25,6 +25,7 @@
 #include "arrow/compare.h"
 #include "arrow/compute/api_scalar.h"
 #include "arrow/compute/cast.h"
+#include "arrow/compute/kernel.h"
 #include "arrow/compute/kernels/base_arithmetic_internal.h"
 #include "arrow/compute/kernels/common_internal.h"
 #include "arrow/compute/kernels/util_internal.h"
@@ -34,6 +35,7 @@
 #include "arrow/util/int_util_overflow.h"
 #include "arrow/util/macros.h"
 #include "arrow/visit_scalar_inline.h"
+#include "arrow/visit_type_inline.h"
 
 namespace arrow {
 
@@ -43,8 +45,7 @@ using internal::MultiplyWithOverflow;
 using internal::NegateWithOverflow;
 using internal::SubtractWithOverflow;
 
-namespace compute {
-namespace internal {
+namespace compute::internal {
 
 using applicator::ScalarBinary;
 using applicator::ScalarBinaryEqualTypes;
@@ -55,6 +56,9 @@ using applicator::ScalarUnaryNotNull;
 using applicator::ScalarUnaryNotNullStateful;
 
 namespace {
+
+// ----------------------------------------------------------------------
+// Begin utility structs for round kernels
 
 // Convenience visitor to detect if a numeric Scalar is positive.
 struct IsPositiveVisitor {
@@ -82,9 +86,25 @@ bool IsPositive(const Scalar& scalar) {
 // N.B. take care not to conflict with type_traits.h as that can cause surprises in a
 // unity build
 
+// A constexpr helper struct to compute powers of 10 at compile time
+// Can use a consteval function once we force C++20
+template <int Exp>
+struct Pow10Struct {
+ private:
+  static constexpr uint64_t half_pow = Pow10Struct<Exp / 2>::value;
+
+ public:
+  static constexpr uint64_t value = half_pow * half_pow * (Exp % 2 ? 10 : 1);
+};
+
+template <>
+struct Pow10Struct<0> {
+  static constexpr uint64_t value = 1;
+};
+
 struct RoundUtil {
   // Calculate powers of ten with arbitrary integer exponent
-  template <typename T = double>
+  template <typename T>
   static enable_if_floating_value<T> Pow10(int64_t power) {
     static constexpr T lut[] = {1e0F, 1e1F, 1e2F,  1e3F,  1e4F,  1e5F,  1e6F,  1e7F,
                                 1e8F, 1e9F, 1e10F, 1e11F, 1e12F, 1e13F, 1e14F, 1e15F};
@@ -96,7 +116,29 @@ struct RoundUtil {
     }
     return (power >= 0) ? pow10 : (1 / pow10);
   }
+
+  // Calculate powers of ten with arbitrary integer exponent
+  template <typename T>
+  static enable_if_integer_value<T> Pow10(int64_t power) {
+    DCHECK(power >= 0);
+
+    static constexpr uint64_t lut[] = {
+        Pow10Struct<0>::value,  Pow10Struct<1>::value,  Pow10Struct<2>::value,
+        Pow10Struct<3>::value,  Pow10Struct<4>::value,  Pow10Struct<5>::value,
+        Pow10Struct<6>::value,  Pow10Struct<7>::value,  Pow10Struct<8>::value,
+        Pow10Struct<9>::value,  Pow10Struct<10>::value, Pow10Struct<11>::value,
+        Pow10Struct<12>::value, Pow10Struct<13>::value, Pow10Struct<14>::value,
+        Pow10Struct<15>::value, Pow10Struct<16>::value, Pow10Struct<17>::value,
+        Pow10Struct<18>::value, Pow10Struct<19>::value};
+
+    auto digits10 = std::numeric_limits<T>::digits10;
+    return lut[std::min(power, static_cast<int64_t>(digits10))];
+  }
 };
+
+// End utility structs for round kernels
+// ----------------------------------------------------------------------
+// Begin round implementations for single scalar
 
 // Specializations of rounding implementations for round kernels
 template <typename Type, RoundMode>
@@ -117,6 +159,21 @@ struct RoundImpl<Type, RoundMode::DOWN> {
       (*val) -= pow10;
     }
   }
+
+  template <typename T = Type>
+  static enable_if_integer_value<T> Round(const T val, const T floor, const T multiple,
+                                          Status* st) {
+    if constexpr (is_signed_integer_value<T>::value) {
+      if (ARROW_PREDICT_FALSE(val < 0 &&
+                              std::numeric_limits<T>::min() + multiple > floor)) {
+        *st = Status::Invalid("Rounding ", val, " down to multiple of ", multiple,
+                              " would overflow");
+        return val;
+      }
+      return val < 0 ? floor - multiple : floor;
+    }
+    return floor;
+  }
 };
 
 template <typename Type>
@@ -134,6 +191,18 @@ struct RoundImpl<Type, RoundMode::UP> {
       (*val) += pow10;
     }
   }
+
+  template <typename T = Type>
+  static enable_if_integer_value<T> Round(const T val, const T floor, const T multiple,
+                                          Status* st) {
+    if (ARROW_PREDICT_FALSE(val > 0 &&
+                            std::numeric_limits<T>::max() - multiple < floor)) {
+      *st = Status::Invalid("Rounding ", val, " up to multiple of ", multiple,
+                            " would overflow");
+      return val;
+    }
+    return val > 0 ? floor + multiple : floor;
+  }
 };
 
 template <typename Type>
@@ -147,6 +216,12 @@ struct RoundImpl<Type, RoundMode::TOWARDS_ZERO> {
   static enable_if_decimal_value<T, void> Round(T* val, const T& remainder,
                                                 const T& pow10, const int32_t scale) {
     (*val) -= remainder;
+  }
+
+  template <typename T = Type>
+  static enable_if_integer_value<T> Round(const T val, const T floor, const T pow10,
+                                          Status* st) {
+    return floor;
   }
 };
 
@@ -167,6 +242,32 @@ struct RoundImpl<Type, RoundMode::TOWARDS_INFINITY> {
       (*val) += pow10;
     }
   }
+
+  template <typename T = Type>
+  static enable_if_integer_value<T> Round(const T val, const T floor, const T multiple,
+                                          Status* st) {
+    if constexpr (is_signed_integer_value<T>::value) {
+      if (ARROW_PREDICT_FALSE(val < 0 &&
+                              std::numeric_limits<T>::min() + multiple > floor)) {
+        *st = Status::Invalid("Rounding ", val, " down to multiple of ", multiple,
+                              " would overflow");
+        return val;
+      }
+    }
+
+    if (ARROW_PREDICT_FALSE(val > 0 &&
+                            std::numeric_limits<T>::max() - multiple < floor)) {
+      *st = Status::Invalid("Rounding ", val, " up to multiple of ", multiple,
+                            " would overflow");
+      return val;
+    }
+
+    if constexpr (is_signed_integer_value<T>::value) {
+      return val < 0 ? floor - multiple : floor + multiple;
+    }
+
+    return floor + multiple;
+  }
 };
 
 // NOTE: RoundImpl variants for the HALF_* rounding modes are only
@@ -185,6 +286,12 @@ struct RoundImpl<Type, RoundMode::HALF_DOWN> {
                                                 const T& pow10, const int32_t scale) {
     RoundImpl<T, RoundMode::DOWN>::Round(val, remainder, pow10, scale);
   }
+
+  template <typename T = Type>
+  static constexpr enable_if_integer_value<T> Round(const T val, const T floor,
+                                                    const T multiple, Status* st) {
+    return RoundImpl<T, RoundMode::DOWN>::Round(val, floor, multiple, st);
+  }
 };
 
 template <typename Type>
@@ -198,6 +305,12 @@ struct RoundImpl<Type, RoundMode::HALF_UP> {
   static enable_if_decimal_value<T, void> Round(T* val, const T& remainder,
                                                 const T& pow10, const int32_t scale) {
     RoundImpl<T, RoundMode::UP>::Round(val, remainder, pow10, scale);
+  }
+
+  template <typename T = Type>
+  static constexpr enable_if_integer_value<T> Round(const T val, const T floor,
+                                                    const T multiple, Status* st) {
+    return RoundImpl<T, RoundMode::UP>::Round(val, floor, multiple, st);
   }
 };
 
@@ -213,6 +326,12 @@ struct RoundImpl<Type, RoundMode::HALF_TOWARDS_ZERO> {
                                                 const T& pow10, const int32_t scale) {
     RoundImpl<T, RoundMode::TOWARDS_ZERO>::Round(val, remainder, pow10, scale);
   }
+
+  template <typename T = Type>
+  static constexpr enable_if_integer_value<T> Round(const T val, const T floor,
+                                                    const T multiple, Status* st) {
+    return RoundImpl<T, RoundMode::TOWARDS_ZERO>::Round(val, floor, multiple, st);
+  }
 };
 
 template <typename Type>
@@ -224,8 +343,14 @@ struct RoundImpl<Type, RoundMode::HALF_TOWARDS_INFINITY> {
 
   template <typename T = Type>
   static enable_if_decimal_value<T, void> Round(T* val, const T& remainder,
-                                                const T& pow10, const int32_t scale) {
-    RoundImpl<T, RoundMode::TOWARDS_INFINITY>::Round(val, remainder, pow10, scale);
+                                                const T& multiple, const int32_t scale) {
+    RoundImpl<T, RoundMode::TOWARDS_INFINITY>::Round(val, remainder, multiple, scale);
+  }
+
+  template <typename T = Type>
+  static constexpr enable_if_integer_value<T> Round(const T val, const T floor,
+                                                    const T multiple, Status* st) {
+    return RoundImpl<T, RoundMode::TOWARDS_INFINITY>::Round(val, floor, multiple, st);
   }
 };
 
@@ -245,6 +370,15 @@ struct RoundImpl<Type, RoundMode::HALF_TO_EVEN> {
     }
     *val = scaled.IncreaseScaleBy(scale);
   }
+
+  template <typename T = Type>
+  static constexpr enable_if_integer_value<T> Round(const T val, const T floor,
+                                                    const T multiple, Status* st) {
+    if ((floor / multiple) % 2 == 0) {
+      return floor;
+    }
+    return RoundImpl<T, RoundMode::TOWARDS_INFINITY>::Round(val, floor, multiple, st);
+  }
 };
 
 template <typename Type>
@@ -263,23 +397,37 @@ struct RoundImpl<Type, RoundMode::HALF_TO_ODD> {
     }
     *val = scaled.IncreaseScaleBy(scale);
   }
+
+  template <typename T = Type>
+  static constexpr enable_if_integer_value<T> Round(const T val, const T floor,
+                                                    const T multiple, Status* st) {
+    if ((floor / multiple) % 2 == 1) {
+      return floor;
+    }
+    return RoundImpl<T, RoundMode::TOWARDS_INFINITY>::Round(val, floor, multiple, st);
+  }
 };
 
+// End round implementations for single scalar
+// ----------------------------------------------------------------------
+// Begin round options wrappers
+
 // Specializations of kernel state for round kernels
-template <typename OptionsType>
+// CType is the physical type used to store pow10
+template <typename OptionsType, typename CType>
 struct RoundOptionsWrapper;
 
-template <>
-struct RoundOptionsWrapper<RoundOptions> : public OptionsWrapper<RoundOptions> {
+template <typename CType>
+struct RoundOptionsWrapper<RoundOptions, CType> : public OptionsWrapper<RoundOptions> {
   using OptionsType = RoundOptions;
-  double pow10;
+  CType pow10;
 
   explicit RoundOptionsWrapper(OptionsType options) : OptionsWrapper(std::move(options)) {
     // Only positive exponents for powers of 10 are used because combining
     // multiply and division operations produced more stable rounding than
     // using multiply-only.  Refer to NumPy's round implementation:
     // https://github.com/numpy/numpy/blob/7b2f20b406d27364c812f7a81a9c901afbd3600c/numpy/core/src/multiarray/calculation.c#L589
-    pow10 = RoundUtil::Pow10(std::abs(options.ndigits));
+    pow10 = RoundUtil::Pow10<CType>(std::abs(options.ndigits));
   }
 
   static Result<std::unique_ptr<KernelState>> Init(KernelContext* ctx,
@@ -292,8 +440,8 @@ struct RoundOptionsWrapper<RoundOptions> : public OptionsWrapper<RoundOptions> {
   }
 };
 
-template <>
-struct RoundOptionsWrapper<RoundBinaryOptions>
+template <typename CType>
+struct RoundOptionsWrapper<RoundBinaryOptions, CType>
     : public OptionsWrapper<RoundBinaryOptions> {
   using OptionsType = RoundBinaryOptions;
 
@@ -310,8 +458,8 @@ struct RoundOptionsWrapper<RoundBinaryOptions>
   }
 };
 
-template <>
-struct RoundOptionsWrapper<RoundToMultipleOptions>
+template <typename CType>
+struct RoundOptionsWrapper<RoundToMultipleOptions, CType>
     : public OptionsWrapper<RoundToMultipleOptions> {
   using OptionsType = RoundToMultipleOptions;
   using OptionsWrapper::OptionsWrapper;
@@ -333,14 +481,8 @@ struct RoundOptionsWrapper<RoundToMultipleOptions>
       return Status::Invalid("Rounding multiple must be positive");
     }
 
-    // Ensure the rounding multiple option matches the kernel's output type.
-    // The output type is not available here so we use the following rule:
-    // If `multiple` is neither a floating-point nor a decimal type, then
-    // cast to float64, else cast to the kernel's input type.
-    std::shared_ptr<DataType> to_type =
-        (!is_floating(multiple->type->id()) && !is_decimal(multiple->type->id()))
-            ? float64()
-            : args.inputs[0].GetSharedPtr();
+    // Ensure the rounding multiple option matches the kernel's input type.
+    std::shared_ptr<DataType> to_type = args.inputs[0].GetSharedPtr();
     if (!multiple->type->Equals(to_type)) {
       ARROW_ASSIGN_OR_RAISE(
           auto casted_multiple,
@@ -355,254 +497,33 @@ struct RoundOptionsWrapper<RoundToMultipleOptions>
   }
 };
 
-template <typename ArrowType, RoundMode RndMode, typename Enable = void>
-struct Round {
-  using CType = typename TypeTraits<ArrowType>::CType;
-  using State = RoundOptionsWrapper<RoundOptions>;
+template <typename ArrowType, typename Enable = void>
+struct RoundOptionsTrait;
 
-  CType pow10;
-  int64_t ndigits;
-
-  explicit Round(const State& state, const DataType& out_ty)
-      : pow10(static_cast<CType>(state.pow10)), ndigits(state.options.ndigits) {}
-
-  template <typename T = ArrowType, typename CType = typename TypeTraits<T>::CType>
-  enable_if_floating_value<CType> Call(KernelContext* ctx, CType arg, Status* st) const {
-    // Do not process Inf or NaN because they will trigger the overflow error at end of
-    // function.
-    if (!std::isfinite(arg)) {
-      return arg;
-    }
-    auto round_val = ndigits >= 0 ? (arg * pow10) : (arg / pow10);
-    auto frac = round_val - std::floor(round_val);
-    if (frac != T(0)) {
-      // Use std::round() if in tie-breaking mode and scaled value is not 0.5.
-      if ((RndMode >= RoundMode::HALF_DOWN) && (frac != T(0.5))) {
-        round_val = std::round(round_val);
-      } else {
-        round_val = RoundImpl<CType, RndMode>::Round(round_val);
-      }
-      // Equality check is ommitted so that the common case of 10^0 (integer rounding)
-      // uses multiply-only
-      round_val = ndigits > 0 ? (round_val / pow10) : (round_val * pow10);
-      if (!std::isfinite(round_val)) {
-        *st = Status::Invalid("overflow occurred during rounding");
-        return arg;
-      }
-    } else {
-      // If scaled value is an integer, then no rounding is needed.
-      round_val = arg;
-    }
-    return round_val;
-  }
+template <typename ArrowType>
+struct RoundOptionsTrait<ArrowType, enable_if_floating_point<ArrowType>> {
+  using CType = double;
 };
 
-template <typename ArrowType, RoundMode kRoundMode>
-struct Round<ArrowType, kRoundMode, enable_if_decimal<ArrowType>> {
-  using CType = typename TypeTraits<ArrowType>::CType;
-  using State = RoundOptionsWrapper<RoundOptions>;
-
-  const ArrowType& ty;
-  int64_t ndigits;
-  int32_t pow;
-  // pow10 is "1" for the given decimal scale. Similarly half_pow10 is "0.5".
-  CType pow10, half_pow10, neg_half_pow10;
-
-  explicit Round(const State& state, const DataType& out_ty)
-      : Round(state.options.ndigits, out_ty) {}
-
-  explicit Round(int64_t ndigits, const DataType& out_ty)
-      : ty(checked_cast<const ArrowType&>(out_ty)),
-        ndigits(ndigits),
-        pow(static_cast<int32_t>(ty.scale() - ndigits)) {
-    if (pow >= ty.precision() || pow < 0) {
-      pow10 = half_pow10 = neg_half_pow10 = 0;
-    } else {
-      pow10 = CType::GetScaleMultiplier(pow);
-      half_pow10 = CType::GetHalfScaleMultiplier(pow);
-      neg_half_pow10 = -half_pow10;
-    }
-  }
-
-  template <typename T = ArrowType, typename CType = typename TypeTraits<T>::CType>
-  enable_if_decimal_value<CType> Call(KernelContext* ctx, CType arg, Status* st) const {
-    if (pow >= ty.precision()) {
-      *st = Status::Invalid("Rounding to ", ndigits,
-                            " digits will not fit in precision of ", ty);
-      return 0;
-    } else if (pow < 0) {
-      // no-op, copy output to input
-      return arg;
-    }
-
-    std::pair<CType, CType> pair;
-    *st = arg.Divide(pow10).Value(&pair);
-    if (!st->ok()) return arg;
-    // The remainder is effectively the scaled fractional part after division.
-    const auto& remainder = pair.second;
-    if (remainder == 0) return arg;
-    if (kRoundMode >= RoundMode::HALF_DOWN) {
-      if (remainder == half_pow10 || remainder == neg_half_pow10) {
-        // On the halfway point, use tiebreaker
-        RoundImpl<CType, kRoundMode>::Round(&arg, remainder, pow10, pow);
-      } else if (remainder.Sign() >= 0) {
-        // Positive, round up/down
-        arg -= remainder;
-        if (remainder > half_pow10) {
-          arg += pow10;
-        }
-      } else {
-        // Negative, round up/down
-        arg -= remainder;
-        if (remainder < neg_half_pow10) {
-          arg -= pow10;
-        }
-      }
-    } else {
-      RoundImpl<CType, kRoundMode>::Round(&arg, remainder, pow10, pow);
-    }
-    if (!arg.FitsInPrecision(ty.precision())) {
-      *st = Status::Invalid("Rounded value ", arg.ToString(ty.scale()),
-                            " does not fit in precision of ", ty);
-      return 0;
-    }
-    return arg;
-  }
+template <typename ArrowType>
+struct RoundOptionsTrait<ArrowType, enable_if_decimal<ArrowType>> {
+  using CType = double;
 };
 
-template <typename ArrowType, RoundMode RndMode, typename Enable = void>
-struct RoundBinary {
-  using CType = typename TypeTraits<ArrowType>::CType;
-  using State = RoundOptionsWrapper<RoundBinaryOptions>;
-
-  explicit RoundBinary(const State& state, const DataType& out_ty) {}
-
-  template <typename T = ArrowType, typename CType0 = typename TypeTraits<T>::CType0,
-            typename CType1 = typename TypeTraits<T>::CType1>
-  enable_if_floating_value<CType> Call(KernelContext* ctx, CType0 arg0, CType1 arg1,
-                                       Status* st) const {
-    // Do not process Inf or NaN because they will trigger the overflow error at end of
-    // function.
-    if (!std::isfinite(arg0)) {
-      return arg0;
-    }
-
-    // Only positive exponents for powers of 10 are used because combining
-    // multiply and division operations produced more stable rounding than
-    // using multiply-only.  Refer to NumPy's round implementation:
-    // https://github.com/numpy/numpy/blob/7b2f20b406d27364c812f7a81a9c901afbd3600c/numpy/core/src/multiarray/calculation.c#L589
-    double pow10 = RoundUtil::Pow10(std::abs(arg1));
-
-    auto round_val = arg1 >= 0 ? (arg0 * pow10) : (arg0 / pow10);
-    auto frac = round_val - std::floor(round_val);
-    if (frac != T(0)) {
-      // Use std::round() if in tie-breaking mode and scaled value is not 0.5.
-      if ((RndMode >= RoundMode::HALF_DOWN) && (frac != T(0.5))) {
-        round_val = std::round(round_val);
-      } else {
-        round_val = RoundImpl<CType, RndMode>::Round(round_val);
-      }
-      // Equality check is omitted so that the common case of 10^0 (integer rounding)
-      // uses multiply-only
-      round_val = arg1 > 0 ? (round_val / pow10) : (round_val * pow10);
-      if (!std::isfinite(round_val)) {
-        *st = Status::Invalid("overflow occurred during rounding");
-        return arg0;
-      }
-    } else {
-      // If scaled value is an integer, then no rounding is needed.
-      round_val = arg0;
-    }
-    return static_cast<CType0>(round_val);
-  }
+template <typename ArrowType>
+struct RoundOptionsTrait<ArrowType, enable_if_integer<ArrowType>> {
+  using CType = typename ArrowType::c_type;
 };
 
-template <typename ArrowType, RoundMode kRoundMode>
-struct RoundBinary<ArrowType, kRoundMode, enable_if_decimal<ArrowType>> {
-  using CType = typename TypeTraits<ArrowType>::CType;
-  using State = RoundOptionsWrapper<RoundBinaryOptions>;
-
-  const ArrowType& ty;
-  int32_t pow;
-  // pow10 is "1" for the given decimal scale. Similarly half_pow10 is "0.5".
-  CType half_pow10, neg_half_pow10;
-
-  explicit RoundBinary(const State& state, const DataType& out_ty)
-      : RoundBinary(out_ty) {}
-
-  explicit RoundBinary(const DataType& out_ty)
-      : ty(checked_cast<const ArrowType&>(out_ty)),
-        pow(static_cast<int32_t>(ty.scale() - 0)) {
-    if (pow >= ty.precision() || pow < 0) {
-      half_pow10 = neg_half_pow10 = 0;
-    } else {
-      half_pow10 = CType::GetHalfScaleMultiplier(pow);
-      neg_half_pow10 = -half_pow10;
-    }
-  }
-
-  template <typename T = ArrowType, typename CType0 = typename TypeTraits<T>::CType0,
-            typename CType1 = typename TypeTraits<T>::CType1>
-  enable_if_decimal_value<CType> Call(KernelContext* ctx, CType0 arg0, CType1 arg1,
-                                      Status* st) const {
-    if (pow - arg1 >= ty.precision()) {
-      *st = Status::Invalid("Rounding to ", arg1, " digits will not fit in precision of ",
-                            ty);
-      return 0;
-    } else if (pow < 0) {
-      // no-op, copy output to input
-      return arg0;
-    }
-
-    CType0 pow10 = CType0::GetScaleMultiplier(static_cast<int32_t>(ty.scale() - arg1));
-
-    std::pair<CType, CType> pair;
-    *st = arg0.Divide(pow10).Value(&pair);
-    if (!st->ok()) return arg0;
-    // The remainder is effectively the scaled fractional part after division.
-    const auto& remainder = pair.second;
-    if (remainder == 0) return arg0;
-    if (kRoundMode >= RoundMode::HALF_DOWN) {
-      if (remainder == half_pow10 || remainder == neg_half_pow10) {
-        // On the halfway point, use tiebreaker
-        RoundImpl<CType0, kRoundMode>::Round(&arg0, remainder, pow10, pow);
-      } else if (remainder.Sign() >= 0) {
-        // Positive, round up/down
-        arg0 -= remainder;
-        if (remainder > half_pow10) {
-          arg0 += pow10;
-        }
-      } else {
-        // Negative, round up/down
-        arg0 -= remainder;
-        if (remainder < neg_half_pow10) {
-          arg0 -= pow10;
-        }
-      }
-    } else {
-      RoundImpl<CType0, kRoundMode>::Round(&arg0, remainder, pow10, pow);
-    }
-    if (!arg0.FitsInPrecision(ty.precision())) {
-      *st = Status::Invalid("Rounded value ", arg0.ToString(ty.scale()),
-                            " does not fit in precision of ", ty);
-      return 0;
-    }
-    return arg0;
-  }
-};
-
-template <typename DecimalType, RoundMode kMode, int32_t kDigits>
-Status FixedRoundDecimalExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
-  using Op = Round<DecimalType, kMode>;
-  return ScalarUnaryNotNullStateful<DecimalType, DecimalType, Op>(
-             Op(kDigits, *out->type()))
-      .Exec(ctx, batch, out);
-}
+// End round options wrappers
+// ----------------------------------------------------------------------
+// Begin round op implementations
 
 template <typename ArrowType, RoundMode kRoundMode, typename Enable = void>
 struct RoundToMultiple {
   using CType = typename TypeTraits<ArrowType>::CType;
-  using State = RoundOptionsWrapper<RoundToMultipleOptions>;
+  using State = RoundOptionsWrapper<RoundToMultipleOptions,
+                                    typename RoundOptionsTrait<ArrowType>::CType>;
 
   CType multiple;
 
@@ -646,8 +567,7 @@ struct RoundToMultiple {
 template <typename ArrowType, RoundMode kRoundMode>
 struct RoundToMultiple<ArrowType, kRoundMode, enable_if_decimal<ArrowType>> {
   using CType = typename TypeTraits<ArrowType>::CType;
-  using State = RoundOptionsWrapper<RoundToMultipleOptions>;
-
+  using State = RoundOptionsWrapper<RoundToMultipleOptions, double>;
   const ArrowType& ty;
   CType multiple, half_multiple, neg_half_multiple;
   bool has_halfway_point;
@@ -744,11 +664,349 @@ struct RoundToMultiple<ArrowType, kRoundMode, enable_if_decimal<ArrowType>> {
   }
 };
 
+template <typename ArrowType, RoundMode kRoundMode>
+struct RoundToMultiple<ArrowType, kRoundMode, enable_if_integer<ArrowType>> {
+  using CType = typename TypeTraits<ArrowType>::CType;
+  using State = RoundOptionsWrapper<RoundToMultipleOptions, CType>;
+  CType multiple;
+
+  explicit RoundToMultiple(const State& state, const DataType& out_ty)
+      : multiple(UnboxScalar<ArrowType>::Unbox(*state.options.multiple)) {
+    const auto& options = state.options;
+    DCHECK(options.multiple);
+    DCHECK(options.multiple->is_valid);
+    DCHECK(is_integer(options.multiple->type->id()));
+  }
+
+  explicit RoundToMultiple(const CType multiple, const DataType& out_ty)
+      : multiple(multiple) {}
+
+  template <typename T = ArrowType, typename CType = typename TypeTraits<T>::CType>
+  enable_if_integer_value<CType> Call(KernelContext* ctx, CType arg, Status* st) const {
+    CType floor = arg / multiple * multiple;
+    CType remainder = arg > floor ? arg - floor : floor - arg;
+
+    if (remainder == 0) {
+      return arg;
+    }
+
+    if (kRoundMode >= RoundMode::HALF_DOWN && remainder * 2 != multiple) {
+      // not half way, round to nearest multiple of multiple like std::round
+      if (remainder * 2 > multiple) {
+        if (arg >= 0) {
+          if (ARROW_PREDICT_FALSE(std::numeric_limits<CType>::max() - multiple < floor)) {
+            *st = Status::Invalid("Rounding ", arg, " up to multiples of ", multiple,
+                                  " would overflow");
+            return arg;
+          }
+          return floor + multiple;
+        } else {
+          if (ARROW_PREDICT_FALSE(std::numeric_limits<CType>::min() + multiple > floor)) {
+            *st = Status::Invalid("Rounding ", arg, " down to multiples of ", multiple,
+                                  " would overflow");
+            return arg;
+          }
+          return floor - multiple;
+        }
+      } else {
+        return floor;
+      }
+    } else {
+      return RoundImpl<CType, kRoundMode>::Round(arg, floor, multiple, st);
+    }
+  }
+};
+
+template <typename ArrowType, RoundMode RndMode, typename Enable = void>
+struct Round {
+  using CType = typename TypeTraits<ArrowType>::CType;
+  using State =
+      RoundOptionsWrapper<RoundOptions, typename RoundOptionsTrait<ArrowType>::CType>;
+  CType pow10;
+  int64_t ndigits;
+
+  explicit Round(const State& state, const DataType& out_ty)
+      : pow10(static_cast<CType>(state.pow10)), ndigits(state.options.ndigits) {}
+
+  template <typename T = ArrowType, typename CType = typename TypeTraits<T>::CType>
+  enable_if_floating_value<CType> Call(KernelContext* ctx, CType arg, Status* st) const {
+    // Do not process Inf or NaN because they will trigger the overflow error at end of
+    // function.
+    if (!std::isfinite(arg)) {
+      return arg;
+    }
+    auto round_val = ndigits >= 0 ? (arg * pow10) : (arg / pow10);
+    auto frac = round_val - std::floor(round_val);
+    if (frac != T(0)) {
+      // Use std::round() if in tie-breaking mode and scaled value is not 0.5.
+      if ((RndMode >= RoundMode::HALF_DOWN) && (frac != T(0.5))) {
+        round_val = std::round(round_val);
+      } else {
+        round_val = RoundImpl<CType, RndMode>::Round(round_val);
+      }
+      // Equality check is ommitted so that the common case of 10^0 (integer rounding)
+      // uses multiply-only
+      round_val = ndigits > 0 ? (round_val / pow10) : (round_val * pow10);
+      if (!std::isfinite(round_val)) {
+        *st = Status::Invalid("overflow occurred during rounding");
+        return arg;
+      }
+    } else {
+      // If scaled value is an integer, then no rounding is needed.
+      round_val = arg;
+    }
+    return round_val;
+  }
+};
+
+template <typename ArrowType, RoundMode kRoundMode>
+struct Round<ArrowType, kRoundMode, enable_if_decimal<ArrowType>> {
+  using CType = typename TypeTraits<ArrowType>::CType;
+  using State = RoundOptionsWrapper<RoundOptions, double>;
+  const ArrowType& ty;
+  int64_t ndigits;
+  int32_t pow;
+  // pow10 is "1" for the given decimal scale. Similarly half_pow10 is "0.5".
+  CType pow10, half_pow10, neg_half_pow10;
+
+  explicit Round(const State& state, const DataType& out_ty)
+      : Round(state.options.ndigits, out_ty) {}
+
+  explicit Round(int64_t ndigits, const DataType& out_ty)
+      : ty(checked_cast<const ArrowType&>(out_ty)),
+        ndigits(ndigits),
+        pow(static_cast<int32_t>(ty.scale() - ndigits)) {
+    if (pow >= ty.precision() || pow < 0) {
+      pow10 = half_pow10 = neg_half_pow10 = 0;
+    } else {
+      pow10 = CType::GetScaleMultiplier(pow);
+      half_pow10 = CType::GetHalfScaleMultiplier(pow);
+      neg_half_pow10 = -half_pow10;
+    }
+  }
+
+  template <typename T = ArrowType, typename CType = typename TypeTraits<T>::CType>
+  enable_if_decimal_value<CType> Call(KernelContext* ctx, CType arg, Status* st) const {
+    if (pow >= ty.precision()) {
+      *st = Status::Invalid("Rounding to ", ndigits,
+                            " digits will not fit in precision of ", ty);
+      return 0;
+    } else if (pow < 0) {
+      // no-op, copy output to input
+      return arg;
+    }
+
+    std::pair<CType, CType> pair;
+    *st = arg.Divide(pow10).Value(&pair);
+    if (!st->ok()) return arg;
+    // The remainder is effectively the scaled fractional part after division.
+    const auto& remainder = pair.second;
+    if (remainder == 0) return arg;
+    if (kRoundMode >= RoundMode::HALF_DOWN) {
+      if (remainder == half_pow10 || remainder == neg_half_pow10) {
+        // On the halfway point, use tiebreaker
+        RoundImpl<CType, kRoundMode>::Round(&arg, remainder, pow10, pow);
+      } else if (remainder.Sign() >= 0) {
+        // Positive, round up/down
+        arg -= remainder;
+        if (remainder > half_pow10) {
+          arg += pow10;
+        }
+      } else {
+        // Negative, round up/down
+        arg -= remainder;
+        if (remainder < neg_half_pow10) {
+          arg -= pow10;
+        }
+      }
+    } else {
+      RoundImpl<CType, kRoundMode>::Round(&arg, remainder, pow10, pow);
+    }
+    if (!arg.FitsInPrecision(ty.precision())) {
+      *st = Status::Invalid("Rounded value ", arg.ToString(ty.scale()),
+                            " does not fit in precision of ", ty);
+      return 0;
+    }
+    return arg;
+  }
+};
+
+template <typename ArrowType, RoundMode kRoundMode>
+struct Round<ArrowType, kRoundMode, enable_if_integer<ArrowType>> {
+  using CType = typename TypeTraits<ArrowType>::CType;
+  using State = RoundOptionsWrapper<RoundOptions, CType>;
+  CType pow10;
+  int64_t ndigits;
+  const DataType& out_ty;
+
+  explicit Round(const State& state, const DataType& out_ty)
+      : pow10(static_cast<CType>(state.pow10)),
+        ndigits(state.options.ndigits),
+        out_ty(out_ty) {}
+
+  template <typename T = ArrowType, typename CType = typename TypeTraits<T>::CType>
+  enable_if_integer_value<CType> Call(KernelContext* ctx, CType arg, Status* st) const {
+    // no-op if ndigits is non-negative
+    if (ndigits >= 0) {
+      return arg;
+    }
+
+    // If ndigits is negative, then round to the nearest multiple of 10^ndigits.
+    RoundToMultiple<ArrowType, kRoundMode> round_to_multiple(pow10, out_ty);
+    return round_to_multiple.Call(ctx, arg, st);
+  }
+};
+
+template <typename ArrowType, RoundMode RndMode, typename Enable = void>
+struct RoundBinary {
+  using CType = typename TypeTraits<ArrowType>::CType;
+  using State = RoundOptionsWrapper<RoundBinaryOptions,
+                                    typename RoundOptionsTrait<ArrowType>::CType>;
+
+  explicit RoundBinary(const State& state, const DataType& out_ty) {}
+
+  template <typename T = ArrowType, typename CType0 = typename TypeTraits<T>::CType0,
+            typename CType1 = typename TypeTraits<T>::CType1>
+  enable_if_floating_value<CType> Call(KernelContext* ctx, CType0 arg0, CType1 arg1,
+                                       Status* st) const {
+    // Do not process Inf or NaN because they will trigger the overflow error at end of
+    // function.
+    if (!std::isfinite(arg0)) {
+      return arg0;
+    }
+
+    // Only positive exponents for powers of 10 are used because combining
+    // multiply and division operations produced more stable rounding than
+    // using multiply-only.  Refer to NumPy's round implementation:
+    // https://github.com/numpy/numpy/blob/7b2f20b406d27364c812f7a81a9c901afbd3600c/numpy/core/src/multiarray/calculation.c#L589
+    double pow10 = RoundUtil::Pow10<double>(std::abs(arg1));
+
+    auto round_val = arg1 >= 0 ? (arg0 * pow10) : (arg0 / pow10);
+    auto frac = round_val - std::floor(round_val);
+    if (frac != T(0)) {
+      // Use std::round() if in tie-breaking mode and scaled value is not 0.5.
+      if ((RndMode >= RoundMode::HALF_DOWN) && (frac != T(0.5))) {
+        round_val = std::round(round_val);
+      } else {
+        round_val = RoundImpl<CType, RndMode>::Round(round_val);
+      }
+      // Equality check is omitted so that the common case of 10^0 (integer rounding)
+      // uses multiply-only
+      round_val = arg1 > 0 ? (round_val / pow10) : (round_val * pow10);
+      if (!std::isfinite(round_val)) {
+        *st = Status::Invalid("overflow occurred during rounding");
+        return arg0;
+      }
+    } else {
+      // If scaled value is an integer, then no rounding is needed.
+      round_val = arg0;
+    }
+    return static_cast<CType0>(round_val);
+  }
+};
+
+template <typename ArrowType, RoundMode kRoundMode>
+struct RoundBinary<ArrowType, kRoundMode, enable_if_decimal<ArrowType>> {
+  using CType = typename TypeTraits<ArrowType>::CType;
+  using State = RoundOptionsWrapper<RoundBinaryOptions, double>;
+  const ArrowType& ty;
+  int32_t pow;
+  // pow10 is "1" for the given decimal scale. Similarly half_pow10 is "0.5".
+  CType half_pow10, neg_half_pow10;
+
+  explicit RoundBinary(const State& state, const DataType& out_ty)
+      : RoundBinary(out_ty) {}
+
+  explicit RoundBinary(const DataType& out_ty)
+      : ty(checked_cast<const ArrowType&>(out_ty)),
+        pow(static_cast<int32_t>(ty.scale() - 0)) {
+    if (pow >= ty.precision() || pow < 0) {
+      half_pow10 = neg_half_pow10 = 0;
+    } else {
+      half_pow10 = CType::GetHalfScaleMultiplier(pow);
+      neg_half_pow10 = -half_pow10;
+    }
+  }
+
+  template <typename T = ArrowType, typename CType0 = typename TypeTraits<T>::CType0,
+            typename CType1 = typename TypeTraits<T>::CType1>
+  enable_if_decimal_value<CType> Call(KernelContext* ctx, CType0 arg0, CType1 arg1,
+                                      Status* st) const {
+    if (pow - arg1 >= ty.precision()) {
+      *st = Status::Invalid("Rounding to ", arg1, " digits will not fit in precision of ",
+                            ty);
+      return 0;
+    } else if (pow < 0) {
+      // no-op, copy output to input
+      return arg0;
+    }
+
+    CType0 pow10 = CType0::GetScaleMultiplier(static_cast<int32_t>(ty.scale() - arg1));
+
+    std::pair<CType, CType> pair;
+    *st = arg0.Divide(pow10).Value(&pair);
+    if (!st->ok()) return arg0;
+    // The remainder is effectively the scaled fractional part after division.
+    const auto& remainder = pair.second;
+    if (remainder == 0) return arg0;
+    if (kRoundMode >= RoundMode::HALF_DOWN) {
+      if (remainder == half_pow10 || remainder == neg_half_pow10) {
+        // On the halfway point, use tiebreaker
+        RoundImpl<CType0, kRoundMode>::Round(&arg0, remainder, pow10, pow);
+      } else if (remainder.Sign() >= 0) {
+        // Positive, round up/down
+        arg0 -= remainder;
+        if (remainder > half_pow10) {
+          arg0 += pow10;
+        }
+      } else {
+        // Negative, round up/down
+        arg0 -= remainder;
+        if (remainder < neg_half_pow10) {
+          arg0 -= pow10;
+        }
+      }
+    } else {
+      RoundImpl<CType0, kRoundMode>::Round(&arg0, remainder, pow10, pow);
+    }
+    if (!arg0.FitsInPrecision(ty.precision())) {
+      *st = Status::Invalid("Rounded value ", arg0.ToString(ty.scale()),
+                            " does not fit in precision of ", ty);
+      return 0;
+    }
+    return arg0;
+  }
+};
+
+template <typename ArrowType, RoundMode kRoundMode>
+struct RoundBinary<ArrowType, kRoundMode, enable_if_integer<ArrowType>> {
+  using CType = typename TypeTraits<ArrowType>::CType;
+  using State = RoundOptionsWrapper<RoundBinaryOptions, CType>;
+
+  const DataType& out_ty;
+  explicit RoundBinary(const State& state, const DataType& out_ty) : out_ty(out_ty) {}
+
+  template <typename T = ArrowType, typename CType0 = typename TypeTraits<T>::CType0,
+            typename CType1 = typename TypeTraits<T>::CType1>
+  enable_if_integer_value<CType> Call(KernelContext* ctx, CType0 arg0, CType1 arg1,
+                                      Status* st) const {
+    // ndigits >= 0 is a no-op
+    if (arg1 >= 0) {
+      return arg0;
+    }
+
+    // If ndigits is negative, then round to the nearest multiple of 10^ndigits.
+    CType pow10 = RoundUtil::Pow10<CType>(std::abs(arg1));
+    RoundToMultiple<ArrowType, kRoundMode> round_to_multiple(pow10, out_ty);
+    return round_to_multiple.Call(ctx, arg0, st);
+  }
+};
+
 struct Floor {
   template <typename T, typename Arg>
   static constexpr enable_if_floating_value<Arg, T> Call(KernelContext*, Arg arg,
                                                          Status*) {
-    static_assert(std::is_same<T, Arg>::value, "");
+    static_assert(std::is_same<T, Arg>::value);
     return RoundImpl<T, RoundMode::DOWN>::Round(arg);
   }
 };
@@ -757,7 +1015,7 @@ struct Ceil {
   template <typename T, typename Arg>
   static constexpr enable_if_floating_value<Arg, T> Call(KernelContext*, Arg arg,
                                                          Status*) {
-    static_assert(std::is_same<T, Arg>::value, "");
+    static_assert(std::is_same<T, Arg>::value);
     return RoundImpl<T, RoundMode::UP>::Round(arg);
   }
 };
@@ -766,10 +1024,14 @@ struct Trunc {
   template <typename T, typename Arg>
   static constexpr enable_if_floating_value<Arg, T> Call(KernelContext*, Arg arg,
                                                          Status*) {
-    static_assert(std::is_same<T, Arg>::value, "");
+    static_assert(std::is_same<T, Arg>::value);
     return RoundImpl<T, RoundMode::TOWARDS_ZERO>::Round(arg);
   }
 };
+
+// End round op implementations
+// ----------------------------------------------------------------------
+// Begin round functions
 
 struct RoundFunction : ScalarFunction {
   using ScalarFunction::ScalarFunction;
@@ -782,6 +1044,10 @@ struct RoundFunction : ScalarFunction {
 
     EnsureDictionaryDecoded(types);
 
+    // for binary round functions, the second scalar must be int32
+    if (types->size() == 2 && (*types)[1].id() != Type::INT32) {
+      (*types)[1] = int32();
+    }
     if (auto kernel = DispatchExactImpl(this, *types)) return kernel;
     return arrow::compute::detail::NoMatchingKernel(this, *types);
   }
@@ -862,6 +1128,10 @@ struct RoundFloatingPointFunction : public RoundFunction {
   }
 };
 
+// End round functions
+// ----------------------------------------------------------------------
+// Begin round kernels
+
 #define ROUND_CASE(MODE)                                                       \
   case RoundMode::MODE: {                                                      \
     using Op = OpImpl<Type, RoundMode::MODE>;                                  \
@@ -874,7 +1144,8 @@ template <typename Type, typename OptionsType,
           template <typename, RoundMode, typename...> class OpImpl>
 struct RoundKernel {
   static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
-    using State = RoundOptionsWrapper<OptionsType>;
+    using State =
+        RoundOptionsWrapper<OptionsType, typename RoundOptionsTrait<Type>::CType>;
     const auto& state = static_cast<const State&>(*ctx->state());
     switch (state.options.round_mode) {
       ROUND_CASE(DOWN)
@@ -909,7 +1180,8 @@ template <typename Type, typename OptionsType,
           template <typename, RoundMode, typename...> class OpImpl>
 struct RoundBinaryKernel {
   static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
-    using State = RoundOptionsWrapper<OptionsType>;
+    using State =
+        RoundOptionsWrapper<OptionsType, typename RoundOptionsTrait<Type>::CType>;
     const auto& state = static_cast<const State&>(*ctx->state());
     switch (state.options.round_mode) {
       ROUND_BINARY_CASE(DOWN)
@@ -931,38 +1203,59 @@ struct RoundBinaryKernel {
 };
 #undef ROUND_BINARY_CASE
 
+template <typename DecimalType, RoundMode kMode, int32_t kDigits>
+Status FixedRoundDecimalExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
+  using Op = Round<DecimalType, kMode>;
+  return ScalarUnaryNotNullStateful<DecimalType, DecimalType, Op>(
+             Op(kDigits, *out->type()))
+      .Exec(ctx, batch, out);
+}
+
+// End round kernels
+// ----------------------------------------------------------------------
+// Begin round kernel generation and function registration
+
+template <
+    template <typename, RoundMode, typename...> class Op,
+    template <typename, typename, template <typename, RoundMode, typename...> typename>
+    class Kernel,
+    typename OptionsType>
+struct RoundKernelGenerator {
+  template <typename ArrowType>
+  Status Visit(const ArrowType& type, ArrayKernelExec* exec, KernelInit* init) {
+    if constexpr (is_integer_type<ArrowType>::value ||
+                  (is_floating_type<ArrowType>::value &&
+                   !is_half_float_type<ArrowType>::value) ||
+                  is_decimal_type<ArrowType>::value) {
+      *exec = Kernel<ArrowType, OptionsType, Op>::Exec;
+      *init = RoundOptionsWrapper<OptionsType,
+                                  typename RoundOptionsTrait<ArrowType>::CType>::Init;
+    } else {
+      DCHECK(false);
+      return Status::NotImplemented("Round does not support ", type.ToString());
+    }
+    return Status::OK();
+  }
+};
+
 // For unary rounding functions that control kernel dispatch based on RoundMode, only on
 // non-null output.
 template <template <typename, RoundMode, typename...> class Op, typename OptionsType>
 std::shared_ptr<ScalarFunction> MakeUnaryRoundFunction(std::string name,
                                                        FunctionDoc doc) {
-  using State = RoundOptionsWrapper<OptionsType>;
   static const OptionsType kDefaultOptions = OptionsType::Defaults();
-  auto func = std::make_shared<RoundIntegerToFloatingPointFunction>(
-      name, Arity::Unary(), std::move(doc), &kDefaultOptions);
-  for (const auto& ty : {float32(), float64(), decimal128(1, 0), decimal256(1, 0)}) {
-    auto type_id = ty->id();
-    ArrayKernelExec exec = nullptr;
-    switch (type_id) {
-      case Type::FLOAT:
-        exec = RoundKernel<FloatType, OptionsType, Op>::Exec;
-        break;
-      case Type::DOUBLE:
-        exec = RoundKernel<DoubleType, OptionsType, Op>::Exec;
-        break;
-      case Type::DECIMAL128:
-        exec = RoundKernel<Decimal128Type, OptionsType, Op>::Exec;
-        break;
-      case Type::DECIMAL256:
-        exec = RoundKernel<Decimal256Type, OptionsType, Op>::Exec;
-        break;
-      default:
-        DCHECK(false);
-        break;
+  auto func = std::make_shared<RoundFunction>(name, Arity::Unary(), std::move(doc),
+                                              &kDefaultOptions);
+  RoundKernelGenerator<Op, RoundKernel, OptionsType> kernel_generator;
+  for (const auto& tys : {NumericTypes(), {decimal128(1, 0), decimal256(1, 0)}}) {
+    for (const auto& ty : tys) {
+      ArrayKernelExec exec;
+      KernelInit init;
+      DCHECK_OK(VisitTypeInline(*ty, &kernel_generator, &exec, &init));
+      DCHECK_OK(func->AddKernel(
+          {InputType(ty->id())},
+          is_decimal(ty->id()) ? OutputType(FirstType) : OutputType(ty), exec, init));
     }
-    DCHECK_OK(func->AddKernel(
-        {InputType(type_id)},
-        is_decimal(type_id) ? OutputType(FirstType) : OutputType(ty), exec, State::Init));
   }
   AddNullExec(func.get());
   return func;
@@ -971,33 +1264,19 @@ std::shared_ptr<ScalarFunction> MakeUnaryRoundFunction(std::string name,
 template <template <typename, RoundMode, typename...> class Op, typename OptionsType>
 std::shared_ptr<ScalarFunction> MakeBinaryRoundFunction(const std::string& name,
                                                         FunctionDoc doc) {
-  using State = RoundOptionsWrapper<OptionsType>;
   static const OptionsType kDefaultOptions = OptionsType::Defaults();
-  auto func = std::make_shared<RoundIntegerToFloatingPointFunction>(
-      name, Arity::Binary(), std::move(doc), &kDefaultOptions);
-  for (const auto& ty : {float32(), float64(), decimal128(1, 0), decimal256(1, 0)}) {
-    auto type_id = ty->id();
-    ArrayKernelExec exec = nullptr;
-    switch (type_id) {
-      case Type::FLOAT:
-        exec = RoundBinaryKernel<FloatType, OptionsType, Op>::Exec;
-        break;
-      case Type::DOUBLE:
-        exec = RoundBinaryKernel<DoubleType, OptionsType, Op>::Exec;
-        break;
-      case Type::DECIMAL128:
-        exec = RoundBinaryKernel<Decimal128Type, OptionsType, Op>::Exec;
-        break;
-      case Type::DECIMAL256:
-        exec = RoundBinaryKernel<Decimal256Type, OptionsType, Op>::Exec;
-        break;
-      default:
-        DCHECK(false);
-        break;
+  auto func = std::make_shared<RoundFunction>(name, Arity::Binary(), std::move(doc),
+                                              &kDefaultOptions);
+  RoundKernelGenerator<Op, RoundBinaryKernel, OptionsType> kernel_generator;
+  for (const auto& tys : {NumericTypes(), {decimal128(1, 0), decimal256(1, 0)}}) {
+    for (const auto& ty : tys) {
+      ArrayKernelExec exec;
+      KernelInit init;
+      DCHECK_OK(VisitTypeInline(*ty, &kernel_generator, &exec, &init));
+      DCHECK_OK(func->AddKernel(
+          {InputType(ty->id()), Type::INT32},
+          is_decimal(ty->id()) ? OutputType(FirstType) : OutputType(ty), exec, init));
     }
-    DCHECK_OK(func->AddKernel(
-        {ty, Type::INT32}, is_decimal(type_id) ? OutputType(FirstType) : OutputType(ty),
-        exec, State::Init));
   }
   AddNullExec(func.get());
   return func;
@@ -1101,6 +1380,7 @@ void RegisterScalarRoundArithmetic(FunctionRegistry* registry) {
   DCHECK_OK(registry->AddFunction(std::move(round_to_multiple)));
 }
 
-}  // namespace internal
-}  // namespace compute
+// End round kernel generation and function registration
+// ----------------------------------------------------------------------
+}  // namespace compute::internal
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/scalar_round.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_round.cc
@@ -120,7 +120,7 @@ struct RoundUtil {
   // Calculate powers of ten with arbitrary integer exponent
   template <typename T>
   static enable_if_integer_value<T> Pow10(int64_t power) {
-    DCHECK(power >= 0);
+    DCHECK_GE(power, 0);
 
     static constexpr uint64_t lut[] = {
         Pow10Struct<0>::value,  Pow10Struct<1>::value,  Pow10Struct<2>::value,

--- a/cpp/src/arrow/compute/kernels/scalar_round_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_round_arithmetic_test.cc
@@ -1052,19 +1052,19 @@ TYPED_TEST(TestUnaryRoundSigned, Round) {
   // Test different rounding mode
   // skip int8 because of its small range
   if constexpr (!std::is_same_v<TypeParam, Int8Type>) {
-    std::string values("[0, 1, -13, -50, 115, -176, 200, 250]");
+    std::string values("[0, 1, -13, -50, 115, -150, -176, 200, 250]");
     this->SetRoundNdigits(-2);
     std::vector<std::pair<RoundMode, std::string>> round_modes_and_expected{{
-        {RoundMode::DOWN, "[0, 0, -100, -100, 100, -200, 200, 200]"},
-        {RoundMode::UP, "[0, 100, -0, -0, 200, -100, 200, 300]"},
-        {RoundMode::TOWARDS_ZERO, "[0, 0, -0, -0, 100, -100, 200, 200]"},
-        {RoundMode::TOWARDS_INFINITY, "[0, 100, -100, -100, 200, -200, 200, 300]"},
-        {RoundMode::HALF_DOWN, "[0, 0, -0, -100, 100, -200, 200, 200]"},
-        {RoundMode::HALF_UP, "[0, 0, -0, -0, 100, -200, 200, 300]"},
-        {RoundMode::HALF_TOWARDS_ZERO, "[0, 0, -0, -0, 100, -200, 200, 200]"},
-        {RoundMode::HALF_TOWARDS_INFINITY, "[0, 0, -0, -100, 100, -200, 200, 300]"},
-        {RoundMode::HALF_TO_EVEN, "[0, 0, -0, -0, 100, -200, 200, 200]"},
-        {RoundMode::HALF_TO_ODD, "[0, 0, -0, -100, 100, -200, 200, 300]"},
+        {RoundMode::DOWN, "[0, 0, -100, -100, 100, -200, -200, 200, 200]"},
+        {RoundMode::UP, "[0, 100, -0, -0, 200, -100, -100, 200, 300]"},
+        {RoundMode::TOWARDS_ZERO, "[0, 0, -0, -0, 100, -100, -100, 200, 200]"},
+        {RoundMode::TOWARDS_INFINITY, "[0, 100, -100, -100, 200, -200, -200, 200, 300]"},
+        {RoundMode::HALF_DOWN, "[0, 0, -0, -100, 100, -200, -200, 200, 200]"},
+        {RoundMode::HALF_UP, "[0, 0, -0, -0, 100, -100, -200, 200, 300]"},
+        {RoundMode::HALF_TOWARDS_ZERO, "[0, 0, -0, -0, 100, -100, -200, 200, 200]"},
+        {RoundMode::HALF_TOWARDS_INFINITY, "[0, 0, -0, -100, 100, -200, -200, 200, 300]"},
+        {RoundMode::HALF_TO_EVEN, "[0, 0, -0, -0, 100, -200, -200, 200, 200]"},
+        {RoundMode::HALF_TO_ODD, "[0, 0, -0, -100, 100, -100, -200, 200, 300]"},
     }};
     for (const auto& pair : round_modes_and_expected) {
       this->SetRoundMode(pair.first);
@@ -1074,12 +1074,9 @@ TYPED_TEST(TestUnaryRoundSigned, Round) {
   }
 
   // An overly large ndigits would cause an error
-  if constexpr (std::is_same_v<TypeParam, Int8Type>) {
-    this->SetRoundNdigits(-100);
-    this->SetRoundMode(RoundMode::UP);
-    auto values = "[1]";
-    this->AssertUnaryOpRaises(Round, values, "out of range");
-  }
+  this->SetRoundNdigits(-100);
+  this->SetRoundMode(RoundMode::UP);
+  this->AssertUnaryOpRaises(Round, "[1]", "out of range");
 
   // Overflow is also treated as error
   if constexpr (std::is_same_v<TypeParam, Int8Type>) {
@@ -1125,19 +1122,19 @@ TYPED_TEST(TestUnaryRoundUnsigned, Round) {
   // Test different rounding mode
   // skip uint8 because of its small range
   if constexpr (!std::is_same_v<TypeParam, UInt8Type>) {
-    std::string values("[0, 1, 13, 50, 115, 176, 200, 250]");
+    std::string values("[0, 1, 13, 50, 115, 150, 176, 200, 250]");
     this->SetRoundNdigits(-2);
     std::vector<std::pair<RoundMode, std::string>> round_modes_and_expected{{
-        {RoundMode::DOWN, "[0, 0, 0, 0, 100, 100, 200, 200]"},
-        {RoundMode::UP, "[0, 100, 100, 100, 200, 200, 200, 300]"},
-        {RoundMode::TOWARDS_ZERO, "[0, 0, 0, 0, 100, 100, 200, 200]"},
-        {RoundMode::TOWARDS_INFINITY, "[0, 100, 100, 100, 200, 200, 200, 300]"},
-        {RoundMode::HALF_DOWN, "[0, 0, 0, 0, 100, 200, 200, 200]"},
-        {RoundMode::HALF_UP, "[0, 0, 0, 100, 100, 200, 200, 300]"},
-        {RoundMode::HALF_TOWARDS_ZERO, "[0, 0, 0, 0, 100, 200, 200, 200]"},
-        {RoundMode::HALF_TOWARDS_INFINITY, "[0, 0, 0, 100, 100, 200, 200, 300]"},
-        {RoundMode::HALF_TO_EVEN, "[0, 0, 0, 0, 100, 200, 200, 200]"},
-        {RoundMode::HALF_TO_ODD, "[0, 0, 0, 100, 100, 200, 200, 300]"},
+        {RoundMode::DOWN, "[0, 0, 0, 0, 100, 100, 100, 200, 200]"},
+        {RoundMode::UP, "[0, 100, 100, 100, 200, 200, 200, 200, 300]"},
+        {RoundMode::TOWARDS_ZERO, "[0, 0, 0, 0, 100, 100, 100, 200, 200]"},
+        {RoundMode::TOWARDS_INFINITY, "[0, 100, 100, 100, 200, 200, 200, 200, 300]"},
+        {RoundMode::HALF_DOWN, "[0, 0, 0, 0, 100, 100, 200, 200, 200]"},
+        {RoundMode::HALF_UP, "[0, 0, 0, 100, 100, 200, 200, 200, 300]"},
+        {RoundMode::HALF_TOWARDS_ZERO, "[0, 0, 0, 0, 100, 100, 200, 200, 200]"},
+        {RoundMode::HALF_TOWARDS_INFINITY, "[0, 0, 0, 100, 100, 200, 200, 200, 300]"},
+        {RoundMode::HALF_TO_EVEN, "[0, 0, 0, 0, 100, 200, 200, 200, 200]"},
+        {RoundMode::HALF_TO_ODD, "[0, 0, 0, 100, 100, 100, 200, 200, 300]"},
     }};
     for (const auto& pair : round_modes_and_expected) {
       this->SetRoundMode(pair.first);
@@ -1147,12 +1144,9 @@ TYPED_TEST(TestUnaryRoundUnsigned, Round) {
   }
 
   // An overly large ndigits would cause an error
-  if constexpr (std::is_same_v<TypeParam, UInt8Type>) {
-    this->SetRoundNdigits(-100);
-    this->SetRoundMode(RoundMode::UP);
-    auto values = "[1]";
-    this->AssertUnaryOpRaises(Round, values, "out of range");
-  }
+  this->SetRoundNdigits(-100);
+  this->SetRoundMode(RoundMode::UP);
+  this->AssertUnaryOpRaises(Round, "[1]", "out of range");
 
   // Overflow is also treated as error
   if constexpr (std::is_same_v<TypeParam, UInt8Type>) {

--- a/cpp/src/arrow/compute/kernels/scalar_round_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_round_arithmetic_test.cc
@@ -34,8 +34,7 @@
 
 #include "arrow/testing/gtest_util.h"
 
-namespace arrow {
-namespace compute {
+namespace arrow::compute {
 
 namespace {
 
@@ -481,11 +480,29 @@ TYPED_TEST_SUITE(TestUnaryRoundArithmeticFloating, FloatingTypes);
 
 TEST(TestUnaryRound, DispatchBestRound) {
   // Integer -> Float64
-  for (std::string name : {"floor", "ceil", "trunc", "round", "round_to_multiple"}) {
+  for (std::string name : {"floor", "ceil", "trunc"}) {
     for (const auto& ty :
          {int8(), int16(), int32(), int64(), uint8(), uint16(), uint32(), uint64()}) {
       CheckDispatchBest(name, {ty}, {float64()});
       CheckDispatchBest(name, {dictionary(int8(), ty)}, {float64()});
+    }
+  }
+  // Integer -> Integer
+  for (std::string name : {"round", "round_to_multiple"}) {
+    for (const auto& ty :
+         {int8(), int16(), int32(), int64(), uint8(), uint16(), uint32(), uint64()}) {
+      CheckDispatchBest(name, {ty}, {ty});
+      CheckDispatchBest(name, {dictionary(int8(), ty)}, {ty});
+    }
+  }
+
+  // Any -> Int32
+  for (std::string name : {"round_binary"}) {
+    for (const auto& ty1 : NumericTypes()) {
+      for (const auto& ty2 : NumericTypes()) {
+        CheckDispatchBest(name, {ty1, ty2}, {ty1, int32()});
+        CheckDispatchBest(name, {dictionary(int8(), ty1), ty2}, {ty1, int32()});
+      }
     }
   }
 }
@@ -1014,13 +1031,13 @@ TYPED_TEST(TestUnaryRoundSigned, Round) {
   this->SetRoundNdigits(0);
   for (const auto& round_mode : kRoundModes) {
     this->SetRoundMode(round_mode);
-    this->AssertUnaryOp(Round, values, ArrayFromJSON(float64(), values));
+    this->AssertUnaryOp(Round, values, ArrayFromJSON(this->type_singleton(), values));
   }
 
   // Test different round N-digits for nearest rounding mode
   std::vector<std::pair<int64_t, std::string>> ndigits_and_expected{{
-      {-2, "[0.0, 0.0, -0.0, -100, 100]"},
-      {-1, "[0.0, 0.0, -10, -50, 120]"},
+      {-2, "[0, 0, -0, -100, 100]"},
+      {-1, "[0, 0, -10, -50, 120]"},
       {0, values},
       {1, values},
       {2, values},
@@ -1028,7 +1045,49 @@ TYPED_TEST(TestUnaryRoundSigned, Round) {
   this->SetRoundMode(RoundMode::HALF_TOWARDS_INFINITY);
   for (const auto& pair : ndigits_and_expected) {
     this->SetRoundNdigits(pair.first);
-    this->AssertUnaryOp(Round, values, ArrayFromJSON(float64(), pair.second));
+    this->AssertUnaryOp(Round, values,
+                        ArrayFromJSON(this->type_singleton(), pair.second));
+  }
+
+  // Test different rounding mode
+  // skip int8 because of its small range
+  if constexpr (!std::is_same_v<TypeParam, Int8Type>) {
+    std::string values("[0, 1, -13, -50, 115, -176, 200, 250]");
+    this->SetRoundNdigits(-2);
+    std::vector<std::pair<RoundMode, std::string>> round_modes_and_expected{{
+        {RoundMode::DOWN, "[0, 0, -100, -100, 100, -200, 200, 200]"},
+        {RoundMode::UP, "[0, 100, -0, -0, 200, -100, 200, 300]"},
+        {RoundMode::TOWARDS_ZERO, "[0, 0, -0, -0, 100, -100, 200, 200]"},
+        {RoundMode::TOWARDS_INFINITY, "[0, 100, -100, -100, 200, -200, 200, 300]"},
+        {RoundMode::HALF_DOWN, "[0, 0, -0, -100, 100, -200, 200, 200]"},
+        {RoundMode::HALF_UP, "[0, 0, -0, -0, 100, -200, 200, 300]"},
+        {RoundMode::HALF_TOWARDS_ZERO, "[0, 0, -0, -0, 100, -200, 200, 200]"},
+        {RoundMode::HALF_TOWARDS_INFINITY, "[0, 0, -0, -100, 100, -200, 200, 300]"},
+        {RoundMode::HALF_TO_EVEN, "[0, 0, -0, -0, 100, -200, 200, 200]"},
+        {RoundMode::HALF_TO_ODD, "[0, 0, -0, -100, 100, -200, 200, 300]"},
+    }};
+    for (const auto& pair : round_modes_and_expected) {
+      this->SetRoundMode(pair.first);
+      this->AssertUnaryOp(Round, values,
+                          ArrayFromJSON(this->type_singleton(), pair.second));
+    }
+  }
+
+  // An overly large ndigits would be truncated to type's max digits
+  if constexpr (std::is_same_v<TypeParam, Int8Type>) {
+    this->SetRoundNdigits(-100);
+    this->SetRoundMode(RoundMode::UP);
+    auto values = "[1]";
+    this->AssertUnaryOp(Round, values, ArrayFromJSON(this->type_singleton(), "[100]"));
+  }
+
+  // A larger than double int64 should be correctly handled
+  if constexpr (std::is_same_v<TypeParam, Int64Type>) {
+    this->SetRoundNdigits(-2);
+    this->SetRoundMode(RoundMode::UP);
+    auto values = "[1152921504606846976]";  // 2 ^ 60
+    this->AssertUnaryOp(Round, values,
+                        ArrayFromJSON(this->type_singleton(), "[1152921504606847000]"));
   }
 }
 
@@ -1038,7 +1097,7 @@ TYPED_TEST(TestUnaryRoundUnsigned, Round) {
   this->SetRoundNdigits(0);
   for (const auto& round_mode : kRoundModes) {
     this->SetRoundMode(round_mode);
-    this->AssertUnaryOp(Round, values, ArrayFromJSON(float64(), values));
+    this->AssertUnaryOp(Round, values, ArrayFromJSON(this->type_singleton(), values));
   }
 
   // Test different round N-digits for nearest rounding mode
@@ -1052,7 +1111,49 @@ TYPED_TEST(TestUnaryRoundUnsigned, Round) {
   this->SetRoundMode(RoundMode::HALF_TOWARDS_INFINITY);
   for (const auto& pair : ndigits_and_expected) {
     this->SetRoundNdigits(pair.first);
-    this->AssertUnaryOp(Round, values, ArrayFromJSON(float64(), pair.second));
+    this->AssertUnaryOp(Round, values,
+                        ArrayFromJSON(this->type_singleton(), pair.second));
+  }
+
+  // Test different rounding mode
+  // skip uint8 because of its small range
+  if constexpr (!std::is_same_v<TypeParam, UInt8Type>) {
+    std::string values("[0, 1, 13, 50, 115, 176, 200, 250]");
+    this->SetRoundNdigits(-2);
+    std::vector<std::pair<RoundMode, std::string>> round_modes_and_expected{{
+        {RoundMode::DOWN, "[0, 0, 0, 0, 100, 100, 200, 200]"},
+        {RoundMode::UP, "[0, 100, 100, 100, 200, 200, 200, 300]"},
+        {RoundMode::TOWARDS_ZERO, "[0, 0, 0, 0, 100, 100, 200, 200]"},
+        {RoundMode::TOWARDS_INFINITY, "[0, 100, 100, 100, 200, 200, 200, 300]"},
+        {RoundMode::HALF_DOWN, "[0, 0, 0, 0, 100, 200, 200, 200]"},
+        {RoundMode::HALF_UP, "[0, 0, 0, 100, 100, 200, 200, 300]"},
+        {RoundMode::HALF_TOWARDS_ZERO, "[0, 0, 0, 0, 100, 200, 200, 200]"},
+        {RoundMode::HALF_TOWARDS_INFINITY, "[0, 0, 0, 100, 100, 200, 200, 300]"},
+        {RoundMode::HALF_TO_EVEN, "[0, 0, 0, 0, 100, 200, 200, 200]"},
+        {RoundMode::HALF_TO_ODD, "[0, 0, 0, 100, 100, 200, 200, 300]"},
+    }};
+    for (const auto& pair : round_modes_and_expected) {
+      this->SetRoundMode(pair.first);
+      this->AssertUnaryOp(Round, values,
+                          ArrayFromJSON(this->type_singleton(), pair.second));
+    }
+  }
+
+  // An overly large ndigits would be truncated to type's max digits
+  if constexpr (std::is_same_v<TypeParam, UInt8Type>) {
+    this->SetRoundNdigits(-100);
+    this->SetRoundMode(RoundMode::UP);
+    auto values = "[1]";
+    this->AssertUnaryOp(Round, values, ArrayFromJSON(this->type_singleton(), "[100]"));
+  }
+
+  // A larger than double uint64 should be correctly handled
+  if constexpr (std::is_same_v<TypeParam, Int64Type>) {
+    this->SetRoundNdigits(-2);
+    this->SetRoundMode(RoundMode::UP);
+    auto values = "[1152921504606846976]";  // 2 ^ 60
+    this->AssertUnaryOp(Round, values,
+                        ArrayFromJSON(this->type_singleton(), "[1152921504606847000]"));
   }
 }
 
@@ -1108,13 +1209,14 @@ TYPED_TEST(TestBinaryRoundSigned, Round) {
   std::string values("[0, 1, -13, -50, 115]");
   for (const auto& round_mode : kRoundModes) {
     this->SetRoundMode(round_mode);
-    this->AssertBinaryOp(RoundBinary, values, 0, ArrayFromJSON(float64(), values));
+    this->AssertBinaryOp(RoundBinary, values, 0,
+                         ArrayFromJSON(this->type_singleton(), values));
   }
 
   // Test different round N-digits for nearest rounding mode
   std::vector<std::pair<int32_t, std::string>> ndigits_and_expected{{
-      {-2, "[0.0, 0.0, -0.0, -100, 100]"},
-      {-1, "[0.0, 0.0, -10, -50, 120]"},
+      {-2, "[0, 0, -0, -100, 100]"},
+      {-1, "[0, 0, -10, -50, 120]"},
       {0, values},
       {1, values},
       {2, values},
@@ -1122,7 +1224,30 @@ TYPED_TEST(TestBinaryRoundSigned, Round) {
   this->SetRoundMode(RoundMode::HALF_TOWARDS_INFINITY);
   for (const auto& pair : ndigits_and_expected) {
     this->AssertBinaryOp(RoundBinary, values, pair.first,
-                         ArrayFromJSON(float64(), pair.second));
+                         ArrayFromJSON(this->type_singleton(), pair.second));
+  }
+
+  // Test different rounding mode
+  // skip int8 because of its small range
+  if constexpr (!std::is_same<TypeParam, Int8Type>::value) {
+    std::string values("[0, 1, -13, -50, 115, -176, 200, 250]");
+    std::vector<std::pair<RoundMode, std::string>> round_modes_and_expected{{
+        {RoundMode::DOWN, "[0, 0, -100, -100, 100, -200, 200, 200]"},
+        {RoundMode::UP, "[0, 100, -0, -0, 200, -100, 200, 300]"},
+        {RoundMode::TOWARDS_ZERO, "[0, 0, -0, -0, 100, -100, 200, 200]"},
+        {RoundMode::TOWARDS_INFINITY, "[0, 100, -100, -100, 200, -200, 200, 300]"},
+        {RoundMode::HALF_DOWN, "[0, 0, -0, -100, 100, -200, 200, 200]"},
+        {RoundMode::HALF_UP, "[0, 0, -0, -0, 100, -200, 200, 300]"},
+        {RoundMode::HALF_TOWARDS_ZERO, "[0, 0, -0, -0, 100, -200, 200, 200]"},
+        {RoundMode::HALF_TOWARDS_INFINITY, "[0, 0, -0, -100, 100, -200, 200, 300]"},
+        {RoundMode::HALF_TO_EVEN, "[0, 0, -0, -0, 100, -200, 200, 200]"},
+        {RoundMode::HALF_TO_ODD, "[0, 0, -0, -100, 100, -200, 200, 300]"},
+    }};
+    for (const auto& pair : round_modes_and_expected) {
+      this->SetRoundMode(pair.first);
+      this->AssertBinaryOp(RoundBinary, values, -2,
+                           ArrayFromJSON(this->type_singleton(), pair.second));
+    }
   }
 }
 
@@ -1131,7 +1256,8 @@ TYPED_TEST(TestBinaryRoundUnsigned, Round) {
   std::string values("[0, 1, 13, 50, 115]");
   for (const auto& round_mode : kRoundModes) {
     this->SetRoundMode(round_mode);
-    this->AssertBinaryOp(RoundBinary, values, 0, ArrayFromJSON(float64(), values));
+    this->AssertBinaryOp(RoundBinary, values, 0,
+                         ArrayFromJSON(this->type_singleton(), values));
   }
 
   // Test different round N-digits for nearest rounding mode
@@ -1145,7 +1271,30 @@ TYPED_TEST(TestBinaryRoundUnsigned, Round) {
   this->SetRoundMode(RoundMode::HALF_TOWARDS_INFINITY);
   for (const auto& pair : ndigits_and_expected) {
     this->AssertBinaryOp(RoundBinary, values, pair.first,
-                         ArrayFromJSON(float64(), pair.second));
+                         ArrayFromJSON(this->type_singleton(), pair.second));
+  }
+
+  // Test different rounding mode
+  // skip uint8 because of its small range
+  if constexpr (!std::is_same<TypeParam, UInt8Type>::value) {
+    std::string values("[0, 1, 13, 50, 115, 176, 200, 250]");
+    std::vector<std::pair<RoundMode, std::string>> round_modes_and_expected{{
+        {RoundMode::DOWN, "[0, 0, 0, 0, 100, 100, 200, 200]"},
+        {RoundMode::UP, "[0, 100, 100, 100, 200, 200, 200, 300]"},
+        {RoundMode::TOWARDS_ZERO, "[0, 0, 0, 0, 100, 100, 200, 200]"},
+        {RoundMode::TOWARDS_INFINITY, "[0, 100, 100, 100, 200, 200, 200, 300]"},
+        {RoundMode::HALF_DOWN, "[0, 0, 0, 0, 100, 200, 200, 200]"},
+        {RoundMode::HALF_UP, "[0, 0, 0, 100, 100, 200, 200, 300]"},
+        {RoundMode::HALF_TOWARDS_ZERO, "[0, 0, 0, 0, 100, 200, 200, 200]"},
+        {RoundMode::HALF_TOWARDS_INFINITY, "[0, 0, 0, 100, 100, 200, 200, 300]"},
+        {RoundMode::HALF_TO_EVEN, "[0, 0, 0, 0, 100, 200, 200, 200]"},
+        {RoundMode::HALF_TO_ODD, "[0, 0, 0, 100, 100, 200, 200, 300]"},
+    }};
+    for (const auto& pair : round_modes_and_expected) {
+      this->SetRoundMode(pair.first);
+      this->AssertBinaryOp(RoundBinary, values, -2,
+                           ArrayFromJSON(this->type_singleton(), pair.second));
+    }
   }
 }
 
@@ -1203,21 +1352,74 @@ TYPED_TEST(TestUnaryRoundToMultipleSigned, RoundToMultiple) {
   this->SetRoundMultiple(1);
   for (const auto& round_mode : kRoundModes) {
     this->SetRoundMode(round_mode);
-    this->AssertUnaryOp(RoundToMultiple, values, ArrayFromJSON(float64(), values));
+    this->AssertUnaryOp(RoundToMultiple, values,
+                        ArrayFromJSON(this->type_singleton(), values));
   }
 
+  // Out of range multiple is not allowed
+  this->SetRoundMultiple(
+      static_cast<double>(
+          std::numeric_limits<typename TypeTraits<TypeParam>::CType>::max()) +
+      1e9);
+  this->AssertUnaryOpRaises(RoundToMultiple, values, "Invalid");
+
   // Test different round multiples for nearest rounding mode
-  std::vector<std::pair<double, std::string>> multiple_and_expected{{
-      {2, "[0.0, 2, -14, -50, 116]"},
-      {0.05, "[0.0, 1, -13, -50, 115]"},
-      {0.1, values},
-      {10, "[0.0, 0.0, -10, -50, 120]"},
-      {100, "[0.0, 0.0, -0.0, -100, 100]"},
+  std::vector<std::pair<int, std::string>> multiple_and_expected{{
+      {2, "[0, 2, -14, -50, 116]"},
+      {10, "[0, 0, -10, -50, 120]"},
+      {100, "[0, 0, -0, -100, 100]"},
   }};
   this->SetRoundMode(RoundMode::HALF_TOWARDS_INFINITY);
   for (const auto& pair : multiple_and_expected) {
     this->SetRoundMultiple(pair.first);
-    this->AssertUnaryOp(RoundToMultiple, values, ArrayFromJSON(float64(), pair.second));
+    this->AssertUnaryOp(RoundToMultiple, values,
+                        ArrayFromJSON(this->type_singleton(), pair.second));
+  }
+
+  // Test different rounding mode
+  values = "[0, -1, 2, -5, 6, -8]";
+  // Even case is tested by round and round_binary so we test an odd case here
+  this->SetRoundMultiple(3);
+  std::vector<std::pair<RoundMode, std::string>> round_modes_and_expected{{
+      {RoundMode::DOWN, "[0, -3, 0, -6, 6, -9]"},
+      {RoundMode::UP, "[0, 0, 3, -3, 6, -6]"},
+      {RoundMode::TOWARDS_ZERO, "[0, 0, 0, -3, 6, -6]"},
+      {RoundMode::TOWARDS_INFINITY, "[0, -3, 3, -6, 6, -9]"},
+      {RoundMode::HALF_DOWN, "[0, 0, 3, -6, 6, -9]"},
+      {RoundMode::HALF_UP, "[0, 0, 3, -6, 6, -9]"},
+      {RoundMode::HALF_TOWARDS_ZERO, "[0, 0, 3, -6, 6, -9]"},
+      {RoundMode::HALF_TOWARDS_INFINITY, "[0, 0, 3, -6, 6, -9]"},
+      {RoundMode::HALF_TO_EVEN, "[0, 0, 3, -6, 6, -9]"},
+      {RoundMode::HALF_TO_ODD, "[0, 0, 3, -6, 6, -9]"},
+  }};
+  for (const auto& pair : round_modes_and_expected) {
+    this->SetRoundMode(pair.first);
+    this->AssertUnaryOp(RoundToMultiple, values,
+                        ArrayFromJSON(this->type_singleton(), pair.second));
+  }
+
+  if constexpr (std::is_same_v<TypeParam, Int32Type>) {
+    // Test overflow handling
+    this->SetRoundMultiple(10);
+    auto input = "[-2147483645]";
+    std::vector<RoundMode> invalid_modes{
+        RoundMode::DOWN, RoundMode::TOWARDS_INFINITY, RoundMode::HALF_DOWN,
+        RoundMode::HALF_TOWARDS_INFINITY, RoundMode::HALF_TO_ODD};
+    std::vector<RoundMode> valid_modes{RoundMode::UP, RoundMode::TOWARDS_ZERO,
+                                       RoundMode::HALF_UP, RoundMode::HALF_TOWARDS_ZERO,
+                                       RoundMode::HALF_TO_EVEN};
+    for (auto mode : invalid_modes) {
+      this->SetRoundMode(mode);
+      this->AssertUnaryOpRaises(
+          RoundToMultiple, input,
+          "Rounding -2147483645 down to multiple of 10 would overflow");
+    }
+
+    for (auto mode : valid_modes) {
+      this->SetRoundMode(mode);
+      this->AssertUnaryOp(RoundToMultiple, input,
+                          ArrayFromJSON(int32(), "[-2147483640]"));
+    }
   }
 }
 
@@ -1227,13 +1429,19 @@ TYPED_TEST(TestUnaryRoundToMultipleUnsigned, RoundToMultiple) {
   this->SetRoundMultiple(1);
   for (const auto& round_mode : kRoundModes) {
     this->SetRoundMode(round_mode);
-    this->AssertUnaryOp(RoundToMultiple, values, ArrayFromJSON(float64(), values));
+    this->AssertUnaryOp(RoundToMultiple, values,
+                        ArrayFromJSON(this->type_singleton(), values));
   }
+
+  // Out of range multiple is not allowed
+  this->SetRoundMultiple(
+      static_cast<double>(
+          std::numeric_limits<typename TypeTraits<TypeParam>::CType>::max()) +
+      1e9);
+  this->AssertUnaryOpRaises(RoundToMultiple, values, "Invalid");
 
   // Test different round multiples for nearest rounding mode
   std::vector<std::pair<double, std::string>> multiple_and_expected{{
-      {0.05, "[0, 1, 13, 50, 115]"},
-      {0.1, values},
       {2, "[0, 2, 14, 50, 116]"},
       {10, "[0, 0, 10, 50, 120]"},
       {100, "[0, 0, 0, 100, 100]"},
@@ -1241,7 +1449,54 @@ TYPED_TEST(TestUnaryRoundToMultipleUnsigned, RoundToMultiple) {
   this->SetRoundMode(RoundMode::HALF_TOWARDS_INFINITY);
   for (const auto& pair : multiple_and_expected) {
     this->SetRoundMultiple(pair.first);
-    this->AssertUnaryOp(RoundToMultiple, values, ArrayFromJSON(float64(), pair.second));
+    this->AssertUnaryOp(RoundToMultiple, values,
+                        ArrayFromJSON(this->type_singleton(), pair.second));
+  }
+
+  // Test different rounding mode
+  values = "[0, 1, 2, 5, 6, 8]";
+  // Even case is tested by round and round_binary so we test an odd case here
+  this->SetRoundMultiple(3);
+  std::vector<std::pair<RoundMode, std::string>> round_modes_and_expected{{
+      {RoundMode::DOWN, "[0, 0, 0, 3, 6, 6]"},
+      {RoundMode::UP, "[0, 3, 3, 6, 6, 9]"},
+      {RoundMode::TOWARDS_ZERO, "[0, 0, 0, 3, 6, 6]"},
+      {RoundMode::TOWARDS_INFINITY, "[0, 3, 3, 6, 6, 9]"},
+      {RoundMode::HALF_DOWN, "[0, 0, 3, 6, 6, 9]"},
+      {RoundMode::HALF_UP, "[0, 0, 3, 6, 6, 9]"},
+      {RoundMode::HALF_TOWARDS_ZERO, "[0, 0, 3, 6, 6, 9]"},
+      {RoundMode::HALF_TOWARDS_INFINITY, "[0, 0, 3, 6, 6, 9]"},
+      {RoundMode::HALF_TO_EVEN, "[0, 0, 3, 6, 6, 9]"},
+      {RoundMode::HALF_TO_ODD, "[0, 0, 3, 6, 6, 9]"},
+  }};
+  for (const auto& pair : round_modes_and_expected) {
+    this->SetRoundMode(pair.first);
+    this->AssertUnaryOp(RoundToMultiple, values,
+                        ArrayFromJSON(this->type_singleton(), pair.second));
+  }
+
+  if constexpr (std::is_same_v<TypeParam, UInt32Type>) {
+    // Test overflow handling
+    this->SetRoundMultiple(10);
+    auto input = "[4294967295]";
+    std::vector<RoundMode> valid_modes{RoundMode::DOWN, RoundMode::TOWARDS_ZERO,
+                                       RoundMode::HALF_DOWN, RoundMode::HALF_TOWARDS_ZERO,
+                                       RoundMode::HALF_TO_ODD};
+    std::vector<RoundMode> invalid_modes{RoundMode::UP, RoundMode::TOWARDS_INFINITY,
+                                         RoundMode::HALF_UP, RoundMode::TOWARDS_INFINITY,
+                                         RoundMode::HALF_TO_EVEN};
+    for (auto mode : invalid_modes) {
+      this->SetRoundMode(mode);
+      this->AssertUnaryOpRaises(
+          RoundToMultiple, input,
+          "Rounding 4294967295 up to multiple of 10 would overflow");
+    }
+
+    for (auto mode : valid_modes) {
+      this->SetRoundMode(mode);
+      this->AssertUnaryOp(RoundToMultiple, input,
+                          ArrayFromJSON(uint32(), "[4294967290]"));
+    }
   }
 }
 
@@ -1444,5 +1699,4 @@ TYPED_TEST(TestUnaryRoundArithmeticFloating, Trunc) {
 }
 
 }  // namespace
-}  // namespace compute
-}  // namespace arrow
+}  // namespace arrow::compute

--- a/cpp/src/arrow/compute/kernels/scalar_round_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_round_arithmetic_test.cc
@@ -1081,6 +1081,13 @@ TYPED_TEST(TestUnaryRoundSigned, Round) {
     this->AssertUnaryOpRaises(Round, values, "out of range");
   }
 
+  // Overflow is also treated as error
+  if constexpr (std::is_same_v<TypeParam, Int8Type>) {
+    this->SetRoundNdigits(-1);
+    this->SetRoundMode(RoundMode::DOWN);
+    this->AssertUnaryOpRaises(Round, "[-127]", "overflow");
+  }
+
   // A larger than double int64 should be correctly handled
   if constexpr (std::is_same_v<TypeParam, Int64Type>) {
     this->SetRoundNdigits(-2);
@@ -1145,6 +1152,13 @@ TYPED_TEST(TestUnaryRoundUnsigned, Round) {
     this->SetRoundMode(RoundMode::UP);
     auto values = "[1]";
     this->AssertUnaryOpRaises(Round, values, "out of range");
+  }
+
+  // Overflow is also treated as error
+  if constexpr (std::is_same_v<TypeParam, UInt8Type>) {
+    this->SetRoundNdigits(-1);
+    this->SetRoundMode(RoundMode::UP);
+    this->AssertUnaryOpRaises(Round, "[255]", "overflow");
   }
 
   // A larger than double uint64 should be correctly handled
@@ -1255,6 +1269,12 @@ TYPED_TEST(TestBinaryRoundSigned, Round) {
     this->SetRoundMode(RoundMode::UP);
     this->AssertBinaryOpRaises(RoundBinary, "[1]", "[-100]", "out of range");
   }
+
+  // Overflow is also treated as error
+  if constexpr (std::is_same_v<TypeParam, Int8Type>) {
+    this->SetRoundMode(RoundMode::DOWN);
+    this->AssertBinaryOpRaises(RoundBinary, "[-127]", "[-1]", "overflow");
+  }
 }
 
 TYPED_TEST(TestBinaryRoundUnsigned, Round) {
@@ -1307,6 +1327,12 @@ TYPED_TEST(TestBinaryRoundUnsigned, Round) {
   if constexpr (std::is_same_v<TypeParam, UInt8Type>) {
     this->SetRoundMode(RoundMode::UP);
     this->AssertBinaryOpRaises(RoundBinary, "[1]", "[-100]", "out of range");
+  }
+
+  // Overflow is also treated as error
+  if constexpr (std::is_same_v<TypeParam, UInt8Type>) {
+    this->SetRoundMode(RoundMode::UP);
+    this->AssertBinaryOpRaises(RoundBinary, "[255]", "[-1]", "overflow");
   }
 }
 

--- a/cpp/src/arrow/compute/kernels/scalar_round_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_round_arithmetic_test.cc
@@ -1073,12 +1073,12 @@ TYPED_TEST(TestUnaryRoundSigned, Round) {
     }
   }
 
-  // An overly large ndigits would be truncated to type's max digits
+  // An overly large ndigits would cause an error
   if constexpr (std::is_same_v<TypeParam, Int8Type>) {
     this->SetRoundNdigits(-100);
     this->SetRoundMode(RoundMode::UP);
     auto values = "[1]";
-    this->AssertUnaryOp(Round, values, ArrayFromJSON(this->type_singleton(), "[100]"));
+    this->AssertUnaryOpRaises(Round, values, "out of range");
   }
 
   // A larger than double int64 should be correctly handled
@@ -1139,12 +1139,12 @@ TYPED_TEST(TestUnaryRoundUnsigned, Round) {
     }
   }
 
-  // An overly large ndigits would be truncated to type's max digits
+  // An overly large ndigits would cause an error
   if constexpr (std::is_same_v<TypeParam, UInt8Type>) {
     this->SetRoundNdigits(-100);
     this->SetRoundMode(RoundMode::UP);
     auto values = "[1]";
-    this->AssertUnaryOp(Round, values, ArrayFromJSON(this->type_singleton(), "[100]"));
+    this->AssertUnaryOpRaises(Round, values, "out of range");
   }
 
   // A larger than double uint64 should be correctly handled
@@ -1249,6 +1249,12 @@ TYPED_TEST(TestBinaryRoundSigned, Round) {
                            ArrayFromJSON(this->type_singleton(), pair.second));
     }
   }
+
+  // An overly large ndigits would cause an error
+  if constexpr (std::is_same_v<TypeParam, Int8Type>) {
+    this->SetRoundMode(RoundMode::UP);
+    this->AssertBinaryOpRaises(RoundBinary, "[1]", "[-100]", "out of range");
+  }
 }
 
 TYPED_TEST(TestBinaryRoundUnsigned, Round) {
@@ -1295,6 +1301,12 @@ TYPED_TEST(TestBinaryRoundUnsigned, Round) {
       this->AssertBinaryOp(RoundBinary, values, -2,
                            ArrayFromJSON(this->type_singleton(), pair.second));
     }
+  }
+
+  // An overly large ndigits would cause an error
+  if constexpr (std::is_same_v<TypeParam, UInt8Type>) {
+    this->SetRoundMode(RoundMode::UP);
+    this->AssertBinaryOpRaises(RoundBinary, "[1]", "[-100]", "out of range");
   }
 }
 

--- a/cpp/src/arrow/engine/substrait/function_test.cc
+++ b/cpp/src/arrow/engine/substrait/function_test.cc
@@ -490,7 +490,7 @@ TEST(FunctionMapping, ValidCases) {
        {{"rounding", {"TIE_AWAY_FROM_ZERO"}}},
        {int64(), int32()},
        "300",
-       float64()},
+       int64()},
   };
   CheckValidTestCases(valid_test_cases);
 }

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -636,7 +636,7 @@ The example values are given for default values of ``ndigits`` and ``multiple``.
 
 The following table gives examples of how ``ndigits`` (for the ``round``
 function) and ``multiple`` (for ``round_to_multiple`` and ``round_binary``) 
-influence the operance performed, respectively.
+influence the operation performed, respectively.
 
 +--------------------+-------------------+---------------------------+
 | Round ``multiple`` | Round ``ndigits`` | Operation performed       |

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -567,12 +567,14 @@ representation based on the rounding criterion.
 +-------------------+------------+-------------+-------------------------+----------------------------------+--------+
 | round_to_multiple | Unary      | Numeric     | Input Type              | :struct:`RoundToMultipleOptions` | (1)(3) |
 +-------------------+------------+-------------+-------------------------+----------------------------------+--------+
+| round_binary      | Binary     | Numeric     | Input Type              | :struct:`RoundBinaryOptions`     | (1)(4) |
++-------------------+------------+-------------+-------------------------+----------------------------------+--------+
 | trunc             | Unary      | Numeric     | Float32/Float64/Decimal |                                  |        |
 +-------------------+------------+-------------+-------------------------+----------------------------------+--------+
 
 * \(1)  By default rounding functions change a value to the nearest 
   integer using HALF_TO_EVEN to resolve ties.  Options are available to control 
-  the rounding criterion.  Both ``round`` and ``round_to_multiple`` have the 
+  the rounding criterion.  All ``round`` functions have the 
   ``round_mode`` option to set the rounding mode.
 * \(2) Round to a number of digits where the ``ndigits`` option of
   :struct:`RoundOptions` specifies the rounding precision in terms of number
@@ -589,8 +591,12 @@ representation based on the rounding criterion.
   For example, 100 corresponds to rounding to the nearest multiple of 100 
   (zeroing the ones and tens digits). Default value of ``multiple`` is 1 which 
   rounds to the nearest integer.
+* \(4) Round the first input to multiple of the second input. The rounding
+  multiple has to be a positive value and can be casted to the first input type.  
+  For example, 100 corresponds to rounding to the nearest multiple of 100 
+  (zeroing the ones and tens digits).
 
-For ``round`` and ``round_to_multiple``, the following rounding modes are available.
+For ``round`` functions, the following rounding modes are available.
 Tie-breaking modes are prefixed with HALF and round non-ties to the nearest integer.
 The example values are given for default values of ``ndigits`` and ``multiple``.
 
@@ -629,8 +635,8 @@ The example values are given for default values of ``ndigits`` and ``multiple``.
 +-----------------------+--------------------------------------------------------------+---------------------------+
 
 The following table gives examples of how ``ndigits`` (for the ``round``
-function) and ``multiple`` (for ``round_to_multiple``) influence the operance
-performed, respectively.
+function) and ``multiple`` (for ``round_to_multiple`` and ``round_binary``) 
+influence the operance performed, respectively.
 
 +--------------------+-------------------+---------------------------+
 | Round ``multiple`` | Round ``ndigits`` | Operation performed       |

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -634,8 +634,8 @@ The example values are given for default values of ``ndigits`` and ``multiple``.
 |                       |                                                              | -3.5 -> -3, -4.5 -> -5    |
 +-----------------------+--------------------------------------------------------------+---------------------------+
 
-The following table gives examples of how ``ndigits`` (for the ``round``
-function) and ``multiple`` (for ``round_to_multiple`` and ``round_binary``) 
+The following table gives examples of how ``ndigits`` (for the ``round`` 
+and ``round_binary`` functions) and ``multiple`` (for ``round_to_multiple``) 
 influence the operation performed, respectively.
 
 +--------------------+-------------------+---------------------------+

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -582,13 +582,11 @@ representation based on the rounding criterion.
   which rounds to the nearest integer. For integer inputs a non-negative 
   ``ndigits`` value is ignored and the input is returned unchanged. For integer
   inputs, if ``-ndigits`` is larger than the maximum number of digits the 
-  input type can hold, it is truncated to the maximum digit. For example, 
-  ``round([123], ndigits=-4, round_mode=DOWN)`` returns [100] for ``int8`` type.
-  For integer inputs, an error is returned on overflow.
+  input type can hold, an error is returned.
 * \(3) Round to a multiple where the ``multiple`` option of
   :struct:`RoundToMultipleOptions` specifies the rounding scale.  The rounding
   multiple has to be a positive value and can be casted to input type.  
-  For example, 100 corresponds to ounding to the nearest multiple of 100 
+  For example, 100 corresponds to rounding to the nearest multiple of 100 
   (zeroing the ones and tens digits). Default value of ``multiple`` is 1 which 
   rounds to the nearest integer.
 

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -563,30 +563,34 @@ representation based on the rounding criterion.
 +-------------------+------------+-------------+-------------------------+----------------------------------+--------+
 | floor             | Unary      | Numeric     | Float32/Float64/Decimal |                                  |        |
 +-------------------+------------+-------------+-------------------------+----------------------------------+--------+
-| round             | Unary      | Numeric     | Float32/Float64/Decimal | :struct:`RoundOptions`           | (1)(2) |
+| round             | Unary      | Numeric     | Input Type              | :struct:`RoundOptions`           | (1)(2) |
 +-------------------+------------+-------------+-------------------------+----------------------------------+--------+
-| round_to_multiple | Unary      | Numeric     | Float32/Float64/Decimal | :struct:`RoundToMultipleOptions` | (1)(3) |
+| round_to_multiple | Unary      | Numeric     | Input Type              | :struct:`RoundToMultipleOptions` | (1)(3) |
 +-------------------+------------+-------------+-------------------------+----------------------------------+--------+
 | trunc             | Unary      | Numeric     | Float32/Float64/Decimal |                                  |        |
 +-------------------+------------+-------------+-------------------------+----------------------------------+--------+
 
-* \(1) Output value is a 64-bit floating-point for integral inputs and the
-  retains the same type for floating-point and decimal inputs.  By default
-  rounding functions displace a value to the nearest integer using
-  HALF_TO_EVEN to resolve ties.  Options are available to control the rounding
-  criterion.  Both ``round`` and ``round_to_multiple`` have the ``round_mode``
-  option to set the rounding mode.
+* \(1)  By default rounding functions displace a value to the nearest 
+  integer using HALF_TO_EVEN to resolve ties.  Options are available to control 
+  the rounding criterion.  Both ``round`` and ``round_to_multiple`` have the 
+  ``round_mode`` option to set the rounding mode.
 * \(2) Round to a number of digits where the ``ndigits`` option of
   :struct:`RoundOptions` specifies the rounding precision in terms of number
   of digits.  A negative value corresponds to digits in the non-fractional
   part.  For example, -2 corresponds to rounding to the nearest multiple of
   100 (zeroing the ones and tens digits).  Default value of ``ndigits`` is 0
-  which rounds to the nearest integer.
+  which rounds to the nearest integer. For integer inputs a non-negative 
+  ``ndigits`` value is ignored and the input is returned unchanged. For integer
+  inputs, if ``-ndigits`` is larger than the maximum number of digits the 
+  input type can hold, it is truncated to the maximum digit. For example, 
+  ``round([123], ndigits=-4, round_mode=DOWN)`` returns [100] for ``int8`` type.
+  For integer inputs, an error is returned on overflow.
 * \(3) Round to a multiple where the ``multiple`` option of
   :struct:`RoundToMultipleOptions` specifies the rounding scale.  The rounding
-  multiple has to be a positive value.  For example, 100 corresponds to
-  rounding to the nearest multiple of 100 (zeroing the ones and tens digits).
-  Default value of ``multiple`` is 1 which rounds to the nearest integer.
+  multiple has to be a positive value and can be casted to input type.  
+  For example, 100 corresponds to ounding to the nearest multiple of 100 
+  (zeroing the ones and tens digits). Default value of ``multiple`` is 1 which 
+  rounds to the nearest integer.
 
 For ``round`` and ``round_to_multiple``, the following rounding modes are available.
 Tie-breaking modes are prefixed with HALF and round non-ties to the nearest integer.

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -570,7 +570,7 @@ representation based on the rounding criterion.
 | trunc             | Unary      | Numeric     | Float32/Float64/Decimal |                                  |        |
 +-------------------+------------+-------------+-------------------------+----------------------------------+--------+
 
-* \(1)  By default rounding functions displace a value to the nearest 
+* \(1)  By default rounding functions change a value to the nearest 
   integer using HALF_TO_EVEN to resolve ties.  Options are available to control 
   the rounding criterion.  Both ``round`` and ``round_to_multiple`` have the 
   ``round_mode`` option to set the rounding mode.

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1610,9 +1610,9 @@ def test_round_binary():
     scale = pa.scalar(-1, pa.int32())
 
     assert pc.round_binary(
-        5, scale, round_mode="half_towards_zero") == expect_zero
+        5.0, scale, round_mode="half_towards_zero") == expect_zero
     assert pc.round_binary(
-        5, scale, round_mode="half_towards_infinity") == expect_inf
+        5.0, scale, round_mode="half_towards_infinity") == expect_inf
 
 
 def test_is_null():


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Currently `round` casts integers to floats which causes undesired behavior.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add round kernels for integer types.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes.

### Are there any user-facing changes?

No.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #35273