### PR TITLE
GH-37022: [CI][Java] Use the official Maven download URL

### DIFF
--- a/ci/docker/java-jni-manylinux-201x.dockerfile
+++ b/ci/docker/java-jni-manylinux-201x.dockerfile
@@ -37,7 +37,10 @@ ARG java=1.8.0
 ARG maven=3.9.3
 RUN yum install -y java-$java-openjdk-devel && \
       yum clean all && \
-      curl https://dlcdn.apache.org/maven/maven-3/${maven}/binaries/apache-maven-${maven}-bin.tar.gz | \
+      curl \
+        --fail \
+        --location \
+        "https://www.apache.org/dyn/closer.lua?action=download&filename=maven/maven-3/${maven}/binaries/apache-maven-${maven}-bin.tar.gz" | \
         tar xfz - -C /usr/local && \
       ln -s /usr/local/apache-maven-${maven}/bin/mvn /usr/local/bin
 


### PR DESCRIPTION
### Rationale for this change

If we use https://dlcdn.apache.org/ instead of
https://www.apache.org/dyn/closer.lua , old source archived can't be downloaded.

### What changes are included in this PR?

Use https://www.apache.org/dyn/closer.lua .

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #37022