### PR TITLE
GH-36417: [C++] Add Buffer::data_as, Buffer::mutable_data_as

### DIFF
--- a/cpp/src/arrow/array/array_base.h
+++ b/cpp/src/arrow/array/array_base.h
@@ -106,7 +106,7 @@ class ARROW_EXPORT Array {
   /// \see GetNullCount
   int64_t ComputeLogicalNullCount() const;
 
-  std::shared_ptr<DataType> type() const { return data_->type; }
+  const std::shared_ptr<DataType>& type() const { return data_->type; }
   Type::type type_id() const { return data_->type->id(); }
 
   /// Buffer for the validity (null) bitmap, if any. Note that Union types
@@ -251,7 +251,7 @@ class ARROW_EXPORT PrimitiveArray : public FlatArray {
                  int64_t null_count = kUnknownNullCount, int64_t offset = 0);
 
   /// Does not account for any slice offset
-  std::shared_ptr<Buffer> values() const { return data_->buffers[1]; }
+  const std::shared_ptr<Buffer>& values() const { return data_->buffers[1]; }
 
  protected:
   PrimitiveArray() : raw_values_(NULLPTR) {}

--- a/cpp/src/arrow/array/array_dict.cc
+++ b/cpp/src/arrow/array/array_dict.cc
@@ -108,7 +108,7 @@ DictionaryArray::DictionaryArray(const std::shared_ptr<DataType>& type,
 
 const std::shared_ptr<Array>& DictionaryArray::dictionary() const {
   if (!dictionary_) {
-    // FIXME this isn't thread safe
+    // TODO(GH-36503) this isn't thread safe
     dictionary_ = MakeArray(data_->dictionary);
   }
   return dictionary_;

--- a/cpp/src/arrow/array/array_dict.cc
+++ b/cpp/src/arrow/array/array_dict.cc
@@ -50,7 +50,7 @@ using internal::CopyBitmap;
 // ----------------------------------------------------------------------
 // DictionaryArray
 
-std::shared_ptr<Array> DictionaryArray::indices() const { return indices_; }
+const std::shared_ptr<Array>& DictionaryArray::indices() const { return indices_; }
 
 int64_t DictionaryArray::GetValueIndex(int64_t i) const {
   const uint8_t* indices_data = data_->buffers[1]->data();
@@ -106,8 +106,9 @@ DictionaryArray::DictionaryArray(const std::shared_ptr<DataType>& type,
   SetData(data);
 }
 
-std::shared_ptr<Array> DictionaryArray::dictionary() const {
+const std::shared_ptr<Array>& DictionaryArray::dictionary() const {
   if (!dictionary_) {
+    // FIXME this isn't thread safe
     dictionary_ = MakeArray(data_->dictionary);
   }
   return dictionary_;

--- a/cpp/src/arrow/array/array_dict.h
+++ b/cpp/src/arrow/array/array_dict.h
@@ -101,8 +101,8 @@ class ARROW_EXPORT DictionaryArray : public Array {
 
   /// \brief Return the dictionary for this array, which is stored as
   /// a member of the ArrayData internal structure
-  std::shared_ptr<Array> dictionary() const;
-  std::shared_ptr<Array> indices() const;
+  const std::shared_ptr<Array>& dictionary() const;
+  const std::shared_ptr<Array>& indices() const;
 
   /// \brief Return the ith value of indices, cast to int64_t. Not recommended
   /// for use in performance-sensitive code. Does not validate whether the

--- a/cpp/src/arrow/array/array_nested.cc
+++ b/cpp/src/arrow/array/array_nested.cc
@@ -611,10 +611,9 @@ const std::shared_ptr<Array>& StructArray::field(int i) const {
   return boxed_fields_[i];
 }
 
-const std::shared_ptr<Array>& StructArray::GetFieldByName(const std::string& name) const {
-  static std::shared_ptr<Array> null;
+std::shared_ptr<Array> StructArray::GetFieldByName(const std::string& name) const {
   int i = struct_type()->GetFieldIndex(name);
-  return i == -1 ? null : field(i);
+  return i == -1 ? nullptr : field(i);
 }
 
 Result<ArrayVector> StructArray::Flatten(MemoryPool* pool) const {

--- a/cpp/src/arrow/array/array_nested.cc
+++ b/cpp/src/arrow/array/array_nested.cc
@@ -470,11 +470,11 @@ const FixedSizeListType* FixedSizeListArray::list_type() const {
   return checked_cast<const FixedSizeListType*>(data_->type.get());
 }
 
-std::shared_ptr<DataType> FixedSizeListArray::value_type() const {
+const std::shared_ptr<DataType>& FixedSizeListArray::value_type() const {
   return list_type()->value_type();
 }
 
-std::shared_ptr<Array> FixedSizeListArray::values() const { return values_; }
+const std::shared_ptr<Array>& FixedSizeListArray::values() const { return values_; }
 
 Result<std::shared_ptr<Array>> FixedSizeListArray::FromArrays(
     const std::shared_ptr<Array>& values, int32_t list_size) {
@@ -611,9 +611,10 @@ const std::shared_ptr<Array>& StructArray::field(int i) const {
   return boxed_fields_[i];
 }
 
-std::shared_ptr<Array> StructArray::GetFieldByName(const std::string& name) const {
+const std::shared_ptr<Array>& StructArray::GetFieldByName(const std::string& name) const {
+  static std::shared_ptr<Array> null;
   int i = struct_type()->GetFieldIndex(name);
-  return i == -1 ? nullptr : field(i);
+  return i == -1 ? null : field(i);
 }
 
 Result<ArrayVector> StructArray::Flatten(MemoryPool* pool) const {

--- a/cpp/src/arrow/array/array_nested.h
+++ b/cpp/src/arrow/array/array_nested.h
@@ -402,7 +402,7 @@ class ARROW_EXPORT StructArray : public Array {
   const ArrayVector& fields() const;
 
   /// Returns null if name not found
-  const std::shared_ptr<Array>& GetFieldByName(const std::string& name) const;
+  std::shared_ptr<Array> GetFieldByName(const std::string& name) const;
 
   /// \brief Flatten this array as a vector of arrays, one for each field
   ///

--- a/cpp/src/arrow/array/array_nested.h
+++ b/cpp/src/arrow/array/array_nested.h
@@ -71,12 +71,12 @@ class BaseListArray : public Array {
   /// \brief Return array object containing the list's values
   ///
   /// Note that this buffer does not account for any slice offset or length.
-  std::shared_ptr<Array> values() const { return values_; }
+  const std::shared_ptr<Array>& values() const { return values_; }
 
   /// Note that this buffer does not account for any slice offset or length.
-  std::shared_ptr<Buffer> value_offsets() const { return data_->buffers[1]; }
+  const std::shared_ptr<Buffer>& value_offsets() const { return data_->buffers[1]; }
 
-  std::shared_ptr<DataType> value_type() const { return list_type_->value_type(); }
+  const std::shared_ptr<DataType>& value_type() const { return list_type_->value_type(); }
 
   /// Return pointer to raw value offsets accounting for any slice offset
   const offset_type* raw_value_offsets() const {
@@ -269,10 +269,10 @@ class ARROW_EXPORT MapArray : public ListArray {
   const MapType* map_type() const { return map_type_; }
 
   /// \brief Return array object containing all map keys
-  std::shared_ptr<Array> keys() const { return keys_; }
+  const std::shared_ptr<Array>& keys() const { return keys_; }
 
   /// \brief Return array object containing all mapped items
-  std::shared_ptr<Array> items() const { return items_; }
+  const std::shared_ptr<Array>& items() const { return items_; }
 
   /// Validate child data before constructing the actual MapArray.
   static Status ValidateChildData(
@@ -310,9 +310,9 @@ class ARROW_EXPORT FixedSizeListArray : public Array {
   const FixedSizeListType* list_type() const;
 
   /// \brief Return array object containing the list's values
-  std::shared_ptr<Array> values() const;
+  const std::shared_ptr<Array>& values() const;
 
-  std::shared_ptr<DataType> value_type() const;
+  const std::shared_ptr<DataType>& value_type() const;
 
   // The following functions will not perform boundschecking
   int64_t value_offset(int64_t i) const {
@@ -402,7 +402,7 @@ class ARROW_EXPORT StructArray : public Array {
   const ArrayVector& fields() const;
 
   /// Returns null if name not found
-  std::shared_ptr<Array> GetFieldByName(const std::string& name) const;
+  const std::shared_ptr<Array>& GetFieldByName(const std::string& name) const;
 
   /// \brief Flatten this array as a vector of arrays, one for each field
   ///
@@ -432,7 +432,7 @@ class ARROW_EXPORT UnionArray : public Array {
   using type_code_t = int8_t;
 
   /// Note that this buffer does not account for any slice offset
-  std::shared_ptr<Buffer> type_codes() const { return data_->buffers[1]; }
+  const std::shared_ptr<Buffer>& type_codes() const { return data_->buffers[1]; }
 
   const type_code_t* raw_type_codes() const { return raw_type_codes_ + data_->offset; }
 
@@ -571,7 +571,7 @@ class ARROW_EXPORT DenseUnionArray : public UnionArray {
   }
 
   /// Note that this buffer does not account for any slice offset
-  std::shared_ptr<Buffer> value_offsets() const { return data_->buffers[2]; }
+  const std::shared_ptr<Buffer>& value_offsets() const { return data_->buffers[2]; }
 
   int32_t value_offset(int64_t i) const { return raw_value_offsets_[i + data_->offset]; }
 

--- a/cpp/src/arrow/array/data.h
+++ b/cpp/src/arrow/array/data.h
@@ -360,6 +360,15 @@ struct ARROW_EXPORT BufferSpan {
   int64_t size = 0;
   // Pointer back to buffer that owns this memory
   const std::shared_ptr<Buffer>* owner = NULLPTR;
+
+  template <typename T>
+  const T* data_as() const {
+    return reinterpret_cast<const T*>(data);
+  }
+  template <typename T>
+  T* mutable_data_as() {
+    return reinterpret_cast<T*>(data);
+  }
 };
 
 /// \brief EXPERIMENTAL: A non-owning ArrayData reference that is cheaply

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -142,7 +142,7 @@ class ARROW_EXPORT Buffer {
   /// \brief Construct an immutable buffer that takes ownership of the contents
   /// of an std::vector (without copying it).
   ///
-  /// \param[in] data a string to own
+  /// \param[in] vec a vector to own
   /// \return a new Buffer instance
   template <typename T>
   static std::shared_ptr<Buffer> FromVectorOfTrivial(std::vector<T> vec) {

--- a/cpp/src/arrow/buffer_builder.h
+++ b/cpp/src/arrow/buffer_builder.h
@@ -204,11 +204,11 @@ class ARROW_EXPORT BufferBuilder {
   uint8_t* mutable_data() { return data_; }
   template <typename T>
   const T* data_as() const {
-    return reinterpret_cast<const T*>(data());
+    return reinterpret_cast<const T*>(data_);
   }
   template <typename T>
   T* mutable_data_as() {
-    return reinterpret_cast<T*>(mutable_data());
+    return reinterpret_cast<T*>(data_);
   }
 
  private:

--- a/cpp/src/arrow/buffer_builder.h
+++ b/cpp/src/arrow/buffer_builder.h
@@ -118,6 +118,11 @@ class ARROW_EXPORT BufferBuilder {
     return Status::OK();
   }
 
+  /// \brief Append the given data to the buffer
+  ///
+  /// The buffer is automatically expanded if necessary.
+  Status Append(std::string_view v) { return Append(v.data(), v.size()); }
+
   /// \brief Append copies of a value to the buffer
   ///
   /// The buffer is automatically expanded if necessary.
@@ -138,6 +143,7 @@ class ARROW_EXPORT BufferBuilder {
     memcpy(data_ + size_, data, static_cast<size_t>(length));
     size_ += length;
   }
+  void UnsafeAppend(std::string_view v) { UnsafeAppend(v.data(), v.size()); }
 
   void UnsafeAppend(const int64_t num_copies, uint8_t value) {
     memset(data_ + size_, value, static_cast<size_t>(num_copies));
@@ -196,6 +202,14 @@ class ARROW_EXPORT BufferBuilder {
   int64_t length() const { return size_; }
   const uint8_t* data() const { return data_; }
   uint8_t* mutable_data() { return data_; }
+  template <typename T>
+  const T* data_as() const {
+    return reinterpret_cast<const T*>(data());
+  }
+  template <typename T>
+  T* mutable_data_as() {
+    return reinterpret_cast<T*>(mutable_data());
+  }
 
  private:
   std::shared_ptr<ResizableBuffer> buffer_;

--- a/cpp/src/arrow/compute/kernels/hash_aggregate.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate.cc
@@ -915,7 +915,7 @@ struct GroupedVarStdImpl : public GroupedAggregator {
     ARROW_ASSIGN_OR_RAISE(auto mapping,
                           AllocateBuffer(num_groups_ * sizeof(uint32_t), pool_));
     for (uint32_t i = 0; static_cast<int64_t>(i) < num_groups_; i++) {
-      mapping->mutable_data_as<uint32_t>()[i] = i;
+      mapping->template mutable_data_as<uint32_t>()[i] = i;
     }
     ArrayData group_id_mapping(uint32(), num_groups_, {nullptr, std::move(mapping)},
                                /*null_count=*/0);
@@ -946,7 +946,7 @@ struct GroupedVarStdImpl : public GroupedAggregator {
     ARROW_ASSIGN_OR_RAISE(auto mapping,
                           AllocateBuffer(num_groups_ * sizeof(uint32_t), pool_));
     for (uint32_t i = 0; static_cast<int64_t>(i) < num_groups_; i++) {
-      mapping->mutable_data_as<uint32_t>()[i] = i;
+      mapping->template mutable_data_as<uint32_t>()[i] = i;
     }
     ArrayData group_id_mapping(uint32(), num_groups_, {nullptr, std::move(mapping)},
                                /*null_count=*/0);

--- a/cpp/src/arrow/compute/kernels/hash_aggregate.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate.cc
@@ -246,10 +246,10 @@ struct GroupedCountAllImpl : public GroupedAggregator {
                const ArrayData& group_id_mapping) override {
     auto other = checked_cast<GroupedCountAllImpl*>(&raw_other);
 
-    auto counts = reinterpret_cast<int64_t*>(counts_.mutable_data());
-    auto other_counts = reinterpret_cast<const int64_t*>(other->counts_.data());
+    auto* counts = counts_.mutable_data_as<int64_t>();
+    const auto* other_counts = other->counts_.data_as<int64_t>();
 
-    auto g = group_id_mapping.GetValues<uint32_t>(1);
+    auto g = group_id_mapping.buffers[1]->data_as<uint32_t>();
     for (int64_t other_g = 0; other_g < group_id_mapping.length; ++other_g, ++g) {
       counts[*g] += other_counts[other_g];
     }
@@ -257,8 +257,8 @@ struct GroupedCountAllImpl : public GroupedAggregator {
   }
 
   Status Consume(const ExecSpan& batch) override {
-    auto counts = reinterpret_cast<int64_t*>(counts_.mutable_data());
-    auto g_begin = batch[0].array.GetValues<uint32_t>(1);
+    auto* counts = counts_.mutable_data_as<int64_t>();
+    const auto* g_begin = batch[0].array.buffers[1].data_as<uint32_t>();
     for (auto g_itr = g_begin, end = g_itr + batch.length; g_itr != end; g_itr++) {
       counts[*g_itr] += 1;
     }
@@ -293,10 +293,10 @@ struct GroupedCountImpl : public GroupedAggregator {
                const ArrayData& group_id_mapping) override {
     auto other = checked_cast<GroupedCountImpl*>(&raw_other);
 
-    auto counts = reinterpret_cast<int64_t*>(counts_.mutable_data());
-    auto other_counts = reinterpret_cast<const int64_t*>(other->counts_.mutable_data());
+    auto* counts = counts_.mutable_data_as<int64_t>();
+    const auto* other_counts = other->counts_.data_as<int64_t>();
 
-    auto g = group_id_mapping.GetValues<uint32_t>(1);
+    const auto* g = group_id_mapping.buffers[1]->data_as<uint32_t>();
     for (int64_t other_g = 0; other_g < group_id_mapping.length; ++other_g, ++g) {
       counts[*g] += other_counts[other_g];
     }
@@ -344,8 +344,8 @@ struct GroupedCountImpl : public GroupedAggregator {
   };
 
   Status Consume(const ExecSpan& batch) override {
-    auto counts = reinterpret_cast<int64_t*>(counts_.mutable_data());
-    auto g_begin = batch[1].array.GetValues<uint32_t>(1);
+    auto* counts = counts_.mutable_data_as<int64_t>();
+    const auto* g_begin = batch[1].array.buffers[1].data_as<uint32_t>();
 
     if (options_.mode == CountOptions::ALL) {
       for (int64_t i = 0; i < batch.length; ++i, ++g_begin) {
@@ -682,7 +682,7 @@ struct GroupedSumNullImpl final : public GroupedNullImpl {
   std::shared_ptr<DataType> out_type() const override { return int64(); }
 
   void output_empty(const std::shared_ptr<Buffer>& data) override {
-    std::fill_n(reinterpret_cast<int64_t*>(data->mutable_data()), num_groups_, 0);
+    std::fill_n(data->mutable_data_as<int64_t>(), num_groups_, 0);
   }
 };
 
@@ -722,7 +722,7 @@ struct GroupedProductNullImpl final : public GroupedNullImpl {
   std::shared_ptr<DataType> out_type() const override { return int64(); }
 
   void output_empty(const std::shared_ptr<Buffer>& data) override {
-    std::fill_n(reinterpret_cast<int64_t*>(data->mutable_data()), num_groups_, 1);
+    std::fill_n(data->mutable_data_as<int64_t>(), num_groups_, 1);
   }
 };
 
@@ -785,7 +785,7 @@ struct GroupedMeanImpl : public GroupedReducingAggregator<Type, GroupedMeanImpl<
     const CType* reduced = reduced_->data();
     ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Buffer> values,
                           AllocateBuffer(num_groups * sizeof(MeanType), pool));
-    MeanType* means = reinterpret_cast<MeanType*>(values->mutable_data());
+    auto* means = values->mutable_data_as<MeanType>();
     for (int64_t i = 0; i < num_groups; ++i) {
       if (counts[i] >= options.min_count) {
         ARROW_ASSIGN_OR_RAISE(means[i], DoMean(reduced[i], counts[i]));
@@ -814,7 +814,7 @@ struct GroupedMeanNullImpl final : public GroupedNullImpl {
   std::shared_ptr<DataType> out_type() const override { return float64(); }
 
   void output_empty(const std::shared_ptr<Buffer>& data) override {
-    std::fill_n(reinterpret_cast<double*>(data->mutable_data()), num_groups_, 0);
+    std::fill_n(data->mutable_data_as<double>(), num_groups_, 0);
   }
 };
 
@@ -915,7 +915,7 @@ struct GroupedVarStdImpl : public GroupedAggregator {
     ARROW_ASSIGN_OR_RAISE(auto mapping,
                           AllocateBuffer(num_groups_ * sizeof(uint32_t), pool_));
     for (uint32_t i = 0; static_cast<int64_t>(i) < num_groups_; i++) {
-      reinterpret_cast<uint32_t*>(mapping->mutable_data())[i] = i;
+      mapping->mutable_data_as<uint32_t>()[i] = i;
     }
     ArrayData group_id_mapping(uint32(), num_groups_, {nullptr, std::move(mapping)},
                                /*null_count=*/0);
@@ -946,7 +946,7 @@ struct GroupedVarStdImpl : public GroupedAggregator {
     ARROW_ASSIGN_OR_RAISE(auto mapping,
                           AllocateBuffer(num_groups_ * sizeof(uint32_t), pool_));
     for (uint32_t i = 0; static_cast<int64_t>(i) < num_groups_; i++) {
-      reinterpret_cast<uint32_t*>(mapping->mutable_data())[i] = i;
+      mapping->mutable_data_as<uint32_t>()[i] = i;
     }
     ArrayData group_id_mapping(uint32(), num_groups_, {nullptr, std::move(mapping)},
                                /*null_count=*/0);
@@ -1049,7 +1049,7 @@ struct GroupedVarStdImpl : public GroupedAggregator {
                           AllocateBuffer(num_groups_ * sizeof(double), pool_));
     int64_t null_count = 0;
 
-    double* results = reinterpret_cast<double*>(values->mutable_data());
+    auto* results = values->mutable_data_as<double>();
     const int64_t* counts = counts_.data();
     const double* m2s = m2s_.data();
     for (int64_t i = 0; i < num_groups_; ++i) {
@@ -1223,7 +1223,7 @@ struct GroupedTDigestImpl : public GroupedAggregator {
                           AllocateBuffer(num_values * sizeof(double), pool_));
     int64_t null_count = 0;
 
-    double* results = reinterpret_cast<double*>(values->mutable_data());
+    auto* results = values->mutable_data_as<double>();
     for (int64_t i = 0; static_cast<size_t>(i) < tdigests_.size(); ++i) {
       if (!tdigests_[i].is_empty() && counts[i] >= options_.min_count &&
           (options_.skip_nulls || bit_util::GetBit(no_nulls_.data(), i))) {
@@ -1567,7 +1567,7 @@ struct GroupedMinMaxImpl<Type,
     ARROW_ASSIGN_OR_RAISE(
         auto raw_offsets,
         AllocateBuffer((1 + values.size()) * sizeof(offset_type), ctx_->memory_pool()));
-    offset_type* offsets = reinterpret_cast<offset_type*>(raw_offsets->mutable_data());
+    auto* offsets = raw_offsets->mutable_data_as<offset_type>();
     offsets[0] = 0;
     offsets++;
     const uint8_t* null_bitmap = array->buffers[0]->data();
@@ -2100,7 +2100,7 @@ struct GroupedFirstLastImpl<Type,
     ARROW_ASSIGN_OR_RAISE(
         auto raw_offsets,
         AllocateBuffer((1 + values.size()) * sizeof(offset_type), ctx_->memory_pool()));
-    offset_type* offsets = reinterpret_cast<offset_type*>(raw_offsets->mutable_data());
+    auto* offsets = raw_offsets->mutable_data_as<offset_type>();
     offsets[0] = 0;
     offsets++;
     const uint8_t* null_bitmap = array->buffers[0]->data();
@@ -2464,9 +2464,9 @@ struct GroupedCountDistinctImpl : public GroupedAggregator {
     ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Buffer> remapped_g,
                           AllocateBuffer(uniques.length * sizeof(uint32_t), pool_));
 
-    const auto* g_mapping = group_id_mapping.GetValues<uint32_t>(1);
-    const auto* other_g = uniques[1].array()->GetValues<uint32_t>(1);
-    auto* g = reinterpret_cast<uint32_t*>(remapped_g->mutable_data());
+    const auto* g_mapping = group_id_mapping.buffers[1]->data_as<uint32_t>();
+    const auto* other_g = uniques[1].array()->buffers[1]->data_as<uint32_t>();
+    auto* g = remapped_g->mutable_data_as<uint32_t>();
 
     for (int64_t i = 0; i < uniques.length; i++) {
       g[i] = g_mapping[other_g[i]];
@@ -2480,7 +2480,7 @@ struct GroupedCountDistinctImpl : public GroupedAggregator {
   Result<Datum> Finalize() override {
     ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Buffer> values,
                           AllocateBuffer(num_groups_ * sizeof(int64_t), pool_));
-    int64_t* counts = reinterpret_cast<int64_t*>(values->mutable_data());
+    auto* counts = values->mutable_data_as<int64_t>();
     std::fill(counts, counts + num_groups_, 0);
 
     ARROW_ASSIGN_OR_RAISE(auto uniques, grouper_->GetUniques());
@@ -2524,9 +2524,9 @@ struct GroupedDistinctImpl : public GroupedCountDistinctImpl {
                                               static_cast<uint32_t>(num_groups_), ctx_));
     ARROW_ASSIGN_OR_RAISE(
         auto list, grouper_->ApplyGroupings(*groupings, *uniques[0].make_array(), ctx_));
-    auto values = list->values();
+    const auto& values = list->values();
     DCHECK_EQ(values->offset(), 0);
-    int32_t* offsets = reinterpret_cast<int32_t*>(list->value_offsets()->mutable_data());
+    auto* offsets = list->value_offsets()->mutable_data_as<int32_t>();
     if (options_.mode == CountOptions::ALL ||
         (options_.mode == CountOptions::ONLY_VALID && values->null_count() == 0)) {
       return list;
@@ -2754,7 +2754,7 @@ struct GroupedOneImpl<Type, enable_if_t<is_base_binary_type<Type>::value ||
     ARROW_ASSIGN_OR_RAISE(
         auto raw_offsets,
         AllocateBuffer((1 + values.size()) * sizeof(offset_type), ctx_->memory_pool()));
-    auto* offsets = reinterpret_cast<offset_type*>(raw_offsets->mutable_data());
+    auto* offsets = raw_offsets->mutable_data_as<offset_type>();
     offsets[0] = 0;
     offsets++;
     const uint8_t* null_bitmap = array->buffers[0]->data();
@@ -2952,7 +2952,7 @@ struct GroupedListImpl final : public GroupedAggregator {
       RETURN_NOT_OK(groups_.Append(g[other_raw_groups[other_g]]));
     }
 
-    const uint8_t* values = reinterpret_cast<const uint8_t*>(other->values_.data());
+    const auto* values = reinterpret_cast<const uint8_t*>(other->values_.data());
     RETURN_NOT_OK(GetSet::AppendBuffers(&values_, values, 0, other->num_args_));
 
     if (other->has_nulls_) {
@@ -3093,7 +3093,7 @@ struct GroupedListImpl<Type, enable_if_t<is_base_binary_type<Type>::value ||
     ARROW_ASSIGN_OR_RAISE(
         auto raw_offsets,
         AllocateBuffer((1 + values.size()) * sizeof(offset_type), ctx_->memory_pool()));
-    auto* offsets = reinterpret_cast<offset_type*>(raw_offsets->mutable_data());
+    auto* offsets = raw_offsets->mutable_data_as<offset_type>();
     offsets[0] = 0;
     offsets++;
     const uint8_t* null_bitmap = array->buffers[0]->data();

--- a/cpp/src/arrow/compute/kernels/hash_aggregate.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate.cc
@@ -249,7 +249,7 @@ struct GroupedCountAllImpl : public GroupedAggregator {
     auto* counts = counts_.mutable_data_as<int64_t>();
     const auto* other_counts = other->counts_.data_as<int64_t>();
 
-    auto g = group_id_mapping.buffers[1]->data_as<uint32_t>();
+    auto* g = group_id_mapping.GetValues<uint32_t>(1);
     for (int64_t other_g = 0; other_g < group_id_mapping.length; ++other_g, ++g) {
       counts[*g] += other_counts[other_g];
     }
@@ -258,7 +258,7 @@ struct GroupedCountAllImpl : public GroupedAggregator {
 
   Status Consume(const ExecSpan& batch) override {
     auto* counts = counts_.mutable_data_as<int64_t>();
-    const auto* g_begin = batch[0].array.buffers[1].data_as<uint32_t>();
+    auto* g_begin = batch[0].array.GetValues<uint32_t>(1);
     for (auto g_itr = g_begin, end = g_itr + batch.length; g_itr != end; g_itr++) {
       counts[*g_itr] += 1;
     }
@@ -296,7 +296,7 @@ struct GroupedCountImpl : public GroupedAggregator {
     auto* counts = counts_.mutable_data_as<int64_t>();
     const auto* other_counts = other->counts_.data_as<int64_t>();
 
-    const auto* g = group_id_mapping.buffers[1]->data_as<uint32_t>();
+    auto* g = group_id_mapping.GetValues<uint32_t>(1);
     for (int64_t other_g = 0; other_g < group_id_mapping.length; ++other_g, ++g) {
       counts[*g] += other_counts[other_g];
     }
@@ -345,7 +345,7 @@ struct GroupedCountImpl : public GroupedAggregator {
 
   Status Consume(const ExecSpan& batch) override {
     auto* counts = counts_.mutable_data_as<int64_t>();
-    const auto* g_begin = batch[1].array.buffers[1].data_as<uint32_t>();
+    auto* g_begin = batch[1].array.GetValues<uint32_t>(1);
 
     if (options_.mode == CountOptions::ALL) {
       for (int64_t i = 0; i < batch.length; ++i, ++g_begin) {
@@ -932,7 +932,7 @@ struct GroupedVarStdImpl : public GroupedAggregator {
     // for int32: -2^62 <= sum < 2^62
     constexpr int64_t max_length = 1ULL << (63 - sizeof(CType) * 8);
 
-    const auto g = batch[1].array.GetValues<uint32_t>(1);
+    const auto* g = batch[1].array.GetValues<uint32_t>(1);
     if (batch[0].is_scalar() && !batch[0].scalar->is_valid) {
       uint8_t* no_nulls = no_nulls_.mutable_data();
       for (int64_t i = 0; i < batch.length; i++) {

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -922,7 +922,7 @@ class ARROW_EXPORT BaseListType : public NestedType {
   ~BaseListType() override;
   const std::shared_ptr<Field>& value_field() const { return children_[0]; }
 
-  std::shared_ptr<DataType> value_type() const { return children_[0]->type(); }
+  const std::shared_ptr<DataType>& value_type() const { return children_[0]->type(); }
 };
 
 /// \brief Concrete type class for list data


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

There's a lot of boilerplate in casting buffer bytes. A templated accessor will decrease that.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

- `{Buffer, BufferBuilder, BufferSpan}::{data_as<T>, mutable_data_as<T>}`
- rewriting a few files' worth of reinterpret_casts to use these accessors to showcase usage
- `Buffer::FromVector`, a std::vector analog to Buffer::FromString
- some tangential cleanup of unnecessary copies in the Array classes

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Not really. The rewritten files exercise the new accessors

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

No, but I've noticed `Buffer::operator[]` again and that should probably be deprecated.


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #36417