### PR TITLE
GH-37257: [Ruby][FlightSQL] Use the same options for auto prepared statement close request

### DIFF
--- a/c_glib/arrow-flight-glib/client.cpp
+++ b/c_glib/arrow-flight-glib/client.cpp
@@ -148,7 +148,7 @@ gaflight_call_options_clear_headers(GAFlightCallOptions *options)
  * @func: (scope call): The user's callback function.
  * @user_data: (closure): Data for @func.
  *
- * Iterates over all header in the options.
+ * Iterates over all headers in the options.
  *
  * Since: 9.0.0
  */

--- a/c_glib/arrow-flight-glib/server.cpp
+++ b/c_glib/arrow-flight-glib/server.cpp
@@ -672,9 +672,8 @@ namespace gaflight {
       auto klass = GAFLIGHT_SERVER_CUSTOM_AUTH_HANDLER_GET_CLASS(handler_);
       auto gacontext = gaflight_server_call_context_new_raw(&context);
       auto gtoken = g_bytes_new_static(token.data(), token.size());
-      GBytes *gpeer_identity = nullptr;
       GError *error = nullptr;
-      klass->is_valid(handler_, gacontext, gtoken, &gpeer_identity, &error);
+      auto gpeer_identity = klass->is_valid(handler_, gacontext, gtoken, &error);
       g_bytes_unref(gtoken);
       g_object_unref(gacontext);
       if (gpeer_identity) {
@@ -760,20 +759,20 @@ gaflight_server_custom_auth_handler_authenticate(
  * @context: A #GAFlightServerCallContext.
  * @token: The client token. May be the empty string if the client does not
  *   provide a token.
- * @peer_identity: (out): The identity of the peer, if this authentication
- *   method supports it.
  * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Validates a per-call client token.
  *
+ * Returns: (nullable) (transfer full): The identity of the peer, if
+ *   this authentication method supports it.
+ *
  * Since: 12.0.0
  */
-void
+GBytes *
 gaflight_server_custom_auth_handler_is_valid(
   GAFlightServerCustomAuthHandler *handler,
   GAFlightServerCallContext *context,
   GBytes *token,
-  GBytes **peer_identity,
   GError **error)
 {
   auto flight_handler =
@@ -791,8 +790,10 @@ gaflight_server_custom_auth_handler_is_valid(
                     status,
                     "[flight-server-custom-auth-handler]"
                     "[is-valid]")) {
-    *peer_identity = g_bytes_new(flight_peer_identity.data(),
-                                 flight_peer_identity.size());
+    return g_bytes_new(flight_peer_identity.data(),
+                       flight_peer_identity.size());
+  } else {
+    return nullptr;
   }
 }
 

--- a/c_glib/arrow-flight-glib/server.h
+++ b/c_glib/arrow-flight-glib/server.h
@@ -84,6 +84,13 @@ struct _GAFlightServerCallContextClass
   GObjectClass parent_class;
 };
 
+GARROW_AVAILABLE_IN_14_0
+void
+gaflight_server_call_context_foreach_incoming_header(
+  GAFlightServerCallContext *context,
+  GAFlightHeaderFunc func,
+  gpointer user_data);
+
 
 #define GAFLIGHT_TYPE_SERVER_AUTH_SENDER        \
   (gaflight_server_auth_sender_get_type())

--- a/c_glib/arrow-flight-glib/server.h
+++ b/c_glib/arrow-flight-glib/server.h
@@ -165,11 +165,10 @@ struct _GAFlightServerCustomAuthHandlerClass
                        GAFlightServerAuthSender *sender,
                        GAFlightServerAuthReader *reader,
                        GError **error);
-  void (*is_valid)(GAFlightServerCustomAuthHandler *handler,
-                   GAFlightServerCallContext *context,
-                   GBytes *token,
-                   GBytes **peer_identity,
-                   GError **error);
+  GBytes *(*is_valid)(GAFlightServerCustomAuthHandler *handler,
+                      GAFlightServerCallContext *context,
+                      GBytes *token,
+                      GError **error);
 };
 
 GARROW_AVAILABLE_IN_12_0
@@ -182,12 +181,11 @@ gaflight_server_custom_auth_handler_authenticate(
   GError **error);
 
 GARROW_AVAILABLE_IN_12_0
-void
+GBytes *
 gaflight_server_custom_auth_handler_is_valid(
   GAFlightServerCustomAuthHandler *handler,
   GAFlightServerCallContext *context,
   GBytes *token,
-  GBytes **peer_identity,
   GError **error);
 
 

--- a/c_glib/doc/arrow-flight-glib/arrow-flight-glib-docs.xml
+++ b/c_glib/doc/arrow-flight-glib/arrow-flight-glib-docs.xml
@@ -55,6 +55,10 @@
     <title>Index of deprecated API</title>
     <xi:include href="xml/api-index-deprecated.xml"><xi:fallback /></xi:include>
   </index>
+  <index id="api-index-14-0-0" role="14.0.0">
+    <title>Index of new symbols in 14.0.0</title>
+    <xi:include href="xml/api-index-14.0.0.xml"><xi:fallback /></xi:include>
+  </index>
   <index id="api-index-12-0-0" role="12.0.0">
     <title>Index of new symbols in 12.0.0</title>
     <xi:include href="xml/api-index-12.0.0.xml"><xi:fallback /></xi:include>

--- a/ruby/red-arrow-flight-sql/test/helper/server.rb
+++ b/ruby/red-arrow-flight-sql/test/helper/server.rb
@@ -39,7 +39,7 @@ module Helper
     end
 
     def virtual_do_create_prepared_statement(context, request)
-      unless request.query == "INSERT INTO page_view_table VALUES (?, true)"
+      unless request.query == "INSERT INTO page_view_table VALUES ($1, true)"
         raise Arrow::Error::Invalid.new("invalid SQL")
       end
       result = ArrowFlightSQL::CreatePreparedStatementResult.new
@@ -61,6 +61,11 @@ module Helper
     def virtual_do_close_prepared_statement(context, request)
       unless request.handle.to_s == "valid-handle"
         raise Arrow::Error::Invalid.new("invalid handle")
+      end
+      access_key = context.incoming_headers.assoc("x-access-key")
+      unless access_key == ["x-access-key", "secret"]
+        message = "invalid access key: #{access_key.inspect}"
+        raise Arrow::Error::Invalid.new(message)
       end
     end
   end

--- a/ruby/red-arrow-flight-sql/test/test-client.rb
+++ b/ruby/red-arrow-flight-sql/test/test-client.rb
@@ -41,9 +41,11 @@ class TestClient < Test::Unit::TestCase
   end
 
   def test_prepare
-    insert_sql = "INSERT INTO page_view_table VALUES (?, true)"
+    insert_sql = "INSERT INTO page_view_table VALUES ($1, true)"
     block_called = false
-    @sql_client.prepare(insert_sql) do |statement|
+    options = ArrowFlight::CallOptions.new
+    options.add_header("x-access-key", "secret")
+    @sql_client.prepare(insert_sql, options) do |statement|
       block_called = true
       assert_equal([
                      Arrow::Schema.new(count: :uint64, private: :boolean),

--- a/ruby/red-arrow-flight/lib/arrow-flight/loader.rb
+++ b/ruby/red-arrow-flight/lib/arrow-flight/loader.rb
@@ -34,6 +34,7 @@ module ArrowFlight
       require "arrow-flight/client-options"
       require "arrow-flight/location"
       require "arrow-flight/record-batch-reader"
+      require "arrow-flight/server-call-context"
       require "arrow-flight/server-options"
       require "arrow-flight/ticket"
     end

--- a/ruby/red-arrow-flight/lib/arrow-flight/server-call-context.rb
+++ b/ruby/red-arrow-flight/lib/arrow-flight/server-call-context.rb
@@ -15,20 +15,17 @@
 # specific language governing permissions and limitations
 # under the License.
 
-module ArrowFlightSQL
-  class Client
-    alias_method :prepare_raw, :prepare
-    def prepare(query, options=nil)
-      statement = prepare_raw(query, options)
-      if block_given?
-        begin
-          yield(statement)
-        ensure
-          statement.close(options) unless statement.closed?
-        end
-      else
-        statement
+module ArrowFlight
+  class ServerCallContext
+    def each_incoming_header
+      return to_enum(__method__) unless block_given?
+      foreach_incoming_header do |key, value|
+        yield(key, value)
       end
+    end
+
+    def incoming_headers
+      each_incoming_header.to_a
     end
   end
 end


### PR DESCRIPTION
### Rationale for this change

If we don't pass the same options for auto prepared statement close request, the close request may be failed.
For example, it's caused when authentication information in the options. 

### What changes are included in this PR?

`ArrowFlightSQL::Client#prepare` change is the main change to use the given options for auto prepared statement close  request too.

Other changes (`gaflight_server_call_context_foreach_incoming_header()` and related changes) are for testing the above change.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #37257