### PR TITLE
GH-33030: [Python] Fix serialization of DataFrames with MultiIndex with ranges and values

### DIFF
--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -218,12 +218,17 @@ def construct_metadata(columns_to_convert, df, column_names, index_levels,
     index_column_metadata = []
     if preserve_index is not False:
         non_str_index_names = []
-        for level, arrow_type, descriptor in zip(index_levels, index_types,
-                                                 index_descriptors):
+        index_types_idx = 0
+        for level, descriptor in zip(index_levels, index_descriptors):
             if isinstance(descriptor, dict):
                 # The index is represented in a non-serialized fashion,
                 # e.g. RangeIndex
                 continue
+
+            # index_types contains only the types of descriptors that aren't
+            # dictionaries, so len(index_types) <= len(index_descriptors)
+            arrow_type = index_types[index_types_idx]
+            index_types_idx += 1
 
             if level.name is not None and not isinstance(level.name, str):
                 non_str_index_names.append(level.name)

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -487,6 +487,22 @@ class TestConvertMetadata:
 
         _check_pandas_roundtrip(df, preserve_index=True)
 
+    def test_multiindex_containing_range_and_values(self):
+        # GH-33030
+        index = pd.MultiIndex.from_arrays(
+            [
+                pd.RangeIndex(3),
+                np.array([20, 21, 22], dtype=np.int64),
+            ],
+            names=["i0", "i1"],
+        )
+        df = pd.DataFrame(
+            {"values": np.array([10, 11, 12], dtype=np.int16)},
+            index=index,
+        )
+
+        _check_pandas_roundtrip(df, preserve_index=None)
+
     def test_metadata_with_mixed_types(self):
         df = pd.DataFrame({'data': [b'some_bytes', 'some_unicode']})
         table = pa.Table.from_pandas(df)


### PR DESCRIPTION

<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Pyarrow may fail to write and read a dataframe with MultiIndex containing a RangeIndex and regular values, when `from_pandas()` is called with `preserve_index=None` (that is the default).

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

This PR fixes the loop in `construct_metadata()` and ensures that all the columns needed by the MultiIndex are serialized.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->


### Are these changes tested?

Yes.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #33030