### PR TITLE
GH-36809: [Python] MapScalar.as_py with custom field name

### DIFF
--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -785,7 +785,7 @@ cdef class MapScalar(ListScalar):
         if arr is None:
             raise IndexError(i)
         dct = arr[_normalize_index(i, len(arr))]
-        return (dct['key'], dct['value'])
+        return (dct[self.type.key_field.name], dct[self.type.item_field.name])
 
     def __iter__(self):
         """
@@ -794,7 +794,7 @@ cdef class MapScalar(ListScalar):
         arr = self.values
         if array is None:
             raise StopIteration
-        for k, v in zip(arr.field('key'), arr.field('value')):
+        for k, v in zip(arr.field(self.type.key_field.name), arr.field(self.type.item_field.name)):
             yield (k.as_py(), v.as_py())
 
     def as_py(self):

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -791,3 +791,26 @@ def test_union():
     assert arr[0].as_py() == b'a'
     assert arr[5].type_code == 1
     assert arr[5].as_py() == 3
+
+
+def test_map_scalar_as_py_with_custom_field_name():
+    """
+    Check we can call `MapScalar.as_py` with custom field names
+
+    See https://github.com/apache/arrow/issues/36809
+    """
+    assert pa.scalar(
+        [("foo", "bar")],
+        pa.map_(
+            pa.string(),
+            pa.string()
+        ),
+    ).as_py() == [("foo", "bar")]
+
+    assert pa.scalar(
+        [("foo", "bar")],
+        pa.map_(
+            pa.field("custom_key", pa.string(), nullable=False),
+            pa.field("custom_value", pa.string()),
+        ),
+    ).as_py() == [("foo", "bar")]


### PR DESCRIPTION
### Rationale for this change

`MapScalar.as_py` doesn't take into account custom key/value field names

### What changes are included in this PR?

Fix and tests 

### Are these changes tested?

Simple unit test

### Are there any user-facing changes?

No API changes.
* Closes: #36809