### PR TITLE
GH-37262: [MATLAB] Add an abstract class called `arrow.type.TimeType`

### DIFF
--- a/matlab/src/cpp/arrow/matlab/type/proxy/time32_type.cc
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/time32_type.cc
@@ -22,9 +22,7 @@
 
 namespace arrow::matlab::type::proxy {
 
-    Time32Type::Time32Type(std::shared_ptr<arrow::Time32Type> time32_type) : FixedWidthType(std::move(time32_type)) {
-        REGISTER_METHOD(Time32Type, getTimeUnit);
-    }
+    Time32Type::Time32Type(std::shared_ptr<arrow::Time32Type> time32_type) : TimeType(std::move(time32_type)) {}
 
     libmexclass::proxy::MakeResult Time32Type::make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
         namespace mda = ::matlab::data;
@@ -44,17 +42,5 @@ namespace arrow::matlab::type::proxy {
         auto type = arrow::time32(timeunit);
         auto time_type = std::static_pointer_cast<arrow::Time32Type>(type);
         return std::make_shared<Time32TypeProxy>(std::move(time_type));
-    }
-
-    void Time32Type::getTimeUnit(libmexclass::proxy::method::Context& context) {
-        namespace mda = ::matlab::data;
-        mda::ArrayFactory factory;
-
-        auto time32_type = std::static_pointer_cast<arrow::Time32Type>(data_type);
-        const auto timeunit = time32_type->unit();
-        // Cast to uint8_t since there are only four supported TimeUnit enumeration values:
-        // Nanosecond, Microsecond, Millisecond, Second
-        auto timeunit_mda = factory.createScalar(static_cast<uint8_t>(timeunit));
-        context.outputs[0] = timeunit_mda;
     }
 }

--- a/matlab/src/cpp/arrow/matlab/type/proxy/time32_type.h
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/time32_type.h
@@ -17,12 +17,11 @@
 
 #pragma once
 
-#include "arrow/matlab/type/proxy/fixed_width_type.h"
-#include "arrow/type_traits.h"
+#include "arrow/matlab/type/proxy/time_type.h"
 
 namespace arrow::matlab::type::proxy {
 
-class Time32Type : public arrow::matlab::type::proxy::FixedWidthType {
+class Time32Type : public arrow::matlab::type::proxy::TimeType {
 
     public:
         Time32Type(std::shared_ptr<arrow::Time32Type> time32_type);
@@ -31,8 +30,6 @@ class Time32Type : public arrow::matlab::type::proxy::FixedWidthType {
 
         static libmexclass::proxy::MakeResult make(const libmexclass::proxy::FunctionArguments& constructor_arguments);
 
-    protected:
-        void getTimeUnit(libmexclass::proxy::method::Context& context);
 };
 
 }

--- a/matlab/src/cpp/arrow/matlab/type/proxy/time_type.cc
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/time_type.cc
@@ -1,0 +1,37 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/matlab/type/proxy/time_type.h"
+
+namespace arrow::matlab::type::proxy {
+
+    TimeType::TimeType(std::shared_ptr<arrow::TimeType> time_type) : FixedWidthType(std::move(time_type)) {
+        REGISTER_METHOD(TimeType, getTimeUnit);
+    }
+
+    void TimeType::getTimeUnit(libmexclass::proxy::method::Context& context) {
+        namespace mda = ::matlab::data;
+        mda::ArrayFactory factory;
+
+        auto time_type = std::static_pointer_cast<arrow::TimeType>(data_type);
+        const auto timeunit = time_type->unit();
+        // Cast to uint8_t since there are only four supported TimeUnit enumeration values:
+        // Nanosecond, Microsecond, Millisecond, Second
+        auto timeunit_mda = factory.createScalar(static_cast<uint8_t>(timeunit));
+        context.outputs[0] = timeunit_mda;
+    }
+}

--- a/matlab/src/cpp/arrow/matlab/type/proxy/time_type.h
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/time_type.h
@@ -24,7 +24,7 @@ namespace arrow::matlab::type::proxy {
 class TimeType : public arrow::matlab::type::proxy::FixedWidthType {
 
     public:
-        TimeType(std::shared_ptr<arrow::Time32Type> time_type);
+        TimeType(std::shared_ptr<arrow::TimeType> time_type);
 
         ~TimeType() {}
 

--- a/matlab/src/cpp/arrow/matlab/type/proxy/time_type.h
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/time_type.h
@@ -1,0 +1,35 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "arrow/matlab/type/proxy/fixed_width_type.h"
+
+namespace arrow::matlab::type::proxy {
+
+class TimeType : public arrow::matlab::type::proxy::FixedWidthType {
+
+    public:
+        TimeType(std::shared_ptr<arrow::Time32Type> time_type);
+
+        ~TimeType() {}
+
+    protected:
+        void getTimeUnit(libmexclass::proxy::method::Context& context);
+};
+
+}

--- a/matlab/src/matlab/+arrow/+type/Time32Type.m
+++ b/matlab/src/matlab/+arrow/+type/Time32Type.m
@@ -15,11 +15,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef Time32Type < arrow.type.TemporalType
-
-    properties(Dependent, GetAccess=public, SetAccess=private)
-        TimeUnit
-    end
+classdef Time32Type < arrow.type.TimeType
 
     methods
         function obj = Time32Type(proxy)
@@ -28,19 +24,14 @@ classdef Time32Type < arrow.type.TemporalType
             end
             import arrow.internal.proxy.validate
 
-            obj@arrow.type.TemporalType(proxy);
-        end
-
-        function timeUnit = get.TimeUnit(obj)
-            timeUnitValue = obj.Proxy.getTimeUnit();
-            timeUnit = arrow.type.TimeUnit(timeUnitValue);
+            obj@arrow.type.TimeType(proxy);
         end
     end
 
     methods (Access=protected)
         function group = getPropertyGroups(~)
-          targets = ["ID" "TimeUnit"];
-          group = matlab.mixin.util.PropertyGroup(targets);
+            targets = ["ID" "TimeUnit"];
+            group = matlab.mixin.util.PropertyGroup(targets);
         end
     end
 

--- a/matlab/src/matlab/+arrow/+type/Time32Type.m
+++ b/matlab/src/matlab/+arrow/+type/Time32Type.m
@@ -28,11 +28,4 @@ classdef Time32Type < arrow.type.TimeType
         end
     end
 
-    methods (Access=protected)
-        function group = getPropertyGroups(~)
-            targets = ["ID" "TimeUnit"];
-            group = matlab.mixin.util.PropertyGroup(targets);
-        end
-    end
-
 end

--- a/matlab/src/matlab/+arrow/+type/TimeType.m
+++ b/matlab/src/matlab/+arrow/+type/TimeType.m
@@ -34,4 +34,12 @@ classdef TimeType < arrow.type.TemporalType
             timeUnit = arrow.type.TimeUnit(timeUnitValue);
         end
     end
+
+    methods (Access=protected)
+        function group = getPropertyGroups(~)
+            targets = ["ID" "TimeUnit"];
+            group = matlab.mixin.util.PropertyGroup(targets);
+        end
+    end
+
 end

--- a/matlab/src/matlab/+arrow/+type/TimeType.m
+++ b/matlab/src/matlab/+arrow/+type/TimeType.m
@@ -1,0 +1,37 @@
+%TIMETYPE Type class for time data.
+
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef TimeType < arrow.type.TemporalType
+
+    properties(Dependent, SetAccess=private, GetAccess=public)
+        TimeUnit
+    end
+
+    methods
+        function obj = TimeType(proxy)
+            arguments
+                proxy(1, 1) libmexclass.proxy.Proxy
+            end
+            obj@arrow.type.TemporalType(proxy);
+        end
+
+        function timeUnit = get.TimeUnit(obj)
+            timeUnitValue = obj.Proxy.getTimeUnit();
+            timeUnit = arrow.type.TimeUnit(timeUnitValue);
+        end
+    end
+end

--- a/matlab/tools/cmake/BuildMatlabArrowInterface.cmake
+++ b/matlab/tools/cmake/BuildMatlabArrowInterface.cmake
@@ -55,6 +55,7 @@ set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_SOURCES "${CMAKE_SOURCE_DIR}/src/cpp/a
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy/fixed_width_type.cc"
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy/string_type.cc"
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy/timestamp_type.cc"
+                                                  "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy/time_type.cc"
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy/time32_type.cc"
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy/field.cc"
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/type/proxy/wrap.cc"


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

To reduce code duplication within `Time32Type` and `Time64Type`, we should add an abstract class called `arrow.type.TimeType` that implements  the getter method for the `TimeUnit` property. This class hierarchy will mirror the class hierarchy in the C++ arrow implementation.

### What changes are included in this PR?

1. Defined a new C++ proxy class for called `arrow::matlab::type::proxy::TimeType`. This class defines a `getTimeUnit` method.
2. Modified the C++ proxy class `Time32Type` to inherit from `arrow::matlab::type::proxy::TimeType`. Removed the `getTimeUnit` method from this class because it's now defined on `TimeType`.
3. Added a new MATLAB class called `arrow.type.TimeType`. It has one method: `get.TimeUnit`.
4. Modified `arrow.type.Time32Type` to inherit from `arrow.type.TimeType` and removed its `get.TimeUnit` method.

### Are these changes tested?

Yes, the existing tests cover these changes.

### Are there any user-facing changes?

No.

### Future Directions

1. #37232
2. #37229
3. #37230   
* Closes: #37262