### PR TITLE
GH-36949: [C++] Fix KeyColumnArray's buffers array bounds assertion.

### DIFF
--- a/cpp/src/arrow/compute/light_array.h
+++ b/cpp/src/arrow/compute/light_array.h
@@ -122,12 +122,12 @@ class ARROW_EXPORT KeyColumnArray {
 
   /// \brief Return one of the underlying mutable buffers
   uint8_t* mutable_data(int i) {
-    ARROW_DCHECK(i >= 0 && i <= kMaxBuffers);
+    ARROW_DCHECK(i >= 0 && i < kMaxBuffers);
     return mutable_buffers_[i];
   }
   /// \brief Return one of the underlying read-only buffers
   const uint8_t* data(int i) const {
-    ARROW_DCHECK(i >= 0 && i <= kMaxBuffers);
+    ARROW_DCHECK(i >= 0 && i < kMaxBuffers);
     return buffers_[i];
   }
   /// \brief Return a mutable version of the offsets buffer
@@ -316,8 +316,7 @@ class ARROW_EXPORT ResizableArrayData {
   ///
   /// If i is 0 (kValidityBuffer) then this returns the validity buffer
   /// If i is 1 (kFixedLengthBuffer) then this returns the buffer used for values (if this
-  /// is a fixed
-  ///           length data type) or offsets (if this is a variable binary type)
+  /// is a fixed length data type) or offsets (if this is a variable binary type)
   /// If i is 2 (kVariableLengthBuffer) then this returns the buffer used for variable
   /// length binary data
   uint8_t* mutable_data(int i) { return buffers_[i]->mutable_data(); }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

file: light_array.h

The length of the buffers array is 3 (kMaxBuffers).

- buffers_[kValidityBuffer]
- buffers_[kFixedLengthBuffer]
- buffers_[kVariableLengthBuffer]

So when we do the check, the asserted index should be less than 3, not equal to.

In addition, fix the comment line break format problem.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- KeyColumnArray

data and mutable_data ARROW_DCHECK.

- ResizableArrayData class 

Comment line break formatting for mutable_data functions

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
no, just change assert bound.

### Are there any user-facing changes?

no
* Closes: #36949