### PR TITLE
GH-36349: [Python][CI] Avoid using 'build/etc/localtime' timezone in hypothesis tests

### DIFF
--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -1069,6 +1069,8 @@ class TestConvertDateTimeLikeTypes:
     @h.given(st.none() | past.timezones)
     @h.settings(deadline=None)
     def test_python_datetime_with_pytz_timezone(self, tz):
+        if str(tz) == "build/etc/localtime":
+            pytest.skip("Localtime timezone not supported")
         values = [datetime(2018, 1, 1, 12, 23, 45, tzinfo=tz)]
         df = pd.DataFrame({'datetime': values})
         _check_pandas_roundtrip(df, check_dtype=False)


### PR DESCRIPTION
### What changes are included in this PR?

Skip the test if the timezone is `zoneinfo.ZoneInfo(key='build/etc/localtime')`, because we don't support roundtripping such a timezone

* Closes: #36349