### PR TITLE
GH-29705: [Python] Clean-up no-longer-used pandas dataframe serialization helpers

### DIFF
--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -673,54 +673,7 @@ def get_datetimetz_type(values, dtype, type_):
     return values, type_
 
 # ----------------------------------------------------------------------
-# Converting pandas.DataFrame to a dict containing only NumPy arrays or other
-# objects friendly to pyarrow.serialize
-
-
-def dataframe_to_serialized_dict(frame):
-    block_manager = frame._data
-
-    blocks = []
-    axes = [ax for ax in block_manager.axes]
-
-    for block in block_manager.blocks:
-        values = block.values
-        block_data = {}
-
-        if _pandas_api.is_datetimetz(values.dtype):
-            block_data['timezone'] = pa.lib.tzinfo_to_string(values.tz)
-            if hasattr(values, 'values'):
-                values = values.values
-        elif _pandas_api.is_categorical(values):
-            block_data.update(dictionary=values.categories,
-                              ordered=values.ordered)
-            values = values.codes
-        block_data.update(
-            placement=block.mgr_locs.as_array,
-            block=values
-        )
-
-        # If we are dealing with an object array, pickle it instead.
-        if values.dtype == np.dtype(object):
-            block_data['object'] = None
-            block_data['block'] = builtin_pickle.dumps(
-                values, protocol=builtin_pickle.HIGHEST_PROTOCOL)
-
-        blocks.append(block_data)
-
-    return {
-        'blocks': blocks,
-        'axes': axes
-    }
-
-
-def serialized_dict_to_dataframe(data):
-    import pandas.core.internals as _int
-    reconstructed_blocks = [_reconstruct_block(block)
-                            for block in data['blocks']]
-
-    block_mgr = _int.BlockManager(reconstructed_blocks, data['axes'])
-    return _pandas_api.data_frame(block_mgr)
+# Converting pyarrow.Table efficiently to pandas.DataFrame
 
 
 def _reconstruct_block(item, columns=None, extension_columns=None):
@@ -788,10 +741,6 @@ def _reconstruct_block(item, columns=None, extension_columns=None):
 def make_datetimetz(tz):
     tz = pa.lib.string_to_tzinfo(tz)
     return _pandas_api.datetimetz_type('ns', tz=tz)
-
-
-# ----------------------------------------------------------------------
-# Converting pyarrow.Table efficiently to pandas.DataFrame
 
 
 def table_to_blockmanager(options, table, categories=None,


### PR DESCRIPTION
Small follow-up on https://github.com/apache/arrow/pull/34926, which removed the `pyarrow.serialization` functionality, making those functions obsolete.

* Closes: #29705