### PR TITLE
GH-36756: [CI][Python] Install Cython < 3.0 on verify-release-candidate script

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -665,7 +665,7 @@ test_python() {
   show_header "Build and test Python libraries"
 
   # Build and test Python
-  maybe_setup_virtualenv cython<3 numpy setuptools_scm setuptools || exit 1
+  maybe_setup_virtualenv "cython<3" numpy setuptools_scm setuptools || exit 1
   maybe_setup_conda --file ci/conda_env_python.txt || exit 1
 
   if [ "${USE_CONDA}" -gt 0 ]; then

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -665,7 +665,7 @@ test_python() {
   show_header "Build and test Python libraries"
 
   # Build and test Python
-  maybe_setup_virtualenv cython numpy setuptools_scm setuptools || exit 1
+  maybe_setup_virtualenv cython<3 numpy setuptools_scm setuptools || exit 1
   maybe_setup_conda --file ci/conda_env_python.txt || exit 1
 
   if [ "${USE_CONDA}" -gt 0 ]; then


### PR DESCRIPTION
### Rationale for this change

Some of our verification tasks fail for 13.0.0

### What changes are included in this PR?

Pin Cython to be less than 3.0

### Are these changes tested?

Archery

### Are there any user-facing changes?

No
* Closes: #36756