### PR TITLE
GH-36885: [Java][Docs] Add substrait dependency to maven build profiles

### DIFF
--- a/docs/source/developers/java/building.rst
+++ b/docs/source/developers/java/building.rst
@@ -219,6 +219,7 @@ CMake
           -DARROW_ORC=ON \
           -DARROW_PARQUET=ON \
           -DARROW_S3=ON \
+          -DARROW_SUBSTRAIT=ON \
           -DARROW_USE_CCACHE=ON \
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_INSTALL_LIBDIR=lib/<your system's architecture> \
@@ -258,6 +259,7 @@ CMake
           -DARROW_ORC=OFF ^
           -DARROW_PARQUET=ON ^
           -DARROW_S3=ON ^
+          -DARROW_SUBSTRAIT=ON ^
           -DARROW_USE_CCACHE=ON ^
           -DARROW_WITH_BROTLI=ON ^
           -DARROW_WITH_LZ4=ON ^

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -1022,6 +1022,7 @@
                     -DARROW_ORC=${ARROW_ORC}
                     -DARROW_PARQUET=${ARROW_PARQUET}
                     -DARROW_S3=ON
+                    -DARROW_SUBSTRAIT=${ARROW_DATASET}
                     -DARROW_USE_CCACHE=ON
                     -DCMAKE_BUILD_TYPE=Release
                     -DCMAKE_INSTALL_LIBDIR=lib/${os.detected.arch}
@@ -1131,6 +1132,7 @@
                     -DARROW_ORC=${ARROW_ORC}
                     -DARROW_PARQUET=${ARROW_PARQUET}
                     -DARROW_S3=ON
+                    -DARROW_SUBSTRAIT=${ARROW_DATASET}
                     -DARROW_USE_CCACHE=ON
                     -DARROW_WITH_BROTLI=ON
                     -DARROW_WITH_LZ4=ON


### PR DESCRIPTION
### Rationale for this change

The Java JNI dataset module recently included the Substrait module as a dependency. The dependency was added to the CI scripts, but not added to the build profiles and documentation yet.

### What changes are included in this PR?

- Update maven build profiles
- Update Java build documentation

### Are these changes tested?

I tested locally on MacOS and was able to reproduce + fix with this change.

### Are there any user-facing changes?

No
* Closes: #36885