### PR TITLE
GH-37307: [Python][CI] Manually skip tests with skip_with_pyarrow_strings marker for nightly dask integration tests

### DIFF
--- a/ci/scripts/integration_dask.sh
+++ b/ci/scripts/integration_dask.sh
@@ -37,6 +37,7 @@ pytest -v --pyargs dask.dataframe.io.tests.test_orc
 # skip failing parquet tests
 # test_pandas_timestamp_overflow_pyarrow is skipped because of GH-33321.
 pytest -v --pyargs dask.dataframe.io.tests.test_parquet \
-  -k "not test_pandas_timestamp_overflow_pyarrow"
+  -k "not test_pandas_timestamp_overflow_pyarrow" \
+  -m "not skip_with_pyarrow_strings"
 # this file contains parquet tests that use S3 filesystem
 pytest -v --pyargs dask.bytes.tests.test_s3

--- a/ci/scripts/integration_dask.sh
+++ b/ci/scripts/integration_dask.sh
@@ -31,7 +31,8 @@ python -c "import dask.dataframe"
 # pytest -sv --pyargs dask.bytes.tests.test_hdfs
 # pytest -sv --pyargs dask.bytes.tests.test_local
 
-pytest -v --pyargs dask.dataframe.tests.test_dataframe
+# The "skip_with_pyarrow_strings" marker is meant to skip automatically, but that doesn't work with --pyargs, so de-selecting manually
+pytest -v --pyargs dask.dataframe.tests.test_dataframe -m "not skip_with_pyarrow_strings"
 pytest -v --pyargs dask.dataframe.io.tests.test_orc
 # skip failing parquet tests
 # test_pandas_timestamp_overflow_pyarrow is skipped because of GH-33321.

--- a/ci/scripts/integration_dask.sh
+++ b/ci/scripts/integration_dask.sh
@@ -38,6 +38,6 @@ pytest -v --pyargs dask.dataframe.io.tests.test_orc
 # test_pandas_timestamp_overflow_pyarrow is skipped because of GH-33321.
 pytest -v --pyargs dask.dataframe.io.tests.test_parquet \
   -k "not test_pandas_timestamp_overflow_pyarrow" \
-  -m "not skip_with_pyarrow_strings"
+  -m "not skip_with_pyarrow_strings and not xfail_with_pyarrow_strings"
 # this file contains parquet tests that use S3 filesystem
 pytest -v --pyargs dask.bytes.tests.test_s3


### PR DESCRIPTION
### Rationale for this change

Dask added some tests with a custom `@pytest.mark.skip_with_pyarrow_strings` mark, which ensures to skip some tests when pyarrow is installed. However, that skip doesn't work correctly when running the tests on an installed version of dask with `pytest --pyargs dask.tests`. 
Therefore manually skipping tests with that mark as a workaround.

* Closes: #37307