### PR TITLE
GH-36346: [C++][S3] Shutdown aws-sdk-cpp related resources on finalize

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -351,6 +351,10 @@ Status EnsureS3Initialized();
 ARROW_EXPORT
 bool IsS3Initialized();
 
+/// Whether S3 was finalized.
+ARROW_EXPORT
+bool IsS3Finalized();
+
 /// Shutdown the S3 APIs.
 ARROW_EXPORT
 Status FinalizeS3();


### PR DESCRIPTION
### Rationale for this change

`arrow::FinalizeS3()` doesn't call both of `RegionResolver::ResetDefaultInstance()` and `Aws::ShutdownAPI()` by #33858.

If we don't call both of them, some aws-sdk-cpp related objects are destroyed on exit. It may cause a crash.

### What changes are included in this PR?

This calls both of them by `arrow::FinalizeS3()` again to prevent crash on exit. All S3 related operations are failed after we call `arrow::fs::FinalizeS3()`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #36346