### PR TITLE
GH-36931: [C++] Add cumulative_mean function

### DIFF
--- a/cpp/src/arrow/compute/api_vector.cc
+++ b/cpp/src/arrow/compute/api_vector.cc
@@ -417,5 +417,10 @@ Result<Datum> CumulativeMin(const Datum& values, const CumulativeOptions& option
   return CallFunction("cumulative_min", {Datum(values)}, &options, ctx);
 }
 
+Result<Datum> CumulativeMean(const Datum& values, const CumulativeOptions& options,
+                             ExecContext* ctx) {
+  return CallFunction("cumulative_mean", {Datum(values)}, &options, ctx);
+}
+
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/api_vector.h
+++ b/cpp/src/arrow/compute/api_vector.h
@@ -226,6 +226,7 @@ class ARROW_EXPORT CumulativeOptions : public FunctionOptions {
   /// - prod: 1
   /// - min: maximum of the input type
   /// - max: minimum of the input type
+  /// - mean: start is ignored because it has no meaning for mean
   std::optional<std::shared_ptr<Scalar>> start;
 
   /// If true, nulls in the input are ignored and produce a corresponding null output.
@@ -664,7 +665,7 @@ Result<Datum> CumulativeMin(
 /// \brief Compute the cumulative mean of an array-like object
 ///
 /// \param[in] values array-like input
-/// \param[in] options configures cumulative mean behavior
+/// \param[in] options configures cumulative mean behavior, `start` is ignored
 /// \param[in] ctx the function execution context, optional
 ARROW_EXPORT
 Result<Datum> CumulativeMean(

--- a/cpp/src/arrow/compute/api_vector.h
+++ b/cpp/src/arrow/compute/api_vector.h
@@ -661,6 +661,16 @@ Result<Datum> CumulativeMin(
     const Datum& values, const CumulativeOptions& options = CumulativeOptions::Defaults(),
     ExecContext* ctx = NULLPTR);
 
+/// \brief Compute the cumulative mean of an array-like object
+///
+/// \param[in] values array-like input
+/// \param[in] options configures cumulative mean behavior
+/// \param[in] ctx the function execution context, optional
+ARROW_EXPORT
+Result<Datum> CumulativeMean(
+    const Datum& values, const CumulativeOptions& options = CumulativeOptions::Defaults(),
+    ExecContext* ctx = NULLPTR);
+
 /// \brief Return the first order difference of an array.
 ///
 /// Computes the first order difference of an array, i.e.

--- a/cpp/src/arrow/compute/kernels/vector_cumulative_ops.cc
+++ b/cpp/src/arrow/compute/kernels/vector_cumulative_ops.cc
@@ -261,7 +261,6 @@ const FunctionDoc cumulative_mean_doc{
      "ignored."),
     {"values"},
     "CumulativeOptions"};
-}  // namespace
 
 // Kernel factory for simple arithmetic operations.
 // Op is a compute kernel representing any binary associative operation with
@@ -370,6 +369,7 @@ void MakeVectorCumulativeStatefulFunction(FunctionRegistry* registry,
 
   DCHECK_OK(registry->AddFunction(std::move(func)));
 }
+}  // namespace
 
 void RegisterVectorCumulativeSum(FunctionRegistry* registry) {
   MakeVectorCumulativeBinaryOpFunction<Add, CumulativeOptions>(registry, "cumulative_sum",

--- a/cpp/src/arrow/compute/kernels/vector_cumulative_ops.cc
+++ b/cpp/src/arrow/compute/kernels/vector_cumulative_ops.cc
@@ -72,9 +72,7 @@ struct CumulativeBinaryOp {
 
   OutValue current_value;
 
-  explicit CumulativeBinaryOp() {
-    current_value = Identity<Op>::template value<OutValue>;
-  }
+  CumulativeBinaryOp() { current_value = Identity<Op>::template value<OutValue>; }
 
   explicit CumulativeBinaryOp(const std::shared_ptr<Scalar> start) {
     current_value = UnboxScalar<OutType>::Unbox(*start);
@@ -94,10 +92,10 @@ struct CumulativeMean {
   int64_t count = 0;
   double sum = 0;
 
-  explicit CumulativeMean() = default;
+  CumulativeMean() = default;
 
   // start value is ignored for CumulativeMean
-  explicit CumulativeMean(const std::shared_ptr<Scalar> start){};
+  explicit CumulativeMean(const std::shared_ptr<Scalar> start) {}
 
   double Call(KernelContext* ctx, ArgValue arg, Status* st) {
     sum += static_cast<double>(arg);

--- a/cpp/src/arrow/compute/kernels/vector_cumulative_ops_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_cumulative_ops_test.cc
@@ -37,7 +37,7 @@
 namespace arrow {
 namespace compute {
 
-constexpr static std::array<const char*, 7> kCumulativeFunctionNames{
+static const std::vector<std::string> kCumulativeFunctionNames{
     "cumulative_sum",          "cumulative_sum_checked", "cumulative_prod",
     "cumulative_prod_checked", "cumulative_min",         "cumulative_max",
     "cumulative_mean"};

--- a/cpp/src/arrow/compute/kernels/vector_cumulative_ops_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_cumulative_ops_test.cc
@@ -37,19 +37,23 @@
 namespace arrow {
 namespace compute {
 
-constexpr static std::array<const char*, 6> kCumulativeFunctionNames{
+constexpr static std::array<const char*, 7> kCumulativeFunctionNames{
     "cumulative_sum",          "cumulative_sum_checked", "cumulative_prod",
-    "cumulative_prod_checked", "cumulative_min",         "cumulative_max"};
+    "cumulative_prod_checked", "cumulative_min",         "cumulative_max",
+    "cumulative_mean"};
 
 TEST(TestCumulative, Empty) {
   for (auto function : kCumulativeFunctionNames) {
     CumulativeOptions options;
     for (auto ty : NumericTypes()) {
+      auto return_ty = std::string(function) == "cumulative_mean" ? float64() : ty;
       auto empty_arr = ArrayFromJSON(ty, "[]");
+      auto expected_arr = ArrayFromJSON(return_ty, "[]");
       auto empty_chunked = ChunkedArrayFromJSON(ty, {"[]"});
-      CheckVectorUnary(function, empty_arr, empty_arr, &options);
+      auto expected_chunked = ChunkedArrayFromJSON(return_ty, {"[]"});
+      CheckVectorUnary(function, empty_arr, expected_arr, &options);
 
-      CheckVectorUnary(function, empty_chunked, empty_chunked, &options);
+      CheckVectorUnary(function, empty_chunked, expected_chunked, &options);
     }
   }
 }
@@ -58,14 +62,19 @@ TEST(TestCumulative, AllNulls) {
   for (auto function : kCumulativeFunctionNames) {
     CumulativeOptions options;
     for (auto ty : NumericTypes()) {
+      auto return_ty = std::string(function) == "cumulative_mean" ? float64() : ty;
       auto nulls_arr = ArrayFromJSON(ty, "[null, null, null]");
+      auto expected_arr = ArrayFromJSON(return_ty, "[null, null, null]");
       auto nulls_one_chunk = ChunkedArrayFromJSON(ty, {"[null, null, null]"});
+      auto expected_one_chunk = ChunkedArrayFromJSON(return_ty, {"[null, null, null]"});
       auto nulls_three_chunks = ChunkedArrayFromJSON(ty, {"[null]", "[null]", "[null]"});
-      CheckVectorUnary(function, nulls_arr, nulls_arr, &options);
+      auto expected_three_chunks =
+          ChunkedArrayFromJSON(return_ty, {"[null]", "[null]", "[null]"});
+      CheckVectorUnary(function, nulls_arr, expected_arr, &options);
 
-      CheckVectorUnary(function, nulls_one_chunk, nulls_one_chunk, &options);
+      CheckVectorUnary(function, nulls_one_chunk, expected_one_chunk, &options);
 
-      CheckVectorUnary(function, nulls_three_chunks, nulls_one_chunk, &options);
+      CheckVectorUnary(function, nulls_three_chunks, expected_one_chunk, &options);
     }
   }
 }
@@ -810,6 +819,72 @@ TEST(TestCumulativeMin, NoStartDoSkip) {
   }
 }
 
+TEST(TestCumulativeMean, NoSkip) {
+  CumulativeOptions options(false);
+  for (auto ty : NumericTypes()) {
+    CheckVectorUnary("cumulative_mean", ArrayFromJSON(ty, "[5, 6, 4, 2, 3, 1]"),
+                     ArrayFromJSON(float64(), "[5, 5.5, 5, 4.25, 4, 3.5]"), &options);
+
+    CheckVectorUnary("cumulative_mean", ArrayFromJSON(ty, "[5, 6, null, 2, null, 1]"),
+                     ArrayFromJSON(float64(), "[5, 5.5, null, null, null, null]"),
+                     &options);
+
+    CheckVectorUnary("cumulative_mean", ArrayFromJSON(ty, "[null, 6, null, 2, null, 1]"),
+                     ArrayFromJSON(float64(), "[null, null, null, null, null, null]"),
+                     &options);
+
+    CheckVectorUnary(
+        "cumulative_mean", ChunkedArrayFromJSON(ty, {"[5, 6, 4]", "[2, 3, 1]"}),
+        ChunkedArrayFromJSON(float64(), {"[5, 5.5, 5, 4.25, 4, 3.5]"}), &options);
+
+    CheckVectorUnary(
+        "cumulative_mean", ChunkedArrayFromJSON(ty, {"[5, 6, null]", "[2, null, 1]"}),
+        ChunkedArrayFromJSON(float64(), {"[5, 5.5, null, null, null, null]"}), &options);
+
+    CheckVectorUnary(
+        "cumulative_mean", ChunkedArrayFromJSON(ty, {"[null, 6, null]", "[2, null, 1]"}),
+        ChunkedArrayFromJSON(float64(), {"[null, null, null, null, null, null]"}),
+        &options);
+  }
+}
+
+TEST(TestCumulativeMean, DoSkip) {
+  CumulativeOptions options(true);
+  for (auto ty : NumericTypes()) {
+    CheckVectorUnary("cumulative_mean", ArrayFromJSON(ty, "[5, 6, 4, 2, 3, 1]"),
+                     ArrayFromJSON(float64(), "[5, 5.5, 5, 4.25, 4, 3.5]"), &options);
+
+    CheckVectorUnary(
+        "cumulative_mean", ArrayFromJSON(ty, "[5, 6, null, 2, null, 1]"),
+        ArrayFromJSON(float64(), "[5, 5.5, null, 4.333333333333333, null, 3.5]"),
+        &options);
+
+    CheckVectorUnary("cumulative_mean", ArrayFromJSON(ty, "[null, 6, null, 2, null, 1]"),
+                     ArrayFromJSON(float64(), "[null, 6, null, 4, null, 3]"), &options);
+
+    CheckVectorUnary(
+        "cumulative_mean", ChunkedArrayFromJSON(ty, {"[5, 6, 4]", "[2, 3, 1]"}),
+        ChunkedArrayFromJSON(float64(), {"[5, 5.5, 5, 4.25, 4, 3.5]"}), &options);
+
+    CheckVectorUnary(
+        "cumulative_mean", ChunkedArrayFromJSON(ty, {"[5, 6, null]", "[2, null, 1]"}),
+        ChunkedArrayFromJSON(float64(), {"[5, 5.5, null, 4.333333333333333, null, 3.5]"}),
+        &options);
+
+    CheckVectorUnary(
+        "cumulative_mean", ChunkedArrayFromJSON(ty, {"[null, 6, null]", "[2, null, 1]"}),
+        ChunkedArrayFromJSON(float64(), {"[null, 6, null, 4, null, 3]"}), &options);
+  }
+}
+
+TEST(TestCumulativeMean, StartValue) {
+  CumulativeOptions options(3, true);  // start should be ignored
+  for (auto ty : NumericTypes()) {
+    CheckVectorUnary("cumulative_mean", ArrayFromJSON(ty, "[5, 6, 4, 2, 3, 1]"),
+                     ArrayFromJSON(float64(), "[5, 5.5, 5, 4.25, 4, 3.5]"), &options);
+  }
+}
+
 TEST(TestCumulativeSum, ConvenienceFunctionCheckOverflow) {
   ASSERT_ARRAYS_EQUAL(*CumulativeSum(ArrayFromJSON(int8(), "[127, 1]"),
                                      CumulativeOptions::Defaults(), false)
@@ -846,6 +921,13 @@ TEST(TestCumulativeMin, ConvenienceFunction) {
       *ArrayFromJSON(int8(), "[-1, -2, -3]"));
 }
 
+TEST(TestCumulativeMean, ConvenienceFunction) {
+  ASSERT_ARRAYS_EQUAL(*CumulativeMean(ArrayFromJSON(int8(), "[-1, -2, -3]"),
+                                      CumulativeOptions::Defaults())
+                           ->make_array(),
+                      *ArrayFromJSON(float64(), "[-1, -1.5, -2]"));
+}
+
 TEST(TestCumulative, NaN) {
   // addition with NaN is always NaN
   CheckVectorUnary("cumulative_sum", ArrayFromJSON(float64(), "[1, 2, NaN, 4, 5]"),
@@ -862,6 +944,10 @@ TEST(TestCumulative, NaN) {
   // min with NaN is always ignored because Nan < a always returns false
   CheckVectorUnary("cumulative_min", ArrayFromJSON(float64(), "[5, 4, NaN, 2, 1]"),
                    ArrayFromJSON(float64(), "[5, 4, 4, 2, 1]"));
+
+  // mean with NaN is always Nan
+  CheckVectorUnary("cumulative_mean", ArrayFromJSON(float64(), "[5, 4, NaN, 2, 1]"),
+                   ArrayFromJSON(float64(), "[5, 4.5, NaN, NaN, NaN]"));
 }
 }  // namespace compute
 }  // namespace arrow

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -1621,21 +1621,23 @@ do not detect overflow. They are alsoavailable in an overflow-checking variant,
 suffixed ``_checked``, which returns an ``Invalid`` :class:`Status` when 
 overflow is detected.
 
-+------------------------+-------+-------------+-------------+--------------------------------+-------+
-| Function name           | Arity | Input types | Output type | Options class                  | Notes |
-+=========================+=======+=============+=============+================================+=======+
-| cumulative_sum          | Unary | Numeric     | Numeric     | :struct:`CumulativeOptions`    | \(1)  |
-+-------------------------+-------+-------------+-------------+--------------------------------+-------+
-| cumulative_sum_checked  | Unary | Numeric     | Numeric     | :struct:`CumulativeOptions`    | \(1)  |
-+-------------------------+-------+-------------+-------------+--------------------------------+-------+
-| cumulative_prod         | Unary | Numeric     | Numeric     | :struct:`CumulativeOptions`    | \(1)  |
-+-------------------------+-------+-------------+-------------+--------------------------------+-------+
-| cumulative_prod_checked | Unary | Numeric     | Numeric     | :struct:`CumulativeOptions`    | \(1)  |
-+-------------------------+-------+-------------+-------------+--------------------------------+-------+
-| cumulative_max          | Unary | Numeric     | Numeric     | :struct:`CumulativeOptions`    | \(1)  |
-+-------------------------+-------+-------------+-------------+--------------------------------+-------+
-| cumulative_min          | Unary | Numeric     | Numeric     | :struct:`CumulativeOptions`    | \(1)  |
-+-------------------------+-------+-------------+-------------+--------------------------------+-------+
++-------------------------+-------+-------------+-------------+--------------------------------+-----------+
+| Function name           | Arity | Input types | Output type | Options class                  | Notes     |
++=========================+=======+=============+=============+================================+===========+
+| cumulative_sum          | Unary | Numeric     | Numeric     | :struct:`CumulativeOptions`    | \(1)      |
++-------------------------+-------+-------------+-------------+--------------------------------+-----------+
+| cumulative_sum_checked  | Unary | Numeric     | Numeric     | :struct:`CumulativeOptions`    | \(1)      |
++-------------------------+-------+-------------+-------------+--------------------------------+-----------+
+| cumulative_prod         | Unary | Numeric     | Numeric     | :struct:`CumulativeOptions`    | \(1)      |
++-------------------------+-------+-------------+-------------+--------------------------------+-----------+
+| cumulative_prod_checked | Unary | Numeric     | Numeric     | :struct:`CumulativeOptions`    | \(1)      |
++-------------------------+-------+-------------+-------------+--------------------------------+-----------+
+| cumulative_max          | Unary | Numeric     | Numeric     | :struct:`CumulativeOptions`    | \(1)      |
++-------------------------+-------+-------------+-------------+--------------------------------+-----------+
+| cumulative_min          | Unary | Numeric     | Numeric     | :struct:`CumulativeOptions`    | \(1)      |
++-------------------------+-------+-------------+-------------+--------------------------------+-----------+
+| cumulative_mean         | Unary | Numeric     | Double      | :struct:`CumulativeOptions`    | \(1) \(2) |
++-------------------------+-------+-------------+-------------+--------------------------------+-----------+
 
 * \(1) CumulativeOptions has two optional parameters. The first parameter
   :member:`CumulativeOptions::start` is a starting value for the running
@@ -1646,6 +1648,8 @@ overflow is detected.
   false (the default), the first encountered null is propagated. When set to
   true, each null in the input produces a corresponding null in the output and
   doesn't affect the accumulation forward.
+
+* \(2) :member:`CumulativeOptions::start` is ignored.
 
 Associative transforms
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -1636,7 +1636,7 @@ overflow is detected.
 +-------------------------+-------+-------------+-------------+--------------------------------+-----------+
 | cumulative_min          | Unary | Numeric     | Numeric     | :struct:`CumulativeOptions`    | \(1)      |
 +-------------------------+-------+-------------+-------------+--------------------------------+-----------+
-| cumulative_mean         | Unary | Numeric     | Double      | :struct:`CumulativeOptions`    | \(1) \(2) |
+| cumulative_mean         | Unary | Numeric     | Float64     | :struct:`CumulativeOptions`    | \(1) \(2) |
 +-------------------------+-------+-------------+-------------+--------------------------------+-----------+
 
 * \(1) CumulativeOptions has two optional parameters. The first parameter


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Add `cumulative_mean` function

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Implement `cumulative_mean` function. The current cumulative_* kernel generator can only be based on a simple binary arithmetic op and the state can only be a single value. I refactored it to using of a generic state such that it can handle complex operations such as `mean`, `median`, `var` etc.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes

### Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #36931