### PR TITLE
GH-37157: [MATLAB] Use `arrow.internal.validate.index.numericOrString()` in the `field()` method of `arrow.tabular.Schema`

### DIFF
--- a/matlab/src/matlab/+arrow/+tabular/Schema.m
+++ b/matlab/src/matlab/+arrow/+tabular/Schema.m
@@ -43,17 +43,22 @@ classdef Schema < matlab.mixin.CustomDisplay
         end
         
         function F = field(obj, idx)
-            idx = convertCharsToStrings(idx);
-            if ~isempty(idx) && isscalar(idx) && isnumeric(idx) && idx >= 1
-                args = struct(Index=int32(idx));
+            import arrow.internal.validate.*
+            
+            idx = index.numericOrString(idx, "int32");
+
+            if isnumeric(idx)
+                % TODO: Consider vectorizing field() to support extracting
+                % multiple fields at once.
+                validateattributes(idx, "int32", "scalar");
+                args = struct(Index=idx);
                 proxyID = obj.Proxy.getFieldByIndex(args);
-            elseif isscalar(idx) && isstring(idx)
-                name = idx;
-                args = struct(Name=name);
-                proxyID = obj.Proxy.getFieldByName(args);
             else
-                error("arrow:tabular:schema:UnsupportedFieldIndexType", ...
-                      "Index must be a positive scalar integer or a valid field name.");
+                % TODO: Consider vectorizing field() to support extracting
+                % multiple fields at once.
+                validateattributes(idx, "string", "scalar");
+                args = struct(Name=idx);
+                proxyID = obj.Proxy.getFieldByName(args);
             end
 
             proxy = libmexclass.proxy.Proxy(Name="arrow.type.proxy.Field", ID=proxyID);

--- a/matlab/test/arrow/tabular/tSchema.m
+++ b/matlab/test/arrow/tabular/tSchema.m
@@ -139,25 +139,25 @@ classdef tSchema < matlab.unittest.TestCase
             ]);
 
             index = [];
-            testCase.verifyError(@() schema.field(index), "arrow:tabular:schema:UnsupportedFieldIndexType");
+            testCase.verifyError(@() schema.field(index), "MATLAB:expectedScalar");
 
             index = 0;
-            testCase.verifyError(@() schema.field(index), "arrow:tabular:schema:UnsupportedFieldIndexType");
+            testCase.verifyError(@() schema.field(index), "arrow:badsubscript:NonPositive");
 
             index = -1;
-            testCase.verifyError(@() schema.field(index), "arrow:tabular:schema:UnsupportedFieldIndexType");
+            testCase.verifyError(@() schema.field(index), "arrow:badsubscript:NonPositive");
 
-            index = -1.23;
-            testCase.verifyError(@() schema.field(index), "arrow:tabular:schema:UnsupportedFieldIndexType");
+            index = 1.23;
+            testCase.verifyError(@() schema.field(index), "arrow:badsubscript:NonInteger");
 
             index = NaN;
-            testCase.verifyError(@() schema.field(index), "arrow:tabular:schema:UnsupportedFieldIndexType");
+            testCase.verifyError(@() schema.field(index), "arrow:badsubscript:NonInteger");
 
             index = {1};
-            testCase.verifyError(@() schema.field(index), "arrow:tabular:schema:UnsupportedFieldIndexType");
+            testCase.verifyError(@() schema.field(index), "arrow:badsubscript:UnsupportedIndexType");
 
             index = [1; 1];
-            testCase.verifyError(@() schema.field(index), "arrow:tabular:schema:UnsupportedFieldIndexType");
+            testCase.verifyError(@() schema.field(index), "MATLAB:expectedScalar");
         end
 
         function GetFieldByIndex(testCase)

--- a/matlab/test/arrow/tabular/tSchema.m
+++ b/matlab/test/arrow/tabular/tSchema.m
@@ -375,7 +375,7 @@ classdef tSchema < matlab.unittest.TestCase
             testCase.verifyEqual(schema.NumFields, int32(0));
             testCase.verifyEqual(schema.FieldNames, string.empty(1, 0));
             testCase.verifyEqual(schema.Fields, arrow.type.Field.empty(0, 0));
-            testCase.verifyError(@() schema.field(0), "arrow:tabular:schema:UnsupportedFieldIndexType");
+            testCase.verifyError(@() schema.field(0), "arrow:badsubscript:NonPositive");
             testCase.verifyError(@() schema.field(1), "arrow:tabular:schema:NumericFieldIndexWithEmptySchema");
 
             % 0x1 empty Field array.
@@ -384,7 +384,7 @@ classdef tSchema < matlab.unittest.TestCase
             testCase.verifyEqual(schema.NumFields, int32(0));
             testCase.verifyEqual(schema.FieldNames, string.empty(1, 0));
             testCase.verifyEqual(schema.Fields, arrow.type.Field.empty(0, 0));
-            testCase.verifyError(@() schema.field(0), "arrow:tabular:schema:UnsupportedFieldIndexType");
+            testCase.verifyError(@() schema.field(0), "arrow:badsubscript:NonPositive");
             testCase.verifyError(@() schema.field(1), "arrow:tabular:schema:NumericFieldIndexWithEmptySchema");
 
             % 1x0 empty Field array.
@@ -393,7 +393,7 @@ classdef tSchema < matlab.unittest.TestCase
             testCase.verifyEqual(schema.NumFields, int32(0));
             testCase.verifyEqual(schema.FieldNames, string.empty(1, 0));
             testCase.verifyEqual(schema.Fields, arrow.type.Field.empty(0, 0));
-            testCase.verifyError(@() schema.field(0), "arrow:tabular:schema:UnsupportedFieldIndexType");
+            testCase.verifyError(@() schema.field(0), "arrow:badsubscript:NonPositive");
             testCase.verifyError(@() schema.field(1), "arrow:tabular:schema:NumericFieldIndexWithEmptySchema");
         end
 
@@ -446,10 +446,10 @@ classdef tSchema < matlab.unittest.TestCase
             ]);
 
             fieldName = [1, 2, 3];
-            testCase.verifyError(@() schema.field(fieldName), "arrow:tabular:schema:UnsupportedFieldIndexType");
+            testCase.verifyError(@() schema.field(fieldName), "MATLAB:expectedScalar");
 
             fieldName = [1; 2; 3];
-            testCase.verifyError(@() schema.field(fieldName), "arrow:tabular:schema:UnsupportedFieldIndexType");
+            testCase.verifyError(@() schema.field(fieldName), "MATLAB:expectedScalar");
         end
 
         function ErrorIfFieldNameIsNonScalar(testCase)
@@ -462,10 +462,10 @@ classdef tSchema < matlab.unittest.TestCase
             ]);
 
             fieldName = ["A", "B", "C"];
-            testCase.verifyError(@() schema.field(fieldName), "arrow:tabular:schema:UnsupportedFieldIndexType");
+            testCase.verifyError(@() schema.field(fieldName), "MATLAB:expectedScalar");
 
             fieldName = ["A";  "B"; "C"];
-            testCase.verifyError(@() schema.field(fieldName), "arrow:tabular:schema:UnsupportedFieldIndexType");
+            testCase.verifyError(@() schema.field(fieldName), "MATLAB:expectedScalar");
         end
 
     end


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Now that the PR introducing the `arrow.internal.validate.inex.numericOrString()` function has been merged (#37150), we should use this utility function within the `field()` method of `arrow.tabular.Schema`. Doing so will remove duplicate code from the code base.

### What changes are included in this PR?

1. Updated the `field()` method of `arrow.tabular.Schema` to use `arrow.internal.validate.index.numericOrString()`.

### Are these changes tested?

Yes. Updated the test points in `test/arrow/tabular/tSchema.m` to account for the new error message IDs.

### Are there any user-facing changes?

No.

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #37157