### PR TITLE
GH-36317: [C++] Return a BufferVector from CleanListOffsets

### DIFF
--- a/cpp/src/arrow/array/array_nested.cc
+++ b/cpp/src/arrow/array/array_nested.cc
@@ -337,17 +337,23 @@ MapArray::MapArray(const std::shared_ptr<DataType>& type, int64_t length,
 }
 
 MapArray::MapArray(const std::shared_ptr<DataType>& type, int64_t length,
+                   BufferVector buffers, const std::shared_ptr<Array>& keys,
+                   const std::shared_ptr<Array>& items, int64_t null_count,
+                   int64_t offset) {
+  auto pair_data = ArrayData::Make(type->fields()[0]->type(), keys->data()->length,
+                                   {nullptr}, {keys->data(), items->data()}, 0, offset);
+  auto map_data =
+      ArrayData::Make(type, length, std::move(buffers), {pair_data}, null_count, offset);
+  SetData(map_data);
+}
+
+MapArray::MapArray(const std::shared_ptr<DataType>& type, int64_t length,
                    const std::shared_ptr<Buffer>& offsets,
                    const std::shared_ptr<Array>& keys,
                    const std::shared_ptr<Array>& items,
                    const std::shared_ptr<Buffer>& null_bitmap, int64_t null_count,
-                   int64_t offset) {
-  auto pair_data = ArrayData::Make(type->fields()[0]->type(), keys->data()->length,
-                                   {nullptr}, {keys->data(), items->data()}, 0, offset);
-  auto map_data = ArrayData::Make(type, length, {null_bitmap, offsets}, {pair_data},
-                                  null_count, offset);
-  SetData(map_data);
-}
+                   int64_t offset)
+    : MapArray(type, length, {null_bitmap, offsets}, keys, items, null_count, offset) {}
 
 Result<std::shared_ptr<Array>> MapArray::FromArraysInternal(
     std::shared_ptr<DataType> type, const std::shared_ptr<Array>& offsets,

--- a/cpp/src/arrow/array/array_nested.cc
+++ b/cpp/src/arrow/array/array_nested.cc
@@ -53,15 +53,17 @@ using internal::CopyBitmap;
 namespace {
 
 template <typename TYPE>
-Status CleanListOffsets(const Array& offsets, MemoryPool* pool,
-                        std::shared_ptr<Buffer>* offset_buf_out,
-                        std::shared_ptr<Buffer>* validity_buf_out) {
+Result<BufferVector> CleanListOffsets(const std::shared_ptr<Buffer>& validity_buffer,
+                                      const Array& offsets, MemoryPool* pool) {
   using offset_type = typename TYPE::offset_type;
   using OffsetArrowType = typename CTypeTraits<offset_type>::ArrowType;
   using OffsetArrayType = typename TypeTraits<OffsetArrowType>::ArrayType;
 
   const auto& typed_offsets = checked_cast<const OffsetArrayType&>(offsets);
   const int64_t num_offsets = offsets.length();
+
+  DCHECK(validity_buffer == nullptr || offsets.null_count() == 0)
+      << "When a validity_buffer is passed, offsets must have no nulls";
 
   if (offsets.null_count() > 0) {
     if (!offsets.IsValid(num_offsets - 1)) {
@@ -74,9 +76,8 @@ Status CleanListOffsets(const Array& offsets, MemoryPool* pool,
     // Copy valid bits, ignoring the final offset (since for a length N list array,
     // we have N + 1 offsets)
     ARROW_ASSIGN_OR_RAISE(
-        auto clean_valid_bits,
+        auto clean_validity_buffer,
         offsets.null_bitmap()->CopySlice(0, bit_util::BytesForBits(num_offsets - 1)));
-    *validity_buf_out = clean_valid_bits;
 
     const offset_type* raw_offsets = typed_offsets.raw_values();
     auto clean_raw_offsets =
@@ -91,13 +92,10 @@ Status CleanListOffsets(const Array& offsets, MemoryPool* pool,
       clean_raw_offsets[i] = current_offset;
     }
 
-    *offset_buf_out = std::move(clean_offsets);
-  } else {
-    *validity_buf_out = offsets.null_bitmap();
-    *offset_buf_out = typed_offsets.values();
+    return BufferVector({std::move(clean_validity_buffer), std::move(clean_offsets)});
   }
 
-  return Status::OK();
+  return BufferVector({validity_buffer, typed_offsets.values()});
 }
 
 template <typename TYPE>
@@ -127,10 +125,8 @@ Result<std::shared_ptr<typename TypeTraits<TYPE>::ArrayType>> ListArrayFromArray
   }
 
   std::shared_ptr<Buffer> offset_buf, validity_buf;
-  RETURN_NOT_OK(CleanListOffsets<TYPE>(offsets, pool, &offset_buf, &validity_buf));
+  ARROW_ASSIGN_OR_RAISE(auto buffers, CleanListOffsets<TYPE>(null_bitmap, offsets, pool));
   int64_t null_count_ = null_bitmap ? null_count : offsets.null_count();
-  BufferVector buffers = {null_bitmap ? std::move(null_bitmap) : validity_buf,
-                          offset_buf};
 
   std::shared_ptr<arrow::ArrayData> internal_data = ArrayData::Make(
       type, offsets.length() - 1, std::move(buffers), null_count_, offsets.offset());
@@ -378,12 +374,10 @@ Result<std::shared_ptr<Array>> MapArray::FromArraysInternal(
     return Status::Invalid("Map key and item arrays must be equal length");
   }
 
-  std::shared_ptr<Buffer> offset_buf, validity_buf;
-  RETURN_NOT_OK(CleanListOffsets<MapType>(*offsets, pool, &offset_buf, &validity_buf));
+  ARROW_ASSIGN_OR_RAISE(auto buffers, CleanListOffsets<MapType>(NULLPTR, *offsets, pool));
 
-  return std::make_shared<MapArray>(type, offsets->length() - 1, offset_buf, keys, items,
-                                    validity_buf, offsets->null_count(),
-                                    offsets->offset());
+  return std::make_shared<MapArray>(type, offsets->length() - 1, std::move(buffers), keys,
+                                    items, offsets->null_count(), offsets->offset());
 }
 
 Result<std::shared_ptr<Array>> MapArray::FromArrays(const std::shared_ptr<Array>& offsets,

--- a/cpp/src/arrow/array/array_nested.h
+++ b/cpp/src/arrow/array/array_nested.h
@@ -234,6 +234,10 @@ class ARROW_EXPORT MapArray : public ListArray {
            const std::shared_ptr<Buffer>& null_bitmap = NULLPTR,
            int64_t null_count = kUnknownNullCount, int64_t offset = 0);
 
+  MapArray(const std::shared_ptr<DataType>& type, int64_t length, BufferVector buffers,
+           const std::shared_ptr<Array>& keys, const std::shared_ptr<Array>& items,
+           int64_t null_count = kUnknownNullCount, int64_t offset = 0);
+
   MapArray(const std::shared_ptr<DataType>& type, int64_t length,
            const std::shared_ptr<Buffer>& value_offsets,
            const std::shared_ptr<Array>& values,


### PR DESCRIPTION
### Rationale for this change

`CleanListOffsets` is taking output parameters when it could return multiple buffers in a vector exactly how they are supposed to be used to construct the list-like array.

Besides that, having the logic for setting the validity buffer split between it and the caller is unnecessarily confusing.

### What changes are included in this PR?

 - Addition of a new constructor for `MapArray` that can accept a pre-allocated `BufferVector`
 - Removal of output parameter in `CleanListOffsets` and change of return type

### Are these changes tested?

Yes, by existing tests. A pre-existing `MapArray` ctor delegates to this new ctor, so all tests that exercise the old ctor also exercise the new.
* Closes: #36317