### PR TITLE
GH-36935: [Go] Fix Timestamp to Time dates

### DIFF
--- a/go/arrow/datatype_fixedwidth.go
+++ b/go/arrow/datatype_fixedwidth.go
@@ -192,10 +192,16 @@ func TimestampFromString(val string, unit TimeUnit) (Timestamp, error) {
 }
 
 func (t Timestamp) ToTime(unit TimeUnit) time.Time {
-	if unit == Second {
+	switch unit {
+	case Second:
 		return time.Unix(int64(t), 0).UTC()
+	case Millisecond:
+		return time.UnixMilli(int64(t)).UTC()
+	case Microsecond:
+		return time.UnixMicro(int64(t)).UTC()
+	default:
+		return time.Unix(0, int64(t)).UTC()
 	}
-	return time.Unix(0, int64(t)*int64(unit.Multiplier())).UTC()
 }
 
 // TimestampFromTime allows converting time.Time to Timestamp
@@ -327,6 +333,8 @@ const (
 
 var TimeUnitValues = []TimeUnit{Second, Millisecond, Microsecond, Nanosecond}
 
+// Multiplier returns a time.Duration value to multiply by in order to
+// convert the value into nanoseconds
 func (u TimeUnit) Multiplier() time.Duration {
 	return [...]time.Duration{time.Second, time.Millisecond, time.Microsecond, time.Nanosecond}[uint(u)&3]
 }

--- a/go/arrow/datatype_fixedwidth_test.go
+++ b/go/arrow/datatype_fixedwidth_test.go
@@ -159,6 +159,13 @@ func TestTimestampType(t *testing.T) {
 	}
 }
 
+func TestTimestampToTime(t *testing.T) {
+	ts := arrow.Timestamp(11865225600000)
+	tm := ts.ToTime(arrow.Millisecond)
+
+	assert.Equal(t, "2345-12-30 00:00:00", tm.Format("2006-01-02 15:04:05.999"))
+}
+
 func TestTime32Type(t *testing.T) {
 	for _, tc := range []struct {
 		unit arrow.TimeUnit


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
The previous solution converted everything to nanoseconds first but you end up with overflowing `int64` potentially. Since we've bumped the minimum version of the library to using go1.17+ we can use the newer `UnixMicro` and `UnixMilli` functions to make this easy.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### Are these changes tested?
Yes, unit test is added.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

* Closes: #36935