### PR TITLE
GH-36618: [C++] Add a test for evaluation of ARROW_CHECK payload

### DIFF
--- a/cpp/src/arrow/util/logging_test.cc
+++ b/cpp/src/arrow/util/logging_test.cc
@@ -68,6 +68,33 @@ TEST(PrintLogTest, LogTestWithInit) {
   ArrowLog::ShutDownArrowLog();
 }
 
+struct LoggingTracer {
+  mutable bool was_printed = false;
+
+  friend std::ostream& operator<<(std::ostream& os, const LoggingTracer& x) {
+    x.was_printed = true;
+    return os;
+  }
+};
+
+TEST(ArrowCheck, PayloadNotEvaluatedOnSuccess) {
+  volatile bool cond = true;
+  LoggingTracer tracer;
+
+  ARROW_CHECK_OR_LOG(cond, WARNING) << "Some message" << tracer;
+  ASSERT_FALSE(tracer.was_printed);
+}
+
+TEST(ArrowCheck, PayloadEvaluatedOnFailure) {
+  volatile bool cond = false;
+  LoggingTracer tracer;
+
+  // Have to use a log level that actually gets printed, otherwise `operator<<`
+  // isn't called (which is good except for this test).
+  ARROW_CHECK_OR_LOG(cond, WARNING) << "Some message" << tracer;
+  ASSERT_TRUE(tracer.was_printed);
+}
+
 }  // namespace util
 
 TEST(DcheckMacros, DoNotEvaluateReleaseMode) {


### PR DESCRIPTION
We want to make sure that the error description payload for ARROW_CHECK is only evaluated if the check fails.

* Closes: #36618