### PR TITLE
GH-36187: [C++] Display the name of the problematic field when returning status "Data type ... is not supported in join non-key field" for HashJoin

### DIFF
--- a/cpp/src/arrow/acero/hash_join_node.cc
+++ b/cpp/src/arrow/acero/hash_join_node.cc
@@ -236,14 +236,14 @@ Status HashJoinSchema::ValidateSchemas(JoinType join_type, const Schema& left_sc
     const auto& type = *field->type();
     if (!IsTypeSupported(type)) {
       return Status::Invalid("Data type ", type,
-                             " is not supported in join non-key field");
+                             " is not supported in join non-key field ", field->name());
     }
   }
   for (const auto& field : right_schema.fields()) {
     const auto& type = *field->type();
     if (!IsTypeSupported(type)) {
       return Status::Invalid("Data type ", type,
-                             " is not supported in join non-key field");
+                             " is not supported in join non-key field ", field->name());
     }
   }
 

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -2422,3 +2422,27 @@ def test_numpy_asarray(constructor):
     result = np.asarray(table3, dtype="int32")
     np.testing.assert_allclose(result, expected)
     assert result.dtype == "int32"
+
+
+def test_invalid_non_join_column():
+    NUM_ITEMS = 30
+    t1 = pa.Table.from_pydict({
+        'id': [x.to_bytes(4, 'big') for x in range(NUM_ITEMS)],
+        'array_column': [[z for z in range(3)] for x in range(NUM_ITEMS)],
+    })
+    t2 = pa.Table.from_pydict({
+        'id': [x.to_bytes(4, 'big') for x in range(NUM_ITEMS)],
+        'value': [x for x in range(NUM_ITEMS)]
+    })
+
+    # check as left table
+    with pytest.raises(pa.lib.ArrowInvalid) as excinfo:
+        t1.join(t2, 'id', join_type='inner')
+    exp_error_msg = "Data type list<item: int64> is not supported " \
+        + "in join non-key field array_column"
+    assert exp_error_msg in str(excinfo.value)
+
+    # check as right table
+    with pytest.raises(pa.lib.ArrowInvalid) as excinfo:
+        t2.join(t1, 'id', join_type='inner')
+    assert exp_error_msg in str(excinfo.value)

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -2427,11 +2427,11 @@ def test_numpy_asarray(constructor):
 def test_invalid_non_join_column():
     NUM_ITEMS = 30
     t1 = pa.Table.from_pydict({
-        'id': [x.to_bytes(4, 'big') for x in range(NUM_ITEMS)],
+        'id': range(NUM_ITEMS),
         'array_column': [[z for z in range(3)] for x in range(NUM_ITEMS)],
     })
     t2 = pa.Table.from_pydict({
-        'id': [x.to_bytes(4, 'big') for x in range(NUM_ITEMS)],
+        'id': range(NUM_ITEMS),
         'value': [x for x in range(NUM_ITEMS)]
     })
 


### PR DESCRIPTION
### Rationale for this change

The change is bases on a user filed [issue](https://github.com/apache/arrow/issues/36187). This would provide a readable error message. 

### What changes are included in this PR?

Did modification to `hash_join_node.cc` to include field name to the already provided error message.
Added python tests to validate the response. 

### Are these changes tested?

A test case has been added to Python under `test_table.py`

### Are there any user-facing changes?

No, just a clear error message is provided. 
* Closes: #36187