### PR TITLE
GH-36771: [R] stringr helper functions drop calling environment when evaluating

### DIFF
--- a/r/R/dplyr-funcs-string.R
+++ b/r/R/dplyr-funcs-string.R
@@ -59,14 +59,17 @@ get_stringr_pattern_options <- function(pattern) {
 
   ensure_opts <- function(opts) {
 
+    # default options for the simple cases
     if (is.character(opts)) {
       opts <- list(pattern = opts, fixed = FALSE, ignore_case = FALSE)
     }
     opts
   }
-  pattern <- clean_pattern_namespace(pattern)
 
-  ensure_opts(eval_tidy(pattern, env = new_environment(as.list(rlang::current_env()), parent = caller_env())))
+  pattern_expr <- clean_pattern_namespace(quo_get_expr(pattern))
+  pattern <- quo_set_expr(pattern, pattern_expr)
+
+  ensure_opts(eval_tidy(pattern, data = list(regex = regex, coll = coll, boundary = boundary, fixed = fixed)))
 }
 
 # Ensure that e.g. stringr::regex and regex both work within patterns
@@ -78,8 +81,6 @@ clean_pattern_namespace <- function(pattern) {
   }
 
   pattern
-
-
 }
 
 #' Does this string contain regex metacharacters?
@@ -254,7 +255,7 @@ register_bindings_string_regex <- function() {
 
 
   register_binding("stringr::str_detect", function(string, pattern, negate = FALSE) {
-    opts <- get_stringr_pattern_options(enexpr(pattern))
+    opts <- get_stringr_pattern_options(enquo(pattern))
     arrow_fun <- ifelse(opts$fixed, "match_substring", "match_substring_regex")
     out <- create_string_match_expr(arrow_fun,
       string = string,
@@ -281,11 +282,12 @@ register_bindings_string_regex <- function() {
   register_binding(
     "stringr::str_count",
     function(string, pattern) {
-      opts <- get_stringr_pattern_options(enexpr(pattern))
+      opts <- get_stringr_pattern_options(enquo(pattern))
       if (!is.string(pattern)) {
         arrow_not_supported("`pattern` must be a length 1 character vector; other values")
       }
       arrow_fun <- ifelse(opts$fixed, "count_substring", "count_substring_regex")
+
       Expression$create(
         arrow_fun,
         string,
@@ -312,7 +314,7 @@ register_bindings_string_regex <- function() {
   })
 
   register_binding("stringr::str_starts", function(string, pattern, negate = FALSE) {
-    opts <- get_stringr_pattern_options(enexpr(pattern))
+    opts <- get_stringr_pattern_options(enquo(pattern))
     if (opts$fixed) {
       out <- call_binding("startsWith", x = string, prefix = opts$pattern)
     } else {
@@ -330,7 +332,7 @@ register_bindings_string_regex <- function() {
   })
 
   register_binding("stringr::str_ends", function(string, pattern, negate = FALSE) {
-    opts <- get_stringr_pattern_options(enexpr(pattern))
+    opts <- get_stringr_pattern_options(enquo(pattern))
     if (opts$fixed) {
       out <- call_binding("endsWith", x = string, suffix = opts$pattern)
     } else {
@@ -365,7 +367,7 @@ register_bindings_string_regex <- function() {
   arrow_stringr_string_replace_function <- function(max_replacements) {
     force(max_replacements)
     function(string, pattern, replacement) {
-      opts <- get_stringr_pattern_options(enexpr(pattern))
+      opts <- get_stringr_pattern_options(enquo(pattern))
       arrow_r_string_replace_function(max_replacements)(
         pattern = opts$pattern,
         replacement = replacement,
@@ -379,7 +381,7 @@ register_bindings_string_regex <- function() {
   arrow_stringr_string_remove_function <- function(max_replacements) {
     force(max_replacements)
     function(string, pattern) {
-      opts <- get_stringr_pattern_options(enexpr(pattern))
+      opts <- get_stringr_pattern_options(enquo(pattern))
       arrow_r_string_replace_function(max_replacements)(
         pattern = opts$pattern,
         replacement = "",
@@ -422,7 +424,7 @@ register_bindings_string_regex <- function() {
              pattern,
              n = Inf,
              simplify = FALSE) {
-      opts <- get_stringr_pattern_options(enexpr(pattern))
+      opts <- get_stringr_pattern_options(enquo(pattern))
       arrow_fun <- ifelse(opts$fixed, "split_pattern", "split_pattern_regex")
       if (opts$ignore_case) {
         arrow_not_supported("Case-insensitive string splitting")

--- a/r/R/dplyr-funcs-string.R
+++ b/r/R/dplyr-funcs-string.R
@@ -58,6 +58,7 @@ get_stringr_pattern_options <- function(pattern) {
   }
 
   ensure_opts <- function(opts) {
+
     if (is.character(opts)) {
       opts <- list(pattern = opts, fixed = FALSE, ignore_case = FALSE)
     }
@@ -66,7 +67,7 @@ get_stringr_pattern_options <- function(pattern) {
 
   pattern <- clean_pattern_namespace(pattern)
 
-  ensure_opts(eval_tidy(pattern, env = caller_env(2)))
+  ensure_opts(eval_tidy(pattern, env = new_environment(as.list(rlang::current_env()), parent = caller_env())))
 
 }
 
@@ -82,6 +83,7 @@ clean_pattern_namespace <- function(pattern) {
   }
 
   pattern
+
 }
 
 #' Does this string contain regex metacharacters?

--- a/r/R/dplyr-funcs-string.R
+++ b/r/R/dplyr-funcs-string.R
@@ -58,6 +58,7 @@ get_stringr_pattern_options <- function(pattern) {
   }
 
   ensure_opts <- function(opts) {
+
     if (is.character(opts)) {
       opts <- list(pattern = opts, fixed = FALSE, ignore_case = FALSE)
     }
@@ -77,6 +78,7 @@ clean_pattern_namespace <- function(pattern) {
   }
 
   pattern
+
 
 }
 

--- a/r/R/dplyr-funcs-string.R
+++ b/r/R/dplyr-funcs-string.R
@@ -58,7 +58,6 @@ get_stringr_pattern_options <- function(pattern) {
   }
 
   ensure_opts <- function(opts) {
-
     if (is.character(opts)) {
       opts <- list(pattern = opts, fixed = FALSE, ignore_case = FALSE)
     }
@@ -68,7 +67,6 @@ get_stringr_pattern_options <- function(pattern) {
   pattern <- clean_pattern_namespace(pattern)
 
   ensure_opts(eval_tidy(pattern, env = new_environment(as.list(rlang::current_env()), parent = caller_env())))
-
 }
 
 # Ensure that e.g. stringr::regex and regex both work within patterns
@@ -76,14 +74,10 @@ clean_pattern_namespace <- function(pattern) {
   modifier_funcs <- c("fixed", "regex", "coll", "boundary")
   if (is_call(pattern, modifier_funcs, ns = "stringr")) {
     function_called <- call_name(pattern[1])
-
-    if (function_called %in% modifier_funcs) {
-      pattern[1] <- call2(function_called)
-    }
+    pattern[1] <- call2(function_called)
   }
 
   pattern
-
 }
 
 #' Does this string contain regex metacharacters?

--- a/r/R/dplyr-funcs-string.R
+++ b/r/R/dplyr-funcs-string.R
@@ -66,7 +66,8 @@ get_stringr_pattern_options <- function(pattern) {
 
   pattern <- clean_pattern_namespace(pattern)
 
-  ensure_opts(eval(pattern))
+  ensure_opts(eval_tidy(pattern, env = caller_env(2)))
+
 }
 
 # Ensure that e.g. stringr::regex and regex both work within patterns

--- a/r/R/dplyr-funcs-string.R
+++ b/r/R/dplyr-funcs-string.R
@@ -63,7 +63,6 @@ get_stringr_pattern_options <- function(pattern) {
     }
     opts
   }
-
   pattern <- clean_pattern_namespace(pattern)
 
   ensure_opts(eval_tidy(pattern, env = new_environment(as.list(rlang::current_env()), parent = caller_env())))
@@ -78,6 +77,7 @@ clean_pattern_namespace <- function(pattern) {
   }
 
   pattern
+
 }
 
 #' Does this string contain regex metacharacters?

--- a/r/tests/testthat/test-dplyr-funcs-string.R
+++ b/r/tests/testthat/test-dplyr-funcs-string.R
@@ -303,6 +303,15 @@ test_that("str_detect", {
       collect(),
     df
   )
+
+  string <- "^F"
+  compare_dplyr_binding(
+    .input %>%
+      filter(str_detect(x, regex(string))) %>%
+      collect(),
+    df
+  )
+
   compare_dplyr_binding(
     .input %>%
       transmute(


### PR DESCRIPTION
### What changes are included in this PR?

Update internals of `get_stringr_pattern_options()` to use `eval_tidy()` instead of `eval()` to ensure we're evaluating things in the right environment.

### Are these changes tested?

Yes

### Are there any user-facing changes?

Yes
* Closes: #36771