### PR TITLE
GH-37045: [MATLAB] Implement featherwrite in terms of arrow.internal.io.feather.Writer

### DIFF
--- a/matlab/src/matlab/featherwrite.m
+++ b/matlab/src/matlab/featherwrite.m
@@ -23,21 +23,11 @@ function featherwrite(filename, t)
 % specific language governing permissions and limitations
 % under the License.
 
-import arrow.util.table2mlarrow;
+    arguments
+        filename(1, 1) string {mustBeNonmissing, mustBeNonzeroLengthText}
+        t table
+    end
 
-% Validate input arguments.
-narginchk(2, 2);
-filename = convertStringsToChars(filename);
-if ~ischar(filename)
-    error('MATLAB:arrow:InvalidFilenameDatatype', ...
-        'Filename must be a character vector or string scalar.');
-end
-if ~istable(t)
-    error('MATLAB:arrow:InvalidInputTable', 't must be a table.');
-end
-
-[variables, metadata] = table2mlarrow(t);
-
-% Write the table to a Feather file.
-arrow.cpp.call('featherwrite', filename, variables, metadata);
+    writer = arrow.internal.io.feather.Writer(filename);
+    writer.write(t);
 end

--- a/matlab/test/tfeather.m
+++ b/matlab/test/tfeather.m
@@ -164,7 +164,7 @@ classdef tfeather < matlab.unittest.TestCase
             
             t = createTable;
             
-            testCase.verifyError(@() featherwrite({filename}, t), 'MATLAB:arrow:InvalidFilenameDatatype');
+            testCase.verifyError(@() featherwrite({table}, t), 'MATLAB:validation:UnableToConvert');
             testCase.verifyError(@() featherread({filename}), 'MATLAB:arrow:InvalidFilenameDatatype');
         end
 
@@ -178,7 +178,7 @@ classdef tfeather < matlab.unittest.TestCase
         end
 
         function ErrorIfTooFewInputs(testCase)
-            testCase.verifyError(@() featherwrite(), 'MATLAB:narginchk:notEnoughInputs');
+            testCase.verifyError(@() featherwrite(), 'MATLAB:minrhs');
             testCase.verifyError(@() featherread(), 'MATLAB:narginchk:notEnoughInputs');
         end
         
@@ -193,7 +193,7 @@ classdef tfeather < matlab.unittest.TestCase
             
             t = table(age, smoker, height, weight, bloodPressure);
             
-            testCase.verifyError(@() featherwrite(filename, t), 'MATLAB:arrow:UnsupportedVariableType');
+            testCase.verifyError(@() featherwrite(filename, t), 'arrow:array:InvalidShape');
         end
         
         function UnsupportedMATLABDatatypes(testCase)
@@ -205,7 +205,7 @@ classdef tfeather < matlab.unittest.TestCase
                                         calendarDuration(5, 3, 2)];
             actualTable = addvars(actualTable, calendarDurationVariable);
 
-            testCase.verifyError(@() featherwrite(filename, actualTable) ,'MATLAB:arrow:UnsupportedVariableType');
+            testCase.verifyError(@() featherwrite(filename, actualTable) ,'arrow:array:UnsupportedMATLABType');
         end
         
         function NumericComplexUnsupported(testCase)
@@ -216,8 +216,7 @@ classdef tfeather < matlab.unittest.TestCase
             actualTable.double(2) = exp(9) + 5i;
             actualTable.int64(2) = 1.0418e+03;
            
-            expectedTable = featherRoundTrip(filename, actualTable);
-            testCase.verifyNotEqual(actualTable, expectedTable);
+            testCase.verifyError(@() featherwrite(filename, actualTable) ,'arrow:array:ComplexNumeric');
         end
     end
 end


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Now that #37043 is merged, we can re-implement `featherwrite` in terms of the new `arrow.internal.io.feather.Writer` class. Once this change is made, we can delete the legacy build infrastructure and featherwrite MEX code. 

### What changes are included in this PR?

1. Re-implemented `featherwrite` using `arrow.internal.io.feather.Writer`. 

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

1. Yes, the existing tests in `tfeather.m` cover these changes.
2. I had to update some of the expected error message IDs in `tfeather.m` because the new implementation throws errors with different IDs. 
3. `featherwrite` used to export the real part of MATLAB complex numeric arrays. The new version of `featherwrite` now errors if the input table contains complex data because feather/Arrow itself does not support complex numeric data. We think this is the right decision. Writing out only the real part is lossy.

### Are there any user-facing changes?

Yes, `featherwrite` no longer supports writing complex numeric arrays.

### Future Directions

1. Once this PR is merged, we will remove the legacy build infrastructure and MEX code. 
* Closes: #37045