### PR TITLE
GH-36698: [Go][Parquet] Add a TimestampLogicalType creation function …

### DIFF
--- a/go/parquet/schema/logical_types.go
+++ b/go/parquet/schema/logical_types.go
@@ -616,6 +616,55 @@ func NewTimestampLogicalTypeForce(isAdjustedToUTC bool, unit TimeUnitType) Logic
 	}
 }
 
+// TimestampOpt options used with New Timestamp Logical Type
+type TimestampOpt func(*TimestampLogicalType)
+
+// WithTSIsAdjustedToUTC sets the IsAdjustedToUTC field of the timestamp type.
+func WithTSIsAdjustedToUTC() TimestampOpt {
+	return func(t *TimestampLogicalType) {
+		t.typ.IsAdjustedToUTC = true
+	}
+}
+
+// WithTSTimeUnitType sets the time unit for the timestamp type
+func WithTSTimeUnitType(unit TimeUnitType) TimestampOpt {
+	return func(t *TimestampLogicalType) {
+		t.typ.Unit = createTimeUnit(unit)
+	}
+}
+
+// WithTSForceConverted enable force converted mode
+func WithTSForceConverted() TimestampOpt {
+	return func(t *TimestampLogicalType) {
+		t.forceConverted = true
+	}
+}
+
+// WithTSFromConverted enable the timestamp logical type to be
+// constructed from a converted type.
+func WithTSFromConverted() TimestampOpt {
+	return func(t *TimestampLogicalType) {
+		t.fromConverted = true
+	}
+}
+
+// NewTimestampLogicalTypeWithOpts creates a new TimestampLogicalType with the provided options.
+//
+// TimestampType Unit defaults to milliseconds (TimeUnitMillis)
+func NewTimestampLogicalTypeWithOpts(opts ...TimestampOpt) LogicalType {
+	ts := &TimestampLogicalType{
+		typ: &format.TimestampType{
+			Unit: createTimeUnit(TimeUnitMillis), // default to milliseconds
+		},
+	}
+
+	for _, o := range opts {
+		o(ts)
+	}
+
+	return ts
+}
+
 // TimestampLogicalType represents an int64 number that can be decoded
 // into a year, month, day, hour, minute, second, and subsecond
 type TimestampLogicalType struct {

--- a/go/parquet/schema/logical_types_test.go
+++ b/go/parquet/schema/logical_types_test.go
@@ -93,6 +93,7 @@ func TestConvertedTypeCompatibility(t *testing.T) {
 		{"time_micro", schema.NewTimeLogicalType(true /* adjutedToUTC */, schema.TimeUnitMicros), schema.ConvertedTypes.TimeMicros},
 		{"timestamp_milli", schema.NewTimestampLogicalType(true /* adjutedToUTC */, schema.TimeUnitMillis), schema.ConvertedTypes.TimestampMillis},
 		{"timestamp_micro", schema.NewTimestampLogicalType(true /* adjutedToUTC */, schema.TimeUnitMicros), schema.ConvertedTypes.TimestampMicros},
+		{"timestamp_milli_opts", schema.NewTimestampLogicalTypeWithOpts(schema.WithTSIsAdjustedToUTC(), schema.WithTSTimeUnitType(schema.TimeUnitMillis)), schema.ConvertedTypes.TimestampMillis},
 		{"uint8", schema.NewIntLogicalType(8 /* bitWidth */, false /* signed */), schema.ConvertedTypes.Uint8},
 		{"uint16", schema.NewIntLogicalType(16 /* bitWidth */, false /* signed */), schema.ConvertedTypes.Uint16},
 		{"uint32", schema.NewIntLogicalType(32 /* bitWidth */, false /* signed */), schema.ConvertedTypes.Uint32},


### PR DESCRIPTION
…with more options

This change introduces a more flexible creation function for TimestampLogicalType which will enable changes to all the flags provided by this type, but without requiring a lot of parameters.

Following on from other great examples in arrow it uses the functional options pattern.


<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Add a `TimestampLogicalType` creation function with more options, in particular an option to set `fromConverted` as I can't see another way to set this private struct property after creation.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This change introduces a more flexible creation function for `TimestampLogicalType` which will enable changes to all the flags provided by this type, but without requiring a lot of parameters.

### Are these changes tested?

Yes I have updated one of the existing tests.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #36698