### PR TITLE
GH-36452: [CI][C++] Test C++20 support with compatible compiler

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1151,12 +1151,12 @@ tasks:
       image: fedora-cpp
 
 {% for cpp_standard in [20] %}
-  test-ubuntu-20.04-cpp-{{ cpp_standard }}:
+  test-ubuntu-22.04-cpp-{{ cpp_standard }}:
     ci: github
     template: docker-tests/github.linux.yml
     params:
       env:
-        UBUNTU: 20.04
+        UBUNTU: 22.04
       flags: "-e CMAKE_CXX_STANDARD={{ cpp_standard }}"
       image: ubuntu-cpp
 {% endfor %}


### PR DESCRIPTION
We were testing C++20 compatibility on a gcc version that only accepts `-std=c++2a`, not `-std=c++20`. Switch to a newer Ubuntu, and therefore gcc, version.

* Closes: #36452