### PR TITLE
GH-36682: [C++] Add missing ARROW_ACERO dependency to ARROW_PYTHON

### DIFF
--- a/cpp/cmake_modules/DefineOptions.cmake
+++ b/cpp/cmake_modules/DefineOptions.cmake
@@ -387,6 +387,7 @@ takes precedence over ccache if a storage backend is configured" ON)
 (This is a deprecated option. Use CMake presets instead.)"
                 OFF
                 DEPENDS
+                ARROW_ACERO
                 ARROW_CSV
                 ARROW_DATASET
                 ARROW_FILESYSTEM


### PR DESCRIPTION
### Rationale for this change

PyArrow wants Acero.

### What changes are included in this PR?

Add `ARROW_ACERO` to `ARROW_PYTHON` dependency.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #36682