### PR TITLE
GH-35636: [C++] Extract two expensive test suites from compute-vector-test

### DIFF
--- a/cpp/src/arrow/compute/kernels/CMakeLists.txt
+++ b/cpp/src/arrow/compute/kernels/CMakeLists.txt
@@ -72,9 +72,13 @@ add_arrow_compute_test(vector_test
                        vector_hash_test.cc
                        vector_nested_test.cc
                        vector_replace_test.cc
-                       vector_sort_test.cc
                        vector_run_end_encode_test.cc
                        select_k_test.cc
+                       test_util.cc)
+
+add_arrow_compute_test(vector_sort_test
+                       SOURCES
+                       vector_sort_test.cc
                        test_util.cc)
 
 add_arrow_compute_test(vector_selection_test

--- a/cpp/src/arrow/compute/kernels/CMakeLists.txt
+++ b/cpp/src/arrow/compute/kernels/CMakeLists.txt
@@ -76,14 +76,9 @@ add_arrow_compute_test(vector_test
                        select_k_test.cc
                        test_util.cc)
 
-add_arrow_compute_test(vector_sort_test
-                       SOURCES
-                       vector_sort_test.cc
-                       test_util.cc)
+add_arrow_compute_test(vector_sort_test SOURCES vector_sort_test.cc test_util.cc)
 
-add_arrow_compute_test(vector_selection_test
-                       SOURCES
-                       vector_selection_test.cc
+add_arrow_compute_test(vector_selection_test SOURCES vector_selection_test.cc
                        test_util.cc)
 
 add_arrow_benchmark(vector_hash_benchmark PREFIX "arrow-compute")

--- a/cpp/src/arrow/compute/kernels/CMakeLists.txt
+++ b/cpp/src/arrow/compute/kernels/CMakeLists.txt
@@ -72,10 +72,14 @@ add_arrow_compute_test(vector_test
                        vector_hash_test.cc
                        vector_nested_test.cc
                        vector_replace_test.cc
-                       vector_selection_test.cc
                        vector_sort_test.cc
                        vector_run_end_encode_test.cc
                        select_k_test.cc
+                       test_util.cc)
+
+add_arrow_compute_test(vector_selection_test
+                       SOURCES
+                       vector_selection_test.cc
                        test_util.cc)
 
 add_arrow_benchmark(vector_hash_benchmark PREFIX "arrow-compute")


### PR DESCRIPTION
### Rationale for this change

`arrow-compute-vector-test` is too big and takes a long time to run because of that.

### What changes are included in this PR?

Extracting two tests.

Timings on my machine (Debug builds with ASAN).

```
debug/arrow-compute-vector-test > /dev/null  11.54s user 0.47s system 99% cpu 12.023 total
debug/arrow-compute-vector-sort-test > /dev/null  13.30s user 0.26s system 99% cpu 13.579 total
debug/arrow-compute-vector-selection-test > /dev/null  6.97s user 0.22s system 99% cpu 7.207 total
```

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* Closes: #35636