### PR TITLE
GH-37073: [Java] JDBC: Only use username/pass auth if token is not provided

### DIFF
--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/client/ArrowFlightSqlClientHandler.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/client/ArrowFlightSqlClientHandler.java
@@ -538,7 +538,7 @@ public final class ArrowFlightSqlClientHandler implements AutoCloseable {
       FlightClient client = null;
       try {
         ClientIncomingAuthHeaderMiddleware.Factory authFactory = null;
-        if (username != null) {
+        if (username != null && token == null) {
           authFactory =
               new ClientIncomingAuthHeaderMiddleware.Factory(new ClientBearerHeaderHandler());
           withMiddlewareFactories(authFactory);

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/client/ArrowFlightSqlClientHandler.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/client/ArrowFlightSqlClientHandler.java
@@ -538,6 +538,7 @@ public final class ArrowFlightSqlClientHandler implements AutoCloseable {
       FlightClient client = null;
       try {
         ClientIncomingAuthHeaderMiddleware.Factory authFactory = null;
+        // Token should take priority since some apps pass in a username/password even when a token is provided
         if (username != null && token == null) {
           authFactory =
               new ClientIncomingAuthHeaderMiddleware.Factory(new ClientBearerHeaderHandler());

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTest.java
@@ -18,6 +18,8 @@
 package org.apache.arrow.driver.jdbc;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.net.URISyntaxException;
 import java.sql.Connection;
@@ -105,12 +107,9 @@ public class ConnectionTest {
   /**
    * Checks if a token is provided it takes precedence over username/pass. In this case,
    * the connection should fail if a token is passed in.
-   *
-   * @throws SQLException on error.
    */
-  @Test(expected = SQLException.class)
-  public void testTokenOverridesUsernameAndPasswordAuth()
-      throws Exception {
+  @Test
+  public void testTokenOverridesUsernameAndPasswordAuth() {
     final Properties properties = new Properties();
 
     properties.put(ArrowFlightConnectionProperty.HOST.camelName(), "localhost");
@@ -123,9 +122,12 @@ public class ConnectionTest {
     properties.put(ArrowFlightConnectionProperty.TOKEN.camelName(), "token");
     properties.put("useEncryption", false);
 
-    DriverManager.getConnection(
-        "jdbc:arrow-flight-sql://" + FLIGHT_SERVER_TEST_RULE.getHost() + ":" +
-            FLIGHT_SERVER_TEST_RULE.getPort(), properties);
+    SQLException e = assertThrows(SQLException.class, () ->
+            DriverManager.getConnection(
+                    "jdbc:arrow-flight-sql://" + FLIGHT_SERVER_TEST_RULE.getHost() + ":" +
+                            FLIGHT_SERVER_TEST_RULE.getPort(),
+                    properties));
+    assertTrue(e.getMessage().contains("UNAUTHENTICATED"));
   }
 
 

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTest.java
@@ -103,6 +103,33 @@ public class ConnectionTest {
   }
 
   /**
+   * Checks if a token is provided it takes precedence over username/pass. In this case,
+   * the connection should fail if a token is passed in.
+   *
+   * @throws SQLException on error.
+   */
+  @Test(expected = SQLException.class)
+  public void testTokenOverridesUsernameAndPasswordAuth()
+      throws Exception {
+    final Properties properties = new Properties();
+
+    properties.put(ArrowFlightConnectionProperty.HOST.camelName(), "localhost");
+    properties.put(ArrowFlightConnectionProperty.PORT.camelName(),
+        FLIGHT_SERVER_TEST_RULE.getPort());
+    properties.put(ArrowFlightConnectionProperty.USER.camelName(),
+        userTest);
+    properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(),
+        passTest);
+    properties.put(ArrowFlightConnectionProperty.TOKEN.camelName(), "token");
+    properties.put("useEncryption", false);
+
+    DriverManager.getConnection(
+        "jdbc:arrow-flight-sql://" + FLIGHT_SERVER_TEST_RULE.getHost() + ":" +
+            FLIGHT_SERVER_TEST_RULE.getPort(), properties);
+  }
+
+
+  /**
    * Checks if the exception SQLException is thrown when trying to establish a connection without a host.
    *
    * @throws SQLException on error.
@@ -136,6 +163,7 @@ public class ConnectionTest {
                  .withPassword(passTest)
                  .withBufferAllocator(allocator)
                  .build()) {
+
       assertNotNull(client);
     }
   }


### PR DESCRIPTION
### Are these changes tested?

Yes 

### Are there any user-facing changes?

Provided token authentication will now take precedence over username/password.
* Closes: #37073