### PR TITLE
GH-34509: [C++][Parquet] Improve docstrings for ArrowReaderProperties::batch_size

### DIFF
--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -820,8 +820,11 @@ class PARQUET_EXPORT ArrowReaderProperties {
   /// \brief Set the maximum number of rows to read into a record batch.
   ///
   /// Will only be fewer rows when there are no more rows in the file.
+  /// Note that some APIs such as ReadTable may ignore this setting.
   void set_batch_size(int64_t batch_size) { batch_size_ = batch_size; }
-  /// Return the batch size, and it only applies to reading into RecordBatch.
+  /// Return the batch size in rows.
+  ///
+  /// Note that some APIs such as ReadTable may ignore this setting.
   int64_t batch_size() const { return batch_size_; }
 
   /// Enable read coalescing (default false).

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -817,11 +817,12 @@ class PARQUET_EXPORT ArrowReaderProperties {
     }
   }
 
-  /// \brief Set the maximum number of rows to read into a chunk or record batch.
+  /// \brief Set the maximum number of rows to read into a arrow chunk or record batch.
   ///
+  /// It's only for `arrow::RecordBatchReader` or RecordBatchGenerator.
   /// Will only be fewer rows when there are no more rows in the file.
   void set_batch_size(int64_t batch_size) { batch_size_ = batch_size; }
-  /// Return the batch size.
+  /// Return the batch size for `arrow::RecordBatchReader` or RecordBatchGenerator.
   int64_t batch_size() const { return batch_size_; }
 
   /// Enable read coalescing (default false).

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -817,12 +817,11 @@ class PARQUET_EXPORT ArrowReaderProperties {
     }
   }
 
-  /// \brief Set the maximum number of rows to read into a arrow chunk or record batch.
+  /// \brief Set the maximum number of rows to read into a record batch.
   ///
-  /// It's only for `arrow::RecordBatchReader` or RecordBatchGenerator.
   /// Will only be fewer rows when there are no more rows in the file.
   void set_batch_size(int64_t batch_size) { batch_size_ = batch_size; }
-  /// Return the batch size for `arrow::RecordBatchReader` or RecordBatchGenerator.
+  /// Return the batch size, and it only applies to reading into RecordBatch.
   int64_t batch_size() const { return batch_size_; }
 
   /// Enable read coalescing (default false).


### PR DESCRIPTION
Make it clear that the `batch_size` setting is ignored by some Parquet FileReader APIs.
* Closes: #34509