### PR TITLE
PARQUET-2327: get min/max column statistics by isset flag

### DIFF
--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -87,8 +87,8 @@ std::string ParquetVersionToString(ParquetVersion::type ver) {
 template <typename DType>
 static std::shared_ptr<Statistics> MakeTypedColumnStats(
     const format::ColumnMetaData& metadata, const ColumnDescriptor* descr) {
-  // If ColumnOrder is defined, return max_value and min_value
-  if (descr->column_order().get_order() == ColumnOrder::TYPE_DEFINED_ORDER) {
+  // Return max_value and min_value if defined
+  if (metadata.statistics.__isset.max_value || metadata.statistics.__isset.min_value) {
     return MakeStatistics<DType>(
         descr, metadata.statistics.min_value, metadata.statistics.max_value,
         metadata.num_values - metadata.statistics.null_count,


### PR DESCRIPTION
### Rationale for this change

min/max statistics can be stored in column chunk metadata in min/max or min_value/max_value fields.
current behavior for selecting a specific pair depends on the sort order, which may contradict to isset flag.

### What changes are included in this PR?

Trivial change to get min/max column statistics by isset flag

### Are these changes tested?

tested on customers data.

### Are there any user-facing changes?

no
