### PR TITLE
GH-36659: [Python] Fix pyarrow.dataset.Partitioning.__eq__ when comparing with other type

### DIFF
--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -2348,10 +2348,9 @@ cdef class Partitioning(_Weakrefable):
         return self.wrapped
 
     def __eq__(self, other):
-        try:
+        if isinstance(other, Partitioning):
             return self.partitioning.Equals(deref((<Partitioning>other).unwrap()))
-        except TypeError:
-            return False
+        return False
 
     def parse(self, path):
         cdef CResult[CExpression] result

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -589,6 +589,7 @@ def test_partitioning():
         partitioning = klass(schema)
         assert isinstance(partitioning, ds.Partitioning)
         assert partitioning == klass(schema)
+        assert partitioning != "other object"
 
     schema = pa.schema([
         pa.field('group', pa.int64()),


### PR DESCRIPTION
### Rationale for this change

Ensure that `part == other` doesn't crash with `other` is not a Partitioning instance

Small follow-up on https://github.com/apache/arrow/pull/36462

* Closes: #36659