### PR TITLE
GH-36744: [Python][Packaging] Add upper pin for cython<3 to pyarrow build dependencies

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -103,7 +103,7 @@ jobs:
         shell: bash
         run: |
           gem install test-unit
-          pip install cython setuptools six pytest jira
+          pip install cython<3 setuptools six pytest jira
       - name: Run Release Test
         env:
           ARROW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -103,7 +103,7 @@ jobs:
         shell: bash
         run: |
           gem install test-unit
-          pip install cython<3 setuptools six pytest jira
+          pip install "cython<3" setuptools six pytest jira
       - name: Run Release Test
         env:
           ARROW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ci/conda_env_python.txt
+++ b/ci/conda_env_python.txt
@@ -18,7 +18,7 @@
 # don't add pandas here, because it is not a mandatory test dependency
 boto3  # not a direct dependency of s3fs, but needed for our s3fs fixture
 cffi
-cython
+cython<3
 cloudpickle
 fsspec
 hypothesis

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -17,7 +17,7 @@
 
 [build-system]
 requires = [
-    "cython >= 0.29.31",
+    "cython >= 0.29.31,<3",
     "oldest-supported-numpy>=0.14",
     "setuptools_scm",
     "setuptools >= 40.1.0",

--- a/python/requirements-build.txt
+++ b/python/requirements-build.txt
@@ -1,4 +1,4 @@
-cython>=0.29.31
+cython>=0.29.31,<3
 oldest-supported-numpy>=0.14
 setuptools_scm
 setuptools>=38.6.0

--- a/python/requirements-wheel-build.txt
+++ b/python/requirements-wheel-build.txt
@@ -1,4 +1,4 @@
-cython>=0.29.31
+cython>=0.29.31,<3
 oldest-supported-numpy>=0.14
 setuptools_scm
 setuptools>=58

--- a/python/setup.py
+++ b/python/setup.py
@@ -40,8 +40,9 @@ import Cython
 # Check if we're running 64-bit Python
 is_64_bit = sys.maxsize > 2**32
 
-if Cython.__version__ < '0.29.31':
-    raise Exception('Please upgrade to Cython 0.29.31 or newer')
+if Cython.__version__ < '0.29.31' or Cython.__version__ >= '3.0':
+    raise Exception(
+        'Please update your Cython version. Supported Cython >= 0.29.31, < 3.0')
 
 setup_dir = os.path.abspath(os.path.dirname(__file__))
 
@@ -491,7 +492,7 @@ setup(
                                  'pyarrow/_generated_version.py'),
         'version_scheme': guess_next_dev_version
     },
-    setup_requires=['setuptools_scm', 'cython >= 0.29.31'] + setup_requires,
+    setup_requires=['setuptools_scm', 'cython >= 0.29.31,<3'] + setup_requires,
     install_requires=install_requires,
     tests_require=['pytest', 'pandas', 'hypothesis'],
     python_requires='>=3.8',


### PR DESCRIPTION
### Rationale for this change

Although we already fixed some cython 3 build issues (https://github.com/apache/arrow/pull/34726), some new have been introduced, which we are seeing now cython 3 is released (https://github.com/apache/arrow/issues/36730)

Adding an upper pin (<3) for the release, so we have more time (the full 14.0 release cycle) to iron out issues.
* Closes: #36744