### PR TITLE
GH-37144: [C++] Add RecordBatchFileReader::To{RecordBatches,Table}

### DIFF
--- a/cpp/src/arrow/ipc/reader.h
+++ b/cpp/src/arrow/ipc/reader.h
@@ -229,6 +229,12 @@ class ARROW_EXPORT RecordBatchFileReader
       const io::IOContext& io_context = io::default_io_context(),
       const io::CacheOptions cache_options = io::CacheOptions::LazyDefaults(),
       arrow::internal::Executor* executor = NULLPTR) = 0;
+
+  /// \brief Collect all batches as a vector of record batches
+  Result<RecordBatchVector> ToRecordBatches();
+
+  /// \brief Collect all batches and concatenate as arrow::Table
+  Result<std::shared_ptr<Table>> ToTable();
 };
 
 /// \brief A general listener class to receive events.

--- a/cpp/src/arrow/table.h
+++ b/cpp/src/arrow/table.h
@@ -75,7 +75,7 @@ class ARROW_EXPORT Table {
 
   /// \brief Construct a Table from a RecordBatchReader.
   ///
-  /// \param[in] reader the arrow::Schema for each batch
+  /// \param[in] reader the arrow::RecordBatchReader that produces batches
   static Result<std::shared_ptr<Table>> FromRecordBatchReader(RecordBatchReader* reader);
 
   /// \brief Construct a Table from RecordBatches, using schema supplied by the first


### PR DESCRIPTION
### Rationale for this change

`RecordBatchReader` has them but `RecordBatchFileReader` doesn't. They are convenient.

### What changes are included in this PR?

Add them.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #37144