### PR TITLE
GH-36892: [C++] Fix performance regressions in `FieldPath::Get`

### DIFF
--- a/cpp/src/arrow/type_benchmark.cc
+++ b/cpp/src/arrow/type_benchmark.cc
@@ -486,7 +486,7 @@ static void BenchmarkFieldPathGet(benchmark::State& state,  // NOLINT non-const 
 
   for (auto _ : state) {
     for (const auto& path : paths) {
-      benchmark::DoNotOptimize(path.Get(input));
+      benchmark::DoNotOptimize(path.Get(input).ValueOrDie());
     }
   }
 

--- a/cpp/src/arrow/type_benchmark.cc
+++ b/cpp/src/arrow/type_benchmark.cc
@@ -24,9 +24,12 @@
 
 #include "benchmark/benchmark.h"
 
+#include "arrow/array.h"
 #include "arrow/result.h"
 #include "arrow/status.h"
+#include "arrow/table.h"
 #include "arrow/testing/gtest_util.h"
+#include "arrow/testing/random.h"
 #include "arrow/type.h"
 #include "arrow/util/key_value_metadata.h"
 #include "arrow/util/macros.h"
@@ -418,6 +421,114 @@ static void ErrorSchemeExceptionNoInline(
   state.SetItemsProcessed(state.iterations() * integers.size());
 }
 
+// ----------------------------------------------------------------------
+// FieldPath::Get benchmarks
+
+static std::shared_ptr<Schema> GenerateTestSchema(int num_columns) {
+  FieldVector fields(num_columns);
+  for (int i = 0; i < num_columns; ++i) {
+    auto name = std::string("f") + std::to_string(i);
+    fields[i] = field(std::move(name), int64());
+  }
+  return schema(std::move(fields));
+}
+
+static std::shared_ptr<Array> GenerateTestArray(int num_columns) {
+  constexpr int64_t kLength = 100;
+
+  auto rand = random::RandomArrayGenerator(0xbeef);
+  auto schm = GenerateTestSchema(num_columns);
+
+  ArrayVector columns(num_columns);
+  for (auto& column : columns) {
+    column = rand.Int64(kLength, 0, std::numeric_limits<int64_t>::max());
+  }
+
+  return *StructArray::Make(columns, schm->fields());
+}
+
+static std::shared_ptr<RecordBatch> ToBatch(const std::shared_ptr<Array>& array) {
+  return *RecordBatch::FromStructArray(array);
+}
+
+static std::shared_ptr<ChunkedArray> ToChunked(const std::shared_ptr<Array>& array,
+                                               double chunk_proportion = 1.0) {
+  auto struct_array = internal::checked_pointer_cast<StructArray>(array);
+  const auto num_rows = struct_array->length();
+  const auto chunk_length = static_cast<int64_t>(std::ceil(num_rows * chunk_proportion));
+
+  ArrayVector chunks;
+  for (int64_t offset = 0; offset < num_rows;) {
+    int64_t slice_length = std::min(chunk_length, num_rows - offset);
+    chunks.push_back(*struct_array->SliceSafe(offset, slice_length));
+    offset += slice_length;
+  }
+
+  return *ChunkedArray::Make(std::move(chunks));
+}
+
+static std::shared_ptr<Table> ToTable(const std::shared_ptr<Array>& array,
+                                      double chunk_proportion = 1.0) {
+  return *Table::FromChunkedStructArray(ToChunked(array, chunk_proportion));
+}
+
+template <typename T>
+static void BenchmarkFieldPathGet(benchmark::State& state,  // NOLINT non-const reference
+                                  const T& input, int num_columns) {
+  // Reassigning a single FieldPath var within each iteration's scope seems to be costly
+  // enough to influence the timings, so we preprocess them.
+  std::vector<FieldPath> paths(num_columns);
+  for (int i = 0; i < num_columns; ++i) {
+    paths[i] = {i};
+  }
+
+  for (auto _ : state) {
+    for (const auto& path : paths) {
+      benchmark::DoNotOptimize(path.Get(input));
+    }
+  }
+
+  state.SetItemsProcessed(state.iterations() * num_columns);
+}
+
+static void FieldPathGetFromWideArray(
+    benchmark::State& state) {  // NOLINT non-const reference
+  constexpr int kNumColumns = 10000;
+  auto array = GenerateTestArray(kNumColumns);
+  BenchmarkFieldPathGet(state, *array, kNumColumns);
+}
+
+static void FieldPathGetFromWideArrayData(
+    benchmark::State& state) {  // NOLINT non-const reference
+  constexpr int kNumColumns = 10000;
+  auto array = GenerateTestArray(kNumColumns);
+  BenchmarkFieldPathGet(state, *array->data(), kNumColumns);
+}
+
+static void FieldPathGetFromWideBatch(
+    benchmark::State& state) {  // NOLINT non-const reference
+  constexpr int kNumColumns = 10000;
+  auto batch = ToBatch(GenerateTestArray(kNumColumns));
+  BenchmarkFieldPathGet(state, *batch, kNumColumns);
+}
+
+static void FieldPathGetFromWideChunkedArray(
+    benchmark::State& state) {  // NOLINT non-const reference
+  constexpr int kNumColumns = 10000;
+  // Percentage representing the size of each chunk relative to the total length (smaller
+  // proportion means more chunks)
+  const double chunk_proportion = state.range(0) / 100.0;
+  auto chunked_array = ToChunked(GenerateTestArray(kNumColumns), chunk_proportion);
+  BenchmarkFieldPathGet(state, *chunked_array, kNumColumns);
+}
+
+static void FieldPathGetFromWideTable(
+    benchmark::State& state) {  // NOLINT non-const reference
+  constexpr int kNumColumns = 10000;
+  auto table = ToTable(GenerateTestArray(kNumColumns));
+  BenchmarkFieldPathGet(state, *table, kNumColumns);
+}
+
 BENCHMARK(TypeEqualsSimple);
 BENCHMARK(TypeEqualsComplex);
 BENCHMARK(TypeEqualsWithMetadata);
@@ -435,5 +546,11 @@ BENCHMARK(ErrorSchemeBoolNoInline);
 BENCHMARK(ErrorSchemeStatusNoInline);
 BENCHMARK(ErrorSchemeResultNoInline);
 BENCHMARK(ErrorSchemeExceptionNoInline);
+
+BENCHMARK(FieldPathGetFromWideArray);
+BENCHMARK(FieldPathGetFromWideArrayData);
+BENCHMARK(FieldPathGetFromWideBatch);
+BENCHMARK(FieldPathGetFromWideTable);
+BENCHMARK(FieldPathGetFromWideChunkedArray)->Arg(2)->Arg(8)->Arg(32)->Arg(100);
 
 }  // namespace arrow

--- a/cpp/src/arrow/type_benchmark.cc
+++ b/cpp/src/arrow/type_benchmark.cc
@@ -531,7 +531,8 @@ static void FieldPathGetFromWideChunkedArray(
 static void FieldPathGetFromWideTable(
     benchmark::State& state) {  // NOLINT non-const reference
   constexpr int kNumColumns = 10000;
-  auto table = ToTable(GenerateTestArray(kNumColumns));
+  const double chunk_proportion = state.range(0) / 100.0;
+  auto table = ToTable(GenerateTestArray(kNumColumns), chunk_proportion);
   BenchmarkFieldPathGet(state, *table, kNumColumns, table->column(0)->num_chunks());
 }
 
@@ -556,7 +557,8 @@ BENCHMARK(ErrorSchemeExceptionNoInline);
 BENCHMARK(FieldPathGetFromWideArray);
 BENCHMARK(FieldPathGetFromWideArrayData);
 BENCHMARK(FieldPathGetFromWideBatch);
-BENCHMARK(FieldPathGetFromWideTable);
-BENCHMARK(FieldPathGetFromWideChunkedArray)->Arg(2)->Arg(8)->Arg(32)->Arg(100);
+
+BENCHMARK(FieldPathGetFromWideChunkedArray)->Arg(2)->Arg(10)->Arg(25)->Arg(100);
+BENCHMARK(FieldPathGetFromWideTable)->Arg(2)->Arg(10)->Arg(25)->Arg(100);
 
 }  // namespace arrow


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

https://github.com/apache/arrow/pull/35197 appears to have introduced significant performance regressions in `FieldPath::Get` - indicated [here](https://conbench.ursa.dev/compare/runs/9cf73ac83f0a44179e6538b2c1c7babd...3d76cb5ffb8849bf8c3ea9b32d08b3b7/), in a benchmark that uses a wide (10K column) dataframe.

### What changes are included in this PR?

- Adds basic benchmarks for `FieldPath::Get` across various input types, as they didn't previously exist
- Addresses several performance issues. These came in the form of extremely high upfront costs for the `RecordBatch` and `ArrayData` overloads specifically
- Some minor refactoring of `NestedSelector`

### Are these changes tested?

Yes (covered by existing tests)

### Are there any user-facing changes?

No

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #36892