### PR TITLE
GH-36671: [Go] BinaryMemoTable optimize allocations of GetOrInsert

### DIFF
--- a/go/arrow/array/dictionary_test.go
+++ b/go/arrow/array/dictionary_test.go
@@ -19,6 +19,7 @@ package array_test
 import (
 	"fmt"
 	"math"
+	"math/rand"
 	"reflect"
 	"strings"
 	"testing"
@@ -1845,4 +1846,22 @@ func TestBinaryDictionaryPanic(t *testing.T) {
 		bldr.NewArray()
 	}()
 	assert.True(t, allocator.paniced)
+}
+
+func BenchmarkBinaryDictionaryBuilder(b *testing.B) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(b, 0)
+
+	dictType := &arrow.DictionaryType{IndexType: &arrow.Int32Type{}, ValueType: arrow.BinaryTypes.String}
+	bldr := array.NewDictionaryBuilder(mem, dictType)
+	defer bldr.Release()
+
+	randString := func() string {
+		return fmt.Sprintf("test-%d", rand.Intn(30))
+	}
+
+	builder := bldr.(*array.BinaryDictionaryBuilder)
+	for i := 0; i < b.N; i++ {
+		assert.NoError(b, builder.AppendString(randString()))
+	}
 }

--- a/go/internal/hashing/xxh3_memo_table.gen.go
+++ b/go/internal/hashing/xxh3_memo_table.gen.go
@@ -298,6 +298,11 @@ func (s *Int8MemoTable) GetOrInsert(val interface{}) (idx int, found bool, err e
 	return
 }
 
+// GetOrInsertBytes is unimplemented
+func (s *Int8MemoTable) GetOrInsertBytes(val []byte) (idx int, found bool, err error) {
+	panic("unimplemented")
+}
+
 type payloadUint8 struct {
 	val     uint8
 	memoIdx int32
@@ -568,6 +573,11 @@ func (s *Uint8MemoTable) GetOrInsert(val interface{}) (idx int, found bool, err 
 		s.tbl.Insert(e, h, val.(uint8), int32(idx))
 	}
 	return
+}
+
+// GetOrInsertBytes is unimplemented
+func (s *Uint8MemoTable) GetOrInsertBytes(val []byte) (idx int, found bool, err error) {
+	panic("unimplemented")
 }
 
 type payloadInt16 struct {
@@ -842,6 +852,11 @@ func (s *Int16MemoTable) GetOrInsert(val interface{}) (idx int, found bool, err 
 	return
 }
 
+// GetOrInsertBytes is unimplemented
+func (s *Int16MemoTable) GetOrInsertBytes(val []byte) (idx int, found bool, err error) {
+	panic("unimplemented")
+}
+
 type payloadUint16 struct {
 	val     uint16
 	memoIdx int32
@@ -1112,6 +1127,11 @@ func (s *Uint16MemoTable) GetOrInsert(val interface{}) (idx int, found bool, err
 		s.tbl.Insert(e, h, val.(uint16), int32(idx))
 	}
 	return
+}
+
+// GetOrInsertBytes is unimplemented
+func (s *Uint16MemoTable) GetOrInsertBytes(val []byte) (idx int, found bool, err error) {
+	panic("unimplemented")
 }
 
 type payloadInt32 struct {
@@ -1386,6 +1406,11 @@ func (s *Int32MemoTable) GetOrInsert(val interface{}) (idx int, found bool, err 
 	return
 }
 
+// GetOrInsertBytes is unimplemented
+func (s *Int32MemoTable) GetOrInsertBytes(val []byte) (idx int, found bool, err error) {
+	panic("unimplemented")
+}
+
 type payloadInt64 struct {
 	val     int64
 	memoIdx int32
@@ -1656,6 +1681,11 @@ func (s *Int64MemoTable) GetOrInsert(val interface{}) (idx int, found bool, err 
 		s.tbl.Insert(e, h, val.(int64), int32(idx))
 	}
 	return
+}
+
+// GetOrInsertBytes is unimplemented
+func (s *Int64MemoTable) GetOrInsertBytes(val []byte) (idx int, found bool, err error) {
+	panic("unimplemented")
 }
 
 type payloadUint32 struct {
@@ -1930,6 +1960,11 @@ func (s *Uint32MemoTable) GetOrInsert(val interface{}) (idx int, found bool, err
 	return
 }
 
+// GetOrInsertBytes is unimplemented
+func (s *Uint32MemoTable) GetOrInsertBytes(val []byte) (idx int, found bool, err error) {
+	panic("unimplemented")
+}
+
 type payloadUint64 struct {
 	val     uint64
 	memoIdx int32
@@ -2200,6 +2235,11 @@ func (s *Uint64MemoTable) GetOrInsert(val interface{}) (idx int, found bool, err
 		s.tbl.Insert(e, h, val.(uint64), int32(idx))
 	}
 	return
+}
+
+// GetOrInsertBytes is unimplemented
+func (s *Uint64MemoTable) GetOrInsertBytes(val []byte) (idx int, found bool, err error) {
+	panic("unimplemented")
 }
 
 type payloadFloat32 struct {
@@ -2493,6 +2533,11 @@ func (s *Float32MemoTable) GetOrInsert(val interface{}) (idx int, found bool, er
 	return
 }
 
+// GetOrInsertBytes is unimplemented
+func (s *Float32MemoTable) GetOrInsertBytes(val []byte) (idx int, found bool, err error) {
+	panic("unimplemented")
+}
+
 type payloadFloat64 struct {
 	val     float64
 	memoIdx int32
@@ -2780,4 +2825,9 @@ func (s *Float64MemoTable) GetOrInsert(val interface{}) (idx int, found bool, er
 		s.tbl.Insert(e, h, val.(float64), int32(idx))
 	}
 	return
+}
+
+// GetOrInsertBytes is unimplemented
+func (s *Float64MemoTable) GetOrInsertBytes(val []byte) (idx int, found bool, err error) {
+	panic("unimplemented")
 }

--- a/go/internal/hashing/xxh3_memo_table.gen.go.tmpl
+++ b/go/internal/hashing/xxh3_memo_table.gen.go.tmpl
@@ -340,4 +340,10 @@ func (s *{{.Name}}MemoTable) GetOrInsert(val interface{}) (idx int, found bool, 
   }
   return
 }
+
+
+// GetOrInsertBytes is unimplemented
+func (s *{{.Name}}MemoTable) GetOrInsertBytes(val []byte) (idx int, found bool, err error) {
+    panic("unimplemented")
+}
 {{end}}


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

The hashing.MemoTable provides an interface with

    GetOrInsert(val interface{}) (idx int, existed bool, err error)

This can cause a costly allocation for binary dictionaries as is detailed in issue https://github.com/apache/arrow/issues/36671

If we expand the MemoTable interface to include:

   
    GetOrInsertBytes(val []byte) (idx int, existed bool, err error)

We can avoid the allocations at runtime to convert from `[]byte` to `interface{}`


### What changes are included in this PR?

No logic was changed with the BinaryMemoTable but instead the same API for `GetOrInsert` was copied to a type specific API of `GetOrInsertBytes`. 

The `BinaryDictionaryBuilder` now simple calls these bytes methods instead of the generic `interface{}` ones.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

No additional tests were included as the current tests exercise this code. 

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #36671