### PR TITLE
GH-36663: [C++] Fix the default value information for enum options

### DIFF
--- a/cpp/cmake_modules/DefineOptions.cmake
+++ b/cpp/cmake_modules/DefineOptions.cmake
@@ -31,24 +31,6 @@ function(check_description_length name description)
   endforeach()
 endfunction()
 
-function(list_join lst glue out)
-  if("${${lst}}" STREQUAL "")
-    set(${out}
-        ""
-        PARENT_SCOPE)
-    return()
-  endif()
-
-  list(GET ${lst} 0 joined)
-  list(REMOVE_AT ${lst} 0)
-  foreach(item ${${lst}})
-    set(joined "${joined}${glue}${item}")
-  endforeach()
-  set(${out}
-      ${joined}
-      PARENT_SCOPE)
-endfunction()
-
 macro(define_option name description default)
   set(options)
   set(one_value_args)
@@ -63,7 +45,7 @@ macro(define_option name description default)
   endif()
 
   check_description_length(${name} ${description})
-  list_join(description "\n" multiline_description)
+  list(JOIN description "\n" multiline_description)
 
   option(${name} "${multiline_description}" ${default})
 
@@ -76,7 +58,7 @@ endmacro()
 
 macro(define_option_string name description default)
   check_description_length(${name} ${description})
-  list_join(description "\n" multiline_description)
+  list(JOIN description "\n" multiline_description)
 
   set(${name}
       ${default}
@@ -87,8 +69,12 @@ macro(define_option_string name description default)
   set("${name}_OPTION_DEFAULT" "\"${default}\"")
   set("${name}_OPTION_TYPE" "string")
   set("${name}_OPTION_POSSIBLE_VALUES" ${ARGN})
-
-  list_join("${name}_OPTION_POSSIBLE_VALUES" "|" "${name}_OPTION_ENUM")
+  list(FIND ${name}_OPTION_POSSIBLE_VALUES "${default}" default_value_index)
+  if(NOT ${default_value_index} EQUAL -1)
+    list(REMOVE_AT ${name}_OPTION_POSSIBLE_VALUES ${default_value_index})
+    list(PREPEND ${name}_OPTION_POSSIBLE_VALUES "${default}")
+  endif()
+  list(JOIN "${name}_OPTION_POSSIBLE_VALUES" "|" "${name}_OPTION_ENUM")
   if(NOT ("${${name}_OPTION_ENUM}" STREQUAL ""))
     set_property(CACHE ${name} PROPERTY STRINGS "${name}_OPTION_POSSIBLE_VALUES")
   endif()


### PR DESCRIPTION
### Rationale for this change

The default for `ARROW_SIMD_LEVEL` is described as `NONE` but it's actually `DEFAULT`.
The default for `ARROW_RUNTIME_SIMD_LEVEL` is described as `NONE` but it's actually `MAX`.

### What changes are included in this PR?

Reorder possible values to put the default value as the first element.

Before:

    --   ARROW_SIMD_LEVEL=SSE4_2 [default=NONE|SSE4_2|AVX2|AVX512|NEON|SVE|SVE128|SVE256|SVE512|DEFAULT]
    --   ARROW_RUNTIME_SIMD_LEVEL=MAX [default=NONE|SSE4_2|AVX2|AVX512|MAX]

After:

    --   ARROW_SIMD_LEVEL=SSE4_2 [default=DEFAULT|NONE|SSE4_2|AVX2|AVX512|NEON|SVE|SVE128|SVE256|SVE512]
    --   ARROW_RUNTIME_SIMD_LEVEL=MAX [default=MAX|NONE|SSE4_2|AVX2|AVX512]

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #36663