### PR TITLE
MINOR: [CI] Use GITHUB_PATH instead of GITHUB_ACTIONS to detect environment

### DIFF
--- a/ci/scripts/install_sccache.sh
+++ b/ci/scripts/install_sccache.sh
@@ -61,7 +61,7 @@ fi
 tar -xzvf $SCCACHE_ARCHIVE --strip-component=1 --directory $PREFIX --exclude="sccache*/*E*E*"
 chmod u+x $PREFIX/sccache
 
-if [ -z "${GITHUB_PATH}" ]; then
+if [ ! -z "${GITHUB_PATH}" ]; then
     echo "$PREFIX" >> $GITHUB_PATH
     # Add executable for windows as mingw workaround.
     echo "SCCACHE_PATH=$PREFIX/sccache.exe" >> $GITHUB_ENV

--- a/ci/scripts/install_sccache.sh
+++ b/ci/scripts/install_sccache.sh
@@ -61,7 +61,7 @@ fi
 tar -xzvf $SCCACHE_ARCHIVE --strip-component=1 --directory $PREFIX --exclude="sccache*/*E*E*"
 chmod u+x $PREFIX/sccache
 
-if [ "${GITHUB_ACTIONS}" = "true" ]; then
+if [ -z "${GITHUB_PATH}" ]; then
     echo "$PREFIX" >> $GITHUB_PATH
     # Add executable for windows as mingw workaround.
     echo "SCCACHE_PATH=$PREFIX/sccache.exe" >> $GITHUB_ENV

--- a/ci/scripts/install_sccache.sh
+++ b/ci/scripts/install_sccache.sh
@@ -61,7 +61,7 @@ fi
 tar -xzvf $SCCACHE_ARCHIVE --strip-component=1 --directory $PREFIX --exclude="sccache*/*E*E*"
 chmod u+x $PREFIX/sccache
 
-if [ ! -z "${GITHUB_PATH}" ]; then
+if [ -n "${GITHUB_PATH}" ]; then
     echo "$PREFIX" >> $GITHUB_PATH
     # Add executable for windows as mingw workaround.
     echo "SCCACHE_PATH=$PREFIX/sccache.exe" >> $GITHUB_ENV


### PR DESCRIPTION
### Rationale for this change

In #35753 we started passing  GITHUB_ACTIONS into the docker containers for better log printing. The sccache script used this var to detect if it was run in gha to add sccache to the path. This now causes false positives.

### What changes are included in this PR?

Use GITHUB_PATH directly instead.

### Are these changes tested?
Will trigger crossbow jobs