### PR TITLE
GH-36916: [C++] Refactor the scan node to make way for adding parquet

### DIFF
--- a/cpp/src/arrow/acero/sink_node_test.cc
+++ b/cpp/src/arrow/acero/sink_node_test.cc
@@ -1,0 +1,77 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+
+#include "arrow/acero/exec_plan.h"
+#include "arrow/acero/options.h"
+#include "arrow/dataset/file_base.h"
+#include "arrow/dataset/file_parquet.h"
+#include "arrow/dataset/partition.h"
+#include "arrow/filesystem/mockfs.h"
+#include "arrow/testing/generator.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/testing/matchers.h"
+
+#include "arrow/table.h"
+#include "arrow/util/key_value_metadata.h"
+
+namespace arrow {
+
+namespace acero {
+
+TEST(SinkNode, CustomFieldMetadata) {
+  // Create an input table with a nullable and a non-nullable type
+  ExecBatch batch = gen::Gen({gen::Step()})->FailOnError()->ExecBatch(/*num_rows=*/1);
+  std::shared_ptr<Schema> test_schema =
+      schema({field("nullable_i32", uint32(), /*nullable=*/true,
+                    key_value_metadata({{"foo", "bar"}})),
+              field("non_nullable_i32", uint32(), /*nullable=*/false)});
+  std::shared_ptr<RecordBatch> record_batch =
+      RecordBatch::Make(test_schema, /*num_rows=*/1,
+                        {batch.values[0].make_array(), batch.values[0].make_array()});
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<Table> table,
+                       Table::FromRecordBatches({std::move(record_batch)}));
+
+  ASSERT_TRUE(table->field(0)->nullable());
+  ASSERT_EQ(1, table->field(0)->metadata()->keys().size());
+  ASSERT_FALSE(table->field(1)->nullable());
+  ASSERT_EQ(0, table->field(1)->metadata()->keys().size());
+
+  Declaration plan = Declaration::Sequence(
+      {{"table_source", TableSourceNodeOptions(std::move(table))},
+       {"project", ProjectNodeOptions({compute::field_ref(0), compute::field_ref(1)})}});
+
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<Table> out_table, DeclarationToTable(plan));
+
+  ASSERT_TRUE(table->field(0)->nullable());
+  ASSERT_EQ(1, table->field(0)->metadata()->keys().size());
+  ASSERT_FALSE(table->field(1)->nullable());
+  ASSERT_EQ(0, table->field(1)->metadata()->keys().size());
+
+  ASSERT_OK_AND_ASSIGN(BatchesWithCommonSchema batches_and_schema,
+                       DeclarationToExecBatches(plan));
+  ASSERT_TRUE(batches_and_schema.schema->field(0)->nullable());
+  ASSERT_FALSE(batches_and_schema.schema->field(1)->nullable());
+}
+
+}  // namespace acero
+}  // namespace arrow

--- a/cpp/src/arrow/dataset/dataset_internal.h
+++ b/cpp/src/arrow/dataset/dataset_internal.h
@@ -89,6 +89,21 @@ arrow::Result<std::shared_ptr<T>> GetFragmentScanOptions(
   return ::arrow::internal::checked_pointer_cast<T>(source);
 }
 
+template <typename T>
+Result<const T*> GetFragmentScanOptions(const FragmentScanOptions* scan_or_format_opts,
+                                        const std::string& type_name) {
+  static T fallback_opts = {};
+  if (scan_or_format_opts == nullptr) {
+    return &fallback_opts;
+  }
+  auto* casted_opts = dynamic_cast<const T*>(scan_or_format_opts);
+  if (!casted_opts) {
+    return Status::Invalid("User provided scan options of type ",
+                           scan_or_format_opts->type_name(), " but expected ", type_name);
+  }
+  return casted_opts;
+}
+
 class FragmentDataset : public Dataset {
  public:
   FragmentDataset(std::shared_ptr<Schema> schema, FragmentVector fragments)

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -134,14 +134,15 @@ Future<std::optional<int64_t>> FileFormat::CountRows(
 }
 
 Future<std::shared_ptr<InspectedFragment>> FileFormat::InspectFragment(
-    const FileSource& source, const FragmentScanOptions* format_options,
-    compute::ExecContext* exec_context) const {
+    const FileFragment& fragment, const FileSource& source,
+    const FragmentScanOptions* format_options, compute::ExecContext* exec_context) const {
   return Status::NotImplemented("This format does not yet support the scan2 node");
 }
 
 Future<std::shared_ptr<FragmentScanner>> FileFormat::BeginScan(
-    const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
-    const FragmentScanOptions* format_options, compute::ExecContext* exec_context) const {
+    const FileSource& source, const FragmentScanRequest& request,
+    InspectedFragment* inspected_fragment, const FragmentScanOptions* format_options,
+    compute::ExecContext* exec_context) const {
   return Status::NotImplemented("This format does not yet support the scan2 node");
 }
 
@@ -174,23 +175,23 @@ Result<RecordBatchGenerator> FileFragment::ScanBatchesAsync(
   return format_->ScanBatchesAsync(options, self);
 }
 
-Future<std::shared_ptr<InspectedFragment>> FileFragment::InspectFragment(
+Future<std::shared_ptr<InspectedFragment>> FileFragment::InspectFragmentImpl(
     const FragmentScanOptions* format_options, compute::ExecContext* exec_context) {
   const FragmentScanOptions* realized_format_options = format_options;
   if (format_options == nullptr) {
     realized_format_options = format_->default_fragment_scan_options.get();
   }
-  return format_->InspectFragment(source_, realized_format_options, exec_context);
+  return format_->InspectFragment(*this, source_, realized_format_options, exec_context);
 }
 
 Future<std::shared_ptr<FragmentScanner>> FileFragment::BeginScan(
-    const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
-    const FragmentScanOptions* format_options, compute::ExecContext* exec_context) {
-  const FragmentScanOptions* realized_format_options = format_options;
-  if (format_options == nullptr) {
+    const FragmentScanRequest& request, InspectedFragment* inspected_fragment,
+    compute::ExecContext* exec_context) {
+  const FragmentScanOptions* realized_format_options = request.format_scan_options;
+  if (realized_format_options == nullptr) {
     realized_format_options = format_->default_fragment_scan_options.get();
   }
-  return format_->BeginScan(request, inspected_fragment, realized_format_options,
+  return format_->BeginScan(source_, request, inspected_fragment, realized_format_options,
                             exec_context);
 }
 

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -165,7 +165,8 @@ class ARROW_DS_EXPORT FileFormat : public std::enable_shared_from_this<FileForma
 
   /// \brief Learn what we need about the file before we start scanning it
   virtual Future<std::shared_ptr<InspectedFragment>> InspectFragment(
-      const FileSource& source, const FragmentScanOptions* format_options,
+      const FileFragment& fragment, const FileSource& source,
+      const FragmentScanOptions* format_options,
       compute::ExecContext* exec_context) const;
 
   virtual Result<RecordBatchGenerator> ScanBatchesAsync(
@@ -176,9 +177,13 @@ class ARROW_DS_EXPORT FileFormat : public std::enable_shared_from_this<FileForma
       const std::shared_ptr<FileFragment>& file, compute::Expression predicate,
       const std::shared_ptr<ScanOptions>& options);
 
+  // `format_options` may seem redundant (there is a `format_options` in `request`)
+  // however, it will overwrite the scan request's format options with the file format's
+  // default options if the scan request does not specify `format_options`.  So the
+  // `format_options` parameter should be preferred over `request.format_scan_options`
   virtual Future<std::shared_ptr<FragmentScanner>> BeginScan(
-      const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
-      const FragmentScanOptions* format_options,
+      const FileSource& source, const FragmentScanRequest& request,
+      InspectedFragment* inspected_fragment, const FragmentScanOptions* format_options,
       compute::ExecContext* exec_context) const;
 
   /// \brief Open a fragment
@@ -221,10 +226,9 @@ class ARROW_DS_EXPORT FileFragment : public Fragment,
       compute::Expression predicate,
       const std::shared_ptr<ScanOptions>& options) override;
   Future<std::shared_ptr<FragmentScanner>> BeginScan(
-      const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
-      const FragmentScanOptions* format_options,
+      const FragmentScanRequest& request, InspectedFragment* inspected_fragment,
       compute::ExecContext* exec_context) override;
-  Future<std::shared_ptr<InspectedFragment>> InspectFragment(
+  Future<std::shared_ptr<InspectedFragment>> InspectFragmentImpl(
       const FragmentScanOptions* format_options,
       compute::ExecContext* exec_context) override;
 

--- a/cpp/src/arrow/dataset/file_csv.h
+++ b/cpp/src/arrow/dataset/file_csv.h
@@ -57,8 +57,8 @@ class ARROW_DS_EXPORT CsvFileFormat : public FileFormat {
   Result<std::shared_ptr<Schema>> Inspect(const FileSource& source) const override;
 
   Future<std::shared_ptr<FragmentScanner>> BeginScan(
-      const FragmentScanRequest& request, const InspectedFragment& inspected_fragment,
-      const FragmentScanOptions* format_options,
+      const FileSource& file_source, const FragmentScanRequest& request,
+      InspectedFragment* inspected_fragment, const FragmentScanOptions* format_options,
       compute::ExecContext* exec_context) const override;
 
   Result<RecordBatchGenerator> ScanBatchesAsync(
@@ -66,7 +66,8 @@ class ARROW_DS_EXPORT CsvFileFormat : public FileFormat {
       const std::shared_ptr<FileFragment>& file) const override;
 
   Future<std::shared_ptr<InspectedFragment>> InspectFragment(
-      const FileSource& source, const FragmentScanOptions* format_options,
+      const FileFragment& fragment, const FileSource& source,
+      const FragmentScanOptions* format_options,
       compute::ExecContext* exec_context) const override;
 
   Future<std::optional<int64_t>> CountRows(

--- a/cpp/src/arrow/dataset/file_csv_test.cc
+++ b/cpp/src/arrow/dataset/file_csv_test.cc
@@ -531,18 +531,13 @@ class TestCsvFileFormatScanNode : public FileFormatScanNodeMixin<CsvFormatHelper
   CsvFragmentScanOptions scan_options_;
 };
 
+TEST_P(TestCsvFileFormatScanNode, Inspect) { TestInspect(); }
 TEST_P(TestCsvFileFormatScanNode, Scan) { TestScan(); }
-TEST_P(TestCsvFileFormatScanNode, ScanProjected) { TestScanProjected(); }
-TEST_P(TestCsvFileFormatScanNode, ScanMissingFilterField) {
-  TestScanMissingFilterField();
-}
+TEST_P(TestCsvFileFormatScanNode, ScanSomeColumns) { TestScanSomeColumns(); }
 // NOTE(ARROW-14658): TestScanProjectedNested is ignored since CSV
 // doesn't have any nested types for us to work with
-TEST_P(TestCsvFileFormatScanNode, ScanProjectedMissingColumns) {
-  TestScanProjectedMissingCols();
-}
-TEST_P(TestCsvFileFormatScanNode, ScanWithDuplicateColumn) {
-  TestScanWithDuplicateColumn();
+TEST_P(TestCsvFileFormatScanNode, ScanWithInvalidOptions) {
+  TestInvalidFormatScanOptions();
 }
 // NOTE: TestScanWithPushdownNulls is ignored since CSV doesn't handle pushdown filtering
 INSTANTIATE_TEST_SUITE_P(TestScanNode, TestCsvFileFormatScanNode,

--- a/cpp/src/arrow/dataset/file_json.h
+++ b/cpp/src/arrow/dataset/file_json.h
@@ -54,12 +54,13 @@ class ARROW_DS_EXPORT JsonFileFormat : public FileFormat {
   Result<std::shared_ptr<Schema>> Inspect(const FileSource& source) const override;
 
   Future<std::shared_ptr<InspectedFragment>> InspectFragment(
-      const FileSource& source, const FragmentScanOptions* format_options,
+      const FileFragment& fragment, const FileSource& source,
+      const FragmentScanOptions* format_options,
       compute::ExecContext* exec_context) const override;
 
   Future<std::shared_ptr<FragmentScanner>> BeginScan(
-      const FragmentScanRequest& scan_request, const InspectedFragment& inspected,
-      const FragmentScanOptions* format_options,
+      const FileSource& file_source, const FragmentScanRequest& scan_request,
+      InspectedFragment* inspected, const FragmentScanOptions* format_options,
       compute::ExecContext* exec_context) const override;
 
   Result<RecordBatchGenerator> ScanBatchesAsync(

--- a/cpp/src/arrow/dataset/file_json_test.cc
+++ b/cpp/src/arrow/dataset/file_json_test.cc
@@ -327,9 +327,7 @@ INSTANTIATE_TEST_SUITE_P(TestJsonScan, TestJsonScan,
 
 // Common tests for new scanner
 TEST_P(TestJsonScanNode, Scan) { TestScan(); }
-TEST_P(TestJsonScanNode, ScanMissingFilterField) { TestScanMissingFilterField(); }
-TEST_P(TestJsonScanNode, ScanProjected) { TestScanProjected(); }
-TEST_P(TestJsonScanNode, ScanProjectedMissingColumns) { TestScanProjectedMissingCols(); }
+TEST_P(TestJsonScanNode, ScanSomeColumns) { TestScanSomeColumns(); }
 // JSON-specific tests for new scanner
 TEST_P(TestJsonScanNode, ScanWithBOM) { TestScanWithBOM(); }
 TEST_P(TestJsonScanNode, ScanWithCustomParseOptions) { TestScanWithCustomParseOptions(); }

--- a/cpp/src/arrow/util/async_util.cc
+++ b/cpp/src/arrow/util/async_util.cc
@@ -65,6 +65,9 @@ class ThrottleImpl : public ThrottledAsyncTaskScheduler::Throttle {
 
   void Pause() override {
     std::lock_guard lg(mutex_);
+    if (paused_) {
+      return;
+    }
     paused_ = true;
     if (!backoff_.is_valid()) {
       backoff_ = Future<>::Make();
@@ -73,6 +76,9 @@ class ThrottleImpl : public ThrottledAsyncTaskScheduler::Throttle {
 
   void Resume() override {
     std::unique_lock lk(mutex_);
+    if (!paused_) {
+      return;
+    }
     paused_ = false;
     // Might be a useless notification if our current cost is full
     // or no one is waiting but it should be ok.


### PR DESCRIPTION
### Rationale for this change

The rationale is described in the github issue.

### What changes are included in this PR?

The scan node is refactored.  A few new unit tests are added.  No functional changes to the new scan node.

### Are these changes tested?

Yes, through a combination of existing and new unit tests.

### Are there any user-facing changes?

No.  The new scan node is not yet user facing.
* Closes: #36916