### PR TITLE
GH-36199: [Python][CI][Spark] Update spark versions used on our nightly tests

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1588,9 +1588,9 @@ tasks:
       image: conda-python-hdfs
 {% endfor %}
 
-{% for python_version, spark_version, test_pyarrow_only, numpy_version in [("3.8", "v3.1.2", "false", "latest"),
-                                                                           ("3.9", "v3.2.0", "false", "1.23"),
-                                                                           ("3.10", "master", "false", "latest")] %}
+{% for python_version, spark_version, test_pyarrow_only, numpy_version in [("3.8", "v3.4.1", "false", "latest"),
+                                                                           ("3.10", "v3.4.0", "false", "1.23"),
+                                                                           ("3.11", "master", "false", "latest")] %}
   test-conda-python-{{ python_version }}-spark-{{ spark_version }}:
     ci: github
     template: docker-tests/github.linux.yml

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1589,7 +1589,7 @@ tasks:
 {% endfor %}
 
 {% for python_version, spark_version, test_pyarrow_only, numpy_version in [("3.8", "v3.4.1", "false", "latest"),
-                                                                           ("3.10", "v3.4.0", "false", "1.23"),
+                                                                           ("3.10", "v3.4.1", "false", "1.23"),
                                                                            ("3.11", "master", "false", "latest")] %}
   test-conda-python-{{ python_version }}-spark-{{ spark_version }}:
     ci: github


### PR DESCRIPTION
### Rationale for this change

We are currently testing with very old or deprecated spark versions.

### What changes are included in this PR?

Update the spark versions to be tested.

### Are these changes tested?

They will via archery

### Are there any user-facing changes?

No
* Closes: #36199