### PR TITLE
GH-37129: [CI][Docs] Use Ubuntu 22.04

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,12 +30,12 @@ env:
 jobs:
 
   complete:
-    name: AMD64 Ubuntu 20.04 Complete Documentation
+    name: AMD64 Ubuntu 22.04 Complete Documentation
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 150
     env:
-      UBUNTU: "20.04"
+      UBUNTU: "22.04"
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v3


### PR DESCRIPTION
### Rationale for this change

It also reduces disk usage because we can use system gRPC on Ubuntu 22.04.

### What changes are included in this PR?

Use Ubuntu 22.04.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #37129