### PR TITLE
GH-36327: [C++][CI] Fix Valgrind failures

### DIFF
--- a/cpp/src/arrow/compute/kernels/ree_util_internal.cc
+++ b/cpp/src/arrow/compute/kernels/ree_util_internal.cc
@@ -36,7 +36,8 @@ Result<std::shared_ptr<Buffer>> AllocateValuesBuffer(int64_t length, const DataT
                                                      MemoryPool* pool,
                                                      int64_t data_buffer_size) {
   if (type.bit_width() == 1) {
-    return AllocateBitmap(length, pool);
+    // Make sure the bitmap is initialized (avoids Valgrind errors).
+    return AllocateEmptyBitmap(length, pool);
   } else if (is_fixed_width(type.id())) {
     return AllocateBuffer(length * type.byte_width(), pool);
   } else {
@@ -62,7 +63,7 @@ Result<std::shared_ptr<ArrayData>> PreallocateValuesArray(
   std::vector<std::shared_ptr<Buffer>> values_data_buffers;
   std::shared_ptr<Buffer> validity_buffer = NULLPTR;
   if (has_validity_buffer) {
-    ARROW_ASSIGN_OR_RAISE(validity_buffer, AllocateBitmap(length, pool));
+    ARROW_ASSIGN_OR_RAISE(validity_buffer, AllocateEmptyBitmap(length, pool));
   }
   ARROW_ASSIGN_OR_RAISE(auto values_buffer, AllocateValuesBuffer(length, *value_type,
                                                                  pool, data_buffer_size));

--- a/cpp/src/arrow/compute/kernels/vector_run_end_encode.cc
+++ b/cpp/src/arrow/compute/kernels/vector_run_end_encode.cc
@@ -28,6 +28,7 @@
 namespace arrow {
 namespace compute {
 namespace internal {
+namespace {
 
 struct RunEndEncondingState : public KernelState {
   explicit RunEndEncondingState(std::shared_ptr<DataType> run_end_type)
@@ -525,6 +526,8 @@ static const FunctionDoc run_end_encode_doc(
 static const FunctionDoc run_end_decode_doc(
     "Decode run-end encoded array",
     ("Return a decoded version of a run-end encoded input array."), {"array"});
+
+}  // namespace
 
 void RegisterVectorRunEndEncode(FunctionRegistry* registry) {
   auto function = std::make_shared<VectorFunction>("run_end_encode", Arity::Unary(),

--- a/cpp/valgrind.supp
+++ b/cpp/valgrind.supp
@@ -69,3 +69,9 @@
     ...
     fun:_dl_allocate_tls
 }
+{
+    <OpenSSL>:Conditional jump or move depends on uninitialised value(s)
+    Memcheck:Cond
+    ...
+    fun:*gcm_cipher*
+}


### PR DESCRIPTION
* Silence Valgrind error in OpenSSL
* Make sure the entire data buffer of pairwise_diff is initialized
* Make sure the bitmaps of REE-encoded data are initialized

* Closes: #36327