### PR TITLE
GH-34884: [Python]: Support pickling pyarrow.dataset PartitioningFactory objects

### DIFF
--- a/python/pyarrow/_dataset.pxd
+++ b/python/pyarrow/_dataset.pxd
@@ -160,11 +160,14 @@ cdef class PartitioningFactory(_Weakrefable):
     cdef:
         shared_ptr[CPartitioningFactory] wrapped
         CPartitioningFactory* factory
+        object constructor
+        object options
 
     cdef init(self, const shared_ptr[CPartitioningFactory]& sp)
 
     @staticmethod
-    cdef wrap(const shared_ptr[CPartitioningFactory]& sp)
+    cdef wrap(const shared_ptr[CPartitioningFactory]& sp,
+              object constructor, object options)
 
     cdef inline shared_ptr[CPartitioningFactory] unwrap(self)
 

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -2374,15 +2374,21 @@ cdef class PartitioningFactory(_Weakrefable):
         self.factory = sp.get()
 
     @staticmethod
-    cdef wrap(const shared_ptr[CPartitioningFactory]& sp):
+    cdef wrap(const shared_ptr[CPartitioningFactory]& sp,
+              object constructor, object options):
         cdef PartitioningFactory self = PartitioningFactory.__new__(
             PartitioningFactory
         )
         self.init(sp)
+        self.constructor = constructor
+        self.options = options
         return self
 
     cdef inline shared_ptr[CPartitioningFactory] unwrap(self):
         return self.wrapped
+
+    def __reduce__(self):
+        return self.constructor, self.options
 
     @property
     def type_name(self):
@@ -2452,6 +2458,10 @@ cdef class KeyValuePartitioning(Partitioning):
             else:
                 res.append(pyarrow_wrap_array(arr))
         return res
+
+
+def _constructor_directory_partitioning_factory(*args):
+    return DirectoryPartitioning.discover(*args)
 
 
 cdef class DirectoryPartitioning(KeyValuePartitioning):
@@ -2571,7 +2581,15 @@ cdef class DirectoryPartitioning(KeyValuePartitioning):
         c_options.segment_encoding = _get_segment_encoding(segment_encoding)
 
         return PartitioningFactory.wrap(
-            CDirectoryPartitioning.MakeFactory(c_field_names, c_options))
+            CDirectoryPartitioning.MakeFactory(c_field_names, c_options),
+            _constructor_directory_partitioning_factory,
+            (field_names, infer_dictionary, max_partition_dictionary_size,
+            schema, segment_encoding)
+        )
+
+
+def _constructor_hive_partitioning_factory(*args):
+    return HivePartitioning.discover(*args)
 
 
 cdef class HivePartitioning(KeyValuePartitioning):
@@ -2714,7 +2732,15 @@ cdef class HivePartitioning(KeyValuePartitioning):
         c_options.segment_encoding = _get_segment_encoding(segment_encoding)
 
         return PartitioningFactory.wrap(
-            CHivePartitioning.MakeFactory(c_options))
+            CHivePartitioning.MakeFactory(c_options),
+            _constructor_hive_partitioning_factory,
+            (infer_dictionary, max_partition_dictionary_size, null_fallback,
+            schema, segment_encoding),
+        )
+
+
+def _constructor_filename_partitioning_factory(*args):
+    return FilenamePartitioning.discover(*args)
 
 
 cdef class FilenamePartitioning(KeyValuePartitioning):
@@ -2823,7 +2849,10 @@ cdef class FilenamePartitioning(KeyValuePartitioning):
         c_options.segment_encoding = _get_segment_encoding(segment_encoding)
 
         return PartitioningFactory.wrap(
-            CFilenamePartitioning.MakeFactory(c_field_names, c_options))
+            CFilenamePartitioning.MakeFactory(c_field_names, c_options),
+            _constructor_filename_partitioning_factory,
+            (field_names, infer_dictionary, schema, segment_encoding)
+        )
 
 
 cdef class DatasetFactory(_Weakrefable):
@@ -2988,7 +3017,7 @@ cdef class FileSystemFactoryOptions(_Weakrefable):
         c_factory = self.options.partitioning.factory()
         if c_factory.get() == nullptr:
             return None
-        return PartitioningFactory.wrap(c_factory)
+        return PartitioningFactory.wrap(c_factory, None, None)
 
     @partitioning_factory.setter
     def partitioning_factory(self, PartitioningFactory value):

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -2584,7 +2584,7 @@ cdef class DirectoryPartitioning(KeyValuePartitioning):
             CDirectoryPartitioning.MakeFactory(c_field_names, c_options),
             _constructor_directory_partitioning_factory,
             (field_names, infer_dictionary, max_partition_dictionary_size,
-            schema, segment_encoding)
+             schema, segment_encoding)
         )
 
 
@@ -2735,7 +2735,7 @@ cdef class HivePartitioning(KeyValuePartitioning):
             CHivePartitioning.MakeFactory(c_options),
             _constructor_hive_partitioning_factory,
             (infer_dictionary, max_partition_dictionary_size, null_fallback,
-            schema, segment_encoding),
+             schema, segment_encoding),
         )
 
 

--- a/python/pyarrow/_dataset_parquet.pyx
+++ b/python/pyarrow/_dataset_parquet.pyx
@@ -805,7 +805,7 @@ cdef class ParquetFactoryOptions(_Weakrefable):
         c_factory = self.options.partitioning.factory()
         if c_factory.get() == nullptr:
             return None
-        return PartitioningFactory.wrap(c_factory)
+        return PartitioningFactory.wrap(c_factory, None, None)
 
     @partitioning_factory.setter
     def partitioning_factory(self, PartitioningFactory value):


### PR DESCRIPTION
### Rationale for this change

https://github.com/apache/arrow/pull/36462 already added support for pickling Partitioning objects, but not yet the PartitioningFactory objects.

The problem for PartitioningFactory is that we currently don't really expose the full class hierarchy in python, just the base class PartitioningFactory. We also don't expose creating those factory objects, except through the `discover` methods of the Partitioning classes. 
I think it would be nice to keep this minimal binding, but that means if we want to make them serializable with pickle, we need another way to do that (and if we don't want to add custom code for serialization on the C++ side). 

In this PR, I went for the route of essentially storing the constructor (the discover static method) and the arguments that were passed to the constructor, on the factory object, so we can use this info for pickling. Not the nicest code, but the simplest solution I could think of.


### Are these changes tested?

Yes
* Closes: #34884