### PR TITLE
GH-36707: [C++] Use ARROW_PACKAGE_PREFIX for OPENSSL_ROOT_DIR too

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -138,6 +138,9 @@ if(ARROW_PACKAGE_PREFIX)
   if(NOT ENV{Boost_ROOT})
     set(ENV{Boost_ROOT} ${ARROW_PACKAGE_PREFIX})
   endif()
+  if(NOT DEFINED OPENSSL_ROOT_DIR)
+    set(OPENSSL_ROOT_DIR ${ARROW_PACKAGE_PREFIX})
+  endif()
 endif()
 
 # For each dependency, set dependency source to global default, if unset


### PR DESCRIPTION
### Rationale for this change

In general, a CMake package uses `${PACKAGE}_ROOT` variable to detect `PACKAGE` but `FindOpenSSL.cmake` uses `OPENSSL_ROOT_DIR` not `OpenSSL_ROOT`.

### What changes are included in this PR?

Set `OPENSSL_ROOT_DIR` explicitly.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #36707