### PR TITLE
GH-36692: [CI][Packaging] Pin gemfury to 0.12.0 due to issue with faraday dependency

### DIFF
--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -131,7 +131,6 @@ on:
 {% endmacro %}
 
 {%- macro github_upload_gemfury(pattern) -%}
-  {%- if arrow.is_default_branch() -%}
   - name: Set up Ruby by apt
     if: runner.os == 'Linux' && runner.arch != 'X64'
     run: |
@@ -150,7 +149,6 @@ on:
     env:
       CROSSBOW_GEMFURY_TOKEN: {{ '${{ secrets.CROSSBOW_GEMFURY_TOKEN }}' }}
       CROSSBOW_GEMFURY_ORG: {{ '${{ secrets.CROSSBOW_GEMFURY_ORG }}' }}
-  {% endif %}
 {% endmacro %}
 
 {%- macro azure_checkout_arrow() -%}

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -131,6 +131,7 @@ on:
 {% endmacro %}
 
 {%- macro github_upload_gemfury(pattern) -%}
+  {%- if arrow.is_default_branch() -%}
   - name: Set up Ruby by apt
     if: runner.os == 'Linux' && runner.arch != 'X64'
     run: |
@@ -162,6 +163,7 @@ on:
     env:
       CROSSBOW_GEMFURY_TOKEN: {{ '${{ secrets.CROSSBOW_GEMFURY_TOKEN }}' }}
       CROSSBOW_GEMFURY_ORG: {{ '${{ secrets.CROSSBOW_GEMFURY_ORG }}' }}
+  {% endif %}
 {% endmacro %}
 
 {%- macro azure_checkout_arrow() -%}

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -144,7 +144,6 @@ on:
   - name: Install gemfury client on ARM self-hosted
     if: runner.os == 'Linux' && runner.arch != 'X64'
     run: |
-      PATH=$(echo $(ruby -r rubygems -e 'puts Gem.user_dir'))/bin:$PATH
       # GH-36692: Pin gemfury due to wrong faraday dependency declaration.
       gem install --user-install gemfury -v 0.12.0
   - name: Instal gemfury client
@@ -156,6 +155,7 @@ on:
   - name: Upload package to Gemfury
     shell: bash
     run: |
+      PATH=$(echo $(ruby -r rubygems -e 'puts Gem.user_dir'))/bin:$PATH
       fury push \
         --api-token=${CROSSBOW_GEMFURY_TOKEN} \
         --as=${CROSSBOW_GEMFURY_ORG} \

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -145,7 +145,8 @@ on:
     shell: bash
     run: |
       PATH=$(echo $(ruby -r rubygems -e 'puts Gem.user_dir') | sed "s/C:\//\/c\//")/bin:$PATH
-      gem install --user-install gemfury
+      # GH-36692: Pin gemfury due to wrong faraday dependency declaration.
+      gem install --user-install gemfury -v 0.12.0
       fury push \
         --api-token=${CROSSBOW_GEMFURY_TOKEN} \
         --as=${CROSSBOW_GEMFURY_ORG} \

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -137,8 +137,7 @@ on:
       sudo apt update
       sudo apt install -y ruby-full
   - name: Set up Ruby by GitHub Actions
-    if: |
-      !(runner.os == 'Linux' && runner.arch != 'X64')
+    if: runner.arch == 'X64' && runner.os != 'macOS'
     uses: ruby/setup-ruby@v1
     with:
       ruby-version: "ruby"

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -131,7 +131,6 @@ on:
 {% endmacro %}
 
 {%- macro github_upload_gemfury(pattern) -%}
-  {%- if arrow.is_default_branch() -%}
   - name: Set up Ruby by apt
     if: runner.os == 'Linux' && runner.arch != 'X64'
     run: |
@@ -147,6 +146,7 @@ on:
     run: |
       # GH-36692: Pin gemfury due to wrong faraday dependency declaration.
       gem install --user-install gemfury -v 0.12.0
+      ruby -r rubygems -e 'puts("#{Gem.user_dir}/bin")' >> $GITHUB_PATH
   - name: Install gemfury client
     if: runner.arch == 'X64'
     run: |
@@ -155,7 +155,6 @@ on:
   - name: Upload package to Gemfury
     shell: bash
     run: |
-      PATH=$(echo $(ruby -r rubygems -e 'puts Gem.user_dir'))/bin:$PATH
       fury push \
         --api-token=${CROSSBOW_GEMFURY_TOKEN} \
         --as=${CROSSBOW_GEMFURY_ORG} \
@@ -163,7 +162,6 @@ on:
     env:
       CROSSBOW_GEMFURY_TOKEN: {{ '${{ secrets.CROSSBOW_GEMFURY_TOKEN }}' }}
       CROSSBOW_GEMFURY_ORG: {{ '${{ secrets.CROSSBOW_GEMFURY_ORG }}' }}
-  {% endif %}
 {% endmacro %}
 
 {%- macro azure_checkout_arrow() -%}

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -144,7 +144,7 @@ on:
   - name: Upload package to Gemfury
     shell: bash
     run: |
-      PATH=$(echo $(ruby -r rubygems -e 'puts Gem.user_dir') | sed "s/C:\//\/c\//")/bin:$PATH
+      PATH=$(echo $(ruby -r rubygems -e 'puts Gem.user_dir'))/bin:$PATH
       # GH-36692: Pin gemfury due to wrong faraday dependency declaration.
       gem install --user-install gemfury -v 0.12.0
       fury push \

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -137,7 +137,8 @@ on:
       sudo apt update
       sudo apt install -y ruby-full
   - name: Set up Ruby by GitHub Actions
-    if: !(runner.os == 'Linux' && runner.arch != 'X64')
+    if: |
+      !(runner.os == 'Linux' && runner.arch != 'X64')
     uses: ruby/setup-ruby@1
     with:
       ruby-version: "ruby"

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -141,12 +141,20 @@ on:
     uses: ruby/setup-ruby@v1
     with:
       ruby-version: "ruby"
-  - name: Upload package to Gemfury
-    shell: bash
+  - name: Install gemfury client on ARM self-hosted
+    if: runner.os == 'Linux' && runner.arch != 'X64'
     run: |
       PATH=$(echo $(ruby -r rubygems -e 'puts Gem.user_dir'))/bin:$PATH
       # GH-36692: Pin gemfury due to wrong faraday dependency declaration.
       gem install --user-install gemfury -v 0.12.0
+  - name: Instal gemfury client
+    if: !{{ runner.os == 'Linux' && runner.arch != 'X64'}}
+    run: |
+      # GH-36692: Pin gemfury due to wrong faraday dependency declaration.
+      gem install gemfury -v 0.12.0
+  - name: Upload package to Gemfury
+    shell: bash
+    run: |
       fury push \
         --api-token=${CROSSBOW_GEMFURY_TOKEN} \
         --as=${CROSSBOW_GEMFURY_ORG} \

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -141,6 +141,7 @@ on:
     shell: bash
     run: |
       PATH=$(echo $(ruby -r rubygems -e 'puts Gem.user_dir') | sed "s/C:\//\/c\//")/bin:$PATH
+      gem install --user-install faraday -v 1.10.3
       gem install --user-install gemfury
       fury push \
         --api-token=${CROSSBOW_GEMFURY_TOKEN} \

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -136,11 +136,15 @@ on:
     run: |
       sudo apt update
       sudo apt install -y ruby-full
+  - name: Set up Ruby by GitHub Actions
+    if: !(runner.os == 'Linux' && runner.arch != 'X64')
+    use: ruby/setup-ruby@1
+    with:
+      ruby-version: "ruby"
   - name: Upload package to Gemfury
     shell: bash
     run: |
       PATH=$(echo $(ruby -r rubygems -e 'puts Gem.user_dir') | sed "s/C:\//\/c\//")/bin:$PATH
-      gem install --user-install faraday -v 1.10.3
       gem install --user-install gemfury
       fury push \
         --api-token=${CROSSBOW_GEMFURY_TOKEN} \

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -138,7 +138,7 @@ on:
       sudo apt install -y ruby-full
   - name: Set up Ruby by GitHub Actions
     if: !(runner.os == 'Linux' && runner.arch != 'X64')
-    use: ruby/setup-ruby@1
+    uses: ruby/setup-ruby@1
     with:
       ruby-version: "ruby"
   - name: Upload package to Gemfury

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -148,7 +148,8 @@ on:
       # GH-36692: Pin gemfury due to wrong faraday dependency declaration.
       gem install --user-install gemfury -v 0.12.0
   - name: Instal gemfury client
-    if: !{{ runner.os == 'Linux' && runner.arch != 'X64'}}
+    if: |
+      !(runner.os == 'Linux' && runner.arch != 'X64')
     run: |
       # GH-36692: Pin gemfury due to wrong faraday dependency declaration.
       gem install gemfury -v 0.12.0

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -142,13 +142,12 @@ on:
     with:
       ruby-version: "ruby"
   - name: Install gemfury client on ARM self-hosted
-    if: runner.os == 'Linux' && runner.arch != 'X64'
+    if: runner.arch != 'X64'
     run: |
       # GH-36692: Pin gemfury due to wrong faraday dependency declaration.
       gem install --user-install gemfury -v 0.12.0
-  - name: Instal gemfury client
-    if: |
-      !(runner.os == 'Linux' && runner.arch != 'X64')
+  - name: Install gemfury client
+    if: runner.arch == 'X64'
     run: |
       # GH-36692: Pin gemfury due to wrong faraday dependency declaration.
       gem install gemfury -v 0.12.0

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -139,7 +139,7 @@ on:
   - name: Set up Ruby by GitHub Actions
     if: |
       !(runner.os == 'Linux' && runner.arch != 'X64')
-    uses: ruby/setup-ruby@1
+    uses: ruby/setup-ruby@v1
     with:
       ruby-version: "ruby"
   - name: Upload package to Gemfury


### PR DESCRIPTION
### Rationale for this change

Some nightly wheel jobs have failed to upload.

### What changes are included in this PR?

Install required gem dependency.

### Are these changes tested?

Yes, crossbow tasks

### Are there any user-facing changes?

No
* Closes: #36692