### PR TITLE
MINOR: [Dev] Add anjakefala and davisusanibar to the contributors list

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -19,8 +19,10 @@ github:
   description: "Apache Arrow is a multi-language toolbox for accelerated data interchange and in-memory processing"
   homepage: https://arrow.apache.org/
   collaborators:
+    - anjakefala
     - benibus
     - danepitkin
+    - davisusanibar
     - felipecrv
     - milesgranger
     - toddfarmer


### PR DESCRIPTION
### Rationale for this change

Disclaimer: These are both colleagues of mine.

@davisusanibar has been an Arrow Java maintainer for > 1 year.
@anjakefala is taking a more active role in contributing to pyarrow issues/triaging, which has an incredibly high volume.