### PR TITLE
GH-36860: [C++] Report CMake error when system Protobuf exists but system gRPC doesn't exist

### DIFF
--- a/cpp/cmake_modules/FindgRPCAlt.cmake
+++ b/cpp/cmake_modules/FindgRPCAlt.cmake
@@ -57,13 +57,15 @@ if(GRPCPP_PC_FOUND)
                HINTS ${GRPCPP_PC_PREFIX}
                NO_DEFAULT_PATH
                PATH_SUFFIXES "bin")
-  set(gRPCAlt_FIND_PACKAGE_ARGS gRPCAlt REQUIRED_VARS GRPCPP_IMPORTED_LOCATION
-                                GRPC_CPP_PLUGIN)
-  if(gRPCAlt_VERSION)
-    list(APPEND gRPCAlt_FIND_PACKAGE_ARGS VERSION_VAR gRPCAlt_VERSION)
-  endif()
-  find_package_handle_standard_args(${gRPCAlt_FIND_PACKAGE_ARGS})
+endif()
+set(gRPCAlt_FIND_PACKAGE_ARGS gRPCAlt REQUIRED_VARS GRPCPP_IMPORTED_LOCATION
+                              GRPC_CPP_PLUGIN)
+if(gRPCAlt_VERSION)
+  list(APPEND gRPCAlt_FIND_PACKAGE_ARGS VERSION_VAR gRPCAlt_VERSION)
+endif()
+find_package_handle_standard_args(${gRPCAlt_FIND_PACKAGE_ARGS})
 
+if(gRPCAlt_FOUND)
   # gRPC does not expose the reflection library via pkg-config, but it should be alongside the main library
   get_filename_component(GRPCPP_IMPORTED_DIRECTORY ${GRPCPP_IMPORTED_LOCATION} DIRECTORY)
   if(ARROW_GRPC_USE_SHARED)
@@ -77,11 +79,7 @@ if(GRPCPP_PC_FOUND)
                NAMES grpc++_reflection ${GRPCPP_REFLECTION_LIB_NAME}
                PATHS ${GRPCPP_IMPORTED_DIRECTORY}
                NO_DEFAULT_PATH)
-else()
-  set(gRPCAlt_FOUND FALSE)
-endif()
 
-if(gRPCAlt_FOUND)
   add_library(gRPC::grpc++ UNKNOWN IMPORTED)
   set_target_properties(gRPC::grpc++
                         PROPERTIES IMPORTED_LOCATION "${GRPCPP_IMPORTED_LOCATION}"


### PR DESCRIPTION
### Rationale for this change

We require system gRPC when system Protobuf is found to avoid underlying library (Abseil) mismatch. We should report it as an error on `cmake...` time instead of build time.

### What changes are included in this PR?

Always call `find_package_handle_standard_args()` to report an error for the case. 

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #36860