### PR TITLE
GH-36680: [Python] Add missing pytest.mark.acero

### DIFF
--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -2424,6 +2424,7 @@ def test_numpy_asarray(constructor):
     assert result.dtype == "int32"
 
 
+@pytest.mark.acero
 def test_invalid_non_join_column():
     NUM_ITEMS = 30
     t1 = pa.Table.from_pydict({


### PR DESCRIPTION
### Rationale for this change

`test_invalid_non_join_column` depends on Acero.

### What changes are included in this PR?

Add `@pytest.mark.acero`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #36680