### PR TITLE
[Abandoned] [Java] Spark integration failure due to Netty version

### DIFF
--- a/java/memory/memory-netty/src/main/java/io/netty/buffer/PooledByteBufAllocatorL.java
+++ b/java/memory/memory-netty/src/main/java/io/netty/buffer/PooledByteBufAllocatorL.java
@@ -161,8 +161,7 @@ public class PooledByteBufAllocatorL {
     }
 
     private UnsafeDirectLittleEndian newDirectBufferL(int initialCapacity, int maxCapacity) {
-      PoolArenasCache cache = threadCache();
-      PoolArena<ByteBuffer> directArena = cache.directArena;
+      PoolArena<ByteBuffer> directArena = threadCache().directArena;
 
       if (directArena != null) {
 
@@ -178,7 +177,7 @@ public class PooledByteBufAllocatorL {
               hugeBufferSize);
         } else {
           // within chunk, use arena.
-          ByteBuf buf = directArena.allocate(cache, initialCapacity, maxCapacity);
+          ByteBuf buf = directArena.allocate(threadCache(), initialCapacity, maxCapacity);
           if (!(buf instanceof PooledUnsafeDirectByteBuf)) {
             fail();
           }


### PR DESCRIPTION
### Rationale for this change

Fix broken CI with Spark due to Arrow upgrading Netty to v4.1.94.

### Are these changes tested?

Unit tests pass, but need to run integration tests (via GHA).

### Are there any user-facing changes?

No
