### PR TITLE
GH-37051: [Dev][JS] Add Dependabot configuration for npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/js/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "MINOR: [JS] "
   - package-ecosystem: "nuget"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,12 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "MINOR: [CI] "
+  - package-ecosystem: "npm"
+    directory: "/js/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "MINOR: [JS] "
   - package-ecosystem: "nuget"
     directory: "/csharp/"
     schedule:


### PR DESCRIPTION
### Rationale for this change

We can add `MINOR: [JS] ` prefix to PRs from Dependabot automatically.

### What changes are included in this PR?

Add a configuration for npm.

### Are these changes tested?

No. I want to test this by merging this to main.

### Are there any user-facing changes?

No.
* Closes: #37051