### PR TITLE
MINOR: [CI][C++] Re-enable optimizations in Valgrind build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -314,7 +314,9 @@ services:
     shm_size: *shm-size
     environment:
       <<: [*common, *ccache, *sccache]
-      ARROW_CXXFLAGS: "-Og"  # Shrink test runtime by enabling minimal optimizations
+      # Shrink test runtime by enabling minimal optimizations
+      ARROW_C_FLAGS_DEBUG: "-g1 -Og"
+      ARROW_CXX_FLAGS_DEBUG: "-g1 -Og"
       ARROW_ENABLE_TIMING_TESTS:  # inherit
       ARROW_FLIGHT: "OFF"
       ARROW_FLIGHT_SQL: "OFF"


### PR DESCRIPTION
ARROW_CXXFLAGS does not take priority anymore, need to pass optimization flags differently.
