### PR TITLE
GH-23870: [Python] Ensure parquet.write_to_dataset doesn't create empty files for non-observed dictionary (category) values

### DIFF
--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -3468,7 +3468,7 @@ def write_to_dataset(table, root_path, partition_cols=None,
         if len(partition_keys) == 1:
             partition_keys = partition_keys[0]
 
-        for keys, subgroup in data_df.groupby(partition_keys):
+        for keys, subgroup in data_df.groupby(partition_keys, observed=True):
             if not isinstance(keys, tuple):
                 keys = (keys,)
             subdir = '/'.join(


### PR DESCRIPTION
### What changes are included in this PR?

If we partition on a categorical variable with "unobserved" categories (values present in the dictionary, but not in the actual data), the legacy path in `pq.write_to_dataset` currently creates empty files. The new dataset-based path already has the preferred behavior, and this PR fixes it for the legacy path and adds a test for both as well.

This also fixes one of the pandas deprecation warnings listed in https://github.com/apache/arrow/issues/36412

### Are these changes tested?

Yes

### Are there any user-facing changes?

Yes, this no longer creates a hive-style directory with one empty file (parquet file with 0 rows) when users have unobserved categories. However, this aligns the legacy path with the new and default dataset-based path.
* Closes: #23870