### PR TITLE
MINOR: [C++] Fix a lint failure

### DIFF
--- a/cpp/src/arrow/acero/aggregate_internal.h
+++ b/cpp/src/arrow/acero/aggregate_internal.h
@@ -52,8 +52,8 @@
 // segment-keys is used to refine the partitioning. However, segment-keys are different in
 // that they partition only consecutive rows into a single group. Such a partition of
 // consecutive rows is called a segment group. For example, consider a column X with
-// values [A, A, B, A] at row-indices [0, 1, 2, 3]. A regular group-by aggregation with keys
-// [X] yields a row-index partitioning [[0, 1, 3], [2]] whereas a segmented-group-by
+// values [A, A, B, A] at row-indices [0, 1, 2, 3]. A regular group-by aggregation with
+// keys [X] yields a row-index partitioning [[0, 1, 3], [2]] whereas a segmented-group-by
 // aggregation with segment-keys [X] yields [[0, 1], [2], [3]].
 //
 // The implementation first segments the input using the segment-keys, then groups by the


### PR DESCRIPTION
### Rationale for this change

GH-37031 had the following lint failure but I merged it. Sorry.

```text
FAILED: CMakeFiles/check-format 
cd /tmp/arrow-lint-3lmfc4qt/cpp-build && /usr/local/bin/python /arrow/cpp/build-support/run_clang_format.py --clang_format_binary /usr/bin/clang-format-14 --exclude_globs /arrow/cpp/build-support/lint_exclusions.txt --source_dir /arrow/cpp/src --source_dir /arrow/cpp/examples --source_dir /arrow/cpp/tools --quiet

--- /arrow/cpp/src/arrow/acero/aggregate_internal.h
+++ /arrow/cpp/src/arrow/acero/aggregate_internal.h (after clang format)
@@ -52,8 +52,8 @@
 // segment-keys is used to refine the partitioning. However, segment-keys are different in
 // that they partition only consecutive rows into a single group. Such a partition of
 // consecutive rows is called a segment group. For example, consider a column X with
-// values [A, A, B, A] at row-indices [0, 1, 2, 3]. A regular group-by aggregation with keys
-// [X] yields a row-index partitioning [[0, 1, 3], [2]] whereas a segmented-group-by
+// values [A, A, B, A] at row-indices [0, 1, 2, 3]. A regular group-by aggregation with
+// keys [X] yields a row-index partitioning [[0, 1, 3], [2]] whereas a segmented-group-by
 // aggregation with segment-keys [X] yields [[0, 1], [2], [3]].
 //
 // The implementation first segments the input using the segment-keys, then groups by the
/arrow/cpp/src/arrow/acero/aggregate_internal.h had clang-format style issues
```

### What changes are included in this PR?

I've fixed it by `ninja format`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.