### PR TITLE
MINOR: [Dev] Add Branch Protection

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -26,6 +26,11 @@ github:
     - felipecrv
     - mapleFU
 
+  protected_branches:
+    main:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+
 notifications:
   commits:      commits@arrow.apache.org
   issues_status: issues@arrow.apache.org


### PR DESCRIPTION
This will add branch protection to `main` which will prevent force pushing and commits without PR(+review). We recently had an accidental push through a release script to main that would have been prevented by this. 

[Infra documentation](https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=INFRA&title=Git+-+.asf.yaml+features#Git.asf.yamlfeatures-Repositoryfeatures) regarding these settings.