### PR TITLE
GH-37160: [MATLAB] `arrow.internal.validate.index.string()` should not error if given a string with zero characters

### DIFF
--- a/matlab/src/matlab/+arrow/+internal/+validate/+index/string.m
+++ b/matlab/src/matlab/+arrow/+internal/+validate/+index/string.m
@@ -30,9 +30,5 @@ function index = string(index)
         errid = "arrow:badsubscript:MissingString";
         msg = "String indices must be nonmissing";
         error(errid, msg);
-    elseif any(strlength(index) == 0)
-        errid = "arrow:badsubscript:ZeroLengthText";
-        msg = "String indices must contain at least one character.";
-        error(errid, msg);
     end
 end

--- a/matlab/test/arrow/internal/validate/index/tString.m
+++ b/matlab/test/arrow/internal/validate/index/tString.m
@@ -35,20 +35,17 @@ classdef tString < matlab.unittest.TestCase
             testCase.verifyError(fcn, errid);
         end
 
-        function ZeroLengthTextError(testCase)
-            % Verify string() throws an error whose idenitifier is 
-            % "arrow:badsubscript:ZeroLengthText" if the index array 
+        function ZeroLengthText(testCase)
+            % Verify string() does not throw an error if the index array 
             % provided has zero length text values.
 
             import arrow.internal.validate.*
 
-            errid = "arrow:badsubscript:ZeroLengthText";
+            idx = index.string("");
+            testCase.verifyEqual(idx, "");
 
-            fcn = @() index.string("");
-            testCase.verifyError(fcn, errid);
-
-            fcn = @() index.string(["A" "" "B"]);
-            testCase.verifyError(fcn, errid);
+            idx = index.string(["A" "" "B"]);
+            testCase.verifyEqual(idx, ["A"; ""; "B"]);
         end
 
         function ValidStringIndices(testCase)


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Currently, `arrow.internal.validate.index.string()` throws an error if given a string value with zero characters.

```matlab
>> arrow.internal.validate.index.string("")
Error using arrow.internal.validate.index.string
String indices must contain at least one character.
```

However, it's possible to have a field whose name is `""` in `arrow.tabular.Schema`. Therefore, we should support accessing that field by its name `""`. 

### What changes are included in this PR?

1. `arrow.internal.validate.index.string()` no longer errors if given a string value with zero characters.

### Are these changes tested?

Yes. Updated the test cases in `test/arrow/internal/validate/index/tString.m` to verify `""` is accepted as an index value.


### Are there any user-facing changes?

No.

* Closes: #37160