### PR TITLE
GH-36502: [C++] Add run-end encoded array support to ReferencedByteRanges

### DIFF
--- a/cpp/src/arrow/util/byte_size.cc
+++ b/cpp/src/arrow/util/byte_size.cc
@@ -298,13 +298,12 @@ struct GetByteRangesArray {
   Status Visit(const RunEndEncodedType& type) const {
     auto [phys_offset, phys_length] = ree_util::FindPhysicalRange(input, offset, length);
     for (int i = 0; i < type.num_fields(); i++) {
-      GetByteRangesArray child{
-          *input.child_data[i],
-          /*offset=*/input.child_data[i]->offset + phys_offset,
-          /*length=*/phys_length,
-          range_starts,
-          range_offsets,
-          range_lengths};
+      GetByteRangesArray child{*input.child_data[i],
+                               /*offset=*/input.child_data[i]->offset + phys_offset,
+                               /*length=*/phys_length,
+                               range_starts,
+                               range_offsets,
+                               range_lengths};
       RETURN_NOT_OK(VisitTypeInline(*type.field(i)->type(), &child));
     }
     return Status::OK();

--- a/cpp/src/arrow/util/byte_size.cc
+++ b/cpp/src/arrow/util/byte_size.cc
@@ -296,12 +296,12 @@ struct GetByteRangesArray {
   }
 
   Status Visit(const RunEndEncodedType& type) const {
-    auto physical_range = ree_util::FindPhysicalRange(input, offset, length);
+    auto [phys_offset, phys_length] = ree_util::FindPhysicalRange(input, offset, length);
     for (int i = 0; i < type.num_fields(); i++) {
       GetByteRangesArray child{
           *input.child_data[i],
-          /*offset=*/input.child_data[i]->offset + physical_range.first,
-          /*length=*/physical_range.second,
+          /*offset=*/input.child_data[i]->offset + phys_offset,
+          /*length=*/phys_length,
           range_starts,
           range_offsets,
           range_lengths};

--- a/cpp/src/arrow/util/byte_size.cc
+++ b/cpp/src/arrow/util/byte_size.cc
@@ -27,6 +27,7 @@
 #include "arrow/record_batch.h"
 #include "arrow/table.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/ree_util.h"
 #include "arrow/visit_type_inline.h"
 
 namespace arrow {
@@ -291,6 +292,21 @@ struct GetByteRangesArray {
       RETURN_NOT_OK(VisitTypeInline(*type.field(i)->type(), &child));
     }
 
+    return Status::OK();
+  }
+
+  Status Visit(const RunEndEncodedType& type) const {
+    auto physical_range = ree_util::FindPhysicalRange(input, offset, length);
+    for (int i = 0; i < type.num_fields(); i++) {
+      GetByteRangesArray child{
+          *input.child_data[i],
+          /*offset=*/input.child_data[i]->offset + physical_range.first,
+          /*length=*/physical_range.second,
+          range_starts,
+          range_offsets,
+          range_lengths};
+      RETURN_NOT_OK(VisitTypeInline(*type.field(i)->type(), &child));
+    }
     return Status::OK();
   }
 

--- a/cpp/src/arrow/util/ree_util.cc
+++ b/cpp/src/arrow/util/ree_util.cc
@@ -85,6 +85,26 @@ int64_t FindPhysicalLength(const ArraySpan& span) {
   return internal::FindPhysicalLength<int64_t>(span);
 }
 
+std::pair<int64_t, int64_t> FindPhysicalRange(const ArraySpan& span, int64_t offset,
+                                              int64_t length) {
+  auto& run_ends_span = RunEndsArray(span);
+  auto type_id = run_ends_span.type->id();
+  if (type_id == Type::INT16) {
+    auto* run_ends = run_ends_span.GetValues<int16_t>(1);
+    return internal::FindPhysicalRange<int16_t>(run_ends, run_ends_span.length, length,
+                                                offset);
+  }
+  if (type_id == Type::INT32) {
+    auto* run_ends = run_ends_span.GetValues<int32_t>(1);
+    return internal::FindPhysicalRange<int32_t>(run_ends, run_ends_span.length, length,
+                                                offset);
+  }
+  DCHECK_EQ(type_id, Type::INT64);
+  auto* run_ends = run_ends_span.GetValues<int64_t>(1);
+  return internal::FindPhysicalRange<int64_t>(run_ends, run_ends_span.length, length,
+                                              offset);
+}
+
 namespace {
 
 template <typename RunEndCType>

--- a/cpp/src/arrow/util/ree_util.cc
+++ b/cpp/src/arrow/util/ree_util.cc
@@ -87,7 +87,7 @@ int64_t FindPhysicalLength(const ArraySpan& span) {
 
 std::pair<int64_t, int64_t> FindPhysicalRange(const ArraySpan& span, int64_t offset,
                                               int64_t length) {
-  auto& run_ends_span = RunEndsArray(span);
+  const auto& run_ends_span = RunEndsArray(span);
   auto type_id = run_ends_span.type->id();
   if (type_id == Type::INT16) {
     auto* run_ends = run_ends_span.GetValues<int16_t>(1);

--- a/cpp/src/arrow/util/ree_util.h
+++ b/cpp/src/arrow/util/ree_util.h
@@ -102,8 +102,7 @@ std::pair<int64_t, int64_t> FindPhysicalRange(const RunEndCType* run_ends,
 template <typename RunEndCType>
 int64_t FindPhysicalLength(const RunEndCType* run_ends, int64_t run_ends_size,
                            int64_t length, int64_t offset) {
-  int64_t physical_length;
-  std::tie(std::ignore, physical_length) =
+  auto [_, physical_length] =
       FindPhysicalRange<RunEndCType>(run_ends, run_ends_size, length, offset);
   return physical_length;
 }

--- a/cpp/src/arrow/util/ree_util.h
+++ b/cpp/src/arrow/util/ree_util.h
@@ -139,7 +139,8 @@ int64_t FindPhysicalLength(const ArraySpan& span) {
 /// \brief Find the physical index into the values array of the REE ArraySpan
 ///
 /// This function uses binary-search, so it has a O(log N) cost.
-int64_t FindPhysicalIndex(const ArraySpan& span, int64_t i, int64_t absolute_offset);
+ARROW_EXPORT int64_t FindPhysicalIndex(const ArraySpan& span, int64_t i,
+                                       int64_t absolute_offset);
 
 /// \brief Find the physical length of an REE ArraySpan
 ///
@@ -150,14 +151,15 @@ int64_t FindPhysicalIndex(const ArraySpan& span, int64_t i, int64_t absolute_off
 /// Avoid calling this function if the physical length can be estabilished in
 /// some other way (e.g. when iterating over the runs sequentially until the
 /// end). This function uses binary-search, so it has a O(log N) cost.
-int64_t FindPhysicalLength(const ArraySpan& span);
+ARROW_EXPORT int64_t FindPhysicalLength(const ArraySpan& span);
 
 /// \brief Find the physical range of physical values referenced by the REE in
 /// the logical range from offset to offset + length
 ///
 /// \return a pair of physical offset and physical length
-std::pair<int64_t, int64_t> FindPhysicalRange(const ArraySpan& span, int64_t offset,
-                                              int64_t length);
+ARROW_EXPORT std::pair<int64_t, int64_t> FindPhysicalRange(const ArraySpan& span,
+                                                           int64_t offset,
+                                                           int64_t length);
 
 template <typename RunEndCType>
 class RunEndEncodedArraySpan {

--- a/cpp/src/arrow/util/ree_util.h
+++ b/cpp/src/arrow/util/ree_util.h
@@ -76,6 +76,8 @@ int64_t FindPhysicalIndex(const RunEndCType* run_ends, int64_t run_ends_size, in
 /// \brief Uses binary-search to calculate the range of physical values (and
 /// run-ends) necessary to represent the logical range of values from
 /// offset to length
+///
+/// \return a pair of physical offset and physical length
 template <typename RunEndCType>
 std::pair<int64_t, int64_t> FindPhysicalRange(const RunEndCType* run_ends,
                                               int64_t run_ends_size, int64_t length,
@@ -151,6 +153,10 @@ int64_t FindPhysicalIndex(const ArraySpan& span, int64_t i, int64_t absolute_off
 /// end). This function uses binary-search, so it has a O(log N) cost.
 int64_t FindPhysicalLength(const ArraySpan& span);
 
+/// \brief Find the physical range of physical values referenced by the REE in
+/// the logical range from offset to offset + length
+///
+/// \return a pair of physical offset and physical length
 std::pair<int64_t, int64_t> FindPhysicalRange(const ArraySpan& span, int64_t offset,
                                               int64_t length);
 


### PR DESCRIPTION
### Rationale for this change

Fix for #36502.

### What changes are included in this PR?

Fix and C++ tests.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Addition of a new function to the `ree_util` namespace.
* Closes: #36502