### PR TITLE
GH-36414: [C++] Add missing type_traits.h predicate: is_var_length_list() 

### DIFF
--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -404,7 +404,7 @@ class RecordBatchSerializer {
   }
 
   template <typename T>
-  enable_if_base_list<typename T::TypeClass, Status> Visit(const T& array) {
+  enable_if_var_size_list<typename T::TypeClass, Status> Visit(const T& array) {
     using offset_type = typename T::offset_type;
 
     std::shared_ptr<Buffer> value_offsets;

--- a/cpp/src/arrow/testing/json_internal.cc
+++ b/cpp/src/arrow/testing/json_internal.cc
@@ -227,7 +227,7 @@ class SchemaWriter {
 
   template <typename T>
   enable_if_t<is_null_type<T>::value || is_primitive_ctype<T>::value ||
-              is_base_binary_type<T>::value || is_base_list_type<T>::value ||
+              is_base_binary_type<T>::value || is_var_length_list_type<T>::value ||
               is_struct_type<T>::value || is_run_end_encoded_type<T>::value>
   WriteTypeMetadata(const T& type) {}
 

--- a/cpp/src/arrow/testing/random_test.cc
+++ b/cpp/src/arrow/testing/random_test.cc
@@ -70,7 +70,7 @@ class RandomArrayTest : public ::testing::TestWithParam<RandomTestParam> {
   }
 
   bool HasList(const DataType& type) {
-    if (is_list_like(type.id()) && type.id() != Type::FIXED_SIZE_LIST) {
+    if (is_var_length_list(type.id())) {
       return true;
     }
     for (const auto& child : type.fields()) {

--- a/cpp/src/arrow/type_test.cc
+++ b/cpp/src/arrow/type_test.cc
@@ -1852,6 +1852,7 @@ TEST(TypesTest, TestMembership) {
   TEST_PREDICATE(all_types, is_dictionary);
   TEST_PREDICATE(all_types, is_fixed_size_binary);
   TEST_PREDICATE(all_types, is_fixed_width);
+  TEST_PREDICATE(all_types, is_var_length_list);
   TEST_PREDICATE(all_types, is_list_like);
   TEST_PREDICATE(all_types, is_nested);
   TEST_PREDICATE(all_types, is_union);

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -709,7 +709,7 @@ using enable_if_list_type = enable_if_t<is_list_type<T>::value, R>;
 
 template <typename T>
 using is_list_like_type =
-    std::integral_constant<bool, is_base_list_type<T>::value ||
+    std::integral_constant<bool, is_var_length_list_type<T>::value ||
                                      is_fixed_size_list_type<T>::value>;
 
 template <typename T, typename R = void>

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -1179,6 +1179,22 @@ constexpr bool is_fixed_width(Type::type type_id) {
   return is_primitive(type_id) || is_dictionary(type_id) || is_fixed_size_binary(type_id);
 }
 
+/// \brief Check for a var-length list type
+///
+/// \param[in] type_id the type-id to check
+/// \return whether type-id is a var-length list type one
+constexpr bool is_var_length_list(Type::type type_id) {
+  switch (type_id) {
+    case Type::LIST:
+    case Type::LARGE_LIST:
+    case Type::MAP:
+      return true;
+    default:
+      break;
+  }
+  return false;
+}
+
 /// \brief Check for a list-like type
 ///
 /// \param[in] type_id the type-id to check
@@ -1482,6 +1498,16 @@ static inline bool is_fixed_size_binary(const DataType& type) {
 /// Convenience for checking using the type's id
 static inline bool is_fixed_width(const DataType& type) {
   return is_fixed_width(type.id());
+}
+
+/// \brief Check for a variable-length list type
+///
+/// \param[in] type the type to check
+/// \return whether type is a variable-length list type
+///
+/// Convenience for checking using the type's id
+static inline bool is_var_length_list(const DataType& type) {
+  return is_var_length_list(type.id());
 }
 
 /// \brief Check for a list-like type

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -1179,10 +1179,10 @@ constexpr bool is_fixed_width(Type::type type_id) {
   return is_primitive(type_id) || is_dictionary(type_id) || is_fixed_size_binary(type_id);
 }
 
-/// \brief Check for a var-length list type
+/// \brief Check for a variable-length list type
 ///
 /// \param[in] type_id the type-id to check
-/// \return whether type-id is a var-length list type one
+/// \return whether type-id is a variable-length list type one
 constexpr bool is_var_length_list(Type::type type_id) {
   switch (type_id) {
     case Type::LIST:


### PR DESCRIPTION
### Rationale for this change

`is_var_length_list_type<T>` is missing its `is_var_length_list(type_id)` counterpart.


### What changes are included in this PR?

 - New function
 - Use of `is_var_length_list_type<T>` directly (instead of using deprecated `is_base_list_type<T>`

### Are these changes tested?

Yes.
* Closes: #36414