### PR TITLE
MINOR: [C++][CI] Bump conda-forge AWS SDK version

### DIFF
--- a/ci/conda_env_cpp.txt
+++ b/ci/conda_env_cpp.txt
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-aws-sdk-cpp=1.10.13
+aws-sdk-cpp
 benchmark>=1.6.0
 boost-cpp>=1.68.0
 brotli

--- a/ci/conda_env_cpp.txt
+++ b/ci/conda_env_cpp.txt
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-aws-sdk-cpp
+aws-sdk-cpp=1.11.68
 benchmark>=1.6.0
 boost-cpp>=1.68.0
 brotli


### PR DESCRIPTION
Our Conda environment file was pinning the AWS SDK to a rather old version. We should update to a more recent one.

We still pin to a specific version because the AWS SDK releases very often and we don't want to suffer occasional regressions from upstream.