### PR TITLE
GH-37208: [R] Use currrently running R binary to compile test program (nix install)

### DIFF
--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -197,7 +197,9 @@ compile_test_program <- function(code) {
   # Note: if we wanted to check for openssl on macOS, we'd have to set the brew
   # path as a -I directory. But since we (currently) only run this code to
   # determine whether we can download a Linux binary, it's not relevant.
-  runner <- "`R CMD config CXX17` `R CMD config CPPFLAGS` `R CMD config CXX17FLAGS` `R CMD config CXX17STD` -E -xc++"
+  r_exec <- paste(R.home(component = "bin"), "R CMD config", sep="/")
+  r_cmd <- paste0("`", r_exec, " ", c("CXX17", "CPPFLAGS", "CXX17FLAGS", "CXX17STD"), "`", collapse = " ")
+  runner <- sprintf("%s -E -xc++", r_cmd)
   suppressWarnings(system2("echo", sprintf('"%s" | %s -', code, runner), stdout = FALSE, stderr = TRUE))
 }
 

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -197,9 +197,14 @@ compile_test_program <- function(code) {
   # Note: if we wanted to check for openssl on macOS, we'd have to set the brew
   # path as a -I directory. But since we (currently) only run this code to
   # determine whether we can download a Linux binary, it's not relevant.
-  r_exec <- file.path(R.home("bin"), "R")
-  r_cmd <- paste0("`", r_exec, " CMD config ", c("CXX17", "CPPFLAGS", "CXX17FLAGS", "CXX17STD"), "`", collapse = " ")
-  runner <- sprintf("%s -E -xc++", r_cmd)
+  runner <- paste(
+    R_CMD_config("CXX17"),
+    R_CMD_config("CPPFLAGS"),
+    R_CMD_config("CXX17FLAGS"),
+    R_CMD_config("CXX17STD"),
+    "-E",
+    "-xc++"
+  )
   suppressWarnings(system2("echo", sprintf('"%s" | %s -', code, runner), stdout = FALSE, stderr = TRUE))
 }
 

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -197,8 +197,8 @@ compile_test_program <- function(code) {
   # Note: if we wanted to check for openssl on macOS, we'd have to set the brew
   # path as a -I directory. But since we (currently) only run this code to
   # determine whether we can download a Linux binary, it's not relevant.
-  r_exec <- paste(R.home(component = "bin"), "R CMD config", sep="/")
-  r_cmd <- paste0("`", r_exec, " ", c("CXX17", "CPPFLAGS", "CXX17FLAGS", "CXX17STD"), "`", collapse = " ")
+  r_exec <- file.path(R.home("bin"), "R")
+  r_cmd <- paste0("`", r_exec, " CMD config ", c("CXX17", "CPPFLAGS", "CXX17FLAGS", "CXX17STD"), "`", collapse = " ")
   runner <- sprintf("%s -E -xc++", r_cmd)
   suppressWarnings(system2("echo", sprintf('"%s" | %s -', code, runner), stdout = FALSE, stderr = TRUE))
 }


### PR DESCRIPTION
### Rationale for this change

See #37208.

### What changes are included in this PR?

Use the currrently running R binary to compile test program (nix install).

### Are these changes tested?

No. Installation.

### Are there any user-facing changes?

No


* Closes: #37208