### PR TITLE
GH-35417: [GLib] Add GArrowRunEndEncodedDataType

### DIFF
--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2240,6 +2240,9 @@ garrow_data_type_new_raw(std::shared_ptr<arrow::DataType> *arrow_data_type)
     }
     type = GARROW_TYPE_EXTENSION_DATA_TYPE;
     break;
+  case arrow::Type::type::RUN_END_ENCODED:
+    type = GARROW_TYPE_RUN_END_ENCODED_DATA_TYPE;
+    break;
   default:
     type = GARROW_TYPE_DATA_TYPE;
     break;

--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -47,6 +47,8 @@ G_BEGIN_DECLS
  * #GArrowDenseUnionDataType is a class for dense union data type.
  *
  * #GArrowDictionaryDataType is a class for dictionary data type.
+ *
+ * #GArrowRunEndEncodedDataType is a class for run end encoded data type.
  */
 
 G_DEFINE_TYPE(GArrowListDataType,
@@ -716,5 +718,81 @@ garrow_dictionary_data_type_is_ordered(GArrowDictionaryDataType *dictionary_data
     std::static_pointer_cast<arrow::DictionaryType>(arrow_data_type);
   return arrow_dictionary_data_type->ordered();
 }
+
+
+G_DEFINE_TYPE(GArrowRunEndEncodedDataType,
+              garrow_run_end_encoded_data_type,
+              GARROW_TYPE_FIXED_WIDTH_DATA_TYPE)
+
+static void
+garrow_run_end_encoded_data_type_init(GArrowRunEndEncodedDataType *object)
+{
+}
+
+static void
+garrow_run_end_encoded_data_type_class_init(
+  GArrowRunEndEncodedDataTypeClass *klass)
+{
+}
+
+/**
+ * garrow_run_end_encoded_data_type_new:
+ * @run_end_data_type: The data type of run-end.
+ * @value_data_type: The data type of value.
+ *
+ * Returns: The newly created run-end encoded data type.
+ *
+ * Since: 13.0.0
+ */
+GArrowRunEndEncodedDataType *
+garrow_run_end_encoded_data_type_new(GArrowDataType *run_end_data_type,
+                                     GArrowDataType *value_data_type)
+{
+  auto arrow_run_end_data_type = garrow_data_type_get_raw(run_end_data_type);
+  auto arrow_value_data_type = garrow_data_type_get_raw(value_data_type);
+  auto arrow_data_type = arrow::run_end_encoded(arrow_run_end_data_type,
+                                                arrow_value_data_type);
+  return GARROW_RUN_END_ENCODED_DATA_TYPE(
+    garrow_data_type_new_raw(&arrow_data_type));
+}
+
+/**
+ * garrow_run_end_encoded_data_type_get_run_end_data_type:
+ * @data_type: The #GArrowRunEndEncodedDataType.
+ *
+ * Returns: (transfer full): The #GArrowDataType of run-end.
+ *
+ * Since: 13.0.0
+ */
+GArrowDataType *
+garrow_run_end_encoded_data_type_get_run_end_data_type(
+  GArrowRunEndEncodedDataType *data_type)
+{
+  auto arrow_data_type = garrow_data_type_get_raw(GARROW_DATA_TYPE(data_type));
+  auto arrow_run_end_encoded_data_type =
+    std::static_pointer_cast<arrow::RunEndEncodedType>(arrow_data_type);
+  auto arrow_run_end_data_type = arrow_run_end_encoded_data_type->run_end_type();
+  return garrow_data_type_new_raw(&arrow_run_end_data_type);
+}
+
+/**
+ * garrow_run_end_encoded_data_type_get_value_data_type:
+ * @data_type: The #GArrowRunEndEncodedDataType.
+ *
+ * Returns: (transfer full): The #GArrowDataType of value.
+ *
+ * Since: 13.0.0
+ */
+GArrowDataType *
+garrow_run_end_encoded_data_type_get_value_data_type(
+  GArrowRunEndEncodedDataType *data_type)
+{
+  auto arrow_data_type = garrow_data_type_get_raw(GARROW_DATA_TYPE(data_type));
+  auto arrow_run_end_encoded_data_type =
+    std::static_pointer_cast<arrow::RunEndEncodedType>(arrow_data_type);
+  auto arrow_value_data_type = arrow_run_end_encoded_data_type->value_type();
+  return garrow_data_type_new_raw(&arrow_value_data_type);
+}
+
 
 G_END_DECLS

--- a/c_glib/arrow-glib/composite-data-type.h
+++ b/c_glib/arrow-glib/composite-data-type.h
@@ -196,4 +196,30 @@ gboolean
 garrow_dictionary_data_type_is_ordered(GArrowDictionaryDataType *dictionary_data_type);
 
 
+#define GARROW_TYPE_RUN_END_ENCODED_DATA_TYPE   \
+  (garrow_run_end_encoded_data_type_get_type())
+G_DECLARE_DERIVABLE_TYPE(GArrowRunEndEncodedDataType,
+                         garrow_run_end_encoded_data_type,
+                         GARROW,
+                         RUN_END_ENCODED_DATA_TYPE,
+                         GArrowFixedWidthDataType)
+struct _GArrowRunEndEncodedDataTypeClass
+{
+  GArrowFixedWidthDataTypeClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_13_0
+GArrowRunEndEncodedDataType *
+garrow_run_end_encoded_data_type_new(GArrowDataType *run_end_data_type,
+                                     GArrowDataType *value_data_type);
+GARROW_AVAILABLE_IN_13_0
+GArrowDataType *
+garrow_run_end_encoded_data_type_get_run_end_data_type(
+  GArrowRunEndEncodedDataType *data_type);
+GARROW_AVAILABLE_IN_13_0
+GArrowDataType *
+garrow_run_end_encoded_data_type_get_value_data_type(
+  GArrowRunEndEncodedDataType *data_type);
+
+
 G_END_DECLS

--- a/c_glib/arrow-glib/type.cpp
+++ b/c_glib/arrow-glib/type.cpp
@@ -108,6 +108,8 @@ garrow_type_from_raw(arrow::Type::type type)
     return GARROW_TYPE_LARGE_LIST;
   case arrow::Type::type::INTERVAL_MONTH_DAY_NANO:
     return GARROW_TYPE_MONTH_DAY_NANO_INTERVAL;
+  case arrow::Type::type::RUN_END_ENCODED:
+    return GARROW_TYPE_RUN_END_ENCODED;
   default:
     return GARROW_TYPE_NA;
   }

--- a/c_glib/arrow-glib/type.h
+++ b/c_glib/arrow-glib/type.h
@@ -68,6 +68,7 @@ G_BEGIN_DECLS
  * @GARROW_TYPE_LARGE_BINARY: 64bit offsets Variable-length bytes (no guarantee of UTF-8-ness).
  * @GARROW_TYPE_LARGE_LIST: A list of some logical data type with 64-bit offsets.
  * @GARROW_TYPE_MONTH_DAY_NANO_INTERVAL: MONTH_DAY_NANO interval in SQL style.
+ * @GARROW_TYPE_RUN_END_ENCODED: Run-end encoded data.
  *
  * They are corresponding to `arrow::Type::type` values.
  */
@@ -110,6 +111,7 @@ typedef enum {
   GARROW_TYPE_LARGE_BINARY,
   GARROW_TYPE_LARGE_LIST,
   GARROW_TYPE_MONTH_DAY_NANO_INTERVAL,
+  GARROW_TYPE_RUN_END_ENCODED,
 } GArrowType;
 
 /**

--- a/c_glib/test/test-run-end-encoded-data-type.rb
+++ b/c_glib/test/test-run-end-encoded-data-type.rb
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestRunEndEncodedDataType < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @run_end_data_type = Arrow::Int32DataType.new
+    @value_data_type = Arrow::StringDataType.new
+    @data_type = Arrow::RunEndEncodedDataType.new(@run_end_data_type,
+                                                  @value_data_type)
+  end
+
+  def test_type
+    assert_equal(Arrow::Type::RUN_END_ENCODED, @data_type.id)
+  end
+
+  def test_name
+    assert_equal("run_end_encoded", @data_type.name)
+  end
+
+  def test_to_s
+    assert_equal("run_end_encoded<run_ends: int32, values: string>",
+                 @data_type.to_s)
+  end
+
+  def test_bit_width
+    assert_equal(-1, @data_type.bit_width)
+  end
+
+  def test_run_end_data_type
+    assert_equal(@run_end_data_type, @data_type.run_end_data_type)
+  end
+
+  def test_value_data_type
+    assert_equal(@value_data_type, @data_type.value_data_type)
+  end
+end


### PR DESCRIPTION
### Rationale for this change

`arrow::RunEndEncodedType` is available since Apache Arrow C++ 12. Apache Arrow GLib should support it.

### What changes are included in this PR?

Add `GArrowRunEndEncodedDataType` as the binding of `arrow::RunEndEncodedType`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #35417