### PR TITLE
GH-37116: [C++][ORC] Link to absl::log_internal_check_op for ABSL_DCHECK*()

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -164,8 +164,7 @@ jobs:
       ARROW_HDFS: ON
       ARROW_HOME: /usr/local
       ARROW_JEMALLOC: ON
-      # TODO(kszucs): link error in the tests
-      ARROW_ORC: OFF
+      ARROW_ORC: ON
       ARROW_PARQUET: ON
       ARROW_S3: ON
       ARROW_WITH_BROTLI: ON

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -4399,6 +4399,11 @@ macro(build_orc)
                         PROPERTIES IMPORTED_LOCATION "${ORC_STATIC_LIB}"
                                    INTERFACE_INCLUDE_DIRECTORIES "${ORC_INCLUDE_DIR}")
   set(ORC_LINK_LIBRARIES LZ4::lz4 ZLIB::ZLIB ${ARROW_ZSTD_LIBZSTD} ${Snappy_TARGET})
+  # Protobuf generated files may use ABSL_DCHECK*() and
+  # absl::log_internal_check_op is needed for them.
+  if(TARGET absl::log_internal_check_op)
+    list(APPEND ORC_LINK_LIBRARIES absl::log_internal_check_op)
+  endif()
   if(NOT MSVC)
     if(NOT APPLE)
       list(APPEND ORC_LINK_LIBRARIES Threads::Threads)


### PR DESCRIPTION
### Rationale for this change

Recent protoc generates files that use ABSL_DCHECK*(). At least 3.21.12 doesn't use ABSL_DCHECK*() and 23.4 uses ABSL_DCHECK*().

If ABSL_DCHECK*() are used, we need to link to absl::log_internal_check_op.

### What changes are included in this PR?

Link to absl::log_internal_check_op if possible.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #37116