### PR TITLE
GH-37197: [Java][CI][Packaging] Free some disk space on the java-jars GitHub job

### DIFF
--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -46,6 +46,7 @@ jobs:
             archery_arch_short: "arm64"
     steps:
       {{ macros.github_checkout_arrow()|indent }}
+      {{ macros.github_free_space()|indent }}
       {{ macros.github_install_archery()|indent }}
       - name: Build C++ libraries
         env:


### PR DESCRIPTION
### Rationale for this change
The java-jars job was failing on the maintenance branch for the release due to disk out of space.

### What changes are included in this PR?

Add a step to do some cleanup for the job.

### Are these changes tested?

Yes, I tested it on the maintenance branch having the job successfully run and via crossbow.

### Are there any user-facing changes?

No
* Closes: #37197