### PR TITLE
GH-36735: [MATLAB] Add `TimeUnit` and `TimeZone` to the `arrow.type.TimestampType` display

### DIFF
--- a/matlab/src/matlab/+arrow/+type/TimestampType.m
+++ b/matlab/src/matlab/+arrow/+type/TimestampType.m
@@ -39,4 +39,11 @@ classdef TimestampType < arrow.type.FixedWidthType
             tz = obj.Proxy.timeZone();
         end
     end
+
+    methods (Access=protected)
+        function propgrp = getPropertyGroups(~)
+          proplist = {'ID', 'TimeUnit', 'TimeZone'};
+          propgrp = matlab.mixin.util.PropertyGroup(proplist);
+        end
+    end
 end

--- a/matlab/src/matlab/+arrow/+type/TimestampType.m
+++ b/matlab/src/matlab/+arrow/+type/TimestampType.m
@@ -41,9 +41,9 @@ classdef TimestampType < arrow.type.FixedWidthType
     end
 
     methods (Access=protected)
-        function propgrp = getPropertyGroups(~)
-          proplist = {'ID', 'TimeUnit', 'TimeZone'};
-          propgrp = matlab.mixin.util.PropertyGroup(proplist);
+        function group = getPropertyGroups(~)
+          targets = ["ID" "TimeUnit" "TimeZone"];
+          group = matlab.mixin.util.PropertyGroup(targets);
         end
     end
 end

--- a/matlab/test/arrow/type/tTimestampType.m
+++ b/matlab/test/arrow/type/tTimestampType.m
@@ -87,7 +87,7 @@ classdef tTimestampType < hFixedWidthType
             fcn = @() arrow.timestamp(TimeZone=["a", "b"]);
             testCase.verifyError(fcn, "MATLAB:validation:IncompatibleSize");
 
-              fcn = @() arrow.timestamp(TimeZone=strings(0, 0));
+            fcn = @() arrow.timestamp(TimeZone=strings(0, 0));
             testCase.verifyError(fcn, "MATLAB:validation:IncompatibleSize");
         end
 
@@ -104,6 +104,29 @@ classdef tTimestampType < hFixedWidthType
             units = ["second" "millisecond"];
             fcn = @() arrow.timestamp(TimeZone=units);
             testCase.verifyError(fcn, "MATLAB:validation:IncompatibleSize");
+        end
+
+        function Display(testCase)
+        % Verify the display of TimestampType objects.
+        %
+        % Example:
+        %
+        %  TimestampType with properties:
+        %
+        %          ID: Timestamp
+        %    TimeUnit: Second
+        %    TimeZone: "America/Anchorage"
+        %
+            type = arrow.timestamp(TimeUnit="Second", TimeZone="America/Anchorage"); %#ok<NASGU>
+            classnameLink = '<a href="matlab:helpPopup arrow.type.TimestampType" style="font-weight:bold">TimestampType</a>';
+            header = "  " + classnameLink + " with properties:" + newline;
+            body = strjust(pad(["ID:"; "TimeUnit:"; "TimeZone:"]));
+            body = body + " " + ["Timestamp"; "Second"; """America/Anchorage"""];
+            body = "    " + body;
+            footer = string(newline);
+            expectedDisplay = char(strjoin([header body' footer], newline));
+            actualDisplay = evalc('disp(type)');
+            testCase.verifyEqual(actualDisplay, expectedDisplay);
         end
     end
 end

--- a/matlab/test/arrow/type/tTimestampType.m
+++ b/matlab/test/arrow/type/tTimestampType.m
@@ -118,7 +118,7 @@ classdef tTimestampType < hFixedWidthType
         %    TimeZone: "America/Anchorage"
         %
             type = arrow.timestamp(TimeUnit="Second", TimeZone="America/Anchorage"); %#ok<NASGU>
-            classnameLink = '<a href="matlab:helpPopup arrow.type.TimestampType" style="font-weight:bold">TimestampType</a>';
+            classnameLink = "<a href=""matlab:helpPopup arrow.type.TimestampType"" style=""font-weight:bold"">TimestampType</a>";
             header = "  " + classnameLink + " with properties:" + newline;
             body = strjust(pad(["ID:"; "TimeUnit:"; "TimeZone:"]));
             body = body + " " + ["Timestamp"; "Second"; """America/Anchorage"""];


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

The `arrow.type.TimestampType` display should include the `TimeUnit` and `TimeZone` properties. Right now we only display the `ID` property: 

```matlab
>> type = arrow.type.timestamp(TimeUnit="Second", TimeZone="America/Anchorage")

type = 

  TimestampType with properties:

    ID: Timestamp
```
We should show the other two properties in the display.

### What changes are included in this PR?

Modified the display of `TimestampType`:

```matlab
>> type = arrow.type.timestamp(TimeUnit="Second", TimeZone="America/Anchorage")

type = 

  TimestampType with properties:

          ID: Timestamp
    TimeUnit: Second
    TimeZone: "America/Anchorage"

```
Now `TimeUnit` and `TimeZone` are included.


### Are these changes tested?

Added a test case to `tTimestampType` called `Display`. It verifies `TimestampType` objects are displayed correctly in the Command Window.

### Are there any user-facing changes?

Yes, users will see the new display.

* Closes: #36735