### PR TITLE
GH-36913: [C++] Skip empty buffer concatenation to fix UBSan error

### DIFF
--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -213,8 +213,11 @@ Result<std::shared_ptr<Buffer>> ConcatenateBuffers(
   ARROW_ASSIGN_OR_RAISE(auto out, AllocateBuffer(out_length, pool));
   auto out_data = out->mutable_data();
   for (const auto& buffer : buffers) {
-    std::memcpy(out_data, buffer->data(), buffer->size());
-    out_data += buffer->size();
+    // Passing nullptr to std::memcpy is undefined behavior, so skip empty buffers
+    if (buffer->size() != 0) {
+      std::memcpy(out_data, buffer->data(), buffer->size());
+      out_data += buffer->size();
+    }
   }
   return std::move(out);
 }

--- a/cpp/src/arrow/buffer_test.cc
+++ b/cpp/src/arrow/buffer_test.cc
@@ -1014,4 +1014,12 @@ TYPED_TEST(TypedTestBuffer, ResizeOOM) {
 #endif
 }
 
+TEST(TestBufferConcatenation, EmptyBuffer) {
+  const std::string contents = "hello, world";
+  auto buffer = std::make_shared<Buffer>(contents);
+  auto empty_buffer = std::make_shared<Buffer>(/*data=*/nullptr, /*size=*/0);
+  ASSERT_OK_AND_ASSIGN(auto result, ConcatenateBuffers({buffer, empty_buffer}));
+  AssertMyBufferEqual(*result, contents);
+}
+
 }  // namespace arrow

--- a/cpp/src/arrow/buffer_test.cc
+++ b/cpp/src/arrow/buffer_test.cc
@@ -1015,6 +1015,7 @@ TYPED_TEST(TypedTestBuffer, ResizeOOM) {
 }
 
 TEST(TestBufferConcatenation, EmptyBuffer) {
+  // GH-36913: UB shouldn't be triggered by copying from a null pointer
   const std::string contents = "hello, world";
   auto buffer = std::make_shared<Buffer>(contents);
   auto empty_buffer = std::make_shared<Buffer>(/*data=*/nullptr, /*size=*/0);


### PR DESCRIPTION
### Rationale for this change

This is a trivial fix for a UBSan error in calls to `ConcatenateBuffers` with an empty buffer that has a null data pointer.

### What changes are included in this PR?

Conditional call to `std::memcpy` based on whether the buffer's length is 0.

### Are these changes tested?

Test added in buffer_test.cc.

### Are there any user-facing changes?

No
* Closes: #36913