### PR TITLE
GH-35130: [Docs] Document how to become a collaborator to get triage role

### DIFF
--- a/docs/source/developers/reviewing.rst
+++ b/docs/source/developers/reviewing.rst
@@ -295,3 +295,21 @@ In addition, we use the following labels to indicate priority:
 * **Priority: Critical**: Indicates issues that are high priority. This is a
   superset of issues marked "Critical Fix", as it also contains certain fixes
   to issues causing errors and crashes.
+
+Collaborators
+=============
+
+The collaborator role allows users to be given triage role to be able to help triaging
+issues. The role allows users to label and assign issues.
+
+A user can ask to become a collaborator or can be proposed by another community member
+when they have been collaborating in the project for a period of time. Collaborations
+can be but are not limited to: creating Pull requests, answering questions, creating
+issues, reviewing PRs, etcetera.
+
+In order to propose someone as a collaborator you must create a PR adding the user to
+the collaborators list on `.asf.yaml <https://github.com/apache/arrow/blob/main/.asf.yaml>`_..
+Committers can review the past collaborations for the user and approve.
+
+Collaborators that have been inactive for a period of time can be removed from the
+list of collaborators.

--- a/docs/source/developers/reviewing.rst
+++ b/docs/source/developers/reviewing.rst
@@ -304,7 +304,7 @@ issues. The role allows users to label and assign issues.
 
 A user can ask to become a collaborator or can be proposed by another community member
 when they have been collaborating in the project for a period of time. Collaborations
-can be but are not limited to: creating Pull requests, answering questions, creating
+can be but are not limited to: creating PRs, answering questions, creating
 issues, reviewing PRs, etcetera.
 
 In order to propose someone as a collaborator you must create a PR adding the user to

--- a/docs/source/developers/reviewing.rst
+++ b/docs/source/developers/reviewing.rst
@@ -308,7 +308,7 @@ can be but are not limited to: creating PRs, answering questions, creating
 issues, reviewing PRs, etcetera.
 
 In order to propose someone as a collaborator you must create a PR adding the user to
-the collaborators list on `.asf.yaml <https://github.com/apache/arrow/blob/main/.asf.yaml>`_..
+the collaborators list on `.asf.yaml <https://github.com/apache/arrow/blob/main/.asf.yaml>`_.
 Committers can review the past collaborations for the user and approve.
 
 Collaborators that have been inactive for a period of time can be removed from the


### PR DESCRIPTION
### Rationale for this change

Since we migrated to GitHub we have been using the collaborator role to allow some contributors to start helping with a triage role.
There has been some discussions on making more clear on the process to become a collaborator.

### What changes are included in this PR?

Add some documentation on how to propose / become a collaborator.

### Are these changes tested?

Will trigger the preview-docs.

### Are there any user-facing changes?

No
* Closes: #35130