### PR TITLE
GH-36776: [C++] Make ListArray::FromArrays() handle sliced offsets Arrays containing nulls

### DIFF
--- a/cpp/src/arrow/array/array_list_test.cc
+++ b/cpp/src/arrow/array/array_list_test.cc
@@ -215,17 +215,20 @@ class TestListArray : public ::testing::Test {
     // Offsets with nulls will match.
     ASSERT_OK_AND_ASSIGN(auto result,
                          ArrayType::FromArrays(*offsets_w_nulls, *values, pool_));
+    ASSERT_OK(result->ValidateFull());
     AssertArraysEqual(*result, *expected);
 
     // Offets without nulls, will replace null with empty list
     ASSERT_OK_AND_ASSIGN(result,
                          ArrayType::FromArrays(*offsets_wo_nulls, *values, pool_));
+    ASSERT_OK(result->ValidateFull());
     AssertArraysEqual(*result, *std::dynamic_pointer_cast<ArrayType>(
                                    ArrayFromJSON(type, "[[0], [], [0, null], [0]]")));
 
     // Specify non-null offsets with null_bitmap
     ASSERT_OK_AND_ASSIGN(result, ArrayType::FromArrays(*offsets_wo_nulls, *values, pool_,
                                                        expected->null_bitmap()));
+    ASSERT_OK(result->ValidateFull());
     AssertArraysEqual(*result, *expected);
 
     // Cannot specify both null offsets with null_bitmap
@@ -248,6 +251,7 @@ class TestListArray : public ::testing::Test {
     auto sliced_offsets = offsets_wo_nulls->Slice(2, 4);
     ASSERT_OK_AND_ASSIGN(auto result,
                          ArrayType::FromArrays(*sliced_offsets, *values, pool_));
+    ASSERT_OK(result->ValidateFull());
     AssertArraysEqual(*result, *expected);
   }
 
@@ -268,6 +272,7 @@ class TestListArray : public ::testing::Test {
     auto sliced_offsets = offsets_w_nulls->Slice(2, 4);
     ASSERT_OK_AND_ASSIGN(auto result,
                          ArrayType::FromArrays(*sliced_offsets, *values, pool_));
+    ASSERT_OK(result->ValidateFull());
     AssertArraysEqual(*result, *expected);
   }
 

--- a/cpp/src/arrow/array/array_list_test.cc
+++ b/cpp/src/arrow/array/array_list_test.cc
@@ -253,6 +253,12 @@ class TestListArray : public ::testing::Test {
                          ArrayType::FromArrays(*sliced_offsets, *values, pool_));
     ASSERT_OK(result->ValidateFull());
     AssertArraysEqual(*result, *expected);
+
+    // Non-zero starter offset
+    sliced_offsets = offsets_wo_nulls->Slice(3, 3);
+    ASSERT_OK_AND_ASSIGN(result, ArrayType::FromArrays(*sliced_offsets, *values, pool_));
+    ASSERT_OK(result->ValidateFull());
+    AssertArraysEqual(*result, *expected->Slice(1, 2));
   }
 
   void TestFromArraysWithSlicedNullOffsets() {
@@ -274,6 +280,12 @@ class TestListArray : public ::testing::Test {
                          ArrayType::FromArrays(*sliced_offsets, *values, pool_));
     ASSERT_OK(result->ValidateFull());
     AssertArraysEqual(*result, *expected);
+
+    // Non-zero starter offset
+    sliced_offsets = offsets_w_nulls->Slice(3, 3);
+    ASSERT_OK_AND_ASSIGN(result, ArrayType::FromArrays(*sliced_offsets, *values, pool_));
+    ASSERT_OK(result->ValidateFull());
+    AssertArraysEqual(*result, *expected->Slice(1, 2));
   }
 
   void TestFromArrays() {

--- a/cpp/src/arrow/array/array_list_test.cc
+++ b/cpp/src/arrow/array/array_list_test.cc
@@ -233,7 +233,7 @@ class TestListArray : public ::testing::Test {
                                                  expected->null_bitmap()));
   }
 
-  void TestFromArraysWithSlicedNullBitmap() {
+  void TestFromArraysWithSlicedNullOffsets() {
     std::vector<offset_type> offsets = {-1, -1, 0, 1, 1, 3};
     std::vector<bool> offsets_w_nulls_is_valid = {true, true, true, false, true, true};
 
@@ -606,7 +606,7 @@ TYPED_TEST(TestListArray, FromArrays) { this->TestFromArrays(); }
 
 TYPED_TEST(TestListArray, FromArraysWithNullBitMap) {
   this->TestFromArraysWithNullBitMap();
-  this->TestFromArraysWithSlicedNullBitmap();
+  this->TestFromArraysWithSlicedNullOffsets();
 }
 
 TYPED_TEST(TestListArray, AppendNull) { this->TestAppendNull(); }

--- a/cpp/src/arrow/array/array_nested.cc
+++ b/cpp/src/arrow/array/array_nested.cc
@@ -75,9 +75,9 @@ Result<BufferVector> CleanListOffsets(const std::shared_ptr<Buffer>& validity_bu
 
     // Copy valid bits, ignoring the final offset (since for a length N list array,
     // we have N + 1 offsets)
-    ARROW_ASSIGN_OR_RAISE(
-        auto clean_validity_buffer,
-        offsets.null_bitmap()->CopySlice(0, bit_util::BytesForBits(num_offsets - 1)));
+    ARROW_ASSIGN_OR_RAISE(auto clean_validity_buffer,
+                          CopyBitmap(pool, offsets.null_bitmap()->data(),
+                                     offsets.offset(), num_offsets - 1));
 
     const offset_type* raw_offsets = typed_offsets.raw_values();
     auto clean_raw_offsets =

--- a/cpp/src/arrow/array/array_nested.cc
+++ b/cpp/src/arrow/array/array_nested.cc
@@ -128,8 +128,9 @@ Result<std::shared_ptr<typename TypeTraits<TYPE>::ArrayType>> ListArrayFromArray
   ARROW_ASSIGN_OR_RAISE(auto buffers, CleanListOffsets<TYPE>(null_bitmap, offsets, pool));
   int64_t null_count_ = null_bitmap ? null_count : offsets.null_count();
 
+  const int64_t offset = offsets.null_count() > 0 ? 0 : offsets.offset();
   std::shared_ptr<arrow::ArrayData> internal_data = ArrayData::Make(
-      type, offsets.length() - 1, std::move(buffers), null_count_, offsets.offset());
+      type, offsets.length() - 1, std::move(buffers), null_count_, offset);
   internal_data->child_data.push_back(values.data());
   return std::make_shared<ArrayType>(internal_data);
 }


### PR DESCRIPTION
### Rationale for this change

It fixes the issue described in #36776 

### What changes are included in this PR?

The fix and a simplifications of the interaction between `ListArrayFromArrays` and `CleanOffsets` which is rather involved.

### Are these changes tested?

Yes. I added a test that reproduces the issue before adding the fixes.
* Closes: #36776