### PR TITLE
GH-36352: [Python] Add project_id to GcsFileSystem options

### DIFF
--- a/python/pyarrow/_gcsfs.pyx
+++ b/python/pyarrow/_gcsfs.pyx
@@ -183,7 +183,7 @@ cdef class GcsFileSystem(FileSystem):
                     opts.default_bucket_location),
                 default_metadata=pyarrow_wrap_metadata(opts.default_metadata),
                 retry_time_limit=retry_time_limit,
-                project_id=from_bytes(opts.project_id)
+                project_id=frombytes(opts.project_id.value())
             ),))
 
     @property
@@ -198,4 +198,4 @@ cdef class GcsFileSystem(FileSystem):
         """
         The GCP project id this filesystem will use.
         """
-        return frombytes(self.gcsfs.options().project_id)
+        return frombytes(self.gcsfs.options().project_id.value())

--- a/python/pyarrow/_gcsfs.pyx
+++ b/python/pyarrow/_gcsfs.pyx
@@ -141,7 +141,7 @@ cdef class GcsFileSystem(FileSystem):
             time_limit_seconds = retry_time_limit.total_seconds()
             options.retry_limit_seconds = time_limit_seconds
         if project_id is not None:
-            options.project_id = tobytes(project_id)
+            options.project_id = <c_string>tobytes(project_id)
 
         with nogil:
             wrapped = GetResultValue(CGcsFileSystem.Make(options))

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -225,7 +225,7 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         c_string endpoint_override
         c_string scheme
         c_string default_bucket_location
-        c_string project_id
+        optional[c_string] project_id
         optional[double] retry_limit_seconds
         shared_ptr[const CKeyValueMetadata] default_metadata
         c_bool Equals(const CS3Options& other)

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -225,6 +225,7 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         c_string endpoint_override
         c_string scheme
         c_string default_bucket_location
+        c_string project_id
         optional[double] retry_limit_seconds
         shared_ptr[const CKeyValueMetadata] default_metadata
         c_bool Equals(const CS3Options& other)

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -1085,12 +1085,6 @@ def test_gcs_options():
     assert isinstance(fs, GcsFileSystem)
     assert pickle.loads(pickle.dumps(fs)) == fs
 
-    with changed_environ('GOOGLE_CLOUD_PROJECT', 'test-project-id-env'):
-        fs = GcsFileSystem()
-        assert isinstance(fs, GcsFileSystem)
-        assert fs.project_id == 'test-project-id-env'
-        assert pickle.loads(pickle.dumps(fs)) == fs
-
     with pytest.raises(ValueError):
         GcsFileSystem(access_token='access')
     with pytest.raises(ValueError):
@@ -1485,7 +1479,7 @@ def test_filesystem_from_uri_gcs(gcs_server):
 
     uri = ("gs://anonymous@" +
            f"mybucket/foo/bar?scheme=http&endpoint_override={host}:{port}&" +
-           "retry_limit_seconds=5")
+           "retry_limit_seconds=5&project_id=test-project-id")
 
     fs, path = FileSystem.from_uri(uri)
     assert isinstance(fs, GcsFileSystem)

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -27,7 +27,7 @@ import weakref
 import pyarrow as pa
 from pyarrow.tests.test_io import assert_file_not_found
 from pyarrow.tests.util import (_filesystem_uri, ProxyHandler,
-                                _configure_s3_limited_user, changed_environ)
+                                _configure_s3_limited_user)
 
 from pyarrow.fs import (FileType, FileInfo, FileSelector, FileSystem,
                         LocalFileSystem, SubTreeFileSystem, _MockFileSystem,


### PR DESCRIPTION
### Rationale for this change
Some of our Python CI tests for GCS are failing due to the new project_id option added for GcsFileSystem here: https://github.com/apache/arrow/pull/36228

### What changes are included in this PR?

Added option

### Are these changes tested?

Will be tested on CI.

### Are there any user-facing changes?

Yes, there is a new project_id option when defining a GcsFileSystem.
* Closes: #36352