### PR TITLE
GH-36634: [Dev] Ensure merge script goes over all pages when requesting info from GitHub

### DIFF
--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -78,7 +78,26 @@ def get_json(url, headers=None):
     response = requests.get(url, headers=headers)
     if response.status_code != 200:
         raise ValueError(response.json())
-    return response.json()
+    # GitHub returns a link header with the next, previous, last
+    # page if there is pagination on the response. See:
+    # https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api#using-link-headers
+    next_responses = None
+    if "link" in response.headers:
+        links = response.headers['link'].split(', ')
+        next_url = None
+        for link in links:
+            if 'rel="next"' in link:
+                # Format: '<url>; rel="next"'
+                next_url = link.split(";")[0][1:-1]
+        if next_url:
+            next_responses = get_json(next_url, headers)
+    ret_val = response.json()
+    if next_responses:
+        if isinstance(ret_val, list):
+            ret_val.extend(next_responses)
+        else:
+            raise ValueError('GitHub response was paginated and is not a list')
+    return ret_val
 
 
 def run_cmd(cmd):

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -89,13 +89,13 @@ def get_json(url, headers=None):
                 # Format: '<url>; rel="next"'
                 next_url = link.split(";")[0][1:-1]
                 next_responses = get_json(next_url, headers)
-    ret_val = response.json()
+    responses = response.json()
     if next_responses:
-        if isinstance(ret_val, list):
-            ret_val.extend(next_responses)
+        if isinstance(responses, list):
+            responses.extend(next_responses)
         else:
             raise ValueError('GitHub response was paginated and is not a list')
-    return ret_val
+    return responses
 
 
 def run_cmd(cmd):

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -84,13 +84,11 @@ def get_json(url, headers=None):
     next_responses = None
     if "link" in response.headers:
         links = response.headers['link'].split(', ')
-        next_url = None
         for link in links:
             if 'rel="next"' in link:
                 # Format: '<url>; rel="next"'
                 next_url = link.split(";")[0][1:-1]
-        if next_url:
-            next_responses = get_json(next_url, headers)
+                next_responses = get_json(next_url, headers)
     ret_val = response.json()
     if next_responses:
         if isinstance(ret_val, list):


### PR DESCRIPTION
### Rationale for this change

We currently were missing maintenance branches due to pagination on GH API.

### What changes are included in this PR?

Check whether the API is returning a paginated view and extend the list returned.

### Are these changes tested?

I have tested locally:

```
(Pdb) pr.maintenance_branches
['maint-0.11.x', 'maint-0.12.x', 'maint-0.14.x', 'maint-0.15.x', 'maint-0.17.x', 'maint-1.0.x', 'maint-3.0.x', 'maint-4.0.x', 'maint-6.0.x', 'maint-7.0.x', 'maint-7.0.1', 'maint-8.0.x', 'maint-9.0.0', 'maint-10.0.x', 'maint-10.0.0', 'maint-10.0.1', 'maint-11.0.0', 'maint-12.0.x', 'maint-12.0.0', 'maint-12.0.1', 'maint-13.0.0']
(Pdb) c
Enter fix version [14.0.0]: 
```
### Are there any user-facing changes?

No
* Closes: #36634