### PR TITLE
GH-36861: [CI] Temporary cache nasm from GitHub to fix VCPKG job

### DIFF
--- a/dev/tasks/vcpkg-tests/cpp-build-vcpkg.bat
+++ b/dev/tasks/vcpkg-tests/cpp-build-vcpkg.bat
@@ -27,7 +27,7 @@ call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Too
 @rem changes in vcpkg
 
 vcpkg install ^
-    --triplet x64-windows ^
+    --triplet x64-windows-static ^
     --x-manifest-root cpp  ^
     --feature-flags=versions ^
     --clean-after-build ^

--- a/dev/tasks/vcpkg-tests/cpp-build-vcpkg.bat
+++ b/dev/tasks/vcpkg-tests/cpp-build-vcpkg.bat
@@ -27,7 +27,7 @@ call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Too
 @rem changes in vcpkg
 
 vcpkg install ^
-    --x-install-root=C:\vcpkg\downloads
+    --downloads-root=C:\vcpkg\downloads ^
     --triplet x64-windows ^
     --x-manifest-root cpp  ^
     --feature-flags=versions ^

--- a/dev/tasks/vcpkg-tests/cpp-build-vcpkg.bat
+++ b/dev/tasks/vcpkg-tests/cpp-build-vcpkg.bat
@@ -27,7 +27,8 @@ call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Too
 @rem changes in vcpkg
 
 vcpkg install ^
-    --triplet x64-windows-static ^
+    --x-install-root=C:\vcpkg\downloads
+    --triplet x64-windows ^
     --x-manifest-root cpp  ^
     --feature-flags=versions ^
     --clean-after-build ^

--- a/dev/tasks/vcpkg-tests/github.windows.yml
+++ b/dev/tasks/vcpkg-tests/github.windows.yml
@@ -74,12 +74,13 @@ jobs:
             setapikey "$GITHUB_TOKEN" \
             -source "https://nuget.pkg.github.com/$GITHUB_REPOSITORY_OWNER/index.json"
       - name: Cache nasm
-        - run: echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
-        - run: New-Item -ItemType "directory" -Path "C:\vcpkg\downloads" -Force
-        - run: Invoke-WebRequest -URI "$env:BASE_URL/$env:FILE_NAME" -OutFile "C:\vcpkg\downloads\$env:FILE_NAME"
-          env:
-            BASE_URL: https://github.com/microsoft/vcpkg/files/12073957
-            FILE_NAME: nasm-2.16.01-win64.zip
+        run: |
+          echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
+          New-Item -ItemType "directory" -Path "C:\vcpkg\downloads" -Force
+          Invoke-WebRequest -URI "$env:BASE_URL/$env:FILE_NAME" -OutFile "C:\vcpkg\downloads\$env:FILE_NAME"
+        env:
+          BASE_URL: https://github.com/microsoft/vcpkg/files/12073957
+          FILE_NAME: nasm-2.16.01-win64.zip
       - name: Install Dependencies with vcpkg and Build Arrow C++
         shell: cmd
         run: |

--- a/dev/tasks/vcpkg-tests/github.windows.yml
+++ b/dev/tasks/vcpkg-tests/github.windows.yml
@@ -75,7 +75,7 @@ jobs:
             -source "https://nuget.pkg.github.com/$GITHUB_REPOSITORY_OWNER/index.json"
       - name: Cache nasm
         run: |
-          echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
+          # echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
           New-Item -ItemType "directory" -Path "C:\vcpkg\downloads" -Force
           Invoke-WebRequest -URI "$env:BASE_URL/$env:FILE_NAME" -OutFile "C:\vcpkg\downloads\$env:FILE_NAME"
         env:

--- a/dev/tasks/vcpkg-tests/github.windows.yml
+++ b/dev/tasks/vcpkg-tests/github.windows.yml
@@ -73,6 +73,13 @@ jobs:
           `vcpkg fetch nuget | tail -n 1` \
             setapikey "$GITHUB_TOKEN" \
             -source "https://nuget.pkg.github.com/$GITHUB_REPOSITORY_OWNER/index.json"
+      - name: Cache nasm
+        - run: echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
+        - run: New-Item -ItemType "directory" -Path "C:\vcpkg\downloads" -Force
+        - run: Invoke-WebRequest -URI "$env:BASE_URL/$env:FILE_NAME" -OutFile "C:\vcpkg\downloads\$env:FILE_NAME"
+          env:
+            BASE_URL: https://github.com/microsoft/vcpkg/files/12073957
+            FILE_NAME: nasm-2.16.01-win64.zip
       - name: Install Dependencies with vcpkg and Build Arrow C++
         shell: cmd
         run: |


### PR DESCRIPTION
### Rationale for this change
Try a workaround to fix our VCPKG nightly tests.

### What changes are included in this PR?

Download nasm from GitHub.

### Are these changes tested?

Archery tests.

### Are there any user-facing changes?

No
* Closes: #36861