### PR TITLE
MINOR: Fix build double declaration

### DIFF
--- a/go/arrow/array/concat_test.go
+++ b/go/arrow/array/concat_test.go
@@ -744,26 +744,6 @@ func TestConcatOverflowRunEndEncoding(t *testing.T) {
 	}
 }
 
-type panicAllocator struct {
-	n int
-	memory.Allocator
-}
-
-func (p *panicAllocator) Allocate(size int) []byte {
-	if size > p.n {
-		panic("panic allocator")
-	}
-	return p.Allocator.Allocate(size)
-}
-
-func (p *panicAllocator) Reallocate(size int, b []byte) []byte {
-	return p.Allocator.Reallocate(size, b)
-}
-
-func (p *panicAllocator) Free(b []byte) {
-	p.Allocator.Free(b)
-}
-
 func TestConcatPanic(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
#36811 and #36854 both introduced a helper in their tests, but the result after merge was a collision causing it to be declared twice which made the Go build fail. By removing one of the duplicate declarations the build is fixed.
