### PR TITLE
GH-37049: [MATLAB] Update feather `Reader` and `Writer` objects to work directly with `arrow.tabular.RecordBatch`s instead of MATLAB `table`s

### DIFF
--- a/matlab/src/matlab/+arrow/+internal/+io/+feather/Reader.m
+++ b/matlab/src/matlab/+arrow/+internal/+io/+feather/Reader.m
@@ -36,11 +36,10 @@ classdef Reader
             obj.Proxy = arrow.internal.proxy.create("arrow.io.feather.proxy.Reader", args);
         end
 
-        function T = read(obj)
+        function recordBatch = read(obj)
             recordBatchProxyID = obj.Proxy.read();
             proxy = libmexclass.proxy.Proxy(Name="arrow.tabular.proxy.RecordBatch", ID=recordBatchProxyID);
             recordBatch = arrow.tabular.RecordBatch(proxy);
-            T = recordBatch.toMATLAB();
         end
 
         function filename = get.Filename(obj)

--- a/matlab/src/matlab/+arrow/+internal/+io/+feather/Writer.m
+++ b/matlab/src/matlab/+arrow/+internal/+io/+feather/Writer.m
@@ -35,9 +35,8 @@ classdef Writer < matlab.mixin.Scalar
             obj.Proxy = arrow.internal.proxy.create(proxyName, args);
         end
 
-        function write(obj, T)
-            rb = arrow.recordbatch(T);
-            args = struct(RecordBatchProxyID=rb.Proxy.ID);
+        function write(obj, recordBatch)
+            args = struct(RecordBatchProxyID=recordBatch.Proxy.ID);
             obj.Proxy.write(args);
         end
 

--- a/matlab/src/matlab/featherwrite.m
+++ b/matlab/src/matlab/featherwrite.m
@@ -28,6 +28,7 @@ function featherwrite(filename, t)
         t table
     end
 
+    recordBatch = arrow.recordbatch(t);
     writer = arrow.internal.io.feather.Writer(filename);
-    writer.write(t);
+    writer.write(recordBatch);
 end

--- a/matlab/test/arrow/io/feather/tRoundTrip.m
+++ b/matlab/test/arrow/io/feather/tRoundTrip.m
@@ -31,27 +31,27 @@ classdef tRoundTrip < matlab.unittest.TestCase
     methods(Test)
         function Basic(testCase)
             import matlab.unittest.fixtures.TemporaryFolderFixture
-            
+            import arrow.internal.io.feather.*
+
             fixture = testCase.applyFixture(TemporaryFolderFixture);
             filename = fullfile(fixture.Folder, "temp.feather");
 
             DoubleVar = [10; 20; 30; 40];
             SingleVar = single([10; 15; 20; 25]);
-            tWrite = table(DoubleVar, SingleVar);
-            
-            featherwrite(tWrite, filename);
-            tRead = featherread(filename);
-            testCase.verifyEqual(tWrite, tRead);
+
+            tableWrite = table(DoubleVar, SingleVar);
+            recordBatchWrite = arrow.recordbatch(tableWrite);
+
+            writer = Writer(filename);
+            writer.write(recordBatchWrite);
+
+            reader = arrow.internal.io.feather.Reader(filename);
+            recordBatchRead = reader.read();
+
+            tableRead = table(recordBatchRead);
+
+            testCase.verifyEqual(tableWrite, tableRead);
         end
     end
-end
 
-function featherwrite(T, filename)
-    writer = arrow.internal.io.feather.Writer(filename);
-    writer.write(T);
-end
-
-function T = featherread(filename)
-    reader = arrow.internal.io.feather.Reader(filename);
-    T = reader.read();
 end


### PR DESCRIPTION
### Rationale for this change

After thinking about how to re-implement `featherread` and `featherwrite`, we realized it would be better if the `Reader` and `Writer` classes worked directly with `arrow.tabular.RecordBatch`s instead of MATLAB `table`s. 

### What changes are included in this PR?

1. Updated `read` method of `arrow.internal.io.feather.Reader` to return an `arrow.tabular.RecordBatch` rather than a MATLAB `table`.
2. Updated `write` method of `arrow.internal.io.feather.Writer` to accept an `arrow.tabular.RecordBatch` rather than a MATLAB `table`.

### Are these changes tested?

Yes.

1. Updated `feather/tRoundTrip.m` to reflect the changes to the `Reader` and `Writer` classes.

### Are there any user-facing changes?

1. No

These are internal APIs.
* Closes: #37049