### PR TITLE
GH-36173: [C++] Add lone high and low code-point test case for UTF8StringToUTF16

### DIFF
--- a/cpp/src/arrow/util/utf8.cc
+++ b/cpp/src/arrow/util/utf8.cc
@@ -176,7 +176,7 @@ ARROW_EXPORT Result<std::string> WideStringToUTF8(const std::wstring& source) {
   }
 }
 
-ARROW_EXPORT Result<std::string> UTF16StringToUTF8(const std::u16string& source) {
+Result<std::string> UTF16StringToUTF8(const std::u16string& source) {
   try {
     return UTF16StringToUTF8Internal(source);
   } catch (std::exception& e) {
@@ -184,7 +184,7 @@ ARROW_EXPORT Result<std::string> UTF16StringToUTF8(const std::u16string& source)
   }
 }
 
-ARROW_EXPORT Result<std::u16string> UTF8StringToUTF16(const std::string& source) {
+Result<std::u16string> UTF8StringToUTF16(const std::string& source) {
   try {
     return UTF8StringToUTF16Internal(source);
   } catch (std::exception& e) {

--- a/cpp/src/arrow/util/utf8_util_test.cc
+++ b/cpp/src/arrow/util/utf8_util_test.cc
@@ -416,6 +416,13 @@ TEST(UTF8StringToUTF16, Basics) {
 
   CheckInvalid("\xff");
   CheckInvalid("h\xc3");
+
+  // maps to lone high surrogate pair
+  CheckInvalid("\xed\xa0\x80");
+
+  // maps to lone low surrogate pair
+  CheckInvalid("\xed\0xb0\x81");
+
 }
 
 TEST(UTF16StringToUTF8, Basics) {

--- a/cpp/src/arrow/util/utf8_util_test.cc
+++ b/cpp/src/arrow/util/utf8_util_test.cc
@@ -417,12 +417,11 @@ TEST(UTF8StringToUTF16, Basics) {
   CheckInvalid("\xff");
   CheckInvalid("h\xc3");
 
-  // maps to lone high surrogate pair
+  // lone high-code point
   CheckInvalid("\xed\xa0\x80");
 
-  // maps to lone low surrogate pair
+  // lone low-code point
   CheckInvalid("\xed\0xb0\x81");
-
 }
 
 TEST(UTF16StringToUTF8, Basics) {

--- a/cpp/src/arrow/util/utf8_util_test.cc
+++ b/cpp/src/arrow/util/utf8_util_test.cc
@@ -421,7 +421,7 @@ TEST(UTF8StringToUTF16, Basics) {
   CheckInvalid("\xed\xa0\x80");
 
   // lone low-code point
-  CheckInvalid("\xed\0xb0\x81");
+  CheckInvalid("\xed\xb0\x81");
 }
 
 TEST(UTF16StringToUTF8, Basics) {


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

This is a followup PR to #36167 that addresses feedback left after the PR was merged.

### What changes are included in this PR?

1. Added a test point verifying `UTF8StringToUTF16` returns an `Invalid` status if given a UTF-8 encoded string that contains a lone high or low code point.
2. Removed `ARROW_EXPORT` from definitions of `UTF8StringToUTF16` and `UTF16StringToUTF18`.


### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* Closes: #36173