### PR TITLE
GH-36812: [C#] Fix C API support to work with .NET desktop framework

### DIFF
--- a/csharp/src/Apache.Arrow/C/CArrowArrayExporter.cs
+++ b/csharp/src/Apache.Arrow/C/CArrowArrayExporter.cs
@@ -26,9 +26,9 @@ namespace Apache.Arrow.C
 #if NET5_0_OR_GREATER
         private static unsafe delegate* unmanaged<CArrowArray*, void> ReleaseArrayPtr => &ReleaseArray;
 #else
-        private unsafe delegate void ReleaseArrowArray(CArrowArray* cArray);
+        internal unsafe delegate void ReleaseArrowArray(CArrowArray* cArray);
         private static unsafe readonly NativeDelegate<ReleaseArrowArray> s_releaseArray = new NativeDelegate<ReleaseArrowArray>(ReleaseArray);
-        private static unsafe delegate* unmanaged[Cdecl]<CArrowArray*, void> ReleaseArrayPtr => (delegate* unmanaged[Cdecl]<CArrowArray*, void>)s_releaseArray.Pointer;
+        private static IntPtr ReleaseArrayPtr => s_releaseArray.Pointer;
 #endif
         /// <summary>
         /// Export an <see cref="IArrowArray"/> to a <see cref="CArrowArray"/>. Whether or not the
@@ -93,7 +93,7 @@ namespace Apache.Arrow.C
             {
                 throw new ArgumentNullException(nameof(cArray));
             }
-            if (cArray->release != null)
+            if (cArray->release != default)
             {
                 throw new ArgumentException("Cannot export array to a struct that is already initialized.", nameof(cArray));
             }
@@ -191,7 +191,7 @@ namespace Apache.Arrow.C
         private unsafe static void ReleaseArray(CArrowArray* cArray)
         {
             Dispose(&cArray->private_data);
-            cArray->release = null;
+            cArray->release = default;
         }
 
         private unsafe static void* FromDisposable(IDisposable disposable)

--- a/csharp/src/Apache.Arrow/C/CArrowArrayStream.cs
+++ b/csharp/src/Apache.Arrow/C/CArrowArrayStream.cs
@@ -35,11 +35,11 @@ namespace Apache.Arrow.C
         ///
         /// Return value: 0 if successful, an `errno`-compatible error code otherwise.
         ///</summary>
-        internal delegate* unmanaged
-#if !NET5_0_OR_GREATER
-            [Cdecl]
+#if NET5_0_OR_GREATER
+        internal delegate* unmanaged <CArrowArrayStream*, CArrowSchema*, int> get_schema;
+#else
+        internal IntPtr get_schema;
 #endif
-            <CArrowArrayStream*, CArrowSchema*, int> get_schema;
 
         /// <summary>
         /// Callback to get the next array. If no error and the array is released, the stream has ended.
@@ -47,11 +47,11 @@ namespace Apache.Arrow.C
         /// 
         /// Return value: 0 if successful, an `errno`-compatible error code otherwise.
         /// </summary>
-        internal delegate* unmanaged
-#if !NET5_0_OR_GREATER
-            [Cdecl]
+#if NET5_0_OR_GREATER
+        internal delegate* unmanaged<CArrowArrayStream*, CArrowArray*, int> get_next;
+#else
+        internal IntPtr get_next;
 #endif
-            <CArrowArrayStream*, CArrowArray*, int> get_next;
 
         /// <summary>
         /// Callback to get optional detailed error information. This must only
@@ -62,21 +62,21 @@ namespace Apache.Arrow.C
         /// Return value: pointer to a null-terminated character array describing the last
         /// error, or NULL if no description is available.
         ///</summary>
-        internal delegate* unmanaged
-#if !NET5_0_OR_GREATER
-            [Cdecl]
+#if NET5_0_OR_GREATER
+        internal delegate* unmanaged<CArrowArrayStream*, byte*> get_last_error;
+#else
+        internal IntPtr get_last_error;
 #endif
-            <CArrowArrayStream*, byte*> get_last_error;
 
         /// <summary>
         /// Release callback: release the stream's own resources. Note that arrays returned by
         /// get_next must be individually released.
         /// </summary>
-        internal delegate* unmanaged
-#if !NET5_0_OR_GREATER
-            [Cdecl]
+#if NET5_0_OR_GREATER
+        internal delegate* unmanaged <CArrowArrayStream*, void> release;
+#else
+        internal IntPtr release;
 #endif
-            <CArrowArrayStream*, void> release;
 
         public void* private_data;
 
@@ -103,10 +103,15 @@ namespace Apache.Arrow.C
         /// </remarks>
         public static void Free(CArrowArrayStream* arrayStream)
         {
-            if (arrayStream->release != null)
+            if (arrayStream->release != default)
             {
                 // Call release if not already called.
+#if NET5_0_OR_GREATER
+
                 arrayStream->release(arrayStream);
+#else
+                Marshal.GetDelegateForFunctionPointer<CArrowArrayStreamExporter.ReleaseArrayStream>(arrayStream->release)(arrayStream);
+#endif
             }
             Marshal.FreeHGlobal((IntPtr)arrayStream);
         }

--- a/csharp/src/Apache.Arrow/C/CArrowArrayStreamExporter.cs
+++ b/csharp/src/Apache.Arrow/C/CArrowArrayStreamExporter.cs
@@ -29,22 +29,18 @@ namespace Apache.Arrow.C
         private static unsafe delegate* unmanaged<CArrowArrayStream*, byte*> GetLastErrorPtr => &GetLastError;
         private static unsafe delegate* unmanaged<CArrowArrayStream*, void> ReleasePtr => &Release;
 #else
-        private unsafe delegate int GetSchemaArrayStream(CArrowArrayStream* cArrayStream, CArrowSchema* cSchema);
+        internal unsafe delegate int GetSchemaArrayStream(CArrowArrayStream* cArrayStream, CArrowSchema* cSchema);
         private static unsafe NativeDelegate<GetSchemaArrayStream> s_getSchemaArrayStream = new NativeDelegate<GetSchemaArrayStream>(GetSchema);
-        private static unsafe delegate* unmanaged[Cdecl]<CArrowArrayStream*, CArrowSchema*, int> GetSchemaPtr =>
-            (delegate* unmanaged[Cdecl]<CArrowArrayStream*, CArrowSchema*, int>)s_getSchemaArrayStream.Pointer;
-        private unsafe delegate int GetNextArrayStream(CArrowArrayStream* cArrayStream, CArrowArray* cArray);
+        private static unsafe IntPtr GetSchemaPtr => s_getSchemaArrayStream.Pointer;
+        internal unsafe delegate int GetNextArrayStream(CArrowArrayStream* cArrayStream, CArrowArray* cArray);
         private static unsafe NativeDelegate<GetNextArrayStream> s_getNextArrayStream = new NativeDelegate<GetNextArrayStream>(GetNext);
-        private static unsafe delegate* unmanaged[Cdecl]<CArrowArrayStream*, CArrowArray*, int> GetNextPtr =>
-            (delegate* unmanaged[Cdecl]<CArrowArrayStream*, CArrowArray*, int>)s_getNextArrayStream.Pointer;
-        private unsafe delegate byte* GetLastErrorArrayStream(CArrowArrayStream* cArrayStream);
+        private static unsafe IntPtr GetNextPtr => s_getNextArrayStream.Pointer;
+        internal unsafe delegate byte* GetLastErrorArrayStream(CArrowArrayStream* cArrayStream);
         private static unsafe NativeDelegate<GetLastErrorArrayStream> s_getLastErrorArrayStream = new NativeDelegate<GetLastErrorArrayStream>(GetLastError);
-        private static unsafe delegate* unmanaged[Cdecl]<CArrowArrayStream*, byte*> GetLastErrorPtr =>
-            (delegate* unmanaged[Cdecl]<CArrowArrayStream*, byte*>)s_getLastErrorArrayStream.Pointer;
-        private unsafe delegate void ReleaseArrayStream(CArrowArrayStream* cArrayStream);
+        private static unsafe IntPtr GetLastErrorPtr => s_getLastErrorArrayStream.Pointer;
+        internal unsafe delegate void ReleaseArrayStream(CArrowArrayStream* cArrayStream);
         private static unsafe NativeDelegate<ReleaseArrayStream> s_releaseArrayStream = new NativeDelegate<ReleaseArrayStream>(Release);
-        private static unsafe delegate* unmanaged[Cdecl]<CArrowArrayStream*, void> ReleasePtr =>
-            (delegate* unmanaged[Cdecl]<CArrowArrayStream*, void>)s_releaseArrayStream.Pointer;
+        private static unsafe IntPtr ReleasePtr => s_releaseArrayStream.Pointer;
 #endif
 
         /// <summary>
@@ -103,7 +99,7 @@ namespace Apache.Arrow.C
             ExportedArrayStream arrayStream = null;
             try
             {
-                cArray->release = null;
+                cArray->release = default;
                 arrayStream = ExportedArrayStream.FromPointer(cArrayStream->private_data);
                 RecordBatch recordBatch = arrayStream.ArrowArrayStream.ReadNextRecordBatchAsync().Result;
                 if (recordBatch != null)
@@ -140,7 +136,7 @@ namespace Apache.Arrow.C
         private unsafe static void Release(CArrowArrayStream* cArrayStream)
         {
             ExportedArrayStream.Free(&cArrayStream->private_data);
-            cArrayStream->release = null;
+            cArrayStream->release = default;
         }
 
         sealed unsafe class ExportedArrayStream : IDisposable

--- a/csharp/src/Apache.Arrow/C/CArrowSchemaExporter.cs
+++ b/csharp/src/Apache.Arrow/C/CArrowSchemaExporter.cs
@@ -30,9 +30,9 @@ namespace Apache.Arrow.C
 #if NET5_0_OR_GREATER
         private static unsafe delegate* unmanaged<CArrowSchema*, void> ReleaseSchemaPtr => &ReleaseCArrowSchema;
 #else
-        private unsafe delegate void ReleaseArrowSchema(CArrowSchema* cArray);
+        internal unsafe delegate void ReleaseArrowSchema(CArrowSchema* cArray);
         private static unsafe readonly NativeDelegate<ReleaseArrowSchema> s_releaseSchema = new NativeDelegate<ReleaseArrowSchema>(ReleaseCArrowSchema);
-        private static unsafe delegate* unmanaged[Cdecl]<CArrowSchema*, void> ReleaseSchemaPtr => (delegate* unmanaged[Cdecl]<CArrowSchema*, void>)s_releaseSchema.Pointer;
+        private static IntPtr ReleaseSchemaPtr => s_releaseSchema.Pointer;
 #endif
 
         /// <summary>
@@ -297,7 +297,7 @@ namespace Apache.Arrow.C
         private static unsafe void ReleaseCArrowSchema(CArrowSchema* schema)
         {
             if (schema == null) return;
-            if (schema->release == null) return;
+            if (schema->release == default) return;
 
             Marshal.FreeHGlobal((IntPtr)schema->format);
             Marshal.FreeHGlobal((IntPtr)schema->name);
@@ -324,7 +324,7 @@ namespace Apache.Arrow.C
             schema->n_children = 0;
             schema->dictionary = null;
             schema->children = null;
-            schema->release = null;
+            schema->release = default;
         }
     }
 }

--- a/csharp/src/Apache.Arrow/C/CArrowSchemaImporter.cs
+++ b/csharp/src/Apache.Arrow/C/CArrowSchemaImporter.cs
@@ -113,7 +113,7 @@ namespace Apache.Arrow.C
                     throw new ArgumentException("Passed null pointer for cSchema.");
                 }
                 _cSchema = cSchema;
-                if (_cSchema->release == null)
+                if (_cSchema->release == default)
                 {
                     throw new ArgumentException("Tried to import a schema that has already been released.");
                 }
@@ -128,9 +128,13 @@ namespace Apache.Arrow.C
             public void Dispose()
             {
                 // We only call release on a root-level schema, not child ones.
-                if (_isRoot && _cSchema->release != null)
+                if (_isRoot && _cSchema->release != default)
                 {
+#if NET5_0_OR_GREATER
                     _cSchema->release(_cSchema);
+#else
+                    Marshal.GetDelegateForFunctionPointer<CArrowSchemaExporter.ReleaseArrowSchema>(_cSchema->release)(_cSchema);
+#endif
                 }
             }
 

--- a/csharp/test/Apache.Arrow.Tests/Apache.Arrow.Tests.csproj
+++ b/csharp/test/Apache.Arrow.Tests/Apache.Arrow.Tests.csproj
@@ -2,10 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0</TargetFrameworks>
-    <!-- Unloading the AppDomain causes net472 tests to hang on completion when Python has been used
     <TargetFrameworks>net7.0;net472</TargetFrameworks>
-    -->
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/csharp/test/Apache.Arrow.Tests/Apache.Arrow.Tests.csproj
+++ b/csharp/test/Apache.Arrow.Tests/Apache.Arrow.Tests.csproj
@@ -2,7 +2,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks>net7.0</TargetFrameworks>
+    <!-- TODO: CI can't run with net472 on non-Windows platforms
     <TargetFrameworks>net7.0;net472</TargetFrameworks>
+    -->
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/csharp/test/Apache.Arrow.Tests/Apache.Arrow.Tests.csproj
+++ b/csharp/test/Apache.Arrow.Tests/Apache.Arrow.Tests.csproj
@@ -3,6 +3,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>net7.0</TargetFrameworks>
+    <!-- Unloading the AppDomain causes net472 tests to hang on completion when Python has been used
+    <TargetFrameworks>net7.0;net472</TargetFrameworks>
+    -->
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
@@ -24,5 +27,9 @@
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net6.0'))">
     <Compile Remove="TimeOnlyTests.cs" />
   </ItemGroup>
-  
+
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net5.0'))">
+    <Compile Remove="Extensions\Net472Extensions.cs" />
+  </ItemGroup>
+
 </Project>

--- a/csharp/test/Apache.Arrow.Tests/ArrayBuilderTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrayBuilderTests.cs
@@ -26,6 +26,7 @@ namespace Apache.Arrow.Tests
     {
         // TODO: Test various builder invariants (Append, AppendRange, Clear, Resize, Reserve, etc)
 
+#if NET5_0_OR_GREATER
         [Fact]
         public void PrimitiveArrayBuildersProduceExpectedArray()
         {
@@ -73,6 +74,7 @@ namespace Apache.Arrow.Tests
                 where TBuilder : PrimitiveArrayBuilder<T, TArray, TBuilder>, new() =>
                 TestArrayBuilder<TArray, TBuilder>(x => x.Append(T.CreateChecked(123)).AppendNull().AppendNull().Append(T.CreateChecked(127)), 4, 2, 0x09);
         }
+#endif
 
         [Fact]
         public void BooleanArrayBuilderProducersExpectedArray()

--- a/csharp/test/Apache.Arrow.Tests/ArrowArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowArrayTests.cs
@@ -93,6 +93,7 @@ namespace Apache.Arrow.Tests
             }
         }
 
+#if NET5_0_OR_GREATER
         [Fact]
         public void SliceArray()
         {
@@ -145,6 +146,7 @@ namespace Apache.Arrow.Tests
                 where TBuilder : PrimitiveArrayBuilder<T, TArray, TBuilder>, new() =>
                 TestSlice<TArray, TBuilder>(x => x.AppendNull().Append(T.CreateChecked(10)).Append(T.CreateChecked(20)).AppendNull().Append(T.CreateChecked(30)));
         }
+#endif
 
         [Fact]
         public void SliceBooleanArray()
@@ -198,7 +200,9 @@ namespace Apache.Arrow.Tests
             IArrowArrayVisitor<Date64Array>,
             IArrowArrayVisitor<Time32Array>,
             IArrowArrayVisitor<Time64Array>,
+#if NET5_0_OR_GREATER
             IArrowArrayVisitor<HalfFloatArray>,
+#endif
             IArrowArrayVisitor<FloatArray>,
             IArrowArrayVisitor<DoubleArray>,
             IArrowArrayVisitor<BooleanArray>,
@@ -240,7 +244,9 @@ namespace Apache.Arrow.Tests
             public void Visit(Time32Array array) => ValidateArrays(array);
             public void Visit(Time64Array array) => ValidateArrays(array);
 
+#if NET5_0_OR_GREATER
             public void Visit(HalfFloatArray array) => ValidateArrays(array);
+#endif
             public void Visit(FloatArray array) => ValidateArrays(array);
             public void Visit(DoubleArray array) => ValidateArrays(array);
             public void Visit(StringArray array) => ValidateArrays(array);

--- a/csharp/test/Apache.Arrow.Tests/ArrowReaderVerifier.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowReaderVerifier.cs
@@ -74,7 +74,9 @@ namespace Apache.Arrow.Tests
             IArrowArrayVisitor<UInt16Array>,
             IArrowArrayVisitor<UInt32Array>,
             IArrowArrayVisitor<UInt64Array>,
+#if NET5_0_OR_GREATER
             IArrowArrayVisitor<HalfFloatArray>,
+#endif
             IArrowArrayVisitor<FloatArray>,
             IArrowArrayVisitor<DoubleArray>,
             IArrowArrayVisitor<BooleanArray>,
@@ -112,7 +114,9 @@ namespace Apache.Arrow.Tests
             public void Visit(UInt16Array array) => CompareArrays(array);
             public void Visit(UInt32Array array) => CompareArrays(array);
             public void Visit(UInt64Array array) => CompareArrays(array);
+#if NET5_0_OR_GREATER
             public void Visit(HalfFloatArray array) => CompareArrays(array);
+#endif
             public void Visit(FloatArray array) => CompareArrays(array);
             public void Visit(DoubleArray array) => CompareArrays(array);
             public void Visit(BooleanArray array) => CompareArrays(array);

--- a/csharp/test/Apache.Arrow.Tests/ArrowStreamReaderTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowStreamReaderTests.cs
@@ -224,6 +224,7 @@ namespace Apache.Arrow.Tests
             // by default return 20 bytes at a time
             public int PartialReadLength { get; set; } = 20;
 
+#if NET5_0_OR_GREATER
             public override int Read(Span<byte> destination)
             {
                 if (destination.Length > PartialReadLength)
@@ -243,6 +244,17 @@ namespace Apache.Arrow.Tests
 
                 return base.ReadAsync(destination, cancellationToken);
             }
+#else
+            public override int Read(byte[] buffer, int offset, int length)
+            {
+                return base.Read(buffer, offset, Math.Min(length, PartialReadLength));
+            }
+
+            public override Task<int> ReadAsync(byte[] buffer, int offset, int length, CancellationToken cancellationToken = default)
+            {
+                return base.ReadAsync(buffer, offset, Math.Min(length, PartialReadLength), cancellationToken);
+            }
+#endif
         }
     }
 }

--- a/csharp/test/Apache.Arrow.Tests/CDataInterfaceDataTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/CDataInterfaceDataTests.cs
@@ -47,7 +47,7 @@ namespace Apache.Arrow.Tests
             Assert.True(cArray->buffers == null);
             Assert.True(cArray->children == null);
             Assert.True(cArray->dictionary == null);
-            Assert.True(cArray->release == null);
+            Assert.True(cArray->release == default);
             Assert.True(cArray->private_data == null);
 
             CArrowArray.Free(cArray);
@@ -59,12 +59,13 @@ namespace Apache.Arrow.Tests
             IArrowArray array = GetTestArray();
             CArrowArray* cArray = CArrowArray.Create();
             CArrowArrayExporter.ExportArray(array, cArray);
-            Assert.False(cArray->release == null);
+            Assert.False(cArray->release == default);
             CArrowArrayImporter.ImportArray(cArray, array.Data.DataType).Dispose();
-            Assert.True(cArray->release == null);
+            Assert.True(cArray->release == default);
             CArrowArray.Free(cArray);
         }
 
+#if NET5_0_OR_GREATER
         [Fact]
         public unsafe void CallsReleaseForInvalid()
         {
@@ -75,7 +76,7 @@ namespace Apache.Arrow.Tests
             var releaseCallback = (CArrowArray* cArray) =>
             {
                 wasCalled = true;
-                cArray->release = null;
+                cArray->release = default;
             };
             cArray->release = (delegate* unmanaged<CArrowArray*, void>)Marshal.GetFunctionPointerForDelegate(
                 releaseCallback);
@@ -90,5 +91,6 @@ namespace Apache.Arrow.Tests
 
             GC.KeepAlive(releaseCallback);
         }
+#endif
     }
 }

--- a/csharp/test/Apache.Arrow.Tests/CDataInterfacePythonTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/CDataInterfacePythonTests.cs
@@ -28,31 +28,39 @@ using Xunit;
 
 namespace Apache.Arrow.Tests
 {
-    public class CDataSchemaPythonTest
+    public class CDataSchemaPythonTest : IClassFixture<CDataSchemaPythonTest.PythonNet>
     {
-        public CDataSchemaPythonTest()
+        class PythonNet : IDisposable
         {
-            bool inCIJob = Environment.GetEnvironmentVariable("GITHUB_ACTIONS") == "true";
-            bool inVerificationJob = Environment.GetEnvironmentVariable("TEST_CSHARP") == "1";
-            bool pythonSet = Environment.GetEnvironmentVariable("PYTHONNET_PYDLL") != null;
-            // We only skip if this is not in CI
-            if (inCIJob && !inVerificationJob && !pythonSet)
+            public PythonNet()
             {
-                throw new Exception("PYTHONNET_PYDLL not set; skipping C Data Interface tests.");
+                bool inCIJob = Environment.GetEnvironmentVariable("GITHUB_ACTIONS") == "true";
+                bool inVerificationJob = Environment.GetEnvironmentVariable("TEST_CSHARP") == "1";
+                bool pythonSet = Environment.GetEnvironmentVariable("PYTHONNET_PYDLL") != null;
+                // We only skip if this is not in CI
+                if (inCIJob && !inVerificationJob && !pythonSet)
+                {
+                    throw new Exception("PYTHONNET_PYDLL not set; skipping C Data Interface tests.");
+                }
+                else
+                {
+                    Skip.If(!pythonSet, "PYTHONNET_PYDLL not set; skipping C Data Interface tests.");
+                }
+
+
+                PythonEngine.Initialize();
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
+                    PythonEngine.PythonPath.IndexOf("dlls", StringComparison.OrdinalIgnoreCase) < 0)
+                {
+                    dynamic sys = Py.Import("sys");
+                    sys.path.append(Path.Combine(Path.GetDirectoryName(Environment.GetEnvironmentVariable("PYTHONNET_PYDLL")), "DLLs"));
+                }
             }
-            else
+
+            public void Dispose()
             {
-                Skip.If(!pythonSet, "PYTHONNET_PYDLL not set; skipping C Data Interface tests.");
-            }
-
-
-            PythonEngine.Initialize();
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
-                PythonEngine.PythonPath.IndexOf("dlls", StringComparison.OrdinalIgnoreCase) < 0)
-            {
-                dynamic sys = Py.Import("sys");
-                sys.path.append(Path.Combine(Path.GetDirectoryName(Environment.GetEnvironmentVariable("PYTHONNET_PYDLL")), "DLLs"));
+                PythonEngine.Shutdown();
             }
         }
 

--- a/csharp/test/Apache.Arrow.Tests/CDataInterfacePythonTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/CDataInterfacePythonTests.cs
@@ -49,7 +49,7 @@ namespace Apache.Arrow.Tests
             PythonEngine.Initialize();
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
-                !PythonEngine.PythonPath.Contains("dlls", StringComparison.OrdinalIgnoreCase))
+                PythonEngine.PythonPath.IndexOf("dlls", StringComparison.OrdinalIgnoreCase) < 0)
             {
                 dynamic sys = Py.Import("sys");
                 sys.path.append(Path.Combine(Path.GetDirectoryName(Environment.GetEnvironmentVariable("PYTHONNET_PYDLL")), "DLLs"));
@@ -360,7 +360,7 @@ namespace Apache.Arrow.Tests
                 }
 
                 // Python should have called release once `exportedPyType` went out-of-scope.
-                Assert.True(cSchema->release == null);
+                Assert.True(cSchema->release == default);
                 Assert.True(cSchema->format == null);
                 Assert.Equal(0, cSchema->flags);
                 Assert.Equal(0, cSchema->n_children);
@@ -395,7 +395,7 @@ namespace Apache.Arrow.Tests
 
                 // Python should have called release once `exportedPyField` went out-of-scope.
                 Assert.True(cSchema->name == null);
-                Assert.True(cSchema->release == null);
+                Assert.True(cSchema->release == default);
                 Assert.True(cSchema->format == null);
 
                 // Since we allocated, we are responsible for freeing the pointer.

--- a/csharp/test/Apache.Arrow.Tests/CDataInterfaceSchemaTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/CDataInterfaceSchemaTests.cs
@@ -35,7 +35,7 @@ namespace Apache.Arrow.Tests
             Assert.Equal(0, cSchema->n_children);
             Assert.True(cSchema->children == null);
             Assert.True(cSchema->dictionary == null);
-            Assert.True(cSchema->release == null);
+            Assert.True(cSchema->release == default);
             Assert.True(cSchema->private_data == null);
 
             CArrowSchema.Free(cSchema);
@@ -86,12 +86,13 @@ namespace Apache.Arrow.Tests
         {
             CArrowSchema* cSchema = CArrowSchema.Create();
             CArrowSchemaExporter.ExportType(Int32Type.Default, cSchema);
-            Assert.False(cSchema->release == null);
+            Assert.False(cSchema->release == default);
             CArrowSchemaImporter.ImportType(cSchema);
-            Assert.True(cSchema->release == null);
+            Assert.True(cSchema->release == default);
             CArrowSchema.Free(cSchema);
         }
 
+#if NET5_0_OR_GREATER // can't round-trip marshaled delegate
         [Fact]
         public unsafe void CallsReleaseForInvalid()
         {
@@ -103,7 +104,7 @@ namespace Apache.Arrow.Tests
             var releaseCallback = (CArrowSchema* cSchema) =>
             {
                 wasCalled = true;
-                cSchema->release = null;
+                cSchema->release = default;
             };
             cSchema->release = (delegate* unmanaged<CArrowSchema*, void>)Marshal.GetFunctionPointerForDelegate(
                 releaseCallback);
@@ -117,5 +118,6 @@ namespace Apache.Arrow.Tests
 
             GC.KeepAlive(releaseCallback);
         }
+#endif
     }
 }

--- a/csharp/test/Apache.Arrow.Tests/Extensions/Net472Extensions.cs
+++ b/csharp/test/Apache.Arrow.Tests/Extensions/Net472Extensions.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+
+namespace Apache.Arrow.Tests
+{
+    internal static class Net472Extensions
+    {
+        public static IEnumerable<(TFirst First, TSecond Second)> Zip<TFirst, TSecond>(this IEnumerable<TFirst> first, IEnumerable<TSecond> second)
+        {
+            using (var enumerator1 = first.GetEnumerator())
+            using (var enumerator2 = second.GetEnumerator())
+            {
+                while (enumerator1.MoveNext() && enumerator2.MoveNext())
+                {
+                    yield return (enumerator1.Current, enumerator2.Current);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### What changes are included in this PR?

The C API support in the C# library has been modified to work correctly on .NET 4.7.2.
The tests have been modified to work correctly on .NET 4.7.2, though that platform is disabled by default as the Python interop seem to cause a hang when unloading the xUnit AppDomain.

**This PR contains a "Critical Fix".**
* Closes: #36812