### PR TITLE
GH-35942: [C++] Improve Decimal ToReal accuracy

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -1025,7 +1025,8 @@ TEST(Cast, DecimalToFloating) {
     }
   }
 
-  // Edge cases are tested for Decimal128::ToReal() and Decimal256::ToReal()
+  // Edge cases are tested for Decimal128::ToReal() and Decimal256::ToReal() in
+  // decimal_test.cc
 }
 
 TEST(Cast, DecimalToString) {

--- a/cpp/src/arrow/util/basic_decimal.cc
+++ b/cpp/src/arrow/util/basic_decimal.cc
@@ -969,6 +969,16 @@ bool BasicDecimal256::FitsInPrecision(int32_t precision) const {
   return BasicDecimal256::Abs(*this) < kDecimal256PowersOfTen[precision];
 }
 
+void BasicDecimal256::GetWholeAndFraction(int scale, BasicDecimal256* whole,
+                                          BasicDecimal256* fraction) const {
+  DCHECK_GE(scale, 0);
+  DCHECK_LE(scale, 76);
+
+  BasicDecimal256 multiplier(kDecimal256PowersOfTen[scale]);
+  auto s = Divide(multiplier, whole, fraction);
+  DCHECK_EQ(s, DecimalStatus::kSuccess);
+}
+
 const BasicDecimal256& BasicDecimal256::GetScaleMultiplier(int32_t scale) {
   DCHECK_GE(scale, 0);
   DCHECK_LE(scale, 76);

--- a/cpp/src/arrow/util/basic_decimal.h
+++ b/cpp/src/arrow/util/basic_decimal.h
@@ -366,6 +366,10 @@ class ARROW_EXPORT BasicDecimal256 : public GenericBasicDecimal<BasicDecimal256,
   /// \brief Get the lowest bits of the two's complement representation of the number.
   uint64_t low_bits() const { return bit_util::little_endian::Make(array_)[0]; }
 
+  /// \brief separate the integer and fractional parts for the given scale.
+  void GetWholeAndFraction(int32_t scale, BasicDecimal256* whole,
+                           BasicDecimal256* fraction) const;
+
   /// \brief Scale multiplier for given scale value.
   static const BasicDecimal256& GetScaleMultiplier(int32_t scale);
   /// \brief Half-scale multiplier for given scale value.

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -1016,7 +1016,7 @@ struct Decimal256RealConversion
   /// Here "exact value" means the closest representable value by Real.
   template <typename Real>
   static Real ToRealPositive(const Decimal256& decimal, int32_t scale) {
-    const auto parts_le = bit_util::little_endian::Make(decimal.native_endian_array());
+    const auto parts_le = decimal.little_endian_array();
     if (scale <= 0 || (parts_le[3] == 0 && parts_le[2] == 0 && parts_le[1] == 0 &&
                        parts_le[0] < RealTraits<Real>::kMaxPreciseInteger)) {
       // No need to split the decimal if it is already an integer (scale <= 0) or if it

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -313,6 +313,13 @@ struct Decimal128RealConversion
     return x;
   }
 
+  /// An appoximate conversion from Decimal128 to Real that guarantees:
+  /// 1. If the decimal is an integer, the conversion is exact.
+  /// 2. If the number of fractional digits is <= RealTraits<Real>::kMantissaDigits (e.g.
+  ///    8 for float and 16 for double), the conversion is within 1 ULP of the exact value
+  /// 3. Otherwise, the conversion is within 2^(-RealTraits<Real>::kMantissaDigits+1)
+  ///    (e.g. 2^-23 for float and 2^-52 for double) of the exact value
+  /// Here "exact" means the closest representable value by Real.
   template <typename Real>
   static Real ToRealPositive(const Decimal128& decimal, int32_t scale) {
     if (scale <= 0 || (decimal.high_bits() == 0 &&
@@ -999,6 +1006,13 @@ struct Decimal256RealConversion
     return x;
   }
 
+  /// An appoximate conversion from Decimal128 to Real that guarantees:
+  /// 1. If the decimal is an integer, the conversion is exact.
+  /// 2. If the number of fractional digits is <= RealTraits<Real>::kMantissaDigits (e.g.
+  ///    8 for float and 16 for double), the conversion is within 1 ULP of the exact value
+  /// 3. Otherwise, the conversion is within 2^(-RealTraits<Real>::kMantissaDigits+1)
+  ///    (e.g. 2^-23 for float and 2^-52 for double) of the exact value
+  /// Here "exact" means the closest representable value by Real.
   template <typename Real>
   static Real ToRealPositive(const Decimal256& decimal, int32_t scale) {
     const auto parts_le = bit_util::little_endian::Make(decimal.native_endian_array());

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -309,7 +309,6 @@ struct Decimal128RealConversion
     Real x = RealTraits<Real>::two_to_64(static_cast<Real>(decimal.high_bits()));
     x += static_cast<Real>(decimal.low_bits());
     x *= LargePowerOfTen<Real>(-scale);
-
     return x;
   }
 

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -316,10 +316,11 @@ struct Decimal128RealConversion
   /// An appoximate conversion from Decimal128 to Real that guarantees:
   /// 1. If the decimal is an integer, the conversion is exact.
   /// 2. If the number of fractional digits is <= RealTraits<Real>::kMantissaDigits (e.g.
-  ///    8 for float and 16 for double), the conversion is within 1 ULP of the exact value
+  ///    8 for float and 16 for double), the conversion is within 1 ULP of the exact
+  ///    value.
   /// 3. Otherwise, the conversion is within 2^(-RealTraits<Real>::kMantissaDigits+1)
-  ///    (e.g. 2^-23 for float and 2^-52 for double) of the exact value
-  /// Here "exact" means the closest representable value by Real.
+  ///    (e.g. 2^-23 for float and 2^-52 for double) of the exact value.
+  /// Here "exact value" means the closest representable value by Real.
   template <typename Real>
   static Real ToRealPositive(const Decimal128& decimal, int32_t scale) {
     if (scale <= 0 || (decimal.high_bits() == 0 &&
@@ -1006,13 +1007,14 @@ struct Decimal256RealConversion
     return x;
   }
 
-  /// An appoximate conversion from Decimal128 to Real that guarantees:
+  /// An appoximate conversion from Decimal256 to Real that guarantees:
   /// 1. If the decimal is an integer, the conversion is exact.
   /// 2. If the number of fractional digits is <= RealTraits<Real>::kMantissaDigits (e.g.
-  ///    8 for float and 16 for double), the conversion is within 1 ULP of the exact value
+  ///    8 for float and 16 for double), the conversion is within 1 ULP of the exact
+  ///    value.
   /// 3. Otherwise, the conversion is within 2^(-RealTraits<Real>::kMantissaDigits+1)
-  ///    (e.g. 2^-23 for float and 2^-52 for double) of the exact value
-  /// Here "exact" means the closest representable value by Real.
+  ///    (e.g. 2^-23 for float and 2^-52 for double) of the exact value.
+  /// Here "exact value" means the closest representable value by Real.
   template <typename Real>
   static Real ToRealPositive(const Decimal256& decimal, int32_t scale) {
     const auto parts_le = bit_util::little_endian::Make(decimal.native_endian_array());

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -305,11 +305,31 @@ struct Decimal128RealConversion
   }
 
   template <typename Real>
-  static Real ToRealPositive(const Decimal128& decimal, int32_t scale) {
+  static Real ToRealPositiveNoSplit(const Decimal128& decimal, int32_t scale) {
     Real x = RealTraits<Real>::two_to_64(static_cast<Real>(decimal.high_bits()));
     x += static_cast<Real>(decimal.low_bits());
     x *= LargePowerOfTen<Real>(-scale);
+
     return x;
+  }
+
+  template <typename Real>
+  static Real ToRealPositive(const Decimal128& decimal, int32_t scale) {
+    if (scale <= 0 || (decimal.high_bits() == 0 &&
+                       decimal.low_bits() <= RealTraits<Real>::kMaxPreciseInteger)) {
+      // No need to split the decimal if it is already an integer (scale <= 0) or if it
+      // can be precisely represented by Real
+      return ToRealPositiveNoSplit<Real>(decimal, scale);
+    }
+
+    // Split decimal into whole and fractional parts to avoid precision loss
+    BasicDecimal128 whole_decimal, fraction_decimal;
+    decimal.GetWholeAndFraction(scale, &whole_decimal, &fraction_decimal);
+
+    Real whole = ToRealPositiveNoSplit<Real>(whole_decimal, 0);
+    Real fraction = ToRealPositiveNoSplit<Real>(fraction_decimal, scale);
+
+    return whole + fraction;
   }
 };
 
@@ -967,7 +987,7 @@ struct Decimal256RealConversion
   }
 
   template <typename Real>
-  static Real ToRealPositive(const Decimal256& decimal, int32_t scale) {
+  static Real ToRealPositiveNoSplit(const Decimal256& decimal, int32_t scale) {
     DCHECK_GE(decimal, 0);
     Real x = 0;
     const auto parts_le = bit_util::little_endian::Make(decimal.native_endian_array());
@@ -977,6 +997,25 @@ struct Decimal256RealConversion
     x += static_cast<Real>(parts_le[0]);
     x *= LargePowerOfTen<Real>(-scale);
     return x;
+  }
+
+  template <typename Real>
+  static Real ToRealPositive(const Decimal256& decimal, int32_t scale) {
+    const auto parts_le = bit_util::little_endian::Make(decimal.native_endian_array());
+    if (scale <= 0 || (parts_le[3] == 0 && parts_le[2] == 0 && parts_le[1] == 0 &&
+                       parts_le[0] < RealTraits<Real>::kMaxPreciseInteger)) {
+      // No need to split the decimal if it is already an integer (scale <= 0) or if it
+      // can be precisely represented by Real
+      return ToRealPositiveNoSplit<Real>(decimal, scale);
+    }
+
+    // Split the decimal into whole and fractional parts to avoid precision loss
+    BasicDecimal256 whole_decimal, fraction_decimal;
+    decimal.GetWholeAndFraction(scale, &whole_decimal, &fraction_decimal);
+
+    Real whole = ToRealPositiveNoSplit<Real>(whole_decimal, 0);
+    Real fraction = ToRealPositiveNoSplit<Real>(fraction_decimal, scale);
+    return whole + fraction;
   }
 };
 

--- a/cpp/src/arrow/util/decimal_internal.h
+++ b/cpp/src/arrow/util/decimal_internal.h
@@ -467,7 +467,7 @@ struct RealTraits<double> {
   // ceil(log10(2 ^ kMantissaBits))
   static constexpr int kMantissaDigits = 16;
   // Integers between zero and kMaxPreciseInteger can be precisely represented
-  static constexpr uint64_t kMaxPreciseInteger = 1ULL << kMantissaBits;
+  static constexpr uint64_t kMaxPreciseInteger = (1ULL << kMantissaBits) - 1;
 };
 
 template <typename DecimalType>

--- a/cpp/src/arrow/util/decimal_internal.h
+++ b/cpp/src/arrow/util/decimal_internal.h
@@ -451,6 +451,8 @@ struct RealTraits<float> {
   static constexpr int kMantissaBits = 24;
   // ceil(log10(2 ^ kMantissaBits))
   static constexpr int kMantissaDigits = 8;
+  // Integers between zero and kMaxPreciseInteger can be precisely represented
+  static constexpr uint64_t kMaxPreciseInteger = 1ULL << kMantissaBits;
 };
 
 template <>
@@ -464,6 +466,8 @@ struct RealTraits<double> {
   static constexpr int kMantissaBits = 53;
   // ceil(log10(2 ^ kMantissaBits))
   static constexpr int kMantissaDigits = 16;
+  // Integers between zero and kMaxPreciseInteger can be precisely represented
+  static constexpr uint64_t kMaxPreciseInteger = 1ULL << kMantissaBits;
 };
 
 template <typename DecimalType>

--- a/cpp/src/arrow/util/decimal_internal.h
+++ b/cpp/src/arrow/util/decimal_internal.h
@@ -452,7 +452,7 @@ struct RealTraits<float> {
   // ceil(log10(2 ^ kMantissaBits))
   static constexpr int kMantissaDigits = 8;
   // Integers between zero and kMaxPreciseInteger can be precisely represented
-  static constexpr uint64_t kMaxPreciseInteger = 1ULL << kMantissaBits;
+  static constexpr uint64_t kMaxPreciseInteger = (1ULL << kMantissaBits) - 1;
 };
 
 template <>

--- a/cpp/src/arrow/util/decimal_test.cc
+++ b/cpp/src/arrow/util/decimal_test.cc
@@ -1131,6 +1131,9 @@ class TestDecimalToReal : public ::testing::Test {
 
   // Test precision of conversions to float values
   void TestPrecision() {
+    static_assert(std::is_same_v<Real, float>,
+                  "double is tested in TestDecimalToRealDouble::Precision, not here");
+
     // 2**63 + 2**40 (exactly representable in a float's 24 bits of precision)
     CheckDecimalToReal<Decimal, Real>("9223373136366403584", 0, 9.223373e+18f);
     CheckDecimalToReal<Decimal, Real>("-9223373136366403584", 0, -9.223373e+18f);
@@ -1257,9 +1260,7 @@ TYPED_TEST(TestDecimalToRealDouble, Precision) {
   // Integers are always exact
   auto scale = TypeParam::kMaxScale - 1;
   std::string seven = "7.";
-  for (int32_t i = 0; i < scale; ++i) {
-    seven += "0";
-  }
+  seven.append(scale, '0');
   CheckDecimalToReal<TypeParam, double>(seven, scale, 7.0);
   CheckDecimalToReal<TypeParam, double>("-" + seven, scale, -7.0);
 

--- a/cpp/src/arrow/util/decimal_test.cc
+++ b/cpp/src/arrow/util/decimal_test.cc
@@ -1051,8 +1051,8 @@ void CheckDecimalToReal(const std::string& decimal_value, int32_t scale, Real ex
 }
 
 template <typename Decimal, typename Real>
-void CheckDecimalToRealWithinByOneULP(const std::string& decimal_value, int32_t scale,
-                                      Real expected) {
+void CheckDecimalToRealWithinOneULP(const std::string& decimal_value, int32_t scale,
+                                    Real expected) {
   Decimal dec(decimal_value);
   auto result = dec.template ToReal<Real>(scale);
   ASSERT_TRUE(result == expected || result == std::nextafter(expected, expected + 1) ||
@@ -1061,8 +1061,8 @@ void CheckDecimalToRealWithinByOneULP(const std::string& decimal_value, int32_t 
 }
 
 template <typename Decimal, typename Real>
-void CheckDecimalToRealWithinByEpsilon(const std::string& decimal_value, int32_t scale,
-                                       Real epsilon, Real expected) {
+void CheckDecimalToRealWithinEpsilon(const std::string& decimal_value, int32_t scale,
+                                     Real epsilon, Real expected) {
   Decimal dec(decimal_value);
   ASSERT_TRUE(std::abs(dec.template ToReal<Real>(scale) - expected) <= epsilon)
       << "Decimal value: " << decimal_value << " Scale: " << scale;
@@ -1153,18 +1153,17 @@ class TestDecimalToReal : public ::testing::Test {
                                       -99999999999999999999.0f);
 
     // Small fractions are within one ULP
-    CheckDecimalToRealWithinByOneULP<Decimal, Real>("9999999.9", 1, 9999999.9f);
-    CheckDecimalToRealWithinByOneULP<Decimal, Real>("-9999999.9", 1, -9999999.9f);
-    CheckDecimalToRealWithinByOneULP<Decimal, Real>("9999999.999999", 6, 9999999.999999f);
-    CheckDecimalToRealWithinByOneULP<Decimal, Real>("-9999999.999999", 6,
-                                                    -9999999.999999f);
+    CheckDecimalToRealWithinOneULP<Decimal, Real>("9999999.9", 1, 9999999.9f);
+    CheckDecimalToRealWithinOneULP<Decimal, Real>("-9999999.9", 1, -9999999.9f);
+    CheckDecimalToRealWithinOneULP<Decimal, Real>("9999999.999999", 6, 9999999.999999f);
+    CheckDecimalToRealWithinOneULP<Decimal, Real>("-9999999.999999", 6, -9999999.999999f);
 
     // Large fractions are within 2^-23
     constexpr Real epsilon = 1.1920928955078125e-07f;  // 2^-23
-    CheckDecimalToRealWithinByEpsilon<Decimal, Real>(
+    CheckDecimalToRealWithinEpsilon<Decimal, Real>(
         "112334829348925.99070703983306884765625", 23, epsilon,
         112334829348925.99070703983306884765625f);
-    CheckDecimalToRealWithinByEpsilon<Decimal, Real>(
+    CheckDecimalToRealWithinEpsilon<Decimal, Real>(
         "1.987748987892758765582589910934859345", 36, epsilon,
         1.987748987892758765582589910934859345f);
   }
@@ -1272,19 +1271,19 @@ TYPED_TEST(TestDecimalToRealDouble, Precision) {
                                         -99999999999999999999.0);
 
   // Small fractions are within one ULP
-  CheckDecimalToRealWithinByOneULP<TypeParam, double>("9999999.9", 1, 9999999.9);
-  CheckDecimalToRealWithinByOneULP<TypeParam, double>("-9999999.9", 1, -9999999.9);
-  CheckDecimalToRealWithinByOneULP<TypeParam, double>("9999999.999999999999999", 15,
-                                                      9999999.999999999999999);
-  CheckDecimalToRealWithinByOneULP<TypeParam, double>("-9999999.999999999999999", 15,
-                                                      -9999999.999999999999999);
+  CheckDecimalToRealWithinOneULP<TypeParam, double>("9999999.9", 1, 9999999.9);
+  CheckDecimalToRealWithinOneULP<TypeParam, double>("-9999999.9", 1, -9999999.9);
+  CheckDecimalToRealWithinOneULP<TypeParam, double>("9999999.999999999999999", 15,
+                                                    9999999.999999999999999);
+  CheckDecimalToRealWithinOneULP<TypeParam, double>("-9999999.999999999999999", 15,
+                                                    -9999999.999999999999999);
 
   // Large fractions are within 2^-52
   constexpr double epsilon = 2.220446049250313080847263336181640625e-16;  // 2^-52
-  CheckDecimalToRealWithinByEpsilon<TypeParam, double>(
+  CheckDecimalToRealWithinEpsilon<TypeParam, double>(
       "112334829348925.99070703983306884765625", 23, epsilon,
       112334829348925.99070703983306884765625);
-  CheckDecimalToRealWithinByEpsilon<TypeParam, double>(
+  CheckDecimalToRealWithinEpsilon<TypeParam, double>(
       "1.987748987892758765582589910934859345", 36, epsilon,
       1.987748987892758765582589910934859345);
 }

--- a/cpp/src/arrow/util/decimal_test.cc
+++ b/cpp/src/arrow/util/decimal_test.cc
@@ -1141,9 +1141,7 @@ class TestDecimalToReal : public ::testing::Test {
     // Integers are always exact
     auto scale = Decimal::kMaxScale - 1;
     std::string seven = "7.";
-    for (int32_t i = 0; i < scale; ++i) {
-      seven += "0";
-    }
+    seven.append(scale, '0');  // pad with trailing zeros
     CheckDecimalToReal<Decimal, Real>(seven, scale, 7.0f);
     CheckDecimalToReal<Decimal, Real>("-" + seven, scale, -7.0f);
 

--- a/cpp/src/arrow/util/decimal_test.cc
+++ b/cpp/src/arrow/util/decimal_test.cc
@@ -1129,11 +1129,6 @@ class TestDecimalToReal : public ::testing::Test {
     CheckDecimalToReal<Decimal, Real>("-" + seven, scale, -7.0f);
 
     // Decimal >= max mantisa integer
-
-    /** The following cases still fail because 9999999 * 1e-1 != 999999.9f
-      CheckDecimalToReal<Decimal, Real>("999999.9", 1, 999999.9);
-      CheckDecimalToReal<Decimal, Real>("-999999.9", 1, -999999.9);
-    */
     CheckDecimalToReal<Decimal, Real>("9999999.9", 1, 9999999.9);
     CheckDecimalToReal<Decimal, Real>("-9999999.9", 1, -9999999.9);
   }

--- a/cpp/src/arrow/util/decimal_test.cc
+++ b/cpp/src/arrow/util/decimal_test.cc
@@ -1128,89 +1128,79 @@ class TestDecimalToReal : public ::testing::Test {
       }
     }
   }
-
-  // Test precision of conversions to float values
-  void TestPrecision() {
-    static_assert(std::is_same_v<Real, float>,
-                  "double is tested in TestDecimalToRealDouble::Precision, not here");
-
-    // 2**63 + 2**40 (exactly representable in a float's 24 bits of precision)
-    CheckDecimalToReal<Decimal, Real>("9223373136366403584", 0, 9.223373e+18f);
-    CheckDecimalToReal<Decimal, Real>("-9223373136366403584", 0, -9.223373e+18f);
-    // 2**64 + 2**41 (exactly representable in a float)
-    CheckDecimalToReal<Decimal, Real>("18446746272732807168", 0, 1.8446746e+19f);
-    CheckDecimalToReal<Decimal, Real>("-18446746272732807168", 0, -1.8446746e+19f);
-
-    // Integers are always exact
-    auto scale = Decimal::kMaxScale - 1;
-    std::string seven = "7.";
-    seven.append(scale, '0');  // pad with trailing zeros
-    CheckDecimalToReal<Decimal, Real>(seven, scale, 7.0f);
-    CheckDecimalToReal<Decimal, Real>("-" + seven, scale, -7.0f);
-
-    CheckDecimalToReal<Decimal, Real>("99999999999999999999.0000000000000000", 16,
-                                      99999999999999999999.0f);
-    CheckDecimalToReal<Decimal, Real>("-99999999999999999999.0000000000000000", 16,
-                                      -99999999999999999999.0f);
-
-    // Small fractions are within one ULP
-    CheckDecimalToRealWithinOneULP<Decimal, Real>("9999999.9", 1, 9999999.9f);
-    CheckDecimalToRealWithinOneULP<Decimal, Real>("-9999999.9", 1, -9999999.9f);
-    CheckDecimalToRealWithinOneULP<Decimal, Real>("9999999.999999", 6, 9999999.999999f);
-    CheckDecimalToRealWithinOneULP<Decimal, Real>("-9999999.999999", 6, -9999999.999999f);
-
-    // Large fractions are within 2^-23
-    constexpr Real epsilon = 1.1920928955078125e-07f;  // 2^-23
-    CheckDecimalToRealWithinEpsilon<Decimal, Real>(
-        "112334829348925.99070703983306884765625", 23, epsilon,
-        112334829348925.99070703983306884765625f);
-    CheckDecimalToRealWithinEpsilon<Decimal, Real>(
-        "1.987748987892758765582589910934859345", 36, epsilon,
-        1.987748987892758765582589910934859345f);
-  }
-
-  // Test conversions with a range of scales
-  void TestLargeValues(int32_t max_scale) {
-    // Note that exact comparisons would succeed on some platforms (Linux, macOS).
-    // Nevertheless, power-of-ten factors are not all exactly representable
-    // in binary floating point.
-    for (int32_t scale = -max_scale; scale <= max_scale; scale++) {
-#ifdef _WIN32
-      // MSVC gives pow(10.f, -45.f) == 0 even though 1e-45f is nonzero
-      if (scale == 45) continue;
-#endif
-      CheckDecimalToRealApprox<Decimal>("1", scale, Pow10(-scale));
-    }
-    for (int32_t scale = -max_scale; scale <= max_scale - 2; scale++) {
-#ifdef _WIN32
-      // MSVC gives pow(10.f, -45.f) == 0 even though 1e-45f is nonzero
-      if (scale == 45) continue;
-#endif
-      const Real factor = static_cast<Real>(123);
-      CheckDecimalToRealApprox<Decimal>("123", scale, factor * Pow10(-scale));
-    }
-  }
 };
 
 TYPED_TEST_SUITE(TestDecimalToReal, RealTypes);
-
 TYPED_TEST(TestDecimalToReal, TestSuccess) { this->TestSuccess(); }
 
-// Custom test for Decimal128::ToReal<float>
-class TestDecimal128ToRealFloat : public TestDecimalToReal<std::pair<Decimal128, float>> {
-};
-TEST_F(TestDecimal128ToRealFloat, LargeValues) { TestLargeValues(/*max_scale=*/38); }
-TEST_F(TestDecimal128ToRealFloat, Precision) { this->TestPrecision(); }
-// Custom test for Decimal256::ToReal<float>
-class TestDecimal256ToRealFloat : public TestDecimalToReal<std::pair<Decimal256, float>> {
-};
-TEST_F(TestDecimal256ToRealFloat, LargeValues) { TestLargeValues(/*max_scale=*/76); }
-TEST_F(TestDecimal256ToRealFloat, Precision) { this->TestPrecision(); }
+// Custom test for Decimal::ToReal<float>
+template <typename DecimalType>
+class TestDecimalToRealFloat : public TestDecimalToReal<std::pair<DecimalType, float>> {};
+TYPED_TEST_SUITE(TestDecimalToRealFloat, DecimalTypes);
+
+TYPED_TEST(TestDecimalToRealFloat, LargeValues) {
+  auto max_scale = TypeParam::kMaxScale;
+  // Note that exact comparisons would succeed on some platforms (Linux, macOS).
+  // Nevertheless, power-of-ten factors are not all exactly representable
+  // in binary floating point.
+  for (int32_t scale = -max_scale; scale <= max_scale; scale++) {
+#ifdef _WIN32
+    // MSVC gives pow(10.f, -45.f) == 0 even though 1e-45f is nonzero
+    if (scale == 45) continue;
+#endif
+    CheckDecimalToRealApprox<TypeParam>("1", scale, this->Pow10(-scale));
+  }
+  for (int32_t scale = -max_scale; scale <= max_scale - 2; scale++) {
+#ifdef _WIN32
+    // MSVC gives pow(10.f, -45.f) == 0 even though 1e-45f is nonzero
+    if (scale == 45) continue;
+#endif
+    const auto factor = static_cast<float>(123);
+    CheckDecimalToRealApprox<TypeParam>("123", scale, factor * this->Pow10(-scale));
+  }
+}
+
+TYPED_TEST(TestDecimalToRealFloat, Precision) {
+  // 2**63 + 2**40 (exactly representable in a float's 24 bits of precision)
+  CheckDecimalToReal<TypeParam, float>("9223373136366403584", 0, 9.223373e+18f);
+  CheckDecimalToReal<TypeParam, float>("-9223373136366403584", 0, -9.223373e+18f);
+  // 2**64 + 2**41 (exactly representable in a float)
+  CheckDecimalToReal<TypeParam, float>("18446746272732807168", 0, 1.8446746e+19f);
+  CheckDecimalToReal<TypeParam, float>("-18446746272732807168", 0, -1.8446746e+19f);
+
+  // Integers are always exact
+  auto scale = TypeParam::kMaxScale - 1;
+  std::string seven = "7.";
+  seven.append(scale, '0');  // pad with trailing zeros
+  CheckDecimalToReal<TypeParam, float>(seven, scale, 7.0f);
+  CheckDecimalToReal<TypeParam, float>("-" + seven, scale, -7.0f);
+
+  CheckDecimalToReal<TypeParam, float>("99999999999999999999.0000000000000000", 16,
+                                       99999999999999999999.0f);
+  CheckDecimalToReal<TypeParam, float>("-99999999999999999999.0000000000000000", 16,
+                                       -99999999999999999999.0f);
+
+  // Small fractions are within one ULP
+  CheckDecimalToRealWithinOneULP<TypeParam, float>("9999999.9", 1, 9999999.9f);
+  CheckDecimalToRealWithinOneULP<TypeParam, float>("-9999999.9", 1, -9999999.9f);
+  CheckDecimalToRealWithinOneULP<TypeParam, float>("9999999.999999", 6, 9999999.999999f);
+  CheckDecimalToRealWithinOneULP<TypeParam, float>("-9999999.999999", 6,
+                                                   -9999999.999999f);
+
+  // Large fractions are within 2^-23
+  constexpr float epsilon = 1.1920928955078125e-07f;  // 2^-23
+  CheckDecimalToRealWithinEpsilon<TypeParam, float>(
+      "112334829348925.99070703983306884765625", 23, epsilon,
+      112334829348925.99070703983306884765625f);
+  CheckDecimalToRealWithinEpsilon<TypeParam, float>(
+      "1.987748987892758765582589910934859345", 36, epsilon,
+      1.987748987892758765582589910934859345f);
+}
 
 // ToReal<double> tests are disabled on MinGW because of precision issues in results
 #ifndef __MINGW32__
 
-// Custom test for Decimal128::ToReal<double>
+// Custom test for Decimal::ToReal<double>
 template <typename DecimalType>
 class TestDecimalToRealDouble : public TestDecimalToReal<std::pair<DecimalType, double>> {
 };

--- a/cpp/src/arrow/util/decimal_test.cc
+++ b/cpp/src/arrow/util/decimal_test.cc
@@ -1119,6 +1119,23 @@ class TestDecimalToReal : public ::testing::Test {
     // 2**64 + 2**41 (exactly representable in a float)
     CheckDecimalToReal<Decimal, Real>("18446746272732807168", 0, 1.8446746e+19f);
     CheckDecimalToReal<Decimal, Real>("-18446746272732807168", 0, -1.8446746e+19f);
+    // Small number but large scale
+    auto scale = Decimal::kMaxScale - 1;
+    std::string seven = "7.";
+    for (int32_t i = 0; i < scale; ++i) {
+      seven += "0";
+    }
+    CheckDecimalToReal<Decimal, Real>(seven, scale, 7.0f);
+    CheckDecimalToReal<Decimal, Real>("-" + seven, scale, -7.0f);
+
+    // Decimal >= max mantisa integer
+
+    /** The following cases still fail because 9999999 * 1e-1 != 999999.9f
+      CheckDecimalToReal<Decimal, Real>("999999.9", 1, 999999.9);
+      CheckDecimalToReal<Decimal, Real>("-999999.9", 1, -999999.9);
+    */
+    CheckDecimalToReal<Decimal, Real>("9999999.9", 1, 9999999.9);
+    CheckDecimalToReal<Decimal, Real>("-9999999.9", 1, -9999999.9);
   }
 
   // Test conversions with a range of scales
@@ -1209,6 +1226,17 @@ TYPED_TEST(TestDecimalToRealDouble, Precision) {
                                         9.999999999999998e+47);
   CheckDecimalToReal<TypeParam, double>("-99999999999999978859343891977453174784", -10,
                                         -9.999999999999998e+47);
+  // Small number but large scale
+  std::string seven = "7.";
+  for (int32_t i = 0; i < TypeParam::kMaxScale - 1; ++i) {
+    seven += "0";
+  }
+  CheckDecimalToReal<TypeParam, double>(seven, TypeParam::kMaxScale - 1, 7.0f);
+  CheckDecimalToReal<TypeParam, double>("-" + seven, TypeParam::kMaxScale - 1, -7.0f);
+
+  // Decimal >= max mantisa integer
+  CheckDecimalToReal<TypeParam, double>("999999999999999.9", 1, 999999999999999.9);
+  CheckDecimalToReal<TypeParam, double>("-999999999999999.9", 1, -999999999999999.9);
 }
 
 #endif  // __MINGW32__


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The current implementation of `Decimal::ToReal` can be naively represented as the following pseudocode:
```
Real v = static_cast<Real>(decimal.as_int128/256())
return v * (10.0**-scale)
```
It stores the intermediate unscaled int128/256 value as a float/double. The unscaled int128/256 value can be very large when the decimal has a large scale, which causes precision issues such as in #36602.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Avoid storing the unscaled large int as float if the representation is not precise, by spliting the decimal into integral and fractional parts and dealing with them separately. This algorithm guarantees that:
1. If the decimal is an integer, the conversion is exact.
2. If the number of fractional digits is <= RealTraits<Real>::kMantissaDigits (e.g. 8 for float and 16 for double), the conversion is within 1 ULP of the exact value. For example Decimal128::ToReal<float>(9999.999) falls into this category because the integer 9999999 is precisely representable by float, whereas 9999.9999 would be in the next category.
3. Otherwise, the conversion is within 2^(-RealTraits<Real>::kMantissaDigits+1) (e.g. 2^-23 for float and 2^-52 for double) of the exact value.

Here "exact value" means the closest representable value by Real.

I believe this algorithm is good enough, because an"exact" algorithm would require iterative multiplication and subtraction of decimals to determain the binary representation of its fractional part. Yet the result would still almost always be inaccurate because float/double can only accurately represent powers of two. IMHO It's not worth it to spend that many expensive operations just to improve the result by one ULP.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes.

### Are there any user-facing changes?
 No.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #35942 
