### PR TITLE
GH-37067: [CI][C++] Use system GoogleTest on Debian 11/Ubuntu 22.04

### DIFF
--- a/ci/docker/debian-11-cpp.dockerfile
+++ b/ci/docker/debian-11-cpp.dockerfile
@@ -120,7 +120,6 @@ ENV absl_SOURCE=BUNDLED \
     CC=gcc \
     CXX=g++ \
     google_cloud_cpp_storage_SOURCE=BUNDLED \
-    GTest_SOURCE=BUNDLED \
     ORC_SOURCE=BUNDLED \
     PATH=/usr/lib/ccache/:$PATH \
     xsimd_SOURCE=BUNDLED

--- a/ci/docker/ubuntu-22.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-22.04-cpp.dockerfile
@@ -79,6 +79,7 @@ RUN apt-get update -y -q && \
         libc-ares-dev \
         libcurl4-openssl-dev \
         libgflags-dev \
+        libgmock-dev \
         libgoogle-glog-dev \
         libgrpc++-dev \
         libidn2-dev \
@@ -165,7 +166,6 @@ RUN /arrow/ci/scripts/install_sccache.sh unknown-linux-musl /usr/local/bin
 # provided by the distribution:
 # - Abseil is old
 # - libc-ares-dev does not install CMake config files
-# - libgtest-dev only provide sources
 ENV absl_SOURCE=BUNDLED \
     ARROW_ACERO=ON \
     ARROW_AZURE=ON \
@@ -197,7 +197,6 @@ ENV absl_SOURCE=BUNDLED \
     ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-${llvm}/bin/llvm-symbolizer \
     AWSSDK_SOURCE=BUNDLED \
     google_cloud_cpp_storage_SOURCE=BUNDLED \
-    GTest_SOURCE=BUNDLED \
     ORC_SOURCE=BUNDLED \
     PARQUET_BUILD_EXAMPLES=ON \
     PARQUET_BUILD_EXECUTABLES=ON \


### PR DESCRIPTION
### Rationale for this change

It reduces build time and avoids run-time library load path problem.

### What changes are included in this PR?

Use system GoogleTest instead of bundled one.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #37067