### PR TITLE
GH-36483: [C++] Make `UTF8StringToUTF16` and `UTF16StringToUTF8` accept `string_views`

### DIFF
--- a/cpp/src/arrow/util/utf8.cc
+++ b/cpp/src/arrow/util/utf8.cc
@@ -146,13 +146,13 @@ std::string WideStringToUTF8Internal(const std::wstring& source) {
   return s;
 }
 
-std::string UTF16StringToUTF8Internal(const std::u16string& source) {
+std::string UTF16StringToUTF8Internal(std::u16string_view source) {
   std::string s;
   ::utf8::utf16to8(source.begin(), source.end(), std::back_inserter(s));
   return s;
 }
 
-std::u16string UTF8StringToUTF16Internal(const std::string& source) {
+std::u16string UTF8StringToUTF16Internal(std::string_view source) {
   std::u16string s;
   ::utf8::utf8to16(source.begin(), source.end(), std::back_inserter(s));
   return s;
@@ -176,7 +176,7 @@ ARROW_EXPORT Result<std::string> WideStringToUTF8(const std::wstring& source) {
   }
 }
 
-Result<std::string> UTF16StringToUTF8(const std::u16string& source) {
+Result<std::string> UTF16StringToUTF8(std::u16string_view source) {
   try {
     return UTF16StringToUTF8Internal(source);
   } catch (std::exception& e) {
@@ -184,7 +184,7 @@ Result<std::string> UTF16StringToUTF8(const std::u16string& source) {
   }
 }
 
-Result<std::u16string> UTF8StringToUTF16(const std::string& source) {
+Result<std::u16string> UTF8StringToUTF16(std::string_view source) {
   try {
     return UTF8StringToUTF16Internal(source);
   } catch (std::exception& e) {

--- a/cpp/src/arrow/util/utf8.h
+++ b/cpp/src/arrow/util/utf8.h
@@ -37,10 +37,10 @@ ARROW_EXPORT Result<std::wstring> UTF8ToWideString(std::string_view source);
 ARROW_EXPORT Result<std::string> WideStringToUTF8(const std::wstring& source);
 
 // Convert UTF8 string to a UTF16 string.
-ARROW_EXPORT Result<std::u16string> UTF8StringToUTF16(const std::string& source);
+ARROW_EXPORT Result<std::u16string> UTF8StringToUTF16(std::string_view source);
 
 // Convert UTF16 string to a UTF8 string.
-ARROW_EXPORT Result<std::string> UTF16StringToUTF8(const std::u16string& source);
+ARROW_EXPORT Result<std::string> UTF16StringToUTF8(std::u16string_view source);
 
 // This function needs to be called before doing UTF8 validation.
 ARROW_EXPORT void InitializeUTF8();

--- a/matlab/src/cpp/arrow/matlab/array/proxy/timestamp_array.cc
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/timestamp_array.cc
@@ -49,7 +49,8 @@ namespace arrow::matlab::array::proxy {
         const mda::TypedArray<mda::MATLABString> units_mda = opts[0]["TimeUnit"];
 
         // extract the time zone string
-        MATLAB_ASSIGN_OR_ERROR(const auto timezone, arrow::util::UTF16StringToUTF8(timezone_mda[0]),
+        const std::u16string u16_timezone = timezone_mda[0];
+        MATLAB_ASSIGN_OR_ERROR(const auto timezone, arrow::util::UTF16StringToUTF8(u16_timezone),
                                error::UNICODE_CONVERSION_ERROR_ID);
 
         // extract the time unit

--- a/matlab/src/cpp/arrow/matlab/array/proxy/timestamp_array.cc
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/timestamp_array.cc
@@ -49,7 +49,7 @@ namespace arrow::matlab::array::proxy {
         const mda::TypedArray<mda::MATLABString> units_mda = opts[0]["TimeUnit"];
 
         // extract the time zone string
-        const std::u16string u16_timezone = timezone_mda[0];
+        const std::u16string& u16_timezone = timezone_mda[0];
         MATLAB_ASSIGN_OR_ERROR(const auto timezone, arrow::util::UTF16StringToUTF8(u16_timezone),
                                error::UNICODE_CONVERSION_ERROR_ID);
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

As @kou pointed out in #36366, it's better to pass read-only string data via  as string_views than as const references. I recently submitted two new functions called `UTF8StringToUTF16` and `UTF16StringToUTF8`, both of which accept const references. This PR changes the signatures of those functions to accept string_views.

### What changes are included in this PR?

Changed the function signatures of `UTF8StringToUTF16` and `UTF16StringToUTF8`:

1. `arrow::Result<std::u16string> UTF8StringToUTF16(const std::string& source)` ->
    `arrow::Result<std::u16string> UTF8StringToUTF16(std::string_view source)` 


2. `arrow::Result<std::string> UTF16StringToUTF8(const std::u16string& source)` ->
    `arrow::Result<std::string> UTF16StringToUTF8(std::u16string_view source)` 

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Uses existing tests in `utf8_util_test.cc`

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

No.

Only the MATLAB Interface uses these functions, so  I don't expect these changes to break anyone's code:

1. Search [results](https://github.com/search?q=repo%3Aapache%2Farrow%20UTF8StringToUTF16&type=code) for `UTF8StringToUTF16`
2. Search [results](https://github.com/search?q=repo%3Aapache%2Farrow+UTF16StringToUTF8&type=code) for `UTF16StringToUTF8`

* Closes: #36483