### PR TITLE
GH-36543: [CI][Docs] Use -g1 instead of -g for building docs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1732,8 +1732,10 @@ services:
         base: ${REPO}:${ARCH}-ubuntu-${UBUNTU}-python-3
     environment:
       <<: [*common, *ccache]
-      ARROW_JAVA_SKIP_GIT_PLUGIN:
       ARROW_CUDA: "ON"
+      ARROW_CXX_FLAGS_DEBUG: "-g1"
+      ARROW_C_FLAGS_DEBUG: "-g1"
+      ARROW_JAVA_SKIP_GIT_PLUGIN:
       ARROW_SUBSTRAIT: "ON"
       BUILD_DOCS_C_GLIB: "ON"
       BUILD_DOCS_CPP: "ON"


### PR DESCRIPTION
### Rationale for this change

Because we don't need to run GDB plugin test for the build.

### What changes are included in this PR?

Specify `-g1` explicitly.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #36543