### PR TITLE
GH-36053:  [C++] summarizing a variable results in NA at random, while there is no NA in the subset of data

### DIFF
--- a/cpp/src/arrow/compute/kernels/hash_aggregate.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate.cc
@@ -491,7 +491,7 @@ struct GroupedReducingAggregator : public GroupedAggregator {
 
     const CType* other_reduced = other->reduced_.data();
     const int64_t* other_counts = other->counts_.data();
-    const uint8_t* other_no_nulls = no_nulls_.mutable_data();
+    const uint8_t* other_no_nulls = other->no_nulls_.data();
 
     auto g = group_id_mapping.GetValues<uint32_t>(1);
     for (int64_t other_g = 0; other_g < group_id_mapping.length; ++other_g, ++g) {


### PR DESCRIPTION
### Rationale for this change

When merging two aggregate states we were failing to use the correct `no_nulls` field.  This field tells us whether we should return `null` if `skip_nulls=False` (if `no_nulls` is false then we return null).

Since we were reading the wrong field we would sometimes emit null even when a column didn't actually have any nulls.

### What changes are included in this PR?

Fixed the bug.

### Are these changes tested?

Yes, I added a new unit test that reproduced this failure quite reliably.

### Are there any user-facing changes?

No.
* Closes: #36053