### PR TITLE
GH-35728: [CI][Python] Move test_total_bytes_allocated to a subprocess to improve reliability

### DIFF
--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -24,6 +24,7 @@ import itertools
 import pickle
 import pytest
 import struct
+import subprocess
 import sys
 import weakref
 
@@ -38,7 +39,17 @@ import pyarrow.tests.strategies as past
 
 
 def test_total_bytes_allocated():
+    code = f"""if 1:
+    import pyarrow as pa
+
     assert pa.total_allocated_bytes() == 0
+    """
+    res = subprocess.run([sys.executable, "-c", code],
+                         universal_newlines=True, stderr=subprocess.PIPE)
+    if res.returncode != 0:
+        print(res.stderr, file=sys.stderr)
+        res.check_returncode()  # fail
+    assert len(res.stderr.splitlines()) == 0
 
 
 def test_weakref():

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -39,7 +39,7 @@ import pyarrow.tests.strategies as past
 
 
 def test_total_bytes_allocated():
-    code = f"""if 1:
+    code = """if 1:
     import pyarrow as pa
 
     assert pa.total_allocated_bytes() == 0


### PR DESCRIPTION
### Rationale for this change

Currently some conda and wheels jobs are failing due to this error:

```
 =================================== FAILURES ===================================
__________________________ test_total_bytes_allocated __________________________

    def test_total_bytes_allocated():
>       assert pa.total_allocated_bytes() == 0
E       assert 1216 == 0
E        +  where 1216 = <built-in function total_allocated_bytes>()
E        +    where <built-in function total_allocated_bytes> = pa.total_allocated_bytes
```

### What changes are included in this PR?

As suggested on the issue trying to move this test to a subprocess to see if it improves reliabilit.

### Are these changes tested?

Archery and CI

### Are there any user-facing changes?

No
* Closes: #35728