### PR TITLE
GH-36500: [CI][Java][JAR] Remove Homebrew's protobuf

### DIFF
--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -100,6 +100,11 @@ jobs:
           brew uninstall grpc || : # gRPC depends on RE2
           brew uninstall grpc@1.54 || : # gRPC 1.54 may be installed too
           brew uninstall re2
+          # We want to use bundled Protobuf for static linking. If
+          # Homebrew's Protobuf is installed, its library file may be
+          # used on test  We uninstall Homebrew's Protobuf to ensure using
+          # bundled Protobuf.
+          brew uninstall protobuf
 
           brew bundle --file=arrow/java/Brewfile
       - name: Build C++ libraries


### PR DESCRIPTION
### Rationale for this change

If we have Homebrew's protobuf is installed, it may be used on test.

### What changes are included in this PR?

Remove Homebrew's protobuf.

Another solution: Set `DYLD_LIBRARY_PATH`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #36500