### PR TITLE
GH-37299: [C++] Fix clang-format version mismatch error with Homebrew's clang-format

### DIFF
--- a/cpp/cmake_modules/FindClangTools.cmake
+++ b/cpp/cmake_modules/FindClangTools.cmake
@@ -108,7 +108,7 @@ else()
 endif()
 
 find_clang_tool(clang-format CLANG_FORMAT_BIN
-                "^clang-format version ${ARROW_CLANG_TOOLS_VERSION_ESCAPED}")
+                "clang-format version ${ARROW_CLANG_TOOLS_VERSION_ESCAPED}")
 if(CLANG_FORMAT_BIN)
   set(CLANG_FORMAT_FOUND 1)
   message(STATUS "clang-format found at ${CLANG_FORMAT_BIN}")


### PR DESCRIPTION
### Rationale for this change

On my mac system, the clang-format version information is:
```
➜  ~ clang-format -version
Homebrew clang-format version 16.0.4
```

This isn't matched by the current clang-format regex in the CMake setup:
```cmake
find_clang_tool(clang-format CLANG_FORMAT_BIN
                "^clang-format version ${ARROW_CLANG_TOOLS_VERSION_ESCAPED}")
```

### What changes are included in this PR?

Make regex more lenient to accomodate the Homebrew clang-format version string.

### Are these changes tested?
no

### Are there any user-facing changes?

no
* Closes: #37299