### PR TITLE
MINOR: [R] Update reference to data.frame which should say tibble instead

### DIFF
--- a/r/data-raw/docgen.R
+++ b/r/data-raw/docgen.R
@@ -54,7 +54,7 @@ file_template <- "# Licensed to the Apache Software Foundation (ASF) under one
 #' to a `dbplyr::tbl_lazy`. This means that the verbs do not eagerly evaluate
 #' the query on the data. To run the query, call either `compute()`,
 #' which returns an `arrow` [Table], or `collect()`, which pulls the resulting
-#' Table into an R `data.frame`.
+#' Table into an R `tibble`.
 #'
 %s
 #'


### PR DESCRIPTION
### Rationale for this change

Incorrect information in docs

### What changes are included in this PR?

Change ref to `data.frame` to `tibble` instead

### Are these changes tested?

No
### Are there any user-facing changes?

No