### PR TITLE
GH-35053: [Java] Fix MemoryUtil to support Java 21

### DIFF
--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/MemoryUtil.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/MemoryUtil.java
@@ -54,6 +54,10 @@ public class MemoryUtil {
    */
   public static final boolean LITTLE_ENDIAN = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN;
 
+  // Java 1.8, 9, 11, 17, 21 becomes 1, 9, 11, 17, and 21.
+  private static final int majorVersion =
+      Integer.parseInt(System.getProperty("java.specification.version").split("\\D+")[0]);
+
   static {
     try {
       // try to get the unsafe object
@@ -94,7 +98,8 @@ public class MemoryUtil {
               @Override
               public Object run() {
                 try {
-                  final Constructor<?> constructor =
+                  final Constructor<?> constructor = (majorVersion >= 21) ?
+                      direct.getClass().getDeclaredConstructor(long.class, long.class) :
                       direct.getClass().getDeclaredConstructor(long.class, int.class);
                   constructor.setAccessible(true);
                   logger.debug("Constructor for direct buffer found and made accessible");


### PR DESCRIPTION
### Rationale for this change

Java 21 switched `DirectByteBuffer(long,int)` constructor to `DirectByteBuffer(long,long)` via https://github.com/openjdk/jdk/commit/a56598f5a534cc9223367e7faa8433ea38661db9
 
### What changes are included in this PR?
In order to avoid `NoSuchMethodException` error in Java 21 environment, this PR aims to choose one of constructors based on the Java version like https://github.com/netty/netty/pull/13366 .
 
### Are these changes tested?

```
$ java -version
openjdk version "21-ea" 2023-09-19
OpenJDK Runtime Environment (build 21-ea+28-2377)
OpenJDK 64-Bit Server VM (build 21-ea+28-2377, mixed mode, sharing)

$ cd java

$ mvn clean package --am --pl memory/memory-core
...
[INFO] Apache Arrow Java Root POM ......................... SUCCESS [  5.693 s]
[INFO] Arrow Memory ....................................... SUCCESS [  1.703 s]
[INFO] Arrow Memory - Core ................................ SUCCESS [  7.050 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  14.630 s
[INFO] Finished at: 2023-06-28T20:43:29-07:00
[INFO] ------------------------------------------------------------------------
```

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #35053