### PR TITLE
GH-36568: [Go] Include Timestamp Zone in ValueStr

### DIFF
--- a/go/arrow/array/timestamp.go
+++ b/go/arrow/array/timestamp.go
@@ -93,7 +93,7 @@ func (a *Timestamp) ValueStr(i int) string {
 
 	dt := a.DataType().(*arrow.TimestampType)
 	z, _ := dt.GetZone()
-	return a.values[i].ToTime(dt.Unit).In(z).Format("2006-01-02 15:04:05.999999999Z")
+	return a.values[i].ToTime(dt.Unit).In(z).Format("2006-01-02 15:04:05.999999999Z0700")
 }
 
 func (a *Timestamp) GetOneForMarshal(i int) interface{} {

--- a/go/arrow/array/timestamp.go
+++ b/go/arrow/array/timestamp.go
@@ -90,7 +90,10 @@ func (a *Timestamp) ValueStr(i int) string {
 	if a.IsNull(i) {
 		return NullValueStr
 	}
-	return a.values[i].ToTime(a.DataType().(*arrow.TimestampType).Unit).Format("2006-01-02 15:04:05.999999999")
+
+	dt := a.DataType().(*arrow.TimestampType)
+	z, _ := dt.GetZone()
+	return a.values[i].ToTime(dt.Unit).In(z).Format("2006-01-02 15:04:05.999999999Z")
 }
 
 func (a *Timestamp) GetOneForMarshal(i int) interface{} {
@@ -289,7 +292,13 @@ func (b *TimestampBuilder) AppendValueFromString(s string) error {
 		b.AppendNull()
 		return nil
 	}
-	v, err := arrow.TimestampFromString(s, b.dtype.Unit)
+
+	loc, err := b.dtype.GetZone()
+	if err != nil {
+		return err
+	}
+
+	v, _, err := arrow.TimestampFromStringInLocation(s, b.dtype.Unit, loc)
 	if err != nil {
 		b.AppendNull()
 		return err

--- a/go/arrow/array/timestamp_test.go
+++ b/go/arrow/array/timestamp_test.go
@@ -233,3 +233,21 @@ func TestTimestampBuilder_Resize(t *testing.T) {
 	ab.Resize(32)
 	assert.Equal(t, 5, ab.Len())
 }
+
+func TestTimestampValueStr(t *testing.T) {		
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	dt := &arrow.TimestampType{Unit: arrow.Second, TimeZone: "America/Phoenix"}
+	b := array.NewTimestampBuilder(mem, dt)
+	defer b.Release()
+
+	b.Append(-34226955)
+	b.Append(1456767743)
+
+	arr := b.NewArray()
+	defer arr.Release()
+
+	assert.Equal(t, "1968-11-30 13:30:45-0700", arr.ValueStr(0))
+	assert.Equal(t, "2016-02-29 10:42:23-0700", arr.ValueStr(1))
+}


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
While trying to fix an issue with Snowflake ADBC timestamp handling, I came across this as part of the problem.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
Adds the timezone string indicator to the output of `ValueStr` for a timestamp array.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

* Closes: #36568