### PR TITLE
GH-36103: [C++] Initial device sync API

### DIFF
--- a/cpp/src/arrow/acero/aggregate_internal.h
+++ b/cpp/src/arrow/acero/aggregate_internal.h
@@ -52,8 +52,8 @@
 // segment-keys is used to refine the partitioning. However, segment-keys are different in
 // that they partition only consecutive rows into a single group. Such a partition of
 // consecutive rows is called a segment group. For example, consider a column X with
-// values [A, A, B, A] at row-indices [0, 1, 2, 3]. A regular group-by aggregation with keys
-// [X] yields a row-index partitioning [[0, 1, 3], [2]] whereas a segmented-group-by
+// values [A, A, B, A] at row-indices [0, 1, 2, 3]. A regular group-by aggregation with
+// keys [X] yields a row-index partitioning [[0, 1, 3], [2]] whereas a segmented-group-by
 // aggregation with segment-keys [X] yields [[0, 1], [2], [3]].
 //
 // The implementation first segments the input using the segment-keys, then groups by the

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -346,7 +346,7 @@ class ARROW_EXPORT Buffer {
   static Result<std::shared_ptr<Buffer>> ViewOrCopy(
       std::shared_ptr<Buffer> source, const std::shared_ptr<MemoryManager>& to);
 
-  virtual std::shared_ptr<DeviceSync> get_device_sync() { return nullptr; }
+  virtual std::shared_ptr<Device::SyncEvent> device_sync_event() { return nullptr; }
 
  protected:
   bool is_mutable_;

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -346,6 +346,8 @@ class ARROW_EXPORT Buffer {
   static Result<std::shared_ptr<Buffer>> ViewOrCopy(
       std::shared_ptr<Buffer> source, const std::shared_ptr<MemoryManager>& to);
 
+  virtual std::shared_ptr<DeviceSync> get_device_sync() { return nullptr; }
+
  protected:
   bool is_mutable_;
   bool is_cpu_;

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -346,7 +346,7 @@ class ARROW_EXPORT Buffer {
   static Result<std::shared_ptr<Buffer>> ViewOrCopy(
       std::shared_ptr<Buffer> source, const std::shared_ptr<MemoryManager>& to);
 
-  virtual std::shared_ptr<Device::SyncEvent> device_sync_event() { return nullptr; }
+  virtual std::shared_ptr<Device::SyncEvent> device_sync_event() { return NULLPTR; }
 
  protected:
   bool is_mutable_;

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -1409,7 +1409,7 @@ struct ArrayImporter {
     RETURN_NOT_OK(Import(&src->array));
     if (src->sync_event != nullptr) {
       ARROW_ASSIGN_OR_RAISE(import_->device_sync_,
-                            memory_mgr_->MakeDeviceSync({src->sync_event, [](void*) {}}));
+                            memory_mgr_->MakeDeviceSyncEvent({src->sync_event, [](void*) {}}));
     }
     // reset internal state before next import
     memory_mgr_.reset();

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -711,10 +711,7 @@ Result<std::pair<std::optional<DeviceAllocationType>, int64_t>> ValidateDeviceIn
 
 Status ExportDeviceArray(const Array& array, std::shared_ptr<Device::SyncEvent> sync,
                          struct ArrowDeviceArray* out, struct ArrowSchema* out_schema) {
-  void* sync_event{nullptr};
-  if (sync) {
-    sync_event = sync->get_raw();
-  }
+  void* sync_event = sync ? sync->get_raw() : nullptr;
 
   SchemaExportGuard guard(out_schema);
   if (out_schema != nullptr) {

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -521,7 +521,7 @@ struct ExportedArrayPrivateData : PoolAllocationMixin<ExportedArrayPrivateData> 
   SmallVector<struct ArrowArray*, 4> child_pointers_;
 
   std::shared_ptr<ArrayData> data_;
-  std::shared_ptr<DeviceSync> sync_;
+  std::shared_ptr<Device::SyncEvent> sync_;
 
   ExportedArrayPrivateData() = default;
   ARROW_DEFAULT_MOVE_AND_ASSIGN(ExportedArrayPrivateData);
@@ -713,7 +713,7 @@ Result<std::pair<std::optional<DeviceAllocationType>, int64_t>> ValidateDeviceIn
   return std::make_pair(device_type, device_id);
 }
 
-Status ExportDeviceArray(const Array& array, std::shared_ptr<DeviceSync> sync,
+Status ExportDeviceArray(const Array& array, std::shared_ptr<Device::SyncEvent> sync,
                          struct ArrowDeviceArray* out, struct ArrowSchema* out_schema) {
   void* sync_event{nullptr};
   if (sync) {
@@ -746,7 +746,7 @@ Status ExportDeviceArray(const Array& array, std::shared_ptr<DeviceSync> sync,
 }
 
 Status ExportDeviceRecordBatch(const RecordBatch& batch,
-                               std::shared_ptr<DeviceSync> sync,
+                               std::shared_ptr<Device::SyncEvent> sync,
                                struct ArrowDeviceArray* out,
                                struct ArrowSchema* out_schema) {
   void* sync_event{nullptr};
@@ -1362,7 +1362,7 @@ namespace {
 // The ArrowArray is released on destruction.
 struct ImportedArrayData {
   struct ArrowArray array_;
-  std::shared_ptr<DeviceSync> device_sync_;
+  std::shared_ptr<Device::SyncEvent> device_sync_;
 
   ImportedArrayData() {
     ArrowArrayMarkReleased(&array_);  // Initially released
@@ -1395,7 +1395,7 @@ class ImportedBuffer : public Buffer {
 
   ~ImportedBuffer() override {}
 
-  std::shared_ptr<DeviceSync> get_device_sync() override { return import_->device_sync_; }
+  std::shared_ptr<Device::SyncEvent> device_sync_event() override { return import_->device_sync_; }
 
  protected:
   std::shared_ptr<ImportedArrayData> import_;

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -1407,7 +1407,7 @@ struct ArrayImporter {
     device_type_ = static_cast<DeviceAllocationType>(src->device_type);
     RETURN_NOT_OK(Import(&src->array));
     if (src->sync_event != nullptr) {
-      ARROW_ASSIGN_OR_RAISE(import_->device_sync_, memory_mgr_->MakeDeviceSyncEvent(
+      ARROW_ASSIGN_OR_RAISE(import_->device_sync_, memory_mgr_->WrapDeviceSyncEvent(
                                                        src->sync_event, [](void*) {}));
     }
     // reset internal state before next import

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -520,9 +520,7 @@ struct ExportedArrayPrivateData : PoolAllocationMixin<ExportedArrayPrivateData> 
   SmallVector<struct ArrowArray, 1> children_;
   SmallVector<struct ArrowArray*, 4> child_pointers_;
 
-  std::shared_ptr<ArrayData> data_;
-
-  // RawSyncEvent sync_event_;
+  std::shared_ptr<ArrayData> data_;  
   std::shared_ptr<DeviceSync> sync_;
 
   ExportedArrayPrivateData() = default;
@@ -1363,8 +1361,7 @@ namespace {
 // The ArrowArray is released on destruction.
 struct ImportedArrayData {
   struct ArrowArray array_;
-  std::shared_ptr<DeviceSync> device_sync;
-  // void* sync_event_;
+  std::shared_ptr<DeviceSync> device_sync;  
 
   ImportedArrayData() {
     ArrowArrayMarkReleased(&array_);  // Initially released
@@ -1414,8 +1411,7 @@ struct ArrayImporter {
   Status Import(struct ArrowDeviceArray* src, const DeviceMemoryMapper& mapper) {
     ARROW_ASSIGN_OR_RAISE(memory_mgr_, mapper(src->device_type, src->device_id));
     device_type_ = static_cast<DeviceAllocationType>(src->device_type);
-    RETURN_NOT_OK(Import(&src->array));
-    // import_->sync_event_ = src->sync_event;
+    RETURN_NOT_OK(Import(&src->array));    
     ARROW_ASSIGN_OR_RAISE(import_->device_sync, memory_mgr_->MakeDeviceSync(src->sync_event));
     // reset internal state before next import
     memory_mgr_.reset();

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -1391,7 +1391,9 @@ class ImportedBuffer : public Buffer {
 
   ~ImportedBuffer() override {}
 
-  std::shared_ptr<Device::SyncEvent> device_sync_event() override { return import_->device_sync_; }
+  std::shared_ptr<Device::SyncEvent> device_sync_event() override {
+    return import_->device_sync_;
+  }
 
  protected:
   std::shared_ptr<ImportedArrayData> import_;
@@ -1408,8 +1410,8 @@ struct ArrayImporter {
     device_type_ = static_cast<DeviceAllocationType>(src->device_type);
     RETURN_NOT_OK(Import(&src->array));
     if (src->sync_event != nullptr) {
-      ARROW_ASSIGN_OR_RAISE(import_->device_sync_,
-                            memory_mgr_->MakeDeviceSyncEvent({src->sync_event, [](void*) {}}));
+      ARROW_ASSIGN_OR_RAISE(import_->device_sync_, memory_mgr_->MakeDeviceSyncEvent(
+                                                       src->sync_event, [](void*) {}));
     }
     // reset internal state before next import
     memory_mgr_.reset();

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -520,7 +520,7 @@ struct ExportedArrayPrivateData : PoolAllocationMixin<ExportedArrayPrivateData> 
   SmallVector<struct ArrowArray, 1> children_;
   SmallVector<struct ArrowArray*, 4> child_pointers_;
 
-  std::shared_ptr<ArrayData> data_;  
+  std::shared_ptr<ArrayData> data_;
   std::shared_ptr<DeviceSync> sync_;
 
   ExportedArrayPrivateData() = default;
@@ -545,11 +545,11 @@ void ReleaseExportedArray(struct ArrowArray* array) {
         << "Dictionary release callback should have marked it released";
   }
   DCHECK_NE(array->private_data, nullptr);
-  auto* pdata = reinterpret_cast<ExportedArrayPrivateData*>(array->private_data);  
+  auto* pdata = reinterpret_cast<ExportedArrayPrivateData*>(array->private_data);
   if (pdata->sync_) {
     pdata->sync_->clear_event();
   }
-  
+
   delete pdata;
 
   ArrowArrayMarkReleased(array);
@@ -715,7 +715,7 @@ Result<std::pair<std::optional<DeviceAllocationType>, int64_t>> ValidateDeviceIn
 
 Status ExportDeviceArray(const Array& array, std::shared_ptr<DeviceSync>& sync,
                          struct ArrowDeviceArray* out, struct ArrowSchema* out_schema) {
-  void* sync_event {nullptr};
+  void* sync_event{nullptr};
   if (sync) {
     ARROW_ASSIGN_OR_RAISE(sync_event, sync->get_event());
   }
@@ -745,14 +745,15 @@ Status ExportDeviceArray(const Array& array, std::shared_ptr<DeviceSync>& sync,
   return Status::OK();
 }
 
-Status ExportDeviceRecordBatch(const RecordBatch& batch, std::shared_ptr<DeviceSync>& sync,
+Status ExportDeviceRecordBatch(const RecordBatch& batch,
+                               std::shared_ptr<DeviceSync>& sync,
                                struct ArrowDeviceArray* out,
                                struct ArrowSchema* out_schema) {
-  void* sync_event {nullptr};
+  void* sync_event{nullptr};
   if (sync) {
     ARROW_ASSIGN_OR_RAISE(sync_event, sync->get_event());
-  }                              
-  
+  }
+
   // XXX perhaps bypass ToStructArray for speed?
   ARROW_ASSIGN_OR_RAISE(auto array, batch.ToStructArray());
 
@@ -1361,7 +1362,7 @@ namespace {
 // The ArrowArray is released on destruction.
 struct ImportedArrayData {
   struct ArrowArray array_;
-  std::shared_ptr<DeviceSync> device_sync;  
+  std::shared_ptr<DeviceSync> device_sync;
 
   ImportedArrayData() {
     ArrowArrayMarkReleased(&array_);  // Initially released
@@ -1394,9 +1395,7 @@ class ImportedBuffer : public Buffer {
 
   ~ImportedBuffer() override {}
 
-  std::shared_ptr<DeviceSync> get_device_sync() override { 
-    return import_->device_sync; 
-  }
+  std::shared_ptr<DeviceSync> get_device_sync() override { return import_->device_sync; }
 
  protected:
   std::shared_ptr<ImportedArrayData> import_;
@@ -1411,8 +1410,9 @@ struct ArrayImporter {
   Status Import(struct ArrowDeviceArray* src, const DeviceMemoryMapper& mapper) {
     ARROW_ASSIGN_OR_RAISE(memory_mgr_, mapper(src->device_type, src->device_id));
     device_type_ = static_cast<DeviceAllocationType>(src->device_type);
-    RETURN_NOT_OK(Import(&src->array));    
-    ARROW_ASSIGN_OR_RAISE(import_->device_sync, memory_mgr_->MakeDeviceSync(src->sync_event));
+    RETURN_NOT_OK(Import(&src->array));
+    ARROW_ASSIGN_OR_RAISE(import_->device_sync,
+                          memory_mgr_->MakeDeviceSync(src->sync_event));
     // reset internal state before next import
     memory_mgr_.reset();
     device_type_ = DeviceAllocationType::kCPU;

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -24,6 +24,7 @@
 #include "arrow/c/abi.h"
 #include "arrow/result.h"
 #include "arrow/status.h"
+#include "arrow/device.h"
 #include "arrow/type_fwd.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
@@ -198,7 +199,7 @@ struct RawSyncEvent {
 /// \param[out] out C struct to export the array to
 /// \param[out] out_schema optional C struct to export the array type to
 ARROW_EXPORT
-Status ExportDeviceArray(const Array& array, RawSyncEvent sync_event,
+Status ExportDeviceArray(const Array& array, std::shared_ptr<DeviceSync>& sync,
                          struct ArrowDeviceArray* out,
                          struct ArrowSchema* out_schema = NULLPTR);
 
@@ -220,7 +221,7 @@ Status ExportDeviceArray(const Array& array, RawSyncEvent sync_event,
 /// \param[out] out C struct where to export the record batch
 /// \param[out] out_schema optional C struct where to export the record batch schema
 ARROW_EXPORT
-Status ExportDeviceRecordBatch(const RecordBatch& batch, RawSyncEvent sync_event,
+Status ExportDeviceRecordBatch(const RecordBatch& batch, std::shared_ptr<DeviceSync>& sync,
                                struct ArrowDeviceArray* out,
                                struct ArrowSchema* out_schema = NULLPTR);
 

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -173,17 +173,6 @@ Result<std::shared_ptr<RecordBatch>> ImportRecordBatch(struct ArrowArray* array,
 ///
 /// @{
 
-/// \brief EXPERIMENTAL: Type for freeing a sync event
-///
-/// If synchronization is necessary for accessing the data on a device,
-/// a pointer to an event needs to be passed when exporting the device
-/// array. It's the responsibility of the release function for the array
-/// to release the event. Both can be null if no sync'ing is necessary.
-struct RawSyncEvent {
-  void* sync_event = NULL;
-  std::function<void(void*)> release_func;
-};
-
 /// \brief EXPERIMENTAL: Export C++ Array as an ArrowDeviceArray.
 ///
 /// The resulting ArrowDeviceArray struct keeps the array data and buffers alive
@@ -191,11 +180,11 @@ struct RawSyncEvent {
 /// the provided array MUST have the same device_type, otherwise an error
 /// will be returned.
 ///
-/// If a non-null sync_event is provided, then the sync_release func must also be
-/// non-null. If the sync_event is null, then the sync_release parameter is not called.
+/// If sync is non-null, get_event will be called on it in order to
+/// potentially provide an event for consumers to synchronize on.
 ///
 /// \param[in] array Array object to export
-/// \param[in] sync_event A struct containing what is needed for syncing if necessary
+/// \param[in] sync shared_ptr to object derived from DeviceSync or null
 /// \param[out] out C struct to export the array to
 /// \param[out] out_schema optional C struct to export the array type to
 ARROW_EXPORT
@@ -213,11 +202,11 @@ Status ExportDeviceArray(const Array& array, std::shared_ptr<DeviceSync>& sync,
 /// otherwise an error will be returned. If columns are on different devices,
 /// they should be exported using different ArrowDeviceArray instances.
 ///
-/// If a non-null sync_event is provided, then the sync_release func must also be
-/// non-null. If the sync_event is null, then the sync_release parameter is ignored.
+/// If sync is non-null, get_event will be called on it in order to
+/// potentially provide an event for consumers to synchronize on.
 ///
 /// \param[in] batch Record batch to export
-/// \param[in] sync_event A struct containing what is needed for syncing if necessary
+/// \param[in] sync shared_ptr to object derived from DeviceSync or null
 /// \param[out] out C struct where to export the record batch
 /// \param[out] out_schema optional C struct where to export the record batch schema
 ARROW_EXPORT

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -188,7 +188,7 @@ Result<std::shared_ptr<RecordBatch>> ImportRecordBatch(struct ArrowArray* array,
 /// \param[out] out C struct to export the array to
 /// \param[out] out_schema optional C struct to export the array type to
 ARROW_EXPORT
-Status ExportDeviceArray(const Array& array, std::shared_ptr<DeviceSync>& sync,
+Status ExportDeviceArray(const Array& array, std::shared_ptr<DeviceSync> sync,
                          struct ArrowDeviceArray* out,
                          struct ArrowSchema* out_schema = NULLPTR);
 
@@ -211,7 +211,7 @@ Status ExportDeviceArray(const Array& array, std::shared_ptr<DeviceSync>& sync,
 /// \param[out] out_schema optional C struct where to export the record batch schema
 ARROW_EXPORT
 Status ExportDeviceRecordBatch(const RecordBatch& batch,
-                               std::shared_ptr<DeviceSync>& sync,
+                               std::shared_ptr<DeviceSync> sync,
                                struct ArrowDeviceArray* out,
                                struct ArrowSchema* out_schema = NULLPTR);
 

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -184,11 +184,11 @@ Result<std::shared_ptr<RecordBatch>> ImportRecordBatch(struct ArrowArray* array,
 /// potentially provide an event for consumers to synchronize on.
 ///
 /// \param[in] array Array object to export
-/// \param[in] sync shared_ptr to object derived from DeviceSync or null
+/// \param[in] sync shared_ptr to object derived from Device::SyncEvent or null
 /// \param[out] out C struct to export the array to
 /// \param[out] out_schema optional C struct to export the array type to
 ARROW_EXPORT
-Status ExportDeviceArray(const Array& array, std::shared_ptr<DeviceSync> sync,
+Status ExportDeviceArray(const Array& array, std::shared_ptr<Device::SyncEvent> sync,
                          struct ArrowDeviceArray* out,
                          struct ArrowSchema* out_schema = NULLPTR);
 
@@ -206,12 +206,12 @@ Status ExportDeviceArray(const Array& array, std::shared_ptr<DeviceSync> sync,
 /// potentially provide an event for consumers to synchronize on.
 ///
 /// \param[in] batch Record batch to export
-/// \param[in] sync shared_ptr to object derived from DeviceSync or null
+/// \param[in] sync shared_ptr to object derived from Device::SyncEvent or null
 /// \param[out] out C struct where to export the record batch
 /// \param[out] out_schema optional C struct where to export the record batch schema
 ARROW_EXPORT
 Status ExportDeviceRecordBatch(const RecordBatch& batch,
-                               std::shared_ptr<DeviceSync> sync,
+                               std::shared_ptr<Device::SyncEvent> sync,
                                struct ArrowDeviceArray* out,
                                struct ArrowSchema* out_schema = NULLPTR);
 

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -22,9 +22,9 @@
 #include <string>
 
 #include "arrow/c/abi.h"
+#include "arrow/device.h"
 #include "arrow/result.h"
 #include "arrow/status.h"
-#include "arrow/device.h"
 #include "arrow/type_fwd.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
@@ -221,7 +221,8 @@ Status ExportDeviceArray(const Array& array, std::shared_ptr<DeviceSync>& sync,
 /// \param[out] out C struct where to export the record batch
 /// \param[out] out_schema optional C struct where to export the record batch schema
 ARROW_EXPORT
-Status ExportDeviceRecordBatch(const RecordBatch& batch, std::shared_ptr<DeviceSync>& sync,
+Status ExportDeviceRecordBatch(const RecordBatch& batch,
+                               std::shared_ptr<DeviceSync>& sync,
                                struct ArrowDeviceArray* out,
                                struct ArrowSchema* out_schema = NULLPTR);
 

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -1193,14 +1193,13 @@ class MyMemoryManager : public CPUMemoryManager {
   }
 
   Result<std::shared_ptr<Device::SyncEvent>> MakeDeviceSyncEvent() override {
-    return std::make_shared<MyDevice::MySyncEvent>(std::unique_ptr<void, void (*)(void*)>{
-        const_cast<void*>(kMyEventPtr), [](void*) {}});
+    return std::make_shared<MyDevice::MySyncEvent>(const_cast<void*>(kMyEventPtr),
+                                                   [](void*) {});
   }
 
   Result<std::shared_ptr<Device::SyncEvent>> MakeDeviceSyncEvent(
       void* sync_event, Device::SyncEvent::release_fn_t release_sync_event) override {
-    return std::make_shared<MyDevice::MySyncEvent>(
-        std::unique_ptr<void, void (*)(void*)>{sync_event, release_sync_event});
+    return std::make_shared<MyDevice::MySyncEvent>(sync_event, release_sync_event);
   }
 
  protected:

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -1143,8 +1143,8 @@ class MyDeviceSync final : public DeviceSync {
 
   virtual ~MyDeviceSync() = default;
 
-  virtual Status wait() override { return Status::OK(); }
-  virtual Status stream_wait(void* stream) override { return Status::OK(); }
+  Status wait() override { return Status::OK(); }
+  Status stream_wait(void* stream) override { return Status::OK(); }
 
  protected:
   Result<void*> create_event() override { return const_cast<void*>(kMyEventPtr); }

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -1196,6 +1196,10 @@ class MyMemoryManager : public CPUMemoryManager {
     return std::make_unique<MyBuffer>(data, size, shared_from_this());
   }
 
+  Result<std::shared_ptr<Device::SyncEvent>> MakeDeviceSync() override {
+    return std::make_shared<MyDevice::MySyncEvent>(nullptr);
+  }
+
   Result<std::shared_ptr<Device::SyncEvent>> MakeDeviceSync(void* sync_event) override {
     return std::make_shared<MyDevice::MySyncEvent>(sync_event);
   }

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -1172,10 +1172,9 @@ class MyDevice : public Device {
 
     virtual ~MySyncEvent() = default;
 
-    Status wait() override { return Status::OK(); }
-    Status stream_wait(void* stream) override { return Status::OK(); }
-
   protected:
+    Status wait_internal() override { return Status::OK(); }
+    Status stream_wait_internal(void* stream) override { return Status::OK(); }
     Result<void*> create_event() override { return const_cast<void*>(kMyEventPtr); }
     Status record_event_on_stream(void* event) override { return Status::OK(); }
     void release_event(void* event) override {}

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -1151,7 +1151,7 @@ class MyBuffer final : public MutableBuffer {
 
 class MyDevice : public Device {
  public:
-  explicit MyDevice(int value) : Device(true), value_(value) {}
+  explicit MyDevice(int64_t value) : Device(true), value_(value) {}
   const char* type_name() const override { return kMyDeviceTypeName; }
   std::string ToString() const override { return kMyDeviceTypeName; }
   bool Equals(const Device& other) const override {

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -1137,28 +1137,18 @@ static const char kMyDeviceTypeName[] = "arrowtest::MyDevice";
 static const ArrowDeviceType kMyDeviceType = ARROW_DEVICE_EXT_DEV;
 static const void* kMyEventPtr = reinterpret_cast<void*>(0xBAADF00D);
 
-
 class MyDeviceSync final : public DeviceSync {
  public:
-  explicit MyDeviceSync(void* sync_event) 
-    : DeviceSync(sync_event) {}
-  
+  explicit MyDeviceSync(void* sync_event) : DeviceSync(sync_event) {}
+
   virtual ~MyDeviceSync() = default;
 
-  virtual Status wait() override {
-    return Status::OK();
-  }
-  virtual Status stream_wait(void* stream) override {
-    return Status::OK();
-  }
+  virtual Status wait() override { return Status::OK(); }
+  virtual Status stream_wait(void* stream) override { return Status::OK(); }
 
  protected:
-  Result<void*> create_event() override {
-    return const_cast<void*>(kMyEventPtr);
-  }
-  Status record_event_on_stream(void* event) override {
-    return Status::OK();
-  }
+  Result<void*> create_event() override { return const_cast<void*>(kMyEventPtr); }
+  Status record_event_on_stream(void* event) override { return Status::OK(); }
   void release_event(void* event) override {}
 };
 
@@ -1185,7 +1175,8 @@ class MyMemoryManager : public CPUMemoryManager {
     return std::make_unique<MyBuffer>(data, size, shared_from_this());
   }
 
-  Result<std::shared_ptr<DeviceSync>> MakeDeviceSync(void* sync_event = nullptr) override {
+  Result<std::shared_ptr<DeviceSync>> MakeDeviceSync(
+      void* sync_event = nullptr) override {
     return std::make_shared<MyDeviceSync>(sync_event);
   }
 
@@ -3594,14 +3585,15 @@ class TestDeviceArrayRoundtrip : public ::testing::Test {
   using ArrayFactory = std::function<Result<std::shared_ptr<Array>>()>;
 
   void SetUp() override { pool_ = default_memory_pool(); }
-  
-  static Result<std::shared_ptr<MemoryManager>> DeviceMapper(ArrowDeviceType type, int64_t id) {
-      if (type != kMyDeviceType) {
-        return Status::NotImplemented("should only be MyDevice") ;
-      }
-      
-      std::shared_ptr<Device> device = std::make_shared<MyDevice>(id);
-      return device->default_memory_manager();
+
+  static Result<std::shared_ptr<MemoryManager>> DeviceMapper(ArrowDeviceType type,
+                                                             int64_t id) {
+    if (type != kMyDeviceType) {
+      return Status::NotImplemented("should only be MyDevice");
+    }
+
+    std::shared_ptr<Device> device = std::make_shared<MyDevice>(id);
+    return device->default_memory_manager();
   }
 
   static Result<std::shared_ptr<ArrayData>> ToDeviceData(
@@ -3631,18 +3623,17 @@ class TestDeviceArrayRoundtrip : public ::testing::Test {
     ARROW_ASSIGN_OR_RAISE(auto result, ToDeviceData(mm, data));
     return MakeArray(result);
   }
-  
-  static ArrayFactory ToDeviceFactory(
-      const std::shared_ptr<MemoryManager>& mm, ArrayFactory&& factory) {
-    return [&]() -> Result<std::shared_ptr<Array>> { 
+
+  static ArrayFactory ToDeviceFactory(const std::shared_ptr<MemoryManager>& mm,
+                                      ArrayFactory&& factory) {
+    return [&]() -> Result<std::shared_ptr<Array>> {
       ARROW_ASSIGN_OR_RAISE(auto arr, factory());
-      return ToDevice(mm, *arr->data()); 
+      return ToDevice(mm, *arr->data());
     };
   }
 
-  static ArrayFactory JSONArrayFactory(
-      const std::shared_ptr<MemoryManager>& mm, std::shared_ptr<DataType> type,
-      const char* json) {
+  static ArrayFactory JSONArrayFactory(const std::shared_ptr<MemoryManager>& mm,
+                                       std::shared_ptr<DataType> type, const char* json) {
     return [=]() { return ToDevice(mm, *ArrayFromJSON(type, json)->data()); };
   }
 
@@ -3710,7 +3701,7 @@ class TestDeviceArrayRoundtrip : public ::testing::Test {
   void TestWithBatchFactory(BatchFactory&& factory) {
     std::shared_ptr<Device> device = std::make_shared<MyDevice>(1);
     auto mm = device->default_memory_manager();
-    
+
     std::shared_ptr<RecordBatch> batch;
     struct ArrowDeviceArray c_array {};
     struct ArrowSchema c_schema {};
@@ -3726,7 +3717,8 @@ class TestDeviceArrayRoundtrip : public ::testing::Test {
     auto new_bytes = pool_->bytes_allocated();
     batch.reset();
     ASSERT_EQ(pool_->bytes_allocated(), new_bytes);
-    ASSERT_OK_AND_ASSIGN(batch, ImportDeviceRecordBatch(&c_array, &c_schema, DeviceMapper));
+    ASSERT_OK_AND_ASSIGN(batch,
+                         ImportDeviceRecordBatch(&c_array, &c_schema, DeviceMapper));
     ASSERT_OK(batch->ValidateFull());
     ASSERT_TRUE(ArrowSchemaIsReleased(&c_schema));
     ASSERT_TRUE(ArrowArrayIsReleased(&c_array.array));
@@ -3734,7 +3726,8 @@ class TestDeviceArrayRoundtrip : public ::testing::Test {
     // Re-export and re-import, now both at once
     ASSERT_OK(ExportDeviceRecordBatch(*batch, sync, &c_array, &c_schema));
     batch.reset();
-    ASSERT_OK_AND_ASSIGN(batch, ImportDeviceRecordBatch(&c_array, &c_schema, DeviceMapper));
+    ASSERT_OK_AND_ASSIGN(batch,
+                         ImportDeviceRecordBatch(&c_array, &c_schema, DeviceMapper));
     ASSERT_OK(batch->ValidateFull());
     ASSERT_TRUE(ArrowSchemaIsReleased(&c_schema));
     ASSERT_TRUE(ArrowArrayIsReleased(&c_array.array));
@@ -3750,11 +3743,13 @@ class TestDeviceArrayRoundtrip : public ::testing::Test {
     ASSERT_EQ(pool_->bytes_allocated(), orig_bytes);
   }
 
-  void TestWithJSON(const std::shared_ptr<MemoryManager>& mm, std::shared_ptr<DataType> type, const char* json) {
+  void TestWithJSON(const std::shared_ptr<MemoryManager>& mm,
+                    std::shared_ptr<DataType> type, const char* json) {
     TestWithArrayFactory(JSONArrayFactory(mm, type, json));
   }
 
-  void TestWithJSONSliced(const std::shared_ptr<MemoryManager>& mm, std::shared_ptr<DataType> type, const char* json) {
+  void TestWithJSONSliced(const std::shared_ptr<MemoryManager>& mm,
+                          std::shared_ptr<DataType> type, const char* json) {
     TestWithArrayFactory(SlicedArrayFactory(JSONArrayFactory(mm, type, json)));
   }
 

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -1175,8 +1175,7 @@ class MyMemoryManager : public CPUMemoryManager {
     return std::make_unique<MyBuffer>(data, size, shared_from_this());
   }
 
-  Result<std::shared_ptr<DeviceSync>> MakeDeviceSync(
-      void* sync_event = nullptr) override {
+  Result<std::shared_ptr<DeviceSync>> MakeDeviceSync(void* sync_event) override {
     return std::make_shared<MyDeviceSync>(sync_event);
   }
 

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -1171,10 +1171,10 @@ class MyDevice : public Device {
     explicit MySyncEvent(void* sync_event) : Device::SyncEvent(sync_event) {}
 
     virtual ~MySyncEvent() = default;
+    Status wait() override { return Status::OK(); }
+    Status stream_wait(void* stream) override { return Status::OK(); }
 
   protected:
-    Status wait_internal() override { return Status::OK(); }
-    Status stream_wait_internal(void* stream) override { return Status::OK(); }
     Result<void*> create_event() override { return const_cast<void*>(kMyEventPtr); }
     Status record_event_on_stream(void* event) override { return Status::OK(); }
     void release_event(void* event) override {}

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -1135,7 +1135,7 @@ TEST_F(TestArrayExport, ExportRecordBatch) {
 
 static const char kMyDeviceTypeName[] = "arrowtest::MyDevice";
 static const ArrowDeviceType kMyDeviceType = ARROW_DEVICE_EXT_DEV;
-static const void* kMyEventPtr = reinterpret_cast<void*>(0xBAADF00D);
+static const void* kMyEventPtr = reinterpret_cast<void*>(uintptr_t(0xBAADF00D));
 
 class MyDeviceSync final : public DeviceSync {
  public:

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -1172,8 +1172,7 @@ class MyDevice : public Device {
         : Device::SyncEvent(sync_event, release_sync_event) {}
 
     virtual ~MySyncEvent() = default;
-    Status Wait() override { return Status::OK(); }
-    Status StreamWait(const Device::Stream&) override { return Status::OK(); }
+    Status Wait() override { return Status::OK(); }    
     Status Record(const Device::Stream&) override { return Status::OK(); }
   };
 

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -1181,7 +1181,7 @@ class MyDevice : public Device {
   };
 
  protected:
-  int value_;
+  int64_t value_;
 };
 
 class MyMemoryManager : public CPUMemoryManager {

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -1196,7 +1196,7 @@ class MyMemoryManager : public CPUMemoryManager {
                                                    [](void*) {});
   }
 
-  Result<std::shared_ptr<Device::SyncEvent>> MakeDeviceSyncEvent(
+  Result<std::shared_ptr<Device::SyncEvent>> WrapDeviceSyncEvent(
       void* sync_event, Device::SyncEvent::release_fn_t release_sync_event) override {
     return std::make_shared<MyDevice::MySyncEvent>(sync_event, release_sync_event);
   }

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -1172,7 +1172,7 @@ class MyDevice : public Device {
         : Device::SyncEvent(sync_event, release_sync_event) {}
 
     virtual ~MySyncEvent() = default;
-    Status Wait() override { return Status::OK(); }    
+    Status Wait() override { return Status::OK(); }
     Status Record(const Device::Stream&) override { return Status::OK(); }
   };
 

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -1168,8 +1168,8 @@ class MyDevice : public Device {
 
   class MySyncEvent final : public Device::SyncEvent {
    public:
-    explicit MySyncEvent(std::unique_ptr<void, void (*)(void*)> sync_event)
-        : Device::SyncEvent(std::move(sync_event)) {}
+    explicit MySyncEvent(void* sync_event, release_fn_t release_sync_event)
+        : Device::SyncEvent(sync_event, release_sync_event) {}
 
     virtual ~MySyncEvent() = default;
     Status Wait() override { return Status::OK(); }

--- a/cpp/src/arrow/device.cc
+++ b/cpp/src/arrow/device.cc
@@ -29,9 +29,12 @@ namespace arrow {
 
 MemoryManager::~MemoryManager() {}
 
-Result<std::shared_ptr<Device::SyncEvent>> MemoryManager::MakeDeviceSyncEvent() { return nullptr; }
+Result<std::shared_ptr<Device::SyncEvent>> MemoryManager::MakeDeviceSyncEvent() {
+  return nullptr;
+}
 
-Result<std::shared_ptr<Device::SyncEvent>> MemoryManager::MakeDeviceSyncEvent(std::unique_ptr<void, void(*)(void*)> event) {
+Result<std::shared_ptr<Device::SyncEvent>> MemoryManager::MakeDeviceSyncEvent(
+    void* sync_event, Device::SyncEvent::release_fn_t release_sync_event) {
   return nullptr;
 }
 

--- a/cpp/src/arrow/device.cc
+++ b/cpp/src/arrow/device.cc
@@ -29,7 +29,7 @@ namespace arrow {
 
 MemoryManager::~MemoryManager() {}
 
-Result<std::shared_ptr<DeviceSync>> MemoryManager::MakeDeviceSync(void* event) {
+Result<std::shared_ptr<Device::SyncEvent>> MemoryManager::MakeDeviceSync(void* event) {
   return nullptr;
 }
 

--- a/cpp/src/arrow/device.cc
+++ b/cpp/src/arrow/device.cc
@@ -29,7 +29,9 @@ namespace arrow {
 
 MemoryManager::~MemoryManager() {}
 
-Result<std::shared_ptr<Device::SyncEvent>> MemoryManager::MakeDeviceSync(void* event) {
+Result<std::shared_ptr<Device::SyncEvent>> MemoryManager::MakeDeviceSync() { return nullptr; }
+
+Result<std::shared_ptr<Device::SyncEvent>> MemoryManager::MakeDeviceSync(std::unique_ptr<void, void(*)(void*)> event) {
   return nullptr;
 }
 

--- a/cpp/src/arrow/device.cc
+++ b/cpp/src/arrow/device.cc
@@ -29,9 +29,9 @@ namespace arrow {
 
 MemoryManager::~MemoryManager() {}
 
-Result<std::shared_ptr<Device::SyncEvent>> MemoryManager::MakeDeviceSync() { return nullptr; }
+Result<std::shared_ptr<Device::SyncEvent>> MemoryManager::MakeDeviceSyncEvent() { return nullptr; }
 
-Result<std::shared_ptr<Device::SyncEvent>> MemoryManager::MakeDeviceSync(std::unique_ptr<void, void(*)(void*)> event) {
+Result<std::shared_ptr<Device::SyncEvent>> MemoryManager::MakeDeviceSyncEvent(std::unique_ptr<void, void(*)(void*)> event) {
   return nullptr;
 }
 

--- a/cpp/src/arrow/device.cc
+++ b/cpp/src/arrow/device.cc
@@ -29,7 +29,9 @@ namespace arrow {
 
 MemoryManager::~MemoryManager() {}
 
-Result<std::shared_ptr<DeviceSync>> MemoryManager::MakeDeviceSync(void* event) { return nullptr; }
+Result<std::shared_ptr<DeviceSync>> MemoryManager::MakeDeviceSync(void* event) {
+  return nullptr;
+}
 
 Device::~Device() {}
 

--- a/cpp/src/arrow/device.cc
+++ b/cpp/src/arrow/device.cc
@@ -29,6 +29,8 @@ namespace arrow {
 
 MemoryManager::~MemoryManager() {}
 
+Result<std::shared_ptr<DeviceSync>> MemoryManager::MakeDeviceSync(void* event) { return nullptr; }
+
 Device::~Device() {}
 
 #define COPY_BUFFER_SUCCESS(maybe_buffer) \

--- a/cpp/src/arrow/device.cc
+++ b/cpp/src/arrow/device.cc
@@ -33,7 +33,7 @@ Result<std::shared_ptr<Device::SyncEvent>> MemoryManager::MakeDeviceSyncEvent() 
   return nullptr;
 }
 
-Result<std::shared_ptr<Device::SyncEvent>> MemoryManager::MakeDeviceSyncEvent(
+Result<std::shared_ptr<Device::SyncEvent>> MemoryManager::WrapDeviceSyncEvent(
     void* sync_event, Device::SyncEvent::release_fn_t release_sync_event) {
   return nullptr;
 }

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -21,6 +21,8 @@
 #include <memory>
 #include <string>
 
+#include "arrow/status.h"
+#include "arrow/result.h"
 #include "arrow/io/type_fwd.h"
 #include "arrow/type_fwd.h"
 #include "arrow/util/compare.h"
@@ -105,6 +107,61 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
   bool is_cpu_;
 };
 
+
+class ARROW_EXPORT DeviceSync {
+ public:
+  explicit DeviceSync(void* sync_event) 
+    : sync_event_{sync_event}, owns_event_{false} {}
+  virtual ~DeviceSync() = default;
+
+  /// @brief Block until sync event is completed.
+  ///
+  /// Should be a no-op for CPU devices.  
+  virtual Status wait() = 0;
+
+  /// @brief Make the provided stream wait on the sync event.
+  ///
+  /// Tells the provided stream that it should wait until the 
+  /// synchronization event is completed without blocking the CPU.
+  /// @param stream Should be appropriate for the underlying device
+  virtual Status stream_wait(void* stream) = 0;
+
+  virtual void set_stream(void* stream) { stream_ = stream; }
+
+  Result<void*> get_event() {
+    if (!sync_event_) {
+      ARROW_ASSIGN_OR_RAISE(sync_event_, create_event());  
+      owns_event_ = true;
+    }
+    return sync_event_;
+  }
+
+  void clear_event() {
+    if (owns_event_) {
+      release_event(sync_event_);
+    }
+    sync_event_ = nullptr;
+  }  
+
+  Status record_event() {
+    if (!stream_) {
+      return Status::Invalid("Cannot record event on null stream, call set_stream first.");
+    }
+    ARROW_ASSIGN_OR_RAISE(auto ev, get_event());
+    return record_event_on_stream(ev);
+  }
+
+ protected:
+  virtual Status record_event_on_stream(void* event) = 0;
+  // allowed to gracefully receive a nullptr
+  virtual void release_event(void* event) = 0;
+  virtual Result<void*> create_event() = 0;
+
+  void* stream_;
+  void* sync_event_; 
+  bool owns_event_;
+};
+
 /// \brief EXPERIMENTAL: An object that provides memory management primitives
 ///
 /// A MemoryManager is always tied to a particular Device instance.
@@ -164,6 +221,8 @@ class ARROW_EXPORT MemoryManager : public std::enable_shared_from_this<MemoryMan
   /// See also the Buffer::View shorthand.
   static Result<std::shared_ptr<Buffer>> ViewBuffer(
       const std::shared_ptr<Buffer>& source, const std::shared_ptr<MemoryManager>& to);
+
+  virtual Result<std::shared_ptr<DeviceSync>> MakeDeviceSync(void* sync_event = nullptr);
 
  protected:
   ARROW_DISALLOW_COPY_AND_ASSIGN(MemoryManager);

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -130,7 +130,6 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
     ///
     /// Tells the provided stream that it should wait until the
     /// synchronization event is completed without blocking the CPU.
-    /// @param stream Should be appropriate for the underlying device
     virtual Status StreamWait(const Stream&) = 0;
 
     /// @brief Record the wrapped event on the stream so it triggers

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -140,10 +140,10 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
     /// If creating this with a passed in event, the caller must ensure
     /// that the event lives until clear_event is called on this as it
     /// won't own it.
-    explicit SyncEvent(std::unique_ptr<void, void (*)(void*)> sync_event)
-        : sync_event_{std::move(sync_event)} {}
+    explicit SyncEvent(void* sync_event, release_fn_t release_sync_event)
+        : sync_event_{sync_event, release_sync_event} {}
 
-    std::unique_ptr<void, void (*)(void*)> sync_event_;
+    std::unique_ptr<void, release_fn_t> sync_event_;
   };
 
  protected:

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -19,6 +19,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <string>
 
 #include "arrow/io/type_fwd.h"
@@ -102,26 +103,40 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
 
   /// \brief EXPERIMENTAL: An object that provides event/stream sync primitives
   ///
-  ///
+  /// This class is thread-safe.
   class ARROW_EXPORT SyncEvent {
    public:
     virtual ~SyncEvent() = default;
 
     /// @brief Block until sync event is completed.
-    ///
-    /// Should be a no-op for CPU devices.
-    virtual Status wait() = 0;
+    Status wait() {
+      const std::lock_guard<std::mutex> lock(mx_);
+      wait_internal();
+    }
 
     /// @brief Make the provided stream wait on the sync event.
     ///
     /// Tells the provided stream that it should wait until the
     /// synchronization event is completed without blocking the CPU.
     /// @param stream Should be appropriate for the underlying device
-    virtual Status stream_wait(void* stream) = 0;
+    Status stream_wait(void* stream) {
+      const std::lock_guard<std::mutex> lock(mx_);
+      stream_wait_internal(stream);
+    }
 
-    virtual void set_stream(void* stream) { stream_ = stream; }
+    void set_stream(void* stream) {
+      const std::lock_guard<std::mutex> lock(mx_);
+      stream_ = stream;
+    }
 
+    /// @brief Returns the stored raw event or creates a new one to return.
+    ///
+    /// clear_event should always be called to cleanup afterwards. If this
+    /// creates the event, then clear_event will call release_event 
+    /// internally. If this doesn't own the event, then the lifetime should
+    /// be controlled externally to this class.
     Result<void*> get_event() {
+      const std::lock_guard<std::mutex> lock(mx_);
       if (!sync_event_) {
         ARROW_ASSIGN_OR_RAISE(sync_event_, create_event());
         owns_event_ = true;
@@ -130,6 +145,7 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
     }
 
     void clear_event() {
+      const std::lock_guard<std::mutex> lock(mx_);
       if (owns_event_) {
         release_event(sync_event_);
       }
@@ -137,6 +153,7 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
     }
 
     Status record_event() {
+      const std::lock_guard<std::mutex> lock(mx_);
       if (!stream_) {
         return Status::Invalid(
             "Cannot record event on null stream, call set_stream first.");
@@ -146,16 +163,26 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
     }
 
    protected:
+    /// If creating this with a passed in event, the caller must ensure
+    /// that the event lives until clear_event is called on this as it
+    /// won't own it.
     explicit SyncEvent(void* sync_event) : sync_event_{sync_event}, owns_event_{false} {}
 
     virtual Status record_event_on_stream(void* event) = 0;
     // allowed to gracefully receive a nullptr
     virtual void release_event(void* event) = 0;
     virtual Result<void*> create_event() = 0;
+    virtual Status wait_internal() = 0;
+    virtual Status stream_wait_internal(void* stream) = 0;
 
     void* stream_;
     void* sync_event_;
     bool owns_event_;
+
+   private:
+    // the mutex is private as all public interfaces lock the mutex
+    // with a guard before calling protected virtual methods.
+    std::mutex mx_;
   };
 
  protected:
@@ -223,7 +250,7 @@ class ARROW_EXPORT MemoryManager : public std::enable_shared_from_this<MemoryMan
   ///
   /// See also the Buffer::View shorthand.
   static Result<std::shared_ptr<Buffer>> ViewBuffer(
-      const std::shared_ptr<Buffer>& source, const std::shared_ptr<MemoryManager>& to);  
+      const std::shared_ptr<Buffer>& source, const std::shared_ptr<MemoryManager>& to);
 
   virtual Result<std::shared_ptr<Device::SyncEvent>> MakeDeviceSync() {
     return nullptr;

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -111,7 +111,7 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
     /// @brief Block until sync event is completed.
     Status wait() {
       const std::lock_guard<std::mutex> lock(mx_);
-      wait_internal();
+      return wait_internal();
     }
 
     /// @brief Make the provided stream wait on the sync event.
@@ -121,7 +121,7 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
     /// @param stream Should be appropriate for the underlying device
     Status stream_wait(void* stream) {
       const std::lock_guard<std::mutex> lock(mx_);
-      stream_wait_internal(stream);
+      return stream_wait_internal(stream);
     }
 
     void set_stream(void* stream) {

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -224,7 +224,10 @@ class ARROW_EXPORT MemoryManager : public std::enable_shared_from_this<MemoryMan
   static Result<std::shared_ptr<Buffer>> ViewBuffer(
       const std::shared_ptr<Buffer>& source, const std::shared_ptr<MemoryManager>& to);
 
-  virtual Result<std::shared_ptr<DeviceSync>> MakeDeviceSync(void* sync_event = nullptr);
+  virtual Result<std::shared_ptr<DeviceSync>> MakeDeviceSync() {
+    return nullptr;
+  }
+  Result<std::shared_ptr<DeviceSync>> MakeDeviceSync(void *sync_event);
 
  protected:
   ARROW_DISALLOW_COPY_AND_ASSIGN(MemoryManager);

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -202,12 +202,12 @@ class ARROW_EXPORT MemoryManager : public std::enable_shared_from_this<MemoryMan
   ///
   /// This version should construct the appropriate event for the device and
   /// provide the unique_ptr with the correct deleter for the event type.  
-  virtual Result<std::shared_ptr<Device::SyncEvent>> MakeDeviceSync();
+  virtual Result<std::shared_ptr<Device::SyncEvent>> MakeDeviceSyncEvent();
 
   /// \brief Create a SyncEvent from imported device array.
   ///   
   /// @param sync_event passed in sync_event from the imported device array.
-  virtual Result<std::shared_ptr<Device::SyncEvent>> MakeDeviceSync(std::unique_ptr<void, void(*)(void*)> sync_event);
+  virtual Result<std::shared_ptr<Device::SyncEvent>> MakeDeviceSyncEvent(std::unique_ptr<void, void(*)(void*)> sync_event);
 
  protected:
   ARROW_DISALLOW_COPY_AND_ASSIGN(MemoryManager);

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -100,6 +100,8 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
   /// \brief Return the DeviceAllocationType of this device
   virtual DeviceAllocationType device_type() const = 0;
 
+  class SyncEvent;
+
   /// \brief EXPERIMENTAL: An opaque wrapper for Device-specific streams
   ///
   /// In essence this is just a wrapper around a void* to represent the
@@ -108,6 +110,12 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
   class ARROW_EXPORT Stream {
    public:
     virtual const void* get_raw() const { return NULLPTR; }
+
+    /// \brief Make the stream wait on the provided event.
+    ///
+    /// Tells the stream that it should wait until the synchronization
+    /// event is completed without blocking the CPU.
+    virtual Status WaitEvent(const SyncEvent&) = 0;
 
    protected:
     Stream() = default;
@@ -125,12 +133,6 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
 
     /// @brief Block until sync event is completed.
     virtual Status Wait() = 0;
-
-    /// @brief Make the provided stream wait on the sync event.
-    ///
-    /// Tells the provided stream that it should wait until the
-    /// synchronization event is completed without blocking the CPU.
-    virtual Status StreamWait(const Stream&) = 0;
 
     /// @brief Record the wrapped event on the stream so it triggers
     /// the event when the stream gets to that point in its queue.

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -215,18 +215,20 @@ class ARROW_EXPORT MemoryManager : public std::enable_shared_from_this<MemoryMan
   static Result<std::shared_ptr<Buffer>> ViewBuffer(
       const std::shared_ptr<Buffer>& source, const std::shared_ptr<MemoryManager>& to);
 
-  /// \brief Create a SyncEvent for exporting
+  /// \brief Create a new SyncEvent.
   ///
   /// This version should construct the appropriate event for the device and
   /// provide the unique_ptr with the correct deleter for the event type.
+  /// If the device does not require or work with any synchronization, it is
+  /// allowed for it to return a nullptr.
   virtual Result<std::shared_ptr<Device::SyncEvent>> MakeDeviceSyncEvent();
 
-  /// \brief Create a SyncEvent from imported device array.
+  /// \brief Wrap an event into a SyncEvent.
   ///
   /// @param sync_event passed in sync_event from the imported device array.
   /// @param release_sync_event destructor to free sync_event. `nullptr` may be
   ///        passed to indicate that no destruction/freeing is necessary
-  virtual Result<std::shared_ptr<Device::SyncEvent>> MakeDeviceSyncEvent(
+  virtual Result<std::shared_ptr<Device::SyncEvent>> WrapDeviceSyncEvent(
       void* sync_event, Device::SyncEvent::release_fn_t release_sync_event);
 
  protected:

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -21,9 +21,9 @@
 #include <memory>
 #include <string>
 
-#include "arrow/status.h"
-#include "arrow/result.h"
 #include "arrow/io/type_fwd.h"
+#include "arrow/result.h"
+#include "arrow/status.h"
 #include "arrow/type_fwd.h"
 #include "arrow/util/compare.h"
 #include "arrow/util/macros.h"
@@ -107,21 +107,22 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
   bool is_cpu_;
 };
 
-
+/// \brief EXPERIMENTAL: An object that provides event/stream sync primitives
+///
+///
 class ARROW_EXPORT DeviceSync {
  public:
-  explicit DeviceSync(void* sync_event) 
-    : sync_event_{sync_event}, owns_event_{false} {}
+  explicit DeviceSync(void* sync_event) : sync_event_{sync_event}, owns_event_{false} {}
   virtual ~DeviceSync() = default;
 
   /// @brief Block until sync event is completed.
   ///
-  /// Should be a no-op for CPU devices.  
+  /// Should be a no-op for CPU devices.
   virtual Status wait() = 0;
 
   /// @brief Make the provided stream wait on the sync event.
   ///
-  /// Tells the provided stream that it should wait until the 
+  /// Tells the provided stream that it should wait until the
   /// synchronization event is completed without blocking the CPU.
   /// @param stream Should be appropriate for the underlying device
   virtual Status stream_wait(void* stream) = 0;
@@ -130,7 +131,7 @@ class ARROW_EXPORT DeviceSync {
 
   Result<void*> get_event() {
     if (!sync_event_) {
-      ARROW_ASSIGN_OR_RAISE(sync_event_, create_event());  
+      ARROW_ASSIGN_OR_RAISE(sync_event_, create_event());
       owns_event_ = true;
     }
     return sync_event_;
@@ -141,11 +142,12 @@ class ARROW_EXPORT DeviceSync {
       release_event(sync_event_);
     }
     sync_event_ = nullptr;
-  }  
+  }
 
   Status record_event() {
     if (!stream_) {
-      return Status::Invalid("Cannot record event on null stream, call set_stream first.");
+      return Status::Invalid(
+          "Cannot record event on null stream, call set_stream first.");
     }
     ARROW_ASSIGN_OR_RAISE(auto ev, get_event());
     return record_event_on_stream(ev);
@@ -158,7 +160,7 @@ class ARROW_EXPORT DeviceSync {
   virtual Result<void*> create_event() = 0;
 
   void* stream_;
-  void* sync_event_; 
+  void* sync_event_;
   bool owns_event_;
 };
 

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -112,7 +112,6 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
 ///
 class ARROW_EXPORT DeviceSync {
  public:
-  explicit DeviceSync(void* sync_event) : sync_event_{sync_event}, owns_event_{false} {}
   virtual ~DeviceSync() = default;
 
   /// @brief Block until sync event is completed.
@@ -154,6 +153,8 @@ class ARROW_EXPORT DeviceSync {
   }
 
  protected:
+  explicit DeviceSync(void* sync_event) : sync_event_{sync_event}, owns_event_{false} {}
+
   virtual Status record_event_on_stream(void* event) = 0;
   // allowed to gracefully receive a nullptr
   virtual void release_event(void* event) = 0;
@@ -222,12 +223,13 @@ class ARROW_EXPORT MemoryManager : public std::enable_shared_from_this<MemoryMan
   ///
   /// See also the Buffer::View shorthand.
   static Result<std::shared_ptr<Buffer>> ViewBuffer(
-      const std::shared_ptr<Buffer>& source, const std::shared_ptr<MemoryManager>& to);
+      const std::shared_ptr<Buffer>& source, const std::shared_ptr<MemoryManager>& to);  
 
   virtual Result<std::shared_ptr<DeviceSync>> MakeDeviceSync() {
     return nullptr;
   }
-  Result<std::shared_ptr<DeviceSync>> MakeDeviceSync(void *sync_event);
+  virtual Result<std::shared_ptr<DeviceSync>> MakeDeviceSync(void *sync_event);
+
 
  protected:
   ARROW_DISALLOW_COPY_AND_ASSIGN(MemoryManager);

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -107,7 +107,7 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
   /// should be trivially constructable from it's device-specific counterparts.
   class ARROW_EXPORT Stream {
    public:
-    virtual const void* get_raw() const { return nullptr; }
+    virtual const void* get_raw() const { return NULLPTR; }
 
    protected:
     Stream() = default;

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -104,7 +104,7 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
   ///
   /// In essence this is just a wrapper around a void* to represent the
   /// standard concept of a stream/queue on a device. Derived classes
-  /// should be trivially constructable from it's device-specific counterparts.
+  /// should be trivially constructible from it's device-specific counterparts.
   class ARROW_EXPORT Stream {
    public:
     virtual const void* get_raw() const { return NULLPTR; }

--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -293,7 +293,7 @@ std::shared_ptr<CudaDevice> CudaMemoryManager::cuda_device() const {
   return checked_pointer_cast<CudaDevice>(device_);
 }
 
-Result<std::shared_ptr<Device::SyncEvent>> CudaMemoryManager::MakeDeviceSyncEvent(
+Result<std::shared_ptr<Device::SyncEvent>> CudaMemoryManager::WrapDeviceSyncEvent(
     void* sync_event, Device::SyncEvent::release_fn_t release_sync_event) {
   return nullptr;
   // auto ev = reinterpret_cast<CUstream*>(sync_event);

--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -293,7 +293,7 @@ std::shared_ptr<CudaDevice> CudaMemoryManager::cuda_device() const {
   return checked_pointer_cast<CudaDevice>(device_);
 }
 
-Result<std::shared_ptr<Device::SyncEvent>> CudaMemoryManager::MakeDeviceSync(std::unique_ptr<void, void(*)(void*)> sync_event) {
+Result<std::shared_ptr<Device::SyncEvent>> CudaMemoryManager::MakeDeviceSyncEvent(std::unique_ptr<void, void(*)(void*)> sync_event) {
   return nullptr;
   // auto ev = reinterpret_cast<CUstream*>(sync_event);
   // return std::make_shared<CudaDeviceSync>(ev);

--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -293,7 +293,8 @@ std::shared_ptr<CudaDevice> CudaMemoryManager::cuda_device() const {
   return checked_pointer_cast<CudaDevice>(device_);
 }
 
-Result<std::shared_ptr<Device::SyncEvent>> CudaMemoryManager::MakeDeviceSyncEvent(std::unique_ptr<void, void(*)(void*)> sync_event) {
+Result<std::shared_ptr<Device::SyncEvent>> CudaMemoryManager::MakeDeviceSyncEvent(
+    void* sync_event, Device::SyncEvent::release_fn_t release_sync_event) {
   return nullptr;
   // auto ev = reinterpret_cast<CUstream*>(sync_event);
   // return std::make_shared<CudaDeviceSync>(ev);

--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -293,7 +293,7 @@ std::shared_ptr<CudaDevice> CudaMemoryManager::cuda_device() const {
   return checked_pointer_cast<CudaDevice>(device_);
 }
 
-Result<std::shared_ptr<DeviceSync>> CudaMemoryManager::MakeDeviceSync(void* sync_event) {
+Result<std::shared_ptr<Device::SyncEvent>> CudaMemoryManager::MakeDeviceSync(void* sync_event) {
   return nullptr;
   // auto ev = reinterpret_cast<CUstream*>(sync_event);
   // return std::make_shared<CudaDeviceSync>(ev);

--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -293,7 +293,7 @@ std::shared_ptr<CudaDevice> CudaMemoryManager::cuda_device() const {
   return checked_pointer_cast<CudaDevice>(device_);
 }
 
-Result<std::shared_ptr<Device::SyncEvent>> CudaMemoryManager::MakeDeviceSync(void* sync_event) {
+Result<std::shared_ptr<Device::SyncEvent>> CudaMemoryManager::MakeDeviceSync(std::unique_ptr<void, void(*)(void*)> sync_event) {
   return nullptr;
   // auto ev = reinterpret_cast<CUstream*>(sync_event);
   // return std::make_shared<CudaDeviceSync>(ev);

--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -293,6 +293,12 @@ std::shared_ptr<CudaDevice> CudaMemoryManager::cuda_device() const {
   return checked_pointer_cast<CudaDevice>(device_);
 }
 
+Result<std::shared_ptr<DeviceSync>> CudaMemoryManager::MakeDeviceSync(void* sync_event) {
+  return nullptr;
+  // auto ev = reinterpret_cast<CUstream*>(sync_event);
+  // return std::make_shared<CudaDeviceSync>(ev);
+}
+
 Result<std::shared_ptr<io::RandomAccessFile>> CudaMemoryManager::GetBufferReader(
     std::shared_ptr<Buffer> buf) {
   if (*buf->device() != *device_) {

--- a/cpp/src/arrow/gpu/cuda_context.h
+++ b/cpp/src/arrow/gpu/cuda_context.h
@@ -179,7 +179,7 @@ class ARROW_EXPORT CudaMemoryManager : public MemoryManager {
   /// having to cast the `device()` result.
   std::shared_ptr<CudaDevice> cuda_device() const;
 
-  Result<std::shared_ptr<Device::SyncEvent>> MakeDeviceSyncEvent(
+  Result<std::shared_ptr<Device::SyncEvent>> WrapDeviceSyncEvent(
       void* sync_event, Device::SyncEvent::release_fn_t release_sync_event) override;
 
  protected:

--- a/cpp/src/arrow/gpu/cuda_context.h
+++ b/cpp/src/arrow/gpu/cuda_context.h
@@ -179,7 +179,7 @@ class ARROW_EXPORT CudaMemoryManager : public MemoryManager {
   /// having to cast the `device()` result.
   std::shared_ptr<CudaDevice> cuda_device() const;
 
-  Result<std::shared_ptr<Device::SyncEvent>> MakeDeviceSync(void* sync_event) override;
+  Result<std::shared_ptr<Device::SyncEvent>> MakeDeviceSync(std::unique_ptr<void, void(*)(void*)> sync_event) override;
 
  protected:
   using MemoryManager::MemoryManager;

--- a/cpp/src/arrow/gpu/cuda_context.h
+++ b/cpp/src/arrow/gpu/cuda_context.h
@@ -179,7 +179,7 @@ class ARROW_EXPORT CudaMemoryManager : public MemoryManager {
   /// having to cast the `device()` result.
   std::shared_ptr<CudaDevice> cuda_device() const;
 
-  Result<std::shared_ptr<DeviceSync>> MakeDeviceSync(void* sync_event) override;
+  Result<std::shared_ptr<Device::SyncEvent>> MakeDeviceSync(void* sync_event) override;
 
  protected:
   using MemoryManager::MemoryManager;

--- a/cpp/src/arrow/gpu/cuda_context.h
+++ b/cpp/src/arrow/gpu/cuda_context.h
@@ -179,7 +179,8 @@ class ARROW_EXPORT CudaMemoryManager : public MemoryManager {
   /// having to cast the `device()` result.
   std::shared_ptr<CudaDevice> cuda_device() const;
 
-  Result<std::shared_ptr<Device::SyncEvent>> MakeDeviceSyncEvent(std::unique_ptr<void, void(*)(void*)> sync_event) override;
+  Result<std::shared_ptr<Device::SyncEvent>> MakeDeviceSyncEvent(
+      void* sync_event, Device::SyncEvent::release_fn_t release_sync_event) override;
 
  protected:
   using MemoryManager::MemoryManager;

--- a/cpp/src/arrow/gpu/cuda_context.h
+++ b/cpp/src/arrow/gpu/cuda_context.h
@@ -179,7 +179,7 @@ class ARROW_EXPORT CudaMemoryManager : public MemoryManager {
   /// having to cast the `device()` result.
   std::shared_ptr<CudaDevice> cuda_device() const;
 
-  Result<std::shared_ptr<Device::SyncEvent>> MakeDeviceSync(std::unique_ptr<void, void(*)(void*)> sync_event) override;
+  Result<std::shared_ptr<Device::SyncEvent>> MakeDeviceSyncEvent(std::unique_ptr<void, void(*)(void*)> sync_event) override;
 
  protected:
   using MemoryManager::MemoryManager;

--- a/cpp/src/arrow/gpu/cuda_context.h
+++ b/cpp/src/arrow/gpu/cuda_context.h
@@ -179,6 +179,8 @@ class ARROW_EXPORT CudaMemoryManager : public MemoryManager {
   /// having to cast the `device()` result.
   std::shared_ptr<CudaDevice> cuda_device() const;
 
+  Result<std::shared_ptr<DeviceSync>> MakeDeviceSync(void* sync_event) override;
+
  protected:
   using MemoryManager::MemoryManager;
   static std::shared_ptr<CudaMemoryManager> Make(const std::shared_ptr<Device>& device);


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
Building on the `ArrowDeviceArray` we need to expand the abstractions for handling events and stream synchronization for devices.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
Initial Abstract implementations for the new DeviceSync API and a CPU implementation. This will be followed up by a CUDA implementation in a subsequent PR.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
Yes, tests are added for Import/Export DeviceArrays using the DeviceSync handling.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

* Closes: #36103