### PR TITLE
MINOR: [R] Bump versions following 12.0.1.1 release

### DIFF
--- a/r/pkgdown/assets/versions.html
+++ b/r/pkgdown/assets/versions.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
-<body><p><a href="../dev/r/">11.0.0.9000 (dev)</a></p>
-<p><a href="../r/">11.0.0 (release)</a></p>
+  <body><p><a href="../dev/r/">12.0.1.9000 (dev)</a></p>
+<p><a href="../r/">12.0.1.1 (release)</a></p>
+<p><a href="../11.0/r/">11.0.0.3</a></p>
 <p><a href="../10.0/r/">10.0.1</a></p>
 <p><a href="../9.0/r/">9.0.0</a></p>
 <p><a href="../8.0/r/">8.0.0</a></p>

--- a/r/pkgdown/assets/versions.html
+++ b/r/pkgdown/assets/versions.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-  <body><p><a href="../dev/r/">12.0.1.9000 (dev)</a></p>
+<body><p><a href="../dev/r/">12.0.1.9000 (dev)</a></p>
 <p><a href="../r/">12.0.1.1 (release)</a></p>
 <p><a href="../11.0/r/">11.0.0.3</a></p>
 <p><a href="../10.0/r/">10.0.1</a></p>

--- a/r/pkgdown/assets/versions.json
+++ b/r/pkgdown/assets/versions.json
@@ -4,7 +4,7 @@
         "version": "dev/"
     },
     {
-        "name": "12.0.1 (release)",
+        "name": "12.0.1.1 (release)",
         "version": ""
     },
     {


### PR DESCRIPTION
### Rationale for this change

Bumping version numbers after 12.0.1.1 release (this is a manual process for CRAN-only releases)