### PR TITLE
GH-37155: [MATLAB] Use `arrow.internal.validate.index.numeric()` in the `column()` method of `arrow.tabular.RecordBatch`

### DIFF
--- a/matlab/test/arrow/tabular/tRecordBatch.m
+++ b/matlab/test/arrow/tabular/tRecordBatch.m
@@ -129,7 +129,7 @@ classdef tRecordBatch < matlab.unittest.TestCase
             tc.verifyError(fcn, "MATLAB:expectedScalar");
         end
 
-        function ErrorIfNonPositiveIndex(tc)
+        function ErrorIfIndexIsNonPositive(tc)
             TOriginal = table(1, 2, 3);
             arrowRecordBatch = arrow.recordbatch(TOriginal);
             fcn = @() arrowRecordBatch.column(-1);

--- a/matlab/test/arrow/tabular/tRecordBatch.m
+++ b/matlab/test/arrow/tabular/tRecordBatch.m
@@ -119,7 +119,14 @@ classdef tRecordBatch < matlab.unittest.TestCase
             TOriginal = table(1, 2, 3);
             arrowRecordBatch = arrow.recordbatch(TOriginal);
             fcn = @() arrowRecordBatch.column(datetime(2022, 1, 3));
-            tc.verifyError(fcn, "arrow:tabular:recordbatch:UnsupportedColumnIndexType");
+            tc.verifyError(fcn, "arrow:badsubscript:NonNumeric");
+        end
+
+        function ErrorIfIndexIsNonScalar(tc)
+            TOriginal = table(1, 2, 3);
+            arrowRecordBatch = arrow.recordbatch(TOriginal);
+            fcn = @() arrowRecordBatch.column([1 2]);
+            tc.verifyError(fcn, "MATLAB:expectedScalar");
         end
     end
 end

--- a/matlab/test/arrow/tabular/tRecordBatch.m
+++ b/matlab/test/arrow/tabular/tRecordBatch.m
@@ -128,5 +128,12 @@ classdef tRecordBatch < matlab.unittest.TestCase
             fcn = @() arrowRecordBatch.column([1 2]);
             tc.verifyError(fcn, "MATLAB:expectedScalar");
         end
+
+        function ErrorIfNonPositiveIndex(tc)
+            TOriginal = table(1, 2, 3);
+            arrowRecordBatch = arrow.recordbatch(TOriginal);
+            fcn = @() arrowRecordBatch.column(-1);
+            tc.verifyError(fcn, "arrow:badsubscript:NonPositive");
+        end
     end
 end


### PR DESCRIPTION
### Rationale for this change

Now that the PR introducing the `arrow.internal.validate.index.numeric()` function has been merged (#37150), we should use this utility function within the `column()` method of `arrow.tabular.RecordBatch`. Doing so will remove duplicate code from the code base.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

1. Updated the `column()` method of `arrow.tabular.RecordBatch` to use `arrow.internal.validate.index.numeric()`. 

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes, these changes are covered by these two existing test classes:

1. `test/arrow/tabular/tRecordBatch.m`
2. `test/arrow/internal/validate/index/tNumeric.m`

In addition, I added a new test point to `tRecordBatch.m` called `ErrorIfNonPositiveIndex` to verify `arrow.internal.validate.index.numeric` is integrated correctly.

### Are there any user-facing changes?

No.

### Future Directions

1. In a future pull request, we will add support for indexing columns by name. Currently, the `column()` method only supports numeric indexing.
* Closes: #37155