### PR TITLE
GH-36402: [CI][macOS] Ignore `brew update` failure

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -186,7 +186,7 @@ jobs:
           rm -f /usr/local/bin/pydoc3* || :
           rm -f /usr/local/bin/python3* || :
           rm -f /usr/local/bin/python3-config || :
-          brew update --preinstall
+          brew update --preinstall || :
           brew bundle --file=cpp/Brewfile
       - name: Install MinIO
         run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -170,7 +170,7 @@ jobs:
           rm -f /usr/local/bin/pydoc3* || :
           rm -f /usr/local/bin/python3* || :
           rm -f /usr/local/bin/python3-config || :
-          brew update --preinstall
+          brew update --preinstall || :
           brew install --overwrite git
           brew bundle --file=cpp/Brewfile
           brew install coreutils

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -151,7 +151,7 @@ jobs:
           rm -f /usr/local/bin/pydoc3* || :
           rm -f /usr/local/bin/python3* || :
           rm -f /usr/local/bin/python3-config || :
-          brew update --preinstall
+          brew update --preinstall || :
           brew install --overwrite git
           brew bundle --file=cpp/Brewfile
           brew bundle --file=c_glib/Brewfile


### PR DESCRIPTION
### Rationale for this change

It's better that we always use the latest Homebrew formulae but it sometimes fails. It's better that we run our tests with old Homebrew formulae than our CI jobs entirely failed.

### What changes are included in this PR?

Ignore `brew update` failure.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #36402