### PR TITLE
GH-35418: [GLib] Add GArrowRunEndEncodedArray

### DIFF
--- a/c_glib/arrow-glib/basic-array.cpp
+++ b/c_glib/arrow-glib/basic-array.cpp
@@ -3655,6 +3655,9 @@ garrow_array_new_raw_valist(std::shared_ptr<arrow::Array> *arrow_array,
       }
     }
     break;
+  case arrow::Type::type::RUN_END_ENCODED:
+    type = GARROW_TYPE_RUN_END_ENCODED_ARRAY;
+    break;
   default:
     type = GARROW_TYPE_ARRAY;
     break;

--- a/c_glib/arrow-glib/composite-array.cpp
+++ b/c_glib/arrow-glib/composite-array.cpp
@@ -59,7 +59,15 @@ G_BEGIN_DECLS
  * #GArrowDictionaryArray is a class for dictionary array. It can
  * store data with dictionary and indices. It's space effective than
  * normal array when the array has many same values. You can convert a
- * normal array to dictionary array by garrow_array_dictionary_encode().
+ * normal array to a dictionary array by
+ * garrow_array_dictionary_encode().
+ *
+ * #GArrowRunEndEncodedArray is a class for run-end encoded array. It
+ * can store data with run-ends and values. It's space effective than
+ * normal array when the array has many continuous same values. You
+ * can convert a normal array to a run-end encoded array by
+ * garrow_array_run_end_encode(). You can convert a run-end encoded
+ * array to a normal array by garrow_run_end_encoded_array_decode().
  */
 
 typedef struct GArrowListArrayPrivate_ {
@@ -1759,5 +1767,331 @@ garrow_dictionary_array_get_dictionary_data_type(GArrowDictionaryArray *array)
   auto data_type = garrow_array_get_value_data_type(GARROW_ARRAY(array));
   return GARROW_DICTIONARY_DATA_TYPE(data_type);
 }
+
+
+struct GArrowRunEndEncodedArrayPrivate {
+  GArrowArray *run_ends;
+  GArrowArray *values;
+};
+
+enum {
+  PROP_RUN_ENDS = 1,
+  PROP_VALUES,
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GArrowRunEndEncodedArray,
+                           garrow_run_end_encoded_array,
+                           GARROW_TYPE_ARRAY)
+
+#define GARROW_RUN_END_ENCODED_ARRAY_GET_PRIVATE(obj)        \
+  static_cast<GArrowRunEndEncodedArrayPrivate *>(            \
+    garrow_run_end_encoded_array_get_instance_private(       \
+      GARROW_RUN_END_ENCODED_ARRAY(obj)))
+
+static void
+garrow_run_end_encoded_array_dispose(GObject *object)
+{
+  auto priv = GARROW_RUN_END_ENCODED_ARRAY_GET_PRIVATE(object);
+
+  if (priv->run_ends) {
+    g_object_unref(priv->run_ends);
+    priv->run_ends = nullptr;
+  }
+
+  if (priv->values) {
+    g_object_unref(priv->values);
+    priv->values = nullptr;
+  }
+
+  G_OBJECT_CLASS(garrow_run_end_encoded_array_parent_class)->dispose(object);
+}
+
+static void
+garrow_run_end_encoded_array_set_property(GObject *object,
+                                          guint prop_id,
+                                          const GValue *value,
+                                          GParamSpec *pspec)
+{
+  auto priv = GARROW_RUN_END_ENCODED_ARRAY_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_RUN_ENDS:
+    priv->run_ends = GARROW_ARRAY(g_value_dup_object(value));
+    break;
+  case PROP_VALUES:
+    priv->values = GARROW_ARRAY(g_value_dup_object(value));
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_run_end_encoded_array_get_property(GObject *object,
+                                          guint prop_id,
+                                          GValue *value,
+                                          GParamSpec *pspec)
+{
+  auto priv = GARROW_RUN_END_ENCODED_ARRAY_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_RUN_ENDS:
+    g_value_set_object(value, priv->run_ends);
+    break;
+  case PROP_VALUES:
+    g_value_set_object(value, priv->values);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_run_end_encoded_array_init(GArrowRunEndEncodedArray *object)
+{
+}
+
+static void
+garrow_run_end_encoded_array_class_init(GArrowRunEndEncodedArrayClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->dispose = garrow_run_end_encoded_array_dispose;
+  gobject_class->set_property = garrow_run_end_encoded_array_set_property;
+  gobject_class->get_property = garrow_run_end_encoded_array_get_property;
+
+  GParamSpec *spec;
+  spec = g_param_spec_object("run-ends",
+                             "The run-ends",
+                             "The GArrowArray for run-ends",
+                             GARROW_TYPE_ARRAY,
+                             static_cast<GParamFlags>(G_PARAM_READWRITE |
+                                                      G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property(gobject_class, PROP_RUN_ENDS, spec);
+
+  spec = g_param_spec_object("values",
+                             "The values",
+                             "The GArrowArray for values",
+                             GARROW_TYPE_ARRAY,
+                             static_cast<GParamFlags>(G_PARAM_READWRITE |
+                                                      G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property(gobject_class, PROP_VALUES, spec);
+}
+
+/**
+ * garrow_run_end_encoded_array_new:
+ * @data_type: The data type of the run-end encoded array.
+ * @logical_length: The logical length of the run-end encoded array.
+ * @run_ends: The run-ends of the run-end encoded array.
+ * @values: The values of the run-end encoded array.
+ * @logical_offset: The offset of the run-end encoded array.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (nullable): A newly created #GArrowRunEndEncodedArray
+ *   or %NULL on error.
+ *
+ * Since: 13.0.0
+ */
+GArrowRunEndEncodedArray *
+garrow_run_end_encoded_array_new(GArrowDataType *data_type,
+                                 gint64 logical_length,
+                                 GArrowArray *run_ends,
+                                 GArrowArray *values,
+                                 gint64 logical_offset,
+                                 GError **error)
+{
+  const auto arrow_data_type = garrow_data_type_get_raw(data_type);
+  const auto arrow_run_ends = garrow_array_get_raw(run_ends);
+  const auto arrow_values = garrow_array_get_raw(values);
+  auto arrow_run_end_encoded_array_result =
+      arrow::RunEndEncodedArray::Make(
+        arrow_data_type,
+        logical_length,
+        arrow_run_ends,
+        arrow_values,
+        logical_offset);
+  if (garrow::check(error,
+                    arrow_run_end_encoded_array_result,
+                    "[run-end-encoded-array][new]")) {
+    auto arrow_array =
+      std::static_pointer_cast<arrow::Array>(*arrow_run_end_encoded_array_result);
+    auto run_end_encoded_array =
+      garrow_array_new_raw(&arrow_array,
+                           "array", &arrow_array,
+                           "value-data-type", data_type,
+                           "run-ends", run_ends,
+                           "values", values,
+                           NULL);
+    return GARROW_RUN_END_ENCODED_ARRAY(run_end_encoded_array);
+  } else {
+    return nullptr;
+  }
+}
+
+/**
+ * garrow_run_end_encoded_array_get_run_ends:
+ * @array: A #GArrowRunEndEncodedArray.
+ *
+ * Returns: (transfer full): The indexes of each run-end.
+ *
+ *   The physical offset to the array is applied.
+ *
+ * Since: 13.0.0
+ */
+GArrowArray *
+garrow_run_end_encoded_array_get_run_ends(GArrowRunEndEncodedArray *array)
+{
+  auto priv = GARROW_RUN_END_ENCODED_ARRAY_GET_PRIVATE(array);
+  if (priv->run_ends) {
+    g_object_ref(priv->run_ends);
+    return priv->run_ends;
+  }
+
+  auto arrow_array = garrow_array_get_raw(GARROW_ARRAY(array));
+  auto arrow_run_end_encoded_array =
+    std::static_pointer_cast<arrow::RunEndEncodedArray>(arrow_array);
+  auto arrow_run_ends = arrow_run_end_encoded_array->run_ends();
+  return garrow_array_new_raw(&arrow_run_ends);
+}
+
+/**
+ * garrow_run_end_encoded_array_get_values:
+ * @array: A #GArrowRunEndEncodedArray.
+ *
+ * Returns: (transfer full): The values of each run.
+ *
+ *   The physical offset to the array is applied.
+ *
+ * Since: 13.0.0
+ */
+GArrowArray *
+garrow_run_end_encoded_array_get_values(GArrowRunEndEncodedArray *array)
+{
+  auto priv = GARROW_RUN_END_ENCODED_ARRAY_GET_PRIVATE(array);
+  if (priv->values) {
+    g_object_ref(priv->values);
+    return priv->values;
+  }
+
+  auto arrow_array = garrow_array_get_raw(GARROW_ARRAY(array));
+  auto arrow_run_end_encoded_array =
+    std::static_pointer_cast<arrow::RunEndEncodedArray>(arrow_array);
+  auto arrow_values = arrow_run_end_encoded_array->values();
+  return garrow_array_new_raw(&arrow_values);
+}
+
+/**
+ * garrow_run_end_encoded_array_get_logical_run_ends:
+ * @array: A #GArrowRunEndEncodedArray.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (transfer full): The logical indexes of each run-end or
+ *   %NULL on error.
+ *
+ *   If a non-zero logical offset is set, this function allocates a
+ *   new array and rewrites all the run end values to be relative to
+ *   the logical offset and cuts the end of the array to the logical
+ *   length.
+ *
+ * Since: 13.0.0
+ */
+GArrowArray *
+garrow_run_end_encoded_array_get_logical_run_ends(
+  GArrowRunEndEncodedArray *array,
+  GError **error)
+{
+  auto arrow_array = garrow_array_get_raw(GARROW_ARRAY(array));
+  auto arrow_run_end_encoded_array =
+    std::static_pointer_cast<arrow::RunEndEncodedArray>(arrow_array);
+  auto arrow_memory_pool = arrow::default_memory_pool();
+  auto arrow_logical_run_ends_result =
+    arrow_run_end_encoded_array->LogicalRunEnds(arrow_memory_pool);
+  if (garrow::check(error,
+                    arrow_logical_run_ends_result,
+                    "[run-end-encoded-array][get-logical-run-ends]")) {
+    auto arrow_array =
+      std::static_pointer_cast<arrow::Array>(*arrow_logical_run_ends_result);
+    return garrow_array_new_raw(&arrow_array,
+                                "array", &arrow_array,
+                                NULL);
+  } else {
+    return nullptr;
+  }
+}
+
+/**
+ * garrow_run_end_encoded_array_get_logical_values:
+ * @array: A #GArrowRunEndEncodedArray.
+ *
+ * Returns: (transfer full): The logical values of each run.
+ *
+ *   If a non-zero logical offset is set, this function allocates a
+ *   new array containing only the values within the logical range.
+ *
+ * Since: 13.0.0
+ */
+GArrowArray *
+garrow_run_end_encoded_array_get_logical_values(GArrowRunEndEncodedArray *array)
+{
+  auto arrow_array = garrow_array_get_raw(GARROW_ARRAY(array));
+  auto arrow_run_end_encoded_array =
+    std::static_pointer_cast<arrow::RunEndEncodedArray>(arrow_array);
+  auto arrow_logical_values =
+    std::static_pointer_cast<arrow::Array>(
+      arrow_run_end_encoded_array->LogicalValues());
+  return garrow_array_new_raw(&arrow_logical_values,
+                              "array", &arrow_logical_values,
+                              NULL);
+}
+
+/**
+ * garrow_run_end_encoded_array_find_physical_offset:
+ * @array: A #GArrowRunEndEncodedArray.
+ *
+ * Returns: Find the physical offset of this array.
+ *
+ *   This function uses binary-search, so it has a O(log N) cost.
+ *
+ * Since: 13.0.0
+ */
+gint64
+garrow_run_end_encoded_array_find_physical_offset(
+  GArrowRunEndEncodedArray *array)
+{
+  auto arrow_array = garrow_array_get_raw(GARROW_ARRAY(array));
+  auto arrow_run_end_encoded_array =
+    std::static_pointer_cast<arrow::RunEndEncodedArray>(arrow_array);
+  return arrow_run_end_encoded_array->FindPhysicalOffset();
+}
+
+/**
+ * garrow_run_end_encoded_array_find_physical_length:
+ * @array: A #GArrowRunEndEncodedArray.
+ *
+ * Returns: Find the physical length of this array.
+ *
+ *   The physical length of an run-end encoded array is the number of
+ *   physical values (and run-ends) necessary to represent the logical
+ *   range of values from offset to length.
+ *
+ *   Avoid calling this function if the physical length can be
+ *   estabilished in some other way (e.g. when iterating over the runs
+ *   sequentially until the end). This function uses binary-search, so
+ *   it has a O(log N) cost.
+ *
+ * Since: 13.0.0
+ */
+gint64
+garrow_run_end_encoded_array_find_physical_length(
+  GArrowRunEndEncodedArray *array)
+{
+  auto arrow_array = garrow_array_get_raw(GARROW_ARRAY(array));
+  auto arrow_run_end_encoded_array =
+    std::static_pointer_cast<arrow::RunEndEncodedArray>(arrow_array);
+  return arrow_run_end_encoded_array->FindPhysicalLength();
+}
+
 
 G_END_DECLS

--- a/c_glib/arrow-glib/composite-array.cpp
+++ b/c_glib/arrow-glib/composite-array.cpp
@@ -57,16 +57,16 @@ G_BEGIN_DECLS
  * #GArrowSparseUnionArray is a class for sparse union array.
  *
  * #GArrowDictionaryArray is a class for dictionary array. It can
- * store data with dictionary and indices. It's space effective than
- * normal array when the array has many same values. You can convert a
- * normal array to a dictionary array by
+ * store data with dictionary and indices. It's more space effective
+ * than normal array when the array has many same values. You can
+ * convert a normal array to a dictionary array by
  * garrow_array_dictionary_encode().
  *
  * #GArrowRunEndEncodedArray is a class for run-end encoded array. It
- * can store data with run-ends and values. It's space effective than
- * normal array when the array has many continuous same values. You
- * can convert a normal array to a run-end encoded array by
- * garrow_array_run_end_encode(). You can convert a run-end encoded
+ * can store data with run-ends and values. It's more space effective
+ * than normal array when the array has many continuous same
+ * values. You can convert a normal array to a run-end encoded array
+ * by garrow_array_run_end_encode(). You can convert a run-end encoded
  * array to a normal array by garrow_run_end_encoded_array_decode().
  */
 

--- a/c_glib/arrow-glib/composite-array.h
+++ b/c_glib/arrow-glib/composite-array.h
@@ -249,4 +249,50 @@ GArrowDictionaryDataType *
 garrow_dictionary_array_get_dictionary_data_type(GArrowDictionaryArray *array);
 #endif
 
+
+#define GARROW_TYPE_RUN_END_ENCODED_ARRAY       \
+  (garrow_run_end_encoded_array_get_type())
+G_DECLARE_DERIVABLE_TYPE(GArrowRunEndEncodedArray,
+                         garrow_run_end_encoded_array,
+                         GARROW,
+                         RUN_END_ENCODED_ARRAY,
+                         GArrowArray)
+struct _GArrowRunEndEncodedArrayClass
+{
+  GArrowArrayClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_13_0
+GArrowRunEndEncodedArray *
+garrow_run_end_encoded_array_new(GArrowDataType *data_type,
+                                 gint64 logical_length,
+                                 GArrowArray *run_ends,
+                                 GArrowArray *values,
+                                 gint64 logical_offset,
+                                 GError **error);
+GARROW_AVAILABLE_IN_13_0
+GArrowArray *
+garrow_run_end_encoded_array_get_run_ends(GArrowRunEndEncodedArray *array);
+GARROW_AVAILABLE_IN_13_0
+GArrowArray *
+garrow_run_end_encoded_array_get_values(GArrowRunEndEncodedArray *array);
+GARROW_AVAILABLE_IN_13_0
+GArrowArray *
+garrow_run_end_encoded_array_get_logical_run_ends(
+  GArrowRunEndEncodedArray *array,
+  GError **error);
+GARROW_AVAILABLE_IN_13_0
+GArrowArray *
+garrow_run_end_encoded_array_get_logical_values(GArrowRunEndEncodedArray *array);
+GARROW_AVAILABLE_IN_13_0
+gint64
+garrow_run_end_encoded_array_find_physical_offset(
+  GArrowRunEndEncodedArray *array);
+GARROW_AVAILABLE_IN_13_0
+gint64
+garrow_run_end_encoded_array_find_physical_length(
+  GArrowRunEndEncodedArray *array);
+
+
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -237,6 +237,9 @@ G_BEGIN_DECLS
  *
  * #GArrowRankOptions is a class to customize the `rank` function.
  *
+ * #GArrowRunEndEncodeOptions is a class to customize the
+ * `run_end_encode` function.
+ *
  * There are many functions to compute data on an array.
  */
 
@@ -5850,6 +5853,228 @@ garrow_record_batch_filter(GArrowRecordBatch *record_batch,
   }
 }
 
+struct GArrowRunEndEncodeOptionsPrivate {
+  GArrowDataType *run_end_data_type;
+};
+
+enum {
+  PROP_RUN_END_ENCODE_OPTIONS_RUN_END_DATA_TYPE = 1,
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GArrowRunEndEncodeOptions,
+                           garrow_run_end_encode_options,
+                           GARROW_TYPE_FUNCTION_OPTIONS)
+
+#define GARROW_RUN_END_ENCODE_OPTIONS_GET_PRIVATE(object)          \
+  static_cast<GArrowRunEndEncodeOptionsPrivate *>(                 \
+    garrow_run_end_encode_options_get_instance_private(            \
+      GARROW_RUN_END_ENCODE_OPTIONS(object)))
+
+static void
+garrow_run_end_encode_options_dispose(GObject *object)
+{
+  auto priv = GARROW_RUN_END_ENCODE_OPTIONS_GET_PRIVATE(object);
+
+  if (priv->run_end_data_type) {
+    g_object_unref(priv->run_end_data_type);
+    priv->run_end_data_type = NULL;
+  }
+
+  G_OBJECT_CLASS(garrow_run_end_encode_options_parent_class)->dispose(object);
+}
+
+static void
+garrow_run_end_encode_options_set_property(GObject *object,
+                                           guint prop_id,
+                                           const GValue *value,
+                                           GParamSpec *pspec)
+{
+  auto priv = GARROW_RUN_END_ENCODE_OPTIONS_GET_PRIVATE(object);
+  auto options =
+    garrow_run_end_encode_options_get_raw(GARROW_RUN_END_ENCODE_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_RUN_END_ENCODE_OPTIONS_RUN_END_DATA_TYPE:
+    {
+      auto run_end_data_type = g_value_dup_object(value);
+      if (priv->run_end_data_type) {
+        g_object_unref(priv->run_end_data_type);
+      }
+      if (run_end_data_type) {
+        priv->run_end_data_type = GARROW_DATA_TYPE(run_end_data_type);
+        options->run_end_type = garrow_data_type_get_raw(priv->run_end_data_type);
+      } else {
+        priv->run_end_data_type = NULL;
+        options->run_end_type = nullptr;
+      }
+      break;
+    }
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_run_end_encode_options_get_property(GObject *object,
+                                           guint prop_id,
+                                           GValue *value,
+                                           GParamSpec *pspec)
+{
+  auto priv = GARROW_RUN_END_ENCODE_OPTIONS_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_RUN_END_ENCODE_OPTIONS_RUN_END_DATA_TYPE:
+    g_value_set_object(value, priv->run_end_data_type);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_run_end_encode_options_init(GArrowRunEndEncodeOptions *object)
+{
+  auto priv = GARROW_FUNCTION_OPTIONS_GET_PRIVATE(object);
+  priv->options = static_cast<arrow::compute::FunctionOptions *>(
+    new arrow::compute::RunEndEncodeOptions());
+}
+
+static void
+garrow_run_end_encode_options_class_init(GArrowRunEndEncodeOptionsClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->dispose = garrow_run_end_encode_options_dispose;
+  gobject_class->set_property = garrow_run_end_encode_options_set_property;
+  gobject_class->get_property = garrow_run_end_encode_options_get_property;
+
+
+  GParamSpec *spec;
+  /**
+   * GArrowRunEndEncodeOptions:run-end-data-type:
+   *
+   * The data type for run-end.
+   *
+   * Since: 13.0.0
+   */
+  spec = g_param_spec_object("run-end-data-type",
+                             "run-end data type",
+                             "The data type for run-end.",
+                             GARROW_TYPE_DATA_TYPE,
+                             static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class,
+                                  PROP_RUN_END_ENCODE_OPTIONS_RUN_END_DATA_TYPE,
+                                  spec);
+}
+
+/**
+ * garrow_run_end_encode_options_new:
+ * @run_end_data_type: (nullable): A #GArrowDataType for run-end. If this
+ *   is %NULL, garrow_int32_data_type_new() is used.
+ *
+ * Returns: A newly created #GArrowRunEndEncodeOptions.
+ *
+ * Since: 13.0.0
+ */
+GArrowRunEndEncodeOptions *
+garrow_run_end_encode_options_new(GArrowDataType *run_end_data_type)
+{
+  bool need_run_end_data_type_unref = false;
+  if (!run_end_data_type) {
+    run_end_data_type = GARROW_DATA_TYPE(garrow_int32_data_type_new());
+    need_run_end_data_type_unref = true;
+  }
+  auto options = g_object_new(GARROW_TYPE_RUN_END_ENCODE_OPTIONS,
+                              "run-end-data-type", run_end_data_type,
+                              NULL);
+  if (need_run_end_data_type_unref) {
+    g_object_unref(run_end_data_type);
+  }
+  return GARROW_RUN_END_ENCODE_OPTIONS(options);
+}
+
+/**
+ * garrow_array_run_end_encode:
+ * @array: A #GArrowArray.
+ * @options: (nullable): A #GArrowRunEndEncodeOptions.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (nullable) (transfer full):
+ *   A newly created #GArrowRunEndEncodeArray for the @array on success,
+ *   %NULL on error.
+ *
+ * Since: 13.0.0
+ */
+GArrowRunEndEncodedArray *
+garrow_array_run_end_encode(GArrowArray *array,
+                            GArrowRunEndEncodeOptions *options,
+                            GError **error)
+{
+  auto arrow_array = garrow_array_get_raw(array);
+  arrow::Result<arrow::Datum> arrow_run_end_encoded_datum_result;
+  if (options) {
+    auto arrow_options = garrow_run_end_encode_options_get_raw(options);
+    arrow_run_end_encoded_datum_result =
+      arrow::compute::RunEndEncode(arrow_array, *arrow_options);
+  } else {
+    arrow_run_end_encoded_datum_result =
+      arrow::compute::RunEndEncode(arrow_array);
+  }
+  if (garrow::check(error,
+                    arrow_run_end_encoded_datum_result,
+                    [&]() {
+                      std::stringstream message;
+                      message << "[array][run-end-encode] <";
+                      message << arrow_array->type()->ToString();
+                      message << ">";
+                      return message.str();
+                    })) {
+    auto arrow_run_end_encoded_array =
+      (*arrow_run_end_encoded_datum_result).make_array();
+    auto run_end_encoded_array =
+      garrow_array_new_raw(&arrow_run_end_encoded_array);
+    return GARROW_RUN_END_ENCODED_ARRAY(run_end_encoded_array);
+  } else {
+    return nullptr;
+  }
+}
+
+/**
+ * garrow_run_end_encoded_array_decode:
+ * @array: A #GArrowRunEndEncodeArray to be decoded.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (nullable) (transfer full):
+ *   A newly decoded #GArrowArray for the @array on success,
+ *   %NULL on error.
+ *
+ * Since: 13.0.0
+ */
+GArrowArray *
+garrow_run_end_encoded_array_decode(GArrowRunEndEncodedArray *array,
+                                    GError **error)
+{
+  auto arrow_array = garrow_array_get_raw(GARROW_ARRAY(array));
+  auto arrow_decoded_datum_result =
+    arrow::compute::RunEndDecode(arrow_array);
+  if (garrow::check(error,
+                    arrow_decoded_datum_result,
+                    [&]() {
+                      std::stringstream message;
+                      message << "[run-end-encoded-array][decode] <";
+                      message << arrow_array->type()->ToString();
+                      message << ">";
+                      return message.str();
+                    })) {
+    auto arrow_decoded_array = (*arrow_decoded_datum_result).make_array();
+    return garrow_array_new_raw(&arrow_decoded_array);
+  } else {
+    return nullptr;
+  }
+}
+
 G_END_DECLS
 
 
@@ -5961,6 +6186,12 @@ garrow_function_options_new_raw(
     const auto arrow_rank_options =
       static_cast<const arrow::compute::RankOptions *>(arrow_options);
     auto options = garrow_rank_options_new_raw(arrow_rank_options);
+    return GARROW_FUNCTION_OPTIONS(options);
+  } else if (arrow_type_name == "RunEndEncodeOptions") {
+    const auto arrow_run_end_encode_options =
+      static_cast<const arrow::compute::RunEndEncodeOptions *>(arrow_options);
+    auto options =
+      garrow_run_end_encode_options_new_raw(arrow_run_end_encode_options);
     return GARROW_FUNCTION_OPTIONS(options);
   } else {
     auto options = g_object_new(GARROW_TYPE_FUNCTION_OPTIONS,
@@ -6415,5 +6646,25 @@ arrow::compute::RankOptions *
 garrow_rank_options_get_raw(GArrowRankOptions *options)
 {
   return static_cast<arrow::compute::RankOptions *>(
+    garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
+}
+
+
+GArrowRunEndEncodeOptions *
+garrow_run_end_encode_options_new_raw(
+  const arrow::compute::RunEndEncodeOptions *arrow_options)
+{
+  GArrowDataType *run_end_data_type = nullptr;
+  if (arrow_options->run_end_type) {
+    auto arrow_run_end_data_type = arrow_options->run_end_type;
+    run_end_data_type = garrow_data_type_new_raw(&arrow_run_end_data_type);
+  }
+  return garrow_run_end_encode_options_new(run_end_data_type);
+}
+
+arrow::compute::RunEndEncodeOptions *
+garrow_run_end_encode_options_get_raw(GArrowRunEndEncodeOptions *options)
+{
+  return static_cast<arrow::compute::RunEndEncodeOptions *>(
     garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
 }

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1086,4 +1086,32 @@ garrow_record_batch_filter(GArrowRecordBatch *record_batch,
                            GArrowFilterOptions *options,
                            GError **error);
 
+#define GARROW_TYPE_RUN_END_ENCODE_OPTIONS      \
+  (garrow_run_end_encode_options_get_type())
+G_DECLARE_DERIVABLE_TYPE(GArrowRunEndEncodeOptions,
+                         garrow_run_end_encode_options,
+                         GARROW,
+                         RUN_END_ENCODE_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowRunEndEncodeOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_13_0
+GArrowRunEndEncodeOptions *
+garrow_run_end_encode_options_new(GArrowDataType *run_end_data_type);
+
+
+GARROW_AVAILABLE_IN_13_0
+GArrowRunEndEncodedArray *
+garrow_array_run_end_encode(GArrowArray *array,
+                            GArrowRunEndEncodeOptions *options,
+                            GError **error);
+GARROW_AVAILABLE_IN_13_0
+GArrowArray *
+garrow_run_end_encoded_array_decode(GArrowRunEndEncodedArray *array,
+                                    GError **error);
+
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -185,3 +185,10 @@ GArrowRankOptions *
 garrow_rank_options_new_raw(const arrow::compute::RankOptions *arrow_options);
 arrow::compute::RankOptions *
 garrow_rank_options_get_raw(GArrowRankOptions *options);
+
+
+GArrowRunEndEncodeOptions *
+garrow_run_end_encode_options_new_raw(
+  const arrow::compute::RunEndEncodeOptions *arrow_options);
+arrow::compute::RunEndEncodeOptions *
+garrow_run_end_encode_options_get_raw(GArrowRunEndEncodeOptions *options);

--- a/c_glib/test/test-run-end-encode.rb
+++ b/c_glib/test/test-run-end-encode.rb
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestRunEndEncode < Test::Unit::TestCase
+  include Helper::Buildable
+  include Helper::Omittable
+
+  def test_int32
+    array = build_int32_array([1, 3, 1, 1, -1, -1])
+    assert_equal(<<-STRING.chomp, array.run_end_encode.to_s)
+
+-- run_ends:
+  [
+    1,
+    2,
+    4,
+    6
+  ]
+-- values:
+  [
+    1,
+    3,
+    1,
+    -1
+  ]
+    STRING
+    assert_equal(array, array.run_end_encode.decode)
+  end
+
+  def test_string
+    array = build_string_array(["Ruby", "Ruby", "Python", "C++", "C++", "C++"])
+    assert_equal(<<-STRING.chomp, array.run_end_encode.to_s)
+
+-- run_ends:
+  [
+    2,
+    3,
+    6
+  ]
+-- values:
+  [
+    "Ruby",
+    "Python",
+    "C++"
+  ]
+    STRING
+    assert_equal(array, array.run_end_encode.decode)
+  end
+end

--- a/c_glib/test/test-run-end-encoded-array.rb
+++ b/c_glib/test/test-run-end-encoded-array.rb
@@ -1,0 +1,100 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestRunEndEncodedArray < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @run_end_data_type = Arrow::Int32DataType.new
+    @value_data_type = Arrow::StringDataType.new
+    @data_type = Arrow::RunEndEncodedDataType.new(@run_end_data_type,
+                                                  @value_data_type)
+  end
+
+  sub_test_case(".new") do
+    def test_new
+      run_ends = build_int32_array([2, 5, 6])
+      values = build_string_array(["hello", "hi", "world"])
+      array = Arrow::RunEndEncodedArray.new(@data_type,
+                                            6,
+                                            run_ends,
+                                            values,
+                                            0)
+      assert_equal(<<-STRING.chomp, array.to_s)
+
+-- run_ends:
+  [
+    2,
+    5,
+    6
+  ]
+-- values:
+  [
+    "hello",
+    "hi",
+    "world"
+  ]
+      STRING
+    end
+  end
+
+  sub_test_case("instance methods") do
+    def setup
+      super
+      @raw_run_ends = [3, 6, 7]
+      @run_ends = build_int32_array(@raw_run_ends)
+      @raw_values = ["hello", "hi", "world"]
+      @values = build_string_array(@raw_values)
+      @offset = 4
+      @array = Arrow::RunEndEncodedArray.new(@data_type,
+                                             3,
+                                             @run_ends,
+                                             @values,
+                                             @offset)
+    end
+
+    def test_run_ends
+      assert_equal(@run_ends, @array.run_ends)
+    end
+
+    def test_values
+      assert_equal(@values, @array.values)
+    end
+
+    def test_logical_run_ends
+      logical_raw_run_ends =
+        @raw_run_ends
+          .collect {|v| v - @offset}
+          .reject(&:negative?)
+      assert_equal(build_int32_array(logical_raw_run_ends),
+                   @array.logical_run_ends)
+    end
+
+    def test_logical_values
+      assert_equal(build_string_array(@raw_values[1..-1]),
+                   @array.logical_values)
+    end
+
+    def test_find_physical_offset
+      assert_equal(1, @array.find_physical_offset)
+    end
+
+    def test_find_physical_length
+      assert_equal(2, @array.find_physical_length)
+    end
+  end
+end


### PR DESCRIPTION
### Rationale for this change

`arrow::RunEndEncodedArray` is available since Apache Arrow C++ 12. Apache Arrow GLib should support it.

### What changes are included in this PR?

Add `GArrowRunEndEncodedArray` as the binding of `arrow::RunEndEncodedArray`.

`garrow_array_run_end_encode()` and `garrow_run_end_encoded_array_decode()` are also added.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.

* Closes: #35418