### PR TITLE
MINOR: [CI][C++] Remove needless NPROC from Windows job

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -272,7 +272,6 @@ jobs:
       CMAKE_INSTALL_LIBDIR: bin
       CMAKE_INSTALL_PREFIX: /usr
       CMAKE_UNITY_BUILD: ON
-      NPROC: 3
     steps:
       - name: Disable Crash Dialogs
         run: |


### PR DESCRIPTION
### Rationale for this change

It's not used ci/scripts/cpp_build.sh. NUMBER_OF_PROCESSORS is used instead because uname is MINGW64_NT-10.0-20348.

### What changes are included in this PR?

Remove unused NPROC.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.