### PR TITLE
GH-36882: [C++][Parquet] Default RLE for bool values in the parquet version 2.x

### DIFF
--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -2328,13 +2328,13 @@ std::shared_ptr<ColumnWriter> ColumnWriter::Make(ColumnChunkMetaDataBuilder* met
   const ColumnDescriptor* descr = metadata->descr();
   const bool use_dictionary = properties->dictionary_enabled(descr->path()) &&
                               descr->physical_type() != Type::BOOLEAN;
-  Encoding::type default_encoding =
-      (descr->physical_type() == Type::BOOLEAN &&
-       properties->data_page_version() == ParquetDataPageVersion::V2)
-          ? Encoding::RLE
-          : Encoding::PLAIN;
-  Encoding::type encoding =
-      properties->encoding(descr->path()).value_or(default_encoding);
+  Encoding::type encoding = properties->encoding(descr->path());
+  if (encoding == Encoding::UNKNOWN) {
+    encoding = (descr->physical_type() == Type::BOOLEAN &&
+                properties->data_page_version() == ParquetDataPageVersion::V2)
+                   ? Encoding::RLE
+                   : Encoding::PLAIN;
+  }
   if (use_dictionary) {
     encoding = properties->dictionary_index_encoding();
   }

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -2331,7 +2331,7 @@ std::shared_ptr<ColumnWriter> ColumnWriter::Make(ColumnChunkMetaDataBuilder* met
   Encoding::type encoding = properties->encoding(descr->path());
   if (encoding == Encoding::UNKNOWN) {
     encoding = (descr->physical_type() == Type::BOOLEAN &&
-                properties->data_page_version() == ParquetDataPageVersion::V2)
+                properties->version() != ParquetVersion::PARQUET_1_0)
                    ? Encoding::RLE
                    : Encoding::PLAIN;
   }

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -2328,7 +2328,13 @@ std::shared_ptr<ColumnWriter> ColumnWriter::Make(ColumnChunkMetaDataBuilder* met
   const ColumnDescriptor* descr = metadata->descr();
   const bool use_dictionary = properties->dictionary_enabled(descr->path()) &&
                               descr->physical_type() != Type::BOOLEAN;
-  Encoding::type encoding = properties->encoding(descr->path());
+  Encoding::type default_encoding =
+      (descr->physical_type() == Type::BOOLEAN &&
+       properties->data_page_version() == ParquetDataPageVersion::V2)
+          ? Encoding::RLE
+          : Encoding::PLAIN;
+  Encoding::type encoding =
+      properties->encoding(descr->path()).value_or(default_encoding);
   if (use_dictionary) {
     encoding = properties->dictionary_index_encoding();
   }

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -109,9 +109,7 @@ class TestPrimitiveWriter : public PrimitiveTypedTest<TestType> {
       wp_builder.dictionary_pagesize_limit(DICTIONARY_PAGE_SIZE);
     } else {
       wp_builder.disable_dictionary();
-      if (column_properties.encoding().has_value()) {
-        wp_builder.encoding(column_properties.encoding().value());
-      }
+      wp_builder.encoding(column_properties.encoding());
     }
     if (enable_checksum) {
       wp_builder.enable_page_checksum();

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -135,14 +136,13 @@ static constexpr int64_t DEFAULT_WRITE_BATCH_SIZE = 1024;
 static constexpr int64_t DEFAULT_MAX_ROW_GROUP_LENGTH = 1024 * 1024;
 static constexpr bool DEFAULT_ARE_STATISTICS_ENABLED = true;
 static constexpr int64_t DEFAULT_MAX_STATISTICS_SIZE = 4096;
-static constexpr Encoding::type DEFAULT_ENCODING = Encoding::PLAIN;
 static const char DEFAULT_CREATED_BY[] = CREATED_BY_VERSION;
 static constexpr Compression::type DEFAULT_COMPRESSION_TYPE = Compression::UNCOMPRESSED;
 static constexpr bool DEFAULT_IS_PAGE_INDEX_ENABLED = false;
 
 class PARQUET_EXPORT ColumnProperties {
  public:
-  ColumnProperties(Encoding::type encoding = DEFAULT_ENCODING,
+  ColumnProperties(std::optional<Encoding::type> encoding = std::nullopt,
                    Compression::type codec = DEFAULT_COMPRESSION_TYPE,
                    bool dictionary_enabled = DEFAULT_IS_DICTIONARY_ENABLED,
                    bool statistics_enabled = DEFAULT_ARE_STATISTICS_ENABLED,
@@ -186,7 +186,7 @@ class PARQUET_EXPORT ColumnProperties {
     page_index_enabled_ = page_index_enabled;
   }
 
-  Encoding::type encoding() const { return encoding_; }
+  std::optional<Encoding::type> encoding() const { return encoding_; }
 
   Compression::type compression() const { return codec_; }
 
@@ -203,7 +203,7 @@ class PARQUET_EXPORT ColumnProperties {
   bool page_index_enabled() const { return page_index_enabled_; }
 
  private:
-  Encoding::type encoding_;
+  std::optional<Encoding::type> encoding_;
   Compression::type codec_;
   bool dictionary_enabled_;
   bool statistics_enabled_;
@@ -710,7 +710,8 @@ class PARQUET_EXPORT WriterProperties {
     return default_column_properties_;
   }
 
-  Encoding::type encoding(const std::shared_ptr<schema::ColumnPath>& path) const {
+  std::optional<Encoding::type> encoding(
+      const std::shared_ptr<schema::ColumnPath>& path) const {
     return column_properties(path).encoding();
   }
 

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <memory>
-#include <optional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -136,13 +135,14 @@ static constexpr int64_t DEFAULT_WRITE_BATCH_SIZE = 1024;
 static constexpr int64_t DEFAULT_MAX_ROW_GROUP_LENGTH = 1024 * 1024;
 static constexpr bool DEFAULT_ARE_STATISTICS_ENABLED = true;
 static constexpr int64_t DEFAULT_MAX_STATISTICS_SIZE = 4096;
+static constexpr Encoding::type DEFAULT_ENCODING = Encoding::UNKNOWN;
 static const char DEFAULT_CREATED_BY[] = CREATED_BY_VERSION;
 static constexpr Compression::type DEFAULT_COMPRESSION_TYPE = Compression::UNCOMPRESSED;
 static constexpr bool DEFAULT_IS_PAGE_INDEX_ENABLED = false;
 
 class PARQUET_EXPORT ColumnProperties {
  public:
-  ColumnProperties(std::optional<Encoding::type> encoding = std::nullopt,
+  ColumnProperties(Encoding::type encoding = DEFAULT_ENCODING,
                    Compression::type codec = DEFAULT_COMPRESSION_TYPE,
                    bool dictionary_enabled = DEFAULT_IS_DICTIONARY_ENABLED,
                    bool statistics_enabled = DEFAULT_ARE_STATISTICS_ENABLED,
@@ -186,7 +186,7 @@ class PARQUET_EXPORT ColumnProperties {
     page_index_enabled_ = page_index_enabled;
   }
 
-  std::optional<Encoding::type> encoding() const { return encoding_; }
+  Encoding::type encoding() const { return encoding_; }
 
   Compression::type compression() const { return codec_; }
 
@@ -203,7 +203,7 @@ class PARQUET_EXPORT ColumnProperties {
   bool page_index_enabled() const { return page_index_enabled_; }
 
  private:
-  std::optional<Encoding::type> encoding_;
+  Encoding::type encoding_;
   Compression::type codec_;
   bool dictionary_enabled_;
   bool statistics_enabled_;
@@ -710,8 +710,7 @@ class PARQUET_EXPORT WriterProperties {
     return default_column_properties_;
   }
 
-  std::optional<Encoding::type> encoding(
-      const std::shared_ptr<schema::ColumnPath>& path) const {
+  Encoding::type encoding(const std::shared_ptr<schema::ColumnPath>& path) const {
     return column_properties(path).encoding();
   }
 

--- a/python/pyarrow/tests/parquet/test_metadata.py
+++ b/python/pyarrow/tests/parquet/test_metadata.py
@@ -128,7 +128,7 @@ def test_parquet_metadata_api():
     assert col_meta.is_stats_set is True
     assert isinstance(col_meta.statistics, pq.Statistics)
     assert col_meta.compression == 'SNAPPY'
-    assert set(col_meta.encodings) == {'PLAIN', 'RLE'}
+    assert set(col_meta.encodings) == {'RLE'}
     assert col_meta.has_dictionary_page is False
     assert col_meta.dictionary_page_offset is None
     assert col_meta.data_page_offset > 0


### PR DESCRIPTION
### Rationale for this change

RLE is usually more efficient than PLAIN encoding for boolean columns, and it is already enabled by default in parquet-mr and arrow-rs.

### What changes are included in this PR?

* Slight breaking change in ColumnProperties to set default encoding to UNKNOWN (used to be PLAIN).
* If UNKNOWN is given, let the column writer decide the column encoding according to the selected Parquet format version and the column type.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes, default encoding of boolean type has been switched to RLE when the selected Parquet format version is at least 2.0 (the current default version is 2.6). It used to always be PLAIN.

* Closes: #36882