### PR TITLE
GH-37245: [MATLAB] `arrow.internal.proxy.validate` throws `MATLAB:UndefinedFunction` when crafting the message to display when throwing the `arrow:proxy:ProxyNameMismatch` error 

### DIFF
--- a/matlab/src/matlab/+arrow/+internal/+proxy/validate.m
+++ b/matlab/src/matlab/+arrow/+internal/+proxy/validate.m
@@ -24,7 +24,7 @@ function validate(proxy, expectedName)
     if proxy.Name ~= expectedName
         errid = "arrow:proxy:ProxyNameMismatch";
         msg = compose("The Name property of the Proxy provided is ""%s"", " + ...
-            "but expected it to be   ""%s"".", proxy.Name, expectedName);
+            "but expected it to be ""%s"".", proxy.Name, expectedName);
         error(errid, msg);
     end
 end

--- a/matlab/src/matlab/+arrow/+internal/+proxy/validate.m
+++ b/matlab/src/matlab/+arrow/+internal/+proxy/validate.m
@@ -18,12 +18,13 @@ function validate(proxy, expectedName)
 % proxy.Name and expectedName are not equal.
     arguments
         proxy(1, 1) libmexclass.proxy.Proxy
-        expectedName(1, 1) string
+        expectedName(1, 1) string {mustBeNonmissing, mustBeNonzeroLengthText}
     end
 
     if proxy.Name ~= expectedName
         errid = "arrow:proxy:ProxyNameMismatch";
-        msg = "Proxy class name is " + proxyName + ", but expected " + expectedProxyName;
+        msg = compose("The Name property of the Proxy provided is ""%s"", " + ...
+            "but expected it to be   ""%s"".", proxy.Name, expectedName);
         error(errid, msg);
     end
 end

--- a/matlab/test/arrow/internal/proxy/tValidate.m
+++ b/matlab/test/arrow/internal/proxy/tValidate.m
@@ -1,0 +1,42 @@
+%TVALIDATE Unit tests for arrow.internal.proxy.validate
+
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef tValidate < matlab.unittest.TestCase
+
+    methods(Test)
+        function ProxyNameMatches(testCase)
+            % Verify arrow.internal.proxy.validate() does not throw an 
+            % error if the Name property of the Proxy provided matches
+            % the expected proxy name.
+            import arrow.internal.proxy.validate
+            a = arrow.array(1);
+            fcn = @() validate(a.Proxy, a.Proxy.Name);
+            testCase.verifyWarningFree(fcn);
+        end
+
+        function ProxyNameMismatchError(testCase)
+            % Verify arrow.internal.proxy.validate() throws an error 
+            % whose identifier is "arrow:proxy:ProxyNameMismatch" if the
+            % Name property of the Proxy provided does not match the 
+            % expected proxy name.
+            import arrow.internal.proxy.validate
+            a = arrow.array(1);
+            fcn = @() validate(a.Proxy, "NotAProxyName");
+            testCase.verifyError(fcn, "arrow:proxy:ProxyNameMismatch");
+        end
+    end
+end


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

When constructing the message to display for with the `arrow:proxy:ProxyNameMismatch` error,  we refer to an undefined variable in `arrow.internal.proxy.validate()`. This causes the function to throw a `MATLAB:UndefinedFunction` error instead of the intended one.

Here's an example of this bug:

```matlab
>> a = arrow.array([1 2 3]);
>> arrow.internal.proxy.validate(a.Proxy, "WrongProxyName")
Unrecognized function or variable 'proxyName'.

Error in arrow.internal.proxy.validate (line 26)
        msg = "Proxy class name is " + proxyName + ", but expected " + expectedProxyName;
```

This was the expected error message:

```matlab
>> a = arrow.array([1 2 3]);
>> arrow.internal.proxy.validate(a.Proxy, "WrongProxyName")
Error using arrow.internal.proxy.validate
Proxy class name is arrow.array.proxy.Float64Array, but expected WrongProxyName
```

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

1. Fixed the typos in `arrow.internal.proxy.validate()` to resolve the `MATLAB:UndefinedFunction` error
2. Added a new test class `test/arrow/internal/proxy/tValidate.m` to test  `arrow.internal.proxy.validate()`
3. Updated the error message to display when throwing an `arrow:proxy:ProxyNameMismatch` error: 

```matlab
>> a = arrow.array([1 2 3]);
>> arrow.internal.proxy.validate(a.Proxy, "WrongProxyName")
Error using arrow.internal.proxy.validate
The Name property of the Proxy provided is "arrow.array.proxy.Float64Array", but
expected it to be "WrongProxyName".
```

### Are these changes tested?

Yes, added a new test class `test/arrow/internal/proxy/tValidate.m`.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
5. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #37245