### PR TITLE
GH-36345: [C++] Prefer TypeError over Invalid in IsIn and IndexIn kernels

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
@@ -209,7 +209,7 @@ struct InitStateVisitor {
       const auto& ty1 = checked_cast<const TimestampType&>(*arg_type);
       const auto& ty2 = checked_cast<const TimestampType&>(*options.value_set.type());
       if (ty1.timezone().empty() ^ ty2.timezone().empty()) {
-        return Status::Invalid(
+        return Status::TypeError(
             "Cannot compare timestamp with timezone to timestamp without timezone, got: ",
             ty1, " and ", ty2);
       }
@@ -218,8 +218,8 @@ struct InitStateVisitor {
       // This is a bit of a hack, but don't implicitly cast from a non-binary
       // type to string, since most types support casting to string and that
       // may lead to surprises. However, we do want most other implicit casts.
-      return Status::Invalid("Array type didn't match type of values set: ", *arg_type,
-                             " vs ", *options.value_set.type());
+      return Status::TypeError("Array type didn't match type of values set: ", *arg_type,
+                               " vs ", *options.value_set.type());
     }
 
     if (!options.value_set.is_arraylike()) {
@@ -236,12 +236,12 @@ struct InitStateVisitor {
         if ((options.value_set.type()->id() == Type::STRING ||
              options.value_set.type()->id() == Type::LARGE_STRING) &&
             !is_base_binary_like(arg_type.id())) {
-          return Status::Invalid("Array type didn't match type of values set: ",
-                                 *arg_type, " vs ", *options.value_set.type());
+          return Status::TypeError("Array type didn't match type of values set: ",
+                                   *arg_type, " vs ", *options.value_set.type());
         }
       } else {
-        return Status::Invalid("Array type doesn't match type of values set: ", *arg_type,
-                               " vs ", *options.value_set.type());
+        return Status::TypeError("Array type doesn't match type of values set: ",
+                                 *arg_type, " vs ", *options.value_set.type());
       }
     }
 
@@ -326,9 +326,13 @@ struct IndexInVisitor {
     const auto& state = checked_cast<const SetLookupState<Type>&>(*ctx->state());
     if (!data.type->Equals(state.value_set_type)) {
       auto materialized_input = data.ToArrayData();
-      ARROW_ASSIGN_OR_RAISE(auto casted_input,
-                            Cast(*materialized_input, state.value_set_type,
-                                 CastOptions::Safe(), ctx->exec_context()));
+      auto cast_result = Cast(*materialized_input, state.value_set_type,
+                              CastOptions::Safe(), ctx->exec_context());
+      if (ARROW_PREDICT_FALSE(!cast_result.ok())) {
+        return Status::TypeError("Array type didn't match type of values set: ",
+                                 *data.type, " vs ", *state.value_set_type);
+      }
+      auto casted_input = *cast_result;
       return ProcessIndexIn(state, *casted_input.array());
     }
     return ProcessIndexIn(state, data);
@@ -423,11 +427,15 @@ struct IsInVisitor {
     const auto& state = checked_cast<const SetLookupState<Type>&>(*ctx->state());
 
     if (!data.type->Equals(state.value_set_type)) {
-      auto materialized_data = data.ToArrayData();
-      ARROW_ASSIGN_OR_RAISE(auto casted_data,
-                            Cast(*materialized_data, state.value_set_type,
-                                 CastOptions::Safe(), ctx->exec_context()));
-      return ProcessIsIn(state, *casted_data.array());
+      auto materialized_input = data.ToArrayData();
+      auto cast_result = Cast(*materialized_input, state.value_set_type,
+                              CastOptions::Safe(), ctx->exec_context());
+      if (ARROW_PREDICT_FALSE(!cast_result.ok())) {
+        return Status::TypeError("Array type didn't match type of values set: ",
+                                 *data.type, " vs ", *state.value_set_type);
+      }
+      auto casted_input = *cast_result;
+      return ProcessIsIn(state, *casted_input.array());
     }
     return ProcessIsIn(state, data);
   }

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
@@ -329,8 +329,11 @@ struct IndexInVisitor {
       auto cast_result = Cast(*materialized_input, state.value_set_type,
                               CastOptions::Safe(), ctx->exec_context());
       if (ARROW_PREDICT_FALSE(!cast_result.ok())) {
-        return Status::TypeError("Array type didn't match type of values set: ",
-                                 *data.type, " vs ", *state.value_set_type);
+        if (cast_result.status().IsNotImplemented()) {
+          return Status::TypeError("Array type didn't match type of values set: ",
+                                   *data.type, " vs ", *state.value_set_type);
+        }
+        return cast_result.status();
       }
       auto casted_input = *cast_result;
       return ProcessIndexIn(state, *casted_input.array());
@@ -431,8 +434,11 @@ struct IsInVisitor {
       auto cast_result = Cast(*materialized_input, state.value_set_type,
                               CastOptions::Safe(), ctx->exec_context());
       if (ARROW_PREDICT_FALSE(!cast_result.ok())) {
-        return Status::TypeError("Array type didn't match type of values set: ",
-                                 *data.type, " vs ", *state.value_set_type);
+        if (cast_result.status().IsNotImplemented()) {
+          return Status::TypeError("Array type didn't match type of values set: ",
+                                   *data.type, " vs ", *state.value_set_type);
+        }
+        return cast_result.status();
       }
       auto casted_input = *cast_result;
       return ProcessIsIn(state, *casted_input.array());

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
@@ -218,7 +218,7 @@ struct InitStateVisitor {
       // This is a bit of a hack, but don't implicitly cast from a non-binary
       // type to string, since most types support casting to string and that
       // may lead to surprises. However, we do want most other implicit casts.
-      return Status::TypeError("Array type didn't match type of values set: ", *arg_type,
+      return Status::TypeError("Array type doesn't match type of values set: ", *arg_type,
                                " vs ", *options.value_set.type());
     }
 
@@ -236,7 +236,7 @@ struct InitStateVisitor {
         if ((options.value_set.type()->id() == Type::STRING ||
              options.value_set.type()->id() == Type::LARGE_STRING) &&
             !is_base_binary_like(arg_type.id())) {
-          return Status::TypeError("Array type didn't match type of values set: ",
+          return Status::TypeError("Array type doesn't match type of values set: ",
                                    *arg_type, " vs ", *options.value_set.type());
         }
       } else {
@@ -330,7 +330,7 @@ struct IndexInVisitor {
                               CastOptions::Safe(), ctx->exec_context());
       if (ARROW_PREDICT_FALSE(!cast_result.ok())) {
         if (cast_result.status().IsNotImplemented()) {
-          return Status::TypeError("Array type didn't match type of values set: ",
+          return Status::TypeError("Array type doesn't match type of values set: ",
                                    *data.type, " vs ", *state.value_set_type);
         }
         return cast_result.status();
@@ -435,7 +435,7 @@ struct IsInVisitor {
                               CastOptions::Safe(), ctx->exec_context());
       if (ARROW_PREDICT_FALSE(!cast_result.ok())) {
         if (cast_result.status().IsNotImplemented()) {
-          return Status::TypeError("Array type didn't match type of values set: ",
+          return Status::TypeError("Array type doesn't match type of values set: ",
                                    *data.type, " vs ", *state.value_set_type);
         }
         return cast_result.status();

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
@@ -146,17 +146,17 @@ TEST_F(TestIsInKernel, ImplicitlyCastValueSet) {
 
   // But explicitly deny implicit casts from non-binary to utf8 to
   // avoid surprises
-  ASSERT_RAISES(Invalid,
+  ASSERT_RAISES(TypeError,
                 IsIn(ArrayFromJSON(utf8(), R"(["aaa", "bbb", "ccc", null, "bbb"])"),
                      SetLookupOptions(ArrayFromJSON(float64(), "[1.0, 2.0]"))));
-  ASSERT_RAISES(Invalid, IsIn(ArrayFromJSON(float64(), "[1.0, 2.0]"),
-                              SetLookupOptions(ArrayFromJSON(
-                                  utf8(), R"(["aaa", "bbb", "ccc", null, "bbb"])"))));
+  ASSERT_RAISES(TypeError, IsIn(ArrayFromJSON(float64(), "[1.0, 2.0]"),
+                                SetLookupOptions(ArrayFromJSON(
+                                    utf8(), R"(["aaa", "bbb", "ccc", null, "bbb"])"))));
 
-  ASSERT_RAISES(Invalid,
+  ASSERT_RAISES(TypeError,
                 IsIn(ArrayFromJSON(large_utf8(), R"(["aaa", "bbb", "ccc", null, "bbb"])"),
                      SetLookupOptions(ArrayFromJSON(float64(), "[1.0, 2.0]"))));
-  ASSERT_RAISES(Invalid,
+  ASSERT_RAISES(TypeError,
                 IsIn(ArrayFromJSON(float64(), "[1.0, 2.0]"),
                      SetLookupOptions(ArrayFromJSON(
                          large_utf8(), R"(["aaa", "bbb", "ccc", null, "bbb"])"))));
@@ -241,11 +241,11 @@ TEST_F(TestIsInKernel, TimeTimestamp) {
   }
 
   // Disallow mixing timezone-aware and timezone-naive values
-  ASSERT_RAISES(Invalid, IsIn(ArrayFromJSON(timestamp(TimeUnit::SECOND), "[0, 1, 2]"),
-                              SetLookupOptions(ArrayFromJSON(
-                                  timestamp(TimeUnit::SECOND, "UTC"), "[0, 2]"))));
+  ASSERT_RAISES(TypeError, IsIn(ArrayFromJSON(timestamp(TimeUnit::SECOND), "[0, 1, 2]"),
+                                SetLookupOptions(ArrayFromJSON(
+                                    timestamp(TimeUnit::SECOND, "UTC"), "[0, 2]"))));
   ASSERT_RAISES(
-      Invalid,
+      TypeError,
       IsIn(ArrayFromJSON(timestamp(TimeUnit::SECOND, "UTC"), "[0, 1, 2]"),
            SetLookupOptions(ArrayFromJSON(timestamp(TimeUnit::SECOND), "[0, 2]"))));
   // However, mixed timezones are allowed (underlying value is UTC)
@@ -353,7 +353,7 @@ TEST_F(TestIsInKernel, FixedSizeBinary) {
             "[true, true, false, false, true]",
             /*skip_nulls=*/true);
 
-  ASSERT_RAISES(Invalid,
+  ASSERT_RAISES(TypeError,
                 IsIn(ArrayFromJSON(fixed_size_binary(3), R"(["abc"])"),
                      SetLookupOptions(ArrayFromJSON(fixed_size_binary(2), R"(["ab"])"))));
 }
@@ -741,11 +741,12 @@ TEST_F(TestIndexInKernel, TimeTimestamp) {
                "[0, 0, 0, 0]");
 
   // Disallow mixing timezone-aware and timezone-naive values
-  ASSERT_RAISES(Invalid, IndexIn(ArrayFromJSON(timestamp(TimeUnit::SECOND), "[0, 1, 2]"),
-                                 SetLookupOptions(ArrayFromJSON(
-                                     timestamp(TimeUnit::SECOND, "UTC"), "[0, 2]"))));
+  ASSERT_RAISES(TypeError,
+                IndexIn(ArrayFromJSON(timestamp(TimeUnit::SECOND), "[0, 1, 2]"),
+                        SetLookupOptions(ArrayFromJSON(timestamp(TimeUnit::SECOND, "UTC"),
+                                                       "[0, 2]"))));
   ASSERT_RAISES(
-      Invalid,
+      TypeError,
       IndexIn(ArrayFromJSON(timestamp(TimeUnit::SECOND, "UTC"), "[0, 1, 2]"),
               SetLookupOptions(ArrayFromJSON(timestamp(TimeUnit::SECOND), "[0, 2]"))));
   // However, mixed timezones are allowed (underlying value is UTC)
@@ -866,18 +867,19 @@ TEST_F(TestIndexInKernel, ImplicitlyCastValueSet) {
                ArrayFromJSON(utf8(), R"(["aaa", "bbb"])"), "[0, 1, null, null, 1]");
   // But explicitly deny implicit casts from non-binary to utf8 to
   // avoid surprises
-  ASSERT_RAISES(Invalid,
+  ASSERT_RAISES(TypeError,
                 IndexIn(ArrayFromJSON(utf8(), R"(["aaa", "bbb", "ccc", null, "bbb"])"),
                         SetLookupOptions(ArrayFromJSON(float64(), "[1.0, 2.0]"))));
-  ASSERT_RAISES(Invalid, IndexIn(ArrayFromJSON(float64(), "[1.0, 2.0]"),
-                                 SetLookupOptions(ArrayFromJSON(
-                                     utf8(), R"(["aaa", "bbb", "ccc", null, "bbb"])"))));
+  ASSERT_RAISES(TypeError,
+                IndexIn(ArrayFromJSON(float64(), "[1.0, 2.0]"),
+                        SetLookupOptions(ArrayFromJSON(
+                            utf8(), R"(["aaa", "bbb", "ccc", null, "bbb"])"))));
 
   ASSERT_RAISES(
-      Invalid,
+      TypeError,
       IndexIn(ArrayFromJSON(large_utf8(), R"(["aaa", "bbb", "ccc", null, "bbb"])"),
               SetLookupOptions(ArrayFromJSON(float64(), "[1.0, 2.0]"))));
-  ASSERT_RAISES(Invalid,
+  ASSERT_RAISES(TypeError,
                 IndexIn(ArrayFromJSON(float64(), "[1.0, 2.0]"),
                         SetLookupOptions(ArrayFromJSON(
                             large_utf8(), R"(["aaa", "bbb", "ccc", null, "bbb"])"))));
@@ -1011,7 +1013,7 @@ TEST_F(TestIndexInKernel, FixedSizeBinary) {
   CheckIndexIn(fixed_size_binary(0), R"([])", R"([])", R"([])");
 
   ASSERT_RAISES(
-      Invalid,
+      TypeError,
       IndexIn(ArrayFromJSON(fixed_size_binary(3), R"(["abc"])"),
               SetLookupOptions(ArrayFromJSON(fixed_size_binary(2), R"(["ab"])"))));
 }

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
@@ -353,7 +353,7 @@ TEST_F(TestIsInKernel, FixedSizeBinary) {
             "[true, true, false, false, true]",
             /*skip_nulls=*/true);
 
-  ASSERT_RAISES(TypeError,
+  ASSERT_RAISES(Invalid,
                 IsIn(ArrayFromJSON(fixed_size_binary(3), R"(["abc"])"),
                      SetLookupOptions(ArrayFromJSON(fixed_size_binary(2), R"(["ab"])"))));
 }
@@ -1013,7 +1013,7 @@ TEST_F(TestIndexInKernel, FixedSizeBinary) {
   CheckIndexIn(fixed_size_binary(0), R"([])", R"([])", R"([])");
 
   ASSERT_RAISES(
-      TypeError,
+      Invalid,
       IndexIn(ArrayFromJSON(fixed_size_binary(3), R"(["abc"])"),
               SetLookupOptions(ArrayFromJSON(fixed_size_binary(2), R"(["ab"])"))));
 }


### PR DESCRIPTION
### Rationale for this change

`TypeError` should be returned when `values` and `value_set` have incompatible types in IsIn and IndeIx.
`Invalid` is still returned if the types are compatible but casting the values fails (for example because of overflow or truncation).

### What changes are included in this PR?

When casting between types is not supported, return TypeError instead of Invalid.


### Are these changes tested?

Yes.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #36345