### PR TITLE
GH-36687: [R] Add correct branch name to autobrew formulae to facilitate local testing

### DIFF
--- a/dev/tasks/homebrew-formulae/autobrew/apache-arrow-static.rb
+++ b/dev/tasks/homebrew-formulae/autobrew/apache-arrow-static.rb
@@ -25,7 +25,7 @@ class ApacheArrowStatic < Formula
   # Uncomment and update to test on a release candidate
   # mirror "https://dist.apache.org/repos/dist/dev/arrow/apache-arrow-8.0.0-rc1/apache-arrow-8.0.0.tar.gz"
   sha256 "9948ddb6d4798b51552d0dca3252dd6e3a7d0f9702714fc6f5a1b59397ce1d28"
-  head "https://github.com/apache/arrow.git"
+  head "https://github.com/apache/arrow.git", branch: "main"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "ef89d21a110b89840cc6148add685d407e75bd633bc8f79625eb33d00e3694b4"

--- a/dev/tasks/homebrew-formulae/autobrew/apache-arrow.rb
+++ b/dev/tasks/homebrew-formulae/autobrew/apache-arrow.rb
@@ -21,7 +21,7 @@ class ApacheArrow < Formula
   homepage "https://arrow.apache.org/"
   url "https://www.apache.org/dyn/closer.lua?path=arrow/arrow-12.0.1.9000/apache-arrow-12.0.1.9000.tar.gz"
   sha256 "9948ddb6d4798b51552d0dca3252dd6e3a7d0f9702714fc6f5a1b59397ce1d28"
-  head "https://github.com/apache/arrow.git"
+  head "https://github.com/apache/arrow.git", branch: "main"
 
   bottle do
     cellar :any

--- a/r/configure
+++ b/r/configure
@@ -238,7 +238,7 @@ do_autobrew () {
   # Setup for local autobrew testing
   if [ -f "tools/apache-arrow.rb" ]; then
     # If you want to use a local apache-arrow.rb formula, do
-    # $ cp ../dev/tasks/homebrew-formulae/autobrew/apache-arrow.rb tools/apache-arrow.rb
+    # $ cp ../dev/tasks/homebrew-formulae/autobrew/apache-arrow*.rb tools
     # before R CMD build or INSTALL (assuming a local checkout of the apache/arrow repository).
     # If you have this, you should use the local autobrew script so they match.
     cp tools/autobrew .


### PR DESCRIPTION
### Rationale for this change

It is currently not possible to recreate an autobrew build locally by following the instructions in the comments. This fixes the local copies of the upstream formulas and the instructions so that future debuggers can recreate an autobrew build.

### What changes are included in this PR?

The branch `master` no longer exists and is the default value. This PR adds the revised default branch name ("main").

### Are these changes tested?

No nightly test covers this because this value would be overwritten to test specific commits anyway.

### Are there any user-facing changes?

No.
* Closes: #36687