### PR TITLE
GH-35943: [Dev] Ensure link issue works when PR body is empty

### DIFF
--- a/.github/workflows/dev_pr/link.js
+++ b/.github/workflows/dev_pr/link.js
@@ -84,7 +84,7 @@ async function commentGitHubURL(github, context, pullRequestNumber, issueID) {
   const issueInfo = await helpers.getGitHubInfo(github, context, issueID, pullRequestNumber);
   const message = "* Closes: #" + issueInfo.number
   if (issueInfo) {
-    if (context.payload.pull_request.body.includes(message)) {
+    if (context.payload.pull_request.body != null && context.payload.pull_request.body.includes(message)) {
       return;
     }
     await github.rest.pulls.update({

--- a/.github/workflows/dev_pr/link.js
+++ b/.github/workflows/dev_pr/link.js
@@ -84,14 +84,15 @@ async function commentGitHubURL(github, context, pullRequestNumber, issueID) {
   const issueInfo = await helpers.getGitHubInfo(github, context, issueID, pullRequestNumber);
   const message = "* Closes: #" + issueInfo.number
   if (issueInfo) {
-    if (context.payload.pull_request.body != null && context.payload.pull_request.body.includes(message)) {
+    const body = context.payload.pull_request.body || "";
+    if (body.includes(message)) {
       return;
     }
     await github.rest.pulls.update({
       owner: context.repo.owner,
       repo: context.repo.repo,
       pull_number: pullRequestNumber,
-      body: (context.payload.pull_request.body || "") + "\n" + message
+      body: body + "\n" + message
     });
   }
 }


### PR DESCRIPTION
### Rationale for this change

Fix a bug when PR body is empty and Dev workflow fails.

### What changes are included in this PR?

Ensure the link issue comment works in case of description being empty.

### Are these changes tested?

I have tested it on my fork here: https://github.com/raulcd/arrow/pull/81


### Are there any user-facing changes?

No
* Closes: #35943