### PR TITLE
GH-37234: [MATLAB] Create an abstract `arrow.type.TemporalType` class

### DIFF
--- a/matlab/src/cpp/arrow/matlab/type/proxy/timestamp_type.cc
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/timestamp_type.cc
@@ -23,8 +23,8 @@
 namespace arrow::matlab::type::proxy {
 
     TimestampType::TimestampType(std::shared_ptr<arrow::TimestampType> timestamp_type) : FixedWidthType(std::move(timestamp_type)) {
-        REGISTER_METHOD(TimestampType, timeUnit);
-        REGISTER_METHOD(TimestampType, timeZone);
+        REGISTER_METHOD(TimestampType, getTimeUnit);
+        REGISTER_METHOD(TimestampType, getTimeZone);
     }
 
     libmexclass::proxy::MakeResult TimestampType::make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
@@ -55,7 +55,7 @@ namespace arrow::matlab::type::proxy {
         return std::make_shared<TimestampTypeProxy>(std::move(time_type));
     }
 
-    void TimestampType::timeZone(libmexclass::proxy::method::Context& context) {
+    void TimestampType::getTimeZone(libmexclass::proxy::method::Context& context) {
         namespace mda = ::matlab::data;
         mda::ArrayFactory factory;
 
@@ -68,7 +68,7 @@ namespace arrow::matlab::type::proxy {
         context.outputs[0] = timezone_mda;
     }
 
-    void TimestampType::timeUnit(libmexclass::proxy::method::Context& context) {
+    void TimestampType::getTimeUnit(libmexclass::proxy::method::Context& context) {
         namespace mda = ::matlab::data;
         mda::ArrayFactory factory;
 

--- a/matlab/src/cpp/arrow/matlab/type/proxy/timestamp_type.h
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/timestamp_type.h
@@ -33,9 +33,9 @@ class TimestampType : public arrow::matlab::type::proxy::FixedWidthType {
 
     protected:
 
-        void timeZone(libmexclass::proxy::method::Context& context);
+        void getTimeZone(libmexclass::proxy::method::Context& context);
 
-        void timeUnit(libmexclass::proxy::method::Context& context);
+        void getTimeUnit(libmexclass::proxy::method::Context& context);
 };
 
 }

--- a/matlab/src/matlab/+arrow/+type/TemporalType.m
+++ b/matlab/src/matlab/+arrow/+type/TemporalType.m
@@ -30,7 +30,7 @@ classdef TemporalType < arrow.type.FixedWidthType
         end
 
         function timeUnit = get.TimeUnit(obj)
-            timeUnitValue = obj.proxy.getTimeUnit();
+            timeUnitValue = obj.Proxy.getTimeUnit();
             timeUnit = arrow.type.TimeUnit(timeUnitValue);
         end
     end

--- a/matlab/src/matlab/+arrow/+type/TemporalType.m
+++ b/matlab/src/matlab/+arrow/+type/TemporalType.m
@@ -1,0 +1,37 @@
+%TEMPORALTYPE Parent class of all temporal types.
+
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef TemporalType < arrow.type.FixedWidthType
+
+    properties(Dependent, GetAccess=public, SetAccess=private)
+        TimeUnit
+    end
+
+    methods
+        function obj = TemporalType(proxy)
+            arguments
+                proxy(1, 1) libmexclass.proxy.Proxy
+            end
+            obj@arrow.type.FixedWidthType(proxy);
+        end
+
+        function timeUnit = get.TimeUnit(obj)
+            timeUnitValue = obj.proxy.getTimeUnit();
+            timeUnit = arrow.type.TimeUnit(timeUnitValue);
+        end
+    end
+end

--- a/matlab/src/matlab/+arrow/+type/TimestampType.m
+++ b/matlab/src/matlab/+arrow/+type/TimestampType.m
@@ -30,7 +30,7 @@ classdef TimestampType < arrow.type.TemporalType
         end
 
         function tz = get.TimeZone(obj)
-            tz = obj.Proxy.timeZone();
+            tz = obj.Proxy.getTimeZone();
         end
     end
 

--- a/matlab/src/matlab/+arrow/+type/TimestampType.m
+++ b/matlab/src/matlab/+arrow/+type/TimestampType.m
@@ -13,12 +13,11 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef TimestampType < arrow.type.FixedWidthType
+classdef TimestampType < arrow.type.TemporalType
 %TIMESTAMPTYPE Type class for timestamp data.
 
-    properties(Dependent, SetAccess=private, GetAccess=public)
+    properties(Dependent, GetAccess=public, SetAccess=private)
         TimeZone
-        TimeUnit
     end
 
     methods
@@ -27,12 +26,7 @@ classdef TimestampType < arrow.type.FixedWidthType
                 proxy(1, 1) libmexclass.proxy.Proxy {validate(proxy, "arrow.type.proxy.TimestampType")}
             end
             import arrow.internal.proxy.validate
-            obj@arrow.type.FixedWidthType(proxy);
-        end
-
-        function unit = get.TimeUnit(obj)
-            val = obj.Proxy.timeUnit();
-            unit = arrow.type.TimeUnit(val);
+            obj@arrow.type.TemporalType(proxy);
         end
 
         function tz = get.TimeZone(obj)


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

To simplify the implementation of `Time32Type`, `Time64Type`, `Date32Type`, and `Date64Type`, it would be helpful to create an abstract `arrow.type.TemporalType` class that the date and time types can inherit from.

As a first step, we can modify the implementation of `TimestampType` to inherit from `TemporalType`.

This mimics the class inheritance hierarchy from the C++ libraries.

### What changes are included in this PR?

1. Added a new MATLAB class called `arrow.type.TemporalType`. It inherits from `arrow.type.FixedWidthType` and defines one read-only property: `TimeUnit`.
2. Modified the MATLAB class `arrow.type.TimestampType` to inherit from `arrow.type.TemporalType` instead of `arrow.type.FixedWidthType`.
3. Renamed the  C++ `proxy::TimestampType` methods `timeUnit()` and `timeZone()` to `getTimeUnit()` and `getTimeZone()`.


### Are these changes tested?

Yes. The existing tests in `tTimetampType.m` cover these changes.

### Are there any user-facing changes?

No.

### Future Directions

1. Add `arrow.type.Time32Type` (#37231)
2. Add `arrow.type.Time64Type` (#37232)
3. Add `arrow.type.Date32Type` (#37229), 
4. Add `arrow.type.Time64Type` (#37230).
5. Add `arrow.array.Time32Array`
6. Add `arrow.array.Time64Array`
7. Add `arrow.array.Date32Array`
8. Add `arrow.array.Date64Array`
* Closes: #37234