### PR TITLE
GH-36947: [CI] Move free up disk space to the Jinja macros to be able to reuse it on docs job

### DIFF
--- a/dev/tasks/docs/github.linux.yml
+++ b/dev/tasks/docs/github.linux.yml
@@ -26,6 +26,7 @@ jobs:
 {{ macros.github_set_env(env) }}
     steps:
       {{ macros.github_checkout_arrow(fetch_depth=fetch_depth|default(1))|indent }}
+      {{ macros.github_free_space()|indent }}
       {{ macros.github_install_archery()|indent }}
 
       - name: Execute Docker Build

--- a/dev/tasks/linux-packages/github.linux.yml
+++ b/dev/tasks/linux-packages/github.linux.yml
@@ -32,56 +32,8 @@ jobs:
     steps:
       {{ macros.github_checkout_arrow()|indent }}
       {{ macros.github_login_dockerhub()|indent }}
+      {{ macros.github_free_space()|indent }}
 
-      - name: Free up disk space
-        if: |
-          env.ARCHITECTURE == 'amd64'
-        run: |
-          df -h
-          echo "::group::/usr/local/*"
-          du -hsc /usr/local/*
-          echo "::endgroup::"
-          echo "::group::/usr/local/bin/*"
-          du -hsc /usr/local/bin/*
-          echo "::endgroup::"
-          # ~1GB (From 1.2GB to 214MB)
-          sudo rm -rf \
-            /usr/local/bin/aliyun \
-            /usr/local/bin/azcopy \
-            /usr/local/bin/bicep \
-            /usr/local/bin/cmake-gui \
-            /usr/local/bin/cpack \
-            /usr/local/bin/helm \
-            /usr/local/bin/hub \
-            /usr/local/bin/kubectl \
-            /usr/local/bin/minikube \
-            /usr/local/bin/node \
-            /usr/local/bin/packer \
-            /usr/local/bin/pulumi* \
-            /usr/local/bin/stack \
-            /usr/local/bin/terraform || :
-          echo "::group::/usr/local/share/*"
-          du -hsc /usr/local/share/*
-          echo "::endgroup::"
-          # 1.3GB
-          sudo rm -rf /usr/local/share/powershell || :
-          echo "::group::/opt/*"
-          du -hsc /opt/*
-          echo "::endgroup::"
-          echo "::group::/opt/hostedtoolcache/*"
-          du -hsc /opt/hostedtoolcache/*
-          echo "::endgroup::"
-          # 5.3GB
-          sudo rm -rf /opt/hostedtoolcache/CodeQL || :
-          # 1.4GB
-          sudo rm -rf /opt/hostedtoolcache/go || :
-          # 489MB
-          sudo rm -rf /opt/hostedtoolcache/PyPy || :
-          # 1.2GB
-          sudo rm -rf /opt/hostedtoolcache/Python || :
-          # 376MB
-          sudo rm -rf /opt/hostedtoolcache/node || :
-          df -h
       - name: Set up Ruby
         run: |
           sudo apt update

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -117,10 +117,12 @@ on:
       sudo rm -rf /opt/hostedtoolcache/go || :
       # 489MB
       sudo rm -rf /opt/hostedtoolcache/PyPy || :
-      # 1.2GB
-      sudo rm -rf /opt/hostedtoolcache/Python || :
       # 376MB
       sudo rm -rf /opt/hostedtoolcache/node || :
+      # Remove Web browser packages
+      sudo apt-get purge -y -f firefox \
+              google-chrome-stable \
+              microsoft-edge-stable
       df -h
 {% endmacro %}
 

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -72,6 +72,58 @@ on:
     run: pip install -e arrow/dev/archery[all]
 {% endmacro %}
 
+{%- macro github_free_space() -%}
+  - name: Free up disk space
+    if: runner.os == 'Linux' && runner.arch == 'X64'
+    shell: bash
+    run: |
+      df -h
+      echo "::group::/usr/local/*"
+      du -hsc /usr/local/*
+      echo "::endgroup::"
+      echo "::group::/usr/local/bin/*"
+      du -hsc /usr/local/bin/*
+      echo "::endgroup::"
+      # ~1GB (From 1.2GB to 214MB)
+      sudo rm -rf \
+        /usr/local/bin/aliyun \
+        /usr/local/bin/azcopy \
+        /usr/local/bin/bicep \
+        /usr/local/bin/cmake-gui \
+        /usr/local/bin/cpack \
+        /usr/local/bin/helm \
+        /usr/local/bin/hub \
+        /usr/local/bin/kubectl \
+        /usr/local/bin/minikube \
+        /usr/local/bin/node \
+        /usr/local/bin/packer \
+        /usr/local/bin/pulumi* \
+        /usr/local/bin/stack \
+        /usr/local/bin/terraform || :
+      echo "::group::/usr/local/share/*"
+      du -hsc /usr/local/share/*
+      echo "::endgroup::"
+      # 1.3GB
+      sudo rm -rf /usr/local/share/powershell || :
+      echo "::group::/opt/*"
+      du -hsc /opt/*
+      echo "::endgroup::"
+      echo "::group::/opt/hostedtoolcache/*"
+      du -hsc /opt/hostedtoolcache/*
+      echo "::endgroup::"
+      # 5.3GB
+      sudo rm -rf /opt/hostedtoolcache/CodeQL || :
+      # 1.4GB
+      sudo rm -rf /opt/hostedtoolcache/go || :
+      # 489MB
+      sudo rm -rf /opt/hostedtoolcache/PyPy || :
+      # 1.2GB
+      sudo rm -rf /opt/hostedtoolcache/Python || :
+      # 376MB
+      sudo rm -rf /opt/hostedtoolcache/node || :
+      df -h
+{% endmacro %}
+
 {%- macro github_upload_releases(pattern) -%}
   - name: Set up Python by actions/setup-python
     if: runner.arch == 'X64'


### PR DESCRIPTION
### Rationale for this change

Try to get rid of some failures on docs generation on release and reuse existing code.

### What changes are included in this PR?

Move step to a macro to be able to reuse it

### Are these changes tested?

Archery tasks

### Are there any user-facing changes?

No
* Closes: #36947