### PR TITLE
GH-36638: [R] Error with create_package_with_all_dependencies() on Windows

### DIFF
--- a/r/R/install-arrow.R
+++ b/r/R/install-arrow.R
@@ -224,7 +224,7 @@ create_package_with_all_dependencies <- function(dest_file = NULL, source_file =
   dir.create(download_dir)
   download_script <- tempfile(fileext = ".R")
   parse_versions_success <- system2(
-    "bash", c(download_dependencies_sh, download_dir),
+    "bash", c(download_dependencies_sh, gsub("\\", "/", download_dir, fixed = TRUE)),
     stdout = download_script,
     stderr = FALSE
   ) == 0

--- a/r/R/install-arrow.R
+++ b/r/R/install-arrow.R
@@ -217,19 +217,25 @@ create_package_with_all_dependencies <- function(dest_file = NULL, source_file =
   untar_dir <- tempfile()
   on.exit(unlink(untar_dir, recursive = TRUE), add = TRUE)
   utils::untar(source_file, exdir = untar_dir)
-  tools_dir <- file.path(untar_dir, "arrow/tools")
+  tools_dir <- file.path(normalizePath(untar_dir, winslash = "/"), "arrow/tools")
   download_dependencies_sh <- file.path(tools_dir, "download_dependencies_R.sh")
   # If you change this path, also need to edit nixlibs.R
   download_dir <- file.path(tools_dir, "thirdparty_dependencies")
   dir.create(download_dir)
   download_script <- tempfile(fileext = ".R")
+
+  if (isTRUE(Sys.info()["sysname"] == "Windows")) {
+    download_dependencies_sh <- wslify_path(download_dependencies_sh)
+  }
+
   parse_versions_success <- system2(
-    "bash", c(download_dependencies_sh, gsub("\\", "/", download_dir, fixed = TRUE)),
+    "bash", c(download_dependencies_sh, download_dir),
     stdout = download_script,
     stderr = FALSE
   ) == 0
+
   if (!parse_versions_success) {
-    stop("Failed to parse versions.txt")
+    stop(paste("Failed to parse versions.txt; view ", download_script, "for more information", collapse = ""))
   }
   # `source` the download_script to use R to download all the dependency bundles
   source(download_script)
@@ -251,4 +257,15 @@ create_package_with_all_dependencies <- function(dest_file = NULL, source_file =
     stop("Failed to create new tar.gz file")
   }
   invisible(dest_file)
+}
+
+# Convert a Windows path to a WSL path
+# e.g. wslify_path("C:/Users/user/AppData/") returns "/mnt/c/Users/user/AppData"
+wslify_path <- function(path) {
+  m <- regexpr("[A-Z]:/", path)
+  drive_expr <- regmatches(path, m)
+  drive_letter <- strsplit(drive_expr, ":/")[[1]]
+  wslified_drive <- paste0("/mnt/", tolower(drive_letter))
+  end_path <- strsplit(path, drive_expr)[[1]][-1]
+  file.path(wslified_drive, end_path)
 }


### PR DESCRIPTION
### Rationale for this change

Fix path to directory which stops `create_package_with_all_dependencies()` working on Windows

### What changes are included in this PR?

Character replacement in the script to ensure that on Windows, wsl-comaptible path is used and paths are normalised.

### Are these changes tested?

I tested it locally myself and it works - there are no tests for this function.

### Are there any user-facing changes?

Nope
* Closes: #36638
