### PR TITLE
GH-36726: [R] calling read_parquet on S3 connections results in error message being ignored

### DIFF
--- a/r/R/io.R
+++ b/r/R/io.R
@@ -250,15 +250,8 @@ make_readable_file <- function(file, mmap = TRUE, random_access = TRUE) {
     }
 
     if (is_url(file)) {
-      file <- tryCatch(
-        {
-          fs_and_path <- FileSystem$from_uri(file)
-          fs_and_path$fs$OpenInputFile(fs_and_path$path)
-        },
-        error = function(e) {
-          MakeRConnectionInputStream(url(file, open = "rb"))
-        }
-      )
+      fs_and_path <- FileSystem$from_uri(file)
+      file <- fs_and_path$fs$OpenInputFile(fs_and_path$path)
     } else if (isTRUE(mmap)) {
       file <- mmap_open(file)
     } else {

--- a/r/R/io.R
+++ b/r/R/io.R
@@ -249,7 +249,9 @@ make_readable_file <- function(file, mmap = TRUE, random_access = TRUE) {
       on.exit(unlink(tf))
     }
 
-    if (is_url(file)) {
+    if (is_http_url(file)) {
+      file <- MakeRConnectionInputStream(url(file, open = "rb"))
+    } else if (is_url(file)) {
       fs_and_path <- FileSystem$from_uri(file)
       file <- fs_and_path$fs$OpenInputFile(fs_and_path$path)
     } else if (isTRUE(mmap)) {

--- a/r/tests/testthat/test-csv.R
+++ b/r/tests/testthat/test-csv.R
@@ -724,3 +724,12 @@ test_that("skip_rows and skip_rows_after_names option", {
     tibble::tibble(`1` = 3:4)
   )
 })
+
+test_that("Can read CSV files from a URL", {
+  skip_if_offline()
+  skip_on_cran()
+  csv_url <- "https://raw.githubusercontent.com/apache/arrow-testing/master/data/csv/aggregate_test_100.csv"
+  cu <- read_csv_arrow(csv_url)
+  expect_true(tibble::is_tibble(cu))
+  expect_identical(dim(cu), c(100L, 13L))
+})

--- a/r/tests/testthat/test-ipc-stream.R
+++ b/r/tests/testthat/test-ipc-stream.R
@@ -50,5 +50,5 @@ test_that("Can read IPC streams from a URL", {
   ipc_url <- "https://github.com/apache/arrow-testing/raw/master/data/arrow-ipc-stream/integration/1.0.0-littleendian/generated_primitive.stream" #nolint
   ipcu <- read_ipc_stream(ipc_url)
   expect_true(tibble::is_tibble(ipcu))
-  expect_identical(dim(cu), c(37L, 30L))
+  expect_identical(dim(ipcu), c(37L, 30L))
 })

--- a/r/tests/testthat/test-ipc-stream.R
+++ b/r/tests/testthat/test-ipc-stream.R
@@ -43,3 +43,12 @@ test_that("write_ipc_stream errors for invalid input type", {
   bad_input <- Array$create(1:5)
   expect_snapshot_error(write_ipc_stream(bad_input, feather_file))
 })
+
+test_that("Can read IPC streams from a URL", {
+  skip_if_offline()
+  skip_on_cran()
+  ipc_url <- "https://github.com/apache/arrow-testing/raw/master/data/arrow-ipc-stream/integration/1.0.0-littleendian/generated_primitive.stream" #nolint
+  ipcu <- read_ipc_stream(ipc_url)
+  expect_true(tibble::is_tibble(ipcu))
+  expect_identical(dim(cu), c(37L, 30L))
+})


### PR DESCRIPTION
### Rationale for this change

Valid error messages were being ignored and incorrect error messages were being displayed

### What changes are included in this PR?

I deleted a `tryCatch()` which was swallowing the error message.  I don't know why it was there, and removing it didn't break any tests, so whatever behaviour it aims to supported is untested, and it may have been unnecessary.

### Are these changes tested?

No

### Are there any user-facing changes?

No
* Closes: #36726