### PR TITLE
GH-37012:  [MATLAB] Remove the private property `ArrowArrays` from `arrow.tabular.RecordBatch`

### DIFF
--- a/matlab/src/cpp/arrow/matlab/array/proxy/numeric_array.h
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/numeric_array.h
@@ -89,7 +89,7 @@ class NumericArray : public arrow::matlab::array::proxy::Array {
 
      // Specialization of NumericArray::Make for arrow::TimestampType.
     template <>
-    libmexclass::proxy::MakeResult NumericArray<arrow::TimestampType>::make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
+    inline libmexclass::proxy::MakeResult NumericArray<arrow::TimestampType>::make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
         namespace mda = ::matlab::data;
         using MatlabBuffer = arrow::matlab::buffer::MatlabBuffer;
         using TimestampArray = arrow::TimestampArray;

--- a/matlab/src/cpp/arrow/matlab/array/proxy/wrap.cc
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/wrap.cc
@@ -15,15 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#pragma once
 
-#include "arrow/array.h"
-#include "arrow/result.h"
-
+#include "arrow/matlab/array/proxy/wrap.h"
 #include "arrow/matlab/array/proxy/array.h"
 #include "arrow/matlab/array/proxy/boolean_array.h"
 #include "arrow/matlab/array/proxy/numeric_array.h"
-#include "arrow/matlab/array/proxy/string-array.h"
+#include "arrow/matlab/array/proxy/string_array.h"
 
 namespace arrow::matlab::array::proxy {
 
@@ -32,9 +29,9 @@ namespace arrow::matlab::array::proxy {
         using ID = arrow::Type::type;
         switch (array->type_id()) {
             case ID::BOOL:
-                return std::make_shared<proxy::BooleanArray>(std::static_pointer_cast<arrow::BooleanArray>(type));
+                return std::make_shared<proxy::BooleanArray>(std::static_pointer_cast<arrow::BooleanArray>(array));
             case ID::UINT8:
-                return std::make_shared<proxy::NumericArray<arrow::UInt8Type>>(std::static_pointer_cast<arrow::UInt8Array>(type));
+                return std::make_shared<proxy::NumericArray<arrow::UInt8Type>>(std::static_pointer_cast<arrow::UInt8Array>(array));
             case ID::UINT16:
                 return std::make_shared<proxy::NumericArray<arrow::UInt16Type>>(std::static_pointer_cast<arrow::UInt16Array>(array));
             case ID::UINT32:
@@ -44,15 +41,15 @@ namespace arrow::matlab::array::proxy {
             case ID::INT8:
                 return std::make_shared<proxy::NumericArray<arrow::Int8Type>>(std::static_pointer_cast<arrow::Int8Array>(array));
             case ID::INT16:
-                return std::make_shared<proxy::NumericArray<rrow::Int16Type>>(std::static_pointer_cast<arrow::Int16Array>(array));
+                return std::make_shared<proxy::NumericArray<arrow::Int16Type>>(std::static_pointer_cast<arrow::Int16Array>(array));
             case ID::INT32:
-                return std::make_shared<proxy::NumericArray<rrow::Int32Type>>(std::static_pointer_cast<arrow::Int32Array>(array));
+                return std::make_shared<proxy::NumericArray<arrow::Int32Type>>(std::static_pointer_cast<arrow::Int32Array>(array));
             case ID::INT64:
-                return std::make_shared<proxy::NumericArray<rrow::Int64Type>>(std::static_pointer_cast<arrow::Int64Array>(array));
+                return std::make_shared<proxy::NumericArray<arrow::Int64Type>>(std::static_pointer_cast<arrow::Int64Array>(array));
             case ID::FLOAT:
                 return std::make_shared<proxy::NumericArray<arrow::FloatType>>(std::static_pointer_cast<arrow::FloatArray>(array));
             case ID::DOUBLE:
-                return std::make_shared<proxy::NumericArray<arrow::DoubleArray>>(std::static_pointer_cast<arrow::DoubleArray>(array));
+                return std::make_shared<proxy::NumericArray<arrow::DoubleType>>(std::static_pointer_cast<arrow::DoubleArray>(array));
             case ID::TIMESTAMP:
                 return std::make_shared<proxy::NumericArray<arrow::TimestampType>>(std::static_pointer_cast<arrow::TimestampArray>(array));
             case ID::STRING:

--- a/matlab/src/cpp/arrow/matlab/array/proxy/wrap.cc
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/wrap.cc
@@ -25,7 +25,6 @@
 namespace arrow::matlab::array::proxy {
 
     arrow::Result<std::shared_ptr<proxy::Array>> wrap(const std::shared_ptr<arrow::Array>& array) {
-        
         using ID = arrow::Type::type;
         switch (array->type_id()) {
             case ID::BOOL:
@@ -58,5 +57,4 @@ namespace arrow::matlab::array::proxy {
                 return arrow::Status::NotImplemented("Unsupported DataType: " + array->type()->ToString());
         }
     }
-
 }

--- a/matlab/src/cpp/arrow/matlab/array/proxy/wrap.cc
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/wrap.cc
@@ -1,0 +1,65 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "arrow/array.h"
+#include "arrow/result.h"
+
+#include "arrow/matlab/array/proxy/array.h"
+#include "arrow/matlab/array/proxy/boolean_array.h"
+#include "arrow/matlab/array/proxy/numeric_array.h"
+#include "arrow/matlab/array/proxy/string-array.h"
+
+namespace arrow::matlab::array::proxy {
+
+    arrow::Result<std::shared_ptr<proxy::Array>> wrap(const std::shared_ptr<arrow::Array>& array) {
+        
+        using ID = arrow::Type::type;
+        switch (array->type_id()) {
+            case ID::BOOL:
+                return std::make_shared<proxy::BooleanArray>(std::static_pointer_cast<arrow::BooleanArray>(type));
+            case ID::UINT8:
+                return std::make_shared<proxy::NumericArray<arrow::UInt8Type>>(std::static_pointer_cast<arrow::UInt8Array>(type));
+            case ID::UINT16:
+                return std::make_shared<proxy::NumericArray<arrow::UInt16Type>>(std::static_pointer_cast<arrow::UInt16Array>(array));
+            case ID::UINT32:
+                return std::make_shared<proxy::NumericArray<arrow::UInt32Type>>(std::static_pointer_cast<arrow::UInt32Array>(array));
+            case ID::UINT64:
+                return std::make_shared<proxy::NumericArray<arrow::UInt64Type>>(std::static_pointer_cast<arrow::UInt64Array>(array));
+            case ID::INT8:
+                return std::make_shared<proxy::NumericArray<arrow::Int8Type>>(std::static_pointer_cast<arrow::Int8Array>(array));
+            case ID::INT16:
+                return std::make_shared<proxy::NumericArray<rrow::Int16Type>>(std::static_pointer_cast<arrow::Int16Array>(array));
+            case ID::INT32:
+                return std::make_shared<proxy::NumericArray<rrow::Int32Type>>(std::static_pointer_cast<arrow::Int32Array>(array));
+            case ID::INT64:
+                return std::make_shared<proxy::NumericArray<rrow::Int64Type>>(std::static_pointer_cast<arrow::Int64Array>(array));
+            case ID::FLOAT:
+                return std::make_shared<proxy::NumericArray<arrow::FloatType>>(std::static_pointer_cast<arrow::FloatArray>(array));
+            case ID::DOUBLE:
+                return std::make_shared<proxy::NumericArray<arrow::DoubleArray>>(std::static_pointer_cast<arrow::DoubleArray>(array));
+            case ID::TIMESTAMP:
+                return std::make_shared<proxy::NumericArray<arrow::TimestampType>>(std::static_pointer_cast<arrow::TimestampArray>(array));
+            case ID::STRING:
+                return std::make_shared<proxy::StringArray>(std::static_pointer_cast<arrow::StringArray>(array));
+            default:
+                return arrow::Status::NotImplemented("Unsupported DataType: " + array->type()->ToString());
+        }
+    }
+
+}

--- a/matlab/src/cpp/arrow/matlab/array/proxy/wrap.h
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/wrap.h
@@ -22,8 +22,8 @@
 
 #include "arrow/matlab/array/proxy/array.h"
 
-namespace arrow::matlab::type::proxy {
+namespace arrow::matlab::array::proxy {
 
-    arrow::Result<std::shared_ptr<Array>> wrap(const std::shared_ptr<arrow::Array>& array);
+    arrow::Result<std::shared_ptr<proxy::Array>> wrap(const std::shared_ptr<arrow::Array>& array);
 
 }

--- a/matlab/src/cpp/arrow/matlab/array/proxy/wrap.h
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/wrap.h
@@ -1,0 +1,29 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "arrow/array.h"
+#include "arrow/result.h"
+
+#include "arrow/matlab/array/proxy/array.h"
+
+namespace arrow::matlab::type::proxy {
+
+    arrow::Result<std::shared_ptr<Array>> wrap(const std::shared_ptr<arrow::Array>& array);
+
+}

--- a/matlab/src/cpp/arrow/matlab/error/error.h
+++ b/matlab/src/cpp/arrow/matlab/error/error.h
@@ -177,4 +177,7 @@ namespace arrow::matlab::error {
     static const char* ARROW_TABULAR_SCHEMA_UNKNOWN_FIELD_NAME = "arrow:tabular:schema:UnknownFieldName";
     static const char* ARROW_TABULAR_SCHEMA_AMBIGUOUS_FIELD_NAME = "arrow:tabular:schema:AmbiguousFieldName";
     static const char* ARROW_TABULAR_SCHEMA_NUMERIC_FIELD_INDEX_WITH_EMPTY_SCHEMA = "arrow:tabular:schema:NumericFieldIndexWithEmptySchema";
+    static const char* UNKNOWN_PROXY_FOR_ARRAY_TYPE = "arrow:array:UnknownProxyForArrayType";
+    static const char* RECORD_BATCH_NUMERIC_INDEX_WITH_EMPTY_RECORD_BATCH = "arrow:tabular:recordbatch:NumericIndexWithEmptyRecordBatch";
+    static const char* RECORD_BATCH_INVALID_NUMERIC_COLUMN_INDEX = "arrow:tabular:recordbatch:InvalidNumericColumnIndex";
 }

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.cc
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.cc
@@ -42,7 +42,7 @@ namespace arrow::matlab::tabular::proxy {
             std::stringstream error_message_stream;
             error_message_stream << "Invalid column index: ";
             error_message_stream << matlab_index;
-            error_message_stream << ". Column index must be between 1 and the number of fields (";
+            error_message_stream << ". Column index must be between 1 and the number of columns (";
             error_message_stream << num_columns;
             error_message_stream << ").";
             return libmexclass::error::Error{error::RECORD_BATCH_INVALID_NUMERIC_COLUMN_INDEX, error_message_stream.str()};

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.cc
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.cc
@@ -34,23 +34,18 @@ namespace arrow::matlab::tabular::proxy {
 
     namespace {
         libmexclass::error::Error make_empty_record_batch_error() {
-            const std::string error_message_id = std::string{error::RECORD_BATCH_NUMERIC_INDEX_WITH_EMPTY_RECORD_BATCH};
-            std::stringstream error_message_stream;
-            error_message_stream << "Numeric indexing using the column method is not supported for record batches with no columns.";
-            const std::string& error_message = error_message_stream.str();
-            return libmexclass::error::Error{error_message_id, error_message};
+            const std::string error_msg =  "Numeric indexing using the column method is not supported for record batches with no columns.";
+            return libmexclass::error::Error{error::RECORD_BATCH_NUMERIC_INDEX_WITH_EMPTY_RECORD_BATCH, error_msg};
         }
-    
+
         libmexclass::error::Error make_invalid_numeric_index_error(const int32_t matlab_index, const int32_t num_columns) {
-            const std::string error_message_id = std::string{error::RECORD_BATCH_INVALID_NUMERIC_COLUMN_INDEX};
             std::stringstream error_message_stream;
             error_message_stream << "Invalid column index: ";
             error_message_stream << matlab_index;
             error_message_stream << ". Column index must be between 1 and the number of fields (";
             error_message_stream << num_columns;
             error_message_stream << ").";
-            const std::string& error_message = error_message_stream.str();
-            return libmexclass::error::Error{error_message_id, error_message};
+            return libmexclass::error::Error{error::RECORD_BATCH_INVALID_NUMERIC_COLUMN_INDEX, error_message_stream.str()};
         }
     }
 

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.cc
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.cc
@@ -58,7 +58,7 @@ namespace arrow::matlab::tabular::proxy {
         REGISTER_METHOD(RecordBatch, toString);
         REGISTER_METHOD(RecordBatch, numColumns);
         REGISTER_METHOD(RecordBatch, columnNames);
-        REGISTER_METHOD(RecordBatch, columnByIndex);
+        REGISTER_METHOD(RecordBatch, getColumnByIndex);
     }
 
     void RecordBatch::toString(libmexclass::proxy::method::Context& context) {
@@ -126,7 +126,7 @@ namespace arrow::matlab::tabular::proxy {
         context.outputs[0] = column_names_mda;
     }
 
-    void RecordBatch::columnByIndex(libmexclass::proxy::method::Context& context) {
+    void RecordBatch::getColumnByIndex(libmexclass::proxy::method::Context& context) {
         namespace mda = ::matlab::data;
         using namespace libmexclass::proxy;
         mda::ArrayFactory factory;

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.cc
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.cc
@@ -33,12 +33,12 @@
 namespace arrow::matlab::tabular::proxy {
 
     namespace {
-        libmexclass::error::Error make_empty_record_batch_error() {
+        libmexclass::error::Error makeEmptyRecordBatchError() {
             const std::string error_msg =  "Numeric indexing using the column method is not supported for record batches with no columns.";
             return libmexclass::error::Error{error::RECORD_BATCH_NUMERIC_INDEX_WITH_EMPTY_RECORD_BATCH, error_msg};
         }
 
-        libmexclass::error::Error make_invalid_numeric_index_error(const int32_t matlab_index, const int32_t num_columns) {
+        libmexclass::error::Error makeInvalidNumericIndexError(const int32_t matlab_index, const int32_t num_columns) {
             std::stringstream error_message_stream;
             error_message_stream << "Invalid column index: ";
             error_message_stream << matlab_index;
@@ -136,12 +136,12 @@ namespace arrow::matlab::tabular::proxy {
         const auto num_columns = record_batch->num_columns();
         
         if (num_columns == 0) {
-            context.error = make_empty_record_batch_error();
+            context.error = makeEmptyRecordBatchError();
             return;
         }
         
         if (matlab_index < 1 || matlab_index > num_columns) {
-            context.error = make_invalid_numeric_index_error(matlab_index, num_columns);
+            context.error = makeInvalidNumericIndexError(matlab_index, num_columns);
             return;
         }
 

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.cc
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.cc
@@ -18,17 +18,47 @@
 #include "libmexclass/proxy/ProxyManager.h"
 
 #include "arrow/matlab/array/proxy/array.h"
+#include "arrow/matlab/array/proxy/wrap.h"
+
 #include "arrow/matlab/error/error.h"
 #include "arrow/matlab/tabular/proxy/record_batch.h"
 #include "arrow/type.h"
 #include "arrow/util/utf8.h"
 
+#include "libmexclass/proxy/ProxyManager.h"
+#include "libmexclass/error/Error.h"
+
+#include <sstream>
+
 namespace arrow::matlab::tabular::proxy {
+
+    namespace {
+        libmexclass::error::Error make_empty_record_batch_error() {
+            const std::string error_message_id = std::string{error::RECORD_BATCH_NUMERIC_INDEX_WITH_EMPTY_RECORD_BATCH};
+            std::stringstream error_message_stream;
+            error_message_stream << "Numeric indexing using the column method is not supported for record batches with no columns.";
+            const std::string& error_message = error_message_stream.str();
+            return libmexclass::error::Error{error_message_id, error_message};
+        }
+    
+        libmexclass::error::Error make_invalid_numeric_index_error(const int32_t matlab_index, const int32_t num_columns) {
+            const std::string error_message_id = std::string{error::RECORD_BATCH_INVALID_NUMERIC_COLUMN_INDEX};
+            std::stringstream error_message_stream;
+            error_message_stream << "Invalid column index: ";
+            error_message_stream << matlab_index;
+            error_message_stream << ". Column index must be between 1 and the number of fields (";
+            error_message_stream << num_columns;
+            error_message_stream << ").";
+            const std::string& error_message = error_message_stream.str();
+            return libmexclass::error::Error{error_message_id, error_message};
+        }
+    }
 
     RecordBatch::RecordBatch(std::shared_ptr<arrow::RecordBatch> record_batch) : record_batch{record_batch} {
         REGISTER_METHOD(RecordBatch, toString);
         REGISTER_METHOD(RecordBatch, numColumns);
         REGISTER_METHOD(RecordBatch, columnNames);
+        REGISTER_METHOD(RecordBatch, columnByIndex);
     }
 
     void RecordBatch::toString(libmexclass::proxy::method::Context& context) {
@@ -96,4 +126,42 @@ namespace arrow::matlab::tabular::proxy {
         context.outputs[0] = column_names_mda;
     }
 
+    void RecordBatch::columnByIndex(libmexclass::proxy::method::Context& context) {
+        namespace mda = ::matlab::data;
+        using namespace libmexclass::proxy;
+        mda::ArrayFactory factory;
+
+        mda::StructArray args = context.inputs[0];
+        const mda::TypedArray<int32_t> index_mda = args[0]["Index"];
+        const auto matlab_index = int32_t(index_mda[0]);
+        
+        // Note: MATLAB uses 1-based indexing, so subtract 1.
+        // arrow::Schema::field does not do any bounds checking.
+        const int32_t index = matlab_index - 1;
+        const auto num_columns = record_batch->num_columns();
+        
+        if (num_columns == 0) {
+            context.error = make_empty_record_batch_error();
+            return;
+        }
+        
+        if (matlab_index < 1 || matlab_index > num_columns) {
+            context.error = make_invalid_numeric_index_error(matlab_index, num_columns);
+            return;
+        }
+
+        const auto array = record_batch->column(index);
+        MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(auto array_proxy,
+                                            arrow::matlab::array::proxy::wrap(array),
+                                            context,
+                                            error::UNKNOWN_PROXY_FOR_ARRAY_TYPE);
+        
+        
+        const auto array_proxy_id = ProxyManager::manageProxy(array_proxy);
+        const auto array_proxy_id_mda = factory.createScalar(array_proxy_id);
+        const auto array_type_id_mda = factory.createScalar(static_cast<int32_t>(array->type_id()));
+        
+        context.outputs[0] = array_proxy_id_mda;
+        context.outputs[1] = array_type_id_mda;
+    }
 }

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.h
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.h
@@ -35,7 +35,8 @@ namespace arrow::matlab::tabular::proxy {
             void toString(libmexclass::proxy::method::Context& context);
             void numColumns(libmexclass::proxy::method::Context& context);
             void columnNames(libmexclass::proxy::method::Context& context);
-    
+            void columnByIndex(libmexclass::proxy::method::Context& context);
+
             std::shared_ptr<arrow::RecordBatch> record_batch;
     };
 

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.h
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.h
@@ -35,7 +35,7 @@ namespace arrow::matlab::tabular::proxy {
             void toString(libmexclass::proxy::method::Context& context);
             void numColumns(libmexclass::proxy::method::Context& context);
             void columnNames(libmexclass::proxy::method::Context& context);
-            void columnByIndex(libmexclass::proxy::method::Context& context);
+            void getColumnByIndex(libmexclass::proxy::method::Context& context);
 
             std::shared_ptr<arrow::RecordBatch> record_batch;
     };

--- a/matlab/src/cpp/arrow/matlab/type/proxy/wrap.h
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/wrap.h
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#pragma once
+
 #include "arrow/type.h"
 #include "arrow/result.h"
 

--- a/matlab/src/matlab/+arrow/+tabular/RecordBatch.m
+++ b/matlab/src/matlab/+arrow/+tabular/RecordBatch.m
@@ -45,7 +45,7 @@ classdef RecordBatch < matlab.mixin.CustomDisplay & ...
                 proxy = libmexclass.proxy.Proxy(Name=traits.ArrayProxyClassName, ID=proxyID);
                 arrowArray = traits.ArrayConstructor(proxy);
             else
-                errid = "arrow:tabular:recordbatch:UnsupportedColumndIndexType";
+                errid = "arrow:tabular:recordbatch:UnsupportedColumnIndexType";
                 msg = "Index must be a positive scalar integer.";
                 error(errid, msg);
             end

--- a/matlab/src/matlab/+arrow/+tabular/RecordBatch.m
+++ b/matlab/src/matlab/+arrow/+tabular/RecordBatch.m
@@ -18,10 +18,6 @@ classdef RecordBatch < matlab.mixin.CustomDisplay & ...
 %arrow.tabular.RecordBatch A tabular data structure representing
 % a set of arrow.array.Array objects with a fixed schema.
 
-    properties (Access=private)
-        ArrowArrays = {};
-    end
-
     properties (Dependent, SetAccess=private, GetAccess=public)
         NumColumns
         ColumnNames
@@ -42,23 +38,35 @@ classdef RecordBatch < matlab.mixin.CustomDisplay & ...
         end
 
         function arrowArray = column(obj, idx)
-            arrowArray = obj.ArrowArrays{idx};
+            if ~isempty(idx) && isscalar(idx) && isnumeric(idx) && idx >= 1
+                args = struct(Index=int32(idx));
+                [proxyID, typeID] = obj.Proxy.getColumnByIndex(args);
+                traits = arrow.type.traits.traits(arrow.type.ID(typeID));
+                proxy = libmexclass.proxy.Proxy(Name=traits.ArrayProxyClassName, ID=proxyID);
+                arrowArray = traits.ArrayConstructor(proxy);
+            else
+                errid = "arrow:tabular:recordbatch:UnsupportedColumndIndexType";
+                msg = "Index must be a positive scalar integer.";
+                error(errid, msg);
+            end
         end
 
         function obj = RecordBatch(T)
-            obj.ArrowArrays = arrow.tabular.RecordBatch.decompose(T);
+            arrowArrays = arrow.tabular.RecordBatch.decompose(T);
             columnNames = string(T.Properties.VariableNames);
-            arrayProxyIDs = arrow.tabular.RecordBatch.getArrowProxyIDs(obj.ArrowArrays);
+            arrayProxyIDs = arrow.tabular.RecordBatch.getArrowProxyIDs(arrowArrays);
             opts = struct("ArrayProxyIDs", arrayProxyIDs, ...
                           "ColumnNames", columnNames);
             obj.Proxy = libmexclass.proxy.Proxy("Name", "arrow.tabular.proxy.RecordBatch", "ConstructorArguments", {opts});
         end
 
         function T = table(obj)
-            matlabArrays = cell(1, numel(obj.ArrowArrays));
+            numColumns = obj.NumColumns;
+            matlabArrays = cell(1, numColumns);
             
-            for ii = 1:numel(obj.ArrowArrays)
-                matlabArrays{ii} = toMATLAB(obj.ArrowArrays{ii});
+            for ii = 1:numColumns
+                arrowArray = obj.column(ii);
+                matlabArrays{ii} = toMATLAB(arrowArray);
             end
 
             variableNames = matlab.lang.makeUniqueStrings(obj.ColumnNames);

--- a/matlab/test/arrow/tabular/tRecordBatch.m
+++ b/matlab/test/arrow/tabular/tRecordBatch.m
@@ -115,11 +115,11 @@ classdef tRecordBatch < matlab.unittest.TestCase
             tc.verifyError(fcn, "arrow:tabular:recordbatch:InvalidNumericColumnIndex");
         end
 
-        function UnsupportedColumndIndexType(tc)
+        function UnsupportedColumnIndexType(tc)
             TOriginal = table(1, 2, 3);
             arrowRecordBatch = arrow.tabular.RecordBatch(TOriginal);
             fcn = @() arrowRecordBatch.column(datetime(2022, 1, 3));
-            tc.verifyError(fcn, "arrow:tabular:recordbatch:UnsupportedColumndIndexType");
+            tc.verifyError(fcn, "arrow:tabular:recordbatch:UnsupportedColumnIndexType");
         end
     end
 end

--- a/matlab/test/arrow/tabular/tRecordBatch.m
+++ b/matlab/test/arrow/tabular/tRecordBatch.m
@@ -46,6 +46,8 @@ classdef tRecordBatch < matlab.unittest.TestCase
             for ii = 1:arrowRecordBatch.NumColumns
                 column = arrowRecordBatch.column(ii);
                 tc.verifyEqual(column.toMATLAB(), TOriginal{:, ii});
+                traits = arrow.type.traits.traits(string(class(TOriginal{:, ii})));
+                tc.verifyInstanceOf(column, traits.ArrayClassName);
             end
         end
 
@@ -99,6 +101,25 @@ classdef tRecordBatch < matlab.unittest.TestCase
             tc.verifyEqual(TOriginal, TConverted);
         end
 
-    end
+        function EmptyRecordBatchColumnIndexError(tc)
+            TOriginal = table();
+            arrowRecordBatch = arrow.tabular.RecordBatch(TOriginal);
+            fcn = @() arrowRecordBatch.column(1);
+            tc.verifyError(fcn, "arrow:tabular:recordbatch:NumericIndexWithEmptyRecordBatch");
+        end
 
+        function InvalidNumericIndexError(tc)
+            TOriginal = table(1, 2, 3);
+            arrowRecordBatch = arrow.tabular.RecordBatch(TOriginal);
+            fcn = @() arrowRecordBatch.column(4);
+            tc.verifyError(fcn, "arrow:tabular:recordbatch:InvalidNumericColumnIndex");
+        end
+
+        function UnsupportedColumndIndexType(tc)
+            TOriginal = table(1, 2, 3);
+            arrowRecordBatch = arrow.tabular.RecordBatch(TOriginal);
+            fcn = @() arrowRecordBatch.column(datetime(2022, 1, 3));
+            tc.verifyError(fcn, "arrow:tabular:recordbatch:UnsupportedColumndIndexType");
+        end
+    end
 end

--- a/matlab/tools/cmake/BuildMatlabArrowInterface.cmake
+++ b/matlab/tools/cmake/BuildMatlabArrowInterface.cmake
@@ -44,6 +44,7 @@ set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/src/c
 set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_SOURCES "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/array/proxy/array.cc"
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/array/proxy/boolean_array.cc"
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/array/proxy/string_array.cc"
+                                                  "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/array/proxy/wrap.cc"
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/tabular/proxy/record_batch.cc"
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/tabular/proxy/schema.cc"
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/bit/pack.cc"


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

In our initial implementation of the MATLAB class `arrow.tabular.RecordBatch`, we included a property property called `ArrowArrays`, which is a `cell` array whose elements are scalar `arrow.array.Array` objects.  These arrays correspond to the columns in the `arrow::RecordBatch` that the MATLAB class wraps.  The purpose of `ArrowArrays` was to enable  zero-copy construction of the `arrow::Array` objects backing the `arrow::RecordBatch` from MATLAB arrays. The `ArrowArrays` property was necessary to ensure the MATLAB data from which the `arrow::Array` columns were constructed don't get deallocated before they are done being used.
 
However, we no longer need the `ArrowArrays` property on `arrow.tabular.RecordBatch` because of #36615, in which we implemented `arrow::matlab::buffer::MatlabBuffer`. This class inherits from `arrow::Buffer` and  stores a reference to the MATLAB data it wraps, ensuring that the wrapped MATLAB data is kept alive as long as the buffer is around. 

We now only create `arrow::Array` objects from `arrow::matlab::buffer::MatlabBuffer` objects - instead of `arrow::Buffer` objects. As a result, the `ArrowArrays` property is no longer necessary on `arrow.tabular.RecordBatch` because the `arrow::Array` columns within the `arrow::RecordBatch` are all backed by `arrow::matlab::buffer::MatlabBuffer` objects. The backing MATLAB data is kept alive as long as the arrays and their buffers are kept alive. 

### What changes are included in this PR?

1. Removed the `ArrowArrays` property from `arrow.tabular.RecordBatch`. 
2. Because `ArrowArrays` is no longer a property, we had to add a new method to `arrow::matlab::tabular::proxy::RecordBatch` called `getColumnByIndex()`. This method creates a proxy object around the specified `arrrow::Array`. The MATLAB method `RecordBatch/column(index)` uses `getColumnByIndex()`.
3. Added a new function called `wrap`, which accepts an `arrow::Array` and returns an `arrow::matlab::array::proxy::Array`. While working on `getColumnByIndex()`, we realized there would be multiple places in the interface where we will need to create proxies around `arrow::Array` objects. We wrote the `wrap` utility function to reduce duplicated code in the future. Currently, only `getColumnByIndex()` utilizes `wrap`.

### Are these changes tested?

Yes.

1. The existing unit tests in `tRecordBatch.m` cover these changes.
2. Added a few more test cases to `tRecordBatch.m` to cover error conditions when a bad `index` value is provided to `arrow.tabular.RecordBatch/column(index)`.

### Are there any user-facing changes?

No.

### Future Directions

1. In a followup PR, we will add support for indexing columns by names (similar to `Schema.field(fieldName)` - #37013).
2. We also plan on adding an index validation function within the `arrow.internal.validate` package.  
3. We also plan on adding a convenience constructor `arrow.recordbatch()` and changing the constructor of `arrow.tabular.RecordBatch` to expect a `libmexclass.proxy.Proxy` object. 

* Closes: #37012 