### PR TITLE
GH-36096: [Python] Call __from_arrow__ in Array.to_pandas

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1475,6 +1475,17 @@ cdef class Array(_PandasConvertible):
         return self.take(indices)
 
     def _to_pandas(self, options, types_mapper=None, **kwargs):
+        pandas_dtype = None
+        try:
+            pandas_dtype = self.type.to_pandas_dtype()
+        except NotImplementedError:
+            pass
+
+        # pandas ExtensionDtype that implements conversion from pyarrow
+        if hasattr(pandas_dtype, '__from_arrow__'):
+            arr = pandas_dtype.__from_arrow__(self)
+            return pandas_api.series(arr, copy=False)
+
         return _array_like_to_pandas(self, options, types_mapper=types_mapper)
 
     def __array__(self, dtype=None):

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -3107,13 +3107,12 @@ cdef class ExtensionArray(Array):
         result.validate()
         return result
 
-    def _to_pandas(self, options, **kwargs):
+    def _to_pandas(self, options, types_mapper=None, **kwargs):
         pandas_dtype = None
-        types_mapper = kwargs.get('types_mapper', None)
 
         if types_mapper:
             pandas_dtype = types_mapper(self.type)
-        elif issubclass(type(self.type), ExtensionType):
+        else:
             try:
                 pandas_dtype = self.type.to_pandas_dtype()
             except NotImplementedError:
@@ -3126,7 +3125,7 @@ cdef class ExtensionArray(Array):
             return pandas_api.series(arr, copy=False)
 
         # otherwise convert the storage array with the base implementation
-        return Array._to_pandas(self.storage, options, **kwargs)
+        return Array._to_pandas(self.storage, options, types_mapper, **kwargs)
 
 
 class FixedShapeTensorArray(ExtensionArray):

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1479,7 +1479,7 @@ cdef class Array(_PandasConvertible):
 
         if types_mapper:
             pandas_dtype = types_mapper(self.type)
-        elif issubclass(type(self.type), ExtensionType):
+        elif self.type.id == _Type_EXTENSION:
             try:
                 pandas_dtype = self.type.to_pandas_dtype()
             except NotImplementedError:

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -462,7 +462,7 @@ cdef class ChunkedArray(_PandasConvertible):
 
         if types_mapper:
             pandas_dtype = types_mapper(self.type)
-        elif issubclass(type(self.type), ExtensionType):
+        elif self.type.id == _Type_EXTENSION:
             try:
                 pandas_dtype = self.type.to_pandas_dtype()
             except NotImplementedError:

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -458,22 +458,6 @@ cdef class ChunkedArray(_PandasConvertible):
         return result
 
     def _to_pandas(self, options, types_mapper=None, **kwargs):
-        pandas_dtype = None
-
-        if types_mapper:
-            pandas_dtype = types_mapper(self.type)
-        elif self.type.id == _Type_EXTENSION:
-            try:
-                pandas_dtype = self.type.to_pandas_dtype()
-            except NotImplementedError:
-                pass
-
-        # Only call __from_arrow__ for Arrow extension types or when explicitly
-        # overridden via types_mapper
-        if hasattr(pandas_dtype, '__from_arrow__'):
-            arr = pandas_dtype.__from_arrow__(self)
-            return pandas_api.series(arr, name=self._name)
-
         return _array_like_to_pandas(self, options, types_mapper=types_mapper)
 
     def to_numpy(self):

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -4820,7 +4820,8 @@ def test_unhashable_map_keys_with_pydicts():
 
 def test_table_column_conversion_for_datetime():
     # GH-35235
-    # pandas implemented __from_arrow__ for DatetimeTZDtype
+    # pandas implemented __from_arrow__ for DatetimeTZDtype,
+    # but we choose to do the conversion in Arrow instead.
     # https://github.com/pandas-dev/pandas/pull/52201
     series = pd.Series(pd.date_range("2012", periods=2, tz="Europe/Brussels"),
                     name="datetime_column")
@@ -4833,7 +4834,8 @@ def test_table_column_conversion_for_datetime():
 
 def test_array_conversion_for_datetime():
     # GH-35235
-    # pandas implemented __from_arrow__ for DatetimeTZDtype
+    # pandas implemented __from_arrow__ for DatetimeTZDtype,
+    # but we choose to do the conversion in Arrow instead.
     # https://github.com/pandas-dev/pandas/pull/52201
     series = pd.Series(pd.date_range("2012", periods=2, tz="Europe/Brussels"))
     arr = pa.array(series)

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -4818,15 +4818,25 @@ def test_unhashable_map_keys_with_pydicts():
             assert tup1[1] == tup2[1]
 
 
-def test_column_conversion_for_datetime():
+def test_table_column_conversion_for_datetime():
     # GH-35235
     # pandas implemented __from_arrow__ for DatetimeTZDtype
     # https://github.com/pandas-dev/pandas/pull/52201
-    arr = pd.Series(pd.date_range("2012", periods=2, tz="Europe/Brussels"),
+    series = pd.Series(pd.date_range("2012", periods=2, tz="Europe/Brussels"),
                     name="datetime_column")
-    table = pa.table({"datetime_column": pa.array(arr)})
+    table = pa.table({"datetime_column": pa.array(series)})
     table_col = table.column("datetime_column")
 
     result = table_col.to_pandas()
     assert result.name == "datetime_column"
-    tm.assert_series_equal(result, arr)
+    tm.assert_series_equal(result, series)
+
+def test_array_conversion_for_datetime():
+    # GH-35235
+    # pandas implemented __from_arrow__ for DatetimeTZDtype
+    # https://github.com/pandas-dev/pandas/pull/52201
+    series = pd.Series(pd.date_range("2012", periods=2, tz="Europe/Brussels"))
+    arr = pa.array(series)
+
+    result = arr.to_pandas()
+    tm.assert_series_equal(result, series)

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -4824,13 +4824,14 @@ def test_table_column_conversion_for_datetime():
     # but we choose to do the conversion in Arrow instead.
     # https://github.com/pandas-dev/pandas/pull/52201
     series = pd.Series(pd.date_range("2012", periods=2, tz="Europe/Brussels"),
-                    name="datetime_column")
+                       name="datetime_column")
     table = pa.table({"datetime_column": pa.array(series)})
     table_col = table.column("datetime_column")
 
     result = table_col.to_pandas()
     assert result.name == "datetime_column"
     tm.assert_series_equal(result, series)
+
 
 def test_array_conversion_for_datetime():
     # GH-35235


### PR DESCRIPTION
### Rationale for this change

Array.to_pandas should mimic ChunkedArray.to_pandas implementation. Notably, there is a missing call to `__from_arrow__` if the attribute exists.

### Are these changes tested?

Requires dev pandas. Can manually kick off integration tests to test with pandas nightly.

### Are there any user-facing changes?

No
* Closes: #36096