### PR TITLE
GH-36541: [Python][CI] Ensure the "Without pandas" CI build has no pandas installed (don't install doc requirements in conda-python image)

### DIFF
--- a/ci/docker/conda-python-pandas.dockerfile
+++ b/ci/docker/conda-python-pandas.dockerfile
@@ -22,6 +22,13 @@ FROM ${repo}:${arch}-conda-python-${python}
 
 ARG pandas=latest
 ARG numpy=latest
+
+# the doc builds are using the conda-python-pandas image,
+# so ensure to install doc requirements
+COPY ci/conda_env_sphinx.txt /arrow/ci/
+RUN mamba install -q -y --file arrow/ci/conda_env_sphinx.txt && \
+    mamba clean --all
+
 COPY ci/scripts/install_pandas.sh /arrow/ci/scripts/
 RUN mamba uninstall -q -y numpy && \
     /arrow/ci/scripts/install_pandas.sh ${pandas} ${numpy}

--- a/ci/docker/conda-python.dockerfile
+++ b/ci/docker/conda-python.dockerfile
@@ -22,11 +22,9 @@ FROM ${repo}:${arch}-conda-cpp
 # install python specific packages
 ARG python=3.8
 COPY ci/conda_env_python.txt \
-     ci/conda_env_sphinx.txt \
      /arrow/ci/
 RUN mamba install -q -y \
         --file arrow/ci/conda_env_python.txt \
-        --file arrow/ci/conda_env_sphinx.txt \
         gdb \
         python=${python} \
         nomkl && \

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -3230,6 +3230,7 @@ def test_json_format(tempdir, dataset_reader):
     assert result.equals(table)
 
 
+@pytest.mark.pandas
 def test_json_format_options(tempdir, dataset_reader):
     table = pa.table({'a': pa.array([1, 2, 3], type="int64"),
                       'b': pa.array([.1, .2, .3], type="float64")})
@@ -3250,6 +3251,7 @@ def test_json_format_options(tempdir, dataset_reader):
     assert result.equals(table)
 
 
+@pytest.mark.pandas
 def test_json_fragment_options(tempdir, dataset_reader):
     table = pa.table({'a': pa.array([1, 2, 3], type="int64"),
                       'b': pa.array([.1, .2, .3], type="float64")})

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1096,7 +1096,8 @@ def test_empty_take():
     ([1, 2, 3], IntegerType),
     (["cat", "dog", "horse"], LabelType)
 ))
-@pytest.mark.parametrize("into", ("to_numpy", "to_pandas"))
+@pytest.mark.parametrize(
+    "into", ["to_numpy", pytest.param("to_pandas", marks=pytest.mark.pandas)])
 def test_extension_array_to_numpy_pandas(data, ty, into):
     storage = pa.array(data)
     ext_arr = pa.ExtensionArray.from_storage(ty(), storage)


### PR DESCRIPTION
### Rationale for this change

The "Without Pandas" CI build is actually having pandas installed and thus not testing the case of an environment without pandas. 


* Closes: #36541