### PR TITLE
GH-35710: [R] Followup improvements to new configure script

### DIFF
--- a/r/configure
+++ b/r/configure
@@ -263,7 +263,6 @@ do_autobrew () {
 # Once libarrow is obtained, this function sets `PKG_LIBS`, `PKG_DIRS`, and `PKG_CFLAGS`
 # either from pkg-config or by inferring things about the directory in $1
 set_pkg_vars () {
-  LIB_DIR="$1/lib"
   if [ "$PKG_CONFIG_AVAILABLE" = "true" ]; then
     set_pkg_vars_with_pc
   else
@@ -281,6 +280,7 @@ set_pkg_vars () {
 
 # If we have pkg-config, it will tell us what libarrow needs
 set_pkg_vars_with_pc () {
+  LIB_DIR="`${PKG_CONFIG} --variable=libdir --silence-errors ${PKG_CONFIG_NAME}`"
   PKG_CFLAGS="`${PKG_CONFIG} --cflags --silence-errors ${PKG_CONFIG_NAME}` $PKG_CFLAGS"
   PKG_LIBS=`${PKG_CONFIG} --libs-only-l --libs-only-other --silence-errors ${PKG_CONFIG_NAME}`
   PKG_DIRS=`${PKG_CONFIG} --libs-only-L --silence-errors ${PKG_CONFIG_NAME}`
@@ -288,6 +288,7 @@ set_pkg_vars_with_pc () {
 
 # If we don't have pkg-config, we can make some inferences
 set_pkg_vars_without_pc () {
+  LIB_DIR="$1/lib"
   PKG_CFLAGS="-I$1/include $PKG_CFLAGS"
   if grep -q "_GLIBCXX_USE_CXX11_ABI=0" "${LIB_DIR}/pkgconfig/arrow.pc"; then
     PKG_CFLAGS="${PKG_CFLAGS} -D_GLIBCXX_USE_CXX11_ABI=0"

--- a/r/tools/check-versions.R
+++ b/r/tools/check-versions.R
@@ -24,6 +24,7 @@ check_versions <- function(r_version, cpp_version) {
   r_parsed <- package_version(r_version)
   r_dev_version <- r_parsed[1, 4]
   r_is_dev <- !is.na(r_dev_version) && r_dev_version > 100
+  r_is_patch <- !is.na(r_dev_version) && r_dev_version <= 100
   cpp_is_dev <- grepl("SNAPSHOT$", cpp_version)
   cpp_parsed <- package_version(sub("-SNAPSHOT$", "", cpp_version))
 
@@ -38,6 +39,16 @@ check_versions <- function(r_version, cpp_version) {
       "*** > or retry with FORCE_BUNDLED_BUILD=true"
     )
     cat(paste0(msg, "\n", collapse = ""))
+  } else if (r_is_patch && as.character(r_parsed[1, 1:3]) == cpp_version) {
+    # Patch releases we do for CRAN feedback get an extra x.y.z.1 version.
+    # These should work with the x.y.z C++ library (which never has .1 added)
+    cat(
+      sprintf(
+        "*** > Using C++ library version %s with R package %s\n",
+        cpp_version,
+        r_version
+      )
+    )
   } else if (r_version != cpp_version) {
     cat(
       sprintf(

--- a/r/tools/test-check-versions.R
+++ b/r/tools/test-check-versions.R
@@ -55,6 +55,11 @@ test_that("check_versions", {
     fixed = TRUE
   )
   expect_output(
+    check_versions("10.0.0.3", "10.0.0"),
+    "*** > Using C++ library version 10.0.0 with R package 10.0.0.3",
+    fixed = TRUE
+  )
+  expect_output(
     check_versions("10.0.0.9000", "11.0.0-SNAPSHOT"),
     "*** > Packages are both on development versions (11.0.0-SNAPSHOT, 10.0.0.9000)\n",
     fixed = TRUE


### PR DESCRIPTION
### Rationale for this change

See #35710

### What changes are included in this PR?

* [Get `LIB_DIR` from `pkg-config` where possible](https://github.com/apache/arrow/pull/36435/commits/c8d09eb7c1077f580100b808a307f92afd17dd38), to handle the possibility that it is `lib64` and not just `lib` on some platforms.
* [Allow x.y.z.1 to use x.y.z C++ library](https://github.com/apache/arrow/pull/36435/commits/a77f909830c89846fd5119de56c536a333e4f44b), so that apt/yum official release packages can be used with patched versions submitted to CRAN.

### Are these changes tested?

The version check change has a unit test. The LIB_DIR change hopefully is well enough covered by our existing CI.


* Closes: #35710