### PR TITLE
GH-36750: [R] Fix test-r-devdocs on MacOS

### DIFF
--- a/dev/tasks/r/github.devdocs.yml
+++ b/dev/tasks/r/github.devdocs.yml
@@ -30,17 +30,11 @@ jobs:
 
     steps:
       {{ macros.github_checkout_arrow()|indent }}
-      # TODO (ARROW-16376): Switch to v2 once we use UCRT
-      - uses: r-lib/actions/setup-r@v1
-        with:
-          # temp workaround the fact that R 4.2 requires UCRT which isn't
-          # currently part of this build.
-          # remove after https://issues.apache.org/jira/browse/ARROW-16376
-          r-version: '4.1'
+      - uses: r-lib/actions/setup-r@v2
       - uses: r-lib/actions/setup-pandoc@v2
-      - name: Install knitr, rmarkdown
-        run: |
-          install.packages(c("rmarkdown", "knitr", "sessioninfo"))
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: rmarkdown, knitr, sessioninfo
         shell: Rscript {0}
       - name: Session info
         run: |

--- a/dev/tasks/r/github.devdocs.yml
+++ b/dev/tasks/r/github.devdocs.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: r-lib/actions/setup-pandoc@v2
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          packages: rmarkdown, knitr, sessioninfo
+          packages: "rmarkdown, knitr, sessioninfo"
         shell: Rscript {0}
       - name: Session info
         run: |

--- a/dev/tasks/r/github.devdocs.yml
+++ b/dev/tasks/r/github.devdocs.yml
@@ -41,7 +41,6 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           packages: "rmarkdown, knitr, sessioninfo"
-        shell: Rscript {0}
       - name: Session info
         run: |
           options(width = 100)

--- a/dev/tasks/r/github.devdocs.yml
+++ b/dev/tasks/r/github.devdocs.yml
@@ -30,7 +30,13 @@ jobs:
 
     steps:
       {{ macros.github_checkout_arrow()|indent }}
-      - uses: r-lib/actions/setup-r@v2
+      # TODO (ARROW-16376): Switch to v2 once we use UCRT
+      - uses: r-lib/actions/setup-r@v1
+        with:
+          # temp workaround the fact that R 4.2 requires UCRT which isn't
+          # currently part of this build.
+          # remove after https://issues.apache.org/jira/browse/ARROW-16376
+          r-version: '4.1'
       - uses: r-lib/actions/setup-pandoc@v2
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:


### PR DESCRIPTION
### Rationale for this change

The test-r-devdocs job is failing. It is failing because we are pinning a version of R that is so old that CRAN no longer serves binaries (#31757), so some of the package builds are failing.

### What changes are included in this PR?

Use the `setup-r-dependencies` action which either installs the correct build dependencies or uses older binary versions to avoid building from source (or both).

### Are these changes tested?

Yes, as part of the test-r-devdocs job.

### Are there any user-facing changes?

No.
* Closes: #36750