### PR TITLE
GH-34567: [JS] Improve build and do not generate `bin/bin` directory

### DIFF
--- a/js/.eslintrc.cjs
+++ b/js/.eslintrc.cjs
@@ -23,7 +23,7 @@ module.exports = {
     },
     parser: "@typescript-eslint/parser",
     parserOptions: {
-        project: "tsconfig.json",
+        project: ["tsconfig.json", "tsconfig/tsconfig.bin.cjs.json"],
         sourceType: "module",
         ecmaVersion: 2020,
     },

--- a/js/gulp/arrow-task.js
+++ b/js/gulp/arrow-task.js
@@ -15,19 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { targetDir, observableFromStreams } from './util.js';
+import { mainExport, targetDir, observableFromStreams } from './util.js';
 
-import { deleteAsync as del } from 'del';
 import gulp from 'gulp';
+import path from 'path';
 import { mkdirp } from 'mkdirp';
+import * as fs from 'fs/promises';
 import gulpRename from 'gulp-rename';
 import gulpReplace from 'gulp-replace';
 import { memoizeTask } from './memoize-task.js';
 import { ReplaySubject, forkJoin as ObservableForkJoin } from 'rxjs';
 import { share } from 'rxjs/operators';
-import util from 'util';
-import stream from 'stream';
-const pipeline = util.promisify(stream.pipeline);
+import { pipeline } from 'stream/promises';
 
 export const arrowTask = ((cache) => memoizeTask(cache, function copyMain(target) {
     const out = targetDir(target);
@@ -54,9 +53,20 @@ export const arrowTask = ((cache) => memoizeTask(cache, function copyMain(target
 }))({});
 
 export const arrowTSTask = ((cache) => memoizeTask(cache, async function copyTS(target, format) {
+    const umd = targetDir(`es5`, `umd`);
     const out = targetDir(target, format);
-    await mkdirp(out);
-    await pipeline(gulp.src(`src/**/*`), gulp.dest(out));
-    await del(`${out}/**/*.js`);
-}))({});
+    const arrowUMD = path.join(umd, `${mainExport}.js`);
+    const arrow2csvUMD = path.join(umd, `bin`, `arrow2csv.js`);
 
+    await mkdirp(path.join(out, 'bin'));
+
+    await Promise.all([
+        pipeline(gulp.src(`src/**/*`), gulp.dest(out)),
+        pipeline(
+            gulp.src([arrowUMD, arrow2csvUMD]),
+            gulpReplace(`../${mainExport}.js`, `./${mainExport}.js`),
+            gulp.dest(path.join(out, 'bin'))
+        ),
+        fs.writeFile(path.join(out, 'bin', 'package.json'), '{"type": "commonjs"}')
+    ]);
+}))({});

--- a/js/gulp/typescript-task.js
+++ b/js/gulp/typescript-task.js
@@ -44,7 +44,7 @@ export default typescriptTask;
 export function compileBinFiles(target, format) {
     const out = targetDir(target, format);
     const tsconfigPath = path.join(`tsconfig`, `tsconfig.${tsconfigName('bin', 'cjs')}.json`);
-    return compileTypescript(path.join(out, 'bin'), tsconfigPath, { target });
+    return compileTypescript(out, tsconfigPath, { target });
 }
 
 function compileTypescript(out, tsconfigPath, tsconfigOverrides) {

--- a/js/gulpfile.js
+++ b/js/gulpfile.js
@@ -54,6 +54,10 @@ knownTargets.forEach((target) => {
     ));
 });
 
+gulp.task(`build:ts`, gulp.series(
+    `build:es5:umd`, `clean:ts`, `compile:ts`, `package:ts`
+));
+
 // The main "apache-arrow" module builds the es2015/umd, es2015/cjs,
 // es2015/esm, and esnext/umd targets, then copies and renames the
 // compiled output into the apache-arrow folder

--- a/js/src/Arrow.ts
+++ b/js/src/Arrow.ts
@@ -99,6 +99,7 @@ import * as util_bit_ from './util/bit.js';
 import * as util_math_ from './util/math.js';
 import * as util_buffer_ from './util/buffer.js';
 import * as util_vector_ from './util/vector.js';
+import * as util_pretty_ from './util/pretty.js';
 import { compareSchemas, compareFields, compareTypes } from './visitor/typecomparator.js';
 
 /** @ignore */
@@ -109,6 +110,7 @@ export const util = {
     ...util_math_,
     ...util_buffer_,
     ...util_vector_,
+    ...util_pretty_,
     compareSchemas,
     compareFields,
     compareTypes,

--- a/js/src/bin/arrow2csv.ts
+++ b/js/src/bin/arrow2csv.ts
@@ -21,8 +21,7 @@
 
 import * as fs from 'fs';
 import * as stream from 'stream';
-import { valueToString } from '../util/pretty.js';
-import { Schema, RecordBatch, RecordBatchReader, AsyncByteQueue } from '../Arrow.node.js';
+import { Schema, RecordBatch, RecordBatchReader, AsyncByteQueue, util } from '../Arrow.js';
 
 import commandLineUsage from 'command-line-usage';
 import commandLineArgs from 'command-line-args';
@@ -129,7 +128,7 @@ function batchesToString(state: ToStringState, schema: Schema) {
     let maxColWidths = [10];
     const { hr, sep, metadata } = state;
 
-    const header = ['row_id', ...schema.fields.map((f) => `${f}`)].map(val => valueToString(val));
+    const header = ['row_id', ...schema.fields.map((f) => `${f}`)].map(val => util.valueToString(val));
 
     state.maxColWidths = header.map((x, i) => Math.max(maxColWidths[i] || 0, x.length));
 
@@ -181,7 +180,7 @@ function batchesToString(state: ToStringState, schema: Schema) {
                     if (rowId % 350 === 0) {
                         this.push(`${formatRow(header, maxColWidths, sep)}\n`);
                     }
-                    this.push(`${formatRow([rowId++, ...row.toArray()].map(v => valueToString(v)), maxColWidths, sep)}\n`);
+                    this.push(`${formatRow([rowId++, ...row.toArray()].map(v => util.valueToString(v)), maxColWidths, sep)}\n`);
                 }
             }
             cb();
@@ -202,7 +201,7 @@ function formatMetadataValue(value = '') {
     try {
         parsed = JSON.stringify(JSON.parse(value), null, 2);
     } catch { parsed = value; }
-    return valueToString(parsed).split('\n').join('\n  ');
+    return util.valueToString(parsed).split('\n').join('\n  ');
 }
 
 function formatMetadata(metadata: Map<string, string>) {
@@ -236,7 +235,7 @@ function measureColumnWidths(rowId: number, batch: RecordBatch, maxColWidths: nu
                     (val.length * elementWidth) // width of stringified 2^N-1
                 );
             } else {
-                maxColWidths[j + 1] = Math.max(maxColWidths[j + 1] || 0, valueToString(val).length);
+                maxColWidths[j + 1] = Math.max(maxColWidths[j + 1] || 0, util.valueToString(val).length);
             }
             ++j;
         }

--- a/js/src/bin/arrow2csv.ts
+++ b/js/src/bin/arrow2csv.ts
@@ -57,9 +57,10 @@ type ToStringState = {
         if (state.closed) { break; }
         for await (reader of recordBatchReaders(source)) {
             hasReaders = true;
-            const transformToString = batchesToString(state, reader.schema);
+            const batches = stream.Readable.from(reader);
+            const toString = batchesToString(state, reader.schema);
             await pipeTo(
-                reader.pipe(transformToString),
+                batches.pipe(toString),
                 process.stdout, { end: false }
             ).catch(() => state.closed = true); // Handle EPIPE errors
         }

--- a/js/tsconfig/tsconfig.base.json
+++ b/js/tsconfig/tsconfig.base.json
@@ -1,5 +1,5 @@
 {
-  "exclude": ["../node_modules"],
+  "exclude": ["../node_modules", "../src/bin/*.ts"],
   "include": ["../src/**/*.ts"],
   "compileOnSave": false,
   "compilerOptions": {


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

`bin/bin` directory is unnecessary and should not be generated.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

* Add setting to exclude in tsconfig
* Correctly set up `bin` out directory

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

The following files are not generated.

```
targets/apache-arrow/bin/bin/arrow2csv.js
targets/apache-arrow/bin/bin/arrow2csv.js.map
targets/apache-arrow/bin/bin/arrow2csv.mjs
targets/apache-arrow/bin/src/bin/arrow2csv.ts
targets/es2015/cjs/bin/bin/arrow2csv.js
targets/es2015/cjs/bin/bin/arrow2csv.js.map
targets/es2015/cjs/bin/src/bin/arrow2csv.ts
targets/es2015/esm/bin/bin/arrow2csv.js
targets/es2015/esm/bin/bin/arrow2csv.js.map
targets/es2015/esm/bin/src/bin/arrow2csv.ts
targets/es2015/umd/bin/bin/arrow2csv.js
targets/es2015/umd/bin/bin/arrow2csv.js.map
targets/es2015/umd/bin/src/bin/arrow2csv.ts
targets/es5/cjs/bin/bin/arrow2csv.js
targets/es5/cjs/bin/bin/arrow2csv.js.map
targets/es5/cjs/bin/src/bin/arrow2csv.ts
targets/es5/esm/bin/bin/arrow2csv.js
targets/es5/esm/bin/bin/arrow2csv.js.map
targets/es5/esm/bin/src/bin/arrow2csv.ts
targets/es5/umd/bin/bin/arrow2csv.js
targets/es5/umd/bin/bin/arrow2csv.js.map
targets/es5/umd/bin/src/bin/arrow2csv.ts
targets/esnext/cjs/bin/bin/arrow2csv.js
targets/esnext/cjs/bin/bin/arrow2csv.js.map
targets/esnext/cjs/bin/src/bin/arrow2csv.ts
targets/esnext/esm/bin/bin/arrow2csv.js
targets/esnext/esm/bin/bin/arrow2csv.js.map
targets/esnext/esm/bin/src/bin/arrow2csv.ts
targets/esnext/umd/bin/bin/arrow2csv.js
targets/esnext/umd/bin/bin/arrow2csv.js.map
targets/esnext/umd/bin/src/bin/arrow2csv.ts
```

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #34567