### PR TITLE
GH-35167: [Docs][C++] Use new API for arrow::json::TableReader

### DIFF
--- a/docs/source/cpp/json.rst
+++ b/docs/source/cpp/json.rst
@@ -59,7 +59,7 @@ the output table.
       // Instantiate TableReader from input stream and options
       std::shared_ptr<arrow::json::TableReader> reader;
       st = arrow::json::TableReader::Make(pool, input, read_options,
-                                          parse_options, &reader);
+                                          parse_options);
       if (!st.ok()) {
          // Handle TableReader instantiation error...
       }

--- a/docs/source/cpp/json.rst
+++ b/docs/source/cpp/json.rst
@@ -60,7 +60,7 @@ the output table.
       std::shared_ptr<arrow::json::TableReader> reader;
       auto maybe_reader = arrow::json::TableReader::Make(pool, input, read_options,
                                           parse_options);
-      if (!st.ok()) {
+      if (!maybe_reader.ok()) {
          // Handle TableReader instantiation error...
       }
 

--- a/docs/source/cpp/json.rst
+++ b/docs/source/cpp/json.rst
@@ -49,7 +49,6 @@ the output table.
 
    {
       // ...
-      arrow::Status st;
       arrow::MemoryPool* pool = default_memory_pool();
       std::shared_ptr<arrow::io::InputStream> input = ...;
 
@@ -57,19 +56,19 @@ the output table.
       auto parse_options = arrow::json::ParseOptions::Defaults();
 
       // Instantiate TableReader from input stream and options
-      std::shared_ptr<arrow::json::TableReader> reader;
       auto maybe_reader = arrow::json::TableReader::Make(pool, input, read_options, parse_options);
       if (!maybe_reader.ok()) {
          // Handle TableReader instantiation error...
       }
+      auto reader = *maybe_reader;
 
-      std::shared_ptr<arrow::Table> table;
       // Read table from JSON file
-      st = reader->Read(&table);
-      if (!st.ok()) {
+      auto maybe_table = reader->Read();
+      if (!maybe_table.ok()) {
          // Handle JSON read error
          // (for example a JSON syntax error or failed type conversion)
       }
+      auto table = *maybe_table;
    }
 
 StreamingReader

--- a/docs/source/cpp/json.rst
+++ b/docs/source/cpp/json.rst
@@ -58,7 +58,7 @@ the output table.
 
       // Instantiate TableReader from input stream and options
       std::shared_ptr<arrow::json::TableReader> reader;
-      st = arrow::json::TableReader::Make(pool, input, read_options,
+      auto maybe_reader = arrow::json::TableReader::Make(pool, input, read_options,
                                           parse_options);
       if (!st.ok()) {
          // Handle TableReader instantiation error...

--- a/docs/source/cpp/json.rst
+++ b/docs/source/cpp/json.rst
@@ -58,8 +58,7 @@ the output table.
 
       // Instantiate TableReader from input stream and options
       std::shared_ptr<arrow::json::TableReader> reader;
-      auto maybe_reader = arrow::json::TableReader::Make(pool, input, read_options,
-                                          parse_options);
+      auto maybe_reader = arrow::json::TableReader::Make(pool, input, read_options, parse_options);
       if (!maybe_reader.ok()) {
          // Handle TableReader instantiation error...
       }


### PR DESCRIPTION
### Rationale for this change

The current document causes a build error.

### What changes are included in this PR?

Use the current API.

### Are these changes tested?

No.

### Are there any user-facing changes?

Yes.

* Closes: #35167