### PR TITLE
GH-36671: [Go] binary dictionary builder

### DIFF
--- a/go/arrow/array/binary_dictionary_builder.go
+++ b/go/arrow/array/binary_dictionary_builder.go
@@ -1,0 +1,264 @@
+package array
+
+import (
+	"bytes"
+	"fmt"
+	"sync/atomic"
+
+	"github.com/apache/arrow/go/v13/arrow"
+	"github.com/apache/arrow/go/v13/arrow/internal/debug"
+	"github.com/apache/arrow/go/v13/internal/hashing"
+	"github.com/apache/arrow/go/v13/internal/json"
+)
+
+type binaryDictionaryBuilder struct {
+	builder
+
+	dt          *arrow.DictionaryType
+	deltaOffset int
+	memoTable   *hashing.BinaryMemoTable
+	idxBuilder  indexBuilder
+}
+
+func (b *binaryDictionaryBuilder) Type() arrow.DataType { return b.dt }
+
+func (b *binaryDictionaryBuilder) Release() {
+	debug.Assert(atomic.LoadInt64(&b.refCount) > 0, "too many releases")
+
+	if atomic.AddInt64(&b.refCount, -1) == 0 {
+		b.idxBuilder.Release()
+		b.idxBuilder.Builder = nil
+		b.memoTable.Release()
+		b.memoTable = nil
+	}
+}
+
+func (b *binaryDictionaryBuilder) AppendNull() {
+	b.length += 1
+	b.nulls += 1
+	b.idxBuilder.AppendNull()
+}
+
+func (b *binaryDictionaryBuilder) AppendNulls(n int) {
+	for i := 0; i < n; i++ {
+		b.AppendNull()
+	}
+}
+
+func (b *binaryDictionaryBuilder) AppendEmptyValue() {
+	b.length += 1
+	b.idxBuilder.AppendEmptyValue()
+}
+
+func (b *binaryDictionaryBuilder) AppendEmptyValues(n int) {
+	for i := 0; i < n; i++ {
+		b.AppendEmptyValue()
+	}
+}
+
+func (b *binaryDictionaryBuilder) Reserve(n int) {
+	b.idxBuilder.Reserve(n)
+}
+
+func (b *binaryDictionaryBuilder) Resize(n int) {
+	b.idxBuilder.Resize(n)
+	b.length = b.idxBuilder.Len()
+}
+
+func (b *binaryDictionaryBuilder) ResetFull() {
+	b.builder.reset()
+	b.idxBuilder.NewArray().Release()
+	b.memoTable.Reset()
+}
+
+func (b *binaryDictionaryBuilder) Cap() int { return b.idxBuilder.Cap() }
+
+func (b *binaryDictionaryBuilder) IsNull(i int) bool { return b.idxBuilder.IsNull(i) }
+
+func (b *binaryDictionaryBuilder) UnmarshalJSON(data []byte) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	t, err := dec.Token()
+	if err != nil {
+		return err
+	}
+
+	if delim, ok := t.(json.Delim); !ok || delim != '[' {
+		return fmt.Errorf("dictionary builder must upack from json array, found %s", delim)
+	}
+
+	return b.Unmarshal(dec)
+}
+
+func (b *binaryDictionaryBuilder) Unmarshal(dec *json.Decoder) error {
+	bldr := NewBuilder(b.mem, b.dt.ValueType)
+	defer bldr.Release()
+
+	if err := bldr.Unmarshal(dec); err != nil {
+		return err
+	}
+
+	arr := bldr.NewArray()
+	defer arr.Release()
+	return b.AppendArray(arr)
+}
+
+func (b *binaryDictionaryBuilder) AppendValueFromString(s string) error {
+	bldr := NewBuilder(b.mem, b.dt.ValueType)
+	defer bldr.Release()
+
+	if err := bldr.AppendValueFromString(s); err != nil {
+		return err
+	}
+
+	arr := bldr.NewArray()
+	defer arr.Release()
+	return b.AppendArray(arr)
+}
+
+func (b *binaryDictionaryBuilder) UnmarshalOne(dec *json.Decoder) error {
+	bldr := NewBuilder(b.mem, b.dt.ValueType)
+	defer bldr.Release()
+
+	if err := bldr.UnmarshalOne(dec); err != nil {
+		return err
+	}
+
+	arr := bldr.NewArray()
+	defer arr.Release()
+	return b.AppendArray(arr)
+}
+
+func (b *binaryDictionaryBuilder) NewArray() arrow.Array {
+	return b.NewDictionaryArray()
+}
+
+func (b *binaryDictionaryBuilder) newData() *Data {
+	indices, dict, err := b.newWithDictOffset(0)
+	if err != nil {
+		panic(err)
+	}
+
+	indices.dtype = b.dt
+	indices.dictionary = dict
+	return indices
+}
+
+func (b *binaryDictionaryBuilder) NewDictionaryArray() *Dictionary {
+	a := &Dictionary{}
+	a.refCount = 1
+
+	indices := b.newData()
+	a.setData(indices)
+	indices.Release()
+	return a
+}
+
+func (b *binaryDictionaryBuilder) newWithDictOffset(offset int) (indices, dict *Data, err error) {
+	idxarr := b.idxBuilder.NewArray()
+	defer idxarr.Release()
+
+	indices = idxarr.Data().(*Data)
+	indices.Retain()
+
+	b.deltaOffset = b.memoTable.Size()
+	dict, err = GetBinaryDictArrayData(b.mem, b.dt.ValueType, b.memoTable, offset)
+	b.reset()
+	return
+}
+
+// NewDelta returns the dictionary indices and a delta dictionary since the
+// last time NewArray or NewDictionaryArray were called, and resets the state
+// of the builder (except for the dictionary / memotable)
+func (b *binaryDictionaryBuilder) NewDelta() (indices, delta arrow.Array, err error) {
+	indicesData, deltaData, err := b.newWithDictOffset(b.deltaOffset)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	defer indicesData.Release()
+	defer deltaData.Release()
+	indices, delta = MakeFromData(indicesData), MakeFromData(deltaData)
+	return
+}
+
+func (b *binaryDictionaryBuilder) insertDictValue(val []byte) error {
+	_, _, err := b.memoTable.GetOrInsert(val)
+	return err
+}
+
+func (b *binaryDictionaryBuilder) appendValue(val []byte) error {
+	idx, _, err := b.memoTable.GetOrInsert(val)
+	b.idxBuilder.Append(idx)
+	b.length += 1
+	return err
+}
+
+func (b *binaryDictionaryBuilder) AppendArray(arr arrow.Array) error {
+	debug.Assert(arrow.TypeEqual(b.dt.ValueType, arr.DataType()), "wrong value type of array to append to dict")
+
+	valfn := getByteValFn(arr)
+	for i := 0; i < arr.Len(); i++ {
+		if arr.IsNull(i) {
+			b.AppendNull()
+		} else {
+			if err := b.appendValue(valfn(i)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (b *binaryDictionaryBuilder) AppendIndices(indices []int, valid []bool) {
+	b.length += len(indices)
+	switch idxbldr := b.idxBuilder.Builder.(type) {
+	case *Int8Builder:
+		vals := make([]int8, len(indices))
+		for i, v := range indices {
+			vals[i] = int8(v)
+		}
+		idxbldr.AppendValues(vals, valid)
+	case *Int16Builder:
+		vals := make([]int16, len(indices))
+		for i, v := range indices {
+			vals[i] = int16(v)
+		}
+		idxbldr.AppendValues(vals, valid)
+	case *Int32Builder:
+		vals := make([]int32, len(indices))
+		for i, v := range indices {
+			vals[i] = int32(v)
+		}
+		idxbldr.AppendValues(vals, valid)
+	case *Int64Builder:
+		vals := make([]int64, len(indices))
+		for i, v := range indices {
+			vals[i] = int64(v)
+		}
+		idxbldr.AppendValues(vals, valid)
+	case *Uint8Builder:
+		vals := make([]uint8, len(indices))
+		for i, v := range indices {
+			vals[i] = uint8(v)
+		}
+		idxbldr.AppendValues(vals, valid)
+	case *Uint16Builder:
+		vals := make([]uint16, len(indices))
+		for i, v := range indices {
+			vals[i] = uint16(v)
+		}
+		idxbldr.AppendValues(vals, valid)
+	case *Uint32Builder:
+		vals := make([]uint32, len(indices))
+		for i, v := range indices {
+			vals[i] = uint32(v)
+		}
+		idxbldr.AppendValues(vals, valid)
+	case *Uint64Builder:
+		vals := make([]uint64, len(indices))
+		for i, v := range indices {
+			vals[i] = uint64(v)
+		}
+		idxbldr.AppendValues(vals, valid)
+	}
+}

--- a/go/arrow/array/union_test.go
+++ b/go/arrow/array/union_test.go
@@ -1062,7 +1062,6 @@ func ExampleSparseUnionBuilder() {
 	defer out.Release()
 
 	fmt.Println(out)
-
 	// Output:
 	// {[{c=foo} {c=bar}]}
 }

--- a/go/arrow/array/util.go
+++ b/go/arrow/array/util.go
@@ -253,6 +253,55 @@ func TableFromJSON(mem memory.Allocator, sc *arrow.Schema, recJSON []string, opt
 	return NewTableFromRecords(sc, batches), nil
 }
 
+func GetBinaryDictArrayData(mem memory.Allocator, valueType arrow.DataType, memoTable *hashing.BinaryMemoTable, startOffset int) (*Data, error) {
+	dictLen := memoTable.Size() - startOffset
+	buffers := []*memory.Buffer{nil, nil}
+
+	buffers[1] = memory.NewResizableBuffer(mem)
+	defer buffers[1].Release()
+
+	switch valueType.ID() {
+	case arrow.BINARY, arrow.STRING:
+		buffers = append(buffers, memory.NewResizableBuffer(mem))
+		defer buffers[2].Release()
+
+		buffers[1].Resize(arrow.Int32Traits.BytesRequired(dictLen + 1))
+		offsets := arrow.Int32Traits.CastFromBytes(buffers[1].Bytes())
+		memoTable.CopyOffsetsSubset(startOffset, offsets)
+
+		valuesz := offsets[len(offsets)-1] - offsets[0]
+		buffers[2].Resize(int(valuesz))
+		memoTable.CopyValuesSubset(startOffset, buffers[2].Bytes())
+	case arrow.LARGE_BINARY, arrow.LARGE_STRING:
+		buffers = append(buffers, memory.NewResizableBuffer(mem))
+		defer buffers[2].Release()
+
+		buffers[1].Resize(arrow.Int64Traits.BytesRequired(dictLen + 1))
+		offsets := arrow.Int64Traits.CastFromBytes(buffers[1].Bytes())
+		memoTable.CopyLargeOffsetsSubset(startOffset, offsets)
+
+		valuesz := offsets[len(offsets)-1] - offsets[0]
+		buffers[2].Resize(int(valuesz))
+		memoTable.CopyValuesSubset(startOffset, buffers[2].Bytes())
+	default: // fixed size
+		bw := int(bitutil.BytesForBits(int64(valueType.(arrow.FixedWidthDataType).BitWidth())))
+		buffers[1].Resize(dictLen * bw)
+		memoTable.CopyFixedWidthValues(startOffset, bw, buffers[1].Bytes())
+	}
+
+	var nullcount int
+	if idx, ok := memoTable.GetNull(); ok && idx >= startOffset {
+		buffers[0] = memory.NewResizableBuffer(mem)
+		defer buffers[0].Release()
+		nullcount = 1
+		buffers[0].Resize(int(bitutil.BytesForBits(int64(dictLen))))
+		memory.Set(buffers[0].Bytes(), 0xFF)
+		bitutil.ClearBit(buffers[0].Bytes(), idx)
+	}
+
+	return NewData(valueType, dictLen, buffers, nil, nullcount, 0), nil
+}
+
 func GetDictArrayData(mem memory.Allocator, valueType arrow.DataType, memoTable hashing.MemoTable, startOffset int) (*Data, error) {
 	dictLen := memoTable.Size() - startOffset
 	buffers := []*memory.Buffer{nil, nil}
@@ -265,35 +314,6 @@ func GetDictArrayData(mem memory.Allocator, valueType arrow.DataType, memoTable 
 		nbytes := tbl.TypeTraits().BytesRequired(dictLen)
 		buffers[1].Resize(nbytes)
 		tbl.WriteOutSubset(startOffset, buffers[1].Bytes())
-	case *hashing.BinaryMemoTable:
-		switch valueType.ID() {
-		case arrow.BINARY, arrow.STRING:
-			buffers = append(buffers, memory.NewResizableBuffer(mem))
-			defer buffers[2].Release()
-
-			buffers[1].Resize(arrow.Int32Traits.BytesRequired(dictLen + 1))
-			offsets := arrow.Int32Traits.CastFromBytes(buffers[1].Bytes())
-			tbl.CopyOffsetsSubset(startOffset, offsets)
-
-			valuesz := offsets[len(offsets)-1] - offsets[0]
-			buffers[2].Resize(int(valuesz))
-			tbl.CopyValuesSubset(startOffset, buffers[2].Bytes())
-		case arrow.LARGE_BINARY, arrow.LARGE_STRING:
-			buffers = append(buffers, memory.NewResizableBuffer(mem))
-			defer buffers[2].Release()
-
-			buffers[1].Resize(arrow.Int64Traits.BytesRequired(dictLen + 1))
-			offsets := arrow.Int64Traits.CastFromBytes(buffers[1].Bytes())
-			tbl.CopyLargeOffsetsSubset(startOffset, offsets)
-
-			valuesz := offsets[len(offsets)-1] - offsets[0]
-			buffers[2].Resize(int(valuesz))
-			tbl.CopyValuesSubset(startOffset, buffers[2].Bytes())
-		default: // fixed size
-			bw := int(bitutil.BytesForBits(int64(valueType.(arrow.FixedWidthDataType).BitWidth())))
-			buffers[1].Resize(dictLen * bw)
-			tbl.CopyFixedWidthValues(startOffset, bw, buffers[1].Bytes())
-		}
 	default:
 		return nil, fmt.Errorf("arrow/array: dictionary unifier unimplemented type: %s", valueType)
 	}


### PR DESCRIPTION

<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

The hashing.MemoTable provides an interface with 
```go
    GetOrInsert(val interface{}) (idx int, existed bool, err error)
```
This can cause a costly allocation for binary dictionaries as is detailed in issue #36671 

Instead we can change the `BinaryDictionaryBuilder` to use a different type of builder that uses a memotable that allows the static `[]byte` type as part of the `GetOrInsert` function to prevent that allocation when converting from `[]byte` to `interface{}`.

Originally I attempted to replace the memotable with a generic `MemoTable[T any]` but because there are two different implementations of memo tables one being for binary memo tables, I tried splitting the generic implementations in two. That code can bee seen on [this branch](https://github.com/thorfour/arrow/tree/go-generic-memotable). This runs into the problem that the util function attempts to convert the memo table back into its implementation: https://github.com/apache/arrow/blob/de8df23a8cd9737b4df5bb1b68fc12a54f252d0d/go/arrow/array/util.go#L268 which Go doesn't allow due to the generic binary memo table being more restrictive than the basic one. So to move forward with replacing the memotable with generics I believe we would need a single implementation of the memo table but would also require things like the builders to be generic as well. 

### What changes are included in this PR?

Adds a `binaryDictionaryBuilder` that is a identical copy to the `dictionaryBuilder` except is uses `[]byte` instead of `interface{}`

For binary dictionary types it now uses the the `binaryDictionaryBuilder` type to avoid the conversion of `[]byte` to `interface{}` 

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

No additional tests have been added for this yet, current test coverage exercises the new builders. But wanted to ensure this was a valid path forward before investing more time in test coverage if deemed necessary.

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #36671