### PR TITLE
GH-36323: [Python] Fix Timestamp scalar repr error on values outside datetime range

### DIFF
--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -113,8 +113,12 @@ cdef class Scalar(_Weakrefable):
         else:
             with nogil:
                 check_status(self.wrapped.get().Validate())
-
+ 
     def __repr__(self):
+        if isinstance(self, TimestampScalar):
+            return '<pyarrow.{}: {!r}>'.format(
+                self.__class__.__name__, str(_pc().strftime(self))
+            )
         return '<pyarrow.{}: {!r}>'.format(
             self.__class__.__name__, self.as_py()
         )

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -1353,7 +1353,7 @@ def test_sequence_timestamp_from_int_with_unit():
     assert len(arr_s) == 1
     assert arr_s.type == s
     assert repr(arr_s[0]) == (
-        "<pyarrow.TimestampScalar: datetime.datetime(1970, 1, 1, 0, 0, 1)>"
+        "<pyarrow.TimestampScalar: '1970-01-01T00:00:01'>"
     )
     assert str(arr_s[0]) == "1970-01-01 00:00:01"
 

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -68,7 +68,6 @@ from pyarrow.tests import util
     ({'a': 1, 'b': [1, 2]}, None, pa.StructScalar),
     ([('a', 1), ('b', 2)], pa.map_(pa.string(), pa.int8()), pa.MapScalar),
 ])
-
 def test_basics(value, ty, klass):
     s = pa.scalar(value, type=ty)
     s.validate()
@@ -154,9 +153,18 @@ def test_hashing_struct_scalar():
     hash2 = hash(b[0])
     assert hash1 == hash2
 
+
 def test_timestamp_scalar():
-    s = repr(pa.scalar("0000-01-01").cast(pa.timestamp("s")))
-    assert s == "<pyarrow.TimestampScalar: '0000-01-01T00:00:00'>"
+    a = repr(pa.scalar("0000-01-01").cast(pa.timestamp("s")))
+    assert a == "<pyarrow.TimestampScalar: '0000-01-01T00:00:00'>"
+    b = repr(pa.scalar(datetime.datetime(2015, 1, 1), type=pa.timestamp('s', tz='UTC')))
+    assert b == "<pyarrow.TimestampScalar: '2015-01-01T00:00:00+0000'>"
+    c = repr(pa.scalar(datetime.datetime(2015, 1, 1), type=pa.timestamp('us')))
+    assert c == "<pyarrow.TimestampScalar: '2015-01-01T00:00:00.000000'>"
+    d = repr(pc.assume_timezone(
+        pa.scalar("2000-01-01").cast(pa.timestamp("s")), "America/New_York"))
+    assert d == "<pyarrow.TimestampScalar: '2000-01-01T00:00:00-0500'>"
+
 
 def test_bool():
     false = pa.scalar(False)

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -68,6 +68,7 @@ from pyarrow.tests import util
     ({'a': 1, 'b': [1, 2]}, None, pa.StructScalar),
     ([('a', 1), ('b', 2)], pa.map_(pa.string(), pa.int8()), pa.MapScalar),
 ])
+
 def test_basics(value, ty, klass):
     s = pa.scalar(value, type=ty)
     s.validate()
@@ -153,6 +154,9 @@ def test_hashing_struct_scalar():
     hash2 = hash(b[0])
     assert hash1 == hash2
 
+def test_timestamp_scalar():
+    s = repr(pa.scalar("0000-01-01").cast(pa.timestamp("s")))
+    assert s == "<pyarrow.TimestampScalar: '0000-01-01T00:00:00'>"
 
 def test_bool():
     false = pa.scalar(False)

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -3605,9 +3605,9 @@ def timestamp(unit, tz=None):
 
     >>> from datetime import datetime
     >>> pa.scalar(datetime(2012, 1, 1), type=pa.timestamp('s', tz='UTC'))
-    <pyarrow.TimestampScalar: datetime.datetime(2012, 1, 1, 0, 0, tzinfo=<UTC>)>
+    <pyarrow.TimestampScalar: '2012-01-01T00:00:00+0000'>
     >>> pa.scalar(datetime(2012, 1, 1), type=pa.timestamp('us'))
-    <pyarrow.TimestampScalar: datetime.datetime(2012, 1, 1, 0, 0)>
+    <pyarrow.TimestampScalar: '2012-01-01T00:00:00.000000'>
 
     Returns
     -------


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
https://github.com/apache/arrow/issues/36323

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Changed the way repr is handled for TimestampScalar

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

I have added a very basic test for this change to see whether it will error or not if outside the range.

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

The functionality of TimestampScalar's repr now uses the `strftime` function.

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #36323