### PR TITLE
GH-37251: [MATLAB] Make `arrow.type.TemporalType` a "tag" class 

### DIFF
--- a/matlab/src/matlab/+arrow/+type/TemporalType.m
+++ b/matlab/src/matlab/+arrow/+type/TemporalType.m
@@ -17,21 +17,12 @@
 
 classdef TemporalType < arrow.type.FixedWidthType
 
-    properties(Dependent, GetAccess=public, SetAccess=private)
-        TimeUnit
-    end
-
     methods
         function obj = TemporalType(proxy)
             arguments
                 proxy(1, 1) libmexclass.proxy.Proxy
             end
             obj@arrow.type.FixedWidthType(proxy);
-        end
-
-        function timeUnit = get.TimeUnit(obj)
-            timeUnitValue = obj.Proxy.getTimeUnit();
-            timeUnit = arrow.type.TimeUnit(timeUnitValue);
         end
     end
 end

--- a/matlab/src/matlab/+arrow/+type/Time32Type.m
+++ b/matlab/src/matlab/+arrow/+type/Time32Type.m
@@ -17,6 +17,10 @@
 
 classdef Time32Type < arrow.type.TemporalType
 
+    properties(Dependent, GetAccess=public, SetAccess=private)
+        TimeUnit
+    end
+
     methods
         function obj = Time32Type(proxy)
             arguments
@@ -25,6 +29,11 @@ classdef Time32Type < arrow.type.TemporalType
             import arrow.internal.proxy.validate
 
             obj@arrow.type.TemporalType(proxy);
+        end
+
+        function timeUnit = get.TimeUnit(obj)
+            timeUnitValue = obj.Proxy.getTimeUnit();
+            timeUnit = arrow.type.TimeUnit(timeUnitValue);
         end
     end
 

--- a/matlab/src/matlab/+arrow/+type/TimestampType.m
+++ b/matlab/src/matlab/+arrow/+type/TimestampType.m
@@ -1,3 +1,5 @@
+%TIMESTAMPTYPE Type class for timestamp data.
+
 % Licensed to the Apache Software Foundation (ASF) under one or more
 % contributor license agreements.  See the NOTICE file distributed with
 % this work for additional information regarding copyright ownership.
@@ -14,9 +16,9 @@
 % permissions and limitations under the License.
 
 classdef TimestampType < arrow.type.TemporalType
-%TIMESTAMPTYPE Type class for timestamp data.
 
     properties(Dependent, GetAccess=public, SetAccess=private)
+        TimeUnit
         TimeZone
     end
 
@@ -27,6 +29,11 @@ classdef TimestampType < arrow.type.TemporalType
             end
             import arrow.internal.proxy.validate
             obj@arrow.type.TemporalType(proxy);
+        end
+
+        function timeUnit = get.TimeUnit(obj)
+            timeUnitValue = obj.Proxy.getTimeUnit();
+            timeUnit = arrow.type.TimeUnit(timeUnitValue);
         end
 
         function tz = get.TimeZone(obj)


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

The original motivation for adding the super-class `arrow.type.TemporalType` in #37236 was to define a common implementation for extracting the `Unit` property from `TimestampType`, `Time32Type`, `Time64Type`, `Date32Type`, and `Date64Type`. However, this approach doesn't work because the `Unit` property on `Date32Type` and `Date64Type` is a `DateUnit`, while the `Unit` property on the other three types is a`TimeUnit`. As a result, we cannot define a shared method for extracting the `Unit` property in `TemporalType`. 

Instead, we plan on making `arrow.type.TemporalType` a "tag"-class (i.e. it has no properties or methods) so it can be used to group the "temporal" types together to ease authoring conditional logical in client code. In a future PR, we plan on adding functions like `arrow.type.isTemporal`, `arrow.type.isNumeric`, etc. so that clients don't need to query the class type information directly (i.e. call `isa(type, "arrow.type.TemporalType")`). 

```matlab
function doStuff(arrowArray)
  import arrow.*

  arrowType = arrowArray.Type;
  if type.isTemporal(arrowType)
      ...
  else if type.isNumeric(arrowType)
      ...
  else 
      ...
  end
end
```

### What changes are included in this PR?

1. Removed the `TimeUnit` property from `arrow.type.TemporalType`
2. Added `TimeUnit` back as a property on `arrow.type.TimestampType` and `arrow.type.Time32Type`


### Are these changes tested?

Yes, the existing tests cover these changes.


### Are there any user-facing changes?

No.

### Future Directions
1. #37232
2. #37229
3. #37230

* Closes: #37251