### PR TITLE
GH-37222: [Docs][MATLAB] Rename `arrow.recordbatch` (all lowercase) to `arrow.recordBatch` (camelCase)

### DIFF
--- a/matlab/README.md
+++ b/matlab/README.md
@@ -225,7 +225,7 @@ matlabTable =
     "B"      2      false
     "C"      3      true
 
->> arrowRecordBatch = arrow.recordbatch(matlabTable)
+>> arrowRecordBatch = arrow.recordBatch(matlabTable)
 
 arrowRecordBatch =
 
@@ -557,7 +557,7 @@ matlabTable =
      "B"        2
      "C"        3
 
->> arrowRecordBatch = arrow.recordbatch(matlabTable)
+>> arrowRecordBatch = arrow.recordBatch(matlabTable)
 
 arrowRecordBatch =
 

--- a/matlab/src/matlab/+arrow/recordBatch.m
+++ b/matlab/src/matlab/+arrow/recordBatch.m
@@ -14,7 +14,7 @@
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
-function rb = recordbatch(T)
+function rb = recordBatch(T)
     arguments
         T table
     end

--- a/matlab/src/matlab/featherwrite.m
+++ b/matlab/src/matlab/featherwrite.m
@@ -28,7 +28,7 @@ function featherwrite(filename, t)
         t table
     end
 
-    recordBatch = arrow.recordbatch(t);
+    recordBatch = arrow.recordBatch(t);
     writer = arrow.internal.io.feather.Writer(filename);
     writer.write(recordBatch);
 end

--- a/matlab/test/arrow/io/feather/tRoundTrip.m
+++ b/matlab/test/arrow/io/feather/tRoundTrip.m
@@ -28,7 +28,7 @@ classdef tRoundTrip < matlab.unittest.TestCase
             SingleVar = single([10; 15; 20; 25]);
 
             tableWrite = table(DoubleVar, SingleVar);
-            recordBatchWrite = arrow.recordbatch(tableWrite);
+            recordBatchWrite = arrow.recordBatch(tableWrite);
 
             writer = Writer(filename);
             writer.write(recordBatchWrite);

--- a/matlab/test/arrow/tabular/tRecordBatch.m
+++ b/matlab/test/arrow/tabular/tRecordBatch.m
@@ -20,7 +20,7 @@ classdef tRecordBatch < matlab.unittest.TestCase
 
         function Basic(tc)
             T = table([1, 2, 3]');
-            arrowRecordBatch = arrow.recordbatch(T);
+            arrowRecordBatch = arrow.recordBatch(T);
             className = string(class(arrowRecordBatch));
             tc.verifyEqual(className, "arrow.tabular.RecordBatch");
         end
@@ -30,21 +30,21 @@ classdef tRecordBatch < matlab.unittest.TestCase
             import arrow.internal.test.tabular.createTableWithSupportedTypes
 
             TOriginal = createTableWithSupportedTypes();
-            arrowRecordBatch = arrow.recordbatch(TOriginal);
+            arrowRecordBatch = arrow.recordBatch(TOriginal);
             expectedColumnNames = string(TOriginal.Properties.VariableNames);
             tc.verifyRecordBatch(arrowRecordBatch, expectedColumnNames, TOriginal);
         end
 
         function ToMATLAB(tc)
             TOriginal = table([1, 2, 3]');
-            arrowRecordBatch = arrow.recordbatch(TOriginal);
+            arrowRecordBatch = arrow.recordBatch(TOriginal);
             TConverted = arrowRecordBatch.toMATLAB();
             tc.verifyEqual(TOriginal, TConverted);
         end
 
         function Table(tc)
             TOriginal = table([1, 2, 3]');
-            arrowRecordBatch = arrow.recordbatch(TOriginal);
+            arrowRecordBatch = arrow.recordBatch(TOriginal);
             TConverted = table(arrowRecordBatch);
             tc.verifyEqual(TOriginal, TConverted);
         end
@@ -52,7 +52,7 @@ classdef tRecordBatch < matlab.unittest.TestCase
         function ColumnNames(tc)
             columnNames = ["A", "B", "C"];
             TOriginal = table(1, 2, 3, VariableNames=columnNames);
-            arrowRecordBatch = arrow.recordbatch(TOriginal);
+            arrowRecordBatch = arrow.recordBatch(TOriginal);
             tc.verifyEqual(arrowRecordBatch.ColumnNames, columnNames);
         end
 
@@ -61,7 +61,7 @@ classdef tRecordBatch < matlab.unittest.TestCase
 
             for nc = numColumns
                 T = array2table(ones(1, nc));
-                arrowRecordBatch = arrow.recordbatch(T);
+                arrowRecordBatch = arrow.recordBatch(T);
                 tc.verifyEqual(arrowRecordBatch.NumColumns, nc);
             end
         end
@@ -72,7 +72,7 @@ classdef tRecordBatch < matlab.unittest.TestCase
             mango = "🥭";
             columnNames = [smiley, tree, mango];
             TOriginal = table(1, 2, 3, VariableNames=columnNames);
-            arrowRecordBatch = arrow.recordbatch(TOriginal);
+            arrowRecordBatch = arrow.recordBatch(TOriginal);
             tc.verifyEqual(arrowRecordBatch.ColumnNames, columnNames);
             TConverted = arrowRecordBatch.toMATLAB();
             tc.verifyEqual(TOriginal, TConverted);
@@ -80,42 +80,42 @@ classdef tRecordBatch < matlab.unittest.TestCase
 
         function EmptyTable(tc)
             TOriginal = table();
-            arrowRecordBatch = arrow.recordbatch(TOriginal);
+            arrowRecordBatch = arrow.recordBatch(TOriginal);
             TConverted = arrowRecordBatch.toMATLAB();
             tc.verifyEqual(TOriginal, TConverted);
         end
 
         function EmptyRecordBatchColumnIndexError(tc)
             TOriginal = table();
-            arrowRecordBatch = arrow.recordbatch(TOriginal);
+            arrowRecordBatch = arrow.recordBatch(TOriginal);
             fcn = @() arrowRecordBatch.column(1);
             tc.verifyError(fcn, "arrow:tabular:recordbatch:NumericIndexWithEmptyRecordBatch");
         end
 
         function InvalidNumericIndexError(tc)
             TOriginal = table(1, 2, 3);
-            arrowRecordBatch = arrow.recordbatch(TOriginal);
+            arrowRecordBatch = arrow.recordBatch(TOriginal);
             fcn = @() arrowRecordBatch.column(4);
             tc.verifyError(fcn, "arrow:tabular:recordbatch:InvalidNumericColumnIndex");
         end
 
         function UnsupportedColumnIndexType(tc)
             TOriginal = table(1, 2, 3);
-            arrowRecordBatch = arrow.recordbatch(TOriginal);
+            arrowRecordBatch = arrow.recordBatch(TOriginal);
             fcn = @() arrowRecordBatch.column(datetime(2022, 1, 3));
             tc.verifyError(fcn, "arrow:badsubscript:NonNumeric");
         end
 
         function ErrorIfIndexIsNonScalar(tc)
             TOriginal = table(1, 2, 3);
-            arrowRecordBatch = arrow.recordbatch(TOriginal);
+            arrowRecordBatch = arrow.recordBatch(TOriginal);
             fcn = @() arrowRecordBatch.column([1 2]);
             tc.verifyError(fcn, "MATLAB:expectedScalar");
         end
 
         function ErrorIfIndexIsNonPositive(tc)
             TOriginal = table(1, 2, 3);
-            arrowRecordBatch = arrow.recordbatch(TOriginal);
+            arrowRecordBatch = arrow.recordBatch(TOriginal);
             fcn = @() arrowRecordBatch.column(-1);
             tc.verifyError(fcn, "arrow:badsubscript:NonPositive");
         end
@@ -203,7 +203,7 @@ classdef tRecordBatch < matlab.unittest.TestCase
                       [1; 2; 3], ...
                       [true; false; true], ...
                       VariableNames=["A", "B", "C"]);
-            recordBatch = arrow.recordbatch(t);
+            recordBatch = arrow.recordBatch(t);
             schema = recordBatch.Schema;
             tc.verifyEqual(schema.NumFields, int32(3));
             tc.verifyEqual(schema.field(1).Type.ID, arrow.type.ID.String);
@@ -218,7 +218,7 @@ classdef tRecordBatch < matlab.unittest.TestCase
         % Verify that trying to set the value of the public Schema property
         % results in an error of type "MATLAB:class:SetProhibited".
             t = table([1; 2; 3]);
-            recordBatch = arrow.recordbatch(t);
+            recordBatch = arrow.recordBatch(t);
             tc.verifyError(@() setfield(recordBatch, "Schema", "Value"), ...
                 "MATLAB:class:SetProhibited");
         end


### PR DESCRIPTION
### Rationale for this change

As @kou suggested in https://github.com/apache/arrow/pull/37215#discussion_r1296559210, it makes sense to rename `arrow.recordbatch` (all lowercase) to `arrow.recordBatch` (camelCase).

`recordBatch` is the first "two-word" function in the top-level `arrow.*` package, so it makes sense to establish a clear camelCase standard for "multi-word" functions in the MATLAB interface at this point.

One part of the rationale motivating this change is that other language bindings follow a similar pattern (e.g. `pyarrow.record_batch` instead of `pyarrow.recordbatch`).

### What changes are included in this PR?

1. Renamed `arrow.recordbatch` (all lowercase) to `arrow.recordBatch` (camelCase).
2. Updated documentation and tests to reflect `arrow.recordbatch` being renamed to `arrow.recordBatch`.

### Are these changes tested?

Yes.

1. All existing MATLAB tests have been updated to use the new name `arrow.recordbatch` and are passing on my Debian 11 machine.

### Are there any user-facing changes?

Yes.

**This PR includes breaking changes to public APIs.**

The public facing API `arrow.recordbatch` has been renamed to `arrow.recordBatch`. Since the MATLAB interface is still "pre 1.0", we don't expect this change to have a significant impact.

### Notes

1. Thank you @sgilmore10 for your help with this pull request!
* Closes: #37222