### PR TITLE
GH-36501: [CI][Java][JAR] Ensure removing Homebrew's gRPC packages

### DIFF
--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -98,7 +98,8 @@ jobs:
           # Homebrew's RE2 is installed, its header file may be used.
           # We uninstall Homebrew's RE2 to ensure using bundled RE2.
           brew uninstall grpc || : # gRPC depends on RE2
-          brew uninstall re2 || :
+          brew uninstall grpc@1.54 || : # gRPC 1.54 may be installed too
+          brew uninstall re2
 
           brew bundle --file=arrow/java/Brewfile
       - name: Build C++ libraries


### PR DESCRIPTION
### Rationale for this change

Homebrew's RE2 package depends on gRPC. There are multiple gRPC packages in Homebrew. We need to remove all gRPC packages to remove RE2 package.

### What changes are included in this PR?

Remove `grpc@1.54` too.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #36501