### PR TITLE
GH-37303: [Python] Update test_option_class_equality due to CumulativeSumOptions refactor

### DIFF
--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -131,6 +131,9 @@ def test_exported_option_classes():
                                       param.VAR_KEYWORD)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:pyarrow.CumulativeSumOptions is deprecated as of 14.0"
+)
 def test_option_class_equality():
     options = [
         pc.ArraySortOptions(),
@@ -210,8 +213,8 @@ def test_option_class_equality():
         buf = option.serialize()
         deserialized = pc.FunctionOptions.deserialize(buf)
         assert option == deserialized
-        # TODO remove the check under the if statement
-        # when the deprecated class CumulativeSumOptions is removed.
+        # TODO remove the check under the if statement and the filterwarnings
+        # mark when the deprecated class CumulativeSumOptions is removed.
         if repr(option).startswith("CumulativeSumOptions"):
             assert repr(deserialized).startswith("CumulativeOptions")
         else:


### PR DESCRIPTION
### Rationale for this change

Merging of https://github.com/apache/arrow/pull/36977 caused a CI failure due to a test giving a warning.

### What changes are included in this PR?

Add a `filterwarnings` mark to the failing tests. This also tests the deprecation message.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #37303