### PR TITLE
GH-37188: [MATLAB] Move `test/util/featherRoundTrip.m` into a packaged test utility function

### DIFF
--- a/matlab/src/matlab/+arrow/+internal/+test/+io/+feather/roundtrip.m
+++ b/matlab/src/matlab/+arrow/+internal/+test/+io/+feather/roundtrip.m
@@ -1,5 +1,7 @@
-% ROUNDTRIP Test utility for round tripping a MATLAB
-% table to a Feather V1 file.
+% ROUNDTRIP Test utility which (1) writes a MATLAB
+% table to a Feather V1 file and then (2) reads the
+% resulting the Feather V1 file back into MATLAB
+% as a table.
 
 % Licensed to the Apache Software Foundation (ASF) under one or more
 % contributor license agreements.  See the NOTICE file distributed with

--- a/matlab/src/matlab/+arrow/+internal/+test/+io/+feather/roundtrip.m
+++ b/matlab/src/matlab/+arrow/+internal/+test/+io/+feather/roundtrip.m
@@ -1,6 +1,5 @@
-function tableOut = featherRoundTrip(filename, tableIn)
-% FEATHERROUNDTRIP Helper function for round tripping a table
-% to a Feather file.
+% ROUNDTRIP Test utility for round tripping a MATLAB
+% table to a Feather V1 file.
 
 % Licensed to the Apache Software Foundation (ASF) under one or more
 % contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +15,11 @@ function tableOut = featherRoundTrip(filename, tableIn)
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
-
-featherwrite(filename, tableIn);
-tableOut = featherread(filename);
+function tRead = roundtrip(filename, tWrite)
+    arguments
+        filename (1, 1) string
+        tWrite table
+    end
+    featherwrite(filename, tWrite);
+    tRead = featherread(filename);
 end

--- a/matlab/test/arrow/io/feather/tRoundTrip.m
+++ b/matlab/test/arrow/io/feather/tRoundTrip.m
@@ -16,18 +16,6 @@
 % permissions and limitations under the License.
 classdef tRoundTrip < matlab.unittest.TestCase
 
-    methods(TestClassSetup)
-        % Delete once arrow.internal.io.feather.Reader is submitted.
-        function addFeatherFunctionsToMATLABPath(testCase)
-            import matlab.unittest.fixtures.PathFixture
-            % Add Feather test utilities to the MATLAB path.
-            testCase.applyFixture(PathFixture('../../../util'));
-            % arrow.cpp.call must be on the MATLAB path.
-            testCase.assertTrue(~isempty(which('arrow.cpp.call')), ...
-                '''arrow.cpp.call'' must be on the MATLAB path. Use ''addpath'' to add folders to the MATLAB path.');
-        end
-    end
-
     methods(Test)
         function Basic(testCase)
             import matlab.unittest.fixtures.TemporaryFolderFixture

--- a/matlab/test/tfeather.m
+++ b/matlab/test/tfeather.m
@@ -16,17 +16,6 @@ classdef tfeather < matlab.unittest.TestCase
     % implied.  See the License for the specific language governing
     % permissions and limitations under the License.
     
-    methods(TestClassSetup)
-        function addFeatherFunctionsToMATLABPath(testCase)
-            import matlab.unittest.fixtures.PathFixture
-            % Add Feather test utilities to the MATLAB path.
-            testCase.applyFixture(PathFixture('util'));
-            % arrow.cpp.call must be on the MATLAB path.
-            testCase.assertTrue(~isempty(which('arrow.cpp.call')), ...
-                '''arrow.cpp.call'' must be on the MATLAB path. Use ''addpath'' to add folders to the MATLAB path.');
-        end
-    end
-    
     methods(TestMethodSetup)
     
         function setupTempWorkingDirectory(testCase)
@@ -40,15 +29,18 @@ classdef tfeather < matlab.unittest.TestCase
 
         function NumericDatatypesNoNulls(testCase)
             import arrow.internal.test.tabular.createTableWithSupportedTypes
+            import arrow.internal.test.io.feather.roundtrip
+
             filename = fullfile(pwd, 'temp.feather');
             
             actualTable = createTableWithSupportedTypes;
-            expectedTable = featherRoundTrip(filename, actualTable);
+            expectedTable = roundtrip(filename, actualTable);
             testCase.verifyEqual(actualTable, expectedTable);
         end
 
         function NumericDatatypesWithNaNRow(testCase)
             import arrow.internal.test.tabular.createTableWithSupportedTypes
+            import arrow.internal.test.io.feather.roundtrip
 
             filename = fullfile(pwd, 'temp.feather');
             
@@ -76,12 +68,13 @@ classdef tfeather < matlab.unittest.TestCase
                            'VariableNames', variableNames);
             addRow(1,:) = {NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN};
             actualTable = [t; addRow];
-            expectedTable = featherRoundTrip(filename, actualTable);
+            expectedTable = roundtrip(filename, actualTable);
             testCase.verifyEqual(actualTable, expectedTable);
         end
 
         function NumericDatatypesWithNaNColumns(testCase)
             import arrow.internal.test.tabular.createTableWithSupportedTypes
+            import arrow.internal.test.io.feather.roundtrip
 
             filename = fullfile(pwd, 'temp.feather');
             
@@ -89,12 +82,13 @@ classdef tfeather < matlab.unittest.TestCase
             actualTable.double = [NaN; NaN; NaN];
             actualTable.int64  = [NaN; NaN; NaN];
             
-            expectedTable = featherRoundTrip(filename, actualTable);
+            expectedTable = roundtrip(filename, actualTable);
             testCase.verifyEqual(actualTable, expectedTable);
         end
         
         function NumericDatatypesWithExpInfSciNotation(testCase)
             import arrow.internal.test.tabular.createTableWithSupportedTypes
+            import arrow.internal.test.io.feather.roundtrip
 
             filename = fullfile(pwd, 'temp.feather');
             
@@ -106,49 +100,54 @@ classdef tfeather < matlab.unittest.TestCase
             
             actualTable.int64(2) = 1.0418e+03;
            
-            expectedTable = featherRoundTrip(filename, actualTable);
+            expectedTable = roundtrip(filename, actualTable);
             testCase.verifyEqual(actualTable, expectedTable);
         end
         
         function IgnoreRowVarNames(testCase)
             import arrow.internal.test.tabular.createTableWithSupportedTypes
+            import arrow.internal.test.io.feather.roundtrip
 
             filename = fullfile(pwd, 'temp.feather');
             
             actualTable = createTableWithSupportedTypes;
             time = {'day1', 'day2', 'day3'};
             actualTable.Properties.RowNames = time;
-            expectedTable = featherRoundTrip(filename, actualTable);
+            expectedTable = roundtrip(filename, actualTable);
             actualTable = createTableWithSupportedTypes;
             testCase.verifyEqual(actualTable, expectedTable);
         end
 
         function NotFeatherExtension(testCase)
             import arrow.internal.test.tabular.createTableWithSupportedTypes
+            import arrow.internal.test.io.feather.roundtrip
 
             filename = fullfile(pwd, 'temp.txt');
             
             actualTable = createTableWithSupportedTypes;
-            expectedTable = featherRoundTrip(filename, actualTable);
+            expectedTable = roundtrip(filename, actualTable);
             testCase.verifyEqual(actualTable, expectedTable);
         end
         
         function EmptyTable(testCase)
+            import arrow.internal.test.io.feather.roundtrip
+
             filename = fullfile(pwd, 'temp.feather');
             
             actualTable = table;
-            expectedTable = featherRoundTrip(filename, actualTable);
+            expectedTable = roundtrip(filename, actualTable);
             testCase.verifyEqual(actualTable, expectedTable);
         end
 
         function zeroByNTable(testCase)
             import arrow.internal.test.tabular.createTableWithSupportedTypes
+            import arrow.internal.test.io.feather.roundtrip
 
             filename = fullfile(pwd, 'temp.feather');
             
             actualTable = createTableWithSupportedTypes;
             actualTable([1, 2], :) = [];
-            expectedTable = featherRoundTrip(filename, actualTable);
+            expectedTable = roundtrip(filename, actualTable);
             testCase.verifyEqual(actualTable, expectedTable);
         end
 
@@ -243,6 +242,8 @@ classdef tfeather < matlab.unittest.TestCase
         end
 
         function SupportedTypes(testCase)
+            import arrow.internal.test.io.feather.roundtrip
+
             filename = fullfile(pwd, 'temp.feather');
 
             % Create a table with all supported MATLAB types.
@@ -260,11 +261,13 @@ classdef tfeather < matlab.unittest.TestCase
                                   string (["A", "B", "C"]'), ...
                                   datetime(2023, 6, 28) + days(0:2)');
 
-            actualTable = featherRoundTrip(filename, expectedTable);
+            actualTable = roundtrip(filename, expectedTable);
             testCase.verifyEqual(actualTable, expectedTable);
         end
 
         function UnicodeVariableNames(testCase)
+            import arrow.internal.test.io.feather.roundtrip
+
             filename = fullfile(pwd, 'temp.feather');
 
             smiley = "😀";
@@ -273,7 +276,7 @@ classdef tfeather < matlab.unittest.TestCase
             columnNames = [smiley, tree, mango];
             expectedTable = table(1, 2, 3, VariableNames=columnNames);
 
-            actualTable = featherRoundTrip(filename, expectedTable);
+            actualTable = roundtrip(filename, expectedTable);
             testCase.verifyEqual(actualTable, expectedTable);
         end
 


### PR DESCRIPTION
> **Warning** - Please don't merge this PR. It is still in progress.

### Rationale for this change

To simplify access to the `featherRoundTrip` function that is used in the `tfeather.m` tests this pull request moves the `featherRoundTrip` code into a new packaged test utility function `arrow.internal.test.io.feather.roundtrip`.

This makes it possible to`import` the function, rather than having to manually add the `test/util` folder to the MATLAB Search Path in the test class setup.

### What changes are included in this PR?

1. Moved `test/util/featherRoundTrip.m` code into a new internal packaged test utility function `arrow.internal.test.io.feather.roundtrip`.

### Are these changes tested?

Yes.

1. Updated all `tfeather.m` test cases to use new packaged function `arrow.internal.test.io.feather.roundtrip`.

### Are there any user-facing changes?

No.

This new packaged function is an internal test utility.

### Future Directions

1. Delete the old Feather MEX code.
2. Move more shared test infrastructure into packaged test functions under `arrow.internal.test.*`.
* Closes: #37188