### PR TITLE
GH-37288: [MATLAB] Add an `arrow.internal.validate.temporal.dateUnit` helper function

### DIFF
--- a/matlab/src/matlab/+arrow/+internal/+validate/+temporal/dateUnit.m
+++ b/matlab/src/matlab/+arrow/+internal/+validate/+temporal/dateUnit.m
@@ -1,5 +1,5 @@
-%TIMEUNIT Validates whether the given arrow.type.TimeUnit enumeration
-% value is supported for the specified time type.
+%DATEUNIT Validates whether the given arrow.type.DateUnit enumeration
+% value is supported for the specified date type.
 
 % Licensed to the Apache Software Foundation (ASF) under one or more
 % contributor license agreements.  See the NOTICE file distributed with
@@ -15,24 +15,24 @@
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
-function timeUnit(timeType, timeUnit)
+function dateUnit(dateType, dateUnit)
     arguments
-        timeType (1,1) string {mustBeMember(timeType, ["Time32", "Time64"])}
-        timeUnit (1,1) arrow.type.TimeUnit
+        dateType (1,1) string {mustBeMember(dateType, ["Date32", "Date64"])}
+        dateUnit (1,1) arrow.type.DateUnit
     end
-    import arrow.type.TimeUnit
+    import arrow.type.DateUnit
 
-    switch timeType
-        case "Time32"
-            if ~(timeUnit == TimeUnit.Second || timeUnit == TimeUnit.Millisecond)
-                errid = "arrow:validate:temporal:UnsupportedTime32TimeUnit";
-                msg = "Supported TimeUnit values for Time32Type are ""Second"" and ""Millisecond"".";
+    switch dateType
+        case "Date32"
+            if dateUnit ~= DateUnit.Day
+                errid = "arrow:validate:temporal:UnsupportedDate32DateUnit";
+                msg = "The DateUnit for Date32Type must be ""Day"".";
                 error(errid, msg);
             end
-        case "Time64"
-            if ~(timeUnit == TimeUnit.Microsecond || timeUnit == TimeUnit.Nanosecond)
-                errid = "arrow:validate:temporal:UnsupportedTime64TimeUnit";
-                msg = "Supported TimeUnit values for Time64Type are ""Microsecond"" and ""Nanosecond"".";
+        case "Date64"
+            if dateUnit ~= DateUnit.Millisecond
+                errid = "arrow:validate:temporal:UnsupportedDate64DateUnit";
+                msg = "The DateUnit for Date64Type must be ""Millisecond"".";
                 error(errid, msg);
             end
     end

--- a/matlab/test/arrow/internal/validate/temporal/tDateUnit.m
+++ b/matlab/test/arrow/internal/validate/temporal/tDateUnit.m
@@ -1,0 +1,116 @@
+%TDATEUNIT Unit tests for arrow.internal.validate.temporal.dateUnit.
+
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef tDateUnit < matlab.unittest.TestCase
+
+    methods(Test)
+
+        function ErrorIfUnsupportedDateType(testCase)
+            import arrow.internal.validate.temporal.dateUnit
+            import arrow.type.DateUnit
+
+            dateType = "abc";
+            unit = DateUnit.Day;
+            fcn = @() dateUnit(dateType, unit);
+            errid = "MATLAB:validators:mustBeMember";
+            testCase.verifyError(fcn, errid);
+
+            dateType = 123;
+            unit = DateUnit.Day;
+            fcn = @() dateUnit(dateType, unit);
+            errid = "MATLAB:validators:mustBeMember";
+            testCase.verifyError(fcn, errid);
+
+            dateType = [1, 2, 3];
+            unit = DateUnit.Day;
+            fcn = @() dateUnit(dateType, unit);
+            errid = "MATLAB:validation:IncompatibleSize";
+            testCase.verifyError(fcn, errid);
+        end
+
+        function ErrorIfUnsupportedDateUnitType(testCase)
+            import arrow.internal.validate.temporal.dateUnit
+            import arrow.type.DateUnit
+
+            dateType = "Date32";
+            unit = "abc";
+            fcn = @() dateUnit(dateType, unit);
+            errid = "MATLAB:validation:UnableToConvert";
+            testCase.verifyError(fcn, errid);
+
+            dateType = "Date32";
+            unit = 123;
+            fcn = @() dateUnit(dateType, unit);
+            errid = "MATLAB:validation:UnableToConvert";
+            testCase.verifyError(fcn, errid);
+
+            dateType = "Date32";
+            unit = [1, 2, 3];
+            fcn = @() dateUnit(dateType, unit);
+            errid = "MATLAB:validation:IncompatibleSize";
+            testCase.verifyError(fcn, errid);
+        end
+
+        function SupportedDate32DateUnit(testCase)
+            import arrow.internal.validate.temporal.dateUnit
+            import arrow.type.DateUnit
+
+            dateType = "Date32";
+
+            unit = DateUnit.Day;
+            fcn = @() dateUnit(dateType, unit);
+            testCase.verifyWarningFree(fcn);
+        end
+
+        function SupportedDate64DateUnit(testCase)
+            import arrow.internal.validate.temporal.dateUnit
+            import arrow.type.DateUnit
+
+            dateType = "Date64";
+
+            unit = DateUnit.Millisecond;
+            fcn = @() dateUnit(dateType, unit);
+            testCase.verifyWarningFree(fcn);
+        end
+
+        function UnsupportedDate32DateUnit(testCase)
+            import arrow.internal.validate.temporal.dateUnit
+            import arrow.type.DateUnit
+
+            dateType = "Date32";
+
+            unit = DateUnit.Millisecond;
+            fcn = @() dateUnit(dateType, unit);
+            errorID = "arrow:validate:temporal:UnsupportedDate32DateUnit";
+            testCase.verifyError(fcn, errorID);
+        end
+
+        function UnsupportedDate64DateUnit(testCase)
+            import arrow.internal.validate.temporal.dateUnit
+            import arrow.type.DateUnit
+
+            dateType = "Date64";
+
+            unit = DateUnit.Day;
+            fcn = @() dateUnit(dateType, unit);
+            errorID = "arrow:validate:temporal:UnsupportedDate64DateUnit";
+            testCase.verifyError(fcn, errorID);
+        end
+
+    end
+
+end

--- a/matlab/test/arrow/internal/validate/temporal/tTimeUnit.m
+++ b/matlab/test/arrow/internal/validate/temporal/tTimeUnit.m
@@ -19,25 +19,25 @@ classdef tTimeUnit < matlab.unittest.TestCase
 
     methods(Test)
 
-        function ErrorIfUnsupportedTemporalType(testCase)
+        function ErrorIfUnsupportedTimeType(testCase)
             import arrow.internal.validate.temporal.timeUnit
             import arrow.type.TimeUnit
 
-            temporalType = "abc";
+            timeType = "abc";
             unit = TimeUnit.Second;
-            fcn = @() timeUnit(temporalType, unit);
+            fcn = @() timeUnit(timeType, unit);
             errid = "MATLAB:validators:mustBeMember";
             testCase.verifyError(fcn, errid);
 
-            temporalType = 123;
+            timeType = 123;
             unit = TimeUnit.Second;
-            fcn = @() timeUnit(temporalType, unit);
+            fcn = @() timeUnit(timeType, unit);
             errid = "MATLAB:validators:mustBeMember";
             testCase.verifyError(fcn, errid);
 
-            temporalType = [1, 2, 3];
+            timeType = [1, 2, 3];
             unit = TimeUnit.Second;
-            fcn = @() timeUnit(temporalType, unit);
+            fcn = @() timeUnit(timeType, unit);
             errid = "MATLAB:validation:IncompatibleSize";
             testCase.verifyError(fcn, errid);
         end
@@ -46,21 +46,21 @@ classdef tTimeUnit < matlab.unittest.TestCase
             import arrow.internal.validate.temporal.timeUnit
             import arrow.type.TimeUnit
 
-            temporalType = "Time32";
+            timeType = "Time32";
             unit = "abc";
-            fcn = @() timeUnit(temporalType, unit);
+            fcn = @() timeUnit(timeType, unit);
             errid = "MATLAB:validation:UnableToConvert";
             testCase.verifyError(fcn, errid);
 
-            temporalType = "Time32";
+            timeType = "Time32";
             unit = 123;
-            fcn = @() timeUnit(temporalType, unit);
+            fcn = @() timeUnit(timeType, unit);
             errid = "MATLAB:validation:UnableToConvert";
             testCase.verifyError(fcn, errid);
 
-            temporalType = "Time32";
+            timeType = "Time32";
             unit = [1, 2, 3];
-            fcn = @() timeUnit(temporalType, unit);
+            fcn = @() timeUnit(timeType, unit);
             errid = "MATLAB:validation:IncompatibleSize";
             testCase.verifyError(fcn, errid);
         end
@@ -69,14 +69,14 @@ classdef tTimeUnit < matlab.unittest.TestCase
             import arrow.internal.validate.temporal.timeUnit
             import arrow.type.TimeUnit
 
-            temporalType = "Time32";
+            timeType = "Time32";
 
             unit = TimeUnit.Second;
-            fcn = @() timeUnit(temporalType, unit);
+            fcn = @() timeUnit(timeType, unit);
             testCase.verifyWarningFree(fcn);
 
             unit = TimeUnit.Millisecond;
-            fcn = @() timeUnit(temporalType, unit);
+            fcn = @() timeUnit(timeType, unit);
             testCase.verifyWarningFree(fcn);
         end
 
@@ -84,14 +84,14 @@ classdef tTimeUnit < matlab.unittest.TestCase
             import arrow.internal.validate.temporal.timeUnit
             import arrow.type.TimeUnit
 
-            temporalType = "Time64";
+            timeType = "Time64";
 
             unit = TimeUnit.Microsecond;
-            fcn = @() timeUnit(temporalType, unit);
+            fcn = @() timeUnit(timeType, unit);
             testCase.verifyWarningFree(fcn);
 
             unit = TimeUnit.Nanosecond;
-            fcn = @() timeUnit(temporalType, unit);
+            fcn = @() timeUnit(timeType, unit);
             testCase.verifyWarningFree(fcn);
         end
 
@@ -99,15 +99,15 @@ classdef tTimeUnit < matlab.unittest.TestCase
             import arrow.internal.validate.temporal.timeUnit
             import arrow.type.TimeUnit
 
-            temporalType = "Time32";
+            timeType = "Time32";
 
             unit = TimeUnit.Microsecond;
-            fcn = @() timeUnit(temporalType, unit);
+            fcn = @() timeUnit(timeType, unit);
             errorID = "arrow:validate:temporal:UnsupportedTime32TimeUnit";
             testCase.verifyError(fcn, errorID);
 
             unit = TimeUnit.Nanosecond;
-            fcn = @() timeUnit(temporalType, unit);
+            fcn = @() timeUnit(timeType, unit);
             errorID = "arrow:validate:temporal:UnsupportedTime32TimeUnit";
             testCase.verifyError(fcn, errorID);
         end
@@ -116,18 +116,19 @@ classdef tTimeUnit < matlab.unittest.TestCase
             import arrow.internal.validate.temporal.timeUnit
             import arrow.type.TimeUnit
 
-            temporalType = "Time64";
+            timeType = "Time64";
 
             unit = TimeUnit.Second;
-            fcn = @() timeUnit(temporalType, unit);
+            fcn = @() timeUnit(timeType, unit);
             errorID = "arrow:validate:temporal:UnsupportedTime64TimeUnit";
             testCase.verifyError(fcn, errorID);
 
             unit = TimeUnit.Millisecond;
-            fcn = @() timeUnit(temporalType, unit);
+            fcn = @() timeUnit(timeType, unit);
             errorID = "arrow:validate:temporal:UnsupportedTime64TimeUnit";
             testCase.verifyError(fcn, errorID);
         end
 
     end
+
 end


### PR DESCRIPTION
### Rationale for this change

To mirror the [`arrow.internal.validate.temporal.timeUnit`](https://github.com/apache/arrow/blob/main/matlab/src/matlab/%2Barrow/%2Binternal/%2Bvalidate/%2Btemporal/timeUnit.m) helper function added in #37250, this pull request adds an `arrow.internal.validate.temporal.dateUnit` helper function.

This helper function can be used to simplify the implementation of `arrow.type.Date32Type` and `arrow.type.Date64Type`.

### What changes are included in this PR?

1. Added a new helper function `arrow.internal.validate.temporal.dateUnit`.
2. Updated comments and variable names in `arrow.internal.validate.temporal.timeUnit` for consistency with `arrow.internal.validate.temporal.dateUnit` and to reflect planned changes to Arrow type class hierarchy:

    *  `TimeType` and `DateType` inherit from `TemporalType`
    * `Time32Type` and `Time64Type` inherit from `TimeType`
    * `Date32Type` and `Date64Type` inherit from `DateType`

### Are these changes tested?

Yes.

1. Added new test class `tDateUnit`.
5. Updated existing test class `tTimeUnit` for consistency with new `tDateUnit` test class.

### Are there any user-facing changes?

No.

`arrow.internal.validate.temporal.dateUnit` is an internal helper function.
* Closes: #37288