### PR TITLE
GH-36149: `table.group_by([]).aggregate` raises an error on some aggregate functions

### DIFF
--- a/cpp/src/arrow/acero/plan_test.cc
+++ b/cpp/src/arrow/acero/plan_test.cc
@@ -1474,7 +1474,11 @@ GetDistinctBatch() {
        "[[48615], [48675], [48735]]"},
       {arrow::int32(), arrow::duration(arrow::TimeUnit::SECOND),
        "[[1, 20], [2, 40], [3, 20]]", "[[4, 60], [5, 40], [6, 30]]",
-       "[[20], [30], [40], [60]]"}};
+       "[[20], [30], [40], [60]]"},
+      {arrow::int32(), arrow::utf8(),
+       std::string(R"([[1, "abcd"], [2, "efgh"], [3, "abcd"]])"),
+       std::string(R"([[4, "efgh"], [5, "hijk"], [6, "abcd"]])"),
+       std::string(R"([["abcd"], ["efgh"], ["hijk"]])")}};
 }
 
 // Order of parameters: Key Type, Value Type, Batch 1, Batch 2, Output
@@ -1498,7 +1502,11 @@ GetDistinctBatchScalar() {
        "[[48615], [48675], [48735]]"},
       {arrow::int32(), arrow::duration(arrow::TimeUnit::SECOND),
        "[[1, 20], [2, 40], [3, 20]]", "[[4, 60], [5, 40], [6, 30]]",
-       "[[20], [30], [40], [60]]"}};
+       "[[20], [30], [40], [60]]"},
+      {arrow::int32(), arrow::utf8(),
+       std::string(R"([[1, "abcd"], [2, "efgh"], [3, "abcd"]])"),
+       std::string(R"([[4, "efgh"], [5, "hijk"], [6, "abcd"]])"),
+       std::string(R"([["abcd"], ["efgh"], ["hijk"]])")}};
 }
 
 INSTANTIATE_TEST_SUITE_P(ScalarAggregatorArrayTest, ScalarAggregateDistinctTest,

--- a/cpp/src/arrow/acero/plan_test.cc
+++ b/cpp/src/arrow/acero/plan_test.cc
@@ -17,7 +17,6 @@
 
 #include <gmock/gmock-matchers.h>
 
-#include <algorithm>
 #include <functional>
 #include <memory>
 
@@ -42,9 +41,6 @@
 #include "arrow/util/macros.h"
 #include "arrow/util/thread_pool.h"
 #include "arrow/util/vector.h"
-
-// TODO: remove after debug
-#include "arrow/api.h"
 
 using testing::Contains;
 using testing::ElementsAre;

--- a/cpp/src/arrow/acero/plan_test.cc
+++ b/cpp/src/arrow/acero/plan_test.cc
@@ -17,6 +17,7 @@
 
 #include <gmock/gmock-matchers.h>
 
+#include <algorithm>
 #include <functional>
 #include <memory>
 
@@ -1444,20 +1445,21 @@ TEST(ExecPlanExecution, ScalarSourceScalarAggSink) {
   AssertExecBatchesEqualIgnoringOrder(result.schema, result.batches, exp_batches);
 }
 
-/// TODO: parametrize this test case for various types and data
-/// 1. Parameterize the types
-/// 2. Parameterize the input data
-
-class ScalarAggregateDistinctTest
+class ScalarAggregateDistinctArrayTest
     : public ::testing::TestWithParam<
           std::tuple<std::shared_ptr<arrow::DataType>, std::shared_ptr<arrow::DataType>,
                      std::string, std::string, std::string>> {};
+
+class ScalarAggregateDistinctScalarTest
+    : public ::testing::TestWithParam<
+          std::tuple<std::shared_ptr<arrow::DataType>, std::shared_ptr<arrow::DataType>,
+                     std::string, std::string, std::string, std::string, std::string>> {};
 
 // Order of parameters: Key Type, Value Type, Batch 1, Batch 2, Output
 static std::vector<
     std::tuple<std::shared_ptr<arrow::DataType>, std::shared_ptr<arrow::DataType>,
                std::string, std::string, std::string>>
-GetDistinctBatch() {
+GetDistinctBatchOfArray() {
   return std::vector<
       std::tuple<std::shared_ptr<arrow::DataType>, std::shared_ptr<arrow::DataType>,
                  std::string, std::string, std::string>>{
@@ -1484,38 +1486,35 @@ GetDistinctBatch() {
 // Order of parameters: Key Type, Value Type, Batch 1, Batch 2, Output
 static std::vector<
     std::tuple<std::shared_ptr<arrow::DataType>, std::shared_ptr<arrow::DataType>,
-               std::string, std::string, std::string>>
-GetDistinctBatchScalar() {
+               std::string, std::string, std::string, std::string, std::string>>
+GetDistinctBatchOfScalar() {
   return std::vector<
       std::tuple<std::shared_ptr<arrow::DataType>, std::shared_ptr<arrow::DataType>,
-                 std::string, std::string, std::string>>{
-      {arrow::int32(), arrow::boolean(), "[[1, false], [2, false], [3, false]]",
-       "[[4, true], [5, true], [6, false]]", "[[false, true]]"},
-      {arrow::int32(), arrow::int32(), "[[1, 10], [2, 20], [3, 10]]",
-       "[[4, 10], [5, 30], [6, 20]]", "[[10, 20, 30]]"},
-      {arrow::int32(), arrow::timestamp(arrow::TimeUnit::SECOND),
-       "[[1, 1609459200], [2, 1609545600], [3, 1609632000]]",
-       "[[4, 1609545600], [5, 1609459200], [6, 1609459200]]",
+                 std::string, std::string, std::string, std::string, std::string>>{
+      {arrow::int32(), arrow::boolean(), "[[1, false]]", "[[2, false]]", "[[3, true]]",
+       "[[4, false]]", "[[false], [true]]"},
+      {arrow::int32(), arrow::int32(), "[[1, 10]]", "[[2, 20]]", "[[3, 10]]", "[[4, 30]]",
+       "[[10], [20], [30]]"},
+      {arrow::int32(), arrow::timestamp(arrow::TimeUnit::SECOND), "[[1, 1609459200]]",
+       "[[2, 1609545600]]", "[[3, 1609632000]]", "[[4, 1609545600]]",
        "[[1609459200], [1609545600], [1609632000]]"},
-      {arrow::int32(), arrow::time32(arrow::TimeUnit::SECOND),
-       "[[1, 48615], [2, 48615], [3, 48735]]", "[[4, 48615], [5, 48735], [6, 48675]]",
-       "[[48615], [48675], [48735]]"},
-      {arrow::int32(), arrow::duration(arrow::TimeUnit::SECOND),
-       "[[1, 20], [2, 40], [3, 20]]", "[[4, 60], [5, 40], [6, 30]]",
-       "[[20], [30], [40], [60]]"},
-      {arrow::int32(), arrow::utf8(),
-       std::string(R"([[1, "abcd"], [2, "efgh"], [3, "abcd"]])"),
-       std::string(R"([[4, "efgh"], [5, "hijk"], [6, "abcd"]])"),
+      {arrow::int32(), arrow::time32(arrow::TimeUnit::SECOND), "[[1, 48615]]",
+       "[[2, 48675]]", "[[3, 48675]]", "[[4, 48735]]", "[[48615], [48675], [48735]]"},
+      {arrow::int32(), arrow::duration(arrow::TimeUnit::SECOND), "[[1, 20]]", "[[2, 60]]",
+       "[[3, 20]]", "[[4, 60]]", "[[20], [60]]"},
+      {arrow::int32(), arrow::utf8(), std::string(R"([[1, "abcd"]])"),
+       std::string(R"([[2, "efgh"]])"), std::string(R"([[3, "hijk"]])"),
+       std::string(R"([[4, "efgh"]])"),
        std::string(R"([["abcd"], ["efgh"], ["hijk"]])")}};
 }
 
-INSTANTIATE_TEST_SUITE_P(ScalarAggregatorArrayTest, ScalarAggregateDistinctTest,
-                         ::testing::ValuesIn(GetDistinctBatch()));
+INSTANTIATE_TEST_SUITE_P(ScalarAggregatorArrayTest, ScalarAggregateDistinctArrayTest,
+                         ::testing::ValuesIn(GetDistinctBatchOfArray()));
 
-INSTANTIATE_TEST_SUITE_P(ScalarAggregatorScalarTest, ScalarAggregateDistinctTest,
-                         ::testing::ValuesIn(GetDistinctBatchScalar()));
+INSTANTIATE_TEST_SUITE_P(ScalarAggregatorScalarTest, ScalarAggregateDistinctScalarTest,
+                         ::testing::ValuesIn(GetDistinctBatchOfScalar()));
 
-TEST_P(ScalarAggregateDistinctTest, WithArray) {
+TEST_P(ScalarAggregateDistinctArrayTest, WithArray) {
   BatchesWithSchema scalar_data;
   auto param = GetParam();
   std::shared_ptr<arrow::DataType> key_type = std::get<0>(param);
@@ -1542,77 +1541,36 @@ TEST_P(ScalarAggregateDistinctTest, WithArray) {
   AssertExecBatchesEqualIgnoringOrder(result.schema, result.batches, exp_batches);
 }
 
-TEST_P(ScalarAggregateDistinctTest, WithScalar) {
+TEST_P(ScalarAggregateDistinctScalarTest, WithScalar) {
   BatchesWithSchema scalar_data;
   auto param = GetParam();
   std::shared_ptr<arrow::DataType> key_type = std::get<0>(param);
   std::shared_ptr<arrow::DataType> val_type = std::get<1>(param);
   std::string first_batch = std::get<2>(param);
   std::string second_batch = std::get<3>(param);
-  std::string output_batch = std::get<4>(param);
+  std::string third_batch = std::get<4>(param);
+  std::string fourth_batch = std::get<5>(param);
+  std::string output_batch = std::get<6>(param);
 
   scalar_data.batches = {
       ExecBatchFromJSON({key_type, val_type}, {ArgShape::SCALAR, ArgShape::SCALAR},
                         first_batch),
       ExecBatchFromJSON({key_type, val_type}, {ArgShape::SCALAR, ArgShape::SCALAR},
                         second_batch),
+      ExecBatchFromJSON({key_type, val_type}, {ArgShape::SCALAR, ArgShape::SCALAR},
+                        third_batch),
+      ExecBatchFromJSON({key_type, val_type}, {ArgShape::SCALAR, ArgShape::SCALAR},
+                        fourth_batch),
   };
-
   scalar_data.schema = schema({field("key", key_type), field("value", val_type)});
   Declaration plan = Declaration::Sequence(
       {{"source", SourceNodeOptions{scalar_data.schema,
                                     scalar_data.gen(/*parallel=*/false, /*slow=*/false)}},
        {"aggregate", AggregateNodeOptions{/*aggregates=*/{
                          {"distinct", nullptr, "value", "distinct(value)"}}}}});
-  // ASSERT_OK_AND_ASSIGN(auto result, DeclarationToExecBatches(std::move(plan)));
-  // auto exp_batches = {ExecBatchFromJSON({val_type}, {ArgShape::ARRAY}, output_batch)};
-  // AssertExecBatchesEqualIgnoringOrder(result.schema, result.batches, exp_batches);
-  ASSERT_OK_AND_ASSIGN(auto result, DeclarationToTable(std::move(plan)));
-  std::cout << result->ToString() << std::endl;
-}
-
-TEST(ExecPlanExecution, ScalarSourceScalarDistinctAggSink) {
-  BatchesWithSchema scalar_data;
-  scalar_data.batches = {
-      ExecBatchFromJSON({int32(), boolean(), arrow::timestamp(arrow::TimeUnit::SECOND),
-                         arrow::time32(arrow::TimeUnit::SECOND),
-                         arrow::duration(arrow::TimeUnit::SECOND), int32()},
-                        {ArgShape::SCALAR, ArgShape::SCALAR, ArgShape::SCALAR,
-                         ArgShape::SCALAR, ArgShape::SCALAR, ArgShape::SCALAR},
-                        "[[5, false, 1609459200, 48615, 60, 10], [5, false, 1609545600, "
-                        "48615, 20, 20], [5, false, 1609632000, 48735, 20, 10]]"),
-      ExecBatchFromJSON({int32(), boolean(), arrow::timestamp(arrow::TimeUnit::SECOND),
-                         arrow::time32(arrow::TimeUnit::SECOND),
-                         arrow::duration(arrow::TimeUnit::SECOND), int32()},
-                        "[[5, true, 1609545600, 48735, 20, 10], [6, false, 1609459200, "
-                        "48855, 40, 30], [7, true, 1609459200, 48735, 60, 20]]")};
-  scalar_data.schema =
-      schema({field("a", int32()), field("b", boolean()),
-              field("c", arrow::timestamp(arrow::TimeUnit::SECOND)),
-              field("d", arrow::time32(arrow::TimeUnit::SECOND)),
-              field("e", arrow::duration(arrow::TimeUnit::SECOND)), field("f", int32())});
-  std::cout << "Data OK" << std::endl;
-  // index can't be tested as it's order-dependent
-  // mode/quantile can't be tested as they're technically vector kernels
-  Declaration plan = Declaration::Sequence(
-      {{"source", SourceNodeOptions{scalar_data.schema,
-                                    scalar_data.gen(/*parallel=*/false, /*slow=*/false)}},
-       {"aggregate",
-        AggregateNodeOptions{/*aggregates=*/{{"distinct", nullptr, "f", "distinct"}}}}});
-
-  // auto exp_batches = {
-  //     ExecBatchFromJSON(
-  //         {boolean(), boolean(), int64(), int64(), float64(), int64(), float64(),
-  //         int64(),
-  //          float64(), float64()},
-  //         {ArgShape::SCALAR, ArgShape::SCALAR, ArgShape::SCALAR, ArgShape::SCALAR,
-  //          ArgShape::SCALAR, ArgShape::SCALAR, ArgShape::SCALAR, ArgShape::SCALAR,
-  //          ArgShape::ARRAY, ArgShape::SCALAR},
-  //         R"([[false, true, 6, 6, 5.5, 26250, 0.7637626158259734, 33, 5.0,
-  //         0.5833333333333334]])"),
-  // };
-  ASSERT_OK_AND_ASSIGN(auto res, DeclarationToTable(std::move(plan)));
-  std::cout << res->ToString() << std::endl;
+  ASSERT_OK_AND_ASSIGN(auto result, DeclarationToExecBatches(std::move(plan)));
+  auto exp_batches = {ExecBatchFromJSON({val_type}, {ArgShape::ARRAY}, output_batch)};
+  AssertExecBatchesEqualIgnoringOrder(result.schema, result.batches, exp_batches);
 }
 
 TEST(ExecPlanExecution, ScalarSourceStandaloneNullaryScalarAggSink) {

--- a/cpp/src/arrow/compute/kernels/aggregate_basic.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic.cc
@@ -205,8 +205,7 @@ struct DistinctImpl : public ScalarAggregator {
     RETURN_NOT_OK(DictTraits::GetDictionaryArrayData(ctx->memory_pool(), this->out_type,
                                                      *this->memo_table_,
                                                      0 /* start_offset */, &data));
-    auto arr = MakeArray(data);
-    *out = Datum(std::move(arr));
+    *out = Datum(MakeArray(data));
     return Status::OK();
   }
 

--- a/cpp/src/arrow/compute/kernels/aggregate_basic.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic.cc
@@ -32,9 +32,6 @@
 
 #include <memory>
 
-// TODO: remove after debug
-#include <iostream>
-
 namespace arrow {
 namespace compute {
 namespace internal {

--- a/cpp/src/arrow/compute/kernels/aggregate_basic.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic.cc
@@ -15,15 +15,21 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include "arrow/array/concatenate.h"
 #include "arrow/compute/api_aggregate.h"
+#include "arrow/compute/api_vector.h"
 #include "arrow/compute/kernels/aggregate_basic_internal.h"
 #include "arrow/compute/kernels/aggregate_internal.h"
 #include "arrow/compute/kernels/common_internal.h"
 #include "arrow/compute/kernels/util_internal.h"
+#include "arrow/result.h"
 #include "arrow/util/cpu_info.h"
 #include "arrow/util/hashing.h"
 
 #include <memory>
+
+// TODO: remove after debug
+#include<iostream>
 
 namespace arrow {
 namespace compute {
@@ -148,6 +154,121 @@ Result<std::unique_ptr<KernelState>> CountAllInit(KernelContext*,
 Result<std::unique_ptr<KernelState>> CountInit(KernelContext*,
                                                const KernelInitArgs& args) {
   return std::make_unique<CountImpl>(static_cast<const CountOptions&>(*args.options));
+}
+
+// ----------------------------------------------------------------------
+// Distinct implementations
+
+/// TODO: like in DistinctCountImpl we have to template this one
+/// the reason is handling scalars would need a ArrayBuilder
+/// and that need the ArrowType to be passed
+
+/// TODO: also check whether can we take a vector of arrays and concatenate them
+/// at the end and find the unique. This could reduce the complicated logic in the merge
+/// function. 
+struct DistinctImpl : public ScalarAggregator {
+  explicit DistinctImpl() = default ;
+
+  Status Consume(KernelContext*, const ExecSpan& batch) override {
+    
+    if (batch[0].is_array()) {
+      std::cout << "Array" << std::endl;
+      const ArraySpan& input = batch[0].array;
+      ARROW_ASSIGN_OR_RAISE(auto unique_array, arrow::compute::Unique(input.ToArray()))
+      std::cout << "unique array " << unique_array->ToString() << std::endl;
+      this->array = std::move(unique_array);
+      std::cout << "this array " << this->array->ToString() << std::endl;
+    } else {
+      std::cout << "Scalar" << std::endl;
+      const Scalar& input = *batch[0].scalar;
+      std::cout << input.ToString() << std::endl;
+      return Status::NotImplemented("Scalar support not implemented");
+    }
+    return Status::OK();
+  }
+
+  Status MergeFrom(KernelContext* ctx, KernelState&& src) override {
+    const auto& other_state = checked_cast<const DistinctImpl&>(src);
+    auto this_array = this->array;
+    auto other_array = other_state.array;
+    if(other_array && this_array) {
+      ARROW_ASSIGN_OR_RAISE(auto merged_array, arrow::Concatenate({this_array, other_array},ctx->memory_pool()));
+      this->array = std::move(merged_array);
+      std::cout << "Merge Array(other_array && this_array): " << this->array->ToString() << std::endl;
+    } else if(other_array) {
+      ARROW_ASSIGN_OR_RAISE(auto unique_array, arrow::compute::Unique(other_array))
+      this->array = std::move(unique_array);
+      std::cout << "Merge Array(other_array): " << this->array->ToString() << std::endl;
+    } else if(this_array) {
+      ARROW_ASSIGN_OR_RAISE(auto unique_array, arrow::compute::Unique(this_array))
+      this->array = std::move(unique_array);
+      std::cout << "Merge Array(this_array): " << this->array->ToString() << std::endl;
+    }
+    return Status::OK();
+  }
+
+  Status Finalize(KernelContext* ctx, Datum* out) override {
+    std::cout << "Finalize" << std::endl;
+    const auto& state = checked_cast<const DistinctImpl&>(*ctx->state());
+    //std::cout << "Finalize Array: " << state.array->ToString() << std::endl;
+    if(state.array) {
+      *out = Datum(state.array);
+    }
+    return Status::OK();
+  }
+  std::shared_ptr<Array> array;
+};
+
+Result<std::unique_ptr<KernelState>> DistinctInit(KernelContext*,
+                                                  const KernelInitArgs& args) {
+  return std::make_unique<DistinctImpl>();
+}
+
+
+void AddDistinctKernel(InputType type, OutputType out_type, ScalarAggregateFunction* func) {
+  AddAggKernel(KernelSignature::Make({type}, out_type),
+               DistinctInit, func);
+  
+}
+
+void AddDistinctKernels(ScalarAggregateFunction* func) {
+  // Boolean
+  AddDistinctKernel(boolean(), boolean(), func);
+  // Number
+  AddDistinctKernel(int8(), int8(), func);
+  AddDistinctKernel(int16(), int16(), func);
+  AddDistinctKernel(int32(), int32(), func);
+  AddDistinctKernel(int64(), int64(), func);
+  AddDistinctKernel(uint8(), uint8(), func);
+  AddDistinctKernel(uint16(), uint16(), func);
+  AddDistinctKernel(uint32(), uint32(), func);
+  AddDistinctKernel(uint64(), uint64(), func);
+  AddDistinctKernel(float16(), float16(), func);
+  AddDistinctKernel(float32(), float32(), func);
+  AddDistinctKernel(float64(), float64(), func);
+  // Date
+  AddDistinctKernel(date32(), date32(), func);
+  AddDistinctKernel(date64(), date64(), func);
+  // Time
+  // AddDistinctKernel(match::SameTypeId(Type::TIME32), arrow::time32(arrow::TimeUnit::SECOND), func);
+  // AddDistinctKernel(match::SameTypeId(Type::TIME32), arrow::time32(arrow::TimeUnit::MILLI), func);
+  // AddDistinctKernel(match::SameTypeId(Type::TIME64), arrow::time64(arrow::TimeUnit::SECOND), func);
+  // AddDistinctKernel(match::SameTypeId(Type::TIME64), arrow::time64(arrow::TimeUnit::MILLI), func);
+  // // Timestamp & Duration
+  AddDistinctKernel(match::SameTypeId(Type::TIMESTAMP), arrow::timestamp(arrow::TimeUnit::SECOND), func);
+  AddDistinctKernel(match::SameTypeId(Type::TIMESTAMP), arrow::timestamp(arrow::TimeUnit::MILLI), func);
+  AddDistinctKernel(match::SameTypeId(Type::TIMESTAMP), arrow::timestamp(arrow::TimeUnit::MICRO), func);
+  AddDistinctKernel(match::SameTypeId(Type::TIMESTAMP), arrow::timestamp(arrow::TimeUnit::NANO), func);
+  // AddDistinctKernel(match::SameTypeId(Type::DURATION), match::SameTypeId(Type::DURATION), func);
+  // // Interval
+  // AddDistinctKernel(month_interval(), month_interval(), func);
+  // AddDistinctKernel(day_time_interval(), day_time_interval(), func);
+  // AddDistinctKernel(month_day_nano_interval(), month_day_nano_interval(), func);
+  // // Binary & String
+  // AddDistinctKernel(match::BinaryLike(), match::BinaryLike(), func);
+  // AddDistinctKernel(match::LargeBinaryLike(), match::LargeBinaryLike(), func);
+  // // Fixed binary & Decimal
+  // AddDistinctKernel(match::FixedSizeBinaryLike(), match::FixedSizeBinaryLike(), func);
 }
 
 // ----------------------------------------------------------------------
@@ -1012,6 +1133,9 @@ const FunctionDoc index_doc{"Find the index of the first occurrence of a given v
                             {"array"},
                             "IndexOptions",
                             /*options_required=*/true};
+const FunctionDoc distinct_doc{"Select unique values",
+                                     ("All unique values are returned"),
+                                     {"array"}};
 
 }  // namespace
 
@@ -1182,6 +1306,11 @@ void RegisterScalarAggregateBasic(FunctionRegistry* registry) {
   AddBasicAggKernels(IndexInit::Init,
                      {fixed_size_binary(1), decimal128(1, 0), decimal256(1, 0), null()},
                      int64(), func.get());
+  DCHECK_OK(registry->AddFunction(std::move(func)));
+  // distinct
+  func = std::make_shared<ScalarAggregateFunction>("distinct", Arity::Unary(), distinct_doc);
+
+  AddDistinctKernels(func.get());
   DCHECK_OK(registry->AddFunction(std::move(func)));
 }
 

--- a/cpp/src/arrow/compute/kernels/aggregate_basic.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic.cc
@@ -236,31 +236,7 @@ void AddDistinctKernel(InputType type, ScalarAggregateFunction* func) {
   AddAggKernel(std::move(sig), DistinctInit<Type, VisitorArgType>, func);
 }
 
-// template <typename Type, typename VisitorArgType = typename Type::c_type>
-// void AddDistinctKernel(const std::vector<std::shared_ptr<DataType>> types,
-//                        ScalarAggregateFunction* func) {
-//   for (const auto& type : types) {
-//     auto sig = KernelSignature::Make({InputType(type)}, DistinctType);
-//     AddAggKernel(std::move(sig), DistinctInit<Type, VisitorArgType>, func);
-//   }
-// }
-
 void AddDistinctKernels(ScalarAggregateFunction* func) {
-  // AddDistinctKernel({null(), boolean()}, func);
-  // AddDistinctKernel(NumericTypes(), func);
-  // AddDistinctKernel(TemporalTypes(), func);
-  // AddDistinctKernel(BaseBinaryTypes(), func);
-  // AddDistinctKernel(match::SameTypeId(Type::TIME32), func);
-  // AddDistinctKernel(match::SameTypeId(Type::TIME64), func);
-  // AddDistinctKernel(match::SameTypeId(Type::TIMESTAMP), func);
-  // AddDistinctKernel(match::SameTypeId(Type::DURATION), func);
-  // AddDistinctKernel(Type::FIXED_SIZE_BINARY, func);
-  // AddDistinctKernel(Type::INTERVAL_MONTHS, func);
-  // AddDistinctKernel(Type::INTERVAL_DAY_TIME, func);
-  // AddDistinctKernel(Type::INTERVAL_MONTH_DAY_NANO, func);
-  // AddDistinctKernel(Type::DECIMAL128, func);
-  // AddDistinctKernel(Type::DECIMAL256, func);
-
   // Boolean
   AddDistinctKernel<BooleanType>(boolean(), func);
   // Number
@@ -292,8 +268,8 @@ void AddDistinctKernels(ScalarAggregateFunction* func) {
   AddDistinctKernel<BinaryType, std::string_view>(match::BinaryLike(), func);
   AddDistinctKernel<LargeBinaryType, std::string_view>(match::LargeBinaryLike(), func);
   // Fixed binary & Decimal
-  // AddDistinctKernel<FixedSizeBinaryType, std::string_view>(
-  //     match::FixedSizeBinaryLike(), func);
+  AddDistinctKernel<FixedSizeBinaryType, std::string_view>(match::FixedSizeBinaryLike(),
+                                                           func);
 }
 
 // ----------------------------------------------------------------------

--- a/python/pyarrow/acero.py
+++ b/python/pyarrow/acero.py
@@ -300,6 +300,7 @@ def _sort_source(table_or_dataset, sort_keys, output_type=Table, **kwargs):
 
 
 def _group_by(table, aggregates, keys):
+
     decl = Declaration.from_sequence([
         Declaration("table_source", TableSourceNodeOptions(table)),
         Declaration("aggregate", AggregateNodeOptions(aggregates, keys=keys))

--- a/python/pyarrow/acero.py
+++ b/python/pyarrow/acero.py
@@ -300,7 +300,6 @@ def _sort_source(table_or_dataset, sort_keys, output_type=Table, **kwargs):
 
 
 def _group_by(table, aggregates, keys):
-
     decl = Declaration.from_sequence([
         Declaration("table_source", TableSourceNodeOptions(table)),
         Declaration("aggregate", AggregateNodeOptions(aggregates, keys=keys))

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -5307,8 +5307,14 @@ list[tuple(str, str, FunctionOptions)]
             # Ensure aggregate function is hash_ if needed
             if len(self.keys) > 0 and not func.startswith("hash_"):
                 func = "hash_" + func
+            import pyarrow.compute as pc
             if len(self.keys) == 0 and func.startswith("hash_"):
-                func = func[5:]
+                scalar_func = func[5:]
+                try:
+                    pc.get_function(scalar_func)
+                    func = scalar_func
+                except:
+                    pass
             # Determine output field name
             func_nohash = func if not func.startswith("hash_") else func[5:]
             if len(target) == 0:

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -5307,11 +5307,10 @@ list[tuple(str, str, FunctionOptions)]
             # Ensure aggregate function is hash_ if needed
             if len(self.keys) > 0 and not func.startswith("hash_"):
                 func = "hash_" + func
-            import pyarrow.compute as pc
             if len(self.keys) == 0 and func.startswith("hash_"):
                 scalar_func = func[5:]
                 try:
-                    pc.get_function(scalar_func)
+                    _pac().get_function(scalar_func)
                     func = scalar_func
                 except:
                     pass

--- a/python/pyarrow/tests/test_acero.py
+++ b/python/pyarrow/tests/test_acero.py
@@ -195,7 +195,7 @@ def test_aggregate_scalar(table_source):
     )
     with pytest.raises(ValueError, match="is a hash aggregate function"):
         _ = decl.to_table()
-        
+
     aggr_opts = AggregateNodeOptions([("a", "hash_list", None, "a_list")])
     decl = Declaration.from_sequence(
         [table_source, Declaration("aggregate", aggr_opts)]

--- a/python/pyarrow/tests/test_acero.py
+++ b/python/pyarrow/tests/test_acero.py
@@ -200,6 +200,15 @@ def test_aggregate_scalar(table_source):
     decl = Declaration.from_sequence(
         [table_source, Declaration("aggregate", aggr_opts)]
     )
+    with pytest.raises(pa.lib.ArrowInvalid, match="is a hash aggregate function"):
+        _ = decl.to_table()
+
+    aggr_opts = AggregateNodeOptions([("a", "hash_one", None, "a_one")])
+    decl = Declaration.from_sequence(
+        [table_source, Declaration("aggregate", aggr_opts)]
+    )
+    with pytest.raises(pa.lib.ArrowInvalid, match="is a hash aggregate function"):
+        _ = decl.to_table()
 
 
 def test_aggregate_hash():

--- a/python/pyarrow/tests/test_acero.py
+++ b/python/pyarrow/tests/test_acero.py
@@ -195,6 +195,11 @@ def test_aggregate_scalar(table_source):
     )
     with pytest.raises(ValueError, match="is a hash aggregate function"):
         _ = decl.to_table()
+        
+    aggr_opts = AggregateNodeOptions([("a", "hash_list", None, "a_list")])
+    decl = Declaration.from_sequence(
+        [table_source, Declaration("aggregate", aggr_opts)]
+    )
 
 
 def test_aggregate_hash():

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -2451,27 +2451,22 @@ def test_invalid_non_join_column():
 
 def test_aggregate_hash_functions():
     table = pa.table({'key': ['a', 'a', 'b', 'b', 'a'], 'value': [11, 112, 0, 1, 2]})
-    
+
     aggregates = [(["value"], "hash_list", None, "value_list")]
     keys = []
-    
+
     with pytest.raises(pa.lib.ArrowInvalid) as excinfo:
         res = table.group_by(keys).aggregate([(['value'], 'hash_list')])
-    assert "The provided function (hash_list) is a hash aggregate function." in str(excinfo.value)
-    
+    assert "The provided function (hash_list) is a hash aggregate function." in str(
+        excinfo.value)
+
+
 def test_scalar_aggregate_distinct_functions():
     table = pa.table({'key': ['a', 'a', 'b', 'b', 'a'], 'value': [11, 11, 10, 12, 12]})
-    
+
     aggregates = [(["value"], "distinct", None, "value_distinct")]
     keys = []
-    
+
     func = pc.get_function("distinct")
     print(func)
     res = table.group_by(keys).aggregate([(['value'], 'distinct')])
-    
-    
-    
-    
-    
-        
-    

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -2451,9 +2451,24 @@ def test_invalid_non_join_column():
 
 def test_aggregate_hash_functions():
     table = pa.table({'key': ['a', 'a', 'b', 'b', 'a'], 'value': [11, 112, 0, 1, 2]})
-    res = table.group_by(['key']).aggregate([('value', 'one')])
-    res = table.group_by([]).aggregate([('value', 'distinct')])
-    print(res)
+    
+    aggregates = [(["value"], "hash_list", None, "value_list")]
+    keys = []
+    
+    with pytest.raises(pa.lib.ArrowInvalid) as excinfo:
+        res = table.group_by(keys).aggregate([(['value'], 'hash_list')])
+    assert "The provided function (hash_list) is a hash aggregate function." in str(excinfo.value)
+    
+def test_scalar_aggregate_distinct_functions():
+    table = pa.table({'key': ['a', 'a', 'b', 'b', 'a'], 'value': [11, 11, 10, 12, 12]})
+    
+    aggregates = [(["value"], "distinct", None, "value_distinct")]
+    keys = []
+    
+    func = pc.get_function("distinct")
+    print(func)
+    res = table.group_by(keys).aggregate([(['value'], 'distinct')])
+    
     
     
     

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -2447,3 +2447,16 @@ def test_invalid_non_join_column():
     with pytest.raises(pa.lib.ArrowInvalid) as excinfo:
         t2.join(t1, 'id', join_type='inner')
     assert exp_error_msg in str(excinfo.value)
+
+
+def test_aggregate_hash_functions():
+    table = pa.table({'key': ['a', 'a', 'b', 'b', 'a'], 'value': [11, 112, 0, 1, 2]})
+    res = table.group_by(['key']).aggregate([('value', 'one')])
+    res = table.group_by([]).aggregate([('value', 'distinct')])
+    print(res)
+    
+    
+    
+    
+        
+    


### PR DESCRIPTION
### Rationale for this change

Based on a user filed [issue](https://github.com/apache/arrow/issues/36149).

### What changes are included in this PR?

- Adding distinct function for Scalar Aggregator
- Adding validation on unsupported `hash_list` and `hash_one` functions as Scalar aggregate functions

### Are these changes tested?

Yes, test cases have been added to both C++ and Python

### Are there any user-facing changes?

Nothing significant.
* Closes: #36149