### PR TITLE
GH-36318: [Go] only decode lengths for the number of existing values, not for all nvalues.

### DIFF
--- a/go/parquet/internal/encoding/delta_bit_packing.go
+++ b/go/parquet/internal/encoding/delta_bit_packing.go
@@ -156,7 +156,7 @@ func (d *DeltaBitPackInt32Decoder) unpackNextMini() error {
 // Decode retrieves min(remaining values, len(out)) values from the data and returns the number
 // of values actually decoded and any errors encountered.
 func (d *DeltaBitPackInt32Decoder) Decode(out []int32) (int, error) {
-	max := shared_utils.MinInt(len(out), d.nvals)
+	max := shared_utils.MinInt(len(out), int(d.totalValues))
 	if max == 0 {
 		return 0, nil
 	}
@@ -315,7 +315,7 @@ const (
 // Consists of a header followed by blocks of delta encoded values binary packed.
 //
 //	Format
-// 		[header] [block 1] [block 2] ... [block N]
+//		[header] [block 1] [block 2] ... [block N]
 //
 //	Header
 //		[block size] [number of mini blocks per block] [total value count] [first value]

--- a/go/parquet/internal/encoding/delta_byte_array_test.go
+++ b/go/parquet/internal/encoding/delta_byte_array_test.go
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package encoding
 
 import (

--- a/go/parquet/internal/encoding/delta_byte_array_test.go
+++ b/go/parquet/internal/encoding/delta_byte_array_test.go
@@ -1,0 +1,31 @@
+package encoding
+
+import (
+	"fmt"
+	"github.com/apache/arrow/go/v13/arrow/memory"
+	"github.com/apache/arrow/go/v13/parquet"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDeltaByteArrayDecoder_SetData(t *testing.T) {
+	tests := []struct {
+		name    string
+		nvalues int
+		data    []byte
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name:    "null only page",
+			nvalues: 126609,
+			data:    []byte{128, 1, 4, 0, 0},
+			wantErr: assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		d := NewDecoder(parquet.Types.ByteArray, parquet.Encodings.DeltaLengthByteArray, nil, memory.DefaultAllocator)
+		t.Run(tt.name, func(t *testing.T) {
+			tt.wantErr(t, d.SetData(tt.nvalues, tt.data), fmt.Sprintf("SetData(%v, %v)", tt.nvalues, tt.data))
+		})
+	}
+}

--- a/go/parquet/internal/encoding/delta_length_byte_array.go
+++ b/go/parquet/internal/encoding/delta_length_byte_array.go
@@ -117,7 +117,7 @@ func (d *DeltaLengthByteArrayDecoder) SetData(nvalues int, data []byte) error {
 	if err := dec.SetData(nvalues, data); err != nil {
 		return err
 	}
-	d.lengths = make([]int32, nvalues)
+	d.lengths = make([]int32, dec.totalValues)
 	dec.Decode(d.lengths)
 
 	return d.decoder.SetData(nvalues, data[int(dec.bytesRead()):])


### PR DESCRIPTION
### Rationale for this change

Fixes issue 36318.
DeltaLengthBinaryArray Encoding fails to handle null values.

### What changes are included in this PR?

Instead of decoding lengths for "all" values (even the undefined ones), we only decode the lengths for the actually set values.
The Go Version of arrow was unable to read parquet files it produced itself if the mentioned encoding was used but the values contain nulls.

### Are these changes tested?

Tests are included.

### Are there any user-facing changes?

No.

**This PR contains a "Critical Fix".**
* Closes: #36318