### PR TITLE
GH-36674: [C++] Use anonymous namespace in arrow/ipc/reader.cc

### DIFF
--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -109,8 +109,6 @@ Status InvalidMessageType(MessageType expected, MessageType actual) {
     }                                                                   \
   } while (0)
 
-}  // namespace
-
 // ----------------------------------------------------------------------
 // Record batch read path
 
@@ -634,34 +632,13 @@ Status GetCompressionExperimental(const flatbuf::Message* message,
   return Status::OK();
 }
 
-static Status ReadContiguousPayload(io::InputStream* file,
+Status ReadContiguousPayload(io::InputStream* file,
                                     std::unique_ptr<Message>* message) {
   ARROW_ASSIGN_OR_RAISE(*message, ReadMessage(file));
   if (*message == nullptr) {
     return Status::Invalid("Unable to read metadata at offset");
   }
   return Status::OK();
-}
-
-Result<std::shared_ptr<RecordBatch>> ReadRecordBatch(
-    const std::shared_ptr<Schema>& schema, const DictionaryMemo* dictionary_memo,
-    const IpcReadOptions& options, io::InputStream* file) {
-  std::unique_ptr<Message> message;
-  RETURN_NOT_OK(ReadContiguousPayload(file, &message));
-  CHECK_HAS_BODY(*message);
-  ARROW_ASSIGN_OR_RAISE(auto reader, Buffer::GetReader(message->body()));
-  return ReadRecordBatch(*message->metadata(), schema, dictionary_memo, options,
-                         reader.get());
-}
-
-Result<std::shared_ptr<RecordBatch>> ReadRecordBatch(
-    const Message& message, const std::shared_ptr<Schema>& schema,
-    const DictionaryMemo* dictionary_memo, const IpcReadOptions& options) {
-  CHECK_MESSAGE_TYPE(MessageType::RECORD_BATCH, message.type());
-  CHECK_HAS_BODY(message);
-  ARROW_ASSIGN_OR_RAISE(auto reader, Buffer::GetReader(message.body()));
-  return ReadRecordBatch(*message.metadata(), schema, dictionary_memo, options,
-                         reader.get());
 }
 
 Result<RecordBatchWithMetadata> ReadRecordBatchInternal(
@@ -764,22 +741,6 @@ Status UnpackSchemaMessage(const Message& message, const IpcReadOptions& options
                              out_schema, field_inclusion_mask, swap_endian);
 }
 
-Result<std::shared_ptr<RecordBatch>> ReadRecordBatch(
-    const Buffer& metadata, const std::shared_ptr<Schema>& schema,
-    const DictionaryMemo* dictionary_memo, const IpcReadOptions& options,
-    io::RandomAccessFile* file) {
-  std::shared_ptr<Schema> out_schema;
-  // Empty means do not use
-  std::vector<bool> inclusion_mask;
-  IpcReadContext context(const_cast<DictionaryMemo*>(dictionary_memo), options, false);
-  RETURN_NOT_OK(GetInclusionMaskAndOutSchema(schema, context.options.included_fields,
-                                             &inclusion_mask, &out_schema));
-  ARROW_ASSIGN_OR_RAISE(
-      auto batch_and_custom_metadata,
-      ReadRecordBatchInternal(metadata, schema, inclusion_mask, context, file));
-  return batch_and_custom_metadata.batch;
-}
-
 Status ReadDictionary(const Buffer& metadata, const IpcReadContext& context,
                       DictionaryKind* kind, io::RandomAccessFile* file) {
   const flatbuf::Message* message = nullptr;
@@ -849,6 +810,45 @@ Status ReadDictionary(const Message& message, const IpcReadContext& context,
   CHECK_HAS_BODY(message);
   ARROW_ASSIGN_OR_RAISE(auto reader, Buffer::GetReader(message.body()));
   return ReadDictionary(*message.metadata(), context, kind, reader.get());
+}
+
+}  // namespace
+
+Result<std::shared_ptr<RecordBatch>> ReadRecordBatch(
+    const Buffer& metadata, const std::shared_ptr<Schema>& schema,
+    const DictionaryMemo* dictionary_memo, const IpcReadOptions& options,
+    io::RandomAccessFile* file) {
+    std::shared_ptr<Schema> out_schema;
+    // Empty means do not use
+    std::vector<bool> inclusion_mask;
+    IpcReadContext context(const_cast<DictionaryMemo*>(dictionary_memo), options, false);
+    RETURN_NOT_OK(GetInclusionMaskAndOutSchema(schema, context.options.included_fields,
+                                               &inclusion_mask, &out_schema));
+    ARROW_ASSIGN_OR_RAISE(
+        auto batch_and_custom_metadata,
+        ReadRecordBatchInternal(metadata, schema, inclusion_mask, context, file));
+    return batch_and_custom_metadata.batch;
+}
+
+Result<std::shared_ptr<RecordBatch>> ReadRecordBatch(
+    const std::shared_ptr<Schema>& schema, const DictionaryMemo* dictionary_memo,
+    const IpcReadOptions& options, io::InputStream* file) {
+    std::unique_ptr<Message> message;
+    RETURN_NOT_OK(ReadContiguousPayload(file, &message));
+    CHECK_HAS_BODY(*message);
+    ARROW_ASSIGN_OR_RAISE(auto reader, Buffer::GetReader(message->body()));
+    return ReadRecordBatch(*message->metadata(), schema, dictionary_memo, options,
+                           reader.get());
+}
+
+Result<std::shared_ptr<RecordBatch>> ReadRecordBatch(
+    const Message& message, const std::shared_ptr<Schema>& schema,
+    const DictionaryMemo* dictionary_memo, const IpcReadOptions& options) {
+    CHECK_MESSAGE_TYPE(MessageType::RECORD_BATCH, message.type());
+    CHECK_HAS_BODY(message);
+    ARROW_ASSIGN_OR_RAISE(auto reader, Buffer::GetReader(message.body()));
+    return ReadRecordBatch(*message.metadata(), schema, dictionary_memo, options,
+                           reader.get());
 }
 
 // Streaming format decoder

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -632,8 +632,7 @@ Status GetCompressionExperimental(const flatbuf::Message* message,
   return Status::OK();
 }
 
-Status ReadContiguousPayload(io::InputStream* file,
-                                    std::unique_ptr<Message>* message) {
+Status ReadContiguousPayload(io::InputStream* file, std::unique_ptr<Message>* message) {
   ARROW_ASSIGN_OR_RAISE(*message, ReadMessage(file));
   if (*message == nullptr) {
     return Status::Invalid("Unable to read metadata at offset");
@@ -818,37 +817,37 @@ Result<std::shared_ptr<RecordBatch>> ReadRecordBatch(
     const Buffer& metadata, const std::shared_ptr<Schema>& schema,
     const DictionaryMemo* dictionary_memo, const IpcReadOptions& options,
     io::RandomAccessFile* file) {
-    std::shared_ptr<Schema> out_schema;
-    // Empty means do not use
-    std::vector<bool> inclusion_mask;
-    IpcReadContext context(const_cast<DictionaryMemo*>(dictionary_memo), options, false);
-    RETURN_NOT_OK(GetInclusionMaskAndOutSchema(schema, context.options.included_fields,
-                                               &inclusion_mask, &out_schema));
-    ARROW_ASSIGN_OR_RAISE(
-        auto batch_and_custom_metadata,
-        ReadRecordBatchInternal(metadata, schema, inclusion_mask, context, file));
-    return batch_and_custom_metadata.batch;
+  std::shared_ptr<Schema> out_schema;
+  // Empty means do not use
+  std::vector<bool> inclusion_mask;
+  IpcReadContext context(const_cast<DictionaryMemo*>(dictionary_memo), options, false);
+  RETURN_NOT_OK(GetInclusionMaskAndOutSchema(schema, context.options.included_fields,
+                                             &inclusion_mask, &out_schema));
+  ARROW_ASSIGN_OR_RAISE(
+      auto batch_and_custom_metadata,
+      ReadRecordBatchInternal(metadata, schema, inclusion_mask, context, file));
+  return batch_and_custom_metadata.batch;
 }
 
 Result<std::shared_ptr<RecordBatch>> ReadRecordBatch(
     const std::shared_ptr<Schema>& schema, const DictionaryMemo* dictionary_memo,
     const IpcReadOptions& options, io::InputStream* file) {
-    std::unique_ptr<Message> message;
-    RETURN_NOT_OK(ReadContiguousPayload(file, &message));
-    CHECK_HAS_BODY(*message);
-    ARROW_ASSIGN_OR_RAISE(auto reader, Buffer::GetReader(message->body()));
-    return ReadRecordBatch(*message->metadata(), schema, dictionary_memo, options,
-                           reader.get());
+  std::unique_ptr<Message> message;
+  RETURN_NOT_OK(ReadContiguousPayload(file, &message));
+  CHECK_HAS_BODY(*message);
+  ARROW_ASSIGN_OR_RAISE(auto reader, Buffer::GetReader(message->body()));
+  return ReadRecordBatch(*message->metadata(), schema, dictionary_memo, options,
+                         reader.get());
 }
 
 Result<std::shared_ptr<RecordBatch>> ReadRecordBatch(
     const Message& message, const std::shared_ptr<Schema>& schema,
     const DictionaryMemo* dictionary_memo, const IpcReadOptions& options) {
-    CHECK_MESSAGE_TYPE(MessageType::RECORD_BATCH, message.type());
-    CHECK_HAS_BODY(message);
-    ARROW_ASSIGN_OR_RAISE(auto reader, Buffer::GetReader(message.body()));
-    return ReadRecordBatch(*message.metadata(), schema, dictionary_memo, options,
-                           reader.get());
+  CHECK_MESSAGE_TYPE(MessageType::RECORD_BATCH, message.type());
+  CHECK_HAS_BODY(message);
+  ARROW_ASSIGN_OR_RAISE(auto reader, Buffer::GetReader(message.body()));
+  return ReadRecordBatch(*message.metadata(), schema, dictionary_memo, options,
+                         reader.get());
 }
 
 // Streaming format decoder


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

The following types and functions should be in file scope:

IpcReadConext, BatchDataReadRequest, ArrayLoader,
DecompressBuffer(s), LoadRecordBatch*, GetCompression*,
ReadRecordBatchInternal,
GetInclusionMaskAndOutSchmea, UnpackSchemaMessage,
ReadDictionary, AsyncRecordBatchStreamReaderImpl.

### What changes are included in this PR?

Use anonymous namespace around the aforementioned definitions.

### Are these changes tested?

No

### Are there any user-facing changes?

No

* Closes: #36674