### PR TITLE
GH-36672: [Python][C++] Add support for vector function UDF

### DIFF
--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2707,6 +2707,10 @@ cdef get_register_aggregate_function():
     reg.register_func = RegisterAggregateFunction
     return reg
 
+cdef get_register_vector_function():
+    cdef RegisterUdf reg = RegisterUdf.__new__(RegisterUdf)
+    reg.register_func = RegisterVectorFunction
+    return reg
 
 def register_scalar_function(func, function_name, function_doc, in_types, out_type,
                              func_registry=None):
@@ -2788,6 +2792,11 @@ def register_scalar_function(func, function_name, function_doc, in_types, out_ty
                                            func, function_name, function_doc, in_types,
                                            out_type, func_registry)
 
+def register_vector_function(func, function_name, function_doc, in_types, out_type,
+                             func_registry=None):
+    return _register_user_defined_function(get_register_vector_function(),
+                                           func, function_name, function_doc, in_types,
+                                           out_type, func_registry)
 
 def register_aggregate_function(func, function_name, function_doc, in_types, out_type,
                                 func_registry=None):

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2854,7 +2854,7 @@ def register_vector_function(func, function_name, function_doc, in_types, out_ty
     >>> func_name = "pct_rank_func"
     >>> in_types = {"array": pa.int64()}
     >>> out_type = pa.float64()
-    >>> pc.register_vector_function(add_constant, func_name, func_doc,
+    >>> pc.register_vector_function(rank_pct, func_name, func_doc,
     ...                   in_types, out_type)
     >>>
     >>> answer = pc.call_function(func_name, [pa.array([20, 30, 40])])

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2802,10 +2802,9 @@ def register_vector_function(func, function_name, function_doc, in_types, out_ty
     This API is EXPERIMENTAL.
 
     A vector function is a function that executes vector
-    operations on arrays. Unlike scalar function, vector
-    function often has a grouping semantics and the output
-    for a row depends on other rows. A typical example
-    of vector function is "rank".
+    operations on arrays. Vector function is often used
+    when compute doesn't fit other more specific types of
+    functions (e.g., scalar and aggregate).
 
     Parameters
     ----------

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2848,22 +2848,23 @@ def register_vector_function(func, function_name, function_doc, in_types, out_ty
     >>> func_doc["summary"] = "percent rank"
     >>> func_doc["description"] = "compute percent rank"
     >>>
-    >>> def rank_pct(ctx, x):
-    ...     return pa.array(x.to_pandas().rank(pct=True))
+    >>> def list_flatten_udf(ctx, x):
+    ...     return pc.list_flatten(x)
     >>>
-    >>> func_name = "pct_rank_func"
-    >>> in_types = {"array": pa.int64()}
-    >>> out_type = pa.float64()
-    >>> pc.register_vector_function(rank_pct, func_name, func_doc,
+    >>> func_name = "list_flatten_udf"
+    >>> in_types = {"array": pa.list_(pa.int64())}
+    >>> out_type = pa.int64()
+    >>> pc.register_vector_function(list_flatten_udf, func_name, func_doc,
     ...                   in_types, out_type)
     >>>
-    >>> answer = pc.call_function(func_name, [pa.array([20, 30, 40])])
+    >>> answer = pc.call_function(func_name, [pa.array([[1, 2], [3, 4]])])
     >>> answer
-    <pyarrow.lib.DoubleArray object at ...>
+    <pyarrow.lib.Int64Array object at ...>
     [
-      0.3333333333333333,
-      0.6666666666666666,
-      1
+      1,
+      2,
+      3,
+      4
     ]
     """
     return _register_user_defined_function(get_register_vector_function(),

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2861,9 +2861,9 @@ def register_vector_function(func, function_name, function_doc, in_types, out_ty
     >>> answer
     <pyarrow.lib.DoubleArray object at ...>
     [
-        0.3333333333333333,
-        0.6666666666666666,
-        1
+      0.3333333333333333,
+      0.6666666666666666,
+      1
     ]
     """
     return _register_user_defined_function(get_register_vector_function(),

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -87,6 +87,7 @@ from pyarrow._compute import (  # noqa
     register_scalar_function,
     register_tabular_function,
     register_aggregate_function,
+    register_vector_function,
     UdfContext,
     # Expressions
     Expression,

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2815,5 +2815,9 @@ cdef extern from "arrow/python/udf.h" namespace "arrow::py" nogil:
                                       function[CallbackUdf] wrapper, const CUdfOptions& options,
                                       CFunctionRegistry* registry)
 
+    CStatus RegisterVectorFunction(PyObject* function,
+                                      function[CallbackUdf] wrapper, const CUdfOptions& options,
+                                      CFunctionRegistry* registry)
+
     CResult[shared_ptr[CRecordBatchReader]] CallTabularFunction(
         const c_string& func_name, const vector[CDatum]& args, CFunctionRegistry* registry)

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2816,8 +2816,8 @@ cdef extern from "arrow/python/udf.h" namespace "arrow::py" nogil:
                                       CFunctionRegistry* registry)
 
     CStatus RegisterVectorFunction(PyObject* function,
-                                      function[CallbackUdf] wrapper, const CUdfOptions& options,
-                                      CFunctionRegistry* registry)
+                                   function[CallbackUdf] wrapper, const CUdfOptions& options,
+                                   CFunctionRegistry* registry)
 
     CResult[shared_ptr[CRecordBatchReader]] CallTabularFunction(
         const c_string& func_name, const vector[CDatum]& args, CFunctionRegistry* registry)

--- a/python/pyarrow/src/arrow/python/udf.cc
+++ b/python/pyarrow/src/arrow/python/udf.cc
@@ -484,15 +484,15 @@ Status PythonUdfExec(compute::KernelContext* ctx, const compute::ExecSpan& batch
   return SafeCallIntoPython([&]() -> Status { return udf->Exec(ctx, batch, out); });
 }
 
-template<class Function, class Kernel>
+template <class Function, class Kernel>
 Status RegisterUdf(PyObject* function, compute::KernelInit kernel_init,
                    UdfWrapperCallback cb, const UdfOptions& options,
                    compute::FunctionRegistry* registry) {
   if (!PyCallable_Check(function)) {
     return Status::TypeError("Expected a callable Python object.");
   }
-  auto scalar_func = std::make_shared<Function>(
-      options.func_name, options.arity, options.func_doc);
+  auto scalar_func =
+      std::make_shared<Function>(options.func_name, options.arity, options.func_doc);
   Py_INCREF(function);
   std::vector<compute::InputType> input_types;
   for (const auto& in_dtype : options.input_types) {
@@ -523,17 +523,17 @@ Status RegisterUdf(PyObject* function, compute::KernelInit kernel_init,
 Status RegisterScalarFunction(PyObject* function, UdfWrapperCallback cb,
                               const UdfOptions& options,
                               compute::FunctionRegistry* registry) {
-  return RegisterUdf<compute::ScalarFunction, compute::ScalarKernel>(function,
-                     PythonUdfKernelInit{std::make_shared<OwnedRefNoGIL>(function)}, cb,
-                     options, registry);
+  return RegisterUdf<compute::ScalarFunction, compute::ScalarKernel>(
+      function, PythonUdfKernelInit{std::make_shared<OwnedRefNoGIL>(function)}, cb,
+      options, registry);
 }
 
 Status RegisterVectorFunction(PyObject* function, UdfWrapperCallback cb,
                               const UdfOptions& options,
                               compute::FunctionRegistry* registry) {
-  return RegisterUdf<compute::VectorFunction, compute::VectorKernel>(function,
-                           PythonUdfKernelInit{std::make_shared<OwnedRefNoGIL>(function)},
-                           cb, options, registry);
+  return RegisterUdf<compute::VectorFunction, compute::VectorKernel>(
+      function, PythonUdfKernelInit{std::make_shared<OwnedRefNoGIL>(function)}, cb,
+      options, registry);
 }
 
 Status RegisterTabularFunction(PyObject* function, UdfWrapperCallback cb,

--- a/python/pyarrow/src/arrow/python/udf.h
+++ b/python/pyarrow/src/arrow/python/udf.h
@@ -67,6 +67,11 @@ Status ARROW_PYTHON_EXPORT RegisterAggregateFunction(
     PyObject* user_function, UdfWrapperCallback wrapper, const UdfOptions& options,
     compute::FunctionRegistry* registry = NULLPTR);
 
+/// \brief register a Vector user-defined-function from Python
+Status ARROW_PYTHON_EXPORT RegisterVectorFunction(
+    PyObject* user_function, UdfWrapperCallback wrapper, const UdfOptions& options,
+    compute::FunctionRegistry* registry = NULLPTR);
+
 Result<std::shared_ptr<RecordBatchReader>> ARROW_PYTHON_EXPORT
 CallTabularFunction(const std::string& func_name, const std::vector<Datum>& args,
                     compute::FunctionRegistry* registry = NULLPTR);

--- a/python/pyarrow/tests/test_udf.py
+++ b/python/pyarrow/tests/test_udf.py
@@ -843,6 +843,13 @@ def test_vector_basic(unary_vector_func_fixture):
     assert result == expected
 
 
+def test_vector_empty(unary_vector_func_fixture):
+    arr = pa.array([1], pa.float64())
+    result = pc.call_function("y=pct_rank(x)", [arr])
+    expected = pa.array(arr.to_pandas().rank(pct=True))
+    assert result == expected
+
+
 def test_vector_struct(struct_vector_func_fixture):
     k = pa.array(
         [1, 1, 2, 2], pa.int64()

--- a/python/pyarrow/tests/test_udf.py
+++ b/python/pyarrow/tests/test_udf.py
@@ -305,7 +305,8 @@ def unary_vector_func_fixture():
     Reigster a vector function
     """
     def pct_rank(ctx, x):
-        return pa.array(x.to_pandas().rank(pct=True))
+        # copy here to get around pandas 1.0 issue
+        return pa.array(x.to_pandas().copy().rank(pct=True))
 
     func_name = "y=pct_rank(x)"
     doc = empty_udf_doc
@@ -836,20 +837,23 @@ def test_hash_agg_random(sum_agg_func_fixture):
     assert result.sort_by('id') == expected.sort_by('id')
 
 
+@pytest.mark.pandas
 def test_vector_basic(unary_vector_func_fixture):
     arr = pa.array([10.0, 20.0, 30.0, 40.0, 50.0], pa.float64())
     result = pc.call_function("y=pct_rank(x)", [arr])
-    expected = pa.array(arr.to_pandas().rank(pct=True))
+    expected = unary_vector_func_fixture(None, arr)
     assert result == expected
 
 
+@pytest.mark.pandas
 def test_vector_empty(unary_vector_func_fixture):
     arr = pa.array([1], pa.float64())
     result = pc.call_function("y=pct_rank(x)", [arr])
-    expected = pa.array(arr.to_pandas().rank(pct=True))
+    expected = unary_vector_func_fixture(None, arr)
     assert result == expected
 
 
+@pytest.mark.pandas
 def test_vector_struct(struct_vector_func_fixture):
     k = pa.array(
         [1, 1, 2, 2], pa.int64()

--- a/python/pyarrow/tests/test_udf.py
+++ b/python/pyarrow/tests/test_udf.py
@@ -299,6 +299,43 @@ def raising_func_fixture():
     return raising_func, func_name
 
 
+@pytest.fixture(scope="session")
+def unary_vector_func_fixture():
+    """
+    Reigster a vector function
+    """
+    import numpy as np
+    def pct_rank(ctx, x):
+        return pa.array(x.to_pandas().rank(pct=True))
+
+    func_name = "y=pct_rank(x)"
+    doc = empty_udf_doc
+    pc.register_vector_function(pct_rank, func_name, doc, {'x': pa.float64()}, pa.float64())
+
+    return pct_rank, func_name
+
+
+@pytest.fixture(scope="session")
+def struct_vector_func_fixture():
+    """
+    Reigster a vector function that returns a struct array
+    """
+    def pivot(ctx, k, v, c):
+        df = pa.RecordBatch.from_arrays([k, v, c], names=['k', 'v', 'c']).to_pandas()
+        df_pivot = df.pivot(columns='c', values='v', index='k').reset_index()
+        return pa.RecordBatch.from_pandas(df_pivot).to_struct_array()
+
+    func_name = "y=pivot(x)"
+    doc = empty_udf_doc
+    pc.register_vector_function(
+        pivot, func_name, doc,
+        {'k': pa.int64(), 'v': pa.float64(), 'c': pa.utf8()},
+        pa.struct([('k', pa.int64()), ('v1', pa.float64()), ('v2', pa.float64())])
+    )
+
+    return pivot, func_name
+
+
 def check_scalar_function(func_fixture,
                           inputs, *,
                           run_in_dataset=True,
@@ -797,3 +834,25 @@ def test_hash_agg_random(sum_agg_func_fixture):
         [("value", "sum")]).rename_columns(['id', 'value_sum_udf'])
 
     assert result.sort_by('id') == expected.sort_by('id')
+
+
+def test_vector_basic(unary_vector_func_fixture):
+    arr = pa.array([10.0, 20.0, 30.0, 40.0, 50.0], pa.float64())
+    result = pc.call_function("y=pct_rank(x)", [arr])
+    expected = pa.array(arr.to_pandas().rank(pct=True))
+    assert result == expected
+
+
+def test_vector_struct(struct_vector_func_fixture):
+    k = pa.array(
+        [1, 1, 2, 2], pa.int64()
+    )
+    v = pa.array(
+        [1.0, 2.0, 3.0, 4.0], pa.float64()
+    )
+    c = pa.array(
+        ['v1', 'v2', 'v1', 'v2']
+    )
+    result = pc.call_function("y=pivot(x)", [k, v, c])
+    expected = struct_vector_func_fixture[0](None, k, v, c)
+    assert result == expected

--- a/python/pyarrow/tests/test_udf.py
+++ b/python/pyarrow/tests/test_udf.py
@@ -841,7 +841,7 @@ def test_hash_agg_random(sum_agg_func_fixture):
 def test_vector_basic(unary_vector_func_fixture):
     arr = pa.array([10.0, 20.0, 30.0, 40.0, 50.0], pa.float64())
     result = pc.call_function("y=pct_rank(x)", [arr])
-    expected = unary_vector_func_fixture(None, arr)
+    expected = unary_vector_func_fixture[0](None, arr)
     assert result == expected
 
 
@@ -849,7 +849,7 @@ def test_vector_basic(unary_vector_func_fixture):
 def test_vector_empty(unary_vector_func_fixture):
     arr = pa.array([1], pa.float64())
     result = pc.call_function("y=pct_rank(x)", [arr])
-    expected = unary_vector_func_fixture(None, arr)
+    expected = unary_vector_func_fixture[0](None, arr)
     assert result == expected
 
 

--- a/python/pyarrow/tests/test_udf.py
+++ b/python/pyarrow/tests/test_udf.py
@@ -304,13 +304,13 @@ def unary_vector_func_fixture():
     """
     Reigster a vector function
     """
-    import numpy as np
     def pct_rank(ctx, x):
         return pa.array(x.to_pandas().rank(pct=True))
 
     func_name = "y=pct_rank(x)"
     doc = empty_udf_doc
-    pc.register_vector_function(pct_rank, func_name, doc, {'x': pa.float64()}, pa.float64())
+    pc.register_vector_function(pct_rank, func_name, doc, {
+                                'x': pa.float64()}, pa.float64())
 
     return pct_rank, func_name
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
In Arrow compute, there are four main types of functions: Scalar, Vector, ScalarAggregate and HashAggregate.

Some of the previous work added support for Scalar, ScalarAggregate(https://github.com/apache/arrow/issues/35515) and HashAggregate(https://github.com/apache/arrow/issues/36252). I think it makes sense to add support for vector function as well to complete all non-decomposable UDF kernel support.

Internally, we plan to extend Acero to implement a "SegmentVectorNode" which would use this API to invoke vector on a segment by segment basis, which will allow to use constant memory to compute things like "rank the value across all rows per segment using a python UDF".

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
The change includes is very similar to the support for aggregate function, which includes code to register the vector UDF, and a kernel that invokes the vector UDF on given inputs.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
Yes. Added new test.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
Yes. This adds an user-facing API to register the vector function. 
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #36672