### PR TITLE
GH-37253: [MATLAB] Add test cases which verify that the `NumFields`, `BitWidth`, and `ID` properties can not be modified to `hFixedWidth` test class

### DIFF
--- a/matlab/test/arrow/type/hFixedWidthType.m
+++ b/matlab/test/arrow/type/hFixedWidthType.m
@@ -26,27 +26,50 @@ classdef hFixedWidthType < matlab.unittest.TestCase
 
     methods(Test)
         function TestClass(testCase)
-        % Verify ArrowType is an object of the expected class type.
+            % Verify ArrowType is an object of the expected class type.
             name = string(class(testCase.ArrowType));
             testCase.verifyEqual(name, testCase.ClassName);
         end
 
         function TestTypeID(testCase)
-        % Verify ID is set to the appropriate arrow.type.ID value.
+            % Verify ID is set to the appropriate arrow.type.ID value.
             arrowType = testCase.ArrowType;
             testCase.verifyEqual(arrowType.ID, testCase.TypeID);
         end
 
         function TestBitWidth(testCase)
-        % Verify the BitWidth value.
+            % Verify the BitWidth value.
             arrowType = testCase.ArrowType;
             testCase.verifyEqual(arrowType.BitWidth, testCase.BitWidth);
         end
 
         function TestNumFields(testCase)
-        % Verify NumFields is set to 0 for primitive types.
+            % Verify NumFields is set to 0 for primitive types.
             arrowType = testCase.ArrowType;
             testCase.verifyEqual(arrowType.NumFields, int32(0));
         end
+
+        function TestBitWidthNoSetter(testCase)
+            % Verify that an error is thrown when trying to set the value
+            % of the BitWidth property.
+            arrowType = testCase.ArrowType;
+            testCase.verifyError(@() setfield(arrowType, "BitWidth", 64), "MATLAB:class:SetProhibited");
+        end
+
+        function TestIDNoSetter(testCase)
+            % Verify that an error is thrown when trying to set the value
+            % of the ID property.
+            arrowType = testCase.ArrowType;
+            testCase.verifyError(@() setfield(arrowType, "ID", 15), "MATLAB:class:SetProhibited");
+        end
+
+        function TestNumFieldsNoSetter(testCase)
+            % Verify that an error is thrown when trying to set the value
+            % of the NumFields property.
+            arrowType = testCase.ArrowType;
+            testCase.verifyError(@() setfield(arrowType, "NumFields", 2), "MATLAB:class:SetProhibited");
+        end
+
     end
+
 end

--- a/matlab/test/arrow/type/tTime32Type.m
+++ b/matlab/test/arrow/type/tTime32Type.m
@@ -107,29 +107,8 @@ classdef tTime32Type < hFixedWidthType
         function TimeUnitNoSetter(testCase)
             % Verify that an error is thrown when trying to set the value
             % of the TimeUnit property.
-            schema = arrow.time32(TimeUnit="Millisecond");
-            testCase.verifyError(@() setfield(schema, "TimeUnit", "Second"), "MATLAB:class:SetProhibited");
-        end
-
-        function BitWidthNoSetter(testCase)
-            % Verify that an error is thrown when trying to set the value
-            % of the BitWidth property.
-            schema = arrow.time32(TimeUnit="Millisecond");
-            testCase.verifyError(@() setfield(schema, "BitWidth", 64), "MATLAB:class:SetProhibited");
-        end
-
-        function IDNoSetter(testCase)
-            % Verify that an error is thrown when trying to set the value
-            % of the ID property.
-            schema = arrow.time32(TimeUnit="Millisecond");
-            testCase.verifyError(@() setfield(schema, "ID", 15), "MATLAB:class:SetProhibited");
-        end
-
-        function NumFieldsNoSetter(testCase)
-            % Verify that an error is thrown when trying to set the value
-            % of the NumFields property.
-            schema = arrow.time32(TimeUnit="Millisecond");
-            testCase.verifyError(@() setfield(schema, "NumFields", 2), "MATLAB:class:SetProhibited");
+            type = arrow.time32(TimeUnit="Millisecond");
+            testCase.verifyError(@() setfield(type, "TimeUnit", "Second"), "MATLAB:class:SetProhibited");
         end
 
         function InvalidProxy(testCase)

--- a/matlab/test/arrow/type/tTime64Type.m
+++ b/matlab/test/arrow/type/tTime64Type.m
@@ -108,29 +108,8 @@ classdef tTime64Type < hFixedWidthType
         function TimeUnitNoSetter(testCase)
             % Verify that an error is thrown when trying to set the value
             % of the TimeUnit property.
-            schema = arrow.time64(TimeUnit="Nanosecond");
-            testCase.verifyError(@() setfield(schema, "TimeUnit", "Microsecond"), "MATLAB:class:SetProhibited");
-        end
-
-        function BitWidthNoSetter(testCase)
-            % Verify that an error is thrown when trying to set the value
-            % of the BitWidth property.
-            schema = arrow.time64(TimeUnit="Nanosecond");
-            testCase.verifyError(@() setfield(schema, "BitWidth", 32), "MATLAB:class:SetProhibited");
-        end
-
-        function IDNoSetter(testCase)
-            % Verify that an error is thrown when trying to set the value
-            % of the ID property.
-            schema = arrow.time64(TimeUnit="Nanosecond");
-            testCase.verifyError(@() setfield(schema, "ID", 15), "MATLAB:class:SetProhibited");
-        end
-
-        function NumFieldsNoSetter(testCase)
-            % Verify that an error is thrown when trying to set the value
-            % of the NumFields property.
-            schema = arrow.time64(TimeUnit="Nanosecond");
-            testCase.verifyError(@() setfield(schema, "NumFields", 2), "MATLAB:class:SetProhibited");
+            type = arrow.time64(TimeUnit="Nanosecond");
+            testCase.verifyError(@() setfield(type, "TimeUnit", "Microsecond"), "MATLAB:class:SetProhibited");
         end
 
         function InvalidProxy(testCase)


### PR DESCRIPTION
### Rationale for this change

As @sgilmore10 pointed out in https://github.com/apache/arrow/pull/37250#discussion_r1298747336, it makes sense to move the tests which verify that the `NumFields`, `BitWidth`, and `ID` properties cannot be set into the `hFixedWidthType` superclass, rather than having these tests implemented in `tTime32Type` and `tTime64Type`, since they are common to all fixed width types.

### What changes are included in this PR?

1. Moved tests which verify that the `BitWidth`, `NumFields`, and `ID` properties cannot be set out of the `tTime32Type` and `tTime64Type` classes and into the superclass `hFixedWidthType`.
2. Fixed typo in `tTime32Type` and `tTime64Type`. Changed variable name `schema` to `type`.

### Are these changes tested?

Yes.

1. Moved tests which verify that the `BitWidth`, `NumFields`, and `ID` properties cannot be set out of the `tTime32Type` and `tTime64Type` classes and into the superclass `hFixedWidthType`.

### Are there any user-facing changes?

No.

This pull request only modifies tests.
* Closes: #37253