### PR TITLE
GH-36863: [C#][Packaging] Do not shutdown PythonEngine on CDataInterfacePythonTests if .NET is > 5.0

### DIFF
--- a/csharp/test/Apache.Arrow.Tests/CDataInterfacePythonTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/CDataInterfacePythonTests.cs
@@ -60,7 +60,9 @@ namespace Apache.Arrow.Tests
 
             public void Dispose()
             {
+#if !NET5_0_OR_GREATER
                 PythonEngine.Shutdown();
+#endif
             }
         }
 


### PR DESCRIPTION
### Rationale for this change

Tests are failing on maintenance branch to generate Nuget packages. This has been tested on the maintenance branch and it solves the issue.

### What changes are included in this PR?

Only Shutdown if `#if !NET5_0_OR_GREATER`

### Are these changes tested?

Locally and via archery.

### Are there any user-facing changes?

No
* Closes: #36863