### PR TITLE
GH-36582: [CI][C++][Homebrew] Backport the latest formula changes

### DIFF
--- a/dev/tasks/homebrew-formulae/apache-arrow-glib.rb
+++ b/dev/tasks/homebrew-formulae/apache-arrow-glib.rb
@@ -42,6 +42,7 @@ class ApacheArrowGlib < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
+  depends_on "vala" => :build
   depends_on "apache-arrow"
   depends_on "glib"
 

--- a/dev/tasks/homebrew-formulae/apache-arrow-glib.rb
+++ b/dev/tasks/homebrew-formulae/apache-arrow-glib.rb
@@ -32,7 +32,7 @@ class ApacheArrowGlib < Formula
   url "https://www.apache.org/dyn/closer.lua?path=arrow/arrow-13.0.0-SNAPSHOT/apache-arrow-13.0.0-SNAPSHOT.tar.gz"
   sha256 "9948ddb6d4798b51552d0dca3252dd6e3a7d0f9702714fc6f5a1b59397ce1d28"
   license "Apache-2.0"
-  head "https://github.com/apache/arrow.git"
+  head "https://github.com/apache/arrow.git", branch: "main"
 
   livecheck do
     formula "apache-arrow"
@@ -42,22 +42,15 @@ class ApacheArrowGlib < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "vala" => :build
   depends_on "apache-arrow"
   depends_on "glib"
-
-  on_linux do
-    depends_on "gcc"
-  end
 
   fails_with gcc: "5"
 
   def install
-    mkdir "build" do
-      system "meson", *std_meson_args, "-Dvapi=true", "../c_glib"
-      system "ninja", "-v"
-      system "ninja", "install", "-v"
-    end
+    system "meson", "setup", "build", "c_glib", *std_meson_args, "-Dvapi=true"
+    system "meson", "compile", "-C", "build", "--verbose"
+    system "meson", "install", "-C", "build"
   end
 
   test do
@@ -82,9 +75,9 @@ class ApacheArrowGlib < Formula
       -DNDEBUG
       -larrow-glib
       -larrow
-      -lglib-2.0
-      -lgobject-2.0
       -lgio-2.0
+      -lgobject-2.0
+      -lglib-2.0
     ]
     system ENV.cc, "test.c", "-o", "test", *flags
     system "./test"


### PR DESCRIPTION
### Rationale for this change

Most Homebrew formulae use OpenSSL v3 for now.

### What changes are included in this PR?

Backport the latest formulae changes including OpenSSL version change.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #36582