### PR TITLE
GH-36319: [Go][Parquet] Improved row group writer error messages

### DIFF
--- a/go/parquet/file/file_writer_test.go
+++ b/go/parquet/file/file_writer_test.go
@@ -139,7 +139,9 @@ func (t *SerializeTestSuite) unequalNumRows(maxRows int64, rowsPerCol []int64) {
 		t.WriteBatchSubset(int(rowsPerCol[col]), 0, cw, t.DefLevels[:rowsPerCol[col]], nil)
 		cw.Close()
 	}
-	t.Error(rgw.Close())
+	err := rgw.Close()
+	t.Error(err)
+	t.ErrorContains(err, "row mismatch for unbuffered row group")
 }
 
 func (t *SerializeTestSuite) unequalNumRowsBuffered(maxRows int64, rowsPerCol []int64) {
@@ -154,7 +156,9 @@ func (t *SerializeTestSuite) unequalNumRowsBuffered(maxRows int64, rowsPerCol []
 		t.WriteBatchSubset(int(rowsPerCol[col]), 0, cw, t.DefLevels[:rowsPerCol[col]], nil)
 		cw.Close()
 	}
-	t.Error(rgw.Close())
+	err := rgw.Close()
+	t.Error(err)
+	t.ErrorContains(err, "row mismatch for buffered row group")
 }
 
 func (t *SerializeTestSuite) TestZeroRows() {

--- a/go/parquet/file/row_group_writer.go
+++ b/go/parquet/file/row_group_writer.go
@@ -110,13 +110,13 @@ func (rg *rowGroupWriter) checkRowsWritten() error {
 		if rg.nrows == 0 {
 			rg.nrows = current
 		} else if rg.nrows != current {
-			return xerrors.New("row mismatch")
+			return xerrors.Errorf("row mismatch for unbuffered row group: %d, count expected: %d, actual: %d", rg.ordinal, current, rg.nrows)
 		}
 	} else if rg.buffered {
 		current := rg.columnWriters[0].RowsWritten()
-		for _, wr := range rg.columnWriters[1:] {
+		for i, wr := range rg.columnWriters[1:] {
 			if current != wr.RowsWritten() {
-				return xerrors.New("row mismatch error")
+				return xerrors.Errorf("row mismatch for buffered row group: %d, column: %d, count expected: %d, actual: %d", rg.ordinal, i+1, current, wr.RowsWritten())
 			}
 		}
 		rg.nrows = current
@@ -182,7 +182,7 @@ func (rg *rowGroupWriter) Column(i int) (ColumnChunkWriter, error) {
 	if i >= 0 && i < len(rg.columnWriters) {
 		return rg.columnWriters[i], nil
 	}
-	return nil, xerrors.New("invalid column number requested")
+	return nil, xerrors.Errorf("invalid column number requested: %d", i)
 }
 
 func (rg *rowGroupWriter) CurrentColumn() int { return rg.metadata.CurrentColumn() }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

Updated error messages for mismatched column row counts to help identify the column, or rowgroup index which failed the check, and how many rows were expected vs found.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #36319