### PR TITLE
GH-37294: [C++] Use std::string for HasSubstr matcher

### DIFF
--- a/cpp/src/arrow/flight/test_definitions.cc
+++ b/cpp/src/arrow/flight/test_definitions.cc
@@ -1679,7 +1679,7 @@ void ErrorHandlingTest::TestAsyncGetFlightInfo() {
 
       // The server-side arrow::Status-to-TransportStatus conversion puts the
       // detail into the main error message.
-      EXPECT_THAT(detail->get().message(),
+      EXPECT_THAT(std::string(detail->get().message()),
                   ::testing::HasSubstr("Expected message. Detail:"));
 
       std::string_view arrow_code, arrow_message, binary_detail;


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Apparently not all versions of GTest/GMock handle `testing::HasSubstr` against a `std::string_view`.

### What changes are included in this PR?

Explicitly wrap in `std::string`.

### Are these changes tested?

They are the tests.

### Are there any user-facing changes?

No.
* Closes: #37294