### PR TITLE
GH-37330: [Docs][CI]Increase the Timeout for the Sphinx build

### DIFF
--- a/.github/workflows/docs_light.yml
+++ b/.github/workflows/docs_light.yml
@@ -41,7 +41,7 @@ jobs:
     name: AMD64 Conda Python 3.9 Sphinx Documentation
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
-    timeout-minutes: 45
+    timeout-minutes: 60
     env:
       PYTHON: "3.9"
     steps:


### PR DESCRIPTION
### Rationale for this change

Failing Sphinc Documentation job due to the timeout limit
https://github.com/apache/arrow/actions/runs/5899257777/job/16097467804

### What changes are included in this PR?

Increase the timeout for `AMD64 Conda Python 3.9 Sphinx Documentation` from 45min to 60min.
* Closes: #37330