### PR TITLE
GH-36456: [CI][R] Unlink system OpenSSL to avoid mixing OpenSSL versions

### DIFF
--- a/dev/tasks/r/github.macos.autobrew.yml
+++ b/dev/tasks/r/github.macos.autobrew.yml
@@ -80,7 +80,7 @@ jobs:
           FORCE_AUTOBREW: true
         {{ macros.github_set_sccache_envvars()|indent(8)}}
         run: |
-          find / -name 'evp.h' || :
+          find / -name 'include/openssl' || :
           arrow/ci/scripts/r_test.sh arrow
       - name: Dump install logs
         run: cat arrow/r/check/arrow.Rcheck/00install.out

--- a/dev/tasks/r/github.macos.autobrew.yml
+++ b/dev/tasks/r/github.macos.autobrew.yml
@@ -39,6 +39,9 @@ jobs:
         run: |
           # minio and sccache are pre-installed on the self-hosted 10.13 runner
           if [ {{ '${{ matrix.platform }}' }} != macos-10.13  ]; then
+            # ensure removing OpenSSL to avoid mixing OpenSSL in the
+            # default path and OpenSSL installed by autobrew
+            brew uninstall openssl || :
             # install minio for tests
             brew install minio
             brew install sccache
@@ -57,7 +60,7 @@ jobs:
           # between pre-installed R version on the self-hosted runners
           rig default {{ '${{ matrix.r-version }}' }}
           rig system setup-user-lib
-          rig system add-pak 
+          rig system add-pak
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           working-directory: 'arrow/r'
@@ -72,7 +75,7 @@ jobs:
           ARROW_USE_PKG_CONFIG: false
           ARROW_R_DEV: true
           FORCE_AUTOBREW: true
-        {{ macros.github_set_sccache_envvars()|indent(8)}}  
+        {{ macros.github_set_sccache_envvars()|indent(8)}}
         run: arrow/ci/scripts/r_test.sh arrow
       - name: Dump install logs
         run: cat arrow/r/check/arrow.Rcheck/00install.out

--- a/dev/tasks/r/github.macos.autobrew.yml
+++ b/dev/tasks/r/github.macos.autobrew.yml
@@ -39,14 +39,17 @@ jobs:
         run: |
           # minio and sccache are pre-installed on the self-hosted 10.13 runner
           if [ {{ '${{ matrix.platform }}' }} != macos-10.13  ]; then
-            # ensure unlinking OpenSSL to avoid mixing OpenSSL in the
-            # default path and OpenSSL installed by autobrew
-            brew unlink openssl || :
-            find / -name 'evp.h'
             # install minio for tests
             brew install minio
             brew install sccache
           fi
+
+          # ensure removing OpenSSL from the default paths to avoid
+          # mixing OpenSSL in the default paths and OpenSSL installed
+          # by autobrew
+          brew unlink openssl || :
+          conda uninstall -y openssl || :
+
           cd arrow/r
           {{ macros.pin_brew_formulae(is_fork)|indent }}
       - uses: r-lib/actions/setup-r@v2

--- a/dev/tasks/r/github.macos.autobrew.yml
+++ b/dev/tasks/r/github.macos.autobrew.yml
@@ -42,6 +42,7 @@ jobs:
             # ensure unlinking OpenSSL to avoid mixing OpenSSL in the
             # default path and OpenSSL installed by autobrew
             brew unlink openssl || :
+            find / -name 'evp.h'
             # install minio for tests
             brew install minio
             brew install sccache

--- a/dev/tasks/r/github.macos.autobrew.yml
+++ b/dev/tasks/r/github.macos.autobrew.yml
@@ -80,7 +80,7 @@ jobs:
           FORCE_AUTOBREW: true
         {{ macros.github_set_sccache_envvars()|indent(8)}}
         run: |
-          find / -name 'include/openssl' || :
+          find / |& grep include/openssl || :
           arrow/ci/scripts/r_test.sh arrow
       - name: Dump install logs
         run: cat arrow/r/check/arrow.Rcheck/00install.out

--- a/dev/tasks/r/github.macos.autobrew.yml
+++ b/dev/tasks/r/github.macos.autobrew.yml
@@ -80,7 +80,7 @@ jobs:
           FORCE_AUTOBREW: true
         {{ macros.github_set_sccache_envvars()|indent(8)}}
         run: |
-          find / |& grep include/openssl || :
+          find / 2>&1 | grep include/openssl || :
           arrow/ci/scripts/r_test.sh arrow
       - name: Dump install logs
         run: cat arrow/r/check/arrow.Rcheck/00install.out

--- a/dev/tasks/r/github.macos.autobrew.yml
+++ b/dev/tasks/r/github.macos.autobrew.yml
@@ -39,9 +39,9 @@ jobs:
         run: |
           # minio and sccache are pre-installed on the self-hosted 10.13 runner
           if [ {{ '${{ matrix.platform }}' }} != macos-10.13  ]; then
-            # ensure removing OpenSSL to avoid mixing OpenSSL in the
+            # ensure unlinking OpenSSL to avoid mixing OpenSSL in the
             # default path and OpenSSL installed by autobrew
-            brew uninstall openssl || :
+            brew unlink openssl || :
             # install minio for tests
             brew install minio
             brew install sccache

--- a/dev/tasks/r/github.macos.autobrew.yml
+++ b/dev/tasks/r/github.macos.autobrew.yml
@@ -35,21 +35,20 @@ jobs:
             - "{{ macros.r_oldrel.ver }}"
     steps:
       {{ macros.github_checkout_arrow()|indent }}
+      - name: Setup hosted
+        if: matrix.platform != 'macos-10.13'
+        run: |
+          # minio and sccache are pre-installed on the self-hosted 10.13 runner.
+          # Install minio for tests.
+          brew install minio
+          brew install sccache
+
+          # Ensure removing OpenSSL from the default paths to avoid
+          # mixing OpenSSL in the default paths and OpenSSL installed
+          # by autobrew.
+          brew unlink openssl || :
       - name: Configure autobrew script
         run: |
-          # minio and sccache are pre-installed on the self-hosted 10.13 runner
-          if [ {{ '${{ matrix.platform }}' }} != macos-10.13  ]; then
-            # install minio for tests
-            brew install minio
-            brew install sccache
-          fi
-
-          # ensure removing OpenSSL from the default paths to avoid
-          # mixing OpenSSL in the default paths and OpenSSL installed
-          # by autobrew
-          brew unlink openssl || :
-          conda uninstall -y openssl || :
-
           cd arrow/r
           {{ macros.pin_brew_formulae(is_fork)|indent }}
       - uses: r-lib/actions/setup-r@v2
@@ -80,7 +79,9 @@ jobs:
           ARROW_R_DEV: true
           FORCE_AUTOBREW: true
         {{ macros.github_set_sccache_envvars()|indent(8)}}
-        run: arrow/ci/scripts/r_test.sh arrow
+        run: |
+          find / -name 'evp.h' || :
+          arrow/ci/scripts/r_test.sh arrow
       - name: Dump install logs
         run: cat arrow/r/check/arrow.Rcheck/00install.out
         if: always()

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -168,9 +168,9 @@ jobs:
           rig system setup-user-lib
           rig system add-pak
 
-          # ensure removing OpenSSL to avoid mixing OpenSSL in the
+          # ensure unlinking OpenSSL to avoid mixing OpenSSL in the
           # default path and OpenSSL installed by autobrew
-          brew uninstall openssl || :
+          brew unlink openssl || :
       {{ macros.github_setup_local_r_repo(false, true)|indent }}
       - name: Prepare Dependency Installation
 

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -186,6 +186,9 @@ jobs:
       - name: Install sccache
         if: startsWith(matrix.platform, 'macos')
         run: brew install sccache
+      - name: Find
+        run: |
+          find / -name 'evp.h' || :
       - name: Build Binary
         id: build
         shell: Rscript {0}

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -167,6 +167,10 @@ jobs:
 
           rig system setup-user-lib
           rig system add-pak
+
+          # ensure removing OpenSSL to avoid mixing OpenSSL in the
+          # default path and OpenSSL installed by autobrew
+          brew uninstall openssl || :
       {{ macros.github_setup_local_r_repo(false, true)|indent }}
       - name: Prepare Dependency Installation
 

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -188,7 +188,7 @@ jobs:
         run: brew install sccache
       - name: Find
         run: |
-          find / -name 'evp.h' || :
+          find / -name 'include/openssl' || :
       - name: Build Binary
         id: build
         shell: Rscript {0}

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -171,6 +171,7 @@ jobs:
           # ensure unlinking OpenSSL to avoid mixing OpenSSL in the
           # default path and OpenSSL installed by autobrew
           brew unlink openssl || :
+          find / -name 'evp.h'
       {{ macros.github_setup_local_r_repo(false, true)|indent }}
       - name: Prepare Dependency Installation
 

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -168,10 +168,10 @@ jobs:
           rig system setup-user-lib
           rig system add-pak
 
-          # ensure unlinking OpenSSL to avoid mixing OpenSSL in the
-          # default path and OpenSSL installed by autobrew
+          # ensure removing OpenSSL from the default paths to avoid
+          # mixing OpenSSL in the default paths and OpenSSL installed
+          # by autobrew
           brew unlink openssl || :
-          find / -name 'evp.h'
       {{ macros.github_setup_local_r_repo(false, true)|indent }}
       - name: Prepare Dependency Installation
 

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -188,7 +188,7 @@ jobs:
         run: brew install sccache
       - name: Find
         run: |
-          find / -name 'include/openssl' || :
+          find / |& grep include/openssl || :
       - name: Build Binary
         id: build
         shell: Rscript {0}

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -188,7 +188,7 @@ jobs:
         run: brew install sccache
       - name: Find
         run: |
-          find / |& grep include/openssl || :
+          find / 2>&1 | grep include/openssl || :
       - name: Build Binary
         id: build
         shell: Rscript {0}


### PR DESCRIPTION
### Rationale for this change

If OpenSSL exists in the default path, we may mix OpenSSL in the default path and OpenSSL installed by autobrew. It may cause a link error, run-time symbol not found error and so on.

### What changes are included in this PR?

Ensure unlinking OpenSSL in the default path.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #36456