### PR TITLE
GH-36309: [C++] Add ability to cast between scalars of list-like types

### DIFF
--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -1139,6 +1139,15 @@ enable_if_list_type<typename ToScalar::TypeClass, Status> CastImpl(
     }
   }
 
+  if constexpr (is_fixed_size_list_type<typename ToScalar::TypeClass>::value) {
+    const auto& fixed_size_list_type = checked_cast<const FixedSizeListType&>(*to->type);
+    if (from.value->length() != fixed_size_list_type.list_size()) {
+      return Status::Invalid("Cannot cast ", from.type->ToString(), " of length ",
+                             from.value->length(), " to fixed size list of length ",
+                             fixed_size_list_type.list_size());
+    }
+  }
+
   DCHECK_EQ(from.is_valid, to->is_valid);
   to->value = from.value;
   return Status::OK();

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -1129,13 +1129,8 @@ Status CastImpl(const StructScalar& from, StringScalar* to) {
 
 // casts between variable-length and fixed-length list types
 template <typename ToScalar>
-enable_if_t<is_list_like_type<typename ToScalar::TypeClass>::value &&
-                ToScalar::TypeClass::type_id != Type::MAP,
-            Status>
-CastImpl(const BaseListScalar& from, ToScalar* to) {
-  DCHECK(from.type->id() == Type::LIST || from.type->id() == Type::LARGE_LIST ||
-         from.type->id() == Type::FIXED_SIZE_LIST);
-
+enable_if_list_type<typename ToScalar::TypeClass, Status> CastImpl(
+    const BaseListScalar& from, ToScalar* to) {
   if constexpr (sizeof(typename ToScalar::TypeClass::offset_type) < sizeof(int64_t)) {
     if (from.value->length() >
         std::numeric_limits<typename ToScalar::TypeClass::offset_type>::max()) {

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -392,8 +392,6 @@ class TestRealScalar : public ::testing::Test {
 
   void TestListOf() { TestListOf<ListScalar>(list(type_)); }
 
-  void TestListViewOf() { TestListOf<ListViewScalar>(list_view(type_)); }
-
  protected:
   std::shared_ptr<DataType> type_;
   std::shared_ptr<Scalar> scalar_val_, scalar_other_, scalar_nan_, scalar_other_nan_,
@@ -411,8 +409,6 @@ TYPED_TEST(TestRealScalar, ApproxEquals) { this->TestApproxEquals(); }
 TYPED_TEST(TestRealScalar, StructOf) { this->TestStructOf(); }
 
 TYPED_TEST(TestRealScalar, ListOf) { this->TestListOf(); }
-
-TYPED_TEST(TestRealScalar, ListViewOf) { this->TestListViewOf(); }
 
 template <typename T>
 class TestDecimalScalar : public ::testing::Test {
@@ -1155,7 +1151,6 @@ class TestListScalar : public ::testing::Test {
     ScalarType scalar(value_);
     TestCast(scalar, list(value_->type()));
     TestCast(scalar, large_list(value_->type()));
-    TestCast(scalar, list_view(value_->type()));
     TestCast(scalar,
              fixed_size_list(value_->type(), static_cast<int32_t>(value_->length())));
   }
@@ -1165,8 +1160,7 @@ class TestListScalar : public ::testing::Test {
   std::shared_ptr<Array> value_;
 };
 
-using ListScalarTestTypes =
-    ::testing::Types<ListType, LargeListType, ListViewType, FixedSizeListType>;
+using ListScalarTestTypes = ::testing::Types<ListType, LargeListType, FixedSizeListType>;
 
 TYPED_TEST_SUITE(TestListScalar, ListScalarTestTypes);
 


### PR DESCRIPTION
### Rationale for this change

Makes it easier to work generically with different list types.

### What changes are included in this PR?

More cast implementations between list-like types of scalars.

### Are these changes tested?

Yes. With new unit tests.
* Closes: #36309