### PR TITLE
GH-36920: [Java][Docs] Add ARROW_JSON var to maven build profile

### DIFF
--- a/docs/source/developers/java/building.rst
+++ b/docs/source/developers/java/building.rst
@@ -216,6 +216,7 @@ CMake
           -DARROW_FILESYSTEM=ON \
           -DARROW_GANDIVA=ON \
           -DARROW_GANDIVA_STATIC_LIBSTDCPP=ON \
+          -DARROW_JSON=ON \
           -DARROW_ORC=ON \
           -DARROW_PARQUET=ON \
           -DARROW_S3=ON \
@@ -256,6 +257,7 @@ CMake
           -DARROW_DATASET=ON ^
           -DARROW_DEPENDENCY_USE_SHARED=OFF ^
           -DARROW_FILESYSTEM=ON ^
+          -DARROW_JSON=ON ^
           -DARROW_ORC=OFF ^
           -DARROW_PARQUET=ON ^
           -DARROW_S3=ON ^

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -1019,6 +1019,7 @@
                     -DARROW_FILESYSTEM=ON
                     -DARROW_GANDIVA=${ARROW_GANDIVA}
                     -DARROW_GANDIVA_STATIC_LIBSTDCPP=ON
+                    -DARROW_JSON=${ARROW_DATASET}
                     -DARROW_ORC=${ARROW_ORC}
                     -DARROW_PARQUET=${ARROW_PARQUET}
                     -DARROW_S3=ON
@@ -1129,6 +1130,7 @@
                     -DARROW_DATASET=ON
                     -DARROW_DEPENDENCY_USE_SHARED=OFF
                     -DARROW_FILESYSTEM=ON
+                    -DARROW_JSON=${ARROW_DATASET}
                     -DARROW_ORC=${ARROW_ORC}
                     -DARROW_PARQUET=${ARROW_PARQUET}
                     -DARROW_S3=ON


### PR DESCRIPTION
### Rationale for this change

JSON support in the datasets module was recently introduced. Update the maven build profile and build documentation to reflect this. Similar to https://github.com/apache/arrow/pull/36899

### What changes are included in this PR?

* update maven build profile
* update build docs

### Are these changes tested?

Yes, tested locally on M1 Mac.

### Are there any user-facing changes?

No
* Closes: #36920