### PR TITLE
MINOR: [R] Remove trailing whitespace in configure

### DIFF
--- a/r/configure
+++ b/r/configure
@@ -50,10 +50,10 @@
 #   Currently the configure script doesn't offer much to make this easy.
 #   If you expect to rebuild multiple times, you should set up a dev
 #   environment.
-# * Installing a dev version as a regular developer. 
+# * Installing a dev version as a regular developer.
 #   The best way is to maintain your own cmake build and install it
 #   to a directory (not system) that you set as the env var
-#   $ARROW_HOME.  
+#   $ARROW_HOME.
 #
 # For more information, see the various installation and developer vignettes.
 
@@ -177,7 +177,7 @@ find_arrow () {
     else
       PC_LIB_VERSION=`grep '^Version' ${_LIBARROW_FOUND}/lib/pkgconfig/arrow.pc | sed s/Version:\ //`
     fi
-    # This is in an R script for convenience and testability. 
+    # This is in an R script for convenience and testability.
     # Success means the found C++ library is ok to use.
     # Error means the versions don't line up and we shouldn't use it.
     # More specific messaging to the user is in the R script


### PR DESCRIPTION
### What changes are included in this PR?

Fixes trailing whitespace in configure so that it's easier to get a clean commit history on the file.

### Are these changes tested?

No.

### Are there any user-facing changes?

No.