### PR TITLE
GH-36477: [CI][macOS] Ignore brew update failure on crossbow tasks

### DIFF
--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -204,7 +204,7 @@ on:
     env:
       ARROW_FORMULA: ./arrow/dev/tasks/homebrew-formulae/{{ formula }}
     run: |
-      brew update || :
+      brew update || echo "brew update did not finish successfully"
       brew --version
       brew unlink python@2 || true
       brew config

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -204,7 +204,7 @@ on:
     env:
       ARROW_FORMULA: ./arrow/dev/tasks/homebrew-formulae/{{ formula }}
     run: |
-      brew update
+      brew update || :
       brew --version
       brew unlink python@2 || true
       brew config

--- a/dev/tasks/verify-rc/github.macos.amd64.yml
+++ b/dev/tasks/verify-rc/github.macos.amd64.yml
@@ -47,7 +47,7 @@ jobs:
           rm -f /usr/local/bin/idle*
           rm -f /usr/local/bin/pydoc3*
           rm -f /usr/local/bin/python3*
-          brew update || :
+          brew update || echo "brew update did not finish successfully"
           brew install --overwrite git
           brew bundle --file=arrow/cpp/Brewfile
           brew bundle --file=arrow/c_glib/Brewfile

--- a/dev/tasks/verify-rc/github.macos.amd64.yml
+++ b/dev/tasks/verify-rc/github.macos.amd64.yml
@@ -47,7 +47,7 @@ jobs:
           rm -f /usr/local/bin/idle*
           rm -f /usr/local/bin/pydoc3*
           rm -f /usr/local/bin/python3*
-          brew update
+          brew update || :
           brew install --overwrite git
           brew bundle --file=arrow/cpp/Brewfile
           brew bundle --file=arrow/c_glib/Brewfile


### PR DESCRIPTION
### Rationale for this change

Some nightly verification tasks are failing.

### What changes are included in this PR?

Ignore possible errors on `brew update` commands on crossbow tasks.

### Are these changes tested?

Crossbow

### Are there any user-facing changes?

No
* Closes: #36477