### PR TITLE
GH-36518: [Java] Fix ArrowFlightJdbcTimeStampVectorAccessor to return Timestamp objects with date and time that corresponds with local time instead of UTC date and time

### DIFF
--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessor.java
@@ -17,7 +17,6 @@
 
 package org.apache.arrow.driver.jdbc.accessor.impl.calendar;
 
-import static java.util.Objects.nonNull;
 import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcTimeStampVectorGetter.Getter;
 import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcTimeStampVectorGetter.Holder;
 import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcTimeStampVectorGetter.createGetter;
@@ -92,9 +91,16 @@ public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAcces
     long value = holder.value;
 
     LocalDateTime localDateTime = this.longToLocalDateTime.fromLong(value);
-    ZoneId defaultTimeZone = TimeZone.getDefault().toZoneId();
-    ZoneId sourceTimeZone = nonNull(this.timeZone) ? this.timeZone.toZoneId() :
-            nonNull(calendar) ? calendar.getTimeZone().toZoneId() : defaultTimeZone;
+    ZoneId defaultTimeZone = Calendar.getInstance().getTimeZone().toZoneId();
+    ZoneId sourceTimeZone;
+
+    if (this.timeZone != null) {
+      sourceTimeZone = this.timeZone.toZoneId();
+    } else if (calendar != null) {
+      sourceTimeZone = calendar.getTimeZone().toZoneId();
+    } else {
+      sourceTimeZone = defaultTimeZone;
+    }
 
     return localDateTime.atZone(sourceTimeZone).withZoneSameInstant(defaultTimeZone).toLocalDateTime();
   }

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessor.java
@@ -45,13 +45,13 @@ public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAcces
   private final TimeZone timeZone;
   private final Getter getter;
   private final TimeUnit timeUnit;
-  private final LongToLocalDateTime longToLocalDateTime;
+  private final LongToUTCDateTime longToUTCDateTime;
   private final Holder holder;
 
   /**
    * Functional interface used to convert a number (in any time resolution) to LocalDateTime.
    */
-  interface LongToLocalDateTime {
+  interface LongToUTCDateTime {
     LocalDateTime fromLong(long value);
   }
 
@@ -67,7 +67,7 @@ public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAcces
 
     this.timeZone = getTimeZoneForVector(vector);
     this.timeUnit = getTimeUnitForVector(vector);
-    this.longToLocalDateTime = getLongToUTCDateTimeForVector(vector);
+    this.longToUTCDateTime = getLongToUTCDateTimeForVector(vector);
   }
 
   @Override
@@ -90,7 +90,7 @@ public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAcces
 
     long value = holder.value;
 
-    LocalDateTime localDateTime = this.longToLocalDateTime.fromLong(value);
+    LocalDateTime localDateTime = this.longToUTCDateTime.fromLong(value);
     ZoneId defaultTimeZone = Calendar.getInstance().getTimeZone().toZoneId();
     ZoneId sourceTimeZone;
 
@@ -153,7 +153,7 @@ public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAcces
     }
   }
 
-  protected static LongToLocalDateTime getLongToUTCDateTimeForVector(TimeStampVector vector) {
+  protected static LongToUTCDateTime getLongToUTCDateTimeForVector(TimeStampVector vector) {
     String timeZoneID = "UTC";
 
     ArrowType.Timestamp arrowType =
@@ -161,14 +161,14 @@ public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAcces
 
     switch (arrowType.getUnit()) {
       case NANOSECOND:
-        return nanoseconds -> DateUtility.getLocalDateTimeFromEpochNano(nanoseconds, timeZoneID);
+        return DateUtility::getLocalDateTimeFromEpochNano;
       case MICROSECOND:
-        return microseconds -> DateUtility.getLocalDateTimeFromEpochMicro(microseconds, timeZoneID);
+        return DateUtility::getLocalDateTimeFromEpochMicro;
       case MILLISECOND:
-        return milliseconds -> DateUtility.getLocalDateTimeFromEpochMilli(milliseconds, timeZoneID);
+        return DateUtility::getLocalDateTimeFromEpochMilli;
       case SECOND:
         return seconds -> DateUtility.getLocalDateTimeFromEpochMilli(
-            TimeUnit.SECONDS.toMillis(seconds), timeZoneID);
+            TimeUnit.SECONDS.toMillis(seconds));
       default:
         throw new UnsupportedOperationException("Invalid Arrow time unit");
     }

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessor.java
@@ -17,6 +17,7 @@
 
 package org.apache.arrow.driver.jdbc.accessor.impl.calendar;
 
+import static java.util.Objects.nonNull;
 import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcTimeStampVectorGetter.Getter;
 import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcTimeStampVectorGetter.Holder;
 import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcTimeStampVectorGetter.createGetter;
@@ -26,7 +27,6 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
@@ -92,13 +92,11 @@ public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAcces
     long value = holder.value;
 
     LocalDateTime localDateTime = this.longToLocalDateTime.fromLong(value);
+    ZoneId defaultTimeZone = TimeZone.getDefault().toZoneId();
+    ZoneId sourceTimeZone = nonNull(this.timeZone) ? this.timeZone.toZoneId() :
+            nonNull(calendar) ? calendar.getTimeZone().toZoneId() : defaultTimeZone;
 
-    ZoneId sourceTimeZone = this.timeZone != null ? this.timeZone.toZoneId() :
-            calendar == null ? TimeZone.getDefault().toZoneId() : calendar.getTimeZone().toZoneId();
-    ZonedDateTime sourceTZDateTime = localDateTime.atZone(sourceTimeZone);
-    localDateTime = sourceTZDateTime.withZoneSameInstant(TimeZone.getDefault().toZoneId()).toLocalDateTime();
-
-    return localDateTime;
+    return localDateTime.atZone(sourceTimeZone).withZoneSameInstant(defaultTimeZone).toLocalDateTime();
   }
 
   @Override

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessor.java
@@ -25,7 +25,8 @@ import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
@@ -67,7 +68,7 @@ public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAcces
 
     this.timeZone = getTimeZoneForVector(vector);
     this.timeUnit = getTimeUnitForVector(vector);
-    this.longToLocalDateTime = getLongToLocalDateTimeForVector(vector, this.timeZone);
+    this.longToLocalDateTime = getLongToUTCDateTimeForVector(vector);
   }
 
   @Override
@@ -92,12 +93,11 @@ public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAcces
 
     LocalDateTime localDateTime = this.longToLocalDateTime.fromLong(value);
 
-    if (calendar != null) {
-      TimeZone timeZone = calendar.getTimeZone();
-      long millis = this.timeUnit.toMillis(value);
-      localDateTime = localDateTime
-          .minus(timeZone.getOffset(millis) - this.timeZone.getOffset(millis), ChronoUnit.MILLIS);
-    }
+    ZoneId sourceTimeZone = this.timeZone != null ? this.timeZone.toZoneId() :
+            calendar == null ? TimeZone.getDefault().toZoneId() : calendar.getTimeZone().toZoneId();
+    ZonedDateTime sourceTZDateTime = localDateTime.atZone(sourceTimeZone);
+    localDateTime = sourceTZDateTime.withZoneSameInstant(TimeZone.getDefault().toZoneId()).toLocalDateTime();
+
     return localDateTime;
   }
 
@@ -149,9 +149,8 @@ public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAcces
     }
   }
 
-  protected static LongToLocalDateTime getLongToLocalDateTimeForVector(TimeStampVector vector,
-                                                                       TimeZone timeZone) {
-    String timeZoneID = timeZone.getID();
+  protected static LongToLocalDateTime getLongToUTCDateTimeForVector(TimeStampVector vector) {
+    String timeZoneID = "UTC";
 
     ArrowType.Timestamp arrowType =
         (ArrowType.Timestamp) vector.getField().getFieldType().getType();
@@ -177,7 +176,7 @@ public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAcces
 
     String timezoneName = arrowType.getTimezone();
     if (timezoneName == null) {
-      return TimeZone.getTimeZone("UTC");
+      return null;
     }
 
     return TimeZone.getTimeZone(timezoneName);

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/DateTimeUtils.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/DateTimeUtils.java
@@ -20,9 +20,11 @@ package org.apache.arrow.driver.jdbc.utils;
 import static org.apache.calcite.avatica.util.DateTimeUtils.MILLIS_PER_DAY;
 
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
@@ -42,15 +44,11 @@ public class DateTimeUtils {
     if (calendar == null) {
       calendar = Calendar.getInstance();
     }
-
-    final TimeZone tz = calendar.getTimeZone();
-    final TimeZone defaultTz = TimeZone.getDefault();
-
-    if (tz != defaultTz) {
-      milliseconds -= tz.getOffset(milliseconds) - defaultTz.getOffset(milliseconds);
-    }
-
-    return milliseconds;
+    Instant currInstant = Instant.ofEpochMilli(milliseconds);
+    LocalDateTime getTimestampWithoutTZ = LocalDateTime.ofInstant(currInstant,
+            TimeZone.getTimeZone("UTC").toZoneId());
+    ZonedDateTime parsedTime = getTimestampWithoutTZ.atZone(calendar.getTimeZone().toZoneId());
+    return parsedTime.toEpochSecond() * 1000;
   }
 
 

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/DateTimeUtils.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/DateTimeUtils.java
@@ -38,7 +38,7 @@ public class DateTimeUtils {
   }
 
   /**
-   * Apply calendar timezone to epoch milliseconds
+   * Apply calendar timezone to epoch milliseconds.
    */
   public static long applyCalendarOffset(long milliseconds, Calendar calendar) {
     if (calendar == null) {

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/DateTimeUtils.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/DateTimeUtils.java
@@ -38,7 +38,7 @@ public class DateTimeUtils {
   }
 
   /**
-   * Subtracts given Calendar's TimeZone offset from epoch milliseconds.
+   * Apply calendar timezone to epoch milliseconds
    */
   public static long applyCalendarOffset(long milliseconds, Calendar calendar) {
     if (calendar == null) {

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
@@ -173,11 +173,13 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
 
   @Test
   public void testShouldGetTimestampReturnValidTimestampWithCalendar() throws Exception {
+    TimeZone.setDefault(TimeZone.getTimeZone("Asia/Hong_Kong"));
+
     TimeZone timeZone = TimeZone.getTimeZone(AMERICA_SAO_PAULO);
     Calendar calendar = Calendar.getInstance(timeZone);
 
     TimeZone finalTimeZoneForResultWithoutCalendar = ofNullable(getTimeZoneForVector(vector))
-            .orElse(TimeZone.getDefault());
+            .orElse(TimeZone.getTimeZone("Asia/Hong_Kong"));
 
     accessorIterator.iterate(vector, (accessor, currentRow) -> {
       final Timestamp resultWithoutCalendar = accessor.getTimestamp(null);
@@ -186,6 +188,7 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
       assertOffsetIsConsistentWithAccessorGetters(timeZone, finalTimeZoneForResultWithoutCalendar, result.getTime(),
               resultWithoutCalendar.getTime(), accessor);
     });
+    TimeZone.setDefault(null);
   }
 
   @Test

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.arrow.driver.jdbc.accessor.impl.calendar;
 
+import static java.util.Optional.ofNullable;
 import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcTimeStampVectorAccessor.getTimeUnitForVector;
 import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcTimeStampVectorAccessor.getTimeZoneForVector;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -175,22 +176,15 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
     TimeZone timeZone = TimeZone.getTimeZone(AMERICA_SAO_PAULO);
     Calendar calendar = Calendar.getInstance(timeZone);
 
-    TimeZone timeZoneForVector = getTimeZoneForVector(vector);
-    timeZoneForVector = timeZoneForVector == null ? TimeZone.getDefault() : timeZoneForVector;
-
-    TimeZone finalTimeZoneForResultWithoutCalendar = timeZoneForVector;
+    TimeZone finalTimeZoneForResultWithoutCalendar = ofNullable(getTimeZoneForVector(vector))
+            .orElse(TimeZone.getDefault());
 
     accessorIterator.iterate(vector, (accessor, currentRow) -> {
       final Timestamp resultWithoutCalendar = accessor.getTimestamp(null);
       final Timestamp result = accessor.getTimestamp(calendar);
-      final TimeZone timeZoneForResult = getTimeZoneForVector(vector) == null ? timeZone :
-              finalTimeZoneForResultWithoutCalendar;
 
-      long offset = timeZoneForResult.getOffset(result.getTime()) -
-              finalTimeZoneForResultWithoutCalendar.getOffset(resultWithoutCalendar.getTime());
-
-      collector.checkThat(resultWithoutCalendar.getTime() - result.getTime(), is(offset));
-      collector.checkThat(accessor.wasNull(), is(false));
+      compareOffset(timeZone, finalTimeZoneForResultWithoutCalendar, result.getTime(), resultWithoutCalendar.getTime(),
+              accessor);
     });
   }
 
@@ -213,23 +207,15 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
     TimeZone timeZone = TimeZone.getTimeZone(AMERICA_SAO_PAULO);
     Calendar calendar = Calendar.getInstance(timeZone);
 
-    TimeZone timeZoneForVector = getTimeZoneForVector(vector);
-    timeZoneForVector = timeZoneForVector == null ? TimeZone.getDefault() : timeZoneForVector;
-
-    TimeZone finalTimeZoneForResultWithoutCalendar = timeZoneForVector;
+    TimeZone finalTimeZoneForResultWithoutCalendar = ofNullable(getTimeZoneForVector(vector))
+            .orElse(TimeZone.getDefault());
 
     accessorIterator.iterate(vector, (accessor, currentRow) -> {
       final Date resultWithoutCalendar = accessor.getDate(null);
       final Date result = accessor.getDate(calendar);
 
-      final TimeZone timeZoneForResult = getTimeZoneForVector(vector) == null ? timeZone :
-              finalTimeZoneForResultWithoutCalendar;
-
-      long offset = timeZoneForResult.getOffset(result.getTime()) -
-              finalTimeZoneForResultWithoutCalendar.getOffset(resultWithoutCalendar.getTime());
-
-      collector.checkThat(resultWithoutCalendar.getTime() - result.getTime(), is(offset));
-      collector.checkThat(accessor.wasNull(), is(false));
+      compareOffset(timeZone, finalTimeZoneForResultWithoutCalendar, result.getTime(), resultWithoutCalendar.getTime(),
+              accessor);
     });
   }
 
@@ -252,23 +238,15 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
     TimeZone timeZone = TimeZone.getTimeZone(AMERICA_SAO_PAULO);
     Calendar calendar = Calendar.getInstance(timeZone);
 
-    TimeZone timeZoneForVector = getTimeZoneForVector(vector);
-    timeZoneForVector = timeZoneForVector == null ? TimeZone.getDefault() : timeZoneForVector;
-
-    TimeZone finalTimeZoneForResultWithoutCalendar = timeZoneForVector;
+    TimeZone finalTimeZoneForResultWithoutCalendar = ofNullable(getTimeZoneForVector(vector))
+            .orElse(TimeZone.getDefault());
 
     accessorIterator.iterate(vector, (accessor, currentRow) -> {
       final Time resultWithoutCalendar = accessor.getTime(null);
       final Time result = accessor.getTime(calendar);
 
-      final TimeZone timeZoneForResult = getTimeZoneForVector(vector) == null ? timeZone :
-              finalTimeZoneForResultWithoutCalendar;
-
-      long offset = timeZoneForResult.getOffset(result.getTime()) -
-              finalTimeZoneForResultWithoutCalendar.getOffset(resultWithoutCalendar.getTime());
-
-      collector.checkThat(resultWithoutCalendar.getTime() - result.getTime(), is(offset));
-      collector.checkThat(accessor.wasNull(), is(false));
+      compareOffset(timeZone, finalTimeZoneForResultWithoutCalendar, result.getTime(), resultWithoutCalendar.getTime(),
+              accessor);
     });
   }
 
@@ -342,5 +320,17 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
         collector.checkThat(accessor.wasNull(), is(false));
       });
     }
+  }
+
+  private void compareOffset(TimeZone timeZone, TimeZone finalTimeZoneForResultWithoutCalendar, long result,
+                             long resultWithoutCalendar, ArrowFlightJdbcTimeStampVectorAccessor accessor) {
+    final TimeZone timeZoneForResult = getTimeZoneForVector(vector) == null ? timeZone :
+            finalTimeZoneForResultWithoutCalendar;
+
+    long offset = timeZoneForResult.getOffset(result) -
+            finalTimeZoneForResultWithoutCalendar.getOffset(resultWithoutCalendar);
+
+    collector.checkThat(resultWithoutCalendar - result, is(offset));
+    collector.checkThat(accessor.wasNull(), is(false));
   }
 }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
@@ -183,8 +183,8 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
       final Timestamp resultWithoutCalendar = accessor.getTimestamp(null);
       final Timestamp result = accessor.getTimestamp(calendar);
 
-      compareOffset(timeZone, finalTimeZoneForResultWithoutCalendar, result.getTime(), resultWithoutCalendar.getTime(),
-              accessor);
+      assertOffsetIsConsistentWithAccessorGetters(timeZone, finalTimeZoneForResultWithoutCalendar, result.getTime(),
+              resultWithoutCalendar.getTime(), accessor);
     });
   }
 
@@ -214,8 +214,8 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
       final Date resultWithoutCalendar = accessor.getDate(null);
       final Date result = accessor.getDate(calendar);
 
-      compareOffset(timeZone, finalTimeZoneForResultWithoutCalendar, result.getTime(), resultWithoutCalendar.getTime(),
-              accessor);
+      assertOffsetIsConsistentWithAccessorGetters(timeZone, finalTimeZoneForResultWithoutCalendar, result.getTime(),
+              resultWithoutCalendar.getTime(), accessor);
     });
   }
 
@@ -245,8 +245,8 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
       final Time resultWithoutCalendar = accessor.getTime(null);
       final Time result = accessor.getTime(calendar);
 
-      compareOffset(timeZone, finalTimeZoneForResultWithoutCalendar, result.getTime(), resultWithoutCalendar.getTime(),
-              accessor);
+      assertOffsetIsConsistentWithAccessorGetters(timeZone, finalTimeZoneForResultWithoutCalendar, result.getTime(),
+              resultWithoutCalendar.getTime(), accessor);
     });
   }
 
@@ -268,11 +268,9 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
       TimeUnit timeUnit = getTimeUnitForVector(vector);
       long millis = timeUnit.toMillis((Long) object);
 
-      Instant currInstant = Instant.ofEpochMilli(millis);
-      LocalDateTime getTimestampWithoutTZ = LocalDateTime.ofInstant(currInstant,
-              TimeZone.getTimeZone("UTC").toZoneId());
-
-      ZonedDateTime sourceTZDateTime = getTimestampWithoutTZ.atZone(TimeZone.getTimeZone(timeZone).toZoneId());
+      ZonedDateTime sourceTZDateTime = LocalDateTime
+              .ofInstant(Instant.ofEpochMilli(millis), TimeZone.getTimeZone("UTC").toZoneId())
+              .atZone(TimeZone.getTimeZone(timeZone).toZoneId());
       expectedTimestamp = new Timestamp(sourceTZDateTime.toEpochSecond() * 1000);
     }
     return expectedTimestamp;
@@ -322,8 +320,10 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
     }
   }
 
-  private void compareOffset(TimeZone timeZone, TimeZone finalTimeZoneForResultWithoutCalendar, long result,
-                             long resultWithoutCalendar, ArrowFlightJdbcTimeStampVectorAccessor accessor) {
+  private void assertOffsetIsConsistentWithAccessorGetters(TimeZone timeZone,
+                                                           TimeZone finalTimeZoneForResultWithoutCalendar, long result,
+                                                           long resultWithoutCalendar,
+                                                           ArrowFlightJdbcTimeStampVectorAccessor accessor) {
     final TimeZone timeZoneForResult = getTimeZoneForVector(vector) == null ? timeZone :
             finalTimeZoneForResultWithoutCalendar;
 

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/DateTimeUtilsTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/DateTimeUtilsTest.java
@@ -67,9 +67,9 @@ public class DateTimeUtilsTest {
     TimeZone.setDefault(alternateTimezone);
 
     try { // Trying to guarantee timezone returns to its original value
-      final long expectedEpochMillis = epochMillis + offset;
+      final long expectedEpochMillis = epochMillis - offset;
       final long actualEpochMillis = DateTimeUtils.applyCalendarOffset(epochMillis, Calendar.getInstance(
-          defaultTimezone));
+              alternateTimezone));
 
       collector.checkThat(actualEpochMillis, is(expectedEpochMillis));
     } finally {


### PR DESCRIPTION
**Rationale for this change**

When calling the getTimestamp method from the ArrowFlightJdbcTimeStampVectorAccessor class, the timezone of the Timestamp object returned is incorrect. The timestamp itself appears to be in GMT/UTC time but the timezone field of the Timestamp object is populated with the timezone of the JDBC client instead.

Example

timestamp on db: 2021-03-28T00:15:00.000 (UTC)

timezone of JDBC client: PST/PDT (Vancouver Time)
Calendar cal <- Calendar with UTC timezone
calling getTimestamp(cal) on a result set will return a timestamp like this: 2021-03-28T00:15:00.000 (PST/PDT)
where 2021-03-28T00:15:00.000 appears to be in UTC time but the timezone of the object itself is PST/PDT


**What changes are included in this PR?**

 - Fixed: Correct behaviour is that the calendar object is used to extend the data into the timezone of the calendar object, essentially asserting that the data is at the timezone defined in the calendar object and returns a time-related object that has local date and time and local timezone
 - Fixed: for vectors that do store timezone information (ie. TimestampVector), the getter methods will use the timezone defined in vector as the timezone assertion and ignores the calendar object if one was passed in
 - Fixed: applyCalendarOffset now correctly creates a corresponding time-related object using the supplied calendar timezone and returns a time-related object that has local date and time and local timezone 

**Are these changes tested?**

Many of the time related tests also face this issue and this fixes them all. Also tested the driver jar in a JDBC client and behaviour is fixed.

**Are there any user-facing changes?**

- No. Closes: https://github.com/apache/arrow/issues/36518


* Closes: #36518