### PR TITLE
GH-36429: [C++][Python] Wrap and Unwrap Functions for Other PyArrow Objects

### DIFF
--- a/docs/source/python/integration/extending.rst
+++ b/docs/source/python/integration/extending.rst
@@ -146,6 +146,41 @@ C++ objects.
    Return whether *obj* wraps an Arrow C++ :type:`SparseCSRMatrix` pointer;
    in other words, whether *obj* is a :py:class:`pyarrow.SparseCSRMatrix` instance.
 
+.. function:: bool arrow::py::is_expression(PyObject* obj)
+
+   Return whether *obj* wraps an Arrow C++ :type:`compute::Expression` pointer;
+   in other words, whether *obj* is a :py:class:`pyarrow.compute.Expression` instance.
+
+.. function:: bool arrow::py::is_filesystem(PyObject* obj)
+
+   Return whether *obj* wraps an Arrow C++ :type:`filesystem::FileSystem` pointer;
+   in other words, whether *obj* is a :py:class:`pyarrow.fs.FileSystem` instance.
+
+.. function:: bool arrow::py::is_dataset(PyObject* obj)
+
+   Return whether *obj* wraps an Arrow C++ :type:`dataset::Dataset` pointer;
+   in other words, whether *obj* is a :py:class:`pyarrow.dataset.Dataset` instance.
+
+.. function:: bool arrow::py::is_fragment(PyObject* obj)
+
+   Return whether *obj* wraps an Arrow C++ :type:`dataset::Fragment` pointer;
+   in other words, whether *obj* is a :py:class:`pyarrow.dataset.Fragment` instance.
+
+.. function:: bool arrow::py::is_partitioning(PyObject* obj)
+
+   Return whether *obj* wraps an Arrow C++ :type:`dataset::Partitioning` pointer;
+   in other words, whether *obj* is a :py:class:`pyarrow.dataset.Partitioning` instance.
+
+.. function:: bool arrow::py::is_scanner(PyObject* obj)
+
+   Return whether *obj* wraps an Arrow C++ :type:`dataset::Scanner` pointer;
+   in other words, whether *obj* is a :py:class:`pyarrow.dataset.Scanner` instance.
+
+.. function:: bool arrow::py::is_record_batch_reader(PyObject* obj)
+
+   Return whether *obj* wraps an Arrow C++ :type:`RecordBatchReader` pointer;
+   in other words, whether *obj* is a :py:class:`pyarrow.RecordBatchReader` instance.
+
 
 The following functions expect a pyarrow object, unwrap the underlying
 Arrow C++ API pointer, and return it as a :class:`Result` object.  An error
@@ -203,6 +238,34 @@ may be returned if the input object doesn't have the expected type.
 
    Unwrap and return the Arrow C++ :type:`SparseCSRMatrix` pointer from *obj*.
 
+.. function:: Result<std::shared_ptr<compute::Expression>> arrow::py::unwrap_expression(PyObject* obj)
+
+   Unwrap and return the Arrow C++ :type:`compute::Expression` pointer from *obj*.
+
+.. function:: Result<std::shared_ptr<filesystem::FileSystem>> arrow::py::unwrap_filesystem(PyObject* obj)
+
+   Unwrap and return the Arrow C++ :type:`filesystem::FileSystem` pointer from *obj*.
+
+.. function:: Result<std::shared_ptr<dataset::Dataset>> arrow::py::unwrap_dataset(PyObject* obj)
+
+   Unwrap and return the Arrow C++ :type:`dataset::Dataset` pointer from *obj*.
+
+.. function:: Result<std::shared_ptr<dataset::Fragment>> arrow::py::unwrap_fragment(PyObject* obj)
+
+   Unwrap and return the Arrow C++ :type:`dataset::Fragment` pointer from *obj*.
+
+.. function:: Result<std::shared_ptr<dataset::Partitioning>> arrow::py::unwrap_partitioning(PyObject* obj)
+
+   Unwrap and return the Arrow C++ :type:`dataset::Partitioning` pointer from *obj*.
+
+.. function:: Result<std::shared_ptr<dataset::Scanner>> arrow::py::unwrap_scanner(PyObject* obj)
+
+   Unwrap and return the Arrow C++ :type:`dataset::Scanner` pointer from *obj*.
+
+.. function:: Result<std::shared_ptr<RecordBatchReader>> arrow::py::unwrap_record_batch_reader(PyObject* obj)
+
+   Unwrap and return the Arrow C++ :type:`RecordBatchReader` pointer from *obj*.
+
 
 The following functions take an Arrow C++ API pointer and wrap it in a
 pyarray object of the corresponding type.  A new reference is returned.
@@ -259,6 +322,34 @@ On error, NULL is returned and a Python exception is set.
 .. function:: PyObject* arrow::py::wrap_sparse_csr_matrix(const std::shared_ptr<SparseCSRMatrix>& sparse_tensor)
 
    Wrap the Arrow C++ *sparse_tensor* in a :py:class:`pyarrow.SparseCSRMatrix` instance.
+
+.. function:: PyObject* arrow::py::wrap_expression(const std::shared_ptr<compute::Expression>& expr)
+
+   Wrap the Arrow C++ *compute expression* in a :py:class:`pyarrow.compute.Expression` instance.
+
+.. function:: PyObject* arrow::py::wrap_filesystem(const std::shared_ptr<filesystem::FileSystem>& fs)
+
+   Wrap the Arrow C++ *filesystem* in a :py:class:`pyarrow.fs.Filesystem` instance.
+
+.. function:: PyObject* arrow::py::wrap_dataset(const std::shared_ptr<dataset::Dataset>& dataset)
+
+   Wrap the Arrow C++ *dataset* in a :py:class:`pyarrow.dataset.Dataset` instance.
+
+.. function:: PyObject* arrow::py::wrap_fragment(const std::shared_ptr<dataset::Fragment>& frag)
+
+   Wrap the Arrow C++ *dataset fragment* in a :py:class:`pyarrow.dataset.Fragment` instance.
+
+.. function:: PyObject* arrow::py::wrap_partitioning(const std::shared_ptr<dataset::Partitioning>& part)
+
+   Wrap the Arrow C++ *dataset partitioning* in a :py:class:`pyarrow.dataset.Partitioning` instance.
+
+.. function:: PyObject* arrow::py::wrap_scanner(const std::shared_ptr<dataset::Scanner>& scanner)
+
+   Wrap the Arrow C++ *dataset scanner* in a :py:class:`pyarrow.dataset.Scanner` instance.
+
+.. function:: PyObject* arrow::py::wrap_record_batch_reader(const std::shared_ptr<RecordBatchReader>& rdr)
+
+   Wrap the Arrow C++ *RecordBatch reader* in a :py:class:`pyarrow.RecordBatchReader` instance.
 
 
 Cython API
@@ -336,6 +427,33 @@ an exception) if the input is not of the right type.
 
    Unwrap the Arrow C++ :cpp:type:`SparseCSRMatrix` pointer from *obj*.
 
+.. function:: pyarrow_unwrap_expression(obj) -> shared_ptr[compute.Expression]
+
+   Unwrap the Arrow C++ :cpp:class:`compute::Expression` pointer from *obj*.
+
+.. function:: pyarrow_unwrap_filesystem(obj) -> shared_ptr[filesystem.FileSystem]
+
+   Unwrap the Arrow C++ :cpp:class:`filesystem::FileSystem` pointer from *obj*.
+
+.. function:: pyarrow_unwrap_dataset(obj) -> shared_ptr[dataset.Dataset]
+
+   Unwrap the Arrow C++ :cpp:class:`dataset::Dataset` pointer from *obj*.
+
+.. function:: pyarrow_unwrap_fragment(obj) -> shared_ptr[dataset.Fragment]
+
+   Unwrap the Arrow C++ :cpp:class:`dataset::Fragment` pointer from *obj*.
+
+.. function:: pyarrow_unwrap_partitioning(obj) -> shared_ptr[dataset.Partitioning]
+
+   Unwrap the Arrow C++ :cpp:class:`dataset::Partitioning` pointer from *obj*.
+
+.. function:: pyarrow_unwrap_scanner(obj) -> shared_ptr[dataset.Scanner]
+
+   Unwrap the Arrow C++ :cpp:class:`dataset::Scanner` pointer from *obj*.
+
+.. function:: pyarrow_unwrap_record_batch_reader(obj) -> shared_ptr[RecordBatchReader]
+
+   Unwrap the Arrow C++ :cpp:class:`RecordBatchReader` pointer from *obj*.
 
 The following functions take a Arrow C++ API pointer and wrap it in a
 pyarray object of the corresponding type.  An exception is raised on error.
@@ -395,6 +513,35 @@ pyarray object of the corresponding type.  An exception is raised on error.
 .. function:: pyarrow_wrap_sparse_csr_matrix(const shared_ptr[CSparseCSRMatrix]& sparse_tensor) -> object
 
    Wrap the Arrow C++ *CSR sparse tensor* in a Python :class:`pyarrow.SparseCSRMatrix` instance.
+
+.. function:: pyarrow_wrap_expression(const shared_ptr[compute.Expression]& expr) -> object
+
+   Wrap the Arrow C++ *compute expression* in a :py:class:`pyarrow.compute.Expression` instance.
+
+.. function:: pyarrow_wrap_filesystem(const shared_ptr[filesystem.FileSystem]& fs) -> object
+
+   Wrap the Arrow C++ *filesystem* in a :py:class:`pyarrow.fs.Filesystem` instance.
+
+.. function:: pyarrow_wrap_dataset(const shared_ptr[dataset.Dataset]& dataset) -> object
+
+   Wrap the Arrow C++ *dataset* in a :py:class:`pyarrow.dataset.Dataset` instance.
+
+.. function:: pyarrow_wrap_fragment(const shared_ptr[dataset.Fragment]& frag) -> object
+
+   Wrap the Arrow C++ *dataset fragment* in a :py:class:`pyarrow.dataset.Fragment` instance.
+
+.. function:: pyarrow_wrap_partitioning(const shared_ptr[dataset.Partitioning]& part) -> object
+
+   Wrap the Arrow C++ *dataset partitioning* in a :py:class:`pyarrow.dataset.Partitioning` instance.
+
+.. function:: pyarrow_wrap_scanner(const shared_ptr[dataset.Scanner]& scanner) -> object
+
+   Wrap the Arrow C++ *dataset scanner* in a :py:class:`pyarrow.dataset.Scanner` instance.
+
+.. function:: pyarrow_wrap_record_batch_reader(const shared_ptr[RecordBatchReader]& rdr) -> object
+
+   Wrap the Arrow C++ *RecordBatch reader* in a :py:class:`pyarrow.RecordBatchReader` instance.
+
 
 
 Example

--- a/python/pyarrow/__init__.pxd
+++ b/python/pyarrow/__init__.pxd
@@ -16,7 +16,7 @@
 # under the License.
 
 from libcpp.memory cimport shared_ptr
-from pyarrow.includes.libarrow cimport (CArray, CBuffer, CDataType,
+from pyarrow.includes.libarrow cimport (CArray, CBuffer, CDataType, CExpression
                                         CField, CRecordBatch, CSchema,
                                         CTable, CTensor, CSparseCOOTensor,
                                         CSparseCSRMatrix, CSparseCSCMatrix,
@@ -40,3 +40,4 @@ cdef extern from "arrow/python/pyarrow.h" namespace "arrow::py":
         const shared_ptr[CSparseCSFTensor]& sp_sparse_tensor)
     cdef object wrap_table(const shared_ptr[CTable]& ctable)
     cdef object wrap_batch(const shared_ptr[CRecordBatch]& cbatch)
+    cdef object wrap_expression(const shared_ptr[CExpression]& cexpr)

--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -637,18 +637,18 @@ cdef public object pyarrow_wrap_sparse_csr_matrix(
     const shared_ptr[CSparseCSRMatrix]& sp_sparse_tensor)
 cdef public object pyarrow_wrap_tensor(const shared_ptr[CTensor]& sp_tensor)
 
-cdef public object pyarrow_wrap_batch(const shared_ptr[CRecordBatch]& cbatch)
-cdef public object pyarrow_wrap_table(const shared_ptr[CTable]& ctable)
+# cdef public object pyarrow_wrap_batch(const shared_ptr[CRecordBatch]& cbatch)
+# cdef public object pyarrow_wrap_table(const shared_ptr[CTable]& ctable)
 
 cdef public object pyarrow_wrap_expression(const shared_ptr[CExpression]& cexpr)
-cdef public object pyarrow_wrap_filesystem(const shared_ptr[CFileSystem]& cfs)
+# cdef public object pyarrow_wrap_filesystem(const shared_ptr[CFileSystem]& cfs)
 
-cdef public object pyarrow_wrap_dataset(const shared_ptr[CDataset]& cdataset)
-cdef public object pyarrow_wrap_fragment(const shared_ptr[CFragment]& cfrag)
-cdef public object pyarrow_wrap_partitioning(const shared_ptr[CPartitioning]& cpart)
+# cdef public object pyarrow_wrap_dataset(const shared_ptr[CDataset]& cdataset)
+# cdef public object pyarrow_wrap_fragment(const shared_ptr[CFragment]& cfrag)
+# cdef public object pyarrow_wrap_partitioning(const shared_ptr[CPartitioning]& cpart)
 
-cdef public object pyarrow_wrap_scanner(const shared_ptr[CScanner]& cscanner)
-cdef public object pyarrow_wrap_record_batch_reader(const shared_ptr[CRecordBatchReader]& crdr)
+# cdef public object pyarrow_wrap_scanner(const shared_ptr[CScanner]& cscanner)
+# cdef public object pyarrow_wrap_record_batch_reader(const shared_ptr[CRecordBatchReader]& crdr)
 
 # Unwrapping Python -> C++
 
@@ -678,11 +678,11 @@ cdef public shared_ptr[CRecordBatch] pyarrow_unwrap_batch(object batch)
 cdef public shared_ptr[CTable] pyarrow_unwrap_table(object table)
 
 cdef public shared_ptr[CExpression] pyarrow_unwrap_expression(object expr)
-cdef public shared_ptr[CFileSystem] pyarrow_unwrap_filesystem(object fs)
+# cdef public shared_ptr[CFileSystem] pyarrow_unwrap_filesystem(object fs)
 
-cdef public shared_ptr[CDataset] pyarrow_unwrap_dataset(object dataset)
-cdef public shared_ptr[CFragment] pyarrow_unwrap_fragment(object frag)
-cdef public shared_ptr[CPartitioning] pyarrow_unwrap_partitioning(object part)
+# cdef public shared_ptr[CDataset] pyarrow_unwrap_dataset(object dataset)
+# cdef public shared_ptr[CFragment] pyarrow_unwrap_fragment(object frag)
+# cdef public shared_ptr[CPartitioning] pyarrow_unwrap_partitioning(object part)
 
-cdef public shared_ptr[CScanner] pyarrow_unwrap_scanner(object scanner)
-cdef public shared_ptr[CRecordBatchReader] pyarrow_unwrap_record_batch_reader(object rdr)
+# cdef public shared_ptr[CScanner] pyarrow_unwrap_scanner(object scanner)
+# cdef public shared_ptr[CRecordBatchReader] pyarrow_unwrap_record_batch_reader(object rdr)

--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -23,6 +23,8 @@ from libcpp.cast cimport dynamic_cast
 from libcpp.memory cimport dynamic_pointer_cast
 from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport *
+from pyarrow.includes.libarrow_dataset cimport *
+from pyarrow.includes.libarrow_fs cimport *
 from pyarrow.includes.libarrow_python cimport *
 
 # Will be available in Cython 3, not backported

--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -638,6 +638,16 @@ cdef public object pyarrow_wrap_tensor(const shared_ptr[CTensor]& sp_tensor)
 cdef public object pyarrow_wrap_batch(const shared_ptr[CRecordBatch]& cbatch)
 cdef public object pyarrow_wrap_table(const shared_ptr[CTable]& ctable)
 
+cdef public object pyarrow_wrap_expression(const shared_ptr[CExpression]& cexpr)
+cdef public object pyarrow_wrap_filesystem(const shared_ptr[CFileSystem]& cfs)
+
+cdef public object pyarrow_wrap_dataset(const shared_ptr[CDataset]& cdataset)
+cdef public object pyarrow_wrap_fragment(const shared_ptr[CFragment]& cfrag)
+cdef public object pyarrow_wrap_partitioning(const shared_ptr[CPartitioning]& cpart)
+
+cdef public object pyarrow_wrap_scanner(const shared_ptr[CScanner]& cscanner)
+cdef public object pyarrow_wrap_record_batch_reader(const shared_ptr[CRecordBatchReader]& crdr)
+
 # Unwrapping Python -> C++
 
 cdef public shared_ptr[CBuffer] pyarrow_unwrap_buffer(object buffer)
@@ -664,3 +674,13 @@ cdef public shared_ptr[CTensor] pyarrow_unwrap_tensor(object tensor)
 
 cdef public shared_ptr[CRecordBatch] pyarrow_unwrap_batch(object batch)
 cdef public shared_ptr[CTable] pyarrow_unwrap_table(object table)
+
+cdef public shared_ptr[CExpression] pyarrow_unwrap_expression(object expr)
+cdef public shared_ptr[CFileSystem] pyarrow_unwrap_filesystem(object fs)
+
+cdef public shared_ptr[CDataset] pyarrow_unwrap_dataset(object dataset)
+cdef public shared_ptr[CFragment] pyarrow_unwrap_fragment(object frag)
+cdef public shared_ptr[CPartitioning] pyarrow_unwrap_partitioning(object part)
+
+cdef public shared_ptr[CScanner] pyarrow_unwrap_scanner(object scanner)
+cdef public shared_ptr[CRecordBatchReader] pyarrow_unwrap_record_batch_reader(object rdr)

--- a/python/pyarrow/public-api.pxi
+++ b/python/pyarrow/public-api.pxi
@@ -436,7 +436,7 @@ cdef api bint pyarrow_is_expression(object expr):
 
 
 cdef api shared_ptr[CExpression] pyarrow_unwrap_expression(object expr):
-    Expression = _pc().Expression
+    from pyarrow.compute import Expression
     cdef Expression expression
     if pyarrow_is_expression(expr):
         expression = <Expression>(expr)
@@ -449,7 +449,7 @@ cdef api object pyarrow_wrap_expression(const shared_ptr[CExpression]& cexpr):
     if cexpr.get() == NULL:
         raise ValueError('Expression was NULL')
 
-    Expression = _pc().Expression
+    from pyarrow.compute import Expression
     cdef Expression expr = Expression.__new__(Expression)
     expr.init(cexpr)
     return expr

--- a/python/pyarrow/public-api.pxi
+++ b/python/pyarrow/public-api.pxi
@@ -16,14 +16,16 @@
 # under the License.
 
 from libcpp.memory cimport shared_ptr
-from pyarrow.includes.libarrow cimport (CArray, CDataType, CExpression,
-                                        CField, CRecordBatch, CRecordBatchReader,
-                                        CSchema, CTable, CTensor,
-                                        CSparseCOOTensor, CSparseCSRMatrix,
-                                        CSparseCSCMatrix, CSparseCSFTensor)
-from pyarrow.includes.libarrow_dataset cimport (CDataset, CFragment,
-                                                CPartitioning, CScanner)
-from pyarrow.includes.libarrow_fs cimport CFileSystem
+from pyarrow.includes.libarrow cimport (
+    CArray, CDataType, CExpression,
+    CField, CRecordBatch, CRecordBatchReader,
+    CSchema, CTable, CTensor,
+    CSparseCOOTensor, CSparseCSRMatrix,
+    CSparseCSCMatrix, CSparseCSFTensor
+)
+# from pyarrow.includes.libarrow_dataset cimport (CDataset, CFragment,
+#                                                 CPartitioning, CScanner)
+# from pyarrow.includes.libarrow_fs cimport CFileSystem
 
 # You cannot assign something to a dereferenced pointer in Cython thus these
 # methods don't use Status to indicate a successful operation.
@@ -443,120 +445,123 @@ cdef api shared_ptr[CExpression] pyarrow_unwrap_expression(object expr):
 
 
 cdef api object pyarrow_wrap_expression(const shared_ptr[CExpression]& cexpr):
+    if cexpr.get() == NULL:
+        raise ValueError('Expression was NULL')
+
     cdef Expression expr = Expression.__new__(Expression)
     expr.init(cexpr)
     return expr
 
 
-cdef api bint pyarrow_is_filesystem(object fs):
-    return isinstance(fs, FileSystem)
+# cdef api bint pyarrow_is_filesystem(object fs):
+#     return isinstance(fs, FileSystem)
 
 
-cdef api shared_ptr[CFileSystem] pyarrow_unwrap_filesystem(object fs):
-    cdef FileSystem filesystem
-    if pyarrow_is_filesystem(fs):
-        filesystem = <FileSystem>(fs)
-        return filesystem.unwrap()
+# cdef api shared_ptr[CFileSystem] pyarrow_unwrap_filesystem(object fs):
+#     cdef FileSystem filesystem
+#     if pyarrow_is_filesystem(fs):
+#         filesystem = <FileSystem>(fs)
+#         return filesystem.unwrap()
 
-    return shared_ptr[CFileSystem]()
-
-
-cdef api object pyarrow_wrap_filesystem(const shared_ptr[CFileSystem]& cfs):
-    cdef FileSystem fs = FileSystem.__new__(FileSystem)
-    fs.init(cfs)
-    return fs
+#     return shared_ptr[CFileSystem]()
 
 
-cdef api bint pyarrow_is_dataset(object dataset):
-    return isinstance(dataset, Dataset)
+# cdef api object pyarrow_wrap_filesystem(const shared_ptr[CFileSystem]& cfs):
+#     cdef FileSystem fs = FileSystem.__new__(FileSystem)
+#     fs.init(cfs)
+#     return fs
 
 
-cdef api shared_ptr[CDataset] pyarrow_unwrap_dataset(object dataset):
-    cdef Dataset d
-    if pyarrow_is_dataset(dataset):
-        d = <Dataset>(dataset)
-        return d.unwrap()
-
-    return shared_ptr[CDataset]()
+# cdef api bint pyarrow_is_dataset(object dataset):
+#     return isinstance(dataset, Dataset)
 
 
-cdef api object pyarrow_wrap_dataset(const shared_ptr[CDataset]& cdataset):
-    cdef Dataset dataset = Dataset.__new__(Dataset)
-    dataset.init(cdataset)
-    return dataset
+# cdef api shared_ptr[CDataset] pyarrow_unwrap_dataset(object dataset):
+#     cdef Dataset d
+#     if pyarrow_is_dataset(dataset):
+#         d = <Dataset>(dataset)
+#         return d.unwrap()
+
+#     return shared_ptr[CDataset]()
 
 
-cdef api bint pyarrow_is_fragment(object frag):
-    return isinstance(frag, Fragment)
+# cdef api object pyarrow_wrap_dataset(const shared_ptr[CDataset]& cdataset):
+#     cdef Dataset dataset = Dataset.__new__(Dataset)
+#     dataset.init(cdataset)
+#     return dataset
 
 
-cdef api shared_ptr[CFragment] pyarrow_unwrap_fragment(object frag):
-    cdef Fragment fragment
-    if pyarrow_is_dataset(frag):
-        fragment = <Fragment>(frag)
-        return fragment.unwrap()
-
-    return shared_ptr[CFragment]()
+# cdef api bint pyarrow_is_fragment(object frag):
+#     return isinstance(frag, Fragment)
 
 
-cdef api object pyarrow_wrap_fragment(const shared_ptr[CFragment]& cfrag):
-    cdef Fragment frag = Fragment.__new__(Fragment)
-    frag.init(cfrag)
-    return frag
+# cdef api shared_ptr[CFragment] pyarrow_unwrap_fragment(object frag):
+#     cdef Fragment fragment
+#     if pyarrow_is_dataset(frag):
+#         fragment = <Fragment>(frag)
+#         return fragment.unwrap()
+
+#     return shared_ptr[CFragment]()
 
 
-cdef api bint pyarrow_is_partitioning(object part):
-    return isinstance(part, Partitioning)
+# cdef api object pyarrow_wrap_fragment(const shared_ptr[CFragment]& cfrag):
+#     cdef Fragment frag = Fragment.__new__(Fragment)
+#     frag.init(cfrag)
+#     return frag
 
 
-cdef api shared_ptr[CPartitioning] pyarrow_unwrap_dataset(object part):
-    cdef Partitioning partitioning
-    if pyarrow_is_partitioning(part):
-        partitioning = <Partitioning>(part)
-        return partitioning.unwrap()
-
-    return shared_ptr[CPartitioning]()
+# cdef api bint pyarrow_is_partitioning(object part):
+#     return isinstance(part, Partitioning)
 
 
-cdef api object pyarrow_wrap_partitioning(const shared_ptr[CPartitioning]& cpart):
-    cdef Partitioning part = Partitioning.__new__(Partitioning)
-    part.init(cpart)
-    return part
+# cdef api shared_ptr[CPartitioning] pyarrow_unwrap_dataset(object part):
+#     cdef Partitioning partitioning
+#     if pyarrow_is_partitioning(part):
+#         partitioning = <Partitioning>(part)
+#         return partitioning.unwrap()
+
+#     return shared_ptr[CPartitioning]()
 
 
-cdef api bint pyarrow_is_scanner(object scanner):
-    return isinstance(scanner, Scanner)
+# cdef api object pyarrow_wrap_partitioning(const shared_ptr[CPartitioning]& cpart):
+#     cdef Partitioning part = Partitioning.__new__(Partitioning)
+#     part.init(cpart)
+#     return part
 
 
-cdef api shared_ptr[CScanner] pyarrow_unwrap_scanner(object scanner):
-    cdef Scanner s
-    if pyarrow_is_scanner(scanner):
-        s = <Scanner>(scanner)
-        return s.unwrap()
-
-    return shared_ptr[CScanner]()
+# cdef api bint pyarrow_is_scanner(object scanner):
+#     return isinstance(scanner, Scanner)
 
 
-cdef api object pyarrow_wrap_scanner(const shared_ptr[CScanner]& cscanner):
-    cdef Scanner scanner = Scanner.__new__(Scanner)
-    scanner.init(cscanner)
-    return scanner
+# cdef api shared_ptr[CScanner] pyarrow_unwrap_scanner(object scanner):
+#     cdef Scanner s
+#     if pyarrow_is_scanner(scanner):
+#         s = <Scanner>(scanner)
+#         return s.unwrap()
+
+#     return shared_ptr[CScanner]()
 
 
-cdef api bint pyarrow_is_record_batch_reader(object rdr):
-    return isinstance(rdr, RecordBatchReader)
+# cdef api object pyarrow_wrap_scanner(const shared_ptr[CScanner]& cscanner):
+#     cdef Scanner scanner = Scanner.__new__(Scanner)
+#     scanner.init(cscanner)
+#     return scanner
 
 
-cdef api shared_ptr[CRecordBatchReader] pyarrow_unwrap_record_batch_reader(object rdr):
-    cdef RecordBatchReader record_batch_reader
-    if pyarrow_is_record_batch_reader(rdr):
-        record_batch_reader = <RecordBatchReader>(rdr)
-        return record_batch_reader.unwrap()
-
-    return shared_ptr[CRecordBatchReader]()
+# cdef api bint pyarrow_is_record_batch_reader(object rdr):
+#     return isinstance(rdr, RecordBatchReader)
 
 
-cdef api object pyarrow_wrap_record_batch_reader(const shared_ptr[CRecordBatchReader]& crdr):
-    cdef RecordBatchReader rdr = RecordBatchReader.__new__(RecordBatchReader)
-    rdr.init(crdr)
-    return rdr
+# cdef api shared_ptr[CRecordBatchReader] pyarrow_unwrap_record_batch_reader(object rdr):
+#     cdef RecordBatchReader record_batch_reader
+#     if pyarrow_is_record_batch_reader(rdr):
+#         record_batch_reader = <RecordBatchReader>(rdr)
+#         return record_batch_reader.unwrap()
+
+#     return shared_ptr[CRecordBatchReader]()
+
+
+# cdef api object pyarrow_wrap_record_batch_reader(const shared_ptr[CRecordBatchReader]& crdr):
+#     cdef RecordBatchReader rdr = RecordBatchReader.__new__(RecordBatchReader)
+#     rdr.init(crdr)
+#     return rdr

--- a/python/pyarrow/public-api.pxi
+++ b/python/pyarrow/public-api.pxi
@@ -432,10 +432,11 @@ cdef api object pyarrow_wrap_batch(
 
 
 cdef api bint pyarrow_is_expression(object expr):
-    return isinstance(expr, Expression)
+    return isinstance(expr, _pc().Expression)
 
 
 cdef api shared_ptr[CExpression] pyarrow_unwrap_expression(object expr):
+    Expression = _pc().Expression
     cdef Expression expression
     if pyarrow_is_expression(expr):
         expression = <Expression>(expr)
@@ -448,6 +449,7 @@ cdef api object pyarrow_wrap_expression(const shared_ptr[CExpression]& cexpr):
     if cexpr.get() == NULL:
         raise ValueError('Expression was NULL')
 
+    Expression = _pc().Expression
     cdef Expression expr = Expression.__new__(Expression)
     expr.init(cexpr)
     return expr

--- a/python/pyarrow/public-api.pxi
+++ b/python/pyarrow/public-api.pxi
@@ -16,9 +16,11 @@
 # under the License.
 
 from libcpp.memory cimport shared_ptr
-from pyarrow.includes.libarrow cimport (CArray, CDataType, CField,
-                                        CRecordBatch, CSchema,
-                                        CTable, CTensor,
+from pyarrow.includes.libarrow cimport (CArray, CDataset, CDataType,
+                                        CExpression, CField, CFileSystem,
+                                        CFragment, CPartitioning,
+                                        CRecordBatch, CRecordBatchReader,
+                                        CScanner, CSchema, CTable, CTensor,
                                         CSparseCOOTensor, CSparseCSRMatrix,
                                         CSparseCSCMatrix, CSparseCSFTensor)
 
@@ -424,3 +426,136 @@ cdef api object pyarrow_wrap_batch(
     cdef RecordBatch batch = RecordBatch.__new__(RecordBatch)
     batch.init(cbatch)
     return batch
+
+
+cdef api bint pyarrow_is_expression(object expr):
+    return isinstance(expr, Expression)
+
+
+cdef api shared_ptr[CExpression] pyarrow_unwrap_expression(object expr):
+    cdef Expression expression
+    if pyarrow_is_expression(fs):
+        expression = <Expression>(fs)
+        return expression.unwrap()
+    
+    return shared_ptr[CExpression]()
+
+
+cdef api object pyarrow_wrap_expression(const shared_ptr[CExpression]& cexpr):
+    cdef Expression expr = Expression.__new__(Expression)
+    expr.init(cexpr)
+    return expr
+
+
+cdef api bint pyarrow_is_filesystem(object fs):
+    return isinstance(fs, FileSystem)
+
+
+cdef api shared_ptr[CFileSystem] pyarrow_unwrap_filesystem(object fs):
+    cdef FileSystem filesystem
+    if pyarrow_is_filesystem(fs):
+        filesystem = <FileSystem>(fs)
+        return filesystem.unwrap()
+    
+    return shared_ptr[CFileSystem]()
+
+
+cdef api object pyarrow_wrap_filesystem(const shared_ptr[CFileSystem]& cfs):
+    cdef FileSystem fs = FileSystem.__new__(FileSystem)
+    fs.init(cfs)
+    return fs
+
+
+cdef api bint pyarrow_is_dataset(object dataset):
+    return isinstance(dataset, Dataset)
+
+
+cdef api shared_ptr[CDataset] pyarrow_unwrap_dataset(object dataset):
+    cdef Dataset d
+    if pyarrow_is_dataset(dataset):
+        d = <Dataset>(dataset)
+        return d.unwrap()
+    
+    return shared_ptr[CDataset]()
+
+
+cdef api object pyarrow_wrap_dataset(const shared_ptr[CDataset]& cdataset):
+    cdef Dataset dataset = Dataset.__new__(Dataset)
+    dataset.init(cdataset)
+    return dataset
+
+
+cdef api bint pyarrow_is_fragment(object frag):
+    return isinstance(frag, Fragment)
+
+
+cdef api shared_ptr[CFragment] pyarrow_unwrap_fragment(object frag):
+    cdef Fragment fragment
+    if pyarrow_is_dataset(frag):
+        fragment = <Fragment>(frag)
+        return fragment.unwrap()
+    
+    return shared_ptr[CFragment]()
+
+
+cdef api object pyarrow_wrap_fragment(const shared_ptr[CFragment]& cfrag):
+    cdef Fragment frag = Fragment.__new__(Fragment)
+    frag.init(cfrag)
+    return frag
+
+
+cdef api bint pyarrow_is_partitioning(object part):
+    return isinstance(part, Partitioning)
+
+
+cdef api shared_ptr[CPartitioning] pyarrow_unwrap_dataset(object part):
+    cdef Partitioning partitioning
+    if pyarrow_is_partitioning(part):
+        partitioning = <Partitioning>(part)
+        return partitioning.unwrap()
+    
+    return shared_ptr[CPartitioning]()
+
+
+cdef api object pyarrow_wrap_partitioning(const shared_ptr[CPartitioning]& cpart):
+    cdef Partitioning part = Partitioning.__new__(Partitioning)
+    part.init(cpart)
+    return part
+
+
+cdef api bint pyarrow_is_scanner(object scanner):
+    return isinstance(scanner, Scanner)
+
+
+cdef api shared_ptr[CScanner] pyarrow_unwrap_scanner(object scanner):
+    cdef Scanner s
+    if pyarrow_is_scanner(scanner):
+        s = <Scanner>(scanner)
+        return s.unwrap()
+    
+    return shared_ptr[CScanner]()
+
+
+cdef api object pyarrow_wrap_scanner(const shared_ptr[CScanner]& cscanner):
+    cdef Scanner scanner = Scanner.__new__(Scanner)
+    scanner.init(cscanner)
+    return scanner
+
+
+cdef api bint pyarrow_is_record_batch_reader(object rdr):
+    return isinstance(rdr, RecordBatchReader)
+
+
+cdef api shared_ptr[CRecordBatchReader] pyarrow_unwrap_record_batch_reader(object rdr):
+    cdef RecordBatchReader record_batch_reader
+    if pyarrow_is_record_batch_reader(rdr):
+        record_batch_reader = <RecordBatchReader>(rdr)
+        return record_batch_reader.unwrap()
+    
+    return shared_ptr[CRecordBatchReader]()
+
+
+cdef api object pyarrow_wrap_record_batch_reader(const shared_ptr[CRecordBatchReader]& crdr):
+    cdef RecordBatchReader rdr = RecordBatchReader.__new__(RecordBatchReader)
+    rdr.init(crdr)
+    return rdr

--- a/python/pyarrow/public-api.pxi
+++ b/python/pyarrow/public-api.pxi
@@ -437,7 +437,7 @@ cdef api shared_ptr[CExpression] pyarrow_unwrap_expression(object expr):
     if pyarrow_is_expression(fs):
         expression = <Expression>(fs)
         return expression.unwrap()
-    
+
     return shared_ptr[CExpression]()
 
 
@@ -456,7 +456,7 @@ cdef api shared_ptr[CFileSystem] pyarrow_unwrap_filesystem(object fs):
     if pyarrow_is_filesystem(fs):
         filesystem = <FileSystem>(fs)
         return filesystem.unwrap()
-    
+
     return shared_ptr[CFileSystem]()
 
 
@@ -475,7 +475,7 @@ cdef api shared_ptr[CDataset] pyarrow_unwrap_dataset(object dataset):
     if pyarrow_is_dataset(dataset):
         d = <Dataset>(dataset)
         return d.unwrap()
-    
+
     return shared_ptr[CDataset]()
 
 
@@ -494,7 +494,7 @@ cdef api shared_ptr[CFragment] pyarrow_unwrap_fragment(object frag):
     if pyarrow_is_dataset(frag):
         fragment = <Fragment>(frag)
         return fragment.unwrap()
-    
+
     return shared_ptr[CFragment]()
 
 
@@ -513,7 +513,7 @@ cdef api shared_ptr[CPartitioning] pyarrow_unwrap_dataset(object part):
     if pyarrow_is_partitioning(part):
         partitioning = <Partitioning>(part)
         return partitioning.unwrap()
-    
+
     return shared_ptr[CPartitioning]()
 
 
@@ -532,7 +532,7 @@ cdef api shared_ptr[CScanner] pyarrow_unwrap_scanner(object scanner):
     if pyarrow_is_scanner(scanner):
         s = <Scanner>(scanner)
         return s.unwrap()
-    
+
     return shared_ptr[CScanner]()
 
 
@@ -551,7 +551,7 @@ cdef api shared_ptr[CRecordBatchReader] pyarrow_unwrap_record_batch_reader(objec
     if pyarrow_is_record_batch_reader(rdr):
         record_batch_reader = <RecordBatchReader>(rdr)
         return record_batch_reader.unwrap()
-    
+
     return shared_ptr[CRecordBatchReader]()
 
 

--- a/python/pyarrow/public-api.pxi
+++ b/python/pyarrow/public-api.pxi
@@ -16,13 +16,14 @@
 # under the License.
 
 from libcpp.memory cimport shared_ptr
-from pyarrow.includes.libarrow cimport (CArray, CDataset, CDataType,
-                                        CExpression, CField, CFileSystem,
-                                        CFragment, CPartitioning,
-                                        CRecordBatch, CRecordBatchReader,
-                                        CScanner, CSchema, CTable, CTensor,
+from pyarrow.includes.libarrow cimport (CArray, CDataType, CExpression,
+                                        CField, CRecordBatch, CRecordBatchReader,
+                                        CSchema, CTable, CTensor,
                                         CSparseCOOTensor, CSparseCSRMatrix,
                                         CSparseCSCMatrix, CSparseCSFTensor)
+from pyarrow.includes.libarrow_dataset cimport (CDataset, CFragment,
+                                                CPartitioning, CScanner)
+from pyarrow.includes.libarrow_fs cimport CFileSystem
 
 # You cannot assign something to a dereferenced pointer in Cython thus these
 # methods don't use Status to indicate a successful operation.
@@ -434,8 +435,8 @@ cdef api bint pyarrow_is_expression(object expr):
 
 cdef api shared_ptr[CExpression] pyarrow_unwrap_expression(object expr):
     cdef Expression expression
-    if pyarrow_is_expression(fs):
-        expression = <Expression>(fs)
+    if pyarrow_is_expression(expr):
+        expression = <Expression>(expr)
         return expression.unwrap()
 
     return shared_ptr[CExpression]()

--- a/python/pyarrow/src/arrow/python/pyarrow.cc
+++ b/python/pyarrow/src/arrow/python/pyarrow.cc
@@ -26,6 +26,10 @@
 #include "arrow/type.h"
 #include "arrow/util/logging.h"
 
+#include "arrow/compute/api.h"
+#include "arrow/dataset/api.h"
+#include "arrow/filesystem/api.h"
+
 #include "arrow/python/common.h"
 #include "arrow/python/datetime.h"
 namespace {
@@ -83,6 +87,16 @@ DEFINE_WRAP_FUNCTIONS(tensor, Tensor)
 
 DEFINE_WRAP_FUNCTIONS(batch, RecordBatch)
 DEFINE_WRAP_FUNCTIONS(table, Table)
+
+DEFINE_WRAP_FUNCTIONS(expression, Expression)
+DEFINE_WRAP_FUNCTIONS(filesystem, FileSystem)
+
+DEFINE_WRAP_FUNCTIONS(dataset, Dataset)
+DEFINE_WRAP_FUNCTIONS(fragment, Fragment)
+DEFINE_WRAP_FUNCTIONS(partitioning, Partitioning)
+
+DEFINE_WRAP_FUNCTIONS(scanner, Scanner)
+DEFINE_WRAP_FUNCTIONS(record_batch_reader, RecordBatchReader)
 
 #undef DEFINE_WRAP_FUNCTIONS
 

--- a/python/pyarrow/src/arrow/python/pyarrow.h
+++ b/python/pyarrow/src/arrow/python/pyarrow.h
@@ -32,16 +32,16 @@ namespace arrow {
 
 class Array;
 class Buffer;
-class Dataset;
+// class Dataset;
 class DataType;
 class Expression;
 class Field;
-class FileSystem;
-class Fragment;
+// class FileSystem;
+// class Fragment;
 class RecordBatch;
-class RecordBatchReader;
-class Partitioning;
-class Scanner;
+// class RecordBatchReader;
+// class Partitioning;
+// class Scanner;
 class Schema;
 class Status;
 class Table;
@@ -79,14 +79,14 @@ DECLARE_WRAP_FUNCTIONS(batch, RecordBatch)
 DECLARE_WRAP_FUNCTIONS(table, Table)
 
 DECLARE_WRAP_FUNCTIONS(expression, Expression)
-DECLARE_WRAP_FUNCTIONS(filesystem, FileSystem)
+// DECLARE_WRAP_FUNCTIONS(filesystem, FileSystem)
 
-DECLARE_WRAP_FUNCTIONS(dataset, Dataset)
-DECLARE_WRAP_FUNCTIONS(fragment, Fragment)
-DECLARE_WRAP_FUNCTIONS(partitioning, Partitioning)
+// DECLARE_WRAP_FUNCTIONS(dataset, Dataset)
+// DECLARE_WRAP_FUNCTIONS(fragment, Fragment)
+// DECLARE_WRAP_FUNCTIONS(partitioning, Partitioning)
 
-DECLARE_WRAP_FUNCTIONS(scanner, Scanner)
-DECLARE_WRAP_FUNCTIONS(record_batch_reader, RecordBatchReader)
+// DECLARE_WRAP_FUNCTIONS(scanner, Scanner)
+// DECLARE_WRAP_FUNCTIONS(record_batch_reader, RecordBatchReader)
 
 #undef DECLARE_WRAP_FUNCTIONS
 

--- a/python/pyarrow/src/arrow/python/pyarrow.h
+++ b/python/pyarrow/src/arrow/python/pyarrow.h
@@ -32,9 +32,16 @@ namespace arrow {
 
 class Array;
 class Buffer;
+class Dataset;
 class DataType;
+class Expression;
 class Field;
+class FileSystem;
+class Fragment;
 class RecordBatch;
+class RecordBatchReader;
+class Partitioning;
+class Scanner;
 class Schema;
 class Status;
 class Table;
@@ -70,6 +77,16 @@ DECLARE_WRAP_FUNCTIONS(tensor, Tensor)
 
 DECLARE_WRAP_FUNCTIONS(batch, RecordBatch)
 DECLARE_WRAP_FUNCTIONS(table, Table)
+
+DECLARE_WRAP_FUNCTIONS(expression, Expression)
+DECLARE_WRAP_FUNCTIONS(filesystem, FileSystem)
+
+DECLARE_WRAP_FUNCTIONS(dataset, Dataset)
+DECLARE_WRAP_FUNCTIONS(fragment, Fragment)
+DECLARE_WRAP_FUNCTIONS(partitioning, Partitioning)
+
+DECLARE_WRAP_FUNCTIONS(scanner, Scanner)
+DECLARE_WRAP_FUNCTIONS(record_batch_reader, RecordBatchReader)
 
 #undef DECLARE_WRAP_FUNCTIONS
 


### PR DESCRIPTION
### Rationale for this change

It is helpful for 3rd-party code that uses Arrow to sometimes create or get Arrow entities in Python code and then pass it in to C++ extension code. Or on the other hand, use the C++ code for missing options and then pass to Python.

### What changes are included in this PR?

This PR includes wrapper and unwrapper functions additional PyArrow objects like datasets, compute expressions, filesystems, and so on.

### Are these changes tested?

Not right now since none of the other wrapper functions were tested.

### Are there any user-facing changes?

Yes, additional user-facing functions were added, and the documentation was updated

* Closes: #36429