### PR TITLE
GH-36696: [Go] Improve the MapOf and ListOf helpers

### DIFF
--- a/go/parquet/schema/helpers.go
+++ b/go/parquet/schema/helpers.go
@@ -33,23 +33,7 @@ import (
 // <list-repetition> can only be optional or required.
 // <element-repetition> can only be optional or required.
 func ListOf(n Node, rep parquet.Repetition, fieldID int32) (*GroupNode, error) {
-	if rep == parquet.Repetitions.Repeated || n.RepetitionType() == parquet.Repetitions.Repeated {
-		return nil, xerrors.New("parquet: listof repetition and element repetition must not be repeated.")
-	}
-	listName := n.Name()
-
-	switch n := n.(type) {
-	case *PrimitiveNode:
-		n.name = "element"
-	case *GroupNode:
-		n.name = "element"
-	}
-
-	list, err := NewGroupNode("list" /* name */, parquet.Repetitions.Repeated, FieldList{n}, -1 /* fieldID */)
-	if err != nil {
-		return nil, err
-	}
-	return NewGroupNodeLogical(listName, rep, FieldList{list}, ListLogicalType{}, fieldID)
+	return ListOfWithName(n.Name(), n, rep, fieldID)
 }
 
 // ListOf is a convenience helper function to create a properly structured
@@ -68,7 +52,7 @@ func ListOfWithName(listName string, element Node, rep parquet.Repetition, field
 		return nil, xerrors.Errorf("parquet: listof repetition must not be repeated, got :%s", rep)
 	}
 
-	if rep == parquet.Repetitions.Repeated || element.RepetitionType() == parquet.Repetitions.Repeated {
+	if element.RepetitionType() == parquet.Repetitions.Repeated {
 		return nil, xerrors.Errorf("parquet: element repetition must not be repeated, got: %s", element.RepetitionType())
 	}
 

--- a/go/parquet/schema/helpers.go
+++ b/go/parquet/schema/helpers.go
@@ -24,14 +24,14 @@ import (
 // ListOf is a convenience helper function to create a properly structured
 // list structure according to the Parquet Spec.
 //
-// <list-repetition> group <name> (LIST) {
-//   repeated group list {
-//     <element-repetition> <element-type> element;
-//   }
-// }
+//	<list-repetition> group <name> (LIST) {
+//	  repeated group list {
+//	    <element-repetition> <element-type> element;
+//	  }
+//	}
 //
-// <list-repetition> can only be optional or required. panics if repeated.
-// <element-repetition> can only be optional or required. panics if repeated.
+// <list-repetition> can only be optional or required.
+// <element-repetition> can only be optional or required.
 func ListOf(n Node, rep parquet.Repetition, fieldID int32) (*GroupNode, error) {
 	if rep == parquet.Repetitions.Repeated || n.RepetitionType() == parquet.Repetitions.Repeated {
 		return nil, xerrors.New("parquet: listof repetition and element repetition must not be repeated.")
@@ -52,15 +52,50 @@ func ListOf(n Node, rep parquet.Repetition, fieldID int32) (*GroupNode, error) {
 	return NewGroupNodeLogical(listName, rep, FieldList{list}, ListLogicalType{}, fieldID)
 }
 
+// ListOf is a convenience helper function to create a properly structured
+// list structure according to the Parquet Spec.
+//
+//	<list-repetition> group <name> (LIST) {
+//	  repeated group list {
+//	    <element-repetition> <element-type> element;
+//	  }
+//	}
+//
+// <list-repetition> can only be optional or required.
+// <element-repetition> can only be optional or required.
+func ListOfWithName(listName string, element Node, rep parquet.Repetition, fieldID int32) (*GroupNode, error) {
+	if rep == parquet.Repetitions.Repeated {
+		return nil, xerrors.Errorf("parquet: listof repetition must not be repeated, got :%s", rep)
+	}
+
+	if rep == parquet.Repetitions.Repeated || element.RepetitionType() == parquet.Repetitions.Repeated {
+		return nil, xerrors.Errorf("parquet: element repetition must not be repeated, got: %s", element.RepetitionType())
+	}
+
+	switch n := element.(type) {
+	case *PrimitiveNode:
+		n.name = "element"
+	case *GroupNode:
+		n.name = "element"
+	}
+
+	list, err := NewGroupNode("list" /* name */, parquet.Repetitions.Repeated, FieldList{element}, -1 /* fieldID */)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewGroupNodeLogical(listName, rep, FieldList{list}, ListLogicalType{}, fieldID)
+}
+
 // MapOf is a convenience helper function to create a properly structured
 // parquet map node setup according to the Parquet Spec.
 //
-// <map-repetition> group <name> (MAP) {
-// 	 repeated group key_value {
-// 	   required <key-type> key;
-//     <value-repetition> <value-type> value;
-//   }
-// }
+//	<map-repetition> group <name> (MAP) {
+//		 repeated group key_value {
+//		   required <key-type> key;
+//	    <value-repetition> <value-type> value;
+//	  }
+//	}
 //
 // key node will be renamed to "key", value node if not nil will be renamed to "value"
 //
@@ -69,14 +104,15 @@ func ListOf(n Node, rep parquet.Repetition, fieldID int32) (*GroupNode, error) {
 // the key node *must* be required repetition. panics if optional or repeated
 //
 // value node can be nil (omitted) or have a repetition of required or optional *only*.
-// panics if value node is not nil and has a repetition of repeated.
 func MapOf(name string, key Node, value Node, mapRep parquet.Repetition, fieldID int32) (*GroupNode, error) {
 	if mapRep == parquet.Repetitions.Repeated {
-		return nil, xerrors.New("parquet: map repetition cannot be Repeated")
+		return nil, xerrors.Errorf("parquet: map repetition cannot be Repeated, got: %s", mapRep)
 	}
+
 	if key.RepetitionType() != parquet.Repetitions.Required {
-		return nil, xerrors.New("parquet: map key repetition must be Required")
+		return nil, xerrors.Errorf("parquet: map key repetition must be Required, got: %s", key.RepetitionType())
 	}
+
 	if value != nil {
 		if value.RepetitionType() == parquet.Repetitions.Repeated {
 			return nil, xerrors.New("parquet: map value cannot have repetition Repeated")

--- a/go/parquet/schema/helpers_test.go
+++ b/go/parquet/schema/helpers_test.go
@@ -62,6 +62,25 @@ func TestListOfNested(t *testing.T) {
 }`, strings.TrimSpace(buf.String()))
 }
 
+func TestListOfWithNameNested(t *testing.T) {
+	n, err := schema.ListOfWithName("arrays", schema.NewInt32Node("element", parquet.Repetitions.Required, -1), parquet.Repetitions.Required, -1)
+	assert.NoError(t, err)
+	final, err := schema.ListOf(n, parquet.Repetitions.Required, -1)
+	assert.NoError(t, err)
+
+	var buf bytes.Buffer
+	schema.PrintSchema(final, &buf, 4)
+	assert.Equal(t,
+		`required group field_id=-1 arrays (List) {
+    repeated group field_id=-1 list {
+        required group field_id=-1 element (List) {
+            repeated group field_id=-1 list {
+                required int32 field_id=-1 element;
+            }
+        }
+    }
+}`, strings.TrimSpace(buf.String()))
+}
 func TestMapOfNestedTypes(t *testing.T) {
 	n, err := schema.NewGroupNode("student", parquet.Repetitions.Required, schema.FieldList{
 		schema.NewByteArrayNode("name", parquet.Repetitions.Required, -1),


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The aim is to improve the MapOf and ListOf helper functions without breaking anything. I have added a `ListOfWithName` which matches the `MapOf` function in that it takes a name, rather than deriving it from the elements name, which should actually be `element`.

This just seems clearer to me as an interface, and makes construction a bit more obvious.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

* Removed references to panics I can't find
* Updated error messages for list and map to be clearer with validation errors
* Added a ListOfWithName to provide a clearer matching method to MapOf which takes a name

Closes #36696 

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes, I added a test for the new `ListOfWithName` function.

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #36696