### PR TITLE
GH-37118 [Java][arrow-jdbc] Support converting JDBC TIMESTAMP_WITH_TIMEZONE to Arrow

### DIFF
--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
@@ -188,12 +188,9 @@ public class JdbcToArrowUtils {
       case Types.TIME:
         return new ArrowType.Time(TimeUnit.MILLISECOND, 32);
       case Types.TIMESTAMP:
-        final String timezone;
-        if (calendar != null) {
-          timezone = calendar.getTimeZone().getID();
-        } else {
-          timezone = null;
-        }
+        return new ArrowType.Timestamp(TimeUnit.MILLISECOND);
+      case Types.TIMESTAMP_WITH_TIMEZONE:
+        final String timezone = calendar == null ? null : calendar.getTimeZone().getID();
         return new ArrowType.Timestamp(TimeUnit.MILLISECOND, timezone);
       case Types.BINARY:
       case Types.VARBINARY:
@@ -473,7 +470,7 @@ public class JdbcToArrowUtils {
       case Time:
         return TimeConsumer.createConsumer((TimeMilliVector) vector, columnIndex, nullable, calendar);
       case Timestamp:
-        if (config.getCalendar() == null) {
+        if (((ArrowType.Timestamp) arrowType).getTimezone() == null) {
           return TimestampConsumer.createConsumer((TimeStampMilliVector) vector, columnIndex, nullable);
         } else {
           return TimestampTZConsumer.createConsumer((TimeStampMilliTZVector) vector, columnIndex, nullable, calendar);

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
@@ -188,7 +188,7 @@ public class JdbcToArrowUtils {
       case Types.TIME:
         return new ArrowType.Time(TimeUnit.MILLISECOND, 32);
       case Types.TIMESTAMP:
-        return new ArrowType.Timestamp(TimeUnit.MILLISECOND);
+        return new ArrowType.Timestamp(TimeUnit.MILLISECOND, null);
       case Types.TIMESTAMP_WITH_TIMEZONE:
         final String timezone = calendar == null ? null : calendar.getTimeZone().getID();
         return new ArrowType.Timestamp(TimeUnit.MILLISECOND, timezone);


### PR DESCRIPTION
### Rationale for this change

We want to support converting `TIMESTAMP_WITH_TIMEZONE` JDBC fields into Arrow.

### What changes are included in this PR?

Convert `TIMESTAMP_WITH_TIMEZONE` fields into Arrow, and include the provided timezone information.
Ensure timezone information is not included in arrow object for regular `TIMESTAMP` fields.

### Are there any user-facing changes?

Potentially, depending on how users are configuring the calendar.


This might also be related to https://github.com/apache/arrow/pull/36519 since we need to ensure handling of timestamps is consistent when converting either jdbc -> arrow or arrow -> jdbc.  
* Closes: apache/arrow#37021
* Closes: apache/arrow-java#171
* GitHub Issue: #171