### PR TITLE
GH-37110: [C++] Expression: SmallestTypeFor lost tz for Scalar

### DIFF
--- a/cpp/src/arrow/compute/expression.cc
+++ b/cpp/src/arrow/compute/expression.cc
@@ -480,26 +480,26 @@ TypeHolder SmallestTypeFor(const arrow::Datum& value) {
           return value.type();
         case TimeUnit::MILLI:
           if (ts % 1000 == 0) {
-            return timestamp(TimeUnit::SECOND);
+            return timestamp(TimeUnit::SECOND, ts_type->timezone());
           }
           return value.type();
         case TimeUnit::MICRO:
           if (ts % 1000000 == 0) {
-            return timestamp(TimeUnit::SECOND);
+            return timestamp(TimeUnit::SECOND, ts_type->timezone());
           }
           if (ts % 1000 == 0) {
-            return timestamp(TimeUnit::MILLI);
+            return timestamp(TimeUnit::MILLI, ts_type->timezone());
           }
           return value.type();
         case TimeUnit::NANO:
           if (ts % 1000000000 == 0) {
-            return timestamp(TimeUnit::SECOND);
+            return timestamp(TimeUnit::SECOND, ts_type->timezone());
           }
           if (ts % 1000000 == 0) {
-            return timestamp(TimeUnit::MILLI);
+            return timestamp(TimeUnit::MILLI, ts_type->timezone());
           }
           if (ts % 1000 == 0) {
-            return timestamp(TimeUnit::MICRO);
+            return timestamp(TimeUnit::MICRO, ts_type->timezone());
           }
           return value.type();
         default:

--- a/cpp/src/arrow/compute/expression_test.cc
+++ b/cpp/src/arrow/compute/expression_test.cc
@@ -63,6 +63,7 @@ const std::shared_ptr<Schema> kBoringSchema = schema({
     field("ts_ns", timestamp(TimeUnit::NANO)),
     field("ts_s", timestamp(TimeUnit::SECOND)),
     field("binary", binary()),
+    field("ts_s_utc", timestamp(TimeUnit::SECOND, "UTC")),
 });
 
 #define EXPECT_OK ARROW_EXPECT_OK
@@ -632,10 +633,16 @@ TEST(Expression, BindWithImplicitCasts) {
                       literal(std::make_shared<TimestampScalar>(0, TimeUnit::SECOND))));
     // GH-37110
     ExpectBindsTo(
-        cmp(field_ref("ts_s"),
+        cmp(field_ref("ts_s_utc"),
             literal(std::make_shared<TimestampScalar>(0, TimeUnit::NANO, "UTC"))),
-        cmp(field_ref("ts_s"),
+        cmp(field_ref("ts_s_utc"),
             literal(std::make_shared<TimestampScalar>(0, TimeUnit::SECOND, "UTC"))));
+    ExpectBindsTo(
+        cmp(field_ref("ts_s_utc"),
+            literal(std::make_shared<TimestampScalar>(123000, TimeUnit::NANO, "UTC"))),
+        cmp(field_ref("ts_s_utc"),
+            literal(std::make_shared<TimestampScalar>(123, TimeUnit::MICRO, "UTC"))));
+
     ExpectBindsTo(
         cmp(field_ref("binary"), literal(std::make_shared<LargeBinaryScalar>("foo"))),
         cmp(field_ref("binary"), literal(std::make_shared<BinaryScalar>("foo"))));

--- a/cpp/src/arrow/compute/expression_test.cc
+++ b/cpp/src/arrow/compute/expression_test.cc
@@ -630,6 +630,12 @@ TEST(Expression, BindWithImplicitCasts) {
                       literal(std::make_shared<TimestampScalar>(0, TimeUnit::NANO))),
                   cmp(field_ref("ts_s"),
                       literal(std::make_shared<TimestampScalar>(0, TimeUnit::SECOND))));
+    // GH-37110
+    ExpectBindsTo(
+        cmp(field_ref("ts_s"),
+            literal(std::make_shared<TimestampScalar>(0, TimeUnit::NANO, "UTC"))),
+        cmp(field_ref("ts_s"),
+            literal(std::make_shared<TimestampScalar>(0, TimeUnit::SECOND, "UTC"))));
     ExpectBindsTo(
         cmp(field_ref("binary"), literal(std::make_shared<LargeBinaryScalar>("foo"))),
         cmp(field_ref("binary"), literal(std::make_shared<BinaryScalar>("foo"))));


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This patch ( https://github.com/apache/arrow/pull/15180 ) adds a `SmallestTypeFor` to handling expression type. However, it lost timezone when handling.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add `timezone` in `SmallestTypeFor`

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Currently not

### Are there any user-facing changes?

Yeah it's a bugfix

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #37110