### PR TITLE
GH-36342: [C++] Add missing move semantic to RecordBatch

### DIFF
--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -176,7 +176,8 @@ std::shared_ptr<RecordBatch> RecordBatch::Make(
     std::shared_ptr<Schema> schema, int64_t num_rows,
     std::vector<std::shared_ptr<Array>> columns) {
   DCHECK_EQ(schema->num_fields(), static_cast<int>(columns.size()));
-  return std::make_shared<SimpleRecordBatch>(std::move(schema), num_rows, columns);
+  return std::make_shared<SimpleRecordBatch>(std::move(schema), num_rows,
+                                             std::move(columns));
 }
 
 std::shared_ptr<RecordBatch> RecordBatch::Make(
@@ -194,7 +195,7 @@ Result<std::shared_ptr<RecordBatch>> RecordBatch::MakeEmpty(
     ARROW_ASSIGN_OR_RAISE(empty_batch[i],
                           MakeEmptyArray(schema->field(i)->type(), memory_pool));
   }
-  return RecordBatch::Make(schema, 0, empty_batch);
+  return RecordBatch::Make(std::move(schema), 0, std::move(empty_batch));
 }
 
 Result<std::shared_ptr<RecordBatch>> RecordBatch::FromStructArray(
@@ -391,7 +392,7 @@ Result<std::shared_ptr<RecordBatchReader>> RecordBatchReader::Make(
     schema = batches[0]->schema();
   }
 
-  return std::make_shared<SimpleRecordBatchReader>(std::move(batches), schema);
+  return std::make_shared<SimpleRecordBatchReader>(std::move(batches), std::move(schema));
 }
 
 Result<std::shared_ptr<RecordBatchReader>> RecordBatchReader::MakeFromIterator(
@@ -400,7 +401,7 @@ Result<std::shared_ptr<RecordBatchReader>> RecordBatchReader::MakeFromIterator(
     return Status::Invalid("Schema cannot be nullptr");
   }
 
-  return std::make_shared<SimpleRecordBatchReader>(std::move(batches), schema);
+  return std::make_shared<SimpleRecordBatchReader>(std::move(batches), std::move(schema));
 }
 
 RecordBatchReader::~RecordBatchReader() {


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

In file record_batch.cc there are some places that using move semantic can avoid coping vector or increasing reference count of shared_ptr.

### What changes are included in this PR?

add std::move at some proper places

### Are these changes tested?

Yes, run `ctest -R arrow-table-test` locally.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #36342