### PR TITLE
GH-36839: [CI][Docs] Update test-ubuntu-default-docs to use GitHub actions instead of Azure

### DIFF
--- a/dev/tasks/docs/github.linux.yml
+++ b/dev/tasks/docs/github.linux.yml
@@ -44,6 +44,7 @@ jobs:
           ref: {{ default_branch|default("main") }}
           path: crossbow
           fetch-depth: 1
+      {% if  publish %}
       - name: Prepare docs
         run: |
           # build files are created by the docker user
@@ -61,3 +62,12 @@ jobs:
         run: |
           aws s3 cp build/docs/ $BUCKET/pr_docs/{{ pr_number }}/ --recursive
           echo ":open_book: You can find the preview here: http://crossbow.voltrondata.com/pr_docs/{{ pr_number }}" >> $GITHUB_STEP_SUMMARY
+      {% endif %}
+      {% if artifacts is defined %}
+      - name: Prepare artifacts
+        run: |
+          cd build
+          sudo chown -R ${USER}: .
+          tar cvzf docs.tar.gz docs
+      {{ macros.github_upload_releases(artifacts)|indent }}
+      {% endif %}

--- a/dev/tasks/docs/github.linux.yml
+++ b/dev/tasks/docs/github.linux.yml
@@ -21,7 +21,7 @@
 
 jobs:
   test:
-    name: Docs Preview
+    name: Build Docs
     runs-on: ubuntu-latest
 {{ macros.github_set_env(env) }}
     steps:
@@ -45,7 +45,7 @@ jobs:
           path: crossbow
           fetch-depth: 1
       {% if  publish %}
-      - name: Prepare docs
+      - name: Prepare Docs Preview
         run: |
           # build files are created by the docker user
           sudo chown -R ${USER}: build
@@ -63,7 +63,7 @@ jobs:
           aws s3 cp build/docs/ $BUCKET/pr_docs/{{ pr_number }}/ --recursive
           echo ":open_book: You can find the preview here: http://crossbow.voltrondata.com/pr_docs/{{ pr_number }}" >> $GITHUB_STEP_SUMMARY
       {% endif %}
-      - name: Prepare artifacts
+      - name: Prepare Docs artifacts
         run: |
           cd build
           sudo chown -R ${USER}: .

--- a/dev/tasks/docs/github.linux.yml
+++ b/dev/tasks/docs/github.linux.yml
@@ -63,11 +63,9 @@ jobs:
           aws s3 cp build/docs/ $BUCKET/pr_docs/{{ pr_number }}/ --recursive
           echo ":open_book: You can find the preview here: http://crossbow.voltrondata.com/pr_docs/{{ pr_number }}" >> $GITHUB_STEP_SUMMARY
       {% endif %}
-      {% if artifacts is defined %}
       - name: Prepare artifacts
         run: |
           cd build
           sudo chown -R ${USER}: .
           tar cvzf docs.tar.gz docs
-      {{ macros.github_upload_releases(artifacts)|indent }}
-      {% endif %}
+      {{ macros.github_upload_releases("build/docs.tar.gz")|indent }}

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1434,7 +1434,6 @@ tasks:
       image: debian-go
   {% endfor %}
 
-
   test-ubuntu-default-docs:
     ci: github
     template: docs/github.linux.yml

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1434,17 +1434,15 @@ tasks:
       image: debian-go
   {% endfor %}
 
+
   test-ubuntu-default-docs:
-    ci: azure
-    template: docker-tests/azure.linux.yml
+    ci: github
+    template: docs/github.linux.yml
     params:
-      artifacts: "build/docs.tar.gz"
+      pr_number: Unset
       flags: "-v $PWD/build/:/build/"
       image: ubuntu-docs
-      post_script: |
-        cd build
-        sudo chown -R ${USER}: .
-        tar cvzf docs.tar.gz docs
+      publish: false
     artifacts:
       - docs.tar.gz
 
@@ -1565,6 +1563,6 @@ tasks:
     template: docs/github.linux.yml
     params:
       pr_number: Unset
-      artifacts: "build/docs.tar.gz"
       flags: "-v $PWD/build/:/build/"
       image: ubuntu-docs
+      publish: true


### PR DESCRIPTION
### Rationale for this change

Currently `test-ubuntu-default-docs` has been failing on Azure for the 13.0.0 RC0 and we had to use GitHub actions to generate the documentation.
Using the same base action for both preview-docs, test and packaging will improve maintainability.

### What changes are included in this PR?

Move `test-ubuntu-default-docs` to use GH actions instead of Azure.

### Are these changes tested?

Yes, with archery related tasks.

### Are there any user-facing changes?

No
* Closes: #36839