### PR TITLE
GH-36513: [Dev][C#] Add Dependabot configuration for NuGet

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,9 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "MINOR: [CI] "
+  - package-ecosystem: "nuget"
+    directory: "/csharp/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "MINOR: [C#] "


### PR DESCRIPTION
### Rationale for this change

We don't want to adjust PR titles from Dependabot manually.

### What changes are included in this PR?

Set the commit message prefix for `/csharp/` from Dependabot.
 
### Are these changes tested?

No. I hope that this works well...

### Are there any user-facing changes?

No.
* Closes: #36513