### PR TITLE
MINOR: [Doc][Release] Update wrong reference from JIRA to GitHub issues

### DIFF
--- a/dev/archery/archery/templates/release_curation.txt.j2
+++ b/dev/archery/archery/templates/release_curation.txt.j2
@@ -39,7 +39,7 @@
 {% for commit in noissue -%}
  - {{ commit.url }} {{ commit.title }}
 {% endfor %}
-### JIRA issues in version {{ release.version }} without a linked patch: {{ nopatch|length }}
+### GitHub issues in version {{ release.version }} without a linked patch: {{ nopatch|length }}
 {% for issue in nopatch -%}
  - https://github.com/apache/arrow/issues/{{ issue.key }}
 {% endfor %}

--- a/dev/release/02-source-test.rb
+++ b/dev/release/02-source-test.rb
@@ -134,7 +134,7 @@ Hi,
 
 I would like to propose the following release candidate (RC0) of Apache
 Arrow version #{@release_version}. This is a release consisting of #{n_resolved_issues}
-resolved JIRA issues[1].
+resolved GitHub issues[1].
 
 This release candidate is based on commit:
 #{@current_commit} [2]

--- a/dev/release/02-source.sh
+++ b/dev/release/02-source.sh
@@ -168,7 +168,7 @@ Hi,
 
 I would like to propose the following release candidate (RC${rc}) of Apache
 Arrow version ${version}. This is a release consisting of ${n_resolved_issues}
-resolved JIRA issues[1].
+resolved GitHub issues[1].
 
 This release candidate is based on commit:
 ${release_hash} [2]


### PR DESCRIPTION
### Rationale for this change

Some stray doc references from the JIRA to GitHub migration.

### What changes are included in this PR?

A couple of docs changes on the mail and the Archery release curate report.

### Are these changes tested?

Yes

### Are there any user-facing changes?

No