### PR TITLE
MINOR: [CI][C++] Allow running TSan build on Ubuntu 22.04

### DIFF
--- a/ci/docker/ubuntu-22.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-22.04-cpp.dockerfile
@@ -189,6 +189,7 @@ ENV absl_SOURCE=BUNDLED \
     ARROW_WITH_SNAPPY=ON \
     ARROW_WITH_ZLIB=ON \
     ARROW_WITH_ZSTD=ON \
+    ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-${llvm}/bin/llvm-symbolizer \
     AWSSDK_SOURCE=BUNDLED \
     google_cloud_cpp_storage_SOURCE=BUNDLED \
     GTest_SOURCE=BUNDLED \


### PR DESCRIPTION
We can't switch the Crossbow Thread Sanitizer build to Ubuntu 22.04 for now, as there are errors in Flight.