### PR TITLE
GH-37209: [CI][Docs][MATLAB] Remove support for `MATLAB_ARROW_INTERFACE` flag from CMake build system and build new MATLAB Interface code by default

### DIFF
--- a/ci/scripts/matlab_build.sh
+++ b/ci/scripts/matlab_build.sh
@@ -29,7 +29,6 @@ cmake \
   -S ${source_dir} \
   -B ${build_dir} \
   -G Ninja \
-  -D MATLAB_ARROW_INTERFACE=ON \
   -D MATLAB_BUILD_TESTS=ON \
   -D CMAKE_INSTALL_PREFIX=${install_dir} \
   -D MATLAB_ADD_INSTALL_DIR_TO_SEARCH_PATH=OFF

--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -379,9 +379,8 @@ endif()
 # Create a subdirectory at CMAKE_INSTALL_PREFIX to install the interface.
 set(CMAKE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/arrow_matlab")
 
-if(MATLAB_ARROW_INTERFACE)
-  include(BuildMatlabArrowInterface)
-endif()
+# Build the MATLAB Interface to Arrow.
+include(BuildMatlabArrowInterface)
 
 # Install MATLAB source files.
 # On macOS, exclude '.DS_Store' files in the source tree from installation.

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -76,11 +76,9 @@ $ cd arrow/matlab
 To build the MATLAB interface, use [CMake](https://cmake.org/cmake/help/latest/):
 
 ```console
-$ cmake -S . -B build -D MATLAB_ARROW_INTERFACE=ON
+$ cmake -S . -B build
 $ cmake --build build --config Release
 ```
-
-**NOTE:** To build the experimental MATLAB interface code, `-D MATLAB_ARROW_INTERFACE=ON` must be specified as shown above.
 
 ## Install
 
@@ -111,7 +109,7 @@ To run the MATLAB tests, start MATLAB in the `arrow/matlab` directory and call t
 To enable the C++ tests, set the `MATLAB_BUILD_TESTS` flag to `ON` at build time: 
 
 ```console
-$ cmake -S . -B build -D MATLAB_ARROW_INTERFACE=ON -D MATLAB_BUILD_TESTS=ON
+$ cmake -S . -B build -D MATLAB_BUILD_TESTS=ON
 $ cmake --build build --config Release
 ```
 


### PR DESCRIPTION
### Rationale for this change

Now that the old Feather V1 code and associated build infrastructure has been removed (#37204), it makes sense to start building the new, experimental MATLAB Interface code by default (without needing to [explicitly specify `-D MATLAB_ARROW_INTERFACE=ON`](https://github.com/apache/arrow/tree/main/matlab#build)).

This pull request removes the `MATLAB_ARROW_INTERFACE` flag entirely, since setting it to `OFF` when we are building the MATLAB Interface code by default would essentially imply that no code should be built.

### What changes are included in this PR?

1. Removed mention of `MATLAB_ARROW_INTERFACE` flag from MATLAB `README.md`.
2. Removed conditional check for `MATLAB_ARROW_INTERFACE` flag from MATLAB `CMakeLists.txt`.
3. Removed `MATLAB_ARROW_INTERFACE` flag from `matlab_build.sh` CI script.

### Are these changes tested?

Yes.

The MATLAB Interface is building as expected by default on my Debian 11 machine.

### Are there any user-facing changes?

Yes.

1. The experimental MATLAB Interface APIs will now be built by default without users explicitly specifying `-D MATLAB_ARROW_INTERFACE=ON` to `cmake`.
2. If users specify a value for `MATLAB_ARROW_INTERFACE`, the value will be ignored by the CMake build system.
* Closes: #37209