### PR TITLE
GH-36488: [C++] Import/Export ArrowDeviceArray

### DIFF
--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -63,13 +63,13 @@ class ARROW_EXPORT Buffer {
         data_(data),
         size_(size),
         capacity_(size),
-        device_type_(DeviceType::kCPU) {
+        device_type_(DeviceAllocationType::kCPU) {
     SetMemoryManager(default_cpu_memory_manager());
   }
 
   Buffer(const uint8_t* data, int64_t size, std::shared_ptr<MemoryManager> mm,
          std::shared_ptr<Buffer> parent = NULLPTR,
-         std::optional<DeviceType> device_type = std::nullopt)
+         std::optional<DeviceAllocationType> device_type = std::nullopt)
       : is_mutable_(false),
         data_(data),
         size_(size),
@@ -254,7 +254,7 @@ class ARROW_EXPORT Buffer {
 
   const std::shared_ptr<MemoryManager>& memory_manager() const { return memory_manager_; }
 
-  std::optional<DeviceType> device_type() const { return device_type_; }
+  std::optional<DeviceAllocationType> device_type() const { return device_type_; }
 
   std::shared_ptr<Buffer> parent() const { return parent_; }
 
@@ -310,7 +310,7 @@ class ARROW_EXPORT Buffer {
   const uint8_t* data_;
   int64_t size_;
   int64_t capacity_;
-  std::optional<DeviceType> device_type_;
+  std::optional<DeviceAllocationType> device_type_;
 
   // null by default, but may be set
   std::shared_ptr<Buffer> parent_;

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -75,7 +75,7 @@ class ARROW_EXPORT Buffer {
         size_(size),
         capacity_(size),
         parent_(std::move(parent)) {
-    // will set device_type from the memory manager
+    // SetMemoryManager will also set device_type_
     SetMemoryManager(std::move(mm));
     // if a device type is specified, use that instead. for example:
     // CUDA_HOST. The CudaMemoryManager will set device_type_ to CUDA,

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -57,12 +57,18 @@ class ARROW_EXPORT Buffer {
   ///
   /// \note The passed memory must be kept alive through some other means
   Buffer(const uint8_t* data, int64_t size)
-      : is_mutable_(false), is_cpu_(true), data_(data), size_(size), capacity_(size), device_type_(DeviceType::CPU) {
+      : is_mutable_(false),
+        is_cpu_(true),
+        data_(data),
+        size_(size),
+        capacity_(size),
+        device_type_(DeviceType::CPU) {
     SetMemoryManager(default_cpu_memory_manager());
   }
 
   Buffer(const uint8_t* data, int64_t size, std::shared_ptr<MemoryManager> mm,
-         std::shared_ptr<Buffer> parent = NULLPTR, DeviceType device_type = DeviceType::UNKNOWN)
+         std::shared_ptr<Buffer> parent = NULLPTR,
+         DeviceType device_type = DeviceType::UNKNOWN)
       : is_mutable_(false),
         data_(data),
         size_(size),

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -62,13 +63,13 @@ class ARROW_EXPORT Buffer {
         data_(data),
         size_(size),
         capacity_(size),
-        device_type_(DeviceType::CPU) {
+        device_type_(DeviceType::kCPU) {
     SetMemoryManager(default_cpu_memory_manager());
   }
 
   Buffer(const uint8_t* data, int64_t size, std::shared_ptr<MemoryManager> mm,
          std::shared_ptr<Buffer> parent = NULLPTR,
-         DeviceType device_type = DeviceType::UNKNOWN)
+         std::optional<DeviceType> device_type = std::nullopt)
       : is_mutable_(false),
         data_(data),
         size_(size),
@@ -79,7 +80,7 @@ class ARROW_EXPORT Buffer {
     // if a device type is specified, use that instead. for example:
     // CUDA_HOST. The CudaMemoryManager will set device_type_ to CUDA,
     // but you can specify CUDA_HOST as the device type to override it.
-    if (device_type != DeviceType::UNKNOWN) {
+    if (device_type != std::nullopt) {
       device_type_ = device_type;
     }
   }
@@ -253,7 +254,7 @@ class ARROW_EXPORT Buffer {
 
   const std::shared_ptr<MemoryManager>& memory_manager() const { return memory_manager_; }
 
-  DeviceType device_type() const { return device_type_; }
+  std::optional<DeviceType> device_type() const { return device_type_; }
 
   std::shared_ptr<Buffer> parent() const { return parent_; }
 
@@ -309,7 +310,7 @@ class ARROW_EXPORT Buffer {
   const uint8_t* data_;
   int64_t size_;
   int64_t capacity_;
-  DeviceType device_type_;
+  std::optional<DeviceType> device_type_;
 
   // null by default, but may be set
   std::shared_ptr<Buffer> parent_;

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -57,18 +57,25 @@ class ARROW_EXPORT Buffer {
   ///
   /// \note The passed memory must be kept alive through some other means
   Buffer(const uint8_t* data, int64_t size)
-      : is_mutable_(false), is_cpu_(true), data_(data), size_(size), capacity_(size) {
+      : is_mutable_(false), is_cpu_(true), data_(data), size_(size), capacity_(size), device_type_(DeviceType::CPU) {
     SetMemoryManager(default_cpu_memory_manager());
   }
 
   Buffer(const uint8_t* data, int64_t size, std::shared_ptr<MemoryManager> mm,
-         std::shared_ptr<Buffer> parent = NULLPTR)
+         std::shared_ptr<Buffer> parent = NULLPTR, DeviceType device_type = DeviceType::UNKNOWN)
       : is_mutable_(false),
         data_(data),
         size_(size),
         capacity_(size),
         parent_(std::move(parent)) {
+    // will set device_type from the memory manager
     SetMemoryManager(std::move(mm));
+    // if a device type is specified, use that instead. for example:
+    // CUDA_HOST. The CudaMemoryManager will set device_type_ to CUDA,
+    // but you can specify CUDA_HOST as the device type to override it.
+    if (device_type != DeviceType::UNKNOWN) {
+      device_type_ = device_type;
+    }
   }
 
   Buffer(uintptr_t address, int64_t size, std::shared_ptr<MemoryManager> mm,
@@ -240,6 +247,8 @@ class ARROW_EXPORT Buffer {
 
   const std::shared_ptr<MemoryManager>& memory_manager() const { return memory_manager_; }
 
+  DeviceType device_type() const { return device_type_; }
+
   std::shared_ptr<Buffer> parent() const { return parent_; }
 
   /// \brief Get a RandomAccessFile for reading a buffer
@@ -294,6 +303,7 @@ class ARROW_EXPORT Buffer {
   const uint8_t* data_;
   int64_t size_;
   int64_t capacity_;
+  DeviceType device_type_;
 
   // null by default, but may be set
   std::shared_ptr<Buffer> parent_;
@@ -309,6 +319,7 @@ class ARROW_EXPORT Buffer {
   void SetMemoryManager(std::shared_ptr<MemoryManager> mm) {
     memory_manager_ = std::move(mm);
     is_cpu_ = memory_manager_->is_cpu();
+    device_type_ = memory_manager_->device()->device_type();
   }
 
  private:

--- a/cpp/src/arrow/buffer_test.cc
+++ b/cpp/src/arrow/buffer_test.cc
@@ -41,7 +41,7 @@ using internal::checked_cast;
 using internal::checked_pointer_cast;
 
 static const char kMyDeviceTypeName[] = "arrowtest::MyDevice";
-static const DeviceType kMyDeviceType = DeviceType::kEXT_DEV;
+static const DeviceAllocationType kMyDeviceType = DeviceAllocationType::kEXT_DEV;
 
 static const int kMyDeviceAllowCopy = 1;
 static const int kMyDeviceAllowView = 2;
@@ -71,7 +71,7 @@ class MyDevice : public Device {
     return checked_cast<const MyDevice&>(other).value_ == value_;
   }
 
-  DeviceType device_type() const override { return kMyDeviceType; }
+  DeviceAllocationType device_type() const override { return kMyDeviceType; }
 
   std::shared_ptr<MemoryManager> default_memory_manager() override;
 
@@ -259,7 +259,7 @@ TEST_F(TestDevice, Copy) {
   ASSERT_EQ(buffer->device(), cpu_device_);
   ASSERT_TRUE(buffer->is_cpu());
   ASSERT_NE(buffer->address(), cpu_src_->address());
-  ASSERT_EQ(buffer->device_type(), DeviceType::kCPU);
+  ASSERT_EQ(buffer->device_type(), DeviceAllocationType::kCPU);
   ASSERT_NE(buffer->data(), nullptr);
   AssertBufferEqual(*buffer, "some data");
 
@@ -267,7 +267,7 @@ TEST_F(TestDevice, Copy) {
   ASSERT_EQ(buffer->device(), cpu_device_);
   ASSERT_TRUE(buffer->is_cpu());
   ASSERT_NE(buffer->address(), cpu_src_->address());
-  ASSERT_EQ(buffer->device_type(), DeviceType::kCPU);
+  ASSERT_EQ(buffer->device_type(), DeviceAllocationType::kCPU);
   ASSERT_NE(buffer->data(), nullptr);
   AssertBufferEqual(*buffer, "some data");
 
@@ -297,7 +297,7 @@ TEST_F(TestDevice, Copy) {
   ASSERT_EQ(buffer->device(), cpu_device_);
   ASSERT_TRUE(buffer->is_cpu());
   ASSERT_NE(buffer->address(), my_copy_src_->address());
-  ASSERT_EQ(buffer->device_type(), DeviceType::kCPU);
+  ASSERT_EQ(buffer->device_type(), DeviceAllocationType::kCPU);
   ASSERT_NE(buffer->data(), nullptr);
   AssertBufferEqual(*buffer, "some data");
 
@@ -305,7 +305,7 @@ TEST_F(TestDevice, Copy) {
   ASSERT_EQ(buffer->device(), cpu_device_);
   ASSERT_TRUE(buffer->is_cpu());
   ASSERT_NE(buffer->address(), my_copy_src_->address());
-  ASSERT_EQ(buffer->device_type(), DeviceType::kCPU);
+  ASSERT_EQ(buffer->device_type(), DeviceAllocationType::kCPU);
   ASSERT_NE(buffer->data(), nullptr);
   AssertBufferEqual(*buffer, "some data");
 
@@ -341,7 +341,7 @@ TEST_F(TestDevice, View) {
   ASSERT_EQ(buffer->device(), cpu_device_);
   ASSERT_TRUE(buffer->is_cpu());
   ASSERT_EQ(buffer->address(), cpu_src_->address());
-  ASSERT_EQ(buffer->device_type(), DeviceType::kCPU);
+  ASSERT_EQ(buffer->device_type(), DeviceAllocationType::kCPU);
   ASSERT_NE(buffer->data(), nullptr);
   AssertBufferEqual(*buffer, "some data");
 
@@ -361,7 +361,7 @@ TEST_F(TestDevice, View) {
   ASSERT_EQ(buffer->device(), cpu_device_);
   ASSERT_TRUE(buffer->is_cpu());
   ASSERT_EQ(buffer->address(), my_copy_src_->address());
-  ASSERT_EQ(buffer->device_type(), DeviceType::kCPU);
+  ASSERT_EQ(buffer->device_type(), DeviceAllocationType::kCPU);
   ASSERT_NE(buffer->data(), nullptr);
   AssertBufferEqual(*buffer, "some data");
 

--- a/cpp/src/arrow/buffer_test.cc
+++ b/cpp/src/arrow/buffer_test.cc
@@ -41,6 +41,7 @@ using internal::checked_cast;
 using internal::checked_pointer_cast;
 
 static const char kMyDeviceTypeName[] = "arrowtest::MyDevice";
+static const DeviceType kMyDeviceType = DeviceType::EXT_DEV;
 
 static const int kMyDeviceAllowCopy = 1;
 static const int kMyDeviceAllowView = 2;
@@ -69,6 +70,8 @@ class MyDevice : public Device {
     }
     return checked_cast<const MyDevice&>(other).value_ == value_;
   }
+
+  DeviceType device_type() const override { return kMyDeviceType; }
 
   std::shared_ptr<MemoryManager> default_memory_manager() override;
 
@@ -256,6 +259,7 @@ TEST_F(TestDevice, Copy) {
   ASSERT_EQ(buffer->device(), cpu_device_);
   ASSERT_TRUE(buffer->is_cpu());
   ASSERT_NE(buffer->address(), cpu_src_->address());
+  ASSERT_EQ(buffer->device_type(), DeviceType::CPU);
   ASSERT_NE(buffer->data(), nullptr);
   AssertBufferEqual(*buffer, "some data");
 
@@ -263,6 +267,7 @@ TEST_F(TestDevice, Copy) {
   ASSERT_EQ(buffer->device(), cpu_device_);
   ASSERT_TRUE(buffer->is_cpu());
   ASSERT_NE(buffer->address(), cpu_src_->address());
+  ASSERT_EQ(buffer->device_type(), DeviceType::CPU);
   ASSERT_NE(buffer->data(), nullptr);
   AssertBufferEqual(*buffer, "some data");
 
@@ -271,6 +276,7 @@ TEST_F(TestDevice, Copy) {
   ASSERT_EQ(buffer->device(), my_copy_device_);
   ASSERT_FALSE(buffer->is_cpu());
   ASSERT_NE(buffer->address(), cpu_src_->address());
+  ASSERT_EQ(buffer->device_type(), kMyDeviceType);
 #ifdef NDEBUG
   ASSERT_EQ(buffer->data(), nullptr);
 #endif
@@ -280,6 +286,7 @@ TEST_F(TestDevice, Copy) {
   ASSERT_EQ(buffer->device(), my_copy_device_);
   ASSERT_FALSE(buffer->is_cpu());
   ASSERT_NE(buffer->address(), cpu_src_->address());
+  ASSERT_EQ(buffer->device_type(), kMyDeviceType);
 #ifdef NDEBUG
   ASSERT_EQ(buffer->data(), nullptr);
 #endif
@@ -290,6 +297,7 @@ TEST_F(TestDevice, Copy) {
   ASSERT_EQ(buffer->device(), cpu_device_);
   ASSERT_TRUE(buffer->is_cpu());
   ASSERT_NE(buffer->address(), my_copy_src_->address());
+  ASSERT_EQ(buffer->device_type(), DeviceType::CPU);
   ASSERT_NE(buffer->data(), nullptr);
   AssertBufferEqual(*buffer, "some data");
 
@@ -297,6 +305,7 @@ TEST_F(TestDevice, Copy) {
   ASSERT_EQ(buffer->device(), cpu_device_);
   ASSERT_TRUE(buffer->is_cpu());
   ASSERT_NE(buffer->address(), my_copy_src_->address());
+  ASSERT_EQ(buffer->device_type(), DeviceType::CPU);
   ASSERT_NE(buffer->data(), nullptr);
   AssertBufferEqual(*buffer, "some data");
 
@@ -305,6 +314,7 @@ TEST_F(TestDevice, Copy) {
   ASSERT_EQ(buffer->device(), my_copy_device_);
   ASSERT_FALSE(buffer->is_cpu());
   ASSERT_NE(buffer->address(), my_copy_src_->address());
+  ASSERT_EQ(buffer->device_type(), kMyDeviceType);
 #ifdef NDEBUG
   ASSERT_EQ(buffer->data(), nullptr);
 #endif
@@ -315,6 +325,7 @@ TEST_F(TestDevice, Copy) {
   ASSERT_EQ(buffer->device(), my_copy_device_);
   ASSERT_FALSE(buffer->is_cpu());
   ASSERT_NE(buffer->address(), my_copy_src_->address());
+  ASSERT_EQ(buffer->device_type(), kMyDeviceType);
 #ifdef NDEBUG
   ASSERT_EQ(buffer->data(), nullptr);
 #endif
@@ -330,6 +341,7 @@ TEST_F(TestDevice, View) {
   ASSERT_EQ(buffer->device(), cpu_device_);
   ASSERT_TRUE(buffer->is_cpu());
   ASSERT_EQ(buffer->address(), cpu_src_->address());
+  ASSERT_EQ(buffer->device_type(), DeviceType::CPU);
   ASSERT_NE(buffer->data(), nullptr);
   AssertBufferEqual(*buffer, "some data");
 
@@ -338,6 +350,7 @@ TEST_F(TestDevice, View) {
   ASSERT_EQ(buffer->device(), my_view_device_);
   ASSERT_FALSE(buffer->is_cpu());
   ASSERT_EQ(buffer->address(), cpu_src_->address());
+  ASSERT_EQ(buffer->device_type(), kMyDeviceType);
 #ifdef NDEBUG
   ASSERT_EQ(buffer->data(), nullptr);
 #endif
@@ -348,6 +361,7 @@ TEST_F(TestDevice, View) {
   ASSERT_EQ(buffer->device(), cpu_device_);
   ASSERT_TRUE(buffer->is_cpu());
   ASSERT_EQ(buffer->address(), my_copy_src_->address());
+  ASSERT_EQ(buffer->device_type(), DeviceType::CPU);
   ASSERT_NE(buffer->data(), nullptr);
   AssertBufferEqual(*buffer, "some data");
 

--- a/cpp/src/arrow/buffer_test.cc
+++ b/cpp/src/arrow/buffer_test.cc
@@ -41,7 +41,7 @@ using internal::checked_cast;
 using internal::checked_pointer_cast;
 
 static const char kMyDeviceTypeName[] = "arrowtest::MyDevice";
-static const DeviceType kMyDeviceType = DeviceType::EXT_DEV;
+static const DeviceType kMyDeviceType = DeviceType::kEXT_DEV;
 
 static const int kMyDeviceAllowCopy = 1;
 static const int kMyDeviceAllowView = 2;
@@ -259,7 +259,7 @@ TEST_F(TestDevice, Copy) {
   ASSERT_EQ(buffer->device(), cpu_device_);
   ASSERT_TRUE(buffer->is_cpu());
   ASSERT_NE(buffer->address(), cpu_src_->address());
-  ASSERT_EQ(buffer->device_type(), DeviceType::CPU);
+  ASSERT_EQ(buffer->device_type(), DeviceType::kCPU);
   ASSERT_NE(buffer->data(), nullptr);
   AssertBufferEqual(*buffer, "some data");
 
@@ -267,7 +267,7 @@ TEST_F(TestDevice, Copy) {
   ASSERT_EQ(buffer->device(), cpu_device_);
   ASSERT_TRUE(buffer->is_cpu());
   ASSERT_NE(buffer->address(), cpu_src_->address());
-  ASSERT_EQ(buffer->device_type(), DeviceType::CPU);
+  ASSERT_EQ(buffer->device_type(), DeviceType::kCPU);
   ASSERT_NE(buffer->data(), nullptr);
   AssertBufferEqual(*buffer, "some data");
 
@@ -297,7 +297,7 @@ TEST_F(TestDevice, Copy) {
   ASSERT_EQ(buffer->device(), cpu_device_);
   ASSERT_TRUE(buffer->is_cpu());
   ASSERT_NE(buffer->address(), my_copy_src_->address());
-  ASSERT_EQ(buffer->device_type(), DeviceType::CPU);
+  ASSERT_EQ(buffer->device_type(), DeviceType::kCPU);
   ASSERT_NE(buffer->data(), nullptr);
   AssertBufferEqual(*buffer, "some data");
 
@@ -305,7 +305,7 @@ TEST_F(TestDevice, Copy) {
   ASSERT_EQ(buffer->device(), cpu_device_);
   ASSERT_TRUE(buffer->is_cpu());
   ASSERT_NE(buffer->address(), my_copy_src_->address());
-  ASSERT_EQ(buffer->device_type(), DeviceType::CPU);
+  ASSERT_EQ(buffer->device_type(), DeviceType::kCPU);
   ASSERT_NE(buffer->data(), nullptr);
   AssertBufferEqual(*buffer, "some data");
 
@@ -341,7 +341,7 @@ TEST_F(TestDevice, View) {
   ASSERT_EQ(buffer->device(), cpu_device_);
   ASSERT_TRUE(buffer->is_cpu());
   ASSERT_EQ(buffer->address(), cpu_src_->address());
-  ASSERT_EQ(buffer->device_type(), DeviceType::CPU);
+  ASSERT_EQ(buffer->device_type(), DeviceType::kCPU);
   ASSERT_NE(buffer->data(), nullptr);
   AssertBufferEqual(*buffer, "some data");
 
@@ -361,7 +361,7 @@ TEST_F(TestDevice, View) {
   ASSERT_EQ(buffer->device(), cpu_device_);
   ASSERT_TRUE(buffer->is_cpu());
   ASSERT_EQ(buffer->address(), my_copy_src_->address());
-  ASSERT_EQ(buffer->device_type(), DeviceType::CPU);
+  ASSERT_EQ(buffer->device_type(), DeviceType::kCPU);
   ASSERT_NE(buffer->data(), nullptr);
   AssertBufferEqual(*buffer, "some data");
 

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -674,7 +674,8 @@ Status ExportRecordBatch(const RecordBatch& batch, struct ArrowArray* out,
 //////////////////////////////////////////////////////////////////////////
 // C device arrays
 
-Status ValidateDeviceInfo(const ArrayData& data, std::optional<DeviceAllocationType>* device_type,
+Status ValidateDeviceInfo(const ArrayData& data,
+                          std::optional<DeviceAllocationType>* device_type,
                           int64_t* device_id) {
   for (const auto& buf : data.buffers) {
     if (!buf) {
@@ -1388,7 +1389,8 @@ class ImportedBuffer : public Buffer {
       : Buffer(data, size), import_(std::move(import)) {}
 
   ImportedBuffer(const uint8_t* data, int64_t size, std::shared_ptr<MemoryManager> mm,
-                 DeviceAllocationType device_type, std::shared_ptr<ImportedArrayData> import)
+                 DeviceAllocationType device_type,
+                 std::shared_ptr<ImportedArrayData> import)
       : Buffer(data, size, mm, nullptr, device_type), import_(std::move(import)) {}
 
   ~ImportedBuffer() override {}

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -675,7 +675,8 @@ Status ExportRecordBatch(const RecordBatch& batch, struct ArrowArray* out,
 //////////////////////////////////////////////////////////////////////////
 // C device arrays
 
-Status ValidateDeviceInfo(const ArrayData& data, DeviceType* device_type, int64_t* device_id) {
+Status ValidateDeviceInfo(const ArrayData& data, DeviceType* device_type,
+                          int64_t* device_id) {
   for (const auto& buf : data.buffers) {
     if (!buf) {
       continue;
@@ -695,7 +696,7 @@ Status ValidateDeviceInfo(const ArrayData& data, DeviceType* device_type, int64_
     if (buf->device()->device_id() != *device_id) {
       return Status::Invalid(
           "Exporting device array with buffers on multiple device ids.");
-    }  
+    }
   }
 
   for (const auto& child : data.child_data) {
@@ -711,7 +712,6 @@ Result<std::pair<DeviceType, int64_t>> ValidateDeviceInfo(const ArrayData& data)
   RETURN_NOT_OK(ValidateDeviceInfo(data, &device_type, &device_id));
   return std::make_pair(device_type, device_id);
 }
-
 
 Status ExportDeviceArray(const Array& array, void* sync_event,
                          ReleaseEventFunc sync_release, struct ArrowDeviceArray* out,

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -227,7 +227,6 @@ Status ExportDeviceRecordBatch(const RecordBatch& batch, RawSyncEvent sync_event
 using DeviceMemoryMapper =
     std::function<Result<std::shared_ptr<MemoryManager>>(ArrowDeviceType, int64_t)>;
 
-
 /// \brief EXPERIMENTAL: Import C++ device array from the C data interface.
 ///
 /// The ArrowArray struct has its contents moved (as per the C data interface

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -198,7 +198,7 @@ struct RawSyncEvent {
 /// \param[out] out C struct to export the array to
 /// \param[out] out_schema optional C struct to export the array type to
 ARROW_EXPORT
-Status ExportDeviceArray(const Array& array, RawSyncEvent sync_event, 
+Status ExportDeviceArray(const Array& array, RawSyncEvent sync_event,
                          struct ArrowDeviceArray* out,
                          struct ArrowSchema* out_schema = NULLPTR);
 
@@ -216,16 +216,16 @@ Status ExportDeviceArray(const Array& array, RawSyncEvent sync_event,
 /// non-null. If the sync_event is null, then the sync_release parameter is ignored.
 ///
 /// \param[in] batch Record batch to export
-/// \param[in] sync_event A struct containing what is needed for syncing if necessary 
-/// \param[out] out C struct where to export the record batch 
+/// \param[in] sync_event A struct containing what is needed for syncing if necessary
+/// \param[out] out C struct where to export the record batch
 /// \param[out] out_schema optional C struct where to export the record batch schema
 ARROW_EXPORT
 Status ExportDeviceRecordBatch(const RecordBatch& batch, RawSyncEvent sync_event,
                                struct ArrowDeviceArray* out,
                                struct ArrowSchema* out_schema = NULLPTR);
 
-using DeviceMemoryMapper = std::function<Result<std::shared_ptr<MemoryManager>>(ArrowDeviceType, int64_t)>;
-
+using DeviceMemoryMapper =
+    std::function<Result<std::shared_ptr<MemoryManager>>(ArrowDeviceType, int64_t)>;
 
 // ARROW_EXPORT
 // Result<std::shared_ptr<MemoryManager>> DefaultMemoryMapper(ArrowDeviceType device_type,
@@ -239,8 +239,8 @@ using DeviceMemoryMapper = std::function<Result<std::shared_ptr<MemoryManager>>(
 ///
 /// \param[in,out] array C data interface struct holding the array data
 /// \param[in] type type of the imported array
-/// \param[in] mapper An object with a `get_manager` method to map a device type to a
-/// memory manager \return Imported array object
+/// \param[in] mapper A function to map device + id to memory manager
+/// \return Imported array object
 ARROW_EXPORT
 Result<std::shared_ptr<Array>> ImportDeviceArray(struct ArrowDeviceArray* array,
                                                  std::shared_ptr<DataType> type,
@@ -255,8 +255,8 @@ Result<std::shared_ptr<Array>> ImportDeviceArray(struct ArrowDeviceArray* array,
 ///
 /// \param[in,out] array C data interface struct holding the array data
 /// \param[in,out] type C data interface struct holding the array type
-/// \param[in] mapper An object with a `get_manager` method to map a device type to a
-/// memory manager \return Imported array object
+/// \param[in] mapper A function to map device + id to memory manager
+/// \return Imported array object
 ARROW_EXPORT
 Result<std::shared_ptr<Array>> ImportDeviceArray(struct ArrowDeviceArray* array,
                                                  struct ArrowSchema* type,
@@ -272,8 +272,8 @@ Result<std::shared_ptr<Array>> ImportDeviceArray(struct ArrowDeviceArray* array,
 ///
 /// \param[in,out] array C data interface struct holding the record batch data
 /// \param[in] schema schema of the imported record batch
-/// \param[in] mapper An object with a `get_manager` method to map a device type to a
-/// memory manager \return Imported record batch object
+/// \param[in] mapper A function to map device + id to memory manager
+/// \return Imported record batch object
 ARROW_EXPORT
 Result<std::shared_ptr<RecordBatch>> ImportDeviceRecordBatch(
     struct ArrowArray* array, std::shared_ptr<Schema> schema,
@@ -291,11 +291,12 @@ Result<std::shared_ptr<RecordBatch>> ImportDeviceRecordBatch(
 ///
 /// \param[in,out] array C data interface struct holding the record batch data
 /// \param[in,out] schema C data interface struct holding the record batch schema
-/// \param[in] mapper An object with a `get_manager` method to map a device type to a
-/// memory manager \return Imported record batch object
+/// \param[in] mapper A function to map device + id to memory manager
+/// \return Imported record batch object
 ARROW_EXPORT
 Result<std::shared_ptr<RecordBatch>> ImportDeviceRecordBatch(
-    struct ArrowArray* array, struct ArrowSchema* schema, const DeviceMemoryMapper& mapper);
+    struct ArrowArray* array, struct ArrowSchema* schema,
+    const DeviceMemoryMapper& mapper);
 
 /// @}
 

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -227,9 +227,6 @@ Status ExportDeviceRecordBatch(const RecordBatch& batch, RawSyncEvent sync_event
 using DeviceMemoryMapper =
     std::function<Result<std::shared_ptr<MemoryManager>>(ArrowDeviceType, int64_t)>;
 
-// ARROW_EXPORT
-// Result<std::shared_ptr<MemoryManager>> DefaultMemoryMapper(ArrowDeviceType device_type,
-//                                                            int64_t device_id);
 
 /// \brief EXPERIMENTAL: Import C++ device array from the C data interface.
 ///
@@ -276,7 +273,7 @@ Result<std::shared_ptr<Array>> ImportDeviceArray(struct ArrowDeviceArray* array,
 /// \return Imported record batch object
 ARROW_EXPORT
 Result<std::shared_ptr<RecordBatch>> ImportDeviceRecordBatch(
-    struct ArrowArray* array, std::shared_ptr<Schema> schema,
+    struct ArrowDeviceArray* array, std::shared_ptr<Schema> schema,
     const DeviceMemoryMapper& mapper);
 
 /// \brief EXPERIMENTAL: Import C++ record batch with buffers on a device and its schema
@@ -295,7 +292,7 @@ Result<std::shared_ptr<RecordBatch>> ImportDeviceRecordBatch(
 /// \return Imported record batch object
 ARROW_EXPORT
 Result<std::shared_ptr<RecordBatch>> ImportDeviceRecordBatch(
-    struct ArrowArray* array, struct ArrowSchema* schema,
+    struct ArrowDeviceArray* array, struct ArrowSchema* schema,
     const DeviceMemoryMapper& mapper);
 
 /// @}

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -179,7 +179,7 @@ Result<std::shared_ptr<RecordBatch>> ImportRecordBatch(struct ArrowArray* array,
 /// array. It's the responsibility of the release function for the array
 /// to release the event. Both can be null if no sync'ing is necessary.
 struct RawSyncEvent {
-  void* sync_event = nullptr;
+  void* sync_event = NULL;
   std::function<void(void*)> release_func;
 };
 

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <string>
 
@@ -176,8 +177,11 @@ Result<std::shared_ptr<RecordBatch>> ImportRecordBatch(struct ArrowArray* array,
 /// If synchronization is necessary for accessing the data on a device,
 /// a pointer to an event needs to be passed when exporting the device
 /// array. It's the responsibility of the release function for the array
-/// to release the event.
-using ReleaseEventFunc = void (*)(void*);
+/// to release the event. Both can be null if no sync'ing is necessary.
+struct RawSyncEvent {
+  void* sync_event = nullptr;
+  std::function<void(void*)> release_func;
+};
 
 /// \brief EXPERIMENTAL: Export C++ Array as an ArrowDeviceArray.
 ///
@@ -190,14 +194,12 @@ using ReleaseEventFunc = void (*)(void*);
 /// non-null. If the sync_event is null, then the sync_release parameter is not called.
 ///
 /// \param[in] array Array object to export
-/// \param[in] sync_event A pointer to an event-like object if necessary for
-/// synchronization, otherwise null.
-/// \param[in] sync_release Function pointer to release the sync event
+/// \param[in] sync_event A struct containing what is needed for syncing if necessary
 /// \param[out] out C struct to export the array to
 /// \param[out] out_schema optional C struct to export the array type to
 ARROW_EXPORT
-Status ExportDeviceArray(const Array& array, void* sync_event,
-                         ReleaseEventFunc sync_release, struct ArrowDeviceArray* out,
+Status ExportDeviceArray(const Array& array, RawSyncEvent sync_event, 
+                         struct ArrowDeviceArray* out,
                          struct ArrowSchema* out_schema = NULLPTR);
 
 /// \brief EXPERIMENTAL: Export C++ RecordBatch as an ArrowDeviceArray.
@@ -214,23 +216,20 @@ Status ExportDeviceArray(const Array& array, void* sync_event,
 /// non-null. If the sync_event is null, then the sync_release parameter is ignored.
 ///
 /// \param[in] batch Record batch to export
-/// \param[in] sync_event A pointer to an event-like object if necessary for
-/// synchronization, otherwise null. \param[in] sync_release Function pointer to release
-/// the sync event \param[out] out C struct where to export the record batch \param[out]
-/// out_schema optional C struct where to export the record batch schema
+/// \param[in] sync_event A struct containing what is needed for syncing if necessary 
+/// \param[out] out C struct where to export the record batch 
+/// \param[out] out_schema optional C struct where to export the record batch schema
 ARROW_EXPORT
-Status ExportDeviceRecordBatch(const RecordBatch& batch, void* sync_event,
-                               ReleaseEventFunc sync_release,
+Status ExportDeviceRecordBatch(const RecordBatch& batch, RawSyncEvent sync_event,
                                struct ArrowDeviceArray* out,
                                struct ArrowSchema* out_schema = NULLPTR);
 
-class ARROW_EXPORT DeviceMemoryMgr {
- public:
-  virtual ~DeviceMemoryMgr() = default;
+using DeviceMemoryMapper = std::function<Result<std::shared_ptr<MemoryManager>>(ArrowDeviceType, int64_t)>;
 
-  virtual Result<std::shared_ptr<MemoryManager>> get_manager(ArrowDeviceType device_type,
-                                                             int64_t device_id) const = 0;
-};
+
+// ARROW_EXPORT
+// Result<std::shared_ptr<MemoryManager>> DefaultMemoryMapper(ArrowDeviceType device_type,
+//                                                            int64_t device_id);
 
 /// \brief EXPERIMENTAL: Import C++ device array from the C data interface.
 ///
@@ -245,7 +244,7 @@ class ARROW_EXPORT DeviceMemoryMgr {
 ARROW_EXPORT
 Result<std::shared_ptr<Array>> ImportDeviceArray(struct ArrowDeviceArray* array,
                                                  std::shared_ptr<DataType> type,
-                                                 const DeviceMemoryMgr& mapper);
+                                                 const DeviceMemoryMapper& mapper);
 
 /// \brief EXPERIMENTAL: Import C++ device array and its type from the C data interface.
 ///
@@ -261,7 +260,7 @@ Result<std::shared_ptr<Array>> ImportDeviceArray(struct ArrowDeviceArray* array,
 ARROW_EXPORT
 Result<std::shared_ptr<Array>> ImportDeviceArray(struct ArrowDeviceArray* array,
                                                  struct ArrowSchema* type,
-                                                 const DeviceMemoryMgr& mapper);
+                                                 const DeviceMemoryMapper& mapper);
 
 /// \brief EXPERIMENTAL: Import C++ record batch with buffers on a device from the C data
 /// interface.
@@ -278,7 +277,7 @@ Result<std::shared_ptr<Array>> ImportDeviceArray(struct ArrowDeviceArray* array,
 ARROW_EXPORT
 Result<std::shared_ptr<RecordBatch>> ImportDeviceRecordBatch(
     struct ArrowArray* array, std::shared_ptr<Schema> schema,
-    const DeviceMemoryMgr& mapper);
+    const DeviceMemoryMapper& mapper);
 
 /// \brief EXPERIMENTAL: Import C++ record batch with buffers on a device and its schema
 /// from the C data interface.
@@ -296,7 +295,7 @@ Result<std::shared_ptr<RecordBatch>> ImportDeviceRecordBatch(
 /// memory manager \return Imported record batch object
 ARROW_EXPORT
 Result<std::shared_ptr<RecordBatch>> ImportDeviceRecordBatch(
-    struct ArrowArray* array, struct ArrowSchema* schema, const DeviceMemoryMgr& mapper);
+    struct ArrowArray* array, struct ArrowSchema* schema, const DeviceMemoryMapper& mapper);
 
 /// @}
 

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -166,14 +166,15 @@ Result<std::shared_ptr<RecordBatch>> ImportRecordBatch(struct ArrowArray* array,
 
 /// @}
 
-/// \defgroup c-data-device-interface Functions for working with the C data device interface.
+/// \defgroup c-data-device-interface Functions for working with the C data device
+/// interface.
 ///
 /// @{
 
 /// \brief EXPERIMENTAL: Type for freeing a sync event
 ///
 /// If synchronization is necessary for accessing the data on a device,
-/// a pointer to an event needs to be passed when exporting the device 
+/// a pointer to an event needs to be passed when exporting the device
 /// array. It's the responsibility of the release function for the array
 /// to release the event.
 using ReleaseEventFunc = void (*)(void*);
@@ -189,13 +190,14 @@ using ReleaseEventFunc = void (*)(void*);
 /// non-null. If the sync_event is null, then the sync_release parameter is ignored.
 ///
 /// \param[in] array Array object to export
-/// \param[in] sync_event A pointer to an event-like object if necessary for synchronization, otherwise null.
-/// \param[in] sync_release Function pointer to release the sync event
-/// \param[out] out C struct to export the array to
-/// \param[out] out_schema optional C struct to export the array type to
+/// \param[in] sync_event A pointer to an event-like object if necessary for
+/// synchronization, otherwise null. \param[in] sync_release Function pointer to release
+/// the sync event \param[out] out C struct to export the array to \param[out] out_schema
+/// optional C struct to export the array type to
 ARROW_EXPORT
-Status ExportDeviceArray(const Array& array, void* sync_event, ReleaseEventFunc sync_release,
-                         struct ArrowDeviceArray* out, struct ArrowSchema* out_schema = NULLPTR);
+Status ExportDeviceArray(const Array& array, void* sync_event,
+                         ReleaseEventFunc sync_release, struct ArrowDeviceArray* out,
+                         struct ArrowSchema* out_schema = NULLPTR);
 
 /// \brief EXPERIMENTAL: Export C++ RecordBatch as an ArrowDeviceArray.
 ///
@@ -211,20 +213,22 @@ Status ExportDeviceArray(const Array& array, void* sync_event, ReleaseEventFunc 
 /// non-null. If the sync_event is null, then the sync_release parameter is ignored.
 ///
 /// \param[in] batch Record batch to export
-/// \param[in] sync_event A pointer to an event-like object if necessary for synchronization, otherwise null.
-/// \param[in] sync_release Function pointer to release the sync event
-/// \param[out] out C struct where to export the record batch
-/// \param[out] out_schema optional C struct where to export the record batch schema
+/// \param[in] sync_event A pointer to an event-like object if necessary for
+/// synchronization, otherwise null. \param[in] sync_release Function pointer to release
+/// the sync event \param[out] out C struct where to export the record batch \param[out]
+/// out_schema optional C struct where to export the record batch schema
 ARROW_EXPORT
-Status ExportDeviceRecordBatch(const RecordBatch& batch, void* sync_event, ReleaseEventFunc sync_release,
-                               struct ArrowDeviceArray* out, struct ArrowSchema* out_schema = NULLPTR);
-
+Status ExportDeviceRecordBatch(const RecordBatch& batch, void* sync_event,
+                               ReleaseEventFunc sync_release,
+                               struct ArrowDeviceArray* out,
+                               struct ArrowSchema* out_schema = NULLPTR);
 
 class ARROW_EXPORT DeviceMemoryMgr {
  public:
   virtual ~DeviceMemoryMgr() = default;
 
-  virtual Result<std::shared_ptr<MemoryManager>> get_manager(ArrowDeviceType device_type, int64_t device_id) const = 0;
+  virtual Result<std::shared_ptr<MemoryManager>> get_manager(ArrowDeviceType device_type,
+                                                             int64_t device_id) const = 0;
 };
 
 /// \brief EXPERIMENTAL: Import C++ device array from the C data interface.
@@ -235,8 +239,8 @@ class ARROW_EXPORT DeviceMemoryMgr {
 ///
 /// \param[in,out] array C data interface struct holding the array data
 /// \param[in] type type of the imported array
-/// \param[in] mapper An object with a `get_manager` method to map a device type to a memory manager
-/// \return Imported array object
+/// \param[in] mapper An object with a `get_manager` method to map a device type to a
+/// memory manager \return Imported array object
 ARROW_EXPORT
 Result<std::shared_ptr<Array>> ImportDeviceArray(struct ArrowDeviceArray* array,
                                                  std::shared_ptr<DataType> type,
@@ -251,14 +255,15 @@ Result<std::shared_ptr<Array>> ImportDeviceArray(struct ArrowDeviceArray* array,
 ///
 /// \param[in,out] array C data interface struct holding the array data
 /// \param[in,out] type C data interface struct holding the array type
-/// \param[in] mapper An object with a `get_manager` method to map a device type to a memory manager
-/// \return Imported array object
+/// \param[in] mapper An object with a `get_manager` method to map a device type to a
+/// memory manager \return Imported array object
 ARROW_EXPORT
 Result<std::shared_ptr<Array>> ImportDeviceArray(struct ArrowDeviceArray* array,
                                                  struct ArrowSchema* type,
                                                  const DeviceMemoryMgr& mapper);
 
-/// \brief EXPERIMENTAL: Import C++ record batch with buffers on a device from the C data interface.
+/// \brief EXPERIMENTAL: Import C++ record batch with buffers on a device from the C data
+/// interface.
 ///
 /// The ArrowArray struct has its contents moved (as per the C data interface
 /// specification) to a private object held alive by the resulting record batch.
@@ -267,14 +272,15 @@ Result<std::shared_ptr<Array>> ImportDeviceArray(struct ArrowDeviceArray* array,
 ///
 /// \param[in,out] array C data interface struct holding the record batch data
 /// \param[in] schema schema of the imported record batch
-/// \param[in] mapper An object with a `get_manager` method to map a device type to a memory manager
-/// \return Imported record batch object
+/// \param[in] mapper An object with a `get_manager` method to map a device type to a
+/// memory manager \return Imported record batch object
 ARROW_EXPORT
-Result<std::shared_ptr<RecordBatch>> ImportDeviceRecordBatch(struct ArrowArray* array,
-                                                             std::shared_ptr<Schema> schema,
-                                                             const DeviceMemoryMgr& mapper);
+Result<std::shared_ptr<RecordBatch>> ImportDeviceRecordBatch(
+    struct ArrowArray* array, std::shared_ptr<Schema> schema,
+    const DeviceMemoryMgr& mapper);
 
-/// \brief EXPERIMENTAL: Import C++ record batch with buffers on a device and its schema from the C data interface.
+/// \brief EXPERIMENTAL: Import C++ record batch with buffers on a device and its schema
+/// from the C data interface.
 ///
 /// The type represented by the ArrowSchema struct must be a struct type array.
 /// The ArrowArray struct has its contents moved (as per the C data interface
@@ -285,13 +291,11 @@ Result<std::shared_ptr<RecordBatch>> ImportDeviceRecordBatch(struct ArrowArray* 
 ///
 /// \param[in,out] array C data interface struct holding the record batch data
 /// \param[in,out] schema C data interface struct holding the record batch schema
-/// \param[in] mapper An object with a `get_manager` method to map a device type to a memory manager
-/// \return Imported record batch object
+/// \param[in] mapper An object with a `get_manager` method to map a device type to a
+/// memory manager \return Imported record batch object
 ARROW_EXPORT
-Result<std::shared_ptr<RecordBatch>> ImportDeviceRecordBatch(struct ArrowArray* array,
-                                                             struct ArrowSchema* schema,
-                                                             const DeviceMemoryMgr& mapper);
-
+Result<std::shared_ptr<RecordBatch>> ImportDeviceRecordBatch(
+    struct ArrowArray* array, struct ArrowSchema* schema, const DeviceMemoryMgr& mapper);
 
 /// @}
 

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -191,9 +191,9 @@ using ReleaseEventFunc = void (*)(void*);
 ///
 /// \param[in] array Array object to export
 /// \param[in] sync_event A pointer to an event-like object if necessary for
-/// synchronization, otherwise null. 
-/// \param[in] sync_release Function pointer to release the sync event 
-/// \param[out] out C struct to export the array to 
+/// synchronization, otherwise null.
+/// \param[in] sync_release Function pointer to release the sync event
+/// \param[out] out C struct to export the array to
 /// \param[out] out_schema optional C struct to export the array type to
 ARROW_EXPORT
 Status ExportDeviceArray(const Array& array, void* sync_event,

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -187,13 +187,14 @@ using ReleaseEventFunc = void (*)(void*);
 /// will be returned.
 ///
 /// If a non-null sync_event is provided, then the sync_release func must also be
-/// non-null. If the sync_event is null, then the sync_release parameter is ignored.
+/// non-null. If the sync_event is null, then the sync_release parameter is not called.
 ///
 /// \param[in] array Array object to export
 /// \param[in] sync_event A pointer to an event-like object if necessary for
-/// synchronization, otherwise null. \param[in] sync_release Function pointer to release
-/// the sync event \param[out] out C struct to export the array to \param[out] out_schema
-/// optional C struct to export the array type to
+/// synchronization, otherwise null. 
+/// \param[in] sync_release Function pointer to release the sync event 
+/// \param[out] out C struct to export the array to 
+/// \param[out] out_schema optional C struct to export the array type to
 ARROW_EXPORT
 Status ExportDeviceArray(const Array& array, void* sync_event,
                          ReleaseEventFunc sync_release, struct ArrowDeviceArray* out,

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -166,6 +166,135 @@ Result<std::shared_ptr<RecordBatch>> ImportRecordBatch(struct ArrowArray* array,
 
 /// @}
 
+/// \defgroup c-data-device-interface Functions for working with the C data device interface.
+///
+/// @{
+
+/// \brief EXPERIMENTAL: Type for freeing a sync event
+///
+/// If synchronization is necessary for accessing the data on a device,
+/// a pointer to an event needs to be passed when exporting the device 
+/// array. It's the responsibility of the release function for the array
+/// to release the event.
+using ReleaseEventFunc = void (*)(void*);
+
+/// \brief EXPERIMENTAL: Export C++ Array as an ArrowDeviceArray.
+///
+/// The resulting ArrowDeviceArray struct keeps the array data and buffers alive
+/// until its release callback is called by the consumer. All buffers in
+/// the provided array MUST have the same device_type, otherwise an error
+/// will be returned.
+///
+/// If a non-null sync_event is provided, then the sync_release func must also be
+/// non-null. If the sync_event is null, then the sync_release parameter is ignored.
+///
+/// \param[in] array Array object to export
+/// \param[in] sync_event A pointer to an event-like object if necessary for synchronization, otherwise null.
+/// \param[in] sync_release Function pointer to release the sync event
+/// \param[out] out C struct to export the array to
+/// \param[out] out_schema optional C struct to export the array type to
+ARROW_EXPORT
+Status ExportDeviceArray(const Array& array, void* sync_event, ReleaseEventFunc sync_release,
+                         struct ArrowDeviceArray* out, struct ArrowSchema* out_schema = NULLPTR);
+
+/// \brief EXPERIMENTAL: Export C++ RecordBatch as an ArrowDeviceArray.
+///
+/// The record batch is exported as if it were a struct array.
+/// The resulting ArrowDeviceArray struct keeps the record batch data and buffers alive
+/// until its release callback is called by the consumer.
+///
+/// All buffers of all columns in the record batch must have the same device_type
+/// otherwise an error will be returned. If columns are on different devices,
+/// they should be exported using different ArrowDeviceArray instances.
+///
+/// If a non-null sync_event is provided, then the sync_release func must also be
+/// non-null. If the sync_event is null, then the sync_release parameter is ignored.
+///
+/// \param[in] batch Record batch to export
+/// \param[in] sync_event A pointer to an event-like object if necessary for synchronization, otherwise null.
+/// \param[in] sync_release Function pointer to release the sync event
+/// \param[out] out C struct where to export the record batch
+/// \param[out] out_schema optional C struct where to export the record batch schema
+ARROW_EXPORT
+Status ExportDeviceRecordBatch(const RecordBatch& batch, void* sync_event, ReleaseEventFunc sync_release,
+                               struct ArrowDeviceArray* out, struct ArrowSchema* out_schema = NULLPTR);
+
+
+class ARROW_EXPORT DeviceMemoryMgr {
+ public:
+  virtual ~DeviceMemoryMgr() = default;
+
+  virtual Result<std::shared_ptr<MemoryManager>> get_manager(ArrowDeviceType device_type, int64_t device_id) const = 0;
+};
+
+/// \brief EXPERIMENTAL: Import C++ device array from the C data interface.
+///
+/// The ArrowArray struct has its contents moved (as per the C data interface
+/// specification) to a private object held alive by the resulting array. The
+/// buffers of the Array are located on the device indicated by the device_type.
+///
+/// \param[in,out] array C data interface struct holding the array data
+/// \param[in] type type of the imported array
+/// \param[in] mapper An object with a `get_manager` method to map a device type to a memory manager
+/// \return Imported array object
+ARROW_EXPORT
+Result<std::shared_ptr<Array>> ImportDeviceArray(struct ArrowDeviceArray* array,
+                                                 std::shared_ptr<DataType> type,
+                                                 const DeviceMemoryMgr& mapper);
+
+/// \brief EXPERIMENTAL: Import C++ device array and its type from the C data interface.
+///
+/// The ArrowArray struct has its contents moved (as per the C data interface
+/// specification) to a private object held alive by the resulting array.
+/// The ArrowSchema struct is released, even if this function fails. The
+/// buffers of the Array are located on the device indicated by the device_type.
+///
+/// \param[in,out] array C data interface struct holding the array data
+/// \param[in,out] type C data interface struct holding the array type
+/// \param[in] mapper An object with a `get_manager` method to map a device type to a memory manager
+/// \return Imported array object
+ARROW_EXPORT
+Result<std::shared_ptr<Array>> ImportDeviceArray(struct ArrowDeviceArray* array,
+                                                 struct ArrowSchema* type,
+                                                 const DeviceMemoryMgr& mapper);
+
+/// \brief EXPERIMENTAL: Import C++ record batch with buffers on a device from the C data interface.
+///
+/// The ArrowArray struct has its contents moved (as per the C data interface
+/// specification) to a private object held alive by the resulting record batch.
+/// The buffers of all columns of the record batch are located on the device
+/// indicated by the device type.
+///
+/// \param[in,out] array C data interface struct holding the record batch data
+/// \param[in] schema schema of the imported record batch
+/// \param[in] mapper An object with a `get_manager` method to map a device type to a memory manager
+/// \return Imported record batch object
+ARROW_EXPORT
+Result<std::shared_ptr<RecordBatch>> ImportDeviceRecordBatch(struct ArrowArray* array,
+                                                             std::shared_ptr<Schema> schema,
+                                                             const DeviceMemoryMgr& mapper);
+
+/// \brief EXPERIMENTAL: Import C++ record batch with buffers on a device and its schema from the C data interface.
+///
+/// The type represented by the ArrowSchema struct must be a struct type array.
+/// The ArrowArray struct has its contents moved (as per the C data interface
+/// specification) to a private object held alive by the resulting record batch.
+/// The ArrowSchema struct is released, even if this function fails. The buffers
+/// of all columns of the record batch are located on the device indicated by the
+/// device type.
+///
+/// \param[in,out] array C data interface struct holding the record batch data
+/// \param[in,out] schema C data interface struct holding the record batch schema
+/// \param[in] mapper An object with a `get_manager` method to map a device type to a memory manager
+/// \return Imported record batch object
+ARROW_EXPORT
+Result<std::shared_ptr<RecordBatch>> ImportDeviceRecordBatch(struct ArrowArray* array,
+                                                             struct ArrowSchema* schema,
+                                                             const DeviceMemoryMgr& mapper);
+
+
+/// @}
+
 /// \defgroup c-stream-interface Functions for working with the C data interface.
 ///
 /// @{

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -1180,7 +1180,7 @@ class MyDevice : public Device {
   const char* type_name() const override { return kMyDeviceTypeName; }
   std::string ToString() const override { return kMyDeviceTypeName; }
   bool Equals(const Device& other) const override {
-    if (other.type_name() != kMyDeviceTypeName) {
+    if (other.type_name() != kMyDeviceTypeName || other.device_type() != device_type()) {
       return false;
     }
     return checked_cast<const MyDevice&>(other).value_ == value_;

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -1486,6 +1486,7 @@ TEST_F(TestDeviceArrayExport, ExportRecordBatch) {
     auto batch = batch_factory();
 
     ASSERT_OK(ExportDeviceRecordBatch(*batch, {nullptr, nullptr}, &c_array, &c_schema));
+    SchemaExportGuard schema_guard(&c_schema);
     ArrayExportGuard array_guard(&c_array.array);
     RecordBatchExportChecker checker{};
     checker(&c_array, *batch, kMyDeviceType, 1, nullptr);

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -565,6 +565,15 @@ struct ArrayExportChecker {
       ASSERT_EQ(c_export->children, nullptr);
     }
   }
+
+  void operator()(struct ArrowDeviceArray* c_export, const ArrayData& expected_data,
+                  const ArrowDeviceType device_type, const int64_t device_id,
+                  const void* sync_event) {
+    ASSERT_EQ(c_export->device_type, device_type);
+    ASSERT_EQ(c_export->device_id, device_id);
+    ASSERT_EQ(c_export->sync_event, sync_event);
+    this->operator()(&c_export->array, expected_data);
+  }
 };
 
 struct RecordBatchExportChecker {
@@ -592,6 +601,15 @@ struct RecordBatchExportChecker {
       ASSERT_EQ(c_export->children, nullptr);
     }
   }
+
+   void operator()(struct ArrowDeviceArray* c_export, const RecordBatch& expected_data,
+                  const ArrowDeviceType device_type, const int64_t device_id,
+                  const void* sync_event) {
+    ASSERT_EQ(c_export->device_type, device_type);
+    ASSERT_EQ(c_export->device_id, device_id);
+    ASSERT_EQ(c_export->sync_event, sync_event);
+    this->operator()(&c_export->array, expected_data);
+  }
 };
 
 class TestArrayExport : public ::testing::Test {
@@ -601,7 +619,7 @@ class TestArrayExport : public ::testing::Test {
   static std::function<Result<std::shared_ptr<Array>>()> JSONArrayFactory(
       std::shared_ptr<DataType> type, const char* json) {
     return [=]() { return ArrayFromJSON(type, json); };
-  }
+  }  
 
   template <typename ArrayFactory, typename ExportCheckFunc>
   void TestWithArrayFactory(ArrayFactory&& factory, ExportCheckFunc&& check_func) {
@@ -1109,6 +1127,379 @@ TEST_F(TestArrayExport, ExportRecordBatch) {
     // Create batch anew, with the same buffer pointers
     batch = batch_factory();
     checker(&c_array, *batch);
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////
+// Device Array Export Tests
+
+static const char kMyDeviceTypeName[] = "arrowtest::MyDevice";
+static const ArrowDeviceType kMyDeviceType = ARROW_DEVICE_EXT_DEV;
+
+class MyBuffer final : public MutableBuffer {
+ public:
+  using MutableBuffer::MutableBuffer;
+
+  ~MyBuffer() {
+    default_memory_pool()->Free(const_cast<uint8_t*>(data_), size_);
+  }
+};
+
+class MyMemoryManager : public CPUMemoryManager {
+ public:
+  explicit MyMemoryManager(const std::shared_ptr<Device>& device)
+    : CPUMemoryManager(device, default_memory_pool()) {}  
+  
+  Result<std::unique_ptr<Buffer>> AllocateBuffer(int64_t size) override {
+    uint8_t* data;
+    RETURN_NOT_OK(pool_->Allocate(size, &data));
+    return std::make_unique<MyBuffer>(data, size, shared_from_this());
+  }
+
+ protected:
+  Result<std::shared_ptr<Buffer>> CopyBufferFrom(
+    const std::shared_ptr<Buffer>& buf, const std::shared_ptr<MemoryManager>& from) override {
+      return CopyNonOwnedFrom(*buf, from);
+  }
+  Result<std::unique_ptr<Buffer>> CopyNonOwnedFrom(
+    const Buffer& buf, const std::shared_ptr<MemoryManager>& from) override {
+    if (!from->is_cpu()) {
+      return nullptr;
+    }
+
+    ARROW_ASSIGN_OR_RAISE(auto dest, AllocateBuffer(buf.size()));
+    if (buf.size() > 0) {
+      memcpy(dest->mutable_data(), buf.data(), static_cast<size_t>(buf.size()));
+    }
+    return std::move(dest);
+  }
+};
+
+class MyDevice : public Device {
+ public:
+  explicit MyDevice(int value) : Device(true), value_(value) {}
+  const char* type_name() const override { return kMyDeviceTypeName; }
+  std::string ToString() const override { return kMyDeviceTypeName; }
+  bool Equals(const Device& other) const override {
+    if (other.type_name() != kMyDeviceTypeName) {
+      return false;
+    }
+    return checked_cast<const MyDevice&>(other).value_ == value_;
+  }
+  DeviceAllocationType device_type() const override { 
+    return static_cast<DeviceAllocationType>(kMyDeviceType); }
+  int64_t device_id() const { return value_; }
+  std::shared_ptr<MemoryManager> default_memory_manager() override {
+    return std::make_shared<MyMemoryManager>(shared_from_this());
+  }
+
+ protected:
+  int value_;
+};
+
+class TestDeviceArrayExport : public ::testing::Test {
+ public:
+  void SetUp() override {    
+    pool_ = default_memory_pool(); 
+  }
+
+  static Result<std::shared_ptr<ArrayData>> ToDeviceData(const std::shared_ptr<MemoryManager>& mm, const ArrayData& data) {
+    arrow::BufferVector buffers;
+    for (const auto& buf : data.buffers) {
+      if (buf) {
+        ARROW_ASSIGN_OR_RAISE(auto dest, mm->CopyBuffer(buf, mm));
+        buffers.push_back(dest);
+      } else {
+        buffers.push_back(nullptr);
+      }
+    }
+
+    arrow::ArrayDataVector children;
+    for (const auto& child :  data.child_data) {
+      ARROW_ASSIGN_OR_RAISE(auto dest, ToDeviceData(mm, *child));
+      children.push_back(dest);
+    }
+
+    return ArrayData::Make(data.type, data.length, buffers, children, data.null_count, data.offset);
+  }
+
+  static Result<std::shared_ptr<Array>> ToDevice(const std::shared_ptr<MemoryManager>& mm, const ArrayData& data) {
+    ARROW_ASSIGN_OR_RAISE(auto result, ToDeviceData(mm, data));
+    return MakeArray(result);
+  }
+
+  template <typename ArrayFactory>
+  static std::function<Result<std::shared_ptr<Array>>()> ToDeviceFactory(const std::shared_ptr<MemoryManager>& mm, ArrayFactory&& factory) {
+    return [&]() { return ToDevice(mm, *factory()->data()); };
+  }
+
+  static std::function<Result<std::shared_ptr<Array>>()> JSONArrayFactory(
+    const std::shared_ptr<MemoryManager>& mm, std::shared_ptr<DataType> type, const char* json) {
+      return [=]() { return ToDevice(mm, *ArrayFromJSON(type, json)->data()); };
+  }
+
+  template <typename ArrayFactory, typename ExportCheckFunc>
+  void TestWithArrayFactory(ArrayFactory&& factory, ExportCheckFunc&& check_func) {
+    auto orig_bytes = pool_->bytes_allocated();
+
+    std::shared_ptr<Array> arr;
+    ASSERT_OK_AND_ASSIGN(arr, ToResult(factory()));
+    ARROW_SCOPED_TRACE("type = ", arr->type()->ToString(),
+                       ", array data = ", arr->ToString());
+    const ArrayData& data = *arr->data();  // non-owning reference
+    struct ArrowDeviceArray c_export;
+    ASSERT_OK(ExportDeviceArray(*arr, {nullptr, nullptr}, &c_export));
+
+    ArrayExportGuard guard(&c_export.array);
+    auto new_bytes = pool_->bytes_allocated();
+    ASSERT_GT(new_bytes, orig_bytes);
+
+    // Release the shared_ptr<Array>, underlying data should be held alive
+    arr.reset();
+    ASSERT_EQ(pool_->bytes_allocated(), new_bytes);
+    check_func(&c_export, data, kMyDeviceType, 1, nullptr);
+
+    // Release the ArrowArray, underlying data should be destroyed
+    guard.Release();
+    ASSERT_EQ(pool_->bytes_allocated(), orig_bytes);
+  }
+
+
+  template <typename ArrayFactory>
+  void TestNested(ArrayFactory&& factory) {
+    ArrayExportChecker checker;
+    TestWithArrayFactory(std::forward<ArrayFactory>(factory), checker);
+  }
+
+  void TestNested(const std::shared_ptr<MemoryManager>& mm, const std::shared_ptr<DataType>& type, const char* json) {
+    TestNested(JSONArrayFactory(mm, type, json));
+  }
+
+  template <typename ArrayFactory>
+  void TestPrimitive(ArrayFactory&& factory) {
+    TestNested(std::forward<ArrayFactory>(factory));
+  }
+
+  void TestPrimitive(const std::shared_ptr<MemoryManager>& mm, const std::shared_ptr<DataType>& type, const char* json) {
+    TestNested(mm, type, json);
+  }  
+
+ protected:
+  MemoryPool* pool_;
+};
+
+TEST_F(TestDeviceArrayExport, Primitive) {
+  std::shared_ptr<Device> device = std::make_shared<MyDevice>(1);
+  auto mm = device->default_memory_manager();
+
+  TestPrimitive(mm, int8(), "[1, 2, null, -3]");
+  TestPrimitive(mm, int16(), "[1, 2, -3]");
+  TestPrimitive(mm, int32(), "[1, 2, null, -3]");
+  TestPrimitive(mm, int64(), "[1, 2, -3]");
+  TestPrimitive(mm, uint8(), "[1, 2, 3]");
+  TestPrimitive(mm, uint16(), "[1, 2, null, 3]");
+  TestPrimitive(mm, uint32(), "[1, 2, 3]");
+  TestPrimitive(mm, uint64(), "[1, 2, null, 3]");
+
+  TestPrimitive(mm, boolean(), "[true, false, null]");
+
+  TestPrimitive(mm, float32(), "[1.5, null]");
+  TestPrimitive(mm, float64(), "[1.5, null]");
+
+  TestPrimitive(mm, fixed_size_binary(3), R"(["foo", "bar", null])");
+  TestPrimitive(mm, binary(), R"(["foo", "bar", null])");
+  TestPrimitive(mm, large_binary(), R"(["foo", "bar", null])");
+  TestPrimitive(mm, utf8(), R"(["foo", "bar", null])");
+  TestPrimitive(mm, large_utf8(), R"(["foo", "bar", null])");
+
+  TestPrimitive(mm, decimal(16, 4), R"(["1234.5670", null])");
+  TestPrimitive(mm, decimal256(16, 4), R"(["1234.5670", null])");
+
+  TestPrimitive(mm, month_day_nano_interval(), R"([[-1, 5, 20], null])");
+}
+
+TEST_F(TestDeviceArrayExport, PrimitiveSliced) {
+  std::shared_ptr<Device> device = std::make_shared<MyDevice>(1);
+  auto mm = device->default_memory_manager();
+
+  auto factory = [=]() { return (*ToDevice(mm, *ArrayFromJSON(int16(), "[1, 2, null, -3]")->data()))->Slice(1, 2); };
+  TestPrimitive(factory);  
+}
+
+
+TEST_F(TestDeviceArrayExport, Temporal) {
+  std::shared_ptr<Device> device = std::make_shared<MyDevice>(1);
+  auto mm = device->default_memory_manager();
+
+  const char* json = "[1, 2, null, 42]";
+  TestPrimitive(mm, date32(), json);
+  TestPrimitive(mm, date64(), json);
+  TestPrimitive(mm, time32(TimeUnit::SECOND), json);
+  TestPrimitive(mm, time32(TimeUnit::MILLI), json);
+  TestPrimitive(mm, time64(TimeUnit::MICRO), json);
+  TestPrimitive(mm, time64(TimeUnit::NANO), json);
+  TestPrimitive(mm, duration(TimeUnit::SECOND), json);
+  TestPrimitive(mm, duration(TimeUnit::MILLI), json);
+  TestPrimitive(mm, duration(TimeUnit::MICRO), json);
+  TestPrimitive(mm, duration(TimeUnit::NANO), json);
+  TestPrimitive(mm, month_interval(), json);
+
+  TestPrimitive(mm, day_time_interval(), "[[7, 600], null]");
+
+  json = R"(["1970-01-01","2000-02-29","1900-02-28"])";
+  TestPrimitive(mm, timestamp(TimeUnit::SECOND), json);
+  TestPrimitive(mm, timestamp(TimeUnit::SECOND, "Europe/Paris"), json);
+  TestPrimitive(mm, timestamp(TimeUnit::MILLI), json);
+  TestPrimitive(mm, timestamp(TimeUnit::MILLI, "Europe/Paris"), json);
+  TestPrimitive(mm, timestamp(TimeUnit::MICRO), json);
+  TestPrimitive(mm, timestamp(TimeUnit::MICRO, "Europe/Paris"), json);
+  TestPrimitive(mm, timestamp(TimeUnit::NANO), json);
+  TestPrimitive(mm, timestamp(TimeUnit::NANO, "Europe/Paris"), json);
+}
+
+TEST_F(TestDeviceArrayExport, List) {
+  std::shared_ptr<Device> device = std::make_shared<MyDevice>(1);
+  auto mm = device->default_memory_manager();
+
+  TestNested(mm, list(int8()), "[[1, 2], [3, null], null]");
+  TestNested(mm, large_list(uint16()), "[[1, 2], [3, null], null]");
+  TestNested(mm, fixed_size_list(int64(), 2), "[[1, 2], [3, null], null]");
+
+  TestNested(mm, list(large_list(int32())), "[[[1, 2], [3], null], null]");
+}
+
+TEST_F(TestDeviceArrayExport, ListSliced) {
+  std::shared_ptr<Device> device = std::make_shared<MyDevice>(1);
+  auto mm = device->default_memory_manager();
+
+  {
+    auto factory = [=]() {
+      return (*ToDevice(mm, *ArrayFromJSON(list(int8()), "[[1, 2], [3, null], [4, 5, 6], null]")->data()))
+          ->Slice(1, 2);
+    };
+    TestNested(factory);
+  }
+  {
+    auto factory = [=]() {
+      auto values = (*ToDevice(mm, *ArrayFromJSON(int16(), "[1, 2, 3, 4, null, 5, 6, 7, 8]")->data()))->Slice(1, 6);
+      auto offsets = (*ToDevice(mm, *ArrayFromJSON(int32(), "[0, 2, 3, 5, 6]")->data()))->Slice(2, 4);
+      return ListArray::FromArrays(*offsets, *values);
+    };
+    TestNested(factory);
+  }
+}
+
+
+TEST_F(TestDeviceArrayExport, Struct) {
+  std::shared_ptr<Device> device = std::make_shared<MyDevice>(1);
+  auto mm = device->default_memory_manager();
+
+  const char* data = R"([[1, "foo"], [2, null]])";
+  auto type = struct_({field("a", int8()), field("b", utf8())});
+  TestNested(mm, type, data);
+}
+
+TEST_F(TestDeviceArrayExport, Map) {
+  std::shared_ptr<Device> device = std::make_shared<MyDevice>(1);
+  auto mm = device->default_memory_manager();
+
+  const char* json = R"([[[1, "foo"], [2, null]], [[3, "bar"]]])";
+  TestNested(mm, map(int8(), utf8()), json);
+  TestNested(mm, map(int8(), utf8(), /*keys_sorted=*/true), json);
+}
+
+TEST_F(TestDeviceArrayExport, Union) {
+  std::shared_ptr<Device> device = std::make_shared<MyDevice>(1);
+  auto mm = device->default_memory_manager();
+
+  const char* data = "[null, [42, 1], [43, true], [42, null], [42, 2]]";
+  // Dense
+  auto field_a = field("a", int8());
+  auto field_b = field("b", boolean(), /*nullable=*/false);
+  auto type = dense_union({field_a, field_b}, {42, 43});
+  TestNested(mm, type, data);
+  // Sparse
+  field_a = field("a", int8(), /*nullable=*/false);
+  field_b = field("b", boolean());
+  type = sparse_union({field_a, field_b}, {42, 43});
+  TestNested(mm, type, data);
+}
+
+TEST_F(TestDeviceArrayExport, Extension) {
+  std::shared_ptr<Device> device = std::make_shared<MyDevice>(1);
+  auto mm = device->default_memory_manager();
+
+  TestPrimitive(ToDeviceFactory(mm, ExampleUuid));
+  TestPrimitive(ToDeviceFactory(mm, ExampleSmallint));
+  TestPrimitive(ToDeviceFactory(mm, ExampleComplex128));
+}
+
+TEST_F(TestDeviceArrayExport, ExportArrayAndType) {
+  std::shared_ptr<Device> device = std::make_shared<MyDevice>(1);
+  auto mm = device->default_memory_manager();
+
+  struct ArrowSchema c_schema {};
+  struct ArrowDeviceArray c_array {};
+  SchemaExportGuard schema_guard(&c_schema);
+  ArrayExportGuard array_guard(&c_array.array);
+
+  auto array = ToDevice(mm, *ArrayFromJSON(int8(), "[1, 2, 3]")->data()).ValueOrDie();
+  ASSERT_OK(ExportDeviceArray(*array, {nullptr, nullptr}, &c_array, &c_schema));
+  const ArrayData& data = *array->data();
+  array.reset();
+  ASSERT_FALSE(ArrowSchemaIsReleased(&c_schema));
+  ASSERT_FALSE(ArrowArrayIsReleased(&c_array.array));
+  ASSERT_EQ(c_schema.format, std::string("c"));
+  ASSERT_EQ(c_schema.n_children, 0);
+  ArrayExportChecker checker{};
+  checker(&c_array, data, kMyDeviceType, 1, nullptr);  
+}
+
+TEST_F(TestDeviceArrayExport, ExportRecordBatch) {
+  std::shared_ptr<Device> device = std::make_shared<MyDevice>(1);
+  auto mm = device->default_memory_manager();
+
+  struct ArrowSchema c_schema {};
+  struct ArrowDeviceArray c_array {};
+
+  auto schema = ::arrow::schema(
+    {field("ints", int16()), field("bools", boolean(), /*nullable=*/false)});
+  schema = schema->WithMetadata(key_value_metadata(kMetadataKeys2, kMetadataValues2));
+  auto arr0 = ToDevice(mm, *ArrayFromJSON(int16(), "[1, 2, null]")->data()).ValueOrDie();
+  auto arr1 = ToDevice(mm, *ArrayFromJSON(boolean(), "[false, true, false]")->data()).ValueOrDie();
+
+  auto batch_factory = [&]() { return RecordBatch::Make(schema, 3, {arr0, arr1}); };
+
+  {
+    auto batch = batch_factory();
+    
+    ASSERT_OK(ExportDeviceRecordBatch(*batch, {nullptr, nullptr}, &c_array, &c_schema));
+    ArrayExportGuard array_guard(&c_array.array);
+    RecordBatchExportChecker checker{};
+    checker(&c_array, *batch, kMyDeviceType, 1, nullptr);
+
+    // create batch anew, with the same buffer pointers
+    batch = batch_factory();
+    checker(&c_array, *batch, kMyDeviceType, 1, nullptr);
+  }
+  {
+    // Check one can export both schema and record batch at once
+    auto batch = batch_factory();
+
+    ASSERT_OK(ExportDeviceRecordBatch(*batch, {nullptr, nullptr}, &c_array, &c_schema));
+    SchemaExportGuard schema_guard(&c_schema);
+    ArrayExportGuard array_guard(&c_array.array);
+    ASSERT_EQ(c_schema.format, std::string("+s"));
+    ASSERT_EQ(c_schema.n_children, 2);
+    ASSERT_NE(c_schema.metadata, nullptr);
+    ASSERT_EQ(kEncodedMetadata2,
+              std::string(c_schema.metadata, kEncodedMetadata2.size()));
+    RecordBatchExportChecker checker{};
+    checker(&c_array, *batch, kMyDeviceType, 1, nullptr);
+
+    // Create batch anew, with the same buffer pointers
+    batch = batch_factory();
+    checker(&c_array, *batch, kMyDeviceType, 1, nullptr);
   }
 }
 

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -1188,7 +1188,7 @@ class MyDevice : public Device {
   DeviceAllocationType device_type() const override {
     return static_cast<DeviceAllocationType>(kMyDeviceType);
   }
-  int64_t device_id() const { return value_; }
+  int64_t device_id() const override { return value_; }
   std::shared_ptr<MemoryManager> default_memory_manager() override {
     return std::make_shared<MyMemoryManager>(shared_from_this());
   }

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -78,8 +78,8 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
 
   /// \brief A device ID to identify this device if there are multiple of this type.
   ///
-  /// If there is no "device_id" equivalent (such as for the main CPU device)
-  /// returns -1.
+  /// If there is no "device_id" equivalent (such as for the main CPU device on 
+  /// non-numa systems) returns -1.
   virtual int64_t device_id() const { return -1; }
 
   /// \brief Whether this device is the main CPU device.

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -78,7 +78,7 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
 
   /// \brief A device ID to identify this device if there are multiple of this type.
   ///
-  /// If there is no "device_id" equivalent (such as for the main CPU device on 
+  /// If there is no "device_id" equivalent (such as for the main CPU device on
   /// non-numa systems) returns -1.
   virtual int64_t device_id() const { return -1; }
 

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -30,7 +30,7 @@
 namespace arrow {
 
 /// \brief EXPERIMENTAL: Device type enum which matches up with C Data Device types
-enum class DeviceType : char {  
+enum class DeviceAllocationType : char {  
   kCPU = 1,
   kCUDA = 2,
   kCUDA_HOST = 3,
@@ -95,8 +95,8 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
   /// MemoryManager instances with non-default parameters.
   virtual std::shared_ptr<MemoryManager> default_memory_manager() = 0;
 
-  /// \brief Return the DeviceType of this device
-  virtual DeviceType device_type() const = 0;
+  /// \brief Return the DeviceAllocationType of this device
+  virtual DeviceAllocationType device_type() const = 0;
 
  protected:
   ARROW_DISALLOW_COPY_AND_ASSIGN(Device);
@@ -199,7 +199,7 @@ class ARROW_EXPORT CPUDevice : public Device {
   const char* type_name() const override;
   std::string ToString() const override;
   bool Equals(const Device&) const override;
-  DeviceType device_type() const override { return DeviceType::kCPU; }
+  DeviceAllocationType device_type() const override { return DeviceAllocationType::kCPU; }
 
   std::shared_ptr<MemoryManager> default_memory_manager() override;
 

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -30,7 +30,7 @@
 namespace arrow {
 
 /// \brief EXPERIMENTAL: Device type enum which matches up with C Data Device types
-enum class DeviceAllocationType : char {  
+enum class DeviceAllocationType : char {
   kCPU = 1,
   kCUDA = 2,
   kCUDA_HOST = 3,

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -30,22 +30,21 @@
 namespace arrow {
 
 /// \brief EXPERIMENTAL: Device type enum which matches up with C Data Device types
-enum class DeviceType : char {
-  UNKNOWN = 0,
-  CPU = 1,
-  CUDA = 2,
-  CUDA_HOST = 3,
-  OPENCL = 4,
-  VULKAN = 7,
-  METAL = 8,
-  VPI = 9,
-  ROCM = 10,
-  ROCM_HOST = 11,
-  EXT_DEV = 12,
-  CUDA_MANAGED = 13,
-  ONEAPI = 14,
-  WEBGPU = 15,
-  HEXAGON = 16,
+enum class DeviceType : char {  
+  kCPU = 1,
+  kCUDA = 2,
+  kCUDA_HOST = 3,
+  kOPENCL = 4,
+  kVULKAN = 7,
+  kMETAL = 8,
+  kVPI = 9,
+  kROCM = 10,
+  kROCM_HOST = 11,
+  kEXT_DEV = 12,
+  kCUDA_MANAGED = 13,
+  kONEAPI = 14,
+  kWEBGPU = 15,
+  kHEXAGON = 16,
 };
 
 class MemoryManager;
@@ -200,7 +199,7 @@ class ARROW_EXPORT CPUDevice : public Device {
   const char* type_name() const override;
   std::string ToString() const override;
   bool Equals(const Device&) const override;
-  DeviceType device_type() const override { return DeviceType::CPU; }
+  DeviceType device_type() const override { return DeviceType::kCPU; }
 
   std::shared_ptr<MemoryManager> default_memory_manager() override;
 

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -29,6 +29,25 @@
 
 namespace arrow {
 
+/// \brief EXPERIMENTAL: Device type enum which matches up with C Data Device types
+enum class DeviceType : char {
+  UNKNOWN = 0,
+  CPU = 1,
+  CUDA = 2,
+  CUDA_HOST = 3,
+  OPENCL = 4,
+  VULKAN = 7,
+  METAL = 8,
+  VPI = 9,
+  ROCM = 10,
+  ROCM_HOST = 11,
+  EXT_DEV = 12,
+  CUDA_MANAGED = 13,
+  ONEAPI = 14,
+  WEBGPU = 15,
+  HEXAGON = 16,
+};
+
 class MemoryManager;
 
 /// \brief EXPERIMENTAL: Abstract interface for hardware devices
@@ -58,6 +77,12 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
   /// \brief Whether this instance points to the same device as another one.
   virtual bool Equals(const Device&) const = 0;
 
+  /// \brief A device ID to identify this device if there are multiple of this type.
+  ///
+  /// If there is no "device_id" equivalent (such as for the main CPU device)
+  /// returns -1.
+  virtual int64_t device_id() const { return -1; }
+
   /// \brief Whether this device is the main CPU device.
   ///
   /// This shorthand method is very useful when deciding whether a memory address
@@ -70,6 +95,9 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
   /// MemoryManager implementation.  Some devices also allow constructing
   /// MemoryManager instances with non-default parameters.
   virtual std::shared_ptr<MemoryManager> default_memory_manager() = 0;
+
+  /// \brief Return the DeviceType of this device
+  virtual DeviceType device_type() const = 0;
 
  protected:
   ARROW_DISALLOW_COPY_AND_ASSIGN(Device);
@@ -172,8 +200,9 @@ class ARROW_EXPORT CPUDevice : public Device {
   const char* type_name() const override;
   std::string ToString() const override;
   bool Equals(const Device&) const override;
+  DeviceType device_type() const override { return DeviceType::CPU; }
 
-  std::shared_ptr<MemoryManager> default_memory_manager() override;
+  std::shared_ptr<MemoryManager> default_memory_manager() override;  
 
   /// \brief Return the global CPUDevice instance
   static std::shared_ptr<Device> Instance();

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -202,7 +202,7 @@ class ARROW_EXPORT CPUDevice : public Device {
   bool Equals(const Device&) const override;
   DeviceType device_type() const override { return DeviceType::CPU; }
 
-  std::shared_ptr<MemoryManager> default_memory_manager() override;  
+  std::shared_ptr<MemoryManager> default_memory_manager() override;
 
   /// \brief Return the global CPUDevice instance
   static std::shared_ptr<Device> Instance();

--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -384,7 +384,8 @@ Result<std::shared_ptr<Buffer>> CudaMemoryManager::ViewBufferTo(
   if (to->is_cpu()) {
     // Device-on-CPU view
     ARROW_ASSIGN_OR_RAISE(auto address, GetHostAddress(buf->address()));
-    return std::make_shared<Buffer>(address, buf->size(), to, buf, DeviceAllocationType::kCUDA_HOST);
+    return std::make_shared<Buffer>(address, buf->size(), to, buf,
+                                    DeviceAllocationType::kCUDA_HOST);
   }
   return nullptr;
 }

--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -384,7 +384,7 @@ Result<std::shared_ptr<Buffer>> CudaMemoryManager::ViewBufferTo(
   if (to->is_cpu()) {
     // Device-on-CPU view
     ARROW_ASSIGN_OR_RAISE(auto address, GetHostAddress(buf->address()));
-    return std::make_shared<Buffer>(address, buf->size(), to, buf, DeviceType::kCUDA_HOST);
+    return std::make_shared<Buffer>(address, buf->size(), to, buf, DeviceAllocationType::kCUDA_HOST);
   }
   return nullptr;
 }

--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -384,7 +384,7 @@ Result<std::shared_ptr<Buffer>> CudaMemoryManager::ViewBufferTo(
   if (to->is_cpu()) {
     // Device-on-CPU view
     ARROW_ASSIGN_OR_RAISE(auto address, GetHostAddress(buf->address()));
-    return std::make_shared<Buffer>(address, buf->size(), to, buf);
+    return std::make_shared<Buffer>(address, buf->size(), to, buf, DeviceType::CUDA_HOST);
   }
   return nullptr;
 }
@@ -521,7 +521,7 @@ Result<std::shared_ptr<CudaContext>> CudaDeviceManager::GetSharedContext(
 Result<std::shared_ptr<CudaHostBuffer>> CudaDeviceManager::AllocateHost(int device_number,
                                                                         int64_t nbytes) {
   uint8_t* data = nullptr;
-  RETURN_NOT_OK(impl_->AllocateHost(device_number, nbytes, &data));
+  RETURN_NOT_OK(impl_->AllocateHost(device_number, nbytes, &data));  
   return std::make_shared<CudaHostBuffer>(data, nbytes);
 }
 

--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -384,7 +384,7 @@ Result<std::shared_ptr<Buffer>> CudaMemoryManager::ViewBufferTo(
   if (to->is_cpu()) {
     // Device-on-CPU view
     ARROW_ASSIGN_OR_RAISE(auto address, GetHostAddress(buf->address()));
-    return std::make_shared<Buffer>(address, buf->size(), to, buf, DeviceType::CUDA_HOST);
+    return std::make_shared<Buffer>(address, buf->size(), to, buf, DeviceType::kCUDA_HOST);
   }
   return nullptr;
 }

--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -521,7 +521,7 @@ Result<std::shared_ptr<CudaContext>> CudaDeviceManager::GetSharedContext(
 Result<std::shared_ptr<CudaHostBuffer>> CudaDeviceManager::AllocateHost(int device_number,
                                                                         int64_t nbytes) {
   uint8_t* data = nullptr;
-  RETURN_NOT_OK(impl_->AllocateHost(device_number, nbytes, &data));  
+  RETURN_NOT_OK(impl_->AllocateHost(device_number, nbytes, &data));
   return std::make_shared<CudaHostBuffer>(data, nbytes);
 }
 

--- a/cpp/src/arrow/gpu/cuda_context.h
+++ b/cpp/src/arrow/gpu/cuda_context.h
@@ -92,7 +92,9 @@ class ARROW_EXPORT CudaDevice : public Device {
   std::string ToString() const override;
   bool Equals(const Device&) const override;
   std::shared_ptr<MemoryManager> default_memory_manager() override;
-  DeviceAllocationType device_type() const override { return DeviceAllocationType::kCUDA; }
+  DeviceAllocationType device_type() const override {
+    return DeviceAllocationType::kCUDA;
+  }
   int64_t device_id() const override { return device_number(); }
 
   /// \brief Return a CudaDevice instance for a particular device

--- a/cpp/src/arrow/gpu/cuda_context.h
+++ b/cpp/src/arrow/gpu/cuda_context.h
@@ -92,7 +92,7 @@ class ARROW_EXPORT CudaDevice : public Device {
   std::string ToString() const override;
   bool Equals(const Device&) const override;
   std::shared_ptr<MemoryManager> default_memory_manager() override;
-  DeviceType device_type() const override { return DeviceType::kCUDA; }
+  DeviceAllocationType device_type() const override { return DeviceAllocationType::kCUDA; }
   int64_t device_id() const override { return device_number(); }
 
   /// \brief Return a CudaDevice instance for a particular device

--- a/cpp/src/arrow/gpu/cuda_context.h
+++ b/cpp/src/arrow/gpu/cuda_context.h
@@ -92,7 +92,7 @@ class ARROW_EXPORT CudaDevice : public Device {
   std::string ToString() const override;
   bool Equals(const Device&) const override;
   std::shared_ptr<MemoryManager> default_memory_manager() override;
-  DeviceType device_type() const override { return DeviceType::CUDA; }
+  DeviceType device_type() const override { return DeviceType::kCUDA; }
   int64_t device_id() const override { return device_number(); }
 
   /// \brief Return a CudaDevice instance for a particular device

--- a/cpp/src/arrow/gpu/cuda_context.h
+++ b/cpp/src/arrow/gpu/cuda_context.h
@@ -92,6 +92,8 @@ class ARROW_EXPORT CudaDevice : public Device {
   std::string ToString() const override;
   bool Equals(const Device&) const override;
   std::shared_ptr<MemoryManager> default_memory_manager() override;
+  DeviceType device_type() const override { return DeviceType::CUDA; }
+  int64_t device_id() const override { return device_number(); }
 
   /// \brief Return a CudaDevice instance for a particular device
   /// \param[in] device_number the CUDA device number

--- a/cpp/src/arrow/gpu/cuda_memory.cc
+++ b/cpp/src/arrow/gpu/cuda_memory.cc
@@ -488,17 +488,16 @@ Result<uint8_t*> GetHostAddress(uintptr_t device_ptr) {
 Result<std::shared_ptr<MemoryManager>> DefaultMemoryMapper(ArrowDeviceType device_type,
                                                            int64_t device_id) {
   switch (device_type) {
-  case ARROW_DEVICE_CPU:
-    return default_cpu_memory_manager();
-  case ARROW_DEVICE_CUDA:
-  case ARROW_DEVICE_CUDA_HOST:
-  case ARROW_DEVICE_CUDA_MANAGED:
-    {
+    case ARROW_DEVICE_CPU:
+      return default_cpu_memory_manager();
+    case ARROW_DEVICE_CUDA:
+    case ARROW_DEVICE_CUDA_HOST:
+    case ARROW_DEVICE_CUDA_MANAGED: {
       ARROW_ASSIGN_OR_RAISE(auto device, arrow::cuda::CudaDevice::Make(device_id));
       return device->default_memory_manager();
     }
-  default:
-    return Status::NotImplemented("memory manager not implemented for device");
+    default:
+      return Status::NotImplemented("memory manager not implemented for device");
   }
 }
 

--- a/cpp/src/arrow/gpu/cuda_memory.cc
+++ b/cpp/src/arrow/gpu/cuda_memory.cc
@@ -200,7 +200,7 @@ Result<std::shared_ptr<CudaIpcMemHandle>> CudaBuffer::ExportForIpc() {
 
 CudaHostBuffer::CudaHostBuffer(uint8_t* data, const int64_t size)
     : MutableBuffer(data, size) {
-  device_type_ = DeviceType::kCUDA_HOST;
+  device_type_ = DeviceAllocationType::kCUDA_HOST;
 }
 
 CudaHostBuffer::~CudaHostBuffer() {

--- a/cpp/src/arrow/gpu/cuda_memory.cc
+++ b/cpp/src/arrow/gpu/cuda_memory.cc
@@ -199,8 +199,8 @@ Result<std::shared_ptr<CudaIpcMemHandle>> CudaBuffer::ExportForIpc() {
 }
 
 CudaHostBuffer::CudaHostBuffer(uint8_t* data, const int64_t size)
-  : MutableBuffer(data, size) {        
-    device_type_ = DeviceType::CUDA_HOST;
+    : MutableBuffer(data, size) {
+  device_type_ = DeviceType::CUDA_HOST;
 }
 
 CudaHostBuffer::~CudaHostBuffer() {

--- a/cpp/src/arrow/gpu/cuda_memory.cc
+++ b/cpp/src/arrow/gpu/cuda_memory.cc
@@ -200,7 +200,7 @@ Result<std::shared_ptr<CudaIpcMemHandle>> CudaBuffer::ExportForIpc() {
 
 CudaHostBuffer::CudaHostBuffer(uint8_t* data, const int64_t size)
     : MutableBuffer(data, size) {
-  device_type_ = DeviceType::CUDA_HOST;
+  device_type_ = DeviceType::kCUDA_HOST;
 }
 
 CudaHostBuffer::~CudaHostBuffer() {
@@ -483,6 +483,23 @@ Result<uint8_t*> GetHostAddress(uintptr_t device_ptr) {
       "cuPointerGetAttribute",
       cuPointerGetAttribute(&ptr, CU_POINTER_ATTRIBUTE_HOST_POINTER, device_ptr));
   return static_cast<uint8_t*>(ptr);
+}
+
+Result<std::shared_ptr<MemoryManager>> DefaultMemoryMapper(ArrowDeviceType device_type,
+                                                           int64_t device_id) {
+  switch (device_type) {
+  case ARROW_DEVICE_CPU:
+    return default_cpu_memory_manager();
+  case ARROW_DEVICE_CUDA:
+  case ARROW_DEVICE_CUDA_HOST:
+  case ARROW_DEVICE_CUDA_MANAGED:
+    {
+      ARROW_ASSIGN_OR_RAISE(auto device, arrow::cuda::CudaDevice::Make(device_id));
+      return device->default_memory_manager();
+    }
+  default:
+    return Status::NotImplemented("memory manager not implemented for device");
+  }
 }
 
 }  // namespace cuda

--- a/cpp/src/arrow/gpu/cuda_memory.cc
+++ b/cpp/src/arrow/gpu/cuda_memory.cc
@@ -198,6 +198,11 @@ Result<std::shared_ptr<CudaIpcMemHandle>> CudaBuffer::ExportForIpc() {
   return handle;
 }
 
+CudaHostBuffer::CudaHostBuffer(uint8_t* data, const int64_t size)
+  : MutableBuffer(data, size) {        
+    device_type_ = DeviceType::CUDA_HOST;
+}
+
 CudaHostBuffer::~CudaHostBuffer() {
   auto maybe_manager = CudaDeviceManager::Instance();
   ARROW_CHECK_OK(maybe_manager.status());

--- a/cpp/src/arrow/gpu/cuda_memory.h
+++ b/cpp/src/arrow/gpu/cuda_memory.h
@@ -111,7 +111,7 @@ class ARROW_EXPORT CudaBuffer : public Buffer {
 class ARROW_EXPORT CudaHostBuffer : public MutableBuffer {
  public:
   CudaHostBuffer(uint8_t* data, const int64_t size);
-  
+
   ~CudaHostBuffer();
 
   /// \brief Return a device address the GPU can read this memory from.

--- a/cpp/src/arrow/gpu/cuda_memory.h
+++ b/cpp/src/arrow/gpu/cuda_memory.h
@@ -21,6 +21,7 @@
 #include <memory>
 
 #include "arrow/buffer.h"
+#include "arrow/c/abi.h"
 #include "arrow/io/concurrency.h"
 #include "arrow/type_fwd.h"
 
@@ -258,6 +259,10 @@ Result<uintptr_t> GetDeviceAddress(const uint8_t* cpu_data,
 /// Low-level: get a CPU address through which the device data be accessed.
 ARROW_EXPORT
 Result<uint8_t*> GetHostAddress(uintptr_t device_ptr);
+
+ARROW_EXPORT
+Result<std::shared_ptr<MemoryManager>> DefaultMemoryMapper(ArrowDeviceType device_type,
+                                                           int64_t device_id);
 
 }  // namespace cuda
 }  // namespace arrow

--- a/cpp/src/arrow/gpu/cuda_memory.h
+++ b/cpp/src/arrow/gpu/cuda_memory.h
@@ -110,7 +110,8 @@ class ARROW_EXPORT CudaBuffer : public Buffer {
 /// \brief Device-accessible CPU memory created using cudaHostAlloc
 class ARROW_EXPORT CudaHostBuffer : public MutableBuffer {
  public:
-  using MutableBuffer::MutableBuffer;
+  CudaHostBuffer(uint8_t* data, const int64_t size);
+  
   ~CudaHostBuffer();
 
   /// \brief Return a device address the GPU can read this memory from.

--- a/cpp/src/arrow/gpu/cuda_test.cc
+++ b/cpp/src/arrow/gpu/cuda_test.cc
@@ -364,7 +364,7 @@ TEST_F(TestCudaHostBuffer, AllocateGlobal) {
 
   ASSERT_TRUE(host_buffer->is_cpu());
   ASSERT_EQ(host_buffer->memory_manager(), cpu_mm_);
-  ASSERT_EQ(host_buffer->device_type(), DeviceType::kCUDA_HOST);
+  ASSERT_EQ(host_buffer->device_type(), DeviceAllocationType::kCUDA_HOST);
 
   ASSERT_OK_AND_ASSIGN(auto device_address, host_buffer->GetDeviceAddress(context_));
   ASSERT_NE(device_address, 0);
@@ -377,7 +377,7 @@ TEST_F(TestCudaHostBuffer, ViewOnDevice) {
 
   ASSERT_TRUE(host_buffer->is_cpu());
   ASSERT_EQ(host_buffer->memory_manager(), cpu_mm_);
-  ASSERT_EQ(host_buffer->device_type(), DeviceType::kCUDA_HOST);
+  ASSERT_EQ(host_buffer->device_type(), DeviceAllocationType::kCUDA_HOST);
 
   // Try to view the host buffer on the device.  This should correspond to
   // GetDeviceAddress() in the previous test.
@@ -387,7 +387,7 @@ TEST_F(TestCudaHostBuffer, ViewOnDevice) {
   ASSERT_NE(device_buffer->address(), 0);
   ASSERT_EQ(device_buffer->size(), host_buffer->size());
   ASSERT_EQ(device_buffer->parent(), host_buffer);
-  ASSERT_EQ(device_buffer->device_type(), DeviceType::kCUDA);
+  ASSERT_EQ(device_buffer->device_type(), DeviceAllocationType::kCUDA);
 
   // View back the device buffer on the CPU.  This should roundtrip.
   ASSERT_OK_AND_ASSIGN(auto buffer, Buffer::View(device_buffer, cpu_mm_));
@@ -396,7 +396,7 @@ TEST_F(TestCudaHostBuffer, ViewOnDevice) {
   ASSERT_EQ(buffer->address(), host_buffer->address());
   ASSERT_EQ(buffer->size(), host_buffer->size());
   ASSERT_EQ(buffer->parent(), device_buffer);
-  ASSERT_EQ(buffer->device_type(), DeviceType::kCUDA_HOST);
+  ASSERT_EQ(buffer->device_type(), DeviceAllocationType::kCUDA_HOST);
 }
 
 // ------------------------------------------------------------------------

--- a/cpp/src/arrow/gpu/cuda_test.cc
+++ b/cpp/src/arrow/gpu/cuda_test.cc
@@ -364,6 +364,7 @@ TEST_F(TestCudaHostBuffer, AllocateGlobal) {
 
   ASSERT_TRUE(host_buffer->is_cpu());
   ASSERT_EQ(host_buffer->memory_manager(), cpu_mm_);
+  ASSERT_EQ(host_buffer->device_type(), DeviceType::CUDA_HOST);
 
   ASSERT_OK_AND_ASSIGN(auto device_address, host_buffer->GetDeviceAddress(context_));
   ASSERT_NE(device_address, 0);
@@ -376,6 +377,7 @@ TEST_F(TestCudaHostBuffer, ViewOnDevice) {
 
   ASSERT_TRUE(host_buffer->is_cpu());
   ASSERT_EQ(host_buffer->memory_manager(), cpu_mm_);
+  ASSERT_EQ(host_buffer->device_type(), DeviceType::CUDA_HOST);
 
   // Try to view the host buffer on the device.  This should correspond to
   // GetDeviceAddress() in the previous test.
@@ -385,6 +387,7 @@ TEST_F(TestCudaHostBuffer, ViewOnDevice) {
   ASSERT_NE(device_buffer->address(), 0);
   ASSERT_EQ(device_buffer->size(), host_buffer->size());
   ASSERT_EQ(device_buffer->parent(), host_buffer);
+  ASSERT_EQ(device_buffer->device_type(), DeviceType::CUDA);
 
   // View back the device buffer on the CPU.  This should roundtrip.
   ASSERT_OK_AND_ASSIGN(auto buffer, Buffer::View(device_buffer, cpu_mm_));
@@ -393,6 +396,7 @@ TEST_F(TestCudaHostBuffer, ViewOnDevice) {
   ASSERT_EQ(buffer->address(), host_buffer->address());
   ASSERT_EQ(buffer->size(), host_buffer->size());
   ASSERT_EQ(buffer->parent(), device_buffer);
+  ASSERT_EQ(buffer->device_type(), DeviceType::CUDA_HOST);
 }
 
 // ------------------------------------------------------------------------

--- a/cpp/src/arrow/gpu/cuda_test.cc
+++ b/cpp/src/arrow/gpu/cuda_test.cc
@@ -364,7 +364,7 @@ TEST_F(TestCudaHostBuffer, AllocateGlobal) {
 
   ASSERT_TRUE(host_buffer->is_cpu());
   ASSERT_EQ(host_buffer->memory_manager(), cpu_mm_);
-  ASSERT_EQ(host_buffer->device_type(), DeviceType::CUDA_HOST);
+  ASSERT_EQ(host_buffer->device_type(), DeviceType::kCUDA_HOST);
 
   ASSERT_OK_AND_ASSIGN(auto device_address, host_buffer->GetDeviceAddress(context_));
   ASSERT_NE(device_address, 0);
@@ -377,7 +377,7 @@ TEST_F(TestCudaHostBuffer, ViewOnDevice) {
 
   ASSERT_TRUE(host_buffer->is_cpu());
   ASSERT_EQ(host_buffer->memory_manager(), cpu_mm_);
-  ASSERT_EQ(host_buffer->device_type(), DeviceType::CUDA_HOST);
+  ASSERT_EQ(host_buffer->device_type(), DeviceType::kCUDA_HOST);
 
   // Try to view the host buffer on the device.  This should correspond to
   // GetDeviceAddress() in the previous test.
@@ -387,7 +387,7 @@ TEST_F(TestCudaHostBuffer, ViewOnDevice) {
   ASSERT_NE(device_buffer->address(), 0);
   ASSERT_EQ(device_buffer->size(), host_buffer->size());
   ASSERT_EQ(device_buffer->parent(), host_buffer);
-  ASSERT_EQ(device_buffer->device_type(), DeviceType::CUDA);
+  ASSERT_EQ(device_buffer->device_type(), DeviceType::kCUDA);
 
   // View back the device buffer on the CPU.  This should roundtrip.
   ASSERT_OK_AND_ASSIGN(auto buffer, Buffer::View(device_buffer, cpu_mm_));
@@ -396,7 +396,7 @@ TEST_F(TestCudaHostBuffer, ViewOnDevice) {
   ASSERT_EQ(buffer->address(), host_buffer->address());
   ASSERT_EQ(buffer->size(), host_buffer->size());
   ASSERT_EQ(buffer->parent(), device_buffer);
-  ASSERT_EQ(buffer->device_type(), DeviceType::CUDA_HOST);
+  ASSERT_EQ(buffer->device_type(), DeviceType::kCUDA_HOST);
 }
 
 // ------------------------------------------------------------------------


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
With the addition of the `ArrowDeviceArray` we should provide import/export functions just like we have for `ArrowArray`.


### What changes are included in this PR?
Adding Import/Export functions to the `bridge.h/.cc` files for C Data Non-CPU data.

This requires adding a device type to buffers and memory managers to propagate through. 

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
Yes.

(Still need to add tests to `bridge_test.cc` but I wanted to get eyes on this first)

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #36488