### PR TITLE
GH-36331: [C++][CI] Sporadic errors in AsofJoinTest

### DIFF
--- a/cpp/src/arrow/acero/asof_join_node_test.cc
+++ b/cpp/src/arrow/acero/asof_join_node_test.cc
@@ -1592,6 +1592,7 @@ T GetEnvValue(const std::string& var, T default_value) {
 }  // namespace
 
 TEST(AsofJoinTest, BackpressureWithBatchesGen) {
+  GTEST_SKIP() << "Skipping - see GH-36331";
   int num_batches = GetEnvValue("ARROW_BACKPRESSURE_DEMO_NUM_BATCHES", 20);
   int batch_size = GetEnvValue("ARROW_BACKPRESSURE_DEMO_BATCH_SIZE", 1);
   return TestBackpressure(MakeIntegerBatchGenForTest, num_batches, batch_size);


### PR DESCRIPTION
### Rationale for this change

Skipping a flaky test until a robust way for it is found.

### What changes are included in this PR?

The `AsofJoinTest.BackpressureWithBatchesGen` test is skipped.

### Are these changes tested?

N/A

### Are there any user-facing changes?

No.

* Closes: #36331