### PR TITLE
GH-37021 [Java][arrow-jdbc] Pluggable getConsumer

### DIFF
--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/ArrowVectorIterator.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/ArrowVectorIterator.java
@@ -139,8 +139,8 @@ public class ArrowVectorIterator implements Iterator<VectorSchemaRoot>, AutoClos
     for (int i = 1; i <= consumers.length; i++) {
       final JdbcFieldInfo columnFieldInfo = JdbcToArrowUtils.getJdbcFieldInfoForColumn(rsmd, i, config);
       ArrowType arrowType = config.getJdbcToArrowTypeConverter().apply(columnFieldInfo);
-      consumers[i - 1] = JdbcToArrowUtils.getConsumer(
-          arrowType, i, isColumnNullable(resultSet.getMetaData(), i, columnFieldInfo), root.getVector(i - 1), config);
+      consumers[i - 1] = config.getJdbcConsumerGetter().apply(
+          arrowType, i, isColumnNullable(resultSet.getMetaData(), i, columnFieldInfo), root.getVector(i - 1));
     }
   }
 

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/ArrowVectorIterator.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/ArrowVectorIterator.java
@@ -140,7 +140,7 @@ public class ArrowVectorIterator implements Iterator<VectorSchemaRoot>, AutoClos
       final JdbcFieldInfo columnFieldInfo = JdbcToArrowUtils.getJdbcFieldInfoForColumn(rsmd, i, config);
       ArrowType arrowType = config.getJdbcToArrowTypeConverter().apply(columnFieldInfo);
       consumers[i - 1] = config.getJdbcConsumerGetter().apply(
-          arrowType, i, isColumnNullable(resultSet.getMetaData(), i, columnFieldInfo), root.getVector(i - 1));
+          arrowType, i, isColumnNullable(resultSet.getMetaData(), i, columnFieldInfo), root.getVector(i - 1), config);
     }
   }
 

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfig.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfig.java
@@ -208,10 +208,10 @@ public final class JdbcToArrowConfig {
         targetBatchSize,
         jdbcToArrowTypeConverter,
         null,
-        null,
-        null,
-        null,
-        null,
+        explicitTypesByColumnIndex,
+        explicitTypesByColumnName,
+        schemaMetadata,
+        columnMetadataByColumnIndex,
         bigDecimalRoundingMode);
   }
 
@@ -248,9 +248,7 @@ public final class JdbcToArrowConfig {
     this.jdbcToArrowTypeConverter = jdbcToArrowTypeConverter != null ? jdbcToArrowTypeConverter :
         (jdbcFieldInfo) -> JdbcToArrowUtils.getArrowTypeFromJdbcType(jdbcFieldInfo, calendar);
 
-    this.jdbcConsumerGetter = jdbcConsumerGetter != null ? jdbcConsumerGetter :
-        (arrowType, columnIndex, nullable, vector) ->
-                JdbcToArrowUtils.getConsumer(arrowType, columnIndex, nullable, vector, this);
+    this.jdbcConsumerGetter = jdbcConsumerGetter != null ? jdbcConsumerGetter : JdbcToArrowUtils::getConsumer;
   }
 
   /**
@@ -390,6 +388,7 @@ public final class JdbcToArrowConfig {
    */
   @FunctionalInterface
   public interface JdbcConsumerFactory {
-    JdbcConsumer apply(ArrowType arrowType, int columnIndex, boolean nullable, FieldVector vector);
+    JdbcConsumer apply(ArrowType arrowType, int columnIndex, boolean nullable, FieldVector vector,
+                       JdbcToArrowConfig config);
   }
 }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfig.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfig.java
@@ -389,7 +389,7 @@ public final class JdbcToArrowConfig {
    * Interface for a function that gets a JDBC consumer for the given values.
    */
   @FunctionalInterface
-  protected interface JdbcConsumerFactory {
+  public interface JdbcConsumerFactory {
     JdbcConsumer apply(ArrowType arrowType, int columnIndex, boolean nullable, FieldVector vector);
   }
 }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigBuilder.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigBuilder.java
@@ -24,8 +24,6 @@ import java.util.Calendar;
 import java.util.Map;
 import java.util.function.Function;
 
-import org.apache.arrow.adapter.jdbc.JdbcToArrowConfig.Function4Arity;
-import org.apache.arrow.adapter.jdbc.consumer.JdbcConsumer;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.FieldVector;
@@ -47,7 +45,7 @@ public class JdbcToArrowConfigBuilder {
   private Map<Integer, Map<String, String>> columnMetadataByColumnIndex;
   private int targetBatchSize;
   private Function<JdbcFieldInfo, ArrowType> jdbcToArrowTypeConverter;
-  private Function4Arity<ArrowType, Integer, Boolean, FieldVector, JdbcConsumer> jdbcConsumerGetter;
+  private JdbcToArrowConfig.JdbcConsumerFactory jdbcConsumerGetter;
   private RoundingMode bigDecimalRoundingMode;
 
   /**
@@ -232,7 +230,7 @@ public class JdbcToArrowConfigBuilder {
    * JdbcToArrowUtils#getConsumer(ArrowType, Integer, Boolean, FieldVector, JdbcToArrowConfig)}.
    */
   public JdbcToArrowConfigBuilder setJdbcConsumerGetter(
-      Function4Arity<ArrowType, Integer, Boolean, FieldVector, JdbcConsumer> jdbcConsumerGetter) {
+      JdbcToArrowConfig.JdbcConsumerFactory jdbcConsumerGetter) {
     this.jdbcConsumerGetter = jdbcConsumerGetter;
     return this;
   }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigBuilder.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigBuilder.java
@@ -24,8 +24,11 @@ import java.util.Calendar;
 import java.util.Map;
 import java.util.function.Function;
 
+import org.apache.arrow.adapter.jdbc.JdbcToArrowConfig.Function4Arity;
+import org.apache.arrow.adapter.jdbc.consumer.JdbcConsumer;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.util.Preconditions;
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 
 /**
@@ -44,6 +47,7 @@ public class JdbcToArrowConfigBuilder {
   private Map<Integer, Map<String, String>> columnMetadataByColumnIndex;
   private int targetBatchSize;
   private Function<JdbcFieldInfo, ArrowType> jdbcToArrowTypeConverter;
+  private Function4Arity<ArrowType, Integer, Boolean, FieldVector, JdbcConsumer> jdbcConsumerGetter;
   private RoundingMode bigDecimalRoundingMode;
 
   /**
@@ -222,6 +226,18 @@ public class JdbcToArrowConfigBuilder {
   }
 
   /**
+   * Set the function used to get a JDBC consumer for a given type.
+   * <p>
+   * Defaults to wrapping {@link
+   * JdbcToArrowUtils#getConsumer(ArrowType, Integer, Boolean, FieldVector, JdbcToArrowConfig)}.
+   */
+  public JdbcToArrowConfigBuilder setJdbcConsumerGetter(
+      Function4Arity<ArrowType, Integer, Boolean, FieldVector, JdbcConsumer> jdbcConsumerGetter) {
+    this.jdbcConsumerGetter = jdbcConsumerGetter;
+    return this;
+  }
+
+  /**
    * Set whether to use the same {@link org.apache.arrow.vector.VectorSchemaRoot} instance on each iteration,
    * or to allocate a new one.
    */
@@ -274,6 +290,7 @@ public class JdbcToArrowConfigBuilder {
         arraySubTypesByColumnName,
         targetBatchSize,
         jdbcToArrowTypeConverter,
+        jdbcConsumerGetter,
         explicitTypesByColumnIndex,
         explicitTypesByColumnName,
         schemaMetadata,

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
@@ -208,7 +208,7 @@ public class JdbcToArrowUtils {
         return new ArrowType.Struct();
       default:
         // no-op, shouldn't get here
-        return null;
+        throw new UnsupportedOperationException("Unmapped JDBC type: " + fieldInfo.getJdbcType());
     }
   }
 
@@ -489,7 +489,7 @@ public class JdbcToArrowUtils {
         return new NullConsumer((NullVector) vector);
       default:
         // no-op, shouldn't get here
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("No consumer for Arrow type: " + arrowType.getTypeID());
     }
   }
 }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
@@ -489,7 +489,7 @@ public class JdbcToArrowUtils {
         return new NullConsumer((NullVector) vector);
       default:
         // no-op, shouldn't get here
-        throw new UnsupportedOperationException("No consumer for Arrow type: " + arrowType.getTypeID());
+        throw new UnsupportedOperationException("No consumer for Arrow type: " + arrowType);
     }
   }
 }

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigTest.java
@@ -117,12 +117,12 @@ public class JdbcToArrowConfigTest {
     assertTrue(config.shouldIncludeMetadata());
 
     config = new JdbcToArrowConfig(allocator, calendar, /* include metadata */ true,
-        /* reuse vector schema root */ true, null, null, JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE, null, null);
+        /* reuse vector schema root */ true, null, null, JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE, null);
     assertTrue(config.shouldIncludeMetadata());
     assertTrue(config.isReuseVectorSchemaRoot());
 
     config = new JdbcToArrowConfig(allocator, calendar, /* include metadata */ false,
-        /* reuse vector schema root */ false, null, null, JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE, null, null);
+        /* reuse vector schema root */ false, null, null, JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE, null);
     assertFalse(config.shouldIncludeMetadata());
     assertFalse(config.isReuseVectorSchemaRoot());
   }

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigTest.java
@@ -117,12 +117,12 @@ public class JdbcToArrowConfigTest {
     assertTrue(config.shouldIncludeMetadata());
 
     config = new JdbcToArrowConfig(allocator, calendar, /* include metadata */ true,
-        /* reuse vector schema root */ true, null, null, JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE, null);
+        /* reuse vector schema root */ true, null, null, JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE, null, null);
     assertTrue(config.shouldIncludeMetadata());
     assertTrue(config.isReuseVectorSchemaRoot());
 
     config = new JdbcToArrowConfig(allocator, calendar, /* include metadata */ false,
-        /* reuse vector schema root */ false, null, null, JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE, null);
+        /* reuse vector schema root */ false, null, null, JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE, null, null);
     assertFalse(config.shouldIncludeMetadata());
     assertFalse(config.isReuseVectorSchemaRoot());
   }

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/example/FlightSqlExample.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/example/FlightSqlExample.java
@@ -300,7 +300,8 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
 
   private static ArrowType getArrowTypeFromJdbcType(final int jdbcDataType, final int precision, final int scale) {
     try {
-      return JdbcToArrowUtils.getArrowTypeFromJdbcType(new JdbcFieldInfo(jdbcDataType, precision, scale), DEFAULT_CALENDAR);
+      return JdbcToArrowUtils.getArrowTypeFromJdbcType(new JdbcFieldInfo(jdbcDataType, precision, scale),
+              DEFAULT_CALENDAR);
     } catch (UnsupportedOperationException ignored) {
       return ArrowType.Utf8.INSTANCE;
     }

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/example/FlightSqlExample.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/example/FlightSqlExample.java
@@ -299,9 +299,11 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
   }
 
   private static ArrowType getArrowTypeFromJdbcType(final int jdbcDataType, final int precision, final int scale) {
-    final ArrowType type =
-        JdbcToArrowUtils.getArrowTypeFromJdbcType(new JdbcFieldInfo(jdbcDataType, precision, scale), DEFAULT_CALENDAR);
-    return isNull(type) ? ArrowType.Utf8.INSTANCE : type;
+    try {
+      return JdbcToArrowUtils.getArrowTypeFromJdbcType(new JdbcFieldInfo(jdbcDataType, precision, scale), DEFAULT_CALENDAR);
+    } catch (UnsupportedOperationException ignored) {
+      return ArrowType.Utf8.INSTANCE;
+    }
   }
 
   private static void saveToVector(final Byte data, final UInt1Vector vector, final int index) {


### PR DESCRIPTION
### Rationale for this change

This was discussed in [this thread](https://github.com/apache/arrow/issues/37021#issuecomment-1666169351). The `getConsumer` implementation depends on the implementation for `getArrowTypeFromJdbcType`, especially for timestamp objects. Since we can provide a different implementation for `JdbcToArrowTypeConverter` it follows we should be able to provide a different implementation for `JdbcConsumerGetter`

### What changes are included in this PR?

Adds a way to configure an alternate `JdbcToArrowUtils.getConsumer` function through `JdbcToArrowConfigBuilder.setJdbcConsumerGetter`.

It also throws a more helpful exception from the default implementations when a provided type is not mapped.

### Are these changes tested?

No, the default behavior remains unchanged.
* Related: #37021
* Closes: #37021