### PR TITLE
GH-36384: [Go] Schema: NumFields

### DIFF
--- a/go/arrow/schema.go
+++ b/go/arrow/schema.go
@@ -194,12 +194,13 @@ func (sc *Schema) WithEndianness(e endian.Endianness) *Schema {
 func (sc *Schema) Endianness() endian.Endianness { return sc.endianness }
 func (sc *Schema) IsNativeEndian() bool          { return sc.endianness == endian.NativeEndian }
 func (sc *Schema) Metadata() Metadata            { return sc.meta }
-func (sc *Schema) Fields() []Field { 
+func (sc *Schema) Fields() []Field {
 	fields := make([]Field, len(sc.fields))
 	copy(fields, sc.fields)
 	return fields
 }
-func (sc *Schema) Field(i int) Field             { return sc.fields[i] }
+func (sc *Schema) Field(i int) Field { return sc.fields[i] }
+func (sc *Schema) NumFields() int    { return len(sc.fields) }
 
 func (sc *Schema) FieldsByName(n string) ([]Field, bool) {
 	indices, ok := sc.index[n]

--- a/go/arrow/schema_test.go
+++ b/go/arrow/schema_test.go
@@ -342,7 +342,7 @@ func TestSchemaAddField(t *testing.T) {
 	if got, want := len(s.Fields()), 3; got != want {
 		t.Fatalf("invalid number of fields. got=%d, want=%d", got, want)
 	}
-	got, want := s.Field(2), Field{Name: "f3", Type: PrimitiveTypes.Int32};
+	got, want := s.Field(2), Field{Name: "f3", Type: PrimitiveTypes.Int32}
 	if !got.Equal(want) {
 		t.Fatalf("invalid field: got=%#v, want=%#v", got, want)
 	}
@@ -461,4 +461,20 @@ func TestSchemaEqual(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSchemaNumFields(t *testing.T) {
+	s := NewSchema([]Field{
+		{Name: "f1", Type: PrimitiveTypes.Int32},
+		{Name: "f2", Type: PrimitiveTypes.Int64},
+	}, nil)
+
+	assert.Equal(t, 2, s.NumFields())
+
+	var err error
+	s, err = s.AddField(2, Field{Name: "f3", Type: PrimitiveTypes.Int32})
+	assert.NoError(t, err)
+
+	assert.Equal(t, 3, s.NumFields())
+	assert.Equal(t, s.NumFields(), len(s.Fields()))
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Previously if one wanted to iterate over the fields in the schema you would call the `Fields()` function and just iterate over the slice. However, due to [this commit](https://github.com/rtpsw/arrow/commit/802674b73c94c84388a6775b424ebe4f6e04274e) there is now an allocation and copy that happens when that's called. So to iterate over the fields without allocations one now must use the `Field(i int)` method; however that means a user must already know exactly how many fields are in the schema which isn't possible today.

This adds a simple `NumFields() int` method that returns the number of fields in a schema to allow a user to iterate over all the fields without having to copy them. 

### What changes are included in this PR?

Expose the number of fields in a schema for iteration over fields.

Single function added `NumFields() int` to schema

### Are these changes tested?

N/A

### Are there any user-facing changes?

Yes this is a new API

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #36384