### PR TITLE
GH-36570: [Dev] Add "Component: Swift" label to PRs

### DIFF
--- a/.github/workflows/dev_pr/labeler.yml
+++ b/.github/workflows/dev_pr/labeler.yml
@@ -45,6 +45,9 @@
 "Component: Ruby":
   - ruby/**/*
 
+"Component: Swift":
+  - swift/**/*
+
 "Component: FlightRPC":
   - cpp/src/arrow/flight/**/*
   - r/R/flight.*


### PR DESCRIPTION
### Rationale for this change

We already have the "Component: Swift" label but it's not added to Swift related PRs automatically.

### What changes are included in this PR?

Add a configuration for labeler.

### Are these changes tested?

No. I want to test this on main.

### Are there any user-facing changes?

No.
* Closes: #36570