### PR TITLE
GH-36337: [Ruby] Relax required Apache Arrow C++ version

### DIFF
--- a/ruby/red-arrow/ext/arrow/extconf.rb
+++ b/ruby/red-arrow/ext/arrow/extconf.rb
@@ -41,8 +41,6 @@ end
 unless required_pkg_config_package([
                                      "arrow",
                                      Arrow::Version::MAJOR,
-                                     Arrow::Version::MINOR,
-                                     Arrow::Version::MICRO,
                                    ],
                                    conda: "libarrow",
                                    debian: "libarrow-dev",


### PR DESCRIPTION
### Rationale for this change

Apache Arrow follows Semantic Versioning. So we can use all Apache Arrow C++ `12.*.*` for Red Arrow 12.0.1. Apache Arrow C GLib `12.*.*` will also work but Red Arrow 12.0.1 may depend on changes for Apache Arrow C GLib 12.0.1. So we should keep depending on the same version of Apache Arrow C GLib.

### What changes are included in this PR?

Relax required Apache Arrow C++ version.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #36337