### PR TITLE
GH-36863: [C#] Remove unnecessary applied fix to not shutdown PythonEngine on CDataInterfacePythonTests if .NET is > 5.0

### DIFF
--- a/csharp/test/Apache.Arrow.Tests/CDataInterfacePythonTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/CDataInterfacePythonTests.cs
@@ -60,9 +60,7 @@ namespace Apache.Arrow.Tests
 
             public void Dispose()
             {
-#if !NET5_0_OR_GREATER
                 PythonEngine.Shutdown();
-#endif
             }
         }
 


### PR DESCRIPTION
### Rationale for this change

Maintenance branch fix is not necessary.

### What changes are included in this PR?

Remove unnecessary patch

### Are these changes tested?

Yes, on CI

### Are there any user-facing changes?

No
* Closes: #36863