### PR TITLE
GH-36492: [CI][Python] Add Ubuntu 22.04 nightly build

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1229,8 +1229,8 @@ tasks:
       image: ubuntu-python
 
   test-ubuntu-22.04-python-3:
-    ci: azure
-    template: docker-tests/azure.linux.yml
+    ci: github
+    template: docker-tests/github.linux.yml
     params:
       env:
         UBUNTU: 22.04

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1228,6 +1228,14 @@ tasks:
         UBUNTU: 20.04
       image: ubuntu-python
 
+  test-ubuntu-22.04-python-3:
+    ci: azure
+    template: docker-tests/azure.linux.yml
+    params:
+      env:
+        UBUNTU: 22.04
+      image: ubuntu-python
+
   test-fedora-35-python-3:
     ci: azure
     template: docker-tests/azure.linux.yml


### PR DESCRIPTION
Ubuntu 22.04 is the most recent LTS version.
It also has recent enough gRPC packages, so Flight will be enabled and tested on this platform.

* Closes: #36492