### PR TITLE
GH-36927: [Java][Docs] Enable Gandiva build as part of Java maven commands

### DIFF
--- a/docs/source/developers/java/building.rst
+++ b/docs/source/developers/java/building.rst
@@ -223,7 +223,6 @@ CMake
           -DCMAKE_INSTALL_PREFIX=java-dist \
           -DCMAKE_UNITY_BUILD=ON
       $ cmake --build cpp-jni --target install --config Release
-      $ export JAVA_JNI_CMAKE_ARGS="-DProtobuf_ROOT=$PWD/cpp-jni/protobuf_ep-install"
       $ cmake \
           -S java \
           -B java-jni \
@@ -234,7 +233,8 @@ CMake
           -DCMAKE_INSTALL_LIBDIR=lib/<your system's architecture> \
           -DCMAKE_INSTALL_PREFIX=java-dist \
           -DCMAKE_PREFIX_PATH=$PWD/java-dist \
-          -DProtobuf_USE_STATIC_LIBS=ON
+          -DProtobuf_USE_STATIC_LIBS=ON \
+          -DProtobuf_ROOT=$PWD/../cpp-jni/protobuf_ep-install
       $ cmake --build java-jni --target install --config Release
       $ ls -latr java-dist/lib/<your system's architecture>/*_{jni,java}.*
       |__ libarrow_dataset_jni.dylib
@@ -271,9 +271,6 @@ CMake
           -DCMAKE_INSTALL_LIBDIR=lib/x86_64 ^
           -DCMAKE_INSTALL_PREFIX=java-dist ^
           -DCMAKE_UNITY_BUILD=ON ^
-          -DPARQUET_BUILD_EXAMPLES=OFF ^
-          -DPARQUET_BUILD_EXECUTABLES=OFF ^
-          -DPARQUET_REQUIRE_ENCRYPTION=OFF ^
           -GNinja
       $ cd cpp-jni
       $ ninja install

--- a/docs/source/developers/java/building.rst
+++ b/docs/source/developers/java/building.rst
@@ -233,8 +233,8 @@ CMake
           -DCMAKE_INSTALL_LIBDIR=lib/<your system's architecture> \
           -DCMAKE_INSTALL_PREFIX=java-dist \
           -DCMAKE_PREFIX_PATH=$PWD/java-dist \
-          -DProtobuf_USE_STATIC_LIBS=ON \
-          -DProtobuf_ROOT=$PWD/../cpp-jni/protobuf_ep-install
+          -DProtobuf_ROOT=$PWD/../cpp-jni/protobuf_ep-install \
+          -DProtobuf_USE_STATIC_LIBS=ON
       $ cmake --build java-jni --target install --config Release
       $ ls -latr java-dist/lib/<your system's architecture>/*_{jni,java}.*
       |__ libarrow_dataset_jni.dylib

--- a/docs/source/developers/java/building.rst
+++ b/docs/source/developers/java/building.rst
@@ -132,11 +132,7 @@ Maven
       $ cd arrow/java
       $ export JAVA_HOME=<absolute path to your java home>
       $ java --version
-      $ mvn generate-resources \
-          -Pgenerate-libs-jni-macos-linux \
-          -DARROW_GANDIVA=ON \
-          -DARROW_JAVA_JNI_ENABLE_GANDIVA=ON \
-          -N
+      $ mvn generate-resources -Pgenerate-libs-jni-macos-linux -N
       $ ls -latr java-dist/lib/<your system's architecture>/*_{jni,java}.*
       |__ libarrow_dataset_jni.dylib
       |__ libarrow_orc_jni.dylib
@@ -227,6 +223,7 @@ CMake
           -DCMAKE_INSTALL_PREFIX=java-dist \
           -DCMAKE_UNITY_BUILD=ON
       $ cmake --build cpp-jni --target install --config Release
+      $ export JAVA_JNI_CMAKE_ARGS="-DProtobuf_ROOT=$PWD/cpp-jni/protobuf_ep-install"
       $ cmake \
           -S java \
           -B java-jni \
@@ -236,7 +233,8 @@ CMake
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_INSTALL_LIBDIR=lib/<your system's architecture> \
           -DCMAKE_INSTALL_PREFIX=java-dist \
-          -DCMAKE_PREFIX_PATH=$PWD/java-dist
+          -DCMAKE_PREFIX_PATH=$PWD/java-dist \
+          -DProtobuf_USE_STATIC_LIBS=ON
       $ cmake --build java-jni --target install --config Release
       $ ls -latr java-dist/lib/<your system's architecture>/*_{jni,java}.*
       |__ libarrow_dataset_jni.dylib
@@ -257,8 +255,9 @@ CMake
           -DARROW_DATASET=ON ^
           -DARROW_DEPENDENCY_USE_SHARED=OFF ^
           -DARROW_FILESYSTEM=ON ^
+          -DARROW_GANDIVA=OFF ^
           -DARROW_JSON=ON ^
-          -DARROW_ORC=OFF ^
+          -DARROW_ORC=ON ^
           -DARROW_PARQUET=ON ^
           -DARROW_S3=ON ^
           -DARROW_SUBSTRAIT=ON ^
@@ -272,6 +271,9 @@ CMake
           -DCMAKE_INSTALL_LIBDIR=lib/x86_64 ^
           -DCMAKE_INSTALL_PREFIX=java-dist ^
           -DCMAKE_UNITY_BUILD=ON ^
+          -DPARQUET_BUILD_EXAMPLES=OFF ^
+          -DPARQUET_BUILD_EXECUTABLES=OFF ^
+          -DPARQUET_REQUIRE_ENCRYPTION=OFF ^
           -GNinja
       $ cd cpp-jni
       $ ninja install
@@ -280,9 +282,10 @@ CMake
           -S java ^
           -B java-jni ^
           -DARROW_JAVA_JNI_ENABLE_C=OFF ^
+          -DARROW_JAVA_JNI_ENABLE_DATASET=ON ^
           -DARROW_JAVA_JNI_ENABLE_DEFAULT=ON ^
           -DARROW_JAVA_JNI_ENABLE_GANDIVA=OFF ^
-          -DARROW_JAVA_JNI_ENABLE_ORC=OFF ^
+          -DARROW_JAVA_JNI_ENABLE_ORC=ON ^
           -DBUILD_TESTING=OFF ^
           -DCMAKE_BUILD_TYPE=Release ^
           -DCMAKE_INSTALL_LIBDIR=lib/x86_64 ^
@@ -290,6 +293,7 @@ CMake
           -DCMAKE_PREFIX_PATH=$PWD/java-dist
       $ cmake --build java-jni --target install --config Release
       $ dir "java-dist/bin"
+      |__ arrow_orc_jni.dll
       |__ arrow_dataset_jni.dll
 
 Archery

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -984,13 +984,13 @@
       <properties>
         <arrow.dataset.jni.dist.dir>java-dist</arrow.dataset.jni.dist.dir>
         <cpp.dependencies.builded>false</cpp.dependencies.builded>
-        <ARROW_CSV>ON</ARROW_CSV>
+        <ARROW_DATASET>ON</ARROW_DATASET>
+        <ARROW_GANDIVA>ON</ARROW_GANDIVA>
         <ARROW_ORC>ON</ARROW_ORC>
         <ARROW_PARQUET>ON</ARROW_PARQUET>
-        <ARROW_GANDIVA>OFF</ARROW_GANDIVA>
         <ARROW_JAVA_JNI_ENABLE_C>OFF</ARROW_JAVA_JNI_ENABLE_C>
         <ARROW_JAVA_JNI_ENABLE_DATASET>ON</ARROW_JAVA_JNI_ENABLE_DATASET>
-        <ARROW_JAVA_JNI_ENABLE_GANDIVA>OFF</ARROW_JAVA_JNI_ENABLE_GANDIVA>
+        <ARROW_JAVA_JNI_ENABLE_GANDIVA>ON</ARROW_JAVA_JNI_ENABLE_GANDIVA>
         <ARROW_JAVA_JNI_ENABLE_ORC>ON</ARROW_JAVA_JNI_ENABLE_ORC>
       </properties>
       <build>
@@ -1012,8 +1012,8 @@
                     -S cpp
                     -B cpp-jni
                     -DARROW_BUILD_SHARED=OFF
-                    -DARROW_CSV=${ARROW_CSV}
-                    -DARROW_DATASET=ON
+                    -DARROW_CSV=${ARROW_DATASET}
+                    -DARROW_DATASET=${ARROW_DATASET}
                     -DARROW_DEPENDENCY_SOURCE=BUNDLED
                     -DARROW_DEPENDENCY_USE_SHARED=OFF
                     -DARROW_FILESYSTEM=ON
@@ -1070,6 +1070,8 @@
                     -DCMAKE_INSTALL_LIBDIR=lib/${os.detected.arch}
                     -DCMAKE_INSTALL_PREFIX=${arrow.dataset.jni.dist.dir}
                     -DCMAKE_PREFIX_PATH=${project.basedir}/../java-dist/lib/${os.detected.arch}/cmake
+                    -DProtobuf_USE_STATIC_LIBS=ON
+                    -DProtobuf_ROOT=${project.basedir}/../cpp-jni/protobuf_ep-install
                   </commandlineArgs>
                   <workingDirectory>../</workingDirectory>
                 </configuration>
@@ -1099,13 +1101,14 @@
       <properties>
         <arrow.dataset.jni.dist.dir>java-dist</arrow.dataset.jni.dist.dir>
         <cpp.dependencies.builded>false</cpp.dependencies.builded>
-        <ARROW_CSV>ON</ARROW_CSV>
-        <ARROW_ORC>OFF</ARROW_ORC>
+        <ARROW_DATASET>ON</ARROW_DATASET>
+        <ARROW_GANDIVA>OFF</ARROW_GANDIVA>
+        <ARROW_ORC>ON</ARROW_ORC>
         <ARROW_PARQUET>ON</ARROW_PARQUET>
         <ARROW_JAVA_JNI_ENABLE_C>OFF</ARROW_JAVA_JNI_ENABLE_C>
         <ARROW_JAVA_JNI_ENABLE_DATASET>ON</ARROW_JAVA_JNI_ENABLE_DATASET>
         <ARROW_JAVA_JNI_ENABLE_GANDIVA>OFF</ARROW_JAVA_JNI_ENABLE_GANDIVA>
-        <ARROW_JAVA_JNI_ENABLE_ORC>OFF</ARROW_JAVA_JNI_ENABLE_ORC>
+        <ARROW_JAVA_JNI_ENABLE_ORC>ON</ARROW_JAVA_JNI_ENABLE_ORC>
       </properties>
       <build>
         <plugins>
@@ -1126,10 +1129,11 @@
                     -S cpp
                     -B cpp-jni
                     -DARROW_BUILD_SHARED=OFF
-                    -DARROW_CSV=${ARROW_CSV}
-                    -DARROW_DATASET=ON
+                    -DARROW_CSV=${ARROW_DATASET}
+                    -DARROW_DATASET=${ARROW_DATASET}
                     -DARROW_DEPENDENCY_USE_SHARED=OFF
                     -DARROW_FILESYSTEM=ON
+                    -DARROW_GANDIVA=${ARROW_GANDIVA}
                     -DARROW_JSON=${ARROW_DATASET}
                     -DARROW_ORC=${ARROW_ORC}
                     -DARROW_PARQUET=${ARROW_PARQUET}
@@ -1145,6 +1149,9 @@
                     -DCMAKE_INSTALL_LIBDIR=lib/${os.detected.arch}
                     -DCMAKE_INSTALL_PREFIX=java-dist
                     -DCMAKE_UNITY_BUILD=ON
+                    -DPARQUET_BUILD_EXAMPLES=OFF
+                    -DPARQUET_BUILD_EXECUTABLES=OFF
+                    -DPARQUET_REQUIRE_ENCRYPTION=OFF
                     -GNinja
                   </commandlineArgs>
                   <workingDirectory>../</workingDirectory>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -1149,9 +1149,6 @@
                     -DCMAKE_INSTALL_LIBDIR=lib/${os.detected.arch}
                     -DCMAKE_INSTALL_PREFIX=java-dist
                     -DCMAKE_UNITY_BUILD=ON
-                    -DPARQUET_BUILD_EXAMPLES=OFF
-                    -DPARQUET_BUILD_EXECUTABLES=OFF
-                    -DPARQUET_REQUIRE_ENCRYPTION=OFF
                     -GNinja
                   </commandlineArgs>
                   <workingDirectory>../</workingDirectory>


### PR DESCRIPTION
### Rationale for this change

To close: https://github.com/apache/arrow/issues/36927

### What changes are included in this PR?

- Enable MacOS Gandiva build as part of Java maven commands
- Enable Windows ORC build as part of Java maven commands

### Are these changes tested?

Yes:
- Gandiva: mvn generate-resources -Pgenerate-libs-jni-macos-linux -N
- ORC: mvn generate-resources -Pgenerate-libs-jni-windows -N

### Are there any user-facing changes?

No
* Closes: apache/arrow#36927
* GitHub Issue: #36927