### PR TITLE
GH-36577: [Dev][C#] Use `version-update:semver-major` for some packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,13 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "MINOR: [C#] "
+    ignore:
+      - dependency-name: "Microsoft.Extensions.*"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "Microsoft.Bcl.*"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "System.*"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
### Rationale for this change

We want to consciously upgrade major versions for `Microsoft.Bcl.*`, `Microsoft.Extensions.*` and `System.*`.

### What changes are included in this PR?

Use `version-update:semver-major` for them.

### Are these changes tested?

No. I want to test this on main.

### Are there any user-facing changes?

No.
* Closes: #36577