### PR TITLE
MINOR: [Docs] add note about how comment bot assigns users

### DIFF
--- a/docs/source/developers/guide/step_by_step/finding_issues.rst
+++ b/docs/source/developers/guide/step_by_step/finding_issues.rst
@@ -69,8 +69,7 @@ in the comments.
    When you find a GitHub issue you would like to work on, please mention
    your interest in the comment section of that issue; that way we will know
    you are working on it.
-   To assign yourself to the issue type 'take' (and nothing else) in a comment
-   on that issue.
+   Consider assigning yourself to the issue (:ref:`issue-assignment`) when the work starts.
 
 Also, do not hesitate to ask questions in the comment. You can get some
 pointers about where to start and similar issues already solved.

--- a/docs/source/developers/guide/step_by_step/finding_issues.rst
+++ b/docs/source/developers/guide/step_by_step/finding_issues.rst
@@ -69,6 +69,8 @@ in the comments.
    When you find a GitHub issue you would like to work on, please mention
    your interest in the comment section of that issue; that way we will know
    you are working on it.
+   To assign yourself to the issue type 'take' (and nothing else) in a comment
+   on that issue.
 
 Also, do not hesitate to ask questions in the comment. You can get some
 pointers about where to start and similar issues already solved.


### PR DESCRIPTION
### Rationale for this change

Each time I wanted to use it, I had to look up the syntax in the github workflows. Most new users wouldn't know about it existing. 

https://github.com/apache/arrow/blob/e5de6a59f410a3255cc84138b44fc5802b627afc/.github/workflows/comment_bot.yml#L182

### What changes are included in this PR?

Doc addition of text teaching about "take".

### Are there any user-facing changes?

Nope