### PR TITLE
GH-35623: [C++][Python] FixedShapeTensorType.ToString() should print the type's parameters

### DIFF
--- a/cpp/src/arrow/extension/fixed_shape_tensor.cc
+++ b/cpp/src/arrow/extension/fixed_shape_tensor.cc
@@ -107,8 +107,7 @@ bool FixedShapeTensorType::ExtensionEquals(const ExtensionType& other) const {
 std::string FixedShapeTensorType::ToString() const {
   std::stringstream ss;
   ss << "extension<" << this->extension_name()
-     << "[value_type=" << value_type_->ToString()
-     << ", shape=[";
+     << "[value_type=" << value_type_->ToString() << ", shape=[";
   std::string separator;
   for (auto v : shape_) {
     ss << separator << v;

--- a/cpp/src/arrow/extension/fixed_shape_tensor.cc
+++ b/cpp/src/arrow/extension/fixed_shape_tensor.cc
@@ -26,7 +26,9 @@
 #include "arrow/tensor.h"
 #include "arrow/util/int_util_overflow.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/print.h"
 #include "arrow/util/sort.h"
+#include "arrow/util/string.h"
 
 #include <rapidjson/document.h>
 #include <rapidjson/writer.h>
@@ -107,30 +109,16 @@ bool FixedShapeTensorType::ExtensionEquals(const ExtensionType& other) const {
 std::string FixedShapeTensorType::ToString() const {
   std::stringstream ss;
   ss << "extension<" << this->extension_name()
-     << "[value_type=" << value_type_->ToString() << ", shape=[";
-  std::string separator;
-  for (auto v : shape_) {
-    ss << separator << v;
-    separator = ",";
-  }
-  ss << "]";
+     << "[value_type=" << value_type_->ToString() << ", shape="
+     << ::arrow::internal::PrintVector<std::vector<int64_t>, std::string>{shape_, ","};
+
   if (!permutation_.empty()) {
-    ss << ", permutation=[";
-    std::string p_separator;
-    for (auto v : permutation_) {
-      ss << p_separator << v;
-      p_separator = ",";
-    }
-    ss << "]";
+    ss << ", permutation="
+       << ::arrow::internal::PrintVector<std::vector<int64_t>, std::string>{permutation_,
+                                                                            ","};
   }
   if (!dim_names_.empty()) {
-    ss << ", dim_names=[";
-    std::string d_separator;
-    for (std::string v : dim_names_) {
-      ss << d_separator << v;
-      d_separator = ",";
-    }
-    ss << "]";
+    ss << ", dim_names=[" << internal::JoinStrings(dim_names_, ",") << "]";
   }
   ss << "]>";
   return ss.str();

--- a/cpp/src/arrow/extension/fixed_shape_tensor.cc
+++ b/cpp/src/arrow/extension/fixed_shape_tensor.cc
@@ -109,12 +109,11 @@ bool FixedShapeTensorType::ExtensionEquals(const ExtensionType& other) const {
 std::string FixedShapeTensorType::ToString() const {
   std::stringstream ss;
   ss << "extension<" << this->extension_name()
-     << "[value_type=" << value_type_->ToString() << ", shape="
-     << ::arrow::internal::PrintVector{shape_, ","};
+     << "[value_type=" << value_type_->ToString()
+     << ", shape=" << ::arrow::internal::PrintVector{shape_, ","};
 
   if (!permutation_.empty()) {
-    ss << ", permutation="
-       << ::arrow::internal::PrintVector{permutation_, ","};
+    ss << ", permutation=" << ::arrow::internal::PrintVector{permutation_, ","};
   }
   if (!dim_names_.empty()) {
     ss << ", dim_names=[" << internal::JoinStrings(dim_names_, ",") << "]";

--- a/cpp/src/arrow/extension/fixed_shape_tensor.cc
+++ b/cpp/src/arrow/extension/fixed_shape_tensor.cc
@@ -104,6 +104,39 @@ bool FixedShapeTensorType::ExtensionEquals(const ExtensionType& other) const {
          permutation_equivalent;
 }
 
+std::string FixedShapeTensorType::ToString() const {
+  std::stringstream ss;
+  ss << "extension<" << this->extension_name()
+     << "[value_type=" << value_type_->ToString()
+     << ", shape=[";
+  std::string separator;
+  for (auto v : shape_) {
+    ss << separator << v;
+    separator = ",";
+  }
+  ss << "]";
+  if (!permutation_.empty()) {
+    ss << ", permutation=[";
+    std::string p_separator;
+    for (auto v : permutation_) {
+      ss << p_separator << v;
+      p_separator = ",";
+    }
+    ss << "]";
+  }
+  if (!dim_names_.empty()) {
+    ss << ", dim_names=[";
+    std::string d_separator;
+    for (std::string v : dim_names_) {
+      ss << d_separator << v;
+      d_separator = ",";
+    }
+    ss << "]";
+  }
+  ss << "]>";
+  return ss.str();
+}
+
 std::string FixedShapeTensorType::Serialize() const {
   rj::Document document;
   document.SetObject();

--- a/cpp/src/arrow/extension/fixed_shape_tensor.cc
+++ b/cpp/src/arrow/extension/fixed_shape_tensor.cc
@@ -110,12 +110,11 @@ std::string FixedShapeTensorType::ToString() const {
   std::stringstream ss;
   ss << "extension<" << this->extension_name()
      << "[value_type=" << value_type_->ToString() << ", shape="
-     << ::arrow::internal::PrintVector<std::vector<int64_t>, std::string>{shape_, ","};
+     << ::arrow::internal::PrintVector{shape_, ","};
 
   if (!permutation_.empty()) {
     ss << ", permutation="
-       << ::arrow::internal::PrintVector<std::vector<int64_t>, std::string>{permutation_,
-                                                                            ","};
+       << ::arrow::internal::PrintVector{permutation_, ","};
   }
   if (!dim_names_.empty()) {
     ss << ", dim_names=[" << internal::JoinStrings(dim_names_, ",") << "]";

--- a/cpp/src/arrow/extension/fixed_shape_tensor.h
+++ b/cpp/src/arrow/extension/fixed_shape_tensor.h
@@ -61,11 +61,7 @@ class ARROW_EXPORT FixedShapeTensorType : public ExtensionType {
         dim_names_(dim_names) {}
 
   std::string extension_name() const override { return "arrow.fixed_shape_tensor"; }
-
-  std::string ToString() const override {
-    return "extension<" + this->extension_name() + "<type: " + value_type_->ToString() +
-           ", " + this->Serialize() + ">>";
-  }
+  std::string ToString() const override;
 
   /// Number of dimensions of tensor elements
   size_t ndim() { return shape_.size(); }

--- a/cpp/src/arrow/extension/fixed_shape_tensor.h
+++ b/cpp/src/arrow/extension/fixed_shape_tensor.h
@@ -62,6 +62,11 @@ class ARROW_EXPORT FixedShapeTensorType : public ExtensionType {
 
   std::string extension_name() const override { return "arrow.fixed_shape_tensor"; }
 
+  std::string ToString() const override {
+    return "extension<" + this->extension_name() + "<type: " + value_type_->ToString() +
+           ", " + this->Serialize() + ">>";
+  }
+
   /// Number of dimensions of tensor elements
   size_t ndim() { return shape_.size(); }
 

--- a/cpp/src/arrow/extension/fixed_shape_tensor_test.cc
+++ b/cpp/src/arrow/extension/fixed_shape_tensor_test.cc
@@ -434,4 +434,32 @@ TEST_F(TestExtensionType, ComputeStrides) {
   ASSERT_EQ(ext_type_7->Serialize(), R"({"shape":[3,4,7],"permutation":[2,0,1]})");
 }
 
+TEST_F(TestExtensionType, ToString) {
+  auto exact_ext_type = internal::checked_pointer_cast<FixedShapeTensorType>(ext_type_);
+
+  auto ext_type_1 = internal::checked_pointer_cast<FixedShapeTensorType>(
+      fixed_shape_tensor(int16(), {3, 4, 7}));
+  auto ext_type_2 = internal::checked_pointer_cast<FixedShapeTensorType>(
+      fixed_shape_tensor(int32(), {3, 4, 7}, {1, 0, 2}));
+  auto ext_type_3 = internal::checked_pointer_cast<FixedShapeTensorType>(
+      fixed_shape_tensor(int64(), {3, 4, 7}, {}, {"C", "H", "W"}));
+
+  std::string result_1 = ext_type_1->ToString();
+  std::string expected_1 =
+      "extension<arrow.fixed_shape_tensor[value_type=int16, shape=[3,4,7]]>";
+  ASSERT_EQ(expected_1, result_1);
+
+  std::string result_2 = ext_type_2->ToString();
+  std::string expected_2 =
+      "extension<arrow.fixed_shape_tensor[value_type=int32, shape=[3,4,7], "
+      "permutation=[1,0,2]]>";
+  ASSERT_EQ(expected_2, result_2);
+
+  std::string result_3 = ext_type_3->ToString();
+  std::string expected_3 =
+      "extension<arrow.fixed_shape_tensor[value_type=int64, shape=[3,4,7], "
+      "dim_names=[C,H,W]]>";
+  ASSERT_EQ(expected_3, result_3);
+}
+
 }  // namespace arrow

--- a/cpp/src/arrow/util/print.h
+++ b/cpp/src/arrow/util/print.h
@@ -71,6 +71,7 @@ struct PrintVector {
     return os;
   }
 };
-
+template <typename Range, typename Separator>
+PrintVector(const Range&, const Separator&) -> PrintVector<Range, Separator>;
 }  // namespace internal
 }  // namespace arrow

--- a/cpp/src/arrow/util/print.h
+++ b/cpp/src/arrow/util/print.h
@@ -18,6 +18,9 @@
 #pragma once
 
 #include <tuple>
+#include "arrow/util/string.h"
+
+using arrow::internal::ToChars;
 
 namespace arrow {
 namespace internal {
@@ -46,6 +49,28 @@ template <typename OStream, typename... Args>
 void PrintTuple(OStream* os, const std::tuple<Args&...>& tup) {
   detail::TuplePrinter<OStream, std::tuple<Args&...>, sizeof...(Args)>::Print(os, tup);
 }
+
+template <typename Range, typename Separator>
+struct PrintVector {
+  const Range& range_;
+  const Separator& separator_;
+
+  template <typename Os>  // template to dodge inclusion of <ostream>
+  friend Os& operator<<(Os& os, PrintVector l) {
+    bool first = true;
+    os << "[";
+    for (const auto& element : l.range_) {
+      if (first) {
+        first = false;
+      } else {
+        os << l.separator_;
+      }
+      os << ToChars(element);  // use ToChars to avoid locale dependence
+    }
+    os << "]";
+    return os;
+  }
+};
 
 }  // namespace internal
 }  // namespace arrow

--- a/docs/source/python/extending_types.rst
+++ b/docs/source/python/extending_types.rst
@@ -419,8 +419,8 @@ Extension arrays can be used as columns in  ``pyarrow.Table`` or
    f0: int8
    f1: string
    f2: bool
-   tensors_int: extension<arrow.fixed_size_tensor>
-   tensors_float: extension<arrow.fixed_size_tensor>
+   tensors_int: extension<arrow.fixed_shape_tensor<type: int32, {"shape":[2,2]}>>
+   tensors_float: extension<arrow.fixed_shape_tensor<type: float, {"shape":[2,2]}>>
    ----
    f0: [[1,2,3]]
    f1: [["foo","bar",null]]

--- a/docs/source/python/extending_types.rst
+++ b/docs/source/python/extending_types.rst
@@ -419,8 +419,8 @@ Extension arrays can be used as columns in  ``pyarrow.Table`` or
    f0: int8
    f1: string
    f2: bool
-   tensors_int: extension<arrow.fixed_shape_tensor<type: int32, {"shape":[2,2]}>>
-   tensors_float: extension<arrow.fixed_shape_tensor<type: float, {"shape":[2,2]}>>
+   tensors_int: extension<arrow.fixed_shape_tensor[value_type=int32, shape=[2,2]]>
+   tensors_float: extension<arrow.fixed_shape_tensor[value_type=float, shape=[2,2]]>
    ----
    f0: [[1,2,3]]
    f1: [["foo","bar",null]]

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1356,15 +1356,15 @@ def test_tensor_type_is_picklable(pickle_module):
 @pytest.mark.parametrize(("tensor_type", "text"), [
     (
         pa.fixed_shape_tensor(pa.int8(), [2, 2, 3]),
-        'fixed_shape_tensor<type: int8, {"shape":[2,2,3]}>'
+        'fixed_shape_tensor[value_type=int8, shape=[2,2,3]]'
     ),
     (
         pa.fixed_shape_tensor(pa.int32(), [2, 2, 3], permutation=[0, 2, 1]),
-        'fixed_shape_tensor<type: int32, {"shape":[2,2,3],"permutation":[0,2,1]}>'
+        'fixed_shape_tensor[value_type=int32, shape=[2,2,3], permutation=[0,2,1]]'
     ),
     (
         pa.fixed_shape_tensor(pa.int64(), [2, 2, 3], dim_names=['C', 'H', 'W']),
-        'fixed_shape_tensor<type: int64, {"shape":[2,2,3],"dim_names":["C","H","W"]}>'
+        'fixed_shape_tensor[value_type=int64, shape=[2,2,3], dim_names=[C,H,W]]'
     )
 ])
 def test_tensor_type_str(tensor_type, text):

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1351,3 +1351,22 @@ def test_tensor_type_is_picklable(pickle_module):
     result = pickle_module.loads(pickle_module.dumps(expected_arr))
 
     assert result == expected_arr
+
+
+@pytest.mark.parametrize(("tensor_type", "text"), [
+    (
+        pa.fixed_shape_tensor(pa.int8(), [2, 2, 3]),
+        'fixed_shape_tensor<type: int8, {"shape":[2,2,3]}>'
+    ),
+    (
+        pa.fixed_shape_tensor(pa.int32(), [2, 2, 3], permutation=[0, 2, 1]),
+        'fixed_shape_tensor<type: int32, {"shape":[2,2,3],"permutation":[0,2,1]}>'
+    ),
+    (
+        pa.fixed_shape_tensor(pa.int64(), [2, 2, 3], dim_names=['C', 'H', 'W']),
+        'fixed_shape_tensor<type: int64, {"shape":[2,2,3],"dim_names":["C","H","W"]}>'
+    )
+])
+def test_tensor_type_str(tensor_type, text):
+    tensor_type_str = tensor_type.__str__()
+    assert text in tensor_type_str

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -1557,7 +1557,7 @@ cdef class FixedShapeTensorType(BaseExtensionType):
 
     >>> import pyarrow as pa
     >>> pa.fixed_shape_tensor(pa.int32(), [2, 2])
-    FixedShapeTensorType(extension<arrow.fixed_shape_tensor<type: int32, {"shape":[2,2]}>>)
+    FixedShapeTensorType(extension<arrow.fixed_shape_tensor[value_type=int32, shape=[2,2]]>)
 
     Create an instance of fixed shape tensor extension type with
     permutation:
@@ -4744,7 +4744,7 @@ def fixed_shape_tensor(DataType value_type, shape, dim_names=None, permutation=N
     >>> import pyarrow as pa
     >>> tensor_type = pa.fixed_shape_tensor(pa.int32(), [2, 2])
     >>> tensor_type
-    FixedShapeTensorType(extension<arrow.fixed_shape_tensor<type: int32, {"shape":[2,2]}>>)
+    FixedShapeTensorType(extension<arrow.fixed_shape_tensor[value_type=int32, shape=[2,2]]>)
 
     Inspect the data type:
 
@@ -4760,7 +4760,7 @@ def fixed_shape_tensor(DataType value_type, shape, dim_names=None, permutation=N
     >>> tensor = pa.ExtensionArray.from_storage(tensor_type, storage)
     >>> pa.table([tensor], names=["tensor_array"])
     pyarrow.Table
-    tensor_array: extension<arrow.fixed_shape_tensor<type: int32, {"shape":[2,2]}>>
+    tensor_array: extension<arrow.fixed_shape_tensor[value_type=int32, shape=[2,2]]>
     ----
     tensor_array: [[[1,2,3,4],[10,20,30,40],[100,200,300,400]]]
 

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -1557,7 +1557,7 @@ cdef class FixedShapeTensorType(BaseExtensionType):
 
     >>> import pyarrow as pa
     >>> pa.fixed_shape_tensor(pa.int32(), [2, 2])
-    FixedShapeTensorType(extension<arrow.fixed_shape_tensor>)
+    FixedShapeTensorType(extension<arrow.fixed_shape_tensor<type: int32, {"shape":[2,2]}>>)
 
     Create an instance of fixed shape tensor extension type with
     permutation:
@@ -4744,7 +4744,7 @@ def fixed_shape_tensor(DataType value_type, shape, dim_names=None, permutation=N
     >>> import pyarrow as pa
     >>> tensor_type = pa.fixed_shape_tensor(pa.int32(), [2, 2])
     >>> tensor_type
-    FixedShapeTensorType(extension<arrow.fixed_shape_tensor>)
+    FixedShapeTensorType(extension<arrow.fixed_shape_tensor<type: int32, {"shape":[2,2]}>>)
 
     Inspect the data type:
 
@@ -4760,7 +4760,7 @@ def fixed_shape_tensor(DataType value_type, shape, dim_names=None, permutation=N
     >>> tensor = pa.ExtensionArray.from_storage(tensor_type, storage)
     >>> pa.table([tensor], names=["tensor_array"])
     pyarrow.Table
-    tensor_array: extension<arrow.fixed_shape_tensor>
+    tensor_array: extension<arrow.fixed_shape_tensor<type: int32, {"shape":[2,2]}>>
     ----
     tensor_array: [[[1,2,3,4],[10,20,30,40],[100,200,300,400]]]
 


### PR DESCRIPTION
### Rationale for this change

The string representation of two different `FixedShapeTensorType` objects is currently the same: `extension<arrow.fixed_shape_tensor>`.

### What changes are included in this PR?

Override general type `ToString()` method for `FixedShapeTensorType`. The string representation of a tensor in this PR is proposed as follows:

``` 
extension<arrow.fixed_shape_tensor[value_type=*, shape=[*]]
```
### Are these changes tested?

Yes, in Python and in C++.

### Are there any user-facing changes?

No.
* Closes: #35623