### PR TITLE
GH-36991: [Python][Packaging] Skip tests on Win that require a tz database

### DIFF
--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -21,6 +21,7 @@ import decimal
 import itertools
 import math
 import re
+import sys
 
 import hypothesis as h
 import numpy as np
@@ -28,6 +29,7 @@ import pytest
 
 from pyarrow.pandas_compat import _pandas_api  # noqa
 import pyarrow as pa
+from pyarrow.tests import util
 import pyarrow.tests.strategies as past
 
 
@@ -1338,6 +1340,8 @@ def test_sequence_timestamp_nanoseconds():
 
 
 @pytest.mark.pandas
+@pytest.mark.skipif(sys.platform == "win32" and not util.windows_has_tzdata(),
+                    reason="Timezone database is not installed on Windows")
 def test_sequence_timestamp_from_int_with_unit():
     # TODO(wesm): This test might be rewritten to assert the actual behavior
     # when pandas is not installed

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -154,6 +154,8 @@ def test_hashing_struct_scalar():
     assert hash1 == hash2
 
 
+@pytest.mark.skipif(sys.platform == "win32" and not util.windows_has_tzdata(),
+                    reason="Timezone database is not installed on Windows")
 def test_timestamp_scalar():
     a = repr(pa.scalar("0000-01-01").cast(pa.timestamp("s")))
     assert a == "<pyarrow.TimestampScalar: '0000-01-01T00:00:00'>"


### PR DESCRIPTION
### Rationale for this change

Some tests require a tz database, which Windows might not provide at the expected file location. Skip them if the tz db is not found.

### What changes are included in this PR?

* Tests skipped if tz db is not found

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* Closes: #36991