### PR TITLE
GH-36883: [R] Remove version number which triggers CRAN warning

### DIFF
--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -30,7 +30,7 @@ if (test_mode && is.na(VERSION)) {
 dev_version <- package_version(VERSION)[1, 4]
 
 # Small dev versions are added for R-only changes during CRAN submission.
-if (is.na(dev_version) || dev_version < 100) {
+if (is.na(dev_version) || dev_version < "100") {
   VERSION <- package_version(VERSION)[1, 1:3]
   arrow_repo <- paste0(getOption("arrow.repo", sprintf("https://apache.jfrog.io/artifactory/arrow/r/%s", VERSION)), "/libarrow/")
 } else {

--- a/r/tools/winlibs.R
+++ b/r/tools/winlibs.R
@@ -53,7 +53,7 @@ if (!file.exists(sprintf("windows/arrow-%s/include/arrow/api.h", VERSION))) {
     dev_version <- package_version(VERSION)[1, 4]
 
     # Small dev versions are added for R-only changes during CRAN submission.
-    if (is.na(dev_version) || dev_version < 100) {
+    if (is.na(dev_version) || dev_version < "100") {
       VERSION <- package_version(VERSION)[1, 1:3]
       get_file(rwinlib, VERSION)
 


### PR DESCRIPTION
### What changes are included in this PR?

Updates package version number to be character not numeric

### Are these changes tested?

No, is configure scripts

### Are there any user-facing changes?

No
* Closes: #36883