### PR TITLE
GH-36789: [C++] Support divide(duration, duration)

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -30,6 +30,7 @@
 #include "arrow/compute/kernels/common_internal.h"
 #include "arrow/compute/kernels/util_internal.h"
 #include "arrow/type.h"
+#include "arrow/type_fwd.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/decimal.h"
 #include "arrow/util/int_util_overflow.h"
@@ -1509,6 +1510,13 @@ void RegisterScalarArithmetic(FunctionRegistry* registry) {
     DCHECK_OK(
         divide->AddKernel({duration(unit), int64()}, duration(unit), std::move(exec)));
   }
+
+  // Add divide(duration, duration) -> float64
+  for (auto unit : TimeUnit::values()) {
+    auto exec = ScalarBinaryNotNull<DoubleType, DoubleType, DoubleType, Divide>::Exec;
+    DCHECK_OK(
+        divide->AddKernel({duration(unit), duration(unit)}, float64(), std::move(exec)));
+  }
   DCHECK_OK(registry->AddFunction(std::move(divide)));
 
   // ----------------------------------------------------------------------
@@ -1520,6 +1528,14 @@ void RegisterScalarArithmetic(FunctionRegistry* registry) {
   for (auto unit : TimeUnit::values()) {
     auto exec = ScalarBinaryNotNull<Int64Type, Int64Type, Int64Type, DivideChecked>::Exec;
     DCHECK_OK(divide_checked->AddKernel({duration(unit), int64()}, duration(unit),
+                                        std::move(exec)));
+  }
+
+  // Add divide_checked(duration, duration) -> float64
+  for (auto unit : TimeUnit::values()) {
+    auto exec =
+        ScalarBinaryNotNull<DoubleType, DoubleType, DoubleType, DivideChecked>::Exec;
+    DCHECK_OK(divide_checked->AddKernel({duration(unit), duration(unit)}, float64(),
                                         std::move(exec)));
   }
 

--- a/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
@@ -1724,14 +1724,14 @@ TEST_F(ScalarTemporalTest, TestTemporalDivideDuration) {
   // div(duration, duration) -> float64
   auto left = ArrayFromJSON(duration(TimeUnit::SECOND), "[1, 2, 3, 4]");
   auto right = ArrayFromJSON(duration(TimeUnit::MILLI), "[4000, 300, 20, 1]");
-  auto expected_left_to_right =
+  auto expected_left_by_right =
       ArrayFromJSON(float64(), "[0.25, 6.666666666666667, 150, 4000]");
-  auto expected_right_to_left =
+  auto expected_right_by_left =
       ArrayFromJSON(float64(), "[4, 0.15, 0.006666666666666667, 0.00025]");
-  CheckScalarBinary("divide", left, right, expected_left_to_right);
-  CheckScalarBinary("divide_checked", left, right, expected_left_to_right);
-  CheckScalarBinary("divide", right, left, expected_right_to_left);
-  CheckScalarBinary("divide_checked", right, left, expected_right_to_left);
+  CheckScalarBinary("divide", left, right, expected_left_by_right);
+  CheckScalarBinary("divide_checked", left, right, expected_left_by_right);
+  CheckScalarBinary("divide", right, left, expected_right_by_left);
+  CheckScalarBinary("divide_checked", right, left, expected_right_by_left);
 
   // Check dispatching
   CheckDispatchBest("divide", {duration(TimeUnit::SECOND), duration(TimeUnit::MILLI)},

--- a/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
@@ -1695,7 +1695,7 @@ TEST_F(ScalarTemporalTest, TestTemporalMultiplyDuration) {
 }
 
 TEST_F(ScalarTemporalTest, TestTemporalDivideDuration) {
-  // div(duration, integer)
+  // div(duration, integer) -> integer
   for (auto u : TimeUnit::values()) {
     for (auto numeric : NumericTypes()) {
       if (!is_integer(numeric->id())) continue;
@@ -1723,9 +1723,14 @@ TEST_F(ScalarTemporalTest, TestTemporalDivideDuration) {
   // div(duration, duration) -> float64
   auto left = ArrayFromJSON(duration(TimeUnit::SECOND), "[1, 2, 3, 4]");
   auto right = ArrayFromJSON(duration(TimeUnit::MILLI), "[4000, 300, 20, 1]");
-  auto expected = ArrayFromJSON(float64(), "[0.25, 6.666666666666667, 150, 4000]");
-  CheckScalarBinary("divide", left, right, expected);
-  CheckScalarBinary("divide_checked", left, right, expected);
+  auto expected_left_to_right =
+      ArrayFromJSON(float64(), "[0.25, 6.666666666666667, 150, 4000]");
+  auto expected_right_to_left =
+      ArrayFromJSON(float64(), "[4, 0.15, 0.006666666666666667, 0.00025]");
+  CheckScalarBinary("divide", left, right, expected_left_to_right);
+  CheckScalarBinary("divide_checked", left, right, expected_left_to_right);
+  CheckScalarBinary("divide", right, left, expected_right_to_left);
+  CheckScalarBinary("divide_checked", right, left, expected_right_to_left);
 }
 
 TEST_F(ScalarTemporalTest, TestTemporalDifferenceWeeks) {

--- a/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
@@ -1695,6 +1695,7 @@ TEST_F(ScalarTemporalTest, TestTemporalMultiplyDuration) {
 }
 
 TEST_F(ScalarTemporalTest, TestTemporalDivideDuration) {
+  // div(duration, integer)
   for (auto u : TimeUnit::values()) {
     for (auto numeric : NumericTypes()) {
       if (!is_integer(numeric->id())) continue;
@@ -1718,6 +1719,13 @@ TEST_F(ScalarTemporalTest, TestTemporalDivideDuration) {
                                       CallFunction("divide_checked", {durations, zeros}));
     }
   }
+
+  // div(duration, duration) -> float64
+  auto left = ArrayFromJSON(duration(TimeUnit::SECOND), "[1, 2, 3, 4]");
+  auto right = ArrayFromJSON(duration(TimeUnit::MILLI), "[4000, 300, 20, 1]");
+  auto expected = ArrayFromJSON(float64(), "[0.25, 6.666666666666667, 150, 4000]");
+  CheckScalarBinary("divide", left, right, expected);
+  CheckScalarBinary("divide_checked", left, right, expected);
 }
 
 TEST_F(ScalarTemporalTest, TestTemporalDifferenceWeeks) {

--- a/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
@@ -26,6 +26,7 @@
 #include "arrow/testing/matchers.h"
 #include "arrow/testing/util.h"
 #include "arrow/type.h"
+#include "arrow/type_fwd.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/formatting.h"
@@ -1731,6 +1732,12 @@ TEST_F(ScalarTemporalTest, TestTemporalDivideDuration) {
   CheckScalarBinary("divide_checked", left, right, expected_left_to_right);
   CheckScalarBinary("divide", right, left, expected_right_to_left);
   CheckScalarBinary("divide_checked", right, left, expected_right_to_left);
+
+  // Check dispatching
+  CheckDispatchBest("divide", {duration(TimeUnit::SECOND), duration(TimeUnit::MILLI)},
+                    {duration(TimeUnit::MILLI), duration(TimeUnit::MILLI)});
+  CheckDispatchBest("divide", {duration(TimeUnit::NANO), duration(TimeUnit::MILLI)},
+                    {duration(TimeUnit::NANO), duration(TimeUnit::NANO)});
 }
 
 TEST_F(ScalarTemporalTest, TestTemporalDifferenceWeeks) {


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Support divide(duration, duration), as pandas and numpy already do.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add kernels divide(duration, duration)->float64 and divide_checked(duration, duration)->float64

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes

### Are there any user-facing changes?

No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #36789