### PR TITLE
GH-36922: [CI][C++][Windows] Search OpenSSL from PATH

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -269,8 +269,6 @@ jobs:
       CMAKE_INSTALL_LIBDIR: bin
       CMAKE_INSTALL_PREFIX: /usr
       CMAKE_UNITY_BUILD: ON
-      OPENSSL_ROOT_DIR: >-
-        C:\Program Files\OpenSSL-Win64
       NPROC: 3
     steps:
       - name: Disable Crash Dialogs


### PR DESCRIPTION
### Rationale for this change

It seems that OpenSSL install script adds the OpenSSL install folder to `PATH`:
https://github.com/actions/runner-images/blob/665e71067ff126acea71e7d93715c83db038597f/images/win/scripts/Installers/Install-OpenSSL.ps1#L37

If OpenSSL install folder exists in `PATH`, we don't need to specify `OPENSSL_ROOT_DIR` explicitly. Because `find_*` such as [`find_library()`](https://cmake.org/cmake/help/latest/command/find_library.html) searches path in `PATH` by default:

> On Windows hosts: `<prefix>/lib/<arch>` if [`CMAKE_LIBRARY_ARCHITECTURE`](https://cmake.org/cmake/help/latest/variable/CMAKE_LIBRARY_ARCHITECTURE.html#variable:CMAKE_LIBRARY_ARCHITECTURE) is set, and `<prefix>/lib` for each `<prefix>/[s]bin` in `PATH`, and `<entry>/lib` for other entries in `PATH`.

### What changes are included in this PR?

Remove `OPENSSL_ROOT_DIR`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #36922