### PR TITLE
GH-37252: [MATLAB] Add `arrow.type.DateUnit` enumeration class

### DIFF
--- a/matlab/src/matlab/+arrow/+type/DateUnit.m
+++ b/matlab/src/matlab/+arrow/+type/DateUnit.m
@@ -1,0 +1,23 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+classdef DateUnit < int16
+% Enumeration class representing Date Units.
+
+    enumeration
+        Day          (0)
+        Millisecond  (1)
+    end
+
+end

--- a/matlab/src/matlab/+arrow/+type/DateUnit.m
+++ b/matlab/src/matlab/+arrow/+type/DateUnit.m
@@ -1,3 +1,5 @@
+% Enumeration class representing Date Units.
+
 % Licensed to the Apache Software Foundation (ASF) under one or more
 % contributor license agreements.  See the NOTICE file distributed with
 % this work for additional information regarding copyright ownership.
@@ -12,8 +14,7 @@
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
-classdef DateUnit < int16
-% Enumeration class representing Date Units.
+classdef DateUnit < uint8
 
     enumeration
         Day          (0)

--- a/matlab/src/matlab/+arrow/+type/TimeUnit.m
+++ b/matlab/src/matlab/+arrow/+type/TimeUnit.m
@@ -1,3 +1,5 @@
+% Enumeration class representing Time Units.
+
 % Licensed to the Apache Software Foundation (ASF) under one or more
 % contributor license agreements.  See the NOTICE file distributed with
 % this work for additional information regarding copyright ownership.
@@ -12,8 +14,7 @@
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
-classdef TimeUnit < int16
-% Enumeration class representing Time Units.
+classdef TimeUnit < uint8
 
     enumeration
         Second       (0)

--- a/matlab/test/arrow/type/tDateUnit.m
+++ b/matlab/test/arrow/type/tDateUnit.m
@@ -1,3 +1,5 @@
+% Tests for the arrow.type.DateUnit enumeration class
+
 % Licensed to the Apache Software Foundation (ASF) under one or more
 % contributor license agreements.  See the NOTICE file distributed with
 % this work for additional information regarding copyright ownership.
@@ -13,7 +15,6 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 classdef tDateUnit < matlab.unittest.TestCase
-% Tests for the arrow.type.DateUnit enumeration class
 
     properties (Constant)
         ClassName = "arrow.type.DateUnit";

--- a/matlab/test/arrow/type/tDateUnit.m
+++ b/matlab/test/arrow/type/tDateUnit.m
@@ -12,40 +12,28 @@
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
-classdef tTimeUnit < matlab.unittest.TestCase
-% Tests for the arrow.type.TimeUnit enumeration class
+classdef tDateUnit < matlab.unittest.TestCase
+% Tests for the arrow.type.DateUnit enumeration class
 
     properties (Constant)
-        ClassName = "arrow.type.TimeUnit";
+        ClassName = "arrow.type.DateUnit";
         EnumerationValues = [ ...
-            arrow.type.TimeUnit.Second; ...
-            arrow.type.TimeUnit.Millisecond; ...
-            arrow.type.TimeUnit.Microsecond; ...
-            arrow.type.TimeUnit.Nanosecond ...
+            arrow.type.DateUnit.Day; ...
+            arrow.type.DateUnit.Millisecond ...
         ];
     end
     
     methods (Test)
 
         function SupportedValues(testCase)
-            % Verify there are four supported TimeUnit enumeration values.
+            % Verify there are two supported DateUnit enumeration values.
 
             actualEnumerationValues = enumeration(testCase.ClassName);
 
             testCase.verifyEqual(actualEnumerationValues, testCase.EnumerationValues);
         end
 
-        function TicksPerSecond(testCase)
-            % Verify the TicksPerSecond property has the right value for
-            % each TimeUnit enumeration value.
-
-            expectedTicksPerSecond = [1 1e3 1e6 1e9];
-            for ii = 1:numel(testCase.EnumerationValues)
-                actualTicksPerSecond = ticksPerSecond(testCase.EnumerationValues(ii));
-                testCase.verifyEqual(actualTicksPerSecond, expectedTicksPerSecond(ii));
-            end
-        end
-
     end
 
 end
+

--- a/matlab/test/arrow/type/tTimeUnit.m
+++ b/matlab/test/arrow/type/tTimeUnit.m
@@ -1,3 +1,5 @@
+% Tests for the arrow.type.TimeUnit enumeration class
+
 % Licensed to the Apache Software Foundation (ASF) under one or more
 % contributor license agreements.  See the NOTICE file distributed with
 % this work for additional information regarding copyright ownership.
@@ -13,7 +15,6 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 classdef tTimeUnit < matlab.unittest.TestCase
-% Tests for the arrow.type.TimeUnit enumeration class
 
     properties (Constant)
         ClassName = "arrow.type.TimeUnit";


### PR DESCRIPTION
### Rationale for this change

In support of adding  `arrow.type.Date32Type` and `arrow.type.Date64Type`, this pull request adds a `arrow.type.DateUnit` enumeration class mirroring the `arrow.type.TimeUnit` enumeration class.

`arrow.type.DateUnit` will have two values: `Day` and `Millisecond`.

### What changes are included in this PR?

1. Added a new enumeration class `arrow.type.DateUnit` which mirrors the `arrow.type.TimeUnit` enumeration class.

**Example**:

```matlab
>> day = arrow.type.DateUnit.Day

day = 

  DateUnit enumeration

    Day

>> millisecond = arrow.type.DateUnit.Millisecond

millisecond = 

  DateUnit enumeration

    Millisecond
```

### Are these changes tested?

Yes.

1. Added a new test class `tDateUnit` for `arrow.type.DateUnit` tests.
2. Updated code for `tTimeUnit` for consistency with `tDateUnit`.

### Are there any user-facing changes?

Yes.

1. There is now a new user-facing `arrow.type.DateUnit` enumeration class.

### Future Directions

1. Add an `arrow.internal.validate.temporal.dateUnit` helper function that mirrors `arrow.internal.validate.temporal.timeUnit`.
2. #37229
3. #37230
* Closes: #37252