### PR TITLE
GH-37320: [C++] Support is distinct and is not distinct expression.

### DIFF
--- a/cpp/src/arrow/compute/expression.cc
+++ b/cpp/src/arrow/compute/expression.cc
@@ -1651,5 +1651,16 @@ Expression or_(const std::vector<Expression>& operands) {
 
 Expression not_(Expression operand) { return call("invert", {std::move(operand)}); }
 
+Expression is_distinct(Expression lhs, Expression rhs) {
+  Expression not_equal_expr = not_equal(lhs, rhs);
+  Expression or_expr = or_(and_(is_null(lhs, true), is_valid(rhs)),
+                           and_(is_null(rhs, true), is_valid(lhs)));
+  return call("coalesce", {std::move(not_equal_expr), std::move(or_expr)});
+}
+
+Expression is_not_distinct(Expression lhs, Expression rhs) {
+  return not_(is_distinct(lhs, rhs));
+}
+
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/expression.h
+++ b/cpp/src/arrow/compute/expression.h
@@ -289,6 +289,9 @@ ARROW_EXPORT Expression or_(Expression lhs, Expression rhs);
 ARROW_EXPORT Expression or_(const std::vector<Expression>&);
 ARROW_EXPORT Expression not_(Expression operand);
 
+ARROW_EXPORT Expression is_distinct(Expression lhs, Expression rhs);
+ARROW_EXPORT Expression is_not_distinct(Expression lhs, Expression rhs);
+
 /// @}
 
 }  // namespace compute


### PR DESCRIPTION
### Rationale for this change

Ordinary comparison operators yield null (signifying “unknown”), not true or false, when either input is null. For example, 7 = NULL yields null, as does 7 <> NULL. When this behavior is not suitable, use the IS [ NOT ] DISTINCT FROM predicates:

a IS DISTINCT FROM b

or

a IS NOT DISTINCT FROM b

a IS DISTINCT b is equal to (a != b) or (b is null and a is not null) or (a is null and  b is not null).

We use coalesce to ensure is not distinct semantics, so we can use not_(is_distinct(lhs, rhs)) directly.

### What changes are included in this PR?

expression.cc
expression.h
expression_test.cc

### Are these changes tested?

yes, expression_test.cc

two test label.
- IsDistinct
- IsNotDistinct

### Are there any user-facing changes?
yes, sql is:

```
select * from test where a is distinct from b;
```

or

```
select * from test where a is not distinct from b;
```
* Closes: #37320