### PR TITLE
GH-36450: [CI][Python] Upload wheel artifacts for Windows

### DIFF
--- a/dev/tasks/python-wheels/github.windows.yml
+++ b/dev/tasks/python-wheels/github.windows.yml
@@ -58,6 +58,11 @@ jobs:
           )
           archery docker run --no-build -e SETUPTOOLS_SCM_PRETEND_VERSION={{ arrow.no_rc_version }} python-wheel-windows-vs2017
 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: wheel
+          path: arrow/python/dist/*.whl
+
       - name: Test wheel
         shell: cmd
         run: |


### PR DESCRIPTION
### Rationale for this change

It's useful for debugging on local.

### What changes are included in this PR?

Add `actions/upload-artifact` step like other jobs for manylinux and macOS.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #36450