### PR TITLE
GH-36511: [C++][FlightRPC] Get rid of GRPCPP_PP_INCLUDE

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -3998,7 +3998,6 @@ if(ARROW_WITH_GRPC)
   if(GRPC_VENDORED)
     # Remove "v" from "vX.Y.Z"
     string(SUBSTRING ${ARROW_GRPC_BUILD_VERSION} 1 -1 ARROW_GRPC_VERSION)
-    set(GRPCPP_PP_INCLUDE TRUE)
     # Examples need to link to static Arrow if we're using static gRPC
     set(ARROW_GRPC_USE_SHARED OFF)
   else()
@@ -4006,18 +4005,6 @@ if(ARROW_WITH_GRPC)
       set(ARROW_GRPC_VERSION ${gRPCAlt_VERSION})
     else()
       set(ARROW_GRPC_VERSION ${gRPC_VERSION})
-    endif()
-    # grpc++ headers may reside in ${GRPC_INCLUDE_DIR}/grpc++ or ${GRPC_INCLUDE_DIR}/grpcpp
-    # depending on the gRPC version.
-    get_target_property(GRPC_INCLUDE_DIR gRPC::grpc++ INTERFACE_INCLUDE_DIRECTORIES)
-    if(GRPC_INCLUDE_DIR MATCHES "^\\$<"
-       OR # generator expression
-          EXISTS "${GRPC_INCLUDE_DIR}/grpcpp/impl/codegen/config_protobuf.h")
-      set(GRPCPP_PP_INCLUDE TRUE)
-    elseif(EXISTS "${GRPC_INCLUDE_DIR}/grpc++/impl/codegen/config_protobuf.h")
-      set(GRPCPP_PP_INCLUDE FALSE)
-    else()
-      message(FATAL_ERROR "Cannot find grpc++ headers in ${GRPC_INCLUDE_DIR}")
     endif()
     if(ARROW_USE_ASAN)
       # Disable ASAN in system gRPC.

--- a/cpp/src/arrow/flight/flight_test.cc
+++ b/cpp/src/arrow/flight/flight_test.cc
@@ -46,11 +46,7 @@
 #error "gRPC headers should not be in public API"
 #endif
 
-#ifdef GRPCPP_PP_INCLUDE
 #include <grpcpp/grpcpp.h>
-#else
-#include <grpc++/grpc++.h>
-#endif
 
 // Include before test_util.h (boost), contains Windows fixes
 #include "arrow/flight/platform.h"

--- a/cpp/src/arrow/flight/transport/grpc/customize_grpc.h
+++ b/cpp/src/arrow/flight/transport/grpc/customize_grpc.h
@@ -31,17 +31,8 @@
 #pragma warning(disable : 4267)
 #endif
 
-#ifdef GRPCPP_PP_INCLUDE
 #include <grpcpp/impl/codegen/config_protobuf.h>
-#else
-#include <grpc++/impl/codegen/config_protobuf.h>
-#endif
-
-#ifdef GRPCPP_PP_INCLUDE
 #include <grpcpp/impl/codegen/proto_utils.h>
-#else
-#include <grpc++/impl/codegen/proto_utils.h>
-#endif
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/cpp/src/arrow/flight/transport/grpc/grpc_client.cc
+++ b/cpp/src/arrow/flight/transport/grpc/grpc_client.cc
@@ -26,13 +26,9 @@
 #include <utility>
 
 #include "arrow/util/config.h"
-#ifdef GRPCPP_PP_INCLUDE
 #include <grpcpp/grpcpp.h>
 #if defined(GRPC_NAMESPACE_FOR_TLS_CREDENTIALS_OPTIONS)
 #include <grpcpp/security/tls_credentials_options.h>
-#endif
-#else
-#include <grpc++/grpc++.h>
 #endif
 
 #include <grpc/grpc_security_constants.h>

--- a/cpp/src/arrow/flight/transport/grpc/grpc_client.cc
+++ b/cpp/src/arrow/flight/transport/grpc/grpc_client.cc
@@ -25,7 +25,6 @@
 #include <unordered_map>
 #include <utility>
 
-#include "arrow/util/config.h"
 #include <grpcpp/grpcpp.h>
 #if defined(GRPC_NAMESPACE_FOR_TLS_CREDENTIALS_OPTIONS)
 #include <grpcpp/security/tls_credentials_options.h>

--- a/cpp/src/arrow/flight/transport/grpc/grpc_server.cc
+++ b/cpp/src/arrow/flight/transport/grpc/grpc_server.cc
@@ -26,11 +26,7 @@
 #include <utility>
 
 #include "arrow/util/config.h"
-#ifdef GRPCPP_PP_INCLUDE
 #include <grpcpp/grpcpp.h>
-#else
-#include <grpc++/grpc++.h>
-#endif
 
 #include "arrow/buffer.h"
 #include "arrow/flight/serialization_internal.h"

--- a/cpp/src/arrow/flight/transport/grpc/grpc_server.cc
+++ b/cpp/src/arrow/flight/transport/grpc/grpc_server.cc
@@ -25,7 +25,6 @@
 #include <unordered_map>
 #include <utility>
 
-#include "arrow/util/config.h"
 #include <grpcpp/grpcpp.h>
 
 #include "arrow/buffer.h"

--- a/cpp/src/arrow/flight/transport/grpc/serialization_internal.cc
+++ b/cpp/src/arrow/flight/transport/grpc/serialization_internal.cc
@@ -36,13 +36,8 @@
 #include <google/protobuf/wire_format_lite.h>
 
 #include <grpc/byte_buffer_reader.h>
-#ifdef GRPCPP_PP_INCLUDE
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/impl/codegen/proto_utils.h>
-#else
-#include <grpc++/grpc++.h>
-#include <grpc++/impl/codegen/proto_utils.h>
-#endif
 
 #if defined(_MSC_VER)
 #pragma warning(pop)

--- a/cpp/src/arrow/flight/transport/grpc/util_internal.cc
+++ b/cpp/src/arrow/flight/transport/grpc/util_internal.cc
@@ -22,11 +22,7 @@
 #include <memory>
 #include <string>
 
-#ifdef GRPCPP_PP_INCLUDE
 #include <grpcpp/grpcpp.h>
-#else
-#include <grpc++/grpc++.h>
-#endif
 
 #include "arrow/flight/transport.h"
 #include "arrow/flight/types.h"

--- a/cpp/src/arrow/util/config.h.cmake
+++ b/cpp/src/arrow/util/config.h.cmake
@@ -57,5 +57,3 @@
 #cmakedefine ARROW_WITH_MUSL
 #cmakedefine ARROW_WITH_OPENTELEMETRY
 #cmakedefine ARROW_WITH_UCX
-
-#cmakedefine GRPCPP_PP_INCLUDE


### PR DESCRIPTION
### Rationale for this change

It's for gRPC < 1.10 and we require gRPC >= 1.30.0. So we can get rid of it.

### What changes are included in this PR?

Get rid of GRPCPP_PP_INCLUDE.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #36511