### PR TITLE
GH-37334: [Packaging][Release][RPM] Don't remove old repodata/*

### DIFF
--- a/dev/release/binary-task.rb
+++ b/dev/release/binary-task.rb
@@ -1785,7 +1785,6 @@ APT::FTPArchive::Release::Description "#{apt_repository_description}";
           release_distribution(distribution,
                                list: uploaded_files_name)
 
-          # Remove old repodata
           distribution_dir = "#{yum_release_repositories_dir}/#{distribution}"
           download_distribution(distribution,
                                 distribution_dir,
@@ -1795,7 +1794,14 @@ APT::FTPArchive::Release::Description "#{apt_repository_description}";
                                              distribution: distribution,
                                              source: distribution_dir,
                                              staging: staging?,
-                                             sync: true,
+                                             # Don't remove old repodata for
+                                             # unsupported distribution version
+                                             # such as Amazon Linux 2.
+                                             # This keeps garbage in repodata/
+                                             # for currently available
+                                             # distribution versions but we
+                                             # accept it for easy to implement.
+                                             sync: false,
                                              sync_pattern: /\/repodata\//)
           uploader.upload
         end


### PR DESCRIPTION
### Rationale for this change

If we remove them, users can't use Yum repositories for unsupported distributions such as Amazon Linux 2.

### What changes are included in this PR?

This keeps garbage in repodata/* but we can accept it because we'll migrate to Debian/RPM type repositories eventually. We don't manage repodata/* by ourselves after we migrate to Debian/RPM type repositories.

See also: GH-37350

### Are these changes tested?

No. I hope that this works.

### Are there any user-facing changes?

Yes.
* Closes: #37334