### PR TITLE
GH-37019: [R] Documentation for read_parquet() et al needs updating

### DIFF
--- a/r/R/csv.R
+++ b/r/R/csv.R
@@ -17,7 +17,7 @@
 
 #' Read a CSV or other delimited file with Arrow
 #'
-#' These functions uses the Arrow C++ CSV reader to read into a `data.frame`.
+#' These functions uses the Arrow C++ CSV reader to read into a `tibble`.
 #' Arrow C++ options have been mapped to argument names that follow those of
 #' `readr::read_delim()`, and `col_select` was inspired by `vroom::vroom()`.
 #'
@@ -127,10 +127,10 @@
 #' parsing options provided in other arguments (e.g. `delim`, `quote`, etc.).
 #' @param convert_options see [file reader options][CsvReadOptions]
 #' @param read_options see [file reader options][CsvReadOptions]
-#' @param as_data_frame Should the function return a `data.frame` (default) or
+#' @param as_data_frame Should the function return a `tibble` (default) or
 #' an Arrow [Table]?
 #'
-#' @return A `data.frame`, or a Table if `as_data_frame = FALSE`.
+#' @return A `tibble`, or a Table if `as_data_frame = FALSE`.
 #' @export
 #' @examples
 #' tf <- tempfile()

--- a/r/R/dplyr-funcs-doc.R
+++ b/r/R/dplyr-funcs-doc.R
@@ -34,7 +34,7 @@
 #' to a `dbplyr::tbl_lazy`. This means that the verbs do not eagerly evaluate
 #' the query on the data. To run the query, call either `compute()`,
 #' which returns an `arrow` [Table], or `collect()`, which pulls the resulting
-#' Table into an R `data.frame`.
+#' Table into an R `tibble`.
 #'
 #' * [`anti_join()`][dplyr::anti_join()]: the `copy` and `na_matches` arguments are ignored
 #' * [`arrange()`][dplyr::arrange()]

--- a/r/R/feather.R
+++ b/r/R/feather.R
@@ -157,7 +157,7 @@ write_ipc_file <- function(x,
 #' @inheritParams read_delim_arrow
 #' @inheritParams make_readable_file
 #'
-#' @return A `data.frame` if `as_data_frame` is `TRUE` (the default), or an
+#' @return A `tibble` if `as_data_frame` is `TRUE` (the default), or an
 #' Arrow [Table] otherwise
 #'
 #' @export

--- a/r/R/ipc-stream.R
+++ b/r/R/ipc-stream.R
@@ -87,11 +87,11 @@ write_to_raw <- function(x, format = c("stream", "file")) {
 #' If a file name or URI, an Arrow [InputStream] will be opened and
 #' closed when finished. If an input stream is provided, it will be left
 #' open.
-#' @param as_data_frame Should the function return a `data.frame` (default) or
+#' @param as_data_frame Should the function return a `tibble` (default) or
 #' an Arrow [Table]?
 #' @param ... extra parameters passed to `read_feather()`.
 #'
-#' @return A `data.frame` if `as_data_frame` is `TRUE` (the default), or an
+#' @return A `tibble` if `as_data_frame` is `TRUE` (the default), or an
 #' Arrow [Table] otherwise
 #' @seealso [write_feather()] for writing IPC files. [RecordBatchReader] for a
 #' lower-level interface.

--- a/r/R/json.R
+++ b/r/R/json.R
@@ -38,7 +38,7 @@
 #' @param schema [Schema] that describes the table.
 #' @param ... Additional options passed to `JsonTableReader$create()`
 #'
-#' @return A `data.frame`, or a Table if `as_data_frame = FALSE`.
+#' @return A `tibble`, or a Table if `as_data_frame = FALSE`.
 #' @export
 #' @examplesIf arrow_with_json()
 #' tf <- tempfile()

--- a/r/R/parquet.R
+++ b/r/R/parquet.R
@@ -24,8 +24,8 @@
 #' @param props [ParquetArrowReaderProperties]
 #' @param ... Additional arguments passed to `ParquetFileReader$create()`
 #'
-#' @return A [arrow::Table][Table], or a `data.frame` if `as_data_frame` is
-#' `TRUE` (the default).
+#' @return A `tibble` if `as_data_frame` is `TRUE` (the default), or an
+#' Arrow [Table] otherwise.
 #' @examplesIf arrow_with_parquet() && !getFromNamespace("on_linux_dev", "arrow")()
 #' tf <- tempfile()
 #' on.exit(unlink(tf))

--- a/r/man/acero.Rd
+++ b/r/man/acero.Rd
@@ -21,7 +21,7 @@ Most verb functions return an \code{arrow_dplyr_query} object, similar in spirit
 to a \code{dbplyr::tbl_lazy}. This means that the verbs do not eagerly evaluate
 the query on the data. To run the query, call either \code{compute()},
 which returns an \code{arrow} \link{Table}, or \code{collect()}, which pulls the resulting
-Table into an R \code{data.frame}.
+Table into an R \code{tibble}.
 \itemize{
 \item \code{\link[dplyr:filter-joins]{anti_join()}}: the \code{copy} and \code{na_matches} arguments are ignored
 \item \code{\link[dplyr:arrange]{arrange()}}

--- a/r/man/read_delim_arrow.Rd
+++ b/r/man/read_delim_arrow.Rd
@@ -128,7 +128,7 @@ parsing options provided in other arguments (e.g. \code{delim}, \code{quote}, et
 
 \item{read_options}{see \link[=CsvReadOptions]{file reader options}}
 
-\item{as_data_frame}{Should the function return a \code{data.frame} (default) or
+\item{as_data_frame}{Should the function return a \code{tibble} (default) or
 an Arrow \link{Table}?}
 
 \item{timestamp_parsers}{User-defined timestamp parsers. If more than one
@@ -141,10 +141,10 @@ starting from the beginning of this vector. Possible values are:
 }}
 }
 \value{
-A \code{data.frame}, or a Table if \code{as_data_frame = FALSE}.
+A \code{tibble}, or a Table if \code{as_data_frame = FALSE}.
 }
 \description{
-These functions uses the Arrow C++ CSV reader to read into a \code{data.frame}.
+These functions uses the Arrow C++ CSV reader to read into a \code{tibble}.
 Arrow C++ options have been mapped to argument names that follow those of
 \code{readr::read_delim()}, and \code{col_select} was inspired by \code{vroom::vroom()}.
 }

--- a/r/man/read_feather.Rd
+++ b/r/man/read_feather.Rd
@@ -21,13 +21,13 @@ open.}
 \link[tidyselect:eval_select]{tidy selection specification}
 of columns, as used in \code{dplyr::select()}.}
 
-\item{as_data_frame}{Should the function return a \code{data.frame} (default) or
+\item{as_data_frame}{Should the function return a \code{tibble} (default) or
 an Arrow \link{Table}?}
 
 \item{mmap}{Logical: whether to memory-map the file (default \code{TRUE})}
 }
 \value{
-A \code{data.frame} if \code{as_data_frame} is \code{TRUE} (the default), or an
+A \code{tibble} if \code{as_data_frame} is \code{TRUE} (the default), or an
 Arrow \link{Table} otherwise
 }
 \description{

--- a/r/man/read_ipc_stream.Rd
+++ b/r/man/read_ipc_stream.Rd
@@ -13,13 +13,13 @@ If a file name or URI, an Arrow \link{InputStream} will be opened and
 closed when finished. If an input stream is provided, it will be left
 open.}
 
-\item{as_data_frame}{Should the function return a \code{data.frame} (default) or
+\item{as_data_frame}{Should the function return a \code{tibble} (default) or
 an Arrow \link{Table}?}
 
 \item{...}{extra parameters passed to \code{read_feather()}.}
 }
 \value{
-A \code{data.frame} if \code{as_data_frame} is \code{TRUE} (the default), or an
+A \code{tibble} if \code{as_data_frame} is \code{TRUE} (the default), or an
 Arrow \link{Table} otherwise
 }
 \description{

--- a/r/man/read_json_arrow.Rd
+++ b/r/man/read_json_arrow.Rd
@@ -28,7 +28,7 @@ To be recognised as literal data, the input must be wrapped with \code{I()}.}
 \link[tidyselect:eval_select]{tidy selection specification}
 of columns, as used in \code{dplyr::select()}.}
 
-\item{as_data_frame}{Should the function return a \code{data.frame} (default) or
+\item{as_data_frame}{Should the function return a \code{tibble} (default) or
 an Arrow \link{Table}?}
 
 \item{schema}{\link{Schema} that describes the table.}
@@ -36,7 +36,7 @@ an Arrow \link{Table}?}
 \item{...}{Additional options passed to \code{JsonTableReader$create()}}
 }
 \value{
-A \code{data.frame}, or a Table if \code{as_data_frame = FALSE}.
+A \code{tibble}, or a Table if \code{as_data_frame = FALSE}.
 }
 \description{
 Wrapper around \link{JsonTableReader} to read a newline-delimited JSON (ndjson) file into a

--- a/r/man/read_parquet.Rd
+++ b/r/man/read_parquet.Rd
@@ -24,7 +24,7 @@ open.}
 \link[tidyselect:eval_select]{tidy selection specification}
 of columns, as used in \code{dplyr::select()}.}
 
-\item{as_data_frame}{Should the function return a \code{data.frame} (default) or
+\item{as_data_frame}{Should the function return a \code{tibble} (default) or
 an Arrow \link{Table}?}
 
 \item{props}{\link{ParquetArrowReaderProperties}}
@@ -32,8 +32,8 @@ an Arrow \link{Table}?}
 \item{...}{Additional arguments passed to \code{ParquetFileReader$create()}}
 }
 \value{
-A \link[=Table]{arrow::Table}, or a \code{data.frame} if \code{as_data_frame} is
-\code{TRUE} (the default).
+A \code{tibble} if \code{as_data_frame} is \code{TRUE} (the default), or an
+Arrow \link{Table} otherwise.
 }
 \description{
 '\href{https://parquet.apache.org/}{Parquet}' is a columnar storage file format.


### PR DESCRIPTION
### Rationale for this change

Docs were out of data with code after previous changes to returned object type

### What changes are included in this PR?

Update docs to reflect correct return type

### Are these changes tested?

No

### Are there any user-facing changes?

No
* Closes: #37019