### PR TITLE
GH-35403: [Docs] Support sphinx 6 for building the docs

### DIFF
--- a/ci/conda_env_sphinx.txt
+++ b/ci/conda_env_sphinx.txt
@@ -25,7 +25,7 @@ sphinx-autobuild
 sphinx-design
 sphinx-copybutton
 sphinxcontrib-jquery
-sphinx>=4.2,<7
+sphinx>=4.2
 # Requirement for doctest-cython
 pytest-cython
 pandas

--- a/ci/conda_env_sphinx.txt
+++ b/ci/conda_env_sphinx.txt
@@ -25,7 +25,7 @@ sphinx-autobuild
 sphinx-design
 sphinx-copybutton
 sphinxcontrib-jquery
-sphinx>=4.2
+sphinx==6.2
 # Requirement for doctest-cython
 pytest-cython
 pandas

--- a/ci/conda_env_sphinx.txt
+++ b/ci/conda_env_sphinx.txt
@@ -22,7 +22,7 @@ ipython
 numpydoc
 pydata-sphinx-theme==0.8
 sphinx-design
-sphinx>=4.2,<6
+sphinx>=4.2,<7
 sphinx-copybutton
 # Requirement for doctest-cython
 pytest-cython

--- a/ci/conda_env_sphinx.txt
+++ b/ci/conda_env_sphinx.txt
@@ -21,9 +21,11 @@ doxygen
 ipython
 numpydoc
 pydata-sphinx-theme==0.8
+sphinx-autobuild
 sphinx-design
-sphinx>=4.2,<7
 sphinx-copybutton
+sphinxcontrib-jquery
+sphinx>=4.2,<7
 # Requirement for doctest-cython
 pytest-cython
 pandas

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -150,6 +150,8 @@ cpp-live:
 
 .PHONY: python
 python:
+	# Remove the following line when sphinx issue (https://github.com/sphinx-doc/sphinx/issues/10943) is closed
+	python -m pip install ../python --quiet --no-dependencies
 	$(SPHINXBUILD) -b html $(SPHINXOPTS) -c $(SOURCEDIR) $(SOURCEDIR)/python $(BUILDDIR)/html/python
 	@echo
 	@echo "Build finished. The HTML files are in $(BUILDDIR)/html/python"

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -150,8 +150,6 @@ cpp-live:
 
 .PHONY: python
 python:
-	# Remove the following line when sphinx issue (https://github.com/sphinx-doc/sphinx/issues/10943) is closed
-	python -m pip install ../python --quiet --no-dependencies
 	$(SPHINXBUILD) -b html $(SPHINXOPTS) -c $(SOURCEDIR) $(SOURCEDIR)/python $(BUILDDIR)/html/python
 	@echo
 	@echo "Build finished. The HTML files are in $(BUILDDIR)/html/python"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,5 +10,5 @@ sphinx-autobuild
 sphinx-design
 sphinx-copybutton
 sphinxcontrib-jquery
-sphinx>=4.2
+sphinx==6.2
 pandas

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,5 +9,6 @@ pydata-sphinx-theme==0.8
 sphinx-autobuild
 sphinx-design
 sphinx-copybutton
+sphinxcontrib-jquery
 sphinx>=4.2,<7
 pandas

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,5 +9,5 @@ pydata-sphinx-theme==0.8
 sphinx-autobuild
 sphinx-design
 sphinx-copybutton
-sphinx>=4.2,<6
+sphinx>=4.2,<7
 pandas

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,5 +10,5 @@ sphinx-autobuild
 sphinx-design
 sphinx-copybutton
 sphinxcontrib-jquery
-sphinx>=4.2,<7
+sphinx>=4.2
 pandas

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -115,6 +115,7 @@ extensions = [
     'IPython.sphinxext.ipython_console_highlighting',
     'IPython.sphinxext.ipython_directive',
     'numpydoc',
+    "sphinxcontrib.jquery",
     'sphinx_design',
     'sphinx_copybutton',
     'sphinx.ext.autodoc',

--- a/docs/source/cpp/build_system.rst
+++ b/docs/source/cpp/build_system.rst
@@ -45,6 +45,7 @@ This minimal ``CMakeLists.txt`` file compiles a ``my_example.cc`` source
 file into an executable linked with the Arrow C++ shared library:
 
 .. code-block:: cmake
+
    cmake_minimum_required(VERSION 3.16)
    
    project(MyExample)

--- a/docs/source/developers/documentation.rst
+++ b/docs/source/developers/documentation.rst
@@ -87,6 +87,14 @@ These two steps are mandatory and must be executed in order.
    not sufficiently comprehensive. Portions of the Python API documentation
    will also not build without CUDA support having been built.
 
+.. note::
+
+   If you are working on the Python documentation and are building the documentation
+   with ``pyarrow`` build from source on macOS Monterey, Python section of the
+   documentation might not be included in the ``_build/html`` when using the
+   ``make html`` command. In this case use ``make python`` to only build the
+   python part of the documentation.
+
 After these steps are completed, the documentation is rendered in HTML
 format in ``arrow/docs/_build/html``.  In particular, you can point your browser
 at ``arrow/docs/_build/html/index.html`` to read the docs and review any changes

--- a/docs/source/developers/documentation.rst
+++ b/docs/source/developers/documentation.rst
@@ -87,18 +87,25 @@ These two steps are mandatory and must be executed in order.
    not sufficiently comprehensive. Portions of the Python API documentation
    will also not build without CUDA support having been built.
 
-.. note::
-
-   If you are working on the Python documentation and are building the documentation
-   with ``pyarrow`` build from source on macOS Monterey, Python section of the
-   documentation might not be included in the ``_build/html``. In this case run
-   ``python -m pip install ../python --quiet --no-dependencies python`` before
-   running the ``make html`` command.
-
 After these steps are completed, the documentation is rendered in HTML
 format in ``arrow/docs/_build/html``.  In particular, you can point your browser
 at ``arrow/docs/_build/html/index.html`` to read the docs and review any changes
 you made.
+
+.. note::
+
+   If you are working on the Python documentation and are building the documentation
+   with ``pyarrow`` build from source on macOS Monterey, Python section of the
+   documentation might not be included in the ``_build/html``. In this case try
+   installing ``pyarrow`` in editable version first before running the ``make html``
+   command.
+
+   .. code-block:: shell
+
+     pushd arrow/docs
+     python -m pip install ../python --quiet
+     make html
+     popd
 
 Building with Docker
 --------------------

--- a/docs/source/developers/documentation.rst
+++ b/docs/source/developers/documentation.rst
@@ -91,9 +91,9 @@ These two steps are mandatory and must be executed in order.
 
    If you are working on the Python documentation and are building the documentation
    with ``pyarrow`` build from source on macOS Monterey, Python section of the
-   documentation might not be included in the ``_build/html`` when using the
-   ``make html`` command. In this case use ``make python`` to only build the
-   python part of the documentation.
+   documentation might not be included in the ``_build/html``. In this case run
+   ``python -m pip install ../python --quiet --no-dependencies python`` before
+   running the ``make html`` command.
 
 After these steps are completed, the documentation is rendered in HTML
 format in ``arrow/docs/_build/html``.  In particular, you can point your browser

--- a/docs/source/developers/documentation.rst
+++ b/docs/source/developers/documentation.rst
@@ -95,9 +95,9 @@ you made.
 .. note::
 
    If you are working on the Python documentation and are building the documentation
-   with ``pyarrow`` build from source on macOS Monterey, Python section of the
-   documentation might not be included in the ``_build/html``. In this case try
-   installing ``pyarrow`` in editable version first before running the ``make html``
+   with ``pyarrow`` build from source on macOS Monterey, the Python section of the
+   documentation might not be included in the ``_build/html``. In this case, try
+   installing ``pyarrow`` in non-editable mode first before running the ``make html``
    command.
 
    .. code-block:: shell

--- a/docs/source/developers/java/building.rst
+++ b/docs/source/developers/java/building.rst
@@ -195,14 +195,14 @@ CMake
 
 - To build all JNI libraries (MacOS / Linux) except the JNI C Data Interface library:
 
-  .. code-block:: text
+  .. code-block::
 
       $ cd arrow
       $ brew bundle --file=cpp/Brewfile
-      Homebrew Bundle complete! 25 Brewfile dependencies now installed.
+      # Homebrew Bundle complete! 25 Brewfile dependencies now installed.
       $ brew uninstall aws-sdk-cpp
-      (We can't use aws-sdk-cpp installed by Homebrew because it has
-      an issue: https://github.com/aws/aws-sdk-cpp/issues/1809 )
+      #  (We can't use aws-sdk-cpp installed by Homebrew because it has
+      #  an issue: https://github.com/aws/aws-sdk-cpp/issues/1809 )
       $ export JAVA_HOME=<absolute path to your java home>
       $ mkdir -p java-dist cpp-jni
       $ cmake \

--- a/docs/source/developers/java/building.rst
+++ b/docs/source/developers/java/building.rst
@@ -195,7 +195,7 @@ CMake
 
 - To build all JNI libraries (MacOS / Linux) except the JNI C Data Interface library:
 
-  .. code-block::
+  .. code-block:: text
 
       $ cd arrow
       $ brew bundle --file=cpp/Brewfile

--- a/docs/source/format/CDeviceDataInterface.rst
+++ b/docs/source/format/CDeviceDataInterface.rst
@@ -282,7 +282,7 @@ has the following fields:
     data.
 
 .. seealso::
-    The :ref:`synchronization event types <_c-device-data-interface-event-types>`
+    The :ref:`synchronization event types <c-device-data-interface-event-types>`
     section below.
 
 .. c:member:: int64_t ArrowDeviceArray.reserved[3]
@@ -563,7 +563,7 @@ streaming source of Arrow arrays. It has the following fields:
 .. c:member:: ArrowDeviceType device_type
 
     *Mandatory.* The device type that this stream produces data on. All
-    ``ArrowDeviceArray``s that are produced by this stream should have the
+    ``ArrowDeviceArray`` s that are produced by this stream should have the
     same device type as is set here. This is a convenience for the consumer
     to not have to check every array that is retrieved and instead allows
     higher-level coding constructs for streams.
@@ -675,7 +675,7 @@ is frozen. This means that the ``ArrowDeviceArray`` structure definition
 should not change in any way -- including adding new members.
 
 Backwards-compatible changes are allowed, for example new macro values for
-:c:typedef:`ArrowDeviceType` or converting the reserved 24 bytes into a
+:c:type:`ArrowDeviceType` or converting the reserved 24 bytes into a
 different type/member without changing the size of the structure.
 
 Any incompatible changes should be part of a new specification, for example


### PR DESCRIPTION
### What changes are included in this PR?

Enable the docs to be built with sphinx 6.x.
- Update the pin in the `requirements.txt`
- Add `sphinxcontrib.jquery` to include jQuery which is used in the dropdown.

### Are these changes tested?

The Sphinx version update and the dropdown are tested locally.

### Are there any user-facing changes?

No.

* Closes: #35403