### PR TITLE
GH-37182: [MATLAB] Add public `Schema` property to MATLAB `arrow.tabular.RecordBatch` class

### DIFF
--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.cc
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.cc
@@ -22,6 +22,7 @@
 
 #include "arrow/matlab/error/error.h"
 #include "arrow/matlab/tabular/proxy/record_batch.h"
+#include "arrow/matlab/tabular/proxy/schema.h"
 #include "arrow/type.h"
 #include "arrow/util/utf8.h"
 
@@ -54,6 +55,7 @@ namespace arrow::matlab::tabular::proxy {
         REGISTER_METHOD(RecordBatch, numColumns);
         REGISTER_METHOD(RecordBatch, columnNames);
         REGISTER_METHOD(RecordBatch, getColumnByIndex);
+        REGISTER_METHOD(RecordBatch, getSchema);
     }
 
     std::shared_ptr<arrow::RecordBatch> RecordBatch::unwrap() {
@@ -163,4 +165,19 @@ namespace arrow::matlab::tabular::proxy {
         context.outputs[0] = array_proxy_id_mda;
         context.outputs[1] = array_type_id_mda;
     }
+
+    void RecordBatch::getSchema(libmexclass::proxy::method::Context& context) {
+        namespace mda = ::matlab::data;
+        using namespace libmexclass::proxy;
+        using SchemaProxy = arrow::matlab::tabular::proxy::Schema;
+        mda::ArrayFactory factory;
+
+        const auto schema = record_batch->schema();
+        const auto schema_proxy = std::make_shared<SchemaProxy>(std::move(schema));
+        const auto schema_proxy_id = ProxyManager::manageProxy(schema_proxy);
+        const auto schema_proxy_id_mda = factory.createScalar(schema_proxy_id);
+
+        context.outputs[0] = schema_proxy_id_mda;
+    }
+
 }

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.h
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.h
@@ -38,6 +38,7 @@ namespace arrow::matlab::tabular::proxy {
             void numColumns(libmexclass::proxy::method::Context& context);
             void columnNames(libmexclass::proxy::method::Context& context);
             void getColumnByIndex(libmexclass::proxy::method::Context& context);
+            void getSchema(libmexclass::proxy::method::Context& context);
 
             std::shared_ptr<arrow::RecordBatch> record_batch;
     };

--- a/matlab/src/matlab/+arrow/+tabular/RecordBatch.m
+++ b/matlab/src/matlab/+arrow/+tabular/RecordBatch.m
@@ -21,6 +21,7 @@ classdef RecordBatch < matlab.mixin.CustomDisplay & ...
     properties (Dependent, SetAccess=private, GetAccess=public)
         NumColumns
         ColumnNames
+        Schema
     end
 
     properties (Hidden, SetAccess=private, GetAccess=public)
@@ -42,6 +43,12 @@ classdef RecordBatch < matlab.mixin.CustomDisplay & ...
 
         function columnNames = get.ColumnNames(obj)
             columnNames = obj.Proxy.columnNames();
+        end
+
+        function schema = get.Schema(obj)
+            proxyID = obj.Proxy.getSchema();
+            proxy = libmexclass.proxy.Proxy(Name="arrow.tabular.proxy.Schema", ID=proxyID);
+            schema = arrow.tabular.Schema(proxy);
         end
 
         function arrowArray = column(obj, idx)

--- a/matlab/test/arrow/tabular/tRecordBatch.m
+++ b/matlab/test/arrow/tabular/tRecordBatch.m
@@ -210,12 +210,12 @@ classdef tRecordBatch < matlab.unittest.TestCase
             tc.verifyEqual(schema.field(3).Name, "C");
         end
 
-        function SchemaNoSetter(testCase)
+        function SchemaNoSetter(tc)
         % Verify that trying to set the value of the public Schema property
         % results in an error of type "MATLAB:class:SetProhibited".
             t = table([1; 2; 3]);
             recordBatch = arrow.recordbatch(t);
-            testCase.verifyError(@() setfield(recordBatch, "Schema", "Value"), ...
+            tc.verifyError(@() setfield(recordBatch, "Schema", "Value"), 
                 "MATLAB:class:SetProhibited");
         end
 

--- a/matlab/test/arrow/tabular/tRecordBatch.m
+++ b/matlab/test/arrow/tabular/tRecordBatch.m
@@ -191,6 +191,34 @@ classdef tRecordBatch < matlab.unittest.TestCase
             fcn = @() RecordBatch.fromArrays(A1, A2, columnNames=["A", missing]);
             tc.verifyError(fcn, "MATLAB:validators:mustBeNonmissing");
         end
+
+        function Schema(tc)
+        % Verify that the public Schema property returns an approprate
+        % instance of arrow.tabular.Schema.
+            t = table(["A"; "B"; "C"], ...
+                      [1; 2; 3], ...
+                      [true; false; true], ...
+                      VariableNames=["A", "B", "C"]);
+            recordBatch = arrow.recordbatch(t);
+            schema = recordBatch.Schema;
+            tc.verifyEqual(schema.NumFields, int32(3));
+            tc.verifyEqual(schema.field(1).Type.ID, arrow.type.ID.String);
+            tc.verifyEqual(schema.field(1).Name, "A");
+            tc.verifyEqual(schema.field(2).Type.ID, arrow.type.ID.Float64);
+            tc.verifyEqual(schema.field(2).Name, "B");
+            tc.verifyEqual(schema.field(3).Type.ID, arrow.type.ID.Boolean);
+            tc.verifyEqual(schema.field(3).Name, "C");
+        end
+
+        function SchemaNoSetter(testCase)
+        % Verify that trying to set the value of the public Schema property
+        % results in an error of type "MATLAB:class:SetProhibited".
+            t = table([1; 2; 3]);
+            recordBatch = arrow.recordbatch(t);
+            testCase.verifyError(@() setfield(recordBatch, "Schema", "Value"), ...
+                "MATLAB:class:SetProhibited");
+        end
+
     end
 
     methods
@@ -210,7 +238,7 @@ classdef tRecordBatch < matlab.unittest.TestCase
 end
 
 function T = createTableWithAllSupportedTypes()
-    T = table(int8   ([1, 2, 3]'), ...
+    T = table(int8  ([1, 2, 3]'), ...
              int16  ([1, 2, 3]'), ...
              int32  ([1, 2, 3]'), ...
              int64  ([1, 2, 3]'), ...

--- a/matlab/test/arrow/tabular/tRecordBatch.m
+++ b/matlab/test/arrow/tabular/tRecordBatch.m
@@ -215,7 +215,7 @@ classdef tRecordBatch < matlab.unittest.TestCase
         % results in an error of type "MATLAB:class:SetProhibited".
             t = table([1; 2; 3]);
             recordBatch = arrow.recordbatch(t);
-            tc.verifyError(@() setfield(recordBatch, "Schema", "Value"), 
+            tc.verifyError(@() setfield(recordBatch, "Schema", "Value"), ...
                 "MATLAB:class:SetProhibited");
         end
 


### PR DESCRIPTION
### Rationale for this change

To make it possible to query the field types and names of a `RecordBatch`, this pull request adds a public `Schema` property to the MATLAB `arrow.tabular.RecordBatch` class.

### What changes are included in this PR?

1. Added a new public `Schema` property to the `arrow.tabular.RecordBatch` MATLAB class.

```matlab
>> t = table(["A","B","C"]',[1,2,3]',[true,false,true]',VariableNames=["A", "B", "C"])

t =

  3x3 table

     A     B      C  
    ___    _    _____

    "A"    1    true 
    "B"    2    false
    "C"    3    true 

>> rb = arrow.recordbatch(t)

rb = 

A:   [
    "A",
    "B",
    "C"
  ]
B:   [
    1,
    2,
    3
  ]
C:   [
    true,
    false,
    true
  ]

>> schema = rb.Schema

schema = 

A: string
B: double
C: bool

>> schema.field(2).Name

ans = 

    "B"

>> schema.field(2).Type

ans = 

  Float64Type with properties:

    ID: Float64
```

### Are these changes tested?

Yes.

1. Added new test cases verifying that the `Schema` property works as expected to `tRecordBatch.m`.

### Are there any user-facing changes?

Yes.

1. There is now a public `Schema` property on the `arrow.tabular.RecordBatch` MATLAB class.
* Closes: #37182