### PR TITLE
GH-36778: [C++][Parquet] Add ReadRowGroupAsync/ReadRowGroupsAsync

### DIFF
--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -319,7 +319,7 @@ class FileReaderImpl : public FileReader {
   }
 
   Result<AsyncBatchGenerator> DoReadRowGroupsAsync(
-      const std::vector<int>& row_groups, const std::vector<int>& indices,
+      const std::vector<int>& row_groups, const std::vector<int>& column_indices,
       ::arrow::internal::Executor* cpu_executor, bool allow_sliced_batches);
 
   AsyncBatchGenerator ReadRowGroupsAsync(const std::vector<int>& row_groups,

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -1338,7 +1338,7 @@ class AsyncBatchGeneratorImpl {
     Future<> all_columns_finished_fut = ::arrow::AllFinished(std::move(column_futs));
 
     // Grab the first batch of data and return it.  If there is more than one batch then
-    // throw the reamining batches into overflow and they will be fetched on the next call
+    // throw the remaining batches into overflow and they will be fetched on the next call
     return all_columns_finished_fut.Then(
         [state = state_, rows_in_batch]() -> Result<std::shared_ptr<RecordBatch>> {
           std::shared_ptr<Table> table =

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -313,6 +313,14 @@ class PARQUET_EXPORT FileReader {
   /// useful when you need to know exactly how many batches you will get from the
   /// operation before you start.
   ///
+  /// Note: When reading multiple row groups there is no guarantee you will get one
+  /// record batch per row group.  Data from multiple row groups could get combined into
+  /// a single batch.
+  ///
+  /// Note: If a row group has 0 rows it will effectively be ignored.  If you are only
+  /// reading empty row groups then the returned generated will immediately finish.  This
+  /// method should never generate an empty record batch.
+  ///
   /// The I/O executor is obtained from the I/O context in the reader properties.
   ///
   /// \param row_groups indices of the row groups to read

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -276,6 +276,10 @@ class PARQUET_EXPORT FileReader {
   /// thread, which is correct.  However, decompression is also done on the I/O thread
   /// which may not be ideal.
   ///
+  /// This method ignores the use_threads property of the ArrowReaderProperties.  It will
+  /// always create a task for each column.  To run without threads you should use a
+  /// serial executor as the CPU executor.
+  ///
   /// The returned generator will respect the batch size set in the ArrowReaderProperties.
   /// Batches will not be larger than the given batch size.  However, batches may be
   /// smaller.  This can happen, for example, when there is not enough data or when a

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -300,12 +300,12 @@ class PARQUET_EXPORT FileReader {
   /// performance.
   ///
   /// This operation is not perfectly async.  The read from disk will be done on an I/O
-  /// thread, which is correct.  However, compression and  column decoding is also done on
+  /// thread, which is correct.  However, compression and column decoding is also done on
   /// the I/O thread which may not be ideal.  The stage after that (transferring the
   /// decoded data into Arrow structures and fulfilling the future) should be done as a
   /// new task on the cpu_executor.
   ///
-  /// The returned generator will respect the batch size set in the reader properties.
+  /// The returned generator will respect the batch size set in the ArrowReaderProperties.
   /// Batches will not be larger than the given batch size.  However, batches may be
   /// smaller.  This can happen, for example, when there is not enough data or when a
   /// string column is too large to fit into a single batch.  The parameter
@@ -318,7 +318,7 @@ class PARQUET_EXPORT FileReader {
   /// a single batch.
   ///
   /// Note: If a row group has 0 rows it will effectively be ignored.  If you are only
-  /// reading empty row groups then the returned generated will immediately finish.  This
+  /// reading empty row groups then the returned generator will immediately finish.  This
   /// method should never generate an empty record batch.
   ///
   /// The I/O executor is obtained from the I/O context in the reader properties.

--- a/cpp/src/parquet/arrow/test_util.h
+++ b/cpp/src/parquet/arrow/test_util.h
@@ -43,7 +43,11 @@ namespace arrow {
 
 using ::arrow::Array;
 using ::arrow::ChunkedArray;
+using ::arrow::Field;
+using ::arrow::RecordBatch;
+using ::arrow::Schema;
 using ::arrow::Status;
+using ::arrow::Table;
 
 template <int32_t PRECISION>
 struct DecimalWithPrecisionAndScale {


### PR DESCRIPTION
### Rationale for this change

The rationale is described in #36778 

### What changes are included in this PR?

New methods are added to `parquet::arrow::FileReader` which read the file asynchronously and respect the batch size property.  In addition, these new methods are a bit simpler than `GetRecordBatchGenerator` as they are able to reuse a lot of the code in the synchronous methods.

### Are these changes tested?

Yes, I've added new unit tests.

### Are there any user-facing changes?

Yes, there are new methods available.  There should be no breaking changes to any existing methods.
* Closes: #36778