### PR TITLE
GH-36924: [Java] support offset/length and filter in scan option

### DIFF
--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -596,8 +596,8 @@ Result<RecordBatchGenerator> ParquetFileFormat::ScanBatchesAsync(
     pre_filtered = true;
     if (row_groups.empty()) return MakeEmptyGenerator<std::shared_ptr<RecordBatch>>();
     if (options->start_offset != kDefaultStartOffset) {
-      ARROW_ASSIGN_OR_RAISE(row_groups,
-                            parquet_fragment->FilterRangeRowGroups(row_groups, options->start_offset, options->length));
+      ARROW_ASSIGN_OR_RAISE(row_groups, parquet_fragment->FilterRangeRowGroups(
+        row_groups, options->start_offset, options->length));
     }
   }
   // Open the reader and pay the real IO cost.
@@ -612,8 +612,8 @@ Result<RecordBatchGenerator> ParquetFileFormat::ScanBatchesAsync(
       ARROW_ASSIGN_OR_RAISE(row_groups,
                             parquet_fragment->FilterRowGroups(options->filter));
       if (options->start_offset != kDefaultStartOffset) {
-        ARROW_ASSIGN_OR_RAISE(row_groups,
-                              parquet_fragment->FilterRangeRowGroups(row_groups, options->start_offset, options->length));
+        ARROW_ASSIGN_OR_RAISE(row_groups, parquet_fragment->FilterRangeRowGroups(
+          row_groups, options->start_offset, options->length));
       }
       if (row_groups.empty()) return MakeEmptyGenerator<std::shared_ptr<RecordBatch>>();
     }

--- a/cpp/src/arrow/dataset/file_parquet.h
+++ b/cpp/src/arrow/dataset/file_parquet.h
@@ -194,7 +194,8 @@ class ARROW_DS_EXPORT ParquetFileFragment : public FileFragment {
 
   /// Return a filtered subset of row group indices.
   Result<std::vector<int>> FilterRowGroups(compute::Expression predicate);
-  Result<std::vector<int>> FilterRangeRowGroups(std::vector<int> pre_filter, int64_t start_offset, int64_t length);
+  Result<std::vector<int>> FilterRangeRowGroups(
+    std::vector<int> pre_filter, int64_t start_offset, int64_t length);
   /// Simplify the predicate against the statistics of each row group.
   Result<std::vector<compute::Expression>> TestRowGroups(compute::Expression predicate);
   /// Try to count rows matching the predicate using metadata. Expects

--- a/cpp/src/arrow/dataset/file_parquet.h
+++ b/cpp/src/arrow/dataset/file_parquet.h
@@ -194,6 +194,7 @@ class ARROW_DS_EXPORT ParquetFileFragment : public FileFragment {
 
   /// Return a filtered subset of row group indices.
   Result<std::vector<int>> FilterRowGroups(compute::Expression predicate);
+  Result<std::vector<int>> FilterRangeRowGroups(int64_t start_offset, int64_t length);
   /// Simplify the predicate against the statistics of each row group.
   Result<std::vector<compute::Expression>> TestRowGroups(compute::Expression predicate);
   /// Try to count rows matching the predicate using metadata. Expects

--- a/cpp/src/arrow/dataset/file_parquet.h
+++ b/cpp/src/arrow/dataset/file_parquet.h
@@ -194,7 +194,7 @@ class ARROW_DS_EXPORT ParquetFileFragment : public FileFragment {
 
   /// Return a filtered subset of row group indices.
   Result<std::vector<int>> FilterRowGroups(compute::Expression predicate);
-  Result<std::vector<int>> FilterRangeRowGroups(int64_t start_offset, int64_t length);
+  Result<std::vector<int>> FilterRangeRowGroups(std::vector<int> pre_filter, int64_t start_offset, int64_t length);
   /// Simplify the predicate against the statistics of each row group.
   Result<std::vector<compute::Expression>> TestRowGroups(compute::Expression predicate);
   /// Try to count rows matching the predicate using metadata. Expects

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -935,6 +935,22 @@ Status ScannerBuilder::BatchSize(int64_t batch_size) {
   return Status::OK();
 }
 
+Status ScannerBuilder::StartOffset(int64_t start_offset) {
+  if (start_offset <= 0) {
+    return Status::Invalid("StartOffset must be greater than 0, got ", start_offset);
+  }
+  scan_options_->start_offset = start_offset;
+  return Status::OK();
+}
+
+Status ScannerBuilder::Length(int64_t length){
+  if (length <= 0) {
+    return Status::Invalid("Length must be greater than 0, got ", length);
+  }
+  scan_options_->length = length;
+  return Status::OK();
+}
+
 Status ScannerBuilder::BatchReadahead(int32_t batch_readahead) {
   if (batch_readahead < 0) {
     return Status::Invalid("BatchReadahead must be greater than or equal 0, got ",

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -943,7 +943,7 @@ Status ScannerBuilder::StartOffset(int64_t start_offset) {
   return Status::OK();
 }
 
-Status ScannerBuilder::Length(int64_t length){
+Status ScannerBuilder::Length(int64_t length) {
   if (length <= 0) {
     return Status::Invalid("Length must be greater than 0, got ", length);
   }

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -138,12 +138,12 @@ struct ARROW_DS_EXPORT ScanOptions {
   acero::BackpressureOptions backpressure =
       acero::BackpressureOptions::DefaultBackpressure();
 
-  /// Parameters which control where the scan starts
-  /// This is used in reading a big file by splitting into multiple scanners
+  /// Parameters which control where the scan starts.
+  /// This is used in reading a big file by splitting into multiple scanners.
   int64_t start_offset = kDefaultStartOffset;
 
-  /// Parameters which control how long the scanner should read
-  /// This is used in reading a big file by splitting into multiple scanners
+  /// Parameters which control how long the scanner should read.
+  /// This is used in reading a big file by splitting into multiple scanners.
   int64_t length;
 };
 

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -138,7 +138,12 @@ struct ARROW_DS_EXPORT ScanOptions {
   acero::BackpressureOptions backpressure =
       acero::BackpressureOptions::DefaultBackpressure();
 
+  /// Parameters which control where the scan starts
+  /// This is used in reading a big file by splitting into multiple scanners
   int64_t start_offset = kDefaultStartOffset;
+
+  /// Parameters which control how long the scanner should read
+  /// This is used in reading a big file by splitting into multiple scanners
   int64_t length;
 };
 

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -55,6 +55,7 @@ constexpr int64_t kDefaultBatchSize = 1 << 17;  // 128Ki rows
 constexpr int32_t kDefaultBatchReadahead = 16;
 constexpr int32_t kDefaultFragmentReadahead = 4;
 constexpr int32_t kDefaultBytesReadahead = 1 << 25;  // 32MiB
+constexpr int64_t kDefaultStartOffset = -1;
 
 /// Scan-specific options, which can be changed between scans of the same dataset.
 struct ARROW_DS_EXPORT ScanOptions {
@@ -136,6 +137,9 @@ struct ARROW_DS_EXPORT ScanOptions {
   /// Parameters which control when the plan should pause for a slow consumer
   acero::BackpressureOptions backpressure =
       acero::BackpressureOptions::DefaultBackpressure();
+
+  int64_t start_offset = kDefaultStartOffset;
+  int64_t length;
 };
 
 /// Scan-specific options, which can be changed between scans of the same dataset.
@@ -495,6 +499,18 @@ class ARROW_DS_EXPORT ScannerBuilder {
   /// \return Failure if any referenced columns does not exist in the dataset's
   ///         Schema.
   Status Filter(const compute::Expression& filter);
+
+  /// \brief set the start offset of the scanner
+  /// \param[in] start_offset start offset for the scan
+  ///
+  /// \return Failure if the start_offset is not greater than 0
+  Status StartOffset(int64_t start_offset);
+
+  /// \brief set the length of the scanner
+  /// \param[in] length length for the scan
+  ///
+  /// \return Failure if the length is not greater than 0
+  Status Length(int64_t length);
 
   /// \brief Indicate if the Scanner should make use of the available
   ///        ThreadPool found in ScanOptions;

--- a/cpp/src/arrow/dataset/test_util_internal.h
+++ b/cpp/src/arrow/dataset/test_util_internal.h
@@ -510,6 +510,11 @@ class FileFormatFixtureMixin : public ::testing::Test {
     ASSERT_OK_AND_ASSIGN(opts_->filter, filter.Bind(*opts_->dataset_schema));
   }
 
+  void SetRange(int64_t start_offset, int64_t length) {
+    opts_->start_offset = start_offset;
+    opts_->length = length;
+  }
+
   void Project(std::vector<std::string> names) {
     ASSERT_OK_AND_ASSIGN(auto projection, ProjectionDescr::FromNames(
                                               std::move(names), *opts_->dataset_schema));

--- a/java/dataset/pom.xml
+++ b/java/dataset/pom.xml
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>org.apache.arrow.orc</groupId>
             <artifactId>arrow-orc</artifactId>
-            <version>${project.version}</version>
+            <version>12.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/java/dataset/pom.xml
+++ b/java/dataset/pom.xml
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>org.apache.arrow.orc</groupId>
             <artifactId>arrow-orc</artifactId>
-            <version>12.0.0</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/java/dataset/src/main/cpp/jni_wrapper.cc
+++ b/java/dataset/src/main/cpp/jni_wrapper.cc
@@ -551,7 +551,7 @@ JNIEXPORT jlong JNICALL Java_org_apache_arrow_dataset_jni_JniWrapper_createRange
     JniAssertOkOrThrow(scanner_builder->Project(column_vector));
   }
   if (filter != nullptr) {
-    // TODO: PR 32625 OR PR 14287.
+    // TODO: issue 32625 https://github.com/apache/arrow/issues/32625
   }
   JniAssertOkOrThrow(scanner_builder->StartOffset(start_offset));
   JniAssertOkOrThrow(scanner_builder->Length(length));

--- a/java/dataset/src/main/cpp/jni_wrapper.cc
+++ b/java/dataset/src/main/cpp/jni_wrapper.cc
@@ -551,10 +551,7 @@ JNIEXPORT jlong JNICALL Java_org_apache_arrow_dataset_jni_JniWrapper_createRange
     JniAssertOkOrThrow(scanner_builder->Project(column_vector));
   }
   if (filter != nullptr) {
-    // TODO: PR 32625 OR PR 14287
-//    arrow::compute::Expression filter_expr = JniGetOrThrow(
-//        arrow::compute::Expression::FromString(JStringToCString(env, filter)));
-//    JniAssertOkOrThrow(scanner_builder->Filter(filter_expr));
+    // TODO: PR 32625 OR PR 14287.
   }
   JniAssertOkOrThrow(scanner_builder->StartOffset(start_offset));
   JniAssertOkOrThrow(scanner_builder->Length(length));

--- a/java/dataset/src/main/cpp/jni_wrapper.cc
+++ b/java/dataset/src/main/cpp/jni_wrapper.cc
@@ -530,6 +530,46 @@ JNIEXPORT jlong JNICALL Java_org_apache_arrow_dataset_jni_JniWrapper_createScann
 
 /*
  * Class:     org_apache_arrow_dataset_jni_JniWrapper
+ * Method:    createRangeScanner
+ * Signature: (J[Ljava/lang/String;Ljava/lang/String;JJJJ)J
+ */
+JNIEXPORT jlong JNICALL Java_org_apache_arrow_dataset_jni_JniWrapper_createRangeScanner(
+    JNIEnv* env, jobject, jlong dataset_id, jobjectArray columns, jstring filter,
+    jlong batch_size, jlong start_offset, jlong length, jlong memory_pool_id) {
+  JNI_METHOD_START
+  arrow::MemoryPool* pool = reinterpret_cast<arrow::MemoryPool*>(memory_pool_id);
+  if (pool == nullptr) {
+    JniThrow("Memory pool does not exist or has been closed");
+  }
+  std::shared_ptr<arrow::dataset::Dataset> dataset =
+      RetrieveNativeInstance<arrow::dataset::Dataset>(dataset_id);
+  std::shared_ptr<arrow::dataset::ScannerBuilder> scanner_builder =
+      JniGetOrThrow(dataset->NewScan());
+  JniAssertOkOrThrow(scanner_builder->Pool(pool));
+  if (columns != nullptr) {
+    std::vector<std::string> column_vector = ToStringVector(env, columns);
+    JniAssertOkOrThrow(scanner_builder->Project(column_vector));
+  }
+  if (filter != nullptr) {
+    // TODO: PR 32625 OR PR 14287
+//    arrow::compute::Expression filter_expr = JniGetOrThrow(
+//        arrow::compute::Expression::FromString(JStringToCString(env, filter)));
+//    JniAssertOkOrThrow(scanner_builder->Filter(filter_expr));
+  }
+  JniAssertOkOrThrow(scanner_builder->StartOffset(start_offset));
+  JniAssertOkOrThrow(scanner_builder->Length(length));
+  JniAssertOkOrThrow(scanner_builder->BatchSize(batch_size));
+
+  auto scanner = JniGetOrThrow(scanner_builder->Finish());
+  std::shared_ptr<DisposableScannerAdaptor> scanner_adaptor =
+      JniGetOrThrow(DisposableScannerAdaptor::Create(scanner));
+  jlong id = CreateNativeRef(scanner_adaptor);
+  return id;
+  JNI_METHOD_END(-1L)
+}
+
+/*
+ * Class:     org_apache_arrow_dataset_jni_JniWrapper
  * Method:    closeScanner
  * Signature: (J)V
  */

--- a/java/dataset/src/main/java/org/apache/arrow/dataset/jni/JniWrapper.java
+++ b/java/dataset/src/main/java/org/apache/arrow/dataset/jni/JniWrapper.java
@@ -96,7 +96,7 @@ public class JniWrapper {
    * @return the native pointer of the arrow::dataset::Scanner instance.
    */
   public native long createRangeScanner(long datasetId, String[] columns, String filter, long batchSize,
-    long startOffset, long length, long memoryPool);
+      long startOffset, long length, long memoryPool);
 
   /**
    * Get a serialized schema from native instance of a Scanner.

--- a/java/dataset/src/main/java/org/apache/arrow/dataset/jni/JniWrapper.java
+++ b/java/dataset/src/main/java/org/apache/arrow/dataset/jni/JniWrapper.java
@@ -88,10 +88,10 @@ public class JniWrapper {
    * @param columns desired column names.
    *                Columns not in this list will not be emitted when performing scan operation. Null equals
    *                to "all columns".
-   * @param filter the filter to apply on the scan
+   * @param filter the filter to apply on the scan.
    * @param batchSize batch size of scanned record batches.
-   * @param startOffset start offset of the range scan
-   * @param length length of the range scan
+   * @param startOffset start offset of the range scan.
+   * @param length length of the range scan.
    * @param memoryPool identifier of memory pool used in the native scanner.
    * @return the native pointer of the arrow::dataset::Scanner instance.
    */

--- a/java/dataset/src/main/java/org/apache/arrow/dataset/jni/JniWrapper.java
+++ b/java/dataset/src/main/java/org/apache/arrow/dataset/jni/JniWrapper.java
@@ -83,6 +83,22 @@ public class JniWrapper {
                                    ByteBuffer substraitFilter, long batchSize, long memoryPool);
 
   /**
+   * Create Scanner from a Dataset and get the native pointer of the Dataset.
+   * @param datasetId the native pointer of the arrow::dataset::Dataset instance.
+   * @param columns desired column names.
+   *                Columns not in this list will not be emitted when performing scan operation. Null equals
+   *                to "all columns".
+   * @param filter the filter to apply on the scan
+   * @param batchSize batch size of scanned record batches.
+   * @param startOffset start offset of the range scan
+   * @param length length of the range scan
+   * @param memoryPool identifier of memory pool used in the native scanner.
+   * @return the native pointer of the arrow::dataset::Scanner instance.
+   */
+  public native long createRangeScanner(long datasetId, String[] columns, String filter, long batchSize,
+    long startOffset, long length, long memoryPool);
+
+  /**
    * Get a serialized schema from native instance of a Scanner.
    *
    * @param scannerId the native pointer of the arrow::dataset::Scanner instance.

--- a/java/dataset/src/main/java/org/apache/arrow/dataset/jni/NativeDataset.java
+++ b/java/dataset/src/main/java/org/apache/arrow/dataset/jni/NativeDataset.java
@@ -49,6 +49,11 @@ public class NativeDataset implements Dataset {
     return new NativeScanner(context, scannerId);
   }
 
+  /**
+   * Create a new scan with range options.
+   * @param options scan options with offset and length
+   * @return newly created native scanner
+   */
   public synchronized NativeScanner newRangeScan(ScanOptions options) {
     if (closed) {
       throw new NativeInstanceReleasedException();

--- a/java/dataset/src/main/java/org/apache/arrow/dataset/jni/NativeDataset.java
+++ b/java/dataset/src/main/java/org/apache/arrow/dataset/jni/NativeDataset.java
@@ -49,6 +49,16 @@ public class NativeDataset implements Dataset {
     return new NativeScanner(context, scannerId);
   }
 
+  public synchronized NativeScanner newRangeScan(ScanOptions options) {
+    if (closed) {
+      throw new NativeInstanceReleasedException();
+    }
+    long scannerId = JniWrapper.get().createRangeScanner(datasetId, options.getColumns().orElse(null),
+        options.getFilter().orElse(null), options.getBatchSize(), options.getStartOffset(), options.getLength(),
+        context.getMemoryPool().getNativeInstanceId());
+    return new NativeScanner(context, scannerId);
+  }
+
   @Override
   public synchronized void close() {
     if (closed) {

--- a/java/dataset/src/main/java/org/apache/arrow/dataset/scanner/ScanOptions.java
+++ b/java/dataset/src/main/java/org/apache/arrow/dataset/scanner/ScanOptions.java
@@ -62,7 +62,16 @@ public class ScanOptions {
     this(batchSize, columns, -1, -1, Optional.empty());
   }
 
-  public ScanOptions(long batchSize, Optional<String[]> columns, long startOffset, long length, Optional<String> filter) {
+  /**
+   * Constructor.
+   * @param batchSize Maximum row number each batch returned
+   * @param columns (Optional) Projected columns
+   * @param startOffset scan range start offset
+   * @param length scan range length
+   * @param filter (Optional) filter to apply with the scan
+   */
+  public ScanOptions(long batchSize, Optional<String[]> columns,
+      long startOffset, long length, Optional<String> filter) {
     Preconditions.checkNotNull(columns);
     this.batchSize = batchSize;
     this.columns = columns;

--- a/java/dataset/src/main/java/org/apache/arrow/dataset/scanner/ScanOptions.java
+++ b/java/dataset/src/main/java/org/apache/arrow/dataset/scanner/ScanOptions.java
@@ -27,7 +27,10 @@ import org.apache.arrow.util.Preconditions;
  */
 public class ScanOptions {
   private final long batchSize;
+  private final long startOffset;
+  private final long length;
   private final Optional<String[]> columns;
+  private final Optional<String> filter;
   private final Optional<ByteBuffer> substraitProjection;
   private final Optional<ByteBuffer> substraitFilter;
 
@@ -56,11 +59,18 @@ public class ScanOptions {
    *                Only columns present in the Array will be scanned.
    */
   public ScanOptions(long batchSize, Optional<String[]> columns) {
+    this(batchSize, columns, -1, -1, Optional.empty());
+  }
+
+  public ScanOptions(long batchSize, Optional<String[]> columns, long startOffset, long length, Optional<String> filter) {
     Preconditions.checkNotNull(columns);
     this.batchSize = batchSize;
     this.columns = columns;
     this.substraitProjection = Optional.empty();
     this.substraitFilter = Optional.empty();
+    this.startOffset = startOffset;
+    this.length = length;
+    this.filter = filter;
   }
 
   public ScanOptions(long batchSize) {
@@ -69,6 +79,18 @@ public class ScanOptions {
 
   public Optional<String[]> getColumns() {
     return columns;
+  }
+
+  public Optional<String> getFilter() {
+    return filter;
+  }
+
+  public long getStartOffset() {
+    return startOffset;
+  }
+
+  public long getLength() {
+    return length;
   }
 
   public long getBatchSize() {


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

currently the dataset scan API doesn't support specifying file start offset and length scan option

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- supported filter through start offset and length in parquet reader
- added interface in the dataset API to specify these options

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

added a cpp test to test the range options

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

- added offset/length option in dataset scan option interface

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: apache/arrow-java#177
* GitHub Issue: #177