### PR TITLE
GH-36524: [GLib] Suppress a pessimizing-move warning

### DIFF
--- a/c_glib/arrow-glib/error.hpp
+++ b/c_glib/arrow-glib/error.hpp
@@ -46,7 +46,7 @@ namespace garrow {
     if (status.ok()) {
       return TRUE;
     } else {
-      std::string context = std::move(context_func());
+      std::string context = context_func();
       g_set_error(error,
                   GARROW_ERROR,
                   garrow_error_from_status(status),


### PR DESCRIPTION
### Rationale for this change

Message from compiler:

    In file included from ../../c_glib/arrow-glib/compute.cpp:28:
    ../../c_glib/arrow-glib/error.hpp: In instantiation of 'gboolean garrow::check(GError**, const arrow::Status&, CONTEXT_FUNC&&) [with CONTEXT_FUNC = garrow_array_cast(GArrowArray*, GArrowDataType*, GArrowCastOptions*, GError**)::<lambda()>&; gboolean = int; GError = _GError]':
    ../../c_glib/arrow-glib/error.hpp:71:17:   required from 'gboolean garrow::check(GError**, const arrow::Result<T>&, CONTEXT_FUNC&&) [with TYPE = std::shared_ptr<arrow::Array>; CONTEXT_FUNC = garrow_array_cast(GArrowArray*, GArrowDataType*, GArrowCastOptions*, GError**)::<lambda()>; gboolean = int; GError = _GError]'
    ../../c_glib/arrow-glib/compute.cpp:4707:20:   required from here
    ../../c_glib/arrow-glib/error.hpp:49:19: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
       49 |       std::string context = std::move(context_func());
          |                   ^~~~~~~
    ../../c_glib/arrow-glib/error.hpp:49:19: note: remove 'std::move' call
    ../../c_glib/arrow-glib/error.hpp: In instantiation of 'gboolean garrow::check(GError**, const arrow::Status&, CONTEXT_FUNC&&) [with CONTEXT_FUNC = garrow_array_unique(GArrowArray*, GError**)::<lambda()>&; gboolean = int; GError = _GError]':
    ../../c_glib/arrow-glib/error.hpp:71:17:   required from 'gboolean garrow::check(GError**, const arrow::Result<T>&, CONTEXT_FUNC&&) [with TYPE = std::shared_ptr<arrow::Array>; CONTEXT_FUNC = garrow_array_unique(GArrowArray*, GError**)::<lambda()>; gboolean = int; GError = _GError]'
    ../../c_glib/arrow-glib/compute.cpp:4740:20:   required from here
    ../../c_glib/arrow-glib/error.hpp:49:19: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
    ../../c_glib/arrow-glib/error.hpp:49:19: note: remove 'std::move' call
    ../../c_glib/arrow-glib/error.hpp: In instantiation of 'gboolean garrow::check(GError**, const arrow::Status&, CONTEXT_FUNC&&) [with CONTEXT_FUNC = garrow_array_dictionary_encode(GArrowArray*, GError**)::<lambda()>&; gboolean = int; GError = _GError]':
    ../../c_glib/arrow-glib/error.hpp:71:17:   required from 'gboolean garrow::check(GError**, const arrow::Result<T>&, CONTEXT_FUNC&&) [with TYPE = arrow::Datum; CONTEXT_FUNC = garrow_array_dictionary_encode(GArrowArray*, GError**)::<lambda()>; gboolean = int; GError = _GError]'
    ../../c_glib/arrow-glib/compute.cpp:4773:20:   required from here
    ../../c_glib/arrow-glib/error.hpp:49:19: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
    ../../c_glib/arrow-glib/error.hpp:49:19: note: remove 'std::move' call

### What changes are included in this PR?

Remove a needless `std::move()`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #36524