### PR TITLE
GH-36363: [MATLAB] Create proxy classes for the DataType class hierarchy

### DIFF
--- a/matlab/src/cpp/arrow/matlab/array/proxy/timestamp_array.cc
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/timestamp_array.cc
@@ -49,13 +49,14 @@ namespace arrow::matlab::array::proxy {
         const mda::TypedArray<mda::MATLABString> units_mda = opts[0]["TimeUnit"];
 
         // extract the time zone string
-        const std::u16string& u16_timezone = timezone_mda[0];
-        MATLAB_ASSIGN_OR_ERROR(const auto timezone, arrow::util::UTF16StringToUTF8(u16_timezone),
+        const std::u16string& utf16_timezone = timezone_mda[0];
+        MATLAB_ASSIGN_OR_ERROR(const auto timezone, arrow::util::UTF16StringToUTF8(utf16_timezone),
                                error::UNICODE_CONVERSION_ERROR_ID);
 
         // extract the time unit
-        MATLAB_ASSIGN_OR_ERROR(const auto time_unit, arrow::matlab::type::timeUnitFromString(units_mda[0]),
-                               error::UKNOWN_TIME_UNIT_ERROR_ID)
+        const std::u16string& utf16_unit = units_mda[0];
+        MATLAB_ASSIGN_OR_ERROR(const auto time_unit, arrow::matlab::type::timeUnitFromString(utf16_unit),
+                               error::UKNOWN_TIME_UNIT_ERROR_ID);
 
         // create the timestamp_type
         auto data_type = arrow::timestamp(time_unit, timezone);

--- a/matlab/src/cpp/arrow/matlab/proxy/factory.cc
+++ b/matlab/src/cpp/arrow/matlab/proxy/factory.cc
@@ -44,6 +44,15 @@ libmexclass::proxy::MakeResult Factory::make_proxy(const ClassName& class_name, 
     REGISTER_PROXY(arrow.tabular.proxy.RecordBatch , arrow::matlab::tabular::proxy::RecordBatch);
     REGISTER_PROXY(arrow.type.proxy.Float32Type    , arrow::matlab::type::proxy::PrimitiveCType<float>);
     REGISTER_PROXY(arrow.type.proxy.Float64Type    , arrow::matlab::type::proxy::PrimitiveCType<double>);
+    REGISTER_PROXY(arrow.type.proxy.UInt8Type      , arrow::matlab::type::proxy::PrimitiveCType<uint8_t>);
+    REGISTER_PROXY(arrow.type.proxy.UInt16Type     , arrow::matlab::type::proxy::PrimitiveCType<uint16_t>);
+    REGISTER_PROXY(arrow.type.proxy.UInt32Type     , arrow::matlab::type::proxy::PrimitiveCType<uint32_t>);
+    REGISTER_PROXY(arrow.type.proxy.UInt64Type     , arrow::matlab::type::proxy::PrimitiveCType<uint64_t>);
+    REGISTER_PROXY(arrow.type.proxy.Int8Type       , arrow::matlab::type::proxy::PrimitiveCType<int8_t>);
+    REGISTER_PROXY(arrow.type.proxy.Int16Type      , arrow::matlab::type::proxy::PrimitiveCType<int16_t>);
+    REGISTER_PROXY(arrow.type.proxy.Int32Type      , arrow::matlab::type::proxy::PrimitiveCType<int32_t>);
+    REGISTER_PROXY(arrow.type.proxy.Int64Type      , arrow::matlab::type::proxy::PrimitiveCType<int64_t>);
+    REGISTER_PROXY(arrow.type.proxy.BooleanType    , arrow::matlab::type::proxy::PrimitiveCType<bool>);
 
     return libmexclass::error::Error{error::UNKNOWN_PROXY_ERROR_ID, "Did not find matching C++ proxy for " + class_name};
 };

--- a/matlab/src/cpp/arrow/matlab/proxy/factory.cc
+++ b/matlab/src/cpp/arrow/matlab/proxy/factory.cc
@@ -42,7 +42,8 @@ libmexclass::proxy::MakeResult Factory::make_proxy(const ClassName& class_name, 
     REGISTER_PROXY(arrow.array.proxy.StringArray   , arrow::matlab::array::proxy::StringArray);
     REGISTER_PROXY(arrow.array.proxy.TimestampArray, arrow::matlab::array::proxy::TimestampArray);
     REGISTER_PROXY(arrow.tabular.proxy.RecordBatch , arrow::matlab::tabular::proxy::RecordBatch);
-    REGISTER_PROXY(arrow.type.proxy.Float64Type    , arrow::matlab::type::proxy::PrimitiveCType<arrow::DoubleType>);
+    REGISTER_PROXY(arrow.type.proxy.Float32Type    , arrow::matlab::type::proxy::PrimitiveCType<float>);
+    REGISTER_PROXY(arrow.type.proxy.Float64Type    , arrow::matlab::type::proxy::PrimitiveCType<double>);
 
     return libmexclass::error::Error{error::UNKNOWN_PROXY_ERROR_ID, "Did not find matching C++ proxy for " + class_name};
 };

--- a/matlab/src/cpp/arrow/matlab/proxy/factory.cc
+++ b/matlab/src/cpp/arrow/matlab/proxy/factory.cc
@@ -22,6 +22,7 @@
 #include "arrow/matlab/tabular/proxy/record_batch.h"
 #include "arrow/matlab/error/error.h"
 #include "arrow/matlab/type/proxy/primitive_ctype.h"
+#include "arrow/matlab/type/proxy/timestamp_type.h"
 
 #include "factory.h"
 
@@ -53,6 +54,7 @@ libmexclass::proxy::MakeResult Factory::make_proxy(const ClassName& class_name, 
     REGISTER_PROXY(arrow.type.proxy.Int32Type      , arrow::matlab::type::proxy::PrimitiveCType<int32_t>);
     REGISTER_PROXY(arrow.type.proxy.Int64Type      , arrow::matlab::type::proxy::PrimitiveCType<int64_t>);
     REGISTER_PROXY(arrow.type.proxy.BooleanType    , arrow::matlab::type::proxy::PrimitiveCType<bool>);
+    REGISTER_PROXY(arrow.type.proxy.TimestampType  , arrow::matlab::type::proxy::TimestampType);
 
     return libmexclass::error::Error{error::UNKNOWN_PROXY_ERROR_ID, "Did not find matching C++ proxy for " + class_name};
 };

--- a/matlab/src/cpp/arrow/matlab/proxy/factory.cc
+++ b/matlab/src/cpp/arrow/matlab/proxy/factory.cc
@@ -22,6 +22,7 @@
 #include "arrow/matlab/tabular/proxy/record_batch.h"
 #include "arrow/matlab/error/error.h"
 #include "arrow/matlab/type/proxy/primitive_ctype.h"
+#include "arrow/matlab/type/proxy/string_type.h"
 #include "arrow/matlab/type/proxy/timestamp_type.h"
 
 #include "factory.h"
@@ -54,6 +55,7 @@ libmexclass::proxy::MakeResult Factory::make_proxy(const ClassName& class_name, 
     REGISTER_PROXY(arrow.type.proxy.Int32Type      , arrow::matlab::type::proxy::PrimitiveCType<int32_t>);
     REGISTER_PROXY(arrow.type.proxy.Int64Type      , arrow::matlab::type::proxy::PrimitiveCType<int64_t>);
     REGISTER_PROXY(arrow.type.proxy.BooleanType    , arrow::matlab::type::proxy::PrimitiveCType<bool>);
+    REGISTER_PROXY(arrow.type.proxy.StringType  , arrow::matlab::type::proxy::StringType);
     REGISTER_PROXY(arrow.type.proxy.TimestampType  , arrow::matlab::type::proxy::TimestampType);
 
     return libmexclass::error::Error{error::UNKNOWN_PROXY_ERROR_ID, "Did not find matching C++ proxy for " + class_name};

--- a/matlab/src/cpp/arrow/matlab/proxy/factory.cc
+++ b/matlab/src/cpp/arrow/matlab/proxy/factory.cc
@@ -55,7 +55,7 @@ libmexclass::proxy::MakeResult Factory::make_proxy(const ClassName& class_name, 
     REGISTER_PROXY(arrow.type.proxy.Int32Type      , arrow::matlab::type::proxy::PrimitiveCType<int32_t>);
     REGISTER_PROXY(arrow.type.proxy.Int64Type      , arrow::matlab::type::proxy::PrimitiveCType<int64_t>);
     REGISTER_PROXY(arrow.type.proxy.BooleanType    , arrow::matlab::type::proxy::PrimitiveCType<bool>);
-    REGISTER_PROXY(arrow.type.proxy.StringType  , arrow::matlab::type::proxy::StringType);
+    REGISTER_PROXY(arrow.type.proxy.StringType     , arrow::matlab::type::proxy::StringType);
     REGISTER_PROXY(arrow.type.proxy.TimestampType  , arrow::matlab::type::proxy::TimestampType);
 
     return libmexclass::error::Error{error::UNKNOWN_PROXY_ERROR_ID, "Did not find matching C++ proxy for " + class_name};

--- a/matlab/src/cpp/arrow/matlab/proxy/factory.cc
+++ b/matlab/src/cpp/arrow/matlab/proxy/factory.cc
@@ -21,6 +21,7 @@
 #include "arrow/matlab/array/proxy/timestamp_array.h"
 #include "arrow/matlab/tabular/proxy/record_batch.h"
 #include "arrow/matlab/error/error.h"
+#include "arrow/matlab/type/proxy/primitive_ctype.h"
 
 #include "factory.h"
 
@@ -41,6 +42,8 @@ libmexclass::proxy::MakeResult Factory::make_proxy(const ClassName& class_name, 
     REGISTER_PROXY(arrow.array.proxy.StringArray   , arrow::matlab::array::proxy::StringArray);
     REGISTER_PROXY(arrow.array.proxy.TimestampArray, arrow::matlab::array::proxy::TimestampArray);
     REGISTER_PROXY(arrow.tabular.proxy.RecordBatch , arrow::matlab::tabular::proxy::RecordBatch);
+    REGISTER_PROXY(arrow.type.proxy.Float64Type    , arrow::matlab::type::proxy::PrimitiveCType<arrow::DoubleType>);
+
     return libmexclass::error::Error{error::UNKNOWN_PROXY_ERROR_ID, "Did not find matching C++ proxy for " + class_name};
 };
 

--- a/matlab/src/cpp/arrow/matlab/type/proxy/fixed_width_type.cc
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/fixed_width_type.cc
@@ -15,28 +15,20 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#pragma once
 
 #include "arrow/matlab/type/proxy/fixed_width_type.h"
-#include "arrow/type_traits.h"
 
 namespace arrow::matlab::type::proxy {
 
-class TimestampType : public arrow::matlab::type::proxy::FixedWidthType {
-        
-    public:
-        TimestampType(std::shared_ptr<arrow::TimestampType> timestamp_type);
+    FixedWidthType::FixedWidthType(std::shared_ptr<arrow::FixedWidthType> type) : Type(type) {
+        REGISTER_METHOD(FixedWidthType, bitWidth);
+    }
 
-        ~TimestampType() {}
-
-        static libmexclass::proxy::MakeResult make(const libmexclass::proxy::FunctionArguments& constructor_arguments);
-
-    protected:
-
-        void timeZone(libmexclass::proxy::method::Context& context);
-
-        void timeUnit(libmexclass::proxy::method::Context& context);
-};
-
+    void FixedWidthType::bitWidth(libmexclass::proxy::method::Context& context) {
+        namespace mda = ::matlab::data;
+         mda::ArrayFactory factory;
+     
+         auto bit_width_mda = factory.createScalar(data_type->bit_width());
+         context.outputs[0] = bit_width_mda;
+    }
 }
-

--- a/matlab/src/cpp/arrow/matlab/type/proxy/fixed_width_type.cc
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/fixed_width_type.cc
@@ -20,7 +20,7 @@
 
 namespace arrow::matlab::type::proxy {
 
-    FixedWidthType::FixedWidthType(std::shared_ptr<arrow::FixedWidthType> type) : Type(type) {
+    FixedWidthType::FixedWidthType(std::shared_ptr<arrow::FixedWidthType> type) : Type(std::move(type)) {
         REGISTER_METHOD(FixedWidthType, bitWidth);
     }
 

--- a/matlab/src/cpp/arrow/matlab/type/proxy/fixed_width_type.h
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/fixed_width_type.h
@@ -14,29 +14,21 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
 #pragma once
 
-#include "arrow/matlab/type/proxy/fixed_width_type.h"
-#include "arrow/type_traits.h"
+#include "arrow/matlab/type/proxy/type.h"
 
 namespace arrow::matlab::type::proxy {
 
-class TimestampType : public arrow::matlab::type::proxy::FixedWidthType {
-        
+class FixedWidthType : public arrow::matlab::type::proxy::Type {
     public:
-        TimestampType(std::shared_ptr<arrow::TimestampType> timestamp_type);
-
-        ~TimestampType() {}
-
-        static libmexclass::proxy::MakeResult make(const libmexclass::proxy::FunctionArguments& constructor_arguments);
+        FixedWidthType(std::shared_ptr<arrow::FixedWidthType> type);
+    
+        virtual ~FixedWidthType() {}
 
     protected:
+        void bitWidth(libmexclass::proxy::method::Context& context);
 
-        void timeZone(libmexclass::proxy::method::Context& context);
-
-        void timeUnit(libmexclass::proxy::method::Context& context);
 };
 
 }
-

--- a/matlab/src/cpp/arrow/matlab/type/proxy/primitive_ctype.h
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/primitive_ctype.h
@@ -40,14 +40,14 @@ class PrimitiveCType : public arrow::matlab::type::proxy::FixedWidthType {
     using ArrowDataType = arrow_type_t<CType>;
     
     public:
-        PrimitiveCType(std::shared_ptr<ArrowDataType> primitive_type) : arrow::matlab::type::proxy::FixedWidthType(primitive_type) {
+        PrimitiveCType(std::shared_ptr<ArrowDataType> primitive_type) : arrow::matlab::type::proxy::FixedWidthType(std::move(primitive_type)) {
         }
 
         ~PrimitiveCType() {}
 
         static libmexclass::proxy::MakeResult make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
             auto data_type = arrow::CTypeTraits<CType>::type_singleton();
-            return std::make_shared<PrimitiveCType>(std::static_pointer_cast<ArrowDataType>(data_type));
+            return std::make_shared<PrimitiveCType>(std::static_pointer_cast<ArrowDataType>(std::move(data_type)));
         }
 };
 

--- a/matlab/src/cpp/arrow/matlab/type/proxy/primitive_ctype.h
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/primitive_ctype.h
@@ -40,7 +40,7 @@ class PrimitiveCType : public arrow::matlab::type::proxy::Type {
     using ArrowDataType = arrow_type_t<CType>;
     
     public:
-        PrimitiveCType(const std::shared_ptr<ArrowDataType> primitive_type) : Type(primitive_type) {
+        PrimitiveCType(std::shared_ptr<ArrowDataType> primitive_type) : Type(primitive_type) {
             REGISTER_METHOD(PrimitiveCType, bitWidth);
         }
 

--- a/matlab/src/cpp/arrow/matlab/type/proxy/primitive_ctype.h
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/primitive_ctype.h
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "arrow/matlab/type/proxy/type.h"
+#include "arrow/type_traits.h"
+
+#include <type_traits>
+
+
+namespace arrow::matlab::type::proxy {
+
+template <typename T,  std::enable_if_t<ARROW::is_primitive_ctype<T>::value, bool>, true>
+class PrimitiveCType : public arrow::matlab::type::proxy::Type {
+    public:
+        PrimitiveCType(const std::shared_ptr<T> primitive_type) {
+            data_type = primitive_type;
+
+            REGISTER_METHOD(PrimitiveCType, bitWidth);
+        }
+
+        ~PrimitiveCType() {}
+
+        static libmexclass::proxy::MakeResult make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
+            auto data_type = typename arrow::TypeTraits<T>::type_singleton();
+            return std::make_shared<PrimitiveCType>(data_type);
+        }
+
+    protected:
+        void bitWidth(libmexclass::proxy::method::Context& context) {
+            namespace mda = ::matlab::data;
+            mda::ArrayFactory factory;
+    
+            auto bit_width_mda = factory.createScalar(data_type->bit_width());
+            context.outputs[0] = bit_width_mda;
+        }
+};
+
+}
+

--- a/matlab/src/cpp/arrow/matlab/type/proxy/primitive_ctype.h
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/primitive_ctype.h
@@ -25,10 +25,11 @@
 
 namespace arrow::matlab::type::proxy {
 
-template <typename T,  std::enable_if_t<ARROW::is_primitive_ctype<T>::value, bool>, true>
+template<typename CType, std::enable_if_t<std::is_base_of_v<arrow::PrimitiveCType, typename arrow::CTypeTraits<CType>::ArrowType>, bool> = true> 
 class PrimitiveCType : public arrow::matlab::type::proxy::Type {
+    using ArrowDataType = typename arrow::CTypeTraits<CType>::ArrowType;
     public:
-        PrimitiveCType(const std::shared_ptr<T> primitive_type) {
+        PrimitiveCType(const std::shared_ptr<ArrowDataType> primitive_type) {
             data_type = primitive_type;
 
             REGISTER_METHOD(PrimitiveCType, bitWidth);
@@ -37,8 +38,8 @@ class PrimitiveCType : public arrow::matlab::type::proxy::Type {
         ~PrimitiveCType() {}
 
         static libmexclass::proxy::MakeResult make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
-            auto data_type = typename arrow::TypeTraits<T>::type_singleton();
-            return std::make_shared<PrimitiveCType>(data_type);
+            auto data_type = arrow::CTypeTraits<CType>::type_singleton();
+            return std::make_shared<PrimitiveCType>(std::static_pointer_cast<ArrowDataType>(data_type));
         }
 
     protected:

--- a/matlab/src/cpp/arrow/matlab/type/proxy/primitive_ctype.h
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/primitive_ctype.h
@@ -25,7 +25,6 @@
 
 namespace arrow::matlab::type::proxy {
 
-
 template <typename CType>
 using arrow_type_t = typename arrow::CTypeTraits<CType>::ArrowType;
 
@@ -41,9 +40,7 @@ class PrimitiveCType : public arrow::matlab::type::proxy::Type {
     using ArrowDataType = arrow_type_t<CType>;
     
     public:
-        PrimitiveCType(const std::shared_ptr<ArrowDataType> primitive_type) {
-            data_type = primitive_type;
-
+        PrimitiveCType(const std::shared_ptr<ArrowDataType> primitive_type) : Type(primitive_type) {
             REGISTER_METHOD(PrimitiveCType, bitWidth);
         }
 

--- a/matlab/src/cpp/arrow/matlab/type/proxy/primitive_ctype.h
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/primitive_ctype.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "arrow/matlab/type/proxy/type.h"
+#include "arrow/matlab/type/proxy/fixed_width_type.h"
 #include "arrow/type_traits.h"
 
 #include <type_traits>
@@ -35,13 +35,12 @@ template<typename CType>
 using enable_if_primitive = std::enable_if_t<is_primitive<CType>::value, bool>; 
 
 template<typename CType, enable_if_primitive<CType> = true>
-class PrimitiveCType : public arrow::matlab::type::proxy::Type {
+class PrimitiveCType : public arrow::matlab::type::proxy::FixedWidthType {
     
     using ArrowDataType = arrow_type_t<CType>;
     
     public:
-        PrimitiveCType(std::shared_ptr<ArrowDataType> primitive_type) : Type(primitive_type) {
-            REGISTER_METHOD(PrimitiveCType, bitWidth);
+        PrimitiveCType(std::shared_ptr<ArrowDataType> primitive_type) : arrow::matlab::type::proxy::FixedWidthType(primitive_type) {
         }
 
         ~PrimitiveCType() {}
@@ -49,15 +48,6 @@ class PrimitiveCType : public arrow::matlab::type::proxy::Type {
         static libmexclass::proxy::MakeResult make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
             auto data_type = arrow::CTypeTraits<CType>::type_singleton();
             return std::make_shared<PrimitiveCType>(std::static_pointer_cast<ArrowDataType>(data_type));
-        }
-
-    protected:
-        void bitWidth(libmexclass::proxy::method::Context& context) {
-            namespace mda = ::matlab::data;
-            mda::ArrayFactory factory;
-    
-            auto bit_width_mda = factory.createScalar(data_type->bit_width());
-            context.outputs[0] = bit_width_mda;
         }
 };
 

--- a/matlab/src/cpp/arrow/matlab/type/proxy/primitive_ctype.h
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/primitive_ctype.h
@@ -25,9 +25,21 @@
 
 namespace arrow::matlab::type::proxy {
 
-template<typename CType, std::enable_if_t<std::is_base_of_v<arrow::PrimitiveCType, typename arrow::CTypeTraits<CType>::ArrowType>, bool> = true> 
+
+template <typename CType>
+using arrow_type_t = typename arrow::CTypeTraits<CType>::ArrowType;
+
+template <typename CType>
+using is_primitive = arrow::is_primitive_ctype<arrow_type_t<CType>>;
+
+template<typename CType>
+using enable_if_primitive = std::enable_if_t<is_primitive<CType>::value, bool>; 
+
+template<typename CType, enable_if_primitive<CType> = true>
 class PrimitiveCType : public arrow::matlab::type::proxy::Type {
-    using ArrowDataType = typename arrow::CTypeTraits<CType>::ArrowType;
+    
+    using ArrowDataType = arrow_type_t<CType>;
+    
     public:
         PrimitiveCType(const std::shared_ptr<ArrowDataType> primitive_type) {
             data_type = primitive_type;

--- a/matlab/src/cpp/arrow/matlab/type/proxy/string_type.cc
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/string_type.cc
@@ -1,0 +1,27 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/matlab/type/proxy/string_type.h"
+
+namespace arrow::matlab::type::proxy {
+
+    StringType::StringType(std::shared_ptr<arrow::StringType> string_type) : Type(string_type) {}
+
+    libmexclass::proxy::MakeResult StringType::make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
+        return std::make_shared<StringType>(std::static_pointer_cast<arrow::StringType>(arrow::utf8()));
+    }
+}

--- a/matlab/src/cpp/arrow/matlab/type/proxy/string_type.cc
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/string_type.cc
@@ -19,9 +19,10 @@
 
 namespace arrow::matlab::type::proxy {
 
-    StringType::StringType(std::shared_ptr<arrow::StringType> string_type) : Type(string_type) {}
+    StringType::StringType(std::shared_ptr<arrow::StringType> string_type) : Type(std::move(string_type)) {}
 
     libmexclass::proxy::MakeResult StringType::make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
-        return std::make_shared<StringType>(std::static_pointer_cast<arrow::StringType>(arrow::utf8()));
+        auto string_type = std::static_pointer_cast<arrow::StringType>(arrow::utf8());
+        return std::make_shared<StringType>(std::move(string_type));
     }
 }

--- a/matlab/src/cpp/arrow/matlab/type/proxy/string_type.h
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/string_type.h
@@ -1,0 +1,35 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "arrow/matlab/type/proxy/type.h"
+
+namespace arrow::matlab::type::proxy {
+
+class StringType : public arrow::matlab::type::proxy::Type {
+        
+    public:
+        StringType(std::shared_ptr<arrow::StringType> string_type);
+
+        ~StringType() {}
+
+        static libmexclass::proxy::MakeResult make(const libmexclass::proxy::FunctionArguments& constructor_arguments);
+};
+
+}
+

--- a/matlab/src/cpp/arrow/matlab/type/proxy/timestamp_type.cc
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/timestamp_type.cc
@@ -39,10 +39,15 @@ namespace arrow::matlab::type::proxy {
         const mda::StringArray timeunit_mda = opts[0]["TimeUnit"];
 
         // extract the time zone
-        MATLAB_ASSIGN_OR_ERROR(const auto timezone, arrow::util::UTF16StringToUTF8(timezone_mda[0]),
+        const std::u16string& utf16_timezone = timezone_mda[0];
+        MATLAB_ASSIGN_OR_ERROR(const auto timezone,
+                               arrow::util::UTF16StringToUTF8(utf16_timezone),
                                error::UNICODE_CONVERSION_ERROR_ID);
+
         // extract the time unit
-        MATLAB_ASSIGN_OR_ERROR(const auto timeunit, arrow::matlab::type::timeUnitFromString(timeunit_mda[0]),
+        const std::u16string& utf16_timeunit = timeunit_mda[0];
+        MATLAB_ASSIGN_OR_ERROR(const auto timeunit,
+                               arrow::matlab::type::timeUnitFromString(utf16_timeunit),
                                error::UKNOWN_TIME_UNIT_ERROR_ID);
 
         auto type = arrow::timestamp(timeunit, timezone);

--- a/matlab/src/cpp/arrow/matlab/type/proxy/timestamp_type.cc
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/timestamp_type.cc
@@ -22,7 +22,7 @@
 
 namespace arrow::matlab::type::proxy {
 
-    TimestampType::TimestampType(std::shared_ptr<arrow::TimestampType> timestamp_type) : FixedWidthType(timestamp_type) {
+    TimestampType::TimestampType(std::shared_ptr<arrow::TimestampType> timestamp_type) : FixedWidthType(std::move(timestamp_type)) {
         REGISTER_METHOD(TimestampType, timeUnit);
         REGISTER_METHOD(TimestampType, timeZone);
     }
@@ -51,8 +51,8 @@ namespace arrow::matlab::type::proxy {
                                error::UKNOWN_TIME_UNIT_ERROR_ID);
 
         auto type = arrow::timestamp(timeunit, timezone);
-
-        return std::make_shared<TimestampTypeProxy>(std::static_pointer_cast<arrow::TimestampType>(type));
+        auto time_type = std::static_pointer_cast<arrow::TimestampType>(type);
+        return std::make_shared<TimestampTypeProxy>(std::move(time_type));
     }
 
     void TimestampType::timeZone(libmexclass::proxy::method::Context& context) {

--- a/matlab/src/cpp/arrow/matlab/type/proxy/timestamp_type.cc
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/timestamp_type.cc
@@ -22,11 +22,9 @@
 
 namespace arrow::matlab::type::proxy {
 
-    TimestampType::TimestampType(std::shared_ptr<arrow::TimestampType> timestamp_type) : Type(timestamp_type) {
+    TimestampType::TimestampType(std::shared_ptr<arrow::TimestampType> timestamp_type) : FixedWidthType(timestamp_type) {
         REGISTER_METHOD(TimestampType, timeUnit);
         REGISTER_METHOD(TimestampType, timeZone);
-        REGISTER_METHOD(TimestampType, bitWidth);
-
     }
 
     libmexclass::proxy::MakeResult TimestampType::make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
@@ -73,13 +71,5 @@ namespace arrow::matlab::type::proxy {
         const auto timeunit = timestamp_type->unit();
         auto timeunit_mda = factory.createScalar(static_cast<int16_t>(timeunit)); 
         context.outputs[0] = timeunit_mda;
-    }
-
-    void TimestampType::bitWidth(libmexclass::proxy::method::Context& context) {
-        namespace mda = ::matlab::data;
-        mda::ArrayFactory factory;
-    
-        auto bit_width_mda = factory.createScalar(data_type->bit_width());
-        context.outputs[0] = bit_width_mda;
     }
 }

--- a/matlab/src/cpp/arrow/matlab/type/proxy/timestamp_type.h
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/timestamp_type.h
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "arrow/matlab/type/proxy/type.h"
+#include "arrow/type_traits.h"
+
+namespace arrow::matlab::type::proxy {
+
+class TimestampType : public arrow::matlab::type::proxy::Type {
+        
+    public:
+        TimestampType(std::shared_ptr<arrow::TimestampType> timestamp_type);
+
+        ~TimestampType() {}
+
+        static libmexclass::proxy::MakeResult make(const libmexclass::proxy::FunctionArguments& constructor_arguments);
+
+    protected:
+        void bitWidth(libmexclass::proxy::method::Context& context);
+
+        void timeZone(libmexclass::proxy::method::Context& context);
+
+        void timeUnit(libmexclass::proxy::method::Context& context);
+};
+
+}
+

--- a/matlab/src/cpp/arrow/matlab/type/proxy/type.cc
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/type.cc
@@ -21,7 +21,7 @@ namespace arrow::matlab::type::proxy {
 
     Type::Type() {
         // Register Proxy methods.
-        REGISTER_METHOD(Type, typeNumber);
+        REGISTER_METHOD(Type, typeID);
         REGISTER_METHOD(Type, numFields);
 
     }
@@ -30,7 +30,7 @@ namespace arrow::matlab::type::proxy {
         return data_type;
     }
 
-    void Type::typeNumber(libmexclass::proxy::method::Context& context) {
+    void Type::typeID(libmexclass::proxy::method::Context& context) {
         namespace mda = ::matlab::data;
         mda::ArrayFactory factory;
         

--- a/matlab/src/cpp/arrow/matlab/type/proxy/type.cc
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/type.cc
@@ -19,7 +19,7 @@
 
 namespace arrow::matlab::type::proxy {
 
-    Type::Type(std::shared_ptr<arrow::DataType> type) : data_type{type} {
+    Type::Type(std::shared_ptr<arrow::DataType> type) : data_type{std::move(type)} {
         REGISTER_METHOD(Type, typeID);
         REGISTER_METHOD(Type, numFields);
     }

--- a/matlab/src/cpp/arrow/matlab/type/proxy/type.cc
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/type.cc
@@ -22,7 +22,6 @@ namespace arrow::matlab::type::proxy {
     Type::Type(std::shared_ptr<arrow::DataType> type) : data_type{type} {
         REGISTER_METHOD(Type, typeID);
         REGISTER_METHOD(Type, numFields);
-
     }
 
     std::shared_ptr<arrow::DataType> Type::unwrap() {

--- a/matlab/src/cpp/arrow/matlab/type/proxy/type.cc
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/type.cc
@@ -26,7 +26,7 @@ namespace arrow::matlab::type::proxy {
 
     }
 
-    std::shared_ptr<arrow::DataType> Type::getType() {
+    std::shared_ptr<arrow::DataType> Type::unwrap() {
         return data_type;
     }
 

--- a/matlab/src/cpp/arrow/matlab/type/proxy/type.cc
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/type.cc
@@ -1,0 +1,50 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/matlab/type/proxy/type.h"
+
+namespace arrow::matlab::type::proxy {
+
+    Type::Type() {
+        // Register Proxy methods.
+        REGISTER_METHOD(Type, typeNumber);
+        REGISTER_METHOD(Type, numFields);
+
+    }
+
+    std::shared_ptr<arrow::DataType> Type::getType() {
+        return data_type;
+    }
+
+    void Type::typeNumber(libmexclass::proxy::method::Context& context) {
+        namespace mda = ::matlab::data;
+        mda::ArrayFactory factory;
+        
+        auto type_number_mda = factory.createScalar(static_cast<int64_t>(data_type->id()));
+        context.outputs[0] = type_number_mda;
+    }
+
+    void Type::numFields(libmexclass::proxy::method::Context& context) {
+        namespace mda = ::matlab::data;
+        mda::ArrayFactory factory;
+        
+        auto num_fields_mda = factory.createScalar(data_type->num_fields());
+        context.outputs[0] = num_fields_mda;
+    }
+
+}
+

--- a/matlab/src/cpp/arrow/matlab/type/proxy/type.cc
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/type.cc
@@ -19,7 +19,7 @@
 
 namespace arrow::matlab::type::proxy {
 
-    Type::Type() {
+    Type::Type(std::shared_ptr<arrow::DataType> type) : data_type{type} {
         // Register Proxy methods.
         REGISTER_METHOD(Type, typeID);
         REGISTER_METHOD(Type, numFields);

--- a/matlab/src/cpp/arrow/matlab/type/proxy/type.cc
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/type.cc
@@ -20,7 +20,6 @@
 namespace arrow::matlab::type::proxy {
 
     Type::Type(std::shared_ptr<arrow::DataType> type) : data_type{type} {
-        // Register Proxy methods.
         REGISTER_METHOD(Type, typeID);
         REGISTER_METHOD(Type, numFields);
 

--- a/matlab/src/cpp/arrow/matlab/type/proxy/type.h
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/type.h
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "arrow/type.h"
+
+#include "libmexclass/proxy/Proxy.h"
+
+namespace arrow::matlab::type::proxy {
+
+class Type : public libmexclass::proxy::Proxy {
+    public:
+        Type();
+    
+        virtual ~Type() {}
+
+        std::shared_ptr<arrow::DataType> getType();
+
+    protected:
+
+        void typeNumber(libmexclass::proxy::method::Context& context);
+    
+        void numFields(libmexclass::proxy::method::Context& context);
+
+        std::shared_ptr<arrow::DataType> data_type;
+};
+
+}

--- a/matlab/src/cpp/arrow/matlab/type/proxy/type.h
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/type.h
@@ -29,7 +29,7 @@ class Type : public libmexclass::proxy::Proxy {
     
         virtual ~Type() {}
 
-        std::shared_ptr<arrow::DataType> getType();
+        std::shared_ptr<arrow::DataType> unwrap();
 
     protected:
 

--- a/matlab/src/cpp/arrow/matlab/type/proxy/type.h
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/type.h
@@ -25,7 +25,7 @@ namespace arrow::matlab::type::proxy {
 
 class Type : public libmexclass::proxy::Proxy {
     public:
-        Type();
+        Type(std::shared_ptr<arrow::DataType> type);
     
         virtual ~Type() {}
 

--- a/matlab/src/cpp/arrow/matlab/type/proxy/type.h
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/type.h
@@ -33,8 +33,8 @@ class Type : public libmexclass::proxy::Proxy {
 
     protected:
 
-        void typeNumber(libmexclass::proxy::method::Context& context);
-    
+        void typeID(libmexclass::proxy::method::Context& context);
+
         void numFields(libmexclass::proxy::method::Context& context);
 
         std::shared_ptr<arrow::DataType> data_type;

--- a/matlab/src/cpp/arrow/matlab/type/time_unit.cc
+++ b/matlab/src/cpp/arrow/matlab/type/time_unit.cc
@@ -20,7 +20,7 @@
 
 namespace arrow::matlab::type {
 
-    arrow::Result<arrow::TimeUnit::type> timeUnitFromString(const std::u16string& unit_str) {
+    arrow::Result<arrow::TimeUnit::type> timeUnitFromString(std::u16string_view unit_str) {
         if (unit_str == u"Second") {
             return arrow::TimeUnit::type::SECOND;
         } else if (unit_str == u"Millisecond") {

--- a/matlab/src/cpp/arrow/matlab/type/time_unit.h
+++ b/matlab/src/cpp/arrow/matlab/type/time_unit.h
@@ -18,10 +18,10 @@
 #include "arrow/type_fwd.h"
 #include "arrow/result.h"
 
-#include <string>
+#include <string_view>
 
 namespace arrow::matlab::type {
 
-    arrow::Result<arrow::TimeUnit::type> timeUnitFromString(const std::u16string& unit_str);
+    arrow::Result<arrow::TimeUnit::type> timeUnitFromString(std::u16string_view unit_str);
 
 }

--- a/matlab/src/matlab/+arrow/+array/TimestampArray.m
+++ b/matlab/src/matlab/+arrow/+array/TimestampArray.m
@@ -48,7 +48,7 @@ classdef TimestampArray < arrow.array.Array
             epoch = datetime(1970, 1, 1, TimeZone="UTC");
 
             tz = obj.Type.TimeZone;
-            ticsPerSecond = obj.Type.TimeUnit.TicksPerSecond;
+            ticsPerSecond = ticksPerSecond(obj.Type.TimeUnit);
             
             dates = datetime(time, ConvertFrom="epochtime", Epoch=epoch, ...
                 TimeZone=tz, TicksPerSecond=ticsPerSecond);
@@ -72,7 +72,7 @@ classdef TimestampArray < arrow.array.Array
             %
             % TODO: convertTo may error if the datetime is 2^63-1 before or
             % after the epoch. We should throw a custom error in this case.
-            time(indices) = convertTo(dates(indices), "epochtime", TicksPerSecond=units.TicksPerSecond);
+            time(indices) = convertTo(dates(indices), "epochtime", TicksPerSecond=ticksPerSecond(units));
         end
     end
 end

--- a/matlab/src/matlab/+arrow/+type/BooleanType.m
+++ b/matlab/src/matlab/+arrow/+type/BooleanType.m
@@ -13,12 +13,12 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef BooleanType < arrow.type.PrimitiveType
+classdef BooleanType < arrow.type.FixedWidthType
 %BOOLEANTYPE Type class for boolean data.
     
     methods 
         function obj = BooleanType()
-            obj@arrow.type.PrimitiveType("Name", "arrow.type.proxy.BooleanType", "ConstructorArguments", {})
+            obj@arrow.type.FixedWidthType("Name", "arrow.type.proxy.BooleanType", "ConstructorArguments", {})
         end
     end
 end

--- a/matlab/src/matlab/+arrow/+type/BooleanType.m
+++ b/matlab/src/matlab/+arrow/+type/BooleanType.m
@@ -16,7 +16,9 @@
 classdef BooleanType < arrow.type.PrimitiveType
 %BOOLEANTYPE Type class for boolean data.
     
-    properties(SetAccess = protected)
-        ID = arrow.type.ID.Boolean
+    methods 
+        function obj = BooleanType()
+            obj@arrow.type.PrimitiveType("Name", "arrow.type.proxy.BooleanType", "ConstructorArguments", {})
+        end
     end
 end

--- a/matlab/src/matlab/+arrow/+type/FixedWidthType.m
+++ b/matlab/src/matlab/+arrow/+type/FixedWidthType.m
@@ -13,15 +13,15 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef (Abstract) PrimitiveType < arrow.type.Type
-%PRIMITIVETYPE Abstract type class representing primtive data types. 
+classdef (Abstract) FixedWidthType < arrow.type.Type
+%FIXEDWIDTHTYPE Abstract type class representing fixed width data types. 
     
     properties(Dependent, SetAccess=private, GetAccess=public)
         BitWidth
     end
 
     methods
-        function obj = PrimitiveType(varargin)
+        function obj = FixedWidthType(varargin)
             obj@arrow.type.Type(varargin{:});
         end
 

--- a/matlab/src/matlab/+arrow/+type/Float32Type.m
+++ b/matlab/src/matlab/+arrow/+type/Float32Type.m
@@ -13,12 +13,12 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef Float32Type < arrow.type.PrimitiveType
+classdef Float32Type < arrow.type.FixedWidthType
 %FLOAT32TYPE Type class for float32 data.
     
     methods 
         function obj = Float32Type()
-            obj@arrow.type.PrimitiveType("Name", "arrow.type.proxy.Float32Type", "ConstructorArguments", {})
+            obj@arrow.type.FixedWidthType("Name", "arrow.type.proxy.Float32Type", "ConstructorArguments", {})
         end
     end
 end

--- a/matlab/src/matlab/+arrow/+type/Float32Type.m
+++ b/matlab/src/matlab/+arrow/+type/Float32Type.m
@@ -16,7 +16,9 @@
 classdef Float32Type < arrow.type.PrimitiveType
 %FLOAT32TYPE Type class for float32 data.
     
-    properties(SetAccess = protected)
-        ID = arrow.type.ID.Float32
+    methods 
+        function obj = Float32Type()
+            obj@arrow.type.PrimitiveType("Name", "arrow.type.proxy.Float32Type", "ConstructorArguments", {})
+        end
     end
 end

--- a/matlab/src/matlab/+arrow/+type/Float64Type.m
+++ b/matlab/src/matlab/+arrow/+type/Float64Type.m
@@ -16,7 +16,9 @@
 classdef Float64Type < arrow.type.PrimitiveType
 %FLOAT64Type Type class for float64 data. 
     
-    properties(SetAccess = protected)
-        ID = arrow.type.ID.Float64
+    methods 
+        function obj = Float64Type()
+            obj@arrow.type.PrimitiveType("Name", "arrow.type.proxy.Float64Type", "ConstructorArguments", {})
+        end
     end
 end

--- a/matlab/src/matlab/+arrow/+type/Float64Type.m
+++ b/matlab/src/matlab/+arrow/+type/Float64Type.m
@@ -13,12 +13,12 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef Float64Type < arrow.type.PrimitiveType
+classdef Float64Type < arrow.type.FixedWidthType
 %FLOAT64Type Type class for float64 data. 
     
     methods 
         function obj = Float64Type()
-            obj@arrow.type.PrimitiveType("Name", "arrow.type.proxy.Float64Type", "ConstructorArguments", {})
+            obj@arrow.type.FixedWidthType("Name", "arrow.type.proxy.Float64Type", "ConstructorArguments", {})
         end
     end
 end

--- a/matlab/src/matlab/+arrow/+type/ID.m
+++ b/matlab/src/matlab/+arrow/+type/ID.m
@@ -35,24 +35,4 @@ classdef ID < uint64
         % Date64 (17)
         Timestamp (18)
     end
-
-    methods
-        function bitWidth = bitWidth(obj)
-            import arrow.type.ID
-            switch obj
-                case ID.Boolean
-                    bitWidth = 1;
-                case {ID.UInt8, ID.Int8}
-                    bitWidth = 8;
-                case {ID.UInt16, ID.Int16}
-                    bitWidth = 16;
-                case {ID.UInt32, ID.Int32, ID.Float32}
-                    bitWidth = 32;
-                case {ID.UInt64, ID.Int64, ID.Float64, ID.Timestamp}
-                    bitWidth = 64;
-                otherwise
-                    bitWidth = NaN;
-            end
-        end
-    end
 end

--- a/matlab/src/matlab/+arrow/+type/Int16Type.m
+++ b/matlab/src/matlab/+arrow/+type/Int16Type.m
@@ -13,12 +13,12 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef Int16Type < arrow.type.PrimitiveType
+classdef Int16Type < arrow.type.FixedWidthType
 %INT16TYPE Type class for int8 data. 
     
     methods 
         function obj = Int16Type()
-            obj@arrow.type.PrimitiveType("Name", "arrow.type.proxy.Int16Type", "ConstructorArguments", {})
+            obj@arrow.type.FixedWidthType("Name", "arrow.type.proxy.Int16Type", "ConstructorArguments", {})
         end
     end
 end

--- a/matlab/src/matlab/+arrow/+type/Int16Type.m
+++ b/matlab/src/matlab/+arrow/+type/Int16Type.m
@@ -16,8 +16,10 @@
 classdef Int16Type < arrow.type.PrimitiveType
 %INT16TYPE Type class for int8 data. 
     
-    properties(SetAccess = protected)
-        ID = arrow.type.ID.Int16
+    methods 
+        function obj = Int16Type()
+            obj@arrow.type.PrimitiveType("Name", "arrow.type.proxy.Int16Type", "ConstructorArguments", {})
+        end
     end
 end
 

--- a/matlab/src/matlab/+arrow/+type/Int32Type.m
+++ b/matlab/src/matlab/+arrow/+type/Int32Type.m
@@ -16,8 +16,10 @@
 classdef Int32Type < arrow.type.PrimitiveType
 %INT32TYPE Type class for int32 data.
 
-    properties(SetAccess = protected)
-        ID = arrow.type.ID.Int32
+    methods 
+        function obj = Int32Type()
+            obj@arrow.type.PrimitiveType("Name", "arrow.type.proxy.Int32Type", "ConstructorArguments", {})
+        end
     end
 end
 

--- a/matlab/src/matlab/+arrow/+type/Int32Type.m
+++ b/matlab/src/matlab/+arrow/+type/Int32Type.m
@@ -13,12 +13,12 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef Int32Type < arrow.type.PrimitiveType
+classdef Int32Type < arrow.type.FixedWidthType
 %INT32TYPE Type class for int32 data.
 
     methods 
         function obj = Int32Type()
-            obj@arrow.type.PrimitiveType("Name", "arrow.type.proxy.Int32Type", "ConstructorArguments", {})
+            obj@arrow.type.FixedWidthType("Name", "arrow.type.proxy.Int32Type", "ConstructorArguments", {})
         end
     end
 end

--- a/matlab/src/matlab/+arrow/+type/Int64Type.m
+++ b/matlab/src/matlab/+arrow/+type/Int64Type.m
@@ -16,7 +16,9 @@
 classdef Int64Type < arrow.type.PrimitiveType
 %INT64TYPE Type class for int64 data.
 
-    properties(SetAccess = protected)
-        ID = arrow.type.ID.Int64
+    methods 
+        function obj = Int64Type()
+            obj@arrow.type.PrimitiveType("Name", "arrow.type.proxy.Int64Type", "ConstructorArguments", {})
+        end
     end
 end

--- a/matlab/src/matlab/+arrow/+type/Int64Type.m
+++ b/matlab/src/matlab/+arrow/+type/Int64Type.m
@@ -13,12 +13,12 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef Int64Type < arrow.type.PrimitiveType
+classdef Int64Type < arrow.type.FixedWidthType
 %INT64TYPE Type class for int64 data.
 
     methods 
         function obj = Int64Type()
-            obj@arrow.type.PrimitiveType("Name", "arrow.type.proxy.Int64Type", "ConstructorArguments", {})
+            obj@arrow.type.FixedWidthType("Name", "arrow.type.proxy.Int64Type", "ConstructorArguments", {})
         end
     end
 end

--- a/matlab/src/matlab/+arrow/+type/Int8Type.m
+++ b/matlab/src/matlab/+arrow/+type/Int8Type.m
@@ -16,8 +16,10 @@
 classdef Int8Type < arrow.type.PrimitiveType
 %INT8TYPE Type class for int8 data. 
     
-    properties(SetAccess = protected)
-        ID = arrow.type.ID.Int8
+    methods 
+        function obj = Int8Type()
+            obj@arrow.type.PrimitiveType("Name", "arrow.type.proxy.Int8Type", "ConstructorArguments", {})
+        end
     end
 end
 

--- a/matlab/src/matlab/+arrow/+type/Int8Type.m
+++ b/matlab/src/matlab/+arrow/+type/Int8Type.m
@@ -13,12 +13,12 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef Int8Type < arrow.type.PrimitiveType
+classdef Int8Type < arrow.type.FixedWidthType
 %INT8TYPE Type class for int8 data. 
     
     methods 
         function obj = Int8Type()
-            obj@arrow.type.PrimitiveType("Name", "arrow.type.proxy.Int8Type", "ConstructorArguments", {})
+            obj@arrow.type.FixedWidthType("Name", "arrow.type.proxy.Int8Type", "ConstructorArguments", {})
         end
     end
 end

--- a/matlab/src/matlab/+arrow/+type/PrimitiveType.m
+++ b/matlab/src/matlab/+arrow/+type/PrimitiveType.m
@@ -13,21 +13,20 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef PrimitiveType < arrow.type.Type
+classdef (Abstract) PrimitiveType < arrow.type.Type
 %PRIMITIVETYPE Abstract type class representing primtive data types. 
     
-    properties(Dependent, SetAccess=protected, GetAccess=public)
+    properties(Dependent, SetAccess=private, GetAccess=public)
         BitWidth
     end
 
-    properties(Constant)
-        NumFields = 0
-        NumBuffers = 2
-    end
-
     methods
-        function width = get.BitWidth(obj)
-            width = bitWidth(obj.ID);
+        function obj = PrimitiveType(varargin)
+            obj@arrow.type.Type(varargin{:});
         end
-    end
+
+        function width = get.BitWidth(obj)
+            width = obj.Proxy.bitWidth();
+        end
+    end 
 end

--- a/matlab/src/matlab/+arrow/+type/StringType.m
+++ b/matlab/src/matlab/+arrow/+type/StringType.m
@@ -16,14 +16,10 @@
 classdef StringType < arrow.type.Type
 %STRINGTYPE Type class for string data.
 
-    properties(SetAccess = protected)
-        ID = arrow.type.ID.String
-    end
-
-    properties(Constant)
-        NumFields = 0
-        NumBuffers = 3
-    end
-
+    methods
+        function obj = StringType()
+            obj@arrow.type.Type("Name", "arrow.type.proxy.StringType", "ConstructorArguments", {});
+        end
+   end
 end
 

--- a/matlab/src/matlab/+arrow/+type/TimeUnit.m
+++ b/matlab/src/matlab/+arrow/+type/TimeUnit.m
@@ -12,33 +12,28 @@
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
-classdef TimeUnit
+classdef TimeUnit < int16
 % Enumeration class representing Time Units.
 
     enumeration
-        Second
-        Millisecond
-        Microsecond
-        Nanosecond
+        Second       (0)
+        Millisecond  (1)
+        Microsecond  (2)
+        Nanosecond   (3)
     end
 
-    properties (Dependent)
-        TicksPerSecond
-    end
-
-
-    methods
-        function ticksPerSecond = get.TicksPerSecond(obj)
+    methods (Hidden)
+        function ticks = ticksPerSecond(obj)
             import arrow.type.TimeUnit
             switch obj
                 case TimeUnit.Second
-                    ticksPerSecond = 1;
+                    ticks = 1;
                 case TimeUnit.Millisecond
-                    ticksPerSecond = 1e3;
+                    ticks = 1e3;
                 case TimeUnit.Microsecond
-                    ticksPerSecond = 1e6;
+                    ticks = 1e6;
                 case TimeUnit.Nanosecond
-                    ticksPerSecond = 1e9;
+                    ticks = 1e9;
             end
         end
     end

--- a/matlab/src/matlab/+arrow/+type/TimestampType.m
+++ b/matlab/src/matlab/+arrow/+type/TimestampType.m
@@ -13,17 +13,13 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef TimestampType < arrow.type.PrimitiveType
+classdef TimestampType < arrow.type.Type
 %TIMESTAMPTYPE Type class for timestamp data.
 
-    
-    properties(SetAccess=private)
-        TimeZone(1, 1) string
-        TimeUnit(1, 1) arrow.type.TimeUnit
-    end
-
-    properties(SetAccess = protected)
-        ID = arrow.type.ID.Timestamp
+    properties(Dependent, SetAccess=private, GetAccess=public)
+        TimeZone
+        TimeUnit
+        BitWidth
     end
 
     methods
@@ -33,8 +29,21 @@ classdef TimestampType < arrow.type.PrimitiveType
                 opts.TimeUnit(1, 1) arrow.type.TimeUnit = arrow.type.TimeUnit.Microsecond
                 opts.TimeZone(1, 1) string {mustBeNonmissing} = "" 
             end
-            obj.TimeUnit = opts.TimeUnit;
-            obj.TimeZone = opts.TimeZone;
+            args = struct(TimeUnit=string(opts.TimeUnit), TimeZone=opts.TimeZone);
+            obj@arrow.type.Type("Name", "arrow.type.proxy.TimestampType", "ConstructorArguments", {args});
+        end
+
+        function bitWidth = get.BitWidth(obj)
+            bitWidth = obj.Proxy.bitWidth();
+        end
+
+        function unit = get.TimeUnit(obj)
+            val = obj.Proxy.timeUnit();
+            unit = arrow.type.TimeUnit(val);
+        end
+
+        function tz = get.TimeZone(obj)
+            tz = obj.Proxy.timeZone();
         end
     end
 end

--- a/matlab/src/matlab/+arrow/+type/TimestampType.m
+++ b/matlab/src/matlab/+arrow/+type/TimestampType.m
@@ -13,13 +13,12 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef TimestampType < arrow.type.Type
+classdef TimestampType < arrow.type.FixedWidthType
 %TIMESTAMPTYPE Type class for timestamp data.
 
     properties(Dependent, SetAccess=private, GetAccess=public)
         TimeZone
         TimeUnit
-        BitWidth
     end
 
     methods
@@ -30,11 +29,7 @@ classdef TimestampType < arrow.type.Type
                 opts.TimeZone(1, 1) string {mustBeNonmissing} = "" 
             end
             args = struct(TimeUnit=string(opts.TimeUnit), TimeZone=opts.TimeZone);
-            obj@arrow.type.Type("Name", "arrow.type.proxy.TimestampType", "ConstructorArguments", {args});
-        end
-
-        function bitWidth = get.BitWidth(obj)
-            bitWidth = obj.Proxy.bitWidth();
+            obj@arrow.type.FixedWidthType("Name", "arrow.type.proxy.TimestampType", "ConstructorArguments", {args});
         end
 
         function unit = get.TimeUnit(obj)

--- a/matlab/src/matlab/+arrow/+type/Type.m
+++ b/matlab/src/matlab/+arrow/+type/Type.m
@@ -13,11 +13,36 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef Type
+classdef (Abstract) Type < matlab.mixin.CustomDisplay
 %TYPE Abstract type class. 
 
-    properties (Abstract, SetAccess=protected)
-        ID(1, 1) arrow.type.ID
+    properties (Dependent, GetAccess=public, SetAccess=private)
+        ID
+        NumFields
+    end
+
+    properties (GetAccess=public, SetAccess=private, Hidden)
+        Proxy
+    end
+
+    methods
+        function obj = Type(varargin)
+            obj.Proxy = libmexclass.proxy.Proxy(varargin{:}); 
+        end
+
+        function numFields = get.NumFields(obj)
+            numFields = obj.Proxy.numFields();
+        end
+
+        function typeID = get.ID(obj)
+            typeID = arrow.type.ID(obj.Proxy.typeID());
+        end
+    end
+
+    methods (Access=protected)
+        function propgrp = getPropertyGroups(~)
+          proplist = {'ID'};
+          propgrp = matlab.mixin.util.PropertyGroup(proplist);
+        end
     end
 end
-

--- a/matlab/src/matlab/+arrow/+type/UInt16Type.m
+++ b/matlab/src/matlab/+arrow/+type/UInt16Type.m
@@ -13,12 +13,12 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef UInt16Type < arrow.type.PrimitiveType
+classdef UInt16Type < arrow.type.FixedWidthType
 %UINT16TYPE Type class for uint16 data.
     
     methods 
         function obj = UInt16Type()
-            obj@arrow.type.PrimitiveType("Name", "arrow.type.proxy.UInt16Type", "ConstructorArguments", {})
+            obj@arrow.type.FixedWidthType("Name", "arrow.type.proxy.UInt16Type", "ConstructorArguments", {})
         end
     end
 end

--- a/matlab/src/matlab/+arrow/+type/UInt16Type.m
+++ b/matlab/src/matlab/+arrow/+type/UInt16Type.m
@@ -16,7 +16,9 @@
 classdef UInt16Type < arrow.type.PrimitiveType
 %UINT16TYPE Type class for uint16 data.
     
-    properties(SetAccess = protected)
-        ID = arrow.type.ID.UInt16
+    methods 
+        function obj = UInt16Type()
+            obj@arrow.type.PrimitiveType("Name", "arrow.type.proxy.UInt16Type", "ConstructorArguments", {})
+        end
     end
 end

--- a/matlab/src/matlab/+arrow/+type/UInt32Type.m
+++ b/matlab/src/matlab/+arrow/+type/UInt32Type.m
@@ -16,7 +16,9 @@
 classdef UInt32Type < arrow.type.PrimitiveType
 %UINT32TYPE Type class for uint32 data.
     
-    properties(SetAccess = protected)
-        ID = arrow.type.ID.UInt32
+    methods 
+        function obj = UInt32Type()
+            obj@arrow.type.PrimitiveType("Name", "arrow.type.proxy.UInt32Type", "ConstructorArguments", {})
+        end
     end
 end

--- a/matlab/src/matlab/+arrow/+type/UInt32Type.m
+++ b/matlab/src/matlab/+arrow/+type/UInt32Type.m
@@ -13,12 +13,12 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef UInt32Type < arrow.type.PrimitiveType
+classdef UInt32Type < arrow.type.FixedWidthType
 %UINT32TYPE Type class for uint32 data.
     
     methods 
         function obj = UInt32Type()
-            obj@arrow.type.PrimitiveType("Name", "arrow.type.proxy.UInt32Type", "ConstructorArguments", {})
+            obj@arrow.type.FixedWidthType("Name", "arrow.type.proxy.UInt32Type", "ConstructorArguments", {})
         end
     end
 end

--- a/matlab/src/matlab/+arrow/+type/UInt64Type.m
+++ b/matlab/src/matlab/+arrow/+type/UInt64Type.m
@@ -13,12 +13,12 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef UInt64Type < arrow.type.PrimitiveType
+classdef UInt64Type < arrow.type.FixedWidthType
 %UINT64TYPE Type class for uint64 data.
     
     methods 
         function obj = UInt64Type()
-            obj@arrow.type.PrimitiveType("Name", "arrow.type.proxy.UInt64Type", "ConstructorArguments", {})
+            obj@arrow.type.FixedWidthType("Name", "arrow.type.proxy.UInt64Type", "ConstructorArguments", {})
         end
     end
 end

--- a/matlab/src/matlab/+arrow/+type/UInt64Type.m
+++ b/matlab/src/matlab/+arrow/+type/UInt64Type.m
@@ -16,7 +16,9 @@
 classdef UInt64Type < arrow.type.PrimitiveType
 %UINT64TYPE Type class for uint64 data.
     
-    properties(SetAccess = protected)
-        ID = arrow.type.ID.UInt64
+    methods 
+        function obj = UInt64Type()
+            obj@arrow.type.PrimitiveType("Name", "arrow.type.proxy.UInt64Type", "ConstructorArguments", {})
+        end
     end
 end

--- a/matlab/src/matlab/+arrow/+type/UInt8Type.m
+++ b/matlab/src/matlab/+arrow/+type/UInt8Type.m
@@ -13,12 +13,12 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef UInt8Type < arrow.type.PrimitiveType
+classdef UInt8Type < arrow.type.FixedWidthType
 %UINT8TYPE Type class for uint8 data.
     
     methods 
         function obj = UInt8Type()
-            obj@arrow.type.PrimitiveType("Name", "arrow.type.proxy.UInt8Type", "ConstructorArguments", {})
+            obj@arrow.type.FixedWidthType("Name", "arrow.type.proxy.UInt8Type", "ConstructorArguments", {})
         end
     end
 end

--- a/matlab/src/matlab/+arrow/+type/UInt8Type.m
+++ b/matlab/src/matlab/+arrow/+type/UInt8Type.m
@@ -16,7 +16,9 @@
 classdef UInt8Type < arrow.type.PrimitiveType
 %UINT8TYPE Type class for uint8 data.
     
-    properties(SetAccess = protected)
-        ID = arrow.type.ID.UInt8
+    methods 
+        function obj = UInt8Type()
+            obj@arrow.type.PrimitiveType("Name", "arrow.type.proxy.UInt8Type", "ConstructorArguments", {})
+        end
     end
 end

--- a/matlab/test/arrow/array/hNumericArray.m
+++ b/matlab/test/arrow/array/hNumericArray.m
@@ -171,7 +171,7 @@ classdef hNumericArray < matlab.unittest.TestCase
         % Verify the array has the expected arrow.type.Type object
             data = tc.MatlabArrayFcn([1 2 3 4]);
             arrowArray = tc.ArrowArrayConstructor(data);
-            tc.verifyEqual(arrowArray.Type, tc.ArrowType);
+            tc.verifyEqual(arrowArray.Type.ID, tc.ArrowType.ID);
         end
     end
 end

--- a/matlab/test/arrow/array/tBooleanArray.m
+++ b/matlab/test/arrow/array/tBooleanArray.m
@@ -155,7 +155,7 @@ classdef tBooleanArray < matlab.unittest.TestCase
         % Verify the array has the expected arrow.type.Type object
             data = tc.MatlabArrayFcn([true false]);
             arrowArray = tc.ArrowArrayConstructor(data);
-            tc.verifyEqual(arrowArray.Type, tc.ArrowType);
+            tc.verifyEqual(arrowArray.Type.ID, tc.ArrowType.ID);
         end
     end
 end

--- a/matlab/test/arrow/array/tStringArray.m
+++ b/matlab/test/arrow/array/tStringArray.m
@@ -149,7 +149,7 @@ classdef tStringArray < matlab.unittest.TestCase
             % Verify the array has the expected arrow.type.Type object
             data = tc.MatlabArrayFcn(["A", "B"]);
             arrowArray = tc.ArrowArrayConstructor(data);
-            tc.verifyEqual(arrowArray.Type, tc.ArrowType);
+            tc.verifyEqual(arrowArray.Type.ID, tc.ArrowType.ID);
         end
 
         function Unicode(tc)

--- a/matlab/test/arrow/type/hFixedWidthType.m
+++ b/matlab/test/arrow/type/hFixedWidthType.m
@@ -13,9 +13,9 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef hPrimitiveType < matlab.unittest.TestCase
+classdef hFixedWidthType < matlab.unittest.TestCase
 % Test class that defines shared unit tests for classes that inherit from
-% arrow.type.PrimitiveType
+% arrow.type.FixedWidthType
 
     properties(Abstract)
         ArrowType

--- a/matlab/test/arrow/type/hPrimitiveType.m
+++ b/matlab/test/arrow/type/hPrimitiveType.m
@@ -39,13 +39,7 @@ classdef hPrimitiveType < matlab.unittest.TestCase
         function TestNumFields(testCase)
         % Verify NumFields is set to 0 for primitive types.
             arrowType = testCase.ArrowType;
-            testCase.verifyEqual(arrowType.NumFields, 0);
-        end
-
-        function TestNumBuffers(testCase)
-        % Verify NumBuffers is set to 2 for primitive types.
-            arrowType = testCase.ArrowType;
-            testCase.verifyEqual(arrowType.NumBuffers, 2);
+            testCase.verifyEqual(arrowType.NumFields, int32(0));
         end
     end
 end

--- a/matlab/test/arrow/type/tBooleanType.m
+++ b/matlab/test/arrow/type/tBooleanType.m
@@ -19,6 +19,6 @@ classdef tBooleanType < hPrimitiveType
     properties
         ArrowType = arrow.type.BooleanType
         TypeID = arrow.type.ID.Boolean
-        BitWidth = 1;
+        BitWidth = int32(1);
     end
 end

--- a/matlab/test/arrow/type/tBooleanType.m
+++ b/matlab/test/arrow/type/tBooleanType.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tBooleanType < hPrimitiveType
+classdef tBooleanType < hFixedWidthType
 % Test class for arrow.type.BooleanType
 
     properties

--- a/matlab/test/arrow/type/tFloat32Type.m
+++ b/matlab/test/arrow/type/tFloat32Type.m
@@ -19,6 +19,6 @@ classdef tFloat32Type < hPrimitiveType
     properties
         ArrowType = arrow.type.Float32Type
         TypeID = arrow.type.ID.Float32
-        BitWidth = 32;
+        BitWidth = int32(32);
     end
 end

--- a/matlab/test/arrow/type/tFloat32Type.m
+++ b/matlab/test/arrow/type/tFloat32Type.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tFloat32Type < hPrimitiveType
+classdef tFloat32Type < hFixedWidthType
 % Test class for arrow.type.Float32Type
 
     properties

--- a/matlab/test/arrow/type/tFloat64Type.m
+++ b/matlab/test/arrow/type/tFloat64Type.m
@@ -19,6 +19,6 @@ classdef tFloat64Type < hPrimitiveType
     properties
         ArrowType = arrow.type.Float64Type
         TypeID = arrow.type.ID.Float64
-        BitWidth = 64;
+        BitWidth = int32(64);
     end
 end

--- a/matlab/test/arrow/type/tFloat64Type.m
+++ b/matlab/test/arrow/type/tFloat64Type.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tFloat64Type < hPrimitiveType
+classdef tFloat64Type < hFixedWidthType
 % Test class for arrow.type.Float64Type
 
     properties

--- a/matlab/test/arrow/type/tID.m
+++ b/matlab/test/arrow/type/tID.m
@@ -26,22 +26,6 @@ classdef tID < matlab.unittest.TestCase
     end
 
     methods (Test)
-        function bitWidth(testCase)
-            import arrow.type.ID
-
-            typeIDs = [ID.Boolean, ID.UInt8, ID.Int8, ID.UInt16, ...
-                       ID.Int16, ID.UInt32, ID.Int32, ID.UInt64, ...
-                       ID.Int64, ID.Float32, ID.Float64];
-
-            expectedWidths = [1, 8, 8, 16, 16, 32, 32, 64, 64, 32, 64];
-
-            for ii = 1:numel(typeIDs)
-                actualWidth = bitWidth(typeIDs(ii)); 
-                expectedWidth = expectedWidths(ii);
-                testCase.verifyEqual(actualWidth, expectedWidth);
-            end
-        end
-
         function CastToUInt64(testCase)
             import arrow.type.ID
 

--- a/matlab/test/arrow/type/tInt16Type.m
+++ b/matlab/test/arrow/type/tInt16Type.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tInt16Type < hPrimitiveType
+classdef tInt16Type < hFixedWidthType
 % Test class for arrow.type.Int16Type
 
     properties

--- a/matlab/test/arrow/type/tInt16Type.m
+++ b/matlab/test/arrow/type/tInt16Type.m
@@ -19,6 +19,6 @@ classdef tInt16Type < hPrimitiveType
     properties
         ArrowType = arrow.type.Int16Type
         TypeID = arrow.type.ID.Int16
-        BitWidth = 16;
+        BitWidth = int32(16);
     end
 end

--- a/matlab/test/arrow/type/tInt32Type.m
+++ b/matlab/test/arrow/type/tInt32Type.m
@@ -19,6 +19,6 @@ classdef tInt32Type < hPrimitiveType
     properties
         ArrowType = arrow.type.Int32Type
         TypeID = arrow.type.ID.Int32
-        BitWidth = 32;
+        BitWidth = int32(32);
     end
 end

--- a/matlab/test/arrow/type/tInt32Type.m
+++ b/matlab/test/arrow/type/tInt32Type.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tInt32Type < hPrimitiveType
+classdef tInt32Type < hFixedWidthType
 % Test class for arrow.type.Int32Type
 
     properties

--- a/matlab/test/arrow/type/tInt64Type.m
+++ b/matlab/test/arrow/type/tInt64Type.m
@@ -19,6 +19,6 @@ classdef tInt64Type < hPrimitiveType
     properties
         ArrowType = arrow.type.Int64Type
         TypeID = arrow.type.ID.Int64
-        BitWidth = 64;
+        BitWidth = int32(64);
     end
 end

--- a/matlab/test/arrow/type/tInt64Type.m
+++ b/matlab/test/arrow/type/tInt64Type.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tInt64Type < hPrimitiveType
+classdef tInt64Type < hFixedWidthType
 % Test class for arrow.type.Int64Type
 
     properties

--- a/matlab/test/arrow/type/tInt8Type.m
+++ b/matlab/test/arrow/type/tInt8Type.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tInt8Type < hPrimitiveType
+classdef tInt8Type < hFixedWidthType
 % Test class for arrow.type.Int8Type
 
     properties

--- a/matlab/test/arrow/type/tInt8Type.m
+++ b/matlab/test/arrow/type/tInt8Type.m
@@ -19,6 +19,6 @@ classdef tInt8Type < hPrimitiveType
     properties
         ArrowType = arrow.type.Int8Type
         TypeID = arrow.type.ID.Int8
-        BitWidth = 8;
+        BitWidth = int32(8);
     end
 end

--- a/matlab/test/arrow/type/tStringType.m
+++ b/matlab/test/arrow/type/tStringType.m
@@ -25,14 +25,9 @@ classdef tStringType < matlab.unittest.TestCase
             tc.verifyEqual(type.ID, arrow.type.ID.String);
         end
 
-        function NumBuffers(tc)
-            type = arrow.type.StringType;
-            tc.verifyEqual(type.NumBuffers, 3);
-        end
-
         function NumFields(tc)
             type = arrow.type.StringType;
-            tc.verifyEqual(type.NumFields, 0);
+            tc.verifyEqual(type.NumFields, int32(0));
         end
 
     end

--- a/matlab/test/arrow/type/tTimeUnit.m
+++ b/matlab/test/arrow/type/tTimeUnit.m
@@ -31,9 +31,9 @@ classdef tTimeUnit < matlab.unittest.TestCase
             import arrow.type.TimeUnit
             units = [TimeUnit.Second, TimeUnit.Millisecond, ...
                               TimeUnit.Microsecond, TimeUnit.Nanosecond]';
-            ticksPerSecond = [1 1e3 1e6 1e9];
+            ticks = [1 1e3 1e6 1e9];
             for ii = 1:numel(units)
-                testCase.verifyEqual(units(ii).TicksPerSecond, ticksPerSecond(ii));
+                testCase.verifyEqual(ticksPerSecond(units(ii)), ticks(ii));
             end
         end
     end

--- a/matlab/test/arrow/type/tTimestampType.m
+++ b/matlab/test/arrow/type/tTimestampType.m
@@ -19,7 +19,7 @@ classdef tTimestampType < hPrimitiveType
     properties
         ArrowType = arrow.type.TimestampType
         TypeID = arrow.type.ID.Timestamp
-        BitWidth = 64;
+        BitWidth = int32(64);
     end
 
     methods(Test)

--- a/matlab/test/arrow/type/tTimestampType.m
+++ b/matlab/test/arrow/type/tTimestampType.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tTimestampType < hPrimitiveType
+classdef tTimestampType < hFixedWidthType
 % Test class for arrow.type.TimestampType
 
     properties

--- a/matlab/test/arrow/type/tUInt16Type.m
+++ b/matlab/test/arrow/type/tUInt16Type.m
@@ -19,6 +19,6 @@ classdef tUInt16Type < hPrimitiveType
     properties
         ArrowType = arrow.type.UInt16Type
         TypeID = arrow.type.ID.UInt16
-        BitWidth = 16;
+        BitWidth = int32(16);
     end
 end

--- a/matlab/test/arrow/type/tUInt16Type.m
+++ b/matlab/test/arrow/type/tUInt16Type.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tUInt16Type < hPrimitiveType
+classdef tUInt16Type < hFixedWidthType
 % Test class for arrow.type.UInt16Type
 
     properties

--- a/matlab/test/arrow/type/tUInt32Type.m
+++ b/matlab/test/arrow/type/tUInt32Type.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tUInt32Type < hPrimitiveType
+classdef tUInt32Type < hFixedWidthType
 % Test class for arrow.type.UInt32Type
 
     properties

--- a/matlab/test/arrow/type/tUInt32Type.m
+++ b/matlab/test/arrow/type/tUInt32Type.m
@@ -19,6 +19,6 @@ classdef tUInt32Type < hPrimitiveType
     properties
         ArrowType = arrow.type.UInt32Type
         TypeID = arrow.type.ID.UInt32
-        BitWidth = 32;
+        BitWidth = int32(32);
     end
 end

--- a/matlab/test/arrow/type/tUInt64Type.m
+++ b/matlab/test/arrow/type/tUInt64Type.m
@@ -19,6 +19,6 @@ classdef tUInt64Type < hPrimitiveType
     properties
         ArrowType = arrow.type.UInt64Type
         TypeID = arrow.type.ID.UInt64
-        BitWidth = 64;
+        BitWidth = int32(64);
     end
 end

--- a/matlab/test/arrow/type/tUInt64Type.m
+++ b/matlab/test/arrow/type/tUInt64Type.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tUInt64Type < hPrimitiveType
+classdef tUInt64Type < hFixedWidthType
 % Test class for arrow.type.UInt64Type
 
     properties

--- a/matlab/test/arrow/type/tUInt8Type.m
+++ b/matlab/test/arrow/type/tUInt8Type.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tUInt8Type < hPrimitiveType
+classdef tUInt8Type < hFixedWidthType
 % Test class for arrow.type.UInt64Type
 
     properties

--- a/matlab/test/arrow/type/tUInt8Type.m
+++ b/matlab/test/arrow/type/tUInt8Type.m
@@ -19,6 +19,6 @@ classdef tUInt8Type < hPrimitiveType
     properties
         ArrowType = arrow.type.UInt8Type
         TypeID = arrow.type.ID.UInt8
-        BitWidth = 8;
+        BitWidth = int32(8);
     end
 end

--- a/matlab/tools/cmake/BuildMatlabArrowInterface.cmake
+++ b/matlab/tools/cmake/BuildMatlabArrowInterface.cmake
@@ -51,6 +51,7 @@ set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_SOURCES "${CMAKE_SOURCE_DIR}/src/cpp/a
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/time_unit.cc"
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy/type.cc"
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy/fixed_width_type.cc"
+                                                  "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy/string_type.cc"
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy/timestamp_type.cc")
 
 set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_FACTORY_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/proxy")

--- a/matlab/tools/cmake/BuildMatlabArrowInterface.cmake
+++ b/matlab/tools/cmake/BuildMatlabArrowInterface.cmake
@@ -37,7 +37,8 @@ set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_LIBRARY_ROOT_INCLUDE_DIR "${CMAKE_SOUR
 set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/array/proxy"
                                                       "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/bit"
                                                       "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/error"
-                                                      "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type")
+                                                      "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type"
+                                                      "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy")
 
 
 set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_SOURCES "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/array/proxy/array.cc"
@@ -47,7 +48,8 @@ set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_SOURCES "${CMAKE_SOURCE_DIR}/src/cpp/a
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/tabular/proxy/record_batch.cc"
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/bit/pack.cc"
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/bit/unpack.cc"
-                                                  "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/time_unit.cc")
+                                                  "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/time_unit.cc"
+                                                  "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy/type.cc")
 
 set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_FACTORY_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/proxy")
 set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_FACTORY_SOURCES "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/proxy/factory.cc")

--- a/matlab/tools/cmake/BuildMatlabArrowInterface.cmake
+++ b/matlab/tools/cmake/BuildMatlabArrowInterface.cmake
@@ -49,7 +49,8 @@ set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_SOURCES "${CMAKE_SOURCE_DIR}/src/cpp/a
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/bit/pack.cc"
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/bit/unpack.cc"
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/time_unit.cc"
-                                                  "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy/type.cc")
+                                                  "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy/type.cc"
+                                                  "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy/timestamp_type.cc")
 
 set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_FACTORY_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/proxy")
 set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_FACTORY_SOURCES "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/proxy/factory.cc")

--- a/matlab/tools/cmake/BuildMatlabArrowInterface.cmake
+++ b/matlab/tools/cmake/BuildMatlabArrowInterface.cmake
@@ -50,6 +50,7 @@ set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_SOURCES "${CMAKE_SOURCE_DIR}/src/cpp/a
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/bit/unpack.cc"
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/time_unit.cc"
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy/type.cc"
+                                                  "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy/fixed_width_type.cc"
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy/timestamp_type.cc")
 
 set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_FACTORY_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/proxy")


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

In the original pull request in which we added the MATLAB `arrow.type.<Type>Type` classes (e.g. `arrow.type.Float32Type`), we did implement these classes as proxies. At the time, we weren't sure if it would be advantageous to implement the type classes as proxies, but now realize it will be for composite data structures, i.e. `Schema`, `StructArray`, `ListArray`. 

### What changes are included in this PR?

1. All classes within the `arrow.type.Type` class hierarchy are implemented as proxies. 


### Are these changes tested?

Yes, we had existing tests for these classes. 


### Are there any user-facing changes?

No.

### Future Directions

1. In a followup PR request, we plan on integrating the proxy type classes and the array classes so that they share the same underlying C++` arrow::DataType` object. We thought doing so in this change would be too much code churn.


### Notes

Thank you @kevingurney for the help!


* Closes: #36363