### PR TITLE
GH-36601: [MATLAB] Add a MATLAB "type traits" class hierarchy

### DIFF
--- a/matlab/src/matlab/+arrow/+type/+traits/BooleanTraits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/BooleanTraits.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef BooleanTraits < arrow.type.traits.Traits
+classdef BooleanTraits < arrow.type.traits.TypeTraits
 
     properties (Constant)
         ArrayConstructor = @arrow.array.BooleanArray

--- a/matlab/src/matlab/+arrow/+type/+traits/BooleanTraits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/BooleanTraits.m
@@ -1,3 +1,18 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
 classdef BooleanTraits < arrow.type.traits.Traits
 
     properties (Constant)

--- a/matlab/src/matlab/+arrow/+type/+traits/BooleanTraits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/BooleanTraits.m
@@ -1,0 +1,14 @@
+classdef BooleanTraits < arrow.type.traits.Traits
+
+    properties (Constant)
+        ArrayConstructor = @arrow.array.BooleanArray
+        ArrayClassName = "arrow.array.BooleanArray"
+        ArrayProxyClassName = "arrow.array.proxy.BooleanArray"
+        TypeConstructor = @arrow.type.BooleanType;
+        TypeClassName = "arrow.type.BooleanType"
+        TypeProxyClassName = "arrow.type.proxy.BooleanType"
+        MatlabConstructor = @logical
+        MatlabClassName = "logical"
+    end
+
+end

--- a/matlab/src/matlab/+arrow/+type/+traits/Float32Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Float32Traits.m
@@ -1,0 +1,14 @@
+classdef Float32Traits < arrow.type.traits.Traits
+
+    properties (Constant)
+        ArrayConstructor = @arrow.array.Float32Array
+        ArrayClassName = "arrow.array.Float32Array"
+        ArrayProxyClassName = "arrow.array.proxy.Float32Array"
+        TypeConstructor = @arrow.type.Float32Type;
+        TypeClassName = "arrow.type.Float32Type"
+        TypeProxyClassName = "arrow.type.proxy.Float32Type"
+        MatlabConstructor = @single
+        MatlabClassName = "single"
+    end
+
+end

--- a/matlab/src/matlab/+arrow/+type/+traits/Float32Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Float32Traits.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef Float32Traits < arrow.type.traits.Traits
+classdef Float32Traits < arrow.type.traits.TypeTraits
 
     properties (Constant)
         ArrayConstructor = @arrow.array.Float32Array

--- a/matlab/src/matlab/+arrow/+type/+traits/Float32Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Float32Traits.m
@@ -1,3 +1,18 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
 classdef Float32Traits < arrow.type.traits.Traits
 
     properties (Constant)

--- a/matlab/src/matlab/+arrow/+type/+traits/Float64Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Float64Traits.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef Float64Traits < arrow.type.traits.Traits
+classdef Float64Traits < arrow.type.traits.TypeTraits
 
     properties (Constant)
         ArrayConstructor = @arrow.array.Float64Array

--- a/matlab/src/matlab/+arrow/+type/+traits/Float64Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Float64Traits.m
@@ -1,3 +1,18 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
 classdef Float64Traits < arrow.type.traits.Traits
 
     properties (Constant)

--- a/matlab/src/matlab/+arrow/+type/+traits/Float64Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Float64Traits.m
@@ -1,0 +1,14 @@
+classdef Float64Traits < arrow.type.traits.Traits
+
+    properties (Constant)
+        ArrayConstructor = @arrow.array.Float64Array
+        ArrayClassName = "arrow.array.Float64Array"
+        ArrayProxyClassName = "arrow.array.proxy.Float64Array"
+        TypeConstructor = @arrow.type.Float64Type;
+        TypeClassName = "arrow.type.Float64Type"
+        TypeProxyClassName = "arrow.type.proxy.Float64Type"
+        MatlabConstructor = @double
+        MatlabClassName = "double"
+    end
+
+end

--- a/matlab/src/matlab/+arrow/+type/+traits/Int16Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Int16Traits.m
@@ -1,3 +1,18 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
 classdef Int16Traits < arrow.type.traits.Traits
 
     properties (Constant)

--- a/matlab/src/matlab/+arrow/+type/+traits/Int16Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Int16Traits.m
@@ -22,8 +22,8 @@ classdef Int16Traits < arrow.type.traits.Traits
         TypeConstructor = @arrow.type.Int16Type;
         TypeClassName = "arrow.type.Int16Type"
         TypeProxyClassName = "arrow.type.proxy.Int16Type"
-        MatlabConstructor = @uint16
-        MatlabClassName = "uint16"
+        MatlabConstructor = @int16
+        MatlabClassName = "int16"
     end
 
 end

--- a/matlab/src/matlab/+arrow/+type/+traits/Int16Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Int16Traits.m
@@ -1,0 +1,14 @@
+classdef Int16Traits < arrow.type.traits.Traits
+
+    properties (Constant)
+        ArrayConstructor = @arrow.array.Int16Array
+        ArrayClassName = "arrow.array.Int16Array"
+        ArrayProxyClassName = "arrow.array.proxy.Int16Array"
+        TypeConstructor = @arrow.type.Int16Type;
+        TypeClassName = "arrow.type.Int16Type"
+        TypeProxyClassName = "arrow.type.proxy.Int16Type"
+        MatlabConstructor = @uint16
+        MatlabClassName = "uint16"
+    end
+
+end

--- a/matlab/src/matlab/+arrow/+type/+traits/Int16Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Int16Traits.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef Int16Traits < arrow.type.traits.Traits
+classdef Int16Traits < arrow.type.traits.TypeTraits
 
     properties (Constant)
         ArrayConstructor = @arrow.array.Int16Array

--- a/matlab/src/matlab/+arrow/+type/+traits/Int32Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Int32Traits.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef Int32Traits < arrow.type.traits.Traits
+classdef Int32Traits < arrow.type.traits.TypeTraits
 
     properties (Constant)
         ArrayConstructor = @arrow.array.Int32Array

--- a/matlab/src/matlab/+arrow/+type/+traits/Int32Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Int32Traits.m
@@ -1,0 +1,14 @@
+classdef Int32Traits < arrow.type.traits.Traits
+
+    properties (Constant)
+        ArrayConstructor = @arrow.array.Int32Array
+        ArrayClassName = "arrow.array.Int32Array"
+        ArrayProxyClassName = "arrow.array.proxy.Int32Array"
+        TypeConstructor = @arrow.type.Int32Type;
+        TypeClassName = "arrow.type.Int32Type"
+        TypeProxyClassName = "arrow.type.proxy.Int32Type"
+        MatlabConstructor = @uint32
+        MatlabClassName = "uint32"
+    end
+
+end

--- a/matlab/src/matlab/+arrow/+type/+traits/Int32Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Int32Traits.m
@@ -1,3 +1,18 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
 classdef Int32Traits < arrow.type.traits.Traits
 
     properties (Constant)

--- a/matlab/src/matlab/+arrow/+type/+traits/Int32Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Int32Traits.m
@@ -22,8 +22,8 @@ classdef Int32Traits < arrow.type.traits.Traits
         TypeConstructor = @arrow.type.Int32Type;
         TypeClassName = "arrow.type.Int32Type"
         TypeProxyClassName = "arrow.type.proxy.Int32Type"
-        MatlabConstructor = @uint32
-        MatlabClassName = "uint32"
+        MatlabConstructor = @int32
+        MatlabClassName = "int32"
     end
 
 end

--- a/matlab/src/matlab/+arrow/+type/+traits/Int64Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Int64Traits.m
@@ -22,8 +22,8 @@ classdef Int64Traits < arrow.type.traits.Traits
         TypeConstructor = @arrow.type.Int64Type;
         TypeClassName = "arrow.type.Int64Type"
         TypeProxyClassName = "arrow.type.proxy.Int64Type"
-        MatlabConstructor = @uint64
-        MatlabClassName = "uint64"
+        MatlabConstructor = @int64
+        MatlabClassName = "int64"
     end
 
 end

--- a/matlab/src/matlab/+arrow/+type/+traits/Int64Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Int64Traits.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef Int64Traits < arrow.type.traits.Traits
+classdef Int64Traits < arrow.type.traits.TypeTraits
 
     properties (Constant)
         ArrayConstructor = @arrow.array.Int64Array

--- a/matlab/src/matlab/+arrow/+type/+traits/Int64Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Int64Traits.m
@@ -1,0 +1,14 @@
+classdef Int64Traits < arrow.type.traits.Traits
+
+    properties (Constant)
+        ArrayConstructor = @arrow.array.Int64Array
+        ArrayClassName = "arrow.array.Int64Array"
+        ArrayProxyClassName = "arrow.array.proxy.Int64Array"
+        TypeConstructor = @arrow.type.Int64Type;
+        TypeClassName = "arrow.type.Int64Type"
+        TypeProxyClassName = "arrow.type.proxy.Int64Type"
+        MatlabConstructor = @uint64
+        MatlabClassName = "uint64"
+    end
+
+end

--- a/matlab/src/matlab/+arrow/+type/+traits/Int64Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Int64Traits.m
@@ -1,3 +1,18 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
 classdef Int64Traits < arrow.type.traits.Traits
 
     properties (Constant)

--- a/matlab/src/matlab/+arrow/+type/+traits/Int8Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Int8Traits.m
@@ -1,0 +1,14 @@
+classdef Int8Traits < arrow.type.traits.Traits
+
+    properties (Constant)
+        ArrayConstructor = @arrow.array.Int8Array
+        ArrayClassName = "arrow.array.Int8Array"
+        ArrayProxyClassName = "arrow.array.proxy.Int8Array"
+        TypeConstructor = @arrow.type.Int8Type;
+        TypeClassName = "arrow.type.Int8Type"
+        TypeProxyClassName = "arrow.type.proxy.Int8Type"
+        MatlabConstructor = @int8
+        MatlabClassName = "int8"
+    end
+
+end

--- a/matlab/src/matlab/+arrow/+type/+traits/Int8Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Int8Traits.m
@@ -1,3 +1,18 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
 classdef Int8Traits < arrow.type.traits.Traits
 
     properties (Constant)

--- a/matlab/src/matlab/+arrow/+type/+traits/Int8Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Int8Traits.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef Int8Traits < arrow.type.traits.Traits
+classdef Int8Traits < arrow.type.traits.TypeTraits
 
     properties (Constant)
         ArrayConstructor = @arrow.array.Int8Array

--- a/matlab/src/matlab/+arrow/+type/+traits/StringTraits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/StringTraits.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef StringTraits < arrow.type.traits.Traits
+classdef StringTraits < arrow.type.traits.TypeTraits
 
     properties (Constant)
         ArrayConstructor = @arrow.array.StringArray

--- a/matlab/src/matlab/+arrow/+type/+traits/StringTraits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/StringTraits.m
@@ -1,3 +1,18 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
 classdef StringTraits < arrow.type.traits.Traits
 
     properties (Constant)

--- a/matlab/src/matlab/+arrow/+type/+traits/StringTraits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/StringTraits.m
@@ -1,0 +1,14 @@
+classdef StringTraits < arrow.type.traits.Traits
+
+    properties (Constant)
+        ArrayConstructor = @arrow.array.StringArray
+        ArrayClassName = "arrow.array.StringArray"
+        ArrayProxyClassName = "arrow.array.proxy.StringArray"
+        TypeConstructor = @arrow.type.StringType;
+        TypeClassName = "arrow.type.StringType"
+        TypeProxyClassName = "arrow.type.proxy.StringType"
+        MatlabConstructor = @string
+        MatlabClassName = "string"
+    end
+
+end

--- a/matlab/src/matlab/+arrow/+type/+traits/TimestampTraits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/TimestampTraits.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef TimestampTraits < arrow.type.traits.Traits
+classdef TimestampTraits < arrow.type.traits.TypeTraits
 
     properties (Constant)
         ArrayConstructor = @arrow.array.TimestampArray

--- a/matlab/src/matlab/+arrow/+type/+traits/TimestampTraits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/TimestampTraits.m
@@ -1,0 +1,14 @@
+classdef TimestampTraits < arrow.type.traits.Traits
+
+    properties (Constant)
+        ArrayConstructor = @arrow.array.TimestampArray
+        ArrayClassName = "arrow.array.TimestampArray"
+        ArrayProxyClassName = "arrow.array.proxy.TimestampArray"
+        TypeConstructor = @arrow.type.TimestampType;
+        TypeClassName = "arrow.type.TimestampType"
+        TypeProxyClassName = "arrow.type.proxy.TimestampType"
+        MatlabConstructor = @datetime
+        MatlabClassName = "datetime"
+    end
+
+end

--- a/matlab/src/matlab/+arrow/+type/+traits/TimestampTraits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/TimestampTraits.m
@@ -1,3 +1,18 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
 classdef TimestampTraits < arrow.type.traits.Traits
 
     properties (Constant)

--- a/matlab/src/matlab/+arrow/+type/+traits/Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Traits.m
@@ -1,0 +1,14 @@
+classdef Traits
+
+    properties (Abstract, Constant)
+        ArrayConstructor
+        ArrayClassName
+        ArrayProxyClassName
+        TypeConstructor
+        TypeClassName
+        TypeProxyClassName
+        MatlabConstructor
+        MatlabClassName
+    end
+
+end

--- a/matlab/src/matlab/+arrow/+type/+traits/Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Traits.m
@@ -1,3 +1,18 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
 classdef Traits
 
     properties (Abstract, Constant)

--- a/matlab/src/matlab/+arrow/+type/+traits/TypeTraits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/TypeTraits.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef Traits
+classdef TypeTraits
 
     properties (Abstract, Constant)
         ArrayConstructor

--- a/matlab/src/matlab/+arrow/+type/+traits/UInt16Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/UInt16Traits.m
@@ -1,3 +1,18 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
 classdef UInt16Traits < arrow.type.traits.Traits
 
     properties (Constant)

--- a/matlab/src/matlab/+arrow/+type/+traits/UInt16Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/UInt16Traits.m
@@ -1,0 +1,14 @@
+classdef UInt16Traits < arrow.type.traits.Traits
+
+    properties (Constant)
+        ArrayConstructor = @arrow.array.UInt16Array
+        ArrayClassName = "arrow.array.UInt16Array"
+        ArrayProxyClassName = "arrow.array.proxy.UInt16Array"
+        TypeConstructor = @arrow.type.UInt16Type;
+        TypeClassName = "arrow.type.UInt16Type"
+        TypeProxyClassName = "arrow.type.proxy.UInt16Type"
+        MatlabConstructor = @uint16
+        MatlabClassName = "uint16"
+    end
+
+end

--- a/matlab/src/matlab/+arrow/+type/+traits/UInt16Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/UInt16Traits.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef UInt16Traits < arrow.type.traits.Traits
+classdef UInt16Traits < arrow.type.traits.TypeTraits
 
     properties (Constant)
         ArrayConstructor = @arrow.array.UInt16Array

--- a/matlab/src/matlab/+arrow/+type/+traits/UInt32Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/UInt32Traits.m
@@ -1,0 +1,14 @@
+classdef UInt32Traits < arrow.type.traits.Traits
+
+    properties (Constant)
+        ArrayConstructor = @arrow.array.UInt32Array
+        ArrayClassName = "arrow.array.UInt32Array"
+        ArrayProxyClassName = "arrow.array.proxy.UInt32Array"
+        TypeConstructor = @arrow.type.UInt32Type;
+        TypeClassName = "arrow.type.UInt32Type"
+        TypeProxyClassName = "arrow.type.proxy.UInt32Type"
+        MatlabConstructor = @uint32
+        MatlabClassName = "uint32"
+    end
+
+end

--- a/matlab/src/matlab/+arrow/+type/+traits/UInt32Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/UInt32Traits.m
@@ -1,3 +1,18 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
 classdef UInt32Traits < arrow.type.traits.Traits
 
     properties (Constant)

--- a/matlab/src/matlab/+arrow/+type/+traits/UInt32Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/UInt32Traits.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef UInt32Traits < arrow.type.traits.Traits
+classdef UInt32Traits < arrow.type.traits.TypeTraits
 
     properties (Constant)
         ArrayConstructor = @arrow.array.UInt32Array

--- a/matlab/src/matlab/+arrow/+type/+traits/UInt64Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/UInt64Traits.m
@@ -1,0 +1,14 @@
+classdef UInt64Traits < arrow.type.traits.Traits
+
+    properties (Constant)
+        ArrayConstructor = @arrow.array.UInt64Array
+        ArrayClassName = "arrow.array.UInt64Array"
+        ArrayProxyClassName = "arrow.array.proxy.UInt64Array"
+        TypeConstructor = @arrow.type.UInt64Type;
+        TypeClassName = "arrow.type.UInt64Type"
+        TypeProxyClassName = "arrow.type.proxy.UInt64Type"
+        MatlabConstructor = @uint64
+        MatlabClassName = "uint64"
+    end
+
+end

--- a/matlab/src/matlab/+arrow/+type/+traits/UInt64Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/UInt64Traits.m
@@ -1,3 +1,18 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
 classdef UInt64Traits < arrow.type.traits.Traits
 
     properties (Constant)

--- a/matlab/src/matlab/+arrow/+type/+traits/UInt64Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/UInt64Traits.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef UInt64Traits < arrow.type.traits.Traits
+classdef UInt64Traits < arrow.type.traits.TypeTraits
 
     properties (Constant)
         ArrayConstructor = @arrow.array.UInt64Array

--- a/matlab/src/matlab/+arrow/+type/+traits/UInt8Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/UInt8Traits.m
@@ -1,3 +1,18 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
 classdef UInt8Traits < arrow.type.traits.Traits
 
     properties (Constant)

--- a/matlab/src/matlab/+arrow/+type/+traits/UInt8Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/UInt8Traits.m
@@ -1,0 +1,14 @@
+classdef UInt8Traits < arrow.type.traits.Traits
+
+    properties (Constant)
+        ArrayConstructor = @arrow.array.UInt8Array
+        ArrayClassName = "arrow.array.UInt8Array"
+        ArrayProxyClassName = "arrow.array.proxy.UInt8Array"
+        TypeConstructor = @arrow.type.UInt8Type;
+        TypeClassName = "arrow.type.UInt8Type"
+        TypeProxyClassName = "arrow.type.proxy.UInt8Type"
+        MatlabConstructor = @uint8
+        MatlabClassName = "uint8"
+    end
+
+end

--- a/matlab/src/matlab/+arrow/+type/+traits/UInt8Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/UInt8Traits.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef UInt8Traits < arrow.type.traits.Traits
+classdef UInt8Traits < arrow.type.traits.TypeTraits
 
     properties (Constant)
         ArrayConstructor = @arrow.array.UInt8Array

--- a/matlab/src/matlab/+arrow/+type/+traits/traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/traits.m
@@ -1,0 +1,39 @@
+function typeTraits = traits(type)
+    arguments
+        type(1,1) arrow.type.Type
+    end
+    
+    import arrow.type.traits.*
+    typeClass = string(class(type));
+    
+    switch typeClass
+        case "arrow.type.UInt8Type"
+            typeTraits = UInt8Traits();
+        case "arrow.type.UInt16Type"
+            typeTraits = UInt16Traits();
+        case "arrow.type.UInt32Type"
+            typeTraits = UInt32Traits();
+        case "arrow.type.UInt64Type"
+            typeTraits = UInt64Traits();
+        case "arrow.type.Int8Type"
+            typeTraits = Int8Traits();
+        case "arrow.type.Int16Type"
+            typeTraits = Int16Traits();
+        case "arrow.type.Int32Type"
+            typeTraits = Int32Traits();
+        case "arrow.type.Int64Type"
+            typeTraits = Int64Traits();
+        case "arrow.type.Float32Type"
+            typeTraits = Float32Traits();
+        case "arrow.type.Float64Type"
+            typeTraits = Float64Traits();
+        case "arrow.type.BooleanType"
+            typeTraits = BooleanTraits();
+        case "arrow.type.StringType"
+            typeTraits = StringTraits();
+        case "arrow.type.TimestampType"
+            typeTraits = TimestampTraits();
+        otherwise
+            error("arrow:type:traits:UnknownType", "Unknown type: " + typeClass);
+    end
+end

--- a/matlab/src/matlab/+arrow/+type/+traits/traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/traits.m
@@ -14,41 +14,73 @@
 % permissions and limitations under the License.
 
 function typeTraits = traits(type)
-    arguments
-        type(1,1) arrow.type.Type
-    end
-    
+    % "Gateway" function that links an arrow Type ID enumeration (e.g.
+    % arrow.type.ID.String) or a MATLAB class string (e.g. "datetime")
+    % to associated type and array information.
     import arrow.type.traits.*
-    typeClass = string(class(type));
+    import arrow.type.*
     
-    switch typeClass
-        case "arrow.type.UInt8Type"
-            typeTraits = UInt8Traits();
-        case "arrow.type.UInt16Type"
-            typeTraits = UInt16Traits();
-        case "arrow.type.UInt32Type"
-            typeTraits = UInt32Traits();
-        case "arrow.type.UInt64Type"
-            typeTraits = UInt64Traits();
-        case "arrow.type.Int8Type"
-            typeTraits = Int8Traits();
-        case "arrow.type.Int16Type"
-            typeTraits = Int16Traits();
-        case "arrow.type.Int32Type"
-            typeTraits = Int32Traits();
-        case "arrow.type.Int64Type"
-            typeTraits = Int64Traits();
-        case "arrow.type.Float32Type"
-            typeTraits = Float32Traits();
-        case "arrow.type.Float64Type"
-            typeTraits = Float64Traits();
-        case "arrow.type.BooleanType"
-            typeTraits = BooleanTraits();
-        case "arrow.type.StringType"
-            typeTraits = StringTraits();
-        case "arrow.type.TimestampType"
-            typeTraits = TimestampTraits();
-        otherwise
-            error("arrow:type:traits:UnknownType", "Unknown type: " + typeClass);
+    if isa(type, "arrow.type.ID")
+        switch type
+            case ID.UInt8
+                typeTraits = UInt8Traits();
+            case ID.UInt16
+                typeTraits = UInt16Traits();
+            case ID.UInt32
+                typeTraits = UInt32Traits();
+            case ID.UInt64
+                typeTraits = UInt64Traits();
+            case ID.Int8
+                typeTraits = Int8Traits();
+            case ID.Int16
+                typeTraits = Int16Traits();
+            case ID.Int32
+                typeTraits = Int32Traits();
+            case ID.Int64
+                typeTraits = Int64Traits();
+            case ID.Float32
+                typeTraits = Float32Traits();
+            case ID.Float64
+                typeTraits = Float64Traits();
+            case ID.Boolean
+                typeTraits = BooleanTraits();
+            case ID.String
+                typeTraits = StringTraits();
+            case ID.Timestamp
+                typeTraits = TimestampTraits();
+            otherwise
+                error("arrow:type:traits:UnsupportedArrowTypeID", "Unsupported Arrow type ID: " + type);
+        end
+    elseif isa(type, "string") % MATLAB class string
+        switch type
+            case "uint8"
+                typeTraits = UInt8Traits();
+            case "uint16"
+                typeTraits = UInt16Traits();
+            case "uint32"
+                typeTraits = UInt32Traits();
+            case "uint64"
+                typeTraits = UInt64Traits();
+            case "int8"
+                typeTraits = Int8Traits();
+            case "int16"
+                typeTraits = Int16Traits();
+            case "int32"
+                typeTraits = Int32Traits();
+            case "int64"
+                typeTraits = Int64Traits();
+            case "single"
+                typeTraits = Float32Traits();
+            case "double"
+                typeTraits = Float64Traits();
+            case "logical"
+                typeTraits = BooleanTraits();
+            case "string"
+                typeTraits = StringTraits();
+            case "datetime"
+                typeTraits = TimestampTraits();
+            otherwise
+                error("arrow:type:traits:UnsupportedMatlabClass", "Unsupported MATLAB class: " + type);
+        end
     end
 end

--- a/matlab/src/matlab/+arrow/+type/+traits/traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/traits.m
@@ -1,3 +1,18 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
 function typeTraits = traits(type)
     arguments
         type(1,1) arrow.type.Type

--- a/matlab/src/matlab/+arrow/+type/+traits/traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/traits.m
@@ -16,7 +16,7 @@
 function typeTraits = traits(type)
     % "Gateway" function that links an arrow Type ID enumeration (e.g.
     % arrow.type.ID.String) or a MATLAB class string (e.g. "datetime")
-    % to associated type and array information.
+    % to associated type information.
     import arrow.type.traits.*
     import arrow.type.*
     
@@ -82,5 +82,8 @@ function typeTraits = traits(type)
             otherwise
                 error("arrow:type:traits:UnsupportedMatlabClass", "Unsupported MATLAB class: " + type);
         end
+    else
+        error("arrow:type:traits:UnsupportedInputType", "The input argument to the traits function " + ...
+                                                        "must be a MATLAB class string or an arrow.type.ID enumeration.");
     end
 end

--- a/matlab/src/matlab/+arrow/+type/Type.m
+++ b/matlab/src/matlab/+arrow/+type/Type.m
@@ -19,5 +19,6 @@ classdef Type
     properties (Abstract, SetAccess=protected)
         ID(1, 1) arrow.type.ID
     end
+    
 end
 

--- a/matlab/test/arrow/type/traits/hTraits.m
+++ b/matlab/test/arrow/type/traits/hTraits.m
@@ -14,7 +14,7 @@
 % permissions and limitations under the License.
 
 classdef hTraits < matlab.unittest.TestCase
-% Superclass for tests that validate the behavior of "type trait objects"
+% Superclass for tests that validate the behavior of "type trait" objects
 % like arrow.type.traits.StringTraits.
 
     properties (Abstract)

--- a/matlab/test/arrow/type/traits/hTraits.m
+++ b/matlab/test/arrow/type/traits/hTraits.m
@@ -1,0 +1,67 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef hTraits < matlab.unittest.TestCase
+
+    properties (Abstract)
+        TraitsConstructor
+        ArrayConstructor
+        ArrayClassName
+        ArrayProxyClassName
+        TypeConstructor
+        TypeClassName
+        TypeProxyClassName
+        MatlabConstructor
+        MatlabClassName
+    end
+
+    properties
+        Traits
+    end
+
+    methods (TestMethodSetup)
+        function setupTraits(testCase)
+            testCase.Traits = testCase.TraitsConstructor();
+        end
+    end
+
+    methods(Test)
+        function TestArrayConstructor(testCase)
+            testCase.verifyEqual(testCase.Traits.ArrayConstructor, testCase.ArrayConstructor);
+        end
+        function TestArrayClassName(testCase)
+            testCase.verifyEqual(testCase.Traits.ArrayClassName, testCase.ArrayClassName);
+        end
+        function TestArrayProxyClassName(testCase)
+            testCase.verifyEqual(testCase.Traits.ArrayProxyClassName, testCase.ArrayProxyClassName);
+        end
+        function TestTypeConstructor(testCase)
+            testCase.verifyEqual(testCase.Traits.TypeConstructor, testCase.TypeConstructor);
+        end
+        function TestTypeClassName(testCase)
+            testCase.verifyEqual(testCase.Traits.TypeClassName, testCase.TypeClassName);
+        end
+        function TestTypeProxyClassName(testCase)
+            testCase.verifyEqual(testCase.Traits.TypeProxyClassName, testCase.TypeProxyClassName);
+        end
+        function TestMatlabConstructor(testCase)
+            testCase.verifyEqual(testCase.Traits.MatlabConstructor, testCase.MatlabConstructor);
+        end
+        function TestMatlabClassName(testCase)
+            testCase.verifyEqual(testCase.Traits.MatlabClassName, testCase.MatlabClassName);
+        end
+    end
+
+end

--- a/matlab/test/arrow/type/traits/hTraits.m
+++ b/matlab/test/arrow/type/traits/hTraits.m
@@ -14,6 +14,8 @@
 % permissions and limitations under the License.
 
 classdef hTraits < matlab.unittest.TestCase
+% Superclass for tests that validate the behavior of "type trait objects"
+% like arrow.type.traits.StringTraits.
 
     properties (Abstract)
         TraitsConstructor
@@ -38,30 +40,39 @@ classdef hTraits < matlab.unittest.TestCase
     end
 
     methods(Test)
+
         function TestArrayConstructor(testCase)
             testCase.verifyEqual(testCase.Traits.ArrayConstructor, testCase.ArrayConstructor);
         end
+
         function TestArrayClassName(testCase)
             testCase.verifyEqual(testCase.Traits.ArrayClassName, testCase.ArrayClassName);
         end
+
         function TestArrayProxyClassName(testCase)
             testCase.verifyEqual(testCase.Traits.ArrayProxyClassName, testCase.ArrayProxyClassName);
         end
+
         function TestTypeConstructor(testCase)
             testCase.verifyEqual(testCase.Traits.TypeConstructor, testCase.TypeConstructor);
         end
+        
         function TestTypeClassName(testCase)
             testCase.verifyEqual(testCase.Traits.TypeClassName, testCase.TypeClassName);
         end
+
         function TestTypeProxyClassName(testCase)
             testCase.verifyEqual(testCase.Traits.TypeProxyClassName, testCase.TypeProxyClassName);
         end
+
         function TestMatlabConstructor(testCase)
             testCase.verifyEqual(testCase.Traits.MatlabConstructor, testCase.MatlabConstructor);
         end
+
         function TestMatlabClassName(testCase)
             testCase.verifyEqual(testCase.Traits.MatlabClassName, testCase.MatlabClassName);
         end
+        
     end
 
 end

--- a/matlab/test/arrow/type/traits/hTypeTraits.m
+++ b/matlab/test/arrow/type/traits/hTypeTraits.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef hTraits < matlab.unittest.TestCase
+classdef hTypeTraits < matlab.unittest.TestCase
 % Superclass for tests that validate the behavior of "type trait" objects
 % like arrow.type.traits.StringTraits.
 

--- a/matlab/test/arrow/type/traits/tBooleanTraits.m
+++ b/matlab/test/arrow/type/traits/tBooleanTraits.m
@@ -13,18 +13,18 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tStringTraits < hTraits
+classdef tBooleanTraits < hTraits
 
     properties
-        TraitsConstructor = @arrow.type.traits.StringTraits
-        ArrayConstructor = @arrow.array.StringArray
-        ArrayClassName = "arrow.array.StringArray"
-        ArrayProxyClassName = "arrow.array.proxy.StringArray"
-        TypeConstructor = @arrow.type.StringType
-        TypeClassName = "arrow.type.StringType"
-        TypeProxyClassName = "arrow.type.proxy.StringType"
-        MatlabConstructor = @string
-        MatlabClassName = "string"
+        TraitsConstructor = @arrow.type.traits.BooleanTraits
+        ArrayConstructor = @arrow.array.BooleanArray
+        ArrayClassName = "arrow.array.BooleanArray"
+        ArrayProxyClassName = "arrow.array.proxy.BooleanArray"
+        TypeConstructor = @arrow.type.BooleanType
+        TypeClassName = "arrow.type.BooleanType"
+        TypeProxyClassName = "arrow.type.proxy.BooleanType"
+        MatlabConstructor = @logical
+        MatlabClassName = "logical"
     end
 
 end

--- a/matlab/test/arrow/type/traits/tBooleanTraits.m
+++ b/matlab/test/arrow/type/traits/tBooleanTraits.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tBooleanTraits < hTraits
+classdef tBooleanTraits < hTypeTraits
 
     properties
         TraitsConstructor = @arrow.type.traits.BooleanTraits

--- a/matlab/test/arrow/type/traits/tInt16Traits.m
+++ b/matlab/test/arrow/type/traits/tInt16Traits.m
@@ -13,18 +13,18 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tStringTraits < hTraits
+classdef tInt16Traits < hTraits
 
     properties
-        TraitsConstructor = @arrow.type.traits.StringTraits
-        ArrayConstructor = @arrow.array.StringArray
-        ArrayClassName = "arrow.array.StringArray"
-        ArrayProxyClassName = "arrow.array.proxy.StringArray"
-        TypeConstructor = @arrow.type.StringType
-        TypeClassName = "arrow.type.StringType"
-        TypeProxyClassName = "arrow.type.proxy.StringType"
-        MatlabConstructor = @string
-        MatlabClassName = "string"
+        TraitsConstructor = @arrow.type.traits.Int16Traits
+        ArrayConstructor = @arrow.array.Int16Array
+        ArrayClassName = "arrow.array.Int16Array"
+        ArrayProxyClassName = "arrow.array.proxy.Int16Array"
+        TypeConstructor = @arrow.type.Int16Type
+        TypeClassName = "arrow.type.Int16Type"
+        TypeProxyClassName = "arrow.type.proxy.Int16Type"
+        MatlabConstructor = @uint16
+        MatlabClassName = "uint16"
     end
 
 end

--- a/matlab/test/arrow/type/traits/tInt16Traits.m
+++ b/matlab/test/arrow/type/traits/tInt16Traits.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tInt16Traits < hTraits
+classdef tInt16Traits < hTypeTraits
 
     properties
         TraitsConstructor = @arrow.type.traits.Int16Traits

--- a/matlab/test/arrow/type/traits/tInt16Traits.m
+++ b/matlab/test/arrow/type/traits/tInt16Traits.m
@@ -23,8 +23,8 @@ classdef tInt16Traits < hTraits
         TypeConstructor = @arrow.type.Int16Type
         TypeClassName = "arrow.type.Int16Type"
         TypeProxyClassName = "arrow.type.proxy.Int16Type"
-        MatlabConstructor = @uint16
-        MatlabClassName = "uint16"
+        MatlabConstructor = @int16
+        MatlabClassName = "int16"
     end
 
 end

--- a/matlab/test/arrow/type/traits/tInt32Traits.m
+++ b/matlab/test/arrow/type/traits/tInt32Traits.m
@@ -23,8 +23,8 @@ classdef tInt32Traits < hTraits
         TypeConstructor = @arrow.type.Int32Type
         TypeClassName = "arrow.type.Int32Type"
         TypeProxyClassName = "arrow.type.proxy.Int32Type"
-        MatlabConstructor = @uint32
-        MatlabClassName = "uint32"
+        MatlabConstructor = @int32
+        MatlabClassName = "int32"
     end
 
 end

--- a/matlab/test/arrow/type/traits/tInt32Traits.m
+++ b/matlab/test/arrow/type/traits/tInt32Traits.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tInt32Traits < hTraits
+classdef tInt32Traits < hTypeTraits
 
     properties
         TraitsConstructor = @arrow.type.traits.Int32Traits

--- a/matlab/test/arrow/type/traits/tInt32Traits.m
+++ b/matlab/test/arrow/type/traits/tInt32Traits.m
@@ -13,18 +13,18 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tStringTraits < hTraits
+classdef tInt32Traits < hTraits
 
     properties
-        TraitsConstructor = @arrow.type.traits.StringTraits
-        ArrayConstructor = @arrow.array.StringArray
-        ArrayClassName = "arrow.array.StringArray"
-        ArrayProxyClassName = "arrow.array.proxy.StringArray"
-        TypeConstructor = @arrow.type.StringType
-        TypeClassName = "arrow.type.StringType"
-        TypeProxyClassName = "arrow.type.proxy.StringType"
-        MatlabConstructor = @string
-        MatlabClassName = "string"
+        TraitsConstructor = @arrow.type.traits.Int32Traits
+        ArrayConstructor = @arrow.array.Int32Array
+        ArrayClassName = "arrow.array.Int32Array"
+        ArrayProxyClassName = "arrow.array.proxy.Int32Array"
+        TypeConstructor = @arrow.type.Int32Type
+        TypeClassName = "arrow.type.Int32Type"
+        TypeProxyClassName = "arrow.type.proxy.Int32Type"
+        MatlabConstructor = @uint32
+        MatlabClassName = "uint32"
     end
 
 end

--- a/matlab/test/arrow/type/traits/tInt64Traits.m
+++ b/matlab/test/arrow/type/traits/tInt64Traits.m
@@ -13,18 +13,18 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tStringTraits < hTraits
+classdef tInt64Traits < hTraits
 
     properties
-        TraitsConstructor = @arrow.type.traits.StringTraits
-        ArrayConstructor = @arrow.array.StringArray
-        ArrayClassName = "arrow.array.StringArray"
-        ArrayProxyClassName = "arrow.array.proxy.StringArray"
-        TypeConstructor = @arrow.type.StringType
-        TypeClassName = "arrow.type.StringType"
-        TypeProxyClassName = "arrow.type.proxy.StringType"
-        MatlabConstructor = @string
-        MatlabClassName = "string"
+        TraitsConstructor = @arrow.type.traits.Int64Traits
+        ArrayConstructor = @arrow.array.Int64Array
+        ArrayClassName = "arrow.array.Int64Array"
+        ArrayProxyClassName = "arrow.array.proxy.Int64Array"
+        TypeConstructor = @arrow.type.Int64Type
+        TypeClassName = "arrow.type.Int64Type"
+        TypeProxyClassName = "arrow.type.proxy.Int64Type"
+        MatlabConstructor = @uint64
+        MatlabClassName = "uint64"
     end
 
 end

--- a/matlab/test/arrow/type/traits/tInt64Traits.m
+++ b/matlab/test/arrow/type/traits/tInt64Traits.m
@@ -23,8 +23,8 @@ classdef tInt64Traits < hTraits
         TypeConstructor = @arrow.type.Int64Type
         TypeClassName = "arrow.type.Int64Type"
         TypeProxyClassName = "arrow.type.proxy.Int64Type"
-        MatlabConstructor = @uint64
-        MatlabClassName = "uint64"
+        MatlabConstructor = @int64
+        MatlabClassName = "int64"
     end
 
 end

--- a/matlab/test/arrow/type/traits/tInt64Traits.m
+++ b/matlab/test/arrow/type/traits/tInt64Traits.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tInt64Traits < hTraits
+classdef tInt64Traits < hTypeTraits
 
     properties
         TraitsConstructor = @arrow.type.traits.Int64Traits

--- a/matlab/test/arrow/type/traits/tInt8Traits.m
+++ b/matlab/test/arrow/type/traits/tInt8Traits.m
@@ -13,18 +13,18 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tStringTraits < hTraits
+classdef tInt8Traits < hTraits
 
     properties
-        TraitsConstructor = @arrow.type.traits.StringTraits
-        ArrayConstructor = @arrow.array.StringArray
-        ArrayClassName = "arrow.array.StringArray"
-        ArrayProxyClassName = "arrow.array.proxy.StringArray"
-        TypeConstructor = @arrow.type.StringType
-        TypeClassName = "arrow.type.StringType"
-        TypeProxyClassName = "arrow.type.proxy.StringType"
-        MatlabConstructor = @string
-        MatlabClassName = "string"
+        TraitsConstructor = @arrow.type.traits.Int8Traits
+        ArrayConstructor = @arrow.array.Int8Array
+        ArrayClassName = "arrow.array.Int8Array"
+        ArrayProxyClassName = "arrow.array.proxy.Int8Array"
+        TypeConstructor = @arrow.type.Int8Type
+        TypeClassName = "arrow.type.Int8Type"
+        TypeProxyClassName = "arrow.type.proxy.Int8Type"
+        MatlabConstructor = @int8
+        MatlabClassName = "int8"
     end
 
 end

--- a/matlab/test/arrow/type/traits/tInt8Traits.m
+++ b/matlab/test/arrow/type/traits/tInt8Traits.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tInt8Traits < hTraits
+classdef tInt8Traits < hTypeTraits
 
     properties
         TraitsConstructor = @arrow.type.traits.Int8Traits

--- a/matlab/test/arrow/type/traits/tStringTraits.m
+++ b/matlab/test/arrow/type/traits/tStringTraits.m
@@ -1,0 +1,30 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef tStringTraits < hTraits
+
+    properties
+        TraitsConstructor = @arrow.type.traits.StringTraits
+        ArrayConstructor = @arrow.array.StringArray
+        ArrayClassName = "arrow.array.StringArray"
+        ArrayProxyClassName = "arrow.array.proxy.StringArray"
+        TypeConstructor = @arrow.type.StringType;
+        TypeClassName = "arrow.type.StringType"
+        TypeProxyClassName = "arrow.type.proxy.StringType"
+        MatlabConstructor = @string
+        MatlabClassName = "string"
+    end
+
+end

--- a/matlab/test/arrow/type/traits/tStringTraits.m
+++ b/matlab/test/arrow/type/traits/tStringTraits.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tStringTraits < hTraits
+classdef tStringTraits < hTypeTraits
 
     properties
         TraitsConstructor = @arrow.type.traits.StringTraits

--- a/matlab/test/arrow/type/traits/tTimestampTraits.m
+++ b/matlab/test/arrow/type/traits/tTimestampTraits.m
@@ -13,18 +13,18 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tStringTraits < hTraits
+classdef tTimestampTraits < hTraits
 
     properties
-        TraitsConstructor = @arrow.type.traits.StringTraits
-        ArrayConstructor = @arrow.array.StringArray
-        ArrayClassName = "arrow.array.StringArray"
-        ArrayProxyClassName = "arrow.array.proxy.StringArray"
-        TypeConstructor = @arrow.type.StringType
-        TypeClassName = "arrow.type.StringType"
-        TypeProxyClassName = "arrow.type.proxy.StringType"
-        MatlabConstructor = @string
-        MatlabClassName = "string"
+        TraitsConstructor = @arrow.type.traits.TimestampTraits
+        ArrayConstructor = @arrow.array.TimestampArray
+        ArrayClassName = "arrow.array.TimestampArray"
+        ArrayProxyClassName = "arrow.array.proxy.TimestampArray"
+        TypeConstructor = @arrow.type.TimestampType
+        TypeClassName = "arrow.type.TimestampType"
+        TypeProxyClassName = "arrow.type.proxy.TimestampType"
+        MatlabConstructor = @datetime
+        MatlabClassName = "datetime"
     end
 
 end

--- a/matlab/test/arrow/type/traits/tTimestampTraits.m
+++ b/matlab/test/arrow/type/traits/tTimestampTraits.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tTimestampTraits < hTraits
+classdef tTimestampTraits < hTypeTraits
 
     properties
         TraitsConstructor = @arrow.type.traits.TimestampTraits

--- a/matlab/test/arrow/type/traits/tUInt16Traits.m
+++ b/matlab/test/arrow/type/traits/tUInt16Traits.m
@@ -13,18 +13,18 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tStringTraits < hTraits
+classdef tUInt16Traits < hTraits
 
     properties
-        TraitsConstructor = @arrow.type.traits.StringTraits
-        ArrayConstructor = @arrow.array.StringArray
-        ArrayClassName = "arrow.array.StringArray"
-        ArrayProxyClassName = "arrow.array.proxy.StringArray"
-        TypeConstructor = @arrow.type.StringType
-        TypeClassName = "arrow.type.StringType"
-        TypeProxyClassName = "arrow.type.proxy.StringType"
-        MatlabConstructor = @string
-        MatlabClassName = "string"
+        TraitsConstructor = @arrow.type.traits.UInt16Traits
+        ArrayConstructor = @arrow.array.UInt16Array
+        ArrayClassName = "arrow.array.UInt16Array"
+        ArrayProxyClassName = "arrow.array.proxy.UInt16Array"
+        TypeConstructor = @arrow.type.UInt16Type
+        TypeClassName = "arrow.type.UInt16Type"
+        TypeProxyClassName = "arrow.type.proxy.UInt16Type"
+        MatlabConstructor = @uint16
+        MatlabClassName = "uint16"
     end
 
 end

--- a/matlab/test/arrow/type/traits/tUInt16Traits.m
+++ b/matlab/test/arrow/type/traits/tUInt16Traits.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tUInt16Traits < hTraits
+classdef tUInt16Traits < hTypeTraits
 
     properties
         TraitsConstructor = @arrow.type.traits.UInt16Traits

--- a/matlab/test/arrow/type/traits/tUInt32Traits.m
+++ b/matlab/test/arrow/type/traits/tUInt32Traits.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tUInt32Traits < hTraits
+classdef tUInt32Traits < hTypeTraits
 
     properties
         TraitsConstructor = @arrow.type.traits.UInt32Traits

--- a/matlab/test/arrow/type/traits/tUInt32Traits.m
+++ b/matlab/test/arrow/type/traits/tUInt32Traits.m
@@ -13,18 +13,18 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tStringTraits < hTraits
+classdef tUInt32Traits < hTraits
 
     properties
-        TraitsConstructor = @arrow.type.traits.StringTraits
-        ArrayConstructor = @arrow.array.StringArray
-        ArrayClassName = "arrow.array.StringArray"
-        ArrayProxyClassName = "arrow.array.proxy.StringArray"
-        TypeConstructor = @arrow.type.StringType
-        TypeClassName = "arrow.type.StringType"
-        TypeProxyClassName = "arrow.type.proxy.StringType"
-        MatlabConstructor = @string
-        MatlabClassName = "string"
+        TraitsConstructor = @arrow.type.traits.UInt32Traits
+        ArrayConstructor = @arrow.array.UInt32Array
+        ArrayClassName = "arrow.array.UInt32Array"
+        ArrayProxyClassName = "arrow.array.proxy.UInt32Array"
+        TypeConstructor = @arrow.type.UInt32Type
+        TypeClassName = "arrow.type.UInt32Type"
+        TypeProxyClassName = "arrow.type.proxy.UInt32Type"
+        MatlabConstructor = @uint32
+        MatlabClassName = "uint32"
     end
 
 end

--- a/matlab/test/arrow/type/traits/tUInt64Traits.m
+++ b/matlab/test/arrow/type/traits/tUInt64Traits.m
@@ -13,18 +13,18 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tStringTraits < hTraits
+classdef tUInt64Traits < hTraits
 
     properties
-        TraitsConstructor = @arrow.type.traits.StringTraits
-        ArrayConstructor = @arrow.array.StringArray
-        ArrayClassName = "arrow.array.StringArray"
-        ArrayProxyClassName = "arrow.array.proxy.StringArray"
-        TypeConstructor = @arrow.type.StringType
-        TypeClassName = "arrow.type.StringType"
-        TypeProxyClassName = "arrow.type.proxy.StringType"
-        MatlabConstructor = @string
-        MatlabClassName = "string"
+        TraitsConstructor = @arrow.type.traits.UInt64Traits
+        ArrayConstructor = @arrow.array.UInt64Array
+        ArrayClassName = "arrow.array.UInt64Array"
+        ArrayProxyClassName = "arrow.array.proxy.UInt64Array"
+        TypeConstructor = @arrow.type.UInt64Type
+        TypeClassName = "arrow.type.UInt64Type"
+        TypeProxyClassName = "arrow.type.proxy.UInt64Type"
+        MatlabConstructor = @uint64
+        MatlabClassName = "uint64"
     end
 
 end

--- a/matlab/test/arrow/type/traits/tUInt64Traits.m
+++ b/matlab/test/arrow/type/traits/tUInt64Traits.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tUInt64Traits < hTraits
+classdef tUInt64Traits < hTypeTraits
 
     properties
         TraitsConstructor = @arrow.type.traits.UInt64Traits

--- a/matlab/test/arrow/type/traits/tUInt8Traits.m
+++ b/matlab/test/arrow/type/traits/tUInt8Traits.m
@@ -13,18 +13,18 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tStringTraits < hTraits
+classdef tUInt8Traits < hTraits
 
     properties
-        TraitsConstructor = @arrow.type.traits.StringTraits
-        ArrayConstructor = @arrow.array.StringArray
-        ArrayClassName = "arrow.array.StringArray"
-        ArrayProxyClassName = "arrow.array.proxy.StringArray"
-        TypeConstructor = @arrow.type.StringType
-        TypeClassName = "arrow.type.StringType"
-        TypeProxyClassName = "arrow.type.proxy.StringType"
-        MatlabConstructor = @string
-        MatlabClassName = "string"
+        TraitsConstructor = @arrow.type.traits.UInt8Traits
+        ArrayConstructor = @arrow.array.UInt8Array
+        ArrayClassName = "arrow.array.UInt8Array"
+        ArrayProxyClassName = "arrow.array.proxy.UInt8Array"
+        TypeConstructor = @arrow.type.UInt8Type
+        TypeClassName = "arrow.type.UInt8Type"
+        TypeProxyClassName = "arrow.type.proxy.UInt8Type"
+        MatlabConstructor = @uint8
+        MatlabClassName = "uint8"
     end
 
 end

--- a/matlab/test/arrow/type/traits/tUInt8Traits.m
+++ b/matlab/test/arrow/type/traits/tUInt8Traits.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tUInt8Traits < hTraits
+classdef tUInt8Traits < hTypeTraits
 
     properties
         TraitsConstructor = @arrow.type.traits.UInt8Traits

--- a/matlab/test/arrow/type/traits/ttraits.m
+++ b/matlab/test/arrow/type/traits/ttraits.m
@@ -302,6 +302,19 @@ classdef ttraits < matlab.unittest.TestCase
             testCase.verifyError(@() traits(type), "arrow:type:traits:UnsupportedMatlabClass");
         end
 
+        function TestErrorIfUnsupportedInputType(testCase)
+            import arrow.type.traits.*
+
+            type = 123;
+            testCase.verifyError(@() traits(type), "arrow:type:traits:UnsupportedInputType");
+
+            type = {'double'};
+            testCase.verifyError(@() traits(type), "arrow:type:traits:UnsupportedInputType");
+
+            type = datetime(2023, 1, 1);
+            testCase.verifyError(@() traits(type), "arrow:type:traits:UnsupportedInputType");
+        end
+
     end
 
 end

--- a/matlab/test/arrow/type/traits/ttraits.m
+++ b/matlab/test/arrow/type/traits/ttraits.m
@@ -14,7 +14,7 @@
 % permissions and limitations under the License.
 
 classdef ttraits < matlab.unittest.TestCase
-    % Tests for the traits "gateway" function.
+    % Tests for the traits (i.e. arrow.type.traits.traits) "gateway" function.
 
     methods(Test)
 

--- a/matlab/test/arrow/type/traits/ttraits.m
+++ b/matlab/test/arrow/type/traits/ttraits.m
@@ -14,137 +14,292 @@
 % permissions and limitations under the License.
 
 classdef ttraits < matlab.unittest.TestCase
-    % Tests for the traits (i.e. arrow.type.traits.traits) "gateway" function.
+    % Tests for the type traits (i.e. arrow.type.traits.traits)
+    % "gateway" function.
 
     methods(Test)
 
-        function TestUInt8Type(testCase)
+        function TestUInt8(testCase)
             import arrow.type.traits.*
+            import arrow.type.*
 
-            type = arrow.type.UInt8Type();
-            expectedTraits = arrow.type.traits.UInt8Traits();
+            typeID = ID.UInt8;
+            expectedTraits = UInt8Traits();
+
+            actualTraits = traits(typeID);
+
+            testCase.verifyEqual(actualTraits, expectedTraits);
+        end
+
+        function TestUInt16(testCase)
+            import arrow.type.traits.*
+            import arrow.type.*
+
+            type = ID.UInt16;
+            expectedTraits = UInt16Traits();
 
             actualTraits = traits(type);
 
             testCase.verifyEqual(actualTraits, expectedTraits);
         end
 
-        function TestUInt16Type(testCase)
+        function TestUInt32(testCase)
             import arrow.type.traits.*
+            import arrow.type.*
 
-            type = arrow.type.UInt16Type();
-            expectedTraits = arrow.type.traits.UInt16Traits();
+            type = ID.UInt32;
+            expectedTraits = UInt32Traits();
 
             actualTraits = traits(type);
 
             testCase.verifyEqual(actualTraits, expectedTraits);
         end
 
-        function TestUInt32Type(testCase)
+        function TestUInt64(testCase)
             import arrow.type.traits.*
+            import arrow.type.*
 
-            type = arrow.type.UInt32Type();
-            expectedTraits = arrow.type.traits.UInt32Traits();
+            type = ID.UInt64;
+            expectedTraits = UInt64Traits();
 
             actualTraits = traits(type);
 
             testCase.verifyEqual(actualTraits, expectedTraits);
         end
 
-        function TestUInt64Type(testCase)
+        function TestInt8(testCase)
             import arrow.type.traits.*
+            import arrow.type.*
 
-            type = arrow.type.UInt64Type();
-            expectedTraits = arrow.type.traits.UInt64Traits();
+            type = ID.Int8;
+            expectedTraits = Int8Traits();
 
             actualTraits = traits(type);
 
             testCase.verifyEqual(actualTraits, expectedTraits);
         end
 
-        function TestInt8Type(testCase)
+        function TestInt16(testCase)
             import arrow.type.traits.*
+            import arrow.type.*
 
-            type = arrow.type.Int8Type();
-            expectedTraits = arrow.type.traits.Int8Traits();
+            type = ID.Int16;
+            expectedTraits = Int16Traits();
 
             actualTraits = traits(type);
 
             testCase.verifyEqual(actualTraits, expectedTraits);
         end
 
-        function TestInt16Type(testCase)
+        function TestInt32(testCase)
             import arrow.type.traits.*
+            import arrow.type.*
 
-            type = arrow.type.Int16Type();
-            expectedTraits = arrow.type.traits.Int16Traits();
-
-            actualTraits = traits(type);
-
-            testCase.verifyEqual(actualTraits, expectedTraits);
-        end
-
-        function TestInt32Type(testCase)
-            import arrow.type.traits.*
-
-            type = arrow.type.Int32Type();
-            expectedTraits = arrow.type.traits.Int32Traits();
+            type = ID.Int32;
+            expectedTraits = Int32Traits();
 
             actualTraits = traits(type);
 
             testCase.verifyEqual(actualTraits, expectedTraits);
         end
         
-        function TestInt64Type(testCase)
+        function TestInt64(testCase)
             import arrow.type.traits.*
+            import arrow.type.*
 
-            type = arrow.type.Int64Type();
-            expectedTraits = arrow.type.traits.Int64Traits();
+            type = ID.Int64;
+            expectedTraits = Int64Traits();
 
             actualTraits = traits(type);
 
             testCase.verifyEqual(actualTraits, expectedTraits);
         end
 
-        function TestStringType(testCase)
+        function TestString(testCase)
             import arrow.type.traits.*
+            import arrow.type.*
 
-            type = arrow.type.StringType();
-            expectedTraits = arrow.type.traits.StringTraits();
+            type = ID.String;
+            expectedTraits = StringTraits();
 
             actualTraits = traits(type);
 
             testCase.verifyEqual(actualTraits, expectedTraits);
         end
 
-        function TestTimestampType(testCase)
+        function TestTimestamp(testCase)
             import arrow.type.traits.*
+            import arrow.type.*
 
-            type = arrow.type.TimestampType();
-            expectedTraits = arrow.type.traits.TimestampTraits();
+            type = ID.Timestamp;
+            expectedTraits = TimestampTraits();
 
             actualTraits = traits(type);
 
             testCase.verifyEqual(actualTraits, expectedTraits);
         end
 
-        function TestBooleanType(testCase)
+        function TestBoolean(testCase)
             import arrow.type.traits.*
+            import arrow.type.*
 
-            type = arrow.type.BooleanType();
-            expectedTraits = arrow.type.traits.BooleanTraits();
+            type = ID.Boolean;
+            expectedTraits = BooleanTraits();
 
             actualTraits = traits(type);
 
             testCase.verifyEqual(actualTraits, expectedTraits);
         end
 
-        function TestErrorIfNotType(testCase)
+        function TestMatlabUInt8(testCase)
             import arrow.type.traits.*
 
-            type = "not-a-type";
+            type = "uint8";
+            expectedTraits = UInt8Traits();
 
-            testCase.verifyError(@() traits(type), "MATLAB:validation:UnableToConvert");
+            actualTraits = traits(type);
+
+            testCase.verifyEqual(actualTraits, expectedTraits);
+        end
+
+        function TestMatlabUInt16(testCase)
+            import arrow.type.traits.*
+
+            type = "uint16";
+            expectedTraits = UInt16Traits();
+
+            actualTraits = traits(type);
+
+            testCase.verifyEqual(actualTraits, expectedTraits);
+        end
+
+        function TestMatlabUInt32(testCase)
+            import arrow.type.traits.*
+
+            type = "uint32";
+            expectedTraits = UInt32Traits();
+
+            actualTraits = traits(type);
+
+            testCase.verifyEqual(actualTraits, expectedTraits);
+        end
+
+        function TestMatlabUInt64(testCase)
+            import arrow.type.traits.*
+
+            type = "uint64";
+            expectedTraits = UInt64Traits();
+
+            actualTraits = traits(type);
+
+            testCase.verifyEqual(actualTraits, expectedTraits);
+        end
+
+        function TestMatlabInt8(testCase)
+            import arrow.type.traits.*
+
+            type = "int8";
+            expectedTraits = Int8Traits();
+
+            actualTraits = traits(type);
+
+            testCase.verifyEqual(actualTraits, expectedTraits);
+        end
+
+        function TestMatlabInt16(testCase)
+            import arrow.type.traits.*
+
+            type = "int16";
+            expectedTraits = Int16Traits();
+
+            actualTraits = traits(type);
+
+            testCase.verifyEqual(actualTraits, expectedTraits);
+        end
+
+        function TestMatlabInt32(testCase)
+            import arrow.type.traits.*
+
+            type = "int32";
+            expectedTraits = Int32Traits();
+
+            actualTraits = traits(type);
+
+            testCase.verifyEqual(actualTraits, expectedTraits);
+        end
+
+        function TestMatlabInt64(testCase)
+            import arrow.type.traits.*
+
+            type = "int64";
+            expectedTraits = Int64Traits();
+
+            actualTraits = traits(type);
+
+            testCase.verifyEqual(actualTraits, expectedTraits);
+        end
+
+        function TestMatlabSingle(testCase)
+            import arrow.type.traits.*
+
+            type = "single";
+            expectedTraits = Float32Traits();
+
+            actualTraits = traits(type);
+
+            testCase.verifyEqual(actualTraits, expectedTraits);
+        end
+
+        function TestMatlabDouble(testCase)
+            import arrow.type.traits.*
+
+            type = "double";
+            expectedTraits = Float64Traits();
+
+            actualTraits = traits(type);
+
+            testCase.verifyEqual(actualTraits, expectedTraits);
+        end
+
+        function TestMatlabLogical(testCase)
+            import arrow.type.traits.*
+
+            type = "logical";
+            expectedTraits = BooleanTraits();
+
+            actualTraits = traits(type);
+
+            testCase.verifyEqual(actualTraits, expectedTraits);
+        end
+
+        function TestMatlabString(testCase)
+            import arrow.type.traits.*
+
+            type = "string";
+            expectedTraits = StringTraits();
+
+            actualTraits = traits(type);
+
+            testCase.verifyEqual(actualTraits, expectedTraits);
+        end
+
+        function TestMatlabDatetime(testCase)
+            import arrow.type.traits.*
+
+            type = "datetime";
+            expectedTraits = TimestampTraits();
+
+            actualTraits = traits(type);
+
+            testCase.verifyEqual(actualTraits, expectedTraits);
+        end
+
+        function TestErrorIfUnsupportedMatlabClass(testCase)
+            import arrow.type.traits.*
+
+            type = "not-a-class";
+
+            testCase.verifyError(@() traits(type), "arrow:type:traits:UnsupportedMatlabClass");
         end
 
     end

--- a/matlab/test/arrow/type/traits/ttraits.m
+++ b/matlab/test/arrow/type/traits/ttraits.m
@@ -1,0 +1,152 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef ttraits < matlab.unittest.TestCase
+    % Tests for the traits "gateway" function.
+
+    methods(Test)
+
+        function TestUInt8Type(testCase)
+            import arrow.type.traits.*
+
+            type = arrow.type.UInt8Type();
+            expectedTraits = arrow.type.traits.UInt8Traits();
+
+            actualTraits = traits(type);
+
+            testCase.verifyEqual(actualTraits, expectedTraits);
+        end
+
+        function TestUInt16Type(testCase)
+            import arrow.type.traits.*
+
+            type = arrow.type.UInt16Type();
+            expectedTraits = arrow.type.traits.UInt16Traits();
+
+            actualTraits = traits(type);
+
+            testCase.verifyEqual(actualTraits, expectedTraits);
+        end
+
+        function TestUInt32Type(testCase)
+            import arrow.type.traits.*
+
+            type = arrow.type.UInt32Type();
+            expectedTraits = arrow.type.traits.UInt32Traits();
+
+            actualTraits = traits(type);
+
+            testCase.verifyEqual(actualTraits, expectedTraits);
+        end
+
+        function TestUInt64Type(testCase)
+            import arrow.type.traits.*
+
+            type = arrow.type.UInt64Type();
+            expectedTraits = arrow.type.traits.UInt64Traits();
+
+            actualTraits = traits(type);
+
+            testCase.verifyEqual(actualTraits, expectedTraits);
+        end
+
+        function TestInt8Type(testCase)
+            import arrow.type.traits.*
+
+            type = arrow.type.Int8Type();
+            expectedTraits = arrow.type.traits.Int8Traits();
+
+            actualTraits = traits(type);
+
+            testCase.verifyEqual(actualTraits, expectedTraits);
+        end
+
+        function TestInt16Type(testCase)
+            import arrow.type.traits.*
+
+            type = arrow.type.Int16Type();
+            expectedTraits = arrow.type.traits.Int16Traits();
+
+            actualTraits = traits(type);
+
+            testCase.verifyEqual(actualTraits, expectedTraits);
+        end
+
+        function TestInt32Type(testCase)
+            import arrow.type.traits.*
+
+            type = arrow.type.Int32Type();
+            expectedTraits = arrow.type.traits.Int32Traits();
+
+            actualTraits = traits(type);
+
+            testCase.verifyEqual(actualTraits, expectedTraits);
+        end
+        
+        function TestInt64Type(testCase)
+            import arrow.type.traits.*
+
+            type = arrow.type.Int64Type();
+            expectedTraits = arrow.type.traits.Int64Traits();
+
+            actualTraits = traits(type);
+
+            testCase.verifyEqual(actualTraits, expectedTraits);
+        end
+
+        function TestStringType(testCase)
+            import arrow.type.traits.*
+
+            type = arrow.type.StringType();
+            expectedTraits = arrow.type.traits.StringTraits();
+
+            actualTraits = traits(type);
+
+            testCase.verifyEqual(actualTraits, expectedTraits);
+        end
+
+        function TestTimestampType(testCase)
+            import arrow.type.traits.*
+
+            type = arrow.type.TimestampType();
+            expectedTraits = arrow.type.traits.TimestampTraits();
+
+            actualTraits = traits(type);
+
+            testCase.verifyEqual(actualTraits, expectedTraits);
+        end
+
+        function TestBooleanType(testCase)
+            import arrow.type.traits.*
+
+            type = arrow.type.BooleanType();
+            expectedTraits = arrow.type.traits.BooleanTraits();
+
+            actualTraits = traits(type);
+
+            testCase.verifyEqual(actualTraits, expectedTraits);
+        end
+
+        function TestErrorIfNotType(testCase)
+            import arrow.type.traits.*
+
+            type = "not-a-type";
+
+            testCase.verifyError(@() traits(type), "MATLAB:validation:UnableToConvert");
+        end
+
+    end
+
+end


### PR DESCRIPTION
### Rationale for this change

To make it easier to write generic code for `arrow.array.Array` and associated objects in the MATLAB interface, it would be helpful to have some kind of ["type traits"-like](https://github.com/apache/arrow/blob/d676078c13a02ad920eeea2acd5fa517f14526e2/cpp/src/arrow/type_traits.h#L105) objects (e.g. `arrow.type.traits.StringTraits`, `arrow.type.traits.UInt8Traits`, etc.).

These "type traits" objects would help centralize various type-specific information in one place (e.g. MATLAB `double` <-> `arrow.type.Float64Type` <-> `arrow.array.Float64Array`), simplifying generic client code.

This would help reduce the number of "switch-like" statements across the MATLAB code base that branch based on type.

### What changes are included in this PR?

1. Added new `arrow.type.traits.TypeTraits` classes (e.g. `arrow.type.traits.UInt8Traits` and `arrow.type.traits.StringTraits`).
2. Added new `arrow.type.traits.traits` "gateway" function for creating "type traits" objects from MATLAB class strings (e.g. `"double"` or `"datetime"`) and `arrow.type.ID` enumeration values (e.g. `arrow.type.ID.Timestamp` or `arrow.type.ID.UInt8`).

### Are these changes tested?

Yes.

1. Added MATLAB tests for the new `arrow.type.traits.TypeTraits` classes.
2. Added MATLAB tests  (`ttraits.m`) for the new `arrow.type.traits.traits` "gateway" function. 

### Are there any user-facing changes?

Yes.

There are now MATLAB "type traits" classes that can be used to simplify writing generic client code that switches based on type.

**Note**: It may make sense to eventually mark these "type traits" APIs as "internal" so that they aren't encouraged to be used by client code outside of the MATLAB interface. The "type traits" classes expose some implementation details such as the `Proxy` classes that are used under the hood to represent a given `Array` object in C++.

**Example**

```matlab
% Construct a "type traits" object from an arrow.type.ID enumeration value
>> logicalTraits = arrow.type.traits.traits(arrow.type.ID.Boolean)

logicalTraits = 

  BooleanTraits with properties:

       ArrayConstructor: @arrow.array.BooleanArray
         ArrayClassName: "arrow.array.BooleanArray"
    ArrayProxyClassName: "arrow.array.proxy.BooleanArray"
        TypeConstructor: @arrow.type.BooleanType
          TypeClassName: "arrow.type.BooleanType"
     TypeProxyClassName: "arrow.type.proxy.BooleanType"
      MatlabConstructor: @logical
        MatlabClassName: "logical"

% Construct a "type traits" object from a MATLAB class string
>> stringTraits = arrow.type.traits.traits("string")

stringTraits = 

  StringTraits with properties:

       ArrayConstructor: @arrow.array.StringArray
         ArrayClassName: "arrow.array.StringArray"
    ArrayProxyClassName: "arrow.array.proxy.StringArray"
        TypeConstructor: @arrow.type.StringType
          TypeClassName: "arrow.type.StringType"
     TypeProxyClassName: "arrow.type.proxy.StringType"
      MatlabConstructor: @string
        MatlabClassName: "string"
```

### Future Directions

1. Re-implement `switch` statement in `RecordBatch` code to use "type traits" classes instead.
2. Look for more opportunties to leverage "type traits" to simplify code in the MATLAB interface.

### Notes

1. Thanks @sgilmore10 for your help with this pull request! 
* Closes: #36601