### PR TITLE
GH-36867: [C++] Add a struct_ and schema overload taking a vector of (name, type) pairs

### DIFF
--- a/cpp/src/arrow/engine/substrait/type_internal.cc
+++ b/cpp/src/arrow/engine/substrait/type_internal.cc
@@ -78,12 +78,9 @@ Result<FieldVector> FieldsFromProto(int size, const Types& types,
       const auto& struct_ = types.Get(i).struct_();
 
       ARROW_ASSIGN_OR_RAISE(
-          type,
-          FieldsFromProto(struct_.types_size(), struct_.types(), next_name, ext_set,
-                          conversion_options)
-              .Map(
-                  static_cast<std::shared_ptr<::arrow::DataType> (*)(const FieldVector&)>(
-                      &::arrow::struct_)));
+          auto fields, FieldsFromProto(struct_.types_size(), struct_.types(), next_name,
+                                       ext_set, conversion_options));
+      type = ::arrow::struct_(std::move(fields));
 
       nullable = IsNullable(struct_);
     } else {

--- a/cpp/src/arrow/engine/substrait/type_internal.cc
+++ b/cpp/src/arrow/engine/substrait/type_internal.cc
@@ -77,9 +77,13 @@ Result<FieldVector> FieldsFromProto(int size, const Types& types,
     if (types.Get(i).has_struct_()) {
       const auto& struct_ = types.Get(i).struct_();
 
-      ARROW_ASSIGN_OR_RAISE(type, FieldsFromProto(struct_.types_size(), struct_.types(),
-                                                  next_name, ext_set, conversion_options)
-                                      .Map(arrow::struct_));
+      ARROW_ASSIGN_OR_RAISE(
+          type,
+          FieldsFromProto(struct_.types_size(), struct_.types(), next_name, ext_set,
+                          conversion_options)
+              .Map(
+                  static_cast<std::shared_ptr<::arrow::DataType> (*)(const FieldVector&)>(
+                      &::arrow::struct_)));
 
       nullable = IsNullable(struct_);
     } else {

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -2121,12 +2121,11 @@ Status SchemaBuilder::AreCompatible(const std::vector<std::shared_ptr<Schema>>& 
 }
 
 std::vector<std::shared_ptr<Field>> make_fields(
-    const std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>>&
-        init_list) {
+    std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>> init_list) {
   std::vector<std::shared_ptr<Field>> fields;
   fields.reserve(init_list.size());
-  for (const auto& pair : init_list) {
-    fields.push_back(std::make_shared<Field>(pair.first, pair.second));
+  for (const auto& [name, type] : init_list) {
+    fields.push_back(field(name, type));
   }
   return fields;
 }
@@ -2137,8 +2136,7 @@ std::shared_ptr<Schema> schema(std::vector<std::shared_ptr<Field>> fields,
 }
 
 std::shared_ptr<Schema> schema(
-    const std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>>&
-        fields,
+    std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>> fields,
     std::shared_ptr<const KeyValueMetadata> metadata) {
   return std::make_shared<Schema>(make_fields(fields), std::move(metadata));
 }
@@ -2667,8 +2665,7 @@ std::shared_ptr<DataType> struct_(const std::vector<std::shared_ptr<Field>>& fie
 }
 
 std::shared_ptr<DataType> struct_(
-    const std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>>&
-        fields) {
+    std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>> fields) {
   return std::make_shared<StructType>(make_fields(fields));
 }
 

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -2121,13 +2121,14 @@ Status SchemaBuilder::AreCompatible(const std::vector<std::shared_ptr<Schema>>& 
 }
 
 std::vector<std::shared_ptr<Field>> make_fields(
-  const std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>>& init_list) {
-    std::vector<std::shared_ptr<Field>> fields;
-    fields.reserve(init_list.size());
-    for (const auto& pair : init_list) {
-        fields.push_back(std::make_shared<Field>(pair.first, pair.second));
-    }
-    return fields;
+    const std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>>&
+        init_list) {
+  std::vector<std::shared_ptr<Field>> fields;
+  fields.reserve(init_list.size());
+  for (const auto& pair : init_list) {
+    fields.push_back(std::make_shared<Field>(pair.first, pair.second));
+  }
+  return fields;
 }
 
 std::shared_ptr<Schema> schema(std::vector<std::shared_ptr<Field>> fields,
@@ -2135,11 +2136,12 @@ std::shared_ptr<Schema> schema(std::vector<std::shared_ptr<Field>> fields,
   return std::make_shared<Schema>(std::move(fields), std::move(metadata));
 }
 
-std::shared_ptr<Schema> schema(const std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>>& fields,
-                               std::shared_ptr<const KeyValueMetadata> metadata) {
-  return std::make_shared<Schema>(std::move(make_fields(fields)), std::move(metadata));
+std::shared_ptr<Schema> schema(
+    const std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>>&
+        fields,
+    std::shared_ptr<const KeyValueMetadata> metadata) {
+  return std::make_shared<Schema>(make_fields(fields), std::move(metadata));
 }
-
 
 std::shared_ptr<Schema> schema(std::vector<std::shared_ptr<Field>> fields,
                                Endianness endianness,
@@ -2147,10 +2149,11 @@ std::shared_ptr<Schema> schema(std::vector<std::shared_ptr<Field>> fields,
   return std::make_shared<Schema>(std::move(fields), endianness, std::move(metadata));
 }
 
-std::shared_ptr<Schema> schema(const std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>>& fields,
-                               Endianness endianness,
-                               std::shared_ptr<const KeyValueMetadata> metadata) {
-  return std::make_shared<Schema>(std::move(make_fields(fields)), endianness, std::move(metadata));
+std::shared_ptr<Schema> schema(
+    const std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>>&
+        fields,
+    Endianness endianness, std::shared_ptr<const KeyValueMetadata> metadata) {
+  return std::make_shared<Schema>(make_fields(fields), endianness, std::move(metadata));
 }
 
 Result<std::shared_ptr<Schema>> UnifySchemas(
@@ -2664,10 +2667,10 @@ std::shared_ptr<DataType> struct_(const std::vector<std::shared_ptr<Field>>& fie
 }
 
 std::shared_ptr<DataType> struct_(
-  const std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>>& fields) {
+    const std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>>&
+        fields) {
   return std::make_shared<StructType>(make_fields(fields));
 }
-
 
 std::shared_ptr<DataType> run_end_encoded(std::shared_ptr<arrow::DataType> run_end_type,
                                           std::shared_ptr<DataType> value_type) {

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -276,6 +276,17 @@ std::shared_ptr<Field> MaybePromoteNullTypes(const Field& existing, const Field&
   // `other` must be null.
   return existing.WithNullable(true);
 }
+
+std::vector<std::shared_ptr<Field>> MakeFields(
+    std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>> init_list) {
+  std::vector<std::shared_ptr<Field>> fields;
+  fields.reserve(init_list.size());
+  for (const auto& [name, type] : init_list) {
+    fields.push_back(field(name, type));
+  }
+  return fields;
+}
+
 }  // namespace
 
 Field::~Field() {}
@@ -2120,16 +2131,6 @@ Status SchemaBuilder::AreCompatible(const std::vector<std::shared_ptr<Schema>>& 
   return Merge(schemas, policy).status();
 }
 
-std::vector<std::shared_ptr<Field>> make_fields(
-    std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>> init_list) {
-  std::vector<std::shared_ptr<Field>> fields;
-  fields.reserve(init_list.size());
-  for (const auto& [name, type] : init_list) {
-    fields.push_back(field(name, type));
-  }
-  return fields;
-}
-
 std::shared_ptr<Schema> schema(std::vector<std::shared_ptr<Field>> fields,
                                std::shared_ptr<const KeyValueMetadata> metadata) {
   return std::make_shared<Schema>(std::move(fields), std::move(metadata));
@@ -2138,7 +2139,7 @@ std::shared_ptr<Schema> schema(std::vector<std::shared_ptr<Field>> fields,
 std::shared_ptr<Schema> schema(
     std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>> fields,
     std::shared_ptr<const KeyValueMetadata> metadata) {
-  return std::make_shared<Schema>(make_fields(fields), std::move(metadata));
+  return std::make_shared<Schema>(MakeFields(fields), std::move(metadata));
 }
 
 std::shared_ptr<Schema> schema(std::vector<std::shared_ptr<Field>> fields,
@@ -2150,7 +2151,7 @@ std::shared_ptr<Schema> schema(std::vector<std::shared_ptr<Field>> fields,
 std::shared_ptr<Schema> schema(
     std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>> fields,
     Endianness endianness, std::shared_ptr<const KeyValueMetadata> metadata) {
-  return std::make_shared<Schema>(make_fields(fields), endianness, std::move(metadata));
+  return std::make_shared<Schema>(MakeFields(fields), endianness, std::move(metadata));
 }
 
 Result<std::shared_ptr<Schema>> UnifySchemas(
@@ -2665,7 +2666,7 @@ std::shared_ptr<DataType> struct_(const std::vector<std::shared_ptr<Field>>& fie
 
 std::shared_ptr<DataType> struct_(
     std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>> fields) {
-  return std::make_shared<StructType>(make_fields(fields));
+  return std::make_shared<StructType>(MakeFields(fields));
 }
 
 std::shared_ptr<DataType> run_end_encoded(std::shared_ptr<arrow::DataType> run_end_type,

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -2120,15 +2120,37 @@ Status SchemaBuilder::AreCompatible(const std::vector<std::shared_ptr<Schema>>& 
   return Merge(schemas, policy).status();
 }
 
+std::vector<std::shared_ptr<Field>> make_fields(
+  const std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>>& init_list) {
+    std::vector<std::shared_ptr<Field>> fields;
+    fields.reserve(init_list.size());
+    for (const auto& pair : init_list) {
+        fields.push_back(std::make_shared<Field>(pair.first, pair.second));
+    }
+    return fields;
+}
+
 std::shared_ptr<Schema> schema(std::vector<std::shared_ptr<Field>> fields,
                                std::shared_ptr<const KeyValueMetadata> metadata) {
   return std::make_shared<Schema>(std::move(fields), std::move(metadata));
 }
 
+std::shared_ptr<Schema> schema(const std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>>& fields,
+                               std::shared_ptr<const KeyValueMetadata> metadata) {
+  return std::make_shared<Schema>(std::move(make_fields(fields)), std::move(metadata));
+}
+
+
 std::shared_ptr<Schema> schema(std::vector<std::shared_ptr<Field>> fields,
                                Endianness endianness,
                                std::shared_ptr<const KeyValueMetadata> metadata) {
   return std::make_shared<Schema>(std::move(fields), endianness, std::move(metadata));
+}
+
+std::shared_ptr<Schema> schema(const std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>>& fields,
+                               Endianness endianness,
+                               std::shared_ptr<const KeyValueMetadata> metadata) {
+  return std::make_shared<Schema>(std::move(make_fields(fields)), endianness, std::move(metadata));
 }
 
 Result<std::shared_ptr<Schema>> UnifySchemas(
@@ -2640,6 +2662,12 @@ std::shared_ptr<DataType> fixed_size_list(const std::shared_ptr<Field>& value_fi
 std::shared_ptr<DataType> struct_(const std::vector<std::shared_ptr<Field>>& fields) {
   return std::make_shared<StructType>(fields);
 }
+
+std::shared_ptr<DataType> struct_(
+  const std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>>& fields) {
+  return std::make_shared<StructType>(make_fields(fields));
+}
+
 
 std::shared_ptr<DataType> run_end_encoded(std::shared_ptr<arrow::DataType> run_end_type,
                                           std::shared_ptr<DataType> value_type) {

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -2148,8 +2148,7 @@ std::shared_ptr<Schema> schema(std::vector<std::shared_ptr<Field>> fields,
 }
 
 std::shared_ptr<Schema> schema(
-    const std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>>&
-        fields,
+    std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>> fields,
     Endianness endianness, std::shared_ptr<const KeyValueMetadata> metadata) {
   return std::make_shared<Schema>(make_fields(fields), endianness, std::move(metadata));
 }

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -562,7 +562,8 @@ ARROW_EXPORT std::shared_ptr<DataType> struct_(
 
 /// \brief Create a StructType instance by initializer_list
 ARROW_EXPORT std::shared_ptr<DataType> struct_(
-    const std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>>& fields);
+    const std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>>&
+        fields);
 
 /// \brief Create a RunEndEncodedType instance
 ARROW_EXPORT std::shared_ptr<DataType> run_end_encoded(
@@ -633,14 +634,15 @@ std::shared_ptr<Schema> schema(
     std::vector<std::shared_ptr<Field>> fields,
     std::shared_ptr<const KeyValueMetadata> metadata = NULLPTR);
 
-/// \brief Create a Schema instance 
+/// \brief Create a Schema instance
 ///
 /// \param fields the schema's fields in the form of initializer_list
 /// \param metadata any custom key-value metadata, default null
 /// \return schema shared_ptr to Schema
 ARROW_EXPORT
 std::shared_ptr<Schema> schema(
-    const std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>>& fields,
+    const std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>>&
+        fields,
     std::shared_ptr<const KeyValueMetadata> metadata = NULLPTR);
 
 /// \brief Create a Schema instance
@@ -662,8 +664,9 @@ std::shared_ptr<Schema> schema(
 /// \return schema shared_ptr to Schema
 ARROW_EXPORT
 std::shared_ptr<Schema> schema(
-    const std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>>& fields, Endianness endianness,
-    std::shared_ptr<const KeyValueMetadata> metadata = NULLPTR);
+    const std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>>&
+        fields,
+    Endianness endianness, std::shared_ptr<const KeyValueMetadata> metadata = NULLPTR);
 
 /// @}
 

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -560,7 +560,7 @@ ARROW_EXPORT std::shared_ptr<DataType> time64(TimeUnit::type unit);
 ARROW_EXPORT std::shared_ptr<DataType> struct_(
     const std::vector<std::shared_ptr<Field>>& fields);
 
-/// \brief Create a StructType instance by initializer_list
+/// \brief Create a StructType instance from (name, type) pairs
 ARROW_EXPORT std::shared_ptr<DataType> struct_(
     std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>> fields);
 
@@ -633,9 +633,11 @@ std::shared_ptr<Schema> schema(
     std::vector<std::shared_ptr<Field>> fields,
     std::shared_ptr<const KeyValueMetadata> metadata = NULLPTR);
 
-/// \brief Create a Schema instance
+/// \brief Create a Schema instance from (name, type) pairs
 ///
-/// \param fields the schema's fields in the form of initializer_list
+/// The schema's fields will all be nullable with no associated metadata.
+///
+/// \param fields (name, type) pairs of the schema's fields
 /// \param metadata any custom key-value metadata, default null
 /// \return schema shared_ptr to Schema
 ARROW_EXPORT
@@ -656,7 +658,9 @@ std::shared_ptr<Schema> schema(
 
 /// \brief Create a Schema instance
 ///
-/// \param fields the schema's fields in the form of initializer_list
+/// The schema's fields will all be nullable with no associated metadata.
+///
+/// \param fields (name, type) pairs of the schema's fields
 /// \param endianness the endianness of the data
 /// \param metadata any custom key-value metadata, default null
 /// \return schema shared_ptr to Schema

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -560,6 +560,10 @@ ARROW_EXPORT std::shared_ptr<DataType> time64(TimeUnit::type unit);
 ARROW_EXPORT std::shared_ptr<DataType> struct_(
     const std::vector<std::shared_ptr<Field>>& fields);
 
+/// \brief Create a StructType instance by initializer_list
+ARROW_EXPORT std::shared_ptr<DataType> struct_(
+    const std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>>& fields);
+
 /// \brief Create a RunEndEncodedType instance
 ARROW_EXPORT std::shared_ptr<DataType> run_end_encoded(
     std::shared_ptr<DataType> run_end_type, std::shared_ptr<DataType> value_type);
@@ -629,6 +633,16 @@ std::shared_ptr<Schema> schema(
     std::vector<std::shared_ptr<Field>> fields,
     std::shared_ptr<const KeyValueMetadata> metadata = NULLPTR);
 
+/// \brief Create a Schema instance 
+///
+/// \param fields the schema's fields in the form of initializer_list
+/// \param metadata any custom key-value metadata, default null
+/// \return schema shared_ptr to Schema
+ARROW_EXPORT
+std::shared_ptr<Schema> schema(
+    const std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>>& fields,
+    std::shared_ptr<const KeyValueMetadata> metadata = NULLPTR);
+
 /// \brief Create a Schema instance
 ///
 /// \param fields the schema's fields
@@ -638,6 +652,17 @@ std::shared_ptr<Schema> schema(
 ARROW_EXPORT
 std::shared_ptr<Schema> schema(
     std::vector<std::shared_ptr<Field>> fields, Endianness endianness,
+    std::shared_ptr<const KeyValueMetadata> metadata = NULLPTR);
+
+/// \brief Create a Schema instance
+///
+/// \param fields the schema's fields in the form of initializer_list
+/// \param endianness the endianness of the data
+/// \param metadata any custom key-value metadata, default null
+/// \return schema shared_ptr to Schema
+ARROW_EXPORT
+std::shared_ptr<Schema> schema(
+    const std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>>& fields, Endianness endianness,
     std::shared_ptr<const KeyValueMetadata> metadata = NULLPTR);
 
 /// @}

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -562,8 +562,7 @@ ARROW_EXPORT std::shared_ptr<DataType> struct_(
 
 /// \brief Create a StructType instance by initializer_list
 ARROW_EXPORT std::shared_ptr<DataType> struct_(
-    const std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>>&
-        fields);
+    std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>> fields);
 
 /// \brief Create a RunEndEncodedType instance
 ARROW_EXPORT std::shared_ptr<DataType> run_end_encoded(
@@ -641,8 +640,7 @@ std::shared_ptr<Schema> schema(
 /// \return schema shared_ptr to Schema
 ARROW_EXPORT
 std::shared_ptr<Schema> schema(
-    const std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>>&
-        fields,
+    std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>> fields,
     std::shared_ptr<const KeyValueMetadata> metadata = NULLPTR);
 
 /// \brief Create a Schema instance

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -662,8 +662,7 @@ std::shared_ptr<Schema> schema(
 /// \return schema shared_ptr to Schema
 ARROW_EXPORT
 std::shared_ptr<Schema> schema(
-    const std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>>&
-        fields,
+    std::initializer_list<std::pair<std::string, std::shared_ptr<DataType>>> fields,
     Endianness endianness, std::shared_ptr<const KeyValueMetadata> metadata = NULLPTR);
 
 /// @}

--- a/cpp/src/arrow/type_test.cc
+++ b/cpp/src/arrow/type_test.cc
@@ -1486,12 +1486,11 @@ TEST(TestStructType, Basics) {
 
   ASSERT_EQ(struct_type.ToString(), "struct<f0: int32, f1: string, f2: uint8>");
 
-  auto t1 =  struct_({{"a", int8()}, {"b", utf8()}});
-  auto t2 =  struct_({field("a", int8()), field("b", utf8())});
-  auto t3 =  struct_({field("c", int8()), field("b", utf8())});
+  auto t1 = struct_({{"a", int8()}, {"b", utf8()}});
+  auto t2 = struct_({field("a", int8()), field("b", utf8())});
+  auto t3 = struct_({field("c", int8()), field("b", utf8())});
   ASSERT_TRUE(t1->Equals(t2));
   ASSERT_TRUE(!t1->Equals(t3));
-
 
   // TODO(wesm): out of bounds for field(...)
 }

--- a/cpp/src/arrow/type_test.cc
+++ b/cpp/src/arrow/type_test.cc
@@ -414,6 +414,13 @@ TEST_F(TestSchema, Basics) {
   ASSERT_NE(schema4->fingerprint(), schema7->fingerprint());
   ASSERT_EQ(schema6->fingerprint(), schema7->fingerprint());
 #endif
+
+  auto schema8 = ::arrow::schema({field("f0", int8()), field("f1", int32())});
+  auto schema9 = ::arrow::schema({{"f0", int8()}, {"f1", int32()}});
+  auto schema10 = ::arrow::schema({{"f2", int8()}, {"f1", int32()}});
+
+  AssertSchemaEqual(schema8, schema9);
+  AssertSchemaNotEqual(schema8, schema10);
 }
 
 TEST_F(TestSchema, ToString) {
@@ -1478,6 +1485,13 @@ TEST(TestStructType, Basics) {
   ASSERT_TRUE(struct_type.field(2)->Equals(f2));
 
   ASSERT_EQ(struct_type.ToString(), "struct<f0: int32, f1: string, f2: uint8>");
+
+  auto t1 =  struct_({{"a", int8()}, {"b", utf8()}});
+  auto t2 =  struct_({field("a", int8()), field("b", utf8())});
+  auto t3 =  struct_({field("c", int8()), field("b", utf8())});
+  ASSERT_TRUE(t1->Equals(t2));
+  ASSERT_TRUE(!t1->Equals(t3));
+
 
   // TODO(wesm): out of bounds for field(...)
 }

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -839,7 +839,8 @@ std::function<std::shared_ptr<::arrow::DataType>(FieldVector)> GetNestedFactory(
   switch (inferred_type.id()) {
     case ::arrow::Type::STRUCT:
       if (origin_type.id() == ::arrow::Type::STRUCT) {
-        return ::arrow::struct_;
+        return static_cast<std::shared_ptr<::arrow::DataType> (*)(const FieldVector&)>(
+            &::arrow::struct_);
       }
       break;
     case ::arrow::Type::LIST:

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -839,8 +839,7 @@ std::function<std::shared_ptr<::arrow::DataType>(FieldVector)> GetNestedFactory(
   switch (inferred_type.id()) {
     case ::arrow::Type::STRUCT:
       if (origin_type.id() == ::arrow::Type::STRUCT) {
-        return static_cast<std::shared_ptr<::arrow::DataType> (*)(const FieldVector&)>(
-            &::arrow::struct_);
+        return [](FieldVector fields) { return ::arrow::struct_(std::move(fields)); };
       }
       break;
     case ::arrow::Type::LIST:


### PR DESCRIPTION
### Rationale for this change
Mostly for convenience. It would be nice to be able to write:
```struct_({{"a", int8()}, {"b", utf8()}});```
instead of:
```struct_({field("a", int8()), field("b", utf8())});```
Same with the schema factory.

### What changes are included in this PR?
Add a struct_ overload and two schema overload taking a vector of (name, type) pairs to construct a vector of fields.

### Are these changes tested?
Yes.

### Are there any user-facing changes?
Yes. Add three ARROW_EXPORT functions.

* Closes: #36867