### PR TITLE
GH-36852: [MATLAB] Add `arrow.type.Field` class

### DIFF
--- a/matlab/src/cpp/arrow/matlab/error/error.h
+++ b/matlab/src/cpp/arrow/matlab/error/error.h
@@ -171,4 +171,5 @@ namespace arrow::matlab::error {
     static const char* STRING_BUILDER_APPEND_FAILED = "arrow:matlab:array:string:StringBuilderAppendFailed";
     static const char* STRING_BUILDER_FINISH_FAILED = "arrow:matlab:array:string:StringBuilderFinishFailed";
     static const char* UKNOWN_TIME_UNIT_ERROR_ID = "arrow:matlab:UnknownTimeUnit";
+    static const char* FIELD_FAILED_TO_CREATE_TYPE_PROXY = "arrow:field:FailedToCreateTypeProxy";
 }

--- a/matlab/src/cpp/arrow/matlab/proxy/factory.cc
+++ b/matlab/src/cpp/arrow/matlab/proxy/factory.cc
@@ -23,6 +23,7 @@
 #include "arrow/matlab/type/proxy/primitive_ctype.h"
 #include "arrow/matlab/type/proxy/string_type.h"
 #include "arrow/matlab/type/proxy/timestamp_type.h"
+#include "arrow/matlab/type/proxy/field.h"
 
 #include "factory.h"
 
@@ -43,6 +44,7 @@ libmexclass::proxy::MakeResult Factory::make_proxy(const ClassName& class_name, 
     REGISTER_PROXY(arrow.array.proxy.StringArray   , arrow::matlab::array::proxy::StringArray);
     REGISTER_PROXY(arrow.array.proxy.TimestampArray, arrow::matlab::array::proxy::NumericArray<arrow::TimestampType>);
     REGISTER_PROXY(arrow.tabular.proxy.RecordBatch , arrow::matlab::tabular::proxy::RecordBatch);
+    REGISTER_PROXY(arrow.type.proxy.Field          , arrow::matlab::type::proxy::Field);
     REGISTER_PROXY(arrow.type.proxy.Float32Type    , arrow::matlab::type::proxy::PrimitiveCType<float>);
     REGISTER_PROXY(arrow.type.proxy.Float64Type    , arrow::matlab::type::proxy::PrimitiveCType<double>);
     REGISTER_PROXY(arrow.type.proxy.UInt8Type      , arrow::matlab::type::proxy::PrimitiveCType<uint8_t>);

--- a/matlab/src/cpp/arrow/matlab/type/proxy/field.cc
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/field.cc
@@ -20,6 +20,12 @@
 #include "arrow/matlab/type/proxy/field.h"
 #include "arrow/matlab/error/error.h"
 
+#include "arrow/matlab/type/proxy/primitive_ctype.h"
+#include "arrow/matlab/type/proxy/timestamp_type.h"
+#include "arrow/matlab/type/proxy/string_type.h"
+
+#include "libmexclass/proxy/ProxyManager.h"
+
 namespace arrow::matlab::type::proxy {
 
     Field::Field(std::shared_ptr<arrow::Field> field) : field{std::move(field)} {
@@ -42,8 +48,52 @@ namespace arrow::matlab::type::proxy {
         context.outputs[0] = str_mda;
     }
 
-    void Field::type(libmexclass::proxy::method::Context& context) {
+    arrow::Result<std::shared_ptr<libmexclass::proxy::Proxy>> makeTypeProxy(const std::shared_ptr<arrow::DataType> datatype) {
+        using arrow_type = arrow::Type::type;
+        namespace type_proxy = arrow::matlab::type::proxy;
+        switch (datatype->id()) {
+            case arrow_type::UINT8:
+                return std::make_shared<type_proxy::PrimitiveCType<uint8_t>>(std::static_pointer_cast<arrow::UInt8Type>(datatype));
+            case arrow_type::UINT16:
+                return std::make_shared<type_proxy::PrimitiveCType<uint16_t>>(std::static_pointer_cast<arrow::UInt16Type>(datatype));
+            case arrow_type::UINT32:
+                return std::make_shared<type_proxy::PrimitiveCType<uint32_t>>(std::static_pointer_cast<arrow::UInt32Type>(datatype));
+            case arrow_type::UINT64:
+                return std::make_shared<type_proxy::PrimitiveCType<uint64_t>>(std::static_pointer_cast<arrow::UInt64Type>(datatype));
+            case arrow_type::INT8:
+                return std::make_shared<type_proxy::PrimitiveCType<int8_t>>(std::static_pointer_cast<arrow::Int8Type>(datatype));
+            case arrow_type::INT16:
+                return std::make_shared<type_proxy::PrimitiveCType<int16_t>>(std::static_pointer_cast<arrow::Int16Type>(datatype));
+            case arrow_type::INT32:
+                return std::make_shared<type_proxy::PrimitiveCType<int32_t>>(std::static_pointer_cast<arrow::Int32Type>(datatype));
+            case arrow_type::INT64:
+                return std::make_shared<type_proxy::PrimitiveCType<int64_t>>(std::static_pointer_cast<arrow::Int64Type>(datatype));
+            case arrow_type::FLOAT:
+                return std::make_shared<type_proxy::PrimitiveCType<float>>(std::static_pointer_cast<arrow::FloatType>(datatype));
+            case arrow_type::DOUBLE:
+                return std::make_shared<type_proxy::PrimitiveCType<double>>(std::static_pointer_cast<arrow::DoubleType>(datatype));
+            case arrow_type::BOOL:
+                return std::make_shared<type_proxy::PrimitiveCType<bool>>(std::static_pointer_cast<arrow::BooleanType>(datatype));
+            case arrow_type::STRING:
+                return std::make_shared<type_proxy::StringType>(std::static_pointer_cast<arrow::StringType>(datatype));
+            case arrow_type::TIMESTAMP:
+                return std::make_shared<type_proxy::TimestampType>(std::static_pointer_cast<arrow::TimestampType>(datatype));
+            default:
+                return arrow::Status::Invalid("Unsupported DataType: " + datatype->ToString());
+        }
+    }
 
+
+    void Field::type(libmexclass::proxy::method::Context& context) {
+        namespace mda = ::matlab::data;
+
+        auto datatype = field->type();
+        MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(auto proxy, makeTypeProxy(datatype), context, "arrow:field:FailedToCreateTypeProxy");
+        const auto proxy_id = libmexclass::proxy::ProxyManager::manageProxy(proxy);
+
+        mda::ArrayFactory factory;
+        context.outputs[0] = factory.createScalar(proxy_id);
+        context.outputs[1] = factory.createScalar(static_cast<uint64_t>(datatype->id()));
     }
 
     void Field::toString(libmexclass::proxy::method::Context& context) {
@@ -54,6 +104,25 @@ namespace arrow::matlab::type::proxy {
         MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(const auto str_utf16, arrow::util::UTF8StringToUTF16(str_utf8), context, error::UNICODE_CONVERSION_ERROR_ID);
         auto str_mda = factory.createScalar(str_utf16);
         context.outputs[0] = str_mda;
+    }
+
+    libmexclass::proxy::MakeResult Field::make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
+        namespace mda = ::matlab::data;
+        using FieldProxy = arrow::matlab::type::proxy::Field;
+
+        mda::StructArray opts = constructor_arguments[0];
+        const mda::StringArray name_mda = opts[0]["Name"];
+        const mda::TypedArray<uint64_t> type_proxy_id_mda = opts[0]["TypeProxyID"];
+
+        const std::u16string& utf16_name = name_mda[0];
+        MATLAB_ASSIGN_OR_ERROR(const auto name,
+                arrow::util::UTF16StringToUTF8(utf16_name),
+                error::UNICODE_CONVERSION_ERROR_ID);
+
+        auto proxy = std::static_pointer_cast<type::proxy::Type>(libmexclass::proxy::ProxyManager::getProxy(type_proxy_id_mda[0]));
+        auto type = proxy->unwrap();
+        auto field = arrow::field(name, type);
+        return std::make_shared<FieldProxy>(std::move(field));
     }
 
 }

--- a/matlab/src/cpp/arrow/matlab/type/proxy/field.cc
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/field.cc
@@ -48,7 +48,7 @@ namespace arrow::matlab::type::proxy {
         context.outputs[0] = str_mda;
     }
 
-    arrow::Result<std::shared_ptr<libmexclass::proxy::Proxy>> makeTypeProxy(const std::shared_ptr<arrow::DataType> datatype) {
+    arrow::Result<std::shared_ptr<libmexclass::proxy::Proxy>> makeTypeProxy(const std::shared_ptr<arrow::DataType>& datatype) {
         using arrow_type = arrow::Type::type;
         namespace type_proxy = arrow::matlab::type::proxy;
         switch (datatype->id()) {

--- a/matlab/src/cpp/arrow/matlab/type/proxy/field.cc
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/field.cc
@@ -42,7 +42,7 @@ namespace arrow::matlab::type::proxy {
         namespace mda = ::matlab::data;
         mda::ArrayFactory factory;
 
-        const auto str_utf8 = field->name();
+        const auto& str_utf8 = field->name();
         MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(const auto str_utf16, arrow::util::UTF8StringToUTF16(str_utf8), context, error::UNICODE_CONVERSION_ERROR_ID);
         auto str_mda = factory.createScalar(str_utf16);
         context.outputs[0] = str_mda;

--- a/matlab/src/cpp/arrow/matlab/type/proxy/field.cc
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/field.cc
@@ -1,0 +1,60 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/util/utf8.h"
+
+#include "arrow/matlab/type/proxy/field.h"
+#include "arrow/matlab/error/error.h"
+
+namespace arrow::matlab::type::proxy {
+
+    Field::Field(std::shared_ptr<arrow::Field> field) : field{std::move(field)} {
+        REGISTER_METHOD(Field, name);
+        REGISTER_METHOD(Field, type);
+        REGISTER_METHOD(Field, toString);
+    }
+
+    std::shared_ptr<arrow::Field> Field::unwrap() {
+        return field;
+    }
+
+    void Field::name(libmexclass::proxy::method::Context& context) {
+        namespace mda = ::matlab::data;
+        mda::ArrayFactory factory;
+
+        const auto str_utf8 = field->name();
+        MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(const auto str_utf16, arrow::util::UTF8StringToUTF16(str_utf8), context, error::UNICODE_CONVERSION_ERROR_ID);
+        auto str_mda = factory.createScalar(str_utf16);
+        context.outputs[0] = str_mda;
+    }
+
+    void Field::type(libmexclass::proxy::method::Context& context) {
+
+    }
+
+    void Field::toString(libmexclass::proxy::method::Context& context) {
+        namespace mda = ::matlab::data;
+        mda::ArrayFactory factory;
+
+        const auto str_utf8 = field->ToString();
+        MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(const auto str_utf16, arrow::util::UTF8StringToUTF16(str_utf8), context, error::UNICODE_CONVERSION_ERROR_ID);
+        auto str_mda = factory.createScalar(str_utf16);
+        context.outputs[0] = str_mda;
+    }
+
+}
+

--- a/matlab/src/cpp/arrow/matlab/type/proxy/field.cc
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/field.cc
@@ -79,7 +79,7 @@ namespace arrow::matlab::type::proxy {
             case arrow_type::TIMESTAMP:
                 return std::make_shared<type_proxy::TimestampType>(std::static_pointer_cast<arrow::TimestampType>(datatype));
             default:
-                return arrow::Status::Invalid("Unsupported DataType: " + datatype->ToString());
+                return arrow::Status::NotImplemented("Unsupported DataType: " + datatype->ToString());
         }
     }
 

--- a/matlab/src/cpp/arrow/matlab/type/proxy/field.cc
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/field.cc
@@ -114,9 +114,9 @@ namespace arrow::matlab::type::proxy {
         const mda::StringArray name_mda = opts[0]["Name"];
         const mda::TypedArray<uint64_t> type_proxy_id_mda = opts[0]["TypeProxyID"];
 
-        const std::u16string& utf16_name = name_mda[0];
+        const std::u16string& name_utf16 = name_mda[0];
         MATLAB_ASSIGN_OR_ERROR(const auto name,
-                arrow::util::UTF16StringToUTF8(utf16_name),
+                arrow::util::UTF16StringToUTF8(name_utf16),
                 error::UNICODE_CONVERSION_ERROR_ID);
 
         auto proxy = std::static_pointer_cast<type::proxy::Type>(libmexclass::proxy::ProxyManager::getProxy(type_proxy_id_mda[0]));

--- a/matlab/src/cpp/arrow/matlab/type/proxy/field.h
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/field.h
@@ -26,7 +26,7 @@ namespace arrow::matlab::type::proxy {
 class Field : public libmexclass::proxy::Proxy {
     public:
         Field(std::shared_ptr<arrow::Field> field);
-    
+
         virtual ~Field() {}
 
         std::shared_ptr<arrow::Field> unwrap();

--- a/matlab/src/cpp/arrow/matlab/type/proxy/field.h
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/field.h
@@ -31,6 +31,8 @@ class Field : public libmexclass::proxy::Proxy {
 
         std::shared_ptr<arrow::Field> unwrap();
 
+        static libmexclass::proxy::MakeResult make(const libmexclass::proxy::FunctionArguments& constructor_arguments);
+
     protected:
         void name(libmexclass::proxy::method::Context& context);
         void type(libmexclass::proxy::method::Context& context);

--- a/matlab/src/cpp/arrow/matlab/type/proxy/field.h
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/field.h
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "arrow/type.h"
+
+#include "libmexclass/proxy/Proxy.h"
+
+namespace arrow::matlab::type::proxy {
+
+class Field : public libmexclass::proxy::Proxy {
+    public:
+        Field(std::shared_ptr<arrow::Field> field);
+    
+        virtual ~Field() {}
+
+        std::shared_ptr<arrow::Field> unwrap();
+
+    protected:
+        void name(libmexclass::proxy::method::Context& context);
+        void type(libmexclass::proxy::method::Context& context);
+        void toString(libmexclass::proxy::method::Context& context);
+
+        std::shared_ptr<arrow::Field> field;
+};
+
+}

--- a/matlab/src/matlab/+arrow/+type/Field.m
+++ b/matlab/src/matlab/+arrow/+type/Field.m
@@ -1,0 +1,67 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef Field < matlab.mixin.CustomDisplay
+%FIELD A class representing a name and a type.
+% Fields are often used in tabular schemas for describing a column's
+% name and type.
+
+    properties (GetAccess=public, SetAccess=private, Hidden)
+        Proxy
+    end
+
+    properties (Dependent)
+        % Name of the field
+        Name
+        % Arrow type of the field
+        Type
+    end
+
+    methods 
+        function obj = Field(proxy)
+            arguments
+                proxy(1, 1) libmexclass.proxy.Proxy {validate(proxy, "arrow.type.proxy.Field")}
+            end
+            import arrow.internal.proxy.validate
+
+            obj.Proxy = proxy;
+        end
+
+        function type = get.Type(obj)
+            [proxyID, typeID] = obj.Proxy.type();
+            traits = arrow.type.traits.traits(arrow.type.ID(typeID));
+            proxy = libmexclass.proxy.Proxy(Name=traits.TypeProxyClassName, ID=proxyID);
+            type = traits.TypeConstructor(proxy);
+        end
+
+        function name = get.Name(obj)
+            name = obj.Proxy.name();
+        end
+
+    end
+
+    methods (Access = private)
+        function str = toString(obj)
+            str = obj.Proxy.toString();
+        end
+    end
+
+    methods (Access=protected)
+        function displayScalarObject(obj)
+            disp(obj.toString());
+        end
+    end
+
+end

--- a/matlab/src/matlab/+arrow/+type/Field.m
+++ b/matlab/src/matlab/+arrow/+type/Field.m
@@ -29,7 +29,7 @@ classdef Field < matlab.mixin.CustomDisplay
         Type
     end
 
-    methods 
+    methods
         function obj = Field(proxy)
             arguments
                 proxy(1, 1) libmexclass.proxy.Proxy {validate(proxy, "arrow.type.proxy.Field")}

--- a/matlab/src/matlab/+arrow/field.m
+++ b/matlab/src/matlab/+arrow/field.m
@@ -1,0 +1,27 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+function f = field(name, type)
+%FIELD Creates an arrow.type.Field object
+    arguments
+        name(1, 1) string {mustBeNonmissing}
+        type(1, 1) arrow.type.Type
+    end
+
+    typeProxyID = type.Proxy.ID;
+    args = struct(Name=name, TypeProxyID=typeProxyID);
+    proxy = arrow.internal.proxy.create("arrow.type.proxy.Field", args);
+    f = arrow.type.Field(proxy);
+end

--- a/matlab/test/arrow/type/tField.m
+++ b/matlab/test/arrow/type/tField.m
@@ -55,7 +55,7 @@ classdef tField < matlab.unittest.TestCase
             smiley = "😀";
             tree =  "🌲";
             mango = "🥭";
-            
+
             type = arrow.type.uint64;
             field = arrow.field(smiley, type);
 

--- a/matlab/test/arrow/type/tField.m
+++ b/matlab/test/arrow/type/tField.m
@@ -1,0 +1,29 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef tField < matlab.unittest.TestCase
+% Test class for arrow.type.Field and arrow.field.
+
+    methods(Test)
+        function TestBasic(testCase)
+            name = "A";
+            type = arrow.type.uint64;
+            field = arrow.field(name, type);
+
+            testCase.verifyEqual(field.Name, name);
+            testCase.verifyEqual(field.Type.ID, type.ID);
+        end
+    end
+end

--- a/matlab/test/arrow/type/tField.m
+++ b/matlab/test/arrow/type/tField.m
@@ -25,5 +25,107 @@ classdef tField < matlab.unittest.TestCase
             testCase.verifyEqual(field.Name, name);
             testCase.verifyEqual(field.Type.ID, type.ID);
         end
+
+        function TestSupportedTypes(testCase)
+            name = "name";
+            supportedTypes = { ...
+                                 arrow.type.uint8, ...
+                                 arrow.type.uint16, ...
+                                 arrow.type.uint32, ...
+                                 arrow.type.uint64, ...
+                                 arrow.type.int8, ...
+                                 arrow.type.int16, ...
+                                 arrow.type.int32, ...
+                                 arrow.type.int64, ...
+                                 arrow.type.boolean, ...
+                                 arrow.type.float32, ...
+                                 arrow.type.float64, ...
+                                 arrow.type.string, ...
+                                 arrow.type.timestamp, ...
+                             };
+            for ii = 1:numel(supportedTypes)
+                supportedType = supportedTypes{ii};
+                field = arrow.field(name, supportedType);
+                testCase.verifyEqual(field.Name, name);
+                testCase.verifyEqual(field.Type.ID, supportedType.ID);
+            end
+        end
+
+        function TestNameUnicode(testCase)
+            smiley = "😀";
+            tree =  "🌲";
+            mango = "🥭";
+            
+            type = arrow.type.uint64;
+            field = arrow.field(smiley, type);
+
+            testCase.verifyEqual(field.Name, smiley);
+            testCase.verifyEqual(field.Type.ID, type.ID);
+
+            field = arrow.field(tree, type);
+
+            testCase.verifyEqual(field.Name, tree);
+            testCase.verifyEqual(field.Type.ID, type.ID);
+
+            field = arrow.field(mango, type);
+
+            testCase.verifyEqual(field.Name, mango);
+            testCase.verifyEqual(field.Type.ID, type.ID);
+        end
+
+        function TestErrorIfNameStringMissing(testCase)
+            name = string(missing);
+            type = arrow.type.uint64;
+            testCase.verifyError(@() arrow.field(name, type), "MATLAB:validators:mustBeNonmissing");
+        end
+
+        function TestNameEmptyString(testCase)
+            name = "";
+            type = arrow.type.uint64;
+            field = arrow.field(name, type);
+
+            testCase.verifyEqual(field.Name, name);
+            testCase.verifyEqual(field.Type.ID, type.ID);
+        end
+
+        function TestNameCharVector(testCase)
+            name = 'ABC';
+            type = arrow.type.uint64;
+            field = arrow.field(name, type);
+
+            testCase.verifyEqual(field.Name, string(name));
+            testCase.verifyEqual(field.Type.ID, type.ID);
+        end
+
+        function TestNameNumber(testCase)
+            name = 123;
+            type = arrow.type.uint64;
+            field = arrow.field(name, type);
+
+            testCase.verifyEqual(field.Name, string(123));
+            testCase.verifyEqual(field.Type.ID, type.ID);
+        end
+
+        function TestArrowTypeUnsupportedInput(testCase)
+            name = "A";
+            type = { 123 };
+            testCase.verifyError(@() arrow.field(name, type), "MATLAB:validation:UnableToConvert");
+        end
+
+        function TestNameUnsupportedInput(testCase)
+            name = table();
+            type = arrow.type.uint64;
+            testCase.verifyError(@() arrow.field(name, type), "MATLAB:validation:UnableToConvert");
+        end
+
+        function TestImmutableProperties(testCase)
+            name = "A";
+            type = arrow.type.uint64;
+            field = arrow.field(name, type);
+
+            testCase.verifyError(@() setfield(field, "Name", "NewValue"), "MATLAB:class:noSetMethod")
+            testCase.verifyError(@() setfield(field, "Type", arrow.type.boolean), "MATLAB:class:noSetMethod")
+        end
+
     end
 end

--- a/matlab/tools/cmake/BuildMatlabArrowInterface.cmake
+++ b/matlab/tools/cmake/BuildMatlabArrowInterface.cmake
@@ -51,7 +51,8 @@ set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_SOURCES "${CMAKE_SOURCE_DIR}/src/cpp/a
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy/type.cc"
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy/fixed_width_type.cc"
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy/string_type.cc"
-                                                  "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy/timestamp_type.cc")
+                                                  "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy/timestamp_type.cc"
+                                                  "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy/field.cc")
 
 set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_FACTORY_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/proxy")
 set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_FACTORY_SOURCES "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/proxy/factory.cc")


### PR DESCRIPTION
### Rationale for this change

Now that the MATLAB interface supports creating `Type` objects - like `arrow.type.Int64Type`, we can add support for `Field` objects (i.e. name + type).

This mirrors the `Field` type in other Arrow interfaces, [like PyArrow](https://arrow.apache.org/docs/python/generated/pyarrow.field.html).


### What changes are included in this PR?

Two new user-facing APIs have been added:

1. `arrow.field(name, type)` constructor function
2. `arrow.type.Field` class (returned by the `arrow.field` constructor function).

**Example**:

```matlab
>> field = arrow.field("Speed", arrow.type.uint64)   

field = 

Speed: uint64

>> field.Type

ans = 

  UInt64Type with properties:

    ID: UInt64

>> field.Name

ans = 

    "Speed"
```

### Are these changes tested?

Yes.

1. Added new `tField.m` MATLAB test class.

### Are there any user-facing changes?

Yes.

Two new user-facing APIs have been added:

1. `arrow.field(name, type)` constructor function
2. `arrow.type.Field` class (returned by the `arrow.field` constructor function)

### Future Directions

1. We intentionally placed `arrow.field` in the top-level `arrow` package, rather than under a nested `arrow.type` package (where the corresponding class `arrow.type.Field` is). This is to avoid naming conflicts between `arrow.type.field` and `arrow.type.Field` and also to make it easier to use the recommended public/user-facing APIs with less typing (i.e. without needing to type nested package names). While working on this change, we realized that it would make sense to move the "type constructor functions" (e.g. `arrow.type.boolean`, `arrow.type.uint64`, etc.) into the top-level `arrow` package, as well (i.e. `arrow.boolean`, `arrow.uint64`, etc.). In other words, moving forward, the recommended APIs for the MATLAB interface will be placed directly under the top-level `arrow` package. This should hopefully result in a simplified public interface, as well as make it easier to use multiple language bindings (e.g. MATLAB and PyArrow) together, with less context switching. 

### Notes

1. @sgilmore10 is working on a follow up PR (to address #36853) for simplifying the `switch` statement code in `makeTypeProxy`. Her solution will be more generic, so that we can re-use it elsewhere across the code base of the MATLAB interface.
2. Thank you @sgilmore10 for your help with this pull request!
* Closes: #36852