### PR TITLE
GH-37128: [Java] Bump CI job from JDK 18 to JDK 20

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -70,8 +70,8 @@ jobs:
           maven: 3.8.5
           image: oracle-java
         - jdk: 20
-          title: AMD64 Oracle Linux Server 8.5 Java JDK 20 Maven 3.9.4
-          maven: 3.9.4
+          title: AMD64 Oracle Linux Server 8.6 Java JDK 20 Maven 3.9.3
+          maven: 3.9.3
           image: oracle-java
     env:
       JDK: ${{ matrix.jdk }}

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -66,9 +66,9 @@ jobs:
           maven: 3.6.2
           image: debian-java
         - jdk: 17
-          title: AMD64 Oracle Linux Server 8.5 Java JDK 17 Maven 3.8.5
-          maven: 3.8.5
-          image: oracle-java
+          title: AMD64 Ubuntu 22.04 Java JDK 17 Maven 3.9.3
+          maven: 3.9.3
+          image: eclipse-java
         - jdk: 20
           title: AMD64 Ubuntu 22.04 Java JDK 20 Maven 3.9.3
           maven: 3.9.3

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -69,9 +69,9 @@ jobs:
           title: AMD64 Oracle Linux Server 8.5 Java JDK 17 Maven 3.8.5
           maven: 3.8.5
           image: oracle-java
-        - jdk: 20
-          title: AMD64 Oracle Linux Server 8.6 Java JDK 20 Maven 3.9.3
-          maven: 3.9.3
+        - jdk: 18
+          title: AMD64 Oracle Linux Server 8.6 Java JDK 18 Maven 3.8.7
+          maven: 3.8.7
           image: oracle-java
     env:
       JDK: ${{ matrix.jdk }}

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -70,7 +70,7 @@ jobs:
           maven: 3.8.5
           image: oracle-java
         - jdk: 20
-          title: AMD64 Oracle Linux Server ??? Java JDK 20 Maven 3.9.3
+          title: AMD64 Ubuntu 22.04 Java JDK 20 Maven 3.9.3
           maven: 3.9.3
           image: eclipse-java
     env:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -69,10 +69,10 @@ jobs:
           title: AMD64 Oracle Linux Server 8.5 Java JDK 17 Maven 3.8.5
           maven: 3.8.5
           image: oracle-java
-        - jdk: 18
-          title: AMD64 Oracle Linux Server 8.6 Java JDK 18 Maven 3.8.7
-          maven: 3.8.7
-          image: oracle-java
+        - jdk: 20
+          title: AMD64 Oracle Linux Server ??? Java JDK 20 Maven 3.9.3
+          maven: 3.9.3
+          image: eclipse-java
     env:
       JDK: ${{ matrix.jdk }}
       MAVEN: ${{ matrix.maven }}

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -69,9 +69,9 @@ jobs:
           title: AMD64 Oracle Linux Server 8.5 Java JDK 17 Maven 3.8.5
           maven: 3.8.5
           image: oracle-java
-        - jdk: 18
-          title: AMD64 Oracle Linux Server 8.6 Java JDK 18 Maven 3.8.5
-          maven: 3.8.5
+        - jdk: 20
+          title: AMD64 Oracle Linux Server 8.5 Java JDK 20 Maven 3.9.4
+          maven: 3.9.4
           image: oracle-java
     env:
       JDK: ${{ matrix.jdk }}

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [8, 11, 17, 18]
+        jdk: [8, 11, 17, 20]
         include:
         - jdk: 8
           title: AMD64 Debian 9 Java JDK 8 Maven 3.5.4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,7 +139,6 @@ x-hierarchy:
   - eclipse-java
   - fedora-cpp:
     - fedora-python
-  - oracle-java
   - python-sdist
   - ubuntu-cpp:
     - ubuntu-cpp-static
@@ -1666,25 +1665,13 @@ services:
         /arrow/ci/scripts/java_build.sh /arrow /build &&
         /arrow/ci/scripts/java_test.sh /arrow /build"
 
-  oracle-java:
-    # Usage:
-    #   docker-compose build oracle-java
-    #   docker-compose run oracle-java
-    # Parameters:
-    #   MAVEN: 3.8.5
-    #   JDK: 17
-    image: ${ARCH}/maven:${MAVEN}-openjdk-${JDK}
-    shm_size: *shm-size
-    volumes: *java-volumes
-    command: *java-command
-
   eclipse-java:
     # Usage:
     #   docker-compose build eclipse-java
     #   docker-compose run eclipse-java
     # Parameters:
     #   MAVEN: 3.9.3
-    #   JDK: 20
+    #   JDK: 17, 20
     image: ${ARCH}/maven:${MAVEN}-eclipse-temurin-${JDK}
     shm_size: *shm-size
     volumes: *java-volumes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1670,8 +1670,8 @@ services:
     #   docker-compose build oracle-java
     #   docker-compose run oracle-java
     # Parameters:
-    #   MAVEN: 3.8.5
-    #   JDK: 17
+    #   MAVEN: 3.8.5, 3.9.4
+    #   JDK: 17, 20
     image: ${ARCH}/maven:${MAVEN}-openjdk-${JDK}
     shm_size: *shm-size
     volumes: *java-volumes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,6 +136,7 @@ x-hierarchy:
     - debian-go-cgo-python
   - debian-java
   - debian-js
+  - eclipse-java
   - fedora-cpp:
     - fedora-python
   - oracle-java
@@ -1670,9 +1671,21 @@ services:
     #   docker-compose build oracle-java
     #   docker-compose run oracle-java
     # Parameters:
-    #   MAVEN: 3.8.5, 3.8.7
-    #   JDK: 17, 18
+    #   MAVEN: 3.8.5
+    #   JDK: 17
     image: ${ARCH}/maven:${MAVEN}-openjdk-${JDK}
+    shm_size: *shm-size
+    volumes: *java-volumes
+    command: *java-command
+
+  eclipse-java:
+    # Usage:
+    #   docker-compose build eclipse-java
+    #   docker-compose run eclipse-java
+    # Parameters:
+    #   MAVEN: 3.9.3
+    #   JDK: 20
+    image: ${ARCH}/maven:${MAVEN}-eclipse-temurin-${JDK}
     shm_size: *shm-size
     volumes: *java-volumes
     command: *java-command

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1670,8 +1670,8 @@ services:
     #   docker-compose build oracle-java
     #   docker-compose run oracle-java
     # Parameters:
-    #   MAVEN: 3.8.5, 3.9.4
-    #   JDK: 17, 20
+    #   MAVEN: 3.8.5, 3.8.7
+    #   JDK: 17, 18
     image: ${ARCH}/maven:${MAVEN}-openjdk-${JDK}
     shm_size: *shm-size
     volumes: *java-volumes

--- a/java/flight/flight-sql-jdbc-core/pom.xml
+++ b/java/flight/flight-sql-jdbc-core/pom.xml
@@ -107,14 +107,14 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.12.4</version>
+            <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <version>3.12.4</version>
+            <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/client/utils/ClientAuthenticationUtilsTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/client/utils/ClientAuthenticationUtilsTest.java
@@ -158,7 +158,7 @@ public class ClientAuthenticationUtilsTest {
           if (method.getName().equals("getInstance")) {
             return invocationOnMock.callRealMethod();
           }
-          return invocationOnMock.getMock();
+          return method.invoke(invocationOnMock.getMock(), invocationOnMock.getArguments());
         }
     );
   }
@@ -169,13 +169,15 @@ public class ClientAuthenticationUtilsTest {
       if (method.getName().equals("getCertificateInputStreamFromSystem")) {
         return invocationOnMock.callRealMethod();
       }
-      return invocationOnMock.getMock();
+      return method.invoke(invocationOnMock.getMock(), invocationOnMock.getArguments());
     });
   }
 
   private void setOperatingSystemMock(MockedStatic<ClientAuthenticationUtils> clientAuthenticationUtilsMockedStatic,
                                       boolean isWindows, boolean isMac) {
     clientAuthenticationUtilsMockedStatic.when(ClientAuthenticationUtils::isMac).thenReturn(isMac);
+    Assert.assertEquals(ClientAuthenticationUtils.isMac(), isMac);
     clientAuthenticationUtilsMockedStatic.when(ClientAuthenticationUtils::isWindows).thenReturn(isWindows);
+    Assert.assertEquals(ClientAuthenticationUtils.isWindows(), isWindows);
   }
 }

--- a/java/flight/flight-sql-jdbc-driver/pom.xml
+++ b/java/flight/flight-sql-jdbc-driver/pom.xml
@@ -68,14 +68,14 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.12.4</version>
+            <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <version>3.12.4</version>
+            <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
### Rationale for this change

Our CI job should be testing the latest Java/Maven combo. It has currently fallen behind by 2 JDK releases (18 -> 20). Also, let's bump the maven version to the latest stable release.

We are also seeing some flaky CI jobs related to CycloneDx that only fails on the Java 17/18 CI jobs (so far). Maybe this resolves it? For more details, see https://github.com/apache/arrow/issues/36371

### What changes are included in this PR?

* Bump Java/Maven versions for one CI job

### Are these changes tested?

Relying on CI to test.

### Are there any user-facing changes?

No
* Closes: #37128