### PR TITLE
GH-36332: [CI][Java] Patch spark to use Netty 4.1.94.Final on our integration tests

### DIFF
--- a/ci/scripts/integration_spark.sh
+++ b/ci/scripts/integration_spark.sh
@@ -45,6 +45,13 @@ export MAVEN_OPTS="${MAVEN_OPTS} -Dorg.slf4j.simpleLogger.log.org.apache.maven.c
 
 pushd ${spark_dir}
 
+  # Due to CVE-2023-34462 we upgraded to a memory netty version which is incompatible
+  # with previous spark versions. Patch the pom to use newer version.
+  sed -i.bak -E -e \
+    "s/^netty\.version>.+<\/netty\.version>/netty\.version>4.1.94.Final<\/netty\.version>/" \
+    pom.xml
+  rm -f pom.xml.bak
+
   if [ "${test_pyarrow_only}" == "true" ]; then
     echo "Building Spark ${SPARK_VERSION} to test pyarrow only"
 


### PR DESCRIPTION
### Rationale for this change
It does seem that the only way to shadow Netty version is to modify the Pom for previous versions.

### What changes are included in this PR?

Try to patch version of Netty on the pom when cloning Spark.

### Are these changes tested?

Archery integration tests

### Are there any user-facing changes?

No
* Closes: #36332