### PR TITLE
GH-37310: [Python][CI] Enable warnings in PyArrow pytests

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -69,6 +69,7 @@ jobs:
             image: conda-python
             title: AMD64 Conda Python 3.9 Without Pandas
             python: 3.9
+            pytest_args: -W error
           - name: conda-python-3.8-pandas-1.0
             cache: conda-python-3.8
             image: conda-python-pandas
@@ -81,13 +82,14 @@ jobs:
             image: conda-python-pandas
             title: AMD64 Conda Python 3.10 Pandas latest
             python: "3.10"
+            pytest_args: -W error
             pandas: latest
     env:
       PYTHON: ${{ matrix.python || 3.8 }}
       UBUNTU: ${{ matrix.ubuntu || 20.04 }}
       PANDAS: ${{ matrix.pandas || 'latest' }}
       NUMPY: ${{ matrix.numpy || 'latest' }}
-      PYTEST_ARGS: -W error
+      PYTEST_ARGS: ${{ matrix.pytest_args || '' }}
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v4

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -155,7 +155,6 @@ jobs:
       ARROW_WITH_BROTLI: ON
       ARROW_BUILD_TESTS: OFF
       PYARROW_TEST_LARGE_MEMORY: ON
-      PYTEST_ARGS: -W error
       # Current oldest supported version according to https://endoflife.date/macos
       MACOSX_DEPLOYMENT_TARGET: 10.15
     steps:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -87,6 +87,7 @@ jobs:
       UBUNTU: ${{ matrix.ubuntu || 20.04 }}
       PANDAS: ${{ matrix.pandas || 'latest' }}
       NUMPY: ${{ matrix.numpy || 'latest' }}
+      PYTEST_ARGS: -W Error
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v4
@@ -152,6 +153,7 @@ jobs:
       ARROW_WITH_BROTLI: ON
       ARROW_BUILD_TESTS: OFF
       PYARROW_TEST_LARGE_MEMORY: ON
+      PYTEST_ARGS: -W Error
       # Current oldest supported version according to https://endoflife.date/macos
       MACOSX_DEPLOYMENT_TARGET: 10.15
     steps:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -87,7 +87,7 @@ jobs:
       UBUNTU: ${{ matrix.ubuntu || 20.04 }}
       PANDAS: ${{ matrix.pandas || 'latest' }}
       NUMPY: ${{ matrix.numpy || 'latest' }}
-      PYTEST_ARGS: -W Error
+      PYTEST_ARGS: -W error
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v4
@@ -153,7 +153,7 @@ jobs:
       ARROW_WITH_BROTLI: ON
       ARROW_BUILD_TESTS: OFF
       PYARROW_TEST_LARGE_MEMORY: ON
-      PYTEST_ARGS: -W Error
+      PYTEST_ARGS: -W error
       # Current oldest supported version according to https://endoflife.date/macos
       MACOSX_DEPLOYMENT_TARGET: 10.15
     steps:

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1275,7 +1275,7 @@ tasks:
         HYPOTHESIS_PROFILE: ci
         PYARROW_TEST_HYPOTHESIS: ON
         # limit to execute hypothesis tests only
-        PYTEST_ARGS: "-m hypothesis -W error"
+        PYTEST_ARGS: "-m hypothesis"
       image: conda-python-pandas
 
   test-conda-python-3.10-substrait:

--- a/python/pyarrow/conftest.py
+++ b/python/pyarrow/conftest.py
@@ -16,7 +16,6 @@
 # under the License.
 
 import pytest
-import warnings
 
 import pyarrow as pa
 from pyarrow import Codec
@@ -121,9 +120,7 @@ except ImportError:
     pass
 
 try:
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        import pandas  # noqa
+    import pandas  # noqa
     defaults['pandas'] = True
 except ImportError:
     defaults['nopandas'] = True

--- a/python/pyarrow/conftest.py
+++ b/python/pyarrow/conftest.py
@@ -16,7 +16,6 @@
 # under the License.
 
 import pytest
-
 import pyarrow as pa
 from pyarrow import Codec
 from pyarrow import fs

--- a/python/pyarrow/conftest.py
+++ b/python/pyarrow/conftest.py
@@ -16,6 +16,8 @@
 # under the License.
 
 import pytest
+import warnings
+
 import pyarrow as pa
 from pyarrow import Codec
 from pyarrow import fs
@@ -119,7 +121,9 @@ except ImportError:
     pass
 
 try:
-    import pandas  # noqa
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        import pandas  # noqa
     defaults['pandas'] = True
 except ImportError:
     defaults['nopandas'] = True

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -239,6 +239,10 @@ def test_named_table(use_threads):
     assert res_tb == test_table_1
 
 
+# TODO GH-37235 Properly handle the following warning:
+# "PytestUnraisableExceptionWarning: Exception ignored in:
+# 'pyarrow._substrait._create_named_table_provider'"
+@pytest.mark.filterwarnings("ignore:Exception ignored")
 def test_named_table_invalid_table_name():
     test_table_1 = pa.Table.from_pydict({"x": [1, 2, 3]})
 


### PR DESCRIPTION
### Rationale for this change

Warnings are enabled for some nightly jobs, but not for CI jobs. This is not helpful since devs typically rely on the CI job as part of the PR process.

### What changes are included in this PR?

* Enable warnings as errors in PR CI
* Remove warnings as errors in Hypothesis tests, which has no PR CI

### Are these changes tested?

Will be tested as part of CI.

### Are there any user-facing changes?

This affects the dev workflow.
* Closes: #37310