### PR TITLE
GH-37340: [MATLAB] The `column(index)` method of `arrow.tabular.RecordBatch` errors if `index` refers to an `arrow.array.Time32Array` column

### DIFF
--- a/matlab/src/cpp/arrow/matlab/array/proxy/wrap.cc
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/wrap.cc
@@ -51,6 +51,8 @@ namespace arrow::matlab::array::proxy {
                 return std::make_shared<proxy::NumericArray<arrow::DoubleType>>(std::static_pointer_cast<arrow::DoubleArray>(array));
             case ID::TIMESTAMP:
                 return std::make_shared<proxy::NumericArray<arrow::TimestampType>>(std::static_pointer_cast<arrow::TimestampArray>(array));
+            case ID::TIME32:
+                return std::make_shared<proxy::NumericArray<arrow::Time32Type>>(std::static_pointer_cast<arrow::Time32Array>(array));
             case ID::STRING:
                 return std::make_shared<proxy::StringArray>(std::static_pointer_cast<arrow::StringArray>(array));
             default:

--- a/matlab/src/matlab/+arrow/+internal/+test/+tabular/createAllSupportedArrayTypes.m
+++ b/matlab/src/matlab/+arrow/+internal/+test/+tabular/createAllSupportedArrayTypes.m
@@ -16,7 +16,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-function [arrowArrays, matlabData] = createSupportedArrays(opts)
+function [arrowArrays, matlabData] = createAllSupportedArrayTypes(opts)
     arguments
         opts.NumRows(1, 1) {mustBeFinite, mustBeNonnegative} = 3;  
     end

--- a/matlab/src/matlab/+arrow/+internal/+test/+tabular/createAllSupportedArrayTypes.m
+++ b/matlab/src/matlab/+arrow/+internal/+test/+tabular/createAllSupportedArrayTypes.m
@@ -1,5 +1,7 @@
-%CREATESUPPORTEDARRAYS Creates a MATLAB cell array containing all the
-%concrete subclasses of arrow.array.Array.
+%CREATEALLSUPPORTEDARRAYTYPES Creates a MATLAB cell array containing all 
+%the concrete subclasses of arrow.array.Array. Returns a cell array
+%containing the MATLAB data from which the arrow arrays were generated
+%as second output argument.
 
 % Licensed to the Apache Software Foundation (ASF) under one or more
 % contributor license agreements.  See the NOTICE file distributed with

--- a/matlab/src/matlab/+arrow/+internal/+test/+tabular/createAllSupportedArrayTypes.m
+++ b/matlab/src/matlab/+arrow/+internal/+test/+tabular/createAllSupportedArrayTypes.m
@@ -61,6 +61,8 @@ end
 
 function classes = getArrayClassNames()
     metaClass = meta.package.fromName("arrow.array").ClassList;
+
+    % Removes all Abstract classes from the list of all subclasses
     abstract = [metaClass.Abstract];
     metaClass(abstract) = [];
     classes = string({metaClass.Name});

--- a/matlab/src/matlab/+arrow/+internal/+test/+tabular/createSupportedArrays.m
+++ b/matlab/src/matlab/+arrow/+internal/+test/+tabular/createSupportedArrays.m
@@ -1,0 +1,66 @@
+%CREATESUPPORTEDARRAYS Creates a MATLAB cell array containing all the
+%concrete subclasses of arrow.array.Array.
+
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+function arrowArrays = createSupportedArrays(opts)
+    arguments
+        opts.NumRows(1, 1) {mustBeFinite, mustBeNonnegative} = 3;  
+    end
+
+    import arrow.type.ID
+    import arrow.array.*
+
+    arrowArrays = cell(14, 1);
+
+    arrowArrays{1}  = BooleanArray.fromMATLAB(randomLogicals(opts.NumRows));
+    arrowArrays{2}  = UInt8Array.fromMATLAB(randomNumbers("uint8", opts.NumRows));
+    arrowArrays{3}  = UInt16Array.fromMATLAB(randomNumbers("uint16", opts.NumRows));
+    arrowArrays{4}  = UInt32Array.fromMATLAB(randomNumbers("uint32", opts.NumRows));
+    arrowArrays{5}  = UInt64Array.fromMATLAB(randomNumbers("uint64", opts.NumRows));
+    arrowArrays{6}  = Int8Array.fromMATLAB(randomNumbers("int8", opts.NumRows));
+    arrowArrays{7}  = Int16Array.fromMATLAB(randomNumbers("int16", opts.NumRows));
+    arrowArrays{8}  = Int32Array.fromMATLAB(randomNumbers("int32", opts.NumRows));
+    arrowArrays{9}  = Int64Array.fromMATLAB(randomNumbers("int64", opts.NumRows));
+    arrowArrays{10} = Float32Array.fromMATLAB(randomNumbers("single", opts.NumRows));
+    arrowArrays{11} = Float64Array.fromMATLAB(randomNumbers("double", opts.NumRows));
+    arrowArrays{12} = StringArray.fromMATLAB(randomStrings(opts.NumRows));
+    arrowArrays{13} = TimestampArray.fromMATLAB(randomDatetimes(opts.NumRows));
+    arrowArrays{14} = Time32Array.fromMATLAB(randomDurations(opts.NumRows));
+end
+
+
+function number = randomNumbers(numberType, numElements)
+    number = cast(randi(255, [numElements 1]), numberType);
+end
+
+function text = randomStrings(numElements)
+    text = string(randi(255, [numElements 1]));
+end
+
+function tf = randomLogicals(numElements)
+    number = randi(2, [numElements 1]) - 1;
+    tf = logical(number);
+end
+
+function times = randomDurations(numElements)
+    number = randi(255, [numElements 1]);
+    times = seconds(number);
+end
+
+function dates = randomDatetimes(numElements)
+    day = days(randi(255, [numElements 1]));
+    dates = datetime(2023, 8, 23) + day;
+end

--- a/matlab/src/matlab/+arrow/+internal/+test/+tabular/createSupportedArrays.m
+++ b/matlab/src/matlab/+arrow/+internal/+test/+tabular/createSupportedArrays.m
@@ -15,7 +15,8 @@
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
-function arrowArrays = createSupportedArrays(opts)
+
+function [arrowArrays, matlabData] = createSupportedArrays(opts)
     arguments
         opts.NumRows(1, 1) {mustBeFinite, mustBeNonnegative} = 3;  
     end
@@ -24,21 +25,49 @@ function arrowArrays = createSupportedArrays(opts)
     import arrow.array.*
 
     arrowArrays = cell(14, 1);
+    matlabData  = cell(14, 1);
 
-    arrowArrays{1}  = BooleanArray.fromMATLAB(randomLogicals(opts.NumRows));
-    arrowArrays{2}  = UInt8Array.fromMATLAB(randomNumbers("uint8", opts.NumRows));
-    arrowArrays{3}  = UInt16Array.fromMATLAB(randomNumbers("uint16", opts.NumRows));
-    arrowArrays{4}  = UInt32Array.fromMATLAB(randomNumbers("uint32", opts.NumRows));
-    arrowArrays{5}  = UInt64Array.fromMATLAB(randomNumbers("uint64", opts.NumRows));
-    arrowArrays{6}  = Int8Array.fromMATLAB(randomNumbers("int8", opts.NumRows));
-    arrowArrays{7}  = Int16Array.fromMATLAB(randomNumbers("int16", opts.NumRows));
-    arrowArrays{8}  = Int32Array.fromMATLAB(randomNumbers("int32", opts.NumRows));
-    arrowArrays{9}  = Int64Array.fromMATLAB(randomNumbers("int64", opts.NumRows));
-    arrowArrays{10} = Float32Array.fromMATLAB(randomNumbers("single", opts.NumRows));
-    arrowArrays{11} = Float64Array.fromMATLAB(randomNumbers("double", opts.NumRows));
-    arrowArrays{12} = StringArray.fromMATLAB(randomStrings(opts.NumRows));
-    arrowArrays{13} = TimestampArray.fromMATLAB(randomDatetimes(opts.NumRows));
-    arrowArrays{14} = Time32Array.fromMATLAB(randomDurations(opts.NumRows));
+    matlabData{1}   = randomLogicals(opts.NumRows); 
+    arrowArrays{1}  = BooleanArray.fromMATLAB(matlabData{1});
+
+    matlabData{2}   = randomNumbers("uint8", opts.NumRows);
+    arrowArrays{2}  = UInt8Array.fromMATLAB(matlabData{2});
+
+    matlabData{3}   = randomNumbers("uint16", opts.NumRows);
+    arrowArrays{3}  = UInt16Array.fromMATLAB(matlabData{3});
+
+    matlabData{4}   = randomNumbers("uint32", opts.NumRows);
+    arrowArrays{4}  = UInt32Array.fromMATLAB(matlabData{4});
+
+    matlabData{5}   = randomNumbers("uint64", opts.NumRows);
+    arrowArrays{5}  = UInt64Array.fromMATLAB(matlabData{5});
+
+    matlabData{6}   = randomNumbers("int8", opts.NumRows);
+    arrowArrays{6}  = Int8Array.fromMATLAB(matlabData{6});
+
+    matlabData{7}   = randomNumbers("int16", opts.NumRows);
+    arrowArrays{7}  = Int16Array.fromMATLAB(matlabData{7});
+
+    matlabData{8}   = randomNumbers("int32", opts.NumRows);
+    arrowArrays{8}  = Int32Array.fromMATLAB(matlabData{8});
+
+    matlabData{9}   = randomNumbers("int64", opts.NumRows);
+    arrowArrays{9}  = Int64Array.fromMATLAB(matlabData{9});
+
+    matlabData{10}   = randomNumbers("single", opts.NumRows);
+    arrowArrays{10} = Float32Array.fromMATLAB(matlabData{10});
+
+    matlabData{11}  = randomNumbers("double", opts.NumRows);
+    arrowArrays{11} = Float64Array.fromMATLAB(matlabData{11});
+
+    matlabData{12}  = randomStrings(opts.NumRows);
+    arrowArrays{12} = StringArray.fromMATLAB(matlabData{12});
+
+    matlabData{13}  = randomDatetimes(opts.NumRows);
+    arrowArrays{13} = TimestampArray.fromMATLAB(matlabData{13});
+
+    matlabData{14}  = randomDurations(opts.NumRows);
+    arrowArrays{14} = Time32Array.fromMATLAB(matlabData{14});
 end
 
 

--- a/matlab/test/arrow/tabular/tRecordBatch.m
+++ b/matlab/test/arrow/tabular/tRecordBatch.m
@@ -34,6 +34,8 @@ classdef tRecordBatch < matlab.unittest.TestCase
             arrowRecordBatch = arrow.recordBatch(TOriginal);
             expectedColumnNames = string(TOriginal.Properties.VariableNames);
 
+            % For each variable in the input MATLAB table, look up the 
+            % corresponding Arrow Array type using type traits.
             expectedArrayClasses = varfun(@(var) traits(string(class(var))).ArrayClassName, ...
                 TOriginal, OutputFormat="uniform");
             tc.verifyRecordBatch(arrowRecordBatch, expectedColumnNames, expectedArrayClasses, TOriginal);

--- a/matlab/test/arrow/tabular/tRecordBatch.m
+++ b/matlab/test/arrow/tabular/tRecordBatch.m
@@ -28,11 +28,15 @@ classdef tRecordBatch < matlab.unittest.TestCase
         function SupportedTypes(tc)
             % Create a table all supported MATLAB types.
             import arrow.internal.test.tabular.createTableWithSupportedTypes
+            import arrow.type.traits.traits
 
             TOriginal = createTableWithSupportedTypes();
             arrowRecordBatch = arrow.recordBatch(TOriginal);
             expectedColumnNames = string(TOriginal.Properties.VariableNames);
-            tc.verifyRecordBatch(arrowRecordBatch, expectedColumnNames, TOriginal);
+
+            expectedArrayClasses = varfun(@(var) traits(string(class(var))).ArrayClassName, ...
+                TOriginal, OutputFormat="uniform");
+            tc.verifyRecordBatch(arrowRecordBatch, expectedColumnNames, expectedArrayClasses, TOriginal);
         end
 
         function ToMATLAB(tc)
@@ -125,19 +129,16 @@ classdef tRecordBatch < matlab.unittest.TestCase
         % RecordBatch when given a comma-separated list of
         % arrow.array.Array values.
             import arrow.tabular.RecordBatch
-            import arrow.internal.test.tabular.createTableWithSupportedTypes
+            import arrow.internal.test.tabular.createAllSupportedArrayTypes
 
-            TOriginal = createTableWithSupportedTypes();
-
-            arrowArrays = cell([1 width(TOriginal)]);
-            for ii = 1:width(TOriginal)
-                arrowArrays{ii} = arrow.array(TOriginal.(ii));
-            end
+            [arrowArrays, matlabData] = createAllSupportedArrayTypes();
+            TOriginal = table(matlabData{:});
 
             arrowRecordBatch = RecordBatch.fromArrays(arrowArrays{:});
             expectedColumnNames = compose("Column%d", 1:width(TOriginal));
             TOriginal.Properties.VariableNames = expectedColumnNames;
-            tc.verifyRecordBatch(arrowRecordBatch, expectedColumnNames, TOriginal);
+            expectedArrayClasses = cellfun(@(c) string(class(c)), arrowArrays, UniformOutput=true);
+            tc.verifyRecordBatch(arrowRecordBatch, expectedColumnNames, expectedArrayClasses, TOriginal);
         end
 
         function FromArraysWithColumnNamesProvided(tc)
@@ -145,19 +146,16 @@ classdef tRecordBatch < matlab.unittest.TestCase
         % RecordBatch when given a comma-separated list of
         % arrow.array.Array values and the ColumnNames nv-pair is provided.
             import arrow.tabular.RecordBatch
-            import arrow.internal.test.tabular.createTableWithSupportedTypes
+            import arrow.internal.test.tabular.createAllSupportedArrayTypes
 
-            TOriginal = createTableWithSupportedTypes();
-
-            arrowArrays = cell([1 width(TOriginal)]);
-            for ii = 1:width(TOriginal)
-                arrowArrays{ii} = arrow.array(TOriginal.(ii));
-            end
+            [arrowArrays, matlabData] = createAllSupportedArrayTypes();
+            TOriginal = table(matlabData{:});
 
             columnNames = compose("MyVar%d", 1:numel(arrowArrays));
             arrowRecordBatch = RecordBatch.fromArrays(arrowArrays{:}, ColumnNames=columnNames);
             TOriginal.Properties.VariableNames = columnNames;
-            tc.verifyRecordBatch(arrowRecordBatch, columnNames, TOriginal);
+            expectedArrayClasses = cellfun(@(c) string(class(c)), arrowArrays, UniformOutput=true);
+            tc.verifyRecordBatch(arrowRecordBatch, columnNames, expectedArrayClasses, TOriginal);
         end
 
         function FromArraysUnequalArrayLengthsError(tc)
@@ -226,7 +224,7 @@ classdef tRecordBatch < matlab.unittest.TestCase
     end
 
     methods
-        function verifyRecordBatch(tc, recordBatch, expectedColumnNames, expectedTable)
+        function verifyRecordBatch(tc, recordBatch, expectedColumnNames, expectedArrayClasses, expectedTable)
             tc.verifyEqual(recordBatch.NumColumns, int32(width(expectedTable)));
             tc.verifyEqual(recordBatch.ColumnNames, expectedColumnNames);
             convertedTable = recordBatch.table();
@@ -234,8 +232,7 @@ classdef tRecordBatch < matlab.unittest.TestCase
              for ii = 1:recordBatch.NumColumns
                 column = recordBatch.column(ii);
                 tc.verifyEqual(column.toMATLAB(), expectedTable{:, ii});
-                traits = arrow.type.traits.traits(string(class(expectedTable{:, ii})));
-                tc.verifyInstanceOf(column, traits.ArrayClassName);
+                tc.verifyInstanceOf(column, expectedArrayClasses(ii));
              end
         end
     end


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

The `column(index)` method of `arrow.tabular.RecordBatch` errors  if `index` refers to an `arrow.array.Time32Array` column.

```matlab
>> string = arrow.array(["A", "B", "C"]);
>> time32 = arrow.array.Time32Array.fromMATLAB(seconds(1:3));
>> rb = arrow.tabular.RecordBatch.fromArrays(string, time32, ColumnNames=["String", "Time32"])

rb = 

String:   [
    "A",
    "B",
    "C"
  ]
Time32:   [
    00:00:01,
    00:00:02,
    00:00:03
  ]

>> time32Column = rb.column(2)

Error using  . 
Unsupported DataType: time32[s]

Error in arrow.tabular.RecordBatch/column (line 63)
            [proxyID, typeID] = obj.Proxy.getColumnByIndex(args);
```

`column(index)` is throwing this error because the case for `Time32` was not added to `arrow::matlab::array::proxy::wrap(arrowArray)` in #37315. `column(index)` calls this function to create proxy objects around existing arrow arrays. Adding the case for `Time32` will resolve this bug.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

1. Updated `arrow::Result<proxy::Array> wrap(const std::shared_ptr<arrow::Array>& array)` to handle wrapping `arrow::Time32Array` instances within `proxy::Time32Array`s.
2. Added a new test utility called `arrow.internal.test.tabular.createAllSupportedArrayTypes`, which returns two cell arrays: `arrowArrays` and `matlabData`. The `arrowArrays` cell array contains one instance of each concrete subclass of `arrow.array.Array`. The `matlabData` cell array contains the MATLAB arrays used to generate each array in `arrowArrays`. This utility can be used to create an `arrow.array.RecordBatch` that contains all the arrow array types that are supported by the MATLAB interface. 

### Are these changes tested?

Yes. Updated the `fromArrays` test cases in `tRecordBatch` to verify the `column(index)` method of `arrow.type.RecordBatch` supports extracting columns of any arrow type (supported by the MATLAB Interface).

### Are there any user-facing changes?

Yes. Fixed a bug in `arrow.tabular.RecordBatch`.

### Future Directions

1. #37345

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #37340