### PR TITLE
GH-36853: [MATLAB] Add utility to create proxies from existing `arrow::DataType` objects

### DIFF
--- a/matlab/src/cpp/arrow/matlab/array/proxy/array.cc
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/array.cc
@@ -83,7 +83,7 @@ namespace arrow::matlab::array::proxy {
         MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(auto type_proxy,
                                             type::proxy::wrap(array->type()),
                                             context,
-                                            "arrow:type:UnknownTypeProxy");
+                                            error::ARRAY_FAILED_TO_CREATE_TYPE_PROXY);
 
         auto type_id = type_proxy->unwrap()->id();
         auto proxy_id = libmexclass::proxy::ProxyManager::manageProxy(type_proxy);

--- a/matlab/src/cpp/arrow/matlab/array/proxy/array.cc
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/array.cc
@@ -20,8 +20,8 @@
 #include "arrow/matlab/array/proxy/array.h"
 #include "arrow/matlab/bit/unpack.h"
 #include "arrow/matlab/error/error.h"
+#include "arrow/matlab/type/proxy/wrap.h"
 #include "arrow/type_traits.h"
-#include "arrow/visit_array_inline.h"
 
 #include "libmexclass/proxy/ProxyManager.h"
 
@@ -80,12 +80,15 @@ namespace arrow::matlab::array::proxy {
 
         mda::ArrayFactory factory;
 
-        auto type_proxy = typeProxy();
+        MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(auto type_proxy,
+                                            type::proxy::wrap(array->type()),
+                                            context,
+                                            "arrow:type:UnknownTypeProxy");
+
         auto type_id = type_proxy->unwrap()->id();
         auto proxy_id = libmexclass::proxy::ProxyManager::manageProxy(type_proxy);
 
         context.outputs[0] = factory.createScalar(proxy_id);
         context.outputs[1] = factory.createScalar(static_cast<int64_t>(type_id));
-
     }
 }

--- a/matlab/src/cpp/arrow/matlab/array/proxy/array.h
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/array.h
@@ -44,8 +44,6 @@ class Array : public libmexclass::proxy::Proxy {
 
         virtual void toMATLAB(libmexclass::proxy::method::Context& context) = 0;
 
-        virtual std::shared_ptr<type::proxy::Type> typeProxy() = 0;
-
         std::shared_ptr<arrow::Array> array;
 };
 

--- a/matlab/src/cpp/arrow/matlab/array/proxy/boolean_array.cc
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/boolean_array.cc
@@ -54,11 +54,4 @@ namespace arrow::matlab::array::proxy {
             auto logical_array_mda = bit::unpack(packed_logical_data_buffer, array_length);
             context.outputs[0] = logical_array_mda;
         }
-
-        std::shared_ptr<type::proxy::Type> BooleanArray::typeProxy() {
-            using BooleanTypeProxy = type::proxy::PrimitiveCType<bool>;
-
-            auto type = std::static_pointer_cast<arrow::BooleanType>(array->type());
-            return std::make_shared<BooleanTypeProxy>(std::move(type));
-        }
 }

--- a/matlab/src/cpp/arrow/matlab/array/proxy/boolean_array.h
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/boolean_array.h
@@ -32,9 +32,6 @@ namespace arrow::matlab::array::proxy {
 
         protected:
             void toMATLAB(libmexclass::proxy::method::Context& context) override;
-
-            std::shared_ptr<type::proxy::Type> typeProxy() override;
-
     };
 
 }

--- a/matlab/src/cpp/arrow/matlab/array/proxy/numeric_array.h
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/numeric_array.h
@@ -85,12 +85,6 @@ class NumericArray : public arrow::matlab::array::proxy::Array {
             ::matlab::data::TypedArray<CType> result = factory.createArray({num_elements, 1}, data_begin, data_end);
             context.outputs[0] = result;
         }
-
-        std::shared_ptr<type::proxy::Type> typeProxy() override {
-          using TypeProxy = typename type::proxy::Traits<ArrowType>::TypeProxy;
-          auto type = std::static_pointer_cast<ArrowType>(array->type());
-          return std::make_shared<TypeProxy>(std::move(type));
-        }
 };
 
      // Specialization of NumericArray::Make for arrow::TimestampType.

--- a/matlab/src/cpp/arrow/matlab/array/proxy/string_array.cc
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/string_array.cc
@@ -81,12 +81,4 @@ namespace arrow::matlab::array::proxy {
             auto array_mda = factory.createArray({array_length, 1}, strings.begin(), strings.end());
             context.outputs[0] = array_mda;
         }
-
-        std::shared_ptr<type::proxy::Type> StringArray::typeProxy() {
-            using StringTypeProxy = type::proxy::StringType;
-
-            auto type = std::static_pointer_cast<arrow::StringType>(array->type());
-            return std::make_shared<StringTypeProxy>(std::move(type));
-        }
-
 }

--- a/matlab/src/cpp/arrow/matlab/array/proxy/string_array.h
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/string_array.h
@@ -33,9 +33,6 @@ namespace arrow::matlab::array::proxy {
 
         protected:
             void toMATLAB(libmexclass::proxy::method::Context& context) override;
-
-            std::shared_ptr<type::proxy::Type> typeProxy() override;
-
     };
 
 }

--- a/matlab/src/cpp/arrow/matlab/error/error.h
+++ b/matlab/src/cpp/arrow/matlab/error/error.h
@@ -172,4 +172,6 @@ namespace arrow::matlab::error {
     static const char* STRING_BUILDER_FINISH_FAILED = "arrow:matlab:array:string:StringBuilderFinishFailed";
     static const char* UKNOWN_TIME_UNIT_ERROR_ID = "arrow:matlab:UnknownTimeUnit";
     static const char* FIELD_FAILED_TO_CREATE_TYPE_PROXY = "arrow:field:FailedToCreateTypeProxy";
+    static const char* ARRAY_FAILED_TO_CREATE_TYPE_PROXY = "arrow:array:FailedToCreateTypeProxy";
+
 }

--- a/matlab/src/cpp/arrow/matlab/error/error.h
+++ b/matlab/src/cpp/arrow/matlab/error/error.h
@@ -173,5 +173,4 @@ namespace arrow::matlab::error {
     static const char* UKNOWN_TIME_UNIT_ERROR_ID = "arrow:matlab:UnknownTimeUnit";
     static const char* FIELD_FAILED_TO_CREATE_TYPE_PROXY = "arrow:field:FailedToCreateTypeProxy";
     static const char* ARRAY_FAILED_TO_CREATE_TYPE_PROXY = "arrow:array:FailedToCreateTypeProxy";
-
 }

--- a/matlab/src/cpp/arrow/matlab/type/proxy/field.cc
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/field.cc
@@ -23,6 +23,7 @@
 #include "arrow/matlab/type/proxy/primitive_ctype.h"
 #include "arrow/matlab/type/proxy/timestamp_type.h"
 #include "arrow/matlab/type/proxy/string_type.h"
+#include "arrow/matlab/type/proxy/wrap.h"
 
 #include "libmexclass/proxy/ProxyManager.h"
 
@@ -48,47 +49,11 @@ namespace arrow::matlab::type::proxy {
         context.outputs[0] = str_mda;
     }
 
-    arrow::Result<std::shared_ptr<libmexclass::proxy::Proxy>> makeTypeProxy(const std::shared_ptr<arrow::DataType>& datatype) {
-        using arrow_type = arrow::Type::type;
-        namespace type_proxy = arrow::matlab::type::proxy;
-        switch (datatype->id()) {
-            case arrow_type::UINT8:
-                return std::make_shared<type_proxy::PrimitiveCType<uint8_t>>(std::static_pointer_cast<arrow::UInt8Type>(datatype));
-            case arrow_type::UINT16:
-                return std::make_shared<type_proxy::PrimitiveCType<uint16_t>>(std::static_pointer_cast<arrow::UInt16Type>(datatype));
-            case arrow_type::UINT32:
-                return std::make_shared<type_proxy::PrimitiveCType<uint32_t>>(std::static_pointer_cast<arrow::UInt32Type>(datatype));
-            case arrow_type::UINT64:
-                return std::make_shared<type_proxy::PrimitiveCType<uint64_t>>(std::static_pointer_cast<arrow::UInt64Type>(datatype));
-            case arrow_type::INT8:
-                return std::make_shared<type_proxy::PrimitiveCType<int8_t>>(std::static_pointer_cast<arrow::Int8Type>(datatype));
-            case arrow_type::INT16:
-                return std::make_shared<type_proxy::PrimitiveCType<int16_t>>(std::static_pointer_cast<arrow::Int16Type>(datatype));
-            case arrow_type::INT32:
-                return std::make_shared<type_proxy::PrimitiveCType<int32_t>>(std::static_pointer_cast<arrow::Int32Type>(datatype));
-            case arrow_type::INT64:
-                return std::make_shared<type_proxy::PrimitiveCType<int64_t>>(std::static_pointer_cast<arrow::Int64Type>(datatype));
-            case arrow_type::FLOAT:
-                return std::make_shared<type_proxy::PrimitiveCType<float>>(std::static_pointer_cast<arrow::FloatType>(datatype));
-            case arrow_type::DOUBLE:
-                return std::make_shared<type_proxy::PrimitiveCType<double>>(std::static_pointer_cast<arrow::DoubleType>(datatype));
-            case arrow_type::BOOL:
-                return std::make_shared<type_proxy::PrimitiveCType<bool>>(std::static_pointer_cast<arrow::BooleanType>(datatype));
-            case arrow_type::STRING:
-                return std::make_shared<type_proxy::StringType>(std::static_pointer_cast<arrow::StringType>(datatype));
-            case arrow_type::TIMESTAMP:
-                return std::make_shared<type_proxy::TimestampType>(std::static_pointer_cast<arrow::TimestampType>(datatype));
-            default:
-                return arrow::Status::NotImplemented("Unsupported DataType: " + datatype->ToString());
-        }
-    }
-
-
     void Field::type(libmexclass::proxy::method::Context& context) {
         namespace mda = ::matlab::data;
 
-        auto datatype = field->type();
-        MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(auto proxy, makeTypeProxy(datatype), context, "arrow:field:FailedToCreateTypeProxy");
+        const auto& datatype = field->type();
+        MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(auto proxy, type::proxy::wrap(datatype), context, error::FIELD_FAILED_TO_CREATE_TYPE_PROXY); 
         const auto proxy_id = libmexclass::proxy::ProxyManager::manageProxy(proxy);
 
         mda::ArrayFactory factory;

--- a/matlab/src/cpp/arrow/matlab/type/proxy/wrap.cc
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/wrap.cc
@@ -1,0 +1,59 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/matlab/type/proxy/wrap.h"
+
+#include "arrow/matlab/type/proxy/primitive_ctype.h"
+#include "arrow/matlab/type/proxy/timestamp_type.h"
+#include "arrow/matlab/type/proxy/string_type.h"
+
+namespace arrow::matlab::type::proxy {
+
+    arrow::Result<std::shared_ptr<type::proxy::Type>> wrap(const std::shared_ptr<arrow::DataType>& type) {
+        using ID = arrow::Type::type;
+        switch (type->id()) {
+            case ID::BOOL:
+                return std::make_shared<PrimitiveCType<bool>>(std::static_pointer_cast<arrow::BooleanType>(type));
+            case ID::UINT8:
+                return std::make_shared<PrimitiveCType<uint8_t>>(std::static_pointer_cast<arrow::UInt8Type>(type));
+            case ID::UINT16:
+                return std::make_shared<PrimitiveCType<uint16_t>>(std::static_pointer_cast<arrow::UInt16Type>(type));
+            case ID::UINT32:
+                return std::make_shared<PrimitiveCType<uint32_t>>(std::static_pointer_cast<arrow::UInt32Type>(type));
+            case ID::UINT64:
+                return std::make_shared<PrimitiveCType<uint64_t>>(std::static_pointer_cast<arrow::UInt64Type>(type));
+            case ID::INT8:
+                return std::make_shared<PrimitiveCType<int8_t>>(std::static_pointer_cast<arrow::Int8Type>(type));
+            case ID::INT16:
+                return std::make_shared<PrimitiveCType<int16_t>>(std::static_pointer_cast<arrow::Int16Type>(type));
+            case ID::INT32:
+                return std::make_shared<PrimitiveCType<int32_t>>(std::static_pointer_cast<arrow::Int32Type>(type));
+            case ID::INT64:
+                return std::make_shared<PrimitiveCType<int64_t>>(std::static_pointer_cast<arrow::Int64Type>(type));
+            case ID::FLOAT:
+                return std::make_shared<PrimitiveCType<float>>(std::static_pointer_cast<arrow::FloatType>(type));
+            case ID::DOUBLE:
+                return std::make_shared<PrimitiveCType<double>>(std::static_pointer_cast<arrow::DoubleType>(type));
+            case ID::TIMESTAMP:
+                return std::make_shared<TimestampType>(std::static_pointer_cast<arrow::TimestampType>(type));
+            case ID::STRING:
+                return std::make_shared<StringType>(std::static_pointer_cast<arrow::StringType>(type));
+            default:
+                return arrow::Status::Invalid("Unknown Type: " + );
+        }
+    }
+}

--- a/matlab/src/cpp/arrow/matlab/type/proxy/wrap.cc
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/wrap.cc
@@ -53,7 +53,7 @@ namespace arrow::matlab::type::proxy {
             case ID::STRING:
                 return std::make_shared<StringType>(std::static_pointer_cast<arrow::StringType>(type));
             default:
-                return arrow::Status::Invalid("Unknown Type: " + );
+                return arrow::Status::NotImplemented("Unknown Type: " + type->ToString());
         }
     }
 }

--- a/matlab/src/cpp/arrow/matlab/type/proxy/wrap.cc
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/wrap.cc
@@ -53,7 +53,7 @@ namespace arrow::matlab::type::proxy {
             case ID::STRING:
                 return std::make_shared<StringType>(std::static_pointer_cast<arrow::StringType>(type));
             default:
-                return arrow::Status::NotImplemented("Unknown Type: " + type->ToString());
+                return arrow::Status::NotImplemented("Unsupported DataType: " + type->ToString());
         }
     }
 }

--- a/matlab/src/cpp/arrow/matlab/type/proxy/wrap.h
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/wrap.h
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/type.h"
+#include "arrow/result.h"
+
+#include "arrow/matlab/type/proxy/type.h"
+
+namespace arrow::matlab::type::proxy {
+
+arrow::Result<std::shared_ptr<Type>> wrap(const std::shared_ptr<arrow::DataType>& type);
+
+
+}

--- a/matlab/tools/cmake/BuildMatlabArrowInterface.cmake
+++ b/matlab/tools/cmake/BuildMatlabArrowInterface.cmake
@@ -52,7 +52,9 @@ set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_SOURCES "${CMAKE_SOURCE_DIR}/src/cpp/a
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy/fixed_width_type.cc"
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy/string_type.cc"
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy/timestamp_type.cc"
-                                                  "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy/field.cc")
+                                                  "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy/field.cc"
+                                                  "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy/wrap.cc")
+
 
 set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_FACTORY_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/proxy")
 set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_FACTORY_SOURCES "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/proxy/factory.cc")


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

There will be many places in the MATLAB interface code base in which we will have to wrap an `arrow::DataType` object within a subclass of `arrow::matlab::type::proxy::Type`. To avoid code duplicaiton, we should add a  utility function called `wrap` that accepts a pointer to an `arrow::DataType` object and returns a pointer to a  `arrow::matlab::type::proxy::Type` object. 

### What changes are included in this PR?

1. Added a new function with the following signature:

```cpp
arrow::Result<std::shared_ptr<arrow::matlab::type::proxy::Type>> wrap(const std::shared_ptr<arrow::DataType>& datatype);
```

2.  Updated the `type` methods of `arrow::matlab::type::proxy::Field` and `arrow::matlab::array::proxy::Array` to use `wrap`.


### Are these changes tested?

No new tests needed.


### Are there any user-facing changes?

No

* Closes: #36853