### PR TITLE
GH-35292: [Release] Retry "apt install"

### DIFF
--- a/dev/release/verify-apt.sh
+++ b/dev/release/verify-apt.sh
@@ -45,7 +45,21 @@ echo "::group::Prepare repository"
 
 export DEBIAN_FRONTEND=noninteractive
 
-APT_INSTALL="apt install -y -V --no-install-recommends"
+retry()
+{
+  local n_retries=0
+  local max_n_retries=3
+  while ! "$@"; do
+    n_retries=$((n_retries + 1))
+    if [ ${n_retries} -eq ${max_n_retries} ]; then
+      echo "Failed: $@"
+      return 1
+    fi
+    echo "Retry: $@"
+  done
+}
+
+APT_INSTALL="retry apt install -y -V --no-install-recommends"
 
 apt update
 ${APT_INSTALL} \


### PR DESCRIPTION
### Rationale for this change

Timeout is still happen on my local environment.

### What changes are included in this PR?

Retry `apt install`.

This is just a workaround. We should not close GH-35292 by this.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #35292