### PR TITLE
GH-36837: [CI][RPM] Use multi-cores to install gems

### DIFF
--- a/dev/release/verify-yum.sh
+++ b/dev/release/verify-yum.sh
@@ -234,7 +234,7 @@ if [ "${have_glib}" = "yes" ]; then
 
   if [ "${have_ruby}" = "yes" ]; then
     ${install_command} "${ruby_devel_packages[@]}"
-    gem install gobject-introspection
+    MAKEFLAGS="-j$(nproc)" gem install gobject-introspection
     ruby -r gi -e "p GI.load('Arrow')"
   fi
   echo "::endgroup::"


### PR DESCRIPTION
### Rationale for this change

We may reduce test time by using multi-cores to install gems.

### What changes are included in this PR?

`gem install` with `MAKEFLAGS=-j$(nproc)` uses multi-cores when building extension libraries.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #36837