### PR TITLE
GH-36498: [Python][CI] Hypothesis nightly test fails with pytz.exceptions.UnknownTimeZoneError: 'Factory'

### DIFF
--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -1070,7 +1070,7 @@ class TestConvertDateTimeLikeTypes:
     @h.given(st.none() | past.timezones)
     @h.settings(deadline=None)
     def test_python_datetime_with_pytz_timezone(self, tz):
-        if str(tz) == "build/etc/localtime":
+        if str(tz) in ["build/etc/localtime", "Factory"]:
             pytest.skip("Localtime timezone not supported")
         values = [datetime(2018, 1, 1, 12, 23, 45, tzinfo=tz)]
         df = pd.DataFrame({'datetime': values})


### PR DESCRIPTION
### What changes are included in this PR?

Skip the test if the timezone is `zoneinfo.ZoneInfo(key='Factory')`, because we don't support roundtripping such a timezone.

* Closes: #36498