### PR TITLE
GH-36412: [Python] Fix deprecation warnings with latest pandas version

### DIFF
--- a/python/pyarrow/tests/test_feather.py
+++ b/python/pyarrow/tests/test_feather.py
@@ -395,7 +395,7 @@ def test_strings(version):
     values = [b'foo', None, 'bar', 'qux', np.nan]
     df = pd.DataFrame({'strings': values * repeats})
 
-    ex_values = [b'foo', None, b'bar', b'qux', np.nan]
+    ex_values = [b'foo', None, b'bar', b'qux', None]
     expected = pd.DataFrame({'strings': ex_values * repeats})
     _check_pandas_roundtrip(df, expected, version=version)
 
@@ -407,7 +407,8 @@ def test_strings(version):
 
     values = ['foo', None, 'bar', 'qux', np.nan]
     df = pd.DataFrame({'strings': values * repeats})
-    expected = pd.DataFrame({'strings': values * repeats})
+    ex_values = ['foo', None, 'bar', 'qux', None]
+    expected = pd.DataFrame({'strings': ex_values * repeats})
     _check_pandas_roundtrip(df, expected, version=version)
 
 

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -3565,12 +3565,16 @@ def test_to_pandas_split_blocks():
     _check_to_pandas_memory_unchanged(t, split_blocks=True)
 
 
+def _get_mgr(df):
+    if Version(pd.__version__) < Version("1.1.0"):
+        return df._data
+    else:
+        return df._mgr
+
+
 def _check_blocks_created(t, number):
     x = t.to_pandas(split_blocks=True)
-    if Version(pd.__version__) < Version("1.1.0"):
-        assert len(x._data.blocks) == number
-    else:
-        assert len(x._mgr.blocks) == number
+    assert len(_get_mgr(x).blocks) == number
 
 
 def test_to_pandas_self_destruct():
@@ -4060,13 +4064,6 @@ def _Int64Dtype__from_arrow__(self, array):
         mask = np.ones(len(arr), dtype=bool)
     int_arr = pd.arrays.IntegerArray(data.copy(), ~mask, copy=False)
     return int_arr
-
-
-def _get_mgr(df):
-    if Version(pd.__version__) < Version("1.1.0"):
-        return df._data
-    else:
-        return df._mgr
 
 
 def test_convert_to_extension_array(monkeypatch):

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -3564,7 +3564,10 @@ def test_to_pandas_split_blocks():
 
 def _check_blocks_created(t, number):
     x = t.to_pandas(split_blocks=True)
-    assert len(x._data.blocks) == number
+    if Version(pd.__version__) < Version("1.1.0"):
+        assert len(x._data.blocks) == number
+    else:
+        assert len(x._mgr.blocks) == number
 
 
 def test_to_pandas_self_destruct():
@@ -4056,6 +4059,13 @@ def _Int64Dtype__from_arrow__(self, array):
     return int_arr
 
 
+def _get_mgr(df):
+    if Version(pd.__version__) < Version("1.1.0"):
+        return df._data
+    else:
+        return df._mgr
+
+
 def test_convert_to_extension_array(monkeypatch):
     import pandas.core.internals as _int
 
@@ -4069,16 +4079,16 @@ def test_convert_to_extension_array(monkeypatch):
     # Int64Dtype is recognized -> convert to extension block by default
     # for a proper roundtrip
     result = table.to_pandas()
-    assert not isinstance(result._data.blocks[0], _int.ExtensionBlock)
-    assert result._data.blocks[0].values.dtype == np.dtype("int64")
-    assert isinstance(result._data.blocks[1], _int.ExtensionBlock)
+    assert not isinstance(_get_mgr(result).blocks[0], _int.ExtensionBlock)
+    assert _get_mgr(result).blocks[0].values.dtype == np.dtype("int64")
+    assert isinstance(_get_mgr(result).blocks[1], _int.ExtensionBlock)
     tm.assert_frame_equal(result, df)
 
     # test with missing values
     df2 = pd.DataFrame({'a': pd.array([1, 2, None], dtype='Int64')})
     table2 = pa.table(df2)
     result = table2.to_pandas()
-    assert isinstance(result._data.blocks[0], _int.ExtensionBlock)
+    assert isinstance(_get_mgr(result).blocks[0], _int.ExtensionBlock)
     tm.assert_frame_equal(result, df2)
 
     # monkeypatch pandas Int64Dtype to *not* have the protocol method
@@ -4090,8 +4100,8 @@ def test_convert_to_extension_array(monkeypatch):
             pd.core.arrays.integer.NumericDtype, "__from_arrow__")
     # Int64Dtype has no __from_arrow__ -> use normal conversion
     result = table.to_pandas()
-    assert len(result._data.blocks) == 1
-    assert not isinstance(result._data.blocks[0], _int.ExtensionBlock)
+    assert len(_get_mgr(result).blocks) == 1
+    assert not isinstance(_get_mgr(result).blocks[0], _int.ExtensionBlock)
 
 
 class MyCustomIntegerType(pa.PyExtensionType):
@@ -4117,12 +4127,12 @@ def test_conversion_extensiontype_to_extensionarray(monkeypatch):
     # extension type points to Int64Dtype, which knows how to create a
     # pandas ExtensionArray
     result = arr.to_pandas()
-    assert isinstance(result._data.blocks[0], _int.ExtensionBlock)
+    assert isinstance(_get_mgr(result).blocks[0], _int.ExtensionBlock)
     expected = pd.Series([1, 2, 3, 4], dtype='Int64')
     tm.assert_series_equal(result, expected)
 
     result = table.to_pandas()
-    assert isinstance(result._data.blocks[0], _int.ExtensionBlock)
+    assert isinstance(_get_mgr(result).blocks[0], _int.ExtensionBlock)
     expected = pd.DataFrame({'a': pd.array([1, 2, 3, 4], dtype='Int64')})
     tm.assert_frame_equal(result, expected)
 
@@ -4136,7 +4146,7 @@ def test_conversion_extensiontype_to_extensionarray(monkeypatch):
             pd.core.arrays.integer.NumericDtype, "__from_arrow__")
 
     result = arr.to_pandas()
-    assert not isinstance(result._data.blocks[0], _int.ExtensionBlock)
+    assert not isinstance(_get_mgr(result).blocks[0], _int.ExtensionBlock)
     expected = pd.Series([1, 2, 3, 4])
     tm.assert_series_equal(result, expected)
 


### PR DESCRIPTION
### What changes are included in this PR?

Fixes some of the deprecation warnings coming from the pandas development version, by updating our test code to avoid the deprecated patterns.

* Issue: #36412
* Closes: #36412