### PR TITLE
GH-36541: [Python][CI] Fixup nopandas build after merge of GH-33321

### DIFF
--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -4258,20 +4258,19 @@ def test_to_pandas_extension_dtypes_mapping():
     assert isinstance(result['a'].dtype, pd.PeriodDtype)
 
 
-@pytest.mark.parametrize("arr",
-                         [pd.period_range("2012-01-01", periods=3, freq="D").array,
-                          pd.interval_range(1, 4).array])
-def test_array_to_pandas(arr):
+def test_array_to_pandas():
     if Version(pd.__version__) < Version("1.1"):
         pytest.skip("ExtensionDtype to_pandas method missing")
 
-    result = pa.array(arr).to_pandas()
-    expected = pd.Series(arr)
-    tm.assert_series_equal(result, expected)
+    for arr in [pd.period_range("2012-01-01", periods=3, freq="D").array,
+                pd.interval_range(1, 4).array]:
+        result = pa.array(arr).to_pandas()
+        expected = pd.Series(arr)
+        tm.assert_series_equal(result, expected)
 
-    result = pa.table({"col": arr})["col"].to_pandas()
-    expected = pd.Series(arr, name="col")
-    tm.assert_series_equal(result, expected)
+        result = pa.table({"col": arr})["col"].to_pandas()
+        expected = pd.Series(arr, name="col")
+        tm.assert_series_equal(result, expected)
 
 
 def test_roundtrip_empty_table_with_extension_dtype_index():

--- a/python/pyarrow/tests/test_schema.py
+++ b/python/pyarrow/tests/test_schema.py
@@ -50,6 +50,7 @@ def test_type_integers():
         assert str(t) == name
 
 
+@pytest.mark.pandas
 def test_type_to_pandas_dtype():
     M8 = np.dtype('datetime64[ms]')
     if Version(pd.__version__) < Version("2.0.0"):


### PR DESCRIPTION
See https://github.com/apache/arrow/pull/35656/files#r1257540254

https://github.com/apache/arrow/pull/36542 fixed the no-pandas build by actually not having pandas installed, but some PRs merged at the same time introduced new failures for this build.
* Closes: #36541