### PR TITLE
GH-37318: [Python]: Optimize combine_chunks when there is only one chunk

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -739,6 +739,8 @@ cdef class ChunkedArray(_PandasConvertible):
         """
         if self.num_chunks == 0:
             return array([], type=self.type)
+        elif self.num_chunks == 1:
+            return self.chunk(0)
         else:
             return concat_arrays(self.chunks)
 


### PR DESCRIPTION
### Rationale for this change

The associated issue explains the rationale.

I'd love to add benchmarks, but don't really know how; Arrow's benchmark system is pretty daunting for adding a pure-python change.

### What changes are included in this PR?

Only a Pyarrow change for combine_chunks to check the number of chunks and return the only chunk if there is only one.

### Are these changes tested?

Yes, no extra tests

### Are there any user-facing changes?

No
* Closes: #37318