### PR TITLE
GH-37329: [Release][Homebrew] Follow directory structure change

### DIFF
--- a/dev/release/post-13-homebrew.sh
+++ b/dev/release/post-13-homebrew.sh
@@ -67,7 +67,7 @@ brew bump-formula-pr \
      apache-arrow-glib
 
 for dependency in $(grep -l -r 'depends_on "apache-arrow"' Formula); do
-  dependency=${dependency#Formula/}
+  dependency=${dependency#Formula/*/}
   dependency=${dependency%.rb}
   if [ ${dependency} = "apache-arrow-glib" ]; then
     continue


### PR DESCRIPTION
### Rationale for this change

    Before: Formula/apache-arrow-glib.rb
    After:  Formula/a/apache-arrow-glib.rb

### What changes are included in this PR?

Remove `Formula/*/` from `Formula/a/apache-arrow-glib.rb` path to detect formula name. 

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #37329