### PR TITLE
GH-36928: [Java] Make it run well with the netty newest version 4.1.96

### DIFF
--- a/java/memory/memory-netty/src/main/java/io/netty/buffer/PooledByteBufAllocatorL.java
+++ b/java/memory/memory-netty/src/main/java/io/netty/buffer/PooledByteBufAllocatorL.java
@@ -161,7 +161,7 @@ public class PooledByteBufAllocatorL {
     }
 
     private UnsafeDirectLittleEndian newDirectBufferL(int initialCapacity, int maxCapacity) {
-      PoolArenasCache cache = threadCache();
+      PoolThreadCache cache = threadCache();
       PoolArena<ByteBuffer> directArena = cache.directArena;
 
       if (directArena != null) {

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -33,7 +33,7 @@
     <dep.junit.jupiter.version>5.9.0</dep.junit.jupiter.version>
     <dep.slf4j.version>1.7.25</dep.slf4j.version>
     <dep.guava-bom.version>31.1-jre</dep.guava-bom.version>
-    <dep.netty-bom.version>4.1.94.Final</dep.netty-bom.version>
+    <dep.netty-bom.version>4.1.96.Final</dep.netty-bom.version>
     <dep.grpc-bom.version>1.56.0</dep.grpc-bom.version>
     <dep.protobuf-bom.version>3.23.1</dep.protobuf-bom.version>
     <dep.jackson-bom.version>2.15.1</dep.jackson-bom.version>


### PR DESCRIPTION
When I used `netty arrow memory 13.0.0` and `netty 4.1.96.Final` in Spark, the following error occurred,
Because `netty 4.1.96.Final` version has revert some modifications, in order to ensure that `netty arrow memory 13.0.0` works well with ``netty 4.1.96.Final`` version, I suggest making similar modifications here.
1.Compilation errors are as follows:
https://ci.appveyor.com/project/ApacheSoftwareFoundation/spark/builds/47657403
<img width="955" alt="image" src="https://github.com/apache/arrow/assets/15246973/e7ee2da9-97c0-474c-a62d-5821858e361f">

2.Some modifications have been reverted in `netty 4.1.96.Final` as follows:
<img width="884" alt="image" src="https://github.com/apache/arrow/assets/15246973/0226685a-cfa3-4b8b-b114-23ad8d027c05">
<img width="907" alt="image" src="https://github.com/apache/arrow/assets/15246973/a6ea21a0-8531-42b6-ab9d-25eaab1c7fde">
https://netty.io/news/2023/07/27/4-1-96-Final.html
https://github.com/netty/netty/pull/13510
* Closes: #36928