### PR TITLE
GH-36969: [R] Disable GCS by default when doing a bundled build on gcc-13

### DIFF
--- a/r/configure
+++ b/r/configure
@@ -105,8 +105,9 @@ fi
 # ARROW_WITH_GOOGLE_CLOUD_CPP to OFF (if not already set)
 if [ -z "$ARROW_WITH_GOOGLE_CLOUD_CPP" ]; then
   CXX17=`${R_HOME}/bin/R CMD config CXX17`
-  if echo "$CXX17" | grep -e "gcc" ; then
-    if $CXX17 --version | grep -e "13.[0-9]\+.[0-9]\+" > /dev/null ; then
+  CXX17_VERSION=`$CXX17 --version`
+  if echo "$CXX17_VERSION" | grep -e "gcc" ; then
+    if echo "$CXX17_VERSION" | grep -e "13.[0-9]\+.[0-9]\+" > /dev/null ; then
       echo "*** Disabling Arrow build with GCS on gcc-13."
       echo "*** Set ARROW_GCS=ON to explicitly enable."
       export ARROW_GCS="OFF"

--- a/r/configure
+++ b/r/configure
@@ -104,10 +104,13 @@ fi
 # gcc-13. As a workaround for the 13.0.0 release, explicitly set
 # ARROW_WITH_GOOGLE_CLOUD_CPP to OFF (if not already set)
 if [ -z "$ARROW_WITH_GOOGLE_CLOUD_CPP" ]; then
-  if ${R_HOME}/bin/R CMD config CXX17 | grep -e "gcc" ; then
-    echo "*** Disabling Arrow build with GCS on gcc-13."
-    echo "*** Set ARROW_WITH_GOOGLE_CLOUD_CPP=ON to explicitly enable."
-    export ARROW_WITH_GOOGLE_CLOUD_CPP="OFF"
+  CXX17=`${R_HOME}/bin/R CMD config CXX17`
+  if echo "$CXX17" | grep -e "gcc" ; then
+    if $CXX17 --version | grep -e "13.[0-9]\+.[0-9]\+" > /dev/null ; then
+      echo "*** Disabling Arrow build with GCS on gcc-13."
+      echo "*** Set ARROW_WITH_GOOGLE_CLOUD_CPP=ON to explicitly enable."
+      export ARROW_WITH_GOOGLE_CLOUD_CPP="OFF"
+    fi
   fi
 fi
 

--- a/r/configure
+++ b/r/configure
@@ -100,6 +100,15 @@ if [ ! "`${R_HOME}/bin/R CMD config CXX17`" ]; then
   exit 1
 fi
 
+# GH-36969: The version of Abseil used in the bundled build won't build on
+# gcc-13. As a workaround for the 13.0.0 release, explicitly set
+# ARROW_WITH_GOOGLE_CLOUD_CPP to OFF (if not already set)
+if [ -z "$ARROW_WITH_GOOGLE_CLOUD_CPP" ]; then
+  if "`${R_HOME}/bin/R CMD config CXX17`" | grep -e "gcc" ; then
+    export ARROW_WITH_GOOGLE_CLOUD_CPP="OFF"
+  fi
+fi
+
 # Test if pkg-config is available to use
 if ${PKG_CONFIG} --version >/dev/null 2>&1; then
   PKG_CONFIG_AVAILABLE="true"

--- a/r/configure
+++ b/r/configure
@@ -106,7 +106,7 @@ fi
 if [ -z "$ARROW_GCS" ]; then
   CXX17=`${R_HOME}/bin/R CMD config CXX17`
   CXX17_VERSION=`$CXX17 --version`
-  if echo "$CXX17_VERSION" | grep -e "gcc" ; then
+  if echo "$CXX17_VERSION" | grep -e "gcc" > /dev/null ; then
     if echo "$CXX17_VERSION" | grep -e "13.[0-9]\+.[0-9]\+" > /dev/null ; then
       echo "*** Disabling Arrow build with GCS on gcc-13."
       echo "*** Set ARROW_GCS=ON to explicitly enable."

--- a/r/configure
+++ b/r/configure
@@ -108,8 +108,8 @@ if [ -z "$ARROW_WITH_GOOGLE_CLOUD_CPP" ]; then
   if echo "$CXX17" | grep -e "gcc" ; then
     if $CXX17 --version | grep -e "13.[0-9]\+.[0-9]\+" > /dev/null ; then
       echo "*** Disabling Arrow build with GCS on gcc-13."
-      echo "*** Set ARROW_WITH_GOOGLE_CLOUD_CPP=ON to explicitly enable."
-      export ARROW_WITH_GOOGLE_CLOUD_CPP="OFF"
+      echo "*** Set ARROW_GCS=ON to explicitly enable."
+      export ARROW_GCS="OFF"
     fi
   fi
 fi

--- a/r/configure
+++ b/r/configure
@@ -104,7 +104,9 @@ fi
 # gcc-13. As a workaround for the 13.0.0 release, explicitly set
 # ARROW_WITH_GOOGLE_CLOUD_CPP to OFF (if not already set)
 if [ -z "$ARROW_WITH_GOOGLE_CLOUD_CPP" ]; then
-  if "`${R_HOME}/bin/R CMD config CXX17`" | grep -e "gcc" ; then
+  if ${R_HOME}/bin/R CMD config CXX17 | grep -e "gcc" ; then
+    echo "*** Disabling Arrow build with GCS on gcc-13."
+    echo "*** Set ARROW_WITH_GOOGLE_CLOUD_CPP=ON to explicitly enable."
     export ARROW_WITH_GOOGLE_CLOUD_CPP="OFF"
   fi
 fi

--- a/r/configure
+++ b/r/configure
@@ -103,7 +103,7 @@ fi
 # GH-36969: The version of Abseil used in the bundled build won't build on
 # gcc-13. As a workaround for the 13.0.0 release, explicitly set
 # ARROW_WITH_GOOGLE_CLOUD_CPP to OFF (if not already set)
-if [ -z "$ARROW_WITH_GOOGLE_CLOUD_CPP" ]; then
+if [ -z "$ARROW_GCS" ]; then
   CXX17=`${R_HOME}/bin/R CMD config CXX17`
   CXX17_VERSION=`$CXX17 --version`
   if echo "$CXX17_VERSION" | grep -e "gcc" ; then

--- a/r/configure
+++ b/r/configure
@@ -106,7 +106,7 @@ fi
 if [ -z "$ARROW_GCS" ]; then
   CXX17=`${R_HOME}/bin/R CMD config CXX17`
   CXX17_VERSION=`$CXX17 --version`
-  if echo "$CXX17_VERSION" | grep -e "gcc" > /dev/null ; then
+  if echo "$CXX17_VERSION" | grep -e "g++" > /dev/null ; then
     if echo "$CXX17_VERSION" | grep -e "13.[0-9]\+.[0-9]\+" > /dev/null ; then
       echo "*** Disabling Arrow build with GCS on gcc-13."
       echo "*** Set ARROW_GCS=ON to explicitly enable."


### PR DESCRIPTION
### Rationale for this change

Currently a naive `install.packages("arrow")` will result in a failed build if gcc-13 is the compiler. This is because we include GCS by default on this type of build (bundled). CRAN's check farm includes at least one system where gcc-13 is the compiler and so we can't error or suggest a user workaround.

### What changes are included in this PR?

This PR explicitly sets the relevant environment variable if the compiler version string contains "g++" and "13.XX.XX". This is admittedly crude; however, the alternative of updating Abseil results in a cascading set of changes that may break other parts of Arrow. Few if any actual users will build the Arrow R package from source using gcc-13, so this has a much lower footprint (and a workaround: you can just set the ARROW_GCS environment variable + custom abseil location yourself before building if you do, in fact, want to attempt this).

### Are these changes tested?

Tested via crossbow (see below).

### Are there any user-facing changes?

No.
* Closes: #36969