### PR TITLE
GH-36621: [C++] Add documentation for ACERO_ALIGNMENT_HANDLING

### DIFF
--- a/docs/source/cpp/env_vars.rst
+++ b/docs/source/cpp/env_vars.rst
@@ -33,15 +33,16 @@ that changing their value later will have an effect.
    undefined behavior if the underlying array is not properly aligned.  On
    most modern CPUs this is not an issue, but some older CPUs may crash or
    suffer poor performance.  For this reason it is recommended that all
-   incoming array buffers are properly aligned.
+   incoming array buffers are properly aligned, but some data sources
+   such as :ref:`Flight <flight-rpc>` may produce unaligned buffers.
 
    The value of this environment variable controls what will happen when
-   Acero detects an unaligned buffer.
+   Acero detects an unaligned buffer:
 
-   - ``warn`` a warning is emitted
-   - ``ignore`` nothing, alignment checking is disabled
-   - ``reallocate`` the buffer is reallocated to a properly aligned address
-   - ``error`` the operation will fail with an error
+   - ``warn``: a warning is emitted
+   - ``ignore``: nothing, alignment checking is disabled
+   - ``reallocate``: the buffer is reallocated to a properly aligned address
+   - ``error``: the operation fails with an error
 
    The default behavior is ``warn``.  On modern hardware it is usually safe
    to change this to ``ignore``.  Changing to ``reallocate`` is the safest

--- a/docs/source/cpp/env_vars.rst
+++ b/docs/source/cpp/env_vars.rst
@@ -26,6 +26,28 @@ Arrow C++ at runtime.  Many of these variables are inspected only once per
 process (for example, when the Arrow C++ DLL is loaded), so you cannot assume
 that changing their value later will have an effect.
 
+.. envvar:: ACERO_ALIGNMENT_HANDLING
+
+   Arrow C++'s Acero module performs computation on streams of data.  This
+   computation may involve a form of "type punning" that is technically
+   undefined behavior if the underlying array is not properly aligned.  On
+   most modern CPUs this is not an issue, but some older CPUs may crash or
+   suffer poor performance.  For this reason it is recommended that all
+   incoming array buffers are properly aligned.
+
+   The value of this environment variable controls what will happen when
+   Acero detects an unaligned buffer.
+
+   - ``warn`` a warning is emitted
+   - ``ignore`` nothing, alignment checking is disabled
+   - ``reallocate`` the buffer is reallocated to a properly aligned address
+   - ``error`` the operation will fail with an error
+
+   The default behavior is ``warn``.  On modern hardware it is usually safe
+   to change this to ``ignore``.  Changing to ``reallocate`` is the safest
+   option but this will have a significant performance impact as the buffer
+   will need to be copied.
+
 .. envvar:: ARROW_DEBUG_MEMORY_POOL
 
    Enable rudimentary memory checks to guard against buffer overflows.


### PR DESCRIPTION
### Rationale for this change

To document an existing environment variable that was not documented.

### What changes are included in this PR?

Adds a documentation section for this environment variable.

### Are these changes tested?

No, there are only docs.

### Are there any user-facing changes?

New documentation
* Closes: #36621