### PR TITLE
GH-36257: [CI][Dev][Archery] bot requires pygithub 1.59.0 or later

### DIFF
--- a/dev/archery/archery/bot.py
+++ b/dev/archery/archery/bot.py
@@ -107,7 +107,10 @@ COMMITTER_ROLES = {'OWNER', 'MEMBER'}
 class PullRequestWorkflowBot:
 
     def __init__(self, event_name, event_payload, token=None, committers=None):
-        self.github = github.Github(token)
+        kwargs = {}
+        if token is not None:
+            kwargs["auth"] = github.Auth.Token(token)
+        self.github = github.Github(**kwargs)
         self.event_name = event_name
         self.event_payload = event_payload
         self.committers = committers
@@ -221,7 +224,10 @@ class CommentBot:
         assert callable(handler)
         self.name = name
         self.handler = handler
-        self.github = github.Github(token)
+        kwargs = {}
+        if token is not None:
+            kwargs["auth"] = github.Auth.Token(token)
+        self.github = github.Github(**kwargs)
 
     def parse_command(self, payload):
         mention = '@{}'.format(self.name)

--- a/dev/archery/archery/tests/test_bot.py
+++ b/dev/archery/archery/tests/test_bot.py
@@ -97,7 +97,7 @@ def test_noop_events(load_fixture, fixture_name):
     payload = load_fixture(fixture_name)
 
     handler = Mock()
-    bot = CommentBot(name='ursabot', token='', handler=handler)
+    bot = CommentBot(name='ursabot', handler=handler)
     bot.handle('issue_comment', payload)
 
     handler.assert_not_called()
@@ -139,7 +139,7 @@ def test_unathorized_user_comment(load_fixture, responses):
 
     payload = load_fixture('event-issue-comment-by-non-authorized-user.json')
     payload["comment"]["body"] = '@ursabot crossbow submit -g nightly'
-    bot = CommentBot(name='ursabot', token='', handler=handler)
+    bot = CommentBot(name='ursabot', handler=handler)
     bot.handle('issue_comment', payload)
 
     print([c.request.body for c in responses.calls])
@@ -179,7 +179,7 @@ def test_issue_comment_without_pull_request(load_fixture, responses):
         pass
 
     payload = load_fixture('event-issue-comment-without-pull-request.json')
-    bot = CommentBot(name='ursabot', token='', handler=handler)
+    bot = CommentBot(name='ursabot', handler=handler)
     bot.handle('issue_comment', payload)
 
     post = responses.calls[2]
@@ -222,7 +222,7 @@ def test_respond_with_usage(load_fixture, responses):
         raise CommandError('test-usage')
 
     payload = load_fixture('event-issue-comment-with-empty-command.json')
-    bot = CommentBot(name='ursabot', token='', handler=handler)
+    bot = CommentBot(name='ursabot', handler=handler)
     bot.handle('issue_comment', payload)
 
     post = responses.calls[3]
@@ -275,7 +275,7 @@ def test_issue_comment_with_commands(load_fixture, responses, command,
     payload = load_fixture('event-issue-comment-build-command.json')
     payload["comment"]["body"] = command
 
-    bot = CommentBot(name='ursabot', token='', handler=handler)
+    bot = CommentBot(name='ursabot', handler=handler)
     bot.handle('issue_comment', payload)
 
     post = responses.calls[3]
@@ -326,7 +326,7 @@ def test_issue_comment_invalid_commands(load_fixture, responses, command,
     payload = load_fixture('event-issue-comment-build-command.json')
     payload["comment"]["body"] = command
 
-    bot = CommentBot(name='ursabot', token='', handler=handler)
+    bot = CommentBot(name='ursabot', handler=handler)
     bot.handle('issue_comment', payload)
 
     # Setting reaction is always the last call
@@ -341,7 +341,7 @@ def test_issue_comment_with_commands_bot_not_first(load_fixture, responses):
     payload = load_fixture('event-issue-comment-build-command.json')
     payload["comment"]["body"] = 'with a comment\n@ursabot build'
 
-    bot = CommentBot(name='ursabot', token='', handler=handler)
+    bot = CommentBot(name='ursabot', handler=handler)
     bot.handle('issue_comment', payload)
 
     handler.assert_not_called()
@@ -375,7 +375,7 @@ def test_open_pull_request(load_fixture, responses, fixture_name, expected_label
     )
     payload = load_fixture(fixture_name)
 
-    bot = PullRequestWorkflowBot('pull_request_target', payload, token='')
+    bot = PullRequestWorkflowBot('pull_request_target', payload)
     bot.handle()
 
     # Setting awaiting committer review or awaiting review label
@@ -412,7 +412,7 @@ def test_open_pull_request_with_committer_list(load_fixture, responses, fixture_
 
     # Even though the author_association is not committer the list overrides.
     bot = PullRequestWorkflowBot(
-        'pull_request_target', payload, token='', committers=['kszucs'])
+        'pull_request_target', payload, committers=['kszucs'])
     bot.handle()
 
     # Setting awaiting committer review or awaiting review label
@@ -453,7 +453,7 @@ def test_open_pull_request_with_existing_label(
     payload = load_fixture(fixture_name)
     payload['pull_request']['labels'] = ['awaiting review']
 
-    bot = PullRequestWorkflowBot('pull_request_target', payload, token='')
+    bot = PullRequestWorkflowBot('pull_request_target', payload)
     bot.handle()
 
     post = responses.calls[-1]
@@ -502,7 +502,7 @@ def test_pull_request_review_awaiting_review(
     payload['pull_request']['labels'] = ['awaiting review']
     payload['review']['state'] = review_state
 
-    bot = PullRequestWorkflowBot('pull_request_review', payload, token='')
+    bot = PullRequestWorkflowBot('pull_request_review', payload)
     bot.handle()
 
     post = responses.calls[-1]
@@ -545,7 +545,7 @@ def test_pull_request_committer_review_awaiting_change_review(
     payload['pull_request']['labels'] = ['awaiting change review']
     payload['review']['state'] = review_state
 
-    bot = PullRequestWorkflowBot('pull_request_review', payload, token='')
+    bot = PullRequestWorkflowBot('pull_request_review', payload)
     bot.handle()
 
     post = responses.calls[-1]
@@ -572,7 +572,7 @@ def test_pull_request_non_committer_review_awaiting_change_review(
     payload['pull_request']['labels'] = ['awaiting change review']
     payload['review']['state'] = review_state
 
-    bot = PullRequestWorkflowBot('pull_request_review', payload, token='')
+    bot = PullRequestWorkflowBot('pull_request_review', payload)
     bot.handle()
 
     # No requests to delete post new labels on non-committer reviews
@@ -609,7 +609,7 @@ def test_pull_request_synchronize_event_on_awaiting_changes(
         status=201
     )
 
-    bot = PullRequestWorkflowBot('pull_request_target', payload, token='')
+    bot = PullRequestWorkflowBot('pull_request_target', payload)
     bot.handle()
     # after push event label changes.
     post = responses.calls[-1]
@@ -633,7 +633,7 @@ def test_pull_request_synchronize_event_on_awaiting_review(
         status=200
     )
 
-    bot = PullRequestWorkflowBot('pull_request_target', payload, token='')
+    bot = PullRequestWorkflowBot('pull_request_target', payload)
     bot.handle()
     # No requests to delete or post new labels on push awaiting review
     assert len(responses.calls) == 2
@@ -663,7 +663,7 @@ def test_pull_request_synchronize_event_on_existing_pr_without_state(
         status=201
     )
 
-    bot = PullRequestWorkflowBot('pull_request_target', payload, token='')
+    bot = PullRequestWorkflowBot('pull_request_target', payload)
     bot.handle()
     # after push event label get set to default
     post = responses.calls[-1]

--- a/dev/archery/requirements.txt
+++ b/dev/archery/requirements.txt
@@ -1,4 +1,4 @@
 click
-pygithub
+pygithub>=1.59.0
 python-dotenv
 ruamel.yaml


### PR DESCRIPTION
### Rationale for this change

pygithub 1.59.0 or later doesn't accept empty string token.

### What changes are included in this PR?

Don't use an empty string for token.

Don't use deprecated `pygithub.Github(token)` API.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #36257