### PR TITLE
GH-36641: [C++] Remove reference to acero from non-acero file

### DIFF
--- a/cpp/src/arrow/compute/util.h
+++ b/cpp/src/arrow/compute/util.h
@@ -169,6 +169,7 @@ ARROW_EXPORT bool are_all_bytes_zero(int64_t hardware_flags, const uint8_t* byte
                                      uint32_t num_bytes);
 
 #if defined(ARROW_HAVE_AVX2)
+
 namespace avx2 {
 ARROW_EXPORT void bits_filter_indexes_avx2(int bit_to_search, const int num_bits,
                                            const uint8_t* bits,
@@ -186,8 +187,7 @@ ARROW_EXPORT bool are_all_bytes_zero_avx2(const uint8_t* bytes, uint32_t num_byt
 
 #endif
 
-};  // namespace bit_util
-
+}  // namespace bit_util
 }  // namespace util
 
 namespace compute {

--- a/cpp/src/arrow/compute/util.h
+++ b/cpp/src/arrow/compute/util.h
@@ -141,39 +141,47 @@ class TempVectorHolder {
 
 namespace bit_util {
 
-void bits_to_indexes(int bit_to_search, int64_t hardware_flags, const int num_bits,
-                     const uint8_t* bits, int* num_indexes, uint16_t* indexes,
-                     int bit_offset = 0);
+ARROW_EXPORT void bits_to_indexes(int bit_to_search, int64_t hardware_flags,
+                                  const int num_bits, const uint8_t* bits,
+                                  int* num_indexes, uint16_t* indexes,
+                                  int bit_offset = 0);
 
-void bits_filter_indexes(int bit_to_search, int64_t hardware_flags, const int num_bits,
-                         const uint8_t* bits, const uint16_t* input_indexes,
-                         int* num_indexes, uint16_t* indexes, int bit_offset = 0);
+ARROW_EXPORT void bits_filter_indexes(int bit_to_search, int64_t hardware_flags,
+                                      const int num_bits, const uint8_t* bits,
+                                      const uint16_t* input_indexes, int* num_indexes,
+                                      uint16_t* indexes, int bit_offset = 0);
 
 // Input and output indexes may be pointing to the same data (in-place filtering).
-void bits_split_indexes(int64_t hardware_flags, const int num_bits, const uint8_t* bits,
-                        int* num_indexes_bit0, uint16_t* indexes_bit0,
-                        uint16_t* indexes_bit1, int bit_offset = 0);
+ARROW_EXPORT void bits_split_indexes(int64_t hardware_flags, const int num_bits,
+                                     const uint8_t* bits, int* num_indexes_bit0,
+                                     uint16_t* indexes_bit0, uint16_t* indexes_bit1,
+                                     int bit_offset = 0);
 
 // Bit 1 is replaced with byte 0xFF.
-void bits_to_bytes(int64_t hardware_flags, const int num_bits, const uint8_t* bits,
-                   uint8_t* bytes, int bit_offset = 0);
+ARROW_EXPORT void bits_to_bytes(int64_t hardware_flags, const int num_bits,
+                                const uint8_t* bits, uint8_t* bytes, int bit_offset = 0);
 
 // Return highest bit of each byte.
-void bytes_to_bits(int64_t hardware_flags, const int num_bits, const uint8_t* bytes,
-                   uint8_t* bits, int bit_offset = 0);
+ARROW_EXPORT void bytes_to_bits(int64_t hardware_flags, const int num_bits,
+                                const uint8_t* bytes, uint8_t* bits, int bit_offset = 0);
 
-bool are_all_bytes_zero(int64_t hardware_flags, const uint8_t* bytes, uint32_t num_bytes);
+ARROW_EXPORT bool are_all_bytes_zero(int64_t hardware_flags, const uint8_t* bytes,
+                                     uint32_t num_bytes);
 
 #if defined(ARROW_HAVE_AVX2)
 namespace avx2 {
-void bits_filter_indexes_avx2(int bit_to_search, const int num_bits, const uint8_t* bits,
-                              const uint16_t* input_indexes, int* num_indexes,
-                              uint16_t* indexes);
-void bits_to_indexes_avx2(int bit_to_search, const int num_bits, const uint8_t* bits,
-                          int* num_indexes, uint16_t* indexes, uint16_t base_index = 0);
-void bits_to_bytes_avx2(const int num_bits, const uint8_t* bits, uint8_t* bytes);
-void bytes_to_bits_avx2(const int num_bits, const uint8_t* bytes, uint8_t* bits);
-bool are_all_bytes_zero_avx2(const uint8_t* bytes, uint32_t num_bytes);
+ARROW_EXPORT void bits_filter_indexes_avx2(int bit_to_search, const int num_bits,
+                                           const uint8_t* bits,
+                                           const uint16_t* input_indexes,
+                                           int* num_indexes, uint16_t* indexes);
+ARROW_EXPORT void bits_to_indexes_avx2(int bit_to_search, const int num_bits,
+                                       const uint8_t* bits, int* num_indexes,
+                                       uint16_t* indexes, uint16_t base_index = 0);
+ARROW_EXPORT void bits_to_bytes_avx2(const int num_bits, const uint8_t* bits,
+                                     uint8_t* bytes);
+ARROW_EXPORT void bytes_to_bits_avx2(const int num_bits, const uint8_t* bytes,
+                                     uint8_t* bits);
+ARROW_EXPORT bool are_all_bytes_zero_avx2(const uint8_t* bytes, uint32_t num_bytes);
 }  // namespace avx2
 
 #endif

--- a/cpp/src/arrow/compute/util.h
+++ b/cpp/src/arrow/compute/util.h
@@ -139,68 +139,46 @@ class TempVectorHolder {
   uint32_t num_elements_;
 };
 
-class ARROW_EXPORT bit_util {
- public:
-  static void bits_to_indexes(int bit_to_search, int64_t hardware_flags,
-                              const int num_bits, const uint8_t* bits, int* num_indexes,
-                              uint16_t* indexes, int bit_offset = 0);
+namespace bit_util {
 
-  static void bits_filter_indexes(int bit_to_search, int64_t hardware_flags,
-                                  const int num_bits, const uint8_t* bits,
-                                  const uint16_t* input_indexes, int* num_indexes,
-                                  uint16_t* indexes, int bit_offset = 0);
+void bits_to_indexes(int bit_to_search, int64_t hardware_flags, const int num_bits,
+                     const uint8_t* bits, int* num_indexes, uint16_t* indexes,
+                     int bit_offset = 0);
 
-  // Input and output indexes may be pointing to the same data (in-place filtering).
-  static void bits_split_indexes(int64_t hardware_flags, const int num_bits,
-                                 const uint8_t* bits, int* num_indexes_bit0,
-                                 uint16_t* indexes_bit0, uint16_t* indexes_bit1,
-                                 int bit_offset = 0);
+void bits_filter_indexes(int bit_to_search, int64_t hardware_flags, const int num_bits,
+                         const uint8_t* bits, const uint16_t* input_indexes,
+                         int* num_indexes, uint16_t* indexes, int bit_offset = 0);
 
-  // Bit 1 is replaced with byte 0xFF.
-  static void bits_to_bytes(int64_t hardware_flags, const int num_bits,
-                            const uint8_t* bits, uint8_t* bytes, int bit_offset = 0);
+// Input and output indexes may be pointing to the same data (in-place filtering).
+void bits_split_indexes(int64_t hardware_flags, const int num_bits, const uint8_t* bits,
+                        int* num_indexes_bit0, uint16_t* indexes_bit0,
+                        uint16_t* indexes_bit1, int bit_offset = 0);
 
-  // Return highest bit of each byte.
-  static void bytes_to_bits(int64_t hardware_flags, const int num_bits,
-                            const uint8_t* bytes, uint8_t* bits, int bit_offset = 0);
+// Bit 1 is replaced with byte 0xFF.
+void bits_to_bytes(int64_t hardware_flags, const int num_bits, const uint8_t* bits,
+                   uint8_t* bytes, int bit_offset = 0);
 
-  static bool are_all_bytes_zero(int64_t hardware_flags, const uint8_t* bytes,
-                                 uint32_t num_bytes);
+// Return highest bit of each byte.
+void bytes_to_bits(int64_t hardware_flags, const int num_bits, const uint8_t* bytes,
+                   uint8_t* bits, int bit_offset = 0);
 
- private:
-  inline static uint64_t SafeLoadUpTo8Bytes(const uint8_t* bytes, int num_bytes);
-  inline static void SafeStoreUpTo8Bytes(uint8_t* bytes, int num_bytes, uint64_t value);
-  inline static void bits_to_indexes_helper(uint64_t word, uint16_t base_index,
-                                            int* num_indexes, uint16_t* indexes);
-  inline static void bits_filter_indexes_helper(uint64_t word,
-                                                const uint16_t* input_indexes,
-                                                int* num_indexes, uint16_t* indexes);
-  template <int bit_to_search, bool filter_input_indexes>
-  static void bits_to_indexes_internal(int64_t hardware_flags, const int num_bits,
-                                       const uint8_t* bits, const uint16_t* input_indexes,
-                                       int* num_indexes, uint16_t* indexes,
-                                       uint16_t base_index = 0);
+bool are_all_bytes_zero(int64_t hardware_flags, const uint8_t* bytes, uint32_t num_bytes);
 
 #if defined(ARROW_HAVE_AVX2)
-  static void bits_to_indexes_avx2(int bit_to_search, const int num_bits,
-                                   const uint8_t* bits, int* num_indexes,
-                                   uint16_t* indexes, uint16_t base_index = 0);
-  static void bits_filter_indexes_avx2(int bit_to_search, const int num_bits,
-                                       const uint8_t* bits, const uint16_t* input_indexes,
-                                       int* num_indexes, uint16_t* indexes);
-  template <int bit_to_search>
-  static void bits_to_indexes_imp_avx2(const int num_bits, const uint8_t* bits,
-                                       int* num_indexes, uint16_t* indexes,
-                                       uint16_t base_index = 0);
-  template <int bit_to_search>
-  static void bits_filter_indexes_imp_avx2(const int num_bits, const uint8_t* bits,
-                                           const uint16_t* input_indexes,
-                                           int* num_indexes, uint16_t* indexes);
-  static void bits_to_bytes_avx2(const int num_bits, const uint8_t* bits, uint8_t* bytes);
-  static void bytes_to_bits_avx2(const int num_bits, const uint8_t* bytes, uint8_t* bits);
-  static bool are_all_bytes_zero_avx2(const uint8_t* bytes, uint32_t num_bytes);
+namespace avx2 {
+void bits_filter_indexes_avx2(int bit_to_search, const int num_bits, const uint8_t* bits,
+                              const uint16_t* input_indexes, int* num_indexes,
+                              uint16_t* indexes);
+void bits_to_indexes_avx2(int bit_to_search, const int num_bits, const uint8_t* bits,
+                          int* num_indexes, uint16_t* indexes, uint16_t base_index = 0);
+void bits_to_bytes_avx2(const int num_bits, const uint8_t* bits, uint8_t* bytes);
+void bytes_to_bits_avx2(const int num_bits, const uint8_t* bytes, uint8_t* bits);
+bool are_all_bytes_zero_avx2(const uint8_t* bytes, uint32_t num_bytes);
+}  // namespace avx2
+
 #endif
-};
+
+};  // namespace bit_util
 
 }  // namespace util
 

--- a/cpp/src/arrow/compute/util_avx2.cc
+++ b/cpp/src/arrow/compute/util_avx2.cc
@@ -16,30 +16,19 @@
 // under the License.
 
 #include <immintrin.h>
+#include <cstring>
 
-#include "arrow/acero/util.h"
 #include "arrow/util/bit_util.h"
-
-namespace arrow {
-namespace util {
+#include "arrow/util/logging.h"
 
 #if defined(ARROW_HAVE_AVX2)
-
-void bit_util::bits_to_indexes_avx2(int bit_to_search, const int num_bits,
-                                    const uint8_t* bits, int* num_indexes,
-                                    uint16_t* indexes, uint16_t base_index) {
-  if (bit_to_search == 0) {
-    bits_to_indexes_imp_avx2<0>(num_bits, bits, num_indexes, indexes, base_index);
-  } else {
-    ARROW_DCHECK(bit_to_search == 1);
-    bits_to_indexes_imp_avx2<1>(num_bits, bits, num_indexes, indexes, base_index);
-  }
-}
+namespace arrow {
+namespace util {
+namespace avx2 {
 
 template <int bit_to_search>
-void bit_util::bits_to_indexes_imp_avx2(const int num_bits, const uint8_t* bits,
-                                        int* num_indexes, uint16_t* indexes,
-                                        uint16_t base_index) {
+void bits_to_indexes_imp_avx2(const int num_bits, const uint8_t* bits, int* num_indexes,
+                              uint16_t* indexes, uint16_t base_index = 0) {
   // 64 bits at a time
   constexpr int unroll = 64;
 
@@ -82,21 +71,20 @@ void bit_util::bits_to_indexes_imp_avx2(const int num_bits, const uint8_t* bits,
   }
 }
 
-void bit_util::bits_filter_indexes_avx2(int bit_to_search, const int num_bits,
-                                        const uint8_t* bits,
-                                        const uint16_t* input_indexes, int* num_indexes,
-                                        uint16_t* indexes) {
+void bits_to_indexes_avx2(int bit_to_search, const int num_bits, const uint8_t* bits,
+                          int* num_indexes, uint16_t* indexes, uint16_t base_index) {
   if (bit_to_search == 0) {
-    bits_filter_indexes_imp_avx2<0>(num_bits, bits, input_indexes, num_indexes, indexes);
+    bits_to_indexes_imp_avx2<0>(num_bits, bits, num_indexes, indexes, base_index);
   } else {
-    bits_filter_indexes_imp_avx2<1>(num_bits, bits, input_indexes, num_indexes, indexes);
+    ARROW_DCHECK(bit_to_search == 1);
+    bits_to_indexes_imp_avx2<1>(num_bits, bits, num_indexes, indexes, base_index);
   }
 }
 
 template <int bit_to_search>
-void bit_util::bits_filter_indexes_imp_avx2(const int num_bits, const uint8_t* bits,
-                                            const uint16_t* input_indexes,
-                                            int* out_num_indexes, uint16_t* indexes) {
+void bits_filter_indexes_imp_avx2(const int num_bits, const uint8_t* bits,
+                                  const uint16_t* input_indexes, int* out_num_indexes,
+                                  uint16_t* indexes) {
   // 64 bits at a time
   constexpr int unroll = 64;
 
@@ -167,8 +155,17 @@ void bit_util::bits_filter_indexes_imp_avx2(const int num_bits, const uint8_t* b
   *out_num_indexes = num_indexes;
 }
 
-void bit_util::bits_to_bytes_avx2(const int num_bits, const uint8_t* bits,
-                                  uint8_t* bytes) {
+void bits_filter_indexes_avx2(int bit_to_search, const int num_bits, const uint8_t* bits,
+                              const uint16_t* input_indexes, int* num_indexes,
+                              uint16_t* indexes) {
+  if (bit_to_search == 0) {
+    bits_filter_indexes_imp_avx2<0>(num_bits, bits, input_indexes, num_indexes, indexes);
+  } else {
+    bits_filter_indexes_imp_avx2<1>(num_bits, bits, input_indexes, num_indexes, indexes);
+  }
+}
+
+void bits_to_bytes_avx2(const int num_bits, const uint8_t* bits, uint8_t* bytes) {
   constexpr int unroll = 32;
 
   constexpr uint64_t kEachByteIs1 = 0x0101010101010101ULL;
@@ -188,8 +185,7 @@ void bit_util::bits_to_bytes_avx2(const int num_bits, const uint8_t* bits,
   }
 }
 
-void bit_util::bytes_to_bits_avx2(const int num_bits, const uint8_t* bytes,
-                                  uint8_t* bits) {
+void bytes_to_bits_avx2(const int num_bits, const uint8_t* bytes, uint8_t* bits) {
   constexpr int unroll = 32;
   // Processing 32 bits at a time
   for (int i = 0; i < num_bits / unroll; ++i) {
@@ -198,7 +194,7 @@ void bit_util::bytes_to_bits_avx2(const int num_bits, const uint8_t* bytes,
   }
 }
 
-bool bit_util::are_all_bytes_zero_avx2(const uint8_t* bytes, uint32_t num_bytes) {
+bool are_all_bytes_zero_avx2(const uint8_t* bytes, uint32_t num_bytes) {
   __m256i result_or = _mm256_setzero_si256();
   uint32_t i;
   for (i = 0; i < num_bytes / 32; ++i) {
@@ -216,7 +212,7 @@ bool bit_util::are_all_bytes_zero_avx2(const uint8_t* bytes, uint32_t num_bytes)
   return result_or32 == 0;
 }
 
-#endif  // ARROW_HAVE_AVX2
-
+}  // namespace avx2
 }  // namespace util
 }  // namespace arrow
+#endif  // ARROW_HAVE_AVX2

--- a/cpp/src/arrow/compute/util_avx2.cc
+++ b/cpp/src/arrow/compute/util_avx2.cc
@@ -22,9 +22,8 @@
 #include "arrow/util/logging.h"
 
 #if defined(ARROW_HAVE_AVX2)
-namespace arrow {
-namespace util {
-namespace avx2 {
+
+namespace arrow::util::avx2 {
 
 template <int bit_to_search>
 void bits_to_indexes_imp_avx2(const int num_bits, const uint8_t* bits, int* num_indexes,
@@ -212,7 +211,6 @@ bool are_all_bytes_zero_avx2(const uint8_t* bytes, uint32_t num_bytes) {
   return result_or32 == 0;
 }
 
-}  // namespace avx2
-}  // namespace util
-}  // namespace arrow
+}  // namespace arrow::util::avx2
+
 #endif  // ARROW_HAVE_AVX2


### PR DESCRIPTION
### Rationale for this change

Files in modules which do not depend on the acero module should not reference files inside the acero module.

### What changes are included in this PR?

There were no changes to the body of any functions.  I simply moved functions around so that the acero include was no longer needed.  There were some conflicts that arose between the class `bit_util` and the namespace `bit_util` and so I got rid of the class in favor of the namespace as that is more similar to how we handle `bit_util` elsewhere.

### Are these changes tested?

Sort of.  I would like to add an AVX2 CI system as well.  I'm not confident any of the CI builds are building with AVX2 enabled.  Also, even if we have an AVX2 CI system it would not have caught this issue since the code was only needed definitions from the acero header and was not relying on any actual compiled symbols.  However, I think setting up tests to catch this sort of invalid include are beyond the scope of this PR.

### Are there any user-facing changes?

No.
* Closes: #36641