### PR TITLE
GH-37263: [C++] Trying to use std::from_chars in Parquet and IO

### DIFF
--- a/cpp/src/arrow/io/interfaces.cc
+++ b/cpp/src/arrow/io/interfaces.cc
@@ -18,6 +18,7 @@
 #include "arrow/io/interfaces.h"
 
 #include <algorithm>
+#include <charconv>
 #include <cstdint>
 #include <iterator>
 #include <list>
@@ -393,10 +394,8 @@ std::shared_ptr<ThreadPool> MakeIOThreadPool() {
   if (maybe_env_var.ok()) {
     auto str = *std::move(maybe_env_var);
     if (!str.empty()) {
-      try {
-        threads = std::stoi(str);
-      } catch (...) {
-      }
+      // If parse failed, the threads will be 0.
+      std::from_chars(str.data(), str.data() + str.size(), threads);
       if (threads <= 0) {
         ARROW_LOG(WARNING)
             << "ARROW_IO_THREADS does not contain a valid number of threads "

--- a/cpp/src/arrow/util/thread_pool.cc
+++ b/cpp/src/arrow/util/thread_pool.cc
@@ -18,6 +18,7 @@
 #include "arrow/util/thread_pool.h"
 
 #include <algorithm>
+#include <charconv>
 #include <condition_variable>
 #include <deque>
 #include <list>
@@ -695,11 +696,10 @@ static int ParseOMPEnvVar(const char* name) {
   if (first_comma != std::string::npos) {
     str = str.substr(0, first_comma);
   }
-  try {
-    return std::max(0, std::stoi(str));
-  } catch (...) {
-    return 0;
-  }
+  int env_value = 0;
+  // If parse failed, the env_value will be 0.
+  std::from_chars(str.data(), str.data() + str.size(), env_value);
+  return env_value;
 }
 
 int ThreadPool::DefaultCapacity() {

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -18,6 +18,7 @@
 #include "parquet/metadata.h"
 
 #include <algorithm>
+#include <charconv>
 #include <cinttypes>
 #include <ostream>
 #include <string>
@@ -1210,9 +1211,12 @@ class ApplicationVersionParser {
       }
       version_parsing_position_ = version_major_end + 1;  // +1 is for '.'.
     }
-    auto version_major_string = version_string_.substr(
-        version_major_start, version_major_end - version_major_start);
-    application_version_.version.major = atoi(version_major_string.c_str());
+    auto [_, result] = std::from_chars(version_string_.data() + version_major_start,
+                                       version_string_.data() + version_major_end,
+                                       application_version_.version.major);
+    if (result != std::errc()) {
+      return false;
+    }
     return true;
   }
 
@@ -1235,9 +1239,12 @@ class ApplicationVersionParser {
       }
       version_parsing_position_ = version_minor_end + 1;  // +1 is for '.'.
     }
-    auto version_minor_string = version_string_.substr(
-        version_minor_start, version_minor_end - version_minor_start);
-    application_version_.version.minor = atoi(version_minor_string.c_str());
+    auto [_, result] = std::from_chars(version_string_.data() + version_minor_start,
+                                       version_string_.data() + version_minor_end,
+                                       application_version_.version.minor);
+    if (result != std::errc()) {
+      return false;
+    }
     return true;
   }
 
@@ -1253,9 +1260,12 @@ class ApplicationVersionParser {
     if (version_patch_end == version_patch_start) {
       return false;
     }
-    auto version_patch_string = version_string_.substr(
-        version_patch_start, version_patch_end - version_patch_start);
-    application_version_.version.patch = atoi(version_patch_string.c_str());
+    auto [_, result] = std::from_chars(version_string_.data() + version_patch_start,
+                                       version_string_.data() + version_patch_end,
+                                       application_version_.version.patch);
+    if (result != std::errc()) {
+      return false;
+    }
     version_parsing_position_ = version_patch_end;
     return true;
   }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Trying to use `std::from_chars` in C++17 instead of `std::stoi` and `atoi`.

The document is:
1. https://en.cppreference.com/w/cpp/utility/from_chars
2. https://en.cppreference.com/w/cpp/string/basic_string/stol

Difference: `from_chars` cannot parse string like "+127"

Performance: https://www.fluentcpp.com/2018/07/27/how-to-efficiently-convert-a-string-to-an-int-in-c/

I'm not familiar with flight and flight sql. So I didn't change them.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Replace string parse to `std::from_chars`.

### Are these changes tested?

no, I think the case is tested by previous cases.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

no

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #37263