### PR TITLE
GH-37151: [MATLAB] Use `makeValidVariableNames` and `makeValidDimensionNames` in implementation of `table` method for `RecordBatch` 

### DIFF
--- a/matlab/src/matlab/+arrow/+tabular/RecordBatch.m
+++ b/matlab/src/matlab/+arrow/+tabular/RecordBatch.m
@@ -59,6 +59,8 @@ classdef RecordBatch < matlab.mixin.CustomDisplay & ...
         end
 
         function T = table(obj)
+            import arrow.tabular.internal.*
+
             numColumns = obj.NumColumns;
             matlabArrays = cell(1, numColumns);
             
@@ -67,10 +69,12 @@ classdef RecordBatch < matlab.mixin.CustomDisplay & ...
                 matlabArrays{ii} = toMATLAB(arrowArray);
             end
 
-            variableNames = matlab.lang.makeUniqueStrings(obj.ColumnNames);
-            % NOTE: Does not currently handle edge cases like ColumnNames
-            %       matching the table DimensionNames.
-            T = table(matlabArrays{:}, VariableNames=variableNames);
+            validVariableNames = makeValidVariableNames(obj.ColumnNames);
+            validDimensionNames = makeValidDimensionNames(validVariableNames);
+
+            T = table(matlabArrays{:}, ...
+                VariableNames=validVariableNames, ...
+                DimensionNames=validDimensionNames);
         end
 
         function T = toMATLAB(obj)


### PR DESCRIPTION
### Rationale for this change

#37098 added utilities for making valid MATLAB `table` `VariableNames` (`makeValidVariableNames`) and `DimensionNames` (`makeValidDimensionNames`) from an arbitrary list of strings.

This pull request uses these utilities to ensure that `RecordBatch` field names are converted to valid MATLAB `table` `VariableNames`/`DimensionNames` when calling the `table`/`toMATLAB` methods.

### What changes are included in this PR?

1. Used `makeValidVariableNames` and `makeValidDimensionNames` utilities in the implementation of the `table` method for the `RecordBatch` class to ensure that column names are converted to valid MATLAB `table` `VariableNames`/`DimensionNames`.

### Are these changes tested?

Yes.

1. The existing tests in `arrow/matlab/test/arrow/tabular/tMakeValidVariableNames.m` and `arrow/matlab/test/arrow/tabular/tMakeValidDimensionNames.m` already test that an arbitrary list of column names are converted into valid MATLAB `table` `VariableNames`/`DimensionNames`.
2. There is currently no straightforward way to create a `RecordBatch` with field names that are invalid MATLAB `VariableNames`/`DimensionNames` using the MATLAB interface. When we have a way to do this in the MATLAB interface, we can add more "integration" tests which verify that a `RecordBatch` with field names that are invalid MATLAB `table` `VariableNames`/`DimensionNames` are converted into valid `VariableNames`/`DimensionNames` when the `table`/`toMATLAB` methods are called.

### Are there any user-facing changes?

Yes.

A `RecordBatch` with field names that are invalid MATLAB `table` `VariableNames`/`DimensionNames` will now be converted into a MATLAB `table` with valid `VariableNames`/`DimensionNames` when calling the `table`/`toMATLAB` methods.

### Future Directions

1. #37046 (this change to the `table` method of the `RecordBatch` class should help preserve the behavior of storing original `RecordBatch` field names in the `VariableDescriptions` property of the output MATLAB `table` returned by `featherread`).
* Closes: #37151