### PR TITLE
GH-37213: [C#] Updating a reference to FlatBuffers missed due to rebase/merge conflict

### DIFF
--- a/csharp/src/Apache.Arrow/Arrays/ArrayData.cs
+++ b/csharp/src/Apache.Arrow/Arrays/ArrayData.cs
@@ -15,7 +15,7 @@
 
 using Apache.Arrow.Memory;
 using Apache.Arrow.Types;
-using FlatBuffers;
+using Google.FlatBuffers;
 using System;
 using System.Collections.Generic;
 using System.Linq;


### PR DESCRIPTION
### Rationale for this change

The build was broken

### What changes are included in this PR?

Updated a newly introduced reference to `using FlatBuffers` to be `using Google.FlatBuffers`

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* Closes: #37213