### PR TITLE
GH-35651: [C++] Suppress self-move warning introduced in gcc 13

### DIFF
--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -404,6 +404,13 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set(CXX_ONLY_FLAGS "${CXX_ONLY_FLAGS} -Wno-noexcept-type")
   endif()
 
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL "13.0" OR CMAKE_CXX_COMPILER_VERSION
+                                                        VERSION_GREATER "13.0")
+    # -Wself-move added in GCC 13 warns when a value is moved to itself
+    # See https://gcc.gnu.org/gcc-13/changes.html
+    set(CXX_ONLY_FLAGS "${CXX_ONLY_FLAGS} -Wno-self-move")
+  endif()
+
   # Disabling semantic interposition allows faster calling conventions
   # when calling global functions internally, and can also help inlining.
   # See https://stackoverflow.com/questions/35745543/new-option-in-gcc-5-3-fno-semantic-interposition

--- a/cpp/src/arrow/util/small_vector_test.cc
+++ b/cpp/src/arrow/util/small_vector_test.cc
@@ -413,12 +413,10 @@ class TestSmallStaticVector : public ::testing::Test {
     ASSERT_EQ(moved_moved_ints.size(), 5);
     EXPECT_THAT(moved_moved_ints, ElementsAre(4, 5, 6, 7, 8));
 
-#ifndef __MINGW32__
     // Move into itself
     moved_moved_ints = std::move(moved_moved_ints);
     ASSERT_EQ(moved_moved_ints.size(), 5);
     EXPECT_THAT(moved_moved_ints, ElementsAre(4, 5, 6, 7, 8));
-#endif
   }
 
   void TestMove() {


### PR DESCRIPTION


<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

PR #35653 had a fix for MinGW, but I think the real cause is that gcc add a new warning -Wself-move.

see https://gcc.gnu.org/gcc-13/changes.html.

We should suppress it if we need to move to itself.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

suppress self-move warning by adding a cpp flag

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #35651