### PR TITLE
GH-36614:  [MATLAB] Subclass arrow::Buffer to keep MATLAB data backing arrow::Arrays alive

### DIFF
--- a/matlab/src/cpp/arrow/matlab/array/proxy/array.cc
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/array.cc
@@ -23,7 +23,7 @@
 
 namespace arrow::matlab::array::proxy {
 
-    Array::Array() {
+    Array::Array(std::shared_ptr<arrow::Array> array) : array{std::move(array)} {
 
         // Register Proxy methods.
         REGISTER_METHOD(Array, toString);

--- a/matlab/src/cpp/arrow/matlab/array/proxy/array.h
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/array.h
@@ -25,7 +25,7 @@ namespace arrow::matlab::array::proxy {
 
 class Array : public libmexclass::proxy::Proxy {
     public:
-        Array();
+        Array(std::shared_ptr<arrow::Array> array);
     
         virtual ~Array() {}
 

--- a/matlab/src/cpp/arrow/matlab/array/proxy/boolean_array.cc
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/boolean_array.cc
@@ -24,7 +24,7 @@
 namespace arrow::matlab::array::proxy {
 
         BooleanArray::BooleanArray(std::shared_ptr<arrow::BooleanArray> array) 
-            : arrow::matlab::array::proxy::Array(std::move(array)) {}
+            : arrow::matlab::array::proxy::Array{std::move(array)} {}
 
         libmexclass::proxy::MakeResult BooleanArray::make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
             ::matlab::data::StructArray opts = constructor_arguments[0];

--- a/matlab/src/cpp/arrow/matlab/array/proxy/boolean_array.cc
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/boolean_array.cc
@@ -23,6 +23,9 @@
 
 namespace arrow::matlab::array::proxy {
 
+        BooleanArray::BooleanArray(std::shared_ptr<arrow::BooleanArray> array) 
+            : arrow::matlab::array::proxy::Array(std::move(array)) {}
+
         libmexclass::proxy::MakeResult BooleanArray::make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
             ::matlab::data::StructArray opts = constructor_arguments[0];
 
@@ -40,7 +43,8 @@ namespace arrow::matlab::array::proxy {
             const auto array_length = logical_mda.getNumberOfElements();
 
             auto array_data = arrow::ArrayData::Make(data_type, array_length, {validity_bitmap_buffer, data_buffer});
-            return std::make_shared<arrow::matlab::array::proxy::BooleanArray>(arrow::MakeArray(array_data));
+            auto arrow_array = std::static_pointer_cast<arrow::BooleanArray>(arrow::MakeArray(array_data));
+            return std::make_shared<arrow::matlab::array::proxy::BooleanArray>(std::move(arrow_array));
         }
 
         void BooleanArray::toMATLAB(libmexclass::proxy::method::Context& context) {

--- a/matlab/src/cpp/arrow/matlab/array/proxy/boolean_array.h
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/boolean_array.h
@@ -20,15 +20,13 @@
 #include "arrow/matlab/array/proxy/array.h"
 
 #include "libmexclass/proxy/Proxy.h"
+#include "arrow/type_fwd.h"
 
 namespace arrow::matlab::array::proxy {
 
     class BooleanArray : public arrow::matlab::array::proxy::Array {
         public:
-            BooleanArray(const std::shared_ptr<arrow::Array> logical_array)
-                : arrow::matlab::array::proxy::Array() {
-                    array = logical_array;
-                }
+            BooleanArray(std::shared_ptr<arrow::BooleanArray> array);
 
             static libmexclass::proxy::MakeResult make(const libmexclass::proxy::FunctionArguments& constructor_arguments);
 

--- a/matlab/src/cpp/arrow/matlab/array/proxy/string_array.cc
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/string_array.cc
@@ -26,6 +26,9 @@
 
 namespace arrow::matlab::array::proxy {
 
+        StringArray::StringArray(const std::shared_ptr<arrow::StringArray> string_array) 
+            : arrow::matlab::array::proxy::Array(std::move(string_array)) {}
+
         libmexclass::proxy::MakeResult StringArray::make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
             namespace mda = ::matlab::data;
 
@@ -53,8 +56,8 @@ namespace arrow::matlab::array::proxy {
             arrow::StringBuilder builder;
             MATLAB_ERROR_IF_NOT_OK(builder.AppendValues(strings, unpacked_validity_bitmap_ptr), error::STRING_BUILDER_APPEND_FAILED);
             MATLAB_ASSIGN_OR_ERROR(auto array, builder.Finish(), error::STRING_BUILDER_FINISH_FAILED);
-
-            return std::make_shared<arrow::matlab::array::proxy::StringArray>(array);
+            auto typed_array = std::static_pointer_cast<arrow::StringArray>(array);
+            return std::make_shared<arrow::matlab::array::proxy::StringArray>(std::move(typed_array));
         }
 
         void StringArray::toMATLAB(libmexclass::proxy::method::Context& context) {

--- a/matlab/src/cpp/arrow/matlab/array/proxy/string_array.h
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/string_array.h
@@ -21,15 +21,14 @@
 
 #include "libmexclass/proxy/Proxy.h"
 
+#include "arrow/type_fwd.h"
+
 namespace arrow::matlab::array::proxy {
 
     class StringArray : public arrow::matlab::array::proxy::Array {
         public:
-            StringArray(const std::shared_ptr<arrow::Array> string_array)
-                : arrow::matlab::array::proxy::Array() {
-                    array = string_array;
-                }
-
+            StringArray(const std::shared_ptr<arrow::StringArray> string_array);
+                
             static libmexclass::proxy::MakeResult make(const libmexclass::proxy::FunctionArguments& constructor_arguments);
 
         protected:

--- a/matlab/src/cpp/arrow/matlab/array/proxy/timestamp_array.cc
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/timestamp_array.cc
@@ -53,8 +53,9 @@ namespace arrow::matlab::array::proxy {
                                error::UNICODE_CONVERSION_ERROR_ID);
 
         // extract the time unit
+        const std::u16string& u16_timeunit = timezone_mda[0];
         MATLAB_ASSIGN_OR_ERROR(const auto time_unit, 
-                               arrow::matlab::type::timeUnitFromString(units_mda[0]),
+                               arrow::matlab::type::timeUnitFromString(u16_timeunit),
                                error::UKNOWN_TIME_UNIT_ERROR_ID)
 
         // create the timestamp_type

--- a/matlab/src/cpp/arrow/matlab/array/proxy/timestamp_array.cc
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/timestamp_array.cc
@@ -53,7 +53,7 @@ namespace arrow::matlab::array::proxy {
                                error::UNICODE_CONVERSION_ERROR_ID);
 
         // extract the time unit
-        const std::u16string& u16_timeunit = timezone_mda[0];
+        const std::u16string& u16_timeunit = units_mda[0];
         MATLAB_ASSIGN_OR_ERROR(const auto time_unit, 
                                arrow::matlab::type::timeUnitFromString(u16_timeunit),
                                error::UKNOWN_TIME_UNIT_ERROR_ID)

--- a/matlab/src/cpp/arrow/matlab/array/proxy/timestamp_array.cc
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/timestamp_array.cc
@@ -28,8 +28,8 @@
 
 namespace arrow::matlab::array::proxy {
 
-    TimestampArray::TimestampArray(std::shared_ptr<arrow::TimestampArray> timestamp_array)
-        : arrow::matlab::array::proxy::Array{std::move(timestamp_array)} {}
+    TimestampArray::TimestampArray(std::shared_ptr<arrow::TimestampArray> array)
+        : arrow::matlab::array::proxy::Array{std::move(array)} {}
 
     libmexclass::proxy::MakeResult TimestampArray::make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
         namespace mda = ::matlab::data;

--- a/matlab/src/cpp/arrow/matlab/array/proxy/timestamp_array.h
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/timestamp_array.h
@@ -29,7 +29,7 @@ namespace arrow::matlab::array::proxy {
 
 class TimestampArray : public arrow::matlab::array::proxy::Array {
     public:
-        TimestampArray(std::shared_ptr<arrow::TimestampArray> timestamp_array);
+        TimestampArray(std::shared_ptr<arrow::TimestampArray> array);
 
         static libmexclass::proxy::MakeResult make(const libmexclass::proxy::FunctionArguments& constructor_arguments);
 

--- a/matlab/src/cpp/arrow/matlab/array/proxy/timestamp_array.h
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/timestamp_array.h
@@ -23,20 +23,24 @@
 
 #include "libmexclass/proxy/Proxy.h"
 
+#include "arrow/type_fwd.h"
+
 namespace arrow::matlab::array::proxy {
 
 class TimestampArray : public arrow::matlab::array::proxy::Array {
     public:
-        TimestampArray(const std::shared_ptr<arrow::Array> timestamp_array)
-            : arrow::matlab::array::proxy::Array() {
-                array = timestamp_array;
-        }
+        TimestampArray(std::shared_ptr<arrow::TimestampArray> timestamp_array);
+
+        TimestampArray(std::shared_ptr<arrow::TimestampArray> timestamp_array, ::matlab::data::TypedArray<int64_t> mda_array);
 
         static libmexclass::proxy::MakeResult make(const libmexclass::proxy::FunctionArguments& constructor_arguments);
 
     protected:
-
         void toMATLAB(libmexclass::proxy::method::Context& context) override;
+    
+    private:
+        const ::matlab::data::Array mda_array;
+
 };
 
 }

--- a/matlab/src/cpp/arrow/matlab/buffer/matlab_buffer.h
+++ b/matlab/src/cpp/arrow/matlab/buffer/matlab_buffer.h
@@ -17,24 +17,32 @@
 
 #pragma once
 
-#include "arrow/array.h"
+#include "arrow/buffer.h"
 
-#include "arrow/matlab/array/proxy/array.h"
+#include "MatlabDataArray.hpp"
 
-#include "libmexclass/proxy/Proxy.h"
+namespace arrow::matlab::buffer {
 
-#include "arrow/type_fwd.h"
+    namespace mda = ::matlab::data;
 
-namespace arrow::matlab::array::proxy {
-
-class TimestampArray : public arrow::matlab::array::proxy::Array {
+    class MatlabBuffer : public arrow::Buffer {
     public:
-        TimestampArray(std::shared_ptr<arrow::TimestampArray> timestamp_array);
-
-        static libmexclass::proxy::MakeResult make(const libmexclass::proxy::FunctionArguments& constructor_arguments);
-
-    protected:
-        void toMATLAB(libmexclass::proxy::method::Context& context) override;
-};
-
+    
+        template<typename CType>
+        MatlabBuffer(const mda::TypedArray<CType> typed_array)  
+            : arrow::Buffer{nullptr, 0}
+            , array{typed_array} {
+                
+                // Get raw pointer of mxArray
+                auto it(typed_array.cbegin());
+                auto dt = it.operator->();
+            
+                data_ = reinterpret_cast<const uint8_t*>(dt);
+                size_ = sizeof(CType) * static_cast<int64_t>(typed_array.getNumberOfElements());
+                capacity_ = size_;
+                is_mutable_ = false;
+            }
+        private:
+            const mda::Array array;
+    };
 }

--- a/matlab/src/cpp/arrow/matlab/buffer/matlab_buffer.h
+++ b/matlab/src/cpp/arrow/matlab/buffer/matlab_buffer.h
@@ -42,7 +42,7 @@ namespace arrow::matlab::buffer {
                 capacity_ = size_;
                 is_mutable_ = false;
             }
-        private:
-            const mda::Array array;
+    private:
+        const mda::Array array;
     };
 }

--- a/matlab/src/matlab/+arrow/+array/NumericArray.m
+++ b/matlab/src/matlab/+arrow/+array/NumericArray.m
@@ -15,11 +15,6 @@
 
 classdef NumericArray < arrow.array.Array
     % arrow.array.NumericArray
-    
-    
-    properties (Hidden, SetAccess=protected)
-        MatlabArray = []
-    end
 
     properties(Abstract, Access=protected)
         NullSubstitutionValue;
@@ -38,9 +33,6 @@ classdef NumericArray < arrow.array.Array
             validElements = arrow.args.parseValidElements(data, opts);
             opts = struct(MatlabArray=data, Valid=validElements);
             obj@arrow.array.Array("Name", proxyName, "ConstructorArguments", {opts});
-            obj.MatlabArray = cast(obj.MatlabArray, type);
-            % Store a reference to the array
-            obj.MatlabArray = data;
         end
 
         function matlabArray = toMATLAB(obj)

--- a/matlab/test/arrow/array/hNumericArray.m
+++ b/matlab/test/arrow/array/hNumericArray.m
@@ -43,14 +43,6 @@ classdef hNumericArray < matlab.unittest.TestCase
             tc.verifyEqual(className, tc.ArrowArrayClassName);
         end
 
-        function ShallowCopyTest(tc)
-        % NumericArrays stores a shallow copy of the array keep the
-        % memory alive.
-            A = tc.ArrowArrayConstructor(tc.MatlabArrayFcn([1, 2, 3]));
-            tc.verifyEqual(A.MatlabArray, tc.MatlabArrayFcn([1, 2, 3]));
-            tc.verifyEqual(toMATLAB(A), tc.MatlabArrayFcn([1 2 3]'));
-        end
-
         function ToMATLAB(tc)
             % Create array from a scalar
             A1 = tc.ArrowArrayConstructor(tc.MatlabArrayFcn(100));

--- a/matlab/tools/cmake/BuildMatlabArrowInterface.cmake
+++ b/matlab/tools/cmake/BuildMatlabArrowInterface.cmake
@@ -38,8 +38,8 @@ set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/src/c
                                                       "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/bit"
                                                       "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/error"
                                                       "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type"
-                                                      "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy")
-
+                                                      "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy"
+                                                      "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/buffer")
 
 set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_SOURCES "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/array/proxy/array.cc"
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/array/proxy/boolean_array.cc"


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

When building `arrow.array.<Numeric>Arrays` from native MATLAB arrays, we avoid copying by

1. Wrapping the MATLAB data inside a non-owning `arrow::Buffer`
2. Constructing an `arrow::ArrayData` object from the `arrow::Buffer`
3. Constructing the `arrow::Array` from the `arrow::Data` object.

Because the `Array`'s underlying `Buffer` does not have ownership of its backing data, we have been storing the original MATLAB array as a property called `MatlabArray` on the MATLAB `arrow.array.NumericArray` class.

This solution is not ideal because the backing MATLAB array is kept separate from the actual `std::shared_ptr<arrow::Array>`, which is stored within the C++ proxy objects (e.g. `arrow::matlab::array::proxy::NumericArray<float64>`).  A better solution would be to create a new subclass of `arrow::Buffer` called `MatlabBuffer`, which will keep the original MATLAB array alive by taking it in as an input parameter and storing it as a member variable. 

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

1. Removed the `MatlabArray` property from the MATLAB class `matlab.io.NumericArray` 
2. Added a private member variable called `mda_array` to `arrow::matlab::array::proxy::NumericArray<CType>` and `arrow::matlab::array::proxy::TimestampArray`. `mda_array` is a `matlab::data::Array` object. This member variable stores the MATLAB array that owns the memory the `arrow::Array` objects are backed by.

### Are these changes tested?

Existing tests used.

### Are there any user-facing changes?
No.

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #36614