### PR TITLE
GH-36353: [R] Fix package version references to be text only and never numeric

### DIFF
--- a/r/R/duckdb.R
+++ b/r/R/duckdb.R
@@ -95,7 +95,7 @@ run_duckdb_examples <- function() {
     packageVersion("duckdb") > "0.2.7" &&
     requireNamespace("dplyr", quietly = TRUE) &&
     requireNamespace("dbplyr", quietly = TRUE) &&
-    getRversion() >= 4
+    getRversion() >= "4"
 }
 
 # Adapted from dbplyr


### PR DESCRIPTION
Fixes #36353
* Closes: #36353