### PR TITLE
GH-36941: [CI][Docs] Use system Protobuf

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -64,7 +64,7 @@ groups:
     - r-binary-packages
     - ubuntu-*
     - wheel-*
-    - test-ubuntu-default-docs
+    - test-ubuntu-*-docs
 
 {############################# Testing tasks #################################}
 

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1498,10 +1498,12 @@ tasks:
       image: debian-go
   {% endfor %}
 
-  test-ubuntu-default-docs:
+  test-ubuntu-22.04-docs:
     ci: github
     template: docs/github.linux.yml
     params:
+      env:
+        UBUNTU: 22.04
       pr_number: Unset
       flags: "-v $PWD/build/:/build/"
       image: ubuntu-docs
@@ -1625,6 +1627,8 @@ tasks:
     ci: github
     template: docs/github.linux.yml
     params:
+      env:
+        UBUNTU: 22.04
       pr_number: Unset
       flags: "-v $PWD/build/:/build/"
       image: ubuntu-docs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1745,7 +1745,6 @@ services:
       BUILD_DOCS_JS: "ON"
       BUILD_DOCS_PYTHON: "ON"
       BUILD_DOCS_R: "ON"
-      Protobuf_SOURCE: "BUNDLED"  # Need Protobuf >= 3.15
     volumes: *ubuntu-volumes
     command: &docs-command >
       /bin/bash -c "


### PR DESCRIPTION
### Rationale for this change

We can reduce disk usage by using system Protobuf and gRPC.

### What changes are included in this PR?

Use system Protobuf.

We can use Protobuf 3.12.0 or later by #35962.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #36941